### PR TITLE
chore(flake/home-manager): `882bd811` -> `4293902b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1651886851,
-        "narHash": "sha256-kbXOJSf1uho0/7P54nZkJdJY3oAelIjyc6tfiRhaXJI=",
+        "lastModified": 1652167840,
+        "narHash": "sha256-Qx//y33FkhUun+en60SakO9iQPPLu18fUpr3kKTkif8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "882bd8118bdbff3a6e53e5ced393932b351ce2f6",
+        "rev": "4293902b64990d43847fe90e50ef7908f7dc1e30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`4293902b`](https://github.com/nix-community/home-manager/commit/4293902b64990d43847fe90e50ef7908f7dc1e30) | `offlineimap: remove dependency on python2 (#2909) (#2951)` |