### PR TITLE
chore(flake/home-manager): `5209ea0d` -> `d07df8d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1641915897,
-        "narHash": "sha256-C5Vw7B8BKA/kr9tWVYjEdD3AjstXFqoxkkzrOwfQZxk=",
+        "lastModified": 1641937533,
+        "narHash": "sha256-IJbR1nNV6v/ruWv9iUFi9/qa8tFLmMhbVjzvhSWCWJY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5209ea0d8c77399ec4987590e9738953f15f8d80",
+        "rev": "d07df8d9a80a4a34ea881bee7860ae437c5d44a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                      |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`d07df8d9`](https://github.com/nix-community/home-manager/commit/d07df8d9a80a4a34ea881bee7860ae437c5d44a5) | `Translate using Weblate (Spanish)` |
| [`8a431023`](https://github.com/nix-community/home-manager/commit/8a431023c0cfdfc29632e69dd17bf34b8e749b80) | `Translate using Weblate (Spanish)` |