### PR TITLE
chore(flake/nixpkgs): `2975ad11` -> `d6b99603`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -130,11 +130,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651008161,
-        "narHash": "sha256-BrX9mEs7QOegsk61xje8yS8RYglZnilcvZNjX8Wt77s=",
+        "lastModified": 1651031716,
+        "narHash": "sha256-muwdDKZ9uMPkeKa2EY0DxJub9nSa+3DZOSACBG+1VP4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2975ad119528863d4bdb28bc160c9072e39b1c02",
+        "rev": "d6b996030dd21c6509803267584b9aca3e133a07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`80d44807`](https://github.com/NixOS/nixpkgs/commit/80d4480778f581d5b73e4464eeb08ae0974e72c2) | `sd-image-aarch64: deduplicate cm4 section`                                 |
| [`05942771`](https://github.com/NixOS/nixpkgs/commit/059427718385d23e125ddfbb630eda0d6fbc4178) | `ubootRaspberryPi4_64bit: remove NVMe support patches`                      |
| [`21b28447`](https://github.com/NixOS/nixpkgs/commit/21b28447eb5b32dbca7cfd51acf716bf41eb732c) | `uboot: add node on where rpi-cm4 patches come from`                        |
| [`77bb75d6`](https://github.com/NixOS/nixpkgs/commit/77bb75d6a24e28d2b1f3be54c4194b22b63d054f) | `ubootRaspberryPi4_64bit: rebase patch series`                              |
| [`cff95d11`](https://github.com/NixOS/nixpkgs/commit/cff95d119343fe2808516a0f8f86c8ba0963b29c) | `ubootRaspberryPi4_64bit: add patch for USB stall with non-MSD USB devices` |
| [`11c1152e`](https://github.com/NixOS/nixpkgs/commit/11c1152e0f4f35e22249bc8d02e1d30e29b53032) | `sd-image-aarch64: add dtbs for rpi-400 and cm4s`                           |
| [`b30105b7`](https://github.com/NixOS/nixpkgs/commit/b30105b7c28b6510980101e8266b2268b1e2313f) | `ubootRaspberryCM4_64bit: merge with ubootRaspberryPi4_64bit`               |
| [`aca45f8c`](https://github.com/NixOS/nixpkgs/commit/aca45f8c678deaa35dc407586e91d302d36dc74d) | `raspberrypiWirelessFirmware: fix install`                                  |
| [`d9e593ed`](https://github.com/NixOS/nixpkgs/commit/d9e593ed5889f3906dc72811c45bf684be8865cf) | `git-cliff: 0.6.1 -> 0.7.0`                                                 |
| [`c425aa49`](https://github.com/NixOS/nixpkgs/commit/c425aa4989502c9dcafdd570ad1dbe89a2976587) | `cargo-make: 0.35.10 -> 0.35.11`                                            |
| [`d2f1613f`](https://github.com/NixOS/nixpkgs/commit/d2f1613f15d68eadfd882a68f2ac42e02d945214) | `python39Packages.pylast: 4.5.0 -> 5.0.0`                                   |
| [`0eb22f6a`](https://github.com/NixOS/nixpkgs/commit/0eb22f6abc3a45926aad1fe0bdb4f7afebfe242e) | `python3Packages.pytest-aiohttp: 1.0.3 -> 1.0.4`                            |
| [`a356e866`](https://github.com/NixOS/nixpkgs/commit/a356e8667645e4d1d40966a049790f32f2ff84db) | `tpm2-pkcs11: 1.7.0 -> 1.8.0`                                               |
| [`dc1ac222`](https://github.com/NixOS/nixpkgs/commit/dc1ac22201007d15aebb7b05acf9dde4b2162db4) | `sharedown: 3.1.0 -> 4.0.2`                                                 |
| [`9be76f92`](https://github.com/NixOS/nixpkgs/commit/9be76f9284014247a0f7a0542294046e857e3a88) | `python39Packages.pyfritzhome: 0.6.4 -> 0.6.5`                              |
| [`dcfaae66`](https://github.com/NixOS/nixpkgs/commit/dcfaae66794be7ff958efe6460eee5f8438a7f45) | `nixos/modules/profiles/all-hardware: add nvme to initrd modules`           |
| [`323f123f`](https://github.com/NixOS/nixpkgs/commit/323f123f6afee22cc0c642988a12285ba0f11b3a) | `ubootRaspberryCM4_64bit: add all NVME patches`                             |
| [`ca0c9279`](https://github.com/NixOS/nixpkgs/commit/ca0c9279ab2471bd8bf67681fb57fe33adbccb27) | `ubootRaspberryCM4_64bit: enable USB and NVME`                              |
| [`d094a3e1`](https://github.com/NixOS/nixpkgs/commit/d094a3e175fb3e1593adcda6a4e973946785dd13) | `uboot: enable parallel building again`                                     |
| [`f6f41cf7`](https://github.com/NixOS/nixpkgs/commit/f6f41cf740527b804abb8ae30f69a2fb534c35f3) | `uboot: 2021.10 -> 2022.01`                                                 |
| [`faf42ffb`](https://github.com/NixOS/nixpkgs/commit/faf42ffbd07f0c877258c8b519c7e973949f89c7) | `ubootRaspberryCM4_64bit: init`                                             |
| [`d1fef1e7`](https://github.com/NixOS/nixpkgs/commit/d1fef1e7c370a39b639836726e956574d4092793) | `sd-image-aarch64: add support for the RaspberryPi CM4`                     |
| [`b12ff7c9`](https://github.com/NixOS/nixpkgs/commit/b12ff7c9ec3797ba2c44538658fd5df2bf3d88a5) | `python39Packages.policyuniverse: 1.5.0.20220421 -> 1.5.0.20220426`         |
| [`97635ecf`](https://github.com/NixOS/nixpkgs/commit/97635ecf20ceef281d3364d151780030f5014244) | `python39Packages.denonavr: 0.10.10 -> 0.10.11`                             |
| [`2d4e01f8`](https://github.com/NixOS/nixpkgs/commit/2d4e01f8b7aa68fc40af0eb5c3ca0e2d9b64113e) | `actually update nvidia-persistenced as well`                               |
| [`8a585231`](https://github.com/NixOS/nixpkgs/commit/8a5852316187a1bc209f6e7704cdf406fc4829bf) | `python39Packages.mailchecker: 4.1.15 -> 4.1.16`                            |
| [`b212f575`](https://github.com/NixOS/nixpkgs/commit/b212f5751417c1d62a924f7cdb5283bb320ab9f7) | `python39Packages.peaqevcore: init at 0.0.16`                               |
| [`0762c405`](https://github.com/NixOS/nixpkgs/commit/0762c405162ceeffb24ab5d1b23516ae608f8754) | `python3Packages.hahomematic: 1.1.5 -> 1.2.0`                               |
| [`d67a297e`](https://github.com/NixOS/nixpkgs/commit/d67a297ec7bf7d40a0bc954546855bbe8399a9a5) | `python3Packages.marshmallow-dataclass: 8.5.5 -> 8.5.6`                     |
| [`f21b16cd`](https://github.com/NixOS/nixpkgs/commit/f21b16cdd9d2d96c0b9690635a92e37833bb9835) | `nvidia_x11: 510.60.02 → 510.68.02`                                         |
| [`3babd377`](https://github.com/NixOS/nixpkgs/commit/3babd3777302bb680baa0b157e3abfda1134ca68) | `protolint: init at 0.37.1`                                                 |
| [`77abea3a`](https://github.com/NixOS/nixpkgs/commit/77abea3aae675b3843f312b2dd99abab2565fa4c) | `trivy: 0.26.0 -> 0.27.0`                                                   |
| [`89147149`](https://github.com/NixOS/nixpkgs/commit/8914714916d96812cb582425233cfcc1cc17be9f) | `mavproxy: 1.8.48 -> 1.8.49`                                                |