### PR TITLE
chore(flake/nixpkgs): `97777606` -> `6f9cb9aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1645072054,
-        "narHash": "sha256-I+HkWU1IpRb93VzjayAybj3L2CcJxNlZDhSeSpL3eSw=",
+        "lastModified": 1645460852,
+        "narHash": "sha256-bFI96ckrJ5/MvqvsexVTAWLope2EQCVZkDbC1fyPbSc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "97777606991c3a78040c883fa97791ae77073022",
+        "rev": "6f9cb9aa5630747e7ecbb847c4af167e3c0b32bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                        |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`4e60a482`](https://github.com/NixOS/nixpkgs/commit/4e60a4823b67f4f6a705613fe02dbda7448a51c7) | `febio-studio: init at 1.6.1`                                         |
| [`61ac4169`](https://github.com/NixOS/nixpkgs/commit/61ac4169922ca62d00bfe7f28dae6e1f27fd9c89) | `coqPackages.hydra-battles: fix version checking logic`               |
| [`02236d54`](https://github.com/NixOS/nixpkgs/commit/02236d5444d6758b5806dd4c580e049a5b87b9c1) | `netdiscover: 0.8.1 -> 0.9`                                           |
| [`dfd948de`](https://github.com/NixOS/nixpkgs/commit/dfd948de987ea0f1988ffc100daf272e8f858150) | `writedisk: init at 1.2.0`                                            |
| [`7de796ec`](https://github.com/NixOS/nixpkgs/commit/7de796ec0a4b197483513f518e65802c80058608) | `vouch-proxy: 0.35.1 -> 0.36.0`                                       |
| [`29461f5b`](https://github.com/NixOS/nixpkgs/commit/29461f5b2311aee28681e98abad77aa19f5ac5a5) | `python310Packages.aiogithubapi: 22.2.2 -> 22.2.3`                    |
| [`28fd2849`](https://github.com/NixOS/nixpkgs/commit/28fd284959f8c5dd03cc0a25ce7e00b70c672381) | `python3Packages.beartype: add format`                                |
| [`4de4b264`](https://github.com/NixOS/nixpkgs/commit/4de4b2643fbed4acf25c3226cde638bc1a34b5fd) | `python3Packages.python-socketio: 5.5.1 -> 5.5.2`                     |
| [`c2adebc3`](https://github.com/NixOS/nixpkgs/commit/c2adebc314e6c7c957fe94f5a2d2e193a0953062) | `python310Packages.plugwise: 0.16.5 -> 0.16.6`                        |
| [`8dc9b6df`](https://github.com/NixOS/nixpkgs/commit/8dc9b6df79fa0ac94eace04cd5756367f83c6750) | `python3Packages.androidtv: 0.0.63 -> 0.0.64`                         |
| [`9802db29`](https://github.com/NixOS/nixpkgs/commit/9802db294938f9bfb966bcb6afcb82f9afc8be4f) | `python3Packages.aiowebostv: 0.1.2 -> 0.1.3`                          |
| [`dae53ea4`](https://github.com/NixOS/nixpkgs/commit/dae53ea4344d3a6d1b283264e25ef6f942704c6d) | `python310Packages.georss-tfs-incidents-client: 0.3 -> 0.4`           |
| [`3ef72d5e`](https://github.com/NixOS/nixpkgs/commit/3ef72d5ea6118ccfeb1bdfae7e2174c4379973bb) | `python310Packages.pywizlight: 0.5.10 -> 0.5.12`                      |
| [`88ce9b6a`](https://github.com/NixOS/nixpkgs/commit/88ce9b6a41e44282b71dcd5570a224ebf5712248) | `python310Packages.georss-generic-client: 0.6 -> 0.7`                 |
| [`e70d829b`](https://github.com/NixOS/nixpkgs/commit/e70d829bdb9f51d82e1ef54e444964e6dcf5ed3c) | `libgovirt: clean up`                                                 |
| [`b224a5af`](https://github.com/NixOS/nixpkgs/commit/b224a5af5e37a9849a815daf06262b383f8b0f20) | `flat-remix-gtk: 20220118 -> 20220215`                                |
| [`c35aa0a0`](https://github.com/NixOS/nixpkgs/commit/c35aa0a0f3c3ad0a054c790331e6cd158b0309a0) | `cwltool: 3.1.20220217190813 -> 3.1.20220217222804`                   |
| [`6aedee00`](https://github.com/NixOS/nixpkgs/commit/6aedee001301c0947cd70e78bc5a8954fcd0113e) | `ffmpeg-normalize: 1.22.5 -> 1.22.6`                                  |
| [`7b2b7e4e`](https://github.com/NixOS/nixpkgs/commit/7b2b7e4e8c1a9890c3b0ac855136980240483964) | `python310Packages.motionblinds: 0.5.12 -> 0.5.13`                    |
| [`2efd5dcd`](https://github.com/NixOS/nixpkgs/commit/2efd5dcd7f377a94f1d0aa72a07086ff83c8d556) | `python3Packages.ocrmypdf: 13.3.0 -> 13.4.0`                          |
| [`977eb59b`](https://github.com/NixOS/nixpkgs/commit/977eb59b5abc99d819b8a4ce2a1a1f8afb91d121) | `python3Packages.pikepdf: 4.4.1 -> 5.0.1`                             |
| [`bde47152`](https://github.com/NixOS/nixpkgs/commit/bde471522292a6908fedfe5db928e28cb09488aa) | `qpdf: 10.6.0 -> 10.6.2`                                              |
| [`95d2f006`](https://github.com/NixOS/nixpkgs/commit/95d2f00643ba602b0156ee48451fa9721b16036e) | `qpdf: 10.4.0 -> 10.6.0`                                              |
| [`af9f064e`](https://github.com/NixOS/nixpkgs/commit/af9f064e454661394c41c45a68940a466918384c) | `deltachat-desktop: fix build`                                        |
| [`8e54a335`](https://github.com/NixOS/nixpkgs/commit/8e54a33514436d1e1c3481d7b45d02df7880a841) | `terraform-providers: update 2022-02-21`                              |
| [`c94b7109`](https://github.com/NixOS/nixpkgs/commit/c94b7109634a5b0df4213de10648d2612b2b5b4b) | `python310Packages.aio-georss-gdacs: 0.5 -> 0.6`                      |
| [`97a60bd1`](https://github.com/NixOS/nixpkgs/commit/97a60bd1c73023697fd54276ad20eb46b7db6e9e) | `python310Packages.pynetbox: 6.6.0 -> 6.6.1`                          |
| [`2b4dbfc4`](https://github.com/NixOS/nixpkgs/commit/2b4dbfc4cafc0bd4c97c1a6602fecf3a8d694253) | `lima: 0.8.2 -> 0.8.3`                                                |
| [`4a0787ef`](https://github.com/NixOS/nixpkgs/commit/4a0787ef51823ef3a51bc790c88bf0cd1a59fff7) | `python310Packages.teslajsonpy: 1.7.0 -> 1.8.0`                       |
| [`927ff6c2`](https://github.com/NixOS/nixpkgs/commit/927ff6c2edf9ee2872f3aa375dda88a5bc3cc077) | `texstudio: 4.2.1 -> 4.2.2`                                           |
| [`4ffd1c3a`](https://github.com/NixOS/nixpkgs/commit/4ffd1c3aa242171a3314b92559cc4e4a05c8f4f7) | `esphome: fix esp32 build`                                            |
| [`3fc658e0`](https://github.com/NixOS/nixpkgs/commit/3fc658e07ea08105349c3823905ba204ab92e5e1) | `python3Packages.bimmer-connected: 0.8.10 -> 0.8.11`                  |
| [`fa7af736`](https://github.com/NixOS/nixpkgs/commit/fa7af73685366d1da6d248679bf2b9ce7007692e) | `alejandra: 0.3.0 -> 0.3.1`                                           |
| [`c2ea196a`](https://github.com/NixOS/nixpkgs/commit/c2ea196a53f8703b76198c1d10aac4b529705b7c) | `comixcursors: init at 0.9.2`                                         |
| [`b53d9c3e`](https://github.com/NixOS/nixpkgs/commit/b53d9c3e5c0684edd4332d0eb6d05ca64aa1ccf4) | `maintainers: add DerickEddington`                                    |
| [`13f55bab`](https://github.com/NixOS/nixpkgs/commit/13f55bab1b1c68a0c7c6b63872ddb9aa57438068) | `ioztat: init at 1.1.0`                                               |
| [`fd5b0c90`](https://github.com/NixOS/nixpkgs/commit/fd5b0c903f01d94aaa788bac6c0fe49081ce8012) | `standardnotes: 3.9.5 -> 3.11.1`                                      |
| [`d81f048e`](https://github.com/NixOS/nixpkgs/commit/d81f048ef4ce360ba2d11d3d7c94398be134b380) | `jless: 0.7.1 -> 0.7.2`                                               |
| [`d9d37eea`](https://github.com/NixOS/nixpkgs/commit/d9d37eea316a06f1b7b6451a33eb7aa51e7a7253) | `esphome: 2022.2.3 -> 2022.2.4`                                       |
| [`5ab8c97a`](https://github.com/NixOS/nixpkgs/commit/5ab8c97a90c3579a47b3cf4ef24f0e16f014d86e) | `python3Packages.rki-covid-parser: 1.3.1 -> 1.3.2`                    |
| [`aa418a01`](https://github.com/NixOS/nixpkgs/commit/aa418a0101119facbbfab2072ca3f3ba7e6bfb1f) | `python3Packages.pyskyqremote: 0.3.1 -> 0.3.2`                        |
| [`4d237532`](https://github.com/NixOS/nixpkgs/commit/4d2375326ea15abadb7cbd1b2be3a494da7deb67) | `python3Packages.georss-qld-bushfire-alert-client: 0.5 -> 0.6`        |
| [`064a1d87`](https://github.com/NixOS/nixpkgs/commit/064a1d87c339abb68d62dc7e5840da481e8ef9dc) | `python3Packages.georss-wa-dfes-client: 0.3 -> 0.4`                   |
| [`ed4b3338`](https://github.com/NixOS/nixpkgs/commit/ed4b33380512de5db187368e7314853e9235d9cc) | `pinentry-bemenu: 0.9.0 -> 0.10.0`                                    |
| [`6a3c746e`](https://github.com/NixOS/nixpkgs/commit/6a3c746e3bca67bc3f589493d364c8970c7162b8) | `python3Packages.aiohttp-wsgi: 0.9.1 -> 0.10.0`                       |
| [`3efa108f`](https://github.com/NixOS/nixpkgs/commit/3efa108f6eaaf2109ec5e83b139a74743fa1d4d2) | `checkov: 2.0.873 -> 2.0.875`                                         |
| [`23881812`](https://github.com/NixOS/nixpkgs/commit/23881812cffcd8f0b51d4f3e640438cd40dc017f) | `python3Packages.pywlroots: 0.15.8 -> 0.15.9`                         |
| [`dae6f96a`](https://github.com/NixOS/nixpkgs/commit/dae6f96a4178bfe3d4bd8782d553ac9e487abc3c) | `haskellPackages.git-annex: Add shellPath for the git-annex-shell.`   |
| [`0c68f9b9`](https://github.com/NixOS/nixpkgs/commit/0c68f9b952c73d9306fc10e506885d59fc4d68f4) | `librest: build developer docs`                                       |
| [`3d1a53e4`](https://github.com/NixOS/nixpkgs/commit/3d1a53e4a4e33a02be134daf81b4b4b0447fef13) | `librest: propagate dependencies listed in Required`                  |
| [`bd76a1ed`](https://github.com/NixOS/nixpkgs/commit/bd76a1edbc5d1681cfd8efbfbfc090aaf362f238) | `phantomjs: drop`                                                     |
| [`f9cdab72`](https://github.com/NixOS/nixpkgs/commit/f9cdab729d89429f48ea91c333c65fa9f7f3bfc7) | `readline5, readline62: drop`                                         |
| [`8b7f1265`](https://github.com/NixOS/nixpkgs/commit/8b7f1265c2213ed6dbd92f84670f7ab0c539d435) | `mdbook-graphviz: 0.1.3 -> 0.1.4`                                     |
| [`be840f03`](https://github.com/NixOS/nixpkgs/commit/be840f035a8a7a2af5d725c15155db8871221a3a) | `exploitdb: 2022-02-17 -> 2022-02-19`                                 |
| [`2d28e648`](https://github.com/NixOS/nixpkgs/commit/2d28e64868296e361202352645c297385be3c15c) | `yq-go: 4.20.1 -> 4.20.2`                                             |
| [`76007afe`](https://github.com/NixOS/nixpkgs/commit/76007afe26b20830bb307ebdf70444ce98023024) | `yate: 6.1.0-1 -> 6.4.0-1`                                            |
| [`79f76cd8`](https://github.com/NixOS/nixpkgs/commit/79f76cd8df535587074f74916fa853097025f4a7) | `fish: fix cross compile`                                             |
| [`74a17478`](https://github.com/NixOS/nixpkgs/commit/74a1747887fa611d31294311dff076aa35071755) | `svgbob: 0.6.4 -> 0.6.5`                                              |
| [`8c6ba1fe`](https://github.com/NixOS/nixpkgs/commit/8c6ba1fe12deea33701028240426284b9343deb4) | `svgbob: 0.6.3 -> 0.6.4`                                              |
| [`6b14b4fb`](https://github.com/NixOS/nixpkgs/commit/6b14b4fb30a94559a3e4e4dac7c83bb15e11e494) | `libliftoff: 0.1.0 -> 0.2.0`                                          |
| [`4710213b`](https://github.com/NixOS/nixpkgs/commit/4710213b36635f0364f53a7e3cd63832abc28b94) | `lagrange: 1.10.5 -> 1.10.6`                                          |
| [`22fc52a4`](https://github.com/NixOS/nixpkgs/commit/22fc52a4b11be91ec8791c3e4427c4823d776d7c) | `bird2: 2.0.8 -> 2.0.9`                                               |
| [`9b84a53c`](https://github.com/NixOS/nixpkgs/commit/9b84a53ce8ef9bef0b6d1374d281dcabced4c17b) | `Adjust ehmry maintainership`                                         |
| [`8b118258`](https://github.com/NixOS/nixpkgs/commit/8b1182587217019753d6bedc7df766ee641b802f) | `certipy: unstable-2021-11-08 -> 2.0`                                 |
| [`5cd89f91`](https://github.com/NixOS/nixpkgs/commit/5cd89f9173c313c85d17c00cb9393b638b664710) | `python3Packages.dsinternals: init at 1.2.4`                          |
| [`da6d0ab6`](https://github.com/NixOS/nixpkgs/commit/da6d0ab616a45d318e9d92d99d7a5b6ee9dc8bda) | `alephone-infinity: 20210408 -> 20220115`                             |
| [`75a46778`](https://github.com/NixOS/nixpkgs/commit/75a4677819589cb610199143e113f86e495404ca) | `jackett: 0.20.576 -> 0.20.596`                                       |
| [`23360348`](https://github.com/NixOS/nixpkgs/commit/233603486790b6ab0b2bac3e88b0751c2066d613) | `remmina: 1.4.23 -> 1.4.24`                                           |
| [`96deebbd`](https://github.com/NixOS/nixpkgs/commit/96deebbd3485a0d071eb350a184b49668f84f340) | `tribler: 7.10.0 -> 7.11.0`                                           |
| [`4994cd3f`](https://github.com/NixOS/nixpkgs/commit/4994cd3f8ed1778d8bf77ee39f75ec435006f25a) | `tuntox: init at 0.0.10`                                              |
| [`ed39a3ff`](https://github.com/NixOS/nixpkgs/commit/ed39a3ffba221a2a98d510d6f04bdb8658e01f2b) | `nimlsp: 0.3.2 -> 0.4.0`                                              |
| [`7d6dc250`](https://github.com/NixOS/nixpkgs/commit/7d6dc250f6da66baa338f360b94d0f03f4bca9bb) | `nimPackages.jsonschema: use buildNimPackage`                         |
| [`712344f0`](https://github.com/NixOS/nixpkgs/commit/712344f0f925b7c312969086050b9f44a720cbb0) | ` python310Packages.mypy-boto3-builder: 6.3.2 -> 7.1.2`               |
| [`8c023415`](https://github.com/NixOS/nixpkgs/commit/8c023415b9696df1361d338fea00ee4cce7af73a) | `python3Packages.newversion: init at 1.8.2`                           |
| [`450eab2c`](https://github.com/NixOS/nixpkgs/commit/450eab2ca784ba51384cb34e146a1be2b88bf144) | `coqPackages_8_14.gaia-hydras: 0.5 -> 0.6`                            |
| [`8208c3ee`](https://github.com/NixOS/nixpkgs/commit/8208c3eec8622becc0806c998146161a82a715ec) | `coqPackages.addition-chains: 0.5 -> 0.6`                             |
| [`d0bb08b5`](https://github.com/NixOS/nixpkgs/commit/d0bb08b5cce184e1f9837eeede8c6e2227bb2379) | `coqPackages.hydra-battles: 0.5 -> 0.6`                               |
| [`7fa2a723`](https://github.com/NixOS/nixpkgs/commit/7fa2a7232d1105501e498d0846828c3b82ab4c4b) | `coqPackages.LibHyps: init at 2.0.4.1`                                |
| [`a8121ca8`](https://github.com/NixOS/nixpkgs/commit/a8121ca80e04d22d98504fdddd90e342fdda7387) | `mastodon: apply upstream patch for CVE-2022-0432`                    |
| [`e7597bcb`](https://github.com/NixOS/nixpkgs/commit/e7597bcb5a5f8324a4997dfdd2d6b43bc8aa85dd) | `postgresql11Packages.repmgr: 5.3.0 -> 5.3.1`                         |
| [`156e0e2b`](https://github.com/NixOS/nixpkgs/commit/156e0e2b071c8de44155ab56830192a6586edc87) | `rsyslog: 8.2112.0 -> 8.2202.0`                                       |
| [`93609b6a`](https://github.com/NixOS/nixpkgs/commit/93609b6af5e30470c9df3c9345b999d27f46bb4b) | `swtpm: add nixosTests.systemd-cryptenroll to passthru.tests`         |
| [`4593c25b`](https://github.com/NixOS/nixpkgs/commit/4593c25b4ab6eb9f19e4bb856d56529dc99a0ab0) | `swtpm: 0.7.0 -> 0.7.1`                                               |
| [`0334f6a8`](https://github.com/NixOS/nixpkgs/commit/0334f6a82561369fa802816e8d255c62ae989b6a) | `prometheus-redis-exporter: 1.35.0 -> 1.35.1`                         |
| [`ef828225`](https://github.com/NixOS/nixpkgs/commit/ef828225247a472b41dca0e2e7e8120407d0290d) | `python3Packages.enlighten: disable failing test`                     |
| [`f55d6277`](https://github.com/NixOS/nixpkgs/commit/f55d6277524dfb3bffcb71ebb17ad5c6340f3308) | `python310Packages.pyoctoprintapi: 0.1.7 -> 0.1.8`                    |
| [`0a5fe820`](https://github.com/NixOS/nixpkgs/commit/0a5fe8205a90fd6f53de10852fcaee01b209dcf0) | `python310Packages.jsonrpclib-pelix: 0.4.3.1 -> 0.4.3.2`              |
| [`09033167`](https://github.com/NixOS/nixpkgs/commit/09033167ee998599b1234bc94f456942e2edc4a8) | `gnome-bluetooth: fix transposition error`                            |
| [`8a5cdd6c`](https://github.com/NixOS/nixpkgs/commit/8a5cdd6c7d4334ca808d87f43caff02df0d263f0) | `quilt: 0.66 -> 0.67`                                                 |
| [`c8c847b8`](https://github.com/NixOS/nixpkgs/commit/c8c847b8e848714f0848479c8d11e2d2d48ffcb2) | `squirrel-sql: 4.2.0 -> 4.3.0`                                        |
| [`96983152`](https://github.com/NixOS/nixpkgs/commit/96983152e7b0576dc0d0887a0e5610cffc8fd28e) | `php81: 8.1.2 -> 8.1.3`                                               |
| [`60dfe5bd`](https://github.com/NixOS/nixpkgs/commit/60dfe5bd6c173fe3e59273983b97b0a745b96f72) | `php80: 8.0.14 -> 8.0.16`                                             |
| [`b1cd9254`](https://github.com/NixOS/nixpkgs/commit/b1cd9254849b3a1a81d225f4a3025e1a53a7a481) | `php74: 7.4.27 -> 7.4.28`                                             |
| [`c6859b76`](https://github.com/NixOS/nixpkgs/commit/c6859b76947766a63ea86410014966d8eb1d3f20) | `python310Packages.coqpit: 0.0.14 -> 0.0.15`                          |
| [`59b1fab5`](https://github.com/NixOS/nixpkgs/commit/59b1fab58026b08ad7c0103ab6b53ca067af41f6) | `libguestfs: 1.44.1 → 1.46.2`                                         |
| [`32a2f83b`](https://github.com/NixOS/nixpkgs/commit/32a2f83b65f5f51e819be4fd9157edc5a0f5c660) | `python310Packages.azure-mgmt-recoveryservicesbackup: 4.1.0 -> 4.1.1` |
| [`08b16191`](https://github.com/NixOS/nixpkgs/commit/08b16191a93d10bdbec0e56e4a90f709e653d5a5) | `datree: 0.15.5 -> 0.15.16`                                           |
| [`04f07d1d`](https://github.com/NixOS/nixpkgs/commit/04f07d1d284d05c1bcf282e3377030e221f0abc4) | `girara: 0.3.6 -> 0.3.7`                                              |
| [`16764012`](https://github.com/NixOS/nixpkgs/commit/16764012f7a84f86b11bda0676c6efedab1b3f6c) | `mutt: 2.2.0 -> 2.2.1`                                                |
| [`f1f722f2`](https://github.com/NixOS/nixpkgs/commit/f1f722f2220203fcb77d279cb590a7e9d8414752) | `bitwarden: 1.31.2 -> 1.31.3`                                         |
| [`f04b77b0`](https://github.com/NixOS/nixpkgs/commit/f04b77b015ca4cbd0c0638c4ee9581697a0f7dcd) | `dolt: 0.36.2 -> 0.37.0`                                              |
| [`3082e064`](https://github.com/NixOS/nixpkgs/commit/3082e064fe3c9008ca559cfd7b7ecba4fffcfec5) | `pycritty: 0.3.5 -> 0.4.0`                                            |
| [`9c001696`](https://github.com/NixOS/nixpkgs/commit/9c0016965665b9041012c5d2b728aeb9e72e5428) | `sqlite-utils: 3.23 -> 3.24`                                          |
| [`b030dbef`](https://github.com/NixOS/nixpkgs/commit/b030dbef0366548c4c1f497671f397d7077f3a46) | `scli: 0.6.6 -> 0.7.0`                                                |
| [`f4bbb877`](https://github.com/NixOS/nixpkgs/commit/f4bbb877aa915a1708b26e356dc6ef309d315eb9) | `python310Packages.python-rapidjson: 1.5 -> 1.6`                      |
| [`0bb30259`](https://github.com/NixOS/nixpkgs/commit/0bb30259bab2bb27b593d3cbc429c8fe0a944dc0) | `python310Packages.aws-lambda-builders: 1.11.0 -> 1.12.0`             |
| [`187d0055`](https://github.com/NixOS/nixpkgs/commit/187d0055d666833c3585d969bfe87c534a4eac8f) | `python310Packages.tinydb: 4.6.1 -> 4.7.0`                            |
| [`5a51b208`](https://github.com/NixOS/nixpkgs/commit/5a51b208691b854765a1eb97039e5fea5560bddb) | `python310Packages.protego: 0.2.0 -> 0.2.1`                           |
| [`857da052`](https://github.com/NixOS/nixpkgs/commit/857da052ee430649b643cb1cbd99212aaa5c1b1d) | `autorestic: 1.5.2 -> 1.5.5`                                          |
| [`8ec5134f`](https://github.com/NixOS/nixpkgs/commit/8ec5134f0e21f096a0f044854713ba05cea768ea) | `werf: 1.2.67 -> 1.2.69`                                              |
| [`a5497466`](https://github.com/NixOS/nixpkgs/commit/a54974664d30444dd9fa253710667f8c92ad9439) | `python310Packages.aioazuredevops: 1.3.5 -> 1.4.3`                    |
| [`03200cc4`](https://github.com/NixOS/nixpkgs/commit/03200cc4c40889f4ad515b3d5fbc606484e30d60) | `buildNimPackages: by default use Nim's platforms`                    |
| [`3ca65662`](https://github.com/NixOS/nixpkgs/commit/3ca6566259091946d621862d8f110d085be4a4fe) | `python310Packages.symengine: 0.8.1 -> 0.9.0`                         |
| [`8b25c418`](https://github.com/NixOS/nixpkgs/commit/8b25c418bc62d1c5e06bf29752940b396e327872) | `tilt: 0.25.0 -> 0.25.1`                                              |
| [`438d759b`](https://github.com/NixOS/nixpkgs/commit/438d759bb49731d2394c4110d3cdf42a4009b377) | `maintainers: remove linarcx`                                         |
| [`50411a70`](https://github.com/NixOS/nixpkgs/commit/50411a706bc42dc01404f87a3d82abd86d4d83ab) | `tiled: 1.8.1 -> 1.8.2`                                               |
| [`efe36ad0`](https://github.com/NixOS/nixpkgs/commit/efe36ad03bbed62de8c9c14939ce72d677e6073f) | `sonobuoy: 0.56.1 -> 0.56.2`                                          |
| [`da95597f`](https://github.com/NixOS/nixpkgs/commit/da95597fe8823153a1fc5e6465e464b893b44852) | `shiori: 1.5.0 -> 1.5.1`                                              |