### PR TITLE
chore(flake/home-manager): `d119cea3` -> `afe96e74`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1646364779,
-        "narHash": "sha256-481vkO9b3h++bHzLbGDDhgpBoXQ0Wlo4lm4h5/EJMO4=",
+        "lastModified": 1646559628,
+        "narHash": "sha256-WDoqxH/IPTV8CkI15wwzvXYgXq9UPr8xd8WKziuaynw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d119cea3763977801ad66330668c1ab4346cb7f7",
+        "rev": "afe96e7433c513bf82375d41473c57d1f66b4e68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                      |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`afe96e74`](https://github.com/nix-community/home-manager/commit/afe96e7433c513bf82375d41473c57d1f66b4e68) | `pubs: add module`                  |
| [`abd221c4`](https://github.com/nix-community/home-manager/commit/abd221c4b38c98293dab38da59a26b14bd4053af) | `Translate using Weblate (Turkish)` |
| [`4e685639`](https://github.com/nix-community/home-manager/commit/4e6856397e930228ca887a4fd28a3292395443bf) | `Translate using Weblate (Polish)`  |
| [`87beebc7`](https://github.com/nix-community/home-manager/commit/87beebc7a2d52dbbf15bbca6099e01d2c719ded3) | `just: add module`                  |