### PR TITLE
chore(flake/nixpkgs): `180be3e2` -> `07a283bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -136,11 +136,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643543326,
-        "narHash": "sha256-x+GAWcv2fxJMCerYkH6jOYnKenzjcFCKQUcx61oTKhY=",
+        "lastModified": 1643919911,
+        "narHash": "sha256-f6/nmdX1Gsc17UL0u7FtBGUKEJ//CztzqTdghuVK4kY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "180be3e2b7ec82fab523a3b132fee63c05145c30",
+        "rev": "07a283bb00398dc8b32e31269ca1fa051c646305",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`fcb7b15b`](https://github.com/NixOS/nixpkgs/commit/fcb7b15b10ad7eb51221df5e2d93a6306f9abe9a) | `home-assistant: update component-packages`                            |
| [`277d6494`](https://github.com/NixOS/nixpkgs/commit/277d6494b24a310c2e91fa0d9b136576f682c162) | `python3Packages.aurorapy: init at 0.2.6`                              |
| [`30da1274`](https://github.com/NixOS/nixpkgs/commit/30da1274dbd90939520fe6e18499489650d06787) | `python310Packages.deezer-python: 5.0.1 -> 5.1.0`                      |
| [`f4dccd58`](https://github.com/NixOS/nixpkgs/commit/f4dccd58f4676b8363ede9e7779c7fb8352ce3b0) | `rocksdb: 6.27.3 -> 6.28.2`                                            |
| [`5a7f3100`](https://github.com/NixOS/nixpkgs/commit/5a7f3100e3ccd4269c0da5a39b7c4c14b6a33dbf) | `vaultwarden: 1.23.1 -> 1.24.0`                                        |
| [`a699e7ce`](https://github.com/NixOS/nixpkgs/commit/a699e7ceb41ebc46798ea3222b6ab7153fef0919) | `home-assistant: update component-packages`                            |
| [`241fc63f`](https://github.com/NixOS/nixpkgs/commit/241fc63f215952427ecfd0c3989f3f965063ce89) | `python3Packages.aioaseko: init at 0.0.1`                              |
| [`5c6b8b6f`](https://github.com/NixOS/nixpkgs/commit/5c6b8b6fcfc029f8468b7a5e4038d1f7bd64fc70) | `home-assistant: update component-packages`                            |
| [`3f76c7d1`](https://github.com/NixOS/nixpkgs/commit/3f76c7d11a8bb09361f3d4c5c676a9ce35fd993c) | `python3Packages.pyaussiebb: init at 0.0.9`                            |
| [`2336118e`](https://github.com/NixOS/nixpkgs/commit/2336118ea9e33f9714efbf0c7e4927abade8cbbc) | `tcpreplay: 4.3.4 -> 4.4.0`                                            |
| [`b484b1c2`](https://github.com/NixOS/nixpkgs/commit/b484b1c2dd85bd4233296278d410d280157949af) | `stgit: 1.4 -> 1.5`                                                    |
| [`9e0cc1ce`](https://github.com/NixOS/nixpkgs/commit/9e0cc1ce07a8d40799d14b106169bb87fc1712d2) | `home-assistant: update component-packages`                            |
| [`e4a506d6`](https://github.com/NixOS/nixpkgs/commit/e4a506d6997ea653a4debb165232d8205d5cd1ab) | `python3Packages.aiooncue: init at 0.3.2`                              |
| [`cd1daa01`](https://github.com/NixOS/nixpkgs/commit/cd1daa018aa17873e0dc6df16a2b26df3595e950) | `sidplayfp: 2.2.2 -> 2.2.3`                                            |
| [`9baf6886`](https://github.com/NixOS/nixpkgs/commit/9baf6886462a2a4cd71599680802d2459f28be23) | `python310Packages.limnoria: 2022.1.1.post1 -> 2022.1.29`              |
| [`d18a68f3`](https://github.com/NixOS/nixpkgs/commit/d18a68f3e047253d89b118c99388744d72dd4ac7) | `home-assistant: update component-packages`                            |
| [`e7271045`](https://github.com/NixOS/nixpkgs/commit/e72710456d5adf5ab44f5ed9c48fc3d6a6e9a453) | `python3Packages.circuit-webhook: init at 1.0.1`                       |
| [`1a476523`](https://github.com/NixOS/nixpkgs/commit/1a476523b8a8c1ac65fb31495c49ebe231d25fac) | `home-assistant: update component-packages`                            |
| [`a4992f0e`](https://github.com/NixOS/nixpkgs/commit/a4992f0e97f374b483929ae11feb763e3cee73ca) | `python3Packages.aiowebostv: init at 0.1.2`                            |
| [`d0e8f0c9`](https://github.com/NixOS/nixpkgs/commit/d0e8f0c9513fb1b3d4358ae2f85b864e95c226ff) | `home-assistant: update component-packages`                            |
| [`2563b468`](https://github.com/NixOS/nixpkgs/commit/2563b46830c9a6e12cdd73a68f820429ea908273) | `python3Packages.rtsp-to-webrtc: init at 0.5.0`                        |
| [`61592546`](https://github.com/NixOS/nixpkgs/commit/6159254671a1e5d52afda2bc56bbdd5ef4020ff0) | `home-assistant: update component-packages`                            |
| [`4be4b4ee`](https://github.com/NixOS/nixpkgs/commit/4be4b4ee54e00ed52aee07c2502604d725e219e9) | `python3Packages.ttls: init at 1.4.2`                                  |
| [`f6068cbf`](https://github.com/NixOS/nixpkgs/commit/f6068cbf1e9a2223a0942b64018991f8191220d8) | `Revert "cups: 2.4.0 -> 2.4.1"`                                        |
| [`ecbb9e66`](https://github.com/NixOS/nixpkgs/commit/ecbb9e669d0a66d9d8297e5f7c278772dec425e3) | `home-assistant: update component-packages`                            |
| [`9edef3a2`](https://github.com/NixOS/nixpkgs/commit/9edef3a262f0ca6cff2aa80a210fcfc73fa269dc) | `azure-cli: fix azure-batch sha`                                       |
| [`4d5d012d`](https://github.com/NixOS/nixpkgs/commit/4d5d012dd4cb4402db469c784df1f9b2136fa73f) | `python310Packages.azure-batch: 11.0.0 -> 12.0.0`                      |
| [`6593e3f2`](https://github.com/NixOS/nixpkgs/commit/6593e3f2ae40e2dafb5f2793c62e08699afba188) | `python3Packages.intellifire4py: init at 0.5`                          |
| [`7cb44e1b`](https://github.com/NixOS/nixpkgs/commit/7cb44e1b8eb4163653588c4ebaaa44d578321acd) | `python310Packages.mautrix: 0.14.8 -> 0.14.10`                         |
| [`2536a4a2`](https://github.com/NixOS/nixpkgs/commit/2536a4a2d887975d9bf16c1b41171b506ec16393) | `terragrunt: 0.36.0 -> 0.36.1`                                         |
| [`3bb74c77`](https://github.com/NixOS/nixpkgs/commit/3bb74c77da6e349b33cbe551bc64fb7fd87f8b93) | `stern: 1.20.1 -> 1.21.0`                                              |
| [`01d86082`](https://github.com/NixOS/nixpkgs/commit/01d86082da7ab8ad86a8cf3742a09f6b5a2ae5f0) | `cups: 2.4.0 -> 2.4.1`                                                 |
| [`a5b8447b`](https://github.com/NixOS/nixpkgs/commit/a5b8447bbd6989c443fb43af7b933347f1da4e4c) | `soft-serve: 0.1.2 -> 0.1.3`                                           |
| [`9c6d41d9`](https://github.com/NixOS/nixpkgs/commit/9c6d41d9f80253206ef84bf5b9ac57f35c36e258) | `saml2aws: 2.33.0 -> 2.34.0`                                           |
| [`38ce6b3c`](https://github.com/NixOS/nixpkgs/commit/38ce6b3ccbd2b24aaf3cf425bf82f60f89ffb9ad) | `python310Packages.awscrt: 0.13.0 -> 0.13.1`                           |
| [`13e6570b`](https://github.com/NixOS/nixpkgs/commit/13e6570b1ee2a71399d9f2ab66ad85a12ae4fb0e) | `python310Packages.xml2rfc: 3.12.0 -> 3.12.1`                          |
| [`349740ca`](https://github.com/NixOS/nixpkgs/commit/349740ca4f9c36ce8cacb6100798447b59f45728) | `python310Packages.django_classytags: 3.0.0 -> 3.0.1`                  |
| [`8c4e1859`](https://github.com/NixOS/nixpkgs/commit/8c4e18593f4401594b1eac9c45e182ee1a68f2c8) | `python310Packages.pytrends: 4.7.3 -> 4.8.0`                           |
| [`e7982e91`](https://github.com/NixOS/nixpkgs/commit/e7982e91d857e33effff6dbaafd2f89a6f2c258f) | `python310Packages.pyshp: 2.1.3 -> 2.2.0`                              |
| [`44a9603a`](https://github.com/NixOS/nixpkgs/commit/44a9603ae7e6967e21b2e857652c610a4fb0fcf8) | `python310Packages.dropbox: 11.26.0 -> 11.27.0`                        |
| [`9f7b4618`](https://github.com/NixOS/nixpkgs/commit/9f7b46184462c86cc4c8a7c5001554db9c1cc496) | `python310Packages.googlemaps: 4.5.3 -> 4.6.0`                         |
| [`750f6312`](https://github.com/NixOS/nixpkgs/commit/750f63123a89145a93f09d82a2b07d1d7ef57338) | `python310Packages.types-urllib3: 1.26.8 -> 1.26.9`                    |
| [`f52a615a`](https://github.com/NixOS/nixpkgs/commit/f52a615afbc381cd06f7702b166727ab21a55ddc) | `python310Packages.snowflake-connector-python: 2.7.3 -> 2.7.4`         |
| [`e5213f40`](https://github.com/NixOS/nixpkgs/commit/e5213f40dbd5a5ce22a13b5a0e130310e43ece76) | `cups: Add passthru printing test`                                     |
| [`0ccdb13c`](https://github.com/NixOS/nixpkgs/commit/0ccdb13c05e26b5e1bbaefea285b9500c8505284) | `numberstation: 1.0.1 -> 1.1.0`                                        |
| [`a751e798`](https://github.com/NixOS/nixpkgs/commit/a751e798041053c226c734c707c2e6dc0fc76c66) | `openai: 0.13.0 -> 0.14.0`                                             |
| [`e796d111`](https://github.com/NixOS/nixpkgs/commit/e796d111569b76db93c4632bdc156a8f3a3c0797) | `python310Packages.pyface: 7.3.0 -> 7.4.0`                             |
| [`2d011298`](https://github.com/NixOS/nixpkgs/commit/2d011298dc4cfbb03279d80db33ea44a568325c0) | `python310Packages.python-telegram-bot: 13.10 -> 13.11`                |
| [`743d0116`](https://github.com/NixOS/nixpkgs/commit/743d01161616720fb668eae2ea7199edb37af9e3) | `hivemind: 1.0.6 -> 1.1.0 (#157994)`                                   |
| [`829196bf`](https://github.com/NixOS/nixpkgs/commit/829196bfbe0d41f636d80ee87a85bfa384dec1f3) | `ruffle: 2021-09-17 -> 2022-02-02 (#157974)`                           |
| [`b8f6ce15`](https://github.com/NixOS/nixpkgs/commit/b8f6ce151a2882309a11b48f29158fea12e44da5) | `gocyclo: 2015-02-08 -> 0.4.0 (#157227)`                               |
| [`3504c23b`](https://github.com/NixOS/nixpkgs/commit/3504c23b789d898b647cfea964179febed81b1b7) | `rpm: fix build for darwin aarch64`                                    |
| [`af577101`](https://github.com/NixOS/nixpkgs/commit/af57710166671dbde702114ca6cbe9f72e438219) | `libxc: 5.2.0 -> 5.2.2`                                                |
| [`db6600c3`](https://github.com/NixOS/nixpkgs/commit/db6600c30147ad6bde737e645db4219d4ee80c0c) | `mastodon: 3.4.5 -> 3.4.6`                                             |
| [`0ebdfab8`](https://github.com/NixOS/nixpkgs/commit/0ebdfab88bb1d794d854e2e2ec0ed45ec1c252f3) | `lean: 3.38.0 -> 3.39.0`                                               |
| [`f53b32b0`](https://github.com/NixOS/nixpkgs/commit/f53b32b059dd42ca873a72b9d1dd87dc7b28e140) | `python3Packages.geometric: init at 0.9.7.2`                           |
| [`778b1f8b`](https://github.com/NixOS/nixpkgs/commit/778b1f8b4f7ac8011e15a1dafb6d90c753ef4750) | `sage: no longer assume fonttools emits deprecation warnings`          |
| [`b8305074`](https://github.com/NixOS/nixpkgs/commit/b8305074253b16fe0d98778491ee08f81f100281) | `nixos/self-deploy: consume self-deploy's startAt attribute`           |
| [`06d0bc55`](https://github.com/NixOS/nixpkgs/commit/06d0bc55bf1f210499326babc6ce33d1548fb6e0) | `gmid: 1.7.5 → 1.8`                                                    |
| [`6daff249`](https://github.com/NixOS/nixpkgs/commit/6daff24989d8142c4dd1e54d7e365d915d8203c3) | `out_of_date_package_report.md: fix typo`                              |
| [`c559795c`](https://github.com/NixOS/nixpkgs/commit/c559795c0fd8c784f890520f1a4949b85bcbcf69) | `duckstation: 0.pre+date=2021-12-16 -> 0.pre+date=2022-01-18`          |
| [`e0a91196`](https://github.com/NixOS/nixpkgs/commit/e0a91196b5a9279ecd924d77287ade72aba536d3) | `trezor-suite: 21.12.2 -> 22.1.1`                                      |
| [`5320a03f`](https://github.com/NixOS/nixpkgs/commit/5320a03fdc39753784de42b8b4af9ef4110f9f4f) | `crystal: remove broken crystal2nix attribute`                         |
| [`37e39b38`](https://github.com/NixOS/nixpkgs/commit/37e39b389795ea9456ff60f6934f14bb61ff754d) | `crystal_1_2: add support for aarch64-darwin`                          |
| [`7acca657`](https://github.com/NixOS/nixpkgs/commit/7acca6575875b60e7bd0ab4a1fd6bbc099522f56) | `chatty: 0.4.0 -> 0.6.0`                                               |
| [`2292af28`](https://github.com/NixOS/nixpkgs/commit/2292af28f1ce1e27c433c59b77153628587141a3) | `python310Packages.google-cloud-logging: 2.7.0 -> 3.0.0`               |
| [`7fbf10b5`](https://github.com/NixOS/nixpkgs/commit/7fbf10b51942ff6e01225849726b4c59efa391e5) | `buf: 1.0.0-rc11 -> 1.0.0-rc12`                                        |
| [`dc5859ef`](https://github.com/NixOS/nixpkgs/commit/dc5859ef7a75e79cfb3cc0084ed59738a018bb17) | `nixos/tests/k3s: remove stale test reference`                         |
| [`5453d969`](https://github.com/NixOS/nixpkgs/commit/5453d9693bf1067d441370b1d12f0c474936b982) | `python310Packages.repoze_who: 2.4 -> 2.4.1`                           |
| [`f3e4bb24`](https://github.com/NixOS/nixpkgs/commit/f3e4bb247f036b00df63364e9adb26743b85399a) | `timetagger: 22.1.4 -> 22.2.1`                                         |
| [`4f393135`](https://github.com/NixOS/nixpkgs/commit/4f39313552307af3130a3cabee8d8967004a7a5f) | `vscode-extensions.alygin.vscode-tlaplus: 1.5.3 -> 1.5.4`              |
| [`9a81c40c`](https://github.com/NixOS/nixpkgs/commit/9a81c40ce60b92068b7845257696919f09fb149f) | `vscode-extensions.timonwong.shellcheck: 0.14.4 -> 0.18.4`             |
| [`f6d1a3a2`](https://github.com/NixOS/nixpkgs/commit/f6d1a3a25c01f4b3c2e4956ab1d16d5aa6d85630) | `vscode-extensions.zhuangtongfa.material-theme: 3.9.12 -> 3.13.17`     |
| [`09d59243`](https://github.com/NixOS/nixpkgs/commit/09d592432581ba5bd2725b604b5490bea5fa460f) | `vscode-extensions.jnoortheen.nix-ide: 0.1.18 -> 0.1.19`               |
| [`16dba82a`](https://github.com/NixOS/nixpkgs/commit/16dba82a7ae3ea82e4e06c1f9e2319f7ee99c1c0) | `vscode-extensions.graphql.vscode-graphql: 0.3.13 -> 0.3.50`           |
| [`c45cab55`](https://github.com/NixOS/nixpkgs/commit/c45cab552ac5695a3ac682e4d12c52f47ba76880) | `vscode-extensions.mishkinf.goto-next-previous-member: 0.0.5 -> 0.0.6` |
| [`bd528715`](https://github.com/NixOS/nixpkgs/commit/bd528715d8f004940ded9351e32c24698bde79f5) | `vscode-extensions.codezombiech.gitignore: 0.6.0 -> 0.7.0`             |
| [`c23128e6`](https://github.com/NixOS/nixpkgs/commit/c23128e6aece4f914e520ea8d76311def648fe57) | `vscode-extensions.github.copilot: 1.7.4421 -> 1.7.4812`               |
| [`7a72dafb`](https://github.com/NixOS/nixpkgs/commit/7a72dafbc10fa421fc07cbaa2af076ba12b3ed78) | `vscode-extensions.edonet.vscode-command-runner: 0.0.116 -> 0.0.122`   |
| [`0272dc8a`](https://github.com/NixOS/nixpkgs/commit/0272dc8a6bcfc3989b740de0465ae3521d0e5b07) | `vscode-extensions.disneystreaming.smithy: init at 0.0.2`              |
| [`ed89d9af`](https://github.com/NixOS/nixpkgs/commit/ed89d9af8c30ab1255371e344b1c8d684dc76617) | `vscode-extensions.Arjun.swagger-viewer: init at 3.1.2`                |
| [`e1808192`](https://github.com/NixOS/nixpkgs/commit/e18081929d8e1767bab8849136102c1b60b367b2) | `vscode-extensions.humao.rest-client: init at 0.24.6`                  |
| [`6ff4ad16`](https://github.com/NixOS/nixpkgs/commit/6ff4ad160f2b58506a76c6ca86fd4ca1825461cc) | `vscode-extensions.benfradet.vscode-unison: init at 0.3.0`             |
| [`08c04a59`](https://github.com/NixOS/nixpkgs/commit/08c04a59a9fb380d2f57debec74fca735a929283) | `vscode-extensions.silvenon.mdx: init at 0.1.0`                        |
| [`65256eda`](https://github.com/NixOS/nixpkgs/commit/65256edaa8c552018276c90e35434f9cab526d2a) | `vscode-extensions.baccata.scaladex-search: 0.0.1 -> 0.2.0`            |
| [`ee99db6c`](https://github.com/NixOS/nixpkgs/commit/ee99db6c3fc1f5d84d32e54be380865a01ff0962) | `vscode-extensions.scalameta.metals: 1.12.0 -> 1.12.18`                |
| [`702a93b1`](https://github.com/NixOS/nixpkgs/commit/702a93b15ebcdb592b7110bbb20aad3f6592997c) | `vscode-extensions.kubukoz.nickel-syntax: init at 0.0.1`               |
| [`df8f06c8`](https://github.com/NixOS/nixpkgs/commit/df8f06c8e58dc0f643c3238ab3ecee223afec4ea) | `release-small.nix: cleanup`                                           |
| [`2571561c`](https://github.com/NixOS/nixpkgs/commit/2571561c50fa86155fb153da0c52005c1a4d5dfe) | `element-desktop: update electron_13 -> electron_15`                   |
| [`cd17b35b`](https://github.com/NixOS/nixpkgs/commit/cd17b35b1c77e4d5102d09895f975778cad3c10a) | `electron_13: 13.6.8 -> 13.6.9`                                        |
| [`c52e8567`](https://github.com/NixOS/nixpkgs/commit/c52e85672b425130b1d76ba8f08abeac02458408) | `qemu: remove broker wrapper script`                                   |
| [`8ab663aa`](https://github.com/NixOS/nixpkgs/commit/8ab663aaa5fbe8ae90931cb64d2dbd64dfac5c0c) | `brave: 1.34.81 -> 1.35.100`                                           |
| [`7b5b5adf`](https://github.com/NixOS/nixpkgs/commit/7b5b5adfcc80164e27031646c99ce87d0fd024aa) | `sentry-native: 0.4.13 -> 0.4.14`                                      |
| [`6d957f73`](https://github.com/NixOS/nixpkgs/commit/6d957f73abd92d193a55b09660c2d2b39bc87e33) | `vowpal-wabbit: 8.11.0 -> 9.0.1`                                       |
| [`ebd52e49`](https://github.com/NixOS/nixpkgs/commit/ebd52e4984e44283adbc2746274b3936983cb5d7) | `python310Packages.vowpalwabbit: 9.0.0 -> 9.0.1`                       |
| [`6536222c`](https://github.com/NixOS/nixpkgs/commit/6536222c0051bcfe9660f83af74d187dcd33a41a) | `python3Packages.pywlroots: 0.15.4 -> 0.15.6`                          |
| [`5d6e9b3d`](https://github.com/NixOS/nixpkgs/commit/5d6e9b3d53734b1956ea35f4b8280e95a064bb09) | `python3Packages.pubnub: 6.0.0 -> 6.0.1`                               |
| [`a63b5c9e`](https://github.com/NixOS/nixpkgs/commit/a63b5c9e5cbc8bbee514eff72acffacde530942d) | `clickhouse-cli: 0.3.7 -> 0.3.8`                                       |
| [`6267a995`](https://github.com/NixOS/nixpkgs/commit/6267a995ec2abd5c4a9f977851e54ffaa7080977) | `nixos/home-assistant: drop --runner flag`                             |
| [`5b8e263c`](https://github.com/NixOS/nixpkgs/commit/5b8e263c9034522effe49a0eb4efbedd96e8815d) | `python3Packages.eebrightbox: drop`                                    |
| [`225fd5c8`](https://github.com/NixOS/nixpkgs/commit/225fd5c892a21ef1d75979aee4c41cd10abb3c8b) | `python3Packages.glean-sdk: 42.2.0 -> 43.0.2`                          |
| [`93a6cd0f`](https://github.com/NixOS/nixpkgs/commit/93a6cd0fd6e5540bfbc40e38502425078d91d137) | `home-assistant: 2021.12.10 -> 2022.2.0`                               |
| [`cb9bb772`](https://github.com/NixOS/nixpkgs/commit/cb9bb7723736fc84c2ad7e9671538dd5c4b2c7ba) | `python3Packages.glances-api: 0.3.3 -> 0.3.4`                          |
| [`bbeaa3c7`](https://github.com/NixOS/nixpkgs/commit/bbeaa3c743b2fa2946e16a807fbefb52785405ee) | `python3Packages.zwave-js-server-python: 0.33.0 -> 0.34.0`             |
| [`82157ea5`](https://github.com/NixOS/nixpkgs/commit/82157ea5048f1fe16398d2cce4cfbfc87f6009b6) | `python3Packages.zeroconf: 0.38.1 -> 0.38.3`                           |
| [`09972dd2`](https://github.com/NixOS/nixpkgs/commit/09972dd20f76b596efd4b3c3488d6067e1e482eb) | `python3Packages.yalexs: 1.1.19 -> 1.1.20`                             |
| [`04fe5e98`](https://github.com/NixOS/nixpkgs/commit/04fe5e989440a477b54a08fe850be1b8a8f353cc) | `python3Packages.yalesmartalarmclient: 0.3.5 -> 0.3.7`                 |
| [`163b78f1`](https://github.com/NixOS/nixpkgs/commit/163b78f1a291b52436f649773d8d7ec2d171e060) | `python3Packages.xknx: 0.18.15 -> 0.19.1`                              |
| [`fd574e3c`](https://github.com/NixOS/nixpkgs/commit/fd574e3c6d1e82075ce971a42ab1791e7143bad8) | `python3Packages.wled: 0.11.0 -> 0.13.0`                               |
| [`cb3fad91`](https://github.com/NixOS/nixpkgs/commit/cb3fad914c0d4016e162e712c6b018b714d2445a) | `python3Packages.awesomeversion: 21.11.0 -> 22.1.0`                    |
| [`2bf4803b`](https://github.com/NixOS/nixpkgs/commit/2bf4803be8b050c74a865e19af2b85837a0fb176) | `python3Packages.soco: 0.25.3 -> 0.26.0`                               |
| [`90a1dc06`](https://github.com/NixOS/nixpkgs/commit/90a1dc061fb6170d0667162e045d99802fb7905d) | `python3Packages.sentry-sdk: 1.5.2 -> 1.5.4`                           |
| [`8e02e37b`](https://github.com/NixOS/nixpkgs/commit/8e02e37bb25c007874fba4cd5578722a119e4535) | `python3Packages.rflink: 0.0.58 -> 0.0.62`                             |
| [`734bdf9a`](https://github.com/NixOS/nixpkgs/commit/734bdf9aa16b6fe2ab8babdee7cb912b22688b6f) | `python3Packages.renault-api: 0.1.6 -> 0.1.7`                          |
| [`db4a4d52`](https://github.com/NixOS/nixpkgs/commit/db4a4d52a86d7d63963d8c6d7680cb4bcdc9a088) | `python3Packages.pysml: 0.0.5 -> 0.0.7`                                |
| [`7154c489`](https://github.com/NixOS/nixpkgs/commit/7154c489566decb6cbee3964a0024ab952425e89) | `python3Packages.pypck: 0.7.11 -> 0.7.13`                              |
| [`f4f6718a`](https://github.com/NixOS/nixpkgs/commit/f4f6718a58cf40719e1fea0628c5e37a24b91966) | `python3Packages.pynuki: 1.4.1 -> 1.5.2`                               |
| [`4e26847e`](https://github.com/NixOS/nixpkgs/commit/4e26847ee5b88df7667f10560cfc9752d542cb37) | `python3Packages.pynina: 2021-11-11 -> 0.1.4`                          |
| [`5aebf78f`](https://github.com/NixOS/nixpkgs/commit/5aebf78fbf703fa827574d52a7937a9bc08278be) | `python3Packages.pylitterbot: 2021.11.0 -> 2021.12.0`                  |
| [`1dbf51c3`](https://github.com/NixOS/nixpkgs/commit/1dbf51c3bef48aa53c1d87554ab2d3166770db7f) | `python3Packages.pyinsteon: 1.0.13 -> 1.0.14`                          |
| [`f239aa2e`](https://github.com/NixOS/nixpkgs/commit/f239aa2e297e57e98ce3119b20e7b02948e1dca7) | `python3Packages.pyezviz: 0.2.0.5 -> 0.2.0.6`                          |
| [`f6ae0ef0`](https://github.com/NixOS/nixpkgs/commit/f6ae0ef02e036bc18a56b2b9cca149eb90d6607b) | `python3Packages.pydaikin: 2.6.0 -> 2.7.0`                             |
| [`b940be13`](https://github.com/NixOS/nixpkgs/commit/b940be13b179f2c124a6d41cb1c6230b79b3fc51) | `python3Packages.pyatv: 0.9.8 -> 0.10.0`                               |
| [`d4767e42`](https://github.com/NixOS/nixpkgs/commit/d4767e4220cf2f423b38bb0c1e2aa1402bad1d42) | `python3Packages.mill-local: 0.1.0 -> 0.1.1`                           |
| [`b2a60329`](https://github.com/NixOS/nixpkgs/commit/b2a603297b75ac13a43e82e30c8b89e50dbb6285) | `python3Packages.influxdb: 5.3.0 -> 5.3.1`                             |
| [`6930626b`](https://github.com/NixOS/nixpkgs/commit/6930626b426db8a30da7f3ec328875abe1adce68) | `python3Packages.hass-nabucasa: 0.51.0 -> 0.52.0`                      |
| [`f84098a5`](https://github.com/NixOS/nixpkgs/commit/f84098a596e5cd904dfa75e880990c670868cadf) | `python3Packages.google-nest-sdm: 1.5.1 -> 1.6.0`                      |
| [`af86d240`](https://github.com/NixOS/nixpkgs/commit/af86d240e801fd57ad1da102ff034cdb31c09e7f) | `python3Packages.garages-amsterdam: 2.1.1 -> 3.2.1`                    |
| [`bd05c3d0`](https://github.com/NixOS/nixpkgs/commit/bd05c3d04bbeb801f36ed7964156ef19c9338482) | `python3Packages.pyrogram: 1.3.6 -> 1.3.7`                             |
| [`abd256b0`](https://github.com/NixOS/nixpkgs/commit/abd256b0c59cbeb0ebcf67fd81f88549464e2394) | `python3Packages.pyisy: 3.0.1 -> 3.0.2`                                |
| [`ee02c9d1`](https://github.com/NixOS/nixpkgs/commit/ee02c9d15c009672ad43c5e2b250d97cd0e9e581) | `terraform: 1.1.4 -> 1.1.5`                                            |
| [`d48f5e54`](https://github.com/NixOS/nixpkgs/commit/d48f5e54db1c0eccfe6f33c0469dba705a794c62) | `fcitx5-hangul: init at 5.0.7`                                         |
| [`a0b66150`](https://github.com/NixOS/nixpkgs/commit/a0b661508a524548fa3e7cabfff32ed666d10b97) | `bottom: 0.6.6 -> 0.6.8`                                               |
| [`4b259a53`](https://github.com/NixOS/nixpkgs/commit/4b259a5334b4bfe35c87ca86c12edea048da04d0) | `nautilus-open-any-terminal: init at 0.2.15`                           |
| [`99ea3df9`](https://github.com/NixOS/nixpkgs/commit/99ea3df9c47ac8aae1b023ab0a3984ef96012d3c) | `python3Packages.fritzconnection: 1.7.2 -> 1.9.1`                      |
| [`3755785f`](https://github.com/NixOS/nixpkgs/commit/3755785f609b3a2846f83b24f2b87719d356d1d4) | `python3Packages.emoji: 1.6.2 -> 1.6.3`                                |
| [`daa05768`](https://github.com/NixOS/nixpkgs/commit/daa057683bdd132e95f066312a97333ad578ee06) | `python3Packages.async-upnp-client: 0.23.1 -> 0.23.4`                  |
| [`eda1a6c1`](https://github.com/NixOS/nixpkgs/commit/eda1a6c1b90145ede964c18d312eda9c11b7cb10) | `python3Packages.aiolookin: 0.0.4 -> 0.1.0`                            |
| [`6c9dbe9a`](https://github.com/NixOS/nixpkgs/commit/6c9dbe9a8979da6ce99a697268606f63d7c220a1) | `python3Packages.aiohwenergy: 0.7.0 -> 0.8.0`                          |
| [`7ce412eb`](https://github.com/NixOS/nixpkgs/commit/7ce412eba26413953a4cf16c2ba554cab08b816b) | `python3Packages.aiohue: 3.0.11 -> 4.0.1`                              |
| [`f3654fb0`](https://github.com/NixOS/nixpkgs/commit/f3654fb0bb87f292a7cc6d59bc1c0bf5a6d3de8e) | `python3Packages.aiodiscover: 1.4.5 -> 1.4.7`                          |
| [`c9b3d27b`](https://github.com/NixOS/nixpkgs/commit/c9b3d27be060e6ae86aab03a6ac0c390a1676e13) | `stdenv.md: Call out that genericBuild has correct order`              |
| [`b8453874`](https://github.com/NixOS/nixpkgs/commit/b8453874f0c00db2141e4bf8dd25650c54288e4a) | `skopeo: 1.5.2 -> 1.6.0`                                               |
| [`8f6cdee2`](https://github.com/NixOS/nixpkgs/commit/8f6cdee25ab8c415f0175b243d2b8dc17e9729d5) | `clusterctl: 1.0.3 -> 1.1.0`                                           |
| [`6e831803`](https://github.com/NixOS/nixpkgs/commit/6e831803c13fc0d6311377fedc2cf3a335565ad7) | `radicale: 3.1.3 -> 3.1.4`                                             |
| [`9c087317`](https://github.com/NixOS/nixpkgs/commit/9c087317e1b70142113912d989ce878c9b5abb40) | `esphome: 2022.1.2 -> 2022.1.3`                                        |
| [`e9ac83eb`](https://github.com/NixOS/nixpkgs/commit/e9ac83ebb5fd3d8a8497a2015c5fb5278c506627) | `connman: 1.40 -> 1.41`                                                |
| [`a3dc9a11`](https://github.com/NixOS/nixpkgs/commit/a3dc9a1123fa7d7fc94489beffde4fdea28065c8) | `neon_0_29: drop`                                                      |
| [`3e77ca67`](https://github.com/NixOS/nixpkgs/commit/3e77ca677f6d7e8168cdddd6207a9264cae86fe6) | `ghidra: 10.1.1 -> 10.1.2`                                             |
| [`dc40d812`](https://github.com/NixOS/nixpkgs/commit/dc40d812828a6bc85d468b2141624ec1ac225305) | `fcitx5-chewing: init at 5.0.9`                                        |
| [`30c8f7c4`](https://github.com/NixOS/nixpkgs/commit/30c8f7c42d12cab1d3d71f668ad238b09a1ab506) | `nixos/kvmgt: add myself to maintainers`                               |
| [`e1f67e1b`](https://github.com/NixOS/nixpkgs/commit/e1f67e1bcc831a50a3474bdf8469873d296db6ae) | `lima: 0.8.1 -> 0.8.2`                                                 |
| [`62ce6f2c`](https://github.com/NixOS/nixpkgs/commit/62ce6f2c9d791fff7714e48b26089d01f3964a5f) | `unifi7: add package`                                                  |
| [`e21174bc`](https://github.com/NixOS/nixpkgs/commit/e21174bcf5db2ad7d17a4ad89564b36978e9f1ca) | `yabridge: Add upstream fix for recent wine 7.1 update`                |
| [`47f0427d`](https://github.com/NixOS/nixpkgs/commit/47f0427d1523f7fe2ebb7430fe5809451e59d1b3) | `chromiumDev: 99.0.4844.11 -> 99.0.4844.16`                            |
| [`b904f580`](https://github.com/NixOS/nixpkgs/commit/b904f5803176261e8873fbcfd4622b125a363cc6) | `chromium: 97.0.4692.99 -> 98.0.4758.80`                               |
| [`e6e371ea`](https://github.com/NixOS/nixpkgs/commit/e6e371ea723163c3aaabf240005b41d1fd76b688) | `marlin-calc: mark as broken on darwin`                                |
| [`ee4d3df0`](https://github.com/NixOS/nixpkgs/commit/ee4d3df08b1c79e7608064741a6e07ebc1b6f197) | `python3Packages.jax: 0.2.27 -> 0.2.28`                                |
| [`46481f30`](https://github.com/NixOS/nixpkgs/commit/46481f3081d37b66f04891b0e06abbe340da33c0) | `spidermonkey_68: drop`                                                |
| [`c9815cd3`](https://github.com/NixOS/nixpkgs/commit/c9815cd3039fc4bae56b6729800634b3eb722bec) | `libproxy: upgrade spidermonkey`                                       |
| [`b41beef8`](https://github.com/NixOS/nixpkgs/commit/b41beef827945f530111320b2fbc515871933c67) | `mediatomb: remove package`                                            |
| [`d3637a6e`](https://github.com/NixOS/nixpkgs/commit/d3637a6e7b5379d935104d379c761b870690823b) | `python3Packages.patrowl4py: 1.1.7 -> 1.1.9`                           |
| [`88326c18`](https://github.com/NixOS/nixpkgs/commit/88326c18bcb4aefa2b7c85637bb841da389641ed) | `python3Packages.grapheme: disable tests`                              |
| [`b816dc20`](https://github.com/NixOS/nixpkgs/commit/b816dc201472f4c3ae6d508213ca56ea5d8d251b) | `python310Packages.chiapos: 1.0.8 -> 1.0.9`                            |
| [`ffa7a2f8`](https://github.com/NixOS/nixpkgs/commit/ffa7a2f804d9d20c3a326f848e5010128abd954a) | `python3Packages.angrop: 9.1.11611 -> 9.1.11752`                       |
| [`0771848d`](https://github.com/NixOS/nixpkgs/commit/0771848d665a59c200df55c832fb84cd60188ace) | `python3Packages.angr: 9.1.11611 -> 9.1.11752`                         |
| [`176c869b`](https://github.com/NixOS/nixpkgs/commit/176c869b180fb9f6722a9002e5b4bbb11b33d2fc) | `python3Packages.cle: 9.1.11611 -> 9.1.11752`                          |
| [`a4bc3811`](https://github.com/NixOS/nixpkgs/commit/a4bc381140d79f7dd38be5511dce0bbff0e7070d) | `python3Packages.claripy: 9.1.11611 -> 9.1.11752`                      |
| [`72f2339e`](https://github.com/NixOS/nixpkgs/commit/72f2339e9421155e311be078750c44f80aa50738) | `python3Packages.pyvex: 9.1.11611 -> 9.1.11752`                        |
| [`d58678bf`](https://github.com/NixOS/nixpkgs/commit/d58678bf328aec8f2fa753fc652eb1d538cf0e01) | `python3Packages.ailment: 9.1.11611 -> 9.1.11752`                      |
| [`68b9d769`](https://github.com/NixOS/nixpkgs/commit/68b9d769ffddbd5b2543fb542fb351001210eb78) | `python3Packages.archinfo: 9.1.11611 -> 9.1.11752`                     |
| [`5c4a13c5`](https://github.com/NixOS/nixpkgs/commit/5c4a13c59053a5e4770fb68ce04bce4a2b6238c4) | `python310Packages.weasyprint: 54.0 -> 54.1`                           |
| [`0aece336`](https://github.com/NixOS/nixpkgs/commit/0aece3361a83b1e92c76398706283f95e9cfa045) | `python3Packages.velbus-aio: 2021.11.7 -> 2022.02.1`                   |
| [`dd70bd48`](https://github.com/NixOS/nixpkgs/commit/dd70bd4814693692729b6f8f586a1da1dfdf852a) | `python310Packages.google-re2: 0.2.20211101 -> 0.2.20220201`           |
| [`7f7db2f6`](https://github.com/NixOS/nixpkgs/commit/7f7db2f6ddfd0b8a6a36aeb880ab52c95e0fc9ba) | `linux_xanmod: 5.15.12 -> 5.15.19`                                     |
| [`ca40ef94`](https://github.com/NixOS/nixpkgs/commit/ca40ef94f63ca94953f024c29f87be77169ad350) | `python3Packages.pontos: 22.1.3 -> 22.2.0`                             |
| [`a57500c7`](https://github.com/NixOS/nixpkgs/commit/a57500c708a3b274c71d0d04c3647d215f9221bd) | `python3Packages.pylutron-caseta: 0.13.0 -> 0.13.1`                    |
| [`5ebb7c05`](https://github.com/NixOS/nixpkgs/commit/5ebb7c05709b57fec4c19161f91268c630b8df18) | `python3Packages.aladdin-connect: 0.3 -> 0.4`                          |
| [`0afbe746`](https://github.com/NixOS/nixpkgs/commit/0afbe74634e292bf053ab747b2c46aa9f0e347fd) | `python3Packages.mailchecker: 4.1.10 -> 4.1.11`                        |
| [`ad624c65`](https://github.com/NixOS/nixpkgs/commit/ad624c655efa87260cafb46095b966a865eeff59) | `python3Packages.identify: 2.4.6 -> 2.4.7`                             |