### PR TITLE
chore(flake/nixpkgs): `ea7be75c` -> `8d486e48`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1649316040,
-        "narHash": "sha256-alWbiaHgSsCeVONwfdw9EZPgbmjOmOd1Mry9g0HaMcU=",
+        "lastModified": 1649377169,
+        "narHash": "sha256-T9MkX36zJdWnwjX0t2atVuXLpxrZXa51qUjhCHYtbx8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ea7be75c9800e912f3b29deb75d5e801acaa49b3",
+        "rev": "8d486e482f434f65b2f6731030423b4b0d8db4b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`eb499e5a`](https://github.com/NixOS/nixpkgs/commit/eb499e5ab6872620751b98d90490e10551dc74be) | `gpsprune: 21.1 -> 21.2`                                                      |
| [`6f29f4d3`](https://github.com/NixOS/nixpkgs/commit/6f29f4d3261b147b7cec6ad5bfdd91ed7be9e5ce) | `nitter: unstable-2022-02-11 -> unstable-2022-03-21`                          |
| [`b08dcc40`](https://github.com/NixOS/nixpkgs/commit/b08dcc40eb033faf58e042dc22b1f389be48f5ac) | `nitter: add update script`                                                   |
| [`05fe9b54`](https://github.com/NixOS/nixpkgs/commit/05fe9b54a5782506c60d94b7eaefce7158da0d77) | `ocamlPackages.cmdliner: Use the upstream Makefile build rules (#166150)`     |
| [`92582676`](https://github.com/NixOS/nixpkgs/commit/9258267684e33d1b295959f78f4c5b3a90640a30) | `nfpm: enable tests`                                                          |
| [`7d55ee2b`](https://github.com/NixOS/nixpkgs/commit/7d55ee2b5ced70c3786013389216bd0ba1f9350f) | `terraform: 1.1.7 -> 1.1.8`                                                   |
| [`0d5da6a3`](https://github.com/NixOS/nixpkgs/commit/0d5da6a3ad41ed5987b290e24431e1c7db1ebb5f) | `civetweb: enable IPv6`                                                       |
| [`3f992e25`](https://github.com/NixOS/nixpkgs/commit/3f992e25f131f4a6ce83efddcec6297e683adcc2) | `services.zfs.expandOnBoot: Test that it works`                               |
| [`bd3e9c3d`](https://github.com/NixOS/nixpkgs/commit/bd3e9c3d051f77338b38ea44cc28cfc465923f41) | `nixos/zfs: better support auto-expanding partitioned disks`                  |
| [`16543b63`](https://github.com/NixOS/nixpkgs/commit/16543b630a58e4b4c0100d130d72a8c5b25fac8f) | `zpool-auto-expand-partitions: init at 0.1.0`                                 |
| [`6042a5d4`](https://github.com/NixOS/nixpkgs/commit/6042a5d4c00934868cca4a3a131c8dd8dbb359e4) | `findomain: 7.2.0 -> 8.0.0`                                                   |
| [`982e21f6`](https://github.com/NixOS/nixpkgs/commit/982e21f69eb9542d91eb53d02b0d4caf3bdd9018) | `python310Packages.pre-commit-hooks: 4.1.0 -> 4.2.0`                          |
| [`e54be9a1`](https://github.com/NixOS/nixpkgs/commit/e54be9a1383a429e879732987c2e368b412d8d51) | `bikeshed: init at 3.4.3`                                                     |
| [`f23cb42a`](https://github.com/NixOS/nixpkgs/commit/f23cb42acfeb707ad416167490399bdc0cddd24f) | `pythonPackages.result: init at 0.7.0`                                        |
| [`625c4889`](https://github.com/NixOS/nixpkgs/commit/625c488985737b0b3aac4366a6a7d6d5d67ac1ba) | `pythonPackages.widlparser: init at 1.0.12`                                   |
| [`d82ad375`](https://github.com/NixOS/nixpkgs/commit/d82ad375116c9df9b1b9522e6cf0c3380c2fcab8) | `pythonPackages.json-home-client: init at 1.1.1`                              |
| [`ea39bd5f`](https://github.com/NixOS/nixpkgs/commit/ea39bd5ffbcc052f19ac837c71bef65e14677767) | `pythonPackages.uri-template: init at 1.2.0`                                  |
| [`1b4b16e1`](https://github.com/NixOS/nixpkgs/commit/1b4b16e1bdc75fe881494b9341c482e9c63174bf) | `nixos/envoy: init`                                                           |
| [`cebeeb86`](https://github.com/NixOS/nixpkgs/commit/cebeeb8623093cd9e05c01d6667e4a79d6ce41dc) | `gitleaks: 8.5.2 -> 8.6.1`                                                    |
| [`dbe9f8fd`](https://github.com/NixOS/nixpkgs/commit/dbe9f8fdd5392538ef64dcbc4e82d3b41ae0e3e4) | `corerad: 1.1.1 -> 1.1.2`                                                     |
| [`1fd8d747`](https://github.com/NixOS/nixpkgs/commit/1fd8d747b1c20c22805b069652d7bf6c6d705267) | `gnome.sushi: 41.1 -> 41.2`                                                   |
| [`a0cd73aa`](https://github.com/NixOS/nixpkgs/commit/a0cd73aaba4a7568a0566f280bbe949d6543c93d) | `go-rice: rename pname; enable tests`                                         |
| [`4da89993`](https://github.com/NixOS/nixpkgs/commit/4da89993ed353d40fa7515f0cfffadc34ebb683c) | `oh-my-zsh: 2022-04-04 -> 2022-04-06 (#167622)`                               |
| [`28e49faa`](https://github.com/NixOS/nixpkgs/commit/28e49faa631c0b85d0f0da4a2bb256d76bc2c8fd) | `sonobuoy: 0.56.3 -> 0.56.4`                                                  |
| [`79cc492c`](https://github.com/NixOS/nixpkgs/commit/79cc492cebc8fc1d1cc5f2fc9658e8ea27b751b2) | `sage: set CXXFLAGS to match CFLAGS in sage-env`                              |
| [`384117bb`](https://github.com/NixOS/nixpkgs/commit/384117bb95a34da017dbffda05603fb08a52fa23) | `sage: import scipy 1.8 update patch`                                         |
| [`239982c6`](https://github.com/NixOS/nixpkgs/commit/239982c6c932b98eb81fec3d18a918f288387ab4) | `mastodon: fix indexing statuses in elasticsearch`                            |
| [`9e80144a`](https://github.com/NixOS/nixpkgs/commit/9e80144a8bb2ad38dba36998d0bc417c6d2b7f7d) | `sage: refresh ipython update patch for ipython 8.1 compat`                   |
| [`49cddf1a`](https://github.com/NixOS/nixpkgs/commit/49cddf1a7836c981cf72ce6b71db9ff9a8f42ae5) | `sage: import networkx 2.7 update patch`                                      |
| [`d4ba3743`](https://github.com/NixOS/nixpkgs/commit/d4ba37439025963be469448d9b4056751d68b11b) | `docker-buildx: 0.8.1 -> 0.8.2`                                               |
| [`a9513a4e`](https://github.com/NixOS/nixpkgs/commit/a9513a4eb765aaf5aeea65b35fec7c8280e0ad6c) | `dragonfly-reverb: 3.2.5 -> 3.2.6`                                            |
| [`a48bc3cc`](https://github.com/NixOS/nixpkgs/commit/a48bc3cc89cf6d30504ec9bffec68df1f366aaf2) | `flint: set enableParallelBuilding = true`                                    |
| [`79b72e21`](https://github.com/NixOS/nixpkgs/commit/79b72e211082add88b5385c21be57e62bb49cdb6) | `emacs.pkgs.control-lock: Add package (#166520)`                              |
| [`be693d6f`](https://github.com/NixOS/nixpkgs/commit/be693d6f68d08bb54407ea94b3bc08f6febce793) | `eksctl: 0.90.0 -> 0.91.0`                                                    |
| [`5eb21a55`](https://github.com/NixOS/nixpkgs/commit/5eb21a55ee235f0f60f94c60ebcfcadda997de96) | `copyDesktopItems: Use variable for repeated path`                            |
| [`d1bbb2b3`](https://github.com/NixOS/nixpkgs/commit/d1bbb2b3d6997bb741770071f6886931a0e888d6) | `copyDesktopItems: Use bin output`                                            |
| [`23d4b86f`](https://github.com/NixOS/nixpkgs/commit/23d4b86f8298c37aebeb1e94633c5202a3886423) | `docker-compose_2: 2.4.0 -> 2.4.1`                                            |
| [`e245a3d1`](https://github.com/NixOS/nixpkgs/commit/e245a3d13271140aa1d5bf870933dee5e1bc9dba) | `python3Packages.toggl-cli: update relaxed constraints`                       |
| [`f401eec2`](https://github.com/NixOS/nixpkgs/commit/f401eec20070d8c8b7316f7f41e8bd003d19ee0f) | `Revert "python3Packages.toggl-cli: 2.4.3 -> 3"`                              |
| [`618c808f`](https://github.com/NixOS/nixpkgs/commit/618c808f9fc9928b345c5661277136aab3ba9d08) | ``istioctl: add `superherointj` and `bryanasdev000` as maintainers``          |
| [`43095fdb`](https://github.com/NixOS/nixpkgs/commit/43095fdb77a82981054742e2943e719aac16ac5f) | `python3Packages.west: disable on older Python releases`                      |
| [`f81323c8`](https://github.com/NixOS/nixpkgs/commit/f81323c8324c2588fd8767811265b79974329ee4) | `python3Packages.azure-eventgrid: disable on older Python releases`           |
| [`03e34c09`](https://github.com/NixOS/nixpkgs/commit/03e34c09eea3dc8f21bcde01b86d60867fdf30c5) | `python3Packages.azure-mgmt-storage: disable on older Python releases`        |
| [`149c8c99`](https://github.com/NixOS/nixpkgs/commit/149c8c992919f0e8a798c1d281dc7f2fb6952e61) | `python3Packages.google-cloud-pubsub: disable on older Python releases`       |
| [`ca9d401d`](https://github.com/NixOS/nixpkgs/commit/ca9d401d6867d8810777552f4bcdbb7f7cedc420) | `python310Packages.dotmap: 1.3.29 -> 1.3.30`                                  |
| [`cbaf3e7e`](https://github.com/NixOS/nixpkgs/commit/cbaf3e7e93e03a36b5b61dd37a35ccd0c6c34a94) | `pantheon.switchboard-plug-sound: 2.3.0 -> 2.3.1`                             |
| [`fc8b3dbb`](https://github.com/NixOS/nixpkgs/commit/fc8b3dbb50e3c603206796015ff890fcba668dcd) | `pantheon.switchboard-plug-onlineaccounts: 6.3.0 -> 6.4.0`                    |
| [`4981cba9`](https://github.com/NixOS/nixpkgs/commit/4981cba909bb3c88a8f460ed63a6b13be94421da) | `pantheon.switchboard-plug-about: 6.0.1 -> 6.1.0`                             |
| [`af8eb674`](https://github.com/NixOS/nixpkgs/commit/af8eb674fea8bf3eadc180ed215012140f03d0ef) | `python310Packages.google-cloud-pubsub: 2.11.0 -> 2.12.0`                     |
| [`d888104e`](https://github.com/NixOS/nixpkgs/commit/d888104e4c7679adee2bf0b06349083fc156771c) | `go_2: remove`                                                                |
| [`3d88f74c`](https://github.com/NixOS/nixpkgs/commit/3d88f74c9d13e599d1bd3633e8afb197b8378071) | `elmPackages.elmi-to-json: build using aeson 1.5.6.0`                         |
| [`8e8d60fe`](https://github.com/NixOS/nixpkgs/commit/8e8d60fea8554e75e35a21be5be7fbc11c32626c) | `python310Packages.azure-mgmt-storage: 19.1.0 -> 20.0.0`                      |
| [`3654aba7`](https://github.com/NixOS/nixpkgs/commit/3654aba7372ae61b4e7fb8a85073745d9f4dcc38) | `amass: 3.19.0 -> 3.19.1`                                                     |
| [`f190a9ec`](https://github.com/NixOS/nixpkgs/commit/f190a9ec4a1771a78c1a960a4cc3ed0393e0f93f) | `bitwig-studio: 4.2.1 -> 4.2.2`                                               |
| [`5aa899c6`](https://github.com/NixOS/nixpkgs/commit/5aa899c6067d3aa23a4a398af7b27445efa99c73) | `python310Packages.azure-eventgrid: 4.7.1 -> 4.8.0`                           |
| [`6c46cc64`](https://github.com/NixOS/nixpkgs/commit/6c46cc64de873a92eacfabd2b53f4f7c455fafd9) | `elmPackages.elm-format: build using hspec-tasty 1.1.6, hspec-golden 0.1.0.3` |
| [`8c2fcae9`](https://github.com/NixOS/nixpkgs/commit/8c2fcae9327415a6b4905b89ca60831e8531d6b9) | `python310Packages.west: 0.12.0 -> 0.13.0`                                    |
| [`926252ad`](https://github.com/NixOS/nixpkgs/commit/926252ade9085113c8a03b77cd60cce656641ade) | `python3Packages.yq: run upstream testsuite`                                  |
| [`4623d107`](https://github.com/NixOS/nixpkgs/commit/4623d107eb0b340ecbf93c73737d00ed0403c0ee) | `tinyemu: set CC and STRIP in makeFlags`                                      |
| [`d42db5cf`](https://github.com/NixOS/nixpkgs/commit/d42db5cfb56fdc2a62db2f63b2499d8d8f1e47be) | `lagrange: 1.12.0 -> 1.12.1`                                                  |
| [`58e59742`](https://github.com/NixOS/nixpkgs/commit/58e59742c8fae1f483729251dee8b882949c6ddc) | `shellhub-agent: 0.9.0 -> 0.9.1`                                              |
| [`15291355`](https://github.com/NixOS/nixpkgs/commit/15291355d81b9f179fc5532cfe58de2984473e57) | `ungoogled-chromium: 100.0.4896.60 -> 100.0.4896.75`                          |
| [`f8b62b5b`](https://github.com/NixOS/nixpkgs/commit/f8b62b5b89abba7b4229fa6f7293cc38ea661716) | `cudatext: 1.159.2 -> 1.160.0`                                                |
| [`e3cdac71`](https://github.com/NixOS/nixpkgs/commit/e3cdac71381ec67eb9b0d8589ba6608fa88d95fe) | `amdvlk: 2022.Q1.3 -> 2022.Q2.1`                                              |
| [`56ca8e55`](https://github.com/NixOS/nixpkgs/commit/56ca8e556844ca1a03b43286f8f62a8dfb58586c) | `sfeed: 1.3 -> 1.4`                                                           |
| [`bca0578a`](https://github.com/NixOS/nixpkgs/commit/bca0578a72c9f6c5edf1fc320bb5031824525412) | `python310Packages.aioswitcher: 2.0.8 -> 2.0.9`                               |
| [`386fb0c3`](https://github.com/NixOS/nixpkgs/commit/386fb0c3cf119a3bb4b83d2379aa9c3f9cbdd009) | `cudatoolkit: 11.6 -> 11.5`                                                   |
| [`4eda7cf9`](https://github.com/NixOS/nixpkgs/commit/4eda7cf9e877d08daf4f26e87097354ec2a1df00) | `cudnn 8.3.2: unbreak for cuda 11.6`                                          |
| [`7e780e73`](https://github.com/NixOS/nixpkgs/commit/7e780e73121c4faf01b91a23ee91cad6e0811d0e) | `cudatoolkit_11: 11.4 -> 11.6`                                                |
| [`1b74f75b`](https://github.com/NixOS/nixpkgs/commit/1b74f75b599493ad41118de40df9a2afeabdf98b) | `python310Packages.caffe: mark as broken`                                     |
| [`42e8edcf`](https://github.com/NixOS/nixpkgs/commit/42e8edcfc69bd728aa920f41aacdce4b8e2003a7) | `python3Packages.chainer: mark cudaSupport broken`                            |
| [`c007910a`](https://github.com/NixOS/nixpkgs/commit/c007910a44024451b02d45ba0bb1f7bb7059cc68) | `opensubdiv: disable opencl when building cuda`                               |
| [`565201d7`](https://github.com/NixOS/nixpkgs/commit/565201d7696221c3110ea54f6767437808a60f9d) | `python310Packages.mxnet: mark cudaSupport broken`                            |
| [`b1674bf9`](https://github.com/NixOS/nixpkgs/commit/b1674bf9a5f4996348267d02bd25bcfc5d4bc284) | `truecrack: doesn't build with cudaSupport`                                   |
| [`3655e56e`](https://github.com/NixOS/nixpkgs/commit/3655e56e5832c447adfc40d13b180912f5957a79) | `gpu-screen-recorder{,-gtk}: only build with cuda10`                          |
| [`be32f3d5`](https://github.com/NixOS/nixpkgs/commit/be32f3d54bc79eb408cd4561c40e80c0c8134605) | `ethminer: fix cuda11 support`                                                |
| [`226fabb1`](https://github.com/NixOS/nixpkgs/commit/226fabb1a6ef81a4b089d4879cf1c46bfd6add4f) | `python3Packages.mxnet: pass explicit cuda gencodes`                          |
| [`e5e38773`](https://github.com/NixOS/nixpkgs/commit/e5e38773a5c6d4c4ba215be87439420b88c9fd2b) | `cudatoolkit: 10.2 -> 11.4`                                                   |
| [`fd5c6c5c`](https://github.com/NixOS/nixpkgs/commit/fd5c6c5ccab8aec6f59ad586a278ec4a9f4cbe32) | `petsc: 3.16.5 -> 3.17.0`                                                     |
| [`55f2b883`](https://github.com/NixOS/nixpkgs/commit/55f2b8834e9e2e083850f19d7672e267c3c627c5) | `matrix-synapse: 1.55.2 -> 1.56.0`                                            |
| [`718f0344`](https://github.com/NixOS/nixpkgs/commit/718f0344043a0bf39a3d4475ac45b6b626f9053f) | `n8n: 0.170.0 → 0.171.0`                                                      |
| [`86dc9d32`](https://github.com/NixOS/nixpkgs/commit/86dc9d32956605294a36e5253eb99b233e035a39) | `gnome.gedit: fix darwin build`                                               |
| [`42bb3293`](https://github.com/NixOS/nixpkgs/commit/42bb3293c2089c00747d6061ff5bffa6115ee07e) | `gnome.gedit: 41.0 → 42.0`                                                    |
| [`6bd27f78`](https://github.com/NixOS/nixpkgs/commit/6bd27f78f0d3edf25efcf93f808057b1fa98d1f6) | `golangci-lint: switch to be buit with go1.18`                                |
| [`dd2cab2b`](https://github.com/NixOS/nixpkgs/commit/dd2cab2b5006db3e10563d6041274c50d578936f) | `keycloak: 16.1.0 -> 17.0.1`                                                  |
| [`f92c7b80`](https://github.com/NixOS/nixpkgs/commit/f92c7b80372f3c1d14ef2f1f17daf471431a212a) | `gitleaks: 8.5.1 -> 8.5.2`                                                    |
| [`89ece15b`](https://github.com/NixOS/nixpkgs/commit/89ece15b15836ae557cbf821ac04ecedc1a119c9) | `interactsh: 1.0.1 -> 1.0.2`                                                  |
| [`24cf6c75`](https://github.com/NixOS/nixpkgs/commit/24cf6c758eae9539f2ca40725e559ef3b0165a63) | `kotlin-language-server: 1.2.0 -> 1.3.0`                                      |
| [`68e29163`](https://github.com/NixOS/nixpkgs/commit/68e29163aa51cf96f63a00015500fdcf722e573d) | `pebble: 2.3.0 -> 2.3.1`                                                      |