### PR TITLE
chore(flake/home-manager): `05d65514` -> `f3be3cda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1641766524,
-        "narHash": "sha256-XQT0psUWZ4QgA4EXzbeKsx8Rf8DDZKVbeq/Iz5Y+i4c=",
+        "lastModified": 1641799033,
+        "narHash": "sha256-f7/p46rC65buVGk7OHb9sxJ+kF1xzs3NUuLZExoqCqY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "05d655146b1e98bf38c57e2ed2bea0f354e73388",
+        "rev": "f3be3cda6a69365f2acecc201b3cd1ee4f6d4614",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                                    |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`f3be3cda`](https://github.com/nix-community/home-manager/commit/f3be3cda6a69365f2acecc201b3cd1ee4f6d4614) | ``services/emacs: add option to set `emacsclient` as the default editor (#2545)`` |