### PR TITLE
chore(flake/home-manager): `32e433d0` -> `e2a85ac4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1647571652,
-        "narHash": "sha256-kDmwh5Nc99B4k8k4OnN1hoRVmU4BdWnKb0zL87K3WaA=",
+        "lastModified": 1647572216,
+        "narHash": "sha256-HDOQ/Yq1ga5mbj0eUp/f5FY96TgOxwBjTfIRGsZsAlw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "32e433d07d56202b7ce91dadfd2a313ee90aef21",
+        "rev": "e2a85ac43f06859a50d067a029f0a303c4ca5264",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                           |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`e2a85ac4`](https://github.com/nix-community/home-manager/commit/e2a85ac43f06859a50d067a029f0a303c4ca5264) | `bspwm: add alwaysResetDesktops (#2785)` |