### PR TITLE
chore(flake/nixpkgs): `6d9dcdcf` -> `9ec9d474`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1645641954,
-        "narHash": "sha256-BkwUyQUsYTVGCGWSpVurAHXHVdBqCYn0ZFO6x+0F5KM=",
+        "lastModified": 1645678056,
+        "narHash": "sha256-P+J3DJmd7xjmH2SICbGrr3Ax0HhPnN3G/zSvqTPV7Vo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6d9dcdcff0d99e559343f1d7143dcef25630a722",
+        "rev": "9ec9d474e3cee47421e30a77a0cdc4f258662762",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`da1a40da`](https://github.com/NixOS/nixpkgs/commit/da1a40da75d5203ed158d0ec1dd4bb95ac32d132) | `Revert "apparmor: 3.0.3 -> 3.0.4"`                                                       |
| [`71fe1192`](https://github.com/NixOS/nixpkgs/commit/71fe1192ce4bb7aa0396676feddbfb25b2a1a8cf) | `soundfont-ydp-grand: init at unstable-2016-08-04`                                        |
| [`851f51c1`](https://github.com/NixOS/nixpkgs/commit/851f51c111f49aa013843ab59affcadcca8e7e3f) | `nss_pam_ldapd: 0.9.11 -> 0.9.12`                                                         |
| [`43f4abad`](https://github.com/NixOS/nixpkgs/commit/43f4abad6402fa29cfe64bca606659792a4a3b58) | `librsb: 1.2.0.9 -> 1.2.0.10`                                                             |
| [`4217504f`](https://github.com/NixOS/nixpkgs/commit/4217504fb9257f37ebd157c0edc5ce6d3428cffd) | `alejandra: 0.4.0 -> 0.5.0`                                                               |
| [`e9a70d75`](https://github.com/NixOS/nixpkgs/commit/e9a70d75f54c0ffba2eee9b6246fba7137cabca4) | `lockfileProgs: 0.1.18 -> 0.1.19`                                                         |
| [`1f005ac7`](https://github.com/NixOS/nixpkgs/commit/1f005ac7f0576dcc4067712431dd58fee4081efd) | `libsForQt5.kquickimageedit: 0.1.3 -> 0.2.0`                                              |
| [`a9f76979`](https://github.com/NixOS/nixpkgs/commit/a9f76979d039107adca41fa5b94237f4fb6a376f) | `sarasa-gothic: 0.35.8 -> 0.35.9`                                                         |
| [`c77da6e9`](https://github.com/NixOS/nixpkgs/commit/c77da6e9bdd4baae9907b17afc7ae006aba5e756) | `maintainers: update mail for kloenk`                                                     |
| [`69452c77`](https://github.com/NixOS/nixpkgs/commit/69452c779b32913b476e5a596c3bd9eb576ac14e) | `schildichat-desktop,schildichat-web: add kloenk as maintainer`                           |
| [`5db03a51`](https://github.com/NixOS/nixpkgs/commit/5db03a5186948f857caf48671fca5e7c7554d86d) | `ibus-engines.m17n: 1.4.6 -> 1.4.9`                                                       |
| [`3b504499`](https://github.com/NixOS/nixpkgs/commit/3b50449992ca00898ac83d1e8278f84449d8c71a) | `coqPackages.iris: 3.5.0 → 3.6.0`                                                         |
| [`89049ef4`](https://github.com/NixOS/nixpkgs/commit/89049ef441f705c75c6483a8ac1d66ac68c49bc6) | `libsForQt5.drumstick: 2.4.1 -> 2.5.1`                                                    |
| [`fac4d443`](https://github.com/NixOS/nixpkgs/commit/fac4d4432fb5950658b4ad3982ed1cde34a25edd) | `babl: 0.1.88 → 0.1.90`                                                                   |
| [`21817517`](https://github.com/NixOS/nixpkgs/commit/218175170f0dcdf51aa477f747e6664aee6a21d9) | `fastjet-contrib: 1.046 -> 1.048`                                                         |
| [`9a6974d5`](https://github.com/NixOS/nixpkgs/commit/9a6974d579dd4c4420a59b5b847263985e60e841) | `osinfo-db: 20211216 → 20220214`                                                          |
| [`f90aab6b`](https://github.com/NixOS/nixpkgs/commit/f90aab6b42211d50cefb9493180a47e1086a4895) | `libosinfo: 1.9.0 → 1.10.0`                                                               |
| [`68ff26dc`](https://github.com/NixOS/nixpkgs/commit/68ff26dcb5cb4ae67bf9bfa2a7ba5d5437f4d34b) | `osinfo-db-tools: 1.9.0 → 1.10.0`                                                         |
| [`be534474`](https://github.com/NixOS/nixpkgs/commit/be5344745add1193ee8d1a8064c3f864ea8415bc) | `python310Packages.slowapi: disable failing tests on Python 3.10`                         |
| [`dbfb811f`](https://github.com/NixOS/nixpkgs/commit/dbfb811fb3a21ca3169b4facafbbe8183e144e45) | `esphome: 2022.2.4 -> 2022.2.5`                                                           |
| [`36778d12`](https://github.com/NixOS/nixpkgs/commit/36778d12fc7df18e9ad0d9faca6886e77856cbf5) | `maintainers: add stehessel`                                                              |
| [`dfdc7878`](https://github.com/NixOS/nixpkgs/commit/dfdc78785e0036213343b664e5537877b2aafafe) | `odo: init at 2.5.0`                                                                      |
| [`6efc9e44`](https://github.com/NixOS/nixpkgs/commit/6efc9e44683cbc91b0e6dd911663badabc230a64) | `tinyssh: 20220101 -> 20220222`                                                           |
| [`e8a0d699`](https://github.com/NixOS/nixpkgs/commit/e8a0d6993d0008dabe639f6157b28bee7b0c8cee) | `fn-cli: 0.6.13 -> 0.6.14`                                                                |
| [`b9eef1cc`](https://github.com/NixOS/nixpkgs/commit/b9eef1ccc365f6ff9126a00edd4ee4c280c3cc18) | `python3Packages.beartype: remove extra blank line`                                       |
| [`fc732cb9`](https://github.com/NixOS/nixpkgs/commit/fc732cb92d9e5053518d0008b9019e8c1cb66823) | `geonkick: 2.8.1 -> 2.9.0`                                                                |
| [`13c0a35f`](https://github.com/NixOS/nixpkgs/commit/13c0a35fc1da35e1ed5819ea7f93b9fc9c069c8b) | `moltenvk: 1.1.7 -> 1.1.8`                                                                |
| [`5bea6d32`](https://github.com/NixOS/nixpkgs/commit/5bea6d32303e3f72f1a90e0ee9c1ceb72c5dd344) | `python3Packages.slowapi: relax dependency constraints`                                   |
| [`a90d9324`](https://github.com/NixOS/nixpkgs/commit/a90d93241e789d63bf2a215fc91a030802d2c4bb) | `tectonic: include symlink to V2 interface`                                               |
| [`9825b9ad`](https://github.com/NixOS/nixpkgs/commit/9825b9ada81bbf55f963272b065ebea05022fbcf) | `portmidi: 2.0.2 -> 2.0.3`                                                                |
| [`eda4fe9d`](https://github.com/NixOS/nixpkgs/commit/eda4fe9d3b51c35d1f29ac2f217cb52728b67090) | `python3Packages.shodan: 1.26.1 -> 1.27.0`                                                |
| [`cac90b3d`](https://github.com/NixOS/nixpkgs/commit/cac90b3ddf1cd7b91ab7a254da173e41f9620eb0) | `python310Packages.beartype: 0.10.1 -> 0.10.2`                                            |
| [`61820898`](https://github.com/NixOS/nixpkgs/commit/61820898b2fc1d2017bb9521757e59b3283baa47) | `checkSSLCert: 2.20.0 -> 2.21.0`                                                          |
| [`507c2ea6`](https://github.com/NixOS/nixpkgs/commit/507c2ea6a327542d4adf7997a861e40b862b6027) | `nuclei: 2.6.0 -> 2.6.1`                                                                  |
| [`a47ff329`](https://github.com/NixOS/nixpkgs/commit/a47ff32985be5c0d756cf3a1eefaefb4ca494557) | `blackshades: 2.4.7 -> 2.4.9`                                                             |
| [`73c5ccbf`](https://github.com/NixOS/nixpkgs/commit/73c5ccbf2146404ca466c9d05df4c34c14d30196) | `linux/hardened/patches/5.4: 5.4.177-hardened1 -> 5.4.180-hardened1`                      |
| [`d9a881c9`](https://github.com/NixOS/nixpkgs/commit/d9a881c99b730c552229303d893985914cb1ae2d) | `linux/hardened/patches/5.15: 5.15.21-hardened1 -> 5.15.24-hardened1`                     |
| [`99c41791`](https://github.com/NixOS/nixpkgs/commit/99c417912077f8fd86f3d7a9c7f7e804ed87f7fb) | `linux/hardened/patches/5.10: 5.10.98-hardened1 -> 5.10.101-hardened1`                    |
| [`745de513`](https://github.com/NixOS/nixpkgs/commit/745de513d61e91672729418cfef8116eab89c72e) | `linux/hardened/patches/4.19: 4.19.227-hardened1 -> 4.19.230-hardened1`                   |
| [`16e2d243`](https://github.com/NixOS/nixpkgs/commit/16e2d243d00053b642e3a33f645f068d2c00dfca) | `linux/hardened/patches/4.14: 4.14.264-hardened1 -> 4.14.267-hardened1`                   |
| [`5a3689c7`](https://github.com/NixOS/nixpkgs/commit/5a3689c7831b10b5c2ec3bd0459fdf1618eb4962) | `trace-cmd: 2.9.6 -> 2.9.7`                                                               |
| [`0e5ebf54`](https://github.com/NixOS/nixpkgs/commit/0e5ebf54d5b0e97c694f4c05228d0a3625dda775) | `linux-rt_5_10: 5.10.78-rt55 -> 5.10.100-rt62`                                            |
| [`bbc4361d`](https://github.com/NixOS/nixpkgs/commit/bbc4361d49822d944c14e5d9a3d5fd076df58dd7) | `sqlx-cli: 0.5.10 -> 0.5.11`                                                              |
| [`974b0d9e`](https://github.com/NixOS/nixpkgs/commit/974b0d9ec5d7afb5923b9a518c2d95a52e8d3d3e) | `rush: 2.1 -> 2.2`                                                                        |
| [`f6956a44`](https://github.com/NixOS/nixpkgs/commit/f6956a44e1bbbdc498866b305deefc23c2b14385) | `matrix-synapse: 1.52.0 -> 1.53.0`                                                        |
| [`b86b8a8a`](https://github.com/NixOS/nixpkgs/commit/b86b8a8a28686dd50736c328f1df265dcebc54c1) | `python310Packages.matrix-common: 1.0.0 -> 1.1.0`                                         |
| [`730edb44`](https://github.com/NixOS/nixpkgs/commit/730edb44a873aa09f8f33424cd730ea75a1f78b5) | `linuxPackages.dddvb: init at 0.9.33-404-ge9ccab3`                                        |
| [`a175e4e1`](https://github.com/NixOS/nixpkgs/commit/a175e4e16b0327b2e686a72166b1c929f5ff52c9) | `scala-cli: 0.1.1 -> 0.1.2`                                                               |
| [`a09c5391`](https://github.com/NixOS/nixpkgs/commit/a09c53910fe74b22880225c41fa5d273827f4966) | `notcurses: 3.0.6 -> 3.0.7`                                                               |
| [`00ee5684`](https://github.com/NixOS/nixpkgs/commit/00ee56846b20c3d826ff659eaf4150d4484f9410) | `gnome.updateScript: allow updating to unstable releases`                                 |
| [`86a0a335`](https://github.com/NixOS/nixpkgs/commit/86a0a335dc5fdf25c84871499c7297c8f35653e2) | `gnome.updateScript: avoid rebuilding the derivation`                                     |
| [`5b8320d4`](https://github.com/NixOS/nixpkgs/commit/5b8320d446e18b4fd6faefa787944d22513ac1ee) | `gnome.updateScript: Use experimental support for custom commit messages`                 |
| [`3cce255f`](https://github.com/NixOS/nixpkgs/commit/3cce255fc1598ce9c7d0c871dbd6dbcd4271e211) | `maintainers/scripts/update.nix: Add experimental support for customizing commit message` |
| [`005ac63a`](https://github.com/NixOS/nixpkgs/commit/005ac63a1910945086e40d197164a5aae4c38090) | `httpTwoLevelsUpdater: init`                                                              |
| [`ba59355e`](https://github.com/NixOS/nixpkgs/commit/ba59355e8105035382b2f4056a97b1ffcd1bb70a) | `gitUpdater: init`                                                                        |
| [`02ae3def`](https://github.com/NixOS/nixpkgs/commit/02ae3defed9086d07963fcecb287f13da1cfe49b) | `chromium: use pkgsBuildHost.jre8_headless instead of pkgsBuildHost.jre8`                 |
| [`a84503e7`](https://github.com/NixOS/nixpkgs/commit/a84503e708f5a6faaf9306351d6297e249baf2e3) | `n8n: 0.163.1 → 0.164.1`                                                                  |
| [`eb0dda98`](https://github.com/NixOS/nixpkgs/commit/eb0dda98dc24e6aa51e41321321ae2c264b5bd44) | `nixos/vaultwarden: fix evaluation`                                                       |
| [`e6760473`](https://github.com/NixOS/nixpkgs/commit/e676047306439245c4e43df5fc5db8cdcad1f461) | `lxgw-wenkai: init at 1.210`                                                              |
| [`31462e50`](https://github.com/NixOS/nixpkgs/commit/31462e501edb12161ef1b066e6b709891f9cc262) | `nixos/virtuoso: drop`                                                                    |
| [`78411af6`](https://github.com/NixOS/nixpkgs/commit/78411af65d0d93a3672831a916ece099ef6b3d12) | `virtuoso: drop`                                                                          |
| [`bcf2265f`](https://github.com/NixOS/nixpkgs/commit/bcf2265feaaf1f0a004c2180b22981d8a68ab901) | `apparmor: 3.0.3 -> 3.0.4`                                                                |
| [`7dd2f0ed`](https://github.com/NixOS/nixpkgs/commit/7dd2f0edd6c7090fbd0de9599e066e2b49924ad8) | `erigon: 2022.01.02 -> 2022.02.02`                                                        |
| [`4fbcc67d`](https://github.com/NixOS/nixpkgs/commit/4fbcc67dc90452df6f119a4246d22fd2294a009f) | `wpa_supplicant: enable WNM (802.11v)`                                                    |
| [`ed521d40`](https://github.com/NixOS/nixpkgs/commit/ed521d40f62e9fda01a48621b2b62a02e2d7ef4e) | `wpa_supplicant: sort config options`                                                     |
| [`e0d6ce7e`](https://github.com/NixOS/nixpkgs/commit/e0d6ce7e7309d301c913ab525cd31c7e17c8b1db) | `python310Packages.django-configurations: 2.3.1 -> 2.3.2`                                 |
| [`dd1cc5d9`](https://github.com/NixOS/nixpkgs/commit/dd1cc5d9abada5571a08349ecc233a96b2205380) | `lightwalletd: 0.4.8 -> 0.4.9`                                                            |
| [`1ceac726`](https://github.com/NixOS/nixpkgs/commit/1ceac72697128cd93875ea8f5c9dd53729e9f201) | `gurobi: 9.1.2 -> 9.5.0`                                                                  |
| [`c2185ac2`](https://github.com/NixOS/nixpkgs/commit/c2185ac23854444d9b97ae7240ecb4f98196ded5) | `ocamlPackages.dose3: 6.1 -> 7.0.0`                                                       |