### PR TITLE
chore(flake/nixpkgs): `e2f381b2` -> `1ee6a7ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1647808254,
-        "narHash": "sha256-yajQF+iTkFdvorc/OsEgC1+HLPT/uwLYE4ds8HAURkA=",
+        "lastModified": 1647853106,
+        "narHash": "sha256-k8nKfLMu9gAiCQji/0HAYoW4RJ7ydmRS8eRAdw6kayM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2f381b2f1879ad6d68be5a9e9e6e3288529bfaf",
+        "rev": "1ee6a7edf163cb07923c6f0d59ac94eab02ede73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                            |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`1ee6a7ed`](https://github.com/NixOS/nixpkgs/commit/1ee6a7edf163cb07923c6f0d59ac94eab02ede73) | `php74Extensions.blackfire: 1.74.0 -> 1.75.0`             |
| [`a30cb0ea`](https://github.com/NixOS/nixpkgs/commit/a30cb0ea42f0bb26d20937bf76ffe020aa5b8812) | `ocamlPackages.gapi_ocaml: 0.4.1 -> 0.4.2`                |
| [`0e882f0d`](https://github.com/NixOS/nixpkgs/commit/0e882f0d2bdc054aede0e552daa4fa384d24a873) | `sonobuoy: 0.56.2 -> 0.56.3`                              |
| [`92a720cb`](https://github.com/NixOS/nixpkgs/commit/92a720cbacbdbbdf4be68eb1d0c2f2b83b226406) | `ci: add warning to actions with writeable GITHUB_TOKEN`  |
| [`a88c8d13`](https://github.com/NixOS/nixpkgs/commit/a88c8d132a905393aefd344718fde02b5e4722c4) | `python3Packages.youtube-search-python: add format`       |
| [`75501aff`](https://github.com/NixOS/nixpkgs/commit/75501aff5a660e09fe1328dc8f6b8900fb6c71d3) | `linuxPackages.lttng-modules: 2.13.1 -> 2.13.2`           |
| [`57fefcdf`](https://github.com/NixOS/nixpkgs/commit/57fefcdf60c4b8d021db89c4d9920ad5541451ff) | `terraform-providers: update 2022-03-21`                  |
| [`aba19ebf`](https://github.com/NixOS/nixpkgs/commit/aba19ebf98ec6d5ab8536fd3f9d6a220818d2554) | `python310Packages.youtube-search-python: 1.6.2 -> 1.6.3` |
| [`ddf002c0`](https://github.com/NixOS/nixpkgs/commit/ddf002c0ac03024d317bf1149290aacfe967a4e6) | `mmdoc: init at 0.9.1`                                    |
| [`e34c8e48`](https://github.com/NixOS/nixpkgs/commit/e34c8e48538747821485e317b53dc16ec6872b31) | `python3Packages.pyaussiebb: 0.0.13 -> 0.0.14`            |
| [`00796dcc`](https://github.com/NixOS/nixpkgs/commit/00796dccffa01959c9a53604ef569acc97cb2a68) | `python3Packages.aioridwell: 2021.12.2 -> 2022.03.0`      |
| [`d386210a`](https://github.com/NixOS/nixpkgs/commit/d386210a918155d448e56c0a412fa5180d2a253f) | `python3Packages.slixmpp: 1.8.0.1 -> 1.8.1`               |
| [`659f0ef7`](https://github.com/NixOS/nixpkgs/commit/659f0ef7df1c73c5cc50e3de10249e14f3cbcba2) | `allure: init at 2.17.3`                                  |
| [`0018daf5`](https://github.com/NixOS/nixpkgs/commit/0018daf5b9c4bbe67253c903b414e41b4f89eb31) | `distrobox: 1.2.13 -> 1.2.14`                             |
| [`2593530f`](https://github.com/NixOS/nixpkgs/commit/2593530f3f1233c2d12604a7a560113b729e87f0) | `minio-certgen: 1.1.0 -> 1.2.0`                           |
| [`ed81545d`](https://github.com/NixOS/nixpkgs/commit/ed81545df5083a95ddcfbff0c029774ecb0326bd) | `squashfsTools: 4.5 -> 4.5.1`                             |
| [`34c841ab`](https://github.com/NixOS/nixpkgs/commit/34c841ab46ce260ab6d75bdf74d0f27db5d3ca15) | `python3Packages.myfitnesspal: add toPythonApplication`   |
| [`649b74f4`](https://github.com/NixOS/nixpkgs/commit/649b74f4558fc50d67ab826aee15e9815a504f03) | `skaffold: 1.36.0 -> 1.37.0`                              |
| [`9b9db934`](https://github.com/NixOS/nixpkgs/commit/9b9db934cd0a6547afdd1665fc59184146b9278d) | `singularity: 3.8.6 -> 3.8.7`                             |
| [`aeba6f56`](https://github.com/NixOS/nixpkgs/commit/aeba6f567558a8bdcec9b032cacaea2a0d306637) | `opentelemetry-collector-contrib: 0.46.0 -> 0.47.0`       |
| [`de62c2c1`](https://github.com/NixOS/nixpkgs/commit/de62c2c1f498c62b502c97c99e85aa285446ed52) | `furnace: 0.5.6 -> 0.5.8`                                 |