### PR TITLE
chore(flake/home-manager): `620ed197` -> `c82b8ac5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650190514,
-        "narHash": "sha256-BoBvGT71yOfrNDTZQs7+FX0zb4yjMBETgIjtTsdJw+o=",
+        "lastModified": 1650229675,
+        "narHash": "sha256-DIH+SJtYqag5tGVlKAT1TBuNyiynrwNkURY44n8NvGI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "620ed197f3624dafa5f42e61d5c043f39b8df366",
+        "rev": "c82b8ac5ad70c17f35eca54e3267e5b0e43fbe6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message               |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`c82b8ac5`](https://github.com/nix-community/home-manager/commit/c82b8ac5ad70c17f35eca54e3267e5b0e43fbe6b) | `sioyek: add module (#2895)` |