### PR TITLE
chore(flake/nixpkgs): `4ad9f4e2` -> `641a189d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642995822,
-        "narHash": "sha256-yeVgyKEq9gyOSGufK8+1vWdhhG2gOMc3cVjixh47LFM=",
+        "lastModified": 1643041544,
+        "narHash": "sha256-RRJE0yPhDM+t78x5CP7BvfzkGsNolvO2D6QKAJSydUU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4ad9f4e242df6a8babd3f3787a2cf8bbdc60a0fb",
+        "rev": "641a189dd9cc226a41120c75330b2b3ac83168dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`f0e9f54d`](https://github.com/NixOS/nixpkgs/commit/f0e9f54d6e27ef1960edaf306efebd42b94087c6) | `lib/meta: fix typo in platformMatch comment`                                 |
| [`ed6b342f`](https://github.com/NixOS/nixpkgs/commit/ed6b342fc3a76908afe4cd7cdbc0f6eaf33082da) | `retroarchFull: use lib.meta.availableOn`                                     |
| [`3fb41650`](https://github.com/NixOS/nixpkgs/commit/3fb41650985708c483cc1470a7a3122c36b71405) | `libreswan: Fix ExecStopPost paths`                                           |
| [`4a465470`](https://github.com/NixOS/nixpkgs/commit/4a46547008f47672262ced00c0862b42b2c8f81f) | `expenses: install shell completion`                                          |
| [`5762b8c8`](https://github.com/NixOS/nixpkgs/commit/5762b8c8a5bfd7fdc7a8e8eaf95d41f687882b08) | `irods: Don't use builtins.nixVersion`                                        |
| [`cad3bc9b`](https://github.com/NixOS/nixpkgs/commit/cad3bc9b8eae8230bd9edeb63f19490e7d6132e2) | `signal-cli: 0.10.1 -> 0.10.2`                                                |
| [`5b8b4164`](https://github.com/NixOS/nixpkgs/commit/5b8b4164fe3609154423ebdd396b5e88d195e83b) | `sigurlx: remove`                                                             |
| [`14d6955a`](https://github.com/NixOS/nixpkgs/commit/14d6955a46a1781ff2e45a78a31e448711f6971c) | `corsmisc: remove`                                                            |
| [`d54a7e72`](https://github.com/NixOS/nixpkgs/commit/d54a7e72a68de12e7746a9815c842c288b96990f) | `python3Packages.pymdown-extensions: remove period from description`          |
| [`37596fe4`](https://github.com/NixOS/nixpkgs/commit/37596fe4a9dc2832fde6e6de335c5114dda88efc) | `imgproxy: 3.1.3 -> 3.2.1`                                                    |
| [`4c8a08d2`](https://github.com/NixOS/nixpkgs/commit/4c8a08d231aad83ddc57a676d7e7e34a0ded4362) | `tuigreet: 0.7.1 -> 0.7.2`                                                    |
| [`e06dfabe`](https://github.com/NixOS/nixpkgs/commit/e06dfabe6ecff752b0b3f1b25129eda62c43dcee) | `htpdate: 1.3.1 -> 1.3.3`                                                     |
| [`f547487c`](https://github.com/NixOS/nixpkgs/commit/f547487c918cccbd9b6ea1830692890cfdfa727e) | `heimer: 3.1.0 -> 3.2.0`                                                      |
| [`786b8a71`](https://github.com/NixOS/nixpkgs/commit/786b8a718d83694c03d34979e9bf8f2bac83c770) | `gosec: 2.9.5 -> 2.9.6`                                                       |
| [`b3e38575`](https://github.com/NixOS/nixpkgs/commit/b3e385753b0ff04c1190961aff540f7f1e694d2d) | `orchis-theme: add withWallpapers option`                                     |
| [`e7dbfd7e`](https://github.com/NixOS/nixpkgs/commit/e7dbfd7ece0e8f11ef0617919cc5597258eda90f) | `terraform.withPlugins: clean and remove 0.12 support (#155477)`              |
| [`e70ba299`](https://github.com/NixOS/nixpkgs/commit/e70ba2998d36c8817d7b06b9854d4fcaa91443f5) | `aws-vault: 6.3.1 -> 6.4.0 (#156374)`                                         |
| [`3c57ff6b`](https://github.com/NixOS/nixpkgs/commit/3c57ff6bf509f16c121fa3fff6addc05defcb698) | `haskellPackages.{regex-rure,jacinda}: add myself as maintainer`              |
| [`c6923ee0`](https://github.com/NixOS/nixpkgs/commit/c6923ee0d9a3b9efefdc80149767c477c6ba2082) | `jacinda: init at 0.2.0.0`                                                    |
| [`452f76cf`](https://github.com/NixOS/nixpkgs/commit/452f76cfaf395cad5642eaa0589ec4241ef9d887) | `rure: init at 0.2.1`                                                         |
| [`7c7e2447`](https://github.com/NixOS/nixpkgs/commit/7c7e244719b74f6a8c1ac3cc538a6feae388ad6b) | `xcowsay: 1.5.1 -> 1.6`                                                       |
| [`2ced62da`](https://github.com/NixOS/nixpkgs/commit/2ced62da40b41033588581dab130a61157fbe2b3) | `globalarrays: 5.8 -> 5.8.1`                                                  |
| [`a6785fe0`](https://github.com/NixOS/nixpkgs/commit/a6785fe0574f3a52c1b33adc1bb43b9356e84ce7) | `rssguard: 4.0.4 -> 4.1.2`                                                    |
| [`392dace8`](https://github.com/NixOS/nixpkgs/commit/392dace8dbf0814f5d904da77b539623e8912713) | `skypeforlinux: 8.79.0.95 -> 8.80.0.143`                                      |
| [`e54ce261`](https://github.com/NixOS/nixpkgs/commit/e54ce2616e8662d414f4dd24893df2af2b013800) | `purpur: init at 1.17.1r1428`                                                 |
| [`d9f26c0c`](https://github.com/NixOS/nixpkgs/commit/d9f26c0c8cd7e4a826f1c5bdf0c4920b77438f3b) | `gifski: 1.6.1 -> 1.6.4`                                                      |
| [`00844298`](https://github.com/NixOS/nixpkgs/commit/00844298cb4e617359ddc981e525505b482f3b39) | `fstar: 2021.12.25 -> 2022.01.15`                                             |
| [`3f70c90d`](https://github.com/NixOS/nixpkgs/commit/3f70c90d7a732a37fa5bde009bf013e2e83a9bf7) | `nixos/tests/installer: Fix race in bcache test`                              |
| [`120c6356`](https://github.com/NixOS/nixpkgs/commit/120c6356b4038a2b3834e689cf7730ebbdf199a2) | `haskellPackages: regenerate package set based on current config`             |
| [`bf18c4a0`](https://github.com/NixOS/nixpkgs/commit/bf18c4a024f31218116573e396344cee84450cec) | `haskellPackages.gi-adwaita: disable on darwin`                               |
| [`676b8002`](https://github.com/NixOS/nixpkgs/commit/676b8002665e10a30232b8290f7a449579ee7194) | `nncp: 8.2.0 -> 8.3.0`                                                        |
| [`9f786dea`](https://github.com/NixOS/nixpkgs/commit/9f786dea838b07e749f8d77257e5917f70201876) | `expenses: 0.2.2 -> 0.2.3`                                                    |
| [`84303050`](https://github.com/NixOS/nixpkgs/commit/84303050380da6d9b00cd71bea108f46bd11c2cf) | `heisenbridge: relax irc constraint`                                          |
| [`68c0f30a`](https://github.com/NixOS/nixpkgs/commit/68c0f30a7986a70665d66661d3941d350a6e68e8) | `haskellPackages: mark builds failing on hydra as broken`                     |
| [`0d8d66ca`](https://github.com/NixOS/nixpkgs/commit/0d8d66ca5f7bb94d4d654def9b311010ccbc127e) | `dyff: 1.4.6 -> 1.4.7`                                                        |
| [`bd1fbc0a`](https://github.com/NixOS/nixpkgs/commit/bd1fbc0a6f2b7e4527182e54b3a46a142ed9d41a) | `resholve: 0.6.8 -> 0.6.9`                                                    |
| [`f316fc4f`](https://github.com/NixOS/nixpkgs/commit/f316fc4ffa610c283ef104a8d83ba0d28c1266f3) | `crowdin-cli: 3.7.5 -> 3.7.7`                                                 |
| [`ff3e9fbb`](https://github.com/NixOS/nixpkgs/commit/ff3e9fbb365f57b31b605b2f84910e757fc85bb5) | `consul: 1.11.1 -> 1.11.2`                                                    |
| [`4daddd25`](https://github.com/NixOS/nixpkgs/commit/4daddd2595ef89bd09da1295c4685d7de2bb4883) | `cocogitto: 4.0.1 -> 4.1.0`                                                   |
| [`cc687107`](https://github.com/NixOS/nixpkgs/commit/cc68710784ffe0ee035ee7b726656c44566cac94) | `terraform-providers: update 2022-01-24`                                      |
| [`41073632`](https://github.com/NixOS/nixpkgs/commit/41073632d0aba94e72e58b2065b22683287efbe6) | `librep: mark as broken on darwin`                                            |
| [`1316a83f`](https://github.com/NixOS/nixpkgs/commit/1316a83f43506a7d0b79913bbb101fba49887bf1) | `onefetch: 2.10.2 -> 2.11.0`                                                  |
| [`ea36532b`](https://github.com/NixOS/nixpkgs/commit/ea36532b50dd166d80969a99bbead4e0c24fec50) | `cloud-nuke: 0.7.3 -> 0.9.1`                                                  |
| [`345110e2`](https://github.com/NixOS/nixpkgs/commit/345110e2de6c0a28b719083cbdf7fe4f5d239e2a) | `procs: 0.11.13 -> 0.12.0`                                                    |
| [`a58997f5`](https://github.com/NixOS/nixpkgs/commit/a58997f52e9d2cc3d6235860cf6df949065efd18) | `python39Packages.oslo-utils: 4.12.0 -> 4.12.1`                               |
| [`978211be`](https://github.com/NixOS/nixpkgs/commit/978211bedf2cd1f502cb174e1489fd3a62719039) | `clj-kondo: 2021.12.19 -> 2022.01.15`                                         |
| [`612a78ac`](https://github.com/NixOS/nixpkgs/commit/612a78acb2a9686b5eadb7d5308e7e61d9516063) | `python39Packages.googleapis-common-protos: 1.53.0 -> 1.54.0`                 |
| [`0f8ef18f`](https://github.com/NixOS/nixpkgs/commit/0f8ef18fa0f55250e894a348da805fdd88b0e4bb) | `python39Packages.google-cloud-core: 2.2.1 -> 2.2.2`                          |
| [`527717df`](https://github.com/NixOS/nixpkgs/commit/527717df6a7587c568bbfd1c734aa555f05f4b51) | `clight: 4.7 -> 4.8`                                                          |
| [`ab7e6995`](https://github.com/NixOS/nixpkgs/commit/ab7e6995ac9df61ceac5188a0ec499e4eb3a825b) | `nixos/nginx: Add defaultListenAddresses option`                              |
| [`f84aef8b`](https://github.com/NixOS/nixpkgs/commit/f84aef8b01dde777aecb1b277b1f1701381dd328) | `arbtt: jailbreak because of tasty-golden version constraint`                 |
| [`ee4d2434`](https://github.com/NixOS/nixpkgs/commit/ee4d2434528ce024ba917847c701f931e692b590) | `mattermost: 6.3.0 -> 6.3.1`                                                  |
| [`8ecd9c89`](https://github.com/NixOS/nixpkgs/commit/8ecd9c8936f71ca0894baea3125768cf68d256c6) | `gvpe: 3.0 -> 3.1`                                                            |
| [`6c8b26da`](https://github.com/NixOS/nixpkgs/commit/6c8b26daa721ec35cb9e7fd4e47e7fdad3c4ac75) | `checkip: 0.16.2 -> 0.17.3`                                                   |
| [`455049e2`](https://github.com/NixOS/nixpkgs/commit/455049e2acb427a8bfb12b6bd3b0ae9d9fa7b9ef) | `cargo-expand: 1.0.13 -> 1.0.14`                                              |
| [`c75d809c`](https://github.com/NixOS/nixpkgs/commit/c75d809c2361a26160f6f4e78b7b2e634666068e) | `evolution-ews: 3.42.1 -> 3.42.3`                                             |
| [`68501b17`](https://github.com/NixOS/nixpkgs/commit/68501b177aba16152a6cd5efc394e4eed02a53e6) | `agi: 2.1.0-dev-20210924 -> 2.2.0-dev-20220120`                               |
| [`65705a83`](https://github.com/NixOS/nixpkgs/commit/65705a834138253f96dbdfe120fab6fa371e2563) | `gqrx: 2.15.4 → 2.15.7`                                                       |
| [`c008b3d1`](https://github.com/NixOS/nixpkgs/commit/c008b3d100a75da35696c5a09afc91f65a034c5e) | `nixos/docs/option-declarations: Document mkEnableOption and mkPackageOption` |
| [`47c36939`](https://github.com/NixOS/nixpkgs/commit/47c36939d57fe12c3d6a68d010fa4e2eb540dbfd) | `rofi-file-browser: 1.2.0 -> 1.3.0`                                           |
| [`c4236291`](https://github.com/NixOS/nixpkgs/commit/c423629183792da33e61c0f4ab9df4f2b77f2825) | `nordzy-icon-theme: unstable-2021-12-14 -> unstable-2022-01-23`               |
| [`4860df78`](https://github.com/NixOS/nixpkgs/commit/4860df782f173cf63492150c9c57af902c731d7d) | `python3Packages.pymdown-extensions: init at 9.1`                             |
| [`8c6d19e2`](https://github.com/NixOS/nixpkgs/commit/8c6d19e284b1b6e8727eb45626bfc01aa4f9f3a1) | `symfony-cli: 5.1.0 -> 5.2.1`                                                 |
| [`fdf7ede3`](https://github.com/NixOS/nixpkgs/commit/fdf7ede344318318f82594b0d8a7012667eba1ea) | `lib/options: Add mkPackageOption`                                            |
| [`1b94b6c8`](https://github.com/NixOS/nixpkgs/commit/1b94b6c8cc4e5e2bdd6643dcd181dcc0da8783cb) | `rtl8189es: init at 2020-10-03`                                               |
| [`1fddaa2d`](https://github.com/NixOS/nixpkgs/commit/1fddaa2d7f40391cc1049203f282feea802863fa) | `python3Packages.intensity-normalization: add format`                         |
| [`eda41f3e`](https://github.com/NixOS/nixpkgs/commit/eda41f3ea7a9791861ae1742624fb999902b66d1) | `python3Packages.precis-i18n: add pythonImportsCheck`                         |
| [`13b8f6e6`](https://github.com/NixOS/nixpkgs/commit/13b8f6e65064a7458ac9d81c0d7f0ec92cbe9a20) | `python3Packages.pyenvisalink: add format`                                    |
| [`88e9324c`](https://github.com/NixOS/nixpkgs/commit/88e9324cc109c09ae2d988973d275b6174dc4864) | `python39Packages.gradient: 1.9.1 -> 1.10.0`                                  |
| [`767fefc2`](https://github.com/NixOS/nixpkgs/commit/767fefc21cf648783daf0484e622e03e91f483ab) | `haskell.lib: move lib.nix into same directory as compose.nix`                |
| [`b2f63fbd`](https://github.com/NixOS/nixpkgs/commit/b2f63fbd6fc99916f50a18cece4bee01da7628ef) | `haskellPackages.hnix: drop obsolete patch`                                   |
| [`5a8df8f9`](https://github.com/NixOS/nixpkgs/commit/5a8df8f99b49daff5d51f6c2a146582bb000ac53) | `haskellPackages.eventlog2html: unbreak`                                      |
| [`a2e87226`](https://github.com/NixOS/nixpkgs/commit/a2e87226ae164c0a927e3c85e780a7090a6da0f9) | `haskellPackages: regenerate package set based on current config`             |
| [`1facbe37`](https://github.com/NixOS/nixpkgs/commit/1facbe37c68b8ad1867e678a565ea8dee3c218dd) | `haskellPackages.hnix: pin at < 0.15`                                         |
| [`05b08055`](https://github.com/NixOS/nixpkgs/commit/05b0805535f5e9d91bd30e6b729e76ce5b8f0ba7) | `haskellPackages.nix-tree: reflect brick 0.65 -> 0.66 update`                 |
| [`f833757b`](https://github.com/NixOS/nixpkgs/commit/f833757ba1907917e53c9d6d7b122844787197ba) | `haskellPackages.raaz: disable parallel building`                             |
| [`ffccc4c5`](https://github.com/NixOS/nixpkgs/commit/ffccc4c558bcf0739e8b8df9109753af4702041f) | `nixosTests.quorum: use succeed everywhere`                                   |
| [`a7c72013`](https://github.com/NixOS/nixpkgs/commit/a7c72013c8816f769f387c2e6d5ff76d801d145d) | `nixosTests.quorum: use less opaque strings and more nix objects`             |
| [`e6b4d398`](https://github.com/NixOS/nixpkgs/commit/e6b4d398bf26cf275123eaec470f527988b2d09b) | `owncloud-client: 2.9.2 -> 2.10.0`                                            |
| [`1bbd4180`](https://github.com/NixOS/nixpkgs/commit/1bbd4180131dbb45c59c441c14ce596a9037e0a0) | `nixos/quorum: Patch test to not run indefinitely`                            |
| [`884daaaf`](https://github.com/NixOS/nixpkgs/commit/884daaafcb7ebe9afe7405cd79154dec6d89ad2c) | `nixos/dokuwiki: Minor code cleanup`                                          |
| [`edf6c78c`](https://github.com/NixOS/nixpkgs/commit/edf6c78c94bd6dccf5bb78c7f1f02d79b42fb5fa) | `python310Packages.pyenvisalink: 4.2 -> 4.3`                                  |
| [`2420d554`](https://github.com/NixOS/nixpkgs/commit/2420d5547daf9366176317ca6c59e6c9d8b60138) | `python310Packages.precis-i18n: 1.0.3 -> 1.0.4`                               |
| [`9326d408`](https://github.com/NixOS/nixpkgs/commit/9326d408cb3b8fcbe7fe67e3fe1a874fe05e5e3e) | `python310Packages.intensity-normalization: 2.1.2 -> 2.1.4`                   |
| [`60d76ea5`](https://github.com/NixOS/nixpkgs/commit/60d76ea50b3aca12d114d2d2595170b3cbd5b846) | `topydo: 0.13 -> 0.14`                                                        |
| [`6b635d4a`](https://github.com/NixOS/nixpkgs/commit/6b635d4a21b4a83f8df8cf7ca212501275ab9d7b) | `haskellPackages: regenerate package set based on current config`             |
| [`5f8b8494`](https://github.com/NixOS/nixpkgs/commit/5f8b849418889e2a60fc829f15a9d00156d0b705) | `all-cabal-hashes: 2022-01-14T12:47:41Z -> 2022-01-18T22:54:05Z`              |
| [`84915c5a`](https://github.com/NixOS/nixpkgs/commit/84915c5ae77fba6c52df1f00ca53c2d9b9011abe) | `haskellPackages: stackage-lts 18.21 -> 18.22`                                |
| [`3ac0d71f`](https://github.com/NixOS/nixpkgs/commit/3ac0d71f3c8e47ee88e68991926e48cd4073b82b) | `haskellPackages.hs-speedscope: unbreak`                                      |
| [`b20c4c3b`](https://github.com/NixOS/nixpkgs/commit/b20c4c3b9f27f393106feccdb2618373cefd88e4) | `opensupaplex: init at 7.1.2`                                                 |
| [`3a97cc72`](https://github.com/NixOS/nixpkgs/commit/3a97cc72f7f7870e23acae1ce0639e7c85ff5886) | `ryujinx: 1.0.7105 -> 1.0.7168`                                               |
| [`a94e7b51`](https://github.com/NixOS/nixpkgs/commit/a94e7b51e49d748872524e21fbb79b4d1401a52f) | `python38Packages.holidays: 0.11.3.1 -> 0.12`                                 |
| [`e0bc5ad7`](https://github.com/NixOS/nixpkgs/commit/e0bc5ad7d9391e136e86e5a9f57991f6cfd934c4) | `nordzy-icon-theme: etc`                                                      |
| [`9d6b9dda`](https://github.com/NixOS/nixpkgs/commit/9d6b9ddac5cebd17a99c397389c4f836c1d175dd) | `nordzy-icon-theme: etc`                                                      |
| [`236074ea`](https://github.com/NixOS/nixpkgs/commit/236074ea759894518beda3eb0ef91070bdfdf0e9) | `nordzy-icon-theme: etc`                                                      |
| [`35b60b25`](https://github.com/NixOS/nixpkgs/commit/35b60b25aa588fe30e236a44cfeacb5a5a69c1a9) | `nordzy-icon-theme: etc`                                                      |
| [`3daa5df0`](https://github.com/NixOS/nixpkgs/commit/3daa5df0d9ec7eccede4a82c8c60bf76a931241a) | `nordzy-icon-theme: init at unstable-2021-12-14`                              |