### PR TITLE
chore(flake/nixpkgs): `b13052a3` -> `30cc7340`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642373004,
-        "narHash": "sha256-AZ1fTklT9OkLFtmZ8qMbQ2Uf1dF0+np3WjnTIIquApA=",
+        "lastModified": 1642517665,
+        "narHash": "sha256-pELpg26Jl2NylAIqSyMaIQpyH1GQvTQ1K291SUJ9A04=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b13052a35a63e1ea9eba916ffe48886ab7af58ce",
+        "rev": "30cc7340f587429a9f34f7e54c41cc506d441011",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`07b64a2a`](https://github.com/NixOS/nixpkgs/commit/07b64a2ad72563fbf63be443954aa20406ae87fd) | `nixos/bookstack: Add option config to replace extraConfig`                                      |
| [`a0b54a06`](https://github.com/NixOS/nixpkgs/commit/a0b54a0626634b34b579e52f84464e5ab890afdd) | `nixos/bookstack: Simplify the nginx setup`                                                      |
| [`df607c1d`](https://github.com/NixOS/nixpkgs/commit/df607c1d1f6ea9ad5fcc99a0cabba0ede4be0d4e) | `nixos/bookstack: Make the hostname configurable...`                                             |
| [`e7fa7fdf`](https://github.com/NixOS/nixpkgs/commit/e7fa7fdffc8c37239fb98e1d902a932cad066ea5) | `nixos/bookstack: Clear the cache more reliably`                                                 |
| [`d35021fc`](https://github.com/NixOS/nixpkgs/commit/d35021fc314ffe4a197f13b21743569bb16498bb) | `monitor: 0.11.0 -> 0.12.0`                                                                      |
| [`3c2143ee`](https://github.com/NixOS/nixpkgs/commit/3c2143ee7f1591b641c06eb8ac476c1b8c12e791) | `cue: 0.4.0 -> 0.4.1`                                                                            |
| [`7caa6f4d`](https://github.com/NixOS/nixpkgs/commit/7caa6f4de48ae4de02e12aaa13a9eb9a66013ae8) | `nixos/borgbackup: move systemd.timers logic into single block`                                  |
| [`a2e3f0c6`](https://github.com/NixOS/nixpkgs/commit/a2e3f0c6b4d9151a593158700bec7f8496f8e122) | `ombi: 4.0.1468 -> 4.3.3 (#154919)`                                                              |
| [`679fcbf3`](https://github.com/NixOS/nixpkgs/commit/679fcbf3660d8d254f6266b6051046aebfb29374) | `itpp: mark as broken on darwin`                                                                 |
| [`5082a3f2`](https://github.com/NixOS/nixpkgs/commit/5082a3f29dd2954e2761b67df08397e22af0aacd) | `python3Packages.hap-python: 4.3.0 -> 4.4.0`                                                     |
| [`5efc7a63`](https://github.com/NixOS/nixpkgs/commit/5efc7a631f49521090789eef24ff1a13adeaa01a) | `home-assistant: 2021.12.9 -> 2021.12.10`                                                        |
| [`0f2cd2b4`](https://github.com/NixOS/nixpkgs/commit/0f2cd2b41c0e175171caf3a23400c9bee1de0709) | `python3Packages.yalexs: 1.1.17 -> 1.1.19`                                                       |
| [`9789ed45`](https://github.com/NixOS/nixpkgs/commit/9789ed45b759c8f770bcba4b06c1a1c5ec386664) | `freenect: fix`                                                                                  |
| [`f533a6d2`](https://github.com/NixOS/nixpkgs/commit/f533a6d2bdd11bf901c7d370e7ddd604b245cf98) | `nixos/modules/syncthing: add 22000/udp to firewall`                                             |
| [`b0c031a6`](https://github.com/NixOS/nixpkgs/commit/b0c031a6fa2f205bcd3f12262f09f7d82b818385) | `python3Packages.flux-led: 0.28.3 -> 0.28.4`                                                     |
| [`a51e06ca`](https://github.com/NixOS/nixpkgs/commit/a51e06caffa3dee1d37071dba5c9ba1f7f412c02) | `runc: 1.0.3 -> 1.1.0`                                                                           |
| [`ecda6429`](https://github.com/NixOS/nixpkgs/commit/ecda6429f2da90cf1b25b8c2677d109bed61f796) | `nixos/nix-serve: add openFirewall option`                                                       |
| [`fec05706`](https://github.com/NixOS/nixpkgs/commit/fec0570642ee72b2715b292db681f3085cb69fd5) | `python3Packages.hwi: allow Python > 3.10`                                                       |
| [`f2e0d5fa`](https://github.com/NixOS/nixpkgs/commit/f2e0d5face404d5e50052493d7c4d39a6e5a3741) | `python3Packages.cot: disable failing test`                                                      |
| [`7be3d85b`](https://github.com/NixOS/nixpkgs/commit/7be3d85b0bee9615527049b4b82fba4e033a6aaa) | `python3Packages.types-tabulate: init at 0.8.5`                                                  |
| [`7cf0869f`](https://github.com/NixOS/nixpkgs/commit/7cf0869f4189c6550681039268de99c81ccb67f9) | `python3Packages.types-freezegun: init at 1.1.6`                                                 |
| [`9ef57dfa`](https://github.com/NixOS/nixpkgs/commit/9ef57dfac71a134056e5eeb43fafb0277cc39fa6) | `cri-tools: 1.22.0 -> 1.23.0`                                                                    |
| [`112b447d`](https://github.com/NixOS/nixpkgs/commit/112b447d702349e1dff5aa56a49006048cb27619) | `add gador as maintainer`                                                                        |
| [`dc101d9f`](https://github.com/NixOS/nixpkgs/commit/dc101d9fef9c4c4f27251cdb500dd7b21aa3718f) | `nixos/mosquitto: wait for network-online.target, not network.target`                            |
| [`6cbf83ba`](https://github.com/NixOS/nixpkgs/commit/6cbf83ba01e4a71f2f24ff0dc20139d3a39134bd) | `treewide: rename name to pname&version`                                                         |
| [`b33ab358`](https://github.com/NixOS/nixpkgs/commit/b33ab358a47aff5dff89255be47fea290f5b5577) | `fceux: 2.6.0 -> 2.6.1`                                                                          |
| [`e6b142a4`](https://github.com/NixOS/nixpkgs/commit/e6b142a46130e136a15d73f359a411bcca9b88f0) | `mill: 0.9.12 -> 0.10.0 (#155369)`                                                               |
| [`68d7778e`](https://github.com/NixOS/nixpkgs/commit/68d7778e92165b0ce6025b0b63169bd634313bc3) | `python3Packages.pdm-pep517: init at 0.9.4 (#155385)`                                            |
| [`b93eef4a`](https://github.com/NixOS/nixpkgs/commit/b93eef4add51a20cda163cd010aad1857ef6b6b1) | `octavePackages.miscellaneous: remove mlterm buildInput`                                         |
| [`fceeb71b`](https://github.com/NixOS/nixpkgs/commit/fceeb71be08ca3bff7c9e5ab59ba6e91e7cc67e9) | `chore: remove unused dependencies from unsupported pythons`                                     |
| [`11c1844e`](https://github.com/NixOS/nixpkgs/commit/11c1844e84163899f4a1b4c21338dd9783e0d8c2) | `python3Packages.pythonfinder: init at 1.2.9`                                                    |
| [`4a403f9e`](https://github.com/NixOS/nixpkgs/commit/4a403f9e3392ae10b61ff137663e736be2baf638) | `treewide: rename name to pname&version`                                                         |
| [`721a4a29`](https://github.com/NixOS/nixpkgs/commit/721a4a296e997c28483beaa213ff4c5a0985f0ce) | `python2Packages: remove imports of files that no longer exist`                                  |
| [`2cf157c7`](https://github.com/NixOS/nixpkgs/commit/2cf157c781ef0b711ee70157f3fb11d9a95877fb) | `nixos/switch-to-configuration: Rework activation script restarts`                               |
| [`efb2746b`](https://github.com/NixOS/nixpkgs/commit/efb2746ba4d0a8200f1d0ec39076cd739bd884b2) | `trilium: 0.49.4 -> 0.49.5`                                                                      |
| [`c9608d9f`](https://github.com/NixOS/nixpkgs/commit/c9608d9fa9303cc357d31605cad1be0555fdf271) | `vscode-extensions.scalameta.metals: 1.11.0 -> 1.12.0`                                           |
| [`966a7403`](https://github.com/NixOS/nixpkgs/commit/966a7403df58a4a72295bce08414de90bb80bbc6) | `btop: 1.1.4 -> 1.2.0`                                                                           |
| [`1caf78f4`](https://github.com/NixOS/nixpkgs/commit/1caf78f4bf5cba45eb04c45a3c9b46bde8fa50e0) | `tree-sitter: adding org grammar`                                                                |
| [`c436db00`](https://github.com/NixOS/nixpkgs/commit/c436db00a546162012f332ad28b1c44baebbcb58) | `python3Packages.installer: init at 0.3.0 (#155377)`                                             |
| [`17d0b66c`](https://github.com/NixOS/nixpkgs/commit/17d0b66cf6940aabb7901fa03e9bd38e4e008963) | `gromacs: 2021.4 -> 2021.5`                                                                      |
| [`9049874f`](https://github.com/NixOS/nixpkgs/commit/9049874ff1e79408862d0ca7b854315c20526c73) | `uriparser: Fix cross building`                                                                  |
| [`91dfaa54`](https://github.com/NixOS/nixpkgs/commit/91dfaa5453fca2a12f375d25b084f82d1a370491) | `nixos/borgbackup: start remote backup only if network is available`                             |
| [`69719883`](https://github.com/NixOS/nixpkgs/commit/697198834c6a861d30b8fbfe4162525c87155e00) | `nixos/borgbackup: Add a persistentTimer option.`                                                |
| [`ed5883c1`](https://github.com/NixOS/nixpkgs/commit/ed5883c1b62cab398c8b5fff78f6b11414f278a9) | `zrepl: 0.4.0 -> 0.5.0`                                                                          |
| [`738ff6b3`](https://github.com/NixOS/nixpkgs/commit/738ff6b30cf2232d12cbc1c4f4d029b76a2a099e) | `wpa_supplicant: 2.9 -> 2.10`                                                                    |
| [`90482284`](https://github.com/NixOS/nixpkgs/commit/90482284fa1265ebfcdf16d763d61dacc72bc834) | `hostapd: 2.9 -> 2.10`                                                                           |
| [`e5333715`](https://github.com/NixOS/nixpkgs/commit/e53337159f064f35e6ddaf74593afb5682c56e13) | `intel-graphics-compiler: mark as broken on darwin`                                              |
| [`dcdc03c7`](https://github.com/NixOS/nixpkgs/commit/dcdc03c7c10939aee574cce3f5cb220018f8309f) | `python3Packages.socketio-client: init at 0.7.2 (#155269)`                                       |
| [`a6f61081`](https://github.com/NixOS/nixpkgs/commit/a6f61081493fa1f3941c0faa0b1b28401ca46b3d) | `inkscape: fix line spacing problem`                                                             |
| [`1ea75adb`](https://github.com/NixOS/nixpkgs/commit/1ea75adb020b250a8459b6cadcb66543b6c1e217) | `git-workspace: 0.8.0 -> 0.9.0`                                                                  |
| [`f32154da`](https://github.com/NixOS/nixpkgs/commit/f32154da149de645bcbe02f6d80a1a71427c67e4) | `spot: 0.2.2 -> 0.3.0`                                                                           |
| [`9f0ec3ed`](https://github.com/NixOS/nixpkgs/commit/9f0ec3ed163477c03f5c625b932aa5db07d93281) | `yaml-merge: unstable- 2016-02-16 -> 2022-01-12`                                                 |
| [`7a414230`](https://github.com/NixOS/nixpkgs/commit/7a41423022053696be6c393c67ce1e7c510741dd) | `python3Packages.demjson: only run tests on Python 2`                                            |
| [`fd6f913a`](https://github.com/NixOS/nixpkgs/commit/fd6f913af54dc668016d9055914c05e5742ff0c3) | `chore(pulumi): regenerate data.nix after version bump`                                          |
| [`d30fe4b4`](https://github.com/NixOS/nixpkgs/commit/d30fe4b438cc969d58fd0614b37d11f13270d43d) | `pulumi: 3.21.0 -> 3.22.1`                                                                       |
| [`5883bf67`](https://github.com/NixOS/nixpkgs/commit/5883bf6728630047b0b0cb07d8fb6e03c24a0593) | `terraform-providers: update 2022-01-17`                                                         |
| [`1e75a13d`](https://github.com/NixOS/nixpkgs/commit/1e75a13d8eae78fd0f7f770fff896b3257b626b9) | `deno: 1.17.2 -> 1.17.3`                                                                         |
| [`2eaa8d8b`](https://github.com/NixOS/nixpkgs/commit/2eaa8d8bbf83c64ea6b744078b8637476808052a) | `vscode: add non-english language packs`                                                         |
| [`e8242572`](https://github.com/NixOS/nixpkgs/commit/e8242572da91a5609e88a49899214ee6ca6b18bc) | `vscode-extensions.streetsidesoftware.code-spell-checker: 2.0.14 -> 2.1.4`                       |
| [`c7b528d3`](https://github.com/NixOS/nixpkgs/commit/c7b528d3ad089654f9e0020404746b3ff87e0bbf) | `python3Packages.gvm-tools: disable failing tests`                                               |
| [`31dda654`](https://github.com/NixOS/nixpkgs/commit/31dda65403b5a81ad90baaa7b2aafd4645319517) | `vscode-extensions.stkb.rewrap: 1.15.4 -> 1.16.0`                                                |
| [`60705324`](https://github.com/NixOS/nixpkgs/commit/607053245155f6a337707887996ca0b39321e21f) | `mautrix-whatsapp: 0.2.2 -> 0.2.3`                                                               |
| [`c81e760f`](https://github.com/NixOS/nixpkgs/commit/c81e760f68083c660e5750a11b815cec115bf151) | `python3Packages.build: ignore DeprecationWarning`                                               |
| [`e94bba22`](https://github.com/NixOS/nixpkgs/commit/e94bba2264b4331183c522388d9fa3a87273694e) | `python310Packages.commoncode: disable failing test`                                             |
| [`4fa7c297`](https://github.com/NixOS/nixpkgs/commit/4fa7c297f2b0cc61fc0ff927a70cce7c294795ff) | `minimap2: 2.23 -> 2.24`                                                                         |
| [`5fc1a37f`](https://github.com/NixOS/nixpkgs/commit/5fc1a37f1be2f8b1b50125926fe1d1bf6ecb1377) | `php: 8.0.13 -> 8.0.14`                                                                          |
| [`6e4afa39`](https://github.com/NixOS/nixpkgs/commit/6e4afa39a5952a5d834cbe2d5d7f03a469b8d1c9) | `php: 7.4.26 -> 7.4.27`                                                                          |
| [`32c8a5de`](https://github.com/NixOS/nixpkgs/commit/32c8a5de6668843c2746e0d52d00d15eebca1012) | `nixos/chromium: Add DefaultSearchProviderEnabled option`                                        |
| [`9db1fb47`](https://github.com/NixOS/nixpkgs/commit/9db1fb4772f6a7ea548d64e3f9e672a69b8418a9) | `nixos/mattermost: update release notes`                                                         |
| [`e6415e1d`](https://github.com/NixOS/nixpkgs/commit/e6415e1dc266204575affe723fbd1843f1e68cb7) | `mattermost: 6.2.1 -> 6.3.0 (extended support release)`                                          |
| [`cd330a16`](https://github.com/NixOS/nixpkgs/commit/cd330a1666a1d5e4aa6465fb188f4456bda6daee) | `python39Packages.google-cloud-bigquery: 2.31.0 -> 2.32.0`                                       |
| [`c3b9a648`](https://github.com/NixOS/nixpkgs/commit/c3b9a648ba8fa45d865827567d8908d051781ad5) | `python39Packages.google-api-core: 2.2.2 -> 2.4.0`                                               |
| [`43d9f800`](https://github.com/NixOS/nixpkgs/commit/43d9f800f7e293b848d219d1554cc45ebe237b25) | `python39Packages.google-cloud-datacatalog: 3.6.1 -> 3.6.2`                                      |
| [`ae9540f0`](https://github.com/NixOS/nixpkgs/commit/ae9540f08f651971baf88081f869c283069257d2) | `python39Packages.google-cloud-storage: 1.44.0 -> 2.0.0`                                         |
| [`0fbc9cb6`](https://github.com/NixOS/nixpkgs/commit/0fbc9cb65354847b59feb9f541a1982cde2bdae2) | `python39Packages.google-cloud-tasks: 2.7.1 -> 2.7.2`                                            |
| [`29a69a76`](https://github.com/NixOS/nixpkgs/commit/29a69a765308793476b3738f8003b8781c051b5f) | `python39Packages.google-cloud-testutils: 1.3.0 -> 1.3.1`                                        |
| [`ff402748`](https://github.com/NixOS/nixpkgs/commit/ff402748b330773e91a9c66166a080afee7211d0) | `yle-dl: 20210917 -> 20211213`                                                                   |
| [`a9581967`](https://github.com/NixOS/nixpkgs/commit/a9581967f798032ab04cc3d951b3c430271bb794) | `opentabletdriver: v0.5.3.3 -> v0.6.0.2`                                                         |
| [`02232b6a`](https://github.com/NixOS/nixpkgs/commit/02232b6ad000e8717879ded5a69e1485ed17b23e) | `python39Packages.cairocffi: 1.2.0 -> 1.3.0`                                                     |
| [`0dbfbd46`](https://github.com/NixOS/nixpkgs/commit/0dbfbd466231c0b31184bb8739e731bd2e67a6cb) | `python39Packages.cairocffi: combine default.nix+generic.nix, add SuperSandro2000 as maintainer` |
| [`52edbfc4`](https://github.com/NixOS/nixpkgs/commit/52edbfc42712fbfe15e8620a9a2d0c663aef4b7a) | `pulumi: use gh for versions and parallelize pulumi API downloads (#154880)`                     |
| [`d952e9aa`](https://github.com/NixOS/nixpkgs/commit/d952e9aa46c974dd35802cd71b903b98282dc8fc) | `python310Packages.tempest: use stable patch URL`                                                |
| [`f9bc03e3`](https://github.com/NixOS/nixpkgs/commit/f9bc03e3c7726af2d397eb697ffe878aae503860) | `nixos/adguardhome: add test`                                                                    |
| [`ecfda6ef`](https://github.com/NixOS/nixpkgs/commit/ecfda6ef7cb5d663af536b9f6ad406d3b4302bf5) | `lighttpd: add patch for CVE-2022-22707`                                                         |
| [`a0b38130`](https://github.com/NixOS/nixpkgs/commit/a0b3813092d6645ee5248f6c931ebd15e92e7293) | `lighttpd: 1.4.59 -> 1.4.63`                                                                     |
| [`43047ec1`](https://github.com/NixOS/nixpkgs/commit/43047ec128536b0324dccfef13d593aab3ce3778) | `nixos/rstudio-server: add to 22.05 release notes`                                               |
| [`0fe01530`](https://github.com/NixOS/nixpkgs/commit/0fe01530034762c50c5b379e3852a8cb53901b0d) | `nixos/rstudio-server: init`                                                                     |
| [`fd51177e`](https://github.com/NixOS/nixpkgs/commit/fd51177e5c91ac86220f2f4a11fcc99f0bb9a6a3) | `rstudio-server, rstudioServerWrapper: init at rstudio.version (1.4.1717)`                       |
| [`d3bc05b0`](https://github.com/NixOS/nixpkgs/commit/d3bc05b0f90a447787d5ef57f7f66478b4ac2ed0) | `add cfhammill (me) to the maintainers list`                                                     |
| [`d18d62d4`](https://github.com/NixOS/nixpkgs/commit/d18d62d487a523376369559fa7425f67c958da8b) | `gqrx: 2.15.2 → 2.15.4`                                                                          |
| [`649a7d75`](https://github.com/NixOS/nixpkgs/commit/649a7d75b4668a8d1a709a9d47d526953c627331) | `polkit: disable gtkdoc when cross compiling`                                                    |
| [`60c7aeb9`](https://github.com/NixOS/nixpkgs/commit/60c7aeb9af0f24035823d523eb72c1d05d755bfa) | `python3Packages.meshtastic: 1.2.56 -> 1.2.57`                                                   |
| [`78abd4df`](https://github.com/NixOS/nixpkgs/commit/78abd4df66a1f9c2ff41060266747f31c9cfc5bd) | `pinta: add translations, use msbuild to install files`                                          |
| [`e2e011e8`](https://github.com/NixOS/nixpkgs/commit/e2e011e803e9aee2f4a51ead8c3befc337ef0607) | `tabbed: fix cross-compilation`                                                                  |
| [`a5ff1dc0`](https://github.com/NixOS/nixpkgs/commit/a5ff1dc05df78ba4c8dfcbe2fc818524ed950fe3) | `btrfs-progs: clarify license`                                                                   |
| [`fc2c685b`](https://github.com/NixOS/nixpkgs/commit/fc2c685b2bad7d3a5cdf173223d960749442847d) | `btrfs-progs: enable parallel building`                                                          |
| [`cd4acca2`](https://github.com/NixOS/nixpkgs/commit/cd4acca2e22c33cfe3b03fc9370925dad6c9dfea) | `btrfs-progs: 5.14.1 -> 5.16`                                                                    |
| [`d5cceedb`](https://github.com/NixOS/nixpkgs/commit/d5cceedbd13767b1770c0baac001167f3bf6d5ae) | `python,pythonPackages: make aliases`                                                            |
| [`9356c347`](https://github.com/NixOS/nixpkgs/commit/9356c3472c3c0a31fb5d6b9640ef7c958f76795c) | `sorcer: does not use python`                                                                    |
| [`6599e769`](https://github.com/NixOS/nixpkgs/commit/6599e769647a93048e935b8f8273e62cdb016e5b) | `netbeans: does not use python`                                                                  |
| [`6fcf587e`](https://github.com/NixOS/nixpkgs/commit/6fcf587ea7134e5245f5747c71e1a135b68d56a1) | `split2flac: use python3Packages.mutagen`                                                        |
| [`1e398ec1`](https://github.com/NixOS/nixpkgs/commit/1e398ec1ee9fa3480355136a09ddde0bd52c453a) | `rhvoice: does not depend on python at runtime`                                                  |
| [`6bd52538`](https://github.com/NixOS/nixpkgs/commit/6bd52538ebe0f325f53572eeea8354abfb357b70) | `openbabel3: use python3`                                                                        |
| [`3c25beab`](https://github.com/NixOS/nixpkgs/commit/3c25beab40840bafbf848746bf5076ecd9b59cff) | `tiledb: use python3`                                                                            |
| [`65e959eb`](https://github.com/NixOS/nixpkgs/commit/65e959eb9a1e88d65c03c732fdb514182327c39d) | `tebreak: also use python3 for tests`                                                            |
| [`0d6e7fed`](https://github.com/NixOS/nixpkgs/commit/0d6e7fed1ea34cbdfe6bba6aad56014d673acf6a) | `shocco: use python3`                                                                            |
| [`ea6b67af`](https://github.com/NixOS/nixpkgs/commit/ea6b67af0b1ddac14d2b3b8471cd2a98300078f1) | `seasocks: use python3`                                                                          |
| [`17f8d7ea`](https://github.com/NixOS/nixpkgs/commit/17f8d7ea533378189a4a674de5864a929ff22931) | `schismtracker: use python3`                                                                     |
| [`b93149c1`](https://github.com/NixOS/nixpkgs/commit/b93149c11fb54ffe1068a31e66c5ab095a8ee236) | `rsyslog: use top-level docutils`                                                                |
| [`d4ebae10`](https://github.com/NixOS/nixpkgs/commit/d4ebae105499a59da3d255f39dd4baedac1953c6) | `heroic: remove unused argument`                                                                 |
| [`bc63d4ea`](https://github.com/NixOS/nixpkgs/commit/bc63d4eab40e3b9fa3fbe773974971db37890ba2) | `aumix: fix build against fno-common toolchains`                                                 |
| [`bd8132ac`](https://github.com/NixOS/nixpkgs/commit/bd8132ac625ddd87fda0bb43f493608e6654c508) | `noto-fonts-cjk: add missing serif font`                                                         |
| [`8f34c147`](https://github.com/NixOS/nixpkgs/commit/8f34c14753533646a1a8ad207a05984b540f3439) | `mlterm: 3.9.1 -> 3.9.2`                                                                         |
| [`c0da379c`](https://github.com/NixOS/nixpkgs/commit/c0da379c1c8219ef667ea969115b1e24ed273bfc) | `firefox_decrypt: init at unstable-2021-12-29`                                                   |
| [`3051b532`](https://github.com/NixOS/nixpkgs/commit/3051b532d1fc7a14cd7cd9cd1289e0d21e596731) | `fbterm: refactor`                                                                               |
| [`1ed395aa`](https://github.com/NixOS/nixpkgs/commit/1ed395aaaf6115a4e2a74c388ec2ecc2b8b2971c) | `pinta: 2.0.1 -> 2.0.2`                                                                          |
| [`0d2fa1e0`](https://github.com/NixOS/nixpkgs/commit/0d2fa1e0d6dddd4fe1b50218d404413696404555) | `python3Packages.wtforms: 2.3.3 -> 3.0.1`                                                        |
| [`6eab9e04`](https://github.com/NixOS/nixpkgs/commit/6eab9e04f45ecf9239da6ae80d985330c7fa38cf) | `inav-blackbox-tools: mark as broken on darwin`                                                  |
| [`8e0e03f7`](https://github.com/NixOS/nixpkgs/commit/8e0e03f79cc3de8e8d0a67c90e9d5e56e6cf40f5) | `i3lock-color: mark as broken on darwin`                                                         |
| [`0610ac7a`](https://github.com/NixOS/nixpkgs/commit/0610ac7ab0ee64f7a27ba005c3d75aa85c0b0753) | `arrayfire: 3.6.4 -> 3.7.3`                                                                      |
| [`40f39098`](https://github.com/NixOS/nixpkgs/commit/40f390988f076ee5341b5ea324d08ba3c9bc63f6) | `python3Packages.treex: relax constraints`                                                       |
| [`b642cf7a`](https://github.com/NixOS/nixpkgs/commit/b642cf7a238337b8de94f95c785c57ce0239c8a8) | `python3Packages.surepy: relax rich constraints`                                                 |
| [`3c2dc29a`](https://github.com/NixOS/nixpkgs/commit/3c2dc29a04e61117dd6e82c881279ddc2bc33c21) | `auto-multiple-choice: Fix TEXINPUTS`                                                            |
| [`6a69cda1`](https://github.com/NixOS/nixpkgs/commit/6a69cda1d53b9389af82cd8e0953b041c544a19b) | `blackshades: 1.3.1 -> 2.4.7`                                                                    |
| [`090872ef`](https://github.com/NixOS/nixpkgs/commit/090872ef68bceff2369e9ebce7a60358a752c4f1) | `terraform_0_12: remove`                                                                         |
| [`d50a5122`](https://github.com/NixOS/nixpkgs/commit/d50a512207b82ef133fc6e9fc2bfa0424c94d876) | `kopia: 0.9.8 -> 0.10.0`                                                                         |
| [`cbbabadd`](https://github.com/NixOS/nixpkgs/commit/cbbabaddf9c2697379f49de6eaf0d7db99db2366) | `nixos/adguardhome: Fix #154775 by checking for settings`                                        |
| [`d9172e7a`](https://github.com/NixOS/nixpkgs/commit/d9172e7a1ad77f08d05e82a2298e7615dd826653) | `fixup! nixos/heisenbridge: Improve hardening`                                                   |
| [`f3fa6bfe`](https://github.com/NixOS/nixpkgs/commit/f3fa6bfe96a03323e8e180889ddb6f5a688290e9) | `terraform-providers.mkProvider: cleanup`                                                        |
| [`68915519`](https://github.com/NixOS/nixpkgs/commit/689155195fe0a8677d529d6915ad1bff06ab3373) | `terraform-providers: split the removed providers`                                               |
| [`4b165e76`](https://github.com/NixOS/nixpkgs/commit/4b165e7675f27efe8e4ac0fabed4faa2dc3d3492) | `nixos/heisenbridge: Fix/improve enable option description`                                      |
| [`854a65fd`](https://github.com/NixOS/nixpkgs/commit/854a65fd471794c11af7a0901e6115515e447390) | `nixos/heisenbridge: Improve hardening`                                                          |
| [`d277f135`](https://github.com/NixOS/nixpkgs/commit/d277f1354abf9d4d86c54f1c4caa61c78e0720a5) | `pantheon.elementary-screenshot: pull upstream fix for meson 0.61`                               |
| [`fcbcf3e4`](https://github.com/NixOS/nixpkgs/commit/fcbcf3e49ac526c582ace2e9ef7db12e7d12a442) | `pantheon.elementary-files: pull upstream fix for meson 0.61`                                    |
| [`76a8c87e`](https://github.com/NixOS/nixpkgs/commit/76a8c87e13ed5dd8c9abea465bc3127274330d20) | `pantheon.elementary-capnet-assist: pull upstream fix for meson 0.61`                            |
| [`990d558f`](https://github.com/NixOS/nixpkgs/commit/990d558faf89caccc9ea441b58fe07e0187fb559) | `pantheon.switchboard: pull upstream fix for meson 0.61`                                         |
| [`bde17935`](https://github.com/NixOS/nixpkgs/commit/bde17935d4352d5c203746d71fc0ce5fcdcdd88c) | `pantheon.elementary-greeter: pull upstream fix for meson 0.61`                                  |
| [`d411c1a3`](https://github.com/NixOS/nixpkgs/commit/d411c1a3d3425e9739ea47f6d52a2f3b5f5d2827) | `pantheon.elementary-code: pull upstream fix for meson 0.61`                                     |
| [`e941b746`](https://github.com/NixOS/nixpkgs/commit/e941b7465bba921d663879713d8da995f82fa3e8) | `pantheon.elementary-shortcut-overlay: pull upstream fix for meson 0.61`                         |
| [`bb56f4b4`](https://github.com/NixOS/nixpkgs/commit/bb56f4b4e88ff115f4b1eb8140e1d96aaaefee77) | `pantheon.elementary-terminal: pull upstream fix for meson 0.61`                                 |
| [`20b0f5fa`](https://github.com/NixOS/nixpkgs/commit/20b0f5fada4d70a9ef67c02d2f9a34441d0ebd01) | `pantheon.elementary-mail: pull upstream fix for meson 0.61`                                     |
| [`84d45234`](https://github.com/NixOS/nixpkgs/commit/84d4523405486ae3e1cdb3c5ce61baf009fe79bd) | `pantheon.elementary-camera: pull upstream fix for meson 0.61`                                   |
| [`56be002a`](https://github.com/NixOS/nixpkgs/commit/56be002ac5d9f2282105cb59494613e6b746cefb) | `pantheon.elementary-music: pull upstream fix for meson 0.61`                                    |
| [`c7ee14f2`](https://github.com/NixOS/nixpkgs/commit/c7ee14f22b117c8923307c568371758761123f6c) | `python3Packages.rich: 10.16.2 -> 11.0.0`                                                        |
| [`89794b91`](https://github.com/NixOS/nixpkgs/commit/89794b91f34c6a456b6ac748dc39a72a2d2cb480) | `ammonite: 2.5.0 -> 2.5.1`                                                                       |
| [`bb0e9dec`](https://github.com/NixOS/nixpkgs/commit/bb0e9dec9907871ccdc9532af8590524bf2e9c38) | `jenkins: 2.319.1 -> 2.319.2`                                                                    |
| [`c3b215f6`](https://github.com/NixOS/nixpkgs/commit/c3b215f678452ee8e3d9a993cba11aafed2c1285) | `lean: 3.37.0 -> 3.38.0`                                                                         |
| [`caf0ba41`](https://github.com/NixOS/nixpkgs/commit/caf0ba41b31b76c8052cdc26bee5a13a07fda5a4) | `libpqxx: 7.6.0 -> 7.7.0`                                                                        |
| [`f22aef82`](https://github.com/NixOS/nixpkgs/commit/f22aef829c81a028b2fa074a0a1004ecaeb9ef4c) | `telepresence2: 2.4.6 -> 2.4.9`                                                                  |
| [`533eb986`](https://github.com/NixOS/nixpkgs/commit/533eb9866c6dfe56637f2f8c76fcca3c7b47f72f) | `release.nix: fix eval with aarch64-, but not x86_64-darwin supported`                           |
| [`e1a00aa3`](https://github.com/NixOS/nixpkgs/commit/e1a00aa35a70e1305da089dd2de7c2f59c2ae038) | `tanka: 0.17.3 -> 0.19.0`                                                                        |
| [`ca3bc92b`](https://github.com/NixOS/nixpkgs/commit/ca3bc92bc48aa13dcd5d6a59d57c1d3493a222e5) | `legendary-gl: 0.20.18 -> 0.20.24`                                                               |
| [`b3e51387`](https://github.com/NixOS/nixpkgs/commit/b3e513875f79a2fed883ee7054c1e8368da44c81) | `vala_0_48: 0.48.21 → 0.48.22`                                                                   |
| [`c702c417`](https://github.com/NixOS/nixpkgs/commit/c702c4178cecf0ed02191a6ff0370e305539f2ad) | `vala_0_52: 0.52.9 → 0.52.10`                                                                    |
| [`2a9cc2a9`](https://github.com/NixOS/nixpkgs/commit/2a9cc2a9e612b0f5854c08329e48d0a18511efb3) | `vala_0_40: drop`                                                                                |