### PR TITLE
chore(flake/home-manager): `5fb55d51` -> `c751aeb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1641457362,
-        "narHash": "sha256-5RW5YvqYZCvzjF6Xns0P5as6P38+4wUMnFz5IMEp9FY=",
+        "lastModified": 1641459437,
+        "narHash": "sha256-z0IOcc6LLbVhyri/aTyWzRqJs3p1pBK9idOiMwCWiqs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5fb55d51e2dcdc0dd5f6c82968c3edff00d73b2b",
+        "rev": "c751aeb19e84a0a777f36fd5ea73482a066bb406",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`2989c0f6`](https://github.com/nix-community/home-manager/commit/2989c0f6b21acfcba4501e856aac1b984006fbd2) | `Translate using Weblate (Chinese (Simplified))` |
| [`a2307ff6`](https://github.com/nix-community/home-manager/commit/a2307ff6f32278f8055e5cd2f178974bed69733b) | `Translate using Weblate (Norwegian Bokmål)`     |
| [`65434ef3`](https://github.com/nix-community/home-manager/commit/65434ef33cd7b32009cd1cb4cc41a54ca26768b8) | `Translate using Weblate (Swedish)`              |
| [`95823b56`](https://github.com/nix-community/home-manager/commit/95823b5639f054ee8216d194a66dd49f59a7672a) | `Update translation files`                       |
| [`a726f7e3`](https://github.com/nix-community/home-manager/commit/a726f7e3e8cec2543e6083f494220e2e0ac9e722) | `Add translation using Weblate (Spanish)`        |
| [`cf0fc744`](https://github.com/nix-community/home-manager/commit/cf0fc744c28eb89f06ff0b9a7b5ed7f98622f62c) | `Translate using Weblate (Spanish)`              |