### PR TITLE
chore(flake/nixpkgs): `cb7aad71` -> `fb627379`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1645740083,
-        "narHash": "sha256-re4GMWyI5zN6+daJv5ejFi22Bm77jf82iEZA6HHWRAc=",
+        "lastModified": 1645783086,
+        "narHash": "sha256-L8YfZmwx3FretBLq55gWt6qgFUsns66l0hb+Ci8V1yI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cb7aad71e54deaaea8cb02c7303f3e081c10a7f8",
+        "rev": "fb6273792e1b29455725a921b7f043de70b4b2e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                      |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`8c912d5c`](https://github.com/NixOS/nixpkgs/commit/8c912d5c91ea4064ec905994e8f6e80f4d843c4a) | `kubectl: build from source`                                        |
| [`ae0a6a6b`](https://github.com/NixOS/nixpkgs/commit/ae0a6a6b08b2ac4a2b2380ece50552c881c6ac0e) | `kubernetes: only build on linux`                                   |
| [`ec2028eb`](https://github.com/NixOS/nixpkgs/commit/ec2028eb3ca59679b829f801524e73223021cb3e) | `nixos/kubernetes: use kubectl from kubernetes`                     |
| [`4ee1f9ea`](https://github.com/NixOS/nixpkgs/commit/4ee1f9eafc15a291bbb838f80a47bf2f4c97ce80) | `podman: 3.4.4 -> 4.0.1`                                            |
| [`ec709341`](https://github.com/NixOS/nixpkgs/commit/ec7093413e4afc37e095ea29cf92e3ada08f6851) | `strawberry: 1.0.1 -> 1.0.2`                                        |
| [`b549b58b`](https://github.com/NixOS/nixpkgs/commit/b549b58b00f44d9f6885a418519b1115ce375595) | `python3Packages.ttls: 1.4.2 -> 1.4.3`                              |
| [`b1725d13`](https://github.com/NixOS/nixpkgs/commit/b1725d1371243b85cfac0bc708921187d3b6e326) | `python3Packages.pycfmodel: 0.16.2 -> 0.16.3`                       |
| [`4ff62919`](https://github.com/NixOS/nixpkgs/commit/4ff62919ccf9449cf993a4b1dcedd3f40ea65129) | `python3Packages.hahomematic: 0.35.3 -> 0.36.0`                     |
| [`67ef7f5c`](https://github.com/NixOS/nixpkgs/commit/67ef7f5c728ee420090f949929d6124bd46ec8f8) | `python3Packages.aiopyarr: 22.2.1 -> 22.2.2`                        |
| [`9db2e932`](https://github.com/NixOS/nixpkgs/commit/9db2e932c3a105da262732caf8dc0e5f87497ed9) | `python3Packages.aiolyric: fix syntax`                              |
| [`20c9e401`](https://github.com/NixOS/nixpkgs/commit/20c9e4013e4b006bc32675b8ce9ae8f5601d3a33) | `python3Packages.pytwitchapi: add format`                           |
| [`d13a0403`](https://github.com/NixOS/nixpkgs/commit/d13a0403a50b320256c6a072be9bbdc5ab7deed0) | `python3Packages.aiolyric: add format`                              |
| [`85260853`](https://github.com/NixOS/nixpkgs/commit/852608531af64d07a2f03cfb5a7e29afe98a9b9f) | `python310Packages.google-cloud-iot: 2.3.0 -> 2.4.0`                |
| [`e6a81f04`](https://github.com/NixOS/nixpkgs/commit/e6a81f04e7f05d945964dd277b266ffd3dd9be4a) | `python310Packages.databricks-connect: 9.1.9 -> 9.1.10`             |
| [`056c3416`](https://github.com/NixOS/nixpkgs/commit/056c34167d3210a674ef21691afbbce1ed63f8ca) | `why3: 1.4.0 → 1.4.1`                                               |
| [`fcc5e680`](https://github.com/NixOS/nixpkgs/commit/fcc5e680d761b4d74f0a6137ff2154d2e7a8c349) | `python310Packages.google-cloud-websecurityscanner: 1.6.1 -> 1.7.0` |
| [`ca86bdc2`](https://github.com/NixOS/nixpkgs/commit/ca86bdc2a16bf0b25d34da896d82e0081f9357d9) | `python310Packages.mypy-boto3-s3: 1.21.0 -> 1.21.7`                 |
| [`a768768d`](https://github.com/NixOS/nixpkgs/commit/a768768d1936f3e4cbac0a1e909a5f28c0311e26) | `python310Packages.fastcore: 1.3.27 -> 1.3.29`                      |
| [`41e5c634`](https://github.com/NixOS/nixpkgs/commit/41e5c634edb17ec1a7f5bfd67de8118c12dc92ab) | `python310Packages.aiolyric: 1.0.9 -> 1.0.10`                       |
| [`4374ade9`](https://github.com/NixOS/nixpkgs/commit/4374ade9dfa63d647b9a1eb7cc7adef0fc583093) | `babashka: 0.7.5 -> 0.7.6`                                          |
| [`4f1ec880`](https://github.com/NixOS/nixpkgs/commit/4f1ec880995affe0dca0b2fb0ca1cf9eec59ede0) | `python310Packages.pytwitchapi: 2.5.1 -> 2.5.2`                     |
| [`551f8cd9`](https://github.com/NixOS/nixpkgs/commit/551f8cd92dcf9d8dab2e18a2e7cc85231c3bc143) | `php74Extensions.redis: 5.3.6 -> 5.3.7`                             |
| [`ed99332d`](https://github.com/NixOS/nixpkgs/commit/ed99332de5a0cd13995b197dd44ac1356ccf34c5) | `php74Extensions.rdkafka: 6.0.0 -> 6.0.1`                           |
| [`8fba55aa`](https://github.com/NixOS/nixpkgs/commit/8fba55aa4f0661200ce5f2d1fd5377f765f77887) | `sigil: 1.8.0 -> 1.9.0`                                             |
| [`e79a6462`](https://github.com/NixOS/nixpkgs/commit/e79a6462987836acd17b947e2ed46de63f41647c) | `grcov: init at 0.8.7`                                              |
| [`0ac4d02e`](https://github.com/NixOS/nixpkgs/commit/0ac4d02ea5a1606d554ed75d9a8888c708c8bd5c) | `php74Extensions.mailparse: 3.1.2 -> 3.1.3`                         |
| [`dd88285b`](https://github.com/NixOS/nixpkgs/commit/dd88285ba075f98604fae27b7d2073988c974719) | `vimPlugins: update`                                                |
| [`93bc3c2a`](https://github.com/NixOS/nixpkgs/commit/93bc3c2aa448ea3c5d5a071d8d6747a0154a06aa) | `vimPlugins: update`                                                |
| [`939e2fad`](https://github.com/NixOS/nixpkgs/commit/939e2fad0bb8032de5fc209977f967531dab00a6) | `vim-plugin-names: updates`                                         |
| [`b2a83e3c`](https://github.com/NixOS/nixpkgs/commit/b2a83e3c95be96d0f727da606e0885a8cb5622b1) | `vim: update the updaters!`                                         |
| [`b71ebb32`](https://github.com/NixOS/nixpkgs/commit/b71ebb32cedef576181e519380f42d1e2fc5d312) | `vim: Update .github/CODEOWNERS and .github/labeler.yml`            |
| [`3f19fc37`](https://github.com/NixOS/nixpkgs/commit/3f19fc37a3557d31b242b220b52c7a1358572f57) | `Move misc/vim-plugins to applications/editors/vim/plugins`         |
| [`a2122813`](https://github.com/NixOS/nixpkgs/commit/a2122813921a74f1c6f04f113b07f89484376765) | `seatd: 0.6.3 -> 0.6.4`                                             |
| [`301dd50a`](https://github.com/NixOS/nixpkgs/commit/301dd50a43fb49e450053fb173f6dc35219d04e5) | `mandelbulber: 2.26 -> 2.27`                                        |
| [`9887158b`](https://github.com/NixOS/nixpkgs/commit/9887158bced2935efde4ef52953e5763b1cab563) | `tauon: 7.1.1 -> 7.1.2`                                             |
| [`0e474ca3`](https://github.com/NixOS/nixpkgs/commit/0e474ca3ea15f886dcacf62e548b5c4569eb0f16) | `elisp-packages: updated at 2022-02-24`                             |
| [`280aca1d`](https://github.com/NixOS/nixpkgs/commit/280aca1dfb9c67ab13ff4ed07cbf511398dea24f) | `tailscale: 1.20.4 -> 1.22.0`                                       |
| [`b74bddce`](https://github.com/NixOS/nixpkgs/commit/b74bddcec97005c5b6b0dc1d73449ebb995cfb3e) | `netavark: 1.0.0 -> 1.0.1`                                          |
| [`d139133a`](https://github.com/NixOS/nixpkgs/commit/d139133aa65b9d05e388f93b81fc3940f0835fdb) | `aardvark-dns: 1.0.0 -> 1.0.1`                                      |
| [`7ef8df87`](https://github.com/NixOS/nixpkgs/commit/7ef8df8767914249192d09d9056f13e04e54a7e6) | `nixosTests.nano: replace with script using GNU expect`             |
| [`9fe6e0e4`](https://github.com/NixOS/nixpkgs/commit/9fe6e0e4680a09016111ec4395c3a8872a35d965) | `python3Packages.pyeapi: does not support Python 3.10`              |
| [`cb0275d0`](https://github.com/NixOS/nixpkgs/commit/cb0275d013f7e812985b027fe3291222710e4785) | `parallel: 20220122 -> 20220222`                                    |
| [`2d229cad`](https://github.com/NixOS/nixpkgs/commit/2d229cad7da3d1e8b8c8476404c7e7c23862fa13) | `checkov: 2.0.885 -> 2.0.900`                                       |
| [`1f414bd1`](https://github.com/NixOS/nixpkgs/commit/1f414bd194572e93ddd9dd8da44f5cb55df95854) | `python3Packages.ciscoconfparse: 1.6.21 -> 1.6.36`                  |
| [`5531b1ec`](https://github.com/NixOS/nixpkgs/commit/5531b1ec05a4b206fa03ee8dff393e9d83472dae) | `python3Packages.yowsup: fix build`                                 |
| [`d941033b`](https://github.com/NixOS/nixpkgs/commit/d941033be34b64e872af1c01fcbc6668b585c1ff) | `python3Packages.transitions: 0.8.10 -> 0.8.11`                     |
| [`d7d6b02c`](https://github.com/NixOS/nixpkgs/commit/d7d6b02c919138b98bf95678ad11f9dc105205cf) | `kubeconform: 0.4.12 -> 0.4.13`                                     |
| [`fe7c9ae1`](https://github.com/NixOS/nixpkgs/commit/fe7c9ae161c78073fc2c11e3641ad850e7e362bf) | `python310Packages.xml2rfc: 3.12.2 -> 3.12.3`                       |
| [`fe19b4f7`](https://github.com/NixOS/nixpkgs/commit/fe19b4f795f780223fc475c94e1ac75dd7fc5e5e) | `python310Packages.google-cloud-redis: 2.5.1 -> 2.6.0`              |
| [`8b491fdf`](https://github.com/NixOS/nixpkgs/commit/8b491fdf13a4dd68a62a8c20100a35ca6756ab30) | `python310Packages.striprtf: 0.0.19 -> 0.0.20`                      |
| [`61d3eaa6`](https://github.com/NixOS/nixpkgs/commit/61d3eaa66dded75776047dca0f2408112fc56f28) | `python310Packages.google-cloud-videointelligence: 2.5.1 -> 2.6.0`  |
| [`c551b782`](https://github.com/NixOS/nixpkgs/commit/c551b7822053506b312be9d057e07b53aba2da2c) | `python3Packages.pyamg: fix build`                                  |
| [`e0feb905`](https://github.com/NixOS/nixpkgs/commit/e0feb90507d5dc91bc24a88fd64f33136ae9f35a) | `thrift: 0.15.0 -> 0.16.0`                                          |
| [`9bd4ed39`](https://github.com/NixOS/nixpkgs/commit/9bd4ed39357f42aaa3bf3a74524975123b29b670) | `maintainers: add DieracDelta`                                      |
| [`b20eba31`](https://github.com/NixOS/nixpkgs/commit/b20eba3135c2763c4c71dd85efaf28358e81d8ab) | `nsd: 4.3.9 -> 4.4.0`                                               |
| [`86150844`](https://github.com/NixOS/nixpkgs/commit/8615084478e8412e7742fea7511db3d16e98f07e) | `pugixml: 1.12 -> 1.12.1`                                           |
| [`524071fd`](https://github.com/NixOS/nixpkgs/commit/524071fda751efc5b82fc5f1f5798c6a74bbe989) | `openimagedenoise: 1.4.2 -> 1.4.3`                                  |
| [`e0620fbe`](https://github.com/NixOS/nixpkgs/commit/e0620fbefe31382a9fddb04543ec8061c1786bf5) | `emacs: Add withToolkitScrollBars argument`                         |