### PR TITLE
chore(flake/nixpkgs): `836c52e6` -> `98000933`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651784339,
-        "narHash": "sha256-AhxtftPAawgom0857uXtJVm+jIZQmcO8b6KjDGWnK3U=",
+        "lastModified": 1651827164,
+        "narHash": "sha256-w1niZCq4rhXX+23xLvrA5KR9OqT/72e5Mx/pfz/bZYU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "836c52e6258794e27faa4ae68e04c183cd4f1818",
+        "rev": "98000933d72a97632caf0db0027ea3eb2e5e7f29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
| [`98000933`](https://github.com/NixOS/nixpkgs/commit/98000933d72a97632caf0db0027ea3eb2e5e7f29) | `xdg-desktop-portal: 1.14.3 → 1.14.4`                                                                                    |
| [`b43b8c72`](https://github.com/NixOS/nixpkgs/commit/b43b8c72453e7f24b1a302d4224e62042db2fbba) | `babl: 0.1.90 → 0.1.92`                                                                                                  |
| [`b380589e`](https://github.com/NixOS/nixpkgs/commit/b380589e3efa5d3f80085c2da36560b45ff81f08) | `networkmanager-sstp: unstable-2020-04-20 → 1.3.0`                                                                       |
| [`ce919800`](https://github.com/NixOS/nixpkgs/commit/ce919800560f981da3bf4b43cee3974bd96fbd50) | `gtranslator: 41.0 → 42.0`                                                                                               |
| [`502aab90`](https://github.com/NixOS/nixpkgs/commit/502aab908218e9487e0e6ca4145ee8f3d00fb434) | `gtkmm3: 3.24.5 → 3.24.6`                                                                                                |
| [`cd1f035c`](https://github.com/NixOS/nixpkgs/commit/cd1f035c0d362790ec1308f39d03325c48a3da48) | `gnome-latex: 3.38.0 → 3.40.0`                                                                                           |
| [`76b2cceb`](https://github.com/NixOS/nixpkgs/commit/76b2cceb788893c125a1c334dafba238b0f1101e) | `gnome-desktop: 42.0 → 42.1`                                                                                             |
| [`41b15d2c`](https://github.com/NixOS/nixpkgs/commit/41b15d2c14f68b8df6322dc3ddd51fe1daf6f7f6) | `gnome.gnome-control-center: 42.0 → 42.1`                                                                                |
| [`80adbe5e`](https://github.com/NixOS/nixpkgs/commit/80adbe5e342d360acfd199dc0a18c4243ca92d96) | `glibmm: 2.66.3 → 2.66.4`                                                                                                |
| [`c478079f`](https://github.com/NixOS/nixpkgs/commit/c478079f2524ad3bbb00af796ee12baf81d0e50d) | `amtk: 5.3.1 → 5.4.0`                                                                                                    |
| [`f3fe021c`](https://github.com/NixOS/nixpkgs/commit/f3fe021cdd8c5ecd87bc507f60378aefd75b223e) | `tepl: 6.00.0 → 6.0.1`                                                                                                   |
| [`b15a9584`](https://github.com/NixOS/nixpkgs/commit/b15a9584ee92cbf9d4c97cb30afc99e27624484e) | `vala_0_56: 0.56.0 → 0.56.1`                                                                                             |
| [`828c7cb9`](https://github.com/NixOS/nixpkgs/commit/828c7cb950a59a4f75e461e3660ca32c880d40f5) | `glibmm_2_68: 2.72.0 -> 2.72.1`                                                                                          |
| [`29d63a16`](https://github.com/NixOS/nixpkgs/commit/29d63a169a51d49a15afd751101c9682231102b9) | `ocamlPackages.js_of_ocaml: 3.11.0 → 4.0.0`                                                                              |
| [`9a45461c`](https://github.com/NixOS/nixpkgs/commit/9a45461cdf08663aef68672ae67355ca83472997) | `netavark: 1.0.2 -> 1.0.3`                                                                                               |
| [`8f14ae64`](https://github.com/NixOS/nixpkgs/commit/8f14ae6428114f88d2856dc4e736ef4cf710057f) | `aardvark-dns: 1.0.2 -> 1.0.3`                                                                                           |
| [`a19c0bc4`](https://github.com/NixOS/nixpkgs/commit/a19c0bc451ff55dc88ac2a3b8740154b6e32c7e1) | `python310Packages.angrop: 9.2.1 -> 9.2.2`                                                                               |
| [`2a83b508`](https://github.com/NixOS/nixpkgs/commit/2a83b508f6f83a4d2d9568ac186af74be7642709) | `python310Packages.angr: 9.2.1 -> 9.2.2`                                                                                 |
| [`0aa4d1a1`](https://github.com/NixOS/nixpkgs/commit/0aa4d1a135311c54edd2dbd89f9e7a0e55e4a291) | `python310Packages.cle: 9.2.1 -> 9.2.2`                                                                                  |
| [`b04d6718`](https://github.com/NixOS/nixpkgs/commit/b04d6718be17436018bf4c0b7eb12c7cefed65fb) | `python310Packages.claripy: 9.2.1 -> 9.2.2`                                                                              |
| [`83f95c3a`](https://github.com/NixOS/nixpkgs/commit/83f95c3acfcec266f6c1816ffa80b541288f1fd7) | `python310Packages.pyvex: 9.2.1 -> 9.2.2`                                                                                |
| [`3d168b76`](https://github.com/NixOS/nixpkgs/commit/3d168b76e18206df1a38c81e5face4e24fdd5162) | `python310Packages.ailment: 9.2.1 -> 9.2.2`                                                                              |
| [`1a8afb33`](https://github.com/NixOS/nixpkgs/commit/1a8afb33025a5e313e654df4afd97474559270c3) | `python310Packages.archinfo: 9.2.1 -> 9.2.2`                                                                             |
| [`578f540e`](https://github.com/NixOS/nixpkgs/commit/578f540e4b5f211819435bf7bee449faafee4a4c) | `collectd: support cross compile`                                                                                        |
| [`8c41f43e`](https://github.com/NixOS/nixpkgs/commit/8c41f43ef2982c0822106374191c8eac05bde472) | `python310Packages.pex: 2.1.84 -> 2.1.85`                                                                                |
| [`5cdfc935`](https://github.com/NixOS/nixpkgs/commit/5cdfc935fa8d37297743af925091e5c7555414c9) | `python310Packages.azure-mgmt-msi: 6.0.0 -> 6.0.1`                                                                       |
| [`57330c0d`](https://github.com/NixOS/nixpkgs/commit/57330c0d38231524d3631b90b04a988c4e1e6933) | `python310Packages.stripe: 2.75.0 -> 2.76.0`                                                                             |
| [`4f67e636`](https://github.com/NixOS/nixpkgs/commit/4f67e636b3e7fd1537d646ff806433ec157a606e) | `python3Packages.Pweave: fix build`                                                                                      |
| [`df591a12`](https://github.com/NixOS/nixpkgs/commit/df591a1268ea528f34bfcb54bedff3e2ba0b0ea8) | `python3Packages.jupyter-sphinx: fix build`                                                                              |
| [`2c95c2bf`](https://github.com/NixOS/nixpkgs/commit/2c95c2bf2187512a172c8b26d9017eb71cda0197) | `python3Packages.jupyter_server: fix build`                                                                              |
| [`a081afe9`](https://github.com/NixOS/nixpkgs/commit/a081afe9e978a09ec99219cf704ff3082dc45313) | `python3Packages.nbconvert: clean up`                                                                                    |
| [`de161602`](https://github.com/NixOS/nixpkgs/commit/de161602c5913f3852afc2d71bbadd25e74f9ef6) | `python3Packages.widgetsnbextension: patch out unnecessary dependency`                                                   |
| [`6ad85fcb`](https://github.com/NixOS/nixpkgs/commit/6ad85fcb619e19338a02c68273dc8cd6ec82ef4f) | `vector: 0.21.1 -> 0.21.2`                                                                                               |
| [`d8da6a15`](https://github.com/NixOS/nixpkgs/commit/d8da6a153b7951f55f4e0243047ad4ae644b4ed5) | `nimble-unwrapped: add meta`                                                                                             |
| [`98ebce8e`](https://github.com/NixOS/nixpkgs/commit/98ebce8e1cbba1af56621fa07f7b69034d9086fb) | `vscode: 1.66.2 -> 1.67.0`                                                                                               |
| [`67b1fac1`](https://github.com/NixOS/nixpkgs/commit/67b1fac192de8d7aa566001f7c7967c340a90a2b) | `nixos/tailscale: add glibc to PATH.`                                                                                    |
| [`afbca20c`](https://github.com/NixOS/nixpkgs/commit/afbca20c70327650df050260f4fbedaec466b4c8) | `home-assistant: support notify_events component`                                                                        |
| [`70df2a9d`](https://github.com/NixOS/nixpkgs/commit/70df2a9dd30f8927bd54a050069713badff4c3a5) | `python3Packages.notify-events: init at 1.1.3`                                                                           |
| [`d8b0b625`](https://github.com/NixOS/nixpkgs/commit/d8b0b625ddba37c15e012dc09ce7d6f64bb048f1) | `home-assistant: support brunt component`                                                                                |
| [`202b93d7`](https://github.com/NixOS/nixpkgs/commit/202b93d7031212d1f59d0654a497fd50ca852904) | `python3Packages.brunt: init at 1.2.0`                                                                                   |
| [`6401b21a`](https://github.com/NixOS/nixpkgs/commit/6401b21ad3973a3a84bca74c5ff0e38b2ca37439) | `docker: 20.10.14 -> 20.10.15`                                                                                           |
| [`1e7cc37c`](https://github.com/NixOS/nixpkgs/commit/1e7cc37ca46b7e6daa477f8ccdd460797a5182d9) | `meld: Fix view not rendering with adwaita-icon-theme 42 due to removed icons`                                           |
| [`01b99ebc`](https://github.com/NixOS/nixpkgs/commit/01b99ebcffe2a03bc67744f78833d43e0d0e6747) | `docker-compose_2: 2.4.1 -> 2.5.0`                                                                                       |
| [`99a8b82a`](https://github.com/NixOS/nixpkgs/commit/99a8b82a6a47f724b6ee3092982a1557eb4dcb17) | `python310Packages.scapy: disable failing tests`                                                                         |
| [`a22128d3`](https://github.com/NixOS/nixpkgs/commit/a22128d33a6d27ae2e04c9179289fd9f19fc810d) | `checkov: 2.0.1110 -> 2.0.1118`                                                                                          |
| [`48d927f8`](https://github.com/NixOS/nixpkgs/commit/48d927f87fb60aab3d82badb61178df0b761544a) | `python310Packages.python-engineio: 4.3.1 -> 4.3.2`                                                                      |
| [`8438c097`](https://github.com/NixOS/nixpkgs/commit/8438c097b2b7125ee3eb448a26a3627f2bf66969) | `python310Packages.python-socketio: 5.5.2 -> 5.6.0`                                                                      |
| [`129d4dd6`](https://github.com/NixOS/nixpkgs/commit/129d4dd6cd5849aa47f2077561e82f7b4c344607) | `python310Packages.plugwise: remove stale description`                                                                   |
| [`045217b8`](https://github.com/NixOS/nixpkgs/commit/045217b848270f9e246555df8ad411e5536f1825) | `python310Packages.plugwise: 0.17.8 -> 0.18.0`                                                                           |
| [`eaaa1160`](https://github.com/NixOS/nixpkgs/commit/eaaa1160167c9f0832f8c871db875a3d985195a0) | `intel-graphics-compiler: move substitutes to postPatch`                                                                 |
| [`f4f9691c`](https://github.com/NixOS/nixpkgs/commit/f4f9691c9fef909ee5dd6f14da6f404852bfc3c3) | `intel-graphics-compiler: remove INSTALL_SPIRVDLL`                                                                       |
| [`37c0bfd1`](https://github.com/NixOS/nixpkgs/commit/37c0bfd127f2797ded4dbaef462ea2dc71df31b6) | `spirv-llvm-translator: remove prePatch since we don't run tests`                                                        |
| [`d14ebd79`](https://github.com/NixOS/nixpkgs/commit/d14ebd795e9fedd0a03525bf7d0884396d05143a) | `intel-graphics-compiler: reindent`                                                                                      |
| [`69a71a0e`](https://github.com/NixOS/nixpkgs/commit/69a71a0ec2da81a4213e1f0ceedb95545d9e2414) | `spirv-llvm-translator: move spirv-tools to nativeBuildInputs`                                                           |
| [`f6afb504`](https://github.com/NixOS/nixpkgs/commit/f6afb504da53fa0e0ba60bc24b94785f87642608) | `python310Packages.pyupgrade: 2.32.0 -> 2.32.1`                                                                          |
| [`000020cd`](https://github.com/NixOS/nixpkgs/commit/000020cd0c97620613fa95a646834a9ab32bc275) | `python310Packages.pyahocorasick: 1.4.1 -> 1.4.4`                                                                        |
| [`31c8ba5a`](https://github.com/NixOS/nixpkgs/commit/31c8ba5a95eafea6093181bd81e4a3015671e09c) | `python310Packages.pyvesync: 2.0.2 -> 2.0.3`                                                                             |
| [`3db1e0ad`](https://github.com/NixOS/nixpkgs/commit/3db1e0adcf40855745954d6e384d6349e10db532) | `python3Packages.pylsp-mypy: disable failing test`                                                                       |
| [`b4fd88d9`](https://github.com/NixOS/nixpkgs/commit/b4fd88d9fa47ca98dd998c99b203f343fc6bb710) | `spyder: fix build`                                                                                                      |
| [`334143a5`](https://github.com/NixOS/nixpkgs/commit/334143a57ee5042433fa84a2dd5873b4d3cd7808) | `python3Packages.qstylizer: init at 0.2.1`                                                                               |
| [`3f753238`](https://github.com/NixOS/nixpkgs/commit/3f753238a8a1b1ed5cb51ef4f85a898864b205ea) | `python3Packages.python-lsp-black: 1.1.0 -> 1.2.1`                                                                       |
| [`0d7b5a7e`](https://github.com/NixOS/nixpkgs/commit/0d7b5a7e6429c40107e795bce92c78d66e319591) | `doc: remove python-language-server from manual`                                                                         |
| [`6293aa70`](https://github.com/NixOS/nixpkgs/commit/6293aa7032b258a5a8ead1685c25a8f7906825b7) | `python3Packages.spyder-kernels: fix build`                                                                              |
| [`7dc40b75`](https://github.com/NixOS/nixpkgs/commit/7dc40b757e7bd424836665234e48017b84d7b922) | `python3Packages.python-lsp-server: 1.3.3 -> 1.4.1`                                                                      |
| [`59a76614`](https://github.com/NixOS/nixpkgs/commit/59a76614f3219348fb44389d19f933ddda4bf12c) | `treewide: chown user:group instead of user.group to fix warnings from coreutils 9.1`                                    |
| [`f18cc2cf`](https://github.com/NixOS/nixpkgs/commit/f18cc2cf02695c9d21d33beb47f2eac7b7d0d079) | `nixos/security/wrappers: chown user:group instead of user.group to fix warnings from coreutils 9.1`                     |
| [`ccf42c79`](https://github.com/NixOS/nixpkgs/commit/ccf42c7987c00fa594bc64798dc28468003e2b37) | `nixos/home-assistant: fix openFirewall`                                                                                 |
| [`5b8df072`](https://github.com/NixOS/nixpkgs/commit/5b8df072cb56f45e9b1655f26ee05f7772fbe49a) | `pre-commit: 2.18.1 -> 2.19.0`                                                                                           |
| [`cd89da18`](https://github.com/NixOS/nixpkgs/commit/cd89da18c4627cb6ae73b42b028193c5e0b4239f) | `home-assistant: support qnap component`                                                                                 |
| [`09c5faf7`](https://github.com/NixOS/nixpkgs/commit/09c5faf7b53a0d0b2dfb0714e77a062b32f02955) | `python3Packages.qnapstats: init at 0.4.0`                                                                               |
| [`5d789b12`](https://github.com/NixOS/nixpkgs/commit/5d789b1280052a68022a2e37432dd102c5d5fc5e) | `python310Packages.ciscoconfparse: 1.6.36 -> 1.6.40`                                                                     |
| [`6b1dcbb1`](https://github.com/NixOS/nixpkgs/commit/6b1dcbb1db92c6a28c0705a8c3da6682b2474c1b) | `nixos/heisenbridge: Fix stupid typo`                                                                                    |
| [`f3ce8bce`](https://github.com/NixOS/nixpkgs/commit/f3ce8bce1e67cad4493cc127c4592c9418154391) | `python310Packages.nettigo-air-monitor: 1.2.2 -> 1.2.3`                                                                  |
| [`26a64f7c`](https://github.com/NixOS/nixpkgs/commit/26a64f7c264436568ced9374cac3df3ab1ab811a) | `calamares: 3.2.56 -> 3.2.57`                                                                                            |
| [`50644fd3`](https://github.com/NixOS/nixpkgs/commit/50644fd3b13aae93697e15f237b3112c2a4fc784) | `n8n: 0.175.0 -> 0.175.1, build with Node 16`                                                                            |
| [`27194d6a`](https://github.com/NixOS/nixpkgs/commit/27194d6afb0d147cce93feb7bc1edcf3338bcaa7) | `timeular: 4.7.1 -> 4.8.0`                                                                                               |
| [`8978e807`](https://github.com/NixOS/nixpkgs/commit/8978e8072deee5f747817f48eed378087955c3f0) | `grim: upstream moved from GitHub to Sourcehut`                                                                          |
| [`4b79fa29`](https://github.com/NixOS/nixpkgs/commit/4b79fa29a60b03eafa75a0f4a92b1b96ef027a7a) | `verilator: 4.220 -> 4.222`                                                                                              |
| [`c745afad`](https://github.com/NixOS/nixpkgs/commit/c745afadf4f7870fb398cf94ddf51652d6fed2d8) | `lmdb: fix cross compilation to mingwW64`                                                                                |
| [`61fc9845`](https://github.com/NixOS/nixpkgs/commit/61fc98459ffecb70c2890d35eaa37e28bb08eda5) | `nixVersions.unstable: pre20220503 -> pre20220505`                                                                       |
| [`cc8a5580`](https://github.com/NixOS/nixpkgs/commit/cc8a55802d2b7fd7a73a46857dd72152be2380d5) | `rocclr: Re-enable support for gfx8`                                                                                     |
| [`a0b66ad3`](https://github.com/NixOS/nixpkgs/commit/a0b66ad30eace3369bc43b73a2a94dbea4560387) | `rocm-llvm: 5.0.2 -> 5.1.1`                                                                                              |
| [`4d5bc15e`](https://github.com/NixOS/nixpkgs/commit/4d5bc15ef3d31c5ab658e8b93631c8b49ec93300) | `hip: 5.0.2 -> 5.1.1`                                                                                                    |
| [`80cb0322`](https://github.com/NixOS/nixpkgs/commit/80cb0322fe80df2d6e14293f8d04da71ad9738ed) | `rocm-opencl-runtime: 5.0.2 → 5.1.1`                                                                                     |
| [`450aa4fc`](https://github.com/NixOS/nixpkgs/commit/450aa4fc2378bce4e466c4a90d2110463f4d14d1) | `rocm-runtime: 5.1.0 → 5.1.1`                                                                                            |
| [`c505c321`](https://github.com/NixOS/nixpkgs/commit/c505c32170f8cadb4e17839400278174af173d88) | `swaggerhole: init at 1.1`                                                                                               |
| [`05cfbf0a`](https://github.com/NixOS/nixpkgs/commit/05cfbf0a55261ab711a385876ee057a0eb3586f5) | `python310Packages.whispers: build as package`                                                                           |
| [`d6bd313f`](https://github.com/NixOS/nixpkgs/commit/d6bd313f07889bdeb9aefd95a7bcdb4cbb108fda) | `buildRustCrate: set meta.mainProgram to crateName`                                                                      |
| [`b9347204`](https://github.com/NixOS/nixpkgs/commit/b93472045a2e732b3fbcfd4044667ec5967b326f) | `haskellPackages.haskell-language-server: Run aarch64 plugin tests on ghc > 9.2`                                         |
| [`22918384`](https://github.com/NixOS/nixpkgs/commit/2291838453cd4fc3622aa73270390fc86c4ebf3e) | `intel-compute-runtime: 21.42.21270 -> 22.17.23034`                                                                      |
| [`4b227488`](https://github.com/NixOS/nixpkgs/commit/4b227488a13f9bd476b53cad2e2df8628efec485) | `intel-graphics-compiler: 1.0.8744 -> 1.0.11061`                                                                         |
| [`e94db331`](https://github.com/NixOS/nixpkgs/commit/e94db331e29bb53dd439d5e3a13d5484d259cf86) | `opencl-clang: 2021-06-22 -> 2022-03-16`                                                                                 |
| [`5966badd`](https://github.com/NixOS/nixpkgs/commit/5966baddb7bba01f6f59b16b1d067d53879b3b71) | `spirv-llvm-translator: 2021-06-13 -> 2022-05-04`                                                                        |
| [`4c7f7f61`](https://github.com/NixOS/nixpkgs/commit/4c7f7f61a79f9a4b90634f28063e5858b7b2fffa) | `trueseeing: init at 2.1.4`                                                                                              |
| [`1a87016d`](https://github.com/NixOS/nixpkgs/commit/1a87016de5daf980152f275a125dc65fbbae18a6) | `erosmb: init at 0.1.1`                                                                                                  |
| [`82102793`](https://github.com/NixOS/nixpkgs/commit/821027934e64a96ac530811172e8c09e7d335f58) | `hylure: init at 0.1`                                                                                                    |
| [`2862810d`](https://github.com/NixOS/nixpkgs/commit/2862810dfaa0a717fcf1924cad819cb186e689bd) | `python3Packages.hy: update meta`                                                                                        |
| [`d956922c`](https://github.com/NixOS/nixpkgs/commit/d956922c41d333efb67dd07d3b64b311a5eb7b2c) | `python3Packages.hy: add passthru.withPackages attribute`                                                                |
| [`927dffd2`](https://github.com/NixOS/nixpkgs/commit/927dffd2a7ec609c19f02c865a108e4dd5ee1830) | `python3Packages.hy: fix version`                                                                                        |
| [`72fd5b71`](https://github.com/NixOS/nixpkgs/commit/72fd5b71bc8d0591b6afb7aab227940f3c670548) | `hy: replace it with python3Packages.hy`                                                                                 |
| [`e0b9154e`](https://github.com/NixOS/nixpkgs/commit/e0b9154e58ede9becc73f1c3a8886125f11eeecc) | `python3Packages.hy: 1.0a3 -> 1.0a4`                                                                                     |
| [`58fe89e8`](https://github.com/NixOS/nixpkgs/commit/58fe89e8462d5c24f84cbb9a41a3b2fc96481105) | `python310Packages.tldextract: 3.2.1 -> 3.3.0`                                                                           |
| [`f2bb2d0c`](https://github.com/NixOS/nixpkgs/commit/f2bb2d0c3bc699fa74798c993fc5d05a802f94eb) | `usbimager: init at 1.0.8`                                                                                               |
| [`64600878`](https://github.com/NixOS/nixpkgs/commit/6460087872dbd08b869156c71f1f23b24d0cd431) | `haskellPackages: mark builds failing on hydra as broken`                                                                |
| [`6cbf6f4e`](https://github.com/NixOS/nixpkgs/commit/6cbf6f4e5ef22c9f8b51c021aef39d6e5cfff67a) | `python310Packages.pyinfra: 2.0.1 -> 2.1`                                                                                |
| [`682e5e5c`](https://github.com/NixOS/nixpkgs/commit/682e5e5cc074ce37e4f766f0b9f6637533bb67b5) | `google-cloud-sdk: 381.0.0 -> 384.0.1`                                                                                   |
| [`b8cc5a11`](https://github.com/NixOS/nixpkgs/commit/b8cc5a1131c79781a91d3c1c194c2284087596ee) | `spago: 0.20.8 -> 0.20.9`                                                                                                |
| [`e319538a`](https://github.com/NixOS/nixpkgs/commit/e319538a91d946eb38bb6044cf2acf987f5253df) | `haskellPackages.hls-fourmolu-plugin: no aarch64-linux tests`                                                            |
| [`c9979ff5`](https://github.com/NixOS/nixpkgs/commit/c9979ff597f8848b4c03d0bb272f527144d89210) | `haskellPackages.hls-rename-plugin: disable flaky tests on Darwin`                                                       |
| [`367b73a4`](https://github.com/NixOS/nixpkgs/commit/367b73a422c8267fe6e9bbae05b5fbfde09cbef2) | `haskellPackages.hls-rename-plugin: no aarch64-linux tests`                                                              |
| [`9e4be532`](https://github.com/NixOS/nixpkgs/commit/9e4be532219685cdd81e4db54f9fc061d250ba25) | `treewide: add meta.mainProgram to some libraries`                                                                       |
| [`16e15fa6`](https://github.com/NixOS/nixpkgs/commit/16e15fa68f0247d1ccc9bf94e2906097bcaa2d5c) | `treewide: add meta.mainProgram to many packages`                                                                        |
| [`97235945`](https://github.com/NixOS/nixpkgs/commit/9723594539d9edef110b0e49a52d9716d5813084) | `github-runner: 2.290.1 -> 2.291.1`                                                                                      |
| [`b9a8078d`](https://github.com/NixOS/nixpkgs/commit/b9a8078d52e60dc80796595d06ded261bd68a798) | `libgit2: 1.4.0 -> 1.4.3, add SuperSandro2000 as maintainer`                                                             |
| [`b1950abf`](https://github.com/NixOS/nixpkgs/commit/b1950abfc1760e8547bd1af1a234e45b19ac1b10) | `crossfire: fix version parsing for nix-env`                                                                             |
| [`c13eca2b`](https://github.com/NixOS/nixpkgs/commit/c13eca2ba972afdc154f39c1796cf93177c1737a) | `python3Packages.python-lsp-black: add missing dependency`                                                               |
| [`ced814af`](https://github.com/NixOS/nixpkgs/commit/ced814af20ced2b7b17da68f5ee6059781458d45) | `libreoffice-fresh: Fix build with poppler 22.04`                                                                        |
| [`6c366db3`](https://github.com/NixOS/nixpkgs/commit/6c366db32ddf8ea4fd8cf0df53348c9ae301fd99) | `haskellPackages.ghc-exactprint_1_4_1: remove at 1.4.1`                                                                  |
| [`6a8a2213`](https://github.com/NixOS/nixpkgs/commit/6a8a22133fae643f0a43b0c53c28d3a944193b4f) | `haskellPackages.jacinda: disable tests only on x86_64-darwin`                                                           |
| [`fdd493e6`](https://github.com/NixOS/nixpkgs/commit/fdd493e6bb874aaedc55457b9d762c35b3190037) | `haskellPackages.servant-cassava: allow servant 0.19`                                                                    |
| [`61ac5be0`](https://github.com/NixOS/nixpkgs/commit/61ac5be0b0f0368a3a1c7671bcd94caa7100428e) | `presage: fix gcc11 build`                                                                                               |
| [`11beba2d`](https://github.com/NixOS/nixpkgs/commit/11beba2dfc8de1593156bd2ea59303fb2c03dc19) | `open-watcom-v2-unwrapped: unstable-2022-04-29 -> unstable-2022-05-03`                                                   |
| [`c8b8c372`](https://github.com/NixOS/nixpkgs/commit/c8b8c372f16225c39dad1c8214f44043e1308430) | `kde/plasma: 5.24.4 -> 5.24.5`                                                                                           |
| [`b534d705`](https://github.com/NixOS/nixpkgs/commit/b534d7055e5f0a6fe1fd04e02b46808e787c6415) | `python310Packages.paramiko: 2.10.3 -> 2.10.4`                                                                           |
| [`52cd85f1`](https://github.com/NixOS/nixpkgs/commit/52cd85f1726c58f6c57b7eeb0be066ad7db603f2) | `python310Packages.paramiko: adopt`                                                                                      |
| [`fe8f77c2`](https://github.com/NixOS/nixpkgs/commit/fe8f77c2c086440e8756cba0abf42e7f1b155015) | `linphone: Cleanup dependencies`                                                                                         |
| [`80ab00ed`](https://github.com/NixOS/nixpkgs/commit/80ab00ed11671f5070942dc11bff092153d3bfd9) | `haskell.packages.ghc922.haskell-language-server: enable 3 plugins`                                                      |
| [`5a5c806c`](https://github.com/NixOS/nixpkgs/commit/5a5c806c9f2e0a42ef7114285d4daaba52ff29e5) | `haskell.packages.ghc922.hlint: unstable -> 3.4`                                                                         |
| [`fdfc491b`](https://github.com/NixOS/nixpkgs/commit/fdfc491ba157b3d80ac59f62e98cb2995c1efac5) | `haskell.packages.ghc922.ghc-exactprint: 1.4.1 -> 1.5.0`                                                                 |
| [`f1607201`](https://github.com/NixOS/nixpkgs/commit/f16072011c9f062bb9a0ea40c293aecae4612309) | `haskellPackages.hls-change-type-signature-plugin: dontCheck`                                                            |
| [`cb03b379`](https://github.com/NixOS/nixpkgs/commit/cb03b379274846c8b1be1affcd402a85f30ae4c8) | `pkgsCross.mingw32.gcc11Stdenv: update mcfgthread patches for gcc-11`                                                    |
| [`5d4c4678`](https://github.com/NixOS/nixpkgs/commit/5d4c4678ff1eb15e5148e8ec5161018933287134) | `haskell.packages.ghc922.hls-fourmolu-plugin: bump assertion from 1.0.2.0 to 1.0.3.0 since jailbreak is still necessary` |
| [`4d5a66a1`](https://github.com/NixOS/nixpkgs/commit/4d5a66a1b5a27c53b6d9c4bf356eb3fea4fadab1) | `haskellPackages.hls-test-utils: remove unneeded patches`                                                                |
| [`95cb7852`](https://github.com/NixOS/nixpkgs/commit/95cb7852a2b4582489e808b1253275899b94d09b) | `haskellPackages: regenerate package set based on current config`                                                        |
| [`d36e5507`](https://github.com/NixOS/nixpkgs/commit/d36e5507ffe3cb4a3dfa6872df9b31e5e7c69f6e) | `all-cabal-hashes: 2022-04-20T23:34:08Z -> 2022-05-01T06:09:30Z`                                                         |
| [`a83edfb8`](https://github.com/NixOS/nixpkgs/commit/a83edfb86b1353acf38f9a69658d157d41124f04) | `haskellPackages: stackage LTS 19.4 -> LTS 19.5`                                                                         |
| [`813f8b5e`](https://github.com/NixOS/nixpkgs/commit/813f8b5efbc827bf39416120b8a651cc1a2df8c5) | `haskellPackages: xhtml is not bundled if haddock is disabled`                                                           |
| [`4901ac20`](https://github.com/NixOS/nixpkgs/commit/4901ac200b9b039c614d0bd9422cb25e35029f5b) | `pax-utils: 1.3.3 -> 1.3.4`                                                                                              |
| [`c9a1647a`](https://github.com/NixOS/nixpkgs/commit/c9a1647adeef403328f7b222666648bf8bfa0320) | `nixos/tailscale: use systemctl restart during activation.`                                                              |
| [`acca3f4b`](https://github.com/NixOS/nixpkgs/commit/acca3f4b812c75f435ed618dca8adacac83975ac) | `nixos/plymouth: Add systemd stage 1 support`                                                                            |
| [`b0c23289`](https://github.com/NixOS/nixpkgs/commit/b0c232895a678da14daf91c365c8d75fb92e9c71) | `mapserver: switch to python3`                                                                                           |
| [`5a777566`](https://github.com/NixOS/nixpkgs/commit/5a77756649f7c95268c86dfa6fa96d65bbccd4b1) | `radicle-upstream: 0.2.12 -> 0.3.0`                                                                                      |
| [`d6d12766`](https://github.com/NixOS/nixpkgs/commit/d6d127668df3dd9c52f4aa07ef6d4755aa45ba5d) | `cmdstan: 2.17.1 -> 2.29.2`                                                                                              |
| [`7c952f77`](https://github.com/NixOS/nixpkgs/commit/7c952f772c790085de5fff2206b16720fa1fadd1) | `poppler: 22.03.0 → 22.04.0`                                                                                             |
| [`556edebe`](https://github.com/NixOS/nixpkgs/commit/556edebe3cec7ff1f4b131ff8da5478000cdea65) | `inkscape: Fix build with poppler 22.04`                                                                                 |
| [`25f2da0d`](https://github.com/NixOS/nixpkgs/commit/25f2da0d70d3d102d989497d5f44902eb9203380) | `scribusUnstable: Fix build with Poppler 22.04`                                                                          |