### PR TITLE
chore(flake/nixpkgs): `00e27c78` -> `6a079dad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1648583894,
-        "narHash": "sha256-wdhgGO3yiBn7fMmI2jSfoondsh2O8Jt81e3H4RYnrHc=",
+        "lastModified": 1648627439,
+        "narHash": "sha256-FH6kH978lbd0DBdMyI6SPIFfjpyMjOuniu3S7cUGChU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "00e27c78d3d2de6964096ceee8d70e5b487365e3",
+        "rev": "6a079dad158f0331e866da8d1da443065deba6fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`ebeae143`](https://github.com/NixOS/nixpkgs/commit/ebeae1436ff4136411f3c9216c7e873be4c5c1dc) | `janet: 1.21.0 -> 1.21.1`                                                  |
| [`eedeae90`](https://github.com/NixOS/nixpkgs/commit/eedeae90ae52551706b44532ed3053391166cf7c) | `python310Packages.stripe: 2.68.0 -> 2.69.0`                               |
| [`c9e8b42e`](https://github.com/NixOS/nixpkgs/commit/c9e8b42ecae56c88f5b12ad8c8e95e588278eff6) | `2048-in-terminal: expand platforms to unix`                               |
| [`d78f645e`](https://github.com/NixOS/nixpkgs/commit/d78f645ea120eb1c2cca3a14b36a9601a186f664) | `cudatoolkit_11: cudatoolkit_11_6 → cudatoolkit_11_5`                      |
| [`6d2ac25d`](https://github.com/NixOS/nixpkgs/commit/6d2ac25d30444a59adfbb520dc544b0c67f5604d) | `python310Packages.hahomematic: 1.0.0 -> 1.0.3`                            |
| [`57a54d6e`](https://github.com/NixOS/nixpkgs/commit/57a54d6e57a0e6cd460e0a44ff784c4287df69f3) | `evil-winrm: init at 3.3 (#153752)`                                        |
| [`40ded161`](https://github.com/NixOS/nixpkgs/commit/40ded1611de3dc1d672613e90b2f8c1d1ed145f2) | `dvc: 2.9.3 -> 2.9.5`                                                      |
| [`5a0fc971`](https://github.com/NixOS/nixpkgs/commit/5a0fc971ad3175cc4aafeecc9bcfb1c2a4bdb5fb) | `python39Packages.paramiko: add comment about pytest-relaxed`              |
| [`8b3e54b4`](https://github.com/NixOS/nixpkgs/commit/8b3e54b48545d02a3b21581c4a5fb96a0261a79e) | `onefetch: 2.11.0 -> 2.12.0`                                               |
| [`befae9fc`](https://github.com/NixOS/nixpkgs/commit/befae9fcbdcbf2c095e457739744e4149b79f860) | `vimPlugins.urlview-nvim: init at 2022-03-29`                              |
| [`71f7aca0`](https://github.com/NixOS/nixpkgs/commit/71f7aca0c236eb29781aaa099d731167eb4d2966) | `vimPlugins.pywal-nvim: init at 2022-02-20`                                |
| [`5e3265af`](https://github.com/NixOS/nixpkgs/commit/5e3265af04cc467ad6f2e57c812610ab0483a9c7) | `pulumi: 3.26.1 -> 3.27.0`                                                 |
| [`44f80c6c`](https://github.com/NixOS/nixpkgs/commit/44f80c6cbf3da72de5eac77c88f65c2fa72af625) | `python3Packages.jinja2: update homepage`                                  |
| [`32a8f307`](https://github.com/NixOS/nixpkgs/commit/32a8f307ac13271f8a362a7db8349733e76a1c75) | `aesfix: init at v1.0.1`                                                   |
| [`630732fd`](https://github.com/NixOS/nixpkgs/commit/630732fdd76df34ea988eaeb7b552992de737971) | `.github/CODEOWNERS: remove non-committer users/teams`                     |
| [`00f86956`](https://github.com/NixOS/nixpkgs/commit/00f86956582eb673ad853e245f0e824ad1fe2897) | `actionlint: wrap with shellcheck and pyflakes`                            |
| [`9fd8faf8`](https://github.com/NixOS/nixpkgs/commit/9fd8faf82457445ee3cb86250611551f9ce2a171) | `python39Packages.ansible-lint: 5.3.2 -> 6.0.2`                            |
| [`bada6a2e`](https://github.com/NixOS/nixpkgs/commit/bada6a2e04b5801a0ac8487a4bd189b51726f733) | `nixos/nix-daemon: fix typo`                                               |
| [`b2ff4f21`](https://github.com/NixOS/nixpkgs/commit/b2ff4f21bec1e2138477865b5c4f89d95e2e8448) | `python39Packages.pytest-relaxed: mark broken`                             |
| [`4b9e65e0`](https://github.com/NixOS/nixpkgs/commit/4b9e65e0664703ce7e0fbb9d256265e799d22f7c) | `chromiumBeta: 100.0.4896.56 -> 100.0.4896.60`                             |
| [`b647d5a4`](https://github.com/NixOS/nixpkgs/commit/b647d5a49d0ac80512f3169789042ac124e23f2c) | `chromium: 99.0.4844.84 -> 100.0.4896.60`                                  |
| [`2682154e`](https://github.com/NixOS/nixpkgs/commit/2682154e8928dd32ebe07789aa3a5a9dcabb2bce) | `gnomeExtensions.sound-output-device-chooser: 39 -> unstable-2022-03-29`   |
| [`03801d38`](https://github.com/NixOS/nixpkgs/commit/03801d38119cdcd299c442b5f054a0c3421fe782) | `sile: 0.12.3 → 0.12.4`                                                    |
| [`ab704e8a`](https://github.com/NixOS/nixpkgs/commit/ab704e8a27fcf59dc9b5e9cc9962000c678235a2) | `sile: 0.12.2 → 0.12.3`                                                    |
| [`b5dbfba1`](https://github.com/NixOS/nixpkgs/commit/b5dbfba122c06646993833443aecb92135991789) | `cypress: 9.5.2 -> 9.5.3`                                                  |
| [`452508d9`](https://github.com/NixOS/nixpkgs/commit/452508d96b3979224cb4282b25882478a52a4da4) | `arkade: 0.8.14 -> 0.8.16`                                                 |
| [`9f16d661`](https://github.com/NixOS/nixpkgs/commit/9f16d661c8a601c5a81b2d033a675ff764176348) | `tflint: 0.34.1 -> 0.35.0`                                                 |
| [`e5bf0233`](https://github.com/NixOS/nixpkgs/commit/e5bf0233a8889b4dfd3490a854cf9caba216a943) | `f1viewer: 2.6.0 -> 2.6.2`                                                 |
| [`cb479c5a`](https://github.com/NixOS/nixpkgs/commit/cb479c5a92d2234668a2d9cdf67011df161ac61b) | `esbuild: 0.14.27 -> 0.14.28`                                              |
| [`3057fe56`](https://github.com/NixOS/nixpkgs/commit/3057fe56ebac9adc98a82bacf6c07840c831ce41) | `python310Packages.ansible-compat: init at 0.5.0`                          |
| [`1c223b63`](https://github.com/NixOS/nixpkgs/commit/1c223b63439ce7ddb5ac36138c03ba306794a9e1) | `element{-desktop,}: 1.10.7 -> 1.10.8`                                     |
| [`796056a4`](https://github.com/NixOS/nixpkgs/commit/796056a4b97228d32b506f12f4a13c073c303585) | `xkeysnail: update example config`                                         |
| [`8d7ec2bd`](https://github.com/NixOS/nixpkgs/commit/8d7ec2bd7e95a5816f427bb1909a46e355314f9a) | `python3Packages.rasterio: 1.2.6 → 1.2.10`                                 |
| [`5115f5bb`](https://github.com/NixOS/nixpkgs/commit/5115f5bb8c1c18ff8ef95b5b8fbf61b61707ab36) | `cargo-spellcheck: 0.11.0 -> 0.11.1`                                       |
| [`066634e5`](https://github.com/NixOS/nixpkgs/commit/066634e509988232b435cf2e64c778ec4508a4b4) | `maintainers: add myself (bobby285271) to the GNOME team`                  |
| [`3ea0bebd`](https://github.com/NixOS/nixpkgs/commit/3ea0bebd9ec5fa8c63ebccfdd03a3b52fad35d20) | `gnome.gnome-logs: 3.36.0 → 42.0`                                          |
| [`b1ad5cd2`](https://github.com/NixOS/nixpkgs/commit/b1ad5cd29eaa5da04cd5072062f176c2cdd4ec0d) | `cppcheck: 2.7.3 -> 2.7.4`                                                 |
| [`a5d12145`](https://github.com/NixOS/nixpkgs/commit/a5d12145047970d663764ce95bf1e459e734a014) | `difftastic: 0.23.0 -> 0.24.0`                                             |
| [`7150ca1c`](https://github.com/NixOS/nixpkgs/commit/7150ca1c28ffe1861371a4df2ee454e0de377745) | `wdt: init at unstable-2022-03-24`                                         |
| [`e2a70307`](https://github.com/NixOS/nixpkgs/commit/e2a703070ba7e85bb8da98bd5328a9c6d65d7d01) | `qownnotes: 22.3.3 -> 22.3.4`                                              |
| [`c6753cfe`](https://github.com/NixOS/nixpkgs/commit/c6753cfebaacfadee615ea4d406ed3bf38945109) | `python3Packages.azure-keyvault-secrets: disable on older Python releases` |
| [`60b19432`](https://github.com/NixOS/nixpkgs/commit/60b194324bd9d382f3a9e8c7d233b10a79f699b4) | `termius: 7.36.1 -> 7.37.0`                                                |
| [`9e1b79d3`](https://github.com/NixOS/nixpkgs/commit/9e1b79d3443a5a0047fbbe8814661df076132f9c) | `python310Packages.azure-keyvault-secrets: 4.3.0 -> 4.4.0`                 |
| [`38a8538a`](https://github.com/NixOS/nixpkgs/commit/38a8538a7b4497e208e94a325e90c226c7774272) | `fly: 7.7.0 -> 7.7.1`                                                      |
| [`3d9954eb`](https://github.com/NixOS/nixpkgs/commit/3d9954ebfb0177a547347f8181a04469b1e3e7ef) | `python310Packages.pyviz-comms: 2.1.0 -> 2.2.0`                            |
| [`32efeb14`](https://github.com/NixOS/nixpkgs/commit/32efeb145762d32d4559d6374a453c64ba68e4cf) | `python310Packages.python-gitlab: 3.2.0 -> 3.3.0`                          |
| [`653e2259`](https://github.com/NixOS/nixpkgs/commit/653e22591a4dbbdbeb3dc37ff84cbb47657d8502) | `python310Packages.azure-storage-blob: 12.10.0 -> 12.11.0`                 |
| [`9683aa44`](https://github.com/NixOS/nixpkgs/commit/9683aa44a2f382c30e33f1c195f80d0c1e1c187b) | `m-cli: 0.2.5 -> 0.3.0`                                                    |
| [`1524abe6`](https://github.com/NixOS/nixpkgs/commit/1524abe689f999c8e8bf0833dd55ca340325a0f1) | `polymc: 1.1.0 -> 1.1.1`                                                   |
| [`d4a34191`](https://github.com/NixOS/nixpkgs/commit/d4a341915766a65e0d61efb3e7cd71dbee9094e7) | `nodePackages.typescript: add mainProgram`                                 |
| [`c56400aa`](https://github.com/NixOS/nixpkgs/commit/c56400aa3ecdc6c09c153b4103d24b133f20fb03) | `dvc: instantiate env to a copy of os.environ`                             |
| [`7e2f8c30`](https://github.com/NixOS/nixpkgs/commit/7e2f8c3066de0cc0a87f0d02dcbb902a7a78a49b) | `python310Packages.gspread: 5.2.0 -> 5.3.0`                                |
| [`aa931a46`](https://github.com/NixOS/nixpkgs/commit/aa931a46e0b6a7a467f42d6442b406fe3329890a) | `gprojector: 3.0.2 -> 3.0.3`                                               |
| [`2eff12f5`](https://github.com/NixOS/nixpkgs/commit/2eff12f5ab457c2a0985688bd882f1eac76fe40b) | `diffoscope: 207 -> 209`                                                   |
| [`de43cdd3`](https://github.com/NixOS/nixpkgs/commit/de43cdd355e2c30d15869b62f5965b2462438acc) | `element-desktop: remove gcc references`                                   |
| [`f1a5d029`](https://github.com/NixOS/nixpkgs/commit/f1a5d029908bcc5433645e127c4669ae5abe3c59) | `teleport: fix suid exec problem`                                          |
| [`de188a24`](https://github.com/NixOS/nixpkgs/commit/de188a2470602ec8a024a951c71e4c49b718199e) | `etebase-server: 0.7.0 -> 0.8.3`                                           |
| [`34241fac`](https://github.com/NixOS/nixpkgs/commit/34241faccad6176da0a373347758d58d9cce6d1e) | `fluxcd: 0.28.3 -> 0.28.4`                                                 |
| [`f756e87e`](https://github.com/NixOS/nixpkgs/commit/f756e87ede0b8b256c4771784a802952ac2d6c07) | `smartgithg: 20.2.5 -> 21.2.2`                                             |
| [`02164f82`](https://github.com/NixOS/nixpkgs/commit/02164f828d8ea54550cb4f34f206bf8b9ee882c7) | `python310Packages.iminuit: 2.10.0 -> 2.11.2`                              |
| [`fad08c37`](https://github.com/NixOS/nixpkgs/commit/fad08c37e322ed894e43180c957bcf31702b766a) | `poco: move openssl to propagatedBuildInputs`                              |
| [`b915133b`](https://github.com/NixOS/nixpkgs/commit/b915133bb16aaef8bfe289aeb795baf7f738290f) | `pipenv: 2022.3.24 -> 2022.3.28`                                           |
| [`60566767`](https://github.com/NixOS/nixpkgs/commit/60566767704d7eea7273dbc453374d4f7440ebda) | `dbeaver: use overridden maven in javaPackages.mavenfod`                   |
| [`4c766274`](https://github.com/NixOS/nixpkgs/commit/4c766274c5669616be17af6f9cece3112cbae4ee) | `javaPackages.mavenfod: use mvnParameters in buildPhase`                   |
| [`40d6259b`](https://github.com/NixOS/nixpkgs/commit/40d6259bc9fb4a4a74f33971b2c619a7e96c751a) | `jc: 1.18.5 -> 1.18.6`                                                     |
| [`d1ac8881`](https://github.com/NixOS/nixpkgs/commit/d1ac88811f0235f9ba0834ab1ac970e6f4e7ffc0) | `nixos/_1password: init`                                                   |
| [`4cb1fc0e`](https://github.com/NixOS/nixpkgs/commit/4cb1fc0e58ecbf0469a05dca8f01372ce7189c9a) | `argo-rollouts: 1.1.1 -> 1.2.0`                                            |
| [`8b7ca8bd`](https://github.com/NixOS/nixpkgs/commit/8b7ca8bdcb949333c5b64839b660d3d0af68565a) | `nixos/prometheus-exporters/kea: wait for kea`                             |
| [`ea84f6b9`](https://github.com/NixOS/nixpkgs/commit/ea84f6b9e93d44fe586dc2af91fca101ee2dd8b9) | `tsm-client: 8.1.13.3 -> 8.1.14.0`                                         |