### PR TITLE
chore(flake/nixpkgs): `47f5a774` -> `ad79594d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -156,11 +156,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643183934,
-        "narHash": "sha256-5h5gkpCjg5bXpi6qmVUYivNhfCSJrhXWAq90mStdwC8=",
+        "lastModified": 1643221379,
+        "narHash": "sha256-ctMJZA++yYzbRCEHFb5ydukKdPgaGY0vCZSlbkFCW6o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47f5a774e037c77dab1b6b22de89a94492c106ac",
+        "rev": "ad79594d1e2fea66bf7d5faeec6ef35319596031",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                          |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`e9c49105`](https://github.com/NixOS/nixpkgs/commit/e9c491052479cfa4479748eaedd33cc56e59eb19) | `nixos/xdg-portals: add portals' desktop files to XDG_DATA_DIRS`        |
| [`273fa931`](https://github.com/NixOS/nixpkgs/commit/273fa93176c851ff97212afd86c9ec7ef930aed8) | `python310Packages.atlassian-python-api: 3.18.0 -> 3.18.1`              |
| [`940737fc`](https://github.com/NixOS/nixpkgs/commit/940737fcf494df9981f0fbf3e55f352cdb4d543c) | `zoom-us: 5.9.1.1380 -> 5.9.3.1911`                                     |
| [`25655970`](https://github.com/NixOS/nixpkgs/commit/25655970c5c9095046d7ebacfaf2c3f8e3dd1de2) | `vector: 0.19.0 -> 0.19.1`                                              |
| [`6a96992f`](https://github.com/NixOS/nixpkgs/commit/6a96992fe0d1fd125684261c5a029e75e7820b4f) | `Fix invalid regular expression #156861`                                |
| [`fb2b2f59`](https://github.com/NixOS/nixpkgs/commit/fb2b2f59c83316e727dc679f1b8b65afd692cccb) | `mlterm: use new tag versioning scheme`                                 |
| [`bafb6c12`](https://github.com/NixOS/nixpkgs/commit/bafb6c12786f59f305dc7faacc8cc4ef288ed16b) | `python310Packages.qcengine: 0.21.0 -> 0.22.0`                          |
| [`a01cad0d`](https://github.com/NixOS/nixpkgs/commit/a01cad0d0f38269b544ab21c0fbfd8df2da072f7) | `ocamlPackages.ppx_import: 1.8.0 -> 1.9.1 (#156399)`                    |
| [`8470f87c`](https://github.com/NixOS/nixpkgs/commit/8470f87cb9bcac110e5342541116ff273feb482b) | `diffoscope: fix nixpkgs patch to be black-compliant`                   |
| [`3a847a03`](https://github.com/NixOS/nixpkgs/commit/3a847a03b0fad90718cbfc2a58bb541ab05ca012) | `python310Packages.python-fsutil: 0.5.0 -> 0.6.0`                       |
| [`a1d5f47e`](https://github.com/NixOS/nixpkgs/commit/a1d5f47ec6e47168f357579860ef0373e49fdfa5) | `python39Packages.bandit: 1.7.1 -> 1.7.2`                               |
| [`91fb1997`](https://github.com/NixOS/nixpkgs/commit/91fb19973e721c59fe46bdb507e2c0034ca23a0b) | `kubernetes-helm: 3.7.2 ->3.8.0 (#156736)`                              |
| [`75adc68b`](https://github.com/NixOS/nixpkgs/commit/75adc68b579ff3f437859f4364afa2925763b3bc) | `live555: adding myself as maintainer`                                  |
| [`cec66bea`](https://github.com/NixOS/nixpkgs/commit/cec66bea3b7663012863f58b0c7de7d747d67631) | `sonobuoy: 0.55.1 -> 0.56.0`                                            |
| [`1526d916`](https://github.com/NixOS/nixpkgs/commit/1526d916ab7731e8121df8a68b8b5db6729d24a7) | `ocamlPackages.ocaml_libvirt: fix build by bringing pre/post phases in` |
| [`0cf3393c`](https://github.com/NixOS/nixpkgs/commit/0cf3393cdd8ccb43aefdeb0a84bc00d93339836e) | `fme: remove`                                                           |
| [`c94eb27a`](https://github.com/NixOS/nixpkgs/commit/c94eb27aeb7173849cd680b59fc5296a1418882e) | `vscode-extensions.elmtooling.elm-ls-vscode: 2.0.1 -> 2.4.0 (#156361)`  |
| [`ebc3be41`](https://github.com/NixOS/nixpkgs/commit/ebc3be413c8fcc8a905e3adb7b6ef021cfc32765) | `nvidia-x11: add GNU which to buildInputs (#156203)`                    |
| [`8ccbba4f`](https://github.com/NixOS/nixpkgs/commit/8ccbba4f55fa42e8bd2059d1635bea9625452950) | `aws-c-common: emit unwind information for RISC-V`                      |
| [`514d0f34`](https://github.com/NixOS/nixpkgs/commit/514d0f3407ea40875b6c666b7e6d84058714809b) | `google-cloud-sdk: 367.0.0 -> 370.0.0`                                  |
| [`774318d7`](https://github.com/NixOS/nixpkgs/commit/774318d795d9ebd798ef8261ab9410f7091d120c) | `python3Packages.dropbox: update meta`                                  |
| [`5e664da1`](https://github.com/NixOS/nixpkgs/commit/5e664da1e4b176f685bd112afb81494861680a78) | `commitizen: enable some tests`                                         |
| [`0293eab6`](https://github.com/NixOS/nixpkgs/commit/0293eab6735becf69d1961770d552ab81ee828d5) | `commitizen: 2.20.3 -> 2.20.4`                                          |
| [`6d5085d5`](https://github.com/NixOS/nixpkgs/commit/6d5085d5deeb936fcd61732213821a4dcb7e65c9) | `go-swag: enable automatic updating by r-ryantm`                        |
| [`b80ea23c`](https://github.com/NixOS/nixpkgs/commit/b80ea23c7b3848d98a99a2fdb958cc351d8e6c4d) | `pynitrokey: init at 0.4.9`                                             |
| [`7bdef9ba`](https://github.com/NixOS/nixpkgs/commit/7bdef9ba9940f67dfb2627f3a092c51a969d28ce) | `nkdfu: init at 0.1`                                                    |
| [`04388257`](https://github.com/NixOS/nixpkgs/commit/0438825730cdb90a5617f8af265ae31e063bd9fb) | `python310Packages.dropbox: 11.25.0 -> 11.26.0`                         |
| [`56642610`](https://github.com/NixOS/nixpkgs/commit/56642610e7b9488d457bd2b1fe21d21001cda485) | `pantheon.elementary-files: 6.1.1 -> 6.1.2`                             |
| [`dfaf2bdf`](https://github.com/NixOS/nixpkgs/commit/dfaf2bdffb11e83ee7653fa2d939fc63054151d6) | `obb: 0.0.1 -> 0.0.2`                                                   |
| [`7be304a5`](https://github.com/NixOS/nixpkgs/commit/7be304a5439303deb7f52eceee1b31bb08610a16) | `nixos/programs/tmux: specify wanted plugins`                           |
| [`dce67211`](https://github.com/NixOS/nixpkgs/commit/dce67211a473a332dbced6b05f03e7df8fdac785) | `python3Packages.schiene: 0.23 -> 0.24`                                 |
| [`7da36af9`](https://github.com/NixOS/nixpkgs/commit/7da36af97805ada2ab6ee46cb6b0914cfdda7b80) | `python3Packages.angrop: 9.1.11508 -> 9.1.11611`                        |
| [`f0aa57f9`](https://github.com/NixOS/nixpkgs/commit/f0aa57f9120f574f54fe39fae37631bd90500eed) | `python3Packages.angr: 9.1.11508 -> 9.1.11611`                          |
| [`8ed588e1`](https://github.com/NixOS/nixpkgs/commit/8ed588e13d35d7f9a07f3fe25e415ff0bc24c1c8) | `python3Packages.cle: 9.1.11508 -> 9.1.11611`                           |
| [`67a5474e`](https://github.com/NixOS/nixpkgs/commit/67a5474ea0598fdd3297962719432d8c4351b2d6) | `python3Packages.claripy: 9.1.11508 -> 9.1.11611`                       |
| [`1e80a631`](https://github.com/NixOS/nixpkgs/commit/1e80a63177656507a8b05212d78a948844539ffc) | `python3Packages.pyvex: 9.1.11508 -> 9.1.11611`                         |
| [`a19320f2`](https://github.com/NixOS/nixpkgs/commit/a19320f26c13c58a25ba8361a2d4d6dba32ce797) | `python3Packages.ailment: 9.1.11508 -> 9.1.11611`                       |
| [`78126c81`](https://github.com/NixOS/nixpkgs/commit/78126c8182bd800324180d7c11b1217fd9a99c41) | `python3Packages.archinfo: 9.1.11508 -> 9.1.11611`                      |
| [`155ea724`](https://github.com/NixOS/nixpkgs/commit/155ea72476083cf0c9b4b319a5ecb77db73dd566) | `linux_lqx: 5.15.16-lqx1 -> 5.15.16-lqx2`                               |
| [`ca07883f`](https://github.com/NixOS/nixpkgs/commit/ca07883f10fc464d5dd877defb72b9dd436af3ca) | `vlc: patch for recent live555 versions`                                |
| [`460fdfce`](https://github.com/NixOS/nixpkgs/commit/460fdfce74c739e774f8ac8e26447977cf63adad) | `live555: 2019.11.22 -> 2022.01.21`                                     |
| [`74507192`](https://github.com/NixOS/nixpkgs/commit/745071926d3716b69d1c53f3f009f912c16b65f8) | `nitrokey-app: fix typo in longDescription`                             |
| [`935fcc56`](https://github.com/NixOS/nixpkgs/commit/935fcc560ba109118836c56222b2c6f6e5c4b33c) | `rivercarro: 0.1.1 -> 0.1.2`                                            |
| [`90e7b6ce`](https://github.com/NixOS/nixpkgs/commit/90e7b6ceb32afec80dcc034d5b199bfb3abe8c16) | `talosctl: init at 0.14.1`                                              |
| [`446c21fd`](https://github.com/NixOS/nixpkgs/commit/446c21fdc75c6a045bf5b715a315bdf87b5e71cb) | `factor out tmp-dir checks`                                             |
| [`03c90974`](https://github.com/NixOS/nixpkgs/commit/03c90974a74fd31dc03af58e6aeedb0c9d1f3a35) | `add tmp_dir access check`                                              |
| [`e17fcbc9`](https://github.com/NixOS/nixpkgs/commit/e17fcbc9663040c932fd49664dc7b8cbd3b5894c) | `introduce writeable_dir argparse type`                                 |
| [`d5e5d66a`](https://github.com/NixOS/nixpkgs/commit/d5e5d66a97f34cb0de3ac9640add00db904eeb1b) | `cyanrip: 0.7.0 -> 0.8.0`                                               |
| [`2b6305f9`](https://github.com/NixOS/nixpkgs/commit/2b6305f97a911c5b94ca094163cad6fbe9d1308d) | `lbry: 0.50.2 -> 0.52.0`                                                |
| [`7765670c`](https://github.com/NixOS/nixpkgs/commit/7765670c8a80695ae1b7c4e4d3ec6389ba533f1f) | `make output_directory an optional parameter`                           |
| [`f9b5f9db`](https://github.com/NixOS/nixpkgs/commit/f9b5f9dba76f15ffc92f8e320df5a520244d263c) | `nixos/test-driver: use an argument instead of the out env-var`         |
| [`8cd010bd`](https://github.com/NixOS/nixpkgs/commit/8cd010bd5d2ebf821e72c1f53c360b9eff170b82) | `minify: 2.9.24 -> 2.9.29`                                              |
| [`7909b1d2`](https://github.com/NixOS/nixpkgs/commit/7909b1d26de6e4f3d8498c1bb8c038686559c01c) | `beyond-identity: 2.45.0-0 -> 2.49.0-0`                                 |
| [`ddad40d3`](https://github.com/NixOS/nixpkgs/commit/ddad40d3b104a2a06e903b9a08798382fa68c7e2) | `@antfu/ni: init at 0.12.0`                                             |
| [`b60f0d13`](https://github.com/NixOS/nixpkgs/commit/b60f0d13a699362c6f0a596a7c4fb4a8b6aaba63) | `dnstake: 0.0.2 -> 0.1.0`                                               |
| [`bc76f7aa`](https://github.com/NixOS/nixpkgs/commit/bc76f7aacee2c1e9eb19393551ab773160978774) | `dnspeep: 0.1.2 -> 0.1.3`                                               |
| [`76c35ec8`](https://github.com/NixOS/nixpkgs/commit/76c35ec8391401d83bc41a515f1199ce6ab04c1d) | `mullvad-vpn: use makeWrapper instead of env hack`                      |
| [`00538458`](https://github.com/NixOS/nixpkgs/commit/00538458bd8aea6f3fb87871ec3e431aa2b2c1a5) | `cherrytree: 0.99.44 -> 0.99.45`                                        |
| [`8a59f179`](https://github.com/NixOS/nixpkgs/commit/8a59f179c6d645f8c8540a5756d42a3b73ede2b5) | `amber-secret: 0.1.1 -> 0.1.2`                                          |
| [`2d7988a1`](https://github.com/NixOS/nixpkgs/commit/2d7988a12457d5fce74de3a8c21652f1062fdf64) | `python3Packages.databricks-connect: disable on older Python releases`  |
| [`0dbfd009`](https://github.com/NixOS/nixpkgs/commit/0dbfd0096833edd6b1860ceb3ba68e60f13d6b2f) | `python310Packages.databricks-connect: 9.1.5 -> 9.1.7`                  |
| [`c03c5c15`](https://github.com/NixOS/nixpkgs/commit/c03c5c1500a34897650b4297934f07b9cd8863ba) | `shogun: fix CMake targets`                                             |
| [`aaea9844`](https://github.com/NixOS/nixpkgs/commit/aaea9844c65f01b6ad605a1d80e2e6cfae4d5352) | `shogun: use Python 3 as build dependency`                              |
| [`af628f46`](https://github.com/NixOS/nixpkgs/commit/af628f46a1beaf74b1848593ee7ba200b4d4a67b) | `nixos/tests/geth: fix api check`                                       |
| [`dbfea908`](https://github.com/NixOS/nixpkgs/commit/dbfea90833766cb7f5e046d3c0eb214e7e435488) | `linux-lqx: 5.15.15 -> 5.15.16`                                         |
| [`75c7a4b4`](https://github.com/NixOS/nixpkgs/commit/75c7a4b46b4319e3cbfff28263f06c1853751e98) | `qbe: unstable-2021-11-22 -> unstable-2021-12-05`                       |
| [`d653b33f`](https://github.com/NixOS/nixpkgs/commit/d653b33f2083022e5e0bfad73002314570379ef1) | `maintainers: add jvanbruegge`                                          |
| [`6fff929c`](https://github.com/NixOS/nixpkgs/commit/6fff929c5ed6cf418d4fa13a0f45c052a8c86394) | `isabelle: Prebuild HOL session`                                        |
| [`ec6f1661`](https://github.com/NixOS/nixpkgs/commit/ec6f1661c75049f767b7adb7e66af707d39c11e2) | `linux-lqx: 5.15.12 -> 5.15.15`                                         |
| [`be0b0486`](https://github.com/NixOS/nixpkgs/commit/be0b0486ba9068e734d99782dd55e047b1d5fb2e) | `mmctl: 6.2.1 -> 6.3.0`                                                 |
| [`b5e0eb76`](https://github.com/NixOS/nixpkgs/commit/b5e0eb762d4fb2311248ff08bd39d0f61404a525) | `linux-lqx: 5.15.11 -> 5.15.12`                                         |
| [`21ca2ac0`](https://github.com/NixOS/nixpkgs/commit/21ca2ac018767221f31afc8e2f7e19f051bef0d7) | `linux_lqx: 5.15.10 -> 5.15.11`                                         |
| [`883d6ff1`](https://github.com/NixOS/nixpkgs/commit/883d6ff1a5c41dedf7d52791a75b9fd74f05a74e) | `linux_lqx: 5.14.19 -> 5.15.10`                                         |
| [`cf60042c`](https://github.com/NixOS/nixpkgs/commit/cf60042ca0e65ff80fd1fba22e0ab247aa1e7849) | `linux_lqx: 5.14.18 -> 5.14.19`                                         |
| [`f5bbf7c6`](https://github.com/NixOS/nixpkgs/commit/f5bbf7c66ca6169a43fc402892f4f4781cdb6430) | `nginxModules: add auth-a2aclr`                                         |
| [`8e29eb27`](https://github.com/NixOS/nixpkgs/commit/8e29eb27f585c29db3fa92f9eb23d699f9270c95) | `nginxModules: format`                                                  |