### PR TITLE
chore(flake/home-manager): `cbc17601` -> `24ed6e6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1643237785,
-        "narHash": "sha256-Qptze30BR0/bIM7mPB5hyEBC4F4P1ygsCddAMkwNJww=",
+        "lastModified": 1643240026,
+        "narHash": "sha256-aBx8Ot/XgO7dlRUdWbG57z7rW3+ak1ZNBt2A0aWtmqU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cbc176010b83361af5eec4b28af78d9fd69a6383",
+        "rev": "24ed6e6d4d8df7045b1fe38dedc3db179321eaa3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`24ed6e6d`](https://github.com/nix-community/home-manager/commit/24ed6e6d4d8df7045b1fe38dedc3db179321eaa3) | ``syncthing: add `cfg` variable for convenience`` |
| [`86248a2d`](https://github.com/nix-community/home-manager/commit/86248a2d5ca027af2ce605defbb505c4f6706fe1) | ``syncthing: add option `extraOptions```          |