### PR TITLE
chore(flake/nixpkgs): `aec48ffc` -> `2d42d654`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,10 +2,7 @@
   "nodes": {
     "agenix": {
       "inputs": {
-        "nixpkgs": [
-          "ragenix",
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1641576265,
@@ -60,6 +57,21 @@
       "original": {
         "owner": "edolstra",
         "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -120,16 +132,46 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642910085,
-        "narHash": "sha256-wdG5bcAD98A/ixa/8dQJdW7DNpi9D0JzKrBDjVUOoww=",
+        "lastModified": 1642953497,
+        "narHash": "sha256-h6+e14NyEQbH7osZtuEHOPS6twL5wINDEeffKaZ0xDY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aec48ffcb120381e24a953486bf02c372f8ae50e",
+        "rev": "2d42d654aa482de067d30285d8d5bdce5e32ec62",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1642880071,
+        "narHash": "sha256-NZW5BczhluZVkKblxrFqJbawUPxuC2HdKQ1t/+vKA34=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "30daa988f107bc4c910c398a77b2b89864049932",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1642880071,
+        "narHash": "sha256-NZW5BczhluZVkKblxrFqJbawUPxuC2HdKQ1t/+vKA34=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "30daa988f107bc4c910c398a77b2b89864049932",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -198,14 +240,8 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "ragenix",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "ragenix",
-          "nixpkgs"
-        ]
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1642838864,


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`2d42d654`](https://github.com/NixOS/nixpkgs/commit/2d42d654aa482de067d30285d8d5bdce5e32ec62) | `mautrix-telegram: 0.11.0 -> 0.11.1 (#156099)`                                      |
| [`3d94cba6`](https://github.com/NixOS/nixpkgs/commit/3d94cba62991fe96e15a4e7da3ca8a188cb459e0) | `gitlab: 14.6.2 -> 14.6.3 (#156296)`                                                |
| [`0e4c2ff9`](https://github.com/NixOS/nixpkgs/commit/0e4c2ff9b9fc017425df352d785efcd5d57aa4ee) | `ocamlPackages.camlpdf: 2.4 → 2.5`                                                  |
| [`deaf36f4`](https://github.com/NixOS/nixpkgs/commit/deaf36f4c68b4d9537d071e821706480d31a12e5) | `snarkos: init at unstable-2021-01-21 (#156209)`                                    |
| [`b876a7e5`](https://github.com/NixOS/nixpkgs/commit/b876a7e5493c399b8a40715ea920d4ef815da229) | `python3Packages.sigrok: init at 0.5.1`                                             |
| [`8499ca25`](https://github.com/NixOS/nixpkgs/commit/8499ca252ab0516c9244eb1150ea6e2e808441ac) | `mandoc: move executableCross assert into meta.broken`                              |
| [`3ab8db0a`](https://github.com/NixOS/nixpkgs/commit/3ab8db0ad04f6f6efae25375ae9577a729d9edc5) | `mandoc: fix executableCross condition`                                             |
| [`c95e816c`](https://github.com/NixOS/nixpkgs/commit/c95e816c655a1032e25ddcd81d1b4b02f7b69757) | `nixos/wordpress: Drop old deprecated interface (#152674)`                          |
| [`3db4201b`](https://github.com/NixOS/nixpkgs/commit/3db4201bc8447282218c7d74b1f17a763820c8f2) | `mixRelease: allow specifying buildInputs (#156288)`                                |
| [`c30f25ff`](https://github.com/NixOS/nixpkgs/commit/c30f25ffbb56719a7e03e6639688a1cee5a4a2c7) | `canon-cups-ufr2: fix library patching; use proot to enable cnsetuputil2 (#156090)` |
| [`63f93a91`](https://github.com/NixOS/nixpkgs/commit/63f93a91d4340a90516764ba3f2849737d8f12c6) | `bumblebee: fix source url`                                                         |
| [`0439a474`](https://github.com/NixOS/nixpkgs/commit/0439a474bf377c435191a052c0d38df9b3bbc144) | `imagemagick: 7.1.0-19 -> 7.1.0-20`                                                 |
| [`ba24545d`](https://github.com/NixOS/nixpkgs/commit/ba24545d7324375e4cc7638a41687d966c41e340) | `maintainers/team-list: add drupol to php team`                                     |
| [`5d861604`](https://github.com/NixOS/nixpkgs/commit/5d861604cf8c0967bf9173bae144e385ef5504c7) | `python3Packages.jsmin: add pythonImportsCheck`                                     |
| [`c78e9334`](https://github.com/NixOS/nixpkgs/commit/c78e9334716a128c0d0c325be69916ad3d74f01b) | `typos: 1.3.4 -> 1.3.5`                                                             |
| [`4c5f5d5b`](https://github.com/NixOS/nixpkgs/commit/4c5f5d5b3a6d05b4f88eca5c139311fe16c745df) | `python3Packages.sagemaker: disable on older Python releases`                       |
| [`43a9b2ec`](https://github.com/NixOS/nixpkgs/commit/43a9b2ecc8c419a96999dbfafc538879a285595e) | `python3Packages.somajo: add pythonImportsCheck`                                    |
| [`43bbef49`](https://github.com/NixOS/nixpkgs/commit/43bbef4978554a733a987ae307aa658ba34af1d0) | `ocamlPackages.lablgtk: 2.18.10 → 2.18.12`                                          |
| [`e3183d75`](https://github.com/NixOS/nixpkgs/commit/e3183d75e3aac9b0aae7cb4e9d2ebe7f71cc03c9) | `ocamlPackages.lablgtk: disable glade support`                                      |
| [`1c1b9186`](https://github.com/NixOS/nixpkgs/commit/1c1b91861a5f66dbd7b3ddb0691de23e4c10827d) | `ocamlPackages.gtktop: remove at 2.0`                                               |
| [`493e1d9b`](https://github.com/NixOS/nixpkgs/commit/493e1d9bc23dc008a2be2849be8bf9b46c525851) | `python310Packages.aiohomekit: 0.6.10 -> 0.6.11`                                    |
| [`c43ee47d`](https://github.com/NixOS/nixpkgs/commit/c43ee47d81f2a7129c8c1576bcdb322622f8a700) | `python3Packages.bsblan: disable on older Python releases`                          |
| [`c59a18ed`](https://github.com/NixOS/nixpkgs/commit/c59a18edec84458805885beaf786aacc69ec5dfc) | `python310Packages.cocotb-bus: 0.2.0 -> 0.2.1`                                      |
| [`63db2abf`](https://github.com/NixOS/nixpkgs/commit/63db2abf0dad8b1db92985db30328f9b12a1437c) | `libadwaita: propagate gtk4`                                                        |
| [`a59d23e2`](https://github.com/NixOS/nixpkgs/commit/a59d23e2b2ec592382653bcbb11ae0ac98c25cc8) | `giara: 0.3 -> 1.0`                                                                 |
| [`fd196d26`](https://github.com/NixOS/nixpkgs/commit/fd196d26a418751d161823e9ff90ebbd600d9b3f) | `python310Packages.zigpy: 0.42.0 -> 0.43.0`                                         |
| [`2984fbf4`](https://github.com/NixOS/nixpkgs/commit/2984fbf4ac79fe766c146ad481a72b9e548ecd86) | `python39Packages.jc: 1.17.6 -> 1.18.1`                                             |
| [`9f482d8f`](https://github.com/NixOS/nixpkgs/commit/9f482d8f8b90960e35d5db004a54025a1d8ffb1b) | `python310Packages.gphoto2: 2.3.1 -> 2.3.2`                                         |
| [`e0801ba6`](https://github.com/NixOS/nixpkgs/commit/e0801ba64b803458644bf26e3e2acdbe7d587895) | `python39Packages.google-cloud-language: 2.3.1 -> 2.3.2`                            |
| [`651242ed`](https://github.com/NixOS/nixpkgs/commit/651242ed728718267b78113fc8e8c82f032e462c) | `python310Packages.motionblinds: 0.5.8.2 -> 0.5.10`                                 |
| [`73486fec`](https://github.com/NixOS/nixpkgs/commit/73486feca0a5c8c8bad8bab91518dc362bdd48a3) | `python39Packages.influxdb-client: 1.24.0 -> 1.25.0`                                |
| [`02d6ae24`](https://github.com/NixOS/nixpkgs/commit/02d6ae24ae4a8a43c6a1346e7dad90707ad8f756) | `python310Packages.cyclonedx-python-lib: 1.1.0 -> 1.1.1`                            |
| [`ef654bec`](https://github.com/NixOS/nixpkgs/commit/ef654bec02f6512cbc118171478aea9b1ca56809) | `python310Packages.pymsteams: 0.2.0 -> 0.2.1`                                       |
| [`1921de36`](https://github.com/NixOS/nixpkgs/commit/1921de36e7e99c3f4eab7702796b12c4c2d370d1) | `python310Packages.aioapns: 2.0.2 -> 2.1`                                           |
| [`0ab07de3`](https://github.com/NixOS/nixpkgs/commit/0ab07de35cb65ec7933849145c625271eb2d082f) | `python39Packages.easy-thumbnails: 2.8 -> 2.8.1`                                    |
| [`607c7e95`](https://github.com/NixOS/nixpkgs/commit/607c7e95dc7928165af8ae3ce74e7056f6d428f1) | `python310Packages.mattermostdriver: 7.3.1 -> 7.3.2`                                |
| [`f5dfef02`](https://github.com/NixOS/nixpkgs/commit/f5dfef02b93f8e51d393b22c631d21e8a204294a) | `python310Packages.afsapi: 0.2.0 -> 0.2.1`                                          |
| [`db3cc2d3`](https://github.com/NixOS/nixpkgs/commit/db3cc2d36ec1b4023abf1e742a69daa0115ff83e) | `python310Packages.bsblan: 0.4.1 -> 0.5.0`                                          |
| [`6cecc1f6`](https://github.com/NixOS/nixpkgs/commit/6cecc1f603bd8b7ce9c1ea57697f0f5324b418c4) | `n8n: 0.105.0 -> 0.160.0, fix build`                                                |
| [`e3d7f9f6`](https://github.com/NixOS/nixpkgs/commit/e3d7f9f641290127a09cdc17b96f1ab053244a7e) | `python310Packages.diagrams: 0.20.0 -> 0.21.0`                                      |
| [`cd8681a9`](https://github.com/NixOS/nixpkgs/commit/cd8681a955eea3e1b367d2349f50465a9323fdef) | `optifinePackages: init`                                                            |
| [`9e852951`](https://github.com/NixOS/nixpkgs/commit/9e852951abd929b6466336bb8614c749370acd2e) | `qownnotes: 22.1.7 -> 22.1.9`                                                       |
| [`c7af30ec`](https://github.com/NixOS/nixpkgs/commit/c7af30ec5256ab003404f6393421e0c6ae236cec) | `supertux: 0.6.2 -> 0.6.3`                                                          |
| [`fcb773a5`](https://github.com/NixOS/nixpkgs/commit/fcb773a54abcee4484a38a63f2c2c15aec6b021e) | `python3Packages.flux-led: 0.28.4 -> 0.28.8`                                        |
| [`1954d712`](https://github.com/NixOS/nixpkgs/commit/1954d712dc2c67dc028dc4a9726a560daec43a37) | `super-productivity: 7.9.2 -> 7.10.0`                                               |
| [`d00bd8a4`](https://github.com/NixOS/nixpkgs/commit/d00bd8a42962ae343b1020eb6038fd597f610274) | `ytarchive: 0.3.0 -> unstable-2021-12-29`                                           |
| [`43610e23`](https://github.com/NixOS/nixpkgs/commit/43610e23cc7e8a44f6688b46d9f2efa5ea90cc66) | `python3Packages.pygraphviz: 1.7 -> 1.8`                                            |
| [`d4076aaa`](https://github.com/NixOS/nixpkgs/commit/d4076aaa99071446e663a257f0add0244012d09d) | `python39Packages.cupy: 9.6.0 -> 10.1.0`                                            |
| [`dbe0d138`](https://github.com/NixOS/nixpkgs/commit/dbe0d13856f7cf389a8b72db9a448ce14e84edf0) | `maigret: 0.4.0 -> 0.4.1`                                                           |
| [`2d8df8ca`](https://github.com/NixOS/nixpkgs/commit/2d8df8cab2cff06eb4bb698ae62b559c2aecec4d) | `inotify-tools: 3.21.9.6 -> 3.22.1.0`                                               |
| [`e5fd2e73`](https://github.com/NixOS/nixpkgs/commit/e5fd2e7324378fdc4c9706c1404644878b7e4bf7) | `python3Packages.nmapthon2: 0.1.2 -> 0.1.3`                                         |
| [`227011af`](https://github.com/NixOS/nixpkgs/commit/227011af5999182379d72c2575edab0d67d8aa1c) | `deeptools: 3.5.0 -> 3.5.1`                                                         |
| [`8deeb8a7`](https://github.com/NixOS/nixpkgs/commit/8deeb8a71fed795591c80eb5a08875d21380bf84) | `broadlink-cli: 0.17.0 -> 0.18.0`                                                   |
| [`0e9544b1`](https://github.com/NixOS/nixpkgs/commit/0e9544b12a4c69adf86c97a40a90b994b5859c29) | `xdg-user-dirs: fix cross compilation`                                              |
| [`a3894294`](https://github.com/NixOS/nixpkgs/commit/a38942945313fb1b9a1e52773e851f0012228b56) | `hplip_3_16_11: drop`                                                               |
| [`0a1da635`](https://github.com/NixOS/nixpkgs/commit/0a1da6357c8993ab5e9a8e0824be2859e1fea90e) | `sogo: 5.4.0 -> 5.5.0`                                                              |
| [`3e01a90d`](https://github.com/NixOS/nixpkgs/commit/3e01a90db43dc7fb1a2c6cea073db9e118393560) | `home-assistant: update component-packages`                                         |
| [`fa3190a1`](https://github.com/NixOS/nixpkgs/commit/fa3190a16cc034d6b0390ac850372776a8bf2d14) | `python310Packages.co2signal: init at 0.4.2`                                        |
| [`056a0fb8`](https://github.com/NixOS/nixpkgs/commit/056a0fb8fa453d94c443c16ae81fc5ba46b3ff48) | `python310Packages.somajo: 2.1.6 -> 2.2.0`                                          |
| [`6d9277e3`](https://github.com/NixOS/nixpkgs/commit/6d9277e37316ebfdf14b96f8eb26a6bf8466062a) | `python310Packages.simpleeval: 0.9.11 -> 0.9.12`                                    |
| [`7606a4dd`](https://github.com/NixOS/nixpkgs/commit/7606a4ddacd248d9b4da81af57cabf52594334a6) | `python310Packages.sagemaker: 2.72.2 -> 2.73.0`                                     |
| [`98b91808`](https://github.com/NixOS/nixpkgs/commit/98b9180882f9604cabd9f3feced54fdf38efa83b) | `python310Packages.python-gitlab: 3.0.0 -> 3.1.0`                                   |
| [`73ad435f`](https://github.com/NixOS/nixpkgs/commit/73ad435f389e92f1212c88b1b5f356dfc67ecf1d) | `sope: 5.4.0 -> 5.5.0`                                                              |
| [`1b259474`](https://github.com/NixOS/nixpkgs/commit/1b259474b8041c91d559741f39117e598e4ffe00) | `python3Packages.pydal: add format`                                                 |
| [`6237084a`](https://github.com/NixOS/nixpkgs/commit/6237084acf3f18220f7562248973ce0567f8b2b5) | `ibus-libpinyin: enable more features`                                              |
| [`c0ebf3ae`](https://github.com/NixOS/nixpkgs/commit/c0ebf3ae09cffc8459243581c1ef388911cd0a9c) | `python310Packages.pydal: 20210626.3 -> 20220114.1`                                 |
| [`29c7aefe`](https://github.com/NixOS/nixpkgs/commit/29c7aefec2f62cadf93c8f86e3d7036bf180341a) | `python310Packages.phonenumbers: 8.12.40 -> 8.12.41`                                |
| [`c3d87e73`](https://github.com/NixOS/nixpkgs/commit/c3d87e73e6c2213ea4977d44e7cc4cc78bc20eed) | `python310Packages.ibm-cloud-sdk-core: 3.13.2 -> 3.14.0`                            |
| [`bcff7661`](https://github.com/NixOS/nixpkgs/commit/bcff7661cf3d40a6af2333cae45ff512c555d312) | `ffado: bump scons`                                                                 |
| [`d0a82640`](https://github.com/NixOS/nixpkgs/commit/d0a826400a0449242a853aa482c52e7e0447e4d1) | `python310Packages.dj-email-url: 1.0.2 -> 1.0.4`                                    |
| [`97052019`](https://github.com/NixOS/nixpkgs/commit/97052019cdbb70f95a33f28632700bedf8e898b1) | `libsigrok: take unversioned python argument`                                       |
| [`4555282b`](https://github.com/NixOS/nixpkgs/commit/4555282bc1fa93d3b66cda4609235922a2ac8a43) | `python3Packages.gamble: init at 0.10`                                              |
| [`69801692`](https://github.com/NixOS/nixpkgs/commit/69801692ae575e742061919a4786e1b1af1169ab) | `net-snmp: General fixup`                                                           |
| [`641a7ded`](https://github.com/NixOS/nixpkgs/commit/641a7dedef9ee47df6af6dc706c35360090061ad) | `artha: 1.0.3 -> 1.0.5`                                                             |
| [`f2c9cb2b`](https://github.com/NixOS/nixpkgs/commit/f2c9cb2bd8977c4cccd54bfce8482ad6d579207e) | `rivercarro: init at 0.1.1`                                                         |
| [`99af47c0`](https://github.com/NixOS/nixpkgs/commit/99af47c0e8c1a35244c4b7c1510ed44c89a4ca19) | `python3Packages.pytibber: 0.21.6 -> 0.22.0`                                        |
| [`87502df4`](https://github.com/NixOS/nixpkgs/commit/87502df43b246c020ff47e99e1d06c4fbb36022f) | `nixos/systemd-boot: fix error output`                                              |
| [`c14c90f4`](https://github.com/NixOS/nixpkgs/commit/c14c90f46179a879a1d4bb3211add3403afeefd6) | `python3Packages.flake8-docstrings: init at 1.6.0`                                  |
| [`937b599a`](https://github.com/NixOS/nixpkgs/commit/937b599abef6af8bbd537297826e75cea37834d5) | `staticjinja: add minimal template test`                                            |
| [`6e453fe7`](https://github.com/NixOS/nixpkgs/commit/6e453fe75c455f9a7dcfe6687baca490eaf993ba) | `staticjinja: 4.1.1 -> 4.1.2`                                                       |
| [`2cebc117`](https://github.com/NixOS/nixpkgs/commit/2cebc117e108350634c5d311c616c8715df923c0) | `python39Packages.stumpy: cleanup test dependencies`                                |