### PR TITLE
chore(flake/nixos-hardware): `ae5047bc` -> `ca4e0ca1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -120,11 +120,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1653029222,
-        "narHash": "sha256-iKQZ6EJCSt7N0rtC2bmLuor6i2LSKmBQcA1FXKdBIos=",
+        "lastModified": 1653029753,
+        "narHash": "sha256-NjxiNOG19pbxmZw60lLQICAUvSWSrHDd+EYe7ZfqCnw=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ae5047bcd0f5cf15a47d1cce98f9a7bb56eb8eaf",
+        "rev": "ca4e0ca18692109a28c4be0b74f6569e1bc8a379",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                     |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`162fb7a9`](https://github.com/NixOS/nixos-hardware/commit/162fb7a9878f8ba190196190f3bb98b599eb2141) | `framework: acpilight should be used`              |
| [`f3dfd301`](https://github.com/NixOS/nixos-hardware/commit/f3dfd30170425adbc377ee502c3b4af13541b3ae) | `framework: Fix headphone noise when on powersave` |