### PR TITLE
chore(flake/nixpkgs): `c04ef155` -> `ab0bd3af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651654660,
-        "narHash": "sha256-ZuQ3wQwIEwqBAEOeL/mY5dV0pxuz7OIz/lzeLBIskAE=",
+        "lastModified": 1651697146,
+        "narHash": "sha256-xGF1+SiK8+/CfS0NE2oILbc9SOB8ZurRtHkYKdffBvc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c04ef155994d060aceedf946eeba0ab756b19c01",
+        "rev": "ab0bd3aff91e64bbeab321b5a182ca24428de937",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`ab0bd3af`](https://github.com/NixOS/nixpkgs/commit/ab0bd3aff91e64bbeab321b5a182ca24428de937) | `python3.pkgs.nbclient: always disable tests`                                                  |
| [`ffa38b77`](https://github.com/NixOS/nixpkgs/commit/ffa38b7712d0dbb3c39fd13500de66c2bbb90498) | `pixie: remove`                                                                                |
| [`b4cc9cd3`](https://github.com/NixOS/nixpkgs/commit/b4cc9cd38f05f1a764e21bfb1b14e89be76068b0) | `Revert "zimg: 3.0.3 -> 3.0.4" (#171566)`                                                      |
| [`8e225170`](https://github.com/NixOS/nixpkgs/commit/8e225170e2e821119c3341e102bc2ad4c9ac3046) | `prometheus-haproxy-exporter: 0.12.0 -> 0.13.0 (#171336)`                                      |
| [`a60992ba`](https://github.com/NixOS/nixpkgs/commit/a60992bad95d7de32c0ed8e68f9c4107db2baed5) | `gosec: enable tests`                                                                          |
| [`b377b29d`](https://github.com/NixOS/nixpkgs/commit/b377b29d9e097cca191ce28689dfbb956f7d8b67) | `dive: enable tests`                                                                           |
| [`c201d1bc`](https://github.com/NixOS/nixpkgs/commit/c201d1bc1dde27d4e7514ab26dd8f6713e6785fa) | `nvchecker: 2.7 -> 2.8`                                                                        |
| [`8696e36f`](https://github.com/NixOS/nixpkgs/commit/8696e36fca99fca1808feb1a953721325d0d7d7a) | `winbox: licenses.gpl3Plus -> licenses.unfree`                                                 |
| [`872280e3`](https://github.com/NixOS/nixpkgs/commit/872280e35aabaa29d5d442c71fdaab6b4a4d43c8) | `fluxcd: 0.29.5 -> 0.30.2`                                                                     |
| [`40d5cb2e`](https://github.com/NixOS/nixpkgs/commit/40d5cb2e8355e8f4346efd0325bd920df29ee133) | `fluxcd: add superherointj as maintainer`                                                      |
| [`4263a211`](https://github.com/NixOS/nixpkgs/commit/4263a2116396f8c773963078f61c57ecaeb84677) | `fluxcd: fix update script unbound variable`                                                   |
| [`ff4c5643`](https://github.com/NixOS/nixpkgs/commit/ff4c5643e6613ccf4e2a4c6aa854522e00dbc67b) | `pdepend: init at 2.10.3`                                                                      |
| [`81b77fd3`](https://github.com/NixOS/nixpkgs/commit/81b77fd3847a2eb23618b7cbaa23049ba6139fa2) | `php74Extensions.openswoole: init at 4.11.1`                                                   |
| [`f27f57a1`](https://github.com/NixOS/nixpkgs/commit/f27f57a12057bee13086ca1b1ad579eb24c214bf) | `scala-cli: 0.1.4 -> 0.1.5`                                                                    |
| [`c52b904e`](https://github.com/NixOS/nixpkgs/commit/c52b904e6664c7e9fd966ee456da2721fa667670) | `haskellPackages.streamly: fix darwin override`                                                |
| [`65d0a8d7`](https://github.com/NixOS/nixpkgs/commit/65d0a8d7a19a3fe1347df128e483435cf5ad3f98) | `python310Packages.pymyq: 3.1.4 -> 3.1.5`                                                      |
| [`141e57f5`](https://github.com/NixOS/nixpkgs/commit/141e57f59862929b77324ee2051c3330c150c8b8) | `python310Packages.sqlalchemy-mixins: 1.5.1 -> 1.5.3`                                          |
| [`2c3b8035`](https://github.com/NixOS/nixpkgs/commit/2c3b80358b89467427e090484c5f7c363bcf97d8) | `python310Packages.slack-sdk: 3.15.2 -> 3.16.0`                                                |
| [`2bca68d1`](https://github.com/NixOS/nixpkgs/commit/2bca68d1be6ad681d4becdb11ac06c7b9d038cdf) | `python39Packages.wandb: 0.12.15 -> 0.12.16`                                                   |
| [`29037ae6`](https://github.com/NixOS/nixpkgs/commit/29037ae61657e2552c12b54551ffdace720d8920) | `ungoogled-chromium: 101.0.4951.41 -> 101.0.4951.54`                                           |
| [`65be503d`](https://github.com/NixOS/nixpkgs/commit/65be503d82bb448a990d11144b7e07702ba5119d) | `xplr: 0.17.3 -> 0.17.6`                                                                       |
| [`ad38a2a6`](https://github.com/NixOS/nixpkgs/commit/ad38a2a6464394697f0672717f39c1b6188c1a89) | `nixos/ssh: remove empty host key files before generating new ones`                            |
| [`79265fba`](https://github.com/NixOS/nixpkgs/commit/79265fba343e801dd5328ae2ca2074669517328a) | `nixos/tests/openssh: add timeouts to all ssh invocations`                                     |
| [`51835cfa`](https://github.com/NixOS/nixpkgs/commit/51835cfa3cc80a3cbdbb8442900044daad0840c0) | `clojure-lsp: 2022.04.18-00.59.32 -> 2022.05.03-12.35.40`                                      |
| [`f908b3e3`](https://github.com/NixOS/nixpkgs/commit/f908b3e348ecfd7651f455d3afa7ba49b027a6ab) | `pantheon.switchboard: 6.0.0 -> 6.0.1`                                                         |
| [`561d29b6`](https://github.com/NixOS/nixpkgs/commit/561d29b64d8b61d4368277c93aced88504f70773) | `cryptomator: 1.6.8 -> 1.6.10`                                                                 |
| [`3e8e52bb`](https://github.com/NixOS/nixpkgs/commit/3e8e52bb91d0da2a06c24ae70975f8ba309eb214) | `nixos/vmware-host: init at 16.2.3`                                                            |
| [`e1da7f4d`](https://github.com/NixOS/nixpkgs/commit/e1da7f4d4483643dcb32bfbc63af281123825056) | `vmware-workstation: init at 16.2.3`                                                           |
| [`59e6af3d`](https://github.com/NixOS/nixpkgs/commit/59e6af3dc14f9dcc80eee84ff945db2734d2c547) | `linuxPackages.vmware: init at 16.2.3`                                                         |
| [`11e5f517`](https://github.com/NixOS/nixpkgs/commit/11e5f517f97739a2280c32e674c1ccbadd97d746) | `python3Packages.pyrogram: 2.0.14 -> 2.0.16`                                                   |
| [`c5a273b3`](https://github.com/NixOS/nixpkgs/commit/c5a273b38ee97ae257a0d08ac854e6f5027f2ee7) | `kiln: 0.2.1 → 0.3.0`                                                                          |
| [`b7d21e81`](https://github.com/NixOS/nixpkgs/commit/b7d21e8167119fd8bd920143f36a4dbe920d6448) | `python310Packages.webssh: 1.5.3 -> 1.6.0`                                                     |
| [`4381a279`](https://github.com/NixOS/nixpkgs/commit/4381a2796d19c099a0ee29342b105aeabd036f60) | `python310Packages.python-sql: switch to pytestCheckHook`                                      |
| [`c660b584`](https://github.com/NixOS/nixpkgs/commit/c660b584ef914cb5be8fdc45de984a725674329d) | `7kaa: fix nix-env version parsing`                                                            |
| [`9ad05a38`](https://github.com/NixOS/nixpkgs/commit/9ad05a3835662c200fbbfbe5894b7e61c31ff022) | `python310Packages.python-sql: 1.3.0 -> 1.4.0`                                                 |
| [`d61d12e3`](https://github.com/NixOS/nixpkgs/commit/d61d12e35622745b6d71cf5e63f169612083027a) | `tusk: fix nix-env version parsing`                                                            |
| [`1e1ac4e2`](https://github.com/NixOS/nixpkgs/commit/1e1ac4e2c65afde99e9420cd71893b47ac14d8bb) | `nodejs-18_x: 18.0.0 -> 18.1.0`                                                                |
| [`9765ee6b`](https://github.com/NixOS/nixpkgs/commit/9765ee6bbf893e7ecebe18915aacb323897d3e6a) | `keycloak: 17.0.1 -> 18.0.0`                                                                   |
| [`4c712af6`](https://github.com/NixOS/nixpkgs/commit/4c712af6fdf0f0952f77122175510c15f9c2fcac) | `rust-motd: 0.1.1 -> 0.2.1`                                                                    |
| [`010e2e5b`](https://github.com/NixOS/nixpkgs/commit/010e2e5b12e2464faa27554a6445cebe79c27466) | `libreoffice: add templates to dolphin "create new" menu`                                      |
| [`2d23275e`](https://github.com/NixOS/nixpkgs/commit/2d23275e050eac5dcc91675ca210c2b4a6054ed0) | `skytemple: 1.3.2 -> 1.3.10`                                                                   |
| [`009eb36c`](https://github.com/NixOS/nixpkgs/commit/009eb36cc8c88bb7bb9f6b777b47668908eedebf) | `pythonPackages.gbulb: init at 0.6.3`                                                          |
| [`ebaa5279`](https://github.com/NixOS/nixpkgs/commit/ebaa5279daf393a44b81b74be8a667af12f830ff) | `python310Packages.pyeapi: fix Python 3.10 support`                                            |
| [`251f3244`](https://github.com/NixOS/nixpkgs/commit/251f3244a7a9d6dd93b29926d70fd55181cfd12d) | `fclones: 0.22.0 -> 0.23.0`                                                                    |
| [`1eaa0f5a`](https://github.com/NixOS/nixpkgs/commit/1eaa0f5a7bb4d18262810315f871115854f7e4e2) | `python39Packages.skia-pathops: init at 0.7.9`                                                 |
| [`ae3522a4`](https://github.com/NixOS/nixpkgs/commit/ae3522a453310117cc6bb1453fef324613da9b63) | `python39Packages.glyphslib: init at 6.0.4`                                                    |
| [`a12295c1`](https://github.com/NixOS/nixpkgs/commit/a12295c1f9871d2a690b5aacd48c281865d43e59) | `pythonPackages39.openstep-plist: init at 0.3.0`                                               |
| [`76fbad7b`](https://github.com/NixOS/nixpkgs/commit/76fbad7ba64df65c3a36fb71def1215797ed964a) | `python39Packages.fontmake: init at 3.3.0`                                                     |
| [`a0ab3450`](https://github.com/NixOS/nixpkgs/commit/a0ab345013c811a3d5841c6f126b7684a96d7e92) | `freeipmi: support cross compile`                                                              |
| [`b2542b5b`](https://github.com/NixOS/nixpkgs/commit/b2542b5b05d1e750e2ade0ae339250ec72640e7d) | `aws-google-auth: 0.0.37 -> 0.0.38`                                                            |
| [`aeeb5ebd`](https://github.com/NixOS/nixpkgs/commit/aeeb5ebd00adb6e247a4a5774a8a84f24fb1cfb2) | `firewalld: init at 1.1.1`                                                                     |
| [`2bddfc7c`](https://github.com/NixOS/nixpkgs/commit/2bddfc7cd326eae64fc1dfb954ae151b7db15860) | `python39Packages.pyeapi: fix Python 3.10 support`                                             |
| [`0e00acaf`](https://github.com/NixOS/nixpkgs/commit/0e00acafe9dc8bbd9e6b49d4341b6bf49b6defb8) | `stdenv.mkDerivation: public -> finalPackage`                                                  |
| [`f066ddda`](https://github.com/NixOS/nixpkgs/commit/f066dddaa5cb6aea4429cd9386d4aa6f3963a889) | `hello: Make pname overridable without breaking src.url`                                       |
| [`ca83dd1a`](https://github.com/NixOS/nixpkgs/commit/ca83dd1ae73a94bee5c67ed21b2f6be41b195f40) | `stdenv.md: Clarify overrideAttrs sentence`                                                    |
| [`2e0bd527`](https://github.com/NixOS/nixpkgs/commit/2e0bd527623626dac4fa9937f94682ecf761af3e) | `rl-2205: Add entry for overlay-style mkDerivation overriding`                                 |
| [`37ab5b43`](https://github.com/NixOS/nixpkgs/commit/37ab5b43963f51f939b9c031a0dd824d82b41259) | `mkDerivation: Add error hint for infinite recursion`                                          |
| [`1bbb5a14`](https://github.com/NixOS/nixpkgs/commit/1bbb5a14c89427241ec2d7d6c55724332dd59803) | `doc/using/overrides: Update for overlay style mkDerivation overrideAttrs`                     |
| [`d629ba27`](https://github.com/NixOS/nixpkgs/commit/d629ba27d963664282253e6bf32d0f1a38af796a) | `Use finalAttrs instead of self for mkDerivation "overlay"`                                    |
| [`41b3688b`](https://github.com/NixOS/nixpkgs/commit/41b3688ba1222b61d19e6f810c9a1867eef69141) | `make-derivation.nix: Remove unnecessary TODO`                                                 |
| [`6d7efb3a`](https://github.com/NixOS/nixpkgs/commit/6d7efb3a16ddbc58d0c4688cbe8213b337388a0c) | `stdenv.mkDerivation: Make self more overlay-like; use self.public`                            |
| [`2f21bc2f`](https://github.com/NixOS/nixpkgs/commit/2f21bc2fdb4349ca89f3c8db9742cdaa15702a52) | `doc/stdenv/meta: tests -> passthru.tests`                                                     |
| [`40ab3b87`](https://github.com/NixOS/nixpkgs/commit/40ab3b8738b4bb10ae849712c6bdc0fdf7564e3e) | `hello: Use callPackage for test`                                                              |
| [`2afc03a0`](https://github.com/NixOS/nixpkgs/commit/2afc03a084cf736cc76f629a45a720c3c44eb27d) | `hello: Define a passthru test via new mkDerivation self arg`                                  |
| [`a4e70852`](https://github.com/NixOS/nixpkgs/commit/a4e708522768a30cd5120a65c979c87abd525336) | `stdenv.mkDerivation: Allow overriding of recursive definitions`                               |
| [`bc97215f`](https://github.com/NixOS/nixpkgs/commit/bc97215ff3ce215971e79e341ec9db3d65f8a43c) | `pferd: 3.3.1 -> 3.4.0`                                                                        |
| [`6273cb33`](https://github.com/NixOS/nixpkgs/commit/6273cb33c02bb62093196368302de1b1b0182c2b) | `wails: 2.0.0-beta.34 -> 2.0.0-beta.36`                                                        |
| [`53d9b639`](https://github.com/NixOS/nixpkgs/commit/53d9b6397c151d71ade76609a10e557c88987e2a) | `bloop: 1.4.13 -> 1.5.0`                                                                       |
| [`89ace396`](https://github.com/NixOS/nixpkgs/commit/89ace3967e0fefef19666366d64d315bae9b8f19) | `nixos/udev: systemd initrd improvements`                                                      |
| [`95fd917f`](https://github.com/NixOS/nixpkgs/commit/95fd917f4ee38d209813495d178ccc16db64cd80) | `breezy: install completions`                                                                  |
| [`205e19ce`](https://github.com/NixOS/nixpkgs/commit/205e19ce38b4ab66216a92780532173df12248f7) | `breezy: 3.2.1 -> 3.2.2`                                                                       |
| [`3219ff29`](https://github.com/NixOS/nixpkgs/commit/3219ff29a2006af52035d2a0dd4f8d6238963255) | `python39Packages.fastbencode: init at 0.0.7`                                                  |
| [`cecb014d`](https://github.com/NixOS/nixpkgs/commit/cecb014d5daeb8b0c75361ed8ba89d9e84279c8e) | `networkmanager-applet: rename from networkmanagerapplet`                                      |
| [`d9da7087`](https://github.com/NixOS/nixpkgs/commit/d9da7087c03e906ed5cc720a57f18de5329f4007) | `python310Packages.nftables: init from pkgs.nftables, reduce with lib; usage over enitre file` |
| [`113ca3c2`](https://github.com/NixOS/nixpkgs/commit/113ca3c22cf9a5afb0577948b85fc523c717ba37) | `tor: 0.4.6.10 -> 0.4.7.7`                                                                     |
| [`93f2fab5`](https://github.com/NixOS/nixpkgs/commit/93f2fab507afe51c8e848c8df26f7c1c9342879f) | `vivaldi: 5.2.2623.39-1 -> 5.2.2623.41-1`                                                      |
| [`3538ce08`](https://github.com/NixOS/nixpkgs/commit/3538ce088a6f1239040e0ec719ae4c9b060ecb4e) | `python39Packages.ufoLib2: add setuptoold-csm in nativeBuildInputs`                            |
| [`30262ff5`](https://github.com/NixOS/nixpkgs/commit/30262ff5978963cdb10d291f5d135e69932bebd6) | `python39Packages.ufo2ft: 2.26.0 -> 2.27.0`                                                    |
| [`1c2c2009`](https://github.com/NixOS/nixpkgs/commit/1c2c2009fc66d64d6fd217aa0601c610ed4f230e) | `python39Packages.fonttools: 4.30.0 -> 4.33.3`                                                 |
| [`0c8e4f4f`](https://github.com/NixOS/nixpkgs/commit/0c8e4f4f19094957758efb1be5ee4b1ebf524b45) | `pgadmin: minor bugfix in version string`                                                      |
| [`709cc706`](https://github.com/NixOS/nixpkgs/commit/709cc7066b631ebc7b97d7213385045985e6e6c9) | `pgadmin4: pass pythonEnv as variable`                                                         |
| [`f764163d`](https://github.com/NixOS/nixpkgs/commit/f764163d458b14a4b94bdeac1d7eadf991887f94) | `protoc-gen-entgrpc: init 0.2.0`                                                               |
| [`0dd6926b`](https://github.com/NixOS/nixpkgs/commit/0dd6926b29a4510d5e1d7540dd5d6a0fb485e578) | `pgadmin: revert version string`                                                               |
| [`eef222b8`](https://github.com/NixOS/nixpkgs/commit/eef222b8c2f220033fb76aa64cdfd9dcf9d6a3aa) | `pgadmin4: fix tests`                                                                          |
| [`eff62ac1`](https://github.com/NixOS/nixpkgs/commit/eff62ac1963df80205482aa6d40962f1abdfa832) | `pgadmin4: make regression test use the same packages`                                         |
| [`5cf8ef4b`](https://github.com/NixOS/nixpkgs/commit/5cf8ef4ba41161531fcfaae7e02c2c616d6902a7) | `pgadmin: add werkzeug override`                                                               |
| [`cf6b75ad`](https://github.com/NixOS/nixpkgs/commit/cf6b75adb05c0f03fa08ed4efd2f79e763f6effe) | `pgadmin: fix pgadmin4 command`                                                                |
| [`fa018142`](https://github.com/NixOS/nixpkgs/commit/fa01814245e0f6a4dedb720027db87923a404ad3) | `pgadmin4: 6.7 -> 6.8`                                                                         |
| [`9f5af25c`](https://github.com/NixOS/nixpkgs/commit/9f5af25c4b05a28c87bffa56ba247f14a88867c1) | `libosmocore: 1.2.0 -> 1.6.0`                                                                  |
| [`19acc905`](https://github.com/NixOS/nixpkgs/commit/19acc905d095a69dea1dd1bfeaf8b2709d0133bf) | `pyinfra: 2.0.1 -> 2.0.2`                                                                      |
| [`820180c4`](https://github.com/NixOS/nixpkgs/commit/820180c4f01a92dd5692d56ef0bc42d62e211727) | `maintainers: add deinferno`                                                                   |
| [`ea5cfaf8`](https://github.com/NixOS/nixpkgs/commit/ea5cfaf8e1123610ac29ef988620d06fca49bc89) | `libinjection: patch for python3 builds`                                                       |
| [`1fc0a5fb`](https://github.com/NixOS/nixpkgs/commit/1fc0a5fbee15c7564eaf49805d158199c83eac56) | `cht-sh: unstable-2022-04-17 -> unstable-2022-04-18`                                           |
| [`58b94a6e`](https://github.com/NixOS/nixpkgs/commit/58b94a6eb0f34f21be50f5c1ab40f5f0d557cc13) | `android-studio: fixing gui for tiling window managers`                                        |
| [`e1b29994`](https://github.com/NixOS/nixpkgs/commit/e1b299949eca2ce21bbf5e7a96c739b3d1d66007) | `codeql: 2.8.2 -> 2.8.5`                                                                       |
| [`18dbdee6`](https://github.com/NixOS/nixpkgs/commit/18dbdee6e19eb1e6b8f29ac64a2bf37bafadcc2b) | `nodejs: mark versions older than 14 as vulnerable`                                            |
| [`f06e9083`](https://github.com/NixOS/nixpkgs/commit/f06e90837263fcf9bf716b4fa2eda7696540f63e) | `docopt_cpp: patch to support python3 for running tests`                                       |