### PR TITLE
chore(flake/nixpkgs): `6a17e6fb` -> `2410a4db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -132,11 +132,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643065737,
-        "narHash": "sha256-HbaX+3IbIe17PoClo96RJKkSOjwEILF3jm5X8C/uPjo=",
+        "lastModified": 1643134871,
+        "narHash": "sha256-MdVTKjnAyTSncdDW+dM1L21/cI533bxurDkkWQxXCK8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6a17e6fbd213e4278bf0c0f184ff1a4ab27a2c28",
+        "rev": "2410a4db4eb5e3a6493de2a4f710241f54b9dba7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                  |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`2410a4db`](https://github.com/NixOS/nixpkgs/commit/2410a4db4eb5e3a6493de2a4f710241f54b9dba7) | `python310Packages.azure-mgmt-compute: 24.0.0 -> 24.0.1`                        |
| [`965bf02c`](https://github.com/NixOS/nixpkgs/commit/965bf02cf0fa9edf6eecaf826ad1330781a74a72) | `python310Packages.django_classytags: 2.0.0 -> 3.0.0`                           |
| [`5e3a0b2a`](https://github.com/NixOS/nixpkgs/commit/5e3a0b2aa2670a47146230f85d0c375dc9c2a871) | `python39Packages.dwdwfsapi: 1.0.4 -> 1.0.5`                                    |
| [`8deb6fd1`](https://github.com/NixOS/nixpkgs/commit/8deb6fd17a0e8c93883323de868fc173fce254cd) | `python3Packages.pytile: 2021.12.0 -> 2022.01.0`                                |
| [`b5eee3ac`](https://github.com/NixOS/nixpkgs/commit/b5eee3acc8459b0701b2774f0a2880f3b1552f2a) | `python3Packages.envoy-reader: 0.20.0 -> 0.21.3`                                |
| [`04560b91`](https://github.com/NixOS/nixpkgs/commit/04560b91633221bc80a5e2aefe75280a4b46bff5) | `nixos/gitlab: Add additional paths to systemd.tmpfiles.rules`                  |
| [`d783dee2`](https://github.com/NixOS/nixpkgs/commit/d783dee256e1fb4df364a262007b9eb68c1abd37) | `gitlab: 14.6.3 -> 14.7.0`                                                      |
| [`a25c61c2`](https://github.com/NixOS/nixpkgs/commit/a25c61c203911ea298d2328d638dde4e371e0ac3) | `python3Packages.sqlite-utils: 3.19 -> 3.22`                                    |
| [`0254b216`](https://github.com/NixOS/nixpkgs/commit/0254b216a35d9fe61f3b115ab2531c9dcf7cde0a) | `golangci-lint: 1.43 -> 1.44`                                                   |
| [`99dad34b`](https://github.com/NixOS/nixpkgs/commit/99dad34bf7eab888bb4f23cece2f2cb2eeb80dcf) | `fluent-bit: 1.8.9 -> 1.8.11`                                                   |
| [`aae77301`](https://github.com/NixOS/nixpkgs/commit/aae7730128579abbd50dee81c3d3695918a6137f) | `adguardhome: 0.107.0 - 0.107.3`                                                |
| [`8187f650`](https://github.com/NixOS/nixpkgs/commit/8187f6500dc4817839df39f2cca044450867f6ca) | `tamarin-prover: install emacs-mode`                                            |
| [`d5e4c312`](https://github.com/NixOS/nixpkgs/commit/d5e4c3129825c848c2dd525bc03dd1ca804dcbb5) | `python3Packages.sphinxcontrib-htmlhelp: actually provide a useful description` |
| [`7891c655`](https://github.com/NixOS/nixpkgs/commit/7891c655a80dda3458bac240cd69fd709e47d4e6) | `python3Packages.datafusion: init at 0.4.0 (#152763)`                           |
| [`85b23d71`](https://github.com/NixOS/nixpkgs/commit/85b23d7198abddb978d093641e0033cc72b4e59a) | `blocky: init at 0.17`                                                          |
| [`7e149abe`](https://github.com/NixOS/nixpkgs/commit/7e149abe9db1509fa974bb2286f862a761ca0a07) | `coqPackages.reglang: mark as compatible with Coq 8.15`                         |
| [`4b7398fe`](https://github.com/NixOS/nixpkgs/commit/4b7398fe10b631aa31eefcbfa711cd694c1ce04f) | `coqPackages_8_15.equations: init at 1.3+8.15`                                  |
| [`f18e7420`](https://github.com/NixOS/nixpkgs/commit/f18e7420793666fa52d832145f7d33ea7b51d2e6) | `coqPackages.deriving: mark as compatible with Coq 8.15`                        |
| [`ec85449f`](https://github.com/NixOS/nixpkgs/commit/ec85449f80ba9c117e08ad4253c46e3febf72dae) | `coqPackages.coq-record-update: mark as compatible with Coq 8.15`               |
| [`e290bc12`](https://github.com/NixOS/nixpkgs/commit/e290bc12f765636dbaad53e06549e78f561f1ca2) | `coqPackages.coq-ext-lib: 0.11.4 -> 0.11.6`                                     |
| [`520383dd`](https://github.com/NixOS/nixpkgs/commit/520383dd0b802d3aaed94d11fe584ad28932dd2c) | `nixos/tests/bird: init`                                                        |
| [`c6bd1eea`](https://github.com/NixOS/nixpkgs/commit/c6bd1eea71b08372ec6d3a60b5203110c9bd66b2) | `nixos/tor: fix tor getting killed by systemd when shuttding down`              |
| [`ba27a0aa`](https://github.com/NixOS/nixpkgs/commit/ba27a0aaeda1cde0f24853a2fa32fe4de4d0ed30) | `nixos/bird: add option to modify config check environment`                     |
| [`1aa68fcd`](https://github.com/NixOS/nixpkgs/commit/1aa68fcdb76fe0f46d46ac332e611a811270a308) | `exploitdb: 2022-01-20 -> 2022-01-25`                                           |
| [`35fa5b5e`](https://github.com/NixOS/nixpkgs/commit/35fa5b5ee6208e18ffe3bfefec0e3e7a9d08a6d7) | `sagetex: etc`                                                                 |
| [`6beb5851`](https://github.com/NixOS/nixpkgs/commit/6beb585135cb26a9362e1dd670ec44c4a163e41d) | `shattered-pixel-dungeon: 1.1.0 -> 1.1.2`                                       |
| [`fc475fa8`](https://github.com/NixOS/nixpkgs/commit/fc475fa802422fe4415c24b470d65308acb50dfd) | `sagetex: etc`                                                                 |
| [`375b48a5`](https://github.com/NixOS/nixpkgs/commit/375b48a52df6d2230493a71d549807402eed318f) | `sagetex: init at 3.6`                                                          |
| [`e65d5300`](https://github.com/NixOS/nixpkgs/commit/e65d53007d5ea3f7a066a2f89ecca1e94b2bf62c) | `python310Packages.django-taggit: 2.0.0 -> 2.1.0`                               |
| [`d33a77c0`](https://github.com/NixOS/nixpkgs/commit/d33a77c0568ed53254fa2226a80fab56acce5bd3) | `cosign: 1.4.1 -> 1.5.0`                                                        |
| [`a8e94e7e`](https://github.com/NixOS/nixpkgs/commit/a8e94e7e9052921d10598a47e986df059f9f4614) | `python310Packages.glom: 20.11.0 -> 22.1.0`                                     |
| [`075b606e`](https://github.com/NixOS/nixpkgs/commit/075b606ef9b10e7bbe4e6d3dd21cf4f171c27e5c) | `coqPackages.corn: mark as compatible with Coq 8.15`                            |
| [`e40a892f`](https://github.com/NixOS/nixpkgs/commit/e40a892f1174aec97c13c210382f24939c805991) | `coqPackages.math-classes: 8.13.0 -> 8.15.0`                                    |
| [`6fd76ce6`](https://github.com/NixOS/nixpkgs/commit/6fd76ce628c458201f74e35a8e834dd9352b14ba) | `python310Packages.markdown-it-py: 2.0.0 -> 2.0.1`                              |
| [`71dd58ce`](https://github.com/NixOS/nixpkgs/commit/71dd58ce85493d9061a2d9e009f8da59e5fea686) | `tree-sitter-markdown: ikatyang parser to MDeiml`                               |
| [`c069b934`](https://github.com/NixOS/nixpkgs/commit/c069b934c2f18729fee2d9dae5630adc3d3d2e47) | `python3Packages.flux-led: 0.28.10 -> 0.28.11`                                  |
| [`cd0e58e5`](https://github.com/NixOS/nixpkgs/commit/cd0e58e56195aa2fdd9be1495c6444d71fbc7dba) | `python3Packages.woob: disable doctest and coverage`                            |
| [`b8882c70`](https://github.com/NixOS/nixpkgs/commit/b8882c701d2e7ac6ae3a8d7850e82303b6271b5d) | `python3Packages.weboob: disable failing tests`                                 |
| [`20e7213d`](https://github.com/NixOS/nixpkgs/commit/20e7213d16eef3c3591f0452796b8d42245da865) | `coq_8_15: 8.15+rc1 → 8.15.0`                                                   |
| [`f8ea1ec9`](https://github.com/NixOS/nixpkgs/commit/f8ea1ec9cec0128e16353c4c2fec606c92cbf2ca) | `dune_2: 2.9.1 -> 2.9.2 (#156329)`                                              |
| [`479a6c43`](https://github.com/NixOS/nixpkgs/commit/479a6c43624e7907e1c1265e232c2be900955a19) | `topgrade: 8.1.2 -> 8.2.0`                                                      |
| [`5c9b88f3`](https://github.com/NixOS/nixpkgs/commit/5c9b88f321234ca1d7a769ef2ddb2346e2fb4388) | `python310Packages.aiounifi: 29 -> 30`                                          |
| [`bbae68bf`](https://github.com/NixOS/nixpkgs/commit/bbae68bf89d0f946403ca2daaa43630464bd3249) | `kubescape: 2.0.142 -> 2.0.143`                                                 |
| [`005f015b`](https://github.com/NixOS/nixpkgs/commit/005f015bf3fba3e72a6da4056c3bff91f7e0e8bb) | `kubescape: 2.0.141 -> 2.0.142`                                                 |
| [`fc92ef3b`](https://github.com/NixOS/nixpkgs/commit/fc92ef3b58c0ce37aa8144b4356e62cadabdedda) | `vimPlugins: update`                                                            |
| [`52a75a30`](https://github.com/NixOS/nixpkgs/commit/52a75a30310755a75b91534e88af7ad31f305525) | `python3Packages.pytest-subprocess: 1.3.2 -> 1.4.0`                             |
| [`a04d00dd`](https://github.com/NixOS/nixpkgs/commit/a04d00dd0d8cafbb1d6248ac7715d0b3e93c1154) | `python310Packages.manimpango: 0.4.0.post0 -> 0.4.0.post1`                      |
| [`3f2bda3d`](https://github.com/NixOS/nixpkgs/commit/3f2bda3de197aa6b911721c00103b3df6e1efc13) | `python310Packages.plaid-python: 8.9.0 -> 8.10.0`                               |
| [`4ceb1897`](https://github.com/NixOS/nixpkgs/commit/4ceb1897d31accc8983de883f5b7a1c228486966) | `python3Packages.pylibftdi: update meta`                                        |
| [`fedc27d1`](https://github.com/NixOS/nixpkgs/commit/fedc27d167224f9adb32d8f0d73d1f2ad628b7e1) | `python310Packages.pylibftdi: 0.19.0 -> 0.20.0`                                 |
| [`9e87a658`](https://github.com/NixOS/nixpkgs/commit/9e87a65871a93df285ab3ed5bf6b9d06aab72c08) | `python310Packages.django-cleanup: 5.2.0 -> 6.0.0`                              |
| [`78a05d47`](https://github.com/NixOS/nixpkgs/commit/78a05d47d4703abe8a21193218845f50db5f3063) | `python3Packages.feedparser: disable failing tests`                             |
| [`6a26c320`](https://github.com/NixOS/nixpkgs/commit/6a26c3206ab58e21c652e1b26786dc4ec8a5755a) | `python310Packages.flake8-length: 0.2.2 -> 0.3.0`                               |
| [`77345eab`](https://github.com/NixOS/nixpkgs/commit/77345eab9b5dec745f443480fd9fe109ee1748ee) | `python310Packages.aioshelly: 1.0.7 -> 1.0.8`                                   |
| [`254db377`](https://github.com/NixOS/nixpkgs/commit/254db3771f611e0e304505512efdb1155735515e) | `python310Packages.pylaunches: 1.2.1 -> 1.2.2`                                  |
| [`b54751a2`](https://github.com/NixOS/nixpkgs/commit/b54751a22183647b2467df863ab4b364792b51af) | `nixStable: 2_6 -> 2_5`                                                         |
| [`4890db4f`](https://github.com/NixOS/nixpkgs/commit/4890db4fdd25beb81eadcc9ed4e6791be4cbabc1) | `python3Packages.rollbar: disable tests`                                        |
| [`6a85c487`](https://github.com/NixOS/nixpkgs/commit/6a85c48734eda626da4f0f7497c07778fbbe3823) | `python310Packages.plexapi: 4.8.0 -> 4.9.1`                                     |
| [`409e81a1`](https://github.com/NixOS/nixpkgs/commit/409e81a1b6fc2424561c68908f9c11dce445777b) | `gleam: 0.18.2 -> 0.19.0 (#156486)`                                             |
| [`ea7407b1`](https://github.com/NixOS/nixpkgs/commit/ea7407b156c3ba87601757a3930de29e2e9d5b72) | `elixir: 1.13.1 -> 1.13.2 (#156462)`                                            |
| [`9af8ecce`](https://github.com/NixOS/nixpkgs/commit/9af8ecce83d8fa7f5cd3be8abf5837560b1aa784) | `maintainer: update lunarequest's name`                                         |
| [`53a6300a`](https://github.com/NixOS/nixpkgs/commit/53a6300ad651fe4d62073f897a73bfa7f7794934) | `conmon: 2.0.32 -> 2.1.0`                                                       |
| [`8d530c67`](https://github.com/NixOS/nixpkgs/commit/8d530c676a53856ddff889d05ba453cbed0b8efa) | `sgx-sdk: fix build`                                                            |
| [`22897649`](https://github.com/NixOS/nixpkgs/commit/2289764950e676c54acda2b84a2aa546b0050866) | `python310Packages.levenshtein: 0.16.0 -> 0.17.0`                               |
| [`dcf2db1a`](https://github.com/NixOS/nixpkgs/commit/dcf2db1a4fbd5aa103786467a8954b23f2da3ee1) | `kubernetes: 1.22.4 -> 1.22.6`                                                  |
| [`b5fc7509`](https://github.com/NixOS/nixpkgs/commit/b5fc7509659c59884b806dfcc8a26735bd281ae2) | `nixUnstable: 2.6pre20211217 -> 2.7pre20220124`                                 |
| [`6e7e03fe`](https://github.com/NixOS/nixpkgs/commit/6e7e03feb7f661e79d41286376700537c2c928c6) | `move mpc_cli to aliases.nix`                                                   |
| [`fd7729c1`](https://github.com/NixOS/nixpkgs/commit/fd7729c1451e66c48d3cef89fc8106d6ca2bb978) | `nix: introduce buildNix function to avoid so much copy-pasting`                |
| [`7366cd77`](https://github.com/NixOS/nixpkgs/commit/7366cd77ccdeee80b1edd1b4621f9c5daa88e42d) | `nix: 2.5.1 -> 2.6.0`                                                           |
| [`2050d991`](https://github.com/NixOS/nixpkgs/commit/2050d991c48398cbbdb9644cfa9c63458c75d8bd) | `maintainers/maintainer-list.nix: remove algorith`                              |
| [`7fb017e3`](https://github.com/NixOS/nixpkgs/commit/7fb017e379323920330054165b95412058cd1afb) | `nixos/modules/services/hardware/triggerhappy.nix: mpc_cli -> mpc-cli`          |
| [`a2658f46`](https://github.com/NixOS/nixpkgs/commit/a2658f46338dea6d09b47c8939821d915cdaeb92) | `nixos/tests/mpd.nix: mpc_cli -> mpc-cli`                                       |
| [`b7875ab3`](https://github.com/NixOS/nixpkgs/commit/b7875ab366ae8fb94a9f3b45b245e43c64d1f75a) | `clerk: mpc_cli -> mpc-cli`                                                     |
| [`52c5f6c6`](https://github.com/NixOS/nixpkgs/commit/52c5f6c6a1f0b8ebe45fc9df9f63b7dc01b1aae7) | `mpc-cli: temporary alias to mpc_cli`                                           |
| [`54d5c634`](https://github.com/NixOS/nixpkgs/commit/54d5c634d04f9c17b093b9bdea48f78bbe458f33) | `mpc_cli: install shell completions`                                            |
| [`c31a567a`](https://github.com/NixOS/nixpkgs/commit/c31a567a83d7a77661014a916830b61658cdf385) | `mpc_cli: put myself as new maintainer`                                         |
| [`6bd19d74`](https://github.com/NixOS/nixpkgs/commit/6bd19d749c7f048f03349e256f35bfceaaf6a455) | `sqlfluff: 0.9.1 -> 0.9.2`                                                      |
| [`056e2fd6`](https://github.com/NixOS/nixpkgs/commit/056e2fd60cf1891b3f6bcd611ec785282b4b11c6) | `srtrelay: unstable-2021-07-28 -> 1.1.0`                                        |
| [`3ba3702e`](https://github.com/NixOS/nixpkgs/commit/3ba3702e624da0a89a4a79b7ee9f89721ffe0160) | `ima-evm-utils: 1.1 -> 1.4`                                                     |
| [`88be3e3c`](https://github.com/NixOS/nixpkgs/commit/88be3e3ca483b7d80bd7c151f9c2045834c715b1) | `flexget: 3.2.13 -> 3.2.15`                                                     |
| [`b725c5c3`](https://github.com/NixOS/nixpkgs/commit/b725c5c3f15d10c0b7d75bf4837ad875b2e42122) | `uutils-coreutils: 0.0.8 -> 0.0.12`                                             |
| [`ecbad79b`](https://github.com/NixOS/nixpkgs/commit/ecbad79bfbf28be30a233db270bb6102c86f53e5) | `lombok: 1.18.20 -> 1.18.22`                                                    |
| [`637a001f`](https://github.com/NixOS/nixpkgs/commit/637a001f69db31ec4ae0a0beaa9e092a6dc09e1f) | `dcap: Init at 2.47.12 (#156282)`                                               |
| [`555014c6`](https://github.com/NixOS/nixpkgs/commit/555014c67d27040c792be370734801e558b43022) | `online-judge-tools: init at 11.5.1`                                            |
| [`abe84c21`](https://github.com/NixOS/nixpkgs/commit/abe84c21a9a45845f68eb02dcc5937ca34224dec) | `neovim: add ldflag for treesitter plugins requiring libstdc++`                 |
| [`7976f70b`](https://github.com/NixOS/nixpkgs/commit/7976f70bae1f688a2d1a9e1863710c63bbc16b5f) | `ffmpeg_5: init at 5.0`                                                         |
| [`e79bb564`](https://github.com/NixOS/nixpkgs/commit/e79bb564af849cab074452a9ed24208e0002c716) | `pdfstudio: merge with package pdfstudioviewer (#156274)`                       |
| [`ae2b1d7e`](https://github.com/NixOS/nixpkgs/commit/ae2b1d7e7f8fc0358035d8920a6fd75fd07355dd) | `python3Packages.rtoml: ignore DeprecationWarning`                              |
| [`885ccad0`](https://github.com/NixOS/nixpkgs/commit/885ccad0962ba49eb32d37ce9b2ca2c0908cea21) | `micropython: 1.17 -> 1.18`                                                     |
| [`b137621f`](https://github.com/NixOS/nixpkgs/commit/b137621f28ff9b8ce952b8fa117c17f6cbd6cb16) | `python3Packages.sgmllib3k: disable failing test on Python 3.10`                |
| [`57bea154`](https://github.com/NixOS/nixpkgs/commit/57bea1542360e28a87cc7a1b9053448e9e0ae57c) | `alot: disable failing test`                                                    |
| [`61982fb6`](https://github.com/NixOS/nixpkgs/commit/61982fb66adc7902488942749479d970f04bc837) | `maintainers: update samuelgrf's email and keys`                                |
| [`32d086c4`](https://github.com/NixOS/nixpkgs/commit/32d086c4bb6838a7dd2a9cf2d67dd03fb7b887ea) | `maintainers: format`                                                           |
| [`3b6c07fb`](https://github.com/NixOS/nixpkgs/commit/3b6c07fb3622f7640222f83c91de4fdfddb68538) | `prometheus-redis-exporter: 1.33.0 -> 1.34.1`                                   |
| [`de07108f`](https://github.com/NixOS/nixpkgs/commit/de07108f8e0ce9f4734e5193137605554cbe0daf) | `btrfs-progs: Add test`                                                         |
| [`7c9fbe98`](https://github.com/NixOS/nixpkgs/commit/7c9fbe98cb4811d2dd387465d98e1799ffaaf8fa) | `python310Packages.whodap: 0.1.2 -> 0.1.3`                                      |
| [`7fc56a03`](https://github.com/NixOS/nixpkgs/commit/7fc56a03f0f093b047b55fed3461b0117d8e63e6) | `rxvt-unicode: 9.26 -> 9.30`                                                    |
| [`1ac83b0d`](https://github.com/NixOS/nixpkgs/commit/1ac83b0de5e29558be07c36b8c675b03f1650b30) | `libptytty: init at 2.0`                                                        |
| [`a3d54dec`](https://github.com/NixOS/nixpkgs/commit/a3d54dece70888e851a00a28a1895ea6b1928fdf) | `btrfs-progs: fix musl build`                                                   |
| [`1616d5df`](https://github.com/NixOS/nixpkgs/commit/1616d5dfb4d5653fb0690e1ee6e98ca6daa33509) | `librespot: mark as broken on darwin`                                           |
| [`78561d2f`](https://github.com/NixOS/nixpkgs/commit/78561d2f6bbab7a20055eca717ccdf1bc67cc952) | `mcfly: 0.5.11 -> 0.5.12`                                                       |
| [`339a63ab`](https://github.com/NixOS/nixpkgs/commit/339a63abbec8a8853e0fc22e93b42145f98683bc) | `gt: init at 2021-09-30`                                                        |
| [`eb5e5f13`](https://github.com/NixOS/nixpkgs/commit/eb5e5f139d833e8c86f21eea79a69e25c10de989) | `libusbgx: init at 2021-10-31`                                                  |
| [`80568491`](https://github.com/NixOS/nixpkgs/commit/80568491efe8b7e8aec2ab3b74a2957600270060) | `checkov: 2.0.727 -> 2.0.753`                                                   |
| [`308f57db`](https://github.com/NixOS/nixpkgs/commit/308f57dbafa5a5167edc8e144c937bd397b65380) | `lynis: 3.0.6 -> 3.0.7`                                                         |
| [`6c76d36a`](https://github.com/NixOS/nixpkgs/commit/6c76d36a3b6a17bf1dad69bd304e7f09ed6eef79) | `strongswan: add strongswan-swanctl test to passthru.tests`                     |
| [`d1089bd7`](https://github.com/NixOS/nixpkgs/commit/d1089bd70b954d6b47b2da9e881921df43fe512d) | `libzim: 7.1.0 -> 7.2.0`                                                        |
| [`c292a879`](https://github.com/NixOS/nixpkgs/commit/c292a8799fb3d3b17476b4bc4d4cc152d4d61049) | `strongswan: 5.9.4 -> 5.9.5`                                                    |
| [`2b90fea7`](https://github.com/NixOS/nixpkgs/commit/2b90fea78c70e9e1265e305112cb57c37ce82d4b) | `python310Packages.nmapthon2: 0.1.3 -> 0.1.5`                                   |
| [`b3ca14d0`](https://github.com/NixOS/nixpkgs/commit/b3ca14d0fd7a5627ff70acba832d894f9c096079) | `ncspot: 0.9.3 -> 0.9.5`                                                        |
| [`48dbe262`](https://github.com/NixOS/nixpkgs/commit/48dbe26229124114f26cfe0eec32866a47888452) | `nixos/doc: Document types.unique`                                              |
| [`8691ab3d`](https://github.com/NixOS/nixpkgs/commit/8691ab3d47f1f9f94b51357fba7b8133cc8bcd88) | `lib.modules: Define mergeOneOption in terms of mergeUniqueOption`              |
| [`4800f308`](https://github.com/NixOS/nixpkgs/commit/4800f308413d03c39be5311ff63a218177af32df) | `nixos: Explain system.build.installBootLoader's odd default`                   |
| [`511e89f5`](https://github.com/NixOS/nixpkgs/commit/511e89f5a66c77c378d30853e5e0ac6995e0013e) | `nixos: Make system.build.installBootLoader a proper option`                    |
| [`2aa7c258`](https://github.com/NixOS/nixpkgs/commit/2aa7c25808847847bc40be93b57a1e6174aeda09) | `nixos: Document system.build.toplevel`                                         |
| [`ba3e91ed`](https://github.com/NixOS/nixpkgs/commit/ba3e91ed43c05a4a0984a6faa948949612fd113c) | `lib.types: Add unique like uniq, but custom errors`                            |
| [`73e2f41e`](https://github.com/NixOS/nixpkgs/commit/73e2f41ea2c5789f888e8c6d000b6b9417cd94fa) | `matrix-synapse: 1.50.1 -> 1.50.2`                                              |
| [`ba480d77`](https://github.com/NixOS/nixpkgs/commit/ba480d77224a53550d538071ea672f4d4ec167b2) | `python3Packages.mkdocs: get tests passing`                                     |
| [`10d33eee`](https://github.com/NixOS/nixpkgs/commit/10d33eee2de8404805cef918511f40f1541d49d7) | `python3Packages.mkdocs: fix indent`                                            |
| [`173a62e8`](https://github.com/NixOS/nixpkgs/commit/173a62e890737bb5195bd308095762d05f5690f4) | `python3Packages.mkdocs: remove unnecessary postPatch step`                     |
| [`60d94441`](https://github.com/NixOS/nixpkgs/commit/60d94441fd3864922cb8e43c0cdc8db6b16ac280) | `python3Packages.mkdocs: 1.2.1 -> 1.2.3`                                        |
| [`58a2318a`](https://github.com/NixOS/nixpkgs/commit/58a2318a576b6ce5483ed724594a6092ad73e16a) | `python3Packages.mkdocs: sort and categorize inputs`                            |
| [`d6521c5e`](https://github.com/NixOS/nixpkgs/commit/d6521c5ef7efbdb01f35b5e60b7f2a2625bc7b06) | `mkdocs: move to python3Packages.mkdocs`                                        |
| [`3463e507`](https://github.com/NixOS/nixpkgs/commit/3463e507c58bab3cc306f6975c1e04d5788dfb6b) | `vnstat: 2.8 -> 2.9`                                                            |
| [`43906b25`](https://github.com/NixOS/nixpkgs/commit/43906b25ca32047fd0deca91b3e7c71283ec01c4) | `gomapenum: 1.0.2 -> 1.0.3`                                                     |
| [`49b635aa`](https://github.com/NixOS/nixpkgs/commit/49b635aa63e36d5a5de68a06e2ae03be613b9753) | `fits-cloudctl: 0.10.5 -> 0.10.6`                                               |
| [`a673c6b8`](https://github.com/NixOS/nixpkgs/commit/a673c6b87c382dbb9ac4b176c5247b233ab0108d) | `fioctl: 0.22 -> 0.23`                                                          |
| [`1c66a470`](https://github.com/NixOS/nixpkgs/commit/1c66a470baea7c14b9dc2cd2cb5845216ee01282) | `godns: 2.5.3 -> 2.6`                                                           |
| [`fabc16d4`](https://github.com/NixOS/nixpkgs/commit/fabc16d410ed1bf00c04824202ce3f09f1aa7c03) | `efm-langserver: 0.0.38 -> 0.0.40`                                              |
| [`c275c834`](https://github.com/NixOS/nixpkgs/commit/c275c834195e93c8e87e2db62d131d5bebd895b7) | `dnsproxy: 0.40.3 -> 0.40.5`                                                    |
| [`57829cc2`](https://github.com/NixOS/nixpkgs/commit/57829cc246ef9d5d39cc6a94c92b7c0a17eba60a) | `fetchgithub: Support sparseCheckout`                                           |
| [`36cc03e1`](https://github.com/NixOS/nixpkgs/commit/36cc03e1516edc4286e7840297de2ccffe536d35) | `fetchgit: Add test for sparseCheckout`                                         |
| [`8c26b2d6`](https://github.com/NixOS/nixpkgs/commit/8c26b2d60f971f3e9f827039913b179c722618f5) | `fetchgit: Add document for sparseCheckout`                                     |
| [`d03a07d5`](https://github.com/NixOS/nixpkgs/commit/d03a07d5a74ef780b9de78225a7d7d59db8f9169) | `fetchgit: Support sparse checkout`                                             |
| [`acd695f9`](https://github.com/NixOS/nixpkgs/commit/acd695f9017120c155bb700b66685ba03627b8d7) | `proxychains-ng: 4.15 -> 4.16`                                                  |
| [`ca0ebd52`](https://github.com/NixOS/nixpkgs/commit/ca0ebd52927125bf1e7b260a59a7078576b06435) | `legendary-gl: 0.20.24 -> 0.20.25`                                              |
| [`08595059`](https://github.com/NixOS/nixpkgs/commit/08595059e836197cb2ea85e8d00c06377b9dfab1) | `wraith: 1.4.7 -> 1.4.10`                                                       |
| [`ccb85a53`](https://github.com/NixOS/nixpkgs/commit/ccb85a53b6a496984073227fd8c4d4c58889f421) | `nixos: Make system.build a submodule with freeformType`                        |
| [`3ac955ac`](https://github.com/NixOS/nixpkgs/commit/3ac955acf44e2155d1fef77c49b5c6f068e6e27b) | `nixos/system/build: Extract`                                                   |
| [`e00f4d62`](https://github.com/NixOS/nixpkgs/commit/e00f4d62b2d489bdaf4adecc88cc1e87c871b72a) | `cargo-tarpaulin: 0.18.5 -> 0.19.1`                                             |
| [`84fc3eca`](https://github.com/NixOS/nixpkgs/commit/84fc3eca44c647827dac23666cbcb1c134fe7f81) | `binance: 1.29.0 -> 1.30.1`                                                     |
| [`6794a2c3`](https://github.com/NixOS/nixpkgs/commit/6794a2c3f67a92f374e02c52edf6442b21a52ecb) | `php81: 8.1.1 -> 8.1.2`                                                         |
| [`75941639`](https://github.com/NixOS/nixpkgs/commit/759416392b476320fa16f2ac863f438b9b3bb19a) | `vintagestory: 1.16.0 -> 1.16.1`                                                |
| [`72a12486`](https://github.com/NixOS/nixpkgs/commit/72a12486732e8e9313fcf5c34d5224cec4d8646e) | `python3Packages.jdatetime: add pythonImportsCheck`                             |
| [`4409b9f3`](https://github.com/NixOS/nixpkgs/commit/4409b9f3c1a13c9359425ff6893dabf9ebaad7b7) | `git-revise: 0.6.0 -> 0.7.0`                                                    |
| [`42128ece`](https://github.com/NixOS/nixpkgs/commit/42128ece370b7a133f912136fc7e61cb9c6ea37b) | `python310Packages.aioesphomeapi: 10.6.0 -> 10.8.0`                             |
| [`d0700b9e`](https://github.com/NixOS/nixpkgs/commit/d0700b9e2276bcdf84783c07327fc2b924072014) | `python310Packages.aiohwenergy: 0.6.0 -> 0.7.0`                                 |
| [`f57c822f`](https://github.com/NixOS/nixpkgs/commit/f57c822f7a1964533f30fd4426ef6a3e3eb7fa0a) | `swayr: 0.11.2 -> 0.12.0`                                                       |
| [`38e16d7c`](https://github.com/NixOS/nixpkgs/commit/38e16d7c76761055096b0dd7e8353e6401f75571) | `python310Packages.jdatetime: 3.8.0 -> 3.8.1`                                   |
| [`280ebc81`](https://github.com/NixOS/nixpkgs/commit/280ebc81a7ecbfabf1d03a37906f17788ee8c757) | `nwg-wrapper: 0.1.0 -> 0.1.2`                                                   |
| [`0b27a6c2`](https://github.com/NixOS/nixpkgs/commit/0b27a6c24e051b10b3164deb83b039a162b8bc29) | `python3Packages.gigalixir: fix build`                                          |
| [`c74a7840`](https://github.com/NixOS/nixpkgs/commit/c74a7840e2c0705971bf0fba9572580ba66a4588) | `diskdev_cmds: fix build using arch's xnu source`                               |
| [`3d2cb0d6`](https://github.com/NixOS/nixpkgs/commit/3d2cb0d6a2871f3a2b6f21a0766b58eedd6d1f34) | `discourse: 2.8.0.beta10 -> 2.8.0.beta11`                                       |
| [`10c0cf6e`](https://github.com/NixOS/nixpkgs/commit/10c0cf6e4f20986b90346570846b5d1f723c6b6d) | `qtile: cleanup`                                                                |
| [`4f7cfc8c`](https://github.com/NixOS/nixpkgs/commit/4f7cfc8cd90e2b46ab53a789755606cd2644a87f) | `nixos/tests/bcachefs: use multi-disk`                                          |