### PR TITLE
chore(flake/nixpkgs): `78520c1f` -> `f771d397`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652242531,
-        "narHash": "sha256-08S4rhmHbv+n+rU0E2u06s204KIHpPJdJnNpusuewz4=",
+        "lastModified": 1652359428,
+        "narHash": "sha256-fyXUZecxcR0YoBgzLGvhNgwDZW/gpch7n4uro0ht+/g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "78520c1fff36113a9a6fe340ce33f57bb2332b67",
+        "rev": "f771d397500b5138329bd206af2634086d51d108",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                     |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`64878e3a`](https://github.com/NixOS/nixpkgs/commit/64878e3a67c4c4be5926135f6d0270d78461a8b7) | `automysqlbackp: fix missing permissions for mysqldump`                            |
| [`05f97621`](https://github.com/NixOS/nixpkgs/commit/05f976210a24e476cc6f87fd6c069eba44f0e2a3) | `rapidsvn: fix the build and use Python 3`                                         |
| [`069e5507`](https://github.com/NixOS/nixpkgs/commit/069e55070c64dd241292265979ca1ba3e28e1070) | `xgboost: expose xgboostWithCuda variant`                                          |
| [`c18e8335`](https://github.com/NixOS/nixpkgs/commit/c18e8335e8a38479e656c3a7f8a309876c950712) | `xgboost: disable TestXGBoostLib when cudaSupport`                                 |
| [`13265d3b`](https://github.com/NixOS/nixpkgs/commit/13265d3bba787054bb5290b3ef60785131f8b60e) | `xgboost: remove nvidia_x11 dependency`                                            |
| [`74240cf1`](https://github.com/NixOS/nixpkgs/commit/74240cf1762616aa7090840fc7df8e0bfcabade8) | `phpPackages.php-parallel-lint: 1.0.0 -> 1.3.2`                                    |
| [`e4bb2cac`](https://github.com/NixOS/nixpkgs/commit/e4bb2cac3926fbe3858050acbfcc79eb69b8a7e4) | `vimPlugins.fzf-lua: init at 2022-05-07`                                           |
| [`3c90c281`](https://github.com/NixOS/nixpkgs/commit/3c90c28124236b28da6ea3850b4badbc6f42a2bd) | `phpPackages.box: 2.7.5 -> 3.16.0`                                                 |
| [`da6f0c5e`](https://github.com/NixOS/nixpkgs/commit/da6f0c5e95beb1d8d33a72077a54826f39021f31) | `dbeaver: add aarch64-darwin to the list of supported platforms`                   |
| [`e2456aed`](https://github.com/NixOS/nixpkgs/commit/e2456aed84d8c42c2098d48f9529d7949040230e) | `getmail6: 6.18.8 -> 6.18.9`                                                       |
| [`b93f65a5`](https://github.com/NixOS/nixpkgs/commit/b93f65a5f353531ecda1ea1ea958dcfd3d6e4b54) | `linux-firmware: 20220310 -> 20220509`                                             |
| [`110ca878`](https://github.com/NixOS/nixpkgs/commit/110ca8783810797ca4188850abd777a3dbd6b300) | `python310Packages.dparse2: init at 0.6.1`                                         |
| [`f51dc952`](https://github.com/NixOS/nixpkgs/commit/f51dc9526531f3438c96b569d6146877f794224f) | `flatbuffers: remove version 1.12`                                                 |
| [`5d44c9a2`](https://github.com/NixOS/nixpkgs/commit/5d44c9a2223e4493e9bac4e5c57beb587530289f) | `vhd2vl: fix the tests`                                                            |
| [`a061adc7`](https://github.com/NixOS/nixpkgs/commit/a061adc787c5a2eb371694eb4076b08ee36973e8) | `python310Packages.dash: 2.3.1 -> 2.4.1`                                           |
| [`41b83068`](https://github.com/NixOS/nixpkgs/commit/41b8306849138b19f1f06016c8a95b83e053b361) | `python310Packages.google-cloud-pubsub: 2.12.0 -> 2.12.1`                          |
| [`d9163e4a`](https://github.com/NixOS/nixpkgs/commit/d9163e4a030cb0f637a2b6b2b879d6f4a72b68e7) | `zsh-fzf-tab: fix Darwin build`                                                    |
| [`407b7c55`](https://github.com/NixOS/nixpkgs/commit/407b7c551c4e9014bd8d4303a97a544672440b2a) | `kdash: fix Darwin build`                                                          |
| [`82440c93`](https://github.com/NixOS/nixpkgs/commit/82440c9374f4de934e287476e2b3a4bbf837d98a) | `moving findlib to propagedNativeBuildInputs`                                      |
| [`7e589a45`](https://github.com/NixOS/nixpkgs/commit/7e589a45ef86abf9a6a737d9730925b81ee663b4) | `coqPackages: etc`                                                                 |
| [`c02bee78`](https://github.com/NixOS/nixpkgs/commit/c02bee786b6349087df7a6b0e9ee07bb6d6ceafd) | `python310Packages.ftputil: 5.0.3 -> 5.0.4`                                        |
| [`1c5cd8bb`](https://github.com/NixOS/nixpkgs/commit/1c5cd8bb2f3ac8ad96cde8672b00ca43f06ce57b) | `python310Packages.puremagic: 1.12 -> 1.13`                                        |
| [`f1a9532e`](https://github.com/NixOS/nixpkgs/commit/f1a9532e0012a9312a85d46d3236b2276ee6e594) | `python310Packages.nose: update homepage (#172635)`                                |
| [`d838e527`](https://github.com/NixOS/nixpkgs/commit/d838e527c397eed2d40b1e2b5770a5b5f601728b) | `python310Packages.mapbox: mark broken (#172627)`                                  |
| [`dea7e48d`](https://github.com/NixOS/nixpkgs/commit/dea7e48d74e292d75146fdb42fa433269fa3f3e3) | `python3Packages.napalm: disable python 3.9 onwards (#172643)`                     |
| [`aa9eb450`](https://github.com/NixOS/nixpkgs/commit/aa9eb4509c2bb0c258f84d3d465096888c1e0565) | `nginx-doc-unstable: init at 2022-05-05`                                           |
| [`c92ef7a1`](https://github.com/NixOS/nixpkgs/commit/c92ef7a135ddce27b294fe11b970f0d21bc9a152) | `nginx: build offline documentation`                                               |
| [`68752301`](https://github.com/NixOS/nixpkgs/commit/6875230170bc389de0110f35b5cb594b53cee2dc) | `python310Packages.rflink: disable failing test`                                   |
| [`3ad11bc2`](https://github.com/NixOS/nixpkgs/commit/3ad11bc20b69e0afa23d9d05c04158eb0c1c0c6d) | `python310Packages.eiswarnung: 1.0.0 -> 1.1.0`                                     |
| [`17be6f75`](https://github.com/NixOS/nixpkgs/commit/17be6f75ce6cb42d7d4514c62f7e5907e5776e34) | `python3Packages.monosat: disable failing tests`                                   |
| [`9ee6f67f`](https://github.com/NixOS/nixpkgs/commit/9ee6f67f8464bbf08184564931f896a523abed52) | `python3Packages.atomman: disable python 3.10, disable failing tests`              |
| [`ff6e3bbc`](https://github.com/NixOS/nixpkgs/commit/ff6e3bbcd8f06c72a01091ed91862a1c6ca51b16) | `python310Packages.scikit-bio: 0.5.6 -> 0.5.7`                                     |
| [`bad52402`](https://github.com/NixOS/nixpkgs/commit/bad52402a5387df45dc98968d95a6506bbc09c5d) | `python3.pkgs.sphinx-better-theme: init at 0.1.5 (#171595)`                        |
| [`98a2e49d`](https://github.com/NixOS/nixpkgs/commit/98a2e49dd102663736d656724205f677a10598d1) | `runc: 1.1.1 -> 1.1.2`                                                             |
| [`b1e6ccc8`](https://github.com/NixOS/nixpkgs/commit/b1e6ccc862a71e3f57e98ec1631a67b2b18fe98c) | `cliscord: fix build on Darwin`                                                    |
| [`73d152e6`](https://github.com/NixOS/nixpkgs/commit/73d152e6230812c80b8b859ff69c2e6ca88162ce) | `podman: mark as broken on x86_64-darwin`                                          |
| [`b54760df`](https://github.com/NixOS/nixpkgs/commit/b54760df333ff2957075218d8c64784d0d08118d) | `checkov: 2.0.1132 -> 2.0.1136`                                                    |
| [`e3d8a347`](https://github.com/NixOS/nixpkgs/commit/e3d8a347fee00b675222ad11a68fd12737e9357f) | `garage: fix build on Darwin`                                                      |
| [`a0db18f0`](https://github.com/NixOS/nixpkgs/commit/a0db18f052dc4104e60d44e662059a79caf070bf) | `python310Packages.python-rabbitair: init at 0.0.8`                                |
| [`b8a2b16f`](https://github.com/NixOS/nixpkgs/commit/b8a2b16f83fb6a2e4847e0b43824cbddc4a9efe4) | `maintainers: update oxalica's keys`                                               |
| [`b1723f8c`](https://github.com/NixOS/nixpkgs/commit/b1723f8c477d5c08158b95583f0b786144d8c092) | `tree-sitter: update grammars and add oxalica as maintainer`                       |
| [`ced8e41e`](https://github.com/NixOS/nixpkgs/commit/ced8e41eefd174f4b8f2f8d4e9b82365dd404191) | `crow-translate: 2.9.2 → 2.9.5`                                                    |
| [`7bf12fe3`](https://github.com/NixOS/nixpkgs/commit/7bf12fe3b5a88016834e3693184e6375cbf4a645) | `kgpg: update description to reflect gnupg`                                        |
| [`7c8f0a30`](https://github.com/NixOS/nixpkgs/commit/7c8f0a3076e9e7757a7db046a48a34d296d6e014) | `python39Packages.sentry-sdk: 1.5.11 -> 1.5.12`                                    |
| [`caf95ff5`](https://github.com/NixOS/nixpkgs/commit/caf95ff50940e3e120e0879312870cdcff8d8fa7) | `CODEOWNERS: rename Gabriel439 to Gabriella439`                                    |
| [`9e7978f7`](https://github.com/NixOS/nixpkgs/commit/9e7978f75f126c2bce9b6f289657d539ba2ec272) | `python310Packages.yalexs: 1.1.24 -> 1.1.25`                                       |
| [`c6cf01e6`](https://github.com/NixOS/nixpkgs/commit/c6cf01e66fe90e3684376f281da1b3334650e227) | `python310Packages.zimports: enable tests`                                         |
| [`d7af2fb8`](https://github.com/NixOS/nixpkgs/commit/d7af2fb8571e983b501601f9af0cb1f06cdbaf3b) | `python310Packages.zimports: 0.5.0 -> 0.6.0`                                       |
| [`fd33656e`](https://github.com/NixOS/nixpkgs/commit/fd33656e3d31f83bb40cb7e2ad4238a5dda74d55) | `pls: init at 4.0.3`                                                               |
| [`0d02ba8f`](https://github.com/NixOS/nixpkgs/commit/0d02ba8ffb2fd52fc8535c917992a88b7155595b) | `emacsPackages.pdf-tools: fix build`                                               |
| [`08594d7a`](https://github.com/NixOS/nixpkgs/commit/08594d7a7e1e2ad4ab65dd0adcf26598cb2461bd) | `factorio: 1.1.57 -> 1.1.59`                                                       |
| [`5b447f98`](https://github.com/NixOS/nixpkgs/commit/5b447f98e18e87f346b2ac6bcae7af7ec9cf7e3e) | `ArchiSteamFarm: fix aarch64 build`                                                |
| [`a7677322`](https://github.com/NixOS/nixpkgs/commit/a7677322d36fc9de29beaf74756624fbe502309a) | `werf: 1.2.91 -> 1.2.99`                                                           |
| [`0165df5b`](https://github.com/NixOS/nixpkgs/commit/0165df5b456a8951ea0dbf3702f24f02dde4588f) | `ue4: link to fixing issue, remove maintainer`                                     |
| [`d86c6050`](https://github.com/NixOS/nixpkgs/commit/d86c6050269100d5384ad4db293f08e7d6bdc4d9) | `libnvidia-container: 1.5.0 -> 1.9.0`                                              |
| [`63453563`](https://github.com/NixOS/nixpkgs/commit/63453563237eb2868de6be359eb49a3090a836ac) | `pdftk-legacy: drop`                                                               |
| [`0bd5909e`](https://github.com/NixOS/nixpkgs/commit/0bd5909ea7ae25fb5cd2667128d3c161abcbdb76) | `openbr: drop`                                                                     |
| [`70aad78d`](https://github.com/NixOS/nixpkgs/commit/70aad78d1931a1496bc5ead8a444422c69d2a7e8) | `vogl: drop`                                                                       |
| [`bb38235d`](https://github.com/NixOS/nixpkgs/commit/bb38235dc6835d83534d5265271ae35b5b36c1e4) | `infobar: drop`                                                                    |
| [`d14b6e65`](https://github.com/NixOS/nixpkgs/commit/d14b6e65fffc88872063d6e0c6f4635bfd6c887e) | `samsung-unified-linux-driver_4_00_39: drop`                                       |
| [`2b6ad306`](https://github.com/NixOS/nixpkgs/commit/2b6ad306109d108711219e9c5e9fa5e58ffdad40) | `libdap: drop`                                                                     |
| [`e8e6743b`](https://github.com/NixOS/nixpkgs/commit/e8e6743b280a33e1538bfa719d39fd93e42ab701) | `neopg: drop`                                                                      |
| [`77e956ef`](https://github.com/NixOS/nixpkgs/commit/77e956ef7685ed489bcb1e775065af7610e4354d) | `Update pkgs/development/python-modules/pandoc-xnos/default.nix`                   |
| [`542eff22`](https://github.com/NixOS/nixpkgs/commit/542eff225dcacac9d105b835333a70bcb5b75500) | `cloudsmith-cli: 0.31.1 → 0.32.0`                                                  |
| [`15cf12c0`](https://github.com/NixOS/nixpkgs/commit/15cf12c0ac44c1884027cc6e304bf0b00a894d53) | `singular: fix darwin build`                                                       |
| [`9d39485d`](https://github.com/NixOS/nixpkgs/commit/9d39485d5863644100c622ae0ad55b6fb0429051) | `python3Packages.diagrams: relax version constraints`                              |
| [`94536501`](https://github.com/NixOS/nixpkgs/commit/945365017ae592a63c23685e5257893b6963d138) | `gtkd: remove the dev output to resolve cycle dependency`                          |
| [`464db0cb`](https://github.com/NixOS/nixpkgs/commit/464db0cb7839c6c699eb8e903d9d7b86df3e02bc) | `gtkd: 3.9.0 -> 3.10.0`                                                            |
| [`89c7a24c`](https://github.com/NixOS/nixpkgs/commit/89c7a24cef2057bbf2996ad1a1924120a5d2d04c) | `flyctl: add testVersion as simple smoke test`                                     |
| [`96a514a2`](https://github.com/NixOS/nixpkgs/commit/96a514a232c866ffc044c88214390ee30bd6804b) | `python3.pkgs.ldaptor: disable checks, remove broken`                              |
| [`8ca6240a`](https://github.com/NixOS/nixpkgs/commit/8ca6240a846001c14662600bc5e8d5ba99180711) | `element-{web,desktop}: 1.10.11 -> 1.10.12`                                        |
| [`26d686cc`](https://github.com/NixOS/nixpkgs/commit/26d686cc860bf438ee818caaaa01180ada7f8493) | `cloudflared: 2022.5.0 -> 2022.5.1`                                                |
| [`0825d9ad`](https://github.com/NixOS/nixpkgs/commit/0825d9ad8842ed5d5507109f470bebf946c6827d) | `terragrunt: 0.36.11 -> 0.37.0`                                                    |
| [`a4022cf3`](https://github.com/NixOS/nixpkgs/commit/a4022cf3de27d356df8d40c1b9f5b9d00cce543e) | `sptlrx: add version test`                                                         |
| [`b116e885`](https://github.com/NixOS/nixpkgs/commit/b116e88556d80ae6ba0d44ca3de384ba2520e8bd) | `split2flac: removed`                                                              |
| [`acce8607`](https://github.com/NixOS/nixpkgs/commit/acce86078c84ae8e15ff3a1bcd86e43d7754e6f0) | `zammad: 5.1.0 -> 5.1.1`                                                           |
| [`b085aefb`](https://github.com/NixOS/nixpkgs/commit/b085aefbd40eb0d7b99572658beaad1428f42226) | `python3Packages.openshift: fix disabled tests`                                    |
| [`0a2adbd8`](https://github.com/NixOS/nixpkgs/commit/0a2adbd84772c6856ada04a964a51ed0c4ed500f) | `python3Packages.validict: init at 0.5.1 (#171558)`                                |
| [`ef38006a`](https://github.com/NixOS/nixpkgs/commit/ef38006a31d5cbf616e91942c1fcd7ce76d525d0) | `shfmt: 3.4.3 -> 3.5.0`                                                            |
| [`1e206598`](https://github.com/NixOS/nixpkgs/commit/1e2065983e248aaf65a7f7c7de673b798fc6f9b9) | `octopus: 11.3 -> 11.4`                                                            |
| [`897fdff7`](https://github.com/NixOS/nixpkgs/commit/897fdff73b7471c97ddfba5fd6916b5ce8a55438) | `snapper: 0.10.0 -> 0.10.2`                                                        |
| [`c5dbc6d1`](https://github.com/NixOS/nixpkgs/commit/c5dbc6d16165577428f03a50fad798088c5a7c58) | `pypiserver: 1.4.2 -> 1.5.0, add SuperSandro2000 as maintainer, add to… (#172417)` |
| [`0ecfb204`](https://github.com/NixOS/nixpkgs/commit/0ecfb204ae24a27c8aa94082675b60ed2ac7818d) | `python310Packages.praw: update disable`                                           |
| [`c2e73ebc`](https://github.com/NixOS/nixpkgs/commit/c2e73ebc70f9318f45fe5063eed0969773af35a7) | `python310Packages.pip-requirements-parser: init at 31.2.0`                        |
| [`b573c0d9`](https://github.com/NixOS/nixpkgs/commit/b573c0d93b01edcbd12784f8484bf06523d79ab3) | `python310Packages.container-inspector: init at 31.0.0`                            |
| [`9a0ff619`](https://github.com/NixOS/nixpkgs/commit/9a0ff61993e02bb9db5860d383866dc7537de148) | `chromium: 101.0.4951.54 -> 101.0.4951.64`                                         |
| [`a76ef494`](https://github.com/NixOS/nixpkgs/commit/a76ef494589dcf8cdaa9f1d42ab45ea427203332) | `open-policy-agent: fix darwin build issues`                                       |
| [`5eef62fc`](https://github.com/NixOS/nixpkgs/commit/5eef62fc0b181fc2c3de2749de5332c6f0832040) | `podman: 4.0.3 -> 4.1.0`                                                           |
| [`82f0b535`](https://github.com/NixOS/nixpkgs/commit/82f0b53588967aa392e8a60fd30022ce8981329b) | `dendrite: 0.8.1 -> 0.8.4`                                                         |
| [`8fc305d5`](https://github.com/NixOS/nixpkgs/commit/8fc305d584e42e567c5f8550d17773ac734edf84) | `vimPlugins.stylish-nvim: init at 2022-02-11`                                      |
| [`69f7c987`](https://github.com/NixOS/nixpkgs/commit/69f7c987501cad5311a615f6fa0bf3d3b975a967) | `python310Packages.pkginfo2: init at 30.0.0`                                       |
| [`b4e8a4bb`](https://github.com/NixOS/nixpkgs/commit/b4e8a4bbda45f0576017281d25e817bc19383bbd) | `libxml2: update homepage`                                                         |
| [`a722d046`](https://github.com/NixOS/nixpkgs/commit/a722d04617fc670306cbe931240ee04afea11205) | `mini-httpd: fix the build`                                                        |
| [`dc2c00a9`](https://github.com/NixOS/nixpkgs/commit/dc2c00a9af91d8886e9b950836e93025a5e14c41) | `libxslt: update homepage`                                                         |
| [`d77b0fc3`](https://github.com/NixOS/nixpkgs/commit/d77b0fc315bc11fda969a88706ed2da304948b2d) | `azimuth: fix compilation`                                                         |
| [`433f7fd2`](https://github.com/NixOS/nixpkgs/commit/433f7fd23378bb5e40f945f2efc18bb489085b5e) | `pe-parse: fix the build`                                                          |
| [`196deeb9`](https://github.com/NixOS/nixpkgs/commit/196deeb961b1a1900a152a04a320cdf0667614d8) | `python310Packages.flux-led: 0.28.28 -> 0.28.29`                                   |
| [`03cecc22`](https://github.com/NixOS/nixpkgs/commit/03cecc226724dda5672ef8591499f21c9c87df04) | `python3Packages.sentry-sdk: fix build, python3Packages.weasyprint:`               |
| [`3f19e359`](https://github.com/NixOS/nixpkgs/commit/3f19e35965f92f6635fe49ba18beaf3932049d17) | `gnss-sdr: 0.0.16 → 0.0.17`                                                        |
| [`f35d9453`](https://github.com/NixOS/nixpkgs/commit/f35d9453f7a0eee735418c2fabcf0f73130a98a4) | `wdomirror: avoid adding a patch`                                                  |
| [`81046b39`](https://github.com/NixOS/nixpkgs/commit/81046b393b404714d56d7bef275cdd28f7cfb044) | `bowtie: fix build on case insensitive file systems`                               |
| [`db93a10d`](https://github.com/NixOS/nixpkgs/commit/db93a10d817edc9cba5d08352411ba911f945f05) | `rc: update 1.7.4 -> unstable-2021-08-03`                                          |
| [`aa1f2083`](https://github.com/NixOS/nixpkgs/commit/aa1f2083a1bf5266ea41a0e22291323e82baf6ee) | `python3Packages.weasyprint: disable failing tests`                                |
| [`dca0c4a8`](https://github.com/NixOS/nixpkgs/commit/dca0c4a803e1b3840236e72278575c0e2f27b92d) | `python310Packages.praw: 7.5.0 -> 7.6.0`                                           |
| [`802a8416`](https://github.com/NixOS/nixpkgs/commit/802a8416b6f0b34afd2eec9d6249aa9763b9924d) | `bowtie: add arm64 patch to build on M1 Macs`                                      |
| [`409d3e7f`](https://github.com/NixOS/nixpkgs/commit/409d3e7f9af4e223f618ca189ee59fffe67323a4) | `python310Packages.aioqsw: 0.0.7 -> 0.0.8`                                         |
| [`e4459d14`](https://github.com/NixOS/nixpkgs/commit/e4459d1400038edbb21b44a0ba4efebf7f71e741) | `tfsec: 1.20.0 -> 1.20.2`                                                          |
| [`40803e47`](https://github.com/NixOS/nixpkgs/commit/40803e47d152fbfeb0c9943aa1a73764f8ec7fde) | `python310Packages.plugwise: 0.18.0 -> 0.18.1`                                     |
| [`8a7a08e1`](https://github.com/NixOS/nixpkgs/commit/8a7a08e149a83fb930eb2a47badf187ec4fdd0eb) | `python310Packages.slack-sdk: 3.16.0 -> 3.16.1`                                    |
| [`e1fa7d7b`](https://github.com/NixOS/nixpkgs/commit/e1fa7d7b2d03b47c83c94dd8d187156f69389127) | `python310Packages.angrop: 9.2.2 -> 9.2.3`                                         |
| [`8e819d9b`](https://github.com/NixOS/nixpkgs/commit/8e819d9b789490772298d5ee06ddfac5779c68c6) | `python310Packages.angr: 9.2.2 -> 9.2.3`                                           |
| [`0e86c357`](https://github.com/NixOS/nixpkgs/commit/0e86c35701c1f61b1b5bdcf48f3478ace062c7f4) | `python310Packages.cle: 9.2.2 -> 9.2.3`                                            |
| [`c124beb2`](https://github.com/NixOS/nixpkgs/commit/c124beb25dd9320bc7d1d365b22b83e8baec8e7b) | `python310Packages.claripy: 9.2.2 -> 9.2.3`                                        |
| [`5db0ce5a`](https://github.com/NixOS/nixpkgs/commit/5db0ce5a2b00dee63a2fcfbaeea9d8e34d26e070) | `python310Packages.pyvex: 9.2.2 -> 9.2.3`                                          |
| [`165dc4ec`](https://github.com/NixOS/nixpkgs/commit/165dc4ec042b27c65e9b132d092ea6f2dec0e19d) | `python310Packages.ailment: 9.2.2 -> 9.2.3`                                        |
| [`a4caa413`](https://github.com/NixOS/nixpkgs/commit/a4caa41357dd2904516c099e966a859626afc7de) | `python310Packages.archinfo: 9.2.2 -> 9.2.3`                                       |
| [`bca4ad04`](https://github.com/NixOS/nixpkgs/commit/bca4ad048701d2b0a472c0e0f0e3e24d62ccc9b0) | `ocamlPackages: inherit ocaml.meta.platforms`                                      |
| [`b1de4bf6`](https://github.com/NixOS/nixpkgs/commit/b1de4bf60f955ed59adb2d8878eb0b5d55fb1b4e) | `ocamlPackages: add meta.mainProgram to many packages`                             |
| [`dd6e29f6`](https://github.com/NixOS/nixpkgs/commit/dd6e29f6cbadee6dc8385ef13cd0c71323ca3eb8) | `python310Packages.fontmath: 0.9.1 -> 0.9.2`                                       |
| [`71fb0570`](https://github.com/NixOS/nixpkgs/commit/71fb057021baa6c2bdb85e2276e511aad434f649) | `python3Packages.azure-eventhub: add missing imput`                                |
| [`0fd6a3a9`](https://github.com/NixOS/nixpkgs/commit/0fd6a3a981ffeb74db42b3fdf35f0f70d819b4cf) | `python3Packages.azure-eventhub: disable on older Python releases`                 |
| [`7d045a76`](https://github.com/NixOS/nixpkgs/commit/7d045a76dd810bb0328ed46ba7d770760a44f52e) | `python310Packages.azure-mgmt-network: disable on older Python releases`           |