### PR TITLE
chore(flake/home-manager): `2f58d0a3` -> `0520e387`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1648303888,
-        "narHash": "sha256-SEetW7ijelQtGQJXNGkLBYvyc9Xe1Ig4qfFPBuPrZe8=",
+        "lastModified": 1648339732,
+        "narHash": "sha256-VxDS6OYdbvBf7v7qa4aR1MRj3G0sxK4imXGJq3RtEz0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f58d0a3de97f4c20efcc6ba00878acfd7b5665d",
+        "rev": "0520e387dcc6e6174fd965b27082ede1672ed740",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                      |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`0520e387`](https://github.com/nix-community/home-manager/commit/0520e387dcc6e6174fd965b27082ede1672ed740) | `overlay: rename parameters to flake specification` |
| [`b23bb058`](https://github.com/nix-community/home-manager/commit/b23bb05890f4a5f31f4e0d7bc2fe25bc6d4166ac) | `flake: only support linux + darwin`                |