### PR TITLE
chore(flake/home-manager): `7c2ae0bd` -> `50204cea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1644706973,
-        "narHash": "sha256-xOyxrhc5V79u0ZNmnPmJbY3ngtp43dNISEmrb8Ie6wQ=",
+        "lastModified": 1644961661,
+        "narHash": "sha256-x1XdER7VT4jqePCWGGutPL46OxJyw8EGFF3rBn0rsuo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7c2ae0bdd20ddcaafe41ef669226a1df67f8aa06",
+        "rev": "50204cea940ffe8aa479c255e84ba1f633084a13",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`50204cea`](https://github.com/nix-community/home-manager/commit/50204cea940ffe8aa479c255e84ba1f633084a13) | `completion.*: add flake-related arguments`   |
| [`23a9f912`](https://github.com/nix-community/home-manager/commit/23a9f9127c3975fd3c25869c55a6014ee2aefaeb) | `home-manager: add more pass-through options` |
| [`03b74951`](https://github.com/nix-community/home-manager/commit/03b7495183e86e3d71852975697dcb7ac8779811) | `docs: fix typo and clarify`                  |