### PR TITLE
chore(flake/home-manager): `e2ebc3a3` -> `b030278d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1648073424,
-        "narHash": "sha256-STX+bmDkKStUm9ArZRzP4sXvhfCHNTKTShh9dFcj2c8=",
+        "lastModified": 1648077099,
+        "narHash": "sha256-+7PrFbm6Kq6y4vVNrpn3I0eeesAqvfj3QGFjcRKvK8Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e2ebc3a3af4d6a942cea2d7d5fe46d56edcecc8b",
+        "rev": "b030278dc6716bbd6501cfb38456aa95be00f48f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                          |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`b030278d`](https://github.com/nix-community/home-manager/commit/b030278dc6716bbd6501cfb38456aa95be00f48f) | `nix: fix attribute path of nix stable` |
| [`9970d232`](https://github.com/nix-community/home-manager/commit/9970d23218d2215fb7e6e2cb74a3533e2b8863ad) | `gtk: fix incorrect test assertion`     |
| [`70c46966`](https://github.com/nix-community/home-manager/commit/70c469661983141d4d83d8180b71c2bb5f66034e) | `tests: bump nmt`                       |