### PR TITLE
chore(flake/nixpkgs): `a2a665fa` -> `ce932dbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1649870523,
-        "narHash": "sha256-h7pkYhjbp4Q454/BgXf0447i+4C+FJEKxSX7T9kesQg=",
+        "lastModified": 1649913345,
+        "narHash": "sha256-iq4xs54MREQYtPPNRqxsI7gK/C97Bef1lWOceFAQ6EA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a2a665fad5e9ac86fa63e703e09b1477164663cc",
+        "rev": "ce932dbcf14884c7c76888ebf8cf80f789250afd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                      |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`5db92536`](https://github.com/NixOS/nixpkgs/commit/5db92536331da585eafa2aa55ce232ac900c9e9d) | `nixos/desktop-managers: Fix eval`                                  |
| [`569f8c87`](https://github.com/NixOS/nixpkgs/commit/569f8c87c00ca28189c5e7a62fe458b74ee019c4) | `bore-cli: init at 0.2.1`                                           |
| [`ae6932e7`](https://github.com/NixOS/nixpkgs/commit/ae6932e7b9b411fd561ccc52e32f33a9aac865d6) | `elan: 1.3.1 -> 1.4.0`                                              |
| [`8ceeec3f`](https://github.com/NixOS/nixpkgs/commit/8ceeec3f8d49dd95082a71a1b9c0b4acd42cd5c8) | `cargo-tally: 1.0.2 -> 1.0.4`                                       |
| [`16710ae6`](https://github.com/NixOS/nixpkgs/commit/16710ae6de2a8396e3c066622ea341656f7cf557) | `esbuild: 0.14.32 -> 0.14.34`                                       |
| [`42e4eb37`](https://github.com/NixOS/nixpkgs/commit/42e4eb37475c3421caa767ddba0a9db713530748) | `libdeltachat: 1.76.0 -> 1.77.0`                                    |
| [`b2070af5`](https://github.com/NixOS/nixpkgs/commit/b2070af53e5e1f14cd75e41233be87afd0482efa) | `starship: use unstable to fix darwin`                              |
| [`095da8fd`](https://github.com/NixOS/nixpkgs/commit/095da8fd9d663eb25566f109cb7c84fc3189fa00) | `gnome.swell-foop: 41.0.1 → 41.1`                                   |
| [`e10c716e`](https://github.com/NixOS/nixpkgs/commit/e10c716ece359529341cee8a8ad1af4501265d37) | `dagger: init at 0.2.6`                                             |
| [`66beaa92`](https://github.com/NixOS/nixpkgs/commit/66beaa922580bbb76bd26ebb5156bcd78959d3bd) | `cpython: update patches for 3.11a7 on darwin`                      |
| [`c9436314`](https://github.com/NixOS/nixpkgs/commit/c94363142d10937b1af659446438c3e7a7451285) | `kaidan: add missing dependency`                                    |
| [`6826bc67`](https://github.com/NixOS/nixpkgs/commit/6826bc67ffb00f62696f2464a57b47d7f4b52414) | `gh: 2.7.0 -> 2.8.0`                                                |
| [`62b81e9e`](https://github.com/NixOS/nixpkgs/commit/62b81e9edba8b7bfecf246dbf67bc5df749a21e1) | `chicken: disable tests for darwin`                                 |
| [`7ce4bc7e`](https://github.com/NixOS/nixpkgs/commit/7ce4bc7ef288dc7d85833da6d613370839c9c0d2) | `iperf3: Add support for SCTP`                                      |
| [`d2979650`](https://github.com/NixOS/nixpkgs/commit/d2979650299c077d7f25c2662f2dcd27106fc8c3) | `vimPlugins.vim-vp4: init at 2021-01-06`                            |
| [`8c44d65e`](https://github.com/NixOS/nixpkgs/commit/8c44d65e63d2ca2b2e1111e5193ddb88362eed28) | `vimPlugins: update`                                                |
| [`7eb14b53`](https://github.com/NixOS/nixpkgs/commit/7eb14b532a042604efbcbda094e3d082543962f9) | `nixos/gnome: set default wallpaper for dark mode as well`          |
| [`00214c23`](https://github.com/NixOS/nixpkgs/commit/00214c234683ddc36e29b269b619f80568cea0d6) | `nodePackages: add ts-node`                                         |
| [`1337dd75`](https://github.com/NixOS/nixpkgs/commit/1337dd75d16ff7126c4a545dee6da6bea913d51c) | `lollypop: 1.4.26 -> 1.4.31`                                        |
| [`acd683b4`](https://github.com/NixOS/nixpkgs/commit/acd683b46285fd2cdacc3a8a16d8f3a1307a90c8) | `python3Packages.geocachingapi: disable on older Python releases`   |
| [`d1c999a3`](https://github.com/NixOS/nixpkgs/commit/d1c999a3bc628f0f9e03dc4cdf41d83c0cc1d513) | `python310Packages.geocachingapi: 0.1.0 -> 0.1.1`                   |
| [`cf43796a`](https://github.com/NixOS/nixpkgs/commit/cf43796a27dede10c156d3bd0562cbb90fb196cf) | `python310Packages.apycula: 0.3 -> 0.3.1`                           |
| [`39e3510d`](https://github.com/NixOS/nixpkgs/commit/39e3510d6d68fd68b4464d32ebcbee4c42df8c54) | `python310Packages.appthreat-vulnerability-db: 2.0.1 -> 2.0.2`      |
| [`a1ea14c1`](https://github.com/NixOS/nixpkgs/commit/a1ea14c1d38cb49c5d93e9dc37c6be5d760ffcfd) | `syft: 0.43.2 -> 0.44.0`                                            |
| [`8c5ed979`](https://github.com/NixOS/nixpkgs/commit/8c5ed979bea1bebf3a1b650ed36638925cd344ea) | `bazel_5: 5.0.0 -> 5.1.1`                                           |
| [`93b9c670`](https://github.com/NixOS/nixpkgs/commit/93b9c6708e7dfdb1ad18a7854fdb3bb14346f354) | `palemoon: 29.4.5.1 -> 29.4.6`                                      |
| [`4dd2e406`](https://github.com/NixOS/nixpkgs/commit/4dd2e406feb4d350a2e239be5b63ad92dbdb64ce) | `mpris-scrobbler: 0.4.0.1 -> 0.4.90`                                |
| [`17c2ca90`](https://github.com/NixOS/nixpkgs/commit/17c2ca9084aa4648d31c2de6558921b408aabb00) | `qutebrowser: fix userscripts directory path`                       |
| [`306ca314`](https://github.com/NixOS/nixpkgs/commit/306ca314d1e5a5fe9b18259c2c064a79dc57d82b) | `geeqie: 1.7.2 -> 1.7.3`                                            |
| [`7eb6efcb`](https://github.com/NixOS/nixpkgs/commit/7eb6efcb4e40f6f30a701f660ee4afad917ca6c5) | `samurai: rewrite`                                                  |
| [`9801fb6c`](https://github.com/NixOS/nixpkgs/commit/9801fb6c1a0ae7e325443ff2fb0c61700865fbf3) | `move muon to muonlang`                                             |
| [`5e5e1c80`](https://github.com/NixOS/nixpkgs/commit/5e5e1c80beb2820d6d085ed9b81fae1e4ce2b4ad) | `python3Packages.tldextract: 3.2.0 -> 3.2.1`                        |
| [`14aaf617`](https://github.com/NixOS/nixpkgs/commit/14aaf6173597170c03aee42fcfd64e03d7392eed) | `calamares: 3.2.54 -> 3.2.55`                                       |
| [`fcb69a85`](https://github.com/NixOS/nixpkgs/commit/fcb69a858359f7b7fe453c06697f6e4200a4d2d4) | `nixos/shellhub-agent: use package internally, avoiding it in PATH` |
| [`d7a0f56c`](https://github.com/NixOS/nixpkgs/commit/d7a0f56c6a2a19c9e6a61716ce5315412b61c2f6) | `nixos/shellhub-agent: avoid code duplication for environment`      |
| [`bd3b046a`](https://github.com/NixOS/nixpkgs/commit/bd3b046ac85758208b362e0b4234fb0466cd5cbd) | `nixos/shellhub-agent: use mkPackageOption to simplify code`        |
| [`8c4bc7f6`](https://github.com/NixOS/nixpkgs/commit/8c4bc7f62c912d7828568492b8715a3006133907) | `nixos/shellhub-agent: allow setting the preferredHostname`         |
| [`67296533`](https://github.com/NixOS/nixpkgs/commit/6729653309e636401ea880acffa17866f18f320d) | `nixos/shellhub-agent: allow setting the keepAliveInterval`         |
| [`60158bfc`](https://github.com/NixOS/nixpkgs/commit/60158bfc22a50d90919ee647b3a36e4f5f255428) | `nixos/shellhub-agent: use new configuration variables`             |
| [`a62471fc`](https://github.com/NixOS/nixpkgs/commit/a62471fc65888bb0ba7b6d8b79352a560cb1629f) | `nixos/shellhub-agent: use mkEnableOption to simplify code`         |
| [`7a6e4879`](https://github.com/NixOS/nixpkgs/commit/7a6e487964192a1dde99ca51ba7b6f7297ea30d2) | `telepresence2: 2.4.10 -> 2.5.4`                                    |
| [`b71479ac`](https://github.com/NixOS/nixpkgs/commit/b71479ac8d8c154186f675ce363a527c2e1877d0) | `openai: 0.16.0 -> 0.18.0`                                          |
| [`61751885`](https://github.com/NixOS/nixpkgs/commit/6175188591f13d8bbcfab928acb5958b0504f59d) | `nixos/shellhub-agent: reformat code using nixpkgs-fmt`             |
| [`9bc43e3b`](https://github.com/NixOS/nixpkgs/commit/9bc43e3bada7016012f6d6d13debf71a884492b0) | `celluloid: 0.22 -> 0.23`                                           |