### PR TITLE
chore(flake/nixpkgs): `ab0bd3af` -> `19e187fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651697146,
-        "narHash": "sha256-xGF1+SiK8+/CfS0NE2oILbc9SOB8ZurRtHkYKdffBvc=",
+        "lastModified": 1651737265,
+        "narHash": "sha256-qQcVdI1ZpKitoh2mzVgi/8EYxqJx8LGKo82ZVztD7BM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ab0bd3aff91e64bbeab321b5a182ca24428de937",
+        "rev": "19e187fbabcefa3f3e608b94ed809f91524501bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`5a51d04e`](https://github.com/NixOS/nixpkgs/commit/5a51d04e450eb5fcdb31b39f9e4e4d694b89afcc) | `onedrive: 2.4.16 -> 2.4.17`                                       |
| [`b8dd32df`](https://github.com/NixOS/nixpkgs/commit/b8dd32df294ddc1b187224f52c80cd1a3bb10852) | `python310Packages.afsapi: 0.2.3 -> 0.2.4`                         |
| [`57ce8ad6`](https://github.com/NixOS/nixpkgs/commit/57ce8ad61ba3d480f450591e8108b106080f41b9) | `skytemple-rust: add Foundation library on darwin`                 |
| [`c777cdf5`](https://github.com/NixOS/nixpkgs/commit/c777cdf5c564015d5f63b09cc93bef4178b19b01) | `easycrypt-runtest: init at 2022.04`                               |
| [`b20934a6`](https://github.com/NixOS/nixpkgs/commit/b20934a65c0541c2b83b688de24e3991b3db426e) | `easycrypt: init at 2022.04`                                       |
| [`04297436`](https://github.com/NixOS/nixpkgs/commit/04297436b85ab7f78c13c7ec42fe9b2b509c3f35) | `python310Packages.sqlmap: 1.6.4 -> 1.6.5`                         |
| [`cda4885f`](https://github.com/NixOS/nixpkgs/commit/cda4885ff84f8ae8dbd0b1dd453ce33d159701a4) | `python310Packages.peaqevcore: 0.0.21 -> 0.0.22`                   |
| [`ae75c14f`](https://github.com/NixOS/nixpkgs/commit/ae75c14f83b2be85572b29cb4b7de1b2f0a17e37) | `awesome-4-0: remove`                                              |
| [`0ab6bceb`](https://github.com/NixOS/nixpkgs/commit/0ab6bcebc81cec39295802a0d76780ddf237722e) | `libdeltachat: 1.78.0 -> 1.79.0`                                   |
| [`55352488`](https://github.com/NixOS/nixpkgs/commit/5535248877bbd27bea37b0a9e1b0231159125ff5) | `rust-analyzer: 2022-04-11 -> 2022-05-02`                          |
| [`9dd25bbe`](https://github.com/NixOS/nixpkgs/commit/9dd25bbe3f416cd806d552c62a946803d4c92296) | `chezmoi: 2.15.1 -> 2.15.2`                                        |
| [`02900c45`](https://github.com/NixOS/nixpkgs/commit/02900c458d35cbfcaba832ab22b80b4c91460a59) | `tut: 0.0.42 -> 0.0.46`                                            |
| [`e02a0ba3`](https://github.com/NixOS/nixpkgs/commit/e02a0ba32c1e2bb2163414a8950f183cc52815fd) | `python310Packages.nbclient: remove comment`                       |
| [`c83d28b8`](https://github.com/NixOS/nixpkgs/commit/c83d28b8b439af732b4a4b96ea72d40f88a4f0bc) | `lookatme: remove`                                                 |
| [`11ca7ae7`](https://github.com/NixOS/nixpkgs/commit/11ca7ae7e12f602a2c9aef1142c6ca79d0e2501d) | `home-assistant: disable more dependency tests`                    |
| [`5aad7233`](https://github.com/NixOS/nixpkgs/commit/5aad723328210a7e2dfc7fcca89291cbe291bf16) | `home-assistant: 2022.4.7 -> 2022.5.0`                             |
| [`b4049c2b`](https://github.com/NixOS/nixpkgs/commit/b4049c2bc99ccddc81df2afce011d49f10a0c8f5) | `python3Packages.ansible: add meta.changelog`                      |
| [`3581eb92`](https://github.com/NixOS/nixpkgs/commit/3581eb92df53449f86128523949f4c6cf84307a0) | `python3Packages.ansible: 5.7.0 -> 5.7.1`                          |
| [`f886c041`](https://github.com/NixOS/nixpkgs/commit/f886c041ca72d7f32ae9953574231aafe3f73ccd) | `python3Packages.insteon-frontend-home-assistant: init at 0.1.0`   |
| [`9170fcf7`](https://github.com/NixOS/nixpkgs/commit/9170fcf74fa760c0f30ad207b3049047075e1652) | `python3Packages.gcal-sync: init at 0.7.1`                         |
| [`063015ee`](https://github.com/NixOS/nixpkgs/commit/063015ee9c4583bb657c564029cfc7b921d10a70) | `poetry2nix: 1.27.1 -> 1.28.0`                                     |
| [`5860a9e5`](https://github.com/NixOS/nixpkgs/commit/5860a9e5e54cb685841c2a204b5454ed50554c5d) | `senpai: unstable-2021-12-14 -> unstable-2022-04-29`               |
| [`ec0ae174`](https://github.com/NixOS/nixpkgs/commit/ec0ae174f8b273e024341d2ffbf2e9e58d30c706) | `Revert "networkmanager-applet: rename from networkmanagerapplet"` |
| [`f7269f24`](https://github.com/NixOS/nixpkgs/commit/f7269f24d57d54ffda51407ccbce8b5b792e54e9) | `vulkan-loader: fix cross-compilation`                             |
| [`440f2e1d`](https://github.com/NixOS/nixpkgs/commit/440f2e1de28ddb442c9f4298246d6bc05c1d3a60) | `python3Packages.pydeconz: 90 -> 91`                               |
| [`2401e18f`](https://github.com/NixOS/nixpkgs/commit/2401e18f68453c8752a3f1fad7ad471c0dac3388) | `python3Packages.total-connect-client: 2022.2.1 -> 2022.3`         |
| [`db3a1b15`](https://github.com/NixOS/nixpkgs/commit/db3a1b15de3094bfccb05afaeb99b4e83b7cd51b) | `python310Packages.PyChromecast: 11.0.0 -> 12.0.0`                 |
| [`f58df705`](https://github.com/NixOS/nixpkgs/commit/f58df705e7c65b58e2c3aa0b6309cf7418bc169c) | `python3Packages.voluptuous: 0.13.0 -> 0.13.1`                     |
| [`8006deeb`](https://github.com/NixOS/nixpkgs/commit/8006deeb3c9a5bdeaae390c6a25b06e5c9f72b3b) | `python3Packages.zwave-js-server-python: 0.35.3 -> 0.36.1`         |
| [`fc3ed4e8`](https://github.com/NixOS/nixpkgs/commit/fc3ed4e81c6b78dbc4500035540d2e4f5b20de27) | `python3Packages.zigpy: 0.44.2 -> 0.45.1`                          |
| [`b1a2be80`](https://github.com/NixOS/nixpkgs/commit/b1a2be803664a1acffdfde452789ec677c026211) | `python3Packages.simplisafe-python: 2022.03.3 -> 2022.5.0`         |
| [`f4c6bea0`](https://github.com/NixOS/nixpkgs/commit/f4c6bea09d5ff7defe4896fd9bf9ced7f5576c0d) | `python3Packages.pytomorrowio: 0.2.1 -> 0.3.3`                     |
| [`ed5b29c1`](https://github.com/NixOS/nixpkgs/commit/ed5b29c1cd7f1098b277add00065715fa4da9cfd) | `python310Packages.pynws: 1.3.2 -> 1.4.1`                          |
| [`f5b90ecc`](https://github.com/NixOS/nixpkgs/commit/f5b90ecc8d3cdb14bce7c88591c5d2e3dc6bcbb5) | `python310Packages.pyinsteon: 1.0.16 -> 1.1.0`                     |
| [`f12a40ff`](https://github.com/NixOS/nixpkgs/commit/f12a40ff5851af9e88c86b4252fe83dfa4968be0) | `python3Packages.pyevilgenius: 1.0.0 -> 2.0.0`                     |
| [`24971206`](https://github.com/NixOS/nixpkgs/commit/24971206cb21a0fe262b4a6d384b5c6f6c0ed3a2) | `python310Packages.pydeconz: 87 -> 90`                             |
| [`c38b06a3`](https://github.com/NixOS/nixpkgs/commit/c38b06a3dc4ca2118aa183a62b73dac0393daa0a) | `python3Packages.async-upnp-client: 0.28.0 -> 0.29.0`              |
| [`44f8ea01`](https://github.com/NixOS/nixpkgs/commit/44f8ea01e05a401439d4bef083ad96af52c7201f) | `python3Packages.androidtv: 0.0.66 -> 0.0.67`                      |
| [`9a99c652`](https://github.com/NixOS/nixpkgs/commit/9a99c65217fc31ad53780e4ccaf6bab7bcda042c) | `python3Packages.aioslimproto: 2.0.0 -> 2.0.1`                     |
| [`e9476f79`](https://github.com/NixOS/nixpkgs/commit/e9476f7925a2fddfda85720c3ee246ed4ed26fa9) | `python3Packages.aioairzone: 0.3.4 -> 0.4.2`                       |
| [`9146215b`](https://github.com/NixOS/nixpkgs/commit/9146215b37ce504c443e440a9be5acc15b77721d) | `python3Packages.nbclient: 0.5.13 -> 0.6.0`                        |
| [`5f8ac4de`](https://github.com/NixOS/nixpkgs/commit/5f8ac4de773cd78bb07809054b83f0e324b3487c) | `python3Packages.nbconvert: 6.4.5 -> 6.5.0`                        |
| [`60b4f7d8`](https://github.com/NixOS/nixpkgs/commit/60b4f7d8e86c81838c76c98a7a7b9de8aec7acd7) | `zerobin: raise version bounds for bleach to <6`                   |
| [`0c90ed17`](https://github.com/NixOS/nixpkgs/commit/0c90ed17cedcd618bdbacb45a3d5a8c5d2ee3b09) | `python3Packages.bleach: 4.1.0 -> 5.0.0`                           |
| [`2d5d1d4c`](https://github.com/NixOS/nixpkgs/commit/2d5d1d4c1326a7472c79cc6c23c2792d6cce32e1) | `pssh: 2.3.1 -> 2.3.4`                                             |
| [`de4a99db`](https://github.com/NixOS/nixpkgs/commit/de4a99db5e4a34e41175179c12f61b724472ca1e) | `brave: fix GPU acceleration on Wayland`                           |
| [`443e8f64`](https://github.com/NixOS/nixpkgs/commit/443e8f6444130d1d301ff83eed1014ac74b247ed) | `caprine-bin: 2.55.2 -> 2.55.4`                                    |
| [`166b1378`](https://github.com/NixOS/nixpkgs/commit/166b1378fe2efa45d1e354fcf65b4bbbb1e4d1c2) | `snakemake: 7.5.0 -> 7.6.1`                                        |
| [`b139ab79`](https://github.com/NixOS/nixpkgs/commit/b139ab79689e7db98bef8f5d96ccde22dc34acad) | `qownnotes: 22.4.1 -> 22.5.0`                                      |
| [`ef459179`](https://github.com/NixOS/nixpkgs/commit/ef459179d25b662126cf557299b372c213e066c9) | `python310Packages.pykulersky: 0.5.3 -> 0.5.4`                     |
| [`eb8ce992`](https://github.com/NixOS/nixpkgs/commit/eb8ce99204db35f505f0c029cf204963e5444bae) | `ssm-session-manager-plugin: 1.2.54.0 -> 1.2.312.0`                |
| [`2efd1090`](https://github.com/NixOS/nixpkgs/commit/2efd1090cf5931bd2e0f328713919ca4bc8adad7) | `rich-cli: 1.5.1 -> 1.7.0`                                         |
| [`3f87b172`](https://github.com/NixOS/nixpkgs/commit/3f87b172c76112c8674333c0f0f4680ca80bc787) | `python3Packages.textual: 0.1.15 -> 0.1.18`                        |
| [`716b60f6`](https://github.com/NixOS/nixpkgs/commit/716b60f62263e4abbfb080f56aa8733ac931779b) | `wolfssl: 5.2.0 -> 5.3.0`                                          |
| [`3c95672b`](https://github.com/NixOS/nixpkgs/commit/3c95672b22c9fc58172d6de885fd6477ce823a36) | `syft: 0.44.1 -> 0.45.1`                                           |
| [`e310b2cd`](https://github.com/NixOS/nixpkgs/commit/e310b2cd84ad1bd84b8a1e7ac47a3569142cad87) | `grype: 0.36.0 -> 0.36.1`                                          |
| [`a5151720`](https://github.com/NixOS/nixpkgs/commit/a5151720c0defe6eb8fb7d3b72874ce0c9d6ddf0) | `python39Packages.howdoi: disable failing tests`                   |
| [`ab093932`](https://github.com/NixOS/nixpkgs/commit/ab09393283f120a01b0fb52202a61cd2e742af90) | `modem-manager-gui: fix build with meson >= 0.61`                  |
| [`3ea13a6f`](https://github.com/NixOS/nixpkgs/commit/3ea13a6f55531faf8b0fb8a429c674dc277809fa) | `hare: run test suite`                                             |
| [`c3a7edf7`](https://github.com/NixOS/nixpkgs/commit/c3a7edf7d23fe20f8ba9a4e0c4b6fe6678f8e0ea) | `purescript: drop ncurses dep`                                     |
| [`7d5e8244`](https://github.com/NixOS/nixpkgs/commit/7d5e82443b3b48415d916dff97fc8ec1c25caee4) | `just: 1.1.2 -> 1.1.3`                                             |
| [`cc67617d`](https://github.com/NixOS/nixpkgs/commit/cc67617dd59d6ada1e7ee71adc145a3fdaafa78d) | `udiskie: 2.4.0 -> 2.4.2`                                          |
| [`ecf564b2`](https://github.com/NixOS/nixpkgs/commit/ecf564b266bc268bb868e66916fc55d3a18ed2b2) | `cargo-sync-readme: 1.0 -> 1.1`                                    |
| [`c0bb20e0`](https://github.com/NixOS/nixpkgs/commit/c0bb20e08e426f585b45cafc51b0ba73109a8434) | `nodejs-18_x: fix completion generation`                           |
| [`7b1a7987`](https://github.com/NixOS/nixpkgs/commit/7b1a798741ceb02aa572a73896bab88c6ea981b1) | `platformsh: 3.79.1 -> 3.79.2`                                     |
| [`70f212bb`](https://github.com/NixOS/nixpkgs/commit/70f212bb5bd19642a5d419c33dd1d4e00eb3962a) | `nodejs-14_x: 14.19.1 -> 14.19.2`                                  |
| [`596c5e7e`](https://github.com/NixOS/nixpkgs/commit/596c5e7ea26ba8c0bcd6d2f09ca7cb8202c20e70) | `Static bwa`                                                       |
| [`47588733`](https://github.com/NixOS/nixpkgs/commit/47588733783c4133de4973caa466d52d9c04992a) | `Static build for samtools`                                        |
| [`967a5d78`](https://github.com/NixOS/nixpkgs/commit/967a5d78962b88f4e91fe5e3e4497912556ea60b) | `Static builds for HTSLIB`                                         |
| [`0b1c28d5`](https://github.com/NixOS/nixpkgs/commit/0b1c28d5a1c46a7a10aa518863b1bd532824495e) | `Static build for megahit`                                         |
| [`342e99a5`](https://github.com/NixOS/nixpkgs/commit/342e99a587bbcb0db2c69ae47dfb4e810d57a950) | `seafile-client: build v8.0.7 from proper commit`                  |
| [`be8f036f`](https://github.com/NixOS/nixpkgs/commit/be8f036f64e9845e31c796932c2b78a9d3df4bcd) | `gopass: 1.14.0 → 1.14.1`                                          |
| [`bb7bb243`](https://github.com/NixOS/nixpkgs/commit/bb7bb2433e39ac57a6aa0bb2937c6ad9e5ba2644) | `cloudflared: 2022.4.1 -> 2022.5.0`                                |
| [`6a4134d8`](https://github.com/NixOS/nixpkgs/commit/6a4134d8ce7f55ab7c56c96e19d43d1a567f4f06) | `fulcio: 0.4.0 -> 0.4.1`                                           |
| [`b060edea`](https://github.com/NixOS/nixpkgs/commit/b060edea818795f18db4d5c12dc0f86e05e9ed60) | `upwork: 5.6.10.7 -> 5.6.10.13`                                    |
| [`37cada5b`](https://github.com/NixOS/nixpkgs/commit/37cada5b6183198cbecd2a481f5c60437b947960) | `vlc: 3.0.17 -> 3.0.17.3`                                          |
| [`5aec68a7`](https://github.com/NixOS/nixpkgs/commit/5aec68a7891d250f020b072a689a19e5f5c2bf1c) | `prometheus-aws-s3-exporter: 0.4.1 -> 0.5.0`                       |
| [`c25b7497`](https://github.com/NixOS/nixpkgs/commit/c25b74970d2bb272e4616a65485f560602a788cc) | `runitor: init at 0.9.2`                                           |
| [`b918d3c7`](https://github.com/NixOS/nixpkgs/commit/b918d3c71cef1b3ba8b04efe1d8ce2905dad2141) | `platformsh: 3.79.0 -> 3.79.1`                                     |
| [`26a47abf`](https://github.com/NixOS/nixpkgs/commit/26a47abfcc94d400a3e55d880d048c76c6dbb251) | `python310Packages.snowflake-connector-python: 2.7.6 -> 2.7.7`     |
| [`d64b2cc1`](https://github.com/NixOS/nixpkgs/commit/d64b2cc1e9c8f160cfa3c10ed3e9aa8b740173e7) | `twister: remove`                                                  |
| [`67b88714`](https://github.com/NixOS/nixpkgs/commit/67b887147fc935ab8587d9b712541dcbf902b48a) | `nmap: remove graphical support`                                   |
| [`1be5ae11`](https://github.com/NixOS/nixpkgs/commit/1be5ae112f4d42c1dfecd9ab555e098edfe4c401) | `xpf: remove`                                                      |
| [`8ddb45c1`](https://github.com/NixOS/nixpkgs/commit/8ddb45c1d52714d1b4ad916104273329bc923d40) | `caffe2: remove`                                                   |
| [`0fd723f3`](https://github.com/NixOS/nixpkgs/commit/0fd723f3b4e2af3338207bc39db580bc7be4c286) | `xpdf: 4.03 -> 4.04`                                               |
| [`0f1bb1f4`](https://github.com/NixOS/nixpkgs/commit/0f1bb1f41d6e1b2b546f0cf02d1a84bd4a0e2bae) | `jadx: 1.3.4 -> 1.3.5`                                             |
| [`153b2faf`](https://github.com/NixOS/nixpkgs/commit/153b2fafb01e84c98464035dbf7c8bf908ed1e30) | `goocanvas2: switch to python3`                                    |
| [`f0c470f5`](https://github.com/NixOS/nixpkgs/commit/f0c470f5eb80e484efd694451862ea8a56083b95) | `oath-toolkit: Rename from oathToolkit to oath-toolkit`            |