### PR TITLE
chore(flake/nixpkgs): `7aa37733` -> `a34c788e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1648034513,
-        "narHash": "sha256-EMeo6i6B3aTBbAhfFYlr6OWCLcXbiePsQTDeAysnOaA=",
+        "lastModified": 1648315950,
+        "narHash": "sha256-B33QHyAQnMyy1R2waifXv8yQJfn5Ih8gIr5rQIAEeY8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7aa377336ec93fbb70150804679d222f14c5e87a",
+        "rev": "a34c788e30fffdbc808e4706bcf50b625af2686a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`f7ad2532`](https://github.com/NixOS/nixpkgs/commit/f7ad253271bc5bd8a951d8b6d3ab4e6ff7f0f18e) | `flatpak: 1.12.6 -> 1.12.7`                                                    |
| [`3e1f1876`](https://github.com/NixOS/nixpkgs/commit/3e1f1876132ebe3f54f6ea55917fa8ae6812da34) | `ocamlPackages.ocaml_data_notation: remove at 0.0.11 (broken)`                 |
| [`151e1ba0`](https://github.com/NixOS/nixpkgs/commit/151e1ba03e345a9261f0af3b18a8b2eced7fe1fa) | `python3Packages.anyconfig: init at 0.12.0`                                    |
| [`40a0c13a`](https://github.com/NixOS/nixpkgs/commit/40a0c13a7005cf93e2f51bec75369129f50db2aa) | `python3Packages.nested-lookup: init at 0.2.23`                                |
| [`eafe52ce`](https://github.com/NixOS/nixpkgs/commit/eafe52cea101d6317c038a53252ad88ff20ae8e0) | `topgrade: 8.2.0 -> 8.3.0`                                                     |
| [`8a866fee`](https://github.com/NixOS/nixpkgs/commit/8a866feee8d290f0fe10e6bceeee17c6031ef3b8) | `fwup: fix darwin #165167 by removing unused dependencies (#165172)`           |
| [`501f6439`](https://github.com/NixOS/nixpkgs/commit/501f6439760dab7c3ae329728762d98c4bbfcd58) | `buildkite-agent: 3.33.3 -> 3.34.1 (#163110)`                                  |
| [`c443e2fc`](https://github.com/NixOS/nixpkgs/commit/c443e2fc5d3a43309441d38706433d061c306495) | `docker-compose_2: 2.3.3 -> 2.3.4`                                             |
| [`8915e6ca`](https://github.com/NixOS/nixpkgs/commit/8915e6ca95ad5d6d251325fdadc4dbfeacb96b27) | `nrfutil: mark broken`                                                         |
| [`346be025`](https://github.com/NixOS/nixpkgs/commit/346be0258052a6e27d819f6a5477757857ecc55c) | `confluent-platform: 5.3.0 -> 7.0.1 (#165739)`                                 |
| [`54f62a4c`](https://github.com/NixOS/nixpkgs/commit/54f62a4cb012caa69ae8f1fee427a500733961e1) | `prisma-engines: add superherointj as maintainer`                              |
| [`34d0b860`](https://github.com/NixOS/nixpkgs/commit/34d0b8601c75bf01777ac621fa8efb94bd710c99) | `git-team: init at 1.7.0`                                                      |
| [`d74b21a2`](https://github.com/NixOS/nixpkgs/commit/d74b21a29403e8ab85b1c1f118bb290317ba9bf2) | `python39Packages.google-cloud-speech: add setuptools`                         |
| [`13e63f67`](https://github.com/NixOS/nixpkgs/commit/13e63f67ddf3d3ba72b73f85f2d87a3fae847017) | `make-bootstrap-tools-cross: fix typo which prevents hydra eval`               |
| [`cc7594a7`](https://github.com/NixOS/nixpkgs/commit/cc7594a705253babadfbe5c39d0f24402062a9cd) | `unigine-superposition: init at 1.1 (#163820)`                                 |
| [`93dbc8b1`](https://github.com/NixOS/nixpkgs/commit/93dbc8b14c06efb7a56d826d11c2bb865996aa0c) | `ligo: 0.34.0 -> 0.36.0`                                                       |
| [`9d397e8f`](https://github.com/NixOS/nixpkgs/commit/9d397e8f1687c998a33268d2595a907d665f7703) | `libgphoto2: 2.5.28 -> 2.5.29`                                                 |
| [`e31ff53c`](https://github.com/NixOS/nixpkgs/commit/e31ff53ceb35200c4b2779a5bfb41b1f978d9526) | `libbluray: 1.3.0 -> 1.3.1`                                                    |
| [`a30fdc5d`](https://github.com/NixOS/nixpkgs/commit/a30fdc5df3007051d839fae4df84ce2f38347f6a) | `suitesparse: 5.10.1 -> 5.11.0`                                                |
| [`2b32a30d`](https://github.com/NixOS/nixpkgs/commit/2b32a30deb88c1bff25e3412b904d8c7c9250638) | `ostree: 2022.1 -> 2022.2`                                                     |
| [`d81e16cc`](https://github.com/NixOS/nixpkgs/commit/d81e16ccf602e4600f88fee523886d1716acac48) | `mupdf: Refactor desktop item (#165117)`                                       |
| [`213b02a8`](https://github.com/NixOS/nixpkgs/commit/213b02a8cc287ac82af8133469dcde24a9aa8c27) | `libsolv: 0.7.20 → 0.7.21`                                                     |
| [`f477b4be`](https://github.com/NixOS/nixpkgs/commit/f477b4be48d2f25a312873d4cede1039015b1522) | `rpm-ostree: 2022.2 -> 2022.3`                                                 |
| [`c2fd5cb6`](https://github.com/NixOS/nixpkgs/commit/c2fd5cb6d3ff92ef0fbeefb0ec9039d3c53761b0) | `upower: 0.99.15 → 0.99.17`                                                    |
| [`8e33d244`](https://github.com/NixOS/nixpkgs/commit/8e33d244af5a9cc2ec9ae877d1b053f8f98edec0) | `libportal: 0.5 -> 0.6`                                                        |
| [`841ef45d`](https://github.com/NixOS/nixpkgs/commit/841ef45dfb500658997c3e974004bbbbd3de87f5) | `metasploit: 6.1.34 -> 6.1.35`                                                 |
| [`2506e6ac`](https://github.com/NixOS/nixpkgs/commit/2506e6ac0f9dd4a1c659c81e4de5b4e516cac541) | `libreddit: 0.22.1 -> 0.22.3`                                                  |
| [`68169890`](https://github.com/NixOS/nixpkgs/commit/6816989022e3f211fbf05ff832b797c25761e605) | `amass: 3.18.2 -> 3.18.3`                                                      |
| [`93c4209d`](https://github.com/NixOS/nixpkgs/commit/93c4209d3fb0916132711996e062960c96f5e9cc) | `cryptomator: 1.6.5 -> 1.6.7`                                                  |
| [`878f72c7`](https://github.com/NixOS/nixpkgs/commit/878f72c7e307e29d40aae96e06b68f5448799c29) | `cryptomator: 1.5.15 -> 1.6.5`                                                 |
| [`a2c06170`](https://github.com/NixOS/nixpkgs/commit/a2c06170a3c247c34a76374dc1a61560e9e419f1) | `jffi: init at 1.3.9`                                                          |
| [`ee3bbd14`](https://github.com/NixOS/nixpkgs/commit/ee3bbd14f943807fa3d21995ffa6f5db454a021a) | `pythonPackages.nbxmpp: 2.0.4 → 2.0.6`                                         |
| [`fc8fa47c`](https://github.com/NixOS/nixpkgs/commit/fc8fa47cdebe1cd63ba36bafe85115db85b2a7fb) | `podman-tui: 0.1.0 -> 0.2.0`                                                   |
| [`435a5b67`](https://github.com/NixOS/nixpkgs/commit/435a5b675be29cf1add3b07684ffc4dac39101f5) | `nixos/pipewire: introduce an explicit option to use Pipewire as audio server` |
| [`45df97e9`](https://github.com/NixOS/nixpkgs/commit/45df97e9ffa7c508fac8a13f46e7526ecfed542f) | `python310Packages.trimesh: 3.10.6 -> 3.10.7`                                  |
| [`3186c367`](https://github.com/NixOS/nixpkgs/commit/3186c367cea0b0b23748f4b9620eac5d6a075049) | `nixos/waydroid: Misc fixes`                                                   |
| [`0e78d578`](https://github.com/NixOS/nixpkgs/commit/0e78d578e643f353d6db74a8514bab28099760dc) | `glib: Fix docs on Darwin`                                                     |
| [`7bd96c43`](https://github.com/NixOS/nixpkgs/commit/7bd96c43cf54088e660967940f6d02056e0c0c8e) | `difftastic: 0.22.0 -> 0.23.0`                                                 |
| [`617074f4`](https://github.com/NixOS/nixpkgs/commit/617074f4c800b4793616ef86041c70037f5f6e16) | `shisho: init at 0.5.2`                                                        |
| [`f99046bc`](https://github.com/NixOS/nixpkgs/commit/f99046bcaba24e145344a8702b52197bac210a60) | `taskwarrior-tui: 0.21.0 -> 0.21.1`                                            |
| [`bc0f24d0`](https://github.com/NixOS/nixpkgs/commit/bc0f24d02a075573a47cd2354f14632dbafdedc1) | `mdbook-pdf: init at 0.1.2`                                                    |
| [`6bbf2eda`](https://github.com/NixOS/nixpkgs/commit/6bbf2eda49bbda2235de9809f9da54d7f8b9b91e) | `Fix lib ref`                                                                  |
| [`6771dc63`](https://github.com/NixOS/nixpkgs/commit/6771dc6346689d755e3529214753d5a4f016aaf7) | `Remove unused module arg`                                                     |
| [`ac3aa4c0`](https://github.com/NixOS/nixpkgs/commit/ac3aa4c073bd09a69b891f5ed08367fda6fa7ea6) | `Add cargo-bootimage package`                                                  |
| [`baa28553`](https://github.com/NixOS/nixpkgs/commit/baa2855358997350574d5dc06f2ec410bbf7a7e9) | `Add maintainer`                                                               |
| [`2c6237c2`](https://github.com/NixOS/nixpkgs/commit/2c6237c2fb2ea70461c60bb1677b4c1f5bf60cda) | `python310Packages.pyrect: 0.1.4 -> 0.2.0`                                     |
| [`ea2b0aeb`](https://github.com/NixOS/nixpkgs/commit/ea2b0aebbf373a5618752f5c711efda1f8ac7bb4) | `pipenv: 2022.3.23 -> 2022.3.24`                                               |
| [`d1ba752c`](https://github.com/NixOS/nixpkgs/commit/d1ba752c47a3d4fae73ac58582c5b5e29ae32ea9) | `python3Packages.metar: patch flaky test`                                      |
| [`01bcf1b1`](https://github.com/NixOS/nixpkgs/commit/01bcf1b1a0b93279ff326a34913302c971718837) | `home-assistant: 2022.3.5 -> 2022.3.6`                                         |
| [`b2fa8a50`](https://github.com/NixOS/nixpkgs/commit/b2fa8a507054f86f1fb18cebae6e7c93ed0faf6e) | `python310Packages.py-synologydsm-api: 1.0.7 -> 1.0.8`                         |
| [`f3180f4c`](https://github.com/NixOS/nixpkgs/commit/f3180f4cdc01bb8626426149032e5e2dd1830349) | `tboot: 1.10.4 -> 1.10.5`                                                      |
| [`1e44a44c`](https://github.com/NixOS/nixpkgs/commit/1e44a44c2a763e36d16ab051e19f03b0e3916344) | `python310Packages.pex: 2.1.73 -> 2.1.74`                                      |
| [`4bbf1a90`](https://github.com/NixOS/nixpkgs/commit/4bbf1a90c4919b2918c2f2123179d8ccb60e8dde) | `dictdDBs.wiktionary: 20210920 -> 20220301`                                    |
| [`b7cbe6e6`](https://github.com/NixOS/nixpkgs/commit/b7cbe6e638f2ff5a0c56902f831fd42bde336f25) | `fluxcd: 0.27.4 -> 0.28.3`                                                     |
| [`38d6c62a`](https://github.com/NixOS/nixpkgs/commit/38d6c62a98506b368e75fb1c31d63ad405bb65c4) | `thermald: 2.4.8 -> 2.4.9`                                                     |
| [`a1546788`](https://github.com/NixOS/nixpkgs/commit/a15467886a7e06c72bfb62ac2b82f1196dfc22cb) | `python310Packages.diff-cover: 6.4.4 -> 6.4.5`                                 |
| [`08903014`](https://github.com/NixOS/nixpkgs/commit/08903014a5fe4cf3fb4b4806d696926ccc66d02d) | `snd: 22.1 -> 22.2`                                                            |
| [`c7fc7f25`](https://github.com/NixOS/nixpkgs/commit/c7fc7f25f12583e5d3766cad3335cf9fc10d3221) | `python310Packages.affine: 2.3.0 -> 2.3.1`                                     |
| [`c4c1d783`](https://github.com/NixOS/nixpkgs/commit/c4c1d7839db6b05c1fa12b8c28fd214e12eb6a35) | `python310Packages.mkdocs-material: 8.2.6 -> 8.2.7`                            |
| [`ddf58f2d`](https://github.com/NixOS/nixpkgs/commit/ddf58f2d55066fd29510933a63f4c2ad8e5aa6d3) | `argocd: 2.3.1 -> 2.3.2`                                                       |
| [`6d33b26f`](https://github.com/NixOS/nixpkgs/commit/6d33b26fd1c51f309b3bad8113893f4c7814d335) | `fish: 3.4.0 -> 3.4.1`                                                         |
| [`7f618b06`](https://github.com/NixOS/nixpkgs/commit/7f618b06a0cbab03d77fbed1289d338d0d57f1e1) | `nerdctl: 0.17.1 -> 0.18.0`                                                    |
| [`0f3e9058`](https://github.com/NixOS/nixpkgs/commit/0f3e905834308026457885cc9eb8bcf5980848b5) | `dwarf-fortress.themes: add -theme suffix to name`                             |
| [`b908951d`](https://github.com/NixOS/nixpkgs/commit/b908951dd6c3b704533abfb61ea47bbc7e535947) | `python310Packages.luxtronik: 0.3.10 -> 0.3.11`                                |
| [`206e030c`](https://github.com/NixOS/nixpkgs/commit/206e030ce23c1623b7f45993eb11c67e4ef94a1e) | `installer/cd-dvd/iso-image: add syslinuxTheme config option`                  |
| [`3d12c9ce`](https://github.com/NixOS/nixpkgs/commit/3d12c9ce1c1a0fb44518646fd5f3ac69e4f0bfc5) | `scribusUnstable: Fix build with Poppler 22.03`                                |
| [`013594c8`](https://github.com/NixOS/nixpkgs/commit/013594c801af8616a0011ed8d8e4e7278f63a10d) | `pdf2djvu: fix build with Poppler 22.03`                                       |
| [`7904ab42`](https://github.com/NixOS/nixpkgs/commit/7904ab42d861b316c7628e5367fb385b08ab021b) | `pdf2djvu: 0.9.17.1 → 0.9.18.2`                                                |
| [`9adc2089`](https://github.com/NixOS/nixpkgs/commit/9adc2089f943115bc7634ba7e381e9c4ed072188) | `plasma5Packages.kitinerary: fix build with Poppler 22.03`                     |
| [`44c7781e`](https://github.com/NixOS/nixpkgs/commit/44c7781ee802a89dd48615801d18da3df296f19c) | `lxqt.lxqt-build-tools: Fix finding GLib 2.72`                                 |
| [`d2784592`](https://github.com/NixOS/nixpkgs/commit/d2784592945822ef3f469fb92af066c1d38bf4fd) | `bcachefs-tools: 2022-03-09 -> 2022-03-22`                                     |
| [`15878975`](https://github.com/NixOS/nixpkgs/commit/158789753f6d8ba7a55a83c79674e9667069a13e) | `linux_testing_bcachefs: 2022-03-09 -> 2022-03-21`                             |
| [`532e6eba`](https://github.com/NixOS/nixpkgs/commit/532e6eba753555011cfe9c3dc1af41b74252bd74) | `buf: 1.1.1 -> 1.3.0`                                                          |
| [`91024781`](https://github.com/NixOS/nixpkgs/commit/91024781530c66bc61f09074c9fcd9bce7d11a87) | `libreoffice: fix build with Poppler 22.03`                                    |
| [`e446f7b0`](https://github.com/NixOS/nixpkgs/commit/e446f7b091cee5f0924b5284802ee12fb3a77a43) | `python3Packages.capstone: fix build on aarch64-darwin`                        |
| [`f318d3b5`](https://github.com/NixOS/nixpkgs/commit/f318d3b5605aaed8b2ee8ba645656fc4f65cfd41) | `python3Packages.unicorn: fix build on aarch64-darwin`                         |
| [`ea031515`](https://github.com/NixOS/nixpkgs/commit/ea031515d4a44a8474cec6fab3568aec0d14208d) | `unused: 0.2.3 -> 0.4.0`                                                       |
| [`534a7351`](https://github.com/NixOS/nixpkgs/commit/534a73511ef95355ef9b11f31bf6deb9fdb84521) | `inkscape: fix build with poppler 22.03`                                       |
| [`1a805fcd`](https://github.com/NixOS/nixpkgs/commit/1a805fcd235ec964db5c1d37711eb24239e01e9c) | `gnomeExtensions: update extensions.json`                                      |
| [`9715d3e5`](https://github.com/NixOS/nixpkgs/commit/9715d3e5b328fe45cf1465541f26f02cc9cf87cf) | `gnomeExtensions.freon: 45 → unstable-2022-02-05`                              |
| [`33a2ef20`](https://github.com/NixOS/nixpkgs/commit/33a2ef20605f1f2546f6df74621a02c3dcb96f1c) | `gnomeExtensions.gsconnect: 53 → 50`                                           |
| [`587e459b`](https://github.com/NixOS/nixpkgs/commit/587e459b6f7f8a43a0c742c1df8953a587625f7d) | `matrix-dendrite: 0.6.5 -> 0.7.0`                                              |
| [`c70a466d`](https://github.com/NixOS/nixpkgs/commit/c70a466d21fbd72f73cfc263e93f967e79953e73) | `nixos/systemd: Allow creation of unit directories`                            |
| [`df26b72f`](https://github.com/NixOS/nixpkgs/commit/df26b72fe7fad5f792a41a789d11a8b84fbc9629) | `exploitdb: 2022-03-22 -> 2022-03-24`                                          |
| [`de234592`](https://github.com/NixOS/nixpkgs/commit/de23459252f7708643c62fd2822157f28898c2a5) | `littlefs-fuse: init at 2.4.1`                                                 |
| [`4ec35ff6`](https://github.com/NixOS/nixpkgs/commit/4ec35ff6d6298f3fc70be458ea1fea68ee85b1e9) | `nixos: init programs/nncp module`                                             |
| [`ad15abe7`](https://github.com/NixOS/nixpkgs/commit/ad15abe7ffbc68ba8a41fdb9270c31b75e2e7fd8) | `squid: 4.17 -> 5.4.1`                                                         |
| [`13f70082`](https://github.com/NixOS/nixpkgs/commit/13f70082dc9cabc795dc3d0edf42eb9e5c714b0f) | `godns: 2.7 -> 2.7.1`                                                          |
| [`5ad177b5`](https://github.com/NixOS/nixpkgs/commit/5ad177b59ce3064460322c51f6c861010fc13505) | `libnma: 1.8.34 → 1.8.36`                                                      |
| [`57b71115`](https://github.com/NixOS/nixpkgs/commit/57b7111537a079a7109b6231758c6bc9a5c27dda) | `gnome.gnome-initial-setup: 42.0 → 42.0.1`                                     |
| [`50bc0910`](https://github.com/NixOS/nixpkgs/commit/50bc0910b6b381f8755f3ab3590f7c6b14501781) | `gtranslator: fix build with meson 0.61`                                       |
| [`b43e9c65`](https://github.com/NixOS/nixpkgs/commit/b43e9c65ebd4729ae9c6cf789f7cd3cebeda8ae3) | `folks: 0.15.4 → 0.15.5`                                                       |
| [`ca71a3f3`](https://github.com/NixOS/nixpkgs/commit/ca71a3f375b7758e02b74ff48fe3b6505341d66d) | `gnome.aisleriot: 3.22.20 → 3.22.21`                                           |
| [`5d92c840`](https://github.com/NixOS/nixpkgs/commit/5d92c840ed00d3a6b9f979e6bd14193d1b2f231d) | `blueberry: fix build with meson 0.61`                                         |
| [`18a72ef6`](https://github.com/NixOS/nixpkgs/commit/18a72ef69f0ea398d8619b4c0703899577860bdd) | `gnome.aisleriot: Fix build`                                                   |
| [`d81828f4`](https://github.com/NixOS/nixpkgs/commit/d81828f4aa27eb3b1650fffcdbec76c1a8b2c540) | `glib-networking: 2.72.beta → 2.72.0`                                          |
| [`d30f68d0`](https://github.com/NixOS/nixpkgs/commit/d30f68d0b8b191cb5d699f701a60dba526d0f706) | `gnomeExtensions: 41 → 42`                                                     |
| [`3b052a0f`](https://github.com/NixOS/nixpkgs/commit/3b052a0f6114fbf0641dd1f6054aaa5ce32c1484) | `orca: 42.rc → 42.0`                                                           |
| [`8be53bf3`](https://github.com/NixOS/nixpkgs/commit/8be53bf3d96aaf716198211646f99c49da8f7e4d) | `gnome.gnome-contacts: 42.beta → 42.0`                                         |
| [`87d18174`](https://github.com/NixOS/nixpkgs/commit/87d18174d317e78fdfd9ab1fd35b685deb812aa8) | `nixos/gdm: fix accessibility menu icon`                                       |
| [`6cc62a8b`](https://github.com/NixOS/nixpkgs/commit/6cc62a8bc011faa61fe317a7aa3df69e7a598b8e) | `networkmanagerapplet: 1.24.0 → 1.26.0`                                        |
| [`053ecedf`](https://github.com/NixOS/nixpkgs/commit/053ecedfe0b6b7dcbeb9d60dfb74e8741987bc2b) | `gjs.tests: fix warning`                                                       |
| [`548f950b`](https://github.com/NixOS/nixpkgs/commit/548f950b3c89c085843114020c0dc1ed85cbc19c) | `gnome.gnome-session-ctl: 41.3 → 42.0`                                         |
| [`d9a73529`](https://github.com/NixOS/nixpkgs/commit/d9a7352912a7b2601e4639b47fbd543de5d076df) | `gnome.gnome-session: 41.3 → 42.0`                                             |
| [`d0af33ab`](https://github.com/NixOS/nixpkgs/commit/d0af33ab0fa907d0d30efcfb41096bce0154280a) | `gtkmm4: 4.6.0 → 4.6.1`                                                        |
| [`2a3f38f3`](https://github.com/NixOS/nixpkgs/commit/2a3f38f305a4f356b0ec9796374bcc5244b6f232) | `gthumb: 3.12.0 → 3.12.1`                                                      |
| [`e182fe06`](https://github.com/NixOS/nixpkgs/commit/e182fe066586913382f389c9ed89a29297e0c26c) | `gnome-connections: 42.beta → 42.0`                                            |
| [`8a91a19d`](https://github.com/NixOS/nixpkgs/commit/8a91a19d5e45385702fdf5a73660393aa919e862) | `gnome.gnome-backgrounds: 42.beta → 42.0`                                      |
| [`cd1d12ca`](https://github.com/NixOS/nixpkgs/commit/cd1d12ca656a5cca5e19f0723dea6d67d68b7eaa) | `gnome.gdm: 41.3 → 42.0`                                                       |
| [`8d24f4a6`](https://github.com/NixOS/nixpkgs/commit/8d24f4a6c851d18858de4ef8ecb9db355eee7960) | `gnome.adwaita-icon-theme: 42.beta → 42.0`                                     |
| [`b11117dd`](https://github.com/NixOS/nixpkgs/commit/b11117dd8633a3e59e8f377e710676a0ce3e3193) | `gnomeExtensions.gsconnect: 50 → 53`                                           |
| [`b9f71fe5`](https://github.com/NixOS/nixpkgs/commit/b9f71fe5d3eae72ce07f2c3dca3debeaea7a5f9a) | `libgsf: 1.14.48 → 1.14.49`                                                    |
| [`fb4b0c01`](https://github.com/NixOS/nixpkgs/commit/fb4b0c019f42b46520da0bb5a3bb333c3671879c) | `gnome.polari: 41.0 → 42.0`                                                    |
| [`3ecef34e`](https://github.com/NixOS/nixpkgs/commit/3ecef34ed099ce9ec0d72e3ae40f39c10440a548) | `gnome.gnome-weather: 42.rc → 42.0`                                            |
| [`d80b0896`](https://github.com/NixOS/nixpkgs/commit/d80b089680f71c8da89a223bc59457a1c4cd9984) | `gnome.gnome-remote-desktop: 42.rc → 42.0`                                     |
| [`1f3e12ea`](https://github.com/NixOS/nixpkgs/commit/1f3e12ea10da54bef15d6d403903635effe8e5a7) | `gnome.gnome-music: 42.beta → 42.0`                                            |
| [`97763f8b`](https://github.com/NixOS/nixpkgs/commit/97763f8b06720c1487f542682e68e6f126bba034) | `gnome.gnome-font-viewer: 42.rc → 42.0`                                        |
| [`dcd3431b`](https://github.com/NixOS/nixpkgs/commit/dcd3431bc94d9beb5f40c0b286a2006f74a4eb9c) | `baobab: 42.rc → 42.0`                                                         |
| [`38d1e91f`](https://github.com/NixOS/nixpkgs/commit/38d1e91f9013ae81a8bcb9c67ff8bde21ba0e39e) | `vala_0_56: 0.55.91 → 0.56.0`                                                  |
| [`5d74b9a1`](https://github.com/NixOS/nixpkgs/commit/5d74b9a1b83f020de7e01d1af3d73f7081c7af87) | `gnome-desktop: 42.rc → 42.0`                                                  |
| [`49e154ce`](https://github.com/NixOS/nixpkgs/commit/49e154ce0bf6c95d8832879719428bb8addb0bf1) | `gnome.file-roller: 3.41.90 → 3.42.0`                                          |
| [`a0d22d2a`](https://github.com/NixOS/nixpkgs/commit/a0d22d2ada9040f9217304785a25cd25ccfddf4b) | `gnome.gpaste: 3.42.6 → 42.0`                                                  |
| [`27d52bf4`](https://github.com/NixOS/nixpkgs/commit/27d52bf401dffdd81ac44d2be1188d687186e67d) | `libgweather: 3.91.0 → 4.0.0`                                                  |
| [`9e4194bd`](https://github.com/NixOS/nixpkgs/commit/9e4194bd5ede9c3671bb1477361607986a81d8ec) | `yelp-tools: 42.beta → 42.0`                                                   |
| [`8f059fbd`](https://github.com/NixOS/nixpkgs/commit/8f059fbd3d62e3251dd74f6ee44ae7d092f6f1ee) | `vala: 0.54.7 → 0.54.8`                                                        |
| [`49d50649`](https://github.com/NixOS/nixpkgs/commit/49d506498eb699e44049adc0f21876c6a73cefac) | `tracker-miners: 3.3.0.rc → 3.3.0`                                             |
| [`a1c0f79f`](https://github.com/NixOS/nixpkgs/commit/a1c0f79f27df4582dfee8b7aed52b452725730df) | `tracker: 3.3.0.rc → 3.3.0`                                                    |
| [`acc8f309`](https://github.com/NixOS/nixpkgs/commit/acc8f309630eaa5b8fec52e3060677bd413b512c) | `pango: 1.50.5 → 1.50.6`                                                       |
| [`c82f942e`](https://github.com/NixOS/nixpkgs/commit/c82f942efcd486f6f838dec7a467c3ef55ce4392) | `libpeas: build developer docs`                                                |
| [`705068d5`](https://github.com/NixOS/nixpkgs/commit/705068d5e32b9301b40ef9fab38c5b3178ad9cfb) | `libpeas: 1.30.0 → 1.32.0`                                                     |
| [`70c0a691`](https://github.com/NixOS/nixpkgs/commit/70c0a6915f1233180bc06326f94bb458a9b67e23) | `gtksourceview5: 5.3.2 → 5.4.0`                                                |
| [`0080317d`](https://github.com/NixOS/nixpkgs/commit/0080317d866e6c090ca1f33d2cfbd50885c07577) | `gtksourceview4: 4.8.2 → 4.8.3`                                                |
| [`d2f46a0e`](https://github.com/NixOS/nixpkgs/commit/d2f46a0e67b9e97782b40e065b7536fd74cc3377) | `gtk4: 4.6.1 → 4.6.2`                                                          |
| [`004ea120`](https://github.com/NixOS/nixpkgs/commit/004ea1200f6b508b1a5aab04d0ad143e232d58c6) | `gsettings-desktop-schemas: 42.rc → 42.0`                                      |
| [`6deb13af`](https://github.com/NixOS/nixpkgs/commit/6deb13afdc859c4c251580b152a36f882c9808dc) | `gnome-user-docs: 41.2 → 42.0`                                                 |
| [`8e4ab2ff`](https://github.com/NixOS/nixpkgs/commit/8e4ab2ff1eb0dfa46798293127986064bb2e34a6) | `gnome-tour: 42.beta → 42.0`                                                   |
| [`31a318d3`](https://github.com/NixOS/nixpkgs/commit/31a318d325592e5c69be0c97ec9809256e497a88) | `gnome-photos: 40.0 → 42.0`                                                    |
| [`c1c386b7`](https://github.com/NixOS/nixpkgs/commit/c1c386b761901ed47fba0199dad94f85b752b434) | `gnome-text-editor: 42.rc1 → 42.0`                                             |
| [`a1cabaf9`](https://github.com/NixOS/nixpkgs/commit/a1cabaf9dee10153fd91ab738f07b409184e11ed) | `gnome.yelp-xsl: 42.beta → 42.0`                                               |
| [`0fa24ad7`](https://github.com/NixOS/nixpkgs/commit/0fa24ad74b50e3b59d21e8e45040db8f87760685) | `gnome.yelp: 42.beta → 42.0`                                                   |
| [`e150d2f3`](https://github.com/NixOS/nixpkgs/commit/e150d2f3e256c31297611e359ea23eb1dc346a1f) | `gnome.tali: 40.5 → 40.6`                                                      |
| [`66b7d51d`](https://github.com/NixOS/nixpkgs/commit/66b7d51d18f182fa23b4dc1f762ffd87857ef3bd) | `gnome.nautilus: 42.rc → 42.0`                                                 |
| [`8422afe2`](https://github.com/NixOS/nixpkgs/commit/8422afe224bf4e0d2260081a3412199276e3d846) | `gnome.metacity: 3.43.1 → 3.44.0`                                              |
| [`5baffcdf`](https://github.com/NixOS/nixpkgs/commit/5baffcdf7619d091c6c514d53afcb12f8e75f9f0) | `gnome.gnome-system-monitor: 42.rc → 42.0`                                     |
| [`6386a0fd`](https://github.com/NixOS/nixpkgs/commit/6386a0fd382d5af31e1c35cc44b119717f396f9d) | `gnome.gnome-sound-recorder: 42.beta → 42.0`                                   |
| [`b2d2fcd8`](https://github.com/NixOS/nixpkgs/commit/b2d2fcd8e48f228cc7a6b0f66eb6895ca9c6ca28) | `gnome.gnome-settings-daemon: 42.rc → 42.1`                                    |
| [`12dbca99`](https://github.com/NixOS/nixpkgs/commit/12dbca9935106fc45f1b8ef7eed04b91ed0496e4) | `gnome.gnome-panel: 3.43.1 → 3.44.0`                                           |
| [`2d614865`](https://github.com/NixOS/nixpkgs/commit/2d61486510210781b4360547693a6a210b915565) | `gnome.gnome-maps: 42.rc → 42.0`                                               |
| [`d389bfd7`](https://github.com/NixOS/nixpkgs/commit/d389bfd7415cfe402d2bd0aeb034ddcf77ed0336) | `gnome.gnome-flashback: 3.43.1 → 3.44.0`                                       |
| [`0b1b922b`](https://github.com/NixOS/nixpkgs/commit/0b1b922bfd899d79f555363306f253b9c17e9ffb) | `gnome.gnome-clocks: 42.beta → 42.0`                                           |
| [`24f85a59`](https://github.com/NixOS/nixpkgs/commit/24f85a59d82488371484be690ec243958ca9eebe) | `gnome.gnome-characters: 42.rc → 42.0`                                         |
| [`d9409428`](https://github.com/NixOS/nixpkgs/commit/d9409428425d0385769ad77dceceb4007c1d04ac) | `gnome.gnome-calculator: 42.rc → 42.0`                                         |
| [`ad2536cd`](https://github.com/NixOS/nixpkgs/commit/ad2536cd9d8706d8c08bde22938ccf076c609437) | `gnome.gnome-applets: 3.43.1 → 3.44.0`                                         |
| [`73e9cb0e`](https://github.com/NixOS/nixpkgs/commit/73e9cb0ef2fd0ba18bc7d86cbf1023ac4d43bc19) | `gnome.eog: 42.rc → 42.0`                                                      |
| [`914fd503`](https://github.com/NixOS/nixpkgs/commit/914fd5031c8bfce3946155133e5d0798c9e9ee2d) | `gjs: 1.71.90 → 1.72.0`                                                        |
| [`245a1b20`](https://github.com/NixOS/nixpkgs/commit/245a1b20d7252f7cf7d41f6b0eff11050df63c67) | `evince: 42.0 → 42.1`                                                          |
| [`1aefc6d8`](https://github.com/NixOS/nixpkgs/commit/1aefc6d80199f35baca6c5b35b746f4aece4e8cd) | `gnomeExtensions.gsconnect: 48 → 50`                                           |
| [`5a00ac1b`](https://github.com/NixOS/nixpkgs/commit/5a00ac1b084d9810e21dd6ce9762673ad3635b35) | `pantheon.gnome-bluetooth-contract: mark as broken`                            |
| [`b214aa70`](https://github.com/NixOS/nixpkgs/commit/b214aa70b45a1f2e45d58f1833b1ccd62cedc248) | `pantheon.evince: drop`                                                        |