### PR TITLE
chore(flake/home-manager): `93a69d07` -> `65a32578`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650478719,
-        "narHash": "sha256-308c2cM4hW9AW6dSQ080ycXGyEJGkG/OwOINkYL9Mnw=",
+        "lastModified": 1650784624,
+        "narHash": "sha256-RTYGFBlxEmhhLLH9UfObyz2d4alhCSf6NQpyID7Mqvg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "93a69d07389311ffd6ce1f4d01836bbc2faec644",
+        "rev": "65a32578d9b1394bea5c6336721ec392aadc89fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message    |
| ----------------------------------------------------------------------------------------------------------- | ----------------- |
| [`65a32578`](https://github.com/nix-community/home-manager/commit/65a32578d9b1394bea5c6336721ec392aadc89fb) | `helix: fix test` |