### PR TITLE
chore(flake/nixpkgs): `ce932dbc` -> `9a5459ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1649913345,
-        "narHash": "sha256-iq4xs54MREQYtPPNRqxsI7gK/C97Bef1lWOceFAQ6EA=",
+        "lastModified": 1649955614,
+        "narHash": "sha256-Vtii9SrPxJVmwEr2t0RzrTMOmQRYXRWvdOTmvzBUaZ4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ce932dbcf14884c7c76888ebf8cf80f789250afd",
+        "rev": "9a5459efddbcce460fddf7f199fe85ba6e3f6ed4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                               |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`bad701b1`](https://github.com/NixOS/nixpkgs/commit/bad701b1d3f28345cfeef0c3950a5d5b7bd06a1f) | `doc/release-notes: mention pdns-recursor options changes`                                   |
| [`fe279765`](https://github.com/NixOS/nixpkgs/commit/fe27976534472b042d41f7b30c0aa0af6e8a7444) | `nixos/tests/pdns-recursor: test a DNS query`                                                |
| [`fd480f55`](https://github.com/NixOS/nixpkgs/commit/fd480f55df0647f8739546ffa9fa780ce17f0a91) | `nixos/pdns-recursor: update default values`                                                 |
| [`def4db69`](https://github.com/NixOS/nixpkgs/commit/def4db69a7a9f4226ce62f3e2832e7f2a66d0e00) | `whipper: add passthru.tests.version`                                                        |
| [`c0cd9980`](https://github.com/NixOS/nixpkgs/commit/c0cd99801e1533b79dcd817f02b01359a9b598c3) | `sonixd: 0.14.0 -> 0.15.0`                                                                   |
| [`6df2186d`](https://github.com/NixOS/nixpkgs/commit/6df2186d5a1326d517dd3a33b0444efe6fa8ce76) | `whipper: propagate setuptools`                                                              |
| [`6ceedff3`](https://github.com/NixOS/nixpkgs/commit/6ceedff331606021084e9d6b6d52216ab2c93025) | `nixosTests.kexec: fix tests with kexecBoot format`                                          |
| [`b825f6db`](https://github.com/NixOS/nixpkgs/commit/b825f6db5610529c3a7d178d26b49395d00b21ed) | `nixos/doc/md-to-db.sh: consistent pandoc version`                                           |
| [`e4ebcb1e`](https://github.com/NixOS/nixpkgs/commit/e4ebcb1e13132fb38270d6869a38f0a64cea8da6) | `oh-my-zsh: 2022-04-09 -> 2022-04-13 (#168604)`                                              |
| [`0aee0a19`](https://github.com/NixOS/nixpkgs/commit/0aee0a19dbd9312d37a15b358ff20e33b398d70d) | `slack: 4.25.0 -> 4.25.1, linux only`                                                        |
| [`1e9b2619`](https://github.com/NixOS/nixpkgs/commit/1e9b26194e85c8f695c024aec51995d5bbce338e) | `postgresqlPackages.pg_auto_failover: 1.6.3 -> 1.6.4 (#168611)`                              |
| [`dda7e9e3`](https://github.com/NixOS/nixpkgs/commit/dda7e9e3ee801d9fbe0cc4d0b3dde024966bc8ee) | `nixos/stage-1-systemd: Add mdraid support (+ test)`                                         |
| [`67b8f5cf`](https://github.com/NixOS/nixpkgs/commit/67b8f5cfff07c44cdb67b46315e078c6ade02122) | `rubyPackages: add pandocomatic (#164545)`                                                   |
| [`ca1b1f6d`](https://github.com/NixOS/nixpkgs/commit/ca1b1f6dc088b9e46662bdb55ef603dcbae9757b) | `nixos/test-driver: highlight driver log lines`                                              |
| [`e633d427`](https://github.com/NixOS/nixpkgs/commit/e633d427477c310891553b4218648e05da1db56c) | `grafana: 8.4.5 -> 8.4.6`                                                                    |
| [`7708fccf`](https://github.com/NixOS/nixpkgs/commit/7708fccf01e0cdc38ce020c30e5c84427c2bec8e) | `grafana: implement update script`                                                           |
| [`b04f6595`](https://github.com/NixOS/nixpkgs/commit/b04f6595050ad88117ad23c096b68cbbfc1e9bc4) | `python310Packages.stripe: 2.71.0 -> 2.72.0`                                                 |
| [`29a38e61`](https://github.com/NixOS/nixpkgs/commit/29a38e618e68181a8df3fc9fc0d52748ea723785) | `arkade: 0.8.22 -> 0.8.23`                                                                   |
| [`f5de595d`](https://github.com/NixOS/nixpkgs/commit/f5de595df79aa927845abfac931035c1ed3dd730) | `python3Packages.openhomedevice: 2.0.1 -> 2.0.2`                                             |
| [`c00ac0d3`](https://github.com/NixOS/nixpkgs/commit/c00ac0d379c7fe6dda72bc12c5943301e52b13eb) | `eksctl: 0.92.0 -> 0.93.0`                                                                   |
| [`b0d433e9`](https://github.com/NixOS/nixpkgs/commit/b0d433e931bb69e75b3a8db7057c0157c1d6642f) | `python310Packages.tablib: update meta`                                                      |
| [`2291f1a4`](https://github.com/NixOS/nixpkgs/commit/2291f1a46488009f6700a4c863eef2b60ac0411e) | `satysfi: 0.0.6 -> 0.0.7`                                                                    |
| [`d21f677b`](https://github.com/NixOS/nixpkgs/commit/d21f677be0dc0c673cf92acce6ba5c7790afd42d) | `lxd: 4.24 -> 5.0.0`                                                                         |
| [`a837d70c`](https://github.com/NixOS/nixpkgs/commit/a837d70cac26db2aa8965e57a4e65be5960df7a5) | `python310Packages.mlflow: 1.25.0 -> 1.25.1`                                                 |
| [`acbf5c20`](https://github.com/NixOS/nixpkgs/commit/acbf5c2030a18f3e93f6e42e361ccb3c7ebc1b65) | `ncspot: 0.9.5 -> 0.9.7`                                                                     |
| [`7c63c591`](https://github.com/NixOS/nixpkgs/commit/7c63c5914d50d703d85d83b91fd1c31365fc3a0c) | `gitRepo: 2.22 -> 2.23`                                                                      |
| [`b6f2d358`](https://github.com/NixOS/nixpkgs/commit/b6f2d3588ccfa916a4130068ff64a1868c166b91) | `git-machete: 3.7.2 -> 3.8.0`                                                                |
| [`1a0addc7`](https://github.com/NixOS/nixpkgs/commit/1a0addc79952506dad19ce53b972e63e545997ba) | `aerc: 0.8.2 -> 0.9.0`                                                                       |
| [`dc44abca`](https://github.com/NixOS/nixpkgs/commit/dc44abca6555b1befad3a72ebbfd69395c9f0575) | `gnome-connections: 42.1.1 → 42.1.2`                                                         |
| [`76f8d7f7`](https://github.com/NixOS/nixpkgs/commit/76f8d7f7510d1bf53ad8b198febf0f0fc7f8e208) | `gtk-frdp: unstable-2022-04-07 → unstable-2022-04-11`                                        |
| [`5ddc4f5f`](https://github.com/NixOS/nixpkgs/commit/5ddc4f5f1677ef94f632803b5ea141dfceda8f17) | `consul: 1.11.4 -> 1.11.5`                                                                   |
| [`cfab91eb`](https://github.com/NixOS/nixpkgs/commit/cfab91ebebf445f2e0d0bedd4647960a66ea8209) | `talosctl: 1.0.1 -> 1.0.2`                                                                   |
| [`58740356`](https://github.com/NixOS/nixpkgs/commit/5874035621255e74773284e679b6da8f0501cd84) | `zcash: 4.6.0-1 -> 4.6.0-2`                                                                  |
| [`15623bcb`](https://github.com/NixOS/nixpkgs/commit/15623bcb654b0c5ef9b455ca1f7b7fb0ffcaea26) | `chromium{Beta,Dev}: Fix a build error by disabling PGO`                                     |
| [`aeb75b3b`](https://github.com/NixOS/nixpkgs/commit/aeb75b3b694850cb93866d417661081014e09279) | `nixos/stage-1-systemd: Implement hibernation + test`                                        |
| [`ffb32037`](https://github.com/NixOS/nixpkgs/commit/ffb320378b4d7c49d55d4119e3c423527ec86c8b) | `nixos/stage-1-systemd: Fix booting grub tests`                                              |
| [`2633e82e`](https://github.com/NixOS/nixpkgs/commit/2633e82e1a1cb73e83f7d8d6c70fbe125d182005) | `nixos/stage-1-systemd: Add LVM2 support`                                                    |
| [`426d2c8e`](https://github.com/NixOS/nixpkgs/commit/426d2c8e9dfb3a7e5e50eedcf9eb5cd825feff9b) | `python310Packages.pytest-astropy: 0.9.0 -> 0.10.0`                                          |
| [`a88af948`](https://github.com/NixOS/nixpkgs/commit/a88af94894f31e6cce358e49610a6fcb5b4f6f13) | `qt5, libsForQt5: 5.12 -> 5.14 on darwin`                                                    |
| [`c55f6106`](https://github.com/NixOS/nixpkgs/commit/c55f61061e4f5c0676f158dc55c68867dd19a1f0) | `libsForQt5.qt5.qtserialbus: enable for qt 5.14`                                             |
| [`415c7521`](https://github.com/NixOS/nixpkgs/commit/415c75218387e7eec2f1b5259793d81cbf058b71) | `python3Packages.policy-sentry: 0.12.2 -> 0.12.3`                                            |
| [`e8062bc6`](https://github.com/NixOS/nixpkgs/commit/e8062bc60caca507637f4a8a417207e09b38d1ca) | `htmltest: 0.15.0 -> 0.16.0`                                                                 |
| [`99e30a24`](https://github.com/NixOS/nixpkgs/commit/99e30a24759d5653807b74c171416b6b9482a82e) | `python3Packages.elkm1-lib: 1.2.2 -> 1.3.1`                                                  |
| [`e9fa89dd`](https://github.com/NixOS/nixpkgs/commit/e9fa89dd820c7f64b59d16d52257a39632bcdf9c) | `pyupgrade: 2.31.1 -> 2.32.0`                                                                |
| [`bd836a8a`](https://github.com/NixOS/nixpkgs/commit/bd836a8a294674d7c3d5abdc37d7b11f2193086b) | `python3Packages.aioshelly: 1.0.11 -> 2.0.0`                                                 |
| [`cc222b4f`](https://github.com/NixOS/nixpkgs/commit/cc222b4fea6606005578c7aede3288a98516db1d) | `bluej: fix gsettings schemas`                                                               |
| [`a94f1230`](https://github.com/NixOS/nixpkgs/commit/a94f1230bbd67bd71d919e0149eacd6a1510036c) | `python310Packages.gspread: 5.3.0 -> 5.3.2`                                                  |
| [`ea829965`](https://github.com/NixOS/nixpkgs/commit/ea829965ada3ffba868b7ce3177c1edef7bf1d43) | `python3Packages.simple-salesforce: disable on older Python releases`                        |
| [`dc381cb5`](https://github.com/NixOS/nixpkgs/commit/dc381cb5ce9ba13e93d58b4f29781cd860d155cd) | `omnisharp-roslyn: 1.38.1 -> 1.38.2`                                                         |
| [`34b74576`](https://github.com/NixOS/nixpkgs/commit/34b7457691a1e91862aa2ab484cbdfdf353213a0) | `infracost: 0.9.21 -> 0.9.22`                                                                |
| [`a0d51901`](https://github.com/NixOS/nixpkgs/commit/a0d5190136c7788f019b2df9d721f4d9268fea15) | `driftctl: 0.27.0 -> 0.28.0`                                                                 |
| [`c1b26fc5`](https://github.com/NixOS/nixpkgs/commit/c1b26fc5e8d2618004027664ac7e0c38276c6cdb) | `python310Packages.mariadb: 1.0.10 -> 1.0.11`                                                |
| [`e968d2b3`](https://github.com/NixOS/nixpkgs/commit/e968d2b34455231984fc46f8965f003448363b16) | `python310Packages.mlflow: 1.24.0 -> 1.25.0`                                                 |
| [`8ea2f75b`](https://github.com/NixOS/nixpkgs/commit/8ea2f75b72e11beb34121022e4d3243bd2fb6c89) | `nixos/kexec-boot: use dirname of script to resolve bzImage and initrd.gz`                   |
| [`f0178e45`](https://github.com/NixOS/nixpkgs/commit/f0178e45eb6f218acef4e8ae46aaea052a2171c7) | `nixosTests.kexec: extend with kexecBoot attribute`                                          |
| [`366c8be2`](https://github.com/NixOS/nixpkgs/commit/366c8be2add24ecfb14ddc8452189358c9cb1439) | `nixos/installer: add kexec-boot`                                                            |
| [`0f432460`](https://github.com/NixOS/nixpkgs/commit/0f4324603369329cc4a70e9a65d847dba5db7577) | `starboard: 0.15.3 -> 0.15.4`                                                                |
| [`756d8c1d`](https://github.com/NixOS/nixpkgs/commit/756d8c1d4f33bfc582fc374a99a85a246b951a98) | `nomachine-client: 7.8.2 -> 7.9.2`                                                           |
| [`7115a940`](https://github.com/NixOS/nixpkgs/commit/7115a9404c7d45d037fad3a735a3e7368f6826b5) | `pythonPackages.simple-salesforce: add zeep to propagatedBuildInputs`                        |
| [`5acc34d9`](https://github.com/NixOS/nixpkgs/commit/5acc34d95a1f550a62b71e49a3867863e2a2a82d) | `vscodium: 1.66.1 -> 1.66.2`                                                                 |
| [`db770979`](https://github.com/NixOS/nixpkgs/commit/db770979f19b8c95a458e5b6e53506f605610f01) | `vscode: 1.66.1 -> 1.66.2`                                                                   |
| [`941cc46e`](https://github.com/NixOS/nixpkgs/commit/941cc46e19776a65fb4b978eca8e8a4de5715bf7) | `google-cloud-sdk: 370.0.0 -> 381.0.0`                                                       |
| [`dadc08be`](https://github.com/NixOS/nixpkgs/commit/dadc08be415ea0f6920d11ddfe18c860d935d24e) | `jetbrains.idea-{community,ultimate}: 2021.3.2 → 2022.1`                                     |
| [`8181a175`](https://github.com/NixOS/nixpkgs/commit/8181a1756a21a0f0b836969a0bc38be84e5a8058) | `cosign: 1.7.1 -> 1.7.2`                                                                     |
| [`de49dacc`](https://github.com/NixOS/nixpkgs/commit/de49dacc0b4700e3a2949defbaf5315e04cbc8ae) | `dprint: 0.24.3 -> 0.24.4`                                                                   |
| [`d8e5afd7`](https://github.com/NixOS/nixpkgs/commit/d8e5afd7838782c862bb7e0583d58f68a7b1af32) | `osu-lazer: 2022.205.0 -> 2022.409.0`                                                        |
| [`9b7cbd2c`](https://github.com/NixOS/nixpkgs/commit/9b7cbd2cc55aae5b847666d401d00fffd343a51c) | `mutagen: 0.11.18 -> 0.13.1`                                                                 |
| [`b261dee8`](https://github.com/NixOS/nixpkgs/commit/b261dee8574a36839d9e3265c6cd8cf700d13b75) | `tests/nix-ld: fix invocation`                                                               |
| [`59a591b1`](https://github.com/NixOS/nixpkgs/commit/59a591b1412cfb55d6976e7ff126a0830abc62a6) | `wire-desktop: mac 3.26.4145 -> 3.27.4357`                                                   |
| [`afcedb3f`](https://github.com/NixOS/nixpkgs/commit/afcedb3f0a4a3e1a2306d5764792b38a8ee84759) | `wire-desktop: linux 3.26.2941 -> 3.27.2944`                                                 |
| [`b34b81c8`](https://github.com/NixOS/nixpkgs/commit/b34b81c848f826a01d8b838bde571a66a9a5336d) | `circleci-cli: 0.1.17087 -> 0.1.17110`                                                       |
| [`d49d06ee`](https://github.com/NixOS/nixpkgs/commit/d49d06eecd9472b6835100a3e5bf54e173808fc0) | `flyctl: 0.0.314 -> 0.0.316`                                                                 |
| [`91d2fd21`](https://github.com/NixOS/nixpkgs/commit/91d2fd21bdfe747e7c4112921efb571c75b70159) | `flow: 0.174.1 -> 0.175.1`                                                                   |
| [`b0f5cd41`](https://github.com/NixOS/nixpkgs/commit/b0f5cd418c74471d80f03da1de5dd5e5b749a82a) | `datadog-agent: 7.34.0 -> 7.35.0`                                                            |
| [`79de6016`](https://github.com/NixOS/nixpkgs/commit/79de601673f4bdc04c370033e2c693987088d1f9) | `checkstyle: 10.0 -> 10.1`                                                                   |
| [`5d5700b9`](https://github.com/NixOS/nixpkgs/commit/5d5700b985af93dc05550827fe3d96712914d2cc) | `azure-storage-azcopy: 10.14.0 -> 10.14.1`                                                   |
| [`77b11e49`](https://github.com/NixOS/nixpkgs/commit/77b11e49fe84794c09236af27dbc0c73a4d4c836) | `python310Packages.tablib: 3.2.0 -> 3.2.1`                                                   |
| [`c6bd4c4a`](https://github.com/NixOS/nixpkgs/commit/c6bd4c4ad1dc2387841e6a7a51dc333a507fd3d9) | `wabt: 1.0.27 -> 1.0.28`                                                                     |
| [`710afcdb`](https://github.com/NixOS/nixpkgs/commit/710afcdb4ff2f06573b450e320f808b5478c5b5d) | `swayr: 0.16.0 -> 0.16.1`                                                                    |
| [`92402c90`](https://github.com/NixOS/nixpkgs/commit/92402c908ff53ee426f112a5fc13928105668f9d) | `mongodb: 5.0.5 -> 5.0.7`                                                                    |
| [`dc724666`](https://github.com/NixOS/nixpkgs/commit/dc72466610d35382d15a8595c81be6cd8aedc97f) | `mongodb: 4.2.17 -> 4.2.19`                                                                  |
| [`7a246abc`](https://github.com/NixOS/nixpkgs/commit/7a246abcf1181d86c7ca1babf2b9623f351a4eec) | `mongodb: 4.4.10 -> 4.4.13`                                                                  |
| [`1be42266`](https://github.com/NixOS/nixpkgs/commit/1be4226669a58a64db6118c5d257ceaee02589cd) | `mongodb: add 5.0`                                                                           |
| [`462b1e44`](https://github.com/NixOS/nixpkgs/commit/462b1e4473d3d322a8ddc3a335ebc8959e645ce8) | `mongodb: add 4.4`                                                                           |
| [`703cea5f`](https://github.com/NixOS/nixpkgs/commit/703cea5f4765bca358cb5cbc48fc61e82151ab7d) | `deno: 1.19.1 -> 1.20.5`                                                                     |
| [`7ba18124`](https://github.com/NixOS/nixpkgs/commit/7ba181240d8e394b3504735b615a1cdfe6d4e2e5) | `debianutils:  4.11.2 -> 5.7`                                                                |
| [`c3428419`](https://github.com/NixOS/nixpkgs/commit/c3428419e05c8e3ef2b722b82b2f7065a6d46441) | `nixos/switch-to-configuration: Provider better error message in cross-compiling situations` |
| [`66a0358a`](https://github.com/NixOS/nixpkgs/commit/66a0358a15337d99e89e31d6c20081b7b74854de) | `nixos-rebuild: document cross compilation subtlety`                                         |
| [`951c0139`](https://github.com/NixOS/nixpkgs/commit/951c01396e976c6374d994d0bf57794246668c9a) | `asmfmt: 1.2.3 -> 1.3.2`                                                                     |
| [`2366f055`](https://github.com/NixOS/nixpkgs/commit/2366f0554e32e4424e45a4bdbd12515b2db13ead) | `go-containerregistry: 0.6.0 -> 0.8.0`                                                       |
| [`b7334992`](https://github.com/NixOS/nixpkgs/commit/b7334992e5ee5a73838013093a9a04766f1a1379) | `rbspy: 0.10.0 -> 0.11.1`                                                                    |
| [`0df4a592`](https://github.com/NixOS/nixpkgs/commit/0df4a5922d3fa548ff41a8e11d36c64ab8d21a18) | `aerc: 0.7.1 -> 0.8.2`                                                                       |
| [`d2ae11af`](https://github.com/NixOS/nixpkgs/commit/d2ae11afb7b2348d3c847e73f7d1e5a2e70bcbc6) | `rbspy: init at 0.10.0`                                                                      |
| [`ba8ec9d6`](https://github.com/NixOS/nixpkgs/commit/ba8ec9d6d22697ccfce290f6e1ba5bb0f7371c4b) | `maintainers: viraptor`                                                                      |
| [`e5c53450`](https://github.com/NixOS/nixpkgs/commit/e5c534504ad33bca46d883d9ca8e54179269c7cb) | `python310Packages.pytest-regressions: 2.3.0 -> 2.3.1`                                       |
| [`01a76b15`](https://github.com/NixOS/nixpkgs/commit/01a76b159a6ab07710492064ae658b9c0a6658ac) | `python310Packages.nilearn: 0.8.1 -> 0.9.0`                                                  |
| [`0181cd96`](https://github.com/NixOS/nixpkgs/commit/0181cd9654ad3cc56277907af942fcff095957fa) | `cadvisor: 0.38.7 -> 0.40.0`                                                                 |
| [`6063283b`](https://github.com/NixOS/nixpkgs/commit/6063283be1ffdd5334569929a3e7e9df03508011) | `groonga: 11.0.9 -> 11.1.0`                                                                  |
| [`01ec4349`](https://github.com/NixOS/nixpkgs/commit/01ec4349f20157dd3bbcc1f3a540eb051c47be50) | `docs: Make coding conventions use pname/version`                                            |