### PR TITLE
chore(flake/home-manager): `742c6cb3` -> `93a69d07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650234580,
-        "narHash": "sha256-wTmlRedCrDl+XYJom65GMfI3RgA3eZE/w03lD28Txoc=",
+        "lastModified": 1650478719,
+        "narHash": "sha256-308c2cM4hW9AW6dSQ080ycXGyEJGkG/OwOINkYL9Mnw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "742c6cb3e9d866e095c629162fe5faf519adeb26",
+        "rev": "93a69d07389311ffd6ce1f4d01836bbc2faec644",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`93a69d07`](https://github.com/nix-community/home-manager/commit/93a69d07389311ffd6ce1f4d01836bbc2faec644) | `Simplify function (#2903)`                                                    |
| [`8ec13d33`](https://github.com/nix-community/home-manager/commit/8ec13d33b17f246e03ddfea100b7c3a143255bea) | `targets.genericLinux: include additional directories in XCURSOR_PATH (#2902)` |
| [`8d38ca88`](https://github.com/nix-community/home-manager/commit/8d38ca886880265d523a66fe3da4d42e92ab0748) | ``xdg-mime-apps: add function `mimeAssociations```                             |