### PR TITLE
chore(flake/nixpkgs): `81699903` -> `e76c8952`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -130,11 +130,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650835985,
-        "narHash": "sha256-EKajv48HSLUmBDp4KYbyjDUJA+aoaOIsldkqQLDf5Fs=",
+        "lastModified": 1650878143,
+        "narHash": "sha256-2jY3TLNMEBBdv2ndNQuvdRwtP3T4kodujm7Qout53qM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8169990346fcd3aeb81222b7dcb70a00750d8f9f",
+        "rev": "e76c8952c938d4b49e70e5e24f6d7568749c7b5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                      |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`85408763`](https://github.com/NixOS/nixpkgs/commit/8540876319735c0891f25c8c7c9d8475159ae8fe) | `hdhomerun-config-gui: fix install bin path`                        |
| [`582a2d76`](https://github.com/NixOS/nixpkgs/commit/582a2d76835681a1d6a6dda245c6fbc7c77b6727) | `python3Packages.pytest-snapshot: disable on older Python releases` |
| [`a97a00fc`](https://github.com/NixOS/nixpkgs/commit/a97a00fcebe2e4186642282b289bcee87a1f0aaf) | `nginx: fixup build with other than gcc11`                          |
| [`a5774e76`](https://github.com/NixOS/nixpkgs/commit/a5774e76bb8c3145eac524be62375c937143b80c) | `terraform-providers: update 2022-04-25`                            |
| [`b2e2247f`](https://github.com/NixOS/nixpkgs/commit/b2e2247f8bc7d92a08a41eec2f9ca860ff597fba) | `python310Packages.pytest-snapshot: 0.8.1 -> 0.9.0`                 |
| [`9ea7bd4e`](https://github.com/NixOS/nixpkgs/commit/9ea7bd4e67cc2bc3069b8961914cd80cc55037fa) | `rmfuse: 0.2.1 -> 0.2.3`                                            |
| [`9af334d8`](https://github.com/NixOS/nixpkgs/commit/9af334d8fcd78bc33590f6b8e3b1ce52d6daf83d) | `Revert "rmfuse: 0.2.1 -> 0.2.3"`                                   |
| [`a44a9240`](https://github.com/NixOS/nixpkgs/commit/a44a9240e2bd44cfe5de8a5ff913191bc2b14022) | `clj-kondo: 2022.04.08 -> 2022.04.23`                               |
| [`c083780b`](https://github.com/NixOS/nixpkgs/commit/c083780b326ada46cd8a6d6e6d97e353409c8463) | `gay: fix build`                                                    |
| [`97913276`](https://github.com/NixOS/nixpkgs/commit/9791327619712bc6d495a6d741b446664730660b) | `python310Packages.teslajsonpy: 2.0.1 -> 2.0.3`                     |
| [`b8ba0589`](https://github.com/NixOS/nixpkgs/commit/b8ba05895967c7e9d79d313187545c740b1227e2) | `gremlin-console: 3.5.3 -> 3.6.0`                                   |
| [`aa4b8850`](https://github.com/NixOS/nixpkgs/commit/aa4b8850a453b0cbe6266242f6ab52e361c8d0b3) | `home-assistant: 2022.4.6 -> 2022.4.7`                              |
| [`6d57d53f`](https://github.com/NixOS/nixpkgs/commit/6d57d53f5b3c8d58c099ee22ff9de04d1db08cc9) | `python3Packages.aiodiscover: 1.4.9 -> 1.4.11`                      |
| [`76bbb97f`](https://github.com/NixOS/nixpkgs/commit/76bbb97fe5356e88af8344b7a3781d1159a753bd) | `rdma-core: 39.1 -> 40.0`                                           |
| [`a8a48a13`](https://github.com/NixOS/nixpkgs/commit/a8a48a133e59d96bf1e7760209c3446c34e3b480) | `home-assistant: update component-packages`                         |
| [`256d9e0a`](https://github.com/NixOS/nixpkgs/commit/256d9e0aabe2d0336509d03c5c4d5f9094d22603) | `python3Packages.pysaj: init at 0.0.16`                             |
| [`0f448413`](https://github.com/NixOS/nixpkgs/commit/0f448413007a0d72ed265c6ce63de73123020df8) | `gitleaks: 8.8.1 -> 8.8.2`                                          |
| [`84958d12`](https://github.com/NixOS/nixpkgs/commit/84958d12dc99c31eb39fd3db33bbce4085415ce7) | `speedometer: remove`                                               |
| [`a394a394`](https://github.com/NixOS/nixpkgs/commit/a394a39401236f06e7469323c5ef8a63dcedaa39) | `slurm: 21.08.6.1 -> 21.08.7.1`                                     |
| [`cfe0988e`](https://github.com/NixOS/nixpkgs/commit/cfe0988e481a669b257bcc4e0f2b33befe97a11f) | `update conda from 4.6.14 to 4.11.0`                                |
| [`d7315feb`](https://github.com/NixOS/nixpkgs/commit/d7315feb492efd00738d7dd62fa19076655f5644) | `uxplay: init at 1.50`                                              |
| [`98358994`](https://github.com/NixOS/nixpkgs/commit/983589949fb0bb7ac15ec75ebb7fcfc7ee1d7d94) | `vpnc: enable parallel building`                                    |
| [`0d92d898`](https://github.com/NixOS/nixpkgs/commit/0d92d898ed0baba5195b8dee0d4d45ed8dbb76cf) | `platformsh: init at v3.78.0`                                       |
| [`00b2f3d8`](https://github.com/NixOS/nixpkgs/commit/00b2f3d8a733ea8c19ede9a2bddc2508cad8ce00) | `python310Packages.lightwave2: 0.8.9 -> 0.8.14`                     |
| [`13977be6`](https://github.com/NixOS/nixpkgs/commit/13977be6e9b157935c092bdbdbf41cf882c23afc) | `git-review: 2.3.0 → 2.3.1`                                         |
| [`77b10ee9`](https://github.com/NixOS/nixpkgs/commit/77b10ee973d54f50acefdd971b55dacd7c3135ce) | `krane: 2.4.0 → 2.4.6`                                              |
| [`0972fd24`](https://github.com/NixOS/nixpkgs/commit/0972fd249445dfc7a8bd26726ee0885a144c01c5) | `pur: 5.4.2 -> 6.1.0`                                               |
| [`3c729e24`](https://github.com/NixOS/nixpkgs/commit/3c729e242bec0c4e28da74e4b2400a25e73b9bd3) | `sumneko-lua-language-server: fix build on darwin`                  |
| [`7f51b529`](https://github.com/NixOS/nixpkgs/commit/7f51b529169c277cd17b99a440cc31561c422973) | `scheme-manpages: 2021-03-11 -> 2022-04-21`                         |
| [`b4810256`](https://github.com/NixOS/nixpkgs/commit/b481025616b5873f1f15e253d384bce8363de9fe) | `amberol: init at 0.3.0`                                            |
| [`319d22ab`](https://github.com/NixOS/nixpkgs/commit/319d22ab467cf7548a19ac86db561959135d1a84) | `git-crypt: 0.6.0 -> 0.7.0`                                         |
| [`f83b8f10`](https://github.com/NixOS/nixpkgs/commit/f83b8f10b81dfbace259d16861a754285493c076) | `git-crypt: adopt`                                                  |
| [`6a5b8390`](https://github.com/NixOS/nixpkgs/commit/6a5b8390695068823f80131be4801297d963880e) | `usbrelay: init at 0.9`                                             |
| [`a9e951eb`](https://github.com/NixOS/nixpkgs/commit/a9e951eb88c93d92af0720046a36a91a06b84162) | `jsonb_deep_sum: init at unstable-2021-12-24`                       |
| [`b19b12d3`](https://github.com/NixOS/nixpkgs/commit/b19b12d33569c2bccabc1dd2d3046a9937f94c1c) | `asdf-vm: 0.9.0 -> 0.10.0`                                          |
| [`0d0feaa4`](https://github.com/NixOS/nixpkgs/commit/0d0feaa4fc281c6d79b7a8afb97237676a623d44) | `gcc{4..10}: add aarch64-darwin to badPlatforms`                    |
| [`81afd541`](https://github.com/NixOS/nixpkgs/commit/81afd541f99a6d1c9aea2ddbad642f8df0db1c18) | `lib/systems/inspect.nix: add isPower64`                            |
| [`104d8c8f`](https://github.com/NixOS/nixpkgs/commit/104d8c8f80cf0527f4e384e67ea6564d22a44e4e) | `ddnet: 16.0.2 -> 16.0.3`                                           |
| [`70f50a9d`](https://github.com/NixOS/nixpkgs/commit/70f50a9dfbbde9bdec0a91cccf347039009b8448) | `ddnet: 16.0.1 -> 16.0.2`                                           |
| [`6fabd819`](https://github.com/NixOS/nixpkgs/commit/6fabd819a05d748d657421ebdda301e2763d5f3b) | `ddnet: 16.0 -> 16.0.1`                                             |
| [`7212c1ac`](https://github.com/NixOS/nixpkgs/commit/7212c1acd99de059242333a411df2f8e468b7d2b) | `ddnet: 15.9.1 -> 16.0`                                             |
| [`57a136f6`](https://github.com/NixOS/nixpkgs/commit/57a136f61db6cb15e1ce39fe77b599df26453ab7) | `sasutils: init at 0.3.12`                                          |
| [`4f624718`](https://github.com/NixOS/nixpkgs/commit/4f62471862d1c1a03939c6588c189aef2eafb0b2) | `rmfuse: 0.2.1 -> 0.2.3`                                            |