### PR TITLE
chore(flake/impermanence): `42394012` -> `ff540dbe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -105,11 +105,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1643832921,
-        "narHash": "sha256-OfdIPxRR5cHp5zpNxfNlPXJSt01Pp/jnbkIcpk90R3Q=",
+        "lastModified": 1644014516,
+        "narHash": "sha256-PkD35S6lduaU6mLcraFY0vj608RPv1kQp5uaFd/s26o=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "423940122a8c4d32724d72fe010076f292c7aaea",
+        "rev": "ff540dbe20556f6119d80f5c79796a0698a4ee38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                         |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`ff540dbe`](https://github.com/nix-community/impermanence/commit/ff540dbe20556f6119d80f5c79796a0698a4ee38) | ``docs: Document `hideMounts` Option`` |
| [`5f5bafee`](https://github.com/nix-community/impermanence/commit/5f5bafee3a82f597ee48117ba126546f1f4320a8) | `feat: Support Hiding of Bind Mounts`  |