### PR TITLE
chore(flake/home-manager): `11c0e5d1` -> `63dccc4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1643926450,
-        "narHash": "sha256-8rjKGATv1UEgwzdTrQ1WHWaL4d50UbAN+TnlWDZZXmo=",
+        "lastModified": 1643933104,
+        "narHash": "sha256-NZPuFxRsZKN8pjRuHPpzlMyt6JQhcjiduBG8bMghSjE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "11c0e5d188ab9db2204f25201483d51ad5131e1d",
+        "rev": "63dccc4e60422c1db2c3929b2fd1541f36b7e664",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message     |
| ----------------------------------------------------------------------------------------------------------- | ------------------ |
| [`63dccc4e`](https://github.com/nix-community/home-manager/commit/63dccc4e60422c1db2c3929b2fd1541f36b7e664) | `twmn: add module` |