### PR TITLE
chore(flake/nixpkgs): `9a5459ef` -> `5ff0fefd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1649955614,
-        "narHash": "sha256-Vtii9SrPxJVmwEr2t0RzrTMOmQRYXRWvdOTmvzBUaZ4=",
+        "lastModified": 1649976856,
+        "narHash": "sha256-lYDbPZICJr99X31WM2KOPt4cCEBPhGyJf7niD3TbTPc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9a5459efddbcce460fddf7f199fe85ba6e3f6ed4",
+        "rev": "5ff0fefd745160350b834197f477f789c75b453d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                 |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`0efb6720`](https://github.com/NixOS/nixpkgs/commit/0efb6720a4bbd88fa0e678cc43ba9971ea54991f) | `nixos/console: Fix attribute path to fix eval`                |
| [`beb649f5`](https://github.com/NixOS/nixpkgs/commit/beb649f5d1e1de2f388ab4187ec193b0e3d6b81a) | `home-assistant: 2022.4.3 -> 2022.4.4`                         |
| [`3c18b810`](https://github.com/NixOS/nixpkgs/commit/3c18b8109fe0a033fa177a1b048d07eba8d09fd3) | `iperf3: fix darwin build`                                     |
| [`50a3da21`](https://github.com/NixOS/nixpkgs/commit/50a3da21cced929670c8942b116b1749bdb2a95f) | `aerc: added PREFIX to makeFlags`                              |
| [`80c9f128`](https://github.com/NixOS/nixpkgs/commit/80c9f128c3b3fd47642a0c939627a7b0c6ed53f3) | `pomerium: 0.17.0 -> 0.17.1`                                   |
| [`d5bc2dd1`](https://github.com/NixOS/nixpkgs/commit/d5bc2dd1ee8f10b5987375ed0b048d32a4ce22da) | `resilio-sync: 2.7.2 -> 2.7.3`                                 |
| [`68e866ec`](https://github.com/NixOS/nixpkgs/commit/68e866ecf276306e48d16c1468542ab05dbae835) | `wire-desktop: fix linux build`                                |
| [`e32344a9`](https://github.com/NixOS/nixpkgs/commit/e32344a937f53333ae95e7e117675dd552c29037) | `gitkraken: 8.3.3 -> 8.4.0`                                    |
| [`4888a0fd`](https://github.com/NixOS/nixpkgs/commit/4888a0fd60ddd193681c65e9d7340b943b0c1e1b) | `python310Packages.geocachingapi: 0.1.1 -> 0.2.1`              |
| [`7257b62f`](https://github.com/NixOS/nixpkgs/commit/7257b62fed7ba24430125245b97fcc0994e21ed7) | `sigma-cli: 0.3.4 -> 0.4.2`                                    |
| [`ca5f2f24`](https://github.com/NixOS/nixpkgs/commit/ca5f2f24dd6c64b64ac0a8fb39ae46b1b9454baf) | `python3Packages.pysigma-backend-splunk: 0.3.2 -> 0.3.2`       |
| [`3256de23`](https://github.com/NixOS/nixpkgs/commit/3256de2306697b893de3c96c2a4ed6381c7a98a5) | `python3Packages.pysigma-pipeline-sysmon: 0.1.3 -> 0.1.5`      |
| [`dce2386b`](https://github.com/NixOS/nixpkgs/commit/dce2386b15053a34afc673e1e7357e770a0dda83) | `python3Packages.pysigma-pipeline-crowdstrike: 0.1.4 -> 0.1.5` |
| [`ae215cde`](https://github.com/NixOS/nixpkgs/commit/ae215cde38b63e2384db78fdc6342f18940abe1b) | `python310Packages.dask-mpi: 2021.11.0 -> 2022.4.0`            |
| [`569beef0`](https://github.com/NixOS/nixpkgs/commit/569beef0505b287d76060c1829cf2cc15af34908) | `python3Packages.pysigma-backend-insightidr: init at 0.1.4`    |
| [`fd3bd023`](https://github.com/NixOS/nixpkgs/commit/fd3bd0233573513aacf629dbbde26cbbaa8d6704) | `python3Packages.pysigma-pipeline-windows: init at 0.1.0`      |
| [`fdf314ec`](https://github.com/NixOS/nixpkgs/commit/fdf314ecc778f0659ab7dd62b80d6baa8555960e) | `elpa-generated.nix manual fixup`                              |
| [`04205fa1`](https://github.com/NixOS/nixpkgs/commit/04205fa1705b45822e4f7b08ac985b1c17404ddc) | `elpa-packages 2022-04-14`                                     |
| [`243a9656`](https://github.com/NixOS/nixpkgs/commit/243a9656cc636d8db3fd9a0bbdcc3b1bdf4653cf) | `melpa-packages 2022-04-14`                                    |
| [`e974d301`](https://github.com/NixOS/nixpkgs/commit/e974d301c79aae8705963b9f9fe43acc53021ec5) | `nongnu-packages 2022-04-14`                                   |
| [`1f29a38f`](https://github.com/NixOS/nixpkgs/commit/1f29a38fd2941967bb78d33b0a5f22e056de0760) | `emacs.pkgs.cedet: remove`                                     |
| [`c3c640b5`](https://github.com/NixOS/nixpkgs/commit/c3c640b525433a2c5e931741c01cd29b754ac2fa) | `python3Packages.hahomematic: 1.1.1 -> 1.1.2`                  |
| [`fac61105`](https://github.com/NixOS/nixpkgs/commit/fac61105f1741d11fb3a95ac8732841a2467c8fe) | `python310Packages.awsiotpythonsdk: 1.5.1 -> 1.5.2`            |
| [`3889ddc2`](https://github.com/NixOS/nixpkgs/commit/3889ddc2fee770d76e3ac6100165e2c49fdc6387) | `_1password-gui: 8.6.0 -> 8.6.1`                               |
| [`6d6c1c34`](https://github.com/NixOS/nixpkgs/commit/6d6c1c341c8731bf53258f7b99c21a1b6c43bbf5) | `nixos/stage-1-systemd: Add keymap support`                    |
| [`73a50cd1`](https://github.com/NixOS/nixpkgs/commit/73a50cd17b6a6e1d555619c383667dac48273443) | `linux-rt_5_4: 5.4.182-rt72 -> 5.4.188-rt73`                   |
| [`d061104f`](https://github.com/NixOS/nixpkgs/commit/d061104f96b538697aea9044505b265403ccb2a1) | `linux: 5.17.2 -> 5.17.3`                                      |
| [`e7051124`](https://github.com/NixOS/nixpkgs/commit/e70511248b567d91eefffe92b918063acc39b097) | `linux: 5.16.19 -> 5.16.20`                                    |
| [`34a4c912`](https://github.com/NixOS/nixpkgs/commit/34a4c9124c31c09899784ccb36f0d0ab860ab0a4) | `linux: 5.15.33 -> 5.15.34`                                    |
| [`2e87b82c`](https://github.com/NixOS/nixpkgs/commit/2e87b82c8301100544162d1404e04c637c66e165) | `linux: 5.10.110 -> 5.10.111`                                  |
| [`9415d291`](https://github.com/NixOS/nixpkgs/commit/9415d2917ce2331bbc31e62ab45f941273c67a6e) | `linux: 4.9.309 -> 4.9.310`                                    |
| [`b6b2d227`](https://github.com/NixOS/nixpkgs/commit/b6b2d2273669a1eaf4f2078b65948ad76ed0d085) | `wayland-utils: add pkg-config to depsBuildBuild`              |
| [`d2b6c105`](https://github.com/NixOS/nixpkgs/commit/d2b6c105b746adc165eb5145656bf65fabb38b51) | `bottles: 2022.3.28-trento-1 -> 2022.4.14-trento`              |
| [`d7bd0d2f`](https://github.com/NixOS/nixpkgs/commit/d7bd0d2fd7a84fc565be4d25fc026d5d801d84c8) | `frogatto: unstable-2021-05-24 -> unstable-2022-04-13`         |
| [`84dbfa8f`](https://github.com/NixOS/nixpkgs/commit/84dbfa8f97099602cc88bcc31a42719920804af8) | `llvmPackages_14: 14.0.0 -> 14.0.1`                            |
| [`c8b87d19`](https://github.com/NixOS/nixpkgs/commit/c8b87d1933895a7f6359dad1bf90f27c0b8784d8) | `jenkins-job-builder: 3.12.0 -> 4.0.0`                         |
| [`71e25838`](https://github.com/NixOS/nixpkgs/commit/71e25838ced47001df06f27d80741b9d497373e7) | `ferdi: update source url`                                     |
| [`0350a328`](https://github.com/NixOS/nixpkgs/commit/0350a32863fa28c9653bdc4de893acbb967ed698) | `signalbackup-tools: 20220316 -> 20220411`                     |
| [`d25da7b2`](https://github.com/NixOS/nixpkgs/commit/d25da7b2aabbce21dcf2a99f9e1da65c25f0260a) | `python3Packages.wandb: 0.12.11 -> 0.12.14`                    |
| [`6a548352`](https://github.com/NixOS/nixpkgs/commit/6a54835299e726268805d458fcaf0bebc9754a50) | `mindustry: Set ALSA_PLUGIN_DIR environment variable`          |
| [`ca0a463f`](https://github.com/NixOS/nixpkgs/commit/ca0a463f7414a1b32a4c272d9cf22ab45518dbfc) | `python3Packages.pysigma: 0.4.5 -> 0.5.0`                      |
| [`cb246b3a`](https://github.com/NixOS/nixpkgs/commit/cb246b3a1df15c4dc0d303b48208450ed65b58b7) | `ghc_filesystem: 1.5.6 -> 1.5.12`                              |
| [`fe5ca118`](https://github.com/NixOS/nixpkgs/commit/fe5ca118bf107c61f2843c09bd3d5437bbd57257) | `fop: 2.6 -> 2.7`                                              |
| [`c0e4e9a3`](https://github.com/NixOS/nixpkgs/commit/c0e4e9a3771b1f5a64e9b4eb56d8d55f5b73e89f) | `python310Packages.datasets: 1.17.0 -> 1.18.3`                 |