### PR TITLE
chore(flake/home-manager): `cf62e96b` -> `e1fab012`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1648751066,
-        "narHash": "sha256-pYUSID9rSgYnl4PNa45/haCaHUKzY+Ul0fkqqSGflxs=",
+        "lastModified": 1648827187,
+        "narHash": "sha256-lNQqw80uMiUb1GgD4QTCc4bsAXPk7/jwH70J9/0e+QA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cf62e96bf7c72e6a88e0bd43165110f42e44cdb4",
+        "rev": "e1fab012e872c129099535b5b535fc2347cfa6f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`e1fab012`](https://github.com/nix-community/home-manager/commit/e1fab012e872c129099535b5b535fc2347cfa6f4) | `nix-darwin: sudo --set-home for multiple user activation (#2857)` |