### PR TITLE
chore(flake/home-manager): `c82b8ac5` -> `bb860e3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650229675,
-        "narHash": "sha256-DIH+SJtYqag5tGVlKAT1TBuNyiynrwNkURY44n8NvGI=",
+        "lastModified": 1650231986,
+        "narHash": "sha256-aUKdez6fKvZthpK0JDGZcGoFMAhHRSFp+3WuyizPDfI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c82b8ac5ad70c17f35eca54e3267e5b0e43fbe6b",
+        "rev": "bb860e3e119ee6d043896544de560cd05096a421",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                          |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`bb860e3e`](https://github.com/nix-community/home-manager/commit/bb860e3e119ee6d043896544de560cd05096a421) | `misc: fix nix.conf generation (#2824)` |