### PR TITLE
chore(flake/home-manager): `66ffa7a0` -> `3071ea20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1649313500,
-        "narHash": "sha256-UQN+1klTXrTvxJlakMUbXr9GW9Y1jOTFTyuI8QffKN8=",
+        "lastModified": 1649352994,
+        "narHash": "sha256-vTHLgqyAUrtIzw/wbOrfqzf20/UuspDRhurj8LbcSWs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "66ffa7a0a6411c7c73a648bd0b426c73e2a14fa0",
+        "rev": "3071ea205da9ad7dd1c4094c2076d44f88ba350e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`3071ea20`](https://github.com/nix-community/home-manager/commit/3071ea205da9ad7dd1c4094c2076d44f88ba350e) | `starship: skip one program invocation on each shell init (#2862)` |
| [`e361373b`](https://github.com/nix-community/home-manager/commit/e361373b5f5003c2806146f97c74f0c9e9d35ef3) | `taskwarrior: make .taskrc writable (#2761)`                       |
| [`3604a20b`](https://github.com/nix-community/home-manager/commit/3604a20b67fbf4deb7cc386040adbcf163853446) | `docs: fix link to rollback instructions`                          |