### PR TITLE
chore(flake/home-manager): `bbc5e0c1` -> `80b43606`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1647901536,
-        "narHash": "sha256-UsznQu7EmpZRQoRKPWYR/ekQl0Ns73FChvMA1/hvfcI=",
+        "lastModified": 1647903177,
+        "narHash": "sha256-9aWSpW/F8POA/7cuVpoqhVGfjAgcGRIinwxUaXmUpkk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bbc5e0c1e1f511a41618afc028bd93c626ea6dbb",
+        "rev": "80b4360678fa7890964ba8e40a722985bf8d107e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                                                                  |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
| [`80b43606`](https://github.com/nix-community/home-manager/commit/80b4360678fa7890964ba8e40a722985bf8d107e) | `i3/sway: improve i3.nix to handle options as list like in sway, adjusted functions for less new-lines (#2314)` |