### PR TITLE
chore(flake/nixpkgs): `4687b2ed` -> `4c999b91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1644992370,
-        "narHash": "sha256-6UmwHOboRwAUMyGNA+vBihf8mDW+paeKXtJkIPXQTog=",
+        "lastModified": 1645036967,
+        "narHash": "sha256-M3n0pUl4f77mjy5SiiQIqhdQlymQFyPgK49dK/vQNf0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4687b2ed82c90c135595cc0487b12d643991d542",
+        "rev": "4c999b91a5fdef78c71d22cefedd4eac34aff5a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`535df3ed`](https://github.com/NixOS/nixpkgs/commit/535df3ed51dccffd566114dbc898d158fe394988) | `kubectl-doctor: 0.3.0 -> 0.3.1 (#160179)`                                 |
| [`a13d0a70`](https://github.com/NixOS/nixpkgs/commit/a13d0a705454baf336c439de3a3cdb7f1fdfd51d) | `python310Packages.concurrent-log-handler: 0.9.19 -> 0.9.20`               |
| [`f61d06c5`](https://github.com/NixOS/nixpkgs/commit/f61d06c5e1c49dbe7ef61d62641514ec97a1c0eb) | `python310Packages.scp: 0.14.2 -> 0.14.3`                                  |
| [`9d92cd0b`](https://github.com/NixOS/nixpkgs/commit/9d92cd0b1cc542e17ce04619b2c09d4ebb8f39d8) | `python310Packages.icecream: 2.1.1 -> 2.1.2`                               |
| [`2cc912c8`](https://github.com/NixOS/nixpkgs/commit/2cc912c8e4ec1fc83be2431ddf5d8c6b8e1cd609) | `diceware: 0.9.6 -> 0.10`                                                  |
| [`29f06e2e`](https://github.com/NixOS/nixpkgs/commit/29f06e2e07b09b5690c93e91334f16e156e6976e) | `python310Packages.blis: 0.7.5 -> 0.7.6`                                   |
| [`2a52ad5f`](https://github.com/NixOS/nixpkgs/commit/2a52ad5f76f271f0e1a847768fc5aa4455121586) | `xpra: 4.3.1 -> 4.3.2`                                                     |
| [`15d1c96f`](https://github.com/NixOS/nixpkgs/commit/15d1c96f91b35ac90d598646b8b9a211c3e1e05f) | `coq-elpi: 1.12.1 -> 1.13.0`                                               |
| [`bdc48927`](https://github.com/NixOS/nixpkgs/commit/bdc4892773d224746667399dc5b24f9a7e3a28c4) | `elpi: 1.13.8 -> 1.14.1`                                                   |
| [`5b2c0489`](https://github.com/NixOS/nixpkgs/commit/5b2c0489775ac4df369b78ff095a6ce5bfe9b9d8) | `home-assistant: 2022.2.6 -> 2022.2.7`                                     |
| [`1cec4dca`](https://github.com/NixOS/nixpkgs/commit/1cec4dcac6e0eb520f01bd9c7a753653633cb1a7) | `python3Packages.aiohue: 4.0.1 -> 4.1.2`                                   |
| [`26826a0d`](https://github.com/NixOS/nixpkgs/commit/26826a0dab54ab030606e95acd4e2b8cb1b7c4f9) | `zettlr: 2.2.1 -> 2.2.2`                                                   |
| [`b37bf4cd`](https://github.com/NixOS/nixpkgs/commit/b37bf4cdf6e0f240ac19cfbd22388b9627f2f855) | `codeql: 2.7.5 -> 2.8.0`                                                   |
| [`2fcef71d`](https://github.com/NixOS/nixpkgs/commit/2fcef71daaf710ada9031e25e37d44acdce8e36d) | `python310Packages.mailchecker: 4.1.11 -> 4.1.12`                          |
| [`6016f1c2`](https://github.com/NixOS/nixpkgs/commit/6016f1c26c4ba404b836358d7bd236debe38bd52) | `apt-cacher-ng: 3.6.3 -> 3.7.4`                                            |
| [`aa5baf4d`](https://github.com/NixOS/nixpkgs/commit/aa5baf4dc3049cdbdbabb41e920bcce0f3a95fdc) | `bingo: init at 0.5.2`                                                     |
| [`04506038`](https://github.com/NixOS/nixpkgs/commit/045060389fda8dddcc038193baeb379867631acc) | `ddnet: 15.8.1 -> 15.9.1 (#160245)`                                        |
| [`27c29776`](https://github.com/NixOS/nixpkgs/commit/27c29776a40edd2b96ff5faad906ca7a981dd5ea) | `containerd: remove broken manual`                                         |
| [`a4485fbc`](https://github.com/NixOS/nixpkgs/commit/a4485fbc8f092f53b35dabc2302555eb0b4bac25) | `containerd: 1.5.9 -> 1.6.0`                                               |
| [`0a3488c1`](https://github.com/NixOS/nixpkgs/commit/0a3488c13efc62fe5d59a934942d0ff8a359a568) | `nerdctl: 0.16.1 -> 0.17.0`                                                |
| [`58a10554`](https://github.com/NixOS/nixpkgs/commit/58a1055438c7783b0d39f4d299d82bfc337f4216) | `pitch-black: init at unstable-2019-07-23 (#156622)`                       |
| [`33674e23`](https://github.com/NixOS/nixpkgs/commit/33674e239f63fc82a3ee6a62c3f49273e8c5d3d7) | `haskellPackages: mark builds failing on hydra as broken`                  |
| [`0f90feb8`](https://github.com/NixOS/nixpkgs/commit/0f90feb8e00665bb3e02dcaa08ee99efe011df87) | `python310Packages.net2grid: 2.0.0 -> 3.0.0`                               |
| [`8c50dc59`](https://github.com/NixOS/nixpkgs/commit/8c50dc598f375089177c5ea6b40482b5dd9d68ec) | `haskellPackages.utc: mark as broken`                                      |
| [`11a28cdc`](https://github.com/NixOS/nixpkgs/commit/11a28cdcde6581e60959cfd35e2ebe393c0116cd) | `python310Packages.plugwise: 0.16.2 -> 0.16.4`                             |
| [`6da33281`](https://github.com/NixOS/nixpkgs/commit/6da33281299732615b5a7881e4346bc4b1363f0a) | `nixos/containerd: fix zfs setting config override`                        |
| [`e85a87ec`](https://github.com/NixOS/nixpkgs/commit/e85a87ece1c9a9b999ae58633858eda137feb659) | `ginkgo: 2.1.2 -> 2.1.3`                                                   |
| [`9b4f6217`](https://github.com/NixOS/nixpkgs/commit/9b4f621741dec9e9d8a3444f0a3b776707d9d14a) | `haskellPackages.http-client-restricted: pin to 0.0.4 for stackage compat` |
| [`f7f47b9b`](https://github.com/NixOS/nixpkgs/commit/f7f47b9b9119c1887961dbe524052dd91b3f2dff) | `haskellPackages.hls-rename-plugin: unbreak`                               |
| [`cbeb06cf`](https://github.com/NixOS/nixpkgs/commit/cbeb06cf2149a5a68801926f09e8f0aae323c482) | `grype: 0.32.0 -> 0.33.0`                                                  |
| [`6d5e3764`](https://github.com/NixOS/nixpkgs/commit/6d5e3764dd3802fe55d8753e27daeb14a76ce0e0) | `coqPackages.VST: 2.8 → 2.9`                                               |
| [`dd09b527`](https://github.com/NixOS/nixpkgs/commit/dd09b527000ea379b5ba4a2696a801af98768142) | `coqPackages.ITree: enable for Coq 8.15`                                   |
| [`c845a272`](https://github.com/NixOS/nixpkgs/commit/c845a272a58a463c90de03525848fdd82bba5e4b) | `coqPackages.compcert: enable for Coq 8.15`                                |
| [`62e791d9`](https://github.com/NixOS/nixpkgs/commit/62e791d9f374116f985db516518bafc190f7384e) | `electron_17: 17.0.0 -> 17.0.1`                                            |
| [`41de21a2`](https://github.com/NixOS/nixpkgs/commit/41de21a2a15981c5309c79c4fa4a51ba862fd883) | `electron_16: 16.0.8 -> 16.0.9`                                            |
| [`f2c15707`](https://github.com/NixOS/nixpkgs/commit/f2c15707a7cb241b7765342b83b2b92b1d6f5c6e) | `electron_15: 15.3.6 -> 15.3.7`                                            |
| [`e7ce85d8`](https://github.com/NixOS/nixpkgs/commit/e7ce85d8d4f05344837b4d75ed11a5d86208fc10) | `electron_14: 14.2.5 -> 14.2.6`                                            |
| [`08046e39`](https://github.com/NixOS/nixpkgs/commit/08046e399700bfd281afe7e13d9f665a7549ff81) | `ktlint: 0.43.2 -> 0.44.0`                                                 |
| [`4ed2fdfc`](https://github.com/NixOS/nixpkgs/commit/4ed2fdfca7c66ef481d43c4c6c0529e371d26531) | `btop: 1.2.2 -> 1.2.3`                                                     |
| [`b1fa7d7b`](https://github.com/NixOS/nixpkgs/commit/b1fa7d7ba0d8edf866be80664e8465f9d34e10c3) | `colordiff: 1.0.19 -> 1.0.20`                                              |
| [`07759534`](https://github.com/NixOS/nixpkgs/commit/077595349b41ecad1844cdb79ca9d9e3af8b7f51) | `ddosify: 0.7.2 -> 0.7.3`                                                  |
| [`ee7e1cc2`](https://github.com/NixOS/nixpkgs/commit/ee7e1cc2b743e580bcb86931d855b54c6f6f2ea5) | `python310Packages.hahomematic: 0.33.0 -> 0.34.0`                          |
| [`b38b641f`](https://github.com/NixOS/nixpkgs/commit/b38b641ff33b15ec1788f6eb6e7fa13fe4419c23) | `sageWithDoc: fix Sphinx warnings which break docgen`                      |
| [`7223c403`](https://github.com/NixOS/nixpkgs/commit/7223c4036acebf1ec1cbcd6e901681fc47eae5e9) | `python310Packages.croniter: 1.2.0 -> 1.3.1`                               |
| [`05eaa4dd`](https://github.com/NixOS/nixpkgs/commit/05eaa4ddd181ec404722ca73e4a15261bbc827fc) | `typos: 1.4.0 -> 1.4.1`                                                    |
| [`fe1bcec6`](https://github.com/NixOS/nixpkgs/commit/fe1bcec6028e81d0eb6f4c338bda9dc6d9462fd0) | `quick-lint-js: init at 2.1.0`                                             |
| [`fa886f18`](https://github.com/NixOS/nixpkgs/commit/fa886f18f35ec2dddc64e020a6b0aa5a3ff9a645) | `rocm-device-libs: drop default for cmakeBuildType`                        |
| [`f28d9be8`](https://github.com/NixOS/nixpkgs/commit/f28d9be832d63b79f5f73b0583f2601a791c88b6) | `nixos/jmusicbot: add option services.jmusicbot.package`                   |
| [`99199825`](https://github.com/NixOS/nixpkgs/commit/9919982599e00e12e0067be45e3a0a4f8becedc6) | `python3Packages.rokuecp: 0.13.2 -> 0.14.0`                                |
| [`7be0ab61`](https://github.com/NixOS/nixpkgs/commit/7be0ab615dde98f6157d00089198e9f5e27daffe) | `rates: 0.5.0 -> 0.6.0`                                                    |
| [`15dd68db`](https://github.com/NixOS/nixpkgs/commit/15dd68db6650c89a398e6df99b25fd8429e3277d) | `mqttui: 0.14.0 -> 0.15.0`                                                 |
| [`8a9bfaee`](https://github.com/NixOS/nixpkgs/commit/8a9bfaee2371ef85f11dfbee1908255a176927f5) | `libqalculate: 3.22.0 -> 4.0.0`                                            |
| [`77672550`](https://github.com/NixOS/nixpkgs/commit/776725509dcb345b8bd33c2023e900f1263e28e7) | `bloomrpc: Add fix when opening a file browser`                            |
| [`de0c0019`](https://github.com/NixOS/nixpkgs/commit/de0c00190bdb99f702f8d14259d0dc5ffba34f6a) | `python310Packages.furo: 2022.1.2 -> 2022.2.14.1`                          |
| [`361b5af1`](https://github.com/NixOS/nixpkgs/commit/361b5af106c1f4fe38ebb12e3ebf8da9ecf95079) | `minizip: rename name to pname&version`                                    |
| [`b7aac2ab`](https://github.com/NixOS/nixpkgs/commit/b7aac2ab11dcd8170663d5535a6d8e7ea527ef6b) | `opencl-headers: rename name to pname&version`                             |
| [`602c7cb1`](https://github.com/NixOS/nixpkgs/commit/602c7cb1b96665d333db8ecff6ee182cab570b21) | `metis: rename name to pname&version`                                      |
| [`4d94f512`](https://github.com/NixOS/nixpkgs/commit/4d94f512e2bce887d2b67143282bde622bed585d) | `haskellPackages: regenerate package set based on current config`          |
| [`aeb2d5e2`](https://github.com/NixOS/nixpkgs/commit/aeb2d5e2bcdde958422875a6a44451c3a2e6fb35) | `all-cabal-hashes: 2022-02-06T15:34:38Z -> 2022-02-14T17:17:31Z`           |
| [`c82e6a38`](https://github.com/NixOS/nixpkgs/commit/c82e6a38872263e5f56bda964dc3874383b513d9) | `haskellPackages: stackage-lts 18.24 -> 18.25`                             |
| [`b4b2a8e0`](https://github.com/NixOS/nixpkgs/commit/b4b2a8e02c198d9d71d006ece6d415b951ff2169) | `haskellPackages.dates: unmark as broken`                                  |
| [`44ff13dd`](https://github.com/NixOS/nixpkgs/commit/44ff13dd3010a395d0b1f72198eb347fc5f1e2a8) | `haskellPackages: mark builds failing on hydra as broken`                  |
| [`fdb42678`](https://github.com/NixOS/nixpkgs/commit/fdb4267874d29a44ab9b781730c0cbf4a793d674) | `picom: 9 -> 9.1`                                                          |
| [`42d5cbb7`](https://github.com/NixOS/nixpkgs/commit/42d5cbb78ea0114853e49bd82d806be0d693e289) | `tlaplus: 1.7.1 -> 1.7.2`                                                  |
| [`a7b92f8f`](https://github.com/NixOS/nixpkgs/commit/a7b92f8f7135c4241cdd0a4a0b6708547f3e749a) | `pugixml: 1.11.4 -> 1.12`                                                  |
| [`b0f07726`](https://github.com/NixOS/nixpkgs/commit/b0f07726034337c032697840559c3066a5e9ea59) | `kube3d: 5.2.2 -> 5.3.0`                                                   |
| [`8f5b8892`](https://github.com/NixOS/nixpkgs/commit/8f5b8892aa7fe3ecd258246bea116f3653e4cf83) | `zsh-fzf-tab: unstable-2021-11-12 -> unstable-2022-02-10`                  |
| [`f8f5615d`](https://github.com/NixOS/nixpkgs/commit/f8f5615dfd7517121ef7b4d7e19acd98df7ef97e) | `super-productivity: switch to electron 17`                                |
| [`a386d540`](https://github.com/NixOS/nixpkgs/commit/a386d540d8db6fd4a611279f1d440ebaee4f3510) | `haskell-language-server: fix reference logic`                             |
| [`ea5e4428`](https://github.com/NixOS/nixpkgs/commit/ea5e442833495d5ebef2a81ba3d5933e5fe880d5) | `haskell-language-server: default to statically linking haskell deps`      |
| [`a7c18f7a`](https://github.com/NixOS/nixpkgs/commit/a7c18f7a90b3c97a90453c06e72ef558c858298a) | `haskell-language-server: retain old postInstall if any`                   |
| [`dbd3a833`](https://github.com/NixOS/nixpkgs/commit/dbd3a833037a3735be0d1480392171beaee9c46b) | `haskell-language-server: make linking configureable in wrapper`           |
| [`ed91ac41`](https://github.com/NixOS/nixpkgs/commit/ed91ac41293ee80d3e18e910aa53a20eb90e9b0c) | `haskellPackages.hs-mesos: place dont-distribute entry appropriately`      |
| [`e6cde9b4`](https://github.com/NixOS/nixpkgs/commit/e6cde9b47a1998c537aac7cec66eb43e2e7e5dbd) | `haskellPackages.numerals: Disable version checks`                         |
| [`6a6a2cdb`](https://github.com/NixOS/nixpkgs/commit/6a6a2cdbe923dbee5e38ba1fd3479cb4b0077afe) | `haskellPackages.ihaskell: use enableSharedExecutable over adhoc flag`     |
| [`63e8fc41`](https://github.com/NixOS/nixpkgs/commit/63e8fc415fc522979b9f6824c756b7b79e75b861) | `haskellPackages.haskell-language-server: fix shared build`                |
| [`550e3a38`](https://github.com/NixOS/nixpkgs/commit/550e3a38bad15a8d34b822e751c5396dcb0e0eef) | `haskell.packages.ghc902.alex: drop unnecessary patch`                     |
| [`f863b454`](https://github.com/NixOS/nixpkgs/commit/f863b4543a5d921e63b722d4b5ff3eb60d6e6b9f) | `haskellPackages: preserve ghc-exactprint 1.4.1`                           |
| [`1409648a`](https://github.com/NixOS/nixpkgs/commit/1409648a62d046f6f7d5c502ba13e6237593f6da) | `haskellPackages: regenerate package set based on current config`          |
| [`d659bfd0`](https://github.com/NixOS/nixpkgs/commit/d659bfd023db51c01d68cf392056d14afcb52c7a) | `all-cabal-hashes: 2022-01-31T19:23:21Z -> 2022-02-06T15:34:38Z`           |
| [`035ddbea`](https://github.com/NixOS/nixpkgs/commit/035ddbea8dc38c3dc57792f576a4a6295951f36b) | `haskellPackages: stackage-lts 18.23 -> 18.24`                             |
| [`e98d8f72`](https://github.com/NixOS/nixpkgs/commit/e98d8f7207250d4e8df3f3d1602a47c9d9c8c3a3) | `feh: correct license`                                                     |
| [`71111251`](https://github.com/NixOS/nixpkgs/commit/711112516037fa45f564971e7d26febbf3f34dbc) | `nixos/squid: add services.squid.proxyAddress`                             |
| [`253c12e0`](https://github.com/NixOS/nixpkgs/commit/253c12e0acc1cf5893fe543472c2c6d7b58489db) | `tarlz: 0.21 -> 0.22`                                                      |