### PR TITLE
chore(flake/nixpkgs): `d66d12d4` -> `ab83c5d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -130,11 +130,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650703034,
-        "narHash": "sha256-djfwG2HDkRZ6jgqPzedpttRI8qhQAheeDASzg4ZcqEI=",
+        "lastModified": 1650792148,
+        "narHash": "sha256-n1MZSZIzvP70BJ56tV8GwQ5L0wHt/nTH9UkF5HTGB/4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d66d12d43f858181f34f8ce1116166c596b737f3",
+        "rev": "ab83c5d70528f1edc7080dead3a5dee61797b3ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`34764700`](https://github.com/NixOS/nixpkgs/commit/347647008b6366890bf013aa3098a50f4faeffc4) | `gnome.tali: 40.6 -> 40.7`                                                                       |
| [`09790451`](https://github.com/NixOS/nixpkgs/commit/0979045133851b18fc6d99e5aada37a63cccce9e) | `python3Packages.simplejson: use unambiguous rev`                                                |
| [`c1641580`](https://github.com/NixOS/nixpkgs/commit/c1641580f13cb877d7cee830f932fa71469e4226) | `nix-eval-jobs: 0.0.4 -> 0.0.5`                                                                  |
| [`f02d6f43`](https://github.com/NixOS/nixpkgs/commit/f02d6f4348d347521bcc043bf2efa66eed784568) | `redmine: Add Felix Singer as maintainer`                                                        |
| [`aff4beb9`](https://github.com/NixOS/nixpkgs/commit/aff4beb95e768ca23a34c0a0ee1c3c8d0bc91ed4) | `libretro: pass explicit parameters to update_cores.py script`                                   |
| [`09d70480`](https://github.com/NixOS/nixpkgs/commit/09d70480590ba4869dee58c983108c92691e6b8d) | `libretro.dosbox: fix build`                                                                     |
| [`b511e03b`](https://github.com/NixOS/nixpkgs/commit/b511e03b04fd348a02fdc0e08cdd1d83c3f173ad) | `libretro: unstable-2022-04-08 -> unstable-2022-04-21`                                           |
| [`2686e382`](https://github.com/NixOS/nixpkgs/commit/2686e382e06b1e4ba43632aa62b930fe9b5a4991) | `python310Packages.xml2rfc: 3.12.3 -> 3.12.4`                                                    |
| [`5eb9d9e2`](https://github.com/NixOS/nixpkgs/commit/5eb9d9e2843758fcc8115fefe7be5d253b9b1099) | `emacs.pkgs.ement: unstable-2021-10-08 -> unstable-2022-04-22`                                   |
| [`8b518f5b`](https://github.com/NixOS/nixpkgs/commit/8b518f5b2feeee3937e9115654e979ce69c63d27) | `python3Packages.wandb: 0.12.14 -> 0.12.15`                                                      |
| [`97a94014`](https://github.com/NixOS/nixpkgs/commit/97a94014f50ac4543c00bb00cfd4c6402e2f6269) | `electron: fix rpath for executable chrome_crashpad_handler`                                     |
| [`646b9a7d`](https://github.com/NixOS/nixpkgs/commit/646b9a7dbc499e31d4ec57555c3b02a15af8e95e) | `python310Packages.pyvips: run tests, cleanup nativeBuildInputs`                                 |
| [`74098019`](https://github.com/NixOS/nixpkgs/commit/7409801908168470ecfec6c6565bef46eb72464e) | `python310Packages.onnx: fix script patching`                                                    |
| [`b880687a`](https://github.com/NixOS/nixpkgs/commit/b880687a2078df737042024a251add385d7279fc) | `gajim: Add missing dependency 'packaging'`                                                      |
| [`6922b878`](https://github.com/NixOS/nixpkgs/commit/6922b8784d44cb676d675514562d994ed37757ab) | `emacs: Add update script for manually packaged packages`                                        |
| [`a1412120`](https://github.com/NixOS/nixpkgs/commit/a14121209eb34eeeb108b28f53b30e84bbf4b1db) | `python3Packages.marshmallow-dataclass: 8.5.3 -> 8.5.5`                                          |
| [`5aab7a2b`](https://github.com/NixOS/nixpkgs/commit/5aab7a2babd71a34d21392c6575de4fc43dfdbc4) | `python3Packages.can: add missing input`                                                         |
| [`d4008177`](https://github.com/NixOS/nixpkgs/commit/d40081772638e9d17510243ce674ad15d6516f54) | `python3Packages.seventeentrack: 2022.04.4 -> 2022.04.5`                                         |
| [`d618e83c`](https://github.com/NixOS/nixpkgs/commit/d618e83c3b28ec35be97f90073bccb5d84ffdd86) | `flrig: 1.3.54 -> 1.4.5`                                                                         |
| [`2347b141`](https://github.com/NixOS/nixpkgs/commit/2347b14150c650fad3e802a4a5fdd33ba1f93e1f) | `hubstaff: don't include updateScript in derivation`                                             |
| [`1ea573a5`](https://github.com/NixOS/nixpkgs/commit/1ea573a5c8a88a857266cc726a21630f9d7c57fa) | `yabridge, yabridgectl: 3.8.0 → 3.8.1`                                                           |
| [`bafe6ab8`](https://github.com/NixOS/nixpkgs/commit/bafe6ab889bdc3c60136e20e8e316f2ca14d07d1) | `python3Packages.pynetdicom: 2.0.1 -> 2.0.2`                                                     |
| [`3b5115cb`](https://github.com/NixOS/nixpkgs/commit/3b5115cb116f07439349bc96c427bb02b1d39804) | `umockdev: 0.17.7 -> 0.17.8`                                                                     |
| [`daee75e5`](https://github.com/NixOS/nixpkgs/commit/daee75e5b32a00c9d5261be4de29ff9a8ccc1dd2) | `emacs.pkgs.tree-sitter-langs: Make language plugins configurable`                               |
| [`b4f90318`](https://github.com/NixOS/nixpkgs/commit/b4f90318fecf53ca26a104a39ac42c914582dfe4) | `emacs.pkgs.tree-sitter-langs: Create script to keep grammars up to date with upstream defaults` |
| [`b15c7034`](https://github.com/NixOS/nixpkgs/commit/b15c703495742190e6d5cf37ac0980391c323428) | `emacs.pkgs.tree-sitter-langs: Use grammars from nixpkgs and sources from melpa`                 |
| [`00af5935`](https://github.com/NixOS/nixpkgs/commit/00af59359fd4ce22922b438527ebe71fefea586e) | `emacs.pkgs.tsc: 0.16.1 -> 0.18.0`                                                               |
| [`028a9348`](https://github.com/NixOS/nixpkgs/commit/028a9348963e73a5998aeb1b3265b005ff06b6b2) | `emacs.pkgs.tsc: Add update script`                                                              |
| [`2c618206`](https://github.com/NixOS/nixpkgs/commit/2c61820661e1633d4be0a090bdd3332988fb8272) | ``emacs.pkgs.tsc/tree-sitter-langs: Remove `rec` from derivations``                              |
| [`4567405c`](https://github.com/NixOS/nixpkgs/commit/4567405cd4a6bcc9f5010d93eeec9c3aa3873c79) | ``emacs.pkgs.tsc: Remove `with` from top-level scope``                                           |
| [`48b6b199`](https://github.com/NixOS/nixpkgs/commit/48b6b199708e418bf56bed158062bfac3ea9aa76) | `emacsPackages.tree-sitter: fix grammar/native executor`                                         |
| [`9a510e04`](https://github.com/NixOS/nixpkgs/commit/9a510e042414341b0ff4de056cb38af6237435a8) | `python3Packages.hyppo: fix build`                                                               |
| [`20c39d57`](https://github.com/NixOS/nixpkgs/commit/20c39d574165c115f513cfb47a34174fd1cc83b4) | `python3Packages.aiolifx fix typo`                                                               |
| [`6fbd7f1c`](https://github.com/NixOS/nixpkgs/commit/6fbd7f1c047c5b8c198fb1e92b3a6520a1a2ac72) | `python3Packages.aiolifx: disable on older Python releases`                                      |
| [`cb536356`](https://github.com/NixOS/nixpkgs/commit/cb536356ee92fbad69189309ca79fe083d9f07ad) | `python310Packages.aiolifx: 0.7.1 -> 0.8.0`                                                      |
| [`f420bdcc`](https://github.com/NixOS/nixpkgs/commit/f420bdcc83fdea9db444b266e64cf2b8fd108070) | `python310Packages.azure-synapse-artifacts: 0.12.0 -> 0.13.0`                                    |
| [`c553acd2`](https://github.com/NixOS/nixpkgs/commit/c553acd27fdcbc5de4d8ec26a829d9fc2870901b) | `python310Packages.deezer-python: 5.2.0 -> 5.3.0`                                                |
| [`9d5bd0bc`](https://github.com/NixOS/nixpkgs/commit/9d5bd0bc2f81fc4309ecca2060a176c5863e77b3) | `python3Packages.archinfo: remove unused input`                                                  |
| [`ecc7c953`](https://github.com/NixOS/nixpkgs/commit/ecc7c9533cd4ab45feb84cbde4f94c1cc7fa03b3) | `python3Packages.cle: 9.2.1 -> 9.2.1`                                                            |
| [`fa46564d`](https://github.com/NixOS/nixpkgs/commit/fa46564ddf3876505193548ba2c01e7a36b808a4) | `python3Packages.ailment: 9.2.1 -> 9.2.1`                                                        |
| [`9f78c177`](https://github.com/NixOS/nixpkgs/commit/9f78c17798baa5bcbc69375a4f33353f2824be7a) | `python3Packages.angrop: 9.1.12332 -> 9.2.1`                                                     |
| [`95762cc1`](https://github.com/NixOS/nixpkgs/commit/95762cc16f77783a9844232ce2fba2d09d6d71cf) | `python3Packages.angr: 9.1.12332 -> 9.2.1`                                                       |
| [`f8d72949`](https://github.com/NixOS/nixpkgs/commit/f8d729492a1a64a378401f0fb509da64157931ac) | `python3Packages.claripy: 9.1.12332 -> 9.2.1`                                                    |
| [`acb32c13`](https://github.com/NixOS/nixpkgs/commit/acb32c13e4492d9e2e7bc98f02114cae36e1ce8f) | `python3Packages.pyvex: 9.1.12332 -> 9.2.1`                                                      |
| [`ad046a0c`](https://github.com/NixOS/nixpkgs/commit/ad046a0c97e998b7639851b604875c84468b5574) | `python3Packages.archinfo: 9.1.12332 -> 9.2.1`                                                   |
| [`2928efa6`](https://github.com/NixOS/nixpkgs/commit/2928efa64010b88a583756d15435c622858bce7c) | `python3Packages.glad: init 0.1.36`                                                              |
| [`54e12e99`](https://github.com/NixOS/nixpkgs/commit/54e12e99532abc61a8b32e3bb4494feb23155736) | `python3Packages.pillow-simd: 7.0.0.post3 -> 9.0.0.post1`                                        |
| [`96d3a705`](https://github.com/NixOS/nixpkgs/commit/96d3a705b8487ea2a55507c5e9bbc17caedaa61a) | `python3Packages.hmmlearn: fix build`                                                            |
| [`42282ebb`](https://github.com/NixOS/nixpkgs/commit/42282ebb76ddfd16a56a9545b56d089a8e48c179) | `python3Packages.geopandas: fix tests`                                                           |
| [`42802b54`](https://github.com/NixOS/nixpkgs/commit/42802b544f9c8c760fa1607b3850110bd19440b8) | `dolt: 0.37.4 -> 0.39.2`                                                                         |
| [`1bb806a0`](https://github.com/NixOS/nixpkgs/commit/1bb806a081208bd0893943385576561a49e3c6da) | `rover: 0.4.8 -> 0.5.1`                                                                          |
| [`9b2a6976`](https://github.com/NixOS/nixpkgs/commit/9b2a6976a6e3d14eacd62f481042f3cc2505752a) | `vector: 0.21.0 -> 0.21.1`                                                                       |
| [`a2054b6d`](https://github.com/NixOS/nixpkgs/commit/a2054b6d2c7254ee34daef3f756a4a95a5689b77) | `vpnc: switch to maintained fork`                                                                |
| [`40696c3e`](https://github.com/NixOS/nixpkgs/commit/40696c3e6f84d8ad6ed265541ef826c245fd5171) | `openconnect: re-enable p11kit`                                                                  |
| [`d4268e79`](https://github.com/NixOS/nixpkgs/commit/d4268e79530b7e4b228216fefe233586edfcb575) | `gnomeExtensions: update-extensions.py remove debug code`                                        |
| [`5c37b636`](https://github.com/NixOS/nixpkgs/commit/5c37b6361592f52d067a5a507e6fcbdfb2e28078) | `python3Packages.slither-analyzer: 0.8.2 -> 0.8.3`                                               |
| [`cad35edf`](https://github.com/NixOS/nixpkgs/commit/cad35edf30b1955c534567ea08d2f5cd4e7a9c27) | `llvmPackage: Only force GCC stdenv for native x86_32`                                           |
| [`9a3454a7`](https://github.com/NixOS/nixpkgs/commit/9a3454a75bcb3e7bedac8ee764d1340157b7b295) | `python310Packages.pyskyqremote: 0.3.5 -> 0.3.6`                                                 |
| [`10f88151`](https://github.com/NixOS/nixpkgs/commit/10f881519c80d5b785b61a6e0c4b25d942f5b870) | `alerta: 8.4.0 -> 8.5.1`                                                                         |
| [`ea63f629`](https://github.com/NixOS/nixpkgs/commit/ea63f62949147bfc9344b9c04a5f886ea9bc8ba1) | `alerta-server: 8.3.3 -> 8.7.0`                                                                  |
| [`3499ba19`](https://github.com/NixOS/nixpkgs/commit/3499ba19b7af62521d2ac1aa24df01caa20018bd) | `alerta-server: add missing input`                                                               |
| [`c9de099f`](https://github.com/NixOS/nixpkgs/commit/c9de099fa1b00bca89183a9e3347c2629f1dcf72) | `lvm2: move fix-blkdeactivate.patch to version 2.03.15+ only`                                    |
| [`bcacb9b8`](https://github.com/NixOS/nixpkgs/commit/bcacb9b84cc0dd65c177fdc0e37186ae2c9c6286) | `ipmiview: 2.19.0 -> 2.20.0`                                                                     |
| [`a7f327c6`](https://github.com/NixOS/nixpkgs/commit/a7f327c6ea2ae72881a7b7b473dd61f9d587f2b3) | `python310Packages.apprise: 0.9.8.1 -> 0.9.8.2`                                                  |
| [`82cd2cc2`](https://github.com/NixOS/nixpkgs/commit/82cd2cc2de707a9c77b4ad4aff6229cb49f55f38) | `python310Packages.apprise: 0.9.8 -> 0.9.8.1`                                                    |
| [`5592b378`](https://github.com/NixOS/nixpkgs/commit/5592b3789a964bc425198ca79554a09021e4427b) | `libpinyin: 2.6.1 -> 2.6.2`                                                                      |
| [`59611577`](https://github.com/NixOS/nixpkgs/commit/5961157781db55f8d54d5c8f488779c90ec7cf2c) | `tree-sitter: Add tree-sitter-scheme`                                                            |
| [`3740158c`](https://github.com/NixOS/nixpkgs/commit/3740158c42044124923f05e20dab24ff4b9def8b) | `python3Packages.flask-appbuilder: 3.4.4 -> 4.0.0`                                               |
| [`4e4feb0e`](https://github.com/NixOS/nixpkgs/commit/4e4feb0e0666c44a53c130efaf1082060104408d) | `ocamlPackages.llvm: switch to python3`                                                          |
| [`92e9f9ba`](https://github.com/NixOS/nixpkgs/commit/92e9f9ba62207297e0620b7bdc990e3fb8e1ce2f) | `python3Packages.celery: 5.2.3 -> 5.2.6`                                                         |
| [`9d5527d7`](https://github.com/NixOS/nixpkgs/commit/9d5527d70688b87e85864816e42e2bfd36d0a5e8) | `opensnitch: 1.5.0 -> 1.5.1`                                                                     |
| [`24b53785`](https://github.com/NixOS/nixpkgs/commit/24b53785cce8f81e2171c2e4042bfd4e3d0b2606) | `nixos/create_ap: add module`                                                                    |
| [`379f6985`](https://github.com/NixOS/nixpkgs/commit/379f69851f070a39ec78a521ecbbca263d75cb8b) | `sonixd: 0.15.0 -> 0.15.1`                                                                       |
| [`1b6f0a2d`](https://github.com/NixOS/nixpkgs/commit/1b6f0a2de829423a3b2c2da41ae773488decb450) | `open-watcom-v2-unwrapped: unstable-2022-04-21 -> unstable-2022-04-23`                           |
| [`c72d40e5`](https://github.com/NixOS/nixpkgs/commit/c72d40e573b799ab764a23093bee928cde08ae2f) | `xconq: fix build by pinning C++ standard version`                                               |
| [`2c6765c6`](https://github.com/NixOS/nixpkgs/commit/2c6765c613cf4a04ab6bc558e88f772015509bec) | `webcamoid: 8.8.0 -> 9.0.0`                                                                      |
| [`e7decf03`](https://github.com/NixOS/nixpkgs/commit/e7decf0387f7e9ee0fe6dc2c7443d44db610ac92) | `python3Packages.winacl: disable on older Python releases`                                       |
| [`935aa9e3`](https://github.com/NixOS/nixpkgs/commit/935aa9e3696a72634d6b4a521a5657c611fadb30) | `minigalaxy: set strictDeps to false`                                                            |
| [`149fc387`](https://github.com/NixOS/nixpkgs/commit/149fc387d67adac4cf9fd452bfb5186a7f53f16b) | `tigervnc: fix build with fresh xorgserver via upstream patch`                                   |
| [`5e9c10a2`](https://github.com/NixOS/nixpkgs/commit/5e9c10a2959053b28c9e377769178cca872b3759) | `python310Packages.zodbpickle: 2.2.0 -> 2.3`                                                     |
| [`4a72aad3`](https://github.com/NixOS/nixpkgs/commit/4a72aad35692b4a14981cfe9dacbfe9921a53f31) | `oed: fix cross-compilation`                                                                     |
| [`15427fea`](https://github.com/NixOS/nixpkgs/commit/15427feaeb182675adaada5e8af21a24ef80d292) | `oksh: fix cross-compilation`                                                                    |
| [`da727b72`](https://github.com/NixOS/nixpkgs/commit/da727b72c93b358edc9b80d66971af7fef6ab3d4) | `mg: fix cross-compilation`                                                                      |
| [`c8577c92`](https://github.com/NixOS/nixpkgs/commit/c8577c92b8fb897a1e19962b0bfc6728795bd4aa) | `polymc: 1.1.1 -> 1.2.1`                                                                         |
| [`ba3cb9e8`](https://github.com/NixOS/nixpkgs/commit/ba3cb9e8f6dc0b91d9470eae5f30202d05bd0ffa) | `calcurse: enable on darwin`                                                                     |
| [`c7b93bcd`](https://github.com/NixOS/nixpkgs/commit/c7b93bcdd1899399f92f9e5eb1f1fbf8b38e62c0) | `tailscale: 1.22.2 -> 1.24.0`                                                                    |
| [`f822e917`](https://github.com/NixOS/nixpkgs/commit/f822e917d40f5fa791566c2d26578e085378bae3) | `python310Packages.lightwave2: 0.8.8 -> 0.8.9`                                                   |
| [`879b212b`](https://github.com/NixOS/nixpkgs/commit/879b212b91952e619f4a6d4cada04c9ee15a8999) | `python310Packages.winacl: 0.1.2 -> 0.1.3`                                                       |
| [`3a279c6d`](https://github.com/NixOS/nixpkgs/commit/3a279c6db035229737941809fe8d3fad0fde09e9) | `cudatext: 1.162.0 -> 1.162.5`                                                                   |
| [`4bcda364`](https://github.com/NixOS/nixpkgs/commit/4bcda364c3ceab680f00ca5f5360066f98d3a70a) | `clojure: 1.11.1.1107 -> 1.11.1.1113`                                                            |
| [`ad605efb`](https://github.com/NixOS/nixpkgs/commit/ad605efb5fbdc2fa33f4ab385a4511fb1ba3f615) | `droidmote: init at 3.0.6`                                                                       |
| [`57f964ef`](https://github.com/NixOS/nixpkgs/commit/57f964efe9f63d928e087ab49b32a74bf14a3e03) | `nickel: init at 0.1.0`                                                                          |
| [`d13f1f86`](https://github.com/NixOS/nixpkgs/commit/d13f1f869f4d60a0b01cc7b7d3bbe8899a5d545b) | `gnomeExtensions: update-extensions.py make var more pythonic`                                   |
| [`7a542392`](https://github.com/NixOS/nixpkgs/commit/7a54239267392e0209137e12e2567cd5262d346d) | `gnomeExtensions: update-extensions.py move info after writing to file`                          |
| [`dcb93d00`](https://github.com/NixOS/nixpkgs/commit/dcb93d0080d17d9ef94afeaa17d484f6ca882508) | `gnomeExtensions: update-extensions.py improve download`                                         |
| [`51fdb8f2`](https://github.com/NixOS/nixpkgs/commit/51fdb8f239cb69f1e88bf38a5b125d83adff0f22) | `gnomeExtensions: update-extensions.py use relative paths`                                       |
| [`c88d1220`](https://github.com/NixOS/nixpkgs/commit/c88d12200cdfd049f2915922c7cc443ac13430b2) | `gnomeExtensions: update-extensions.py improve collision warning`                                |
| [`30818451`](https://github.com/NixOS/nixpkgs/commit/30818451447ab1c076caa5c36fc0310895f2ab3d) | `gnomeExtensions: update-extensions.py fix typos`                                                |
| [`bce4a670`](https://github.com/NixOS/nixpkgs/commit/bce4a670cc2ffbbbf222249bb2442a73509b68ae) | `gnomeExtensions: update-extensions.py fix where metadata.json missing`                          |
| [`5ce8c340`](https://github.com/NixOS/nixpkgs/commit/5ce8c3404395d5b6ef92eb6c456eaeeea1964c67) | `gnomeExtensions: update-extensions.py format`                                                   |
| [`da09d908`](https://github.com/NixOS/nixpkgs/commit/da09d908bec3586eadedb3d06271caafee965bbe) | `chromiumDev: 102.0.4997.0 -> 102.0.5005.12`                                                     |
| [`8be8be71`](https://github.com/NixOS/nixpkgs/commit/8be8be71cff14d0e4f01e2fa8fd579ffbfde39e7) | `ghorg: 1.7.12 -> 1.7.13`                                                                        |
| [`9f302132`](https://github.com/NixOS/nixpkgs/commit/9f302132b28a44cd0291e06a85f08a3eb5732594) | `python310Packages.phonenumbers: 8.12.46 -> 8.12.47`                                             |
| [`51114edb`](https://github.com/NixOS/nixpkgs/commit/51114edb8f88d2c2bd46a3667693f18109ef4d31) | `bazel_3: fix build with gcc11`                                                                  |
| [`28e8501d`](https://github.com/NixOS/nixpkgs/commit/28e8501d8e67d08892db837b1238fedf54c6eb0a) | `apksigcopier: remove linting, use installCheckPhase`                                            |
| [`3b0f9301`](https://github.com/NixOS/nixpkgs/commit/3b0f9301bbca58b78336c4a604cbf3fd79297d65) | `rawtherapee: Add note about removing the patch in 5.9`                                          |
| [`52ca1804`](https://github.com/NixOS/nixpkgs/commit/52ca1804a1e87e7842df4ec75b82cd9e5cb2f0e7) | `dovecot_fts_xapian: 1.5.4b -> 1.5.5`                                                            |
| [`0ddbd36e`](https://github.com/NixOS/nixpkgs/commit/0ddbd36e06dce61645798a352fb6ebb489cd5a4b) | `bitwig-studio: 4.2.2 -> 4.2.3`                                                                  |
| [`a79a8d95`](https://github.com/NixOS/nixpkgs/commit/a79a8d95d13b6fa9ebef707a489b5b53192050ff) | `dnstake: 0.1.0 -> 0.1.1`                                                                        |
| [`84b547ca`](https://github.com/NixOS/nixpkgs/commit/84b547cac06c89b960b5d6fe7404ef5768318db8) | `calcurse: 4.7.1 -> 4.8.0`                                                                       |
| [`3230e673`](https://github.com/NixOS/nixpkgs/commit/3230e673105caec3b1f402e77d8041383237bad8) | `clickhouse-backup: 1.3.1 -> 1.3.2`                                                              |
| [`36b08540`](https://github.com/NixOS/nixpkgs/commit/36b0854076004c7801b6ebfcc0b175d6666dd0c7) | `rawtherapee: Add glibc-2.34 malloc error patch`                                                 |
| [`994b6400`](https://github.com/NixOS/nixpkgs/commit/994b6400c883bb13485685da06e4893289126f90) | `php: remove whitespace`                                                                         |
| [`8fb8ccb1`](https://github.com/NixOS/nixpkgs/commit/8fb8ccb179f32e61f6243cce4d0109a18a06cc2c) | `php: fix extensions on php-cgi`                                                                 |
| [`9277e000`](https://github.com/NixOS/nixpkgs/commit/9277e0002ae9e99d2cd4ae1452ce4ed3f4e97e92) | `Update pkgs/development/python-modules/sentry-sdk/default.nix`                                  |
| [`26d74675`](https://github.com/NixOS/nixpkgs/commit/26d74675fa8df3637fd674ca7b289a3bba50fd7a) | `python3Packages.net2grid: remove`                                                               |
| [`f3d888fc`](https://github.com/NixOS/nixpkgs/commit/f3d888fc30a1d40dbc15900f1bdc5a67f02abffe) | `bazel-buildtools: 5.0.1 -> 5.1.0`                                                               |
| [`d748aedb`](https://github.com/NixOS/nixpkgs/commit/d748aedb2b86196e801e90aef58eda959a644aea) | `watchexec: 1.17.1 -> 1.19.0`                                                                    |
| [`4d68e1be`](https://github.com/NixOS/nixpkgs/commit/4d68e1befb69d37d1218fa1a368b50b43cf0882e) | `libvmaf: 2.3.0 -> 2.3.1`                                                                        |
| [`efb1e895`](https://github.com/NixOS/nixpkgs/commit/efb1e8956939e5cdb18bf163d616efc329ab339a) | `bash-preexec: 0.4.1 -> 0.5.0`                                                                   |
| [`9407edc1`](https://github.com/NixOS/nixpkgs/commit/9407edc17d7bcccb20e1630eadbee094f03a6fae) | `rabbitmq-server: switch to python3`                                                             |
| [`f7861fa5`](https://github.com/NixOS/nixpkgs/commit/f7861fa5e02dda17c798df5933a52231cd67080b) | `python310Packages.ffcv: move pkgconfig to nativeBuildInputs`                                    |
| [`30b30332`](https://github.com/NixOS/nixpkgs/commit/30b30332967dc5caadd84c3d5930221e5c7813d6) | `python310Packages.pycapnp: move things to nativeBuildInputs`                                    |
| [`ca9bf3e0`](https://github.com/NixOS/nixpkgs/commit/ca9bf3e05fa544a9a84af3fc9269834cd931744f) | `crystal: remove myself as maintainer`                                                           |
| [`399a20a3`](https://github.com/NixOS/nixpkgs/commit/399a20a384f3c15637ba9466c96f5e51fa5cd0c0) | `android-studio: remove myself as maintainer`                                                    |
| [`368ce6ab`](https://github.com/NixOS/nixpkgs/commit/368ce6abb2a708c63e5577a80b328fa466224773) | `kotlin: 1.6.20 → 1.6.21`                                                                        |
| [`54f84ac6`](https://github.com/NixOS/nixpkgs/commit/54f84ac616a9338f6408d6852d336487d25816f4) | `retroarch: 1.10.2 -> 1.10.3`                                                                    |
| [`2dc4427d`](https://github.com/NixOS/nixpkgs/commit/2dc4427d358e6ca37934de16cd626bc4e4665e2a) | `gnome-builder: 42.0 → 42.1`                                                                     |
| [`d30e9aab`](https://github.com/NixOS/nixpkgs/commit/d30e9aabf499077d4cc7b61c0aad4eb337266e8b) | `snes9x: fix cross-compilation`                                                                  |
| [`62905f67`](https://github.com/NixOS/nixpkgs/commit/62905f6706648e84c3af6570ba2f03cc41dfab07) | `snes9x: init at 1.61`                                                                           |
| [`67ae929d`](https://github.com/NixOS/nixpkgs/commit/67ae929deb3b3c5102848485dbb3f48e5ff27278) | `mesa: disable withValgrind if valgrind-light is marked as broken`                               |
| [`582a42ec`](https://github.com/NixOS/nixpkgs/commit/582a42ece7e2a86d5b076addd5f18a6379fd326a) | `lvm2: fix static compilation`                                                                   |
| [`aa305e50`](https://github.com/NixOS/nixpkgs/commit/aa305e509322a6cefa4660402689b45bbc292f30) | `python3Packages.sentry-sdk: disable tests`                                                      |
| [`6e06f630`](https://github.com/NixOS/nixpkgs/commit/6e06f630400ad9e4c364862efab1ba1c9561c954) | `python3Packages.readme_renderer: 34.0 -> 35.0`                                                  |
| [`cd8f1c2f`](https://github.com/NixOS/nixpkgs/commit/cd8f1c2f111880de24e577599edbcb139eec3571) | `rcs: cleanup remove unecessary input`                                                           |
| [`e8f99f7f`](https://github.com/NixOS/nixpkgs/commit/e8f99f7fd686936a48e0a212ab489ea73090ee67) | `scala-cli: 0.1.3 -> 0.1.4`                                                                      |
| [`905fad4c`](https://github.com/NixOS/nixpkgs/commit/905fad4c4b5c80b9d802d1780d56418c55be60ab) | `darktable: add glib-networking dependency`                                                      |
| [`627cc295`](https://github.com/NixOS/nixpkgs/commit/627cc295bb3ecaf5114808956e76a986f4d5bcb3) | `qownnotes: 22.3.4 -> 22.4.1`                                                                    |
| [`0edfd89d`](https://github.com/NixOS/nixpkgs/commit/0edfd89d6e24064d2b0fd0853b8e19c42906dc1b) | `nixos/tools: add copySystemConfiguration to configuration file template`                        |
| [`a8d61ae5`](https://github.com/NixOS/nixpkgs/commit/a8d61ae53092520faba23759d90b8e42f32fbb17) | `Revert "rcs: fix build w/glibc-2.34"`                                                           |
| [`10ce5761`](https://github.com/NixOS/nixpkgs/commit/10ce57613612bdfc460471b5300d48c8ca4e4598) | `goffice: 0.10.51 -> 0.10.52`                                                                    |
| [`6951ba02`](https://github.com/NixOS/nixpkgs/commit/6951ba02f4c7cef6cd38825ae8fc5f51be05205d) | `nginxStable: add patch for CVE-2021-3618`                                                       |
| [`bd2a384c`](https://github.com/NixOS/nixpkgs/commit/bd2a384c40c4176c279502c46c2ac411f8c31cbd) | `thanos: 0.25.1 -> 0.25.2`                                                                       |
| [`fb909729`](https://github.com/NixOS/nixpkgs/commit/fb90972987eb0ddb1914e4d7e8ac77186cbda444) | `androidStudioPackages.{canary,dev}: 2021.3.1.1 -> 2021.3.1.7`                                   |
| [`61069589`](https://github.com/NixOS/nixpkgs/commit/61069589c24fc7f7bd09f8599b1699a1c8830ee6) | `androidStudioPackages.beta: 2021.2.1.8 -> 2021.2.1.11`                                          |
| [`7a13b86d`](https://github.com/NixOS/nixpkgs/commit/7a13b86dbd88871124a9af6654b5eaef00a19f82) | `androidStudioPackages.stable: 2021.1.1.21 -> 2021.1.1.23`                                       |
| [`eb286631`](https://github.com/NixOS/nixpkgs/commit/eb286631b4cec28424fb4056735a79cdb36eec59) | `haskell.compiler: check targetPlatform for Cabal Paths module patch`                            |
| [`cb720edb`](https://github.com/NixOS/nixpkgs/commit/cb720edb7dd3529787bdd2945e5da9402c3bca08) | `kodi: More robust handling of kodi webserver assets`                                            |
| [`89f15314`](https://github.com/NixOS/nixpkgs/commit/89f15314013af00739b3eb394d064989e43f8e4b) | `icingaweb2: 2.10.0 -> 2.10.1`                                                                   |
| [`67303b06`](https://github.com/NixOS/nixpkgs/commit/67303b06c0a20f3dfa11a390ffd35e4762a7c179) | `python3.pkgs.ihatemoney: fix build with flask-talisman 1`                                       |
| [`d3aa7c14`](https://github.com/NixOS/nixpkgs/commit/d3aa7c14039471d52b2d36266008502d78c0e179) | `python310Packages.flask-talisman: 0.8.1 -> 1.0.0`                                               |
| [`0d579123`](https://github.com/NixOS/nixpkgs/commit/0d5791236431766fa70ceca0e1df17ac8087ed13) | `wvkbd: init at 0.7`                                                                             |
| [`686e1352`](https://github.com/NixOS/nixpkgs/commit/686e1352f725d3bd7808cd66f2d8923db17ac9c0) | `libraw_0_20: init at 0.20.2`                                                                    |
| [`2bc097e4`](https://github.com/NixOS/nixpkgs/commit/2bc097e409da9e62d3c3f9e3bd3b938c303fa867) | `freeimage: unstable-2020-07-04 -> unstable-2021-11-01`                                          |
| [`ae4dae29`](https://github.com/NixOS/nixpkgs/commit/ae4dae2909aad127686306ce140f6551db6cf9c3) | `libraw: 0.20.2 -> unstable-2021-12-03`                                                          |