### PR TITLE
chore(flake/nixpkgs): `e00186bc` -> `4f0b5370`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1641946385,
-        "narHash": "sha256-8RA8lefnbL9TAxNdyLKJ4T6KsknRMbsU8ghKfraDQbA=",
+        "lastModified": 1642008389,
+        "narHash": "sha256-nWYdmvmBOXYFktxe7ffwc8ESJQkIqTrzyCIZJk+Sir0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e00186bc0f4453298bd3ab6e0fba3113e55951a3",
+        "rev": "4f0b53702b8fdeea4c68fe34bdf9ce90817910fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                               |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`b44d1e37`](https://github.com/NixOS/nixpkgs/commit/b44d1e37c130076cca0d5649202cda764419e052) | `md-tangle: init at 1.3.1`                                                   |
| [`cfa23c7b`](https://github.com/NixOS/nixpkgs/commit/cfa23c7bbb9628e16f2526bbf6632eea2d7f7171) | `reorder all-packages.nix`                                                   |
| [`25e1800f`](https://github.com/NixOS/nixpkgs/commit/25e1800f2d889e0206d2bce73e7db43b8211273f) | `gnome.rygel: 0.40.2 -> 0.40.3`                                              |
| [`84e626c6`](https://github.com/NixOS/nixpkgs/commit/84e626c60c693f851b77710b74f6c4d6431c1a6d) | `gnome.gnome-autoar: 0.4.1 -> 0.4.2`                                         |
| [`7548f438`](https://github.com/NixOS/nixpkgs/commit/7548f4380e7472db25175740af9b868274c24206) | `python3Packages.apache-airflow: adjust inputs and substituteInPlace`        |
| [`9cf36f12`](https://github.com/NixOS/nixpkgs/commit/9cf36f1225db91144191bb9d1350ec0ee4773922) | `gnome.gnome-boxes: 41.2 -> 41.3`                                            |
| [`d12672ec`](https://github.com/NixOS/nixpkgs/commit/d12672ecaa6c64cd09e22c69abf4c4c1c43df2a7) | `python310Packages.python-daemon: add patches and switch to pytestCheckHook` |
| [`e8c09c51`](https://github.com/NixOS/nixpkgs/commit/e8c09c51f87dea896fc3fb92363083378e207354) | `python310Packages.flask_login: adjust inputs`                               |
| [`5c8ddfd0`](https://github.com/NixOS/nixpkgs/commit/5c8ddfd0b54205504181475f4e7498356a8c505e) | `nixos/stage-1: update udev.log_level name in docs`                          |
| [`b7c632d7`](https://github.com/NixOS/nixpkgs/commit/b7c632d7fd8efe50c3ecb80b90a8d5e83606c4ee) | `python3Packages.opt-einsum: switch to pytestCheckHook`                      |
| [`5d5d787f`](https://github.com/NixOS/nixpkgs/commit/5d5d787fb634cad0298246162c0a9fd6c17b38a5) | `higan: mark as broken on Darwin`                                            |
| [`1fd0f9aa`](https://github.com/NixOS/nixpkgs/commit/1fd0f9aa6f3b934b023d7cc9b30e12a4e9032b5d) | `python3Packages.semver: exclude documentation from tests`                   |
| [`ad234430`](https://github.com/NixOS/nixpkgs/commit/ad234430b7fc11876b6a8d487081f8a4c880bcd2) | `python3Packages.types-requests: 2.27.5 -> 2.27.6`                           |
| [`ef0de7cc`](https://github.com/NixOS/nixpkgs/commit/ef0de7ccb521a1355994b01a8b562aaf152bef9f) | `nixos/wordpress: Ensure no passwordFile if local db deployment (#148613)`   |
| [`78e1aa4c`](https://github.com/NixOS/nixpkgs/commit/78e1aa4c963a902106d3c404d0f6aaf88fcd9a2c) | `tailor: switch to pypy2`                                                    |
| [`e0a15f26`](https://github.com/NixOS/nixpkgs/commit/e0a15f263dbf954c350a7f91526a4d8e93bb2847) | `cvs2svn: switch to pypy2`                                                   |
| [`7148ebef`](https://github.com/NixOS/nixpkgs/commit/7148ebef251c01b04675bdb2fe41edd8ec0ab9e5) | `docbookrx: drop`                                                            |
| [`7b68f646`](https://github.com/NixOS/nixpkgs/commit/7b68f646ea77383a628b93a7ca5255c5f1696978) | `signal-cli: 0.9.2 -> 0.10.0`                                                |
| [`2fca4556`](https://github.com/NixOS/nixpkgs/commit/2fca45565d7ea04ebb22c0793848e5a10f2509b6) | `gcc9: Add no-sys-dir patch for RISC-V (#154230)`                            |
| [`861f4e4c`](https://github.com/NixOS/nixpkgs/commit/861f4e4c01895fae9b8675e254b33ca7378bff6f) | `lispPackages.cl-mustache: init at 20200325-git`                             |
| [`7a73bd3d`](https://github.com/NixOS/nixpkgs/commit/7a73bd3d084d8070a3564a9eeed9f66093ae421c) | `linuxPackages.tuxedo-keyboard: update description to point to module`       |
| [`ea9647d2`](https://github.com/NixOS/nixpkgs/commit/ea9647d202267338ce757149f3cc6d22e8d3aa7b) | `linuxPackages.tuxedo-keyboard: 3.0.8 -> 3.0.9`                              |
| [`4f15ea2f`](https://github.com/NixOS/nixpkgs/commit/4f15ea2f31173419f1c1e5bba98959ab1407c324) | `quicklisp-to-nix: fix trailing whitespace`                                  |
| [`df58e804`](https://github.com/NixOS/nixpkgs/commit/df58e804e32693ac3ba97ecce66b4a86faf87ed7) | `python3Packages.emv: relax terminaltables constraint`                       |
| [`9f25f013`](https://github.com/NixOS/nixpkgs/commit/9f25f0135384cbc1decf171e916daa06f7e20e16) | `python310Packages.json-schema-for-humans: relax pyyaml constraint`          |
| [`54d4b707`](https://github.com/NixOS/nixpkgs/commit/54d4b7079b914cca5c9a824e22c1eef338854ccc) | `quicklisp-to-nix: document --cacheFaslDir option in help screen`            |
| [`c5fbaf61`](https://github.com/NixOS/nixpkgs/commit/c5fbaf6131caf06eb09eba086c47c62c3e848b95) | `nixops: Remove unused expressions in subdirectories`                        |
| [`20df3f66`](https://github.com/NixOS/nixpkgs/commit/20df3f6612f15ead16e5f8078dde0e7185b1d123) | `pleroma: 2.4.1 -> 2.4.2 (#154729)`                                          |
| [`734af732`](https://github.com/NixOS/nixpkgs/commit/734af7329892b7636fa4167b1003b1cf424f3920) | `bpftrace: 0.14.0 -> 0.14.1`                                                 |
| [`c8ef5732`](https://github.com/NixOS/nixpkgs/commit/c8ef57323965a27a2d63b5ba3dd1ee42aa6773ae) | `python310Packages.aiorun: 2021.8.1 -> 2021.10.1`                            |
| [`1c6c231f`](https://github.com/NixOS/nixpkgs/commit/1c6c231fe23763885d2594e1ac6a5dd7ac3062a4) | `python3Packages.python-http-client: disable failing test`                   |
| [`1e4b8ffb`](https://github.com/NixOS/nixpkgs/commit/1e4b8ffb110d918f468a893308658612c4796f6d) | `pleroma: add kloenk as maintainer`                                          |
| [`202e6860`](https://github.com/NixOS/nixpkgs/commit/202e6860897d2519d3395eded0531e7c888b4e4d) | `terraform-ls: 0.25.0 -> 0.25.2`                                             |
| [`90060e51`](https://github.com/NixOS/nixpkgs/commit/90060e51d358ad1e59781602989605ebbb0fb3ae) | `python3Packages.adb-shell: disable failing tests`                           |
| [`ac7b13ff`](https://github.com/NixOS/nixpkgs/commit/ac7b13ff2f7570c7353f7eec7857657262c4eaa2) | `python310Packages.quandl: adjust inputs`                                    |
| [`c2413627`](https://github.com/NixOS/nixpkgs/commit/c24136277bc77998a89e37cfd78f3cf6ff80ff9b) | `python310Packages.APScheduler: disable failing tests`                       |
| [`5c8072c3`](https://github.com/NixOS/nixpkgs/commit/5c8072c376ee0527e25dc04cea40fcc819ea79b2) | `nixops: Re-package environment using poetry2nix`                            |
| [`bd8adc08`](https://github.com/NixOS/nixpkgs/commit/bd8adc086ac3a5cc13586a2ad0b7d895cd40a237) | `vscode-extensions.cweijan.vscode-database-client2: init at 4.3.3`           |
| [`b8116767`](https://github.com/NixOS/nixpkgs/commit/b81167678dc2d2ccfe2f71d2a0fbe6461553336f) | `vscode-extensions.tuttieee.emacs-mcx: init at 0.37.1`                       |
| [`cc7336ed`](https://github.com/NixOS/nixpkgs/commit/cc7336ed1807f66c50e115796d4917f4f1fef588) | `vscode-extensions.usernamehw.errorlens: 3.4.0 → 3.4.1`                      |
| [`ac938d63`](https://github.com/NixOS/nixpkgs/commit/ac938d63c62e405d5d3d22feed7282255b27ef0e) | `vscode-extensions.serayuzgur.crates: 0.5.9 → 0.5.10`                        |
| [`10afefe5`](https://github.com/NixOS/nixpkgs/commit/10afefe564be7b03fe8c56f5ba6f4ecec6d51952) | `vscode-extensions.mechatroner.rainbow-csv: 1.7.1 → 2.0.0`                   |
| [`502f780d`](https://github.com/NixOS/nixpkgs/commit/502f780d2fcfa29f32e5a21cf364aba71ee61643) | `python3Packages.hahomematic: 0.18.0 -> 0.19.0`                              |
| [`1d820c22`](https://github.com/NixOS/nixpkgs/commit/1d820c22244634ad2936c73ac8680f5086d4e8e5) | `poetry2nix: 1.24.1 -> 1.25.0`                                               |
| [`159739fa`](https://github.com/NixOS/nixpkgs/commit/159739faafefce4ac26eae91e48032e5d92c5d2e) | `conmon: 2.0.31 -> 2.0.32`                                                   |
| [`12920518`](https://github.com/NixOS/nixpkgs/commit/12920518e601192a056e298a0c5b48d45e82e426) | `althttpd: unstable-2021-06-09 -> unstable-2022-01-10`                       |
| [`bc151db9`](https://github.com/NixOS/nixpkgs/commit/bc151db96f2f032059576259c7541568cffacb94) | `llama: init at 1.0.1`                                                       |
| [`88382b95`](https://github.com/NixOS/nixpkgs/commit/88382b95bfc9db839fe94b9dc9b0779e10b6531d) | `maintainers: add portothree`                                                |
| [`128359ae`](https://github.com/NixOS/nixpkgs/commit/128359aeca4ae0b07efa4912ef051a3d0e054431) | `chart-testing: install shell completion`                                    |
| [`d276350e`](https://github.com/NixOS/nixpkgs/commit/d276350eb5758b8d26668c2f06b39351944262f7) | `libxslt: Use python as function argument instead of python3`                |
| [`a9977abe`](https://github.com/NixOS/nixpkgs/commit/a9977abefe78db53a42263deea9c9dfe3fe8c283) | `flashfocus: unpin pyyaml`                                                   |
| [`6bc0a044`](https://github.com/NixOS/nixpkgs/commit/6bc0a0443ad803fbe1bc3020423d6f791ff869df) | `discord-canary: 0.0.131 -> 0.0.132`                                         |
| [`d1556aac`](https://github.com/NixOS/nixpkgs/commit/d1556aac1306e36412408e2a680b7bea8970bfee) | `pinsel: init at unstable-2021-09-13`                                        |
| [`0c72fb35`](https://github.com/NixOS/nixpkgs/commit/0c72fb355cf1147de6106f3185fc8d0db22c9b3c) | `discordchatexporter-cli: 2.30.1 -> 2.31.1`                                  |
| [`ed89030b`](https://github.com/NixOS/nixpkgs/commit/ed89030b17286382363919367704ff1b29052de4) | `python310Packages.sybil: disable failing tests`                             |
| [`c2068461`](https://github.com/NixOS/nixpkgs/commit/c20684619d3b8e4967ec157060cc05c6cdf6f626) | `python3Packages.pylaunches: 1.2.0 -> 1.2.1`                                 |
| [`f7fa10ff`](https://github.com/NixOS/nixpkgs/commit/f7fa10ff43e47fb6420ee1722d3e18519b1520a6) | `python310Packages.rpyc: disable failing test`                               |
| [`218132f9`](https://github.com/NixOS/nixpkgs/commit/218132f91cb7b6f40792d3c58a58dc40c208545b) | `python3Packages.identify: 2.4.2 -> 2.4.3`                                   |
| [`f75d4858`](https://github.com/NixOS/nixpkgs/commit/f75d4858015dc849c47e81d6b2ba96ecc4c9932d) | `minio-client: 2021-12-20T23-43-34Z -> 2022-01-07T06-01-38Z`                 |
| [`c45c58d7`](https://github.com/NixOS/nixpkgs/commit/c45c58d7dc67f65ab607604907ae79bc41a782ad) | `minio: 2021-12-27T07-23-18Z -> 2022-01-08T03-11-54Z`                        |
| [`6d302618`](https://github.com/NixOS/nixpkgs/commit/6d3026184a4b718f5bd361526410f78fa396b747) | `maintainers: add ricochet`                                                  |
| [`cd96c5af`](https://github.com/NixOS/nixpkgs/commit/cd96c5afdd968ce36984bda5a2f6a91c51dffdfc) | `image-roll: 1.4.0 -> 1.4.1`                                                 |
| [`ceafd6f0`](https://github.com/NixOS/nixpkgs/commit/ceafd6f03035ed6c573bf2d090dc254929ed2145) | `faraday-agent-dispatcher: init at 2.1.3`                                    |
| [`8956803a`](https://github.com/NixOS/nixpkgs/commit/8956803ade4f16319f2685ae9e1b7cfed85e9848) | `prosody-filer service: init`                                                |
| [`b0dacda1`](https://github.com/NixOS/nixpkgs/commit/b0dacda1a253400d5ebca40d523413c51a6067f2) | `prosody-filer: init at unstable-2021-05-24`                                 |
| [`61dd0c8e`](https://github.com/NixOS/nixpkgs/commit/61dd0c8e854f60f285e04fd4862d51ac02832dcb) | `linux: 5.4.170 -> 5.4.171`                                                  |
| [`4cf69dc1`](https://github.com/NixOS/nixpkgs/commit/4cf69dc13ac34c043057f5405ab5f90e61569dfa) | `linux: 5.15.13 -> 5.15.14`                                                  |
| [`caa8c496`](https://github.com/NixOS/nixpkgs/commit/caa8c4963dfe90acba8628feb32cdf2c76469784) | `linux: 5.10.90 -> 5.10.91`                                                  |
| [`84e167d8`](https://github.com/NixOS/nixpkgs/commit/84e167d8b325b37aa3e5269a4a1d5cd861bf6aff) | `linux: 4.9.296 -> 4.9.297`                                                  |
| [`e30d7555`](https://github.com/NixOS/nixpkgs/commit/e30d75558ef7c4a5867f662bfcda2c1e75da6f87) | `linux: 4.4.298 -> 4.4.299`                                                  |
| [`7bf2f23d`](https://github.com/NixOS/nixpkgs/commit/7bf2f23df2d1886f472557a0bbaea76dc88415bb) | `linux: 4.19.224 -> 4.19.225`                                                |
| [`169ed133`](https://github.com/NixOS/nixpkgs/commit/169ed1335f5337a1361af418d579a6f133735e8d) | `linux: 4.14.261 -> 4.14.262`                                                |
| [`70577a04`](https://github.com/NixOS/nixpkgs/commit/70577a04275f76da1f851fc29dd786f146c8a9ac) | `seaweedfs: 2.71 -> 2.85`                                                    |
| [`c7de7dbb`](https://github.com/NixOS/nixpkgs/commit/c7de7dbb531c0e686f1ccefe6dd9db140e3eb6e6) | `prisma: 3.7.0 -> 3.8.0`                                                     |
| [`4bae5a8d`](https://github.com/NixOS/nixpkgs/commit/4bae5a8dbff7b4f52e31e5b5b01592ca08e97efb) | `kodi.packages.arteplussept: init at 1.1.1`                                  |
| [`be7888d7`](https://github.com/NixOS/nixpkgs/commit/be7888d726197ebd1a86b32460194d93e26a8e01) | `kodi.packages.xbmcswift2: init at 19.0.7`                                   |
| [`b2fce43a`](https://github.com/NixOS/nixpkgs/commit/b2fce43a6170b2f7cbedf7d9c03362a3d8112148) | `kodi.packages.orftvthek: 0.12.3-1 -> 0.12.3+matrix.1`                       |
| [`d1de6589`](https://github.com/NixOS/nixpkgs/commit/d1de6589a4d5e373f9194d956554f951166366d9) | `nodejs-12_x: 12.22.8 -> 12.22.9`                                            |
| [`2cfe7ecb`](https://github.com/NixOS/nixpkgs/commit/2cfe7ecbc9388e3a9c045519e0311e6986c13cd7) | `nodejs-14_x: 14.18.2 -> 14.18.3`                                            |
| [`2ac55ced`](https://github.com/NixOS/nixpkgs/commit/2ac55cedc9dfbbbecfcfe2afea86f76fc80aefb0) | `nodejs-16_x: 16.13.1 -> 16.13.2`                                            |
| [`4bfeab40`](https://github.com/NixOS/nixpkgs/commit/4bfeab40d63b0de4a41aff56a8574fbb3e703ff5) | `nodejs-17_x: 17.3.0 -> 17.3.1`                                              |
| [`9948da79`](https://github.com/NixOS/nixpkgs/commit/9948da796066a6843aeda32e0b3c6f407e5a7677) | `goreleaser: 1.2.2 -> 1.2.5`                                                 |
| [`43c3499d`](https://github.com/NixOS/nixpkgs/commit/43c3499d7e49c81ca121a104e39b12dae2b685f9) | `flow: 0.168.0 -> 0.169.0`                                                   |
| [`60ef6075`](https://github.com/NixOS/nixpkgs/commit/60ef60759d3f3f172f3b4ef84c5002f8c4bebcdb) | `python310Packages.enrich: 1.2.6 -> 1.2.7`                                   |
| [`61e4531e`](https://github.com/NixOS/nixpkgs/commit/61e4531e7046a436adc5eb533d755a2a39f2c518) | `conftest: 0.28.3 -> 0.30.0`                                                 |
| [`24c15bd3`](https://github.com/NixOS/nixpkgs/commit/24c15bd31da3e9374b774c8d0256e63b79ea0ff6) | `cloud-nuke: 0.7.1 -> 0.7.3`                                                 |
| [`a2bbddbf`](https://github.com/NixOS/nixpkgs/commit/a2bbddbf366838a8a767d6914e1a32214499f1a4) | `chart-testing: 3.4.0 -> 3.5.0`                                              |
| [`907685f8`](https://github.com/NixOS/nixpkgs/commit/907685f8bb6da2e90fcdea8d5e3bd76da63d6c07) | `bump: 0.2.2 -> 0.2.3`                                                       |
| [`c4260c76`](https://github.com/NixOS/nixpkgs/commit/c4260c76cf8ffa2dcef8d6d8c97343652c21c59e) | `kube3d: add darwin platforms`                                               |
| [`d7c53592`](https://github.com/NixOS/nixpkgs/commit/d7c5359249798fc85f74a5b6301df5d4c02469a7) | `wownero: use fetchFromGitea`                                                |
| [`768d0d60`](https://github.com/NixOS/nixpkgs/commit/768d0d6098c6281829b033382c14bf7b2c32c4e5) | `nixos/netdata: expose /etc/netdata`                                         |
| [`9e6145c7`](https://github.com/NixOS/nixpkgs/commit/9e6145c73b76777558d93dc1796c32302e8c9bc5) | `nixos/netdata: add configDir option`                                        |
| [`12e9ffc2`](https://github.com/NixOS/nixpkgs/commit/12e9ffc2db66ed76871213322814a42b76512590) | `calls: 0.3.1 -> 41.1`                                                       |
| [`bdaba51c`](https://github.com/NixOS/nixpkgs/commit/bdaba51c6e089c80707b74d1897179125bc947d1) | `gfold: init at 3.0.0`                                                       |
| [`64594b8a`](https://github.com/NixOS/nixpkgs/commit/64594b8a14e72850511eca9a9449e1a84f3cdc75) | `maintainers: add shanesveller`                                              |
| [`ee51400f`](https://github.com/NixOS/nixpkgs/commit/ee51400f00bd76590461e9461b0f4df170d84c86) | `tuigreet: 0.6.1 -> 0.7.1`                                                   |
| [`f62c11fc`](https://github.com/NixOS/nixpkgs/commit/f62c11fcc3ae06a31e23ae9f5894f259c128e095) | `nixos/pam: Fix apparmor syntax error`                                       |
| [`92c42893`](https://github.com/NixOS/nixpkgs/commit/92c428939e3fc011bcb83b6e06934e31fc651502) | `python3Packages.keyring: 23.4.0 -> 23.5.0`                                  |