### PR TITLE
chore(flake/nixpkgs): `f6afd49a` -> `d66d12d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650662748,
-        "narHash": "sha256-6Sz30OUCmMgE0rBqbdbLuLFk9ifnmJHNXPK6S8bLQM8=",
+        "lastModified": 1650703034,
+        "narHash": "sha256-djfwG2HDkRZ6jgqPzedpttRI8qhQAheeDASzg4ZcqEI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f6afd49aa339caabf62b83c9c9f305b5d751b517",
+        "rev": "d66d12d43f858181f34f8ce1116166c596b737f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                        |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`e92dc71f`](https://github.com/NixOS/nixpkgs/commit/e92dc71feeb853f1f788a2bcc0d9fd7b332d213e) | `bomutils: fix build with gcc 11 (#169845)`                           |
| [`f542643e`](https://github.com/NixOS/nixpkgs/commit/f542643ed32d915a4322b31e1d2c33b9207f0a8a) | `aws-sdk-cpp: revert to older version on i686-linux`                  |
| [`9c1b29e6`](https://github.com/NixOS/nixpkgs/commit/9c1b29e66294b69a84c1cc1c6ff6d606c23d327b) | `ledger: Don't depend on python3 if usePython is false`               |
| [`d73efdae`](https://github.com/NixOS/nixpkgs/commit/d73efdae64e203d2659773cfb46839ed92f7e3cd) | `dune_3: 3.1.0 -> 3.1.1`                                              |
| [`2795e934`](https://github.com/NixOS/nixpkgs/commit/2795e9345e473a7b5ed2851ca1249175aa4603db) | `monotone: fix build by forcing C++11`                                |
| [`9f9b94fe`](https://github.com/NixOS/nixpkgs/commit/9f9b94fe1983533c1d101874061c3ea0a333b7f2) | `oclgrind: switch to python3`                                         |
| [`ecaf258f`](https://github.com/NixOS/nixpkgs/commit/ecaf258f7a8c9d84a31a450c88d50d4668b15625) | `lhapdf.pdf_sets: update`                                             |
| [`ba635f7d`](https://github.com/NixOS/nixpkgs/commit/ba635f7d5d983992ea2380da46381f6af611e1e6) | `python3Packages.flax: fix build`                                     |
| [`348b256e`](https://github.com/NixOS/nixpkgs/commit/348b256e9848bb5141cc0f435b51e23bb96897a7) | `python3Packages.xxhash: fix version with setuptools-scm`             |
| [`1acf421f`](https://github.com/NixOS/nixpkgs/commit/1acf421ff2da4f14fa258592a7e42a379eb41849) | `git-lfs: 3.1.2 -> 3.1.4`                                             |
| [`d2822bdf`](https://github.com/NixOS/nixpkgs/commit/d2822bdfed09b54112930a973150390f3e017186) | `winpdb: remove`                                                      |
| [`1ecd1536`](https://github.com/NixOS/nixpkgs/commit/1ecd1536442f49555f5d5974d3c92ec5d1bddd29) | `saleae-logic-2: 2.3.47 -> 2.3.50`                                    |
| [`99c5e10c`](https://github.com/NixOS/nixpkgs/commit/99c5e10c0be68fd61bcb22b98583b4e32138560e) | `libvirt: Fix incorrect path to pkttyagent`                           |
| [`d030ffde`](https://github.com/NixOS/nixpkgs/commit/d030ffdeb61fd8ab73bb5ee28da6e47fc0889d9f) | `cppcheck: 2.7.4 -> 2.7.5`                                            |
| [`2b9e207a`](https://github.com/NixOS/nixpkgs/commit/2b9e207a04b34b66632ea2cfca2ae0e4e52c5999) | `electron_18: init at 18.1.0`                                         |
| [`015cb565`](https://github.com/NixOS/nixpkgs/commit/015cb5656abc39d18b142c843b41964926581d02) | `electron_17: 17.3.1 → 17.4.1`                                        |
| [`d2a5b128`](https://github.com/NixOS/nixpkgs/commit/d2a5b1281c6a97f40cd29dc5732cc1ee312aa632) | `electron_16: 16.2.1 → 16.2.3`                                        |
| [`163c5386`](https://github.com/NixOS/nixpkgs/commit/163c53865c782adb12302e98265b72a3106759a0) | `electron_15: 15.5.1 → 15.5.2`                                        |
| [`96993e27`](https://github.com/NixOS/nixpkgs/commit/96993e273048e0887b7b4b36e5564a9a145f4d51) | `flyway: 8.5.1 -> 8.5.9`                                              |
| [`3788e27a`](https://github.com/NixOS/nixpkgs/commit/3788e27a24f5b7cdb3f734b775868b66461bfa68) | `deno: 1.20.5 -> 1.21.0`                                              |
| [`a142e404`](https://github.com/NixOS/nixpkgs/commit/a142e404fe1efd39a8c3e1e191c80dddb79dd896) | `vault: 1.10.0 -> 1.10.1`                                             |
| [`ddf38696`](https://github.com/NixOS/nixpkgs/commit/ddf38696146e8640979d12290e2361a6c6ee788d) | `werf: 1.2.87 -> 1.2.91`                                              |
| [`0beb7ab9`](https://github.com/NixOS/nixpkgs/commit/0beb7ab9f49cb348ac2d128cafc9ce4f142e20a1) | `libe57format: fix build for gcc11`                                   |
| [`03451de0`](https://github.com/NixOS/nixpkgs/commit/03451de0b28f0b60dba7427b6313ce07e34eac12) | `exploitdb: 2022-04-12 -> 2022-04-20`                                 |
| [`fb0687cf`](https://github.com/NixOS/nixpkgs/commit/fb0687cf00b6145c48b5e4b064ecccd89d59c7f1) | `flow: 0.175.1 -> 0.176.2`                                            |
| [`c2e1bced`](https://github.com/NixOS/nixpkgs/commit/c2e1bcedeb7e503d508856ae97b3ebd64d5dea29) | `findomain: 8.0.0 -> 8.1.1`                                           |
| [`04fd6e83`](https://github.com/NixOS/nixpkgs/commit/04fd6e83f4fe8062324f5f6c6137129f8f0292f8) | `prometheus-nextcloud-exporter: 0.5.0 -> 0.5.1`                       |
| [`38f1d4d1`](https://github.com/NixOS/nixpkgs/commit/38f1d4d19350f69b2d3d21b6c24f51c96ac62923) | `esbuild: 0.14.34 -> 0.14.38`                                         |
| [`a5b0d262`](https://github.com/NixOS/nixpkgs/commit/a5b0d262a4ef38046dae83c75ffeb04ff0132373) | `plex: 1.25.9.5721-965587f64 -> 1.26.0.5715-8cf78dab3`                |
| [`41808d42`](https://github.com/NixOS/nixpkgs/commit/41808d42d21f685e3fd3cdb2c9f04082f0818e30) | `doc: move testers to their own chapter`                              |
| [`3cc2e86b`](https://github.com/NixOS/nixpkgs/commit/3cc2e86bab4dcfa1abc7c835fae6336b068cd77e) | `testers: convert to a format that is kind of compatible with nixdoc` |
| [`f1c7f19e`](https://github.com/NixOS/nixpkgs/commit/f1c7f19e49190cf58041908f9c194431e2513688) | `treewide: testVersion -> testers.testVersion`                        |
| [`250ef1ff`](https://github.com/NixOS/nixpkgs/commit/250ef1ff392b938415726a9331a30012573efaea) | `testers.testVersion: move from trivial-builders.nix`                 |
| [`bf27f751`](https://github.com/NixOS/nixpkgs/commit/bf27f751bab6d4bd1465e307f899fdcefa13e480) | `ejson2env: 2.0.4 -> 2.0.5`                                           |
| [`54d69052`](https://github.com/NixOS/nixpkgs/commit/54d69052305ed313000a7903b0880854d1e6f4bf) | `fluxcd: 0.29.1 -> 0.29.3`                                            |
| [`a9fdf69f`](https://github.com/NixOS/nixpkgs/commit/a9fdf69f9fe255f6ec659165ad3cf7a1cdec76c1) | `gitoxide: 0.10.0 -> 0.12.0`                                          |
| [`c7f09c80`](https://github.com/NixOS/nixpkgs/commit/c7f09c80bef6f7d02fe72edf7055974532566150) | `git-extras: 6.3.0 -> 6.4.0`                                          |
| [`2c5cd9ed`](https://github.com/NixOS/nixpkgs/commit/2c5cd9eddaedf4ee71da216c632d2260c1e332c0) | `gtksourceview5: 5.4.0 -> 5.4.1`                                      |
| [`261cb2e6`](https://github.com/NixOS/nixpkgs/commit/261cb2e66f63ee55ccf14082ed85cc96887b610b) | `argo: 3.3.1 -> 3.3.2`                                                |
| [`1d01a8d2`](https://github.com/NixOS/nixpkgs/commit/1d01a8d25c36da18bf34a3c337e3383eebce58a9) | `aliyun-cli: 3.0.116 -> 3.0.117`                                      |
| [`cae857ab`](https://github.com/NixOS/nixpkgs/commit/cae857abfd10e526fe1f36c78b79c0af8c423779) | `zeek: 4.2.0 -> 4.2.1`                                                |
| [`38aa92b3`](https://github.com/NixOS/nixpkgs/commit/38aa92b3d2e84645416c78405118e805460e893b) | `ntdb: remove`                                                        |
| [`7dc99549`](https://github.com/NixOS/nixpkgs/commit/7dc99549561bf92e5b8ace0cfaceea85a98a7661) | `nextcloud: 22.2.6 -> 22.2.7, 23.0.3 -> 23.0.4`                       |
| [`c0edac77`](https://github.com/NixOS/nixpkgs/commit/c0edac77b30c49e49e865d2ffe53cef4cd20c642) | `libpqxx_6: 6.4.5 -> 6.4.8`                                           |
| [`06e48b15`](https://github.com/NixOS/nixpkgs/commit/06e48b1552f20408be3a76edc3b00a70a556c6bb) | `zkfuse: add a -std=c++14 workaround for gcc-11`                      |
| [`a61732d4`](https://github.com/NixOS/nixpkgs/commit/a61732d482a3df79be24dc8152d4b41624c2697c) | `conftest: 0.30.0 -> 0.31.0`                                          |
| [`2d1b9c06`](https://github.com/NixOS/nixpkgs/commit/2d1b9c0632dbbbf2d150bb0de027cbbd2ea9400d) | `tdlib: 1.8.1 -> 1.8.3`                                               |
| [`87438184`](https://github.com/NixOS/nixpkgs/commit/874381847b1063b811c4631244a77356335d04ce) | `gnumeric: mark aarch64-darwin as broken`                             |
| [`57998352`](https://github.com/NixOS/nixpkgs/commit/579983525cea451e5e5ab25934fd38bedfd58c15) | `gnumeric: 1.12.51 -> 1.12.52`                                        |
| [`e76dad1a`](https://github.com/NixOS/nixpkgs/commit/e76dad1a77ed5bf5cc5253d0ed9a842a1c135e7f) | `git-review: 2.2.0 -> 2.3.0`                                          |
| [`9d0e77b3`](https://github.com/NixOS/nixpkgs/commit/9d0e77b38e0f8f82b9d26bf9044ff843184155aa) | `python310Packages.vispy: 0.9.6 -> 0.10.0`                            |
| [`c9464f47`](https://github.com/NixOS/nixpkgs/commit/c9464f4716ea18614ba8952e73bf75fbd3c15818) | `pyinfra: 2.0 -> 2.0.1`                                               |
| [`3326297c`](https://github.com/NixOS/nixpkgs/commit/3326297c8e93c895f7bac7a84729216515383a84) | `ethtool: 5.16 -> 5.17`                                               |