### PR TITLE
chore(flake/nixpkgs): `29bccd95` -> `ff691ed9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652705607,
-        "narHash": "sha256-KV7Sy2r9eSWoRgOQXnZR0KW5g6PlcMF+ovzLjNW1064=",
+        "lastModified": 1652739558,
+        "narHash": "sha256-znGkjGugajqF/sFS+H4+ENmGTaVPFE0uu1JjQZJLEaQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "29bccd95f778fae365a6af72c326187f0a79e6f8",
+        "rev": "ff691ed9ba21528c1b4e034f36a04027e4522c58",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                      |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`ff691ed9`](https://github.com/NixOS/nixpkgs/commit/ff691ed9ba21528c1b4e034f36a04027e4522c58) | `nixos/gdm: Fix missing icons`                                      |
| [`4a1f7f84`](https://github.com/NixOS/nixpkgs/commit/4a1f7f84724ef242d5ec9faa25081d558c79be08) | `buildMozillaMach: fix builds with crash reporting disabled`        |
| [`f150888d`](https://github.com/NixOS/nixpkgs/commit/f150888da6699b4f6215e9bd25d1074c4e756508) | `coqPackages.interval: 4.4.0 -> 4.5.1`                              |
| [`72cb3780`](https://github.com/NixOS/nixpkgs/commit/72cb3780a57881aa2fc5e2268380d85de7ea2b4c) | `python310Packages.dulwich: 0.20.35 -> 0.20.36`                     |
| [`dfc19305`](https://github.com/NixOS/nixpkgs/commit/dfc193057c3e7b414b21c43f860efe8e93228969) | `python3Packages.ocrmypdf: 13.4.3 -> 13.4.4`                        |
| [`4783e24e`](https://github.com/NixOS/nixpkgs/commit/4783e24e0cffb6dd124f01c85b95be1d703c556e) | `python310Packages.torchmetrics: 0.8.1 -> 0.8.2`                    |
| [`19c5dc94`](https://github.com/NixOS/nixpkgs/commit/19c5dc94fa86077771111e30c1e2fbce60fdcb9c) | `python3Packages.pikepdf: 5.1.2 -> 5.1.3`                           |
| [`93b45825`](https://github.com/NixOS/nixpkgs/commit/93b45825ddaff290ab9c885c6d2393725a91fbe7) | `python3.pkgs.ijson: enable yail backend`                           |
| [`df9525d8`](https://github.com/NixOS/nixpkgs/commit/df9525d89ab5a9455ad79a94478c22ed57e55f4d) | `python3Packages.gcal-sync: 0.7.1 -> 0.8.0`                         |
| [`2d1048a3`](https://github.com/NixOS/nixpkgs/commit/2d1048a3d1ddbfb1681359ea874438b038acc439) | `python310Packages.manuel: 1.10.1 -> 1.11.2`                        |
| [`9430c997`](https://github.com/NixOS/nixpkgs/commit/9430c997887c4d5da77ce8fc426ba7d40e1b23ef) | `python3Packages.pywlroots: 0.15.13 -> 0.15.14`                     |
| [`c0d95d28`](https://github.com/NixOS/nixpkgs/commit/c0d95d280928e3536321ea4abdc89eff2b7e38bb) | `python3Packages.cheroot: disable failing test on Darwin`           |
| [`6ecb4d7c`](https://github.com/NixOS/nixpkgs/commit/6ecb4d7c4310a223fdfcd2ac7d92d4b72f2a001a) | `python310Packages.pylsp-mypy: 0.5.7 -> 0.5.8`                      |
| [`d06d9330`](https://github.com/NixOS/nixpkgs/commit/d06d9330c4a68915705a9dd898e12f664b05019c) | `python310Packages.django-anymail: 8.5 -> 8.6`                      |
| [`cbf36994`](https://github.com/NixOS/nixpkgs/commit/cbf3699448d0c65b7f364fa0396b6b7a8ab04e5c) | `python310Packages.twentemilieu: 0.6.0 -> 0.6.1`                    |
| [`0659e76d`](https://github.com/NixOS/nixpkgs/commit/0659e76d17ec294b07bd78e6f071ef360b89b73d) | `ocamlPackages.merlin: 4.4 → 4.5`                                   |
| [`fdf08063`](https://github.com/NixOS/nixpkgs/commit/fdf08063866138def7a5f6615cb71bb505b31ffc) | `root5: fix build with recent gcc`                                  |
| [`560ca022`](https://github.com/NixOS/nixpkgs/commit/560ca02280cea47c8ad70dd0aeadd667bc55a5c2) | `nixos/nitter: update example configuration file URL`               |
| [`8ef6c2bb`](https://github.com/NixOS/nixpkgs/commit/8ef6c2bbf8e22216610cd6e935f424ccea759db4) | `nitter: unstable-2022-03-21 -> unstable-2022-05-13`                |
| [`0f42a04e`](https://github.com/NixOS/nixpkgs/commit/0f42a04eb04fbcfd6df50930a739bb1e67effd2a) | `nitter: compile markdown`                                          |
| [`d1e5ca20`](https://github.com/NixOS/nixpkgs/commit/d1e5ca2014084a50807ccc1003711b6be0fb5928) | `mpc-qt: 2019-06-09 -> 22.02`                                       |
| [`3e789af2`](https://github.com/NixOS/nixpkgs/commit/3e789af26cb39c8e25678616c184579532562058) | `bullet: 3.22b -> 3.23`                                             |
| [`30f0af5f`](https://github.com/NixOS/nixpkgs/commit/30f0af5f6abb06174325151e9ede005b0305ae87) | `systemfd: 0.3.0 -> 0.4.0`                                          |
| [`f6cede3f`](https://github.com/NixOS/nixpkgs/commit/f6cede3f93211d64e63848ca06d805006d86da6a) | `python310Packages.pycep-parser: 0.3.4 -> 0.3.5`                    |
| [`0c6396c7`](https://github.com/NixOS/nixpkgs/commit/0c6396c7041e27a47469008965347011b0c88914) | `python310Packages.pyskyqhub: 0.1.8 -> 0.1.9`                       |
| [`b2b2282f`](https://github.com/NixOS/nixpkgs/commit/b2b2282f5d41da0db87d5bcf87aa95b9727260e9) | `python39Packages.sanic: fix build on darwin`                       |
| [`6088824e`](https://github.com/NixOS/nixpkgs/commit/6088824eee448ea6dfda4084bd66c1326f3d2760) | `folly: fix build`                                                  |
| [`9252a7da`](https://github.com/NixOS/nixpkgs/commit/9252a7daa80bf81e76bf826caef8cb6dd08b1325) | `lib/tests/modules.sh: Fix for singular type descriptions`          |
| [`7bec3e60`](https://github.com/NixOS/nixpkgs/commit/7bec3e60efb9203c444bfaf8f35cfb1252ece170) | ` lib/types: Drop misleading plural from type descriptions #170561` |
| [`368e6d00`](https://github.com/NixOS/nixpkgs/commit/368e6d00f8fa611682acae6c17ec2268d9239795) | `libdigidocpp: 3.14.7 -> 3.14.8`                                    |
| [`2a6a3d2c`](https://github.com/NixOS/nixpkgs/commit/2a6a3d2c47626782f604a1fb4ec506c834efb47a) | `nixos/wrappers: require argc to be at least one`                   |
| [`1009d6e7`](https://github.com/NixOS/nixpkgs/commit/1009d6e79e7f4ef92d7db27214c55a36f5e22c6f) | `nixos/wrappers: create a new assert macro that always asserts`     |