### PR TITLE
chore(flake/home-manager): `0b1745b4` -> `1faefcde`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1645628011,
-        "narHash": "sha256-iNZCTjJ63TN5oM6rx2f4H0zaCbXM/iup7UWtQuCuyTM=",
+        "lastModified": 1645739024,
+        "narHash": "sha256-+JWHsxioBwwsEFAo2lK2+x8mRwzFqC1674vGFVRL3cs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0b1745b4ef4c35ec5d554b176539730fcb5ec141",
+        "rev": "1faefcded37d4d094d086ccf9796de50ca5bc7f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                            |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`1faefcde`](https://github.com/nix-community/home-manager/commit/1faefcded37d4d094d086ccf9796de50ca5bc7f7) | `Translate using Weblate (Russian)`       |
| [`2248ea18`](https://github.com/nix-community/home-manager/commit/2248ea1831611aa5c4926c5ccfa0eb7803af78b3) | `Add translation using Weblate (Italian)` |
| [`1950eb87`](https://github.com/nix-community/home-manager/commit/1950eb878b0290ca2b2f0d85804281b57799c64a) | `Add translation using Weblate (Italian)` |