### PR TITLE
chore(flake/utils): `a97445c4` -> `04c1b180`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -254,11 +254,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1652774318,
-        "narHash": "sha256-a2GM7Gk2exiVLn/AiVhy6oHJcifU/gDNHk2aKSYp/ok=",
+        "lastModified": 1652776076,
+        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a97445c4fcd22ca0d1d5a969972eb24bc819ff3a",
+        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                     |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`04c1b180`](https://github.com/numtide/flake-utils/commit/04c1b180862888302ddfb2e3ad9eaa63afc60cf8) | `feat: add convenience eachDefaultSystemMap (#60)` |