### PR TITLE
chore(flake/deploy-rs): `3180b55a` -> `4154ba1a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1643452512,
-        "narHash": "sha256-X+ZZhxzSSI0UyNVbVn3YH53Iiai0cUPZLq2ls751z4I=",
+        "lastModified": 1643787431,
+        "narHash": "sha256-8IwuVgXulRE3ZWq6z8mytarawC32pKPKR20EyDtSH+w=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "3180b55ad44777edd90c08f9f9d4df74ec1549b9",
+        "rev": "4154ba1aaaf7333a916384c348d867d03b6f1409",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                          |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`441dd052`](https://github.com/serokell/deploy-rs/commit/441dd052e8e233fdf38582f1e439eda4812b77cd) | `Automatically update flake.lock to the latest version` |