### PR TITLE
chore(flake/nixos-hardware): `ca4e0ca1` -> `b49fe0e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -120,11 +120,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1653029753,
-        "narHash": "sha256-NjxiNOG19pbxmZw60lLQICAUvSWSrHDd+EYe7ZfqCnw=",
+        "lastModified": 1653029861,
+        "narHash": "sha256-f9IkBMBuFZcq+lspk91OKsNaBtrrDsKn+ItHmj2fO/4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ca4e0ca18692109a28c4be0b74f6569e1bc8a379",
+        "rev": "b49fe0e96e6b1233340eae44b257160f3c71a32d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`b750b56a`](https://github.com/NixOS/nixos-hardware/commit/b750b56a20a335056c1211b91ae16a7fa057f1c2) | `feat: add acpi_call and ssd for thinkpad x270`                          |
| [`68c87ede`](https://github.com/NixOS/nixos-hardware/commit/68c87edeb979e10ccb29db2125a6bbd372092f28) | `dell-xps-15-9560-nvidia: use Nvidia Offload mode to save battery power` |