### PR TITLE
chore(flake/nixpkgs): `6f21ff94` -> `6896623f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1645917420,
-        "narHash": "sha256-y/F63lVqvxlBt5brDCV/QUdcnP7acvtR6Mf0Phrr13Q=",
+        "lastModified": 1645958901,
+        "narHash": "sha256-vcPuKbeJemK+a7Oce4fSMsGt9n99Ogwv/At0Oy/aW6E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6f21ff94fc44af21973c6fdae6e03323382b7909",
+        "rev": "6896623f630ce8703e2201625eabd9f01dfcc5e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                          |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`d118f55e`](https://github.com/NixOS/nixpkgs/commit/d118f55e2310b29fdb037d900e062705edcb27dd) | `php74Packages.composer: 2.2.6 -> 2.2.7`                                |
| [`6e389e63`](https://github.com/NixOS/nixpkgs/commit/6e389e63678fe13660bcc9f708649e64eae6bb05) | `nixos/bird: run service as non-root user, add test for reload`         |
| [`33a22b33`](https://github.com/NixOS/nixpkgs/commit/33a22b332a8743acdc01505b238de9f882657a77) | `python310Packages.motionblinds: 0.5.13 -> 0.6.0`                       |
| [`eec72b56`](https://github.com/NixOS/nixpkgs/commit/eec72b56d773d0e808d8c95c72290a7f16f12962) | `cataclysm-dda: enable parallel building (#161957)`                     |
| [`17df62a9`](https://github.com/NixOS/nixpkgs/commit/17df62a9373741f490aacb817c0341704dd5a830) | `shiori: fix NixOS test (#161969)`                                      |
| [`9e609e9d`](https://github.com/NixOS/nixpkgs/commit/9e609e9d81c0156163e1d0985f5858597fcf79e2) | `rtsp-simple-server: 0.17.8 -> 0.17.17`                                 |
| [`dc23e694`](https://github.com/NixOS/nixpkgs/commit/dc23e69491c746083210618e7b55dd1afb010621) | `python3Packages.tensorflow: 2.7.0 -> 2.7.1 (#161589)`                  |
| [`23380df7`](https://github.com/NixOS/nixpkgs/commit/23380df7de6a417630aa181e7e5bb60fa475d45d) | `randtype: mark as broken on darwin`                                    |
| [`e0819e3c`](https://github.com/NixOS/nixpkgs/commit/e0819e3c508fea4e4c7903684ecd66ce58a31c02) | `jool: 4.1.6 -> 4.1.7`                                                  |
| [`fe73c827`](https://github.com/NixOS/nixpkgs/commit/fe73c8276aaeea3f05c6d8090bbc34a592ad77a6) | `libtracefs: 1.2.5 -> 1.3.0`                                            |
| [`0dadec45`](https://github.com/NixOS/nixpkgs/commit/0dadec45d805c31a0cff3d1ea4e0a3e9a357edfe) | `logrotate/systemd: add 'minsize = 1M' to wtmp/btmp rotation`           |
| [`f2943856`](https://github.com/NixOS/nixpkgs/commit/f29438562f9693f724e022e1fe0196ad983bdf6f) | `nextcloud-client: add xdg-utils`                                       |
| [`2bdadac1`](https://github.com/NixOS/nixpkgs/commit/2bdadac12312a5078fea298b94d5ac1d50337e2d) | `python310Packages.ibm-cloud-sdk-core: 3.14.0 -> 3.15.0`                |
| [`74b76b9e`](https://github.com/NixOS/nixpkgs/commit/74b76b9e042887aa38ebbbb4a5cd2f2d6327d380) | `python310Packages.azure-mgmt-batch: 16.0.0 -> 16.1.0`                  |
| [`4497d352`](https://github.com/NixOS/nixpkgs/commit/4497d3522e8ec59a160e2e9d0ba7853d97fe3ca9) | `dockle: 0.4.4 -> 0.4.5`                                                |
| [`8a1af228`](https://github.com/NixOS/nixpkgs/commit/8a1af22836abb4718e9e6c0598af3bf3e82a38de) | `python310Packages.google-cloud-dataproc: 3.2.0 -> 3.3.0`               |
| [`41fbd969`](https://github.com/NixOS/nixpkgs/commit/41fbd969da4a668125042781c6eb41f58f53feb1) | `python310Packages.ormar: 0.10.24 -> 0.10.25`                           |
| [`9adfe4a6`](https://github.com/NixOS/nixpkgs/commit/9adfe4a6ac8173d3e08348e96733f8dc6d096713) | `accountsservice: Fix setting profile picture in GNOME Settings`        |
| [`7614caf3`](https://github.com/NixOS/nixpkgs/commit/7614caf32979bda5133735504c819bd58f244e7b) | `accountsservice: clean up`                                             |
| [`56471498`](https://github.com/NixOS/nixpkgs/commit/56471498943c97a8bf7b81f4a5a2bfa5420c0f16) | `accountsservice: 0.6.55 → 22.07.5`                                     |
| [`0d09c4cc`](https://github.com/NixOS/nixpkgs/commit/0d09c4cc6fe9b86abb2e859a6283e572dd531ce8) | `qownnotes: 22.2.7 -> 22.2.9`                                           |
| [`b4524d8e`](https://github.com/NixOS/nixpkgs/commit/b4524d8eda7fae5fc81e83286a402a37526220eb) | `haskellPackages.haskellSrc2nix: stdenvNoCC.mkDerivation -> runCommand` |
| [`46bb6a78`](https://github.com/NixOS/nixpkgs/commit/46bb6a78dbcf293dc651b8bcb02f16e6d78b24ae) | `haskellPackages.callCabal2nix: Use stdenvNoCC`                         |
| [`257427dc`](https://github.com/NixOS/nixpkgs/commit/257427dca5b443c8ccd3ac63891fb29f5f14181d) | `espanso: set platform to linux only`                                   |
| [`0b1856bf`](https://github.com/NixOS/nixpkgs/commit/0b1856bfe3837b4509b180b4e9e51d19a88231ba) | `buildDotnetModule: enable RestoreUseStaticGraphEvaluation`             |
| [`992b656c`](https://github.com/NixOS/nixpkgs/commit/992b656c9ea6ab583123273f39f1b22a8f29e96d) | `buildDotnetModule: use setup hooks`                                    |
| [`c27afb62`](https://github.com/NixOS/nixpkgs/commit/c27afb62d45d1c12053404c24fdf579935b7ca1e) | `zrythm: 1.0.0-alpha.26.0.13 -> 1.0.0-alpha.28.1.3`                     |