### PR TITLE
chore(flake/impermanence): `635bcd2d` -> `2f39baeb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -105,11 +105,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1644791231,
-        "narHash": "sha256-iDihsF1fUMK4xXiUudPnDM3veH1LXbbxfP9Lzekw9iU=",
+        "lastModified": 1646131459,
+        "narHash": "sha256-GPmgxvUFvQ1GmsGfWHy9+rcxWrczeDhS9XnAIPHi9XQ=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "635bcd2d88739197a0b584aa9fadaa53c717a853",
+        "rev": "2f39baeb7d039fda5fc8225111bb79474138e6f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`95f9089e`](https://github.com/nix-community/impermanence/commit/95f9089e869d2f047b60c75f74f643df46257e77) | `nixos: Minimize the amount of text added to the activation script`    |
| [`e8a4cefe`](https://github.com/nix-community/impermanence/commit/e8a4cefe13d803d11b1e6f1187257bed61be9f7b) | `nixos: Add an internal debugging option to aid script debugging`      |
| [`6ee09b4a`](https://github.com/nix-community/impermanence/commit/6ee09b4a7115db5be468504047ad81e4f07d09c6) | `create-directories: Set noglob and inherit_errexit, document options` |