### PR TITLE
chore(flake/home-manager): `0fad959d` -> `57476b5d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1647755261,
-        "narHash": "sha256-qsrPnMlonGNIKskMqD5p1HG1HhBaZXUi3ta7l2Wtb4Q=",
+        "lastModified": 1647797554,
+        "narHash": "sha256-V2szrnWB8hscmN86ENXXhzRJ09XEld9Ck+Os49LdqcM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0fad959df8076766d4259c1f76750f892a0cafa1",
+        "rev": "57476b5d286aa9416ed4472d19d37bbd93d30191",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`57476b5d`](https://github.com/nix-community/home-manager/commit/57476b5d286aa9416ed4472d19d37bbd93d30191) | `xcursor: remove warning and use mkDefault for GTK options (#2808)` |