### PR TITLE
chore(flake/nixpkgs): `b06d35b4` -> `f6afd49a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650527056,
-        "narHash": "sha256-dyBthjAs6JlNNDMi7SY+d2CirgBDqjG8SvZKeUvTLqM=",
+        "lastModified": 1650662748,
+        "narHash": "sha256-6Sz30OUCmMgE0rBqbdbLuLFk9ifnmJHNXPK6S8bLQM8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b06d35b406c2396dd1611dc8601138fa3d06ee60",
+        "rev": "f6afd49aa339caabf62b83c9c9f305b5d751b517",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`adf3fe68`](https://github.com/NixOS/nixpkgs/commit/adf3fe6811c62431b6cdbbac5cc7d6497927aa56) | `nixos/tests/installer: disable vlans for initial VM`                       |
| [`3f27c0e5`](https://github.com/NixOS/nixpkgs/commit/3f27c0e57f97e3e096b3aeecf958a5f2bbd9477c) | `kops: 1.23.0 -> 1.23.1 (#169805)`                                          |
| [`c75499ad`](https://github.com/NixOS/nixpkgs/commit/c75499ad9e04463dfc86f28d0c7cee3922ae98ed) | `python310Packages.flask-httpauth: 4.5.0 -> 4.6.0`                          |
| [`985b6397`](https://github.com/NixOS/nixpkgs/commit/985b6397b5d8b84cf1d52286c6b5e265c29efc1f) | `python3Packages.qiskit-terra: 0.20.0 -> 0.20.1`                            |
| [`fc40e3c1`](https://github.com/NixOS/nixpkgs/commit/fc40e3c103be977b3c72cf0acb653721cb3f7e86) | `python3Packages.qiskit: 0.36.0 -> 0.36.1`                                  |
| [`2adbfbd2`](https://github.com/NixOS/nixpkgs/commit/2adbfbd2bd2e435a8a8340e93c4e485a46aac099) | `python310Packages.qiskit-ibmq-provider: 0.19.0 -> 0.19.1`                  |
| [`94c54c37`](https://github.com/NixOS/nixpkgs/commit/94c54c379a48be5f89c3df10a9db56f362aa274a) | `tup: generate verbose build scripts in setup hook`                         |
| [`ed3cc967`](https://github.com/NixOS/nixpkgs/commit/ed3cc9672ad507ca4d00e15b35f3d24edd1dff6c) | `nixos/tests/installer: add missing dependency to image`                    |
| [`3e5baa14`](https://github.com/NixOS/nixpkgs/commit/3e5baa14fbc08be30efd0b1541ff71d063bd3db4) | `python3Packages.blspy: unbreak`                                            |
| [`0ca5daa1`](https://github.com/NixOS/nixpkgs/commit/0ca5daa176ada1f11b51f71e4130a263f32ba6bd) | `python310Packages.xhtml2pdf: 0.2.6 -> 0.2.7`                               |
| [`7f3efc4f`](https://github.com/NixOS/nixpkgs/commit/7f3efc4ffb6c1e64aede5be27ee981fd3b848d38) | `python310Packages.pyhanko: init at 0.12.1`                                 |
| [`6d882ff4`](https://github.com/NixOS/nixpkgs/commit/6d882ff425e065c4ee0f454e0c7e7fc13e1fbae0) | `python310Packages.certomancer: init at 0.8.2`                              |
| [`8a9ba90b`](https://github.com/NixOS/nixpkgs/commit/8a9ba90b53571e6b3eb49e61dae182ea6947108b) | `python310Packages.pyhanko-certvalidator: init at 0.19.5`                   |
| [`56cc5428`](https://github.com/NixOS/nixpkgs/commit/56cc54287d423a1c0891415cedbe7a62c92f8372) | `python310Packages.uharfbuzz: init at 0.24.1`                               |
| [`322a82a0`](https://github.com/NixOS/nixpkgs/commit/322a82a0ad79fa80bf12dde39ddde6226363fe5e) | `python310Packages.python-barcode: init at 0.13.1`                          |
| [`3cab9870`](https://github.com/NixOS/nixpkgs/commit/3cab98701d5a2bf520a2480f49612cc18d01e6cd) | `python310Packages.python-pae: init at 0.1.0`                               |
| [`3a73bf2b`](https://github.com/NixOS/nixpkgs/commit/3a73bf2b6e30e93ad363846b33f34a890b794a63) | `patchelf: clarify license`                                                 |
| [`661dfd83`](https://github.com/NixOS/nixpkgs/commit/661dfd834787f157b70597f9f0f3e7202ba74332) | `pkgsMusl.coreutils: fix build on aarch64`                                  |
| [`e22d0b49`](https://github.com/NixOS/nixpkgs/commit/e22d0b49a9553861cdaee9f71b37db4baf2bb992) | `patchelf: use 0.13.x on aarch64+musl`                                      |
| [`3838a0a7`](https://github.com/NixOS/nixpkgs/commit/3838a0a7e7ef2a3faebb908cbab58d75b513b51c) | `patchelf_0_13: init at 0.13.1`                                             |
| [`89cb8c91`](https://github.com/NixOS/nixpkgs/commit/89cb8c91848ce7fee00c66ea9afe8c152ea860bd) | `python310Packages.azure-mgmt-servicelinker: 1.0.0b1 -> 1.0.0`              |
| [`b80f570a`](https://github.com/NixOS/nixpkgs/commit/b80f570a92d04e8ace67ff09c34aa48708a5c88c) | `python3Packages.zwave-js-server-python: 0.35.2 -> 0.35.3`                  |
| [`6ca65957`](https://github.com/NixOS/nixpkgs/commit/6ca65957c9fe4bc730f31c5af2e7853d4790571c) | `hydra-check: 1.2.0 -> 1.3.4`                                               |
| [`9e91af54`](https://github.com/NixOS/nixpkgs/commit/9e91af54b8b2ca8d0e7f302b0be3282781c4c54c) | `python310Packages.pytest-mpl: 0.14.0 -> 0.15.0`                            |
| [`1812c327`](https://github.com/NixOS/nixpkgs/commit/1812c3275b01ecbdc6870435362a92c09601f387) | `python3Packages.azure-mgmt-reservations: disable on older Python releases` |
| [`f195f959`](https://github.com/NixOS/nixpkgs/commit/f195f9592c5500d77db3e5b45d8aa9e3c58ac0e2) | `python310Packages.azure-mgmt-reservations: 1.0.0 -> 2.0.0`                 |
| [`4f9b8a07`](https://github.com/NixOS/nixpkgs/commit/4f9b8a07024c3397d33df3f26906839cd03f0297) | `lib/strings: optimise hasInfix function (#168175)`                         |
| [`5f241076`](https://github.com/NixOS/nixpkgs/commit/5f241076f44c9833b973b17d5074534217090d22) | `gnome-breeze: remove`                                                      |
| [`77c966e0`](https://github.com/NixOS/nixpkgs/commit/77c966e06ea1f9c85200c38ae394bf56df725d0c) | `neovim-ruby: 0.8.1 -> 0.9.0 update some Neovim Ruby gem versions`          |
| [`ae841fd9`](https://github.com/NixOS/nixpkgs/commit/ae841fd9abdd462bc0e543fb200503fbd95e7e49) | `barrage: init at 1.0.5`                                                    |
| [`34158db5`](https://github.com/NixOS/nixpkgs/commit/34158db51669b3ee360350d35313cb50406ae837) | `lbreakouthd: init at 1.0.9`                                                |
| [`e94105fd`](https://github.com/NixOS/nixpkgs/commit/e94105fde8106c8ff65ec89a7800f8476dcd3993) | `ammonite: 2.5.2 -> 2.5.3 (#168845)`                                        |
| [`a8a87078`](https://github.com/NixOS/nixpkgs/commit/a8a870789da6b3d511f3316c0eaf2985d407d4b5) | `python310Packages.authheaders: 0.14.1 -> 0.15.1`                           |
| [`65c84834`](https://github.com/NixOS/nixpkgs/commit/65c84834aacbba6be72b8501e94f5f64a70bfb9b) | `efm-langserver: 0.0.42 -> 0.0.44`                                          |
| [`6b841f4d`](https://github.com/NixOS/nixpkgs/commit/6b841f4d89ec78c8b92ed31d1003ddc86155a19b) | `lpairs2: init at 2.1`                                                      |
| [`c1747310`](https://github.com/NixOS/nixpkgs/commit/c1747310047966202facec0e88469ac60f8d54a7) | `lbreakout2: rewrite`                                                       |
| [`1930dbac`](https://github.com/NixOS/nixpkgs/commit/1930dbac0a9efdaa2a4e218dfc29aa05c29de0fd) | `checkov: 2.0.1075 -> 2.0.1076`                                             |
| [`e6e8c014`](https://github.com/NixOS/nixpkgs/commit/e6e8c01472f7061f30dff85596257e6f8dab5b70) | `python310Packages.eagle100: 0.1.0 -> 0.1.1`                                |
| [`5e2b2659`](https://github.com/NixOS/nixpkgs/commit/5e2b2659dc462eaedb029568548a8623e014596a) | `ocamlPackages.reperf: init 1.5.1`                                          |
| [`16ed5d04`](https://github.com/NixOS/nixpkgs/commit/16ed5d0446f4a7b43be34df2ece2ac800b640881) | `python3.pkgs.pyttsx3: init at 2.90`                                        |
| [`df550f6e`](https://github.com/NixOS/nixpkgs/commit/df550f6e584c9c89db2d237d27e7be2d932b7d3e) | `espeakup: init at 0.90`                                                    |
| [`433db931`](https://github.com/NixOS/nixpkgs/commit/433db93155fc72aabdd0089d87f3fa971e453600) | `maintainers: add ethindp`                                                  |
| [`6c87c725`](https://github.com/NixOS/nixpkgs/commit/6c87c725e2c94278a1fdd1b3773deb4dd3dc19cb) | `firectl: 0.1.0 -> 0.1.0-unstable-2022-03-01`                               |
| [`4eff2009`](https://github.com/NixOS/nixpkgs/commit/4eff2009a57c57e1989750d105ada62a456e7fff) | `difftastic: 0.26.3 -> 0.27.0`                                              |
| [`165da724`](https://github.com/NixOS/nixpkgs/commit/165da7245c7c41383740c8ec11d6d76312a4ec78) | `ocamlPackages.caqti: 1.7.0 -> 1.8.0`                                       |
| [`9ff2c003`](https://github.com/NixOS/nixpkgs/commit/9ff2c0035f606c6b18830e1942431fedf0ecf0b0) | `ocamlPackages.alcotest: 1.4.0 -> 1.5.0`                                    |
| [`fd2c6872`](https://github.com/NixOS/nixpkgs/commit/fd2c6872e77660c0778c07922b7a89e6bf36844f) | `cargo-diet: 1.2.3 -> 1.2.4`                                                |
| [`dfad862b`](https://github.com/NixOS/nixpkgs/commit/dfad862ba4734f297c1b73580b81fcef9eef732b) | `cargo-depgraph: 1.2.2 -> 1.2.4`                                            |
| [`fda2cdf4`](https://github.com/NixOS/nixpkgs/commit/fda2cdf47142665e93987a1fdbde2af32513f6fb) | `python310Packages.crytic-compile: 0.2.2 -> 0.2.3`                          |
| [`a7d2820c`](https://github.com/NixOS/nixpkgs/commit/a7d2820c3973e4410e23c89d10e18a16c6bf2984) | `cargo-outdated: 0.11.0 -> 0.11.1`                                          |
| [`df8f6ba8`](https://github.com/NixOS/nixpkgs/commit/df8f6ba88a66abf6efd867c0caad9792a4beb17f) | `cargo-release: 0.20.3 -> 0.20.5`                                           |
| [`57207d6e`](https://github.com/NixOS/nixpkgs/commit/57207d6e72ef1d8e27e57edfcb51d2e624968da2) | `cargo-nextest: 0.9.12 -> 0.9.14`                                           |
| [`f768ad5a`](https://github.com/NixOS/nixpkgs/commit/f768ad5a9ede0b15c373776513264aeba41efdd1) | `bore-cli: 0.2.1 -> 0.2.3`                                                  |
| [`ddf6457d`](https://github.com/NixOS/nixpkgs/commit/ddf6457d2dca6b7eac434d1131d06797abbe50de) | ``comma: Fix panic due to missing `nix-index` in path``                     |
| [`1d7c4641`](https://github.com/NixOS/nixpkgs/commit/1d7c4641170b92bded78ce13f71c89dbd0f9ce38) | `python310Packages.policyuniverse: 1.5.0.20220420 -> 1.5.0.20220421`        |
| [`58b7695f`](https://github.com/NixOS/nixpkgs/commit/58b7695fdc0d23260550ad28eaac72ad1d21189a) | `checkSSLCert: 2.24.0 -> 2.25.0`                                            |
| [`f137a6ee`](https://github.com/NixOS/nixpkgs/commit/f137a6eef64aaa7071c163bebfc476b0a0d99164) | `consul-template: 0.28.0 -> 0.29.0`                                         |
| [`49dace38`](https://github.com/NixOS/nixpkgs/commit/49dace385791938bb84bcdb9870a54ee03a1643f) | `ronn: 0.7.3 → 0.9.1 (#169617)`                                             |
| [`37f52328`](https://github.com/NixOS/nixpkgs/commit/37f523286881e4aef8bec21cb97088f724262b05) | `circleci-cli: 0.1.17110 -> 0.1.17142`                                      |
| [`9fd11f52`](https://github.com/NixOS/nixpkgs/commit/9fd11f525af528af53d497a542585c30914074c3) | `lagrange: 1.12.1 -> 1.12.2`                                                |
| [`46e828aa`](https://github.com/NixOS/nixpkgs/commit/46e828aa13993865a5064d782d1dde0d88781fe6) | `cilium-cli: 0.10.4 -> 0.11.1`                                              |
| [`0fda27c4`](https://github.com/NixOS/nixpkgs/commit/0fda27c4958836824addc0e3e513f5fb72da5676) | `checkmate: 0.5.8 -> 0.5.9`                                                 |
| [`ebbffb62`](https://github.com/NixOS/nixpkgs/commit/ebbffb62eeb09bbfa98b13ed22cc9d24dd3e1b78) | `checkip: 0.24.5 -> 0.35.2`                                                 |
| [`f86e2a09`](https://github.com/NixOS/nixpkgs/commit/f86e2a0932cd839eaf2568b999b9e1e958d1a315) | `python310Packages.databricks-connect: 9.1.13 -> 9.1.14`                    |
| [`75d69638`](https://github.com/NixOS/nixpkgs/commit/75d69638864ebe820f96d6b98b4a7f2e83e6d026) | `python310Packages.bitstruct: 8.14.0 -> 8.14.1`                             |
| [`21d8d6ef`](https://github.com/NixOS/nixpkgs/commit/21d8d6efa583613e471acb979dad44fe8bb4f638) | `alfaview: 8.41.0 -> 8.42.0`                                                |
| [`b9789fb7`](https://github.com/NixOS/nixpkgs/commit/b9789fb75c72feac74d0cf84baffdc3b3f27a11f) | `python310Packages.stripe: 2.73.0 -> 2.74.0`                                |
| [`35fb3cc6`](https://github.com/NixOS/nixpkgs/commit/35fb3cc6fc274e57f3522f1f8caf407de6df2ffe) | `feroxbuster: 2.6.4 -> 2.7.0`                                               |
| [`c0681019`](https://github.com/NixOS/nixpkgs/commit/c0681019f44121cfed941dd600174a1b73a18961) | `gnome.gnome-initial-setup: 42.1 -> 42.1.1`                                 |
| [`04efa9b7`](https://github.com/NixOS/nixpkgs/commit/04efa9b7bb9c204705a80bc07a6f5645a682ac87) | `python310Packages.lightwave2: 0.8.4 -> 0.8.8`                              |
| [`926ef37b`](https://github.com/NixOS/nixpkgs/commit/926ef37b800df28a9f39d44969d3385cf818f8dc) | `buf: 1.3.0 -> 1.4.0`                                                       |
| [`e31f7ee3`](https://github.com/NixOS/nixpkgs/commit/e31f7ee3e8eed11e9971e1c371bd1edc6e25ba27) | `gitleaks: 8.7.2 -> 8.8.1`                                                  |
| [`f7f3725f`](https://github.com/NixOS/nixpkgs/commit/f7f3725fc61b5c1166a0fd748f2fee47c977b353) | `gau: 2.0.9 -> 2.1.1`                                                       |
| [`9e2b395e`](https://github.com/NixOS/nixpkgs/commit/9e2b395ec45285000c6bc52fc7352ed644cc1d3d) | `btop: 1.2.5 -> 1.2.6`                                                      |
| [`1c4a478b`](https://github.com/NixOS/nixpkgs/commit/1c4a478b19c3215575225aca5606c7e064c6c601) | `python3Packages.bimmer-connected: 0.8.11 -> 0.8.12`                        |
| [`7b185dd4`](https://github.com/NixOS/nixpkgs/commit/7b185dd49170296f71d1654aea171151c711513b) | `atlassian-jira: 8.22.0 -> 8.22.1`                                          |
| [`eed65357`](https://github.com/NixOS/nixpkgs/commit/eed65357919870061fba1fb6a70756041903f42b) | `epiphany: 42.1 -> 42.2`                                                    |
| [`03e4688c`](https://github.com/NixOS/nixpkgs/commit/03e4688c7f27b04f251769a711b5e1483f22f16a) | `argocd-autopilot: 0.3.2 -> 0.3.5`                                          |
| [`b124b40c`](https://github.com/NixOS/nixpkgs/commit/b124b40ce78d6102c1453594f46f10ea7e0cfe3e) | `ani-cli: 2.0 -> 2.1`                                                       |
| [`c90fe46c`](https://github.com/NixOS/nixpkgs/commit/c90fe46cb221a94e7dc8e5b913a9b6cf377e4028) | `actionlint: 1.6.11 -> 1.6.12`                                              |
| [`f73ff5c2`](https://github.com/NixOS/nixpkgs/commit/f73ff5c2298a14ea1dc1722cb15cf94b3b879281) | `emacsWrapper: add missing variable substitutions to Darwin app`            |
| [`f67df180`](https://github.com/NixOS/nixpkgs/commit/f67df1807f44ad62cf932bf4f3469b3105962f43) | `ugrep: 3.7.7 -> 3.7.9`                                                     |
| [`b66cbbd7`](https://github.com/NixOS/nixpkgs/commit/b66cbbd74ee72d4c904f9386c159405106f4fab0) | `jdk8: fix manpage symlink on darwin`                                       |
| [`41442654`](https://github.com/NixOS/nixpkgs/commit/414426546904670bc47c735fff06cc90f8b0c510) | `python310Packages.hahomematic: 1.1.2 -> 1.1.4`                             |
| [`65048d77`](https://github.com/NixOS/nixpkgs/commit/65048d7799932c808336c0fc0515b8ac184baabd) | `python310Packages.seabreeze: remove pytest runner`                         |
| [`498bf516`](https://github.com/NixOS/nixpkgs/commit/498bf51644b9e226766ac8072b42dae8879ec4cf) | `python310Packages.pyplaato: 0.0.17 -> 0.0.18`                              |
| [`b9e02e74`](https://github.com/NixOS/nixpkgs/commit/b9e02e7495e1bb9d524b6e47aeef005e2da6bcaf) | `jesec-libtorrent: disable checks`                                          |
| [`73ff43b3`](https://github.com/NixOS/nixpkgs/commit/73ff43b391531565a8542acbdee03693a51d1cc3) | `jesec-rtorrent: clean up formatting`                                       |
| [`90147b38`](https://github.com/NixOS/nixpkgs/commit/90147b38081852ae46c79461edcebb1bbd372702) | `python310Packages.dropbox: 11.29.0 -> 11.30.0 (#169585)`                   |
| [`6d558934`](https://github.com/NixOS/nixpkgs/commit/6d5589346b4d21c068d9309fde31cb80880330b9) | `jesec-rtorrent: 0.9.8-r15 -> 0.9.8-r16`                                    |
| [`a0976913`](https://github.com/NixOS/nixpkgs/commit/a0976913ee3db29ded2f5f6045ad1218b343aed4) | `1password: 2.0.0 -> 2.0.2`                                                 |
| [`862c4f21`](https://github.com/NixOS/nixpkgs/commit/862c4f219a4626293c71475275170e1db0a13c25) | `apple-sdk: update comment about frameworks version`                        |
| [`69e66123`](https://github.com/NixOS/nixpkgs/commit/69e661230508bf2c4b7b8dbb0518de6c951986ce) | `{jesec-,}rtorrent: don't use package sets`                                 |
| [`ec35f59f`](https://github.com/NixOS/nixpkgs/commit/ec35f59fd10ce8cd3965eab830a00087fa636b0c) | `chickenPackages.chickenEggs.srfi-189: init at 0.1`                         |
| [`212fecb7`](https://github.com/NixOS/nixpkgs/commit/212fecb7343e4ff35794df584d23e54283178737) | `chickenPackages.chickenEggs.srfi-13: 0.3 -> 0.3.1`                         |
| [`5bbb538e`](https://github.com/NixOS/nixpkgs/commit/5bbb538e7261294c694fce1534efcf2d9b02672b) | `doc: Explain how to use and maintain CHICKEN.`                             |
| [`4cb5e8a9`](https://github.com/NixOS/nixpkgs/commit/4cb5e8a9148368318420a99c6de8198b65ed5a2f) | `raspberrypifw: mark as broken on Darwin`                                   |
| [`2cbdaf9f`](https://github.com/NixOS/nixpkgs/commit/2cbdaf9fbeef3e2a8280aaf2a91812dd29ef7964) | `blackfire: 2.5.2 -> 2.8.0`                                                 |
| [`6088afd5`](https://github.com/NixOS/nixpkgs/commit/6088afd590420b5e510e6a5ef94a414a07c22e3e) | `libraspberrypi: unstable-2021-10-25 -> unstable-2022-03-23`                |
| [`8878107e`](https://github.com/NixOS/nixpkgs/commit/8878107e897e7b809a383a00764c8598eb3ebce0) | `raspberrypiWirelessFirmware: 2021-11-02 -> 2021-12-06`                     |
| [`79b13a79`](https://github.com/NixOS/nixpkgs/commit/79b13a796c52a8dd7c793dee33726b6a58577faf) | `linux_rpi{1,2,3,4}: 1.20220118 -> 1.20220331`                              |
| [`d4eb5c68`](https://github.com/NixOS/nixpkgs/commit/d4eb5c68f2fb16d80641597e8ee66d793c6cb9bd) | `raspberrypifw: 1.20220118 -> 1.20220331`                                   |
| [`693d9601`](https://github.com/NixOS/nixpkgs/commit/693d960118eb3a7032d7c40bb9220c7ffb551ab1) | `raspberrypi-eeprom: 2021.12.02 -> unstable-2022-03-10`                     |
| [`9f227ab5`](https://github.com/NixOS/nixpkgs/commit/9f227ab554aacf331b4c8bb2f6663fe3ad63e937) | `comic-mono: init at 2020-12-28`                                            |
| [`4590810a`](https://github.com/NixOS/nixpkgs/commit/4590810a5dae05be8842f78bf8cbddcee0521f3c) | `maintainers: add an-empty-string`                                          |
| [`80adc1cd`](https://github.com/NixOS/nixpkgs/commit/80adc1cdacafded8a96f66be7ce7721f74e84c79) | `spot: 0.3.1 -> 0.3.3`                                                      |
| [`212074cd`](https://github.com/NixOS/nixpkgs/commit/212074cde1dfbd8c8414acfecdc7024555c056d8) | `nixos-artwork: fix gnome not adding wallpapers to list of backgrounds`     |
| [`cd2a6cd9`](https://github.com/NixOS/nixpkgs/commit/cd2a6cd9cb1a094320c2d02e3638974c98b931e8) | `nixos/gnome: Add the NixOS background metadata`                            |
| [`51a498e7`](https://github.com/NixOS/nixpkgs/commit/51a498e719373a3761dad843a6060da738b14ed5) | `yuzu-{ea,mainline}: {2557,953} -> {2690,992}`                              |
| [`818ac0c9`](https://github.com/NixOS/nixpkgs/commit/818ac0c9ae465a9fb51cdfed7814760c501ed2b3) | `Revert "nixos/gnome3: install nixos wallpapers"`                           |
| [`b555b643`](https://github.com/NixOS/nixpkgs/commit/b555b6434649157882a85dc8cf842694ee728430) | `nixVersions.stable: 2.7.0 -> 2.8.0`                                        |
| [`515b8980`](https://github.com/NixOS/nixpkgs/commit/515b89802eea50d947d56b4b963f5b660f451ab0) | `pythonPackages.wifi: init 0.3.5`                                           |
| [`dcf8b950`](https://github.com/NixOS/nixpkgs/commit/dcf8b95055b93bc8945dd6cb85eb9d8c50c221a7) | `didyoumean: init at 1.1.0`                                                 |
| [`7e56a8b1`](https://github.com/NixOS/nixpkgs/commit/7e56a8b18fac820dbb17da99a510ed8a6c11d2ca) | `zn_poly: 0.9.1 -> 0.9.2`                                                   |
| [`1200c1c3`](https://github.com/NixOS/nixpkgs/commit/1200c1c3e080048b9e3d00422dbefeded54d4b3d) | `imagemagick: 7.1.0-29 -> 7.1.0-30`                                         |
| [`e0968c03`](https://github.com/NixOS/nixpkgs/commit/e0968c03d709189045b94cd95572a2f7a80e0625) | `alpnpass: init at 0.1`                                                     |
| [`65aca452`](https://github.com/NixOS/nixpkgs/commit/65aca4520dd96910cdb54e65925f9ffc2c6c449a) | `python310Packages.phe: 1.4.0 -> 1.5.0`                                     |
| [`9cb508ad`](https://github.com/NixOS/nixpkgs/commit/9cb508adf7d22359a98390577a2a95ba95d78bae) | `jamesdsp: add PulseAudio support`                                          |
| [`5b17034d`](https://github.com/NixOS/nixpkgs/commit/5b17034ddcc2a4942f2c806b2541313f52f8cfc7) | `lshw: rename version to fix repology listing`                              |
| [`3f8ac21f`](https://github.com/NixOS/nixpkgs/commit/3f8ac21fda22b1a832d4ba331e6c511407fb7d68) | `dolphin-emu-{beta,primehack}: fix build`                                   |
| [`12e2fb84`](https://github.com/NixOS/nixpkgs/commit/12e2fb84186ebc0092eceab2da2d134d11223484) | `grafana: 8.4.6 -> 8.4.7`                                                   |
| [`881ea516`](https://github.com/NixOS/nixpkgs/commit/881ea516cf552fbb159aed4462873762a8297409) | `python3: Whitelist config options when overriding interpreter`             |
| [`ba02fd04`](https://github.com/NixOS/nixpkgs/commit/ba02fd0434ed92b7335f17c97af689b9db1413e0) | `python3: fix overriding of interpreters, closes #163639`                   |
| [`b8f5fca3`](https://github.com/NixOS/nixpkgs/commit/b8f5fca3e98e596596d29dc0d7d5f3596a278d50) | `metadata-cleaner: 2.2.1 -> 2.2.2`                                          |
| [`7e9b0ed5`](https://github.com/NixOS/nixpkgs/commit/7e9b0ed5f48658869a40aceb45a8b3414021bab3) | `python3Packages.fints: 3.0.1 -> 3.1.0`                                     |
| [`dc470f74`](https://github.com/NixOS/nixpkgs/commit/dc470f7448b110e4f2c624860e6c6113e652ea2a) | `portfolio-filemanager: 0.9.12 -> 0.9.14`                                   |
| [`547797de`](https://github.com/NixOS/nixpkgs/commit/547797dea82951e9690f7ab882889c742e26e84e) | `pubs: 0.8.3 -> 0.9.0`                                                      |
| [`7aed8286`](https://github.com/NixOS/nixpkgs/commit/7aed828633645235dcec46e5acb1a605e5e95469) | `gnomeExtensions.night-theme-switcher: remove manual packaging`             |
| [`a02643d6`](https://github.com/NixOS/nixpkgs/commit/a02643d6a595f3aea405a942f904d32b788eab6c) | `lshw: B.02.18 -> B.02.19`                                                  |
| [`9c653ec6`](https://github.com/NixOS/nixpkgs/commit/9c653ec608ee6025ee0187b32634539cf693e8f8) | `wasmtime: 0.35.2 -> 0.36.0`                                                |
| [`be1846ef`](https://github.com/NixOS/nixpkgs/commit/be1846ef623b8200624d6dbe2ce92d7d6d09a32c) | `pmbootstrap: 1.41.0 -> 1.43.0`                                             |
| [`f27893f4`](https://github.com/NixOS/nixpkgs/commit/f27893f48f24699949bded204c58d3feeef4d009) | `swaylock-effects: fix the build (mismatched-dealloc error)`                |
| [`e0a43635`](https://github.com/NixOS/nixpkgs/commit/e0a436357186710e44a2ddba9110d49c400831bc) | `gitlab-runner: 14.9.1 -> 14.10.0 (#169411)`                                |