### PR TITLE
chore(flake/home-manager): `50204cea` -> `a3c18a60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1644961661,
-        "narHash": "sha256-x1XdER7VT4jqePCWGGutPL46OxJyw8EGFF3rBn0rsuo=",
+        "lastModified": 1645025890,
+        "narHash": "sha256-pwlZPAsuGS14VXjjDYUBau+NzvUCDxwOfn1NwQOMDnQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "50204cea940ffe8aa479c255e84ba1f633084a13",
+        "rev": "a3c18a60d598157f34d7774956c05fb975838994",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`a3c18a60`](https://github.com/nix-community/home-manager/commit/a3c18a60d598157f34d7774956c05fb975838994) | ``neovim: add `extraLuaPackages` to neovim, fixes #1964. (#2617)`` |