### PR TITLE
chore(flake/home-manager): `418ae217` -> `acf824c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1643409745,
-        "narHash": "sha256-30sdz0T1SMdEAbAxjqGBMmiP0ag1/MPUfeXD9kg3JNI=",
+        "lastModified": 1643411645,
+        "narHash": "sha256-q1TjWmK1MeGNfcU8ud11v9ZTqq2UI8YiCVKCD2MeAEk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "418ae217ddf31e02649d07e58da05110840a7962",
+        "rev": "acf824c9ed70f623b424c2ca41d0f6821014c67c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                         |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`acf824c9`](https://github.com/nix-community/home-manager/commit/acf824c9ed70f623b424c2ca41d0f6821014c67c) | `sbt: trim output of password command` |