### PR TITLE
chore(flake/nixpkgs): `fd7e8516` -> `b47203b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,10 +2,7 @@
   "nodes": {
     "agenix": {
       "inputs": {
-        "nixpkgs": [
-          "ragenix",
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1641576265,
@@ -60,6 +57,21 @@
       "original": {
         "owner": "edolstra",
         "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -120,16 +132,46 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642195662,
-        "narHash": "sha256-bRRq9bJFzp2PSb7t4BMVAc8zapFEzpfcCprs7TNPIIc=",
+        "lastModified": 1642238013,
+        "narHash": "sha256-MMW3dkmhj6UwtzhgSjmrlaZVqaGXaU1DpIIi65LMCg0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fd7e851613488b079af50cbb4217d9ad6d7cd580",
+        "rev": "b47203b28f5cf1efc4e3476ca8f333db3a2c3223",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1642069818,
+        "narHash": "sha256-666w6j8wl/bojfgpp0k58/UJ5rbrdYFbI2RFT2BXbSQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "46821ea01c8f54d2a20f5a503809abfc605269d7",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1642069818,
+        "narHash": "sha256-666w6j8wl/bojfgpp0k58/UJ5rbrdYFbI2RFT2BXbSQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "46821ea01c8f54d2a20f5a503809abfc605269d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -198,14 +240,8 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "ragenix",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "ragenix",
-          "nixpkgs"
-        ]
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1641609771,


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`ab58c31e`](https://github.com/NixOS/nixpkgs/commit/ab58c31ecb3ebf597f63e30ce34e80f3da87c0e0) | `pythonPackages.timetagger: 21.11.2 -> 22.1.2`         |
| [`65aaf4e2`](https://github.com/NixOS/nixpkgs/commit/65aaf4e22dcf77a7559b4745f1e301059f9dff82) | `Add timetagger to release notes`                      |
| [`1f10b043`](https://github.com/NixOS/nixpkgs/commit/1f10b0434f96c8fc7b68ab32f245159e6dbc83fb) | `timetagger: Make enable option with mkOption`         |
| [`b90efe70`](https://github.com/NixOS/nixpkgs/commit/b90efe70883d5de9ccd4aa99f56f83b483fe4b97) | `pythonPackages.pscript: Add test inputs`              |
| [`6304e619`](https://github.com/NixOS/nixpkgs/commit/6304e619bca38074a1933a62993a87dee1df226f) | `pythonPackages.timetagger: Add test inputs`           |
| [`87419823`](https://github.com/NixOS/nixpkgs/commit/87419823ada3f19b0c5fc5cac26614b8c48417ac) | `pythonPackages.asgineer: Add test inputs`             |
| [`a24dc8d2`](https://github.com/NixOS/nixpkgs/commit/a24dc8d2ef61ccbd16f2a046c83be2e5ab2bdd9a) | `timetagger: Use default value for package option`     |
| [`f3eaf668`](https://github.com/NixOS/nixpkgs/commit/f3eaf668820a41ec78a6b6d8aedb078b4a87372e) | `Add service module for timetagger`                    |
| [`a2a43df9`](https://github.com/NixOS/nixpkgs/commit/a2a43df955355e4679acc04dc71a7c737950dd60) | `timetagger: init at 21.11.2`                          |
| [`e9d1e53c`](https://github.com/NixOS/nixpkgs/commit/e9d1e53c6ebbfe512d3fd8ea76a428eb7cf3a2e5) | `pythonPackages.asgineer: init at 0.8.1`               |
| [`4f44ede4`](https://github.com/NixOS/nixpkgs/commit/4f44ede48e9e8b8c2849f247f514d61e11149649) | `pythonPackages.itemdb: init at 1.1.1`                 |
| [`84ca2001`](https://github.com/NixOS/nixpkgs/commit/84ca20017bb8e36e11ebdf9ae9939230ba531fd9) | `pythonPackages.pscript: init at 0.7.6`                |
| [`079205c6`](https://github.com/NixOS/nixpkgs/commit/079205c6f9a7d9f82e18ab0ac062dd714cd5403e) | `maintainers: add derekcollison`                       |
| [`3b151fce`](https://github.com/NixOS/nixpkgs/commit/3b151fcec87a19f7d3e197d17c6ad43843b02073) | `hidrd: mark as broken on darwin`                      |
| [`bb08b954`](https://github.com/NixOS/nixpkgs/commit/bb08b95456ae497f1bd594889328867debc0f270) | `gthree: mark as broken on darwin`                     |
| [`a3720ac9`](https://github.com/NixOS/nixpkgs/commit/a3720ac9a1b5625f8f39fb50d61f13e627390576) | `xiphos: clean up dependencies`                        |
| [`7cf24465`](https://github.com/NixOS/nixpkgs/commit/7cf24465b2e971b2e7ea797a9654ad0205213765) | `xiphos: drop lucene`                                  |
| [`569eea8e`](https://github.com/NixOS/nixpkgs/commit/569eea8ec1ea42a83dda23fe00bc6c0d080bc93f) | `xiphos: do not use patchFlags`                        |
| [`94517ee0`](https://github.com/NixOS/nixpkgs/commit/94517ee0c77aebad0278a5e8888b86b66f8dad59) | `gnome2.gtkhtml4: do not use patchFlags`               |
| [`fe1ba3c9`](https://github.com/NixOS/nixpkgs/commit/fe1ba3c9be690ce82e3f008912cc6a50bb2cc4b3) | `xiphos: clean up the expression`                      |
| [`2efc9721`](https://github.com/NixOS/nixpkgs/commit/2efc97211316560936d8b69f6c5ce8e7af74ff8e) | `wluma: 2.0.1 -> 3.0.0 (#155059)`                      |
| [`08157484`](https://github.com/NixOS/nixpkgs/commit/081574842a69cecc73ca6c134eb6f02b5aaf64ed) | `wrangler: 1.19.6 -> 1.19.7 (#154459)`                 |
| [`31b1d005`](https://github.com/NixOS/nixpkgs/commit/31b1d00569111ee2e0649337b0c2f0f028352099) | `esbuild: 0.14.8 -> 0.14.11 (#154463)`                 |
| [`f51b5782`](https://github.com/NixOS/nixpkgs/commit/f51b5782da82f3f1085fa2a473232ee3fe6e6953) | `heisenbridge: 1.8.2 -> 1.10.0`                        |
| [`8a6cde91`](https://github.com/NixOS/nixpkgs/commit/8a6cde9143085d40886de34037c913323984e7f4) | `discord: add derivations for {x86_64,aarch64}-darwin` |
| [`ae1bee34`](https://github.com/NixOS/nixpkgs/commit/ae1bee344a09129db2c13d5564e632934b68cdaf) | `blightmud: init at 3.5.0`                             |
| [`36026bb0`](https://github.com/NixOS/nixpkgs/commit/36026bb0c4da767610f2a8eceaa1123e1b1cb2ae) | `linuxPackages.kvmfr: patch for 5.16`                  |
| [`c45b63bc`](https://github.com/NixOS/nixpkgs/commit/c45b63bcbfe364cc0d1c80321a55fae45125d0fe) | `exploitdb: 2022-01-11 -> 2022-01-14`                  |
| [`4369bebd`](https://github.com/NixOS/nixpkgs/commit/4369bebd9a32658ded22b580886587cdc577a29d) | `nixos/tests: remove broken prosody-mysql test`        |
| [`8b8fbbf1`](https://github.com/NixOS/nixpkgs/commit/8b8fbbf1fa5d8da120e89a279b646bf16760d30a) | `prosody:  0.11.10 -> 0.11.12`                         |
| [`e6acb6f5`](https://github.com/NixOS/nixpkgs/commit/e6acb6f5cb8b4dd89dde94151fc9a695cb1d78d1) | `python3Packages.logfury: adjust inputs`               |
| [`f86eb879`](https://github.com/NixOS/nixpkgs/commit/f86eb879a0adb7425e48e910e3e212946224224a) | `python3Packages.scrapy: disable failing test`         |
| [`97003d11`](https://github.com/NixOS/nixpkgs/commit/97003d11f001ca0c2bc5f5ac9540aee8e28ff386) | `python310Packages.bibtexparser: 1.1.0 -> 1.2.0`       |
| [`379ab505`](https://github.com/NixOS/nixpkgs/commit/379ab505d0b42238208fa87ae32d630b88bef98e) | `python310Packages.batchgenerators: remove unittest2`  |
| [`e956c766`](https://github.com/NixOS/nixpkgs/commit/e956c766327c95bf39a5a09f8c9c62d10d595ead) | `python3Packages.tifffile: refactor`                   |
| [`70126f0e`](https://github.com/NixOS/nixpkgs/commit/70126f0e4ac7b4df2becc34696e35a8e38837b55) | `ocamlPackages.progress: 0.1.1 → 0.2.1`                |
| [`94aeee3a`](https://github.com/NixOS/nixpkgs/commit/94aeee3af18511fed2712ba64b065bd554a8d0a7) | `ocamlPackages.vector: init at 1.0.0`                  |
| [`55eac498`](https://github.com/NixOS/nixpkgs/commit/55eac498436b38fe8630dea089cdd861e191130b) | `ocamlPackages.terminal: init at 0.2.1`                |
| [`7b71c6e7`](https://github.com/NixOS/nixpkgs/commit/7b71c6e756f0cb8fd56ebca0646bb786b535f7f0) | `python3Packages.roombapy: replace hbmqtt with amqtt`  |
| [`827da032`](https://github.com/NixOS/nixpkgs/commit/827da032023260cb3ff28f9f4bf1ad205c68f365) | `glitter: 1.5.11 -> 1.5.12`                            |
| [`2bf50427`](https://github.com/NixOS/nixpkgs/commit/2bf5042700a2c085c0b13dba22015a7fe3fda224) | `python3Packages.amqtt: 0.10.0 -> unstable-2022-01-11` |
| [`5eb7d1ed`](https://github.com/NixOS/nixpkgs/commit/5eb7d1ed25f83c591d4764b345b337bd5422cb6d) | `python3Packages.pytest-logdog: init at 0.1.0`         |
| [`2b7f7b4b`](https://github.com/NixOS/nixpkgs/commit/2b7f7b4b66a435df6651c619ca893a167a207854) | `python3Packages.transitions: disable failing tests`   |
| [`85c0199c`](https://github.com/NixOS/nixpkgs/commit/85c0199ce6c288141cf3c98d7b2673ce370db866) | `python3Packages.can: 3.3.4 -> unstable-2022-01-11`    |
| [`d14c5678`](https://github.com/NixOS/nixpkgs/commit/d14c5678306b71393619796c70d50ca07eb257cb) | `luna-icons: 1.8 -> 1.9`                               |
| [`2b9f8eb0`](https://github.com/NixOS/nixpkgs/commit/2b9f8eb0a27df820dc2ab77231e9c816cc95ad41) | `graphia: mark as broken on darwin`                    |
| [`69d78f17`](https://github.com/NixOS/nixpkgs/commit/69d78f174a80db9edc542dd8a384a8d6941ed66e) | `gplates: mark as broken on darwin`                    |
| [`ff372d0e`](https://github.com/NixOS/nixpkgs/commit/ff372d0ef113d714249c34a6bc53cb89d6635afe) | `spice-up: 1.8.2 -> 1.9.1`                             |
| [`85d37ab4`](https://github.com/NixOS/nixpkgs/commit/85d37ab46deb80a14c967fc273d6c76a42348103) | `python3Packages.homematicip: disable failing tests`   |
| [`d1838b51`](https://github.com/NixOS/nixpkgs/commit/d1838b51480573593f51242c6da0c7a628afd2d8) | `anytype: 0.22.3 -> 0.23.0`                            |
| [`e9675aa7`](https://github.com/NixOS/nixpkgs/commit/e9675aa7f9de1b65d8b62513acfc1c10ef6aaba5) | `python3Packages.dacite: disable failing test`         |
| [`ed1fdb90`](https://github.com/NixOS/nixpkgs/commit/ed1fdb90f219e0402494dbd92890be35741f3739) | `sumneko-lua-language-server: 2.5.6 -> 2.6.0`          |
| [`07151cbb`](https://github.com/NixOS/nixpkgs/commit/07151cbba5c93c433db261e9a291d3312a56166a) | `st: 0.8.4 → 0.8.5`                                    |
| [`20ccf2eb`](https://github.com/NixOS/nixpkgs/commit/20ccf2eba53dfd4818d722dd6e2f62c21678e978) | `ii: 1.8 → 1.9`                                        |
| [`4aa35b41`](https://github.com/NixOS/nixpkgs/commit/4aa35b41c256de1ee85bb7833e72b12e42938741) | `ft2-clone: 1.49 -> 1.50`                              |
| [`f49d9538`](https://github.com/NixOS/nixpkgs/commit/f49d95382eea61da124df341f7c800fe29ee3263) | `gnome: Drop old removed aliases`                      |
| [`e703bc0a`](https://github.com/NixOS/nixpkgs/commit/e703bc0ade3b6a3669f77d0acede1c2047e51fc2) | `gnome: Remove old aliases`                            |
| [`d85f289e`](https://github.com/NixOS/nixpkgs/commit/d85f289e17f2330d365be80debbe112b985b6f23) | `drone-cli: 1.4.0 -> 1.5.0`                            |
| [`e9efbc0b`](https://github.com/NixOS/nixpkgs/commit/e9efbc0bbb222cc90d14ba919f77bb198dd2d55f) | `nixos/tests/tinywl: init`                             |