### PR TITLE
chore(flake/nixpkgs): `7f4a8f37` -> `2975ad11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -130,11 +130,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650923622,
-        "narHash": "sha256-M98iI5KKM5+JfBL94PMEwG1Ybs4+/2RFSgLpJU/XFLg=",
+        "lastModified": 1651008161,
+        "narHash": "sha256-BrX9mEs7QOegsk61xje8yS8RYglZnilcvZNjX8Wt77s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7f4a8f37d4621b27fc0c4eeb3880ecf1cb055371",
+        "rev": "2975ad119528863d4bdb28bc160c9072e39b1c02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                       |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`2975ad11`](https://github.com/NixOS/nixpkgs/commit/2975ad119528863d4bdb28bc160c9072e39b1c02) | `duply: 2.3.1 -> 2.4`                                                |
| [`e10da1c7`](https://github.com/NixOS/nixpkgs/commit/e10da1c7f542515b609f8dfbcf788f3d85b14936) | `gh: 2.8.0 -> 2.9.0`                                                 |
| [`69d1acda`](https://github.com/NixOS/nixpkgs/commit/69d1acda00eddcfe51292f69ffea231925c5f66e) | `nixos/xfs: Fix evaluation (#170471)`                                |
| [`54e79570`](https://github.com/NixOS/nixpkgs/commit/54e795706d9fa90004ed1274af639a717f04a2aa) | `emacs: Build from git instead of tarball to fix native compilation` |
| [`7142b03e`](https://github.com/NixOS/nixpkgs/commit/7142b03eb735e7aa86fd02d6f22abbe8cd0deab6) | `python3Packages.pytorch-metric-learning: mark as broken`            |
| [`1fbd9216`](https://github.com/NixOS/nixpkgs/commit/1fbd921649561a3f811c8750b6b19cd6ce5cecc6) | `opensmtpd: support cross compile (#170379)`                         |
| [`e1d79576`](https://github.com/NixOS/nixpkgs/commit/e1d795764a13cc588492731973e4fcd8fe0eb4e8) | `jitsi-meet-electron: 2022.1.1 -> 2022.3.1 (#170303)`                |
| [`7665c2e5`](https://github.com/NixOS/nixpkgs/commit/7665c2e599ee8247d662de92d9412931c626b053) | `vouch-proxy: 0.36.0 -> 0.37.0`                                      |
| [`e374150e`](https://github.com/NixOS/nixpkgs/commit/e374150e4a31efe3a2677458aed7723155802136) | `nix-eval-jobs: 0.0.5 -> 0.0.6`                                      |
| [`97c0c426`](https://github.com/NixOS/nixpkgs/commit/97c0c426746c36e2d656663f47fe6c978c2b93ae) | `corerad: 1.1.2 -> 1.2.0`                                            |
| [`725c990d`](https://github.com/NixOS/nixpkgs/commit/725c990db09b4c887b2cce157cfc78ae8d69c64d) | `barrier: pick up new commit to fix compilation`                     |
| [`38aec67f`](https://github.com/NixOS/nixpkgs/commit/38aec67f6a93a654688c713da89d6f76afdd3948) | `fix missing throwSystem on src`                                     |
| [`d5b4effe`](https://github.com/NixOS/nixpkgs/commit/d5b4effe828646683d9020bca361bc8a29e817d1) | `update comment`                                                     |
| [`f2ff2227`](https://github.com/NixOS/nixpkgs/commit/f2ff2227a980e531d10fe4e219a19f0fa609f942) | `Remove unnecessary conditional`                                     |
| [`fae6e0dd`](https://github.com/NixOS/nixpkgs/commit/fae6e0ddb013f16227add2356ddf4270e7f3745a) | `throw unsupported system in installPhase`                           |
| [`3211c5f6`](https://github.com/NixOS/nixpkgs/commit/3211c5f62879e7a66925292c6a765f9cb9a5573b) | `false preferred over null on dontUnpack`                            |
| [`3c0367bc`](https://github.com/NixOS/nixpkgs/commit/3c0367bcc2e5356657fb598254437ba3f1deb690) | `wp4nix: init at 1.0.0`                                              |
| [`74d938f1`](https://github.com/NixOS/nixpkgs/commit/74d938f11966446d25585821d96551f7f84b086d) | `hcloud: fix version ldflag`                                         |
| [`67db991f`](https://github.com/NixOS/nixpkgs/commit/67db991f17d459a81f2e312233c6af0394e45b56) | `vapoursynth: fix nix search version parsing`                        |
| [`32a1b56a`](https://github.com/NixOS/nixpkgs/commit/32a1b56a7435c49650d4461eea854b6bfae3b09f) | `vapoursynth: reduce with usage`                                     |
| [`ab968d7d`](https://github.com/NixOS/nixpkgs/commit/ab968d7dd0df4f13d7ff1ae6d4794950a55c63f7) | `assaultcube: 1.2.0.2 -> 1.3.0.2`                                    |
| [`ca3c297d`](https://github.com/NixOS/nixpkgs/commit/ca3c297d867f59859ba464c5b818086385b76e8c) | `simpleitk: move headers to dev output (#170165)`                    |
| [`ec2c6af0`](https://github.com/NixOS/nixpkgs/commit/ec2c6af0f1a5a09c202ca9436bcdad8d80f86034) | `wmii: hg-2012-12-09 -> unstable-2022-04-04`                         |
| [`eb1bc95c`](https://github.com/NixOS/nixpkgs/commit/eb1bc95c2d886a13e16cc6d0469c7405bd296373) | `caddy: 2.4.6 -> 2.5.0`                                              |
| [`786a6094`](https://github.com/NixOS/nixpkgs/commit/786a6094962bae771c9f7f085deefd0a7e157876) | `ranger: add optional python dependencies (#170328)`                 |
| [`7fe8c7fd`](https://github.com/NixOS/nixpkgs/commit/7fe8c7fd43743178c7681e87b5cddfef774b85c8) | `python3Packages.svdtools: remove stale substituteInPlace`           |
| [`debfa672`](https://github.com/NixOS/nixpkgs/commit/debfa6723c4affb080fcf1ce74d166aba5414f50) | `python3Packages.boxx: disable on older Python releases`             |
| [`9d15d462`](https://github.com/NixOS/nixpkgs/commit/9d15d4620b0e559020f89c768d38096b22b6e58d) | `evolution: 3.44.0 -> 3.44.1`                                        |
| [`68322e12`](https://github.com/NixOS/nixpkgs/commit/68322e1297ce606a37622186c85c7b60dd336a1c) | `coqPackages.mathcomp-word: 1.0 → 1.1`                               |
| [`0872d0d8`](https://github.com/NixOS/nixpkgs/commit/0872d0d82ea419bda0330ffc15121dfee4995285) | `terraform-providers.buildkite: init at v0.8.0 (#170405)`            |
| [`7e2dc25c`](https://github.com/NixOS/nixpkgs/commit/7e2dc25cd1150e63a98d1c1dd83313b8286e487a) | `python310Packages.boxx: 0.9.11 -> 0.10.0`                           |
| [`45ec327c`](https://github.com/NixOS/nixpkgs/commit/45ec327c04e358363d2aa4882aa365c703857357) | `python310Packages.svdtools: 0.1.21 -> 0.1.22`                       |
| [`82fbd081`](https://github.com/NixOS/nixpkgs/commit/82fbd08191e65e8ab21cf37efff9510537454c47) | `python310Packages.mocket: 3.10.4 -> 3.10.5`                         |
| [`12c59672`](https://github.com/NixOS/nixpkgs/commit/12c596725d142c64e364c32456eb0d7cd1d39485) | `python3Packages.ansible-compat: use ansible-core`                   |
| [`19b27559`](https://github.com/NixOS/nixpkgs/commit/19b2755900038866fe20888e4503573059816136) | `python3Packages.ansible-runner: use ansible-core`                   |
| [`813330fa`](https://github.com/NixOS/nixpkgs/commit/813330fa92cd8a9e5c8b38fd9f2d020334566e24) | `kargo: use ansible-core`                                            |
| [`198793be`](https://github.com/NixOS/nixpkgs/commit/198793be2dd136b1ee7a67119d7ba4808389c00a) | `python3Packages.pytest-ansible: mark broken with ansible>=2.10`     |
| [`7fb99b72`](https://github.com/NixOS/nixpkgs/commit/7fb99b7216002dfbd8bf1b5d5bdf4a829e1a1650) | `python3Packages.labgrid: add packaging module`                      |
| [`e6194ec4`](https://github.com/NixOS/nixpkgs/commit/e6194ec45c9f44745c3e1979d4fc535a64d7156e) | `python310Packages.ansible-later: 2.0.10 -> 2.0.11`                  |
| [`0f946e28`](https://github.com/NixOS/nixpkgs/commit/0f946e28754e1da24d373fe9c64b89b51acb3463) | `ansible: prune old versions; restructure`                           |
| [`89f390a4`](https://github.com/NixOS/nixpkgs/commit/89f390a40b79bcf2170c4060540a5392c8d1a06a) | `mmark: 1.3.6 -> 2.2.25`                                             |
| [`7fadb8fb`](https://github.com/NixOS/nixpkgs/commit/7fadb8fb78260a2025d24b60b632289f608f8680) | `session-desktop-appimage: 1.7.9 -> 1.8.4`                           |
| [`0c922b4e`](https://github.com/NixOS/nixpkgs/commit/0c922b4ea680ff2fa2d7c120c0eaea32694f7eb0) | `evtest: update sha256 hash`                                         |
| [`dd4ca36a`](https://github.com/NixOS/nixpkgs/commit/dd4ca36aac752f0b15824b241343d8d7bb0ac006) | `natscli: 0.0.30 -> 0.0.32`                                          |
| [`2be43f13`](https://github.com/NixOS/nixpkgs/commit/2be43f13935d1e65718f3453d4159bf66c2c4f6f) | `python3Packages.winsspi: disable on older Python releases`          |
| [`162ea08a`](https://github.com/NixOS/nixpkgs/commit/162ea08aab1a156308a6f35bec867479da5be4b4) | `python310Packages.pypykatz: 0.5.6 -> 0.5.7`                         |
| [`c7352fbc`](https://github.com/NixOS/nixpkgs/commit/c7352fbc0eba3f2d7d06a429e997cb3a5b53c603) | `python310Packages.winsspi: 0.0.9 -> 0.0.10`                         |
| [`48d473f1`](https://github.com/NixOS/nixpkgs/commit/48d473f1c319157f85a1e22cd1e16e8831c81227) | `upower: fix cross-compilation support`                              |
| [`bea03532`](https://github.com/NixOS/nixpkgs/commit/bea03532b9a185ff62ae4540ebf6999eea407747) | `python3Packages.mkdocs-material: disable on older Python releases`  |
| [`b491eacf`](https://github.com/NixOS/nixpkgs/commit/b491eacf7fa61cefdf0bfe35fe70ca6e6085ee78) | `python3Packages.jeepney: 0.7.1 -> 0.8.0`                            |
| [`05a6bcb7`](https://github.com/NixOS/nixpkgs/commit/05a6bcb708967bb6ceff019207c607c253612cf5) | `python310Packages.pyoppleio: 1.0.6 -> 1.0.7`                        |
| [`3a27c7fe`](https://github.com/NixOS/nixpkgs/commit/3a27c7fe7083b752bf62bd3936ae7fa80a6f71ff) | `clucene_core_2: fix cross compile`                                  |
| [`7859b5e8`](https://github.com/NixOS/nixpkgs/commit/7859b5e8f7671af4c276a98833af40ea45f38090) | `upgrade ansible collections to 5.6.0`                               |
| [`2866c3f4`](https://github.com/NixOS/nixpkgs/commit/2866c3f4cab5322b17a8c8324fb032ac5ed294fb) | `upgrade ansible-core to 2.12.5`                                     |
| [`6885610b`](https://github.com/NixOS/nixpkgs/commit/6885610b2044bd9a5ac1e4fedec199cc2a16ce5d) | `python310Packages.glcontext: 2.3.5 -> 2.3.6`                        |
| [`01edd1a4`](https://github.com/NixOS/nixpkgs/commit/01edd1a40921de1053b97d300683e8dea6fbc010) | `pure-maps: 2.9.2 -> 3.0.0`                                          |
| [`84f4037e`](https://github.com/NixOS/nixpkgs/commit/84f4037e741679291d4075a158cf390f70a99e5d) | `libsForQt5.mapbox-gl-qml: 1.7.7.1 -> 2.0.1`                         |
| [`492cb7ef`](https://github.com/NixOS/nixpkgs/commit/492cb7efa0c50651590eb3acbed32e446cc3a5ca) | `libsForQt5.maplibre-gl-native: init at unstable-2022-04-07`         |
| [`7c01ec62`](https://github.com/NixOS/nixpkgs/commit/7c01ec626b2a5cb398b192f639e5b4387ab32570) | `tmuxp: 1.9.2 -> 1.11.0`                                             |
| [`73884e5f`](https://github.com/NixOS/nixpkgs/commit/73884e5fb18cd63e89903327729e0f9d874e42fd) | `libtmux: 0.10.3 -> 0.11.0`                                          |
| [`5283e2c5`](https://github.com/NixOS/nixpkgs/commit/5283e2c5ed2780b13c438509c44b769a49953bd5) | `libtmux: avoid passing pkgs as input`                               |
| [`5f5f908c`](https://github.com/NixOS/nixpkgs/commit/5f5f908cdea6565a5c754e2f0e7e9cf8332e323c) | `python3Packages.rapidfuzz: 2.0.8 -> 2.0.11`                         |
| [`a4ba2bd9`](https://github.com/NixOS/nixpkgs/commit/a4ba2bd977433708a0be3e2c51b5eabfa2ac9c3d) | `jarowinkler-cpp: init at 1.0.0`                                     |
| [`463ca4ee`](https://github.com/NixOS/nixpkgs/commit/463ca4ee100b3a2f7ca7afb9ea2b51314ade293b) | `rapidfuzz-cpp: init at 1.0.1`                                       |
| [`4fabde08`](https://github.com/NixOS/nixpkgs/commit/4fabde08f941424dc033e6c983af2436123d3cf9) | `taskflow: init at 3.3.0`                                            |
| [`df2e1177`](https://github.com/NixOS/nixpkgs/commit/df2e11770d0797853a5f77ecf48096533091ca65) | `python310Packages.mypy-boto3-s3: 1.21.34 -> 1.22.0.post1`           |
| [`5c63410e`](https://github.com/NixOS/nixpkgs/commit/5c63410e0eb6bb61804abfeabefa7bdcc32153e3) | `python3Packages.pycoolmasternet-async: 0.1.2 -> 0.1.3`              |
| [`9e39f6ea`](https://github.com/NixOS/nixpkgs/commit/9e39f6eae2b1aad269142191e858010c18869553) | `python3Packages.aprslib: 0.7.0 -> 0.7.1`                            |
| [`d21c94cd`](https://github.com/NixOS/nixpkgs/commit/d21c94cd35ab90d237a768cbce4a1376c339f705) | `python3Packages.pikepdf: 5.1.1 -> 5.1.2`                            |
| [`bdfa16df`](https://github.com/NixOS/nixpkgs/commit/bdfa16df6c41e54f20f00ef7dc029b358488c76d) | `ytfzf: 2.2 -> 2.3`                                                  |
| [`5c0ff7c3`](https://github.com/NixOS/nixpkgs/commit/5c0ff7c3d993130cdc0e132d0a7a146390618ea2) | `python310Packages.hahomematic: 1.1.4 -> 1.1.5`                      |
| [`4d12f939`](https://github.com/NixOS/nixpkgs/commit/4d12f939d4cd5e7cde66a5a92363d6cb61b7ca9a) | `cypress: 9.5.4 -> 9.6.0`                                            |
| [`293a5455`](https://github.com/NixOS/nixpkgs/commit/293a5455f31039a590cca0b844d134736fedae46) | `python310Packages.ffcv: fix build (#170158)`                        |
| [`c0212333`](https://github.com/NixOS/nixpkgs/commit/c0212333c618ab675bd31424706f9fc0c8351673) | `python310Packages.mkdocs-material: 8.2.9 -> 8.2.11`                 |
| [`579330cb`](https://github.com/NixOS/nixpkgs/commit/579330cb448161937f620a307983e78ce2ba3842) | `pouf: init at 0.4.1 (#170330)`                                      |
| [`d59a5a9f`](https://github.com/NixOS/nixpkgs/commit/d59a5a9f1b4e483b885ddfb62dab7bf6fc542254) | `python310Packages.caldav: 0.8.2 -> 0.9.0`                           |
| [`ee533442`](https://github.com/NixOS/nixpkgs/commit/ee533442b29f7d84d24bead654b2f7250d9918ed) | `maintainers: add serge`                                             |
| [`37f9102a`](https://github.com/NixOS/nixpkgs/commit/37f9102a1deb4c14110db47c7f8444bba7b37759) | `kacst: init at 2.01`                                                |
| [`e05409c5`](https://github.com/NixOS/nixpkgs/commit/e05409c5ce2058f7e1d8c89e2928cbef645085dc) | `python310Packages.flake8-bugbear: 22.3.23 -> 22.4.25 (#170281)`     |
| [`b2cc79c2`](https://github.com/NixOS/nixpkgs/commit/b2cc79c2a8d13161a6c82dee6ecb8d5c5f040780) | `gofumpt: enable tests`                                              |
| [`8a5f8a4d`](https://github.com/NixOS/nixpkgs/commit/8a5f8a4d8747e446165ee439e07850c68f2ead3f) | `gortr: enable tests`                                                |
| [`eddb2a15`](https://github.com/NixOS/nixpkgs/commit/eddb2a151f1ed061e6aa2129866305a0a165de26) | `checkov: 2.0.1077 -> 2.0.1084`                                      |
| [`7c1c86a7`](https://github.com/NixOS/nixpkgs/commit/7c1c86a713ff99ce6adc3157e5750f6ad77e16dc) | `protolock: enable tests`                                            |
| [`06ad766d`](https://github.com/NixOS/nixpkgs/commit/06ad766d4231748b22380309db33d79f1650c212) | `python3Packages.weconnect-mqtt: 0.32.0 -> 0.33.0`                   |
| [`676198fd`](https://github.com/NixOS/nixpkgs/commit/676198fded3bd18516af19e4b9e5e8d0ba82ee5f) | `python3Packages.weconnect: 0.38.1 -> 0.39.0`                        |
| [`6d1396e4`](https://github.com/NixOS/nixpkgs/commit/6d1396e41334c9635e8b80dd3d77f2374d9ad0d8) | `quickemu: 3.14 -> 3.15`                                             |
| [`6da8554b`](https://github.com/NixOS/nixpkgs/commit/6da8554b2eb85ce06dd86f5549ff54fff2a43d73) | `nuclei: 2.6.8 -> 2.6.9`                                             |
| [`9759288f`](https://github.com/NixOS/nixpkgs/commit/9759288f340754dbe1a33e55343a1931eb807140) | `hcloud: 1.29.0 -> 1.29.5`                                           |
| [`23089a1c`](https://github.com/NixOS/nixpkgs/commit/23089a1c18b14bffaa793ed59740eefb2a94dbda) | `go-protobuf: enable tests`                                          |
| [`44318a9e`](https://github.com/NixOS/nixpkgs/commit/44318a9e10c42aed4b0aa5468892f29ce20a5bbe) | `python3Packages.pytest-isort: switch to GitHub as source`           |
| [`092dad1b`](https://github.com/NixOS/nixpkgs/commit/092dad1b2a238e6dfd86bffc54bc3a0e1e2b81ca) | `python3Packages.pyrogram: 1.4.16 -> 2.0.13`                         |
| [`30e155c5`](https://github.com/NixOS/nixpkgs/commit/30e155c55264c66610db2ac249edf0238673f790) | `dapr-cli: 1.1.0 -> 1.7.0`                                           |
| [`50502019`](https://github.com/NixOS/nixpkgs/commit/505020191dcda961d428212e623c52b337faba8a) | `czkawka: 4.0.0 -> 4.1.0`                                            |
| [`2f39155a`](https://github.com/NixOS/nixpkgs/commit/2f39155ad40b7826fcd7d4d82a3170d4d2d59fe6) | `python3Packages.dropbox: Update hash for re-release of 11.30.0`     |
| [`163c21d9`](https://github.com/NixOS/nixpkgs/commit/163c21d9bb157ef015f36680d9f9c1d8af8c430f) | `routinator: 0.11.1 -> 0.11.2`                                       |
| [`fece5997`](https://github.com/NixOS/nixpkgs/commit/fece5997c0cd1a18fa8cd1466fa3a49503cef2d4) | `mockgen: fix tests`                                                 |
| [`7e66d64e`](https://github.com/NixOS/nixpkgs/commit/7e66d64ed57d3446d5fc33983e86cfa13c717ae9) | `nut: fix compile error`                                             |
| [`6e1e5eac`](https://github.com/NixOS/nixpkgs/commit/6e1e5eaccd3a0984f26b2b678581b49ac5217597) | `home-assistant: update component-packages`                          |
| [`370c03a0`](https://github.com/NixOS/nixpkgs/commit/370c03a02ebc62224345472b1eee152072f7fc59) | `python3Packages.rjpl: init at 0.3.6`                                |
| [`6920d8ca`](https://github.com/NixOS/nixpkgs/commit/6920d8ca42b081c874486ad16fc66f43d8bb8074) | `treewide: Simplify negated uses of versionAtLeast, versionOlder`    |
| [`00e66f10`](https://github.com/NixOS/nixpkgs/commit/00e66f10fa1120875201eace3b0a238f7d1b39ca) | `coq: Rename internal versionAtLeast helper to coqAtLeast`           |
| [`7db78648`](https://github.com/NixOS/nixpkgs/commit/7db7864871845b83af9cc8564a6f1180d2b52542) | `calibre-web: relax Flask, Flask-Login and lxml requirements`        |
| [`1bb9bb53`](https://github.com/NixOS/nixpkgs/commit/1bb9bb532397cd44d227f1c3e8eb3dac9fce20da) | `protoc-gen-doc: 1.5.0 -> 1.5.1`                                     |
| [`f33c02c4`](https://github.com/NixOS/nixpkgs/commit/f33c02c4311d755fd2efb36e1ba0f87b98bb0eb9) | `ChowPhaser: init at 1.1.1`                                          |
| [`3ace2795`](https://github.com/NixOS/nixpkgs/commit/3ace2795b393de60f05b62b177bfa730fd46b4c8) | `chntpw: Import debian bugfix patches`                               |
| [`af7d06ed`](https://github.com/NixOS/nixpkgs/commit/af7d06ed59d9caa1bb03de7c6624d93b2c084cdf) | `fenics: use normal pytest`                                          |
| [`0dc64213`](https://github.com/NixOS/nixpkgs/commit/0dc64213dc7d792ea07deda5da31ad53ec8b40f8) | `python3Packages.update-dotdee: disable failing test`                |
| [`6f5f386a`](https://github.com/NixOS/nixpkgs/commit/6f5f386a6c24d5a5035616e498036bb8163f5719) | `openrct2: 0.3.5.1 -> 0.4.0`                                         |
| [`c62e601a`](https://github.com/NixOS/nixpkgs/commit/c62e601ac83b0870445ae32bee957106e2f50b0e) | `odpdown: remove`                                                    |
| [`83677514`](https://github.com/NixOS/nixpkgs/commit/83677514e6f9bb827b8c593c154db11e06fcfd4f) | `.github/CODEOWNERS: add IvarWithoutBones for dotnet`                |
| [`d8051a6a`](https://github.com/NixOS/nixpkgs/commit/d8051a6a4c20424393bf5c994e70a9c2bbf9ead1) | `kubernetes-helm: 3.8.1 -> 3.8.2`                                    |
| [`6ed76cba`](https://github.com/NixOS/nixpkgs/commit/6ed76cba02c579466d67cda632a0954444796112) | `dry up installPhase with shared runHooks`                           |
| [`df760d5b`](https://github.com/NixOS/nixpkgs/commit/df760d5b58e043507495bf04073ce7e8b1edafbb) | `Update darwin versions and comment on difference to linux`          |
| [`49d3cbee`](https://github.com/NixOS/nixpkgs/commit/49d3cbee1836e1f4d4b152c9c7d922f23d278947) | `omnisharp-roslyn: fix errors related to dlls`                       |
| [`c6ecf373`](https://github.com/NixOS/nixpkgs/commit/c6ecf3733804e7ff62f92650b45d6f7837c4a40d) | `swaytools: 0.1.0 -> 0.1.1`                                          |
| [`d6d8c43d`](https://github.com/NixOS/nixpkgs/commit/d6d8c43d117281f4e0372d43f4573504001253d4) | `pythonInterpreters.graalpython37: remove`                           |
| [`e0516f24`](https://github.com/NixOS/nixpkgs/commit/e0516f24a9a8db7cd6e0c7dcfc8180b8c113b52e) | `python3Packages.dropbox: Clean up package and enable more tests`    |
| [`d14db18f`](https://github.com/NixOS/nixpkgs/commit/d14db18fc785c543c0b38aa5425f7a38d9643921) | `python310Packages.fuse: 1.0.4 -> 1.0.5`                             |
| [`0a803ad7`](https://github.com/NixOS/nixpkgs/commit/0a803ad7098f3074ef266e607d2fd62e4a354c5a) | `freerdp: 2.6.1 -> 2.7.0`                                            |
| [`d5d7d011`](https://github.com/NixOS/nixpkgs/commit/d5d7d01114822ca42a3e558dd41a5e34a49d785d) | `tree-sitter: revert the parser for nix`                             |
| [`434d86b2`](https://github.com/NixOS/nixpkgs/commit/434d86b2bc3f58bdf0e6a9f9f25917ce610f8fc7) | `libixp_hg: hg-2012-12-02 -> unstable-2022-04-04`                    |
| [`aa2afa75`](https://github.com/NixOS/nixpkgs/commit/aa2afa75230a74a5406ab4027a4b1a72ebfd6dc7) | `nix-direnv: 2.0.0 -> 2.0.1`                                         |
| [`2b071e05`](https://github.com/NixOS/nixpkgs/commit/2b071e05f02d0ef4011ca77b50e93fd146be09ba) | `go-license-detector: 3.1.0 -> 4.3.0`                                |
| [`4deb5189`](https://github.com/NixOS/nixpkgs/commit/4deb5189a879593b4871479746d7b9acb4cb0eed) | `dotter: 0.12.9 -> 0.12.10`                                          |
| [`ef0d40db`](https://github.com/NixOS/nixpkgs/commit/ef0d40db01c1f1a1295fb50dfde42ac2bf10f11b) | `python3Packages.vivisect: unbreak on python3`                       |
| [`6f77ffd7`](https://github.com/NixOS/nixpkgs/commit/6f77ffd7f2cb307d746f84db4d0d9708c644628a) | `browserpass: 3.0.6 -> 3.0.10`                                       |
| [`1f4037d1`](https://github.com/NixOS/nixpkgs/commit/1f4037d13c637d6d807d15f15a4cf62331c90be1) | `flow: 0.176.2 -> 0.176.3`                                           |
| [`d9eaa9d7`](https://github.com/NixOS/nixpkgs/commit/d9eaa9d70dbcb670d5b2ba1f3d1778b924975dda) | `evans: 0.10.3 -> 0.10.5`                                            |
| [`126d6553`](https://github.com/NixOS/nixpkgs/commit/126d6553b34e4efb555fe4f554394bdaad902905) | `python310Packages.pg8000: 1.26.0 -> 1.26.1`                         |
| [`5af0d861`](https://github.com/NixOS/nixpkgs/commit/5af0d861aaee215ee998d71803d64b61cb506696) | `awslogs: relax jmespath constraint`                                 |
| [`d1402a59`](https://github.com/NixOS/nixpkgs/commit/d1402a59b0477e4f40def3b2d49e6f2c1384de62) | `docker-slim: 1.37.5 -> 1.37.6`                                      |
| [`011f56b2`](https://github.com/NixOS/nixpkgs/commit/011f56b2cb724a8cdc318ee9df28ad1d5bc9b34a) | `tree-sitter: update grammars`                                       |
| [`16dc611f`](https://github.com/NixOS/nixpkgs/commit/16dc611f05fe455e6451e45b5d42e19682031a07) | `bazel-remote: 2.3.6 -> 2.3.7`                                       |
| [`f1527704`](https://github.com/NixOS/nixpkgs/commit/f15277040ca9b9b7f67a92904ec670112657c11d) | `kotatogram-desktop: merge tg_owt post-patch commands`               |
| [`18833d2d`](https://github.com/NixOS/nixpkgs/commit/18833d2d94f6c937edea83ead19d7dde8bc4bca6) | `kotatogram-desktop: fix build with KF5.94`                          |
| [`cc17b841`](https://github.com/NixOS/nixpkgs/commit/cc17b8413c6d9dd0039540edf73808a975404f13) | `shortwave: 2.0.1 -> 3.0.0`                                          |
| [`2bc5c67f`](https://github.com/NixOS/nixpkgs/commit/2bc5c67f1c8c92d940b4e2238bfee7eaf5388935) | `python310Packages.scikit-learn-extra: disable failing test`         |