### PR TITLE
chore(flake/nixpkgs): `e10e367d` -> `665bb90f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1649462329,
-        "narHash": "sha256-RFn4ZIA7/dW8Jjz1okEOCFjh3Hu1kHCR176A8NqCtV8=",
+        "lastModified": 1649549506,
+        "narHash": "sha256-flgjQ/ZTxobJJS3QWmecyfkYO5j+/WC0IKzyWvK/fs0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e10e367defcb64675f021e82cc9e0a0f4ec4f0b4",
+        "rev": "665bb90fc3f6c39cfb290ecc100b3433082e5d64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                     |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`665bb90f`](https://github.com/NixOS/nixpkgs/commit/665bb90fc3f6c39cfb290ecc100b3433082e5d64) | `qemu: remove redundant copy of qemu-ga`                                           |
| [`c60f46b8`](https://github.com/NixOS/nixpkgs/commit/c60f46b8f341ab04fcf51b89d872f9507d5bd91e) | `matrix-synapse-tools.synadm: 0.33.1 -> 0.34`                                      |
| [`9dba703f`](https://github.com/NixOS/nixpkgs/commit/9dba703fbd4c74f5712cb4a6114b51b079fe75c6) | `python3Packages.asdf: 2.10.1 -> 2.11.0`                                           |
| [`ae3b36d8`](https://github.com/NixOS/nixpkgs/commit/ae3b36d8053bbb581cd5220c3f3440cbb532ab5e) | `python3Package.asdf-transform-schemas: init at 0.2.2`                             |
| [`0a793b83`](https://github.com/NixOS/nixpkgs/commit/0a793b83f3fb9036a769e598eda222caafe7c27e) | `python3Packages.asdf-standard: init at 1.0.1`                                     |
| [`180b51bf`](https://github.com/NixOS/nixpkgs/commit/180b51bf25b74e0ced3611c1663643f426bca3cc) | `haskellPackages: mark builds failing on hydra as broken`                          |
| [`e27f7cdd`](https://github.com/NixOS/nixpkgs/commit/e27f7cdd74b2711dc87ed31ace326e2986eda349) | `python3Packages.slixmpp: 1.8.1 -> 1.8.2`                                          |
| [`96f5fb2a`](https://github.com/NixOS/nixpkgs/commit/96f5fb2a139bd479593f2f186cf5969858f4ccc9) | `python3Packages.losant-rest: 1.16.0 -> 1.16.1`                                    |
| [`bc2af61b`](https://github.com/NixOS/nixpkgs/commit/bc2af61be5579e04f2fee34f234f007f17cf8434) | `python3Packages.hahomematic: 1.0.6 -> 1.1.0`                                      |
| [`c92de474`](https://github.com/NixOS/nixpkgs/commit/c92de4744196b390d2cf11e5d631f37cffa0ae96) | `python3Packages.ghapi: 0.1.19 -> 0.1.20`                                          |
| [`2d8f379e`](https://github.com/NixOS/nixpkgs/commit/2d8f379ee0f0482265237d71416b31304b197c11) | `python3Packages.aio-georss-gdacs: 0.6 -> 0.7`                                     |
| [`851000e6`](https://github.com/NixOS/nixpkgs/commit/851000e64e907dd5293bd4e079b4ab8bfbee5e79) | `python3Packages.aio-georss-client: 0.9 -> 0.10`                                   |
| [`c67fa73b`](https://github.com/NixOS/nixpkgs/commit/c67fa73bf9bb4aaea660118c7cd79b1dc9841905) | `python3Packages.astropy-extension-helpers: disable on older Python releases`      |
| [`26846a34`](https://github.com/NixOS/nixpkgs/commit/26846a348e53fde832072344adda423818c0bdda) | `httpx: 1.2.0 -> 1.2.1`                                                            |
| [`8f6854ac`](https://github.com/NixOS/nixpkgs/commit/8f6854ac153547ed49399c3b1b74325211bb4223) | `scaleway-cli: 2.4.0 -> 2.5.1`                                                     |
| [`6dd377e3`](https://github.com/NixOS/nixpkgs/commit/6dd377e367e011f365e558b0039a8bf67d250961) | `ocamlPackages.ptime: 0.8.5 -> 0.8.6`                                              |
| [`1c334eff`](https://github.com/NixOS/nixpkgs/commit/1c334eff79c1f0cace046bbda1ee05f190f5eca6) | `gallery-dl: 1.21.0 -> 1.21.1`                                                     |
| [`c9346a6a`](https://github.com/NixOS/nixpkgs/commit/c9346a6ac842706b2b3533603300654b515abf3f) | `bluespec: 2021.07 -> 2022.01`                                                     |
| [`00db31b9`](https://github.com/NixOS/nixpkgs/commit/00db31b93c8004348ec1954606c4ac88b9207ed5) | `librewolf: 98.0.2-1 -> 99.0-1`                                                    |
| [`605ba3fa`](https://github.com/NixOS/nixpkgs/commit/605ba3fa7b52c48af2e2588eac1c708b6f18cdad) | `mame: use lua 5.3`                                                                |
| [`003f0f80`](https://github.com/NixOS/nixpkgs/commit/003f0f801a26b03f3730e45cb4516deed21bbd29) | `witness: 0.1.6 -> 0.1.7`                                                          |
| [`92202813`](https://github.com/NixOS/nixpkgs/commit/922028139c33aad8d70381999ea579263ef338fd) | `upwork: 5.6.10.1 -> 5.6.10.7`                                                     |
| [`84b7eb9a`](https://github.com/NixOS/nixpkgs/commit/84b7eb9a1819a787f2c6ae557bc295988254b86e) | `remind: 03.04.02 -> 04.00.00`                                                     |
| [`88e6baf8`](https://github.com/NixOS/nixpkgs/commit/88e6baf83235bcca1e4335f5978f69b4126f70cf) | `octave: Remove JIT support (removed upstream)`                                    |
| [`99be8cc3`](https://github.com/NixOS/nixpkgs/commit/99be8cc32d79425550775ead29bd4f1162f25061) | `python3Packages.gremlinpython: 3.5.1 -> 3.6.0`                                    |
| [`38a9ef81`](https://github.com/NixOS/nixpkgs/commit/38a9ef814bcbcc9e6265c99fe1e47cb67b06ac7d) | `ryujinx: 1.1.91 -> 1.1.100`                                                       |
| [`41234df5`](https://github.com/NixOS/nixpkgs/commit/41234df5c67e927b108ea4a070d70b494de2df33) | `pythonPackages.polars: init at 0.13.19`                                           |
| [`e5691468`](https://github.com/NixOS/nixpkgs/commit/e56914680c8a2bbc704da02fa78b833d048e46a9) | `libsForQt5.qtutilities: 6.5.3 -> 6.6.0`                                           |
| [`a876b46f`](https://github.com/NixOS/nixpkgs/commit/a876b46fef86ddc616ed36e59d80895ec83d3661) | `nixos/release-notes: add programs.nethoscope`                                     |
| [`c57232d3`](https://github.com/NixOS/nixpkgs/commit/c57232d31cccfee6444bdd9dcddad95f816f85f2) | `programs/nethoscope: add security.wrapper`                                        |
| [`ce56f53d`](https://github.com/NixOS/nixpkgs/commit/ce56f53d3272901bb96972239bc254df5b56c703) | `nethoscope: init at 0.1.1`                                                        |
| [`9b227257`](https://github.com/NixOS/nixpkgs/commit/9b227257e9de7d8ce04954ab556e64ee8218ce9c) | `python3Packages.astroquery: fix build and restore tests`                          |
| [`bba4dd5d`](https://github.com/NixOS/nixpkgs/commit/bba4dd5dd2b26d4be1c10434c56de5f83c9a81a1) | `python3Packages.pyvo: init at 1.3`                                                |
| [`71e504ff`](https://github.com/NixOS/nixpkgs/commit/71e504ff21517889f334ffd3f027c2388a3ad44c) | ``scmpuff: remove unnecessary `platforms```                                        |
| [`15313692`](https://github.com/NixOS/nixpkgs/commit/15313692cdad6fc066bfa4c441ada9bb9b10804a) | `mastodon.updateScript: use correct input for nix-prefetch-git, better formatting` |
| [`6a441683`](https://github.com/NixOS/nixpkgs/commit/6a441683a0556f29fc416413b41aab88a3226a62) | `mastodon: 3.5.0 -> 3.5.1`                                                         |
| [`3d94275c`](https://github.com/NixOS/nixpkgs/commit/3d94275c1555d429503421d518bc3d1c429f5516) | ``maintainers: add `samyak```                                                      |
| [`36d4734b`](https://github.com/NixOS/nixpkgs/commit/36d4734b641de3c62c207b93ceb520d29e43365a) | `toipe: init at 0.3.1`                                                             |
| [`75ffac01`](https://github.com/NixOS/nixpkgs/commit/75ffac013cf34a7ccb34a003390f20cce24bd1bc) | ``maintainers: fix `loicreynier```                                                 |
| [`16998f56`](https://github.com/NixOS/nixpkgs/commit/16998f568b4bbf3706cede067dc3d86441fe4d4f) | `crystal-builder: support the new crystal2nix format`                              |
| [`23f619dc`](https://github.com/NixOS/nixpkgs/commit/23f619dca7bcde1e827f632f46e77e58abca2d0a) | `routinator: 0.11.0 -> 0.11.1`                                                     |
| [`d90962e7`](https://github.com/NixOS/nixpkgs/commit/d90962e7ed929b1231cb4709ab81f76f200d1cb4) | `croc: 9.5.2 -> 9.5.3`                                                             |
| [`3a8da578`](https://github.com/NixOS/nixpkgs/commit/3a8da578a7dd4a19b31303915ca831191d0f1511) | `nixos/pam_mount: add more config options`                                         |
| [`b20a1c34`](https://github.com/NixOS/nixpkgs/commit/b20a1c34c2c387d9eee230be3341db7993131c23) | `nixos/pam: fix pam_mount called multiple times`                                   |
| [`3681f292`](https://github.com/NixOS/nixpkgs/commit/3681f292a07907f397f17cc8d2e765debfdc4922) | `python310Packages.whodap: 0.1.4 -> 0.1.5`                                         |
| [`0e46be9a`](https://github.com/NixOS/nixpkgs/commit/0e46be9abb0b909b18434ea026030f11b242b118) | `openethereum: 3.2.6 -> 3.3.5`                                                     |
| [`7f4f71d3`](https://github.com/NixOS/nixpkgs/commit/7f4f71d3e7f915a694ef1089243c4ce098219fac) | `mame: add patch to disable PDF documentation`                                     |
| [`38f35736`](https://github.com/NixOS/nixpkgs/commit/38f3573664a46300a60b60c39b456637e6104b60) | `credhub-cli: 2.9.1 -> 2.9.3`                                                      |
| [`5e868ecb`](https://github.com/NixOS/nixpkgs/commit/5e868ecb7fbc77859afcc6eea4de3d0ba4a679d6) | `haskellPackages: regenerate package set based on current config`                  |
| [`d0fb4235`](https://github.com/NixOS/nixpkgs/commit/d0fb4235c4312f31a770f200be15fd56dda92693) | `xgboost: fix eval without aliases`                                                |
| [`f2f10367`](https://github.com/NixOS/nixpkgs/commit/f2f10367b9e1b955d4f0fdf41ba6d44daac05a89) | `haskell.compiler.ghc8107Binary: build on aarch64 on Hydra`                        |
| [`df0feb7a`](https://github.com/NixOS/nixpkgs/commit/df0feb7a1fa9170fe509bd3758e33c5ca333e13f) | `elementary-xfce-icon-theme: transfer maintainership to xfce team`                 |
| [`d186f76c`](https://github.com/NixOS/nixpkgs/commit/d186f76cefb58b61e5c8a72a7188b269032116f7) | `mame: use system libraries when possible`                                         |
| [`eca01bff`](https://github.com/NixOS/nixpkgs/commit/eca01bff99ffbc88b30078d291b5ae997769b076) | `deltachat-desktop: 1.28.1 -> 1.28.2`                                              |
| [`aec46d1e`](https://github.com/NixOS/nixpkgs/commit/aec46d1e405726abffa3c421be86951ecc552165) | `mame: 0.239 -> 0.242`                                                             |
| [`876b195e`](https://github.com/NixOS/nixpkgs/commit/876b195ecc9f596c9f84670a511fb047c201b0f6) | `mame: add updateScript`                                                           |
| [`e8e1cccd`](https://github.com/NixOS/nixpkgs/commit/e8e1cccd58436917e7f5082797bccb577f2ce592) | `python3Packages.python-binance: add format`                                       |
| [`bc45ba10`](https://github.com/NixOS/nixpkgs/commit/bc45ba1038748effb1862645077fc3ab6be3b4db) | `foliate: Minor cleanup`                                                           |
| [`56f79db0`](https://github.com/NixOS/nixpkgs/commit/56f79db0ba428f392c60a702ec07279fc3454958) | `scmpuff: 0.3.0 -> 0.5.0`                                                          |
| [`5dadb0d9`](https://github.com/NixOS/nixpkgs/commit/5dadb0d98b87d903f9c4eecd0b37a34e6c00561e) | `wstunnel: fix build`                                                              |
| [`375eaf2b`](https://github.com/NixOS/nixpkgs/commit/375eaf2b4fce26764ccddf347a0b422a82fe8e2b) | `terraform-full: Fix eval (#167857)`                                               |
| [`7d691ead`](https://github.com/NixOS/nixpkgs/commit/7d691eadc377619481f6b3acdbcc7df91d2524b8) | `ipxe: 1.21.1 -> unstable-2022-04-06`                                              |
| [`84b890e8`](https://github.com/NixOS/nixpkgs/commit/84b890e86117849e0fb20dbd85ba7a164c1461db) | `python310Packages.sabyenc3: 5.1.6 -> 5.1.7`                                       |
| [`ba944d42`](https://github.com/NixOS/nixpkgs/commit/ba944d42b3174ef48438ffcf70b44b7df5cf5256) | `bcachefs-tools: unstable-2022-03-22 -> unstable-2022-04-08`                       |
| [`3bc83026`](https://github.com/NixOS/nixpkgs/commit/3bc830267e9f6dd7255958baed9a973d03c794ba) | `linux_testing_bcachefs: unstable-2022-03-21 -> unstable-2022-04-08`               |
| [`81e9dbc4`](https://github.com/NixOS/nixpkgs/commit/81e9dbc4cf05615bd3101561decff4e4b3c01fe9) | `python310Packages.stripe: 2.70.0 -> 2.71.0`                                       |
| [`1d63f89c`](https://github.com/NixOS/nixpkgs/commit/1d63f89caaf140ac33f1796dc0aaeb20f4ac4e55) | `cudaPackages: overhaul of how we package cuda packages`                           |
| [`c5aa205d`](https://github.com/NixOS/nixpkgs/commit/c5aa205dd5258489f3315791a69421a2d181822e) | `python310Packages.python-binance: 1.0.10 -> 1.0.16`                               |
| [`49ec9e33`](https://github.com/NixOS/nixpkgs/commit/49ec9e33e9ab3be35645fd13ffec5419e3459bea) | `python310Packages.pex: 2.1.77 -> 2.1.78`                                          |
| [`efc8de69`](https://github.com/NixOS/nixpkgs/commit/efc8de690c438add3e6175c0eb285fd4e562f8c0) | `dprint: 0.22.2 -> 0.24.3`                                                         |
| [`61516367`](https://github.com/NixOS/nixpkgs/commit/615163679e5c9053d9d3a8ba2fc8897689bc4ab2) | `cargo-about: 0.5.0 -> 0.5.1`                                                      |
| [`3852ba68`](https://github.com/NixOS/nixpkgs/commit/3852ba6881dc5f56dc2a09727287e26c7426ba0e) | `gping: 1.3.0 -> 1.3.1`                                                            |
| [`07ef761f`](https://github.com/NixOS/nixpkgs/commit/07ef761ff04cb0bcf5736368e56590ae8d4c04cc) | `i3status-rust: 0.21.8 -> 0.21.9`                                                  |
| [`f3fc2a53`](https://github.com/NixOS/nixpkgs/commit/f3fc2a5320d9b23fe713d3ebead6815fe7698383) | `jql: 3.2.0 -> 3.2.4`                                                              |
| [`9bea21d0`](https://github.com/NixOS/nixpkgs/commit/9bea21d0c418aceeb451a84099bf0d3849cccd05) | `datafusion-cli: init at unstable-2022-04-08`                                      |
| [`9dec3ecd`](https://github.com/NixOS/nixpkgs/commit/9dec3ecd7086f7384ebef8a6475f4599071fa6d0) | `eksctl: 0.91.0 -> 0.92.0`                                                         |
| [`1e29572c`](https://github.com/NixOS/nixpkgs/commit/1e29572c5770acad2a0448228220a3dfdaa1d850) | `resholve: add release note for API reorg`                                         |
| [`368346c5`](https://github.com/NixOS/nixpkgs/commit/368346c5a13a5c5c6f6dfbe5e7719c3065ce3429) | `resholve: track API update in dependent packages`                                 |
| [`09d441d2`](https://github.com/NixOS/nixpkgs/commit/09d441d21c547254cbd6eb2f2ba8f079b2a16a32) | `resholve: 0.6.9 -> 0.8.0`                                                         |
| [`9a83d8ce`](https://github.com/NixOS/nixpkgs/commit/9a83d8ce9490bc240518440f66e9366c6cab1de7) | `binlore: 0.1.4 -> 0.2.0`                                                          |
| [`ec1fbd13`](https://github.com/NixOS/nixpkgs/commit/ec1fbd13615e0d0bde557961394285527a8b201a) | `threema-desktop: 1.0.3 -> 1.2.0`                                                  |
| [`8ab5294e`](https://github.com/NixOS/nixpkgs/commit/8ab5294ee950f99b7c3898d848cb61f7852ebb39) | `pipenv: 2022.3.28 -> 2022.4.8`                                                    |
| [`445ad286`](https://github.com/NixOS/nixpkgs/commit/445ad286a05f03e96ac7826e8d5f678bebe66407) | `python310Packages.hid: 1.0.4 -> 1.0.5`                                            |
| [`351814a1`](https://github.com/NixOS/nixpkgs/commit/351814a1512cf522cefef35227058a24c242240b) | `postgresql11Packages.plpgsql_check: 2.1.2 -> 2.1.3`                               |
| [`f34e6466`](https://github.com/NixOS/nixpkgs/commit/f34e646637cd4a1934fb097027f81543202d663c) | `python310Packages.greeclimate: 1.1.0 -> 1.1.1`                                    |
| [`aefc117a`](https://github.com/NixOS/nixpkgs/commit/aefc117a59d13760e85063e8cffce5e0ae993c6b) | `python310Packages.gradient: 1.10.0 -> 1.11.0`                                     |
| [`cb2cd8f2`](https://github.com/NixOS/nixpkgs/commit/cb2cd8f23f58b974b6270fd3c9f3e480498a0a7a) | `python310Packages.globus-sdk: 3.6.0 -> 3.7.0`                                     |
| [`4eeab0f0`](https://github.com/NixOS/nixpkgs/commit/4eeab0f0ab8db80a572d1fd223a3c004af5d5b2e) | `haskell.compiler.ghcHEAD: 9.3.20211111 -> 9.3.20220406`                           |
| [`eab6133b`](https://github.com/NixOS/nixpkgs/commit/eab6133b18ac806a5ca0894c0728d34b5fa935a3) | `libretro: rename script`                                                          |
| [`5f80a7ad`](https://github.com/NixOS/nixpkgs/commit/5f80a7ad986a684bfc4cf9fff2dbbe34fe92d116) | `python3Packages.fipy: fix broken build`                                           |
| [`3c1b1480`](https://github.com/NixOS/nixpkgs/commit/3c1b148066610e9afc864bcea8fad4942ca14873) | `libretro: unstable-2022-04-05 -> unstable-2022-04-08`                             |
| [`13188121`](https://github.com/NixOS/nixpkgs/commit/13188121a48fd453dc45f31fee649a7a57e1117f) | `libretro.hatari: simplify build`                                                  |
| [`1ba13633`](https://github.com/NixOS/nixpkgs/commit/1ba13633adf68378034d73ea732b0244bfbde66d) | `php74Extensions.xdebug: 3.1.3 -> 3.1.4`                                           |
| [`fbf65094`](https://github.com/NixOS/nixpkgs/commit/fbf65094b0418097f3c5dc31f031660c3f8f37ad) | `php74Packages.phpstan: 1.5.3 -> 1.5.4`                                            |
| [`d7c3643e`](https://github.com/NixOS/nixpkgs/commit/d7c3643e6e1e242a4e692b51d43a80f0c7b3a1e3) | `tor-browser-bundle-bin: 11.0.9 -> 11.0.10`                                        |
| [`5e40bd33`](https://github.com/NixOS/nixpkgs/commit/5e40bd3313ffb111135b49052754a2f463f025d1) | `git-branchless: 0.3.10 -> 0.3.12`                                                 |
| [`82040f52`](https://github.com/NixOS/nixpkgs/commit/82040f52c9129f10f18e61e40b9521e311e34cf4) | `pdns-recursor: 4.6.1 -> 4.6.2`                                                    |
| [`e6acb0c6`](https://github.com/NixOS/nixpkgs/commit/e6acb0c6a8b18bbb598616cc5845be735ae4e31b) | `libretro.citra: fix build`                                                        |
| [`dfc0ddaa`](https://github.com/NixOS/nixpkgs/commit/dfc0ddaa871f470e5643947256ca60d751cda502) | `wiki-js: 2.5.276 -> 2.5.277`                                                      |
| [`2e2aed71`](https://github.com/NixOS/nixpkgs/commit/2e2aed71002ade3bc5291faea27470cbb43be204) | `wiki-js: add update script`                                                       |
| [`7c4c28b2`](https://github.com/NixOS/nixpkgs/commit/7c4c28b2ca7685a369813dc3bed644ea4c1ceb50) | `libretro.citra-canary: remove it`                                                 |
| [`fea4c06e`](https://github.com/NixOS/nixpkgs/commit/fea4c06edeed4ba4ff899c15b76fa713043d3637) | `libretro: unstable-2022-03-09 -> unstable-2022-04-05`                             |
| [`19ea6302`](https://github.com/NixOS/nixpkgs/commit/19ea6302e381835fe1fc19cdfaced7d83c4e47d8) | `retroarch: 1.10.1 -> 1.10.2`                                                      |
| [`f5241283`](https://github.com/NixOS/nixpkgs/commit/f5241283fd965edfcbf33e6e6bbca1e22adc036f) | `libretro: unstable-2022-01-21 -> unstable-2022-03-09`                             |
| [`e0eeb37b`](https://github.com/NixOS/nixpkgs/commit/e0eeb37b38212ff33379d26650131a3af3bc3de5) | `retroarch: 1.10.0 -> 1.10.1`                                                      |
| [`6b4c7368`](https://github.com/NixOS/nixpkgs/commit/6b4c7368fa83180853063373a5b7e332fe44363c) | `retroarchBare: re-add support to Darwin`                                          |
| [`bd1e8ccf`](https://github.com/NixOS/nixpkgs/commit/bd1e8ccfefc954e61861c3ee106e7a5474fe1a4a) | `octave: 6.4.0 -> 7.1.0`                                                           |
| [`0637d548`](https://github.com/NixOS/nixpkgs/commit/0637d548543b75be9de785bc22d2ccb79974f1a3) | `doit: 0.34.2 -> 0.35.0`                                                           |
| [`59cb94fb`](https://github.com/NixOS/nixpkgs/commit/59cb94fb28181b9d974ba0fd9812cbb87c144e9b) | `python3Packages.astropy-extension-helpers: 0.1 -> 1.0.0`                          |
| [`156bacf9`](https://github.com/NixOS/nixpkgs/commit/156bacf937734e0f9cf4a211067c29daacd8cef9) | `morgen: 2.5.0 -> 2.5.2`                                                           |
| [`0d2748ca`](https://github.com/NixOS/nixpkgs/commit/0d2748ca8a1179c5c804fe1d5011f71c777e35d4) | `notcurses: 3.0.7 -> 3.0.8`                                                        |
| [`55cfd2ef`](https://github.com/NixOS/nixpkgs/commit/55cfd2ef53583e60e8f337a93ae1db9b1a3d7ca3) | `nm-tray: 0.4.3 -> 0.5.0`                                                          |
| [`f0bc2c78`](https://github.com/NixOS/nixpkgs/commit/f0bc2c78743d3fa3b858a28d298257a26eab6fd6) | `flat-remix-gnome: 20211223 -> 20220407`                                           |
| [`1bf8e7a8`](https://github.com/NixOS/nixpkgs/commit/1bf8e7a811034a24a62927ccda475f07406ac01e) | `pre-commit: Add libiconv for tests on x86_64-darwin`                              |
| [`ec2a87e3`](https://github.com/NixOS/nixpkgs/commit/ec2a87e36df0d19d484d6c0af2b44d09870204c8) | `mongodb-compass: 1.31.0 -> 1.31.1`                                                |
| [`826f849a`](https://github.com/NixOS/nixpkgs/commit/826f849af768a1079ecd803ddad2419734fc8778) | `lrzip: 0.650 -> 0.651`                                                            |
| [`f79ae019`](https://github.com/NixOS/nixpkgs/commit/f79ae01933f8ea8f7a2dbf4cbb283165c042ce51) | `vscodium: 1.66.0 -> 1.66.1`                                                       |
| [`457dbe93`](https://github.com/NixOS/nixpkgs/commit/457dbe93705bd314737a7e337a0a2dd6c2505ecd) | `libqalculate: 4.1.0 -> 4.1.1`                                                     |
| [`af9cad4c`](https://github.com/NixOS/nixpkgs/commit/af9cad4c9427ef795ba71aa09e05b91b8b817a75) | `vscode: 1.66.0 -> 1.66.1`                                                         |
| [`490ec6a9`](https://github.com/NixOS/nixpkgs/commit/490ec6a9c1e6a5693f1759bc9432804216a941f5) | `release-haskell.nix: test all haskell based elmPackages`                          |
| [`09c71b6c`](https://github.com/NixOS/nixpkgs/commit/09c71b6c614559e73224e6e3b9a11f6c584fdb06) | `flyctl: 0.0.310 -> 0.0.314`                                                       |
| [`dcbabe12`](https://github.com/NixOS/nixpkgs/commit/dcbabe12219785c66f3bbc688b4f80a39f7446c9) | `esbuild: 0.14.29 -> 0.14.32`                                                      |
| [`06438e67`](https://github.com/NixOS/nixpkgs/commit/06438e6783834d10a6c0bb08fc88cb4352d34d01) | `cloudflared: 2022.3.4 -> 2022.4.0`                                                |
| [`f0da4d8e`](https://github.com/NixOS/nixpkgs/commit/f0da4d8ea28992b9f619e50ccf63efc146dcf788) | `haskell.packages.ghc922.hls-fourmolu-plugin: jailbreak`                           |
| [`af7c34be`](https://github.com/NixOS/nixpkgs/commit/af7c34be0b874493e10df040da137e2611a3e237) | `rustfmt: drop separate nightly alias`                                             |
| [`dedab357`](https://github.com/NixOS/nixpkgs/commit/dedab357c81905e785d13a7162c58d9b6e797eda) | `super-slicer: 2.3.57.10 -> 2.3.57.12`                                             |
| [`b46cbe49`](https://github.com/NixOS/nixpkgs/commit/b46cbe495cc4e24da4fed89f1f9eb589a10d1aad) | `pantheon.switchboard-plug-keyboard: 2.6.0 -> 2.7.0`                               |
| [`abc7fcc7`](https://github.com/NixOS/nixpkgs/commit/abc7fcc7d446b986b6d1351471cb96b5be003ae4) | `pantheon.elementary-notifications: 6.0.0 -> 6.0.1`                                |
| [`53b09d37`](https://github.com/NixOS/nixpkgs/commit/53b09d37915148d2ecd5445b0805aeadc88046ec) | `pantheon.gala: 6.3.0 -> 6.3.1`                                                    |
| [`504b2dba`](https://github.com/NixOS/nixpkgs/commit/504b2dba55b3c95e6507a80803f9671e07dcf65c) | `armadillo: 10.8.2 -> 11.0.0`                                                      |
| [`3bde7576`](https://github.com/NixOS/nixpkgs/commit/3bde7576132241b83f37d53d09bac5ba8458a1ee) | `haskellPackages.hint: disable tests`                                              |
| [`216f2754`](https://github.com/NixOS/nixpkgs/commit/216f2754c5fc561d429342edbcb0ade6c56b010e) | `niv: build using up to date dependencies`                                         |
| [`d317a29a`](https://github.com/NixOS/nixpkgs/commit/d317a29a606c54b47fcc2f23ce07ea29d353a258) | `haskellPackages: regenerate package set based on current config`                  |
| [`28ca22e7`](https://github.com/NixOS/nixpkgs/commit/28ca22e7d00171eb3c27e2942573785edaf19836) | `haskellPackages: stackage LTS 19.1 -> LTS 19.2`                                   |
| [`493062e5`](https://github.com/NixOS/nixpkgs/commit/493062e5fa31fa46da461f3289c588928382bb05) | `all-cabal-hashes: 2022-04-03T10:13:27Z -> 2022-04-06T22:24:53Z`                   |
| [`3da361fa`](https://github.com/NixOS/nixpkgs/commit/3da361fa40c8279695ea0a93dda4836a987f160d) | `jenkins: 2.332.1 -> 2.332.2`                                                      |