### PR TITLE
chore(flake/nixpkgs): `4c999b91` -> `97777606`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1645036967,
-        "narHash": "sha256-M3n0pUl4f77mjy5SiiQIqhdQlymQFyPgK49dK/vQNf0=",
+        "lastModified": 1645072054,
+        "narHash": "sha256-I+HkWU1IpRb93VzjayAybj3L2CcJxNlZDhSeSpL3eSw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c999b91a5fdef78c71d22cefedd4eac34aff5a7",
+        "rev": "97777606991c3a78040c883fa97791ae77073022",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| [`f5237b2d`](https://github.com/NixOS/nixpkgs/commit/f5237b2df9fe7ed229bf8d8c1fdf337e055629fa) | `clickclack: 0.2 -> 0.2.2`                                                                                  |
| [`9d07a91a`](https://github.com/NixOS/nixpkgs/commit/9d07a91aebe96b9b9df5c71d059fa72f65cfc766) | `yambar: mesonFeatureFlag with descriptive argument names`                                                  |
| [`5cfeb52d`](https://github.com/NixOS/nixpkgs/commit/5cfeb52dd8f903379aa2cfd687f5d6c8cabaf2c7) | `solo2-cli: install udev file`                                                                              |
| [`d67ffe7b`](https://github.com/NixOS/nixpkgs/commit/d67ffe7bcb11d76d88e4d0ea66a98162f8cf5de9) | `gnome.gpaste: 3.42.2 -> 3.42.5`                                                                            |
| [`854a00b9`](https://github.com/NixOS/nixpkgs/commit/854a00b962b7860711caea124d69f3c24fb112c8) | `yelp: Use webkit2gtk-4.0 ABI`                                                                              |
| [`f70e28e3`](https://github.com/NixOS/nixpkgs/commit/f70e28e3b1e46d48c695589c6a45fd11917add6b) | `gnome.gnome-autoar: 0.4.2 -> 0.4.3`                                                                        |
| [`7ff5dd05`](https://github.com/NixOS/nixpkgs/commit/7ff5dd058dcea77d9f0b4c35fd3db98825ecb264) | `gnome.gnome-software: 41.3 -> 41.4`                                                                        |
| [`08a56a04`](https://github.com/NixOS/nixpkgs/commit/08a56a043548f3ae15cace1a4df1554ef1547729) | `evolution-data-server: 3.42.3 -> 3.42.4`                                                                   |
| [`1f9f0687`](https://github.com/NixOS/nixpkgs/commit/1f9f068724c01a5b7f8417be5f7a7af9ef4ea016) | `gnome.gedit: 40.1 -> 41.0`                                                                                 |
| [`4aa5df74`](https://github.com/NixOS/nixpkgs/commit/4aa5df74fc1d5c4168fe45e5ec54fdce3a9c72a7) | `gnome.gnome-control-center: 41.2 -> 41.4`                                                                  |
| [`9137d7d1`](https://github.com/NixOS/nixpkgs/commit/9137d7d156e4029c00e9ea37ea7381dfb442b8b7) | `vassal: 3.6.4 -> 3.6.5`                                                                                    |
| [`c8fb08b1`](https://github.com/NixOS/nixpkgs/commit/c8fb08b1e4687aaca9d35bfad4c80296f54aeb2f) | `tetgen: also install library and headers`                                                                  |
| [`53578062`](https://github.com/NixOS/nixpkgs/commit/53578062a472fdd322492cf59f3699ab1231f6f2) | `zig: 0.9.0 -> 0.9.1`                                                                                       |
| [`11b3b8dc`](https://github.com/NixOS/nixpkgs/commit/11b3b8dc852bf59646d3ad5342e5d13df41cdb81) | `rednotebook: 2.22 -> 2.23`                                                                                 |
| [`047429df`](https://github.com/NixOS/nixpkgs/commit/047429df52f6c7204206adaf95c0f8373e2df1d8) | `nixos/home-assistant: fix package override`                                                                |
| [`3a39f65e`](https://github.com/NixOS/nixpkgs/commit/3a39f65e22ea56bfceb70729d3384a3fa5e47e66) | `home-assistant: 2022.2.7 -> 2022.2.8`                                                                      |
| [`25061092`](https://github.com/NixOS/nixpkgs/commit/250610921a34e2d64263d2e8ed72c33abd77cbf9) | `python3Packages.aiohue: 4.1.2 -> 4.2.0`                                                                    |
| [`54105e1f`](https://github.com/NixOS/nixpkgs/commit/54105e1f856e989897d9ec81580db8dd4dbd8b7a) | `vimPlugins.winshift-nvim: init at 2021-11-15`                                                              |
| [`8d95ce92`](https://github.com/NixOS/nixpkgs/commit/8d95ce925bfcba5413aa6055c26995c68fbd92a2) | `datadog-agent: 7.33.0 -> 7.33.1`                                                                           |
| [`ed8716d9`](https://github.com/NixOS/nixpkgs/commit/ed8716d97e2a4f4a503837f9f5ec802bfa1b4c51) | `whalebird: 4.5.0 -> 4.5.1`                                                                                 |
| [`3c2757d2`](https://github.com/NixOS/nixpkgs/commit/3c2757d25d1ea5133fe8d207e995032b722b9e39) | `terraform: 1.1.5 -> 1.1.6`                                                                                 |
| [`825458c1`](https://github.com/NixOS/nixpkgs/commit/825458c16a9c8dcdaf04c26e702229023a76c825) | `erlang-ls: 0.22.0 -> 0.23.0`                                                                               |
| [`fb26c1c6`](https://github.com/NixOS/nixpkgs/commit/fb26c1c637e6fe80e2f40c8eaa8c5255b0a41efe) | `frugal: 3.14.13 -> 3.14.14`                                                                                |
| [`d71b0609`](https://github.com/NixOS/nixpkgs/commit/d71b060905879b5dbd1af34bb9056733b8cffe71) | `mask: 0.11.0 -> 0.11.1`                                                                                    |
| [`9d08c90f`](https://github.com/NixOS/nixpkgs/commit/9d08c90f3c2546aae2c5770efaee2969ec34deee) | `jmusicbot: fix starting on java 17`                                                                        |
| [`969b67bd`](https://github.com/NixOS/nixpkgs/commit/969b67bdae1859cf9d0351a271ebe814df4651ec) | `netdata: 1.33.0 -> 1.33.1`                                                                                 |
| [`36192a1d`](https://github.com/NixOS/nixpkgs/commit/36192a1df4c54d8db698606d9d998f3268952dee) | `skopeo: 1.6.0 -> 1.6.1`                                                                                    |
| [`19be17d5`](https://github.com/NixOS/nixpkgs/commit/19be17d54f52b4fa0424f6e88867e57a09c94da2) | `wrapFirefox: remove old npapi plugin related options`                                                      |
| [`e155371d`](https://github.com/NixOS/nixpkgs/commit/e155371d1e56c9906e9c31e06403b042b955a88d) | `azpainter: 2.1.6 -> 3.0.4`                                                                                 |
| [`5aa133e5`](https://github.com/NixOS/nixpkgs/commit/5aa133e53796454f2e5920d74787b0f5f917f253) | `python3Packages.yalesmartalarmclient: 0.3.7 -> 0.3.8`                                                      |
| [`29fd7874`](https://github.com/NixOS/nixpkgs/commit/29fd78747ae72b28d06bf19df2b8faf2a1d9a7eb) | `nixos/manual: use system nixpkgs to build pxe image`                                                       |
| [`7852ea15`](https://github.com/NixOS/nixpkgs/commit/7852ea15964f685bd73eaa7e11279668ec5c0d40) | `nixos/matomo: point path.geoip2 outside of the nix store.`                                                 |
| [`a67172eb`](https://github.com/NixOS/nixpkgs/commit/a67172ebf667d248c85397835e1e5f9b47d6c4c1) | `volk: fix build for apple silicon`                                                                         |
| [`38ef358b`](https://github.com/NixOS/nixpkgs/commit/38ef358b651dd8d7458e1c2eec8d69939075700b) | `signalbackup-tools: 20220107 -> 20220216`                                                                  |
| [`de60e2ff`](https://github.com/NixOS/nixpkgs/commit/de60e2ffd322490b524452e4a38c182f0b69f29e) | `python3Packages.pywizlight: 0.5.8 -> 0.5.9`                                                                |
| [`50e6588e`](https://github.com/NixOS/nixpkgs/commit/50e6588e384bac469e0eec7965238ab362fda32a) | `plasma-theme-switcher: init at 0.1`                                                                        |
| [`ce4df6fa`](https://github.com/NixOS/nixpkgs/commit/ce4df6fac5207730e66a704188998b3d4cc8d5d5) | `maintainers: add kevink`                                                                                   |
| [`14f5ef75`](https://github.com/NixOS/nixpkgs/commit/14f5ef756b36998d3d93939433cf5a96d4bce2ae) | `thunderbird: 91.6.0 -> 91.6.1`                                                                             |
| [`e9523119`](https://github.com/NixOS/nixpkgs/commit/e9523119c4f16be6c4e48abc522ffb9dae36c290) | `go-ethereum: 1.10.15 -> 1.10.16`                                                                           |
| [`0281345a`](https://github.com/NixOS/nixpkgs/commit/0281345a065ef605a818a8c0b2eb37841b59a8fb) | `mariadb-galera: 26.4.10 -> 26.4.11`                                                                        |
| [`0ee8f4a1`](https://github.com/NixOS/nixpkgs/commit/0ee8f4a1b513d6584fba17b609c958956bc673e8) | `werf: 1.2.65 -> 1.2.67`                                                                                    |
| [`46d1691d`](https://github.com/NixOS/nixpkgs/commit/46d1691d5c4902822f7b6e181a874ec376f562b4) | `ungoogled-chromium: 98.0.4758.80 -> 98.0.4758.102`                                                         |
| [`71ec27ad`](https://github.com/NixOS/nixpkgs/commit/71ec27ad49e4a300167d47bb4a48f5082eaa879f) | `csview: 0.3.12 -> 1.0.1`                                                                                   |
| [`27bc7562`](https://github.com/NixOS/nixpkgs/commit/27bc7562499652cbb82e95ce76a42097d0daef9d) | `nextcloud22: 22.2.4 -> 22.2.5`                                                                             |
| [`7602ca0e`](https://github.com/NixOS/nixpkgs/commit/7602ca0e8e5d20b979aca1694bdb3c75ac341684) | `nextcloud21: 21.0.8 -> 21.0.9`                                                                             |
| [`f4c0c776`](https://github.com/NixOS/nixpkgs/commit/f4c0c776826a58d4f7c9a3096da7d52a43bd855f) | `nextcloud23: 23.0.1 -> 23.0.2`                                                                             |
| [`0ca96471`](https://github.com/NixOS/nixpkgs/commit/0ca96471d9eca37c236ad1b43423e5f4400cf92c) | `cargo-release: 0.20.1 -> 0.20.2`                                                                           |
| [`cb50e4d9`](https://github.com/NixOS/nixpkgs/commit/cb50e4d9a95e8b8331267846786897008b5b0e81) | `tinyemu: 2018-09-23 -> 2019-12-21`                                                                         |
| [`8ff85d5a`](https://github.com/NixOS/nixpkgs/commit/8ff85d5a9de5436009345523b0b9087282a2beb1) | `tiny8086: refactor`                                                                                        |
| [`cecc4e40`](https://github.com/NixOS/nixpkgs/commit/cecc4e406d748857bd64a51c43570d5360300f1d) | `hercules: refactor`                                                                                        |
| [`b3c62405`](https://github.com/NixOS/nixpkgs/commit/b3c62405d4e67f3ad748b374f6ef60326a4ce448) | `dynamips: refactor`                                                                                        |
| [`4a45cd99`](https://github.com/NixOS/nixpkgs/commit/4a45cd997b43a7a12daf845f940ec2d824169619) | `treewide: move some emulators to their correct place`                                                      |
| [`36928989`](https://github.com/NixOS/nixpkgs/commit/36928989d729c9f0c9753595e207f55327fa069a) | `Move misc/emulators to applications/emulators - part 2`                                                    |
| [`8d65e832`](https://github.com/NixOS/nixpkgs/commit/8d65e832f0a18f60e2040940c80d96373ac8b88c) | `Move misc/emulators to applications/emulators - part 1`                                                    |
| [`abcc6ade`](https://github.com/NixOS/nixpkgs/commit/abcc6adeb6090247d7bb1ca5ec20e587be192070) | ` gst_all_1.gst-plugins-bad: fix build on Darwin`                                                           |
| [`27b06df6`](https://github.com/NixOS/nixpkgs/commit/27b06df6e07fa0c46783e002ec8d6ac996b36c18) | `thunderbird-bin: 91.5.1 -> 91.6.1`                                                                         |
| [`dece6ab9`](https://github.com/NixOS/nixpkgs/commit/dece6ab9aa917486f703e15108dee6928b6c02b1) | `gitaly: clear patches for libgit2`                                                                         |
| [`e82383cf`](https://github.com/NixOS/nixpkgs/commit/e82383cf3aa106082f081df1e4323cd8a77470d0) | `gitstatus: clear patches for libgit2 fork`                                                                 |
| [`b836f5bd`](https://github.com/NixOS/nixpkgs/commit/b836f5bd4e4d342a072f2b72c7edb3814977646e) | `turbogit: pin libgit2 to 1.3.0`                                                                            |
| [`3b53789e`](https://github.com/NixOS/nixpkgs/commit/3b53789e933b8b20db226a33730400bf665b1f04) | `python39Packages.pytgit2: pin to libgit2 1.3.0 due to failing tests`                                       |
| [`e388cf16`](https://github.com/NixOS/nixpkgs/commit/e388cf1654ed59a00ec3bb877e7e94252dcda9a6) | `libgit2_1_3_0: init at 1.3.0`                                                                              |
| [`7630d65b`](https://github.com/NixOS/nixpkgs/commit/7630d65bdb84b78d1b2c562da0235aeda4fc9091) | `libgit2_1_1: drop because unused`                                                                          |
| [`99d0740a`](https://github.com/NixOS/nixpkgs/commit/99d0740a73617a60410cd2f15b15451d6bcb8297) | `libgit2_0_27: move top-level entry into julia_10`                                                          |
| [`4ae62215`](https://github.com/NixOS/nixpkgs/commit/4ae622152b15464407c8893342c93e51536df246) | `python39Packages.pygit2: use disabledTestPaths, add missing meta.maintainers, remove disabled for python2` |
| [`4e014a2c`](https://github.com/NixOS/nixpkgs/commit/4e014a2c26da8841da576a59651eaa0642bd7e98) | `checkov: 2.0.845 -> 2.0.853`                                                                               |
| [`fca1c916`](https://github.com/NixOS/nixpkgs/commit/fca1c9165c7a005ac662d39298828490e36a9c6e) | `libgit2: 1.3.0 -> 1.4.0, update meta`                                                                      |
| [`7e948a6c`](https://github.com/NixOS/nixpkgs/commit/7e948a6c9a6f47d71133ce594955acbecc5a4e4e) | `chromium: 98.0.4758.80 -> 98.0.4758.102`                                                                   |
| [`1310f227`](https://github.com/NixOS/nixpkgs/commit/1310f227e84edaaa2d0377e116463a6a313dd10a) | `libgit2: rename directory to expected name`                                                                |
| [`71e9485a`](https://github.com/NixOS/nixpkgs/commit/71e9485a197fa2b0f918e048daed5cb157a24c1c) | `seaweedfs: 2.88 -> 2.89`                                                                                   |
| [`1c85c368`](https://github.com/NixOS/nixpkgs/commit/1c85c368a7d5eddf462a76245b397c0f2fb74df7) | `setzer: 0.4.2 -> 0.4.3`                                                                                    |
| [`25365685`](https://github.com/NixOS/nixpkgs/commit/25365685ea0b85fdb4199bb66a5ca923541d44be) | `mariadb_108: 10.8.1 -> 10.8.2`                                                                             |
| [`068a3217`](https://github.com/NixOS/nixpkgs/commit/068a321777fca49935072ad2098a774ccc281d7a) | `mariadb_107: 10.7.2 -> 10.7.3`                                                                             |
| [`45ab3705`](https://github.com/NixOS/nixpkgs/commit/45ab3705c8b651bf386b1c7ee47c45f92a2600e6) | `mariadb_106: 10.6.6 -> 10.6.7`                                                                             |
| [`b445fd58`](https://github.com/NixOS/nixpkgs/commit/b445fd58544eb75ec068b4152eae899405f44bf9) | `mariadb_105: 10.5.14 -> 10.5.15`                                                                           |
| [`1a1666da`](https://github.com/NixOS/nixpkgs/commit/1a1666daafa5b82eeb7da382291c870cc38ade1b) | `mariadb_104: 10.4.23 -> 10.4.24`                                                                           |
| [`0b06254f`](https://github.com/NixOS/nixpkgs/commit/0b06254f5d35834fb1f612632bb58200f4cfa6c3) | `Revert "Revert "Merge pull request #158822 from helsinki-systems/upd/mariadb""`                            |
| [`9ead68aa`](https://github.com/NixOS/nixpkgs/commit/9ead68aa4b70f9cc934d15937e34cfb47ffb1b61) | `firefox-bin: provide wrapper with libName`                                                                 |
| [`810c5799`](https://github.com/NixOS/nixpkgs/commit/810c57990e74e6c3ef2e0a76e282f77f0fd6bd66) | `nats-server: add nixosTests.nats as passthru test`                                                         |
| [`270c351b`](https://github.com/NixOS/nixpkgs/commit/270c351bdfab53699fec23b32fc0fbcfa9a59df9) | `nats-server: 2.7.0 -> 2.7.2`                                                                               |
| [`bc0839b3`](https://github.com/NixOS/nixpkgs/commit/bc0839b3d6e286926459f2e56cddd4b953b799bf) | `apr-util: drop FreeBSD override`                                                                           |
| [`bca64be8`](https://github.com/NixOS/nixpkgs/commit/bca64be89364655b19b44cd28627bca511af5ee4) | `apr-util: support cross-compilation`                                                                       |
| [`66b3c56b`](https://github.com/NixOS/nixpkgs/commit/66b3c56bb7f37493f2df4009775f8701e7edbb7a) | `apr-util: fix eval for cross-compilation`                                                                  |