### PR TITLE
chore(flake/nixpkgs): `4dab52db` -> `1ffba9f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650118033,
-        "narHash": "sha256-EdI6eoFmnK8MJc8m3LdaFka2uNQ0Wv2/EtHfmPiGnqE=",
+        "lastModified": 1650161686,
+        "narHash": "sha256-70ZWAlOQ9nAZ08OU6WY7n4Ij2kOO199dLfNlvO/+pf8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4dab52dbc93fd0d1b23fa0908de04fc3eb49a34c",
+        "rev": "1ffba9f2f683063c2b14c9f4d12c55ad5f4ed887",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`b94a4c22`](https://github.com/NixOS/nixpkgs/commit/b94a4c22702f541ed9e098b8fb0db263fc24332b) | `nixos/mininet: telnet → inetutils`                                                                  |
| [`7833517a`](https://github.com/NixOS/nixpkgs/commit/7833517adc1c4d44a83e0b8b4e9ca35c5213dc87) | `yt-dlp: 2022.3.8.2 → 2022.04.08`                                                                    |
| [`7bd8dc9d`](https://github.com/NixOS/nixpkgs/commit/7bd8dc9dd15f310a8ad0192225364a9232f56385) | `gopls: 0.8.2 -> 0.8.3`                                                                              |
| [`c28265b2`](https://github.com/NixOS/nixpkgs/commit/c28265b2891a18e6149a8d3c7d3966be1bd0a710) | `python3Packages.brother: 1.1.0 -> 1.2.0`                                                            |
| [`88c2ebda`](https://github.com/NixOS/nixpkgs/commit/88c2ebdaeb1889e535f6bfb8b091b6e5b023a500) | `python3Packages.pysnmplib: init at 5.0.10`                                                          |
| [`d36ab136`](https://github.com/NixOS/nixpkgs/commit/d36ab13695f7888cb4764aa9e6f4cf9be7aa15c6) | `python3Packages.pysnmp-pysmi: init at 1.1.8`                                                        |
| [`928e563a`](https://github.com/NixOS/nixpkgs/commit/928e563a1d022ec540e7df7eca1f5128eb03c053) | `zenith: 0.12.0 -> 0.13.1`                                                                           |
| [`f3bdf57f`](https://github.com/NixOS/nixpkgs/commit/f3bdf57f61c178228c802cb2c6bf48bc309da9e0) | `ungoogled-chromium: 100.0.4896.88 -> 100.0.4896.127`                                                |
| [`2833064b`](https://github.com/NixOS/nixpkgs/commit/2833064bcc9f7e6b0bf88995121b688055c56f46) | `neovide: 2022-02-04 -> 0.8.0 (#168770)`                                                             |
| [`7771628e`](https://github.com/NixOS/nixpkgs/commit/7771628eb1dc0c9e7577ed10b5471dacadbd8c72) | `home-assistant: update component-packages`                                                          |
| [`f905e9f2`](https://github.com/NixOS/nixpkgs/commit/f905e9f20340e25ae78b393e51079a2b5de7a95e) | `python3Packages.aio-geojson-generic-client: init at 0.1`                                            |
| [`1879daa0`](https://github.com/NixOS/nixpkgs/commit/1879daa085ff0969db78cfce0d0ba8a6553017bd) | `home-assistant: update component-packages`                                                          |
| [`0fdca0cc`](https://github.com/NixOS/nixpkgs/commit/0fdca0cc2f26816e1d07cb06af26e1f2184989a3) | `python3Packages.oasatelematics: init at 0.3`                                                        |
| [`ba5b9116`](https://github.com/NixOS/nixpkgs/commit/ba5b91166ad31a11b86edf0521ba12e356d527a1) | `cubiomes-viewer: 2.0.0 -> 2.1.1`                                                                    |
| [`acac82f1`](https://github.com/NixOS/nixpkgs/commit/acac82f1caad842b5089353fb03864b7dd7dc964) | `home-assistant: update component-packages`                                                          |
| [`f470406b`](https://github.com/NixOS/nixpkgs/commit/f470406b6b1258b9873bb7057354f6590395e713) | `python3Packages.meteofrance-api: init at 1.0.2`                                                     |
| [`ed778189`](https://github.com/NixOS/nixpkgs/commit/ed778189c96fa0a2b1057b1a24256992520f5171) | `home-assistant: update component-packages`                                                          |
| [`0a25dbfa`](https://github.com/NixOS/nixpkgs/commit/0a25dbfa97cc4b0983c14457f30498902d0da288) | `python3Packages.rova: init at 0.3.0`                                                                |
| [`ed97ebc9`](https://github.com/NixOS/nixpkgs/commit/ed97ebc9d257092c7d66db0058e4aa1156be9866) | `cmus: fix build on aarch64-darwin`                                                                  |
| [`b9bf28fd`](https://github.com/NixOS/nixpkgs/commit/b9bf28fd70ae179f703b6bd99f7b0620473b183f) | `nixos/stage-1-init: Pass all parameters to the builder`                                             |
| [`689781a0`](https://github.com/NixOS/nixpkgs/commit/689781a0692e8f00769bac599524b410709da89c) | `python3Packages.zimports: propagate tomli`                                                          |
| [`98ca6c1f`](https://github.com/NixOS/nixpkgs/commit/98ca6c1fbd51de674a78cec6e091bd5c262f0216) | `home-assistant: update component-packages`                                                          |
| [`ae51dd5b`](https://github.com/NixOS/nixpkgs/commit/ae51dd5b70cab6200c85e540476a1f64b1945744) | `python3Packages.python-family-hub-local: init at 0.0.2`                                             |
| [`f718d306`](https://github.com/NixOS/nixpkgs/commit/f718d306566402ffb502001b2427629e4eadb12f) | `dgraph: 20.07.3 -> 21.12.0`                                                                         |
| [`66430ab0`](https://github.com/NixOS/nixpkgs/commit/66430ab09ec0375d535812a0e29decc84b076f5b) | `banking: 0.3.0 -> 0.4.0`                                                                            |
| [`4a86b1c7`](https://github.com/NixOS/nixpkgs/commit/4a86b1c78201bc92fee43f119e0ba1ad9982d8a4) | `setzer: 0.4.4 -> 0.4.7`                                                                             |
| [`b363e6b6`](https://github.com/NixOS/nixpkgs/commit/b363e6b691691b78601cb6a3e2c705b3ba173b7c) | `home-assistant: update component-packages`                                                          |
| [`5307f207`](https://github.com/NixOS/nixpkgs/commit/5307f207b93143f3db5766463478d90d8dcf6a5d) | `python3Packages.securetar: init at 2022.02.0`                                                       |
| [`fc8cdc28`](https://github.com/NixOS/nixpkgs/commit/fc8cdc28c5db77594f2d9fc98597031f81329a52) | `python310Packages.types-setuptools: 57.4.11 -> 57.4.14`                                             |
| [`0b478f90`](https://github.com/NixOS/nixpkgs/commit/0b478f9069aedf7ac433cb0202ececcffa9174b9) | `sof-firmware: 2.0 -> 2.1.1`                                                                         |
| [`ea1de3f2`](https://github.com/NixOS/nixpkgs/commit/ea1de3f2ce068f70f14742dfd9e19e7dadb8d3a6) | `home-assistant: 2022.4.4 -> 2022.4.5`                                                               |
| [`36873851`](https://github.com/NixOS/nixpkgs/commit/36873851dc6b084ec0f997db35bfe0e81581a221) | `sic-image-cli: 0.19.1 -> 0.20.0`                                                                    |
| [`6961aae3`](https://github.com/NixOS/nixpkgs/commit/6961aae3da2d00a17f7a410eb4f5a95afe21570a) | `python3Packages.google-cloud-error-reporting: disable on older Python releases`                     |
| [`a5fb565b`](https://github.com/NixOS/nixpkgs/commit/a5fb565bf50b4efb8409f58a5c7ba47418be64ad) | `nixos/auto-upgrade: add persistent option`                                                          |
| [`5a1c6f1d`](https://github.com/NixOS/nixpkgs/commit/5a1c6f1d63c2a1debe221c33f20aa0ee8c4dcfa7) | `python3Packages.shiv: init at 1.0.1`                                                                |
| [`267fa3bc`](https://github.com/NixOS/nixpkgs/commit/267fa3bc87368171815e5961ae343bc03f4f1403) | `python310Packages.google-cloud-error-reporting: 1.5.1 -> 1.5.2`                                     |
| [`554fc3d6`](https://github.com/NixOS/nixpkgs/commit/554fc3d6274d7f63acea680e7f3e0bfbab3b798d) | `gmid: 1.8.1 -> 1.8.3`                                                                               |
| [`228209d6`](https://github.com/NixOS/nixpkgs/commit/228209d60b661109fcea362de18594e7d9c8a2e5) | `libnfc: 1.7.1 -> 1.8.0`                                                                             |
| [`cb285332`](https://github.com/NixOS/nixpkgs/commit/cb285332031e9ec9e345ef5e99a0d12758564179) | `syft: 0.44.0 -> 0.44.1`                                                                             |
| [`ec548e26`](https://github.com/NixOS/nixpkgs/commit/ec548e26d54c74a73e01854d8b272a69e3659047) | `driftctl: 0.28.0 -> 0.28.1`                                                                         |
| [`b690d6af`](https://github.com/NixOS/nixpkgs/commit/b690d6aff3e62a4e43c658ed92e51f64e7177daf) | `python310Packages.diff-cover: 6.4.5 -> 6.5.0`                                                       |
| [`b2f53084`](https://github.com/NixOS/nixpkgs/commit/b2f53084006be15f213f87fd2fc1739899869016) | `nixos/doc: move "Building NixOS" into "Installation", not "Development"`                            |
| [`5ed926eb`](https://github.com/NixOS/nixpkgs/commit/5ed926eb38cc58138021719bb913ca2303f7d114) | `trivy: 0.25.3 -> 0.26.0`                                                                            |
| [`6b2691d7`](https://github.com/NixOS/nixpkgs/commit/6b2691d7ce0ebfadf750a29a2733fbaffec03d5f) | `graalvmXX-ce: add documentation to mkGraal function`                                                |
| [`d9d57d20`](https://github.com/NixOS/nixpkgs/commit/d9d57d2053478dc5cfe9435e71bbc22485b39282) | `yaru-theme: unstable-2022-04-07 -> 22.04.4`                                                         |
| [`5c9a8665`](https://github.com/NixOS/nixpkgs/commit/5c9a8665511a7757aac91b020c8b7162d7cde479) | `graalvmXX-ce: add sourcesPath parameter`                                                            |
| [`7062faa1`](https://github.com/NixOS/nixpkgs/commit/7062faa185108f3d609a2dc20c4c4b4cb4419293) | `python310Packages.pg8000: 1.24.1 -> 1.24.2`                                                         |
| [`2ca1c986`](https://github.com/NixOS/nixpkgs/commit/2ca1c986175e864bb67a955a4189f7acf51f8b1b) | `vscode: fix auto encoding detection crashing editor window`                                         |
| [`92fe27da`](https://github.com/NixOS/nixpkgs/commit/92fe27da603271baf3495a8496a9d917c639329d) | `vscode: move asar to nativeBuildInputs`                                                             |
| [`11aa7654`](https://github.com/NixOS/nixpkgs/commit/11aa76540c10a85759a1d4b7d4ebe03a51136c93) | `haste-server: 3dcc43578b99dbafac35dece9d774ff2af39e8d0 -> 72863858338a57d54eb9dee55530e90ebbc22453` |
| [`bd7d8adc`](https://github.com/NixOS/nixpkgs/commit/bd7d8adc321dae1c2c9f10989b49ec016f3d9eed) | `nextcloud-client: split headers into dev output`                                                    |
| [`3bc98d3b`](https://github.com/NixOS/nixpkgs/commit/3bc98d3bc10f7bd4fd2df3b31b2eefb7fe26410c) | `nextcloud-client: place vfs plugins in correct directory`                                           |
| [`0a2bc834`](https://github.com/NixOS/nixpkgs/commit/0a2bc8348099cdd38122d59e92fa72e49adae561) | `diffoscope: 209 -> 210`                                                                             |
| [`cdc17db8`](https://github.com/NixOS/nixpkgs/commit/cdc17db88264d66527c95cffaf78e60ed433faaf) | `xfitter: 2.0.1 -> 2.2.0`                                                                            |
| [`f1ae889c`](https://github.com/NixOS/nixpkgs/commit/f1ae889cc21b7cfa5b3c1c5598888f3a73047368) | `kt: 12.1.0 -> 13.1.0`                                                                               |
| [`e532f3ec`](https://github.com/NixOS/nixpkgs/commit/e532f3ecf44d0bbb7b6ae45a0e3e87ec4dc40b8c) | `nextcloud-client: build man pages`                                                                  |
| [`60714e2c`](https://github.com/NixOS/nixpkgs/commit/60714e2cd319d3217e33397e65a63ad8beb4a8e9) | `nextcloud-client: build dolphin plugin`                                                             |
| [`01bc138a`](https://github.com/NixOS/nixpkgs/commit/01bc138a8ef25314e08843845655480c9b04e879) | `nixos/stage-1-init: Merge mdraid module into swraid`                                                |
| [`a6a25ec4`](https://github.com/NixOS/nixpkgs/commit/a6a25ec43d65f9dbf77ed52d28f582fb6ed03d68) | `chromium: 100.0.4896.88 -> 100.0.4896.127`                                                          |
| [`df30f5b7`](https://github.com/NixOS/nixpkgs/commit/df30f5b75bdaae8dfd1316531c922277b22357f1) | `gnome-firmware: 3.34.0 → 42.1`                                                                      |
| [`e5fe7999`](https://github.com/NixOS/nixpkgs/commit/e5fe7999879627f170efcb97df2cedb67402f88c) | `gnome-firmware: rename from gnome-firmware-updater`                                                 |
| [`c357dd1d`](https://github.com/NixOS/nixpkgs/commit/c357dd1d9f0e909c2fc7d4494308ce789cfec131) | `python3Packages.pysnmp-pyasn1: init at 1.1.2`                                                       |
| [`d580e84c`](https://github.com/NixOS/nixpkgs/commit/d580e84c541992aacc7974666f29f68ef29cff47) | ``Fixed `dm-haiku` and `flax` builds.``                                                              |
| [`b1674903`](https://github.com/NixOS/nixpkgs/commit/b16749039a6dc396ce43d8c3a368117b000d229c) | `megacmd: autoreconfHook and enableParallelBuilding`                                                 |
| [`079d0fef`](https://github.com/NixOS/nixpkgs/commit/079d0fef5e3432036af8ce8a5c2b71418ccf1c7f) | `CoinMP: enableParallelBuilding`                                                                     |
| [`9d46a102`](https://github.com/NixOS/nixpkgs/commit/9d46a1025a36e2e301a9782a2ff6ba080c0bd7fe) | `pkgs/stdenv/linux: add powerpc64le bootstrap-files`                                                 |
| [`bcd08bb6`](https://github.com/NixOS/nixpkgs/commit/bcd08bb618dc599f157490db01c3d9caf7984fd3) | `python3Packages.tzlocal: 4.1 -> 4.2`                                                                |
| [`745790d3`](https://github.com/NixOS/nixpkgs/commit/745790d3c1285ab3eb486cb3c66e16c2ebf37c70) | `python3Packages.pylama: 8.3.7 -> 8.3.8`                                                             |
| [`555bc533`](https://github.com/NixOS/nixpkgs/commit/555bc5335bf8dcec8e0562ca1bedc96efdc8fc80) | `openstack-image-zfs: start copying the channel now that we've mostly got the expressions down`      |
| [`d99f3013`](https://github.com/NixOS/nixpkgs/commit/d99f30137492749eb011f01b5fcd3c29fd411825) | `openstack-config: note the image metadata needed to boot a uefi image`                              |
| [`d3aff5fa`](https://github.com/NixOS/nixpkgs/commit/d3aff5fa3cb1ecd9d339e3801373ec3cca0057e4) | ``openstack-config: make the expandOnBoot option default to `all```                                  |
| [`8a5bdce5`](https://github.com/NixOS/nixpkgs/commit/8a5bdce5665e24c1656aab2235ac9bd556316adf) | `make-single-disk-zfs-image: init`                                                                   |
| [`b4c495ae`](https://github.com/NixOS/nixpkgs/commit/b4c495aeffb610cffd08e0000817f02742365dec) | `openstack-image-zfs: make the generated configuration.nix valid`                                    |
| [`9e3dab7d`](https://github.com/NixOS/nixpkgs/commit/9e3dab7d2e2f7e08baa65dfec78e27343608bdbd) | `openstack-image-zfs: build a single-image ZFS root`                                                 |
| [`0a086bf7`](https://github.com/NixOS/nixpkgs/commit/0a086bf7bf88d617f0cb126f8119e9e57b77af45) | `openstack-config: enable tty1`                                                                      |
| [`1c0b76b5`](https://github.com/NixOS/nixpkgs/commit/1c0b76b5c447ff0879ae5e57fa8af0cb5639bdd8) | `openstack-image-zfs: don't support vpc type, default to qcow2`                                      |
| [`d4c502a9`](https://github.com/NixOS/nixpkgs/commit/d4c502a94a03a66da48870f30588dc7d601c50f8) | `openstack-metadata-fetcher: don't fail if any specific wget's fail`                                 |
| [`a8f41adb`](https://github.com/NixOS/nixpkgs/commit/a8f41adbb753f1a94cfd9086f09b177cf11a7a4b) | `amazon-image: use make-multi-disk-zfs-image`                                                        |
| [`14304bfe`](https://github.com/NixOS/nixpkgs/commit/14304bfe40d8fa90f6a371cd6445a3ec7d09e0e9) | `openstack-config: setup serial access on ttyS0`                                                     |
| [`e5a7d077`](https://github.com/NixOS/nixpkgs/commit/e5a7d077c1a1d6a91e40634e9fd4841a91b4bb1f) | `openstack-config: support a ZFS root with /boot perhaps coming from an ESP`                         |
| [`80b00ef0`](https://github.com/NixOS/nixpkgs/commit/80b00ef02a8efc958e2a16a7264c147e2a8ffbf4) | `openstack-options: init`                                                                            |
| [`b8fe7923`](https://github.com/NixOS/nixpkgs/commit/b8fe792394757f415c71c6cf20de10899c2388b1) | `openstack-image-zfs: init`                                                                          |
| [`e9f01548`](https://github.com/NixOS/nixpkgs/commit/e9f015480c0573736cc87b5a90588a0b92a507d3) | `openstack-image: make it easy to disable copying the channel to improve iteration time`             |
| [`b3dfff28`](https://github.com/NixOS/nixpkgs/commit/b3dfff282b114daf304aa4c97a2532cd9b6b8ca3) | `openstack-image: minor cleanups`                                                                    |
| [`067b774e`](https://github.com/NixOS/nixpkgs/commit/067b774e7c998b93ce678c964a4886c81dad0747) | `thunderbird-bin: 91.7.0 -> 91.8.0`                                                                  |
| [`51f16633`](https://github.com/NixOS/nixpkgs/commit/51f1663342257f21635563a9cb83091e4bab58fe) | `wcslib: 7.7 -> 7.9`                                                                                 |
| [`5610ff5b`](https://github.com/NixOS/nixpkgs/commit/5610ff5ba1cb55ccbf07b377e992614f8ae21a1d) | `Improved error message on disabling NSS modules when disabling nscd`                                |