### PR TITLE
chore(flake/deploy-rs): `4154ba1a` -> `83e0c782`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1643787431,
-        "narHash": "sha256-8IwuVgXulRE3ZWq6z8mytarawC32pKPKR20EyDtSH+w=",
+        "lastModified": 1648475189,
+        "narHash": "sha256-gAGAS6IagwoUr1B0ohE3iR6sZ8hP4LSqzYLC8Mq3WGU=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "4154ba1aaaf7333a916384c348d867d03b6f1409",
+        "rev": "83e0c78291cd08cb827ba0d553ad9158ae5a95c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                          |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`af404f90`](https://github.com/serokell/deploy-rs/commit/af404f90f3c0a7946ccb5d443617f2997ca7d1e9) | `Automatically update flake.lock to the latest version` |