### PR TITLE
chore(flake/nixpkgs): `d33eace0` -> `0b9843c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651571043,
-        "narHash": "sha256-3PAjKbf8ZntRvDDn/VZIKrF4qh7ltZAUmTImRAp0D9o=",
+        "lastModified": 1651636606,
+        "narHash": "sha256-fr3oyaV4rFu6Jp6RrDmA2lYMD/iUfxfReuGdrayZOAw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d33eace057c830a5c1b43914d1e4287f7db605bb",
+        "rev": "0b9843c3bcca2ac748db8b52659e6cad5c0fd794",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`338ed797`](https://github.com/NixOS/nixpkgs/commit/338ed797fe4a2caa02f7bb4568627ac1f71e0f84) | `gfortran: fix wrapper host/target offset for cross`                           |
| [`3382215f`](https://github.com/NixOS/nixpkgs/commit/3382215fd732192dddf071ab0dc15e5cb9ff83cd) | `firefox-devedition-bin-unwrapped: 100.0b7 -> 101.0b2`                         |
| [`4df2c1fe`](https://github.com/NixOS/nixpkgs/commit/4df2c1fe35da1207b9c8c199339e01901d60bf59) | `jwt-cli: 5.0.2 -> 5.0.3`                                                      |
| [`6a415cd3`](https://github.com/NixOS/nixpkgs/commit/6a415cd37c166059c817dd32632716d4af11985c) | `containerd: 1.6.3 -> 1.6.4`                                                   |
| [`5912e391`](https://github.com/NixOS/nixpkgs/commit/5912e391b5af902d687c0c29f991553ced8fa229) | `chickenEggs.tcp6: init at 0.2.1`                                              |
| [`5c9f8061`](https://github.com/NixOS/nixpkgs/commit/5c9f806102ab6846db36a553e1d8d9798da3a3df) | `chickenEggs.socket: init at 0.3.3`                                            |
| [`298a451e`](https://github.com/NixOS/nixpkgs/commit/298a451eb65c006c550589861b62bbed82f28286) | `chickenEggs.foreigners: init at 1.5`                                          |
| [`e31de323`](https://github.com/NixOS/nixpkgs/commit/e31de323966763d0baf976aaf019589f10bfb82d) | `chickenEggs.feature-test: init at 0.2.0`                                      |
| [`b756fabd`](https://github.com/NixOS/nixpkgs/commit/b756fabd1a12e7454e40a151bbddcb83b888d42f) | `chickenEggs.address-info: init at 1.0.5`                                      |
| [`876def94`](https://github.com/NixOS/nixpkgs/commit/876def9433d8ee01d0675f71bb5c38623b25a37a) | `chickenEggs.sha2: init at 4.0.5`                                              |
| [`e9fa73c9`](https://github.com/NixOS/nixpkgs/commit/e9fa73c93d1fd27166af5311cdb6ca1d4a9266a2) | `chickenEggs.message-digest-primitive: init at 4.3.2`                          |
| [`e7bd776d`](https://github.com/NixOS/nixpkgs/commit/e7bd776d5b315a5d21c41851596dbd8d2c5945ab) | `chickenEggs.json: init at 1.6`                                                |
| [`01ab95c8`](https://github.com/NixOS/nixpkgs/commit/01ab95c8861a9279346e6b553b9a9fbe9790b3b3) | `chickenEggs.packrat: init at 1.5`                                             |
| [`09f4886b`](https://github.com/NixOS/nixpkgs/commit/09f4886b37cf356b6f6427571b1cf92080d31304) | `chickenEggs.utf8: init at 3.6.2`                                              |
| [`95d24cad`](https://github.com/NixOS/nixpkgs/commit/95d24cad2ad8c986f7822098848da166c01f7544) | `chickenEggs.uri-generic: init at 3.2`                                         |
| [`7e65e01f`](https://github.com/NixOS/nixpkgs/commit/7e65e01f838ad0344eb8e06f54b84cdb45de420f) | `chickenEggs.uri-common: init at 2.0`                                          |
| [`534f88d3`](https://github.com/NixOS/nixpkgs/commit/534f88d368dd745ba71c378dfc56009f87d1ffd9) | `chickenEggs.symbol-utils: init at 2.1.0`                                      |
| [`42cd5123`](https://github.com/NixOS/nixpkgs/commit/42cd512356cdcb75fb09be073ce9579e0fb8862b) | `chickenEggs.string-utils: init at 2.4.0`                                      |
| [`e91febd4`](https://github.com/NixOS/nixpkgs/commit/e91febd45456e762843f46638bc3959f85b9fdb0) | `chickenEggs.srfi-69: init at 0.4.1`                                           |
| [`236e58ec`](https://github.com/NixOS/nixpkgs/commit/236e58ec33668296406cc78b36295d6298a40a04) | `chickenEggs.srfi-18: init at 0.1.6`                                           |
| [`d74cdc67`](https://github.com/NixOS/nixpkgs/commit/d74cdc673462e539f5ca5a5b7538322934749763) | `chickenEggs.spiffy: init at 6.3`                                              |
| [`477e0610`](https://github.com/NixOS/nixpkgs/commit/477e06109e6276da7e3f2a8b27d6d02caebbcc5b) | `chickenEggs.sendfile: init at 1.8.3`                                          |
| [`8d3b68f5`](https://github.com/NixOS/nixpkgs/commit/8d3b68f5183b17445b0de1f59064e0ab6008eb8a) | `chickenEggs.regex: init at 2.0`                                               |
| [`8c7f1233`](https://github.com/NixOS/nixpkgs/commit/8c7f1233e617e49d795cf0a08c08bb2355e7822c) | `chickenEggs.miscmacros: init at 1.0`                                          |
| [`bb9bf815`](https://github.com/NixOS/nixpkgs/commit/bb9bf815fea322e55d610da704ab2997b5a87659) | `chickenEggs.memory-mapped-files: init at 0.4`                                 |
| [`588e7507`](https://github.com/NixOS/nixpkgs/commit/588e750718594a97543cf6f41724c18a9b45bc7c) | `chickenEggs.set: init at 2.2`                                                 |
| [`38f7ead8`](https://github.com/NixOS/nixpkgs/commit/38f7ead82d8d0059c99cb0f105dcdf6f7ca36297) | `chickenEggs.intarweb: init at 2.0.1`                                          |
| [`4c7e5a08`](https://github.com/NixOS/nixpkgs/commit/4c7e5a0812aece2351d162b6bbea2cd180e29ff9) | `chickenEggs.defstruct: init at 2.0`                                           |
| [`bdfbb00e`](https://github.com/NixOS/nixpkgs/commit/bdfbb00e0c530588704ae3eb6d5fd83a1dcd7e06) | `chickenEggs.check-errors: init at 3.2.0`                                      |
| [`6ebe5ef3`](https://github.com/NixOS/nixpkgs/commit/6ebe5ef3200e9cae7d26b2519cc995eb87084ef4) | `chickenEggs.base64: init at 1.0`                                              |
| [`91d2292a`](https://github.com/NixOS/nixpkgs/commit/91d2292a53fc07bbb744c42f4ae5ecce262b40e5) | `chickenEggs.apropos: init at 3.6.0`                                           |
| [`006c38fa`](https://github.com/NixOS/nixpkgs/commit/006c38fa5353e0a157d1af59ca4b345f42a7ae16) | `platforms.nix: use {} on failed detection instead of silently assuming pc`    |
| [`4def222e`](https://github.com/NixOS/nixpkgs/commit/4def222ea40aef58ee83fb00bd412b78ee807205) | `stdenv/check-meta: add a "maintainerless" warning`                            |
| [`3a34b6c8`](https://github.com/NixOS/nixpkgs/commit/3a34b6c820b1cd62ed1b1747b6cad6275e81321d) | `stdenv/check-meta: add an eval warning option`                                |
| [`5e420c24`](https://github.com/NixOS/nixpkgs/commit/5e420c24556053e2a5ad3ca69993afb42fffbc54) | `stdenv/check-meta: turn validity.valid into a str`                            |
| [`f1531b1b`](https://github.com/NixOS/nixpkgs/commit/f1531b1b825101dc68395de89846e64a2bb182fe) | `unifi: 7.0.25 -> 7.1.61`                                                      |
| [`4d5de1d8`](https://github.com/NixOS/nixpkgs/commit/4d5de1d8d1d8398d466267a2746ab1f5f7e527a5) | `nixVersions.unstable: pre20220428 -> pre20220503`                             |
| [`fa380c99`](https://github.com/NixOS/nixpkgs/commit/fa380c997000add0e38767692a1c5a46531323b8) | `python310Packages.canonicaljson: update disable`                              |
| [`607152a4`](https://github.com/NixOS/nixpkgs/commit/607152a41dea1e1339ef73c312bdcbfeb0a0fa9b) | `partition-manager: 4.2.0 -> 22.04.0`                                          |
| [`057f88b3`](https://github.com/NixOS/nixpkgs/commit/057f88b3d265cf758e1cc251ef18c1404127281d) | `kpmcore: 4.2.0 -> 22.04.0`                                                    |
| [`bcb44569`](https://github.com/NixOS/nixpkgs/commit/bcb4456920eadfcaf7ef430abf0c5b2ae159a6d6) | `nixos/release-notes: add calamares installer to highlights`                   |
| [`c21720a4`](https://github.com/NixOS/nixpkgs/commit/c21720a46ecdfad2ba6c3290e683588a500d0a20) | `nixos/release: add calamares installer`                                       |
| [`89096bcc`](https://github.com/NixOS/nixpkgs/commit/89096bcce0e929de2d8fdb26a6ce577d2321d685) | `installation-cd: add calamares-plasma5 cd`                                    |
| [`67b5b4ca`](https://github.com/NixOS/nixpkgs/commit/67b5b4cabfee04ad6ec82333b964c31fb16ed472) | `installation-cd: add calamares-gnome cd`                                      |
| [`3ec2fd82`](https://github.com/NixOS/nixpkgs/commit/3ec2fd8203d39a59960806d9519125740dc78400) | `calamares: fix modules functionality and add nixos support`                   |
| [`d8eaef42`](https://github.com/NixOS/nixpkgs/commit/d8eaef42d6127b19e241a33bc9cb0724a2a1f464) | `maintainer-list: add vlinkz`                                                  |
| [`7481fa91`](https://github.com/NixOS/nixpkgs/commit/7481fa9135ab0a2d60659bf182f337071379dd3c) | `calamares-nixos-extensions: init at 0.3.8`                                    |
| [`b5749189`](https://github.com/NixOS/nixpkgs/commit/b5749189cb884e7c68c5c095ab8697aa8e89fc50) | `python310Packages.canonicaljson: 1.6.0 -> 1.6.1`                              |
| [`deed4a3d`](https://github.com/NixOS/nixpkgs/commit/deed4a3d6c082eb5fe7b6602c059e8735fc97d42) | `nixos/stage-1: remove dead code`                                              |
| [`24738379`](https://github.com/NixOS/nixpkgs/commit/2473837984348f435be4d7679133a19853690000) | `nss_latest: 3.77 -> 3.78`                                                     |
| [`c7733032`](https://github.com/NixOS/nixpkgs/commit/c7733032152e9c34f59aa1214553da03b87dd2b3) | `Revert "Revert "nss_latest: 3.76.1 -> 3.77""`                                 |
| [`f6fd7e36`](https://github.com/NixOS/nixpkgs/commit/f6fd7e36d36b4fc714bec0489375aad905d83295) | `firefox-esr: 91.8.0esr -> 91.9.0esr`                                          |
| [`a1f9d3a5`](https://github.com/NixOS/nixpkgs/commit/a1f9d3a52e8a542bc5717af3677c905f73f60ce6) | `firefox-bin: 99.0.1 -> 100.0`                                                 |
| [`3f2a09af`](https://github.com/NixOS/nixpkgs/commit/3f2a09af84263b58cbf6069c299c5a0b8a563d4d) | `firefox: 99.0.1 -> 100.0`                                                     |
| [`8d03b241`](https://github.com/NixOS/nixpkgs/commit/8d03b2418ef76eb64007648d9e5698989dd0df8a) | `qgis-ltr: 3.22.5 -> 3.22.6`                                                   |
| [`14d77e89`](https://github.com/NixOS/nixpkgs/commit/14d77e895d48b314612bdd37effee43c02dc6667) | `qgis: 3.24.1 -> 3.24.2`                                                       |
| [`8907bea5`](https://github.com/NixOS/nixpkgs/commit/8907bea5c1917b5eb328dc2ccd7ec7ed84cd7098) | `python310Packages.types-paramiko: 2.8.21 -> 2.10.0`                           |
| [`7f9c7443`](https://github.com/NixOS/nixpkgs/commit/7f9c7443ae1d41611c2c1366296d6731989c3106) | `yarn2nix: extend NixOS/nix#5128 workaround to 2.4+`                           |
| [`f7041d78`](https://github.com/NixOS/nixpkgs/commit/f7041d789397ad1113a8e2ff1f5b503cbba55ebf) | `nextcloud-client: 3.4.4 -> 3.5.0`                                             |
| [`7af591c7`](https://github.com/NixOS/nixpkgs/commit/7af591c79ca61603776ae54244fe5f701590db3b) | `gitlab: 14.10.0 -> 14.10.1 (#171363)`                                         |
| [`7523edc3`](https://github.com/NixOS/nixpkgs/commit/7523edc3e90a0f4c8821b687cab6b0f74576c5af) | `zellij: 0.27.0 -> 0.29.1`                                                     |
| [`75a38be9`](https://github.com/NixOS/nixpkgs/commit/75a38be967f062c01220e1a1314f900c9db42b9d) | `python310Packages.jug: update inputs`                                         |
| [`fb60c5e7`](https://github.com/NixOS/nixpkgs/commit/fb60c5e7b3273d165ff682be81265b3ef301dee2) | `solc: add darwin binary for now`                                              |
| [`67f61465`](https://github.com/NixOS/nixpkgs/commit/67f614650047eae778594fa83535b274c8ca8e09) | `glibmm: 2.66.2 -> 2.66.3`                                                     |
| [`bdcb8188`](https://github.com/NixOS/nixpkgs/commit/bdcb818804ba66bd52bb089b4f8ad33b3f18ca51) | `Replace "rm" call with "git rm"`                                              |
| [`02967092`](https://github.com/NixOS/nixpkgs/commit/029670929914a322333cefd1db80a9356d671e77) | `python310Packages.pyomo: 6.3.0 -> 6.4.0`                                      |
| [`b597b5c3`](https://github.com/NixOS/nixpkgs/commit/b597b5c3fc97ea661692eb5ddfb7387af16fc7a4) | `hare: init at 0.pre+date=2022-04-27`                                          |
| [`9ded9f11`](https://github.com/NixOS/nixpkgs/commit/9ded9f11002882d46c7be47527278ae01039c134) | `harec: init at 0.pre+date=2022-04-26`                                         |
| [`6ac337aa`](https://github.com/NixOS/nixpkgs/commit/6ac337aa06d044cf0a6a8caebb232223d22b402b) | `python310Packages.namedlist: add patch for collections.abc`                   |
| [`82507844`](https://github.com/NixOS/nixpkgs/commit/825078447ac48ed4912e609d671d1f037a1e813c) | `podman: add oci-containers.podman to passthru.tests`                          |
| [`bbf483c4`](https://github.com/NixOS/nixpkgs/commit/bbf483c46e007036475674a60c5fbd8e5a3e6b32) | `nixos/release: add podman, oci-containers.podman to tested`                   |
| [`346742d3`](https://github.com/NixOS/nixpkgs/commit/346742d3cb85314f63ee54ca97a7ed971f50cc50) | `python310Packages.jug: 2.1.1 -> 2.2.0`                                        |
| [`a032d2f2`](https://github.com/NixOS/nixpkgs/commit/a032d2f2441105894c64af5c857e92a56536e369) | `python310Packages.envs: 1.3 -> 1.4`                                           |
| [`2e13dc77`](https://github.com/NixOS/nixpkgs/commit/2e13dc779513e45a972f10099d1a4d4be447399e) | `python310Packages.glances-api: 0.3.4 -> 0.3.5`                                |
| [`8aa77956`](https://github.com/NixOS/nixpkgs/commit/8aa77956a1a819a0be41a20105015d84e68196cf) | `python310Packages.bpython: disable failing test`                              |
| [`fa1e8856`](https://github.com/NixOS/nixpkgs/commit/fa1e88569880cf9f875842cdb6f6fe2cf58237a9) | `gitRepo: 2.24.1 -> 2.25`                                                      |
| [`fb5fd132`](https://github.com/NixOS/nixpkgs/commit/fb5fd13212e10b53bda033b24f1fca0860e18990) | `python310Packages.cert-chain-resolver: add missing input`                     |
| [`2c83b549`](https://github.com/NixOS/nixpkgs/commit/2c83b549280b32353c12b05373fd74829355a593) | `bottles: 2022.4.28-trento -> 2022.5.2-trento`                                 |
| [`21f526a7`](https://github.com/NixOS/nixpkgs/commit/21f526a7f33f5c689260ee8e992d954fd7188d3b) | `vimPlugins: update`                                                           |
| [`d4894355`](https://github.com/NixOS/nixpkgs/commit/d4894355c114e6950d7cb844c0220c91098cf479) | `vim/update.py: distinguish between vim/neovim plugins`                        |
| [`733730ef`](https://github.com/NixOS/nixpkgs/commit/733730eff86f0df80aeddaafe729e562d26c1b1b) | `john: update source to GitHub and homepage url`                               |
| [`9f8d8443`](https://github.com/NixOS/nixpkgs/commit/9f8d844340e8026758b56c449f7c3596155cf3e7) | `foot: 1.11.0 -> 1.12.1`                                                       |
| [`37f3a23a`](https://github.com/NixOS/nixpkgs/commit/37f3a23a029326e42bb59445a059b8a3c70fab1a) | `fcft: 3.0.1 -> 3.1.1`                                                         |
| [`3e36af97`](https://github.com/NixOS/nixpkgs/commit/3e36af97686dc67c365a107fe37dbf73b2faa45b) | `quickemu: fix spice-gtk dependency`                                           |
| [`9f05fc66`](https://github.com/NixOS/nixpkgs/commit/9f05fc666188c06d5bcc8c1f352d77244ec6f91d) | `config.allowUnsupportedSystem: define as option`                              |
| [`9f473092`](https://github.com/NixOS/nixpkgs/commit/9f473092f84f9d704810146fec2a919bf96e5bf0) | `config.allowBroken: define as option`                                         |
| [`1c49b812`](https://github.com/NixOS/nixpkgs/commit/1c49b81263858c69b932da05ae63a7767b308e74) | `config.allowUnfree: define as option`                                         |
| [`82da3193`](https://github.com/NixOS/nixpkgs/commit/82da3193fcfc7ffada71d73725436a4d205d2df4) | `uchiwa: remove`                                                               |
| [`5a2f238b`](https://github.com/NixOS/nixpkgs/commit/5a2f238b9a55c425488bbcb1676f64e3c3f55942) | `systemd-boot: use mktemp from coreutils in installer`                         |
| [`7058d597`](https://github.com/NixOS/nixpkgs/commit/7058d597ebb5194e86ad3943cd32ac0e69b7bc1d) | `plexamp: 4.2.0 -> 4.2.1`                                                      |
| [`536a78ec`](https://github.com/NixOS/nixpkgs/commit/536a78ecc92688f186d44c8022054ff15de190db) | `nixos/thefuck: rename variable and move fishInitScript into its own variable` |
| [`9add6bdf`](https://github.com/NixOS/nixpkgs/commit/9add6bdfc8eff26a0ecbd9efbb74f9397dafa89c) | `nixos/thefuck: fix programs.thefuck.alias for fish`                           |
| [`26e02c19`](https://github.com/NixOS/nixpkgs/commit/26e02c1972fb05799289ff25801bcbaa535f72bf) | `mindustry: propagate more runtime depends`                                    |
| [`7bcf1516`](https://github.com/NixOS/nixpkgs/commit/7bcf151685b950a2a5a040f379ca23bfee279865) | `unityhub: fix nix-env version parsing`                                        |
| [`0201c6cf`](https://github.com/NixOS/nixpkgs/commit/0201c6cf46c66a39571071d2b53c52052750d8d6) | `uni-vga: reduce with lib usage`                                               |
| [`f5e69689`](https://github.com/NixOS/nixpkgs/commit/f5e6968955b4a38ed52674563930245836a808c8) | `inih: fix version parsing with nix-env`                                       |
| [`94648ef6`](https://github.com/NixOS/nixpkgs/commit/94648ef64e2673ed44cc60013a40e8ddba83d21e) | `ventoy-bin: 1.0.72 -> 1.0.74`                                                 |
| [`23d3cd04`](https://github.com/NixOS/nixpkgs/commit/23d3cd040e8f7c3e616ff57b9ce5bd4d28aa9a5a) | `python3.pkgs.dropbox: build offline html documentation`                       |
| [`3bb2ac5a`](https://github.com/NixOS/nixpkgs/commit/3bb2ac5adfb3f2bceba113f011212aa35b199348) | `python3.pkgs.beautifulsoup4: build offline html documentation`                |
| [`6b8b02ce`](https://github.com/NixOS/nixpkgs/commit/6b8b02cef77a7dcd1192cc47ce60fd2e128617a4) | `python3.pkgs.sphinxHook: new package`                                         |
| [`b531bf47`](https://github.com/NixOS/nixpkgs/commit/b531bf477a4aec9c58cf5b4fd1a7297db4533ce1) | `wallabag: fix comment with usage instructions`                                |
| [`835cbb4e`](https://github.com/NixOS/nixpkgs/commit/835cbb4e6aa10e968ff34bb426c33f8259e1cd3a) | `python310Packages.aws-lambda-builders: 1.14.0 -> 1.15.0`                      |
| [`8b0e73e7`](https://github.com/NixOS/nixpkgs/commit/8b0e73e70cda02d67119b53e00ce6832b00172f2) | `john: add gcc11 patch`                                                        |
| [`868991db`](https://github.com/NixOS/nixpkgs/commit/868991dbace0c702db3738bdfaea99e90200e244) | `firefox-devedition-bin-unwrapped: 100.0b6 -> 100.0b7`                         |
| [`64913c64`](https://github.com/NixOS/nixpkgs/commit/64913c64b3cd3aededb42001947232196546dfab) | `greg: 0.4.7 -> 0.4.8`                                                         |
| [`c6e3cedd`](https://github.com/NixOS/nixpkgs/commit/c6e3ceddd02dfa632b625430d516eca8efe9fb76) | `liquibase: fix Main -> LiquibaseCommandLine`                                  |
| [`b5017f53`](https://github.com/NixOS/nixpkgs/commit/b5017f53af93ce8e4e27284fc9d7be6991b02439) | `linuxKernel.packages.linux_5_16.evdi: 1.10.0 -> 1.10.1`                       |
| [`d0b90bd1`](https://github.com/NixOS/nixpkgs/commit/d0b90bd181c45ac2ec34124b1389ccf90f6a989d) | `yquake2: migrate from cmake to gnumake`                                       |
| [`8aeb2797`](https://github.com/NixOS/nixpkgs/commit/8aeb279701fe867dc728e8dabab0a28a062ace84) | `yquake2: 8.00 -> 8.01`                                                        |