### PR TITLE
chore(flake/nixpkgs): `a19ed837` -> `f6ee4912`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1641233575,
-        "narHash": "sha256-7RQLnIAIEpqv2hv8C2tHGit07hF2RQ4beyzHacJ/i4I=",
+        "lastModified": 1641476363,
+        "narHash": "sha256-KdzsYpe84Wx0e6uO4e83GhpZ97UyIBdEO0YbSUGgrB4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a19ed837728332d183ed641edb310d1b6a50f55d",
+        "rev": "f6ee491278eb30e4619253fef211f1c1a92f8f65",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                          |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`f6ee4912`](https://github.com/NixOS/nixpkgs/commit/f6ee491278eb30e4619253fef211f1c1a92f8f65) | `rebar3: 3.17.0 -> 3.18.0 (#153710)`                                    |
| [`1d435065`](https://github.com/NixOS/nixpkgs/commit/1d4350656972f9369463e2326821e9b771763301) | `python38Packages.fontparts: 0.10.1 -> 0.10.2`                          |
| [`74ae0ea8`](https://github.com/NixOS/nixpkgs/commit/74ae0ea8b794b9ee055a942991ecd86504dd4131) | `minigalaxy: init at 1.1.0`                                             |
| [`40bf36ec`](https://github.com/NixOS/nixpkgs/commit/40bf36ec59101baee8a9318df5de0bee8688df39) | `python38Packages.geoalchemy2: 0.10.0 -> 0.10.1`                        |
| [`4fabed44`](https://github.com/NixOS/nixpkgs/commit/4fabed4488c1c0b88642fadf540d7e92d79aa426) | `python3Packages.meshtastic: 1.2.51 -> 1.2.52`                          |
| [`9c2683eb`](https://github.com/NixOS/nixpkgs/commit/9c2683eb75b8354bfb5ecf107c23598e7edf410b) | `python3Packages.filebrowser_safe: update meta`                         |
| [`87baecc0`](https://github.com/NixOS/nixpkgs/commit/87baecc0ce63953958ceb5eaccebb2f5d602ba34) | `python3Packages.pysimplegui: update meta`                              |
| [`ec3c2e37`](https://github.com/NixOS/nixpkgs/commit/ec3c2e3776dd7e2904950cb77684fd4279f4ac0e) | `python3Packages.python-gitlab: update supported Python releases`       |
| [`c2da87c1`](https://github.com/NixOS/nixpkgs/commit/c2da87c13f53fbbf5a395c005e413035f923c70c) | `python38Packages.limnoria: 2022.1.1 -> 2022.1.1.post1`                 |
| [`58703232`](https://github.com/NixOS/nixpkgs/commit/58703232948d8200099930c009842cea835f63c1) | `libreddit: 0.21.4 -> 0.21.7`                                           |
| [`8e39c0f7`](https://github.com/NixOS/nixpkgs/commit/8e39c0f750f91c6717f017355de9f381344e9286) | `mercurial: extend tests timeout`                                       |
| [`3d869b89`](https://github.com/NixOS/nixpkgs/commit/3d869b89b0ed87520d7c925ae63d1e0e0929fd3c) | `mercurial: disable check phase on Darwin`                              |
| [`b35674c0`](https://github.com/NixOS/nixpkgs/commit/b35674c03e0ced5bf2795a45286607a2da632a3c) | `python38Packages.parfive: 1.5.0 -> 1.5.1`                              |
| [`e465dd55`](https://github.com/NixOS/nixpkgs/commit/e465dd55ecf9ce4c17ffe6210b360c6c457d08b2) | `ocamlPackages.uunf: fix aarch64-linux build`                           |
| [`3dc83b28`](https://github.com/NixOS/nixpkgs/commit/3dc83b28a1fced399f51b9f62e2304d5a0f82053) | `python38Packages.python-gitlab: 2.10.1 -> 3.0.0`                       |
| [`33fc3566`](https://github.com/NixOS/nixpkgs/commit/33fc3566162a338224bb34b74a8580f31afd7375) | `icdiff: remove self (aneeshusa) from maintainers`                      |
| [`082d7c22`](https://github.com/NixOS/nixpkgs/commit/082d7c22d8b25865a1cffeaf96022db2c698d2c7) | ``gotop: switch to `proxyVendor```                                      |
| [`49eb2524`](https://github.com/NixOS/nixpkgs/commit/49eb25241e921996057b7c1adc5ce89abd018878) | ``livepeer: switch to `proxyVendor```                                   |
| [`dc748e7d`](https://github.com/NixOS/nixpkgs/commit/dc748e7ddf0a39899b253ee45ae92e1a7e5a24c6) | ``hydron: switch to `proxyVendor```                                     |
| [`f24d06a3`](https://github.com/NixOS/nixpkgs/commit/f24d06a39541f835213feeb352a769f0504d5889) | ``aerc: switch to `proxyVendor```                                       |
| [`8c9182c1`](https://github.com/NixOS/nixpkgs/commit/8c9182c1c55d0978f9316a8c84045de6999e6991) | ``hugo: switch to `proxyVendor```                                       |
| [`96b524c4`](https://github.com/NixOS/nixpkgs/commit/96b524c47b6f15638fdccd40fb60cd692f7be010) | ``erigon: switch to `proxyVendor```                                     |
| [`8a8c88de`](https://github.com/NixOS/nixpkgs/commit/8a8c88de70bd7f967cb20ad07583ea9ef12a4a94) | ``buildGoModule: use `proxyVendor` instead of `runVend```               |
| [`1fe22e19`](https://github.com/NixOS/nixpkgs/commit/1fe22e19782dabfce0e26d7d6d8e7c4e3b42f739) | `bucklespring: 1.5.0 -> 1.5.1`                                          |
| [`6f6a0cff`](https://github.com/NixOS/nixpkgs/commit/6f6a0cff8a193a53a927778ea5c8246ae749e38a) | `python38Packages.pysimplegui: 4.55.1 -> 4.56.0`                        |
| [`22ef914f`](https://github.com/NixOS/nixpkgs/commit/22ef914f45016582348ef081286677c3f356db37) | `em: init at 1.0.0`                                                     |
| [`151810b3`](https://github.com/NixOS/nixpkgs/commit/151810b33270c63f5dbb97ca25a8555a93fa2ee3) | `gnome-podcasts: mark as broken on darwin`                              |
| [`3c4a898b`](https://github.com/NixOS/nixpkgs/commit/3c4a898b40e0cb60da6ad13c00feb6ceff1c3be9) | `python3Packages.mcstatus: add alias in all-packages`                   |
| [`12e13654`](https://github.com/NixOS/nixpkgs/commit/12e13654ce8d3626964b2b88b5033e5a34d8aedd) | `python3Packages.optax: init at unstable-2022-01-05 (#153655)`          |
| [`5d244d5c`](https://github.com/NixOS/nixpkgs/commit/5d244d5c5f2b37c94cdd9fac9587da2ae7349ff5) | `nix-top: 0.2.0 -> 0.3.0`                                               |
| [`6b9f31d4`](https://github.com/NixOS/nixpkgs/commit/6b9f31d4ab9667f348220fc6732ab205fa69bf42) | `python38Packages.filebrowser_safe: 1.1.0 -> 1.1.1`                     |
| [`5ef18697`](https://github.com/NixOS/nixpkgs/commit/5ef18697ff82531d707b6a2f7353edf0ddb3afeb) | `rizin: 0.3.1 -> 0.3.2`                                                 |
| [`0c8b2ce6`](https://github.com/NixOS/nixpkgs/commit/0c8b2ce6c023e664d341e62d7f5cf4616a7e352d) | `terraform-providers.minio: init at 1.2.0`                              |
| [`e67813b0`](https://github.com/NixOS/nixpkgs/commit/e67813b0c687e2c7363cf8d0134bdb698fd0faf7) | `doc/go: remove platform from example`                                  |
| [`f49bd944`](https://github.com/NixOS/nixpkgs/commit/f49bd944c5a5f09411bbeaa3c9d3e8f47a9464d6) | `terraform-providers: disable CGO, set ldflags`                         |
| [`8772f866`](https://github.com/NixOS/nixpkgs/commit/8772f8661202714cf1bcaf46d2f99eea7e681bd0) | `python3Packages.oocsi: 0.4.2 -> 0.4.3`                                 |
| [`9791807f`](https://github.com/NixOS/nixpkgs/commit/9791807f001b89e4dfdf63fbf9cab03383df49bf) | `python3Packages.vt-py: 0.12.0 -> 0.13.0`                               |
| [`7580fbb4`](https://github.com/NixOS/nixpkgs/commit/7580fbb4be6fa9ef922bd3b1b90aecefffc91616) | `berry: 0.1.7 -> 0.1.9`                                                 |
| [`0eef882c`](https://github.com/NixOS/nixpkgs/commit/0eef882cf5e3fcd82e8492dab4bb140cdaad842c) | `pekwm: 0.1.18 -> 0.2.1`                                                |
| [`98f31f13`](https://github.com/NixOS/nixpkgs/commit/98f31f139aed9caa6d5aa0a3bb0a11962f1f8329) | `ppsspp: 1.11 -> 1.12.3`                                                |
| [`8a0de217`](https://github.com/NixOS/nixpkgs/commit/8a0de217302f223208f86db1081cde4ac8fed99a) | `udiskie: 2.3.3 -> 2.4.0`                                               |
| [`8254f078`](https://github.com/NixOS/nixpkgs/commit/8254f078fc653202f0f8f432df849469d7ed58b7) | `grc: update meta.homepage`                                             |
| [`dce2b3eb`](https://github.com/NixOS/nixpkgs/commit/dce2b3eb6d04d85399348195ead8b9cc55557bc1) | `udevil: refactor`                                                      |
| [`74b562f8`](https://github.com/NixOS/nixpkgs/commit/74b562f81a8b47684c65bb8cb13f24b33f2bf17a) | `grib-api: remove`                                                      |
| [`24a90eb1`](https://github.com/NixOS/nixpkgs/commit/24a90eb1fbf056caaac2770e3fbd18fd54e13305) | `python38Packages.genanki: 0.12.0 -> 0.13.0`                            |
| [`7dae53c9`](https://github.com/NixOS/nixpkgs/commit/7dae53c963e2710f46a896dbad480c4738eb0b96) | `markdown-anki-decks: relax genanki constraint`                         |
| [`75b3b8c4`](https://github.com/NixOS/nixpkgs/commit/75b3b8c4b16ccddc62465739a520578cfe50ed42) | `python3Packages.dulwich: 0.20.26 -> 0.20.27`                           |
| [`8ef375f7`](https://github.com/NixOS/nixpkgs/commit/8ef375f7b37f6dd0828a99ab1d109ed64638cfe8) | `python3Packages.dm-haiku: init at 0.0.5 (#153122)`                     |
| [`2cb945d5`](https://github.com/NixOS/nixpkgs/commit/2cb945d526347aeb5a0ec96edef5f41c6562bd4f) | `wolfssl: 5.1.0 -> 5.1.1`                                               |
| [`4540a9dc`](https://github.com/NixOS/nixpkgs/commit/4540a9dcd2fa6791678aef87d916777d5ab62ca0) | `mob: add optional speech support`                                      |
| [`0cf654d9`](https://github.com/NixOS/nixpkgs/commit/0cf654d9b2354bca6f2b26cf52e9ed01d56559eb) | `terrascan: 1.12.0 -> 1.13.0`                                           |
| [`c8ab07a8`](https://github.com/NixOS/nixpkgs/commit/c8ab07a8e1fcee6cad9165b9663377cc409d85c3) | `mercurial: 6.0 -> 6.0.1`                                               |
| [`cc708106`](https://github.com/NixOS/nixpkgs/commit/cc708106e0dfae8def34216bcd510f95a0f8390a) | `vimPlugins.telescope-github-nvim: init at 2021-08-25`                  |
| [`364315cb`](https://github.com/NixOS/nixpkgs/commit/364315cbca1fd12328aa500995a08f0816177926) | `vimPlugins.telescope-file-browser-nvim: init at 2021-12-29`            |
| [`a125a8a5`](https://github.com/NixOS/nixpkgs/commit/a125a8a51d854d1886c42c561e66cbdc58a31c4c) | `vimPlugins.impatient-nvim: init at 2021-12-26`                         |
| [`22cd481e`](https://github.com/NixOS/nixpkgs/commit/22cd481eb09695715277c47113a7f642c4c4c89a) | `vimPlugins.lua-dev-nvim: init at 2021-12-31`                           |
| [`0baa07bd`](https://github.com/NixOS/nixpkgs/commit/0baa07bd59d2e854e827f4a4a86ce7c1bcbd1d0d) | `libcrafter: switch to fetchFromGitHub`                                 |
| [`0c8ea703`](https://github.com/NixOS/nixpkgs/commit/0c8ea70368ba8fac80dc4185e238444db3aaae35) | `libcec: switch to fetchFromGitHub`                                     |
| [`9fa99d44`](https://github.com/NixOS/nixpkgs/commit/9fa99d440b705988ba1bbbad2252b5c261bb08e8) | `gpxsee: 10.0 → 10.1`                                                   |
| [`8325cfb3`](https://github.com/NixOS/nixpkgs/commit/8325cfb39d84453c5f3b4341c7b9c2d5da3e57ff) | `rethinkdb: pin Boost dep to boost170`                                  |
| [`cba86fea`](https://github.com/NixOS/nixpkgs/commit/cba86feaaf71e3cf450bfb90cb08ed42347504f6) | `ite-backlight: init at v1.1`                                           |
| [`20d41417`](https://github.com/NixOS/nixpkgs/commit/20d414175fbdc2f8917fdfe929a825cc85e8ace3) | `clojure: 1.10.3.1053 -> 1.10.3.1058`                                   |
| [`843508da`](https://github.com/NixOS/nixpkgs/commit/843508dad46d2205ea8dd81c446349d573187a87) | `chromiumDev: Backport important fixes for Wayland`                     |
| [`1a4a216b`](https://github.com/NixOS/nixpkgs/commit/1a4a216bf519b6c0926bfc64e86c2503671f792a) | `onlykey: set the group correctly in the udev rule (#153618)`           |
| [`e1b3d18c`](https://github.com/NixOS/nixpkgs/commit/e1b3d18cbc513cb81731829e66bb1741f49c39a8) | `cocogitto: init as 4.0.1`                                              |
| [`db2953eb`](https://github.com/NixOS/nixpkgs/commit/db2953eb199bf02328ba06f045b5592625cbd939) | `nixos/tinc: add mic92 maintainer`                                      |
| [`3ad8f52d`](https://github.com/NixOS/nixpkgs/commit/3ad8f52de0aaad1a7c798ad8b1649cb18becb906) | `nixos-install: copy channels before system eval`                       |
| [`115a6f07`](https://github.com/NixOS/nixpkgs/commit/115a6f077fc29e7dc846618be86ece84c6d6aea7) | `llvmPackages_{12,13,git}.compiler-rt: remove new runtimes in useLLVM`  |
| [`ff811628`](https://github.com/NixOS/nixpkgs/commit/ff81162833bf4614766c31f5c3056770817deeec) | `python3Packages.hahomematic: 0.12.0 -> 0.13.3`                         |
| [`271ca2b0`](https://github.com/NixOS/nixpkgs/commit/271ca2b032cbf6106ecdabdf191cda0503c0c625) | `python3Packages.environs: 9.3.5 -> 9.4.0`                              |
| [`4ae16720`](https://github.com/NixOS/nixpkgs/commit/4ae1672085bbde9304f80fb2f115788c8732af44) | `python3Packages.sumo: relax castepxbin constraint`                     |
| [`4c21eb40`](https://github.com/NixOS/nixpkgs/commit/4c21eb400aa94bb13fa259258cef184f646a9f1d) | `python3Packages.gcsfs: update homepage`                                |
| [`43a1e275`](https://github.com/NixOS/nixpkgs/commit/43a1e275c44395751c3ff5af09d2b1cc1b79e331) | `python3Packages.parsy: switch to pytestCheckHook`                      |
| [`a207408a`](https://github.com/NixOS/nixpkgs/commit/a207408aa280e2dbf1db0bbc23a01a25237b911b) | `ocamlPackages.dbf: init at 1.1.0`                                      |
| [`e01959e3`](https://github.com/NixOS/nixpkgs/commit/e01959e3cefd016dc271ef8985831c012dc46fd7) | `maintainers: add deltadelta`                                           |
| [`a2fa7414`](https://github.com/NixOS/nixpkgs/commit/a2fa741467689446957b968a20b28d6f5126ba25) | `python3Packages.pyebus: 1.2.4 -> 1.4.0`                                |
| [`ef7f5fdc`](https://github.com/NixOS/nixpkgs/commit/ef7f5fdc827069bf885f66f939ea8f3e0ab910bf) | `checkov: 2.0.702 -> 2.0.706`                                           |
| [`ea6b995d`](https://github.com/NixOS/nixpkgs/commit/ea6b995da5dea47ebd38db11133ee9a2ba357749) | `python3Packages.flux-led: 0.27.36 -> 0.27.40`                          |
| [`07db5d29`](https://github.com/NixOS/nixpkgs/commit/07db5d29809b0e30084c769c3c49ba2cf9a50c82) | `python3Packages.pycm: disable failing test`                            |
| [`5050956b`](https://github.com/NixOS/nixpkgs/commit/5050956be28718c234e93048223f59e43113cc97) | `python3Packages.pydmd: disable failing and long-running tests`         |
| [`50284bd7`](https://github.com/NixOS/nixpkgs/commit/50284bd7c0e621c43c93f415f228213c0a029bcb) | `python3Packages.sqlobject: disable failing test`                       |
| [`3dd76988`](https://github.com/NixOS/nixpkgs/commit/3dd76988673bd6a67ab43567963ead57030af355) | `obb: switch to passthru.tests`                                         |
| [`b65eb7ec`](https://github.com/NixOS/nixpkgs/commit/b65eb7ec84816acba5b6b5721fd6a3cdddf160a3) | `obb: switch to fetchFromGitHub`                                        |
| [`492a4bd3`](https://github.com/NixOS/nixpkgs/commit/492a4bd35757398939cff434a1fa2a7cec50f400) | `super-slicer: 2.3.57.8 -> 2.3.57.9`                                    |
| [`a173e35a`](https://github.com/NixOS/nixpkgs/commit/a173e35a9e624423dce0b42f566c1e922e1735d9) | `zellij: 0.23.0 -> 0.24.0 (#153587)`                                    |
| [`893ffee2`](https://github.com/NixOS/nixpkgs/commit/893ffee2866dbf9f2aa6e3128368e0cd5729e4b9) | `Revert "nixos/documentation: avoid copying nixpkgs subpaths"`          |
| [`43cba143`](https://github.com/NixOS/nixpkgs/commit/43cba143c05a491265b6f7da81ce7d9284158c31) | `kube-linter: init at 0.2.5`                                            |
| [`81755f96`](https://github.com/NixOS/nixpkgs/commit/81755f9615136c9176d0a860d1b796bb6b8ff103) | `maintainers: add mtesseract`                                           |
| [`021a011b`](https://github.com/NixOS/nixpkgs/commit/021a011b29d7ad19fbf412c61ee145b544e3967b) | `json-schema-for-humans: 0.39.3 -> 0.39.5`                              |
| [`6597f5a2`](https://github.com/NixOS/nixpkgs/commit/6597f5a27438abcfbe75fa8cbdc33fe686ab9582) | `python3Packages.ansible-runner: disable failing tests`                 |
| [`681f18ff`](https://github.com/NixOS/nixpkgs/commit/681f18ffa80a55c870cdd721c548676ba5c2eef2) | `python38Packages.deemix: 3.6.4 -> 3.6.5`                               |
| [`b3cfebfc`](https://github.com/NixOS/nixpkgs/commit/b3cfebfcb8f4be78d3bcedddd3421f45efb61793) | `python38Packages.deezer-py: 1.3.2 -> 1.3.5`                            |
| [`c2ecf54b`](https://github.com/NixOS/nixpkgs/commit/c2ecf54bb1cb7e5015424951fdfae61b18dfd8c2) | `python38Packages.ipympl: 0.8.4 -> 0.8.5`                               |
| [`751d9583`](https://github.com/NixOS/nixpkgs/commit/751d9583ee70974d8e6cf980559d322b26ddd74f) | `python38Packages.watermark: 2.2.0 -> 2.3.0`                            |
| [`cc545663`](https://github.com/NixOS/nixpkgs/commit/cc545663cec6603e4c889c259a7f657e9f4229dc) | `Export static libc, libm, libdl from the prebuilt crt as well.`        |
| [`9e851977`](https://github.com/NixOS/nixpkgs/commit/9e8519777b13400ce63b15439798659c081fcf81) | `gnome-icon-theme: mark as broken on darwin`                            |
| [`e6043946`](https://github.com/NixOS/nixpkgs/commit/e604394699d95482f3cf8e792cdb7666ac9407a9) | `bitcoin-classic.src: fix sha`                                          |
| [`adfe7f33`](https://github.com/NixOS/nixpkgs/commit/adfe7f334ae8b11c5bec6a54a29dbd8cdc55616f) | `box2d: make src name independent`                                      |
| [`f6a8702c`](https://github.com/NixOS/nixpkgs/commit/f6a8702cea88e42112e335fcf17bf7d5ea38abae) | `go-task: 3.9.2 -> 3.10.0`                                              |
| [`8df2c9fe`](https://github.com/NixOS/nixpkgs/commit/8df2c9feb492771a9e45582fec92d73667932850) | `dashpay.src: fix sha256`                                               |
| [`dcc20d7c`](https://github.com/NixOS/nixpkgs/commit/dcc20d7c1710cd043554378fd1b04dc819361108) | `firebird_4.src: fix sha256`                                            |
| [`c5c1b337`](https://github.com/NixOS/nixpkgs/commit/c5c1b337e52b99d92d8330f48a544e0f48ca7889) | `python3Packages.gcsfs.src: fix sha`                                    |
| [`18c2e991`](https://github.com/NixOS/nixpkgs/commit/18c2e9910faea24d5d6cf2fb9d548de7cd0ae228) | `python38Packages.trimesh: 3.9.39 -> 3.9.40`                            |
| [`602ab517`](https://github.com/NixOS/nixpkgs/commit/602ab517343d506e4752d1513c069cb7cc1f6442) | `python38Packages.pysptk: 0.1.18 -> 0.1.20`                             |
| [`8a877241`](https://github.com/NixOS/nixpkgs/commit/8a87724121364e46e4e9c35b7f232253629cbd08) | `python38Packages.pynamodb: 5.1.0 -> 5.2.0`                             |
| [`49c28083`](https://github.com/NixOS/nixpkgs/commit/49c280834055dbcb78d318872bb0e9d24fb3fa4d) | `python38Packages.goodwe: 0.2.9 -> 0.2.10`                              |
| [`648005c3`](https://github.com/NixOS/nixpkgs/commit/648005c3de02882f0437eba8290c4fb7f985cdf8) | ``jaeles: remove unnecessary `runVend```                                |
| [`617bbe97`](https://github.com/NixOS/nixpkgs/commit/617bbe97dff657709a070199da8255201b5bb74c) | `python38Packages.nameparser: 1.0.6 -> 1.1.0`                           |
| [`6ea4ab36`](https://github.com/NixOS/nixpkgs/commit/6ea4ab36bd5cbc9950a57cae21ef26512c6e3ec7) | `python38Packages.mypy-boto3-s3: 1.20.17 -> 1.20.28`                    |
| [`312315fe`](https://github.com/NixOS/nixpkgs/commit/312315fe8383896829b40207adb9801f6dd38fc4) | `haskellPackages.crackNum: re-enable on aarch64-linux`                  |
| [`75464803`](https://github.com/NixOS/nixpkgs/commit/7546480323cbab1aae70e1447fc127bb1861740c) | `Revert "linuxPackages: bump default 5.10 -> 5.15"`                     |
| [`74777686`](https://github.com/NixOS/nixpkgs/commit/747776863cd077b0e5171eac1dd2637db9acea14) | `haskellPackages: mark builds failing on hydra as broken`               |
| [`8bedcaca`](https://github.com/NixOS/nixpkgs/commit/8bedcacaf137c71bbc7096c88d37229e73c8e48c) | `linux: enable X86_SGX{_KVM} on x86_64 only`                            |
| [`dc2909ec`](https://github.com/NixOS/nixpkgs/commit/dc2909ec58ee6e46872d4249af92f3022cb3fc49) | `libcangjie: switch to fetchFromGitLab & update homepage`               |
| [`33d32827`](https://github.com/NixOS/nixpkgs/commit/33d3282770622a68d0597039a2238238db9ccdf7) | `keybinder: switch to fetchFromGitHub`                                  |
| [`9f250850`](https://github.com/NixOS/nixpkgs/commit/9f2508505e08a88765e0a5c45a2c99d137d2fd15) | `graphene-hardened-malloc: switch to fetchFromGitHub`                   |
| [`7b1ce7a5`](https://github.com/NixOS/nixpkgs/commit/7b1ce7a5f91f439700dfed62274d7dfc334d293e) | `LASzip2: switch to fetchFromGitHub`                                    |
| [`43a33f1f`](https://github.com/NixOS/nixpkgs/commit/43a33f1f01c8d28df0a79343566218ea0ef98943) | `chromium: 96.0.4664.110 -> 97.0.4692.71`                               |
| [`babb121d`](https://github.com/NixOS/nixpkgs/commit/babb121da82f5d74f0107d2754cb4dcfc7716686) | `linux/hardened/patches/5.4: 5.4.167-hardened1 -> 5.4.169-hardened1`    |
| [`5bea8cae`](https://github.com/NixOS/nixpkgs/commit/5bea8cae1ca66b0ef9a5f11a4d43da53caa93151) | `linux/hardened/patches/5.15: 5.15.10-hardened1 -> 5.15.12-hardened1`   |
| [`b23f71e8`](https://github.com/NixOS/nixpkgs/commit/b23f71e8056f2099c1dbe899378a4b297a9ba2b0) | `linux/hardened/patches/5.10: 5.10.87-hardened1 -> 5.10.89-hardened1`   |
| [`c389f9ac`](https://github.com/NixOS/nixpkgs/commit/c389f9ace80bb021babe264ba599d336a056bda6) | `linux/hardened/patches/4.19: 4.19.221-hardened1 -> 4.19.223-hardened1` |
| [`aa88b7f3`](https://github.com/NixOS/nixpkgs/commit/aa88b7f3ecc7d6d309a3ec73b70eb34328c41ce1) | `linux/hardened/patches/4.14: 4.14.258-hardened1 -> 4.14.260-hardened1` |
| [`3951393f`](https://github.com/NixOS/nixpkgs/commit/3951393fe99d137fb11e6651dbe1450e15e9da4c) | `obb: init at 0.0.1`                                                    |
| [`dac33ebc`](https://github.com/NixOS/nixpkgs/commit/dac33ebc3fa1a85072abc57be44be5bab0beb116) | `roc-toolkit: fix aarch64-linux build`                                  |
| [`24ba4098`](https://github.com/NixOS/nixpkgs/commit/24ba4098a8a0883d11cb87243bb53f64280fdaf3) | `electron_16: 16.0.5 -> 16.0.6`                                         |
| [`aeb6554e`](https://github.com/NixOS/nixpkgs/commit/aeb6554ea12519e95439fa926ee9a8da10c7892b) | `electron_13: 13.6.3 -> 13.6.6`                                         |
| [`244948e6`](https://github.com/NixOS/nixpkgs/commit/244948e66b0ad1054fea09e1add0c64a7968a301) | `rshell: one item er line`                                              |
| [`7e041d34`](https://github.com/NixOS/nixpkgs/commit/7e041d344690f638da46a6dfc7edf780ae222af7) | `gajim: add plugin installer`                                           |
| [`c138c66d`](https://github.com/NixOS/nixpkgs/commit/c138c66dcbd6cc986c44e3be0a1c8e47d0fe5573) | `gajim: fix tests`                                                      |
| [`6299ff2b`](https://github.com/NixOS/nixpkgs/commit/6299ff2be1e0841d3500b35b318d4ced281fd2aa) | `consul: 1.10.3 -> 1.11.1`                                              |
| [`eaff5241`](https://github.com/NixOS/nixpkgs/commit/eaff5241bf0929415717478fcb00802b15296918) | `maintainers: add techknowlogick`                                       |
| [`fda6ac57`](https://github.com/NixOS/nixpkgs/commit/fda6ac57097d559d2581fa3213ef944c74e04bfa) | `maintainers: add willcohen`                                            |
| [`49ca628c`](https://github.com/NixOS/nixpkgs/commit/49ca628c396a4a0d408c874e1cac9dee552028b3) | `kubescape: 1.0.136 -> 1.0.137`                                         |
| [`eb9951e7`](https://github.com/NixOS/nixpkgs/commit/eb9951e70ad0110242769e617a7b0f20fffb1892) | `haskellPackages.gtk2hs-buildtools: remove -O0 workaround`              |
| [`e09df20b`](https://github.com/NixOS/nixpkgs/commit/e09df20b20207110903c416bf8d2c802381cab94) | `python3Packages.adafruit-platformdetect: 3.18.0 -> 3.19.1`             |
| [`16ba1d62`](https://github.com/NixOS/nixpkgs/commit/16ba1d62e52f94dcc7a7a1202d799100ff3f629f) | `pythonPackages.sfepy: 2021.2 -> 2021.4`                                |