### PR TITLE
chore(flake/nixpkgs): `9fc8e0bb` -> `607285bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1644403595,
-        "narHash": "sha256-q/C6w9VQ3n3cJbMoT1DdhoyDIpQqXB2vKx/X3L4ovao=",
+        "lastModified": 1644447333,
+        "narHash": "sha256-NuDF0GV7NmSWChFlZPKbYyMRY+cQqA+jxKc40dHCYV4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9fc8e0bb56e58f35f5f8bc1323e1325595b4cd89",
+        "rev": "607285bc0ec9920ee4de432c62499bf0a409ee40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                               |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`b5915094`](https://github.com/NixOS/nixpkgs/commit/b59150949cc48faa1d924a3dc825343684cd14aa) | `1password-gui: 8.3.0 -> 8.5.0`                                              |
| [`e73edac0`](https://github.com/NixOS/nixpkgs/commit/e73edac05b9923433515b42b4282f66f2590ebf7) | `chef-dk: install all binaries`                                              |
| [`90afb85a`](https://github.com/NixOS/nixpkgs/commit/90afb85ad3f18a3c912c0f84003aeee05e714566) | `radare2: 5.5.4 -> 5.6.0`                                                    |
| [`b63e6649`](https://github.com/NixOS/nixpkgs/commit/b63e6649a6fab8192eae9826482f0c301addc997) | `systemd: add myself as maintainer, drop eelco`                              |
| [`64189924`](https://github.com/NixOS/nixpkgs/commit/641899248d329de7cedbf9ddc377c58e0de6a6d3) | `webkitgtk: 2.34.4 -> 2.34.5`                                                |
| [`7bb11f29`](https://github.com/NixOS/nixpkgs/commit/7bb11f2950c8ffe666141faa80a8fe0ea4067d6e) | `python310Packages.pip-tools: 6.5.0 -> 6.5.1`                                |
| [`e1b74dce`](https://github.com/NixOS/nixpkgs/commit/e1b74dce5cceeb550c301c2de94397dc445a9fe9) | `python310Packages.ufoLib2: 0.13.0 -> 0.13.1`                                |
| [`a5812635`](https://github.com/NixOS/nixpkgs/commit/a581263556e862474ad9c446d65f0d50cfbb6dae) | `python310Packages.pywayland: 0.4.9 -> 0.4.10`                               |
| [`94c73cb7`](https://github.com/NixOS/nixpkgs/commit/94c73cb74fa6e873a0861a23b44f61a8f5fad760) | `grafana: 8.3.4 -> 8.3.5`                                                    |
| [`ea5dd097`](https://github.com/NixOS/nixpkgs/commit/ea5dd0974d1e74d7338a8763b0f313bb09fa5ed9) | `mupdf: 1.18 -> 1.19`                                                        |
| [`381d870f`](https://github.com/NixOS/nixpkgs/commit/381d870fa382af666f4342e12617369fc27532a2) | `matrix-synapse.tools.synadm: 0.32 -> 0.33.1`                                |
| [`6b9adcbb`](https://github.com/NixOS/nixpkgs/commit/6b9adcbbe1a5cf12e1d115092fe8282d8a4fc0bd) | `python39Packages.pytest-celery: switch to correct versioned github tarball` |
| [`43ff5d91`](https://github.com/NixOS/nixpkgs/commit/43ff5d91b57260213d057e598642282fc5930337) | `python310Packages.pywizlight: 0.5.2 -> 0.5.3`                               |
| [`d881ad34`](https://github.com/NixOS/nixpkgs/commit/d881ad34758b147bea90b3d4419e900ca2e586f5) | `typos: 1.3.7 -> 1.4.0`                                                      |
| [`5ccceacc`](https://github.com/NixOS/nixpkgs/commit/5ccceaccdc9192d298391c9eb841edc026418ba3) | `python310Packages.slack-sdk: 3.14.0 -> 3.14.1`                              |
| [`ca54a649`](https://github.com/NixOS/nixpkgs/commit/ca54a649b6675cc3625527717d22b0bcc8d6682e) | `thunderbird: 91.5.1 -> 91.6.0`                                              |
| [`3e75cee1`](https://github.com/NixOS/nixpkgs/commit/3e75cee1989ac1f24c88c85436523dfb6e97d777) | `spidermonkey_91: 91.5.0 -> 91.6.0`                                          |
| [`30d7dbc2`](https://github.com/NixOS/nixpkgs/commit/30d7dbc2be0b13b17e40b1e556f511f99c2a6bb5) | `nixos/rsyncd: fix module eval`                                              |
| [`71dad304`](https://github.com/NixOS/nixpkgs/commit/71dad3047930d9222c343cdc9a91173423647854) | `grim: 1.3.2 -> 1.4.0`                                                       |
| [`69e2db39`](https://github.com/NixOS/nixpkgs/commit/69e2db3900c0d94c7fc3cf09038cbe45e3d38d32) | `epson-escpr2: 1.1.45 -> 1.1.46`                                             |
| [`884b8ebc`](https://github.com/NixOS/nixpkgs/commit/884b8ebc8e577a951f4d67274c2fee0ab17c1f43) | `imagemagick: 7.1.0-22 -> 7.1.0-23`                                          |
| [`1189d2c1`](https://github.com/NixOS/nixpkgs/commit/1189d2c1f1492fc2cc75083a3b8cd6a96522ac60) | `microcodeIntel: 20210608 -> 20220207`                                       |
| [`d34a4653`](https://github.com/NixOS/nixpkgs/commit/d34a4653279524056bcfbda2b58d36c4dd8fd604) | `passExtensions.pass-audit: 1.1 -> 1.2`                                      |
| [`91948945`](https://github.com/NixOS/nixpkgs/commit/91948945a1373cef73f8d512d55b7279e00abb4b) | `gogoclient: drop`                                                           |
| [`57c751e8`](https://github.com/NixOS/nixpkgs/commit/57c751e81257d8fb7262be3552a61b425e7e02c5) | `tela-circle-icon-theme: unstable-2021-12-24 -> 2022-02-08`                  |
| [`f5f6dab7`](https://github.com/NixOS/nixpkgs/commit/f5f6dab7122ba1620c38e657a4519e265f47517b) | `graphite-kde-theme: unstable-2022-01-22 -> 2022-02-08`                      |
| [`1c22d6c0`](https://github.com/NixOS/nixpkgs/commit/1c22d6c0c9e5490732d3fb1103d42e95e9f8a7c9) | `python3Packages.async-upnp-client: 0.23.4 -> 0.23.5`                        |
| [`9f67b1d4`](https://github.com/NixOS/nixpkgs/commit/9f67b1d450c2a5abfd303a2abd2a8f6122057538) | `mate.mate-tweak: 22.04.0 -> 22.04.1`                                        |
| [`af8869b9`](https://github.com/NixOS/nixpkgs/commit/af8869b94024a58fd09dc8b176b898da9b63a38f) | `xfce.xfce4-sensors-plugin: 1.4.2 -> 1.4.3`                                  |
| [`699c09cb`](https://github.com/NixOS/nixpkgs/commit/699c09cbdadf608dc328c6cce0367dbe8f450639) | `xfce.xfce4-cpugraph-plugin: 1.2.5 -> 1.2.6`                                 |
| [`0955a4fa`](https://github.com/NixOS/nixpkgs/commit/0955a4fa354ffb5b7b341826a533c9453058d00e) | `collectd: don't build with xen plugin by default`                           |
| [`8c77a3fc`](https://github.com/NixOS/nixpkgs/commit/8c77a3fc029b6a07f5feb2d0c8be47fcca0e5074) | `ipaexfont: 003.01 -> 004.01`                                                |
| [`3de881ec`](https://github.com/NixOS/nixpkgs/commit/3de881ec50d3dd4dc34903f6fcd993e0c8cef0e1) | `deskew: 1.25 -> 1.30`                                                       |
| [`b1b19bcf`](https://github.com/NixOS/nixpkgs/commit/b1b19bcf9b16a3515c6d6f2870f52eab3932142a) | `graphite-gtk-theme: unstable-2022-01-07 -> unstable-2022-02-04`             |
| [`267fad11`](https://github.com/NixOS/nixpkgs/commit/267fad119fd4486b3a773b48affbd37284e61c68) | `minetest: remove unused patches`                                            |
| [`6e78755e`](https://github.com/NixOS/nixpkgs/commit/6e78755eaf3b86980ae094c761c2f6e82f392f66) | `minetest: 5.4.1 -> 5.5.0`                                                   |
| [`2bbe6d7b`](https://github.com/NixOS/nixpkgs/commit/2bbe6d7b8a63f27a910dbff85fc5e3382bb6143c) | `minetest: remove version 4`                                                 |
| [`37c4bacf`](https://github.com/NixOS/nixpkgs/commit/37c4bacf4c62d956a570bfe0420ae39932046b8f) | `xfce.xfce4-cpufreq-plugin: 1.2.5 -> 1.2.6`                                  |
| [`7b48f61b`](https://github.com/NixOS/nixpkgs/commit/7b48f61bff90ebc37dfb0cf97827f480a427888a) | `phoc: 0.11.0 -> 0.12.0`                                                     |
| [`12a58924`](https://github.com/NixOS/nixpkgs/commit/12a589244e53bf99e764c3cef57f3a2e835f6d90) | `phosh: 0.14.1 -> 0.15.0`                                                    |
| [`e779f3de`](https://github.com/NixOS/nixpkgs/commit/e779f3dee4640e44c2e5995afc1ee0559e045ec5) | `nixos/tests/wine: fix disksize type`                                        |
| [`159af502`](https://github.com/NixOS/nixpkgs/commit/159af50269a077d3bbd61d050d083761baee2f0e) | `zsh-powerlevel10k: 1.15.0 -> 1.16.0`                                        |