### PR TITLE
chore(flake/nixpkgs): `12417777` -> `9a2de8ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1648352901,
-        "narHash": "sha256-1R31hIpqA+3mKBSayiqUhCm21gw4YRioPuR1WqjlCwU=",
+        "lastModified": 1648541205,
+        "narHash": "sha256-+3At/4RniKCVa9/fLjd+tC6QYyYbSWuv7eUDgX87vGM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "12417777b226eff91efee8b03578daa76c8178a3",
+        "rev": "9a2de8ca73e84455276d84c044791b7dbc3d77e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`9a2de8ca`](https://github.com/NixOS/nixpkgs/commit/9a2de8ca73e84455276d84c044791b7dbc3d77e9) | `Revert "gnome.gnome-color-manager: 3.32.0 → 3.36.0"`                            |
| [`1c48b0f8`](https://github.com/NixOS/nixpkgs/commit/1c48b0f89609e7dc242d0ad20477cb9355ea3bf3) | `ocamlPackages.mimic: remove spurious dependencies`                              |
| [`9dde893c`](https://github.com/NixOS/nixpkgs/commit/9dde893c70ecde505e900764e076c6714cfd7537) | `python3Packages.aioairzone: 0.2.0 -> 0.2.1`                                     |
| [`92a37b61`](https://github.com/NixOS/nixpkgs/commit/92a37b613cda93a3eeea5d71c596afbb7dc8141f) | `python3Packages.rokuecp: 0.15.0 -> 0.16.0`                                      |
| [`69ec8f29`](https://github.com/NixOS/nixpkgs/commit/69ec8f29f583715e15049fe8dc46bc0fd70e69b9) | `python3Packages.sense-energy: 0.10.3 -> 0.10.4`                                 |
| [`0e671e2b`](https://github.com/NixOS/nixpkgs/commit/0e671e2b2b6e65c5712e0ccd8c2645d47f18f362) | `strawberry: 1.0.2 -> 1.0.3`                                                     |
| [`fc3331b5`](https://github.com/NixOS/nixpkgs/commit/fc3331b5223deb61ba7482c9794471665c34d577) | `neovim-remote: add meta.mainProgram (#166173)`                                  |
| [`a48d78cb`](https://github.com/NixOS/nixpkgs/commit/a48d78cb66d86458efe2b34fa94a02345d9b7c12) | `cocoapods: add meta.mainProgram`                                                |
| [`6f9296d1`](https://github.com/NixOS/nixpkgs/commit/6f9296d1b6b7da4b88b848ef36e1bccf3a615300) | `cocoapods: move to more appropriate directory`                                  |
| [`7ef7e309`](https://github.com/NixOS/nixpkgs/commit/7ef7e3092bccd4fdd664c59b895aa311b55dca45) | `python310Packages.mypy-boto3-builder: 7.5.3 -> 7.5.4`                           |
| [`47417621`](https://github.com/NixOS/nixpkgs/commit/47417621a5a54a78944f959230a94e5f5ac1836c) | `_1password: add shell completions`                                              |
| [`03fb5c81`](https://github.com/NixOS/nixpkgs/commit/03fb5c816d6788529771d84ca0989668812dc80b) | `python310Packages.hahomematic: 0.38.5 -> 1.0.0`                                 |
| [`adc4d551`](https://github.com/NixOS/nixpkgs/commit/adc4d551fae8d256cb4b77710178bc779847ef07) | `python310Packages.google-cloud-vision: 2.7.1 -> 2.7.2`                          |
| [`93eb4dbd`](https://github.com/NixOS/nixpkgs/commit/93eb4dbde177b5a0ede1c3174f5cb8a7c566906a) | `_1password: refactor code to reduce duplication`                                |
| [`159d4b45`](https://github.com/NixOS/nixpkgs/commit/159d4b45b4da6928c364bb83eeba2ef7cc75b183) | `python3Packages.ormar: 0.10.25 -> 0.11.0`                                       |
| [`5e92becb`](https://github.com/NixOS/nixpkgs/commit/5e92becb9b35c69b522e0453deca8b8113592f3c) | `robin-map: 0.6.3 -> 1.0.0`                                                      |
| [`914545b2`](https://github.com/NixOS/nixpkgs/commit/914545b23faded2c3abfed5babdf58e090fd0fb0) | `python3Packages.minidb: 2.0.5 -> 2.0.6`                                         |
| [`3657f403`](https://github.com/NixOS/nixpkgs/commit/3657f4033bdb45c5a76591dfdfd1844bc45e533c) | `salt: 3004 -> 3004.1`                                                           |
| [`2cb9593c`](https://github.com/NixOS/nixpkgs/commit/2cb9593cad3a351d064621def6875eee78feaecb) | `firefox: always build with clang`                                               |
| [`4cf4a7b8`](https://github.com/NixOS/nixpkgs/commit/4cf4a7b848b45149c07dd69631ac7d65a49947b4) | `firefox: add pname to throw message`                                            |
| [`05a6b3c2`](https://github.com/NixOS/nixpkgs/commit/05a6b3c2b7ef059a1dccb34c8ebc06ffbb4f2d1f) | `librewolf: disable pgo support`                                                 |
| [`6e24b768`](https://github.com/NixOS/nixpkgs/commit/6e24b768b357fe906a6fdf739fbd0f108c56149a) | `thunderbird: disable pgo support`                                               |
| [`0d3772f6`](https://github.com/NixOS/nixpkgs/commit/0d3772f6455c0185c9dee3f8c31130e7ad6edff9) | `firefox: add profile-guided optimization`                                       |
| [`f37810ba`](https://github.com/NixOS/nixpkgs/commit/f37810ba4ddb9fe77022bb868429a273f6a1d0e2) | `ocamlPackages.core_unix: init at 0.14`                                          |
| [`20e5f8f6`](https://github.com/NixOS/nixpkgs/commit/20e5f8f6a37d4b409f1f20d7e446fce483b0a095) | `python3Packages.aiogithubapi: 22.2.4 -> 22.3.1`                                 |
| [`cee1fe7b`](https://github.com/NixOS/nixpkgs/commit/cee1fe7b6fe30283eaa2e64d07a8fd3b861b7733) | `python3Packages.aioairzone: 0.1.2 -> 0.2.0`                                     |
| [`e1537bad`](https://github.com/NixOS/nixpkgs/commit/e1537badd3c56cb0d860a03b4b826f17f3b59536) | `python3Packages.pyoverkiz: 1.3.10 -> 1.3.12`                                    |
| [`9c16cf90`](https://github.com/NixOS/nixpkgs/commit/9c16cf9005af3f7dc9c7ad013bf09cb6822e22f5) | `ocamlPackages.ocplib-endian: disable for OCaml ≤ 4.02`                          |
| [`9211608d`](https://github.com/NixOS/nixpkgs/commit/9211608da78fc354236de1e981577d7ac4a43afe) | `ocamlPackages.wasm: disable with OCaml 4.02`                                    |
| [`3d7f865d`](https://github.com/NixOS/nixpkgs/commit/3d7f865ddbcd01b16fc2dc6081ef84ff25b9bd50) | `ocamlPackages.uutf: disable with OCaml ≤ 4.02`                                  |
| [`700c4a70`](https://github.com/NixOS/nixpkgs/commit/700c4a7055242915c890aa79bd7f534b77a1d65b) | `ocamlPackages.bolt: remove at 1.4 (broken with OCaml 4.02)`                     |
| [`dd3e2f95`](https://github.com/NixOS/nixpkgs/commit/dd3e2f9587d76cf59c4ad1de640c587131e6e3d6) | `python3Packages.metar: patch another failing test`                              |
| [`23a1f8d4`](https://github.com/NixOS/nixpkgs/commit/23a1f8d4cce101784e402b262637e303f044bf92) | `python3Packages.mcstatus: 9.0.2 -> 9.0.3`                                       |
| [`6d90a2cb`](https://github.com/NixOS/nixpkgs/commit/6d90a2cbf1c500ada84f03f4c3425a8fbfaf3e3f) | `python3Packages.asyncstdlib: update ordering`                                   |
| [`93a7c9e4`](https://github.com/NixOS/nixpkgs/commit/93a7c9e4be173e3b669b3d80ae9f65699f5b8c6d) | `python3Packages.azure-mgmt-cognitiveservices: disable on older Python releases` |
| [`ffd4e2fe`](https://github.com/NixOS/nixpkgs/commit/ffd4e2fe0913fe05b092bdeee833fc733dd77c83) | `python3Packages.azure-mgmt-signalr: disable on older Python releases`           |
| [`ed6ba92f`](https://github.com/NixOS/nixpkgs/commit/ed6ba92fa334b512b0cba4002c6ad0d1dd52c455) | `python3Packages.elastic-apm: 6.8.0 -> 6.8.1`                                    |
| [`0aa98b5a`](https://github.com/NixOS/nixpkgs/commit/0aa98b5a31ed5049e61efd3ce2c905e10f191cdd) | `pdns: remove boost override`                                                    |
| [`80d8655c`](https://github.com/NixOS/nixpkgs/commit/80d8655c15055472f0118a877351085cc22c1e92) | `ocamlPackages.fiat-p256: remove at 0.2.1`                                       |
| [`2a324748`](https://github.com/NixOS/nixpkgs/commit/2a3247480291c808d227b29d125c7324f11b353f) | `firefox: fix drmSupport flag`                                                   |
| [`999f3c2b`](https://github.com/NixOS/nixpkgs/commit/999f3c2b9d61942e3fd07dfaa1d6c51d080351ce) | `pdns: rename from powerdns`                                                     |
| [`5cfb6815`](https://github.com/NixOS/nixpkgs/commit/5cfb6815f3f83ffb6b5800ff372e69c57533dba4) | `python310Packages.azure-mgmt-signalr: 1.0.0 -> 1.1.0`                           |
| [`bda82086`](https://github.com/NixOS/nixpkgs/commit/bda820861213579f27b25eec27e80b7e58d9d463) | `python310Packages.azure-mgmt-cognitiveservices: 13.0.0 -> 13.1.0`               |
| [`3221d6d4`](https://github.com/NixOS/nixpkgs/commit/3221d6d4188ac63fbb77f9d11aabf6c890a76eeb) | `rl-2205: fix typo in frrrouting announcement`                                   |
| [`2f2049b1`](https://github.com/NixOS/nixpkgs/commit/2f2049b1fd78bff3395c823baf91da815ddcc116) | `python310Packages.asyncstdlib: 3.10.3 -> 3.10.4`                                |
| [`af262002`](https://github.com/NixOS/nixpkgs/commit/af26200234b81d2ed83b3937b73099892bcbdea4) | `gnomeExtensions: add gnome40Extensions to gnomeExtensions`                      |
| [`b133ad05`](https://github.com/NixOS/nixpkgs/commit/b133ad055b129b7b7e8e66f883b6120f41f8b584) | `ydotool: minor fixes (#166050)`                                                 |
| [`ee684089`](https://github.com/NixOS/nixpkgs/commit/ee684089c3509820d6f1fc8938025d091797c3d6) | `melt: init at 0.2.0 (#164439)`                                                  |
| [`fc49bc19`](https://github.com/NixOS/nixpkgs/commit/fc49bc19edd8e9eaea703c795395c2f78354ba80) | `powerdns: redact configure flags from version output to reduce closure size`    |
| [`e85e545d`](https://github.com/NixOS/nixpkgs/commit/e85e545dbda8bdf09b32e69545ace49b7bc63c23) | `powerdns: 4.3.1 -> 4.6.1`                                                       |
| [`e7aa35cc`](https://github.com/NixOS/nixpkgs/commit/e7aa35ccf1d2f864d022da23661c702a1099e050) | `python310Packages.aiowebostv: 0.1.3 -> 0.2.0`                                   |
| [`adf885ca`](https://github.com/NixOS/nixpkgs/commit/adf885ca00c87beded0c4697b5818710d5cd485f) | `gummy: init at 0.1`                                                             |
| [`d999e481`](https://github.com/NixOS/nixpkgs/commit/d999e481028779e10c1556e208604056015f8026) | `logiops: init at 0.2.3`                                                         |
| [`8c496e61`](https://github.com/NixOS/nixpkgs/commit/8c496e61930d1e83282d919da3a86ce4cff3091b) | `vimPlugins.vim-svelte: init at 2022-02-17`                                      |
| [`85f2d57a`](https://github.com/NixOS/nixpkgs/commit/85f2d57a48fc16bf7811a6c64c9ef5b145884020) | `vimPlugins.coc-svelte: init at 2022-03-14`                                      |
| [`996863b0`](https://github.com/NixOS/nixpkgs/commit/996863b07e7c40ab9cb6a0ef664aa49fd0093f47) | `vimPlugins.coc-tailwindcss: init at 2020-08-19`                                 |
| [`c8a5b5aa`](https://github.com/NixOS/nixpkgs/commit/c8a5b5aa89a2f8fa8bbe44f51a0e92c13d0e5d35) | `vimPlugins: update`                                                             |
| [`9c37bef3`](https://github.com/NixOS/nixpkgs/commit/9c37bef37c6f9238de20911a8793d3629581f852) | `oh-my-zsh: 2022-03-26 -> 2022-03-28`                                            |
| [`de0f59ea`](https://github.com/NixOS/nixpkgs/commit/de0f59ea3782a272b7b76620cfb73d172786aa99) | `kaf: init at 0.1.44 (#164175)`                                                  |
| [`8aa41aea`](https://github.com/NixOS/nixpkgs/commit/8aa41aeaea77d1ad943abbbbaf0252b1a4cee81c) | `teleport: fix exec srv command not found (#165588)`                             |
| [`ed6c2f9d`](https://github.com/NixOS/nixpkgs/commit/ed6c2f9d8489c17fecb4011f57280372e70be26c) | `argocd-autopilot: init at 0.3.0`                                                |
| [`51631359`](https://github.com/NixOS/nixpkgs/commit/51631359fa1d9a6f229aaac9e0af7beec7742389) | `yq-go: 4.23.1 -> 4.24.2`                                                        |
| [`b3de8509`](https://github.com/NixOS/nixpkgs/commit/b3de8509511fecc7276f6b5b393d823ea329cc87) | `python39Packages.swift: 2.29.0 -> 2.29.1`                                       |
| [`87c0118a`](https://github.com/NixOS/nixpkgs/commit/87c0118ab1873a48f584566daf05ce6d691e8e2b) | `sshuttle: 1.0.5 -> 1.1.0, add SuperSandro2000 as maintainer`                    |
| [`7be87f3d`](https://github.com/NixOS/nixpkgs/commit/7be87f3dabfeeb0f8bcacb9b4a5a6040362dc30d) | `python3Packages.pyskyqhub: 0.1.7 -> 0.1.8`                                      |
| [`cd4a0b88`](https://github.com/NixOS/nixpkgs/commit/cd4a0b8875a03fdbfb2a5f0bc343083ac930777d) | `python3Packages.pyskyqhub: 0.1.6 -> 0.1.7`                                      |
| [`97f06b5e`](https://github.com/NixOS/nixpkgs/commit/97f06b5e0b3906e6f0141d85dcd5ab3aa2a55816) | `byzan: switch to working source`                                                |
| [`21120194`](https://github.com/NixOS/nixpkgs/commit/21120194ee6db25b41359ed0eb0eca0e5da855d7) | `luarocks-packages: replace git://github.com with https://`                      |
| [`17c8525e`](https://github.com/NixOS/nixpkgs/commit/17c8525e51ac96ef83369a1071d573098cd8e45e) | `onlykey: replace git://github.com with https://`                                |
| [`bea3dc3a`](https://github.com/NixOS/nixpkgs/commit/bea3dc3a4cbdf9e1275604d58a2fa534455152e8) | `nixui: replace git://github.com with https://`                                  |
| [`7963f78b`](https://github.com/NixOS/nixpkgs/commit/7963f78ba7c52a85e0db3f3a7748f5f68da4eb49) | `python3Packages.habanero: add pythonImportsCheck`                               |
| [`3ae9e59e`](https://github.com/NixOS/nixpkgs/commit/3ae9e59e41776520c05836501223671d3586839d) | `python39Packages.editorconfig: workaround removal of git://`                    |
| [`be3b235c`](https://github.com/NixOS/nixpkgs/commit/be3b235cd19e0be790087a6e3f972a847ad44aed) | `rar: 6.0.2 -> 6.11`                                                             |
| [`b83c8aff`](https://github.com/NixOS/nixpkgs/commit/b83c8aff1e21a071ce8a623dbdc76ac148156c08) | `rar: fix build on darwin`                                                       |
| [`881e60eb`](https://github.com/NixOS/nixpkgs/commit/881e60eb98bac9ccb92f2c9d7ee05aff9afc0f37) | `linuxPackages.rtl8821ce: fix build for kernel >= 5.17`                          |
| [`bb18719b`](https://github.com/NixOS/nixpkgs/commit/bb18719b6d305b8395b6d4def57b1a8d452794e7) | `python310Packages.habanero: 1.0.0 -> 1.2.0`                                     |
| [`7d1a55bd`](https://github.com/NixOS/nixpkgs/commit/7d1a55bdfb7feca0fdfe9ea7105b5c340f455999) | `gitlab: 14.8.4 -> 14.9.1 (#165309)`                                             |
| [`566270be`](https://github.com/NixOS/nixpkgs/commit/566270be89071fcc732d20b5d907794b1f13b2e5) | `linux: 5.4.187 -> 5.4.188`                                                      |
| [`2ddb5604`](https://github.com/NixOS/nixpkgs/commit/2ddb5604db46d2b8e30d49ba5db7c87281afafac) | `linux: 5.17 -> 5.17.1`                                                          |
| [`aa374b7a`](https://github.com/NixOS/nixpkgs/commit/aa374b7acb3119ec7c83f3d564942549e24c9fc0) | `linux: 5.16.17 -> 5.16.18`                                                      |
| [`6c6a932a`](https://github.com/NixOS/nixpkgs/commit/6c6a932a9e28ef618fce839d545b6867d533ed40) | `linux: 5.15.31 -> 5.15.32`                                                      |
| [`2abfedc5`](https://github.com/NixOS/nixpkgs/commit/2abfedc54c38442a6660c3a5569bd53c0ed5aa18) | `linux: 5.10.108 -> 5.10.109`                                                    |
| [`61df0a1d`](https://github.com/NixOS/nixpkgs/commit/61df0a1d7dd69a973913fe98efccc6bbdbd206a6) | `linux: 4.9.308 -> 4.9.309`                                                      |
| [`f77a0e19`](https://github.com/NixOS/nixpkgs/commit/f77a0e19341a9c1b41d0951f30d732de51530221) | `linux: 4.19.236 -> 4.19.237`                                                    |
| [`9ee8097b`](https://github.com/NixOS/nixpkgs/commit/9ee8097b31a2f7aed41b7bc1c15d7f3fbee2bc5f) | `linux: 4.14.273 -> 4.14.274`                                                    |
| [`9c26dceb`](https://github.com/NixOS/nixpkgs/commit/9c26dceb88f76bf503d474a2593175446f9bcdb4) | `python3Packages.ansible-later: set version, enable tests`                       |
| [`e2cc03a0`](https://github.com/NixOS/nixpkgs/commit/e2cc03a069d834236dff1fb89eb955a26f15a9ea) | `python3Packages.subarulink: 0.4.3 -> 0.5.0`                                     |
| [`27d0d8d6`](https://github.com/NixOS/nixpkgs/commit/27d0d8d64b4aa5b12065ec75061666d60bb9cccd) | `python310Packages.ansible-later: 2.0.6 -> 2.0.8`                                |
| [`be917906`](https://github.com/NixOS/nixpkgs/commit/be917906e2e78d9af6bce7f8758d09dc4b517c16) | `python3Packages.minikerberos: 0.2.18 -> 0.2.20`                                 |
| [`b0d31a69`](https://github.com/NixOS/nixpkgs/commit/b0d31a697f9bd46d43caf58082cda5d5ea5be8ac) | `python3Packages.unicrypto: 0.0.2 -> 0.0.5`                                      |
| [`d0b22196`](https://github.com/NixOS/nixpkgs/commit/d0b22196f515b0143d8b5bdf312f2e42e312646d) | `python3Packages.unicrypto: init at 0.0.2`                                       |
| [`939ac39e`](https://github.com/NixOS/nixpkgs/commit/939ac39ee49de2a2e747c4d5533b1bb8a95b53c3) | `python3Packages.asyncmy: 0.2.3 -> 0.2.4`                                        |
| [`c5914daa`](https://github.com/NixOS/nixpkgs/commit/c5914daa9f80bef4669909f5d9879c2869c67dad) | `python3Packages.s3-credentials: add pythonImportsCheck`                         |
| [`478e6f96`](https://github.com/NixOS/nixpkgs/commit/478e6f963e3c22ecbd352dae1101569b2d8e5eea) | `python3Packages.androidtv: 0.0.65 -> 0.0.66`                                    |
| [`06327ff6`](https://github.com/NixOS/nixpkgs/commit/06327ff6d2198a56abe5e15452919f744e364595) | `python3Packages.elkm1-lib: 1.2.0 -> 1.2.1`                                      |
| [`49e412b0`](https://github.com/NixOS/nixpkgs/commit/49e412b04614d8a5f1b4c91a166efdfdecd91cbb) | `rancher: 2.6.0 -> 2.6.4`                                                        |
| [`db55843a`](https://github.com/NixOS/nixpkgs/commit/db55843a2e7e0d08548f4031dc04f17439c18f9a) | `python3Packages.mcstatus: 8.0.0 -> 9.0.2`                                       |
| [`a107f9de`](https://github.com/NixOS/nixpkgs/commit/a107f9de561054afc111dd9ccf993bd8e38f79aa) | `ffuf: 1.3.1 -> 1.4.0`                                                           |
| [`32ee651e`](https://github.com/NixOS/nixpkgs/commit/32ee651ea94214b8c769b1482b2bf44da533cf7a) | `python310Packages.sabyenc3: 5.1.3 -> 5.1.5`                                     |
| [`70dc29f9`](https://github.com/NixOS/nixpkgs/commit/70dc29f9e8c4bce8d541f997cd7b18e583ed6278) | `terraform-providers: update 2022-03-28`                                         |
| [`87c74b81`](https://github.com/NixOS/nixpkgs/commit/87c74b8120980461a9d4ce8f341551ce0fb50728) | `User manual: document duneVersion`                                              |
| [`7cc59659`](https://github.com/NixOS/nixpkgs/commit/7cc596593c5cae180024b1322f366847ae764bbe) | `ocamlPackages.dune-private-libs: 2.9.3 → 3.0.3`                                 |
| [`b19721dc`](https://github.com/NixOS/nixpkgs/commit/b19721dc2a8ceb8d1f46260aad0d5a8783a4b499) | `ocamlPackages.stdune: init at 3.0.3`                                            |
| [`ab975418`](https://github.com/NixOS/nixpkgs/commit/ab97541807bc7126d577cdc75f46e07a5b052e7b) | `ocamlPackages.dyn: init at 3.0.3`                                               |
| [`ac07d2fa`](https://github.com/NixOS/nixpkgs/commit/ac07d2fa3edf8fb74f34c641b892161a177609df) | `ocamlPackages.ordering: init at 3.0.3`                                          |
| [`bb559f92`](https://github.com/NixOS/nixpkgs/commit/bb559f92af22bca4f1b58a0fe5b1412fea7e7cca) | `stog: use dune version 3`                                                       |
| [`15f220b0`](https://github.com/NixOS/nixpkgs/commit/15f220b07ced65b6ca8ed862249bf180b5ace9ca) | `ocamlPackages.buildDunePackage: add support for dune 3`                         |
| [`97e58635`](https://github.com/NixOS/nixpkgs/commit/97e586356901b2ea7b6df453caf43b98fae355a3) | `deltachat-desktop: update react-string-replace to 1.0.0`                        |
| [`401a033c`](https://github.com/NixOS/nixpkgs/commit/401a033c6fab4ac564b24d8a466505a72213690f) | `deltachat-desktop: fix icon`                                                    |
| [`4c0dc16f`](https://github.com/NixOS/nixpkgs/commit/4c0dc16f28692de49919551466caf0c0856c6f83) | `ircdog: 0.2.1 -> 0.3.0`                                                         |
| [`1724e20f`](https://github.com/NixOS/nixpkgs/commit/1724e20fbc851f0dd40827335e042b13f8291e9a) | `Revert "python39Packages.google-auth-oauthlib: 0.4.6 -> 0.5.1"`                 |
| [`c1a928b3`](https://github.com/NixOS/nixpkgs/commit/c1a928b30bcc77456ea2db8df464eae865e25e7d) | `crystal: remove pointless reference to crystal.lib`                             |
| [`30527ee7`](https://github.com/NixOS/nixpkgs/commit/30527ee7e5ebfaf0a82973259ae1791e5e3a8fff) | `python310Packages.mypy-boto3-builder: 7.4.1 -> 7.5.3`                           |
| [`08b1f113`](https://github.com/NixOS/nixpkgs/commit/08b1f113d9ad681deb392e53ec5742e47d0734fc) | `python310Packages.types-requests: 2.27.14 -> 2.27.15`                           |
| [`6e6a3202`](https://github.com/NixOS/nixpkgs/commit/6e6a3202c4ce57f230b9d68df26c5813c9170e3a) | `all-packages.nix: pythonXPackages point to pythonXXPackages`                    |
| [`1edfe6d9`](https://github.com/NixOS/nixpkgs/commit/1edfe6d91bd8348cfccacd72e82d1d06ad470117) | `cosmopolitan: 0.3 -> unstable-2022-03-22`                                       |
| [`a39b29dd`](https://github.com/NixOS/nixpkgs/commit/a39b29dd095327add9a8fbd09ce52f6b9526c7ad) | `git-branchless: 0.3.9 -> 0.3.10`                                                |
| [`f4182075`](https://github.com/NixOS/nixpkgs/commit/f4182075ff292f9c737fa2281f60ea4f514ace89) | `Update pkgs/development/python-modules/osc-lib/default.nix`                     |
| [`e3d498d1`](https://github.com/NixOS/nixpkgs/commit/e3d498d19ee7bb185873a626da2a5b3f959effa5) | `pscale: 0.89.0 -> 0.90.0`                                                       |
| [`d4b233e3`](https://github.com/NixOS/nixpkgs/commit/d4b233e330f21cc526ac64923d94c6aea0d4400d) | `python39Packages.google-cloud-bigquery: disable tests which require network`    |
| [`6d111cbf`](https://github.com/NixOS/nixpkgs/commit/6d111cbf6153183e251a9518ba5f424d0e731638) | `Clarify that lld package provides unwrapped lld`                                |
| [`a0968ef3`](https://github.com/NixOS/nixpkgs/commit/a0968ef3b4b65d4c47a4c91e9464503264445837) | `python310Packages.debugpy: 1.5.1 -> 1.6.0`                                      |
| [`ca79392b`](https://github.com/NixOS/nixpkgs/commit/ca79392bbca3b8e8155780e80dae0e94b308c1f9) | `python39Packages.osc-lib: 2.5.0 -> unstable-2022-03-09`                         |
| [`68eb7fdd`](https://github.com/NixOS/nixpkgs/commit/68eb7fdd62ac795260ba6d838522750ef5551397) | `s3-credentials: init at 0.10`                                                   |
| [`5e7bced9`](https://github.com/NixOS/nixpkgs/commit/5e7bced95e9e0114653435528c1cdb8e03d48491) | `python3Packages.invocations: init at 2.6.0`                                     |
| [`82761fb6`](https://github.com/NixOS/nixpkgs/commit/82761fb688373e2ca6f08b1f4e718a4f5859eaba) | `python3Packages.releases: init at 1.6.3`                                        |
| [`91e952f8`](https://github.com/NixOS/nixpkgs/commit/91e952f8861e0171abae80a95dab40a54fd8627d) | `python39Packages.arviz: 0.11.4 -> 0.12.0`                                       |
| [`3c245b4e`](https://github.com/NixOS/nixpkgs/commit/3c245b4e49da57dee44ecc3e8164987f1d96c894) | `spicetify-cli: 2.9.2 -> 2.9.4`                                                  |
| [`07c164d3`](https://github.com/NixOS/nixpkgs/commit/07c164d35b10741954fe110510c76efc20b465f5) | `python310Packages.scikit-fmm: 2022.2.2 -> 2022.3.26`                            |
| [`5c4c67e5`](https://github.com/NixOS/nixpkgs/commit/5c4c67e55d79a17d0c6eaf85eaf41783069cc191) | `python39Packages.python-novaclient: 17.6.0 -> 17.7.0`                           |