### PR TITLE
chore(flake/nixpkgs): `6a079dad` -> `10632447`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1648627439,
-        "narHash": "sha256-FH6kH978lbd0DBdMyI6SPIFfjpyMjOuniu3S7cUGChU=",
+        "lastModified": 1648673296,
+        "narHash": "sha256-dlQP4/escrnt8vm1WAbWrYeFvYF1F1K3m+9qsUHwL+I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6a079dad158f0331e866da8d1da443065deba6fa",
+        "rev": "1063244793d9b2dc3db515ac5b70a85385ec9b10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| [`0a2ae8bc`](https://github.com/NixOS/nixpkgs/commit/0a2ae8bc533dc4320f8460949ec154398800fb09) | `gh: 2.6.0 -> 2.7.0`                                                                                    |
| [`90c46e80`](https://github.com/NixOS/nixpkgs/commit/90c46e80c66d1616882ea472d536e5c3f8a7857a) | `python310Packages.huawei-lte-api: 1.5.4 -> 1.6`                                                        |
| [`b2635c2b`](https://github.com/NixOS/nixpkgs/commit/b2635c2b71150ec1ab0e3a591685f653b5db7485) | `python3Packages.tensorflow-datasets: run tests in parallel`                                            |
| [`45709072`](https://github.com/NixOS/nixpkgs/commit/4570907282908a9f423807750994212abd803412) | `python3Packages.optax: run tests in parallel`                                                          |
| [`6fa30f68`](https://github.com/NixOS/nixpkgs/commit/6fa30f68552aa526a13382f2f0120736660219d2) | `python3Packages.flax: run tests in parallel`                                                           |
| [`740a83a9`](https://github.com/NixOS/nixpkgs/commit/740a83a9bdb25fdf0ca3bdcc187f329d1969ee07) | `python3Packages.dm-haiku: run tests in parallel`                                                       |
| [`3c25104d`](https://github.com/NixOS/nixpkgs/commit/3c25104d0e88e949d30ce67a1b693ab59ec9155d) | `stripe-cli: add meta.mainProgram (#166457)`                                                            |
| [`a01a4d4d`](https://github.com/NixOS/nixpkgs/commit/a01a4d4d678e0075440bae47e7c323403027f896) | `wp-cli: add meta.mainProgram (#166453)`                                                                |
| [`6aa45d8b`](https://github.com/NixOS/nixpkgs/commit/6aa45d8b5943eb03269a67d1a7646d8010fb7996) | `wl-mirror: 0.8.1 -> 0.9.2`                                                                             |
| [`95b8f0a8`](https://github.com/NixOS/nixpkgs/commit/95b8f0a84ad7329fda0a05201252888ec94cda80) | `python310Packages.libcloud: 3.5.0 -> 3.5.1`                                                            |
| [`e01c4120`](https://github.com/NixOS/nixpkgs/commit/e01c41205234a68a55903e05800e62d0de302e1a) | `fuzzel: fixup build after librsvg update`                                                              |
| [`b0d30448`](https://github.com/NixOS/nixpkgs/commit/b0d3044823591c4947a82cd43f0d3e17b3abece4) | `haskellPackages.graphql: convert assert on hspec into warning`                                         |
| [`13c34c9a`](https://github.com/NixOS/nixpkgs/commit/13c34c9a86981fc7cca93475b7017d8e9acafa89) | `profanity: 0.11.1 -> 0.12.0`                                                                           |
| [`bb22a2de`](https://github.com/NixOS/nixpkgs/commit/bb22a2debcbb2695a4eb1be9b319952f17cfefb2) | `nixos/zrepl: note about systemd unit, add snapshot test`                                               |
| [`288c8f8f`](https://github.com/NixOS/nixpkgs/commit/288c8f8fbe3453f1bb5fb717a26f94ac50754067) | `oil: 0.9.8 -> 0.9.9`                                                                                   |
| [`0a380794`](https://github.com/NixOS/nixpkgs/commit/0a3807942595869cf21027e0fa799368e3ac7442) | `ntfy-sh: init at 1.18.1 (#166102)`                                                                     |
| [`2337e48a`](https://github.com/NixOS/nixpkgs/commit/2337e48adb6dc88bdb2dceb433770180c28bf288) | `oh-my-zsh: 2022-03-28 -> 2022-03-29 (#166373)`                                                         |
| [`c84d82e9`](https://github.com/NixOS/nixpkgs/commit/c84d82e9627f3d681be67b140a0b646deb9f18fb) | `bullet: 3.21 -> 3.22a`                                                                                 |
| [`43b5a5ec`](https://github.com/NixOS/nixpkgs/commit/43b5a5ec59098dc94ff32eb2a8b5e43fe9cab6a9) | `postman: add darwin packages (#164697)`                                                                |
| [`b9b68043`](https://github.com/NixOS/nixpkgs/commit/b9b680439852b9f4511d672fd56c349bd80b95c5) | `python310Packages.pylitterbot: 2021.12.0 -> 2022.3.0`                                                  |
| [`2344c427`](https://github.com/NixOS/nixpkgs/commit/2344c427cfbecf3da911a923fa1c8a8016a5dd07) | `nfpm: 2.15.0 -> 2.15.1`                                                                                |
| [`07d588de`](https://github.com/NixOS/nixpkgs/commit/07d588de4db68e8094b16fe100eb15fef72b417a) | `morgen: 2.4.4 -> 2.5.0`                                                                                |
| [`ef7564a0`](https://github.com/NixOS/nixpkgs/commit/ef7564a0acae0118b882a80df6e9cb35beaaee7f) | `python3Packages.metar: disable test, remove patch`                                                     |
| [`cec30d58`](https://github.com/NixOS/nixpkgs/commit/cec30d5845d0aa7a80c1740ce6dfb11c47d7b57e) | `python310Packages.desktop-notifier: 3.3.5 -> 3.4.0`                                                    |
| [`a8dfd8fd`](https://github.com/NixOS/nixpkgs/commit/a8dfd8fdac5eef9bd5dd04bdd343de2331231c27) | `entangle: fix build with meson 0.61`                                                                   |
| [`d23a53bd`](https://github.com/NixOS/nixpkgs/commit/d23a53bd363216299f1c2ea51984ca8d5fcec60a) | `drawing: fix build with meson 0.61`                                                                    |
| [`a1d2c351`](https://github.com/NixOS/nixpkgs/commit/a1d2c3511f5de62fcb7d848d83f7eb0024bba4b4) | `nvidia_x11: 470.94 → 470.103.01`                                                                       |
| [`0ec675a1`](https://github.com/NixOS/nixpkgs/commit/0ec675a11dc6c770b74c472269404b3a0392013b) | `python310Packages.geojson-client: 0.7 -> 0.8`                                                          |
| [`dd697d41`](https://github.com/NixOS/nixpkgs/commit/dd697d414853a99d0d5f05ee23430923c6da1176) | `strawberry: add libgpod`                                                                               |
| [`4ceda585`](https://github.com/NixOS/nixpkgs/commit/4ceda5853fa4530ec989e902081d51c6e7159328) | `drop shards_0_15`                                                                                      |
| [`37463c21`](https://github.com/NixOS/nixpkgs/commit/37463c21cc9270a2c35e2681295f9fe5368596c7) | `shards: 0.16 -> 0.17`                                                                                  |
| [`8cc2efce`](https://github.com/NixOS/nixpkgs/commit/8cc2efce4a5c01d5efaf86767ee6a33a985cf5ae) | `python3Packages.msldap: disable on older Python releases`                                              |
| [`645796c0`](https://github.com/NixOS/nixpkgs/commit/645796c0cb544431c0ee3bfad48f12bf9867bd78) | `dconf-editor: fix build with Meson 0.61`                                                               |
| [`289a54ef`](https://github.com/NixOS/nixpkgs/commit/289a54ef8dc95e90ba20bb73751c5291d1aee881) | `dconf-editor: Respect NIX_GSETTINGS_OVERRIDES_DIR variable`                                            |
| [`5fa8d3ac`](https://github.com/NixOS/nixpkgs/commit/5fa8d3ac3871ca58b56dcc9a4de2b246053ca27e) | `gnome-2048: fix build with meson 0.61`                                                                 |
| [`68824fbc`](https://github.com/NixOS/nixpkgs/commit/68824fbc89d6105cf2bf997bae51bc281d8bad52) | `gnome.gnome-screenshot: fix build with meson 0.61`                                                     |
| [`dbc55b66`](https://github.com/NixOS/nixpkgs/commit/dbc55b66671e4bb4479b37dbd484118985048a9e) | `gnome.gnome-screenshot: format`                                                                        |
| [`3d1d33c5`](https://github.com/NixOS/nixpkgs/commit/3d1d33c5ff17c582cea2f0f63a65cb37cc43318c) | `gnome.gnome-books: fix build with meson 0.61`                                                          |
| [`d3dab0e6`](https://github.com/NixOS/nixpkgs/commit/d3dab0e67dcceacc7b09d1c65f7442c6ee7ba656) | `gnome.devhelp: fix build with meson 0.61`                                                              |
| [`feb68f31`](https://github.com/NixOS/nixpkgs/commit/feb68f31e12b85dbf55bb4df3e60adba6b86475b) | `python310Packages.msldap: 0.3.30 -> 0.3.38`                                                            |
| [`a7cfb52b`](https://github.com/NixOS/nixpkgs/commit/a7cfb52b0a08282a655c32c8b93c3dbf0c9830e0) | `python310Packages.asyncmy: 0.2.4 -> 0.2.5`                                                             |
| [`9f4b404b`](https://github.com/NixOS/nixpkgs/commit/9f4b404b5cb159b6630485326e8dcebabad222f5) | `maintainers/teams: add cosmopolitan team`                                                              |
| [`bd84351d`](https://github.com/NixOS/nixpkgs/commit/bd84351def15c0fe7a8a387347a6f10b4805f6ca) | `python-cosmopolitan: init at 3.6.14`                                                                   |
| [`f760f24d`](https://github.com/NixOS/nixpkgs/commit/f760f24de31ba7f01d3eecc017b499e738eefaec) | `doc/release-notes: document cosmoc removal`                                                            |
| [`d1eb392e`](https://github.com/NixOS/nixpkgs/commit/d1eb392e95c2ec286162bd567c5e15d8fdc1a855) | `cosmopolitan: remove redundant fix`                                                                    |
| [`96d31267`](https://github.com/NixOS/nixpkgs/commit/96d31267813b8ed32e480ad7c9bbc9a7e4e9a86c) | `cosmopolitan: lint`                                                                                    |
| [`89604525`](https://github.com/NixOS/nixpkgs/commit/89604525d7aafa64f66769d7d05990dc5b31a56a) | `cosmopolitan: unclutter output`                                                                        |
| [`f92cfbce`](https://github.com/NixOS/nixpkgs/commit/f92cfbce3aab64699bbb73199611ab6144c71cf4) | `cosmopolitan: remove redundant test`                                                                   |
| [`0d5810ed`](https://github.com/NixOS/nixpkgs/commit/0d5810ede00b98e6e0cf01bc9e5da8fea4611201) | `cosmoc: init`                                                                                          |
| [`ff4d8134`](https://github.com/NixOS/nixpkgs/commit/ff4d8134a2ece2f6f4fe9ca0dc1d12dcbf453f6f) | `sane-backend: deprecate phases`                                                                        |
| [`7e845eda`](https://github.com/NixOS/nixpkgs/commit/7e845eda916d48ecd05978bdef1218c5d1195c28) | `spike: 1.0.0 -> 1.1.0`                                                                                 |
| [`b92c00e5`](https://github.com/NixOS/nixpkgs/commit/b92c00e5ef21a8d58e028a7637592af1f40c3e12) | `python310Packages.dash: 2.3.0 -> 2.3.1`                                                                |
| [`1121300b`](https://github.com/NixOS/nixpkgs/commit/1121300b4195a540d66c012280a52545d99ae430) | `lief: 0.11.5 -> 0.12.0`                                                                                |
| [`88a70a93`](https://github.com/NixOS/nixpkgs/commit/88a70a935ecbae6c5a9546200790c1188674c099) | `mycli: 1.24.3 -> 1.24.4`                                                                               |
| [`71317b98`](https://github.com/NixOS/nixpkgs/commit/71317b9801ea3545c704652ecff1b904842c2066) | `python310Packages.pyoverkiz: 1.3.12 -> 1.3.13`                                                         |
| [`b376c1ce`](https://github.com/NixOS/nixpkgs/commit/b376c1ce9df5ac104baff7d0ce5048d16c485348) | `linuxPackages.nvidia_x11_legacy390: mark as broken`                                                    |
| [`f687794f`](https://github.com/NixOS/nixpkgs/commit/f687794fb59d51167cdb88826f28966c4b722d1e) | `python39Packages.snowflake-connector-python: 2.7.4 -> 2.7.6`                                           |
| [`a677b22a`](https://github.com/NixOS/nixpkgs/commit/a677b22ac044292daa73ad56deab6e15af8a451e) | `esphome: 2022.3.1 -> 2022.3.2`                                                                         |
| [`889fd0ca`](https://github.com/NixOS/nixpkgs/commit/889fd0ca40b06cc040b3640a70de8a3c977587f9) | `_1password: fixup packaging`                                                                           |
| [`b9c5ad1c`](https://github.com/NixOS/nixpkgs/commit/b9c5ad1c06328e058ca80bc2cb9884f37cbef564) | `gnomeExtensions: auto-update`                                                                          |
| [`1c0f4cb8`](https://github.com/NixOS/nixpkgs/commit/1c0f4cb80963872a9133482fa1c7d2c4e2e719e7) | `fuse: fix nix-update/nix-prefetch crashing`                                                            |
| [`8d636482`](https://github.com/NixOS/nixpkgs/commit/8d636482f1eb7113e629ae604074e4c706068c1f) | `jetbrains.clion: fix build`                                                                            |
| [`6443507c`](https://github.com/NixOS/nixpkgs/commit/6443507c122a6b17397c8efecfea23c25024dc01) | `cosmopolitan: add checkPhase`                                                                          |
| [`961472b7`](https://github.com/NixOS/nixpkgs/commit/961472b74a1c1873b548075973b4fa592b06ffe8) | `cosmopolitan: only build libc`                                                                         |
| [`978da552`](https://github.com/NixOS/nixpkgs/commit/978da552e5728d10b73610d0b26058bb1277f20f) | `dasel: 1.24.0 -> 1.24.1`                                                                               |
| [`7b74c9ff`](https://github.com/NixOS/nixpkgs/commit/7b74c9ff048ac7cdac04974ef791d9b249139511) | `release-haskell.nix: re-enable x86_64-darwin`                                                          |
| [`052cd371`](https://github.com/NixOS/nixpkgs/commit/052cd37187b66f9717c7f3e0f4075adb078817f6) | `haskellPackages.taffybar: mark broken`                                                                 |
| [`3a08f8d9`](https://github.com/NixOS/nixpkgs/commit/3a08f8d91c5c3f81fadc3a8a2ff8361e0966d27b) | `cosmopolitan: don't extend include path`                                                               |
| [`d0e3a369`](https://github.com/NixOS/nixpkgs/commit/d0e3a3696147b5d49ce4489e86b92b0c33c8c3b5) | `symfony-cli: 5.4.2 -> 5.4.5`                                                                           |
| [`53dff2f7`](https://github.com/NixOS/nixpkgs/commit/53dff2f7c8557d911ec5b1681639214f8c1f7f4f) | `rink: 0.6.2 -> 0.6.3`                                                                                  |
| [`8de8aab4`](https://github.com/NixOS/nixpkgs/commit/8de8aab4883cb83ae350f159899ca762bd436256) | `haskellPackages.yarn2nix: remove broken flag`                                                          |
| [`4c31a79b`](https://github.com/NixOS/nixpkgs/commit/4c31a79bbcaef5dba26ce528383577d7d0e0b7cd) | `haskellPackages.yarn2nix: 0.8.0 -> 0.10.1`                                                             |
| [`f85b49ff`](https://github.com/NixOS/nixpkgs/commit/f85b49ff197237d80af2d80a121f6d290be7f1ee) | `vaultenv: provide aeson 1.5.6.0`                                                                       |
| [`d59d8621`](https://github.com/NixOS/nixpkgs/commit/d59d8621cd105b7e5f10cab6705388ccec7b19e1) | `pakcs: build using GHC 8.10.7`                                                                         |
| [`e14278d3`](https://github.com/NixOS/nixpkgs/commit/e14278d33be7a1b496d237cce746ab16eb1750f6) | `yi: build using GHC 8.10.7`                                                                            |
| [`6aa03ecb`](https://github.com/NixOS/nixpkgs/commit/6aa03ecb26c8010a4707ff0450d7cdc191d11c0a) | `haskellPackages: mark builds failing on hydra as broken`                                               |
| [`6da02123`](https://github.com/NixOS/nixpkgs/commit/6da02123602069ced56d0c733658a4fd509b6964) | `taffybar: build using GHC 8.10.7`                                                                      |
| [`9f034e5d`](https://github.com/NixOS/nixpkgs/commit/9f034e5d188ca856c6d84e1dfecefc455da6fd02) | `libgda: propagate libxml2`                                                                             |
| [`8e0f6609`](https://github.com/NixOS/nixpkgs/commit/8e0f6609c3086522314b967218005a7c7fc7b923) | ``libgda: remove `? null` from inputs``                                                                 |
| [`a9ab92ee`](https://github.com/NixOS/nixpkgs/commit/a9ab92ee1271b41369a0cc58fa8af5685042b7ed) | `gtkpod: fix build`                                                                                     |
| [`073206c8`](https://github.com/NixOS/nixpkgs/commit/073206c8e017533f76418ba180db35021a46d6f5) | `libgpod: reduce propagated libraries, cleanup`                                                         |
| [`ba04eeb1`](https://github.com/NixOS/nixpkgs/commit/ba04eeb1f466cd2a4923ea403f37abf0ee041ace) | `Revert "poetry: apply toPythonApplication"`                                                            |
| [`1f57d3e7`](https://github.com/NixOS/nixpkgs/commit/1f57d3e7224290eebda23fa1c79718d6b8361574) | `nix-linter: 0.2.0.3 -> 0.2.0.4`                                                                        |
| [`4ed08031`](https://github.com/NixOS/nixpkgs/commit/4ed08031db4a77a577dc1a8c27310bdb54fa25a4) | `haskellPackages.mattermost-api: build with aeson 1.5`                                                  |
| [`f9268040`](https://github.com/NixOS/nixpkgs/commit/f9268040166a01420d396cff7c5fb8b5113a202b) | `haskellPackages.sbv: provide new solvers for version 8.17`                                             |
| [`b4e65fc3`](https://github.com/NixOS/nixpkgs/commit/b4e65fc3d7baa1ffe8dd80320f504bb3c333283a) | `haskellPackages.geojson: disable test suite failing to compile`                                        |
| [`229609de`](https://github.com/NixOS/nixpkgs/commit/229609de1667dacbc2662b59362c76bf4e468e63) | `haskellPackages.cabal-install-parsers: provide Cabal 3.6`                                              |
| [`3388c768`](https://github.com/NixOS/nixpkgs/commit/3388c7684ea8d34a20e96b3f9c4bc0b4c11bb6ca) | `haskellPackages.mustache: drop upstreamed patch`                                                       |
| [`e63b736b`](https://github.com/NixOS/nixpkgs/commit/e63b736b1be211c39d38e3419022760c4dc41042) | `haskellPackages.git-annex: update sha256 for 10.20220322`                                              |
| [`ad560b3e`](https://github.com/NixOS/nixpkgs/commit/ad560b3ef4820f505a533953cd23bfc0b3342d90) | `haskellPackages.knob: remove patch after 0.2`                                                          |
| [`27aed0d1`](https://github.com/NixOS/nixpkgs/commit/27aed0d10bec72ab2cbf24a192e05b431995e746) | `haskellPackages.mmark: 0.0.7.4 -> 0.0.7.5`                                                             |
| [`08458844`](https://github.com/NixOS/nixpkgs/commit/084588444df732a5bb6b0ac87df92b770f3a00c2) | ``haskellPackages: use fetchpatch's `relative` argument``                                               |
| [`66996acc`](https://github.com/NixOS/nixpkgs/commit/66996acc2a9afd1b0c34beffc2bab3e8daecbcad) | `all-cabal-hashes: 2022-03-22T14:25:11Z -> 2022-03-26T03:24:04Z`                                        |
| [`9f7ac926`](https://github.com/NixOS/nixpkgs/commit/9f7ac9269852b12a220a8cc48d1879ddfab0a115) | `dhall-text: remove at 1.0.18`                                                                          |
| [`f6d7cbb2`](https://github.com/NixOS/nixpkgs/commit/f6d7cbb2470cce467e320ede800ae3d411e88181) | `haskellPackages.validation: allow lens 5.* in test suite`                                              |
| [`c1f8889b`](https://github.com/NixOS/nixpkgs/commit/c1f8889beb3242322aa972019b417913a54e00a9) | `haskell.packages.ghc{884,8017}.mysql-simple: provide blaze-textual`                                    |
| [`194c266f`](https://github.com/NixOS/nixpkgs/commit/194c266f9a89db524175ce2803b39093447202ce) | `haskellPackages: configuration-common.nix add imports at top of file`                                  |
| [`38df6e7a`](https://github.com/NixOS/nixpkgs/commit/38df6e7a57de75acd0a8dfb9109ec7dd3984863d) | `haskellPackages.arch-web: jailbreak`                                                                   |
| [`8bb8fcbc`](https://github.com/NixOS/nixpkgs/commit/8bb8fcbc6a7e11dfc9bca59a5f9fa55c57cc8db1) | `haskellPackages.nvfetcher: jailbreak`                                                                  |
| [`b2f458dc`](https://github.com/NixOS/nixpkgs/commit/b2f458dc40243376e7859bcd155d851f3fa068b8) | `hledger-check-fancyassertions: update source hash for 1.25`                                            |
| [`484ae5b0`](https://github.com/NixOS/nixpkgs/commit/484ae5b0a134debc48bfcc2c40a05dcd47371385) | `nixos/doc/rl-22.05: note default GHC update`                                                           |
| [`a39208dd`](https://github.com/NixOS/nixpkgs/commit/a39208ddded07c3e7921288e94486614eb4ecbb7) | `haskellPackages: mark more packages as broken or unsupported`                                          |
| [`9a683652`](https://github.com/NixOS/nixpkgs/commit/9a68365233554005b3443b09f249dd212e873d0e) | `haskellPackages: enable builds for some pkgs needed by top-level pkgs`                                 |
| [`22091f9a`](https://github.com/NixOS/nixpkgs/commit/22091f9a3933c41d57bffaa990e08bad824e1c50) | `haskellPackages: regenerate package set based on current config`                                       |
| [`213a8085`](https://github.com/NixOS/nixpkgs/commit/213a808539ffd79c21f5cd5625fc1ff98545461c) | `haskellPackages: mark packages failing on hydra as broken`                                             |
| [`fa552e76`](https://github.com/NixOS/nixpkgs/commit/fa552e76e681b3b84b9917a09c40201799ded4f0) | `maintainers/scripts/haskell: add script to find broken maintained packages`                            |
| [`8b791af7`](https://github.com/NixOS/nixpkgs/commit/8b791af7b14a7797e1bf0b4ca52341a5907eda93) | `haskellPackages: regenerate package set based on current config`                                       |
| [`44456a87`](https://github.com/NixOS/nixpkgs/commit/44456a87e8d5facd0ca7a29b79af27aec42981f9) | `haskellPackages: prune broken.yaml`                                                                    |
| [`9b2781de`](https://github.com/NixOS/nixpkgs/commit/9b2781de35448ad725f3714e31a35612f9c09f53) | `haskellPackages: fix time-travelling comment`                                                          |
| [`f60832c1`](https://github.com/NixOS/nixpkgs/commit/f60832c17a9bb1b34e1bcb919c6e8e0377b2566c) | `haskellPackages: move knob patch to configuration-common`                                              |
| [`832c0911`](https://github.com/NixOS/nixpkgs/commit/832c091143013150c41d82ecbd17a680607c68e1) | `lambdabot: apply patch to fix GHC 9 build`                                                             |
| [`fe3d3d57`](https://github.com/NixOS/nixpkgs/commit/fe3d3d5764e3e422ea7979eb68a72080046e35d7) | `haskellPackages.dice: apply patch to fix GHC 9 build`                                                  |
| [`f8c740b7`](https://github.com/NixOS/nixpkgs/commit/f8c740b781135a7564fa32658c5887e606138e08) | `haskellPackages.misfortune: apply patch to fix GHC 9 build`                                            |
| [`f79f6076`](https://github.com/NixOS/nixpkgs/commit/f79f6076d700a5b54365fdfbcfc039316951ac1e) | `haskellPackages: regenerate package set based on current config`                                       |
| [`add80ae7`](https://github.com/NixOS/nixpkgs/commit/add80ae7d0324b6cc459e59588c8f2603e30e4f1) | `all-cabal-hashes: 2022-03-20T09:57:59Z -> 2022-03-22T14:25:11Z`                                        |
| [`d7b31a50`](https://github.com/NixOS/nixpkgs/commit/d7b31a50c1e843947cfc43ae4ea694388972088b) | `haskellPackages.reflex-dom: jailbreak`                                                                 |
| [`ff9be3cd`](https://github.com/NixOS/nixpkgs/commit/ff9be3cd21d0c7b7408a9d9dbf26f4a59f0b2f53) | `haskellPackages.jsaddle-webkit2gtk: add patch`                                                         |
| [`53b13c99`](https://github.com/NixOS/nixpkgs/commit/53b13c99955ae68709f17ff227576576d33bf437) | `haskellPackages.stylish-haskell: pin deps`                                                             |
| [`6b3818b9`](https://github.com/NixOS/nixpkgs/commit/6b3818b9c07e15ca022533e6d11701fdfcdacf68) | `haskellPackages.niv: pin aeson < 2.0`                                                                  |
| [`7fb5fa68`](https://github.com/NixOS/nixpkgs/commit/7fb5fa680a30edae3a32367d83cc5684c38e0afa) | `haskellPackages.policeman: drop`                                                                       |
| [`406981a4`](https://github.com/NixOS/nixpkgs/commit/406981a49a49fc3e134eb4189bf8988525570c28) | `haskellPackages.moto-postgresql: Patch for MonadFail`                                                  |
| [`76be4bd3`](https://github.com/NixOS/nixpkgs/commit/76be4bd38157740144cec1cc30107dfcca9af927) | `haskellPackages.moto: Patch for GHC 9.0`                                                               |
| [`96cdae60`](https://github.com/NixOS/nixpkgs/commit/96cdae6026120cdcd82f28aa8ad18474fe7043ec) | `haskellPackages.pipes-aeson: Patch for aeson-2`                                                        |
| [`1cbdce18`](https://github.com/NixOS/nixpkgs/commit/1cbdce18e13baec367f7ef5d09a76011bab8a41d) | `haskellPackages.large-hashable: 0.1.0.4 -> unstable-2021-11-01`                                        |
| [`267cf195`](https://github.com/NixOS/nixpkgs/commit/267cf195d74304c1c52589f6b0977c6511bf4c58) | `Assert versions that have 9.2 compatible versions on Hackage`                                          |
| [`b34575a0`](https://github.com/NixOS/nixpkgs/commit/b34575a0b56dfa147e754d7de8fa56ac2554313f) | `haskellPackages.update-nix-fetchgit: Document when to remove our patch`                                |
| [`702fa7b5`](https://github.com/NixOS/nixpkgs/commit/702fa7b52ea36cdeadcea29b3fdcd6ffc397b43d) | `haskellPackages.update-nix-fetchgit: Patch to make compatible with github-rest version in package set` |
| [`16f3fbbd`](https://github.com/NixOS/nixpkgs/commit/16f3fbbd6f332daeb36c1c3fa75587ff6d6faf5a) | `haskellPackages.clay: drop jailbreak`                                                                  |
| [`4cf31659`](https://github.com/NixOS/nixpkgs/commit/4cf31659f419632f2b7ffc086076c594c52ab1bc) | `haskellPackages.ghcup: drop maintainership`                                                            |
| [`80f8dc82`](https://github.com/NixOS/nixpkgs/commit/80f8dc823b8e285716e50f00a0d904468e76c035) | `haskellPackages.neuron: pin clay version`                                                              |
| [`d2fe726d`](https://github.com/NixOS/nixpkgs/commit/d2fe726d1c5621870b74215995691673e7a13814) | `haskellPackages.matrix-client: drop jailbreak`                                                         |
| [`48b01ad7`](https://github.com/NixOS/nixpkgs/commit/48b01ad75f2d59f176ea3665fd6757184c56c3ab) | `matterhorn: build with aeson 1.5.6.0`                                                                  |
| [`8656de86`](https://github.com/NixOS/nixpkgs/commit/8656de8646c61a12223109e3d30ae6f322b3f85f) | `haskell.packages.ghc922.llvm-hs-pure: fix build with bytestring 0.11`                                  |
| [`71cfd5ea`](https://github.com/NixOS/nixpkgs/commit/71cfd5ea3efb896748960e1609bc1a75765add15) | `haskellPackages: regenerate package set based on current config`                                       |
| [`7c53f076`](https://github.com/NixOS/nixpkgs/commit/7c53f076efe18d8c2ce33903c4d11589261173b5) | `all-cabal-hashes: 2022-03-19T10:17:05Z -> 2022-03-20T09:57:59Z`                                        |
| [`9b8dfcd9`](https://github.com/NixOS/nixpkgs/commit/9b8dfcd9bf449d0b8dd9a3e788df33340dc909c8) | `haskellPackages: stackage Nightly 2022-03-17 -> LTS 19.0`                                              |
| [`57b1c86e`](https://github.com/NixOS/nixpkgs/commit/57b1c86e746152c7ec0a9660b0eb9a4d18a486f9) | `maintainers/haskell/update-stackage.sh: always mktemp for tmp files`                                   |
| [`cd0ddefb`](https://github.com/NixOS/nixpkgs/commit/cd0ddefb4382e26c8f8f7bd0acd2c18b2fae94c3) | `maintainers/haskell/update-stackage.sh: make shellcheck happy`                                         |
| [`22ced213`](https://github.com/NixOS/nixpkgs/commit/22ced213c00d26d3337815221ee5ab1e38f15bff) | `maintainers/haskell/update-stackage.sh: make solver configurable`                                      |
| [`e3ab27de`](https://github.com/NixOS/nixpkgs/commit/e3ab27de78c0f31e725d80811dcb7cf4c0a2c213) | `haskellPackages.hadolint: allow deepseq 1.4.5.0`                                                       |
| [`b83cf107`](https://github.com/NixOS/nixpkgs/commit/b83cf10783ef164f468690432a08818ddfb9c5c8) | `haskellPackages.monad-validate: append patch`                                                          |
| [`fceb5f98`](https://github.com/NixOS/nixpkgs/commit/fceb5f98a1cfa768a6d2ceb75a1d0279f1453d5e) | `haskellPackages.jwt: Disable checks`                                                                   |
| [`6b250818`](https://github.com/NixOS/nixpkgs/commit/6b25081893536afdd18e9a134e8c9418130dc13f) | `haskellPackages.{alg,category,util}: work around Safe Haskell error`                                   |
| [`177255c8`](https://github.com/NixOS/nixpkgs/commit/177255c8aac086b4ea999252a2f042b94e478091) | `haskellPackages.descriptive: pin aeson < 2.0`                                                          |
| [`2812c1a7`](https://github.com/NixOS/nixpkgs/commit/2812c1a74ef312f89b519935fce595591ddfabc4) | `haskellPackages.mmsyn5: lift too strict base constraint`                                               |
| [`4e332dd5`](https://github.com/NixOS/nixpkgs/commit/4e332dd5579b29c101e7fc6cec5b30e8f42919b1) | `haskellPackages.yi-language: disable test suite requiring hspec < 2.8`                                 |
| [`5833e429`](https://github.com/NixOS/nixpkgs/commit/5833e429976c8dc95115e011748727fbf744c88e) | `haskellPackages.snap: Update comment`                                                                  |
| [`ce4bff54`](https://github.com/NixOS/nixpkgs/commit/ce4bff5467c3b143ca8c854f45593624659ca770) | `haskellPackages.hinit: jailbreak`                                                                      |
| [`5bb4a850`](https://github.com/NixOS/nixpkgs/commit/5bb4a85079ff217f76e982b61ca03b27db7f51d1) | `haskellPackages.matrix-client: jailbreak`                                                              |
| [`9e5ac862`](https://github.com/NixOS/nixpkgs/commit/9e5ac8625ea28c58601cfe1053a38b927d32c245) | `haskellPackages: Fix whitespace lint`                                                                  |
| [`44eec005`](https://github.com/NixOS/nixpkgs/commit/44eec0054edee48df3b5ee672cd92b703a05ef12) | `haskellPackages: regenerate package set based on current config`                                       |
| [`6ef31eaf`](https://github.com/NixOS/nixpkgs/commit/6ef31eaf005a77df4167e29224f357ae2365a89a) | `all-cabal-hashes: 2022-03-11T16:24:54Z -> 2022-03-19T10:17:05Z`                                        |
| [`2a6a5749`](https://github.com/NixOS/nixpkgs/commit/2a6a57498bb33b52eb0bebe925331e3c4c599586) | `haskellPackages: stackage-nightly 2022-03-10 -> 2022-03-17`                                            |
| [`d0fda788`](https://github.com/NixOS/nixpkgs/commit/d0fda788aec3a18350b73ba64bae372f0f51fe14) | `haskellPackages.shake-bench: Fix build`                                                                |
| [`ad32e89c`](https://github.com/NixOS/nixpkgs/commit/ad32e89c440f76dfb96c1557ac13c35c18c01fbe) | `haskellPackages.snap: Fix build`                                                                       |
| [`299bfb16`](https://github.com/NixOS/nixpkgs/commit/299bfb168e74945c9b642d0bf3d5efe370121440) | `pkgsStatic.{haskellPackages,ghc}: default to BigNum`                                                   |
| [`4ec13a76`](https://github.com/NixOS/nixpkgs/commit/4ec13a76b0108e4691195b5633b7e5cbd4def2a2) | `release-haskell.nix: test package that needs -fexternal-dynamic-refs`                                  |
| [`654940f3`](https://github.com/NixOS/nixpkgs/commit/654940f36b5dfa19d87098efca6c4dac44a84eda) | `haskellPackages.mkDerivation: check haddock availability`                                              |
| [`4884fcc0`](https://github.com/NixOS/nixpkgs/commit/4884fcc0d2b7581ef670a3cbd71363023a3ee6eb) | `ghc: enable static RTS`                                                                                |
| [`0da85d3f`](https://github.com/NixOS/nixpkgs/commit/0da85d3f7790ed4acc0fd2ba42d40f8b376d1118) | `release-haskell.nix: temporarily disable x86_64-darwin`                                                |
| [`70e6eb9e`](https://github.com/NixOS/nixpkgs/commit/70e6eb9ec8d548b836f8dedbf63d86a6bd737dc3) | `haskellPackages.stack: Patch for new Cabal`                                                            |
| [`0ba189f2`](https://github.com/NixOS/nixpkgs/commit/0ba189f2d7ba8f6c225fbea2a6b4ba2e037a70b7) | `haskellPackages.knob: add patch for GHC 9 support`                                                     |
| [`1a78adaa`](https://github.com/NixOS/nixpkgs/commit/1a78adaa30fee69e5172efe42579b4065b48067b) | `haskellPackages.neuron: Fix build`                                                                     |
| [`3cf437e4`](https://github.com/NixOS/nixpkgs/commit/3cf437e4617fdad853616f3c3a50468b92d28037) | `haskellPackages.shower: jailbreak`                                                                     |
| [`4585f07f`](https://github.com/NixOS/nixpkgs/commit/4585f07fced49290a6e5e7a4f917ff6e99922887) | `haskellPackages.reflex-dom-core: add patches`                                                          |
| [`ab1a3c72`](https://github.com/NixOS/nixpkgs/commit/ab1a3c722494742360de874f87cb3d5ce43de417) | `haskellPackages.reflex: add patch`                                                                     |
| [`a17834b4`](https://github.com/NixOS/nixpkgs/commit/a17834b4690e0f86865dd7e3219ec3c13a5494d8) | `haskellPackages.dependent-sum-aeson-orphans: jailbreak`                                                |
| [`d3dcfdaf`](https://github.com/NixOS/nixpkgs/commit/d3dcfdaf4cc4f24ead76cd4a6e53ee0701131d14) | `haskellPackages.jsaddle-dom: Fix build`                                                                |
| [`102af71d`](https://github.com/NixOS/nixpkgs/commit/102af71d8c2db79058f568776c29ae2c5a1460d6) | `haskellPackages.ghcjs-dom: fix package qualified import issue`                                         |
| [`0eef4333`](https://github.com/NixOS/nixpkgs/commit/0eef43331cca9fa0a38a1b3dd2f0a13bf556541b) | `haskellPackages.jsaddle: jailbreak`                                                                    |
| [`c13629eb`](https://github.com/NixOS/nixpkgs/commit/c13629eb1265a6c1c0048b81044b2556140de357) | `haskellPackages.elm2nix: Patch for aeson-2`                                                            |
| [`bb72482c`](https://github.com/NixOS/nixpkgs/commit/bb72482cc3eb6f6604641a246ce26bc8c3dff627) | `haskell-language-server: Disable more flaky tests`                                                     |
| [`0146f135`](https://github.com/NixOS/nixpkgs/commit/0146f135aef4e8d084863a7dea05a43a0887f3df) | `haskellPackages.mustache: patch for unordered-containers 0.2.17`                                       |
| [`c8a4385f`](https://github.com/NixOS/nixpkgs/commit/c8a4385f728bda7211bed1f568357389e7157509) | `haskellPackages.patch: Add patch for ghc 9.0 compat`                                                   |
| [`8f980b43`](https://github.com/NixOS/nixpkgs/commit/8f980b43835b24b15c4ba995932427b6f3daade4) | `haskell.packages.ghc922.ghc-lib-parser-ex: adjust for hackage update`                                  |
| [`2ff66af8`](https://github.com/NixOS/nixpkgs/commit/2ff66af811dc4ee5a6903bec3df1454a299903f1) | `gitit: patch to build with hoauth >= 2.3.0 and pandoc >= 2.17`                                         |
| [`4eba052b`](https://github.com/NixOS/nixpkgs/commit/4eba052b8d10601c6519faca564cdf6cc95e9ad9) | `haskellPackages: regenerate package set based on current config`                                       |
| [`14fd5837`](https://github.com/NixOS/nixpkgs/commit/14fd583715ef7db3b8c3b0aa0ba3e3ed43d6e582) | `all-cabal-hashes: 2022-03-09T16:42:26Z -> 2022-03-11T16:24:54Z`                                        |
| [`19f8fcd7`](https://github.com/NixOS/nixpkgs/commit/19f8fcd76692a28dabaf195e30b467d2d72992e2) | `haskellPackages: stackage-nightly 2022-03-09 -> 2022-03-10`                                            |
| [`c2c0e150`](https://github.com/NixOS/nixpkgs/commit/c2c0e150da6596b3e4a58b62a2094a553fcebb2b) | `arion: Fix name-setting patch`                                                                         |