### PR TITLE
chore(flake/nixpkgs): `98000933` -> `afb8c54d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651827164,
-        "narHash": "sha256-w1niZCq4rhXX+23xLvrA5KR9OqT/72e5Mx/pfz/bZYU=",
+        "lastModified": 1652027045,
+        "narHash": "sha256-HrvhQn772bJG4KwfOhNkrPZaX9Jltb0DhX6pLNc32c4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "98000933d72a97632caf0db0027ea3eb2e5e7f29",
+        "rev": "afb8c54d8463f5035f6ece71cb54ba899378680f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                         |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`afb8c54d`](https://github.com/NixOS/nixpkgs/commit/afb8c54d8463f5035f6ece71cb54ba899378680f) | `lua52Packages.luasystem: fix build on darwin`                                         |
| [`13d4c4ef`](https://github.com/NixOS/nixpkgs/commit/13d4c4ef11f650cea2ec00905f668349e0160f17) | `cargo-make: 0.35.11 -> 0.35.12`                                                       |
| [`51f78a34`](https://github.com/NixOS/nixpkgs/commit/51f78a34bf57954ae30aad58aceb04da9d0e7800) | `python310Packages.poetry-dynamic-versioning: 0.15.0 -> 0.16.0`                        |
| [`8d9b3b3a`](https://github.com/NixOS/nixpkgs/commit/8d9b3b3a243151309ce603552c0f99cca0d14912) | `python310Packages.linkify-it-py: 1.0.3 -> 2.0.0`                                      |
| [`11c89da7`](https://github.com/NixOS/nixpkgs/commit/11c89da75d454dfe06313e7b3ba696af875cf38b) | `python310Packages.types-tabulate: 0.8.8 -> 0.8.9`                                     |
| [`387d0835`](https://github.com/NixOS/nixpkgs/commit/387d083590c959d02f5a606937d5ffc9088e24d8) | `rox-filer: pull upstream fix for -fno-common toolchains`                              |
| [`b9eea893`](https://github.com/NixOS/nixpkgs/commit/b9eea8930c533842f041a8af6389bff57a59615b) | `metasploit: 6.1.40 -> 6.1.41`                                                         |
| [`83cfaa76`](https://github.com/NixOS/nixpkgs/commit/83cfaa762b1881ba4b190f799af9d3f2c4e81641) | `ncrack: pull upstream fix for fno-common toolchains`                                  |
| [`8c8607d7`](https://github.com/NixOS/nixpkgs/commit/8c8607d7a39b1ce79f01b9b9d87d99e9d03989ff) | `python3Packages.total-connect-client: 2022.3 -> 2022.5`                               |
| [`6220a45f`](https://github.com/NixOS/nixpkgs/commit/6220a45fdb50dd733212a1a79a62eab1580b1324) | `python3Packages.mcstatus: 9.0.4 -> 9.1.0`                                             |
| [`a6d36a55`](https://github.com/NixOS/nixpkgs/commit/a6d36a550dd6d117ad7c18e45e46c6865c9f5aa1) | `python310Packages.fakeredis: 1.7.1 -> 1.7.4`                                          |
| [`2ddfd7e8`](https://github.com/NixOS/nixpkgs/commit/2ddfd7e81bf47cc31257b58dbc0525e0cc50e2a6) | `nixos/borgmatic: use pkgs.formats.yaml`                                               |
| [`e994576b`](https://github.com/NixOS/nixpkgs/commit/e994576b0d2824b3f8dc4442b031bccd8faadc1f) | `installation-cd-base: fix eval`                                                       |
| [`428045f3`](https://github.com/NixOS/nixpkgs/commit/428045f39b3ad96ce0e9276dbebab317200c3ada) | `bwa: pull upstream fix for -fno-common tollchains`                                    |
| [`08085640`](https://github.com/NixOS/nixpkgs/commit/08085640ee1094bb5fa18b0e962ae64c8f6cc1d8) | `scli: change maintainer @alex-eyre to @alexeyre`                                      |
| [`f18b66dd`](https://github.com/NixOS/nixpkgs/commit/f18b66dd983f88e552fcd2b069284fe4cd0217b2) | `nimbo: change maintainer @alex-eyre to @alexeyre`                                     |
| [`0f5f6f61`](https://github.com/NixOS/nixpkgs/commit/0f5f6f617a0bd880279b2178a5b85c2e07ebc4df) | `maintainers: rename @alex-eyre to @alexeyre`                                          |
| [`0a623980`](https://github.com/NixOS/nixpkgs/commit/0a623980428250b5a51bc2c0b606de733281ccba) | `python310Packages.py-canary: add format`                                              |
| [`11a0360f`](https://github.com/NixOS/nixpkgs/commit/11a0360f81537e72d7feeb23be213b9cf6c1f154) | `python310Packages.types-dateutil: 2.8.14 -> 2.8.15`                                   |
| [`5b50f0de`](https://github.com/NixOS/nixpkgs/commit/5b50f0de1d5e01c11bf612ed1ca468a645fc161b) | `xnee: pull fix pending upstream inclusion for -fno-common toolchain support`          |
| [`17acaf17`](https://github.com/NixOS/nixpkgs/commit/17acaf170887f9c7aa76d01e74b92de5123a01fd) | `kube-hunter: 0.6.5 -> 0.6.7`                                                          |
| [`3ecfee92`](https://github.com/NixOS/nixpkgs/commit/3ecfee92ed4b82aa8233e926ad8cb1bd03de06be) | `iosevka-bin: 15.2.0 -> 15.3.0`                                                        |
| [`453590ad`](https://github.com/NixOS/nixpkgs/commit/453590adec901a3f088b7c5090e6858255cc26e5) | `elasticsearch-curator: 5.8.1 -> 5.8.4`                                                |
| [`3aef2398`](https://github.com/NixOS/nixpkgs/commit/3aef23986c605532f6e971463514413d40ce2aea) | `python3Packages.requests-aws4auth: specify extras-require`                            |
| [`905f72e4`](https://github.com/NixOS/nixpkgs/commit/905f72e4ee14b426a98ab763f595a6cc3be675e3) | `python310Packages.py-canary: 0.5.1 -> 0.5.2`                                          |
| [`0cd600f9`](https://github.com/NixOS/nixpkgs/commit/0cd600f9298cfe8e3a3c06c44540dcb51e87afc7) | `dropwatch: 1.5.3 -> 1.5.4`                                                            |
| [`08a7a667`](https://github.com/NixOS/nixpkgs/commit/08a7a6670e1e583f518e11ae13e6fe490ef8cf5c) | `bashblog: add hooks on install phase`                                                 |
| [`e77d20ed`](https://github.com/NixOS/nixpkgs/commit/e77d20ed558efc22e214bdd5c7f2bc1aea4ac9ea) | `flexget: 3.3.8 -> 3.3.9`                                                              |
| [`98c41cf5`](https://github.com/NixOS/nixpkgs/commit/98c41cf5b439e1fe2c1122916646de7a35932310) | `zsh-fzf-tab: unstable-2022-02-10 -> unstable-2022-04-15`                              |
| [`d707e510`](https://github.com/NixOS/nixpkgs/commit/d707e510df39cdd8fe1d3e244371a3a9f23051d2) | `python3Packages.pyrogram: 2.0.16 -> 2.0.17`                                           |
| [`ec31b56d`](https://github.com/NixOS/nixpkgs/commit/ec31b56db168022642cbc33315209debf7aea730) | `abcmidi: 2022.04.28 -> 2022.05.05`                                                    |
| [`d51fa879`](https://github.com/NixOS/nixpkgs/commit/d51fa879756e4f79ae20e77b10a70360c6f8e340) | `lxde: bring gtk2-x11 to the scope`                                                    |
| [`d9f391d7`](https://github.com/NixOS/nixpkgs/commit/d9f391d75c562df1f411d19a364fdc4321340e83) | `python310Packages.oscrypto: 1.2.1 -> 1.3.0`                                           |
| [`a917f83e`](https://github.com/NixOS/nixpkgs/commit/a917f83e33a7187bfadc3b88a24b61801dff82fc) | `neofetch: unstable-2020-11-26 -> unstable-2020-12-10`                                 |
| [`c268cb07`](https://github.com/NixOS/nixpkgs/commit/c268cb0725f0cef8539419bc20dc956fb9ce4a30) | `lxde: refactor`                                                                       |
| [`5bfd8093`](https://github.com/NixOS/nixpkgs/commit/5bfd8093b72b0321354259cec9dc1050114a223c) | `xwinmosaic: pull upstream fix for -fno-common toolchains`                             |
| [`a8060ad8`](https://github.com/NixOS/nixpkgs/commit/a8060ad83a839fc124128ba78ffda63e9d04d4ce) | `elmPackages.{elm-test,elm-create-app...}: update nodejs dependecies`                  |
| [`5ba317f2`](https://github.com/NixOS/nixpkgs/commit/5ba317f26a36273dc576f3e358b4ad772d5b1a5f) | `python310Packages.malduck: add format`                                                |
| [`0ff07eff`](https://github.com/NixOS/nixpkgs/commit/0ff07effdc7b38cbbc744be70217104e0b255a15) | `python310Packages.karton-autoit-ripper: update stale substituteInPlace`               |
| [`c793d21b`](https://github.com/NixOS/nixpkgs/commit/c793d21b64cf18fbca5cb2da903c7e68f0a67b6f) | `python310Packages.devolo-home-control-api: 0.18.1 -> 0.18.2`                          |
| [`e9ebd66b`](https://github.com/NixOS/nixpkgs/commit/e9ebd66bf63a1a07b7449432db3938ce87becc66) | `arcan: refactor`                                                                      |
| [`3414ffe1`](https://github.com/NixOS/nixpkgs/commit/3414ffe11fd6f4783e335ad67a5ea4ad1aca6a9f) | `python310Packages.devolo-plc-api: 0.7.1 -> 0.8.0`                                     |
| [`9331ecf1`](https://github.com/NixOS/nixpkgs/commit/9331ecf18eaae1a1cbb5cc5d3c32a90960f4d20d) | `arcan.pipeworld: 0.pre+date=2021-12-03 -> 0.6.1+date=2022-04-03`                      |
| [`9642a2fe`](https://github.com/NixOS/nixpkgs/commit/9642a2fe7233027d617205dbbdb99cd46013e3d5) | `arcan.durden: 0.6.1+date=2022-03-11 -> 0.6.1+date=2022-04-16`                         |
| [`2f653769`](https://github.com/NixOS/nixpkgs/commit/2f653769f8d759b9a2e64f0ff44913843dac867e) | `freetalk: pull pending fix for -fno-common toolchains`                                |
| [`b61c2dc0`](https://github.com/NixOS/nixpkgs/commit/b61c2dc01d9fbe3b24bdbb73d8535028bdac0441) | `python310Packages.pydeps: 1.10.17 -> 1.10.18`                                         |
| [`b0d08ba0`](https://github.com/NixOS/nixpkgs/commit/b0d08ba09030cc491f8435b9f0a1c53d10d0fcf4) | `python310Packages.yalexs: 1.1.23 -> 1.1.24`                                           |
| [`319dfb27`](https://github.com/NixOS/nixpkgs/commit/319dfb2709de79379e16204c43591f1c0cd053c5) | `python310Packages.pyzerproc: 0.4.10 -> 0.4.11`                                        |
| [`7c32eb3f`](https://github.com/NixOS/nixpkgs/commit/7c32eb3fe57a78fc739e2840056bec28cf8ea132) | `all-packages.nix: reorder desktops/`                                                  |
| [`5b55f851`](https://github.com/NixOS/nixpkgs/commit/5b55f851ac310bfc993c0c3582fa071beb1f81c7) | `snakemake: 7.6.1 -> 7.6.2`                                                            |
| [`dbf2b915`](https://github.com/NixOS/nixpkgs/commit/dbf2b9152fab6b6f2aa35c32d65ceec4cc61b394) | `nixos/tests/systemd-nspawn: add test for machinectl pull-tar`                         |
| [`f398d4f0`](https://github.com/NixOS/nixpkgs/commit/f398d4f0fdc1dcd28a79beec885008d91c1cd529) | `python310Packages.types-pytz: 2021.3.7 -> 2021.3.8`                                   |
| [`eabc4578`](https://github.com/NixOS/nixpkgs/commit/eabc4578dbcd3912fee3bb37ae4d7bf1b35ea431) | `tfsec: 1.19.1 -> 1.20.0`                                                              |
| [`f2105a9f`](https://github.com/NixOS/nixpkgs/commit/f2105a9fabd117e1cdc0a50d3fc2d0863f8b3ddc) | `python310Packages.phonenumbers: 8.12.47 -> 8.12.48`                                   |
| [`ed76aec1`](https://github.com/NixOS/nixpkgs/commit/ed76aec1fd45060f30a9a13e47473a3bca34d7a9) | `python310Packages.types-toml: 0.10.6 -> 0.10.7`                                       |
| [`a6244415`](https://github.com/NixOS/nixpkgs/commit/a62444153e7589ab3cf9d3575aa4e889d0be8da4) | `duckstation: fix Cubeb under SDL interface`                                           |
| [`7699ee43`](https://github.com/NixOS/nixpkgs/commit/7699ee43269822c3844370b760507c4017bac7e1) | `citra: fix Cubeb under SDL interface`                                                 |
| [`8281169a`](https://github.com/NixOS/nixpkgs/commit/8281169ad828c9ccd2b0b1917029377316601f00) | `python310Packages.azure-mgmt-recoveryservicesbackup: diable on older Python releases` |
| [`f174d308`](https://github.com/NixOS/nixpkgs/commit/f174d308de4fe8a3854bbb4ca4f8aca5384c119b) | `python310Packages.nutils: add format`                                                 |
| [`53a2f812`](https://github.com/NixOS/nixpkgs/commit/53a2f8129cea6e67a163283d38abf8fcb7cf8520) | `python310Packages.holoviews: disable on older Python releases`                        |
| [`dcf8a34e`](https://github.com/NixOS/nixpkgs/commit/dcf8a34e1cdc2f932039efd4a5c6cc44c7b531d6) | `amberol: 0.4.3 -> 0.6.0`                                                              |
| [`7b4cc764`](https://github.com/NixOS/nixpkgs/commit/7b4cc7647f6b78cb990a5478b1e536ff7207b889) | `python310Packages.dunamai: 1.11.1 -> 1.12.0`                                          |
| [`be99d5c1`](https://github.com/NixOS/nixpkgs/commit/be99d5c1d5fe7959491383595697c78f5dd96727) | `upterm: 0.7.3 -> 0.8.2`                                                               |
| [`f1801888`](https://github.com/NixOS/nixpkgs/commit/f1801888282556727785eef66fb3f965a8e713ff) | `sigi: 3.2.1 -> 3.3.0`                                                                 |
| [`a2e220cd`](https://github.com/NixOS/nixpkgs/commit/a2e220cd65480b2d9e8e6e6bc570d7229115aa0b) | `dieharder: init at 3.31.1`                                                            |
| [`27b8af8d`](https://github.com/NixOS/nixpkgs/commit/27b8af8d1c2dc408656e0301932f1e6c69991779) | `netatalk: 3.1.12 -> 3.1.13`                                                           |
| [`47bed4ae`](https://github.com/NixOS/nixpkgs/commit/47bed4ae046a397b06318cc6ca2cfdfdf0bd7b06) | `prospector: 1.5.1 -> 1.7.7`                                                           |
| [`22898dff`](https://github.com/NixOS/nixpkgs/commit/22898dff8cdc8e9f457a1d97bd6c5dc274a2a0a2) | `pythonPackages.python-magic: Fix typo in alias`                                       |
| [`205f6c60`](https://github.com/NixOS/nixpkgs/commit/205f6c6023b1d7cf5b4e5c240afd043ef90e35d9) | `python310Packages.holoviews: 1.14.8 -> 1.14.9`                                        |
| [`4bc4e820`](https://github.com/NixOS/nixpkgs/commit/4bc4e82021b61c54115108ce8ac8301d4253102e) | `python3Packages.hatch-vcs: init at 0.2.0`                                             |
| [`2700dc9e`](https://github.com/NixOS/nixpkgs/commit/2700dc9e8e6745d557f47a955f8ca3be33798b25) | `python310Packages.azure-mgmt-recoveryservicesbackup: 4.1.1 -> 4.2.0`                  |
| [`65401d1b`](https://github.com/NixOS/nixpkgs/commit/65401d1b9fcc6f327b1c6b661fe99bb81b024b0b) | `uncrustify: 0.74.0 -> 0.75.0`                                                         |
| [`21e9ee96`](https://github.com/NixOS/nixpkgs/commit/21e9ee96a3c22fb5274d43c5e5b8958660c048a2) | `python310Packages.aws-adfs: 2.0.2 -> 2.0.3`                                           |
| [`fab6e261`](https://github.com/NixOS/nixpkgs/commit/fab6e2617d5ead762298e9d7125ba1f967cee7cb) | `python310Packages.snapcast: disable on older Python releases`                         |
| [`17b0f145`](https://github.com/NixOS/nixpkgs/commit/17b0f145a3771391ed2b2b2daf19f2846754f9f8) | `gnome.mutter: 42.0 → 42.1`                                                            |
| [`d9fed886`](https://github.com/NixOS/nixpkgs/commit/d9fed886f308001ad4fef6d8df03e4a07975282d) | `gnome.gnome-shell-extensions: 42.0 → 42.1`                                            |
| [`6f44ed88`](https://github.com/NixOS/nixpkgs/commit/6f44ed8857f4df690907deb81798feb13c74894f) | `gnome.gnome-shell: 42.0 → 42.1`                                                       |
| [`5d2dfa25`](https://github.com/NixOS/nixpkgs/commit/5d2dfa253eaf9092bfc10695e40b2c80371dd55c) | `firejail: Fix resolve binary paths in user environment`                               |
| [`6c3425e2`](https://github.com/NixOS/nixpkgs/commit/6c3425e2439a1c31cff63dbf312bca4e113b373e) | `calibre: 5.37.0 -> 5.42.0`                                                            |
| [`7b71709d`](https://github.com/NixOS/nixpkgs/commit/7b71709dcaa4847367f60621e5bedd766a01d74b) | `python3Packages.imap-tools: 0.54.0 -> 0.55.0`                                         |
| [`056d3bb4`](https://github.com/NixOS/nixpkgs/commit/056d3bb4ac3bcfeb710b5dfba7bed01968667360) | `python310Packages.snapcast: 2.1.3 -> 2.2.0`                                           |
| [`c82c56ba`](https://github.com/NixOS/nixpkgs/commit/c82c56ba783dd62de7c7dc823c0c43260f9e9401) | `bicon: unstable-2018-09-10 ->  unstable-2020-06-04`                                   |
| [`0eb15b8f`](https://github.com/NixOS/nixpkgs/commit/0eb15b8fd8e3c2ba4869ddf65595b3fe94d8adcc) | `python3Packages.contexttimer: fix typo`                                               |
| [`ecb61e6f`](https://github.com/NixOS/nixpkgs/commit/ecb61e6ff62de07d84a63383c67c0bdd442291d8) | `home-assistant: support nextbus component`                                            |
| [`b0c03acd`](https://github.com/NixOS/nixpkgs/commit/b0c03acd183ba00ca6145acfb89eff306dd59995) | `python3Packages.py-nextbusnext: init at 0.1.5`                                        |
| [`fa03d607`](https://github.com/NixOS/nixpkgs/commit/fa03d60746ae10a6149196bc08d90f8bf39c2ff1) | `python3Packages.nutils: fix test issues`                                              |
| [`c00d014a`](https://github.com/NixOS/nixpkgs/commit/c00d014a15cf005efd5388540f829438b4bc6aa1) | `catclock: 2015-10-04 -> 2021-11-15`                                                   |
| [`71f10994`](https://github.com/NixOS/nixpkgs/commit/71f10994f2ba24a6069f4c7076097a27c3b91fcb) | `simh: add -fcommon workaround`                                                        |
| [`a7241ea2`](https://github.com/NixOS/nixpkgs/commit/a7241ea207b603f3d3515b45600c3747c71bc39c) | `coq: default to 8.15`                                                                 |
| [`38dc7529`](https://github.com/NixOS/nixpkgs/commit/38dc75293de6fab9620a736962f0177bc049af8c) | `coqPackages.mathcomp-tarjan: enable with Coq 8.15`                                    |
| [`a1cb58e4`](https://github.com/NixOS/nixpkgs/commit/a1cb58e4cfcd499fd08a398ba3011e223040b744) | `coqPackages.semantics: enable with Coq 8.15`                                          |
| [`7711b577`](https://github.com/NixOS/nixpkgs/commit/7711b57784a0ef0e027f9bd465155a704810ec6a) | `coqPackages.smpl: init at 8.14 & 8.15`                                                |
| [`e34f56ce`](https://github.com/NixOS/nixpkgs/commit/e34f56ce98a9cfbea6703e65dd96fa7fa09fc91c) | `coqPackages.itauto: init at 8.14.0 & 8.15.0`                                          |
| [`f393892b`](https://github.com/NixOS/nixpkgs/commit/f393892bb369a73ff655d7336369d43fd45f06ff) | `coqPackages.smtcoq: disable for Coq > 8.13`                                           |
| [`e9d3fe8f`](https://github.com/NixOS/nixpkgs/commit/e9d3fe8f289627ed3f224339241d7317675effc2) | `coqPackages.goedel: enable with Coq 8.15`                                             |
| [`4847e438`](https://github.com/NixOS/nixpkgs/commit/4847e4382c9ae9691bf1f20d32c4c64c44a7e3b3) | `coqPackages.category-theory: enable with Coq 8.15`                                    |
| [`d317484d`](https://github.com/NixOS/nixpkgs/commit/d317484de16e4446c2771826c6eb1d853eb0297d) | `coqPackages.graph-theory: enable for Coq 8.15`                                        |
| [`94c97dfa`](https://github.com/NixOS/nixpkgs/commit/94c97dfa94876f455c3eacd48ae1a9d0b24d5daa) | `coqPackages.QuickChick: 1.5.0 → 1.6.2`                                                |
| [`98912aaa`](https://github.com/NixOS/nixpkgs/commit/98912aaadfbe51243925beb53597df2459becae6) | `python3Packages.async-lru: unstable-2022-02-03 -> 1.0.3`                              |
| [`1532844b`](https://github.com/NixOS/nixpkgs/commit/1532844bcfc507b81a92104321aa11bfc7cab486) | `facetimehd-calibration: add alexshpilkin as maintainer`                               |
| [`60ad3e3b`](https://github.com/NixOS/nixpkgs/commit/60ad3e3bb19ea76268d928909e44de5825f8e23b) | `python310Packages.yte: 1.2.2 -> 1.2.3`                                                |
| [`d91435f8`](https://github.com/NixOS/nixpkgs/commit/d91435f85b231c8faff411829db86079849a557a) | `maintainers: add alexshpilkin`                                                        |
| [`1b7407f8`](https://github.com/NixOS/nixpkgs/commit/1b7407f8a13834b0a0769964661d1869254d5903) | `python310Packages.mypy-boto3-s3: 1.22.6 -> 1.22.8`                                    |
| [`c489ec67`](https://github.com/NixOS/nixpkgs/commit/c489ec67bfb933856bd5e7ce8d3f99fa82800fd0) | `python310Packages.trimesh: 3.11.2 -> 3.12.0`                                          |
| [`78b446e0`](https://github.com/NixOS/nixpkgs/commit/78b446e0aa538dd76a6cdbad0b377ae3df4e91fd) | `python310Packages.hahomematic: 1.2.2 -> 1.3.0`                                        |
| [`4655bf1c`](https://github.com/NixOS/nixpkgs/commit/4655bf1cf480fcedff4a92cc474bd51e2a0a1d76) | `rust-analyzer: Update repo owner`                                                     |
| [`18c33779`](https://github.com/NixOS/nixpkgs/commit/18c337799397829017cb9aaa7e44cd9d5886f744) | `ffmpeg-normalize: 1.22.10 -> 1.23.0`                                                  |
| [`9669d16f`](https://github.com/NixOS/nixpkgs/commit/9669d16f9a471e442b9df38e01651a33058d92bb) | `taplo-cli: 0.6.1 -> 0.6.2`                                                            |
| [`20ec825c`](https://github.com/NixOS/nixpkgs/commit/20ec825c44929f70d05c996289d80809d1ff7fbc) | `eksctl: 0.95.0 -> 0.96.0`                                                             |
| [`4bdef23d`](https://github.com/NixOS/nixpkgs/commit/4bdef23d6a0b1fb19c8ec7551467813fe74aca02) | `cargo-expand: 1.0.16 -> 1.0.19`                                                       |
| [`bd037e7f`](https://github.com/NixOS/nixpkgs/commit/bd037e7f3a4ee67016cca70711bf018652d76255) | `brook: 20220406 -> 20220501`                                                          |
| [`be9c4140`](https://github.com/NixOS/nixpkgs/commit/be9c4140e74d9fe094ed00f9bd4d92e154f38f79) | `python310Packages.urwid: add SuperSandro2000 as maintainer, enable on python2 again`  |
| [`1069f1d1`](https://github.com/NixOS/nixpkgs/commit/1069f1d1a740e35f631ba4cd7e7e855b84535dca) | `python310Packages.xmltodict: adopt`                                                   |
| [`c70641c8`](https://github.com/NixOS/nixpkgs/commit/c70641c8d9aaeb8bbb8a759739646b262b77bbd2) | `rhythmbox: 3.4.4 → 3.4.5`                                                             |
| [`90fe3b14`](https://github.com/NixOS/nixpkgs/commit/90fe3b144bcd2e05e1b44857e56d42340ea66a61) | `babashka: 0.8.1 -> 0.8.2`                                                             |
| [`57bce154`](https://github.com/NixOS/nixpkgs/commit/57bce154f5becf2b43420179b0513de4af7f907c) | `sqlfluff: 0.13.0 -> 0.13.1`                                                           |