### PR TITLE
chore(flake/flake-compat): `b7547d3e` -> `64a525ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -50,11 +50,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "lastModified": 1648199409,
+        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                 | Commit Message                           |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
| [`aee797a6`](https://github.com/edolstra/flake-compat/commit/aee797a673956f9ac563ce8495db0ff7204cbaa3) | `add support for new style of defaults`  |
| [`3b935d92`](https://github.com/edolstra/flake-compat/commit/3b935d922dddd81b0bf77f3d55b4561a0dc14ab8) | `Pass along submodules flag to fetchGit` |