### PR TITLE
chore(flake/nixpkgs): `77843aaf` -> `e10e367d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1649418399,
-        "narHash": "sha256-eFC2KJ9d7S8HaqcEAr/R8lWoBz0KGNDOaBsYWalJPdk=",
+        "lastModified": 1649462329,
+        "narHash": "sha256-RFn4ZIA7/dW8Jjz1okEOCFjh3Hu1kHCR176A8NqCtV8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "77843aaf9d4f97a424a6248f0298ff41846e0338",
+        "rev": "e10e367defcb64675f021e82cc9e0a0f4ec4f0b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`dc358800`](https://github.com/NixOS/nixpkgs/commit/dc358800084097ea2bba6e880801d6ef7932ba75) | `gnomeExtensions: auto-update`                                                        |
| [`31d887cd`](https://github.com/NixOS/nixpkgs/commit/31d887cd15767e35a15952245ae8fb888a73c202) | `memtester: 4.5.0 -> 4.5.1`                                                           |
| [`75eb0967`](https://github.com/NixOS/nixpkgs/commit/75eb096778e65cbf422ce6b65c2ee78de9aba896) | `webkitgtk: 2.34.6 → 2.36.0`                                                          |
| [`e326cbbf`](https://github.com/NixOS/nixpkgs/commit/e326cbbf937fe8af2e54eaab863ea26e956ee527) | `libnma: 1.8.36 -> 1.8.38`                                                            |
| [`b1c63eb9`](https://github.com/NixOS/nixpkgs/commit/b1c63eb9bd3aabcdcc9fbf0f1b9d78f50261c2e9) | `python310Packages.autograd: 1.3 -> 1.4`                                              |
| [`84865c07`](https://github.com/NixOS/nixpkgs/commit/84865c071a7d1879d826fe7dc2b2570a38511a8b) | `cargo-rr: 0.1.3 -> 0.2.0`                                                            |
| [`2796dcfb`](https://github.com/NixOS/nixpkgs/commit/2796dcfbdf5c38e8bc8c7a50f1032113bb9af7ff) | `kamid: init at 0.1 (#162739)`                                                        |
| [`ac6ae29f`](https://github.com/NixOS/nixpkgs/commit/ac6ae29f4690b55f94b88dfe7dcbbd1b877178d3) | `ipfetch: fix phase name`                                                             |
| [`8cb7f599`](https://github.com/NixOS/nixpkgs/commit/8cb7f599f9e488f7e0ed320ab8d437b488ba079a) | `haskell.compiler.ghc902: fix seperate bin outputs on aarch64-darwin`                 |
| [`c161381a`](https://github.com/NixOS/nixpkgs/commit/c161381a5c11f163aa000bc6d58d79348e4367bd) | `python310Packages.aioairzone: 0.3.2 -> 0.3.3`                                        |
| [`96b04c98`](https://github.com/NixOS/nixpkgs/commit/96b04c9895a5a27864e9014b879194780cf53602) | `nodejs-17_x: 17.8.0 -> 17.9.0`                                                       |
| [`76e2f93d`](https://github.com/NixOS/nixpkgs/commit/76e2f93d1a7a1adf778bbe29d081a7834c0db4bc) | `gnome.zenity: 3.41.0 -> 3.42.0`                                                      |
| [`3cd8c087`](https://github.com/NixOS/nixpkgs/commit/3cd8c0878f9af06720ef9a59398990d2570b9b48) | `errcheck: 1.6.0 -> unstable-2022-03-26 (#167423)`                                    |
| [`8f39325c`](https://github.com/NixOS/nixpkgs/commit/8f39325c05d0eb603928e9838a80ca58e68ffacc) | `python310Packages.google-cloud-dataproc: 4.0.1 -> 4.0.2`                             |
| [`8126f997`](https://github.com/NixOS/nixpkgs/commit/8126f997ac7a346df904142ec58c1b23a868b2bc) | `gnome.ghex: fix darwin build`                                                        |
| [`6f43a406`](https://github.com/NixOS/nixpkgs/commit/6f43a406c96bf26e93d40bfaba0a7487c75c5196) | `corerad, gopls: set buildGo118Module in top-level`                                   |
| [`f35d4e3c`](https://github.com/NixOS/nixpkgs/commit/f35d4e3c73eaecfa5d1eabdcfd14d8047b440a15) | `vector: 0.20.0 -> 0.20.1`                                                            |
| [`c584898c`](https://github.com/NixOS/nixpkgs/commit/c584898c0bc15f5eb04a3c0866efab1a9a37a390) | `konstraint: 0.18.0 -> 0.19.0`                                                        |
| [`8c7490ed`](https://github.com/NixOS/nixpkgs/commit/8c7490edebde6d9283e9871caf60abc7fc2ee0d0) | ``terraform-providers.opennebula: drop unnecessary `deleteVendor```                   |
| [`34e802e8`](https://github.com/NixOS/nixpkgs/commit/34e802e8159091b4432f3d25e7c227a7dd66f757) | ``terraform-providers.logicmonitor: drop unnecessary `deleteVendor```                 |
| [`85b98f65`](https://github.com/NixOS/nixpkgs/commit/85b98f65e71478e0f2cfe62ccf92fa628f8cd9f7) | `mdbook: 0.4.15 -> 0.4.17`                                                            |
| [`10636e54`](https://github.com/NixOS/nixpkgs/commit/10636e54bf88166cbfb493ee09bd5fdb7f5a9e61) | `seatd: honor systemdSupport attr (#160967)`                                          |
| [`54463e07`](https://github.com/NixOS/nixpkgs/commit/54463e07a230679ae981c6129c49cdce15e36b57) | `driftctl: 0.26.0 -> 0.27.0`                                                          |
| [`e0eb0416`](https://github.com/NixOS/nixpkgs/commit/e0eb0416f93b669224f475984c4a30e92c3d97cf) | `gnome.ghex: 4.beta.1 → 42.0`                                                         |
| [`90b55fdf`](https://github.com/NixOS/nixpkgs/commit/90b55fdfac17b37e774a97c927d4e7faf9eb1505) | `curlie: enable tests`                                                                |
| [`e7f88473`](https://github.com/NixOS/nixpkgs/commit/e7f884730cad5026a0713b4d5930ccd4e797306a) | `delve: Switch to buildGoModule`                                                      |
| [`8babfc3a`](https://github.com/NixOS/nixpkgs/commit/8babfc3adf04e84bd844f6947b337e74381ef92c) | `terraform-providers: update 2022-04-08`                                              |
| [`aeed4599`](https://github.com/NixOS/nixpkgs/commit/aeed45992b25409ec06bdcbabd97fc45ca080b5b) | `nixos/documentation: apply cleanSourceFilter`                                        |
| [`37a8a582`](https://github.com/NixOS/nixpkgs/commit/37a8a582d717e475f9bcade0e7234783baf784fe) | `nixos/libvirtd: provide path to cloud-hypervisor for virtchd.service`                |
| [`09785263`](https://github.com/NixOS/nixpkgs/commit/09785263d193065c8427e937b8499feb3d0fa2ce) | `python310Packages.ledgerblue: disable on older Python releases`                      |
| [`aa3fd4ae`](https://github.com/NixOS/nixpkgs/commit/aa3fd4aed55fedeb9264ce5364efd2269c8c5254) | `openocd: fix segfault caused by libusb incompatibility`                              |
| [`f79f1832`](https://github.com/NixOS/nixpkgs/commit/f79f18328181c8b348f2abe13f9aa228519af972) | `feroxbuster: 2.6.1 -> 2.6.2`                                                         |
| [`cec8ddc7`](https://github.com/NixOS/nixpkgs/commit/cec8ddc7c95580865e60699df034e594867924f5) | `tfsec: 1.15.4 -> 1.18.0`                                                             |
| [`f46c19b5`](https://github.com/NixOS/nixpkgs/commit/f46c19b575ca612192e268d1b0f64754d1ee93b1) | `lfs: 2.4.0 -> 2.5.0`                                                                 |
| [`01dbdc39`](https://github.com/NixOS/nixpkgs/commit/01dbdc394763a18bc8eb8aaab47880c7fb63b346) | `lf: 26 -> 27`                                                                        |
| [`d1d28e25`](https://github.com/NixOS/nixpkgs/commit/d1d28e2514d5766a91f40991b65a4d5654b5ecc4) | `gnome-connections: 42.0 → 42.1.1`                                                    |
| [`576ebc9e`](https://github.com/NixOS/nixpkgs/commit/576ebc9efe1862de9fa965ccca0ceb46ce06857e) | `gtk-frdp: unstable-2021-10-28 → unstable-2022-04-07`                                 |
| [`57739be6`](https://github.com/NixOS/nixpkgs/commit/57739be66c7ad2f0c83c8532dd30ce9707d5f6c9) | `gnome.gnome-nettool: 3.8.1 → 42.0`                                                   |
| [`b2dca16a`](https://github.com/NixOS/nixpkgs/commit/b2dca16aeba45f774f87ac20ae1f816ab6633b1a) | `python310Packages.pycfmodel: 0.18.1 -> 0.18.2`                                       |
| [`325adc92`](https://github.com/NixOS/nixpkgs/commit/325adc928057d9d73406e0014844c4c2ecbaa8c9) | `xgboost: fix cmake for cuda>=11.4`                                                   |
| [`9b377e72`](https://github.com/NixOS/nixpkgs/commit/9b377e72cfbfcef56217414b6c6b3ad5520dd21f) | `xfsprogs: 5.14.2 -> 5.15.0`                                                          |
| [`364927e7`](https://github.com/NixOS/nixpkgs/commit/364927e70b8b4d3a02882209c40d470f89118ba6) | `python3Packages.pyhaversion: 22.04.0 -> 22.4.1`                                      |
| [`16fe3fbe`](https://github.com/NixOS/nixpkgs/commit/16fe3fbef08320f15a6e0bbf9c10d0023ed2c0f5) | `python310Packages.ledgerblue: 0.1.41 -> 0.1.42`                                      |
| [`9982187e`](https://github.com/NixOS/nixpkgs/commit/9982187ea4e5023983d18446345ce856cad5b3ae) | `qFlipper: 0.8.2 -> 1.0.1`                                                            |
| [`4610dba0`](https://github.com/NixOS/nixpkgs/commit/4610dba0109e01d3a4b95128ac750d855aa41690) | `home-manager: add new dependency (ncurses)`                                          |
| [`d1832325`](https://github.com/NixOS/nixpkgs/commit/d183232545ae53c1ca3de4dfd016c0cb0b4ba84a) | `cargo-rr: fix 'list-git-tags' call`                                                  |
| [`5e9f74f9`](https://github.com/NixOS/nixpkgs/commit/5e9f74f971a29c245005c4b6792abd479512ce8a) | `python3Packages.awesomeversion: 22.2.0 -> 22.4.0`                                    |
| [`15dff0f2`](https://github.com/NixOS/nixpkgs/commit/15dff0f2a8eeddf6c294046ca93a75787c8f076a) | `treewide: prevent using appendToName to have a consistent package name for repology` |
| [`92bbf43c`](https://github.com/NixOS/nixpkgs/commit/92bbf43c5c5c63220e2e6d95a7e0e521dfc33944) | `libargs: 6.2.7 -> 6.3.0`                                                             |
| [`23554630`](https://github.com/NixOS/nixpkgs/commit/23554630946fbc7b81106e1202ab996483d6d567) | `tmux-thumbs: init at 0.7.1`                                                          |
| [`3dc0287d`](https://github.com/NixOS/nixpkgs/commit/3dc0287de026a5fc157839af35cb459760eb136f) | `thumbs: init at 0.7.1`                                                               |
| [`e46d0c5f`](https://github.com/NixOS/nixpkgs/commit/e46d0c5f523dc51527c29ff1a950ea170f7d408f) | `maintainers: add ghostbuster91`                                                      |
| [`06d0d460`](https://github.com/NixOS/nixpkgs/commit/06d0d4604952ffab8b5b13583865308bdaac5c43) | `mop: 0.2.0 -> 1.0.0`                                                                 |
| [`b153524b`](https://github.com/NixOS/nixpkgs/commit/b153524b48e737fcb11795656c06064206019000) | `ncdu2: init at 2.0`                                                                  |
| [`850992fc`](https://github.com/NixOS/nixpkgs/commit/850992fc1f740708e35a52f8063d980675b9a82d) | `xwayland: 22.1.0 -> 22.1.1`                                                          |
| [`0fb036a2`](https://github.com/NixOS/nixpkgs/commit/0fb036a25fa702737a0bedb0fb246938355bb13e) | `agkozak-zsh-prompt: init at 3.11.1`                                                  |
| [`52ad014f`](https://github.com/NixOS/nixpkgs/commit/52ad014fe640b2743d6c87e5fa8120b24ed2c210) | `postfixadmin: 3.3.10 -> 3.3.11`                                                      |
| [`a52c0134`](https://github.com/NixOS/nixpkgs/commit/a52c01340d6fca30d3204c8ac57ccc60b46a4655) | `splat: init at 1.4.2`                                                                |
| [`187f86a2`](https://github.com/NixOS/nixpkgs/commit/187f86a227ad9afadb21f2b13057a6ff47cf1ff1) | `obs-studio: 27.2.1 -> 27.2.2`                                                        |
| [`056b2ab4`](https://github.com/NixOS/nixpkgs/commit/056b2ab46bf391cb923c24da90356db6988605ec) | `jump: 0.40.0 -> 0.41.0`                                                              |
| [`ee885d43`](https://github.com/NixOS/nixpkgs/commit/ee885d43f704c686733311385788816156041ee7) | `es: 0.9.1 -> 0.9.2`                                                                  |
| [`12c1e476`](https://github.com/NixOS/nixpkgs/commit/12c1e476814ad4497c24998b1b64914b76aa712e) | `datadog-agent: 7.33.1 -> 7.34.0`                                                     |
| [`0de0c604`](https://github.com/NixOS/nixpkgs/commit/0de0c6049ca8d44e90e0cbbd774b235eb62eae83) | `opaline: 0.3.2 -> 0.3.3`                                                             |
| [`abfcc2e0`](https://github.com/NixOS/nixpkgs/commit/abfcc2e0ffa1546d73f8df4373838f3c1275b392) | `mozillavpn: init at 2.7.1`                                                           |