### PR TITLE
chore(flake/utils): `74f7e431` -> `3f197dc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -291,11 +291,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1642700575,
+        "narHash": "sha256-VkhNIkF/z2wmAZ4/2FmovUsZtvWK8MpBFoEx0gN058Y=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "3f197dc7591cc6edc83e1eb44698283c19fd28a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                         |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`3f197dc7`](https://github.com/numtide/flake-utils/commit/3f197dc7591cc6edc83e1eb44698283c19fd28a2) | `add system map for convenience (#55)` |