### PR TITLE
chore(flake/impermanence): `ff2240b0` -> `05cc388c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -105,11 +105,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1642362310,
-        "narHash": "sha256-/ZkAKJpvAFG9Nd0kOUUmqLb1pKOa0cpU832khuxUAUo=",
+        "lastModified": 1643658165,
+        "narHash": "sha256-sel3Dhkc0APCMzZuNDS5L0FUM20OaeL1tfI/0cS38Xc=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "ff2240b04ffb9322241b9f6374305cbf6a98a285",
+        "rev": "05cc388c3e459996ef0552ba74f529b84343497a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`05cc388c`](https://github.com/nix-community/impermanence/commit/05cc388c3e459996ef0552ba74f529b84343497a) | `fix(nixos): allow eval to succeed when the module is unused`        |
| [`3fe959d3`](https://github.com/nix-community/impermanence/commit/3fe959d3dc34e7db6ef3aae55fa2aa6cbbd5719a) | `refactor: utillinux -> util-linux`                                  |
| [`406924e6`](https://github.com/nix-community/impermanence/commit/406924e62e5eaedb2f73375dde95417aaa14c356) | `nixos: Add support for custom permissions on created directories`   |
| [`7f12a9d7`](https://github.com/nix-community/impermanence/commit/7f12a9d7ccdba843460036f93ed2d87d7cba4aa0) | `nixos: Implement support for user files and directories`            |
| [`5738763c`](https://github.com/nix-community/impermanence/commit/5738763c8d91653923469b8a7cf1382c3ee14ff1) | `nixos: Assert that no duplicate files or directories are specified` |
| [`0befe72b`](https://github.com/nix-community/impermanence/commit/0befe72b48d590b079f3be47515896258facad17) | `nixos: Refactor the module to simplify future extensibility`        |