### PR TITLE
chore(flake/nixpkgs): `a34c788e` -> `12417777`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1648315950,
-        "narHash": "sha256-B33QHyAQnMyy1R2waifXv8yQJfn5Ih8gIr5rQIAEeY8=",
+        "lastModified": 1648352901,
+        "narHash": "sha256-1R31hIpqA+3mKBSayiqUhCm21gw4YRioPuR1WqjlCwU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a34c788e30fffdbc808e4706bcf50b625af2686a",
+        "rev": "12417777b226eff91efee8b03578daa76c8178a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                      |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`12417777`](https://github.com/NixOS/nixpkgs/commit/12417777b226eff91efee8b03578daa76c8178a3) | `deltachat-desktop: 1.26.0 -> 1.28.0`                               |
| [`1a8b5880`](https://github.com/NixOS/nixpkgs/commit/1a8b5880b0b3f97b0f98fccc881027f0fc39758f) | `python310Packages.robotframework: 4.1.3 -> 5.0`                    |
| [`1b9bb690`](https://github.com/NixOS/nixpkgs/commit/1b9bb6909a44a0000bbe0abe06a5d7a9db4a309a) | `nix-tour: 0.0.1 -> unstable-2022-01-03`                            |
| [`01dd7667`](https://github.com/NixOS/nixpkgs/commit/01dd7667016871c639bd9022b1d86df715c6ea7f) | `nix-tour: Add XDG desktop entry`                                   |
| [`976de01d`](https://github.com/NixOS/nixpkgs/commit/976de01d446de011e90b1938ad2cafe86196eb80) | `nix-tour: refactoring`                                             |
| [`7574eb2c`](https://github.com/NixOS/nixpkgs/commit/7574eb2cbaa059f3141ca8e8d22eeccf5e22cc8e) | `gnome.gpaste: 42.0 → 42.1`                                         |
| [`56b755ce`](https://github.com/NixOS/nixpkgs/commit/56b755cebf05793970d606afef73df7d2d31628c) | `twitter-color-emoji: 13.0.2 -> 14.0.0`                             |
| [`1e32d288`](https://github.com/NixOS/nixpkgs/commit/1e32d28824ccdaf171f8044478bbb5ad8f042aaa) | `nixos/dendrite: always substitute environment variables in config` |
| [`1da79f04`](https://github.com/NixOS/nixpkgs/commit/1da79f049b673fa971317cced36502580bbb6378) | `clojure: 1.10.3.1093 -> 1.11.0.1097`                               |
| [`89704501`](https://github.com/NixOS/nixpkgs/commit/89704501dc1ef3f422c2560ee71430d75d1b15fd) | `chromium: 99.0.4844.82 -> 99.0.4844.84`                            |
| [`a6504af8`](https://github.com/NixOS/nixpkgs/commit/a6504af8dafad63dfa31ad30f2d842812caa1bf9) | `wxGTK: remove myself from maintainers`                             |
| [`0e1ebb95`](https://github.com/NixOS/nixpkgs/commit/0e1ebb957b0cf07d20c6cc0b3e0bf1ec1a47cb8a) | `perlPackages.AudioFLACHeader: init at 2.4`                         |
| [`e13e37b7`](https://github.com/NixOS/nixpkgs/commit/e13e37b70108f0ebaa75db62eca99bc26898fdc2) | `solc: 0.8.2 -> 0.8.13 (#160957)`                                   |
| [`972dbe30`](https://github.com/NixOS/nixpkgs/commit/972dbe303a8bb9da364d67230b2b04cc9633a5f8) | `prometheus-alertmanager: 0.23.0 -> 0.24.0 (#165813)`               |
| [`5c9a017e`](https://github.com/NixOS/nixpkgs/commit/5c9a017ee38d14638c9daa7c066762523e557e39) | `python3Packages.scmrepo: 0.0.7 -> 0.0.13`                          |
| [`51228022`](https://github.com/NixOS/nixpkgs/commit/51228022baf52d0e03c42e9e41003d54abc65599) | `python3Packages.dulwich: 0.20.32 -> 0.20.35`                       |
| [`73719073`](https://github.com/NixOS/nixpkgs/commit/73719073f34c7040a4ba422fe2ab9d14361b26be) | `python3Packages.glean-sdk: relax glean_parser constraint`          |
| [`95f91dbe`](https://github.com/NixOS/nixpkgs/commit/95f91dbed5774ded765534bbb159c9911124991c) | `gnome.nautilus: remove unused exempi dependency`                   |
| [`12e70267`](https://github.com/NixOS/nixpkgs/commit/12e702672786dbc5bbf5dda6b9167413d83ff3e0) | `python3Packages.glean-parser: update pname`                        |
| [`9d080d0a`](https://github.com/NixOS/nixpkgs/commit/9d080d0a775373e44babfbd7ce95b3d22d8e0b4e) | `networkmanager: 1.36.2 → 1.36.4`                                   |
| [`45ab96dd`](https://github.com/NixOS/nixpkgs/commit/45ab96dd9c1b04a662bc7a8f7b9ff71cbc5e190a) | `cppcheck: set doCheck = true`                                      |
| [`eb7d3b1d`](https://github.com/NixOS/nixpkgs/commit/eb7d3b1ddd0f66b508747615df1251b5add43435) | `xh: install manpages, docs`                                        |
| [`adf02642`](https://github.com/NixOS/nixpkgs/commit/adf026421ee171d2ff2a4f10b57c102b77931fad) | `freeplane: 1.9.5 -> 1.9.14`                                        |
| [`f2c5ee8e`](https://github.com/NixOS/nixpkgs/commit/f2c5ee8ef3c461e8c2836c122c6025bf2cfd7a4a) | `mutt: 2.2.1 -> 2.2.2`                                              |
| [`4f988c3f`](https://github.com/NixOS/nixpkgs/commit/4f988c3f09d53672c4a392b2b5b29a1ed9660b6b) | `dfeet: fix build with meson 0.61`                                  |
| [`494ce6bb`](https://github.com/NixOS/nixpkgs/commit/494ce6bbcb4b811bf76cec0fb96c76cc4cef1792) | `cppcheck: 2.7 -> 2.7.3`                                            |
| [`589c764e`](https://github.com/NixOS/nixpkgs/commit/589c764e8e3437977beccd3d167eb1a1ce3f78d2) | `cppcheck: fix cppcheck-htmlreport`                                 |
| [`974ede57`](https://github.com/NixOS/nixpkgs/commit/974ede575bbe1dc35cfe641c3959969017d1311f) | `xfig: Install icons and fix desktop file`                          |
| [`a21c84bc`](https://github.com/NixOS/nixpkgs/commit/a21c84bc753dbb330dfbf8fa15ce414c658714dc) | `python3Packages.nilearn: reduce test suite significantly`          |