### PR TITLE
chore(flake/nixpkgs): `34b15bb8` -> `ba88a5af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650206354,
-        "narHash": "sha256-miqvz7okUhmXZJyV5v3zufoupNZ09YWfJ47YUbFu2yQ=",
+        "lastModified": 1650222748,
+        "narHash": "sha256-AHh/goEfG5hlhIMVgGQwACbuv5Wit2ND9vrcB4QthJs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "34b15bb8350943c1652082fe58dcc99884193a0d",
+        "rev": "ba88a5afa6fff7710c17b5423ff9d721386c4164",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                     |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`4572069a`](https://github.com/NixOS/nixpkgs/commit/4572069a3aa8ae762a1f5b4d6bdb33d91e87f251) | `doc/release-notes: add ssmtp removal notice and alternative`                      |
| [`0492ef0e`](https://github.com/NixOS/nixpkgs/commit/0492ef0e855a21c13beec61054d0b2eee648a1a0) | `ssmtp: drop unmaintained program`                                                 |
| [`f613f464`](https://github.com/NixOS/nixpkgs/commit/f613f4648899a0fca1455eccc7b10b20dc3557b2) | `home-assistant: support stookalert component`                                     |
| [`7aa71eb3`](https://github.com/NixOS/nixpkgs/commit/7aa71eb389b59ed021c90bf5f52e0d6009222e3f) | `python3Packages.stookalert: init at 0.1.4`                                        |
| [`ab62ad49`](https://github.com/NixOS/nixpkgs/commit/ab62ad49ec68ce4412dc40adf348f680644a55df) | `home-assistant: update component-packages`                                        |
| [`e9055d04`](https://github.com/NixOS/nixpkgs/commit/e9055d047fc6cc1444dfc6af8c6d0609ff6c483f) | `python3Packages.pytomorrowio: init at 0.2.1`                                      |
| [`a6a8731d`](https://github.com/NixOS/nixpkgs/commit/a6a8731dc75b967d7e8b0f21a901623e8202b472) | `curl: enable ca-bundle if activated http3 protocol`                               |
| [`da0be8f6`](https://github.com/NixOS/nixpkgs/commit/da0be8f6e5fd6c65ace972cbd42748a7e27df4ad) | `python310Packages.types-tabulate: 0.8.6 -> 0.8.7`                                 |
| [`4ad5ab71`](https://github.com/NixOS/nixpkgs/commit/4ad5ab71ab4621cf8d2f7d3e70bb3f5f41c5eb19) | `python310Packages.types-cryptography: 3.3.19 -> 3.3.20`                           |
| [`8aeebf20`](https://github.com/NixOS/nixpkgs/commit/8aeebf202ff3d293babf4488b74386a65d08b902) | `python310Packages.types-paramiko: 2.8.17 -> 2.8.19`                               |
| [`4489718d`](https://github.com/NixOS/nixpkgs/commit/4489718d8ff8c5f584160113d8482f8546c14804) | `emacsWrapper: preload autoloads`                                                  |
| [`aaa165b6`](https://github.com/NixOS/nixpkgs/commit/aaa165b6e5a356790896c86ac745e85ad9b1d56f) | `mautrix-whatsapp: 0.3.0 -> 0.3.1`                                                 |
| [`b4129b27`](https://github.com/NixOS/nixpkgs/commit/b4129b277ec6580b1cde7c58d502ecabd692f4cc) | `python310Packages.asyncssh: 2.10.0 -> 2.10.1`                                     |
| [`03b2a022`](https://github.com/NixOS/nixpkgs/commit/03b2a0221cec97b8e1e8158f12d98c4f9cd1e87f) | `python310Packages.types-dateutil: 2.8.10 -> 2.8.11`                               |
| [`45c9af19`](https://github.com/NixOS/nixpkgs/commit/45c9af19f4c1be64b3ea67d9a3f08e32614a68f7) | `python310Packages.types-decorator: 5.1.4 -> 5.1.5`                                |
| [`21b306c7`](https://github.com/NixOS/nixpkgs/commit/21b306c7fbbbd9c6d0b5b84b0d2f2f1c509fcdd8) | `python310Packages.policyuniverse: 1.5.0.20220414 -> 1.5.0.20220416`               |
| [`37d4c2e2`](https://github.com/NixOS/nixpkgs/commit/37d4c2e267e3d616ac5cb2377b744bbebfb56cff) | `netcdf: 4.8.0 -> 4.8.1`                                                           |
| [`a735e0b9`](https://github.com/NixOS/nixpkgs/commit/a735e0b978c5a29699b9422d1cb8dc03776b8c71) | `libjson: fixup build with gcc 11`                                                 |
| [`072d6270`](https://github.com/NixOS/nixpkgs/commit/072d6270cab89b2e824c37646244bf41c6e6b6b0) | `python310Packages.aenum: 3.1.8 -> 3.1.11`                                         |
| [`f1a4f201`](https://github.com/NixOS/nixpkgs/commit/f1a4f201d2e5579a5eb08c97f32f5234d819f4f2) | `log4shib: fixup build with gcc 11`                                                |
| [`61970a41`](https://github.com/NixOS/nixpkgs/commit/61970a41ec4605b23558fadfc75a1560c2bddef4) | `Revert "rustfmt: actually fix the failing test"`                                  |
| [`a5aa12b4`](https://github.com/NixOS/nixpkgs/commit/a5aa12b44617d965b0f7024167407c4161b1a6cf) | `mrustc: fixup build`                                                              |
| [`309a9c59`](https://github.com/NixOS/nixpkgs/commit/309a9c59fb2b3bcadd8a2c362e9dc0e184e9c2b9) | `mediastreamer: fixup build with gcc 11`                                           |
| [`1ca464f9`](https://github.com/NixOS/nixpkgs/commit/1ca464f98f8aab56cc7ad49237f5c667c3b8e1c3) | `smesh: fixup build with gcc 11`                                                   |
| [`9a96bf85`](https://github.com/NixOS/nixpkgs/commit/9a96bf85309d70a4c21b629bca0ced3876fb891e) | `glm: fixup with other compilers than gcc >= 11`                                   |
| [`97c708a8`](https://github.com/NixOS/nixpkgs/commit/97c708a87aaf81e2bab91f9798780bcd483f3491) | `python310Packages.plaid-python: 9.2.0 -> 9.3.0`                                   |
| [`122330cf`](https://github.com/NixOS/nixpkgs/commit/122330cfd2e261e3a28c288535c9a6f11095a608) | `python310Packages.types-urllib3: 1.26.11 -> 1.26.13`                              |
| [`0e531c29`](https://github.com/NixOS/nixpkgs/commit/0e531c29af03538f4ecaebc76595a6b8a4baf133) | `python310Packages.lxmf: 0.1.4 -> 0.1.5`                                           |
| [`c705239a`](https://github.com/NixOS/nixpkgs/commit/c705239a5de14642f50f7755dd91b38e0ffcf3cd) | `cjdns: don't set -Wno-error=stringop-overread with gcc<11`                        |
| [`3feca938`](https://github.com/NixOS/nixpkgs/commit/3feca9381d0653aaff903c089acbfe6736d22481) | `python310Packages.types-requests: 2.27.16 -> 2.27.19`                             |
| [`538ea893`](https://github.com/NixOS/nixpkgs/commit/538ea8934cf61da43a4f323b0084d0fb894b687f) | `release-small: replace ssmtp package use with msmtp`                              |
| [`68128e7b`](https://github.com/NixOS/nixpkgs/commit/68128e7b7efbc419a9c9da1d6e2836552cefaccc) | `nixos/nagios: replace ssmtp package use with msmtp`                               |
| [`cfc763bf`](https://github.com/NixOS/nixpkgs/commit/cfc763bf36bb09770ec6ff2c378ee11dfe8b16bc) | `nixos/ssmtp: drop module`                                                         |
| [`788bd96c`](https://github.com/NixOS/nixpkgs/commit/788bd96c1c5ff1917c86a687461a5b20bce52bd1) | `nixosTests.mailcatcher: replace ssmtp module use with msmtp`                      |
| [`20319182`](https://github.com/NixOS/nixpkgs/commit/20319182ada632cb039916ef3b0d150d6308e97f) | `python3Packages.mailchecker: 4.1.13 -> 4.1.15`                                    |
| [`85eb3867`](https://github.com/NixOS/nixpkgs/commit/85eb38677ba96ad02a9a6e4413337090f23e14fa) | `nuclei: 2.6.7 -> 2.6.8`                                                           |
| [`11b544c0`](https://github.com/NixOS/nixpkgs/commit/11b544c084934389a89fc9b8d0a0ddb78cb6b366) | `python310Packages.symengine: move patching to right phase`                        |
| [`f1189d81`](https://github.com/NixOS/nixpkgs/commit/f1189d812e5042de9571ce1e0e0f6fca5380ad6e) | `fast-downward: substitute version, fix buildInputs, minor cleanup`                |
| [`2151e9af`](https://github.com/NixOS/nixpkgs/commit/2151e9af9cbed96a1353ec8964446a47204d62b0) | ``archiveopteryx: fix build on aarch64 by conditioning `-Wno-error` flag``         |
| [`3795a2f7`](https://github.com/NixOS/nixpkgs/commit/3795a2f70718f775048904fac400e569f07c8441) | ``flatcc: add two `-Wno-error` for compilation on gcc11 and later``                |
| [`5275050a`](https://github.com/NixOS/nixpkgs/commit/5275050ab037eef4dc8e358c7907c931f78c5d85) | ``fityk: add `-std=c++11` flag for gcc11 and later``                               |
| [`8c5a5814`](https://github.com/NixOS/nixpkgs/commit/8c5a58144d5d5e81af9be0078a490cf44a19f45a) | `fast-downward: 19.12 → 21.12.0`                                                   |
| [`a8b50d73`](https://github.com/NixOS/nixpkgs/commit/a8b50d73b2450fcaa181ae53076f538355af3d8c) | `deliantra: refactor and override stdenv`                                          |
| [`91ffe81b`](https://github.com/NixOS/nixpkgs/commit/91ffe81b174d2d7faf40404f77b7747dc7c3dda3) | ``coan: use `-std=c++11` flag for gcc11 and later``                                |
| [`9028cd4e`](https://github.com/NixOS/nixpkgs/commit/9028cd4effb3beeef7064cedb5ed75db51c15ee9) | ``cjdns: add extra `-Wno-error` for gcc11``                                        |
| [`fb73942a`](https://github.com/NixOS/nixpkgs/commit/fb73942a4e04861eb75d32435fef5ff70e956e29) | `qt5: inherit stdenv for modules and override gcc version for qt512 and qt514`     |
| [`e91da70b`](https://github.com/NixOS/nixpkgs/commit/e91da70b45818a8b5bed647b490e7ba48346a5f1) | `python3Packages.astropy-extension-helpers: disable racy test`                     |
| [`83e19bd6`](https://github.com/NixOS/nixpkgs/commit/83e19bd62ee767a9003088013c8ba61dd7211f95) | `python3Packages.graphql-relay: 3.1.5 -> 3.2.0`                                    |
| [`4df59460`](https://github.com/NixOS/nixpkgs/commit/4df594601b4ead114232f37337a883fef6eaaea5) | `python3Packages.pytest-describe: init at 2.0.1`                                   |
| [`081f27f0`](https://github.com/NixOS/nixpkgs/commit/081f27f094feb27f554836681bce579505d999da) | `python3Packages.symengine: fix build with setuptools 61`                          |
| [`9ada55ce`](https://github.com/NixOS/nixpkgs/commit/9ada55cec55cd7a1db6ac7a3bb93140961cfeac0) | `libsForQt5.mapbox-gl-native: fix build`                                           |
| [`9043d626`](https://github.com/NixOS/nixpkgs/commit/9043d626c47b1e44366b71f0a6c663d6143195a1) | `python3Packages.requests: disable fatal tests on aarch64-darwin`                  |
| [`86d2ccf4`](https://github.com/NixOS/nixpkgs/commit/86d2ccf412d47034be8ebc289abf01e34227975d) | `python3Packages.path: disable racy test`                                          |
| [`75e732b7`](https://github.com/NixOS/nixpkgs/commit/75e732b70902eb57cf87870113896f8bf306b20a) | ``gnuapl: add extra `-Wno-error` for gcc11``                                       |
| [`5ea7a84c`](https://github.com/NixOS/nixpkgs/commit/5ea7a84ceb8996e1726c03d119a735080b1110ec) | ``fwbuilder: add `Wno-error` for gcc11``                                           |
| [`cc4c52b4`](https://github.com/NixOS/nixpkgs/commit/cc4c52b4b81d33dafc2cba61b506c27af8b6c6e2) | `drumgizmo: use gcc10Stdenv`                                                       |
| [`001e5336`](https://github.com/NixOS/nixpkgs/commit/001e5336d98576432345142600eced5e9c9e7bf0) | `cromfs: use gcc10Stdenv`                                                          |
| [`e7fd0ebf`](https://github.com/NixOS/nixpkgs/commit/e7fd0ebfa91bf3a1b4411ff76d891dd1c133644f) | ``cpp-ipfs-api: add `-Wno-error` flag to fix build on gcc11``                      |
| [`8a9d5e29`](https://github.com/NixOS/nixpkgs/commit/8a9d5e296b12810f7a5a2684c412e1188172a6a9) | ``cmtk: add `-std=c++11` to fix build on gcc11``                                   |
| [`6833a14e`](https://github.com/NixOS/nixpkgs/commit/6833a14e6bedba7d07b45d9ccba5686080d3ce75) | ``clucene-core: use `-std=c++11```                                                 |
| [`f30a8549`](https://github.com/NixOS/nixpkgs/commit/f30a85492cc7d495bdc3afd17e5f8dbfd32fd4d3) | `bpp: use gcc10Stdenv`                                                             |
| [`d320445a`](https://github.com/NixOS/nixpkgs/commit/d320445a8ccbcff2ae8764e7c6147e91e59fb475) | `belle-sip: add extra Wno-error flag needed by gcc11`                              |
| [`89ec6994`](https://github.com/NixOS/nixpkgs/commit/89ec69946c1652103349dd3c2c84697828b6b203) | `bazel_4: use gcc10Stdenv`                                                         |
| [`065409f6`](https://github.com/NixOS/nixpkgs/commit/065409f697056980c6b8a1e1dcd9e21b58bdd443) | `archiveopteryx: fix build on gcc11 with extra flags`                              |
| [`e432bbad`](https://github.com/NixOS/nixpkgs/commit/e432bbad7885d4c7880794858252d33af57cd90c) | `armips: use gcc10Stdenv`                                                          |
| [`0323c98c`](https://github.com/NixOS/nixpkgs/commit/0323c98ce767eb7f7b33a60bd53b606333ab0a1d) | `apsw: 3.37.0-r1 → 3.38.1-r1`                                                      |
| [`0e83e67a`](https://github.com/NixOS/nixpkgs/commit/0e83e67ae1a1ee0b2361f29c7b8c1bf1c46626f1) | `python3Packages.cryptography: fix disabledTestPaths value`                        |
| [`084f4811`](https://github.com/NixOS/nixpkgs/commit/084f4811ec23f4b0be6a10db44f6f970ba770759) | `python3Packages.twisted: prune patches`                                           |
| [`0d756105`](https://github.com/NixOS/nixpkgs/commit/0d75610566bf815a073953290a08579c11b81517) | `puddletag: relax lxml version`                                                    |
| [`cd7a1607`](https://github.com/NixOS/nixpkgs/commit/cd7a1607c662931c127037b06aabb006bdf60aa2) | `python310Packages.scikit-build: 0.13.1 -> 0.14.1`                                 |
| [`d8e61ab1`](https://github.com/NixOS/nixpkgs/commit/d8e61ab141fbd730b1c8cb542b33af4c6b240e0c) | `python310Packages.levenshtein: fix build`                                         |
| [`4e567243`](https://github.com/NixOS/nixpkgs/commit/4e5672439c33e85d7eafff30de3b6b560bbc77ca) | `python3Packages.rapidfuzz: 1.9.1 -> 2.0.8`                                        |
| [`0aba33ec`](https://github.com/NixOS/nixpkgs/commit/0aba33ec297ea1cbb8c7a659fc40afa56ba9dca5) | `python310Packages.cython_3: init at 3.0.0a10`                                     |
| [`5005b425`](https://github.com/NixOS/nixpkgs/commit/5005b4256107146e4762d34718ec976b7219899c) | `python3Packages.jarowinkler: init at 1.0.2`                                       |
| [`c2eae201`](https://github.com/NixOS/nixpkgs/commit/c2eae2011ceaad99b16a199eda90177e26934282) | `python3Packages.rapidfuzz-capi: init at 1.0.5`                                    |
| [`cd3b084c`](https://github.com/NixOS/nixpkgs/commit/cd3b084c17052771ce7c23243d7f251687095f84) | `python3Packages.grip: 4.5.2 -> 4.6.1`                                             |
| [`e87755d9`](https://github.com/NixOS/nixpkgs/commit/e87755d957088e5366d98197a774eddbfe7d886a) | `pgadmin4: relax pytz constraint`                                                  |
| [`1607fca7`](https://github.com/NixOS/nixpkgs/commit/1607fca7a8db5cca002ca339f422c67b3d529f80) | `pdm: 1.13.3 -> 1.14.0`                                                            |
| [`55ac1785`](https://github.com/NixOS/nixpkgs/commit/55ac17856a944e4de6aefc69a12014bb97338db6) | `python3Packages.installer: 0.3.0 -> 0.5.1`                                        |
| [`fd89ce66`](https://github.com/NixOS/nixpkgs/commit/fd89ce6694b0493f9545ad49c34618aeec740601) | `python3Packages.myfitnesspal: propagate typing-extensions`                        |
| [`c089f9c3`](https://github.com/NixOS/nixpkgs/commit/c089f9c37750606957a878fe37736c0124ec6cac) | `oci-cli: 3.6.0 -> 3.7.2`                                                          |
| [`18e3fc03`](https://github.com/NixOS/nixpkgs/commit/18e3fc0341d351cf3e78eb7309cf928dc65ef6e3) | `python3Packages.oci: 2.60.0 -> 2.63.0`                                            |
| [`9ae1ca3f`](https://github.com/NixOS/nixpkgs/commit/9ae1ca3fe6510f7cfc2a3f1ddc9b382357e66372) | `litecli: 1.6.0 -> 1.8.0`                                                          |
| [`621a68e4`](https://github.com/NixOS/nixpkgs/commit/621a68e48918d3e2f2f430e1cdbc273e3c4c6831) | `python3Packages.json-schema-for-humans: relax pytz constraint`                    |
| [`bd382e63`](https://github.com/NixOS/nixpkgs/commit/bd382e63411b45cfe7659f628c4bd590c727761c) | `python3Packages.vdirsyncer: relax click-log constraint`                           |
| [`56a90cd7`](https://github.com/NixOS/nixpkgs/commit/56a90cd79111f94c9250731336fe4baee03ebfa0) | `python3Packages.prompt_toolkit: propagate six`                                    |
| [`b66f4f6d`](https://github.com/NixOS/nixpkgs/commit/b66f4f6d8f46d9249437e509be8c0b549461d3d8) | `python3Packages.gipc: remove broken flag`                                         |
| [`fa37f4a1`](https://github.com/NixOS/nixpkgs/commit/fa37f4a1ff95696d0d1f7a6f64c3fd70ed21735c) | `python3Packages.flask-restx: patch for werkzeug 2.1 compat`                       |
| [`75331fc5`](https://github.com/NixOS/nixpkgs/commit/75331fc5e58c9c5c4fb009af2a378c087d2485bd) | `python3Packages.SQLAlchemy-ImageAttach: drop`                                     |
| [`8adac3f8`](https://github.com/NixOS/nixpkgs/commit/8adac3f85fa16aa4dd7fce698ffb1b49f6b3dd40) | `python3Packages.pyrad: revamp`                                                    |
| [`8c7d490d`](https://github.com/NixOS/nixpkgs/commit/8c7d490da6e39682fc46228feb6a8bd9733cddd4) | `python3Packages.pyslurm: 19-05-0 -> 21.08.4`                                      |
| [`9a9f7b94`](https://github.com/NixOS/nixpkgs/commit/9a9f7b940bf6e658890000cffd2a56fd6bb64f63) | `python3Packages.pytorch-bin: don't build on hydra`                                |
| [`4e4e4a57`](https://github.com/NixOS/nixpkgs/commit/4e4e4a570f4a2db98f7201c3b801f1f08c3642e2) | `python3Packages.trytond: fix werkzeug2.1 compat in test suite`                    |
| [`8e3fae56`](https://github.com/NixOS/nixpkgs/commit/8e3fae565c7bdab658aadc7327cb2a19e05d108e) | `python3Packages.chalice: relax jmespath constraint`                               |
| [`2f7893fb`](https://github.com/NixOS/nixpkgs/commit/2f7893fbf69006a303ab0b61d6e857a4e00b38d2) | `python3Packages.sanic: disable test_noisy_exceptions`                             |
| [`77e83e98`](https://github.com/NixOS/nixpkgs/commit/77e83e985a5e6a218aac78c0c5404c048f219bd6) | `python3Packages.scikit-build: fix build`                                          |
| [`cc58bb11`](https://github.com/NixOS/nixpkgs/commit/cc58bb11698cc49cf8101e392842f33a6a96c55e) | `python3Packages.matchpy: 0.5.1 -> 0.5.5`                                          |
| [`5bd5ab24`](https://github.com/NixOS/nixpkgs/commit/5bd5ab24100c2ec8fd9df43cc233c42a3e9705a1) | `ruby_3_1: 3.1.1 -> 3.1.2`                                                         |
| [`3e995fbb`](https://github.com/NixOS/nixpkgs/commit/3e995fbb3146d9ba5abf76697726631f5f241f12) | `ruby_3_0: 3.0.3 -> 3.0.4`                                                         |
| [`dd5210d8`](https://github.com/NixOS/nixpkgs/commit/dd5210d85aad4b4fc4ee3e9b13c651f36453b5e4) | `ruby_2_7: 2.7.5 -> 2.7.6`                                                         |
| [`60d698f8`](https://github.com/NixOS/nixpkgs/commit/60d698f8bfcf16a67a3ddf2ae2ccbf542c559c72) | `python3Packages.datasette: relax click & jinja2 constraints`                      |
| [`b08880a4`](https://github.com/NixOS/nixpkgs/commit/b08880a4f8afc27ee4d39daf22a371e89fe569ec) | `python3Packages.ansible-runner: build requires pbr`                               |
| [`50907e30`](https://github.com/NixOS/nixpkgs/commit/50907e300935a4bd8c09e74ff6a961358703194f) | `python3Packages.kivy-garden: fix source`                                          |
| [`498a4d8f`](https://github.com/NixOS/nixpkgs/commit/498a4d8feb0a2a92b02689341d852604ddd0142e) | `python3Packages.jaxlib: set platforms`                                            |
| [`b95480ef`](https://github.com/NixOS/nixpkgs/commit/b95480efb117f524dd0c90f4bab90b8cdc9635e0) | `fava: 1.19 -> 1.21; fix Werkzeug compat`                                          |
| [`8e6075b2`](https://github.com/NixOS/nixpkgs/commit/8e6075b2acda414c1633d318b37d796b0edf769f) | `python3Packages.atom: fix versioning and tests`                                   |
| [`2dde351e`](https://github.com/NixOS/nixpkgs/commit/2dde351eca481f756c0cba29673616040d13e58e) | `python3Packages.glean-parser: relax markupsafe constraint`                        |
| [`f6e6d951`](https://github.com/NixOS/nixpkgs/commit/f6e6d9510069981ddcfba55538a2d3cb0e3ea02e) | `python3Packages.flask-socketio: 5.0.1 -> 5.1.1`                                   |
| [`5eb123c3`](https://github.com/NixOS/nixpkgs/commit/5eb123c36504ff166c89aa68f542f34d9045ad9f) | `python3Packages.approvaltests: 4.0.0 -> 5.0.0`                                    |
| [`c0ea8f06`](https://github.com/NixOS/nixpkgs/commit/c0ea8f066ef1c041442df6f233cc1a96505604f0) | `python3Packages.python3-saml: relax lxml constraint`                              |
| [`1ccdd9ad`](https://github.com/NixOS/nixpkgs/commit/1ccdd9ad738ebc43ad843659bca9d91c19f071e8) | `python3Packages.starlette: 0.18.0 -> 0.19.0`                                      |
| [`4584d22b`](https://github.com/NixOS/nixpkgs/commit/4584d22ba16a1f4f03a8e4692a6adfd5100d008d) | `python3Packages.azure-core: propagate typing-extensions`                          |
| [`04c0a4b7`](https://github.com/NixOS/nixpkgs/commit/04c0a4b7b639a19348d39071c85eedce9df80737) | `home-assistant-cli: downgrade click to 8.0.4`                                     |
| [`95769fb2`](https://github.com/NixOS/nixpkgs/commit/95769fb2c8210c7de17cfe0a4419a337e82c6390) | `octoprint: fix eval`                                                              |
| [`3d0ccac7`](https://github.com/NixOS/nixpkgs/commit/3d0ccac7fe2247d5d9051d88ec45150b21d64b21) | `home-assistant: reduce component tests processes`                                 |
| [`2d1e788f`](https://github.com/NixOS/nixpkgs/commit/2d1e788f6072b90899cd159dba288625870f52e6) | `buku: update sqlalchemy hash`                                                     |
| [`69900853`](https://github.com/NixOS/nixpkgs/commit/69900853ca5dc675ebc74a04a2e663899b3650f2) | `mailman: fix build`                                                               |
| [`e391e40d`](https://github.com/NixOS/nixpkgs/commit/e391e40d0218a128c7144a4ae9faf11aac7222ad) | `python3Packages.falcon: fix build; cythonize!`                                    |
| [`7f613bbd`](https://github.com/NixOS/nixpkgs/commit/7f613bbdb66228538757faea2cdaa65dab57ffd0) | `awsebcli: fixup, downgrade jmespath`                                              |
| [`a4842356`](https://github.com/NixOS/nixpkgs/commit/a484235634a63c35e4e3a22d9f17f7938d7bf374) | `grab-site: update sqlalchemy hash`                                                |
| [`1828ad60`](https://github.com/NixOS/nixpkgs/commit/1828ad603b55d4fab1b0caa6964fac78948cf78e) | `python3.pkgs.pylint: 2.13.4 -> 2.13.5`                                            |
| [`abacec3d`](https://github.com/NixOS/nixpkgs/commit/abacec3d0bf5d6d5d2eb821ef7a148031d1bb67d) | `python3Packages.pytest-shutil: fix build`                                         |
| [`90112c22`](https://github.com/NixOS/nixpkgs/commit/90112c221fa2a783a0c7a198238f596298fe9c39) | `python3Packages.fakeredis: relax redis constraint`                                |
| [`1feb3397`](https://github.com/NixOS/nixpkgs/commit/1feb33974a6e36188a6f1104c104d45b39c555ce) | `python3Packages.mkdocs-material: 8.2.7 -> 8.2.9`                                  |
| [`3847540f`](https://github.com/NixOS/nixpkgs/commit/3847540f6d42e327930833921e5b3ec598c87d81) | `python3Packages.mkdocs: 1.2.3 -> 1.3.0`                                           |
| [`b4ead6ab`](https://github.com/NixOS/nixpkgs/commit/b4ead6abae46bd26d6ad667b372fb324b6ea8abb) | `python3Packges.pep257: remove together with pytest-pep257`                        |
| [`5ee7d17a`](https://github.com/NixOS/nixpkgs/commit/5ee7d17afc450ecf199e9d8d636e57e397fb3b28) | `python3Packages.path: rename from path.py; 12.0.1 -> 16.4.0`                      |
| [`8aaa0192`](https://github.com/NixOS/nixpkgs/commit/8aaa0192217668bd99a1c1d490a1f20db8911e42) | `python3Packages.twisted: 22.2.0 -> 22.4.0`                                        |
| [`d735ed38`](https://github.com/NixOS/nixpkgs/commit/d735ed3864920076030454b74d494d592b844e63) | `python3Packages.pytest-asyncio: 0.18.1 -> 0.18.3`                                 |
| [`bfcb28e1`](https://github.com/NixOS/nixpkgs/commit/bfcb28e12864af4acbceee9966791036f04fc163) | `python3Packages.async_generator: does not depend on pytest-asyncio`               |
| [`c2d27581`](https://github.com/NixOS/nixpkgs/commit/c2d27581473839bc979b695a18cf4e2a911a1337) | `borgbackup: disable racy test`                                                    |
| [`9f340b5b`](https://github.com/NixOS/nixpkgs/commit/9f340b5bf1cb63f10dd34c3ff69b582216168c75) | `treewide: remove redundant numprocesses pytest-xdist parameter`                   |
| [`836e3af5`](https://github.com/NixOS/nixpkgs/commit/836e3af5447ee51c81566b6717f445213c50f47b) | `python3Packages.jax: disable test_custom_linear_solve_aux`                        |
| [`84cc0b74`](https://github.com/NixOS/nixpkgs/commit/84cc0b7449edec98b4d94857e549a9430b257b3d) | `python310Packages.click: 8.1.1 -> 8.1.2`                                          |
| [`6fc914b3`](https://github.com/NixOS/nixpkgs/commit/6fc914b33759b5a831b634b4fb1bed092f71c186) | `python39Packages.ncclient: 0.6.12 -> 0.6.13`                                      |
| [`406c7d8c`](https://github.com/NixOS/nixpkgs/commit/406c7d8c3db0568fc2b4a2c65da85b348d52e155) | `python3Packages.img2pdf: 0.4.3 -> 0.4.4`                                          |
| [`4e23b47f`](https://github.com/NixOS/nixpkgs/commit/4e23b47f4825b417863574c1bca5dcd900f2d839) | `python3Packages.pikepdf: disable failing test`                                    |
| [`fe31277c`](https://github.com/NixOS/nixpkgs/commit/fe31277c3cbdb53a9cf8338d9b17fc98c8942201) | `python3Packages.pillow: 9.0.1 -> 9.1.0`                                           |
| [`35a6f46d`](https://github.com/NixOS/nixpkgs/commit/35a6f46d6d85a0138808422afda2f0a84aaeb1d9) | `python3Packages.fastparquet: 0.7.1 -> 0.8.1`                                      |
| [`d57404ea`](https://github.com/NixOS/nixpkgs/commit/d57404ea3dcb3ab98913414a6f6fba854a8509b2) | `python3Packages.jax: test with limited parallelism`                               |
| [`214d1517`](https://github.com/NixOS/nixpkgs/commit/214d151733609316e45aaf60d95c0ac6b43707ae) | `python3Packages.rich: 12.0.1 -> 12.2.0`                                           |
| [`ba47e594`](https://github.com/NixOS/nixpkgs/commit/ba47e59440bbcfd1f769600783331f4cb4c95bbe) | `python3Packges.websocket: add missing six dependency`                             |
| [`7fc6852d`](https://github.com/NixOS/nixpkgs/commit/7fc6852dbfa61c86021292e6c9cf99cd764f615a) | `python3Packages.google-cloud-testutils: propagate packaging`                      |
| [`26970a06`](https://github.com/NixOS/nixpkgs/commit/26970a06a9aeed8f4c79ac7631a68e4663247a5f) | `python3Packages.mitmproxy: add dontUsePytestXdist flag`                           |
| [`5a6793c4`](https://github.com/NixOS/nixpkgs/commit/5a6793c4f8d9e582d8ccfca7380838c5870a0f78) | `python3Packages.junos-eznc: fix build and tests`                                  |
| [`44f0a04d`](https://github.com/NixOS/nixpkgs/commit/44f0a04ddd7e98f186ef11a70fba5d7db5ee32f1) | `python3Packages.pandas: use upstreams fast test settings`                         |
| [`8b069e36`](https://github.com/NixOS/nixpkgs/commit/8b069e36f9fdaa8498ad7fe5b5e7255daaff0024) | `python3Packages.sqlalchemy: 1.4.34 -> 1.4.35`                                     |
| [`29b968bf`](https://github.com/NixOS/nixpkgs/commit/29b968bf1732c77bab8ab8c00cc6da6fe9e60f53) | `python3Packages.httplib2: 0.20.3 -> 0.20.4`                                       |
| [`48796979`](https://github.com/NixOS/nixpkgs/commit/487969790f378cb9d4e86fb72274ee4312eff3d1) | `python3Packages.shapely: update patch to apply to 1.8.1.post1`                    |
| [`9639fdbb`](https://github.com/NixOS/nixpkgs/commit/9639fdbb920a200bebc144cd07a984d27c5caf8f) | `python3Packages.pycurl: re-enable tests that no longer fail`                      |
| [`b5facab1`](https://github.com/NixOS/nixpkgs/commit/b5facab1efb476520dd62de05d3bde2e571b333c) | `python39Packages.pytest-xdist: run xdist hook before pytestCheckPhase`            |
| [`352ae0b7`](https://github.com/NixOS/nixpkgs/commit/352ae0b79e526dc110858acd16d4d01bf3cd415f) | `python39Packages.yanc: only disable tests on python >=3.5`                        |
| [`f0719291`](https://github.com/NixOS/nixpkgs/commit/f0719291bc23766be9d266fbe2ac1c397fe856ef) | `python39Packages.cffi: move prePatch to postPatch to not break patches`           |
| [`d52b53fd`](https://github.com/NixOS/nixpkgs/commit/d52b53fd9ea0c8a75383457a60bcf22fe3b6f5f1) | `python3.pkgs.bcrypt: fix build`                                                   |
| [`0594c921`](https://github.com/NixOS/nixpkgs/commit/0594c921f191904dd8cb014aadd6af3f521f73b2) | `python3Packages.bcrypt: add pythonImportsCheck`                                   |
| [`c7fa6772`](https://github.com/NixOS/nixpkgs/commit/c7fa67725a918662beb99cbbb5110f65a715db4b) | `python39Packages.bcrypt: remove unused dependencies`                              |
| [`27b5b67d`](https://github.com/NixOS/nixpkgs/commit/27b5b67d9f929dd024e6caf63c518e93c5400b8c) | `python3Packages.pdm-pep517: 0.12.1 -> 0.12.3`                                     |
| [`c2131658`](https://github.com/NixOS/nixpkgs/commit/c213165843d8c1b2ba7047ece89d1112409d00ef) | `python3Packages.nbconvert: propagate beautifulsoup4`                              |
| [`bfea00a6`](https://github.com/NixOS/nixpkgs/commit/bfea00a6039e639d733dc7151571d390912afc5a) | `python3Packages.azure-mgmt-core: propagate typing-extensions`                     |
| [`c0a3fcdf`](https://github.com/NixOS/nixpkgs/commit/c0a3fcdf9f368906d3bafe63b547cb0971d377c9) | `python3Packages.azure-core: 1.23.0 -> 1.23.1`                                     |
| [`280ec33c`](https://github.com/NixOS/nixpkgs/commit/280ec33cd21b90ce681d97f28ed72375a93b48ba) | `awscli: 1.22.67 -> 1.22.88`                                                       |
| [`95f40510`](https://github.com/NixOS/nixpkgs/commit/95f405100f188b05c4817fdb0eff7130fe29e1cc) | `python3Packages.botocore: 1.24.30 -> 1.24.33`                                     |
| [`41d6a4e1`](https://github.com/NixOS/nixpkgs/commit/41d6a4e19cc5c3674db091469e87429f504a5fc8) | `python3Packages.ipykernel: 6.11.0 -> 6.12.1`                                      |
| [`00f38e1a`](https://github.com/NixOS/nixpkgs/commit/00f38e1a832f8b2e39f63f34e7ded26058ed8dbe) | `python39Packages.hypothesmith: remove linting programs`                           |
| [`334fb0c7`](https://github.com/NixOS/nixpkgs/commit/334fb0c7ed3e2e2446b5fe52c8b2e9747e6da509) | `python39Packages.typer: remove linting programs`                                  |
| [`1e38fae0`](https://github.com/NixOS/nixpkgs/commit/1e38fae01e13a2257722feadc81fad79cf05276e) | `python39Packages.ipython: remove optional black depedency, update homepage`       |
| [`4775c308`](https://github.com/NixOS/nixpkgs/commit/4775c308fa481128d971fd9f15313ebaf6aeb76c) | `pytest-httpbin: drop assertion that doesn't hold anymore`                         |
| [`26122503`](https://github.com/NixOS/nixpkgs/commit/26122503115d906c951e40a827f21f54c996d537) | `python3Packages.ephemeral-port-reserve: skip test_fqdn on darwin`                 |
| [`5279d5eb`](https://github.com/NixOS/nixpkgs/commit/5279d5ebc4eff52403201334827e2bd65eba4bb7) | `python3Packages.asgiref: fix tests on darwin`                                     |
| [`cce35dad`](https://github.com/NixOS/nixpkgs/commit/cce35dad7ab540adec0fb7cb3454647ddf91a089) | `python3Packages.httpbin: apply patch for werkzeug 2.1.0 compatibility`            |
| [`46111b2b`](https://github.com/NixOS/nixpkgs/commit/46111b2bcd4e107f08c70346c1de7314650e3059) | `python3Packages.flask-restful: apply patch for werkzeug 2.1.0 compat`             |
| [`8502ec56`](https://github.com/NixOS/nixpkgs/commit/8502ec56ec039186eabbb8f97653092fcb16b55e) | `python3Packages.pylint: 2.13.3 -> 2.13.4`                                         |
| [`04cc7098`](https://github.com/NixOS/nixpkgs/commit/04cc709898d1f542404283f4811c0cc430c3427b) | `python3Packages.httplib2: drop xdist, prone to race conditions`                   |
| [`c994f0ed`](https://github.com/NixOS/nixpkgs/commit/c994f0ed6354628a5e834f818692a79a79467e6d) | `python3Packages.funcparserlib: add six to check deps`                             |
| [`72f9e7ce`](https://github.com/NixOS/nixpkgs/commit/72f9e7ced48ac268c82dd2768a495d694d78c2dc) | `python3Packages.pandas: 1.4.1 -> 1.4.2`                                           |
| [`0822ef73`](https://github.com/NixOS/nixpkgs/commit/0822ef73055798f6eae5cda61562e54d796700a7) | `python3Packages.flask-paranoid: 0.2 -> 0.3.0`                                     |
| [`3467f4e8`](https://github.com/NixOS/nixpkgs/commit/3467f4e89524549f11fdb4160da874922cfb19df) | `python3Packages.moto: update disabled tests, drop xdist`                          |
| [`008fbda8`](https://github.com/NixOS/nixpkgs/commit/008fbda841b9b008de6583bc40d5543dae9755f9) | `python3Packages.pytest-xdist: fix hook being applied multiple times`              |
| [`2e4bb34c`](https://github.com/NixOS/nixpkgs/commit/2e4bb34c632b93921042816be0d892d2c9d8d4d1) | `python3Packages.dugong: disable tests on python310`                               |
| [`45e30be2`](https://github.com/NixOS/nixpkgs/commit/45e30be21ad53fddbe1f0f0dc466fa7e94972712) | `python3Packages.clize: relax docutils constraint, set up extras-require`          |
| [`280d3f06`](https://github.com/NixOS/nixpkgs/commit/280d3f06e9bceb369a477f288971fefb520d2ce9) | `python3Packaegs.sphinx_rtd_theme: update docutils pin relaxation`                 |
| [`32b8c9e7`](https://github.com/NixOS/nixpkgs/commit/32b8c9e7b96de613f245f93bce8c8923db680720) | `python3Packages.django-modelcluster: rename, fix build, enable tests`             |
| [`ccc1ddd2`](https://github.com/NixOS/nixpkgs/commit/ccc1ddd231f96d43d93eb400afddc229767613d0) | `python3Packaegs.pyspark: update py4j pin relaxation`                              |
| [`dd0dd6a6`](https://github.com/NixOS/nixpkgs/commit/dd0dd6a6d0793dcf9d327ffd578c08ea77ea7496) | `python3Packages.ovh: propagate requests`                                          |
| [`d744db51`](https://github.com/NixOS/nixpkgs/commit/d744db51bc6e497f128094df7b0bc77633b46cc9) | `python3Packages.nunavut: propagate importlib-resources`                           |
| [`1a22bd12`](https://github.com/NixOS/nixpkgs/commit/1a22bd129a7a4d61d8c490d16d262e8244e95d1f) | `python3Packages.importlib-resources: use pyproject format`                        |
| [`67579d12`](https://github.com/NixOS/nixpkgs/commit/67579d12adfc21cb8b50e499f2f90376e890f924) | `python3Packages.fn: patch for python3.10 compat`                                  |
| [`4c3a9544`](https://github.com/NixOS/nixpkgs/commit/4c3a954438cc157d8e0be81e2d86eec1b888da4c) | `python3Packages.numpydoc: relax jinja2 constraint, disable failing tests`         |
| [`dc9fdf54`](https://github.com/NixOS/nixpkgs/commit/dc9fdf545cd3f9e723a164632215bf45016ff73f) | `python3Packages.pympler: disable failing test`                                    |
| [`9628bac8`](https://github.com/NixOS/nixpkgs/commit/9628bac854169e9a4ec264910b52bede30176eb5) | `python3Packages.dateparser: 1.1.0 -> 1.1.1`                                       |
| [`27c0f6ef`](https://github.com/NixOS/nixpkgs/commit/27c0f6efa9203b1a8ad52f2dfee294dd90962f7d) | `Revert "python3Packages.regex: 2022.3.2 -> 2022.3.15"`                            |
| [`349e9dae`](https://github.com/NixOS/nixpkgs/commit/349e9dae04d7ac17a5d3b102b07e594a82db3ee7) | `python3Packages.flask-security-too: disable tests incompatible with flask>=2.1.0` |
| [`935ec0a8`](https://github.com/NixOS/nixpkgs/commit/935ec0a8356345ad0318bbb466611c52de0dca87) | `python3Packages.flask-security-too: split off extra-requires`                     |
| [`4d623588`](https://github.com/NixOS/nixpkgs/commit/4d62358894717bf75d63ce2f47b2d6d327c85dc1) | `python3Packages.flask-paranoid: disable failing tests`                            |
| [`b801565f`](https://github.com/NixOS/nixpkgs/commit/b801565f228550894c61071dbf253f8caf65706a) | `python3Packages.reedsolo: python 3.10 compat`                                     |
| [`90161bca`](https://github.com/NixOS/nixpkgs/commit/90161bca631b7b426173e7bf7926c45cb724ab7e) | `python3Packages.reedsolo: use git tag`                                            |
| [`c4b104a8`](https://github.com/NixOS/nixpkgs/commit/c4b104a8508dfccf4792670b3086db5776701702) | `python310Packages.py-radix: disable`                                              |
| [`8e64a0c0`](https://github.com/NixOS/nixpkgs/commit/8e64a0c0d8f32468212f24768e371c611f0e873c) | `python3Packages.wasm: disable`                                                    |