### PR TITLE
chore(flake/nixpkgs): `9f09fe7a` -> `256efb15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1641520708,
-        "narHash": "sha256-jGELR9I16UdMZmZ4j48k+yvUOYUVKThsoft41Pgx+h4=",
+        "lastModified": 1641564989,
+        "narHash": "sha256-Y9FiFkEQupqvdniGRv6SKOaIjsoColv5OrouZDSsmqE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9f09fe7a15bfe656de7b1648ff8a312f4e05a686",
+        "rev": "256efb151240733658b0a1196760dbefdb4b6640",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                               |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`949155cb`](https://github.com/NixOS/nixpkgs/commit/949155cbecf4787874af0791fe3519bca8ef1a27) | `pinta: 2.0 -> 2.0.1`                                                        |
| [`7c9aa260`](https://github.com/NixOS/nixpkgs/commit/7c9aa260f2f84e1143824f544e95e2d1dbc1be35) | `python38Packages.shodan: 1.25.0 -> 1.26.0`                                  |
| [`d1acd89e`](https://github.com/NixOS/nixpkgs/commit/d1acd89e0116ff88eba80541027429fc922612e9) | `nimPackages.pixie: 1.1.3 -> 3.1.2`                                          |
| [`2aa77995`](https://github.com/NixOS/nixpkgs/commit/2aa7799528e26d0900fb046560b0937351516e8e) | `nimPackages.nimBuilder: collect deps from $pkgsHostTarget`                  |
| [`d19a3d44`](https://github.com/NixOS/nixpkgs/commit/d19a3d449aaecdff960f5956460d5a4544b10464) | `python3Packages.types-requests: 2.26.3 -> 2.27.0`                           |
| [`34334cf2`](https://github.com/NixOS/nixpkgs/commit/34334cf242296d2204bd23c4d425bee6ddefc6c5) | `python38Packages.azure-mgmt-notificationhubs: 7.0.0 -> 8.0.0`               |
| [`00bcc4cf`](https://github.com/NixOS/nixpkgs/commit/00bcc4cfdab88c05285cf983633de499b1442bc6) | `python3Packages.hydra: disable failing tests`                               |
| [`77f5a8ea`](https://github.com/NixOS/nixpkgs/commit/77f5a8eabc6ee208f215569642d32ca1c788308a) | `python3Packages.block-io: update inputs`                                    |
| [`8aae0b20`](https://github.com/NixOS/nixpkgs/commit/8aae0b20f3af9df3890535de0b3b8935213a393a) | `python3Packages.bitcoin-utils-fork-minimal: init at 0.4.11.4`               |
| [`465d38d5`](https://github.com/NixOS/nixpkgs/commit/465d38d53afce5697dcf21a513f6564b267bb1b8) | `python3Packages.bitcoinrpc: init at 0.5.0`                                  |
| [`2320573b`](https://github.com/NixOS/nixpkgs/commit/2320573b696600fc868e3cc35ce7fb4b56a10f8e) | `7zz: 21.04 -> 21.07`                                                        |
| [`5bc97cf9`](https://github.com/NixOS/nixpkgs/commit/5bc97cf9b396396779273af46178cf29ccc6dd1f) | `python3Packages.base58check: init at 1.0.2`                                 |
| [`b6fac428`](https://github.com/NixOS/nixpkgs/commit/b6fac428b11d618931ae4d231c6f0f5a3c5cc0ff) | `crda: update homepage`                                                      |
| [`93347854`](https://github.com/NixOS/nixpkgs/commit/9334785442ec4a50921f3a46ba5593e99ca8ff0b) | `crafty: remove`                                                             |
| [`af6a78c0`](https://github.com/NixOS/nixpkgs/commit/af6a78c0cafd67d7c8a21418ddbf2f332a8c3d04) | `cpuminer-multi: remove`                                                     |
| [`28d7cd8c`](https://github.com/NixOS/nixpkgs/commit/28d7cd8c46a9afec083f5c08c82e117d054a5eb3) | `coqPackages.CoLoR: update homepage`                                         |
| [`5e09daba`](https://github.com/NixOS/nixpkgs/commit/5e09daba1be25edf68f344da2bc8ab71b264debd) | `comic-relief: update homepage`                                              |
| [`9fdcccb6`](https://github.com/NixOS/nixpkgs/commit/9fdcccb613693c84ac464c1d31f890f72c801601) | `circus: update homepage`                                                    |
| [`8641b298`](https://github.com/NixOS/nixpkgs/commit/8641b298b126a289aadfdafa0d2939cd8a65e96d) | `chunkwm: remove`                                                            |
| [`5e04dac5`](https://github.com/NixOS/nixpkgs/commit/5e04dac5d6fdd4cce69e73946dbb39ce3f0e925b) | `ceph: update homepage`                                                      |
| [`84ee8e02`](https://github.com/NixOS/nixpkgs/commit/84ee8e02f45cb4b4182c53b0c7aacf64f2219902) | `cde: update homepage`                                                       |
| [`a90680e0`](https://github.com/NixOS/nixpkgs/commit/a90680e06f77892311fb6cc45e8179ed32fccb92) | `cayley: update homepage`                                                    |
| [`184340bf`](https://github.com/NixOS/nixpkgs/commit/184340bff50ce8f12eb4fb140ddfd2ed0f9f9fc5) | `caudec: update homepage and fix source URL`                                 |
| [`ea793d9e`](https://github.com/NixOS/nixpkgs/commit/ea793d9eccff4642d8f423cdc7b3ea4609e9b775) | `bunny: remove`                                                              |
| [`45e81e03`](https://github.com/NixOS/nixpkgs/commit/45e81e03ac57a51c57485761af8151af6e15c1e2) | `bsod: remove`                                                               |
| [`95d3bdb7`](https://github.com/NixOS/nixpkgs/commit/95d3bdb7a6999f3fd39972463b7a5dcd6eccdcda) | `bitcoin: update homepage`                                                   |
| [`05745bda`](https://github.com/NixOS/nixpkgs/commit/05745bdae39fb46e0eef3c93fa0a714c2526d395) | `bin_replace_string: remove`                                                 |
| [`e62da01a`](https://github.com/NixOS/nixpkgs/commit/e62da01a80d8af422d33cc397592bf636a1448eb) | `bee: update homepage`                                                       |
| [`5aeec270`](https://github.com/NixOS/nixpkgs/commit/5aeec27082e4375970bdad13c0e521160a015df6) | `beancount: update homepage`                                                 |
| [`16091bda`](https://github.com/NixOS/nixpkgs/commit/16091bda7974cd56ae07511860aabd77ce4ce12e) | `bashburn: remove`                                                           |
| [`c9339da1`](https://github.com/NixOS/nixpkgs/commit/c9339da1d11f784b198d80d59177fbdc6b5a977e) | `banner: update homepage`                                                    |
| [`ce4535e0`](https://github.com/NixOS/nixpkgs/commit/ce4535e01eef55cb5e653b20144b617d5011a319) | `banking: update homepage`                                                   |
| [`0bc6122a`](https://github.com/NixOS/nixpkgs/commit/0bc6122a2ac6e8ea045076b386422baeac66c750) | `astyle: update homepage`                                                    |
| [`801c41bd`](https://github.com/NixOS/nixpkgs/commit/801c41bd296e224042b0d967144fe45633031916) | `asn1c: remove`                                                              |
| [`f2a8126d`](https://github.com/NixOS/nixpkgs/commit/f2a8126dcc0b4024804eac136c23fe72450598e0) | `argtable: update homepage`                                                  |
| [`f9bbc840`](https://github.com/NixOS/nixpkgs/commit/f9bbc840e3fd93cd0a66de54ef81cb3fe70e3193) | `aqbanking: update homepage`                                                 |
| [`2c5e45c3`](https://github.com/NixOS/nixpkgs/commit/2c5e45c35c42ff06a30addc44f2e260b1651b02d) | `bypass403: remove`                                                          |
| [`12fb16f8`](https://github.com/NixOS/nixpkgs/commit/12fb16f8ad2b0971d1d73b45dd0a636cd1d33336) | `broot: 1.7.4 -> 1.9.1`                                                      |
| [`789434b7`](https://github.com/NixOS/nixpkgs/commit/789434b790d4cade0eceaff4716fe53b24223072) | `python3Packages.striprtf: add pythonImportsCheck`                           |
| [`abed3ce2`](https://github.com/NixOS/nixpkgs/commit/abed3ce21137e29ba11a6a553ea26f152a8584f4) | `python3Packages.identify: 2.4.1 -> 2.4.2`                                   |
| [`f8f6be81`](https://github.com/NixOS/nixpkgs/commit/f8f6be817f3b902ca1a2cc514999a5444c4f3d6b) | `python3Packages.meross-iot: 0.4.3.0 -> 0.4.4.1`                             |
| [`3c0f090c`](https://github.com/NixOS/nixpkgs/commit/3c0f090cacf5c9acca53b3d1b361784853646a5a) | `terraform: 1.1.2 -> 1.1.3`                                                  |
| [`ac6f54c1`](https://github.com/NixOS/nixpkgs/commit/ac6f54c1f78ba5d7dc8836dadb09d68e0155aed8) | `python3Packages.hahomematic: 0.13.3 -> 0.14.0`                              |
| [`e24fb016`](https://github.com/NixOS/nixpkgs/commit/e24fb01615acf8e56cbb5e91b711dc505f5c248f) | `gitlab: 14.6.0 -> 14.6.1 (#153764)`                                         |
| [`bfbd34eb`](https://github.com/NixOS/nixpkgs/commit/bfbd34eb3574f0d049e7cfa4bb37eb833b5e8882) | `checkov: 2.0.707 -> 2.0.708`                                                |
| [`30255bda`](https://github.com/NixOS/nixpkgs/commit/30255bdad573a520207fc787c52ad8c89eabc842) | `python38Packages.azure-mgmt-consumption: 8.0.0 -> 9.0.0`                    |
| [`c1220ff9`](https://github.com/NixOS/nixpkgs/commit/c1220ff9b0d8092564dee7ba083cfe2c572eed8e) | `bazel_4: dont propagate absl-py (#153779)`                                  |
| [`71fc9310`](https://github.com/NixOS/nixpkgs/commit/71fc9310a8ba04e3d47c48b8eb49112fcc384273) | `python38Packages.google-cloud-spanner: 3.12.0 -> 3.12.1`                    |
| [`06c274d7`](https://github.com/NixOS/nixpkgs/commit/06c274d7de20e99deb072ed33c17c96652ec1844) | `python38Packages.qcs-api-client: 0.20.7 -> 0.20.9`                          |
| [`a8245fd6`](https://github.com/NixOS/nixpkgs/commit/a8245fd6aef701d75c0ea2681682561dab92efee) | `python38Packages.trimesh: 3.9.40 -> 3.9.41`                                 |
| [`33a74f77`](https://github.com/NixOS/nixpkgs/commit/33a74f77a2c92dcddcbdd2daad521f7898314fb5) | `python38Packages.plaid-python: 8.8.0 -> 8.9.0`                              |
| [`df623cc5`](https://github.com/NixOS/nixpkgs/commit/df623cc58427aa722bb9f7ff824a6da8a344d593) | `python38Packages.goodwe: 0.2.10 -> 0.2.11`                                  |
| [`e9e90a94`](https://github.com/NixOS/nixpkgs/commit/e9e90a941b4cad2cc737570579f942e0dc57d9cf) | `treewide: replace http://web.archive.org with https://web.archive.org`      |
| [`0f050a12`](https://github.com/NixOS/nixpkgs/commit/0f050a1236954d26fc31eaae2803ffc0854a3e7b) | `treewide: replace http://github.com with https://github.com`                |
| [`9a58b51e`](https://github.com/NixOS/nixpkgs/commit/9a58b51e6ab40f8519fadabc2786dc9a56f27c63) | `treewide: fix homepages with permanent redirect to https`                   |
| [`6195b7c6`](https://github.com/NixOS/nixpkgs/commit/6195b7c6e0e462f280c770c3c5c8a72004074dc8) | `python38Packages.striprtf: 0.0.18 -> 0.0.19`                                |
| [`d77bbfcb`](https://github.com/NixOS/nixpkgs/commit/d77bbfcbb650d9c219ca3286e1efb707b922d7c2) | ``etcd: remove unnecessary `platform```                                      |
| [`7251af38`](https://github.com/NixOS/nixpkgs/commit/7251af3871b58b537c772e1409f6b098deec668f) | `blocksat-cli: 0.4.1 -> 0.4.2`                                               |
| [`9b830a41`](https://github.com/NixOS/nixpkgs/commit/9b830a41f55fb4741c48a5f977d2e61d55a7854e) | `termscp: 0.7.0 -> 0.8.0`                                                    |
| [`5fb039e9`](https://github.com/NixOS/nixpkgs/commit/5fb039e9d87694bb2860aa2fae77ec0bea8f30ba) | `kubescape: 1.0.137 -> 1.0.138`                                              |
| [`a8ef6056`](https://github.com/NixOS/nixpkgs/commit/a8ef60565ac9dc3fe2c68dc6a7fb29765e8bc2cf) | `mercurial: add CA cert to test env for libgit`                              |
| [`e9297912`](https://github.com/NixOS/nixpkgs/commit/e929791228b17b53bd6767ccca78f65195c074e1) | `mercurial: extend tests timeout for Hydra`                                  |
| [`3035c4ab`](https://github.com/NixOS/nixpkgs/commit/3035c4ab5cd049c007a7ffd38f2104f503112e81) | `vscode-extensions.apollographql.vscode-apollo: init at 1.19.9`              |
| [`d6f2a19f`](https://github.com/NixOS/nixpkgs/commit/d6f2a19ff4727475cd56c320dd7a5636d2e11c6c) | `maintainers: add datafoo`                                                   |
| [`45477f7c`](https://github.com/NixOS/nixpkgs/commit/45477f7ce5597ab3cc71fe4214d6b38119476426) | `nixos/caddy: add globalConfig option`                                       |
| [`46214206`](https://github.com/NixOS/nixpkgs/commit/462142060866ea45f35220c9b66f7d6984f3d0f1) | `fd: 8.3.0 -> 8.3.1`                                                         |
| [`958754bf`](https://github.com/NixOS/nixpkgs/commit/958754bfd5fa702e3c561301ca442e9fc0e80d4f) | `zoom-us: 5.8.6.739 -> 5.9.1.1380`                                           |
| [`cdfbc23f`](https://github.com/NixOS/nixpkgs/commit/cdfbc23f2de54271243f3fa215e436a89d2d2652) | `deno: 1.17.1 -> 1.17.2`                                                     |
| [`7d23c743`](https://github.com/NixOS/nixpkgs/commit/7d23c7437b52c2247edc1004ffb5012f2b112fac) | `mc: fix path of cat`                                                        |
| [`c2368173`](https://github.com/NixOS/nixpkgs/commit/c2368173cf5dfe1f8d87c4c6ff53bd5ca04b540e) | `python3Packages.algebraic-data-types: 0.1.1 -> 0.2.1`                       |
| [`3c846ac1`](https://github.com/NixOS/nixpkgs/commit/3c846ac1c5d9be73f08616d87fad091854e97a45) | `nghttp3: unstable-2021.11.10 -> unstable-2021-12-22`                        |
| [`8538701a`](https://github.com/NixOS/nixpkgs/commit/8538701a989d96c9f0a05cbd75936ca8e9b7c44d) | `ngtcp2: unstable-2021.11.10 -> unstable-2021-12-19`                         |
| [`5cfcc8ea`](https://github.com/NixOS/nixpkgs/commit/5cfcc8ea540d8ed86d91a360f1c9a830345d3bc4) | `quictls: 3.0.0+quic_unstable-2021-11-02 -> 3.0.1+quick_unstable-2021-12.14` |
| [`36969191`](https://github.com/NixOS/nixpkgs/commit/3696919111998f279df4b6233d592734ee8f223b) | `lagrange: 1.9.3 → 1.9.5`                                                    |
| [`e8f5af7c`](https://github.com/NixOS/nixpkgs/commit/e8f5af7cec7d35f559024c9209cc7a547d8c934b) | `bypass403: mark broken, upstream no longer exists`                          |
| [`d24b615d`](https://github.com/NixOS/nixpkgs/commit/d24b615dbf5a60abea7d8d6e87254a10cad92cf7) | `python38Packages.makefun: 1.12.1 -> 1.13.0`                                 |
| [`ea368b3c`](https://github.com/NixOS/nixpkgs/commit/ea368b3c62230e9fdad5e9dbf2d1e04e15b5f15d) | `gnomeExtensions.taskwhisperer: 16 -> 20`                                    |
| [`2dbca5d4`](https://github.com/NixOS/nixpkgs/commit/2dbca5d4b9aa012e48fb5aa39a656db2e7faf048) | `pinentry: remove qt for darwin due to build issues with qt`                 |