### PR TITLE
chore(flake/home-manager): `3071ea20` -> `8a046f36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1649352994,
-        "narHash": "sha256-vTHLgqyAUrtIzw/wbOrfqzf20/UuspDRhurj8LbcSWs=",
+        "lastModified": 1649352998,
+        "narHash": "sha256-snkQ47BEzeyTYh6tzEhEi6YLl7fOxGFQzqVYW6X7Cis=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3071ea205da9ad7dd1c4094c2076d44f88ba350e",
+        "rev": "8a046f36ebca680312828e945a4f4928ad503474",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`8a046f36`](https://github.com/nix-community/home-manager/commit/8a046f36ebca680312828e945a4f4928ad503474) | `Translate using Weblate (Portuguese (Brazil))` |