### PR TITLE
chore(flake/home-manager): `80b43606` -> `48a1584d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1647903177,
-        "narHash": "sha256-9aWSpW/F8POA/7cuVpoqhVGfjAgcGRIinwxUaXmUpkk=",
+        "lastModified": 1647979468,
+        "narHash": "sha256-mavkG6rOyM5NPcb/hEmZQwRZaJeaa7XFfWTWf0TNCo0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "80b4360678fa7890964ba8e40a722985bf8d107e",
+        "rev": "48a1584d8ba427dd9d74e2b2b842c70a6dd9c4fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`48a1584d`](https://github.com/nix-community/home-manager/commit/48a1584d8ba427dd9d74e2b2b842c70a6dd9c4fa) | `i3-sway: Empty set argument was passed to wrong function (#2819)` |