### PR TITLE
chore(flake/nixpkgs): `52c2ca47` -> `98bcd08c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652915791,
-        "narHash": "sha256-LsHphcsg09ap8neohd1XQKpwS/BmqBQNzanJTL+1xKY=",
+        "lastModified": 1653086549,
+        "narHash": "sha256-9Gt55P+hh70m/vx0zS5iJrMFrU4Rf0uO+nG9NFxTW1U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "52c2ca47bb6761df879bd99656cb81e636d026d9",
+        "rev": "98bcd08cb1778d103bac1149621b3568014aadbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`89802ae6`](https://github.com/NixOS/nixpkgs/commit/89802ae630381ce7f54c2950ceab00d18a7b1fd4) | `terraform-providers.b2: init at 0.8.0`                                              |
| [`61e7aeee`](https://github.com/NixOS/nixpkgs/commit/61e7aeee528d34501f217d5712ba04c15c84862e) | `svtplay-dl: 4.11 -> 4.12`                                                           |
| [`632a0423`](https://github.com/NixOS/nixpkgs/commit/632a0423b0b672b67c3fbae94331b585f03ada60) | `python310Packages.google-cloud-asset: disable on older Python releases`             |
| [`c68ebdc4`](https://github.com/NixOS/nixpkgs/commit/c68ebdc49638a3fbd503fc7c56ab4641f908972a) | `haskellPackages: mark builds failing on hydra as broken`                            |
| [`5c429765`](https://github.com/NixOS/nixpkgs/commit/5c42976597838a10f7d0bbb5a3c400ddeb7c9cfc) | `maintainers/scripts/haskell/hydra-report.hs: remove redundant pragmas`              |
| [`0d4417d8`](https://github.com/NixOS/nixpkgs/commit/0d4417d888a53c70147d06fadcabfba0e3716935) | `haskellPackages: mark builds failing on hydra as broken`                            |
| [`cb20a401`](https://github.com/NixOS/nixpkgs/commit/cb20a401772b4da7cd5c118b714f24aee3032b14) | `maintainers/scripts/haskell/hydra-report.hs: fix outdated hydra-unstable reference` |
| [`25e4e7af`](https://github.com/NixOS/nixpkgs/commit/25e4e7af034950c2d0f408b4b12b362968572ac2) | `ipxe: do not call syslinux on aarch64`                                              |
| [`8c292bd1`](https://github.com/NixOS/nixpkgs/commit/8c292bd1bfb314bb0f88a1e326afbeff7c0221f1) | `python310Packages.google-cloud-translate: 3.7.2 -> 3.7.3`                           |
| [`cf099ebf`](https://github.com/NixOS/nixpkgs/commit/cf099ebfbaf8999cfd36a0dde095be7d350e4aaf) | `splat: build script only recognizes x86_64`                                         |
| [`fa644600`](https://github.com/NixOS/nixpkgs/commit/fa6446008f96f0534fe5043c29e91dbebb49cb92) | `python310Packages.google-cloud-asset: 3.8.1 -> 3.9.0`                               |
| [`fc76b27a`](https://github.com/NixOS/nixpkgs/commit/fc76b27ae74d53d1d986c622e16bf4a3e32b1137) | `python310Packages.gcal-sync: 0.8.1 -> 0.9.0`                                        |
| [`28e51c32`](https://github.com/NixOS/nixpkgs/commit/28e51c32665555876de6a87c88fbec670a686e25) | `libsForQt5.quazip: 1.2 -> 1.3`                                                      |
| [`42da4ace`](https://github.com/NixOS/nixpkgs/commit/42da4ace4c9c320deb3935e74b7755bc7dce678c) | `libsForQt5.mauiPackages.pix: init at 2.1.2`                                         |
| [`3bf346ea`](https://github.com/NixOS/nixpkgs/commit/3bf346ea4026be1d32bbe7b4397ac0a94966c68b) | `libsForQt5.mauiPackages.mauikit-imagetools: init at 2.1.2`                          |
| [`d5a2974e`](https://github.com/NixOS/nixpkgs/commit/d5a2974e52103113256942a378906b401e31721b) | `libsForQt5.mauiPackages: init at 2.1.2`                                             |
| [`f7a78e15`](https://github.com/NixOS/nixpkgs/commit/f7a78e155670c5d91da896cc38cbc0080ffba70c) | `python310Packages.ssh-mitm: 2.0.0 -> 2.0.1`                                         |
| [`6efcdce0`](https://github.com/NixOS/nixpkgs/commit/6efcdce0b15f5cb037678f5524675340fd9b2c23) | `rstcheck: add to all-packages.nix`                                                  |
| [`8f64b92d`](https://github.com/NixOS/nixpkgs/commit/8f64b92d8fb54e17b9a8e80655f0fb1ed22d6f39) | `python310Packages.rstcheck: 3.3.1 -> 5.0.0`                                         |
| [`8d6c6000`](https://github.com/NixOS/nixpkgs/commit/8d6c60001c7727ee96b13e3ab186f9181f15e00c) | `release-cross.nix: fix RISC-V embedded`                                             |
| [`05565293`](https://github.com/NixOS/nixpkgs/commit/055652935e2f81c70db8e932137dc5c37436c913) | `python310Packages.types-docutils: init at 0.18.3`                                   |
| [`53002e84`](https://github.com/NixOS/nixpkgs/commit/53002e84ef298720ba2a92055f100592cb6e1d7a) | `flyctl: 0.0.323 -> 0.0.328`                                                         |
| [`d1b0b0e6`](https://github.com/NixOS/nixpkgs/commit/d1b0b0e668bd9cce268aaaa13d78e3a38624f756) | `python310Packages.twilio: 7.8.0 -> 7.9.1`                                           |
| [`b6d6a89f`](https://github.com/NixOS/nixpkgs/commit/b6d6a89fad7416983a81b1e15263c1327f12c828) | `goldendict: 2021-03-09 → 2022-05-10, fix build on darwin`                           |
| [`39f9c2dc`](https://github.com/NixOS/nixpkgs/commit/39f9c2dcfebcf1dc7607e8dcf8ce620ab76c6899) | `libfreeaptx: avoid rebuilding on Linux for now`                                     |
| [`f963b7f1`](https://github.com/NixOS/nixpkgs/commit/f963b7f107698386be154daffd06e9d3828acf6f) | `xsuspender: 1.1 -> 1.3`                                                             |
| [`8581c7e4`](https://github.com/NixOS/nixpkgs/commit/8581c7e4d1c2e43dc9e4fa90e62c409d9db6293a) | `erlangR25: fix version`                                                             |
| [`745914cf`](https://github.com/NixOS/nixpkgs/commit/745914cf0dd796764f790bbb830d78b801bc01c1) | `python310Packages.google-cloud-language: 2.4.1 -> 2.4.2`                            |
| [`b10f0f69`](https://github.com/NixOS/nixpkgs/commit/b10f0f69585daade7f1c38f313d7dbbee78ee310) | `nushell: 0.61.0 -> 0.62.0`                                                          |
| [`5bd7f945`](https://github.com/NixOS/nixpkgs/commit/5bd7f9457276b64760a76e76f5992217a051401e) | `crow-translate: 2.9.5 -> 2.9.8`                                                     |
| [`dbb31f2e`](https://github.com/NixOS/nixpkgs/commit/dbb31f2e0c1ee064c21a95d903ff6674c1a6ed3b) | `sdrpp: fix build on darwin`                                                         |
| [`7a5fdfb8`](https://github.com/NixOS/nixpkgs/commit/7a5fdfb81825e195e8a37dbfca6966040684b40d) | `python310Packages.sagemaker: 2.82.0 -> 2.91.1`                                      |
| [`09230879`](https://github.com/NixOS/nixpkgs/commit/092308792121db350cf9832613aaaf7ff914782f) | `jira-cli-go: init at 0.3.0 (#173440)`                                               |
| [`d7e8e2f9`](https://github.com/NixOS/nixpkgs/commit/d7e8e2f9fc9cd13a4b87cf749fb59d62bfffbc3f) | `python310Packages.pathos: 0.2.5 -> 0.2.8`                                           |
| [`374d4ad1`](https://github.com/NixOS/nixpkgs/commit/374d4ad151183b3b6d44373768eae70a74897c05) | `python310Packages.pox: 0.2.7 -> 0.3.1`                                              |
| [`7ff77911`](https://github.com/NixOS/nixpkgs/commit/7ff779112500d66925edc777cf51a33668a8f7ec) | `python310Packages.ppft: 1.6.6.1 -> 1.7.6.5`                                         |
| [`6501ee65`](https://github.com/NixOS/nixpkgs/commit/6501ee65b0493c880ba2e2b9d62766d6bb10cbca) | `imagemagick: 7.1.0-34 -> 7.1.0-35`                                                  |
| [`9abfef3f`](https://github.com/NixOS/nixpkgs/commit/9abfef3f54a1bae43d09c6df7abf348efad3f8a7) | `xpra: 4.3.2 -> 4.3.3 (#172682)`                                                     |
| [`610d4925`](https://github.com/NixOS/nixpkgs/commit/610d4925e393d730dd35ff89be999ff2749a9b6e) | `hobbits: 0.52.0 → 0.53.1, fix build on aarch64-linux`                               |
| [`7be670e9`](https://github.com/NixOS/nixpkgs/commit/7be670e9b59de5cab4a5c879179f5b7c84e6caa6) | `python310Packages.google-resumable-media: 2.3.2 -> 2.3.3`                           |
| [`702561fd`](https://github.com/NixOS/nixpkgs/commit/702561fd9851ad4f27c09b8961f3598232660e33) | `pffft: init at 2022-04-10`                                                          |
| [`88ccdd66`](https://github.com/NixOS/nixpkgs/commit/88ccdd668776856c08fe27fbbf994be54e093b23) | `privacyidea: 3.6.3 -> 3.7.1`                                                        |
| [`09ec1d2e`](https://github.com/NixOS/nixpkgs/commit/09ec1d2e42ef56c64d71b5c64a03898c097e91c0) | `python310Packages.google-cloud-firestore: 2.4.0 -> 2.5.0`                           |
| [`814537f2`](https://github.com/NixOS/nixpkgs/commit/814537f297a54c969236bbd7e72b58e8ce1990aa) | `erlangR25: init at 25.0 (#173674)`                                                  |
| [`a4ae7b86`](https://github.com/NixOS/nixpkgs/commit/a4ae7b86c9dd77d6a14ec2a7073abf7414a86bdf) | `haskellPackages.fast-tags: apply patch for nondeterministic tests`                  |
| [`e408978e`](https://github.com/NixOS/nixpkgs/commit/e408978ee7653b8d8d51f5043d0c6627372c24c3) | `python310Packages.identify: 2.5.0 -> 2.5.1`                                         |
| [`667e13c6`](https://github.com/NixOS/nixpkgs/commit/667e13c61935d64e8720b2959bd7f7391e005076) | `openjdk17: 17.0.1 -> 17.0.3 (darwin)`                                               |
| [`be15e454`](https://github.com/NixOS/nixpkgs/commit/be15e454d899c89cf3c9e85c2376fb8cdca689ca) | `ber-metaocaml: apply glibc>=2.34 fix from ocaml/4.07.nix`                           |
| [`5ece709f`](https://github.com/NixOS/nixpkgs/commit/5ece709f37c2da516ff180022adfb91ea6140273) | `gitlab-runner: 14.10.1 -> 15.0.0`                                                   |
| [`419e19ca`](https://github.com/NixOS/nixpkgs/commit/419e19ca81234ab5bc5b7ed81ce43f5e1bd03f3e) | `clamav: Fix cli clamav programs not finding configuration files`                    |
| [`c8310399`](https://github.com/NixOS/nixpkgs/commit/c8310399496fdf9207c066dbfdf3f3394aa9b4ab) | `python310Packages.periodictable: add pythonImportsCheck`                            |
| [`0dbb3831`](https://github.com/NixOS/nixpkgs/commit/0dbb383188968b6b494ed546a3f7513ffcec901e) | `python310Packages.habanero: 1.2.0 -> 1.2.2`                                         |
| [`9487de8e`](https://github.com/NixOS/nixpkgs/commit/9487de8ece1da1c93821a91113d47a58cdbbd99f) | `python310Packages.types-dateutil: 2.8.15 -> 2.8.16`                                 |
| [`ba54ba93`](https://github.com/NixOS/nixpkgs/commit/ba54ba93161b96a3f5a9f0072be2930bcd4dd4e8) | `ocamlPackages: add meta.mainProgram to packages with multiple executables`          |
| [`ef3bf2e6`](https://github.com/NixOS/nixpkgs/commit/ef3bf2e60285d3f3299755c28a55918440d5c300) | `ocamlPackages.awa,ocamlPackages.awa-lwt: correct meta.mainProgram`                  |
| [`ab44808c`](https://github.com/NixOS/nixpkgs/commit/ab44808c8e0d56145a7c238d6ad743c86034f30a) | `ocamlPackages.atdgen: correct meta.mainProgram`                                     |
| [`84467ab4`](https://github.com/NixOS/nixpkgs/commit/84467ab40fda190c18703bdaf2f32994a1da7f5e) | `dmrconfig: pull upstram fix for -fno-common toolchains`                             |
| [`adbfe679`](https://github.com/NixOS/nixpkgs/commit/adbfe6790f3e1fa0636386e6f8b8e56d2ed4fd13) | `rt-tests: quote homepage url`                                                       |
| [`4db66502`](https://github.com/NixOS/nixpkgs/commit/4db6650243c204338e426bc1d671a24397e108f0) | `python310Packages.google-cloud-dlp: 3.6.2 -> 3.7.0`                                 |
| [`c8178c85`](https://github.com/NixOS/nixpkgs/commit/c8178c8534b2f340392cc61d7bfbc1e8380ce78f) | `python310Packages.thinc: 8.0.15 -> 8.0.16`                                          |
| [`a8c70ea3`](https://github.com/NixOS/nixpkgs/commit/a8c70ea3f1b49f9e9499dfba5482147e8be438aa) | `python310Packages.plaid-python: 9.3.0 -> 9.4.0`                                     |
| [`1354ca92`](https://github.com/NixOS/nixpkgs/commit/1354ca9264866ae22b4c5401c13111a440ecfdfd) | `python3Packages.calmjs-parse: 1.2.5 -> 1.3.0`                                       |
| [`d4116367`](https://github.com/NixOS/nixpkgs/commit/d4116367bd1446f5e74f8d1f5ca00c6eb3e9e200) | `python310Packages.trimesh: 3.12.0 -> 3.12.3`                                        |
| [`62c52708`](https://github.com/NixOS/nixpkgs/commit/62c52708d2517fbad7f37c525f469924b565c7af) | `python310Packages.google-cloud-datastore: 2.5.1 -> 2.6.0`                           |
| [`075a9d36`](https://github.com/NixOS/nixpkgs/commit/075a9d361c251194160afd135ea6ad657dd5b376) | `python310Packages.pynetgear: 0.10.0 -> 0.10.1`                                      |
| [`4c60f14b`](https://github.com/NixOS/nixpkgs/commit/4c60f14b145dfe69c1f16715b987610ef46484e9) | `python310Packages.peaqevcore: 0.0.24 -> 0.1.1`                                      |
| [`8b974a11`](https://github.com/NixOS/nixpkgs/commit/8b974a1132d883e8d0764739fd70077efc452a53) | `python310Packages.pycfmodel: 0.19.1 -> 0.20.0`                                      |
| [`dabc1c5a`](https://github.com/NixOS/nixpkgs/commit/dabc1c5a1ea5c6ef229500daa83825a6709e5f3b) | `lima: 0.10.0 -> 0.11.0`                                                             |
| [`f95356f4`](https://github.com/NixOS/nixpkgs/commit/f95356f44eebb7b2dd64a2a2e661921ea1eeb008) | `python310Packages.periodictable: 1.6.0 -> 1.6.1`                                    |
| [`e74068c2`](https://github.com/NixOS/nixpkgs/commit/e74068c2f3942bbb83b56ef92d5c06e588289cab) | `python310Packages.google-cloud-speech: 2.13.1 -> 2.14.0`                            |
| [`fec6cf1c`](https://github.com/NixOS/nixpkgs/commit/fec6cf1cb127539afc52fd48de6f1007b91eb103) | `python310Packages.types-requests: 2.27.26 -> 2.27.27`                               |
| [`3211982d`](https://github.com/NixOS/nixpkgs/commit/3211982dedbd2b06eb1a58c20259531c22f6d94f) | `babeld: 1.12 -> 1.12.1`                                                             |
| [`8d83675c`](https://github.com/NixOS/nixpkgs/commit/8d83675c0674f25455740e3af7d436cb59f08cb3) | `babeld: 1.11 -> 1.12`                                                               |
| [`a4ebcee8`](https://github.com/NixOS/nixpkgs/commit/a4ebcee81e196b5bfe987dbcfaf9882c195ecc12) | `tilemaker: init at 2.2.0`                                                           |
| [`d8d447f9`](https://github.com/NixOS/nixpkgs/commit/d8d447f9a89fb6d63b7d3c7c3b977209520f0405) | `haskellPackages.sensei: fix build`                                                  |
| [`5e3d09b3`](https://github.com/NixOS/nixpkgs/commit/5e3d09b3b0b488b574b2122817153770098b861a) | `tinygo: 0.16.0 -> 0.23.0`                                                           |
| [`6cdf90a2`](https://github.com/NixOS/nixpkgs/commit/6cdf90a219dbca46f75bf74bfdfc01bf998acbd5) | `thunderbird: use buildMozillaMach top-level builder`                                |
| [`318fae87`](https://github.com/NixOS/nixpkgs/commit/318fae87c0b61eb2eabe6d96b5824cc6e282c513) | `buildMozillaMach: Add distribution identifier and distribution.ini`                 |
| [`e2f8d2eb`](https://github.com/NixOS/nixpkgs/commit/e2f8d2ebb0b4d156d12565fc6320382573e92ad4) | `haskell.packages.ghc922.hls-ormolu-plugin: jailbreak`                               |
| [`e7ae976b`](https://github.com/NixOS/nixpkgs/commit/e7ae976b6f5d6275cbdbf102a02e8054192ff1c0) | `nghttp3: 0.4.0 -> 0.4.1`                                                            |
| [`10fbc4fd`](https://github.com/NixOS/nixpkgs/commit/10fbc4fdc6bcd776c961b512a45051305aaa8138) | `ngtcp2: 0.4.0 -> 0.5.0`                                                             |
| [`2e333f7d`](https://github.com/NixOS/nixpkgs/commit/2e333f7d8313e4974d9108057544356c2e890334) | `deltachat-cursed: remove superfluous dependencies`                                  |
| [`b91c1d9d`](https://github.com/NixOS/nixpkgs/commit/b91c1d9d523ed57bc785e0780251b4158985634c) | `libdeltachat: 1.80.0 -> 1.82.0`                                                     |
| [`6c09d5de`](https://github.com/NixOS/nixpkgs/commit/6c09d5de9388a3820e4c681af40c4ed7745d4c6f) | `quictls: 3.0.1+quick_unstable-2021-12.14 -> 3.0.3+quick_unstable-2022-05.04`        |
| [`02a28055`](https://github.com/NixOS/nixpkgs/commit/02a280555695a84ca10676e4adb5ed9154745db8) | `maintainers: update kittywitch's name, email and keys`                              |
| [`f6359e83`](https://github.com/NixOS/nixpkgs/commit/f6359e83f0c56781de22adab136d770f61fc2072) | `python3Packages.gcal-sync: 0.8.0 -> 0.8.1`                                          |
| [`bb2d65d1`](https://github.com/NixOS/nixpkgs/commit/bb2d65d1422f4f5f480fc9a6ed51d9484abfae10) | `python3Packages.bond-api: 0.1.17 -> 0.1.18`                                         |
| [`aa96ef34`](https://github.com/NixOS/nixpkgs/commit/aa96ef34f4746ac7e6e7e87685987c55bdb3f944) | `calligra: fix build with poppler 22.04`                                             |
| [`b8255c19`](https://github.com/NixOS/nixpkgs/commit/b8255c192ecc39ac88d12993c439bcec231739aa) | `python310Packages.djangorestframework-dataclasses: init at 1.1.1`                   |
| [`d93a5877`](https://github.com/NixOS/nixpkgs/commit/d93a587732a895dba779e225128106ab2424aad2) | `rt-tests: init at 2.3 (#172330)`                                                    |
| [`21ce40f7`](https://github.com/NixOS/nixpkgs/commit/21ce40f7a40f6e8b61c6f7e3211c57b1219770d7) | `perlPackages.Sereal: drop TestMemoryGrowth dependency`                              |
| [`89190d67`](https://github.com/NixOS/nixpkgs/commit/89190d67fdde06b8f69c8f53a77b3a49e91a55cf) | `waypoint: 0.8.1 -> 0.8.2`                                                           |
| [`065085b3`](https://github.com/NixOS/nixpkgs/commit/065085b340637fe4433c83dc4e055083867826df) | `rl-2205: mention changes to the xmonad haskell module`                              |
| [`34a1ff28`](https://github.com/NixOS/nixpkgs/commit/34a1ff28e0e5e914a9111b6e44e5f1c17935be51) | `nixos/xmonad: adjust example to reflect v0.17.0 update of xmonad`                   |
| [`f227fb7b`](https://github.com/NixOS/nixpkgs/commit/f227fb7b605cf5321e61a12ea0c4fa9749562421) | `python310Packages.dulwich: 0.20.39 -> 0.20.40`                                      |
| [`cfd919e7`](https://github.com/NixOS/nixpkgs/commit/cfd919e70ca3361b2b0c71f2672a70c95d252b68) | `python310Packages.dulwich: 0.20.38 -> 0.20.39`                                      |
| [`1920be67`](https://github.com/NixOS/nixpkgs/commit/1920be67a75a9067f1e86120e5551dc0a65fb9b7) | `zoneminder: 1.36.10 -> 1.36.15`                                                     |
| [`82273adf`](https://github.com/NixOS/nixpkgs/commit/82273adfcd53a9f3ba5401ae642a6b11c5ffa065) | `linux/hardened/patches/5.4: 5.4.193-hardened1 -> 5.4.195-hardened1`                 |
| [`5c957108`](https://github.com/NixOS/nixpkgs/commit/5c9571087e7ec83d9bf6f30b0a1c98417dec5843) | `linux/hardened/patches/5.17: 5.17.7-hardened1 -> 5.17.9-hardened1`                  |
| [`7f512f71`](https://github.com/NixOS/nixpkgs/commit/7f512f715339d6a197d3b093d09f10e0eafa0da8) | `linux/hardened/patches/5.15: 5.15.39-hardened1 -> 5.15.41-hardened1`                |
| [`240e2247`](https://github.com/NixOS/nixpkgs/commit/240e2247834fbd3188ed0be96f50b0826187a55f) | `linux/hardened/patches/5.10: 5.10.115-hardened1 -> 5.10.117-hardened1`              |
| [`28a954ca`](https://github.com/NixOS/nixpkgs/commit/28a954cabf6a9d9b52776cb977653fe9f8cb0133) | `linux/hardened/patches/4.19: 4.19.242-hardened1 -> 4.19.244-hardened1`              |
| [`eea0f099`](https://github.com/NixOS/nixpkgs/commit/eea0f09983cfa986de0d8e057e5c55db5b021793) | `linux/hardened/patches/4.14: 4.14.278-hardened1 -> 4.14.280-hardened1`              |
| [`3edcbfce`](https://github.com/NixOS/nixpkgs/commit/3edcbfce898010ded1b2a97fca2a699d21952e68) | `linux_latest-libre: 18713 -> 18738`                                                 |
| [`1f98b560`](https://github.com/NixOS/nixpkgs/commit/1f98b560c8ffec12d100ae1e7c498eeda6eb0e26) | `linux-rt_5_4: 5.4.188-rt73 -> 5.4.193-rt74`                                         |
| [`c49791b3`](https://github.com/NixOS/nixpkgs/commit/c49791b3261b94a72b0e0b87a42822452d8f0bf9) | `linux-rt_5_10: 5.10.109-rt65 -> 5.10.115-rt67`                                      |
| [`d56829b5`](https://github.com/NixOS/nixpkgs/commit/d56829b5febff16f60880244b6a6e9244769c2fa) | `linux: 5.4.193 -> 5.4.195`                                                          |
| [`cfb71b71`](https://github.com/NixOS/nixpkgs/commit/cfb71b715e561785c8178b9ce2d2fdcbed63cdaf) | `linux: 5.17.7 -> 5.17.9`                                                            |
| [`8935b4d5`](https://github.com/NixOS/nixpkgs/commit/8935b4d5334c1c43793f7137c22664edfcf6ee9d) | `linux: 5.15.39 -> 5.15.41`                                                          |
| [`1b81fcd6`](https://github.com/NixOS/nixpkgs/commit/1b81fcd6780ea47873512dc97c488a1a0a2b264d) | `linux: 5.10.115 -> 5.10.117`                                                        |
| [`4072349a`](https://github.com/NixOS/nixpkgs/commit/4072349a31d8fbdc1bad9c0fe78021f14e235d88) | `linux: 4.9.313 -> 4.9.315`                                                          |
| [`a7d95e31`](https://github.com/NixOS/nixpkgs/commit/a7d95e31bc4fae38dd12e16ccb17313f046a8d00) | `linux: 4.19.242 -> 4.19.244`                                                        |
| [`3431806d`](https://github.com/NixOS/nixpkgs/commit/3431806dfa89c6bc26230e3519c40b8db190ad95) | `linux: 4.14.278 -> 4.14.280`                                                        |
| [`01353ba2`](https://github.com/NixOS/nixpkgs/commit/01353ba28a62319ee56f4ac719bd4c514948e7a6) | `add -std=c++14 to CXXFLAGS`                                                         |
| [`27bfb7cf`](https://github.com/NixOS/nixpkgs/commit/27bfb7cfb90fd349e68cb785693d5985f29beed3) | `alejandra: 1.2.0 -> 1.4.0`                                                          |
| [`e6d2c2d2`](https://github.com/NixOS/nixpkgs/commit/e6d2c2d2f9ef2951c656479b3a80f5fdd2324093) | `heisenbridge: 1.12.0 -> 1.13.0`                                                     |
| [`5953a2f9`](https://github.com/NixOS/nixpkgs/commit/5953a2f9abd69d1c27ef4afe45036c5dd1dfc418) | `ddrutility: add -fcommon workaround`                                                |
| [`8d1019e8`](https://github.com/NixOS/nixpkgs/commit/8d1019e80a517169de72cf9d169ec9070a8226bc) | `python310Packages.scikit-build: 0.14.1 -> 0.15.0`                                   |
| [`ab9bd1e2`](https://github.com/NixOS/nixpkgs/commit/ab9bd1e209f098af250aa354cea71344c06eae17) | `cde: add -fcommon workaround`                                                       |
| [`fc8976aa`](https://github.com/NixOS/nixpkgs/commit/fc8976aa7800b64bf69e1448ca506f8f19ff7c74) | `arsenal: 1.0.2 -> 1.1.0`                                                            |
| [`7470efb0`](https://github.com/NixOS/nixpkgs/commit/7470efb0d391cb8f5d4a7800c3f63e63f410cf31) | `ccl: pull upstream fix for -fno-common`                                             |
| [`02e1ddd1`](https://github.com/NixOS/nixpkgs/commit/02e1ddd11c3c645977e74549b7b5ba5f0c40c7ed) | `python310Packages.pyfzf: init at 0.3.1`                                             |
| [`b9fcbcb5`](https://github.com/NixOS/nixpkgs/commit/b9fcbcb596ccad6ec8f9fc9067b37c8e7eb74614) | `btar: add -fcommon workaround`                                                      |
| [`5d372d74`](https://github.com/NixOS/nixpkgs/commit/5d372d74c6ae325d433bcd3da611e86801b20bda) | `bristol: add -fcommon workaround`                                                   |
| [`3f00d294`](https://github.com/NixOS/nixpkgs/commit/3f00d294568effb1117614e7ddb14dea5246c102) | `exploitdb: 2022-05-13 -> 2022-05-18`                                                |