### PR TITLE
chore(flake/home-manager): `c47c350f` -> `192675b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1642882610,
-        "narHash": "sha256-pmdgeJ9v6y+T0UfNQ/Z+Hdv5tPshFFra5JLF/byUA/Y=",
+        "lastModified": 1643065825,
+        "narHash": "sha256-3KcOJgqUZNJxavcyhv/DCn6WV2czmYFE3SZFEgYD49g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c47c350f6518ed39c2a16e4fadf9137b6c559ddc",
+        "rev": "192675b1496073cc384a5caa566c600e31145d82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`192675b1`](https://github.com/nix-community/home-manager/commit/192675b1496073cc384a5caa566c600e31145d82) | `docs: fix a few stray periods` |