### PR TITLE
chore(flake/nixpkgs): `18c84ea8` -> `a19ed837`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1641210259,
-        "narHash": "sha256-O7oWcTw9WY/gbZPPqDpNYOAeT4bOK+1rtYC9ZaevTT0=",
+        "lastModified": 1641233575,
+        "narHash": "sha256-7RQLnIAIEpqv2hv8C2tHGit07hF2RQ4beyzHacJ/i4I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "18c84ea816348e2a098390101b92d1e39a9dbd45",
+        "rev": "a19ed837728332d183ed641edb310d1b6a50f55d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`230009c2`](https://github.com/NixOS/nixpkgs/commit/230009c20e3dbaeb33a2df4eba779de17e4f1d33) | `python3Packages.metar: 1.8.0 -> 1.9.0`                                             |
| [`ba8ae636`](https://github.com/NixOS/nixpkgs/commit/ba8ae636862bc9a27615f9a8e4fd9287372b1f71) | `commitizen: rename to cz-cli to follow upstream`                                   |
| [`31d923d2`](https://github.com/NixOS/nixpkgs/commit/31d923d222ebd188c90a2d5ed6d086e7d8e36bc0) | `python3Packages.mcstatus: 7.0.0 -> 8.0.0`                                          |
| [`d2f03f1c`](https://github.com/NixOS/nixpkgs/commit/d2f03f1c040ecf77e2fc0f342d56916236490fbd) | `vimPlugins.project-nvim: init @ 2021-11-06`                                        |
| [`d76e8ee6`](https://github.com/NixOS/nixpkgs/commit/d76e8ee6f5797fa867b1c6162bf98a18a255481d) | `vimPlugins: update`                                                                |
| [`59da9130`](https://github.com/NixOS/nixpkgs/commit/59da9130e8e757ed64e933b05ab23e03ebb0cd67) | `wasabibackend: 1.1.12 -> 1.1.13.0, use buildDotnetModule`                          |
| [`944a2dc8`](https://github.com/NixOS/nixpkgs/commit/944a2dc83568f515cd3b0f8bb777dbbe0d14226a) | `Treewide: fix some permanent redirects on homepages`                               |
| [`3447ac99`](https://github.com/NixOS/nixpkgs/commit/3447ac99bb23d8ce98a454e2bafe91230b1012a6) | `python38Packages.pywbem: 1.3.0 -> 1.4.0`                                           |
| [`5fcd49b6`](https://github.com/NixOS/nixpkgs/commit/5fcd49b6d32ddf69aaef83ba7576874e860d9a47) | `python3Packages.twitterapi: 2.7.10 -> 2.7.11`                                      |
| [`6d835d9c`](https://github.com/NixOS/nixpkgs/commit/6d835d9cf59e86749157c9d1936c01007073a077) | `vsce/ethansk.restore-terminals: init at 1.1.6`                                     |
| [`f0ee5a13`](https://github.com/NixOS/nixpkgs/commit/f0ee5a13f7b1bca2cae2f9d7be5cd42488e0f174) | `vsce/rioj7.commandOnAllFiles: init at 0.3.0`                                       |
| [`faba7254`](https://github.com/NixOS/nixpkgs/commit/faba7254a6eeadb0da39c94ea63f90d49eea32ef) | `vsce/xadillax.viml: init at 1.0.1`                                                 |
| [`5b3eac31`](https://github.com/NixOS/nixpkgs/commit/5b3eac3130bb68737b8f433722515acc5a6c24b1) | `lean: 3.35.0 -> 3.35.1`                                                            |
| [`4d69ad4b`](https://github.com/NixOS/nixpkgs/commit/4d69ad4b1f4133fea19471361a4626ee47bbabb9) | `nixos/heisenbridge: Init`                                                          |
| [`3d47865f`](https://github.com/NixOS/nixpkgs/commit/3d47865f7fe85234687d2372ea9d561421b06fbe) | `nixos/matrix-conduit: init`                                                        |
| [`cf806553`](https://github.com/NixOS/nixpkgs/commit/cf806553ed6354a118068d3bb03dfa601010d0d8) | `matrix-conduit: init at 0.2.0`                                                     |
| [`b0779163`](https://github.com/NixOS/nixpkgs/commit/b0779163d20cbf1eeb5cd7eba538a1194fb40155) | `interactsh: 0.0.6 -> 0.0.7`                                                        |
| [`75a86ab9`](https://github.com/NixOS/nixpkgs/commit/75a86ab9f5691930f79de6c72e9f80eb280cf2dd) | `ivan: 058 -> 059`                                                                  |
| [`d218e587`](https://github.com/NixOS/nixpkgs/commit/d218e587d3df81f85c340d8a92a84c3738f79c83) | `vlc: add myself as maintainer`                                                     |
| [`2f1a2e2e`](https://github.com/NixOS/nixpkgs/commit/2f1a2e2e5722ae25d354ea4080aabc30ad67160b) | `vlc: refactor`                                                                     |
| [`fae46e66`](https://github.com/NixOS/nixpkgs/commit/fae46e66a5df220327b45e0d7c27c6961cf922ce) | ``elvish: move test to `installCheckPhase```                                        |
| [`a08f1060`](https://github.com/NixOS/nixpkgs/commit/a08f1060e34fc97a2a6d3d724298f24600e40392) | `vlc: document patch`                                                               |
| [`fffeab2a`](https://github.com/NixOS/nixpkgs/commit/fffeab2a053510a0de0e93394026ca54535a85e3) | `postman: 9.6.1 -> 9.7.1`                                                           |
| [`86d00329`](https://github.com/NixOS/nixpkgs/commit/86d00329cb911133aeb7cc4c790d131867f49dcc) | `vlc: nullify libcaca attribute`                                                    |
| [`9167342f`](https://github.com/NixOS/nixpkgs/commit/9167342f791d0ded4112d37e3f573de23613a1f0) | `Update cawilliamson maintainer details (chrisaw -> cawilliamson)`                  |
| [`d24db22d`](https://github.com/NixOS/nixpkgs/commit/d24db22d21389486e4a29757ae0a7299f0e9e62c) | `lxqt.lxqt-session: 1.0.0 -> 1.0.1`                                                 |
| [`d66bdefa`](https://github.com/NixOS/nixpkgs/commit/d66bdefaf56d505f9a4c61eed516c406e8f3ce37) | `sdrangel: pin boost`                                                               |
| [`0b2e3c4a`](https://github.com/NixOS/nixpkgs/commit/0b2e3c4abae223b113dbb1ddb2d5e4814cc04fe3) | `python3Packages.limnoria: enable tests`                                            |
| [`1aa42552`](https://github.com/NixOS/nixpkgs/commit/1aa42552ff055fafbf54c436dd00735fdb6f45bd) | `python3Packages.limnoria: disable on older Python releases`                        |
| [`df583011`](https://github.com/NixOS/nixpkgs/commit/df583011106021eca6b1c154ceb1bdd8ff58c5d7) | `jitsi-meet-electron: add pipewire screensharing support`                           |
| [`22d6f654`](https://github.com/NixOS/nixpkgs/commit/22d6f654c4df6c22a3ac54e2c3a798dcbda1f1f7) | `python38Packages.limnoria: 2021.11.20 -> 2022.1.1`                                 |
| [`5773043a`](https://github.com/NixOS/nixpkgs/commit/5773043ac1445a0e9904d6618d337b32891db210) | ``elvish: properly set buildinfo via `ldflags```                                    |
| [`da82d35d`](https://github.com/NixOS/nixpkgs/commit/da82d35dcb0b5720d581fd0ff23450c83ebd2701) | `kodi.packages.orftvthek : init at 0.12.3-1`                                        |
| [`bca10d1f`](https://github.com/NixOS/nixpkgs/commit/bca10d1f5a3129c8fa37ed9f37e21f74b841175d) | `kodi.packages.simplejson: init at 3.17.0+matrix.2`                                 |
| [`685dacce`](https://github.com/NixOS/nixpkgs/commit/685dacce1db65c0deee2390c757a5597a67895fb) | `kodi.packages.future: init at 0.18.2+matrix.1`                                     |
| [`4ed62dd5`](https://github.com/NixOS/nixpkgs/commit/4ed62dd5c1d5528ab03d31791ea9d74fcbc77838) | `buf: 1.0.0-rc8 -> 1.0.0-rc10`                                                      |
| [`f2cf229e`](https://github.com/NixOS/nixpkgs/commit/f2cf229e670df32d05a58fa492b36f9cac38388a) | `zigbee2mqtt: 1.22.1 -> 1.22.2`                                                     |
| [`f2f972dc`](https://github.com/NixOS/nixpkgs/commit/f2f972dc200ac3fe7f74eb96fe5d91017447d76d) | `firefox-wrapper: add replace to nativeBuildInputs instead of string interpolation` |
| [`33452047`](https://github.com/NixOS/nixpkgs/commit/334520473efa35aa47a3816f19670661dc201509) | `cmst: 2019.01.13 -> 2021.12.02`                                                    |
| [`3074f764`](https://github.com/NixOS/nixpkgs/commit/3074f76478af9073cc2a9fb97fa7f5ef87524e90) | `kube-capacity: 0.6.1 -> 0.6.2`                                                     |
| [`5128f58f`](https://github.com/NixOS/nixpkgs/commit/5128f58f480599f9d2f931775d8e39f507c5e335) | `fselect: 0.7.8 -> 0.7.9`                                                           |
| [`4768d1e9`](https://github.com/NixOS/nixpkgs/commit/4768d1e9fab65f703a59459b44cec5c9773a4144) | `linux_xanmod: 5.15.11 -> 5.15.12`                                                  |
| [`8b138c90`](https://github.com/NixOS/nixpkgs/commit/8b138c90318712d0a0c19732a32a4d1394f5168f) | `github-runner: Extend script to update all platform deps`                          |
| [`c8b997df`](https://github.com/NixOS/nixpkgs/commit/c8b997df95bf0a179cd6e872dc847f4d45d4d389) | `github-runner: Add @kfollesdal to maintainers`                                     |
| [`a32ca288`](https://github.com/NixOS/nixpkgs/commit/a32ca2885c310ceff857deb71503eeb044a581d6) | `github-runner: Add script to create deps.nix.`                                     |
| [`24b79667`](https://github.com/NixOS/nixpkgs/commit/24b79667cfef613cbc261f1e1651396368a8ae19) | `github-runne: 2.285.1 -> 2.286.0`                                                  |
| [`f7ff512d`](https://github.com/NixOS/nixpkgs/commit/f7ff512d6dddfbbb9f02bc35cb2d1ef21137798e) | `nixos/logrotate: rotate login/logout logs by default`                              |
| [`c2fd94a6`](https://github.com/NixOS/nixpkgs/commit/c2fd94a61cbcf7133dc3e6f8d915c172062865c2) | `nixos/logrotate: enable multiple paths per entry`                                  |
| [`650945df`](https://github.com/NixOS/nixpkgs/commit/650945df314e58a40e6f4dab7be3448301929f5f) | `nixos/minecraft-server: systemd unit hardening`                                    |
| [`8583c5f4`](https://github.com/NixOS/nixpkgs/commit/8583c5f48bb1aea53dcebf76613a1d694d578e69) | `doc: remove reference to unix-man-urls.lua`                                        |
| [`876689aa`](https://github.com/NixOS/nixpkgs/commit/876689aa99892cfe87e94ce8447e3da3392545d7) | `enlightenment.enlightenment: 0.24.2 -> 0.25.0`                                     |
| [`554c0583`](https://github.com/NixOS/nixpkgs/commit/554c0583fc6b81b167ff2d6b3ff71e30cb91eeca) | `enlightenment.evisum: 0.5.13 -> 0.6.0`                                             |
| [`35ea3fa2`](https://github.com/NixOS/nixpkgs/commit/35ea3fa2d77a8145d94096c7ce21e06663d5d99c) | `enlightenment.rage: 0.3.1 -> 0.4.0`                                                |
| [`d90ab56f`](https://github.com/NixOS/nixpkgs/commit/d90ab56f7ad9a91e5987e61092a2934d437062e2) | `enlightenment.ephoto: 1.5 -> 1.6.0`                                                |
| [`7981024a`](https://github.com/NixOS/nixpkgs/commit/7981024aaf0a785069f09924764e8a024919abf5) | `enlightenment.efl: 1.25.1 -> 1.26.0`                                               |