### PR TITLE
chore(flake/nixpkgs): `ff691ed9` -> `0623ef84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652739558,
-        "narHash": "sha256-znGkjGugajqF/sFS+H4+ENmGTaVPFE0uu1JjQZJLEaQ=",
+        "lastModified": 1652785304,
+        "narHash": "sha256-C6EZVwHJagiHPNjP5uWPz6xT0xzQyghrsVLnKOmGaHQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ff691ed9ba21528c1b4e034f36a04027e4522c58",
+        "rev": "0623ef8417a209e4ff29fe75bc28db93a4270bfa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`e11568dd`](https://github.com/NixOS/nixpkgs/commit/e11568dd9cfccfeb1267199feafea247f444848e) | ``Revert "Merge #171177: go-modules/packages: Improve `checkFlags` handling"`` |
| [`cc60c249`](https://github.com/NixOS/nixpkgs/commit/cc60c24909a8b207a0a2dfc18082453ab85c46af) | `openssl: disable ct feature in static mode (#173288)`                         |
| [`d9d59c3e`](https://github.com/NixOS/nixpkgs/commit/d9d59c3ec60f0d834be0aa5fa9910fa6ec9831af) | `python310Packages.azure-mgmt-recoveryservicesbackup: 4.2.0 -> 5.0.0`          |
| [`5d483e4d`](https://github.com/NixOS/nixpkgs/commit/5d483e4d3b9b3fdf6c66273f0405a8af3c13cd66) | `python310Packages.azure-multiapi-storage: 0.8.0 -> 0.9.0`                     |
| [`4b0da188`](https://github.com/NixOS/nixpkgs/commit/4b0da1885ff972d4680ae192fcaec333fdfb862f) | `ocamlPackages.easy-format: 1.3.2 → 1.3.3`                                     |
| [`c4d5cc1e`](https://github.com/NixOS/nixpkgs/commit/c4d5cc1e73c838fbf5734d78f1b55141667b2710) | `python310Packages.bugsnag: 4.2.0 -> 4.2.1`                                    |
| [`9cdd4e03`](https://github.com/NixOS/nixpkgs/commit/9cdd4e03aecc332128f61bdb26364cebc0be0e7c) | `python310Packages.pg8000: 1.26.1 -> 1.27.1`                                   |
| [`365be2ab`](https://github.com/NixOS/nixpkgs/commit/365be2abe0dcecf064a40745c688a11939118b5d) | `pulseeffects-legacy: drop myself from maintainers`                            |
| [`7d85b91e`](https://github.com/NixOS/nixpkgs/commit/7d85b91eba6bafd180965ef94d221474ce41dead) | `discount: 2.2.7 -> 2.2.7b`                                                    |
| [`434f417e`](https://github.com/NixOS/nixpkgs/commit/434f417e2c9a939b22409788f6d8b172d31d10ce) | `xdg-dbus-proxy: 0.1.3 → 0.1.4`                                                |
| [`7bd68b1d`](https://github.com/NixOS/nixpkgs/commit/7bd68b1df6456c11973ff3ec736e9c70721c5603) | `link-grammar: 5.10.2 → 5.10.4`                                                |
| [`277f39af`](https://github.com/NixOS/nixpkgs/commit/277f39afc9ced4db8120d236017c2f2659e4a35d) | `gnomeExtensions.dash-to-dock: 71+date=2022-02-23 → 72`                        |
| [`9a312725`](https://github.com/NixOS/nixpkgs/commit/9a312725c171304a4692ce73986e7a66cb064ddd) | `protoc-gen-go-vtproto: 0.2.0 -> 0.3.0`                                        |
| [`55f38ee6`](https://github.com/NixOS/nixpkgs/commit/55f38ee6ab5cd7871a76af156d3874d39b8d2486) | `python310Packages.hatchling: 0.24.0 -> 0.25.0`                                |
| [`4571db9a`](https://github.com/NixOS/nixpkgs/commit/4571db9a8845176195b00df3028d6b02adde7325) | `sumneko-lua-language-server: disable cwd support only on x86-darwin`          |
| [`8cd45ee3`](https://github.com/NixOS/nixpkgs/commit/8cd45ee35f1772860dd8e82d9b09e5d96276e82b) | `sumneko-lua-language-server: 3.2.1 -> 3.2.3`                                  |
| [`8e4f7c9d`](https://github.com/NixOS/nixpkgs/commit/8e4f7c9d5168449ef5925f68a25d740de67e121b) | `python310Packages.fastcore: 1.4.2 -> 1.4.3`                                   |
| [`8eb3f281`](https://github.com/NixOS/nixpkgs/commit/8eb3f281dc1bd1a0599d29eca38e9bd9cfae3590) | `python310Packages.poetry-dynamic-versioning: 0.16.0 -> 0.17.0`                |
| [`3c2e95f4`](https://github.com/NixOS/nixpkgs/commit/3c2e95f4f02f492d93067e21a619e8e3ee2a0dfe) | `python3Packages.pyrfxtrx: 0.28.0 -> 0.29.0`                                   |
| [`5da9a690`](https://github.com/NixOS/nixpkgs/commit/5da9a6908336b383b84df9adbe94801ab76ec370) | `python310Packages.numpy-stl: 2.16.3 -> 2.17.0`                                |
| [`5b7e1045`](https://github.com/NixOS/nixpkgs/commit/5b7e1045c653867d542203099f6ce14ecc9aae06) | `python310Packages.mt-940: 4.23.0 -> 4.26.0`                                   |
| [`ea940467`](https://github.com/NixOS/nixpkgs/commit/ea940467508243aee5b0efd83ecd33abe5372d70) | `addic7ed-cli: move to top-level`                                              |
| [`403d5ae1`](https://github.com/NixOS/nixpkgs/commit/403d5ae1a6be960874183c5c824dce5fc7b60e18) | `j: 902-release-b -> 904-beta-c`                                               |
| [`1c802f3b`](https://github.com/NixOS/nixpkgs/commit/1c802f3bfa5324d7915dad3dc2e41234526a2f78) | `python310Packages.cachelib: 0.6.0 -> 0.7.0`                                   |
| [`889bb1a1`](https://github.com/NixOS/nixpkgs/commit/889bb1a1aa82d7ec5ddaa0164c3add8be6a9bb10) | `python3Packages.pandas: remove unused commands`                               |
| [`1a174767`](https://github.com/NixOS/nixpkgs/commit/1a1747677efe715c2143d3f0e82a79a91c144b85) | `python310Packages.graphtage: 0.2.5 -> 0.2.6`                                  |
| [`cdbb3a70`](https://github.com/NixOS/nixpkgs/commit/cdbb3a70bb4502d36a21039e149e3421212fcec3) | `python310Packages.herepy: 3.5.7 -> 3.5.8`                                     |
| [`aaa12217`](https://github.com/NixOS/nixpkgs/commit/aaa1221775b090c09f49b985380474f427836a64) | `python310Packages.types-requests: 2.27.25 -> 2.27.26`                         |
| [`dd96e9f5`](https://github.com/NixOS/nixpkgs/commit/dd96e9f5676382ba412d371d03067b300d2b3d54) | `git-sync: unstable-2021-07-14 -> unstable-2022-03-20`                         |
| [`89c3a254`](https://github.com/NixOS/nixpkgs/commit/89c3a254458324999c77eb619ba6ea165bc4f468) | `gnome3.adwaita-icon-theme: reduce build parallelism`                          |
| [`d9c2f003`](https://github.com/NixOS/nixpkgs/commit/d9c2f0036d866dd0cdebd2296a9e06c78aeefaed) | `jameica 2.10.1 -> 2.10.2`                                                     |
| [`a30a3442`](https://github.com/NixOS/nixpkgs/commit/a30a34427c7235706164054394b3a5a628952a96) | `Revert "libpcap: move dev things to extra output"`                            |
| [`49f02552`](https://github.com/NixOS/nixpkgs/commit/49f025520c03a77b318c9a5338ec9fdecc69da4c) | `python310Packages.azure-core: update disabled`                                |
| [`4c0c8ac7`](https://github.com/NixOS/nixpkgs/commit/4c0c8ac7fe0caca8655e2e75807bac1a4cf0fbe6) | `rc: fixup build`                                                              |
| [`c4fe785a`](https://github.com/NixOS/nixpkgs/commit/c4fe785aa5a6352445eddab15764c59c56897fbc) | `logseq: 0.6.8 -> 0.6.9`                                                       |
| [`016facb8`](https://github.com/NixOS/nixpkgs/commit/016facb869ed894692bee9963d580d77b45d146b) | `hyperkitty: backport patch fixing Python 3.10 support`                        |
| [`a4c0d2b3`](https://github.com/NixOS/nixpkgs/commit/a4c0d2b344721ad37667776ba5388271ca756e01) | `netbox: fix build, drop overrides, update Django`                             |
| [`b50d94a3`](https://github.com/NixOS/nixpkgs/commit/b50d94a3f27ce81ba39068c2450084460c627886) | `python*Packages.djangorestframework: add missing dependency`                  |
| [`681f4c49`](https://github.com/NixOS/nixpkgs/commit/681f4c49e9ca1b71e3580db619c891c07973fcaa) | `apache-airflow: mark broken`                                                  |
| [`36c7b97e`](https://github.com/NixOS/nixpkgs/commit/36c7b97ebf49d371f87851cff81a960e40df3373) | `python*Packages.mkdocs-material: 8.2.11 -> 8.2.15`                            |
| [`20581e0c`](https://github.com/NixOS/nixpkgs/commit/20581e0cc9350b2bddb2b99543094372f9079ddf) | `python*Packages.pymdown-extensions: 9.1 -> 9.4`                               |
| [`83ac14f8`](https://github.com/NixOS/nixpkgs/commit/83ac14f820ef075bb1231ee3ec9db4b01505cd10) | `cinny: 2.0.2 -> 2.0.3`                                                        |
| [`c1809efb`](https://github.com/NixOS/nixpkgs/commit/c1809efb1d6fbcefba0a020b3f05091a64453b24) | `python*Packages.azure-core: 1.23.1 -> 1.24.0, fix tests`                      |
| [`9eb26885`](https://github.com/NixOS/nixpkgs/commit/9eb2688533e2eda865ab9545bf0527186f5ec27a) | `icu: Remove icu59 and icu65`                                                  |
| [`dee976c3`](https://github.com/NixOS/nixpkgs/commit/dee976c3d5309f0632534b10e8562c9be6328f79) | `icu: Remove redundant compiler overrides`                                     |
| [`6eb4f210`](https://github.com/NixOS/nixpkgs/commit/6eb4f210a5b7871329f4dda239110fb840fbb1d6) | `http-parser: fix i686 build`                                                  |
| [`954efdff`](https://github.com/NixOS/nixpkgs/commit/954efdfff3a45afd0aa74b3244a98d73a9162803) | `curl: disable test 1086 on darwin`                                            |
| [`40840d78`](https://github.com/NixOS/nixpkgs/commit/40840d782048b2769885044afb0d44f4b3bdcb6d) | `cgminer: add -fcommon workaround`                                             |
| [`bee3e742`](https://github.com/NixOS/nixpkgs/commit/bee3e742effa0932bda95f2134c8846687318a3b) | `go_1_17: 1.17.9 -> 1.17.10`                                                   |
| [`d82c0a58`](https://github.com/NixOS/nixpkgs/commit/d82c0a58790d932e99ae625b316a07dfdda4aa93) | `python310Packages.jsonschema: 4.4.0 -> 4.5.1`                                 |
| [`ade93faa`](https://github.com/NixOS/nixpkgs/commit/ade93faa94dd7bcb43b7555d92d6d19ab1dc97a5) | `python39Packages.sphinx: fix reproducibility (#172642)`                       |
| [`eeff6c49`](https://github.com/NixOS/nixpkgs/commit/eeff6c493373d3fff11421b55309fab6a1d4ec7d) | `systemd: fix reproducibility of dbus interface xml`                           |
| [`e3ec2287`](https://github.com/NixOS/nixpkgs/commit/e3ec22876e3b3e58fed5eb9f7dae6a132dd78680) | `python310Packages.fsspec: 2022.01.0 -> 2022.3.0`                              |
| [`c5edd992`](https://github.com/NixOS/nixpkgs/commit/c5edd9926d07a1de54d743dbce645778dead7b13) | `curl: 7.83.0 -> 7.83.1`                                                       |
| [`d538cef5`](https://github.com/NixOS/nixpkgs/commit/d538cef5a8d306384af7ed12ad6f55f054a31f50) | `dbus: enable strictDeps`                                                      |
| [`fa93551f`](https://github.com/NixOS/nixpkgs/commit/fa93551f03f731e7fbad90edd1f22ce6c0935a74) | `python310Packages.pyparsing: 3.0.7 -> 3.0.9`                                  |
| [`d71354cc`](https://github.com/NixOS/nixpkgs/commit/d71354cca676158526ca07189e7eb98f164cdbff) | `python310Packages.jinja2: 3.1.1 -> 3.1.2`                                     |
| [`161b0839`](https://github.com/NixOS/nixpkgs/commit/161b08390f29100f7b5b29e451ce0c195e92a242) | `python310Packages.werkzeug: add SuperSandro2000 as maintainer`                |
| [`e960e5c6`](https://github.com/NixOS/nixpkgs/commit/e960e5c643aad0aa94c107ac682733e16d466af1) | `python310Packages.click: 8.1.2 -> 8.1.3`                                      |
| [`45f50eb9`](https://github.com/NixOS/nixpkgs/commit/45f50eb9ac5cd038c9fc13a4519bd55f20bac2b9) | `python310Packages.flask: 2.1.1 -> 2.1.2`                                      |
| [`f0e058f1`](https://github.com/NixOS/nixpkgs/commit/f0e058f1e3b74827cb3727f3d44a05709a3d593e) | `python310Packages.stack-data: disable failing tests`                          |
| [`c2b2a9ce`](https://github.com/NixOS/nixpkgs/commit/c2b2a9ce788f7760bd3148ba9b5c14267f9916e6) | `python310Packages.werkzeug: 2.1.0 -> 2.1.2`                                   |
| [`be4c9c60`](https://github.com/NixOS/nixpkgs/commit/be4c9c60c2e9cd447805b1cd8d0f2493d2e6f323) | `dbus: 1.12.20 -> 1.14.0`                                                      |
| [`757ee2ed`](https://github.com/NixOS/nixpkgs/commit/757ee2ed93ad2aea8af83240af184c1a28ad0443) | `dbus: remove useless nulls`                                                   |
| [`f779fff0`](https://github.com/NixOS/nixpkgs/commit/f779fff0bb634fc3893712bf11380444bbf0e7e7) | `libnotify: 0.7.11 -> 0.7.12`                                                  |
| [`7ac2961e`](https://github.com/NixOS/nixpkgs/commit/7ac2961ee3e212ee69ea5176fcc28f17ba354072) | `terraform-inventory: 0.7-pre -> 0.10`                                         |
| [`87ac2775`](https://github.com/NixOS/nixpkgs/commit/87ac2775d8723cdd636d5637502730873da1a7fc) | `curl: enable tests`                                                           |
| [`ca55f66c`](https://github.com/NixOS/nixpkgs/commit/ca55f66c6d06e3d6d091b60a8e1fad828e710a4d) | `sqlite: 3.38.4 -> 3.38.5`                                                     |
| [`4fae05e8`](https://github.com/NixOS/nixpkgs/commit/4fae05e8d646e8b21c02c9642dce7a028c3b1279) | `sqlite: 3.38.3 -> 3.38.4`                                                     |
| [`bb438b6f`](https://github.com/NixOS/nixpkgs/commit/bb438b6f2ca4f1c5d62f4de1bf7e41c87f77dde8) | `krb5: 1.19.2 -> 1.19.3`                                                       |
| [`7d5b75b1`](https://github.com/NixOS/nixpkgs/commit/7d5b75b12ab622480ce32ae2e0801edcf23a66d3) | `SDL2: use wayland-scanner from PATH`                                          |
| [`4729cb69`](https://github.com/NixOS/nixpkgs/commit/4729cb69e35e67bcc0221da00953524d62402a89) | `SDL2: fix cross-compilation`                                                  |
| [`d954878d`](https://github.com/NixOS/nixpkgs/commit/d954878d809103dce1deef350ea476c5175af16d) | `autoconf: build offline html documentation (#172103)`                         |
| [`4317c931`](https://github.com/NixOS/nixpkgs/commit/4317c93104b4473d2482766fe867f646752dd499) | `rhash: Correctly set target platform when configuring`                        |
| [`7169abf5`](https://github.com/NixOS/nixpkgs/commit/7169abf52fedeefe18ff2517a5b6ef7bac93ad15) | ` python310Packages.babel: 2.9.1 -> 2.10.1  (#171867)`                         |
| [`cb8f9183`](https://github.com/NixOS/nixpkgs/commit/cb8f9183299e3c0a2aad2fa4260707dadb61a631) | `python310Packages.rich: 12.4.0 -> 12.4.1`                                     |
| [`194f81ef`](https://github.com/NixOS/nixpkgs/commit/194f81efa1aeac917ca27a1d09d9065d66ad8317) | `rich-cli: 1.7.0 -> 1.8.0`                                                     |
| [`6fa9cc41`](https://github.com/NixOS/nixpkgs/commit/6fa9cc41ef209ac6aa3fe6b7e6b302bc2df33349) | `python3Packages.rich: 12.3.0 -> 12.4.0`                                       |
| [`7d039927`](https://github.com/NixOS/nixpkgs/commit/7d0399279a6949ad4bddd95a4023ab02dc2286be) | `gettext: enable strictDeps`                                                   |
| [`e63edadf`](https://github.com/NixOS/nixpkgs/commit/e63edadf368acabccabb6377b4bc2b0eab0eda6c) | `python3Packages.platformdirs: 2.5.1 -> 2.5.2`                                 |
| [`42091a7b`](https://github.com/NixOS/nixpkgs/commit/42091a7b8b21f591bf7af5760b55b108348d3712) | `autoconf213: move 'm4' and 'perl' to nativeBuildInputs (strictDeps = true)`   |
| [`34a388a7`](https://github.com/NixOS/nixpkgs/commit/34a388a7ddf77579a6030c679a8b6cff8549e48c) | `python310Packages.zipp: adopt, execute tests`                                 |
| [`283500ed`](https://github.com/NixOS/nixpkgs/commit/283500ede38216fd0ec331d552ab7bf2198252be) | `python310Packages.func-timeout: init at 4.3.5`                                |
| [`4f180210`](https://github.com/NixOS/nixpkgs/commit/4f180210a094506ea9fa8f700012b993a7aed334) | `bash: enable strictDeps`                                                      |
| [`ea79263e`](https://github.com/NixOS/nixpkgs/commit/ea79263e608224491030a0cdf27b9f11ecff2928) | `pkgs/shells: enable strictDeps`                                               |
| [`0bf838dc`](https://github.com/NixOS/nixpkgs/commit/0bf838dc6eab2a9e3d21d1a7fa758467874005bb) | `dgsh: mark broken`                                                            |
| [`92f4d121`](https://github.com/NixOS/nixpkgs/commit/92f4d121a64db24022738fa1812fb7a1b1b1a742) | `python3.pkgs.pygobject3: 3.42.0 → 3.42.1`                                     |
| [`64853939`](https://github.com/NixOS/nixpkgs/commit/648539391106a7a48abd1d3be45bb0930747984d) | `pango: 1.50.6 → 1.50.7`                                                       |
| [`f9eaa902`](https://github.com/NixOS/nixpkgs/commit/f9eaa902c0aedf01d476aa7eb2c040c9f9b99387) | `atk: 2.36.0 → 2.38.0`                                                         |
| [`9d8bbb54`](https://github.com/NixOS/nixpkgs/commit/9d8bbb544b43a1ba9eac7deab92195a297a17d4d) | `spirv-llvm-translator: fix duplicate makeFlags merge`                         |
| [`5a3e803b`](https://github.com/NixOS/nixpkgs/commit/5a3e803bf3de0e2132e450db86c3197ccc0f02ad) | `glibc: 2.34-115 -> 2.34-210`                                                  |
| [`d5beaa1a`](https://github.com/NixOS/nixpkgs/commit/d5beaa1a93ea679bc855ac89197d8cbacb60438d) | `python310Packages.pkgconfig: fix pkg-config not always being in PATH`         |
| [`509e2b49`](https://github.com/NixOS/nixpkgs/commit/509e2b499edb97f3dd0ecf1f4b69735dff0b4395) | `systemd: Remove accidential sysinit re-add`                                   |
| [`09159b20`](https://github.com/NixOS/nixpkgs/commit/09159b20889a21dcf5d0c39ffb8328da25ec6552) | `python3Packages.markdown: 3.3.6 -> 3.3.7`                                     |
| [`7fb011df`](https://github.com/NixOS/nixpkgs/commit/7fb011df898c703c9435d28633c32b150a6680cd) | `Libsystem: Update headers.txt`                                                |
| [`972c7e99`](https://github.com/NixOS/nixpkgs/commit/972c7e99ff692a465509604027d65c28adde3aca) | `Libsystem: Replace cpio with copyHierarchy`                                   |
| [`e4b942ec`](https://github.com/NixOS/nixpkgs/commit/e4b942eccfec761f901a3c7932495cae03ab0809) | `wg-quick: fix postUp always generated issue`                                  |
| [`bd9f3ec6`](https://github.com/NixOS/nixpkgs/commit/bd9f3ec6644117d80fefe2790bb12ee757ca54c6) | `python310Packages.pygments: 2.11.2 -> 2.12.0`                                 |
| [`bad010fa`](https://github.com/NixOS/nixpkgs/commit/bad010fae807f2dbf104c1cdd1c98c1d0e6b7a2d) | `python310Packages.wcag-contrast-ratio: init at 0.9`                           |
| [`90157969`](https://github.com/NixOS/nixpkgs/commit/90157969cf10699f9a65077fb709b8935b2612f4) | `python310Packages.pygments: adopt, enable tests`                              |
| [`77c177eb`](https://github.com/NixOS/nixpkgs/commit/77c177ebe197a9de3d2a397997d70fa13d12aab4) | `fribidi: 1.0.11 -> 1.0.12`                                                    |
| [`96ed54cf`](https://github.com/NixOS/nixpkgs/commit/96ed54cfce2bedfb4551ea4d33cc2ce507998c9f) | `lzip: 1.22 -> 1.23, split output`                                             |
| [`1d17d14c`](https://github.com/NixOS/nixpkgs/commit/1d17d14cb72c8a3d122827c53f6d30bd9e490314) | `pip-audit: 2.0.0 -> 2.2.1`                                                    |
| [`d759e894`](https://github.com/NixOS/nixpkgs/commit/d759e894b2949ca7b8cdf0bb666e6f36d95a4f8f) | `python310Packages.pip-api: 0.0.28 -> 0.0.29`                                  |
| [`86e49c71`](https://github.com/NixOS/nixpkgs/commit/86e49c7114f4832cc74c59d61eedfa7a9c008a5f) | `pip-audit: init at 2.0.0`                                                     |
| [`b897629a`](https://github.com/NixOS/nixpkgs/commit/b897629a2c60dd602eaff6b02640d6aeec52e8e4) | `python3Packages.pip-api: init at 0.0.28`                                      |
| [`de6f14d3`](https://github.com/NixOS/nixpkgs/commit/de6f14d3d855d331c8516d12b7288aa0ddcb27f3) | `python3Packages.pretend: enable tests`                                        |
| [`3c746671`](https://github.com/NixOS/nixpkgs/commit/3c7466715aa2ed6be4cc17519ab065bb659f28b5) | `python3Packages.cachecontrol: enable filecache`                               |
| [`99786f9a`](https://github.com/NixOS/nixpkgs/commit/99786f9a57a2a9a0ac680550af645dfcdbc7da29) | ``go-modules/packages: Improve `checkFlags` handling``                         |
| [`5e2a1ebd`](https://github.com/NixOS/nixpkgs/commit/5e2a1ebdc4e000bc6e1316ab81c38a87a8ed417a) | `elfutils: 0.186 -> 0.187`                                                     |
| [`8473cb3a`](https://github.com/NixOS/nixpkgs/commit/8473cb3a2a108c3c089845e8164266943363fc51) | `gst_all_1.base: fix strictDeps`                                               |
| [`faef0834`](https://github.com/NixOS/nixpkgs/commit/faef08342601b39b87fc2aa6d90557fba6249a25) | `libical: enable strictDeps and fix cross`                                     |
| [`784ea321`](https://github.com/NixOS/nixpkgs/commit/784ea32182571783f40163739edd00db8ec401ea) | `gst_all_1.gstreamer: enable strictDeps and fix cross`                         |
| [`99dd6e95`](https://github.com/NixOS/nixpkgs/commit/99dd6e952f99e91e9b8526855ebaf790fdbde37c) | `python3Packages.sqlalchemy: 1.4.35 -> 1.4.36`                                 |
| [`c96b21c7`](https://github.com/NixOS/nixpkgs/commit/c96b21c78be0c5f954ac7fc218c5fadb683656dd) | `libpcap: move dev things to extra output`                                     |
| [`44370b35`](https://github.com/NixOS/nixpkgs/commit/44370b355e5ea046bf3727b9e90db6428e10ea2a) | `bluez: install gatttool too`                                                  |
| [`a7f9bb67`](https://github.com/NixOS/nixpkgs/commit/a7f9bb67da1f4090a50ba0445fdb05f43e233bc7) | `audit: enable strictDeps`                                                     |
| [`155dbcfc`](https://github.com/NixOS/nixpkgs/commit/155dbcfc81ab2cd7242e143958ea890f5e262ed3) | `libclc: 11.0.1 -> 12.0.1`                                                     |
| [`266b01d1`](https://github.com/NixOS/nixpkgs/commit/266b01d1d421844a42571dc9b09ca27c28c211d9) | `SPIRV-LLVM-Translator: Build and install llvm-spirv tool`                     |
| [`93d02ccf`](https://github.com/NixOS/nixpkgs/commit/93d02ccfb1669a94fd367debd8b56afef62fa0c9) | `mpris-scrobbler: 0.4.90 -> 0.4.95`                                            |
| [`ff6eb929`](https://github.com/NixOS/nixpkgs/commit/ff6eb9293739279c81f1e8e73c058ff6bcd4ed0e) | `libbsd: 0.11.5 -> 0.11.6`                                                     |