### PR TITLE
chore(flake/nixpkgs): `7c4a6c57` -> `6d9dcdcf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1645548382,
-        "narHash": "sha256-N97JIrL1HdF/ILkmznHWj9ojnybUT4QuCW+prnoyCeM=",
+        "lastModified": 1645641954,
+        "narHash": "sha256-BkwUyQUsYTVGCGWSpVurAHXHVdBqCYn0ZFO6x+0F5KM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7c4a6c57b6590138f983be626d6b91dd16a53d25",
+        "rev": "6d9dcdcff0d99e559343f1d7143dcef25630a722",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`6d9dcdcf`](https://github.com/NixOS/nixpkgs/commit/6d9dcdcff0d99e559343f1d7143dcef25630a722) | `new-session-manager: 1.5.1 -> 1.5.3`                                      |
| [`f1789bd3`](https://github.com/NixOS/nixpkgs/commit/f1789bd3a00282d60a3f205260eea2f82d00090c) | `diffoscope: 204 -> 205`                                                   |
| [`f48ff2a0`](https://github.com/NixOS/nixpkgs/commit/f48ff2a079b10a25c063a9002b079dfe1987538b) | ``add `/usr` neededForBoot entry to 21.11 release notes``                  |
| [`059b8a6e`](https://github.com/NixOS/nixpkgs/commit/059b8a6e28198b4a6b6581b62332ac7621dda6a5) | `fluxcd: 0.27.0 -> 0.27.2`                                                 |
| [`5d2606d1`](https://github.com/NixOS/nixpkgs/commit/5d2606d1f0ee0b723b073c8f7ea83cca1fdc9757) | `gitlab-runner: 14.7.0 -> 14.8.0`                                          |
| [`9c7955d6`](https://github.com/NixOS/nixpkgs/commit/9c7955d6ed06fe6c599241d3b78b67fc6f76d778) | `python3Packages.simple-di: add format`                                    |
| [`621ec997`](https://github.com/NixOS/nixpkgs/commit/621ec997e44810426bbb952a3242614512d0cca8) | `python3Packages.karton-config-extractor: disable on older Python releses` |
| [`d806547d`](https://github.com/NixOS/nixpkgs/commit/d806547debfbaa5a74ddf7533e45a83a455290ee) | `cassandra_3_11: 3.11.10 -> 3.11.12`                                       |
| [`313acb6c`](https://github.com/NixOS/nixpkgs/commit/313acb6cc2cbe704f41d408ce5ae1f155e2ede28) | `cassandra_3_0: 3.0.24 -> 3.0.26`                                          |
| [`72ddd738`](https://github.com/NixOS/nixpkgs/commit/72ddd738f4ca72f2bbe1d61f6706e644d9ff5aa2) | `cassandra: Remove javadoc which is not shipped in new versions`           |
| [`147a5146`](https://github.com/NixOS/nixpkgs/commit/147a51467ade5d65f5cc2927d62f29a50deec040) | `fluffychat: fix olm FOD`                                                  |
| [`c625e715`](https://github.com/NixOS/nixpkgs/commit/c625e715f857ff2401658f0aa5b1e7c7681d0a34) | `fluffychat: add .desktop`                                                 |
| [`0bd82b77`](https://github.com/NixOS/nixpkgs/commit/0bd82b7767fcadf1bcc6d3a7c5b2b05c70340a99) | `flutter.mkFlutterApp: fix installing .desktop`                            |
| [`141644ff`](https://github.com/NixOS/nixpkgs/commit/141644ff03365689664e9905528d7730b8b44130) | `fluffychat: fix olm`                                                      |
| [`5ecd24b0`](https://github.com/NixOS/nixpkgs/commit/5ecd24b0432f705a6d1fcf0845a5a411ce84893e) | `firmware-updater: update vendor hash`                                     |
| [`2c686d25`](https://github.com/NixOS/nixpkgs/commit/2c686d250e03c0d951dd9190df803fb25b639123) | `flutter: 2.10.0 -> 2.10.1`                                                |
| [`b39b297b`](https://github.com/NixOS/nixpkgs/commit/b39b297b207abd478f55e3a980f164f24f24e8eb) | `duckscript: init at 0.8.10`                                               |
| [`1495ce56`](https://github.com/NixOS/nixpkgs/commit/1495ce56ba94da18c6a8b7ea07c869c17899c5cd) | `flutter.mkFlutterApp: allow extra fetch commands`                         |
| [`847b557e`](https://github.com/NixOS/nixpkgs/commit/847b557ef35ad873acc4ddc53036b80b5d996a81) | `flutter.mkFlutterApp: disable fetch buildPhase`                           |
| [`82646d94`](https://github.com/NixOS/nixpkgs/commit/82646d94992d5abaa9b01d45e8b108364d354799) | `firmware-updater: fix license`                                            |
| [`f32c9135`](https://github.com/NixOS/nixpkgs/commit/f32c9135963082f19d07a81d0d4acd6d460d1b9e) | `python310Packages.karton-config-extractor: 2.0.1 -> 2.0.2`                |
| [`469ae421`](https://github.com/NixOS/nixpkgs/commit/469ae42107cadab393a5fda7de8fb49618a92e39) | `gromacs: 2021.5 -> 2022`                                                  |
| [`94bebb63`](https://github.com/NixOS/nixpkgs/commit/94bebb637cd33f0a312d4bdd39998c25cde40e4c) | `python310Packages.simple-di: 0.1.4 -> 0.1.5`                              |
| [`b041085b`](https://github.com/NixOS/nixpkgs/commit/b041085bb11f050c08cfcccdef7c61508dac52a9) | `trivy: 0.23.0 -> 0.24.0`                                                  |
| [`3c4fb6d5`](https://github.com/NixOS/nixpkgs/commit/3c4fb6d5c1d85c20d68871eed1ddff0de508395c) | `gromit-mpx: 1.4.1 -> 1.4.2`                                               |
| [`70f8a206`](https://github.com/NixOS/nixpkgs/commit/70f8a206e64c4d55fba4b0302795450559b3d6a9) | `python3Packages.pywizlight: 0.5.12 -> 0.5.13`                             |
| [`ce422e76`](https://github.com/NixOS/nixpkgs/commit/ce422e76a5aabf5f247c064b7b44409bf2d80f0e) | `mpd-discord-rpc: 1.3.0 -> 1.4.0`                                          |
| [`36c1ca82`](https://github.com/NixOS/nixpkgs/commit/36c1ca8260c2db27083066457331ff395f871371) | `libsForQt5.krohnkite: 0.7 -> 0.8.2`                                       |
| [`be6d29f0`](https://github.com/NixOS/nixpkgs/commit/be6d29f0744910e5d47818456cb984e6133ec452) | `python3Packages.dasbus: init at 1.6`                                      |
| [`8dcd75a3`](https://github.com/NixOS/nixpkgs/commit/8dcd75a367cbb2ad18f4a2e2def7ad7fa60f554d) | `minio-client: 2022-02-13T23-26-13Z -> 2022-02-16T05-54-01Z`               |
| [`2d9b86e9`](https://github.com/NixOS/nixpkgs/commit/2d9b86e991b98b018f6f31818af46909642ebb0c) | `mdzk: 0.5.1 -> 0.5.2`                                                     |
| [`4ce30aba`](https://github.com/NixOS/nixpkgs/commit/4ce30abaf613c4ff11886fd3d1f6327697b508f1) | `ostree: 2021.6 → 2022.1`                                                  |
| [`18bcf613`](https://github.com/NixOS/nixpkgs/commit/18bcf6138827a16fdc09c3599fb516781c41e464) | `python310Packages.pontos: 22.2.2 -> 22.2.4`                               |
| [`15f46a56`](https://github.com/NixOS/nixpkgs/commit/15f46a561ddb2b4d3b685f8488e506a11c9aafed) | `amdvlk: 2022.Q1.1 -> 2022.Q1.3`                                           |
| [`b436e0f1`](https://github.com/NixOS/nixpkgs/commit/b436e0f165f65ac9eac7a8fbf58110056c74ebc7) | `exploitdb: 2022-02-22 -> 2022-02-23`                                      |
| [`55f16afb`](https://github.com/NixOS/nixpkgs/commit/55f16afb6f684baa83733641ad014428eee75c2c) | `libmodulemd: 2.13.0 → 2.14.0`                                             |
| [`04a8c7b3`](https://github.com/NixOS/nixpkgs/commit/04a8c7b34a8c4f3cf2406ca8b3d9f2bbd7b391f7) | `python3Packages.requests-cache: 0.9.1 -> 0.9.3`                           |
| [`d104e21d`](https://github.com/NixOS/nixpkgs/commit/d104e21d89a934459d3f4d62aa827fdf8ea99bb2) | `python310Packages.sentry-sdk: 1.5.5 -> 1.5.6`                             |
| [`29ea452f`](https://github.com/NixOS/nixpkgs/commit/29ea452faac561f0f6d484571451702bfd8fd050) | `python3Packages.tifffile: 2021.11.2 -> 2022.2.9`                          |
| [`d0e42fc0`](https://github.com/NixOS/nixpkgs/commit/d0e42fc00fb10400823b5061c792543060c1b4a4) | `python3Packages.gcsfs: 2021.10.1 -> 2022.01.0`                            |
| [`8713d025`](https://github.com/NixOS/nixpkgs/commit/8713d0255555a99f3f45e4b857f3690402ab9fea) | `python3Packages.fsspec: 2021.10.1 -> 2022.01.0`                           |
| [`ad822f99`](https://github.com/NixOS/nixpkgs/commit/ad822f99858e0f580209a8b876f744c821e78100) | `python3Packages.distributed: 2021.12.0 -> 2022.2.0`                       |
| [`6148760c`](https://github.com/NixOS/nixpkgs/commit/6148760cc27e68bb848a6ad5183fe41d96686f60) | `python3Packages.dask: 2022.01.0 -> 2022.02.0`                             |
| [`d7a71d0a`](https://github.com/NixOS/nixpkgs/commit/d7a71d0a4a4cabb1fe1e8ffc777632c1230a5d87) | `terrascan: 1.13.1 -> 1.13.2`                                              |
| [`887d370d`](https://github.com/NixOS/nixpkgs/commit/887d370d3f47aafc6ce09a3b7dc31dffe4396299) | `python310Packages.flux-led: 0.28.26 -> 0.28.27`                           |
| [`53cdda8b`](https://github.com/NixOS/nixpkgs/commit/53cdda8bc325d7269b71a21069350602d114dc35) | `python3Packages.renault-api: 0.1.8 -> 0.1.9`                              |
| [`4fadbf0c`](https://github.com/NixOS/nixpkgs/commit/4fadbf0c955083c38c28a4489b322be30f05c140) | `python3Packages.pyuptimerobot: 21.11.0 -> 22.2.0`                         |
| [`c34d322f`](https://github.com/NixOS/nixpkgs/commit/c34d322fb3b6afcba8d9f730dd2f62b18a0970b7) | `kubescape: 2.0.147 -> 2.0.148`                                            |
| [`0459cdea`](https://github.com/NixOS/nixpkgs/commit/0459cdeaed59a69d78308cd2ed0327d3b4ce13c6) | `dbeaver: 21.3.4 -> 21.3.5`                                                |
| [`219288d7`](https://github.com/NixOS/nixpkgs/commit/219288d779fa3d93c3938ec6eef38808d745bcf9) | `python310Packages.pysaml2: 7.1.0 -> 7.1.1`                                |
| [`220b8b81`](https://github.com/NixOS/nixpkgs/commit/220b8b81c7c57ae136be7d50f8d265146a863d4b) | `wg-netmanager: 0.5.0 -> 0.5.1`                                            |
| [`91f3a459`](https://github.com/NixOS/nixpkgs/commit/91f3a4593ca072dd68c512a193a43886b252f1a1) | `cinnamon.xreader: 3.2.2 -> 3.3.0`                                         |
| [`df5c6e08`](https://github.com/NixOS/nixpkgs/commit/df5c6e08b814836efa854c27acbf30b577d978c3) | `coqPackages_8_15.coqhammer: enable at 1.3.2`                              |
| [`fb12caf0`](https://github.com/NixOS/nixpkgs/commit/fb12caf06d3acb8ad4ec3ed891d8d1fb7c2facb0) | `libmodsecurity: add passthru test for nginx-modsecurity`                  |
| [`21f5ce0b`](https://github.com/NixOS/nixpkgs/commit/21f5ce0bd9a1503fc41f09bcbfb4770ab37c3925) | `nixos/tests/nginx-modsecurity: init`                                      |
| [`1986e432`](https://github.com/NixOS/nixpkgs/commit/1986e432438ec82092dbf5c56e97ca340de511f7) | `signify: allow cross-compilation`                                         |
| [`87fddd12`](https://github.com/NixOS/nixpkgs/commit/87fddd120efc5ce1aa2d6e825610841a68e7aa54) | `flyctl: 0.0.297 -> 0.0.298`                                               |
| [`a632265b`](https://github.com/NixOS/nixpkgs/commit/a632265bb41e5b35b7a5242df824d2d344b7a270) | `python310Packages.localimport: 1.7.3 -> 1.7.6`                            |
| [`8375ac2a`](https://github.com/NixOS/nixpkgs/commit/8375ac2ac620ab7480d9cec0ab9c61b7ddf4633a) | `python310Packages.aiolyric: 1.0.8 -> 1.0.9`                               |
| [`31ffa0cb`](https://github.com/NixOS/nixpkgs/commit/31ffa0cbf21bc2cc77e973ddb978b5581d0ddbcd) | `testssl: 3.0.6 -> 3.0.7`                                                  |
| [`68473a39`](https://github.com/NixOS/nixpkgs/commit/68473a393f88908d58385218bbbc8f2908cdee33) | `python310Packages.pyrogram: 1.4.3 -> 1.4.7`                               |
| [`1fdf67b6`](https://github.com/NixOS/nixpkgs/commit/1fdf67b6917e64f95c7c42d242ba730a57a5ddb8) | `Disable stackprotector on aarch64-darwin for PETSc`                       |
| [`ba7b2c8e`](https://github.com/NixOS/nixpkgs/commit/ba7b2c8e252a3ce981d87136b3b1c40f7319ba21) | `mido: Reduce dependances`                                                 |
| [`7c497590`](https://github.com/NixOS/nixpkgs/commit/7c497590b3afef65f28a2dad784613d1b5881a93) | `python310Packages.hahomematic: 0.35.1 -> 0.35.2`                          |
| [`439ed789`](https://github.com/NixOS/nixpkgs/commit/439ed7894068736fbea561bbad62fd5abe0f0ed6) | `python39Packages.pc-ble-driver-py: 0.16.2 -> 0.16.3`                      |
| [`7b4153de`](https://github.com/NixOS/nixpkgs/commit/7b4153de97d88c9d63424c66424a74d6889e3fff) | `apkeep: 0.7.0 -> 0.9.0`                                                   |
| [`7cc9eb95`](https://github.com/NixOS/nixpkgs/commit/7cc9eb95e1743891b894b38e72321060d5a586b3) | `python310Packages.aioshelly: 1.0.9 -> 1.0.10`                             |
| [`a126cc78`](https://github.com/NixOS/nixpkgs/commit/a126cc78b4ed10badf1134ac25fe50ab26bcf7f8) | `glooctl: 1.10.8 -> 1.10.10`                                               |
| [`2ef808d2`](https://github.com/NixOS/nixpkgs/commit/2ef808d2663862f78f1799ca525a614bae95ab28) | `eternal-terminal: remove broken linker flag for c++fs (#161416)`          |
| [`47dc10cb`](https://github.com/NixOS/nixpkgs/commit/47dc10cb7d59215f464f767358612854c5522c15) | `upterm: 0.6.7 -> 0.7.3`                                                   |
| [`ec239953`](https://github.com/NixOS/nixpkgs/commit/ec239953a9528bc70c61ecd1f99c2eecf674ec25) | `datree: 0.15.16 -> 0.15.22`                                               |
| [`ef319a62`](https://github.com/NixOS/nixpkgs/commit/ef319a62b399b2ee4c2fe6a75ae8f0682eeb3bf2) | `opensnitch-ui: inlude dependency pyasn (#160134)`                         |
| [`c9953493`](https://github.com/NixOS/nixpkgs/commit/c995349365e82fcf8510a97d9847b9136e92cf49) | `maintainers: Add ozkutuk`                                                 |
| [`becd20aa`](https://github.com/NixOS/nixpkgs/commit/becd20aa668995f514f1fc1299d979cd46824870) | `python3Packages.videocr: init at 0.1.6`                                   |
| [`e0d35ba8`](https://github.com/NixOS/nixpkgs/commit/e0d35ba801380c9d3c98f046845ce51030a833f6) | `i3status-rust: 0.21.5 -> 0.21.6`                                          |
| [`02f8153b`](https://github.com/NixOS/nixpkgs/commit/02f8153b6744e4df9e4caaa1ff8a2fbce440a101) | `python310Packages.types-requests: 2.27.10 -> 2.27.11`                     |
| [`1bfcbcc0`](https://github.com/NixOS/nixpkgs/commit/1bfcbcc05d0a962e0a138ccfb14d187c9993e196) | `java-service-wrapper: 3.5.48 -> 3.5.49`                                   |
| [`08372f66`](https://github.com/NixOS/nixpkgs/commit/08372f66b28b904199f37b2c388e2aadd2d0ba54) | `xdg-desktop-portal-gtk: 1.10.0 → 1.12.0`                                  |
| [`600edd5e`](https://github.com/NixOS/nixpkgs/commit/600edd5e3f78c7d22070951bef210aef1c0c7735) | `xdg-desktop-portal: 1.10.0 → 1.12.1`                                      |
| [`49c6568a`](https://github.com/NixOS/nixpkgs/commit/49c6568a8f4de3782b7cb9c5a0af3f758eded1bc) | `flatpak: 1.12.4 → 1.12.6`                                                 |
| [`2bdd38d8`](https://github.com/NixOS/nixpkgs/commit/2bdd38d848fc5bb417bdbb237d1034787cd27850) | `ocamlPackages.gg: 0.9.1 → 1.0.0`                                          |
| [`02a518f0`](https://github.com/NixOS/nixpkgs/commit/02a518f00e83c78fda66d9ba722a501367ad1a66) | `openshift: fix build on darwin`                                           |
| [`e2e23aac`](https://github.com/NixOS/nixpkgs/commit/e2e23aac07ead3372473526d057fb9df486fe32f) | `commitizen: use argcomplete 1.12.3`                                       |
| [`f9d835ba`](https://github.com/NixOS/nixpkgs/commit/f9d835ba152834e28df3dca5436052d3a5aeb1ed) | `werf: 1.2.69 -> 1.2.70`                                                   |
| [`e60782c7`](https://github.com/NixOS/nixpkgs/commit/e60782c7fa2c6258e6ef7da5fe0c44da25c69f34) | `firefox: use rustPlatform.bindgenHook`                                    |
| [`6d900390`](https://github.com/NixOS/nixpkgs/commit/6d900390cad16324e46458e5c4d41eaf8892fa02) | `wluma: use rustPlatform.bindgenHook`                                      |
| [`f3027942`](https://github.com/NixOS/nixpkgs/commit/f3027942a4fbc43df98f73aa3616cfa061502af8) | `matrix-conduit: use rustPlatform.bindgenHook`                             |
| [`a6898bc1`](https://github.com/NixOS/nixpkgs/commit/a6898bc1205701671eddfc67f80f643165253e7f) | `ashpd-demo: use rustPlatform.bindgenHook`                                 |
| [`7e29b55e`](https://github.com/NixOS/nixpkgs/commit/7e29b55e9d4c09ed7d045bcb2593ed025ad95107) | `helvum: use rustPlatform.bindgenHook`                                     |
| [`bedabfbc`](https://github.com/NixOS/nixpkgs/commit/bedabfbcef9285804729aa78f933d8ceb4897ecf) | `rustPlatform.bindgenHook: init`                                           |
| [`fde95785`](https://github.com/NixOS/nixpkgs/commit/fde95785c90a82c20e728251a14f4a4c6cd85973) | `commitizen: 2.20.4 -> 2.21.2`                                             |
| [`79dd82ea`](https://github.com/NixOS/nixpkgs/commit/79dd82eadd34300b04d1363be6a2ab84670ac0cb) | `mtxclient: 0.6.1 -> 0.6.2`                                                |
| [`50323b2c`](https://github.com/NixOS/nixpkgs/commit/50323b2c9b95b85ad9fc5a51dafd15fb427d001b) | `ticker: 4.4.4 -> 4.5.0`                                                   |
| [`1769d0eb`](https://github.com/NixOS/nixpkgs/commit/1769d0eb4b515f946dcc65ae04fb5df39ef6a60f) | `symfony-cli: 5.3.4 -> 5.4.0`                                              |
| [`ba576835`](https://github.com/NixOS/nixpkgs/commit/ba57683511dec72ff0e753f80de9616bd758d55b) | `swego: 0.97 -> 0.98`                                                      |
| [`b4ac004d`](https://github.com/NixOS/nixpkgs/commit/b4ac004d09a32160932a22f53c767f3f578051a3) | `nixos/test/networking: test bonding netdev creation`                      |
| [`c2147ab6`](https://github.com/NixOS/nixpkgs/commit/c2147ab6a88250ed668c1b3e577b8c735f63d054) | `modprobe: install systemd's modprobe options`                             |
| [`ff13cd5d`](https://github.com/NixOS/nixpkgs/commit/ff13cd5d3e39fb6dbe456e92e28beb7e8f637f3c) | `lib/modules: Use types.raw for _module.args`                              |
| [`665344f1`](https://github.com/NixOS/nixpkgs/commit/665344f14839ea286a7aeb329fbf4f44da268ce4) | `lib/types: Introduce types.raw for unprocessed values`                    |
| [`df94e74d`](https://github.com/NixOS/nixpkgs/commit/df94e74d685de7b9b68dec0d5937052d084a7276) | `headphones: 0.6.0-alpha.1 -> 0.6.0-beta.5`                                |
| [`dd001162`](https://github.com/NixOS/nixpkgs/commit/dd00116269179f636a29191af1e3cfce9ca84a0b) | `dotter: init at 0.12.9`                                                   |
| [`0dd8ef5e`](https://github.com/NixOS/nixpkgs/commit/0dd8ef5ef7bab2214b3ad2b34ba8466c37e9e078) | `nixos/home-assistant: update package option description`                  |
| [`1090fcb7`](https://github.com/NixOS/nixpkgs/commit/1090fcb7c937e6659f93ffbd7794e9f57de71e42) | `nixos/home-assistant: allow null config value`                            |
| [`4956aa9a`](https://github.com/NixOS/nixpkgs/commit/4956aa9a01d2dd6dce1ac51b80ffd22a5ffa7f1f) | `imgproxy: 3.2.2 -> 3.3.0`                                                 |
| [`da6aa1a2`](https://github.com/NixOS/nixpkgs/commit/da6aa1a265003fcd86e8b6843c4275b742440dd1) | `fselect: 0.7.9 -> 0.8.0`                                                  |
| [`7143f443`](https://github.com/NixOS/nixpkgs/commit/7143f443af4866875252e96378c4569827f3df52) | `ddosify: 0.7.3 -> 0.7.4`                                                  |
| [`a89a5676`](https://github.com/NixOS/nixpkgs/commit/a89a56769ec7d6f58753180565077c9dff955978) | `python310Packages.pyoverkiz: 1.3.5 -> 1.3.6`                              |
| [`0450d5dd`](https://github.com/NixOS/nixpkgs/commit/0450d5dda8f82a71c863fdba7888c5e6ed6deeb3) | `alejandra: 0.3.1 -> 0.4.0`                                                |
| [`5559fd35`](https://github.com/NixOS/nixpkgs/commit/5559fd35fdb17f848382e75699b51ca91f9b66e5) | `got: 0.66 -> 0.67`                                                        |
| [`fd20b684`](https://github.com/NixOS/nixpkgs/commit/fd20b684114601b65767036612b30a4a22b38fa7) | `doulos-sil: 6.001 -> 6.101`                                               |
| [`3db3cb00`](https://github.com/NixOS/nixpkgs/commit/3db3cb00cb5d7c69ba3409231982934b5fd4cbb8) | `andika: 6.001 -> 6.101`                                                   |
| [`fcea2d96`](https://github.com/NixOS/nixpkgs/commit/fcea2d9652f7835017e0da3dc77030fa0757deb5) | `python3Packages.pyroute2-ipset: 0.6.5 -> 0.6.7`                           |
| [`8ec171dc`](https://github.com/NixOS/nixpkgs/commit/8ec171dc8f46a29dab5418414628deef8a9a6194) | `python3Packages.pyroute2: 0.6.5 -> 0.6.7`                                 |
| [`5b42c045`](https://github.com/NixOS/nixpkgs/commit/5b42c045a80f3d5694b327ea0b53cb46581df3c2) | `python3Packages.pyroute2-protocols: 0.6.5 -> 0.6.7`                       |
| [`b5c8b979`](https://github.com/NixOS/nixpkgs/commit/b5c8b9791fea6e8148d9e052a62b36aceae49043) | `python3Packages.pyroute2-nslink: 0.6.5 -> 0.6.7`                          |
| [`b9650e22`](https://github.com/NixOS/nixpkgs/commit/b9650e22d9f87acf1a1075171d7994934e4d778b) | `python3Packages.pyroute2-nftables: 0.6.5 -> 0.6.7`                        |
| [`95ffac75`](https://github.com/NixOS/nixpkgs/commit/95ffac758cfce9dae18c998c8b27e58ad85da9b1) | `python3Packages.pyroute2-ndb: 0.6.5 -> 0.6.7`                             |
| [`69cb5eda`](https://github.com/NixOS/nixpkgs/commit/69cb5edaf77d73b2e685fddbff9797fdd06af9db) | `python3Packages.pyroute2-ipdb: 0.6.5 -> 0.6.7`                            |
| [`fb8072c4`](https://github.com/NixOS/nixpkgs/commit/fb8072c40cf14b0165ad4ec8af3fc4d1c2c87b7e) | `python3Packages.pyroute2-ethtool: 0.6.5 -> 0.6.7`                         |
| [`62047167`](https://github.com/NixOS/nixpkgs/commit/620471678e65a5cf87f3ce7e9e506f28547bbdb1) | `python3Packages.pyroute2-core: 0.6.5 -> 0.6.7`                            |
| [`87cc2bc2`](https://github.com/NixOS/nixpkgs/commit/87cc2bc2944bb05e0d24c8430648647d4199ab11) | `charis-sil: 6.001 -> 6.101`                                               |
| [`1f3babaa`](https://github.com/NixOS/nixpkgs/commit/1f3babaa22650eb16f006d8724c31eeb2cf3b2b6) | `dtrx: 8.2.1 -> 8.2.2`                                                     |
| [`8906d7c9`](https://github.com/NixOS/nixpkgs/commit/8906d7c9b8740824e43804af4d3742dddc012948) | `dolt: 0.37.0 -> 0.37.1`                                                   |
| [`0db4ecb8`](https://github.com/NixOS/nixpkgs/commit/0db4ecb8aff277700e2d889aa32e93cf37120729) | `maintainers/scripts/remove-old-aliases.py: script to remove old aliases`  |
| [`21eb8f63`](https://github.com/NixOS/nixpkgs/commit/21eb8f63d59606dc973fe67dfbe73ca2a4887f75) | `gdown: 4.3.0 -> 4.3.1`                                                    |
| [`8e666465`](https://github.com/NixOS/nixpkgs/commit/8e666465186f058f0be8a01e496f421c157033b3) | `appflowy: 0.0.2 -> 0.0.3`                                                 |
| [`10600763`](https://github.com/NixOS/nixpkgs/commit/10600763f5d18984a4b4f043a46b0022970e9371) | `gnomeExtensions: auto-update`                                             |
| [`6b001db3`](https://github.com/NixOS/nixpkgs/commit/6b001db34c2030871475e27cc6c8ce2066322f6b) | `go-task: 3.10.0 -> 3.11.0`                                                |
| [`ab68ec83`](https://github.com/NixOS/nixpkgs/commit/ab68ec83ebd4f166d0c4b92af0747ab6baac09fa) | `drogon: 1.7.4 -> 1.7.5`                                                   |
| [`2b81805f`](https://github.com/NixOS/nixpkgs/commit/2b81805f80efd6f1090fa8b5fc707449c540d047) | `cherrytree: 0.99.45 -> 0.99.46`                                           |
| [`65b33e4d`](https://github.com/NixOS/nixpkgs/commit/65b33e4d9dd86578069b287c7c9b466fc554d889) | `python310Packages.pythonfinder: 1.2.9 -> 1.2.10`                          |
| [`00acde8e`](https://github.com/NixOS/nixpkgs/commit/00acde8e58a8636f840a33be6e0e857ba7f62d45) | `shipyard: 0.3.44 -> 0.3.45`                                               |
| [`a7a964dd`](https://github.com/NixOS/nixpkgs/commit/a7a964dddcb9faf0994e2c1338335ca154b87d3c) | `ryzenadj: 0.8.3 -> 0.9.0`                                                 |
| [`e169c528`](https://github.com/NixOS/nixpkgs/commit/e169c528ffe12300555ce5c959d55b3b2b75f7d7) | `otpclient: 2.4.7 -> 2.4.8`                                                |
| [`dfca3ba2`](https://github.com/NixOS/nixpkgs/commit/dfca3ba25b2bc45cecf2d1e4dabb4eafcb92d713) | `home-assistant: add fiblary3 dependency for fibaro`                       |
| [`2e8071c4`](https://github.com/NixOS/nixpkgs/commit/2e8071c4e294f12669a181a7db699277472fb204) | `home-assistant: revamp manual package choosing`                           |
| [`d7c43309`](https://github.com/NixOS/nixpkgs/commit/d7c433094b0b559f89b74c3f03482af9aefb091f) | `python3Packages.fiblary3: init at 0.1.12`                                 |
| [`2eb8fcaa`](https://github.com/NixOS/nixpkgs/commit/2eb8fcaa178d94f5fd5e0a33a3eb58c9f0f70807) | `libtsm: 4.0.1 -> 4.0.2`                                                   |