### PR TITLE
chore(flake/nixpkgs): `faad1164` -> `91094c90`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1644315559,
-        "narHash": "sha256-husNq8H/9DI5Oy1TK/RElNtPfldseMVY/9mSc2GdOQI=",
+        "lastModified": 1644361147,
+        "narHash": "sha256-z2Vn/dGmdHDcz35ZlSOf3iNv0koma6kOgrZ7cux336o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "faad11645619099b11e438c4d89110aafd70261f",
+        "rev": "91094c90221b1e8fa354f9a964280408e0c869e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [`48e25458`](https://github.com/NixOS/nixpkgs/commit/48e25458e0181a9ad81544d89f1a573bb6570538) | `megacmd: 1.4.0 → 1.5.0`                                                                            |
| [`dc6cbf16`](https://github.com/NixOS/nixpkgs/commit/dc6cbf16b8f3f1d7efd8d80f8dbac7cc3209047e) | `etcher: downgrade electron to v12`                                                                 |
| [`b397055f`](https://github.com/NixOS/nixpkgs/commit/b397055f12130e78d3b95bdc701df505306f86ac) | `etcher: 1.6.0 -> 1.7.3`                                                                            |
| [`3af1bbfc`](https://github.com/NixOS/nixpkgs/commit/3af1bbfc6843cf6532110e374bc03a703f85764c) | `python39Packages.devolo-home-control-api: fix version number`                                      |
| [`bae00be6`](https://github.com/NixOS/nixpkgs/commit/bae00be602d6817cafbdd0fe6fbfc6af51d863e4) | `dolphinEmuMaster: 5.0-15445 -> 5.0-15993`                                                          |
| [`196b1235`](https://github.com/NixOS/nixpkgs/commit/196b123511ae4abb10b682ce0a435452b9f8f3d5) | `subsurface: make build src name independent`                                                       |
| [`6a854c69`](https://github.com/NixOS/nixpkgs/commit/6a854c696862b1251e7efab9e15ec030b35654d9) | `python3Packages.pygame: 2.1.0 -> 2.1.2`                                                            |
| [`043cccef`](https://github.com/NixOS/nixpkgs/commit/043cccef2c1fc792c5f56a4f4cfa2893d1429ef2) | `knot-dns: 3.1.5 -> 3.1.6`                                                                          |
| [`40bde30d`](https://github.com/NixOS/nixpkgs/commit/40bde30d2a1a9fd3635b6c53cbf18a22d3b290af) | `mailutils: 3.13 -> 3.14`                                                                           |
| [`bff4b9cd`](https://github.com/NixOS/nixpkgs/commit/bff4b9cdc740b9b7015b425929bf34afeb260f5b) | `python3Packages.opensimplex: 0.3 -> 0.4.2`                                                         |
| [`cff82556`](https://github.com/NixOS/nixpkgs/commit/cff82556ec9b8a4f7fd52a0372ac510853016051) | `jetbrains: 11_0_11-b1504.13 -> 11_0_13-b1751.25`                                                   |
| [`2909f5b0`](https://github.com/NixOS/nixpkgs/commit/2909f5b0417abf0553f8e83666ef1d907f9e968a) | `jetbrains: allow to override JAVA_HOME/ANDROID_JAVA_HOME/JDK_HOME`                                 |
| [`dd37d07c`](https://github.com/NixOS/nixpkgs/commit/dd37d07ccf912ee35a4f041182890e10db5ce7a4) | `nixos-rebuild: also forward the long version of -L`                                                |
| [`8d854f52`](https://github.com/NixOS/nixpkgs/commit/8d854f52eb3efa72144ecc3e4081b7a3c6487f03) | `n8n: register updateScript`                                                                        |
| [`018997e2`](https://github.com/NixOS/nixpkgs/commit/018997e2c2792caf4fcf407a1a7b9d8cc23ab8aa) | `n8n: 0.160.0 -> 0.162.0`                                                                           |
| [`6c976d30`](https://github.com/NixOS/nixpkgs/commit/6c976d3099e3e4b3b61f86390e11eaee24db7155) | `spago: 0.20.4 -> 0.20.5`                                                                           |
| [`c803d8e8`](https://github.com/NixOS/nixpkgs/commit/c803d8e88c2ca5b5083df61a6f47444de60de43e) | `jitsi-meet-electron: 2.8.11 -> 2022.1.1`                                                           |
| [`9181a25b`](https://github.com/NixOS/nixpkgs/commit/9181a25b036c84e0195cc3737b1666a29f387706) | `syft: 0.36.0 -> 0.37.10`                                                                           |
| [`e9912ce7`](https://github.com/NixOS/nixpkgs/commit/e9912ce72d015b71784df264fe5efcaa9dfa8253) | `git-branchless: 0.3.8 -> 0.3.9`                                                                    |
| [`e6c94c7f`](https://github.com/NixOS/nixpkgs/commit/e6c94c7f56c983c1bef30511c460b2e0b61e56da) | `Remove oxalica as the maintainer at her request`                                                   |
| [`1c7214f1`](https://github.com/NixOS/nixpkgs/commit/1c7214f164f2430093999c33b592778948fa4657) | `vscode-extensions.vadimcn.vscode-lldb: 1.6.8 -> 1.6.10`                                            |
| [`80fba0e5`](https://github.com/NixOS/nixpkgs/commit/80fba0e5d31a593b320d7cac03e6e936ee177289) | `python39Packages.setupmeta: fix version number`                                                    |
| [`09537081`](https://github.com/NixOS/nixpkgs/commit/095370811e5a69e9b0290e773a288f2699181430) | `fluxcd: 0.26.1 -> 0.26.2`                                                                          |
| [`7ab67fda`](https://github.com/NixOS/nixpkgs/commit/7ab67fdaeb59cc86e6c555f6aac685a7c0c57f9b) | `omnisharp-roslyn: 1.37.15 -> 1.38.0`                                                               |
| [`948603bb`](https://github.com/NixOS/nixpkgs/commit/948603bb9760c28772f5a9d63bae285d89a46a2c) | `ledger-live-desktop: 2.37.2 -> 2.38.2`                                                             |
| [`0a15821e`](https://github.com/NixOS/nixpkgs/commit/0a15821ee7fba4d90a277283a30e6016dfb685bc) | `ledger-live-desktop: 2.37.2 -> 2.38.2`                                                             |
| [`2a5eece2`](https://github.com/NixOS/nixpkgs/commit/2a5eece23131bd1637d991eba8ee250938142669) | `python3Packages.nats-py: 0.11.5 -> 2.0.0`                                                          |
| [`dc9a5b59`](https://github.com/NixOS/nixpkgs/commit/dc9a5b5985cfb6fad69eb1b88730473111fa1fc9) | `python3Packages.csvw: disable failing tests on Python 3.10`                                        |
| [`4ff59329`](https://github.com/NixOS/nixpkgs/commit/4ff59329ded0e9296d09e485ca77996d467e3851) | `python310Packages.packageurl-python: 0.9.6 -> 0.9.7`                                               |
| [`75e29573`](https://github.com/NixOS/nixpkgs/commit/75e29573a8c5fb0608b999ed80035c8572b21b67) | `python39Packages.scikit-survival: fix version number`                                              |
| [`7c393884`](https://github.com/NixOS/nixpkgs/commit/7c393884f1ff512358aea42a33ac606f227fd18b) | `python310Packages.pymavlink: 2.4.19 -> 2.4.20`                                                     |
| [`9b9e2d34`](https://github.com/NixOS/nixpkgs/commit/9b9e2d3469ce39ecc327b4d20b55921cd3e61d9d) | `python39Packages.greeclimate: fix version number`                                                  |
| [`08aec5fb`](https://github.com/NixOS/nixpkgs/commit/08aec5fbdca153a2de313fafb0f8a5272c54719a) | `python39Packages.pijuice: fix version number, disable tests`                                       |
| [`f6b1790d`](https://github.com/NixOS/nixpkgs/commit/f6b1790dbea4a9c66f8f543193cda4fa77ec4fb2) | `python39Packages.rxv: fix version number`                                                          |
| [`59be1661`](https://github.com/NixOS/nixpkgs/commit/59be16611c6cd0674081f0c45cc83aeb8b1d1122) | `rPackages: fix evaluation`                                                                         |
| [`39d8c486`](https://github.com/NixOS/nixpkgs/commit/39d8c4866f600bbdd7ac3383f42563a31b1ce34d) | `python310Packages.azure-mgmt-iothubprovisioningservices: 1.0.0 -> 1.1.0`                           |
| [`fee3df43`](https://github.com/NixOS/nixpkgs/commit/fee3df437fabb571a7095b47efc221f19ea57509) | `python39Packages.garages-amsterdam: fix version number, update homepage`                           |
| [`fb0ddd27`](https://github.com/NixOS/nixpkgs/commit/fb0ddd271ebf49498fedbcdb873294fd417a3320) | `python3Packages.pyhumps: init at 3.5.0`                                                            |
| [`e9a32bb7`](https://github.com/NixOS/nixpkgs/commit/e9a32bb715147e5698e86cf8c7b749013874f65b) | `python39Packages.plumbum: fix version, enable tests, add meta`                                     |
| [`0a21b293`](https://github.com/NixOS/nixpkgs/commit/0a21b2930d00a45da9e8f51834893ea667eaf912) | `python39Packages.pysiaalarm: fix version number, remove unused setuptools`                         |
| [`d336e259`](https://github.com/NixOS/nixpkgs/commit/d336e2596fa3e1e37aa0aea9e617280e481db3f2) | `python39Packages.prance: fix version number, update homepage`                                      |
| [`686db44a`](https://github.com/NixOS/nixpkgs/commit/686db44ab6695f61e82096c6ca6e98c639bda19e) | `python3Packages.warrant-lite: init at 1.0.4`                                                       |
| [`590b57dd`](https://github.com/NixOS/nixpkgs/commit/590b57dda619501e85224ff2b931e277482ac086) | `python3Packages.flowlogs_reader: 3.1.0 -> 3.2.0`                                                   |
| [`f32afc87`](https://github.com/NixOS/nixpkgs/commit/f32afc87762efe4cc5e80ba5bfa32880c09150eb) | `python39Packages.astropy-extension-helpers: fix version number`                                    |
| [`5658eeea`](https://github.com/NixOS/nixpkgs/commit/5658eeea776423b8374f97a8fbd206233e39402f) | `python3Packages.click-configfile: adjust install_requires`                                         |
| [`bcec18a3`](https://github.com/NixOS/nixpkgs/commit/bcec18a34572a5f72091eb22b9a544e4094a4684) | `easyeffects: 6.1.3 → 6.2.3`                                                                        |
| [`f5499849`](https://github.com/NixOS/nixpkgs/commit/f5499849e25b80fc988ae0196cbbf6889e2a3fa2) | `python39Packages.moonraker-api: fix version number`                                                |
| [`6ddaba62`](https://github.com/NixOS/nixpkgs/commit/6ddaba62ad693e587a3887f11a6bda61a114f52b) | `python3Packages.secp256k1: fix build`                                                              |
| [`2179d25d`](https://github.com/NixOS/nixpkgs/commit/2179d25d38a7a56c51008209811a84b91231dc1d) | `python39Packages.forecast-solar: fix version number`                                               |
| [`d47ad69e`](https://github.com/NixOS/nixpkgs/commit/d47ad69e7accd840d16d2c72c4912c79ea4753a7) | `python39Packages.drms: fix version number`                                                         |
| [`d24b8431`](https://github.com/NixOS/nixpkgs/commit/d24b8431aaed3f7e959bef5cf155cc58a9e6be07) | `packages-config.nix: ignore haskellPackages.hs-mesos`                                              |
| [`b28a3d56`](https://github.com/NixOS/nixpkgs/commit/b28a3d56b14ce9a5f0b5565203c764451087b6c8) | `python3Packages.velbus-aio: 2022.02.1 -> 2022.2.3`                                                 |
| [`2376811b`](https://github.com/NixOS/nixpkgs/commit/2376811b2b392a3b261ec38ce4cde4a3f200d35d) | `python39Packages.django-auth-ldap: fix version number`                                             |
| [`2a285d4d`](https://github.com/NixOS/nixpkgs/commit/2a285d4d68d18a9ec08c477b7570f2595d240497) | `python39Packages.doc8: fix version number`                                                         |
| [`fc7550d3`](https://github.com/NixOS/nixpkgs/commit/fc7550d33c5eaac554ac4f2cb8d345d1df1be7cb) | `secp256k1: unstable-2021-06-06 -> unstable-2022-02-06`                                             |
| [`3d6eb148`](https://github.com/NixOS/nixpkgs/commit/3d6eb1487ea7d3dc736127d21ed31653c8f207be) | `python39Packages.casa-formats-io: fix version number, update homepage`                             |
| [`0d79bd66`](https://github.com/NixOS/nixpkgs/commit/0d79bd66999ae23fb13abd08cf312b5b0ad3e492) | `python39Packages.boost-histogram: fix version number, remove default meta.platforms`               |
| [`dacbe2de`](https://github.com/NixOS/nixpkgs/commit/dacbe2de52dbcd04d5fb77d777dd7391c5097c4c) | `python39Packages.aiomusiccast: fix version number`                                                 |
| [`3d8dd6bb`](https://github.com/NixOS/nixpkgs/commit/3d8dd6bbd9b7f8bcb9f5e015a13a2a3773c1d4ba) | `python39Packages.adguardhome: fix version number`                                                  |
| [`4b13f83b`](https://github.com/NixOS/nixpkgs/commit/4b13f83bf08e52174565843fb25c672ef1e350ea) | `python310Packages.od: 2.0.1 -> 2.0.2`                                                              |
| [`9b014bdb`](https://github.com/NixOS/nixpkgs/commit/9b014bdb4793f1e1817b8415aa73bffd3dfe0543) | `vimPlugins: update`                                                                                |
| [`3307d705`](https://github.com/NixOS/nixpkgs/commit/3307d70562ae081c515955a95aa770346ee7cc53) | `vimPlugins: add a few plugins for completion and misc other bits`                                  |
| [`210ef18b`](https://github.com/NixOS/nixpkgs/commit/210ef18b57a651e6f185d2c4fefd1359c14046fd) | `python39Packages.cartopy: fix version number`                                                      |
| [`48a98a84`](https://github.com/NixOS/nixpkgs/commit/48a98a84e0c488e4ec21a20377b3f3b665468b27) | `python3Packages.tomli: add downstream dependency tests`                                            |
| [`ce92a609`](https://github.com/NixOS/nixpkgs/commit/ce92a609bdc89bbb633c54cc8a2e1fe55b2070a9) | `python3Packages.thinc: enable tests`                                                               |
| [`36be2dd2`](https://github.com/NixOS/nixpkgs/commit/36be2dd24023cfc44e92d482298997cf70cd3235) | `python3Packages.thinc: fix relax dependencies`                                                     |
| [`bb89d8d9`](https://github.com/NixOS/nixpkgs/commit/bb89d8d9eefc138e03466e8a0464ecd384edef0a) | `ocamlPackages.core: 0.11.2 → 0.11.3`                                                               |
| [`1fc7d47c`](https://github.com/NixOS/nixpkgs/commit/1fc7d47cb46ec90802ebac81fa77e692610bfbdf) | `python3Packages.fastnumbers: disable tests on ARM`                                                 |
| [`092fe809`](https://github.com/NixOS/nixpkgs/commit/092fe80925dc09e2fd187d90f5f21712381e72e3) | `python3Packages.atlassian-python-api: add pythonImportsCheck`                                      |
| [`a0a6c43b`](https://github.com/NixOS/nixpkgs/commit/a0a6c43b2a1e007c6c4883541717694704ecc710) | `dbeaver: fix mavenDeps sha256Hash`                                                                 |
| [`f2594443`](https://github.com/NixOS/nixpkgs/commit/f25944439889667110b7e0f4236234a0515d0365) | `terraform: fix overrideAttrs with passthru attributes (#158632)`                                   |
| [`2fcfc72e`](https://github.com/NixOS/nixpkgs/commit/2fcfc72e682fa7d1e5c7dc33d5cda16188b48112) | `terraform-providers: wrap mkProvider in lib.makeOverridable (#158618)`                             |
| [`58f58c8d`](https://github.com/NixOS/nixpkgs/commit/58f58c8de6c7aebd4df1f5080bcef7b7cb7b673b) | `lean: 3.39.0 -> 3.39.1`                                                                            |
| [`a061b27b`](https://github.com/NixOS/nixpkgs/commit/a061b27b2d65121f294cff9e784c9172fd57c1fb) | `displaylink: add dependency on required-file source to avoid unchanged manual interactions needed` |
| [`84c1ce02`](https://github.com/NixOS/nixpkgs/commit/84c1ce02241ce01cc214b78b153901edc6c84997) | `python310Packages.deezer-python: 5.1.0 -> 5.1.1`                                                   |
| [`2c9572c8`](https://github.com/NixOS/nixpkgs/commit/2c9572c86268edd3240f27d80d3b5a270eadbc00) | `lightning-loop: 0.16.0-beta -> 0.17.0-beta`                                                        |
| [`46f01a5e`](https://github.com/NixOS/nixpkgs/commit/46f01a5ea4e5598af6e2b387c5bb3727df0f7325) | `python310Packages.google-resumable-media: 2.1.0 -> 2.2.0`                                          |
| [`1a417bc1`](https://github.com/NixOS/nixpkgs/commit/1a417bc1dda28270baa23ddaa1aba15cdaf2a92f) | `nixos/cloud-init: fix trivial error that prevents deploy`                                          |
| [`547809e2`](https://github.com/NixOS/nixpkgs/commit/547809e2be04bff715b225eff27abcbd3a3a5d7c) | `btcpayserver: 1.4.3 -> 1.4.4`                                                                      |
| [`8c27f7a2`](https://github.com/NixOS/nixpkgs/commit/8c27f7a2bd3ce539f6441123c41376a591ab3395) | `haskellPackages.ghcWithPackages: throw on old override interface`                                  |
| [`fae4895e`](https://github.com/NixOS/nixpkgs/commit/fae4895e11885ca16bf22cbbd17f990920ed24e5) | `Falkon: 3.1.0 -> 3.2.0`                                                                            |
| [`57e73ca3`](https://github.com/NixOS/nixpkgs/commit/57e73ca3ec6248576bf9822b7a265dbc1ecac13a) | `jamesdsp: init at 2.3 (#154158)`                                                                   |
| [`cf5cccc7`](https://github.com/NixOS/nixpkgs/commit/cf5cccc798005545ee99ca4507a8887dca3e5d31) | `slack: changed download URL`                                                                       |
| [`15dfa560`](https://github.com/NixOS/nixpkgs/commit/15dfa560c1b5a983b8f767835b65f0a6d96a02be) | `python310Packages.flux-led: 0.28.21 -> 0.28.22`                                                    |
| [`b4cd49fc`](https://github.com/NixOS/nixpkgs/commit/b4cd49fcf9c4f20639137d229a6df65935a1fc4f) | `duf: 0.8.0 -> 0.8.1`                                                                               |
| [`6d18192b`](https://github.com/NixOS/nixpkgs/commit/6d18192b31ff34fb3b5ee60421f150f16f0c1313) | `python3Packages.nagiosplugin: switch to pytestCheckHook`                                           |
| [`e509500c`](https://github.com/NixOS/nixpkgs/commit/e509500c7370554deb9c3ca66368d8ed92d876fd) | `python3Packages.graphene: disable failing tests on Python 3.10`                                    |
| [`26b1df8a`](https://github.com/NixOS/nixpkgs/commit/26b1df8a99c99b7e2d0d058c453ea3b00de1b4d8) | `python310Packages.atlassian-python-api: 3.18.1 -> 3.19.0`                                          |
| [`833bcbc8`](https://github.com/NixOS/nixpkgs/commit/833bcbc84438c1f4182f2887d4bcfc47c4b43fbc) | `nixos/firewall: make 'networking.firewall.package' example less confusing`                         |
| [`b246a82e`](https://github.com/NixOS/nixpkgs/commit/b246a82ed309cc9b0528b368e62cf782c3962596) | `python310Packages.heatzypy: 2.0.1 -> 2.0.2`                                                        |
| [`07ee6deb`](https://github.com/NixOS/nixpkgs/commit/07ee6debee984e6b5c4d73b79bc9589dc16b6a73) | `checkov: 2.0.795 -> 2.0.805`                                                                       |
| [`adb08ddf`](https://github.com/NixOS/nixpkgs/commit/adb08ddf379e903efd5cd7aadaf1a89f1ce86151) | `tfsec: 1.0.11 -> 1.1.2`                                                                            |
| [`ddbcd756`](https://github.com/NixOS/nixpkgs/commit/ddbcd7568f92f57b61ca934ce3a6de4b56779f56) | `julia_17-bin: 1.7.1 -> 1.7.2`                                                                      |
| [`33a0ea3a`](https://github.com/NixOS/nixpkgs/commit/33a0ea3a3bde4cc9702007690b11f72761ed0f7d) | `tmuxPlugins.cpu: unstable-2020-07-25 -> unstable-2021-12-15`                                       |
| [`f448fc73`](https://github.com/NixOS/nixpkgs/commit/f448fc739446db64e42e7870d7484d09c213acaa) | `firefox-bin: 96.0.3 -> 97.0`                                                                       |
| [`38219f7c`](https://github.com/NixOS/nixpkgs/commit/38219f7cc7e1eb28defe943164020d58e03d68b6) | `firefox-esr-91: 91.5.1esr -> 91.6.0esr`                                                            |
| [`a41acde0`](https://github.com/NixOS/nixpkgs/commit/a41acde05c59544f17d8a35579b91ef16e16f8c3) | `firefox: 96.0.3 -> 97.0`                                                                           |
| [`9694c778`](https://github.com/NixOS/nixpkgs/commit/9694c778f2856cb0062453b2e4ff5c8028b05105) | `home-assistant: 2022.2.2 -> 2022.2.3`                                                              |
| [`ceda5a3e`](https://github.com/NixOS/nixpkgs/commit/ceda5a3e788c10f4ac4298e4996615fcc7d225f7) | `simgear: 2020.3.11 -> 2020.3.12`                                                                   |
| [`20bb580c`](https://github.com/NixOS/nixpkgs/commit/20bb580cce5aab03f5f374873e72413b7ffbb248) | `tmuxPlugins.tmux-fzf: unstable-2020-12-07 -> unstable-2021-10-20`                                  |
| [`2b3f77b7`](https://github.com/NixOS/nixpkgs/commit/2b3f77b716f8cec333ff72e8a70cf1851a023f4e) | `nixos/udev: set firmware path in a separate modprobe.d file`                                       |
| [`7446e158`](https://github.com/NixOS/nixpkgs/commit/7446e158d8b9f13d4770b71b066dc0383456f8f9) | `7kaa: init at 2.15.4p1`                                                                            |
| [`3dc6fab5`](https://github.com/NixOS/nixpkgs/commit/3dc6fab5c9362db2cf079ffa15f2b62b05001747) | `nixos/stage-1: add nixos modprobe options`                                                         |
| [`e062e44e`](https://github.com/NixOS/nixpkgs/commit/e062e44e6567ae4418501ac3a80387561e666a4f) | `odoo: fix package: use werkzeug v1`                                                                |
| [`7a7876a9`](https://github.com/NixOS/nixpkgs/commit/7a7876a90bda89399bde38694e055c15201842be) | `werkzeug/1: init at 1.0.1`                                                                         |
| [`4eb1a437`](https://github.com/NixOS/nixpkgs/commit/4eb1a437e93c77395405e90a1d915e1844344a98) | `odoo: 15.0.20211029 -> 15.0.20220126`                                                              |
| [`aca79695`](https://github.com/NixOS/nixpkgs/commit/aca79695b924a4d9c273c019342d1dbe1470f08c) | `mat2: fix nautilus-extension`                                                                      |
| [`46ad1dbb`](https://github.com/NixOS/nixpkgs/commit/46ad1dbb4fe3f7413850aba5efd975c4badf290a) | `libnats-c: 2.1.0 -> 3.2.0`                                                                         |
| [`b52c3e74`](https://github.com/NixOS/nixpkgs/commit/b52c3e742eb31f2c915fdcc9ef75d366cc37ee0f) | `besu: init at 21.10.8`                                                                             |
| [`fcc99913`](https://github.com/NixOS/nixpkgs/commit/fcc9991376b91f148f7ca1e94be46c19a33c80f5) | `pijuice: fix for python 3.9`                                                                       |
| [`4091631b`](https://github.com/NixOS/nixpkgs/commit/4091631b52aa2a8732f2a3b0e399405320ef744b) | `matrix-synapse-shared-secret-auth: add sumnerevans as maintainer`                                  |
| [`20b33836`](https://github.com/NixOS/nixpkgs/commit/20b338368c0d993471602e380feda4b51c407c16) | `matrix-synapse-shared-secret-auth: 1.0.2 -> 2.0.1`                                                 |