### PR TITLE
chore(flake/home-manager): `8f7d9255` -> `650cfe60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1645742524,
-        "narHash": "sha256-U5igXJiPzk/ztKlclarCs5W9S4e21tM0tpmJkttJzaU=",
+        "lastModified": 1645746341,
+        "narHash": "sha256-j4fTWByYMGSSl0P7HEJQmbU/ifJtW25n/SoF6hgXN8c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8f7d9255034b12d52242a87f41d2dd8242992083",
+        "rev": "650cfe60f31f3d27ba869bf7db12ca8ded5f1d74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                     |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`650cfe60`](https://github.com/nix-community/home-manager/commit/650cfe60f31f3d27ba869bf7db12ca8ded5f1d74) | `vscode: fix name of extension in example (#2759)` |