### PR TITLE
chore(flake/home-manager): `46bba772` -> `986cf41b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1642372264,
-        "narHash": "sha256-SRnw7qcHmvUBxby925Vm+nhPqq7YVs1qquNqv7TRyVY=",
+        "lastModified": 1642375172,
+        "narHash": "sha256-6q9Tfu5fw2IGoHXIAZb09yq1TOvCaPH5rCrNyau4+w4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "46bba772f26f89b62811f487d2b0d5357c91bc32",
+        "rev": "986cf41b3bf1936b9d06ef0958683f376f1319d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`986cf41b`](https://github.com/nix-community/home-manager/commit/986cf41b3bf1936b9d06ef0958683f376f1319d9) | `kitty: Allow package to be configurable (#2640)` |