### PR TITLE
chore(flake/nixpkgs): `ba88a5af` -> `b06d35b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650222748,
-        "narHash": "sha256-AHh/goEfG5hlhIMVgGQwACbuv5Wit2ND9vrcB4QthJs=",
+        "lastModified": 1650527056,
+        "narHash": "sha256-dyBthjAs6JlNNDMi7SY+d2CirgBDqjG8SvZKeUvTLqM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ba88a5afa6fff7710c17b5423ff9d721386c4164",
+        "rev": "b06d35b406c2396dd1611dc8601138fa3d06ee60",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`d100a223`](https://github.com/NixOS/nixpkgs/commit/d100a223aa4dbc57810b56238eee335e4508c16a) | `python310Packages.types-dateutil: 2.8.11 -> 2.8.12`                             |
| [`f630d0ed`](https://github.com/NixOS/nixpkgs/commit/f630d0eda9f5ce207472c573b2f6a7913327fa62) | `checkov: 2.0.1068 -> 2.0.1075`                                                  |
| [`c94fae10`](https://github.com/NixOS/nixpkgs/commit/c94fae104603e9b6ca27cf7aa4ba8a6052ce4ab2) | `python310Packages.types-decorator: 5.1.5 -> 5.1.6`                              |
| [`55ec5642`](https://github.com/NixOS/nixpkgs/commit/55ec5642a5ae0544d9d67bc7674739bd5bb696e1) | `python3Packages.mdurl: 0.1.0 -> 0.1.1`                                          |
| [`b0fd5a29`](https://github.com/NixOS/nixpkgs/commit/b0fd5a29d5b6a55795610433c3b2ced5697edaca) | `python3Packages.md-toc: 8.1.2 -> 8.1.3`                                         |
| [`ccc8e853`](https://github.com/NixOS/nixpkgs/commit/ccc8e853b5abb56715a04183a7e50159a88aa6bc) | `gitleaks: 8.7.1 -> 8.7.2`                                                       |
| [`b0f62d6b`](https://github.com/NixOS/nixpkgs/commit/b0f62d6bc30d0d11727853b47c1e9d8af7373039) | `gitleaks: 8.7.0 -> 8.7.1`                                                       |
| [`3a9e595d`](https://github.com/NixOS/nixpkgs/commit/3a9e595d9b740b49d982fdf53d59239747352a20) | `python3Packages.boschshcpy: 0.2.31 -> 0.2.32`                                   |
| [`0779a04a`](https://github.com/NixOS/nixpkgs/commit/0779a04aadd6ac02864f1d71ca0c320815a847b5) | `python310Packages.policyuniverse: 1.5.0.20220416 -> 1.5.0.20220420`             |
| [`bd893ba9`](https://github.com/NixOS/nixpkgs/commit/bd893ba963fb3b58b49b0a0edb7e82f0ba952754) | `maigret: 0.4.2 -> 0.4.3`                                                        |
| [`353647de`](https://github.com/NixOS/nixpkgs/commit/353647de4780c17e8ac00f22adf470dc47acfb82) | `python310Packages.pykeyatome: 1.5.1 -> 1.5.2`                                   |
| [`99e47617`](https://github.com/NixOS/nixpkgs/commit/99e47617042d76425dc640df1677028f1681e4f9) | `magma: 2.5.4 → 2.6.2`                                                           |
| [`252a6b8a`](https://github.com/NixOS/nixpkgs/commit/252a6b8a9360ed26c9b12694e3d9f2d0e335f056) | `python310Packages.xknx: 0.20.3 -> 0.20.4`                                       |
| [`ec9741e8`](https://github.com/NixOS/nixpkgs/commit/ec9741e8c1333d2cfb6070fa6fdf1689f4a80ddc) | `python310Packages.west: 0.13.0 -> 0.13.1`                                       |
| [`cdfcc5ce`](https://github.com/NixOS/nixpkgs/commit/cdfcc5cecf00fd0be74c1e03effe10970212576a) | `kubectl: add fish completions`                                                  |
| [`2b4cebe8`](https://github.com/NixOS/nixpkgs/commit/2b4cebe8136502005840cd73c7536bc39c779dd6) | `solana-testnet: 1.9.2 -> 1.100.9`                                               |
| [`d4ad7180`](https://github.com/NixOS/nixpkgs/commit/d4ad7180165494e318526bde95d5594ca131474b) | `python310Packages.pex: 2.1.81 -> 2.1.82`                                        |
| [`76b68621`](https://github.com/NixOS/nixpkgs/commit/76b68621e88f674922aa70276a8333f319ce9c05) | `lemmy: fix update.sh script`                                                    |
| [`b4a6c73c`](https://github.com/NixOS/nixpkgs/commit/b4a6c73c01106f7372a8c9f56cbcb9a152d7d3a1) | `radicale: 3.1.6 -> 3.1.7`                                                       |
| [`ddbc061b`](https://github.com/NixOS/nixpkgs/commit/ddbc061b4bd47cbc78b4288693e23552b91b1f4e) | `hasura-graphql-engine: mark as broken`                                          |
| [`9cd8281b`](https://github.com/NixOS/nixpkgs/commit/9cd8281b8b142c572eda5d5693aa192000ec4250) | `hyper-haskell-server-with-packages: mark broken`                                |
| [`53d05a92`](https://github.com/NixOS/nixpkgs/commit/53d05a92ebab7449136751125460b8f31cf7bbaa) | `python310Packages.types-requests: 2.27.19 -> 2.27.20`                           |
| [`3e6d4c00`](https://github.com/NixOS/nixpkgs/commit/3e6d4c00a9ad98fcdceb476aab68de2f92b752b2) | `jl: mark broken`                                                                |
| [`f1f7144d`](https://github.com/NixOS/nixpkgs/commit/f1f7144df4643993d9d7c74c8df5ed9e026c37f5) | `haskellPackages: mark builds failing on hydra as broken`                        |
| [`c30b0af1`](https://github.com/NixOS/nixpkgs/commit/c30b0af1bd6909d667a69cd0e15c3e112366c693) | `bitmask-vpn: install the app's icon (#168904)`                                  |
| [`272876ed`](https://github.com/NixOS/nixpkgs/commit/272876edaee628787b4dd5b3715e7a5e076a8176) | `ionide.ionide-fsharp: 5.11.0 -> 6.0.1 (#168874)`                                |
| [`cb083a20`](https://github.com/NixOS/nixpkgs/commit/cb083a2026e6e8014f274ab3dfb264997be5563d) | `weighttp: remove`                                                               |
| [`92c04965`](https://github.com/NixOS/nixpkgs/commit/92c049659a25d530bd6790e47c5f0cd3b096dbde) | `cudaPackages_11_6: better message on why gcc10`                                 |
| [`7e698702`](https://github.com/NixOS/nixpkgs/commit/7e69870247ae3c8e0782c7bc0c19c96427122c4c) | `Revert "wpa_supplicant: fix withDbus=false build"`                              |
| [`1a1ce8f8`](https://github.com/NixOS/nixpkgs/commit/1a1ce8f8c74712871a8737e653aa9246e43efa3f) | `python3Packages.aioqsw: init at 0.0.5`                                          |
| [`3d707f09`](https://github.com/NixOS/nixpkgs/commit/3d707f0920755102083f1d34287f1f9d06d00d96) | `python3Packages.eagle100: init at 0.1.0`                                        |
| [`1613460b`](https://github.com/NixOS/nixpkgs/commit/1613460b35e8fcbc326557bee54215c1e06c31d3) | `siege: 4.1.2 -> 4.1.3`                                                          |
| [`49974bd3`](https://github.com/NixOS/nixpkgs/commit/49974bd39777bfc84199319b346170b072ecabf3) | `python3Packages.seventeentrack: init at 2022.04.4`                              |
| [`11ff7da6`](https://github.com/NixOS/nixpkgs/commit/11ff7da635524eab596982a22cc715a5ac8b9429) | `nccl: 2.7.8-1 -> 2.12.10-1`                                                     |
| [`d5239ed8`](https://github.com/NixOS/nixpkgs/commit/d5239ed8d0e6197e1123e0e61b99f58f4a0e584b) | `cudaPackages: undo the cudaPackages_11_3 fallback`                              |
| [`b1eef8c0`](https://github.com/NixOS/nixpkgs/commit/b1eef8c0f0d3ca1263590a16a36b1d1832b5d4f1) | `ocamlPackages.toml: 6.0.0 -> 7.0.0 (#165676)`                                   |
| [`e8f3e829`](https://github.com/NixOS/nixpkgs/commit/e8f3e829a750794f42634f4975062177e7c5466f) | `cudaPackages: 11_5 -> 11_6, recover from gcc10->gcc11`                          |
| [`67e9ab56`](https://github.com/NixOS/nixpkgs/commit/67e9ab5612efbbd4274d6330034280fb14c4b6c5) | `nushell: 0.60.0 -> 0.61.0`                                                      |
| [`df873bb8`](https://github.com/NixOS/nixpkgs/commit/df873bb84f6212a30c25eaee662095d615a35ae0) | `awscli2: use python-dateutil directly`                                          |
| [`5a9a3c22`](https://github.com/NixOS/nixpkgs/commit/5a9a3c221fe19535d6da88e8aec65bd4605503a5) | `home-assistant: 2022.4.5 -> 2022.4.6`                                           |
| [`b587fa28`](https://github.com/NixOS/nixpkgs/commit/b587fa2897da0a53939d5994ee8a6f30c498e0c0) | `bottles: move patching from preConfigure into postPatch`                        |
| [`d002c9f5`](https://github.com/NixOS/nixpkgs/commit/d002c9f58f2e63cb2548ee6649d9deb310788818) | `bottles: remove custom updater`                                                 |
| [`4202e1bf`](https://github.com/NixOS/nixpkgs/commit/4202e1bf0b212fdb738de028d226d595a0c227be) | `consul: 1.11.5 -> 1.12.0`                                                       |
| [`db4a2977`](https://github.com/NixOS/nixpkgs/commit/db4a2977daef7e13f442d923a2f813c033ea7ecb) | `devilutionx: 1.3.0 -> 1.4.0`                                                    |
| [`576b229f`](https://github.com/NixOS/nixpkgs/commit/576b229fccc55a8e410725da7aaf7f7f5a4e803d) | `debian-goodies: init at 0.87`                                                   |
| [`f5dcf2fa`](https://github.com/NixOS/nixpkgs/commit/f5dcf2fa818a9012f560144fbb11a11984aab77a) | `python3Packages.dm-tree: fix gcc11 build due to abseil-cpp version mismatch`    |
| [`6a9aafbf`](https://github.com/NixOS/nixpkgs/commit/6a9aafbf3bc051b2fdbd91c35f2153ba9dc27398) | `pigz: use github as a source`                                                   |
| [`20206d6e`](https://github.com/NixOS/nixpkgs/commit/20206d6e58d46bc6b03dd5b55c66cb82daa8dda0) | `oh-my-zsh: 2022-04-18 -> 2022-04-19 (#169408)`                                  |
| [`b2613561`](https://github.com/NixOS/nixpkgs/commit/b261356146d0834c6e2146f04018c081fa3985aa) | `awscli2: 2.4.23 -> 2.5.6 (#169441)`                                             |
| [`3924c086`](https://github.com/NixOS/nixpkgs/commit/3924c086f64c71bdacf6d104f8b0010dd18a8760) | `python310Packages.pixcat: init at 0.1.4 (#162556)`                              |
| [`2696f4c6`](https://github.com/NixOS/nixpkgs/commit/2696f4c69688d6c31fb8363fdf556e06047eb068) | `terraform: 1.1.8 -> 1.1.9 (#169452)`                                            |
| [`e551794b`](https://github.com/NixOS/nixpkgs/commit/e551794bfe83c9140bfb94e6ac843e58a7b77718) | `sccache: Fix sccache compilation on aarch64-linux platform`                     |
| [`e148dfe8`](https://github.com/NixOS/nixpkgs/commit/e148dfe8b866064124677c32a4f0dab7ab7a41b0) | `metal-cli: 0.7.3 -> 0.7.4`                                                      |
| [`9a6c54e2`](https://github.com/NixOS/nixpkgs/commit/9a6c54e28b821469e9268525be08c6eee245628f) | `terraform.mkProvider: include rev in src`                                       |
| [`36b6d377`](https://github.com/NixOS/nixpkgs/commit/36b6d377c06b9fb5589cabe4b7f26784bb3ab21b) | `fluxcd: 0.28.5 -> 0.29.1`                                                       |
| [`6bd609ac`](https://github.com/NixOS/nixpkgs/commit/6bd609ac0eed972c46a3e0624e65570e18d8c016) | `vimPlugins: update`                                                             |
| [`325a5254`](https://github.com/NixOS/nixpkgs/commit/325a525467f6200eae76a1406b1684d02536c8e4) | `nixos/consul: allow ipv6-only`                                                  |
| [`9d733f3d`](https://github.com/NixOS/nixpkgs/commit/9d733f3d4975fb3c516a2bf2bf1bc6f50781a553) | `qemu: 6.2.0 -> 7.0.0`                                                           |
| [`92555464`](https://github.com/NixOS/nixpkgs/commit/925554648196d96644fcdebc8aa2818bbe5761b0) | `richgo: enable tests`                                                           |
| [`581998a7`](https://github.com/NixOS/nixpkgs/commit/581998a73e648a93978570e70017939acb3a6f8a) | `python39Packages.pytest-testmon: fix build`                                     |
| [`6b70d7a4`](https://github.com/NixOS/nixpkgs/commit/6b70d7a4f0e31409b928609a909f9767634f07f0) | `addlicense: init at 1.0.0`                                                      |
| [`a49e4933`](https://github.com/NixOS/nixpkgs/commit/a49e4933767acaafebda4c94ac629c2cfdc48f4b) | `python3Packages.httpx-ntlm: relax dependency constraints`                       |
| [`39396a4b`](https://github.com/NixOS/nixpkgs/commit/39396a4bbbd295aeba13b97ea4934833c5a4274d) | `python310Packages.faraday-plugins: 1.6.2 -> 1.6.3`                              |
| [`572131c6`](https://github.com/NixOS/nixpkgs/commit/572131c6a945069dba5a12a0354df8254224a458) | `nixos/mailman: ensure Postfix is started after Mailman`                         |
| [`52a744b7`](https://github.com/NixOS/nixpkgs/commit/52a744b7f89a9add978bc1d6cc5d92352580eca4) | `testers.testEqualDerivation: move from build-support/test-equal-derivation.nix` |
| [`5d5fe2be`](https://github.com/NixOS/nixpkgs/commit/5d5fe2be203a122e668f183e61e83ede43ff04b7) | `python310Packages.cyclonedx-python-lib: 2.2.0 -> 2.3.0`                         |
| [`7de75144`](https://github.com/NixOS/nixpkgs/commit/7de75144a7c8fa4f28a91d6ca68dd2d31949926a) | `python3Packages.shtab: 1.5.3 -> 1.5.4`                                          |
| [`8059cfce`](https://github.com/NixOS/nixpkgs/commit/8059cfcecb9d71cd6bbdcf77366bc36ae4ceca56) | `python3Packages.flask-security-too: 4.1.3 -> 4.1.4`                             |
| [`5799e258`](https://github.com/NixOS/nixpkgs/commit/5799e2580d4516c616bbf478090098ea1d6a6903) | `franz: 5.6.1 -> 5.9.2`                                                          |
| [`e7e330d1`](https://github.com/NixOS/nixpkgs/commit/e7e330d112783de9976c4c299a20e04b691b2c25) | `python3Packages.kaldi-active-grammar: add note about updating dragonfly`        |
| [`5a27ee3e`](https://github.com/NixOS/nixpkgs/commit/5a27ee3e7ce84e79198889cb19536c01f963c4e3) | `dragonfly: 0.32.0 -> 0.35.0`                                                    |
| [`a7e62c21`](https://github.com/NixOS/nixpkgs/commit/a7e62c21c1fbb36588e06dadd252f3fced6dbda2) | `ocamlPackages.pure-splitmix: init at 0.3`                                       |
| [`9aa4c5db`](https://github.com/NixOS/nixpkgs/commit/9aa4c5dbfc806b2f71ad351fc79d5d0312e0caa4) | `isabelle: Make closer to upstream`                                              |
| [`1e03b381`](https://github.com/NixOS/nixpkgs/commit/1e03b381e7af7e167cace24b0fc72754e794e40c) | `python310Packages.aiohomekit: 0.7.16 -> 0.7.17`                                 |
| [`7383ec70`](https://github.com/NixOS/nixpkgs/commit/7383ec7045c66d11cf48dad2afee8d6920e568aa) | `python3Packages.setupmeta: add missing input`                                   |
| [`27245956`](https://github.com/NixOS/nixpkgs/commit/27245956af1f03ceb5be370c8218e2bbdd6c32ea) | `trash-cli: 0.21.10.24 -> 0.22.4.16`                                             |
| [`3540cc8d`](https://github.com/NixOS/nixpkgs/commit/3540cc8d16870c2a39f4254152e9be1cb2214473) | `ocamlPackages.hacl-star-raw: fix aarch64-darwin`                                |
| [`30943ab9`](https://github.com/NixOS/nixpkgs/commit/30943ab97bb29bfd55c3972dddddb9cd26bf5591) | `unifont: 14.0.02 -> 14.0.03`                                                    |
| [`dca08f64`](https://github.com/NixOS/nixpkgs/commit/dca08f645d6632449f5a5a1e329296a87033503f) | `naproche: add to release-haskell.nix`                                           |
| [`ab0788c8`](https://github.com/NixOS/nixpkgs/commit/ab0788c8f5c2109de29b3be5858fc32a9332a36d) | `ocamlPackages.flex: init unstable-2020-09-12`                                   |
| [`2e52d5c8`](https://github.com/NixOS/nixpkgs/commit/2e52d5c892e03a9f9d61d2479b10c908d9bdec39) | `naproche: 0.1.0.0 -> 2022-04-19`                                                |
| [`d386719c`](https://github.com/NixOS/nixpkgs/commit/d386719c7e6ffc5baa14ec5bdf1f1d3350b3da81) | `python3Packages.python-miio: update decorator`                                  |
| [`4389bfe8`](https://github.com/NixOS/nixpkgs/commit/4389bfe8f033695ae32bee8aed7d8b0d0d646411) | `gspell: 1.9.1 -> 1.10.0`                                                        |
| [`efd13315`](https://github.com/NixOS/nixpkgs/commit/efd13315f77c6313f71feced31fef6fa972e0964) | `ocamlPackages.brisk-reconciler: init unstable-2020-12-02`                       |
| [`2272244c`](https://github.com/NixOS/nixpkgs/commit/2272244c04d264272cd36d0e848620a15e61c0ae) | `notejot: 3.4.9 -> 3.5.1`                                                        |
| [`74ccb557`](https://github.com/NixOS/nixpkgs/commit/74ccb557e2210285ec870d7f5d7b83cf1267c0d1) | `python310Packages.pex: 2.1.80 -> 2.1.81`                                        |
| [`6efbfd12`](https://github.com/NixOS/nixpkgs/commit/6efbfd12e7a595833f6c26d350ed89bcb41bbb68) | `inkscape: add pyserial`                                                         |
| [`3469e707`](https://github.com/NixOS/nixpkgs/commit/3469e707e19f73027230e654dd80a8ae21f407f5) | `python310Packages.pycfmodel: 0.19.0 -> 0.19.1`                                  |
| [`522afed5`](https://github.com/NixOS/nixpkgs/commit/522afed5a67e6944135359bc4621633058b5adcc) | `cudatext: 1.161.0 -> 1.162.0`                                                   |
| [`d09ee141`](https://github.com/NixOS/nixpkgs/commit/d09ee141f077cc5ad42acff11a094bad8336c09b) | `python3Packages.radio_beam: propagate numpy, scipy, six`                        |
| [`d8eb5fd7`](https://github.com/NixOS/nixpkgs/commit/d8eb5fd7a4e7c9e86012ea4f84b3c138b6534fec) | `python3Packages.flask-admin: disable test that fails with werkzeug>=2.1.0`      |
| [`16e78118`](https://github.com/NixOS/nixpkgs/commit/16e781187a61a84a5ff90ff9769ebf1acd28f31d) | `cfripper: 1.8.0 -> 1.9.0`                                                       |
| [`67884e4e`](https://github.com/NixOS/nixpkgs/commit/67884e4e9a1e057bcdd049879848d98d734cd03d) | `python3Packages.pyfaidx: disable failing tests`                                 |
| [`f2d98aed`](https://github.com/NixOS/nixpkgs/commit/f2d98aedb13d662eb3cc273e06f96a3195467b3d) | `python3Packags.geoalchemy2: disable test that depend on pgsql instance`         |
| [`f9c5259b`](https://github.com/NixOS/nixpkgs/commit/f9c5259b71c83173fb20bfc93cfaa9eb343aa12b) | `python3Packages.sendgrid: propagate six`                                        |
| [`1ac3bb0c`](https://github.com/NixOS/nixpkgs/commit/1ac3bb0c7d1220db270477dc4300365c0d073691) | `python3Packages.kbcstorage: rename from sapi-python-client; fix build`          |
| [`683e87e2`](https://github.com/NixOS/nixpkgs/commit/683e87e2ebb23bc873b7f6bbd3a4419341d06181) | `moltenvk: 1.1.8 -> 1.1.9`                                                       |
| [`3c1742cc`](https://github.com/NixOS/nixpkgs/commit/3c1742cc089399ce64e80564d293e7c2b6461786) | `Revert "python3Packages.gym: 0.21.0 -> 0.22.0"`                                 |
| [`98e82ea0`](https://github.com/NixOS/nixpkgs/commit/98e82ea091d4e08870cc2c8b24d398ccdf186b49) | `python3Packages.flask-bcrypt: 0.7.1 -> 1.0.1`                                   |
| [`b3b47962`](https://github.com/NixOS/nixpkgs/commit/b3b47962f04d7fa8448bd5748eb0532c6f4fd876) | `python3Packages.flask-seasurf: 0.3.0 -> 1.1.1`                                  |
| [`fe21e62b`](https://github.com/NixOS/nixpkgs/commit/fe21e62b9a7d6962e734f4ad51e8720230bb6090) | `python3Packages.kaldi-active-grammar: propagate six`                            |
| [`a6b4d66b`](https://github.com/NixOS/nixpkgs/commit/a6b4d66b773cf040ce5a0980aa11e4457df44548) | `python3Packages.python-vagrant: use pyproject format`                           |
| [`f394cc6c`](https://github.com/NixOS/nixpkgs/commit/f394cc6c547f1162dac673f0fba11eca75022a98) | `aws-sdk-cpp: 1.9.150 → 1.9.238`                                                 |
| [`088112c8`](https://github.com/NixOS/nixpkgs/commit/088112c89714e6daf490cb3877773e83c6fbdea2) | `acpilight: set mainProgram = "xbacklight"`                                      |
| [`23689c5f`](https://github.com/NixOS/nixpkgs/commit/23689c5f21e84ae02d6e1c4d465fe773609f82e9) | `pulumi-bin: 3.28.0 -> 3.29.1`                                                   |
| [`bf796813`](https://github.com/NixOS/nixpkgs/commit/bf7968139acdb2b7b80f4f7f7f546c8df1c39a2b) | `chromium: Fix Wayland screen sharing`                                           |
| [`85020dcb`](https://github.com/NixOS/nixpkgs/commit/85020dcbda5ec9697e0906cb8e011006fd8573e2) | `qtmultimedia: restrict libpulseaudio to linux`                                  |
| [`c9c6d2a1`](https://github.com/NixOS/nixpkgs/commit/c9c6d2a18ac4f114030e669ae95f9f00f43a1f77) | `talosctl: 1.0.2 -> 1.0.3`                                                       |
| [`551b703f`](https://github.com/NixOS/nixpkgs/commit/551b703fd1df586f68282ca4fa7735b2c9945a16) | `python3Packages.pyvesync: 2.0.1 -> 2.0.2`                                       |
| [`4cbce553`](https://github.com/NixOS/nixpkgs/commit/4cbce55388652ebb2b394fa4ad91209bcfb76fd9) | `python3Packages.cupy: fix build`                                                |
| [`cc12a292`](https://github.com/NixOS/nixpkgs/commit/cc12a2922114ec184b4ab5f33a695ce689b6065f) | `librealsenseWithCuda: fix build`                                                |
| [`834faa24`](https://github.com/NixOS/nixpkgs/commit/834faa24b416c549c2b6da70024f7a9b13d8a835) | `coqPackages.Verdi: 20210524 → 20211026`                                         |
| [`aa2a3960`](https://github.com/NixOS/nixpkgs/commit/aa2a396048f3dfc42dc17bc99ef68ce7cc9c40d7) | `graalvmXX-ce: refactor`                                                         |
| [`7c55d1d1`](https://github.com/NixOS/nixpkgs/commit/7c55d1d1646db5645d7e82613506fdaf7853d423) | `gpu-burn: fix build`                                                            |
| [`0f316e55`](https://github.com/NixOS/nixpkgs/commit/0f316e5553561774a795f6ec69949ab70bd93a8f) | `emacsWrapper: fix mishandling of empty package list`                            |
| [`e56192d8`](https://github.com/NixOS/nixpkgs/commit/e56192d840768a1e7cc9d66ea0e533d728fbc55b) | `cudaPackages: recurse`                                                          |
| [`d924de58`](https://github.com/NixOS/nixpkgs/commit/d924de58be179e38ce352171055c2832c3ca4d97) | `cudaPackages.cudnn: migrate to redist cuda, fix missing zlib (#168748)`         |
| [`047473aa`](https://github.com/NixOS/nixpkgs/commit/047473aa32471086d42177c3b70c573ea1b748db) | `nixos/nextcloud: Support create database locally`                               |
| [`2085f10e`](https://github.com/NixOS/nixpkgs/commit/2085f10ea4f88acfb0c02e40700438b3d6158511) | `nix-template: 0.2.0 -> 0.3.0 (#169282)`                                         |
| [`d89adda6`](https://github.com/NixOS/nixpkgs/commit/d89adda6ea57e61f2ea8d1c0dc50a57d3587742f) | `libdvbcsa: init at 1.1.0`                                                       |
| [`4d5ce1c2`](https://github.com/NixOS/nixpkgs/commit/4d5ce1c2b6fc48b15a9e84439f5970b41d221fe6) | `maintainers: add melias122`                                                     |
| [`e1212c4c`](https://github.com/NixOS/nixpkgs/commit/e1212c4c2812e92d1c7cbed63eb0e417de89a430) | `pigeon: unstable -> 1.1.0 (#169123)`                                            |
| [`896c716d`](https://github.com/NixOS/nixpkgs/commit/896c716d1b8fa7b39ed1c96f4ae9ec3f3e957a37) | `netbox: 3.1.10 -> 3.2.1`                                                        |
| [`021fad38`](https://github.com/NixOS/nixpkgs/commit/021fad3832c5b234be31c31e5f69394745e0a2d3) | `python3Packages.graphene-django: unstable-2021-06-11 -> unstable-2022-03-03`    |
| [`2eeed290`](https://github.com/NixOS/nixpkgs/commit/2eeed2904aba82cc5af46e9925dcdb2a3121242d) | `python3Packages.aiotractive: 0.5.3 -> 0.5.4`                                    |