### PR TITLE
chore(flake/home-manager): `c7a13f76` -> `ccd00e3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1645867939,
-        "narHash": "sha256-p3vHHMM5W6ojmStJqKpLvdnzxxKGG015U7OK6PJE8lo=",
+        "lastModified": 1645905972,
+        "narHash": "sha256-wP5R/s7JOQ8DWByflZreLfGwBTY6pzjEAT+Mrhd74U8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c7a13f76a78bb5c225ca5e08e9a109347d130792",
+        "rev": "ccd00e3c93b89b26ca86749cfe64b371e2dd7910",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`ccd00e3c`](https://github.com/nix-community/home-manager/commit/ccd00e3c93b89b26ca86749cfe64b371e2dd7910) | `launchd: fix undefined variable in activation script (#2763)` |