### PR TITLE
chore(flake/nixpkgs): `6f9cb9aa` -> `93883402`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1645460852,
-        "narHash": "sha256-bFI96ckrJ5/MvqvsexVTAWLope2EQCVZkDbC1fyPbSc=",
+        "lastModified": 1645503040,
+        "narHash": "sha256-XE4o3NrqBKLs4RlzjHgGy15KC3AY8AsUeVPdB7nmXiE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6f9cb9aa5630747e7ecbb847c4af167e3c0b32bc",
+        "rev": "93883402a445ad467320925a0a5dbe43a949f25b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [`74b10859`](https://github.com/NixOS/nixpkgs/commit/74b10859829153d5c5d50f7c77b86763759e8654) | `netavark: init at 1.0.0`                                                                           |
| [`d4dc5559`](https://github.com/NixOS/nixpkgs/commit/d4dc5559857ea6132a557b570809ee7f8edf7c12) | `aardvark-dns: init at 1.0.0`                                                                       |
| [`0d033358`](https://github.com/NixOS/nixpkgs/commit/0d033358d6fcbed3a1cf0864e0acddbb06ed74b3) | `python3Packages.pivy: fix build`                                                                   |
| [`e88b01cc`](https://github.com/NixOS/nixpkgs/commit/e88b01cc7c39b05228e76158f60e81a71390ead2) | `rmview: 3.1 -> 3.1.1`                                                                              |
| [`4faad70d`](https://github.com/NixOS/nixpkgs/commit/4faad70d25b06084d9d86834108e2a4504e039c3) | `globe-cli: init at 0.2.0 (#161239)`                                                                |
| [`80001395`](https://github.com/NixOS/nixpkgs/commit/800013956d54e37c4803a0e6aa2ed57bf29c107a) | `awsebcli: 3.14.2 -> 3.20.3`                                                                        |
| [`13910710`](https://github.com/NixOS/nixpkgs/commit/13910710546b0b1ebb6a042d0aea99f6de52d226) | `libspf2: update description and homepage to match upstream`                                        |
| [`11291893`](https://github.com/NixOS/nixpkgs/commit/112918938f65bb72680f58d78a51645fcb53a905) | `xboxdrv: bump scons (#158405)`                                                                     |
| [`2d67cc2b`](https://github.com/NixOS/nixpkgs/commit/2d67cc2bf6768355f0310ae840330db9d336b1a9) | `removing maintainer wucke13 from some packages`                                                    |
| [`e54a3f08`](https://github.com/NixOS/nixpkgs/commit/e54a3f0819dfd9a56973172bfd93265b37ce0f03) | `cmake-language-server: build with pyparsing 3.0.6`                                                 |
| [`b0834fa2`](https://github.com/NixOS/nixpkgs/commit/b0834fa2b7ab7f7f7010e6e355840110aab0b9c0) | `asciidoc-full{,-with-plugins}: remove appendToName to have a consistent package name for repology` |
| [`0100a758`](https://github.com/NixOS/nixpkgs/commit/0100a7580176124cc58dae9d713167a85498cef6) | `kmod-blacklist-ubuntu: don't refer to grep/xargs`                                                  |
| [`81ef57d6`](https://github.com/NixOS/nixpkgs/commit/81ef57d6949b8a7b80a7e7ccf792df0be7df0e84) | `amule-{daemon,gui}: renamed package name to kebap-case`                                            |
| [`0074ebd5`](https://github.com/NixOS/nixpkgs/commit/0074ebd592d5ccb1f6677887cf162f35c38015af) | `imagemagick: 7.1.0-25 -> 7.1.0-26`                                                                 |
| [`2bee70d5`](https://github.com/NixOS/nixpkgs/commit/2bee70d513298c4a439680df3792594c0b0baa63) | `statix: 0.5.3 -> 0.5.4`                                                                            |
| [`1b1f3370`](https://github.com/NixOS/nixpkgs/commit/1b1f33706876b032aa747f81ffd6c7f88977d1e4) | `argo-rollouts: init at 1.1.1`                                                                      |
| [`e77507b4`](https://github.com/NixOS/nixpkgs/commit/e77507b4356a057e71c78a284afb1a24cbcabe9b) | `python3Packages.pywayland: 0.4.10 -> 0.4.11`                                                       |
| [`83d6f37b`](https://github.com/NixOS/nixpkgs/commit/83d6f37bd97a9b88eec8c370847746beeb7b2423) | `timg: 1.4.3 -> 1.4.4`                                                                              |
| [`d6468ecd`](https://github.com/NixOS/nixpkgs/commit/d6468ecd57e1b7a6c4a8be295db1c9a873e60867) | `vttest: 20210210 -> 20220215`                                                                      |
| [`9a5767cd`](https://github.com/NixOS/nixpkgs/commit/9a5767cd5c147afab072d369e7ac3a73eadb79bf) | `amuleGui,amuleDaemon: remove appendToName to have a consistent package name for repology`          |
| [`7159ea47`](https://github.com/NixOS/nixpkgs/commit/7159ea47a45a2acfbb1f30422b51105d97d3b19c) | `ocamlPackages.torch: 0.13 → 0.14`                                                                  |
| [`87c1d9f9`](https://github.com/NixOS/nixpkgs/commit/87c1d9f92ce36f139e2ad0d5cef59a88965dd9f9) | `bada-bib: 0.4.1 -> 0.5.1`                                                                          |
| [`aaee8f07`](https://github.com/NixOS/nixpkgs/commit/aaee8f073356860348540c59e50e9afce806cb05) | `iosevka: 11.0.1 → 14.0.1`                                                                          |
| [`3feee7f6`](https://github.com/NixOS/nixpkgs/commit/3feee7f66e7c1914c3fa973b50cffccb0b9318a9) | `hexd: 1.0.0 -> 1.1.0`                                                                              |
| [`48c30036`](https://github.com/NixOS/nixpkgs/commit/48c3003616afc893806326aed5467902d64f7d23) | `gentium: 6.001 -> 6.101`                                                                           |
| [`70f2d860`](https://github.com/NixOS/nixpkgs/commit/70f2d8602b1d1916faa2893ee48df4912cd010e5) | `miniserve: 0.19.1 -> 0.19.2`                                                                       |
| [`ab959a45`](https://github.com/NixOS/nixpkgs/commit/ab959a45fa3a07f3a428fda8fceaa0642b94ca27) | `marwaita: 12.1 -> 13.0`                                                                            |
| [`c653ea92`](https://github.com/NixOS/nixpkgs/commit/c653ea92251681c2212ccbcc5f4368cbe6f090f1) | `lfs: 1.4.0 -> 2.0.1`                                                                               |
| [`b6e09527`](https://github.com/NixOS/nixpkgs/commit/b6e09527b294f06fbd700382c20b4c3054c00e5e) | `libserdes: fix compatibility with Avro master branch`                                              |
| [`b41b7172`](https://github.com/NixOS/nixpkgs/commit/b41b71729ea3ac47cf47cf729bd091a7f665deda) | `avro-cpp: 1.8.2 -> 1.10.2`                                                                         |
| [`af98faa4`](https://github.com/NixOS/nixpkgs/commit/af98faa42831adc098431fac90d528b3e22ae585) | `duktape: 2.6.0 -> 2.7.0`                                                                           |
| [`61518b58`](https://github.com/NixOS/nixpkgs/commit/61518b585417799911377aa0ab114854d0964964) | `libhomfly: 1.02r5 -> 1.02r6`                                                                       |
| [`5a44607a`](https://github.com/NixOS/nixpkgs/commit/5a44607ad47899d5754b25df9f34f3f1ea6ac4f0) | `cargo-expand: 1.0.14 -> 1.0.16`                                                                    |
| [`e4068080`](https://github.com/NixOS/nixpkgs/commit/e40680801b3be291c5d2547e2ae3b16d308764d8) | `orchis-theme: 2021-12-13 -> 2022-02-18`                                                            |
| [`33b6c73f`](https://github.com/NixOS/nixpkgs/commit/33b6c73fc3319f1a32941cb653f856c163bdb4ca) | `python3Packages.augmax: init at unstable-2022-02-19`                                               |
| [`57fc08cf`](https://github.com/NixOS/nixpkgs/commit/57fc08cfdbd1a3a59f26416814dc10f8379d6e67) | `nixos: Switch to default systemd-nspawn behaviour`                                                 |
| [`d98a7906`](https://github.com/NixOS/nixpkgs/commit/d98a7906b7308eb34fa482f8b03cd4e34513abfa) | `termusic: init at 0.6.10`                                                                          |
| [`8a3191fa`](https://github.com/NixOS/nixpkgs/commit/8a3191fa1b0bf9fb9c3d59cfb1184adff4312377) | `obs-studio: enable AV1 encoding`                                                                   |
| [`22d5fde0`](https://github.com/NixOS/nixpkgs/commit/22d5fde0eed2605fd7a50a66b0da87b42f6b1b83) | `octavePackages.symbolic: 2.9.0 -> unstable-2021-10-16`                                             |
| [`db693baf`](https://github.com/NixOS/nixpkgs/commit/db693baf19c7dc20ec118d9c584f4d4b66234d39) | `vim/update.py: accept github token as argument`                                                    |
| [`9d9b5b32`](https://github.com/NixOS/nixpkgs/commit/9d9b5b321e914543def772e595d78cdfdbb61568) | `vim/update.py: add dummy nixpkgs_repo to shutdown pyright warnings`                                |
| [`8250f0f4`](https://github.com/NixOS/nixpkgs/commit/8250f0f4ea6c88095586c1a9434519b1ed8d5f07) | `hdf5-mpi,hdf5-cpp,hdf5-fortran,hdf5-threadsafe: remove appendToName to`                            |
| [`d3c64caf`](https://github.com/NixOS/nixpkgs/commit/d3c64cafdab87cdba69d4a4b72633969edffb2e5) | `manta: use nodejs-14_x, default nodejs version on release-21.11`                                   |
| [`1df9e95e`](https://github.com/NixOS/nixpkgs/commit/1df9e95ed751f9a37e7d5d9db1efc4eff242e043) | `nixos/miniflux: no cleartext password in the store`                                                |