### PR TITLE
chore(flake/home-manager): `a69f3e9b` -> `9bceb829`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1642445622,
-        "narHash": "sha256-EpiRAcFWs5HdyPr+1i5wtc7tsDUm/BoIIyP9wjAck2o=",
+        "lastModified": 1642455502,
+        "narHash": "sha256-tqz6MsyEgiFQUUDEfKdTJmog19R78WRxi0ZdC33biM8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a69f3e9b0390f03defb834b15e80c236a537157d",
+        "rev": "9bceb8292e9a2c84db999cb5817d77fb8d6b83fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                           |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`9bceb829`](https://github.com/nix-community/home-manager/commit/9bceb8292e9a2c84db999cb5817d77fb8d6b83fe) | `waybar: fix deprecated "modules" setting check (#2646)` |
| [`60d2c966`](https://github.com/nix-community/home-manager/commit/60d2c9660be43da4d1ba36f89892b38358039824) | `rbw: Fix a typo (#2648)`                                |