### PR TITLE
chore(flake/nixpkgs): `256efb15` -> `85a078a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1641564989,
-        "narHash": "sha256-Y9FiFkEQupqvdniGRv6SKOaIjsoColv5OrouZDSsmqE=",
+        "lastModified": 1641608739,
+        "narHash": "sha256-8kpW/lv3Cw/hta6YS+XiTw8DNN0TzcFXtdn6ZmrxI9w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "256efb151240733658b0a1196760dbefdb4b6640",
+        "rev": "85a078a25d7d41d805ef5fb3e90af7476d5fefd4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`b4ee6e0b`](https://github.com/NixOS/nixpkgs/commit/b4ee6e0b5dbc68aa5eb81ba50babb1c4b7eab5a7) | ``etcd: version the default `etcd```                                                 |
| [`5e53a3dd`](https://github.com/NixOS/nixpkgs/commit/5e53a3dd200a9ab07699bffecb0d044a6389ab14) | `terraform-providers.libvirt: remove separate derivation, add override for cdrtools` |
| [`5708e6aa`](https://github.com/NixOS/nixpkgs/commit/5708e6aa25e3c33dd04a7485277fe08f86cc5b1f) | `spigot: 20200901 -> 20210527`                                                       |
| [`1e910209`](https://github.com/NixOS/nixpkgs/commit/1e910209ae414755415ed8ef990fa3cbb07c8cd9) | `mkShell: make it buildable (#153194)`                                               |
| [`cacab72b`](https://github.com/NixOS/nixpkgs/commit/cacab72b753b3793bc3d6bbe41374044d990cfa9) | `go_1_17: 1.17.5 -> 1.17.6`                                                          |
| [`c5e9e730`](https://github.com/NixOS/nixpkgs/commit/c5e9e73029beb7cc25c10e8c712e1874b1c53d1a) | `gmsh: 4.9.0 -> 4.9.2`                                                               |
| [`de673964`](https://github.com/NixOS/nixpkgs/commit/de6739642c187656e8426496adc0e3926c0ad2d7) | `fio: add missing six dependency`                                                    |
| [`c94d5d98`](https://github.com/NixOS/nixpkgs/commit/c94d5d98f732c0d9c192ce45cd49a2f3663b7cf3) | `feh: 3.7.2 -> 3.8`                                                                  |
| [`807d89ce`](https://github.com/NixOS/nixpkgs/commit/807d89ced3792a19a9ea8b982514c6bc14855eac) | `vscode-extensions.hashicorp.terraform: 2.17.0 -> 2.18.0`                            |
| [`a40d8182`](https://github.com/NixOS/nixpkgs/commit/a40d8182da6c9a7aaccc05aceeaa49980870b58b) | `linux/hardened/patches/5.4: 5.4.169-hardened1 -> 5.4.170-hardened1`                 |
| [`2fe8933a`](https://github.com/NixOS/nixpkgs/commit/2fe8933a6298f3b1d6c6a07e47944f46d6b57e0a) | `linux/hardened/patches/4.19: 4.19.223-hardened1 -> 4.19.224-hardened1`              |
| [`99a4be5a`](https://github.com/NixOS/nixpkgs/commit/99a4be5a2da1ed33d10716ab7edd43f6e5500387) | `linux/hardened/patches/4.14: 4.14.260-hardened1 -> 4.14.261-hardened1`              |
| [`fa0e80ce`](https://github.com/NixOS/nixpkgs/commit/fa0e80ce0d2643cd51cdffadc7edbd65f91fe483) | `linux-rt_5_10: 5.10.87-rt59 -> 5.10.90-rt60`                                        |
| [`4594d249`](https://github.com/NixOS/nixpkgs/commit/4594d2494f1e15853e6845257c5beff19898a2d3) | `linux: 5.4.169 -> 5.4.170`                                                          |
| [`066a0b11`](https://github.com/NixOS/nixpkgs/commit/066a0b1197c73ffcb17b3d70eceade0e4934a501) | `linux: 5.15.12 -> 5.15.13`                                                          |
| [`6bcc2e35`](https://github.com/NixOS/nixpkgs/commit/6bcc2e352975cd9b09c9387a310b65f40c4eb418) | `linux: 5.10.89 -> 5.10.90`                                                          |
| [`b2ac2d62`](https://github.com/NixOS/nixpkgs/commit/b2ac2d62f8296938ceb4b26422f8ccf1f37a6215) | `linux: 4.9.295 -> 4.9.296`                                                          |
| [`0fb1f458`](https://github.com/NixOS/nixpkgs/commit/0fb1f45869f80f434fb2bce318c898f5e407449f) | `linux: 4.4.297 -> 4.4.298`                                                          |
| [`e22fa956`](https://github.com/NixOS/nixpkgs/commit/e22fa956c30606491ee5cb651db06cdb6500cd6d) | `linux: 4.19.223 -> 4.19.224`                                                        |
| [`ce05c553`](https://github.com/NixOS/nixpkgs/commit/ce05c553adce24487e2d4527fdd484ea7ed6bc3a) | `linux: 4.14.260 -> 4.14.261`                                                        |
| [`62dd28e2`](https://github.com/NixOS/nixpkgs/commit/62dd28e2f1222031a5dd399b4992d00af643ab3e) | `timedoctor: update maintainer`                                                      |
| [`4b4022db`](https://github.com/NixOS/nixpkgs/commit/4b4022db067be5e43a846edc48d3c2888ccad5bf) | `netdata: 1.31.0 -> 1.32.1`                                                          |
| [`156393e1`](https://github.com/NixOS/nixpkgs/commit/156393e104b6c5866d83d1b9318f89403b75aa3d) | `netdata: go.d.plugin: 0.28.1 -> 0.31.0`                                             |
| [`cc091b95`](https://github.com/NixOS/nixpkgs/commit/cc091b950cd5e6646c664d2f2b1fe6feec54216b) | `python3Packages.opencv4: fix installation metadata`                                 |
| [`1640412a`](https://github.com/NixOS/nixpkgs/commit/1640412a3ead36438b1cb37fb5f8339ea82c25e0) | `dwm: 6.2 -> 6.3`                                                                    |
| [`267d073a`](https://github.com/NixOS/nixpkgs/commit/267d073ac065dce9d760784f5ca057b7df1e876a) | `wordpress: 5.8.2 -> 5.8.3`                                                          |
| [`81d4c287`](https://github.com/NixOS/nixpkgs/commit/81d4c287488bcaeca6b9a154429a4f07ff18d7c1) | `lean: 3.36.0 -> 3.37.0`                                                             |
| [`568e0bc4`](https://github.com/NixOS/nixpkgs/commit/568e0bc498ee51fdd88e1e94089de05f2fdbd18b) | `Revert "python3Packages.pip-tools: 6.3.1 -> 6.4.0"`                                 |
| [`628e9059`](https://github.com/NixOS/nixpkgs/commit/628e9059a9e16e53c851f27e432c5f104beff17a) | `ocamlPackages.ca-certs-nss: 3.71.0.1 -> 3.74`                                       |
| [`a48ac877`](https://github.com/NixOS/nixpkgs/commit/a48ac877a63f2664a0fa36baa51a320dbc98b829) | `lensfun: make sourceRoot independent`                                               |
| [`785f04f9`](https://github.com/NixOS/nixpkgs/commit/785f04f9863ed1054f5ecc3d27bc555a22c8c06b) | `varnish: use jemalloc instead of glibc's malloc on linux.`                          |
| [`0701f290`](https://github.com/NixOS/nixpkgs/commit/0701f2904bdc2033981f7f78a4c0857e3348190a) | `python3Packages.tensorflow-metadata: init at 1.5.0 (#153767)`                       |
| [`292e674b`](https://github.com/NixOS/nixpkgs/commit/292e674bb11a7962a1d597420be914c48f3f8e10) | `python3Packages.flax: init at 0.3.6 (#153761)`                                      |
| [`6b9d877c`](https://github.com/NixOS/nixpkgs/commit/6b9d877c85a0a210ec755b35beb20952f66a52fd) | `graphite-gtk-theme: init at unstable-2022-01-04`                                    |
| [`1bdceb96`](https://github.com/NixOS/nixpkgs/commit/1bdceb96281f9146585ac80a12de8cb9858179a8) | `xsecurelock: add coreutils to saver_blank script path`                              |
| [`57bf320a`](https://github.com/NixOS/nixpkgs/commit/57bf320aad836878752f1b600f087db54abf0eee) | `libmysqlconnectorcpp: 8.0.23 -> 8.0.27`                                             |
| [`77eb74e1`](https://github.com/NixOS/nixpkgs/commit/77eb74e19d292a39720b76d628656bd6e926ce12) | `ungoogled-chromium: 96.0.4664.110 -> 97.0.4692.71`                                  |
| [`6ececace`](https://github.com/NixOS/nixpkgs/commit/6ececace95544c18aa77886f4266a024b7cd404a) | `krapslog: 0.3.0 -> 0.3.1`                                                           |
| [`59332446`](https://github.com/NixOS/nixpkgs/commit/593324465fbdbdd02f81b1954751140e56732322) | `csview: 0.3.10 -> 0.3.12`                                                           |
| [`5e89c658`](https://github.com/NixOS/nixpkgs/commit/5e89c6580d0c1731b4dfedb1c5a28ecd25e8ee10) | `cargo-tally: 1.0.0 -> 1.0.2`                                                        |
| [`bb40350e`](https://github.com/NixOS/nixpkgs/commit/bb40350e527facd331c700b6c5a3b744959d9301) | `gnunet-gtk: 0.14.0 -> 0.15.0`                                                       |
| [`c73b3c03`](https://github.com/NixOS/nixpkgs/commit/c73b3c0383b8a20a2533b9f07abe98ca096b032a) | `oha: 0.4.7 -> 0.5.0`                                                                |
| [`eb5c249b`](https://github.com/NixOS/nixpkgs/commit/eb5c249b403dd7a16536e8f1df88ef2534347c31) | `btop: 1.1.3 -> 1.1.4`                                                               |
| [`03ca8743`](https://github.com/NixOS/nixpkgs/commit/03ca8743152359935c11737e690cb659724f72a2) | `python3Packages.gradient: 1.8.13 -> 1.9.1`                                          |
| [`947a771b`](https://github.com/NixOS/nixpkgs/commit/947a771b0407703ad57d97fb6e576047d2886de8) | `python3Packages.gql: init at 3.0.0rc0`                                              |
| [`94c5e47f`](https://github.com/NixOS/nixpkgs/commit/94c5e47f9abe3deabc27f82686c9bbad1069e833) | `vscode-extensions.stkb.rewrap: 1.14.0 -> 1.15.4`                                    |
| [`c673de90`](https://github.com/NixOS/nixpkgs/commit/c673de90c6a100a55d946d698a37c91d015044d0) | `vscode-extensions.esbenp.prettier-vscode: 9.0.0 -> 9.1.0`                           |
| [`53caa408`](https://github.com/NixOS/nixpkgs/commit/53caa40811ea654d78d01bf2d2b575bd089d52c7) | `vscode-extensions.davidanson.vscode-markdownlint: 0.42.1 -> 0.45.0`                 |
| [`e38b7b1c`](https://github.com/NixOS/nixpkgs/commit/e38b7b1cef7d9b6b7d25694a72bd80cf46ec969b) | `python3Packages.gradient-utils: disable metrics tests`                              |
| [`bd72557a`](https://github.com/NixOS/nixpkgs/commit/bd72557ae9204b36937c0f65ce3993373bf8ecb1) | `vscode-extensions.streetsidesoftware.code-spell-checker: 1.10.2 -> 2.0.14`          |
| [`ea634d99`](https://github.com/NixOS/nixpkgs/commit/ea634d99e81f08f92a802e5526102bd0bd3cc6d3) | `materialize: 0.10.0 -> 0.15.0`                                                      |
| [`4e2ca8b0`](https://github.com/NixOS/nixpkgs/commit/4e2ca8b0a99eed958d32974a074cb11cedce3cc9) | `vscode-extensions.jakebecker.elixir-ls: init at 0.9.0`                              |
| [`c7218b3f`](https://github.com/NixOS/nixpkgs/commit/c7218b3f7e72f39df3477e38cfc4362fdaec9a66) | `vscode-extensions.bungcip.better-toml: init at 0.3.2`                               |
| [`048cb042`](https://github.com/NixOS/nixpkgs/commit/048cb042d61d00543d8b03985dd7d0128d85469c) | `nixos/tests/boot: Add ubootExtlinux test`                                           |
| [`2cb7743e`](https://github.com/NixOS/nixpkgs/commit/2cb7743e9c0f5c525c33ae2bccc7af30aefd97f0) | `sd-image-x86_64: init`                                                              |
| [`b70c23ea`](https://github.com/NixOS/nixpkgs/commit/b70c23ea61e88f6e6de55f3fb9c9c09ebb308e2a) | `sd-image: Propagate imageName to derivation`                                        |
| [`28b9bb54`](https://github.com/NixOS/nixpkgs/commit/28b9bb54087371e558e97e3beeccac1f6f5362cd) | `ubootQemuX86: init`                                                                 |
| [`823acb25`](https://github.com/NixOS/nixpkgs/commit/823acb25dd40392c1fc9f4bc5b7f5a369a6dd6eb) | `sd-image-riscv64-qemu: init`                                                        |
| [`16a907b0`](https://github.com/NixOS/nixpkgs/commit/16a907b00bc0aea1def4a39596fd745ad7705206) | `generic-extlinux-compatible: Allow disabling generation of device tree directives`  |
| [`d7cdd09a`](https://github.com/NixOS/nixpkgs/commit/d7cdd09ad26be7a8c26080cfad3059b278305214) | `all-hardware: Add virtio_mmio module`                                               |
| [`41cad5ea`](https://github.com/NixOS/nixpkgs/commit/41cad5ea68cbac8065b79a6c8b2c1182aa1c3f1d) | `all-hardware: Disable VMWare and Hyper-V modules on non-X86 platforms`              |
| [`37ec5df9`](https://github.com/NixOS/nixpkgs/commit/37ec5df9460dfcb5415aa9deb086b99a7a957cd0) | `python3Packages.django-environ: rename from django_environ`                         |
| [`31f20a69`](https://github.com/NixOS/nixpkgs/commit/31f20a69d95d010261534fe22bc233e924e83d71) | `python3Packages.django-oauth-toolkit: 1.2.0 -> 1.6.1`                               |
| [`5274779f`](https://github.com/NixOS/nixpkgs/commit/5274779f1927cb869653ad987f0c24652bc5f84a) | `python3Packages.oauthlib: 2020-05-08 -> 3.1.1`                                      |
| [`c57eccc3`](https://github.com/NixOS/nixpkgs/commit/c57eccc31a60e0b7eeb5f03be45b37fffba9b6e2) | `python3Packages.django-allauth: 0.40.0 -> 0.47.0`                                   |
| [`ec706249`](https://github.com/NixOS/nixpkgs/commit/ec7062492f88984017da132aa28167d0a5d3a456) | `python3Packages.pydub: clean up and adopt`                                          |
| [`c75bc3ab`](https://github.com/NixOS/nixpkgs/commit/c75bc3abc760a07eb7afc0be26eb1813a9867a84) | `nixos-rebuild: remove jq`                                                           |
| [`c274d045`](https://github.com/NixOS/nixpkgs/commit/c274d045ac254afe96b1f8139e974ada2c42059e) | `nixos-rebuild: do not resolve flake path`                                           |
| [`b1a89232`](https://github.com/NixOS/nixpkgs/commit/b1a8923231a273a8787dcfbc1444e6246ab7ac88) | `golden-cheetah: inline patch`                                                       |
| [`d4dc638d`](https://github.com/NixOS/nixpkgs/commit/d4dc638d77fc31aaa3000090e50a69fa6096fb86) | `nixos/test-driver: also passthru driverInteractive`                                 |
| [`2d5b086b`](https://github.com/NixOS/nixpkgs/commit/2d5b086b36cfb998eccee300291bb5e3bbf403b2) | `antimicrox: 3.2.0 -> 3.2.1`                                                         |
| [`843bac60`](https://github.com/NixOS/nixpkgs/commit/843bac6005e26b1823dfc2ebb1c1f697c48549d3) | `abiword: 3.0.4 -> 3.0.5`                                                            |
| [`cdc50f2c`](https://github.com/NixOS/nixpkgs/commit/cdc50f2c04bd9e6cc5848daf9c3ff552d6807db9) | `pcm: 202110 -> 202112`                                                              |
| [`a57c2d20`](https://github.com/NixOS/nixpkgs/commit/a57c2d2092ad9484ee14ecfebe6141cb74216c79) | `pt2-clone: 1.37 -> 1.38`                                                            |