### PR TITLE
chore(flake/ragenix): `9ff41d5a` -> `2597056b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,7 +2,10 @@
   "nodes": {
     "agenix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "ragenix",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1641576265,
@@ -57,21 +60,6 @@
       "original": {
         "owner": "edolstra",
         "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -146,52 +134,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-ronn": {
-      "locked": {
-        "lastModified": 1642436540,
-        "narHash": "sha256-D2eoDUNBiWszaQLFTCP2unffwTSLz5VaUHaG+QWsCXE=",
-        "owner": "veehaitch",
-        "repo": "nixpkgs",
-        "rev": "0df6b5ecb8173818a042a1bc840b5805a7ee6ee9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "veehaitch",
-        "ref": "ronn-r13y",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1642130244,
-        "narHash": "sha256-/5FhZkZFQCRQIRFosUQW1zmDrsNHVOJIB/+XgRPHiPU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "bc59ba15b64d0a0ee1d1764f18b4f3480d2c3e5a",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1642130244,
-        "narHash": "sha256-/5FhZkZFQCRQIRFosUQW1zmDrsNHVOJIB/+XgRPHiPU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "bc59ba15b64d0a0ee1d1764f18b4f3480d2c3e5a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "pre-commit-hooks": {
       "inputs": {
         "flake-utils": [
@@ -224,15 +166,14 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nixpkgs-ronn": "nixpkgs-ronn",
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1642461916,
-        "narHash": "sha256-5/IpWPcqndDnK2fkldD+e/Y4oheQozDXcP7R6hqUQHU=",
+        "lastModified": 1642763311,
+        "narHash": "sha256-rhxV3sp3jcWT0m2P3fX8m1yhkKyrXimKqUo35j0byYY=",
         "owner": "yaxitech",
         "repo": "ragenix",
-        "rev": "9ff41d5a0ad5f51c42979509904f93891ab461f9",
+        "rev": "2597056bdc15b0d8042e84d71c60225210d17c2f",
         "type": "github"
       },
       "original": {
@@ -257,8 +198,14 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_3"
+        "flake-utils": [
+          "ragenix",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "ragenix",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1642214598,


### PR DESCRIPTION
| SHA256                                                                                            | Commit Message                                                 |
| ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`2597056b`](https://github.com/yaxitech/ragenix/commit/2597056bdc15b0d8042e84d71c60225210d17c2f) | ``Revert "Flake: use `ronn` from nixos/nixpkgs#155363" (#86)`` |