### PR TITLE
chore(flake/nixpkgs): `ab83c5d7` -> `81699903`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -130,11 +130,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650792148,
-        "narHash": "sha256-n1MZSZIzvP70BJ56tV8GwQ5L0wHt/nTH9UkF5HTGB/4=",
+        "lastModified": 1650835985,
+        "narHash": "sha256-EKajv48HSLUmBDp4KYbyjDUJA+aoaOIsldkqQLDf5Fs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ab83c5d70528f1edc7080dead3a5dee61797b3ff",
+        "rev": "8169990346fcd3aeb81222b7dcb70a00750d8f9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                    |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`910a7833`](https://github.com/NixOS/nixpkgs/commit/910a7833de829c10230f03eb9d089331a33f0d80) | `home-assistant: update component-packages`                       |
| [`440d748e`](https://github.com/NixOS/nixpkgs/commit/440d748e1089ec1c2906fb3226d70ae799fcecc3) | `python3Packages.peco: init at 0.0.29`                            |
| [`0edd0271`](https://github.com/NixOS/nixpkgs/commit/0edd0271dc4767c16009e746bba0f3a6c9503806) | `home-assistant: update component-packages`                       |
| [`b9f25a97`](https://github.com/NixOS/nixpkgs/commit/b9f25a978a728ac7e60acfbcaa0804785e9c869f) | `python3Packages.arris-tg2492lg: init at 2.1.0`                   |
| [`5ba1c523`](https://github.com/NixOS/nixpkgs/commit/5ba1c5231f51df29c629ab1c0fb1dcf2d63bd6fc) | `home-assistant: update component-packages`                       |
| [`79fe52c1`](https://github.com/NixOS/nixpkgs/commit/79fe52c1c3073870427be1ebdade2af185cf3c63) | `python3Packages.zwave-me-ws: init at 0.2.4`                      |
| [`9a9735fd`](https://github.com/NixOS/nixpkgs/commit/9a9735fd9a19cf3c6f80e8f4c531d8f04bee2093) | `sphinxbase: remove`                                              |
| [`33207688`](https://github.com/NixOS/nixpkgs/commit/33207688a35841a0625c1d98034c6a1e607e1a97) | `pocketsphinx: remove`                                            |
| [`3d957ef3`](https://github.com/NixOS/nixpkgs/commit/3d957ef33b5603d025935b4950a423ddc5054f40) | `parlatype: remove`                                               |
| [`c60d8629`](https://github.com/NixOS/nixpkgs/commit/c60d862933db1847e09f3e57b4bd69dfb3bea7e3) | `subnetcalc: init at 2.4.19`                                      |
| [`255fe81e`](https://github.com/NixOS/nixpkgs/commit/255fe81ed63af9003795ba660904cfecbdd3210d) | `libraw: update two commits ahead`                                |
| [`da80a59e`](https://github.com/NixOS/nixpkgs/commit/da80a59e8f646ca284d2c7ffe070ad8e010c614f) | `libwebsockets: 4.3.0 -> 4.3.1`                                   |
| [`43049e86`](https://github.com/NixOS/nixpkgs/commit/43049e863cce1d1bca7d017afa60186be0c047e6) | `lasso: switch to python3`                                        |
| [`e325f7ae`](https://github.com/NixOS/nixpkgs/commit/e325f7aeaafa51db41bd7e8d86d04b934dbab949) | `igrep: 0.2.0 -> 0.5.0`                                           |
| [`e66cf9c6`](https://github.com/NixOS/nixpkgs/commit/e66cf9c6c81a99864b15c7c75bc7f0f192ba30e6) | `elan: 1.4.0 -> 1.4.1`                                            |
| [`c924a4f5`](https://github.com/NixOS/nixpkgs/commit/c924a4f5803c7f45997c791124f187cc334f9e95) | `dprint: 0.24.4 -> 0.26.0`                                        |
| [`0cf5df6f`](https://github.com/NixOS/nixpkgs/commit/0cf5df6fa5412318817274d55528c7eafff8d17d) | `i3status-rust: 0.21.9 -> 0.21.10`                                |
| [`3a796780`](https://github.com/NixOS/nixpkgs/commit/3a796780a39a46f625238c73f0a7eef3050bbb23) | `home-assistant: update component-packages`                       |
| [`d2124429`](https://github.com/NixOS/nixpkgs/commit/d21244296929214217b027aa3615df4263cf7e80) | `python3Packages.pysensibo: init at 1.0.12`                       |
| [`dbf44382`](https://github.com/NixOS/nixpkgs/commit/dbf443827d27d3343023ad057bea2bc1e3103681) | `prboom: remove`                                                  |
| [`e883c037`](https://github.com/NixOS/nixpkgs/commit/e883c03703f958ddd4599fa96331a7c9c5891ba6) | `home-assistant: update component-packages`                       |
| [`6c89269a`](https://github.com/NixOS/nixpkgs/commit/6c89269afc1938b706e6bab3aa16e40064b6e773) | `python3Packages.fivem-api: init at 0.1.2`                        |
| [`b2db21e6`](https://github.com/NixOS/nixpkgs/commit/b2db21e6506e6d8a334be3105cfcbc642c7e8b79) | `buho: init at 2.1.1`                                             |
| [`3185d903`](https://github.com/NixOS/nixpkgs/commit/3185d90322141934e818bc27d4210349c8a78245) | `python3Packages.bottleneck: disable failing test`                |
| [`c7d26e16`](https://github.com/NixOS/nixpkgs/commit/c7d26e160f7cb27a5c449a23a9bda7cf78a7f016) | `libraw: switch the default back to 0.20`                         |
| [`ded34c9c`](https://github.com/NixOS/nixpkgs/commit/ded34c9cb0002f25a0bfe3afe1342384f16fad17) | `prboom-plus: init at 2.6.2`                                      |
| [`9a4208b0`](https://github.com/NixOS/nixpkgs/commit/9a4208b06fb4a45fa714dac5f9894e8aff2233b6) | `flexget: unbreak by adding some more explicit dependencies`      |
| [`a3c60593`](https://github.com/NixOS/nixpkgs/commit/a3c605936a1d4ac47c61c875cf63b3d9e0b4415d) | `xonotic: fix compiling with GCC11 (#170036)`                     |
| [`50121730`](https://github.com/NixOS/nixpkgs/commit/50121730cae36c893be51dedd41d2113e3c5a653) | `pngtools: init at unstable-2022-03-14 (#169875)`                 |
| [`6508304a`](https://github.com/NixOS/nixpkgs/commit/6508304a8893567ef6b2bf73baaed0f0dda75319) | `nginxModules.vts: fix build on gcc11`                            |
| [`e50cb00f`](https://github.com/NixOS/nixpkgs/commit/e50cb00ff5f5e2f80f2933ec5683ccd5b57765f4) | `python3Packages.async-upnp-client: 0.27.0 -> 0.28.0`             |
| [`858b460f`](https://github.com/NixOS/nixpkgs/commit/858b460f3ca0efaadab65d2fdad39905a14b3607) | `gitlab: 14.9.2 -> 14.9.3 (#168402)`                              |
| [`b8149cba`](https://github.com/NixOS/nixpkgs/commit/b8149cba835168450c897b43405af46ba0079ee1) | `nix-du: 0.5.0 -> 0.5.1`                                          |
| [`22fc1f60`](https://github.com/NixOS/nixpkgs/commit/22fc1f600ef7c829e51f4188bb1d504f52fb0011) | `plantuml: Support PDF output`                                    |
| [`04c6c6a1`](https://github.com/NixOS/nixpkgs/commit/04c6c6a1182ce8070f935f55517dc0e57031787b) | `github-backup: 0.40.1 -> 0.41.0`                                 |
| [`21554166`](https://github.com/NixOS/nixpkgs/commit/215541667b0bd5e89701a9b8c33d04a3202df915) | `fail2ban: add pyinotify support`                                 |
| [`827a77d4`](https://github.com/NixOS/nixpkgs/commit/827a77d46df6f9f56e4ffe8fcb41ca51b25b2947) | `pdal: 2.3.0 -> 2.4.0`                                            |
| [`12dbdfb6`](https://github.com/NixOS/nixpkgs/commit/12dbdfb6198b0f68732caedecacbf9a607de447e) | `checkov: 2.0.1076 -> 2.0.1077`                                   |
| [`91ac8a7c`](https://github.com/NixOS/nixpkgs/commit/91ac8a7cd20814d924fb29526f55f94ef10c1da1) | `nvtop: 1.2.2 -> 2.0.1`                                           |
| [`85d729d4`](https://github.com/NixOS/nixpkgs/commit/85d729d4e52f735ca6c01698c9080be1e9cc57de) | `radare2: 5.6.4 -> 5.6.8`                                         |
| [`0d3eb08f`](https://github.com/NixOS/nixpkgs/commit/0d3eb08f2c26a90237fafdbcfd9b8a9b8f6f2562) | `gns3: 2.2.29 -> 2.2.31`                                          |
| [`698ae84d`](https://github.com/NixOS/nixpkgs/commit/698ae84da4a2248e889717a0caa6462a36428c53) | `gns3-gui: 2.2.29 -> 2.2.31`                                      |
| [`29770c61`](https://github.com/NixOS/nixpkgs/commit/29770c619aec2245e69c37da3c766f0b3105fd83) | `gns3-server: 2.2.29 -> 2.2.31`                                   |
| [`95aa9e35`](https://github.com/NixOS/nixpkgs/commit/95aa9e35502a9f868de11f464576f67bf90562a8) | `imagemagick: 7.1.0-30 -> 7.1.0-31`                               |
| [`b2bebc35`](https://github.com/NixOS/nixpkgs/commit/b2bebc358632c5f2c97c4c407aa7882d27c3e192) | `pkgsMusl.openssh: fix build`                                     |
| [`31ed8a57`](https://github.com/NixOS/nixpkgs/commit/31ed8a5745a6de1fe684f730bd9056f122d04318) | `python3Packages.dm-sonnet, python3Packages.graph_nets: remove`   |
| [`ad97a488`](https://github.com/NixOS/nixpkgs/commit/ad97a4885528522216877350e33f3586b838ad8e) | `rr: disable LTO and build with current stdenv`                   |
| [`daa5805b`](https://github.com/NixOS/nixpkgs/commit/daa5805bdf0fd88034c4aedbf16d1748e71991d9) | `python3Packages.elkm1-lib: 1.3.1 -> 1.3.4`                       |
| [`7bd9488e`](https://github.com/NixOS/nixpkgs/commit/7bd9488e0fe5f139e5f2aa2a722a70b03da782c1) | `python3Packages.intellifire4py: 1.0.2 -> 1.0.5`                  |
| [`002ab067`](https://github.com/NixOS/nixpkgs/commit/002ab067def81d2a2221fb931f844538520b00c8) | `python3Packages.wandb: disable on older Python releases`         |
| [`8af77278`](https://github.com/NixOS/nixpkgs/commit/8af772780679441fcf2baaa3b518aa134320489d) | `python3Packages.sentry-sdk: 1.5.8 -> 1.5.10`                     |
| [`97165f33`](https://github.com/NixOS/nixpkgs/commit/97165f331eee24f445a0fa70c566083c6659dea1) | `x16-emulator: 38 -> 40`                                          |
| [`5088ed86`](https://github.com/NixOS/nixpkgs/commit/5088ed8640d4db3bd2e5cbda521079d300369865) | `x16-rom: 38 -> 40`                                               |
| [`b5058d02`](https://github.com/NixOS/nixpkgs/commit/b5058d029c70e92930c9c4c13bfe3ade59283ab1) | `python310Packages.google-cloud-bigquery: fix build`              |
| [`c5aa93e1`](https://github.com/NixOS/nixpkgs/commit/c5aa93e1a9c74c7df80b506c89fe2f3ce336e2ae) | `python310Packages.db-dtypes: init at 1.0.0`                      |
| [`4320942d`](https://github.com/NixOS/nixpkgs/commit/4320942d19118d38caf33a56a4eaa318de3ed104) | `python310Packages.google-cloud-bigquery-storage: init at 2.13.1` |
| [`d538bbe9`](https://github.com/NixOS/nixpkgs/commit/d538bbe92cf422f47df087625b5e393d9700fff9) | `postfix: 3.6.5 -> 3.6.6`                                         |
| [`9b2ca297`](https://github.com/NixOS/nixpkgs/commit/9b2ca297b637a8c26fa2fb3d619901078c490b84) | `graphene-hardened-malloc: 8 -> 11`                               |
| [`3bd928c9`](https://github.com/NixOS/nixpkgs/commit/3bd928c9b44b7574c2668101d101c366fe02aedc) | `metasploit: 6.1.38 -> 6.1.39`                                    |
| [`51ea542c`](https://github.com/NixOS/nixpkgs/commit/51ea542cd18a036040c42461c1dcdcba5a2363de) | `exploitdb: 2022-04-20 -> 2022-04-23`                             |
| [`7022bcf5`](https://github.com/NixOS/nixpkgs/commit/7022bcf5dc17dc47fb9ac4ebfa6e0fd57cdba966) | `vigra: 1.11.1 → unstable-2022-01-11`                             |
| [`2b730c8d`](https://github.com/NixOS/nixpkgs/commit/2b730c8d5c26d85ecd6678f83d425830681d77c2) | `enblend-enfuse: 4.2 → unstable-2022-03-06`                       |
| [`9ebc2ad1`](https://github.com/NixOS/nixpkgs/commit/9ebc2ad1ca8d115f5d3afa69e2a37375d27c844a) | `sqlfluff: 0.12.0 -> 0.13.0`                                      |
| [`9931c4a4`](https://github.com/NixOS/nixpkgs/commit/9931c4a4072215569a80a8e31316ab35bc65c8a5) | ``nixos/nextcloud: make `profile.enabled` configurable``          |
| [`9e26e53a`](https://github.com/NixOS/nixpkgs/commit/9e26e53a66fab70e94e0b3bb8b2353569dd13dca) | `wl-clipboard-x11: add artturin to maintainers`                   |
| [`9ed9d37b`](https://github.com/NixOS/nixpkgs/commit/9ed9d37b5ed52c8b58b9e33da7027f99cc0b007d) | `python310Packages.faraday-plugins: 1.6.3 -> 1.6.4`               |
| [`943c2eb1`](https://github.com/NixOS/nixpkgs/commit/943c2eb1b20e5a78819ea2d0de973f94b9585d67) | `nodejs-18_x: init at 18.0.0`                                     |
| [`e593b9b4`](https://github.com/NixOS/nixpkgs/commit/e593b9b41f1f4c10acbf35d2a47ab2babe80d8b2) | `pydb: remove`                                                    |
| [`0c890f58`](https://github.com/NixOS/nixpkgs/commit/0c890f586676a9c48a2c893c89334915d1fb1e4e) | `treewide: remove samuelgrf from maintainers`                     |
| [`7a33f3d0`](https://github.com/NixOS/nixpkgs/commit/7a33f3d009d8e2817958ad1c434f59435fed3d1f) | `kjv: get patches from archive.org`                               |
| [`165ea6d6`](https://github.com/NixOS/nixpkgs/commit/165ea6d63948a5dd6108013eda83d089f793da25) | `python310Packages.sqlitedict: 1.7.0 -> 2.0.0`                    |
| [`c6a937fc`](https://github.com/NixOS/nixpkgs/commit/c6a937fcfc6cd70342359b24d4316eb2e83a003f) | `armadillo: 11.0.0 -> 11.0.1`                                     |
| [`3b448f48`](https://github.com/NixOS/nixpkgs/commit/3b448f48d9dd571ea0d9fff4a0eb63765b230f3d) | `libkqueue: init at 2.6.0`                                        |
| [`683d310d`](https://github.com/NixOS/nixpkgs/commit/683d310db70ff530a2ab2f0d3ebd7f18a32a9f00) | `zuo: init at 2022-04-15`                                         |
| [`f3d70ac6`](https://github.com/NixOS/nixpkgs/commit/f3d70ac6634350b5bef3952b4f4d35e4420621e8) | `sampler: build on Darwin`                                        |
| [`f17ccd67`](https://github.com/NixOS/nixpkgs/commit/f17ccd671f9c8d32bfe34d9bed9c5c366a9f939a) | `libsystemtap: 3.2 -> 4.6`                                        |
| [`07e68f3f`](https://github.com/NixOS/nixpkgs/commit/07e68f3fc4fa685f4ffda02cb60c4011c84fbbf8) | `chia-plotter: 1.1.7 -> 1.1.8`                                    |
| [`dbc95f15`](https://github.com/NixOS/nixpkgs/commit/dbc95f15b8dad5224cbb6a52df979023db6cba98) | `nixos/test-driver: Avoid shell injection in machine.execute()`   |
| [`ed945aeb`](https://github.com/NixOS/nixpkgs/commit/ed945aeb6e4278a3f1b3f137665ad47b79f525c9) | `nixos/manual: Clarify execute exit status`                       |
| [`f7e89a59`](https://github.com/NixOS/nixpkgs/commit/f7e89a59da9f4531c21df0736b5fdfeba19d7c77) | ``nixos/test-driver: fix missing shellopts in `execute```         |
| [`7586158a`](https://github.com/NixOS/nixpkgs/commit/7586158ac902878712f6511263ad075abca8c16f) | ``nixos/manual: Refine doc for `execute` et al``                  |
| [`f202a18f`](https://github.com/NixOS/nixpkgs/commit/f202a18f608c4ee1c2a257f6703a8351f1e2dc91) | `atlassian-confluence: 7.14.1 -> 7.17.1`                          |
| [`8fa00724`](https://github.com/NixOS/nixpkgs/commit/8fa007242cf4491d853daad3b7df1bdb57b1d541) | `atlassian-jira: 8.22.0 -> 8.22.2`                                |
| [`99199524`](https://github.com/NixOS/nixpkgs/commit/9919952421f39d20eb28e0bbeaf7206d6950bf6c) | `bada-bib: 0.6.1 -> 0.6.2`                                        |
| [`77f15bc6`](https://github.com/NixOS/nixpkgs/commit/77f15bc69feebcea77d4d075b8302d99871b12ab) | `xfce.xfce4-terminal: 0.8.10 -> 1.0.1`                            |
| [`c29cca1e`](https://github.com/NixOS/nixpkgs/commit/c29cca1eef4e16dab6354a96076396362a9a016f) | `xfce.xfce4-eyes-plugin: 4.5.1 -> 4.6.0`                          |
| [`9d295d7c`](https://github.com/NixOS/nixpkgs/commit/9d295d7ca4cdb04092e371fe81c02796f7e2e806) | `xfce.xfce4-panel: 4.16.3 -> 4.16.4`                              |
| [`86ee754c`](https://github.com/NixOS/nixpkgs/commit/86ee754c4f5cc76ac6bea9066f00d48edc247a5b) | `wlr-randr: add wayland-scanner to nativeBuildInputs`             |
| [`abe8ff56`](https://github.com/NixOS/nixpkgs/commit/abe8ff56e274d80a82b51d022875123ffaa3ebc8) | `update remote package hash`                                      |
| [`2f444f12`](https://github.com/NixOS/nixpkgs/commit/2f444f12c8c6dceba20db54b4afe33192a929a7d) | `runescape-launcher: use package from archive.org`                |
| [`14f36b6f`](https://github.com/NixOS/nixpkgs/commit/14f36b6f87d5f4c2f00d846d82743b4f68323d11) | `Update hash + add myself as maintainer`                          |
| [`c3c57914`](https://github.com/NixOS/nixpkgs/commit/c3c57914b3f32d632d805e285b492ce2785bdd7d) | `python310Packages.pytest-check: 1.0.4 -> 1.0.5`                  |
| [`51f78ade`](https://github.com/NixOS/nixpkgs/commit/51f78ade780e2cd94d3fa2fb855aa02742bc7664) | `nixos/jira: set home for jira user`                              |
| [`ff15d086`](https://github.com/NixOS/nixpkgs/commit/ff15d08681f22613392f7d9cba700c2fa6eb5641) | `fluidd: 1.17.1 -> 1.17.2`                                        |
| [`6af7f6eb`](https://github.com/NixOS/nixpkgs/commit/6af7f6eb783ddf103561aa4c4e2e68abe01336ab) | `tests/step-ca: give name, fix acme usage`                        |
| [`1d79ffcb`](https://github.com/NixOS/nixpkgs/commit/1d79ffcb6814bc93bc790517187ccfdab43eaa21) | `tests/peertube: update redis usage`                              |
| [`54bf7c3c`](https://github.com/NixOS/nixpkgs/commit/54bf7c3c5b2f6c466e7e7c93d0b19babab19085c) | `bluejeans-gui: 2.26.0.136 -> 2.27.0.130`                         |
| [`75648090`](https://github.com/NixOS/nixpkgs/commit/7564809000aea811d68e8197e4304c7bb4e73f59) | `libinput-gestures: 2.39 -> 2.72`                                 |
| [`142dab5c`](https://github.com/NixOS/nixpkgs/commit/142dab5c73090f9445458b75e64ce4183554b53e) | `scryer-prolog: v0.8.127 -> v0.9.0`                               |
| [`80f0cf33`](https://github.com/NixOS/nixpkgs/commit/80f0cf33d8a922b021e366015e09f00d31c4b339) | `signify: 30 -> 31`                                               |