### PR TITLE
chore(flake/home-manager): `8a046f36` -> `55779b20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1649352998,
-        "narHash": "sha256-snkQ47BEzeyTYh6tzEhEi6YLl7fOxGFQzqVYW6X7Cis=",
+        "lastModified": 1649369183,
+        "narHash": "sha256-peE/lM2YMMgE0tKDVTVhhGTEyrWp0Z15DfoabuqsQkM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8a046f36ebca680312828e945a4f4928ad503474",
+        "rev": "55779b20cd5a57cae3e1f8508f93fdd7ffdc5826",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                      |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`55779b20`](https://github.com/nix-community/home-manager/commit/55779b20cd5a57cae3e1f8508f93fdd7ffdc5826) | `pandoc: fix test case`             |
| [`47b3719f`](https://github.com/nix-community/home-manager/commit/47b3719f51b020729de0b8f26a7606fb401b5de9) | `taskwarrior: minor script cleanup` |