### PR TITLE
chore(flake/home-manager): `2499b916` -> `ea85f4b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1645924784,
-        "narHash": "sha256-mpwIohyuc3RAHmVXEm/vUHGMu2V9SLr4P3kh0xckwpI=",
+        "lastModified": 1645970334,
+        "narHash": "sha256-6nn4YF9bPtkxkB7bM6yJO3m//p3sGilxNQFjm1epLEM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2499b916921adde8a694117bc007efdde8bbd918",
+        "rev": "ea85f4b1fdf3f25cf97dc49f4a9ec4eafda2ea25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`ea85f4b1`](https://github.com/nix-community/home-manager/commit/ea85f4b1fdf3f25cf97dc49f4a9ec4eafda2ea25) | `launchd: fix multiple agents` |