### PR TITLE
chore(flake/nixgl): `b29530a5` -> `6a00a8c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -119,20 +119,12 @@
       }
     },
     "nixgl": {
-      "inputs": {
-        "flake-utils": [
-          "utils"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
       "locked": {
-        "lastModified": 1643150838,
-        "narHash": "sha256-EuaRM5Bo/7nZvRNkQWURKAoyB0G93j4bJlPhyE5bdqU=",
+        "lastModified": 1643653689,
+        "narHash": "sha256-8J6HqBr8+JlZzjyMV8FrCS6ZI6rHo1pTMPilSBf6TaE=",
         "owner": "lovesegfault",
         "repo": "nixgl",
-        "rev": "b29530a598cb48ae8f3000fcfe44b37f08fa06b8",
+        "rev": "6a00a8c7694c791a1cd11abcc320191c6f240d94",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -28,11 +28,7 @@
 
     impermanence.url = "github:nix-community/impermanence";
 
-    nixgl = {
-      url = "github:lovesegfault/nixgl/flake";
-      inputs.flake-utils.follows = "utils";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    nixgl.url = "github:lovesegfault/nixgl/flake";
 
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
 


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                               |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`6a00a8c7`](https://github.com/lovesegfault/nixGL/commit/6a00a8c7694c791a1cd11abcc320191c6f240d94) | `docs: add info on using the nixgl flake`    |
| [`c53b23e1`](https://github.com/lovesegfault/nixGL/commit/c53b23e1dbf83d0fa39e9001ed5ed6ef2dea28fe) | `refactor(flake): use final instead of prev` |
| [`69e5e3e2`](https://github.com/lovesegfault/nixGL/commit/69e5e3e2161ccb72f5882cc0cabbbb9db693ec63) | `refactor(flake): only expose overlay`       |