### PR TITLE
chore(flake/nixpkgs): `4dc70faa` -> `078e4df0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -144,11 +144,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643309186,
-        "narHash": "sha256-SxUOfcUMoXOK4TclHWD6NRNC/2e73/boCqr0HMVJZD4=",
+        "lastModified": 1643397120,
+        "narHash": "sha256-pNcGnMUW4YO2XfkaraTqqgJvf7u9/pbH8AUYR/ioQKk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4dc70faa6fa89a4dc39f2a74c9631996731ad958",
+        "rev": "078e4df095d9d1f4b5c4cb30da88546f20473b3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`078e4df0`](https://github.com/NixOS/nixpkgs/commit/078e4df095d9d1f4b5c4cb30da88546f20473b3a) | `gupnp: 1.4.1 -> 1.4.3`                                                                         |
| [`65a33fec`](https://github.com/NixOS/nixpkgs/commit/65a33fec2a6ab71d165e2caacc7254c6669edec0) | `python3Packages.jaxlibWithCuda: init at 0.1.75 (#157055)`                                      |
| [`5b958f0c`](https://github.com/NixOS/nixpkgs/commit/5b958f0c226edd2a90d1f776cd7db0fdf47276e3) | `python3Packages.apache-beam: fix build`                                                        |
| [`da815397`](https://github.com/NixOS/nixpkgs/commit/da815397a7e60c89bff5a80b24a7ca713599078e) | `python3Packages.sentry-sdk: disable web test`                                                  |
| [`ec0a4972`](https://github.com/NixOS/nixpkgs/commit/ec0a4972c81a18b02d6a7b9c49b491d8f9ddcd1d) | `vimPlugins.fidget-nvim: init at 2022-01-26`                                                    |
| [`232fc419`](https://github.com/NixOS/nixpkgs/commit/232fc41914cdd64bda2cf8df021c23b20ccf363e) | `vimPlugins: update`                                                                            |
| [`68544ccc`](https://github.com/NixOS/nixpkgs/commit/68544ccc3460d7ebecfb921f1841d7fece2319c9) | `python310Packages.nengo: 3.1.0 -> 3.2.0`                                                       |
| [`b404fb82`](https://github.com/NixOS/nixpkgs/commit/b404fb822899a3c2ff83d0d691debcfaaa564303) | `python39Packages.pdm-pep517: 0.9.4 -> 0.10.2`                                                  |
| [`9441234a`](https://github.com/NixOS/nixpkgs/commit/9441234abcec11c95d60cf1900fc63c3600c7320) | `rpm-ostree: 2021.14 -> 2022.1`                                                                 |
| [`bd8eca52`](https://github.com/NixOS/nixpkgs/commit/bd8eca52fadda92f9ac987b386388469f5b47071) | `timetagger: use SPDX 3.0 license identifier`                                                   |
| [`d90ae4bf`](https://github.com/NixOS/nixpkgs/commit/d90ae4bfac0f23a38700de4278486c9483015504) | `python3Packages.timetagger: disable tests on python versions older than 3.10`                  |
| [`ef0bee50`](https://github.com/NixOS/nixpkgs/commit/ef0bee504770e9d1b8ee553425c379556bccf60e) | `python3Packages.timetagger: format`                                                            |
| [`60376d0d`](https://github.com/NixOS/nixpkgs/commit/60376d0d7dca6ed29d60280cd17b27b37645d141) | `timetagger: 22.1.2 -> 22.1.3`                                                                  |
| [`581b57b2`](https://github.com/NixOS/nixpkgs/commit/581b57b274cab94bc89d060df17d0a5509d68b65) | `netpbm: 10.96.2 -> 10.97.2`                                                                    |
| [`f07cd03e`](https://github.com/NixOS/nixpkgs/commit/f07cd03eadba172e2c7c287144a36f8451d3d389) | `python3Packages.importlab: init at 0.7`                                                        |
| [`c707c3ab`](https://github.com/NixOS/nixpkgs/commit/c707c3ab3e568503090a61cc6c04865fb4876b3e) | `python3Packages.meshtastic: 1.2.76 -> 1.2.77`                                                  |
| [`0b2eb3e2`](https://github.com/NixOS/nixpkgs/commit/0b2eb3e2a6635d11088b081c6c1ff9b2b416bc84) | `vips: 8.12.1 -> 8.12.2`                                                                        |
| [`13c3d9f5`](https://github.com/NixOS/nixpkgs/commit/13c3d9f5c8c3efb12417dc250061597a92e5d530) | `python310Packages.trimesh: 3.9.42 -> 3.9.43`                                                   |
| [`614a3c32`](https://github.com/NixOS/nixpkgs/commit/614a3c32292885f23a9771b10dc0711ffff489e2) | `python310Packages.pony: 0.7.15rc1 -> 0.7.16`                                                   |
| [`71557df5`](https://github.com/NixOS/nixpkgs/commit/71557df5928b0e90e4238b9b81f0145df00b8cd6) | `telepresence2: 2.4.9 -> 2.4.10`                                                                |
| [`fb6b8ffb`](https://github.com/NixOS/nixpkgs/commit/fb6b8ffbca4f14784853f82e2ae216aa0efe0547) | `python310Packages.jdatetime: 3.8.1 -> 3.8.2`                                                   |
| [`50b04db0`](https://github.com/NixOS/nixpkgs/commit/50b04db0c0d2822a046945951cf93ed1f83f7501) | `python310Packages.aioconsole: 0.3.3 -> 0.4.0`                                                  |
| [`6db3ef22`](https://github.com/NixOS/nixpkgs/commit/6db3ef222870aaae2a6a8aebebd9f1c60b72453d) | `python310Packages.pymazda: 0.3.1 -> 0.3.2`                                                     |
| [`066a7a30`](https://github.com/NixOS/nixpkgs/commit/066a7a3091b307ed1d47f79191fc0be18611e107) | `python310Packages.chiavdf: 1.0.4 -> 1.0.5`                                                     |
| [`5911f67c`](https://github.com/NixOS/nixpkgs/commit/5911f67c522127961b4de46791e639ca9aa8e62d) | `python310Packages.svglib: 1.2.0 -> 1.2.1`                                                      |
| [`0646cd48`](https://github.com/NixOS/nixpkgs/commit/0646cd48211abc34f1fe6b95a7be3d89dcc4a4b7) | `python310Packages.types-decorator: 5.1.3 -> 5.1.4`                                             |
| [`da637a36`](https://github.com/NixOS/nixpkgs/commit/da637a36249f283b2d785831814165559a1e966c) | `python310Packages.httpagentparser: 1.9.1 -> 1.9.2`                                             |
| [`80ec92d5`](https://github.com/NixOS/nixpkgs/commit/80ec92d55a0ef54eeee13759258ac6acbdfcf2eb) | `openrgb: add desktop icon`                                                                     |
| [`0700dde6`](https://github.com/NixOS/nixpkgs/commit/0700dde63b10aff31b96240d83a035a6f0e7fd5e) | `php74Extensions.blackfire: 1.71.0 -> 1.72.0`                                                   |
| [`cc44eb98`](https://github.com/NixOS/nixpkgs/commit/cc44eb980615068d90f0affcbca1c1fb06c4451e) | `link-grammar: 5.9.1 -> 5.10.2`                                                                 |
| [`d4ecaf69`](https://github.com/NixOS/nixpkgs/commit/d4ecaf699e25872a010438c88ec24696cb727862) | `glib: correct update script`                                                                   |
| [`70574630`](https://github.com/NixOS/nixpkgs/commit/70574630cac16a0f657f3bdde59bf03d84fc231f) | `laminar: 1.1 -> 1.2`                                                                           |
| [`5efc8ca9`](https://github.com/NixOS/nixpkgs/commit/5efc8ca954272c4376ac929f4c5ffefcc20551d5) | `h: 1.0.0 -> 1.0.3 (#156966)`                                                                   |
| [`3f81985d`](https://github.com/NixOS/nixpkgs/commit/3f81985d746fbbfff71d91b6e34d70e9699de3c7) | `bcachefs-tools: 2021-12-25 -> 2022-01-12`                                                      |
| [`067201c3`](https://github.com/NixOS/nixpkgs/commit/067201c3cccc7e5290447a3d9a331c558179a75d) | `linux_testing-bcachefs: 2021-12-26 -> 2022-01-12`                                              |
| [`07029944`](https://github.com/NixOS/nixpkgs/commit/07029944a55c5dee33ed0a2414605c61715487e9) | `river: make XWayland support optional (#157002)`                                               |
| [`99deb1c4`](https://github.com/NixOS/nixpkgs/commit/99deb1c41814a9991756bae8793b074544743898) | `podman-compose: available on all unix platforms`                                               |
| [`63a65f2d`](https://github.com/NixOS/nixpkgs/commit/63a65f2d1acaff52ec38e027e67cf2f98a615273) | `macdylibbundler: 1.0.0 -> 1.0.4`                                                               |
| [`36a038ca`](https://github.com/NixOS/nixpkgs/commit/36a038ca52fe70d44f22420316effd8db2e37100) | `python310Packages.pyweatherflowrest: 1.0.7 -> 1.0.8`                                           |
| [`36bea6f5`](https://github.com/NixOS/nixpkgs/commit/36bea6f5f8357ee4e06ab5f9e22c446e28a4b3af) | `darktable: set lua version in all-packages.nix`                                                |
| [`a3690228`](https://github.com/NixOS/nixpkgs/commit/a36902286e17406c76996ee4525049d4d28ef543) | `yq-go: 4.17.2 -> 4.18.1`                                                                       |
| [`a9ebd6de`](https://github.com/NixOS/nixpkgs/commit/a9ebd6decfdb99b7b1445f0bb25ca721ec7ce616) | `dart: 2.14.3 -> 2.15.1`                                                                        |
| [`37df4305`](https://github.com/NixOS/nixpkgs/commit/37df4305c65ab6d3f34beebbacca491b4d122769) | `polymc: 1.0.4 -> 1.0.6`                                                                        |
| [`5253f848`](https://github.com/NixOS/nixpkgs/commit/5253f848dd03f490e4d0c1ce75f4cc841aed067b) | `python310Packages.types-futures: 3.3.7 -> 3.3.8`                                               |
| [`86d7f2d5`](https://github.com/NixOS/nixpkgs/commit/86d7f2d5e1d1de07a18c524682057cc02caecdd5) | `linuxPackages.amdgpu-pro: fix build`                                                           |
| [`c053bd3a`](https://github.com/NixOS/nixpkgs/commit/c053bd3a4b7353a2f0bf3bd7c6b3949ecbf50748) | `bundler: 2.2.24 -> 2.3.6`                                                                      |
| [`8e660e42`](https://github.com/NixOS/nixpkgs/commit/8e660e42f60bd21580ca11cedaed4d3ed423118d) | `libesmtp: 1.0.6 -> 1.1.0`                                                                      |
| [`5bb20f9d`](https://github.com/NixOS/nixpkgs/commit/5bb20f9dc70e9ee16e21cc404b6508654931ce41) | `mandown: init at 0.1.3`                                                                        |
| [`8804d87b`](https://github.com/NixOS/nixpkgs/commit/8804d87bd35f52f81d964061457f14a39ee861c5) | `tailscale: 1.20.2 -> 1.20.3`                                                                   |
| [`c2d49ebb`](https://github.com/NixOS/nixpkgs/commit/c2d49ebbaa30b7f5175b09258dd9c6951d7a69ae) | `python310Packages.aioesphomeapi: 10.8.0 -> 10.8.1`                                             |
| [`40057471`](https://github.com/NixOS/nixpkgs/commit/40057471f245e073a955020b4a1777d236b8fa9e) | `kdiff3: 1.8.5 -> 1.9.4`                                                                        |
| [`4b4f7e12`](https://github.com/NixOS/nixpkgs/commit/4b4f7e12cddb80dca862bd4a1d47ddfc9edb67ec) | `vault: 1.9.2 -> 1.9.3`                                                                         |
| [`16a14fbc`](https://github.com/NixOS/nixpkgs/commit/16a14fbc13425d087dd2d948ddc6df9e9c715489) | `thunderbird-unwrapped: 91.5.0 -> 91.5.1`                                                       |
| [`a175820f`](https://github.com/NixOS/nixpkgs/commit/a175820f63c00a7eb1b18c654aa5ad0f2b98c8b0) | `pokerth, pokerth-server: pin to boost16x to fix build`                                         |
| [`268157dc`](https://github.com/NixOS/nixpkgs/commit/268157dc83f8bbf421d983093715b6f667e976cf) | `nixos/nix-daemon: fix buildMachines eval`                                                      |
| [`b56e79f0`](https://github.com/NixOS/nixpkgs/commit/b56e79f0bdd5251386835ecb0ac05bede81a9d55) | `vorta: 0.8.2 -> 0.8.3`                                                                         |
| [`54cbee8d`](https://github.com/NixOS/nixpkgs/commit/54cbee8d9700668eaa51219f6c852b4019cfd2ba) | `root: tweak wrapping flags for auxiliary programs, avoid forcing CMAKE_CXX_STANDARD (#157069)` |
| [`fef09da9`](https://github.com/NixOS/nixpkgs/commit/fef09da9973bad931741a6e0a48fe68535a840eb) | `lighttpd: add patch to fix build on darwin x86_64`                                             |
| [`d9e21f28`](https://github.com/NixOS/nixpkgs/commit/d9e21f284317f85b3476c0043f4efea87a226c3a) | `smooth: 0.9.8 -> 0.9.9`                                                                        |
| [`e533f9d3`](https://github.com/NixOS/nixpkgs/commit/e533f9d3b2f2c0d578c935741674d72a7a1ecee2) | `breitbandmessung: throw later for unsupported systems`                                         |
| [`37ca422c`](https://github.com/NixOS/nixpkgs/commit/37ca422c73e1c8f4276072bb36f2013be7aaae43) | `libosmium: 2.17.2 -> 2.17.3`                                                                   |
| [`725d843c`](https://github.com/NixOS/nixpkgs/commit/725d843cc80359ae475715e9815c6a3010fc0b7a) | `flatpak: 1.12.2 -> 1.12.4`                                                                     |
| [`de5bdb94`](https://github.com/NixOS/nixpkgs/commit/de5bdb94f355b03a34019c34905affc3310cf113) | `softether_4_25: drop`                                                                          |
| [`68e9cd0f`](https://github.com/NixOS/nixpkgs/commit/68e9cd0f7eac10a8f82a3a8a5a46a0127eaa9b42) | `nixos/lib: Use SingleLineStr in systemd description`                                           |
| [`93f88be7`](https://github.com/NixOS/nixpkgs/commit/93f88be7d11bb7bf62bcd9b8767db41cb9d68b03) | `python3Packages.treex: jaxlib belongs in buildInputs`                                          |
| [`236bab3f`](https://github.com/NixOS/nixpkgs/commit/236bab3f1fbb85e06ee21c813253f192f31289c0) | `python3Packages.optax: jaxlib belongs in buildInputs`                                          |
| [`c674a64c`](https://github.com/NixOS/nixpkgs/commit/c674a64ce671d3b8df1b6afa57e581dc47d793cd) | `python3Packages.flax: jaxlib belongs in buildInputs`                                           |
| [`9d9a54ad`](https://github.com/NixOS/nixpkgs/commit/9d9a54adeaff2f1c4d46dad6baa8084867303b71) | `python3Packages.elegy: jaxlib belongs in buildInputs`                                          |
| [`97a90b8d`](https://github.com/NixOS/nixpkgs/commit/97a90b8d6fb51d3308255a90ba9c5f6a2b9e7a0e) | `python3Packages.treeo: jaxlib is a test dependency`                                            |
| [`501df061`](https://github.com/NixOS/nixpkgs/commit/501df061ed4be9c1609bbb0c73cddf458dfc3f80) | `python3Packages.jmp: jaxlib is a test dependency`                                              |
| [`6c2acb04`](https://github.com/NixOS/nixpkgs/commit/6c2acb04c244f6065f223072cd6b1829114560b7) | `python3Packages.dm-haiku: jaxlib is a test dependency`                                         |
| [`617d557d`](https://github.com/NixOS/nixpkgs/commit/617d557d3bdd0d558d52ed423314ac12ead6e8e3) | `gnome-2048: init at 3.38.2`                                                                    |
| [`1387fd0f`](https://github.com/NixOS/nixpkgs/commit/1387fd0fd14d2ba0c948cd4f27e2a9366bffba3c) | `keepalived: 2.2.4 -> 2.2.7`                                                                    |
| [`f8c8a891`](https://github.com/NixOS/nixpkgs/commit/f8c8a8918af3c840c0eaba6fe652016a1ced85e0) | `flatpak-builder: 1.2.0 -> 1.2.2`                                                               |
| [`8909cf13`](https://github.com/NixOS/nixpkgs/commit/8909cf13be969d216acf0ddc5efa7ae87865975b) | `python310Packages.azure-mgmt-applicationinsights: 2.0.0 -> 2.1.0`                              |
| [`f329ced6`](https://github.com/NixOS/nixpkgs/commit/f329ced6f2fac212e341d00a6ff08502b36e7f8d) | `python310Packages.sqlite-utils: 3.22 -> 3.22.1`                                                |
| [`1b121393`](https://github.com/NixOS/nixpkgs/commit/1b12139305b2db98dc8f2326ae75003645530d40) | `python39Packages.mautrix: 0.14.5 -> 0.14.6`                                                    |
| [`eff0fc08`](https://github.com/NixOS/nixpkgs/commit/eff0fc087cdaeb4360e529d313436ec6bd64f27f) | `python310Packages.sagemaker: 2.73.0 -> 2.74.0`                                                 |
| [`4e8deff9`](https://github.com/NixOS/nixpkgs/commit/4e8deff9c86da7d44c4d38dfb839cf480bd36bf3) | `spot: 0.3.0 -> 0.3.1`                                                                          |
| [`846fafa6`](https://github.com/NixOS/nixpkgs/commit/846fafa68e26d4ea642bbbacd5ea07b9503d75f6) | `lighttpd: 1.4.63 -> 1.4.64`                                                                    |
| [`fa7b83fa`](https://github.com/NixOS/nixpkgs/commit/fa7b83fa48a9567ee81edad1f2ac428a503c56ed) | `python3Packages.objax: fix tensorboard dependency (#156909)`                                   |
| [`13b987ab`](https://github.com/NixOS/nixpkgs/commit/13b987abce920e379b7bf7707fca004f485c3f91) | `linode-cli: 5.14.0 -> 5.15.0`                                                                  |
| [`eeb0e220`](https://github.com/NixOS/nixpkgs/commit/eeb0e220cddb17b00f7f84e25dbd036520c27a22) | `signal-desktop: 5.29.0 -> 5.29.1`                                                              |
| [`cf2bdd29`](https://github.com/NixOS/nixpkgs/commit/cf2bdd298b4a406bfe37efb1e9fc37294bad02f1) | `varnish60: 6.0.9 -> 6.0.10`                                                                    |
| [`683d5696`](https://github.com/NixOS/nixpkgs/commit/683d5696e38d777c1743d5b57a2c6d9a2a586457) | `varnish70: 7.0.1 -> 7.0.2`                                                                     |
| [`956dab36`](https://github.com/NixOS/nixpkgs/commit/956dab36a3a8691b851186e9579c7c64dd4aaed5) | `nextcloud: use tmpfiles to create group-readable home`                                         |
| [`46c42753`](https://github.com/NixOS/nixpkgs/commit/46c427535a72a3bcd32c2e9ff0eafc0e9e399996) | `scribusUnstable: fix build with latest poppler`                                                |
| [`d8bcc674`](https://github.com/NixOS/nixpkgs/commit/d8bcc674c4bac48aedc7f421fcc2c3d0487a150a) | `gdal: fix build with latest poppler`                                                           |
| [`a18bad9b`](https://github.com/NixOS/nixpkgs/commit/a18bad9ba31880f612d6536611a4daf7f044800d) | `kodi.packages.controller-topology-project: init at unstable-2022-01-22`                        |
| [`c4b98513`](https://github.com/NixOS/nixpkgs/commit/c4b9851332bcef5e4554e306df791b3b4b14409a) | `inkscape: fix build with Poppler 21.11.0`                                                      |
| [`490b9b0f`](https://github.com/NixOS/nixpkgs/commit/490b9b0fa0e7e90ca5bea9cfe79561a97a641530) | `poppler-data: clean up`                                                                        |
| [`8e7c58dc`](https://github.com/NixOS/nixpkgs/commit/8e7c58dc44e043f8629d5e96848ab594f684cbbc) | `poppler: 21.06.1 → 22.01.0`                                                                    |
| [`a68c4e1d`](https://github.com/NixOS/nixpkgs/commit/a68c4e1d287ed3fecb825934e2de17244d637f23) | `nextcloud-client: 3.4.1 -> 3.4.2`                                                              |
| [`ddab6418`](https://github.com/NixOS/nixpkgs/commit/ddab64189776da29169fbdc30b9e6c0024ebb43b) | `python3Packages.warcio: init at 1.7.4`                                                         |
| [`9ec1d80c`](https://github.com/NixOS/nixpkgs/commit/9ec1d80c55807213d54548708c52a8c1c9a7df4a) | `nixos/tests/breitbandmessung: use virtualisation.resolution option`                            |
| [`a56682b8`](https://github.com/NixOS/nixpkgs/commit/a56682b80e51912c0c0b35e1efdb90c1725d2b47) | `ashpd-demo: 0.0.1-alpha → 0.2.2`                                                               |
| [`ee68e7a2`](https://github.com/NixOS/nixpkgs/commit/ee68e7a2a9c8cc97aae3a5e16b7b3ad5bb273a50) | `libshumate: unstable-2021-10-06 → 1.0.0.alpha.1`                                               |
| [`6896f3be`](https://github.com/NixOS/nixpkgs/commit/6896f3beb7b358b23f9fc485bc36887e0b376630) | `phoronix-test-suite: 10.8.0 -> 10.8.1`                                                         |
| [`487aa078`](https://github.com/NixOS/nixpkgs/commit/487aa0781d2151e5be83f0f39f73c3941ba24028) | `breitbandmessung: init at 3.1.0`                                                               |
| [`b2eb5f62`](https://github.com/NixOS/nixpkgs/commit/b2eb5f62a7fd94ab58acafec9f64e54f97c508a6) | `wayland: enable ozone via $NIXOS_OZONE_WL`                                                     |
| [`471845e5`](https://github.com/NixOS/nixpkgs/commit/471845e52a1f6c24e0251acc376dc09dd18f732e) | `qownnotes: 22.1.9 -> 22.1.10.1`                                                                |
| [`c8033a07`](https://github.com/NixOS/nixpkgs/commit/c8033a0787adce888234db268e216928279183ef) | `LAStools: 201003 -> 2.0.0`                                                                     |
| [`e5dfca88`](https://github.com/NixOS/nixpkgs/commit/e5dfca887c243a401effa3eb7912d2b2a5ed57ea) | `hydrus: 470b -> 471`                                                                           |
| [`b94195fc`](https://github.com/NixOS/nixpkgs/commit/b94195fc843a23a0be33a674297e145e463556a4) | `phpExtensions.ds: init at 1.4.0`                                                               |
| [`fd61b4ca`](https://github.com/NixOS/nixpkgs/commit/fd61b4ca596dd8a2acd7a270c10cf65e321c6ac3) | `nix: remove pointless let..in from common`                                                     |
| [`0419f3b4`](https://github.com/NixOS/nixpkgs/commit/0419f3b47bf51e644f0bfb46ef216685bd944c02) | `hydra: don't use nixUnstable alias`                                                            |
| [`421abd6e`](https://github.com/NixOS/nixpkgs/commit/421abd6e8a2e03c0056487da2cd4123a25e02fa7) | `nixVersions: move buildNix functionality into common.nix`                                      |
| [`c1d240ff`](https://github.com/NixOS/nixpkgs/commit/c1d240ffcb119c201ef1f59d4cd6e5136071a308) | `nixVersions: keep attrset chronologically sorted`                                              |
| [`3e049210`](https://github.com/NixOS/nixpkgs/commit/3e049210ef271658194875df81b58e0d43bac10f) | `treewide: replace nix_2_3 with nixVersions.nix_2_3`                                            |
| [`3a7e6f7b`](https://github.com/NixOS/nixpkgs/commit/3a7e6f7bd4b172c68dd67d37730c1b7709f7f343) | `treewide: replace nix_2_4 with nixVersions.nix_2_4`                                            |
| [`a1be7cb1`](https://github.com/NixOS/nixpkgs/commit/a1be7cb1c3efe7006984fb15a72afc83889ea356) | `nixVersions: init`                                                                             |
| [`e4d25f9d`](https://github.com/NixOS/nixpkgs/commit/e4d25f9d5a762dd4682796f2bd1b3ca8403919b8) | `nix: move declaration to top-level/all-packages`                                               |
| [`52103132`](https://github.com/NixOS/nixpkgs/commit/5210313299beadedb004cfd4dc1758be10d65031) | `nixStable: make an alias of nix`                                                               |
| [`65f90920`](https://github.com/NixOS/nixpkgs/commit/65f90920df524c4eb706c84bff248ac24ff0ff7b) | `nix: update boehmgc-coroutine-sp-fallback.patch`                                               |
| [`1ba24285`](https://github.com/NixOS/nixpkgs/commit/1ba2428545462ec1e72b7271f768b1c48f7ed152) | `nix: factor out common.nix`                                                                    |
| [`daca8307`](https://github.com/NixOS/nixpkgs/commit/daca830722a48d67065658f8259782fd0734eb9f) | `doc/coding-conventions: Fix version attribute suffix to match reality`                         |
| [`59078992`](https://github.com/NixOS/nixpkgs/commit/59078992d1d0b961d57b477b946a31d7aed3d6aa) | `ptcollab: 0.5.0.3 -> 0.6.0.2`                                                                  |
| [`c7d93e26`](https://github.com/NixOS/nixpkgs/commit/c7d93e26160310fa44881d90214dedd1324433f7) | `poco: 1.10.1 -> 1.11.1`                                                                        |
| [`54aa307b`](https://github.com/NixOS/nixpkgs/commit/54aa307bd6bcf9e3390eaf5b22a1431502be17e0) | `go-swagger: 0.28.0 -> 0.29.0`                                                                  |
| [`c6d7a29a`](https://github.com/NixOS/nixpkgs/commit/c6d7a29ab605a5e1804cd30d5320c27dc8dfc91b) | `codeql: 2.7.3 -> 2.7.5`                                                                        |
| [`799d59f7`](https://github.com/NixOS/nixpkgs/commit/799d59f72503fe4da547fce984cba90bdfe9d713) | `mysocketw: switch to fork with version 3.10.27`                                                |
| [`497a16f2`](https://github.com/NixOS/nixpkgs/commit/497a16f2a61e296b6cfc66646e39162d3c263651) | `signal-desktop: 5.28.0 -> 5.29.0`                                                              |
| [`e06082ed`](https://github.com/NixOS/nixpkgs/commit/e06082eda06ee586de17e0a060e8cd0eddd20c69) | `signal-desktop: 5.27.1 -> 5.28.0`                                                              |
| [`45db27da`](https://github.com/NixOS/nixpkgs/commit/45db27da2ee6b8923c2ad5fcde2af1d82215fb69) | `xxh: added tests`                                                                              |
| [`5e9f0c1e`](https://github.com/NixOS/nixpkgs/commit/5e9f0c1e979eafe21808905a2830c0c628e6bef5) | `xxh: 0.8.7 -> 0.8.8`                                                                           |
| [`6024d6cc`](https://github.com/NixOS/nixpkgs/commit/6024d6cc61064ed231e2b0e89416ec2fe873fc0e) | `xxh: better description`                                                                       |
| [`a37d5183`](https://github.com/NixOS/nixpkgs/commit/a37d5183204a2587780691b52955a31487a17753) | `xxh: formatting`                                                                               |
| [`510ef169`](https://github.com/NixOS/nixpkgs/commit/510ef1697788b82d3caa5d60b84ffab3263a2418) | `xxh:platform set by python`                                                                    |
| [`424f07f3`](https://github.com/NixOS/nixpkgs/commit/424f07f328f2b696aa316da6b0302eae4152b46d) | `xxh: init at 0.8.7`                                                                            |