### PR TITLE
chore(flake/nixpkgs): `e76c8952` -> `7f4a8f37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -130,11 +130,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650878143,
-        "narHash": "sha256-2jY3TLNMEBBdv2ndNQuvdRwtP3T4kodujm7Qout53qM=",
+        "lastModified": 1650923622,
+        "narHash": "sha256-M98iI5KKM5+JfBL94PMEwG1Ybs4+/2RFSgLpJU/XFLg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e76c8952c938d4b49e70e5e24f6d7568749c7b5d",
+        "rev": "7f4a8f37d4621b27fc0c4eeb3880ecf1cb055371",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`7f4a8f37`](https://github.com/NixOS/nixpkgs/commit/7f4a8f37d4621b27fc0c4eeb3880ecf1cb055371) | `jitsi-meet-electron: respect NIXOS_OZONE_WL (#170304)`                  |
| [`26f5f9c6`](https://github.com/NixOS/nixpkgs/commit/26f5f9c6e32b8149887f60f0d570ac8d5c9b2e2a) | `home-assistant: update component-packages`                              |
| [`766646b0`](https://github.com/NixOS/nixpkgs/commit/766646b0f28a39c4e8b593c61211b4db4987d013) | `python3Packages.pyoppleio: init at 1.0.6`                               |
| [`a2801d43`](https://github.com/NixOS/nixpkgs/commit/a2801d435b5d825e633066a3ee2f8fa84976ce92) | `home-assistant: update component-packages`                              |
| [`3e213d5f`](https://github.com/NixOS/nixpkgs/commit/3e213d5f38b8b984b0c4c751cb2c4ccab824701f) | `python3Packages.hkavr: init at 0.0.5`                                   |
| [`b511a75c`](https://github.com/NixOS/nixpkgs/commit/b511a75cb908aea3b157e9b138281f01f49e4745) | `home-assistant: update component-packages`                              |
| [`cb610be2`](https://github.com/NixOS/nixpkgs/commit/cb610be2a0950efe7688872e1aa3d360abdce5eb) | `python3Packages.pencompy: init at 0.0.4`                                |
| [`ca47537b`](https://github.com/NixOS/nixpkgs/commit/ca47537b9d4293233783e27180fa7fa6d90e40bd) | `python3Packages.neo4j-driver: 4.4.2 -> 4.4.3`                           |
| [`d7ebbcde`](https://github.com/NixOS/nixpkgs/commit/d7ebbcde879a0b1808e185fb662f20f8ed7b2538) | `pulumi-bin: 3.29.1 -> 3.30.0`                                           |
| [`7cee7f98`](https://github.com/NixOS/nixpkgs/commit/7cee7f985e252cb34b72d9d75aab31ce692ed5b0) | `fwupd: 1.7.6 -> 1.7.7`                                                  |
| [`1d395b2c`](https://github.com/NixOS/nixpkgs/commit/1d395b2c9a82a8bca6f7f67640641c73e833f3d4) | `python3Packages.seventeentrack: 2022.04.5 -> 2022.04.6`                 |
| [`3a52ece9`](https://github.com/NixOS/nixpkgs/commit/3a52ece9da409dcd9377a5f4b757c29811902f1e) | `vault-bin: 1.10.0 -> 1.10.1`                                            |
| [`a0a3c850`](https://github.com/NixOS/nixpkgs/commit/a0a3c85083ced9c00eac2ccb072fd3088ead3c6e) | `ledger-udev-rules: 2019-05-30 -> 2021-09-10`                            |
| [`bbf502a6`](https://github.com/NixOS/nixpkgs/commit/bbf502a6b09fc3d541855900af09513de7344f47) | `libnftnl: update homepage to https`                                     |
| [`3ee2e79f`](https://github.com/NixOS/nixpkgs/commit/3ee2e79f5d2084d02b6b79134c1fd3dc404c1976) | `python310Packages.aioftp: 0.21.0 -> 0.21.2`                             |
| [`aedd51b0`](https://github.com/NixOS/nixpkgs/commit/aedd51b084df24886ed8222b3b63b322ac1a1fbf) | `python310Packages.asciimatics: 1.13.0 -> 1.14.0`                        |
| [`f8e483d8`](https://github.com/NixOS/nixpkgs/commit/f8e483d87a371c6dc26263df37fb1922830c1cb6) | `python310Packages.amply: 0.1.4 -> 0.1.5`                                |
| [`304d78ce`](https://github.com/NixOS/nixpkgs/commit/304d78cec6b97ffe4734cba3a181c633339bdcc4) | `n8n: 0.173.1 → 0.174.0`                                                 |
| [`eca073f6`](https://github.com/NixOS/nixpkgs/commit/eca073f6e50b0c3a882559aea71aae975704ad73) | `azure-cli: pin azure-mgmt-servicelinker`                                |
| [`97f1222d`](https://github.com/NixOS/nixpkgs/commit/97f1222dc764c7e10743fe5e720e6771032545cd) | `gnome.gnome-music: 42.0 → 42.1`                                         |
| [`4679e06c`](https://github.com/NixOS/nixpkgs/commit/4679e06cfb21c4cc4f89444b52fdb83d8352b8d0) | `python310Packages.deezer-python: 5.3.0 -> 5.3.1`                        |
| [`7ff11b66`](https://github.com/NixOS/nixpkgs/commit/7ff11b66e5d7e048b0fce90216f44c7ee0910071) | `python3Packages.dropbox: Add sfrijters as maintainer`                   |
| [`484a6779`](https://github.com/NixOS/nixpkgs/commit/484a67794d97e1a118730a29cb14bfd22130c859) | `python310Packages.coqpit: 0.0.15 -> 0.0.16`                             |
| [`69eeae8d`](https://github.com/NixOS/nixpkgs/commit/69eeae8d53880576b05ac0dcf3a639968f5199a1) | `goreleaser: 1.8.1 -> 1.8.3`                                             |
| [`babdc25b`](https://github.com/NixOS/nixpkgs/commit/babdc25b1aaa005262b42ae48f04cc4443abcf50) | `oh-my-zsh: 2022-04-19 -> 2022-04-22 (#169921)`                          |
| [`a40607f7`](https://github.com/NixOS/nixpkgs/commit/a40607f7afa163c7ad89715b2aaa76c82e59cd00) | `cpufetch: update meta.license`                                          |
| [`ad3a396e`](https://github.com/NixOS/nixpkgs/commit/ad3a396ee694940f00f7356d41090ccb395672df) | `vscode-extensions.pkief.material-icon-theme: 4.14.1 -> 4.16.0`          |
| [`8a31cb6e`](https://github.com/NixOS/nixpkgs/commit/8a31cb6e479f08dad1b2dd4521aab84201c6b4f7) | `vscode-extensions.ms-azuretools.vscode-docker: 1.20.0 -> 1.22.0`        |
| [`5bbdf1dd`](https://github.com/NixOS/nixpkgs/commit/5bbdf1dd3355760b3fb7cf9812695aea480296d1) | `vscode-extensions.johnpapa.vscode-peacock: 4.0.0 -> 4.0.1`              |
| [`ea81084e`](https://github.com/NixOS/nixpkgs/commit/ea81084e526248555ed43ce86c647fb61e186e80) | `vscode-extensions.esbenp.prettier-vscode: 9.3.0 -> 9.5.0`               |
| [`68e9b54c`](https://github.com/NixOS/nixpkgs/commit/68e9b54c50867735e85a840fadd278eb025fb7bf) | `vscode-extensions.eamodio.gitlens: 12.0.3 -> 12.0.6`                    |
| [`19f5cc6e`](https://github.com/NixOS/nixpkgs/commit/19f5cc6ee7bc9b9615a2a8a27cabcb1d906c344c) | `vscode-extensions.davidanson.vscode-markdownlint: 0.46.0 -> 0.47.0`     |
| [`a14a51f4`](https://github.com/NixOS/nixpkgs/commit/a14a51f4172b3217aa8342e07168d84fc6fc85f0) | `devspace: init at 5.18.4`                                               |
| [`1a9e59ac`](https://github.com/NixOS/nixpkgs/commit/1a9e59acb740170445dc5d7f5c11d72c32d85e3f) | `clementine: 1.4.0rc1 -> unstable-2022-04-11`                            |
| [`b4a661a4`](https://github.com/NixOS/nixpkgs/commit/b4a661a46740e56cedf85a35beffd97050515215) | `mepo: 0.3 -> 0.4.1`                                                     |
| [`c3c33251`](https://github.com/NixOS/nixpkgs/commit/c3c33251e2894d05e3fb7ff3bb7857f543f09055) | `Grafana Mimir: Add maintainers`                                         |
| [`0e29eb34`](https://github.com/NixOS/nixpkgs/commit/0e29eb34e21d86fb3a1cc39c251f8e768e5be277) | `Grafana Mimir: init at v2.0.0`                                          |
| [`795cd447`](https://github.com/NixOS/nixpkgs/commit/795cd44716f1885febec24a4ecc392baca531184) | `libechonest: fix build with gcc 11`                                     |
| [`0d56b692`](https://github.com/NixOS/nixpkgs/commit/0d56b692fa0531c16160f60a64bc3f482a3d98fe) | `gromacs: 2022 -> 2022.1`                                                |
| [`5838726c`](https://github.com/NixOS/nixpkgs/commit/5838726cb99855821d1f465d90a2f9aa9d716750) | `calculix: 2.17 -> 2.19`                                                 |
| [`94f12251`](https://github.com/NixOS/nixpkgs/commit/94f1225197c156725f8d218416e4471462b71010) | `calculix: fix build with gfortran 10`                                   |
| [`570591c4`](https://github.com/NixOS/nixpkgs/commit/570591c456d32bd5fc6fa284a8a8bcc6e4cfc599) | `gnome.gvfs: 1.50.0 -> 1.50.1`                                           |
| [`cad0ef2f`](https://github.com/NixOS/nixpkgs/commit/cad0ef2f059fa9c9a84d4eaa68c161ed2ab02177) | `libadwaita: 1.1.0 -> 1.1.1`                                             |
| [`2d928b6c`](https://github.com/NixOS/nixpkgs/commit/2d928b6c61397c48cf3eef5d9cdec4ec4fffa2d0) | `kabeljau: init at 1.0.1 (#168930)`                                      |
| [`7c4d42ca`](https://github.com/NixOS/nixpkgs/commit/7c4d42ca7720da83c3d1484c5f1b8fff29032b35) | `gnome-text-editor: 42.0 -> 42.1`                                        |
| [`ca3dae7c`](https://github.com/NixOS/nixpkgs/commit/ca3dae7c22aa554460ebf325c2879aaec2536ddb) | `gnome.gnome-remote-desktop: 42.0 -> 42.1`                               |
| [`4983d550`](https://github.com/NixOS/nixpkgs/commit/4983d550e4ee5531aced18344a160c41800195e0) | `gnome.eog: 42.0 -> 42.1`                                                |
| [`1606016e`](https://github.com/NixOS/nixpkgs/commit/1606016efdcc49e3f0636da44b81bc93c318d83f) | `gnome.nautilus: 42.0 -> 42.1.1`                                         |
| [`8b62eae0`](https://github.com/NixOS/nixpkgs/commit/8b62eae04069ef0cd821f91759ad11d5ef94261d) | `evolution-data-server: 3.44.0 -> 3.44.1`                                |
| [`01a46a98`](https://github.com/NixOS/nixpkgs/commit/01a46a981727d5c04b21cd841667d0d5f198c787) | `python3Packages.collections-extended: add missing input`                |
| [`fac3deee`](https://github.com/NixOS/nixpkgs/commit/fac3deeeddfaa7616b4ddac36f6803ec0101180d) | `python3Packages.aiohttp-swagger: don't use custom client for tests`     |
| [`25251762`](https://github.com/NixOS/nixpkgs/commit/25251762f7bdb352b8917f94862329edd9f5c6b4) | `python3Packages.aiohttp-remotes: set pytest flags`                      |
| [`880071b4`](https://github.com/NixOS/nixpkgs/commit/880071b4cffab3c3693685669344334a2315d4e4) | `python3Packages.ansible-later: 2.0.9 -> 2.0.10`                         |
| [`8037d235`](https://github.com/NixOS/nixpkgs/commit/8037d235e25607c2b8f8da41a5daf37ef122acb4) | `bctoolbox: fix cross-compilation`                                       |
| [`d3ea1663`](https://github.com/NixOS/nixpkgs/commit/d3ea16638bdfa59ef47ffebe438052c08ff91831) | `python3Packages.ansible-doctor: 1.2.1 -> 1.2.4`                         |
| [`fb838c9d`](https://github.com/NixOS/nixpkgs/commit/fb838c9d1a41fdabe97d128ba1f58f5c1c931425) | `bingo: 0.5.2 -> 0.6.0`                                                  |
| [`48bf204a`](https://github.com/NixOS/nixpkgs/commit/48bf204a58938376d6f6e2136d89878b9afcda7d) | `gbl: init at 0.3.1`                                                     |
| [`d11118ec`](https://github.com/NixOS/nixpkgs/commit/d11118ecfbc06f02a93a4ce94aa6b519197e77b0) | `flyctl: 0.0.320 -> 0.0.323`                                             |
| [`eabc6334`](https://github.com/NixOS/nixpkgs/commit/eabc63347375c00eb35b88ad9d5833b5c9df96d3) | `python3Packages.aws-adfs: update substituteInPlace`                     |
| [`6fe8ff98`](https://github.com/NixOS/nixpkgs/commit/6fe8ff983e26ae90bc66253df12ebb441a464af7) | `python3Packages.apsw: fix tests, add gador as maintainer`               |
| [`99413d0f`](https://github.com/NixOS/nixpkgs/commit/99413d0f20a9d90db4ec1327553f16564610a86b) | `cpufetch: 1.01 -> 1.02`                                                 |
| [`6ef74142`](https://github.com/NixOS/nixpkgs/commit/6ef74142ebc6451320c3af2e3ae77b871a07a274) | `archivy: 1.7.1 -> 1.7.2`                                                |
| [`4dd38e1b`](https://github.com/NixOS/nixpkgs/commit/4dd38e1b456965296ee16d56ea0c6d9ded493ac3) | `osu-lazer: update dependencies`                                         |
| [`58c8e4c8`](https://github.com/NixOS/nixpkgs/commit/58c8e4c8c0a82c1de690226af5eb4153a7c495e6) | `osu-lazer: fix update.sh script`                                        |
| [`46f5fd8c`](https://github.com/NixOS/nixpkgs/commit/46f5fd8cfd8e660796a60e394a98de3df491c926) | `eksctl: 0.93.0 -> 0.94.0`                                               |
| [`5f441966`](https://github.com/NixOS/nixpkgs/commit/5f4419669239b6fe391130fb1cd0368e9d3626b7) | `ArchiSteamFarm: update dependencies`                                    |
| [`8a67b740`](https://github.com/NixOS/nixpkgs/commit/8a67b74064ec8e423cfd3d5724774a108befe544) | `ryujinx: update dependencies`                                           |
| [`6c3e18f7`](https://github.com/NixOS/nixpkgs/commit/6c3e18f759ce234b43f919779ab6bea44f12ace4) | `omnisharp-roslyn: update dependencies`                                  |
| [`3570e5bf`](https://github.com/NixOS/nixpkgs/commit/3570e5bf40f3c097cbfed67cf185487c7116b8f5) | `inklecate: update dependencies`                                         |
| [`c40790c7`](https://github.com/NixOS/nixpkgs/commit/c40790c7232625cee78a9770ab21282d270f0825) | `github-runner: update dependencies`                                     |
| [`604b9fed`](https://github.com/NixOS/nixpkgs/commit/604b9fed209049e013df8d24c85f491b0f5e06f6) | `dotnet-sdk: 6.0.201 -> 6.0.202`                                         |
| [`c98f0a46`](https://github.com/NixOS/nixpkgs/commit/c98f0a46f3cdf70e885cf972d07823202d314b1b) | `dasel: 1.24.1 -> 1.24.3`                                                |
| [`6cab7fb1`](https://github.com/NixOS/nixpkgs/commit/6cab7fb12d3fc59955f396ddc3855999fb94e832) | `atuin: 0.8.1 -> 0.9.1`                                                  |
| [`abc28679`](https://github.com/NixOS/nixpkgs/commit/abc2867933b2a5f8263f7570877d77be77b1eb7a) | `apkeep: 0.10.0 -> 0.11.0`                                               |
| [`b7ed282b`](https://github.com/NixOS/nixpkgs/commit/b7ed282b365e565cdcb82d923c8a989894cbd601) | `ibus: remove python2 library option`                                    |
| [`13961618`](https://github.com/NixOS/nixpkgs/commit/13961618532f97c7770a929fba7563f88a850558) | `zoxide: 0.8.0 -> 0.8.1`                                                 |
| [`7d79c0d2`](https://github.com/NixOS/nixpkgs/commit/7d79c0d22a874efe1c39e7e97f722020e8462118) | `python310Packages.intensity-normalization: mark broken`                 |
| [`a01811ab`](https://github.com/NixOS/nixpkgs/commit/a01811ab3b9b08773b53bc3fbfd9feef431a8460) | `nomad_1_1: 1.1.8 -> 1.1.12`                                             |
| [`dc4b2812`](https://github.com/NixOS/nixpkgs/commit/dc4b2812e4c1b24f08349d4fdf23a8d85e0575a4) | `nixos/stage-1-systemd: Also accept packages as store paths`             |
| [`592f5036`](https://github.com/NixOS/nixpkgs/commit/592f50365de901aa6007883cd30691e6f0efcf6b) | `libhandy: fix enableGlade build`                                        |
| [`e93ac26f`](https://github.com/NixOS/nixpkgs/commit/e93ac26f47f32d2815ed1ec8333aefe7fcb5413b) | `libhandy: 1.6.1 -> 1.6.2`                                               |
| [`6a666dbe`](https://github.com/NixOS/nixpkgs/commit/6a666dbecdabf8de9b792edca8a865bbb04a5d9d) | `gnome.gnome-maps: 42.0 → 42.1`                                          |
| [`1d24939a`](https://github.com/NixOS/nixpkgs/commit/1d24939a9a16f356923ca9403b2d90fa19da8036) | `git-machete: 3.8.0 -> 3.9.0`                                            |
| [`08d41ae3`](https://github.com/NixOS/nixpkgs/commit/08d41ae317d1f1d7db672776957212e9f3fb2fc6) | `vapoursynth: R57 -> R58`                                                |
| [`63e04ef9`](https://github.com/NixOS/nixpkgs/commit/63e04ef92442e57ae786bcb479dcea3007de5c12) | `irpf: fixed login bug`                                                  |
| [`aa534e38`](https://github.com/NixOS/nixpkgs/commit/aa534e38696adb411e5c628e8ba1f5ab5fafc03d) | `obs-vkcapture: init at 1.1.3`                                           |
| [`6b694a5f`](https://github.com/NixOS/nixpkgs/commit/6b694a5feecf894d9baad5b60db697133b310cbd) | `dagger: 0.2.6 -> 0.2.7`                                                 |
| [`e3025623`](https://github.com/NixOS/nixpkgs/commit/e3025623e6de3731112d95ae482900df65a7a49d) | `coc-haxe: init at 0.8.0`                                                |
| [`d1c3fea7`](https://github.com/NixOS/nixpkgs/commit/d1c3fea7ecbed758168787fe4e4a3157e52bc808) | `dcm2niix: support usage of suggested Cloudflare zlib`                   |
| [`9019ce01`](https://github.com/NixOS/nixpkgs/commit/9019ce010601fcd8dff20b1e996a19eccc7b60ec) | `dcm2niix: add maintainer`                                               |
| [`e097044b`](https://github.com/NixOS/nixpkgs/commit/e097044b9209742dfd4b23dcb36726d531a44a65) | `nixos/kexec-boot: auto-detect the right kernel name to support aarch64` |
| [`78a6caa5`](https://github.com/NixOS/nixpkgs/commit/78a6caa5f808538a0fcae6d02f4eeb3dd2037be0) | `nixosTests.kexec: better test if we are in a new system`                |
| [`4de5a2f7`](https://github.com/NixOS/nixpkgs/commit/4de5a2f79a874ee8c71bde69fe52c48c4fe85896) | `openai: 0.18.0 -> 0.18.1`                                               |
| [`b71ff4c6`](https://github.com/NixOS/nixpkgs/commit/b71ff4c656321c2a771b0453a21418ddc0d6d8f2) | `asterisk: add support for open-source opus codec`                       |
| [`8fde5025`](https://github.com/NixOS/nixpkgs/commit/8fde5025c30a0e62632b8280630f1e808a41e9eb) | `phosh: 0.16.0 -> 0.17.0`                                                |
| [`10bb7d69`](https://github.com/NixOS/nixpkgs/commit/10bb7d6911b0feeedf3816ed7f80fa2e4567dfe1) | `cldr-emoji-annotation: drop`                                            |
| [`fcd9db43`](https://github.com/NixOS/nixpkgs/commit/fcd9db43682097fe586737bc9a2c1560ca9e312f) | `fcitx5: move from cldr-emoji-annotation to cldr-annotations`            |
| [`09b7444b`](https://github.com/NixOS/nixpkgs/commit/09b7444b82827acbd89970997ebc11b5e59558e6) | `dcm2niix: add support for configuring optional compile-time modules`    |
| [`62d781f0`](https://github.com/NixOS/nixpkgs/commit/62d781f09be7bc526e89a6b9bb7ed432dc33df15) | `tests.pkgs-lib: Fix for darwin`                                         |
| [`337c72b5`](https://github.com/NixOS/nixpkgs/commit/337c72b5cde3a034e92cc6c99865869774be7d47) | `pkgs.formats.javaProperties: Add type coercions`                        |
| [`46156529`](https://github.com/NixOS/nixpkgs/commit/46156529f2682412b8867f7bc40b32b350a00bd9) | `tests.pkgs-lib.formats: Allow strings with context in test runner`      |
| [`614cef92`](https://github.com/NixOS/nixpkgs/commit/614cef9232d0985fa0c833ce13196c0f3d567f6f) | `redis-plus-plus: init at 1.3.3`                                         |
| [`c2c95b88`](https://github.com/NixOS/nixpkgs/commit/c2c95b8851528475f742eaaef323771e7adc4f87) | `libyang: 2.0.112 -> 2.0.164`                                            |
| [`00c7a8ee`](https://github.com/NixOS/nixpkgs/commit/00c7a8ee424c2702951e83136577b71a058d618b) | `caprine-bin: init at 2.55.2`                                            |