### PR TITLE
chore(flake/nixpkgs): `c0e8b179` -> `cf26d7da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,10 +2,7 @@
   "nodes": {
     "agenix": {
       "inputs": {
-        "nixpkgs": [
-          "ragenix",
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1641576265,
@@ -60,6 +57,21 @@
       "original": {
         "owner": "edolstra",
         "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -120,16 +132,46 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1641653663,
-        "narHash": "sha256-zcJADGmWNP4//EJ9pfU+VeQPIXSTOer/PZ55M0KVjsg=",
+        "lastModified": 1641694724,
+        "narHash": "sha256-MayqlovgyixG3bS/PmOOVm5nVP5Z6SF2kPDPci/UsdU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c0e8b179c5bc0d0bd1d110919a8c2ace0ad3c35d",
+        "rev": "cf26d7da025a6df4ea053a9f17e4e1d50cf5fa92",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1641671388,
+        "narHash": "sha256-aHoO6CpPLJK8hLkPJrpMnCRnj3YbfQZ7HNcXcnI83E0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "32356ce11b8cc5cc421b68138ae8c730cc8ad4a2",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1641671388,
+        "narHash": "sha256-aHoO6CpPLJK8hLkPJrpMnCRnj3YbfQZ7HNcXcnI83E0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "32356ce11b8cc5cc421b68138ae8c730cc8ad4a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -198,14 +240,8 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "ragenix",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "ragenix",
-          "nixpkgs"
-        ]
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1641609771,


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`cb6adff3`](https://github.com/NixOS/nixpkgs/commit/cb6adff3ba6f9a347dcc2d7afbade1e25fee0a7b) | `python3Packages.img2pdf: run tests (#152365)`                                      |
| [`752ae866`](https://github.com/NixOS/nixpkgs/commit/752ae8660562b7a037d7c49bcf95465028a35005) | `python38Packages.python-telegram-bot: 13.8.1 -> 13.9`                              |
| [`4d70e2dc`](https://github.com/NixOS/nixpkgs/commit/4d70e2dca4457e22753aba5ba118a59e1d5535fe) | `vala_0_52: 0.52.8 → 0.52.9`                                                        |
| [`f0225e37`](https://github.com/NixOS/nixpkgs/commit/f0225e376fede135d36f91893b8af26d0e33232e) | `vala_0_48: 0.48.20 → 0.48.21`                                                      |
| [`e4255a2a`](https://github.com/NixOS/nixpkgs/commit/e4255a2ad0ccb08bd0ac20ac0bdbd6c6654c68bf) | `CODEOWNERS: subscribe to few pkgs, modules and tests`                              |
| [`8c161f6a`](https://github.com/NixOS/nixpkgs/commit/8c161f6a62852e7e36b3dbb2ca3168e07a3e5ec8) | `emacs.pkgs.melpa*: Fix version number checks if number is zero`                    |
| [`ff0ee5bf`](https://github.com/NixOS/nixpkgs/commit/ff0ee5bf85841c0e4af0d739c490495830b50ea2) | `octoprint: ignore pyyaml version constraint`                                       |
| [`c3037644`](https://github.com/NixOS/nixpkgs/commit/c3037644d7c4b08c81f62c45b77a9c88b25736fd) | `azure-cli: fix pinning for azure-mgmt-compute`                                     |
| [`52658fb0`](https://github.com/NixOS/nixpkgs/commit/52658fb09090ef5958037130ed865dd841b822a3) | `python38Packages.azure-mgmt-compute: 23.1.0 -> 24.0.0`                             |
| [`234f0a25`](https://github.com/NixOS/nixpkgs/commit/234f0a25b71e392a7c2ea544f65d648826bcc560) | `python38Packages.schema-salad: 8.2.20211222191353 -> 8.2.20220103095339`           |
| [`7f725209`](https://github.com/NixOS/nixpkgs/commit/7f7252093ffdd080d0e3f3faa7a4a9ccda51e616) | `emacs.pkgs.melpa*: Fix version numbers with negative numbers`                      |
| [`8ee96596`](https://github.com/NixOS/nixpkgs/commit/8ee965960239255c696d950f302b040a22524092) | `python3Packages.hahomematic: 0.15.2 -> 0.16.0`                                     |
| [`cf141804`](https://github.com/NixOS/nixpkgs/commit/cf141804e3d7540600aa7cf5fe534a7819ac3947) | `python3Packages.hahomematic: 0.15.0 -> 0.15.2`                                     |
| [`e0a7e674`](https://github.com/NixOS/nixpkgs/commit/e0a7e674584196fb64d2d43e7f1f91a10737b492) | `python3Packages.pydevccu: 0.0.9 -> 0.1.0`                                          |
| [`5f8f72c1`](https://github.com/NixOS/nixpkgs/commit/5f8f72c10c43514a4e9093efb9029cf3f8a9ec00) | `klee: init at 2.2`                                                                 |
| [`30b3b39f`](https://github.com/NixOS/nixpkgs/commit/30b3b39f72e7c61844df3dc1fe793d7805aae646) | `org-generated.nix: remove`                                                         |
| [`b575e8c2`](https://github.com/NixOS/nixpkgs/commit/b575e8c297302fb1429649f62609ffb4fbf7dc41) | `emacsPackages.tramp: remove`                                                       |
| [`39ce4ddd`](https://github.com/NixOS/nixpkgs/commit/39ce4ddd85bad02d48c7c0588d50ee03af6a8ef9) | `nixos/prometheus: fix usage of bearer_token`                                       |
| [`6ee417ac`](https://github.com/NixOS/nixpkgs/commit/6ee417ace669ff6f051d00797046dc11c694cbc7) | `emacsPackages.bqn-mode: 0.pre+date=2021-12-03 -> 0.pre+date=2022-01-07`            |
| [`ce9d3bee`](https://github.com/NixOS/nixpkgs/commit/ce9d3bee88fd01fc4f8e8ec911a1778f6479091c) | `emacsPackages.tramp: 2.5.1 -> 2.5.2`                                               |
| [`34b6ed85`](https://github.com/NixOS/nixpkgs/commit/34b6ed85730156d554ed2adaf4656f6c302050ce) | `emacsPackages.apheleia: 1.1.2+unstable=2021-10-03 -> 1.2`                          |
| [`0a19fe83`](https://github.com/NixOS/nixpkgs/commit/0a19fe8310099fe1857e1be505df7db97da9d035) | `uriparser: 0.9.5 -> 0.9.5 (security, fixes #153777) (#154033)`                     |
| [`46223d06`](https://github.com/NixOS/nixpkgs/commit/46223d06c63b9bdf979a714cec4ba7c45d098946) | `elpa-generated.nix: manual fixup of duplicate shell-command-plus`                  |
| [`69dadbcd`](https://github.com/NixOS/nixpkgs/commit/69dadbcd8bc98f9ab27cbf985059c8511946dafc) | `elpa-packages 2022-01-08`                                                          |
| [`9c51fce6`](https://github.com/NixOS/nixpkgs/commit/9c51fce6a92a73517cedc58969239ddc726faf60) | `timg: 1.4.2 -> 1.4.3`                                                              |
| [`0a0c1140`](https://github.com/NixOS/nixpkgs/commit/0a0c1140dc3ca394e29033d059d7c18fd4bdfd7d) | `melpa-packages 2022-01-08`                                                         |
| [`a404e491`](https://github.com/NixOS/nixpkgs/commit/a404e49124416564236169ac67c2c87bc4945b8d) | `python3Packages.typical: 2.7.9 -> 2.8.0`                                           |
| [`17113a7b`](https://github.com/NixOS/nixpkgs/commit/17113a7b699b243514c1e9dabae81abdc9963d71) | `python3Packages.fastjsonschema: 2.15.1 -> 2.15.2`                                  |
| [`41d2ab40`](https://github.com/NixOS/nixpkgs/commit/41d2ab408517d45f1edeb45649045a0e3ea109bb) | `python38Packages.bitarray: 2.3.4 -> 2.3.5`                                         |
| [`2fbf860e`](https://github.com/NixOS/nixpkgs/commit/2fbf860e58b9aed749db94e92591b41ed163aea6) | `python38Packages.types-futures: 3.3.1 -> 3.3.2`                                    |
| [`6015cd8e`](https://github.com/NixOS/nixpkgs/commit/6015cd8ea8d4030655a1379aad6628555cdf8455) | `python38Packages.pudb: 2021.2.2 -> 2022.1`                                         |
| [`89d61280`](https://github.com/NixOS/nixpkgs/commit/89d612804d0cdfb4c8280070a6ad4acae09f734c) | `python38Packages.jdatetime: 3.7.0 -> 3.8.0`                                        |
| [`6a1109ad`](https://github.com/NixOS/nixpkgs/commit/6a1109adfa4b81627c967e1aa791e816a49e12de) | `vimPlugins.parinfer-rust at init`                                                  |
| [`d8c384e6`](https://github.com/NixOS/nixpkgs/commit/d8c384e6b81598689e0e96b341f1b149a88a2ddc) | `python38Packages.pyrogram: 1.2.0 -> 1.3.0`                                         |
| [`427d3d15`](https://github.com/NixOS/nixpkgs/commit/427d3d15d4f5b5aa5c02ffc79b7277714ebb5e9f) | `python3Packages.mdformat: 0.7.11 -> 0.7.12`                                        |
| [`81e1292b`](https://github.com/NixOS/nixpkgs/commit/81e1292bb39c8fd6d5ecf16b80ebc80c2cc61316) | `python38Packages.enamlx: 0.5.0 -> 0.6.0`                                           |
| [`6f99ebff`](https://github.com/NixOS/nixpkgs/commit/6f99ebff740502d13becd18f1c12d0b47f2e1ecd) | `python3Packages.orm: 0.1.5 -> 0.3.1`                                               |
| [`cf62e9c0`](https://github.com/NixOS/nixpkgs/commit/cf62e9c07a29453468ede8917ecb3800392ee3a3) | `python3Packages.typesystem: 0.2.4 -> 0.4.1`                                        |
| [`1cdee8ee`](https://github.com/NixOS/nixpkgs/commit/1cdee8eec0935c763dd8f4320eabfa53fa3cf97f) | `python38Packages.lightgbm: 3.3.1 -> 3.3.2`                                         |
| [`51494bfe`](https://github.com/NixOS/nixpkgs/commit/51494bfecb7af9b2407a74362ae724bd2feafd69) | `python38Packages.cornice: 6.0.0 -> 6.0.1`                                          |
| [`33f86c6a`](https://github.com/NixOS/nixpkgs/commit/33f86c6aa79383ba909b3e98eff17a49f21402fe) | `python38Packages.types-setuptools: 57.4.5 -> 57.4.6`                               |
| [`ceb262a9`](https://github.com/NixOS/nixpkgs/commit/ceb262a9231afc472db047222ef3d7538911b1c9) | `python38Packages.types-pytz: 2021.3.3 -> 2021.3.4`                                 |
| [`fbc1fd22`](https://github.com/NixOS/nixpkgs/commit/fbc1fd224a7bc460ed0f02b8e4180209ff1bec55) | `python38Packages.geoalchemy2: 0.10.1 -> 0.10.2`                                    |
| [`c1b06381`](https://github.com/NixOS/nixpkgs/commit/c1b06381d8a742d9a6214018399b56f443d0717e) | `nongnu-packages 2022-01-08`                                                        |
| [`d990513e`](https://github.com/NixOS/nixpkgs/commit/d990513e494758bdad6d67cde33bbb7f28d36b6a) | `calibre: fix build on staging-next due to missing setuptools`                      |
| [`13c7faa8`](https://github.com/NixOS/nixpkgs/commit/13c7faa86538bb62904fe8e60dbadcc2455fc0f3) | `duf: 0.6.2 -> 0.7.0`                                                               |
| [`9d7399d9`](https://github.com/NixOS/nixpkgs/commit/9d7399d998dc8328b3960c4c5704280dcdd45cfc) | `bat: 0.18.3 -> 0.19.0`                                                             |
| [`840d7881`](https://github.com/NixOS/nixpkgs/commit/840d7881a60826eed652958d2edebf45f541cf26) | `icewm: 2.6.0 → 2.9.4`                                                              |
| [`d69abfe5`](https://github.com/NixOS/nixpkgs/commit/d69abfe510c77fa4cd01346e155c8a6e0e6de920) | `mercurial: move tests to passthru.tests`                                           |
| [`e898681c`](https://github.com/NixOS/nixpkgs/commit/e898681ce1f119ae3b7208c6950a9db16ff3cae1) | `flexget: 3.2.7 -> 3.2.8`                                                           |
| [`b2645131`](https://github.com/NixOS/nixpkgs/commit/b26451314a196a4e4d3afbc886c7df57001a5c31) | `python3.pkgs.weasyprint: 53.4 → 54.0`                                              |
| [`9ef985aa`](https://github.com/NixOS/nixpkgs/commit/9ef985aa84f1c2b1da55a8a3ab341182c79c34eb) | `phoronix-test-suite: 10.6.1 -> 10.8.0`                                             |
| [`9d3ba92d`](https://github.com/NixOS/nixpkgs/commit/9d3ba92d635aaf728423488205b04f15e8953887) | `nixos/documentation: fix docs cross build`                                         |
| [`345370b2`](https://github.com/NixOS/nixpkgs/commit/345370b21cdba29aab36f53ae101543ead01f748) | `swiften: another build fix attempt`                                                |
| [`573edbf4`](https://github.com/NixOS/nixpkgs/commit/573edbf405c369e9d9c8860b8b4abe7d87d1cb3d) | `swiften: use dependencies from nix`                                                |
| [`0edf0fd2`](https://github.com/NixOS/nixpkgs/commit/0edf0fd22074c2ee178b194203643c19f9fb66d0) | `hello: Test independence of environment.noXlibs`                                   |
| [`c555a4e3`](https://github.com/NixOS/nixpkgs/commit/c555a4e329904552a92947e125d9bc9d9a17c59e) | `testEqualDerivation: init`                                                         |
| [`419cf5cd`](https://github.com/NixOS/nixpkgs/commit/419cf5cd4f1409d0b92a9d5ef956ec2e4970e406) | `swiften: format the expression`                                                    |
| [`ec90decc`](https://github.com/NixOS/nixpkgs/commit/ec90decc7d175814f673803682b41d66f891f7b2) | `swiften: fix build`                                                                |
| [`37e9987f`](https://github.com/NixOS/nixpkgs/commit/37e9987fb94f3e52f23d284fe07b4a5b7c844e06) | `swiften: use system expat`                                                         |
| [`eed857b5`](https://github.com/NixOS/nixpkgs/commit/eed857b539fd78ffcaf74d52543c17b568a2a4ad) | `python3.pkgs.panflute: 2.1.0 → 2.1.3`                                              |
| [`8fc9b26b`](https://github.com/NixOS/nixpkgs/commit/8fc9b26bc36ce17045439d0a64ed8f6ba36f0dfc) | `notmuch: 0.34.1 → 0.34.2`                                                          |
| [`2dae7387`](https://github.com/NixOS/nixpkgs/commit/2dae738752d1f19f862626bf38ead9ed4ff77fb4) | `libcryptui: fix build with latest gnupg`                                           |
| [`be9e2cf9`](https://github.com/NixOS/nixpkgs/commit/be9e2cf9cc2b39f25d1388ce6827b9b5870a34d7) | `python38Packages.python-keystoneclient: 4.3.0 -> 4.4.0`                            |
| [`41688346`](https://github.com/NixOS/nixpkgs/commit/416883461db4d3b8d451155dd6b6886da876f16e) | `mercurialFull: skip an unstable experimental test`                                 |
| [`e8522472`](https://github.com/NixOS/nixpkgs/commit/e852247238a8271972a1669704e2dd82b31ad75b) | `python38Packages.python-ironicclient: 4.9.0 -> 4.10.0`                             |
| [`bf42bd1f`](https://github.com/NixOS/nixpkgs/commit/bf42bd1f5f4dd2ad78cdcc5e08d7fbe6355f3e1d) | `python38Packages.python-heatclient: 2.4.0 -> 2.5.0`                                |
| [`539f55df`](https://github.com/NixOS/nixpkgs/commit/539f55df445f935add5765e8fb8919a8cc076456) | ``pluginupdate.py: make experimental feature `nix-command` explicit``               |
| [`f3386ca8`](https://github.com/NixOS/nixpkgs/commit/f3386ca8cce32ed7ced59ea043543336d3249b72) | `qt5: apply makeScope overrides to qtModule`                                        |
| [`fe00d45c`](https://github.com/NixOS/nixpkgs/commit/fe00d45c50de7dc3a4fe3803f13b5b5119244d2f) | ``buildGoModule: remove `runVend```                                                 |
| [`d50b6bff`](https://github.com/NixOS/nixpkgs/commit/d50b6bff8956e674ff4091f2ff27e965c078b215) | `go_1_16: 1.16.12 -> 1.16.13`                                                       |
| [`58add1bf`](https://github.com/NixOS/nixpkgs/commit/58add1bf846024da2803b849cb8b25052433580d) | `deluge: 2.0.3 -> 2.0.5`                                                            |
| [`62c344c7`](https://github.com/NixOS/nixpkgs/commit/62c344c7a28b82db849f094602a3773354c2cd20) | `comma: init at 1.1.0`                                                              |
| [`6a75955c`](https://github.com/NixOS/nixpkgs/commit/6a75955c21c4f93dc0a24fc12729ab55039370c5) | `nixos/sniproxy: remove unused logDir option`                                       |
| [`f7500b6f`](https://github.com/NixOS/nixpkgs/commit/f7500b6f57949425bb594e79fe8e25ec93842a94) | `python3Packages.hydra: fix bad merge conflict resolution`                          |
| [`71e415bf`](https://github.com/NixOS/nixpkgs/commit/71e415bf85c3ed07a9dc9fbfb7eb68754dd37fa4) | `Revert "Revert "python3Packages.pip-tools: 6.3.1 -> 6.4.0""`                       |
| [`a5f7429e`](https://github.com/NixOS/nixpkgs/commit/a5f7429ef095b403eac47eae94efd57ed16d5cbe) | `python3Packages.treex: init at 0.6.7`                                              |
| [`0341138a`](https://github.com/NixOS/nixpkgs/commit/0341138ad72a1900ee347c6804da9212be443e08) | `python3Packages.apache-beam: init at 2.35.0`                                       |
| [`5b9e2929`](https://github.com/NixOS/nixpkgs/commit/5b9e29297d3f3ea64302b6257d873efadf739fe0) | `pangoxsl: remove the package`                                                      |
| [`422c5a5d`](https://github.com/NixOS/nixpkgs/commit/422c5a5db556511c2b32fcea552c5a74bea980e3) | `stunnel: allow servers to connect to other hosts`                                  |
| [`a7f3bd4b`](https://github.com/NixOS/nixpkgs/commit/a7f3bd4bf7ad413bb4fcfe9fdb1866cc9e1fb704) | `mercurial: add pacien as maintainer`                                               |
| [`c788416d`](https://github.com/NixOS/nixpkgs/commit/c788416d11b703eb7db02236f2ed54912ccc5912) | `mosquitto: 2.0.12 -> 2.0.14`                                                       |
| [`c7548ff9`](https://github.com/NixOS/nixpkgs/commit/c7548ff9a94a1c3e7a3b15381fd0236de773fb98) | `aws-sdk-cpp: fix cmake config`                                                     |
| [`fe912e67`](https://github.com/NixOS/nixpkgs/commit/fe912e67e38a1ad1b8a9f33a41db4f1d6d775280) | `aws-sdk-cpp: update GitHub repo owner`                                             |
| [`5f490b42`](https://github.com/NixOS/nixpkgs/commit/5f490b427049a237fe30a1d2563631cd625c565a) | `kde/gear: 21.12.0 -> 21.12.1`                                                      |
| [`e95023d4`](https://github.com/NixOS/nixpkgs/commit/e95023d46641c8400b245cf12657db0668b6ed71) | `gns3: 2.2.18 -> 2.2.28`                                                            |
| [`982010d2`](https://github.com/NixOS/nixpkgs/commit/982010d21906f34de829b151f0357c98ea4d4c52) | `htslib: 1.13 -> 1.14`                                                              |
| [`44bf8b5b`](https://github.com/NixOS/nixpkgs/commit/44bf8b5b28b386b6dda8be487b2849303d4697ea) | `nix-eval-jobs: 0.0.2 -> 0.0.3`                                                     |
| [`11ade17a`](https://github.com/NixOS/nixpkgs/commit/11ade17a3fd0d1c46bc3011707c2d327a1b411df) | `kde/plasma5: 5.23.4 -> 5.23.5`                                                     |
| [`79e0cc23`](https://github.com/NixOS/nixpkgs/commit/79e0cc2369bd8536b662ae70a0eb4ff9f0bcd45b) | `python310Packages.subunit: fix tests, again`                                       |
| [`9988b481`](https://github.com/NixOS/nixpkgs/commit/9988b481a9d848e61d20deb37691b01d541cc70f) | `python3Packages.pydantic: 1.8.2 -> 1.9.0`                                          |
| [`fa44da7f`](https://github.com/NixOS/nixpkgs/commit/fa44da7f5167e2866a2227d55ebf13335d825025) | `python3Packages.parsy: fix eval`                                                   |
| [`fba4cce6`](https://github.com/NixOS/nixpkgs/commit/fba4cce694d76ec190c28bfd8365cb4da8503ffa) | `python3Packages.nidaqmx: fix eval failing due to misspelling`                      |
| [`8b285365`](https://github.com/NixOS/nixpkgs/commit/8b2853659868448ccf8ced72cc4c656f9c5e0fab) | `python3Packages.subunit: fix tests for 3.10`                                       |
| [`5b706ee4`](https://github.com/NixOS/nixpkgs/commit/5b706ee48ae078ba889ce3ede13bd480f57235f9) | `python3Packages.jedi: 0.18.0 -> 0.18.1`                                            |
| [`fd9a113d`](https://github.com/NixOS/nixpkgs/commit/fd9a113db992848c465821e17562d650cee659ad) | `python310Packages.subunit: fix evaluation`                                         |
| [`cafcd1d0`](https://github.com/NixOS/nixpkgs/commit/cafcd1d061bfff62c6d372a7f98a09b5bdc4e468) | `python310Packages.subunit: disable tests`                                          |
| [`58d0c2ba`](https://github.com/NixOS/nixpkgs/commit/58d0c2baf03cedfaff3e3300bc0f4364b96755e0) | `python310Packages.parso: 0.8.1 -> 0.8.3, disable 3.10 incompatible tests`          |
| [`3709c129`](https://github.com/NixOS/nixpkgs/commit/3709c129eff4a74f27c104cce7f75b76c0908469) | `python310Packages.fixtures: propagate implicit six dependency`                     |
| [`24ac7e12`](https://github.com/NixOS/nixpkgs/commit/24ac7e12359a2137cec1e1aaf162bfab40f7a9be) | `python310Packages.html5lib: use pytestCheckHook, disable tests`                    |
| [`76e8c85e`](https://github.com/NixOS/nixpkgs/commit/76e8c85e6570211ab284a41b2d98654451a52ea8) | `python3Packages.testtools: remove unittest2, unneeded`                             |
| [`ff799008`](https://github.com/NixOS/nixpkgs/commit/ff7990087c63623eb31ef8e22bcfdc2254927cb2) | `python3Packages.nidaqmx: mark disabled for 3.10+`                                  |
| [`cf30a8b9`](https://github.com/NixOS/nixpkgs/commit/cf30a8b90471fe14bfd3fea63d37431b4adb98a9) | `python310Packages.quamash: fix build for 3.10`                                     |
| [`e0a0f3be`](https://github.com/NixOS/nixpkgs/commit/e0a0f3be9483ab958648f76b5245b50bb7cfe45d) | `python3Packages.remarhsal: fix build, enable tests, migrate to pyproject format`   |
| [`86e2880d`](https://github.com/NixOS/nixpkgs/commit/86e2880d1146aa0df6025ad5d1da84e4a137317e) | `tests.concat: added empty case`                                                    |
| [`a3f99775`](https://github.com/NixOS/nixpkgs/commit/a3f99775dab6584271881171003ab55a06381a80) | `Revert "castxml: mark as broken on Darwin"`                                        |
| [`79e65cb5`](https://github.com/NixOS/nixpkgs/commit/79e65cb57db2cb1366453626b03970bda2304a9b) | `appflowy: init at 0.0.2`                                                           |
| [`eb901b0b`](https://github.com/NixOS/nixpkgs/commit/eb901b0b6f7e2104517c6b9cfa8a3953ab0c0f9a) | `python3Packages.duckdb: fix eval`                                                  |
| [`d69234ac`](https://github.com/NixOS/nixpkgs/commit/d69234ac7221ff15869cf13b1b40003afb4294d6) | `home-assistant: relax PyJWT constraint`                                            |
| [`bc370f5a`](https://github.com/NixOS/nixpkgs/commit/bc370f5af3b288a5a9a812bbf168fd4282e14698) | `python3Packages.httplib2: disable failing test`                                    |
| [`033686d7`](https://github.com/NixOS/nixpkgs/commit/033686d737a6de959eff6f539c575ed79eae0755) | `python3Packages.python-multipart: fix tests`                                       |
| [`eb301258`](https://github.com/NixOS/nixpkgs/commit/eb301258ef2aa4c95245311a2e888a12ac0fd811) | `andyetitmoves: deprecate phases and refactor`                                      |
| [`741668e4`](https://github.com/NixOS/nixpkgs/commit/741668e4b0d5ae964d3fb42399cebab6078f4524) | `nimbo: add awscli to $PATH instead of propagatedBuildInputs`                       |
| [`482634d5`](https://github.com/NixOS/nixpkgs/commit/482634d5ca393aac313daee6a42b3ffc6454bc07) | `awscli: 1.22.14 -> 1.22.21`                                                        |
| [`16b86120`](https://github.com/NixOS/nixpkgs/commit/16b86120168543ad15050eea8625c4433a069733) | `awscli: pin pyyaml`                                                                |
| [`793a2f50`](https://github.com/NixOS/nixpkgs/commit/793a2f50f13f0c630cffbbb214f4128254945701) | `nixos/test-driver: remove unused imports, add pylint unused-import check`          |
| [`a2f50928`](https://github.com/NixOS/nixpkgs/commit/a2f5092867927ea6a9bfc916ae191d3722350a33) | `nixos/test-driver: simplify logic, reduce interaction surface`                     |
| [`7830f000`](https://github.com/NixOS/nixpkgs/commit/7830f000c57bb616b178a6a8eaef9659938ca7ea) | `nixos/test-driver: simplify coopmulti`                                             |
| [`ac6c06c5`](https://github.com/NixOS/nixpkgs/commit/ac6c06c549ed0d18e87776405d8daba16de4ae1e) | `nixos/test-driver: bump version`                                                   |
| [`4e1556ed`](https://github.com/NixOS/nixpkgs/commit/4e1556ed4d43da1f930b3fcf0fc20d827a34f3d2) | `nixos/test-driver: add polling_condition`                                          |
| [`5187d2cd`](https://github.com/NixOS/nixpkgs/commit/5187d2cd8f41b482dde3a7534143ccd526d67f08) | `concatText: test now works`                                                        |
| [`9b760ab5`](https://github.com/NixOS/nixpkgs/commit/9b760ab5c480c517646def9a5484e361ded9bed7) | `mesa: 21.3.2 -> 21.3.3`                                                            |
| [`1ec33143`](https://github.com/NixOS/nixpkgs/commit/1ec3314344cb9fb2716c2a8f7aff773790153eaf) | `python3Packages.pymavlink: fix src hash broken in merge conflict resolution`       |
| [`37e104da`](https://github.com/NixOS/nixpkgs/commit/37e104da68f8edaf590c6ffdc70d5065545e23e3) | `Revert "matplotlib-inline: Don't depend on matplotlib -> smaller ipython closure"` |
| [`f38610c0`](https://github.com/NixOS/nixpkgs/commit/f38610c09ba8babd6e21b5d0e6f106762e5dcdbe) | `matplotlib-inline: Don't depend on matplotlib -> smaller ipython closure`          |
| [`b5fbd8a0`](https://github.com/NixOS/nixpkgs/commit/b5fbd8a057dbf9515969f5e5f2d34fd9c078f24d) | `lirc: fix build against pyyaml-6.0`                                                |
| [`6aff8a56`](https://github.com/NixOS/nixpkgs/commit/6aff8a56b29298b23a7fd0dccd5c564c2ba6046c) | `python310Packages.tensorflow-bin: disable on 3.10`                                 |
| [`9bb624e6`](https://github.com/NixOS/nixpkgs/commit/9bb624e69f41ae0e397c0f78ffc05ba5392b02b2) | `python310Packages.pytest: fix tests`                                               |
| [`2db51d1e`](https://github.com/NixOS/nixpkgs/commit/2db51d1e742bd83e5277e81340c42c2775af93ed) | `python38Packages: Stop recursing into package set`                                 |
| [`125f023a`](https://github.com/NixOS/nixpkgs/commit/125f023a50a7664d914226e16b9d2a4b368c9c3a) | `python310Packages: Recurse into package set`                                       |
| [`76488857`](https://github.com/NixOS/nixpkgs/commit/76488857ab523252a1e785e1d97e95534865dd4c) | `python310: 3.10.0 -> 3.10.1`                                                       |
| [`0826392b`](https://github.com/NixOS/nixpkgs/commit/0826392b3a0314a9db40078a81968c4848ea9652) | `boehmgc: revert "8.0.6 -> 8.2.0", experimental release`                            |
| [`fb883d4a`](https://github.com/NixOS/nixpkgs/commit/fb883d4a9eb80c52c0e8ad3f5f20d0b654f442c8) | `libwacom: 1.12 -> 1.99.1`                                                          |
| [`cafbe817`](https://github.com/NixOS/nixpkgs/commit/cafbe8171c8a36d8f4fa843c1d4d893a61489112) | `python: conditionalize redundant Darwin patch (#137858)`                           |
| [`b44c9edd`](https://github.com/NixOS/nixpkgs/commit/b44c9edd22cb9e6094c0c5edf3dbbd3f33e8fc75) | `c-blosc: 1.21.0 -> 1.21.1`                                                         |
| [`9ae41915`](https://github.com/NixOS/nixpkgs/commit/9ae419154078175419683aa853e65a44104cb9aa) | `fribidi: 1.0.10 -> 1.0.11`                                                         |
| [`653ff61c`](https://github.com/NixOS/nixpkgs/commit/653ff61cb6f891bf493035af81d16c8e002fdbee) | `cmake: 3.21.2 -> 3.22.1 (#147818)`                                                 |
| [`05cfc5fd`](https://github.com/NixOS/nixpkgs/commit/05cfc5fdab2a943ee0de9cf003ff038e8388d289) | `poppler_data: 0.4.10 -> 0.4.11 (#149621)`                                          |
| [`c9c2296a`](https://github.com/NixOS/nixpkgs/commit/c9c2296ac77574c5b82991005efdbf580ca6245d) | `libtasn1: 4.17.0 -> 4.18.0 (#149963)`                                              |
| [`c6beba46`](https://github.com/NixOS/nixpkgs/commit/c6beba466135b51591777594e07e6f84dbc7c10e) | `libksba: 1.5.1 -> 1.6.0 (#149974)`                                                 |
| [`ce78b172`](https://github.com/NixOS/nixpkgs/commit/ce78b172740cbb24dd49da7990de7630e04178b8) | `libpipeline: 1.5.3 -> 1.5.4 (#149987)`                                             |
| [`fc3193aa`](https://github.com/NixOS/nixpkgs/commit/fc3193aaa69abe6bb84ab6f7bb2d90079b217d23) | `libevdev: 1.11.0 -> 1.12.0 (#149993)`                                              |
| [`1b67f41c`](https://github.com/NixOS/nixpkgs/commit/1b67f41ce52725b47461b80dad898a39ce9afa59) | `libmbim: 1.26.0 -> 1.26.2 (#150000)`                                               |
| [`094be66c`](https://github.com/NixOS/nixpkgs/commit/094be66ce2d9a70b954c1255d1c4616881bd545d) | `libedit: 20210714-3.1 -> 20210910-3.1 (#150017)`                                   |
| [`ebc4991c`](https://github.com/NixOS/nixpkgs/commit/ebc4991cc89c2f7eec9d50dfb7e9dbcf3dadac59) | `aws-c-s3: 0.1.27 -> 0.1.29 (#151654)`                                              |
| [`6a6756ce`](https://github.com/NixOS/nixpkgs/commit/6a6756ce7ec780ae1ecae79e8a85188c89937981) | `binutils: add patch for CVE-2021-45078 (#151658)`                                  |
| [`9e9b71c1`](https://github.com/NixOS/nixpkgs/commit/9e9b71c11c67e5da9e6e0d3b45d9621e5b1f0e0b) | `python3Packages.lxml: 4.6.4-5 -> 4.7.1 (#150913)`                                  |