### PR TITLE
chore(flake/deploy-rs): `584ec123` -> `0ac333cd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1641976303,
-        "narHash": "sha256-RrGWgT68L7hRc8NaFpqk10sh8wjEnEdFKkYzJYUS/h4=",
+        "lastModified": 1642113498,
+        "narHash": "sha256-4tNIt2EGDppYQI06gsid0QKW5dtBEOAiNKfMYC8wxv8=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "584ec123d358a6490156595b510c2e786f8886f8",
+        "rev": "0ac333cdc03407538b5b19d60a8e7c64588490fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                     |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`0ac333cd`](https://github.com/serokell/deploy-rs/commit/0ac333cdc03407538b5b19d60a8e7c64588490fb) | `chore: replace .license files with dep5 config`   |
| [`14daa4ac`](https://github.com/serokell/deploy-rs/commit/14daa4acf67b80d2d8dadeddfb95fc3d59721f26) | `chore: link LICENSES/MPL-2.0.txt to root LICENSE` |
| [`f2a3044a`](https://github.com/serokell/deploy-rs/commit/f2a3044a0d49fb5666fd2d90da6f10114f6abc27) | `optimize release build for size`                  |