### PR TITLE
chore(flake/home-manager): `ac722cdd` -> `267462df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1651598446,
-        "narHash": "sha256-UykdAyAcf2zFW5Wbv3uXDhMg9Fd+zarrRQxfMnR2BAs=",
+        "lastModified": 1651652192,
+        "narHash": "sha256-3FUsIJ81p57rOxODRVZ+anhnVav96VWbgNA1H3Np+TY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ac722cddf44276d2b11d797b2ace273d0b674000",
+        "rev": "267462dfb36d447421c789a3adf9d460cd09c147",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                     |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`267462df`](https://github.com/nix-community/home-manager/commit/267462dfb36d447421c789a3adf9d460cd09c147) | `cursor: fix coercion error`       |
| [`c13ffa3e`](https://github.com/nix-community/home-manager/commit/c13ffa3ed42a653c058d78771f4ff0ef8798e7fd) | `home.pointerCursor: init (#2891)` |