### PR TITLE
chore(flake/nixpkgs): `641a189d` -> `7916caf7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643041544,
-        "narHash": "sha256-RRJE0yPhDM+t78x5CP7BvfzkGsNolvO2D6QKAJSydUU=",
+        "lastModified": 1643059314,
+        "narHash": "sha256-NOUcKuAHorc3LlzskPJt/9rWOK0Fneaz9+Hgd6BHKSA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "641a189dd9cc226a41120c75330b2b3ac83168dc",
+        "rev": "7916caf75964b01421fc3d40a3676908f36aa7ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                               |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`7916caf7`](https://github.com/NixOS/nixpkgs/commit/7916caf75964b01421fc3d40a3676908f36aa7ff) | `wpgtk: 6.1.3 -> 6.5.0`                                                                      |
| [`3a879825`](https://github.com/NixOS/nixpkgs/commit/3a879825374b7c696398c9fbbc29d005a713b34d) | `video2midi: 0.4.0.2 -> 0.4.6.5`                                                             |
| [`5c09fe18`](https://github.com/NixOS/nixpkgs/commit/5c09fe1887a09b482aaf2b7213d8c9032b52c81a) | `libsForQt5.qcoro: 0.3.0 -> 0.4.0`                                                           |
| [`8477e534`](https://github.com/NixOS/nixpkgs/commit/8477e53482b36a2e5f01b928863f3c1c36609916) | `spotdl: 3.7.2 -> 3.9.2`                                                                     |
| [`493d141d`](https://github.com/NixOS/nixpkgs/commit/493d141d065d29afa731de27e284eb768c71b329) | `stunnel: 5.61 -> 5.62`                                                                      |
| [`b67fc5a3`](https://github.com/NixOS/nixpkgs/commit/b67fc5a3e5b9345d8e66701fca29e3ee0980204e) | `python310Packages.total-connect-client: 2021.12 -> 2022.1`                                  |
| [`3e2706a0`](https://github.com/NixOS/nixpkgs/commit/3e2706a0eb7b7c7b7c71ca8fe675a07db3ebecd6) | `python310Packages.bond-api: 0.1.15 -> 0.1.16`                                               |
| [`8bd7d6d6`](https://github.com/NixOS/nixpkgs/commit/8bd7d6d6e0994aea4d2f2d42b7283db497dd5c30) | `star: 2.7.9a -> 2.7.10a`                                                                    |
| [`93a5b04b`](https://github.com/NixOS/nixpkgs/commit/93a5b04b9aa673902424dbad8e635650eacfd564) | `scs: 3.0.0 -> 3.1.0`                                                                        |
| [`2a82cd67`](https://github.com/NixOS/nixpkgs/commit/2a82cd67b5453c126db511243defbe13d18f2d9d) | `lego: 4.5.3 -> 4.6.0`                                                                       |
| [`24822e28`](https://github.com/NixOS/nixpkgs/commit/24822e28f8f59604fc39570696e180673db2473e) | `lazygit: 0.31.4 -> 0.32.2`                                                                  |
| [`af2b1f15`](https://github.com/NixOS/nixpkgs/commit/af2b1f15b4ee693cfb40234e5ec01424d40bafdf) | `steampipe: 0.12.0 -> 0.12.1`                                                                |
| [`60638a2d`](https://github.com/NixOS/nixpkgs/commit/60638a2dc5f7f8d2b3925af8ba5772a181094612) | `groestlcoin_hash: init at 1.0.1`                                                            |
| [`f243b177`](https://github.com/NixOS/nixpkgs/commit/f243b177d5577a6d3a7be5052e938091f3bf017f) | `havoc: 0.3.1 -> 0.4.0`                                                                      |
| [`d38cf78e`](https://github.com/NixOS/nixpkgs/commit/d38cf78e0e886031bfcefda0e5ba3712fd58246e) | `koreader: 2021.12.1 -> 2022.01`                                                             |
| [`1abaf88b`](https://github.com/NixOS/nixpkgs/commit/1abaf88baef399a3502bf10073d6f4fc2eb26359) | `goreleaser: 1.2.5 -> 1.3.1`                                                                 |
| [`a1a75336`](https://github.com/NixOS/nixpkgs/commit/a1a75336c38d643663bfc4044e658d07141c5ea3) | `cpp-utilities: 5.11.3 -> 5.12.0`                                                            |
| [`28278871`](https://github.com/NixOS/nixpkgs/commit/282788713f3c3d13d52290f6db18ab312fc889bd) | `tlp: 1.4.0 -> 1.5.0`                                                                        |
| [`9a7bb1ef`](https://github.com/NixOS/nixpkgs/commit/9a7bb1ef06a28d4b8ef61801413cda55e3ffde49) | `Fixed typo while fixing maintainer list merge conflict`                                     |
| [`4329d79d`](https://github.com/NixOS/nixpkgs/commit/4329d79dbab9f9ae6654c59ac428b8935eb7f7c5) | `nixos/tests: link tests to their packages`                                                  |
| [`fd6b95db`](https://github.com/NixOS/nixpkgs/commit/fd6b95db2263e80269834e2508302de4aed025d7) | `nixos/tests: add missing tests`                                                             |
| [`0ac894e7`](https://github.com/NixOS/nixpkgs/commit/0ac894e7d1d91e32fdcdc901229f16f27f321374) | `wine-wayland: disabled Xinerama support for Wayland builds, removing needless dependencies` |
| [`74f85d37`](https://github.com/NixOS/nixpkgs/commit/74f85d3714d5af52f199114af65012d531be730b) | `wine-wayland: fixed vkd3d dependency in wineWow builds and standardized the derivation`     |
| [`c4367451`](https://github.com/NixOS/nixpkgs/commit/c4367451b3d62b6abd78cdfc676df7bf5111b0da) | `wine-wayland: fixed wineWow builds with wayland support`                                    |
| [`052832e9`](https://github.com/NixOS/nixpkgs/commit/052832e9be1de6e23805301f8e7300c45baa51db) | `theLoungePlugins: recurseIntoAttrs`                                                         |
| [`abdbf22a`](https://github.com/NixOS/nixpkgs/commit/abdbf22a30cf51bc2bc4d2ed3e8de96acae672db) | `wine-wayland: added derivation for building the experimental Wayland driver for Wine`       |
| [`5d70684d`](https://github.com/NixOS/nixpkgs/commit/5d70684de97030ee565ddd902e4b1659861f5ca3) | `maintainers: add jmc-figueira`                                                              |
| [`b5e918b5`](https://github.com/NixOS/nixpkgs/commit/b5e918b5d2fe126836e665f03077e300ad42d1b0) | `pythonPackages.python-keycloak: init at 0.26.1`                                             |