### PR TITLE
chore(flake/nixpkgs): `cf26d7da` -> `7635d29d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1641694724,
-        "narHash": "sha256-MayqlovgyixG3bS/PmOOVm5nVP5Z6SF2kPDPci/UsdU=",
+        "lastModified": 1641743096,
+        "narHash": "sha256-BUUFzTI1MS8CJk3QgVnNA2vVsHETmwFJmzgiUIxqtoE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf26d7da025a6df4ea053a9f17e4e1d50cf5fa92",
+        "rev": "7635d29dd8e8d55982387f2c9e95400d2319a82f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`19be0891`](https://github.com/NixOS/nixpkgs/commit/19be0891069a116ea6eff5d3a1aa87ad2a1b39bc) | `tensorboardx: fix tests`                                                  |
| [`f32e876f`](https://github.com/NixOS/nixpkgs/commit/f32e876f36da2c6626a456ad16a2ade5fa762358) | `python3.pkgs.tensorboardx: re-enable disabled test`                       |
| [`fdc80b46`](https://github.com/NixOS/nixpkgs/commit/fdc80b46b27eb7cef9b06a7196c516961a9ce7e1) | `python3Packages.pycocotools: drop maintainership`                         |
| [`08e6b802`](https://github.com/NixOS/nixpkgs/commit/08e6b80248e25d2d32d22c00a2f17e5b626b95d8) | `rime-data: 0.38.20210628 -> 0.38.20211002`                                |
| [`9648b4f6`](https://github.com/NixOS/nixpkgs/commit/9648b4f6a3c13d19b6c6ebba0bedfe327a4b3e59) | `maintainers: add qbit`                                                    |
| [`71930ab2`](https://github.com/NixOS/nixpkgs/commit/71930ab2f4cd152d83c976e18be17e24acccad31) | `yash: init at 2.52`                                                       |
| [`72af5962`](https://github.com/NixOS/nixpkgs/commit/72af5962468ca956cf6f9778545aa4a11e05b78e) | `tautulli: 2.8.0 -> 2.8.1`                                                 |
| [`41710117`](https://github.com/NixOS/nixpkgs/commit/417101172d118da24deb027aad999be8013f2e7d) | `tautulli: add some missing files and update licence`                      |
| [`d45abd5f`](https://github.com/NixOS/nixpkgs/commit/d45abd5fc9c22a09638f3ad487738e0da4a7900d) | `python38Packages.mocket: 3.10.2 -> 3.10.3`                                |
| [`a0785fd0`](https://github.com/NixOS/nixpkgs/commit/a0785fd0c73c626fae92bea7fac81d46e926905d) | `python38Packages.pycocotools: 2.0.3 -> 2.0.4`                             |
| [`87c9cbde`](https://github.com/NixOS/nixpkgs/commit/87c9cbdea4f3ecd035fd172f862fcb4dca1d6de9) | `python3Packages.pyradios: update meta`                                    |
| [`37bb0ba9`](https://github.com/NixOS/nixpkgs/commit/37bb0ba9f41a2825bb9821d20cf7c72c76344565) | `python38Packages.pyradios: 0.0.22 -> 1.0.1`                               |
| [`f0ed9541`](https://github.com/NixOS/nixpkgs/commit/f0ed9541586dbc2209501b9cdce876c703336e88) | `amdvlk: fix repo hash for v2021.Q4.3`                                     |
| [`ff5850f5`](https://github.com/NixOS/nixpkgs/commit/ff5850f5d759294a6c44f093190044733b47044d) | `python38Packages.deezer-py: 1.3.5 -> 1.3.6`                               |
| [`db0a716d`](https://github.com/NixOS/nixpkgs/commit/db0a716d2bd8b59a12d5606616dad3fd3f6088be) | `python38Packages.types-toml: 0.10.2 -> 0.10.3`                            |
| [`0ecf7d41`](https://github.com/NixOS/nixpkgs/commit/0ecf7d414811f831060cf55707c374d54fbb1dec) | `pam_pgsql: 0.7.3.2 -> unstable-2020-05-05`                                |
| [`e1e4e1c2`](https://github.com/NixOS/nixpkgs/commit/e1e4e1c2cb82cdd1afeca2ba45214afeb4b4bdf6) | `postgresqlPackages.tds_fdw: 2.0.2 -> unstable-2021-12-14`                 |
| [`f2c5970a`](https://github.com/NixOS/nixpkgs/commit/f2c5970a7654c8fed9ba13f70071c29161d80c7c) | `users-groups service: add autoSubUidGidRange option`                      |
| [`35a91860`](https://github.com/NixOS/nixpkgs/commit/35a9186075f70b58fa0095b49446dc86c46eefec) | `python38Packages.goodwe: 0.2.11 -> 0.2.12`                                |
| [`6675c8e9`](https://github.com/NixOS/nixpkgs/commit/6675c8e96d401881c60f3add3c5703319fc645f4) | `tailscale: remove old xversion tag`                                       |
| [`48271361`](https://github.com/NixOS/nixpkgs/commit/482713610577999076af1d3ce4f981cd2b71c2fd) | `python38Packages.trimesh: 3.9.41 -> 3.9.42`                               |
| [`d5e4ceac`](https://github.com/NixOS/nixpkgs/commit/d5e4ceac727c4b28a139c7707e5e5cc8eaf74a35) | `touchegg: 2.0.12 -> 2.0.13`                                               |
| [`745b35fa`](https://github.com/NixOS/nixpkgs/commit/745b35facdba2c3b96171ab74267bef3dc4cbd35) | `python38Packages.cocotb: 1.6.0 -> 1.6.1`                                  |
| [`509a9f5f`](https://github.com/NixOS/nixpkgs/commit/509a9f5f14775e761afa8b06e3b752929232b0ab) | `asdf: fix cross compilation and set strictDeps`                           |
| [`a2aee625`](https://github.com/NixOS/nixpkgs/commit/a2aee6257316f779c06d24d3badd6cc304747f32) | `zpaqd: fix cross compilation`                                             |
| [`c9f08ace`](https://github.com/NixOS/nixpkgs/commit/c9f08ace52ee152e0dd75bc071e4159c0bcc7cc2) | `zpaq: cleanup and fix cross compilation`                                  |
| [`29d7307a`](https://github.com/NixOS/nixpkgs/commit/29d7307a05f3467a51b559dae6e2025afa446127) | `abootimg: fix cross compilation and set strictDeps`                       |
| [`52f2f6cf`](https://github.com/NixOS/nixpkgs/commit/52f2f6cf4be9eb88711644282e5e706cfa03cc69) | `cryptopp: be graceful when removing static lib, fixing cross compilation` |
| [`e2441863`](https://github.com/NixOS/nixpkgs/commit/e2441863d447d25757ccb1586d352380d8a95042) | `gnome-photos: remove adwaita-icon-theme dependency`                       |
| [`051f0406`](https://github.com/NixOS/nixpkgs/commit/051f0406cb3c6c28e19f57c8d1ae51c0a458baf9) | `aws-crt-cpp: add dev output`                                              |
| [`708a15bc`](https://github.com/NixOS/nixpkgs/commit/708a15bc2b7ef7411117ad4f0ec34ef43340f2b9) | `python3Packages.readme_renderer: relax cmarkgfm constraint`               |
| [`c60fa622`](https://github.com/NixOS/nixpkgs/commit/c60fa62269269bc553af574dd0dbed36f8b19ad7) | `python3Packages.natsort: 7.2.0 -> 8.0.2`                                  |
| [`874acbb2`](https://github.com/NixOS/nixpkgs/commit/874acbb235945ffb1fbced580cde0394bcada466) | `python3Packages.dulwich: 0.20.27 -> 0.20.30`                              |
| [`701f1c4c`](https://github.com/NixOS/nixpkgs/commit/701f1c4c55be8ac28bf8fd5acf9d3bb6f047248b) | `gnome.gnome-shell: switch to non-full asciidoc`                           |
| [`0b0fcb01`](https://github.com/NixOS/nixpkgs/commit/0b0fcb01c70ee40618fde848d87779e4444a46b9) | `libvncserver: add dev output`                                             |
| [`d3bf3e01`](https://github.com/NixOS/nixpkgs/commit/d3bf3e012e2a3a506ea1272bc43d5e566206b3b4) | `libgtop: add dev output`                                                  |
| [`72f8b239`](https://github.com/NixOS/nixpkgs/commit/72f8b239059c4019bcebd6f58ca07dedea546c89) | `notcurses: 2.4.9 -> 3.0.3`                                                |
| [`0610155a`](https://github.com/NixOS/nixpkgs/commit/0610155a9ba59dda22679bd69f12841730e5188e) | `qrcodegen: mark as broken on Darwin`                                      |
| [`bca4a0c3`](https://github.com/NixOS/nixpkgs/commit/bca4a0c32ff0b8dca8a555967baf98f12ceebc6d) | `qrcodegen: refactor`                                                      |
| [`cacd9fcf`](https://github.com/NixOS/nixpkgs/commit/cacd9fcfb0928d729dfbcebb2a40c764c26c634c) | `remote-touchpad: 1.0.4 -> 1.0.5`                                          |
| [`2be5e93e`](https://github.com/NixOS/nixpkgs/commit/2be5e93ecca1e1ec03101ca91b949843bf691355) | `uwsgi service: deduplicate plugins list`                                  |
| [`4be78f0d`](https://github.com/NixOS/nixpkgs/commit/4be78f0dd3040627cf88fee2c4c4e7f2b0e4af50) | `uwsgi service: redefine PATH envvar`                                      |
| [`ce9b3a37`](https://github.com/NixOS/nixpkgs/commit/ce9b3a37232d1e9b2812b11439696d13e384661d) | `buildGraalVmNativeImage: enable utf-8 by default`                         |
| [`3c1b474e`](https://github.com/NixOS/nixpkgs/commit/3c1b474e44c01d49a79b6b9eaa49a1eccb736b09) | `nixos/tracker: Define env var so it can find miners’ subcommands`         |
| [`7e95149b`](https://github.com/NixOS/nixpkgs/commit/7e95149bdbc0db67070e0bad9115a48d82e72bed) | `glib: Add helpers for finding schema datadir`                             |
| [`a2968d98`](https://github.com/NixOS/nixpkgs/commit/a2968d985bf46d046f67e33c313e61d310d0885a) | `godot: 3.4 -> 3.4.2`                                                      |
| [`9e47e609`](https://github.com/NixOS/nixpkgs/commit/9e47e60971567decc140ccda13c615f963139766) | `amdgpu-pro: 17.40 -> 21.30`                                               |
| [`2f846e69`](https://github.com/NixOS/nixpkgs/commit/2f846e69c4f46b70cb40330fe7c949a071f6a92f) | `nixos/xserver: set correct LD_LIBRARY_PATH for opengl driver`             |