### PR TITLE
chore(flake/home-manager): `6c730bc0` -> `e2ebc3a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1648061814,
-        "narHash": "sha256-nnY5r7G0Kgz8EG6kbO1xAIgISAhWsD1qlItaYyxywqU=",
+        "lastModified": 1648073424,
+        "narHash": "sha256-STX+bmDkKStUm9ArZRzP4sXvhfCHNTKTShh9dFcj2c8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6c730bc0542442e6f20b821c5d03f83e9468573e",
+        "rev": "e2ebc3a3af4d6a942cea2d7d5fe46d56edcecc8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                            |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`e2ebc3a3`](https://github.com/nix-community/home-manager/commit/e2ebc3a3af4d6a942cea2d7d5fe46d56edcecc8b) | `picom: use types.lines for extraOptions` |
| [`0cf9dadf`](https://github.com/nix-community/home-manager/commit/0cf9dadf5bf34314ea5526636b597150e6430032) | `irssi: use types.lines for extraConfig`  |