### PR TITLE
chore(flake/nixpkgs): `f6ee4912` -> `9f09fe7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1641476363,
-        "narHash": "sha256-KdzsYpe84Wx0e6uO4e83GhpZ97UyIBdEO0YbSUGgrB4=",
+        "lastModified": 1641520708,
+        "narHash": "sha256-jGELR9I16UdMZmZ4j48k+yvUOYUVKThsoft41Pgx+h4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f6ee491278eb30e4619253fef211f1c1a92f8f65",
+        "rev": "9f09fe7a15bfe656de7b1648ff8a312f4e05a686",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`3b800d74`](https://github.com/NixOS/nixpkgs/commit/3b800d743e18715166aab2ad2caaa7ffa3ef0d90) | `python38Packages.pytest-console-scripts: 1.2.1 -> 1.2.2`                      |
| [`d43869af`](https://github.com/NixOS/nixpkgs/commit/d43869afb6e3dec74932a3ca373bf24a426013cb) | `python38Packages.sunpy: 3.1.2 -> 3.1.3`                                       |
| [`e1c79ccf`](https://github.com/NixOS/nixpkgs/commit/e1c79ccfe4076fe4ac8d61aaf87565c7582bfd2e) | `clojure-lsp: fix build on macOS`                                              |
| [`0b5c462b`](https://github.com/NixOS/nixpkgs/commit/0b5c462b4efb9f4e05b8cb70f925a53b51471ec4) | `ovito: 3.4.0 -> 3.6.0`                                                        |
| [`a7690bba`](https://github.com/NixOS/nixpkgs/commit/a7690bba3e34711a8947e152e35d024c36461661) | `openbazaar: remove`                                                           |
| [`9be55be6`](https://github.com/NixOS/nixpkgs/commit/9be55be68e7ba7c91c740fca8c4331a0de4d3125) | `python3Packages.uritemplate: 3.0.1 -> 4.1.1`                                  |
| [`7a022212`](https://github.com/NixOS/nixpkgs/commit/7a022212c83000b4d56d93df4cd5610caa74e4b9) | `liquidctl: 1.7.2 -> 1.8.0`                                                    |
| [`14927bdc`](https://github.com/NixOS/nixpkgs/commit/14927bdce643e9b2ebb153b9413d301622c37cd5) | `libreoffice-fresh: 7.2.4.1 -> 7.2.5.2`                                        |
| [`bc0c803a`](https://github.com/NixOS/nixpkgs/commit/bc0c803a50ad8f129fdc298b25e5bbae02528859) | `python38Packages.miniaudio: 1.45 -> 1.46`                                     |
| [`93c3b17f`](https://github.com/NixOS/nixpkgs/commit/93c3b17f751e1240ab23aefee44c92f1ead1904c) | `ovito: mark as broken on darwin`                                              |
| [`84ab3070`](https://github.com/NixOS/nixpkgs/commit/84ab3070b31ea715a3de0cc4cde379f89010f482) | `python38Packages.google-cloud-storage: 1.43.0 -> 1.44.0`                      |
| [`ff0c3a06`](https://github.com/NixOS/nixpkgs/commit/ff0c3a068d0b6274a75456f84b3e2216421d4b97) | `python38Packages.mautrix: 0.14.0 -> 0.14.3`                                   |
| [`f77dcd50`](https://github.com/NixOS/nixpkgs/commit/f77dcd50aa589306bf81535e4efef35bea7fdd73) | `python38Packages.chainer: 7.8.0 -> 7.8.1`                                     |
| [`17c0bbb4`](https://github.com/NixOS/nixpkgs/commit/17c0bbb496667bb4f99fdd526245aaa2bb876a7f) | `qscintilla: cleanup`                                                          |
| [`20e00ef5`](https://github.com/NixOS/nixpkgs/commit/20e00ef5897b26dfd78680a21d709a9dcb61a6c4) | `baresip: 0.6.5 -> 1.1.0`                                                      |
| [`f77a556c`](https://github.com/NixOS/nixpkgs/commit/f77a556c73cf19a6a7108693db307a43be507cbf) | `direnv: 2.30.2 -> 2.30.3 (#153654)`                                           |
| [`e511e5a6`](https://github.com/NixOS/nixpkgs/commit/e511e5a66c9d195f13eb8487d4e6c24cbc063645) | `librem: 0.6.0 -> 1.0.0`                                                       |
| [`cf531684`](https://github.com/NixOS/nixpkgs/commit/cf53168416019e83ccee486301ace03c415d69af) | `libre: 0.6.1 -> 2.0.1`                                                        |
| [`bb358d65`](https://github.com/NixOS/nixpkgs/commit/bb358d65666f7e710f25f828f4626febda8eb348) | `nixos/wordpress: Disable directory indexes`                                   |
| [`9a4b481c`](https://github.com/NixOS/nixpkgs/commit/9a4b481cdcb88c8717c7f9a9471b5987af488f02) | `indradb: init at unstable-2021-01-05 (#153637)`                               |
| [`5bb94d32`](https://github.com/NixOS/nixpkgs/commit/5bb94d32cd9bd8626c76ee0ffdba9bc4885f178a) | `jsonnet: 0.17.0 -> 0.18.0`                                                    |
| [`8efa46a8`](https://github.com/NixOS/nixpkgs/commit/8efa46a893ed68af726cb7c24e3620ed295bfb65) | `yosys: 0.12+36 -> 0.12.54, with yosys-bluespec update`                        |
| [`76cbdfd8`](https://github.com/NixOS/nixpkgs/commit/76cbdfd89b9b45c35a5a071ab5b1368eb98edc52) | `nextpnr: 2021.15.21 -> 2022.01.03, with apycula update`                       |
| [`8553a5d3`](https://github.com/NixOS/nixpkgs/commit/8553a5d3dc2aa6bb10f4b0c67a51fe34ad03c49e) | `containerd: 1.5.8 -> 1.5.9`                                                   |
| [`e4f81857`](https://github.com/NixOS/nixpkgs/commit/e4f818576620732ec564d21e88e96b579d9a0782) | `python3{8,9}Packages.scikit-learn: 1.0.1 -> 1.0.2`                            |
| [`18d0fe9b`](https://github.com/NixOS/nixpkgs/commit/18d0fe9b696633d58bf6dbc1a6c750a72cabcf27) | `docker_20_10: 20.10.9 -> 20.10.12`                                            |
| [`dd4432a1`](https://github.com/NixOS/nixpkgs/commit/dd4432a118ec94f97e9c7667c02b7049d5db1814) | `signal-desktop: 5.26.1 -> 5.27.0`                                             |
| [`a8d77ae5`](https://github.com/NixOS/nixpkgs/commit/a8d77ae561ec40dd4b22c79fd974c29307ae4a62) | `quark-engine: relax prompt-toolkit constraint`                                |
| [`a98370af`](https://github.com/NixOS/nixpkgs/commit/a98370af81bd86f2ef3d2177536bb905b10af450) | `qt5: remove stdenv from qt5-packages`                                         |
| [`b8504e9b`](https://github.com/NixOS/nixpkgs/commit/b8504e9b84e2dcd7cfed69b291b532913197bfb8) | `qscintilla: cleanup of derivations`                                           |
| [`ac384536`](https://github.com/NixOS/nixpkgs/commit/ac384536170b8f8ab2a750485760935270e4029d) | `checkov: 2.0.706 -> 2.0.707`                                                  |
| [`e618a4d3`](https://github.com/NixOS/nixpkgs/commit/e618a4d3ed5daf6a2b25e7917c27a20d49a36e62) | `python3Packages.datashader: relax xarray constraint`                          |
| [`7f2bc1d7`](https://github.com/NixOS/nixpkgs/commit/7f2bc1d736683cffedaaad34748840c026c0892b) | `nixos/bookstack: fix setup service`                                           |
| [`fac05ccc`](https://github.com/NixOS/nixpkgs/commit/fac05cccc5a68663335f044d98e9854c992ebd07) | `libressl: 3.4.1 -> 3.4.2`                                                     |
| [`8dfa5168`](https://github.com/NixOS/nixpkgs/commit/8dfa5168245896a50e2ba0168d17715e949cc802) | `qscintilla, python3Packages.qscintilla-qt5: syntax`                           |
| [`24522dcd`](https://github.com/NixOS/nixpkgs/commit/24522dcd0fa808ef34b486363a578d1af3118ead) | `qscintilla: migrate to libsForQt5.qscintilla`                                 |
| [`9d8903ba`](https://github.com/NixOS/nixpkgs/commit/9d8903bab640891b1655023eef3da939618cea32) | `qscintilla-qt4: Remove qt5/darwin support`                                    |
| [`2cdbb565`](https://github.com/NixOS/nixpkgs/commit/2cdbb565adbed90914eb2ea417b834837af10378) | `qgis: update QSCI_SIP_DIR location`                                           |
| [`693a0e84`](https://github.com/NixOS/nixpkgs/commit/693a0e84b2135cd55f760da9c5da68941b40732b) | `sqliteman: specify use of qscintilla-qt4`                                     |
| [`06d2d8bc`](https://github.com/NixOS/nixpkgs/commit/06d2d8bc2d2093ee74e89d67d899bb4e3ec12ba1) | `miniaudicle: specify use of qscintilla-qt4`                                   |
| [`b83d9bd7`](https://github.com/NixOS/nixpkgs/commit/b83d9bd7050f54170d6a537db200cfd7f46acee8) | `pythonPackages.qscintilla-qt5: fix darwin linking`                            |
| [`c39ac297`](https://github.com/NixOS/nixpkgs/commit/c39ac297240440bb863ff2148b8f28bdc6819c6f) | `pythonPackages.qscintilla-qt5: fix darwin make`                               |
| [`b1964626`](https://github.com/NixOS/nixpkgs/commit/b1964626fbae34612e37faf1df7466f2a4ab462a) | `pythonPackages.qscintilla: default to Qt5`                                    |
| [`7a7a1806`](https://github.com/NixOS/nixpkgs/commit/7a7a18064ae40a75bb09e317d93b5bac83ae12ba) | `qscintilla: default to Qt5`                                                   |
| [`aa44e613`](https://github.com/NixOS/nixpkgs/commit/aa44e613ef8b1ace137837ca14f0d74f5c98a98e) | `pythonPackages.qscintilla-qt5: use pyproject`                                 |
| [`fde6436f`](https://github.com/NixOS/nixpkgs/commit/fde6436feb1fb695913b675add3e79b13bd2ce3a) | `pythonPackages.qscintilla-qt4: put qscintilla here`                           |
| [`f7a0145a`](https://github.com/NixOS/nixpkgs/commit/f7a0145a933f3e5f55c2c43157f56729083bfa95) | `qscintilla: update to use Qt5 only`                                           |
| [`0c098957`](https://github.com/NixOS/nixpkgs/commit/0c09895790ebbebf73b637f531a71273112960a2) | `qscintilla-qt4: move qscintilla recipe here`                                  |
| [`a4b6d674`](https://github.com/NixOS/nixpkgs/commit/a4b6d6742e11809adf1e98330148af5265adc2cd) | `arrow-cpp: blacklist all TestS3FS tests on darwin`                            |
| [`b97ccaa1`](https://github.com/NixOS/nixpkgs/commit/b97ccaa18d61b888b00513c0754745c27c36b293) | `fetchFromSourcehut: allow recursive fetching`                                 |
| [`5f1c91ab`](https://github.com/NixOS/nixpkgs/commit/5f1c91abf9573e41e91c4a7e6c0950c8ac5d6df0) | `python3Packages.tables: 3.6.1 -> 3.7.0`                                       |
| [`78700df9`](https://github.com/NixOS/nixpkgs/commit/78700df9422e34cb8b6d9b4e12a52fa8f12848e8) | `apacheHttpd: 2.4.51 -> 2.4.52`                                                |
| [`cb5bd71e`](https://github.com/NixOS/nixpkgs/commit/cb5bd71ee147d8da7c4e503c633b8b9006ffd046) | `dyncall: 1.2 -> 1.3`                                                          |
| [`385cc6af`](https://github.com/NixOS/nixpkgs/commit/385cc6af3534270dedba6e173a2a9e03384f2b36) | `python38Packages.pyfftw: 0.12.0 -> 0.13.0`                                    |
| [`c8d13796`](https://github.com/NixOS/nixpkgs/commit/c8d137961d29b7ad1e9470718802209b0e636776) | `nixos/tests/systemd-binfmt: Add ldPreload test for LD_PRELOAD error messages` |
| [`1f5e0c84`](https://github.com/NixOS/nixpkgs/commit/1f5e0c848e1573116e5c5dc71a98d33b042bd0aa) | `python3Packages.tensorly: 0.4.5 -> 0.7.0`                                     |
| [`9e5d0a94`](https://github.com/NixOS/nixpkgs/commit/9e5d0a94581ef8769bf0184d495a43c5d80fda43) | `nixos/binfmt: Preserve argv[0] when using QEMU`                               |
| [`3011531c`](https://github.com/NixOS/nixpkgs/commit/3011531cf9553e7ddb93faa023fff27f3fe4777a) | `qemu: Add binfmt preserve-argv[0] wrapper`                                    |