### PR TITLE
chore(flake/nixpkgs): `ab456c4d` -> `78520c1f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652161506,
-        "narHash": "sha256-16+yPCPFcS70E02YnvGdPboUS351NmbDchkm4VWKL7w=",
+        "lastModified": 1652242531,
+        "narHash": "sha256-08S4rhmHbv+n+rU0E2u06s204KIHpPJdJnNpusuewz4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ab456c4d4583721157a2e4d48904709e3471ebc7",
+        "rev": "78520c1fff36113a9a6fe340ce33f57bb2332b67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`3f898ed1`](https://github.com/NixOS/nixpkgs/commit/3f898ed15a4bc20a14687b2384bd991ad7837d6c) | `eterm: reformat knownVulnerabilities message`                                                       |
| [`547f9bf9`](https://github.com/NixOS/nixpkgs/commit/547f9bf973df9eaba3941cc19d0d149607cd6445) | `xca: 2.2.1 -> 2.4.0`                                                                                |
| [`104a92fe`](https://github.com/NixOS/nixpkgs/commit/104a92fe7722ae5f7b908e89f880afcf35988262) | ``dictd: remove deprecated `enable-dictorg` flag``                                                   |
| [`7c38f2d1`](https://github.com/NixOS/nixpkgs/commit/7c38f2d12ac62b0f078ce0141ace6298979ddca8) | `gh: 2.9.0 -> 2.10.1`                                                                                |
| [`446ba0dc`](https://github.com/NixOS/nixpkgs/commit/446ba0dc2230d4c5cc90023c85ce773f99dafc62) | `profanity: 0.12.0 -> 0.12.1`                                                                        |
| [`749d9e08`](https://github.com/NixOS/nixpkgs/commit/749d9e08620f3c3de7c167c222bc56d15fab4ff9) | `python3Packages.jenkinsapi: disable python 3.6 onwards`                                             |
| [`cb7412c7`](https://github.com/NixOS/nixpkgs/commit/cb7412c787a149d91e561f970a47d7a5e2821696) | `rdfind: fix build`                                                                                  |
| [`119c335a`](https://github.com/NixOS/nixpkgs/commit/119c335a4f156f8899751000f163c22385d3de34) | `scite: 5.0.2 -> 5.2.2`                                                                              |
| [`fdb0c163`](https://github.com/NixOS/nixpkgs/commit/fdb0c163eceff0317ad666234d98493690ec89b0) | `python3Packages.github3_py: update list of dependencies`                                            |
| [`95e6d4f7`](https://github.com/NixOS/nixpkgs/commit/95e6d4f76359dce39c436753fc807bef78ca4ffb) | `python3Packages.gidgethub: set format to flit`                                                      |
| [`288c3c6f`](https://github.com/NixOS/nixpkgs/commit/288c3c6fbcc10eb6fde316ae03c56937fb828c07) | `waylandpp: 0.2.10 -> 1.0.0 (#172097)`                                                               |
| [`fe66cf22`](https://github.com/NixOS/nixpkgs/commit/fe66cf22fdf55eab2b2ed8c0ad86bf4fa61602f8) | `gnome.pomodoro: 20.0 -> 21.1 (#172147)`                                                             |
| [`6a503166`](https://github.com/NixOS/nixpkgs/commit/6a503166b0ddffdcf391017dd9238c9a2738a6b2) | `phwmon: remove`                                                                                     |
| [`f15e339a`](https://github.com/NixOS/nixpkgs/commit/f15e339ab0c8dff0d09a0c6a8d8fd273e7fc44af) | `terraform-providers.googleworkspace: init at 0.6.0`                                                 |
| [`e6547695`](https://github.com/NixOS/nixpkgs/commit/e65476950bcf766354c2f336adbb900786a44679) | `terraform-providers.cloudamqp: 1.15.3 -> 1.16.0`                                                    |
| [`db9c0e88`](https://github.com/NixOS/nixpkgs/commit/db9c0e88530942ae8f6ae94bae08939fb06b673b) | `python310Packages.pyopenssl: mark broken on aarch64-darwin`                                         |
| [`b140f3f0`](https://github.com/NixOS/nixpkgs/commit/b140f3f0b4f668a9168a9428e0593433010580e4) | `checkov: 2.0.1118 -> 2.0.1132`                                                                      |
| [`5c8ab091`](https://github.com/NixOS/nixpkgs/commit/5c8ab091771fb27e1ee792639c197fe4185ba99e) | `python310Packages.ujson: adopt, update meta data`                                                   |
| [`a797299a`](https://github.com/NixOS/nixpkgs/commit/a797299a78f4befb7dbd6bdb04a9687bd449a07d) | `perlPackages.CryptOpenSSLRandom: mark broken for aarch64-darwin`                                    |
| [`6951b5c1`](https://github.com/NixOS/nixpkgs/commit/6951b5c187bbf43830ef49a6f37db45882edebba) | ``hydra-unstable: drop TestMore, which is an alias for `null```                                      |
| [`eee661ba`](https://github.com/NixOS/nixpkgs/commit/eee661ba01f05f5b2b9b5527df0643ef8f4b024f) | `vyper: relax semantic-version dependency`                                                           |
| [`0ae3ed37`](https://github.com/NixOS/nixpkgs/commit/0ae3ed37c19884850bd961b1576c1c150d9fb480) | `palemoon: 29.4.6 -> 31.0.0`                                                                         |
| [`d652974d`](https://github.com/NixOS/nixpkgs/commit/d652974d1a645c504abb65ee5e85d11e738df936) | `python3Packages.sanic: fix build on aarch64 (#172155)`                                              |
| [`b8f84c3d`](https://github.com/NixOS/nixpkgs/commit/b8f84c3d182854430909419f4ed8ab0d0fa22858) | `python3Packages.eventlet: disable failing test`                                                     |
| [`f433d91b`](https://github.com/NixOS/nixpkgs/commit/f433d91bb3fae87f5232a8946965777802b16b59) | `anbox: drop kernel modules package`                                                                 |
| [`44d5d31d`](https://github.com/NixOS/nixpkgs/commit/44d5d31d98435036d445b224ee4d56055c6515b5) | `Revert "pythonPackages: set mainProgram to pname by default"`                                       |
| [`78ebec14`](https://github.com/NixOS/nixpkgs/commit/78ebec14483cecafa6ff8ceb095f92257890c5c7) | `open-policy-agent: 0.38.1 -> 0.40.0`                                                                |
| [`f24cf442`](https://github.com/NixOS/nixpkgs/commit/f24cf4422db3f0d76f91af15d68dcaedaf22eba3) | `maintainers: change musfay to muscaln`                                                              |
| [`6fc1fdc4`](https://github.com/NixOS/nixpkgs/commit/6fc1fdc4be4950716e7c5bbb1a406cc3a5e43a2e) | `n8n: 0.175.1 → 0.176.0`                                                                             |
| [`271905a3`](https://github.com/NixOS/nixpkgs/commit/271905a33f9b755dc63620b7a5040ebde8e3f83c) | `minetest: add aliases and release notes for v4 deprecation`                                         |
| [`273e32f1`](https://github.com/NixOS/nixpkgs/commit/273e32f1aa4d021dfe32a97e15a1897a4cba1e65) | `minetest: use irrlichtmt from Nixpkgs, add optional touch support`                                  |
| [`df4afffb`](https://github.com/NixOS/nixpkgs/commit/df4afffb3c4aecdd1460e02f3ec788be30593b7b) | `irrlichtmt: init at 1.9.0mt4`                                                                       |
| [`381ef9d2`](https://github.com/NixOS/nixpkgs/commit/381ef9d262b1cdb5fc4e0636f7f0fdb0214b97e5) | `python3Packages.shiv: disable failing tests`                                                        |
| [`20653f46`](https://github.com/NixOS/nixpkgs/commit/20653f46b81bb78bed01ac47edafc7aa895c81ec) | `ocropus: remove`                                                                                    |
| [`69c4a080`](https://github.com/NixOS/nixpkgs/commit/69c4a08072f4b5446b89e4032489f324c48c2d6e) | `envoy: fix sha256 for aarch64-linux`                                                                |
| [`6be42c87`](https://github.com/NixOS/nixpkgs/commit/6be42c879ddd2584f646a86764f7df3212e6c21c) | `python310Packages.pydeconz: 91 -> 92`                                                               |
| [`2a55c8ee`](https://github.com/NixOS/nixpkgs/commit/2a55c8ee8153ef3a91f36bed003e186f0e846810) | `python310Packages.google-cloud-bigquery: 3.0.1 -> 3.1.0`                                            |
| [`d404697e`](https://github.com/NixOS/nixpkgs/commit/d404697e7c89e9e0da4d420a157f53cbd6aea76e) | `nanovna-saver: 0.3.8 -> 0.4.0`                                                                      |
| [`69146c56`](https://github.com/NixOS/nixpkgs/commit/69146c5629b61fc9d661d5f1be55c65da2a110b4) | `dsf2flac: unstable-2018-01-02 → unstable-2021-07-31`                                                |
| [`98a2cf22`](https://github.com/NixOS/nixpkgs/commit/98a2cf221dfe7bbf2e13691f3255481e6a63b20a) | `lumo: remove`                                                                                       |
| [`fd841451`](https://github.com/NixOS/nixpkgs/commit/fd8414512baac8b96fbd245b6903afaa956de3d3) | `gimx: fix build`                                                                                    |
| [`fa04419d`](https://github.com/NixOS/nixpkgs/commit/fa04419da05819924ca501f82ab14accff6023ec) | `ocamlPackages.cryptokit: 1.16.1 → 1.17`                                                             |
| [`cbd4728f`](https://github.com/NixOS/nixpkgs/commit/cbd4728f8aa0481f252da5a654a224d134d3fa06) | `opa: drop spurious dependency on cryptokit`                                                         |
| [`5fd7f4ef`](https://github.com/NixOS/nixpkgs/commit/5fd7f4ef825f2251aeab5c1f526da955dcb4caef) | `molden: unbreak build, make compatible with gcc-10`                                                 |
| [`8f54cca4`](https://github.com/NixOS/nixpkgs/commit/8f54cca448ff7c3f2700d0cd546df5a8d88e3b8c) | `nixos/doc: Add Snipe-IT to 22.05 release notes`                                                     |
| [`9cb38873`](https://github.com/NixOS/nixpkgs/commit/9cb388739f5edba3b6f81a70d337f6ab341a9cc6) | `nixos/snipe-it: init`                                                                               |
| [`b9a74a1b`](https://github.com/NixOS/nixpkgs/commit/b9a74a1b67200f83f3f5e2b038eb34701c0c9edb) | `snipe-it: init at 5.4.3`                                                                            |
| [`37578b91`](https://github.com/NixOS/nixpkgs/commit/37578b911e95aa092c1897d38df3732301063fce) | `rcshist: use webarchive of source tgz (#172339)`                                                    |
| [`7bfe1e3b`](https://github.com/NixOS/nixpkgs/commit/7bfe1e3b52944e520109ca94c1df3d1f2826a128) | `python3Packages.ibis-framework: depend on graphviz-nox instead of graphviz`                         |
| [`96e5ab89`](https://github.com/NixOS/nixpkgs/commit/96e5ab89864c50037842880890d52a7c4a9b8570) | `python3Packages.ibis-framework: allow setting features for backend deps`                            |
| [`d339433f`](https://github.com/NixOS/nixpkgs/commit/d339433f8d018d9e2afa27df5fdf3959f80ee770) | `wireplumber: 0.4.9 → 0.4.10`                                                                        |
| [`74c9d798`](https://github.com/NixOS/nixpkgs/commit/74c9d7985b2a6457aa7e42a1aa71db3ec3e85cb8) | `python310Packages.zope_lifecycleevent: 4.3 -> 4.4`                                                  |
| [`29d9779e`](https://github.com/NixOS/nixpkgs/commit/29d9779e9b267df3879e7cbc59e8b49fde084523) | `python310Packages.ansible-compat: 2.0.2 -> 2.0.3`                                                   |
| [`08a0f925`](https://github.com/NixOS/nixpkgs/commit/08a0f925e04bc949c4041c258144b2d45c4946ce) | `getmail6: 6.18.7 -> 6.18.8`                                                                         |
| [`3b538cd7`](https://github.com/NixOS/nixpkgs/commit/3b538cd79012f73261743a525e1022a0a1532f36) | `luaPackages: update (add cldr, fluent, loadkit; bump cassowary)`                                    |
| [`9254e550`](https://github.com/NixOS/nixpkgs/commit/9254e550a8518d6f78a920c980bfd10ffddb539c) | `luaPackages: add new packages cldr, fluent, and loadkit`                                            |
| [`e4fb3cb6`](https://github.com/NixOS/nixpkgs/commit/e4fb3cb6894368f2bd472df7d4f56e957fa4206d) | `python3Packages.apache-beam: patch in upstream deprecation fix`                                     |
| [`15751e9f`](https://github.com/NixOS/nixpkgs/commit/15751e9f727b7557ace90a03d52cfb0464dbdc12) | `python3Packages.google-cloud-bigquery: patch for arrow 8 and parallelize tests`                     |
| [`3bf21749`](https://github.com/NixOS/nixpkgs/commit/3bf217495b166a0513788c16aa96efba5425d6bc) | `python3Packages.db-dtypes: patch to support arrow 8`                                                |
| [`e0f70681`](https://github.com/NixOS/nixpkgs/commit/e0f70681f9ee98371cc74cb28ec906fcf357b96c) | `python3Packages.pyarrow: enable s3`                                                                 |
| [`315002db`](https://github.com/NixOS/nixpkgs/commit/315002db4e19d66b7460f4baa6c0d111682a03fc) | `arrow-cpp: 7.0.0 -> 8.0.0`                                                                          |
| [`a44b5a56`](https://github.com/NixOS/nixpkgs/commit/a44b5a56041367fb7babccba59ba8da4831cfc34) | `haskellPackages: mark builds failing on hydra as broken`                                            |
| [`7d673c71`](https://github.com/NixOS/nixpkgs/commit/7d673c71c1a838dc8e2b51e3e48e719f6629fc67) | `luaPackages: add new package - tl (teal language)`                                                  |
| [`757f518f`](https://github.com/NixOS/nixpkgs/commit/757f518f803e684500076f169078ab0de8a9835b) | `gmtp: fix with non-binary wrapper for wrapGAppsHook`                                                |
| [`22042803`](https://github.com/NixOS/nixpkgs/commit/220428039c8cdb58dcdde4d766ef99fac71c285d) | `bluej: fix with non-binary wrapper for wrapGAppsHook`                                               |
| [`9709c5f4`](https://github.com/NixOS/nixpkgs/commit/9709c5f4a4ba7b3e2889b4f1fe79c9e42e829909) | `cryptomator: use non-binary wrapper for wrapGAppsHook`                                              |
| [`86e7fa94`](https://github.com/NixOS/nixpkgs/commit/86e7fa945e310b1c21ea837109879e7c8b935e2b) | `tlaplusToolbox: use non-binary wrapper for wrapGAppsHook`                                           |
| [`c07919c7`](https://github.com/NixOS/nixpkgs/commit/c07919c76caadd5915cbef41786f595e33cc263b) | `hydra: fix evaluation with aliases disabled`                                                        |
| [`10bb8b18`](https://github.com/NixOS/nixpkgs/commit/10bb8b1818d309a144b2a0775ce1d0194a433852) | `ocamlPackages.easy-format: 1.2.0 → 1.3.2`                                                           |
| [`f3ef6622`](https://github.com/NixOS/nixpkgs/commit/f3ef66220b4224c130cd0c7b860d105c49ea9da8) | `ocamlPackages.biniou: remove legacy version 1.0.9 for OCaml < 4.02`                                 |
| [`18aee8a1`](https://github.com/NixOS/nixpkgs/commit/18aee8a1ad6a99dbcd5096711b22e4f48e4d8b83) | `terragrunt: 0.36.10 -> 0.36.11`                                                                     |
| [`a2ee3ed3`](https://github.com/NixOS/nixpkgs/commit/a2ee3ed3f284c5b33432fbd55d07a624f01ff8c5) | `vscode: use non-binary wrapper for wrapGAppsHook`                                                   |
| [`a6977778`](https://github.com/NixOS/nixpkgs/commit/a6977778089a7f9b31335e5d202cf20798705b6e) | `discord: use non-binary wrapper for wrapGAppsHook`                                                  |
| [`6d06f475`](https://github.com/NixOS/nixpkgs/commit/6d06f47584813ec31e5ad167e3f488fbebaac7a1) | `brave: use non-binary wrapper for wrapGAppsHook`                                                    |
| [`6afb6d40`](https://github.com/NixOS/nixpkgs/commit/6afb6d4032adb78d50bd52cbac9bd33ec6f23c01) | `fnc: 0.10 -> 0.12`                                                                                  |
| [`3120f41d`](https://github.com/NixOS/nixpkgs/commit/3120f41ddd58d5a0a466634efdf9b99de1262001) | `python3Packages.pydyf: fix failing tests`                                                           |
| [`8cc63bb7`](https://github.com/NixOS/nixpkgs/commit/8cc63bb7866788e582d05c6209abfb5006805b0c) | `libast: 0.7.1 -> 0.8`                                                                               |
| [`de869f03`](https://github.com/NixOS/nixpkgs/commit/de869f039d591f205e6bf09fd4cc7a55246f1ee2) | `siesta: fix hardcoded path to rm`                                                                   |
| [`70d7d6ee`](https://github.com/NixOS/nixpkgs/commit/70d7d6eefa40a486de4c41ebd5fa4f859151553e) | `signal-desktop: use non-binary wrapper for wrapGAppsHook`                                           |
| [`4029d50b`](https://github.com/NixOS/nixpkgs/commit/4029d50b1e23718b9c6e1b03ded22b552038ae93) | `maintainers: expand jceb's name (#172312)`                                                          |
| [`3d195260`](https://github.com/NixOS/nixpkgs/commit/3d195260adae3ed4436f456a80a563a8844d6aa9) | `yex-lang: unstable-2021-12-25 -> 0.pre+date=2022-05-10`                                             |
| [`18d7643c`](https://github.com/NixOS/nixpkgs/commit/18d7643c9d19d89658cc820b474201cea9135af6) | `dgen-sdl: fixup meta.homepage`                                                                      |
| [`b8985bb9`](https://github.com/NixOS/nixpkgs/commit/b8985bb965737ce8d117b7a2c5242aabf0e6062c) | `teapot: use Museoa as backup`                                                                       |
| [`b4a61b63`](https://github.com/NixOS/nixpkgs/commit/b4a61b636a21c7e4608ae9003ccb3865176f395c) | `teams: fix wrapper workaround`                                                                      |
| [`0bc70ad4`](https://github.com/NixOS/nixpkgs/commit/0bc70ad43489682489adfcf0678cec700c6d5a20) | `zeroc-ice: 3.7.6 -> 3.7.7, drop Darwin`                                                             |
| [`14d0c3f3`](https://github.com/NixOS/nixpkgs/commit/14d0c3f3a17fda1e1ad7f8ea3cddb2615d095d16) | `csound: darwin support`                                                                             |
| [`bb55ac97`](https://github.com/NixOS/nixpkgs/commit/bb55ac971a77b7d23d4963eb6ba33652a568d1ef) | `python310Packages.extractcode: 30.0.0 -> 31.0.0`                                                    |
| [`c0d01f15`](https://github.com/NixOS/nixpkgs/commit/c0d01f15f9274c0314a29b5154ab24ab5ca675a5) | `pythonPackages.nutils: Mark broken for aarch64`                                                     |
| [`4fbc3657`](https://github.com/NixOS/nixpkgs/commit/4fbc3657db02f9739f2009fbb924aad2ac93ebf1) | `python310Packages.aws-lambda-builders: 1.15.0 -> 1.16.0`                                            |
| [`4a3bbec4`](https://github.com/NixOS/nixpkgs/commit/4a3bbec489c0e076a807ccf6d877662547ea2ad9) | `python3Packages.prox-tv: ignore unstable test`                                                      |
| [`b544d177`](https://github.com/NixOS/nixpkgs/commit/b544d177a26985b5fc1149612bac511f35be6a48) | `lib.licenses: add DRL-1.0`                                                                          |
| [`83b7231f`](https://github.com/NixOS/nixpkgs/commit/83b7231f6a4c7fa7c3e31f2a71b42f2d70da6285) | `clip: init at 2.1.1`                                                                                |
| [`7fde85cb`](https://github.com/NixOS/nixpkgs/commit/7fde85cbe1893c1b0f729063d705786391a1f911) | `python310Packages.oletools: 0.60 -> 0.60.1`                                                         |
| [`97ed4e85`](https://github.com/NixOS/nixpkgs/commit/97ed4e85eab62532cb8fc3bc6e2cdc446b2f8bbf) | `python310Packages.dbf: disable on older Python releases`                                            |
| [`3e7a9344`](https://github.com/NixOS/nixpkgs/commit/3e7a93449edda39ce34c09e95ecec2ab2ba6ca1e) | `cinny: 1.8.2 -> 2.0.0`                                                                              |
| [`f6004cdb`](https://github.com/NixOS/nixpkgs/commit/f6004cdb2ecb5128abb35d8fe75249676e0b1b34) | `python310Packages.hvplot: disable on older Python releases`                                         |
| [`7bd29be2`](https://github.com/NixOS/nixpkgs/commit/7bd29be23bb81d928dc358a6488d96bc2d3e2611) | `python310Packages.dbf: 0.99.1 -> 0.99.2`                                                            |
| [`9d9b4dc6`](https://github.com/NixOS/nixpkgs/commit/9d9b4dc64b366c33ce05b21c4e488e22eca9ece6) | `envoy: fix sha256 for x86_64-linux`                                                                 |
| [`fc9d5ea6`](https://github.com/NixOS/nixpkgs/commit/fc9d5ea630a06349a8b49d9c7e68a9f8abf11aab) | `python310Packages.hvplot: 0.7.3 -> 0.8.0`                                                           |
| [`12e43250`](https://github.com/NixOS/nixpkgs/commit/12e43250db62ccb4fdb8b871b50f61dc7b163f27) | `curlcpp: drop`                                                                                      |
| [`06841666`](https://github.com/NixOS/nixpkgs/commit/0684166637e6c9ce87d209d704797f1a9b7e1c3a) | `haste-server: 72863858338a57d54eb9dee55530e90ebbc22453 -> 68f6fe2b96ad02e21645480448113954bc87e1f5` |
| [`9a4ea414`](https://github.com/NixOS/nixpkgs/commit/9a4ea4146e31d172f51591840f7927ccc32dc75f) | `python3Packages.ipwhl: 1.0.0 -> 1.1.0`                                                              |
| [`ced69442`](https://github.com/NixOS/nixpkgs/commit/ced69442bca98f4d61189d61d5be13aeedcdaccb) | `mepo: 0.4.1 -> 0.4.2`                                                                               |
| [`430f6d45`](https://github.com/NixOS/nixpkgs/commit/430f6d45e3487fe745c7774f72f02aa129fcabef) | `skopeo: 1.7.0 -> 1.8.0`                                                                             |
| [`705acec5`](https://github.com/NixOS/nixpkgs/commit/705acec552eb83238e381aee71ac7071ba5ab6b3) | `home-assistant: support metoffice component`                                                        |
| [`39688e7f`](https://github.com/NixOS/nixpkgs/commit/39688e7fec0670d6d4fb266ba8c4aee405b2aea1) | `python3Packages.datapoint: init at 0.9.8`                                                           |
| [`33892e97`](https://github.com/NixOS/nixpkgs/commit/33892e97554a4af39dde7f7243468f01c3809219) | `home-assistant: support sabnzbd component`                                                          |
| [`a18a0fa2`](https://github.com/NixOS/nixpkgs/commit/a18a0fa29d69ef50f5cfdecda9f7f942aca2ba67) | `python3Packages.pysabnzbd: init at 1.1.1`                                                           |
| [`ae40cc00`](https://github.com/NixOS/nixpkgs/commit/ae40cc00325b365b8749a06dd3af5f4f95ff9696) | `python3Packages.slicer: disable failing tests`                                                      |
| [`ed649982`](https://github.com/NixOS/nixpkgs/commit/ed6499826a7f401c536ae6262c52fc636a4f3851) | `python3Packages.nbclient: 0.6.2 -> 0.6.3`                                                           |
| [`977f14fa`](https://github.com/NixOS/nixpkgs/commit/977f14fab1227bea9f7272cbbbba9f563d102f7a) | `re2c: add some key reverse dependencies to passthru.tests`                                          |
| [`4bc8d425`](https://github.com/NixOS/nixpkgs/commit/4bc8d425f2c8b1d537293e10e2e8bd9713d9d616) | `imlib2: add some key reverse-dependencies to passthru.tests`                                        |
| [`0fc6a60e`](https://github.com/NixOS/nixpkgs/commit/0fc6a60ecc20d72d218465831f2882544881d71c) | `flyctl: fix ldflags date parsing`                                                                   |
| [`6b8d9125`](https://github.com/NixOS/nixpkgs/commit/6b8d91253d3b921fbdba840af1835d7183f6d7d9) | `melt: 0.3.0 -> 0.4.0`                                                                               |
| [`a07cc041`](https://github.com/NixOS/nixpkgs/commit/a07cc041090da87693501b86cf8e5bf3529e8ed9) | `hydra: don't force HYDRA_RELEASE`                                                                   |
| [`cec7fc48`](https://github.com/NixOS/nixpkgs/commit/cec7fc48bb7e7a944fc00ba100018cc1237f6f83) | `hydra-unstable: 2021-12-17 -> 2022-02-07`                                                           |
| [`3c34e350`](https://github.com/NixOS/nixpkgs/commit/3c34e350c930fc1e164627d5ca8daa4dd9f2451a) | `perlPackages.UUID4Tiny: init at 0.002`                                                              |
| [`2e882e09`](https://github.com/NixOS/nixpkgs/commit/2e882e09033b481a8f4531c30cfab7fc855c3909) | `hydra-unstable: 2021-08-11 -> 2021-12-17`                                                           |
| [`52a78362`](https://github.com/NixOS/nixpkgs/commit/52a78362ac76d96644ea0057a8544e14ee6667a0) | `zkar: init at 1.3.0`                                                                                |
| [`9ca7db22`](https://github.com/NixOS/nixpkgs/commit/9ca7db22af02d7f80b81318a11a66a881c3d1176) | `polkadot: 0.9.18 -> 0.9.21`                                                                         |
| [`43cbc7f7`](https://github.com/NixOS/nixpkgs/commit/43cbc7f79f3ab4b76ba615f5fb7dcce00a3d7973) | `python3Packages.skytemple-files: mark broken on darwin`                                             |
| [`145de7cd`](https://github.com/NixOS/nixpkgs/commit/145de7cdc8d8be8ebf9ee31dc8a25300cc7edc23) | `shellhub-agent: 0.9.1 -> 0.9.2`                                                                     |
| [`c36d585e`](https://github.com/NixOS/nixpkgs/commit/c36d585e14b84f3f046a45b5a36949aa33393f1f) | `ares: 126 -> 127`                                                                                   |
| [`89412f83`](https://github.com/NixOS/nixpkgs/commit/89412f830e0855fa56ae8d409991b79cbd6b5f73) | `nuclei: 2.6.9 -> 2.7.0`                                                                             |
| [`27424231`](https://github.com/NixOS/nixpkgs/commit/27424231b35c6b0b040afd6e2caf00d7a8887b36) | `teamviewer: 15.26.4 -> 15.29.4`                                                                     |
| [`56481a2e`](https://github.com/NixOS/nixpkgs/commit/56481a2ecc842ad2d1915381d9684f33ff74d477) | `srain: 1.3.2 -> 1.4.0`                                                                              |
| [`9bd212ea`](https://github.com/NixOS/nixpkgs/commit/9bd212eaf0e11b9802dd2e7bea41152cd1d985a0) | `haskellPackages: update note about dhall in stackage`                                               |
| [`1905c075`](https://github.com/NixOS/nixpkgs/commit/1905c075b014add9485aefb808dcebd362a07d16) | `raven-reader: init at 1.0.72`                                                                       |
| [`a0e539ac`](https://github.com/NixOS/nixpkgs/commit/a0e539ac408b9509723f930151fc900e5b0463ce) | `vvave: init at 2.1.1`                                                                               |
| [`2d1af85d`](https://github.com/NixOS/nixpkgs/commit/2d1af85d4733b886986f8585baa1daf845104a7d) | `mauikit-nota: init at 2.1.1`                                                                        |
| [`04ba6470`](https://github.com/NixOS/nixpkgs/commit/04ba6470497fcce936f968b7e77c4387a420fe02) | `communicator: init at 2.1.1`                                                                        |
| [`ac564365`](https://github.com/NixOS/nixpkgs/commit/ac564365d4e0138712c3eed96b4251b4716e73af) | `emulationstation: pin boost 1.69`                                                                   |
| [`3592c25f`](https://github.com/NixOS/nixpkgs/commit/3592c25fb2917f1946ead3e0391960eccbc7ffef) | `terragrunt: 0.36.6 -> 0.36.10`                                                                      |
| [`52310fb5`](https://github.com/NixOS/nixpkgs/commit/52310fb50cc308d60fd64762bed78fb987b09b9c) | `thedesk: update electron`                                                                           |
| [`dcb178bf`](https://github.com/NixOS/nixpkgs/commit/dcb178bff97a36d405662b358424e8e4ea02ed6a) | `whalebird: 4.5.2 -> 4.5.4`                                                                          |
| [`85e59afc`](https://github.com/NixOS/nixpkgs/commit/85e59afc49fc172b60d3320a4a2a9d4f6b5a2919) | `snazy: 0.4.0 -> 0.9.0`                                                                              |
| [`4a3ed385`](https://github.com/NixOS/nixpkgs/commit/4a3ed385520d47d29b285344a4786711052000a7) | `driftctl: 0.28.1 -> 0.29.0`                                                                         |
| [`2381aa28`](https://github.com/NixOS/nixpkgs/commit/2381aa28fd1ff0641805b3b8fcc8031a42e2c4e5) | `scorecard: 4.1.0 -> 4.2.0`                                                                          |
| [`7fe4f29d`](https://github.com/NixOS/nixpkgs/commit/7fe4f29d680475303a41b71f261eef0ec6fff717) | `swaylock-effects: 1.6-3 -> unstable-2021-10-21`                                                     |
| [`cb8084f1`](https://github.com/NixOS/nixpkgs/commit/cb8084f11415ef75d824c06b5477289ddfeaefe3) | `unpackerr: 0.9.9 -> 0.10.0`                                                                         |
| [`440710cb`](https://github.com/NixOS/nixpkgs/commit/440710cb693b51e7ca76d434d44f6a74b6516d27) | `haskellPackages.git-annex: update hash`                                                             |
| [`fa78bd44`](https://github.com/NixOS/nixpkgs/commit/fa78bd440e338cfc2fd54d2e499760ceadf597f8) | `uxplay: 1.50 -> 1.52`                                                                               |
| [`a7be18ee`](https://github.com/NixOS/nixpkgs/commit/a7be18ee8528414a7af01674401a173453d0f972) | `python310Packages.PyChromecast: 12.1.1 -> 12.1.2`                                                   |
| [`940c886a`](https://github.com/NixOS/nixpkgs/commit/940c886a0b4fa368d51b7a66f3f67e3243c54038) | `exoscale-cli: add self as maintainer`                                                               |
| [`d753ffac`](https://github.com/NixOS/nixpkgs/commit/d753ffac205762e8d6a010ae1c01ef66788a8ad2) | `exoscale-cli: add man pages and completions`                                                        |
| [`db502a76`](https://github.com/NixOS/nixpkgs/commit/db502a76f01b10f889a2807dcccc1e2a893461ee) | `haskellPackages: regenerate package set based on current config`                                    |
| [`44c21a80`](https://github.com/NixOS/nixpkgs/commit/44c21a80ece6818cfed347da38501146ea286768) | `haskellPackages.cabal2nix-unstable: 2021-10-23 -> 2022-04-27`                                       |