### PR TITLE
chore(flake/home-manager): `24ed6e6d` -> `8d3fe136`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1643240026,
-        "narHash": "sha256-aBx8Ot/XgO7dlRUdWbG57z7rW3+ak1ZNBt2A0aWtmqU=",
+        "lastModified": 1643297255,
+        "narHash": "sha256-fKkSbAk2+9iFVhFkVpxi/x0K7Jn7bprtv8axt4duPBo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "24ed6e6d4d8df7045b1fe38dedc3db179321eaa3",
+        "rev": "8d3fe1366b8b6c4748a847d1e3b41a73269caaee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`8d3fe136`](https://github.com/nix-community/home-manager/commit/8d3fe1366b8b6c4748a847d1e3b41a73269caaee) | `neovim: support different configuration languages (#2637)` |