### PR TITLE
chore(flake/home-manager): `aa6261bb` -> `4e92ec84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1643306305,
-        "narHash": "sha256-c0vlWHLIZK4vs+43IrIEZGz7Slp18DoWOkJgIGb21jU=",
+        "lastModified": 1643307345,
+        "narHash": "sha256-xiu7i6Q3Dqu4lLfDNaAL/f2DVewBxL+ysMuAyJiGv+4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "aa6261bb96b8e19805d6b7ea764929f015a0ac09",
+        "rev": "4e92ec84f93a293042a64c3ed56ac8aee62fb6e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------- |
| [`4e92ec84`](https://github.com/nix-community/home-manager/commit/4e92ec84f93a293042a64c3ed56ac8aee62fb6e1) | `ion: Add module (#2625)` |