### PR TITLE
chore(flake/nixpkgs): `19e187fb` -> `836c52e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651737265,
-        "narHash": "sha256-qQcVdI1ZpKitoh2mzVgi/8EYxqJx8LGKo82ZVztD7BM=",
+        "lastModified": 1651784339,
+        "narHash": "sha256-AhxtftPAawgom0857uXtJVm+jIZQmcO8b6KjDGWnK3U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "19e187fbabcefa3f3e608b94ed809f91524501bb",
+        "rev": "836c52e6258794e27faa4ae68e04c183cd4f1818",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`fbccf6ea`](https://github.com/NixOS/nixpkgs/commit/fbccf6ead2e02e188daaa5a52bc98da4dc7679ea) | `python39Packages.ipywidgets: use pytestCheckHook and general cleanup`     |
| [`162d2d3a`](https://github.com/NixOS/nixpkgs/commit/162d2d3ac5a5b5add6ced417ad99ac42df45b729) | `emacs.pkgs.ement: unstable-2022-04-22 -> unstable-2022-05-05`             |
| [`c58ed2fc`](https://github.com/NixOS/nixpkgs/commit/c58ed2fc0f592ebc280bfba077ea418ce10213d1) | `python3Packages.awkward: update meta.homepage`                            |
| [`f02a08d4`](https://github.com/NixOS/nixpkgs/commit/f02a08d477f217b9772f0df082c31455f2bf6462) | `headset-charge-indicator: init at 2021-08-15`                             |
| [`881a8cbe`](https://github.com/NixOS/nixpkgs/commit/881a8cbe801431ad1676f00627e0aca42ef9cd59) | `nixos/kanidm: fix release notes`                                          |
| [`c126babb`](https://github.com/NixOS/nixpkgs/commit/c126babb28f381d307855a633a63595600a61df2) | `nixos/kanidm: init`                                                       |
| [`3b5fc1fd`](https://github.com/NixOS/nixpkgs/commit/3b5fc1fde1c0e5270fae49a30c684553f86be3c5) | `kanidm: init at 1.1.0-alpha.8`                                            |
| [`9af7f009`](https://github.com/NixOS/nixpkgs/commit/9af7f009d1dbe89a9df5421c0d28ffcd661b1beb) | `python3Packages.azure-mgmt-msi: update propagatedBuildInputs`             |
| [`974603c9`](https://github.com/NixOS/nixpkgs/commit/974603c931d773dcfb8acf2e355ed8dceeb28e94) | `ecdsautils: 0.4.0 -> 0.4.1`                                               |
| [`6bffe188`](https://github.com/NixOS/nixpkgs/commit/6bffe188e6f85409612273a8088817d6833de660) | `python310Packages.databricks-connect: 9.1.14 -> 9.1.15`                   |
| [`1d33da66`](https://github.com/NixOS/nixpkgs/commit/1d33da66a1bf17e1514d1ff7cb6567b1c0416392) | `python310Packages.aiolimiter: init at 1.0.0`                              |
| [`38c70972`](https://github.com/NixOS/nixpkgs/commit/38c709720f2864e30beeeddd499b4d3f2930b174) | `python310Packages.azure-mgmt-resource: 21.0.0 -> 21.1.0`                  |
| [`bb117f73`](https://github.com/NixOS/nixpkgs/commit/bb117f734884be975a81be01bb3eb9e71934b7c3) | `python310Packages.globus-sdk: 3.7.0 -> 3.8.0`                             |
| [`321d31a4`](https://github.com/NixOS/nixpkgs/commit/321d31a4aff87cc5ddb28fd06b99c465cbd2ed12) | `iwd: 1.26 -> 1.27`                                                        |
| [`ab27f31b`](https://github.com/NixOS/nixpkgs/commit/ab27f31b98e7ad5f6d8fca45bf7e7aaca3b4c62d) | `home-assistant: update component-packages`                                |
| [`38c5c8c0`](https://github.com/NixOS/nixpkgs/commit/38c5c8c04d6d2eaab7be63d94743960ec12a291a) | `python310Packages.raincloudy: init at 1.1.1`                              |
| [`815f83a0`](https://github.com/NixOS/nixpkgs/commit/815f83a01ee32906a5cf06fb0690a3222630d5d8) | `home-assistant: update component-packages`                                |
| [`d2905c6f`](https://github.com/NixOS/nixpkgs/commit/d2905c6fbc337d752f57d65e2c9f32f3470fc477) | `python310Packages.pyrainbird: init at 0.4.3`                              |
| [`d487bcce`](https://github.com/NixOS/nixpkgs/commit/d487bcce32a697842e2c6ed7d848995311dac66c) | `bolt: 0.9.1 → 0.9.2`                                                      |
| [`23c4e4aa`](https://github.com/NixOS/nixpkgs/commit/23c4e4aa6d0d0ab67e54d22e4fdc6692d02349cd) | `sqlite-utils: 3.26 -> 3.26.1`                                             |
| [`e9f479ec`](https://github.com/NixOS/nixpkgs/commit/e9f479eca0d2adab576fe209682c58c8769df5cb) | `librewolf: 100.0-1 -> 100.0-2`                                            |
| [`0d03ca8d`](https://github.com/NixOS/nixpkgs/commit/0d03ca8d0cda430b5dd50f5c421ad10a7ca218ea) | `hopper: 4.5.29 -> 5.5.3`                                                  |
| [`0558cb24`](https://github.com/NixOS/nixpkgs/commit/0558cb24cd5e42f55288555fb7b954ae6426f540) | `libffi_3_3: init`                                                         |
| [`cb7c4401`](https://github.com/NixOS/nixpkgs/commit/cb7c4401e644caab54621b5538a8bc32f545c347) | `maintainers: add armeenm`                                                 |
| [`f0255a6f`](https://github.com/NixOS/nixpkgs/commit/f0255a6fce5343faa1cb878c74bc3644dd2379c0) | `python310Packages.nbclient: run tests`                                    |
| [`a38b583a`](https://github.com/NixOS/nixpkgs/commit/a38b583a1c58627262c75ebaa02a434f46adb74b) | `python310Packages.setupmeta: 3.3.0 -> 3.3.1`                              |
| [`7ec5bd9e`](https://github.com/NixOS/nixpkgs/commit/7ec5bd9ecb10245a5b303e472eb3213d854ed984) | `sift: add self to maintainers`                                            |
| [`763a2d7b`](https://github.com/NixOS/nixpkgs/commit/763a2d7b16de443a008c4d479d3291f11e9da85a) | `sift: add bash completion`                                                |
| [`3b26a349`](https://github.com/NixOS/nixpkgs/commit/3b26a349c00f380915efcf5323415adcb8fa7762) | `python310Packages.impacket: 0.9.24 -> 0.10.0`                             |
| [`e33dbfd2`](https://github.com/NixOS/nixpkgs/commit/e33dbfd2887a14cc56499751e6d92798a082232f) | `opentabletdriver: 0.6.0.3 -> 0.6.0.4`                                     |
| [`6f960f08`](https://github.com/NixOS/nixpkgs/commit/6f960f08b54ff10b818a868511a9b0ea9af29913) | `home-assistant: update component-packages`                                |
| [`a2c236d7`](https://github.com/NixOS/nixpkgs/commit/a2c236d7ef082f82076215dab20ff981e862ea34) | `python310Packages.meater-python: init at 0.0.8`                           |
| [`58ec9c11`](https://github.com/NixOS/nixpkgs/commit/58ec9c11ed1af8ced8eca964fbc195dd802d0618) | `python310Packages.scancode-toolkit: relax intbitset constraint`           |
| [`0f5df81d`](https://github.com/NixOS/nixpkgs/commit/0f5df81ddb3669a6beede8987c583749a49fceba) | `python310Packages.intbitset: fix license`                                 |
| [`01853e27`](https://github.com/NixOS/nixpkgs/commit/01853e27627c2c517be4b199a41b4cf256841f85) | `bsp-layout: fix postInstall`                                              |
| [`ca8c8a1a`](https://github.com/NixOS/nixpkgs/commit/ca8c8a1a2534c16bb3d7b8f40337dbc4724ae366) | `python39Packages.wandb: use the correct nbclient dependency`              |
| [`41fbaa22`](https://github.com/NixOS/nixpkgs/commit/41fbaa228dc3fc7523f5e14ef62e761b3b2a4378) | `python3Packages.bond-api: 0.1.16 -> 0.1.17`                               |
| [`1dcc140d`](https://github.com/NixOS/nixpkgs/commit/1dcc140d7fd7837144dd3420252815e69c2cbfe2) | `sweethome3d: fix impurity`                                                |
| [`6036f050`](https://github.com/NixOS/nixpkgs/commit/6036f050e713eb002bd70063611bebc32fd26f6b) | `melody: 0.13.10 -> 0.18.0`                                                |
| [`f6c4cf25`](https://github.com/NixOS/nixpkgs/commit/f6c4cf25ffac4b6b1c5d943d0a8ec18807ffa1b4) | `flip-link: 0.1.4 -> 0.1.6`                                                |
| [`f989e139`](https://github.com/NixOS/nixpkgs/commit/f989e13983fd1619f723b42ba271fe0b781dd24b) | `zfs: Support zfs_force=y on the command line as well.`                    |
| [`3ed4d50f`](https://github.com/NixOS/nixpkgs/commit/3ed4d50f6f28a396e919c31840bfba922d53fe92) | `xfsprogs: 5.15.0 -> 5.16.0`                                               |
| [`bf59489f`](https://github.com/NixOS/nixpkgs/commit/bf59489fead28019ec634fef6353b1547ae23617) | `liferea: 1.12.9 -> 1.13.8`                                                |
| [`d0b632a1`](https://github.com/NixOS/nixpkgs/commit/d0b632a11b614058d0470474f4560baae057792b) | `proxysql: fix build`                                                      |
| [`abc98356`](https://github.com/NixOS/nixpkgs/commit/abc98356be380561a9fa57c572b498f38c720fb7) | `maintainers: add zebreus`                                                 |
| [`b8b17d9b`](https://github.com/NixOS/nixpkgs/commit/b8b17d9b8e00eb6da4e2f8d67a393f7670000fb1) | `power-profiles-daemon: 0.10.1 → 0.11.1`                                   |
| [`d9d51eec`](https://github.com/NixOS/nixpkgs/commit/d9d51eec4f3eb119bdb397d96893a1f1a3cd3ac6) | `libwebsockets: disable -Werror`                                           |
| [`e0b5ba54`](https://github.com/NixOS/nixpkgs/commit/e0b5ba54798162d18ce2dbc42911f18facae1707) | `nixos: Don't use grep to request ZFS credentials, and consider keystatus` |
| [`3a71b113`](https://github.com/NixOS/nixpkgs/commit/3a71b113299c409c0961af6295bb9f496268f25b) | `nixos: Include zfsroot in installer-systemd-stage-1 tests`                |
| [`0a161580`](https://github.com/NixOS/nixpkgs/commit/0a16158078ecf6d1cff298a3bfc3fc608d65b5ca) | `zfs: Update comment for https://github.com/zfsonlinux/zfs/pull/4943`      |
| [`8555a7fd`](https://github.com/NixOS/nixpkgs/commit/8555a7fdbfdf7d27096de9b23b650244d842780c) | `zfs: Allow three tries to decrypt datasets`                               |
| [`44a6882f`](https://github.com/NixOS/nixpkgs/commit/44a6882f55865b39f4ba9b9cb3ae3ddb661c1b24) | `nixos/stage-1-systemd: ZFS support`                                       |
| [`56ab4f61`](https://github.com/NixOS/nixpkgs/commit/56ab4f61bc8f9210f76412c615beef64246e50f3) | `nixos/lxd: improve tests`                                                 |
| [`eb50502c`](https://github.com/NixOS/nixpkgs/commit/eb50502c5fb000d0d1e5d27fa3c36d7542a213ea) | `lucenepp: install header files of lucene-contrib`                         |
| [`023a12f0`](https://github.com/NixOS/nixpkgs/commit/023a12f0ad349f999bba6cbd195d3601a6e23a6b) | `inspircd: 3.12.0 -> 3.13.0`                                               |
| [`14d54882`](https://github.com/NixOS/nixpkgs/commit/14d54882216532cf1eb3c7eee262e6f854aca996) | `libwebsockets: drop unmaintained older versions`                          |
| [`c517610e`](https://github.com/NixOS/nixpkgs/commit/c517610eeb50c86ad223fbc10ce746d1bbc2dcfa) | `swaynotificationcenter: 0.3 -> 0.5`                                       |
| [`014b59a4`](https://github.com/NixOS/nixpkgs/commit/014b59a4b891ecdec0e162677360d0777dfb5a7a) | `umockdev: Make library path references absolute`                          |
| [`35b85a12`](https://github.com/NixOS/nixpkgs/commit/35b85a126d8a23a6b563bb21308a2c067006153e) | `umockdev: 0.17.8 → 0.17.9`                                                |
| [`47f0136d`](https://github.com/NixOS/nixpkgs/commit/47f0136dab6586948f563854ce19175eb10d76b4) | `neomutt: 20220415 -> 20220429`                                            |
| [`e6acae67`](https://github.com/NixOS/nixpkgs/commit/e6acae6768384615b898d297ceb67cc9c659c8d7) | `wiki-js: 2.5.277 -> 2.5.279`                                              |
| [`f7ad1883`](https://github.com/NixOS/nixpkgs/commit/f7ad1883059b27ec9017438e81aa9ceca875b7a7) | `mediainfo-gui: 21.09 -> 22.03`                                            |
| [`7532dcd6`](https://github.com/NixOS/nixpkgs/commit/7532dcd683dbdd0d1b32ff069a73bfe4b18c6e16) | `libmediainfo: 21.09 -> 22.03`                                             |
| [`3d76f7ec`](https://github.com/NixOS/nixpkgs/commit/3d76f7ec3927f3354bc2df6760e30c2226255d61) | `input-remapper: unstable-2022-02-09 -> 1.4.2`                             |
| [`a3c0afb1`](https://github.com/NixOS/nixpkgs/commit/a3c0afb1e22616b2f9dfab6964966d4ff0e9781c) | `got: 0.68.1 -> 0.69`                                                      |
| [`4986504f`](https://github.com/NixOS/nixpkgs/commit/4986504f04680788b6c2904a1acc71135388d0dd) | `python38Packages.backports-zoneinfo: test data for zoneinfo 2022a`        |
| [`568cb2d6`](https://github.com/NixOS/nixpkgs/commit/568cb2d6abf3e0cdd6607b5e918522aba824c19f) | `nixos/systemd/nspawn: Add missing nspawn unit options`                    |
| [`0d8a3244`](https://github.com/NixOS/nixpkgs/commit/0d8a3244643cfb8982126c65263294ae9a3f66b1) | `AusweisApp2: 1.22.4 -> 1.22.5`                                            |
| [`5a47886f`](https://github.com/NixOS/nixpkgs/commit/5a47886f78abda3ec91888256b2a5d120c7c4b4c) | `microsoft-edge: 98.0.1108.56 -> 100.0.1185.44`                            |
| [`82060bee`](https://github.com/NixOS/nixpkgs/commit/82060bee0b912334d828a1d2a771fdb55694561e) | `portfolio: 0.57.1 -> 0.57.2`                                              |
| [`2f99b713`](https://github.com/NixOS/nixpkgs/commit/2f99b71368ce0cb24c1f38a136c24f3de12b34f9) | `timeular: 3.9.1 -> 4.7.1`                                                 |
| [`22419c93`](https://github.com/NixOS/nixpkgs/commit/22419c93cd3a2290a6d53b70201a702847e47275) | `weechat-otr: Fix build and knownVulnerabilities`                          |
| [`a2b02ea6`](https://github.com/NixOS/nixpkgs/commit/a2b02ea64694c35ce4a22eab2e7c005c93c7157c) | `telegraf: 1.22.0 -> 1.22.1`                                               |
| [`76591b5b`](https://github.com/NixOS/nixpkgs/commit/76591b5b62275ed19e86353c2c6c91e0267dfc15) | `psi-plus: 1.5.1615 -> 1.5.1618`                                           |
| [`dcbe74f3`](https://github.com/NixOS/nixpkgs/commit/dcbe74f3d71a4256b1bc9053d762faccfeb9254c) | `protoc-gen-twirp_php: set version`                                        |
| [`5f63e522`](https://github.com/NixOS/nixpkgs/commit/5f63e522ac18db9c8434a2ec553953b77040f925) | `protoc-gen-twirp_php: 0.8.0 -> 0.8.1`                                     |
| [`16131300`](https://github.com/NixOS/nixpkgs/commit/16131300633776df7392539249af61f73811a93a) | `p4v: 2020.1.1966006 -> 2021.3.2186916`                                    |