### PR TITLE
chore(flake/home-manager): `46978d20` -> `46bba772`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1642356109,
-        "narHash": "sha256-OhZ6CiAi9pcMshon3Lmc1TTkdz+/AZmLsIYQ/Nt4ZIo=",
+        "lastModified": 1642372264,
+        "narHash": "sha256-SRnw7qcHmvUBxby925Vm+nhPqq7YVs1qquNqv7TRyVY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "46978d2047a61f6db79826537138b6db8241bd37",
+        "rev": "46bba772f26f89b62811f487d2b0d5357c91bc32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`46bba772`](https://github.com/nix-community/home-manager/commit/46bba772f26f89b62811f487d2b0d5357c91bc32) | `modules/misc/news.nix: fix instructions (#2643)` |