### PR TITLE
chore(flake/nixpkgs): `10632447` -> `1ddbc47d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1648673296,
-        "narHash": "sha256-dlQP4/escrnt8vm1WAbWrYeFvYF1F1K3m+9qsUHwL+I=",
+        "lastModified": 1649014612,
+        "narHash": "sha256-gJBss4NDhyH21tywYduTxnhbmyJj0C6RBD/8Ze2ABzQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1063244793d9b2dc3db515ac5b70a85385ec9b10",
+        "rev": "1ddbc47dc7439f50d12e8daabd01efaa78320e39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`1ddbc47d`](https://github.com/NixOS/nixpkgs/commit/1ddbc47dc7439f50d12e8daabd01efaa78320e39) | `ocamlPackages.type_conv: remove at 108.08.00, 109.60.01, 113.00.02`   |
| [`095466ad`](https://github.com/NixOS/nixpkgs/commit/095466adaae13aeaae7902b73f3d81d80a8c4cd4) | `python310Packages.immutables: 0.16 -> 0.17`                           |
| [`65725c16`](https://github.com/NixOS/nixpkgs/commit/65725c1637954525bac0199f21fc42a8c52ed323) | `nixos/tests/hibernate: fix eval`                                      |
| [`56b46539`](https://github.com/NixOS/nixpkgs/commit/56b465390449926626d3378e05b8e507061cd828) | `nixos/stage-2-init: Re-add creation of /etc`                          |
| [`b4309d20`](https://github.com/NixOS/nixpkgs/commit/b4309d202fd3ebe94d9f785cda9c0df2c4afd78e) | `snapper: 0.9.1 -> 0.10.0`                                             |
| [`7dbe7487`](https://github.com/NixOS/nixpkgs/commit/7dbe7487b675d594ede82be4175a44a2bfab8498) | `Update doc/stdenv/cross-compilation.chapter.md`                       |
| [`4e9f1e53`](https://github.com/NixOS/nixpkgs/commit/4e9f1e537ed673b53b5a3e7d9e3601c9c84961eb) | `nixos/tests/boot: fix after aa0f27abb06ca66a1dc99493ada65e2bbd6000c9` |
| [`799bda94`](https://github.com/NixOS/nixpkgs/commit/799bda94db01d575f8f143c968d1186d891f2982) | `nixos/kea: Allow specifying custom config file`                       |
| [`63b1f562`](https://github.com/NixOS/nixpkgs/commit/63b1f5625485a160929a2f3984fb1bb5675efa03) | `polkadot: fix build on non-darwin`                                    |
| [`44a3d91e`](https://github.com/NixOS/nixpkgs/commit/44a3d91e5fb706202f33e2d4180c99dd4a288203) | `nixos/collectd: put extraconfig before plugins`                       |
| [`2be63967`](https://github.com/NixOS/nixpkgs/commit/2be6396776a444126796ed8acb6c1c3b2d3e9f51) | `r3rs: remove after being marked broken for over two years`            |
| [`c33000fb`](https://github.com/NixOS/nixpkgs/commit/c33000fbdd38f337280a05db4674ccaa7c3e5c02) | `qxt: remove after being marked broken for over two years`             |
| [`de7dfaf2`](https://github.com/NixOS/nixpkgs/commit/de7dfaf2acca2a626e9d76dd01d0226d6b59c650) | `qmc2: remove after being marked broken for over two years`            |
| [`ca81c782`](https://github.com/NixOS/nixpkgs/commit/ca81c7821844739c7a29badd010317066f608f5e) | `pure: remove after being marked broken for over two years`            |
| [`f75ec63a`](https://github.com/NixOS/nixpkgs/commit/f75ec63a9bb37372c7bb5350be178ef24b63a00b) | `photivo: remove after being marked broken for over two years`         |
| [`63828897`](https://github.com/NixOS/nixpkgs/commit/63828897eb7680347f66fcc218f0d44677d8338b) | `packetbeat: remove after being marked broken for over two years`      |
| [`672ea43d`](https://github.com/NixOS/nixpkgs/commit/672ea43d0ed3c71d4a3f90a4bfaa179b4364548e) | `otter: remove after being marked broken for over two years`           |
| [`148b8f15`](https://github.com/NixOS/nixpkgs/commit/148b8f1543cb5bde3fbf9b5f10eaffdd12036a00) | `ori: remove after being marked broken for over two years`             |
| [`06be9880`](https://github.com/NixOS/nixpkgs/commit/06be988015f6efef126a066e64c37b2fe0acad45) | `openxpki: remove after being marked broken for over two years`        |
| [`64a3d95f`](https://github.com/NixOS/nixpkgs/commit/64a3d95fc11c7bdf4ff63f65987ee57c6358f7f1) | `openspace: remove after being marked broken for over two years`       |
| [`f9ad6fb7`](https://github.com/NixOS/nixpkgs/commit/f9ad6fb74402bdfa8532743207dc4f975ef0fbaf) | `openmvs: remove after being marked broken for over two years`         |
| [`eb13e249`](https://github.com/NixOS/nixpkgs/commit/eb13e249f08c7cd85ef0853758b5e4405510181f) | `openfire: remove after being marked broken for over two years`        |
| [`357bf5e7`](https://github.com/NixOS/nixpkgs/commit/357bf5e7fe076995e8d9e96857855998ade96fe5) | `notbit: remove after being marked broken for over two years`          |
| [`60f1e6ff`](https://github.com/NixOS/nixpkgs/commit/60f1e6ffe29a4b288f3801ff97b74e035109eee1) | `ncbi_tools: remove after being marked broken for over two years`      |
| [`7a5f2559`](https://github.com/NixOS/nixpkgs/commit/7a5f25594e48d366c588eab8d252ac223b2e8f54) | `myserver: remove after being marked broken for over two years`        |
| [`3156594f`](https://github.com/NixOS/nixpkgs/commit/3156594f923e469679b6b7d5442ec1730e8dc4fb) | `mht2htm: remove after being marked broken for over two years`         |
| [`aa2c7c30`](https://github.com/NixOS/nixpkgs/commit/aa2c7c30df3a41f9e61421a440581c319465253a) | `metaocaml_3_09: remove after being marked broken for over two years`  |
| [`d0063f80`](https://github.com/NixOS/nixpkgs/commit/d0063f803c0756d50b16a98527b8c1e80cd6f79c) | `meo: remove after being marked broken for over two years`             |
| [`33e8308d`](https://github.com/NixOS/nixpkgs/commit/33e8308dbc0a3a05a5f5142520a49f913ae01248) | `lean2: remove after being marked broken for over two years`           |
| [`90c42fa3`](https://github.com/NixOS/nixpkgs/commit/90c42fa33f847428d3297673f9bc2c03658fcf5f) | `jonprl: remove after being marked broken for over two years`          |
| [`b0c83c33`](https://github.com/NixOS/nixpkgs/commit/b0c83c33405b6b311057d99bcd4615bfb54f8049) | `inav: remove after being marked broken for over two years`            |
| [`b4713da6`](https://github.com/NixOS/nixpkgs/commit/b4713da648a425a9f8cf9b44828e5281ff99d6ba) | `imatix_gsl: remove after being marked broken for over two years`      |
| [`03a6a8c2`](https://github.com/NixOS/nixpkgs/commit/03a6a8c2accb78a1a6a402a76052ef531aa75643) | `ilixi: remove after being marked broken for over two years`           |
| [`852a93a6`](https://github.com/NixOS/nixpkgs/commit/852a93a6c88c4bc4b3aab651bc31c895812b3a8c) | `hhvm: remove after being marked broken for over two years`            |
| [`72602b6e`](https://github.com/NixOS/nixpkgs/commit/72602b6e9e1f2bf1f07244374e545cc070492287) | `gtkmathview: remove after being marked broken for over two years`     |
| [`71276302`](https://github.com/NixOS/nixpkgs/commit/71276302bb3bd33972f1282ab1daff03dcf0584d) | `gnutls-kdh: remove after being marked broken for over two years`      |
| [`42d49fd7`](https://github.com/NixOS/nixpkgs/commit/42d49fd75debe7e640a279fdc2b9d29af59083e3) | `gnokii: remove after being marked broken for over two years`          |
| [`7fdc8476`](https://github.com/NixOS/nixpkgs/commit/7fdc84763a94139d5ac6315551474d42e5faf00c) | `git-dit: remove after being marked broken for over two years`         |
| [`46604954`](https://github.com/NixOS/nixpkgs/commit/46604954b9dc35196ae226fc7234555dd7c922c7) | `gdata-sharp: remove after being marked broken for over two years`     |
| [`121d8861`](https://github.com/NixOS/nixpkgs/commit/121d886113731ddeadc79c362f8b6a8f0e3cd4e5) | `foo-yc20: remove after being marked broken for over two years`        |
| [`5cb86e08`](https://github.com/NixOS/nixpkgs/commit/5cb86e081fee9ee516320f0e4b5c5db38699a26e) | `fakenes: remove after being marked broken for over two years`         |
| [`7f05ada1`](https://github.com/NixOS/nixpkgs/commit/7f05ada11a7007f60b4b4076abcbddb745f83c13) | `clfswm: remove after being marked broken for over two years`          |
| [`d8393bc0`](https://github.com/NixOS/nixpkgs/commit/d8393bc040a04c037ee90f8cdcc6cf90ceca02fc) | `chaps: remove after being marked broken for over two years`           |
| [`00514a02`](https://github.com/NixOS/nixpkgs/commit/00514a0289d061c5217c997328b351b71d708247) | `bonfire: remove after being marked broken for over two years`         |
| [`e4d66b08`](https://github.com/NixOS/nixpkgs/commit/e4d66b08e959b4de4ed3eee6f0d72cf405633d00) | `bitkeeper: remove after being marked broken for over two years`       |
| [`9717c7ba`](https://github.com/NixOS/nixpkgs/commit/9717c7ba7e48fbad9a8fb73e5d243789358c83d6) | `betaflight: remove after being marked broken for over two years`      |
| [`8e7dd685`](https://github.com/NixOS/nixpkgs/commit/8e7dd685e95256403c9a2f89aef4a7fb1defe74b) | `bareos: remove after being marked broken for over two years`          |
| [`8a5bb02b`](https://github.com/NixOS/nixpkgs/commit/8a5bb02b6461647da0d4917a4a91386f0748da87) | `aliceml: remove after being marked broken for over two years`         |
| [`af541e7f`](https://github.com/NixOS/nixpkgs/commit/af541e7f95f34fd10b2044daef67143bb8257d06) | `aldor: remove after being marked broken for over two years`           |
| [`64d12b6b`](https://github.com/NixOS/nixpkgs/commit/64d12b6bf72e01000766cd7724f4d004fa02b80d) | `texlive: recompute 2021.20211227 fixed hashes (#167026)`              |
| [`5be97bb4`](https://github.com/NixOS/nixpkgs/commit/5be97bb4aa028f101b8b42848870ae661c905660) | `reap: init at 0.3-unreleased`                                         |
| [`1865515d`](https://github.com/NixOS/nixpkgs/commit/1865515d6383ef0c9fdd56d1a01955bce49844e4) | `wasmtime: make derivation available only on linux for now`            |
| [`d233c169`](https://github.com/NixOS/nixpkgs/commit/d233c169c72cd0dbbf11aed6a96685870b19dfde) | `Fix wasmtime build`                                                   |
| [`a4b3bd08`](https://github.com/NixOS/nixpkgs/commit/a4b3bd08d9b92ada4b3f1ac0d6a19f829b913f6e) | `wasmtime: 0.21.0 -> 0.35.2`                                           |
| [`f4edf204`](https://github.com/NixOS/nixpkgs/commit/f4edf20487ef7493b4f797e7b6e51c7ab332c3e3) | `roapi-http: init at 0.6.0`                                            |
| [`d720420f`](https://github.com/NixOS/nixpkgs/commit/d720420f3795f54683db2f4114e7d5d3af3887d5) | `haskellPackages: correct broken status of some packages`              |
| [`6fc9e4b7`](https://github.com/NixOS/nixpkgs/commit/6fc9e4b7008cff19718f5a1ebf0331e1910e1530) | `openttd-jgrpp: Add optional but recommended zstd dependency`          |
| [`459d0413`](https://github.com/NixOS/nixpkgs/commit/459d04132d0398b175b3915d3e4e3eb2adf1eb3e) | `lutris: 0.5.9.1 -> 0.5.10`                                            |
| [`3d16e9db`](https://github.com/NixOS/nixpkgs/commit/3d16e9db858e54b48ea58ef965c1ecaa0bf8fac3) | `openttd-jgrpp: 0.44.0 -> 0.47.1`                                      |
| [`98e1f0ba`](https://github.com/NixOS/nixpkgs/commit/98e1f0ba4e95a8d23a77900155649397b840ab73) | `openttd: 12.1 -> 12.2`                                                |
| [`fc0ebeac`](https://github.com/NixOS/nixpkgs/commit/fc0ebeacfed66910d20b1b2d1b20ba3a4fce2ae0) | `haskellPackages: mark builds failing on hydra as broken`              |
| [`117fe1fd`](https://github.com/NixOS/nixpkgs/commit/117fe1fd2b3254e59bd4506b980b2f0a4996a722) | `maintainers/teams: clean up cleanup team`                             |
| [`98b5d522`](https://github.com/NixOS/nixpkgs/commit/98b5d522b6d010c4b90c6450fd3d3d0147a7a95f) | `python310Packages.simplisafe-python: 2022.03.2 -> 2022.03.3`          |
| [`ea473fac`](https://github.com/NixOS/nixpkgs/commit/ea473fac72d16c5fb9a159cad8cf96a21becea7c) | `nixos/stage-2-init: Don't clear environment`                          |
| [`e09bece8`](https://github.com/NixOS/nixpkgs/commit/e09bece8a81af7c9462b721949264acd85a47999) | `gradle: 7.4 -> 7.4.2`                                                 |
| [`60d6830f`](https://github.com/NixOS/nixpkgs/commit/60d6830fec322b291d6e4771e6633c77db616cb6) | `python310Packages.awscrt: 0.13.6 -> 0.13.7`                           |
| [`c79c23d0`](https://github.com/NixOS/nixpkgs/commit/c79c23d01756160083740fee71d9b4090e2b31e4) | `saxon: use jdk_headless instead of jdk`                               |
| [`2abee3b8`](https://github.com/NixOS/nixpkgs/commit/2abee3b82bdb06430ce1131aecd24db55e4d4df4) | `newsboat: 2.26 -> 2.27`                                               |
| [`5262a53d`](https://github.com/NixOS/nixpkgs/commit/5262a53dca6cfbfb46d45ed05cf2c90267e0a0dd) | `python310Packages.python-box: 6.0.1 -> 6.0.2`                         |
| [`f3aa17de`](https://github.com/NixOS/nixpkgs/commit/f3aa17de86033e1906c05a43c89e089a2326e9fc) | `python3Packages.pysnooper: disable on older Python releases`          |
| [`28d736ac`](https://github.com/NixOS/nixpkgs/commit/28d736ac6adcd397e24414450f838746822f25e7) | `terrascan: 1.13.2 -> 1.14.0`                                          |
| [`7b587ffe`](https://github.com/NixOS/nixpkgs/commit/7b587ffe610266ae575400c1f6d0f259561c5cf0) | `jing-trang: use jdk_headless instead of jdk`                          |
| [`d341a902`](https://github.com/NixOS/nixpkgs/commit/d341a9022e847f47f7f3889227505eaac1548691) | `naabu: 2.0.5 -> 2.0.6`                                                |
| [`884395ea`](https://github.com/NixOS/nixpkgs/commit/884395eae0b0ea5e30976c9238c249e719a330b5) | `zzuf: use autoreconfHook`                                             |
| [`e48ff4cd`](https://github.com/NixOS/nixpkgs/commit/e48ff4cdb06d4c161114018131d39cf305047cf5) | `python310Packages.ipyparallel: 8.2.0 -> 8.2.1`                        |
| [`4cc3aa4d`](https://github.com/NixOS/nixpkgs/commit/4cc3aa4d6010e78dc5ef6a2ead9ea67d07d11a1f) | `python3Packages.mizani: adjust disable`                               |
| [`6fb4383a`](https://github.com/NixOS/nixpkgs/commit/6fb4383ad48c2d627e82298ec5eea7fa048900a9) | `python310Packages.pysnooper: 1.1.0 -> 1.1.1`                          |
| [`12c1aa29`](https://github.com/NixOS/nixpkgs/commit/12c1aa29f39754c727e7ce8bf901bbe1e654f491) | `libreddit: 0.22.5 -> 0.22.6`                                          |
| [`879d0536`](https://github.com/NixOS/nixpkgs/commit/879d0536cd2cdd03b83306ffaf0c9c97c804a2df) | `python310Packages.PyChromecast: 10.3.0 -> 11.0.0`                     |
| [`fb1494f9`](https://github.com/NixOS/nixpkgs/commit/fb1494f95a3618066ca02008c3337bce41ff0061) | `rnote: 0.3.5 -> 0.4.0`                                                |
| [`044cd995`](https://github.com/NixOS/nixpkgs/commit/044cd9950469de2232fd1d0c2f25022cbbd94a3f) | `pulumi: 3.27.0 -> 3.28.0`                                             |
| [`8b9bbbc9`](https://github.com/NixOS/nixpkgs/commit/8b9bbbc97994958969c8ff137b1e15d675679992) | `python3Packages.caffeWithCuda: init at 1.0`                           |
| [`a60ab2a1`](https://github.com/NixOS/nixpkgs/commit/a60ab2a1c73453828f81d52a6a3fa3d4586c6fdf) | `caffeWithCuda: init at 1.0`                                           |
| [`1ef351f4`](https://github.com/NixOS/nixpkgs/commit/1ef351f4afa35309c6c1b70ab234bbbd74a83cbb) | `caffe: use CUDA 10.1, cuDNN 7.6`                                      |
| [`f01177be`](https://github.com/NixOS/nixpkgs/commit/f01177be3da5329f467d4bae8c7abc56085c2765) | `metadata-cleaner: 2.1.5 -> 2.2.1`                                     |
| [`c9d66a7f`](https://github.com/NixOS/nixpkgs/commit/c9d66a7fff7a683182fdd5738d02a00b8b2bfdeb) | `cross-compilation.chapter.md: give examples of all depFooBar cases`   |
| [`3821355a`](https://github.com/NixOS/nixpkgs/commit/3821355aebb50d962d65384a80afe0124806b757) | `python3Packages.easygui: use README.md`                               |
| [`80b0dabd`](https://github.com/NixOS/nixpkgs/commit/80b0dabd3a6a14ce7851fb9171faad93702c4041) | `python310Packages.mizani: 0.7.3 -> 0.7.4`                             |
| [`50150c52`](https://github.com/NixOS/nixpkgs/commit/50150c52661e05b656458c5ce8acc73feec9da3d) | `python310Packages.mcstatus: 9.0.3 -> 9.0.4`                           |
| [`63f9a72f`](https://github.com/NixOS/nixpkgs/commit/63f9a72fba67857e1b8467b0f96e8efb5c003700) | `python39Packages.elastic-apm: 6.8.1 -> 6.9.1`                         |
| [`6b096be4`](https://github.com/NixOS/nixpkgs/commit/6b096be49ccfaed282455f2eb0c9be216b7e4400) | `python310Packages.ha-philipsjs: 2.7.6 -> 2.9.0`                       |
| [`b85bfe99`](https://github.com/NixOS/nixpkgs/commit/b85bfe9989ab44301d93d3eaecc090bc669c6a7c) | `python3Packages.cloudflare: disable on older Python releases`         |
| [`6e9df508`](https://github.com/NixOS/nixpkgs/commit/6e9df508370b582417e976ee75ada577f3a3483f) | `python3Packages.azure-keyvault: update input`                         |
| [`170f6095`](https://github.com/NixOS/nixpkgs/commit/170f609504cdd02fef31f8cfe88534140708d3c3) | `python3Packages.azure-keyvault: update disable`                       |
| [`6c5fc227`](https://github.com/NixOS/nixpkgs/commit/6c5fc227d9fb0e29fb4faa2d83d9c47006c8a8fe) | `python3Packages.dotmap: disable on older Python releases`             |
| [`c48f377d`](https://github.com/NixOS/nixpkgs/commit/c48f377dd7b9793f1550804bda1e52b2fd6dfaad) | `python310Packages.google-nest-sdm: 1.8.0 -> 1.9.0`                    |
| [`9f12e57e`](https://github.com/NixOS/nixpkgs/commit/9f12e57e8facc76d7e1a1fde76625b2ee1c1b23d) | `python310Packages.zigpy-deconz: 0.14.0 -> 0.15.0`                     |
| [`3fef225b`](https://github.com/NixOS/nixpkgs/commit/3fef225bbf73baf4eeb78e3799db56c8dcaac0ac) | `python310Packages.glean-parser: 5.1.1 -> 5.1.2`                       |
| [`9f19ba38`](https://github.com/NixOS/nixpkgs/commit/9f19ba380e63700f03304edcd2cc6b027ad4c65f) | `sq: init at 0.15.4`                                                   |
| [`ce05c3ae`](https://github.com/NixOS/nixpkgs/commit/ce05c3ae6b7ad230787b17562274716f0f36eb8c) | `maestral: add NixOS tests`                                            |
| [`e38cc45d`](https://github.com/NixOS/nixpkgs/commit/e38cc45dd196bcbe177e6852b2f8ebc4bcca3bd7) | `nixos: add maestral tests`                                            |
| [`b49659fd`](https://github.com/NixOS/nixpkgs/commit/b49659fdb74c722a6cb99c91377f8c41f3d0e478) | `zellij: 0.26.1 -> 0.27.0`                                             |
| [`b033a909`](https://github.com/NixOS/nixpkgs/commit/b033a90943c1e8d27c00eb2209fa7bcf297bfd5c) | `python310Packages.asyncsleepiq: 1.2.1 -> 1.2.3`                       |
| [`38b94582`](https://github.com/NixOS/nixpkgs/commit/38b945824742d594b55709409179a62a3a2b9ffb) | `pipewire: apply patch for missing declarations`                       |
| [`cda7657a`](https://github.com/NixOS/nixpkgs/commit/cda7657af04c9b2b9ac8bbe13046002425c66dd2) | `python310Packages.fastapi: 0.75.0 -> 0.75.1`                          |
| [`ca75d76d`](https://github.com/NixOS/nixpkgs/commit/ca75d76df4a64ed9781b7a86c86c6e8d46e79d27) | `python310Packages.easygui: 0.98.2 -> 0.98.3`                          |
| [`41b3f559`](https://github.com/NixOS/nixpkgs/commit/41b3f559f7cb72ebc9a419a57f21f4f8e19eb35b) | `elmPackages: update nodejs dependecies`                               |
| [`8f3181f6`](https://github.com/NixOS/nixpkgs/commit/8f3181f67202ccc67307e22192c1468a5f779b61) | `nixos/tests/mtp: init`                                                |
| [`376d67e1`](https://github.com/NixOS/nixpkgs/commit/376d67e1cd05d5ac8a64a3f47f17b80fb6394792) | `prometheus-wireguard-exporter: 3.6.2 -> 3.6.3`                        |
| [`549a1bf9`](https://github.com/NixOS/nixpkgs/commit/549a1bf9eb8bfa37526d4cefa82c019d92908565) | `cryptowatch-desktop: init at 0.5.0`                                   |
| [`9230d299`](https://github.com/NixOS/nixpkgs/commit/9230d299009d3dce2c04e3593027ca8ce36d3767) | `zigbee2mqtt: 1.24.0 -> 1.25.0`                                        |
| [`96674e9c`](https://github.com/NixOS/nixpkgs/commit/96674e9c3b55995ded1b99ec41599e8d6f7f436b) | `qemu: add patch to fix MTP devices`                                   |
| [`3aa6277c`](https://github.com/NixOS/nixpkgs/commit/3aa6277c43b1e393b400af53c82715202e0ea5da) | `php74Packages.composer: 2.2.9 -> 2.3.3`                               |
| [`bbf52810`](https://github.com/NixOS/nixpkgs/commit/bbf528105b4b37843b3d8162dd00ce058ede1891) | `php74Packages.phpstan: 1.5.0 -> 1.5.3`                                |
| [`815601ff`](https://github.com/NixOS/nixpkgs/commit/815601ff61555c150edaed35a07b20efdfb8bc95) | `glib: use correct meson for cross compilation`                        |
| [`cfb80832`](https://github.com/NixOS/nixpkgs/commit/cfb8083201fb1209def2f1c55346ced4562d6738) | `python310Packages.dotmap: 1.3.26 -> 1.3.27`                           |
| [`b652b434`](https://github.com/NixOS/nixpkgs/commit/b652b434a4d0bb11411024648121b3666f1faa92) | `davinci-resolve: unbreak`                                             |
| [`dd6d916d`](https://github.com/NixOS/nixpkgs/commit/dd6d916ddd69edda03624695427adf4bba75c8d3) | `vcluster: 0.6.0 -> 0.7.0`                                             |
| [`c1ecd463`](https://github.com/NixOS/nixpkgs/commit/c1ecd4637e74e31ba821d3426eccd8bb7ca3ce09) | `fluxctl: 1.24.3 -> 1.25.0`                                            |
| [`4aac9fc8`](https://github.com/NixOS/nixpkgs/commit/4aac9fc8c3732e0f861d78bd11d76849d32036ae) | `helmfile: 0.143.3 -> 0.143.5`                                         |
| [`417c4d1c`](https://github.com/NixOS/nixpkgs/commit/417c4d1c47e306664d7d020a0cb9647f26709fe3) | `argo: 3.3.0 -> 3.3.1`                                                 |
| [`755c98a3`](https://github.com/NixOS/nixpkgs/commit/755c98a360808aae99490373e0fc2171529792c5) | `python3.pkgs.kubernetes: fix darwin build`                            |
| [`7b7f2a09`](https://github.com/NixOS/nixpkgs/commit/7b7f2a0928b84fe72129b7aeaf6206cf38d33ec5) | `uutils-coreutils: 0.0.12 -> 0.0.13`                                   |
| [`4d628da3`](https://github.com/NixOS/nixpkgs/commit/4d628da3d72f3bfb4d6114c2dd1a5e7fa53ef58b) | `grails: 5.1.4 -> 5.1.6`                                               |
| [`6a36abcd`](https://github.com/NixOS/nixpkgs/commit/6a36abcd5943bd1bfafeb753093c809685470fc1) | `haskellPackages.leveldb-haskell: fix build`                           |
| [`1bab8ca9`](https://github.com/NixOS/nixpkgs/commit/1bab8ca98a788726e3eb9c0750e54b4d849ba506) | `d-spy: init at 1.2.0`                                                 |
| [`be1232ea`](https://github.com/NixOS/nixpkgs/commit/be1232ea2ff017f22ce3d37ba0edc9667f9cb4ee) | `graalvmXX-ce: fix relative paths`                                     |
| [`d8d3deb8`](https://github.com/NixOS/nixpkgs/commit/d8d3deb8d91c01892f70e7e5ab7fdf182ab6d71d) | `gcr: use wrapGAppsHook`                                               |
| [`75e301c3`](https://github.com/NixOS/nixpkgs/commit/75e301c3577776d76bc9287ba3f57b2657c403f0) | `imagemagick6: remove erictapen as maintainer`                         |
| [`fd211d7a`](https://github.com/NixOS/nixpkgs/commit/fd211d7aaa4210cc9dc9e8e75976dcb5daba5542) | `drawing: 0.8.5 -> 1.0.0`                                              |
| [`f665340b`](https://github.com/NixOS/nixpkgs/commit/f665340b6c09fb1ba4a644465e65ac20e3e9bbce) | `pipewire: 0.3.48 -> 0.3.49`                                           |
| [`2d7d3692`](https://github.com/NixOS/nixpkgs/commit/2d7d3692c125cc07954b342f84c797019c37633c) | ``graalvmXX-ce: use the release version as `defaultVersion```          |
| [`dfdab815`](https://github.com/NixOS/nixpkgs/commit/dfdab81577d516aa81b50a97f8d0d853fb99a832) | `palemoon: 29.4.5 -> 29.4.5.1, add version test`                       |
| [`8b7daabf`](https://github.com/NixOS/nixpkgs/commit/8b7daabf5bbc44d7f99db5a137983c954b47d326) | `mozc: make mozc.el to find mozc_emacs_helper`                         |
| [`bfc50149`](https://github.com/NixOS/nixpkgs/commit/bfc501493fd792d5e9a874db54e15d4f51dfe5b7) | `graalvmXX-ce: add review suggestions`                                 |
| [`3d3e4fc4`](https://github.com/NixOS/nixpkgs/commit/3d3e4fc4989546412270f2c410de2e334935bd7f) | `obliv-c: 0.0pre20180624 → 0.0pre20210621`                             |
| [`02d7b7a7`](https://github.com/NixOS/nixpkgs/commit/02d7b7a7a0085a1e882419d901583e41536ba08a) | `obliv-c: fix build`                                                   |
| [`c167b827`](https://github.com/NixOS/nixpkgs/commit/c167b827b5dabe47f8469603e13c74b693255212) | `gnome.sushi: 41.0 → 41.1`                                             |
| [`79cccf41`](https://github.com/NixOS/nixpkgs/commit/79cccf419b549df732b9c024c85d1ca421161754) | `gnome.gucharmap: 14.0.2 → 14.0.3`                                     |
| [`524c4634`](https://github.com/NixOS/nixpkgs/commit/524c463486410271b1a6e0bde8a841fb1d4b7dbe) | `gnome.five-or-more: 3.32.2 → 3.32.3`                                  |
| [`e0b8dc89`](https://github.com/NixOS/nixpkgs/commit/e0b8dc89044f2dae9a2a0fc3451e4872a03969c3) | `intel-ocl: add http url to url list`                                  |
| [`12f94fda`](https://github.com/NixOS/nixpkgs/commit/12f94fda6b50584b067d2b711568845b37eee946) | `jql: 3.1.3 -> 3.2.0`                                                  |
| [`65fadfb8`](https://github.com/NixOS/nixpkgs/commit/65fadfb83849a273cb8ecc1895dafbb2d3329d72) | `taskwarrior-tui: 0.21.1 -> 0.22.0`                                    |
| [`286be1f7`](https://github.com/NixOS/nixpkgs/commit/286be1f7f3d7d13ee30839878cda148d9e2721a4) | `kak-lsp: 12.0.1 -> 12.1.0`                                            |
| [`5770223a`](https://github.com/NixOS/nixpkgs/commit/5770223a74ee8cfab853f42a4bcfcfba5f066295) | `swayr: 0.15.0 -> 0.16.0`                                              |