### PR TITLE
chore(flake/nixpkgs): `91094c90` -> `9fc8e0bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1644361147,
-        "narHash": "sha256-z2Vn/dGmdHDcz35ZlSOf3iNv0koma6kOgrZ7cux336o=",
+        "lastModified": 1644403595,
+        "narHash": "sha256-q/C6w9VQ3n3cJbMoT1DdhoyDIpQqXB2vKx/X3L4ovao=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "91094c90221b1e8fa354f9a964280408e0c869e1",
+        "rev": "9fc8e0bb56e58f35f5f8bc1323e1325595b4cd89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                    |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`44bc0ee6`](https://github.com/NixOS/nixpkgs/commit/44bc0ee64b7090ef0ec19d60901f817c631b3bad) | `fheroes2: 0.9.11 -> 0.9.12`                                      |
| [`09837994`](https://github.com/NixOS/nixpkgs/commit/09837994ba5bd238e26585e037dc786aec738adc) | `anbox: 2020-11-29 -> 2021-10-20, fix build`                      |
| [`e7604cab`](https://github.com/NixOS/nixpkgs/commit/e7604cab7b95d701b6cc534771683b55542b1415) | `exploitdb: 2022-02-05 -> 2022-02-09`                             |
| [`324e8d21`](https://github.com/NixOS/nixpkgs/commit/324e8d212bb2ded6b4bea7c39d73cad002e57b05) | `contrast: 0.0.3 → 0.0.5`                                         |
| [`d818fd7e`](https://github.com/NixOS/nixpkgs/commit/d818fd7e7115f0e0a3d821d454f818d7003ffa36) | `Revert "python3Packages.django_2: fix pname"`                    |
| [`2bd97adf`](https://github.com/NixOS/nixpkgs/commit/2bd97adf432316e6ea4a482f096cc27ba514401f) | `Revert "python3Packages.django_3: fix pname"`                    |
| [`21c5cfb8`](https://github.com/NixOS/nixpkgs/commit/21c5cfb88e075dab08b8948d1aaca549508faec5) | `python39Packages.fiona: 1.8.20 -> 1.8.21`                        |
| [`6629a887`](https://github.com/NixOS/nixpkgs/commit/6629a887140c8df27798885d3f11ea0ca2bbc34a) | `screen: drop outdated hack for cross compilation`                |
| [`fb067d4c`](https://github.com/NixOS/nixpkgs/commit/fb067d4c1799a25c54392229796171c5ac63b820) | `python310Packages.pytest-cases: 3.6.8 -> 3.6.9`                  |
| [`c54baf94`](https://github.com/NixOS/nixpkgs/commit/c54baf949ad582bd7107f8863c50c4999abaad59) | `python39Packages.librosa: 0.8.1 -> 0.9.0`                        |
| [`900e3184`](https://github.com/NixOS/nixpkgs/commit/900e31847089b26d4db4272029e8640668d67541) | `python3Packages.django_3: fix pname`                             |
| [`1862f492`](https://github.com/NixOS/nixpkgs/commit/1862f4928c3cf1d97793dca824aa5eaee3830927) | `python3Packages.django_2: fix pname`                             |
| [`840351f7`](https://github.com/NixOS/nixpkgs/commit/840351f7e0c7be5b0ef46b22128f86582bae19b4) | `python39Packages.ipyvuetify: 1.8.1 -> 1.8.2`                     |
| [`92ffa5e9`](https://github.com/NixOS/nixpkgs/commit/92ffa5e9c96c14df8e9f1e290ca2b39dba86b7c6) | `python3Packages.python-nest: 4.1.0 -> 4.2.0`                     |
| [`d303d903`](https://github.com/NixOS/nixpkgs/commit/d303d903768497334996c586f8f53438c0c6471f) | `python3Packages.aiosenseme: init at 0.6.1`                       |
| [`3093caa2`](https://github.com/NixOS/nixpkgs/commit/3093caa2fc7be7a331ec574e0157cc0370b06974) | `python3Packages.aiooncue: 0.3.2 -> 0.3.3`                        |
| [`62076173`](https://github.com/NixOS/nixpkgs/commit/620761739cc9f52cfd884f5ca61d0b31201a0f67) | `python3Packages.django_4: init at 4.0.2`                         |
| [`92a6ad86`](https://github.com/NixOS/nixpkgs/commit/92a6ad8626eb08dbf76fa389d595c7ac7accd70e) | `packagekit: use Nix backend`                                     |
| [`3ecddf79`](https://github.com/NixOS/nixpkgs/commit/3ecddf791da4d893beb35fb09eb9da55b326f4fb) | `nixos/shellinabox: drop`                                         |
| [`64e026af`](https://github.com/NixOS/nixpkgs/commit/64e026af23a4887a090fd1065af2bc1ff6e03cad) | `shellinabox: drop`                                               |
| [`9dc2281f`](https://github.com/NixOS/nixpkgs/commit/9dc2281fa83f8c3c8824776cd2216e0e3f0a0eaa) | `python3Packages.amcrest: 1.9.3 -> 1.9.4`                         |
| [`d6209cb7`](https://github.com/NixOS/nixpkgs/commit/d6209cb7ab69794abe10643d2d7f75b0162e55ef) | `gnomeExtensions.pop-shell: fix executables`                      |
| [`6a099ac6`](https://github.com/NixOS/nixpkgs/commit/6a099ac6e25873fa5cfccfb00b110779b457a4a2) | `checkov: 2.0.805 -> 2.0.812`                                     |
| [`86e3ea38`](https://github.com/NixOS/nixpkgs/commit/86e3ea384d261a6eab722132ba396e2637e1feca) | `quickjs: add mainProgram`                                        |
| [`2d120094`](https://github.com/NixOS/nixpkgs/commit/2d120094632e01e1396d65a065fcae513d1f7af1) | `thinkfan: 1.3.0 -> 1.3.1`                                        |
| [`83a9f9e7`](https://github.com/NixOS/nixpkgs/commit/83a9f9e760da115aea6cf3e4537bdfe587da8ab9) | `realvnc-vnc-viewer: 6.21.920 -> 6.21.1109`                       |
| [`0358703d`](https://github.com/NixOS/nixpkgs/commit/0358703df27cdc2526b7c17701a1da79e4e4ad5b) | `command-not-found: add interactive option for auto run`          |
| [`d046fcf4`](https://github.com/NixOS/nixpkgs/commit/d046fcf4b1da09e04a1b9a04c1d9ac9e42fffc94) | `command-not-found: make NIX_AUTO_RUN work when multiple choices` |