### PR TITLE
chore(flake/nixpkgs): `17cbd972` -> `6f21ff94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1645875852,
-        "narHash": "sha256-r2QeA4wq+4tT0dq71PQI9drZzklBUrtQ8AZyEXTI3JA=",
+        "lastModified": 1645917420,
+        "narHash": "sha256-y/F63lVqvxlBt5brDCV/QUdcnP7acvtR6Mf0Phrr13Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "17cbd972947f1fa3480118ff0774430d76af0e95",
+        "rev": "6f21ff94fc44af21973c6fdae6e03323382b7909",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`d1418cce`](https://github.com/NixOS/nixpkgs/commit/d1418cce93da4c3fb5d2a419ada82d20f77e24c5) | `velero: 1.7.1 -> 1.8.0`                                                   |
| [`953c9a5d`](https://github.com/NixOS/nixpkgs/commit/953c9a5d6e162ee35455f13b77d2c4d279356223) | `coreboot-toolchain: 4.15 -> 4.16`                                         |
| [`005a18f6`](https://github.com/NixOS/nixpkgs/commit/005a18f6bda9376fe8f92b324db4ac05cd5387de) | `hepmc3: 3.2.4 -> 3.2.5`                                                   |
| [`c267e9ce`](https://github.com/NixOS/nixpkgs/commit/c267e9ce37dd2f2f9975ab83c538a624f1fede50) | `mumble,murmur: 1.3.4 -> 1.4.231`                                          |
| [`b438b68c`](https://github.com/NixOS/nixpkgs/commit/b438b68cb495e48f104e4f87ac28ef52c6e7b3cd) | `python3Packages.zcs: patch to fix the test`                               |
| [`cc0b1fdd`](https://github.com/NixOS/nixpkgs/commit/cc0b1fddcdd9a55005d18ecee6fc30eabc89d156) | `python3Packages.mlflow: 1.22.0 -> 1.23.1`                                 |
| [`154e13a5`](https://github.com/NixOS/nixpkgs/commit/154e13a556984f1aa2f88b6c866a8370cf21af1a) | `chromiumDev: 100.0.4892.0 -> 100.0.4896.12`                               |
| [`05b2b4e3`](https://github.com/NixOS/nixpkgs/commit/05b2b4e3cbfa23926cb30ffab16d2f2409a1b6c0) | `chromiumBeta: 99.0.4844.35 -> 99.0.4844.45`                               |
| [`6431bebc`](https://github.com/NixOS/nixpkgs/commit/6431bebc93b6ce35f98d9c6d1b09975126a391d8) | `mesa: Limit the devDoesNotDependOnLLVM test to Linux`                     |
| [`1827d631`](https://github.com/NixOS/nixpkgs/commit/1827d6315a8a6862e9bb40f1bc554045efd95065) | `uncrustify: 0.72.0 -> 0.74.0`                                             |
| [`c9fa0313`](https://github.com/NixOS/nixpkgs/commit/c9fa03136ad26fab9c5d4d62c57fc26e2d5dc9e5) | `or-tools: disable parallel-building`                                      |
| [`464bb0bb`](https://github.com/NixOS/nixpkgs/commit/464bb0bb59a27f311441429fa99167de3f300ae8) | `evolution-ews: 3.42.3 -> 3.42.4`                                          |
| [`35c1b68c`](https://github.com/NixOS/nixpkgs/commit/35c1b68c8640f2a22ee925c903bfc29d5c125259) | `lfs: 2.1.0 -> 2.1.1`                                                      |
| [`24cbda98`](https://github.com/NixOS/nixpkgs/commit/24cbda98f321bad884e3e464ec0ef965d4a91777) | `fetchzip: remove need for overrideAttrs`                                  |
| [`b97b9c37`](https://github.com/NixOS/nixpkgs/commit/b97b9c376c093ca3a582a4477e6e61a40a9fc6d5) | `tor-browser-bundle-bin: add tor.calyxinstitute.org mirror`                |
| [`f17c99c1`](https://github.com/NixOS/nixpkgs/commit/f17c99c166c064b6fcf597ff681ced509810f779) | `fend: 0.1.28 -> 0.1.29`                                                   |
| [`8d87ec8d`](https://github.com/NixOS/nixpkgs/commit/8d87ec8d17a4a7f4c8d88816de4d4e6063a98077) | `shadowsocks-rust: 1.13.3 -> 1.13.5`                                       |
| [`6fede792`](https://github.com/NixOS/nixpkgs/commit/6fede79227a872f860d3ba8ee95d08459c4a0509) | `unrar: 6.1.4 -> 6.1.5`                                                    |
| [`ce25f6f2`](https://github.com/NixOS/nixpkgs/commit/ce25f6f2db789d8374d0fa5a737cd6f3ab09d813) | `argo: fix cross compilation`                                              |
| [`9c61cdfb`](https://github.com/NixOS/nixpkgs/commit/9c61cdfb85f87abbe25e47d4005407a34179a88a) | `gnome.gpaste: 3.42.5 -> 3.42.6`                                           |
| [`dd9760d9`](https://github.com/NixOS/nixpkgs/commit/dd9760d9f7e5b13d2323781cf468d5fe90d1794c) | `purescript: 0.14.5 -> 0.14.6`                                             |
| [`61d2bc0c`](https://github.com/NixOS/nixpkgs/commit/61d2bc0cfe14ca32d420766b83ad0a839a3503c1) | `gnome-tour: 40.0 -> 40.1`                                                 |
| [`0c8d2aa9`](https://github.com/NixOS/nixpkgs/commit/0c8d2aa94d06f552d215638347725fc4a119b403) | `rofi: fix cross compilation`                                              |
| [`c790751a`](https://github.com/NixOS/nixpkgs/commit/c790751a59657d98cbfa9cf003688ccf3851ced8) | `gegl: 0.4.34 → 0.4.36`                                                    |
| [`e0df172c`](https://github.com/NixOS/nixpkgs/commit/e0df172ce2111052f20dd180fc91cc0e9bbdfc0f) | `gitlab: 14.7.3 -> 14.7.4 (#161948)`                                       |
| [`03fbc3ea`](https://github.com/NixOS/nixpkgs/commit/03fbc3ea99fa1b5379a68019cf81267bcd403db2) | `release-notes: mention pgadmin`                                           |
| [`42a5831e`](https://github.com/NixOS/nixpkgs/commit/42a5831e6235f815546411c48106381f2b2d1a8a) | `nixos/pgadmin: init`                                                      |
| [`ae2f179c`](https://github.com/NixOS/nixpkgs/commit/ae2f179c9b27f6d4c40e46a07b1d748ba53f3b33) | `tests/pgadmin4-standalone: add`                                           |
| [`3cbd5a6d`](https://github.com/NixOS/nixpkgs/commit/3cbd5a6deb68511189d19bfbf51b925b34830035) | `pgadmin4: expose setup.py as pgadmin4-setup`                              |
| [`0afa5a14`](https://github.com/NixOS/nixpkgs/commit/0afa5a144439f544c195ce796e91a2b5d7bce2d7) | `pgadmin4: 6.3 -> 6.5`                                                     |
| [`3bcb49ab`](https://github.com/NixOS/nixpkgs/commit/3bcb49aba45e58d8eedeca0f8804fb329cdcad23) | `ocamlPackages.pycaml: remove at 0.82-14`                                  |
| [`69ec03d1`](https://github.com/NixOS/nixpkgs/commit/69ec03d112f9ca80f12ae5e744c5d3cc5e262724) | `pgadmin3: move`                                                           |
| [`0dda2d38`](https://github.com/NixOS/nixpkgs/commit/0dda2d3888eb8726dcdd891f34cbc64db8d1c85a) | `pgadmin4: init at 6.3`                                                    |
| [`37a19c55`](https://github.com/NixOS/nixpkgs/commit/37a19c55df912a111d10f4b78367ad906db031b0) | `chromium: Suffix instead of prefix ${xdg-utils}/bin to $PATH`             |
| [`b8d80588`](https://github.com/NixOS/nixpkgs/commit/b8d80588aa51e038f16e12faa558ba2238251ba5) | `python3Packages.google-cloud-translate: disable on older Python releases` |
| [`192eb5d8`](https://github.com/NixOS/nixpkgs/commit/192eb5d89603b16cd8c4b0c0326fbec89379b391) | `hydra-unstable: fixup eval.patch`                                         |
| [`000b4cde`](https://github.com/NixOS/nixpkgs/commit/000b4cde6318d69bf62fd5c04d5071cb3e8cea7b) | `eksctl: 0.84.0 -> 0.85.0`                                                 |
| [`fa6e55be`](https://github.com/NixOS/nixpkgs/commit/fa6e55bec215143b09fccdbfe483ebda60218712) | `ghorg: 1.5.1 -> 1.7.8`                                                    |
| [`c1cb95b4`](https://github.com/NixOS/nixpkgs/commit/c1cb95b42154f73a9931aa83980478ec34016001) | `coreboot-toolchain: Fix update script`                                    |
| [`15f70d79`](https://github.com/NixOS/nixpkgs/commit/15f70d798a20ff95abb80c34f8c6e7ed8ffee7f1) | `python310Packages.zict: 2.0.0 -> 2.1.0`                                   |
| [`ccb4820b`](https://github.com/NixOS/nixpkgs/commit/ccb4820b682055c1eb5011dfef80b04517909a55) | `bosh-cli: 6.4.16 -> 6.4.17`                                               |
| [`25489d96`](https://github.com/NixOS/nixpkgs/commit/25489d9628703d94028e59b1a2a877108bc5a94e) | `redmine: 4.2.3 -> 4.2.4`                                                  |
| [`756cd052`](https://github.com/NixOS/nixpkgs/commit/756cd052e7da25fcfa26318c09e7e4a74ff4837c) | `tmux: add utf8proc on Darwin`                                             |
| [`807e90c6`](https://github.com/NixOS/nixpkgs/commit/807e90c62a5e0f29e5563df83cf6afb7d93d2fc2) | `shiori: 1.5.1 -> 1.5.2`                                                   |
| [`5534c689`](https://github.com/NixOS/nixpkgs/commit/5534c689cbb872a4a26193fbcbffc477757cd351) | `pjsip: 2.11.1 -> 2.12`                                                    |
| [`1e5d3fe5`](https://github.com/NixOS/nixpkgs/commit/1e5d3fe52fcef44b561b77aae9a7bb9b92d4687f) | `python310Packages.google-cloud-translate: 3.6.1 -> 3.7.0`                 |
| [`78382f9b`](https://github.com/NixOS/nixpkgs/commit/78382f9be9058ed33e2e13aa0b5a1abf5ef2b471) | `buttercup-desktop: 2.13.0 -> 2.14.2`                                      |
| [`86cd00d9`](https://github.com/NixOS/nixpkgs/commit/86cd00d92def448d10aaade3387de525fdfb7928) | `android-studio: Remove version string from desktop and icon file.`        |
| [`2c12568d`](https://github.com/NixOS/nixpkgs/commit/2c12568dd5741d4c63fb0892b4581584797cbcff) | `python310Packages.pglast: 3.8 -> 3.9`                                     |
| [`e874111a`](https://github.com/NixOS/nixpkgs/commit/e874111a93b8fdba0d63ef31f5c14f6269520d9d) | `antimicrox: 3.2.1 -> 3.2.2`                                               |
| [`0f558b35`](https://github.com/NixOS/nixpkgs/commit/0f558b35e63e657fa0392cc4df777730820fbcba) | `morgen: 2.4.3 -> 2.4.4`                                                   |
| [`8ba0abae`](https://github.com/NixOS/nixpkgs/commit/8ba0abae7196ac90ea5106edc0d11d4733634de9) | `actionlint: 1.6.8 -> 1.6.9`                                               |
| [`ba115276`](https://github.com/NixOS/nixpkgs/commit/ba1152768ab54a5df9d873aa7dc56d0897388c0b) | `mobilecoin-wallet: 1.4.1 -> 1.5.0`                                        |
| [`f414b5bc`](https://github.com/NixOS/nixpkgs/commit/f414b5bc2919e5a9edddca282578d0d36fb987d5) | `firefly-desktop: 1.2.0 -> 1.3.3`                                          |
| [`f4ed38c5`](https://github.com/NixOS/nixpkgs/commit/f4ed38c560d3ec8f9753a80af75f510bb8db4b81) | `waypoint: 0.7.1 -> 0.7.2`                                                 |
| [`6fb057df`](https://github.com/NixOS/nixpkgs/commit/6fb057df970f2c0f996a30ad9600f7ac5b87595d) | `shipyard: 0.3.45 -> 0.3.47`                                               |
| [`4ada5cb4`](https://github.com/NixOS/nixpkgs/commit/4ada5cb4b16723b0bdccf7aa6486847880b68879) | `sentry-cli: 1.72.2 -> 1.73.0`                                             |
| [`3aa20d02`](https://github.com/NixOS/nixpkgs/commit/3aa20d022246301e0759c276563330ed452bd93a) | `netpbm: 10.97.3 -> 10.97.4`                                               |
| [`84539c6a`](https://github.com/NixOS/nixpkgs/commit/84539c6a7067c77158452ce3e021460d98739075) | `fossil: 2.17 -> 2.18`                                                     |
| [`eb85cca5`](https://github.com/NixOS/nixpkgs/commit/eb85cca5addf55bf7afbf43ca5d93763251da5db) | `usbguard: 1.0.0 -> 1.1.0`                                                 |
| [`9d4d6435`](https://github.com/NixOS/nixpkgs/commit/9d4d64358ea285566b40120bc69e52dd026967b1) | `postgresqlPackages.timescaledb: 2.5.2 -> 2.6.0`                           |
| [`86e02dc2`](https://github.com/NixOS/nixpkgs/commit/86e02dc24ab5c8d2fe592b8bb3dc6d0b04f55664) | `universal-ctags: remove incorrect use of checkFlags`                      |
| [`c58e4250`](https://github.com/NixOS/nixpkgs/commit/c58e42508bfcc3c9de658846b1e7b8f58b82f9e0) | `universal-ctags: 5.9.20210411.0 -> 5.9.20220220.0`                        |
| [`f34d6416`](https://github.com/NixOS/nixpkgs/commit/f34d6416579c50c49be71a8fea115a74cea4a308) | `cryfs: 0.11.1 -> 0.11.2`                                                  |
| [`103da52f`](https://github.com/NixOS/nixpkgs/commit/103da52f9b9c8b86513908b9026bf249ad5803be) | `ytarchive: 2021-12-29 -> 2022-02-16`                                      |
| [`d079f1c0`](https://github.com/NixOS/nixpkgs/commit/d079f1c0d991ae3a41d04659e98f02ddb9dc788a) | `carla: 2.4.1 -> 2.4.2`                                                    |
| [`015845aa`](https://github.com/NixOS/nixpkgs/commit/015845aa4b7a16f5b38deaeee972467c82eb8874) | `oxen: mark as broken on darwin`                                           |
| [`403cff50`](https://github.com/NixOS/nixpkgs/commit/403cff50e67ca0b49e3c6b381631df7c95fdd40e) | `flite: disable parallelism`                                               |
| [`08590cf6`](https://github.com/NixOS/nixpkgs/commit/08590cf6b993824dfa4b3f9174fe625a2287cdae) | `live555: 2022.01.21 -> 2022.02.07`                                        |