### PR TITLE
chore(flake/nixpkgs): `6efb3968` -> `ca3c54a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1641789839,
-        "narHash": "sha256-go3JSvI/h0IO7l7RO60WD+7KS8DmRWVrm2UQBzId8H4=",
+        "lastModified": 1641832899,
+        "narHash": "sha256-DeOIMVFHvwCXDcrtO5Yhj4tK9I5t3pZVxGCb73gFZ+4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6efb39682f9c007608eb966681a11a91fcbf0c9c",
+        "rev": "ca3c54a88d29b909ae52c10ae9004b21ba895eb4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`e2aab323`](https://github.com/NixOS/nixpkgs/commit/e2aab323796ef1854dbf1741200cffff6037b7cc) | `batman-adv: 2021.1 -> 2021.4`                                                        |
| [`0a99fa03`](https://github.com/NixOS/nixpkgs/commit/0a99fa0331b842cb75e942114de73b545ee71ed1) | `linux_latest: 5.15.12 -> 5.16`                                                       |
| [`a12bb274`](https://github.com/NixOS/nixpkgs/commit/a12bb274f915088f638168531cd8f9d85c0b5be5) | `vimPlugins: update`                                                                  |
| [`d72a2e7b`](https://github.com/NixOS/nixpkgs/commit/d72a2e7baf39f6683005e66ffcaa9f5e93aaa9da) | `firmwareLinuxNonfree -> linux-firmware`                                              |
| [`c1376aed`](https://github.com/NixOS/nixpkgs/commit/c1376aedd7243c9887fd192a4e6420da3c99104a) | `linuxKernel.kernels: also enable SND_SOC_SOF_INTEL_SOUNDWIRE_LINK between 5.10-5.11` |
| [`a4f9bd11`](https://github.com/NixOS/nixpkgs/commit/a4f9bd1118f25c865056d1228f3683b272660d25) | `htpdate: 1.2.2 -> 1.3.1`                                                             |
| [`40e76191`](https://github.com/NixOS/nixpkgs/commit/40e761918d7b66cf3acb1bc50fdcdc6dc3fb76a0) | `vmm_clock: init at 0.1.0`                                                            |
| [`edbf02ff`](https://github.com/NixOS/nixpkgs/commit/edbf02ff4abf578c966a26d6f21e0911118addc7) | `wireshark: add manpages`                                                             |
| [`afdfec50`](https://github.com/NixOS/nixpkgs/commit/afdfec504f7557350479c26f8beee4a49b29b2fa) | `cp2k: 8.2.0 -> 9.1.0`                                                                |
| [`9968242e`](https://github.com/NixOS/nixpkgs/commit/9968242e1e1e9b5180b3f6868aeb99637f078adf) | `alsa-firmware: 1.2.1 -> 1.2.4`                                                       |
| [`d551a1ce`](https://github.com/NixOS/nixpkgs/commit/d551a1ce219f19a70ebcc920e9d03346c6abb72c) | `tuhi: init at 0.5`                                                                   |
| [`bfe256a8`](https://github.com/NixOS/nixpkgs/commit/bfe256a8532ad6677e4816a6aafd785373e0b937) | `maintainers: add julienmalka`                                                        |
| [`9fe7556f`](https://github.com/NixOS/nixpkgs/commit/9fe7556f72c23eeeb778ae28f674e00808c30bc0) | `python3Packages.css-parser: add pythonImportsCheck`                                  |
| [`d230a3fd`](https://github.com/NixOS/nixpkgs/commit/d230a3fd7589475c324cedd95b203c543fdbab0f) | `symfony-cli: 4.26.9 -> 5.0.7`                                                        |
| [`c354ba00`](https://github.com/NixOS/nixpkgs/commit/c354ba00e9efac0f57ba381a3fa5d713c9a5c59e) | `python310Packages.dnslib: 0.9.16 -> 0.9.18`                                          |
| [`2b914ee8`](https://github.com/NixOS/nixpkgs/commit/2b914ee8e20c7082b18a550bd93e1e7b384adc0f) | `deco: 0.0.2 -> unstable-2019-04-03`                                                  |
| [`7a585527`](https://github.com/NixOS/nixpkgs/commit/7a5855272e640578cd731592dd28a65c1a8a9192) | `python310Packages.css-parser: 1.0.6 -> 1.0.7`                                        |
| [`b889981f`](https://github.com/NixOS/nixpkgs/commit/b889981f3fc16f6080479df821dbda1a4a49caf6) | `python310Packages.goodwe: 0.2.12 -> 0.2.13`                                          |
| [`8f200e0e`](https://github.com/NixOS/nixpkgs/commit/8f200e0e38b1adfaf15790a003e1488115805652) | `linux: enable IO_STRICT_DEVMEM`                                                      |
| [`c7babfc4`](https://github.com/NixOS/nixpkgs/commit/c7babfc4f25be60c6c806991e593b27e59838d99) | `python3Packages.afdko: Skip broken test on RISC-V (#154209)`                         |
| [`dd9685f7`](https://github.com/NixOS/nixpkgs/commit/dd9685f7e8e478b72dec604d08e25613b4524873) | `python3Packages.img2pdf: disable tests on aarch64 (#154148)`                         |
| [`871b03cc`](https://github.com/NixOS/nixpkgs/commit/871b03cc67ef813fc1ff4f6798ddd4e71b6569b9) | `linuxPackages.kvmfr: mark broken on Linux 5.16`                                      |
| [`38e1dbd9`](https://github.com/NixOS/nixpkgs/commit/38e1dbd942d63cc8712d9f949c126f1fcdde59df) | `nixos/thelounge: private -> public`                                                  |
| [`935303fd`](https://github.com/NixOS/nixpkgs/commit/935303fd36d3d78f040f6d180cb0299d0ebdc318) | `linux config: SND_SOC_INTEL_SOUNDWIRE_SOF_MACH >= 5.10`                              |
| [`24246874`](https://github.com/NixOS/nixpkgs/commit/2424687448b0e85aabe207c66e450427262d5eb8) | `linuxPackages.exfat-nofuse: assert -> meta.broken`                                   |
| [`5d264ed8`](https://github.com/NixOS/nixpkgs/commit/5d264ed80eec68291b44f3911ec36237115cf317) | `python3Packages.gmypy2: 2.1.0b5 -> 2.1.2`                                            |
| [`4fc67da8`](https://github.com/NixOS/nixpkgs/commit/4fc67da841d1c80b8d774a7b8c8e6baf13f9496e) | `lib.checkListOfEnum: init`                                                           |
| [`9ad49004`](https://github.com/NixOS/nixpkgs/commit/9ad49004804bec8659fa57f98da6692ad119fbd9) | `gnuradio: 3.9.4.0 -> 3.9.5.0`                                                        |
| [`06ed1e74`](https://github.com/NixOS/nixpkgs/commit/06ed1e74c30218d4b85becdd650081f89ab622bf) | `gnuradio3_8: 3.8.4.0 -> 3.8.5.0`                                                     |
| [`b39c01b6`](https://github.com/NixOS/nixpkgs/commit/b39c01b69cb279e54a21b69087cd2b4b4ab98872) | `linux: enable DEBUG_LIST`                                                            |
| [`d559444e`](https://github.com/NixOS/nixpkgs/commit/d559444ece1e0403a6278e482cb63112c618d635) | `linuxPackages.liquidtux: set meta.broken`                                            |
| [`7ada385a`](https://github.com/NixOS/nixpkgs/commit/7ada385af0b5ca1ce6ed865a7b2fc7ce603e8831) | `zsh: Support building from Git checkouts`                                            |
| [`29c02b33`](https://github.com/NixOS/nixpkgs/commit/29c02b33a95c0f6952bcc31c30dd052e74f16b1c) | `aria2: fix cross compilation and set strictDeps`                                     |
| [`ed330761`](https://github.com/NixOS/nixpkgs/commit/ed3307611597baa7cca6c4c651c54574ef79e7dc) | `fcitx5-chinese-addons: 5.0.9 -> 5.0.10`                                              |
| [`e3c65712`](https://github.com/NixOS/nixpkgs/commit/e3c657125ccd5b9f43f990319340d5163e78b32f) | `fcitx5-rime: 5.0.9 -> 5.0.10`                                                        |
| [`9bcdcb61`](https://github.com/NixOS/nixpkgs/commit/9bcdcb6199655a86d5073237c646804f12aef2c9) | `zsh-prezto: unstable-2021-06-02 → unstable-2021-11-16`                               |
| [`0bf01ef2`](https://github.com/NixOS/nixpkgs/commit/0bf01ef23a3f489e22d4561e063f3aa324c52851) | `python38Packages.soco: 0.25.2 -> 0.25.3`                                             |
| [`d2e6d89b`](https://github.com/NixOS/nixpkgs/commit/d2e6d89ba7048ac644a405aeb5a91946b0cd05c0) | `popsicle: init at unstable-2021-12-20`                                               |
| [`f38f6571`](https://github.com/NixOS/nixpkgs/commit/f38f65717816fd051baa3ae04056e9dee2bc9b22) | `maintainers: add lammermann`                                                         |
| [`b2510794`](https://github.com/NixOS/nixpkgs/commit/b25107949d255346cef4089db7cf04288d876a32) | `papermc: 1.17.1r399 -> 1.18.1r132`                                                   |
| [`e4069436`](https://github.com/NixOS/nixpkgs/commit/e40694361b66fa36d6713693cb20913029969e8a) | `fcitx5-configtool: 5.0.9 -> 5.0.10`                                                  |
| [`2b045fe3`](https://github.com/NixOS/nixpkgs/commit/2b045fe352b368daaacd55ed6c735f4f460c1ade) | `libsForQt5.fcitx5-qt: 5.0.8 -> 5.0.9`                                                |
| [`8c66b455`](https://github.com/NixOS/nixpkgs/commit/8c66b455ec3a04539c0c13c7568ac300b0595719) | `fcitx5-gtk: 5.0.10 -> 5.0.11`                                                        |
| [`8df8477e`](https://github.com/NixOS/nixpkgs/commit/8df8477e02ccab6114c6e8f326ed7662e7d1b97e) | `fcitx5: 5.0.11 -> 5.0.12`                                                            |
| [`2fd9c12c`](https://github.com/NixOS/nixpkgs/commit/2fd9c12c7f52ed4f493010cb160e37e5303d8c0a) | `libime: 1.0.10 -> 1.0.11`                                                            |
| [`aaafdfd1`](https://github.com/NixOS/nixpkgs/commit/aaafdfd1d7b65c1c29b1180eb7d7adf05a487257) | `duo-unix: 1.11.4 -> 1.11.5`                                                          |
| [`0de4ecff`](https://github.com/NixOS/nixpkgs/commit/0de4ecff8cbeb9c3f36e58b3bdb406d676a5e118) | `lib/modules: extract multiply-used value in byName`                                  |
| [`2dcae7d8`](https://github.com/NixOS/nixpkgs/commit/2dcae7d82f5ef0b373413d2fbfc1001141561c74) | `lib/attrsets: use builtins.zipAttrsWith if available`                                |
| [`afecbb2f`](https://github.com/NixOS/nixpkgs/commit/afecbb2f7534a0530fc0da53af74d0bb85697d36) | `lib/modules: optimize byName`                                                        |
| [`33aab6d4`](https://github.com/NixOS/nixpkgs/commit/33aab6d425ee52c5fe3d0b34407e10d2423b8c61) | `alsa-plugins: 1.2.5 -> 1.2.6`                                                        |
| [`7df27785`](https://github.com/NixOS/nixpkgs/commit/7df27785bddeb376f9d51c02959c0ea7ea791db1) | `pony-corral: 0.5.3 -> 0.5.4`                                                         |
| [`5f66167e`](https://github.com/NixOS/nixpkgs/commit/5f66167ed74afcd6c4bc1eaec7c6220c3794db07) | `pony-stable: removal`                                                                |
| [`38aaa7d0`](https://github.com/NixOS/nixpkgs/commit/38aaa7d05cfa597cff9e4b06c75fe72cc0c76698) | `ponyc: 0.42.0 -> 0.44.0`                                                             |