### PR TITLE
chore(flake/nixpkgs): `655ed68c` -> `52c2ca47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652829244,
-        "narHash": "sha256-zNAigraCjLVE76jSsBiuCa/zPuzp4p9UESHIIoia4VY=",
+        "lastModified": 1652915791,
+        "narHash": "sha256-LsHphcsg09ap8neohd1XQKpwS/BmqBQNzanJTL+1xKY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "655ed68c7c3651f9c705f60b64946ad60bcf812a",
+        "rev": "52c2ca47bb6761df879bd99656cb81e636d026d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`39bdec65`](https://github.com/NixOS/nixpkgs/commit/39bdec651203ed48b9ed5e72487ea4ced7a7c495) | `terraform: 1.1.9 -> 1.2.0`                                                   |
| [`23796e7e`](https://github.com/NixOS/nixpkgs/commit/23796e7ee67827fed6a5c1425d2e2ffec70b42d1) | `python3Packages.ansible: 5.7.1 -> 5.8.0`                                     |
| [`4ca72ffe`](https://github.com/NixOS/nixpkgs/commit/4ca72ffe4e3f60ba48b5a10a3e22f328f96a6d7f) | `ocamlPackages.lwt: 5.4.1 → 5.5.0`                                            |
| [`19e278b2`](https://github.com/NixOS/nixpkgs/commit/19e278b288e7c4362e1679c7d778373c8655faf6) | `home-assistant: 2022.5.4 -> 2022.5.5`                                        |
| [`66e01d34`](https://github.com/NixOS/nixpkgs/commit/66e01d3478b3fafdbb627485fa9cd60d5e0e0bf4) | `cgit-pink: 1.3.0 -> 1.4.1`                                                   |
| [`8e117607`](https://github.com/NixOS/nixpkgs/commit/8e1176077746d4ef0911247e6d4adfa1e0b3c54c) | `cgit-pink: remove duplicate maintainer entry`                                |
| [`977df9de`](https://github.com/NixOS/nixpkgs/commit/977df9de2e2705651903e7a7ba2478f52917b7e5) | `pika-backup: 0.3.5 -> 0.4.0`                                                 |
| [`3fa11ba9`](https://github.com/NixOS/nixpkgs/commit/3fa11ba9f4ee9f2a86c8c16eff864c5c8a2eb065) | `authenticator: use wrapGAppsHook4`                                           |
| [`e44b273d`](https://github.com/NixOS/nixpkgs/commit/e44b273d9f5a5d528eafd49606d177e805e0eba6) | `metadata-cleaner: use wrapGAppsHook4`                                        |
| [`4a134469`](https://github.com/NixOS/nixpkgs/commit/4a1344693d7845cf504187b3375a14415a6e0cc1) | `megapixels: use wrapGAppsHook4`                                              |
| [`1397fd67`](https://github.com/NixOS/nixpkgs/commit/1397fd6738bd0579d3976e9985f7dce0f8952587) | `banking: use wrapGAppsHook4`                                                 |
| [`3b35e34b`](https://github.com/NixOS/nixpkgs/commit/3b35e34b6d7a0f80dc976dab6a1f3622a347b9d6) | `mousai: use wrapGAppsHook4`                                                  |
| [`10992be6`](https://github.com/NixOS/nixpkgs/commit/10992be63e95276466bb358ce845f9951417734b) | `qtcreator: 5.0.2 -> 5.0.3 (#173357)`                                         |
| [`0c28d3bb`](https://github.com/NixOS/nixpkgs/commit/0c28d3bbec9ee084ea8fca0909d3f8d8dbc1330a) | `tree-sitter: revert #172850 for nix`                                         |
| [`1cf8b6d6`](https://github.com/NixOS/nixpkgs/commit/1cf8b6d6b14a43753c3b9aea5d974df930a85e30) | `anki-bin: 2.1.51 -> 2.1.52`                                                  |
| [`c5f9c896`](https://github.com/NixOS/nixpkgs/commit/c5f9c896c5ebf7dfea099510a40121b0c23108c3) | `nextcloud-client: 3.5.0 -> 3.5.1`                                            |
| [`4b37f162`](https://github.com/NixOS/nixpkgs/commit/4b37f1623235324e9b7225e20aaff5126fce2d8f) | `lean: 3.42.1 -> 3.43.0`                                                      |
| [`39cc8048`](https://github.com/NixOS/nixpkgs/commit/39cc8048a2fb5c82aa0452431d713c62b3fdd169) | `python310Packages.mailchecker: 4.1.16 -> 4.1.17`                             |
| [`0a449d8f`](https://github.com/NixOS/nixpkgs/commit/0a449d8fffd274987262c8eb34e1dbb5dcacabcb) | `lean: 3.42.0 -> 3.42.1`                                                      |
| [`121a2689`](https://github.com/NixOS/nixpkgs/commit/121a26897fa38c709197987c3eb82836463726c8) | `npiperelay: init at 0.1.0`                                                   |
| [`5726b8fa`](https://github.com/NixOS/nixpkgs/commit/5726b8faec7e5d1cbb08debd26f8ea0063f33abe) | `go_1_18: Fix build when targetting MinGW`                                    |
| [`f4033eee`](https://github.com/NixOS/nixpkgs/commit/f4033eeeafc0c180a45c9e17b9577e6ce2c93681) | `go: Fix build when targetting MinGW`                                         |
| [`561381b1`](https://github.com/NixOS/nixpkgs/commit/561381b146feaa50db9941e930de6534909f7dc3) | `ledger-live-desktop: 2.40.4 -> 2.41.3`                                       |
| [`56891b17`](https://github.com/NixOS/nixpkgs/commit/56891b17091fb1bb4dc00d118307d453e9aedcca) | `python310Packages.angrop: 9.2.3 -> 9.2.4`                                    |
| [`4b8062ed`](https://github.com/NixOS/nixpkgs/commit/4b8062edf809fe39b286ea37597cfbd55e742956) | `python310Packages.angr: 9.2.3 -> 9.2.4`                                      |
| [`078f4320`](https://github.com/NixOS/nixpkgs/commit/078f43200cc82ea5d843c4ca7773530f8e276064) | `python310Packages.cle: 9.2.3 -> 9.2.4`                                       |
| [`be5eaac3`](https://github.com/NixOS/nixpkgs/commit/be5eaac3be82235ece1fbdb90857dbf6aaeaf3a2) | `python310Packages.claripy: 9.2.3 -> 9.2.4`                                   |
| [`5fb91d9f`](https://github.com/NixOS/nixpkgs/commit/5fb91d9fda3289a2b20267f423428bb5aad00dad) | `python310Packages.pyvex: 9.2.3 -> 9.2.4`                                     |
| [`47436a61`](https://github.com/NixOS/nixpkgs/commit/47436a6114e6284b11b8761e2c7eb79ea3865b47) | `python310Packages.ailment: 9.2.3 -> 9.2.4`                                   |
| [`0cbc8362`](https://github.com/NixOS/nixpkgs/commit/0cbc836279417fed35c3fece22265160d4fdd5ca) | `python310Packages.archinfo: 9.2.3 -> 9.2.4`                                  |
| [`53466092`](https://github.com/NixOS/nixpkgs/commit/53466092bf227d5de3e4b581c58fea4d63c44525) | `python310Packages.deepdiff: 5.7.0 -> 5.8.2`                                  |
| [`ff78be01`](https://github.com/NixOS/nixpkgs/commit/ff78be018d9e6661ca1e867aa6bd7d5a1f04a9d8) | `cgit,cgit-pink: enableParallelBuilding`                                      |
| [`b85e96bb`](https://github.com/NixOS/nixpkgs/commit/b85e96bb2bdd61cb553d0e71da32c4134c66da42) | `python310Packages.plugwise: 0.18.3 -> 0.18.4`                                |
| [`a0bcf1e9`](https://github.com/NixOS/nixpkgs/commit/a0bcf1e9ea964f07128c99d39daa486b0cfca00d) | `nixos/nextcloud: styling`                                                    |
| [`e46bff95`](https://github.com/NixOS/nixpkgs/commit/e46bff95697e7a6d8345770c2b26fc542b29b676) | `nixos/nextcloud: upgrade instructions / info for v23`                        |
| [`cf412af2`](https://github.com/NixOS/nixpkgs/commit/cf412af251157812f69596d1353ad9e49c031d2e) | `python310Packages.urlextract: 1.5.0 -> 1.6.0`                                |
| [`6f80d683`](https://github.com/NixOS/nixpkgs/commit/6f80d6836ac46607c2058d928bd4464ea83ffcc8) | `nixos/nextcloud: mariadb workaround is for versions >=24 not needed anymore` |
| [`53a512c8`](https://github.com/NixOS/nixpkgs/commit/53a512c88fd807467350ada1cd913e07afb33fe2) | `python3Packages.catboost: mark cuda build as broken`                         |
| [`02c59167`](https://github.com/NixOS/nixpkgs/commit/02c591678f2e9917bce9a7061038c91a6e9a0fde) | `python310Packages.doc8: 0.11.1 -> 0.11.2`                                    |
| [`b96c7cae`](https://github.com/NixOS/nixpkgs/commit/b96c7caea612ea494806f109b76e05e81220dcbb) | `mxnet: mark cuda build as broken`                                            |
| [`451f200f`](https://github.com/NixOS/nixpkgs/commit/451f200f676de18f7ecb54b1652d064c04a3c959) | `python310Packages.xknx: 0.21.2 -> 0.21.3`                                    |
| [`1bd9ff36`](https://github.com/NixOS/nixpkgs/commit/1bd9ff368f1b59f405a7cd950fd43bc336e29016) | `python310Packages.marshmallow-oneofschema: enable tests`                     |
| [`6a6cfdc9`](https://github.com/NixOS/nixpkgs/commit/6a6cfdc9f8e53b03fc9e7cdccbe537ffbb536fcc) | `python310Packages.marshmallow: add missing input`                            |
| [`477822a5`](https://github.com/NixOS/nixpkgs/commit/477822a5371b4f4d5ff4e4d4140a2803379cfc7d) | `python310Packages.cyclonedx-python-lib: 2.3.0 -> 2.4.0`                      |
| [`99b3c498`](https://github.com/NixOS/nixpkgs/commit/99b3c498a2adfe66434417a817bf5e28e29c9afe) | `python310Packages.ansible-later: 2.0.12 -> 2.0.13`                           |
| [`b32d017b`](https://github.com/NixOS/nixpkgs/commit/b32d017b60db46e719737a579c1f7362d0c53cef) | `python3Packages.pyrogram: 2.0.23 -> 2.0.24`                                  |
| [`0f8888e2`](https://github.com/NixOS/nixpkgs/commit/0f8888e2c18d520cb83e4c07175a88dcc0157d18) | `python310Packages.elementpath: 2.5.1 -> 2.5.2`                               |
| [`d383d27f`](https://github.com/NixOS/nixpkgs/commit/d383d27f29c841da02bca68c4053f6a328be7a94) | `jl: 0.0.5 -> 0.1.0`                                                          |
| [`4ff95784`](https://github.com/NixOS/nixpkgs/commit/4ff9578411c81cf2ac8040579de413a152a12a5e) | `dockutil 2.0.5 -> 3.0.2 (#167488)`                                           |
| [`3b0c84bb`](https://github.com/NixOS/nixpkgs/commit/3b0c84bb7a0ff45d54e404b85a9ce70c92af2f2d) | `pantheon.elementary-photos: 2.7.4 -> 2.7.5`                                  |
| [`bbb20d3b`](https://github.com/NixOS/nixpkgs/commit/bbb20d3b9e35356276e9baa49adf3718d0d59893) | `buildbot: fix dependencies`                                                  |
| [`a438660f`](https://github.com/NixOS/nixpkgs/commit/a438660fe07be813e6eca27585e62e57c1c135d0) | `python310Packages.rns: 0.3.5 -> 0.3.6`                                       |
| [`b3445aff`](https://github.com/NixOS/nixpkgs/commit/b3445aff661c814a5661413ae12406d4d4130e17) | `btrfs-progs: remove obsolete _PYTHON_HOST_PLATFORM`                          |
| [`1605472a`](https://github.com/NixOS/nixpkgs/commit/1605472a15e6031fa13a84f35cc9d95a638a237d) | `btrfs-progs: install Python bindings`                                        |
| [`520ca935`](https://github.com/NixOS/nixpkgs/commit/520ca935405c108b02cad79be66f7f842effbdca) | `python310Packages.marshmallow: 3.13.0 -> 3.15.0`                             |
| [`f586c868`](https://github.com/NixOS/nixpkgs/commit/f586c868d3e1b916c26f1fa57207fa5d35e2435e) | `python310Packages.hahomematic: 1.3.1 -> 1.4.0`                               |
| [`6e632447`](https://github.com/NixOS/nixpkgs/commit/6e63244762f1083bc4fd74a61033dbd485f1a574) | `shibboleth-sp: fix build`                                                    |
| [`8a1e40c9`](https://github.com/NixOS/nixpkgs/commit/8a1e40c96bc21e055383297297267a8cc9443d9f) | `opensaml-cpp: fix build`                                                     |
| [`cc975df4`](https://github.com/NixOS/nixpkgs/commit/cc975df49c31c220e0c012250cb5dc91e6e19eb6) | `xml-tooling-c: fix build`                                                    |
| [`73714678`](https://github.com/NixOS/nixpkgs/commit/73714678f13f0e8e5cf043d51afcf23e5c18943b) | `trying to fix darwin build`                                                  |
| [`6f0d3c8e`](https://github.com/NixOS/nixpkgs/commit/6f0d3c8ec71dfca5a6bde1d57d85bd48483476ad) | `drawio: 18.0.4 -> 18.0.6`                                                    |
| [`293b1a9a`](https://github.com/NixOS/nixpkgs/commit/293b1a9afdf325bd44aad9974dbe420366d37a47) | `python310Packages.humanize: 4.0.0 -> 4.1.0`                                  |
| [`42fd630f`](https://github.com/NixOS/nixpkgs/commit/42fd630fe77aad9f882c7a96c720b6ed4c08542f) | `proxychains: install default config`                                         |
| [`bf3dca0b`](https://github.com/NixOS/nixpkgs/commit/bf3dca0b580f40c4ab4ff24d0f8c7975a910246e) | `python310Packages.dulwich: 0.20.36 -> 0.20.38`                               |
| [`530f1da4`](https://github.com/NixOS/nixpkgs/commit/530f1da4453e5fd4e61562401742f2fc0dafcd0f) | `driftctl: 0.29.0 -> 0.30.0`                                                  |
| [`ae3e4d22`](https://github.com/NixOS/nixpkgs/commit/ae3e4d2201abb0fec7929095e1a1ae2feef69f01) | `opentelemetry-collector: 0.47.0 -> 0.51.0`                                   |
| [`51c86e49`](https://github.com/NixOS/nixpkgs/commit/51c86e49d8212ad2ce1109379eea2800b2cb3a58) | `opentelemetry-collector-contrib: 0.47.0 -> 0.51.0`                           |
| [`80813d57`](https://github.com/NixOS/nixpkgs/commit/80813d573ac07683ccc9574124719049e30ba985) | `stripe-cli: 1.8.8 -> 1.8.11`                                                 |
| [`429ab766`](https://github.com/NixOS/nixpkgs/commit/429ab766c3c8576c81212d6208821dfd2e18617c) | `nerdctl: 0.19.0 -> 0.20.0`                                                   |
| [`6fd83b70`](https://github.com/NixOS/nixpkgs/commit/6fd83b70a9f8fdecc27f2ac08d876ac21b6121b2) | `libfpx: pull upstream fix for -fno-common toolchains`                        |
| [`fdf74c77`](https://github.com/NixOS/nixpkgs/commit/fdf74c7741465d8d1da7a910cd17d38068c74ff1) | `maintainers/create-amis.sh: Add more AWS regions`                            |
| [`2cdca032`](https://github.com/NixOS/nixpkgs/commit/2cdca0320d8cabc00522f5e7026cfbc3677ca0d0) | `hubicfuse: pull upstream fix for -fno-common tollchains`                     |
| [`47fabead`](https://github.com/NixOS/nixpkgs/commit/47fabead8086049aa278cacc3c6c5d0de84d386b) | `light: pull upstream fix for -fno-common toolchains`                         |
| [`83523b81`](https://github.com/NixOS/nixpkgs/commit/83523b81152536eaa35d409cfe6e0a1da80cef94) | `konstraint: 0.19.1 -> 0.20.0`                                                |
| [`73fe05a5`](https://github.com/NixOS/nixpkgs/commit/73fe05a563411225e9cb9c8170c24196b03e6c1f) | `nodePackages: add meta.mainProgram to packages with multiple executables`    |
| [`0f2efa91`](https://github.com/NixOS/nixpkgs/commit/0f2efa91a6b70089b92480ba613571e92322f753) | `nodejs-17_x: drop`                                                           |
| [`0fb4d8c4`](https://github.com/NixOS/nixpkgs/commit/0fb4d8c4b24a816fda8a184b73dfc18369b75047) | `nodejs-18_x: 18.1.0 -> 18.2.0`                                               |
| [`a5f35137`](https://github.com/NixOS/nixpkgs/commit/a5f35137c86d0cc66c57ee5ec67d08c9acdf00b5) | `nodejs-14_x: 14.19.2 -> 14.19.3`                                             |
| [`6e8aeecd`](https://github.com/NixOS/nixpkgs/commit/6e8aeecde41f3cef17edb912085dd69511cbf43e) | `tilt: mark broken on x86_64 Darwin`                                          |
| [`0644f259`](https://github.com/NixOS/nixpkgs/commit/0644f25938d8857a6d02022ff5ab6233da99f6ec) | `pantheon.switchboard-plug-onlineaccounts: 6.4.0 -> 6.5.0`                    |
| [`669283f0`](https://github.com/NixOS/nixpkgs/commit/669283f06a78741ac640f0700e06794ef7db4cc0) | `python3Packages.ansible-core: 2.12.5 -> 2.13.0`                              |
| [`28c3b331`](https://github.com/NixOS/nixpkgs/commit/28c3b33165b32a63693b6577e97246f9e58c7dca) | `lightwalletd: 0.4.9 -> 0.4.10`                                               |
| [`19c42b88`](https://github.com/NixOS/nixpkgs/commit/19c42b883f668d17ac8670c19707c6dd9e7bd28b) | `trivy: 0.27.1 -> 0.28.0`                                                     |
| [`fa585a07`](https://github.com/NixOS/nixpkgs/commit/fa585a07f65f4ee954758c67db6c75463a6f6560) | `zoom-us: change wrapper name to fix IPC`                                     |
| [`215155b4`](https://github.com/NixOS/nixpkgs/commit/215155b44065e6b2652535f720fa04ac20e8980f) | `zoom: add dep for udev, fix launching`                                       |
| [`5791f1c4`](https://github.com/NixOS/nixpkgs/commit/5791f1c43f97a00ed4c6daf2394e759448620636) | `zoom-us: Update dependencies`                                                |
| [`bb17d93a`](https://github.com/NixOS/nixpkgs/commit/bb17d93a56ae3bc47255c6f2136f56afee87d231) | `zoom-us: 5.9.6.2225 -> 5.10.4.2845 on x86_64-linux`                          |
| [`336ee6b1`](https://github.com/NixOS/nixpkgs/commit/336ee6b108ec2d004c9bd322220b189d0370b022) | `xanmod-kernels: make myself a maintainer`                                    |
| [`fe151054`](https://github.com/NixOS/nixpkgs/commit/fe151054ff804eae5e99ee19cb86a024704465f1) | `linux_xanmod_latest: 5.17.4 -> 5.17.8`                                       |
| [`3133e29f`](https://github.com/NixOS/nixpkgs/commit/3133e29fcefe0b619eaa8d951ad21294b3358a03) | `linux_xanmod: 5.15.35 -> 5.15.40`                                            |
| [`4f45341b`](https://github.com/NixOS/nixpkgs/commit/4f45341b0d9f2ffb2e45a6561aef595e5e11fcef) | `n8n: 0.176.0 → 0.177.0`                                                      |
| [`f52c4ffe`](https://github.com/NixOS/nixpkgs/commit/f52c4ffe0827be01aaee2dbd6802b953e53772b5) | `cocoapods: fix deprecation about Gemfile`                                    |
| [`a23fbeb6`](https://github.com/NixOS/nixpkgs/commit/a23fbeb6e8d5c7f35c9feba25da0061ebcf79efe) | `testers.testVersion: if grep failed then print the output of the command`    |
| [`b43b2856`](https://github.com/NixOS/nixpkgs/commit/b43b28568ff35d9896476bb14a5542ac6f88ba8d) | `cocoapods: 1.11.0 -> 1.11.3`                                                 |
| [`33294cea`](https://github.com/NixOS/nixpkgs/commit/33294cea74a9dad4ecc919d25ecd2437f341e193) | `git-workspace: 0.9.0 -> 1.0.3`                                               |
| [`27e96516`](https://github.com/NixOS/nixpkgs/commit/27e96516f80f38958f628688ad35b538b71de1c9) | `alfis: 0.7.0 -> 0.7.3`                                                       |
| [`aa61d406`](https://github.com/NixOS/nixpkgs/commit/aa61d40652db53fae17fd1a3b677e4ab336296c1) | `python310Packages.napalm: 3.3.1 -> 3.4.1`                                    |
| [`0beb34d9`](https://github.com/NixOS/nixpkgs/commit/0beb34d91744c7c2494e5a227f791165792fbdd6) | `temporal: 1.15.0 -> 1.16.2`                                                  |
| [`1a634cc0`](https://github.com/NixOS/nixpkgs/commit/1a634cc0577f4bf55b9556ecf8aa721c3ec865e3) | `treewide: remove unecessary XDG_DATA_DIRS from appimage wrapType2`           |
| [`ea48d036`](https://github.com/NixOS/nixpkgs/commit/ea48d0369edd463d1ed7d5ad16000e38d6711dea) | `python3Packages.uamqp: re-introduce darwin-fixing patch for x86_64`          |
| [`5ce31ec2`](https://github.com/NixOS/nixpkgs/commit/5ce31ec2fda36614a42fe80b0744da78de8a16b7) | `nix-fallback-paths.nix: Update to 2.8.1`                                     |
| [`72ffe3a6`](https://github.com/NixOS/nixpkgs/commit/72ffe3a604d37f8d5581c62870fe0678d9011613) | `_9pfs: add -fcommon workaround`                                              |
| [`ab010f68`](https://github.com/NixOS/nixpkgs/commit/ab010f68fe5442e177ced608b53c31214fcf1fbf) | `musikcube: Fix Linux build`                                                  |
| [`4a18eff4`](https://github.com/NixOS/nixpkgs/commit/4a18eff46c5969ae81c80b47ca324fc9e1bbd6b6) | `tpmmanager: switch to Qt5`                                                   |
| [`4a6744b2`](https://github.com/NixOS/nixpkgs/commit/4a6744b2b210d1f04d354aa31a638a172a6d70f0) | `proxychains-ng: install default config, zsh completion`                      |
| [`1d447b0a`](https://github.com/NixOS/nixpkgs/commit/1d447b0a21f1f7c4aec098fb261b3b9ef97fa4b4) | `dlib: 19.23 -> 19.24`                                                        |
| [`0c9a754a`](https://github.com/NixOS/nixpkgs/commit/0c9a754a6ccac679c69fc433816a4d8730bd241d) | `prometheus: fix build when all service discovery plugins are disabled`       |
| [`21073940`](https://github.com/NixOS/nixpkgs/commit/210739403a8cfb40f236ea3104dd7096d98193d1) | `tpmmanager: fix hash`                                                        |
| [`19d2c6f6`](https://github.com/NixOS/nixpkgs/commit/19d2c6f64d3a8e569d39f7faf44c6102c0974cd5) | `mojave-gtk-theme: add update script`                                         |
| [`4d602688`](https://github.com/NixOS/nixpkgs/commit/4d60268814af2037629d1115eeaff40ec5c8cb1a) | `mojave-gtk-theme: unstable-2021-12-20 -> 2022-05-12`                         |
| [`104bc12c`](https://github.com/NixOS/nixpkgs/commit/104bc12c7395f45789ab415e5f8e9bf50c2bfa8e) | `nomad-pack: 2022-04-12 -> 2022-05-12`                                        |
| [`75eff269`](https://github.com/NixOS/nixpkgs/commit/75eff269f76f6aa01ecc0e08a7958f80846747f2) | `python310Packages.netmiko: 4.0.0 -> 4.1.0`                                   |
| [`04c57e28`](https://github.com/NixOS/nixpkgs/commit/04c57e28c15a599b32704077b34eecf54ae898c4) | `Revert "python3Packages.napalm: disable python 3.9 onwards (#172643)"`       |
| [`fa7ce6bc`](https://github.com/NixOS/nixpkgs/commit/fa7ce6bc7ffb66c4a0762faa58589a3424749901) | `nixos/openssh: Add sntrup761x25519-sha512 kexAlgo`                           |
| [`bbb27f8e`](https://github.com/NixOS/nixpkgs/commit/bbb27f8eb3f11b634c9dce12113407af9a290f78) | `spidermonkey_91: 91.8.0 -> 91.9.0`                                           |
| [`1c73a077`](https://github.com/NixOS/nixpkgs/commit/1c73a0773caa843fe16ff6e31eb2fcf7c7362695) | `doc: clarify what a 'mass rebuild' is`                                       |
| [`20dad991`](https://github.com/NixOS/nixpkgs/commit/20dad99154f282a4ab6e75348f7c4ed711141af7) | `matrix-synapse-plugins.matrix-synapse-mjolnir-antispam: 1.4.1 -> 1.4.2`      |
| [`ecd8d423`](https://github.com/NixOS/nixpkgs/commit/ecd8d42397d0142b9b54e1e0664acb43c146fe98) | `nextcloud24: init at 24.0.0`                                                 |
| [`573127a0`](https://github.com/NixOS/nixpkgs/commit/573127a0f20e5046f8b4d8dd5d90b1696219e01e) | `linux_xanmod_latest: 5.17.2 -> 5.17.4`                                       |
| [`97164719`](https://github.com/NixOS/nixpkgs/commit/97164719dc1e69e722855bee50f2741b1b0e9693) | `linux_xanmod: 5.15.34 -> 5.15.35`                                            |
| [`55d27980`](https://github.com/NixOS/nixpkgs/commit/55d279809c7e4d876e137819d1e6c6d0fe28d66a) | `wine-packages: fix Hydra build failures on Darwin`                           |
| [`75c7e048`](https://github.com/NixOS/nixpkgs/commit/75c7e048010a501c20a301ac1cc86bdaa30fad5f) | `moltenvk: fix Hydra build failures`                                          |
| [`21552c54`](https://github.com/NixOS/nixpkgs/commit/21552c541f70519a3329d001385bd3f573a8ac77) | `ocamlPackages.graphql_ppx: 1.2.0 -> 1.2.2`                                   |
| [`cef71b49`](https://github.com/NixOS/nixpkgs/commit/cef71b49d5acefb82258f5e1d1e07459bc89172f) | `wasabibackend: 1.1.13.0 -> 1.1.13.1`                                         |
| [`0c795a81`](https://github.com/NixOS/nixpkgs/commit/0c795a8127dbed56a0accd5466f6c7ffb80638d7) | `nixos/wireguard: fix dependencies on network-related targets`                |
| [`7e397432`](https://github.com/NixOS/nixpkgs/commit/7e397432743a969b161ac1739b2abc7b37f47625) | `garble: 0.5.1 -> 0.6.0`                                                      |
| [`49df9b76`](https://github.com/NixOS/nixpkgs/commit/49df9b76fe99769c676b7c06e30ab7f52e2da01a) | `storm: 2.3.0 -> 2.4.0`                                                       |
| [`9841a677`](https://github.com/NixOS/nixpkgs/commit/9841a677e6bdde14babd9c487c017351588272bd) | `argus-clients: 3.0.8.2 -> 3.0.8.3`                                           |
| [`e70add1c`](https://github.com/NixOS/nixpkgs/commit/e70add1c86e7f45745c7299dd2ae00af9c39775e) | `tixati: 2.88 -> 2.89`                                                        |
| [`e7a656dd`](https://github.com/NixOS/nixpkgs/commit/e7a656ddbe3e1e673562e258d0639b1ce57d8fb8) | `console-bridge: 1.0.1 -> 1.0.2`                                              |