### PR TITLE
chore(flake/home-manager): `7add9ce2` -> `0586d2d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650059391,
-        "narHash": "sha256-2kYYStLpPCcYToW+uZTP0jxmdR95URCret/vfpzJn4s=",
+        "lastModified": 1650148387,
+        "narHash": "sha256-Gle79/BVconHI4nfA5iXctjOPvoVuAYCYX12aM825DE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7add9ce2e5c517fcc4b25b3ed13e7e28cd325034",
+        "rev": "0586d2d42a7790554842e31efc61c06d1e236280",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`0586d2d4`](https://github.com/nix-community/home-manager/commit/0586d2d42a7790554842e31efc61c06d1e236280) | `keychain: set SHELL during initialization (#2880)`    |
| [`a640dddc`](https://github.com/nix-community/home-manager/commit/a640dddc9a176585b7f1a01579f3dcd5bda58b40) | `waybar: fix command not found when reloading (#2865)` |