### PR TITLE
chore(flake/home-manager): `1ca6293c` -> `e2aa1f59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1644255659,
-        "narHash": "sha256-VuPFOttrBRTOJqPY5yboxVdk1xZjSSlOSDDbBCMKioo=",
+        "lastModified": 1644346464,
+        "narHash": "sha256-hS8hwbr/PflMIfTWTmB7Xo5jIrsWhSAqtz5XXxPa0zQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1ca6293c8fb1dbe13c48fe518440c288256cd562",
+        "rev": "e2aa1f598674aa9c06f28f5db60b89f37f1e961b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`e2aa1f59`](https://github.com/nix-community/home-manager/commit/e2aa1f598674aa9c06f28f5db60b89f37f1e961b) | ``kitty: add option `theme` (#2710)`` |