### PR TITLE
chore(flake/nixpkgs): `9783ef30` -> `21968db3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1646007876,
-        "narHash": "sha256-3vO/3q7LfCZAx3gNUC02b9my8Nxhr2Nr7+ZgqWGmJu0=",
+        "lastModified": 1646051047,
+        "narHash": "sha256-XDJGACWVeNs3OAECpx20zegX/YDigHOUZ1nVmCJUeEM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9783ef308da620a48a9849d977dd1dfdf7f9ba45",
+        "rev": "21968db378c9144f418c1e8e7002316aa8b75776",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`ab34433b`](https://github.com/NixOS/nixpkgs/commit/ab34433bc0dcdf9b3cfbc8bb187030920b4c0e7b) | `emojipick: init at 2021-01-27 (#158187)`                                            |
| [`53e70ab7`](https://github.com/NixOS/nixpkgs/commit/53e70ab75490df87a165d704a9e98312b3f5137b) | `maintainers/teams: add minijackson to the beam team`                                |
| [`6a96ddb6`](https://github.com/NixOS/nixpkgs/commit/6a96ddb67509064c2d445b3fae73d4c4c38c539d) | `pkgs-lib: Implement settings format for Elixir`                                     |
| [`3bce8227`](https://github.com/NixOS/nixpkgs/commit/3bce8227a0019104590dfab07d527f7493a9e1f6) | `llvmPackages_14.lld: Update fix-root-src-dir.patch to fix the build`                |
| [`1bdf7862`](https://github.com/NixOS/nixpkgs/commit/1bdf7862e3f8007cdb21bbbde1d496064f869bb3) | `chromiumBeta: Fix the build`                                                        |
| [`c0952b64`](https://github.com/NixOS/nixpkgs/commit/c0952b6478194c01081d338b46402803cbfd14a6) | `chromium{Beta,Dev}: Switch to LLVM 14`                                              |
| [`0d39e18c`](https://github.com/NixOS/nixpkgs/commit/0d39e18c48e9cd709566400774f574dd12d2684c) | `maestral-gui: 1.5.2 -> 1.5.3`                                                       |
| [`1e6f7736`](https://github.com/NixOS/nixpkgs/commit/1e6f7736a2f6f0c30bcc51f4f14bcd4147c26292) | `python3Packages.maestral: 1.5.2 -> 1.5.3`                                           |
| [`39db09d8`](https://github.com/NixOS/nixpkgs/commit/39db09d87bc478ca14cdce86bbfaf6977bb88309) | `python39Packages.bandit: 1.7.2 -> 1.7.3`                                            |
| [`807cf78f`](https://github.com/NixOS/nixpkgs/commit/807cf78f4bbf2aeb72753be46d40b99f4f69878d) | `yq-go: 4.20.2 -> 4.21.1`                                                            |
| [`b8b1c733`](https://github.com/NixOS/nixpkgs/commit/b8b1c733b2397dc3b45333a1c9c2929d69ed6f9f) | `okteta: 0.26.6 -> 0.26.7`                                                           |
| [`de4352ba`](https://github.com/NixOS/nixpkgs/commit/de4352babbbba55e6617a10d9c42a77ec710c31c) | `{lib,}ktorrent: move to pkgs/application/kde`                                       |
| [`a7f2e16a`](https://github.com/NixOS/nixpkgs/commit/a7f2e16a4f9e0cf153866f4a431bc04a108c840a) | `gitlab: 14.7.4 -> 14.8.2 (#162088)`                                                 |
| [`f49a6fea`](https://github.com/NixOS/nixpkgs/commit/f49a6fea32978a555ef15734d729b1cbb8c43413) | `metasploit: 6.1.30 -> 6.1.31`                                                       |
| [`6c39270a`](https://github.com/NixOS/nixpkgs/commit/6c39270a3ab1fc828585c28e5931fca093669b11) | `checkov: 2.0.900 -> 2.0.906`                                                        |
| [`434bdc8e`](https://github.com/NixOS/nixpkgs/commit/434bdc8e4a13f500f35241839ae82e0d8acbff3d) | `skanlite: move to pkgs/application/kde`                                             |
| [`c57495ca`](https://github.com/NixOS/nixpkgs/commit/c57495ca2723eb7802245a51a408f583405c1060) | `vscode-extensions.takayama.vscode-qq: update 1.4.0 -> 1.4.2`                        |
| [`0432d5f1`](https://github.com/NixOS/nixpkgs/commit/0432d5f1dad88c0510386c60c3b9e3ad43f34081) | `jwm: 2.4.0 -> 2.4.1`                                                                |
| [`60840fc6`](https://github.com/NixOS/nixpkgs/commit/60840fc63f3bafa5605c9e5138c2997dfb32d937) | `grype: 0.33.0 -> 0.33.1`                                                            |
| [`8a9421f0`](https://github.com/NixOS/nixpkgs/commit/8a9421f0285d99b1f3cf19eb449a262c8cadf017) | `crystal: add support for passing custom build options when using the shard builder` |
| [`6db4dc07`](https://github.com/NixOS/nixpkgs/commit/6db4dc07c61bfa8670583d586a6477ef070ea717) | `remind: 03.04.00 -> 03.04.01`                                                       |
| [`4884066c`](https://github.com/NixOS/nixpkgs/commit/4884066cf4e32e893414bfbf7173b4e3bbca1e52) | `godns: 2.6 -> 2.7`                                                                  |
| [`e769e730`](https://github.com/NixOS/nixpkgs/commit/e769e73003858b1974aeb79a0317171d4ad100df) | `python310Packages.fastapi: 0.74.0 -> 0.74.1`                                        |
| [`d4de0d56`](https://github.com/NixOS/nixpkgs/commit/d4de0d56282716fcd54a077e80aaa41c567f83b4) | `python310Packages.pyisy: 3.0.2 -> 3.0.3`                                            |
| [`51bbbb19`](https://github.com/NixOS/nixpkgs/commit/51bbbb19ed244d766c0079cfd11b7435f750ad9f) | `python310Packages.slixmpp: 1.7.1 -> 1.8.0.1`                                        |
| [`102c02f4`](https://github.com/NixOS/nixpkgs/commit/102c02f432c5ec2529da3a3c4a65b5074daafc02) | `terraform-providers: update 2022-02-28`                                             |
| [`efa6365c`](https://github.com/NixOS/nixpkgs/commit/efa6365cf6254db27d88eeb2140365c19430cb32) | `python310Packages.spacy-legacy: 3.0.8 -> 3.0.9`                                     |
| [`50e0e124`](https://github.com/NixOS/nixpkgs/commit/50e0e1248290466943b040ea300178ac02497313) | `python310Packages.trimesh: 3.10.1 -> 3.10.2`                                        |
| [`142326c2`](https://github.com/NixOS/nixpkgs/commit/142326c28aa4839dcf029d8bc38befb6e182efbf) | `python310Packages.py3status: 3.40 -> 3.41`                                          |
| [`ee62ae9a`](https://github.com/NixOS/nixpkgs/commit/ee62ae9a6993113581443d0a2eba0ec63f014fa8) | `python310Packages.plexapi: 4.9.2 -> 4.10.0`                                         |
| [`c3dbdb1d`](https://github.com/NixOS/nixpkgs/commit/c3dbdb1d1076830c2244d65180e2d33f841d7ebe) | `python310Packages.pyoverkiz: 1.3.8 -> 1.3.9`                                        |
| [`cc871935`](https://github.com/NixOS/nixpkgs/commit/cc87193562dcb336c986a83f9ba89fca87e76186) | `python310Packages.python-hosts: 1.0.2 -> 1.0.3`                                     |
| [`bbba21ba`](https://github.com/NixOS/nixpkgs/commit/bbba21baaa6f42fe1bd0284cc418cbddadcf379d) | `python310Packages.willow: 1.4 -> 1.4.1`                                             |
| [`f8c560e2`](https://github.com/NixOS/nixpkgs/commit/f8c560e285a175a7a1c571968974d314397bc2bd) | `netdata: fix protobuf support`                                                      |
| [`66691701`](https://github.com/NixOS/nixpkgs/commit/66691701dff52dd85048910e552ae43b8dad7048) | `jetbrains: update (#161186)`                                                        |
| [`158bf609`](https://github.com/NixOS/nixpkgs/commit/158bf609c53ba114d8828dd402813699bc53188f) | `checkip: 0.18.0 -> 0.18.1`                                                          |
| [`1639ba3e`](https://github.com/NixOS/nixpkgs/commit/1639ba3e819abcae801647e89f72c37949261822) | `certipy: 2.0.7 -> 2.0.9`                                                            |
| [`9363ec25`](https://github.com/NixOS/nixpkgs/commit/9363ec256daa0e2b1e51ff124c27e96156d9837c) | `pdf2odt: use resholvePackage`                                                       |
| [`11870cb2`](https://github.com/NixOS/nixpkgs/commit/11870cb2b0880659dfb9faaad6a13503447302c7) | `ccache: 4.5.1 -> 4.6`                                                               |
| [`f73cd879`](https://github.com/NixOS/nixpkgs/commit/f73cd879137938f275513b194d8fdfe14afff499) | `maintainers: remove meutraa`                                                        |
| [`f0f954ab`](https://github.com/NixOS/nixpkgs/commit/f0f954ab65a76c76668dfd1fa754edd2b2591b92) | `melpa-generated: updated at 2022-02-27`                                             |
| [`6bd94480`](https://github.com/NixOS/nixpkgs/commit/6bd9448062fcb75c55c0fa7adf93d3562aa01734) | `python39Packages.oslo-db: 11.1.0 -> 11.2.0`                                         |
| [`679c50b9`](https://github.com/NixOS/nixpkgs/commit/679c50b9f042bff5c9131b369692f3a95ceb9278) | `nongnu-generated: updated at 2022-02-27`                                            |
| [`abb2cd33`](https://github.com/NixOS/nixpkgs/commit/abb2cd336d25bc769dcd55e4fda5a816fbd62e0f) | `elpa-generated: updated at 2022-02-27`                                              |
| [`8022c82a`](https://github.com/NixOS/nixpkgs/commit/8022c82a39c19bd1fe000884703601532204b82f) | `nixosTests.switchTest: fix race condition on /testpath`                             |
| [`4d12b79c`](https://github.com/NixOS/nixpkgs/commit/4d12b79cd7edfbe01216171dd6ef0e4c64851b0a) | `logrotate: do not enable logrotate.service itself`                                  |
| [`c3010a99`](https://github.com/NixOS/nixpkgs/commit/c3010a9971571a3cf53994e62443df3b1c69d1b3) | `tdesktop: 3.4.8 -> 3.5.2`                                                           |
| [`cdfd5b47`](https://github.com/NixOS/nixpkgs/commit/cdfd5b47fc8cf838dd0941f05b549b4992ede451) | `php.packages.phing: init at 2.17.1`                                                 |
| [`00725d5d`](https://github.com/NixOS/nixpkgs/commit/00725d5dd622da37a39e6d4890e8302c45f478f9) | `irods: 4.2.7 -> 4.2.11`                                                             |
| [`8142ba3e`](https://github.com/NixOS/nixpkgs/commit/8142ba3e889e063726a0bd897cdecd40cb4a8b1e) | `mercurial.withExtensions: deprecate phases`                                         |
| [`b549e7bb`](https://github.com/NixOS/nixpkgs/commit/b549e7bbb5fa55cacf97b9aa405f73c030cf712b) | `genJqSecretsReplacementSnippet: Fix error handling`                                 |
| [`762faa21`](https://github.com/NixOS/nixpkgs/commit/762faa21a2f98ecfaa4bce76a0e167311ccd4ce8) | `tlaps: 1.4.3 -> 1.4.5`                                                              |
| [`97e4ab5e`](https://github.com/NixOS/nixpkgs/commit/97e4ab5ee8575d8bb2f3d3ec6e1daf1473b61a4b) | `nerd-font-patcher: use upstream repo with sparseCheckout`                           |
| [`5a853021`](https://github.com/NixOS/nixpkgs/commit/5a85302190a2894e51e7447d9924622b1b00479e) | `qtspim: 9.1.22 -> 9.1.23`                                                           |
| [`a08b85f4`](https://github.com/NixOS/nixpkgs/commit/a08b85f477ed3351025b1b57213297271b9eda47) | `samurai: apply upstream CVE fixes (security)`                                       |