### PR TITLE
chore(flake/home-manager): `95d39e13` -> `a52aed72`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1643567433,
-        "narHash": "sha256-tyFgodcZRlt0ZshbgyLf4m/Sd/ys9p0AHfeVZQ50WKU=",
+        "lastModified": 1643579427,
+        "narHash": "sha256-tV4M4+Aqd/3ZjEz1Q07j89KIlkt1oFH34RzpBkUeO/0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "95d39e13a4a7a818c87f2701b59820d3ac0e674c",
+        "rev": "a52aed72c84a2a10102a92397339fa01fc0fe9cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                           |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`a52aed72`](https://github.com/nix-community/home-manager/commit/a52aed72c84a2a10102a92397339fa01fc0fe9cf) | `Translate using Weblate (Korean)`       |
| [`d30f4693`](https://github.com/nix-community/home-manager/commit/d30f46934d0253dcaf72a095cb82f9a3aa1a830a) | `Add translation using Weblate (Korean)` |
| [`774d6e35`](https://github.com/nix-community/home-manager/commit/774d6e35a56b158447a20c15d16b17d2736b43fd) | `Translate using Weblate (Korean)`       |