### PR TITLE
chore(flake/nixpkgs): `8753d892` -> `e1118817`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1649593102,
-        "narHash": "sha256-WUuFr7Nl0l45hdN9sKklMUx0rM6E3tG1+UgPWhDUkUY=",
+        "lastModified": 1649784051,
+        "narHash": "sha256-XN6gEvLzUglWIClT1CyyriZfcAhdFj28krCtWLJ/UBI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8753d89223921ca9993ae2524277f0c6492fa2b4",
+        "rev": "e1118817a12dba39081d9e70ae52dd38aa184c2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                         |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`72f3b1a4`](https://github.com/NixOS/nixpkgs/commit/72f3b1a4d1cb99ed41f5794fd17cdb8814480f8f) | `coqPackages.CoLoR: 1.8.1 → 1.8.2`                                                     |
| [`592dc9ed`](https://github.com/NixOS/nixpkgs/commit/592dc9ed7f049c565e9d7c04a4907e57ae17e2d9) | `jellyfin-web: add platforms`                                                          |
| [`7be04844`](https://github.com/NixOS/nixpkgs/commit/7be04844b0bd05be311704edbb4f205a6f7a3110) | `jellyfin: add platforms`                                                              |
| [`b56b2401`](https://github.com/NixOS/nixpkgs/commit/b56b2401b8be1c722d751af1e88b2d3f1db94c30) | `basiliskii: init at unstable-2022-04-05`                                              |
| [`7aa2c5cf`](https://github.com/NixOS/nixpkgs/commit/7aa2c5cfb4c771302c4bcd2f38d0590952bf93df) | `openvpn: use update-systemd-resolved instead of vendoring it`                         |
| [`adbf08f9`](https://github.com/NixOS/nixpkgs/commit/adbf08f9ec3247e43e444c57bac01b52dd648ac6) | `update-systemd-resolved: inject PATH to avoid wrapping`                               |
| [`983a9f4b`](https://github.com/NixOS/nixpkgs/commit/983a9f4bb6fa8f450e932cba57e73c2bf70792bd) | `ocamlPackages.phylogenetics: 0.0.0 -> 0.1.0`                                          |
| [`0a2f8109`](https://github.com/NixOS/nixpkgs/commit/0a2f8109f4781a9489301b7af90e8f05d189fde9) | `abc-verifier: 2022.03.04 -> 2022.03.22`                                               |
| [`338ce3ed`](https://github.com/NixOS/nixpkgs/commit/338ce3ed6a02ab7a236a82ffab9e7f7bd5e6a760) | `yosys: 0.15 -> 0.16`                                                                  |
| [`dacbee21`](https://github.com/NixOS/nixpkgs/commit/dacbee21829cdac656711a5362e6eca90d4c2da6) | ``util-linux: remove `? null` from inputs and convert to boolean flags``               |
| [`135dbd8e`](https://github.com/NixOS/nixpkgs/commit/135dbd8ec1f171d1373dfbcd1b669bbf835dad90) | `util-linuxCurses: move to aliases`                                                    |
| [`c3b1a3bb`](https://github.com/NixOS/nixpkgs/commit/c3b1a3bbf41439235e31c8f45a59546650832f95) | `yq-go: 4.24.2 -> 4.24.4`                                                              |
| [`e45e7cab`](https://github.com/NixOS/nixpkgs/commit/e45e7cab9af6076075c0ecfed97de8f01043026a) | `loki: 2.4.2 -> 2.5.0`                                                                 |
| [`a8f27b19`](https://github.com/NixOS/nixpkgs/commit/a8f27b19daa85a858b58f004a122e48e8ef63ea5) | `atuin: 0.8.0 -> 0.8.1`                                                                |
| [`9e4ba681`](https://github.com/NixOS/nixpkgs/commit/9e4ba681fddd06b0d84048e3b512f86ce9f8131d) | `openjdk: add support for powerpc64le`                                                 |
| [`3bbfc784`](https://github.com/NixOS/nixpkgs/commit/3bbfc7849e9ab88ffac01a16b214e54862572c4c) | `nixos/prometheus: Remove upstream-deprecated alertManagerTimeout`                     |
| [`24ce3fcf`](https://github.com/NixOS/nixpkgs/commit/24ce3fcf7c756389d955b2334840089c194690b9) | `python311: 3.11.0a6 -> 3.11.0a7`                                                      |
| [`3966e8d6`](https://github.com/NixOS/nixpkgs/commit/3966e8d69d6817b5a327d0f26a1f6666b6b25868) | `home-assistant: update component packages`                                            |
| [`ce697cdf`](https://github.com/NixOS/nixpkgs/commit/ce697cdfa8776187760033cc3d46151c010d9991) | `home-assistant: allow requirements parser to deal with extras`                        |
| [`612a4ba5`](https://github.com/NixOS/nixpkgs/commit/612a4ba51fb02e5e61d556bdfa67561c9e000600) | `python310Packages.pure-python-adb: disable tests`                                     |
| [`139ba48b`](https://github.com/NixOS/nixpkgs/commit/139ba48b97da3e3dcbd7bc4bd946e89fb711ec83) | `python3Packages.pure-python-adb: split off async requirements`                        |
| [`83f634c4`](https://github.com/NixOS/nixpkgs/commit/83f634c4e4a39352465ada45c4c90b4f4ee28dbe) | `python3Packages.androidtv: split off extra requires`                                  |
| [`aa90072f`](https://github.com/NixOS/nixpkgs/commit/aa90072fc9ed83aa646a947ef3ca741beb11f702) | `python3Packages.adb-shell: split off extra requires`                                  |
| [`e365a5bc`](https://github.com/NixOS/nixpkgs/commit/e365a5bc06b466245b5d206f4e7ad6ff423de2c7) | `python3Packages.pytradfri: split off async extra`                                     |
| [`7d4be895`](https://github.com/NixOS/nixpkgs/commit/7d4be895ad489fcabc68831eceecc645d5d626e0) | `python3Packages.samsungctl: split off websocket extra`                                |
| [`7b12ac7d`](https://github.com/NixOS/nixpkgs/commit/7b12ac7d5813513c658770e2ca1d3d57662369f1) | `python3Packages.samsungtvws: enable tests, split off extras`                          |
| [`7e288190`](https://github.com/NixOS/nixpkgs/commit/7e2881905c9c7af1e7a9f73fbebfc154370b9f5e) | `python3Packages.py3rijndael: init at 0.3.3`                                           |
| [`3957a12e`](https://github.com/NixOS/nixpkgs/commit/3957a12e9d51489a11e64d4c5d64bfb263beac25) | `python3Packages.pygatt: split off GATTTOOL extra`                                     |
| [`9a089988`](https://github.com/NixOS/nixpkgs/commit/9a0899888935a4469d82362f8ef88030673a3325) | `lisgd: 0.3.2 -> 0.3.3`                                                                |
| [`ac71310d`](https://github.com/NixOS/nixpkgs/commit/ac71310ddc5b4a4e662eafeff9aed785b47c54c9) | `stylua: 0.13.0 -> 0.13.1`                                                             |
| [`dad93dbb`](https://github.com/NixOS/nixpkgs/commit/dad93dbbd3ef5f950c094bab6b7a39299ee796f5) | `invocieplane: Add patches for CVE-2021-29024, CVE-2021-29023`                         |
| [`82841125`](https://github.com/NixOS/nixpkgs/commit/82841125f55180291787dd56d190337510f4b9f6) | `assh: enable tests`                                                                   |
| [`b130f233`](https://github.com/NixOS/nixpkgs/commit/b130f233d6e2ca4d06989174e31ea17e35ea93ff) | `pipecontrol: init at 0.2.2 (#164808)`                                                 |
| [`271564ed`](https://github.com/NixOS/nixpkgs/commit/271564ed3c57e8e0fb7ae513ac0a63c35dbd55ea) | `glfw: remove merged X11 patch`                                                        |
| [`a26c5495`](https://github.com/NixOS/nixpkgs/commit/a26c5495cd40f6adb9e36cb68d1fa5300fa7f182) | `git: add reasonable defaults for boolean flags`                                       |
| [`bd3b4c54`](https://github.com/NixOS/nixpkgs/commit/bd3b4c54834e038e42c050b3486bfcf8d5ebdb6f) | `qtwebengine: honor pipewireSupport (#161018)`                                         |
| [`910e566d`](https://github.com/NixOS/nixpkgs/commit/910e566d350e282a45c3d5ed4b0f010adcdeb8be) | `qutebrowser: honor pipewireSupport (#161020)`                                         |
| [`ec0ae676`](https://github.com/NixOS/nixpkgs/commit/ec0ae67667c9d87f5ad79f7367aace1cbd8b7cce) | `plymouth: fix maintainer list`                                                        |
| [`e87240e2`](https://github.com/NixOS/nixpkgs/commit/e87240e2163a32f989eb43b9b7a4a562745c0c31) | `nixos/nginx: add extraParameters to http3 protocol`                                   |
| [`c508da30`](https://github.com/NixOS/nixpkgs/commit/c508da303b0e27b2d4003f0550e3ba3d79716b8f) | `nixos/nginx: add reuseport option`                                                    |
| [`660a36f1`](https://github.com/NixOS/nixpkgs/commit/660a36f173cfcf049623ed075d518bb753b0fbb8) | `nixos/nginx: fix http3 configuration`                                                 |
| [`3f7da58c`](https://github.com/NixOS/nixpkgs/commit/3f7da58c0b8c93bb225b3ab4ffd4db9278904ea6) | `python3Packages.sphinxcontrib-bibtex: disable on older Python releases`               |
| [`af31997f`](https://github.com/NixOS/nixpkgs/commit/af31997fe2823d292803799a85d5938fd6754da3) | `python310Packages.hahomematic: 1.1.0 -> 1.1.1`                                        |
| [`ffe759bb`](https://github.com/NixOS/nixpkgs/commit/ffe759bb5bc99c4b56db60f411961045b6db70a7) | `coqPackages.gappalib: 1.5.0 → 1.5.1`                                                  |
| [`f8be8367`](https://github.com/NixOS/nixpkgs/commit/f8be8367014bdc550732429b0988d14e832a1c81) | `cargo-deny: 0.11.3 -> 0.11.4`                                                         |
| [`3df2691e`](https://github.com/NixOS/nixpkgs/commit/3df2691e6b5500e853bb62591fce613603fc2478) | `nixos/stage-1-systemd: Handover between the systemds directly`                        |
| [`2ff94ac9`](https://github.com/NixOS/nixpkgs/commit/2ff94ac9d4c096c03f8e1338f0a435486afbb09e) | `python310Packages.pycfmodel: 0.18.2 -> 0.19.0`                                        |
| [`d123a1a5`](https://github.com/NixOS/nixpkgs/commit/d123a1a575560335079e7494655f165ed805ce02) | `gqrx: 2.15.8 -> 2.15.9`                                                               |
| [`7a32fdb1`](https://github.com/NixOS/nixpkgs/commit/7a32fdb1fe99937e506532005a2559c5f7162ae0) | `xmrig: 6.16.4 -> 6.17.0`                                                              |
| [`77d6781c`](https://github.com/NixOS/nixpkgs/commit/77d6781cdc7b472bc5d6991b5afc5b6c0928d3d6) | `openssl: specify the ABI explicitly on mips64`                                        |
| [`a51fea44`](https://github.com/NixOS/nixpkgs/commit/a51fea4403cac553ef31f8036c04fb946db0f75b) | `microcodeAmd, microcodeIntel: fix reproducibility`                                    |
| [`5e8f01e2`](https://github.com/NixOS/nixpkgs/commit/5e8f01e28e6f3a39fbf63f9159dd362d3a3291ef) | `python310Packages.sunpy: 3.1.4 -> 3.1.6`                                              |
| [`1258b99c`](https://github.com/NixOS/nixpkgs/commit/1258b99c8a5c4554d9988da325f84db47db2e5d8) | `aliyun-cli: 3.0.115 -> 3.0.116`                                                       |
| [`e0e7a0a7`](https://github.com/NixOS/nixpkgs/commit/e0e7a0a702d61ddb24ef519d40d916d5ef69f909) | `gnss-sdr: Fix build with boost patch`                                                 |
| [`1bc3080a`](https://github.com/NixOS/nixpkgs/commit/1bc3080a83280d8b2b0f4af06874b4b60c9ee436) | `gremlin-console: 3.5.2 -> 3.5.3`                                                      |
| [`e1a464b3`](https://github.com/NixOS/nixpkgs/commit/e1a464b3f8fd8ee6005b165bb0d8fb064ea877e7) | `n8n: 0.171.0 → 0.172.0`                                                               |
| [`22c4920c`](https://github.com/NixOS/nixpkgs/commit/22c4920c8062b3e35d3d12e9b4a5a8bfad0b80ef) | `cassandra.updateScript: Add signature check`                                          |
| [`d0dec918`](https://github.com/NixOS/nixpkgs/commit/d0dec918b5168334053bdd40122a09988eadb287) | `cassandra*: Refactor: store versions in JSON`                                         |
| [`efd55dbe`](https://github.com/NixOS/nixpkgs/commit/efd55dbef432a640c96af70a25693f038d91b805) | `cassandra.updateScript: Generate JSON`                                                |
| [`0038244d`](https://github.com/NixOS/nixpkgs/commit/0038244d60e1fa1da679f6b9e1046fde4325b49c) | `cassandra: Make updateScript update individual version`                               |
| [`ab554992`](https://github.com/NixOS/nixpkgs/commit/ab55499253468ea2be69d3760077073c17da9103) | `cassandra: Add updateScript`                                                          |
| [`bc50e0ec`](https://github.com/NixOS/nixpkgs/commit/bc50e0ec126ef55b96d3d75b4ddd62c8492c2568) | `python310Packages.pip-tools: 6.5.1 -> 6.6.0 (#167660)`                                |
| [`b6a852d5`](https://github.com/NixOS/nixpkgs/commit/b6a852d51d310a9cb514631490b5d2ca139f6c9a) | `kubescape: 2.0.150 -> 2.0.152`                                                        |
| [`e56a8b16`](https://github.com/NixOS/nixpkgs/commit/e56a8b16ebc794fe8cd3edf8c8d5f6f2ae35cb91) | `python310Packages.jupyterlab: 3.3.2 -> 3.3.3 (#167705)`                               |
| [`597ebfca`](https://github.com/NixOS/nixpkgs/commit/597ebfcae25188cb7a1de01c99f88299323c545e) | `astc-encoder: limit to 64-bit target architectures`                                   |
| [`ce686f05`](https://github.com/NixOS/nixpkgs/commit/ce686f05056e971be5d81f5ee4f34c434e5b98d4) | `oh-my-zsh: 2022-04-06 -> 2022-04-09 (#168073)`                                        |
| [`ee3d6e23`](https://github.com/NixOS/nixpkgs/commit/ee3d6e2354ee612345f4f798e441b7d053ee31c9) | `rust-analyzer-unwrapped: 2022-04-04 -> 2022-04-11`                                    |
| [`b2116b65`](https://github.com/NixOS/nixpkgs/commit/b2116b65610d1ca1c53237293305ceec446773ae) | `sonixd: init at 0.14.0`                                                               |
| [`46a3a7b9`](https://github.com/NixOS/nixpkgs/commit/46a3a7b9a247f77af0800ceefe868c37f9efe6a4) | `nixos/udev: remove rule for kqemu`                                                    |
| [`553189b3`](https://github.com/NixOS/nixpkgs/commit/553189b37462ede694d0138587cdab829f8d4828) | `gopls: 0.8.1 -> 0.8.2 (#168261)`                                                      |
| [`ef5a14b6`](https://github.com/NixOS/nixpkgs/commit/ef5a14b6ad54bc3508599e04b54580514871fbda) | `toipe: 0.3.1 -> 0.4.0`                                                                |
| [`63528cb1`](https://github.com/NixOS/nixpkgs/commit/63528cb1a6183fceb4f18ca1b74617eca8dd67a1) | ``nixos/systemd: remove duplicate definition of `systemd.user.timers```                |
| [`33772708`](https://github.com/NixOS/nixpkgs/commit/33772708c6d0e33f697426ba386aa0149cbcbecb) | `s2n-tls: disable unsupported feature (post-quantum cryptography) on mips64 (#161163)` |
| [`adab6ce5`](https://github.com/NixOS/nixpkgs/commit/adab6ce5527a8c87f87ed0cae60a020cf9a8d942) | `nixos/systemd-stage-1: Minor fixups`                                                  |
| [`3cc26915`](https://github.com/NixOS/nixpkgs/commit/3cc26915217f1bdf93bb883f504c05f72b182e4a) | `python310Packages.sphinxcontrib-bibtex: 2.4.1 -> 2.4.2`                               |
| [`55a070a6`](https://github.com/NixOS/nixpkgs/commit/55a070a61664412398e561d2fdac7ace618c44d6) | `wolfram-for-jupyter-kernel: init at 0.9.2`                                            |
| [`2055f853`](https://github.com/NixOS/nixpkgs/commit/2055f85304933814a367e816d010d769d6c4cb16) | `wolfram-engine: init at 13.0.1`                                                       |
| [`0fc32505`](https://github.com/NixOS/nixpkgs/commit/0fc325059423e2e38fda7373ea3448a30fca1484) | `wezterm: 20220319-142410-0fcdea07 -> 20220408-101518-b908e2dd`                        |
| [`2c1e6217`](https://github.com/NixOS/nixpkgs/commit/2c1e621741d74d88b8983cfb186713f6b5925c43) | `pcmsolver: replace python2 by python3 as build dependency`                            |
| [`a82378a7`](https://github.com/NixOS/nixpkgs/commit/a82378a76a28e0da67572cda4dc1f04eed0af9d9) | `pcmsolver: fix glibc >= 2.34 compatibility`                                           |
| [`7f67b9d3`](https://github.com/NixOS/nixpkgs/commit/7f67b9d301d443383f961e4597eec41a3e32850a) | `fits-cloudctl: 0.10.12 -> 0.10.13`                                                    |
| [`7fbeeb53`](https://github.com/NixOS/nixpkgs/commit/7fbeeb5382b061cc384b0ba763fdf8926ea8ee00) | `fennel: 1.0.0 -> 1.1.0`                                                               |
| [`af0e1375`](https://github.com/NixOS/nixpkgs/commit/af0e1375e412cd1dd063443ddf99ade6a661fe62) | `faustPhysicalModeling: 2.37.3 -> 2.40.0`                                              |
| [`68a880ec`](https://github.com/NixOS/nixpkgs/commit/68a880ecb172c3f94acdc344da2124ca5e44eea0) | `difftastic: 0.26.0 -> 0.26.3`                                                         |
| [`adc727d6`](https://github.com/NixOS/nixpkgs/commit/adc727d6f8367a1e84326007d2ef1a724575252e) | `python310Packages.editables: 0.2 -> 0.3`                                              |
| [`a59b03b3`](https://github.com/NixOS/nixpkgs/commit/a59b03b38a8139dbc70ddf4198e018253ca0ecf9) | `ejson2env: 2.0.2 -> 2.0.4`                                                            |
| [`e5ca3bbc`](https://github.com/NixOS/nixpkgs/commit/e5ca3bbc0a2116528f2a58c2bffb8bbb151aa1cf) | `unigine-tropics: init at 1.3`                                                         |
| [`17867e6f`](https://github.com/NixOS/nixpkgs/commit/17867e6fbccdfc8f8200490785e0151da61067b9) | `lapce: 0.0.10 -> 0.0.12`                                                              |
| [`e37855ba`](https://github.com/NixOS/nixpkgs/commit/e37855ba15f544eded14129d1759f789c69069ed) | `dnsproxy: 0.42.0 -> 0.42.1`                                                           |
| [`6bfb28f9`](https://github.com/NixOS/nixpkgs/commit/6bfb28f90db9e022491f05fc9f6c6457d5468b38) | `unixODBCDrivers.redshift: init at 1.4.49.1000`                                        |
| [`fa4f79ef`](https://github.com/NixOS/nixpkgs/commit/fa4f79ef636870ef01b1d12ee0645ab9d1b99413) | `abcmidi: 2022.02.21 -> 2022.03.20`                                                    |
| [`8505845d`](https://github.com/NixOS/nixpkgs/commit/8505845d24e6976a0f653c1ae490c21f6653845b) | `cmctl: 1.7.2 -> 1.8.0`                                                                |
| [`e321a614`](https://github.com/NixOS/nixpkgs/commit/e321a614e2707dbec7fa7d876d9d869d426a45ef) | `bullet: 3.22a -> 3.22b`                                                               |
| [`4ac8a78c`](https://github.com/NixOS/nixpkgs/commit/4ac8a78cbb9a03caba9675ad474cd55e6eba2168) | `netcdf: disable tests on aarch64-darwin`                                              |
| [`0caca7c4`](https://github.com/NixOS/nixpkgs/commit/0caca7c40f4c44f065d7bd4156d0ada550ce77e0) | `chezmoi: 2.15.0 -> 2.15.1`                                                            |
| [`aa58c159`](https://github.com/NixOS/nixpkgs/commit/aa58c15998c62722e8a77b5f1eaa47af76f38d5f) | `checkip: 0.19.0 -> 0.24.5`                                                            |
| [`cc90d526`](https://github.com/NixOS/nixpkgs/commit/cc90d526933904f7fe8e39236a98b31154dcc581) | `terraform-providers: update 2022-04-11`                                               |
| [`d4071bd1`](https://github.com/NixOS/nixpkgs/commit/d4071bd1fcd27d62f7cd1eafe026511008aebc0c) | `python310Packages.env-canada: 0.5.22 -> 0.5.23`                                       |
| [`e2e68e29`](https://github.com/NixOS/nixpkgs/commit/e2e68e29f9647a19a0c62809f1bc259f1a6d0ddf) | `libsForQt5.bismuth: 3.0.0 -> 3.1.0`                                                   |
| [`8f07a30e`](https://github.com/NixOS/nixpkgs/commit/8f07a30e7df58088f6b7837904ad97a47952bcbe) | `astc-encoder: 3.5 -> 3.6`                                                             |
| [`4093d69e`](https://github.com/NixOS/nixpkgs/commit/4093d69e477c08788e9f09c7368650ec9da1d6a8) | `dsq: 0.12.0 -> 0.13.0`                                                                |
| [`a2c44cba`](https://github.com/NixOS/nixpkgs/commit/a2c44cba88f13909fdf39c5678bd96962144d705) | `discordchatexporter-cli: 2.33.2 -> 2.34`                                              |
| [`3a84954a`](https://github.com/NixOS/nixpkgs/commit/3a84954a8983e6bb23d9ce2710df3fe393dd89d7) | `alttpr-opentracker: autoPatchelfIgnoreMissingDeps is now a list`                      |
| [`3d558785`](https://github.com/NixOS/nixpkgs/commit/3d558785a1c5a173b5d23e606ed998610582ef7e) | `openvino: autoPatchelfIgnoreMissingDeps is now a list`                                |
| [`a7fc2f63`](https://github.com/NixOS/nixpkgs/commit/a7fc2f6392be849f811c0a3f29f559311dc695df) | `autoPatchelfHook: more precise dependency ignorance`                                  |
| [`60dc89be`](https://github.com/NixOS/nixpkgs/commit/60dc89be41bce80a086872492510a2312f920657) | `alejandra: 1.1.0 -> 1.2.0`                                                            |