### PR TITLE
chore(flake/deploy-rs): `715e92a1` -> `584ec123`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1638665590,
-        "narHash": "sha256-nhtfL3z4TizWHemyZvgLvq11FhYX5Ya4ke+t6Np5PKQ=",
+        "lastModified": 1641976303,
+        "narHash": "sha256-RrGWgT68L7hRc8NaFpqk10sh8wjEnEdFKkYzJYUS/h4=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "715e92a13018bc1745fb680b5860af0c5641026a",
+        "rev": "584ec123d358a6490156595b510c2e786f8886f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message |
| --------------------------------------------------------------------------------------------------- | -------------- |
| [`c9e68bb3`](https://github.com/serokell/deploy-rs/commit/c9e68bb39e951d2ec1f84a8479888c9a270b3846) | `Fix typo`     |