### PR TITLE
chore(flake/nixpkgs): `8d486e48` -> `77843aaf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1649377169,
-        "narHash": "sha256-T9MkX36zJdWnwjX0t2atVuXLpxrZXa51qUjhCHYtbx8=",
+        "lastModified": 1649418399,
+        "narHash": "sha256-eFC2KJ9d7S8HaqcEAr/R8lWoBz0KGNDOaBsYWalJPdk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8d486e482f434f65b2f6731030423b4b0d8db4b1",
+        "rev": "77843aaf9d4f97a424a6248f0298ff41846e0338",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                          |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`22660f2e`](https://github.com/NixOS/nixpkgs/commit/22660f2e236ba50bfb3917bceef76c96d1b7a388) | `libvirt: patch more binary paths in systemd units`                     |
| [`527c3946`](https://github.com/NixOS/nixpkgs/commit/527c39464e9becbcd303c688d4dd0b5fbcc5d094) | `python3Packages.slicerator: disable on older Python releases`          |
| [`24b77b24`](https://github.com/NixOS/nixpkgs/commit/24b77b240d65e9150983a7853fde194f4e02ca5e) | ` python3Packages.pyplaato: disable on older Python releases`           |
| [`ae8e8aae`](https://github.com/NixOS/nixpkgs/commit/ae8e8aaee7f17df2b3ca552ec4dc2a339248858c) | `treewide: remove obsolete kernel version checks`                       |
| [`c099ec6a`](https://github.com/NixOS/nixpkgs/commit/c099ec6affa6b5e1456e37dba8735b37f60da5c6) | `nixos/klogd: remove`                                                   |
| [`d77b153f`](https://github.com/NixOS/nixpkgs/commit/d77b153fe921e94e4adddc684b60a6dd7a8d1838) | `python3Packages.wasabi: disable on older Python releases`              |
| [`687834f4`](https://github.com/NixOS/nixpkgs/commit/687834f44d67a50945872b77772cd8adc0f66972) | `openconnect: 8.10 -> 8.20, unstable-2021-05-05 -> 2022-03-14, cleanup` |
| [`db726c35`](https://github.com/NixOS/nixpkgs/commit/db726c35225dbcfda496e9ea314e26052a7f075e) | `cassowary: enable tests`                                               |
| [`4ed91442`](https://github.com/NixOS/nixpkgs/commit/4ed91442a1d81cf051bb76440a0daf10aad42bfc) | `Move libunwind to buildInputs`                                         |
| [`c7390885`](https://github.com/NixOS/nixpkgs/commit/c7390885a9235f8de575ed150eb8a93fa7040b18) | `asterisk: update all packages`                                         |
| [`97836a11`](https://github.com/NixOS/nixpkgs/commit/97836a11309a2a1d590a179dd85aa86a3bce19d9) | `obsidian: Fix meta`                                                    |
| [`be759b46`](https://github.com/NixOS/nixpkgs/commit/be759b46f524cfc41e15b9cbedd12493ed16ea3a) | `python310Packages.databricks-connect: 9.1.12 -> 9.1.13`                |
| [`fe871db0`](https://github.com/NixOS/nixpkgs/commit/fe871db0886079d3561975ab8941935543102ead) | `ffmpeg_5: 5.0 -> 5.0.1`                                                |
| [`23e9e781`](https://github.com/NixOS/nixpkgs/commit/23e9e781e292a246c4f884d58661136eab726c45) | `build(deps): bump cachix/install-nix-action from 16 to 17`             |
| [`71fb9043`](https://github.com/NixOS/nixpkgs/commit/71fb9043326c146523480cf82a692170551fd8f5) | `python310Packages.scmrepo: 0.0.17 -> 0.0.18`                           |
| [`73e0a8f4`](https://github.com/NixOS/nixpkgs/commit/73e0a8f4e1e3329fc34d3f289168cef646dd5802) | `python310Packages.scmrepo: 0.0.16 -> 0.0.17`                           |
| [`8e23db16`](https://github.com/NixOS/nixpkgs/commit/8e23db16418fcc6c6387542049d920e097f76d37) | `python310Packages.cloudflare: 2.9.9 -> 2.9.10`                         |
| [`2a2a0c7d`](https://github.com/NixOS/nixpkgs/commit/2a2a0c7df3ae3c0841e2dd707e9d84f7ec8203be) | `python310Packages.trimesh: 3.10.7 -> 3.10.8`                           |
| [`e6698f62`](https://github.com/NixOS/nixpkgs/commit/e6698f624b35e65554c877c2dc848312bc248386) | `python310Packages.hahomematic: 1.0.5 -> 1.0.6`                         |
| [`f596fc39`](https://github.com/NixOS/nixpkgs/commit/f596fc3904df0a99e487ab5986d5ab3ba827bd7c) | `python310Packages.furo: 2022.3.4 -> 2022.4.7`                          |
| [`2e2b664a`](https://github.com/NixOS/nixpkgs/commit/2e2b664a8f686d7bed0aed80c15170ecad2c95ed) | `libsForQt5.applet-window-buttons: 0.10.1 -> 0.11.1`                    |
| [`96081a32`](https://github.com/NixOS/nixpkgs/commit/96081a324c3d774c544792475925dbd000e3b2ce) | `index-fm: no longer depends on applet-window-buttons`                  |
| [`e75fcaf7`](https://github.com/NixOS/nixpkgs/commit/e75fcaf708acf8b1aac72939e1a0e8f8d3e0c298) | `python310Packages.slicerator: 1.0.0 -> 1.1.0`                          |
| [`b3af29aa`](https://github.com/NixOS/nixpkgs/commit/b3af29aa16c88d12bc0f6bfc8bda7600fbd1df7a) | `curlie: set and test version`                                          |
| [`1b039205`](https://github.com/NixOS/nixpkgs/commit/1b0392052d4f1c97a71a765ca1ea2b66fce84ef7) | `deadnix: 0.1.3 -> 0.1.5`                                               |
| [`4bb88937`](https://github.com/NixOS/nixpkgs/commit/4bb889376f540d0ca203726539546272f3d60e16) | `iwd: 1.25 -> 1.26`                                                     |
| [`5c320f83`](https://github.com/NixOS/nixpkgs/commit/5c320f8385232b1617a93486ff978f15ae7a1b0d) | `sqlfluff: 0.11.2 -> 0.12.0`                                            |
| [`eed1123e`](https://github.com/NixOS/nixpkgs/commit/eed1123ed1d174cb57cbcf2e6485b22d9e514ded) | `scala-cli: 0.1.2 -> 0.1.3`                                             |
| [`db20d4e7`](https://github.com/NixOS/nixpkgs/commit/db20d4e7f6acb0e9f4b16e7eda090747fd881795) | `python310Packages.python-smarttub: 0.0.30 -> 0.0.31`                   |
| [`dd2a308c`](https://github.com/NixOS/nixpkgs/commit/dd2a308c4331580635b3500dbc4c2a1b834f3712) | `stellar-core: add missing compile dependency`                          |
| [`5f267306`](https://github.com/NixOS/nixpkgs/commit/5f2673066f5256d0cb1d8271f3cd0a2ed10fe0ed) | `python310Packages.pyplaato: 0.0.16 -> 0.0.17`                          |
| [`28d8eab4`](https://github.com/NixOS/nixpkgs/commit/28d8eab486b4c3d9f45586613db4ec5b3792a460) | `talosctl: 0.14.3 -> 1.0.1`                                             |
| [`038cb5a9`](https://github.com/NixOS/nixpkgs/commit/038cb5a97db356c6152bd6d294270fcbc3cd8c40) | `signal-desktop: 5.37.0 -> 5.38.0`                                      |
| [`dfbd945f`](https://github.com/NixOS/nixpkgs/commit/dfbd945f5c6c3bea9fd8bb9d40ac522046d7804f) | `python310Packages.pre-commit-hooks: 4.1.0 -> 4.2.0`                    |
| [`c2f27faa`](https://github.com/NixOS/nixpkgs/commit/c2f27faa94f96738b9b4de3e926acfc8cf738e17) | `exoscale-cli: 1.52.0 -> 1.52.1`                                        |
| [`238f61a2`](https://github.com/NixOS/nixpkgs/commit/238f61a2d42a056486206c5d7e48314b78c614df) | `python3Packages.elkm1-lib: 1.2.1 -> 1.2.2`                             |
| [`e54fe8f2`](https://github.com/NixOS/nixpkgs/commit/e54fe8f21743808ae71cd52f8cd471019b4b3046) | `python3Packages.myjwt: disable on older Python releases`               |
| [`64f33505`](https://github.com/NixOS/nixpkgs/commit/64f3350532071a9866d586ae369f76d988e8a111) | `cod: fix tests`                                                        |
| [`4417580b`](https://github.com/NixOS/nixpkgs/commit/4417580bbf0de5a8915b070bdc895feb0e3edecd) | `python310Packages.myjwt: 1.5.0 -> 1.6.0`                               |
| [`24f995fa`](https://github.com/NixOS/nixpkgs/commit/24f995fa2de1fee0ec43edc82b745d0ebf662775) | `material-design-icons: 5.3.45 -> 6.6.96`                               |
| [`2a4778fa`](https://github.com/NixOS/nixpkgs/commit/2a4778fae3dee52f02ef23e359013208ad99ca07) | `stellar-core: 17.0.0 -> 18.5.0`                                        |
| [`021be8c6`](https://github.com/NixOS/nixpkgs/commit/021be8c614be53579959081d0e214292449d4fd0) | `dex-oidc: 2.31.0 -> 2.31.1`                                            |
| [`d632f659`](https://github.com/NixOS/nixpkgs/commit/d632f6599a883439479746db10bc2cb105671912) | `syft: 0.43.0 -> 0.43.2`                                                |
| [`6911f1ef`](https://github.com/NixOS/nixpkgs/commit/6911f1ef788f6f3b5e4ecac827f6f42914cca557) | `drawing: fix build with meson 0.61`                                    |
| [`7979a1b2`](https://github.com/NixOS/nixpkgs/commit/7979a1b2941aea41bc01aec100d908639e279145) | `spidermonkey_91: 91.7.0 -> 91.8.0`                                     |
| [`56a43116`](https://github.com/NixOS/nixpkgs/commit/56a43116e5414980be66d15d70002f7c5b337c5b) | `arc-theme: 20220223 -> 20220405`                                       |
| [`03b659b9`](https://github.com/NixOS/nixpkgs/commit/03b659b9b25fda90520bcedc4e63ed3cd6320c54) | `koules: init at 1.4`                                                   |
| [`271e25dc`](https://github.com/NixOS/nixpkgs/commit/271e25dc09689c03ec0b317d9f38c75de8a38846) | `aliyun-cli: 3.0.113 -> 3.0.115`                                        |
| [`d7a6ec66`](https://github.com/NixOS/nixpkgs/commit/d7a6ec66b092131ccda42d236f1eb052954f39a1) | `plex: 1.25.8.5663-e071c3d62 -> 1.25.9.5721-965587f64`                  |
| [`07369ae0`](https://github.com/NixOS/nixpkgs/commit/07369ae043be7f47bfe3528fdb09c2366b3d9b5f) | `gnome.gnome-initial-setup: 42.0.1 -> 42.1`                             |
| [`1de1469a`](https://github.com/NixOS/nixpkgs/commit/1de1469af87df0792a499dbbbafb2ad922271311) | `mypaint: Fix build`                                                    |
| [`3449b89a`](https://github.com/NixOS/nixpkgs/commit/3449b89a6b5b2dfde7f9e5d6649cd8e552632889) | `xfce.thunar: 4.16.10 -> 4.16.11`                                       |
| [`86f5d425`](https://github.com/NixOS/nixpkgs/commit/86f5d4259ecbfddd8991e7d1963cfe1d8609ee00) | `Obsidian: electron_16 -> electron_17`                                  |
| [`51bf2a20`](https://github.com/NixOS/nixpkgs/commit/51bf2a201105af3ab8eb9705e9c83bdda45cad47) | `fulcio: 0.2.0 -> 0.3.0`                                                |
| [`d7389c98`](https://github.com/NixOS/nixpkgs/commit/d7389c985a7a88482604d27563549ee7c83d5b29) | `trivy: 0.25.2 -> 0.25.3`                                               |
| [`a440e3ec`](https://github.com/NixOS/nixpkgs/commit/a440e3ec9148634d381d00a07dc4fcb48aaf3acd) | `curlie: 1.6.7 -> 1.6.9`                                                |
| [`8771b59a`](https://github.com/NixOS/nixpkgs/commit/8771b59a5fbf0190cb9afe9d06198b6687630b16) | `apt: 2.3.15 -> 2.4.4`                                                  |
| [`89adbcc9`](https://github.com/NixOS/nixpkgs/commit/89adbcc9b3a6b377e2dd4ecddcd5f80cbdb9d7b7) | `elementary-xfce-icon-theme: 0.15.2 -> 0.16`                            |
| [`64c5c832`](https://github.com/NixOS/nixpkgs/commit/64c5c832ce760a7fd32a5b66fca1dbed3c2991d8) | `languagetool: 5.6 -> 5.7`                                              |
| [`0e3e49fc`](https://github.com/NixOS/nixpkgs/commit/0e3e49fc674f96c5b71951b68a2dba5999326b37) | `python310Packages.wasabi: 0.9.0 -> 0.9.1`                              |
| [`a46b4929`](https://github.com/NixOS/nixpkgs/commit/a46b49291d7977894e21fce9aa10a9a84bd93013) | `callaudiod: 0.1.3 -> 0.1.4`                                            |
| [`72c95f28`](https://github.com/NixOS/nixpkgs/commit/72c95f2878c59ca359670376e393044238ef6258) | `php.extensions.datadog_trace: init at 0.70.0`                          |
| [`322a608a`](https://github.com/NixOS/nixpkgs/commit/322a608a5e71dfcaf74cb66dd0cb2689947b68c0) | `mutt-ics: add new package`                                             |