### PR TITLE
chore(flake/home-manager): `6d9d9294` -> `44934a1a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1644534280,
-        "narHash": "sha256-Gzf/Jq/F1vvTp6XkzPU+pBCj3OSAFLiR7f0ptwRseiI=",
+        "lastModified": 1644706031,
+        "narHash": "sha256-R+y9dbh5IR+SF9yjEWd9fbwjlCv2S4ZOp98AyJraAWM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6d9d9294d09b5e88df65f8c6651efb8a4d7d2476",
+        "rev": "44934a1a9107922a4cbdb8966ca5eff2312ce128",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`4160629a`](https://github.com/nix-community/home-manager/commit/4160629af7b66066726ba948660645b0a17c87b3) | `Translate using Weblate (Turkish)`        |
| [`ae95406f`](https://github.com/nix-community/home-manager/commit/ae95406f86c3d2b023822b0487df71673ce35092) | `Translate using Weblate (Turkish)`        |
| [`54c2cf7f`](https://github.com/nix-community/home-manager/commit/54c2cf7fb8183f88aec179e7efe54deed93d27fa) | `Translate using Weblate (Japanese)`       |
| [`37f0a161`](https://github.com/nix-community/home-manager/commit/37f0a161a03d32ea10c0e1402339b23b1df6bfaf) | `Add translation using Weblate (Turkish)`  |
| [`be7f132a`](https://github.com/nix-community/home-manager/commit/be7f132a125aea7922dae1814d04e6de8710fc83) | `Add translation using Weblate (Turkish)`  |
| [`b784f588`](https://github.com/nix-community/home-manager/commit/b784f588eed7ad260e588717b57c27662ce23a42) | `Translate using Weblate (Japanese)`       |
| [`68cf4bef`](https://github.com/nix-community/home-manager/commit/68cf4bef2e5fecdcc2546f182f659517cc8700fb) | `Translate using Weblate (Japanese)`       |
| [`ec5c5ae9`](https://github.com/nix-community/home-manager/commit/ec5c5ae9a8069f1479d2f1ae093dadfca7c25399) | `Translate using Weblate (Japanese)`       |
| [`e448c3c1`](https://github.com/nix-community/home-manager/commit/e448c3c1232065eb225bdd7d31a805610233a73d) | `Add translation using Weblate (Japanese)` |
| [`a2363ceb`](https://github.com/nix-community/home-manager/commit/a2363ceb1d4f8ee17d23e9b00d7d2930f76cddde) | `Translate using Weblate (Japanese)`       |