### PR TITLE
chore(flake/home-manager): `65a32578` -> `09f3e679`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1650784624,
-        "narHash": "sha256-RTYGFBlxEmhhLLH9UfObyz2d4alhCSf6NQpyID7Mqvg=",
+        "lastModified": 1650836336,
+        "narHash": "sha256-W9NfDZVSBrmiURX3LUQOp6McJMEqpw6njC1/vtRLp+M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "65a32578d9b1394bea5c6336721ec392aadc89fb",
+        "rev": "09f3e67950823d5abe192e474f1af51914f4cb9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                       |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`09f3e679`](https://github.com/nix-community/home-manager/commit/09f3e67950823d5abe192e474f1af51914f4cb9a) | `Translate using Weblate (Italian)`                  |
| [`5997c434`](https://github.com/nix-community/home-manager/commit/5997c434580fd3a2d7c5931b2647e07791ddb018) | `Add translation using Weblate (Persian)`            |
| [`845aaaf4`](https://github.com/nix-community/home-manager/commit/845aaaf4db2b411d686290fb0c47fc988bca3f14) | `Translate using Weblate (Persian)`                  |
| [`6f025b38`](https://github.com/nix-community/home-manager/commit/6f025b38253ae14f38b366c37d8e568a2f8e67b3) | `i3-sway: only return current user's socket (#2914)` |