### PR TITLE
chore(flake/nixpkgs): `1ee6a7ed` -> `7aa37733`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1647853106,
-        "narHash": "sha256-k8nKfLMu9gAiCQji/0HAYoW4RJ7ydmRS8eRAdw6kayM=",
+        "lastModified": 1648034513,
+        "narHash": "sha256-EMeo6i6B3aTBbAhfFYlr6OWCLcXbiePsQTDeAysnOaA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1ee6a7edf163cb07923c6f0d59ac94eab02ede73",
+        "rev": "7aa377336ec93fbb70150804679d222f14c5e87a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`a701c092`](https://github.com/NixOS/nixpkgs/commit/a701c09286bfdbdea027ef5c0fc7b414587c0a43) | `nixos-rebuild: use log instead of echo, always print to stderr`                                 |
| [`f4998c54`](https://github.com/NixOS/nixpkgs/commit/f4998c542d68a8a6e3d345d5c106e5915f430a16) | `ocaml-ng.ocamlPackages_4_14: 4.14.0-β1 → 4.14.0-rc2`                                            |
| [`0b12dcaf`](https://github.com/NixOS/nixpkgs/commit/0b12dcaf81879e39f6c1bdd151e80ba21946e2ed) | `kde-rounded-corners: unstable-2021-11-06 -> 0.1.1`                                              |
| [`2e7cf56e`](https://github.com/NixOS/nixpkgs/commit/2e7cf56e4509ba0341c282499c795fd8297369d6) | `kde/plasma5: 5.24.0 -> 5.24.3`                                                                  |
| [`4789fec7`](https://github.com/NixOS/nixpkgs/commit/4789fec756f307976a2c19852772bf48184c037c) | `python3Packages.pyzbar: init at 0.1.9 (#164944)`                                                |
| [`9215ee68`](https://github.com/NixOS/nixpkgs/commit/9215ee680573f156412189597827fd6e5744a59b) | `python39Packages.pycurl: remove unused nose, update meta`                                       |
| [`b22a1d15`](https://github.com/NixOS/nixpkgs/commit/b22a1d153080add8ef5604a0698ad933c9f7418e) | `wxwidgets: fix building on darwin`                                                              |
| [`c4defd8a`](https://github.com/NixOS/nixpkgs/commit/c4defd8a12839ce3ba46d2a8ee4f49ec536b9f82) | `protoc-gen-go: 1.27.1 -> 1.28.0`                                                                |
| [`ddcca205`](https://github.com/NixOS/nixpkgs/commit/ddcca2059410bd85e2058e285208763ba215dfe6) | `n8n: 0.168.1 → 0.169.0 (#165066)`                                                               |
| [`2bf50134`](https://github.com/NixOS/nixpkgs/commit/2bf50134c534e2b3ecd259ed114cbb8c31ee5b35) | `python39Packages.h2: add SuperSandro2000 as maintainer`                                         |
| [`0880b7ea`](https://github.com/NixOS/nixpkgs/commit/0880b7eae1fae86258496af8ebf4441d13d9d31c) | `corrscope: 0.7.1 -> 0.8.0`                                                                      |
| [`354e855d`](https://github.com/NixOS/nixpkgs/commit/354e855d60634566c9c16513ac15eb1460550826) | `python3.pkgs.pint-pandas: init at 0.2 (#165138)`                                                |
| [`f8990c1b`](https://github.com/NixOS/nixpkgs/commit/f8990c1bd615b5697d6fd1f26ea4dee8302c2616) | `wireplumber: 0.4.8 → 0.4.9`                                                                     |
| [`b5908fb2`](https://github.com/NixOS/nixpkgs/commit/b5908fb2681deeab457c51b6413cef0a72770c81) | `python39Packages.flask: update homepage`                                                        |
| [`80e7ea13`](https://github.com/NixOS/nixpkgs/commit/80e7ea13fcaf5cfd59de5be5f586a7e1db71cbe7) | `python39Packages.certifi: disable on python older 3.5, add SuperSandro2000 as maintainer`       |
| [`61f79889`](https://github.com/NixOS/nixpkgs/commit/61f798890ec12e5fe0adb8959070cab7c34f3fd4) | `souffle: 2.0.2 -> 2.2 (#164103)`                                                                |
| [`3bf28598`](https://github.com/NixOS/nixpkgs/commit/3bf28598c18a52ef0e184e70f0e6def2b8f1a67a) | `autoadb: init at unstable-2020-06-01 (#165244)`                                                 |
| [`247c94fc`](https://github.com/NixOS/nixpkgs/commit/247c94fc6a90f0c5bc1a0cf1725bcb6c061c8f32) | `terraform-providers: update 2022-03-23`                                                         |
| [`d0d06a70`](https://github.com/NixOS/nixpkgs/commit/d0d06a70d589bbf6e90f8f48bad94640c5efef5e) | `python39Packages.click: add SuperSandro2000 as maintainer`                                      |
| [`e0bd1283`](https://github.com/NixOS/nixpkgs/commit/e0bd12836bb36d211798b9221e0d7ef976fa447f) | `udis86: 1.7.2 -> unstable-2014-12-25, patch for python3 builds (#165177)`                       |
| [`8e9b5c9f`](https://github.com/NixOS/nixpkgs/commit/8e9b5c9f88bb5fb68d44ad94e8f03a6bd42d7263) | `katago: 1.10.0 -> 1.11.0 (#165090)`                                                             |
| [`f40327ce`](https://github.com/NixOS/nixpkgs/commit/f40327ce40985c5b765b4b5277471330263f84ed) | `hut: init at unstable-2022-03-02 (#162663)`                                                     |
| [`e9c91a13`](https://github.com/NixOS/nixpkgs/commit/e9c91a137a4aa8b35a3cdb01a3fc10e8885d1470) | `gotktrix: init at 0.1.1 (#162571)`                                                              |
| [`607723da`](https://github.com/NixOS/nixpkgs/commit/607723da2450a30d3cd98c6dcb9e3d6a572734de) | `python39Packages.brotli: update comments, add SuperSandro2000 as maintainer`                    |
| [`9994b33f`](https://github.com/NixOS/nixpkgs/commit/9994b33f0e82661ab1d2a837ad2da42d3e121e4c) | `biblatex-check: 2019-11-09 -> 1.0.1 (#157597)`                                                  |
| [`fab200cb`](https://github.com/NixOS/nixpkgs/commit/fab200cb0afee7933f1937d01772232c26838732) | `python39Packages.parver: drop version constraint on arpeggio, add SuperSandro200 as maintainer` |
| [`01ed018d`](https://github.com/NixOS/nixpkgs/commit/01ed018d6de1a729b3d2ed2b245850c6c1b3f2a1) | `python310Packages.arpeggio: 1.10.2 -> 2.0.0, add SuperSandro2000 as maintainer`                 |
| [`964b4a6b`](https://github.com/NixOS/nixpkgs/commit/964b4a6bd2f7be1090bffb41237141836ed97078) | `tree-sitter: update grammars`                                                                   |
| [`edbaf11e`](https://github.com/NixOS/nixpkgs/commit/edbaf11e94aa603085a5fa61aa760595c5392bca) | `tree-sitter: unquote latest version in update script`                                           |
| [`ecacb5de`](https://github.com/NixOS/nixpkgs/commit/ecacb5de41c8d8d7aa95b5a3d7bb5ca68b362058) | `gitkraken: 8.3.0 -> 8.3.3 (#162753)`                                                            |
| [`9eeffe65`](https://github.com/NixOS/nixpkgs/commit/9eeffe65addea33801bac5fcf911c452cc67beed) | `gpu-screen-recorder: init at 1.0.0`                                                             |
| [`4f1949bc`](https://github.com/NixOS/nixpkgs/commit/4f1949bc59173a2b4d29046891d75ebc0982b4a4) | `pxz: use upstream's Makefile (#165264)`                                                         |
| [`713648a1`](https://github.com/NixOS/nixpkgs/commit/713648a19b149484625fb88ab97c51b55de1cb93) | `boost: unbreak build for 1.65 and 1.66 (#163216)`                                               |
| [`e67d3a3e`](https://github.com/NixOS/nixpkgs/commit/e67d3a3e141cddf2b46567cefa9f33cb86d78d18) | `prusa-slicer: 2.4.0 -> 2.4.1 (#163933)`                                                         |
| [`f3f02bff`](https://github.com/NixOS/nixpkgs/commit/f3f02bff9db946eb1ded5c1616ce2b6c225ca071) | `LAStools: 2.0.0 -> 2.0.1`                                                                       |
| [`6324abc9`](https://github.com/NixOS/nixpkgs/commit/6324abc93e79839a2952ead746a3d202de78eda0) | `libpng_apng: drop`                                                                              |
| [`b7639c40`](https://github.com/NixOS/nixpkgs/commit/b7639c40d1f249a4961a663d768a2a55e1a052d6) | `essentia-extractor: fix eval on darwin`                                                         |
| [`3ec7f8d4`](https://github.com/NixOS/nixpkgs/commit/3ec7f8d487042210c6861ea618aef73d932faac5) | `firefox: set consistent remoting name`                                                          |
| [`16129972`](https://github.com/NixOS/nixpkgs/commit/16129972c067a3142670dd74d60a707f3a9d1b56) | `firefox-bin: 98.0.1 -> 98.0.2`                                                                  |
| [`06518a49`](https://github.com/NixOS/nixpkgs/commit/06518a49919e0d86b3e2845402eb3103679600c6) | `firefox: 98.0.1 -> 98.0.2`                                                                      |
| [`f8a02df9`](https://github.com/NixOS/nixpkgs/commit/f8a02df9ebb13722aecdeac23953eca74e10265c) | `python310Packages.mypy-boto3-builder: 7.3.0 -> 7.4.1`                                           |
| [`25e7d380`](https://github.com/NixOS/nixpkgs/commit/25e7d38000b7dd99ee7782befc25de41a1558c5b) | `act: 0.2.25 -> 0.2.26`                                                                          |
| [`7f08e0ca`](https://github.com/NixOS/nixpkgs/commit/7f08e0ca6d029a0b54ba124f01da8731af68a74e) | `haskellPackages.hoogleLocal: build database locally`                                            |
| [`44d602cc`](https://github.com/NixOS/nixpkgs/commit/44d602cc8f13849187d5bdca9f0b1cb270ef97e4) | `plasma-systemmonitor: add required dependencies`                                                |
| [`22bf6be3`](https://github.com/NixOS/nixpkgs/commit/22bf6be3e06a6c658d679eb0147975190cb837a3) | `linuxPackages.rtl8814au: 2021-10-25 -> 2022-02-21`                                              |
| [`252608fb`](https://github.com/NixOS/nixpkgs/commit/252608fbbbd6093a1cc92018e80d66dd7bcee01e) | `prometheus-cpp: fix use with CMake and clean up`                                                |
| [`3ff5f0eb`](https://github.com/NixOS/nixpkgs/commit/3ff5f0eb764e42d922f22e7007db67c9bf23ae08) | `spidermonkey: use the same LLVM as rustc`                                                       |
| [`04f60d49`](https://github.com/NixOS/nixpkgs/commit/04f60d49c8dbab8437f37db627da2367fed68d23) | `nixVersion.unstable: pre20220311 -> pre20220322`                                                |
| [`c573e3ea`](https://github.com/NixOS/nixpkgs/commit/c573e3eaa8717fbabab3f9a58bfed637fb441eac) | `qemu: support running Linux 5.17 on aarch64-darwin`                                             |
| [`d1bb89b5`](https://github.com/NixOS/nixpkgs/commit/d1bb89b5cbe59dd575c49cd3229ef08b88ea1067) | `python310Packages.ibm-cloud-sdk-core: 3.15.0 -> 3.15.1`                                         |
| [`40b9dfc7`](https://github.com/NixOS/nixpkgs/commit/40b9dfc73958dc311c1b1d197658bf204868080b) | `syft: 0.41.6 -> 0.42.2`                                                                         |
| [`dd9d0d51`](https://github.com/NixOS/nixpkgs/commit/dd9d0d51bcb91b4096aca0c396c14f3f382b091a) | `ugrep: 3.7.1 -> 3.7.6`                                                                          |
| [`f76e48f5`](https://github.com/NixOS/nixpkgs/commit/f76e48f569c5a56b57b067430e45e693a0154690) | `tilt: 0.25.3 -> 0.26.2`                                                                         |
| [`f8f5522e`](https://github.com/NixOS/nixpkgs/commit/f8f5522e9d6bf01a598effc6f50ab856bc81a2a4) | `keyscope: 1.1.0 -> 1.2.2`                                                                       |
| [`4ff38ab6`](https://github.com/NixOS/nixpkgs/commit/4ff38ab6e9f8255cc84c183488eba8ae836d9a54) | `cargo-supply-chain: 0.2.0 -> 0.3.1`                                                             |
| [`ffdd9491`](https://github.com/NixOS/nixpkgs/commit/ffdd9491876fa43a888d3be69ac1a733b4277d5c) | `cargo-tarpaulin: 0.19.1 -> 0.20.0`                                                              |
| [`6d41c4ba`](https://github.com/NixOS/nixpkgs/commit/6d41c4ba708555a667fff65da7a367d1e5f447f2) | `i3wsr: 2.1.0 -> 2.1.1`                                                                          |
| [`7c44799c`](https://github.com/NixOS/nixpkgs/commit/7c44799cd524e1e895386ba0016e510a0d8dd644) | `CODEOWNERS: formatting`                                                                         |
| [`54041b9b`](https://github.com/NixOS/nixpkgs/commit/54041b9b84f8e43e612f172efe63eff0ab355009) | `CODEOWNERS: remove @Kloenk from systemd files`                                                  |
| [`d220f223`](https://github.com/NixOS/nixpkgs/commit/d220f223ec66f8eb71a1e96c6c859e3918a67ee1) | `CODEOWNERS: use correct paths for systemd`                                                      |
| [`a3fcf30d`](https://github.com/NixOS/nixpkgs/commit/a3fcf30d67e18a91c257f063f1c72e75a3a4c363) | `squeak: fix a src URL, transition meta to OpenSmalltalk`                                        |
| [`0cb5668d`](https://github.com/NixOS/nixpkgs/commit/0cb5668d6503aaff7a3bc0a92153256609630f46) | `squeak: 4.10.2.2614 -> 5.3-19459`                                                               |
| [`94fa436e`](https://github.com/NixOS/nixpkgs/commit/94fa436e1b208d5c5dc4c2afa2f4ccbc3a2122ca) | `Zettlr: 2.2.3 -> 2.2.4`                                                                         |
| [`1bf88c64`](https://github.com/NixOS/nixpkgs/commit/1bf88c64d8af2c861b19bc1a413e00eb086a64eb) | `qscintilla: 2.13.1 -> 2.13.2`                                                                   |
| [`3fcee877`](https://github.com/NixOS/nixpkgs/commit/3fcee877c43d5f451da06e9ea359241bac9647c7) | `python310Packages.pubnub: 6.1.0 -> 6.2.0`                                                       |
| [`611e9302`](https://github.com/NixOS/nixpkgs/commit/611e9302f9b33ca72cfce239445444aad3653b47) | `nixos-rebuild: add --no-flake switch`                                                           |
| [`ea822db5`](https://github.com/NixOS/nixpkgs/commit/ea822db5c5e854225abb588bf4d016978c9b70f3) | `steampipe: 0.13.2 -> 0.13.3`                                                                    |
| [`c7172046`](https://github.com/NixOS/nixpkgs/commit/c7172046c7aa28bce8ce3f024d74518669cedfbe) | `nixos-rebuild: add meta & add Profpatsch as maintainer`                                         |
| [`d3a855b9`](https://github.com/NixOS/nixpkgs/commit/d3a855b9b000ced9f5f8ffed8d4eb957a6c5a4ce) | `stunnel: 5.62 -> 5.63`                                                                          |
| [`488869f6`](https://github.com/NixOS/nixpkgs/commit/488869f602eea53e3fe08c89bdb655811877cde0) | `nixos-rebuild: support --quiet, --print-build-logs`                                             |
| [`fd620c8d`](https://github.com/NixOS/nixpkgs/commit/fd620c8da1ac24f3dc4366a01d9570e87ffac16e) | `qgis: 3.24.0 -> 3.24.1`                                                                         |
| [`826febf7`](https://github.com/NixOS/nixpkgs/commit/826febf74f022d51ec6c539b05259e9eb2611df9) | `qgis-ltr: 3.22.4 -> 3.22.5`                                                                     |
| [`de4a69b2`](https://github.com/NixOS/nixpkgs/commit/de4a69b2de1f157989fb1780d89d8db004169bd1) | `nixos/tests/avahi: Fix running background command`                                              |
| [`5af555af`](https://github.com/NixOS/nixpkgs/commit/5af555af48164cf4d0b8326468c7d5a499b00e4f) | `graphite-gtk-theme: unstable-2022-02-04 -> 2022-03-22`                                          |
| [`be37c9a4`](https://github.com/NixOS/nixpkgs/commit/be37c9a4e1466e9e1610c83ab201279a31325f50) | `graphite-gtk-theme: add update script`                                                          |
| [`a68d71c7`](https://github.com/NixOS/nixpkgs/commit/a68d71c775bed051dec17028ff85c63beebeaa6f) | `fq: 0.0.4 -> 0.0.6`                                                                             |
| [`9e533703`](https://github.com/NixOS/nixpkgs/commit/9e53370359f669ccad1f3ed569dae57fd39ac600) | `matrix-synapse: 1.54.0 -> 1.55.0`                                                               |
| [`bb82344c`](https://github.com/NixOS/nixpkgs/commit/bb82344ca6925b1b4e4a7de9465016ba40904fc3) | `python3Packages.zipstream-ng: init at 1.3.4`                                                    |
| [`c60647f5`](https://github.com/NixOS/nixpkgs/commit/c60647f50bf00af087e411a2891ce132883d6b1c) | `pr-tracker: 1.1.0 -> 1.2.0`                                                                     |
| [`1a889c09`](https://github.com/NixOS/nixpkgs/commit/1a889c097be3e0778983de446173d822be5c0634) | `ucx: 1.12.0 -> 1.12.1`                                                                          |
| [`23b9ad34`](https://github.com/NixOS/nixpkgs/commit/23b9ad346a30b89b4e080b0a062700a305a99851) | `exploitdb: 2022-03-15 -> 2022-03-22`                                                            |
| [`de096b7c`](https://github.com/NixOS/nixpkgs/commit/de096b7c8331acfea75f4d97717e25a1cd03c721) | `isso: 0.12.5 -> 0.12.6.1`                                                                       |
| [`699c3005`](https://github.com/NixOS/nixpkgs/commit/699c30056b6f278077fe21aad3d7f7336a7cc783) | `gitlab-runner: 14.8.2 -> 14.9.0`                                                                |
| [`4ceb138f`](https://github.com/NixOS/nixpkgs/commit/4ceb138f4b77e6ad5e15c372a895981d285bd5a8) | `haskellPackages.HaskellNet-SSL: mark unbroken`                                                  |
| [`086c5106`](https://github.com/NixOS/nixpkgs/commit/086c5106d1bc351caac49e8a40bb99b16182823c) | `u9fs: unstable-2020-11-21 -> unstable-2021-25`                                                  |
| [`9ff032c2`](https://github.com/NixOS/nixpkgs/commit/9ff032c2918ada79edf6598220ae4a9ff43a3462) | `simgrid: 3.30 -> 3.31`                                                                          |
| [`fd02a092`](https://github.com/NixOS/nixpkgs/commit/fd02a092d28cfc9179dd43b5296d2a1e003def38) | `u9fs: use install(1) for copying files`                                                         |
| [`168bdc3c`](https://github.com/NixOS/nixpkgs/commit/168bdc3c7d124a0b638c4648df5fa252d384f44b) | `u9fs: fix man page location`                                                                    |
| [`788b69df`](https://github.com/NixOS/nixpkgs/commit/788b69dfe731adca6fece863d151792af0f7fa0a) | `python310Packages.docplex: 2.22.213 -> 2.23.222`                                                |
| [`deab83e1`](https://github.com/NixOS/nixpkgs/commit/deab83e11674f1cfbc9d5e5626d12ed9344d8091) | `cgit-pink: init at 1.3.0`                                                                       |
| [`b4c2ffaf`](https://github.com/NixOS/nixpkgs/commit/b4c2ffaffa600ffce2121e21f65641ec92955781) | ` nixos/wg-quick: add autostart option to interfaces (#162219)`                                  |
| [`216b4f18`](https://github.com/NixOS/nixpkgs/commit/216b4f181379ad704b6102eef4ad36b4a18b2d30) | `ocenaudio: 3.11.5 -> 3.11.7`                                                                    |
| [`8ae47900`](https://github.com/NixOS/nixpkgs/commit/8ae47900166db91ce816bfa769ce930910bb2b5e) | `nuclei: 2.6.3 -> 2.6.5`                                                                         |
| [`55381a3c`](https://github.com/NixOS/nixpkgs/commit/55381a3ce18de3bc60f38990b5f3c7ddef5e6075) | `abuild: 3.7.0 -> 3.9.0`                                                                         |
| [`6d766ae8`](https://github.com/NixOS/nixpkgs/commit/6d766ae8b7961fb0ca64639d5318dd29cccc3748) | `nixos/test-driver: deduplicate VLANs`                                                           |
| [`084268aa`](https://github.com/NixOS/nixpkgs/commit/084268aab1fdf1e4bbf732acb2c1ab7ae71c159a) | `python310Packages.pyglet: 1.5.22 -> 1.5.23`                                                     |
| [`9496786b`](https://github.com/NixOS/nixpkgs/commit/9496786b36c435d3424f9f27215d87c75e14ed6e) | `cfn-nag: init at 0.8.9`                                                                         |
| [`5b1c414b`](https://github.com/NixOS/nixpkgs/commit/5b1c414be6941eebcf9a63b644f091a6bac2d5dc) | `python39Packages.sentry-sdk: 1.5.6 -> 1.5.8`                                                    |
| [`052632fd`](https://github.com/NixOS/nixpkgs/commit/052632fd15550d83fe98ed599c8504eaad67f0b5) | `nixos/iwd: workaround for race condition where wlan device disappears`                          |
| [`c7b7ad77`](https://github.com/NixOS/nixpkgs/commit/c7b7ad77985e941081dc635d39b5debb0c3155dd) | `libudev-zero: 1.0.0 -> 1.0.1`                                                                   |
| [`3031d330`](https://github.com/NixOS/nixpkgs/commit/3031d3308d0a249ed99ed31a9973447a1feab26a) | `python3Packages.dataclasses-json: 0.5.6 -> 0.5.7`                                               |
| [`37102b6b`](https://github.com/NixOS/nixpkgs/commit/37102b6bffa5e5efbb021c39f1271cf5c396a6a2) | `bookworm: 1.1.2 -> unstable-2022-01-09`                                                         |
| [`6340db62`](https://github.com/NixOS/nixpkgs/commit/6340db62495590ec33b05867cd4654123e70010f) | `libreoffice-qt: kf5 header files have moved into a subdir`                                      |
| [`11901d89`](https://github.com/NixOS/nixpkgs/commit/11901d89c45423ec6787a37001203f3905fe06d9) | `dmtcp: 2021-03-01 -> 2022-02-28`                                                                |
| [`b2a46c27`](https://github.com/NixOS/nixpkgs/commit/b2a46c270544fc6a2987264fbd92fe724b3b1f2e) | `python310Packages.catalogue: 2.0.6 -> 2.0.7`                                                    |
| [`da450f6b`](https://github.com/NixOS/nixpkgs/commit/da450f6b1d4614ae6d060fa75e99eb5906f18b8d) | `treewide: clean up obsolete version checks`                                                     |
| [`cb040db7`](https://github.com/NixOS/nixpkgs/commit/cb040db7ab06db02e9e6544b574ec232c61eceeb) | `pkgsStatic.gcc: fix build`                                                                      |