### PR TITLE
chore(flake/nixgl): `17658df1` -> `56f2fbcc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -99,12 +99,15 @@
       }
     },
     "nixgl": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
       "locked": {
-        "lastModified": 1644013836,
-        "narHash": "sha256-8J6HqBr8+JlZzjyMV8FrCS6ZI6rHo1pTMPilSBf6TaE=",
+        "lastModified": 1651078744,
+        "narHash": "sha256-+S/NEzZoTt7EoSOMEUsR/LuNTtzYhbribFaIewNxdCQ=",
         "owner": "guibou",
         "repo": "nixgl",
-        "rev": "17658df1e17a64bc23ee5c93cfa9e8b663a4ac81",
+        "rev": "56f2fbcce7a08c60c98394a64e900d5e9227bcb2",
         "type": "github"
       },
       "original": {
@@ -129,6 +132,20 @@
       }
     },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1651024496,
+        "narHash": "sha256-uKSrrw/neSkxX6TXPSaMyfu7iKzFrK7F6HOt6vQefGY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d9e593ed5889f3906dc72811c45bf684be8865cf",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1651031716,
         "narHash": "sha256-muwdDKZ9uMPkeKa2EY0DxJub9nSa+3DZOSACBG+1VP4=",
@@ -200,7 +217,7 @@
         "impermanence": "impermanence",
         "nixgl": "nixgl",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "pre-commit-hooks": "pre-commit-hooks",
         "ragenix": "ragenix",
         "templates": "templates",


### PR DESCRIPTION
| SHA256                                                                                        | Commit Message                                          |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`c9f0eee6`](https://github.com/guibou/nixGL/commit/c9f0eee68e78109deb6cf5d1ff624bbb8e518887) | `Delete flake.lock`                                     |
| [`461b0bb6`](https://github.com/guibou/nixGL/commit/461b0bb67c900bf45d023d9c1e92de4b24f06252) | `nix flake update`                                      |
| [`4de92f0e`](https://github.com/guibou/nixGL/commit/4de92f0e7794a22e38d57a825bdab20e37fd9ca4) | `Update README.md`                                      |
| [`950c19ae`](https://github.com/guibou/nixGL/commit/950c19ae707d96c6775f8b15ed50dde0d17ccdbc) | ``flake.nix: use default `nixpkgs` from registry``      |
| [`0ac157a6`](https://github.com/guibou/nixGL/commit/0ac157a664a50f324b438fc9e18cf6c453e4d448) | `Update flake doc`                                      |
| [`569f95d9`](https://github.com/guibou/nixGL/commit/569f95d9577154b26d5ce774895fee727f070455) | `README: evaluations not using auto detection are pure` |
| [`7e65b5bd`](https://github.com/guibou/nixGL/commit/7e65b5bdf052f582be2c635fd655c8942729287e) | `More doc about flake usage`                            |
| [`35bc966e`](https://github.com/guibou/nixGL/commit/35bc966e345f84a740150fee2554458a24bde287) | `Add more doc about flake use`                          |
| [`4792b84c`](https://github.com/guibou/nixGL/commit/4792b84c7cea1b7f1d5711b9582e9745ea7e5443) | `extand flake support and doc`                          |
| [`b8e8474b`](https://github.com/guibou/nixGL/commit/b8e8474b0a36a0b86648b975cd51c7daab976f12) | `sync nixGLCommon pkg and bin name`                     |
| [`4a3093f9`](https://github.com/guibou/nixGL/commit/4a3093f9959927d08a9b4579b94cc4b4e3a8075f) | `add defaultPackage target to flake.nix`                |