### PR TITLE
chore(flake/nixpkgs): `f771d397` -> `8e14a655`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652359428,
-        "narHash": "sha256-fyXUZecxcR0YoBgzLGvhNgwDZW/gpch7n4uro0ht+/g=",
+        "lastModified": 1652401584,
+        "narHash": "sha256-TdmqYuakB6mdgX8Ps0gnovC4jhqqwx15ht42Wm4nPpM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f771d397500b5138329bd206af2634086d51d108",
+        "rev": "8e14a65562cd6d976c00487557d9b5f0027a901e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`3382e4d2`](https://github.com/NixOS/nixpkgs/commit/3382e4d22224b1236361fca8ab37de5c22b1e6d7) | `opendungeons: fix compilation`                                                                  |
| [`59ee75c6`](https://github.com/NixOS/nixpkgs/commit/59ee75c60797e25f0d9e147f97b94d457aa2fcdd) | `ssocr: unstable-2018-08-11 -> 2.22.1 (#172444)`                                                 |
| [`357da6c2`](https://github.com/NixOS/nixpkgs/commit/357da6c29693d0909e0852297ae0edc74d9399ab) | `buildRustPackage: make cargoDeps logic easier to follow`                                        |
| [`c53a9ada`](https://github.com/NixOS/nixpkgs/commit/c53a9ada0b99236c57c86c2a305fb8a006b2bcba) | `nodePackages: remove lumo-build-deps`                                                           |
| [`e7f347cf`](https://github.com/NixOS/nixpkgs/commit/e7f347cf21c392fd394ce0dcccde3f2f575d4758) | `plasma5Packages.elisa: reduce runtime closure size`                                             |
| [`0041eeba`](https://github.com/NixOS/nixpkgs/commit/0041eeba055a3466e1ae42eb1f23a13c7fe5be74) | `nomad_1_3: init at 1.3.0`                                                                       |
| [`975d8340`](https://github.com/NixOS/nixpkgs/commit/975d834041846f063a007a9d0ba4a0efc47210bd) | `clojupyter: 0.3.2 -> 0.3.3`                                                                     |
| [`da2f2d49`](https://github.com/NixOS/nixpkgs/commit/da2f2d49a6b58e0487bb976b8dd2ac29f27ef2c7) | `fpc: fix build on aarch64`                                                                      |
| [`e8488cd5`](https://github.com/NixOS/nixpkgs/commit/e8488cd500d82332745ca6fa84c63607ef3f94d7) | `python3Packages.pydicom: 2.2.2 -> 2.3.0`                                                        |
| [`4b7172b6`](https://github.com/NixOS/nixpkgs/commit/4b7172b6aa37d3ac95132fdefe53003046085242) | `python3Packages.phonemizer: fix build`                                                          |
| [`dd982701`](https://github.com/NixOS/nixpkgs/commit/dd9827019f3ff0ad2c18ae07a0e987d46a09e8b0) | `python3Packages.dlinfo: init at 1.2.1`                                                          |
| [`163f8185`](https://github.com/NixOS/nixpkgs/commit/163f8185b0ffd1fee2d20c2ec6c2a69d3a2458d8) | `ibus-engines.typing-booster: fix wrapper arguments escaping`                                    |
| [`9c5fb741`](https://github.com/NixOS/nixpkgs/commit/9c5fb7413283254607d4d805b6d486da7b0c4628) | `pufferpanel: fix wrapper arguments escaping`                                                    |
| [`407a02d0`](https://github.com/NixOS/nixpkgs/commit/407a02d056cc3c93dfd3dc0ffec24dd54a8bf5cc) | `navidrome: fix wrapper arguments escaping`                                                      |
| [`ae82656f`](https://github.com/NixOS/nixpkgs/commit/ae82656f09311d34900c6dfe192a050059daf6c4) | `sqitchMysql,sqitchPg: fix wrapper arguments escaping`                                           |
| [`d66c280a`](https://github.com/NixOS/nixpkgs/commit/d66c280a4ad5f11641739116e6a12a75b9251d5f) | `hercules-ci-agent: fix wrapper arguments escaping`                                              |
| [`75c1da2d`](https://github.com/NixOS/nixpkgs/commit/75c1da2d100ecc8f6c6b7b12db19b84e0084e935) | `hci: fix wrapper arguments escaping`                                                            |
| [`2f341cd4`](https://github.com/NixOS/nixpkgs/commit/2f341cd4272266ca21065b789c3d9d416b1ec0ad) | `nuspell: fix wrapper arguments escaping`                                                        |
| [`215fcc72`](https://github.com/NixOS/nixpkgs/commit/215fcc7256e82356be1ba733e6b326a82f7ef055) | `hunspell: fix wrapper arguments escaping`                                                       |
| [`78f3ef31`](https://github.com/NixOS/nixpkgs/commit/78f3ef31e7f2f6a4d5319cbf9f241af82970b26b) | `i3blocks-gaps: fix wrapper arguments escaping`                                                  |
| [`e372ae00`](https://github.com/NixOS/nixpkgs/commit/e372ae003eb9a811b995b9ad329389c3743219cf) | `nextcloud-client: fix stray cacheDir`                                                           |
| [`1f7ac05b`](https://github.com/NixOS/nixpkgs/commit/1f7ac05b45845b3ed6371ed8d74a6661facffefe) | `linux-firmware: fetchgit -> fetchzip`                                                           |
| [`44414b48`](https://github.com/NixOS/nixpkgs/commit/44414b485d7edd6639bf90a9295acc5957a8be30) | `nb: init at 5.7.8 (#110962)`                                                                    |
| [`61731ab0`](https://github.com/NixOS/nixpkgs/commit/61731ab0b190e71b7079e297699906628e1def0f) | `git-machete: 3.9.0 -> 3.9.1`                                                                    |
| [`ff9bda44`](https://github.com/NixOS/nixpkgs/commit/ff9bda440ac81f255e890d25b800c77f7d8dd8a6) | `aravis: 0.6.4 -> 0.8.21, add myself as maintainer`                                              |
| [`80b396fa`](https://github.com/NixOS/nixpkgs/commit/80b396fa2067a94511ffc79a67dfc6ed3eea7867) | `salt: 3004.1 - bugfixes (#172129)`                                                              |
| [`ad6a0e8a`](https://github.com/NixOS/nixpkgs/commit/ad6a0e8a63e1ecc98a9fae5e8e4ba06a3a827ec2) | `lhs2tex: Add to top-level`                                                                      |
| [`aed4c3b8`](https://github.com/NixOS/nixpkgs/commit/aed4c3b84bc11d5d6577dc3f4cb915dc185536e8) | `deno: 1.21.2 -> 1.21.3`                                                                         |
| [`fae6a45e`](https://github.com/NixOS/nixpkgs/commit/fae6a45e9223c789a9ce9f3ac1ceff315523fc50) | `darkstat: Fix build on darwin`                                                                  |
| [`7ab6a92a`](https://github.com/NixOS/nixpkgs/commit/7ab6a92aa8d43d1bb7331906272adf1218270588) | `libtree: 2.0.0 -> 3.1.0`                                                                        |
| [`1ba72de3`](https://github.com/NixOS/nixpkgs/commit/1ba72de384350473dd6dc3d612ef945a2941429d) | `ripser: 1.0.0 -> 1.2.1`                                                                         |
| [`47055aff`](https://github.com/NixOS/nixpkgs/commit/47055affcb95053bb9458d08ec20e694f056cef4) | `python3Packages.ducc0: init at 0.23.0`                                                          |
| [`d75e54f7`](https://github.com/NixOS/nixpkgs/commit/d75e54f70ce2e040c2cd855c0d27af1338c31279) | `libreoffice: fix -qt build`                                                                     |
| [`500b7ae5`](https://github.com/NixOS/nixpkgs/commit/500b7ae53cc9911b6123ecc9a2413623e955a6a3) | `yubihsm-connector: init at 3.0.2 (#169682)`                                                     |
| [`8f9fd7c7`](https://github.com/NixOS/nixpkgs/commit/8f9fd7c7757c7e3d0728f0700b95df41ff050bf9) | `python3Packages.httpie-ntlm: init at 1.0.2`                                                     |
| [`6281fca1`](https://github.com/NixOS/nixpkgs/commit/6281fca1610cf4ecda47ea6c04887989fbde0098) | `httpie: Make available as python library`                                                       |
| [`d56cd1ca`](https://github.com/NixOS/nixpkgs/commit/d56cd1ca2f69638363d81a6146a17dc03c900a7a) | `bat: 0.20.0 -> 0.21.0`                                                                          |
| [`0922bf32`](https://github.com/NixOS/nixpkgs/commit/0922bf32f44e095ae095fe5441727d6b97a5d3e9) | `go_1_18: 1.18.1 -> 1.18.2`                                                                      |
| [`d491e5fd`](https://github.com/NixOS/nixpkgs/commit/d491e5fd3ae91ad79cb16dfc0709546371996bd0) | `vimPlugins.coconut-vim: init at 2017-10-10`                                                     |
| [`820b6810`](https://github.com/NixOS/nixpkgs/commit/820b68102e9412ae0d48e1389a991b242eda0ac0) | `joshuto: fix build for darwin x86_64`                                                           |
| [`06b1d5f9`](https://github.com/NixOS/nixpkgs/commit/06b1d5f96c3b4e2e72088ed983b6230697db8344) | `python3Packages.aioimaplib: disable python 3.10`                                                |
| [`0749a1e7`](https://github.com/NixOS/nixpkgs/commit/0749a1e703dc41ca44c39bc2b7e6640c0a32fe68) | `python310Packages.plugwise: 0.18.1 -> 0.18.2`                                                   |
| [`795b2931`](https://github.com/NixOS/nixpkgs/commit/795b29319cc8e8f1e0dc5ab98f514e7dca14f205) | `python3Packages.shapely: 1.8.1.post1 -> 1.8.2`                                                  |
| [`ef1b558e`](https://github.com/NixOS/nixpkgs/commit/ef1b558e0faeec755da436b0dec4f284b5ca3428) | `python3Packages.pip-tools: fix aarch64-darwin build`                                            |
| [`70030a7f`](https://github.com/NixOS/nixpkgs/commit/70030a7ff3d5f46a57b52ac223f0aea23543072f) | `esptool: 3.3 -> 3.3.1`                                                                          |
| [`07aba57b`](https://github.com/NixOS/nixpkgs/commit/07aba57bca44794f59ec60757c1d74793c6281c6) | `zbackup: Fix build error`                                                                       |
| [`21693b09`](https://github.com/NixOS/nixpkgs/commit/21693b099b844a89a4f5de314aacb5ea147491f2) | `python310Packages.pglast: disable on older Python releases`                                     |
| [`bfeb72c9`](https://github.com/NixOS/nixpkgs/commit/bfeb72c912c86401520bad787b0ff1d329b37642) | `httpie: Remove unused patch`                                                                    |
| [`c004f77a`](https://github.com/NixOS/nixpkgs/commit/c004f77a941fd92f60b130ffba0de7117e6d143c) | `httpie: 3.1.0 -> 3.2.1`                                                                         |
| [`10c13ff5`](https://github.com/NixOS/nixpkgs/commit/10c13ff5d15d0e7b49471166466adfacfc06549a) | `dotter: fix for darwin`                                                                         |
| [`b125089f`](https://github.com/NixOS/nixpkgs/commit/b125089f5a8bd6eb1975236a1c2de77a5005cbc9) | `alan_2: add -fcommon workaround for gcc-10`                                                     |
| [`e686d3e8`](https://github.com/NixOS/nixpkgs/commit/e686d3e812124ca02d393122fec8028b9e3bd2bb) | `_0verkill: add -fcommon workaround for gcc-10`                                                  |
| [`a649cff5`](https://github.com/NixOS/nixpkgs/commit/a649cff5d4a19d3dcd76b5cd19a012033d5b838f) | `aircrack-ng: 1.6 -> 1.7`                                                                        |
| [`01b93635`](https://github.com/NixOS/nixpkgs/commit/01b936359afd6aa63acd2ad7b8b2d080644f0f8b) | `age-plugin-yubikey: 0.2.0 -> 0.3.0`                                                             |
| [`77f93e23`](https://github.com/NixOS/nixpkgs/commit/77f93e23c7e9b472dfc7dbbc1ed3a3bad8e9b2c0) | `twitch-chat-downloader: 3.2.1 -> 3.2.2`                                                         |
| [`f35a9cf9`](https://github.com/NixOS/nixpkgs/commit/f35a9cf9675caf4cb370c67e0ba274075fc51d6a) | `python310Packages.pglast: 3.9 -> 3.10`                                                          |
| [`40733622`](https://github.com/NixOS/nixpkgs/commit/40733622e731d5f15db7d138369b4d7490434042) | `yubihsm-shell: init at 2.3.1`                                                                   |
| [`fd2616c9`](https://github.com/NixOS/nixpkgs/commit/fd2616c92c81ba72ac72e433b2e3a055e324a97d) | `public-inbox: unstable-2022-04-05 -> 1.8.0`                                                     |
| [`c646d375`](https://github.com/NixOS/nixpkgs/commit/c646d375d3a22cad5e1557f852c3bc449e23b4ea) | `nixos/public-inbox: support enabling confinement`                                               |
| [`8b2b5be3`](https://github.com/NixOS/nixpkgs/commit/8b2b5be3b5ff994ea33dce231feacf18960399ad) | `public-inbox: 1.7.0 -> unstable-2022-04-05`                                                     |
| [`6cf2f469`](https://github.com/NixOS/nixpkgs/commit/6cf2f46995425cd1d837dbdd21da6c70a250c1a7) | `public-inbox: 1.6.1 -> 1.7.0`                                                                   |
| [`0e290442`](https://github.com/NixOS/nixpkgs/commit/0e290442bae19e6a31511358e74d754f2b16041e) | `nixos/public-inbox: add tests`                                                                  |
| [`8514800c`](https://github.com/NixOS/nixpkgs/commit/8514800c42a2d292fcc81b6ecc9f0f10eef60868) | `nixos/public-inbox: init`                                                                       |
| [`9b6223d1`](https://github.com/NixOS/nixpkgs/commit/9b6223d1fa2dcb23462a8451d7fafcff8616f16a) | `public-inbox: 1.2.0 -> 1.6.1`                                                                   |
| [`8878fa39`](https://github.com/NixOS/nixpkgs/commit/8878fa39bed66c31eb8bea99659f489147a30659) | `python39Packages.clickgen: 1.1.9 -> 1.2.0, mark as broken on darwin`                            |
| [`ad630d5a`](https://github.com/NixOS/nixpkgs/commit/ad630d5a7f53fca0a762c4af15fcd6fd09c7c6c4) | `python310Packages.datatable: mark broken`                                                       |
| [`4af17099`](https://github.com/NixOS/nixpkgs/commit/4af170995955bcfba8b229dfd5bf227ba85e1635) | `bubblewrap: 0.6.1 -> 0.6.2`                                                                     |
| [`d6d8e9db`](https://github.com/NixOS/nixpkgs/commit/d6d8e9dba72fd7502aa9fb70f7915f0614519f4e) | `python310Packages.chainer: fix tests with new pytest warnings, little cleanup`                  |
| [`b053f97b`](https://github.com/NixOS/nixpkgs/commit/b053f97b3d6284b0a945c09c9e45d1852c01fb85) | `python3Packages.notify-py: fix tests`                                                           |
| [`9bbc9ca7`](https://github.com/NixOS/nixpkgs/commit/9bbc9ca76fb2079a8b9880fbfba191bc40992c4e) | `python3Packages.karton-core: 4.4.0 -> 4.4.1`                                                    |
| [`2fb4326f`](https://github.com/NixOS/nixpkgs/commit/2fb4326ff6276502cc47c320abf475a62245214b) | `python39Packages.clickgen: 1.1.9 -> 1.2.0, mark as broken on darwin`                            |
| [`419f74cb`](https://github.com/NixOS/nixpkgs/commit/419f74cba787dae11895a0885c5a87c64d285760) | `vault-bin: 1.10.2 -> 1.10.3`                                                                    |
| [`a2c44380`](https://github.com/NixOS/nixpkgs/commit/a2c4438067c749c3e1c575c5434378b6f092e6c3) | `vault: 1.10.2 -> 1.10.3`                                                                        |
| [`9cdae4a7`](https://github.com/NixOS/nixpkgs/commit/9cdae4a776ff5f8373a0bbd10e572de49a09680c) | `ombi: 4.10.2 -> 4.16.12`                                                                        |
| [`47ff7333`](https://github.com/NixOS/nixpkgs/commit/47ff7333f493324e8b0e91ac1e15342845ba630f) | `brave: 1.38.111 -> 1.38.115`                                                                    |
| [`a0f35c34`](https://github.com/NixOS/nixpkgs/commit/a0f35c34e186e3c63b5de560135598840358f090) | `ungoogled-chromium: 101.0.4951.54 -> 101.0.4951.64`                                             |
| [`af2bab67`](https://github.com/NixOS/nixpkgs/commit/af2bab671f95a475cdb6f3b785993f5bbb094685) | `nomad_1_2: 1.2.6 -> 1.2.7`                                                                      |
| [`2f48033f`](https://github.com/NixOS/nixpkgs/commit/2f48033f2560e4ff2c8b14227a0c4b4747c0a06f) | `maintainers: add parras`                                                                        |
| [`181a3650`](https://github.com/NixOS/nixpkgs/commit/181a365076a43bb5b350b3666e0977b1e607d64e) | `amberol: 0.6.0 -> 0.6.1`                                                                        |
| [`618b7b73`](https://github.com/NixOS/nixpkgs/commit/618b7b7303f36592aec1f2154e3b03e35604c325) | `python310Packages.emcee: 3.1.1 -> 3.1.2`                                                        |
| [`e6d5a401`](https://github.com/NixOS/nixpkgs/commit/e6d5a401838dab24e90b596507464041bf1fbc47) | `netcoredbg: 1.2.0-825 -> 2.0.0-895`                                                             |
| [`6507555e`](https://github.com/NixOS/nixpkgs/commit/6507555ebf4d8944600c8a92d5df336cecb945b3) | `python310Packages.license-expression: 21.6.14 -> 30.0.0`                                        |
| [`dedc5dd9`](https://github.com/NixOS/nixpkgs/commit/dedc5dd9c7975583fca62df1090f101191f0d155) | `python310Packages.boolean-py: 3.8 -> 4.0`                                                       |
| [`1764a03b`](https://github.com/NixOS/nixpkgs/commit/1764a03b8918b2873835e17b3dea96c7f19db365) | `pantheon.elementary-greeter: 6.0.2 -> 6.1.0`                                                    |
| [`02632f30`](https://github.com/NixOS/nixpkgs/commit/02632f304e102cacdb0f99ad3dd486b5fb9242e7) | `pantheon.elementary-calculator: 1.7.2 -> 2.0.0`                                                 |
| [`ee67a98c`](https://github.com/NixOS/nixpkgs/commit/ee67a98c585011425f7dd3af08714677bb46c916) | `libpulseaudio: make darwin changes conditionally to avoid mass-rebuild`                         |
| [`b0f5004a`](https://github.com/NixOS/nixpkgs/commit/b0f5004a06d1d2e076c571a67a2f35ca28975d4d) | `wrapFirefox: move back into $out`                                                               |
| [`9cf2c679`](https://github.com/NixOS/nixpkgs/commit/9cf2c67910794bf17b28cec21fbb726d9b36fefc) | `libpulseaudio: fix build on x86_64-darwin`                                                      |
| [`d620787d`](https://github.com/NixOS/nixpkgs/commit/d620787dd78e5d3aa612cdb8adbc472dd941a764) | `fltk: support cross-compilation`                                                                |
| [`e3a4076f`](https://github.com/NixOS/nixpkgs/commit/e3a4076faadb2476710f7712e7ad3579f4056441) | `teleport: add rdpclient`                                                                        |
| [`25cf5ebc`](https://github.com/NixOS/nixpkgs/commit/25cf5ebcd09b155219b11fccff44bd34a61dfb77) | `teleport: 8.1.3 -> 9.1.2`                                                                       |
| [`17b7390b`](https://github.com/NixOS/nixpkgs/commit/17b7390be987fe6e234bcb0a1afc64eaa4bafffb) | `konstraint: 0.19.0 -> 0.19.1`                                                                   |
| [`9d976822`](https://github.com/NixOS/nixpkgs/commit/9d976822edfe7935848da53a9d915fac434f1975) | `python310Packages.magic-wormhole: adopt, fix dependencies, run tests with trial`                |
| [`64c7e7e3`](https://github.com/NixOS/nixpkgs/commit/64c7e7e3c59b6ac7e8b26283e9f3e5d9b98b72f1) | `python310Packages.magic-wormhole-transit-relay: adopt, fix dependencies, run tests with trial`  |
| [`281ebacf`](https://github.com/NixOS/nixpkgs/commit/281ebacfa99e4405af050281d67f8e1da5a3dbee) | `python310Packages.magic-wormhole-mailbox-server: adopt, fix requirements, run tests with trial` |
| [`03ebf37b`](https://github.com/NixOS/nixpkgs/commit/03ebf37be754073601817f78993c178275546013) | `python310Packages.autobahn: adopt, populate passthru.extras-require`                            |
| [`293f3d8e`](https://github.com/NixOS/nixpkgs/commit/293f3d8ec5db5ceda882a71a959ec79194e6b588) | `python310Packages.argon2-cffi: normalise pname`                                                 |
| [`ed63368d`](https://github.com/NixOS/nixpkgs/commit/ed63368dfe9db50dc42c6cd5c781aba72d8735ae) | `podman: fix wrapper arguments escaping`                                                         |
| [`0b941452`](https://github.com/NixOS/nixpkgs/commit/0b9414528838e42803d384816aa7913108ee1d13) | `vdr: fix wrapper arguments escaping`                                                            |
| [`76f93323`](https://github.com/NixOS/nixpkgs/commit/76f93323f278fed174ba646018572040ed756110) | `qucs-s: fix wrapper arguments escaping`                                                         |
| [`6d230e4e`](https://github.com/NixOS/nixpkgs/commit/6d230e4e0a09d4ef6954bc56c54a6408de7c0556) | `soapysdr: fix wrapper arguments escaping`                                                       |
| [`5f3016cd`](https://github.com/NixOS/nixpkgs/commit/5f3016cde8820a383c048d616d971dac2442b31c) | `jameica: fix wrapper arguments escaping`                                                        |
| [`48e5fbac`](https://github.com/NixOS/nixpkgs/commit/48e5fbac720e6606a6890841bc2c7b064771370f) | `tremc: fix wrapper arguments escaping`                                                          |
| [`b2a87aef`](https://github.com/NixOS/nixpkgs/commit/b2a87aef369037a69cf95b3c3a11a2047ce32775) | `chatty: fix wrapper arguments escaping`                                                         |
| [`545a1edd`](https://github.com/NixOS/nixpkgs/commit/545a1eddcdd13b10d6cb2cf391e4a4aff8bffc12) | `megapixels: fix wrapper arguments escaping`                                                     |
| [`8fe47199`](https://github.com/NixOS/nixpkgs/commit/8fe47199cca2a83d72eb88101b06b4797bad3347) | `image_optim: fix wrapper arguments escaping`                                                    |
| [`0bc0dc80`](https://github.com/NixOS/nixpkgs/commit/0bc0dc8090e6609838816f43dc7799e32c674434) | `desktop manager script: start properly`                                                         |