### PR TITLE
chore(flake/nixpkgs): `f101b1d0` -> `e00186bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,10 +2,7 @@
   "nodes": {
     "agenix": {
       "inputs": {
-        "nixpkgs": [
-          "ragenix",
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1641576265,
@@ -60,6 +57,21 @@
       "original": {
         "owner": "edolstra",
         "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -120,16 +132,46 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1641908842,
-        "narHash": "sha256-GlOPk7IQxquq7jeZClhhmtMk2ByCq9e13dP9i2SGISE=",
+        "lastModified": 1641946385,
+        "narHash": "sha256-8RA8lefnbL9TAxNdyLKJ4T6KsknRMbsU8ghKfraDQbA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f101b1d0f976b95444cdaf19a8f3d09148bd9c02",
+        "rev": "e00186bc0f4453298bd3ab6e0fba3113e55951a3",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1641909823,
+        "narHash": "sha256-Uxo+Wm6c/ijNhaJlYtFLJG9mh75FYZaBreMC2ZE0nEY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f0f67400bc49c44f305d6fe17698a2f1ce1c29a0",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1641909823,
+        "narHash": "sha256-Uxo+Wm6c/ijNhaJlYtFLJG9mh75FYZaBreMC2ZE0nEY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f0f67400bc49c44f305d6fe17698a2f1ce1c29a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -198,14 +240,8 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "ragenix",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "ragenix",
-          "nixpkgs"
-        ]
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1641609771,


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                           |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`9292a52c`](https://github.com/NixOS/nixpkgs/commit/9292a52ce081291e72d84c2a8ed1b4904da80e72) | `mill: 0.9.11 -> 0.9.12`                                                                 |
| [`298f2b76`](https://github.com/NixOS/nixpkgs/commit/298f2b76e5f4dc4dea4217b938535e50e1650cd2) | `jackett: 0.20.184 -> 0.20.285`                                                          |
| [`ae9cb351`](https://github.com/NixOS/nixpkgs/commit/ae9cb35195d3882d601c06d659002025b3d67132) | `driftctl: 0.17 -> 0.18.3`                                                               |
| [`7166f36c`](https://github.com/NixOS/nixpkgs/commit/7166f36cb27809583d3dce64dbe144319858074a) | `mark: 6.5.1 -> 6.7`                                                                     |
| [`36ba8c55`](https://github.com/NixOS/nixpkgs/commit/36ba8c55f43563f3731e098d9aa1526589167cd5) | `moonlight-embedded: 2.5.1 -> 2.5.2`                                                     |
| [`6c284f51`](https://github.com/NixOS/nixpkgs/commit/6c284f51782d75088e11eb56129c78387e91a76a) | `html-xml-utils: 8.0 -> 8.1`                                                             |
| [`c5070b61`](https://github.com/NixOS/nixpkgs/commit/c5070b61b2b2065b144a64bccfa989fadae652a4) | `java-service-wrapper: 3.5.46 -> 3.5.48`                                                 |
| [`a1e73582`](https://github.com/NixOS/nixpkgs/commit/a1e735824e4d153d8719f943f0f83e885a18c4bf) | `python38Packages.nbsphinx: 0.8.7 -> 0.8.8`                                              |
| [`3fcdc513`](https://github.com/NixOS/nixpkgs/commit/3fcdc51354a3e919dfe50b8ab04d525c67e64d55) | `python3Packages.types-setuptools: 57.4.6 -> 57.4.7`                                     |
| [`7d8d3c71`](https://github.com/NixOS/nixpkgs/commit/7d8d3c71228756406b70e142411295affbbb3fa1) | `yubikey-manager: fix build`                                                             |
| [`36a7c960`](https://github.com/NixOS/nixpkgs/commit/36a7c960d3135cf85bf52700b8e585c945fdddac) | `python3Packages.flux-led: 0.27.45 -> 0.28.0`                                            |
| [`11644ddc`](https://github.com/NixOS/nixpkgs/commit/11644ddcf276907dd48866582c3af33c9d6e7489) | `flutter: add missing dart-sdk cache folder`                                             |
| [`09e1b9a4`](https://github.com/NixOS/nixpkgs/commit/09e1b9a45f6ebca72cd9e7408f467b04f675252f) | `checkov: 2.0.708 -> 2.0.710`                                                            |
| [`2285d931`](https://github.com/NixOS/nixpkgs/commit/2285d931e79b2a241a2be6dfb805a7344a0046bd) | `python3.pkgs.jupyterlab_server: re-enable some tests`                                   |
| [`9751d51c`](https://github.com/NixOS/nixpkgs/commit/9751d51c2de3d3476da27e7451a44909492e1278) | `python3Packages.meshtastic: 1.2.52 -> 1.2.53`                                           |
| [`5072e7ea`](https://github.com/NixOS/nixpkgs/commit/5072e7ead68aba055cf00548f7ece4ececcdd763) | `minify: 2.9.22 -> 2.9.24`                                                               |
| [`ce53f09f`](https://github.com/NixOS/nixpkgs/commit/ce53f09f6fcf25c075905b435a6c211c7ead9372) | `moolticute: 0.53.2 -> 0.53.7`                                                           |
| [`d4bd9222`](https://github.com/NixOS/nixpkgs/commit/d4bd92225e4a295ab2788294f9f9888021f776ef) | `python310Packages.aiopvpc: fix python 3.10 build`                                       |
| [`bceba2b4`](https://github.com/NixOS/nixpkgs/commit/bceba2b4220dab149a9dfe2409568399621f5767) | `geekbench: 5.4.3 -> 5.4.4`                                                              |
| [`df2852b9`](https://github.com/NixOS/nixpkgs/commit/df2852b9116676560230329670847dd605d8da0e) | `dprint: 0.18.2 -> 0.19.2`                                                               |
| [`56fe75ef`](https://github.com/NixOS/nixpkgs/commit/56fe75efd43c1afa856d908863d4b473a8624a95) | `fwbuilder: init at 6.0.0-rc1`                                                           |
| [`bf601a58`](https://github.com/NixOS/nixpkgs/commit/bf601a58aab73e91501c0ed0f67e9788129bc051) | `COPYING: 2021 -> 2022`                                                                  |
| [`dfdb5a94`](https://github.com/NixOS/nixpkgs/commit/dfdb5a946d3f6fe03172b355b08216a6e0abe7f3) | `conan: remove PyYAML version restriction`                                               |
| [`ab5ee58d`](https://github.com/NixOS/nixpkgs/commit/ab5ee58d9027050a3e34072941042f99f89e3001) | `gptman: 0.8.2 -> 0.8.3`                                                                 |
| [`167402b5`](https://github.com/NixOS/nixpkgs/commit/167402b517697d09d7d102886b0df16153e1af33) | `svkbd: 0.4 -> 0.4.1`                                                                    |
| [`27638b2c`](https://github.com/NixOS/nixpkgs/commit/27638b2c9bd3fd1f20bfdf7345e0d3d94cb38c55) | `maintainers: update kmein's email`                                                      |
| [`9ca2dc07`](https://github.com/NixOS/nixpkgs/commit/9ca2dc072cae19523bccbf87207680d80a581da1) | `photon-rss: init at unstable-2022-01-11`                                                |
| [`15079ba1`](https://github.com/NixOS/nixpkgs/commit/15079ba19e3281e9c8afa208c69efe9d9da378e3) | `ratt: init at unstable-2022-01-11`                                                      |
| [`e781760e`](https://github.com/NixOS/nixpkgs/commit/e781760ec4f7b7257cfffa270733070cccfeac21) | `monero-gui: 0.17.3.0 -> 0.17.3.1`                                                       |
| [`26244770`](https://github.com/NixOS/nixpkgs/commit/262447705c48d0c7dd3746b6a6c872ab8bd33007) | `nixos/ssh: add programs.ssh.knownHostsFiles option`                                     |
| [`89a18020`](https://github.com/NixOS/nixpkgs/commit/89a18020fa043e3d943c2b43bb87bfd0a4e23acd) | `mob: 2.1.0 -> 2.2.0`                                                                    |
| [`810e09c5`](https://github.com/NixOS/nixpkgs/commit/810e09c544b500e25951291eaf64fedb8c067300) | `amaranth, glasgow: add myself as maintainer`                                            |
| [`94f60c1e`](https://github.com/NixOS/nixpkgs/commit/94f60c1ee91f348150fed639ab6e0b706144d9cb) | `glasgow: unstable-2021-03-02 -> unstable-2021-12-12`                                    |
| [`88e33869`](https://github.com/NixOS/nixpkgs/commit/88e338692e3e8bb554716a1f47f595cded6c20bb) | `amaranth-boards: rename from nmigen-boards, unstable-2021-02-09 -> unstable-2021-12-17` |
| [`fb361d39`](https://github.com/NixOS/nixpkgs/commit/fb361d399e1cb06140c8bfc4ca913a410aa02166) | `amaranth-soc: rename from nmigen-soc, unstable-2021-02-09 -> unstable-2021-12-10`       |
| [`34d3df28`](https://github.com/NixOS/nixpkgs/commit/34d3df28d58878dcfacb50ad55f24af509320e29) | `amaranth: rename from nmigen, unstable-2021-02-09 -> 0.3`                               |
| [`9b7691cb`](https://github.com/NixOS/nixpkgs/commit/9b7691cbb45649a11d664382ccd4531c916d53c8) | `zsh: exclude util-linux on darwin`                                                      |
| [`fbc2b8cd`](https://github.com/NixOS/nixpkgs/commit/fbc2b8cded956c32a42c4bdaf0da44defe3c8dde) | `maintainers: add elatov`                                                                |
| [`84f8ae0e`](https://github.com/NixOS/nixpkgs/commit/84f8ae0eba826ef17b0b1e60e9d6c0d75c55de77) | `python3Packages.pywlroots: 0.14.11 -> 0.14.12`                                          |
| [`26c29a52`](https://github.com/NixOS/nixpkgs/commit/26c29a52bdeb15bacf3ee99127778b1a2336fc03) | `macchina: 5.0.5 -> 6.0.5`                                                               |
| [`30bfcfbf`](https://github.com/NixOS/nixpkgs/commit/30bfcfbf355bafecee3da17905656f96c250a973) | `log4j-vuln-scanner: 0.11 -> 0.13`                                                       |
| [`45dffc49`](https://github.com/NixOS/nixpkgs/commit/45dffc49d21077eb39e9e2939349175239db81ab) | `log4j-sniffer: 1.0.0 -> 1.2.0`                                                          |
| [`34c1ae49`](https://github.com/NixOS/nixpkgs/commit/34c1ae49a7d6ca7f82e722310efc06e2d0e389a5) | `python3.pkgs.pygls: unpin pydantic`                                                     |
| [`1e47c205`](https://github.com/NixOS/nixpkgs/commit/1e47c2055d77df23209e6bd04cd3996d915ef21c) | `ivan: maintainer was removed`                                                           |
| [`a41b0b4b`](https://github.com/NixOS/nixpkgs/commit/a41b0b4b941752d27eab0d16fb3ea51c96f94ba0) | `gqrx: 2.15.1 -> 2.15.2`                                                                 |
| [`17153b78`](https://github.com/NixOS/nixpkgs/commit/17153b78f3491ccf176d6bc7de6ca7518cb62eb9) | `python3Packages.kaptan: remove PyYAML version restriction`                              |
| [`d2573f64`](https://github.com/NixOS/nixpkgs/commit/d2573f647bf36d90d361b3dd5dbea4695c9dfc59) | `json-tricks: init at 3.15.5`                                                            |
| [`7aff8533`](https://github.com/NixOS/nixpkgs/commit/7aff85339a41270e727a66c7d774fa73fe00dae0) | `metasploit: 6.1.23 -> 6.1.24`                                                           |
| [`54c051fa`](https://github.com/NixOS/nixpkgs/commit/54c051fab56824adf7d2ef6ac8da5bd67dd3e622) | `python3Packages.aioridwell: 2021.10.0 -> 2021.12.2`                                     |
| [`1f754ea0`](https://github.com/NixOS/nixpkgs/commit/1f754ea07e139e7fceda89a5732b848712400983) | `vscode-extensions.antyos.openscad: init at 1.1.1`                                       |
| [`2ebda61e`](https://github.com/NixOS/nixpkgs/commit/2ebda61ecb0382db8301f402a8568a4b5ac9ca1d) | `python3Packages.sounddevice: 0.4.3 → 0.4.4, fix on darwin`                              |
| [`89cc3979`](https://github.com/NixOS/nixpkgs/commit/89cc3979f742300d010a2222b7080d6120058dcd) | `python3Packages.GitPython: 3.1.24 -> 3.1.25`                                            |
| [`49c8bee3`](https://github.com/NixOS/nixpkgs/commit/49c8bee3168a3266461203519933a018031d4ab9) | `qodem: init at 1.0.1`                                                                   |
| [`e0ab0a72`](https://github.com/NixOS/nixpkgs/commit/e0ab0a7214f9a62f03722d93b4101b05a9dee9c0) | `strace: 5.15 -> 5.16`                                                                   |
| [`c861fd0a`](https://github.com/NixOS/nixpkgs/commit/c861fd0a756dc370dc80600776b0b2acb01eb989) | `python310Packages.smart-meter-texas: 0.4.7 -> 0.5.0`                                    |
| [`f3b193a5`](https://github.com/NixOS/nixpkgs/commit/f3b193a5df4df99c5da9494650877912068c5e66) | `python310Packages.pymelcloud: 2.5.6 -> 2.11.0`                                          |
| [`1a454a32`](https://github.com/NixOS/nixpkgs/commit/1a454a32d7f864f63216fffca86814e59f4c0f0d) | `cloud-hypervisor: 20.1 -> 20.2`                                                         |
| [`74a88c49`](https://github.com/NixOS/nixpkgs/commit/74a88c4961faf65a1b71565444ff759d68754700) | `baget service: init`                                                                    |
| [`209bfb6a`](https://github.com/NixOS/nixpkgs/commit/209bfb6ac61e802589260af4e762eebd2550c84d) | `baget: init at 0.4.0-preview2`                                                          |
| [`fb624bf1`](https://github.com/NixOS/nixpkgs/commit/fb624bf1adc73d61afe0cdd461daa0b2c9711efe) | `python310Packages.datadog: 0.42.0 -> 0.43.0`                                            |
| [`31bee607`](https://github.com/NixOS/nixpkgs/commit/31bee6078b1270d8cbb8df9d099e418ec0d9214c) | `python3Packages.idasen: 0.8.1 -> 0.8.2`                                                 |
| [`555d3e15`](https://github.com/NixOS/nixpkgs/commit/555d3e151162ba31ede3ee5ab78d6af791b365d4) | `python310Packages.bleak: 0.13.0 -> 0.14.0`                                              |
| [`85887e82`](https://github.com/NixOS/nixpkgs/commit/85887e827b81d3f2856205819664521e44ef79c3) | `grype: 0.30.0 -> 0.31.1`                                                                |
| [`a2f83d08`](https://github.com/NixOS/nixpkgs/commit/a2f83d086916c74b4f8db83b7d22c8ea339a35c0) | `lfs: 1.3.1 -> 1.4.0`                                                                    |
| [`e6480a82`](https://github.com/NixOS/nixpkgs/commit/e6480a823e6130e45310f2b42d0adf2224ead331) | `spicetify-cli: 2.8.3 -> 2.8.4`                                                          |
| [`164e9acc`](https://github.com/NixOS/nixpkgs/commit/164e9acca4e8f64930ba772b28674a111c2b5b82) | `python310Packages.pamqp: 3.0.1 -> 3.1.0`                                                |
| [`01aecb0c`](https://github.com/NixOS/nixpkgs/commit/01aecb0c3d5144b87236a80d40032ef8e8b93c40) | `python310Packages.pyhomematic: 0.1.76 -> 0.1.77`                                        |
| [`821a2619`](https://github.com/NixOS/nixpkgs/commit/821a26192f0bb4cff9669f2b653114ac5f1db866) | `python3Packages.aioitertools: fix python 3.10`                                          |
| [`4d47e883`](https://github.com/NixOS/nixpkgs/commit/4d47e88395fdc963a83f65ecbaae4935142eb772) | `python310Packages.chiavdf: 1.0.3 -> 1.0.4`                                              |
| [`65dde73a`](https://github.com/NixOS/nixpkgs/commit/65dde73ad64f7d37847a541b546a14dd3717e8ee) | `python3.pkgs.openapi-core: disable failing test`                                        |
| [`a32c0151`](https://github.com/NixOS/nixpkgs/commit/a32c0151e415895e50425bf97c7a543410265b73) | `python310Packages.scikit-survival: 0.16.0 -> 0.17.0`                                    |
| [`cfb96b0a`](https://github.com/NixOS/nixpkgs/commit/cfb96b0a3d1e3c4cd7a25eb1d6b3c1c2af1df7bb) | `python310Packages.holidays: 0.11.3.1 -> 0.12`                                           |
| [`3b4585e3`](https://github.com/NixOS/nixpkgs/commit/3b4585e3be90c51c0625d9717cb7134af6c5d888) | `python310Packages.screenlogicpy: 0.5.3 -> 0.5.4`                                        |
| [`287e5f99`](https://github.com/NixOS/nixpkgs/commit/287e5f9966d9b081eedb76672ddc80dac7d873e5) | `python3Packages.luxtronik: 0.3.9 -> 0.3.10`                                             |
| [`c3e75b19`](https://github.com/NixOS/nixpkgs/commit/c3e75b195ef0d3011b47073c4d108d50dfc26e44) | `python3Packages.formbox: 0.1.0 -> 0.3.0`                                                |
| [`fd1bafd7`](https://github.com/NixOS/nixpkgs/commit/fd1bafd73a7281a3de0c8e63a8faca7df1ebd46b) | `python310Packages.django-taggit: 1.5.1 -> 2.0.0`                                        |
| [`18a37f66`](https://github.com/NixOS/nixpkgs/commit/18a37f663a6a65ef68070b2eb83d238209101066) | `liburing: use patch from commit instead of PR`                                          |
| [`53c7536d`](https://github.com/NixOS/nixpkgs/commit/53c7536da064efd9ee7bc85ef9f188b37d2a8818) | `liburing: fix build on armv6l`                                                          |
| [`0c10d0dc`](https://github.com/NixOS/nixpkgs/commit/0c10d0dcf160bd32d331ff59e839a6157bec6602) | `python310Packages.spyse-python: relax limiter constraint`                               |
| [`7c7127f7`](https://github.com/NixOS/nixpkgs/commit/7c7127f7a0962a84794dda25cb2011b441ef6ff8) | `python310Packages.limiter: 0.1.2 -> 0.2.0`                                              |
| [`46324ebb`](https://github.com/NixOS/nixpkgs/commit/46324ebbdd61db3285c38c2e724975fce19a8158) | `kondo: 0.4 -> 0.5`                                                                      |
| [`83455370`](https://github.com/NixOS/nixpkgs/commit/83455370854bcd3144fdad76afdc7a5cb3effdc0) | `gnome.gnome-software: 41.2 -> 41.3`                                                     |
| [`9fd9e5e5`](https://github.com/NixOS/nixpkgs/commit/9fd9e5e56e1aee370af97731c191c8f7572dcb2a) | `android-udev-rules: 20210501 -> 20220102`                                               |
| [`df634a03`](https://github.com/NixOS/nixpkgs/commit/df634a03f59621c687535beb565368d463ef727a) | `xgboost: 1.5.0 -> 1.5.1`                                                                |
| [`8b2fbc8f`](https://github.com/NixOS/nixpkgs/commit/8b2fbc8f8ab66027a105e9a7248bcdc5e850d552) | `gbenchmark: 1.6.0 -> 1.6.1`                                                             |
| [`9dc2e56e`](https://github.com/NixOS/nixpkgs/commit/9dc2e56e7d6bee46960a46e8f21f8b13e0a3db05) | `thermald: 2.4.6 -> 2.4.7`                                                               |
| [`af91fc45`](https://github.com/NixOS/nixpkgs/commit/af91fc45b19a005add371314032fcfc29f648cbb) | `kalker: 1.0.1-2 -> 1.1.0`                                                               |
| [`535dd737`](https://github.com/NixOS/nixpkgs/commit/535dd7377c3fe55a90cc2c29ab70ca1bcddeb56b) | `exploitdb: 2022-01-06 -> 2022-01-11`                                                    |
| [`e7448adb`](https://github.com/NixOS/nixpkgs/commit/e7448adb546ea44bdd6c8e188d1516bbc46236ca) | `jo: 1.4 -> 1.6`                                                                         |
| [`f465e9e9`](https://github.com/NixOS/nixpkgs/commit/f465e9e97c05706b293740fb5b6507fedc28c7b9) | `kubescape: 1.0.138 -> 1.0.139`                                                          |
| [`4f23b112`](https://github.com/NixOS/nixpkgs/commit/4f23b112581a4217449332e17f27f577ed1fbd3a) | `python310Packages.zstd: 1.5.0.4 -> 1.5.1.0`                                             |
| [`cab3599e`](https://github.com/NixOS/nixpkgs/commit/cab3599ef959096d712a419d3157f56c9fcfdadc) | `python3Packages.poetry: disable failing test`                                           |
| [`b0770408`](https://github.com/NixOS/nixpkgs/commit/b0770408976ec309f70e19dd78599bf8f2ad7145) | `notmuch: fix test with gnupg 2.3`                                                       |
| [`2df8608a`](https://github.com/NixOS/nixpkgs/commit/2df8608a2469e0aa3a96201c3c63b8533dad995c) | `python3Packages.types-requests: 2.27.2 -> 2.27.5`                                       |
| [`d5f87952`](https://github.com/NixOS/nixpkgs/commit/d5f87952a5e30ecfedbe99df95de99b62cfe7c9d) | `python3Packages.types-urllib3: init at 1.26.4`                                          |
| [`6f10ae26`](https://github.com/NixOS/nixpkgs/commit/6f10ae26f29c63aa05fbf3a46e8d99cff579b37f) | `python3Packages.loguru: disable failing tests`                                          |
| [`d323f67c`](https://github.com/NixOS/nixpkgs/commit/d323f67c004b6b210fd0a5013cca265615317264) | `python3Packages.cherrypy: switch to pytestCheckHook`                                    |
| [`625bda3e`](https://github.com/NixOS/nixpkgs/commit/625bda3e1fbca0d4439b295d88e4a78123c88deb) | `telega-server: fix substitutions for dwebp and ffmpeg binaries`                         |
| [`be72b6fe`](https://github.com/NixOS/nixpkgs/commit/be72b6fedd989a4e5fa8c706040782c21cc646e9) | `gofumpt: 0.2.0 -> 0.2.1`                                                                |
| [`354ef7d9`](https://github.com/NixOS/nixpkgs/commit/354ef7d909b7e1b47db6699e41f6aaa0185c12f2) | `go-chromecast: 0.2.10 -> 0.2.11`                                                        |
| [`11167fc4`](https://github.com/NixOS/nixpkgs/commit/11167fc4f1217f7fb29c1fdcdb696b6d0e70bb49) | `python3Packages.cherrypy: 18.6.0 -> 18.6.1`                                             |
| [`bb64be22`](https://github.com/NixOS/nixpkgs/commit/bb64be2280d17e5eb59a9bc5497a4bf36232e74f) | `glab: 1.21.1 -> 1.22.0`                                                                 |
| [`6648bde2`](https://github.com/NixOS/nixpkgs/commit/6648bde21fe4b075d4b832aa1150082ccafd6b84) | `gifski: 1.5.1 -> 1.6.1`                                                                 |
| [`8efd3bac`](https://github.com/NixOS/nixpkgs/commit/8efd3bacc29e726d1dd5c409ffb1bf9716b6710b) | `prometheus-bind-exporter: 0.4.0 -> 0.5.0`                                               |
| [`1bd6af3e`](https://github.com/NixOS/nixpkgs/commit/1bd6af3eb49a4efa0eb7243b0fbe99d2ad18e218) | `umockdev: 0.17.1 -> 0.17.2`                                                             |
| [`7dd2423b`](https://github.com/NixOS/nixpkgs/commit/7dd2423b97a9fda22061d92aee31aa93160f7dfd) | `code-minimap: 0.6.2 -> 0.6.4`                                                           |
| [`2ebe9ded`](https://github.com/NixOS/nixpkgs/commit/2ebe9dede8c4da6dd61dc7c7b5500888923f2380) | `ftjam: init at 2.5.2`                                                                   |
| [`12b5c971`](https://github.com/NixOS/nixpkgs/commit/12b5c971bf07367e2ee51924619cd7511b4f92d4) | `jam: refactor`                                                                          |
| [`7432c431`](https://github.com/NixOS/nixpkgs/commit/7432c431c73adfdb6b0d3e55b526e3e35ebe90b8) | `the-legend-of-edgar: init at 1.35`                                                      |
| [`fbcf8ffa`](https://github.com/NixOS/nixpkgs/commit/fbcf8ffa1090bfb80fe72fbd70c07a6244b35f45) | `blockattack: init at 2.7.0`                                                             |
| [`70595c9e`](https://github.com/NixOS/nixpkgs/commit/70595c9e1e528852906c8509752d3c97bc7a4971) | `python3Packages.versionfinder: disable failing tests`                                   |
| [`b451eca6`](https://github.com/NixOS/nixpkgs/commit/b451eca621d8cd52345e2094e46e970719b6a902) | `nscd service: fix ordering and start automatically`                                     |
| [`06771b90`](https://github.com/NixOS/nixpkgs/commit/06771b90b2b8ff77d9e33561f9844b934010be09) | `nixos/vmware-guest: add mptspi kernel module to initrd`                                 |
| [`42344819`](https://github.com/NixOS/nixpkgs/commit/423448195a68b6d6d00c713adb8321f8ca852117) | `parity-ui: drop broken package`                                                         |
| [`eb13aa4d`](https://github.com/NixOS/nixpkgs/commit/eb13aa4d27febd4c05bd37d72711440be17ca6d0) | `python3.pkgs.umap-learn: fix test_save_load`                                            |
| [`b52607f4`](https://github.com/NixOS/nixpkgs/commit/b52607f43b11319edb716d65bbecbfdbf2f5b92b) | `nixos/acme: ensure web servers using certs can access them`                             |
| [`42368a62`](https://github.com/NixOS/nixpkgs/commit/42368a62af0669403333b212b2f87853da827226) | `glew: switch to use cmake`                                                              |
| [`6fbdc81a`](https://github.com/NixOS/nixpkgs/commit/6fbdc81a8d8eed491da989187a028fcad9cf10b4) | `wine{Unstable,Staging}: 7.0-rc4 -> 7.0-rc5`                                             |
| [`5600589b`](https://github.com/NixOS/nixpkgs/commit/5600589b2d9a710b57e82411c50315bf3602d33a) | `wine{Unstable,Staging}: 7.0-rc3 -> 7.0-rc4`                                             |
| [`e7d80af2`](https://github.com/NixOS/nixpkgs/commit/e7d80af2630ec60df16bb0227a14e351fb528a94) | `wine{Unstable,Staging}: 7.0-rc2 -> 7.0-rc3`                                             |
| [`49a8f776`](https://github.com/NixOS/nixpkgs/commit/49a8f776f37ec89baa4f2b4623140dff4f0ad990) | `octoprint.python.pkgs.costestimate: 3.3.0 -> 3.4.0`                                     |
| [`e73fb8d3`](https://github.com/NixOS/nixpkgs/commit/e73fb8d32fd231057b52e257bd8f96a40e2c224a) | `opensmtpd-extras: drop python2 option`                                                  |
| [`c8a29fc9`](https://github.com/NixOS/nixpkgs/commit/c8a29fc99905c3897a80cf3331fe316d012e044d) | `k3d: remove`                                                                            |
| [`6bf3e2cd`](https://github.com/NixOS/nixpkgs/commit/6bf3e2cde097adc60c677dbadb03cb683a5c8149) | `kalendar: 0.3.1 -> 0.4.0`                                                               |
| [`0d7fc6f0`](https://github.com/NixOS/nixpkgs/commit/0d7fc6f090aa5e66f39578fc67ea238f1daa9ef0) | `nixos/hardware/rtl-sdr: Fix description`                                                |
| [`ca0fbf97`](https://github.com/NixOS/nixpkgs/commit/ca0fbf9739e0b214b7e3f74c1bdfa4d258b827ba) | `nixos/hardware/hackrf: new module`                                                      |
| [`40fb59cf`](https://github.com/NixOS/nixpkgs/commit/40fb59cfc389d1726dcbf72f4fcd2cfbefcf960c) | `nixos/elasticsearch: fix postStart to allow non-localhost listenAddress`                |
| [`d4c39730`](https://github.com/NixOS/nixpkgs/commit/d4c3973092acda3f7a342d7690c2de5b946823ac) | `imgbrd-grabber: 7.5.1 -> 7.7.0`                                                         |
| [`4798a650`](https://github.com/NixOS/nixpkgs/commit/4798a65015ecb197d9a50050a9041fa7aeabc400) | `Point the "mail" command to use the system-wide mail.rc`                                |
| [`63ce7d31`](https://github.com/NixOS/nixpkgs/commit/63ce7d3184bf841da8239d8a78e7e9c931022a5c) | `lib/attrset: miscellaneous optimizations`                                               |
| [`a54f2231`](https://github.com/NixOS/nixpkgs/commit/a54f2231c9c4ea9e456511e855df11fe7df5ba71) | `lib/attrset: optimize element access in recursiveUpdateUntil`                           |
| [`218af59c`](https://github.com/NixOS/nixpkgs/commit/218af59cb8053f397bd763861dcc16137c2641c2) | `python3Packages.syslog-rfc5424-formatter: init at 1.2.2`                                |