### PR TITLE
chore(flake/nixpkgs): `607285bc` -> `7dfba0cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1644447333,
-        "narHash": "sha256-NuDF0GV7NmSWChFlZPKbYyMRY+cQqA+jxKc40dHCYV4=",
+        "lastModified": 1644494270,
+        "narHash": "sha256-2AxKk/PvqAsq+v9J9VYsmfpfc43PkHkA0iJ98RP+Rbk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "607285bc0ec9920ee4de432c62499bf0a409ee40",
+        "rev": "7dfba0cf2692db4cf6cf988ab8fe3a8f2b8a3a90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`58971291`](https://github.com/NixOS/nixpkgs/commit/589712910b141cfa97ddb69969d302bde2f2058f) | `symfony-cli: 5.3.0 -> 5.3.3`                                               |
| [`cc04e93d`](https://github.com/NixOS/nixpkgs/commit/cc04e93dd65092c795b4c4d44544062c606642a6) | `buildah: 1.23.1 -> 1.24.1`                                                 |
| [`34e964f4`](https://github.com/NixOS/nixpkgs/commit/34e964f44cc970c9d2b87c203729ada5a92ea693) | `cri-o: 1.22.1 -> 1.23.0`                                                   |
| [`ade08f80`](https://github.com/NixOS/nixpkgs/commit/ade08f80fc32dab5fd7dce5dd99e77871c4f797a) | `lagrange: 1.10.3 -> 1.10.4`                                                |
| [`ce3082a0`](https://github.com/NixOS/nixpkgs/commit/ce3082a02d7c1ea0bc8ddaacaa10243b05f6132b) | `python310Packages.types-requests: 2.27.8 -> 2.27.9`                        |
| [`f84d2b39`](https://github.com/NixOS/nixpkgs/commit/f84d2b39043138efd149bf789b97fe9574711fe4) | `python310Packages.ovoenergy: 1.1.12 -> 1.2.0`                              |
| [`fda49570`](https://github.com/NixOS/nixpkgs/commit/fda49570ba6153cb01ffe6dec30416090cbb51b3) | `tfsec: 1.1.2 -> 1.1.3`                                                     |
| [`3bf56677`](https://github.com/NixOS/nixpkgs/commit/3bf56677f3ff7bb3140051602ac55e6ab570ed87) | `python3Packages.google-nest-sdm: 1.6.0 -> 1.7.0`                           |
| [`5fe1d1c1`](https://github.com/NixOS/nixpkgs/commit/5fe1d1c1ba63803c0637bde6e544bcb9527c86fe) | `python3Packages.pywemo: 0.7.0 -> 0.8.0`                                    |
| [`c3c21de2`](https://github.com/NixOS/nixpkgs/commit/c3c21de26bc33ec5ff6228e621cebbbe3c2c0b8c) | `home-assistant: update component-packages`                                 |
| [`fa886479`](https://github.com/NixOS/nixpkgs/commit/fa88647993424af657aa8706df8489c4b3ecc05c) | `python3Packages.aiosteamist: init at 0.3.1`                                |
| [`4d0e250a`](https://github.com/NixOS/nixpkgs/commit/4d0e250a0c550e381f7f3a76e4b2e9b7db0079c4) | `home-assistant: update component-packages`                                 |
| [`20fb68ff`](https://github.com/NixOS/nixpkgs/commit/20fb68ff55c2ebe869a2a51848aebbbe406cf92a) | `python3Packages.discovery30303: init at 0.2.1`                             |
| [`19ccd3a9`](https://github.com/NixOS/nixpkgs/commit/19ccd3a9888de5ddf9189a0b4e9644c9757080c7) | `python310Packages.trimesh: 3.9.43 -> 3.10.0`                               |
| [`0f01c989`](https://github.com/NixOS/nixpkgs/commit/0f01c9892016bac57a8ff37627e14be922dd01ad) | `python310Packages.gipc: 1.3.0 -> 1.4.0`                                    |
| [`47a61dcd`](https://github.com/NixOS/nixpkgs/commit/47a61dcdf8a6d0bbb5e3af3620cee2172dc6fce7) | `python3Packages.glean-sdk: 43.0.2 -> 44.0.0`                               |
| [`beeabe61`](https://github.com/NixOS/nixpkgs/commit/beeabe61fecb28ede0f69c560a1b248c6a4684e4) | `python310Packages.glean-parser: 4.4.0 -> 5.0.1`                            |
| [`b3dda019`](https://github.com/NixOS/nixpkgs/commit/b3dda0193ba5a4da744ffac6e3fe09b4e48f22e1) | `opensnitch: 1.4.3 -> 1.5.0`                                                |
| [`626dc5f0`](https://github.com/NixOS/nixpkgs/commit/626dc5f00a51f8f899536093f726dff6d978acf4) | `python3Packages.warlock: enable tests`                                     |
| [`ba3b21dc`](https://github.com/NixOS/nixpkgs/commit/ba3b21dc062f5c474ebb97aee72c8b68b2a02173) | `python3Packages.pygraphviz: 1.8 -> 1.9`                                    |
| [`5bdc8550`](https://github.com/NixOS/nixpkgs/commit/5bdc8550353cfaae158790ab08de4d8be5120314) | `python310Packages.aioesphomeapi: 10.8.1 -> 10.8.2`                         |
| [`290e4ff2`](https://github.com/NixOS/nixpkgs/commit/290e4ff2caf1151655ff4f760f229b0eac81ebbf) | `python3Packages.flake8-bugbear: init at 22.1.11`                           |
| [`083c3a94`](https://github.com/NixOS/nixpkgs/commit/083c3a940e4f9c6bde8d01d82807d83b83bd3e09) | `add jfchevrette as maintainers`                                            |
| [`314de8ae`](https://github.com/NixOS/nixpkgs/commit/314de8ae28ef0629b930cf2654ae1658fa0dca5a) | `add support for aarch64-darwin and x86_64-darwin`                          |
| [`bd215094`](https://github.com/NixOS/nixpkgs/commit/bd2150947460809b200d50df7bbc387b0b1c8b34) | `python3Packages.srpenergy: 1.3.5 -> 1.3.6`                                 |
| [`70a0139e`](https://github.com/NixOS/nixpkgs/commit/70a0139e7862294b3d1a849cd55ebe095b1efa25) | `python310Packages.pynamodb: 5.2.0 -> 5.2.1`                                |
| [`06368058`](https://github.com/NixOS/nixpkgs/commit/063680580c5950e855ffff39d1609c67313f0218) | `go: remove outdated alias throws`                                          |
| [`f4ca7eab`](https://github.com/NixOS/nixpkgs/commit/f4ca7eab458b919a47b019fc66f5e40640ab9067) | `esphome.dashboard: use pythonPackages.callPackage`                         |
| [`02197c4b`](https://github.com/NixOS/nixpkgs/commit/02197c4b5e61f73152c807cd5b8ebdafeab0cdbf) | `python3Packages.pyrogram: 1.3.7 -> 1.4.3`                                  |
| [`d1d32662`](https://github.com/NixOS/nixpkgs/commit/d1d326627049a156a800b46d3e36005d4e3411af) | `python3Packages.pytest-subprocess: 1.4.0 -> 1.4.1`                         |
| [`4fc58aa2`](https://github.com/NixOS/nixpkgs/commit/4fc58aa24cd526658a1b4c95f4f247f28532d2cc) | `difftastic: 0.12.0 -> 0.19.0`                                              |
| [`2770c2f2`](https://github.com/NixOS/nixpkgs/commit/2770c2f25ae2e8f6ab6204a1ac3f050fbe093642) | `vimPlugins.vim-clap: fix cargoSha256`                                      |
| [`1de14c4e`](https://github.com/NixOS/nixpkgs/commit/1de14c4ebe121a47d3346095b4ff1427eb1105ea) | `tree-sitter: update grammars`                                              |
| [`b7b8e957`](https://github.com/NixOS/nixpkgs/commit/b7b8e9574ff305e85be4e64e3d20286ce818fa58) | `tree-sitter: fix update script's prefetch`                                 |
| [`f78a083d`](https://github.com/NixOS/nixpkgs/commit/f78a083dddec6e14eae842655f6f01a45ff2113a) | `vimPlugins: update`                                                        |
| [`c65dea71`](https://github.com/NixOS/nixpkgs/commit/c65dea71411175638ef4bb8ec994021c18d41efd) | `python3Packages.pyrfxtrx: 0.27.0 -> 0.27.1`                                |
| [`0fbe6cb4`](https://github.com/NixOS/nixpkgs/commit/0fbe6cb466e9402ff9a440e891ae3866ac1b2ef0) | `python310Packages.diagrams: 0.21.0 -> 0.21.1`                              |
| [`3b93e99c`](https://github.com/NixOS/nixpkgs/commit/3b93e99c670e311a86ebf702e34322c8aeb04828) | `leetcode-cli: init at 0.3.10`                                              |
| [`564d59b3`](https://github.com/NixOS/nixpkgs/commit/564d59b339e29a5728fd295f45a42d8bcc1e2baa) | `maintainers: add congee`                                                   |
| [`69b4c554`](https://github.com/NixOS/nixpkgs/commit/69b4c554668a2762a730b80421cbf3c32c251032) | `julia-mono: 0.043 → 0.044`                                                 |
| [`f5417e72`](https://github.com/NixOS/nixpkgs/commit/f5417e72aecee6a3bd9377986a30db6469cec386) | `mtpfs: mark as broken on darwin`                                           |
| [`37c635b5`](https://github.com/NixOS/nixpkgs/commit/37c635b565982f076345bc756a81b57d484e440d) | `cfripper: 1.3.1 -> 1.3.3`                                                  |
| [`4ebed727`](https://github.com/NixOS/nixpkgs/commit/4ebed7273319ce9e6661f5794057812dfcc17fe4) | `btrbk: 0.31.3 -> 0.32.0`                                                   |
| [`d275f0ee`](https://github.com/NixOS/nixpkgs/commit/d275f0eecd97566ef5f0d70c836a3674371cde3f) | `babashka: 0.7.3 -> 0.7.4`                                                  |
| [`359687c5`](https://github.com/NixOS/nixpkgs/commit/359687c5b0ea6c2509c013693d51360bf0c90fe3) | `add jfchevrette to maintainers`                                            |
| [`e646b64e`](https://github.com/NixOS/nixpkgs/commit/e646b64ebbfd11f901e6a601a1ad422cd71f2da3) | `jless: init at 0.7.1`                                                      |
| [`464e9792`](https://github.com/NixOS/nixpkgs/commit/464e9792ff3e472944043d5c88cc455e5df70256) | `treewide: rename name to pname&version (#158454)`                          |
| [`aa0ff15b`](https://github.com/NixOS/nixpkgs/commit/aa0ff15bf54478d9f6544afaceda6daece3da3eb) | `radicale: 3.1.4 -> 3.1.5`                                                  |
| [`eb31e13b`](https://github.com/NixOS/nixpkgs/commit/eb31e13b541ed6a5580da3653d5c206286f54137) | `proxysql: fix build`                                                       |
| [`444cc624`](https://github.com/NixOS/nixpkgs/commit/444cc6249b897f8b6af4d4e534ad0a1135eea276) | `gdu: 5.13.0 -> 5.13.1`                                                     |
| [`f5be6f48`](https://github.com/NixOS/nixpkgs/commit/f5be6f48ff8ec879a23f8fea68725767c7fc2326) | `glooctl: init at 1.10.6`                                                   |
| [`9d74725e`](https://github.com/NixOS/nixpkgs/commit/9d74725ec413f97d61db0d5e8399f0dde37e40d3) | `checkov: 2.0.812 -> 2.0.814`                                               |
| [`767370c4`](https://github.com/NixOS/nixpkgs/commit/767370c47823abb55b92df89056b5a47494d963e) | `pantheon.elementary-default-settings: install dockitem for appcenter`      |
| [`5efa1bce`](https://github.com/NixOS/nixpkgs/commit/5efa1bce1707f93be859fcf378842aba2e3849e4) | `prometheus-alertmanager: 0.21.0 -> 0.23.0`                                 |
| [`ea611d2e`](https://github.com/NixOS/nixpkgs/commit/ea611d2e171f3f1722faa7d5cd156c0ff6bef854) | `nixos/pantheon: mention latest appcenter and packagekit changes in manual` |
| [`bb357d82`](https://github.com/NixOS/nixpkgs/commit/bb357d8203cc901bf1e729ec544c8c8b52cc329d) | `nixos/pantheon: install appcenter if flatpak is enabled`                   |
| [`59dc15a3`](https://github.com/NixOS/nixpkgs/commit/59dc15a3d8678332e70086d568695aea0fe24cfe) | `pantheon.appcenter: drop the disable packagekit patch again`               |
| [`e717c594`](https://github.com/NixOS/nixpkgs/commit/e717c594abb80c90bfbebe61c1d47387906e2d1a) | `nixos/pantheon: enable packagekit by default`                              |
| [`8454a7ed`](https://github.com/NixOS/nixpkgs/commit/8454a7ed0ec9b703ff7a0bd839f8f22b8c391b23) | `vultr-cli: 2.12.0 -> 2.12.1`                                               |
| [`1389f383`](https://github.com/NixOS/nixpkgs/commit/1389f383e9d8df4809a8a220b1ba90cc9fd2e123) | `pinentry-bemenu: init at 0.9.0`                                            |
| [`86aef2a8`](https://github.com/NixOS/nixpkgs/commit/86aef2a8c7ad3753ed51ca5f4175f6a50a2b41e4) | `maintainers: add jc`                                                       |
| [`4304bd21`](https://github.com/NixOS/nixpkgs/commit/4304bd2154031b3bbb3e87c2082fe777054e4215) | `werf: 1.2.60 -> 1.2.65`                                                    |
| [`18c0cca7`](https://github.com/NixOS/nixpkgs/commit/18c0cca770e290dd885b5aa21000be2b910617d1) | `maintainers: update azahi`                                                 |
| [`d282f448`](https://github.com/NixOS/nixpkgs/commit/d282f448ff74243ed1a1661c09ae27f010096cef) | `nixos/retroarch: add RetroArch as a desktop session`                       |
| [`875fde78`](https://github.com/NixOS/nixpkgs/commit/875fde78de099f986f954154f40d53213b7b9b16) | `orjail: init at 1.1`                                                       |
| [`12f343da`](https://github.com/NixOS/nixpkgs/commit/12f343da4c24a3d7ca22e4f2e55fbd50d79d0662) | `treewide: rename name to pname&version`                                    |
| [`6e7aebd8`](https://github.com/NixOS/nixpkgs/commit/6e7aebd89d833cb0a4d5d487a57ba54e97c83323) | `python3Packages.torchvision: 0.11.2 -> 0.11.3`                             |
| [`74b1a3d6`](https://github.com/NixOS/nixpkgs/commit/74b1a3d6e26f22f51107f5c652685311a76a7949) | `python3Packages.pytorch: 1.9.0 -> 1.10.2`                                  |