### PR TITLE
chore(flake/nixpkgs): `9a2de8ca` -> `00e27c78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1648541205,
-        "narHash": "sha256-+3At/4RniKCVa9/fLjd+tC6QYyYbSWuv7eUDgX87vGM=",
+        "lastModified": 1648583894,
+        "narHash": "sha256-wdhgGO3yiBn7fMmI2jSfoondsh2O8Jt81e3H4RYnrHc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9a2de8ca73e84455276d84c044791b7dbc3d77e9",
+        "rev": "00e27c78d3d2de6964096ceee8d70e5b487365e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                               |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`b77b6bca`](https://github.com/NixOS/nixpkgs/commit/b77b6bca3848113a1cd85ed9d04a7f232d088aaf) | `roon-bridge: 1.8-880 -> 1.8-918`                                                            |
| [`fed59bde`](https://github.com/NixOS/nixpkgs/commit/fed59bdef375bbf21442b82fe378881cba0bf650) | `roon-server: 1.8-903 -> 1.8-923`                                                            |
| [`4d5c0f0b`](https://github.com/NixOS/nixpkgs/commit/4d5c0f0ba4fabbfd447c62ed1eb2d06cff7e83de) | `python39Packages.pycrypto: update meta`                                                     |
| [`0d2fc67c`](https://github.com/NixOS/nixpkgs/commit/0d2fc67c5011d4716770c99ab673159bd703e9ca) | `python310Packages.bids-validator: 1.9.2 -> 1.9.3`                                           |
| [`08ab0fab`](https://github.com/NixOS/nixpkgs/commit/08ab0fab0a7058f099b7d73dc9692419097b0336) | `python3Packages.click: add downstream tests`                                                |
| [`388382de`](https://github.com/NixOS/nixpkgs/commit/388382de81a53a4331a29545b6c2db88e3b11993) | `python3Packages.azure-keyvault-keys: disable on older Python releases`                      |
| [`1a718a16`](https://github.com/NixOS/nixpkgs/commit/1a718a1677940796b42486b659aa29344c956e49) | `python310Packages.azure-keyvault-keys: 4.4.0 -> 4.5.0`                                      |
| [`b228be7e`](https://github.com/NixOS/nixpkgs/commit/b228be7ef6c602b1d096a8e50bd563d1f38ed9ae) | `python3Packages.osmnx: 1.1.1 → 1.1.2`                                                       |
| [`8e27053f`](https://github.com/NixOS/nixpkgs/commit/8e27053ff079c2a34d50b7ca7ab8759113670ed2) | `python310Packages.azure-keyvault-administration: 4.0.0 -> 4.1.0`                            |
| [`64ead2ba`](https://github.com/NixOS/nixpkgs/commit/64ead2ba7da2da3b269cff762c83c705e9dd6f11) | `unifi7: 7.0.23 -> 7.0.25`                                                                   |
| [`41e26044`](https://github.com/NixOS/nixpkgs/commit/41e2604483babe9e70429887ff5293aaa8bdb1bb) | `nixos/dhcpd6: Use fixed-address6 for dhcpd6 address reservations`                           |
| [`316e4a4c`](https://github.com/NixOS/nixpkgs/commit/316e4a4ca184512a1620baf014452c97bc11b025) | `perlPackages.PLS: shorten shebang on Darwin`                                                |
| [`66cb2008`](https://github.com/NixOS/nixpkgs/commit/66cb200860e0e399460e9c18b8e79b05b0375fe7) | `python3Packages.notifymuch: Init at 0.1 (#166075)`                                          |
| [`ea35502f`](https://github.com/NixOS/nixpkgs/commit/ea35502fe4db6f9be94ae8461bf14c223ccef180) | `xtris: fix darwin build`                                                                    |
| [`448c1d0e`](https://github.com/NixOS/nixpkgs/commit/448c1d0e86cc8f77b07d9a389340e3e1ffbdd3f0) | `polkadot: fix darwin build`                                                                 |
| [`e0e1ad16`](https://github.com/NixOS/nixpkgs/commit/e0e1ad16be1a8c0e1038961e5df2973e6927cc57) | `krelay: init at 0.0.2`                                                                      |
| [`b7e6749a`](https://github.com/NixOS/nixpkgs/commit/b7e6749a32a2d9950a753138b614f7b543c96d9b) | `home-assistant: 2022.3.7 -> 2022.3.8`                                                       |
| [`e9c2918e`](https://github.com/NixOS/nixpkgs/commit/e9c2918e9bce73019f9581b26555bbd5bcb44e78) | `gnome.gnome-control-center: fix Online Accounts configuration on X11`                       |
| [`6cdf6954`](https://github.com/NixOS/nixpkgs/commit/6cdf69546b32b657fd64e9d2aa48d4a25c809fef) | `firefox: allow RDD sandbox access to gpu drivers`                                           |
| [`e9252627`](https://github.com/NixOS/nixpkgs/commit/e92526274d79415b9f8b6623af23b3952f7119cb) | `python39Packages.libcst: switch to pytestCheckHook, remove linters`                         |
| [`bd820dba`](https://github.com/NixOS/nixpkgs/commit/bd820dbaabc1890743743748966ad5745565645b) | `python39Packages.tempora: switch to pytestCheckHook, remove linter`                         |
| [`f4e164ee`](https://github.com/NixOS/nixpkgs/commit/f4e164ee0262f35cf5ff3b949a5592e0cadedc7c) | `python39Packages.portend: switch to pytestCheckHook, remove linter`                         |
| [`9dbdba06`](https://github.com/NixOS/nixpkgs/commit/9dbdba06180218bcfb78dbd1ca9e05a9d19e9aef) | `python310Packages.backports_functools_lru_cache: switch to pytestCheckHook, remove linters` |
| [`fc5e712d`](https://github.com/NixOS/nixpkgs/commit/fc5e712dcc2a01ef0ed9ae9024e59a0aa60b49cd) | `session-desktop-appimage: refactor`                                                         |
| [`b2000742`](https://github.com/NixOS/nixpkgs/commit/b2000742e7322cda33d20e0be5b41e6a123ce3d0) | `cudatext: 1.159.0 -> 1.159.2`                                                               |
| [`1ab9577e`](https://github.com/NixOS/nixpkgs/commit/1ab9577ed65a4ee76b5a0b6a3453fd3f7edb6de8) | `drawio: 17.2.1 -> 17.2.4`                                                                   |
| [`05a6c124`](https://github.com/NixOS/nixpkgs/commit/05a6c124e65d30b5e68468c8b87f73d6b1a8c587) | `lvm2: don't use targetPlatform`                                                             |
| [`9fe1eae4`](https://github.com/NixOS/nixpkgs/commit/9fe1eae494c581ebb4023c1c4fce88d96f9a7a77) | `bluej: 5.0.2 -> 5.0.3`                                                                      |
| [`2f3e0789`](https://github.com/NixOS/nixpkgs/commit/2f3e0789fdc7c7f594d4ab2e879deb4f3023c6c0) | `python39Packages.pymarshal: remove pytest-cov, pytest-runner`                               |
| [`13baee82`](https://github.com/NixOS/nixpkgs/commit/13baee8253b0d6cf678691a0d75e44cd334e3b95) | `terraform-providers.utils: init at 0.17.17`                                                 |
| [`22773bb8`](https://github.com/NixOS/nixpkgs/commit/22773bb820a745a5d442012acac0d4c61bc76242) | `python3Packages.sip: fix builds of dependents on non-x86 Linux`                             |
| [`3b8a5bfe`](https://github.com/NixOS/nixpkgs/commit/3b8a5bfefa327d0163707748c4a9bff678d7e0a3) | `python3.pkgs.paramiko: apply patch to fix usage of dsa keys`                                |
| [`29d6ea9c`](https://github.com/NixOS/nixpkgs/commit/29d6ea9c6cbf329972fa715815283553569551bf) | `python3.pkgs.paramiko: 2.9.2 -> 2.10.3`                                                     |
| [`28e54219`](https://github.com/NixOS/nixpkgs/commit/28e54219279388e71feca63470d9857b5e36109f) | `slic3r: switch to fetchFromGitHub`                                                          |
| [`2612a06b`](https://github.com/NixOS/nixpkgs/commit/2612a06b21efbb6b15255ad3710fa805729b8d36) | `twister: switch to fetchFromGitHub`                                                         |
| [`19135190`](https://github.com/NixOS/nixpkgs/commit/191351907106a82c985a4d0ed7467aad8b3aecec) | `darcs-to-git: switch to fetchFromGitHub`                                                    |
| [`da2cbf54`](https://github.com/NixOS/nixpkgs/commit/da2cbf54e8ec3e66e2e24d2c55823bce98a7f96b) | `haskellPackages.ghcjs-base_0_2_0_3: switch to fetchFromGitHub`                              |
| [`88ca5815`](https://github.com/NixOS/nixpkgs/commit/88ca581508c64c88dcb1aaef176885ad10381598) | `hammer: switch to fetchFromGitHub`                                                          |
| [`ab7a5fa3`](https://github.com/NixOS/nixpkgs/commit/ab7a5fa31cd4648341fd15233b545ad3f4d3f04b) | `disk_indicator: switch to fetchFromGitHub`                                                  |
| [`cdf7d5d6`](https://github.com/NixOS/nixpkgs/commit/cdf7d5d62d4de2603b20da14006d082ade5c1048) | `pa_applet: switch to fetchFromGitHub`                                                       |
| [`b4c72db1`](https://github.com/NixOS/nixpkgs/commit/b4c72db1782e54fdfce0b500ea0181e6cb8a424b) | `carddav-util: switch to fetchFromGitHub`                                                    |
| [`fa1a2339`](https://github.com/NixOS/nixpkgs/commit/fa1a23392dfd62daf816f7be7a52ace62d0de1a2) | `nixui: switch to fetchFromGitHub`                                                           |
| [`35c43df7`](https://github.com/NixOS/nixpkgs/commit/35c43df71174c913245f84f51df1cf4e372add8f) | `scsh: switch to fetchFromGitHub`                                                            |
| [`20a5de1e`](https://github.com/NixOS/nixpkgs/commit/20a5de1e431d2ef4a4f0ccbeca0fb0f7b6c233a3) | `python310Packages.scmrepo: 0.0.13 -> 0.0.14`                                                |
| [`c01faddb`](https://github.com/NixOS/nixpkgs/commit/c01faddbd5881f6667703fa176baf5f8fe5c776e) | `kubecolor: fix --kubecolor-version, add SuperSandro2000 as maintainer`                      |
| [`51ec0035`](https://github.com/NixOS/nixpkgs/commit/51ec00354b7af264d5db042a56c98ba4fe1afe35) | `lowdown: 0.10.0 -> 0.11.1`                                                                  |
| [`e4e8a630`](https://github.com/NixOS/nixpkgs/commit/e4e8a630d72247e6f8e35bb8ec97170e66d1ec31) | `clojure: 1.11.0.1097 -> 1.11.0.1100`                                                        |
| [`54066822`](https://github.com/NixOS/nixpkgs/commit/54066822a56a217514f9cfce6e66588546be7e48) | `nbench: fix darwin build`                                                                   |
| [`66d28a38`](https://github.com/NixOS/nixpkgs/commit/66d28a38c04dfc53a6d50c4c0803bf05ca8e1caf) | `python310Packages.ansible-later: 2.0.6 -> 2.0.8`                                            |
| [`9f715a3d`](https://github.com/NixOS/nixpkgs/commit/9f715a3d31a743630e49d1a8886b0372a305a88a) | `nixos/grafana: Add foldersFromFilesStructure option for dashboard provisioning (#132348)`   |
| [`3491c5ea`](https://github.com/NixOS/nixpkgs/commit/3491c5ea290bca5437845b6348919fcb23950af9) | `runc: 1.1.0 -> 1.1.1`                                                                       |
| [`1fff543a`](https://github.com/NixOS/nixpkgs/commit/1fff543a34647f34eab621084b160c4bc4dc147e) | `neovim: remove with lib over entire file`                                                   |
| [`bb35948c`](https://github.com/NixOS/nixpkgs/commit/bb35948c1ccd81a8e3b6165a6b01c7f54523f629) | `gerrit: 3.4.1 -> 3.5.1 (#166178)`                                                           |
| [`9b7f392f`](https://github.com/NixOS/nixpkgs/commit/9b7f392f756e55ec9e5bc88f2defee626b1325f3) | `vte: 0.67.90 → 0.68.0`                                                                      |
| [`ae92c8f5`](https://github.com/NixOS/nixpkgs/commit/ae92c8f516a90b9bf8d96c7cab77a22134a889f1) | `gnome.yelp: 42.0 → 42.1`                                                                    |
| [`16b40423`](https://github.com/NixOS/nixpkgs/commit/16b40423732c1ffb728182838422f8a772174e1a) | `gnome.gnome-terminal: 3.43.90 → 3.44.0`                                                     |
| [`d9e7d63c`](https://github.com/NixOS/nixpkgs/commit/d9e7d63cc53ff6cc669168f4ed0bc573bb78d670) | `sam-ba: 2.16 -> 3.5`                                                                        |
| [`90d60458`](https://github.com/NixOS/nixpkgs/commit/90d6045851f2086701e4dafedd66216e79af3ac9) | `python3Packages.azure-keyvault-certificates: disable on older Python releases`              |
| [`790d23bf`](https://github.com/NixOS/nixpkgs/commit/790d23bf71787e649a3dbf901a32445aec4870a9) | `python310Packages.pyrogram: 1.4.9 -> 1.4.12`                                                |
| [`4a0bc9ae`](https://github.com/NixOS/nixpkgs/commit/4a0bc9ae527a6a72da4e37afd865e90f6352f717) | `python310Packages.azure-keyvault-certificates: 4.3.0 -> 4.4.0`                              |
| [`db282610`](https://github.com/NixOS/nixpkgs/commit/db282610c604bc0c625121665503b1237b3719bc) | `python3Packages.jsbeautifier: switch to pytestCheckHook, add pythonImportsCheck`            |
| [`5b45f145`](https://github.com/NixOS/nixpkgs/commit/5b45f1458f69c697e9da6235df589f18a2fdb02e) | `picoc: fix darwin build`                                                                    |
| [`aeb65012`](https://github.com/NixOS/nixpkgs/commit/aeb65012faef8aa9329b4caccfab94fda0684c77) | `ocamlPackages.{macaddr,ipaddr}: minor cleaning`                                             |
| [`9ec6f8fc`](https://github.com/NixOS/nixpkgs/commit/9ec6f8fc9bb351c4ab47de9666763d602b9d68c2) | `fac-build: fix darwin build`                                                                |
| [`93fb6f2b`](https://github.com/NixOS/nixpkgs/commit/93fb6f2bbc9d59c358ce1d455fe4bc4388825997) | `obsidian: 0.13.31 -> 0.14.2`                                                                |
| [`0bc4ac64`](https://github.com/NixOS/nixpkgs/commit/0bc4ac64dbdd9549bde7245ed9e5e6a8e28b4ee8) | `bless: disable tests via mesonFlags`                                                        |
| [`33b04f2a`](https://github.com/NixOS/nixpkgs/commit/33b04f2a80aa6a4556a0cbc102f82c2b8d788fe0) | `nixos/unifi-video: add deprecation warning for openFirewall`                                |
| [`b69780ec`](https://github.com/NixOS/nixpkgs/commit/b69780ecdb4093d31f18f438580934a49d8f68ad) | `python310Packages.jsbeautifier: 1.14.0 -> 1.14.1`                                           |
| [`351ce2ec`](https://github.com/NixOS/nixpkgs/commit/351ce2ecfea82033036f8bb0d26c604f827fc2c4) | `tilt: 0.26.2 -> 0.26.3`                                                                     |
| [`f24ae965`](https://github.com/NixOS/nixpkgs/commit/f24ae9654df290aeace55bfdf522b97ada707e3b) | `nixos/sslmate-agent: init`                                                                  |
| [`e994ca85`](https://github.com/NixOS/nixpkgs/commit/e994ca8597bf837b249347f1f575718f55f95dbe) | `sslmate-agent: init at 1.99.11`                                                             |
| [`5abbb68d`](https://github.com/NixOS/nixpkgs/commit/5abbb68d16ecd8674d393cf6aa087aa57f9d59c5) | `nixos/gnome: Re-enable VTE shell integration`                                               |
| [`d56a4c82`](https://github.com/NixOS/nixpkgs/commit/d56a4c822c7c05ca1e69c80a12bd038703dcc0ea) | `traefik: 2.6.1 -> 2.6.2`                                                                    |
| [`4ced0ddc`](https://github.com/NixOS/nixpkgs/commit/4ced0ddc9825f535d7365636e987432283d67d69) | `clojure-lsp: 2022.02.23-12.12.12 -> 2022.03.26-18.47.08`                                    |
| [`e87b6f72`](https://github.com/NixOS/nixpkgs/commit/e87b6f72d11ff413b7647681c8c84b6474b6be37) | `ocamlPackages.{macaddr,ipaddr}: 5.2.0 -> 5.3.0`                                             |
| [`603e9d7b`](https://github.com/NixOS/nixpkgs/commit/603e9d7b6483e43fd7d1742875d278bd7c3dff87) | `flywheel-cli: init at 16.2.0`                                                               |
| [`c1a36657`](https://github.com/NixOS/nixpkgs/commit/c1a3665786ab5670a94953fa2b3801bfe72e9ea0) | `dancing-script: init at 2.0`                                                                |
| [`a8aaeb6e`](https://github.com/NixOS/nixpkgs/commit/a8aaeb6e5379f8b6455fa1072822de0c8099bbbe) | `clickhouse 21.8.12.29 -> 22.3.2.2`                                                          |
| [`bcdb2fde`](https://github.com/NixOS/nixpkgs/commit/bcdb2fdee603dd13066f184b0fe6c2b744752428) | `mate.mate-backgrounds: fix build with meson 0.61`                                           |
| [`c75a58bb`](https://github.com/NixOS/nixpkgs/commit/c75a58bb927d010f90c66f54999d42e5a93c1f6c) | `bless: fix build with meson 0.61`                                                           |
| [`6e822b50`](https://github.com/NixOS/nixpkgs/commit/6e822b50dfe52a53fb1ca257465691ddffdc659b) | `reicast: remove`                                                                            |
| [`fd50b869`](https://github.com/NixOS/nixpkgs/commit/fd50b86920839582243c3ef62e43b32ce7f945e4) | `flycast: init at 1.2`                                                                       |
| [`8923ef18`](https://github.com/NixOS/nixpkgs/commit/8923ef18cf3d8c1f2e4d61700c5246edb8c8fe0c) | `python39Packages.tensorflow-tensorboard: relax version constraint`                          |
| [`83712ae1`](https://github.com/NixOS/nixpkgs/commit/83712ae183c16f789e605e2c5e1e40dfa5862fbe) | `python39Packages.google-auth-oauthlib: 0.4.6 -> 0.5.1`                                      |
| [`60e62c36`](https://github.com/NixOS/nixpkgs/commit/60e62c36df25e882d73881a627b8cd6816340bee) | `nixos/unifi-video: clean up indentation and formatting`                                     |
| [`2b52fed9`](https://github.com/NixOS/nixpkgs/commit/2b52fed9751f66a8228f3df3750a41b6ff31ba04) | `gnomeExtensions.freon: package automatically`                                               |
| [`d3fb4568`](https://github.com/NixOS/nixpkgs/commit/d3fb4568b3e963bb3843cb43c1b6e58f122b66b8) | `monit: don't abuse meta.homepage`                                                           |
| [`76a6908a`](https://github.com/NixOS/nixpkgs/commit/76a6908a09c8187215cb28515ed58ad34b04b350) | `monit: 5.31.0 -> 5.32.0`                                                                    |
| [`95a3f6ad`](https://github.com/NixOS/nixpkgs/commit/95a3f6ad266c1a340630bbdb4787e202bf9bd883) | `nixos/unifi-video: rename openPorts to openFirewall`                                        |
| [`cb1c5dbb`](https://github.com/NixOS/nixpkgs/commit/cb1c5dbb15f1c2f0802007c7ac661d371d00babf) | `nixos/unifi-video: convert int to string in default command`                                |
| [`b84f1396`](https://github.com/NixOS/nixpkgs/commit/b84f13964d35651fb7bde47ba4b0088f98f8b6e7) | `gotify-desktop: 1.2.0 -> 1.3.1`                                                             |
| [`21e45db6`](https://github.com/NixOS/nixpkgs/commit/21e45db6f1b196678e967b516a0761922bdf5dd7) | `vim: make customizable`                                                                     |
| [`e6ff028c`](https://github.com/NixOS/nixpkgs/commit/e6ff028cfa9990336a9ae4ee094c1513d7796d83) | `vim_configurable: drop patchelf`                                                            |
| [`0eb92176`](https://github.com/NixOS/nixpkgs/commit/0eb92176bf486dab758ce55c494623f24937e45b) | `vim_configurable: don't accept arbitrary arguments`                                         |
| [`65a6e2cb`](https://github.com/NixOS/nixpkgs/commit/65a6e2cb0df39aafa8d14b1b5e752688d0ba9290) | `vim_configurable: don't rewrap`                                                             |
| [`7ab1fd26`](https://github.com/NixOS/nixpkgs/commit/7ab1fd262ffae10c85f4100027872d5954e60797) | `vimUtils.makeCustomizable: rewrite to include more things`                                  |
| [`557e8963`](https://github.com/NixOS/nixpkgs/commit/557e8963e8c7970e280bfbaa9d7e8cae79f98420) | `maintainers: add rbreslow`                                                                  |
| [`12200d74`](https://github.com/NixOS/nixpkgs/commit/12200d74572e1551eae857541a31ae25fa9d6bf8) | `tonelib-metal: init at 1.1.0`                                                               |
| [`fb6dbccb`](https://github.com/NixOS/nixpkgs/commit/fb6dbccbfadaac68d9175a30089795704866c577) | `joycond: don't use dkms hid-nintendo on kernel 5.16 or newer`                               |
| [`c6775848`](https://github.com/NixOS/nixpkgs/commit/c67758484f85a677c346af2fdbdb5d03e92cd2b5) | `nixos/factorio: add bind address option`                                                    |
| [`c74d7847`](https://github.com/NixOS/nixpkgs/commit/c74d784771c9cee62bfd85b302f4568894df291e) | `network-interfaces: use altered interface name for setting use_tempaddr`                    |