### PR TITLE
chore(flake/nixpkgs): `2641efd7` -> `b4ac5539`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642052904,
-        "narHash": "sha256-q+faEQXptqjt1RrOJbVe+qb4NY8NlkjhZMlbyZ+raao=",
+        "lastModified": 1642106561,
+        "narHash": "sha256-Ym6ZxoQ2uRGpVgn6A/C9LOVqOxlz3R4NUx+Dzb2geYI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2641efd7d026fc3a44c8cc83c6be959f7e3e99b1",
+        "rev": "b4ac5539ea325cadce07b99c837d6cccbdddda3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`47619623`](https://github.com/NixOS/nixpkgs/commit/47619623ea15c6464b0e378092d5a46742dd3f9e) | `stm32cubemx: 6.2.1 -> 6.4.0`                                             |
| [`61affb7d`](https://github.com/NixOS/nixpkgs/commit/61affb7d91b9e91da6d17130b258f00a5da18fee) | `chromiumBeta: 98.0.4758.48 -> 98.0.4758.54`                              |
| [`6c0fc251`](https://github.com/NixOS/nixpkgs/commit/6c0fc2514d831ed9c926a35cf9e564ad35d67e4e) | `gdk-pixbuf-xlib: 2020-06-11-unstable -> 2.40.2`                          |
| [`ba97ea6d`](https://github.com/NixOS/nixpkgs/commit/ba97ea6dcbf56f4f826dd540e8f109896c90f3c0) | `ttygif: 1.5.0 -> 1.6.0`                                                  |
| [`dd4109a2`](https://github.com/NixOS/nixpkgs/commit/dd4109a2aa3f2318a895d46cdfec52c6419b3cb5) | `tinyssh: 20210601 -> 20220101`                                           |
| [`6ba9a810`](https://github.com/NixOS/nixpkgs/commit/6ba9a810593bed397b257fb5e96ef57759bcbe41) | `git-hub: 2.1.1 -> 2.1.2`                                                 |
| [`75f0a6b6`](https://github.com/NixOS/nixpkgs/commit/75f0a6b65baed0fe6c27377eec4dd50255e58e36) | `inadyn: 2.9.0 -> 2.9.1`                                                  |
| [`09b3ac7a`](https://github.com/NixOS/nixpkgs/commit/09b3ac7aa51ecdcaa169066df8aa6239907fdfe5) | `python3Packages.glom: switch to pytestCheckHook`                         |
| [`2d3dd648`](https://github.com/NixOS/nixpkgs/commit/2d3dd64808ab2d1a631c1f05556fbe59a7143d86) | `scala: 2.13.7 -> 2.13.8`                                                 |
| [`37076fc6`](https://github.com/NixOS/nixpkgs/commit/37076fc603a3d38340065f7eebbd4cef0ac2dfc5) | `python3Packages.boltons: add patch for pprint`                           |
| [`99ee04b5`](https://github.com/NixOS/nixpkgs/commit/99ee04b5d181a43fd6e28e6e1140f58410b5a9e7) | `cryptsetup: 2.4.2 -> 2.4.3`                                              |
| [`441efc81`](https://github.com/NixOS/nixpkgs/commit/441efc81bce144361401f32696aebecea10d99d9) | `libkeyfinder: 2.2.5 -> 2.2.6`                                            |
| [`077a0b2e`](https://github.com/NixOS/nixpkgs/commit/077a0b2ee6d9a317252cf72c0f339d99281d41e2) | `python310Packages.marshmallow-dataclass: ignore DeprecationWarning`      |
| [`93a324cd`](https://github.com/NixOS/nixpkgs/commit/93a324cd589e1069e206147a23e5d7921d1ecb46) | `python310Packages.debugpy: disable failing tests`                        |
| [`fb43fde2`](https://github.com/NixOS/nixpkgs/commit/fb43fde2f50b4223b0bd1552e0177d1c678be8ae) | `python3Packages.igraph: 0.9.8 -> 0.9.9`                                  |
| [`fc4fbe94`](https://github.com/NixOS/nixpkgs/commit/fc4fbe94786700baae9466f5d2ae7c5f22a9db67) | `igraph: 0.9.5 -> 0.9.6`                                                  |
| [`421976c3`](https://github.com/NixOS/nixpkgs/commit/421976c3e3628e817214a13639af0cf8ad66be47) | `stfl: don't overwrite buildPhase, potentially make makeFlags working`    |
| [`24e553ce`](https://github.com/NixOS/nixpkgs/commit/24e553ceabca4964ecf031c357ebc3376d4ad5c1) | `maloader: use fetchFromGitHub`                                           |
| [`75a8b258`](https://github.com/NixOS/nixpkgs/commit/75a8b258eb380f9e0699e4dc3a840b11f1ccd460) | `nginxQuic: 10522e8dea41 -> 6f8253673669`                                 |
| [`d1c70dc1`](https://github.com/NixOS/nixpkgs/commit/d1c70dc13797d7fbf5ddced6c546434ac31bcdb7) | `calibre: added pycryptodome Python package`                              |
| [`ce350124`](https://github.com/NixOS/nixpkgs/commit/ce350124114a0b04521bb29afdb415b746b6e364) | `xiphos: code refactor`                                                   |
| [`0aca8215`](https://github.com/NixOS/nixpkgs/commit/0aca8215824746ef207129e9b43df6b321d82ee2) | `python3Packages.eventlet: switch to pytestCheckHook`                     |
| [`8d0e70bb`](https://github.com/NixOS/nixpkgs/commit/8d0e70bb58ee8b7916d7e3a1be47e891ba7615c6) | `variety: use runtimeShell instead of stdenv.shell`                       |
| [`3bbec485`](https://github.com/NixOS/nixpkgs/commit/3bbec485b194e37b96e6f9e2244d8930d873f2b1) | `octoprint: update celery override`                                       |
| [`da5f68cf`](https://github.com/NixOS/nixpkgs/commit/da5f68cf2a37869ba7dd2bea35065e416ffc5384) | `python3Packages.deemix: 3.6.5 -> 3.6.6`                                  |
| [`56b407d5`](https://github.com/NixOS/nixpkgs/commit/56b407d573f33218365404e720812a9377819824) | `blender-with-packages: add wrapper to load python packages with blender` |
| [`d2b979b3`](https://github.com/NixOS/nixpkgs/commit/d2b979b35497b20ce9f4b6616c206686014b5061) | `python3Packages.boxx: init at 0.9.9`                                     |
| [`a27bb785`](https://github.com/NixOS/nixpkgs/commit/a27bb7859ab5dfbcd882839145735f0e456b07d4) | `python3Packages.pyquaternion: init at 0.9.9`                             |
| [`424073c2`](https://github.com/NixOS/nixpkgs/commit/424073c2cd43225b76475047e1a398a73895375d) | `python3Packages.bbox: init at 0.9.2`                                     |
| [`12e1a359`](https://github.com/NixOS/nixpkgs/commit/12e1a3595cdbee391556e9dec678d1113a34743f) | `python3Packages.yacs: init at 0.1.8`                                     |
| [`86d2d4b0`](https://github.com/NixOS/nixpkgs/commit/86d2d4b0adbe7f5566eefb52648380ca670b1abd) | `python3Packages.zcs: init at 0.1.17`                                     |
| [`cdd46ad4`](https://github.com/NixOS/nixpkgs/commit/cdd46ad46348b377b5d6f1459f9a11eb83ea3093) | `python3Packages.celery: 5.2.1 -> 5.2.3`                                  |
| [`6bded8d7`](https://github.com/NixOS/nixpkgs/commit/6bded8d77f7b72c64ba9e558bad6a87f9a48ece0) | `python3Packages.kombu: 5.2.2 -> 5.2.3`                                   |
| [`1f96de6b`](https://github.com/NixOS/nixpkgs/commit/1f96de6bff378aa0c6bcdd1f9cd56bfb0a229d59) | `python3Packages.amqp: 5.0.6 -> 5.0.9`                                    |
| [`664b8d39`](https://github.com/NixOS/nixpkgs/commit/664b8d39b71d67c7841d851f1ba1c0c9d0443126) | `python3Packages.vine: switch to pytestCheckHook`                         |
| [`19e96206`](https://github.com/NixOS/nixpkgs/commit/19e962061275a9d91906d7c1212668053bf0471b) | `vscode-extensions.scalameta.metals: 1.10.15 -> 1.11.0`                   |
| [`43e26251`](https://github.com/NixOS/nixpkgs/commit/43e26251cd565240fabca029afb4bf1e3c938bed) | `python3Packages.aioresponses: 0.7.2 -> 0.7.3`                            |
| [`7508d822`](https://github.com/NixOS/nixpkgs/commit/7508d82289268bf8ebddbf40fce537b09d052d8a) | `xiphos: 4.1.0 -> 4.2.1`                                                  |
| [`adfc569e`](https://github.com/NixOS/nixpkgs/commit/adfc569e05e21e697997c3c2a8cac99923090627) | `spidermonkey_91: 91.4.0 -> 91.5.0`                                       |
| [`86968426`](https://github.com/NixOS/nixpkgs/commit/869684264137c977fe4e55d13ccde4d72ca1e3c8) | `gtkhtml4: added support for enchant2`                                    |
| [`095f4170`](https://github.com/NixOS/nixpkgs/commit/095f4170642b2c5977dce23c296503f25243bc0e) | `python310Packages.aspell-python: disable failing tests`                  |
| [`d76a2e59`](https://github.com/NixOS/nixpkgs/commit/d76a2e59297d23af97942361a04c405e0bf4e08b) | `python3Packages.schema: switch to pytestCheckHook`                       |
| [`6948bb31`](https://github.com/NixOS/nixpkgs/commit/6948bb31e9d5980a24b8c4232075a8b7661a5ebd) | `syncterm: init at 1.1`                                                   |
| [`b014866d`](https://github.com/NixOS/nixpkgs/commit/b014866de5561e6b4df4a047ddc4ec1c862fadee) | `python3Packages.contextlib2: update check section`                       |
| [`4f45adf0`](https://github.com/NixOS/nixpkgs/commit/4f45adf0e438590788573fb0e8a6be543ec89ec1) | `checkov: 2.0.710 -> 2.0.712`                                             |
| [`58948dcc`](https://github.com/NixOS/nixpkgs/commit/58948dcc4e2f631f5507ca3d48f9d60345853db0) | `tree-sitter: 0.20.1 -> 0.20.2`                                           |
| [`a23dd4d2`](https://github.com/NixOS/nixpkgs/commit/a23dd4d2f6b502da002260a6cce52507c80842ab) | `python3Packages.cloudsplaining: 0.4.9 -> 0.4.10`                         |
| [`bc1e6f67`](https://github.com/NixOS/nixpkgs/commit/bc1e6f678407897337777a54fadbb572225bc505) | `erlang: 24.2, 23.3.4.10, 22.3.4.24 (#153709)`                            |
| [`c6fd68bd`](https://github.com/NixOS/nixpkgs/commit/c6fd68bda6defb39e627d8f88040ff27925a29aa) | `emacs.pkgs.elpaPackages.org-transclusion: Mark broken`                   |
| [`7c706f46`](https://github.com/NixOS/nixpkgs/commit/7c706f46a3a6300bfd837389bf48900f3ef652de) | `emacs.pkgs.melpaStablepackages.revbufs: Mark broken`                     |
| [`85bf035d`](https://github.com/NixOS/nixpkgs/commit/85bf035d37d97f510c09f4c4657f0415cc4c410f) | `emacs.pkgs.melpaStablepackages.org-dp: Mark broken`                      |
| [`e5b708d1`](https://github.com/NixOS/nixpkgs/commit/e5b708d1ed18ba51dc98635a154084669e709614) | `emacs.pkgs.melpaStablepackages.ligo-mode: Mark broken`                   |
| [`49d99e50`](https://github.com/NixOS/nixpkgs/commit/49d99e5034034a044a4f7e360435fd32aa62380a) | `emacs.pkgs.melpaStablepackages.gl-conf-mode: Mark broken`                |
| [`5f3302af`](https://github.com/NixOS/nixpkgs/commit/5f3302af087a8883b2191edb1ecff3ea1c3109d9) | `emacs.pkgs.melpaStablepackages.fold-dwim: Mark broken`                   |
| [`20b3fe46`](https://github.com/NixOS/nixpkgs/commit/20b3fe46d561ee2a51089a59b49f6dc5a1f6ba1d) | `emacs.pkgs.melpaStablepackages.abridge-diff: Reorder broken override`    |
| [`9fde065d`](https://github.com/NixOS/nixpkgs/commit/9fde065dc6a3aa77241833c1b20efe8c3b43c0c7) | `emacs.pkgs.melpaStablepackages.abridge-diff: Mark broken`                |
| [`7eca5b29`](https://github.com/NixOS/nixpkgs/commit/7eca5b29dafe3eee62fb7c3bf317a88e6002db0a) | `python3Packages.cyclonedx-python-lib: 0.12.3 -> 1.0.0`                   |
| [`fd31ae1e`](https://github.com/NixOS/nixpkgs/commit/fd31ae1e115c3de58789bcb7dff09ce40e770f0c) | `emacs.pkgs.ement: unstable-2021-09-16 -> unstable-2021-10-08`            |
| [`847a715c`](https://github.com/NixOS/nixpkgs/commit/847a715cfa7ed92cff06a780ec684e26388498e1) | `electricsheep.src: fix sha`                                              |
| [`dc274811`](https://github.com/NixOS/nixpkgs/commit/dc2748118a5e60d7c781a8c1ebe3765c8cf16035) | `aws-sam-cli: 1.36.0 -> 1.37.0`                                           |
| [`d49cc4d0`](https://github.com/NixOS/nixpkgs/commit/d49cc4d00ef7d0b958cd4bfe497f6ce7cef97652) | `thunderbird-bin: 91.4.1 -> 91.5.0`                                       |
| [`0bb8de5d`](https://github.com/NixOS/nixpkgs/commit/0bb8de5df1327cb1b70addf48b803a9710ea85ec) | `python310Packages.mayavi: add pythonImportsCheck`                        |
| [`509be35c`](https://github.com/NixOS/nixpkgs/commit/509be35c30df4c80e12ac5273d81ec4a2f166d8f) | `python310Packages.envisage: disable failing tests`                       |
| [`768523dd`](https://github.com/NixOS/nixpkgs/commit/768523dd4327a9ec53ecf7ad7a5a9c0f5464e5c1) | `pandoc-drawio-filter: init at 1.0`                                       |
| [`6828eb8e`](https://github.com/NixOS/nixpkgs/commit/6828eb8e559d5bdc149bea22e4c2a34ad367c425) | `python310Packages.traits: cleanup`                                       |
| [`770e32fa`](https://github.com/NixOS/nixpkgs/commit/770e32fa8970e2c3e60a6e9802d89307fba8419a) | `Update pkgs/tools/misc/yubikey-manager/default.nix`                      |
| [`c2798838`](https://github.com/NixOS/nixpkgs/commit/c2798838e7687e8ada3b096ca69f7685d3ed8de8) | `python310Packages.serverlessrepo: relax dependency constraints`          |
| [`a42847ac`](https://github.com/NixOS/nixpkgs/commit/a42847acf1fe30d9c4088474d58cf14b137cdeb4) | `python3Packages.apptools: adjust inputs and disable tests`               |
| [`03b8ba00`](https://github.com/NixOS/nixpkgs/commit/03b8ba007099d5de52d8a0429031aaeb0f099717) | `mpvScripts.sponsorblock: update script: do not use shallow fetch`        |
| [`01580a59`](https://github.com/NixOS/nixpkgs/commit/01580a59e436d33dd2186628b7c6226aaec5a5d9) | `python3Packages.sendgrid: 6.9.3 -> 6.9.4`                                |
| [`33589934`](https://github.com/NixOS/nixpkgs/commit/33589934a52ae7536185ed3e6b03aa3f2cadd775) | `python310Packages.restfly: 1.4.4 -> 1.4.5`                               |
| [`ba98cdde`](https://github.com/NixOS/nixpkgs/commit/ba98cddea6f66071bfedc60f487a49716b18f2b5) | `python3Packages.time-machine: 2.5.0 -> 2.6.0`                            |
| [`7dc24c09`](https://github.com/NixOS/nixpkgs/commit/7dc24c092332a6313309926028656915d676e10e) | `nixos/starship: use expect for testing`                                  |
| [`da5f261f`](https://github.com/NixOS/nixpkgs/commit/da5f261fdf048d10a08e229caea904847c5686e2) | `bloop: 1.4.11 -> 1.4.12`                                                 |
| [`e6ea8407`](https://github.com/NixOS/nixpkgs/commit/e6ea8407a3bb7c8cebe0897f3090258ed5ad21be) | `tig: 2.5.4 -> 2.5.5`                                                     |
| [`4d1de6bd`](https://github.com/NixOS/nixpkgs/commit/4d1de6bdac9a352044d254d492c8ee1b1ee2136a) | `pwsafe: substitute paths in .desktop file`                               |
| [`72908cb5`](https://github.com/NixOS/nixpkgs/commit/72908cb5a8d1dfc54a127a0b1f9fa3fd7f808b4b) | `services.heisenbridge: Don't use lt/gt signs in mkEnableOption`          |
| [`191ba295`](https://github.com/NixOS/nixpkgs/commit/191ba295e6daee9b7f2e70a1c07ccb025735124a) | `nixos/heisenbridge: Add to modules-list.nix`                             |
| [`37aefe32`](https://github.com/NixOS/nixpkgs/commit/37aefe329d5a2761e5b5e72411fb3bea80396f11) | `ace-of-penguins: init at 1.4`                                            |
| [`5d07e1cc`](https://github.com/NixOS/nixpkgs/commit/5d07e1cc64db016b36e97a7418f91f7c700c9c61) | `mtr: 0.94 -> 0.95`                                                       |
| [`7738de90`](https://github.com/NixOS/nixpkgs/commit/7738de9075c9ddaa5d4a39d26ef94ec8475febd0) | `hydrus: 468 -> 469`                                                      |
| [`0e5389c1`](https://github.com/NixOS/nixpkgs/commit/0e5389c1f8449d1a1cba9fab479f4452fdb32bbe) | `hydrus: 467 -> 468`                                                      |
| [`be4504dd`](https://github.com/NixOS/nixpkgs/commit/be4504dd16ad176e94e82b0a6172381566246138) | `pdfstudio: 2021.1.1 -> 2021.1.2`                                         |
| [`ebbbd421`](https://github.com/NixOS/nixpkgs/commit/ebbbd421406fdd926f2e8b1333f90bb46a597a64) | `qpdfview: refactor`                                                      |
| [`002ab67a`](https://github.com/NixOS/nixpkgs/commit/002ab67a213b3ee0d71d5f3cc396d77cefc9aedd) | `ratmen: refactor`                                                        |
| [`cdb4d0a3`](https://github.com/NixOS/nixpkgs/commit/cdb4d0a390940c8261fee957d70bddef8248c327) | `sile: 0.12.0 → 0.12.1`                                                   |
| [`0a297501`](https://github.com/NixOS/nixpkgs/commit/0a2975012967105804d5401895e82611de4facb4) | `mycli: 1.24.1 -> 1.24.2`                                                 |
| [`ef859b0c`](https://github.com/NixOS/nixpkgs/commit/ef859b0c0cecd01c87f75adb9556ee055d3794a6) | `synth: 0.6.3 -> 0.6.4`                                                   |
| [`33d34165`](https://github.com/NixOS/nixpkgs/commit/33d341655e2631d2dbc63cbe29c6387b13ba0250) | `python3Packages.pynetdicom: disable failing test`                        |
| [`2a1bea69`](https://github.com/NixOS/nixpkgs/commit/2a1bea692f4a4fc4afbdaf1c9fa32b605305f4ce) | `python3Packages.minexr: init at 1.0.1`                                   |
| [`2913e239`](https://github.com/NixOS/nixpkgs/commit/2913e23931dc22c9bcc33db5711bd360382243df) | `python3Packages.bpycv: init at 0.2.43`                                   |
| [`49d5367d`](https://github.com/NixOS/nixpkgs/commit/49d5367d0e4cdca9a2b7ef1addaf964c4fcd599b) | `qogir-icon-theme: 2021-10-14 -> 2022-01-12`                              |
| [`b6080f1e`](https://github.com/NixOS/nixpkgs/commit/b6080f1e5795c0086508a1e20c4d8ae61d90e36f) | `anystyle-cli: fix PATH in wrapper`                                       |
| [`b815b221`](https://github.com/NixOS/nixpkgs/commit/b815b221479753e0d6ed3fd4055e02d3f8af7075) | `Update pkgs/tools/misc/yubikey-manager/default.nix`                      |
| [`e11c5181`](https://github.com/NixOS/nixpkgs/commit/e11c51818adb1a23c00f5779a4a0e5fdc0abcf62) | `appgate-sdp: 5.5.1 -> 5.5.2`                                             |
| [`715563e5`](https://github.com/NixOS/nixpkgs/commit/715563e5eba28d10736ac42f1640c3930767f6e1) | `headscale: 0.11.0 -> 0.12.2`                                             |
| [`cd2f11b1`](https://github.com/NixOS/nixpkgs/commit/cd2f11b1d918cee9eabdc5963a0916a752d6fc7f) | `Apply suggestions from code review`                                      |
| [`d28799ab`](https://github.com/NixOS/nixpkgs/commit/d28799abfa9fba4ef066c5a69b56819595bfebab) | `yubikey-manager: replace myself as maintainer with other known users`    |
| [`e5c57c36`](https://github.com/NixOS/nixpkgs/commit/e5c57c36bfeda1399397611e9b1af9f0c848d635) | `imgbrd-grabber: 7.7.0 -> 7.7.1`                                          |
| [`e12befea`](https://github.com/NixOS/nixpkgs/commit/e12befeada257f44569ef0a990bad1780ea7694c) | `thunderbird: 91.4.1 -> 91.5.0`                                           |
| [`c5648deb`](https://github.com/NixOS/nixpkgs/commit/c5648deb83a31c00c71c3b11b50c7f457730eaec) | `kubectl-example: 1.0.1 -> 1.1.0`                                         |
| [`18b4ded9`](https://github.com/NixOS/nixpkgs/commit/18b4ded9f09f96d6a83f5fe190e2caa72f20326d) | `kube-capacity: 0.6.2 -> 0.7.0`                                           |
| [`c0a73793`](https://github.com/NixOS/nixpkgs/commit/c0a737930a208dc218427ab148880a95290a9105) | `snapmaker-luban: 4.1.2 -> 4.1.3`                                         |
| [`5d04bb95`](https://github.com/NixOS/nixpkgs/commit/5d04bb956279eae4d22d884ba4405cf5eade3853) | `whalebird: 4.4.6 -> 4.5.0`                                               |
| [`b88ddadf`](https://github.com/NixOS/nixpkgs/commit/b88ddadf8bd289f8ea561f3b3f2ca7e1b6fe2861) | `nixos/intel-sgx: add option for Intel SGX DCAP compatibility`            |
| [`1b34a8e8`](https://github.com/NixOS/nixpkgs/commit/1b34a8e8b35e44b4f71563b4cc68b1d5df410b78) | `texstudio: 4.1.2 -> 4.2.0`                                               |
| [`746e627b`](https://github.com/NixOS/nixpkgs/commit/746e627b4032898290f1b51dccf715d3a819366b) | `nixos/mpd: use upstream units`                                           |
| [`0a4d8388`](https://github.com/NixOS/nixpkgs/commit/0a4d838815d8a9bd26c9ae935172f54e8400cdf7) | `strawberry: 1.0.0 -> 1.0.1`                                              |
| [`da54875f`](https://github.com/NixOS/nixpkgs/commit/da54875f8400d7ecd69cb907b759140e0176dda5) | `super-productivity: 7.9.1 -> 7.9.2`                                      |
| [`74a565da`](https://github.com/NixOS/nixpkgs/commit/74a565dac5a4f9ba8aba10d79998281a1cc208a5) | `fnm: 1.28.2 -> 1.29.2`                                                   |
| [`c345fc50`](https://github.com/NixOS/nixpkgs/commit/c345fc506763d6e39c0e8357ddf3d2791a7c7207) | `dnsproxy: 0.40.1 -> 0.40.3`                                              |
| [`8cc12597`](https://github.com/NixOS/nixpkgs/commit/8cc125972e56d0c730554e5f312622d75e106d28) | `victor-mono: 1.5.1 -> 1.5.2`                                             |
| [`36e46255`](https://github.com/NixOS/nixpkgs/commit/36e46255d5b395c56d15ebd1c07ca16642234ba4) | `gitRepo: 2.19 -> 2.20`                                                   |
| [`33e61e2b`](https://github.com/NixOS/nixpkgs/commit/33e61e2bc8db12aa43b1a0c41af8a73aa43f409c) | `bazarr: 1.0.0 -> 1.0.2`                                                  |
| [`3c5f1379`](https://github.com/NixOS/nixpkgs/commit/3c5f1379f4e0bcfeda0069efbf503180d82d521e) | `synth: 0.6.2 -> 0.6.3`                                                   |
| [`1c7b2186`](https://github.com/NixOS/nixpkgs/commit/1c7b2186e23d06e277d1e9adb9557dd4dfa11b4a) | `avizo: unstable-2021-07-21 -> 1.1`                                       |
| [`9baa45ff`](https://github.com/NixOS/nixpkgs/commit/9baa45ff0d82f6f2463820f65e397604ac7cca93) | `python3Packages.django-extensions: 3.1.3 -> 3.1.5`                       |
| [`c0b9a9ee`](https://github.com/NixOS/nixpkgs/commit/c0b9a9ee448d33f480dd47ccb35c998d7cbab37c) | `python3Packages.django_extensions: rename to django-extensions`          |
| [`f8a84952`](https://github.com/NixOS/nixpkgs/commit/f8a84952e083a2bffabee6517f4de9f1f2450255) | `blockbench-electron: 3.7.5 -> 4.1.1`                                     |
| [`11d91bd3`](https://github.com/NixOS/nixpkgs/commit/11d91bd3185af9f4f8a084fbe1535486c8da8653) | `CONTRIBUTING: Make clearer where branch policy can be found`             |
| [`1783cfde`](https://github.com/NixOS/nixpkgs/commit/1783cfde53a58b1fa38449e47f45dd65091de7ae) | ``nixos/nixos-enter: Don't passthru `TMPDIR```                            |
| [`2f0cfde4`](https://github.com/NixOS/nixpkgs/commit/2f0cfde482e780dd7abcc8b4e1f51d160f74f7aa) | ``tests/systemd-boot: Add tests for `extraFiles```                        |
| [`13903fef`](https://github.com/NixOS/nixpkgs/commit/13903fef2de2171d44e47c2c8d29eb194b614082) | `nixos/systemd-boot: Add option to add netboot.xyz`                       |
| [`f6b61981`](https://github.com/NixOS/nixpkgs/commit/f6b61981b16448315686a07707eca4acffe33fb4) | `nixos/systemd-boot: Support extra EFI entries`                           |
| [`96690c5b`](https://github.com/NixOS/nixpkgs/commit/96690c5b6620866a6268dec07e21fa2f2f05aee1) | `netbootxyz-efi: init at 2.0.53`                                          |