### PR TITLE
chore(flake/nixpkgs): `dcd79648` -> `4dddff09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1649058080,
-        "narHash": "sha256-Uydcy+qZDD3fbbeqh8zQwZ10F7QtizkwcGtrmnjEZZE=",
+        "lastModified": 1649122591,
+        "narHash": "sha256-g0Wmjgkkxuzpk9vXnhmqPBd5sBF+50crdmHEPz3zH9M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dcd796487a1632b74e8a62ec4aed39f0c15a72ae",
+        "rev": "4dddff0976bc8d3ef077d81bc44f00796b49e395",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                               |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`4561be30`](https://github.com/NixOS/nixpkgs/commit/4561be306455a4ed12c5c66408816298d14eb8f9) | `janet: 1.21.1 -> 1.21.2`                                                    |
| [`70b2abc3`](https://github.com/NixOS/nixpkgs/commit/70b2abc3ff78850705aba55eded84c2165e6fc77) | `igraph: random improvements`                                                |
| [`a0a955ba`](https://github.com/NixOS/nixpkgs/commit/a0a955ba455156a3f3e29bd20a36dced0e26304b) | `plfit: init at 0.9.3`                                                       |
| [`2817885f`](https://github.com/NixOS/nixpkgs/commit/2817885f015bec9fe61c699d3755a9a6c2cf7eac) | `mosh: fix build on x86_64-linux`                                            |
| [`97ed9eff`](https://github.com/NixOS/nixpkgs/commit/97ed9effd2294dda796acfca1643a184f2af21fa) | `python3Packages.adafruit-platformdetect: 3.22.0 -> 3.22.1`                  |
| [`824de3c9`](https://github.com/NixOS/nixpkgs/commit/824de3c96718979c4db39bb5a92c1a12b5878d21) | `python310Packages.pypandoc: 1.7.4 -> 1.7.5`                                 |
| [`d90f4d50`](https://github.com/NixOS/nixpkgs/commit/d90f4d50305b24077e6c2c8f5b377d3a7abcb200) | `pre-commit: enable tests`                                                   |
| [`6edf36f8`](https://github.com/NixOS/nixpkgs/commit/6edf36f81c55fcdeffa54dcadda10976f9ce6886) | `python39Packages.nodeenv: hardcode which path`                              |
| [`b393b879`](https://github.com/NixOS/nixpkgs/commit/b393b879e0516b36a68a61ae011ca8ab72d081b6) | `pre-commit: 2.17.0 -> 2.18.1`                                               |
| [`0e319a33`](https://github.com/NixOS/nixpkgs/commit/0e319a33248a99d67e45bf3c0b8344a14e3e5ad0) | `texlive: 2021.20211227 -> 2021-final (#167229)`                             |
| [`a3a55b73`](https://github.com/NixOS/nixpkgs/commit/a3a55b732e33b559f36c30ae71a89588984556d1) | `nlopt: fix darwin build`                                                    |
| [`e3958c80`](https://github.com/NixOS/nixpkgs/commit/e3958c80981201a746645356eed755831027f61b) | `eclipses: 2021-12 -> 2022-03`                                               |
| [`308b6bc3`](https://github.com/NixOS/nixpkgs/commit/308b6bc3d6e5d7367606a7133e35238c819e9cc8) | `python310Packages.pynetgear: 0.9.2 -> 0.9.3`                                |
| [`c8151fe6`](https://github.com/NixOS/nixpkgs/commit/c8151fe657612a32307ed17fdc7db2ee52157e69) | `luaPackages.libluv: fix darwin build`                                       |
| [`c1af79c6`](https://github.com/NixOS/nixpkgs/commit/c1af79c69d248d5bc55df8ffbe86a1122a0b897e) | `nixos/ethminer: only pull in nvidia_x11 when needed`                        |
| [`7cbf02e3`](https://github.com/NixOS/nixpkgs/commit/7cbf02e39e0890cc5700e72d895ef1cfd9022472) | `gdcm: 3.0.11 -> 3.0.12`                                                     |
| [`41d3ca06`](https://github.com/NixOS/nixpkgs/commit/41d3ca0677077cf9d74d4c636f9c300014585c2c) | `nixos/systemd-stage-1: Use an own systemd package`                          |
| [`a6a606b0`](https://github.com/NixOS/nixpkgs/commit/a6a606b032b761bc4b2e9a59781a2afeeafb58a4) | `eksctl: 0.89.0 -> 0.90.0`                                                   |
| [`bced1899`](https://github.com/NixOS/nixpkgs/commit/bced189985b8666d595f7098ac0a5bc2275dae69) | `scsh: Update to latest head, unbreaking the build`                          |
| [`23ae4dfc`](https://github.com/NixOS/nixpkgs/commit/23ae4dfc223d75ed1265f43775f9ba1e76feb517) | `python3.pkgs.numba: added optional CUDA support`                            |
| [`a1390787`](https://github.com/NixOS/nixpkgs/commit/a1390787c3c165d93482ccd26587e855778a63b3) | `remove jb55 as maintainer from some packages`                               |
| [`1ea45507`](https://github.com/NixOS/nixpkgs/commit/1ea4550773cf5e35b7ba037afa4e77ab17739ca1) | `coqPackages.coqprime: 8.14.1 → 8.15`                                        |
| [`13571146`](https://github.com/NixOS/nixpkgs/commit/13571146d77d0340296a0f096055f38eda108a46) | `ffuf: 1.4.0 -> 1.4.1`                                                       |
| [`149f31a8`](https://github.com/NixOS/nixpkgs/commit/149f31a857f98945389d9b6e3fcd07603085b3ec) | `jacktrip: init at 1.5.3 (#166137)`                                          |
| [`49c51cdd`](https://github.com/NixOS/nixpkgs/commit/49c51cdd516d51e3ebbb7930e5edb4174c25a0fa) | `openssl_1_0_2: drop`                                                        |
| [`35e93564`](https://github.com/NixOS/nixpkgs/commit/35e93564adf2f4a816815466b9ff1e79e1a34e06) | `sslyze: drop`                                                               |
| [`6fa52289`](https://github.com/NixOS/nixpkgs/commit/6fa52289b4f7723960909c7532981c3a3fe90464) | `wapiti: 3.0.9 -> 3.1.1`                                                     |
| [`36a7bc52`](https://github.com/NixOS/nixpkgs/commit/36a7bc52fbdba272a0e4078d39314185a2cefcf6) | `apostrophe: 2.6.1 -> 2.6.2`                                                 |
| [`f27a7697`](https://github.com/NixOS/nixpkgs/commit/f27a769728ac25e619ac0f647436f08835e1f37e) | `fzf: 0.29.0 -> 0.30.0`                                                      |
| [`ac93d53e`](https://github.com/NixOS/nixpkgs/commit/ac93d53e9fc3bac5ffb29c005c1bc899838c8c7e) | `gpshell, globalplatform, gppcscconnectionplugin: drop`                      |
| [`32e1d67c`](https://github.com/NixOS/nixpkgs/commit/32e1d67cc691756bce2e407baab58ced7c9874b8) | `epsxe: drop`                                                                |
| [`dac6f134`](https://github.com/NixOS/nixpkgs/commit/dac6f134316f1859f4f75a593309ecd00fc779ec) | `pbis-open: drop`                                                            |
| [`9dca986a`](https://github.com/NixOS/nixpkgs/commit/9dca986a47d8dd7fd02b3244fcf0f8892d931676) | `Revert "ovftool: init at 4.4.1"`                                            |
| [`b52d39ee`](https://github.com/NixOS/nixpkgs/commit/b52d39ee09d9f82f063a615e3370feae461df6a6) | `eagle7: drop`                                                               |
| [`ea7bb554`](https://github.com/NixOS/nixpkgs/commit/ea7bb55441a4699a8cfaaf0eabd88c501ed2405a) | `botan: drop`                                                                |
| [`5aafec86`](https://github.com/NixOS/nixpkgs/commit/5aafec8647976b65dc0a9716778b8d9ca9a30f58) | `proxytunnel: drop`                                                          |
| [`6e9e5dfd`](https://github.com/NixOS/nixpkgs/commit/6e9e5dfd556484766a0265c959ae70ac34d22079) | `intecture-*: drop`                                                          |
| [`9c34fd2d`](https://github.com/NixOS/nixpkgs/commit/9c34fd2d73aa7a9c4492ff3ae32de0dd24ef1254) | `gtmess: drop`                                                               |
| [`0412e8a3`](https://github.com/NixOS/nixpkgs/commit/0412e8a3967e0068707e8d3b71a1bcc2fa94e688) | `ucommon: switch to gnutls version, because modern openssl is not supported` |
| [`0fae2737`](https://github.com/NixOS/nixpkgs/commit/0fae27376d8a80e76d1ab45380583866f68b32ee) | `cipherscan: drop`                                                           |
| [`2105726e`](https://github.com/NixOS/nixpkgs/commit/2105726e8737229754f797961cce4dc6177e3c32) | `xfsdump: init at 3.1.10`                                                    |
| [`beb02229`](https://github.com/NixOS/nixpkgs/commit/beb02229fb92b5dfad59e27ced9f635846d1a5c1) | `nixos/systemd-unit-options: Fix indentation`                                |
| [`cb69b89d`](https://github.com/NixOS/nixpkgs/commit/cb69b89d9033c5edfcac1781b4b630841a9cb746) | `pulumi: fix hashes`                                                         |
| [`9957c180`](https://github.com/NixOS/nixpkgs/commit/9957c18098341b0120306e80c9862cdfcf45c978) | `findomain: 7.0.1 -> 7.2.0`                                                  |
| [`75ece4eb`](https://github.com/NixOS/nixpkgs/commit/75ece4eb82a59aa78721d35b2f0bbf8285e1ee56) | `nixos/stage-1-systemd: Limit files to the bare necessities`                 |
| [`dcca8f5b`](https://github.com/NixOS/nixpkgs/commit/dcca8f5be287bf7efd4867d0e0ed7643434a8236) | `tests.pkgs-lib.formats: Detect when impossible input is fed`                |
| [`ef6d9dfd`](https://github.com/NixOS/nixpkgs/commit/ef6d9dfd710cf082b90aa78804f0743aa9b1a8a8) | `pkgs.formats.javaProperties: Add implementation note to type`               |
| [`4b9efea2`](https://github.com/NixOS/nixpkgs/commit/4b9efea2554e035ec03f73fb922eab16db8c7fb3) | `nixos/stage-1-systemd: Implement job scripts`                               |
| [`c1c122de`](https://github.com/NixOS/nixpkgs/commit/c1c122def24ef8a10776d9a6bf44ff28e3344804) | `ddosify: 0.7.5 -> 0.7.6`                                                    |
| [`96695335`](https://github.com/NixOS/nixpkgs/commit/966953354cd9c59f72e1b1748eb8d74c47815b5a) | `nixos/ethminer: fix option types for maxPower, recheckInterval`             |
| [`5e38d36a`](https://github.com/NixOS/nixpkgs/commit/5e38d36a6b3a21d36b1ef0f81d9b4e2674a25ea1) | `nixos/ethminer: only pull in cudatoolkit when needed`                       |
| [`bee11786`](https://github.com/NixOS/nixpkgs/commit/bee11786f699784403452e66f99a91351ba0e87c) | `coqPackages.relation-algebra: 1.7.6, 1.7.7`                                 |
| [`ff32bb3c`](https://github.com/NixOS/nixpkgs/commit/ff32bb3cf2f084a170adfd504c8b44d187be27e0) | `coqPackages.aac-tactics: 8.13.2, 8.14.1, 8.15.1`                            |
| [`edc6a9ec`](https://github.com/NixOS/nixpkgs/commit/edc6a9ecdabd231416c669e7dd47a1a8afb790c8) | `docker-compose_2: 2.3.4 -> 2.4.0`                                           |
| [`e6747852`](https://github.com/NixOS/nixpkgs/commit/e67478523677eea6c004992c7a0ae1cadcccacb6) | `python310Packages.pysigma: 0.4.4 -> 0.4.5`                                  |
| [`7e2ecc94`](https://github.com/NixOS/nixpkgs/commit/7e2ecc948e970ed55db0532371c3730a777be8bd) | `chezmoi: 2.14.0 -> 2.15.0`                                                  |
| [`03213c62`](https://github.com/NixOS/nixpkgs/commit/03213c6216ee05925f0bf757f97d34ac6abbcefe) | `python3Packages.amazon-ion: disable on older Python releases`               |
| [`1c073f24`](https://github.com/NixOS/nixpkgs/commit/1c073f2494736752d01bcf9ced08eae6458949c0) | `python310Packages.dotmap: 1.3.27 -> 1.3.28`                                 |
| [`be8f812f`](https://github.com/NixOS/nixpkgs/commit/be8f812fcaf2d4360cd906879d66e5f2e1063e62) | `ethercalc: migrate from nodejs-12_x to nodejs-14_x`                         |
| [`91e578b4`](https://github.com/NixOS/nixpkgs/commit/91e578b4d95d7c2884524fbbec69c393abe15646) | `dbeaver: 22.0.1 -> 22.0.2`                                                  |
| [`ea4a8734`](https://github.com/NixOS/nixpkgs/commit/ea4a873438d811cb5509b22392225a2e3b9358ad) | `python310Packages.goodwe: 0.2.16 -> 0.2.17`                                 |
| [`93dd7a21`](https://github.com/NixOS/nixpkgs/commit/93dd7a21ae174695b6d55cbbdc0d9fb063eb8787) | `mosh: support cross compile`                                                |
| [`226f12b5`](https://github.com/NixOS/nixpkgs/commit/226f12b555d2bfcddf2d6b01229ed9eae39c9050) | `bctoolbox: 5.1.12 -> 5.1.17`                                                |
| [`80fd713f`](https://github.com/NixOS/nixpkgs/commit/80fd713fe6d7bb9f0247e1f967046ce6889c18dd) | `python310Packages.frozendict: 2.3.0 -> 2.3.1`                               |
| [`3f4a9735`](https://github.com/NixOS/nixpkgs/commit/3f4a9735c9b9cca22cb318c829274aa1561d6e6d) | `python310Packages.env-canada: 0.5.21 -> 0.5.22`                             |
| [`a7351457`](https://github.com/NixOS/nixpkgs/commit/a73514572f5abb58919b04d133aea0fb3451920e) | `flexget: 3.3.6 -> 3.3.8`                                                    |
| [`dcd59e93`](https://github.com/NixOS/nixpkgs/commit/dcd59e93a56a76cc0be671ca84343d1bd06fb4b4) | `vale: 2.15.4 -> 2.15.5`                                                     |
| [`327076a5`](https://github.com/NixOS/nixpkgs/commit/327076a54b73da302bad56ec54bd91cb77ded48a) | `python310Packages.amazon-ion: 0.8.0 -> 0.9.1`                               |
| [`ed5fca78`](https://github.com/NixOS/nixpkgs/commit/ed5fca782abe15c82dbab988f59ee3646a64acc1) | `python310Packages.aioairzone: 0.3.1 -> 0.3.2`                               |
| [`eefbb7c5`](https://github.com/NixOS/nixpkgs/commit/eefbb7c5661a895900df2f1ff9ab4c9f1e11b964) | `poke: 2.2 -> 2.3`                                                           |
| [`bf445c21`](https://github.com/NixOS/nixpkgs/commit/bf445c21ac4e455e34f11edefd8cf3979a6b5b74) | `python310Packages.cloudflare: 2.9.8 -> 2.9.9`                               |
| [`59729543`](https://github.com/NixOS/nixpkgs/commit/59729543d0349f31cf414113435ffd2c593a828e) | `mycli: 1.24.4 -> 1.25.0`                                                    |
| [`d6ddf68c`](https://github.com/NixOS/nixpkgs/commit/d6ddf68c114bcfff0d365fdc54c0a3bdfa339f8a) | `pylnk3: init at 0.4.2`                                                      |
| [`a59178d2`](https://github.com/NixOS/nixpkgs/commit/a59178d2ebff4f0c800eaca48f238d268a89f30c) | `gthumb: 3.12.1 -> 3.12.2`                                                   |
| [`6ae3cfc4`](https://github.com/NixOS/nixpkgs/commit/6ae3cfc430bb416ca59cbff435aeddc2d63289f9) | `ibus: switch from cldr-emoji-annotation to cldr-annotations`                |
| [`03e46048`](https://github.com/NixOS/nixpkgs/commit/03e460480e90fca799880616e42a7ace86c729a4) | `python3Packages.pikepdf: disable on older Python releases`                  |
| [`36a2f67a`](https://github.com/NixOS/nixpkgs/commit/36a2f67a648df7aeedc1f04dc4401b79d493a32d) | `cldr-annotations: init at 40.0`                                             |
| [`84f98081`](https://github.com/NixOS/nixpkgs/commit/84f98081dc5ec0992757cb5099b4c537a08a938b) | `ocrfeeder: Mark as broken due to upstream issue`                            |
| [`43a87e10`](https://github.com/NixOS/nixpkgs/commit/43a87e10f5bf9a5b13939b2b62406ed2ceedcf43) | `bottles: 2022.3.14-trento-3 -> 2022.3.28-trento-1`                          |
| [`2a5b81d5`](https://github.com/NixOS/nixpkgs/commit/2a5b81d50f1c448acbc8e01a42a6f4d4ed9ec6ce) | `bada-bib: 0.6.0 -> 0.6.1`                                                   |
| [`bf39f5b9`](https://github.com/NixOS/nixpkgs/commit/bf39f5b9dca46ae71a8d457096b72d7258833f71) | `b43Firmware: support cross compile`                                         |
| [`6f8e808b`](https://github.com/NixOS/nixpkgs/commit/6f8e808b8a9b7d3d8ebf361b36b94a28a8751878) | `claws-mail: 4.0.0 -> 4.1.0`                                                 |
| [`f81b05ab`](https://github.com/NixOS/nixpkgs/commit/f81b05ab46afd7b0b8907f4b990345760ee24bd7) | `prometheus-backbox-exporter: correctly expose version info`                 |
| [`17c1d3e0`](https://github.com/NixOS/nixpkgs/commit/17c1d3e0b2f0ba578b8a6a16cc9ea0d2ee631025) | `python3Packages.pikepdf: 5.0.1 -> 5.1.1`                                    |
| [`acae74c7`](https://github.com/NixOS/nixpkgs/commit/acae74c7aea0da60be49f4be6f9e7e895ffc1476) | `python3Packages.google-re2: add pythonImportsCheck`                         |
| [`664aae26`](https://github.com/NixOS/nixpkgs/commit/664aae266284bd80a5fb929b08c6878fdd066120) | `wlclock: init at 1.0.1`                                                     |
| [`19315d0d`](https://github.com/NixOS/nixpkgs/commit/19315d0dde6ba1b2f941106e22237f14f1a57c59) | `syft: 0.42.4 -> 0.43.0`                                                     |
| [`200175a7`](https://github.com/NixOS/nixpkgs/commit/200175a7011c0602c0a8e6d4c6583d9d577a03d1) | `config.allowAliases: Define as option`                                      |
| [`60df4bd6`](https://github.com/NixOS/nixpkgs/commit/60df4bd6ec25671ec68ad7189db65eeb3a4a6787) | `python310Packages.google-re2: 0.2.20220201 -> 0.2.20220401`                 |
| [`2f7dda44`](https://github.com/NixOS/nixpkgs/commit/2f7dda4450092f9f3019d131784c4c098f30d6a8) | `ocrfeeder: 0.8.3 -> 0.8.5`                                                  |
| [`14960141`](https://github.com/NixOS/nixpkgs/commit/14960141d2accd8f6f07468fe7cb9ed97424bdf4) | `babeld: 1.10 -> 1.11`                                                       |
| [`2b7d401e`](https://github.com/NixOS/nixpkgs/commit/2b7d401ee6117182a4b0811d6301547fed12f73b) | `chromiumDev: 101.0.4951.15 -> 102.0.4972.0`                                 |
| [`5d652d05`](https://github.com/NixOS/nixpkgs/commit/5d652d056ca31ef5623de9aa80a827eec293c539) | `ograc: init at 0.1.6`                                                       |
| [`35b456de`](https://github.com/NixOS/nixpkgs/commit/35b456de97e683175460946bd9c72dc3510c5f06) | `mattermost: 6.3.3 -> 6.3.6`                                                 |
| [`1f78ade8`](https://github.com/NixOS/nixpkgs/commit/1f78ade8858f21a517d22df31e045856eee03e31) | `kde/plasma5: 5.24.3 -> 5.24.4`                                              |
| [`266737e7`](https://github.com/NixOS/nixpkgs/commit/266737e76e3e25f94ff0569537cb096999d222c2) | `flexget: 3.3.4 -> 3.3.6`                                                    |
| [`c1706880`](https://github.com/NixOS/nixpkgs/commit/c1706880ea2afc092b77c29794619237dadf4622) | `ferdi: 5.8.0 -> 5.8.1`                                                      |
| [`4c159638`](https://github.com/NixOS/nixpkgs/commit/4c1596384cc18e79e3672eb163e05485a78d521e) | `pgadimin4: 6.5 -> 6.7`                                                      |
| [`d3dc9359`](https://github.com/NixOS/nixpkgs/commit/d3dc935902781fb6eef9964a6b3ac5b3fbc816a7) | `vale: 2.15.3 -> 2.15.4`                                                     |
| [`f6d9cedb`](https://github.com/NixOS/nixpkgs/commit/f6d9cedbb88ddef62650b0551b69a561fa3de1a0) | `tachyon: 0.99.3 -> 0.99.4`                                                  |
| [`63c705fd`](https://github.com/NixOS/nixpkgs/commit/63c705fda998ea99607d8aaa8553c1b4174d5f7d) | `unicode-emoji: 12.1 -> 14.0`                                                |
| [`4f859973`](https://github.com/NixOS/nixpkgs/commit/4f85997362d9f97fe5282d18956e07cafa44b82c) | `certigo: 1.15.0 -> 1.15.1`                                                  |
| [`f50e41bf`](https://github.com/NixOS/nixpkgs/commit/f50e41bfd60a7c705086354e020807d0295c3526) | `rPackages: nloptr requires libiconv`                                        |
| [`78a439e5`](https://github.com/NixOS/nixpkgs/commit/78a439e5143ddf9e1cb0e485ea05e74f61635b40) | `rPackages: Disable stackprotector on aarch64-darwin`                        |
| [`6af3e616`](https://github.com/NixOS/nixpkgs/commit/6af3e61632c651db2dc1fe55ae48460006eda0ad) | `nixos/qemu-vm: allow booting VM with the custom kernel`                     |
| [`ecc5b854`](https://github.com/NixOS/nixpkgs/commit/ecc5b8546465ef955bbd9bf3da734fcc690da1d1) | `postgresql11Packages.pgroonga: 2.3.5 -> 2.3.6`                              |
| [`acef747b`](https://github.com/NixOS/nixpkgs/commit/acef747bd2a2b218adaf309d1a99cb022164dcc2) | `gogs: 0.12.5 -> 0.12.6`                                                     |
| [`ae5d0223`](https://github.com/NixOS/nixpkgs/commit/ae5d022389517d39664b617cb249077ee108784d) | `thanos: 0.24.0 -> 0.25.1`                                                   |
| [`013afb52`](https://github.com/NixOS/nixpkgs/commit/013afb52c7865aa5169ecc466a5c80c1ef11f3a8) | `praat: 6.2.09 -> 6.2.10`                                                    |
| [`6d84e807`](https://github.com/NixOS/nixpkgs/commit/6d84e807412c9c223657053af69fd6a2d608f9b9) | `gemConfig update for exiv and maxmind`                                      |
| [`edd46c86`](https://github.com/NixOS/nixpkgs/commit/edd46c86115dd4ef94ba8b1984cb0b27e251de86) | `whitebophir: 1.16.0 -> 1.17.0`                                              |
| [`f676d119`](https://github.com/NixOS/nixpkgs/commit/f676d1192e3516a6612564b833c97b15c6c4b307) | `whitebophir: pin to nodejs-14_x to unbreak the build`                       |