### PR TITLE
chore(flake/nixpkgs): `ca3c54a8` -> `3fe528de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1641832899,
-        "narHash": "sha256-DeOIMVFHvwCXDcrtO5Yhj4tK9I5t3pZVxGCb73gFZ+4=",
+        "lastModified": 1641865627,
+        "narHash": "sha256-B3b7KCThCx5bcDtWCX9ZZIl/EVs/lB8iDdI277/tvNA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ca3c54a88d29b909ae52c10ae9004b21ba895eb4",
+        "rev": "3fe528dec572a26404f130893d2c22a35646247c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`c8681ada`](https://github.com/NixOS/nixpkgs/commit/c8681ada7256c3c92c481c4a2330d0c56574ce52) | `firefox-bin: 95.0.2 -> 96.0`                                                        |
| [`4ab147dc`](https://github.com/NixOS/nixpkgs/commit/4ab147dc229cf03c880fbb66381cda1f7ba316b0) | `firefox-91-esr: 91.4.1esr -> 91.5.0esr`                                             |
| [`74cba068`](https://github.com/NixOS/nixpkgs/commit/74cba0680a9acd083c1b58715166658304a937c9) | `firefox: 95.0.2 -> 96.0`                                                            |
| [`21dc827a`](https://github.com/NixOS/nixpkgs/commit/21dc827a948da8302b5b08cfdc81d58053a8e318) | `solana-testnet: init at 1.9.2 (#152055)`                                            |
| [`714a6778`](https://github.com/NixOS/nixpkgs/commit/714a6778503d31ff68c6c8e4d849f455ea193519) | `varnish: build modules for varnish 6 & 7.`                                          |
| [`5f36161a`](https://github.com/NixOS/nixpkgs/commit/5f36161ae19fc226b7b2797cd3ba38794dc0bc37) | `linuxKernel.kernels: mark {IO_,}STRICT_DEVMEM optional to unbreak hardened kernels` |
| [`31f8c0e0`](https://github.com/NixOS/nixpkgs/commit/31f8c0e0c57140da875cd7433253611d6f38f01b) | `werf: update vendorSha256`                                                          |
| [`8398ddfc`](https://github.com/NixOS/nixpkgs/commit/8398ddfcf7e855169daa47bcf649be7580af9d66) | `terraformer: update vendorSha256`                                                   |
| [`cc6cad75`](https://github.com/NixOS/nixpkgs/commit/cc6cad7534cf4e03bb1b1ed3f5ed9107ccfce433) | `actionlint: update vendorSha256`                                                    |
| [`65ef3c22`](https://github.com/NixOS/nixpkgs/commit/65ef3c227d6708cb295f379e28739d6ae869cd3c) | `agebox: update vendorSha256`                                                        |
| [`b2393844`](https://github.com/NixOS/nixpkgs/commit/b2393844dd15ed1e12a873d7582e19f5d315c707) | `age: update vendorSha256`                                                           |
| [`a4124d6d`](https://github.com/NixOS/nixpkgs/commit/a4124d6d9302a97f9ab9359cdab1c4386d580c33) | `minio-client: update vendorSha256`                                                  |
| [`435a8c34`](https://github.com/NixOS/nixpkgs/commit/435a8c34bd205dc7a0557e02cf7a4b5180be8bcc) | `minio: update vendorSha256`                                                         |
| [`18f7554a`](https://github.com/NixOS/nixpkgs/commit/18f7554a51df6961c69d115b1924650503396647) | `docker-compose_2: update vendorSha256`                                              |
| [`45efe8a6`](https://github.com/NixOS/nixpkgs/commit/45efe8a685cab5e87daacba333c74c65c3e074a0) | `packer: update vendorSha256`                                                        |
| [`2bf3351f`](https://github.com/NixOS/nixpkgs/commit/2bf3351f737199eff322b6b154b2c3f68fa825df) | `vault: update vendorSha256`                                                         |
| [`17b3ec07`](https://github.com/NixOS/nixpkgs/commit/17b3ec07e0e6294f0691c395ac5f1630c4ab4a54) | `colima: update vendorSha256`                                                        |
| [`a6454f35`](https://github.com/NixOS/nixpkgs/commit/a6454f352562149021cecd1b0081db9342e75b7b) | `lima: update vendorSha256`                                                          |
| [`c43b896e`](https://github.com/NixOS/nixpkgs/commit/c43b896e07066d2e8c3be71d026d0ee5fd3b7aaa) | `minikube: update vendorSha256`                                                      |
| [`8a90348c`](https://github.com/NixOS/nixpkgs/commit/8a90348ce5a68c41a1927f21b6b75fd14950edcf) | `qgit: 2.9 -> 2.10`                                                                  |
| [`845f228f`](https://github.com/NixOS/nixpkgs/commit/845f228ff80954ff1de170434adfb2a0e7cc208e) | `zsh: fix build on darwin`                                                           |
| [`0cacc3a0`](https://github.com/NixOS/nixpkgs/commit/0cacc3a0d6ceb4f170c017180607e4f02308f02c) | `yaml-merge: fix build issue`                                                        |
| [`2c138222`](https://github.com/NixOS/nixpkgs/commit/2c1382227a3fc95ebd98795be8eaf50150233334) | `grype: 0.28.0 -> 0.30.0`                                                            |
| [`56c01891`](https://github.com/NixOS/nixpkgs/commit/56c01891f923da1af2ca1773884ac93c1f548e3d) | `vala-lint: unstable-2021-11-18 -> unstable-2021-12-28`                              |
| [`ff5e6707`](https://github.com/NixOS/nixpkgs/commit/ff5e6707f0279c5edef140dd411ba625ec9fa56c) | `oci-cli: 2.23.0 -> 3.4.1`                                                           |
| [`5a63df0c`](https://github.com/NixOS/nixpkgs/commit/5a63df0c118656b9349ee60a944a2024b3efd6cd) | `python3Packages.transip: switch to pytestCheckHook`                                 |
| [`7c96cb46`](https://github.com/NixOS/nixpkgs/commit/7c96cb466825387c10aba3487cb82c1eb8de3ea1) | `lexicon: 3.5.2 -> 3.9.0`                                                            |
| [`11d0f20e`](https://github.com/NixOS/nixpkgs/commit/11d0f20e2bea8b4ee24b0fc1305259ff764a8c51) | `python3Packages.oci: 2.52.0 -> 2.53.1`                                              |
| [`6e1b142c`](https://github.com/NixOS/nixpkgs/commit/6e1b142c4bf6076f176aff1536b2ef9655be9e9b) | `python3Packages.elegy: init at 0.8.4`                                               |
| [`a57b7622`](https://github.com/NixOS/nixpkgs/commit/a57b762251b37db77a43ddce8a821ef964f3fdc3) | `senpai: unstable-2021-11-29 -> unstable-2021-12-14`                                 |
| [`0fefa7eb`](https://github.com/NixOS/nixpkgs/commit/0fefa7eb9d88d2e71fb39b35c6b04efb082d893c) | `lychee: 0.8.1 -> 0.8.2`                                                             |
| [`d8851e7e`](https://github.com/NixOS/nixpkgs/commit/d8851e7efedfb5fbe154e3408a3738070ba85b81) | `python310Packages.chiabip158: 1.0 -> 1.1`                                           |
| [`c9cc3e10`](https://github.com/NixOS/nixpkgs/commit/c9cc3e10d5a3a57f62fe01976a372ff81f64e260) | `keymapviz: 1.9.0 -> 1.10.1`                                                         |
| [`5bf9a071`](https://github.com/NixOS/nixpkgs/commit/5bf9a07184467db9c1e7f4484b121dd1986eeecd) | `chiapos: unbreak`                                                                   |
| [`f16e78d0`](https://github.com/NixOS/nixpkgs/commit/f16e78d0a04270caf524a36c3beb1d00bc446f4d) | `zombietrackergps: 1.03 → 1.10`                                                      |
| [`6cc6cb67`](https://github.com/NixOS/nixpkgs/commit/6cc6cb67fab316a15f6d6b65fc6b62592169b523) | `ldutils: 1.03 → 1.10`                                                               |
| [`4ea6bfad`](https://github.com/NixOS/nixpkgs/commit/4ea6bfadfbdcf22fd4a6b939ecfc7f1f0a4b036d) | `wlroots_0_12: drop`                                                                 |
| [`84595758`](https://github.com/NixOS/nixpkgs/commit/84595758cce3462fc08c2d3e38526b81694b55b7) | `phoc: 0.9.0 -> 0.11.0`                                                              |
| [`45129c9d`](https://github.com/NixOS/nixpkgs/commit/45129c9dec3c0492f71f9e3b36d7692a3094ec52) | `subtitleeditor: use enchant2`                                                       |
| [`16216b2e`](https://github.com/NixOS/nixpkgs/commit/16216b2e043ac97054098d4ff38707d7b379ff51) | `rPackages.geomorph: fix build`                                                      |
| [`cad7decd`](https://github.com/NixOS/nixpkgs/commit/cad7decdd2c559668adcd462e7fb54c1cb1c49bd) | `rPackages.ragg: fix build`                                                          |
| [`18b3b8e2`](https://github.com/NixOS/nixpkgs/commit/18b3b8e2a79606b913dfaafcd1d1c68f61b14128) | `rPackages: CRAN and BioC update`                                                    |
| [`feb634ba`](https://github.com/NixOS/nixpkgs/commit/feb634ba0c13266df9c5ca916dbf2ea39a68387c) | `home-assistant: handle disabled components`                                         |
| [`d0e7ab6f`](https://github.com/NixOS/nixpkgs/commit/d0e7ab6fcc49642ceb5be0d36a08e96c73440de1) | `home-assistant: 2021.12.7 -> 2021.12.8`                                             |
| [`98f91952`](https://github.com/NixOS/nixpkgs/commit/98f919522abb069e756f74bfc4ccde691309b9cf) | `python3Packages.python-smarttub: 0.0.28 -> 0.0.29`                                  |
| [`d6e86c81`](https://github.com/NixOS/nixpkgs/commit/d6e86c8183ae99e786cd7905099ae5b4e7f00e0d) | `python3Packages.micloud: 0.4 -> 0.5`                                                |
| [`02c59ff6`](https://github.com/NixOS/nixpkgs/commit/02c59ff6e0d12c54c639f19029c3391762b4b2ee) | `rPackages: CRAN and BioC update`                                                    |
| [`114470d2`](https://github.com/NixOS/nixpkgs/commit/114470d28e7fe1681fa74a7ebd50ad1e931babdd) | `python3Packages.wandb: init at 0.12.7`                                              |
| [`c28f99ab`](https://github.com/NixOS/nixpkgs/commit/c28f99abe9b2c5e37c6017518ce391dc013f126a) | `python3Packages.yaspin: init at 2.1.0`                                              |