### PR TITLE
chore(flake/nixpkgs): `0b9843c3` -> `c04ef155`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651636606,
-        "narHash": "sha256-fr3oyaV4rFu6Jp6RrDmA2lYMD/iUfxfReuGdrayZOAw=",
+        "lastModified": 1651654660,
+        "narHash": "sha256-ZuQ3wQwIEwqBAEOeL/mY5dV0pxuz7OIz/lzeLBIskAE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0b9843c3bcca2ac748db8b52659e6cad5c0fd794",
+        "rev": "c04ef155994d060aceedf946eeba0ab756b19c01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`1d2a0b80`](https://github.com/NixOS/nixpkgs/commit/1d2a0b801a8c5aad8d7d302df661a16142eddc7d) | `nixos/tests/matrix-appservice-irc: disable registration verification` |
| [`19687b6c`](https://github.com/NixOS/nixpkgs/commit/19687b6c9c7acd06c0d9e6d2872f371cdae99731) | `matrix-appservice-irc: 0.33.1 -> 0.34.0`                              |
| [`404e8283`](https://github.com/NixOS/nixpkgs/commit/404e8283e9dcd874cd4192aa298262c56e6d76c6) | `mastodon: 3.5.1 -> 3.5.2`                                             |
| [`562fdfd0`](https://github.com/NixOS/nixpkgs/commit/562fdfd04ea1565bb079a3aa29abef4be9df6018) | `kdash: 0.2.4 -> 0.3.1`                                                |
| [`7e2559da`](https://github.com/NixOS/nixpkgs/commit/7e2559da3618d78f896317ede0e8f2d7142c9db9) | `python310Packages.superqt: 0.3.1 -> 0.3.2`                            |
| [`af911e84`](https://github.com/NixOS/nixpkgs/commit/af911e8452bd05d40674bf603332f37480ceb03d) | `doctest: 2.4.7 -> 2.4.8 (#164599)`                                    |
| [`c62eceb9`](https://github.com/NixOS/nixpkgs/commit/c62eceb91e5b463974fca2bcedf033ae1f6c52db) | `openssl_3_0: 3.0.2 -> 3.0.3`                                          |
| [`9d984937`](https://github.com/NixOS/nixpkgs/commit/9d9849374f60dea33a9005b0adc96ec3595bb64c) | `python310Packages.xknx: 0.21.1 -> 0.21.2`                             |
| [`1c8e735d`](https://github.com/NixOS/nixpkgs/commit/1c8e735d76120fd2e6a42fb53e4268890c395f3b) | `python310Packages.stripe: 2.74.0 -> 2.75.0`                           |
| [`8e756d0c`](https://github.com/NixOS/nixpkgs/commit/8e756d0ce7bfae2457ceaca8d3e11c371a0f7ff6) | `python310Packages.mypy-boto3-s3: 1.22.0.post1 -> 1.22.6`              |
| [`a656052b`](https://github.com/NixOS/nixpkgs/commit/a656052b5d7a02bd49be50aef559d8a4e23f8852) | `Vulkan: Refactor (pkgconfig -> pkg-config)`                           |
| [`b04e8524`](https://github.com/NixOS/nixpkgs/commit/b04e85247425c5a4a24a43a9f7f51be4f797ae4c) | `librewolf: 99.0.1-4 -> 100.0-1`                                       |
| [`c15cf25d`](https://github.com/NixOS/nixpkgs/commit/c15cf25d3d8af5db8bd090d41a639bc912c39543) | `roon-server: 1.8-933 -> 1.8-935`                                      |
| [`23fbc081`](https://github.com/NixOS/nixpkgs/commit/23fbc0816c62f4a95f28e0cd9520f2bcff4d452a) | `hqplayerd: 4.30.3-87 -> 4.31.0-89`                                    |
| [`352750b3`](https://github.com/NixOS/nixpkgs/commit/352750b3af534ae614cd4659b2eed711d3136751) | `python39Packages.sentry-sdk: 1.5.10 -> 1.5.11`                        |
| [`3e93ff80`](https://github.com/NixOS/nixpkgs/commit/3e93ff80f8837aaadc5a3a7c0111e2fc6f39ffec) | `checkov: 2.0.1102 -> 2.0.1110`                                        |
| [`37fec07a`](https://github.com/NixOS/nixpkgs/commit/37fec07a96a35b4e996468ac9f14794929555b5f) | `python310Packages.aiooncue: 0.3.3 -> 0.3.4`                           |
| [`ac2858f9`](https://github.com/NixOS/nixpkgs/commit/ac2858f9f59a41edd516d57d85c1a9365f8f22a3) | `python310Packages.pynetgear: 0.9.4 -> 0.10.0`                         |
| [`c094f76b`](https://github.com/NixOS/nixpkgs/commit/c094f76bf94471857c43dd7406b4c807515a434d) | `python310Packages.luxtronik: 0.3.12 -> 0.3.13`                        |
| [`4fc3c441`](https://github.com/NixOS/nixpkgs/commit/4fc3c441e976e92383b90d4398556496b8f3bdf5) | `python310Packages.exceptiongroup: 1.0.0rc2 -> 1.0.0rc5`               |
| [`9600919e`](https://github.com/NixOS/nixpkgs/commit/9600919e140428252d812d03f53170ccc710b3ea) | `urlwatch: 2.24 -> 2.25`                                               |
| [`0ad18569`](https://github.com/NixOS/nixpkgs/commit/0ad185694c0b70d1f779c7ac357a8af86a46a6d6) | `opencpn: unstable-2019-11-21 -> 5.6.2`                                |
| [`aefb74d2`](https://github.com/NixOS/nixpkgs/commit/aefb74d24caf3a9a0bb88d782480bf0cf2e4ae7a) | `python310Packages.aioslimproto: 1.0.1 -> 2.0.0`                       |
| [`b75d93d7`](https://github.com/NixOS/nixpkgs/commit/b75d93d7328dea9963bff216df6c466f5cdf75ff) | `python310Packages.lektor: 3.3.3 -> 3.3.4`                             |
| [`be971bce`](https://github.com/NixOS/nixpkgs/commit/be971bce5ba1a981d4910505e686a0259a5e1bc5) | `python39Packages.loopy: 2020.2 -> 2020.2.1`                           |
| [`7f1ddd2d`](https://github.com/NixOS/nixpkgs/commit/7f1ddd2da55978274f012cd05a3b803050cabb40) | `matrix-synapse: 1.57.0 -> 1.58.0`                                     |
| [`5f3b40fd`](https://github.com/NixOS/nixpkgs/commit/5f3b40fdbeb9f46d81d2ffe4fd0b77ad88963cac) | `python310Packages.signedjson: 1.1.1 -> 1.1.4`                         |
| [`12fc9780`](https://github.com/NixOS/nixpkgs/commit/12fc9780aa9d73df78a89f34ed5e381a87ca0277) | `python310Packages.zeroconf: disable failing test`                     |
| [`1b44874d`](https://github.com/NixOS/nixpkgs/commit/1b44874d7248bb24870d2adbd04dad82742bb1a0) | `htmlcxx: 0.86 -> 0.87`                                                |
| [`01ede6f1`](https://github.com/NixOS/nixpkgs/commit/01ede6f1baec0ac450832cd80b571425a791f6f3) | `kdash: init at 0.2.4`                                                 |