### PR TITLE
chore(flake/ragenix): `2597056b` -> `6ac2ad1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -169,11 +169,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1642763311,
-        "narHash": "sha256-rhxV3sp3jcWT0m2P3fX8m1yhkKyrXimKqUo35j0byYY=",
+        "lastModified": 1642767541,
+        "narHash": "sha256-C68URUIEacWerJLJ8zXWzPuKbhwDEyq5Xh3H5etx/4g=",
         "owner": "yaxitech",
         "repo": "ragenix",
-        "rev": "2597056bdc15b0d8042e84d71c60225210d17c2f",
+        "rev": "6ac2ad1b2c713297ed2e8fd78b84b06c4555a079",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                            | Commit Message                       |
| ------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`6ac2ad1b`](https://github.com/yaxitech/ragenix/commit/6ac2ad1b2c713297ed2e8fd78b84b06c4555a079) | `Manpage: fix check and typos (#87)` |