### PR TITLE
chore(flake/nixpkgs): `1ffba9f2` -> `34b15bb8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650161686,
-        "narHash": "sha256-70ZWAlOQ9nAZ08OU6WY7n4Ij2kOO199dLfNlvO/+pf8=",
+        "lastModified": 1650206354,
+        "narHash": "sha256-miqvz7okUhmXZJyV5v3zufoupNZ09YWfJ47YUbFu2yQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1ffba9f2f683063c2b14c9f4d12c55ad5f4ed887",
+        "rev": "34b15bb8350943c1652082fe58dcc99884193a0d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                      |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`288c5c3b`](https://github.com/NixOS/nixpkgs/commit/288c5c3b5ee5aefffed0584e288b14e23125b3ee) | `sumneko-lua-language-server: 2.6.7 -> 3.1.0`                       |
| [`5f95bff4`](https://github.com/NixOS/nixpkgs/commit/5f95bff4812281609d75af940376b10ba181d7ce) | `nixos/nvidia: fix type of bus ID option to accept empty string`    |
| [`d8b45531`](https://github.com/NixOS/nixpkgs/commit/d8b455312ecc706675958bc1c7fdf238e62f26a9) | `python310Packages.jupyterlab: 3.3.3 -> 3.3.4 (#168906)`            |
| [`89158c89`](https://github.com/NixOS/nixpkgs/commit/89158c89c53140ae6dacd043efa74ad598c470b2) | `gnome.ghex: 42.0 -> 42.1`                                          |
| [`c17f2305`](https://github.com/NixOS/nixpkgs/commit/c17f2305a8b84d2adc77b6c8c27778e52a8a575a) | `maintainers: add builditluc`                                       |
| [`b46d7231`](https://github.com/NixOS/nixpkgs/commit/b46d7231859156b75be3b82b8a6a8fe6fb381fe8) | `wiki-tui: 0.4.5 -> 0.4.7`                                          |
| [`7a05dabd`](https://github.com/NixOS/nixpkgs/commit/7a05dabd70a3aed5040c9a95a44c698631c55c21) | `nearcore: init at 1.25.0 (#168635)`                                |
| [`2e2a2542`](https://github.com/NixOS/nixpkgs/commit/2e2a25426a8755423f8dd9b8486b1e79343a8de0) | `mongodb-compass: 1.31.1 -> 1.31.2`                                 |
| [`b9121c70`](https://github.com/NixOS/nixpkgs/commit/b9121c70d830d308be69f107614c51c05ab1a7d5) | `popeye: 0.9.8 -> 0.10.0`                                           |
| [`54b98b1e`](https://github.com/NixOS/nixpkgs/commit/54b98b1ec58b7a849f7ad28022d3201ac30a2a2f) | `python310Packages.types-toml: 0.10.4 -> 0.10.5`                    |
| [`0340108e`](https://github.com/NixOS/nixpkgs/commit/0340108ee0bdb408a8417ec1a8c8ce8de0e5af8f) | `python310Packages.tubeup: 0.0.27 -> 0.0.28`                        |
| [`4961050a`](https://github.com/NixOS/nixpkgs/commit/4961050a8fea68f3c65ddfb7cb03aeb760e36062) | `python310Packages.types-freezegun: 1.1.8 -> 1.1.9`                 |
| [`c03e1141`](https://github.com/NixOS/nixpkgs/commit/c03e1141b95c589140ad9cdd198d946c67e946ae) | `godns: 2.7.3 -> 2.7.4`                                             |
| [`b4e7303d`](https://github.com/NixOS/nixpkgs/commit/b4e7303ddfb7a8df37678e152b13148f40ce9acb) | `nixos/specialisation: fix curly brackets`                          |
| [`db1cef72`](https://github.com/NixOS/nixpkgs/commit/db1cef7220ef8d97bbde06ee25e1b42c71ea22ac) | `calcoo: init at 2.1.0`                                             |
| [`614b54d9`](https://github.com/NixOS/nixpkgs/commit/614b54d9b04092d6926afd49d64efe86272f7dd1) | `hardware/nvidia: stricter constraints on PCI bus-id.`              |
| [`20b225bf`](https://github.com/NixOS/nixpkgs/commit/20b225bf4c520ed927ee4cc60324a3e425ad2a6f) | `python310Packages.h3: 3.7.3 -> 3.7.4`                              |
| [`44ad2f72`](https://github.com/NixOS/nixpkgs/commit/44ad2f72ec25f5e6245c32df5ecb67faf2bb648d) | `fsql: 0.3.1 -> 0.4.0`                                              |
| [`0d3082aa`](https://github.com/NixOS/nixpkgs/commit/0d3082aa8c70a6febde55b1180f161b9395e73aa) | `goreleaser: 1.7.0 -> 1.8.1`                                        |
| [`b79e0a0e`](https://github.com/NixOS/nixpkgs/commit/b79e0a0e06578629b6cbc0a89a0ba62c0dc2f4f3) | `nixos/dendrite: set LimitNOFILE to 65535`                          |
| [`0fd88ab0`](https://github.com/NixOS/nixpkgs/commit/0fd88ab06a630e960ba1d22f8e23f22157f4ba86) | `quick-lint-js: 2.3.1 -> 2.4.0`                                     |
| [`8def4d30`](https://github.com/NixOS/nixpkgs/commit/8def4d308e66b3d145f26500d74c92e9d09a9320) | `Revert "cln: fix darwin build"`                                    |
| [`940ad02f`](https://github.com/NixOS/nixpkgs/commit/940ad02f7b4a89e33715dc1df258a2ae138eab1d) | `pomerium: note aarch64-linux as supported`                         |
| [`b23255a5`](https://github.com/NixOS/nixpkgs/commit/b23255a51c3faa1994f17b0cff36732f6e202723) | `envoy: add fetch hash for aarch64-linux`                           |
| [`536b77fd`](https://github.com/NixOS/nixpkgs/commit/536b77fd501f6554a5739f161e72ad78e9001d99) | `envoy: switch to headless JDK for compilation`                     |
| [`6cb9bedd`](https://github.com/NixOS/nixpkgs/commit/6cb9beddb14ab304bdab7424e16148c34782fbe7) | `ngtcp2: unstable-2021-12-19 -> unstable-2022-04-11`                |
| [`1a14dd01`](https://github.com/NixOS/nixpkgs/commit/1a14dd01f37cabf5390ce9d28f9d290bcc9a13b6) | `nghttp3: unstable-2021-12-22 -> unstable-2022-04-10`               |
| [`ebd77acb`](https://github.com/NixOS/nixpkgs/commit/ebd77acb8009d035b9c4cf37af0b3f06f0294393) | `3.0.1+quick_unstable-2021-12.14 > 3.0.2+quick_unstable-2022-03.15` |
| [`fccd8f51`](https://github.com/NixOS/nixpkgs/commit/fccd8f5131e598f88a20d425f679988d7d4dd6f2) | `azuredatastudio: 1.33.1 -> 1.35.1`                                 |
| [`075c5eb8`](https://github.com/NixOS/nixpkgs/commit/075c5eb8d39f63a3fd9bcd903d7a19fe22a35224) | `llvmPackages_14.clang: include clang-tools-extra in src for use`   |
| [`d8fe2323`](https://github.com/NixOS/nixpkgs/commit/d8fe23231a627f82305b483693d0e7967bbe8621) | `mbpfan: 2.2.1 -> 2.3.0`                                            |