### PR TITLE
chore(flake/nixpkgs): `9ddd6d72` -> `47f5a774`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -156,11 +156,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643140919,
-        "narHash": "sha256-L3R/OxLzejyJ9j0pOkMxr9BY3qWhUrtic2Dv3I63mcY=",
+        "lastModified": 1643183934,
+        "narHash": "sha256-5h5gkpCjg5bXpi6qmVUYivNhfCSJrhXWAq90mStdwC8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ddd6d7266f287eb6a2cd0d3c1797e2708f621b2",
+        "rev": "47f5a774e037c77dab1b6b22de89a94492c106ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                                                  |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
| [`0072957c`](https://github.com/NixOS/nixpkgs/commit/0072957c7e6e129da972c83f3648057084600760) | `qgis-ltr: 3.16.14 -> 3.16.16`                                                                                                                  |
| [`2ca00af2`](https://github.com/NixOS/nixpkgs/commit/2ca00af2c7ab3aa197fa106d91e8a23d13d7743d) | `qgis: 3.22.1 -> 3.22.3`                                                                                                                        |
| [`de256f2c`](https://github.com/NixOS/nixpkgs/commit/de256f2c029238e60a4be5bec42db6c7c86f3e0e) | `qgis, qgis-ltr: only expose unwrapped via passthru`                                                                                            |
| [`85d0a94f`](https://github.com/NixOS/nixpkgs/commit/85d0a94f900a281e1de3a9a7a6dd52bd09736692) | `qgis, pyqt: introduce qgis-ltr and update qgis`                                                                                                |
| [`ce4927f0`](https://github.com/NixOS/nixpkgs/commit/ce4927f0d5d7f22f8773906743b0e6f13e635337) | `qgis: enable 3D, grass`                                                                                                                        |
| [`8b2cf0a4`](https://github.com/NixOS/nixpkgs/commit/8b2cf0a45d117f30e0ec29247de8b528136e901c) | `grass: wrap grass with wrapGAppsHook`                                                                                                          |
| [`92b62e73`](https://github.com/NixOS/nixpkgs/commit/92b62e73530a19e6fd09d663984a4b064e5b4d5f) | `grass: Add pdal dep and missing feature flags`                                                                                                 |
| [`b9ea948a`](https://github.com/NixOS/nixpkgs/commit/b9ea948aca2872b53bec94210f632d1a8c6ebb1d) | `grass: 7.6.1 -> 7.8.6`                                                                                                                         |
| [`cea532f6`](https://github.com/NixOS/nixpkgs/commit/cea532f629a7004e622bf0f334b3f8f8e1a0f06f) | ``manual: document deprecated `minimumOCamlVersion```                                                                                           |
| [`6a19bd17`](https://github.com/NixOS/nixpkgs/commit/6a19bd175ba5692c77dcdbb4be2e728bbc04b3c4) | `tabnine: 3.7.25 -> 4.0.60`                                                                                                                     |
| [`eb98ee1e`](https://github.com/NixOS/nixpkgs/commit/eb98ee1e8b2ce272a08d7e35b8e9771e1c941545) | `maintainers: add jsierles`                                                                                                                     |
| [`6b3bf392`](https://github.com/NixOS/nixpkgs/commit/6b3bf39220430ad0275f51492a6846d4a6b92cb5) | `cwltool: 3.1.20220119140128 -> 3.1.20220124184855`                                                                                             |
| [`8fd3da81`](https://github.com/NixOS/nixpkgs/commit/8fd3da81873b6cef33b9267b2dbffb15efa0017c) | `python3Packages.pypoint: 2.2.1 -> 2.3.0`                                                                                                       |
| [`028421b6`](https://github.com/NixOS/nixpkgs/commit/028421b6a90157d24010385548de90e692a31cde) | `python3Packages.python-izone: 1.2.3 -> 1.2.4`                                                                                                  |
| [`6d711636`](https://github.com/NixOS/nixpkgs/commit/6d7116365a7a3d9435f9390f198e4b771a087a4c) | `metadata-cleaner: 2.1.3 -> 2.1.4`                                                                                                              |
| [`d52b090b`](https://github.com/NixOS/nixpkgs/commit/d52b090b2b8f6c4b1c7d3fce54e553cc8e85bc22) | `python3Packages.mat2: 0.12.2 -> 0.12.3`                                                                                                        |
| [`91e5be0f`](https://github.com/NixOS/nixpkgs/commit/91e5be0fc0eb4e1f1d95a16de867d30a7551b295) | `neovim: fix treesitter for darwin`                                                                                                             |
| [`23b3acf5`](https://github.com/NixOS/nixpkgs/commit/23b3acf554106b8417722e1b9d4df056f327ca1d) | `python3Packages.adafruit-platformdetect: 3.19.3 -> 3.19.4`                                                                                     |
| [`be3e6db3`](https://github.com/NixOS/nixpkgs/commit/be3e6db3226e39842c2bff45a1cf220f0187d374) | `libdeltachat: 1.71.0 -> 1.72.0`                                                                                                                |
| [`bc910854`](https://github.com/NixOS/nixpkgs/commit/bc91085425bfa59da1a02b9c87eaf9ef95ab83df) | `checkov: 2.0.762 -> 2.0.763`                                                                                                                   |
| [`df3dfc6d`](https://github.com/NixOS/nixpkgs/commit/df3dfc6d64c8439e064fa63771931aa46d0979e9) | `maintainers: update emmanuelrosa's email`                                                                                                      |
| [`cf710999`](https://github.com/NixOS/nixpkgs/commit/cf710999c63893957b1d1e01f1062af9a2c6b181) | `python3Packages.hahomematic: 0.21.2 -> 0.27.0`                                                                                                 |
| [`baf9192e`](https://github.com/NixOS/nixpkgs/commit/baf9192e65084c82f5909f8a053ff629a891fc7e) | `qtile: 0.19.0 -> 0.20.0`                                                                                                                       |
| [`e2b54ce4`](https://github.com/NixOS/nixpkgs/commit/e2b54ce4497e393412d83e1bffbbc456bb19b1bd) | `python3Packages.pywlroots: 0.14.12 -> 0.15.3`                                                                                                  |
| [`ed8cada7`](https://github.com/NixOS/nixpkgs/commit/ed8cada7434f0e0757baa02fd8bcc6b3dc039a77) | `libthreadar: mark as broken on darwin`                                                                                                         |
| [`9bdb1f92`](https://github.com/NixOS/nixpkgs/commit/9bdb1f9287581a5b7fe48f4d22c26f4a14678acc) | `matrix-synapse: 1.50.2 -> 1.51.0`                                                                                                              |
| [`d9ad2b40`](https://github.com/NixOS/nixpkgs/commit/d9ad2b40f14cf5c8e668e7efb51de5c4a987a371) | `nixos/tests/home-assistant: test ping via wake_on_lan component`                                                                               |
| [`d4061dcc`](https://github.com/NixOS/nixpkgs/commit/d4061dcc6e429510c3ac4e1fc3da34325eed8096) | `nixos/home-assistant: allow capset with components using ping command`                                                                         |
| [`edf59fe7`](https://github.com/NixOS/nixpkgs/commit/edf59fe71ae49be70b9ceefa6051e9055ae7cb7b) | `python3Packages.qcs-api-client: 0.20.9 -> 0.20.10`                                                                                             |
| [`8ef0fd5f`](https://github.com/NixOS/nixpkgs/commit/8ef0fd5ff14faf645bd00e27004489189f7d9291) | `checkov: 2.0.753 -> 2.0.762`                                                                                                                   |
| [`ec07330c`](https://github.com/NixOS/nixpkgs/commit/ec07330c8bad2c40d8475386e5790739eea74405) | `python3Packages.sunpy: disable failing tests`                                                                                                  |
| [`eda25592`](https://github.com/NixOS/nixpkgs/commit/eda25592175c47d37f45a051fcac7168e6aa20f8) | `python3Packages.aioftp: remove pytest-cov`                                                                                                     |
| [`32f16772`](https://github.com/NixOS/nixpkgs/commit/32f16772c5502aee74563e0a5096b66c15393494) | `python3Packages.siosocks: disable blocking tests`                                                                                              |
| [`01fd9023`](https://github.com/NixOS/nixpkgs/commit/01fd90232dc5d08901a35ab25b81dc8e5ad022ae) | `python3Packages.cftime: enable tests`                                                                                                          |
| [`ed55d1f6`](https://github.com/NixOS/nixpkgs/commit/ed55d1f607ddc5e35a24b8dbf90283f0c6f1240d) | `bazel_5: Explicitly add a dependency on bazel-rc`                                                                                              |
| [`97f90da9`](https://github.com/NixOS/nixpkgs/commit/97f90da9fa19c0788a31b2fe46788b1818706604) | `mpd: 0.23.4 -> 0.23.5`                                                                                                                         |
| [`f01e14c7`](https://github.com/NixOS/nixpkgs/commit/f01e14c731cb7ce5caa9285af9e4b19c79c7d3b0) | `pantheon.elementary-tasks: 6.1.0 -> 6.2.0`                                                                                                     |
| [`5faa988b`](https://github.com/NixOS/nixpkgs/commit/5faa988b1f032e8dc717ec9896a4a3c13d2b281c) | `pantheon.elementary-mail: 6.3.1 -> 6.4.0`                                                                                                      |
| [`34d5d14f`](https://github.com/NixOS/nixpkgs/commit/34d5d14fd0d9e0cab8458342f9e7fb105ceb7db3) | `pantheon.elementary-greeter: add patch for revert pull request 566`                                                                            |
| [`e1a28002`](https://github.com/NixOS/nixpkgs/commit/e1a28002a3a0f0ebbdcf24cc350d20551be517f0) | `bazel_5: Build xcode-locator selectively for x86_64 (on "x86_64-darwin") or arm64 (on "aarch64-darwin")`                                       |
| [`04500fd3`](https://github.com/NixOS/nixpkgs/commit/04500fd3a2d1feecd2a6b138d3d88eef1f52fa22) | `bazel_5: Build xcode-locator as a universal binary only on "aarch64-darwin"`                                                                   |
| [`6cd1a186`](https://github.com/NixOS/nixpkgs/commit/6cd1a18620cace3480208664e816ae2c24d45792) | `bazel_5:`                                                                                                                                      |
| [`03832463`](https://github.com/NixOS/nixpkgs/commit/0383246382df1b521076a2b7a1c11a25da087493) | `gitless: relax pygit2 constraint and limit to Python 3`                                                                                        |
| [`9b9954fc`](https://github.com/NixOS/nixpkgs/commit/9b9954fccc894c93946c4b1cb9b7c101b434c9fa) | `python310Packages.cftime: 1.5.1.1 -> 1.5.2`                                                                                                    |
| [`92ce3cbd`](https://github.com/NixOS/nixpkgs/commit/92ce3cbd56aef470d96d007d3dc303d253d7ecb8) | `mob: 2.2.0 -> 2.2.1`                                                                                                                           |
| [`b72e9a7a`](https://github.com/NixOS/nixpkgs/commit/b72e9a7ac0b4e7cb1166b325b59478bb75c64c7e) | `minikube: 1.24.0 -> 1.25.1`                                                                                                                    |
| [`e8e8139f`](https://github.com/NixOS/nixpkgs/commit/e8e8139f13c5ca22b7b7521bdd86b5c37f266701) | `tree-sitter-lua: switch to MunifTanjim's parser`                                                                                               |
| [`8b6ffc52`](https://github.com/NixOS/nixpkgs/commit/8b6ffc52c7dc97211c6f53d59b22b2b59a032541) | `istioctl: 1.12.1 -> 1.12.2`                                                                                                                    |
| [`4861b597`](https://github.com/NixOS/nixpkgs/commit/4861b5971b9bbe5ffd881b97bf6ec530121e52cf) | `ocamlPackages.ocamlbuild: rename name to pname&version`                                                                                        |
| [`45ec3d3d`](https://github.com/NixOS/nixpkgs/commit/45ec3d3d4abdfa98be7b02afd0f1c5b870b6d775) | `pantheon.elementary-session-settings: fix xsession TryExec`                                                                                    |
| [`046f4d52`](https://github.com/NixOS/nixpkgs/commit/046f4d5220dba7b7ca7296075a1e27362a97b269) | `pkgs/pantheon: drop repoName`                                                                                                                  |
| [`fae32545`](https://github.com/NixOS/nixpkgs/commit/fae325457a0f53a6aa026ed5fd61c99a062c56d5) | `pkgs/pantheon: reorder attributes`                                                                                                             |
| [`e7fd5598`](https://github.com/NixOS/nixpkgs/commit/e7fd5598ac0ba27ba92ca78bf9c7e9faea0850c3) | `disfetch: 3.2 -> 3.3`                                                                                                                          |
| [`4f22e7e9`](https://github.com/NixOS/nixpkgs/commit/4f22e7e994d80733592f3d28cac344148a9a3b70) | `cargo-release: 0.19.0 -> 0.19.3`                                                                                                               |
| [`e925610c`](https://github.com/NixOS/nixpkgs/commit/e925610ca3242af9ae1e4acc6b286bd0870309ba) | `python3Packages.pygeos: init at 0.12.0`                                                                                                        |
| [`a8de70bc`](https://github.com/NixOS/nixpkgs/commit/a8de70bcc6c3c48a1c5eef5af0e5ae2de4a3dc66) | `bazel_5: removed trailing spaces`                                                                                                              |
| [`e5e0fc67`](https://github.com/NixOS/nixpkgs/commit/e5e0fc67ae5c847b8b9fed2f32e3f0845fd3ee91) | `wiki-js: 2.5.268 -> 2.5.272`                                                                                                                   |
| [`2a701e80`](https://github.com/NixOS/nixpkgs/commit/2a701e80619658fd6554f2c2370545b511da087e) | `nixos/matrix-synapse: Wrap register_new_matrix_user`                                                                                           |
| [`2f4574a2`](https://github.com/NixOS/nixpkgs/commit/2f4574a21346f257b1f5864ef95878f5dcef22d2) | `maintainers: add nialov`                                                                                                                       |
| [`a3de5e71`](https://github.com/NixOS/nixpkgs/commit/a3de5e71f97326c30e288f6595b8ac4a66d4e8ad) | `bazel_5: remove patching of tools/xcode/realpath/BUILD and tools/xcode/stdredirect/BUILD in darwinPatches as these files do not exist anymore` |
| [`eeede618`](https://github.com/NixOS/nixpkgs/commit/eeede618926e7b4a9d7d9d6990e790a78fc87cf6) | `bazel_5: init at 5.0.0`                                                                                                                        |
| [`a1c05720`](https://github.com/NixOS/nixpkgs/commit/a1c057209bc83e3fe778d64520b48ee27be03035) | `plex-mpv-shim: fix tray icon`                                                                                                                  |
| [`806f9d2d`](https://github.com/NixOS/nixpkgs/commit/806f9d2df2f680472881eb337698502de8cdd18c) | `python310Packages.moderngl-window: 2.1.0 -> 2.4.1`                                                                                             |
| [`88362d1a`](https://github.com/NixOS/nixpkgs/commit/88362d1a35ba4ac92e9bf728b68c32f14468daa3) | `nixos/matrix-synapse: Remove webclient from default listener`                                                                                  |
| [`ce00fa6d`](https://github.com/NixOS/nixpkgs/commit/ce00fa6d26ec7cb4647b82b72611b42ae1c49ed0) | `dash: add test`                                                                                                                                |
| [`7ec65f33`](https://github.com/NixOS/nixpkgs/commit/7ec65f335437c5ad70c885cea0d907688e472f2f) | `git-lfs: Build subcommands`                                                                                                                    |
| [`b43196df`](https://github.com/NixOS/nixpkgs/commit/b43196dffcd410abf8fed49b4ebf2517e710f63f) | `python3Packages.pydevccu: 0.1.0 -> 0.1.1`                                                                                                      |
| [`7f814614`](https://github.com/NixOS/nixpkgs/commit/7f814614d6e30ea71ee874eb60da881db18e363a) | `linode-cli: 5.14.0 -> 5.14.0`                                                                                                                  |
| [`973bb726`](https://github.com/NixOS/nixpkgs/commit/973bb726b32895a9fd13593aaa0e15dd7691d0de) | `python38Packages.pypugjs: 5.9.9 -> 5.9.10`                                                                                                     |
| [`a378d976`](https://github.com/NixOS/nixpkgs/commit/a378d976fcf7c9a22e90af1432459fdb0f0e9ed8) | `python38Packages.trytond: 6.2.2 -> 6.2.3`                                                                                                      |