### PR TITLE
chore(flake/home-manager): `bb860e3e` -> `5ac84ebe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650231986,
-        "narHash": "sha256-aUKdez6fKvZthpK0JDGZcGoFMAhHRSFp+3WuyizPDfI=",
+        "lastModified": 1650233681,
+        "narHash": "sha256-blYegazPGO2uobXTiP4EBXy10gHtBX2MvFsiUaEUyZ8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bb860e3e119ee6d043896544de560cd05096a421",
+        "rev": "5ac84ebeef5d2566ea458b81375cc6eafa19c225",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                                |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`5ac84ebe`](https://github.com/nix-community/home-manager/commit/5ac84ebeef5d2566ea458b81375cc6eafa19c225) | `Add lib argument to homeManagerConfiguration (#2753)`                        |
| [`f47001ce`](https://github.com/nix-community/home-manager/commit/f47001cec9f5c7fa557733db6101d1240aa2f297) | `xdg-desktop-entries: add 'actions' option, deprecate fileValidation (#2778)` |