### PR TITLE
chore(flake/nixpkgs): `a6498737` -> `ea7be75c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1649270075,
-        "narHash": "sha256-m4QzKyk2xtJNKK07MWQK0b0fafj0/4fPlFa4F/YPehw=",
+        "lastModified": 1649316040,
+        "narHash": "sha256-alWbiaHgSsCeVONwfdw9EZPgbmjOmOd1Mry9g0HaMcU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a64987375ffc8e9cc093150596c9bee215e4d6f4",
+        "rev": "ea7be75c9800e912f3b29deb75d5e801acaa49b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                        |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`13c5740e`](https://github.com/NixOS/nixpkgs/commit/13c5740eb8235d499a1733d40189b0a64426729d) | `zathura: 0.4.8 -> 0.4.9`                                             |
| [`cd001748`](https://github.com/NixOS/nixpkgs/commit/cd001748be2f06d7bac20e7c525f54adf04b8073) | `swayidle: fix printf for i686`                                       |
| [`2363be98`](https://github.com/NixOS/nixpkgs/commit/2363be984a8f70e25899851744798693fa46792c) | `libjxl: disable tests for i686`                                      |
| [`42ab9c51`](https://github.com/NixOS/nixpkgs/commit/42ab9c513618eafaf673814ba58f52c8ab54839d) | `python3.pkgs.afdko: disable a test for i686`                         |
| [`92e78e89`](https://github.com/NixOS/nixpkgs/commit/92e78e890f4a6a3056a2430e3474b66a2a408f32) | `actionlint: 1.6.10 -> 1.6.11`                                        |
| [`e7001451`](https://github.com/NixOS/nixpkgs/commit/e7001451a509a3ae6ec75eddeeac161de30e69c3) | `ocamlPackages.findlib: 1.9.1 → 1.9.3`                                |
| [`32329558`](https://github.com/NixOS/nixpkgs/commit/323295583ccbf82bf100152406d5fd10b415bde8) | `python310Packages.youtube-search-python: 1.6.3 -> 1.6.4`             |
| [`bbc6a3e0`](https://github.com/NixOS/nixpkgs/commit/bbc6a3e05b2b2b8e4656d8c9acf0cd5f99e82d62) | `python310Packages.pycfmodel: 0.18.0 -> 0.18.1`                       |
| [`f7429cb1`](https://github.com/NixOS/nixpkgs/commit/f7429cb1048ea053e33ca8bc5f4fc79aceed8d1a) | `yq: fix build`                                                       |
| [`241de3da`](https://github.com/NixOS/nixpkgs/commit/241de3da58866bb0eb86dd44c5bfd263e95a4071) | `wxmaxima: 21.11.0 -> 22.03.0`                                        |
| [`deee0951`](https://github.com/NixOS/nixpkgs/commit/deee09513341c8f68ce538348c208740631b4467) | `kustomize: various`                                                  |
| [`81744636`](https://github.com/NixOS/nixpkgs/commit/817446361d5ab2e8af84717d975cb1160f093c91) | `home-assistant: pin aioairzone==0.2.3`                               |
| [`655d9c2d`](https://github.com/NixOS/nixpkgs/commit/655d9c2d36400da1992dc160dffbb8a60eaa0ca1) | `python3Packages.zigpy-cc: disable failing tests`                     |
| [`6518b777`](https://github.com/NixOS/nixpkgs/commit/6518b77721a4362fddda3e249603aab42dc31cb3) | `python3Packages.samsungtvws: propagate async extra dependencies`     |
| [`5800217e`](https://github.com/NixOS/nixpkgs/commit/5800217e89b721dd24ddc9e89962e8498de057d1) | `python3Packages.ha-av: drop`                                         |
| [`98df8103`](https://github.com/NixOS/nixpkgs/commit/98df8103d23884f18b770397bcf8016f44dc829e) | `home-assistant: 2022.3.8 -> 2022.4.0`                                |
| [`3e1efa38`](https://github.com/NixOS/nixpkgs/commit/3e1efa384d11e513198608725d3b234fcff9e060) | `python3Packages.pybluez: use correct upstream, fixes build`          |
| [`0bdc5fa6`](https://github.com/NixOS/nixpkgs/commit/0bdc5fa67bfd53fcf4961b2cdeed83390400f2a8) | `asciigraph: switch to buildGoModule`                                 |
| [`e12a1433`](https://github.com/NixOS/nixpkgs/commit/e12a1433cc46e0163f2a3d6cb2d2ab3f2af6a208) | `python3Packages.gattlib: init at unstable-2021-06-16`                |
| [`dd986a65`](https://github.com/NixOS/nixpkgs/commit/dd986a65f6a214f949dc278dd4e1d1266cfc5793) | `python3Packages.lru-dict: init at 1.1.7`                             |
| [`d8902889`](https://github.com/NixOS/nixpkgs/commit/d8902889ff9609bb8600d1c662085e800c9592b9) | `python3Packages.zha-quirks: 0.0.67 -> 0.0.69`                        |
| [`d365acea`](https://github.com/NixOS/nixpkgs/commit/d365acea6477722476e5f97f833bc8a794f59bfa) | `python3Packages.zigpy: 0.43.0 -> 0.44.1`                             |
| [`4719d5ed`](https://github.com/NixOS/nixpkgs/commit/4719d5ed7cca39529991df6256777c9ef55c6a15) | `python3Packages.yeelight: 0.7.9 -> 0.7.10`                           |
| [`da94409b`](https://github.com/NixOS/nixpkgs/commit/da94409bb5f5cebf874be402cc20ac6504cb4fc1) | `python3Packages.xknx: 0.19.2 -> 0.20.1`                              |
| [`1aa31fa3`](https://github.com/NixOS/nixpkgs/commit/1aa31fa30be81462bb029c2a522510c96eb20ed3) | `python3Packages.vehicle: 0.3.1 -> 0.4.0`                             |
| [`2473bb0d`](https://github.com/NixOS/nixpkgs/commit/2473bb0d7caf30f8020d7a5dcae9f15d0068b489) | `python3Packages.pysma: 0.6.10 -> 0.6.11`                             |
| [`7614ad21`](https://github.com/NixOS/nixpkgs/commit/7614ad2121d3fd993839a68f96385c0e51e71c03) | `python3Packages.plugwise: 0.16.6 -> 0.17.3`                          |
| [`6584c787`](https://github.com/NixOS/nixpkgs/commit/6584c787a7fec8c7603f02b6b996b05c1e2d4bca) | `python3Packages.hyperion-py: 0.7.4 -> 0.7.5`                         |
| [`378454d8`](https://github.com/NixOS/nixpkgs/commit/378454d8dc5e3db1ae7a93bbf5a40cf65c1cd422) | `vultr-cli: 2.12.1 -> 2.12.2`                                         |
| [`f4e66759`](https://github.com/NixOS/nixpkgs/commit/f4e667594f5a0a4c84cda92f0ff5754d8e2eb123) | `ugrep: 3.7.6 -> 3.7.7`                                               |
| [`832d4ec7`](https://github.com/NixOS/nixpkgs/commit/832d4ec77e121be299fb2840e24639089d50d184) | `vnote: 3.12.888 -> 3.13.0`                                           |
| [`88489ec7`](https://github.com/NixOS/nixpkgs/commit/88489ec78afd7f3ba9f56638399bdc8c764424a6) | `ocrmypdf: 13.4.1 -> 13.4.2`                                          |
| [`09c8dffa`](https://github.com/NixOS/nixpkgs/commit/09c8dffafcb5310e096af2af76fb35e329d47fb5) | `haskellPackages: mark builds failing on hydra as broken`             |
| [`cd3c6e8b`](https://github.com/NixOS/nixpkgs/commit/cd3c6e8bb487ac6bdbe4069222e638d76882923c) | `nix-doc: 0.5.2->0.5.3`                                               |
| [`e465efae`](https://github.com/NixOS/nixpkgs/commit/e465efaefaaee225bd08e6a78b36ba7a310339ad) | `python3Packages.hangups: 0.4.17 -> 0.4.18`                           |
| [`0bfbf4c8`](https://github.com/NixOS/nixpkgs/commit/0bfbf4c86d22517ac4f7aab8134835519ca97f7f) | `python3Packages.av: 8.1.0 -> 9.1.1`                                  |
| [`1d3f7357`](https://github.com/NixOS/nixpkgs/commit/1d3f73573f1d3227bb95972e35a8ae0a1db9f90d) | `python3Packages.async-upnp-client: 0.23.5 -> 0.27.0`                 |
| [`c45133c5`](https://github.com/NixOS/nixpkgs/commit/c45133c56979a2b262588e971ca61f1237b4c730) | `python3Packages.amberelectric: 1.0.3 -> 1.0.4`                       |
| [`de1f5f6b`](https://github.com/NixOS/nixpkgs/commit/de1f5f6b0ef16faddc1ab8aedc431d8e8331ac10) | `stagit: 1.0 -> 1.1`                                                  |
| [`0cfc54bb`](https://github.com/NixOS/nixpkgs/commit/0cfc54bb46aeec10db8a69370919dc06cb2a7f69) | `webtorrent_desktop: run in fhsenv`                                   |
| [`e905ff84`](https://github.com/NixOS/nixpkgs/commit/e905ff84a5aa262415919c6436cf04bb916c7341) | `rust-analyzer-unwrapped: 2022-03-07 -> 2022-04-04`                   |
| [`4455bb34`](https://github.com/NixOS/nixpkgs/commit/4455bb34387b0159c04b49a7f37cd11d9a56bddd) | `termscp: 0.8.0 -> 0.8.1`                                             |
| [`05bb0a39`](https://github.com/NixOS/nixpkgs/commit/05bb0a39e3a626880d0263f7880061e6fd88c912) | `clojure: 1.11.0.1100 -> 1.11.1.1107`                                 |
| [`596c6435`](https://github.com/NixOS/nixpkgs/commit/596c6435d4b14f57cfa3d187f5fc51c1a7954601) | `skypeforlinux: 8.81.0.268 -> 8.82.0.403`                             |
| [`d8d21367`](https://github.com/NixOS/nixpkgs/commit/d8d21367180ba7a3d21db6fb04196adfcd0421ab) | `ocaml 4.00 – 4.09: make compatible with glibc-2.34`                  |
| [`4fe54b0e`](https://github.com/NixOS/nixpkgs/commit/4fe54b0e390e9eae442a30edb6fe8870d2ed9c70) | `simgear: 2020.3.12 -> 2020.3.13`                                     |
| [`0b94920e`](https://github.com/NixOS/nixpkgs/commit/0b94920e898567c33094e4d1330bb74593c7f2b4) | `ryujinx: 1.1.77 -> 1.1.91`                                           |
| [`23502f26`](https://github.com/NixOS/nixpkgs/commit/23502f26b28b1f3b2bc50868f929b3b14ad65a7a) | `shadowsocks-rust: 1.13.5 -> 1.14.2`                                  |
| [`eacb8875`](https://github.com/NixOS/nixpkgs/commit/eacb88754aba7f99cc6e865a9269a430ecaac25f) | `python3Packages.pysma: 0.6.10 -> 0.6.11`                             |
| [`d7580d51`](https://github.com/NixOS/nixpkgs/commit/d7580d5134c5135cf4e720bbb9433115fc541938) | `flow: enable FLOW_RELEASE flag to demote warnings`                   |
| [`f51d0956`](https://github.com/NixOS/nixpkgs/commit/f51d0956afdb184b8a0ffc5b17dd4d2cc3406fd3) | `clair: enable tests`                                                 |
| [`5e1aad2d`](https://github.com/NixOS/nixpkgs/commit/5e1aad2d708aae178376b821e15eea682876137f) | `certigo: enable tests`                                               |
| [`d68daaad`](https://github.com/NixOS/nixpkgs/commit/d68daaad8cbd719daaf2ef6f0d148a95c81e1f67) | `mosh: add perl back to buildInputs to fix shebang fixing`            |
| [`dcc45dd9`](https://github.com/NixOS/nixpkgs/commit/dcc45dd93587299bbde7671300f74626af768085) | `python310Packages.meshio: 5.3.2 -> 5.3.4`                            |
| [`e16daee0`](https://github.com/NixOS/nixpkgs/commit/e16daee0f5e4f74cd4208268d727c564282f85b0) | `faas-cli: 0.14.3 -> 0.14.4`                                          |
| [`81572162`](https://github.com/NixOS/nixpkgs/commit/815721620cb14911a0606645ad0d570a31074eb2) | `gsctl: 1.1.4 -> 1.1.5`                                               |
| [`e8e0ad7d`](https://github.com/NixOS/nixpkgs/commit/e8e0ad7dfb99e923fbc79b2f79dd84ff2ed03a69) | `xxh: 0.8.9 -> 0.8.10`                                                |
| [`a964dcad`](https://github.com/NixOS/nixpkgs/commit/a964dcad739fe70ed5e01646594aafdfb2be4560) | `haskell.compiler.ghcjs: pass fetchFromGitHub to ghcjs-base`          |
| [`d6bc67cf`](https://github.com/NixOS/nixpkgs/commit/d6bc67cf96912aaff3dd1eef3c00359b72999464) | `slack: 4.23.0 -> 4.25.0`                                             |
| [`2e8743b8`](https://github.com/NixOS/nixpkgs/commit/2e8743b8e53638d8af54c74c023e0bb317557afb) | `haskell: update link to calendar for maintainer rotation`            |
| [`f10066e8`](https://github.com/NixOS/nixpkgs/commit/f10066e81b102858d8ab757db14222d751e94d5c) | `haskellPackages.jsaddle-webkit2gtk: remove obsolete patch`           |
| [`9b7e3e28`](https://github.com/NixOS/nixpkgs/commit/9b7e3e288c376f91c021908b5da5d7ab918faab0) | `harvid: 0.8.3 -> 0.9.0`                                              |
| [`f5536149`](https://github.com/NixOS/nixpkgs/commit/f5536149557e611a8f8b6503bd51cb2e62306a2a) | `haskellPackages.graphql-engine: 2.0.10 -> 2.3.1`                     |
| [`ae349e39`](https://github.com/NixOS/nixpkgs/commit/ae349e390c747b09d12723e1e1d14b5ac03da0d3) | `haskellPackages: regenerate package set based on current config`     |
| [`f513fcc9`](https://github.com/NixOS/nixpkgs/commit/f513fcc9a9989c9d3f1e081015bb96b8efd5ea7b) | `all-cabal-hashes: 2022-03-30T19:23:57Z -> 2022-04-03T10:13:27Z`      |
| [`f787a94d`](https://github.com/NixOS/nixpkgs/commit/f787a94d5e2a27a37312d63ace83f858d20a39f6) | `flat-remix-gtk: 20220321 -> 20220330`                                |
| [`35f137ea`](https://github.com/NixOS/nixpkgs/commit/35f137ea98ea0276926c1b0ddb002a832a2f9c01) | `haskellPackages.inline-c{,-cpp}: Add myself as maintainer`           |
| [`517cb71b`](https://github.com/NixOS/nixpkgs/commit/517cb71b026be805c41945dc86a7352b1bf8aa92) | `haskellPackages.inline-c-cpp: Fix tests on darwin`                   |
| [`1d3b238d`](https://github.com/NixOS/nixpkgs/commit/1d3b238d28f7f2035d5aea995fca8e6c552206a0) | `all-cabal-hashes: Set name`                                          |
| [`76be6eaf`](https://github.com/NixOS/nixpkgs/commit/76be6eaf29de81e7cdbad268e8f90106dcf021b5) | `haskell.compiler.ghc902: Backport -fcompact-unwind`                  |
| [`6016ed50`](https://github.com/NixOS/nixpkgs/commit/6016ed50768d2ccc5417382970bb16948bc76c95) | `treewide: replace uses of ghc.name to find packages' datadir`        |
| [`456faf71`](https://github.com/NixOS/nixpkgs/commit/456faf71e5a842128589e0b44dea3d426fa87e40) | `ghcWithPackages: use haskellCompilerName for ghclibdir`              |
| [`78a93b53`](https://github.com/NixOS/nixpkgs/commit/78a93b5352a26bbbad4a9f22f0fcdaf76f5dc176) | `haskellPackages.mkDerivation: get ghclibdir via haskellCompilerName` |
| [`9dddd48c`](https://github.com/NixOS/nixpkgs/commit/9dddd48c4c744ad478e20e8967006c5f32474a54) | `nixos/grub: added configuration option for entry options`            |
| [`383fbfad`](https://github.com/NixOS/nixpkgs/commit/383fbfadccaa12f908f79ab83f21fa5dbe10c6be) | `ghcWithPackages: use packageCfgDir over ghc.name where appropriate`  |
| [`538a6dba`](https://github.com/NixOS/nixpkgs/commit/538a6dba9ba6186d48b58e3eec646cc7baa7e121) | `ghorg: 1.7.11 -> 1.7.12`                                             |