### PR TITLE
chore(flake/nixpkgs): `7635d29d` -> `6efb3968`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1641743096,
-        "narHash": "sha256-BUUFzTI1MS8CJk3QgVnNA2vVsHETmwFJmzgiUIxqtoE=",
+        "lastModified": 1641789839,
+        "narHash": "sha256-go3JSvI/h0IO7l7RO60WD+7KS8DmRWVrm2UQBzId8H4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7635d29dd8e8d55982387f2c9e95400d2319a82f",
+        "rev": "6efb39682f9c007608eb966681a11a91fcbf0c9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`af991701`](https://github.com/NixOS/nixpkgs/commit/af991701576bcfe83b8875b54127a9b726a5dede) | `terraform-providers: update 2022-01-10`                                         |
| [`dcabc919`](https://github.com/NixOS/nixpkgs/commit/dcabc91904953dcff2f32f1de2a6aef0188c2def) | `virtualbox: 6.1.28 -> 6.1.30`                                                   |
| [`2ae06932`](https://github.com/NixOS/nixpkgs/commit/2ae06932dc9e2613a6891180510ace21db2645a3) | `spamassassin: support for fetching rules over HTTPS`                            |
| [`be5b9fef`](https://github.com/NixOS/nixpkgs/commit/be5b9fef4f4fea332336297f70fb3a0dbf4c29c2) | `linuxKernel.packages.linux_5_15_hardened.vhba: 20211023 -> 20211218`            |
| [`1febc39a`](https://github.com/NixOS/nixpkgs/commit/1febc39a5a550214f0c48fde26636eedfa617efd) | `linuxPackages.lttng-modules: 2.13.0 -> 2.13.1`                                  |
| [`a35652f4`](https://github.com/NixOS/nixpkgs/commit/a35652f40f9d21bab21168e9ab77edfdb7e6ef74) | `linuxPackages.jool: 4.1.5 -> 4.1.6`                                             |
| [`00d2701b`](https://github.com/NixOS/nixpkgs/commit/00d2701b971df1f73b87e0a391ccd93e54833a01) | ``v2ray, v2ray-domain-list-community: switch to go_1_17, update `vendorSha256``` |
| [`7d1d2fe2`](https://github.com/NixOS/nixpkgs/commit/7d1d2fe2f8c930dac1ea34b34b26979e4c5658fc) | `ArchiSteamFarm: 5.2.0.10 -> 5.2.1.5; ASF-ui: update`                            |
| [`0b0f051e`](https://github.com/NixOS/nixpkgs/commit/0b0f051eef7cdfacad0ef158252fd6b8b4c7159d) | `mbrola: fix cross compilation`                                                  |
| [`9e97ef79`](https://github.com/NixOS/nixpkgs/commit/9e97ef794a8f22e96e1d8ec3d80f0cf14e27fad4) | `lib/qemu-common: Add serial device name for RISC-V`                             |
| [`a0af8785`](https://github.com/NixOS/nixpkgs/commit/a0af8785fce91d5877792cb9ae2a39955437a1e2) | `python3Packages.flux-led: 0.27.43 -> 0.27.44`                                   |
| [`ec9217de`](https://github.com/NixOS/nixpkgs/commit/ec9217de49b5e4ecb33f4683e8d3898727e0927f) | `python310Packages.meross-iot: 0.4.4.1 -> 0.4.4.2`                               |
| [`addbaf25`](https://github.com/NixOS/nixpkgs/commit/addbaf25a16c9edd48d426c2fc07ef8abdd8cc8d) | `terraform-providers: updates, switch go_1_17`                                   |
| [`df7f6e9e`](https://github.com/NixOS/nixpkgs/commit/df7f6e9ecaabaedb0bdfc4a713f7c1fcc7f51cd6) | `terraform: switch to go_1_17`                                                   |
| [`d7054157`](https://github.com/NixOS/nixpkgs/commit/d7054157281a569a662de9fa7f9cdfe96a083186) | `python38Packages.tgcrypto: 1.2.2 -> 1.2.3`                                      |
| [`bd2aeade`](https://github.com/NixOS/nixpkgs/commit/bd2aeade45130a03710553066e416ef8d9ebedee) | `etcd_3_5: init at 3.5.1`                                                        |
| [`91b1b02d`](https://github.com/NixOS/nixpkgs/commit/91b1b02d527fc08066c60a0c918c427e13b88cd7) | `Refactor all-packages.nix`                                                      |
| [`250cadf9`](https://github.com/NixOS/nixpkgs/commit/250cadf958c83052a925d6d8a795d1f6f9753382) | `elf2uf2-rs: Init at unstable-2021-12-12`                                        |
| [`0028d75b`](https://github.com/NixOS/nixpkgs/commit/0028d75b1c912e4bcbae870e40ee8fd553f32a17) | `nixos/thelounge: add winter to maintainers`                                     |
| [`e5e46f1a`](https://github.com/NixOS/nixpkgs/commit/e5e46f1add3362d9b35f4a82ed95716c9d115e99) | `nodePackages: add The Lounge plugins`                                           |
| [`fe20f479`](https://github.com/NixOS/nixpkgs/commit/fe20f479e9a6bee55d47ad450ec81b07200a8168) | `nixos/thelounge: add plugins option`                                            |
| [`4cb152fc`](https://github.com/NixOS/nixpkgs/commit/4cb152fceaf8d3a93227b6965325fc81a689951c) | `Update pkgs/applications/editors/jetbrains/default.nix`                         |
| [`39fc4398`](https://github.com/NixOS/nixpkgs/commit/39fc43985911719350305e2b215dae51011598b0) | `getmail6: 6.18.5 -> 6.18.6`                                                     |
| [`1f78e4c1`](https://github.com/NixOS/nixpkgs/commit/1f78e4c10173a03ac41b9121b88b690546dd2f7a) | `protontricks: 1.6.2 → 1.7.0`                                                    |
| [`91d02282`](https://github.com/NixOS/nixpkgs/commit/91d0228224279e10bb74be6656b0820a93d8ab37) | `gallery-dl: 1.19.3 -> 1.20.1`                                                   |
| [`f89427f9`](https://github.com/NixOS/nixpkgs/commit/f89427f939ae8c834f85e741c680cee25bcc4d3a) | `tagtime: init at 2018-09-02`                                                    |
| [`2af27e44`](https://github.com/NixOS/nixpkgs/commit/2af27e443f3ee0a242ea9513d8c872aadab63346) | `alsa-ucm-conf: 1.2.5.1 -> 1.2.6.3`                                              |
| [`b61827f6`](https://github.com/NixOS/nixpkgs/commit/b61827f61d6a8abc0279be50d84ba4309539a39c) | `gns3-{gui,server}: 2.2.28 -> 2.2.29`                                            |
| [`1ed1e00d`](https://github.com/NixOS/nixpkgs/commit/1ed1e00d2be929740f214f8053316bd0e4d64d2f) | `commit-formatter: init at 0.2.1`                                                |
| [`7d988867`](https://github.com/NixOS/nixpkgs/commit/7d988867ffbd36a57e5df29611b17bb1c6e905ac) | `mtr-exporter: init at 0.1.0 (3ce854a5)`                                         |
| [`51967ca7`](https://github.com/NixOS/nixpkgs/commit/51967ca77a23215df766a4cf72a56ac219e49d2a) | `nixos/ddclient: better default for nsupdate`                                    |
| [`2febc7dd`](https://github.com/NixOS/nixpkgs/commit/2febc7dd79653114eae54e27c9be215fe53b7ce5) | `nixos/ddclient: don't store config world-readable`                              |
| [`51f93cb7`](https://github.com/NixOS/nixpkgs/commit/51f93cb778f95937daabb80b1d47f244e9537343) | `roc-toolkit: fix cross compilation`                                             |
| [`bc547213`](https://github.com/NixOS/nixpkgs/commit/bc547213ebc45895e1a1a38f8d395a7f57882aa3) | `astrolog: fix cross compilation`                                                |
| [`67e5298b`](https://github.com/NixOS/nixpkgs/commit/67e5298bfb49471dc4e43a35f4bc97186a120f26) | `speechd: Fix espeak-mbrola voice check`                                         |
| [`b0a4fa52`](https://github.com/NixOS/nixpkgs/commit/b0a4fa5273467246d0e86033c5712978237eb953) | `speechd: clean up`                                                              |
| [`3ace1a91`](https://github.com/NixOS/nixpkgs/commit/3ace1a91eca77224ebf79a36699f6389cca831b5) | `speechd: 0.10.2 → 0.11.1`                                                       |
| [`f5e0f293`](https://github.com/NixOS/nixpkgs/commit/f5e0f2932e9a4f05bc267fbbf9c554e237cb91ba) | `sshd: disable trigger limit for systemd socket`                                 |
| [`b9c6bff4`](https://github.com/NixOS/nixpkgs/commit/b9c6bff4f07ea912a8be8af1a0a3bb043626f75c) | `nextinspace: 1.0.6 -> 2.0.3`                                                    |
| [`fd39255c`](https://github.com/NixOS/nixpkgs/commit/fd39255c33390ef35d656596053ce05c8b22656f) | `vscode-extensions: update installed extensions`                                 |
| [`76034fee`](https://github.com/NixOS/nixpkgs/commit/76034fee72c735a6419477f9e968284fa44e6b1e) | `jetbrains.goland: Fix debugging`                                                |
| [`12cc34ce`](https://github.com/NixOS/nixpkgs/commit/12cc34ce2dd2f8d5973b91ca0c6c16d98f335fd6) | `yosys: Add yosys-symbiflow-plugins`                                             |
| [`bb551205`](https://github.com/NixOS/nixpkgs/commit/bb551205bbd247230a027a47ab095ca015544119) | `python38Packages.jupyterlab_server: 2.10.2 -> 2.10.3`                           |
| [`58fe065d`](https://github.com/NixOS/nixpkgs/commit/58fe065d8b6379519519a803f5f7f929c1b1678c) | `kodi: Build with libudfread`                                                    |
| [`14398f74`](https://github.com/NixOS/nixpkgs/commit/14398f74ac8186cbaaad31852b024001a448e7c7) | `libudfread: Init at 1.1.2`                                                      |
| [`a2bcf439`](https://github.com/NixOS/nixpkgs/commit/a2bcf4393da415c9aac831b000cc3d2dcba36a5b) | `geckodriver: 0.29.1 -> 0.30.0`                                                  |
| [`b1a677f0`](https://github.com/NixOS/nixpkgs/commit/b1a677f080e1308ff4104698652f9b5908604461) | `brave: 1.33.106 -> 1.34.80`                                                     |
| [`91b623dc`](https://github.com/NixOS/nixpkgs/commit/91b623dc6c9928fcef71e3f038e4fec9280978e5) | `nvidia_x11: 390.143 -> 390.147`                                                 |
| [`ac0eb5f1`](https://github.com/NixOS/nixpkgs/commit/ac0eb5f1fb037dfb6d6ae67e46f3f27aa46968dc) | `pulumi-bin: 3.19.0 -> 3.21.0`                                                   |
| [`5dfe6563`](https://github.com/NixOS/nixpkgs/commit/5dfe656306305b6d1d8f493af42a4b74297c3b70) | `Deterministic ordering in nix-expr codegen in pulumi/update.sh`                 |
| [`6754a1da`](https://github.com/NixOS/nixpkgs/commit/6754a1dad003e7483ad7b049f5a6c8537ebd56b9) | `android-tools: 31.0.3 -> 31.0.3p1`                                              |
| [`31721bef`](https://github.com/NixOS/nixpkgs/commit/31721bef6a68c2247f578fe975d890cca2f66855) | `gammastep: 2.0.7 -> 2.0.8`                                                      |
| [`f515ff71`](https://github.com/NixOS/nixpkgs/commit/f515ff71a9c1dc68f01b43a43621e49c16bc715d) | `cmst: add romildo as maintainer`                                                |
| [`710d933e`](https://github.com/NixOS/nixpkgs/commit/710d933eca85d86accbc4c99ff1497528140bae2) | `cmst: 2021.12.02 -> 2022.01.05`                                                 |
| [`9dc050e7`](https://github.com/NixOS/nixpkgs/commit/9dc050e7ce8fee4d14794abccc26913d6ce773cc) | `python3Packages.censys: 2.1.0 -> 2.1.1`                                         |
| [`31c351f0`](https://github.com/NixOS/nixpkgs/commit/31c351f04c12f21e3ccd580d294dd7ae17830ac3) | `python3Packages.rich: 10.16.1 -> 10.16.2`                                       |
| [`6ec211a5`](https://github.com/NixOS/nixpkgs/commit/6ec211a5bcde0e454b09fae06f3d63e260f76444) | `ArchiSteamFarm: support aarch64 in the update script`                           |
| [`5ff685cc`](https://github.com/NixOS/nixpkgs/commit/5ff685cca51010402ecc50ba412b584697141668) | `ArchiSteamFarm: fix build for #145090 and #151468`                              |
| [`b61a335d`](https://github.com/NixOS/nixpkgs/commit/b61a335d618682955947d3c5a17ab178f6283335) | `ArchiSteamFarm: fix build on aarch64`                                           |
| [`86f45c7c`](https://github.com/NixOS/nixpkgs/commit/86f45c7c6f8223e6a414139c322b6221fbe50314) | `ArchiSteamFarm: 5.2.0.9 -> 5.2.0.10; ASF-ui: update`                            |
| [`4b513af5`](https://github.com/NixOS/nixpkgs/commit/4b513af50111de7cd24c246cd2de776e9b0681aa) | `ArchiSteamFarm: 5.1.5.3 -> 5.2.0.9 & ASF-ui: update`                            |
| [`98ccbafb`](https://github.com/NixOS/nixpkgs/commit/98ccbafb0597848e4cb90688c4f7d679b5242a6a) | `ASF-ui: init`                                                                   |
| [`bf30cd48`](https://github.com/NixOS/nixpkgs/commit/bf30cd48ed498bafa56831f687299cba0a94e0eb) | `nixos/archisteamfarm: init`                                                     |
| [`769340d3`](https://github.com/NixOS/nixpkgs/commit/769340d3c0ed89c3400c4d3e1596a576785fbb24) | `zsh-history-search-multi-word: init at unstable-2021-11-13`                     |
| [`4c6570f2`](https://github.com/NixOS/nixpkgs/commit/4c6570f29cdce7977d13b61786a79efa76a3d504) | `nomad: 1.1.8 -> 1.2.3`                                                          |
| [`77549658`](https://github.com/NixOS/nixpkgs/commit/77549658a64e7fc70ddaf96183b51e582feed0c5) | `nginxQuic: 0ee56d2eac44 -> 10522e8dea41`                                        |
| [`5cecafbc`](https://github.com/NixOS/nixpkgs/commit/5cecafbc93e95ccf21360194b0dd7af84be40341) | `nginxMainline: 1.21.4 -> 1.21.5`                                                |
| [`25edd522`](https://github.com/NixOS/nixpkgs/commit/25edd522e69fbd1e8c43397c2dbe214b2e238eb9) | `mod_cspnonce: init at 1.3`                                                      |