### PR TITLE
chore(flake/home-manager): `cfab869f` -> `0382c5f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1648917498,
-        "narHash": "sha256-fdyVHsP6XeyCk9FRyjV6Wv+7qiOzWxykGXdNixadvyg=",
+        "lastModified": 1649084009,
+        "narHash": "sha256-jfU0rYnMbL8jMNH+o+BYGxsb7d+HrtbFYtG5/kbQDLc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cfab869fcebc56710be6ec3aca76036b25c04a0d",
+        "rev": "0382c5f75e9b4ffb0cdc75535c3e249019710a02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                           |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`0382c5f7`](https://github.com/nix-community/home-manager/commit/0382c5f75e9b4ffb0cdc75535c3e249019710a02) | `git: Add option to use difftastic as diff tool (#2850)` |