### PR TITLE
chore(flake/nixpkgs): `b47203b2` -> `0a223c8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,10 +2,7 @@
   "nodes": {
     "agenix": {
       "inputs": {
-        "nixpkgs": [
-          "ragenix",
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1641576265,
@@ -60,6 +57,21 @@
       "original": {
         "owner": "edolstra",
         "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -120,16 +132,46 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642238013,
-        "narHash": "sha256-MMW3dkmhj6UwtzhgSjmrlaZVqaGXaU1DpIIi65LMCg0=",
+        "lastModified": 1642285376,
+        "narHash": "sha256-LfZBVKCrPOx5k9pUoJlRsBvdz7yn1qYHenCKuqwwFGo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b47203b28f5cf1efc4e3476ca8f333db3a2c3223",
+        "rev": "0a223c8d509cea6b4be3906f9c39820ff195fad2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1642069818,
+        "narHash": "sha256-666w6j8wl/bojfgpp0k58/UJ5rbrdYFbI2RFT2BXbSQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "46821ea01c8f54d2a20f5a503809abfc605269d7",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1642069818,
+        "narHash": "sha256-666w6j8wl/bojfgpp0k58/UJ5rbrdYFbI2RFT2BXbSQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "46821ea01c8f54d2a20f5a503809abfc605269d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -198,14 +240,8 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "ragenix",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "ragenix",
-          "nixpkgs"
-        ]
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1642214598,


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`1e4664e1`](https://github.com/NixOS/nixpkgs/commit/1e4664e1a0f78ef487cf0d7432a118e6f9a069cf) | `betaflight-configurator: 10.7.1 -> 10.7.2`                               |
| [`d5dae656`](https://github.com/NixOS/nixpkgs/commit/d5dae6569ea9952f1ae4e727946d93a71c507821) | `webdis: 0.1.16 -> 0.1.19`                                                |
| [`31f069f7`](https://github.com/NixOS/nixpkgs/commit/31f069f779ee739fba946ccc58521ebb57646b19) | `dictu: 0.22.0 -> 0.23.0`                                                 |
| [`4a94071f`](https://github.com/NixOS/nixpkgs/commit/4a94071fb3e4fddc8b98dc13104ac720eceb728c) | `mkgmap: 4836 -> 4855`                                                    |
| [`0c7342b6`](https://github.com/NixOS/nixpkgs/commit/0c7342b6e730ddbf6ba9a1bd596d8f8cab9356f2) | `horizon-eda: 2.1.0 -> 2.2.0`                                             |
| [`12098119`](https://github.com/NixOS/nixpkgs/commit/12098119d9ab25a467eaa85dc26901b63d188696) | `python2Packages.pyyaml: init at 5.4.1.1`                                 |
| [`2cb556b6`](https://github.com/NixOS/nixpkgs/commit/2cb556b6105da17706f7d29859c4b881684ba466) | `argocd: 2.2.1 -> 2.2.2 (#154369)`                                        |
| [`3d1b5e73`](https://github.com/NixOS/nixpkgs/commit/3d1b5e732b9cf4429ac7a17cf2d865f15dc15443) | `intel-media-driver: 22.1.0 -> 22.1.1`                                    |
| [`d654246e`](https://github.com/NixOS/nixpkgs/commit/d654246e6acdd40806b53d42aada4b21ab40fa14) | `mimeo: 2021.2 -> 2021.11`                                                |
| [`892a9971`](https://github.com/NixOS/nixpkgs/commit/892a9971b04a8e2d1661331469554b556ac620ae) | `signal-desktop: Fix "Failed to load GLES library: libGLESv2.so.2"`       |
| [`814c0ee7`](https://github.com/NixOS/nixpkgs/commit/814c0ee73ecf9fa9b370117056a1164030666ed8) | `CODEOWNERS: Add entries for a few Matrix-related applications`           |
| [`75d417c2`](https://github.com/NixOS/nixpkgs/commit/75d417c267b51c51587ec67af71b8a98ca358123) | `nixos/dokuwiki: Drop deprecated old interface (#152676)`                 |
| [`3f9ced9a`](https://github.com/NixOS/nixpkgs/commit/3f9ced9a62edea0f8e079825cf728a58c33e892f) | `swayidle: 1.7 -> 1.7.1`                                                  |
| [`60dec7aa`](https://github.com/NixOS/nixpkgs/commit/60dec7aa319dc620cd77ecae8ce48f5374450452) | `telescope: 0.7 -> 0.7.1`                                                 |
| [`2ced686d`](https://github.com/NixOS/nixpkgs/commit/2ced686d5b94ec67d66892257074ebe612b9292b) | `pythonInterpreters.pypy38_prebuilt: 7.3.6 -> 7.3.7`                      |
| [`731db182`](https://github.com/NixOS/nixpkgs/commit/731db1820d8bcb2c03f1a5288cf68ef7b56fbd90) | `pythonInterpreters.pypy27_prebuilt: 7.3.3 -> 7.3.6`                      |
| [`3469429c`](https://github.com/NixOS/nixpkgs/commit/3469429c39f09f0f6b848e76a1c24770bae02d83) | `prosody: remove outdated passthrough test reference`                     |
| [`c34b7c01`](https://github.com/NixOS/nixpkgs/commit/c34b7c0102595649f953c93c859f83b740e7d136) | `libxls: fix cross-compilation`                                           |
| [`5c8d6d6c`](https://github.com/NixOS/nixpkgs/commit/5c8d6d6cee72a39dd117f59a3a6a7c62329ae92d) | `doc: fix broken link`                                                    |
| [`79b8a3e2`](https://github.com/NixOS/nixpkgs/commit/79b8a3e26342acda4881c6d5a6644af9d827c349) | `blink1-tool: 1.98a -> 2.2.0`                                             |
| [`e8a7b9cd`](https://github.com/NixOS/nixpkgs/commit/e8a7b9cd2029cf08be9b148a60332735713689e9) | `v2ray-domain-list-community: 20211228022859 -> 20220114024213`           |
| [`570e93c2`](https://github.com/NixOS/nixpkgs/commit/570e93c25eb8020c53aeeb3c2acbecd464cc15a8) | `firefox-bin: 96.0 -> 96.0.1`                                             |
| [`4c3a07ff`](https://github.com/NixOS/nixpkgs/commit/4c3a07ffe02b369ef1f99dd855b651e92a10b32c) | `firefox: 96.0 -> 96.0.1`                                                 |
| [`9042e83c`](https://github.com/NixOS/nixpkgs/commit/9042e83cff13c726615969521ed348582b9f61e4) | `python.pkgs.roboschool: mark as removed`                                 |
| [`ba8ec8bf`](https://github.com/NixOS/nixpkgs/commit/ba8ec8bf860a0afa3c001025b046e4fe5232a339) | `jwt-cli: 5.0.0 -> 5.0.1`                                                 |
| [`d2c90ae4`](https://github.com/NixOS/nixpkgs/commit/d2c90ae47f816976466046d13a86d81750c7e63a) | `libplctag: 2.4.8 -> 2.4.10`                                              |
| [`97851190`](https://github.com/NixOS/nixpkgs/commit/978511905033f66f95c3fc659206d92953f67383) | `libzim: 7.0.0 -> 7.1.0`                                                  |
| [`0c0b0905`](https://github.com/NixOS/nixpkgs/commit/0c0b0905e73f7b6b8b9728bb6f6ba906f1f9cc3a) | `python3Packages.consonance: 0.1.3 -> 0.1.5`                              |
| [`003ed52f`](https://github.com/NixOS/nixpkgs/commit/003ed52fd1507daf2639b95979c8d41874971d86) | `python3Packages.exchangelib: 4.6.2 -> 4.7.0`                             |
| [`79e607c3`](https://github.com/NixOS/nixpkgs/commit/79e607c35195d45ea766450831b6f954099c30d5) | `electron: mark versions <= 12 as EOL`                                    |
| [`f45e0799`](https://github.com/NixOS/nixpkgs/commit/f45e0799993d4c30ae4b8e818713c3b74c68e611) | `love: updates, fetch from GitHub, refactor name to pname + version, etc` |
| [`1f9646ca`](https://github.com/NixOS/nixpkgs/commit/1f9646cad883a58634a1846d27f0c0bf353a5f48) | `starship: 1.1.1 -> 1.2.1`                                                |
| [`6b55249a`](https://github.com/NixOS/nixpkgs/commit/6b55249a5d0490fb4c00a8f0db677869ac643311) | `nixos/tests/ergochat: init`                                              |
| [`eaf8890a`](https://github.com/NixOS/nixpkgs/commit/eaf8890a6c665801d0fddb0d0285fed242be8b0d) | `nixos/ergochat: init`                                                    |
| [`07d7fdce`](https://github.com/NixOS/nixpkgs/commit/07d7fdce3e2186c28900a6ad3c278de7e15a625d) | `gitea: 1.15.9 -> 1.15.10`                                                |
| [`6910d932`](https://github.com/NixOS/nixpkgs/commit/6910d932219393679c1b634ea193d36d41497a53) | `home-assistant: 2021.12.8 -> 2021.12.9`                                  |
| [`b9db387e`](https://github.com/NixOS/nixpkgs/commit/b9db387e54c4a9eb3fee59cc021122da9b6b40b9) | `python3Packages.yalexs: 1.1.15 -> 1.1.17`                                |
| [`7d5be070`](https://github.com/NixOS/nixpkgs/commit/7d5be0709ba2ee27005425261faf4805cb48ed6f) | `python3Packages.hass-nabucasa: 0.50.0 -> 0.51.0`                         |
| [`9847bae8`](https://github.com/NixOS/nixpkgs/commit/9847bae85b9a20bfe0be5bbe36f1dbede84e314b) | `python3Packages.pycognito: 2021.03.1 -> 2022.01.0`                       |
| [`f632960d`](https://github.com/NixOS/nixpkgs/commit/f632960d9bd3fddb7764d3dd3d621054611079d2) | `python3Packages.aioharmony: 0.2.8 -> 0.2.9`                              |
| [`9f928fe9`](https://github.com/NixOS/nixpkgs/commit/9f928fe96960cf19c9e93fc5abb6537b2029e77c) | `grapejuice: 3.64.16 -> 4.10.2`                                           |
| [`a580c998`](https://github.com/NixOS/nixpkgs/commit/a580c99869a1a67dfc55321781046e6115652d29) | `github-changelog-generator: 1.14.3 -> 1.16.4`                            |
| [`9917a5cf`](https://github.com/NixOS/nixpkgs/commit/9917a5cf11ffc2e5dec598f7fe4eda1869c39095) | `nixos/tests/systemd-networkd-vrf: move disabled check inline`            |
| [`1eab8b2d`](https://github.com/NixOS/nixpkgs/commit/1eab8b2d6a34a9063931b5c0752a1479db7bc740) | `ergochat: init at 2.9.1`                                                 |
| [`ca1cddd1`](https://github.com/NixOS/nixpkgs/commit/ca1cddd15b366dc0cac086016e3e4533b89b88aa) | `gnomeExtensions.volume-mixer: add override to fix extension`             |
| [`507a4178`](https://github.com/NixOS/nixpkgs/commit/507a4178a4930362ca311a384a487576c0101dc2) | `lxqt.lxqt-globalkeys: 1.0.0 -> 1.0.1`                                    |
| [`9fa39c96`](https://github.com/NixOS/nixpkgs/commit/9fa39c9691ad060e049d61d248d123fedef7c5bd) | `python310Packages.tatsu: 5.7.1 -> 5.7.3`                                 |
| [`1c458270`](https://github.com/NixOS/nixpkgs/commit/1c458270e7adb3654afb51c47ba100b68f5ab56b) | `doppler: 3.36.2 -> 3.37.0`                                               |
| [`13e40916`](https://github.com/NixOS/nixpkgs/commit/13e40916acd56bd8b74d228d75f034c9749c5301) | `do-agent: 3.12.0 -> 3.13.0`                                              |
| [`2fe15274`](https://github.com/NixOS/nixpkgs/commit/2fe15274ec53219be2a2f9a8ba5d71795ba1090d) | `whois: 5.5.10 -> 5.5.11`                                                 |
| [`2b4b2f1a`](https://github.com/NixOS/nixpkgs/commit/2b4b2f1a4786f1fc66b64328f32bb17d4c0b81c2) | `chezmoi: 2.9.4 -> 2.9.5`                                                 |
| [`54b44d01`](https://github.com/NixOS/nixpkgs/commit/54b44d01c000aee41c336526e8b4502b30d28fee) | `checkstyle: 8.45.1 -> 9.2.1`                                             |
| [`18ec76af`](https://github.com/NixOS/nixpkgs/commit/18ec76afecd588a9b06e305a967e9b3ef6f3b6e3) | `cargo-release: 0.18.6 -> 0.19.0`                                         |
| [`4220fc15`](https://github.com/NixOS/nixpkgs/commit/4220fc15116ce1473395fd9ac99f0d13b0e6f82e) | `cargo-expand: 1.0.10 -> 1.0.13`                                          |
| [`a389c191`](https://github.com/NixOS/nixpkgs/commit/a389c191b4454396d994dda6827dee63c8243fbd) | `calc: 2.14.0.13 -> 2.14.0.14`                                            |
| [`4c29d01a`](https://github.com/NixOS/nixpkgs/commit/4c29d01a8f2159f14a45464c3737c0677e35f597) | `xd: 0.4.0 -> 0.4.2`                                                      |
| [`c73d9079`](https://github.com/NixOS/nixpkgs/commit/c73d90790c1508580ed964255ea56b8ea8c70fcb) | `adapta-backgrounds: fix cross compilation and set strictDeps`            |
| [`f5cd7567`](https://github.com/NixOS/nixpkgs/commit/f5cd7567d36340548b0ad8d6c756274aefb3ff12) | `dar: 2.7.1 -> 2.7.3`                                                     |
| [`89f0ae0b`](https://github.com/NixOS/nixpkgs/commit/89f0ae0b70a0dbf21947db3606f7c0ba73030ad5) | `cxxopts: unstable-2020-12-14 -> 3.0.0`                                   |
| [`0d92b8ae`](https://github.com/NixOS/nixpkgs/commit/0d92b8ae4eb03dfc518504c70aa6cd598a9d84ec) | `postgresql11Packages.plpgsql_check: 2.0.6 -> 2.1.0`                      |
| [`aea02423`](https://github.com/NixOS/nixpkgs/commit/aea02423ee49a9162d7ca137dc8b57319793bead) | `cargo-tarpaulin: 0.18.3 -> 0.18.5`                                       |