### PR TITLE
chore(flake/nixpkgs): `0a223c8d` -> `b13052a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642285376,
-        "narHash": "sha256-LfZBVKCrPOx5k9pUoJlRsBvdz7yn1qYHenCKuqwwFGo=",
+        "lastModified": 1642373004,
+        "narHash": "sha256-AZ1fTklT9OkLFtmZ8qMbQ2Uf1dF0+np3WjnTIIquApA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0a223c8d509cea6b4be3906f9c39820ff195fad2",
+        "rev": "b13052a35a63e1ea9eba916ffe48886ab7af58ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`3a82e3cc`](https://github.com/NixOS/nixpkgs/commit/3a82e3cc939998e3bf604c55b93474689a724cab) | `nodePackages.thelounge: add winter to maintainers`                                 |
| [`cf12e0e7`](https://github.com/NixOS/nixpkgs/commit/cf12e0e7ed02b91b202e68d15f045b6982f22d71) | `nixos/thelounge: add test`                                                         |
| [`bbfca6b6`](https://github.com/NixOS/nixpkgs/commit/bbfca6b6b9f6f79994c4fb82bd13629b4ba759cc) | `nixos/prosody-filer: remove usage of literalExample`                               |
| [`f60b7917`](https://github.com/NixOS/nixpkgs/commit/f60b7917bfa2ea1c5bebf720dcadfa5e3ced8a18) | `n2048: refactor`                                                                   |
| [`74168b1f`](https://github.com/NixOS/nixpkgs/commit/74168b1feaf84b6ed4573e5adce7472b13791d8e) | `yex-lang: minor adjustements (#155229)`                                            |
| [`1ab07956`](https://github.com/NixOS/nixpkgs/commit/1ab0795642b66a1d6f0cee1f64a88759fce8691d) | `python3Packages.cozy: remove (#154903)`                                            |
| [`c875cdce`](https://github.com/NixOS/nixpkgs/commit/c875cdce3fbc4264734c919d7cdd4aa65e6ac6d9) | `lemmy: 0.14.0 -> 0.15.1 (#155236)`                                                 |
| [`cf3c3da4`](https://github.com/NixOS/nixpkgs/commit/cf3c3da4699f018c8907a224b14bbea2bbf1a493) | `vimPlugins.vim-markdown-composer: update cargoSha256`                              |
| [`03bfd9f5`](https://github.com/NixOS/nixpkgs/commit/03bfd9f53e4fa2f82b88296ff029fb03968a6e73) | `barcode: pull upstream fix for -fno-common toolchains`                             |
| [`90af6344`](https://github.com/NixOS/nixpkgs/commit/90af6344ab0c62ff654ed4c64ad87e53a382e439) | `apache-jena: refactor, apache-jena-fuseki: refactor`                               |
| [`72f9a086`](https://github.com/NixOS/nixpkgs/commit/72f9a08648a27096b9a176a12b1e09573244adb6) | `PageEdit: init at 1.7.0 (#153403)`                                                 |
| [`4b775ed5`](https://github.com/NixOS/nixpkgs/commit/4b775ed53fb40936cdbc83db185e24aedd5b98ef) | `kodi.packages.trakt: init at 3.5.0`                                                |
| [`e58344d0`](https://github.com/NixOS/nixpkgs/commit/e58344d08e761cba6c6c6620fd8939d112aba5d3) | `kodi.packages.trakt-py: init at 4.4.0`                                             |
| [`a1ed2b84`](https://github.com/NixOS/nixpkgs/commit/a1ed2b8400f043effcaeeebb6c1a2065c8e09372) | `kodi.packages.arrow: init at 1.0.3.1`                                              |
| [`6a7da24a`](https://github.com/NixOS/nixpkgs/commit/6a7da24a485051fb3286bc778b93533b7c015bfa) | `kodi.packages.typing_extensions: init at 3.7.4.3`                                  |
| [`21046086`](https://github.com/NixOS/nixpkgs/commit/2104608642f3be6671ace4d6d9b29837cbf4ad2b) | `nixos/borgbackup: allow empty archive base name`                                   |
| [`7b38dfca`](https://github.com/NixOS/nixpkgs/commit/7b38dfca529f783003b6a07ac238abe5ab029e2c) | `python3Packages.pony: 0.7.14 -> 0.7.15rc1`                                         |
| [`34950c73`](https://github.com/NixOS/nixpkgs/commit/34950c73596cd2a8369d929cd5dd412a5ca308e0) | `sinit: refactor`                                                                   |
| [`66370f4f`](https://github.com/NixOS/nixpkgs/commit/66370f4f12a3cd5bb66c3c9a070a77b5c2cbe9ab) | `cubiomes-viewer: init at 1.12.1`                                                   |
| [`baf11b26`](https://github.com/NixOS/nixpkgs/commit/baf11b26b230974157e0e5507411661393fd47bc) | `mold: set enableParallelBuilding = true`                                           |
| [`b755af85`](https://github.com/NixOS/nixpkgs/commit/b755af85fc17d0962934019db35488fb6b56dbb1) | `yex-lang: init at unstable-2021-12-25`                                             |
| [`81712905`](https://github.com/NixOS/nixpkgs/commit/81712905af5b544af318ca97714b70e25a4b676f) | `python3Packages.identify: 2.4.3 -> 2.4.4`                                          |
| [`438b4fd0`](https://github.com/NixOS/nixpkgs/commit/438b4fd0e32c3fe746505ad80b5612468e2121d8) | `opentracker: mark linux only`                                                      |
| [`2a1ff6dd`](https://github.com/NixOS/nixpkgs/commit/2a1ff6dd5140f3e7eae4446547ab53470ca6bad1) | `python3Packages.python-kasa: 0.4.0 -> 0.4.1`                                       |
| [`65b77d8a`](https://github.com/NixOS/nixpkgs/commit/65b77d8aaa1b79185ff02505ad00d980bd5218fd) | `lsd: 0.20.1 -> 0.21.0`                                                             |
| [`a8affa91`](https://github.com/NixOS/nixpkgs/commit/a8affa912c883c59f7052779a2440c796715ced8) | `chromium: Backport important fixes for Wayland`                                    |
| [`71523a4e`](https://github.com/NixOS/nixpkgs/commit/71523a4e7e999976259650d72a831fd26e026557) | `python3Packages.teslajsonpy: 1.4.2 -> 1.5.0`                                       |
| [`8eb05125`](https://github.com/NixOS/nixpkgs/commit/8eb05125ef93f013198b0047699515bb38cd1b80) | `python3Packages.nexia: 0.9.12 -> 0.9.13`                                           |
| [`fb9ce2d9`](https://github.com/NixOS/nixpkgs/commit/fb9ce2d9f25b5d61e04f7e78a6666869e5f6c6bc) | `python3Packages.sense-energy: 0.9.3 -> 0.9.4`                                      |
| [`d5026c33`](https://github.com/NixOS/nixpkgs/commit/d5026c33182093d2984c348df541d8b912bdd7d6) | `python3Packages.aiogithubapi: 21.11.0 -> 22.1.0`                                   |
| [`f0996f2d`](https://github.com/NixOS/nixpkgs/commit/f0996f2d22216c9468205b1ae207d89bfa48fd8e) | `python3Packages.pyrogram: 1.3.1 -> 1.3.5`                                          |
| [`6652fefd`](https://github.com/NixOS/nixpkgs/commit/6652fefdabef78b468eb75cc40e15704cc324d7c) | `timeline: use newer wxPython`                                                      |
| [`d63c752b`](https://github.com/NixOS/nixpkgs/commit/d63c752b0062861fc0c45adc9db0e1379b353a88) | `python3Packages.graph-tool: rename file`                                           |
| [`4bf9e61a`](https://github.com/NixOS/nixpkgs/commit/4bf9e61a76ba26a8b61b3fafebfd8d8e5f9613f4) | `python3Packages.pytest_5: remove`                                                  |
| [`470fdb30`](https://github.com/NixOS/nixpkgs/commit/470fdb307a9ae2c9b309c1e55d97a2c05ef01b8e) | `python36Packages.ipython: remove`                                                  |
| [`ea222b17`](https://github.com/NixOS/nixpkgs/commit/ea222b17d1af9fe42f21741f4c818774ba78efaf) | `python-modules: remove unused secretstorage/2.nix`                                 |
| [`ae18d68b`](https://github.com/NixOS/nixpkgs/commit/ae18d68b6b117528e6cd72325ead36b48562d43f) | `python2.pkgs: move expressions into python2-modules/ folder`                       |
| [`2027fb60`](https://github.com/NixOS/nixpkgs/commit/2027fb600d891379c53c4762463e65d040359682) | `alot: application instead of python library`                                       |
| [`bbf10ee6`](https://github.com/NixOS/nixpkgs/commit/bbf10ee6a8946a3308bae6a14dda29119ca1cc78) | `krita: 5.0.0 -> 5.0.2`                                                             |
| [`226586e5`](https://github.com/NixOS/nixpkgs/commit/226586e56943aacb314c1fe78ff048f58e529c8d) | `python3Packages.mitogen: 0.3.0 -> 0.3.2`                                           |
| [`f92cb93d`](https://github.com/NixOS/nixpkgs/commit/f92cb93d5fda54149f63a8ea704f84baf5d3a058) | `python3Packages.meshtastic: 1.2.54 -> 1.2.56`                                      |
| [`629605c2`](https://github.com/NixOS/nixpkgs/commit/629605c2ac3418672d2a9985d5d20172f1797c83) | `python3Packages.bimmer-connected: 0.8.7 -> 0.8.10`                                 |
| [`979e54b0`](https://github.com/NixOS/nixpkgs/commit/979e54b0ea0d10844afbc7424dda179ee92ae349) | `doit: 0.33.1 -> 0.34.0`                                                            |
| [`8c946f4b`](https://github.com/NixOS/nixpkgs/commit/8c946f4baa56ca966c26aea7bea1f161e82e274f) | `python38Packages.sopel: 7.1.6 -> 7.1.7`                                            |
| [`7c1d6cfb`](https://github.com/NixOS/nixpkgs/commit/7c1d6cfb95373af83148c57551650179ae2ae17e) | `gnuradio3_7: remove`                                                               |
| [`0a780fe3`](https://github.com/NixOS/nixpkgs/commit/0a780fe392341e84fa20ca1b2b0e079c54659bc7) | `python38Packages.irc: 19.0.1 -> 20.0.0`                                            |
| [`9cf1c7c4`](https://github.com/NixOS/nixpkgs/commit/9cf1c7c4a7b67d1aa750e21f8c88ddc21d34f858) | `python38Packages.transformers: 4.12.5 -> 4.15.0`                                   |
| [`08e95726`](https://github.com/NixOS/nixpkgs/commit/08e9572677967f0245b6defd3f3d97c6d7f44d89) | `python38Packages.pybotvac: 0.0.22 -> 0.0.23`                                       |
| [`209326c6`](https://github.com/NixOS/nixpkgs/commit/209326c600b2031deb0b7465a2a5b2a3d3debc44) | `pythonPackages.python-miio: 0.5.9.1 -> 0.5.9.2`                                    |
| [`2f99db6b`](https://github.com/NixOS/nixpkgs/commit/2f99db6b3e6f8364c6edff70622ec48b501cc52d) | `python38Packages.pyatv: 0.9.7 -> 0.9.8`                                            |
| [`c4777aeb`](https://github.com/NixOS/nixpkgs/commit/c4777aeb997da3583f8c72b0939ed653d3fd30cb) | `python38Packages.sagemaker: 2.70.0 -> 2.72.2`                                      |
| [`5ec497a2`](https://github.com/NixOS/nixpkgs/commit/5ec497a248608c2d4bdf340c76057ce3779bb589) | `python38Packages.pytelegrambotapi: 4.2.1 -> 4.3.0`                                 |
| [`97a0cf62`](https://github.com/NixOS/nixpkgs/commit/97a0cf62f098d21a31c4dc03294e4919e88c225f) | `keycloak service: allow to set empty frontend URL`                                 |
| [`84f70eef`](https://github.com/NixOS/nixpkgs/commit/84f70eefd1c4f90e892164afa39931a9fc5ba8db) | `keycloak service: add themes support`                                              |
| [`6a0de2a2`](https://github.com/NixOS/nixpkgs/commit/6a0de2a2f2b4cf0f9bd963ab70e277c65dd03d29) | `python3Packages.mlflow: Fix broken package`                                        |
| [`134fa81d`](https://github.com/NixOS/nixpkgs/commit/134fa81d6dd39a07fa5d00aa9029bbf25f71bf58) | `python3Packages.pywayland: 0.4.7 -> 0.4.8`                                         |
| [`ec01395f`](https://github.com/NixOS/nixpkgs/commit/ec01395f811a1987f4210383cbdaba2569edac46) | `python3Packages.sentry-sdk: 1.5.1 -> 1.5.2`                                        |
| [`1f858b31`](https://github.com/NixOS/nixpkgs/commit/1f858b31c6e67cbfd327996142b0279ae3604be4) | `python3Packages.pyhiveapi: 0.4.3 -> 0.4.6`                                         |
| [`d83a1a48`](https://github.com/NixOS/nixpkgs/commit/d83a1a4846112195f9a1fca4fd1c042e8b70b7cc) | `python3Packages.pikepdf: 4.3.0 -> 4.3.1`                                           |
| [`1b5158c4`](https://github.com/NixOS/nixpkgs/commit/1b5158c4bc0d5e13b715e9d11ea100e9c4e77018) | `python3Packages.greeclimate: 1.0.1 -> 1.0.2`                                       |
| [`3cef3028`](https://github.com/NixOS/nixpkgs/commit/3cef3028c2a691a781ceeddf5f2ae640f7a04b5e) | `python3Packages.drf-jwt: 1.19.1 -> 1.19.2`                                         |
| [`a42abe27`](https://github.com/NixOS/nixpkgs/commit/a42abe27c0b58749f1c563fc77305d145c739746) | `keycloak service: use 'attrsOf anything' for extraConfig`                          |
| [`827267a2`](https://github.com/NixOS/nixpkgs/commit/827267a27f300a8fe503986da2570bc3b9252e69) | `keycloak service: update HTTPS configuration`                                      |
| [`3c7e78cc`](https://github.com/NixOS/nixpkgs/commit/3c7e78cc6ab73ca9b0dbcb376122befa59098300) | `keycloak service: ordering for CLI script`                                         |
| [`e24c1567`](https://github.com/NixOS/nixpkgs/commit/e24c1567a6ebcbfc37b5fedcca695593ac37be5c) | `i3lock-blur: mark as broken on darwin`                                             |
| [`cef5f8db`](https://github.com/NixOS/nixpkgs/commit/cef5f8dba6ba9175bd40ba71b4b60e0f0b2eaf5f) | `notion-app-enhanced: 2.0.16-5 -> 2.0.18-1`                                         |
| [`d5744cff`](https://github.com/NixOS/nixpkgs/commit/d5744cffdc9f77b79b58ff175c6611a3ae4e11ef) | `abcmidi: 2021.12.12 -> 2022.01.13`                                                 |
| [`b254d2b1`](https://github.com/NixOS/nixpkgs/commit/b254d2b1fefa96aed7f832ba5f1ab792ff50b8c4) | `minecraftServers: init - move all minecraft-server versions into minecraftServers` |
| [`e0843a80`](https://github.com/NixOS/nixpkgs/commit/e0843a80e2a77888866d10482372894ad051ec8a) | `minecraft-server: fix using latest jre for all minecraft server versions`          |
| [`63c488bf`](https://github.com/NixOS/nixpkgs/commit/63c488bf3b2bca92d6a564ba42a4a25e63be48a1) | `minecraft-server: add jyooru as maintainer`                                        |
| [`867b8e21`](https://github.com/NixOS/nixpkgs/commit/867b8e2188cbe46cee7385b11750dde16f805570) | `minecraft-server: package major versions`                                          |
| [`29f997ef`](https://github.com/NixOS/nixpkgs/commit/29f997efd8392db6ed39360ac223a20d80432548) | `python3Packages.hangups: 0.4.15 -> 0.4.17`                                         |
| [`554616d5`](https://github.com/NixOS/nixpkgs/commit/554616d5eda58b55702a63846b234d561540e4ec) | `python3Packages.fiona: drop gdal_2 pin`                                            |
| [`8afa8e93`](https://github.com/NixOS/nixpkgs/commit/8afa8e93b4e76b603a532514d9e6df9d7c1c8ce4) | `python3Packages.rasterio: drop gdal_2 pin`                                         |
| [`3c0752db`](https://github.com/NixOS/nixpkgs/commit/3c0752dbe0b6bf8b700725bcd4ef1bb66538bd38) | `displaycal: drop`                                                                  |
| [`03ddc5b2`](https://github.com/NixOS/nixpkgs/commit/03ddc5b29511cbedeff6fe49951ad6ed80b36c65) | `mididings: drop`                                                                   |
| [`0a29b6bc`](https://github.com/NixOS/nixpkgs/commit/0a29b6bcd1f87fae4dcc2d200b25b88501802e7e) | `getmail: drop`                                                                     |
| [`308e8396`](https://github.com/NixOS/nixpkgs/commit/308e8396b73947dca793085a0377c32d1b477dfe) | `ino: drop`                                                                         |
| [`fa0e52a9`](https://github.com/NixOS/nixpkgs/commit/fa0e52a9182b799f1fa9475d80210951bc199722) | `vigra: use python3`                                                                |
| [`9cdd711a`](https://github.com/NixOS/nixpkgs/commit/9cdd711a66b7d383ed61adfa7c37b570ee46a5b3) | `systemtap: use python3`                                                            |
| [`88b69dbc`](https://github.com/NixOS/nixpkgs/commit/88b69dbcbc5ae086ea93d8ba9eba059c0cde5ec9) | `quickder: use python3`                                                             |
| [`b8594d2b`](https://github.com/NixOS/nixpkgs/commit/b8594d2b00755fe4d740b5e5be54815653d81638) | `opae: use python3`                                                                 |
| [`6bcbf84f`](https://github.com/NixOS/nixpkgs/commit/6bcbf84fb188ce60d06510bfcb282e19fdad02d8) | `git-crecord: 20161216.0 -> 20201025.0`                                             |
| [`33610bfe`](https://github.com/NixOS/nixpkgs/commit/33610bfeca7469cf4cb698ec8208849357de8e7e) | `gitinspector: drop`                                                                |
| [`878c9204`](https://github.com/NixOS/nixpkgs/commit/878c920437255850408c8f9777ace404d362a630) | `gdal: use python3`                                                                 |
| [`492e5e07`](https://github.com/NixOS/nixpkgs/commit/492e5e07c9f2d622e776fcc2887ecded5edf0a43) | `lumpy: drop`                                                                       |
| [`369db3b2`](https://github.com/NixOS/nixpkgs/commit/369db3b2f321c8fe263084dd876dfb3a330b36cf) | `mailpile, nixos/mailpile: drop`                                                    |
| [`608cde3b`](https://github.com/NixOS/nixpkgs/commit/608cde3bd4485d8e0337dc9495ed3909459a052a) | `metamorphose2: drop`                                                               |
| [`4a1da0be`](https://github.com/NixOS/nixpkgs/commit/4a1da0bed973596414962755ac6cafc0479550c6) | `neap: drop`                                                                        |
| [`5d0261b4`](https://github.com/NixOS/nixpkgs/commit/5d0261b438867a1af13cc8c1b22228e6991d59c1) | `curaByDagoma: drop`                                                                |
| [`dda538b1`](https://github.com/NixOS/nixpkgs/commit/dda538b172517b4c2344fdbcacf1aca2635a2826) | `renpy: drop`                                                                       |
| [`78bc359e`](https://github.com/NixOS/nixpkgs/commit/78bc359e037c846b566d49e2a7fd829c94a8a58a) | `python2Packages.cjson: drop`                                                       |
| [`33df2ffa`](https://github.com/NixOS/nixpkgs/commit/33df2ffa0a5e666f9fd9a2a836b2ff4f96224e6d) | `blink: drop`                                                                       |
| [`802f80b5`](https://github.com/NixOS/nixpkgs/commit/802f80b50c60bedc8bcb0ebb02cf39c91bff7622) | `pyrex, pyrex096, pyrex095: drop`                                                   |
| [`6c67bfc9`](https://github.com/NixOS/nixpkgs/commit/6c67bfc98618b2ac2cb68e12fed394bdbb285494) | `cde-gtk-theme: drop`                                                               |
| [`4a065e56`](https://github.com/NixOS/nixpkgs/commit/4a065e569ba568ec708100bf20a49d0521ebe02c) | `solo2-cli: init at 0.1.1`                                                          |
| [`1f71224f`](https://github.com/NixOS/nixpkgs/commit/1f71224fe86605ef4cd23ed327b3da7882dad382) | `nixos/modules/rename: Sort alphabetically`                                         |
| [`61265ec0`](https://github.com/NixOS/nixpkgs/commit/61265ec0b4176678aa776d901ace3d5191728b65) | `home-assistant: outsource component tests`                                         |
| [`cca85c7c`](https://github.com/NixOS/nixpkgs/commit/cca85c7c3d1e4708b89a92d5bd11200aa2d6675a) | `tailscale: 1.18.2 -> 1.20.1`                                                       |
| [`c2ab1f23`](https://github.com/NixOS/nixpkgs/commit/c2ab1f2380063a923c34ddc344a23dcd87ba939a) | `python38Packages.cx_Freeze: 6.8.4 -> 6.9`                                          |
| [`6054fb82`](https://github.com/NixOS/nixpkgs/commit/6054fb82d5e5351d6432f57bd66de64723fe53ba) | `python3Packages.rpi-bad-power: init at 0.1.0`                                      |
| [`6cb5b31d`](https://github.com/NixOS/nixpkgs/commit/6cb5b31dc4a3e37309696f127adb740fa4c2d86a) | `home-assistant: prune overrides`                                                   |
| [`155f3153`](https://github.com/NixOS/nixpkgs/commit/155f315319cac7136db5f048b4341b34a370ae18) | `multimc: document replacement`                                                     |
| [`f4ef2647`](https://github.com/NixOS/nixpkgs/commit/f4ef264724d836112ec906f516a89b0193c3f546) | `polymc: init at 1.0.4`                                                             |
| [`9dcc01f0`](https://github.com/NixOS/nixpkgs/commit/9dcc01f0f5d62fbb6fb75cb89c01b139baa03f97) | `python38Packages.scikits-odes: 2.6.2 -> 2.6.3`                                     |
| [`3ee20629`](https://github.com/NixOS/nixpkgs/commit/3ee206291a20b2d18e651c77bf161ef42108901f) | `linux: enable BPF_UNPRIV_DEFAULT_OFF between 5.10 and 5.15`                        |
| [`1bc66cb8`](https://github.com/NixOS/nixpkgs/commit/1bc66cb8423de33846e3c88e083a2a008fd182e3) | `nerdctl: 0.15.0 -> 0.16.0`                                                         |
| [`d8062c34`](https://github.com/NixOS/nixpkgs/commit/d8062c345d08c7c3545bf11141faad5eeb2caf66) | `colima: 0.3.1 -> 0.3.2`                                                            |
| [`89ddab6c`](https://github.com/NixOS/nixpkgs/commit/89ddab6c82ec3fa7f0ef28fbbfc4493aaea82b0f) | `cloudflared: 2021.12.3 -> 2022.1.2`                                                |
| [`ca74d2fa`](https://github.com/NixOS/nixpkgs/commit/ca74d2faaae268caa975e4a648b574297d4e4719) | `nats-server: 2.6.3 -> 2.7.0`                                                       |
| [`08232177`](https://github.com/NixOS/nixpkgs/commit/0823217739d553efdd8b98ea25e72c9dec25ff95) | `gnuradio3_8.pkgs.osmosdr: 0.2.2 -> 0.2.3`                                          |
| [`d21fa199`](https://github.com/NixOS/nixpkgs/commit/d21fa199ae37ef9e6e8cb672b08902c2818884d2) | `gnuradio.pkgs: Remove redundent null attributes`                                   |
| [`dbda4fc2`](https://github.com/NixOS/nixpkgs/commit/dbda4fc20c937282e9965fe56995d6e935632529) | `gnuradio.pkgs.grnet: disable for GR 3.10`                                          |
| [`1794554a`](https://github.com/NixOS/nixpkgs/commit/1794554a9aa7dccc6a1b42b50402cb88c10c1d7d) | `gnuradio: 3.9 -> 3.10`                                                             |
| [`b648a474`](https://github.com/NixOS/nixpkgs/commit/b648a4742effbfbf9da7196f016fa5d68ff9c356) | `skawarePackages.buildPackage: reformat with nixpkgs-fmt`                           |
| [`bb888535`](https://github.com/NixOS/nixpkgs/commit/bb8885351616ccab0f399614d2365a2a0ac71583) | `skawarePackages: fix llvm build`                                                   |
| [`51077332`](https://github.com/NixOS/nixpkgs/commit/510773323bcc8eaa57f965791f0bac57cb862c96) | `nsync: apply suggestions from code review`                                         |
| [`b241f314`](https://github.com/NixOS/nixpkgs/commit/b241f3143a4f14e1bda901c4132cdd69443152b8) | `diffoscope: 197 -> 200`                                                            |
| [`610b8b22`](https://github.com/NixOS/nixpkgs/commit/610b8b2210428080020d00ec0e083fb54fedaf1f) | `Cleanup: Factor out lib for metadata`                                              |
| [`57c9949a`](https://github.com/NixOS/nixpkgs/commit/57c9949a64a32681d5305a3f3f103c2e9422c192) | `license: gpl2Plus`                                                                 |
| [`3db46978`](https://github.com/NixOS/nixpkgs/commit/3db469781ad1de6f667d55b9f4cb88db127b5b77) | `Update pkgs/data/themes/lightly-qt/default.nix`                                   |
| [`b0d472b8`](https://github.com/NixOS/nixpkgs/commit/b0d472b8e7403ef9fcb9cecd7ab7b596b0324e72) | `Fix styling`                                                                       |
| [`be7e5971`](https://github.com/NixOS/nixpkgs/commit/be7e5971739da2cf4928b63c44f4071a21217780) | `lightly-qt: init at 0.4.1`                                                         |
| [`23e1f0d0`](https://github.com/NixOS/nixpkgs/commit/23e1f0d0131bc82208db0784b4c85e0b750af74c) | `python310Packages.tatsu: Fix the build`                                            |
| [`9b394d9d`](https://github.com/NixOS/nixpkgs/commit/9b394d9dbff1223393052b3b7f789a64f0a6d9d4) | `fceux: 2.5.0 -> 2.6.0`                                                             |
| [`f3516813`](https://github.com/NixOS/nixpkgs/commit/f3516813d829ac711d044da9aac8aecc7f628c46) | `thermald: disable network access`                                                  |
| [`7417f5b9`](https://github.com/NixOS/nixpkgs/commit/7417f5b981c863d284395cd2cd7d9cbe28c9aa11) | `ipget: 0.7.0 -> 0.8.0`                                                             |
| [`15087b82`](https://github.com/NixOS/nixpkgs/commit/15087b82725755fbae5c985e94880a1db5c25be7) | `dvc: 0.24.3 -> 2.9.3`                                                              |
| [`688cbf96`](https://github.com/NixOS/nixpkgs/commit/688cbf96965d545a959323fc508b2e06fa353f28) | `python3Packages.python-benedict: init at 0.24.3`                                   |
| [`03f587e5`](https://github.com/NixOS/nixpkgs/commit/03f587e5264a15d9e6b73da78256f4bcc21641d9) | `python3Packages.python-fsutil: init at 0.5.0`                                      |
| [`8b77b0ca`](https://github.com/NixOS/nixpkgs/commit/8b77b0ca84b21dec77073fbad87e773e4f10aed7) | `python3Packages.mailchecker: init at 4.1.8`                                        |
| [`9ff6000a`](https://github.com/NixOS/nixpkgs/commit/9ff6000a29556b6322efb425fd06553a5d8ecf81) | `python3Packages.aiohttp-retry: init at 2.5.6`                                      |
| [`5c401b54`](https://github.com/NixOS/nixpkgs/commit/5c401b54421efbdf56e4fde560bbaead4f1bc0a7) | `python3Packages.scmrepo: init at 0.0.7`                                            |
| [`c2526743`](https://github.com/NixOS/nixpkgs/commit/c2526743ddb15a35015c414a00a96db3abbaa950) | `lunatic: 0.7.0 -> 0.7.4`                                                           |
| [`8a1cb86e`](https://github.com/NixOS/nixpkgs/commit/8a1cb86eb9c7fda44b0a152c753122950c2110c0) | `python3Packages.dictdiffer: init at 0.9.0`                                         |
| [`581861a7`](https://github.com/NixOS/nixpkgs/commit/581861a7c0e14714f1876a7454fff331e6a622ed) | `python3Packages.flatten-dict: init at 0.4.2`                                       |
| [`6c3e84d2`](https://github.com/NixOS/nixpkgs/commit/6c3e84d2cb14610cf053299400442a30ac6f1ae5) | `python3Packages.shtab: init at 1.5.3`                                              |
| [`80cb7d89`](https://github.com/NixOS/nixpkgs/commit/80cb7d891bd082011d9a68ceeba323bc9e18850b) | `arkade: 0.8.11 -> 0.8.12`                                                          |
| [`eb4fd7e7`](https://github.com/NixOS/nixpkgs/commit/eb4fd7e716c210684fef1e54348802b1c065a952) | `nsync: init at 1.24.0`                                                             |
| [`6639cd8c`](https://github.com/NixOS/nixpkgs/commit/6639cd8c652dcd99862b852766272fc2136f47da) | ``sgx-ssl: don't run test app in `installCheckPhase```                              |
| [`499c06a1`](https://github.com/NixOS/nixpkgs/commit/499c06a14fc11ac144f5f35ec3686470d5ccf522) | `flameshot: 0.10.2 -> 11.0.0`                                                       |
| [`cfbcb36a`](https://github.com/NixOS/nixpkgs/commit/cfbcb36a86fd3f1b6268088272ddb008053c922a) | `python3Packages.grandalf: 0.6 -> 0.7`                                              |
| [`63971d1f`](https://github.com/NixOS/nixpkgs/commit/63971d1fdae3e4776a7fd382ee6148a741b5176b) | `nixos/ddclient: don't chown secrets until dynamicuser issue is resolved`           |
| [`f56bff76`](https://github.com/NixOS/nixpkgs/commit/f56bff760abdc33f7726fcda5082ea2c44ff3541) | `python3Packages.tempest: remove unittest2 requirement`                             |
| [`16e55220`](https://github.com/NixOS/nixpkgs/commit/16e552207519f0d8015ef5bd2c2fae685eb0a53e) | `mautrix-facebook: Add version test.`                                               |
| [`fffad300`](https://github.com/NixOS/nixpkgs/commit/fffad300050ed810014397419d23ecdfdddcb867) | `mautrix-facebook: Update to latest git.`                                           |
| [`7a3e6212`](https://github.com/NixOS/nixpkgs/commit/7a3e62127da1171b0276b9bd71411606036422a3) | `mautrix-facebook: Remove max version requirements.`                                |
| [`48b494e3`](https://github.com/NixOS/nixpkgs/commit/48b494e35f387397ae938d6938f7785b9a246302) | `eternal-terminal: 6.1.9 -> 6.1.11`                                                 |
| [`1ab055c4`](https://github.com/NixOS/nixpkgs/commit/1ab055c4fb806a4df446e28416d84b46aa23bffd) | `checkSSLCert: add homepage`                                                        |
| [`3e9e9682`](https://github.com/NixOS/nixpkgs/commit/3e9e96827574f1181ec9072e5fb8eabef661d87b) | `checkSSLCert: 1.80.0 -> 2.19.0`                                                    |
| [`e1968150`](https://github.com/NixOS/nixpkgs/commit/e19681509b81005eff58ea063c8d2669642aaf36) | `linux/hardened/patches/5.4: 5.4.170-hardened1 -> 5.4.171-hardened1`                |
| [`ead5545b`](https://github.com/NixOS/nixpkgs/commit/ead5545be3916a68d69a6a1095ea8b750d43f3fb) | `linux/hardened/patches/5.15: 5.15.12-hardened1 -> 5.15.14-hardened1`               |
| [`f14a7fef`](https://github.com/NixOS/nixpkgs/commit/f14a7feff2c34a9546b828b10d0dff8336a2c649) | `linux/hardened/patches/5.10: 5.10.89-hardened1 -> 5.10.91-hardened1`               |
| [`56224051`](https://github.com/NixOS/nixpkgs/commit/56224051e3b96df0b4004ba981c6423d9784ea4a) | `linux/hardened/patches/4.19: 4.19.224-hardened1 -> 4.19.225-hardened1`             |
| [`230a6813`](https://github.com/NixOS/nixpkgs/commit/230a6813d9ef8efa262730983b77401d1dbc8e27) | `linux/hardened/patches/4.14: 4.14.261-hardened1 -> 4.14.262-hardened1`             |
| [`c5f9bb4d`](https://github.com/NixOS/nixpkgs/commit/c5f9bb4d2185d04ac9f3f00feced506ff0170ffc) | `linux-rt_5_4: 5.4.161-rt67 -> 5.4.170-rt68`                                        |
| [`3bf3b824`](https://github.com/NixOS/nixpkgs/commit/3bf3b8240cf03c513116b900b5e13e2c9527493c) | `python3Packages.python-socketio: 5.5.0 -> 5.5.1`                                   |
| [`736b4ddd`](https://github.com/NixOS/nixpkgs/commit/736b4ddd46ca5aecafe40fb9c705a1eda5013850) | `python3Packages.python-engineio: 4.3.0 -> 4.3.1`                                   |
| [`525962b0`](https://github.com/NixOS/nixpkgs/commit/525962b064b05860ceaf4d0e5bf791dbd5f72673) | `mojave-gtk-theme: add optional arguments`                                          |
| [`1a808ce3`](https://github.com/NixOS/nixpkgs/commit/1a808ce3844fe5782b62c767ac443a49b9e2dc3c) | `mojave-gtk-theme: replace duplicate files with hardlinks`                          |
| [`0540e9f6`](https://github.com/NixOS/nixpkgs/commit/0540e9f60e1eb84d8acdf8478db4be993f2381a8) | `mojave-gtk-theme: 2021-07-20 -> unstable-2021-12-20`                               |
| [`c554b0de`](https://github.com/NixOS/nixpkgs/commit/c554b0de65e373c3f4b39496d1ff50eabe66c920) | `ipfs-cluster: 0.14.1 -> 0.14.4`                                                    |
| [`2d0cecac`](https://github.com/NixOS/nixpkgs/commit/2d0cecac60dde15095f4a56012e10bd008e65cd4) | `zulu: 11.50.19 -> 11.52.13`                                                        |
| [`a0a30c25`](https://github.com/NixOS/nixpkgs/commit/a0a30c25ac7de14eecd014ed4c0b59aaa1a6eb79) | `python3Packages.twinkly-client: 0.0.2 -> 0.0.3`                                    |
| [`1f3b77cd`](https://github.com/NixOS/nixpkgs/commit/1f3b77cd07246db9dfa75ed25d5ef5c892a2dc98) | `python3Packages.spacy: 3.2.0 -> 3.2.1`                                             |
| [`a0ba9289`](https://github.com/NixOS/nixpkgs/commit/a0ba92896ba79e4b1f2c60d6f73860b6f1af9c52) | `python3Packages.spacy-loggers: init at 1.0.1`                                      |
| [`db091609`](https://github.com/NixOS/nixpkgs/commit/db091609ffcee8751219f67d58823632aebcac2d) | `sgx-ssl: init at lin_2.15.1_1.1.1l`                                                |
| [`59f5fe8b`](https://github.com/NixOS/nixpkgs/commit/59f5fe8bcdc1d3eb9a4f9a94281606ad6719e15a) | `maintainer: add trundle`                                                           |
| [`63477f9a`](https://github.com/NixOS/nixpkgs/commit/63477f9a27e1ac9d73452ee85ca917f3d436b43f) | `wasabibackend: use postFixup instead of postInstall`                               |
| [`00ea8f61`](https://github.com/NixOS/nixpkgs/commit/00ea8f615ed1de9ec9751076fa3c47244749ce72) | `nbxplorer: use postFixup instead of preInstall`                                    |
| [`05ea38ab`](https://github.com/NixOS/nixpkgs/commit/05ea38abd04942f98c68fe54aace4e2a8e84c9cc) | `btcpayserver: use postFixup instead of postInstall`                                |
| [`ec52dd49`](https://github.com/NixOS/nixpkgs/commit/ec52dd4971bd8ca583703e8ce60f4a0f2dcdd646) | `opentabletdriver: use postFixup instead of postInstall`                            |
| [`f3537d9d`](https://github.com/NixOS/nixpkgs/commit/f3537d9db11f4cf7ad7948c6972f52cb7e33a852) | `alttpr-opentracker: add gtk3 to buildInputs`                                       |