### PR TITLE
chore(flake/home-manager): `a4b0a3fa` -> `32e433d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1647570173,
-        "narHash": "sha256-paZtVviwGeVkaiJktFoIFVOEQIcdGriQTKjmdUzA66E=",
+        "lastModified": 1647571652,
+        "narHash": "sha256-kDmwh5Nc99B4k8k4OnN1hoRVmU4BdWnKb0zL87K3WaA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a4b0a3faa4055521f2a20cfafe26eb85e6954751",
+        "rev": "32e433d07d56202b7ce91dadfd2a313ee90aef21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                               |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`32e433d0`](https://github.com/nix-community/home-manager/commit/32e433d07d56202b7ce91dadfd2a313ee90aef21) | `nix: add structural settings (#2718)`       |
| [`590da80c`](https://github.com/nix-community/home-manager/commit/590da80ceb32edff0bd44b0c3e0fa99eb8173825) | `neovim/coc: fix loading CoC plugin (#2801)` |