### PR TITLE
chore(flake/gitignore): `5b9e0ff9` -> `bff2832e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1635165013,
-        "narHash": "sha256-o/BdVjNwcB6jOmzZjOH703BesSkkS5O7ej3xhyO8hAY=",
+        "lastModified": 1646480205,
+        "narHash": "sha256-kekOlTlu45vuK2L9nq8iVN17V3sB0WWPqTTW3a2SQG0=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "5b9e0ff9d3b551234b4f3eb3983744fa354b17f1",
+        "rev": "bff2832ec341cf30acb3a4d3e2e7f1f7b590116a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                     | Commit Message                                         |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`bff2832e`](https://github.com/hercules-ci/gitignore.nix/commit/bff2832ec341cf30acb3a4d3e2e7f1f7b590116a) | `README: add "added but ignored", dotfiles comparison` |
| [`c581cb17`](https://github.com/hercules-ci/gitignore.nix/commit/c581cb17c8bec07239c29fa046e33dbcb1d70fa9) | ``README.md: add `fetchGit```                          |