### PR TITLE
chore(flake/nixpkgs): `4f0b5370` -> `2641efd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642008389,
-        "narHash": "sha256-nWYdmvmBOXYFktxe7ffwc8ESJQkIqTrzyCIZJk+Sir0=",
+        "lastModified": 1642052904,
+        "narHash": "sha256-q+faEQXptqjt1RrOJbVe+qb4NY8NlkjhZMlbyZ+raao=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4f0b53702b8fdeea4c68fe34bdf9ce90817910fb",
+        "rev": "2641efd7d026fc3a44c8cc83c6be959f7e3e99b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`400be991`](https://github.com/NixOS/nixpkgs/commit/400be99192b675e5e34bc9abcd580895c00d05ab) | `avro-cpp: use the default boost version (#154784)`                       |
| [`cea5f29a`](https://github.com/NixOS/nixpkgs/commit/cea5f29a52525d971a9d7ec267fe77bd04ae713b) | `tendermint: pin to go 1.16`                                              |
| [`64dd661b`](https://github.com/NixOS/nixpkgs/commit/64dd661bf7a5abca25f06ceb4b4add0504686c6b) | `telepresence2: pin to go 1.16`                                           |
| [`88b29b7f`](https://github.com/NixOS/nixpkgs/commit/88b29b7fc80da49adae42f0ffca8e50457ad0045) | `ipfs-cluster: pin to go 1.16`                                            |
| [`cee6ccfc`](https://github.com/NixOS/nixpkgs/commit/cee6ccfc754af33f9fb03b15b938707c584a6342) | `ncdns: pin to go 1.16`                                                   |
| [`8af07258`](https://github.com/NixOS/nixpkgs/commit/8af072583df84fda56ebf6089570e1d744269340) | `wprecon: mark broken`                                                    |
| [`5f250ebd`](https://github.com/NixOS/nixpkgs/commit/5f250ebdb9b537a03350e6150ce93c6480ce9001) | `erlang-ls: 0.20.0 -> 0.21.2 (#148837)`                                   |
| [`0c3ae89f`](https://github.com/NixOS/nixpkgs/commit/0c3ae89fe69f008272d46d5c016db68dcb65d7f5) | `python3Packages.flux-led: 0.28.0 -> 0.28.1`                              |
| [`102c6a93`](https://github.com/NixOS/nixpkgs/commit/102c6a93795953c9bd900fd28e56badafc5bf748) | `python310Packages.pontos: 22.1.0 -> 22.1.1`                              |
| [`7b5db5f5`](https://github.com/NixOS/nixpkgs/commit/7b5db5f50b97fc6066c8ff2d5e4d6c7658796190) | `mpvScripts.sponsorblock: unstable-2020-07-05 -> unstable-2021-12-23`     |
| [`e8f170c4`](https://github.com/NixOS/nixpkgs/commit/e8f170c46959ff6893a6e2a51c1de3e4afdc4086) | `mpvScripts.sponsorblock: add update script`                              |
| [`5c61c3ce`](https://github.com/NixOS/nixpkgs/commit/5c61c3ce36e761ac70a36cb20199c83e8f06cae4) | `python310Packages.python-http-client: 3.3.4 -> 3.3.5`                    |
| [`f0a1e6e9`](https://github.com/NixOS/nixpkgs/commit/f0a1e6e9e94c58c9e625e3752f8df94d411a0b9e) | `steampipe: 0.11.0 -> 0.11.2`                                             |
| [`64fa8e6b`](https://github.com/NixOS/nixpkgs/commit/64fa8e6b5b36e5413e7b154d7f795afce45f21ca) | `featherpad: 1.1.0 -> 1.1.1`                                              |
| [`cf340a9d`](https://github.com/NixOS/nixpkgs/commit/cf340a9dae95b874e946ac8a3b94f7bf3f9cfb6f) | `finalfusion-utils: 0.13.2 -> 0.14.1`                                     |
| [`8b8328c5`](https://github.com/NixOS/nixpkgs/commit/8b8328c5d727d2b8ee5881c949cd9a969023c71d) | `python310Packages.Pyro4: 4.81 -> 4.82`                                   |
| [`5321a6b8`](https://github.com/NixOS/nixpkgs/commit/5321a6b82afca8980c2faf923c2713d3dc1ca25c) | `tree-sitter updater: use GITHUB_TOKEN if present`                        |
| [`dd5d6b87`](https://github.com/NixOS/nixpkgs/commit/dd5d6b87bba663542504a810498b7b228f876864) | `gitty: 0.5.0 -> 0.6.0`                                                   |
| [`bad08fbe`](https://github.com/NixOS/nixpkgs/commit/bad08fbef10c3b61af48349b4135ddc0209d4a95) | `gphoto2: 2.5.27 -> 2.5.28`                                               |
| [`4d0c0f64`](https://github.com/NixOS/nixpkgs/commit/4d0c0f64b1aedb3eedb47f730671a4f603488aab) | `vimPlugins.mini-nvim: init at 2022-01-06`                                |
| [`5a8040b9`](https://github.com/NixOS/nixpkgs/commit/5a8040b96433ee38c1143c36a538a53a66f566b9) | `python310Packages.pysma: 0.6.9 -> 0.6.10`                                |
| [`4466e249`](https://github.com/NixOS/nixpkgs/commit/4466e2496dc5592ee50df0f531806655290dbb17) | `python3Packages.pytest-order: 1.0.0 -> 1.0.1`                            |
| [`4b46a593`](https://github.com/NixOS/nixpkgs/commit/4b46a593ef0a6b546f2c32b9be838c7aa6c4e97e) | `mani: 0.10.0 -> 0.11.1`                                                  |
| [`82727b33`](https://github.com/NixOS/nixpkgs/commit/82727b33e6466c2dea12cb0d5e7315e752f599e0) | `calibre-web: relax lxml constraint`                                      |
| [`6ba5d82e`](https://github.com/NixOS/nixpkgs/commit/6ba5d82e36edb977f3f9846dc3b683436ca6b6cf) | `python3Packages.pyrogram: 1.3.0 -> 1.3.1`                                |
| [`2cd29223`](https://github.com/NixOS/nixpkgs/commit/2cd29223cad2508f3febf2d41cb8cf24180b6fde) | `cvs2svn: use more universal reference to interpreter`                    |
| [`f5d5398b`](https://github.com/NixOS/nixpkgs/commit/f5d5398b0e4dffa058939363bb78a126e65dba10) | `python310Packages.deprecations: fix tests`                               |
| [`af6c20ea`](https://github.com/NixOS/nixpkgs/commit/af6c20ea05afbbb63135d3699fe52118dbcf635a) | `bitlbee: python2 -> python3`                                             |
| [`9120e419`](https://github.com/NixOS/nixpkgs/commit/9120e419f461821e4450dcca2a5a800ebf076f6d) | `libsForQt5.kbreakout: fix meta.homepage`                                 |
| [`6f3b6981`](https://github.com/NixOS/nixpkgs/commit/6f3b698103018f7c358653b050e92a4e5260be6c) | `python310Packages.pecan: 1.4.0 -> 1.4.1`                                 |
| [`d4e16ab3`](https://github.com/NixOS/nixpkgs/commit/d4e16ab3e35affeaf4b1e3c63012f4fedb92c3ae) | `python310Packages.billiard: add pythonImportsCheck`                      |
| [`25294359`](https://github.com/NixOS/nixpkgs/commit/252943597e52b66fc70f69cdca05ee77be777f31) | `python310Packages.case: adjust inputs`                                   |
| [`7bb06e1a`](https://github.com/NixOS/nixpkgs/commit/7bb06e1a157f659f12c4d73255178c84e2666c71) | `python3.pkgs.jedi-language-server: 0.34.12 -> 0.35.1`                    |
| [`be5fbe4c`](https://github.com/NixOS/nixpkgs/commit/be5fbe4c1b006b049cdeaa2b81f98e282caa6231) | `hugo: 0.91.2 -> 0.92.0`                                                  |
| [`1a549598`](https://github.com/NixOS/nixpkgs/commit/1a549598b4a9f57ee47d407d9d4a7bc5e98e5476) | `cwltool: 3.1.20211104071347 -> 3.1.20211107152837`                       |
| [`bc99971c`](https://github.com/NixOS/nixpkgs/commit/bc99971c843db3f9324080a9809887ce88da6d2e) | `notmuch: 0.34.2 -> 0.34.3`                                               |
| [`1b8861e0`](https://github.com/NixOS/nixpkgs/commit/1b8861e0d445ca095c466175e6074de478cc3a47) | `tor-browser-bundle-bin: 11.0.3 -> 11.0.4`                                |
| [`e352f62f`](https://github.com/NixOS/nixpkgs/commit/e352f62f80d49c0a6e908b42f4d879ca08e41e70) | `python3Packages.pyspnego: fix meta.homepage`                             |
| [`f4cab67d`](https://github.com/NixOS/nixpkgs/commit/f4cab67db40004092cdd1a30276e2e3087381df7) | `python3Packages.pykeyatome: fix meta.homepage`                           |
| [`f366ae64`](https://github.com/NixOS/nixpkgs/commit/f366ae6429096615914dd24a3ae59d7215b34180) | `nixos/starship: add a test`                                              |
| [`3f1ef8fe`](https://github.com/NixOS/nixpkgs/commit/3f1ef8fe14ed87c0999f2a5ce7a5a1b3c3b8d7ec) | `nixos/starship: init`                                                    |
| [`54f8775d`](https://github.com/NixOS/nixpkgs/commit/54f8775d64d6bcd3080b7c334a843a640a0dfe3e) | `mpvScripts.sponsorblock: fix blatant ignorance of CONTRIBUTING.md`       |
| [`32ac4568`](https://github.com/NixOS/nixpkgs/commit/32ac456825417a9cd02d9b4ac5bbf6c81524cbe8) | `wiki-tui: 0.4.3 -> 0.4.4`                                                |
| [`075ca59a`](https://github.com/NixOS/nixpkgs/commit/075ca59a72318b43301fec4ae98b6e8a2f0c9776) | `trilium: 0.48.8 -> 0.49.4`                                               |
| [`1e6acdc3`](https://github.com/NixOS/nixpkgs/commit/1e6acdc3be93b12b7cdb092f0578c8d69b04375d) | `kup: init at 0.9.1`                                                      |
| [`20d9f5d9`](https://github.com/NixOS/nixpkgs/commit/20d9f5d9f3f3098b73eed20a867f3ab615dc87ae) | `jenkins-job-builder: fix build, relax pyyaml version constraint`         |
| [`9cf4be40`](https://github.com/NixOS/nixpkgs/commit/9cf4be40d3023b77a9393b999f37b0be57bc90ba) | `chromiumDev: 98.0.4758.9 -> 99.0.4818.0`                                 |
| [`1be7e767`](https://github.com/NixOS/nixpkgs/commit/1be7e7673151a6c07ef8b5da9204e10790b1f029) | `chromiumBeta: 97.0.4692.71 -> 98.0.4758.48`                              |
| [`0883bd1e`](https://github.com/NixOS/nixpkgs/commit/0883bd1e02df2760f18ef267b811d920b2b50c23) | `libite: 2.4.0 -> 2.5.1`                                                  |
| [`8283c311`](https://github.com/NixOS/nixpkgs/commit/8283c311f88e6ac6f6e3add4b5db8e8c852706aa) | `kora-icon-theme: 1.4.9 -> 1.5.0`                                         |
| [`2875c98a`](https://github.com/NixOS/nixpkgs/commit/2875c98aaf193dac2c5f05c272b65357a5e92889) | `ferdi: 5.6.5 -> 5.6.10`                                                  |
| [`91d9a31e`](https://github.com/NixOS/nixpkgs/commit/91d9a31e67e5a18783a9b5c9da1edb9f6e09ab9e) | `wsjtx: 2.5.3 -> 2.5.4`                                                   |
| [`6ce11c54`](https://github.com/NixOS/nixpkgs/commit/6ce11c544143fed16cb0c95853f413eaf8992605) | `metersLv2: refactor`                                                     |
| [`c57bb5bb`](https://github.com/NixOS/nixpkgs/commit/c57bb5bb4a2048da490f11a732a9dc84da85d0b3) | `frr: fix clippy build on aarch64-linux`                                  |
| [`6008460c`](https://github.com/NixOS/nixpkgs/commit/6008460c047033c415f92505bfb4caf09ce3b65e) | `nixos/frr: add to release notes`                                         |
| [`24ffe314`](https://github.com/NixOS/nixpkgs/commit/24ffe3140186bcadcb8044979b1bfb3a1d609126) | `frr: 7.5.1 -> 8.1`                                                       |
| [`a43da2c3`](https://github.com/NixOS/nixpkgs/commit/a43da2c353e9c43b8cf34210851d80c18974e5fb) | `libyang: 1.0.240 -> 2.0.112`                                             |
| [`33911b09`](https://github.com/NixOS/nixpkgs/commit/33911b092d06e02f55998a7f74d4f28f21517974) | `nixos/tests/frr: init`                                                   |
| [`0098575c`](https://github.com/NixOS/nixpkgs/commit/0098575c865cff58e2d7d4c11d2e42223712a3c2) | `nixos/frr: init`                                                         |
| [`89956e7d`](https://github.com/NixOS/nixpkgs/commit/89956e7d6e5f15a4e005e61895c9c5ad1b0a4b31) | `frr: init at 7.5.1`                                                      |
| [`5b646ed2`](https://github.com/NixOS/nixpkgs/commit/5b646ed20a471d84c61a6df14f7a99ffde2ea307) | `libyang: init at 1.0.240`                                                |
| [`5303bde0`](https://github.com/NixOS/nixpkgs/commit/5303bde0e5c7852b9aa0882275763faad65bcb4f) | `ocamlPackages.type_conv{109.60.01,112.01.01}: switch to fetchFromGitHub` |
| [`a6bd34cb`](https://github.com/NixOS/nixpkgs/commit/a6bd34cb799454cd44fcdd8cfa9e7371fd1a0ad6) | `ocamlPackages.lwt_ppx: switch to fetchFromGitHub`                        |
| [`92864e8e`](https://github.com/NixOS/nixpkgs/commit/92864e8e8b2d5427773a58b3849c30d4074c9cd6) | `libcec_platform: switch to fetchFromGitHub`                              |
| [`1d107641`](https://github.com/NixOS/nixpkgs/commit/1d107641d16837636a3e1662ef3bc272ba719554) | `lolcode: switch to fetchFromGitHub`                                      |
| [`4a4e3751`](https://github.com/NixOS/nixpkgs/commit/4a4e3751fa93175ad52187c21f78863613f28932) | `bats: switch to fetchFromGitHub`                                         |
| [`05ebdaae`](https://github.com/NixOS/nixpkgs/commit/05ebdaaecc9898b7b297ad567dbbbdaff180b802) | `teyjus: switch to fetchFromGitHub`                                       |
| [`317db0f1`](https://github.com/NixOS/nixpkgs/commit/317db0f19fbc320789411958021ffac1daca5ac4) | `mosml: switch to fetchFromGitHub`                                        |
| [`16c55985`](https://github.com/NixOS/nixpkgs/commit/16c559857c9c23725e6dbd67f5357240cf379c26) | `fsharp: switch to fetchFromGitHub`                                       |
| [`45eeb92d`](https://github.com/NixOS/nixpkgs/commit/45eeb92d4435ad6913d6281e2389cb2b6fee552f) | `chickenPackages_4.egg2nix: switch to fetchFromGitHub`                    |
| [`17c63d32`](https://github.com/NixOS/nixpkgs/commit/17c63d329d46cb3de1ab22545e74e1d243b688d6) | `toggldesktop: switch to fetchFromGitHub`                                 |
| [`a3480de4`](https://github.com/NixOS/nixpkgs/commit/a3480de4d406ffce017dba27a37dad2b77d3d495) | `elements: switch to fetchFromGitHub`                                     |
| [`c2fc2a37`](https://github.com/NixOS/nixpkgs/commit/c2fc2a373d907b7432f0d214bbd9cbfa3e078bbf) | `heroic: 1.10.3 -> 2.0.2`                                                 |
| [`32c71774`](https://github.com/NixOS/nixpkgs/commit/32c717749c398be042b8a6c6155a61e5b79e4366) | `honeyvent: init at 1.1.0`                                                |
| [`a7e766f1`](https://github.com/NixOS/nixpkgs/commit/a7e766f12106c905b50bb491af24131292030c55) | `honeymarker: init at 0.2.1`                                              |
| [`3db1a835`](https://github.com/NixOS/nixpkgs/commit/3db1a83518a8a65c24d9ab73a7d3eff0915e7627) | `honeytail: init at 1.6.0`                                                |
| [`233cc0d5`](https://github.com/NixOS/nixpkgs/commit/233cc0d593890f1c57b30e1b0752ecb51016482e) | `argo: 3.2.4 -> 3.2.6`                                                    |
| [`933c7f09`](https://github.com/NixOS/nixpkgs/commit/933c7f0902dfa64a3a727c975c7c53ab73d17d80) | `spire: init at 1.1.2`                                                    |