### PR TITLE
chore(flake/ragenix): `c1b2716c` -> `c767f9d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1645358570,
-        "narHash": "sha256-yfXkytFbwUqSvIgKEjr2pk5TpCxA1WdGpzs7dQmAVhM=",
+        "lastModified": 1645806025,
+        "narHash": "sha256-YWxg0hn1rK9Ja9A3sG0+OSx4535Nt9isU9w0kCTTK0g=",
         "owner": "yaxitech",
         "repo": "ragenix",
-        "rev": "c1b2716c63960f5ef08aacba6f86f81e535667a7",
+        "rev": "c767f9d65ac98105c70a01cf6e124bb5802628d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                            | Commit Message                          |
| ------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`b55cf7e1`](https://github.com/yaxitech/ragenix/commit/b55cf7e1c033354cbde27ab3bb95798cd7cffb00) | `flake: simplify devShell`              |
| [`842389c5`](https://github.com/yaxitech/ragenix/commit/842389c5e2353d734fe58e7e6728c060ceb256e3) | `flake: avoid unnecessary store copies` |