### PR TITLE
chore(flake/nixpkgs): `afb8c54d` -> `58585adb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652027045,
-        "narHash": "sha256-HrvhQn772bJG4KwfOhNkrPZaX9Jltb0DhX6pLNc32c4=",
+        "lastModified": 1652060829,
+        "narHash": "sha256-ND2od94mb0z7YKDvrMA/CYRgFz35uaCenNlu0vwPp/A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "afb8c54d8463f5035f6ece71cb54ba899378680f",
+        "rev": "58585adbcd7fa9889d3d3731fc9c1766317dec77",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
| [`e1309bdb`](https://github.com/NixOS/nixpkgs/commit/e1309bdbd4a6cff21a21782c29f9eea6b47145b1) | `rofi-rbw : init at 0.5.0 (#171160)`                                                                  |
| [`419af304`](https://github.com/NixOS/nixpkgs/commit/419af30452f089f5b07820485b4df4703160713d) | `Enable multithreading for cfitsio (#168579)`                                                         |
| [`0d5fb7da`](https://github.com/NixOS/nixpkgs/commit/0d5fb7da36b483f410036a6ca503c7cebf0b9fd9) | `home-assistant: 2022.5.2 -> 2022.5.3`                                                                |
| [`f7aaeb93`](https://github.com/NixOS/nixpkgs/commit/f7aaeb935564c74d1583ac519ab5be0ca1365f6a) | `python3Packages.ukrainealarm: init at 0.0.1`                                                         |
| [`e4b55064`](https://github.com/NixOS/nixpkgs/commit/e4b550643cae8e0853277f106d38963364fccd16) | `polymc: 1.2.1 -> 1.2.2`                                                                              |
| [`489e27ef`](https://github.com/NixOS/nixpkgs/commit/489e27efa8a8680fa3cb2cb089e81168ae4b0647) | `libressl_3_5: init at 3.5.2`                                                                         |
| [`da4707d6`](https://github.com/NixOS/nixpkgs/commit/da4707d6366e0784116102743c58c89d98b7ac68) | `window-managers/sway: enable strictDeps`                                                             |
| [`56bd1c58`](https://github.com/NixOS/nixpkgs/commit/56bd1c58b579655bbca5e0162fb6a2f22ea16f6e) | `swaylock: enable strictDeps and pull patch to fix cross`                                             |
| [`1d82f62a`](https://github.com/NixOS/nixpkgs/commit/1d82f62aefd35988d9210942bbfeff1f677970d1) | `UHK-agent: Support for Ultimate Hacking Keyboard udev-rules and configuration application (#132420)` |
| [`2f677eae`](https://github.com/NixOS/nixpkgs/commit/2f677eae73fd58b85dcd82f85002c8550adc0a59) | `imagemagick: 7.1.0-32 -> 7.1.0-33`                                                                   |
| [`9dc9e434`](https://github.com/NixOS/nixpkgs/commit/9dc9e4344d1a0a2eac4b77253f6e2d75682dc2bd) | `getmail6: 6.18.6 -> 6.18.7`                                                                          |
| [`a2675e7e`](https://github.com/NixOS/nixpkgs/commit/a2675e7e293fe53d9ab3b0ac47b8814cf2c2adcb) | `python3Packages.twisted: use extras-require`                                                         |
| [`c07476f4`](https://github.com/NixOS/nixpkgs/commit/c07476f4c596443a6d29d430526c0c510858a5fe) | `privacyidea: fix sqlalchemy hash`                                                                    |
| [`99597986`](https://github.com/NixOS/nixpkgs/commit/995979860bbbd9f31a31c0c306f857e4d2c2ecb2) | `python3Packages.trytond: 6.2.6 -> 6.4.0`                                                             |
| [`921f4f96`](https://github.com/NixOS/nixpkgs/commit/921f4f96eae4a51fa8a7dee3f298355d0ef08c01) | `python3Packages.relatorio: 0.10.0 -> 0.10.1`                                                         |
| [`99ed2710`](https://github.com/NixOS/nixpkgs/commit/99ed27107eafcd4bad40d0dbb1b65b92616bb98c) | `python3Packages.passlib: specify extras-require`                                                     |
| [`8655fac3`](https://github.com/NixOS/nixpkgs/commit/8655fac3536ba3564daf95544a22dd70c1dfb335) | `pylint: add longDescription`                                                                         |
| [`0596c29b`](https://github.com/NixOS/nixpkgs/commit/0596c29b4a60e5c2f764b2d3e0873c4dbeadfb8b) | `pylint: add totoroot as maintainer`                                                                  |
| [`16e2b76b`](https://github.com/NixOS/nixpkgs/commit/16e2b76b1a5a8b0ee8007881f41432dc5319f9ae) | `pylint: add top-level package`                                                                       |
| [`72fe39ec`](https://github.com/NixOS/nixpkgs/commit/72fe39ecf33631f759c84f8af5627ee581ef71bc) | `qogir-theme: 2021-12-25 -> 2022-04-29 (#171132)`                                                     |
| [`5c52081c`](https://github.com/NixOS/nixpkgs/commit/5c52081c13eed291246b12c6ea5660296a7d4193) | `slurm: 21.08.7.1 -> 21.08.8.2`                                                                       |
| [`b330818d`](https://github.com/NixOS/nixpkgs/commit/b330818d6962afbc202ee6b56314e611f95e2ae8) | `ovftool: init at 4.4.1`                                                                              |
| [`7ae04c1c`](https://github.com/NixOS/nixpkgs/commit/7ae04c1c4d6f4a2b10214c8ffa248f1cb4ca4a8b) | `xorg.xcbutilerrors: add dev output to not propagate a dev output`                                    |
| [`1391482b`](https://github.com/NixOS/nixpkgs/commit/1391482b41a65d67fd2a5af3ac670264a0f6b2db) | `virtctl: init at 0.52.0 (#171734)`                                                                   |
| [`d9361ea3`](https://github.com/NixOS/nixpkgs/commit/d9361ea36c54030f916a972a2634aa3939187091) | `Revert "python310Packages.m2r: adopt, run tests"`                                                    |
| [`26ec7081`](https://github.com/NixOS/nixpkgs/commit/26ec7081d647a51d63ac0695ad43758178f6962a) | `nixos/usbrelayd: set myself as module maintainer`                                                    |
| [`98152f70`](https://github.com/NixOS/nixpkgs/commit/98152f70fddfc38eb6cfcb07dbd0458c51e5dfb0) | `gnum4: Disable stack protector when using MinGW (#171828)`                                           |
| [`13870b02`](https://github.com/NixOS/nixpkgs/commit/13870b025a2729370f32b9145329243d9a0d7626) | `python310Packages.m2r: adopt, run tests`                                                             |
| [`3effbca0`](https://github.com/NixOS/nixpkgs/commit/3effbca0bc361f406cc22e6bd5f18edd7b6fa413) | `usbrelay: 0.9 -> 1.0`                                                                                |
| [`c353f171`](https://github.com/NixOS/nixpkgs/commit/c353f171b98440def5b11c4553cc4ac9eb71f3f3) | `horizon-eda: 2.2.0 -> 2.3.0`                                                                         |
| [`fe4650c4`](https://github.com/NixOS/nixpkgs/commit/fe4650c43670771ab61c8819b986295c4d7f8fc1) | `aerc: 0.9.0 -> 0.10.0`                                                                               |
| [`49dce718`](https://github.com/NixOS/nixpkgs/commit/49dce7182fe550d190b73ede64295c486c1b6763) | `stlink: fix stlink build for macos`                                                                  |
| [`14aa4a4d`](https://github.com/NixOS/nixpkgs/commit/14aa4a4d0ddf9a9471a199cabfc3d35e6b66a0dd) | `luaPackages.vicious: 2.5.0 -> 2.5.1`                                                                 |
| [`f0eff199`](https://github.com/NixOS/nixpkgs/commit/f0eff1991c228cd7b7be76a827aba0c2b0aa57f9) | `kitty: libGL doesn't have to be a propagatedBuildInputs`                                             |
| [`9db1d178`](https://github.com/NixOS/nixpkgs/commit/9db1d1782b74f6717d2c5b3d171d60596b05a9fc) | `nixos/tinc: unbreak the service`                                                                     |
| [`fdca0048`](https://github.com/NixOS/nixpkgs/commit/fdca00482fdb55b07b4507079d80ab9617bcdd2e) | `arduino-cli: 0.20.2 -> 0.21.1`                                                                       |
| [`f6c5c129`](https://github.com/NixOS/nixpkgs/commit/f6c5c1292ab690ea2e6d07f17eb0f2b5e9c65923) | `vimb: 3.3.0 -> 3.6.0`                                                                                |
| [`e8dc36df`](https://github.com/NixOS/nixpkgs/commit/e8dc36df5cd2eb680ca7c0663372477461705acc) | `python310Packages.pkutils: 2.0.0 -> 3.0.2`                                                           |
| [`fb7b4d04`](https://github.com/NixOS/nixpkgs/commit/fb7b4d044e56f55d2dc0082fda1ba705017824c8) | `jenkins: 2.332.2 -> 2.332.3`                                                                         |
| [`fa43ff6f`](https://github.com/NixOS/nixpkgs/commit/fa43ff6fe432039aaf9f410ae97a40d7675359cd) | `mautrix-facebook: 0.4.0 -> 2022-05-06-5e2c4e7f`                                                      |
| [`c1bdd973`](https://github.com/NixOS/nixpkgs/commit/c1bdd973d0c8def3345fa55c87d7979edde756d2) | `python310Packages.python-trovo: 0.1.5 -> 0.1.6`                                                      |
| [`80a74ba3`](https://github.com/NixOS/nixpkgs/commit/80a74ba322bd3a0f2402837a769b8192c59754f4) | `libsForQt5.mauikit-texteditor: init at 2.1.1`                                                        |
| [`9b4f18ae`](https://github.com/NixOS/nixpkgs/commit/9b4f18aeee4ef233d3b1da78f8000f8c227bb524) | `libsForQt5.mauikit-accounts: init at 2.1.1`                                                          |
| [`37b5883f`](https://github.com/NixOS/nixpkgs/commit/37b5883fe6ac5514dbaf27adba2c788b9ad8ec47) | `binance: 1.30.1 -> 1.35.0`                                                                           |
| [`04f6a432`](https://github.com/NixOS/nixpkgs/commit/04f6a432c45f47560680f29595ffffe6a6644821) | `Update link from old nix manual to current stable one`                                               |
| [`527f2375`](https://github.com/NixOS/nixpkgs/commit/527f2375d0c75641c8cebd2b00a6bea5820a1338) | `k3s: 1.23.5+k3s1 -> 1.23.6+k3s1`                                                                     |
| [`399cbca0`](https://github.com/NixOS/nixpkgs/commit/399cbca0a3650b8cf6c88ff6bfc541345debeb4b) | `kak-lsp: 12.1.0 -> 12.2.0`                                                                           |
| [`2d019e09`](https://github.com/NixOS/nixpkgs/commit/2d019e0931aadb3ef29a17f501e55362ec210559) | `stdenv: deprecate unused adapters`                                                                   |
| [`44a91b71`](https://github.com/NixOS/nixpkgs/commit/44a91b715327dc058b30265a9c787da640095f26) | `monkeysAudio: Update license`                                                                        |
| [`f8ee62b3`](https://github.com/NixOS/nixpkgs/commit/f8ee62b3dccac88700dbfb5c7650cd718259386b) | `monkeysAudio: Add -old suffix to pname - to update URL`                                              |
| [`0b084cd7`](https://github.com/NixOS/nixpkgs/commit/0b084cd7afc8fa706026339cb0d0a982377a6397) | `monkeysAudio: Fix compilation using an older version of gcc`                                         |
| [`e3104e95`](https://github.com/NixOS/nixpkgs/commit/e3104e95c5ad501e85828642b086e468222440ff) | `sublime-merge-dev: 2067 → 2070`                                                                      |
| [`cd9591cc`](https://github.com/NixOS/nixpkgs/commit/cd9591ccd9fd5584288efe4aa8566d70e72600f8) | `sublime-merge: 2068 → 2071`                                                                          |
| [`51838e18`](https://github.com/NixOS/nixpkgs/commit/51838e184e797af125183e62c17a81116bc37942) | `flashfocus: use make it possible to use nc_flash_window`                                             |
| [`165d8e6d`](https://github.com/NixOS/nixpkgs/commit/165d8e6db51dc8b5699f5d43263e174af876d930) | `netcat-openbsd: init at 1.218-5`                                                                     |
| [`d9c32163`](https://github.com/NixOS/nixpkgs/commit/d9c321639ccbdb32948056f1a2934eec1244b8f7) | `jpegrescan: 2016-06-01 -> 2019-03-27`                                                                |
| [`3ae56658`](https://github.com/NixOS/nixpkgs/commit/3ae5665843f2cbd341b29d9a387039f3cffd3fba) | `libyang: 2.0.164 -> 2.0.194`                                                                         |
| [`414083d8`](https://github.com/NixOS/nixpkgs/commit/414083d8cf4a94e426c4b36b0ee497b8048b0c5c) | `python310Packages.treq: adopt, enable tests, cleanup dependencies`                                   |
| [`3863692d`](https://github.com/NixOS/nixpkgs/commit/3863692d0046753ad4707a41b2891d14201b983b) | `deadpixi-sam-unstable: fix remote connection and add icon`                                           |
| [`3592ccf6`](https://github.com/NixOS/nixpkgs/commit/3592ccf6cc19460bf585a61d43ebedd28cc34018) | `kicad-unstable: 2022-03-19 -> 2022-05-06`                                                            |
| [`4fa28aad`](https://github.com/NixOS/nixpkgs/commit/4fa28aadcdd1015a2e42000ab68ac1575626f04b) | `python39Packages.pdfminer: 20220319 -> 20220506`                                                     |
| [`a198efc3`](https://github.com/NixOS/nixpkgs/commit/a198efc31350f957f9b10df0cf40bbb7223ed57a) | `python3Packages.python-memcached: 1.51 -> 1.59`                                                      |
| [`64436e0d`](https://github.com/NixOS/nixpkgs/commit/64436e0df5cfea5e8ddfa85ab21aabf9e78f446d) | `kicad: 6.0.4 -> 6.0.5`                                                                               |
| [`97a2e11a`](https://github.com/NixOS/nixpkgs/commit/97a2e11a75b9f5cc30e4e68bd901d39dd372e485) | `protobuf: remove 3.1`                                                                                |
| [`dacd54d3`](https://github.com/NixOS/nixpkgs/commit/dacd54d3f71303bffad8002084d2e117d8321464) | `openjdk: mark major version 12 through 16 as EOL`                                                    |
| [`d4b3932c`](https://github.com/NixOS/nixpkgs/commit/d4b3932c4433cb59d4b825d71622bb37fb988281) | `bdfresize: init at 1.5`                                                                              |
| [`160094c9`](https://github.com/NixOS/nixpkgs/commit/160094c9ecfcc739c7779f69309b6fc713866663) | `hydrus: 482 -> 483`                                                                                  |
| [`6051f802`](https://github.com/NixOS/nixpkgs/commit/6051f8028dd0487d73a657b524e4247934d34350) | `nixos/tools: move firefox into user packages`                                                        |
| [`b469011b`](https://github.com/NixOS/nixpkgs/commit/b469011b7ef3825f9432291464fd00b964a186a9) | `rgp: 1.12 -> 1.13`                                                                                   |
| [`e168e463`](https://github.com/NixOS/nixpkgs/commit/e168e46338e1659bd4c366c685da31810466090b) | `chickenPackages: recurse into attrs`                                                                 |
| [`3caced88`](https://github.com/NixOS/nixpkgs/commit/3caced8853a95b280c1afeb3516348768bffe372) | `go-junit-report: 2018-06-14 -> 1.0.0`                                                                |
| [`1d0ffa45`](https://github.com/NixOS/nixpkgs/commit/1d0ffa450b2025f188d81df73ebbce764c872e25) | `compile-daemon: 2017-03-08 -> 1.4.0`                                                                 |
| [`e602c06b`](https://github.com/NixOS/nixpkgs/commit/e602c06be76673aaa1afd57d66be93d91174e276) | `zigbee2mqtt: 1.25.0 -> 1.25.1`                                                                       |
| [`c9f742f7`](https://github.com/NixOS/nixpkgs/commit/c9f742f7bc09672c661a0597f048fa3d5d9f399f) | `anki -> 2.1.51`                                                                                      |
| [`3020f31d`](https://github.com/NixOS/nixpkgs/commit/3020f31d9b66d4eb164d84d8edb5ac6eaa453b61) | `cmst: 2022.03.13 -> 2020.11.01`                                                                      |
| [`b05132d1`](https://github.com/NixOS/nixpkgs/commit/b05132d12fe0956543ba9f2cd3f34e9e7ae1174c) | `cmst: add update script`                                                                             |
| [`8b4c5b38`](https://github.com/NixOS/nixpkgs/commit/8b4c5b383dd0d223ec40572965915d30cfea2cf2) | `swtpm: 0.7.2 -> 0.7.3`                                                                               |
| [`f3100dd4`](https://github.com/NixOS/nixpkgs/commit/f3100dd4e0072cf641d52ae3dc9da959e5335bf9) | `sile: Change default interpreter to Lua 5.4`                                                         |
| [`7603cb80`](https://github.com/NixOS/nixpkgs/commit/7603cb807f7cdd248e7f196be59a7b8db2f8950a) | `telegram-bot-api: init at 5.7`                                                                       |
| [`fc576251`](https://github.com/NixOS/nixpkgs/commit/fc576251524198b6c3e0a91f9e34b048d13f6e01) | `maintainers: add Anillc`                                                                             |