### PR TITLE
chore(flake/nixpkgs): `b4ac5539` -> `d4cc90ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642106561,
-        "narHash": "sha256-Ym6ZxoQ2uRGpVgn6A/C9LOVqOxlz3R4NUx+Dzb2geYI=",
+        "lastModified": 1642150059,
+        "narHash": "sha256-qfaHY0RNlW2osN1NlMVdqDioJNi1pOvZ0xQgioa+D8Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b4ac5539ea325cadce07b99c837d6cccbdddda3b",
+        "rev": "d4cc90aea59dfc7738532cd10266f607e3f76e05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                       |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`656e878a`](https://github.com/NixOS/nixpkgs/commit/656e878a109682c147ef1a3c101e33cc47fd38e1) | `lima: 0.8.0 -> 0.8.1`                                               |
| [`b316efff`](https://github.com/NixOS/nixpkgs/commit/b316efff4b10d79d49f8e8fe63bbc93fbedefe9f) | `update-python-libraries: skip replacing 'rev' when set to variable` |
| [`ce0a9077`](https://github.com/NixOS/nixpkgs/commit/ce0a90773077a52e2ce7fd6094078b075dd76867) | `update-python-libraries: support pyproject and flit formats`        |
| [`d016f26c`](https://github.com/NixOS/nixpkgs/commit/d016f26cda25afbc0718a5fef173b4e1de4d4eaa) | `python3Packages.weasyprint: disabled overly sensitive tab tests`    |
| [`bf0f2327`](https://github.com/NixOS/nixpkgs/commit/bf0f23274136ddb2b6b0fa91952e1453b990a88d) | `python3Packages.uamqp: 1.4.3 -> 1.5.1`                              |
| [`0dc088f8`](https://github.com/NixOS/nixpkgs/commit/0dc088f8fb8a434269c59a1b1feafeea10cf868b) | `azure-cli: 2.30.0 -> 2.32.0`                                        |
| [`b9f67c80`](https://github.com/NixOS/nixpkgs/commit/b9f67c80b93d8cfb784d51ba948a01d3fb1c0fae) | `python3Packages.humanfriendly: 9.2 -> 10.0`                         |
| [`28caec18`](https://github.com/NixOS/nixpkgs/commit/28caec1863c257403d4456c2d6a8b24f9c61c653) | `python3Packages.msal-extensions: 0.3.0 -> 0.3.1`                    |
| [`ca58830d`](https://github.com/NixOS/nixpkgs/commit/ca58830d5bddc425f5ff97cea04de5f603948c04) | `python3Packages.azure-synapse-artifacts: 0.10.0 -> 0.11.0`          |
| [`3ff5aff3`](https://github.com/NixOS/nixpkgs/commit/3ff5aff30fe253a5a31b90a7294f5c6497c0df6f) | `python3Packages.azure-servicefabric: 8.0.0.0 -> 8.2.0.0`            |
| [`c64cbc43`](https://github.com/NixOS/nixpkgs/commit/c64cbc43e32af56db372011a796923517d040926) | `python3Packages.azure-servicebus: 7.4.0 -> 7.5.0`                   |
| [`7e41403f`](https://github.com/NixOS/nixpkgs/commit/7e41403fb41d224a56a5e4b23011eee45dec96cd) | `python3Packages.azure-mgmt-web: 5.0.0 -> 6.0.0`                     |
| [`6292946a`](https://github.com/NixOS/nixpkgs/commit/6292946a6881bf9739d7a9a253b5567744ea65f7) | `python3Packages.azure-mgmt-netapp: 5.1.0 -> 6.0.1`                  |
| [`7a254a7f`](https://github.com/NixOS/nixpkgs/commit/7a254a7fc8d0c089e5c95725d444c1724efb66b9) | `python3Packages.azure-mgmt-imagebuilder: 0.4.0 -> 1.0.0`            |
| [`a0165628`](https://github.com/NixOS/nixpkgs/commit/a0165628912888aa63958c9a52bc20676704b199) | `python3Packages.azure-mgmt-eventgrid: 10.0.0 -> 10.1.0`             |
| [`c2adb775`](https://github.com/NixOS/nixpkgs/commit/c2adb775da3a7ae4366ff2887583f4c1d19c2593) | `python3Packages.azure-mgmt-datafactory: 2.1.0 -> 2.2.0`             |
| [`42774808`](https://github.com/NixOS/nixpkgs/commit/4277480825c95b132ef55cc9ff34ebd37b458f4b) | `python3Packages.azure-mgmt-applicationinsights: 1.0.0 -> 2.0.0`     |
| [`ec31075e`](https://github.com/NixOS/nixpkgs/commit/ec31075eaefa30e3da5eb100e5ea73580136fa4c) | `python3Packages.azure-mgmt-apimanagement: 2.1.0 -> 3.0.0`           |
| [`a7d7bebd`](https://github.com/NixOS/nixpkgs/commit/a7d7bebd0d52520c7306250c2311be2307874023) | `python3Packages.azure-eventhub: 5.6.1 -> 5.7.0`                     |
| [`b409d14e`](https://github.com/NixOS/nixpkgs/commit/b409d14ef1fde3625f74539d14b55672ae4bd268) | `electron_16: 16.0.6 -> 16.0.7`                                      |
| [`459949f7`](https://github.com/NixOS/nixpkgs/commit/459949f7a18e34b4771b5792e40dab10909290e7) | `electron_15: 15.3.4 -> 15.3.5`                                      |
| [`dc0e1436`](https://github.com/NixOS/nixpkgs/commit/dc0e14368abd408996155274274d7b36ba58eb94) | `electron_14: 14.2.3 -> 14.2.4`                                      |
| [`1e540bba`](https://github.com/NixOS/nixpkgs/commit/1e540bba5a6ed8e26eabe20913397be1d07ff8dd) | `electron_13: 13.6.6 -> 13.6.7`                                      |
| [`a5d4af40`](https://github.com/NixOS/nixpkgs/commit/a5d4af4024750c773cb50f3f7289834d8ed128f1) | `python3Packages.wandb: 0.12.7 -> 0.12.9 (#154800)`                  |
| [`1d817316`](https://github.com/NixOS/nixpkgs/commit/1d817316423c385b027f9a46455ca2c1c4fc1423) | `kicad: 6.0.0 -> 6.0.1`                                              |
| [`d98b76cf`](https://github.com/NixOS/nixpkgs/commit/d98b76cf5b29a4348ef7924bed12609c98dcab59) | `kicad-unstable: 2021-12-23 -> 2022-01-13`                           |
| [`1ea35d50`](https://github.com/NixOS/nixpkgs/commit/1ea35d50d84aa6e85a99a4ed593df7ed629b3974) | `python3Packages.pygal: 2.4.0 -> 3.0.0`                              |
| [`615520b1`](https://github.com/NixOS/nixpkgs/commit/615520b1785d6988505e9f9ede34a3c0d6f19d30) | `python3Packages.meshtastic: 1.2.53 -> 1.2.54`                       |
| [`2d377340`](https://github.com/NixOS/nixpkgs/commit/2d377340cafb32c709a406fc61530362a8cbf74e) | `python310Packages.cssutils: fix tests`                              |
| [`285a0f70`](https://github.com/NixOS/nixpkgs/commit/285a0f7042fcdbfa14a5151970f553250c537be0) | `python3Packages.restview: 2.9.3 -> 3.0.0`                           |
| [`2b7f3690`](https://github.com/NixOS/nixpkgs/commit/2b7f36902600d22d11ddffe39f2e701e77552ea4) | `grafana-loki: 2.4.1 -> 2.4.2 (#154835)`                             |
| [`c812713c`](https://github.com/NixOS/nixpkgs/commit/c812713c102dd1645c421fc434b944b9a5a76e6d) | `dablin: 1.13.0 -> 1.14.0`                                           |
| [`40c7f692`](https://github.com/NixOS/nixpkgs/commit/40c7f692a461d79ed177d8d2dd22c463a326526c) | `maigret: 0.3.1 -> 0.4.0`                                            |
| [`8537ce50`](https://github.com/NixOS/nixpkgs/commit/8537ce50c93f162e70112c2bef0dbc24e2301002) | `python3Packages.hahomematic: 0.21.0 -> 0.21.2`                      |
| [`5f07376b`](https://github.com/NixOS/nixpkgs/commit/5f07376b951dc2285a4043e541019decd29b4b14) | `python3Packages.hahomematic: 0.20.0 -> 0.21.0`                      |
| [`f610a972`](https://github.com/NixOS/nixpkgs/commit/f610a972a2c103a375f53ea41436ae36a8d4bc34) | `python3Packages.hahomematic: 0.19.0 -> 0.20.0`                      |
| [`5d888bff`](https://github.com/NixOS/nixpkgs/commit/5d888bff2777402b4112eed22c7e5287f8e3bf01) | `pijuice: init at 1.7`                                               |
| [`a26feceb`](https://github.com/NixOS/nixpkgs/commit/a26feceb1a4d63779a861717d01d2d57772b6788) | `python3Packages.faraday-plugins: 1.5.9 -> 1.5.10`                   |
| [`89b41c0f`](https://github.com/NixOS/nixpkgs/commit/89b41c0f31844ee58bedbdb6759066abbfcbcbe1) | `proxychains-ng: fix build on aarch64-darwin`                        |
| [`3c6e3dbc`](https://github.com/NixOS/nixpkgs/commit/3c6e3dbc3945ee67db73581351ba0621187fce68) | `open-policy-agent: 0.35.0 -> 0.36.1`                                |
| [`2afbf727`](https://github.com/NixOS/nixpkgs/commit/2afbf72715010b29b81bd83709257116187facd8) | `scalafmt: 3.3.0 -> 3.3.1`                                           |
| [`1148571e`](https://github.com/NixOS/nixpkgs/commit/1148571e05d62517b5831b2f28433807776d8dec) | `pt2-clone: 1.38 -> 1.39`                                            |
| [`d2f52435`](https://github.com/NixOS/nixpkgs/commit/d2f524351426a7efebcfabae43c800ed5977f69c) | `metals: 0.10.9 -> 0.11.0`                                           |
| [`022fc3ab`](https://github.com/NixOS/nixpkgs/commit/022fc3ab02c636703a4e14d55fa9da62fab176ab) | `sigi: 2.1.1 -> 3.0.0`                                               |
| [`7c27b825`](https://github.com/NixOS/nixpkgs/commit/7c27b825fc9b36e10f40bdf72467ec85d121063a) | `pgcli: 3.2.0 -> 3.3.0`                                              |
| [`72501ea6`](https://github.com/NixOS/nixpkgs/commit/72501ea60841f6f5f54ac667da3ea58610e50f4e) | `code-server: 3.12.0 -> 4.0.1`                                       |
| [`6730766b`](https://github.com/NixOS/nixpkgs/commit/6730766ba004ef3407ce0d0b3a8299ef72fcdfb9) | `electron: remove electron_{3,4,5,6}`                                |