### PR TITLE
chore(flake/nixpkgs): `35db2e60` -> `e2f381b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1646633962,
-        "narHash": "sha256-SvDOQ7zEAK+K1xDPyKYAVnEcFSEar+nF8gT+VcbauUE=",
+        "lastModified": 1647808254,
+        "narHash": "sha256-yajQF+iTkFdvorc/OsEgC1+HLPT/uwLYE4ds8HAURkA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "35db2e60df598e3d5c88adab65f70b91f6645b45",
+        "rev": "e2f381b2f1879ad6d68be5a9e9e6e3288529bfaf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`e2f381b2`](https://github.com/NixOS/nixpkgs/commit/e2f381b2f1879ad6d68be5a9e9e6e3288529bfaf) | `blender: 2.93.5 -> 3.1.0 (#164987)`                                      |
| [`17988778`](https://github.com/NixOS/nixpkgs/commit/17988778f188a74576fba156c0e91f7b299d46f8) | `wrangler: 1.19.8 -> 1.19.9`                                              |
| [`41f28e9f`](https://github.com/NixOS/nixpkgs/commit/41f28e9fbcb2eb1deb6c2a220bedef9969e49fa7) | `nixos/tests: add mastodon test`                                          |
| [`4bf427a7`](https://github.com/NixOS/nixpkgs/commit/4bf427a738e2e7786d39afdf16dd299d1805c23a) | `rover: init at 0.4.8`                                                    |
| [`a3f2a62e`](https://github.com/NixOS/nixpkgs/commit/a3f2a62e4bae6075c51d793e9ea01863697f5da5) | `dua: 2.17.0 -> 2.17.1`                                                   |
| [`ba39a493`](https://github.com/NixOS/nixpkgs/commit/ba39a493b7d47e1b34b33a264ee9adab1f1cf39e) | `i3wsr: 2.0.1 -> 2.1.0`                                                   |
| [`2a804d82`](https://github.com/NixOS/nixpkgs/commit/2a804d82aa70ddf078d9a1e4c6250a9a62437e2d) | `python310Packages.elementpath: 2.4.0 -> 2.5.0`                           |
| [`1282a971`](https://github.com/NixOS/nixpkgs/commit/1282a971ebb7841b5f4d30d96b22b1c4ac5f27c8) | `Update pkgs/applications/audio/open-music-kontrollers/synthpod.nix`      |
| [`a73b85d7`](https://github.com/NixOS/nixpkgs/commit/a73b85d7515fedd5479fd3ef089290c59a32e6b5) | `yq-go: 4.22.1 -> 4.23.1`                                                 |
| [`dd6c7096`](https://github.com/NixOS/nixpkgs/commit/dd6c7096d629d9c6814c6980180254d3336a9a3b) | `wine{unstable,staging}: 7.2 -> 7.4, vkd3d: 1.2 -> 1.3`                   |
| [`95d00c34`](https://github.com/NixOS/nixpkgs/commit/95d00c348aeb1b8300fe486f471c454653d3329e) | `python3Packages.invoke: remove whitespaces`                              |
| [`0edae27e`](https://github.com/NixOS/nixpkgs/commit/0edae27e27d8ed4702dce69e890f610032d8304e) | `python3Packages.invoke: update meta, add pythonImportsCheck`             |
| [`1d512e62`](https://github.com/NixOS/nixpkgs/commit/1d512e6283f4ec753a4e6be7cbd50ffd503d7e5f) | `python3Packages.hahomematic: 0.37.7 -> 0.38.2`                           |
| [`eb0e44bb`](https://github.com/NixOS/nixpkgs/commit/eb0e44bb54b5c74c9f139c36b28f933d68447c42) | `python3Packages.azure-core: disable test failing on some darwin systems` |
| [`a6a8886d`](https://github.com/NixOS/nixpkgs/commit/a6a8886d70a2b0ccd87e1623b6a4b96c9459a29a) | `python3Packages.qiling: add missing pyyaml dep`                          |
| [`81b63b6e`](https://github.com/NixOS/nixpkgs/commit/81b63b6ef6f2e7e2d9adea64d744d1975e6b8860) | `nixos/oauth2_proxy: add missing oidc providers (#164632)`                |
| [`c0a4d8e7`](https://github.com/NixOS/nixpkgs/commit/c0a4d8e7145c928799cb38a98085789595b28c0a) | `corerad: 1.1.0 -> 1.1.1`                                                 |
| [`c83df4a4`](https://github.com/NixOS/nixpkgs/commit/c83df4a4cb66e34c7f46676b644e778987dae997) | `python310Packages.limnoria: 2022.2.3 -> 2022.3.17`                       |
| [`60f170aa`](https://github.com/NixOS/nixpkgs/commit/60f170aa46da621a36e4c0b910e0be85cc2843a5) | `python310Packages.discogs-client: 2.3.13 -> 2.3.14`                      |
| [`6575433b`](https://github.com/NixOS/nixpkgs/commit/6575433b6d6292452f27cc6a8ace9078263f7fce) | `vice: add desktop items for all computer model emulators`                |
| [`a9f42063`](https://github.com/NixOS/nixpkgs/commit/a9f420634dae4b836b17f769c699f3c362f79014) | `sabnzbd: 3.5.2 -> 3.5.3`                                                 |
| [`6ab2bfcf`](https://github.com/NixOS/nixpkgs/commit/6ab2bfcfc3c18dee30a2bf5476a96f2d61a545f7) | ` python3Packages.ropper: use buildPythonPackage`                         |
| [`4a8eecb6`](https://github.com/NixOS/nixpkgs/commit/4a8eecb628cf75386900f90198c095eab47144ac) | `flow: 0.174.0 -> 0.174.1`                                                |
| [`7c40872b`](https://github.com/NixOS/nixpkgs/commit/7c40872bb3fe56a929fdb4a49008c859809961ed) | `python310Packages.invoke: 1.6.0 -> 1.7.0`                                |
| [`016a19d1`](https://github.com/NixOS/nixpkgs/commit/016a19d13c5b4319228719244e3564cd82ce72e7) | `gitlab: 14.8.2 -> 14.8.4 (#164564)`                                      |
| [`9da5c78a`](https://github.com/NixOS/nixpkgs/commit/9da5c78ae4343642ea694004c1fe0896e2d60157) | `yaru-theme: 22.04.1 -> 22.04.2`                                          |
| [`4e4a88d0`](https://github.com/NixOS/nixpkgs/commit/4e4a88d03a8f4727693580aac837acdca54bd005) | `haskell.package-list: only include versions that conform to PVP`         |
| [`292daa12`](https://github.com/NixOS/nixpkgs/commit/292daa1285c888e110af4d03ce544b9d2963b9aa) | `smem: switch to python3`                                                 |
| [`df57bab6`](https://github.com/NixOS/nixpkgs/commit/df57bab6238a361c38b9d1b75714ae610ff6a7f1) | `jumpapp: 1.1 -> 1.2`                                                     |
| [`216d2149`](https://github.com/NixOS/nixpkgs/commit/216d21499a6198bfa53777b157e73ae8ad166795) | `python3Packages.broadlink: disable on older Python releases`             |
| [`69774699`](https://github.com/NixOS/nixpkgs/commit/69774699662cc6b718148831f4dd2f607385a1f7) | `cloud-nuke: 0.11.1 -> 0.11.3`                                            |
| [`512404e0`](https://github.com/NixOS/nixpkgs/commit/512404e0e40de9543dabea45499f4a3b0b065da0) | `python310Packages.broadlink: 0.18.0 -> 0.18.1`                           |
| [`9b2abc03`](https://github.com/NixOS/nixpkgs/commit/9b2abc03b2376162f260426554f8996406d8297c) | `cawbird: 1.4.2 -> 1.5`                                                   |
| [`108601b3`](https://github.com/NixOS/nixpkgs/commit/108601b3efd33c54d553e04e725b32811696b599) | `python3Packages.myfitnesspal: disable on older Python releases`          |
| [`c4c64b6a`](https://github.com/NixOS/nixpkgs/commit/c4c64b6a324fe5c73b6b8b57ef86c2ff12eacb4b) | `meld: pull upstream fix for meson-0.60`                                  |
| [`4d1a2994`](https://github.com/NixOS/nixpkgs/commit/4d1a29944a2e24f160b398b76de499b63a1104ed) | `python3Packages.qiling: 1.4.1 -> 1.4.2`                                  |
| [`e3658e6c`](https://github.com/NixOS/nixpkgs/commit/e3658e6c238c8515963d586218a6cc478d3a2678) | `broadlink-cli: 0.18.0 -> 0.18.1`                                         |
| [`6f227f03`](https://github.com/NixOS/nixpkgs/commit/6f227f03cb0e717c7a6ea396d5e7e76de46f0d84) | `qalculate-gtk: 4.0.0 -> 4.1.0`                                           |
| [`87277387`](https://github.com/NixOS/nixpkgs/commit/8727738771cd9af7bd032061392d74d063ebd88b) | `libqalculate: 4.0.0 -> 4.1.0`                                            |
| [`4345ab5c`](https://github.com/NixOS/nixpkgs/commit/4345ab5c7092326ab57b8e09878d8e76f79b383e) | `cask: templates were dropped from latest version`                        |
| [`fdc1b46e`](https://github.com/NixOS/nixpkgs/commit/fdc1b46e1e183878e88292150e9368042cf2e431) | `python310Packages.myfitnesspal: 1.16.6 -> 1.17.0`                        |
| [`ed86dba6`](https://github.com/NixOS/nixpkgs/commit/ed86dba63ac9a190b170fa9d62cf71ef8be4dfec) | `werf: 1.2.76 -> 1.2.77`                                                  |
| [`e883b173`](https://github.com/NixOS/nixpkgs/commit/e883b173193361fa48b285e2986d9411d62eb890) | `vale: 2.15.2 -> 2.15.3`                                                  |
| [`6c7d1af7`](https://github.com/NixOS/nixpkgs/commit/6c7d1af736e31b20ba677c120427a0b1d2ff23ba) | `trinsic-cli: 1.3.0 -> 1.4.0`                                             |
| [`0fb9c4be`](https://github.com/NixOS/nixpkgs/commit/0fb9c4bec36c5f73171ef13e9f0e92fc022b6ba2) | `suitesparse-graphblas: 6.2.2 -> 6.2.5`                                   |
| [`c9e14750`](https://github.com/NixOS/nixpkgs/commit/c9e1475085ec722c4398f23482c4fed1e34cac62) | `nixos/tests/terminal-emulators: fix test for st`                         |
| [`27086927`](https://github.com/NixOS/nixpkgs/commit/2708692778b13e4eeeb9335cd7eecd5f6b93ca15) | `vte: add tested vte-based terminals to passthru.tests`                   |
| [`69486230`](https://github.com/NixOS/nixpkgs/commit/694862304bf19ac6eb1f730f7fc9bfd3066a4006) | `nixos/tests: add passthru.tests to all tested terminal emulators`        |
| [`ca3bec60`](https://github.com/NixOS/nixpkgs/commit/ca3bec60313490e7c941076fd2d43f59c92923f3) | `terraformer: 0.8.18 -> 0.8.19`                                           |
| [`d56b8d52`](https://github.com/NixOS/nixpkgs/commit/d56b8d529e0c5ed2340c0920aad35d214a252550) | `terraform-ls: 0.25.2 -> 0.26.0`                                          |
| [`c3aa9107`](https://github.com/NixOS/nixpkgs/commit/c3aa9107d4255fe5fe1ab34a9f723a9c65cc08f6) | `diffoscope: disable test depending on black, re-enable fixed test`       |
| [`d31c6bd0`](https://github.com/NixOS/nixpkgs/commit/d31c6bd0eb8352d6884774aaa8b1e0c05449da93) | `onefetch: patch flaky test`                                              |
| [`2f4e0dfb`](https://github.com/NixOS/nixpkgs/commit/2f4e0dfb09b6d9a0b0ce5fb405f12404f802aa30) | `python310Packages.python-crfsuite: mark as broken`                       |
| [`4ba2b7b9`](https://github.com/NixOS/nixpkgs/commit/4ba2b7b94e2f89003ab215a1436f16b003a5646a) | `gruut-ipa: 0.12.0 -> 0.13.0`                                             |
| [`7ab33da4`](https://github.com/NixOS/nixpkgs/commit/7ab33da48f0e0c2882368a048f42762516caaf75) | `python310Packages.types-requests: 2.27.13 -> 2.27.14`                    |
| [`29984502`](https://github.com/NixOS/nixpkgs/commit/2998450275692727354921c0aedb945db4ccf124) | `swaykbdd: 1.0 -> 1.1`                                                    |
| [`f309e138`](https://github.com/NixOS/nixpkgs/commit/f309e138eb722371f23148aec44bedb12523e2a9) | `atlassian-jira: 8.21.0 -> 8.22.0`                                        |
| [`7433e080`](https://github.com/NixOS/nixpkgs/commit/7433e080a66fbd1d73bfc33ac9b14259ee1f1a3e) | `wezterm: 20220101-133340-7edc5b5a -> 20220319-142410-0fcdea07`           |
| [`6c92dd00`](https://github.com/NixOS/nixpkgs/commit/6c92dd00aa9bbe3c14e67d3293835da1a7c81f81) | `steampipe: 0.13.0 -> 0.13.2`                                             |
| [`ab6bd248`](https://github.com/NixOS/nixpkgs/commit/ab6bd24835713a5b672e10c9f7621c5dd4854a48) | `palemoon: 29.4.4 -> 30.0.0`                                              |
| [`a1a6103a`](https://github.com/NixOS/nixpkgs/commit/a1a6103a9fad54d0c18ac2a1960767debf88f4ee) | `sentry-cli: 1.73.1 -> 1.74.2`                                            |
| [`3d25f046`](https://github.com/NixOS/nixpkgs/commit/3d25f046b39158959e64444da2483ea2b30aad3b) | `docker: add a patch to fix Docker buildkit when using ZFS graph driver.` |
| [`30d50ea2`](https://github.com/NixOS/nixpkgs/commit/30d50ea29a3602c2a0959c003bde9cd03f15a8b1) | `cudatext: 1.156.2 -> 1.158.2`                                            |
| [`1502634e`](https://github.com/NixOS/nixpkgs/commit/1502634e1afa3b3bf0fac86ca15b6c71f0f40530) | `rclone: prefix PATH of fuse`                                             |
| [`d216b6ab`](https://github.com/NixOS/nixpkgs/commit/d216b6ab039217d8538f1ebd32b1272c1f00b5f0) | `hydrus: 477 -> 477`                                                      |
| [`8afbf997`](https://github.com/NixOS/nixpkgs/commit/8afbf99747e9c0eff46e4e02cee8f1f37d6552b0) | `hydrus: 475 -> 476`                                                      |
| [`265e5723`](https://github.com/NixOS/nixpkgs/commit/265e57233dfcb2f213094126779812a1725ca7fa) | `hydrus: 474 -> 475`                                                      |
| [`dc07aeb3`](https://github.com/NixOS/nixpkgs/commit/dc07aeb38ddb41a68bf22969e9bce40ae9d4f73b) | `python3Packages.mkdocs-material: init at 8.2.5`                          |
| [`6b5006b2`](https://github.com/NixOS/nixpkgs/commit/6b5006b249f007141692a3f294b01b13414c7516) | `Revert "rust: run update-hashes.sh to update hashes"`                    |
| [`0f89cfb3`](https://github.com/NixOS/nixpkgs/commit/0f89cfb39574362b0065410d58ebcea5cf90daf1) | `prometheus-apcupsd-exporter: 0.2.0 -> 0.3.0`                             |
| [`b250ca54`](https://github.com/NixOS/nixpkgs/commit/b250ca540ef8c47b67c4a93f4537d392377eacb4) | `prometheus-wireguard-exporter: 3.5.0 -> 3.6.2`                           |
| [`427e1072`](https://github.com/NixOS/nixpkgs/commit/427e1072fbbb3e6f33a97340ad298f534758c2e5) | `alfis: 0.6.10 -> 0.6.11`                                                 |
| [`25e7331e`](https://github.com/NixOS/nixpkgs/commit/25e7331ebfd2e0ca87c65a4c09219b5e8721d34c) | `virtiofsd: 1.0.0 -> 1.1.0`                                               |
| [`a0f5e025`](https://github.com/NixOS/nixpkgs/commit/a0f5e0257f0c978ec47d935c6fdf2ff58ef07a9c) | `toml2json: init at 1.3.0`                                                |
| [`c1ff5908`](https://github.com/NixOS/nixpkgs/commit/c1ff59080e78d6746efc45e624935bcf0fa0a38b) | `materialize: 0.15.0 -> 0.17.0`                                           |
| [`852c8ab3`](https://github.com/NixOS/nixpkgs/commit/852c8ab3d06308804a5295ba7ff829bc78eda105) | `rust: run update-hashes.sh to update hashes`                             |
| [`e163db34`](https://github.com/NixOS/nixpkgs/commit/e163db3404264e4acc113f497c9502b707f8caba) | `python310Packages.pysaml2: 7.1.1 -> 7.1.2`                               |
| [`5b032109`](https://github.com/NixOS/nixpkgs/commit/5b0321098a9d07db3d781957b59491414614e13c) | `python310Packages.scikit-hep-testdata: 0.4.11 -> 0.4.12`                 |
| [`16bec16f`](https://github.com/NixOS/nixpkgs/commit/16bec16f5ab8b09aadffb01e6d202e8082401dc4) | `ko: 0.11.0 -> 0.11.1`                                                    |
| [`53e4f8d2`](https://github.com/NixOS/nixpkgs/commit/53e4f8d2376c68dfdd614a123d5da0a8b10cf3be) | `python310Packages.typed-settings: 0.11.1 -> 1.0.0`                       |
| [`21c4a5dd`](https://github.com/NixOS/nixpkgs/commit/21c4a5ddb0a52964453fcec29b05c57a092cda92) | `python310Packages.aiobotocore: 2.1.1 -> 2.1.2`                           |
| [`fd609f92`](https://github.com/NixOS/nixpkgs/commit/fd609f92336b4c1677697b09202cfc1439f35aec) | `nixos services.xserver.displayManager.session: drop type`                |
| [`d7f09c6e`](https://github.com/NixOS/nixpkgs/commit/d7f09c6eaa57492df2e93dbec8a7fae1f0a9c6a0) | `circup: remove whitespaces`                                              |
| [`13f95830`](https://github.com/NixOS/nixpkgs/commit/13f95830f43e683b8472b8387d32061f97bc4098) | `mysocketw: update meta`                                                  |
| [`5bc6e362`](https://github.com/NixOS/nixpkgs/commit/5bc6e362e6ac62e2349190333b475325f6e90a8d) | `python3Packages.wrf-python: remove duplicate input`                      |
| [`71f27edc`](https://github.com/NixOS/nixpkgs/commit/71f27edcf38a22cee4df87771c1f1e0573cab228) | `python3Packages.wrf-python: add pythonImportsCheck`                      |
| [`9c5285c7`](https://github.com/NixOS/nixpkgs/commit/9c5285c7810062bfa22c35bd4b3e573c787064e2) | `python3Packages.archinfo: 9.1.11752 -> 9.1.12332`                        |
| [`1885dbf3`](https://github.com/NixOS/nixpkgs/commit/1885dbf32596733a1b430934f0644f01d29a9e0a) | `nextcloud-client: 3.4.3 -> 3.4.4`                                        |
| [`a1beec32`](https://github.com/NixOS/nixpkgs/commit/a1beec3269f8e47800cc373ade065f1f8b70c308) | `python3Packages.angrop: 9.1.11752 -> 9.1.12332`                          |
| [`ca659fc2`](https://github.com/NixOS/nixpkgs/commit/ca659fc2368d663c51c0942ba39565f4bdc610eb) | `python3Packages.angr: 9.1.11752 -> 9.1.12332`                            |
| [`adda1660`](https://github.com/NixOS/nixpkgs/commit/adda1660e45aa9076b94b4cf5b467f584f075827) | `python3Packages.cle: 9.1.11752 -> 9.1.12332`                             |
| [`aafde323`](https://github.com/NixOS/nixpkgs/commit/aafde323d2e517f6b87bac4288719d5742102ecd) | `python3Packages.claripy: 9.1.11752 -> 9.1.12332`                         |
| [`f96ed6b1`](https://github.com/NixOS/nixpkgs/commit/f96ed6b1ae6835474b2f1009b66a0ec5a1b28b59) | `python3Packages.pyvex: 9.1.11752 -> 9.1.12332`                           |
| [`03650e56`](https://github.com/NixOS/nixpkgs/commit/03650e56157b63223559808832b02be4b5f9f222) | `python3Packages.ailment: 9.1.11752 -> 9.1.12332`                         |
| [`ec0f4c90`](https://github.com/NixOS/nixpkgs/commit/ec0f4c9069629c0174890af11425c44934545418) | `corerad: 1.0.0 -> 1.1.0`                                                 |
| [`c29f879d`](https://github.com/NixOS/nixpkgs/commit/c29f879db3fc8cd6ba305b79539bf185a200e8e3) | `pflask: 2015-12-17 -> 2018-01-23`                                        |
| [`ad5808a7`](https://github.com/NixOS/nixpkgs/commit/ad5808a75a83f5066a05cbcf5a88301ea0412a93) | `python310Packages.wrf-python: 1.3.2.6 -> 1.3.3`                          |
| [`9b2a36b8`](https://github.com/NixOS/nixpkgs/commit/9b2a36b85ee0578c6de57744b5086a4a26c24546) | `python310Packages.types-tabulate: 0.8.5 -> 0.8.6`                        |
| [`d3d385b9`](https://github.com/NixOS/nixpkgs/commit/d3d385b9d7ce891ebe1866b7aaa815f15952595a) | `python310Packages.types-pytz: 2021.3.5 -> 2021.3.6`                      |
| [`364ab1f8`](https://github.com/NixOS/nixpkgs/commit/364ab1f897d89487c3c9710046017a50b5c61637) | `ktlint: 0.44.0 -> 0.45.0`                                                |
| [`5679b2b6`](https://github.com/NixOS/nixpkgs/commit/5679b2b6987329910aea97458c4fa01e62f1e340) | `nixos-rebuild: add installer test to passthru.tests`                     |
| [`cb7bc7c6`](https://github.com/NixOS/nixpkgs/commit/cb7bc7c60f39e6ebe8bad32720ff3548618b4d97) | `nixos-rebuild: Print commands as they are run on verbose flag`           |
| [`ed5687d1`](https://github.com/NixOS/nixpkgs/commit/ed5687d165e9be5c2ddbddf1f3f6135c7fbc7867) | `libressl_3_2: add alias marking end-of-life`                             |
| [`a672df20`](https://github.com/NixOS/nixpkgs/commit/a672df209eb1dfeabc243949dd9d508f53b85ae4) | `goreman: 0.3.9 -> 0.3.11 (#163805)`                                      |
| [`442c54c4`](https://github.com/NixOS/nixpkgs/commit/442c54c4754971ff27f1fd5a96601f766ddf9295) | `awsebcli: fixup!`                                                        |
| [`90fdf944`](https://github.com/NixOS/nixpkgs/commit/90fdf944bd61a2bf6530259f75a30c07b59a3d47) | `shopify-cli: init at 2.14.0`                                             |
| [`12ddfe6b`](https://github.com/NixOS/nixpkgs/commit/12ddfe6bb8d3d99e37671c918374be8557e9f558) | `golangci-lint: 1.44.2 -> 1.45.0`                                         |
| [`23f2f31d`](https://github.com/NixOS/nixpkgs/commit/23f2f31dfbc361064f938393ba7a4aeee760c449) | `python310Packages.aws-lambda-builders: 1.13.0 -> 1.14.0`                 |
| [`0131290c`](https://github.com/NixOS/nixpkgs/commit/0131290c87087491848e3a2ac992def88bd271bb) | `rizin: fix typo paraemter -> parameter`                                  |
| [`21656462`](https://github.com/NixOS/nixpkgs/commit/21656462ce82a891f6a3f0ac7aa2e48a0ccda779) | `tab: 8.0 -> 9.0`                                                         |
| [`5cff7cb9`](https://github.com/NixOS/nixpkgs/commit/5cff7cb98ee802f9fc2780a6a039f562e0bf3d91) | `python3Packages.xhtml2pdf: 0.2.5 -> 0.2.6`                               |
| [`3de1c051`](https://github.com/NixOS/nixpkgs/commit/3de1c0516f8b6f30fb1533dbab08eb1111c0cd12) | `open-music-kontrollers: init`                                            |
| [`249efba2`](https://github.com/NixOS/nixpkgs/commit/249efba24469d11921363962bf08705cb931d72f) | `metasploit: 6.1.32 -> 6.1.34`                                            |
| [`4c3fe51e`](https://github.com/NixOS/nixpkgs/commit/4c3fe51e6aa56811256a4b67130880973640b669) | `checkov: 2.0.971 -> 2.0.975`                                             |
| [`161b19e0`](https://github.com/NixOS/nixpkgs/commit/161b19e07ee95943bd7b5e7da4c9524b75f80cf3) | `python3Packages.flake8-blind-except: add pythonImportsCheck`             |
| [`6c1085a6`](https://github.com/NixOS/nixpkgs/commit/6c1085a647f879acf3c43c6f6562097165d7ac46) | `python3Packages.graphql-subscription-manager: add format`                |
| [`fc8f0a6f`](https://github.com/NixOS/nixpkgs/commit/fc8f0a6f0c39a36fd36a5d85df057ef1804cb9f4) | `gruut: 2.2.0 -> 2.2.3`                                                   |
| [`1f60c633`](https://github.com/NixOS/nixpkgs/commit/1f60c6334e8b491c4d05ee6941f4a432cacb4935) | `python3Packages.pyclip: disable on older Python releases`                |