### PR TITLE
chore(flake/nixpkgs): `3fe528de` -> `f101b1d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1641865627,
-        "narHash": "sha256-B3b7KCThCx5bcDtWCX9ZZIl/EVs/lB8iDdI277/tvNA=",
+        "lastModified": 1641908842,
+        "narHash": "sha256-GlOPk7IQxquq7jeZClhhmtMk2ByCq9e13dP9i2SGISE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3fe528dec572a26404f130893d2c22a35646247c",
+        "rev": "f101b1d0f976b95444cdaf19a8f3d09148bd9c02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`690debd3`](https://github.com/NixOS/nixpkgs/commit/690debd36ec8fffeee1a8d1eab6cc70899359a74) | `gomapenum: 1.0.0 -> 1.0.2`                                                                   |
| [`e99d9860`](https://github.com/NixOS/nixpkgs/commit/e99d9860f94f70db6778b170c00eb243a47da01b) | `python310Packages.grappelli_safe: 1.0.0 -> 1.1.1`                                            |
| [`3616d6cb`](https://github.com/NixOS/nixpkgs/commit/3616d6cb744eae1699d57c5a7443003c0d577143) | `python3Packages.hahomematic: 0.17.1 -> 0.18.0`                                               |
| [`c673f8a0`](https://github.com/NixOS/nixpkgs/commit/c673f8a04dcb08760fb6ba79c40c21ae48d87c1a) | `python3Packages.flux-led: 0.27.44 -> 0.27.45`                                                |
| [`de4f3524`](https://github.com/NixOS/nixpkgs/commit/de4f35243daff2e3f04b29642bd7915e3089fb3f) | `ginkgo: 1.16.5 -> 2.0.0`                                                                     |
| [`a4b6785d`](https://github.com/NixOS/nixpkgs/commit/a4b6785de97e0f0524281647671cee7ce23a911c) | `isabelle: patch jni libs for nitpick`                                                        |
| [`b081303c`](https://github.com/NixOS/nixpkgs/commit/b081303c2437c3bb9e0bef86ac891b69cfe0d70a) | `httpx: 1.1.4 -> 1.1.5`                                                                       |
| [`bd9bf2ee`](https://github.com/NixOS/nixpkgs/commit/bd9bf2ee927d947af2b054b93016d53f897cce25) | `python3Packages.annexremote: disable failing tests`                                          |
| [`087ce9fd`](https://github.com/NixOS/nixpkgs/commit/087ce9fd018b414c412e447eb79f1487768b5ea2) | `mmixware: unstable-2019-02-19 -> unstable-2021-06-18`                                        |
| [`21769949`](https://github.com/NixOS/nixpkgs/commit/21769949dc5bb3c4f0a6bf74423f5fc1a4ef56b2) | `python3Packages.labmath: 1.2.0 -> 2.2.0`                                                     |
| [`135519c7`](https://github.com/NixOS/nixpkgs/commit/135519c7fa2985917e0c74a11b195a9f07db8dbf) | `cyclone-scheme: 0.30.0 -> 0.34.0`                                                            |
| [`0806c260`](https://github.com/NixOS/nixpkgs/commit/0806c2602a21a7450e614618725ce5ab12502c61) | `Update nixos/modules/services/networking/teleport.nix`                                       |
| [`009f8ca2`](https://github.com/NixOS/nixpkgs/commit/009f8ca222425162c27c685d859b0596ae98fa8b) | `python310Packages.cirq-google: disable failing tests`                                        |
| [`11a2ff4f`](https://github.com/NixOS/nixpkgs/commit/11a2ff4fb8e7dca4343458fe5c2152f6532529b5) | `htmlq: 0.3.0 -> 0.4.0`                                                                       |
| [`e74ca28b`](https://github.com/NixOS/nixpkgs/commit/e74ca28beda7b927f2372885e046698e3043b2dd) | `vim-plugins: Fix name of attribute`                                                          |
| [`ba434d95`](https://github.com/NixOS/nixpkgs/commit/ba434d950decf83597a1c73b2fb6af7cd24e7d5e) | `vscode-extensions.pkief.material-product-icons: init at 1.1.1`                               |
| [`47dc5bf2`](https://github.com/NixOS/nixpkgs/commit/47dc5bf2b95b466bcc434e2e089bbb91f640450b) | `nixos/teleport: add release notes`                                                           |
| [`2e9a9321`](https://github.com/NixOS/nixpkgs/commit/2e9a9321936824d5409e4b2dbcad5bb3470afb20) | `teleport: add tests`                                                                         |
| [`77b44222`](https://github.com/NixOS/nixpkgs/commit/77b442226d3aaf45a13a8ebbf2567eb759f4db63) | `nixos/tests/teleport: init`                                                                  |
| [`d811a6ea`](https://github.com/NixOS/nixpkgs/commit/d811a6ea7312dd22ca9cbeb176aca3146fac8574) | `nixos/teleport: init`                                                                        |
| [`63f429de`](https://github.com/NixOS/nixpkgs/commit/63f429de02e654d5fdec1afd5bd86fdd89d8bc00) | `python310Packages.pytest-doctestplus: add patch to remove distutils`                         |
| [`98c8ce49`](https://github.com/NixOS/nixpkgs/commit/98c8ce498f9df6eff4fc4bf49421b271b896afd4) | `python3Packages.denonavr: disable failing tests`                                             |
| [`55d6c2cd`](https://github.com/NixOS/nixpkgs/commit/55d6c2cdb63042c6a57210b32dd388ddac269df1) | `python3Packages.pyrmvtransport: support for later pytest-httpx`                              |
| [`c93fe3d0`](https://github.com/NixOS/nixpkgs/commit/c93fe3d0dc6318a3f7f1143232fca92490644371) | `python3Packages.devolo-plc-api: 0.7.0 -> 0.7.1`                                              |
| [`cb398669`](https://github.com/NixOS/nixpkgs/commit/cb398669d435d2c1fdd57cc43bdea0f7a3fd3909) | `python3Packages.zeep: disable outdated tests`                                                |
| [`7e228858`](https://github.com/NixOS/nixpkgs/commit/7e228858764216f20bc96de71ee261d80941d61a) | `python3Packages.glances-api: 0.3.2 -> 0.3.3`                                                 |
| [`3be14d7b`](https://github.com/NixOS/nixpkgs/commit/3be14d7b3a00e566c0f4389769346cf499c63edc) | `python3Packages.luftdaten: 0.7.1 -> 0.7.2`                                                   |
| [`20d3d8ee`](https://github.com/NixOS/nixpkgs/commit/20d3d8eeea03ad53918f74c8f91a606273e870a4) | `python3Packages.aiocurrencylayer: 1.0.2 -> 1.0.3`                                            |
| [`64aab9c2`](https://github.com/NixOS/nixpkgs/commit/64aab9c28d071e774d6f8c48694b2de2d844d2c0) | `python3Packages.netdata: 1.0.1 -> 1.0.2`                                                     |
| [`3228ecd3`](https://github.com/NixOS/nixpkgs/commit/3228ecd3d9ba9ee79c83d3ec9ac7e3bfd89a8ddd) | `python3Packages.pytest-httpx: 0.15.0 -> 0.17.3`                                              |
| [`6b98aa0d`](https://github.com/NixOS/nixpkgs/commit/6b98aa0d5469f20c01835bbf36f0400e19ff0c08) | `python3Packages.requests-toolbelt: disable warnings`                                         |
| [`b2737d49`](https://github.com/NixOS/nixpkgs/commit/b2737d4980a17cc2b7d600d7d0b32fd7333aca88) | `python3Packages.tensorflow-datasets: init at 4.4.0 (#154117)`                                |
| [`6faf96d5`](https://github.com/NixOS/nixpkgs/commit/6faf96d5023042b1204310c107a33a950273bc15) | `haskellPackages: mark builds failing on hydra as broken`                                     |
| [`da2e5ac7`](https://github.com/NixOS/nixpkgs/commit/da2e5ac775db0a42ad6a90aa3a57c93c34b82bb7) | `dua: 2.14.11 -> 2.16.0`                                                                      |
| [`40d28cd7`](https://github.com/NixOS/nixpkgs/commit/40d28cd73345bbb0b8f6ef520de1ed043c8904a1) | `fq: 0.0.2 -> 0.0.3`                                                                          |
| [`21e5e2a5`](https://github.com/NixOS/nixpkgs/commit/21e5e2a54886d35d6df21a345c05b7527ce3801d) | `ugrep: 3.4.0 -> 3.5.0`                                                                       |
| [`c7b6d5ff`](https://github.com/NixOS/nixpkgs/commit/c7b6d5ffc190e488d08deae367edd41552402543) | `vscode-extensions.github.vscode-pull-request-github: 0.35.2021122109 -> 0.35.2022010609`     |
| [`444baf10`](https://github.com/NixOS/nixpkgs/commit/444baf106d54d186723d64f70c0768f6ce68a471) | `vyper: 0.3.0 -> 0.3.1`                                                                       |
| [`30ca2615`](https://github.com/NixOS/nixpkgs/commit/30ca2615e48fbf587ca9a447cbbf6adafe59d1d8) | `disfetch: 2.15 -> 3.2`                                                                       |
| [`24fa2560`](https://github.com/NixOS/nixpkgs/commit/24fa256045310dac062f09989620c11ababc8450) | `crowdin-cli: 3.7.4 -> 3.7.5`                                                                 |
| [`69ccf66f`](https://github.com/NixOS/nixpkgs/commit/69ccf66f8ab02adcad21ef29b53d19e7c2c335e9) | `crd2pulumi: 1.0.10 -> 1.1.0`                                                                 |
| [`231e9609`](https://github.com/NixOS/nixpkgs/commit/231e96096316ece50435387e15e0afbc81aa2c7e) | `python310Packages.goodwe: 0.2.13 -> 0.2.14`                                                  |
| [`147d1224`](https://github.com/NixOS/nixpkgs/commit/147d122488eb9f9401c1adc9c96002c3554c85db) | `python310Packages.thespian: 3.10.5 -> 3.10.6`                                                |
| [`dd87641b`](https://github.com/NixOS/nixpkgs/commit/dd87641b8b68bf07182888dcf7d222aace4b1330) | `python310Packages.confluent-kafka: 1.7.0 -> 1.8.2`                                           |
| [`73f65158`](https://github.com/NixOS/nixpkgs/commit/73f65158dda507fed7b97eeaea1f4aeb5d834419) | `python3Packages.ncclient: remove unused dependency`                                          |
| [`c2f341e4`](https://github.com/NixOS/nixpkgs/commit/c2f341e4de47f9b9d43f90e9814ca63dacec57df) | `weidu: 247 -> 249`                                                                           |
| [`9613e4a2`](https://github.com/NixOS/nixpkgs/commit/9613e4a2708a97e81c9ec48765baf67f15664f77) | `python310Packages.chiapos: 1.0.7 -> 1.0.8`                                                   |
| [`7d5300d2`](https://github.com/NixOS/nixpkgs/commit/7d5300d2f2f20372ac9dafb53b75e48406005ea0) | `pantheon.elementary-videos: 2.8.1 -> 2.8.3`                                                  |
| [`75d64f2c`](https://github.com/NixOS/nixpkgs/commit/75d64f2c1978a81669861888e153eff4fe41fd18) | `zsh: remove superfluous darwin postInstall make`                                             |
| [`d5f87a4a`](https://github.com/NixOS/nixpkgs/commit/d5f87a4a149e297514e9bb8533af7e309b9d470a) | `cargo-generate: 0.11.1 -> 0.12.0`                                                            |
| [`b2dea162`](https://github.com/NixOS/nixpkgs/commit/b2dea1626e26cb34ed12c78847df95f23e294dfe) | `v2ray-geoip: 202112300030 -> 202201060033`                                                   |
| [`bb600e55`](https://github.com/NixOS/nixpkgs/commit/bb600e55287c6e12211af536bc134b2bc2251500) | `ansible-lint: 5.3.1 -> 5.3.2`                                                                |
| [`0081189a`](https://github.com/NixOS/nixpkgs/commit/0081189a9c5abb057ceda8766ffbc2931ddf61d3) | `b3sum: 1.2.0 -> 1.3.0`                                                                       |
| [`716fb1c0`](https://github.com/NixOS/nixpkgs/commit/716fb1c04ed126149ad0038b6e5e9e8e84d1ee41) | `assh: 2.12.1 -> 2.12.2`                                                                      |
| [`d7e26307`](https://github.com/NixOS/nixpkgs/commit/d7e26307386a622948b66b0d859252f5698cbd44) | `cht-sh: unstable-2021-11-17 -> unstable-2022-01-01`                                          |
| [`d9d30199`](https://github.com/NixOS/nixpkgs/commit/d9d30199ec6d8b0a12b9e7d77c019e0fcac96f66) | `isabelle: patch zipperposition binary`                                                       |
| [`de69cfae`](https://github.com/NixOS/nixpkgs/commit/de69cfae3c71ffcee468c28845c6b414d3302c7f) | `autosuspend: 4.0.1 -> 4.1.0`                                                                 |
| [`a78a7310`](https://github.com/NixOS/nixpkgs/commit/a78a7310caf282c9db9736c25b21a21099896360) | `xchm: 1.32 -> 1.33`                                                                          |
| [`c8121360`](https://github.com/NixOS/nixpkgs/commit/c81213600a01134ea0b18f01bdb6d55f837a2181) | `python310Packages.xarray: fix build`                                                         |
| [`2218998b`](https://github.com/NixOS/nixpkgs/commit/2218998b7ab636ed201bf0ca2083df6ee81961a0) | `python3Packages.vt-py: 0.13.0 -> 0.13.1`                                                     |
| [`64e27090`](https://github.com/NixOS/nixpkgs/commit/64e2709015a866c2f02cc16875f931c7c8be988f) | `python3Packages.aioconsole: disable failing tests`                                           |
| [`2625adb7`](https://github.com/NixOS/nixpkgs/commit/2625adb74f7ad94c30b0d02e7a8368357c4990de) | `sqlfluff: 0.9.0 -> 0.9.1`                                                                    |
| [`7a8b98ee`](https://github.com/NixOS/nixpkgs/commit/7a8b98ee8d18880786e1463352814a353260022e) | `python3Packages.oyaml: 1.0 -> unstable-2021-12-03`                                           |
| [`2f76e57f`](https://github.com/NixOS/nixpkgs/commit/2f76e57f6a40b5e6e98fe5df99d4dca2fbfeeb01) | `python3Packages.trio: fix python310 by not treating deprecation warnings as errors in tests` |
| [`d0a0625e`](https://github.com/NixOS/nixpkgs/commit/d0a0625e3c2bcf074454e94ff129e65d251e8453) | `python3Packages.requests-toolbelt: switch to pytestCheckHook`                                |
| [`205b0f2c`](https://github.com/NixOS/nixpkgs/commit/205b0f2c5e8216827126ddb73fd25c96d39d4b29) | `Idris2: Refactor default.nix`                                                                |
| [`14a53845`](https://github.com/NixOS/nixpkgs/commit/14a538452be2ba4f436aad0e3c946b04a125afff) | `python3Packages.pontos: 21.11.0 -> 22.1.0`                                                   |
| [`d222225b`](https://github.com/NixOS/nixpkgs/commit/d222225ba6ebbed7b9cb42e33f0bdda03de0cabd) | `python3Packages.hahomematic: 0.16.0 -> 0.17.1`                                               |
| [`06a4b7c7`](https://github.com/NixOS/nixpkgs/commit/06a4b7c78768df3c1994fdc23fe24616c668205f) | `python3Packages.adafruit-platformdetect: 3.19.1 -> 3.19.2`                                   |
| [`9457af45`](https://github.com/NixOS/nixpkgs/commit/9457af45a96c7093d684d845d4266ea783e09897) | `checkov: remove obsolete overrides`                                                          |
| [`80fb0564`](https://github.com/NixOS/nixpkgs/commit/80fb0564e99c2dd194a1b1bfeffe817f1f0ef35a) | `inherd-quake: 0.3.0 -> 0.4.0`                                                                |
| [`5a65d5c7`](https://github.com/NixOS/nixpkgs/commit/5a65d5c705a462916c3e5e869c6903bfb878822f) | `clojure-lsp: disable integration-test`                                                       |
| [`315b52cb`](https://github.com/NixOS/nixpkgs/commit/315b52cb98c48f08c55aa3401491f5261d32e873) | `awscli2: 2.3.4 -> 2.4.9`                                                                     |
| [`a3d54a46`](https://github.com/NixOS/nixpkgs/commit/a3d54a465d1c27caee33233aa7c927cb44b8eccd) | `inkscape: Remove networkmanager as an inkscape dependency`                                   |
| [`adf8815c`](https://github.com/NixOS/nixpkgs/commit/adf8815c8ea78ad0bcada51fe41f1015a67ee5ec) | `python3Packages.s3transfer: enable tests`                                                    |
| [`2d7b3699`](https://github.com/NixOS/nixpkgs/commit/2d7b3699b3ba04ed99b8c865058ee372d91785d1) | `python3Packages.cirq-rigetti: relax dependency constrains`                                   |
| [`9d64a1a9`](https://github.com/NixOS/nixpkgs/commit/9d64a1a98f7541fb80450533b8a28c818ec22b21) | `python3Packages.qcs-api-client: enable tests`                                                |
| [`0e87f1f5`](https://github.com/NixOS/nixpkgs/commit/0e87f1f5aaeea491f0c504064e5af1602aa0f886) | `haskellPackages.reflex-dom-core: Fix build by pinning patch`                                 |
| [`e49d3a2e`](https://github.com/NixOS/nixpkgs/commit/e49d3a2ebc2bc16da1bb71417a70afe91b98dc8a) | `haskellPackages.ghcup: Fix build`                                                            |
| [`967c9bcc`](https://github.com/NixOS/nixpkgs/commit/967c9bccb4acecffa1348f849fdbbc68b553d22f) | `python310Packages.mdformat: 0.7.12 -> 0.7.13`                                                |
| [`85fb5562`](https://github.com/NixOS/nixpkgs/commit/85fb55626b580642d6b738939695d4139b937891) | `haskellPackages.haskell-language-server: Fix build by pinning dependencies`                  |
| [`dc0704c0`](https://github.com/NixOS/nixpkgs/commit/dc0704c08ffd886046ed6ec736599743f901cc2a) | `haskellPackages.mfsolve: disable broken test suite`                                          |
| [`f371562b`](https://github.com/NixOS/nixpkgs/commit/f371562bb440bf76d20d350ff336064ced981c94) | `haskellPackages.git-annex: adjust src hash for 8.20211231`                                   |
| [`b7f010ed`](https://github.com/NixOS/nixpkgs/commit/b7f010ed965dace4a954fbb8bd34a63cc4042197) | `vivaldi-ffmpeg-codecs: 94.0.4606.50 -> 97.0.4692.56`                                         |
| [`1054bfd2`](https://github.com/NixOS/nixpkgs/commit/1054bfd2949db4d3e1f8e91bc47f424c67af7361) | `clojure-lsp: 2021.11.02 -> 2022.01.03`                                                       |
| [`fb075fab`](https://github.com/NixOS/nixpkgs/commit/fb075fab731adbacfec384ad910bf48920c099c4) | `haskellPackages.{ghcWithPackages, ghcWithHoogle}: make overrideable`                         |
| [`baaf9459`](https://github.com/NixOS/nixpkgs/commit/baaf9459d6105c243239289e1e82e3cdd5ac4809) | `haskellPackages.callPackage: support returning functions`                                    |
| [`f662c8be`](https://github.com/NixOS/nixpkgs/commit/f662c8be61bb678797b18ae1874ad992e6102511) | `ghcWithPackages: remove check for GHC >= 6.12`                                               |
| [`180213a0`](https://github.com/NixOS/nixpkgs/commit/180213a0aca0f783fed14e0e71e558693d4cbd0b) | `nixos/kresd: fix IPv6 scope syntax`                                                          |
| [`1071b77c`](https://github.com/NixOS/nixpkgs/commit/1071b77c21f2e3bbccd20ace7272f3d843fea0b4) | `knot-resolver: 5.4.3 -> 5.4.4`                                                               |
| [`11b0130e`](https://github.com/NixOS/nixpkgs/commit/11b0130ebd95bdef797e02a8c5b20ebbe2daa71c) | `haskellPackages.text-short: bump latest version to fix eval errors`                          |
| [`882ecaa5`](https://github.com/NixOS/nixpkgs/commit/882ecaa53044af65cf6aab5d62802454cbf0e87d) | `haskellPackages.hlint: bump latest version`                                                  |
| [`d0e6c53a`](https://github.com/NixOS/nixpkgs/commit/d0e6c53a9678ec169a2a112a3b40239892d66d6a) | `haskellPackages.lsp: bump override for most recent version`                                  |
| [`9a558b9b`](https://github.com/NixOS/nixpkgs/commit/9a558b9b8ac1332004091cfc9aacedece205817d) | `haskellPackages: regenerate package set based on current config`                             |
| [`7269b849`](https://github.com/NixOS/nixpkgs/commit/7269b849576a9073991660fa61ca621732467fd6) | `all-cabal-hashes: 2021-12-28T00:33:48Z -> 2022-01-05T00:50:25Z`                              |
| [`c091486f`](https://github.com/NixOS/nixpkgs/commit/c091486f096426c2bb4e0abfa9d7d13f4b38c921) | `haskellPackages: stackage-lts 18.20 -> 18.21`                                                |
| [`07c58667`](https://github.com/NixOS/nixpkgs/commit/07c58667ccab64b3dfbc620f58ae8a12a2b3f6bc) | `jql: 3.0.4 -> 3.0.6`                                                                         |
| [`b488b8ae`](https://github.com/NixOS/nixpkgs/commit/b488b8ae9bd459bfa43c0db3edfdc25446db11cd) | `imgproxy: 3.0.0 -> 3.1.3`                                                                    |
| [`1fcaa65c`](https://github.com/NixOS/nixpkgs/commit/1fcaa65c896c7fbe374201b753697041d854dcc0) | `nats-server: 2.6.0 -> 2.6.3`                                                                 |