### PR TITLE
chore(flake/impermanence): `ff540dbe` -> `bc3376a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -105,11 +105,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1644014516,
-        "narHash": "sha256-PkD35S6lduaU6mLcraFY0vj608RPv1kQp5uaFd/s26o=",
+        "lastModified": 1644608592,
+        "narHash": "sha256-pgHgpslRmMFHSfKo9gIAk9g6xxWn51nvjSfxSgX6Tpw=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "ff540dbe20556f6119d80f5c79796a0698a4ee38",
+        "rev": "bc3376a8e5ede458b14ccb7fb3fc680bf870f4d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                      |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`7a36ba92`](https://github.com/nix-community/impermanence/commit/7a36ba9279fe8abccf5be2820bd60d4ec9d86207) | `Add default NixOS module to flake` |