### PR TITLE
chore(flake/nixpkgs): `4dddff09` -> `a6498737`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1649122591,
-        "narHash": "sha256-g0Wmjgkkxuzpk9vXnhmqPBd5sBF+50crdmHEPz3zH9M=",
+        "lastModified": 1649270075,
+        "narHash": "sha256-m4QzKyk2xtJNKK07MWQK0b0fafj0/4fPlFa4F/YPehw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4dddff0976bc8d3ef077d81bc44f00796b49e395",
+        "rev": "a64987375ffc8e9cc093150596c9bee215e4d6f4",
         "type": "github"
       },
       "original": {

--- a/hosts/foucault/default.nix
+++ b/hosts/foucault/default.nix
@@ -6,7 +6,6 @@
     ../../dev/virt-manager.nix
 
     ../../hardware/nixos-aarch64-builder
-    ../../hardware/printer.nix
     ../../hardware/thinkpad-p1.nix
     ../../hardware/yubikey.nix
 


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                          |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`540878be`](https://github.com/NixOS/nixpkgs/commit/540878bed60e08d2a4a7b6d947c7b606154e5f53) | `kubectx: enable tests`                                                                 |
| [`db007909`](https://github.com/NixOS/nixpkgs/commit/db0079094889d6404928a764c58ca04f340ba4c0) | `iamy: enable tests`                                                                    |
| [`63f47cdc`](https://github.com/NixOS/nixpkgs/commit/63f47cdc7456035cc2c8d4c154afb76cd8798fc2) | `saml2aws: enable tests`                                                                |
| [`1234b384`](https://github.com/NixOS/nixpkgs/commit/1234b384381e30522075157d839a4222d76cf5a2) | `ctop: enable tests`                                                                    |
| [`59d06e48`](https://github.com/NixOS/nixpkgs/commit/59d06e482608eeaf1eda9281be22bfdaa72a47bc) | `wireshark-cli: support cross compile`                                                  |
| [`7eb1a323`](https://github.com/NixOS/nixpkgs/commit/7eb1a32324f039230261195ee8f913bfb4617f91) | `subversion-client: remove appendToName to have a consistent package name for repology` |
| [`041060b4`](https://github.com/NixOS/nixpkgs/commit/041060b41517ae4823ad7f0268f662aeb7279f5f) | `goreman: enable tests (#167538)`                                                       |
| [`2b6e571f`](https://github.com/NixOS/nixpkgs/commit/2b6e571f8f6e7414486a8730f32708773cbaa2d7) | `python310Packages.azure-identity: 1.8.0 -> 1.9.0`                                      |
| [`caa91541`](https://github.com/NixOS/nixpkgs/commit/caa91541bc483f009693fbaf0497f13fcd85f2f7) | `go_1_18: don't force gcc8 on aarch64-linux`                                            |
| [`c28846f1`](https://github.com/NixOS/nixpkgs/commit/c28846f1ec1628fff05f16580b2f3097e68010cd) | `python310Packages.types-cryptography: 3.3.18 -> 3.3.19`                                |
| [`3f68060f`](https://github.com/NixOS/nixpkgs/commit/3f68060ff03f8b41a0d475a3c56444ef733c239c) | `Update pkgs/shells/nushell/default.nix`                                                |
| [`54a21b8d`](https://github.com/NixOS/nixpkgs/commit/54a21b8dc568b1c58c20cbb79c8a9690dac7a0cc) | `nushell: 0.44.0 -> 0.60.0`                                                             |
| [`0a160772`](https://github.com/NixOS/nixpkgs/commit/0a1607729bbbf94b8221667c759c7da2503e7e29) | `proton-caller: 2.3.2 -> 3.1.0`                                                         |
| [`0d79899a`](https://github.com/NixOS/nixpkgs/commit/0d79899aaa6c1f836574f38d30c482aa04d7eec0) | `python310Packages.srp: disable on older Python releases`                               |
| [`55fd7039`](https://github.com/NixOS/nixpkgs/commit/55fd703986aac4ceaf567afd2b97183c1c91d4fe) | `cosign: 1.6.0 -> 1.7.1`                                                                |
| [`4b0a37b8`](https://github.com/NixOS/nixpkgs/commit/4b0a37b89f847d2affed3e678c753f4e60979595) | `argocd-autopilot: 0.3.0 -> 0.3.1`                                                      |
| [`6c21273e`](https://github.com/NixOS/nixpkgs/commit/6c21273e1ecea72de026fc4b4839678aa0eb4bca) | `argocd: 2.3.2 -> 2.3.3`                                                                |
| [`955cb034`](https://github.com/NixOS/nixpkgs/commit/955cb0340858480612efd3f23e86e5db551bd62c) | `python310Packages.tweepy: 4.6.0 -> 4.8.0`                                              |
| [`f0b94551`](https://github.com/NixOS/nixpkgs/commit/f0b94551bc083b97559357b17cd49b0a151c8a18) | `python3Package.mergedb: add setuptools`                                                |
| [`dcfbb20d`](https://github.com/NixOS/nixpkgs/commit/dcfbb20d257794217d67990da32f22d77823f34c) | `python3Packages.hg-git: disable on older Python releases`                              |
| [`16e14a8a`](https://github.com/NixOS/nixpkgs/commit/16e14a8acb6f9ea4fabdeb0fa9b1c7cda3adf5c0) | `python3Package.mergedb: add some blank lines`                                          |
| [`10ee8df2`](https://github.com/NixOS/nixpkgs/commit/10ee8df24baeac9b2aeb6b7ab58a946933b6bb24) | `  python3Packages.oslo-log: disable on older Python releases`                          |
| [`6b81f25a`](https://github.com/NixOS/nixpkgs/commit/6b81f25aeab10c56dd1e72754eee7dd789912689) | `python310Packages.python-kasa: 0.4.2 -> 0.4.3`                                         |
| [`d44c411e`](https://github.com/NixOS/nixpkgs/commit/d44c411ed27bddf129774d9d17247179b61ec049) | `python310Packages.pysimplegui: 4.57.0 -> 4.59.0`                                       |
| [`f7eb323b`](https://github.com/NixOS/nixpkgs/commit/f7eb323b86d79e315936ec31cd5cbfbf98388cc1) | `python310Packages.hatchling: 0.20.1 -> 0.22.0`                                         |
| [`bc765081`](https://github.com/NixOS/nixpkgs/commit/bc7650810c38ebdb372948d38f860582be358784) | `python310Packages.pyhaversion: 22.02.0 -> 22.04.0`                                     |
| [`90c4e577`](https://github.com/NixOS/nixpkgs/commit/90c4e577206219a05631a35d36070a206b44548b) | `python310Packages.pyisy: 3.0.5 -> 3.0.6`                                               |
| [`3ccdd3ed`](https://github.com/NixOS/nixpkgs/commit/3ccdd3ed3dcc23d63e64e23d0b1fc12e6d575fdc) | `python310Packages.twilio: 7.7.0 -> 7.8.0`                                              |
| [`d240ca09`](https://github.com/NixOS/nixpkgs/commit/d240ca09aa43b3650da8b5b5ebc77053e7ecbaf6) | `ocamlPackages.torch: Mark as broken with pytorch >= 1.11`                              |
| [`ed1bc6d3`](https://github.com/NixOS/nixpkgs/commit/ed1bc6d3699f825efd5c2aa319f3b00c6667c0df) | `ocamlPackages.asn1-combinators: disable with OCaml < 4.08`                             |
| [`9bf28042`](https://github.com/NixOS/nixpkgs/commit/9bf28042f513bc7b54b7b4af5debaaf9a887478a) | `ocamlPackages.sqlite3EZ: remove at 0.1.0`                                              |
| [`5339c6f0`](https://github.com/NixOS/nixpkgs/commit/5339c6f0aa2893a85a645cc1bf11e6e8bc3964c2) | `python310Packages.pex: 2.1.76 -> 2.1.77`                                               |
| [`747d2ec3`](https://github.com/NixOS/nixpkgs/commit/747d2ec39cbef1a4eac81e517f0b1d7cdef0692c) | `audacity: mark darwin as broken`                                                       |
| [`7c15e524`](https://github.com/NixOS/nixpkgs/commit/7c15e52492233d6aa63302e6f2dda8ba1d1b2e0c) | `python310Packages.oslo-log: 4.6.1 -> 4.7.0`                                            |
| [`db14ca11`](https://github.com/NixOS/nixpkgs/commit/db14ca11223f01469845bc4ff81401ec30e958c7) | `python310Packages.pynetgear: 0.9.3 -> 0.9.4`                                           |
| [`51206ddf`](https://github.com/NixOS/nixpkgs/commit/51206ddf64b8ca582c1ab4c391eb4a48b120bd6d) | `python310Packages.nats-py: 2.0.0 -> 2.1.0`                                             |
| [`029dafa9`](https://github.com/NixOS/nixpkgs/commit/029dafa9f97d045f294a3b9abc47de217f8cdd35) | `python310Packages.teslajsonpy: 1.9.0 -> 2.0.1`                                         |
| [`d4a1fcc4`](https://github.com/NixOS/nixpkgs/commit/d4a1fcc4e8bc047c55740f8d344d80c7dbd81d18) | `python310Packages.pyscss: 1.3.7 -> 1.4.0`                                              |
| [`ec071ba0`](https://github.com/NixOS/nixpkgs/commit/ec071ba08de97e4fa0d4895b12d5efd98415cdfc) | `python310Packages.pyplaato: 0.0.15 -> 0.0.16`                                          |
| [`46de35bf`](https://github.com/NixOS/nixpkgs/commit/46de35bff05e2e4412ce5a220cc8e624d1417026) | `python310Packages.karton-core: 4.3.0 -> 4.4.0`                                         |
| [`3389b48e`](https://github.com/NixOS/nixpkgs/commit/3389b48e99f49ee42e16608b56c3aa1ca9e68001) | `python310Packages.jupytext: 1.13.7 -> 1.13.8`                                          |
| [`e15ae73b`](https://github.com/NixOS/nixpkgs/commit/e15ae73b7abc81133624644953fbfda9b5382065) | `libsecret: fix build on darwin`                                                        |
| [`81ad142b`](https://github.com/NixOS/nixpkgs/commit/81ad142b8306891ccb738cda896824409847f0d9) | `python310Packages.hg-git: 0.10.4 -> 1.0.0`                                             |
| [`22f857bf`](https://github.com/NixOS/nixpkgs/commit/22f857bf484921f02a8bad0eb0ade7169b32e663) | `nix-bisect: apply patch to fix nix compat`                                             |
| [`e29253ad`](https://github.com/NixOS/nixpkgs/commit/e29253ad9b847873fa8c5d736a45951d67623eef) | `gnome.eog: Hardcode library path in gir`                                               |
| [`ec5a6c8a`](https://github.com/NixOS/nixpkgs/commit/ec5a6c8ae5692f51e811a27e4cce5b2082b7156a) | `nextdns: 1.37.10 -> 1.37.11`                                                           |
| [`d3424f16`](https://github.com/NixOS/nixpkgs/commit/d3424f16f231cb408058b8b993d58f9e3b6e13d8) | `deltachat-desktop: 1.28.0 -> 1.28.1`                                                   |
| [`1bd060ba`](https://github.com/NixOS/nixpkgs/commit/1bd060ba6791e13b209c258aae9be08836aa308a) | `awsebcli: fixup`                                                                       |
| [`fbad896c`](https://github.com/NixOS/nixpkgs/commit/fbad896c730d4fd15cd6911d5e5eb76b64a36b6b) | `python310Packages.google-cloud-bigtable: 2.7.1 -> 2.8.0`                               |
| [`daa0d0d2`](https://github.com/NixOS/nixpkgs/commit/daa0d0d2650a20d992bf35b9e2ed1933bacac95a) | `gnomeExtensions.system-monitor: Use upstream Makefile to fix version`                  |
| [`d93cf53f`](https://github.com/NixOS/nixpkgs/commit/d93cf53f6587b2998bff2b2a38e1f650cac60bf2) | `firefox-bin: 98.0.2 -> 99.0`                                                           |
| [`35ae0b7a`](https://github.com/NixOS/nixpkgs/commit/35ae0b7a1baff5e3fda4f6e050448df2acc8b217) | `firefox: 91.7.1 -> 91.8.0`                                                             |
| [`e1e03e5b`](https://github.com/NixOS/nixpkgs/commit/e1e03e5bc2db16baabcaa3669d7577647cb02959) | `firefox: 98.0.2 -> 99.0`                                                               |
| [`d8710ac5`](https://github.com/NixOS/nixpkgs/commit/d8710ac534fdb541314534c5ea68e1ddaad8573f) | `indradb: fix build`                                                                    |
| [`557f7572`](https://github.com/NixOS/nixpkgs/commit/557f7572d8db3fb5ddddf5099c81725fb779edb7) | `rustfmt: stop pretending we're on nightly`                                             |
| [`b75018a7`](https://github.com/NixOS/nixpkgs/commit/b75018a78939f48250e7286bcf93820e93cfa713) | `bugdom: Enable on Darwin`                                                              |
| [`7acbb839`](https://github.com/NixOS/nixpkgs/commit/7acbb8398eaa980cb7d8a1d82e402245f5732e29) | `audacity: 3.0.2 -> 3.1.3`                                                              |
| [`9931d6bb`](https://github.com/NixOS/nixpkgs/commit/9931d6bbbf99ad1fc13303bbc548b7a415770a47) | `python3.aplpy: 2.0.3 -> 2.1.0`                                                         |
| [`be4566c5`](https://github.com/NixOS/nixpkgs/commit/be4566c532d740bdd7ee3a4fb259c4f5b1370d1b) | `nextdns: enable tests`                                                                 |
| [`204d20c9`](https://github.com/NixOS/nixpkgs/commit/204d20c9ef9a9a9a1a356021567ac1e026b3fa7f) | `Adding graysonhead to maintainers`                                                     |
| [`c19e64e4`](https://github.com/NixOS/nixpkgs/commit/c19e64e43a6f953afaa3e153805cc6c53feaf065) | `python3Package.mergedb: init at 0.1.1`                                                 |
| [`4097e922`](https://github.com/NixOS/nixpkgs/commit/4097e922f6e877fccb1fd96a54ad09d0d9bf26ed) | `pytrainer: 2.0.2 -> 2.1.0`                                                             |
| [`6ff5ad20`](https://github.com/NixOS/nixpkgs/commit/6ff5ad209748a93072e8ff6e3440d5846b1d7490) | `nethogs: 0.8.6 -> 0.8.7`                                                               |
| [`c235949c`](https://github.com/NixOS/nixpkgs/commit/c235949ce89731ac670dcdbea297717aa1e60209) | `svtplay-dl: 4.10 -> 4.11`                                                              |
| [`9e2d17a2`](https://github.com/NixOS/nixpkgs/commit/9e2d17a29d041e20f0f79f2443c016ad58389cdc) | `istioctl: enable tests`                                                                |
| [`9c0c4fcf`](https://github.com/NixOS/nixpkgs/commit/9c0c4fcf01fec234620ddc6c43162bf488d0b672) | `gobuster: enable tests`                                                                |
| [`3ebf3359`](https://github.com/NixOS/nixpkgs/commit/3ebf33593c719a86c7ce4d996b012b0dc57e9aad) | `yq-go: enable tests`                                                                   |
| [`aa453311`](https://github.com/NixOS/nixpkgs/commit/aa45331156956d2ea9e8c2c2e5bdfd590a4c418c) | `kubeseal: enable tests`                                                                |
| [`bf2d815f`](https://github.com/NixOS/nixpkgs/commit/bf2d815f5f96075ee468f83b35a316ae8bb895d9) | `python3Packages.lektor: disable on older Python releases`                              |
| [`e3eef795`](https://github.com/NixOS/nixpkgs/commit/e3eef795d86ff6ca9d6285d9055f601a2f534d9e) | `arkade: 0.8.19 -> 0.8.20`                                                              |
| [`2d58e98f`](https://github.com/NixOS/nixpkgs/commit/2d58e98feb1e263bac4ae2e1bf4f969465ab309a) | `docui: enable tests`                                                                   |
| [`84032b1f`](https://github.com/NixOS/nixpkgs/commit/84032b1febdf0131ba2ebb3f473ca497103f01d3) | `traefik: enable tests`                                                                 |
| [`083ebe13`](https://github.com/NixOS/nixpkgs/commit/083ebe133bb434d2319fb5a0f89347c7ba806d64) | `python3Packages.rdflib: update dependencies`                                           |
| [`d60926bf`](https://github.com/NixOS/nixpkgs/commit/d60926bff10a77b13105017bd4c316b174901e16) | `echoip: enable tests`                                                                  |
| [`6532f90a`](https://github.com/NixOS/nixpkgs/commit/6532f90a8f873228a05b1a93ed67383d24c09855) | `imgproxy: enable tests`                                                                |
| [`bcf7e934`](https://github.com/NixOS/nixpkgs/commit/bcf7e9346dd060cb1ef800435b22c4865039ff0c) | `python310Packages.lektor: 3.3.2 -> 3.3.3`                                              |
| [`e52016f9`](https://github.com/NixOS/nixpkgs/commit/e52016f9b62aa98df7606b1e23a838a12fb142a0) | `python3Packages.teletype: disable on older Python releases`                            |
| [`c61e5f06`](https://github.com/NixOS/nixpkgs/commit/c61e5f06472fb035bbe97c4343edf7b04ed0bb29) | `python310Packages.teletype: 1.3.2 -> 1.3.4`                                            |
| [`f0969c2b`](https://github.com/NixOS/nixpkgs/commit/f0969c2be9341b2acf59c86f5a22f7812507f231) | `python3Packages.google-cloud-secret-manager: disable on older Python releases`         |
| [`f8002a66`](https://github.com/NixOS/nixpkgs/commit/f8002a6687c52288f1f0796a5c757d5ab515afa0) | `nixos/qtile: expose package option`                                                    |
| [`9687fffa`](https://github.com/NixOS/nixpkgs/commit/9687fffa009db7b1732547456e0a1de1bae6996d) | `chromium: 100.0.4896.60 -> 100.0.4896.75`                                              |
| [`812352fa`](https://github.com/NixOS/nixpkgs/commit/812352faf7eac19b97acfbf2b43e059161582acc) | `ledger-live-desktop: 2.39.2 -> 2.40.2`                                                 |
| [`5beb251a`](https://github.com/NixOS/nixpkgs/commit/5beb251a7d6a45c3ecfa56e38cd7cc3873187311) | `python39Packages.bc-python-hcl2: 0.3.33 -> 0.3.37`                                     |
| [`ccaec92c`](https://github.com/NixOS/nixpkgs/commit/ccaec92c2768203b74fa70521f854b3f0849ae3b) | `python310Packages.dunamai: 1.10.0 -> 1.11.1`                                           |
| [`0e141f03`](https://github.com/NixOS/nixpkgs/commit/0e141f0382685c8ec32a28b84f6edd274ebd0ae9) | `nixos tests atop: don't allow unfree packages`                                         |
| [`f1aa084b`](https://github.com/NixOS/nixpkgs/commit/f1aa084baa724e97e8aa24b28f6d000952a31340) | `python310Packages.dotmap: 1.3.28 -> 1.3.29`                                            |
| [`c2828e84`](https://github.com/NixOS/nixpkgs/commit/c2828e8479f84baaf176d0986164231e408d6e1a) | `nixos/qtile: expose unwrapped package to systemPackages`                               |
| [`fffabe75`](https://github.com/NixOS/nixpkgs/commit/fffabe7500e972eb5275199c82a35132a07fa29f) | `lib.sanitizeDerivationName: Simplify regex`                                            |
| [`bfc562ab`](https://github.com/NixOS/nixpkgs/commit/bfc562ab9ae6f741172abf37bb27639dc9a79337) | `argononed: init at unstable-2022-03-26`                                                |
| [`6427998d`](https://github.com/NixOS/nixpkgs/commit/6427998d85dffc8d3cd724f358ed4af8e4961398) | `nixosTests.installer.*: provide a missing dependency`                                  |
| [`12c54cfa`](https://github.com/NixOS/nixpkgs/commit/12c54cfaf09e07cd5354deca9c992a90dfef1db8) | `apfs: unstable-2021-09-21 -> unstable-2022-02-03`                                      |
| [`53058f36`](https://github.com/NixOS/nixpkgs/commit/53058f36381b6dc02c886624adf8f9eedb97ece4) | `plantuml: 1.2022.2 -> 1.2022.3`                                                        |
| [`25de2935`](https://github.com/NixOS/nixpkgs/commit/25de2935efce46fe51ac0e169fe13709166c788f) | `lib/modules: Document _module.args`                                                    |
| [`972a7a30`](https://github.com/NixOS/nixpkgs/commit/972a7a30fe5218b496bfe8da9df738f6f3733406) | `python310Packages.afsapi: 0.2.2 -> 0.2.3`                                              |
| [`0a69aa9f`](https://github.com/NixOS/nixpkgs/commit/0a69aa9f8ada8d537dcb40bf63920208b1bd2cf0) | `vimPlugins: update`                                                                    |
| [`ac60e92b`](https://github.com/NixOS/nixpkgs/commit/ac60e92b15adfcb14d65dcfb2265f24bb69e22c0) | `busybox: fix CVE-2022-28391`                                                           |
| [`3aeaa275`](https://github.com/NixOS/nixpkgs/commit/3aeaa2755d947ab30f0321f58485ecb58ec9440b) | `mercurial: 6.1 -> 6.1.1`                                                               |
| [`1d26e398`](https://github.com/NixOS/nixpkgs/commit/1d26e3984dafde64a453a1519175fa48b591bf2d) | `kustomize: 4.5.3 -> 4.5.4`                                                             |
| [`74176d27`](https://github.com/NixOS/nixpkgs/commit/74176d27e36cd99e766b96749540ef6c2871627e) | `prisma-engines: 3.11.0 -> 3.12.0`                                                      |
| [`01bc3d29`](https://github.com/NixOS/nixpkgs/commit/01bc3d29b5db49b48fe760f5427ec02ea5790319) | `nodePackages.prisma: 3.11.0 -> 3.12.0`                                                 |
| [`68ee8e4b`](https://github.com/NixOS/nixpkgs/commit/68ee8e4b77c853220cec3b90ba6d2780278c8867) | `oh-my-zsh: 2022-03-31 -> 2022-04-04 (#167357)`                                         |
| [`29c80c30`](https://github.com/NixOS/nixpkgs/commit/29c80c305815a30c504c773cb674f8dcb4f285ea) | `berry: 0.1.10 -> 0.1.11`                                                               |
| [`7041bb5e`](https://github.com/NixOS/nixpkgs/commit/7041bb5e98c0c36a9b47b7f4860fd560d153317b) | `buildkite-agent: 3.35.0 -> 3.35.1 (#167355)`                                           |
| [`7a935cc6`](https://github.com/NixOS/nixpkgs/commit/7a935cc6d00c94f4a6cd1778f39d3a679a828205) | `Add aliases for removed packages`                                                      |
| [`3212b0aa`](https://github.com/NixOS/nixpkgs/commit/3212b0aad230cf526c7f4ce6042d0d162d66cebf) | `kubeless: remove`                                                                      |
| [`9e98fe29`](https://github.com/NixOS/nixpkgs/commit/9e98fe299f7e025223810c5a6da0365738391f38) | `kube-aws: remove`                                                                      |
| [`6fdd912b`](https://github.com/NixOS/nixpkgs/commit/6fdd912bd63f676657c696a12ca9a344961b676c) | `container-linux-config-transpiler: remove`                                             |
| [`426ec897`](https://github.com/NixOS/nixpkgs/commit/426ec8974ec225efc81676cee00e213aa2fef5f0) | `mpi: 4.1.2 -> 4.1.3`                                                                   |
| [`59a65713`](https://github.com/NixOS/nixpkgs/commit/59a657131c7a1686658d460c20feeda8ca29f5cb) | `python310Packages.graphql-subscription-manager: 0.5.5 -> 0.5.6`                        |
| [`c5660f8f`](https://github.com/NixOS/nixpkgs/commit/c5660f8f51ef2e046f1af9093567221584525c95) | `vaultwarden-vault: 2.25.0 -> 2.27.0`                                                   |
| [`24a7a492`](https://github.com/NixOS/nixpkgs/commit/24a7a4920609a55a27bf95ec62cfdb71fe75bf4e) | `buildpack: 0.24.0 -> 0.24.1`                                                           |
| [`0e694518`](https://github.com/NixOS/nixpkgs/commit/0e6945185b65ed6a163501d66420f8a16e49e4c3) | `nodejs-12_x: 12.22.11 -> 12.22.12`                                                     |
| [`923fad86`](https://github.com/NixOS/nixpkgs/commit/923fad863ca592af9170ae89abc8326119a9e790) | `z3: Remove unused fetchpatch`                                                          |
| [`894d1602`](https://github.com/NixOS/nixpkgs/commit/894d1602bbe1f0eb26be5843403a1f6b5337faca) | `python310Packages.chiavdf: 1.0.5 -> 1.0.6`                                             |
| [`db57a90d`](https://github.com/NixOS/nixpkgs/commit/db57a90dccb2b0fc0b6d5302f08365db1e4db81e) | `qt5*.qtwayland: deconflict patching`                                                   |
| [`701ea1da`](https://github.com/NixOS/nixpkgs/commit/701ea1da06fc57d8b26c19c3d668fe348aaab9e3) | `buttersink: remove`                                                                    |
| [`9b09e3f7`](https://github.com/NixOS/nixpkgs/commit/9b09e3f7ad53aee821b5b119ffb65060b4c33aea) | `whatweb: init at 0.5.5`                                                                |
| [`1bff2d6c`](https://github.com/NixOS/nixpkgs/commit/1bff2d6c4591685be9e41e85f0cbcc4002fc743c) | `python310Packages.google-cloud-secret-manager: 2.9.2 -> 2.10.0`                        |
| [`249aa8d8`](https://github.com/NixOS/nixpkgs/commit/249aa8d8dc0fc893b023442af0951576d185ac3f) | `Revert "plasma5Packages.kitinerary: fix build with Poppler 22.03"`                     |
| [`7f337e98`](https://github.com/NixOS/nixpkgs/commit/7f337e988d56a8b5c78f25cbcb88dc67ec08caa9) | `interfacer: remove`                                                                    |
| [`dc2750c8`](https://github.com/NixOS/nixpkgs/commit/dc2750c88ce32872b3dc58fe22ed02226a72a378) | `heapster: remove`                                                                      |
| [`d528fabf`](https://github.com/NixOS/nixpkgs/commit/d528fabf88215ead0a7217467932c55b3edca261) | `mesos-exporter: remove`                                                                |
| [`86262a00`](https://github.com/NixOS/nixpkgs/commit/86262a00c59567e17748c2457095fb2ad7ba8a13) | `teleconsole: remove`                                                                   |
| [`dd37fc35`](https://github.com/NixOS/nixpkgs/commit/dd37fc3587d78e370298a844bf764c8b797ee1ce) | `helix: use release tarball to fetch tree-sitter grammars`                              |