### PR TITLE
chore(flake/nixpkgs): `9ec9d474` -> `cb7aad71`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1645678056,
-        "narHash": "sha256-P+J3DJmd7xjmH2SICbGrr3Ax0HhPnN3G/zSvqTPV7Vo=",
+        "lastModified": 1645740083,
+        "narHash": "sha256-re4GMWyI5zN6+daJv5ejFi22Bm77jf82iEZA6HHWRAc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ec9d474e3cee47421e30a77a0cdc4f258662762",
+        "rev": "cb7aad71e54deaaea8cb02c7303f3e081c10a7f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`cb7aad71`](https://github.com/NixOS/nixpkgs/commit/cb7aad71e54deaaea8cb02c7303f3e081c10a7f8) | `fscrypt-experimental: 0.3.1 -> 0.3.3`                                                |
| [`e2e2a905`](https://github.com/NixOS/nixpkgs/commit/e2e2a9059395dc03a39265ad5419ad612d6a465e) | `python310Packages.google-cloud-trace: 1.5.1 -> 1.6.0`                                |
| [`55dd9b0c`](https://github.com/NixOS/nixpkgs/commit/55dd9b0c5edf8d10d1d1cb21007c1e762a62fda3) | `symfony-cli: 5.4.0 -> 5.4.1`                                                         |
| [`d6a24fc1`](https://github.com/NixOS/nixpkgs/commit/d6a24fc1084f8351cb9d76cd92a41a0cc9f8053a) | `cwltool: 3.1.20220217222804 -> 3.1.20220221074232`                                   |
| [`b4a0042c`](https://github.com/NixOS/nixpkgs/commit/b4a0042c422a4634ed2a80bf7c966b7aab91d58a) | `gitea: 1.16.1 -> 1.16.2`                                                             |
| [`2159235e`](https://github.com/NixOS/nixpkgs/commit/2159235eed59861476469311dc6b31b967ea0617) | `ocamlPackages.mdx: disable for OCaml < 4.08`                                         |
| [`8eb44ac8`](https://github.com/NixOS/nixpkgs/commit/8eb44ac8a305d3b003e71bf279b057cdd5ed6c32) | `python3Packages.cssutils: 2.3.0 -> 2.4.0`                                            |
| [`4c6f337c`](https://github.com/NixOS/nixpkgs/commit/4c6f337c48eb06c3cded4652bf1445241901d828) | `nano: 6.1 -> 6.2`                                                                    |
| [`84241375`](https://github.com/NixOS/nixpkgs/commit/8424137563659838431f15c8940c323f3a74ef0c) | `vimPlugins.todo-nvim: init at 2022-02-19`                                            |
| [`c5d25af7`](https://github.com/NixOS/nixpkgs/commit/c5d25af7302f4d5df9d15aa6c2c29524b78a7adb) | `survex: 1.2.44 -> 1.4.1`                                                             |
| [`5aebf509`](https://github.com/NixOS/nixpkgs/commit/5aebf5097b34f8ff2c3de64a7a3d85a9c2d1e6a1) | `nixos/manual: add 22.05 section to list`                                             |
| [`bf021cf9`](https://github.com/NixOS/nixpkgs/commit/bf021cf990178161f1fe7440250904c80a6f5865) | `nixos/release-notes: fix typos in 22.05 section.`                                    |
| [`57219450`](https://github.com/NixOS/nixpkgs/commit/5721945070e61e6d92c8a2391624673deb733105) | `nixos/tetrd: add to module list and fix enable description`                          |
| [`0b80e178`](https://github.com/NixOS/nixpkgs/commit/0b80e178f129c215b693fe948d3795d22c2f7fee) | `python3Packages.mwdblib: 4.0.0 -> 4.1.0`                                             |
| [`10472241`](https://github.com/NixOS/nixpkgs/commit/104722413228f1dc53c80cdb9c1e90e3dcca92a8) | `python3Packages.karton-mwdb-reporter: 1.0.1 -> unstable-2022-02-22`                  |
| [`ce9d28cc`](https://github.com/NixOS/nixpkgs/commit/ce9d28cc49b04d6cdc9e788e111fd79648beaef2) | `picard-tools: 2.26.10 -> 2.26.11`                                                    |
| [`d27d50d4`](https://github.com/NixOS/nixpkgs/commit/d27d50d45c40324d6166e11c3eab05204442b5f6) | `home-assistant: support signal_messenger component`                                  |
| [`9568aa18`](https://github.com/NixOS/nixpkgs/commit/9568aa18084a28b16a226baba917eac1d4e2cb6d) | `python3Packages.pysignalclirestapi: init at 0.3.18`                                  |
| [`d9fe24c1`](https://github.com/NixOS/nixpkgs/commit/d9fe24c1f962ad54957b3ac41f2c4356a1828635) | `steam: use XDG_DATA_DIRS to specify vulkan icd paths`                                |
| [`26c6b2eb`](https://github.com/NixOS/nixpkgs/commit/26c6b2eb794d0bf0f12cb3430b6084bfe2f57d9d) | `linuxPackages.nvidia_x11: fix vulkan icd installation paths`                         |
| [`344d01c3`](https://github.com/NixOS/nixpkgs/commit/344d01c3964245c6e1ade2c1d63fe8d6d16e0266) | `home-assistant: support volvooncall component`                                       |
| [`3a6d134b`](https://github.com/NixOS/nixpkgs/commit/3a6d134b23552d2df34ef3e3b8d98db10e7b398b) | `python3Packages.volvooncall: init at 0.9.2`                                          |
| [`b7304edb`](https://github.com/NixOS/nixpkgs/commit/b7304edb3f9ef82474796438599471e375b40f2a) | `wxwidgets: remove darwin from inputs`                                                |
| [`211ec209`](https://github.com/NixOS/nixpkgs/commit/211ec209b1814ddd38e53743cd721e200acab626) | `vimPlugins.surround-nvim: Switch to new fork`                                        |
| [`1191d095`](https://github.com/NixOS/nixpkgs/commit/1191d095b6d76d52ec2cc8e6acddb94941698816) | `vimPlugins: update`                                                                  |
| [`ea3c248e`](https://github.com/NixOS/nixpkgs/commit/ea3c248efead4e3417551f807486754f58140cc4) | `vimPlugins.surround-nvim: remove`                                                    |
| [`c95df566`](https://github.com/NixOS/nixpkgs/commit/c95df5664e52e9b86da6983e488657f618210cbb) | `python310Packages.sphinxext-opengraph: 0.6.0 -> 0.6.1`                               |
| [`dbc2bfa3`](https://github.com/NixOS/nixpkgs/commit/dbc2bfa37d0452b72df69d326fb425dcac3dc9c7) | `python310Packages.google-cloud-tasks: 2.7.2 -> 2.8.0`                                |
| [`50ab65be`](https://github.com/NixOS/nixpkgs/commit/50ab65beba214adbb5f318744e260e4a13083bef) | `python310Packages.connexion: 2.11.2 -> 2.12.0`                                       |
| [`5f9b2148`](https://github.com/NixOS/nixpkgs/commit/5f9b2148b775d50027882d82e2a337864aa8882c) | `nixos/k40-whisperer: module init`                                                    |
| [`78626c82`](https://github.com/NixOS/nixpkgs/commit/78626c8200de3cfa3d56365f0527dec87b0bb7d5) | `k40-whisperer: init at 0.59`                                                         |
| [`d013bbaa`](https://github.com/NixOS/nixpkgs/commit/d013bbaab9d04c070b6c991d86c6a2590441eab5) | `unshield: 1.4.3 -> 1.5.1`                                                            |
| [`09c1b672`](https://github.com/NixOS/nixpkgs/commit/09c1b6727507372edce41281c9569d11f7922513) | `minio-client: 2022-02-16T05-54-01Z -> 2022-02-23T03-15-59Z`                          |
| [`fd4f3342`](https://github.com/NixOS/nixpkgs/commit/fd4f33424e84c36af0de4e49897a2806ac7ceba6) | `python310Packages.google-resumable-media: 2.2.1 -> 2.3.0`                            |
| [`51216724`](https://github.com/NixOS/nixpkgs/commit/5121672472e19ae22b5dcef5443ce4cabff64d1d) | `python310Packages.pyhaversion: 21.11.1 -> 22.02.0`                                   |
| [`c710148f`](https://github.com/NixOS/nixpkgs/commit/c710148f70d9059c8b184690159cd9ea83cf7cbf) | `opsdroid: 0.24.1 -> 0.25.0`                                                          |
| [`d7efdd01`](https://github.com/NixOS/nixpkgs/commit/d7efdd010b9a0d39f27bac2e0fd175b746bbc87d) | `python3Packages.mailchecker: 4.1.12 -> 4.1.13`                                       |
| [`75e3333c`](https://github.com/NixOS/nixpkgs/commit/75e3333ce6d757eb26522e5e271145542a5fea29) | `luna-icons: 1.9 -> 1.9.1`                                                            |
| [`41961a9e`](https://github.com/NixOS/nixpkgs/commit/41961a9e1a043b5ea53ebb00aa96dff36ff3bdf9) | `python310Packages.ansible-runner: 2.1.1 -> 2.1.2`                                    |
| [`1b40de5f`](https://github.com/NixOS/nixpkgs/commit/1b40de5f6921a12d82f156507821b2d8fdb54955) | `log4j-sniffer: 1.8.0 -> 1.9.0`                                                       |
| [`601b38a0`](https://github.com/NixOS/nixpkgs/commit/601b38a02c7a0c09d45027184853d5e8fc9e1698) | `libfprint: 1.94.2 -> 1.94.3`                                                         |
| [`bdc5169f`](https://github.com/NixOS/nixpkgs/commit/bdc5169fa402490c607c80416aec5e8c1037671b) | `gnomeExtensions.dash-to-dock: 71+date=2022-01-24 -> 71+date=2022-02-23`              |
| [`256f5ac3`](https://github.com/NixOS/nixpkgs/commit/256f5ac39751b816d2fe20f2ace0d56e42914de2) | `just: 0.11.2 -> 1.0.0`                                                               |
| [`ea9a2d58`](https://github.com/NixOS/nixpkgs/commit/ea9a2d5871f5e6f16a9c85659d638418eb6410ff) | `lfs: 2.0.1 -> 2.1.0`                                                                 |
| [`9c70e731`](https://github.com/NixOS/nixpkgs/commit/9c70e731165e0f99c43406855311002b5ad4918f) | `syslogng: 3.34.1 -> 3.35.1`                                                          |
| [`8b7cd39d`](https://github.com/NixOS/nixpkgs/commit/8b7cd39d38ecfda73cd015a504bcc604242f8ebf) | `libsForQt5.phonon-backend-vlc: 0.11.2 -> 0.11.3`                                     |
| [`e7288018`](https://github.com/NixOS/nixpkgs/commit/e7288018c3bee0207acb19e56dd3b00fec3c8ade) | `python310Packages.google-cloud-automl: 2.6.0 -> 2.7.0`                               |
| [`0251616b`](https://github.com/NixOS/nixpkgs/commit/0251616bfd5cc3dac50d5f140e04b7be6b8ed991) | `python310Packages.azure-mgmt-kusto: 2.1.0 -> 2.2.0`                                  |
| [`c23a65f9`](https://github.com/NixOS/nixpkgs/commit/c23a65f993af089ebbfdafd1613a1856b7dca555) | `croc: 9.5.1 -> 9.5.2`                                                                |
| [`275e9a3b`](https://github.com/NixOS/nixpkgs/commit/275e9a3b2d7ee254040b401a837690a92cfa5711) | `flyctl: 0.0.298 -> 0.0.300`                                                          |
| [`6faef6b2`](https://github.com/NixOS/nixpkgs/commit/6faef6b2d64b7bdd4b6a7d61cc8985e38e2a22f3) | `cni-plugins: 1.0.1 -> 1.1.0`                                                         |
| [`829d02b2`](https://github.com/NixOS/nixpkgs/commit/829d02b29906651b6211da7794dc28d31a5ab78e) | `jotta-cli: 0.13.53591 -> 0.13.55213`                                                 |
| [`52e9fca9`](https://github.com/NixOS/nixpkgs/commit/52e9fca9eeb1737488165fbd149a682843d73e65) | `gnomeExtensions.arcmenu: 21 -> 23`                                                   |
| [`a56a5155`](https://github.com/NixOS/nixpkgs/commit/a56a5155b15a95284385a46665d3f10344c3722a) | `python310Packages.hahomematic: 0.35.2 -> 0.35.3`                                     |
| [`98fd8b69`](https://github.com/NixOS/nixpkgs/commit/98fd8b692832d938fadcd8f50d7ec2e9bcab3d5e) | `pru: init at 0.2.1`                                                                  |
| [`0a4f8a49`](https://github.com/NixOS/nixpkgs/commit/0a4f8a4984d1adf9b5573d0ad68df8fc9e37731f) | `bazel-remote: 2.3.3 -> 2.3.4`                                                        |
| [`baf5cacf`](https://github.com/NixOS/nixpkgs/commit/baf5cacf839e0503cc3e267de36076120c9fb5a6) | `plexamp: 4.0.1 -> 4.0.2`                                                             |
| [`75508a94`](https://github.com/NixOS/nixpkgs/commit/75508a94218612b6cd273cf48863ee6dc4e4cbd8) | `tautulli: 2.9.3 -> 2.9.4`                                                            |
| [`d3e13578`](https://github.com/NixOS/nixpkgs/commit/d3e13578acf4762a87f4efdafbbdf15ea373ad96) | `plex: 1.25.5.5492-12f6b8c83 -> 1.25.6.5577-c8bd13540`                                |
| [`42b147a4`](https://github.com/NixOS/nixpkgs/commit/42b147a4a20c1363b9890fa50f302d4a1ef67879) | `python3Packages.pywlroots: 0.15.9 -> 0.15.10`                                        |
| [`2d6990be`](https://github.com/NixOS/nixpkgs/commit/2d6990bec6674cd9bca228fedce3b422d66090bc) | `gosec: 2.9.6 -> 2.10.0`                                                              |
| [`5a0b4d86`](https://github.com/NixOS/nixpkgs/commit/5a0b4d86fe6d0568a2219187c27bbc8fe78818a2) | `gitleaks: 8.2.7 -> 8.3.0`                                                            |
| [`234a4600`](https://github.com/NixOS/nixpkgs/commit/234a4600de50d77d4db5ebe1323d2a41aa933bd0) | `borgbackup: 1.1.17 -> 1.2.0`                                                         |
| [`753a43ca`](https://github.com/NixOS/nixpkgs/commit/753a43caf07790a923d8f6394744f1c5b0eb8ee4) | `nixos/doc: improve release notes for iptables-nft and systemd with nftables backend` |
| [`6f7d5ceb`](https://github.com/NixOS/nixpkgs/commit/6f7d5cebf2d4217ffc12f2d326c2d5785390ae4c) | `mednaffe: Enable for Darwin, fix wrapping`                                           |
| [`3e3cb9b7`](https://github.com/NixOS/nixpkgs/commit/3e3cb9b7c98854bb3c8a88179bfa972753978a3c) | `mednafen: Fix on Darwin`                                                             |
| [`413afdae`](https://github.com/NixOS/nixpkgs/commit/413afdae6e29ff8f90f6576cf7317455013e8ebd) | `openstack-metadata-fetcher: do not fail if no user-data is provided`                 |
| [`7543524f`](https://github.com/NixOS/nixpkgs/commit/7543524f9cae53177a67d384cf96c344a1042903) | `nanodbc: init at 2.13.0`                                                             |
| [`dc4b9569`](https://github.com/NixOS/nixpkgs/commit/dc4b9569d17d6498e58723c56a45af0e869f7347) | `sish: 2.0.1 -> 2.1.0`                                                                |
| [`bc72c7ae`](https://github.com/NixOS/nixpkgs/commit/bc72c7aeb9febc87e0a1fa8f2a00c3670fa01e69) | `notcurses: 3.0.6 -> 3.0.7`                                                           |
| [`a55e1812`](https://github.com/NixOS/nixpkgs/commit/a55e181257801cfd0d3f3aa1e18bdf208779e382) | `wireplumber: install system units to the right place`                                |
| [`edba1fc5`](https://github.com/NixOS/nixpkgs/commit/edba1fc562fd04fee1f777fe003862a52879c95b) | `pure-prompt: 1.20.0 -> 1.20.1`                                                       |
| [`07dd74b8`](https://github.com/NixOS/nixpkgs/commit/07dd74b828f367a513935e4fccdd4c32fdcddc19) | `exiv2: fix paths in *.cmake`                                                         |
| [`495a8d9b`](https://github.com/NixOS/nixpkgs/commit/495a8d9bb3ad0fd3a65ad3f3dd8eb3b529a4521c) | `wireplumber: also install system units`                                              |
| [`e67dd381`](https://github.com/NixOS/nixpkgs/commit/e67dd381d33681ce876030db03bc1e58b6ad075d) | `nixos/pipewire: default to wireplumber`                                              |
| [`38862374`](https://github.com/NixOS/nixpkgs/commit/38862374212fcd136bb2572cf3df11e90b5757ed) | `vscode: Update .github/CODEOWNERS`                                                   |
| [`2d98f7cf`](https://github.com/NixOS/nixpkgs/commit/2d98f7cff3813d46c18acfc31c6d3a53f47d8f13) | `vscode: update the updaters!`                                                        |
| [`8f868e15`](https://github.com/NixOS/nixpkgs/commit/8f868e154ca265e38481ab15d28429f7ff72e0e4) | `Move misc/vscode-extensions to applications/editors/vscode/extensions`               |
| [`223709c3`](https://github.com/NixOS/nixpkgs/commit/223709c3888a4517a9bc2ee0376aae26bfd47340) | `namecoind: nc0.21.1 -> nc22.0`                                                       |
| [`1781d283`](https://github.com/NixOS/nixpkgs/commit/1781d283f3a24ef32d0d65d54197e7cc061ff55b) | `sd-image-aarch64: Enable arm_boost for Pi 4`                                         |
| [`57272beb`](https://github.com/NixOS/nixpkgs/commit/57272bebeef8ce0ccbb8909c9443445d3ab70316) | `raspberrypi-eeprom: 2021.04.29 -> 2021.12.02`                                        |
| [`51b7e23e`](https://github.com/NixOS/nixpkgs/commit/51b7e23e8fcea6768ad80faefc02c60b209e71ee) | `raspberrypi-fw: use fetchurl to avoid darwin issue`                                  |
| [`963f011f`](https://github.com/NixOS/nixpkgs/commit/963f011f16315e44a141724df09a94378aac8291) | `sd-image-aarch64.nix: Add config for Pi Zero 2 W`                                    |
| [`d5797296`](https://github.com/NixOS/nixpkgs/commit/d57972961cb454a66ffbc26a44860b57e78efbf1) | `ubootRaspberryPi3_{32,64}bit: Add patch to load correct DT for Pi Zero 2 W`          |
| [`7851f68a`](https://github.com/NixOS/nixpkgs/commit/7851f68a6802ca1158fb63ae3214997238fc17d8) | `raspberrypi-wireless-firmware: 2021-06-28 -> 2021-11-02`                             |
| [`10afc59e`](https://github.com/NixOS/nixpkgs/commit/10afc59e3a50731b390bc03220b71c5ddc6e9c9a) | `raspberrypi-armstubs: 2021-07-05 -> 2021-11-01`                                      |
| [`2164279a`](https://github.com/NixOS/nixpkgs/commit/2164279a0465bd4960bb38fa7888bd882549454c) | `raspberrypifw: 1.20210805 -> 1.20211118`                                             |
| [`40d13627`](https://github.com/NixOS/nixpkgs/commit/40d136278235bca9bc61995caa36c4ab5289194b) | `linux_rpi: 5.10.52-1.20210805 -> 5.10.92-1.20220118`                                 |
| [`1e853c8d`](https://github.com/NixOS/nixpkgs/commit/1e853c8d2d895987d5ebdafcb1fe135e839cadf2) | `libraspberrypi: unstable-2021-06-23 -> unstable-2021-10-25`                          |
| [`fc77f3d7`](https://github.com/NixOS/nixpkgs/commit/fc77f3d7397168cb5efff674fa30f7c12cb9d7e6) | `python3Packages.mwdblib: 3.4.1 -> 4.0.0`                                             |
| [`3879ea4e`](https://github.com/NixOS/nixpkgs/commit/3879ea4efaf6e8fbb2cf8a607a8968a28d6e7fa9) | `ocamlPackages.pyml: 20210226 -> 20211015`                                            |
| [`82b74886`](https://github.com/NixOS/nixpkgs/commit/82b7488678297e1f19944a7e1693282506b4268f) | `moonraker: unstable-2021-11-13 -> unstable-2021-12-05`                               |
| [`88f44264`](https://github.com/NixOS/nixpkgs/commit/88f44264ba6658e267e72712681f83213f259631) | `mapproxy: 1.13.2 -> 1.14.0`                                                          |
| [`e3b90f1c`](https://github.com/NixOS/nixpkgs/commit/e3b90f1cf46a128799b558ca8fa3d04d9dd63215) | `coursier: 2.0.16 -> 2.1.0-M1`                                                        |
| [`19307413`](https://github.com/NixOS/nixpkgs/commit/19307413e8b0e20f7a7d572c6cbef9b82091c432) | `asdf-vm: 0.8.1 -> 0.9.0`                                                             |