### PR TITLE
chore(flake/templates): `17d85577` -> `f4c17dfb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -259,11 +259,11 @@
     },
     "templates": {
       "locked": {
-        "lastModified": 1639745621,
-        "narHash": "sha256-AXMHlBOgZ65I0uFC2mdm51pzCG2qzYSKalLh9W6YOiU=",
+        "lastModified": 1643098319,
+        "narHash": "sha256-G1+o3y5VxhybrkuAKWGNBThGvDWv2+wV9iylte/yvq4=",
         "owner": "NixOS",
         "repo": "templates",
-        "rev": "17d855776f9d2c13193890e8cf143ab2f56e0d70",
+        "rev": "f4c17dfb52bd4144725d9d9352cc317df8fb13b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                                   |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
| [`319bbb34`](https://github.com/NixOS/templates/commit/319bbb34b05b5ba67eb87d3189943ae87ed65727) | `templates/hercules-ci: init`                                    |
| [`323483cd`](https://github.com/NixOS/templates/commit/323483cd0730425fe81d4c135c0be1c60f127675) | `go: inital example using buildGoModule`                         |
| [`e0545c4a`](https://github.com/NixOS/templates/commit/e0545c4a9b00677a6066b83bea158ccbe1e05196) | `syntax fixes`                                                   |
| [`8a1c1051`](https://github.com/NixOS/templates/commit/8a1c1051a10096095f38833e32edeb33cf49365f) | `better formatting for abstract`                                 |
| [`effb5049`](https://github.com/NixOS/templates/commit/effb5049bef4bcb5fd4284af8367e264be50f69b) | `improve GitHub formatting to not mistake yaml block for header` |
| [`739fa1f2`](https://github.com/NixOS/templates/commit/739fa1f2861b1d05cc59e33b3eb41e3b67b269b1) | `move abstract in separate yaml block for better Github display` |
| [`cd2be47d`](https://github.com/NixOS/templates/commit/cd2be47dc6605d9b6ce00bdba602cfc4383e29d0) | `add citeproc, crossref and some explanation`                    |
| [`c48dcd84`](https://github.com/NixOS/templates/commit/c48dcd8479acade4e0f07e66e711f51f523e24cb) | `Add basic doc`                                                  |
| [`b5a1e269`](https://github.com/NixOS/templates/commit/b5a1e2692c57116ecc4ba80b40402663feb244ab) | `template for pandoc with xelatex and custom font support`       |
| [`c5ef8f83`](https://github.com/NixOS/templates/commit/c5ef8f83d9e3d5c94baebf0e5086b809dfc14897) | `Initial work on a full example schema`                          |