### PR TITLE
chore(flake/nixpkgs): `21968db3` -> `e6e5c034`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1646051047,
-        "narHash": "sha256-XDJGACWVeNs3OAECpx20zegX/YDigHOUZ1nVmCJUeEM=",
+        "lastModified": 1646414049,
+        "narHash": "sha256-sSmRFE9yVn8W2BQPkJww6tJt9wE9WY3o/mhXBXCp788=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21968db378c9144f418c1e8e7002316aa8b75776",
+        "rev": "e6e5c03449dcf0349a719b68e0aa6378a1c07e87",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`086e8066`](https://github.com/NixOS/nixpkgs/commit/086e8066f5b403515b9253492f0770c2148df7ea) | `pythia: 8.306 -> 8.307`                                                       |
| [`da882cdd`](https://github.com/NixOS/nixpkgs/commit/da882cddccc10149c4bdbff5fbb0e1f5fc926f79) | `arrow-cpp: libnsl is not necessary for building (#162757)`                    |
| [`ccb18516`](https://github.com/NixOS/nixpkgs/commit/ccb1851610cb0d0ffc463fc6ebf0c6591f957f4c) | `signal-desktop: Add xdg-utils/bin to PATH`                                    |
| [`e556e61a`](https://github.com/NixOS/nixpkgs/commit/e556e61a551c79f99ba19dcb206c87caa1e2a432) | `midimonster: init at 0.6.0`                                                   |
| [`31077c91`](https://github.com/NixOS/nixpkgs/commit/31077c914842426bdfd7440d2e97a07c0703b293) | `linuxPackages.rtl88x2bu: switch to the new, maintained repo`                  |
| [`edbfbd64`](https://github.com/NixOS/nixpkgs/commit/edbfbd641d527435f62968acfc076e39397bf2d3) | `rdap: init at 2019-10-17`                                                     |
| [`af8dd580`](https://github.com/NixOS/nixpkgs/commit/af8dd58004cf54d9b463726346641a474cc5ebd4) | `maintainers: add sebastianblunt`                                              |
| [`7d620546`](https://github.com/NixOS/nixpkgs/commit/7d62054650523a1256fae4aeacf3d77ae4b5f9e7) | `angsd: init at 0.937`                                                         |
| [`e61bec5c`](https://github.com/NixOS/nixpkgs/commit/e61bec5c0d15158a9865f12fd86618c475ba2046) | `tboot: 1.10.3 -> 1.10.4`                                                      |
| [`c0ac65d9`](https://github.com/NixOS/nixpkgs/commit/c0ac65d9b38de59f08c1ecaf08140766b9a01823) | `ocaml: default to version 4.13`                                               |
| [`f5174986`](https://github.com/NixOS/nixpkgs/commit/f517498672b18e09737f848f235f3103bd77c275) | `flow: use OCaml 4.12`                                                         |
| [`28b02ff0`](https://github.com/NixOS/nixpkgs/commit/28b02ff09c5be062437c2c792de85cfc57c4df4a) | `ocamlformat: build versions [0.17.0; 0.19.0[ with OCaml 4.12`                 |
| [`1a765a28`](https://github.com/NixOS/nixpkgs/commit/1a765a28275fd4bcf468ffa71025d88d0591f4a3) | `reason: use OCaml 4.12`                                                       |
| [`9fd44c40`](https://github.com/NixOS/nixpkgs/commit/9fd44c40572a7f6f0a3f5f94d791620bdf5b3d20) | `stog: use OCaml 4.12`                                                         |
| [`25a6f427`](https://github.com/NixOS/nixpkgs/commit/25a6f427eb769916a8f8ca1f7c3348250cc1cdab) | `sks: use OCaml 4.12`                                                          |
| [`ed7b5516`](https://github.com/NixOS/nixpkgs/commit/ed7b5516016876a29a568bc37fff22b121f5769d) | `abella: use OCaml 4.12`                                                       |
| [`251f4cdd`](https://github.com/NixOS/nixpkgs/commit/251f4cddca5b2955bfbe5f69ab078d086277b342) | `hol_light: use OCaml 4.12`                                                    |
| [`9da30617`](https://github.com/NixOS/nixpkgs/commit/9da306179ad4d32998f9035cc2bcfc64729a2dcb) | `orpie: use OCaml 4.12`                                                        |
| [`d579cf4e`](https://github.com/NixOS/nixpkgs/commit/d579cf4e21d4ce6c381f322bcdd35c688d577dcd) | `ledit: use OCaml 4.12`                                                        |
| [`03fc4992`](https://github.com/NixOS/nixpkgs/commit/03fc4992af530d68ebad33c9f746adda00a75505) | `prooftree: use OCaml 4.12`                                                    |
| [`5db8d97e`](https://github.com/NixOS/nixpkgs/commit/5db8d97e6245d373b7c58859d5e3cbee39fbf4c0) | `haxe: use OCaml 4.12 for version 4.2`                                         |
| [`3436dfc7`](https://github.com/NixOS/nixpkgs/commit/3436dfc72433557eb475e4d5066a4d96ad821299) | `ocamlPackages.pythonlib: disable for OCaml ≥ 4.13`                            |
| [`b9384170`](https://github.com/NixOS/nixpkgs/commit/b93841708700eaf02b8d9b24cadc3b9efec56699) | `reason: disable for OCaml ≥ 4.13`                                             |
| [`87b8f79f`](https://github.com/NixOS/nixpkgs/commit/87b8f79fa425022d2305937a6b234bb02902b883) | `ocamlPackages.ocaml-migrate-parsetree: disable with OCaml ≥ 4.13`             |
| [`5bd7b701`](https://github.com/NixOS/nixpkgs/commit/5bd7b7017bb0c85bafb456b574b54b04bc822fc1) | `ocamlPackages.wasm: disable for OCaml ≥ 4.13`                                 |
| [`315ed6fa`](https://github.com/NixOS/nixpkgs/commit/315ed6fad04b9bb54bbacddfcaa9154a33699413) | `ocamlPackages.camlp5: disable for OCaml ≥ 4.13`                               |
| [`f73281a7`](https://github.com/NixOS/nixpkgs/commit/f73281a7278fecbae3ad35a4e46d69dcda6fee11) | `smug: init at 0.2.7`                                                          |
| [`f6c6d63d`](https://github.com/NixOS/nixpkgs/commit/f6c6d63d1ce68f3458cdbe34cf7337dde5022630) | `shellspec: init at 0.28.1`                                                    |
| [`7db71a91`](https://github.com/NixOS/nixpkgs/commit/7db71a91056efe56fef6e4325a3a07d5806c5b9c) | `lagrange: 1.10.6 -> 1.11.1`                                                   |
| [`cb3adf5b`](https://github.com/NixOS/nixpkgs/commit/cb3adf5bf20197b7ccb3b00bcdd6cfabb1d5807f) | `vk-messenger: 5.2.3 -> 5.3.2`                                                 |
| [`38246ed1`](https://github.com/NixOS/nixpkgs/commit/38246ed1942a9f6f55e28c8c452cec9f3c3ad772) | `nixos/snowflake-proxy: init`                                                  |
| [`56095bf0`](https://github.com/NixOS/nixpkgs/commit/56095bf066d844bd42b205f60e78bb4ec6ab3585) | `php74Packages.phpstan: 1.4.6 -> 1.4.7`                                        |
| [`2e46cc1f`](https://github.com/NixOS/nixpkgs/commit/2e46cc1f00cd965cef074d655b3813832c71a745) | `nixos/earlyoom: remove useKernelOOMKiller`                                    |
| [`c738e61a`](https://github.com/NixOS/nixpkgs/commit/c738e61a9491674bf19cfb540d6756c8c227ad21) | `qemu: put virtiofsd in bin/`                                                  |
| [`ba21f946`](https://github.com/NixOS/nixpkgs/commit/ba21f946e378b311e5c249132010c3d6220861e0) | `vscodium: 1.64.2 -> 1.65.0`                                                   |
| [`d9a87bf9`](https://github.com/NixOS/nixpkgs/commit/d9a87bf933b71a65ab3a050effe9da9600b0b5a6) | `vscode: 1.64.2 -> 1.65.0`                                                     |
| [`dffdae60`](https://github.com/NixOS/nixpkgs/commit/dffdae60a33c1cf65988c59d2d00df290ecb0a46) | `python310Packages.google-resumable-media: 2.3.0 -> 2.3.1`                     |
| [`e85b65f9`](https://github.com/NixOS/nixpkgs/commit/e85b65f9868c7e160abc2ede9e09606561126670) | `minimap2: enable aarch64 builds (#161169)`                                    |
| [`b236e970`](https://github.com/NixOS/nixpkgs/commit/b236e970ef4906f4b35cd11383447ebe83f76b05) | `vtm: init at 0.6.0 (#161464)`                                                 |
| [`71237d0c`](https://github.com/NixOS/nixpkgs/commit/71237d0c8e72ea9935e43bba98d820c19cec6e47) | `limesctl: 2.0.1 -> 3.0.0`                                                     |
| [`6f4ecb8a`](https://github.com/NixOS/nixpkgs/commit/6f4ecb8ae81c77d823797d0e8736bb43187542ac) | `cf-vault: init at 0.0.11`                                                     |
| [`e56adb0e`](https://github.com/NixOS/nixpkgs/commit/e56adb0e605b4e90e50a86cca9a18f2c18ff20ae) | `papirus-icon-theme: 20220204 -> 20220302`                                     |
| [`d2c558d9`](https://github.com/NixOS/nixpkgs/commit/d2c558d95f23cc4db59b178b82796a7c3dc8e19f) | `python39Packages.bandit: 1.7.3 -> 1.7.4`                                      |
| [`094460db`](https://github.com/NixOS/nixpkgs/commit/094460dbe5ea5ca4a72a52403498766d2b2b7bbe) | `ejson2env: init at 2.0.2`                                                     |
| [`40985ede`](https://github.com/NixOS/nixpkgs/commit/40985edea4cb45c2fa6499cf59c6eff01fb2bc30) | `maintainers: viraptor`                                                        |
| [`ffa377b6`](https://github.com/NixOS/nixpkgs/commit/ffa377b6263f01b80cbc444352fbf3835c418ead) | `ocamlPackages.base_0_12: Add dune_1 to build inputs for dune.configurator`    |
| [`b80a39b9`](https://github.com/NixOS/nixpkgs/commit/b80a39b91b0730277c116ce766387b5f0862f47b) | `podman: ensure paths exist for the wrapper`                                   |
| [`568355c8`](https://github.com/NixOS/nixpkgs/commit/568355c818bd3bff4828f29aff82a7484a8556d7) | `numix-icon-theme-circle: 22.02.06 -> 22.03.01`                                |
| [`fd2c89dc`](https://github.com/NixOS/nixpkgs/commit/fd2c89dc6b589ac097a871ecbcdd69cc3b712c5d) | `python3Packages.pyobihai: add format`                                         |
| [`427f133e`](https://github.com/NixOS/nixpkgs/commit/427f133ed5161527af5893d5987eb1f619e3c546) | `numix-icon-theme-square: 22.02.06 -> 22.03.01`                                |
| [`51ae0d1e`](https://github.com/NixOS/nixpkgs/commit/51ae0d1eaa4c57c131f46965d04ba9d65e581b92) | `python310Packages.slack-sdk: 3.15.1 -> 3.15.2`                                |
| [`2d461e7b`](https://github.com/NixOS/nixpkgs/commit/2d461e7bc56fc4f70a9172c58f9f75f366347eb7) | `wireplumber: fix global config path`                                          |
| [`de585f82`](https://github.com/NixOS/nixpkgs/commit/de585f82e1453e5bc441bf1b4d4cf4bb5492d115) | `avizo: 1.1 -> 1.2`                                                            |
| [`693b3321`](https://github.com/NixOS/nixpkgs/commit/693b3321c3a280dffbf440e41ddfaf0e155026b7) | `python310Packages.azure-mgmt-containerregistry: 9.0.0 -> 9.1.0`               |
| [`e556b50e`](https://github.com/NixOS/nixpkgs/commit/e556b50ec3d307703bea4cf598471949eb8c852c) | `exoscale-cli: 1.49.3 -> 1.50.0`                                               |
| [`bc8aa440`](https://github.com/NixOS/nixpkgs/commit/bc8aa44089edf0ae1daeb019f41daed599f6c583) | `esbuild: 0.14.23 -> 0.14.24`                                                  |
| [`2167e68d`](https://github.com/NixOS/nixpkgs/commit/2167e68d9e71946e5d81ba10dc9af8824fe63488) | `python310Packages.pyobihai: 1.3.1 -> 1.3.2`                                   |
| [`74518e84`](https://github.com/NixOS/nixpkgs/commit/74518e846dce00c3fcaf02c94764208d11df8f0a) | `elements: 0.21.0.1 -> 0.21.0.2`                                               |
| [`d2ec3265`](https://github.com/NixOS/nixpkgs/commit/d2ec32656fe8731506ad2fa2532b9c016530e68e) | `python310Packages.azure-mgmt-datafactory: 2.2.1 -> 2.3.0`                     |
| [`1940031d`](https://github.com/NixOS/nixpkgs/commit/1940031dfe56faac051fe091e32af27e38accfec) | `vimPlugins.vim-clap: fix cargoSha256`                                         |
| [`14ada3ad`](https://github.com/NixOS/nixpkgs/commit/14ada3add8cb4410c86ca0068c5f905994a1fd1f) | `consul-template: 0.27.2 -> 0.28.0`                                            |
| [`6874a12a`](https://github.com/NixOS/nixpkgs/commit/6874a12a72b2034b40d55e543d4579c19f7b196b) | `cmark-gfm: 0.29.0.gfm.2 -> 0.29.0.gfm.3`                                      |
| [`82542559`](https://github.com/NixOS/nixpkgs/commit/82542559e62975914c4ede799d56c2d46dc51748) | `pythonPackages: add isPy310 and isPy311`                                      |
| [`03a4f90f`](https://github.com/NixOS/nixpkgs/commit/03a4f90f697f2b8baf3cca75d8e7a510cd781f12) | `cudatoolkit_11_6: 11.6.0 -> 11.6.1`                                           |
| [`75eef6f0`](https://github.com/NixOS/nixpkgs/commit/75eef6f0d023403eaa3cbba8f499e05cd08f60dc) | `checkmate: 0.5.7 -> 0.5.8`                                                    |
| [`8cbdd4d7`](https://github.com/NixOS/nixpkgs/commit/8cbdd4d7487578284f8d1251c4df4e6ff8b5545b) | `python310Packages.pycfmodel: 0.17.0 -> 0.17.1`                                |
| [`9a30f53f`](https://github.com/NixOS/nixpkgs/commit/9a30f53ffe466793c9b3019fcaf65cd2d54f44ad) | `nixos/firejail: Fix order of extrsArgs before profile wrappedBinaries option` |
| [`999e6eb2`](https://github.com/NixOS/nixpkgs/commit/999e6eb2d9b9d6fa4ed9bd5ace50b0551c660f2d) | `cargo-llvm-lines: 0.4.13 -> 0.4.14`                                           |
| [`5390449f`](https://github.com/NixOS/nixpkgs/commit/5390449f5ff426cbc1df7920780fd591df5c5c86) | `calibre: remove duplicate "jeepney" in buildInputs`                           |
| [`9ff63d04`](https://github.com/NixOS/nixpkgs/commit/9ff63d04ed4bc8f2fce2c537349f432e5ef298e7) | `python310Packages.dropbox: 11.27.0 -> 11.28.0`                                |
| [`bae181d3`](https://github.com/NixOS/nixpkgs/commit/bae181d3f0f453d9a23cf5e899c2cb0f96e91fef) | `nixos/os-release: generate from attrset`                                      |
| [`3143de97`](https://github.com/NixOS/nixpkgs/commit/3143de97f9f0a70f2d2c4fb29fd83612fa2d6076) | `krunner-pass: pass-otp has been deprecated`                                   |
| [`b685f44e`](https://github.com/NixOS/nixpkgs/commit/b685f44ef2adbcc4b4330e22e427c03bdb03ef72) | `steam-run: inherit extraInstallCommands`                                      |
| [`543aa630`](https://github.com/NixOS/nixpkgs/commit/543aa6308108733eb8461a38d5e23e1e0397cac4) | `diffr: fix cargoSha256`                                                       |
| [`886c14f3`](https://github.com/NixOS/nixpkgs/commit/886c14f3d41e22ba6a9b740a78dfaa5ea938f5e0) | `python310Packages.cfn-lint: 0.56.4 -> 0.58.2`                                 |
| [`976d703d`](https://github.com/NixOS/nixpkgs/commit/976d703d23d05296af45495ac6aa5a345773fecc) | `singularity: enable setting vm mem in buildImage`                             |
| [`aff93f52`](https://github.com/NixOS/nixpkgs/commit/aff93f52880b36925efb9fd73a4c60348dbd290e) | `endlessh-go: init at 20220213`                                                |
| [`6eed87d4`](https://github.com/NixOS/nixpkgs/commit/6eed87d4490ce045dda1091999d1e38605afb8ea) | `go_1_16: 1.16.14 -> 1.16.15`                                                  |
| [`38cf6fea`](https://github.com/NixOS/nixpkgs/commit/38cf6fea696adec20ea36b12af0792a2b488d3a2) | `qemu: fix qemu.ga including qemu in it's closure`                             |
| [`691919bf`](https://github.com/NixOS/nixpkgs/commit/691919bf0003817a02fa0c4bb3210a6aa633f03a) | `chromiumDev: 100.0.4896.12 -> 100.0.4896.20`                                  |
| [`05aa1711`](https://github.com/NixOS/nixpkgs/commit/05aa1711fd50a5fec1eb8397b7616f1cad622e15) | `chromiumBeta: 99.0.4844.51 -> 100.0.4896.20`                                  |
| [`80dfb3f7`](https://github.com/NixOS/nixpkgs/commit/80dfb3f7449d01d8248d079dd34854d809f3c56f) | `openssh_hpn: 8.8p1 -> 8.9p1`                                                  |
| [`910f115c`](https://github.com/NixOS/nixpkgs/commit/910f115cfa78e5d153c758d82f5b89a2bfe93368) | `libdeltachat: 1.75.0 -> 1.76.0`                                               |
| [`801f6c4b`](https://github.com/NixOS/nixpkgs/commit/801f6c4be9ec220cdb566e4c42861215f12b960f) | `gopls: 0.7.5 -> 0.8.0`                                                        |
| [`f6ad15fd`](https://github.com/NixOS/nixpkgs/commit/f6ad15fd8c6d09b7e03e5252cfaa594d14f67f50) | `nixos/switchTest: Make checks more precise`                                   |
| [`1def5575`](https://github.com/NixOS/nixpkgs/commit/1def557525157481da42fbd153a00729cce32d87) | `nixos/switch-to-configuration: Document and test socket-activated services`   |
| [`d4b9a7a1`](https://github.com/NixOS/nixpkgs/commit/d4b9a7a1794fba495990561f029e97d20ae83b1f) | `gitea: 1.16.2 -> 1.16.3`                                                      |
| [`ad267cc9`](https://github.com/NixOS/nixpkgs/commit/ad267cc9cf3d5a6ae63940df31eb31382d6356e6) | `python3Packages.isbnlib: 3.10.9 -> 3.10.10`                                   |
| [`537d3bec`](https://github.com/NixOS/nixpkgs/commit/537d3becbd64c589a1ab58b6584b2840f81ac1f7) | `sarasa-gothic: 0.35.9 -> 0.36.0`                                              |
| [`ab8ff08f`](https://github.com/NixOS/nixpkgs/commit/ab8ff08fd995d0e410b9fe0ecccf900bb9e79c21) | `prometheus-varnish-exporter: 1.6 -> 1.6.1`                                    |
| [`da19aaee`](https://github.com/NixOS/nixpkgs/commit/da19aaee59c0b4b0abf84185e5072cb5b21e9734) | `tectonic: 0.8.1 -> 0.8.2`                                                     |
| [`d50924f3`](https://github.com/NixOS/nixpkgs/commit/d50924f33b55f74ee13ba0d4f218c38099ad84fa) | `discord-canary: 0.0.133 -> 0.0.134`                                           |
| [`c346cecb`](https://github.com/NixOS/nixpkgs/commit/c346cecbf3ae9850082104dc3fd6a406a4091b38) | `python310Packages.azure-mgmt-compute: 26.0.0 -> 26.1.0`                       |
| [`cf983786`](https://github.com/NixOS/nixpkgs/commit/cf9837864d529afde37b47ba6b940a8502b0f6b2) | `python310Packages.python-songpal: 0.14 -> 0.14.1`                             |
| [`52a0af5f`](https://github.com/NixOS/nixpkgs/commit/52a0af5fb214c547b73ed700f6fcbb6f27b34375) | `python310Packages.samsungtvws: 2.0.0 -> 2.1.0`                                |
| [`26d7a5cf`](https://github.com/NixOS/nixpkgs/commit/26d7a5cf7714567c5959ae8c95071b6d1b18335f) | `python310Packages.jupyterlab: 3.2.9 -> 3.3.0`                                 |
| [`bc847302`](https://github.com/NixOS/nixpkgs/commit/bc84730269c8520ce2f2bb93388dd9412e5118e9) | `python310Packages.stripe: 2.66.0 -> 2.67.0`                                   |
| [`2568c6c9`](https://github.com/NixOS/nixpkgs/commit/2568c6c9a3db047737b7cdcfbf55bea9cb9d1fc5) | `python310Packages.google-cloud-bigquery: 2.34.0 -> 2.34.1`                    |
| [`7f1eb5ba`](https://github.com/NixOS/nixpkgs/commit/7f1eb5ba09f17a1a4d00e5c54c2193f2348f7760) | `python310Packages.spacy: 3.2.2 -> 3.2.3`                                      |
| [`1f1eefec`](https://github.com/NixOS/nixpkgs/commit/1f1eefec2290138f21958df522de23104a445df7) | `python310Packages.bitarray: 2.3.7 -> 2.4.0`                                   |
| [`bdcb90bd`](https://github.com/NixOS/nixpkgs/commit/bdcb90bde8c3f874983873cf893af8d87e04f45c) | `python310Packages.aiolifx: 0.7.0 -> 0.7.1`                                    |
| [`507cb692`](https://github.com/NixOS/nixpkgs/commit/507cb692f0e4c7141a4e996491a95690f9101df6) | `python310Packages.neo: 0.10.0 -> 0.10.1`                                      |
| [`a28d8a4a`](https://github.com/NixOS/nixpkgs/commit/a28d8a4a0daa98eaa9da83ea325f3ed1ccb11916) | `python310Packages.sabyenc3: 4.0.2 -> 5.0.1`                                   |
| [`fbcf2574`](https://github.com/NixOS/nixpkgs/commit/fbcf2574f655808c61dc3b82cce51da86d47a53c) | `python310Packages.pubnub: 6.0.1 -> 6.1.0`                                     |
| [`99805240`](https://github.com/NixOS/nixpkgs/commit/998052403dd0f6f7ea1586fbfea09b139f7dc1c7) | `python310Packages.pyrfxtrx: 0.27.1 -> 0.28.0`                                 |
| [`fcae1634`](https://github.com/NixOS/nixpkgs/commit/fcae1634e8fe68913aac693713fc14cdabdfcce3) | `python310Packages.globus-sdk: 3.4.2 -> 3.5.0`                                 |
| [`c81926c4`](https://github.com/NixOS/nixpkgs/commit/c81926c414790c88aa45d8781d5d9ac6857e4675) | `python310Packages.google-cloud-dataproc: 3.3.0 -> 4.0.0`                      |
| [`facbc476`](https://github.com/NixOS/nixpkgs/commit/facbc4767d795372d45302a31c01c131bf912e4d) | `python310Packages.sqlite-utils: 3.24 -> 3.25`                                 |
| [`28f86f66`](https://github.com/NixOS/nixpkgs/commit/28f86f66e89a15340d8eb3480c94bcf1ac8de1d9) | `python310Packages.azure-identity: 1.7.1 -> 1.8.0`                             |
| [`27439c97`](https://github.com/NixOS/nixpkgs/commit/27439c97e797fc13503b286b1fcc290c314807ab) | `python310Packages.pyglet: 1.5.21 -> 1.5.22`                                   |
| [`a4a65127`](https://github.com/NixOS/nixpkgs/commit/a4a65127de84442017852c4c88093f91a436ed11) | `hcl2json: init at 0.3.4`                                                      |
| [`ef546c98`](https://github.com/NixOS/nixpkgs/commit/ef546c98dc68007584fa8710f47fea6deb083788) | `terraform-providers.aws: 4.2.0 -> 4.3.0`                                      |
| [`432c775f`](https://github.com/NixOS/nixpkgs/commit/432c775f3ba4eb75388d1eb9ca6ba80faa26897f) | `ocamlPackages.apron: set strictDeps = false to fix install failure`           |
| [`c5df8a40`](https://github.com/NixOS/nixpkgs/commit/c5df8a40a5a4067d529ad2a94617895147eb37d1) | `containerd: 1.6.0 -> 1.6.1`                                                   |
| [`dc7da9ac`](https://github.com/NixOS/nixpkgs/commit/dc7da9ac1f6c2163628a66cceb710cfeb903470d) | `stylua: 0.12.3 -> 0.12.4`                                                     |
| [`e28c5cd7`](https://github.com/NixOS/nixpkgs/commit/e28c5cd7ac73026057b1dc2783c081340dc04358) | `pkgsStatic.cryptsetup: don't --enable-static-cryptsetup`                      |
| [`4762a265`](https://github.com/NixOS/nixpkgs/commit/4762a265d40b69f7076a3613ea61dd014915a6d9) | `pkgsMusl.screen: fix build`                                                   |
| [`7ecf7a34`](https://github.com/NixOS/nixpkgs/commit/7ecf7a3493c60f1c1f853f0393551447aa16a437) | `pkgsMusl.socat: fix build`                                                    |
| [`24278c45`](https://github.com/NixOS/nixpkgs/commit/24278c45af69273a1cedd3e713bd4cff8a27a3af) | `mailutils: add debug info`                                                    |
| [`e47e5519`](https://github.com/NixOS/nixpkgs/commit/e47e551964d5bf7f917d12145242fdb0f52bf4a0) | `nixops_unstable: 2.0.0-pre (2022-02-21) -> 2.0.0-pre-d939c9b (2022-03-03)`    |
| [`5b4c6317`](https://github.com/NixOS/nixpkgs/commit/5b4c63172c625e9bae11ce6fbb7aeea161c097bb) | `nixops_unstable: Fall back to "dirty" when rev missing`                       |
| [`b543a5e2`](https://github.com/NixOS/nixpkgs/commit/b543a5e27db60f05cd8cb924e9d5af64c9f5bc26) | `devpi-client: add missing input, switch to pytestCheckHook`                   |
| [`b49faa87`](https://github.com/NixOS/nixpkgs/commit/b49faa878203ef532cd3eeb766c528a4495ee61f) | `exploitdb: 2022-03-01 -> 2022-03-03`                                          |
| [`d2c3410e`](https://github.com/NixOS/nixpkgs/commit/d2c3410efdfd1642f52f9c67246791895534333a) | `nixopsUnstable -> nixops_unstable`                                            |
| [`0bd069dd`](https://github.com/NixOS/nixpkgs/commit/0bd069dd41725c95a85a34e719b0573f1b98d5c9) | `nixopsUnstable: Set version to <version>-pre-<commit>`                        |
| [`121b56dc`](https://github.com/NixOS/nixpkgs/commit/121b56dcd03837aed1aad7a3bdf41c28af3e4c24) | `nixopsUnstable: 2.0.0-pre (2021-12-01) -> 2.0.0-pre (2022-02-21)`             |
| [`cb20e934`](https://github.com/NixOS/nixpkgs/commit/cb20e934db502a9ad3497b85399ceb27ef7ccffb) | `clojure: 1.10.3.1082 -> 1.10.3.1087`                                          |
| [`7ec2c0f2`](https://github.com/NixOS/nixpkgs/commit/7ec2c0f27677cfee4b830eb77d2301bf453ad3f3) | `crun: 1.4.2 -> 1.4.3`                                                         |
| [`9c889648`](https://github.com/NixOS/nixpkgs/commit/9c88964863fe8232eff7bc2dc2f6df5ecd1d0572) | `python3Packages.blinkpy: disable failing tests on Python 3.10`                |
| [`3024ba0b`](https://github.com/NixOS/nixpkgs/commit/3024ba0b76bf451d38b1ef83be7f4b525671329b) | `parcel: init at 2.3.2`                                                        |
| [`e1f1924a`](https://github.com/NixOS/nixpkgs/commit/e1f1924a20ffe7b795df52e518736b393fd25556) | `podman: 4.0.1 -> 4.0.2`                                                       |
| [`f258f9ee`](https://github.com/NixOS/nixpkgs/commit/f258f9eed909bd6aa0da9f06cab20f3fca929f8a) | `python3Packages.testfixtures: 6.18.4 -> 6.18.5`                               |
| [`bfaf867d`](https://github.com/NixOS/nixpkgs/commit/bfaf867dcb356eb1b803cbb7627004ff95f38a2e) | `xscreensaver: 6.02 -> 6.03`                                                   |
| [`beff7579`](https://github.com/NixOS/nixpkgs/commit/beff75796080a043ebcb1dbfbb80eb5560bfd39c) | `seabios: 1.15.0 -> 1.16.0`                                                    |
| [`4a701a51`](https://github.com/NixOS/nixpkgs/commit/4a701a51aa7f0affc43fb9187f08e436577d2704) | `spice-gtk: fix build for withPolkit==false case`                              |
| [`085183d3`](https://github.com/NixOS/nixpkgs/commit/085183d3063a5bac633edd4a17f6954becbf1da7) | `gau: 2.0.8 -> 2.0.9`                                                          |
| [`126ce87b`](https://github.com/NixOS/nixpkgs/commit/126ce87b0c7e526c8d1f2eccd868e89ef61deab3) | `nixos/tests: fix flaky cntr test`                                             |
| [`92ede7bf`](https://github.com/NixOS/nixpkgs/commit/92ede7bf7a6cc74144a2263118af71ff24da8719) | `flexget: 3.2.18 -> 3.3.2`                                                     |
| [`ea27b224`](https://github.com/NixOS/nixpkgs/commit/ea27b2243bfacde2ed3fa05efdcc2bc842995119) | `clang13Stdenv: init (#162346)`                                                |
| [`03785706`](https://github.com/NixOS/nixpkgs/commit/03785706bd8654a310d7ba2ea5de4d3b91a6268a) | `earthly: 0.6.8 -> 0.6.9`                                                      |
| [`fba25be5`](https://github.com/NixOS/nixpkgs/commit/fba25be56f4bb4ecbfbba756c52211835e1ad8c3) | `dismap: 0.2 -> 0.3`                                                           |
| [`7ea65457`](https://github.com/NixOS/nixpkgs/commit/7ea654576d25d28af9aa765851a15b1d52bfc596) | `thermald: disable -Werror`                                                    |
| [`ba88ba13`](https://github.com/NixOS/nixpkgs/commit/ba88ba13b42e1d26a39d39697236817408f81342) | `python310Packages.sqlmap: 1.6.2 -> 1.6.3`                                     |
| [`27ebe78e`](https://github.com/NixOS/nixpkgs/commit/27ebe78ea1d5344e7447d788435f6fd74b1fd0bc) | `convco: 0.3.8 -> 0.3.9`                                                       |
| [`77f77acf`](https://github.com/NixOS/nixpkgs/commit/77f77acffc569814a9a5e9a3a07b83a32cc14b77) | `python3Packages.ihatemoney: fix build`                                        |
| [`7a3e6d66`](https://github.com/NixOS/nixpkgs/commit/7a3e6d6604ad99c77e7a98943734bdeea564bff2) | `syncthing: 1.19.0 -> 1.19.1`                                                  |
| [`c1802276`](https://github.com/NixOS/nixpkgs/commit/c1802276f46449cd4eb9d58d784189697b3023de) | `tectonic: 0.8.0 -> 0.8.1`                                                     |
| [`76467026`](https://github.com/NixOS/nixpkgs/commit/764670261a559e0e2e89dcce487fb9bd3ae19f9e) | `nixos/opensnitch: Add options to configure daemon`                            |
| [`17e776ee`](https://github.com/NixOS/nixpkgs/commit/17e776eeb5150b6b24f03cef56f7f24dde4cd7e1) | `python3Packages.kaldi-active-grammar: fix build`                              |