### PR TITLE
chore(flake/home-manager): `b030278d` -> `ac940411`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1648077099,
-        "narHash": "sha256-+7PrFbm6Kq6y4vVNrpn3I0eeesAqvfj3QGFjcRKvK8Q=",
+        "lastModified": 1648078876,
+        "narHash": "sha256-oa3RA0Z0UwEZ1M5kQOT9oUVd4ew3XePOu2oDTenFd98=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b030278dc6716bbd6501cfb38456aa95be00f48f",
+        "rev": "ac9404115362c901ffe5c5c215f76f74b79d5eda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message   |
| ----------------------------------------------------------------------------------------------------------- | ---------------- |
| [`ac940411`](https://github.com/nix-community/home-manager/commit/ac9404115362c901ffe5c5c215f76f74b79d5eda) | `docs: bump nmd` |