### PR TITLE
chore(flake/nixpkgs): `e1118817` -> `a2a665fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1649784051,
-        "narHash": "sha256-XN6gEvLzUglWIClT1CyyriZfcAhdFj28krCtWLJ/UBI=",
+        "lastModified": 1649870523,
+        "narHash": "sha256-h7pkYhjbp4Q454/BgXf0447i+4C+FJEKxSX7T9kesQg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e1118817a12dba39081d9e70ae52dd38aa184c2e",
+        "rev": "a2a665fad5e9ac86fa63e703e09b1477164663cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`fbeaf0e6`](https://github.com/NixOS/nixpkgs/commit/fbeaf0e6128d4341dcc4a0f520b8360da9242981) | `libsForQt5.qca-qt5: mark as broken on darwin`                             |
| [`252458b9`](https://github.com/NixOS/nixpkgs/commit/252458b9c556a31c5c52f3e9ead169ef49e38d29) | `libsForQt5.qca-qt5_2_3_2: init at 2.3.2`                                  |
| [`4a92b1e8`](https://github.com/NixOS/nixpkgs/commit/4a92b1e81fcc8ed7bcdee47591ee4ea261238cc7) | `firefox-devedition-bin-unwrapped: 99.0b6 -> 100.0b5`                      |
| [`e76aa74c`](https://github.com/NixOS/nixpkgs/commit/e76aa74c2824cf0a66a463b67b9b93a2c0cfc046) | `nixos/xfce: option to disable xfce4-screensaver`                          |
| [`3a1ad97b`](https://github.com/NixOS/nixpkgs/commit/3a1ad97bbe28535dece0b120fa6980a9a51a49f8) | `buildkite-agent: 3.35.1 -> 3.35.2 (#168443)`                              |
| [`ecaee94b`](https://github.com/NixOS/nixpkgs/commit/ecaee94bc095e30b39fb9ea6334fbd33a4d42845) | `linux-wifi-hotspot: init at 4.4.0`                                        |
| [`c480fadd`](https://github.com/NixOS/nixpkgs/commit/c480fadd4bdee91dfdbb8232a1c4ad8432187196) | `atuin: simplify completion generation`                                    |
| [`79c22361`](https://github.com/NixOS/nixpkgs/commit/79c22361e387ed761b2feddafd742e8f8191049f) | `exploitdb: 2022-04-08 -> 2022-04-12`                                      |
| [`db6a3b62`](https://github.com/NixOS/nixpkgs/commit/db6a3b620a2b4e9432af7824e8ee851d38423328) | `cloudflared: 2022.4.0 -> 2022.4.1 + fix tests for linux (#167419)`        |
| [`b4d69f1f`](https://github.com/NixOS/nixpkgs/commit/b4d69f1fbea22734facb7e54457f557867a88859) | `ArchiSteamFarm: disable nixpkgs-update`                                   |
| [`10c1ac7d`](https://github.com/NixOS/nixpkgs/commit/10c1ac7dc996c90948875ec6fc62e2a752a8f1f5) | `terraform-providers.htpasswd: init at 1.0.1`                              |
| [`40f140ad`](https://github.com/NixOS/nixpkgs/commit/40f140ad872cb9d85ffff366a45739d30256b350) | `crosvm: 99.14468.0.0-rc1 -> 100.14526.0.0-rc1`                            |
| [`26d66fbf`](https://github.com/NixOS/nixpkgs/commit/26d66fbfa9bad792b9d8d629808f544f2d21d84e) | `crosvm.updateScript: generate Cargo.lock`                                 |
| [`fd3f3930`](https://github.com/NixOS/nixpkgs/commit/fd3f39303b4f3831747f6cdf7409915fec77446a) | `squashfs-tools-ng: 1.1.3 -> 1.1.4`                                        |
| [`4d9a820d`](https://github.com/NixOS/nixpkgs/commit/4d9a820dc791b641611cd73bd52d0e974e22604b) | `mutt: 2.2.2 -> 2.2.3`                                                     |
| [`1eac8d2c`](https://github.com/NixOS/nixpkgs/commit/1eac8d2c54b1265159bb2a380439a63d5c86c21d) | `wezterm: Add nixosTests.allTerminfo`                                      |
| [`a03b332b`](https://github.com/NixOS/nixpkgs/commit/a03b332b81d8def4c9c9c7e94fa3300b2e551fb3) | `nixos/terminfo: add enableAllTerminfo option`                             |
| [`313e2a51`](https://github.com/NixOS/nixpkgs/commit/313e2a51240d632bb4fc1f1c891bcbbd564f9503) | `quirc: fix darwin build`                                                  |
| [`e51d4a13`](https://github.com/NixOS/nixpkgs/commit/e51d4a13bc9345554991cb4f97a8962e27af98d8) | `quirc: 2020-04-16 -> 2021-10-08`                                          |
| [`5f000fa1`](https://github.com/NixOS/nixpkgs/commit/5f000fa1674ffbbdf3a78a245b52cafae74f1788) | `python310Packages.pex: 2.1.78 -> 2.1.79`                                  |
| [`4ba5f267`](https://github.com/NixOS/nixpkgs/commit/4ba5f26780e7a27aa2e97676603cd9ef04f11e74) | `go_1_18: 1.18 -> 1.18.1`                                                  |
| [`5abe58a5`](https://github.com/NixOS/nixpkgs/commit/5abe58a5496e8b02f67ea85b3c80e3296000b414) | `epiphany: 42.0 -> 42.1`                                                   |
| [`c6eee638`](https://github.com/NixOS/nixpkgs/commit/c6eee6386d4c95fb3917ff60ab6001065ebb4256) | `subversion_1_10: 1.10.7 -> 1.10.8`                                        |
| [`8f43f3dc`](https://github.com/NixOS/nixpkgs/commit/8f43f3dc4011a5b39848311cdb934ab74fb806c5) | `subversion: 1.14.1 -> 1.14.2`                                             |
| [`7cf8a80c`](https://github.com/NixOS/nixpkgs/commit/7cf8a80c3a46860e9d07d14f75ba7c766b102f2b) | `home-assistant: 2022.4.2 -> 2022.4.3`                                     |
| [`ef797b8a`](https://github.com/NixOS/nixpkgs/commit/ef797b8aebd51cccb200d91ad0ad1ef3161dd451) | `python3Packages.renault-api: 0.1.10 -> 0.1.11`                            |
| [`15afc867`](https://github.com/NixOS/nixpkgs/commit/15afc867f1bd36ce82f1f9cebb28205e7dcd5fac) | `appthreat-depscan: 2.1.2 -> 2.1.3`                                        |
| [`2ca89bdd`](https://github.com/NixOS/nixpkgs/commit/2ca89bddafab6a170bfb7e3adf48d829a0072a0e) | `home-assistant: disable tests for rtsp-to-webrtc package`                 |
| [`94fa4159`](https://github.com/NixOS/nixpkgs/commit/94fa415923508a4c59dfb77ceec5237f0b5a09bf) | `home-assistant: 2022.4.0 - 2022.4.2`                                      |
| [`7e9a2215`](https://github.com/NixOS/nixpkgs/commit/7e9a2215a4e8cd3873ac5e14d7b2024ff66b7f30) | `python3Packages.zha-quirks: 0.0.69 -> 0.0.72`                             |
| [`b01daaf8`](https://github.com/NixOS/nixpkgs/commit/b01daaf8f5b6dbcc459902bf4556e0ba30e73bd7) | `python3Packages.zigpy: 0.44.1 -> 0.44.2`                                  |
| [`33a1eaa3`](https://github.com/NixOS/nixpkgs/commit/33a1eaa3a8add506ca8bd91146b16dd91fce729f) | `python3Packages.rtsp-to-webrtc: 0.5.0 -> 0.5.1`                           |
| [`5b367e4e`](https://github.com/NixOS/nixpkgs/commit/5b367e4e4c9aa81f6478beeeb2e5893fcce5af77) | `broot: 1.9.1 -> 1.11.1`                                                   |
| [`1c515484`](https://github.com/NixOS/nixpkgs/commit/1c5154846809853016a07d2bc8e48827de72e01c) | `boost: support for cross-compiling boost to a mips64 target`              |
| [`d2f296b3`](https://github.com/NixOS/nixpkgs/commit/d2f296b3e8e2016990c38e6c66e9aa22b4e3a2aa) | `chromium: 100.0.4896.75 -> 100.0.4896.88`                                 |
| [`8255068a`](https://github.com/NixOS/nixpkgs/commit/8255068a6336896806245dab54e340c381b3fe86) | `chromiumDev: 102.0.4987.0 -> 102.0.4997.0`                                |
| [`a6770353`](https://github.com/NixOS/nixpkgs/commit/a67703536a715b35fb14120742de894096f08a8d) | `ungoogled-chromium: 100.0.4896.75 -> 100.0.4896.88`                       |
| [`a8bdbec2`](https://github.com/NixOS/nixpkgs/commit/a8bdbec20c26a36cf7ec72fc50985640153a84a0) | `zettlr: 2.2.4 -> 2.2.5`                                                   |
| [`7024b4e5`](https://github.com/NixOS/nixpkgs/commit/7024b4e5e369f3d7d47c01dd21c7390657fee4d0) | `nixos/udev: Put all initrd options into a namespace`                      |
| [`7c4cc512`](https://github.com/NixOS/nixpkgs/commit/7c4cc5125ab27b0d7feb9ef077192e3acb2cc29c) | `drawio: 17.2.4 -> 17.4.2`                                                 |
| [`0a607aab`](https://github.com/NixOS/nixpkgs/commit/0a607aab4a584d8e944b4ad325a358147bb300fd) | `python3Packages.luxtronik: 0.3.11 -> 0.3.12`                              |
| [`a9b854d4`](https://github.com/NixOS/nixpkgs/commit/a9b854d4a3bb4d13657056e2565b4e95323801ea) | `python3Packages.renault-api: 0.1.10 -> 0.1.11`                            |
| [`8ef9cc3c`](https://github.com/NixOS/nixpkgs/commit/8ef9cc3cc7cb3127695d793b3af1b19e863654fe) | `nuclei: 2.6.5 -> 2.6.6`                                                   |
| [`830c576a`](https://github.com/NixOS/nixpkgs/commit/830c576ad453795dad1e1f019b908c0ed02b7cf4) | `coreclr: remove from nixpkgs`                                             |
| [`f8dc166d`](https://github.com/NixOS/nixpkgs/commit/f8dc166d73cdee0bb477fafbaced576d6c4ec023) | `k3s: 1.23.4+k3s1 -> 1.23.5+k3s1`                                          |
| [`0977227b`](https://github.com/NixOS/nixpkgs/commit/0977227b8622daccb5a8435d3d4216eedf845973) | ``nixos/paperless-ng: rename to `paperless`, use `paperless-ngx` package`` |
| [`46c33313`](https://github.com/NixOS/nixpkgs/commit/46c333138443b76362591318ffd5541fcce53540) | `nixos/paperless-ng: simplify redis logic`                                 |
| [`e8d30cd3`](https://github.com/NixOS/nixpkgs/commit/e8d30cd3291c3119270beb0f2312f819eb2203e0) | `nixVersions: add artturin to maintainers`                                 |
| [`a1d12edc`](https://github.com/NixOS/nixpkgs/commit/a1d12edc46f08cf09a8caad32bfff64df8bca75e) | `nixVersions.unstable: pre20220322 -> pre20220411`                         |
| [`a47871ff`](https://github.com/NixOS/nixpkgs/commit/a47871ffc46c5e255ddc2c97e8ad3baa06fea72a) | `shibokeh2: mark as broken for python 3.10`                                |
| [`2e7cca76`](https://github.com/NixOS/nixpkgs/commit/2e7cca769034e5cb84d56138f2b198ee12fefd11) | `element{-desktop,}: 1.10.8 -> 1.10.9`                                     |
| [`239b635a`](https://github.com/NixOS/nixpkgs/commit/239b635ac2d4a252698b60444507c904e30f7627) | `gsctl: fix tests for linux`                                               |
| [`e9e76773`](https://github.com/NixOS/nixpkgs/commit/e9e76773efa9d6818b97978bfe8d3bd25c51920f) | `napari: fix after the transition to pyproject.toml`                       |
| [`4f985714`](https://github.com/NixOS/nixpkgs/commit/4f9857143ccd4b4ddf972cae7a1002be01b6fcdf) | `github-runner: 2.289.2 -> 2.290.0`                                        |
| [`d0e5a586`](https://github.com/NixOS/nixpkgs/commit/d0e5a586b1e782b8a24b6a362d88edb3d6f2c269) | `firefox-bin: 99.0 -> 99.0.1`                                              |
| [`07c6d442`](https://github.com/NixOS/nixpkgs/commit/07c6d44239b194d5b3a5791ee69203c90b505057) | `firefox: 99.0 -> 99.0.1`                                                  |
| [`01b44fee`](https://github.com/NixOS/nixpkgs/commit/01b44fee06b2529c337fda01d55da4b20a75b1a6) | `python310Packages.phonenumbers: 8.12.44 -> 8.12.46`                       |
| [`dccd5a44`](https://github.com/NixOS/nixpkgs/commit/dccd5a44d1b253d7f8595517287aad1c74228d14) | ``nixos/cockroachdb: use `escapeSystemdExecArgs` for ExecStart args``      |
| [`d215163f`](https://github.com/NixOS/nixpkgs/commit/d215163ff9d37bf3bac8024c84589ec82a1e70af) | ``nixos/cockroachdb: add `extraArgs` option``                              |
| [`f7341940`](https://github.com/NixOS/nixpkgs/commit/f7341940275e24857369bf468923c60073defc99) | `pkgconf: refactor`                                                        |
| [`33303525`](https://github.com/NixOS/nixpkgs/commit/333035257da88ae644f414cc13d9cb4de4fded7d) | `duckdb: 0.3.2 -> 0.3.3`                                                   |
| [`8442d63c`](https://github.com/NixOS/nixpkgs/commit/8442d63c5b662958c9ceb1bbf08bb492bf4a6d9b) | `python3Packages.dm-haiku: fix build`                                      |
| [`b3a47430`](https://github.com/NixOS/nixpkgs/commit/b3a47430aebd96f925cd743d67dc183d1e744968) | `ipfs: 0.12.1 -> 0.12.2`                                                   |
| [`a62d3aa8`](https://github.com/NixOS/nixpkgs/commit/a62d3aa8bf4fe2be14a78b26ff737f1987cbbd62) | `metasploit: 6.1.36 -> 6.1.37`                                             |
| [`158b9d52`](https://github.com/NixOS/nixpkgs/commit/158b9d526d7adebfaedab83604ab961c824edb33) | `python3Packages.chex: unstable-2021-12-16 -> 0.1.2`                       |
| [`69319ee4`](https://github.com/NixOS/nixpkgs/commit/69319ee4a6a611729e0907d6cc970201c9d2a654) | `nixos/paperless-ng: fix /proc access for service`                         |
| [`308c4bf0`](https://github.com/NixOS/nixpkgs/commit/308c4bf0f7caaf59a42a9092d0e3a889490c7902) | `nixos/paperless-ng: minor improvments`                                    |
| [`99f40c2c`](https://github.com/NixOS/nixpkgs/commit/99f40c2c13e48dc9c22221462d4d8b06d0930790) | ``paperless-ng: delete pkg, add alias to `paperless-ngx```                 |
| [`9faba97d`](https://github.com/NixOS/nixpkgs/commit/9faba97d247efa0977b9b67d0e8b67fc573b7036) | `paperless-ngx: init at 1.6.0`                                             |
| [`904e3139`](https://github.com/NixOS/nixpkgs/commit/904e3139be692bdde04c9f101c8a161dcb285439) | `python3Packages.xknx: 0.20.1 -> 0.20.2`                                   |
| [`097be28b`](https://github.com/NixOS/nixpkgs/commit/097be28b9ba10b659d7d3ad7c7ca79d5b4f0bc94) | `python3Packages.devolo-home-control-api: 0.17.4 -> 0.18.1`                |
| [`d7160ccd`](https://github.com/NixOS/nixpkgs/commit/d7160ccdfc767bc25f5da34b879ae382bd0dd7e7) | `python3Packages.pyoverkiz: 1.3.14 -> 1.4.0`                               |
| [`672f7edb`](https://github.com/NixOS/nixpkgs/commit/672f7edb4d7a14e6d2e8026f49c66be270818b0a) | `python3Packages.tensorflow-datasets: fix build`                           |
| [`fb44ecd1`](https://github.com/NixOS/nixpkgs/commit/fb44ecd129c8ee49fb599f82f2ff8041ebd34682) | `nixos/udev: Add systemd stage 1 support`                                  |
| [`28539842`](https://github.com/NixOS/nixpkgs/commit/28539842d8c2b4a41c7ab4b31da5eeae828dbe2f) | `nixos/utils: move removePackagesByName to here from gnome`                |
| [`28e936ba`](https://github.com/NixOS/nixpkgs/commit/28e936ba64c015caa1ce1be21ea7c790898ce336) | `nixos/xserver: add excludePackages option`                                |
| [`dbf02e3a`](https://github.com/NixOS/nixpkgs/commit/dbf02e3a52d3e37759328e2c90b38ee8ba95b2f2) | `chromiumDev: 102.0.4972.0 -> 102.0.4987.0`                                |
| [`92559b73`](https://github.com/NixOS/nixpkgs/commit/92559b7330a56778dde383225bae47e225de4861) | `chromium: get-commit-message.py: Support releases with 1 security fix`    |
| [`12f66be9`](https://github.com/NixOS/nixpkgs/commit/12f66be9deb220ea6439aa41605ddfee91a0e4dc) | `libsForQt5.qca-qt5: 2.3.1 -> 2.3.4`                                       |
| [`acc99abf`](https://github.com/NixOS/nixpkgs/commit/acc99abf6a4a25ec0796cbcb7a9faf487e56cea8) | `python3Packages.twisted: Patch HTTP request smuggling issue`              |
| [`3ed4e07a`](https://github.com/NixOS/nixpkgs/commit/3ed4e07a52697dd12396ee7f8621d9485eef3d32) | `protobuf2_5: remove`                                                      |
| [`e7c301df`](https://github.com/NixOS/nixpkgs/commit/e7c301df52edcf6043ebd56b0da8db94be621d96) | `nixos/mailman: remove obsolete setting`                                   |
| [`a167391b`](https://github.com/NixOS/nixpkgs/commit/a167391bc80c48f31d17712d0fdbb32f8854f7ca) | `lightning-loop: 0.17.0-beta -> 0.18.0-beta`                               |
| [`d6026416`](https://github.com/NixOS/nixpkgs/commit/d6026416f496c3352aea5e7a14f6cf5407d414a6) | `roundcubePlugins.carddav: v3.0.3 -> v4.3.0`                               |