### PR TITLE
chore(flake/nixpkgs): `2d42d654` -> `4ad9f4e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642953497,
-        "narHash": "sha256-h6+e14NyEQbH7osZtuEHOPS6twL5wINDEeffKaZ0xDY=",
+        "lastModified": 1642995822,
+        "narHash": "sha256-yeVgyKEq9gyOSGufK8+1vWdhhG2gOMc3cVjixh47LFM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2d42d654aa482de067d30285d8d5bdce5e32ec62",
+        "rev": "4ad9f4e242df6a8babd3f3787a2cf8bbdc60a0fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                          |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`4ad9f4e2`](https://github.com/NixOS/nixpkgs/commit/4ad9f4e242df6a8babd3f3787a2cf8bbdc60a0fb) | `apfel: 3.0.5 -> 3.0.6`                                                 |
| [`998f87ed`](https://github.com/NixOS/nixpkgs/commit/998f87ed0244e118aa96d1c387435fd8cb8aedd8) | `gopls: 0.7.4 -> 0.7.5`                                                 |
| [`c1801065`](https://github.com/NixOS/nixpkgs/commit/c1801065f4458ec0a320c074ad48781956eb9093) | `indicator-sound-switcher: init at 2.3.6 (#147413)`                     |
| [`96718156`](https://github.com/NixOS/nixpkgs/commit/96718156c793be6fb228733f2a330ac1401da659) | `clifm: 1.3 -> 1.4`                                                     |
| [`a899a381`](https://github.com/NixOS/nixpkgs/commit/a899a38128f9d3b8ab1127a205ebd8ab9fbc4e54) | `clair: 4.3.5 -> 4.3.6`                                                 |
| [`a316ed0c`](https://github.com/NixOS/nixpkgs/commit/a316ed0c205d43f93b3f857735dabb934e002119) | `chezmoi: 2.9.5 -> 2.10.1`                                              |
| [`27e10a3b`](https://github.com/NixOS/nixpkgs/commit/27e10a3b92e9df8b899dd09b1dafab28f2303ff1) | `snis: init at 20211017 (#142034)`                                      |
| [`5f45d80e`](https://github.com/NixOS/nixpkgs/commit/5f45d80e002b7c71ef1d2437595e0e6c62de4073) | `certigo: 1.13.0 -> 1.14.1`                                             |
| [`ccab29ce`](https://github.com/NixOS/nixpkgs/commit/ccab29ceb13ad3ff7a0dbbf4867f6d305ba84cc7) | `jackett: 0.20.417 -> 0.20.428`                                         |
| [`4916f0ee`](https://github.com/NixOS/nixpkgs/commit/4916f0eee2da6cd5ecd4e4610cd0723cdb9059b2) | `cargo-udeps: 0.1.25 -> 0.1.26`                                         |
| [`d53ef8b8`](https://github.com/NixOS/nixpkgs/commit/d53ef8b8229336b0f7dcb5b8fbeba217a0bf2033) | `nixos/locate Add support for plocate (#156185)`                        |
| [`c78dba5f`](https://github.com/NixOS/nixpkgs/commit/c78dba5f76837695d75b6f7903cb776b904a2653) | `kubernetes: use maintainer team`                                       |
| [`745e1ea2`](https://github.com/NixOS/nixpkgs/commit/745e1ea21b7644d20224154a992528beaf7bccb5) | `maintainers/teams: add kubernetes`                                     |
| [`2702a699`](https://github.com/NixOS/nixpkgs/commit/2702a6999f32dbb202147451d5fa55fccd821bf9) | `kubectl: move alongside kubernetes`                                    |
| [`5d18ae84`](https://github.com/NixOS/nixpkgs/commit/5d18ae8459855d0a143d2ca0bc7929225b8602b6) | `.github/CODEOWNERS: add kubernetes`                                    |
| [`7b7c23fe`](https://github.com/NixOS/nixpkgs/commit/7b7c23fe42dc34f6475ee3728e89f72f61d12efd) | `bfs: 2.3 -> 2.3.1`                                                     |
| [`fff9730c`](https://github.com/NixOS/nixpkgs/commit/fff9730ce0a324f2a19abb619e3cd8ae866f8912) | `bazel-buildtools: 4.2.4 -> 4.2.5`                                      |
| [`667ff184`](https://github.com/NixOS/nixpkgs/commit/667ff184351c3f1a5173030f34f4fddfd1b9776b) | `Groestlcoin: init at 22.0`                                             |
| [`4f45f1ab`](https://github.com/NixOS/nixpkgs/commit/4f45f1ab490440a1218461499be5e4cb49142c82) | `aliyun-cli: 3.0.102 -> 3.0.104`                                        |
| [`177f8cac`](https://github.com/NixOS/nixpkgs/commit/177f8cac9bd9e035027203f37d066e77694040f0) | `Update pkgs/development/python-modules/ihatemoney/default.nix`         |
| [`6c3385ba`](https://github.com/NixOS/nixpkgs/commit/6c3385ba022de3de10f9943825fe3b6698b76f16) | `python310Packages.youtube-search-python: 1.6.0 -> 1.6.1`               |
| [`5e822e54`](https://github.com/NixOS/nixpkgs/commit/5e822e54d20ddd4805022cfcf8e813111ce00c27) | `AusweisApp2: 1.22.2 -> 1.22.3`                                         |
| [`0522e55f`](https://github.com/NixOS/nixpkgs/commit/0522e55f996974f1f677617ddc2d9537845907b3) | `ocamlPackages.ppxlib: 0.23.0 -> 0.24.0 (#154901)`                      |
| [`02ffdfc6`](https://github.com/NixOS/nixpkgs/commit/02ffdfc68587a68d5e96a3c314f378f438b251eb) | `stellarsolver: enable on non-linux`                                    |
| [`8718a35c`](https://github.com/NixOS/nixpkgs/commit/8718a35c5f57f29bbd889677cd898ff458cfec40) | `gay: refactor python packaging method`                                 |
| [`96349a61`](https://github.com/NixOS/nixpkgs/commit/96349a614291eb323b2403716faf9f6b59a3c93b) | `python310Packages.libarchive-c: 3.2 -> 4.0`                            |
| [`1526558d`](https://github.com/NixOS/nixpkgs/commit/1526558d4bf6fe56177be628699b108e528b6d51) | `xgboost: 1.5.1 -> 1.5.2`                                               |
| [`bba53f20`](https://github.com/NixOS/nixpkgs/commit/bba53f208055cc7e872025551efcf5a463cfd142) | `libagent: 0.14.1 -> 0.14.4 (#154780)`                                  |
| [`31e8ff77`](https://github.com/NixOS/nixpkgs/commit/31e8ff776acc7d7e87ecbec4ef9f4504070a7ba7) | `remake: 4.3+dbg-1.5 -> 4.3+dbg-1.6`                                    |
| [`2e719d1c`](https://github.com/NixOS/nixpkgs/commit/2e719d1cdab9e81750c19425a1f5c7678b5e73ad) | `sway: 1.6.1 -> 1.7`                                                    |
| [`ae917ed0`](https://github.com/NixOS/nixpkgs/commit/ae917ed02476a2b98d5019f6abe028a2e7bcd271) | `xl2tpd: 1.3.16 -> 1.3.17`                                              |
| [`e15eef0a`](https://github.com/NixOS/nixpkgs/commit/e15eef0aab665446f959d1e54f1c6b919f27d2c2) | `zettlr: 2.1.1 -> 2.1.2`                                                |
| [`290b04c5`](https://github.com/NixOS/nixpkgs/commit/290b04c5a8cfc4fad000364139145b3e9fe6f83b) | `lzwolf: init at unstable-2022-01-04`                                   |
| [`c0134288`](https://github.com/NixOS/nixpkgs/commit/c0134288e7a25e95d0ee926aa710118d39cf639a) | `nodePackages.triton: add completion`                                   |
| [`75902bb8`](https://github.com/NixOS/nixpkgs/commit/75902bb873391f19a0063f56089b44d6b5d3af76) | `nodePackages.manta: add completion`                                    |
| [`f2ed702e`](https://github.com/NixOS/nixpkgs/commit/f2ed702e7eed6c8973e9b93628dd41b38b1615ec) | `rehex: 0.3.92 -> 0.4.1`                                                |
| [`6e66a077`](https://github.com/NixOS/nixpkgs/commit/6e66a07719650782617d47caac06e2069c027c50) | `zola: 0.15.2 -> 0.15.3`                                                |
| [`9655e2f7`](https://github.com/NixOS/nixpkgs/commit/9655e2f79503bd1b073a6e71a4576765c4cfa1ad) | `libretro.citra-canary: init at unstable-2022-01-21`                    |
| [`f501e952`](https://github.com/NixOS/nixpkgs/commit/f501e9521adca23a1efeec1ed6b2385f1880cbe5) | `kube-hunter: 0.6.3 -> 0.6.4`                                           |
| [`8b86f981`](https://github.com/NixOS/nixpkgs/commit/8b86f9816dd46a8b29088ddd91b0a590829f282a) | `handbrake: convert nixos test to runCommand`                           |
| [`63921adc`](https://github.com/NixOS/nixpkgs/commit/63921adcd4ff10d8c7f2082df31291a1a3bfd5f6) | `flexget: 3.2.11 -> 3.2.13`                                             |
| [`6833cd17`](https://github.com/NixOS/nixpkgs/commit/6833cd17bd87f22be92af972e34039154ebe204a) | `python3Packages.ansimarkup: init at 1.5.0`                             |
| [`5404f234`](https://github.com/NixOS/nixpkgs/commit/5404f23417e41d64f45c95be881fd08d698f9ffd) | `stellarsolver: 1.8 -> 1.9`                                             |
| [`16305595`](https://github.com/NixOS/nixpkgs/commit/163055958b5c3841009f8eeb288ebcf2a71fbf0e) | `terragrunt: 0.35.20 -> 0.36.0`                                         |
| [`fa74c63b`](https://github.com/NixOS/nixpkgs/commit/fa74c63bdc1065e51486ce3d687db64c2105191d) | `vlc: optional Wayland support`                                         |
| [`857d2878`](https://github.com/NixOS/nixpkgs/commit/857d2878552a4197b4ba5cd6d54f05e199eaf40f) | `sdat2img: init at unstable-2021-11-9`                                  |
| [`c642e1fc`](https://github.com/NixOS/nixpkgs/commit/c642e1fc5c236650a11f8d3206f36b73b5cbf0c7) | `maintainers: add gruve-p`                                              |
| [`8704f948`](https://github.com/NixOS/nixpkgs/commit/8704f948f1a0453d6ffdde7f5ba1ce70a2bc0d0c) | `mpich: 3.4.3 -> 4.0`                                                   |
| [`5947b9e9`](https://github.com/NixOS/nixpkgs/commit/5947b9e974318a76d942d9edd7ce4ab3078628ad) | `alacritty: fix build on aarch64`                                       |
| [`e54d9608`](https://github.com/NixOS/nixpkgs/commit/e54d96082474cedcb7430cc582639f35aa5dd61e) | `libxc: 5.1.7 -> 5.2.0`                                                 |
| [`10047fc2`](https://github.com/NixOS/nixpkgs/commit/10047fc2b3592585a20c091ac28e5e8e9c078081) | `python3Packages.ihatemoney: fix build`                                 |
| [`f7184176`](https://github.com/NixOS/nixpkgs/commit/f71841764835f3fce502015e3013a8101c380dfa) | `python3Packages.sqlalchemy-continuum: 1.3.11 -> 1.3.12`                |
| [`8f377752`](https://github.com/NixOS/nixpkgs/commit/8f37775234ea075244384dc5d9407d8f9557024b) | `alacritty: 0.9.0 -> 0.10.0`                                            |
| [`86cc0e8f`](https://github.com/NixOS/nixpkgs/commit/86cc0e8fc272cf4aeaf44acbf83ce5f2590aa3b8) | `streamlink: 3.0.3 -> 3.1.0`                                            |
| [`543dbb4f`](https://github.com/NixOS/nixpkgs/commit/543dbb4ffb974111511f3f9d6f58fc22abe4da8f) | `gnomeExtension.pop-shell: 2021-11-30 -> 2022-01-14`                    |
| [`23f87f4b`](https://github.com/NixOS/nixpkgs/commit/23f87f4b69c8ce802af64ad340c8851f7db9f756) | `onionshare: 2.4 -> 2.5`                                                |
| [`ccfbc1e9`](https://github.com/NixOS/nixpkgs/commit/ccfbc1e98d700f17507d7b2c1acc5221baab10d2) | `snowflake: init at 2.0.1`                                              |
| [`4f01e47c`](https://github.com/NixOS/nixpkgs/commit/4f01e47c3a9fa1bede8c0558095c526623ed0f7f) | `vulkan-tools: 1.2.189.1 -> 1.2.198.0`                                  |
| [`5cfcd0b5`](https://github.com/NixOS/nixpkgs/commit/5cfcd0b5b28d3f62c0e6a0a59878613b9f03c4dc) | `factorio-*: 1.1.50->1.1.53`                                            |
| [`899605d9`](https://github.com/NixOS/nixpkgs/commit/899605d9b3c0ef408aea837d3f5e568ce62215d8) | `maintainers: update sikmir's email`                                    |
| [`e1317cb5`](https://github.com/NixOS/nixpkgs/commit/e1317cb5a170da463a095839dac925fa144d73f8) | `tile38: init at 1.27.1`                                                |
| [`4bd708e4`](https://github.com/NixOS/nixpkgs/commit/4bd708e40b74283818d2262bfddb1e16adb3bd20) | `ttyper: 0.4.0 -> 0.4.1`                                                |
| [`7d70d8f5`](https://github.com/NixOS/nixpkgs/commit/7d70d8f5411bb769a83224d291f5674c5c594460) | `python3Packages.pydrive2: init at 1.10.0`                              |
| [`29dd066a`](https://github.com/NixOS/nixpkgs/commit/29dd066a556a86d608d72e0d14d964a1439fea7a) | `maintainers: fixed formatting of maintainer entry for jmc-figueira`    |
| [`5bf92ebb`](https://github.com/NixOS/nixpkgs/commit/5bf92ebbed94040841d7353184fb7d20da5ad063) | `plocate: add SuperSandro200 to maintainers`                            |
| [`d8f4d44f`](https://github.com/NixOS/nixpkgs/commit/d8f4d44f1a6934609e14b690f9ba16260188d1db) | `python39Packages.ipympl: 0.8.5 -> 0.8.7`                               |
| [`206d3698`](https://github.com/NixOS/nixpkgs/commit/206d369867051e2052c197a4e5f60b981130f347) | `python39Packages.openai: 0.11.5 -> 0.12.0`                             |
| [`7d1e58df`](https://github.com/NixOS/nixpkgs/commit/7d1e58dff20c72844866e18bfaf1a1af9d9c47c9) | `svt-av1: 0.8.7 -> 0.9.0`                                               |
| [`52bec72f`](https://github.com/NixOS/nixpkgs/commit/52bec72f73a93c00726fed60c1364dfb6e4d4760) | `licenses: add Alliance for Open Media Patent License 1.0`              |
| [`555111f1`](https://github.com/NixOS/nixpkgs/commit/555111f1a90a3519856aaf6403a0118d6ae55dee) | `buku: remove problematic test dependencies`                            |
| [`6ac669cc`](https://github.com/NixOS/nixpkgs/commit/6ac669cca9046874a4de925e5bca53b6dbeee773) | `gnomeExtensions: auto-update`                                          |
| [`84fe9e42`](https://github.com/NixOS/nixpkgs/commit/84fe9e42ff55f9905e27df62ee12ecb1c843267d) | `mblock-mlink: init at 1.2.0`                                           |
| [`a3354b61`](https://github.com/NixOS/nixpkgs/commit/a3354b61b699d4fb34ce17a94562ddf65b19cf96) | `xpra: 4.2 -> 4.3.1`                                                    |
| [`e14ce3e4`](https://github.com/NixOS/nixpkgs/commit/e14ce3e49a81d93869b47e2c7a72d5ce4d5f6d59) | `buku: make bukuserver optional`                                        |
| [`027d3534`](https://github.com/NixOS/nixpkgs/commit/027d353491860c8fd232e6bd09d45516b166659a) | `treewide: rename name to pname&version`                                |
| [`d32ccbc6`](https://github.com/NixOS/nixpkgs/commit/d32ccbc6da437cfd582254d055209126769a72fa) | `retroarch: add changelog`                                              |
| [`1b79b5bb`](https://github.com/NixOS/nixpkgs/commit/1b79b5bb0aba9f012671fb1d8628490ea87218f1) | `retroarchFull: remove cores not supported on platform`                 |
| [`2ac298e4`](https://github.com/NixOS/nixpkgs/commit/2ac298e45b25cb3e3c34f221a280be2bfd03635b) | `libretro: unstable-2021-12-06 -> unstable-2022-01-21`                  |
| [`b7a61775`](https://github.com/NixOS/nixpkgs/commit/b7a617754c18472a01e69d4eb24487b8bd9229c7) | `retroarch: 1.9.14 -> 1.10.0`                                           |
| [`9fede6b8`](https://github.com/NixOS/nixpkgs/commit/9fede6b8336d922586f97c32af0b68335b8c795d) | `wluma: 4.0.0 -> 4.1.0`                                                 |
| [`54a25c67`](https://github.com/NixOS/nixpkgs/commit/54a25c67f9e778b949fe26608e7b2a108e847ff0) | `maintainers: add jmc-figueira`                                         |
| [`628bf327`](https://github.com/NixOS/nixpkgs/commit/628bf32777c4eb65ae91aa6f48cad95d6d3d913e) | `syft: init at 0.36.0`                                                  |
| [`dbfd4f7a`](https://github.com/NixOS/nixpkgs/commit/dbfd4f7a6a35b717a538c30bfffcb256ae85389c) | `elvis-erlang: 1.0.1 -> 1.1.0`                                          |
| [`abb3c48c`](https://github.com/NixOS/nixpkgs/commit/abb3c48c43f2e76f4f1f1bec7cbe1893711d1757) | `qcad: 3.27.1.0 -> 3.27.1.3`                                            |
| [`603cd98b`](https://github.com/NixOS/nixpkgs/commit/603cd98bf290743a28cf905d56c6f2a4ef71ed89) | `libpinyin: 2.3.0 -> 2.6.1`                                             |
| [`3fd202bd`](https://github.com/NixOS/nixpkgs/commit/3fd202bda57688f5267a3f592fc8e889ac8ad1e9) | `python3Packages.svdtools: 0.1.20 -> 0.1.21`                            |
| [`d124b878`](https://github.com/NixOS/nixpkgs/commit/d124b87875cb79b15755b5b061e1d53993eb7e18) | `python3Packages.cepa: init at 1.8.3`                                   |
| [`2a15c338`](https://github.com/NixOS/nixpkgs/commit/2a15c3388cc19561224afa8b879f941220e2fd26) | `deltachat-cursed: 0.3.0 -> 0.3.1`                                      |
| [`8f682301`](https://github.com/NixOS/nixpkgs/commit/8f6823019a4646e5c0b095a09d35ec6dbdccc179) | `python3Packages.pytradfri: 8.0.0 -> 8.0.1`                             |
| [`701dcec3`](https://github.com/NixOS/nixpkgs/commit/701dcec35145c66f3a588c7f617cda709734850c) | `framac: Update to GTK 3`                                               |
| [`3284833e`](https://github.com/NixOS/nixpkgs/commit/3284833ed9eac60c9b224820b104c2e1da77ef03) | `freerdp: 2.4.1 -> 2.5.0`                                               |
| [`ccd4dc3b`](https://github.com/NixOS/nixpkgs/commit/ccd4dc3b98a175fac2b19343ba91aa41750b8311) | `sd-image-riscv64: Add an -installer variant like others`               |
| [`5d48d815`](https://github.com/NixOS/nixpkgs/commit/5d48d8158662b175e747250d8697b3ca3463ee27) | `opensbi: init at 1.0`                                                  |
| [`63c1c307`](https://github.com/NixOS/nixpkgs/commit/63c1c30753259fe3c89a04f2886f1dd9835105cc) | `nixos/roon-server: open TCP ports 9330-9332 in firewall`               |
| [`450ce00e`](https://github.com/NixOS/nixpkgs/commit/450ce00ec4c2f48fffb552f03898e5a3d64164f4) | `installer/cd-dvd/iso-image: avoid leaking build timestamps on non-x86` |
| [`7efd6c82`](https://github.com/NixOS/nixpkgs/commit/7efd6c8260ad4d220996606b77623fd3b46c899c) | `Fix loading of libcrypto when using salt-ssh`                          |
| [`ea027652`](https://github.com/NixOS/nixpkgs/commit/ea0276523a26f661d7f783f7d036d113cc6e1d5e) | `nixos/tests/jibri: updated test with a new log message`                |
| [`7a3322a0`](https://github.com/NixOS/nixpkgs/commit/7a3322a07854300817711e48a3abaad915912f54) | `jibri: 8.0-93-g51fe7a2 -> 8.0-114-g20e233e`                            |
| [`589657d9`](https://github.com/NixOS/nixpkgs/commit/589657d9c513aed45fd0058efb9d845647a5a951) | `jitsi-videobridge: 2.1-570-gb802be83 -> 2.1-595-g3637fda4`             |
| [`c27a7046`](https://github.com/NixOS/nixpkgs/commit/c27a704630c4557ac3bc9a5c65a454a959902861) | `jicofo: 1.0-813 -> 1.0-832`                                            |
| [`964e1ce6`](https://github.com/NixOS/nixpkgs/commit/964e1ce61ddca9b3359a53b2cb92f1533d57ed65) | `jitsi-meet-prosody: 1.0.5415 -> 1.0.5675`                              |
| [`acc3a3c9`](https://github.com/NixOS/nixpkgs/commit/acc3a3c9e8278cd7cd8437ab2ee79001d1156139) | `jitsi-meet: 1.0.5415 -> 1.0.5675`                                      |
| [`5c630dbe`](https://github.com/NixOS/nixpkgs/commit/5c630dbeaa746c234f2aae23c70fef51822637cb) | `meshcentral: 0.9.56 -> 0.9.59`                                         |
| [`9fed6fea`](https://github.com/NixOS/nixpkgs/commit/9fed6feac8748e1ea24bf9ec0f272e2cfab2e9ab) | `firefly-desktop: init at 1.2.0`                                        |
| [`da8923a8`](https://github.com/NixOS/nixpkgs/commit/da8923a825594bfba0393ca64dd0f2da5a092fdd) | `maintainers: add tgunnoe`                                              |