### PR TITLE
chore(flake/nixpkgs): `7916caf7` -> `6a17e6fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643059314,
-        "narHash": "sha256-NOUcKuAHorc3LlzskPJt/9rWOK0Fneaz9+Hgd6BHKSA=",
+        "lastModified": 1643065737,
+        "narHash": "sha256-HbaX+3IbIe17PoClo96RJKkSOjwEILF3jm5X8C/uPjo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7916caf75964b01421fc3d40a3676908f36aa7ff",
+        "rev": "6a17e6fbd213e4278bf0c0f184ff1a4ab27a2c28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`048d5eea`](https://github.com/NixOS/nixpkgs/commit/048d5eeabdce817afcda5580bc92c64a28af2278) | `fcitx5-unikey: init at 5.0.7 (#154699)`                     |
| [`be8a4c32`](https://github.com/NixOS/nixpkgs/commit/be8a4c32229928e486ea764a755105a9e20c154c) | `python3Packages.txtorcon: disable tests on aarch64-darwin`  |
| [`1c58cdbe`](https://github.com/NixOS/nixpkgs/commit/1c58cdbeed880e99d816c234a954d4cdfc073b6c) | `nixos/modprobe: add boot.initrd.extraModprobeConfig option` |
| [`e8b241cd`](https://github.com/NixOS/nixpkgs/commit/e8b241cdbad6f7c0af4115c0d733874b02f5c54f) | `chromiumDev: Fix the configuration phase`                   |
| [`d0ed7ee0`](https://github.com/NixOS/nixpkgs/commit/d0ed7ee0b040ba45609028663d6d2c686fee7820) | `chromium: get-commit-message.py: Improve the parsing`       |
| [`84c9735a`](https://github.com/NixOS/nixpkgs/commit/84c9735af51da3a3136efeaf179d3dbb23ac964e) | `python310Packages.aenum: 3.1.6 -> 3.1.8`                    |
| [`911ef677`](https://github.com/NixOS/nixpkgs/commit/911ef6778ea4328ad741b6a20effbce69da9fa0b) | `log4j-sniffer: 1.2.0 -> 1.6.0`                              |
| [`040139e4`](https://github.com/NixOS/nixpkgs/commit/040139e4a8fb94326c2ad4bee6eec16137d343cc) | `python3Packages.cyclonedx-python-lib: 1.2.0 -> 1.3.0`       |
| [`f26f2358`](https://github.com/NixOS/nixpkgs/commit/f26f2358001a8f10436ed166f4d2d07bb8698dc3) | `python3Packages.cyclonedx-python-lib: 1.1.1 -> 1.2.0`       |
| [`15e16965`](https://github.com/NixOS/nixpkgs/commit/15e1696532ef874befb555cde22d7a240f5669df) | `tree-sitter: update grammars`                               |
| [`a7c14c9a`](https://github.com/NixOS/nixpkgs/commit/a7c14c9aa9d17a6a98b9806e6102a0a806e50018) | ``tree-sitter: print `{ lib }:` in update script``           |
| [`d5a2fbcf`](https://github.com/NixOS/nixpkgs/commit/d5a2fbcf8da108a88f9c468baeb2a9a784bae87a) | `tree-sitter: allow token-less execution`                    |
| [`a39a1168`](https://github.com/NixOS/nixpkgs/commit/a39a11681a437b3151336ea866e1315a084c2996) | `tree-sitter: handle errors in update script`                |
| [`61f4f686`](https://github.com/NixOS/nixpkgs/commit/61f4f686c5f24662dae2263012c887e0658f0544) | `tree-sitter: 0.20.3 -> 0.20.4`                              |
| [`60dce839`](https://github.com/NixOS/nixpkgs/commit/60dce83995a9d2110068f11e0cb0729e32d728ce) | `tree-sitter: 0.20.2 -> 0.20.3`                              |
| [`607b4ca8`](https://github.com/NixOS/nixpkgs/commit/607b4ca82bbd76655e843231330e58bd49b65891) | `python3Packages.denonavr: enable test`                      |
| [`8a389486`](https://github.com/NixOS/nixpkgs/commit/8a389486588764a6811d56c1c45b02f76223ff54) | `python3Packages.denonavr: 0.10.9 -> 0.10.10`                |
| [`88aa0c5b`](https://github.com/NixOS/nixpkgs/commit/88aa0c5bf1b80b1392b88e80a2d3aff52f15ab23) | `python3Packages.identify: 2.4.4 -> 2.4.5`                   |
| [`8cc3513d`](https://github.com/NixOS/nixpkgs/commit/8cc3513d49d4211664b67f657f39e95b0c070c46) | `python3Packages.meshtastic: 1.2.58 -> 1.2.75`               |
| [`e26c3587`](https://github.com/NixOS/nixpkgs/commit/e26c3587d390d45b5de22bda6025b2cd6394e237) | `python3Packages.flux-led: 0.28.8 -> 0.28.10`                |
| [`75cb365f`](https://github.com/NixOS/nixpkgs/commit/75cb365fa2695c98db5571f74997117ca6012cd9) | `gay: fix package`                                           |