### PR TITLE
chore(flake/nixpkgs): `d4cb3566` -> `1c0f3cd8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642648262,
-        "narHash": "sha256-8uAsEFTGhgIqCo3OQU0Z3HyeNb35kCiroY9eGA/+cwQ=",
+        "lastModified": 1642694151,
+        "narHash": "sha256-e5IUzWN12iduNLlKZN/wlAxpfDl9FHKxxnPpyAQJyZ8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d4cb356679379b4aec5e53b6cd820869b2d919dd",
+        "rev": "1c0f3cd8dfb451fcde1e164426ef9211f7c595c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                       |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`bb6bc8b3`](https://github.com/NixOS/nixpkgs/commit/bb6bc8b315e7c941f30a64d7e58682ec235f9bb4) | `molden: fix download URL`                                           |
| [`80475b46`](https://github.com/NixOS/nixpkgs/commit/80475b46f52a1e28a70b1866c2a8edb071208ac8) | `nixos/invoiceplane: init module and package at 1.5.11 (#146909)`    |
| [`8072fdf5`](https://github.com/NixOS/nixpkgs/commit/8072fdf5ca1f31546f5dbf3a1888eeba8ca4ae28) | `python310Packages.python-telegram-bot: 13.9 -> 13.10`               |
| [`cfa0fa97`](https://github.com/NixOS/nixpkgs/commit/cfa0fa97320d24a5d58f4e6d69c47c38661ab843) | `python3Packages.shodan: 1.26.0 -> 1.26.1`                           |
| [`84930221`](https://github.com/NixOS/nixpkgs/commit/84930221fc769078feac517a4c0a986083553ac9) | `sherpa: 2.2.11 -> 2.2.12`                                           |
| [`84127a71`](https://github.com/NixOS/nixpkgs/commit/84127a719f1f1f73fbe632a288090002a47adc37) | `caffeine-ng: 3.4.2 -> 3.5.1`                                        |
| [`5c53a84b`](https://github.com/NixOS/nixpkgs/commit/5c53a84b938a9a732c28b829200fb1b779c3bb27) | `python310Packages.pyswitchbot: 0.13.0 -> 0.13.2`                    |
| [`1876bf60`](https://github.com/NixOS/nixpkgs/commit/1876bf609950bd97b389fab9180a0e3b3ba2a355) | `solaar: 1.1.0 -> 1.1.1`                                             |
| [`a30df390`](https://github.com/NixOS/nixpkgs/commit/a30df390471d1e5dfd5dc82dbfa28a765f07e0b7) | `gnugrep: add myself as maintainer`                                  |
| [`26052c37`](https://github.com/NixOS/nixpkgs/commit/26052c3706c866198649920c6b903381a424cbf3) | `python3Packages.pymsteams: disable on older Python releases`        |
| [`c6b4d6fa`](https://github.com/NixOS/nixpkgs/commit/c6b4d6fa430398fa606e8c579c52a232da95189c) | `spotify-qt: 3.7 -> 3.8`                                             |
| [`3cbb0208`](https://github.com/NixOS/nixpkgs/commit/3cbb02087b4c2dfc3be664d7152cec51765e53ef) | `socat: 1.7.4.2 -> 1.7.4.3`                                          |
| [`226728e6`](https://github.com/NixOS/nixpkgs/commit/226728e600264087ddb257c1e09bad7fb0efb924) | `python310Packages.pymsteams: 0.1.16 -> 0.2.0`                       |
| [`19f8d8b6`](https://github.com/NixOS/nixpkgs/commit/19f8d8b693610ef6e62427ea51e7e772769b0f3b) | `metasploit: 6.1.24 -> 6.1.25`                                       |
| [`5fd24d88`](https://github.com/NixOS/nixpkgs/commit/5fd24d884acb8776715e5e559743e7ce6dc66d7d) | `exploitdb: 2022-01-14 -> 2022-01-20`                                |
| [`9372199f`](https://github.com/NixOS/nixpkgs/commit/9372199ffb25b256683dd088c6ee292af8b1cb99) | `python3Packages.pyathena:: add pythonImportsCheck`                  |
| [`e3deffc3`](https://github.com/NixOS/nixpkgs/commit/e3deffc3e8e3a68cd665b43228c74cd2490a4060) | `ocamlPackages.lablgtk3: 3.1.1 → 3.1.2`                              |
| [`a5b5ef0d`](https://github.com/NixOS/nixpkgs/commit/a5b5ef0d37b9db663f6e845d93d15fe8e05e78bd) | `Use jdk11 instead of packaged java to fix printing`                 |
| [`4be87942`](https://github.com/NixOS/nixpkgs/commit/4be87942bc150b2159e80837fe3693ce1893d00f) | `python310Packages.pydelijn: 0.6.1 -> 1.0.0`                         |
| [`b69f2210`](https://github.com/NixOS/nixpkgs/commit/b69f2210e281e03d38ebc065472ecc12f7b1a381) | `ratman: init at 0.3.1 (#155619)`                                    |
| [`2f066bd7`](https://github.com/NixOS/nixpkgs/commit/2f066bd7fcd11f66616a206dc52164beaa343472) | `python310Packages.pyathena: 2.3.2 -> 2.4.1`                         |
| [`44af29e6`](https://github.com/NixOS/nixpkgs/commit/44af29e6f5d8ca7d27ff951a52615ae238c27ccb) | `nixosTests.xmonad: test configured recompilation`                   |
| [`c625aff4`](https://github.com/NixOS/nixpkgs/commit/c625aff4d1a8257a10dbaf656adaa0723658d97c) | `mainprogram -> mainProgram`                                         |
| [`27fda8f1`](https://github.com/NixOS/nixpkgs/commit/27fda8f14d8c3d2e4bd4c611dc3a552e1c4cfacb) | `fixed buildInputs`                                                  |
| [`358ff989`](https://github.com/NixOS/nixpkgs/commit/358ff989767672c8bb4ecc4dd71a699f798d09d7) | `Enable asciidoctor-rouge extension`                                 |
| [`99398592`](https://github.com/NixOS/nixpkgs/commit/993985922bb93eea8207d756797b1db8c1efeaae) | `python310Packages.pa-ringbuffer: 0.1.3 -> 0.1.4`                    |
| [`6c72deb5`](https://github.com/NixOS/nixpkgs/commit/6c72deb51b13235adb4bd13ebba95e907f839e15) | `nixos/xmonad: update example config`                                |
| [`a78547d9`](https://github.com/NixOS/nixpkgs/commit/a78547d9687d35b12d9dafed3775b2e7a56c77e6) | `python3Packages.pyturbojpeg: 1.6.4 -> 1.6.5`                        |
| [`e32bd105`](https://github.com/NixOS/nixpkgs/commit/e32bd1054e945d68c140d9eb52089f8419032527) | `numix-icon-theme-square: 21.12.05 -> 22.01.15`                      |
| [`492e72ad`](https://github.com/NixOS/nixpkgs/commit/492e72adec1dd1da16e832bffa88ad391e8c8e98) | `numix-icon-theme-circle: 21.12.05 -> 22.01.15`                      |
| [`f37a71a7`](https://github.com/NixOS/nixpkgs/commit/f37a71a73706590b45ad82e98042702c4abf4a93) | `drush: 6.1.0 -> 8.4.10`                                             |
| [`b839b657`](https://github.com/NixOS/nixpkgs/commit/b839b657502705c9a1d60f89855e2b5396fe12ec) | `python310Packages.deep-translator: 1.6.0 -> 1.6.1`                  |
| [`cd873d3b`](https://github.com/NixOS/nixpkgs/commit/cd873d3b547253e5a1508a63aefd6552bd7c2657) | `amass: 3.15.2 -> 3.16.0`                                            |
| [`77528a24`](https://github.com/NixOS/nixpkgs/commit/77528a24f84ee4b363d72a84b08e4a225b7d4e2c) | `ucx: 1.11.2 -> 1.12.0`                                              |
| [`61d6c0e2`](https://github.com/NixOS/nixpkgs/commit/61d6c0e234050451deb96e6ad441d3fe3b2dbc50) | `Update pkgs/applications/misc/pdfstudioviewer/default.nix`          |
| [`cbee7202`](https://github.com/NixOS/nixpkgs/commit/cbee72024c30f9153f6e8db2c33d8f700d8b4722) | `file formatting`                                                    |
| [`9ae0c9a9`](https://github.com/NixOS/nixpkgs/commit/9ae0c9a972cdb79f1ce0a4916ed589f2e477ac84) | `Implemented reviewer suggestions`                                   |
| [`05ad6b0a`](https://github.com/NixOS/nixpkgs/commit/05ad6b0a111a702cd044928057bd4b02ddecbc9d) | `Update pkgs/applications/misc/pdfstudioviewer/default.nix`          |
| [`6114ed43`](https://github.com/NixOS/nixpkgs/commit/6114ed4314a6fe1965b2619bd06bbee7ba021215) | `Update pkgs/applications/misc/pdfstudioviewer/default.nix`          |
| [`e14cabc7`](https://github.com/NixOS/nixpkgs/commit/e14cabc709aa762a06dfbe4dbe922481ba8f7832) | `Update pkgs/applications/misc/pdfstudioviewer/default.nix`          |
| [`a3ea1bc5`](https://github.com/NixOS/nixpkgs/commit/a3ea1bc599f5c7dcea950b40c05f1abd3e5cd191) | `nixos/xmonad: enableConfiguredRecompile`                            |
| [`d5cc6c22`](https://github.com/NixOS/nixpkgs/commit/d5cc6c22ad1a905bae720f6d984c01bac23d5556) | `asciidoctor-with-extensions: enable html5s backend (#104831)`       |
| [`f7f1f47f`](https://github.com/NixOS/nixpkgs/commit/f7f1f47f9f1b57c4c9a43576ea8770ab2fac3dc5) | `pdfstudioviewer: init at 2021.1.2`                                  |
| [`d7d893c1`](https://github.com/NixOS/nixpkgs/commit/d7d893c17a56070ee51e2a514d98d9fc6e3e93d0) | `sfxr-qt: 1.3.0 -> 1.4.0`                                            |
| [`87efc216`](https://github.com/NixOS/nixpkgs/commit/87efc2168a181d9c19a824f7ede0c6a123b27e7e) | `snd: 21.8 -> 22.0`                                                  |
| [`6732e79a`](https://github.com/NixOS/nixpkgs/commit/6732e79a3225267220475b6f0a71f249ceb98361) | `gophernotes: 0.7.3 -> 0.7.4`                                        |
| [`532fa984`](https://github.com/NixOS/nixpkgs/commit/532fa984d517a04990f7d87cbc4051094c327a06) | `autorestic: 1.5.0 -> 1.5.1`                                         |
| [`3168017b`](https://github.com/NixOS/nixpkgs/commit/3168017b90440220c69d4ba8f39f469024b4cafe) | `nixos/lib: Clarify that nixos.evalModules impl is NOT experimental` |
| [`d3f956ab`](https://github.com/NixOS/nixpkgs/commit/d3f956aba324a18bfafde59138929b320a9b4a2b) | `nixos/lib: Add featureFlags, use it for minimal modules`            |
| [`25caf736`](https://github.com/NixOS/nixpkgs/commit/25caf736d5c16fa0c026c26ff4e7b7779fcbb7ae) | `nixos/eval-config: Layer on top of nixos/eval-config-minimal`       |
| [`e31e096b`](https://github.com/NixOS/nixpkgs/commit/e31e096b667f671aea424681f2b4a65e385efe50) | `nixos/lib: Move evalModules into its own file`                      |
| [`be3967e3`](https://github.com/NixOS/nixpkgs/commit/be3967e351b6e1b010e95ec16217ed2db33da0c5) | `nixos/nixpkgs.nix: Make independent`                                |
| [`fbd038ec`](https://github.com/NixOS/nixpkgs/commit/fbd038eca24703d8c5cc3ce28adda3e71c5fabf4) | `nixos/lib: init (experimental)`                                     |
| [`367ec166`](https://github.com/NixOS/nixpkgs/commit/367ec166d6ace50854a513a2c9eb703752a745a6) | `kube3d: 5.2.1 -> 5.2.2`                                             |
| [`a748e994`](https://github.com/NixOS/nixpkgs/commit/a748e9941c8abdd1314da625497907853a903336) | `joker: 0.17.3 -> 0.18.0`                                            |
| [`a1d26044`](https://github.com/NixOS/nixpkgs/commit/a1d260449beaccb383c4fa690925d1e512d03cab) | `helmsman: 3.7.7 -> 3.8.0`                                           |
| [`fcc8421e`](https://github.com/NixOS/nixpkgs/commit/fcc8421ec73d3ba7ba238cc0520899f7f74b80ad) | `guile-sdl2: 0.5.0 → 0.7.0`                                          |