### PR TITLE
chore(flake/nixpkgs): `58585adb` -> `43c99beb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652060829,
-        "narHash": "sha256-ND2od94mb0z7YKDvrMA/CYRgFz35uaCenNlu0vwPp/A=",
+        "lastModified": 1652073560,
+        "narHash": "sha256-WigD7BFlm4Wr12ujm9HE7yH3U3LWtfoGu3im6EAu9RE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "58585adbcd7fa9889d3d3731fc9c1766317dec77",
+        "rev": "43c99bebdab0ed66de2c4264e48b25999c2d9573",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                      |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`544626b1`](https://github.com/NixOS/nixpkgs/commit/544626b11b1bd11feb8bab214595de64a99baa20) | `python310Packages.zope_event: update homepage`                     |
| [`850c9fea`](https://github.com/NixOS/nixpkgs/commit/850c9fea3e9e0f572f80e8eb1df2e325c21cf43d) | `cdparanoiaIII: Fix Darwin build after #171046`                     |
| [`863cdf8f`](https://github.com/NixOS/nixpkgs/commit/863cdf8f097c172ed92ccb689c6d52915c2858c3) | `wrapFirefox: handle binary wrappers`                               |
| [`5b42ce1d`](https://github.com/NixOS/nixpkgs/commit/5b42ce1da780a024a8d78846ad1fa0ef408caa5d) | `imlib2: add explicit svg & heif support-disabling`                 |
| [`2bebc577`](https://github.com/NixOS/nixpkgs/commit/2bebc577d88eaefeae686d7972d268af65a1051f) | `python3Packages.PyICU: 2.8.1 -> 2.9`                               |
| [`6e0f386a`](https://github.com/NixOS/nixpkgs/commit/6e0f386ae4e04d29db0c31c0e073bf434ae1d587) | `pythonPackages.limits: hack around versioneer non-reproducibility` |
| [`888c82fb`](https://github.com/NixOS/nixpkgs/commit/888c82fbba7cf3016943d577e91bc0a71ab136bc) | `Revert "gnome: fix compilation with gcc 11.3.0"`                   |
| [`d4aa6506`](https://github.com/NixOS/nixpkgs/commit/d4aa650608fdbf78a9697e272d88f5f6e809744b) | `makeBinaryWrapper: really unset NIX_CFLAGS`                        |
| [`69c7dbb8`](https://github.com/NixOS/nixpkgs/commit/69c7dbb88086b9bd5dce9c314779bed6ac6cb0a9) | `makeBinaryWrapper: add overlength-strings test`                    |
| [`42a4c05d`](https://github.com/NixOS/nixpkgs/commit/42a4c05dd092e379c57eefb174bb1a5fea90b92a) | `makeBinaryWrapper: add -Wno-overlength-strings`                    |
| [`976e6545`](https://github.com/NixOS/nixpkgs/commit/976e65456a25614b4823349be44c24658fce2dce) | `gcc11: downgrade to 11.2.0 also on x86_64-darwin`                  |
| [`251ab5f3`](https://github.com/NixOS/nixpkgs/commit/251ab5f3f61e2402833291d28ca6a19ec8839e2a) | `gnome: fix compilation with gcc 11.3.0`                            |
| [`4ff62d90`](https://github.com/NixOS/nixpkgs/commit/4ff62d90ac452024e8fe2c422e7c9f12438abdc4) | `wlogout: enable strictDeps`                                        |
| [`772502c3`](https://github.com/NixOS/nixpkgs/commit/772502c35843f8e8e7610dc63e1b7384f6f5072c) | `wlogout: disable gtk-layer-shell when cross-compiling`             |
| [`c5e7eff5`](https://github.com/NixOS/nixpkgs/commit/c5e7eff560302b7bf047c5f2a5d4fa184c694fae) | `wlogout: support cross-compilation`                                |
| [`ec87e38d`](https://github.com/NixOS/nixpkgs/commit/ec87e38d65d4ea1fa7ab76c7efe70098e36769d0) | `Revert "gcc: 11.2.0 -> 11.3.0" for aarch64-darwin`                 |
| [`7c4e34a1`](https://github.com/NixOS/nixpkgs/commit/7c4e34a13bc902b61fb5c2a469baf0e6facd04b2) | `Re-revert "zimg: 3.0.3 -> 3.0.4"`                                  |
| [`2bd7ade9`](https://github.com/NixOS/nixpkgs/commit/2bd7ade9310421f06c1476ca852d1c72bf1dc414) | `python3Packages.matplotlib: 3.5.1 -> 3.5.2`                        |
| [`207c4030`](https://github.com/NixOS/nixpkgs/commit/207c4030f52ccefe6908b4589b837300bd6debfe) | `libxml2: 2.9.13 -> 2.9.14`                                         |
| [`a7be3b26`](https://github.com/NixOS/nixpkgs/commit/a7be3b2607fef40cb8a9a04ea4ee7753ad8a58e0) | `openssl_1_1: 1.1.1n -> 1.1.1o`                                     |
| [`4aa18d92`](https://github.com/NixOS/nixpkgs/commit/4aa18d9249777f24aee61690e6cf7aa1353b69d1) | `libarchive: disable cpio file-access-time related tests`           |
| [`df9ffaf7`](https://github.com/NixOS/nixpkgs/commit/df9ffaf7761e0268c6b8f27044f935a896953dc7) | `notmuch: skip a test incompatible with newer gmime3`               |
| [`52a2ace0`](https://github.com/NixOS/nixpkgs/commit/52a2ace065810fa36ae5d9c7b2e8608d1a8711fb) | `gmime3: 3.2.7 -> 3.2.11`                                           |
| [`79d9ef8a`](https://github.com/NixOS/nixpkgs/commit/79d9ef8a93be99bca1ee66eb53388e0cfbc3ea68) | `python3Packages.pycurl: pull fix for curl 7.83.0`                  |
| [`8a00f0ca`](https://github.com/NixOS/nixpkgs/commit/8a00f0ca38b0c841f5d7a55bca4280bf0b46a96c) | `cdparanoiaIII: Cleanup`                                            |
| [`29bd2460`](https://github.com/NixOS/nixpkgs/commit/29bd246024a12f79097e3988becd9a98ebe515a7) | `gitless: use pythonRelaxDepsHook`                                  |
| [`4ca1a5fd`](https://github.com/NixOS/nixpkgs/commit/4ca1a5fd256cb3ae44cae0d421926fa1a6155177) | `python3Packages.testtools: use pythonRelaxDepsHook`                |
| [`6e954818`](https://github.com/NixOS/nixpkgs/commit/6e95481822edd16b900bc63416c06eaa98f32a53) | `archivy: use pythonRelaxDepsHook`                                  |
| [`e19019fe`](https://github.com/NixOS/nixpkgs/commit/e19019fe327a7a9cd8539cfda2381bc2cc59ff75) | `pythonRelaxDepsHook: init`                                         |
| [`2047e6eb`](https://github.com/NixOS/nixpkgs/commit/2047e6eb7de7669d67ed5a234a2b89fd5da3b955) | `ghostscript: 9.55.0 -> 9.56.1`                                     |
| [`093a9536`](https://github.com/NixOS/nixpkgs/commit/093a95361bfc1b49823dc99444ddb285a57b2402) | `libsndfile: 1.0.31 -> 1.1.0`                                       |
| [`1c4be4e2`](https://github.com/NixOS/nixpkgs/commit/1c4be4e27174812a00531521adeb323a414d31ee) | `python310Packages.limits: remove extra requirements`               |
| [`22f5d327`](https://github.com/NixOS/nixpkgs/commit/22f5d327101dbf13c072761417f460ed413725e8) | `python39Packages.limits: 2.4.0 -> 2.6.1`                           |
| [`a14a3f1e`](https://github.com/NixOS/nixpkgs/commit/a14a3f1e3c66e93b9403d3fd9dd38b099e1574db) | `python3Packages.limits: enable tests`                              |
| [`de181bc8`](https://github.com/NixOS/nixpkgs/commit/de181bc8f17f1239772ba4555b7424e4497ae5d0) | `expat: 2.4.7 -> 2.4.8`                                             |
| [`37c28808`](https://github.com/NixOS/nixpkgs/commit/37c288082b2108671d551e770f79f2f505fbdb07) | `pipewire: 0.3.50 -> 0.3.51`                                        |
| [`2b71de4a`](https://github.com/NixOS/nixpkgs/commit/2b71de4a3dafbac8533469d5f1a5d7fb10758614) | `pipewire: 0.3.49 -> 0.3.50`                                        |
| [`d8891b53`](https://github.com/NixOS/nixpkgs/commit/d8891b5307f43b799a550910eca65bf85c3808e2) | `python310Packages.setuptools-rust: 1.2.0 -> 1.3.0`                 |
| [`34cdbb4e`](https://github.com/NixOS/nixpkgs/commit/34cdbb4e731ab34d531a202990879a0587a02b4e) | `sqlite: 3.38.2 -> 3.38.3`                                          |
| [`d97e95e8`](https://github.com/NixOS/nixpkgs/commit/d97e95e86298c09bff338c7e9d1778e06792168f) | `gtk3: support cross-compilation`                                   |
| [`ff2aff2a`](https://github.com/NixOS/nixpkgs/commit/ff2aff2a1b6bb665a7e77c5b6de8d6feb4be091e) | `cldr-annotations: 40.0 -> 41.0`                                    |
| [`74d30c2f`](https://github.com/NixOS/nixpkgs/commit/74d30c2fcd3c35ae6984a477247c980e045c6be7) | `python310Packages.rich: 12.2.0 -> 12.3.0`                          |
| [`910f84bf`](https://github.com/NixOS/nixpkgs/commit/910f84bf9ec3ef574699c85d6b132bacca71dd84) | `libseccomp: re-enable checkPhase`                                  |
| [`c60ce4af`](https://github.com/NixOS/nixpkgs/commit/c60ce4afdc13018ab0d7268c6defb2b42f8c93b7) | `libnotify: 0.7.9 -> 0.7.11`                                        |
| [`f8d7adf2`](https://github.com/NixOS/nixpkgs/commit/f8d7adf28432b9f90ae64e305e137088ec8efd57) | `fluidsynth: fix build on darwin`                                   |
| [`85f5539c`](https://github.com/NixOS/nixpkgs/commit/85f5539c4bed08e58c1ea4d00fdc903e9abb2951) | `curl: 7.82.0 -> 7.83.0`                                            |
| [`629a7447`](https://github.com/NixOS/nixpkgs/commit/629a74477f7036cec9e186ffab42915a17b7a9dd) | `libpulseaudio: preserve vapi files`                                |
| [`f8cc8ff5`](https://github.com/NixOS/nixpkgs/commit/f8cc8ff5755528d9a73671481ba3d6fb00f4e8d5) | `makeBinaryWrapper: unset NIX_CFLAGS`                               |
| [`532ebf6b`](https://github.com/NixOS/nixpkgs/commit/532ebf6b579ebf657a473c371eef7d52e13804a4) | `wrapGAppsHook: use makeBinaryWrapper`                              |
| [`95473329`](https://github.com/NixOS/nixpkgs/commit/954733296484a04ae626929792467f52080ce7c6) | `python310Packages.curio: ignore flaky test`                        |
| [`4ff24ba8`](https://github.com/NixOS/nixpkgs/commit/4ff24ba8584e5c46b333864e1e72c117634a9e8a) | `python3Package.protobuf: 3.19.3 -> 3.19.4`                         |
| [`d2275a71`](https://github.com/NixOS/nixpkgs/commit/d2275a71e6bdfb08863d22c4ce9bc3422271eacd) | `librsvg: 2.54.0 -> 2.54.1`                                         |
| [`e69c11d0`](https://github.com/NixOS/nixpkgs/commit/e69c11d0dd8f4a1bbce00b7edd686d3b1cc4513d) | `libopenmpt: 0.6.2 -> 0.6.3`                                        |
| [`dbf7109d`](https://github.com/NixOS/nixpkgs/commit/dbf7109d7e451a82f61ef47dcf5106b6add9ad50) | `webrtc-audio-processing: enable powerpc64le`                       |
| [`e4c5ff61`](https://github.com/NixOS/nixpkgs/commit/e4c5ff6156b249f5a6f4017c9b792131352d9759) | `bluez: add upstream patch for /var/lib/bluetooth`                  |
| [`b79ebdec`](https://github.com/NixOS/nixpkgs/commit/b79ebdec9b76a04b4d583929d222e67384a6e444) | `util-linux: fix static build by disabling systemd support`         |
| [`71ca6660`](https://github.com/NixOS/nixpkgs/commit/71ca66602b1209d784321b59a01a099ce9e97f8a) | `systemd: mark as broken for static builds`                         |
| [`15f68580`](https://github.com/NixOS/nixpkgs/commit/15f685808fa7f192cb466d8ff6f607cb338df12b) | `kbd: fix static build`                                             |
| [`6694081a`](https://github.com/NixOS/nixpkgs/commit/6694081af04c9cac0f97af88f14cf85599c58518) | `elfutils: mark as broken when building a static library`           |
| [`890cd18a`](https://github.com/NixOS/nixpkgs/commit/890cd18a55f5dc5bce5eb647c5b8081dc87496f6) | `python310Packages.pkgconfig: execute tests, adopt`                 |
| [`e35682b2`](https://github.com/NixOS/nixpkgs/commit/e35682b207b733ca044caf618b8945f309e1d523) | `gcc: 11.2.0 -> 11.3.0`                                             |
| [`0c219747`](https://github.com/NixOS/nixpkgs/commit/0c2197472daaf4f61b5c09692df5c083f855a0e1) | `vim: 8.2.4609 -> 8.2.4816`                                         |
| [`a649d4f0`](https://github.com/NixOS/nixpkgs/commit/a649d4f03832964080ca853695cd74d5fbaafa14) | `python: use whitespace to split possible existing options`         |
| [`7d81750f`](https://github.com/NixOS/nixpkgs/commit/7d81750f21bff6d599ce4e08c3e13be23b5104b8) | `python3Packages.flask-restful: update pname`                       |
| [`77a189e0`](https://github.com/NixOS/nixpkgs/commit/77a189e066a839b1c8bb7cb8c125d434d15854ac) | `systemd: disable EFI stripping`                                    |
| [`4f55f016`](https://github.com/NixOS/nixpkgs/commit/4f55f016f5fe90aedeaa627f629bc095f4ea2ee0) | `icu: 70.1 -> 71.1`                                                 |
| [`8203e061`](https://github.com/NixOS/nixpkgs/commit/8203e061ec0556b4d4a972b18ba92509cb1ddd04) | `icu71: init at 71.1`                                               |
| [`d9218155`](https://github.com/NixOS/nixpkgs/commit/d9218155d2b3b0ce9d0c7fbc6bcfbf5beec4670c) | `ghostscript: use system-wide openjpeg`                             |
| [`e34b2286`](https://github.com/NixOS/nixpkgs/commit/e34b228626cc36ea05455376f5d21c13fd9040cf) | `pandoc: don't use remove-references-to with haskellPackages.HTTP`  |
| [`f6999e0c`](https://github.com/NixOS/nixpkgs/commit/f6999e0cc5d3b5b970bfa2fdc52e9c9fbcde2091) | `sane-backends: fix build on Darwin`                                |
| [`078379eb`](https://github.com/NixOS/nixpkgs/commit/078379eb336c73ebe87323732b53ea06e8e700cb) | `imlib2: add svg and heif support`                                  |
| [`688695bd`](https://github.com/NixOS/nixpkgs/commit/688695bde7c85088cccc1419a0f8a273966415eb) | `imlib2: 1.7.5 -> 1.8.1`                                            |
| [`f0dd951d`](https://github.com/NixOS/nixpkgs/commit/f0dd951db17b18608c2c52447ae8b91f5c725f2f) | `libsForQt5.signond: 8.60 -> 8.61`                                  |
| [`63a37b84`](https://github.com/NixOS/nixpkgs/commit/63a37b844cc5e82eb4e963f6fc85b99d2050117f) | `darwin: deprecate phases`                                          |
| [`e68d2cf1`](https://github.com/NixOS/nixpkgs/commit/e68d2cf1284087f39b1ff55b62f656b0d111f352) | `help2man: restore nls support on darwin, make nls explicit`        |