### PR TITLE
chore(flake/home-manager): `888eac32` -> `f5a44afa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1648366999,
-        "narHash": "sha256-Sdm0lI2ZBc70EnMMmvfDVY7gIM3M4c2L86EdQ9tKRE4=",
+        "lastModified": 1648367040,
+        "narHash": "sha256-m1wXRaAfMETyEUPr5XUyeC+b48pW/CrLD3FgUtHK16w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "888eac32bd657bfe0d024c8770130d80d1c02cd3",
+        "rev": "f5a44afa19f8f99af4e1a88c97e2327590cd4217",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`f5a44afa`](https://github.com/nix-community/home-manager/commit/f5a44afa19f8f99af4e1a88c97e2327590cd4217) | `Translate using Weblate (Turkish)`  |
| [`80583677`](https://github.com/nix-community/home-manager/commit/80583677e79a683cec24de55f2c80bab1fa0d198) | `Translate using Weblate (Japanese)` |
| [`c607ae86`](https://github.com/nix-community/home-manager/commit/c607ae8671d622604630ed3b4bbbc12eb24e791f) | `Update translation files`           |