### PR TITLE
chore(flake/templates): `f4c17dfb` -> `f6d05e35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -248,11 +248,11 @@
     },
     "templates": {
       "locked": {
-        "lastModified": 1643098319,
-        "narHash": "sha256-G1+o3y5VxhybrkuAKWGNBThGvDWv2+wV9iylte/yvq4=",
+        "lastModified": 1643245158,
+        "narHash": "sha256-yzAqHxpKZw0fkLeoKopkmPwI7Ym7K95ZzZxXIxOpmPo=",
         "owner": "NixOS",
         "repo": "templates",
-        "rev": "f4c17dfb52bd4144725d9d9352cc317df8fb13b5",
+        "rev": "f6d05e35e00a7dc960a113a95e6d46ee7309ee4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                                        |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
| [`7749fa53`](https://github.com/NixOS/templates/commit/7749fa53756fd148337b8fbbcebfe7b158dce1f9) | `attribute self.lastModifiedDate missing in newer versions of flakes` |