### PR TITLE
chore(flake/home-manager): `e8a68de7` -> `d469b9bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1642857913,
-        "narHash": "sha256-yXgRdcse8SvrZnW/3OUfJ6oiXsag7LZJulMt+Tsbpqs=",
+        "lastModified": 1642864354,
+        "narHash": "sha256-ToKzPh4/4t8hiURT+rQo1SdocOfy3kDTbEuYubYPFlE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e8a68de7abb034d39c762c03a3b09ba6304d2fbf",
+        "rev": "d469b9bf8a1ca8b596eb86a25b478560fdf3cc2b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message       |
| ----------------------------------------------------------------------------------------------------------- | -------------------- |
| [`d469b9bf`](https://github.com/nix-community/home-manager/commit/d469b9bf8a1ca8b596eb86a25b478560fdf3cc2b) | `watson: add module` |
| [`32da35f6`](https://github.com/nix-community/home-manager/commit/32da35f65bb68710615eb82053439b89a1ee230d) | `helix: add module`  |