### PR TITLE
chore(flake/home-manager): `a52aed72` -> `184b0154`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1643579427,
-        "narHash": "sha256-tV4M4+Aqd/3ZjEz1Q07j89KIlkt1oFH34RzpBkUeO/0=",
+        "lastModified": 1643835431,
+        "narHash": "sha256-oi5avP0pp02+gKiN9sdW5p9IyR5gEEskXkwsQVnnvhY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a52aed72c84a2a10102a92397339fa01fc0fe9cf",
+        "rev": "184b0154f274f61070a0cc096b84244c0fc54c17",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`184b0154`](https://github.com/nix-community/home-manager/commit/184b0154f274f61070a0cc096b84244c0fc54c17) | `vscode: Add immutable extensions dir option (#2613)` |