### PR TITLE
chore(flake/nixpkgs): `ad79594d` -> `d01b2cc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -144,11 +144,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643221379,
-        "narHash": "sha256-ctMJZA++yYzbRCEHFb5ydukKdPgaGY0vCZSlbkFCW6o=",
+        "lastModified": 1643262078,
+        "narHash": "sha256-1aVvEq0GDONmBDntHck168jonD9saMRshVgT47EwfqE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ad79594d1e2fea66bf7d5faeec6ef35319596031",
+        "rev": "d01b2cc71bf6e220e164bf57d757624b01429ba0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                    |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`d01b2cc7`](https://github.com/NixOS/nixpkgs/commit/d01b2cc71bf6e220e164bf57d757624b01429ba0) | `openssl: remove assert restricting withPerl=false (#156949)`     |
| [`ae5361fa`](https://github.com/NixOS/nixpkgs/commit/ae5361fa1b3aefe862b843133901667444389f3e) | `fix MTP support on KDE Plasma and Dolphin (#155405)`             |
| [`a3629257`](https://github.com/NixOS/nixpkgs/commit/a362925794d7b6f7e562b4c49136ac685d1e38cc) | `graalvm11-ce: 21.3.0 -> 22.0.0.2`                                |
| [`234b4a15`](https://github.com/NixOS/nixpkgs/commit/234b4a1534252017b77e93d067ec8300951c77cc) | `resholve: work around nixpkgs aarch64-darwin issues (#155251)`   |
| [`dd6e6b0f`](https://github.com/NixOS/nixpkgs/commit/dd6e6b0fcba3cbd48a0457c17227dd1e8e44445d) | `symfony-cli: 5.2.1 -> 5.2.2`                                     |
| [`50abbca9`](https://github.com/NixOS/nixpkgs/commit/50abbca9af7475b7a629060dc81ae565deca9c65) | `spotify-unwrapped: 1.1.72.439.gc253025e -> 1.1.77.643.g3c4c6fc6` |
| [`2d670842`](https://github.com/NixOS/nixpkgs/commit/2d6708424331719c8693d07f916e2503aeb1ff12) | `sssd: 2.6.2 -> 2.6.3`                                            |
| [`23c87e79`](https://github.com/NixOS/nixpkgs/commit/23c87e799185769b8706f95a1d5c992fd63a77da) | `nixos/testing-python: actually copy build artefacts`             |
| [`d1d974ca`](https://github.com/NixOS/nixpkgs/commit/d1d974caea9678df94c578063cd64d85ba6ba63a) | `crun: 1.4.1 -> 1.4.2`                                            |
| [`0b2d7180`](https://github.com/NixOS/nixpkgs/commit/0b2d7180bdf3648adef83bc64c70064cd492de6c) | `postfix: 3.6.3 -> 3.6.4`                                         |
| [`96e055fb`](https://github.com/NixOS/nixpkgs/commit/96e055fba48de677035da731594a38faa7a9e277) | `rng-tools: fix path to opensc-pkcs11.so`                         |
| [`05ecd170`](https://github.com/NixOS/nixpkgs/commit/05ecd1702530a50522bd535fd1fe714b86fe14c2) | `python3Packages.pykrakenapi: 0.2.3 -> 0.2.4`                     |
| [`410e0cd9`](https://github.com/NixOS/nixpkgs/commit/410e0cd920399f0c95a0018db58d14104b5b9556) | `zprint: 1.2.0 -> 1.2.1`                                          |
| [`9cd3ed6e`](https://github.com/NixOS/nixpkgs/commit/9cd3ed6e8cbdfc2310557608b6c055aeb4aaf7ec) | `streamlink: 3.1.0 -> 3.1.1`                                      |
| [`59539a3d`](https://github.com/NixOS/nixpkgs/commit/59539a3d3e7a5e263747bdf03ca8e41318fcd5f5) | `libvlc: fix build`                                               |
| [`a86365b0`](https://github.com/NixOS/nixpkgs/commit/a86365b05576776e279d823ffcc72f3511b2d9b8) | `linux: upgrade hardened kernel (CVE-2022-0185)`                  |
| [`e81a21bc`](https://github.com/NixOS/nixpkgs/commit/e81a21bcd5f600d8408f6c5406e6bd6e9f0c0fa5) | `colmena: 0.2.0 -> 0.2.1`                                         |
| [`55c4eced`](https://github.com/NixOS/nixpkgs/commit/55c4eced2cdb10a6b3669eb18c93f6c6efb4a745) | `python39Packages.dask-ml: 2021.11.30 -> 2022.1.22`               |
| [`b9c37264`](https://github.com/NixOS/nixpkgs/commit/b9c3726403a14b9fc820f5e621cc2a33218d772f) | `fluxcd: 0.24.1 -> 0.25.3`                                        |
| [`a83ad33b`](https://github.com/NixOS/nixpkgs/commit/a83ad33b153f0d871e9581ecfad91ce5945f1d25) | `openai: 0.12.0 -> 0.13.0`                                        |
| [`411bb3c3`](https://github.com/NixOS/nixpkgs/commit/411bb3c35f729ea88f84c35150e7b67727d8d075) | `add --no-interactive flag`                                       |
| [`d590556d`](https://github.com/NixOS/nixpkgs/commit/d590556d5cd2d3b80e9ef6ba73cfa740fed895cf) | `update docs`                                                     |
| [`44830dc0`](https://github.com/NixOS/nixpkgs/commit/44830dc0482b0325b384203b79a7f1bf4ce5e5fa) | `use lib.optionalString`                                          |
| [`75de3397`](https://github.com/NixOS/nixpkgs/commit/75de3397fd9b4e93752ecc6123deec8521aa0532) | `nixos/tests: fix #146169`                                        |
| [`421a2216`](https://github.com/NixOS/nixpkgs/commit/421a2216957707ba49dd72d109a9db0e45e349c3) | `python3Packages.hahomematic: 0.27.0 -> 0.27.2`                   |
| [`4aeff465`](https://github.com/NixOS/nixpkgs/commit/4aeff465cac510217978268300a34cbe5e3dfa1d) | `python310Packages.zha-quirks: 0.0.65 -> 0.0.66`                  |
| [`ef828091`](https://github.com/NixOS/nixpkgs/commit/ef8280914f6e2ce5d5760d287abd7baee9baba20) | `nixos/openvswitch: remove ipsec`                                 |
| [`737de29e`](https://github.com/NixOS/nixpkgs/commit/737de29e11d8fcf329e46879d4d0d0c33cdc6ac8) | `nixos/racoon: drop`                                              |
| [`b5f5cc6d`](https://github.com/NixOS/nixpkgs/commit/b5f5cc6d4417391394c7b513bf45a171a1b99c9b) | `ipsecTools: drop`                                                |
| [`9d74005c`](https://github.com/NixOS/nixpkgs/commit/9d74005cc1040a478ab8971d4ae63146cef3064d) | `zeek: 4.1.1 -> 4.2.0`                                            |
| [`210b3ba8`](https://github.com/NixOS/nixpkgs/commit/210b3ba8984b6ac3627ff666ba6e5995786354db) | `python3Packages.pubnub: 5.5.0 -> 6.0.0`                          |
| [`1d589acc`](https://github.com/NixOS/nixpkgs/commit/1d589accbe0a35d4f7d021a5c5fc32cdbde8e021) | `python3Packages.rokuecp: 0.8.4 -> 0.11.0`                        |
| [`e8b0af1b`](https://github.com/NixOS/nixpkgs/commit/e8b0af1b58c141f81a582f28d6daaf1e5ad9a080) | `unrar: 6.1.3 -> 6.1.4`                                           |
| [`aea084ad`](https://github.com/NixOS/nixpkgs/commit/aea084ad9833de4c163b1da4648e114b5af76398) | `python3Packages.pydeconz: 85 -> 86`                              |
| [`3f39eb8b`](https://github.com/NixOS/nixpkgs/commit/3f39eb8bf5e25b2c84f66b41ee8c01b063a109e1) | `python3Packages.regenmaschine: 2021.10.0 -> 2022.01.0`           |
| [`d5071b8f`](https://github.com/NixOS/nixpkgs/commit/d5071b8ffa8598d7ea701f29dcf56f01f36254a3) | `python3Packages.aiogithubapi: 22.1.0 -> 22.1.2`                  |
| [`39341ed3`](https://github.com/NixOS/nixpkgs/commit/39341ed38be4695623893222b4b82873b348bb61) | `xen: mark unsupported versions as vulnerable`                    |
| [`3d5e949f`](https://github.com/NixOS/nixpkgs/commit/3d5e949f613df54f559e1965d26d7f96d865ab5e) | `esphome: 2022.1.1 -> 2022.1.2`                                   |
| [`7fa8e89f`](https://github.com/NixOS/nixpkgs/commit/7fa8e89f4ca58a87ab4d5d8c19b7cfdf6b326c24) | `metal-cli: 0.7.0 -> 0.7.1`                                       |
| [`1f52c373`](https://github.com/NixOS/nixpkgs/commit/1f52c3736ff8f1b3272bd08cf36a2caee37ba606) | `urlwatch: add jq`                                                |
| [`9761d254`](https://github.com/NixOS/nixpkgs/commit/9761d254912dde6f3eca0abe6bfb0574c9b4e3ab) | `imath: 3.1.3 -> 3.1.4`                                           |
| [`8df9dae0`](https://github.com/NixOS/nixpkgs/commit/8df9dae0fe56e34c0ea807a7619ab4c725e21ac7) | `dua: 2.16.0 -> 2.17.0`                                           |
| [`28b3e689`](https://github.com/NixOS/nixpkgs/commit/28b3e689bfcbce2d5fb033870c67b532075963be) | `nixos/tests/teeworlds: fix blocking execute calls`               |
| [`4b08c14b`](https://github.com/NixOS/nixpkgs/commit/4b08c14b4ba9e3270a3b740fedbff9761eb1e875) | `volatility3: 1.0.1 -> 2.0.0`                                     |
| [`5161de0a`](https://github.com/NixOS/nixpkgs/commit/5161de0a1ec43a7bd7f5c3af7428f99b4f0905f3) | `cmake_2_8: drop`                                                 |
| [`479ca096`](https://github.com/NixOS/nixpkgs/commit/479ca09609e7210b73df28f869bfbdddc9551519) | `tulip: 5.2.1 -> 5.6.1`                                           |
| [`71b4acaa`](https://github.com/NixOS/nixpkgs/commit/71b4acaa4af37ec14244e56d2a54e18e1f03eefb) | `python3Packages.entrypoint2: 0.2.4 -> 1.0`                       |