### PR TITLE
chore(flake/home-manager): `46dc2e5d` -> `835797f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1647807776,
-        "narHash": "sha256-cdURsjVEAFD23Na6mhzCM/6YUyA0F6CZAO/6fqV05Y4=",
+        "lastModified": 1647821523,
+        "narHash": "sha256-NAIY357pAOcxK6bAt83kKEJ2LxZhLCiPIlmQ2iTQbk4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "46dc2e5d9f55164d28705facd0f9a3b4c0d2807a",
+        "rev": "835797f3a4a59459a316ae8d4ab91fa59faf61a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`835797f3`](https://github.com/nix-community/home-manager/commit/835797f3a4a59459a316ae8d4ab91fa59faf61a4) | `xsession.pointerCursor: escape special characters in the cursor path (#2805)` |