### PR TITLE
chore(flake/home-manager): `fb939d1a` -> `418ae217`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1643407286,
-        "narHash": "sha256-0ua1W4xOYdBW7tkZHAqOy0lzkL2OHBb3sVXgDPvM5k8=",
+        "lastModified": 1643409745,
+        "narHash": "sha256-30sdz0T1SMdEAbAxjqGBMmiP0ag1/MPUfeXD9kg3JNI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fb939d1acf2d677d4404452f072bb0fe3ae4417d",
+        "rev": "418ae217ddf31e02649d07e58da05110840a7962",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                         |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`418ae217`](https://github.com/nix-community/home-manager/commit/418ae217ddf31e02649d07e58da05110840a7962) | `home-manager.autoUpgrade: add module` |