### PR TITLE
chore(flake/home-manager): `7cf15b19` -> `e96fc6d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1647644064,
-        "narHash": "sha256-RdZl1uIZslc8ViQwBJAJbkKpJN8J3y/U4xjZuLyFaMY=",
+        "lastModified": 1647731541,
+        "narHash": "sha256-WQG5HRq9uylQV0urLuy/RKzoXAaBPhWUrYdEGnRDCxM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7cf15b19a931b99f9a918887fc488d577fd07516",
+        "rev": "e96fc6d8f90c96320a9c7e6663b734ab50ec1794",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                            |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`e96fc6d8`](https://github.com/nix-community/home-manager/commit/e96fc6d8f90c96320a9c7e6663b734ab50ec1794) | `tmux: add notes to existing keybindings (#2540) (#2742)` |