### PR TITLE
chore(flake/nixpkgs): `6896623f` -> `9783ef30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1645958901,
-        "narHash": "sha256-vcPuKbeJemK+a7Oce4fSMsGt9n99Ogwv/At0Oy/aW6E=",
+        "lastModified": 1646007876,
+        "narHash": "sha256-3vO/3q7LfCZAx3gNUC02b9my8Nxhr2Nr7+ZgqWGmJu0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6896623f630ce8703e2201625eabd9f01dfcc5e0",
+        "rev": "9783ef308da620a48a9849d977dd1dfdf7f9ba45",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`0a800749`](https://github.com/NixOS/nixpkgs/commit/0a8007498f9dba0d5feb191d16317ffa85a9e698) | `bash: use default PATH in FHS environments`                                   |
| [`a1df6e1b`](https://github.com/NixOS/nixpkgs/commit/a1df6e1ba3e0a26fcc7923d3555ea97d698e36dd) | `python310Packages.pyamg: 4.2.1 -> 4.2.2`                                      |
| [`820d3be4`](https://github.com/NixOS/nixpkgs/commit/820d3be48821a91469aa25536c3596de48ab7d6d) | `k3s: add superherointj to maintainers`                                        |
| [`f79572f9`](https://github.com/NixOS/nixpkgs/commit/f79572f92ff4fa7024aad4c50494318fdb331fe4) | `k3s: update script fixed`                                                     |
| [`56828530`](https://github.com/NixOS/nixpkgs/commit/56828530275888e4d79ee64f8ff772bdbfe34637) | `nixos/release: disable nfs3.simple`                                           |
| [`fa52a102`](https://github.com/NixOS/nixpkgs/commit/fa52a102be121ea203f4fb4a1fcb403426c0fee5) | `linuxPackages: use 5_10 kernel on i686`                                       |
| [`836c6353`](https://github.com/NixOS/nixpkgs/commit/836c6353cc33fd43e3c956040e77d050a4e6e727) | `linux_5_15: mark as broken on i686`                                           |
| [`177281ad`](https://github.com/NixOS/nixpkgs/commit/177281ad00b6e5f1b3ba9acced399e2bc7d37340) | `nixos/amazon-image: use 5_10 kernel and add assert`                           |
| [`881a1092`](https://github.com/NixOS/nixpkgs/commit/881a10922712ae4dbb784d5240728222ea176bf3) | `Revert "Revert "linuxPackages: bump default 5.10 -> 5.15""`                   |
| [`a0abe63e`](https://github.com/NixOS/nixpkgs/commit/a0abe63e440a320323251895d2f6de61e0893d57) | `python310Packages.aiogithubapi: 22.2.3 -> 22.2.4`                             |
| [`f006f108`](https://github.com/NixOS/nixpkgs/commit/f006f108ab66d49d4755819213be80bd2f9c0d3b) | `python310Packages.APScheduler: 3.8.1 -> 3.9.0.post1`                          |
| [`1300b351`](https://github.com/NixOS/nixpkgs/commit/1300b351a73d9a4792bf7eae9bf8048e46abcd24) | `vscode-extensions.redhat.java: 1.2.0 -> 1.3.0`                                |
| [`0e734b2f`](https://github.com/NixOS/nixpkgs/commit/0e734b2fe223b3e9dd3cad878ed41738fb6017a3) | `python310Packages.django-dynamic-preferences: 1.11.0 -> 1.12.0`               |
| [`d91c40a3`](https://github.com/NixOS/nixpkgs/commit/d91c40a3cd423124518a6f7c4a3b7d7b192cf5f8) | `vscode-extensions.llvm-vs-code-extensions.vscode-clangd: 0.1.13 -> 0.1.15`    |
| [`11189a2c`](https://github.com/NixOS/nixpkgs/commit/11189a2cd4224efa55f1402630dba47908178311) | `vimPlugins.vim-CtrlXA: init at 2021-08-09`                                    |
| [`507ab175`](https://github.com/NixOS/nixpkgs/commit/507ab175316c6b1d4510b696182b1af6148aa7ca) | `python3Packages.celery: add nixosTests.sourcehut as passthru test`            |
| [`899f4107`](https://github.com/NixOS/nixpkgs/commit/899f4107a4ceff0a32b71c648a74970837d0e6ad) | `python3Packages.weconnect-mqtt: 0.29.1 -> 0.30.0`                             |
| [`74cb03c8`](https://github.com/NixOS/nixpkgs/commit/74cb03c8efd046bde52a915e0403a65b89aea727) | `python3Packages.weconnect: 0.36.4 -> 0.37.0`                                  |
| [`323837f7`](https://github.com/NixOS/nixpkgs/commit/323837f7db75d84672a9d5a2368905b132ef91cf) | `llvmPackages_14: 2022-01-07 -> 14.0.0-rc1`                                    |
| [`0685f53c`](https://github.com/NixOS/nixpkgs/commit/0685f53c66ec580e560cbc04f468bbb3f6d7d5a1) | `python310Packages.hg-evolve: 10.4.1 -> 10.5.0`                                |
| [`27e7b4d9`](https://github.com/NixOS/nixpkgs/commit/27e7b4d9c754e6595e3c5033b691cadd40b999bf) | `steam: add dotnet support`                                                    |
| [`b3bb79b6`](https://github.com/NixOS/nixpkgs/commit/b3bb79b6b1747755846a3c974b6ca0e865bb05ff) | `aquosctl: init at unstable-2014-04-06`                                        |
| [`b2ffb9fc`](https://github.com/NixOS/nixpkgs/commit/b2ffb9fc96c3b2c1f16112a750da03c82b789760) | `qgis-ltr: add willcohen to maintainers`                                       |
| [`e18d2801`](https://github.com/NixOS/nixpkgs/commit/e18d2801ad5b50bc82e4a42dd083d9795d75966a) | `qgis: add willcohen to maintainers`                                           |
| [`9f27578b`](https://github.com/NixOS/nixpkgs/commit/9f27578b401813f9355ca3c789e10df872541d7d) | `qgis-ltr: 3.16.16 -> 3.22.4`                                                  |
| [`2448f4dd`](https://github.com/NixOS/nixpkgs/commit/2448f4dd455119cfd272bc6618cbd2db38a86bc7) | `qgis: 3.22.3 -> 3.24.0`                                                       |
| [`22ce0cf3`](https://github.com/NixOS/nixpkgs/commit/22ce0cf3649ca70d026c227d4116ba48d75a894c) | `texworks: 0.6.6 -> 0.6.7`                                                     |
| [`339463b0`](https://github.com/NixOS/nixpkgs/commit/339463b00d7b42c2bd09086386edb4cfd06beb4c) | `python310Packages.python-izone: 1.2.4 -> 1.2.7`                               |
| [`169ba823`](https://github.com/NixOS/nixpkgs/commit/169ba823d9379e6adec8ff703adb43be5b4e4659) | `cmark-gfm: fix includes`                                                      |
| [`ea7ff89d`](https://github.com/NixOS/nixpkgs/commit/ea7ff89d2cc3790ba087a17d14d807bd04881f8a) | `archivy: 1.6.1 -> 1.7.1`                                                      |
| [`cd1c866d`](https://github.com/NixOS/nixpkgs/commit/cd1c866d87f943c266a315c2cb0bd34a5acd12dd) | `readability-lxml: init at 0.8.1`                                              |
| [`a9defb71`](https://github.com/NixOS/nixpkgs/commit/a9defb71ed07cc53cc47b9a9da8cf0767b437014) | `python39Packages.fontparts: 0.10.2 -> 0.10.3`                                 |
| [`45cd41de`](https://github.com/NixOS/nixpkgs/commit/45cd41de23593be4ab1da45546b883ef14f3e596) | `llvmPackages_{git,14}: Replace tabs in lld/default.nix`                       |
| [`fbb2eb81`](https://github.com/NixOS/nixpkgs/commit/fbb2eb81f87e113a10c11050b90f25c875f665ea) | `texlab: 3.3.1 -> 3.3.2`                                                       |
| [`c06351b0`](https://github.com/NixOS/nixpkgs/commit/c06351b06e94305f152b53aaa1eb9eb52cdfbda3) | `opentabletdriver: v0.6.0.2 -> v0.6.0.3`                                       |
| [`d61e45b6`](https://github.com/NixOS/nixpkgs/commit/d61e45b686bba959ae361425a47a881a43a56fad) | `llvmPackages_14: init at 2022-01-07`                                          |
| [`e2ba45f5`](https://github.com/NixOS/nixpkgs/commit/e2ba45f5abc7332b07d57d9cb17ea9da3b3a8887) | `llvmPackages_14: Copy the files from llvmPackages_git`                        |
| [`faae760e`](https://github.com/NixOS/nixpkgs/commit/faae760e98c9a17d9604d2b66b8a15a13071f94e) | `llvmPackages_git.llvm: Drop llvm-config-link-static.patch (#162101)`          |
| [`c596cb7c`](https://github.com/NixOS/nixpkgs/commit/c596cb7cb25a60a94f7dc21601497c7fb7fb5f7c) | `omnisharp-roslyn: support Darwin`                                             |
| [`e1214d5d`](https://github.com/NixOS/nixpkgs/commit/e1214d5d8a959d78b0607d54d9b165b27f68bd54) | `python310Packages.samsungtvws: 1.7.0 -> 2.0.0`                                |
| [`f04b4d06`](https://github.com/NixOS/nixpkgs/commit/f04b4d064033a7adfb4d1c1838192e63c6239165) | `calibre: 5.34.0 -> 5.37.0`                                                    |
| [`98b8385e`](https://github.com/NixOS/nixpkgs/commit/98b8385e20ee82adce7d2b7d72374efa44226665) | `oven-media-engine: 0.13.0 -> 0.13.1`                                          |
| [`19185e8c`](https://github.com/NixOS/nixpkgs/commit/19185e8ca9f2176242bd7910cbd35e6e7fdd545c) | `du-dust: 0.7.5 -> 0.8.0`                                                      |
| [`64ba26f7`](https://github.com/NixOS/nixpkgs/commit/64ba26f745354ace38e955ca0554b0825c901ce3) | `purescript: 0.14.6 -> 0.14.7`                                                 |
| [`8e97a58b`](https://github.com/NixOS/nixpkgs/commit/8e97a58b5665f9f4eabe7602ac06de16b031a41a) | `okapi: 1.3.0 -> 1.4.0`                                                        |
| [`9a07db13`](https://github.com/NixOS/nixpkgs/commit/9a07db13ca03d93362edb6e6a7ab22813f6f6ba8) | `nfpm: 2.13.0 -> 2.14.0`                                                       |
| [`5668e630`](https://github.com/NixOS/nixpkgs/commit/5668e6309f97e4a35e60bbb21f5d442ac92cb588) | `python310Packages.rpyc: 5.0.1 -> 5.1.0`                                       |
| [`bd61b913`](https://github.com/NixOS/nixpkgs/commit/bd61b9139fac3cd637a91a00b80ec79aeec228a7) | `mob: 2.3.0 -> 2.5.0`                                                          |
| [`0f43432b`](https://github.com/NixOS/nixpkgs/commit/0f43432b55212b0abf58095b18c000e15d1608e0) | `php74Extensions.mongodb: 1.12.0 -> 1.12.1`                                    |
| [`aa23e9cd`](https://github.com/NixOS/nixpkgs/commit/aa23e9cdb4fbe367a7aceee96a00d5865fafeb50) | `minio-client: 2022-02-23T03-15-59Z -> 2022-02-26T03-58-31Z`                   |
| [`9f064b9d`](https://github.com/NixOS/nixpkgs/commit/9f064b9d541652f8b92fa70b786525b0eacac9d5) | `lfs: 2.1.1 -> 2.2.0`                                                          |
| [`78ec9971`](https://github.com/NixOS/nixpkgs/commit/78ec9971a49bc005082d8cb100b484f1d096b42b) | `bat: 0.19.0 -> 0.20.0`                                                        |
| [`867bbad5`](https://github.com/NixOS/nixpkgs/commit/867bbad5c295ec1959bb15e6ffa87b4875f840dd) | `gdown: 4.3.1 -> 4.4.0`                                                        |
| [`6e1e1ddf`](https://github.com/NixOS/nixpkgs/commit/6e1e1ddf070a703c51f77ffa7aa176c339dc055a) | `python3Packages.ipython: disable clipboard test on darwin (targeting master)` |
| [`9d3a2508`](https://github.com/NixOS/nixpkgs/commit/9d3a2508162e770ee90c5fbf17d743ce50986831) | `bazarr: 1.0.2 -> 1.0.3`                                                       |
| [`06e5302e`](https://github.com/NixOS/nixpkgs/commit/06e5302eb5ede88379355afc88d12305f8890d8d) | `apktool: 2.6.0 -> 2.6.1`                                                      |
| [`6fa9f8b5`](https://github.com/NixOS/nixpkgs/commit/6fa9f8b56410b8dc9e3d22b102fd256264a4f94f) | `plexamp: 4.0.2 -> 4.0.3`                                                      |
| [`e517d280`](https://github.com/NixOS/nixpkgs/commit/e517d280c01521b15795c9b493fc1e7c911fd3bd) | `libtraceevent: 1.5.0 -> 1.5.1`                                                |
| [`d4096ffd`](https://github.com/NixOS/nixpkgs/commit/d4096ffd0a36e5600906cad6deca864a0c9b01db) | `mpd-discord-rpc: 1.4.0 -> 1.4.1`                                              |
| [`0b77e65f`](https://github.com/NixOS/nixpkgs/commit/0b77e65fa61c5b20b973b42952f0051f8cacdf43) | `html-xml-utils: 8.2 -> 8.3`                                                   |
| [`01e0cb64`](https://github.com/NixOS/nixpkgs/commit/01e0cb64c9ab3369e667d5a37f113551e3a7e9c7) | `htslib: 1.14 -> 1.15`                                                         |
| [`8dd0738b`](https://github.com/NixOS/nixpkgs/commit/8dd0738b7cb5bb7a298c24d2185d2825da465167) | `cargo-udeps: 0.1.26 -> 0.1.27`                                                |
| [`330d9344`](https://github.com/NixOS/nixpkgs/commit/330d9344d2880aacca1f5bd330d46f6c014d9cb0) | `sage: make it possible not to rebuild sage-tests`                             |
| [`7442533b`](https://github.com/NixOS/nixpkgs/commit/7442533bf1bda4d21ff8abeec6b4d6f0f2deffa5) | `sage: support adding extra Python packages to environment`                    |
| [`126605f9`](https://github.com/NixOS/nixpkgs/commit/126605f9192e32462aacb8f5ea0608a223bb309e) | `minio: 2022-02-18T01-50-10Z -> 2022-02-24T22-12-01Z`                          |
| [`19492c48`](https://github.com/NixOS/nixpkgs/commit/19492c486d650be80b7646d59c22e77033000857) | `cilium-cli: 0.10.3 -> 0.10.4`                                                 |
| [`fd61918d`](https://github.com/NixOS/nixpkgs/commit/fd61918dfdd9c16d17f4905587537ce9d743f747) | `monit: 5.30.0 -> 5.31.0`                                                      |
| [`2daa686c`](https://github.com/NixOS/nixpkgs/commit/2daa686c8c36f8b269554314e382d2fe7697e0c2) | `natural-docs: 2.1.1 -> 2.2`                                                   |
| [`a13cdfe5`](https://github.com/NixOS/nixpkgs/commit/a13cdfe520d87db401dd000fbd67cad728162a60) | `ocamlPackages tree-wide: Move buildInputs that should be nativeBuildInputs`   |
| [`20648fc2`](https://github.com/NixOS/nixpkgs/commit/20648fc2cc7bcf0512f422bb6b481ed9941b4a18) | `icoutils: fix build on aarch64-darwin`                                        |
| [`5e94787f`](https://github.com/NixOS/nixpkgs/commit/5e94787f63e8fb4aa8e0101494781860ac0a391f) | `catgirl: 2.0a -> 2.1`                                                         |
| [`599b22c2`](https://github.com/NixOS/nixpkgs/commit/599b22c26faff1108cbb8b388d768bc266ea3b27) | `pim6sd: mark as broken on darwin`                                             |
| [`13e35662`](https://github.com/NixOS/nixpkgs/commit/13e35662ccfc4b516dca5e2802cb57ec6a08c57a) | `add a defaultText`                                                            |
| [`3dea07f9`](https://github.com/NixOS/nixpkgs/commit/3dea07f9a6cdc1cdac518eede1d753ba1235c7c5) | `scrcpy: install shell completions`                                            |
| [`7974b85c`](https://github.com/NixOS/nixpkgs/commit/7974b85c836d47459786b4b532ab439c02fa5aca) | `scrcpy: make libusb1 an unconditional dependency`                             |
| [`368480a9`](https://github.com/NixOS/nixpkgs/commit/368480a95b0d7c0187cbd6698481c38a0b7286ae) | `scrcpy: 1.22 -> 1.23`                                                         |
| [`6157673d`](https://github.com/NixOS/nixpkgs/commit/6157673df02f0a0d5809e40241fe71be9effbea7) | `hopefully IFD was the problem`                                                |
| [`b5ec72fc`](https://github.com/NixOS/nixpkgs/commit/b5ec72fc13d94ad709bd013eeeaba54b258de18f) | `tweaks`                                                                       |
| [`005769ee`](https://github.com/NixOS/nixpkgs/commit/005769ee13b16110ffd593bb727053a2f135b976) | `whitespace`                                                                   |
| [`74dcaf57`](https://github.com/NixOS/nixpkgs/commit/74dcaf578442bfafba924e5494bef2dc830d0991) | `zammad: test passes!`                                                         |
| [`00e74ad9`](https://github.com/NixOS/nixpkgs/commit/00e74ad907f9e9c57be90bf3983d2f7ea7442b56) | `minor changes`                                                                |
| [`4d38b646`](https://github.com/NixOS/nixpkgs/commit/4d38b6460f564bd69586fe5c1bdead99310f31cd) | `zammad: reformat`                                                             |
| [`75fe105a`](https://github.com/NixOS/nixpkgs/commit/75fe105a3d080bc91db9f79d80c56d24e6631592) | `Zammad: more fixes`                                                           |
| [`aac7f854`](https://github.com/NixOS/nixpkgs/commit/aac7f85483b7ab70adf62f6217bedb5a0b41d9d0) | `zammad: fix module databases`                                                 |
| [`e1009112`](https://github.com/NixOS/nixpkgs/commit/e1009112b609e0a59fa6e66c87e35e640a10fde5) | `minor tweaks`                                                                 |
| [`34e0a1a1`](https://github.com/NixOS/nixpkgs/commit/34e0a1a1f13a2d81ffb9a9030dd25f67c3d60006) | `fix zammad service`                                                           |
| [`94cc607f`](https://github.com/NixOS/nixpkgs/commit/94cc607fa6958cdcfe3789ebe49588687f8a15b0) | `applyPatches args`                                                            |
| [`e7aba931`](https://github.com/NixOS/nixpkgs/commit/e7aba931e2c5f1e716f80f9c7911c0712e26ec28) | `zammad: fix module/test`                                                      |
| [`c270d3d5`](https://github.com/NixOS/nixpkgs/commit/c270d3d52705b76ff0dc5e6c6453e4c07f70a30d) | `zammad: patch ruby 2.7 version`                                               |
| [`e662b519`](https://github.com/NixOS/nixpkgs/commit/e662b519a260b2085d58478e34afbcc4ecb2e40d) | `zammad: add module test`                                                      |
| [`9bc86d94`](https://github.com/NixOS/nixpkgs/commit/9bc86d946b4447e9c138ff80e786ec1c50ca78b7) | `zammad: init module`                                                          |
| [`7cf49c38`](https://github.com/NixOS/nixpkgs/commit/7cf49c38a5943571ce523700bd896f0fdadc8224) | `zammad: init at 5.0.2`                                                        |
| [`7a363690`](https://github.com/NixOS/nixpkgs/commit/7a36369036c44fd6bb5a6f57a6ccf75cea43dfec) | `maintainers: add n0emis`                                                      |
| [`bd9781ee`](https://github.com/NixOS/nixpkgs/commit/bd9781eed56eee7baa40d8ecc55a84b9a623d1dd) | `scorecard: 4.0.1 -> 4.1.0`                                                    |
| [`e458303d`](https://github.com/NixOS/nixpkgs/commit/e458303d2f1810634ad2483acd624562ff8ed550) | `punes: 0.108 -> 0.109`                                                        |
| [`93e8885f`](https://github.com/NixOS/nixpkgs/commit/93e8885f2acb1bdc84d950a1601e4da1a5a62ed9) | `rednotebook: 2.23 -> 2.24`                                                    |
| [`3375bca8`](https://github.com/NixOS/nixpkgs/commit/3375bca83021cca5ee61742f0be2c7b46e6a7930) | `pgbadger: mark as broken on darwin`                                           |
| [`8c7d82a0`](https://github.com/NixOS/nixpkgs/commit/8c7d82a08fa42f4ab8901b885cd7931859e45e9d) | `brook: 20210701 -> 20220401`                                                  |
| [`377cfd90`](https://github.com/NixOS/nixpkgs/commit/377cfd903bda6ed175f8e0189388c81889bed8bd) | `pam_p11: fix on darwin`                                                       |
| [`2809b540`](https://github.com/NixOS/nixpkgs/commit/2809b54022aa7336ae2dc3b4b0277db22feb5ddd) | `scalafmt: 3.4.0 -> 3.4.3`                                                     |
| [`79f727ad`](https://github.com/NixOS/nixpkgs/commit/79f727ad47270cd9d7d976c9e39c9b0e895cd083) | `gsctl: 0.15.4 -> 1.1.4`                                                       |
| [`f9416351`](https://github.com/NixOS/nixpkgs/commit/f94163514ff4210a6ce9c175000ccaf74a6a9adb) | `synapse-admin: 0.8.4 -> 0.8.5`                                                |
| [`b550b4b6`](https://github.com/NixOS/nixpkgs/commit/b550b4b6f8413c086a1ec4235e174cda82538e73) | `nixos/nix-daemon: Ensure continued availability of daemon socket`             |
| [`49edd414`](https://github.com/NixOS/nixpkgs/commit/49edd414ef915936a70ce906180372b96cf5a04f) | `lgogdownloader: 3.8 -> 3.9`                                                   |
| [`ca930183`](https://github.com/NixOS/nixpkgs/commit/ca9301834ae72869474ff26199521334685197a1) | `minio-certgen: 0.0.2 -> 1.0.1`                                                |
| [`da1f31a6`](https://github.com/NixOS/nixpkgs/commit/da1f31a62ef82b4a3edf8a7f7bdf2d42e4ffab15) | `redhat-official-fonts: 2.3.2 -> 4.0.2`                                        |
| [`4badff49`](https://github.com/NixOS/nixpkgs/commit/4badff49fda90fba01684d2f19c31442688252b4) | `llvmPackages_git.*: Bump to newer commit`                                     |