### PR TITLE
chore(flake/home-manager): `1477eb15` -> `46978d20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1642355281,
-        "narHash": "sha256-Y2G6pd6XtPKiZfxw4VKsLdaq3wohlByM4dIKdk3X05A=",
+        "lastModified": 1642356109,
+        "narHash": "sha256-OhZ6CiAi9pcMshon3Lmc1TTkdz+/AZmLsIYQ/Nt4ZIo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1477eb1555d780470fe5959aa6f60ba8b1fb608f",
+        "rev": "46978d2047a61f6db79826537138b6db8241bd37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                     |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`46978d20`](https://github.com/nix-community/home-manager/commit/46978d2047a61f6db79826537138b6db8241bd37) | `docs: add link to contributing chapter in readme` |
| [`b2592ae6`](https://github.com/nix-community/home-manager/commit/b2592ae67cab0a6fcd02fccdfe7a0ef80c1a2395) | `docs: fix typo`                                   |