### PR TITLE
chore(flake/home-manager): `5375afb2` -> `c859a526`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1645133661,
-        "narHash": "sha256-3VaHmwFoZmMKUgi1PSRhmzWoOm+cNdmsJ+vlRwl4iYA=",
+        "lastModified": 1645134494,
+        "narHash": "sha256-kh2cyxegkEk6vz+Jhp+ztUdc+Wnneq4bc69g3pHTOi8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5375afb2fbe6043c02f333e93289507caef0ea9f",
+        "rev": "c859a5265ac08db6f5bd750f04e6654cd5b12eab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                     |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`c859a526`](https://github.com/nix-community/home-manager/commit/c859a5265ac08db6f5bd750f04e6654cd5b12eab) | `sway: add tray.target`            |
| [`30082a62`](https://github.com/nix-community/home-manager/commit/30082a623ac3a88b6649251602c10464570dc011) | `docs: fix standalone flake setup` |