### PR TITLE
chore(flake/pre-commit-hooks): `6799201b` -> `b6bc0b21`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1645781104,
-        "narHash": "sha256-d5iDimTPC4r1hKFHAguCnkY9gPbieAIkApLUuYA+Xb4=",
+        "lastModified": 1646153636,
+        "narHash": "sha256-AlWHMzK+xJ1mG267FdT8dCq/HvLCA6jwmx2ZUy5O8tY=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "6799201bec19b753a4ac305a53d34371e497941e",
+        "rev": "b6bc0b21e1617e2b07d8205e7fae7224036dfa4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`de7d26b3`](https://github.com/cachix/pre-commit-hooks.nix/commit/de7d26b318f77f2dd3a292ac36949511346ba5fd) | ``feat: Add `alejandra``` |