### PR TITLE
chore(flake/home-manager): `0586d2d4` -> `8ab155c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650059391,
-        "narHash": "sha256-2kYYStLpPCcYToW+uZTP0jxmdR95URCret/vfpzJn4s=",
+        "lastModified": 1650148597,
+        "narHash": "sha256-/1V3grYy4GaqRgPjbBwWUY8mvZK/lfIPkkVtU/870ss=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7add9ce2e5c517fcc4b25b3ed13e7e28cd325034",
+        "rev": "8ab155c61f5821ffda723de88b0009769771d4f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`8ab155c6`](https://github.com/nix-community/home-manager/commit/8ab155c61f5821ffda723de88b0009769771d4f2) | ``modules: Export `pkgs` to match NixOS (#2696)`` |
| [`2e473a7b`](https://github.com/nix-community/home-manager/commit/2e473a7b0903709817b1b8cf0ef0cae1defac358) | `neomutt/signature: unset if disabled (#2877)`    |