### PR TITLE
chore(flake/nixpkgs): `30cc7340` -> `32e4b994`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642517665,
-        "narHash": "sha256-pELpg26Jl2NylAIqSyMaIQpyH1GQvTQ1K291SUJ9A04=",
+        "lastModified": 1642564372,
+        "narHash": "sha256-ISTWzJJM9es1XZjjnN9iIO0a1LpTW2m/Ha/fOOfBaiA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30cc7340f587429a9f34f7e54c41cc506d441011",
+        "rev": "32e4b9949dbd609aef891402002c0031fa312480",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
| [`6dfff632`](https://github.com/NixOS/nixpkgs/commit/6dfff632dfdd644825c3e0c9f0d40b2bde6c915a) | `vscode-utils.buildVscodeExtension: move unzip to nativeBuildInputs`                                                      |
| [`142229d2`](https://github.com/NixOS/nixpkgs/commit/142229d25239d35553401acd00b88a2da9ca8434) | `haskellPackages: mark builds failing on hydra as broken`                                                                 |
| [`48965506`](https://github.com/NixOS/nixpkgs/commit/48965506a1ac5b0a08a0224551e8604c323691d1) | `lib/asserts: use throw to display message for assertMsg`                                                                 |
| [`ef6f8783`](https://github.com/NixOS/nixpkgs/commit/ef6f8783ea42565020efaf8d37638849817e09a9) | `nixos/doc/rl-2205.section.md: Hint to avoid merge conflicts`                                                             |
| [`b7452fee`](https://github.com/NixOS/nixpkgs/commit/b7452fee4d29326c6f6ba45e1e0a8d93cfe5ecd3) | `oven-media-engine: remove unused ffmpeg_3_4 import`                                                                      |
| [`711a269a`](https://github.com/NixOS/nixpkgs/commit/711a269add671b6f66fed58c98c4c5d6e3271ee7) | `rstudio: set meta.mainProgram`                                                                                           |
| [`202a42f2`](https://github.com/NixOS/nixpkgs/commit/202a42f21fcb9d858b496331bee0d8848895f683) | `maintainers: update newam's email`                                                                                       |
| [`5a82b24b`](https://github.com/NixOS/nixpkgs/commit/5a82b24bd5ab60a5f69d152880614ac9a1e8a479) | `python3Packages.flask-security-too: init at 4.1.2`                                                                       |
| [`1d1dc779`](https://github.com/NixOS/nixpkgs/commit/1d1dc7798ded248dfa67f950e7a97c24a8a76964) | `tlauncher: remove`                                                                                                       |
| [`25d0a000`](https://github.com/NixOS/nixpkgs/commit/25d0a0007169c602cdc3f9c54445dc40065e12e2) | `vscode-extensions.christian-kohler.path-intellisense: init at 2.6.1`                                                     |
| [`95dfbf36`](https://github.com/NixOS/nixpkgs/commit/95dfbf360c09df1556a312297a7b3605252a2227) | `nncp: 8.0.2 -> 8.1.0`                                                                                                    |
| [`272fc86d`](https://github.com/NixOS/nixpkgs/commit/272fc86d2ce5d88c5abf16d701c34d310a446a2d) | `nixos/mbpfan: convert to structural settings`                                                                            |
| [`d3a146c2`](https://github.com/NixOS/nixpkgs/commit/d3a146c2ec9c1dae66d11d1cd45052e5a9fde9c5) | `bespokesynth: 1.0 -> 1.1.0. Fixing issues with file loading (#144708)`                                                   |
| [`6f7bf7bc`](https://github.com/NixOS/nixpkgs/commit/6f7bf7bc46de41bce75b1c4c6b684907943d4bb8) | `nixos/mbpfan: set aggressive default values`                                                                             |
| [`e1fb4063`](https://github.com/NixOS/nixpkgs/commit/e1fb4063999293bd953331999160e906dac285c3) | `python3Packages.mongomock: init at 3.23.0`                                                                               |
| [`aad4d13f`](https://github.com/NixOS/nixpkgs/commit/aad4d13f529e01942dbe9891c3b10d2d2e6e7615) | `Update pkgs/development/python-modules/flask-gravatar/default.nix`                                                       |
| [`ce6f4cb5`](https://github.com/NixOS/nixpkgs/commit/ce6f4cb53e8a91959d618777b7dc2f6dc4777340) | `plex: 1.25.2.5319-c43dc0277 -> 1.25.3.5409-f11334058`                                                                    |
| [`ba7c4fa9`](https://github.com/NixOS/nixpkgs/commit/ba7c4fa91dbfb59f5c65e8ed0186fea4e6471ac2) | `kicad: enable i18n by default (#155065)`                                                                                 |
| [`88a4c4c4`](https://github.com/NixOS/nixpkgs/commit/88a4c4c46618c280dd0c9d0da4b2b3f199af70e8) | `mdcat: 0.25.0 -> 0.25.1`                                                                                                 |
| [`ae7e8b42`](https://github.com/NixOS/nixpkgs/commit/ae7e8b427e6b807d32fade6034f3122e86d49ed3) | `matrix-synapse: 1.49.2 -> 1.50.1`                                                                                        |
| [`7908ed9e`](https://github.com/NixOS/nixpkgs/commit/7908ed9ef064459173b69efde00904fd46b0e5c6) | `gpuvis: 20210220 -> 20211204`                                                                                            |
| [`87fb0aed`](https://github.com/NixOS/nixpkgs/commit/87fb0aed8561aaf14fcedbc8d03af8178f0b9b47) | `all-packages.nix: reformat some expressions`                                                                             |
| [`91cc0cf6`](https://github.com/NixOS/nixpkgs/commit/91cc0cf63bc9959f9cdcc60ab15cf2eae6d870b1) | `Update nixos/modules/services/system/cachix-agent/default.nix`                                                           |
| [`617f6e0a`](https://github.com/NixOS/nixpkgs/commit/617f6e0a8b3f2411db670a50ca8af0743e8f0af7) | `pipenv: refact to use installShellCompletion`                                                                            |
| [`89b3b42c`](https://github.com/NixOS/nixpkgs/commit/89b3b42c78b0cc15921fea3aeb3922d1bb8a81d7) | `hlint: add manpage (#155382)`                                                                                            |
| [`af080751`](https://github.com/NixOS/nixpkgs/commit/af080751af5752982a6adb43161a6e392d2da9eb) | `matrix_common: init at 1.0.0`                                                                                            |
| [`6f00dbfe`](https://github.com/NixOS/nixpkgs/commit/6f00dbfe275a0c9c38004532372ec1e74e596468) | `hnix: add missing patch`                                                                                                 |
| [`41a0b8d8`](https://github.com/NixOS/nixpkgs/commit/41a0b8d86af6bf58debfb06c6508c69797af46f3) | `hnix: patch to fix the build`                                                                                            |
| [`04386f35`](https://github.com/NixOS/nixpkgs/commit/04386f35520ebca9d58fe1a2848de2fce9697142) | `fuse-overlayfs: 1.8 -> 1.8.1`                                                                                            |
| [`d6a6139d`](https://github.com/NixOS/nixpkgs/commit/d6a6139d650784f602a5a0c1c5b2a9547ee72de7) | `pferd: 3.2.0 -> 3.3.1`                                                                                                   |
| [`c6a18b48`](https://github.com/NixOS/nixpkgs/commit/c6a18b488ca0a5805fd67aebdcf526cb82fffdf3) | `python3Packages.flask-gravatar: init at 0.5.0`                                                                           |
| [`bc53afc5`](https://github.com/NixOS/nixpkgs/commit/bc53afc5744166078f76875a2e162e3395bff040) | `python3Packages.httpagentparser: init at 1.9.1`                                                                          |
| [`d851c11a`](https://github.com/NixOS/nixpkgs/commit/d851c11a9f15058c906af79ba0982b2faafef654) | `openssh: add release-notes entry for services.openssh.{challengeResponseAuthentication -> kbdInteractiveAuthentication}` |
| [`11b2191b`](https://github.com/NixOS/nixpkgs/commit/11b2191b74c0a8b6bf30fc1136033321a2ea1b96) | `openssh: Update tests to use new option name`                                                                            |
| [`6d985ef1`](https://github.com/NixOS/nixpkgs/commit/6d985ef1744ba2d2c3eacf269af52bd3eaf58f93) | `openssh: Rename option, old option is deprecated upstream`                                                               |
| [`24df24be`](https://github.com/NixOS/nixpkgs/commit/24df24be7306e75162adce0a70e8dc70cef44f94) | `python3Packages.speaklater3: init at 1.4`                                                                                |
| [`4396e4f6`](https://github.com/NixOS/nixpkgs/commit/4396e4f65889ed0a85b24183240f06cd53f3801c) | `python3Packages.flask-paranoid: init at 0.2`                                                                             |
| [`120a09c4`](https://github.com/NixOS/nixpkgs/commit/120a09c4a02bf1af49952bbbdac048694cad0fef) | `qownnotes: 21.12.8 -> 22.1.7`                                                                                            |
| [`ef532480`](https://github.com/NixOS/nixpkgs/commit/ef5324801ff835708615ac940c8d65c3e5089252) | `fix hercules-ci-agent build`                                                                                             |
| [`42994be6`](https://github.com/NixOS/nixpkgs/commit/42994be64b12ed7713aaf6f50ae550f999057833) | `nixos: add cachix-agent service`                                                                                         |
| [`ff788f18`](https://github.com/NixOS/nixpkgs/commit/ff788f18b64ed0bbcac0c89fc5b31374d1b8ed22) | `checkov: 2.0.712 -> 2.0.727`                                                                                             |
| [`0a85191a`](https://github.com/NixOS/nixpkgs/commit/0a85191a3ba37c8c8be5dbd447dca186bc464e28) | `python3Packages.sentinels: init at 1.0.0`                                                                                |
| [`6e22314d`](https://github.com/NixOS/nixpkgs/commit/6e22314d38f18be4659e558e409f915467ec46ff) | `minder: 1.13.1 -> 1.14.0`                                                                                                |
| [`ba989d87`](https://github.com/NixOS/nixpkgs/commit/ba989d87fe1fb98500722a32a2c6af20ef2e4983) | `cutter: 2.0.4 -> 2.0.5`                                                                                                  |
| [`e2d1f6aa`](https://github.com/NixOS/nixpkgs/commit/e2d1f6aabfef4c8009d01ad39b7e6235a364c37f) | `rizin: 0.3.2 -> 0.3.4`                                                                                                   |
| [`6f05ed53`](https://github.com/NixOS/nixpkgs/commit/6f05ed5371929a5a2ebada3e5f38aeb79226b2a7) | `alps: init at 2021-09-29`                                                                                                |
| [`6782373c`](https://github.com/NixOS/nixpkgs/commit/6782373cf32a0e2a15f50601b59bc1be24317bb6) | `maintainers: add gordias`                                                                                                |
| [`5b189555`](https://github.com/NixOS/nixpkgs/commit/5b189555832b11a87f18b441d468582fe1dd33c3) | `among-sus: 2020-10-19 -> 2021-05-19`                                                                                     |
| [`2b1d66bc`](https://github.com/NixOS/nixpkgs/commit/2b1d66bccfd64f754f7dbbef92be833293dd08da) | `lagrange: 1.9.5 → 1.10.0`                                                                                                |
| [`bfc686cc`](https://github.com/NixOS/nixpkgs/commit/bfc686ccb53094863a653f4790dcda4c48065f2b) | `vscode-extensions.jdinhlife.gruvbox: init at 1.5.1`                                                                      |
| [`95430e31`](https://github.com/NixOS/nixpkgs/commit/95430e31f5af1e68540d2f1076a51bdcb9cd54bd) | `nixos/keycloak: Reformat the code with nixpkgs-fmt`                                                                      |
| [`21b1de2b`](https://github.com/NixOS/nixpkgs/commit/21b1de2bcd06ca1eb98ef46d3cb4aaf9461067c4) | `nixos/keycloak: Inherit library functions and builtins`                                                                  |
| [`756f4530`](https://github.com/NixOS/nixpkgs/commit/756f45306b69ac4fe0a4cd4e2d42bb3d29162f43) | `tsm-client: 8.1.13.2 -> 8.1.13.3`                                                                                        |
| [`be904af9`](https://github.com/NixOS/nixpkgs/commit/be904af99c0a9a26f2beb4cab2da45ff0c139bc7) | `tsm-client: 8.1.13.1 -> 8.1.13.2`                                                                                        |
| [`4a42ca06`](https://github.com/NixOS/nixpkgs/commit/4a42ca06c10fc049a63cc12201ab1b93125230fe) | `tsm-client: 8.1.13.0 -> 8.1.13.1`                                                                                        |
| [`66d068bf`](https://github.com/NixOS/nixpkgs/commit/66d068bf66f8e5f55c589ff4c6114c0773c4ee70) | `tsm-client: use rpm source instead of deb/Ubuntu`                                                                        |
| [`f6dca95c`](https://github.com/NixOS/nixpkgs/commit/f6dca95c5dc8ab63322e439ae33a148877838ba9) | `tsm-client: add test derivation and a module test`                                                                       |
| [`c2192ed7`](https://github.com/NixOS/nixpkgs/commit/c2192ed77ae517094a235dfb0ef33d7b88d81212) | ``nixos/tsm-{client,backup}: use new type `nonEmptyStr```                                                                 |
| [`c5effcaa`](https://github.com/NixOS/nixpkgs/commit/c5effcaaeac42e3d54dd04985645ab2600641ad8) | `nixos/tsm-backup: enable most systemd sandboxing options`                                                                |
| [`3f6d1f5f`](https://github.com/NixOS/nixpkgs/commit/3f6d1f5f60461dc60992bf200e8c13535e2727a7) | `nixos/tsm-{client,backup}: update links in module comments`                                                              |
| [`8fa6f90a`](https://github.com/NixOS/nixpkgs/commit/8fa6f90ad6d03a8eb9b7a069f78f7f10a1fa2b51) | `tsm-client: set mainProgram`                                                                                             |
| [`7934926b`](https://github.com/NixOS/nixpkgs/commit/7934926b2e9761fe38ef567efaa0791d7d96388d) | `tsm-client: makeWrapper buildInputs to nativeBuildInputs`                                                                |
| [`5ad0ecb9`](https://github.com/NixOS/nixpkgs/commit/5ad0ecb9019e964d2abfe034e184f8b846e42dfa) | `tsm-client: 8.1.8.0 -> 8.1.13.0`                                                                                         |
| [`517ae2a2`](https://github.com/NixOS/nixpkgs/commit/517ae2a288d11366de4f6867f74e04215e916b85) | `tsm-client: update URL structure`                                                                                        |
| [`6d134acc`](https://github.com/NixOS/nixpkgs/commit/6d134acc4a18897eb248e7ce7daeecc06e68d517) | `tsm-client: use explicit package option for Java GUI`                                                                    |
| [`ce6eea60`](https://github.com/NixOS/nixpkgs/commit/ce6eea6002704b5a2285fb7800e247e3e0946f6c) | `tsm-client: add gnugrep to PATH`                                                                                         |
| [`6e157a48`](https://github.com/NixOS/nixpkgs/commit/6e157a481a7bd03ac6bbeb86847f4d593ed0a854) | `tsm-client: fix lvm2 support`                                                                                            |
| [`5010f4ff`](https://github.com/NixOS/nixpkgs/commit/5010f4fff90803f2026a6d5c8a5bb005434091a1) | `nixos/keycloak: Use LoadCredential to load secrets`                                                                      |
| [`af2e1acb`](https://github.com/NixOS/nixpkgs/commit/af2e1acb5fdb01a51be40364f939e41570efda16) | `haskellPackages: drop references to cabal-install-parsers_0_4_2`                                                         |
| [`ed64cf50`](https://github.com/NixOS/nixpkgs/commit/ed64cf5062597dd500f0abb7825826ba3e445a61) | `sierra-gtk-theme: be more specific with patchShebangs`                                                                   |
| [`405fdb24`](https://github.com/NixOS/nixpkgs/commit/405fdb241a62f5698125109a71c09f15b802c372) | `sierra-gtk-theme: add optional arguments`                                                                                |
| [`3739c52a`](https://github.com/NixOS/nixpkgs/commit/3739c52a6077e4e8e0d96df2b3cc4b4fa87b71fa) | `sierra-gtk-theme: replace duplicate files with hardlinks`                                                                |
| [`a6f06687`](https://github.com/NixOS/nixpkgs/commit/a6f06687d4697ae3714da21142895c287c7718f7) | `sierra-gtk-theme: run hooks in installPhase`                                                                             |
| [`fdf34ebd`](https://github.com/NixOS/nixpkgs/commit/fdf34ebdcbfc58ae69d9898c6df5778b6f0e4d75) | `sierra-gtk-theme: reformat`                                                                                              |
| [`e60f130e`](https://github.com/NixOS/nixpkgs/commit/e60f130e9717591817a5c3867962e799d1a2b6a9) | `sierra-gtk-theme: 2019-12-16 -> unstable-2021-05-24`                                                                     |
| [`1f42b69c`](https://github.com/NixOS/nixpkgs/commit/1f42b69c6755cfdcd08740d4d4bb066721764289) | `renderdoc: 1.16 -> 1.17`                                                                                                 |
| [`d32d994c`](https://github.com/NixOS/nixpkgs/commit/d32d994cc195858ec6569011a642d29350241edc) | `pipenv: add pipenv shell completions`                                                                                    |
| [`7a8250dd`](https://github.com/NixOS/nixpkgs/commit/7a8250dd3be513ed08607b2ac9d3433918d8e87b) | `haskellPackages.haskell-ci{,-unstable}: adjust overrides to >= 0.14`                                                     |
| [`6a34e454`](https://github.com/NixOS/nixpkgs/commit/6a34e454be11fded3ea1131697df28750d9d4849) | `haskellPackages.glade: Deactivate glade`                                                                                 |
| [`4fb58529`](https://github.com/NixOS/nixpkgs/commit/4fb58529f616c089a1f56431952fd69bfe9ec1ae) | `zcash: 4.5.1 -> 4.6.0-1`                                                                                                 |
| [`9a99754c`](https://github.com/NixOS/nixpkgs/commit/9a99754c20aa47ac3d744934c96d16616d4eb14e) | `haskellPackages: regenerate package set based on current config`                                                         |
| [`e4cf20c0`](https://github.com/NixOS/nixpkgs/commit/e4cf20c00ff96e5ce031fba73067114291bc8ddc) | `all-cabal-hashes: 2022-01-11T06:28:14Z -> 2022-01-14T12:47:41Z`                                                          |
| [`3ea7dded`](https://github.com/NixOS/nixpkgs/commit/3ea7dded40e945c12029f213853063c8103f6364) | `haskell.packages.ghc921.retrie: 1.2.0.0 -> 1.2.0.1`                                                                      |
| [`8404b4d2`](https://github.com/NixOS/nixpkgs/commit/8404b4d23713aea00c45a090f3b2ec693520f468) | `haskell.packages.ghc921.path: 0.9.1 -> 0.9.2`                                                                            |
| [`93fd2b2a`](https://github.com/NixOS/nixpkgs/commit/93fd2b2a7d6b1de5ba228444ad7a9b44581266bd) | `haskell.packages.ghc921.ghc-lib-parser: 9.2.1.20211101 -> 9.2.1.20220109`                                                |
| [`770e3998`](https://github.com/NixOS/nixpkgs/commit/770e39981bb472d3e2229fcdfe4884855944e729) | `haskell.packages.ghc921.ghc-exactprint: 1.3.0 -> 1.4.1`                                                                  |
| [`72b3fbc9`](https://github.com/NixOS/nixpkgs/commit/72b3fbc969815e7ce0f899aa3f240fc8e9779576) | `haskell.packages.ghc921.attoparsec: 0.14.3 -> 0.14.4`                                                                    |
| [`1f4dff46`](https://github.com/NixOS/nixpkgs/commit/1f4dff4634ad98e631eb4edcf3844df5ce16462a) | `haskell.packages.ghc921.hashable: 1.4.0.1 -> 1.4.0.2`                                                                    |
| [`26cd4c1b`](https://github.com/NixOS/nixpkgs/commit/26cd4c1be1c25dcd448e631e36127c01263b337c) | `haskellPackages.haskell-ci-unstable: bump attoparsec dependency`                                                         |
| [`8cfaa618`](https://github.com/NixOS/nixpkgs/commit/8cfaa61875142fc738b777968254f246cb72b34d) | `haskellPackages: regenerate package set based on current config`                                                         |
| [`4326f3ec`](https://github.com/NixOS/nixpkgs/commit/4326f3ec8438700d4b05492c949b12c057d3e644) | `all-cabal-hashes: 2022-01-05T00:50:25Z -> 2022-01-11T06:28:14Z`                                                          |
| [`f3f82d83`](https://github.com/NixOS/nixpkgs/commit/f3f82d83302f0ef41df881d38cf21c25c7507898) | ``steam: fix `/etc/resolv.conf` reference in FHS env``                                                                    |
| [`f4487abe`](https://github.com/NixOS/nixpkgs/commit/f4487abeb95eef2dcdc077dcf1d04b9d63df97e9) | `xdg-desktop-portal-wlr: 0.4.0 -> 0.5.0`                                                                                  |
| [`9ac11c07`](https://github.com/NixOS/nixpkgs/commit/9ac11c07628c1a35b4a47ae4f76372f131d04c75) | `nixos/malloc: fix scudo on non-x86_64 machines`                                                                          |