### PR TITLE
chore(flake/home-manager): `e96fc6d8` -> `0fad959d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1647731541,
-        "narHash": "sha256-WQG5HRq9uylQV0urLuy/RKzoXAaBPhWUrYdEGnRDCxM=",
+        "lastModified": 1647755261,
+        "narHash": "sha256-qsrPnMlonGNIKskMqD5p1HG1HhBaZXUi3ta7l2Wtb4Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e96fc6d8f90c96320a9c7e6663b734ab50ec1794",
+        "rev": "0fad959df8076766d4259c1f76750f892a0cafa1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`0fad959d`](https://github.com/nix-community/home-manager/commit/0fad959df8076766d4259c1f76750f892a0cafa1) | `stalebot: disable auto-closing of issues and pull requests (#2800)` |