### PR TITLE
chore(flake/nixpkgs): `64cb9c78` -> `8cec3cc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1644225686,
-        "narHash": "sha256-XDslFfn44H93WjGytIhrPSduGIug1p4cPN/cEuHdIBI=",
+        "lastModified": 1644269936,
+        "narHash": "sha256-Pxn2au1JChCuxiKtmF8hpV7DyvKrCYd0vLzZGjGV0VE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64cb9c78e14d0ffc9ee627772a972aa4b59bbfd8",
+        "rev": "8cec3cc29e2bc2a7dea71de46d3fd4441700de2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`8cec3cc2`](https://github.com/NixOS/nixpkgs/commit/8cec3cc29e2bc2a7dea71de46d3fd4441700de2e) | `vimPlugins.vim-nixhash: init at 2022-02-06`                              |
| [`32d2af12`](https://github.com/NixOS/nixpkgs/commit/32d2af12f242bfc87cb67fc4337afd9d15b3f809) | `vimPlugins: update`                                                      |
| [`4422196e`](https://github.com/NixOS/nixpkgs/commit/4422196ea9cac74f595ecd6f63028af96d75c8ee) | `python310Packages.jq: 1.2.1 -> 1.2.2`                                    |
| [`5749c2be`](https://github.com/NixOS/nixpkgs/commit/5749c2be28241c7abd1632bea061802dad2ff44f) | `python3Packages.pytibber: 0.22.0 -> 0.22.1`                              |
| [`3724b8cf`](https://github.com/NixOS/nixpkgs/commit/3724b8cfa8436b9ced841078a8934584b692fc79) | `idrisPackages.protobuf: move to alias set`                               |
| [`21e7625d`](https://github.com/NixOS/nixpkgs/commit/21e7625d6854a95d1ecb4e463a7f1e52513ad7b4) | `bloomrpc: init at 1.5.3 (#120292)`                                       |
| [`cb648f08`](https://github.com/NixOS/nixpkgs/commit/cb648f080dba0fd0b953686c43b0ce05d0ed9ef2) | `wg-netmanager: init at 0.3.6 (#155149)`                                  |
| [`87ef1e84`](https://github.com/NixOS/nixpkgs/commit/87ef1e84fd0b75a6e1c7dcab0fed06cb08d6f34c) | `slack: fix linux url and updater`                                        |
| [`e4ac3450`](https://github.com/NixOS/nixpkgs/commit/e4ac34506a0e06ce77368c569bb2fb294a72f0f2) | `tdesktop: Remove myself as maintainer`                                   |
| [`faa11fc7`](https://github.com/NixOS/nixpkgs/commit/faa11fc73b4ef2438235e1a0b1004f0841854a98) | `freedv: 1.6.1 -> 1.7.0`                                                  |
| [`bbace3e7`](https://github.com/NixOS/nixpkgs/commit/bbace3e730ababc8fadd57f7b03fd18db010725e) | `node-packages.nix: generate`                                             |
| [`3e2a8d53`](https://github.com/NixOS/nixpkgs/commit/3e2a8d53f56b9757c86f7aa9f1b987407fee6ca8) | `python39Packages.spectral-cube: fix version number (#158434)`            |
| [`1c239a1c`](https://github.com/NixOS/nixpkgs/commit/1c239a1c4f4ed444444576827e857b0582cb970d) | `python39Packages.titlecase: fix version number (#158433)`                |
| [`ff85de6c`](https://github.com/NixOS/nixpkgs/commit/ff85de6ce806a4ef6cb163d7944b51ca84ad434b) | ``plex: remove unused option `managePlugins```                            |
| [`a1f1e85d`](https://github.com/NixOS/nixpkgs/commit/a1f1e85d30180f23cb77697b9c459785d2fd5fa2) | `top-level/all-packages: remove trailing whitespace`                      |
| [`0ad434aa`](https://github.com/NixOS/nixpkgs/commit/0ad434aa2c4b81001b1554fa78c64b1c48458e21) | `nodePackages.@uppy/companion: init at 3.1.1`                             |
| [`a0e52205`](https://github.com/NixOS/nixpkgs/commit/a0e52205352eae381daaae4b1d38f9c64d20899a) | `mediaelch: 2.8.12 -> 2.8.14`                                             |
| [`de4b6944`](https://github.com/NixOS/nixpkgs/commit/de4b6944e02c93cae19635fa0c64f7b3aeaba28c) | `gping: add test`                                                         |
| [`c40dadac`](https://github.com/NixOS/nixpkgs/commit/c40dadac171a05b37a067ee5393b764860d8e76f) | `gping: 1.2.6 -> 1.2.7`                                                   |
| [`fc4a8a2c`](https://github.com/NixOS/nixpkgs/commit/fc4a8a2c35d0cf19426cdd44a0bd1ba7a23f5fd3) | `gitea: 1.16.0 -> 1.16.1`                                                 |
| [`d9b2a0cf`](https://github.com/NixOS/nixpkgs/commit/d9b2a0cf0e7ebcb8bdf02e2ced833bf8ea840149) | `dbeaver: 21.3.3 -> 21.3.4`                                               |
| [`97e6067d`](https://github.com/NixOS/nixpkgs/commit/97e6067dd9d2b12ac321663d08ea603de7c345da) | `vscode-extensions.davidanson.vscode-markdownlint: 0.45.0 -> 0.46.0`      |
| [`956f2820`](https://github.com/NixOS/nixpkgs/commit/956f28202fb67c76cba159cdbeddab8401a7148c) | `vscode-extensions.streetsidesoftware.code-spell-checker: 2.1.4 -> 2.1.5` |
| [`c53cdc07`](https://github.com/NixOS/nixpkgs/commit/c53cdc07d07f028bdf0c7e9f74a3aa12c5397665) | `vscode-extensions.stkb.rewrap: 1.16.0 -> 1.16.1`                         |
| [`ca656864`](https://github.com/NixOS/nixpkgs/commit/ca6568648fbcbfd917b3ac11469ce891c6337da6) | `python310Packages.pynetbox: 6.5.0 -> 6.6.0`                              |
| [`2fb3a86e`](https://github.com/NixOS/nixpkgs/commit/2fb3a86e5039dc71f319b0e84a0050645172335f) | `vdr: 2.6.0 -> 2.6.1`                                                     |
| [`9b5b9101`](https://github.com/NixOS/nixpkgs/commit/9b5b9101fabcaa4d7f340d3ad0d9f66d884346e4) | `maintainers: add nelsonjeppesen`                                         |
| [`aae194d8`](https://github.com/NixOS/nixpkgs/commit/aae194d8b236bd41c94cdcc0b85f01a2cc9f783d) | `kitty-themes: init at unstable-2022-02-03`                               |
| [`b8654c7c`](https://github.com/NixOS/nixpkgs/commit/b8654c7cd2afde041d1d84f69e75cc0e7bb61efc) | `wifite: 2.5.7 -> 2.6.0`                                                  |
| [`4c6d4928`](https://github.com/NixOS/nixpkgs/commit/4c6d49282b1d63de6a2977a1d3ed97656cb58963) | `cryptopp: add an option to build with OpenMP`                            |
| [`c87e86df`](https://github.com/NixOS/nixpkgs/commit/c87e86dfeb9d0fa6b7462e02f58f8876b9d8e20c) | `scalapack: allow to build with ILP64 interface`                          |
| [`77a5a7a3`](https://github.com/NixOS/nixpkgs/commit/77a5a7a308cbaa46e1d0abfe43fd488cb665cc10) | `multimc: add link to pr in aliases`                                      |
| [`d5ff49af`](https://github.com/NixOS/nixpkgs/commit/d5ff49afba8fac1a64a7739da24ab13fc9b7a1d6) | `epm: 4.4 -> 5.0.0`                                                       |
| [`2d055bb3`](https://github.com/NixOS/nixpkgs/commit/2d055bb37a6cb7c47af78fd165322477a86c3e9f) | `nixos/cfssl: minor updates/cleanup`                                      |
| [`67abfde6`](https://github.com/NixOS/nixpkgs/commit/67abfde6110bab513bcebccb894b38a0cc920150) | `nixos/cfssl: use systemd StateDirectory to provision the data directory` |
| [`af390da3`](https://github.com/NixOS/nixpkgs/commit/af390da36af7fa8a1f576e9d1550d1c875cee3b1) | `tdlib: 1.8.0 -> 1.8.1`                                                   |
| [`52899ec6`](https://github.com/NixOS/nixpkgs/commit/52899ec696cb78be8d7b49f0f1a6b4708604d687) | `scalapack: 2.1.0 -> 2.2.0`                                               |
| [`0aac2819`](https://github.com/NixOS/nixpkgs/commit/0aac28197e82e67de5199b59f61c1cb59caa04be) | `kde/gear: 21.12.1 -> 21.12.2`                                            |
| [`d86fef1a`](https://github.com/NixOS/nixpkgs/commit/d86fef1a57282cd1891688b540caf5caa1127eb4) | `nixos/doc: add moosefs module to release notes`                          |
| [`b74dc1a2`](https://github.com/NixOS/nixpkgs/commit/b74dc1a2308feeedb93e56c6f33e45d5b9812c69) | `nixos/tests: add moosefs test`                                           |
| [`b302bda0`](https://github.com/NixOS/nixpkgs/commit/b302bda010aada3452e21c6b0ae5284605fa3734) | `nixos: init moosefs module`                                              |
| [`cbb34c53`](https://github.com/NixOS/nixpkgs/commit/cbb34c531c649fad10ef15237281dcad116340fa) | `softether: 4.29 -> 4.38`                                                 |
| [`f13b40ab`](https://github.com/NixOS/nixpkgs/commit/f13b40ab4eecb1136c357396985b7edb3b4ea25b) | `mattermost-desktop: 4.6.2 -> 5.0.3`                                      |
| [`61b935ba`](https://github.com/NixOS/nixpkgs/commit/61b935bad9e97439df53b54818af54dedecbab2e) | `mattermost-desktop: format with nixpkgs-fmt`                             |
| [`381cd253`](https://github.com/NixOS/nixpkgs/commit/381cd2534bd89b4a6ac3bc5f746d83e5190f36cf) | `p2pool: 1.4 -> 1.6`                                                      |
| [`02ad5efe`](https://github.com/NixOS/nixpkgs/commit/02ad5efebf476dbcec9b5e820bb1d6f17068577e) | `p2pool: add update script`                                               |
| [`eedda294`](https://github.com/NixOS/nixpkgs/commit/eedda294251b8600f57b8f4111044b6a8b3c1901) | `swift: 5.4.2 -> 5.5.2`                                                   |
| [`eda51e3e`](https://github.com/NixOS/nixpkgs/commit/eda51e3ea844f7a341b2e198608c38588479ad93) | `bazel_3, bazel_4: Explicitly add a dependency on bazel-rc`               |