### PR TITLE
chore(flake/templates): `7cf40931` -> `2f865344`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
     },
     "templates": {
       "locked": {
-        "lastModified": 1646878339,
-        "narHash": "sha256-SFFw1DXI9YLzEWMRMX2U6KbouEWFDDirUiUELLxvXuM=",
+        "lastModified": 1649246137,
+        "narHash": "sha256-cbAjf3JPoHlJD5Ayoj1sd1Gz1EZMHrFnZWIxbSGslmU=",
         "owner": "NixOS",
         "repo": "templates",
-        "rev": "7cf40931c2d92199e518743fe87132b7e1b187dd",
+        "rev": "2f86534428917d96d414964c69a5cfe353500ad5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                    |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`6296caa9`](https://github.com/NixOS/templates/commit/6296caa969420047c3de8b336f481106cf7af6f8) | `self.lastModifiedDate fix for all templates`     |
| [`53418d1b`](https://github.com/NixOS/templates/commit/53418d1b8f5cb55c62149b6370b9fbeec8125a82) | `Add support for x86_64-darwin`                   |
| [`63c24312`](https://github.com/NixOS/templates/commit/63c243127ca90ee4a46ffa14279fe0f407eb6b3c) | `rust: update naersk url to nix-community/naersk` |