### PR TITLE
chore(flake/nixpkgs): `c59a0dbc` -> `4dab52db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650077293,
-        "narHash": "sha256-Q14fxqkzmcx5/kl3OMf7v3qzm4jorMYhDmZS7Nlt8Ws=",
+        "lastModified": 1650118033,
+        "narHash": "sha256-EdI6eoFmnK8MJc8m3LdaFka2uNQ0Wv2/EtHfmPiGnqE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c59a0dbc738181bc20aaee4b0ad1a4bcfdaa347f",
+        "rev": "4dab52dbc93fd0d1b23fa0908de04fc3eb49a34c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
| [`b01b9080`](https://github.com/NixOS/nixpkgs/commit/b01b9080bd892b1084515a46fe8507699d9272fa) | `vector: 0.20.1 -> 0.21.0`                                                                               |
| [`7d83997e`](https://github.com/NixOS/nixpkgs/commit/7d83997eb49f8098ac3dd2c1641d873bbba394c8) | `busybox: 1.34.1 -> 1.35.0`                                                                              |
| [`9f4b7f29`](https://github.com/NixOS/nixpkgs/commit/9f4b7f2952d71eb2a8abd99d3d15c7e4ccd90aee) | `libpostal: mark supported on darwin`                                                                    |
| [`faad370e`](https://github.com/NixOS/nixpkgs/commit/faad370edcb37162401be50d45526f52bb16a713) | `nixos/ipfs: fix the services.ipfs.autoMigrate option`                                                   |
| [`8a5e5152`](https://github.com/NixOS/nixpkgs/commit/8a5e51525d44b1468018c0b0a4c0758bcb533657) | `nixos/ipfs: add Luflosi as maintainer`                                                                  |
| [`6b2eca8d`](https://github.com/NixOS/nixpkgs/commit/6b2eca8d5654837a2e7ac2caf2938e79d02778cb) | `nixos/ipfs: remove unused code`                                                                         |
| [`077d187a`](https://github.com/NixOS/nixpkgs/commit/077d187a4b37ba81ebe9f6985c1dbd0b19f6d33d) | `broadcom_sta: fix build on linux 5.17`                                                                  |
| [`bc5e8ae5`](https://github.com/NixOS/nixpkgs/commit/bc5e8ae506d1d25cd62560e6bc626cf334f7336f) | `buildRustCrate: don't try to set CARGO_FEATURE_ variables for dep: features`                            |
| [`4624d0a8`](https://github.com/NixOS/nixpkgs/commit/4624d0a8d30b6f5c67347114b05bd95baed7e2dc) | `bacon: 2.0.1 -> 2.1.0`                                                                                  |
| [`4f1fd175`](https://github.com/NixOS/nixpkgs/commit/4f1fd175d300020f5b318500a57f974df9b2e8fc) | `brave: 1.37.113 -> 1.37.116`                                                                            |
| [`bc73bc21`](https://github.com/NixOS/nixpkgs/commit/bc73bc21ce933a4a9b31ff2ee64deb655498fb2d) | `graalvm17-ce: enable Native Image in aarch64-linux`                                                     |
| [`0e9bebed`](https://github.com/NixOS/nixpkgs/commit/0e9bebed0c0ed6f15d7c6873df57d463297eb02f) | `neovim: 0.6.0 -> 0.7.0`                                                                                 |
| [`3016d0ae`](https://github.com/NixOS/nixpkgs/commit/3016d0aeb8458210e449bf2adeafef2ee539e89c) | `polybar: 3.5.7 -> 3.6.2`                                                                                |
| [`70d0e245`](https://github.com/NixOS/nixpkgs/commit/70d0e2456857dc10dd7d2654277fc1dd8d8cc216) | `nixos/logrotate: use packages from buildPackages in configuration checkPhase, fixing cross compilation` |
| [`a86ec5d4`](https://github.com/NixOS/nixpkgs/commit/a86ec5d4d60b7aebd07e3d465423430e93d985dd) | `python3Packages.pymazda: 0.3.2 -> 0.3.3`                                                                |
| [`389ea38a`](https://github.com/NixOS/nixpkgs/commit/389ea38a85daef56c4e0f4cd0eb5ab65b48a0057) | `python3Packages.syslog-rfc5424-formatter: disable on older Python releases`                             |
| [`8fe13bfa`](https://github.com/NixOS/nixpkgs/commit/8fe13bfac72307b2e5b06d103e8c81239c255261) | `python310Packages.syslog-rfc5424-formatter: 1.2.2 -> 1.2.3`                                             |
| [`b558afaa`](https://github.com/NixOS/nixpkgs/commit/b558afaa5f27e13808dfe03722fbb657f5265edf) | `python3Packages.flux-led: 0.28.27 -> 0.28.28`                                                           |
| [`5e6bd577`](https://github.com/NixOS/nixpkgs/commit/5e6bd5771bdf0ac79b705e1444b194ecb70adc4b) | `kde-frameworks: update homepage`                                                                        |
| [`913242e4`](https://github.com/NixOS/nixpkgs/commit/913242e45c185b008f6e3bec8c3812bcba8b5491) | `python3Packages.git-annex-adapter: fix build`                                                           |
| [`67565c3a`](https://github.com/NixOS/nixpkgs/commit/67565c3af8982a4ccfe9d2ffbf9ca48116cc87eb) | `tests/emacs-daemon: fix failure for unset $DISPLAY`                                                     |
| [`55f57fac`](https://github.com/NixOS/nixpkgs/commit/55f57facbfabaee42908c24a2ac4b4dd8443fa65) | `emacs: 27.2 -> 28.1`                                                                                    |
| [`db6e8b75`](https://github.com/NixOS/nixpkgs/commit/db6e8b7538b6330d6aaa1c2fe437e2a1d0ca9ad9) | `vivaldi-ffmepg-codecs: 97.0.4692.71 -> 101.0.4951.15`                                                   |
| [`20f9d3e2`](https://github.com/NixOS/nixpkgs/commit/20f9d3e2ca5bf4d45396d2b3ed5dfc2bd275b330) | `vivaldi: 5.1.2567.73-1 -> 5.2.2623.39-1`                                                                |
| [`aa3157a8`](https://github.com/NixOS/nixpkgs/commit/aa3157a802a9c9e24d60a7b92d9f5516493b882e) | `sudolikeaboss: remove`                                                                                  |
| [`d78ebf03`](https://github.com/NixOS/nixpkgs/commit/d78ebf03f16a444999adea68305664f53f026768) | `python310Packages.pyamg: 4.2.2 -> 4.2.3`                                                                |
| [`d48d193e`](https://github.com/NixOS/nixpkgs/commit/d48d193e6b2adf6edb9ff08d64ca487aad44049e) | `babashka: 0.8.0 -> 0.8.1`                                                                               |
| [`44a44019`](https://github.com/NixOS/nixpkgs/commit/44a44019456f9a0b9697dcae4664724ab340f700) | `buildGraalvmNativeImage: mark as broken if Native Image is not available`                               |
| [`158b0e03`](https://github.com/NixOS/nixpkgs/commit/158b0e037f175cd3a93ed5766be8cc4d10f4b3ef) | `graalvm17-ce: re-enable it on aarch64-linux`                                                            |
| [`4f8562f6`](https://github.com/NixOS/nixpkgs/commit/4f8562f6824e99973c67dd220617fb4517d41209) | `nixos/doc: add note about the recent graalvmXX-ce changes`                                              |
| [`399ed1f1`](https://github.com/NixOS/nixpkgs/commit/399ed1f1bda0546f4fbd73cd5c4d1dc0acc51fb1) | `graalvmXX-ce: remove Ruby/Python/WASM support`                                                          |
| [`782d03bc`](https://github.com/NixOS/nixpkgs/commit/782d03bca71ecfe225a6d71a9ca2d5055d8af327) | `graalvmXX-ee: remove`                                                                                   |
| [`efed8d05`](https://github.com/NixOS/nixpkgs/commit/efed8d05c7e6e4bc068fa1e0b8bab69aae5ac1af) | `python310Packages.mechanize: 0.4.7 -> 0.4.8`                                                            |
| [`b56bba18`](https://github.com/NixOS/nixpkgs/commit/b56bba188bb4a3deab64f00a89c646a748db4fdf) | `eva: 0.2.7 -> 0.3.0`                                                                                    |
| [`53988762`](https://github.com/NixOS/nixpkgs/commit/539887622b9bc33186fc0aed6f1eaccdb9e19833) | `starship: 2022-04-12 -> 1.6.2`                                                                          |
| [`942f536c`](https://github.com/NixOS/nixpkgs/commit/942f536c766f883694eccb50a9f1660e90a0da62) | `wasilibc: unstable-2021-09-23 -> unstable-2022-04-12`                                                   |
| [`c8c6adce`](https://github.com/NixOS/nixpkgs/commit/c8c6adced1331844ea047dc921f4e9335dff85aa) | `tldr: install completions`                                                                              |
| [`641257cc`](https://github.com/NixOS/nixpkgs/commit/641257cc96ee8d12fc0fb5f541625e1939ecd700) | `tldr: 1.4.2 -> 1.4.3`                                                                                   |
| [`fc88850f`](https://github.com/NixOS/nixpkgs/commit/fc88850f1077142a7abe70b5ffd390e453ea4095) | `dabet: init at 3.0.0`                                                                                   |
| [`f87ed34b`](https://github.com/NixOS/nixpkgs/commit/f87ed34bca7df09582a32df9be757f19a4b2e028) | `gotktrix: 0.1.2 -> 0.1.3`                                                                               |
| [`ee81903b`](https://github.com/NixOS/nixpkgs/commit/ee81903bdfe1c45cb9cdf137b2b2b27f51782b82) | `abcmidi: 2022.03.20 -> 2022.04.06`                                                                      |
| [`682b3d03`](https://github.com/NixOS/nixpkgs/commit/682b3d03efb4abfa3e715ab7a6fb111d7d479081) | `sickgear: 0.25.28 -> 0.25.31`                                                                           |
| [`9ff1ab40`](https://github.com/NixOS/nixpkgs/commit/9ff1ab4037e2c20bb4ff11af452e4321d17edc99) | `nixos/doc: add notes on additional drivers or firmware`                                                 |
| [`b8170722`](https://github.com/NixOS/nixpkgs/commit/b817072297e6ad9ebc73637c1d0dff0804554759) | `ejson2env: add version`                                                                                 |
| [`a0257674`](https://github.com/NixOS/nixpkgs/commit/a0257674da77e84bb33d655e3be0f92cbd4fe217) | `python310Packages.vertica-python: 1.0.4 -> 1.0.5`                                                       |
| [`72ff0a0b`](https://github.com/NixOS/nixpkgs/commit/72ff0a0bf853da399322acad72f1910727b219c7) | `openssh_hpn: 8.9p1 -> 9.0p1`                                                                            |
| [`825c7d59`](https://github.com/NixOS/nixpkgs/commit/825c7d5938eb5c0f866474df4db4f074a5b31cc3) | `dsq: pass version to the build`                                                                         |
| [`5d89f265`](https://github.com/NixOS/nixpkgs/commit/5d89f265661a113235d30bd16bb8e87e0126d108) | `python3Packages.nomadnet: init at 0.1.7`                                                                |
| [`bed3a732`](https://github.com/NixOS/nixpkgs/commit/bed3a732cb086389793d959633b6df2dbd641abe) | `python3Packages.lxmf: init at 0.1.4`                                                                    |
| [`0c401715`](https://github.com/NixOS/nixpkgs/commit/0c4017153957120c0953a355ee5eb39d5bf8acec) | `python3Packages.rns: init at 0.3.4`                                                                     |
| [`cb79cf47`](https://github.com/NixOS/nixpkgs/commit/cb79cf47f7624a46acbd964c207bdb4375a56bf7) | `gscan2pdf: 2.12.5 -> 2.12.6`                                                                            |
| [`219ca584`](https://github.com/NixOS/nixpkgs/commit/219ca5845235c7481e48096e32b34aac78630d79) | `gitUpdater: add explicit url parameter to specify a git tree for tags`                                  |
| [`745dd2d1`](https://github.com/NixOS/nixpkgs/commit/745dd2d18bdcbf1a8f175174b523e20341bbe579) | `xprintidle: init at 0.2.4`                                                                              |
| [`d1009de6`](https://github.com/NixOS/nixpkgs/commit/d1009de69837eddf285f89c68c89a26375d0e76a) | `mackerel-agent: 0.72.8 -> 0.72.9`                                                                       |
| [`f8e08ed2`](https://github.com/NixOS/nixpkgs/commit/f8e08ed20e65e1a20032b937158d6022c0f35300) | `liquibase: 4.8.0 -> 4.9.0`                                                                              |
| [`98aa1c7e`](https://github.com/NixOS/nixpkgs/commit/98aa1c7e30c035120cfa16030005515f6614eecc) | `Update nixos/modules/programs/chromium.nix`                                                             |
| [`de7e9374`](https://github.com/NixOS/nixpkgs/commit/de7e93748181f071d4689c319bfa1dc41573ad65) | `Removing trailing whitespace`                                                                           |
| [`8dda9e74`](https://github.com/NixOS/nixpkgs/commit/8dda9e74d50bdda66607587b0cf077767ebbb20f) | `programs.chromium fix policies for brave`                                                               |