### PR TITLE
chore(flake/nixpkgs): `cb19ae8a` -> `aec48ffc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642866692,
-        "narHash": "sha256-plKaYrIfvZ27ZdfPIWG2v2tchZFtsRL4gNcst7DTBCs=",
+        "lastModified": 1642910085,
+        "narHash": "sha256-wdG5bcAD98A/ixa/8dQJdW7DNpi9D0JzKrBDjVUOoww=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cb19ae8afe362b6c686ba271cd41c7b008071456",
+        "rev": "aec48ffcb120381e24a953486bf02c372f8ae50e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`c24af464`](https://github.com/NixOS/nixpkgs/commit/c24af4642ceeab94936602bf96b8e5c591b79264) | `sambamba: 0.8.1 -> 0.8.2 (#155972)`                                                       |
| [`b9e9910c`](https://github.com/NixOS/nixpkgs/commit/b9e9910c012c56d92f2d71ebb7ed22ae24073e4c) | `Added new vim plugin: Coq nvim (#155421)`                                                 |
| [`7267839e`](https://github.com/NixOS/nixpkgs/commit/7267839e761cca2160233422b86296511591f32c) | `gprojector: init at 3.0.2 (#154932)`                                                      |
| [`61344186`](https://github.com/NixOS/nixpkgs/commit/613441860fc5bdbb30547d2b5c2514440f86fede) | `python3Packages.s3transfer: ignore test_compat on darwin (#155896)`                       |
| [`4cf0848f`](https://github.com/NixOS/nixpkgs/commit/4cf0848fc85a05bf46b142d3981f542e2e924034) | `nixosTests.boot-stage1: fix kernel build with 5.15`                                       |
| [`fb9297fc`](https://github.com/NixOS/nixpkgs/commit/fb9297fc3a2f70bdc97df0be2b0b3459b1f6da3a) | `python3Packages.pip: add pip-tools to tests`                                              |
| [`4e7fdc04`](https://github.com/NixOS/nixpkgs/commit/4e7fdc04c8115b2d797f4af8c69a745301f62317) | `argocd: 2.2.2 -> 2.2.3`                                                                   |
| [`ff78d373`](https://github.com/NixOS/nixpkgs/commit/ff78d373f9630382e1049867e3ff48214261bdec) | `python39Packages.liquidctl: 1.8.0 -> 1.8.1`                                               |
| [`58548a31`](https://github.com/NixOS/nixpkgs/commit/58548a314e25b63a228f6ecff0efdd9cb7d85e13) | `python39Packages.launchpadlib: 1.10.15.1 -> 1.10.16`                                      |
| [`7f5ea74f`](https://github.com/NixOS/nixpkgs/commit/7f5ea74fc95250438f35c582531b9e466cfa3621) | `skaffold: 1.35.1 -> 1.35.2`                                                               |
| [`994bd50d`](https://github.com/NixOS/nixpkgs/commit/994bd50deb4b3563cb3039834a790c58761a9e95) | `rubyPackages: update (#155876)`                                                           |
| [`295a85a6`](https://github.com/NixOS/nixpkgs/commit/295a85a6290d62e92d4fafc353594db666ef7ff8) | `clojure-lsp: 2021.11.02-15.24.47 -> 2022.01.22-01.31.09`                                  |
| [`7dd52153`](https://github.com/NixOS/nixpkgs/commit/7dd52153d4ff8dc2ec88e722547b5109861a47fa) | `ddosify: 0.7.1 -> 0.7.2`                                                                  |
| [`5de74e97`](https://github.com/NixOS/nixpkgs/commit/5de74e978d8878704a101ff3d61b32bee6fa428c) | `mongodb-compass: 1.29.6 -> 1.30.1`                                                        |
| [`d15b4964`](https://github.com/NixOS/nixpkgs/commit/d15b4964bd9346e2d0b9eb4de2947386a9bf9fb3) | `python310Packages.azure-mgmt-subscription: 2.0.0 -> 3.0.0`                                |
| [`112b79f8`](https://github.com/NixOS/nixpkgs/commit/112b79f8eed86338cdd4010d48476ac5fd7bca16) | `python310Packages.snowflake-connector-python: 2.7.2 -> 2.7.3`                             |
| [`76087ffd`](https://github.com/NixOS/nixpkgs/commit/76087ffda91251227cca1488d2b1a51db665592a) | `googleearth: Drop the package`                                                            |
| [`e9d74bf1`](https://github.com/NixOS/nixpkgs/commit/e9d74bf19bcff3170beee79eb90813c176d38304) | `hqplayerd: 4.28.2-76 -> 4.29.1-80`                                                        |
| [`1d495808`](https://github.com/NixOS/nixpkgs/commit/1d49580806f3dc8651d14c423dbee83d7fb96e83) | `src: switch to Python3`                                                                   |
| [`bb3add15`](https://github.com/NixOS/nixpkgs/commit/bb3add15ae114b99cec853f4ad6394c149b82676) | `python3Packages.dufte: fix tests for darwin`                                              |
| [`485d0fed`](https://github.com/NixOS/nixpkgs/commit/485d0fedc13d4e5678e14d2c84cd4b708a638612) | `panicparse: init at 2.2.0`                                                                |
| [`fafa1363`](https://github.com/NixOS/nixpkgs/commit/fafa1363f91d685135c8138f27e479ba72a837f2) | `brave: 1.34.80 -> 1.34.81`                                                                |
| [`db3d4f78`](https://github.com/NixOS/nixpkgs/commit/db3d4f7812a788c902b479a69bf5d4b4bbdd463c) | `catgirl: 2.0 -> 2.0a`                                                                     |
| [`195ac60c`](https://github.com/NixOS/nixpkgs/commit/195ac60c4e4a0acbf8f0ac12bc2b44e4ce27459c) | `reorder games section`                                                                    |
| [`c22cced4`](https://github.com/NixOS/nixpkgs/commit/c22cced43f8a74f3bef09437292f24ad5b45776c) | `yq-go: 4.16.2 -> 4.17.2`                                                                  |
| [`c4189a37`](https://github.com/NixOS/nixpkgs/commit/c4189a376d036cd42cb9536d5b32a6e69d2d45ff) | `jwt-cli: 5.0.1 -> 5.0.2`                                                                  |
| [`792ce2cb`](https://github.com/NixOS/nixpkgs/commit/792ce2cbc0856f5cef09986d967a992b169c0c1c) | `python3Packages.orjson: 3.6.5 -> 3.6.6`                                                   |
| [`4ea4a8ba`](https://github.com/NixOS/nixpkgs/commit/4ea4a8ba32320848d52fd154b012dd8e75a1c7aa) | `python3Packages.pymazda: add format`                                                      |
| [`958db137`](https://github.com/NixOS/nixpkgs/commit/958db13790d32eb7f0085fcdc74f9658072f19cb) | `diffoscope: 200 -> 201`                                                                   |
| [`b67aa192`](https://github.com/NixOS/nixpkgs/commit/b67aa192ba63a0abef5726fab3f2cfba3043cc29) | `drawio: add a check phase`                                                                |
| [`23507a5d`](https://github.com/NixOS/nixpkgs/commit/23507a5d7c4f31d44a575a95d68da2e3f6764bf4) | `drawio: 16.1.2 -> 16.4.0`                                                                 |
| [`fdf31022`](https://github.com/NixOS/nixpkgs/commit/fdf31022e027afbef88ba266cee4cc4cdde6198f) | `surge: init at 0.23.1`                                                                    |
| [`154f9ee2`](https://github.com/NixOS/nixpkgs/commit/154f9ee226dadad4fd68b2370d45c074b7306a60) | `krane: 2.3.4 → 2.4.0`                                                                     |
| [`ae6513b6`](https://github.com/NixOS/nixpkgs/commit/ae6513b613f1cf5652602982b4dadf9f19bda91c) | `python310Packages.pymazda: 0.3.0 -> 0.3.1`                                                |
| [`5d29853c`](https://github.com/NixOS/nixpkgs/commit/5d29853c389b52d75104415060fbeb2cd170a8fa) | `nixos/documentation.nix: Use builtins.storePath when appropriate`                         |
| [`0b222173`](https://github.com/NixOS/nixpkgs/commit/0b222173dba00680074ef9e98a5bad224f62967e) | `flake.nix: Set nixpkgs.config.path`                                                       |
| [`fecf3250`](https://github.com/NixOS/nixpkgs/commit/fecf32505984f4b8feae4c54663f322dcc8bd080) | `nixos/documentation.nix: Only use store non-flake pkgs.path directly when already copied` |
| [`15a00be1`](https://github.com/NixOS/nixpkgs/commit/15a00be189be329f488986cd72d7315fa643b89a) | `nixos/documentation: avoid copying nixpkgs subpaths, iteration 2`                         |
| [`813f9da8`](https://github.com/NixOS/nixpkgs/commit/813f9da8ab69f106055dd4a8fead7bc0a21a251b) | `pkgs.path: Avoid copying when used via flake`                                             |
| [`9a5d0ecd`](https://github.com/NixOS/nixpkgs/commit/9a5d0ecdac37a8aac403567623d8c16a833a48d7) | `python310Packages.dufte: 0.2.27 -> 0.2.29`                                                |
| [`119f988e`](https://github.com/NixOS/nixpkgs/commit/119f988e9d2ebc57d3fa3dd57219a095946f5774) | `python310Packages.tern: 2.9.0 -> 2.9.1`                                                   |
| [`d7ba76ec`](https://github.com/NixOS/nixpkgs/commit/d7ba76ec79c241c5eacc781ec48f6050c5a2b7d4) | `python39Packages.treex: 0.6.7 -> 0.6.8`                                                   |
| [`13541537`](https://github.com/NixOS/nixpkgs/commit/13541537bf298e9185a66c2f8e25c439023f19cf) | `python3Packages.meshtastic: 1.2.57 -> 1.2.58`                                             |
| [`6c18c678`](https://github.com/NixOS/nixpkgs/commit/6c18c678d2a87e19929b4d0567ce67304e2dcb8f) | `plocate: 1.1.7 -> 1.1.14`                                                                 |
| [`b24db018`](https://github.com/NixOS/nixpkgs/commit/b24db0182d3bde56e03cfe1a9ec3fdb6011f2c99) | `src: 1.28 -> 1.29`                                                                        |
| [`76cbe7fe`](https://github.com/NixOS/nixpkgs/commit/76cbe7fe31f3c7c4e54bda44eb036cb2d19b72f0) | `miniflux: 2.0.34 → 2.0.35`                                                                |
| [`a88e39e9`](https://github.com/NixOS/nixpkgs/commit/a88e39e972695856db58b0a4bfdb43a92b99c431) | `vimPlugins.nvim-comment: init at 2022-01-04`                                              |
| [`f9265f65`](https://github.com/NixOS/nixpkgs/commit/f9265f6537b8ac58a8142f124234b3b9dd8ed85f) | `vimPlugins.circles-nvim: init at 2022-01-11`                                              |
| [`5c79054b`](https://github.com/NixOS/nixpkgs/commit/5c79054b9895f4a240839802aceaed3fbd11895e) | `vimPlugins.Navigator-nvim: init at 2021-11-18`                                            |
| [`45fb0f90`](https://github.com/NixOS/nixpkgs/commit/45fb0f90a5490077842b0e5decac691d42b766f2) | `vimPlugins.switch-vim: init at 2021-09-29`                                                |
| [`1729f3be`](https://github.com/NixOS/nixpkgs/commit/1729f3be43ccb72c754eee8942f1e88aa5f02e95) | `vimPlugins.vim-clap: fix cargoSha256`                                                     |
| [`2667ef3b`](https://github.com/NixOS/nixpkgs/commit/2667ef3b7360979b8b4f5f40fff76aa86addd1df) | `vimPlugins.catppuccin-nvim: init at 2022-01-21`                                           |
| [`ab24f53e`](https://github.com/NixOS/nixpkgs/commit/ab24f53ea5eb98d02dfda05e8aaf3da936645106) | `vimPlugins: resolve github repository redirects`                                          |
| [`78c06b9b`](https://github.com/NixOS/nixpkgs/commit/78c06b9ba25e45cdedf720808cb7a6881d544306) | `vimPlugins: update`                                                                       |
| [`0576218a`](https://github.com/NixOS/nixpkgs/commit/0576218a4e654e81d5c85871150eb77e8ae1c3b1) | `ytfzf: 2.0 -> 2.1`                                                                        |
| [`05fa1e51`](https://github.com/NixOS/nixpkgs/commit/05fa1e51666617df615a74467905770faa632c91) | `proxmark-rrg: 4.14434 -> 4.14831`                                                         |
| [`58335362`](https://github.com/NixOS/nixpkgs/commit/58335362578e827ea1deb7935d6aafd1c2382aad) | `mariadb: mention multiple release support in release notes`                               |
| [`ef5d714f`](https://github.com/NixOS/nixpkgs/commit/ef5d714f8ce548716a95ed8cc66cb02851d63189) | `nixos/tests/mysql-backup: test multiple mariadb versions`                                 |
| [`37ba30c4`](https://github.com/NixOS/nixpkgs/commit/37ba30c49479b561b081d33cd9305140ec192bf4) | `nixos/tests/mysql-autobackup: test multiple mariadb versions`                             |
| [`a2ec554e`](https://github.com/NixOS/nixpkgs/commit/a2ec554e83acf57441060f3765efbcd25afec6c6) | `nixos/tests/mysql-replication: test multiple mariadb versions`                            |
| [`65dfe147`](https://github.com/NixOS/nixpkgs/commit/65dfe147b762c59eebe823acc44a1b7c8da00b1d) | `nixos/tests/mariadb-galera: test multiple mariadb versions`                               |
| [`38998112`](https://github.com/NixOS/nixpkgs/commit/38998112c1dc0fe64b5c1828337dd9fed3dcc006) | `nixos/tests/mysql: test multiple mariadb versions`                                        |
| [`98c82952`](https://github.com/NixOS/nixpkgs/commit/98c829527953fa9cbf0469fd769c44c1fba36490) | `mariadb: support multiple versions`                                                       |
| [`1f4f0a75`](https://github.com/NixOS/nixpkgs/commit/1f4f0a752d209dd024182826fd659a1a375d2635) | `plik,plikd: 1.3.1 -> 1.3.4`                                                               |
| [`ea166b8b`](https://github.com/NixOS/nixpkgs/commit/ea166b8bc02c6f565b6af3818ca9e1886bb1ddf5) | `python3Packages.dulwich: 0.20.30 -> 0.20.31`                                              |
| [`aab745de`](https://github.com/NixOS/nixpkgs/commit/aab745deddb5bf27a34fcd6bc21a79d107037019) | `cargo-geiger: 0.10.2 -> 0.11.2`                                                           |
| [`29837fcf`](https://github.com/NixOS/nixpkgs/commit/29837fcf68ad18c4bbf757ae2a5cb09e33094948) | `lingua-franca: 0.1.0 -> 0.1.1`                                                            |
| [`8283f2b1`](https://github.com/NixOS/nixpkgs/commit/8283f2b1ae627f389199506e64cc2291748aed4a) | `lingua-franca: add to top-level packages`                                                 |
| [`8b875ed6`](https://github.com/NixOS/nixpkgs/commit/8b875ed689d202801775ad7285d9aad0b2cb204b) | `ssm-session-manager-plugin: drop awscli build dependency`                                 |
| [`0657e317`](https://github.com/NixOS/nixpkgs/commit/0657e31781a363beb3f2f2dc9164acf5fa684199) | `starboard: 0.12.0 -> 0.14.0`                                                              |
| [`73fa2491`](https://github.com/NixOS/nixpkgs/commit/73fa2491fc57677361d881b1e36057581754b48e) | `kernel: rtw89 is part of newer kernels`                                                   |
| [`4280b73c`](https://github.com/NixOS/nixpkgs/commit/4280b73c84574694cac2a9127f84fcc621537fd9) | `python3Packages.formbox: 0.3.0 -> 0.4.1`                                                  |
| [`454f054c`](https://github.com/NixOS/nixpkgs/commit/454f054c5dd6f5f6ffd20cb016160d39a75a44ea) | `grype: 0.31.1 -> 0.32.0`                                                                  |
| [`1fc1506d`](https://github.com/NixOS/nixpkgs/commit/1fc1506d089d336c23ad567242555eb183e8884a) | `libnma: 1.8.32 -> 1.8.34`                                                                 |
| [`b865941f`](https://github.com/NixOS/nixpkgs/commit/b865941fea70ac85464cf42bdaacab179b9daf55) | `uboot: add Olimex A64 OLinuXino`                                                          |
| [`478a8fef`](https://github.com/NixOS/nixpkgs/commit/478a8fefa9815ba81409fc4532c3036ca8bad861) | `goffice: 0.10.50 -> 0.10.51`                                                              |
| [`5bfb7384`](https://github.com/NixOS/nixpkgs/commit/5bfb738471cdd61125d2a2f33a1869faa37a56c3) | `libgroove: drop`                                                                          |
| [`d12377b3`](https://github.com/NixOS/nixpkgs/commit/d12377b3c42b59d5d4803ee8a867df4b3b096789) | `python310Packages.zigpy-znp: 0.6.4 -> 0.7.0`                                              |
| [`cdee27dc`](https://github.com/NixOS/nixpkgs/commit/cdee27dcf84fe41281005353983118370390b969) | `python310Packages.wrf-python: 1.3.2 -> 1.3.2.6`                                           |
| [`c8f06984`](https://github.com/NixOS/nixpkgs/commit/c8f06984f211fbe2d7f30991634141b891ad9f4d) | `qtractor: 0.9.24 -> 0.9.25`                                                               |
| [`67e6d200`](https://github.com/NixOS/nixpkgs/commit/67e6d20064e93ab8ca56eb798b28c5e9bd1b009c) | `python310Packages.vertica-python: 1.0.2 -> 1.0.3`                                         |
| [`e456fb1c`](https://github.com/NixOS/nixpkgs/commit/e456fb1c2c7e7fbe6d80574890e1629e551231d6) | `qjackctl: 0.9.5 -> 0.9.6`                                                                 |
| [`45967894`](https://github.com/NixOS/nixpkgs/commit/45967894fb46de261e1b7bff7695f8735a3dae35) | `python310Packages.types-protobuf: 3.18.4 -> 3.19.5`                                       |
| [`58da28ff`](https://github.com/NixOS/nixpkgs/commit/58da28ff043cfd5895a28b1eb28c34aa4521107d) | `r2mod_cli: 1.2.0 -> 1.2.1`                                                                |
| [`0160b7bd`](https://github.com/NixOS/nixpkgs/commit/0160b7bd1fb7aafd0f944f7b7914b74a9211fecd) | `qpwgraph: 0.1.1 -> 0.2.0`                                                                 |
| [`3fcb41f0`](https://github.com/NixOS/nixpkgs/commit/3fcb41f09257f70ee02f056587603fcb0d824c98) | `python310Packages.types-futures: 3.3.2 -> 3.3.7`                                          |
| [`e1ff4238`](https://github.com/NixOS/nixpkgs/commit/e1ff423829e34472b93fe5afd72aa67dd6cf3e36) | `python310Packages.types-urllib3: 1.26.4 -> 1.26.7`                                        |
| [`ea3f0fc1`](https://github.com/NixOS/nixpkgs/commit/ea3f0fc12590d8885a3192e3fb2e702108394827) | `python310Packages.tinydb: 4.5.2 -> 4.6.1`                                                 |
| [`f02f48ad`](https://github.com/NixOS/nixpkgs/commit/f02f48ad463ded168ea4ac5668d65fc12ba007d8) | `python310Packages.zstandard: 0.16.0 -> 0.17.0`                                            |
| [`d388d118`](https://github.com/NixOS/nixpkgs/commit/d388d118681e7a3b4a0bb386c2da5d600f1d4c51) | `python310Packages.teslajsonpy: 1.5.0 -> 1.6.0`                                            |
| [`165e0cf8`](https://github.com/NixOS/nixpkgs/commit/165e0cf8316ba70ac4aba0e7967f7a976ef3049c) | `python310Packages.svglib: 1.1.0 -> 1.2.0`                                                 |
| [`9d73d50b`](https://github.com/NixOS/nixpkgs/commit/9d73d50bcbd232a39842205053411b6a1575e23a) | `python310Packages.stripe: 2.64.0 -> 2.65.0`                                               |
| [`982fdde7`](https://github.com/NixOS/nixpkgs/commit/982fdde7756bc63e83e20ab0148db84952be2b8d) | `neovim.tests: remove alias`                                                               |
| [`1210dffb`](https://github.com/NixOS/nixpkgs/commit/1210dffb9537f8d159b1ccf1a420ec1890f59cb4) | `wolfssl: enable tests`                                                                    |
| [`0efda5e2`](https://github.com/NixOS/nixpkgs/commit/0efda5e2d01eb7ffa5e0b605cc68858e4d1a67ae) | `nixos/dovecot: make use of mkEnableOption`                                                |
| [`c6683b4f`](https://github.com/NixOS/nixpkgs/commit/c6683b4f2723a018d9f66063dafa2444061387fc) | `nixos/dovecot: make ssl_dh optional`                                                      |
| [`f7b74591`](https://github.com/NixOS/nixpkgs/commit/f7b74591ea65f774190251fde9e72b95845f7987) | `python310Packages.downloader-cli: 0.3.1 -> 0.3.2`                                         |
| [`abe5804e`](https://github.com/NixOS/nixpkgs/commit/abe5804eff8efae2fcec83f6b1ba9f5ab108d4b7) | `wine{Unstable,Staging}: 7.0-rc6 -> 7.0`                                                   |
| [`ead5bfe3`](https://github.com/NixOS/nixpkgs/commit/ead5bfe3c81f020ecbf15bd83088553d979c6da3) | `wineStable: 6.0.2 -> 7.0`                                                                 |
| [`7342cdc7`](https://github.com/NixOS/nixpkgs/commit/7342cdc70156522050ce813386f6e159ca749d82) | `wine{Unstable,Staging}: 7.0-rc5 -> 7.0-rc6`                                               |
| [`f19a3884`](https://github.com/NixOS/nixpkgs/commit/f19a3884bcccb94fefbc974bd0b4452990fc7d5a) | `vulkan: 1.2.189.1 -> 1.2.198.0`                                                           |
| [`be279547`](https://github.com/NixOS/nixpkgs/commit/be279547db1c69cc5f06babdc2bc9e366f80d159) | `python3Packages.sphinx-inline-tabs: 2021.08.17.beta10 -> 2022.01.02.beta11`               |
| [`cbd80f29`](https://github.com/NixOS/nixpkgs/commit/cbd80f293c2f28440a95f24c781c2981738d247d) | `Zettlr: 2.0.2 -> 2.1.1`                                                                   |
| [`8d0d78ef`](https://github.com/NixOS/nixpkgs/commit/8d0d78efd9b80a1ea82f138c40fb5505a6fee50f) | `bluez5: add experimental variant`                                                         |