### PR TITLE
chore(flake/home-manager): `0382c5f7` -> `399a3dfe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1649084009,
-        "narHash": "sha256-jfU0rYnMbL8jMNH+o+BYGxsb7d+HrtbFYtG5/kbQDLc=",
+        "lastModified": 1649130015,
+        "narHash": "sha256-3il2e7gxuMm/EsplFuxajW4DSNr1QVDW2iW0PdbtLH8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0382c5f75e9b4ffb0cdc75535c3e249019710a02",
+        "rev": "399a3dfeafa7328f40b99759d94d908185ce72a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`399a3dfe`](https://github.com/nix-community/home-manager/commit/399a3dfeafa7328f40b99759d94d908185ce72a6) | `gpg: create homedir with 700 permissions (#2823)`                   |
| [`a985e711`](https://github.com/nix-community/home-manager/commit/a985e711e88e3aab82c54df39bc4666f98f54937) | `screen-locker: Add option to configure x screensaver cycle (#2853)` |
| [`3549f5d0`](https://github.com/nix-community/home-manager/commit/3549f5d0f5aff2aea3d4d2e99f83776a218ab55a) | `xdg-user-dirs: allow paths and define sessionVariables (#2757)`     |