### PR TITLE
chore(flake/nixpkgs): `72e32989` -> `4687b2ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1644950430,
-        "narHash": "sha256-eNaz6k9Gyno2nKuArhVXGtzVRInibLo2bCqOBG4JftE=",
+        "lastModified": 1644992370,
+        "narHash": "sha256-6UmwHOboRwAUMyGNA+vBihf8mDW+paeKXtJkIPXQTog=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "72e329890a04ca23ec7bbeedd9fe0fc19a4b7f7c",
+        "rev": "4687b2ed82c90c135595cc0487b12d643991d542",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                       |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`4bfaf285`](https://github.com/NixOS/nixpkgs/commit/4bfaf285378b17f49eeae930f43065abbe89c94d) | ``tex.dblatex: remove legacy `? null` and assert``                   |
| [`9dee6cdb`](https://github.com/NixOS/nixpkgs/commit/9dee6cdb29175f464d640984eaf15017926072b0) | `snarkos: 2.0.1 -> 2.0.2 (#160227)`                                  |
| [`e7793302`](https://github.com/NixOS/nixpkgs/commit/e77933024d340885de3a4d55aa4f6d2de47dbabf) | `haveged: 1.9.15 -> 1.9.17`                                          |
| [`32bd0aaf`](https://github.com/NixOS/nixpkgs/commit/32bd0aafab0076ef09a3f256f61240c05daa0f4d) | `nixos/tests/home-assistant: test package and components passing`    |
| [`3f8ddef9`](https://github.com/NixOS/nixpkgs/commit/3f8ddef902ab472c2b4d4de18123c114df3f7d2c) | `home-assistant: expose installed extraPackages and extraComponents` |
| [`c1d20422`](https://github.com/NixOS/nixpkgs/commit/c1d2042219f20d169c415096aa1228162433ba77) | `home-assistant: clean up preStart`                                  |
| [`2f644fd3`](https://github.com/NixOS/nixpkgs/commit/2f644fd3e6e0e553b2a215b832128dcd2332f61c) | `nixos/home-assistant: add rpi_power component by default on arm`    |
| [`191fb818`](https://github.com/NixOS/nixpkgs/commit/191fb818e61d3d3682bccaa9a867f082396488dc) | `nixos/tests/home-assistant: test module-based package loading`      |
| [`918100f4`](https://github.com/NixOS/nixpkgs/commit/918100f48f76152fbfcf20689af33288067d1122) | `nixos/home-assistant: Wait for {mysql,postgresql}.service`          |
| [`13faa004`](https://github.com/NixOS/nixpkgs/commit/13faa004b65c15a5a687db38943eb34347e20479) | `nixos/home-assistant: add extraPackages option`                     |
| [`4b47eaee`](https://github.com/NixOS/nixpkgs/commit/4b47eaee4ddabffc96a0f368a09670c46c93945f) | `nixos/tests/home-assistant: test module-based component loading`    |
| [`4a0b964b`](https://github.com/NixOS/nixpkgs/commit/4a0b964b34c5ace3071a2fa3a0160ef179314893) | `nixos/home-assistant: add extraComponents option`                   |
| [`59a367bc`](https://github.com/NixOS/nixpkgs/commit/59a367bcabae16ec0c18df29fda4b09dfa36ba53) | `nixos/home-assistant: convert to rfc42 style settings`              |
| [`2c19ae1e`](https://github.com/NixOS/nixpkgs/commit/2c19ae1e4d8f232883ecf5ffbce68edd955384b8) | `plocate: 1.1.14 -> 1.1.15`                                          |
| [`05640ec1`](https://github.com/NixOS/nixpkgs/commit/05640ec19d610ab00109d74fc77c7d10d4909577) | `nixos/tests/home-assistant: add comments & reformat`                |
| [`9896247f`](https://github.com/NixOS/nixpkgs/commit/9896247fb6d2c646f19fcd90ade45d6abd89930b) | `nixos/home-assistant: Wait for network-online.target`               |
| [`82f0df4d`](https://github.com/NixOS/nixpkgs/commit/82f0df4d688315fd0ce4d4e850fc4dab47ee5741) | `home-assistant: drop patch that ignores OSErrors in hass fixture`   |
| [`5aabba49`](https://github.com/NixOS/nixpkgs/commit/5aabba490e4a6001b9bda3f485210cdbec7e2d28) | `nixos/home-assistant: update default package example`               |
| [`42c09098`](https://github.com/NixOS/nixpkgs/commit/42c09098485931abe5051021fb6986fe6f8fa072) | `nixos/home-assistant: move module into home-automation category`    |
| [`7a632f5c`](https://github.com/NixOS/nixpkgs/commit/7a632f5c1d698e75d10830a763fb2c9082c11b4d) | `fpp: 0.9.2 -> 0.9.5`                                                |
| [`cac31887`](https://github.com/NixOS/nixpkgs/commit/cac3188706f34691fa07d10fe89e274439503eed) | `gh: 2.5.0 -> 2.5.1`                                                 |
| [`7ff1fdfc`](https://github.com/NixOS/nixpkgs/commit/7ff1fdfc7834c3a616a1f70a4e70eaf78fdadb80) | `opencbm: 0.4.99.103 -> 0.4.99.104`                                  |
| [`c3f2886c`](https://github.com/NixOS/nixpkgs/commit/c3f2886c7929e7a16fc26637a793b01a2e7f80f3) | `semver-tool: 3.2.0 -> 3.3.0`                                        |
| [`73ba387f`](https://github.com/NixOS/nixpkgs/commit/73ba387fc13b17cfc67423ea902e9be28a4c831d) | `zbar: enable parallel building`                                     |
| [`7f949060`](https://github.com/NixOS/nixpkgs/commit/7f94906083b34e061f221a1aa4a41a0fcbc7374a) | `formula: init at 2.0`                                               |
| [`9f7d08df`](https://github.com/NixOS/nixpkgs/commit/9f7d08df91168280bfe51e3ab6c651bb0c43ffd8) | `tailwind: add support for plugins`                                  |
| [`54f2fb8c`](https://github.com/NixOS/nixpkgs/commit/54f2fb8ce125393faf6cd002df4b92684cd05e98) | `python3Packages.cirq-rigetti: relax dependency constraints`         |
| [`2606caad`](https://github.com/NixOS/nixpkgs/commit/2606caade968b8988ecdbb9f771e35c2441591f9) | `python3Packages.pyquil: 3.0.1 -> 3.1.0`                             |
| [`10cf978c`](https://github.com/NixOS/nixpkgs/commit/10cf978c5b6c87f937975408788de14fc963fae4) | `icecat-bin: drop`                                                   |
| [`3d713efe`](https://github.com/NixOS/nixpkgs/commit/3d713efe41ebcca0ebc6ff16dac958cdf3f4ac2d) | `nixos/switch-to-configuration: avoid Array::Compare dependency`     |
| [`5096ad4c`](https://github.com/NixOS/nixpkgs/commit/5096ad4c496cd1d9035cc5f36f01c7c2a39e5248) | `perlPackages.HashStoredIterator: init at 0.008`                     |
| [`b9ca8734`](https://github.com/NixOS/nixpkgs/commit/b9ca873473bf3e934ec7d425d7aad9808d4cdc10) | `python3Packages.net2grid: init at 2.0.0`                            |
| [`6e6c0b08`](https://github.com/NixOS/nixpkgs/commit/6e6c0b086dde14a032302cad6ce41e5d829139a3) | `python3Packages.eiswarnung: init at 1.0.0`                          |
| [`e571aac1`](https://github.com/NixOS/nixpkgs/commit/e571aac18e5504ca14f0a7599f73ee0b8d65cd6f) | `python3Packages.autarco: init at 0.1.0`                             |
| [`f7e01145`](https://github.com/NixOS/nixpkgs/commit/f7e01145afe002d043f49bf2f5509f56d95fbe07) | `gradle: Update hashes of dependents for 7.4`                        |
| [`555e7133`](https://github.com/NixOS/nixpkgs/commit/555e71335641d3613f19ca0dc266996e5b33b793) | `gradle: 7.3.3 -> 7.4`                                               |
| [`507b23f0`](https://github.com/NixOS/nixpkgs/commit/507b23f0d1f21923dd29ebd889f06375c16343a0) | `chemtool: Set platforms to linux`                                   |
| [`099fefbc`](https://github.com/NixOS/nixpkgs/commit/099fefbcebd685a53ef02ecddb3c9c909e04d726) | `jmol: 14.32.6 -> 14.32.21`                                          |
| [`12f6d0d3`](https://github.com/NixOS/nixpkgs/commit/12f6d0d3a099751f0f1ba2113907aadc042dc649) | `transfig: Remove package, replaced with fig2dev`                    |
| [`e8f39149`](https://github.com/NixOS/nixpkgs/commit/e8f3914985b238f21d32bf6f8c83ebff88c2be8d) | `treewide: Replace transfig with fig2dev`                            |
| [`0ee46299`](https://github.com/NixOS/nixpkgs/commit/0ee4629994945361353a8e30fcaf164203be689a) | `fig2dev: Enable transfig binary`                                    |
| [`0806fcb9`](https://github.com/NixOS/nixpkgs/commit/0806fcb901ac1035836fa6990b926cefcab10b16) | `fig2dev: Set platforms to unix`                                     |
| [`75a3c2b9`](https://github.com/NixOS/nixpkgs/commit/75a3c2b9eea32398f7cc865b6facb3c80cddebfe) | `circup: init at 1.0.3`                                              |
| [`a023ae01`](https://github.com/NixOS/nixpkgs/commit/a023ae01ccbe652b477e2bce596cc23ad3f9e00f) | `python3Packages.findimports: init at 2.2.0`                         |
| [`b95eb610`](https://github.com/NixOS/nixpkgs/commit/b95eb610d4101e51c9e7bdb045bcd29f03e35cea) | `rakudo: 2021.12 -> 2022.02`                                         |
| [`16c797e8`](https://github.com/NixOS/nixpkgs/commit/16c797e8da1bb409fd1d3d2518bb0479b7f1fe6e) | `moarvm: 2021.12 -> 2022.02`                                         |
| [`9efc7c01`](https://github.com/NixOS/nixpkgs/commit/9efc7c01f072eae3ff14e0877005268347130887) | `nqp: 2021.12 -> 2022.02`                                            |
| [`4be6e3e9`](https://github.com/NixOS/nixpkgs/commit/4be6e3e90de83787e23e86d5f41e7769d995930b) | `python3Packages.aiopyarr: init at 22.2.1`                           |
| [`71bcac92`](https://github.com/NixOS/nixpkgs/commit/71bcac92f37d1d06e516a50b9619e941f35fa3d1) | `zettlr: 2.1.3 -> 2.2.1`                                             |
| [`25a935a9`](https://github.com/NixOS/nixpkgs/commit/25a935a9aa54220ce85bbe741183fe5799310da3) | `vivaldi: 5.0.2497.51-1 -> 5.1.2567.39-1`                            |
| [`c7aa4409`](https://github.com/NixOS/nixpkgs/commit/c7aa4409336c3da6907e890d18eda792c5a78662) | `rpg-cli: 1.0.0 -> 1.0.1`                                            |
| [`aaf2c5a9`](https://github.com/NixOS/nixpkgs/commit/aaf2c5a99a5ab15ea7bc0f4d3e41a8a9af21d5f4) | `regbot: 0.3.8 -> 0.3.10`                                            |
| [`9798f38c`](https://github.com/NixOS/nixpkgs/commit/9798f38c851b593f4c40e568639bd5de2b3e667a) | `primesieve: 7.7 -> 7.8`                                             |
| [`2d54c0f3`](https://github.com/NixOS/nixpkgs/commit/2d54c0f37b5edf8c530bb38a536a0506c822bfd6) | `nanoflann: 1.3.2 -> 1.4.2`                                          |
| [`f1684271`](https://github.com/NixOS/nixpkgs/commit/f1684271848f2faf83b948b56af645ecdbad6484) | `mani: 0.11.1 -> 0.12.0`                                             |
| [`f441e459`](https://github.com/NixOS/nixpkgs/commit/f441e459a079ea80d77f142ec819d1be7e56499b) | `darktable: 3.8.0 -> 3.8.1`                                          |
| [`068c36f8`](https://github.com/NixOS/nixpkgs/commit/068c36f83b0c922d4026711b392d6c2a55ae3b05) | `gnomeExtensions.arcmenu: 20 -> 21`                                  |
| [`2de7302d`](https://github.com/NixOS/nixpkgs/commit/2de7302ded3f52c8c712e086fe84be525d70322b) | `enlightenment.enlightenment: 0.25.1 -> 0.25.3`                      |
| [`8a65a94a`](https://github.com/NixOS/nixpkgs/commit/8a65a94a87f5e454f5c8cd1f5da646c53eb4cadf) | `enlightenment.efl: 1.26.1 -> 1.26.2`                                |
| [`354b2407`](https://github.com/NixOS/nixpkgs/commit/354b24078289c9948f596f7ce2f4ad465ac20635) | `nixos/agate: add nixos test`                                        |
| [`0a6d22c6`](https://github.com/NixOS/nixpkgs/commit/0a6d22c6c3f51407317512cf4c44335f6db664ef) | `nixos/agate: init`                                                  |
| [`fa0e7ec9`](https://github.com/NixOS/nixpkgs/commit/fa0e7ec94400969679cf98099df2622f61732fdf) | `artim-dark: init at unstable-2021-12-29`                            |