### PR TITLE
chore(flake/nixpkgs): `7c09dc2d` -> `72e32989`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1644906324,
-        "narHash": "sha256-20Di/wvWpTIUY/YzG3ibz2H9lwhYTuAIKhg872kn8nE=",
+        "lastModified": 1644950430,
+        "narHash": "sha256-eNaz6k9Gyno2nKuArhVXGtzVRInibLo2bCqOBG4JftE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7c09dc2d8a667ca8a669c03b072166fe14f35b71",
+        "rev": "72e329890a04ca23ec7bbeedd9fe0fc19a4b7f7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                     |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`72e32989`](https://github.com/NixOS/nixpkgs/commit/72e329890a04ca23ec7bbeedd9fe0fc19a4b7f7c) | `lilv: add pipewire test`                                                          |
| [`cc7c06cc`](https://github.com/NixOS/nixpkgs/commit/cc7c06cc0af0673cf4ac12a20a6f76435f19136e) | `lilv: add dev output`                                                             |
| [`9e0b3c02`](https://github.com/NixOS/nixpkgs/commit/9e0b3c024fb2275ba118b70ce4deccddf879c63e) | `cl-wordle: 0.2.0 -> 0.4.0`                                                        |
| [`60799b8e`](https://github.com/NixOS/nixpkgs/commit/60799b8ef50f75853c739b2954526355ec061bbd) | `python3Packages.dendropy: disable failing test`                                   |
| [`3723fec5`](https://github.com/NixOS/nixpkgs/commit/3723fec53b4385242a24bdcea46d9ec791af71c0) | `yq-go: 4.19.1 -> 4.20.1`                                                          |
| [`fb7eab6a`](https://github.com/NixOS/nixpkgs/commit/fb7eab6ac8e506e488d016b258a6cd212fa3aae5) | `vscode-extensions: retry if the marketplace API closes the connection unexpected` |
| [`691fc707`](https://github.com/NixOS/nixpkgs/commit/691fc7077ec25ff0295b909dc4a989fa123f0f51) | `gallery-dl: 1.20.4 -> 1.20.5`                                                     |
| [`b103bca9`](https://github.com/NixOS/nixpkgs/commit/b103bca9775237c6d04feffda99d8f90b63113be) | `python3Packages.emv: relax pycountry constraint`                                  |
| [`27c3711a`](https://github.com/NixOS/nixpkgs/commit/27c3711a5f8d890a8dee9b814a5c4a13c768ff55) | `gitstatus: 1.5.3 -> 1.5.4`                                                        |
| [`2a82287c`](https://github.com/NixOS/nixpkgs/commit/2a82287cf1aa4008801dd68ccbc1f6283c0095b4) | `libindicator: rename name to pname&version (#160010)`                             |
| [`e2856ed1`](https://github.com/NixOS/nixpkgs/commit/e2856ed17ff08920cc32669b72af3725a2d8653e) | `mdcat: 0.26.0 -> 0.26.1`                                                          |
| [`7c521003`](https://github.com/NixOS/nixpkgs/commit/7c5210039bf5f7de0bf3b1999b187aa9c5f6a4ec) | `gnome.gnome-todo: unstable-2022-01-01 -> unstable-2022-02-01`                     |
| [`8144bd30`](https://github.com/NixOS/nixpkgs/commit/8144bd3050e1f16237834fcad9f5d4c4e9afcddf) | `Fix: provide right python version instead of patching source`                     |
| [`86e32988`](https://github.com/NixOS/nixpkgs/commit/86e329884037db58578bb0fb4d8a7c42510e53d1) | `git-lfs: 3.0.2 -> 3.1.1`                                                          |
| [`ae6b8cf9`](https://github.com/NixOS/nixpkgs/commit/ae6b8cf9b3e709e1043a6a210c4a21b37bf9601d) | `elmPackages: restore positions, use makeScope, cleanup`                           |
| [`771f110d`](https://github.com/NixOS/nixpkgs/commit/771f110d9ce91561c7a8ffe006195e30dcd3656c) | `php74Extensions.blackfire: 1.72.0 -> 1.74.0`                                      |
| [`07c953ae`](https://github.com/NixOS/nixpkgs/commit/07c953ae72414208bd7344746960c9659622b161) | `orca: 41.1 -> 41.2`                                                               |
| [`5aa283f0`](https://github.com/NixOS/nixpkgs/commit/5aa283f01c3b0fda11eba139dfb9316d6d1ef733) | `python3Packages.asyncwhois: 0.4.1 -> 1.0.0`                                       |
| [`966006a0`](https://github.com/NixOS/nixpkgs/commit/966006a0ac2109f9fc68c47df277160974edeb80) | `ofono: 1.33 -> 1.34`                                                              |
| [`dc4a2782`](https://github.com/NixOS/nixpkgs/commit/dc4a27829ece9c834c40bcef6c205a32338b6c00) | `gandom-fonts: 0.6 -> 0.8`                                                         |
| [`760e49ae`](https://github.com/NixOS/nixpkgs/commit/760e49aece76cffb962f962e83a89a0db600fed8) | `gnome.gnome-maps: 41.2 -> 41.4`                                                   |
| [`d055f486`](https://github.com/NixOS/nixpkgs/commit/d055f486025159f5d1693a2f341578550cabc8a9) | `dupeguru: Use pyqt5_sip from python3.pkgs`                                        |
| [`38afa0bd`](https://github.com/NixOS/nixpkgs/commit/38afa0bd753c07e6fc4dfbc5bdec9819e15e0e21) | `hplip: Fix missing pyqt5_sip module`                                              |
| [`19f52c38`](https://github.com/NixOS/nixpkgs/commit/19f52c3818747cc1b60935ec56ae502f12a86ded) | `pyqt5_sip: init at 12.9.1`                                                        |
| [`36e6f399`](https://github.com/NixOS/nixpkgs/commit/36e6f39984200f6eeb6a494ebe197c9cc77474b3) | `pkcs11helper: 1.27 -> 1.28`                                                       |
| [`7f2880d9`](https://github.com/NixOS/nixpkgs/commit/7f2880d976ff446945b8f0daa18d322e312b96a3) | `python3Packages.p1monitor: update supported Python releases`                      |
| [`aaa9586c`](https://github.com/NixOS/nixpkgs/commit/aaa9586c1ae22c72b3a9f22604dfed81276cc262) | `montserrat: 7.210 -> 7.222`                                                       |
| [`facaf233`](https://github.com/NixOS/nixpkgs/commit/facaf23362771f717bdc3dc6cae5e75c08f08f7d) | `python3Packages.nose2: add pythonImportsCheck`                                    |
| [`5492d782`](https://github.com/NixOS/nixpkgs/commit/5492d78236333fc890abbec9cd924c186b11d1b6) | `python3Packages.pynndescent: add pythonImportsCheck`                              |
| [`860c78fd`](https://github.com/NixOS/nixpkgs/commit/860c78fd14b8e4b164ae23f0d919c54959cd759b) | `lens: 5.2.6 -> 5.3.4`                                                             |
| [`62d4c5bd`](https://github.com/NixOS/nixpkgs/commit/62d4c5bd200872780962c57890367ede3c1fb30b) | `python3Packages.identify: 2.4.9 -> 2.4.10`                                        |
| [`6067bd6a`](https://github.com/NixOS/nixpkgs/commit/6067bd6a2e3f69720dc6e8c901dfe04af5cee9d1) | `gnome.gnome-initial-setup: 41.2 -> 41.4`                                          |
| [`05c6180b`](https://github.com/NixOS/nixpkgs/commit/05c6180b5f302b8056ac8397928317a2a29d15ca) | `vimPlugins.rest-nvim: init at 2022-01-26`                                         |
| [`9a867982`](https://github.com/NixOS/nixpkgs/commit/9a8679821b113fbf71a27bdafbc9cec4f3b04c9e) | `cargo-deny: 0.11.2 -> 0.11.3`                                                     |
| [`a99b6b80`](https://github.com/NixOS/nixpkgs/commit/a99b6b807062443afb67d577b4547e3f4193072a) | `python310Packages.google-cloud-container: 2.10.3 -> 2.10.4`                       |
| [`876cd6bc`](https://github.com/NixOS/nixpkgs/commit/876cd6bcc20440ae78ac496da4f7171705062181) | `coq: misc`                                                                        |
| [`20052b80`](https://github.com/NixOS/nixpkgs/commit/20052b805ce4f2dab80ab691c516a9da66b3b693) | `checkov: 2.0.842 -> 2.0.845`                                                      |
| [`498e2d92`](https://github.com/NixOS/nixpkgs/commit/498e2d92a971036407fcca9501264815b2432b57) | `python3Packages.intellifire4py: 0.9.7 -> 0.9.8`                                   |
| [`c70f92b7`](https://github.com/NixOS/nixpkgs/commit/c70f92b77a8312ec8bc22db3aea27cb3020d03cc) | `python3Packages.mypy-boto3-s3: add format`                                        |
| [`8a439961`](https://github.com/NixOS/nixpkgs/commit/8a439961242c7c88df23543a9d6d471636a9b193) | `gotop: 4.1.2 -> 4.1.3`                                                            |
| [`ff3bfb76`](https://github.com/NixOS/nixpkgs/commit/ff3bfb7608a61dc60235f71d7b3b5a8047a73951) | `python3Packages.pyowm: add format`                                                |
| [`18d9d660`](https://github.com/NixOS/nixpkgs/commit/18d9d6600dbe1d5904d8169d3eb92d3f8d225941) | `python310Packages.flux-led: 0.28.25 -> 0.28.26`                                   |
| [`152dd4c8`](https://github.com/NixOS/nixpkgs/commit/152dd4c81daa1c24d6ff65c3771070e8f4f7f098) | `nixos/kubernetes: Update deprecated scheduler opts`                               |
| [`ee88cb92`](https://github.com/NixOS/nixpkgs/commit/ee88cb928d133dd446b4141911ff8c9f187202c6) | `python310Packages.sense-energy: 0.10.1 -> 0.10.2`                                 |
| [`0c66a2f3`](https://github.com/NixOS/nixpkgs/commit/0c66a2f30dae9c99dd2acdb376ffe70f3d3386a2) | `archivebox: refactor and fix`                                                     |
| [`90270592`](https://github.com/NixOS/nixpkgs/commit/902705927a61ed68911d8017a262728c1ac263e9) | `maintainers: update @novoxd github login`                                         |
| [`4c129894`](https://github.com/NixOS/nixpkgs/commit/4c1298943b123012433bc8b5b4269229a3774da6) | `dupeguru: 4.0.4 -> 4.1.1`                                                         |
| [`1eebfebd`](https://github.com/NixOS/nixpkgs/commit/1eebfebda542cca603079d556e37c2242e581b25) | `python310Packages.jdatetime: 3.8.2 -> 4.0.0`                                      |
| [`7c08af79`](https://github.com/NixOS/nixpkgs/commit/7c08af790f6b058f90e40928d2809f532bfd5f54) | `podman-tui: init at 0.1.0`                                                        |
| [`6f9cf70a`](https://github.com/NixOS/nixpkgs/commit/6f9cf70a4829a593bc3e419f3b98adccb4de2982) | `jc: 1.18.2 -> 1.18.3`                                                             |
| [`da9c48b2`](https://github.com/NixOS/nixpkgs/commit/da9c48b2cf38800c8df24fff903cd047473fb742) | `python310Packages.pyowm: 3.2.0 -> 3.3.0`                                          |
| [`0fb241ed`](https://github.com/NixOS/nixpkgs/commit/0fb241ed2e981073df4c32e8f4c931d04f997762) | `janus-gateway: 0.11.7 -> 0.11.8`                                                  |
| [`592c073a`](https://github.com/NixOS/nixpkgs/commit/592c073afd3026b772cf28f83b47e98fe5d530c5) | `maintainers: add aaronjheng`                                                      |
| [`46a77c08`](https://github.com/NixOS/nixpkgs/commit/46a77c081265a0795eeca87b8530ec803fcddb92) | `python310Packages.google-cloud-bigquery-datatransfer: 3.5.0 -> 3.6.0`             |
| [`27d8498e`](https://github.com/NixOS/nixpkgs/commit/27d8498eeee3b84aef15aef79be0cb812f38c232) | `xf86_input_wacom: 0.40.0 -> 1.0.0`                                                |
| [`16298a93`](https://github.com/NixOS/nixpkgs/commit/16298a931ecf6af478e895d8dcaa57def7b3a6e3) | `alejandra: unstable-2022-02-12 -> 0.1.0`                                          |
| [`2b986027`](https://github.com/NixOS/nixpkgs/commit/2b986027a453d81f30ba5a55e28c0bbcb3070dfd) | `python310Packages.mypy-boto3-s3: 1.20.49 -> 1.21.0`                               |
| [`46dd7f68`](https://github.com/NixOS/nixpkgs/commit/46dd7f68f389543178956c78420a0631e37dfc48) | `amazon-qldb-shell: init at 2.0.0`                                                 |
| [`acfd0f66`](https://github.com/NixOS/nixpkgs/commit/acfd0f66fa1439637b3bf5b5649f6fb1af6c9c2c) | `plexamp: 3.9.1 -> 4.0.0`                                                          |
| [`c90a20d3`](https://github.com/NixOS/nixpkgs/commit/c90a20d38e714bf2fc212b047d9010e7acd40951) | `delta: 0.11.3 -> 0.12.0`                                                          |
| [`c1c60661`](https://github.com/NixOS/nixpkgs/commit/c1c60661851614b8369d173f8258b7f73640d70b) | `hplip: 3.20.11 -> 3.21.12`                                                        |
| [`61cce0f2`](https://github.com/NixOS/nixpkgs/commit/61cce0f23c2e872cd7472ed9c95329782d6cc75c) | `google-clasp: use nodePackages."@google/clasp"`                                   |
| [`973855b8`](https://github.com/NixOS/nixpkgs/commit/973855b8430663750aa5376b5ce3b4c0977fc42c) | `nodePackages."@google/clasp": init at 2.4.1`                                      |
| [`989f47d4`](https://github.com/NixOS/nixpkgs/commit/989f47d49e0b2e14004bfeb2b3983f4027305c1f) | `nodePackages: update`                                                             |
| [`59806bca`](https://github.com/NixOS/nixpkgs/commit/59806bca6a11488b5239739de817c9b321abc605) | `lziprecover: 1.22 -> 1.23`                                                        |
| [`40f93dc9`](https://github.com/NixOS/nixpkgs/commit/40f93dc95e946a91eb5380499fdb999de71c16ee) | `checkov: 2.0.833 -> 2.0.842`                                                      |
| [`9fdbf32f`](https://github.com/NixOS/nixpkgs/commit/9fdbf32f1a031d15967fc42394f4442511b27986) | `gns3-gui: fix build`                                                              |
| [`228b4d51`](https://github.com/NixOS/nixpkgs/commit/228b4d51e17f071121701a750df01cf5d2e2d164) | `libplctag: 2.4.12 -> 2.5.0`                                                       |
| [`449cde71`](https://github.com/NixOS/nixpkgs/commit/449cde714d46dc6766781a7e30e4a1cd1bbd375b) | `smpeg: rename name to pname&version`                                              |
| [`056b9458`](https://github.com/NixOS/nixpkgs/commit/056b94582a4470f067c9e9e4e64bcc86fceb89ba) | `retext: 7.0.4 -> 7.2.3`                                                           |
| [`caa34f16`](https://github.com/NixOS/nixpkgs/commit/caa34f1650df5b9127e31bed7ad0130dd4427369) | `buildpack: 0.23.0 -> 0.24.0`                                                      |
| [`e6deab9c`](https://github.com/NixOS/nixpkgs/commit/e6deab9c39123a125e4a5be46ef7dc1a8dcf7370) | `python3Packages.markups: rename`                                                  |
| [`20862876`](https://github.com/NixOS/nixpkgs/commit/208628765626cd4e06017ec0ebed4492473aea05) | `python3Packages.Markups: disable failing test`                                    |
| [`fe046a11`](https://github.com/NixOS/nixpkgs/commit/fe046a112d3e8c8acaeb7f2e70a32c1afb9f1448) | `python3Packages.textile: init at 4.0.2`                                           |
| [`bfa38e4c`](https://github.com/NixOS/nixpkgs/commit/bfa38e4c1a6155067c71bbfa0e29188f31cd3426) | `git-machete: 3.5.0 -> 3.7.2`                                                      |
| [`1fc19f2f`](https://github.com/NixOS/nixpkgs/commit/1fc19f2f527143a80393ca68ba384226acc0db5b) | `python3Packages.ibis-framework: relax atpublic constraint`                        |
| [`a4916af1`](https://github.com/NixOS/nixpkgs/commit/a4916af11c80b30add8b854bdadf7a37463d76ff) | `python3Packages.flask-appbuilder: 3.4.3 -> 3.4.4`                                 |
| [`e4b0bbb3`](https://github.com/NixOS/nixpkgs/commit/e4b0bbb36e6251dcbd51fec429b87ee0cef590cc) | `python3Packages.globus-sdk: 3.2.1 -> 3.4.1`                                       |
| [`3c583540`](https://github.com/NixOS/nixpkgs/commit/3c583540a8f68f4fbd2fb660b20a467e90f20519) | `python3Packages.xxh: limit the supported Python releases`                         |
| [`6160b005`](https://github.com/NixOS/nixpkgs/commit/6160b005e007aac8a06ee425d6d7c98427758e51) | `tribler: remove local apispec`                                                    |
| [`3bbd6325`](https://github.com/NixOS/nixpkgs/commit/3bbd6325b21ac33fa2c93ea31eef6b1f1ffed792) | `python3Packages.aiohttp-apispec: enable tests`                                    |
| [`e0f783ca`](https://github.com/NixOS/nixpkgs/commit/e0f783ca387bddfdddc3340eb3503df4da9fb10e) | `python3Packages.aiohttp-apispec: 2.2.2 -> 3.0.0b1`                                |
| [`6833b1a1`](https://github.com/NixOS/nixpkgs/commit/6833b1a1a76752de5d9d2ee207255afa7d66740b) | `ocoprint: fix build due to recent python upgrades`                                |
| [`d584164d`](https://github.com/NixOS/nixpkgs/commit/d584164d24ebe8caa1cf6d753f7c55765e4ec680) | `python3Packages.aiohttp-apispec: move to python-modules`                          |
| [`cf266b99`](https://github.com/NixOS/nixpkgs/commit/cf266b999fb0227cdf037ab6a56097149ef2e8d6) | `python310Packages.xxh: 0.8.8 -> 0.8.9`                                            |
| [`3aa8b1af`](https://github.com/NixOS/nixpkgs/commit/3aa8b1af4540a21829013f609579fbd96f91fbe6) | `python3Packages.sentry-sdk: 1.5.4 -> 1.5.5`                                       |
| [`1ce46a88`](https://github.com/NixOS/nixpkgs/commit/1ce46a885ea7df707c28d07d87412387f0424770) | `python310Packages.approvaltests: 3.5.0 -> 3.6.0`                                  |
| [`3db630a0`](https://github.com/NixOS/nixpkgs/commit/3db630a0bdbc059071076a4f0c98bb52c78019dd) | `python39Packages.pynndescent: 0.5.5 -> 0.5.6`                                     |
| [`f2c0615e`](https://github.com/NixOS/nixpkgs/commit/f2c0615ee7e1267bfde094f0356bd3e8d9c7ffaf) | `python39Packages.nose2: 0.10.0 -> 0.11.0`                                         |
| [`8ea36e10`](https://github.com/NixOS/nixpkgs/commit/8ea36e1056356f7e9dc9a0ccfc9541abad66e118) | `nfpm: 2.12.2 -> 2.13.0`                                                           |
| [`b5efa36c`](https://github.com/NixOS/nixpkgs/commit/b5efa36c5ed0ec344061f003cb452346d1e79742) | `mdcat: 0.25.1 -> 0.26.0`                                                          |
| [`258a05b4`](https://github.com/NixOS/nixpkgs/commit/258a05b4271607f1b7296a81ccff79fbf0807878) | `kanboard: 1.2.21 -> 1.2.22`                                                       |
| [`2551494d`](https://github.com/NixOS/nixpkgs/commit/2551494d202cc3c1bc4050848dbfe2cb99850a04) | `earthly: 0.6.5 -> 0.6.7`                                                          |
| [`b9b86016`](https://github.com/NixOS/nixpkgs/commit/b9b86016fd81c5cb09bc4e40039334376d000838) | `kalendar: 0.4.0 -> 1.0.0`                                                         |
| [`5eaa1214`](https://github.com/NixOS/nixpkgs/commit/5eaa121444d880fb8cf6fe4f371721be8347afd4) | `tvm: 0.7.0 -> 0.8.0`                                                              |
| [`9ac1f8e1`](https://github.com/NixOS/nixpkgs/commit/9ac1f8e165678cbc28fd81fe0794e35515c949fd) | `topicctl: 1.2.0 -> 1.3.1`                                                         |
| [`2d505e91`](https://github.com/NixOS/nixpkgs/commit/2d505e91371a3a1c1a1de62a958a4f0b94a1c47c) | `qbec: 0.14.8 -> 0.15.1`                                                           |
| [`1f38e43e`](https://github.com/NixOS/nixpkgs/commit/1f38e43ea8ae5c6535e49a2aaab0a5be0091a667) | `operator-sdk: 1.12.0 -> 1.17.0`                                                   |
| [`1d595eac`](https://github.com/NixOS/nixpkgs/commit/1d595eac03a23dca6ba81997820c3f1ec56c7f35) | `opentelemetry-collector-contrib: 0.43.0 -> 0.44.0`                                |
| [`4317fb02`](https://github.com/NixOS/nixpkgs/commit/4317fb02ff1df6f29bb0b201b3ab48abd3f82740) | `opentelemetry-collector: 0.43.1 -> 0.44.0`                                        |
| [`e51bb574`](https://github.com/NixOS/nixpkgs/commit/e51bb574bb7af3bce1bc2f10d47a1a4176ac5179) | `nix-build-uncached: 1.1.0 -> 1.1.1`                                               |
| [`29510f4e`](https://github.com/NixOS/nixpkgs/commit/29510f4ec8192ce4104ef8856cdf122192a23d36) | `obs-studio-plugins.obs-multi-rtmp: 0.2.7.1 -> 0.2.8.1`                            |
| [`86347464`](https://github.com/NixOS/nixpkgs/commit/863474645bb73c4b63360f9d5b906665f866b16a) | `mycorrhiza: 1.7.0 -> 1.8.1`                                                       |
| [`a1f6ee07`](https://github.com/NixOS/nixpkgs/commit/a1f6ee078b182ac269e96b911bee7c6b3ed6c251) | `arkade: 0.8.12 -> 0.8.14`                                                         |
| [`853c6ca7`](https://github.com/NixOS/nixpkgs/commit/853c6ca71b22bf08b02e0560592d34b0b5d0d337) | `memcached: 1.6.12 -> 1.6.14`                                                      |
| [`2fea3f30`](https://github.com/NixOS/nixpkgs/commit/2fea3f30b571a60f78b2c3fa2aac5c005cf94cf2) | `kubernetes: 1.22.6 -> 1.23.3`                                                     |
| [`377f4b2f`](https://github.com/NixOS/nixpkgs/commit/377f4b2f0b8329697d9e2f14ff4d7fc1fd534b04) | `prosody: optional luaEnv customization`                                           |
| [`16d0b4a6`](https://github.com/NixOS/nixpkgs/commit/16d0b4a69f94adb523da8732b231b0d1738bd713) | `prosody: work around makeWrapper bug`                                             |
| [`0c1cf5c7`](https://github.com/NixOS/nixpkgs/commit/0c1cf5c7b44ccc3e29c321a607cc00669a51a0a3) | `prosody: set lua env in wrapper`                                                  |
| [`877f1347`](https://github.com/NixOS/nixpkgs/commit/877f1347ce3bb8bc5e95f4c446d5fddb85564d9f) | `gns3-server: fix build, use buildPythonApplication`                               |
| [`47eb36c1`](https://github.com/NixOS/nixpkgs/commit/47eb36c19198b7c1116a68e977b4cebce611eb80) | `geonkick: 2.8.0 -> 2.8.1`                                                         |
| [`db4690e9`](https://github.com/NixOS/nixpkgs/commit/db4690e97aa9f661649e23d88fb463ee27bfc46c) | `insomnia: remove gconf dependency`                                                |
| [`8430d38b`](https://github.com/NixOS/nixpkgs/commit/8430d38becf067b6f280d206ea638a0493fd989e) | `cypress: remove gconf dependency`                                                 |
| [`ca01d7a6`](https://github.com/NixOS/nixpkgs/commit/ca01d7a6b293a887652793b53d069e121cbc303d) | `slack: remove gconf dependency`                                                   |
| [`c3bd37b2`](https://github.com/NixOS/nixpkgs/commit/c3bd37b2af89f5d35551795812ad21fd64776081) | `skypeforlinux: remove gconf dependency`                                           |
| [`4883f070`](https://github.com/NixOS/nixpkgs/commit/4883f0707440427523ea6ad7c2daedbf3acef7fe) | `signal-desktop: remove gconf dependency`                                          |
| [`1ea5cf23`](https://github.com/NixOS/nixpkgs/commit/1ea5cf23a18f4fd4269dda82dcf793b5b5debff2) | `gitter: remove gconf dependency`                                                  |
| [`f73ec5d6`](https://github.com/NixOS/nixpkgs/commit/f73ec5d6c6833d54341c7f55f07af92d9d8dbbe0) | `unityhub: remove gconf dependency`                                                |
| [`2503c5d9`](https://github.com/NixOS/nixpkgs/commit/2503c5d9cefd1980d5587be89aa213296b1424f5) | `franz: remove gconf dependency`                                                   |
| [`129dafb3`](https://github.com/NixOS/nixpkgs/commit/129dafb38235bbf1d4624a05122f23732125480e) | `mullvad-vpn: remove gconf dependency`                                             |
| [`811ad0e5`](https://github.com/NixOS/nixpkgs/commit/811ad0e5e81555c24bee4b3a85cd933b9e3c891e) | `vivaldi: remove gconf dependency`                                                 |
| [`9e0d4936`](https://github.com/NixOS/nixpkgs/commit/9e0d493664b20c336a726657ff75919769a61d19) | `opera: remove gconf dependency`                                                   |
| [`a30aecca`](https://github.com/NixOS/nixpkgs/commit/a30aeccad6b98a2e990f07fd66cd0ad42d35c0b0) | `icecat: remove gconf dependency`                                                  |
| [`92660774`](https://github.com/NixOS/nixpkgs/commit/926607745d885c48bfbd710138479c666df765dc) | `brave: remove gconf dependency`                                                   |
| [`c5c04b8d`](https://github.com/NixOS/nixpkgs/commit/c5c04b8d08bc3b35955e4d597605b16cca67f88e) | `mongodb-compass: remove gconf dependency`                                         |
| [`6a56488e`](https://github.com/NixOS/nixpkgs/commit/6a56488e1787557d65f1435d0180622481d41927) | `nwjs: remove gconf dependency`                                                    |
| [`5c814b40`](https://github.com/NixOS/nixpkgs/commit/5c814b404dccf844236d05f2dfa02ced07b0aa28) | `chromedriver: remove gconf dependency`                                            |
| [`3b0e22f1`](https://github.com/NixOS/nixpkgs/commit/3b0e22f1e7657786b7c62ece8cca114d2bb71022) | `google-chrome: remove gconf dependency`                                           |
| [`2d123001`](https://github.com/NixOS/nixpkgs/commit/2d123001fbc1771b5be3813c0b5403dc7f8cddfb) | `phrase-cli: init at 2.4.4`                                                        |
| [`24d93503`](https://github.com/NixOS/nixpkgs/commit/24d9350347766daaebb74de2daadf813e7ec5429) | `maintainers: add juboba`                                                          |
| [`91c7b737`](https://github.com/NixOS/nixpkgs/commit/91c7b7370748b45f883ad1d80ee5b16df4588d4e) | `nixos/input-remapper: add release note`                                           |
| [`93d8783a`](https://github.com/NixOS/nixpkgs/commit/93d8783ad6fa49f7024568e9785074d2fc5ffc35) | `nixos/input-remapper: init`                                                       |
| [`639ff4f2`](https://github.com/NixOS/nixpkgs/commit/639ff4f23c3191d53d7add71f2ef109c0f6d7163) | `input-remapper: init at unstable-2022-02-09`                                      |
| [`fbc2b41e`](https://github.com/NixOS/nixpkgs/commit/fbc2b41e3e9d7c24a11d10fe8e4b5c7dab47febb) | `maintainers: add LunNova`                                                         |
| [`5f909309`](https://github.com/NixOS/nixpkgs/commit/5f909309d2243cf9f8e22b2ad54e581d4894c84a) | `hydrus: 472 -> 473`                                                               |
| [`bc344bda`](https://github.com/NixOS/nixpkgs/commit/bc344bda398f9b305e5b26ac6981fbf0ce30f9ef) | `lemonade: init at unstable-2021-06-18`                                            |
| [`4f0170c1`](https://github.com/NixOS/nixpkgs/commit/4f0170c1e72acdcb660e423f9679520a88c4fdba) | `mattermost: 6.3.2 -> 6.3.3`                                                       |
| [`f3cc015b`](https://github.com/NixOS/nixpkgs/commit/f3cc015b87ffad59c38f91ffe4d84a66e90964b9) | `prometheus: Optionally remove more service discovery.`                            |
| [`d44a7cbf`](https://github.com/NixOS/nixpkgs/commit/d44a7cbfbc063e818d3c2282d10ab8c76f54a15b) | `Update pkgs/applications/audio/sptlrx/default.nix`                                |
| [`7d656c99`](https://github.com/NixOS/nixpkgs/commit/7d656c99c029fafdcff31eeeacaf34941a5c1afb) | `sptlrx: init at 0.1.0`                                                            |
| [`175cc7ef`](https://github.com/NixOS/nixpkgs/commit/175cc7efd2a4ae5d76df1e184ffe636633c0694d) | `prometheus: Optionally remove service discovery.`                                 |
| [`9bb910ed`](https://github.com/NixOS/nixpkgs/commit/9bb910edb044756d0cd494dd18c7f06cd931e428) | `yuzu-ea: 2156 -> 2432`                                                            |