### PR TITLE
chore(flake/home-manager): `f71d41ba` -> `a69f3e9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1642379981,
-        "narHash": "sha256-FE0RIZmrG2ScKGRthNzcFAssLW7MgMLun0g7Qg2zZMA=",
+        "lastModified": 1642445622,
+        "narHash": "sha256-EpiRAcFWs5HdyPr+1i5wtc7tsDUm/BoIIyP9wjAck2o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f71d41ba360cd49b3647bf91402c7479e859fd2e",
+        "rev": "a69f3e9b0390f03defb834b15e80c236a537157d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`a69f3e9b`](https://github.com/nix-community/home-manager/commit/a69f3e9b0390f03defb834b15e80c236a537157d) | `kime: Fix kime systemd service broken (#2621)` |