### PR TITLE
chore(flake/nixpkgs): `32e4b994` -> `d4cb3566`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642564372,
-        "narHash": "sha256-ISTWzJJM9es1XZjjnN9iIO0a1LpTW2m/Ha/fOOfBaiA=",
+        "lastModified": 1642648262,
+        "narHash": "sha256-8uAsEFTGhgIqCo3OQU0Z3HyeNb35kCiroY9eGA/+cwQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "32e4b9949dbd609aef891402002c0031fa312480",
+        "rev": "d4cb356679379b4aec5e53b6cd820869b2d919dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
| [`565670a4`](https://github.com/NixOS/nixpkgs/commit/565670a40759c194ae01af99a01ef593c26ac7e1) | `wike: 1.6.3 -> 1.7.0`                                                                                                         |
| [`5b3d192e`](https://github.com/NixOS/nixpkgs/commit/5b3d192e40b09262efcf9d250f41203e6ccd0d9d) | `rucredstash: init at 0.9.0 (#155135)`                                                                                         |
| [`ab001e25`](https://github.com/NixOS/nixpkgs/commit/ab001e250a4abc8f57db6257864c00d1cd807179) | `dtrx: 7.1 -> 8.2.1 (resurrected)`                                                                                             |
| [`57998144`](https://github.com/NixOS/nixpkgs/commit/579981443168f818c3a764e7400735e4f017192f) | `python310Packages.debian: 0.1.42 -> 0.1.43, add SuperSandro2000 as maintainer`                                                |
| [`4ad70945`](https://github.com/NixOS/nixpkgs/commit/4ad70945832f80e8dcff8c5a9ca1c3bcdf846f42) | `python310Packages.iminuit: 2.8.4 -> 2.9.0`                                                                                    |
| [`6749f353`](https://github.com/NixOS/nixpkgs/commit/6749f353af4fff42d5837d97d405e0aae9e8c3ad) | `buf: 1.0.0-rc10 -> 1.0.0-rc11 (#155518)`                                                                                      |
| [`31e5b8dc`](https://github.com/NixOS/nixpkgs/commit/31e5b8dc2198eacec3e009e21fc8226486aa674e) | `Remove myself from maintainers`                                                                                               |
| [`b3515c14`](https://github.com/NixOS/nixpkgs/commit/b3515c140109e0309135694f48dd2eb2135c7c40) | `python310Packages.green: 3.3.0 -> 3.4.0`                                                                                      |
| [`95732323`](https://github.com/NixOS/nixpkgs/commit/95732323ae530b399511ac9a4e654d2116ec079c) | `helm-docs: 1.5.0 -> 1.7.0`                                                                                                    |
| [`f9945f6d`](https://github.com/NixOS/nixpkgs/commit/f9945f6d8795d899b2b839103e93edfa64f9ef4a) | `python310Packages.google-cloud-texttospeech: 2.9.0 -> 2.9.1`                                                                  |
| [`1b846402`](https://github.com/NixOS/nixpkgs/commit/1b8464022b57192968929ddc6be89785c27185ad) | `czkawka: 3.1.1 -> 4.0.0`                                                                                                      |
| [`b528e350`](https://github.com/NixOS/nixpkgs/commit/b528e350cdd45d78e8b6b9e7488a34d8c3312e70) | `xfce: use pkgs.vte instead of gnome.vte`                                                                                      |
| [`d9639ee3`](https://github.com/NixOS/nixpkgs/commit/d9639ee3b3ee8e0257675156231b53d0b2b317a3) | `python310Packages.google-cloud-storage: 2.0.0 -> 2.1.0`                                                                       |
| [`75f9d755`](https://github.com/NixOS/nixpkgs/commit/75f9d755aa13eab29595720df891d5917cc9440d) | `kubescape: 2.0.139 -> 2.0.141`                                                                                                |
| [`c7193ca1`](https://github.com/NixOS/nixpkgs/commit/c7193ca132e0a7e204fbb36eb2f78286a1333349) | `hydrus: 469 -> 470b`                                                                                                          |
| [`cf194c51`](https://github.com/NixOS/nixpkgs/commit/cf194c51e4e057f1155f0ca4b756aa2aa0a0b3fa) | `python310Packages.google-cloud-speech: 2.11.1 -> 2.12.0`                                                                      |
| [`34d62f3a`](https://github.com/NixOS/nixpkgs/commit/34d62f3a4084fe2053553a8380da2dfd8bb6e1a5) | `python3Packages.pywilight: 0.0.73 -> 0.0.74`                                                                                  |
| [`f22f0c6e`](https://github.com/NixOS/nixpkgs/commit/f22f0c6e4dd8db9ccc5472d0bc5b01bafb16d76b) | `python310Packages.google-cloud-securitycenter: 1.7.0 -> 1.8.0`                                                                |
| [`fb27a93f`](https://github.com/NixOS/nixpkgs/commit/fb27a93faf63af1d6a60770d52ef883f9497ab79) | `python310Packages.google-cloud-redis: 2.5.0 -> 2.5.1`                                                                         |
| [`717e8671`](https://github.com/NixOS/nixpkgs/commit/717e867172a2ce863a46aa048d5ba191d285f75d) | `python310Packages.google-cloud-dlp: 3.4.0 -> 3.5.0`                                                                           |
| [`14c90550`](https://github.com/NixOS/nixpkgs/commit/14c905502c0917c57404fc8b6abb45ab5cdb29a9) | `python310Packages.google-cloud-dataproc: 3.1.1 -> 3.2.0`                                                                      |
| [`408e785e`](https://github.com/NixOS/nixpkgs/commit/408e785e658b0b2ffd127be23311f90bf2a4b0d9) | `python310Packages.google-cloud-bigquery-datatransfer: 3.4.1 -> 3.5.0`                                                         |
| [`5fe0d707`](https://github.com/NixOS/nixpkgs/commit/5fe0d70748ef8039e71463f71e1b38ea5ede3cea) | `python310Packages.google-cloud-automl: 2.5.2 -> 2.6.0`                                                                        |
| [`debe8a4a`](https://github.com/NixOS/nixpkgs/commit/debe8a4a6d558df4e3b8c08fc4088441c0e3486a) | `python310Packages.goodwe: 0.2.14 -> 0.2.15`                                                                                   |
| [`57ec5512`](https://github.com/NixOS/nixpkgs/commit/57ec55124116c41ab64fb491251905a5aa46e3c7) | `python310Packages.glean-parser: 4.3.1 -> 4.4.0`                                                                               |
| [`b22f235e`](https://github.com/NixOS/nixpkgs/commit/b22f235ec793dd3859b625c0abdb25712d876ac6) | `python310Packages.glcontext: 2.3.3 -> 2.3.4`                                                                                  |
| [`32fc7222`](https://github.com/NixOS/nixpkgs/commit/32fc7222b688f949511463f70a6cb7ae795f63e0) | `esphome: 2021.12.3 -> 2022.1.1`                                                                                               |
| [`8903bd2c`](https://github.com/NixOS/nixpkgs/commit/8903bd2caba8f63447bcaa5c0eff0a6b86722e82) | `terraform: 1.1.3 -> 1.1.4`                                                                                                    |
| [`c3e8270c`](https://github.com/NixOS/nixpkgs/commit/c3e8270c3a623c8230879d8eb174d31fb9382d35) | `google-chrome: fix hardware acceleration on Wayland (#155447)`                                                                |
| [`66d044d1`](https://github.com/NixOS/nixpkgs/commit/66d044d1171f0086a131a5aebd7b85f70e7b31fa) | `terraform-providers.gandi: 1.1.1 -> 2.0.0`                                                                                    |
| [`f9be5c75`](https://github.com/NixOS/nixpkgs/commit/f9be5c755658fe5956adf2c873cf6383355764cd) | `python3Packages.awsiotpythonsdk: disable on older Python releases`                                                            |
| [`098c250a`](https://github.com/NixOS/nixpkgs/commit/098c250a15925fea9aa206488b54a51039f07151) | `python310Packages.exchangelib: 4.7.0 -> 4.7.1`                                                                                |
| [`3592fd48`](https://github.com/NixOS/nixpkgs/commit/3592fd48baef1cf71b8d195969786beac4fad3d6) | `python310Packages.enturclient: 0.2.2 -> 0.2.3`                                                                                |
| [`e63bffa2`](https://github.com/NixOS/nixpkgs/commit/e63bffa2bd4c0ee44c623ee465043575aeed78d7) | `jabcode: mark as broken on darwin`                                                                                            |
| [`b2445ca6`](https://github.com/NixOS/nixpkgs/commit/b2445ca61396528de927a86e74fc8de239bad05a) | `firejail: add apparmor support`                                                                                               |
| [`33a76a32`](https://github.com/NixOS/nixpkgs/commit/33a76a32534499ef863720594871597a4536a3ee) | `libplacebo: 4.157.0 -> 4.192.0`                                                                                               |
| [`c0b8c167`](https://github.com/NixOS/nixpkgs/commit/c0b8c1675731cb5e59d1d65cbd69c68220fa9040) | `python310Packages.doit: 0.34.0 -> 0.34.1`                                                                                     |
| [`f7d105e4`](https://github.com/NixOS/nixpkgs/commit/f7d105e481d3219ea9362137e66260973e381721) | `python310Packages.dnslib: 0.9.18 -> 0.9.19`                                                                                   |
| [`6ebcda6d`](https://github.com/NixOS/nixpkgs/commit/6ebcda6d31dea970892b9cbae99a15269c174232) | `python310Packages.django-oauth-toolkit: 1.6.1 -> 1.6.3`                                                                       |
| [`2d207146`](https://github.com/NixOS/nixpkgs/commit/2d207146ee1218f154047580fa07761a2bf2d9fc) | `mathematica: Refactor install process with autoPatchelfHook (#154295)`                                                        |
| [`d1bc8239`](https://github.com/NixOS/nixpkgs/commit/d1bc8239f594d45b43b8a79bde96aaa2a2e175a6) | `python310Packages.django-maintenance-mode: 0.14.0 -> 0.16.2`                                                                  |
| [`6173ac1a`](https://github.com/NixOS/nixpkgs/commit/6173ac1aa00f0cbe4a39d5a65c56171f82ca40f7) | `python310Packages.django-debug-toolbar: 3.2.2 -> 3.2.4`                                                                       |
| [`dc539082`](https://github.com/NixOS/nixpkgs/commit/dc539082d5daed4956453a87f2524a49c1656d56) | `python310Packages.deezer-python: 4.3.0 -> 5.0.0`                                                                              |
| [`e0bc22ad`](https://github.com/NixOS/nixpkgs/commit/e0bc22ad7bd758bd164d9f4fbbd972b56335c38c) | `firejail: improve local profile customization support`                                                                        |
| [`b3da6aa7`](https://github.com/NixOS/nixpkgs/commit/b3da6aa7bcdddf18710cd7e16a77603964e7c4b4) | `python3Packages.pynut2: disable tests`                                                                                        |
| [`2d8398d0`](https://github.com/NixOS/nixpkgs/commit/2d8398d0b581760e5ead42fa112874ba770cabb6) | `python310Packages.cyclonedx-python-lib: 1.0.0 -> 1.1.0`                                                                       |
| [`881972bf`](https://github.com/NixOS/nixpkgs/commit/881972bfa66aeb911a77cd0bf05d12e3ba538c97) | `firejail: remove deprecated flag, see: https://github.com/netblue30/firejail/commit/4909fa7efce4a36bd16e7bf80c9642b93c262ddf` |
| [`6d60c48b`](https://github.com/NixOS/nixpkgs/commit/6d60c48bf7fee606b0a098244197bbcbaad71a4d) | `scorecard: 3.2.1 -> 4.0.1`                                                                                                    |
| [`ef905b66`](https://github.com/NixOS/nixpkgs/commit/ef905b6646404e3075092ac21cc3cffd084e2005) | `sfizz: 1.1.1 -> 1.2.0`                                                                                                        |
| [`5000afbf`](https://github.com/NixOS/nixpkgs/commit/5000afbfb118509691cf501ec27e40a9d0a4e475) | `home-assistant: test nut integration`                                                                                         |
| [`5a30b589`](https://github.com/NixOS/nixpkgs/commit/5a30b5898f9cba290e15e1b240f36b042db9cb23) | `tixati: 2.87 -> 2.88`                                                                                                         |
| [`cda331a6`](https://github.com/NixOS/nixpkgs/commit/cda331a6edcefc607b347973f21a54893c1d5174) | `ugrep: 3.5.0 -> 3.6.0`                                                                                                        |
| [`1d3f0903`](https://github.com/NixOS/nixpkgs/commit/1d3f0903a8b4062f9207c5561b236bbc3f1ebf82) | `nixos/mosquitto: add package option`                                                                                          |
| [`b39a5b29`](https://github.com/NixOS/nixpkgs/commit/b39a5b29ac571fbf3ec4d977e420922773a3f3b1) | `vscode-extensions.oderwat.indent-rainbow: init at 8.2.2`                                                                      |
| [`8f086db0`](https://github.com/NixOS/nixpkgs/commit/8f086db04f4b9db4a132725566b4a1c38def163b) | `nixos/cinnamon: fix gnome alias deperaction`                                                                                  |
| [`5074eb03`](https://github.com/NixOS/nixpkgs/commit/5074eb03478fc4fae10a04c3818f5c594880b16a) | `swagger-codegen3: 3.0.31 -> 3.0.32`                                                                                           |
| [`dbd45cdf`](https://github.com/NixOS/nixpkgs/commit/dbd45cdffb0447c3acbdab7bd4403b7e5601b634) | `python310Packages.ckcc-protocol: 1.1.0 -> 1.2.1`                                                                              |
| [`e98b2935`](https://github.com/NixOS/nixpkgs/commit/e98b2935b8db92ebcc38fc51c349695c8a9894d0) | `python310Packages.chart-studio: 5.4.0 -> 5.5.0`                                                                               |
| [`c5ceb2b0`](https://github.com/NixOS/nixpkgs/commit/c5ceb2b05c09160077b5a86f4ba06e01bd949d04) | `docker-compose_2: 2.2.2 -> 2.2.3`                                                                                             |
| [`259955a9`](https://github.com/NixOS/nixpkgs/commit/259955a975f1861551e8471347519ff3ace2953c) | `docker-compose_2: add SuperSandro2000 as maintainer, strip more`                                                              |
| [`7930a45f`](https://github.com/NixOS/nixpkgs/commit/7930a45fae77e970e07522b644a40b8953da5975) | `terragrunt: 0.35.16 -> 0.35.20`                                                                                               |
| [`80d40430`](https://github.com/NixOS/nixpkgs/commit/80d4043005a88523096e1e111775f319736cb259) | `wluma: 3.0.0 -> 4.0.0`                                                                                                        |
| [`6d008297`](https://github.com/NixOS/nixpkgs/commit/6d0082972925ae926494fd6698528ecc6a79280e) | `symfony-cli: 5.0.7 -> 5.1.0`                                                                                                  |
| [`c19862c6`](https://github.com/NixOS/nixpkgs/commit/c19862c6e5d5b1b3ce66d044033204dd11c600f9) | `apt: 2.3.8 -> 2.3.14`                                                                                                         |
| [`4351cfa3`](https://github.com/NixOS/nixpkgs/commit/4351cfa35c8ddc484289858e07625b9ddb1733a8) | `ronn: add test for HTML reproducibility`                                                                                      |
| [`c859908c`](https://github.com/NixOS/nixpkgs/commit/c859908cd68d842b6204d9fe6521e911f57e565e) | ``rubyPackages.rdiscount: use lib from `pkgs.discount```                                                                       |
| [`57fd0ad5`](https://github.com/NixOS/nixpkgs/commit/57fd0ad582bc15ca007106853f579824ca9ffb31) | ``discount: fix `install_name` on Darwin``                                                                                     |
| [`d8ae5dc8`](https://github.com/NixOS/nixpkgs/commit/d8ae5dc8134f7f181d9ece8e68aa2ea1b55cbb44) | `discount: use deterministic mangling`                                                                                         |
| [`f5e40fe4`](https://github.com/NixOS/nixpkgs/commit/f5e40fe4ecd2b129823f6a762bd1a4f6bb3e79a1) | `python310Packages.canmatrix: 0.9.3 -> 0.9.5`                                                                                  |
| [`6de75c79`](https://github.com/NixOS/nixpkgs/commit/6de75c797afd0e3aa9805d2b7fa8c4e277ee18ab) | `gnome2.vte: drop`                                                                                                             |
| [`7da8eaa0`](https://github.com/NixOS/nixpkgs/commit/7da8eaa0e07eda221f1796bfae13b06f69640af4) | `radare2: don't inherit gnome2's vte version`                                                                                  |
| [`fb7eb9e8`](https://github.com/NixOS/nixpkgs/commit/fb7eb9e80ce07d07c0a9cc6700e45a0c312dcb47) | `grip: trim dependencies`                                                                                                      |
| [`9b91a19e`](https://github.com/NixOS/nixpkgs/commit/9b91a19e87e6de07851d33bc1d59ebcef97ba75f) | `lilyterm: drop`                                                                                                               |
| [`08af30fe`](https://github.com/NixOS/nixpkgs/commit/08af30fedf2ca8100c841f0641e6d4926fb49bef) | `evilvte: drop`                                                                                                                |
| [`0c691d2f`](https://github.com/NixOS/nixpkgs/commit/0c691d2fc65fc9c7c793e764dd202615fc85bfea) | `typos: 1.3.3 -> 1.3.4`                                                                                                        |
| [`8c955de3`](https://github.com/NixOS/nixpkgs/commit/8c955de38908c3e9b97b757f0ea21d45d1940ee8) | `maintainers: add smasher164`                                                                                                  |
| [`0fbe799b`](https://github.com/NixOS/nixpkgs/commit/0fbe799b6cc9cd34e7a65a59e8c1363da5f4ed90) | `ivy: init at 0.1.13`                                                                                                          |
| [`b21923ee`](https://github.com/NixOS/nixpkgs/commit/b21923eeefcd9b1df4dfee7c285e4d19707b4eaf) | `plexamp: 3.9.0 -> 3.9.1`                                                                                                      |
| [`57c6492e`](https://github.com/NixOS/nixpkgs/commit/57c6492efc16d5198ecb74aab0668bc719a4a32d) | `syncthing: 1.18.5 -> 1.18.6`                                                                                                  |
| [`24efc4dd`](https://github.com/NixOS/nixpkgs/commit/24efc4dd622f392266221dcf0a01f5fe16f77c72) | `python310Packages.azure-mgmt-containerregistry: 8.2.0 -> 9.0.0`                                                               |
| [`a085e442`](https://github.com/NixOS/nixpkgs/commit/a085e442dcf7dbeaf493f69757c5b0750aa387bf) | `python310Packages.awsiotpythonsdk: 1.4.9 -> 1.5.0`                                                                            |
| [`e26986e8`](https://github.com/NixOS/nixpkgs/commit/e26986e8e12f8242567724aef855de39ce932878) | `python310Packages.atlassian-python-api: 3.8.0 -> 3.18.0`                                                                      |
| [`dae8cbdd`](https://github.com/NixOS/nixpkgs/commit/dae8cbdd3c27f7b29e3e5d38ce860e9d90903c5a) | `accountsservice: build with systemd to allow user switching`                                                                  |
| [`460af326`](https://github.com/NixOS/nixpkgs/commit/460af326e43399d03a12529c05879d88110db1da) | `inklecate: switch to source release`                                                                                          |
| [`eff260aa`](https://github.com/NixOS/nixpkgs/commit/eff260aaf2ddc17305efd18cf6cb26306316ddb8) | `linux config: enable Landlock LSM`                                                                                            |
| [`db072e6f`](https://github.com/NixOS/nixpkgs/commit/db072e6feaba17abe750fe6402312962b16d2e6b) | `python310Packages.asteval: 0.9.25 -> 0.9.26`                                                                                  |
| [`2040c11b`](https://github.com/NixOS/nixpkgs/commit/2040c11beacb6aec51f9a5630f6c55e5a74de957) | `x42-plugins: 20211016 -> 20220107`                                                                                            |
| [`4db154ca`](https://github.com/NixOS/nixpkgs/commit/4db154ca619c8da8655e79faabb38c13ff2ad053) | `libreswan: fix more binary paths`                                                                                             |
| [`741a5850`](https://github.com/NixOS/nixpkgs/commit/741a585052c99be0bf2633c6195be57a464b962e) | `nixos/tests/libreswan: fixup 739c51ae4ef`                                                                                     |
| [`3c434c4a`](https://github.com/NixOS/nixpkgs/commit/3c434c4a998ac600d4b2be77ecdabbc3bbb96c9b) | `amdvlk: 2021.Q4.3 -> 2022.Q1.1`                                                                                               |
| [`a8684a7a`](https://github.com/NixOS/nixpkgs/commit/a8684a7a649488aef85e55e79508aaa2a6709a27) | `python310Packages.aioswitcher: 2.0.6 -> 2.0.7`                                                                                |
| [`af992ad6`](https://github.com/NixOS/nixpkgs/commit/af992ad62b312e4cc6095bfd18b9282b70fd7de8) | `pyradio: 0.8.9.9 -> 0.8.9.10`                                                                                                 |
| [`94536b57`](https://github.com/NixOS/nixpkgs/commit/94536b5712872b5d7fa1b043ba77a4b3ad1c5726) | `python310Packages.aioshelly: 1.0.5 -> 1.0.7`                                                                                  |
| [`54a62ae2`](https://github.com/NixOS/nixpkgs/commit/54a62ae266343b584b92d1f2b636a913899c86a8) | `nixos/tests/lorri: Remove redundant stdout redirect`                                                                          |
| [`e684ccbf`](https://github.com/NixOS/nixpkgs/commit/e684ccbf30fd50b593346d503de980db616ac00c) | `vivaldi-widevine: 4.10.1582.1 -> 4.10.2391.0`                                                                                 |
| [`a8e0a630`](https://github.com/NixOS/nixpkgs/commit/a8e0a63085d831514f2e4d91f6bf4c322f734b07) | `python310Packages.aiohwenergy: 0.4.0 -> 0.6.0`                                                                                |
| [`4bc9dec8`](https://github.com/NixOS/nixpkgs/commit/4bc9dec82a74244f0c49ed3bb19ad97586a49922) | `python310Packages.aiohomekit: 0.6.4 -> 0.6.10`                                                                                |
| [`e41c567a`](https://github.com/NixOS/nixpkgs/commit/e41c567a55be98ad1570b44d87c44eb4229bee52) | `python310Packages.aenum: 3.1.5 -> 3.1.6`                                                                                      |
| [`9671380d`](https://github.com/NixOS/nixpkgs/commit/9671380d6667bb25b1e8968b59fa2458b9844496) | `pijul: 1.0.0-alpha.57 -> 1.0.0-beta`                                                                                          |
| [`2e3aa420`](https://github.com/NixOS/nixpkgs/commit/2e3aa420cd096edec2fb87556e3974b727d8ddff) | `python310Packages.adjusttext: 0.7.3 -> 0.7.3.1`                                                                               |
| [`a67cc4e7`](https://github.com/NixOS/nixpkgs/commit/a67cc4e7484eb271ad507e5dd8e6e920e1f20c53) | `umockdev: 0.17.2 -> 0.17.5`                                                                                                   |
| [`6c6c397b`](https://github.com/NixOS/nixpkgs/commit/6c6c397b9273bec9a35c5644bfb5f21025a20a63) | `vintagestory: 1.15.10 -> 1.16.0`                                                                                              |
| [`29a51e79`](https://github.com/NixOS/nixpkgs/commit/29a51e79c38d2887cbfd935d9251c28be25e3bf1) | `pypi-mirror: 4.1.0 -> 4.2.0`                                                                                                  |
| [`f12f99a3`](https://github.com/NixOS/nixpkgs/commit/f12f99a320c2c748421970800162f462f8dba7e3) | `pifi: remove (#155569)`                                                                                                       |
| [`7945280b`](https://github.com/NixOS/nixpkgs/commit/7945280b9b2e348738cb9d164a0848feaf2c311d) | `pre-commit: 2.16.0 -> 2.17.0`                                                                                                 |
| [`e1205438`](https://github.com/NixOS/nixpkgs/commit/e1205438610a9a8e295779bc04d521f056ae318e) | `vale: 2.13.0 -> 2.14.0`                                                                                                       |
| [`feffa9b7`](https://github.com/NixOS/nixpkgs/commit/feffa9b7115f4776f86b50eb9559c4395c63eb70) | `pithos: 1.5.0 -> 1.5.1`                                                                                                       |
| [`1ecb2abd`](https://github.com/NixOS/nixpkgs/commit/1ecb2abd94e8f1d2a37f56c4ec8e996768ed953d) | `pgcli: 3.3.0 -> 3.3.1`                                                                                                        |
| [`6912fb74`](https://github.com/NixOS/nixpkgs/commit/6912fb742861318eec5c5efb674aab9f712c3366) | `python3Packages.cli-helpers: 2.2.0 -> 2.2.1`                                                                                  |
| [`d04b212b`](https://github.com/NixOS/nixpkgs/commit/d04b212b371c03224e55e1d88480245316ecc462) | `palemoon: 29.4.3 -> 29.4.4`                                                                                                   |
| [`73aaf861`](https://github.com/NixOS/nixpkgs/commit/73aaf861da5bcd54e6f1e9cecdfc72c1b0aaf4d4) | `kernelshark: 2.0.2 -> 2.1.0`                                                                                                  |