### PR TITLE
chore(flake/nixpkgs): `fb627379` -> `17cbd972`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1645783086,
-        "narHash": "sha256-L8YfZmwx3FretBLq55gWt6qgFUsns66l0hb+Ci8V1yI=",
+        "lastModified": 1645875852,
+        "narHash": "sha256-r2QeA4wq+4tT0dq71PQI9drZzklBUrtQ8AZyEXTI3JA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fb6273792e1b29455725a921b7f043de70b4b2e7",
+        "rev": "17cbd972947f1fa3480118ff0774430d76af0e95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`a06b41a0`](https://github.com/NixOS/nixpkgs/commit/a06b41a02fb9b810dff1716f9d7235362482de59) | `python3Packages.google-cloud-bigtable: disable on older Python releases`             |
| [`86292fe1`](https://github.com/NixOS/nixpkgs/commit/86292fe1163e37094cefecf2fa122bd00701290a) | `python3Packages.geojson-client: disable on older Python releases`                    |
| [`b78433c2`](https://github.com/NixOS/nixpkgs/commit/b78433c2ffa6fc9ea87f0d0d3c386aaf3b0a5839) | `python3Packages.meshtastic: 1.2.85 -> 1.2.87`                                        |
| [`2ca82804`](https://github.com/NixOS/nixpkgs/commit/2ca82804d9a2053b5980864572623a2fd241cc7c) | `python310Packages.geojson-client: 0.6 -> 0.7`                                        |
| [`6c1e19fc`](https://github.com/NixOS/nixpkgs/commit/6c1e19fcdec3a22851a7af3ee61f22417893206d) | `exploitdb: 2022-02-24 -> 2022-02-25`                                                 |
| [`623e8057`](https://github.com/NixOS/nixpkgs/commit/623e8057cf375dd27d35d2729a7eb7d386f952c3) | `cpuid: 20211210 -> 20220224`                                                         |
| [`c8d677a2`](https://github.com/NixOS/nixpkgs/commit/c8d677a2ec57c6063601a0e06ead718a98f377c9) | `httplz: 1.12.3 -> 1.12.4`                                                            |
| [`73b24b90`](https://github.com/NixOS/nixpkgs/commit/73b24b905d7a5e2440467f09bda95671804de05f) | `rubberband: fix cross compilation`                                                   |
| [`dcd54b9c`](https://github.com/NixOS/nixpkgs/commit/dcd54b9c13c95fda50cee31fddbe46ec276d9a6b) | `pwgen_secure: fix missing words.txt (#161585)`                                       |
| [`33984cd8`](https://github.com/NixOS/nixpkgs/commit/33984cd89ca94954353be396631bcb6a9190c0d2) | `python3Packages.jax: support MKL BLAS/LAPACK implementations`                        |
| [`5ea69616`](https://github.com/NixOS/nixpkgs/commit/5ea69616c69f9dd19b4d90dd519377832f0f3cff) | `findomain: 7.0.0 -> 7.0.1`                                                           |
| [`09307092`](https://github.com/NixOS/nixpkgs/commit/093070927299b9b31ece0365ac0e82208c081837) | `hydra-unstable: fix build with nixVersions.unstable`                                 |
| [`165edd3c`](https://github.com/NixOS/nixpkgs/commit/165edd3cc8a53b9ef94a99fa4321487058c6d7c3) | `meshlab: 2021.10 -> 2022.02`                                                         |
| [`5f056712`](https://github.com/NixOS/nixpkgs/commit/5f056712f0920245b095ae9c74757d6661659024) | `python310Packages.google-cloud-bigtable: 2.5.1 -> 2.5.2`                             |
| [`e281cd6b`](https://github.com/NixOS/nixpkgs/commit/e281cd6b1252477e6c1eb89d630de0c30ded9b0b) | `istioctl: 1.13.0 -> 1.13.1`                                                          |
| [`4ed702b5`](https://github.com/NixOS/nixpkgs/commit/4ed702b59d0e76075ec0b50f2e9bfe269b5639f3) | `erigon: 2022.02.02 -> 2022.02.03`                                                    |
| [`60624257`](https://github.com/NixOS/nixpkgs/commit/606242570bfb8faeff13770ecfbe4bda5d2b816a) | `nuclei: 2.6.1 -> 2.6.2`                                                              |
| [`3180e710`](https://github.com/NixOS/nixpkgs/commit/3180e710ff0ee8258a513807fa1620cfa6051541) | `jamulus: 3.8.1 -> 3.8.2`                                                             |
| [`c5a7ed0a`](https://github.com/NixOS/nixpkgs/commit/c5a7ed0a883333252c14e031efefc9ac44c6fd42) | `mubeng: 0.9.1 -> 0.9.2`                                                              |
| [`b71dc21f`](https://github.com/NixOS/nixpkgs/commit/b71dc21f1768a5fe3dc0659750413f7b882b14b3) | `haproxy: 2.5.2 -> 2.5.3`                                                             |
| [`f529057d`](https://github.com/NixOS/nixpkgs/commit/f529057dada89f0932040003f57638386b636d93) | `checkip: 0.17.3 -> 0.18.0`                                                           |
| [`eb67ca9a`](https://github.com/NixOS/nixpkgs/commit/eb67ca9ac1f99b877bd80652604eb204fb35d35d) | `python310Packages.cupy: 10.1.0 -> 10.2.0`                                            |
| [`e40bc249`](https://github.com/NixOS/nixpkgs/commit/e40bc2494096f0b358fd2142de976164f4068ad6) | `intel-media-sdk: 22.1.0 -> 22.2.0`                                                   |
| [`f69cd3d3`](https://github.com/NixOS/nixpkgs/commit/f69cd3d324db1d6a23f15c0460af4e6820b93425) | `freerdp: 2.5.0 -> 2.6.0`                                                             |
| [`5a6b9954`](https://github.com/NixOS/nixpkgs/commit/5a6b995479d4c57e37cb28f1f565db9f76b0df7c) | `imagemagick: add curl dependency`                                                    |
| [`d9b6b8a8`](https://github.com/NixOS/nixpkgs/commit/d9b6b8a84934aaf5b7261abcdb98f7786e32a0e8) | `ytfzf: 2.1 -> 2.2`                                                                   |
| [`c88fc745`](https://github.com/NixOS/nixpkgs/commit/c88fc7454a9b27d67f733143fc41547f10c5feae) | `cups-filters: 1.28.11 -> 1.28.12`                                                    |
| [`21a1125f`](https://github.com/NixOS/nixpkgs/commit/21a1125f3729e145650b253b19dc9bcd5a0e34cf) | `gmsh: 4.9.4 -> 4.9.5`                                                                |
| [`4759acb8`](https://github.com/NixOS/nixpkgs/commit/4759acb8a50abde3587d28277697b381a23cd556) | `ipfs: 0.11.0 -> 0.12.0`                                                              |
| [`ab1e19e3`](https://github.com/NixOS/nixpkgs/commit/ab1e19e33694f9068aaeb9539164d3739c79840b) | `alejandra: 0.5.0 -> 0.6.0`                                                           |
| [`9654fd31`](https://github.com/NixOS/nixpkgs/commit/9654fd3182d564aa09dcc977f6135217a3cbe766) | `tilix: 1.9.4 -> 1.9.5`                                                               |
| [`6bb093a5`](https://github.com/NixOS/nixpkgs/commit/6bb093a5c1daa4e3451e9ab82ce0113b5e018327) | `werf: 1.2.70 -> 1.2.71`                                                              |
| [`7485a6ac`](https://github.com/NixOS/nixpkgs/commit/7485a6ac038ca276a0607ef1a3e98d13db1da7a9) | `gpac: 1.0.1 -> 2.0.0`                                                                |
| [`72419c91`](https://github.com/NixOS/nixpkgs/commit/72419c91e4943141100ca2304482086a2649c973) | `subgit: 3.3.12 -> 3.3.13`                                                            |
| [`3ac47080`](https://github.com/NixOS/nixpkgs/commit/3ac4708072af03992593ed61a6ec5c485deba2fb) | `frugal: 3.14.14 -> 3.14.15`                                                          |
| [`287381ce`](https://github.com/NixOS/nixpkgs/commit/287381cef4390b5307700b4a970d5fa7937b5c35) | `go-swag: 1.7.9-p1 -> 1.8.0`                                                          |
| [`32b2f848`](https://github.com/NixOS/nixpkgs/commit/32b2f8481a464d54ecebacc27416162364be651f) | `gofumpt: 0.2.1 -> 0.3.0`                                                             |
| [`d95cba44`](https://github.com/NixOS/nixpkgs/commit/d95cba4463cb951518fcbd132981143c269a82dc) | `liquibase: 4.7.1 -> 4.8.0`                                                           |
| [`35e9fa3d`](https://github.com/NixOS/nixpkgs/commit/35e9fa3d13a260cb546478fec91b0b4ea54f3377) | `exodus: 21.12.3 -> 22.2.11`                                                          |
| [`7d4c1995`](https://github.com/NixOS/nixpkgs/commit/7d4c1995de4af86f4d85867dc6d00f1d824fb54a) | `python310Packages.teamcity-messages: 1.30 -> 1.31`                                   |
| [`066a581a`](https://github.com/NixOS/nixpkgs/commit/066a581a80c0939423ff8b2d4b451a07ea8e5865) | `nixos/doc: add release note for makeDesktopItem changes`                             |
| [`8bb8f9c8`](https://github.com/NixOS/nixpkgs/commit/8bb8f9c8118be62d632b6636c2f52e26e2f763bd) | `firefox/wrapper: allow specifying StartupWMClass`                                    |
| [`cb2cfba6`](https://github.com/NixOS/nixpkgs/commit/cb2cfba6f7690d4b8754b0dd5a504efe93d7f44d) | `treewide: switch all desktop file generators to new API`                             |
| [`0c713dbe`](https://github.com/NixOS/nixpkgs/commit/0c713dbed40dd87090a4632cffc7b088653f35cb) | `build-support/makeDesktopItem: make fully declarative, add all missing options`      |
| [`c1844a2b`](https://github.com/NixOS/nixpkgs/commit/c1844a2b58b993c97ecd5fc8329f0383e44958fc) | `suitesparse-graphblas: 6.1.4 -> 6.2.1`                                               |
| [`551e4c56`](https://github.com/NixOS/nixpkgs/commit/551e4c56a35d768bccd9a8e440a50a5fd4a5f1e6) | `kdev-{php,python}: download from KDE mirrors`                                        |
| [`fd2f1b5d`](https://github.com/NixOS/nixpkgs/commit/fd2f1b5dea4f288ca6eb5c9be2c038ac6f4d1fa0) | `wolfssl: 5.1.1 -> 5.2.0`                                                             |
| [`5611ddcd`](https://github.com/NixOS/nixpkgs/commit/5611ddcd65667809865977b970502a80e1bb4992) | `amazon-qldb-shell: fix passthru.tests by specifying mainProgram`                     |
| [`2b32daed`](https://github.com/NixOS/nixpkgs/commit/2b32daedf4ccd553affa7012e28d9b8c25c883d1) | `freetds: 1.3.8 -> 1.3.9`                                                             |
| [`1808423f`](https://github.com/NixOS/nixpkgs/commit/1808423ff2a9573e1f083d935476b49f1aaf24ff) | `oven-media-engine: 0.12.11 -> 0.13.0`                                                |
| [`1c979d94`](https://github.com/NixOS/nixpkgs/commit/1c979d946b0665da30938991000266d2319f4ba0) | `minizinc: 2.5.5 -> 2.6.0`                                                            |
| [`270f7d21`](https://github.com/NixOS/nixpkgs/commit/270f7d21c7f19676b9b9d1c2b7a2833ba2a143f4) | `elisp-packages: updated at 2022-02-25`                                               |
| [`6ca22f0c`](https://github.com/NixOS/nixpkgs/commit/6ca22f0c060803e8c9c3efc33fc65c44e8ba4543) | `cargo-msrv: 0.14.2 -> 0.15.0`                                                        |
| [`640f96d0`](https://github.com/NixOS/nixpkgs/commit/640f96d0461ac8985ac1caa905e728a33e37c433) | `dprint: 0.22.0 -> 0.22.2`                                                            |
| [`fcb5f68c`](https://github.com/NixOS/nixpkgs/commit/fcb5f68c28b6da9546279ae66d8431ae43ddf167) | `blocky: 0.17 -> 0.18`                                                                |
| [`050eb35c`](https://github.com/NixOS/nixpkgs/commit/050eb35cee1919520c16200d1739e7d8e12debed) | `duo-unix: 1.11.5 -> 1.12.0`                                                          |
| [`b8d575e5`](https://github.com/NixOS/nixpkgs/commit/b8d575e5b5007b980331af0a08af1c62f8305577) | `python310Packages.fastapi: 0.73.0 -> 0.74.0`                                         |
| [`869c8e25`](https://github.com/NixOS/nixpkgs/commit/869c8e25eff41bef4b75d339e694ecbe0edaf1c6) | `ncnn: 20211208 -> 20220216`                                                          |
| [`58526c22`](https://github.com/NixOS/nixpkgs/commit/58526c2229a3866dc57b2006a848b61f3584cef3) | `python310Packages.fastprogress: 1.0.0 -> 1.0.2`                                      |
| [`5918b5cb`](https://github.com/NixOS/nixpkgs/commit/5918b5cb4d62180faf20894bc251acfe4de84192) | `wakatime: 1.35.4 -> 1.37.0`                                                          |
| [`4ee698fa`](https://github.com/NixOS/nixpkgs/commit/4ee698fad8e2da7189f29c69afb5afa92f29c542) | `python310Packages.bids-validator: 1.8.9 -> 1.9.2`                                    |
| [`b6866874`](https://github.com/NixOS/nixpkgs/commit/b68668746c4cb2c52448b9d521c2b6baf436016c) | `python310Packages.islpy: 2021.1 -> 2022.1.1`                                         |
| [`fc2cdef5`](https://github.com/NixOS/nixpkgs/commit/fc2cdef599281e4193a32d4cca9a1696c8c30e04) | `curaengine: 4.12.1 -> 4.13.1`                                                        |
| [`0b92e6dc`](https://github.com/NixOS/nixpkgs/commit/0b92e6dc0a49dc4afc21a92ac45da4d346182f46) | `python310Packages.pyicloud: 0.10.2 -> 1.0.0`                                         |
| [`f8f5be81`](https://github.com/NixOS/nixpkgs/commit/f8f5be818254609f6cf85c54b9bf8f5851e2cd42) | `python310Packages.mariadb: 1.0.9 -> 1.0.10`                                          |
| [`f03446cc`](https://github.com/NixOS/nixpkgs/commit/f03446cc4960a745ce814789e3170d7ea031ee0f) | `fits-cloudctl: 0.10.8 -> 0.10.9`                                                     |
| [`0eb1d070`](https://github.com/NixOS/nixpkgs/commit/0eb1d070c85fb8bd14858596a6b29ae363a6af90) | `ipfs-migrator: 1.7.1 -> 2.0.2`                                                       |
| [`1e7c64aa`](https://github.com/NixOS/nixpkgs/commit/1e7c64aae12a346c862882b39aa39faa84e8936a) | `bcftools: 1.14 -> 1.15`                                                              |
| [`668473f0`](https://github.com/NixOS/nixpkgs/commit/668473f04916350224f8972e7532612254091783) | `logseq: 0.5.9 -> 0.6.0`                                                              |
| [`ce6fe7b1`](https://github.com/NixOS/nixpkgs/commit/ce6fe7b1c2d77f719d9e4e4de5cec43c1abed47e) | `nomad-autoscaler: 0.3.5 -> 0.3.6`                                                    |
| [`0e0b02c1`](https://github.com/NixOS/nixpkgs/commit/0e0b02c1f798032d0df7f0109e7536ee40b25b4b) | `python310Packages.qimage2ndarray: 1.8.3 -> 1.9.0`                                    |
| [`db94accb`](https://github.com/NixOS/nixpkgs/commit/db94accbcae041647bcdeaa6b106bd19c1b8ab5d) | `chezmoi: 2.12.0 -> 2.12.1`                                                           |
| [`fedd518c`](https://github.com/NixOS/nixpkgs/commit/fedd518caf83cb1298304773ea662e89ead2a1be) | `python310Packages.sphinxcontrib-tikz: 0.4.15 -> 0.4.16`                              |
| [`975f7d04`](https://github.com/NixOS/nixpkgs/commit/975f7d0463751a09ed858a78b06b0a0447241980) | `aliases.nix: deprecate ocaml aliases`                                                |
| [`a36f4559`](https://github.com/NixOS/nixpkgs/commit/a36f455905d55838a0d284656e096fbdb857cf3a) | `aliases.nix: convert or remove aliases older than 2019-06-01`                        |
| [`3bfc9a1c`](https://github.com/NixOS/nixpkgs/commit/3bfc9a1cc614cd2ba4506d4f833e8367c8f5a7b2) | `libcouchbase: 3.2.4 -> 3.2.5`                                                        |
| [`8af32947`](https://github.com/NixOS/nixpkgs/commit/8af32947b4de0299cc8f223a3787c782cc840a4b) | `firecracker: 0.25.2 -> 1.0.0`                                                        |
| [`50705e9f`](https://github.com/NixOS/nixpkgs/commit/50705e9f0c44bd5bda560d7d3bf3adb15c9585ff) | `openvswitch: 2.16.2 -> 2.17.0`                                                       |
| [`3c962d11`](https://github.com/NixOS/nixpkgs/commit/3c962d11e476788aff46425d57629262f13e4390) | `gensio: 2.2.9 -> 2.3.6`                                                              |
| [`4bc58eef`](https://github.com/NixOS/nixpkgs/commit/4bc58eef87f35a7172f3483746fb0c431df8d808) | `mold: 1.0.3 -> 1.1`                                                                  |
| [`ac216552`](https://github.com/NixOS/nixpkgs/commit/ac2165529b9e8704d87badffa0e84c4f1842e935) | `angband: 4.2.3 -> 4.2.4`                                                             |
| [`6f4be680`](https://github.com/NixOS/nixpkgs/commit/6f4be6806200b3fa929d2bdaf085a69cd73cc70a) | `oil: 0.9.7 -> 0.9.8`                                                                 |
| [`733e15de`](https://github.com/NixOS/nixpkgs/commit/733e15de50df4561149b5595e5d4c98d8cd70665) | `gnome.gnome-mines: 40.0 -> 40.1`                                                     |
| [`a658e56a`](https://github.com/NixOS/nixpkgs/commit/a658e56aefd7335763a09dc8e9ccc6d15c36ec74) | `sabnzbd: 3.5.0 -> 3.5.1`                                                             |
| [`91950402`](https://github.com/NixOS/nixpkgs/commit/919504028f0cbf8fd22f29d1a4807ab4cf7271cd) | `ocserv: 1.1.5 -> 1.1.6`                                                              |
| [`8b2bc00e`](https://github.com/NixOS/nixpkgs/commit/8b2bc00ec85723145fd8bee0252e290ec98672cd) | `obs-studio: 27.2.0 -> 27.2.1`                                                        |
| [`69380e54`](https://github.com/NixOS/nixpkgs/commit/69380e5461fb308f4efa1dae06a4b31b81edcbea) | `pspg: 5.5.3 -> 5.5.4`                                                                |
| [`199f1c91`](https://github.com/NixOS/nixpkgs/commit/199f1c91fb25c4a6d5ee87003479bcc180cacf14) | `python310Packages.sopel: 7.1.7 -> 7.1.8`                                             |
| [`ddf9003d`](https://github.com/NixOS/nixpkgs/commit/ddf9003dc1b2cc3e951c220d709511fedbac30df) | `python310Packages.bitarray: 2.3.6 -> 2.3.7`                                          |
| [`95237563`](https://github.com/NixOS/nixpkgs/commit/9523756331e06ace7982a505df7d6d3f731999dc) | `python39Packages.gehomesdk: 0.4.23 -> 0.4.24`                                        |
| [`4bb2d9b4`](https://github.com/NixOS/nixpkgs/commit/4bb2d9b4e51221c4f306184419f77341e5988cd3) | `folly: 2022.02.14.00 -> 2022.02.21.00`                                               |
| [`3b26fc4a`](https://github.com/NixOS/nixpkgs/commit/3b26fc4a3dee45d90f3fe8660d921cacda731285) | `python310Packages.py_scrypt: 0.8.19 -> 0.8.20`                                       |
| [`b9cac792`](https://github.com/NixOS/nixpkgs/commit/b9cac792d254108c428b1f1ad00ebaef63fb8dce) | `remarkable-mouse: 7.0.0 -> 7.0.1`                                                    |
| [`a5a193eb`](https://github.com/NixOS/nixpkgs/commit/a5a193eb5312417261a8a8e0aa2bdfa41b7e4308) | `tela-icon-theme: 2022-01-25 -> 2022-02-21`                                           |
| [`fa7c86fe`](https://github.com/NixOS/nixpkgs/commit/fa7c86fe2f85041e5352368684b93440e525fc5e) | `scs: 3.1.0 -> 3.2.0`                                                                 |
| [`9f105df1`](https://github.com/NixOS/nixpkgs/commit/9f105df1b3646ccf08411e00aed48ce24f5e5db7) | `seaweedfs: 2.89 -> 2.90`                                                             |
| [`90f77aa1`](https://github.com/NixOS/nixpkgs/commit/90f77aa1434644fb2c6cf369d774bfac6a361f4c) | `python39Packages.jupyter-server-mathjax: 0.2.3 -> 0.2.5`                             |
| [`f184a17d`](https://github.com/NixOS/nixpkgs/commit/f184a17d9ca5f6d1a8fd008b1b4ded3ccdf66889) | `circleci-cli: 0.1.16737 -> 0.1.16947`                                                |
| [`6487f51f`](https://github.com/NixOS/nixpkgs/commit/6487f51f74c2ae4fa120c660776997aff2a2130a) | `vale: 2.15.1 -> 2.15.2`                                                              |
| [`f8e0e77e`](https://github.com/NixOS/nixpkgs/commit/f8e0e77e262f92d7f96d68755340c6450bdd1c01) | `xbanish: 1.7 -> 1.8`                                                                 |
| [`7a728a16`](https://github.com/NixOS/nixpkgs/commit/7a728a162418f0f0fe8664e8c971fb4d2bcb2188) | `rates: 0.6.0 -> 0.7.0`                                                               |
| [`3b45a6bf`](https://github.com/NixOS/nixpkgs/commit/3b45a6bf1fb1d241f2cbae322511f0d3d627743d) | `python310Packages.scp: 0.14.3 -> 0.14.4`                                             |
| [`dbd8653c`](https://github.com/NixOS/nixpkgs/commit/dbd8653cd5ceeeb46ba87735dd3d864a1fd5465e) | `nsxiv: init at 28`                                                                   |
| [`9e605c8d`](https://github.com/NixOS/nixpkgs/commit/9e605c8d06f9303518f38ad972b1b0a7bfbbc8d7) | `qmk-udev-rules: 0.13.23 -> 0.15.25`                                                  |
| [`aee24ba3`](https://github.com/NixOS/nixpkgs/commit/aee24ba341de5ad11085e624adab8340c7812210) | `python310Packages.google-cloud-org-policy: 1.2.1 -> 1.3.0`                           |
| [`e68fc847`](https://github.com/NixOS/nixpkgs/commit/e68fc84783b5d7b962203758cfec1f49d9226acd) | `OSCAR: 1.3.0 -> 1.3.1`                                                               |
| [`46f8c783`](https://github.com/NixOS/nixpkgs/commit/46f8c78337c51b188ba9fa4ea48617d433a26144) | `opentelemetry-collector-contrib: 0.44.0 -> 0.45.1`                                   |
| [`1986bedc`](https://github.com/NixOS/nixpkgs/commit/1986bedcffc8f378a8bfe90e8225c9d5fcf69883) | `python3Packages: document how to handle extras-require`                              |
| [`51ef95e6`](https://github.com/NixOS/nixpkgs/commit/51ef95e6faa8efd644424dd72796e1bb9997983c) | `python3.pkgs.dask: don't offer an option for extras-require`                         |
| [`ff845153`](https://github.com/NixOS/nixpkgs/commit/ff845153ac41dc64bfd14a0221167a7a2a7e7cd5) | `python27Packages.gtkme: init at version 1.5.1`                                       |
| [`0702d31a`](https://github.com/NixOS/nixpkgs/commit/0702d31a28d03eec928e7b04791409203a2ae118) | `schildichat: 1.9.8-sc.1 -> 1.10.3-sc.0.test.1 (#161584)`                             |
| [`e6733110`](https://github.com/NixOS/nixpkgs/commit/e67331103e23dc2a2ee44dbf0e093bcdda417462) | `python3.pkgs.panel: fix package by switching to prebuilt wheel`                      |
| [`4d1bfdd7`](https://github.com/NixOS/nixpkgs/commit/4d1bfdd7447e78e1fedd31e3edb5f327bd9cddc7) | `terragrunt: 0.36.1 -> 0.36.2`                                                        |
| [`e562efef`](https://github.com/NixOS/nixpkgs/commit/e562efeff6830cf0428bc81480637e741a72f7bd) | `qtstyleplugin-kvantum-qt4: 0.20.2 -> 1.0.1`                                          |
| [`126d0be6`](https://github.com/NixOS/nixpkgs/commit/126d0be6b87c9426172ac01667ac135b5d1c39b4) | `minikube: 1.25.1 -> 1.25.2`                                                          |
| [`c2deb7a9`](https://github.com/NixOS/nixpkgs/commit/c2deb7a921f29a3583eaf7b3b535ef0f86913b51) | `python3Packages.aesara: move cython to nativeBuildInputs`                            |
| [`3ed84b7b`](https://github.com/NixOS/nixpkgs/commit/3ed84b7b65bf456b91388237983b09d3a7ea8a08) | `python310Packages.google-cloud-os-config: 1.9.0 -> 1.10.0`                           |
| [`2ebe62c9`](https://github.com/NixOS/nixpkgs/commit/2ebe62c929af98a38ca58449983e4817760970d5) | `python3Packages.pytest-console-scripts: clean-ip`                                    |
| [`37f23fbf`](https://github.com/NixOS/nixpkgs/commit/37f23fbfb1ddf22a71aac40ca8d15759fa2932c9) | `python3Packages.identify: 2.4.10 -> 2.4.11`                                          |
| [`3917530a`](https://github.com/NixOS/nixpkgs/commit/3917530ac3c9c23be36f63198d380f7b624390bf) | `vimPlugins.lightline-lsp: init at 2022-01-09`                                        |
| [`4dd229ff`](https://github.com/NixOS/nixpkgs/commit/4dd229ff0ad53046400cb4e792ca41cf0009392d) | `vimPlugins.nvim-lightline-lsp: init at 2022-01-06`                                   |
| [`a7024faa`](https://github.com/NixOS/nixpkgs/commit/a7024faac52b8a884330e25934797b3efaa589c5) | `vimPlugins: update`                                                                  |
| [`75e1bb15`](https://github.com/NixOS/nixpkgs/commit/75e1bb15fa4d877c7b22e1e629a5d6f5df24a54a) | `vim/update.py: make '--add' option work`                                             |
| [`50fd62c9`](https://github.com/NixOS/nixpkgs/commit/50fd62c90b7d859547969f8e4bd3c74037d8a3b2) | `python310Packages.qiskit-finance: 0.3.0 -> 0.3.1`                                    |
| [`ad161944`](https://github.com/NixOS/nixpkgs/commit/ad161944605a00dbf036dee4eea10eab8a286121) | `nixos/bird: improve systemd hardening / capability set`                              |
| [`a5276e1f`](https://github.com/NixOS/nixpkgs/commit/a5276e1fbdb1773554fb882ad4432116b9b4d918) | `bird: change runtstatedir to systemd convention`                                     |
| [`9abf72f2`](https://github.com/NixOS/nixpkgs/commit/9abf72f229f355c14dc4e332fa16ca8f1d36c1d5) | `bird1: drop package + modules`                                                       |
| [`3ab90617`](https://github.com/NixOS/nixpkgs/commit/3ab90617d3f597004882fee9af51478ab9a74210) | `python3Packages.datamodeldict: clean-up`                                             |
| [`6895ccff`](https://github.com/NixOS/nixpkgs/commit/6895ccff47d4f5a5b8bd6a0c88595f3bfaaca42a) | `python3Packages.tldextract: add format`                                              |
| [`82e1f86e`](https://github.com/NixOS/nixpkgs/commit/82e1f86e3cb7178429974e1d6b583047dc94b4e8) | `python3Packages.influxdb-client: add format`                                         |
| [`55a717e0`](https://github.com/NixOS/nixpkgs/commit/55a717e0156dcda57922f1808a479ebe61e46ab8) | `python3Packages.aws-lambda-builders: disable on older Python releases`               |
| [`3a0afd54`](https://github.com/NixOS/nixpkgs/commit/3a0afd5401cbd3f8a019399486b1bf8d09286e59) | `geoipupdate: set version with ldflags`                                               |
| [`8d78ce1e`](https://github.com/NixOS/nixpkgs/commit/8d78ce1eb419baf7c8681bbeb0c017a7346f28c0) | `libxmlb: 0.3.1 → 0.3.7`                                                              |
| [`a9e45e14`](https://github.com/NixOS/nixpkgs/commit/a9e45e14e79aff14ce725187b96f155d70350383) | `gping: 1.2.7 -> 1.3.0`                                                               |
| [`553eae0c`](https://github.com/NixOS/nixpkgs/commit/553eae0caf4cdef03d45051a91bfec1cad2a50ba) | `python3Packages.pydexcom: 0.2.2 -> 0.2.3`                                            |
| [`c8d35543`](https://github.com/NixOS/nixpkgs/commit/c8d355433e47067c2cab8a9049a060cc9f1699eb) | `python3Packages.b2sdk: add format`                                                   |
| [`7e20e903`](https://github.com/NixOS/nixpkgs/commit/7e20e9039e7f2c41d478441d0ef453a34c1ec57a) | `coqPackages: tree-wide move packages to nativeBuildInputs and add strictDeps = true` |
| [`07fbf1cc`](https://github.com/NixOS/nixpkgs/commit/07fbf1ccda0da87c411f498ab8ff0ed0d4911eda) | `librosa: 0.9.0 -> 0.9.1`                                                             |
| [`214e341f`](https://github.com/NixOS/nixpkgs/commit/214e341fa7c366881c1882d01c03f9001cd3048e) | `dunst: 1.7.3 -> 1.8.0`                                                               |
| [`dc30367f`](https://github.com/NixOS/nixpkgs/commit/dc30367f3881b13db425b60ebbcf33788a9ae1f1) | `deno: 1.19.0 -> 1.19.1`                                                              |
| [`a816bcca`](https://github.com/NixOS/nixpkgs/commit/a816bccad90a185e98f6e1a8faf4b0e15ef8e575) | `quick-lint-js: 2.2.0 -> 2.3.0`                                                       |
| [`7f3b4e95`](https://github.com/NixOS/nixpkgs/commit/7f3b4e95a24b8ccc923e21dd6dfcf82c8f052fb7) | `bats: 1.5.0 -> 1.6.0`                                                                |
| [`b0c64a2d`](https://github.com/NixOS/nixpkgs/commit/b0c64a2dfe5ddb617703b938b814d3745247b334) | `certigo: 1.14.1 -> 1.15.0`                                                           |
| [`76f3e4a8`](https://github.com/NixOS/nixpkgs/commit/76f3e4a80251dc6e6f291e799cd91b18ea575d65) | `cargo-valgrind: 2.0.2 -> 2.0.3`                                                      |
| [`5d535adc`](https://github.com/NixOS/nixpkgs/commit/5d535adc7a2924554bfa23726252f4d04332d88f) | `cargo-make: 0.35.8 -> 0.35.9`                                                        |
| [`df215753`](https://github.com/NixOS/nixpkgs/commit/df21575304c73a8593ef3d124e29028993b34c9b) | `mariadb: fix invalid PLUGIN_AUTH_PAM value`                                          |
| [`c5a109f8`](https://github.com/NixOS/nixpkgs/commit/c5a109f8477a2a93edc20da74d381d2eb3df0e5e) | `heroic: 2.0.2 -> 2.2.1`                                                              |
| [`d9ce0db8`](https://github.com/NixOS/nixpkgs/commit/d9ce0db8f7505a77385e0fb3ed864d653ecfd3fa) | `amazon-qldb-shell: 2.0.0 -> 2.0.1`                                                   |
| [`16b568a8`](https://github.com/NixOS/nixpkgs/commit/16b568a8fddb9a52d182d4320a8c2f1ba9a7ddf3) | `linux_latest-libre: 18587 -> 18613`                                                  |
| [`8236ce5d`](https://github.com/NixOS/nixpkgs/commit/8236ce5d1b88df6bca009a7d7b1f16eb4cf83696) | `linux: 5.4.180 -> 5.4.181`                                                           |
| [`5d84cca2`](https://github.com/NixOS/nixpkgs/commit/5d84cca2bc1204bab5da0b62f9ab899f6c07ba03) | `linux: 5.16.10 -> 5.16.11`                                                           |
| [`5ecbcef8`](https://github.com/NixOS/nixpkgs/commit/5ecbcef8e9564c1d876c7780799176bea6eb5058) | `linux: 5.15.24 -> 5.15.25`                                                           |
| [`4975bf04`](https://github.com/NixOS/nixpkgs/commit/4975bf0463ec440ecfaa9b3727cead597002084b) | `linux: 5.10.101 -> 5.10.102`                                                         |