### PR TITLE
chore(flake/home-manager): `8cf13abf` -> `c4913317`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1642463060,
-        "narHash": "sha256-6xXRxvMk4OV/k6VwJq54pahToT4FCZzOKfbvG7f6l1E=",
+        "lastModified": 1642463065,
+        "narHash": "sha256-Db53xzDOouhsDAQ/QCvLeM0r7p+my5Zb5jgWGpCrOVo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8cf13abffc0808b337590a9e382604ab6c2cb3e7",
+        "rev": "c491331718bd41722a2982a5532eb0ff51c3ca28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`c4913317`](https://github.com/nix-community/home-manager/commit/c491331718bd41722a2982a5532eb0ff51c3ca28) | `Translate using Weblate (German)`                    |
| [`5e4f439e`](https://github.com/nix-community/home-manager/commit/5e4f439e0cc19941173f037d0556407cac91ed4d) | `Add translation using Weblate (Portuguese (Brazil))` |
| [`eccd7047`](https://github.com/nix-community/home-manager/commit/eccd70475613bfbd19148d7abeef58164a2a2f36) | `Add translation using Weblate (Portuguese (Brazil))` |
| [`4d4c1f34`](https://github.com/nix-community/home-manager/commit/4d4c1f343bf16a472827855323a2539f073ff373) | `Translate using Weblate (German)`                    |