### PR TITLE
chore(flake/nixpkgs): `2410a4db` -> `9ddd6d72`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -156,11 +156,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643134871,
-        "narHash": "sha256-MdVTKjnAyTSncdDW+dM1L21/cI533bxurDkkWQxXCK8=",
+        "lastModified": 1643140919,
+        "narHash": "sha256-L3R/OxLzejyJ9j0pOkMxr9BY3qWhUrtic2Dv3I63mcY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2410a4db4eb5e3a6493de2a4f710241f54b9dba7",
+        "rev": "9ddd6d7266f287eb6a2cd0d3c1797e2708f621b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`bd3256cf`](https://github.com/NixOS/nixpkgs/commit/bd3256cf4f7a651e234403977fa29d4dfde255b8) | `polkit: fix local priviledge escalation in pkexec`                            |
| [`475d525b`](https://github.com/NixOS/nixpkgs/commit/475d525b0f143450bfc1be38c60583a6d6b309c6) | `kdeltachat: unstable-2021-12-26 -> unstable-2022-01-02`                       |
| [`e014c529`](https://github.com/NixOS/nixpkgs/commit/e014c52972e97a991e931c7950621fb4d98ed9a9) | `libdeltachat: 1.70.0 -> 1.71.0`                                               |
| [`54a44e4f`](https://github.com/NixOS/nixpkgs/commit/54a44e4f7725f83ac60d084254aef5188580392f) | `python310Packages.django-oauth-toolkit: 1.6.3 -> 1.7.0`                       |
| [`bada781a`](https://github.com/NixOS/nixpkgs/commit/bada781aed0fa4bb744817c329e5ceca30462d9c) | `python310Packages.fastapi: 0.71.0 -> 0.73.0`                                  |
| [`752cf518`](https://github.com/NixOS/nixpkgs/commit/752cf518945a96c64ff12afc8831460e8d7d9d82) | `python310Packages.od: 1.0 -> 2.0.1`                                           |
| [`b98584d3`](https://github.com/NixOS/nixpkgs/commit/b98584d32a388a3d8edd807c6f3af5c8b00474a0) | `python310Packages.groestlcoin_hash: 1.0.1 -> 1.0.3`                           |
| [`c4baf7b2`](https://github.com/NixOS/nixpkgs/commit/c4baf7b23be8f9c2a0681578ae70c9d71ffe99a1) | `lens: fix filechooser`                                                        |
| [`9ac627da`](https://github.com/NixOS/nixpkgs/commit/9ac627da5b65c394b7e0a5afd444a273a42dd72d) | `python3Packages.dulwich: 0.20.31 -> 0.20.32`                                  |
| [`55ae0867`](https://github.com/NixOS/nixpkgs/commit/55ae086747caa71b92f6713a58a909acef944705) | `pathDerivation: Copy path`                                                    |
| [`cb2f8a87`](https://github.com/NixOS/nixpkgs/commit/cb2f8a87d5389c7347b27937cbcde510696e36f7) | `Check that nix-env output doesn't depend on the Nixpkgs location`             |
| [`12ce1f2f`](https://github.com/NixOS/nixpkgs/commit/12ce1f2f06e1633ca205441a1de1af1c2e13bd97) | `kapp: 0.43.0 -> 0.44.0`                                                       |
| [`2f14e11f`](https://github.com/NixOS/nixpkgs/commit/2f14e11f3a545130409c520909a64b86e92f737d) | `cryptsetup: don't look at targetPlatform`                                     |
| [`4bde5a3a`](https://github.com/NixOS/nixpkgs/commit/4bde5a3a68d8d7095017f57c831b6f9540848e16) | `libredirect: fix build for aarch64-darwin (PR #156460)`                       |
| [`fde0b2e2`](https://github.com/NixOS/nixpkgs/commit/fde0b2e2f28aeac074e424bb0a17917ceeee43b9) | `vim: 8.2.3877 -> 8.2.4186 (security)`                                         |
| [`cf3fd4d3`](https://github.com/NixOS/nixpkgs/commit/cf3fd4d37d6a8fe6f3777b088ce614950c1e9c1e) | `python3Packages.heatzypy: 1.4.2 -> 2.0.1`                                     |
| [`1ab8a4f4`](https://github.com/NixOS/nixpkgs/commit/1ab8a4f45be45efbd54e0b9d32ba396c9ec4e7ef) | `sway: fix eval`                                                               |
| [`260bdcf0`](https://github.com/NixOS/nixpkgs/commit/260bdcf048b961fa62f65673a83d46cc4756aeac) | `realesrgan-ncnn-vulkan: init at 0.1.3.2`                                      |
| [`0fbb1737`](https://github.com/NixOS/nixpkgs/commit/0fbb17370399ac73eda80512f21cdf9731a46411) | `glslang: fix SPIRVTargets.cmake`                                              |
| [`96ff4336`](https://github.com/NixOS/nixpkgs/commit/96ff43366db95b242aebe75f1bfc4325a52e97db) | `maintainers: change name of tilcreator`                                       |
| [`7d8a2243`](https://github.com/NixOS/nixpkgs/commit/7d8a22436c3af77843729d0552ac6f245e2944f8) | `ncnn: init at 20211208`                                                       |
| [`9a8e7903`](https://github.com/NixOS/nixpkgs/commit/9a8e79033bc105045dba9e23b029a0c655df45dc) | `river: 0.1.0 -> 0.1.2`                                                        |
| [`d3ec14f6`](https://github.com/NixOS/nixpkgs/commit/d3ec14f6cb05c8532a0ee8af97fb2c6ed28509dd) | `darwin.text_cmds: fix build`                                                  |
| [`d1ad218c`](https://github.com/NixOS/nixpkgs/commit/d1ad218cc116993218a53a130b4c6d94dc73c355) | `mpc_cli: add ncfavier as maintainer`                                          |
| [`44d16005`](https://github.com/NixOS/nixpkgs/commit/44d160059b012cf148a86a1e5309bca2d83f62cd) | `maintainers: add github handle for algorith`                                  |
| [`1a6f79a4`](https://github.com/NixOS/nixpkgs/commit/1a6f79a47e8ff16af7bcdbf8767b557c77a00522) | `zrythm: fix build with meson 0.60`                                            |
| [`c5d52173`](https://github.com/NixOS/nixpkgs/commit/c5d52173c2e46487f23fc695883f2f812a08c5ca) | `yabridge: fix meson options`                                                  |
| [`d251bc57`](https://github.com/NixOS/nixpkgs/commit/d251bc57bc989e1728391ad1e76b6ba8647194ca) | `scrcpy: remove unknown override_server_path option`                           |
| [`915e4a0f`](https://github.com/NixOS/nixpkgs/commit/915e4a0fd07484333ef27b832ae85eee7b92da38) | `retro-gtk: fix build with meson 0.60`                                         |
| [`5276d5f6`](https://github.com/NixOS/nixpkgs/commit/5276d5f62bb18c463d724447e9ad685b5cf85807) | `parlatype: remove libreoffice build option`                                   |
| [`7d97b7dc`](https://github.com/NixOS/nixpkgs/commit/7d97b7dcf545650d9e34073905dcdb5d4326f439) | `libhttpseverywhere: fix build with meson 0.60`                                |
| [`9ab8b140`](https://github.com/NixOS/nixpkgs/commit/9ab8b1400c5ac6cb2d0ed0bc7787cdecc86a6903) | `libfprint-tod: fix build with meson 0.60`                                     |
| [`4068bcbf`](https://github.com/NixOS/nixpkgs/commit/4068bcbf353d3eded339349dfe25abbdf0d58930) | `iptsd: rename systemd build option to service_manager=systemd`                |
| [`49d7624b`](https://github.com/NixOS/nixpkgs/commit/49d7624b770d4bcd03bb66b8e134dfdab5b6e203) | `intel-gpu-tools: fix build with meson 0.60`                                   |
| [`49c85141`](https://github.com/NixOS/nixpkgs/commit/49c85141aaa5186424d59dac4634b7401d0533e1) | `hexchat: rename with-text option to text-frontend`                            |
| [`3026e3df`](https://github.com/NixOS/nixpkgs/commit/3026e3dfd416bf479305adb38d1d606378024d85) | `gtg: fix build with meson 0.60`                                               |
| [`b5c610ba`](https://github.com/NixOS/nixpkgs/commit/b5c610bac8f4128d3574def467362740373d3d3a) | `arcan.xarcan: fix build with meson 0.60`                                      |
| [`e2686f5a`](https://github.com/NixOS/nixpkgs/commit/e2686f5ab3881a366e6894293d1ee4aecfcb2d09) | `mpc_cli: fix build with meson 0.60`                                           |
| [`edf5e394`](https://github.com/NixOS/nixpkgs/commit/edf5e394d3f5d50c0a7b7bcf495ce8aa80d97e47) | `fwupd: fix aarch64 build`                                                     |
| [`c09da206`](https://github.com/NixOS/nixpkgs/commit/c09da2061b000fb33a706697e05d204e2d3a8723) | `home-assistant: update constraint relaxing mechanism`                         |
| [`bbaa13e9`](https://github.com/NixOS/nixpkgs/commit/bbaa13e9abf391e463749859d0d4a92713c69d94) | `python3Packages.poetry: propagate packaging and relax constraint`             |
| [`11110136`](https://github.com/NixOS/nixpkgs/commit/11110136f5061f2112858557938c62ce3fc79fa5) | `orc: disable a benchmark test on x86_64-darwin`                               |
| [`5411ee64`](https://github.com/NixOS/nixpkgs/commit/5411ee6465351f02e5a8cad63f24ca1f45c3e84e) | `libmodulemd: fix build with newer meson`                                      |
| [`14dfd74d`](https://github.com/NixOS/nixpkgs/commit/14dfd74d8e4901918c57fbdfc4ee60c7bb7f469a) | `gnome.gnome-settings-daemon338: fix build with new meson`                     |
| [`03a4213c`](https://github.com/NixOS/nixpkgs/commit/03a4213c4f31401938b0079a00491023a92336ca) | `azure-cli: fix adal tests`                                                    |
| [`c8aa2e9d`](https://github.com/NixOS/nixpkgs/commit/c8aa2e9d7aa3b28f4b59dcc328ec2c64abf6f089) | `gtk3: fix patch hash`                                                         |
| [`99050a2c`](https://github.com/NixOS/nixpkgs/commit/99050a2c3143a14805fea973b05c628efed54c23) | `ocamlPackages.ca-certs: disable test suite expecting nss db`                  |
| [`3c984f9f`](https://github.com/NixOS/nixpkgs/commit/3c984f9fe1257b88a5492de780c419deeb28c0a1) | `meson: do not update ldconfig cache`                                          |
| [`76736500`](https://github.com/NixOS/nixpkgs/commit/7673650020d6b35cc1ad8bd76c2caac590133134) | `stdenv/darwin: fix for curl with zstd and idn2`                               |
| [`c1a71226`](https://github.com/NixOS/nixpkgs/commit/c1a712267026f3a2c7d1b0bd48db4842b0595409) | `mesa: 21.3.3 -> 21.3.4`                                                       |
| [`37ed2951`](https://github.com/NixOS/nixpkgs/commit/37ed2951d2729a0409e219fe0f54e081b2d882c8) | `libredirect: improve musl support (#154039)`                                  |
| [`c797aa41`](https://github.com/NixOS/nixpkgs/commit/c797aa41f4453e619f6624c06407d30b1c7c7454) | `libuv: 1.42.0 -> 1.43.0 (#154195)`                                            |
| [`1ea759f9`](https://github.com/NixOS/nixpkgs/commit/1ea759f94cf9b9d7c2e7af199c0f32c7cd8354c5) | `gnumake: add debug info`                                                      |
| [`41d9dfb6`](https://github.com/NixOS/nixpkgs/commit/41d9dfb6195a80624648f96dc9fc3a0c1aeaba09) | `meson: Remove 0.57, use 0.60 everywhere`                                      |
| [`23f24c95`](https://github.com/NixOS/nixpkgs/commit/23f24c95d776496adcb0cac27793cad3266052a9) | `shared-mime-info: 2.1 -> unstable-2021-12-03`                                 |
| [`e7da4b5f`](https://github.com/NixOS/nixpkgs/commit/e7da4b5f40c7a9bf62f1e4d96aad9655c153d8dc) | `systemd: removed unknown meson options`                                       |
| [`a4733c79`](https://github.com/NixOS/nixpkgs/commit/a4733c7952d2511c057437e3040fb6bad2baeb46) | `libnice: added graphviz build input`                                          |
| [`6f4c70cb`](https://github.com/NixOS/nixpkgs/commit/6f4c70cbfe018cd57b1e56836905e5d05414c7ee) | `gst-plugins-base 1.18.4 -> 1.18.5`                                            |
| [`93a83a76`](https://github.com/NixOS/nixpkgs/commit/93a83a761a253d6c849ef8c70b9802860828b9a4) | `libbpf: Fix musl build`                                                       |
| [`2303031e`](https://github.com/NixOS/nixpkgs/commit/2303031e51ca6e4bc11db858492992c0ea0ecd2a) | `spidermonkey: Force lp64d ABI for riscv64`                                    |
| [`ef4fe46f`](https://github.com/NixOS/nixpkgs/commit/ef4fe46f17065d178f1067a24a9919ec57c93536) | `spidermonkey: Add patch to support riscv64`                                   |
| [`aeea1bb5`](https://github.com/NixOS/nixpkgs/commit/aeea1bb53b28fc7bbe4583bd21f5bda8b05d5041) | `alsa-lib: 1.2.5.1 -> 1.2.6.1`                                                 |
| [`81d8b35f`](https://github.com/NixOS/nixpkgs/commit/81d8b35ff51efd02c9dad8380cc497ade75c62bd) | `commitizen: init @ 2.20.3`                                                    |
| [`23ba741a`](https://github.com/NixOS/nixpkgs/commit/23ba741aecb970a451e1be24b59ddc6daba32edc) | `libsoup_3: 3.0.3 → 3.0.4`                                                     |
| [`7eefe525`](https://github.com/NixOS/nixpkgs/commit/7eefe5259a8fc5970152d8489af1d5decef54eba) | `tracker: ignore hidden executables in subcommand directory`                   |
| [`ad7c7d63`](https://github.com/NixOS/nixpkgs/commit/ad7c7d632342687a93b8e06c61f9bfd6e64bf479) | `libjxl: Use own libhwy package, fix RISC-V build`                             |
| [`e7239d0e`](https://github.com/NixOS/nixpkgs/commit/e7239d0e8a7cb1c6805eda61944e26f6c815e909) | `libhwy: init at 0.15.0`                                                       |
| [`bec45206`](https://github.com/NixOS/nixpkgs/commit/bec452064c3df1bb8634958069085e12e708ae87) | `vala: 0.54.5 → 0.54.6`                                                        |
| [`77f02854`](https://github.com/NixOS/nixpkgs/commit/77f02854488a9bf8ef7db1a28d57e616d3424bcd) | `python3Packages.html5lib: update to latest pytest (#153108)`                  |
| [`e324d9d9`](https://github.com/NixOS/nixpkgs/commit/e324d9d94cfd1196ad7bbf74372d815bca94917b) | `xxHash: 0.8.0 -> 0.8.1 (#153001)`                                             |
| [`f9c2ed07`](https://github.com/NixOS/nixpkgs/commit/f9c2ed0713296a247bec8f142f32c479e1a2dcd1) | `python3Packages.pybind11: 2.8.1 -> 2.9.0 (#152525)`                           |
| [`c363e252`](https://github.com/NixOS/nixpkgs/commit/c363e252209911d52f64f299def3e6fd4923f25c) | `re2: 2021-09-01 -> 2021-11-01 (#153111)`                                      |
| [`f789367c`](https://github.com/NixOS/nixpkgs/commit/f789367c26ade97c7d04752a253eb3e2c2c523e3) | `ghostscript: 9.53.3 -> 9.55.0 (#153239)`                                      |
| [`fb69d766`](https://github.com/NixOS/nixpkgs/commit/fb69d7668fc2a1259e9ee8e434d79f9b3dd6d3be) | `lvm2-2_02: fix build (#154041)`                                               |
| [`0ed184fb`](https://github.com/NixOS/nixpkgs/commit/0ed184fb68d646408be936af83d52a1d7f23b296) | `python3Packages.html-sanitizer: 1.9.1 -> 1.9.2`                               |
| [`08f22ce9`](https://github.com/NixOS/nixpkgs/commit/08f22ce9cc4dfd837e54693aeceb77c3ec5d4211) | `llvmPackages_12.llvm: create fix-llvm-issue-49955.patch`                      |
| [`8722d156`](https://github.com/NixOS/nixpkgs/commit/8722d1569127fefcda863820484a6689cdc98e1e) | `mypy: 0.930 -> 0.931`                                                         |
| [`294c2118`](https://github.com/NixOS/nixpkgs/commit/294c211818331eae1d118bb574f0ef144d6f75d1) | `iso-codes: 4.6.0. -> 4.9.0`                                                   |
| [`38377ab0`](https://github.com/NixOS/nixpkgs/commit/38377ab02680908d1c83fd5f5691e0594e08df30) | `libredirect: build fat library for x86_64, arm64, arm64e on darwin (#153441)` |
| [`e238f456`](https://github.com/NixOS/nixpkgs/commit/e238f456b8d643d5afe5370e942e82204907d0ef) | `llvmPackages_*.clang: pick clangUseLLVM if targetPlatform.useLLVM`            |
| [`766f5ffb`](https://github.com/NixOS/nixpkgs/commit/766f5ffb761bc916ea0f270f472d04ab30664d52) | `llvmPackages_*: respect cc for target when choosing C++ flavour`              |
| [`7340ea55`](https://github.com/NixOS/nixpkgs/commit/7340ea55e8449babaccedd4885bcc5c6f24047a9) | ``sqlite: add `nixpkgs-update: no auto update` for the update bot``            |
| [`2d0daff4`](https://github.com/NixOS/nixpkgs/commit/2d0daff40dce0c5496c50622dd77ceca1d21f9f0) | `sqlite: 3.37.0 -> 3.37.2`                                                     |
| [`17c5a15c`](https://github.com/NixOS/nixpkgs/commit/17c5a15c89f2523b2543f946daa4d018e04d731a) | `wrapCCWith: rely on the new bintools attribute for default value`             |
| [`30f2fe6f`](https://github.com/NixOS/nixpkgs/commit/30f2fe6f8499fb2a8a6d5e3be0ba912eb00e133b) | `python3Packages.charset-normalizer: 2.0.9 -> 2.0.10`                          |
| [`eb9b64fc`](https://github.com/NixOS/nixpkgs/commit/eb9b64fc3290e4e8ee7e2d65bbf3b690ccf7eff7) | `cacert: 3.71 -> 3.74`                                                         |
| [`da28ed7d`](https://github.com/NixOS/nixpkgs/commit/da28ed7df04714648a90fd8f249fa319d9ed1bcd) | `nss: 3.73.1 -> 3.74`                                                          |
| [`2b9c5958`](https://github.com/NixOS/nixpkgs/commit/2b9c5958a10affa63551166c281bcd36ea021674) | `netbsd.compat: don't use musl's sys/cdefs.h`                                  |
| [`7be5fbf7`](https://github.com/NixOS/nixpkgs/commit/7be5fbf70fdc995034b2658bd814cfa45dfddc9a) | `pkgsStatic.netbsd: fix nbtool_config.h conflicts`                             |
| [`e57acb94`](https://github.com/NixOS/nixpkgs/commit/e57acb94b39867c43a7dcc64dfb886743c8f481f) | `python3Packages.unicodedata2: 13.0.0-2 -> 14.0.0`                             |
| [`04e867f8`](https://github.com/NixOS/nixpkgs/commit/04e867f86b0693385bc6f445ad7ba2fb504c14e2) | `yapf: 0.31.0 -> 0.32.0`                                                       |
| [`20b0e16c`](https://github.com/NixOS/nixpkgs/commit/20b0e16c329467b563e3d9edf9dd60ba72f38f70) | `curl: 7.80.0 -> 7.81.0`                                                       |
| [`bc2d6de6`](https://github.com/NixOS/nixpkgs/commit/bc2d6de6463d0bbaa25a2c5083f62eefb0b5e7e3) | `libgda: remove unnecessary gcc6 override`                                     |
| [`ade38fcf`](https://github.com/NixOS/nixpkgs/commit/ade38fcf21c702a2bbaade528201ace363dc2cbb) | `python3Packages.django_3: 3.2.9 -> 3.2.11`                                    |
| [`ffcf2ec8`](https://github.com/NixOS/nixpkgs/commit/ffcf2ec83359d4f222857849d12948b3bf73185b) | `python3Packages.django_2: 2.2.24 -> 2.2.26`                                   |
| [`e4fddecd`](https://github.com/NixOS/nixpkgs/commit/e4fddecdb38913dec4e2819a1c879aeca5dca336) | `llvmPackages_{11,12,13,git}.libllvm: enable static build`                     |
| [`e5ccc412`](https://github.com/NixOS/nixpkgs/commit/e5ccc412d27aafef9b5707a96e16b60d8e7c1d8f) | `llvmPackages_*.libllvm: only build tests if doCheck`                          |
| [`f4d0af8c`](https://github.com/NixOS/nixpkgs/commit/f4d0af8cac928aef6fff19eb60f39c7c3828dbed) | `python3Packages.flit: 3.2.0 -> 3.6.0`                                         |
| [`7e2fff28`](https://github.com/NixOS/nixpkgs/commit/7e2fff28e773650d9356c44b096019fe3ef30841) | `hunspell: switch to fetchFromGitHub`                                          |
| [`c70dca82`](https://github.com/NixOS/nixpkgs/commit/c70dca8249904e65fdb2cd6bbab6f4ab2fad2618) | `llvmPackages_*.libllvm: make llvm-config and llvm-config equivalent`          |
| [`d807aaa3`](https://github.com/NixOS/nixpkgs/commit/d807aaa30c19dde0284d72fca6c82824cd07eaec) | `llvmPackages*.libllvm: drop outputs.patch for llvm-config.patch`              |
| [`a11763fa`](https://github.com/NixOS/nixpkgs/commit/a11763fa36aa7fcb8da75d28adfdc11e9640d2d7) | `libjxl: Fix tests on darwin`                                                  |
| [`d21e4dda`](https://github.com/NixOS/nixpkgs/commit/d21e4dda7c7018dfe1f4624079e6ad819ab23255) | `gtk3: fix darwin build`                                                       |
| [`a42a04fa`](https://github.com/NixOS/nixpkgs/commit/a42a04fadd59769a1ef0584ec21442a5cb6fdef4) | `libresolv: fix build on aarch64-darwin`                                       |
| [`37916039`](https://github.com/NixOS/nixpkgs/commit/3791603924420581557604258f16bb3ed0c03b00) | `configdHeaders: init at 453.19`                                               |
| [`a238071d`](https://github.com/NixOS/nixpkgs/commit/a238071df44df8bebfa4f08fe81661b86f8d4f95) | `openexr: add patch for CVE-2021-45942`                                        |