### PR TITLE
chore(flake/nixpkgs): `1ddbc47d` -> `dcd79648`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1649014612,
-        "narHash": "sha256-gJBss4NDhyH21tywYduTxnhbmyJj0C6RBD/8Ze2ABzQ=",
+        "lastModified": 1649058080,
+        "narHash": "sha256-Uydcy+qZDD3fbbeqh8zQwZ10F7QtizkwcGtrmnjEZZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1ddbc47dc7439f50d12e8daabd01efaa78320e39",
+        "rev": "dcd796487a1632b74e8a62ec4aed39f0c15a72ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`0ae931fb`](https://github.com/NixOS/nixpkgs/commit/0ae931fb87a4e8241c9c5233a4eacccfa00fd68b) | `terraform-providers: update 2022-04-04`                               |
| [`9ba99e62`](https://github.com/NixOS/nixpkgs/commit/9ba99e62709a6795354be5db6aa4bb0f07df9fec) | `tiled: 1.8.2 -> 1.8.4`                                                |
| [`07b55d9c`](https://github.com/NixOS/nixpkgs/commit/07b55d9c8052e413d24000c4347b758f22879f60) | `perlPackages.CompressRawZlib: 2.101 -> 2.103`                         |
| [`0f4a2f12`](https://github.com/NixOS/nixpkgs/commit/0f4a2f12afb14a429485751a394fb566a60c3b33) | `fixup! CONTRIBUTING: rebase master to staging without pinging people` |
| [`d6fc009d`](https://github.com/NixOS/nixpkgs/commit/d6fc009d2cb0c847123169aea74efdeeb417208d) | `metasploit: 6.1.35 -> 6.1.36`                                         |
| [`b479e8d1`](https://github.com/NixOS/nixpkgs/commit/b479e8d1fdf1f46fd414b7372668373b89d90613) | `tarsnap: fix build on darwin aarch64/arm64`                           |
| [`e52d6c12`](https://github.com/NixOS/nixpkgs/commit/e52d6c1260e37aa6b3413f7dfa3846481325342d) | `gdal: enable tests`                                                   |
| [`c506050b`](https://github.com/NixOS/nixpkgs/commit/c506050b94a5e3d41e78d2f8e481e6852c33fba4) | `touchegg: 2.0.13 -> 2.0.14`                                           |
| [`70e644b4`](https://github.com/NixOS/nixpkgs/commit/70e644b4897faffb89d578aa530ac8b2d68f4e56) | `arkade: 0.8.16 -> 0.8.18`                                             |
| [`af8c5986`](https://github.com/NixOS/nixpkgs/commit/af8c598679f14b1f001b6d670b8a8e15a115e274) | `CONTRIBUTING: rebase master to staging without pinging people`        |
| [`835c3419`](https://github.com/NixOS/nixpkgs/commit/835c3419d9b98654e13cd5874020f987074fb57b) | `redis: enable tests`                                                  |