### PR TITLE
chore(flake/pre-commit-hooks): `b6bc0b21` -> `e5e7b3b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1646153636,
-        "narHash": "sha256-AlWHMzK+xJ1mG267FdT8dCq/HvLCA6jwmx2ZUy5O8tY=",
+        "lastModified": 1649054408,
+        "narHash": "sha256-wz8AH7orqUE4Xog29WMTqOYBs0DMj2wFM8ulrTRVgz0=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "b6bc0b21e1617e2b07d8205e7fae7224036dfa4b",
+        "rev": "e5e7b3b542e7f4f96967966a943d7e1c07558042",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                       |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`7393d3b6`](https://github.com/cachix/pre-commit-hooks.nix/commit/7393d3b644fd749d2d32c61273a0a7e271f5778f) | `update flake-utils for aarch64-darwin support`      |
| [`7300bcec`](https://github.com/cachix/pre-commit-hooks.nix/commit/7300bcec9636bd8472485988028f488294b38443) | `chore(deps): bump actions/checkout from 2.4.0 to 3` |