### PR TITLE
chore(flake/home-manager): `4f4165a8` -> `0232fe1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1645140957,
-        "narHash": "sha256-WTJzLSCDLBI537o2L/3kRyqEV5YRT7+1QSGryeKReHE=",
+        "lastModified": 1645244400,
+        "narHash": "sha256-o7KCd6ySFZ9/LbS62aTeuFmBWtP7Tt3Q3RcNjYgTgZU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4f4165a8b9108818ab0193bbd1a252106870b2a2",
+        "rev": "0232fe1b75e6d7864fd82b5c72f6646f87838fc3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                     |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`0232fe1b`](https://github.com/nix-community/home-manager/commit/0232fe1b75e6d7864fd82b5c72f6646f87838fc3) | `atuin: don't install widget on limited terminals` |