### PR TITLE
chore(flake/nixpkgs): `d4cc90ae` -> `fd7e8516`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642150059,
-        "narHash": "sha256-qfaHY0RNlW2osN1NlMVdqDioJNi1pOvZ0xQgioa+D8Y=",
+        "lastModified": 1642195662,
+        "narHash": "sha256-bRRq9bJFzp2PSb7t4BMVAc8zapFEzpfcCprs7TNPIIc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d4cc90aea59dfc7738532cd10266f607e3f76e05",
+        "rev": "fd7e851613488b079af50cbb4217d9ad6d7cd580",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
| [`97a8c722`](https://github.com/NixOS/nixpkgs/commit/97a8c7228abcbf1696554dc930f05666d5cd522e) | `linuxPackages.nvidia_x11_beta: 495.29.05 -> 510.39.01`                                                            |
| [`4e7e160e`](https://github.com/NixOS/nixpkgs/commit/4e7e160ea6a44e7d1731e11399a5bdd6a6bd505b) | `olm: 3.2.8 -> 3.2.9`                                                                                              |
| [`b6a83b48`](https://github.com/NixOS/nixpkgs/commit/b6a83b4867b909adc50b4da5dc239763b0795f2c) | `mautrix-signal: 2021-11-12 -> 2022-01-14`                                                                         |
| [`e040f9cd`](https://github.com/NixOS/nixpkgs/commit/e040f9cd641d41f32abdccf8c706aec6a2379c50) | `mautrix: 0.14.3 -> 0.14.4`                                                                                        |
| [`b24a2be2`](https://github.com/NixOS/nixpkgs/commit/b24a2be269d0780a4627e955b4abf9fd254dadbc) | `deadnix: init at 0.1.3`                                                                                           |
| [`47a8b156`](https://github.com/NixOS/nixpkgs/commit/47a8b15664f45dc66c166be35e0615163b6199d3) | `evolution-data-server: propagate libgdata`                                                                        |
| [`ffde221d`](https://github.com/NixOS/nixpkgs/commit/ffde221dcb839fc4febdf8106ae5e896383ebaf4) | `python3Packages.pytorch-bin: enable on darwin (cpu build)`                                                        |
| [`8a552994`](https://github.com/NixOS/nixpkgs/commit/8a552994d8e91b206b7d807917d1bbca54ce1145) | `nixos/build-vm.nix: Fix docs eval`                                                                                |
| [`43d5b318`](https://github.com/NixOS/nixpkgs/commit/43d5b318d80322bd460edee2e054f3d5f5db027e) | `python3Packages.ytmusicapi: 0.19.5 -> 0.20.0`                                                                     |
| [`a40f3bc8`](https://github.com/NixOS/nixpkgs/commit/a40f3bc88e10dbe9abdb1a5553a0cd7f0c41682a) | `python3Packages.pyturbojpeg: 1.6.3 -> 1.6.4`                                                                      |
| [`c52d6cf4`](https://github.com/NixOS/nixpkgs/commit/c52d6cf465394106940801292762aa70c6f0fa6c) | `python3Packages.repeated_test: remove`                                                                            |
| [`50ede5f4`](https://github.com/NixOS/nixpkgs/commit/50ede5f4e0997259e1f170342e185b9f8929e181) | `clamav: 0.103.3 -> 0.103.5`                                                                                       |
| [`d67829cf`](https://github.com/NixOS/nixpkgs/commit/d67829cf88d5f58598199ab3f61a78329c0247a7) | `ocamlPackages.fix: 20201120 -> 20211231`                                                                          |
| [`c1336ddd`](https://github.com/NixOS/nixpkgs/commit/c1336ddd8c809ca2da4e4e79c6f9614c99688636) | `wireplumber: backport default device selection fix from master`                                                   |
| [`e09b9d40`](https://github.com/NixOS/nixpkgs/commit/e09b9d401fe58a3f2bac3b93830a82ec4d8f8b01) | `hyper: 3.1.4 -> 3.1.5`                                                                                            |
| [`c9fa779a`](https://github.com/NixOS/nixpkgs/commit/c9fa779ad7b9c396ccae65a90cf43746d5047c84) | `khronos-ocl-icd-loader: 2021.06.30 -> 2022.01.04`                                                                 |
| [`162d4c51`](https://github.com/NixOS/nixpkgs/commit/162d4c51b3e193bf78beb584b172462a68adb66b) | `ryzenadj: 0.8.2 -> 0.8.3`                                                                                         |
| [`2a0c0881`](https://github.com/NixOS/nixpkgs/commit/2a0c0881c2e9df1b4667f86fa7cc43b061722845) | `ferdi: 5.6.5 -> 5.7.0`                                                                                            |
| [`35f8dc6e`](https://github.com/NixOS/nixpkgs/commit/35f8dc6ecc69a90dfa9287088fd49c7c2cb3e9a3) | `yaml-merge: unstable-2016-02-16 -> unstable-2022-01-12`                                                           |
| [`98ba0568`](https://github.com/NixOS/nixpkgs/commit/98ba056822f3a1c846daec2080267bfa73e3869f) | `python310Packages.sqlalchemy-migrate: fix build by removing unittest2, adopt into openstack team, minor cleanups` |
| [`57309193`](https://github.com/NixOS/nixpkgs/commit/573091938b584a99927e413dced7f48a369774b0) | `crun: 1.4 -> 1.4.1`                                                                                               |
| [`e5a50e8f`](https://github.com/NixOS/nixpkgs/commit/e5a50e8f2995ff359a170d52cc40adbcfdd92ba4) | `gitlab: 14.6.1 -> 14.6.2 (#154997)`                                                                               |
| [`8cb070da`](https://github.com/NixOS/nixpkgs/commit/8cb070da131c2adc102bec2db2470292647e1fe9) | `dura: init at 0.1.0`                                                                                              |
| [`7ce72f00`](https://github.com/NixOS/nixpkgs/commit/7ce72f00e69cfb4a0727889f6775c2c78bb9ef4b) | `python3Packages.wavedrom: minor adjustments`                                                                      |
| [`c1d77e4d`](https://github.com/NixOS/nixpkgs/commit/c1d77e4dd1c05cfd7efe6b0ecff001514e48c867) | `colima: 0.2.2 -> 0.3.1`                                                                                           |
| [`526276aa`](https://github.com/NixOS/nixpkgs/commit/526276aa9b3b8d4ae3b9f5f2ae872a6295f0e5ff) | `python3Packages.attrdict: refactor for Python 3.10`                                                               |
| [`f5914d93`](https://github.com/NixOS/nixpkgs/commit/f5914d93477172e80cabfc87fb758e7012572f91) | `python.pkgs.roboschool: remove`                                                                                   |
| [`3fc8be27`](https://github.com/NixOS/nixpkgs/commit/3fc8be277da9ef16fded052863df1d336176ca54) | `sqlcipher: grab CFLAGS from sqlite`                                                                               |
| [`d1787b02`](https://github.com/NixOS/nixpkgs/commit/d1787b020f4a94add60a7bb07072766b17464183) | `vyper: remove unused postPatch and add setuptools-scm`                                                            |
| [`3a8627dc`](https://github.com/NixOS/nixpkgs/commit/3a8627dcf796b8dfd41d3e4886dff7683fc9f21f) | `python3Packages.cart: adjust inputs`                                                                              |
| [`387f3616`](https://github.com/NixOS/nixpkgs/commit/387f36163830ba937e0b425ba091b3b98fda30f4) | `python3Packages.flux-led: 0.28.2 -> 0.28.3`                                                                       |
| [`2bb53292`](https://github.com/NixOS/nixpkgs/commit/2bb53292610b10f27db73db588f2120abc4d6cf9) | `python3Packages.flux-led: 0.28.1 -> 0.28.2`                                                                       |
| [`6390150a`](https://github.com/NixOS/nixpkgs/commit/6390150a0562aef42e7197760c98fc668cac0d7c) | `python3Packages.connexion: relax pyyaml and jsonschema constraint`                                                |
| [`4eae92ee`](https://github.com/NixOS/nixpkgs/commit/4eae92eea2aa27055c6f85c7eaf5fca41bcd4315) | `go365: fix for darwin`                                                                                            |
| [`cc5ffb3d`](https://github.com/NixOS/nixpkgs/commit/cc5ffb3de43f93be6e065963a93a34f294c01022) | `root: Explicit specify -Dtmva=ON`                                                                                 |
| [`336cc50b`](https://github.com/NixOS/nixpkgs/commit/336cc50b1ffd8b6be32d2f85496686944cc66ab7) | `root: add openblas and lapack into buildInputs for TMVA`                                                          |
| [`fca7543b`](https://github.com/NixOS/nixpkgs/commit/fca7543bd13bb4b248072c8bf5ebda6befe316e6) | `telescope: 0.6.1 → 0.7`                                                                                           |
| [`84d39618`](https://github.com/NixOS/nixpkgs/commit/84d39618cb41f6c2b3842aa173454c9983b6b2d4) | `zxing-cpp: 1.1.1 -> 1.2.0`                                                                                        |
| [`d8527685`](https://github.com/NixOS/nixpkgs/commit/d852768538d8e36117a7c367f5625296b08200fd) | `tinycc: unstable-2021-10-09 -> 0.9.27+date=2022-01-11`                                                            |
| [`8c306506`](https://github.com/NixOS/nixpkgs/commit/8c30650658e26faba9dee6e46caf5e387ba22286) | `home-assistant: add new overrides`                                                                                |
| [`d79b4037`](https://github.com/NixOS/nixpkgs/commit/d79b4037a352909445925a386be51b8e5548d712) | `python3Packages.testfixtures: disable failing tests`                                                              |
| [`32003c30`](https://github.com/NixOS/nixpkgs/commit/32003c3051f73892f5e465d0eb80f3d438e5dde2) | `toil: 5.4.0 -> 5.6.0`                                                                                             |
| [`694e98f8`](https://github.com/NixOS/nixpkgs/commit/694e98f8a61f86fa723503e114b6fcb38d863595) | `python3Packages.py-tes: init at 0.4.2`                                                                            |
| [`9fa6b9b0`](https://github.com/NixOS/nixpkgs/commit/9fa6b9b025bf67a4b55b3b1cc1e08917b50fc4b0) | `python3Packages.catalogue: disable failing test`                                                                  |
| [`c627a7e4`](https://github.com/NixOS/nixpkgs/commit/c627a7e4e7afa5e6d8c9879afca5d4cbf9e708d3) | `python3Packages.enaml: 0.13.0 -> 0.14.0`                                                                          |
| [`b1c6a1d4`](https://github.com/NixOS/nixpkgs/commit/b1c6a1d42bfd0f348cf968beeae842623ba51265) | `mepo: init at 0.2`                                                                                                |
| [`b7ada477`](https://github.com/NixOS/nixpkgs/commit/b7ada477f87847e8ced41affa5532d0d5302c04f) | `wireplumber: 0.4.6 → 0.4.7`                                                                                       |
| [`442dc01a`](https://github.com/NixOS/nixpkgs/commit/442dc01aacbe16aa16e61ba834e61ce3f939b1c7) | `rdma-core: 38.0 -> 38.1`                                                                                          |
| [`e6988fea`](https://github.com/NixOS/nixpkgs/commit/e6988feaac2829ad8c3f56d4138091a07a36befd) | `sqlcipher: sync flags with sqlite`                                                                                |
| [`f52d6fb3`](https://github.com/NixOS/nixpkgs/commit/f52d6fb31d3dde7ce4849de9a14e38d5293da723) | `sqlcipher: enable JSON1 extension`                                                                                |
| [`432c6278`](https://github.com/NixOS/nixpkgs/commit/432c6278446ea7aea5e10014fcd0f4dbaa5aef59) | `python3Packages.torchinfo: init at 1.6.2`                                                                         |
| [`f14e41ec`](https://github.com/NixOS/nixpkgs/commit/f14e41ecf98b6e0201f400e2203852103e4d999d) | `texlive.combine: pass --sort to mktexlsr`                                                                         |
| [`9fcb1258`](https://github.com/NixOS/nixpkgs/commit/9fcb1258a85c1281e282ca472d5cd468a391c631) | `texlive: 2021.20210408 -> 2021.20211227`                                                                          |
| [`7660d567`](https://github.com/NixOS/nixpkgs/commit/7660d567dddd29e6f94ad7f5b14428b0bffde986) | `texlive.bin.texlinks: fix build for darwin sandbox`                                                               |
| [`e16643f0`](https://github.com/NixOS/nixpkgs/commit/e16643f01d786625a128cae4c730ff124b80f6c9) | `logrotate: 3.18.1 -> 3.19.0`                                                                                      |
| [`aba6be08`](https://github.com/NixOS/nixpkgs/commit/aba6be0888dcb5e7d725be0827725fa1b20691ee) | `evolution-data-server: 3.42.2 -> 3.42.3`                                                                          |
| [`ff111388`](https://github.com/NixOS/nixpkgs/commit/ff11138831a203a94afa33a31c3cb1e8c186f423) | `discord-ptb: 0.0.26 -> 0.0.27`                                                                                    |
| [`a2710255`](https://github.com/NixOS/nixpkgs/commit/a2710255c988de1f8ab17edea20f13f8b6c70efe) | `flake.nix: Remove redundant module lambda`                                                                        |
| [`439d7d49`](https://github.com/NixOS/nixpkgs/commit/439d7d493dc74ecf3306091a5b17121ecedb444d) | `nixos: Add release note about vmVariant`                                                                          |
| [`6510ec5a`](https://github.com/NixOS/nixpkgs/commit/6510ec5acdd465a016e5671ffa99460ef70e6c25) | `nixos: Make system.build.vm a standard attribute based on vmVariant`                                              |
| [`4014fb6a`](https://github.com/NixOS/nixpkgs/commit/4014fb6a64bc5f68326fc08cbaa83475db1fae8e) | `nixos: Make system.build a lazyAttrsOf unspecified`                                                               |
| [`a0ad8dcd`](https://github.com/NixOS/nixpkgs/commit/a0ad8dcd354c67f084511e4ae78a27af83df95fd) | `flake.nix: lib.nixosSystem: Set system.build.vm* with lib.mkDefault`                                              |
| [`9fd9c617`](https://github.com/NixOS/nixpkgs/commit/9fd9c617a9c84293b67b2a43ca752b30565f2b88) | `nixos/lib/eval-config.nix: Return all of evalModules return attrs`                                                |
| [`537db623`](https://github.com/NixOS/nixpkgs/commit/537db62345147565ae592d2b6641a662e07a152a) | `flake.nix: Deduplicate vmConfig, vmWithBootloaderConfig`                                                          |
| [`f72432ae`](https://github.com/NixOS/nixpkgs/commit/f72432aeb2a3aa1d75bd56204571fb394fcc9abb) | `nixos: Move build-vm into virtualisation.vmVariant`                                                               |
| [`8fd49c11`](https://github.com/NixOS/nixpkgs/commit/8fd49c116bcd256263c7aad8ca5d4b7fa10d4ca2) | `nixos/default.nix: Use extendModules`                                                                             |