### PR TITLE
chore(flake/nixpkgs): `1d7db1b9` -> `29bccd95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652659998,
-        "narHash": "sha256-FqNrXC1EE6U2RACwXBlsAvg1lqQGLYpuYb6+W3DL9vA=",
+        "lastModified": 1652705607,
+        "narHash": "sha256-KV7Sy2r9eSWoRgOQXnZR0KW5g6PlcMF+ovzLjNW1064=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1d7db1b9e4cf1ee075a9f52e5c36f7b9f4207502",
+        "rev": "29bccd95f778fae365a6af72c326187f0a79e6f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`29bccd95`](https://github.com/NixOS/nixpkgs/commit/29bccd95f778fae365a6af72c326187f0a79e6f8) | `tilt: 0.26.3 -> 0.30.0 (#173252)`                            |
| [`85558fff`](https://github.com/NixOS/nixpkgs/commit/85558fff8bcf2811f838c141be5d5ff0e75abb96) | `clightning: 0.11.0.1 -> 0.11.1`                              |
| [`6423fced`](https://github.com/NixOS/nixpkgs/commit/6423fcedb301ebdf02d9e8a8dd2af3dfdcc1455f) | `nixosTests.keepassxc: Simplify OCR test`                     |
| [`16fc84cd`](https://github.com/NixOS/nixpkgs/commit/16fc84cd4be51376b7517f48d37811eb6ec27471) | `clamav: 0.103.6 -> 0.105.0`                                  |
| [`57affb10`](https://github.com/NixOS/nixpkgs/commit/57affb106a7fb2c23898e5f418d34eb82275c3c5) | `libreddit: 0.22.6 -> 0.22.7`                                 |
| [`be73a962`](https://github.com/NixOS/nixpkgs/commit/be73a96276f9a1cd1f2dfefdb3bc64dff932f434) | `terraform-providers: update 2022-05-16`                      |
| [`aee07772`](https://github.com/NixOS/nixpkgs/commit/aee07772236445705fde307ba9cfadd419d1c41c) | `python310Packages.pex: 2.1.87 -> 2.1.88`                     |
| [`ff29d2ca`](https://github.com/NixOS/nixpkgs/commit/ff29d2caa935a8e6216380dfcd7ee714fd8bd5bf) | `gtk4: 4.6.3 → 4.6.4`                                         |
| [`2ed533a8`](https://github.com/NixOS/nixpkgs/commit/2ed533a838c77c7b60ecec25aff3b7088e6521fc) | `gtk4: patch fixing g-c-c crashes`                            |
| [`bf8d9545`](https://github.com/NixOS/nixpkgs/commit/bf8d954594690e9dd92df738813ad36f072777a1) | `kube-router: 1.2.2 -> 1.4.0`                                 |
| [`6c0dc6d6`](https://github.com/NixOS/nixpkgs/commit/6c0dc6d621280a2a50ac3544e6f71102f0065ae0) | `nixos/ddclient: turn verbose off by default`                 |
| [`27123795`](https://github.com/NixOS/nixpkgs/commit/27123795ad29ab118455069a0af142668025b247) | `writeCBin: fix formatting`                                   |
| [`26a87ada`](https://github.com/NixOS/nixpkgs/commit/26a87ada65c74ecab36789aaf5915f55148e1100) | `sage: 9.5 -> 9.6`                                            |
| [`399a676a`](https://github.com/NixOS/nixpkgs/commit/399a676ada6f42e1623eb038cdebb090b2c12345) | `gnomeExtensions.vitals: remove workaround`                   |
| [`c952517f`](https://github.com/NixOS/nixpkgs/commit/c952517f974254cd9bcd9367e8337fd861747ef8) | `python310Packages.pynx584: 0.6 -> 0.7`                       |
| [`81cac41c`](https://github.com/NixOS/nixpkgs/commit/81cac41c65083b57013699752aaec74854366acd) | `python310Packages.geocachingapi: 0.2.1 -> 0.2.2`             |
| [`c750f146`](https://github.com/NixOS/nixpkgs/commit/c750f1466d4ca483f53e2ee00d255a80c25d9abc) | `python3Packages.embrace: disable check phase on Darwin`      |
| [`1ed0bc2b`](https://github.com/NixOS/nixpkgs/commit/1ed0bc2be357a50500ef86f5adf32134f8073a2b) | `makemkv: install mmccextr`                                   |
| [`10b16ea5`](https://github.com/NixOS/nixpkgs/commit/10b16ea5e7e58c93781dc8f7f78e2f8621498da1) | `sageWithDoc: make jupyter-sphinx available for docbuild`     |
| [`e531fc20`](https://github.com/NixOS/nixpkgs/commit/e531fc20cdbd15dfff7169bfa9392a53b0a8e385) | `python3Packages.lrcalc-python: init at 2.1`                  |
| [`09ab2aba`](https://github.com/NixOS/nixpkgs/commit/09ab2aba13e275eefb4cbb237c54847070006297) | `lrcalc: 1.2 -> 2.1`                                          |
| [`bd253b46`](https://github.com/NixOS/nixpkgs/commit/bd253b46fa7db40f1b858332e3c5d2ffd00ec83b) | `frr: 8.1 -> 8.2.2`                                           |
| [`2a78dc8e`](https://github.com/NixOS/nixpkgs/commit/2a78dc8e4b47c9ea2de8270e046eec800b13f1cf) | `wishlist: 0.4.0 -> 0.5.0`                                    |
| [`b431e456`](https://github.com/NixOS/nixpkgs/commit/b431e456607e79f18fea835f2c0850d0aeb937f5) | `system76-keyboard-configurator: init at 1.0.0`               |
| [`1f15388a`](https://github.com/NixOS/nixpkgs/commit/1f15388af162cfabf5f5fb7f4bc2099715ca428b) | `gnupg1orig: add -fcommon workaround`                         |
| [`cb4dd421`](https://github.com/NixOS/nixpkgs/commit/cb4dd421de39233037b728a85b516ded46ef8f72) | `devspace: 5.18.4 -> 5.18.5`                                  |
| [`bba2c44b`](https://github.com/NixOS/nixpkgs/commit/bba2c44b0eca4b4d9dde53481002b012aceb9bc0) | `oci-image-tool: remove`                                      |
| [`482aaa50`](https://github.com/NixOS/nixpkgs/commit/482aaa5029c23c94281cd82c047ddc61b2aeadf9) | `fx: 22.0.10 → 24.0.0`                                        |
| [`4db7ee21`](https://github.com/NixOS/nixpkgs/commit/4db7ee21d700814e7fd91b0906df84ee8f02a1e4) | `keepassxc: 2.6.6 -> 2.7.1`                                   |
| [`833884de`](https://github.com/NixOS/nixpkgs/commit/833884de60dc28084a3fc7177a4152094f06412a) | `clamav: 0.103.5 -> 0.103.6`                                  |
| [`20a44234`](https://github.com/NixOS/nixpkgs/commit/20a44234da1778d561d20ae6a40a43d09151c386) | `cdpr: pull patch pending upstream inclusion for -fno-common` |
| [`72429cd8`](https://github.com/NixOS/nixpkgs/commit/72429cd8ea51ffac7272bb144b36939d4268ac07) | `microcodeIntel: 20220419 -> 20220510`                        |
| [`32bed4c4`](https://github.com/NixOS/nixpkgs/commit/32bed4c4554220f0ece456d4f3662fc81fafd14b) | `afpfs-ng: add -fcommon workaround`                           |
| [`a60c1dbb`](https://github.com/NixOS/nixpkgs/commit/a60c1dbb51350c3a7c7ec766c130014d46cdf1eb) | `bats: move installCheck into passthru.tests`                 |
| [`749b97bb`](https://github.com/NixOS/nixpkgs/commit/749b97bb2345395e4f7d947c71ac603dbce01d72) | `bats: improve package w/ new resholve features`              |
| [`573f33f6`](https://github.com/NixOS/nixpkgs/commit/573f33f6853c4026db51f671fc9678023bc89969) | `yubioath-desktop: 5.0.5 -> 5.1.0`                            |
| [`7b3ac385`](https://github.com/NixOS/nixpkgs/commit/7b3ac385e53101e229122d687fd0021a637407aa) | `k0sctl: 0.11.4 -> 0.12.6`                                    |