### PR TITLE
chore(flake/home-manager): `07b941f0` -> `66ffa7a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1649130493,
-        "narHash": "sha256-tp2UxeS1A5ESb+I/rh4GoD0DH7edOGdc2fsP6D8o27Y=",
+        "lastModified": 1649313500,
+        "narHash": "sha256-UQN+1klTXrTvxJlakMUbXr9GW9Y1jOTFTyuI8QffKN8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "07b941f0c45ac4af6732d96f4cb6142824eee3df",
+        "rev": "66ffa7a0a6411c7c73a648bd0b426c73e2a14fa0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                             |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`66ffa7a0`](https://github.com/nix-community/home-manager/commit/66ffa7a0a6411c7c73a648bd0b426c73e2a14fa0) | `systemd: fix creation of user service unit files (#2867)` |