### PR TITLE
chore(flake/nixpkgs): `8cec3cc2` -> `faad1164`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1644269936,
-        "narHash": "sha256-Pxn2au1JChCuxiKtmF8hpV7DyvKrCYd0vLzZGjGV0VE=",
+        "lastModified": 1644315559,
+        "narHash": "sha256-husNq8H/9DI5Oy1TK/RElNtPfldseMVY/9mSc2GdOQI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8cec3cc29e2bc2a7dea71de46d3fd4441700de2e",
+        "rev": "faad11645619099b11e438c4d89110aafd70261f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                   |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`4ec82ab9`](https://github.com/NixOS/nixpkgs/commit/4ec82ab922bfcd437b4ef6cf620c051de5afd8ff) | `python310Packages.nagiosplugin: 1.3.2 -> 1.3.3`                 |
| [`032d5f18`](https://github.com/NixOS/nixpkgs/commit/032d5f183718fd92366bc4b3b12dfbe62a305e36) | `python310Packages.google-cloud-spanner: 3.12.1 -> 3.13.0`       |
| [`5e89ca2d`](https://github.com/NixOS/nixpkgs/commit/5e89ca2dacd322f56de696c313d9cd1e55b9c154) | `python3Packages.hwi: relax typing-extensions constraint`        |
| [`19485de0`](https://github.com/NixOS/nixpkgs/commit/19485de0a9927f67e881af6a068226c0ee755dc6) | `python310Packages.zigpy-zigate: 0.7.4 -> 0.8.0`                 |
| [`0184f0e0`](https://github.com/NixOS/nixpkgs/commit/0184f0e0a546ca7d78d0d3201b0e53b595f9c12f) | `electron: mark versions <= 13 as EOL`                           |
| [`f3cb640d`](https://github.com/NixOS/nixpkgs/commit/f3cb640d5823ab2b5415241698e395d6a58ae155) | `release.nix: fix packages.json.br for tarball`                  |
| [`88fec5f2`](https://github.com/NixOS/nixpkgs/commit/88fec5f29ec03031ce6b8c0d38ee0d1b6f0ca048) | `electron: depend on libglvnd`                                   |
| [`fbe8be9a`](https://github.com/NixOS/nixpkgs/commit/fbe8be9a8cada3d0608222aa91aa4359ddd6b271) | `electron_17: init at 17.0.0`                                    |
| [`a54eb24c`](https://github.com/NixOS/nixpkgs/commit/a54eb24c7f8779d0208862264c8c2c0995582250) | `python310Packages.google-cloud-bigtable: 2.4.0 -> 2.5.0`        |
| [`8b0b5be1`](https://github.com/NixOS/nixpkgs/commit/8b0b5be13a2415b12b83f9e573565a46a204d06b) | `foundationdb61: pin Boost dep to boost168 (#157967)`            |
| [`582c36f5`](https://github.com/NixOS/nixpkgs/commit/582c36f56384560b3d62dce36d3ead51389072c9) | `cl-wordle: 0.1.2 -> 0.2.0`                                      |
| [`8cc0ddad`](https://github.com/NixOS/nixpkgs/commit/8cc0ddad31b635a1d844571de29be92030befe40) | `python310Packages.cocotb: 1.6.1 -> 1.6.2`                       |
| [`d49eefbe`](https://github.com/NixOS/nixpkgs/commit/d49eefbe6adce501e1831bf628c621df42d8d2cb) | `bats: use resholvePackage`                                      |
| [`3325d1bc`](https://github.com/NixOS/nixpkgs/commit/3325d1bc6298ba50baf82836a9b67773d6d81a2f) | `shunit2: 2019-08-10 (unstable) -> 2.1.8`                        |
| [`14d355b7`](https://github.com/NixOS/nixpkgs/commit/14d355b7c0262cbaddfc3090b9a6ef5eea2ee7c5) | `shunit2: use resholvePackage`                                   |
| [`5469552b`](https://github.com/NixOS/nixpkgs/commit/5469552b2f8eb31eb7cfd5b6db4a0805d3fea293) | `osmium-tool: 1.13.2 → 1.14.0`                                   |
| [`c73ce486`](https://github.com/NixOS/nixpkgs/commit/c73ce48659efd337f23e64bc431ccf98f19ede16) | `libosmium: 2.17.3 → 2.18.0`                                     |
| [`12010061`](https://github.com/NixOS/nixpkgs/commit/1201006163a60312bc0a1d1c803b165adb2bf332) | `apt: 2.3.14 -> 2.3.15`                                          |
| [`8219ba4f`](https://github.com/NixOS/nixpkgs/commit/8219ba4f50badfa7d805581e494b99fc8e74654b) | `schildichat: 1.9.7-sc.1 -> 1.9.8-sc.1`                          |
| [`135a653a`](https://github.com/NixOS/nixpkgs/commit/135a653a1c64976307e8bcc17b7394bdf37443d8) | `cargo-cache: 0.7.0 -> 0.8.1`                                    |
| [`16a5e376`](https://github.com/NixOS/nixpkgs/commit/16a5e376afe71c0962c37cd6f3974cd7fdf6ce91) | `gpxsee: 10.1 → 10.3`                                            |
| [`690c6dd1`](https://github.com/NixOS/nixpkgs/commit/690c6dd1d3425eafe7b7d5d5ec80ba5fe241d33f) | `toppler: 1.1.6 -> 1.3`                                          |
| [`227e220b`](https://github.com/NixOS/nixpkgs/commit/227e220be6dfec38eb733f614095debd95d3bf12) | `pikchr -> unstable-2021-07-22 -> unstable-2022-01-30`           |
| [`fd3be5cd`](https://github.com/NixOS/nixpkgs/commit/fd3be5cd566457847333ff2f8fbfd1b07c8a2541) | `gotests: 1.5.3 -> 1.6.0`                                        |
| [`88a62d1c`](https://github.com/NixOS/nixpkgs/commit/88a62d1cc8d913eba765a7a3e23476c45b58bf47) | `wireplumber: 0.4.7 → 0.4.8`                                     |
| [`c100cfcd`](https://github.com/NixOS/nixpkgs/commit/c100cfcddaa99b3a46dc2fd0b2fe3b0ac53e3394) | `cargo-fuzz: 0.10.2 -> 0.11.0`                                   |
| [`33782d5c`](https://github.com/NixOS/nixpkgs/commit/33782d5c0a20a35413843c2507033b88f3b10e8e) | `ginkgo: 2.1.0 -> 2.1.1`                                         |
| [`b4ba1f9a`](https://github.com/NixOS/nixpkgs/commit/b4ba1f9aa77f8fe58ed909bd5ae75b8b928dfb0b) | `rpm-ostree: 2022.1 -> 2022.2`                                   |
| [`5e7ec2c9`](https://github.com/NixOS/nixpkgs/commit/5e7ec2c9adf6981a47396215b49c4690a043e8b3) | ``nixos/doc/2205: add note for `go_1_17` `vendorSha256```        |
| [`f109a5a0`](https://github.com/NixOS/nixpkgs/commit/f109a5a01f94a8a7f0108c412fcc7086e00e4d90) | `pmbootstrap: 1.40.0 -> 1.41.0`                                  |
| [`9dba1d06`](https://github.com/NixOS/nixpkgs/commit/9dba1d065024ee708de867a8764cb2098198641b) | `python3Packages.aionanoleaf: 0.1.1 -> 0.2.0`                    |
| [`581e8e60`](https://github.com/NixOS/nixpkgs/commit/581e8e6011cbd86c281a5e65850436369d50bca2) | `python3Packages.skodaconnect: 1.1.17 -> 1.1.18`                 |
| [`f3de2598`](https://github.com/NixOS/nixpkgs/commit/f3de2598a91460bae912d99a7fbc769a016dad55) | `spicetify-cli: 2.8.5 -> 2.9.0`                                  |
| [`cb7ea19d`](https://github.com/NixOS/nixpkgs/commit/cb7ea19d9751f018280dbc5cbc5cc1947c9ae77f) | `deep-translator: 1.6.1 -> 1.7.0`                                |
| [`e7d968ca`](https://github.com/NixOS/nixpkgs/commit/e7d968cab232703324c9fbc693c92b06f192ddbe) | `rofi-file-browser: 1.3.0 -> 1.3.1`                              |
| [`22c9c238`](https://github.com/NixOS/nixpkgs/commit/22c9c238906e6f9374eb56884a8bdc90ee6a2694) | `python3Packages.cdcs: 0.1.5 -> 0.1.6`                           |
| [`6ea5ed2a`](https://github.com/NixOS/nixpkgs/commit/6ea5ed2a7d1ab718f5d7528db10f131119379c31) | `python3Packages.pygame-gui: 0.5.7 -> 0.6.4`                     |
| [`e859a7ce`](https://github.com/NixOS/nixpkgs/commit/e859a7ce297cfdb2544107d78b39bf550056aad3) | `python3Packages.python-i18n: init at 0.3.9`                     |
| [`9482d8e0`](https://github.com/NixOS/nixpkgs/commit/9482d8e0606e1a2bfa1092dd8929099476bae002) | `python3Packages.whodap: 0.1.3 -> 0.1.4`                         |
| [`26ca9776`](https://github.com/NixOS/nixpkgs/commit/26ca9776aae60d81721e242defa73cfe7a53e061) | `nixos/autorandr: added new KillMode`                            |
| [`5e78d68b`](https://github.com/NixOS/nixpkgs/commit/5e78d68b2dcbf5c020da12e41afecc26665a4bb5) | `python3Packages.adafruit-platformdetect: 3.19.4 -> 3.19.5`      |
| [`ca402a45`](https://github.com/NixOS/nixpkgs/commit/ca402a454736274d75604a1a80c40a1cc1571140) | `python3Packages.pywizlight: 0.5 -> 0.5.2`                       |
| [`3b050bd9`](https://github.com/NixOS/nixpkgs/commit/3b050bd9c3a972cf090211a0767dded75ab9a572) | `gforth: use pname`                                              |
| [`c7b9a485`](https://github.com/NixOS/nixpkgs/commit/c7b9a48569acdb4b8384528d2acc074907b7242d) | `python3Packages.plexapi: 4.9.1 -> 4.9.2`                        |
| [`ecc4121b`](https://github.com/NixOS/nixpkgs/commit/ecc4121b433bb1c4dbed328f945cb38163bc5c8b) | `python3Packages.motionblinds: 0.5.10 -> 0.5.11`                 |
| [`a48d6c4c`](https://github.com/NixOS/nixpkgs/commit/a48d6c4cb8b16c8c7148674f8ad27497b1d38f17) | `python3Packages.python-ipmi: 0.5.1 -> 0.5.2`                    |
| [`08836b25`](https://github.com/NixOS/nixpkgs/commit/08836b254e9bbb684d50b2320e0969466e2bda75) | `gforth: enable swig bindings`                                   |
| [`c2305c92`](https://github.com/NixOS/nixpkgs/commit/c2305c9295bb5f88562560094c83a37489d101a7) | `mailman-rss: move expression`                                   |
| [`624abacb`](https://github.com/NixOS/nixpkgs/commit/624abacbe30898195f67127619a6199e0dee0fc5) | `python310Packages.pytest-raisin: 0.3 -> 0.4`                    |
| [`45222180`](https://github.com/NixOS/nixpkgs/commit/452221802dd32706298edb1de002cdf9b5a2a599) | `python3Packages.slack-sdk: 3.13.0 -> 3.14.0`                    |
| [`93e99492`](https://github.com/NixOS/nixpkgs/commit/93e9949259322f0ba49b38bb6eb53baaeb8ed706) | `python3Packages.sphinx-copybutton: 0.4.0 -> 0.5.0`              |
| [`e139593a`](https://github.com/NixOS/nixpkgs/commit/e139593aae459dee0d4b6c852958837a95640fc5) | `python310Packages.jupyter-repo2docker: 2021.08.0 -> 2022.02.0`  |
| [`f5227f06`](https://github.com/NixOS/nixpkgs/commit/f5227f0643c0475b16a9eb4e756d40cd663866cc) | ``bootstrap-tools: disable iconv for the `hello` test``          |
| [`69582763`](https://github.com/NixOS/nixpkgs/commit/6958276347071cf1092c0db4b2c503eb5acb889f) | `Revert "Revert "hello: 2.10 -> 2.12" (#158328)"`                |
| [`199f5ef9`](https://github.com/NixOS/nixpkgs/commit/199f5ef929eb0d22dbddb62605b7bd954c221913) | `mailutils: 3.12 -> 3.13`                                        |
| [`49e2877f`](https://github.com/NixOS/nixpkgs/commit/49e2877f51528046262a5fdabbdb474881adc25a) | `nomad-autoscaler: various fixes`                                |
| [`ab07e129`](https://github.com/NixOS/nixpkgs/commit/ab07e129886629b235906e9fa31902138dfe53ba) | `treewide: drop unnecessary go_1_17, buildGo117{Module,Package}` |
| [`2211a7cf`](https://github.com/NixOS/nixpkgs/commit/2211a7cf7498ec326fa66cb81e4cdb2c5a07b10c) | `programs/calls: enable dconf`                                   |
| [`d45c0bf6`](https://github.com/NixOS/nixpkgs/commit/d45c0bf61f9af1b0a0e060742bd8524dee6c3131) | `qownnotes: 22.1.11 -> 22.2.1`                                   |
| [`21a7a51f`](https://github.com/NixOS/nixpkgs/commit/21a7a51f8266f94d160d1f499626993f70ea1925) | `trinsic-cli: 1.1.2 -> 1.3.0`                                    |
| [`202f13c7`](https://github.com/NixOS/nixpkgs/commit/202f13c7b076fe878ae1b401cf1114c3f6ad2969) | `linthesia: init at 0.8.0`                                       |
| [`1c583d89`](https://github.com/NixOS/nixpkgs/commit/1c583d89e056e6d5ca63e4abf86d3803970a89bd) | `SDL2_ttf_2_0_15: init`                                          |
| [`ff811677`](https://github.com/NixOS/nixpkgs/commit/ff811677ccc74bc018616c953004750d87fe99c4) | `android-studio-stable: 2021.1.1.20 -> 2021.1.1.21`              |
| [`3ca052a4`](https://github.com/NixOS/nixpkgs/commit/3ca052a4ec0b337226dcd7cbf68750447a729cc7) | `python3Packages.types-setuptools: 57.4.8 -> 57.4.9`             |
| [`08e9a94c`](https://github.com/NixOS/nixpkgs/commit/08e9a94c10943ad1548238294fe5257a7d91fe84) | `electron_17: init at 17.0.0`                                    |
| [`81f99f41`](https://github.com/NixOS/nixpkgs/commit/81f99f4170be618468dc07506b931aa922241534) | `zeitgeist: 1.0.3 → 1.0.4`                                       |
| [`86e4fa89`](https://github.com/NixOS/nixpkgs/commit/86e4fa89eed2cbe78bcc4046aade39eba52a0bd4) | `ptcollab: 0.6.0.2 -> 0.6.1.0`                                   |
| [`82b2a833`](https://github.com/NixOS/nixpkgs/commit/82b2a833d85d951e207e1c572725b7fc327c7845) | `linuxPackages.nvidia_x11: add jonringer as maintainer`          |
| [`1da4e07e`](https://github.com/NixOS/nixpkgs/commit/1da4e07ea68c1782f11889f507d3e923d6b9ad85) | `linuxPackage.nvidia_x11: suffix x86_64 vulkan icd`              |
| [`56076698`](https://github.com/NixOS/nixpkgs/commit/56076698c2d08be341a9e517aa0c92242f64d7d6) | `minecraft-servers: fix update.py`                               |
| [`8d9215d3`](https://github.com/NixOS/nixpkgs/commit/8d9215d3dce6bd16eac3668bfb64e4646f62efb4) | `pdfsam-basic: 4.2.10 -> 4.2.12`                                 |
| [`6b5cebe2`](https://github.com/NixOS/nixpkgs/commit/6b5cebe20fa716f10e8deae119520b630300e433) | `ms-dotnettools.csharp: 1.23.15 -> 1.23.16`                      |
| [`be7f8fae`](https://github.com/NixOS/nixpkgs/commit/be7f8fae432ab5cd7ad819121eba50ed6aaf86f9) | `ms-dotnettools-csharp: Add Darwin support`                      |
| [`1a5c6d8d`](https://github.com/NixOS/nixpkgs/commit/1a5c6d8d551c44242d2d31965534dcb2cf5b79cb) | `gforth: remove useless comment`                                 |
| [`0e00c0b8`](https://github.com/NixOS/nixpkgs/commit/0e00c0b8f3c2f3eea9ef70daa2eaf02aac2fa464) | `gforth: replace name with pname`                                |
| [`65c327d4`](https://github.com/NixOS/nixpkgs/commit/65c327d4b601d0d152f80f1452a2cbb037eefa08) | `grub2_xen: pull upstream fix for binutils-2.36`                 |
| [`43cab046`](https://github.com/NixOS/nixpkgs/commit/43cab046883d2869f57a440047cefd6ab945cb0a) | `gforth: 0.7.3 -> 0.7.9_20211111`                                |