### PR TITLE
chore(flake/home-manager): `5ac84ebe` -> `742c6cb3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650233681,
-        "narHash": "sha256-blYegazPGO2uobXTiP4EBXy10gHtBX2MvFsiUaEUyZ8=",
+        "lastModified": 1650234580,
+        "narHash": "sha256-wTmlRedCrDl+XYJom65GMfI3RgA3eZE/w03lD28Txoc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5ac84ebeef5d2566ea458b81375cc6eafa19c225",
+        "rev": "742c6cb3e9d866e095c629162fe5faf519adeb26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`742c6cb3`](https://github.com/nix-community/home-manager/commit/742c6cb3e9d866e095c629162fe5faf519adeb26) | `chromium: add vivaldi`                                       |
| [`c2726860`](https://github.com/nix-community/home-manager/commit/c2726860a28a2f9331ef8bb4a8505998818bf471) | ``nix-darwin,nixos: convert `modulesPath` to string (#2714)`` |