### PR TITLE
chore(flake/nixpkgs): `43c99beb` -> `e2a18027`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652073560,
-        "narHash": "sha256-WigD7BFlm4Wr12ujm9HE7yH3U3LWtfoGu3im6EAu9RE=",
+        "lastModified": 1652116346,
+        "narHash": "sha256-WkBuS1H2PJ9TVKnJG0DYMMV5HnNPe513h/UfOFYLQLA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "43c99bebdab0ed66de2c4264e48b25999c2d9573",
+        "rev": "e2a1802777ecddcd3fce0d3d066cf8fc8c481dc9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                    |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`bff1539d`](https://github.com/NixOS/nixpkgs/commit/bff1539d6308493d959497d3a47373cd4a0ea80b) | `thiefmd: 0.2.4 -> 0.2.5-stability`                                               |
| [`c19b1b15`](https://github.com/NixOS/nixpkgs/commit/c19b1b15bc65d2e1f16ad1c27051260351520e7e) | `python3Packages.uharfbuzz: mark as broken on darwin`                             |
| [`d346c957`](https://github.com/NixOS/nixpkgs/commit/d346c95784d9f249e9c56478c24dc7cec3dc3798) | `exaile: add python3 to PATH (#169494)`                                           |
| [`5fdc74a2`](https://github.com/NixOS/nixpkgs/commit/5fdc74a2ac093c214bfba43c4fb70c3f9951d4e4) | `roxctl: init at 3.69.1 (#168512)`                                                |
| [`3b58c57a`](https://github.com/NixOS/nixpkgs/commit/3b58c57aab6706a902aa048572ff870fe498bf55) | `gotify-server: 2.1.0 -> 2.1.4 (#168910)`                                         |
| [`7f5d5228`](https://github.com/NixOS/nixpkgs/commit/7f5d5228a9f4db3cf58a99858868fce5443878f4) | `python3Packages.sjcl: init at 0.2.1`                                             |
| [`fcf3fb06`](https://github.com/NixOS/nixpkgs/commit/fcf3fb06ac364d2b9f9d3da498a0171a342dea3b) | `xvkbd: 3.9 -> 4.1`                                                               |
| [`29d3bfce`](https://github.com/NixOS/nixpkgs/commit/29d3bfce16f74ae129a0b4fcf3c2aa2a9a4848b9) | `python3Packages.protonvpn-nm-lib: change platform to linux`                      |
| [`cd75ecd1`](https://github.com/NixOS/nixpkgs/commit/cd75ecd1b7ba4215cae6a0655fa33cf765ee969d) | `python3Packages.proton-client: change platform to linux`                         |
| [`2ba55cd4`](https://github.com/NixOS/nixpkgs/commit/2ba55cd49bc58322db2c6286bfc3135bd2c64a5e) | `python310Packages.pyskyqremote: 0.3.6 -> 0.3.7`                                  |
| [`0f822a76`](https://github.com/NixOS/nixpkgs/commit/0f822a767f59841bfd1e7ce823830a7af48bd4cc) | `vial: 0.5 -> 0.5.2`                                                              |
| [`d46665e8`](https://github.com/NixOS/nixpkgs/commit/d46665e879a51c307759a776f5ca464985c3197f) | `ISSUE_TEMPLATE/build_failure.md: create`                                         |
| [`0fc95f66`](https://github.com/NixOS/nixpkgs/commit/0fc95f66fa3a506b9f7ff84eb5b68121cf1aefe5) | `pcb2gcode: cherry-pick patch from upstream to fix build`                         |
| [`c5468253`](https://github.com/NixOS/nixpkgs/commit/c54682539bf67ffe4c2bc299d2fb451a335ed70c) | `os-specific/linux/vmm_clock: mark kernels older than 4.19 as broken`             |
| [`c3bbe1d9`](https://github.com/NixOS/nixpkgs/commit/c3bbe1d9c716936cd446233b41206f461514c526) | `testers.nixosTest: Remove redundant system.stateVersion = lib.trivial.release;`  |
| [`a5e2f0f4`](https://github.com/NixOS/nixpkgs/commit/a5e2f0f4106d623762e07f128805e116e3ba4761) | `siesta: fix build for gcc/gfortran-10/11`                                        |
| [`5f67086a`](https://github.com/NixOS/nixpkgs/commit/5f67086a8a5a8177997eeedc8f08609433961825) | `python310Packages.exchangelib: 4.7.2 -> 4.7.3`                                   |
| [`b7c84005`](https://github.com/NixOS/nixpkgs/commit/b7c8400546f18686446d825de43feb182e1d22d3) | `gbl: darwin support`                                                             |
| [`93abb7be`](https://github.com/NixOS/nixpkgs/commit/93abb7bef7a73f0c5fa0453d60c024ca7464f1c5) | `tests.testers.nixosTest-example: move from tests.nixos-functions.nixosTest-test` |
| [`ae172a2b`](https://github.com/NixOS/nixpkgs/commit/ae172a2bb4c94da68fb0adfd77d5aacd71c8b930) | `treewide: nixosTest -> testers.nixosTest`                                        |
| [`74542384`](https://github.com/NixOS/nixpkgs/commit/745423848b444fc6dfba67a5189285ef7dbc702e) | `psensor: add -Wno-error due to increasing compiler strictness`                   |
| [`93cb8037`](https://github.com/NixOS/nixpkgs/commit/93cb80377cd1bc7c55bb91edd69d4f44639d8a84) | `python310Packages.pymbolic: enable tests`                                        |
| [`88090385`](https://github.com/NixOS/nixpkgs/commit/8809038568aad423f39156735c222dc7a4dd51a9) | `conftest: 0.31.0 -> 0.32.0`                                                      |
| [`75c90fc7`](https://github.com/NixOS/nixpkgs/commit/75c90fc796f77df28aee12ee612145b07f2f6a5a) | `python3Packages.falcon: exclude tests`                                           |
| [`ce9122d1`](https://github.com/NixOS/nixpkgs/commit/ce9122d1e824b91ced170b6629202527f51411de) | `pressureaudio: remove autoreconfHook to fix build for ZHF`                       |
| [`abf015d9`](https://github.com/NixOS/nixpkgs/commit/abf015d99a5a1878c8287ee005b105cd4b735462) | `shelf: init at 2.1.1 (#154748)`                                                  |
| [`f1d34a1a`](https://github.com/NixOS/nixpkgs/commit/f1d34a1a0114ded13721fc327b2b831f4e97cbed) | `libgtkflow: init at 0.8.0`                                                       |
| [`305aabda`](https://github.com/NixOS/nixpkgs/commit/305aabda40e65a8df61c409dae4a61b59e0c4fd7) | `python310Packages.txaio: remove unused input`                                    |
| [`4839ffca`](https://github.com/NixOS/nixpkgs/commit/4839ffca1ff6acfd62fbc83bd0fba94b1b9865da) | `refind: 0.13.2 -> 0.13.3.1`                                                      |
| [`3a71e04f`](https://github.com/NixOS/nixpkgs/commit/3a71e04f36c500df36a1a7374dec9cfd50c27f11) | `Update pkgs/applications/version-management/rcshist/default.nix`                 |
| [`99bfa8b9`](https://github.com/NixOS/nixpkgs/commit/99bfa8b949565e4f0863e25ed5542e6985c6d0d4) | `rcshist: init at 1.04`                                                           |
| [`0d763720`](https://github.com/NixOS/nixpkgs/commit/0d7637203e9be03281115e1cbabf3884ad33d0ac) | `libressl: remove weird and old man compression workaround`                       |
| [`4b2e0fe9`](https://github.com/NixOS/nixpkgs/commit/4b2e0fe978cccdc9f6d7f3dc301b8e6c0a1904c2) | `python310Packages.approvaltests: 5.0.1 -> 5.0.2`                                 |
| [`199933ef`](https://github.com/NixOS/nixpkgs/commit/199933efdf5945792f149253256e983f0643cddb) | `nixos/mandoc: Leave shell argument quoting to nix`                               |
| [`865d79bb`](https://github.com/NixOS/nixpkgs/commit/865d79bb5b5fc04b32222c6029f83e91d64951b5) | `elmerfem: make elmerfem-9.0 properly`                                            |
| [`6c60d3d3`](https://github.com/NixOS/nixpkgs/commit/6c60d3d38ac1512df424ea474dc9e71373b2fe80) | `gqview: add -fcommon workaround`                                                 |
| [`ca767e5e`](https://github.com/NixOS/nixpkgs/commit/ca767e5ea8c59b74a9d19934e54f5691c72a96e0) | `ntfy-sh: 1.21.2 -> 1.22.0`                                                       |
| [`e4eba471`](https://github.com/NixOS/nixpkgs/commit/e4eba471d19d2366a17cf36dd96a0e33a2b34807) | `python3Packages.httpx-socks: specify extras-require`                             |
| [`a664572f`](https://github.com/NixOS/nixpkgs/commit/a664572fa654fdd4b7a7e39c8c79cc164a93139c) | `wapiti: update propagatedBuildInputs`                                            |
| [`1724a34a`](https://github.com/NixOS/nixpkgs/commit/1724a34a0d32a8af8400f46d9254776035636df7) | `python3Packages.httpx: specify extras-require`                                   |
| [`cbfb0da7`](https://github.com/NixOS/nixpkgs/commit/cbfb0da7a26bc6ce6e63b262ce5f7949682478cc) | `python3Packages.httpcore: specify extras-require`                                |
| [`b5d30ae3`](https://github.com/NixOS/nixpkgs/commit/b5d30ae3a37ebd1a19afa241b052e0af3748eedc) | `bazel_0, bazel_0_26, bazel_0_29, bazel_1: remove`                                |
| [`0e8ede9c`](https://github.com/NixOS/nixpkgs/commit/0e8ede9cc4a3660dd23f6c58a2f549b9e3cda118) | `g15daemon: add -fcommon workaround`                                              |
| [`f42f88bd`](https://github.com/NixOS/nixpkgs/commit/f42f88bd15d540a6c46fbdf0cee1994e0e252a9b) | `rnote: 0.5.0-hotfix-2 -> 0.5.1-hotfix-1`                                         |
| [`be012719`](https://github.com/NixOS/nixpkgs/commit/be0127196301eb6dd388ac2ae61bf47cfa007831) | `syncthing: 1.19.2 -> 1.20.1`                                                     |
| [`fc060ca6`](https://github.com/NixOS/nixpkgs/commit/fc060ca64781731c7c1cefdee436d1101ae94fdd) | `chatty: 0.6.3 -> 0.6.4`                                                          |
| [`5a1209a1`](https://github.com/NixOS/nixpkgs/commit/5a1209a15aae2757a397916508695b3e05e677c5) | `boltbrowser: 2.0 -> 2.1`                                                         |
| [`c3191963`](https://github.com/NixOS/nixpkgs/commit/c31919630b8cd93297e607d13a453563dc67c1da) | `python310Packages.pycryptodome-test-vectors: 1.0.7 -> 1.0.8`                     |
| [`2578b89c`](https://github.com/NixOS/nixpkgs/commit/2578b89c84b3cf0f18ea18a9766b0cf10048cb46) | `python310Packages.pymbolic: 2021.1 -> 2022.1`                                    |
| [`88639cd7`](https://github.com/NixOS/nixpkgs/commit/88639cd7a93312cfb367e71f673a0fb97eed7ab8) | `python310Packages.peaqevcore: 0.0.22 -> 0.0.23`                                  |
| [`ae9a9ee9`](https://github.com/NixOS/nixpkgs/commit/ae9a9ee9419244c2ba13a8386d4e5844e665ca79) | `recutils: 1.8 -> 1.9`                                                            |
| [`181dbcf0`](https://github.com/NixOS/nixpkgs/commit/181dbcf0f21b24eeb097960b6c95df8fb9200d17) | `python3Packages.pytube: 12.0.0 -> 12.1.0`                                        |
| [`e1d1b600`](https://github.com/NixOS/nixpkgs/commit/e1d1b600ad0baf94d9aaed17d3e3be66ce4ef93f) | `python310Packages.txaio: remove unused dependency`                               |
| [`d5cdae6c`](https://github.com/NixOS/nixpkgs/commit/d5cdae6c5da043dbf5c58c2b5243cf3c7f7c3e50) | `fortune: 3.12.0 -> 3.14.0`                                                       |
| [`bf09f6c8`](https://github.com/NixOS/nixpkgs/commit/bf09f6c83afefd3c2dae00eeec0802644ceb7456) | `fortune: add an option to let user use offensive`                                |
| [`defb2298`](https://github.com/NixOS/nixpkgs/commit/defb2298de66f6b32ec228a532dc6c8e34733b25) | `envoy: fix builds for x86_64-linux and aarch64-linux`                            |
| [`7215264e`](https://github.com/NixOS/nixpkgs/commit/7215264eb3e96d78c6cee677745c6c10e3fe44bb) | `feedreader: remove`                                                              |
| [`098b5c19`](https://github.com/NixOS/nixpkgs/commit/098b5c191fb09efc3cc4b2e838b878b8261c9e40) | `python3Packages.pyrogram: 2.0.17 -> 2.0.19`                                      |
| [`bbb9a73d`](https://github.com/NixOS/nixpkgs/commit/bbb9a73d62e71e1a4d6bca7c8426feedb6323f00) | `python310Packages.ldaptor: adopt, use twisted.extras-require.tls, mark broken`   |
| [`19663984`](https://github.com/NixOS/nixpkgs/commit/1966398414a1e4fca5342e0ecb2e409dd4c84640) | `cargo-edit: 0.8.0 -> 0.9.0`                                                      |
| [`0194fb5f`](https://github.com/NixOS/nixpkgs/commit/0194fb5f8497be28ac7b11fdf73cc718199f5ecf) | `zeroc-ice: mark broken`                                                          |
| [`4ff50cc1`](https://github.com/NixOS/nixpkgs/commit/4ff50cc175647afc2e2a5b651540881c40212c9e) | `rsyslog: 8.2202.0 -> 8.2204.1`                                                   |
| [`0b13ca52`](https://github.com/NixOS/nixpkgs/commit/0b13ca520afd8e0877f164aaeabaa7ac0105e8bc) | `lua53Packages.lmpfrlib: init at 20170112-2`                                      |
| [`ca428a06`](https://github.com/NixOS/nixpkgs/commit/ca428a0687d60753e23fc0033ef403d13d719444) | `lua53Packages.lmathx: init at 20150624-1`                                        |
| [`ad48be73`](https://github.com/NixOS/nixpkgs/commit/ad48be73f575f494c8f695b6ff4592ae367857c4) | `gtkdialog: pull gentoo patch for -fno-common toolchains`                         |
| [`28942721`](https://github.com/NixOS/nixpkgs/commit/28942721a1c225278de7c2715c8a45fbfe8202d3) | `libreoffice-fresh: 7.2.5.2 -> 7.3.3.2`                                           |
| [`62e689da`](https://github.com/NixOS/nixpkgs/commit/62e689da1287eea56ec571e4d5baa619e401f341) | `libreoffice-still: apply review comments`                                        |
| [`de396a3c`](https://github.com/NixOS/nixpkgs/commit/de396a3c0a6f6b6c94c1fb188a476cb274b7d351) | `boost159: fix build on aarch64-darwin`                                           |
| [`31b1d66b`](https://github.com/NixOS/nixpkgs/commit/31b1d66bfe0a88c424ac93437bc570c4ac99bc9a) | `powerdevil: drop ddcutil dependency`                                             |
| [`ae48e41a`](https://github.com/NixOS/nixpkgs/commit/ae48e41ad71f44589cab39c3736b38d663356d46) | `python310Packages.mysql-connector: 8.0.24 -> 8.0.29`                             |
| [`6b6ac53c`](https://github.com/NixOS/nixpkgs/commit/6b6ac53ca52be99ee7e430f10c711fe3c599e3df) | `python310Packages.py3exiv2: disable tests`                                       |
| [`34724f22`](https://github.com/NixOS/nixpkgs/commit/34724f221eedda583e063154799531ea80fb0c3d) | `ubootQemuRiscv64Smode: Fix build with binutils 2.38`                             |
| [`3f8c7838`](https://github.com/NixOS/nixpkgs/commit/3f8c7838ad8ab300b3dc0118b824c27894c725d7) | `python3Packages.zeroconf: 0.38.5 -> 0.38.6`                                      |
| [`dfd3754f`](https://github.com/NixOS/nixpkgs/commit/dfd3754f612a2e563ada9eaa4554e451040939a1) | `libreoffice-still: 7.1.8.1 -> 7.2.6.2`                                           |
| [`985494e6`](https://github.com/NixOS/nixpkgs/commit/985494e6e516ececbc9f3498cc8a547ba90e4b8f) | `laminar: split documentation into separate output`                               |
| [`924ebf65`](https://github.com/NixOS/nixpkgs/commit/924ebf6556118f1ccbc83e5d19e90e5ebde8efb2) | `curl: add some key reverse-dependencies to passthru.tests`                       |
| [`a0085798`](https://github.com/NixOS/nixpkgs/commit/a00857983edb1e0f4947e567903838047913dd36) | `Nit, remove trailing whitespace`                                                 |
| [`1f4de2c0`](https://github.com/NixOS/nixpkgs/commit/1f4de2c0c901aeb9e32f42995d729e7ff6b35658) | `python310Packages.py3exiv2: remove whitespace`                                   |
| [`80ca2744`](https://github.com/NixOS/nixpkgs/commit/80ca27442bbe9378efd75f537fafa38d38607d2c) | `python310Packages.py3exiv2: disable on older Python releases`                    |
| [`1cf7a75d`](https://github.com/NixOS/nixpkgs/commit/1cf7a75d80118ef89a54718ab9f6218f8459da40) | `Fix warning about UPNP letter case`                                              |
| [`2032969f`](https://github.com/NixOS/nixpkgs/commit/2032969f0a8b63b3d80596c4ea69856027305709) | `Initial port of haven-cli`                                                       |
| [`ea9be9e2`](https://github.com/NixOS/nixpkgs/commit/ea9be9e24ffdfc2f1cc3973fa784c899b872c0e8) | `powershell: 7.2.2 -> 7.2.3`                                                      |
| [`037ec9ab`](https://github.com/NixOS/nixpkgs/commit/037ec9ab0d7fc633ce95660f2a33432d4398654e) | `musikcube: fix darwin build`                                                     |
| [`881d8649`](https://github.com/NixOS/nixpkgs/commit/881d8649427e0d6333a609a8b0cc9ec4f81d95ce) | `gnome.atomix: pull upstream fix for -fno-common toolchains`                      |
| [`e6daff8e`](https://github.com/NixOS/nixpkgs/commit/e6daff8e0797ee0a44c6a55aeb2d3f57d428fd15) | `python310Packages.py3exiv2: 0.9.3 -> 0.11.0`                                     |
| [`165a8a63`](https://github.com/NixOS/nixpkgs/commit/165a8a6315f2e7ef71352f470be8c60dae508a17) | `python310Packages.editorconfig: adopt, update homepage, fix checkInputs`         |
| [`4761e503`](https://github.com/NixOS/nixpkgs/commit/4761e5037253e22d47b389ebbb318d355db6bd80) | `pkgsStatic.perl: fix build`                                                      |
| [`c92b0c5c`](https://github.com/NixOS/nixpkgs/commit/c92b0c5c69aa07a208252847a54b83073a8b59cc) | `lagrange: 1.12.2 → 1.13.3`                                                       |
| [`08d33e37`](https://github.com/NixOS/nixpkgs/commit/08d33e379bbe29328f70d46446f9e4ec55632280) | `sealcurses: init at unstable-2022-04-28`                                         |
| [`daace980`](https://github.com/NixOS/nixpkgs/commit/daace980f6936ca0d61452658c5af0994908d2ce) | `the-foundation: init at 1.4.0`                                                   |
| [`3babc11a`](https://github.com/NixOS/nixpkgs/commit/3babc11a0f764fbb8b129476b2d91f485db597ad) | `meshcentral: 0.9.98 -> 1.0.18`                                                   |
| [`57cd07f3`](https://github.com/NixOS/nixpkgs/commit/57cd07f3a9d27d1a63918fe21add060ecde4a29f) | `treewide: pkgs.systemd -> config.systemd.package`                                |
| [`b99b2783`](https://github.com/NixOS/nixpkgs/commit/b99b2783ec241b209a266091c0f3f07f9ffbb5fa) | `maintainers: add binsky`                                                         |
| [`e8ffb6a7`](https://github.com/NixOS/nixpkgs/commit/e8ffb6a727081632781ac1051cf5b192f7cf5cd3) | `doc/testers: Mention nixosTests in nixosTest doc`                                |
| [`7edb4146`](https://github.com/NixOS/nixpkgs/commit/7edb41466086f8cd19fc738e8f9c46b7c64fe182) | `testers.nixosTest: Move from top-level and improve docs`                         |
| [`28f99aad`](https://github.com/NixOS/nixpkgs/commit/28f99aad3180b8da8db1bd2f8bbe98947de867c3) | `nixos/testing-python.nix: Set meta.mainProgram`                                  |
| [`c071530c`](https://github.com/NixOS/nixpkgs/commit/c071530ca51013059cb8181d6a34e65fef9702a1) | `testers.invalidateFetcherByDrvHash: Move from top-level`                         |
| [`1b86e9c2`](https://github.com/NixOS/nixpkgs/commit/1b86e9c2086dd35845fb9dc7060fe4628204d46d) | `bcachefs-tools: add installer tests to passthru.tests`                           |
| [`39b9cf31`](https://github.com/NixOS/nixpkgs/commit/39b9cf311be06e50ec79ae022a268acce2b00959) | `nixos/tests/installer: add bcachefs tests`                                       |
| [`ca079e30`](https://github.com/NixOS/nixpkgs/commit/ca079e3074549256640126069dcc96a98cbbf3d8) | `phantomjs2: remove`                                                              |
| [`09046b11`](https://github.com/NixOS/nixpkgs/commit/09046b11ceda489ec0dd9751fb8ed2fdff7e380a) | `Remove whitespace`                                                               |
| [`ec9f5dfd`](https://github.com/NixOS/nixpkgs/commit/ec9f5dfd31c1e42a9af1dabeedf0eccd9876e1b1) | `android-studio: add e2fsprogs dependency`                                        |
| [`9cdbd720`](https://github.com/NixOS/nixpkgs/commit/9cdbd72004edee9f6b7ed0181996c2104cafb48a) | `php.extensions.readline: Actually use readline`                                  |
| [`03e31c53`](https://github.com/NixOS/nixpkgs/commit/03e31c533ce0bc568d2aebed5847934d7224c735) | `php.mkExtension: make source name agnostic`                                      |
| [`b2ae4d5a`](https://github.com/NixOS/nixpkgs/commit/b2ae4d5a0ed0578f3bed6424c0ba51fc9dd61a18) | `php.mkExtension: Run installPhase pre/post hooks`                                |
| [`497d46b0`](https://github.com/NixOS/nixpkgs/commit/497d46b0125741a8be64dcf2d1fa340ebf5eba11) | `php.mkExtension: Format`                                                         |
| [`66d16134`](https://github.com/NixOS/nixpkgs/commit/66d16134307f91c58447c7c9f71ae1444025982f) | `dprint: 0.26.0 -> 0.27.0`                                                        |
| [`acc0931d`](https://github.com/NixOS/nixpkgs/commit/acc0931de1f5420bbb0c73d1cc816a6e254b1c79) | `python3Packages: restore warning, but fix tests`                                 |
| [`632043a5`](https://github.com/NixOS/nixpkgs/commit/632043a5bb44d64a57294e15e5f06c1090d57b02) | `python3Packages.chainer: rm cupy warning`                                        |
| [`6f1dbeb3`](https://github.com/NixOS/nixpkgs/commit/6f1dbeb35f4d828dbfc3baf9db5af61812ff42cd) | `dante: remove hardwired PATH= from redefgen.sh script`                           |
| [`1092aa46`](https://github.com/NixOS/nixpkgs/commit/1092aa465699c31e6054c6278c9a496d4febb5de) | `py-wmi-client: remove`                                                           |
| [`187c58e7`](https://github.com/NixOS/nixpkgs/commit/187c58e74de2407c7d65462923b9e4a9513dbcb0) | `qcachegrind: drop python profiling support`                                      |
| [`127f8ef9`](https://github.com/NixOS/nixpkgs/commit/127f8ef97e4c15ecc34122a3a1aba8c0ad3cbb4b) | `qpid-cpp: switch to python3`                                                     |
| [`01169764`](https://github.com/NixOS/nixpkgs/commit/01169764651784c15c13415e2b5589e62b4f6f96) | `kdb: switch to python3`                                                          |
| [`813fd5e9`](https://github.com/NixOS/nixpkgs/commit/813fd5e96ddec1d6b25b273cff477ef08a282f3d) | `swiften: remove python2 dependency`                                              |
| [`63029bcf`](https://github.com/NixOS/nixpkgs/commit/63029bcf2e68b38cb02abbc4b10f026cbfc4f237) | `kreport: switch to python3`                                                      |
| [`f77b63b4`](https://github.com/NixOS/nixpkgs/commit/f77b63b46f44a29625b91b0d0a15b8e8d878a350) | `goku: 0.3.6 -> 0.5.1`                                                            |
| [`12c1a063`](https://github.com/NixOS/nixpkgs/commit/12c1a063bcf4bac7d6b0a629ace59500cb9d52a4) | `re2: add some key reverse dependencies to passthru.tests`                        |
| [`5fe2ade9`](https://github.com/NixOS/nixpkgs/commit/5fe2ade9cada715ebbdd1a7038dc256ea1aa5e05) | `freetype: add some key reverse dependencies to passthru.tests`                   |