### PR TITLE
chore(flake/nixpkgs): `93883402` -> `7c4a6c57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1645503040,
-        "narHash": "sha256-XE4o3NrqBKLs4RlzjHgGy15KC3AY8AsUeVPdB7nmXiE=",
+        "lastModified": 1645548382,
+        "narHash": "sha256-N97JIrL1HdF/ILkmznHWj9ojnybUT4QuCW+prnoyCeM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "93883402a445ad467320925a0a5dbe43a949f25b",
+        "rev": "7c4a6c57b6590138f983be626d6b91dd16a53d25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                          |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`e71f3a7e`](https://github.com/NixOS/nixpkgs/commit/e71f3a7ef823decbfc9efe46231c849804c241b3) | `pinta: re-added missing runtime icons`                                 |
| [`67574bd9`](https://github.com/NixOS/nixpkgs/commit/67574bd99457d0971357baded8274c4442d8c2f7) | `nim: 1.6.2 -> 1.6.4`                                                   |
| [`9f2d210f`](https://github.com/NixOS/nixpkgs/commit/9f2d210fde8e647bcfd92e70098faffb7ae0636d) | `elmPackages.elm: explicitely use ghc8107`                              |
| [`ec9dcce5`](https://github.com/NixOS/nixpkgs/commit/ec9dcce541319b164b8e6370dc141815518cd07f) | `python310Packages.beartype: 0.9.1 -> 0.10.1`                           |
| [`d76955da`](https://github.com/NixOS/nixpkgs/commit/d76955da6899b4cddcd28e7383f5d67c73fffde3) | `netdata: add protobuf support`                                         |
| [`25db9143`](https://github.com/NixOS/nixpkgs/commit/25db9143c4dcdb2d419ad349f3fc23a40e33dffd) | `python310Packages.sphinxext-opengraph: 0.5.1 -> 0.6.0`                 |
| [`60b70fec`](https://github.com/NixOS/nixpkgs/commit/60b70fec0b966a4711328703005f69f470a06b39) | `mpd-discord-rpc: 1.2.3 -> 1.3.0`                                       |
| [`98035afe`](https://github.com/NixOS/nixpkgs/commit/98035afeb8346fbb2d3bab9d875f2ef529f213ac) | `mdzk: 0.5.0 -> 0.5.1`                                                  |
| [`f93c5851`](https://github.com/NixOS/nixpkgs/commit/f93c58512ce886f26d3fa0b25b7a0c176f6dd8d8) | `python3Packages.uvloop: fix build on aarch64-darwin`                   |
| [`74f880ab`](https://github.com/NixOS/nixpkgs/commit/74f880ab5823cd98a587ac628881896b786c9e8c) | `lispPackages.slynk: init at sly-20210411-git`                          |
| [`95ca2ce4`](https://github.com/NixOS/nixpkgs/commit/95ca2ce47a571fb6683574c48f79c135eeb441c2) | `lispPackages.mmap: init at 20201220-git`                               |
| [`5497715d`](https://github.com/NixOS/nixpkgs/commit/5497715d1d8675b13850336ffd975815eec0f8ae) | `exploitdb: 2022-02-19 -> 2022-02-22`                                   |
| [`ff916c7e`](https://github.com/NixOS/nixpkgs/commit/ff916c7e607b9975aad28eff0d13c366caa12fc2) | `python310Packages.cloudsmith-api: 1.8.2 -> 1.30.0`                     |
| [`56d6192b`](https://github.com/NixOS/nixpkgs/commit/56d6192bfd3f53cf4189782d985e847665504e92) | `checkov: 2.0.875 -> 2.0.885`                                           |
| [`206f3e74`](https://github.com/NixOS/nixpkgs/commit/206f3e74ddda6e53fcc8db05cce571e597b46a9f) | `python3Packages.adafruit-platformdetect: 3.19.2 -> 3.20.0`             |
| [`6a353243`](https://github.com/NixOS/nixpkgs/commit/6a353243b8cf5fe3dc0a41e7182910ae137a4f9a) | `jackett: 0.20.596 -> 0.20.604`                                         |
| [`acc9c35d`](https://github.com/NixOS/nixpkgs/commit/acc9c35df0f71723c5b67bbf2426f8a3dc786a96) | `python3Packages.pyswitchbot: disable on older Python releases`         |
| [`67027010`](https://github.com/NixOS/nixpkgs/commit/67027010941515b4419244ed161dd0f655f959aa) | `abcmidi: 2022.01.28 -> 2022.02.13`                                     |
| [`f122e955`](https://github.com/NixOS/nixpkgs/commit/f122e9550c93c8995d3552c187ba53024b0fc3e0) | `python3Packages.imap-tools: 0.51.0 -> 0.51.1`                          |
| [`0ec19bc5`](https://github.com/NixOS/nixpkgs/commit/0ec19bc5b71472fd69034c8af4aca74f5679027e) | `gvm-libs: 21.4.3 -> 21.4.4`                                            |
| [`e1a362eb`](https://github.com/NixOS/nixpkgs/commit/e1a362eb388cc7568503e6defb268e8cced6f4e9) | `python3Packages.async-lru: unstable-2020-10-24 -> unstable-2022-02-03` |
| [`0010bbc4`](https://github.com/NixOS/nixpkgs/commit/0010bbc46515ad9e4b9f84265aed135b0d7bb1af) | `python3Packages.pytube: 11.0.2 -> 12.0.0`                              |
| [`86b9be78`](https://github.com/NixOS/nixpkgs/commit/86b9be78430de76bd944d35bdb794c773174d06c) | `vala_0_52: drop`                                                       |
| [`f879d400`](https://github.com/NixOS/nixpkgs/commit/f879d400d62e3e1eef8d52b9e63636bbab59be8f) | `python310Packages.azure-mgmt-containerservice: 16.4.0 -> 17.0.0`       |
| [`f20f185b`](https://github.com/NixOS/nixpkgs/commit/f20f185b8f6e8c180fe42fb6c231cd809657652a) | `git-gone: 0.3.7 -> 0.3.8`                                              |
| [`61f9295f`](https://github.com/NixOS/nixpkgs/commit/61f9295f1164e51d08ad5261bf45a40fba85cbae) | `python310Packages.rki-covid-parser: 1.3.2 -> 1.3.3`                    |
| [`a3a73e8d`](https://github.com/NixOS/nixpkgs/commit/a3a73e8d8dec0061a087543a765201a78452ae01) | `python310Packages.pex: 2.1.66 -> 2.1.67`                               |
| [`ef27286f`](https://github.com/NixOS/nixpkgs/commit/ef27286f781d8ec92012066b5731656f2cceffc9) | `vala_0_48: 0.48.22 → 0.48.23`                                          |
| [`75924574`](https://github.com/NixOS/nixpkgs/commit/759245748cf570876f0eb4ea966388814bf9e4ad) | `python310Packages.pyswitchbot: 0.13.2 -> 0.13.3`                       |
| [`c908f448`](https://github.com/NixOS/nixpkgs/commit/c908f448da09a6b9bc461932c95e0c7ae3fcee1e) | `python310Packages.hahomematic: 0.35.0 -> 0.35.1`                       |
| [`73a0253d`](https://github.com/NixOS/nixpkgs/commit/73a0253df156299e65d7db76e7f86e64dede68a0) | `bemenu: 0.6.6 -> 0.6.7`                                                |
| [`cd8dfd14`](https://github.com/NixOS/nixpkgs/commit/cd8dfd140ce52c6552048093b5092023d4bf27fb) | `python310Packages.subarulink: 0.4.2 -> 0.4.3`                          |
| [`e9bbf660`](https://github.com/NixOS/nixpkgs/commit/e9bbf66080754975eb932180df0ec580cf08dc5b) | `shadowsocks-rust: 1.13.2 -> 1.13.3`                                    |
| [`c19d2d6c`](https://github.com/NixOS/nixpkgs/commit/c19d2d6c3db22e75cec1e2b8fe10db09a510295b) | `resvg: 0.21.0 -> 0.22.0`                                               |
| [`a01f82c9`](https://github.com/NixOS/nixpkgs/commit/a01f82c9435120fed4fc7d6fbaff43b783fd5605) | `btcpayserver: 1.4.4 -> 1.4.6`                                          |
| [`7b6c4c54`](https://github.com/NixOS/nixpkgs/commit/7b6c4c5438e82a808997d485cc0da2f0c9be5f49) | `python3Packages.whitenoise: 5.3.0 -> 6.0.0`                            |
| [`0480c113`](https://github.com/NixOS/nixpkgs/commit/0480c113a1040323080b27be739e22be6c7ecdda) | `buildbot: 3.4.0 -> 3.4.1`                                              |
| [`cc4703a9`](https://github.com/NixOS/nixpkgs/commit/cc4703a9594d4ad0761cb6ed8ed6cdc34bf01a47) | `mycorrhiza: 1.8.1 -> 1.8.2`                                            |
| [`b333395b`](https://github.com/NixOS/nixpkgs/commit/b333395be54397a62e6befe2bc91664f53306b41) | `lib/tests: Add tests for emptyValue`                                   |
| [`38228902`](https://github.com/NixOS/nixpkgs/commit/382289027f92ff3973f14d983a55b183c9b1c0bd) | `lib/types: Fix emptyValue of listOf and nonEmptyListOf`                |
| [`4308069b`](https://github.com/NixOS/nixpkgs/commit/4308069bf1b3d5207e6f69472a05444ca9fa2d7a) | `rtabmap: init at unstable-2022-02-07`                                  |
| [`63599248`](https://github.com/NixOS/nixpkgs/commit/635992489cf0ceb53eb25ccd45bddef53afb2483) | `vtk: move headers out of /include/vtk-*`                               |
| [`16a1b346`](https://github.com/NixOS/nixpkgs/commit/16a1b346d4ef285cffe712e898de18b4948c5ece) | `vtk: create versionless symlinks in /lib`                              |
| [`116ae00e`](https://github.com/NixOS/nixpkgs/commit/116ae00e73d78e723b813b8872553c68cbcb1dac) | `nixos/step-ca: create a step-ca user`                                  |