### PR TITLE
chore(flake/nixpkgs): `d3b68c67` -> `c59a0dbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650020041,
-        "narHash": "sha256-mtGIrXOrewxq2aLt1FUWVL0bRzxEsr0sznO+e3L7nWc=",
+        "lastModified": 1650077293,
+        "narHash": "sha256-Q14fxqkzmcx5/kl3OMf7v3qzm4jorMYhDmZS7Nlt8Ws=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d3b68c67ea981267eb406097aba5c8c299fd1d68",
+        "rev": "c59a0dbc738181bc20aaee4b0ad1a4bcfdaa347f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`bc710213`](https://github.com/NixOS/nixpkgs/commit/bc7102133f734715729a923d3a3b08abf288fac4) | `libbpf: remove unused with builtins`                                                           |
| [`b45fbd05`](https://github.com/NixOS/nixpkgs/commit/b45fbd05f3cf05905484a57863a3e3daf7e30784) | `vimPlugins.coc-flutter: init at 1.9.7`                                                         |
| [`bb426117`](https://github.com/NixOS/nixpkgs/commit/bb426117beec29e9712031a1ccb70dd6a0d0123d) | `add coc-flutter NPM dependency`                                                                |
| [`ebe4780c`](https://github.com/NixOS/nixpkgs/commit/ebe4780c21c9a93044fb78f50648370d7a9f50a3) | `discord-canary: 0.0.134 -> 0.0.135`                                                            |
| [`659ce471`](https://github.com/NixOS/nixpkgs/commit/659ce471aef17d9553b9aebe9eda641316159033) | `pony-corral: 0.5.4 -> 0.5.7`                                                                   |
| [`6f3df13a`](https://github.com/NixOS/nixpkgs/commit/6f3df13a9b77965f6aa2088098ea62e103e9a14e) | `ponyc: 0.44.0 -> 0.49.0`                                                                       |
| [`dcf937e9`](https://github.com/NixOS/nixpkgs/commit/dcf937e9e264b0fafba2f88c486ffee180d20319) | `python3Packages.boltztrap2: add pythonImportsCheck`                                            |
| [`77e1ad8f`](https://github.com/NixOS/nixpkgs/commit/77e1ad8f3a99467a0b4f77bd321991d2e85c2765) | `python310Packages.gb-io: init at 0.1.1`                                                        |
| [`1a1f0df5`](https://github.com/NixOS/nixpkgs/commit/1a1f0df5ac4e028d43fa883590b45a604df451c5) | `python3Packages.pyezviz: 0.2.0.6 -> 0.2.0.7`                                                   |
| [`b8cd059d`](https://github.com/NixOS/nixpkgs/commit/b8cd059d5458ca1f5be94afa2e30712b13afbd28) | `python3Packages.boschshcpy: 0.2.30 -> 0.2.31`                                                  |
| [`16b58a5f`](https://github.com/NixOS/nixpkgs/commit/16b58a5fbefcf5cdecfff231ae7afa81c4aad188) | `python3Packages.asdf-standard: 1.0.1 -> 1.0.2`                                                 |
| [`c39d8b0b`](https://github.com/NixOS/nixpkgs/commit/c39d8b0bed0c06f12c35bebe957da7111a17de81) | `spire: 1.2.1 -> 1.2.3`                                                                         |
| [`205c92f9`](https://github.com/NixOS/nixpkgs/commit/205c92f9143d238030739588b4af77b09bd922b0) | `python3Packages.xknx: 0.20.2 -> 0.20.3`                                                        |
| [`d80c876d`](https://github.com/NixOS/nixpkgs/commit/d80c876d48d673aef50994b5920257bde403be3e) | `metasploit: 6.1.37 -> 6.1.38`                                                                  |
| [`ff73ea1c`](https://github.com/NixOS/nixpkgs/commit/ff73ea1c8f25ee574cb87a5d6c2824100ca6d711) | `template-glib: fix buildInputs`                                                                |
| [`c611bdf2`](https://github.com/NixOS/nixpkgs/commit/c611bdf21f1261c833e05236bfc3d6183bdfcc95) | `pscircle: fix buildInputs`                                                                     |
| [`98b58acb`](https://github.com/NixOS/nixpkgs/commit/98b58acbf8543409b19f8578575a45711d9d68c3) | `gti: 1.7.0 -> 1.8.0`                                                                           |
| [`17a406f2`](https://github.com/NixOS/nixpkgs/commit/17a406f28add4a194242d1b2f3b0a37efc2e2449) | `nixos/matrix-synapse: fix typo in mkRemovedOptionModule replacementInstructions`               |
| [`a491ff3d`](https://github.com/NixOS/nixpkgs/commit/a491ff3da806b3747771f762c2becc16503906ae) | `hwi: 2.0.2 -> 2.1.0`                                                                           |
| [`86477ef2`](https://github.com/NixOS/nixpkgs/commit/86477ef2326f4c98f6f8fd19cd8a61d61b571f5d) | `kotatogram-desktop: reference llvm stdenv directly`                                            |
| [`7c060cf3`](https://github.com/NixOS/nixpkgs/commit/7c060cf3bb61fdaf73e5b9286e63466974ff70f4) | `python3Packages.pywlroots: 0.15.11 -> 0.15.12`                                                 |
| [`77a8b9fa`](https://github.com/NixOS/nixpkgs/commit/77a8b9fa82a45bbf48978aaa095ce72b8ff5e0a9) | `zesarux: fix build for libcaca-0.99.beta20`                                                    |
| [`87aaadd0`](https://github.com/NixOS/nixpkgs/commit/87aaadd0f4eadf0231d3e7c897062c593405891f) | `python3Packages.pyvis: unstable-2021-04-29 -> 0.2.1`                                           |
| [`a86ab314`](https://github.com/NixOS/nixpkgs/commit/a86ab314f6062064312d0df860a83b109f2f43e5) | `slides: 0.7.3 -> 0.8.0`                                                                        |
| [`da7db625`](https://github.com/NixOS/nixpkgs/commit/da7db62574d6aca32724e36c431a41aca77c5f41) | `python3Packages.cypherpunkpay: init at 1.0.15`                                                 |
| [`c58d2930`](https://github.com/NixOS/nixpkgs/commit/c58d293034443bbd1b08ead1be89dca03dc4cf21) | `python3Packages.waitress: 2.0.0 -> 2.1.1`                                                      |
| [`f1c41485`](https://github.com/NixOS/nixpkgs/commit/f1c414858b151a466861959baff9636008654c0c) | `python3Packages.yoyo-migrations: init at 7.3.2`                                                |
| [`96ba8a65`](https://github.com/NixOS/nixpkgs/commit/96ba8a65a1ab2518fd8df11276685ad7a182df97) | `python3Packages.pypng: init at 0.0.21`                                                         |
| [`55b00e72`](https://github.com/NixOS/nixpkgs/commit/55b00e72d4331f1920c2b1727ea25df738359ab0) | `python3Packages.monero: init at 1.0.1`                                                         |
| [`5d05f3ac`](https://github.com/NixOS/nixpkgs/commit/5d05f3acf015f6ac10a1a4acac661893ca8068ac) | `melt: 0.2.0 -> 0.3.0`                                                                          |
| [`5ca6bb92`](https://github.com/NixOS/nixpkgs/commit/5ca6bb92327a8f30547bd7438a1e774b66fc3792) | `python3Packages.pypykatz: 0.5.2 -> 0.5.6`                                                      |
| [`881f8078`](https://github.com/NixOS/nixpkgs/commit/881f80782440306f1e6d604f2e1e8dcb21c530e7) | `python3Packages.aesedb: init at 0.0.5`                                                         |
| [`4aab12d5`](https://github.com/NixOS/nixpkgs/commit/4aab12d5a1aa1c09e1b5a2f759097848ae619f1f) | `lib/systems/platforms: correctly import examples.nix`                                          |
| [`ac83e58d`](https://github.com/NixOS/nixpkgs/commit/ac83e58d622dddb4a64c526fe29f9c70c9f5eb62) | `glab: install shell completions (#168166)`                                                     |
| [`4c11b49f`](https://github.com/NixOS/nixpkgs/commit/4c11b49f2c7f3b12c982d036cfdef063fbaf50cc) | `python310Packages.pysigma-backend-insightidr: 0.1.4 -> 0.1.5`                                  |
| [`2af96a48`](https://github.com/NixOS/nixpkgs/commit/2af96a4832eab80071287f7c39a2ef6e85aa7906) | `update node-packages.nix`                                                                      |
| [`96ea452f`](https://github.com/NixOS/nixpkgs/commit/96ea452f5cbb289e4df3920b0958bc5b6bea6d4e) | `pythonPackages.nix-prefetch-github: 5.0.1 -> 5.1.2`                                            |
| [`985e1340`](https://github.com/NixOS/nixpkgs/commit/985e1340e25264a2ff1b7d7bfa578527ba42ea00) | `neomutt: 20220408 -> 20220415`                                                                 |
| [`f573afae`](https://github.com/NixOS/nixpkgs/commit/f573afae7763ff2823a7c948e08dab0a7e7b40e8) | `soft-serve: 0.2.3 -> 0.3.0`                                                                    |
| [`aaffbf92`](https://github.com/NixOS/nixpkgs/commit/aaffbf925cecbe3de2c85f3e564e69221e29e440) | `spdlog: fix build on aarch64-darwin`                                                           |
| [`a839c59d`](https://github.com/NixOS/nixpkgs/commit/a839c59d4ecfa9bdef0980044289a3d46a306156) | `spdlog: 1.9.2 -> 1.10.0`                                                                       |
| [`24dbe601`](https://github.com/NixOS/nixpkgs/commit/24dbe601c9f98f31213db21c07b7ffd7316b9534) | `mtools: Fix build on darwin by providing libiconv to buildInputs`                              |
| [`6f2f0aae`](https://github.com/NixOS/nixpkgs/commit/6f2f0aaeb76a3c80557afae8eafe22b985cc3e01) | `php74Packages.composer: 2.3.3 -> 2.3.5`                                                        |
| [`c8af35f3`](https://github.com/NixOS/nixpkgs/commit/c8af35f3511135de0fa600f8666168955e54c62a) | `python310Packages.plugwise: 0.17.6 -> 0.17.7`                                                  |
| [`f4e30266`](https://github.com/NixOS/nixpkgs/commit/f4e30266399c0ed3a73c02f61c4281ae562cc96a) | `blanket: 0.5.0 -> 0.6.0`                                                                       |
| [`92282f19`](https://github.com/NixOS/nixpkgs/commit/92282f192977fb765c3ecdef260f89e682fbf3a2) | `python3Packages.pyefergy: disable tests`                                                       |
| [`7210bc05`](https://github.com/NixOS/nixpkgs/commit/7210bc054e0034614325c4dfb5d33a3a11e3eb8a) | `python3Packages.iso4217: 1.8 -> 1.9`                                                           |
| [`08bdeab5`](https://github.com/NixOS/nixpkgs/commit/08bdeab5c0ff1967f325e8b88367459ee6e50796) | `python3Packages.sqlite-utils: add pythonImportsCheck`                                          |
| [`c30945a9`](https://github.com/NixOS/nixpkgs/commit/c30945a93fbd3122a55ee6a63c9bfef7556bc82e) | `element-{web,desktop}: 1.10.9 -> 1.10.10`                                                      |
| [`2be32fb5`](https://github.com/NixOS/nixpkgs/commit/2be32fb551caaf9fc6418fa414a3d85fab0381c1) | `kotatogram-desktop: fix screensharing on Wayland`                                              |
| [`7cd37990`](https://github.com/NixOS/nixpkgs/commit/7cd37990742643121a7abb8307b03df069575a70) | `kotatogram-desktop: use clang*Stdenv instead of llvmPackages_*.*stdenv`                        |
| [`868da590`](https://github.com/NixOS/nixpkgs/commit/868da590664a9a733d7a24a3faa3a1b4b0e4cf2c) | `kotatogram-desktop: update patches to fix build on Darwin`                                     |
| [`923748a6`](https://github.com/NixOS/nixpkgs/commit/923748a634f02aab2192d92fb9b6fd24553a6aaf) | `kotatogram-desktop: update tg_owt`                                                             |
| [`11e148c2`](https://github.com/NixOS/nixpkgs/commit/11e148c25978bb994a9a070f82be9c42e8e72100) | `napari: 0.4.14 -> 0.4.15`                                                                      |
| [`572d0f99`](https://github.com/NixOS/nixpkgs/commit/572d0f99978cfd4c59e1facc99e1561cd4e68e11) | `firefox-devedition-bin-unwrapped: 100.0b5 -> 100.0b6`                                          |
| [`bedc267a`](https://github.com/NixOS/nixpkgs/commit/bedc267a787ee68b4c02f168414f67885907f7b0) | `autoPatchelfHook: fix precise dependency ignorance`                                            |
| [`f27bf2d1`](https://github.com/NixOS/nixpkgs/commit/f27bf2d18452191cee3117122777985775d194ae) | `dsq: 0.13.0 -> 0.14.0`                                                                         |
| [`1027708f`](https://github.com/NixOS/nixpkgs/commit/1027708f7857ebdd499cf867559de7e2778b09d1) | `cudatext: 1.160.2 -> 1.161.0`                                                                  |
| [`17592568`](https://github.com/NixOS/nixpkgs/commit/175925681ae2980c5d7737245295799a8220d8b8) | `libsForQt5.bismuth: 3.1.0 -> 3.1.1`                                                            |
| [`f8f803a0`](https://github.com/NixOS/nixpkgs/commit/f8f803a0911b6426444d8cf0ca6c18a9101a0784) | `cubicsdr: 0.2.5 -> 0.2.7`                                                                      |
| [`d2b696f5`](https://github.com/NixOS/nixpkgs/commit/d2b696f5d47cbc80bb043ab877505c27ef2dfe97) | `python3Packages.qiskit-finance: fix build`                                                     |
| [`85b36507`](https://github.com/NixOS/nixpkgs/commit/85b365078ae553ccc8ef9dbd36de85445d74e29e) | `python3Packages.qiskit: 0.34.2 -> 0.36.0`                                                      |
| [`42a14c6b`](https://github.com/NixOS/nixpkgs/commit/42a14c6b27cbe25fcfa423d11ce23f68a8496b99) | `python3Packages.qiskit-nature: 0.3.1 -> 0.3.2`                                                 |
| [`e95a6329`](https://github.com/NixOS/nixpkgs/commit/e95a63295b2e0eff8eb57fee6ef71d60553f7246) | `python3Packages.qiskit-ibmq-provider: 0.18.3 -> 0.19.0`                                        |
| [`c519bc33`](https://github.com/NixOS/nixpkgs/commit/c519bc33e89fad4b97685725760dfd26f7f8f96b) | `python3Packages.qiskit-aer: 0.10.3 -> 0.10.4`                                                  |
| [`04cac0d4`](https://github.com/NixOS/nixpkgs/commit/04cac0d41a59478630c222e2626a95abf809ce5a) | `jaxlib: fixed build with newer bazel version`                                                  |
| [`fbfa7ea8`](https://github.com/NixOS/nixpkgs/commit/fbfa7ea82dd27b19d56c9f505ff5a013e749a630) | `mruby: add patch for CVE-2022-1212`                                                            |
| [`8c335044`](https://github.com/NixOS/nixpkgs/commit/8c33504431e9669f324db150174d5bc8de2bbfcf) | `discourse: 2.9.0.beta3 -> 2.9.0.beta4`                                                         |
| [`1b1204bc`](https://github.com/NixOS/nixpkgs/commit/1b1204bc49114b80d4573c421bc4bfd677275ea4) | `python3Packages.qiskit-terra: 0.19.2 -> 0.20.0`                                                |
| [`3bb46db1`](https://github.com/NixOS/nixpkgs/commit/3bb46db14e289d751d5ab06b59fb88d38ad8038c) | `nixos/release-notes: document ncdns incompatible changes`                                      |
| [`a1cb6e5a`](https://github.com/NixOS/nixpkgs/commit/a1cb6e5a88b607ef18feedee5d9b6ac952173d9d) | `nixos/tests/ncdns: fix test`                                                                   |
| [`d39a10da`](https://github.com/NixOS/nixpkgs/commit/d39a10daa8488cc23ad43d48dd27cd74dff192e1) | `nixos/ncdns: listen on IPv6 by default`                                                        |
| [`affb1469`](https://github.com/NixOS/nixpkgs/commit/affb14690618427ec173231a939a79047751e72f) | `python310Packages.sqlite-utils: 3.25.1 -> 3.26`                                                |
| [`f81ef7f3`](https://github.com/NixOS/nixpkgs/commit/f81ef7f3fd80d86c2b58bbea62d0f0cc7ac6595c) | `skaffold: 1.37.1 -> 1.38.0`                                                                    |
| [`f681f8f1`](https://github.com/NixOS/nixpkgs/commit/f681f8f18b18fc9441d0594680a6f63822f6bd5d) | `librewolf: 99.0-1 -> 99.0.1-3`                                                                 |
| [`c28d2ec4`](https://github.com/NixOS/nixpkgs/commit/c28d2ec40e96ae580a4d63f1ff71fb83402ebc2f) | `github-runner: 2.290.0 -> 2.290.1`                                                             |
| [`c8a9752b`](https://github.com/NixOS/nixpkgs/commit/c8a9752b78e346a05351fb6d8582b25a07493e60) | `rspamd: 3.1 -> 3.2`                                                                            |
| [`af4513a9`](https://github.com/NixOS/nixpkgs/commit/af4513a975bc43257e6d2567ddeeeec6594169a5) | `python310Packages.ipympl: 0.8.8 -> 0.9.0`                                                      |
| [`a3e1e927`](https://github.com/NixOS/nixpkgs/commit/a3e1e9271e0ff87309d44f9817baadb09b305757) | `cln: fix darwin build`                                                                         |
| [`a1244414`](https://github.com/NixOS/nixpkgs/commit/a1244414d524a2ce9cc91ce53d53e0320677f1fd) | `coqPackages.smtcoq: init at itp22`                                                             |
| [`85662537`](https://github.com/NixOS/nixpkgs/commit/85662537465b671eb19616845166bfe22c19bb13) | `coqPackages.trakt: init at 1.0`                                                                |
| [`eb63cc10`](https://github.com/NixOS/nixpkgs/commit/eb63cc10d58e89d302d801e9bdb12b714bd0b9fb) | `xmrig-mo:  6.16.4-mo1 -> 6.16.5-mo1`                                                           |
| [`9552ab1c`](https://github.com/NixOS/nixpkgs/commit/9552ab1ca330b8ace2c60df95e4bf9a1d1394a27) | `patroni: enable for unix`                                                                      |
| [`a4b6c7c6`](https://github.com/NixOS/nixpkgs/commit/a4b6c7c6c487db181f50a3a0feaf1b00db018a56) | `caffeine-ng: fix broken tray icon`                                                             |
| [`7a5d6894`](https://github.com/NixOS/nixpkgs/commit/7a5d68948cd01ade9856bd0c5aae0074289ab73d) | `anytype: 0.24.0 -> 0.25.0`                                                                     |
| [`4cb0e30e`](https://github.com/NixOS/nixpkgs/commit/4cb0e30e581cc6ce3c94e38081f843a25053cf5e) | `adguardhome: 0.107.5 - 0.107.6`                                                                |
| [`2bc6afce`](https://github.com/NixOS/nixpkgs/commit/2bc6afceaf93cce7749612aa56e1626cf54f6269) | `portfolio: adds shawn8901 as maintainer`                                                       |
| [`ae10b8d0`](https://github.com/NixOS/nixpkgs/commit/ae10b8d024ad669a2812e96e9d8c1578ed4904ff) | `wormhole-william: enable tests`                                                                |
| [`d1559c59`](https://github.com/NixOS/nixpkgs/commit/d1559c59c21d9e34dd8585aeb8692457eaed1b7e) | `python310Packages.boltztrap2: 22.3.2 -> 22.4.1`                                                |
| [`ed30d3b0`](https://github.com/NixOS/nixpkgs/commit/ed30d3b02f56c1da19fb35459c3aa120b75eaf7b) | `keycloak: Switch to the new Quarkus version of Keycloak`                                       |
| [`343e37e9`](https://github.com/NixOS/nixpkgs/commit/343e37e9bb10128231ae9a68f9beaa3f9495b179) | `python310Packages.pubnub: 6.2.0 -> 6.3.0`                                                      |
| [`6bc41e6a`](https://github.com/NixOS/nixpkgs/commit/6bc41e6a5c8a1ee7029e3dd08ea1cf20f8b003f3) | `python3Packages.igraph: 0.9.9 -> 0.9.10`                                                       |
| [`161e5696`](https://github.com/NixOS/nixpkgs/commit/161e569665c8e3cdde5a9a0e6e6c07ba6d24ddd7) | `igraph: 0.9.7 -> 0.9.8`                                                                        |
| [`8b5c9741`](https://github.com/NixOS/nixpkgs/commit/8b5c9741f9cb552e92886bfc084fada4088ce0f2) | `portfolio: 0.56.5 -> 0.57.1`                                                                   |
| [`9d4635ed`](https://github.com/NixOS/nixpkgs/commit/9d4635ed6d8fc6139af16a2083202748b9071afd) | `mill: 0.10.2 -> 0.10.3`                                                                        |
| [`1da640b2`](https://github.com/NixOS/nixpkgs/commit/1da640b2076bfe44e124cef34e0845a1cd8701ab) | `stork: 1.4.1 -> 1.4.2`                                                                         |
| [`5382623d`](https://github.com/NixOS/nixpkgs/commit/5382623d7f035fb65e84d4712ab357b18ff00d88) | `vivaldi-widevine: 4.10.2391.0 -> 4.10.2449.0`                                                  |
| [`6951c5b6`](https://github.com/NixOS/nixpkgs/commit/6951c5b6d990fb381fd030864bdd4bef1b8ece6b) | `python310Packages.asn1crypto: 1.4.0 -> 1.5.1`                                                  |
| [`03771f6d`](https://github.com/NixOS/nixpkgs/commit/03771f6d87321907b7c87dd5ecc096c2c09676fc) | `python310Packages.testing-common-database: patch collections.Callable for python 3.10 support` |
| [`33b61afd`](https://github.com/NixOS/nixpkgs/commit/33b61afdd9c092c118b860f8e87dfeb814b05e0d) | `python39Packages.django-hijack-admin: mark as broken`                                          |
| [`3760e94f`](https://github.com/NixOS/nixpkgs/commit/3760e94ffa50e5bab21edbb93a384d682101f72e) | `python3Packages.django-hijack: 2.1.10 -> 3.2.0`                                                |
| [`d018a536`](https://github.com/NixOS/nixpkgs/commit/d018a53664cb57abf14af63320b2bacf131c2428) | `trilium: 0.50.2 -> 0.50.3`                                                                     |
| [`a02786a2`](https://github.com/NixOS/nixpkgs/commit/a02786a2e81127e111f346151d403434d90c8006) | `ntfy-sh: 1.19.0 -> 1.20.0`                                                                     |
| [`d36e0267`](https://github.com/NixOS/nixpkgs/commit/d36e02678bbcf55dfe745e19363e3dd494d13408) | `hydrus: 479 -> 480`                                                                            |
| [`b68eb22b`](https://github.com/NixOS/nixpkgs/commit/b68eb22b90e3b42f10e93d0289747147ac530bf8) | `xjadeo: 0.8.10 -> 0.8.11`                                                                      |
| [`e251a4e6`](https://github.com/NixOS/nixpkgs/commit/e251a4e67fe849104c63a94102fdd2772f3ef8a1) | `protoc-gen-twirp: 8.1.1 -> 8.1.2`                                                              |
| [`fb245f54`](https://github.com/NixOS/nixpkgs/commit/fb245f546a122d65a107f7fdeff9e44501964279) | `rasdaemon: 0.6.7 -> 0.6.8`                                                                     |
| [`b5639fc9`](https://github.com/NixOS/nixpkgs/commit/b5639fc91bf5a4858f0f0a3db867d7fb9df790e2) | `liquid-dsp: 20170307 -> 1.4.0`                                                                 |
| [`d8bae875`](https://github.com/NixOS/nixpkgs/commit/d8bae875e07d7dc43bf1bf9087bdf10f076793a0) | `nixosTests.haste-server: init`                                                                 |
| [`a1cbf8cf`](https://github.com/NixOS/nixpkgs/commit/a1cbf8cfffc04a4cb493fa4f1c296668119ac4ca) | `nixos/haste-server: add`                                                                       |
| [`442ced61`](https://github.com/NixOS/nixpkgs/commit/442ced61547e4a6942166ee81df3f800ff66f786) | `haste-server: init at 3dcc43578b99dbafac35dece9d774ff2af39e8d0`                                |
| [`4257b3c0`](https://github.com/NixOS/nixpkgs/commit/4257b3c056882e60298367ce3ecdf2a803c7ef08) | `prometheus-bird-exporter: 1.4.0 -> 1.4.1`                                                      |