### PR TITLE
chore(flake/nixpkgs): `98bcd08c` -> `c11d9597`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1653086549,
-        "narHash": "sha256-9Gt55P+hh70m/vx0zS5iJrMFrU4Rf0uO+nG9NFxTW1U=",
+        "lastModified": 1653315696,
+        "narHash": "sha256-7tLCnzCz/fq86NEoF9+g/NkQRA2J+nkgytc7l2HuWnY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "98bcd08cb1778d103bac1149621b3568014aadbd",
+        "rev": "c11d9597c1b3cdc4fb44cbab48deec2cfbaa5281",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`6436bdeb`](https://github.com/NixOS/nixpkgs/commit/6436bdeb7f4f74264c17a92457e1ebc8ca6fbe43) | `gcc: add langD support to gcc 10`                                                                |
| [`7b5bd9f7`](https://github.com/NixOS/nixpkgs/commit/7b5bd9f71926d2a8c85ddaa3f78b872f71d2ac57) | `linuxPackages.apfs: add patch for Linux 5.18`                                                    |
| [`0795cb72`](https://github.com/NixOS/nixpkgs/commit/0795cb72d313d15c1721bbd633fbf550961dc77e) | `linuxPackages.zenpower: clarify license`                                                         |
| [`c5bfda47`](https://github.com/NixOS/nixpkgs/commit/c5bfda47e760cd9b091d2c7d9d09db16c470f7fc) | `linuxPackages.zenpower: 0.1.13 -> unstable-2022-04-13`                                           |
| [`fa2393f0`](https://github.com/NixOS/nixpkgs/commit/fa2393f03111219bf855ca325ac486ad971103bc) | `pulumi: update updater`                                                                          |
| [`d17f9fbc`](https://github.com/NixOS/nixpkgs/commit/d17f9fbc86c9aae6a11cb1c693a9d1477c22699a) | `maintainers: init snpschaaf`                                                                     |
| [`3d162497`](https://github.com/NixOS/nixpkgs/commit/3d162497370cae2a8dd62eb644a81d6630b0cf71) | `python3Packages.mkdocs-drawio-exporter: init at 0.8.0`                                           |
| [`26e7906a`](https://github.com/NixOS/nixpkgs/commit/26e7906a969db1b2e44ca9125b985ca38c039597) | `ocamlPackages.hacl_x25519: 0.2.0 -> 0.2.2`                                                       |
| [`ad81f8db`](https://github.com/NixOS/nixpkgs/commit/ad81f8dbeff52b2746c1859a879e09e3c7f4c02c) | `ocamlPackages.faraday: 0.7.2 -> 0.8.1`                                                           |
| [`ba114c44`](https://github.com/NixOS/nixpkgs/commit/ba114c44650d42f10cec28080c1de96866342b65) | `box64: init at 0.1.8`                                                                            |
| [`572ff94f`](https://github.com/NixOS/nixpkgs/commit/572ff94f55b8dc9ee230212df72c2d40beefc73e) | `nixos/users-group: make homeMode respect is_dry and create home directly with right permissions` |
| [`5463b86d`](https://github.com/NixOS/nixpkgs/commit/5463b86d03d456c1d2496a09c6e9f82c9bd66c87) | `nixos/users: Fix typo`                                                                           |
| [`c67d1d87`](https://github.com/NixOS/nixpkgs/commit/c67d1d875264e43a1ddf2d29e2152d335cca8c58) | `terraform-providers: update 2022-05-23`                                                          |
| [`aab6863d`](https://github.com/NixOS/nixpkgs/commit/aab6863dde3bfb47a0fe161d1c2efcf5a50791c8) | `python310Packages.pywemo: 0.8.0 -> 0.8.1`                                                        |
| [`93fe6c89`](https://github.com/NixOS/nixpkgs/commit/93fe6c89c87ceb1aed4454d5dbd227f13bf5e281) | `isync: set mainProgram`                                                                          |
| [`2c4171ca`](https://github.com/NixOS/nixpkgs/commit/2c4171ca838f1edc20ecb3cb2232998479cc4f07) | `abcmidi: 2022.05.05 -> 2022.05.20 (#173912)`                                                     |
| [`e5caa559`](https://github.com/NixOS/nixpkgs/commit/e5caa559c41a0b23c0fcdf16bcdf9f84c5c7e83f) | `mesa: Add support for building the Zink driver`                                                  |
| [`bf139d83`](https://github.com/NixOS/nixpkgs/commit/bf139d83eca3ef5442aa875458193d44ddf9dc6c) | `systems: support cross-compiling for Renesas RX microcontrollers (#173858)`                      |
| [`644d8ed0`](https://github.com/NixOS/nixpkgs/commit/644d8ed029f742c0ad428f90f7cbeee483e002c2) | `notepad-next: mark as broken for aarch64`                                                        |
| [`b6750072`](https://github.com/NixOS/nixpkgs/commit/b67500724f05d5ee4c05eaa9c1a068e21d8bbfe3) | `nixosTests.mysql-backup: fix`                                                                    |
| [`f01320c2`](https://github.com/NixOS/nixpkgs/commit/f01320c21335bf2e240ce3b75e94ac33dfcb7fbd) | `openambit: pull upstream fix for -fno-common toolchains`                                         |
| [`d9aa9aa4`](https://github.com/NixOS/nixpkgs/commit/d9aa9aa45c44d7c18bc5a7eb747d99e5e6533f0f) | `python3Packages.airtouch4pyapi: make compatible with Home Assistant`                             |
| [`7c00f54a`](https://github.com/NixOS/nixpkgs/commit/7c00f54ab65b4b1984b11513ba62c5d051c7757c) | `python310Packages.beautifultable: disable on older Python releases`                              |
| [`eb8c029c`](https://github.com/NixOS/nixpkgs/commit/eb8c029c9c7c61c4ea3c7b1ee0b6d45b1ad9e282) | `python310Packages.beautifultable: 1.0.1 -> 1.1.0`                                                |
| [`86b4f37f`](https://github.com/NixOS/nixpkgs/commit/86b4f37fcadb442cb33a3ad863768f3f47414830) | `checkov: 2.0.1147 -> 2.0.1153`                                                                   |
| [`1191cec7`](https://github.com/NixOS/nixpkgs/commit/1191cec77b19fbf93bc4dace8fd2eb9f6c7447c5) | `python310Packages.ssh-mitm: 2.0.2 -> 2.0.3`                                                      |
| [`ac191eb2`](https://github.com/NixOS/nixpkgs/commit/ac191eb2d52f09c4667f606494a52960f4c35261) | `roon-bridge: 1.8-918 -> 1.8-943`                                                                 |
| [`87bcdd81`](https://github.com/NixOS/nixpkgs/commit/87bcdd81df312e759a92bd6dbb5b3bdfcdbf233a) | `roon-server: 1.8-935 -> 1.8-943`                                                                 |
| [`1b815c86`](https://github.com/NixOS/nixpkgs/commit/1b815c86c1fd62732c342d5901c9a7b2c0c99579) | `home-assistant: don't run pylint tests`                                                          |
| [`b048539a`](https://github.com/NixOS/nixpkgs/commit/b048539afb23542dd33768604c5935a60a7926ba) | `python3Packages.pamqp: run tests`                                                                |
| [`efd3568e`](https://github.com/NixOS/nixpkgs/commit/efd3568e0269a2d816c81dbca79170b8a4b694ce) | `python3Packages.lektor: does not depend on pytest-pylint`                                        |
| [`e381b640`](https://github.com/NixOS/nixpkgs/commit/e381b64026110f81fd0777bba61619feeb2a0508) | `python3Packages.pytile: does not depend on pylint`                                               |
| [`ab17708c`](https://github.com/NixOS/nixpkgs/commit/ab17708c101647f268918b7ee7e5bc6a087a4f8c) | `python310Packages.python-glanceclient: 3.6.0 -> 4.0.0`                                           |
| [`f1a5ae8f`](https://github.com/NixOS/nixpkgs/commit/f1a5ae8f8d8293df8c920bb6103f8e3e2f22966b) | `deltachat-cursed: 0.3.1 -> 0.4.1`                                                                |
| [`11ba416a`](https://github.com/NixOS/nixpkgs/commit/11ba416a6531786257b5ae1059dddca1928b3f8a) | `python310Packages.pyglet: 1.5.24 -> 1.5.26`                                                      |
| [`d40419c2`](https://github.com/NixOS/nixpkgs/commit/d40419c24194f8a93db21d32828217ced0637ffa) | `chipsec: restrict to x86-only`                                                                   |
| [`d6d211b4`](https://github.com/NixOS/nixpkgs/commit/d6d211b445caf11a88defebf8ad55809c21bf7c8) | `buildCrystalPackage: enableParallelBuilding`                                                     |
| [`254ffa6f`](https://github.com/NixOS/nixpkgs/commit/254ffa6f532d95e16d50aff37ff0a0e07e63dfbe) | `falcon: use gcc10Stdenv`                                                                         |
| [`5b020adc`](https://github.com/NixOS/nixpkgs/commit/5b020adcf61ac51c7381a1bace1326c4c2b27d8f) | `python3Packages.rasterio: fix on darwin`                                                         |
| [`5c26b9f3`](https://github.com/NixOS/nixpkgs/commit/5c26b9f376209360db32b2c1fcff259ac00ea56b) | `oonf-olsrd2: add -fcommon workaround`                                                            |
| [`8875168b`](https://github.com/NixOS/nixpkgs/commit/8875168bb29c4cdd22c9e159d9ae0d8812a8ac32) | `nautilus-open-any-terminal: 0.2.16 -> 0.3.0`                                                     |
| [`f33ccd6e`](https://github.com/NixOS/nixpkgs/commit/f33ccd6ec992c9e6298462ef40c3f376d92250e9) | `nbd: 3.21 -> 3.24`                                                                               |
| [`6e8e1faa`](https://github.com/NixOS/nixpkgs/commit/6e8e1faabeb492f70404c95e33b7d314ae3017e2) | `nixos/tests: add nginx-http3 test`                                                               |
| [`00dab1a9`](https://github.com/NixOS/nixpkgs/commit/00dab1a9a9d075eb0483f0fd444c608d2afa3cd8) | `hammer: e7aa734 -> nightly_20220416`                                                             |
| [`d887e164`](https://github.com/NixOS/nixpkgs/commit/d887e16488c4103031296d15480d82d8b0002cb0) | `pgadmin: set mainProgram`                                                                        |
| [`61e1418f`](https://github.com/NixOS/nixpkgs/commit/61e1418f8affb9616f71d26c14e01824a722bcde) | `sqlx-cli: 0.5.11 -> 0.5.13`                                                                      |
| [`3217850d`](https://github.com/NixOS/nixpkgs/commit/3217850d04784719fc51e2379bf0ab70251f38e3) | `mob: build against newer go version`                                                             |
| [`b7a56be5`](https://github.com/NixOS/nixpkgs/commit/b7a56be5142c252d8708c146ad78c7033b5632e2) | `go_1_16: remove`                                                                                 |
| [`dab5668f`](https://github.com/NixOS/nixpkgs/commit/dab5668f6be905a7f0de39a7d67fd8f78a13d600) | `nomad_1_1: drop`                                                                                 |
| [`235dd723`](https://github.com/NixOS/nixpkgs/commit/235dd7235f80c13e74c2be4d8787c37b1ed13926) | `gvisor: mark as broken`                                                                          |
| [`dedeed74`](https://github.com/NixOS/nixpkgs/commit/dedeed7420218501723f17444f03ae83cf5e94b9) | `flexget: 3.3.10 -> 3.3.11`                                                                       |
| [`272430c8`](https://github.com/NixOS/nixpkgs/commit/272430c82399d0a2f22b51dd0e564a8709ba6782) | `treewide: migrate python packages to optional-dependencies`                                      |
| [`809ffd6c`](https://github.com/NixOS/nixpkgs/commit/809ffd6cd33b0020c6ac0be57bf25f3da4c17d31) | `doc/python: use optional-dependencies instead of extras-require`                                 |
| [`4e7ddc2c`](https://github.com/NixOS/nixpkgs/commit/4e7ddc2c38a0038f5061f43c7b301a5dabf7c615) | `difftastic: patch bundled mimalloc source to build on older macos`                               |
| [`0ec34d4c`](https://github.com/NixOS/nixpkgs/commit/0ec34d4cd172ba2c5e8418b8276879471eb86f1b) | `utahfs: mark as broken`                                                                          |
| [`caa2b2ee`](https://github.com/NixOS/nixpkgs/commit/caa2b2ee685f71f9c4d96de02234c42eb4e9343d) | `goofys: mark as broken`                                                                          |
| [`d0707050`](https://github.com/NixOS/nixpkgs/commit/d07070507c76d766535fa1059e2dcc86051d4edd) | `yajsv: fix build with newer go`                                                                  |
| [`ceebedb1`](https://github.com/NixOS/nixpkgs/commit/ceebedb1dbf3f52c0c932cf7bb907d47455cf4dd) | `sampler: fix build with go 1.17`                                                                 |
| [`07e00947`](https://github.com/NixOS/nixpkgs/commit/07e009474944aed41d3af7a3cdafc420f9272c6e) | `obfs4: 0.0.11 -> 0.0.12`                                                                         |
| [`6a932206`](https://github.com/NixOS/nixpkgs/commit/6a9322064d1ac3da1d2c003ca6eee54f3a6a270d) | `vouch-proxy: disable checkPhase`                                                                 |
| [`fa887469`](https://github.com/NixOS/nixpkgs/commit/fa8874694f28f1f83cb9b29e8dda1e7ca18f58cf) | `mycorrhiza: 1.8.2 -> 1.9.0`                                                                      |
| [`ff95455a`](https://github.com/NixOS/nixpkgs/commit/ff95455ab2a4cca77f70a62bcb82fe54d20161e1) | `textql: 2.0.3 -> unstable-2021-07-06`                                                            |
| [`5c46ce19`](https://github.com/NixOS/nixpkgs/commit/5c46ce199dafce61df441f01f0ed9494f2844827) | `godu: don't pin to go1.16`                                                                       |
| [`8d2436df`](https://github.com/NixOS/nixpkgs/commit/8d2436dfffed8cedbe043bcfb4996143e42bc8b1) | `ipfs-migrator-all-fs-repo-migrations: don't pin to go1.16`                                       |
| [`8da44262`](https://github.com/NixOS/nixpkgs/commit/8da4426222ffeedebebcafaf05d1dbdc455875ee) | `ipfs: don't pin to go1.16`                                                                       |
| [`0ebd5585`](https://github.com/NixOS/nixpkgs/commit/0ebd5585bedb53858bad44c91a1099cfd3c3306f) | `gomobile: don't pin to go 1.16`                                                                  |
| [`1909454e`](https://github.com/NixOS/nixpkgs/commit/1909454e55132ea7055c6977ad12b6fade91cd9f) | `Revert "ncdns: pin to go 1.16"`                                                                  |
| [`394687bf`](https://github.com/NixOS/nixpkgs/commit/394687bf39bb3b166759853d8b257997483415eb) | `neovim-remote: 2.4.0 -> 2.5.1`                                                                   |
| [`d156db7d`](https://github.com/NixOS/nixpkgs/commit/d156db7d1752b48531b91d65db8f9bc91e29c399) | `nixos/gollum: add option 'no-edit'`                                                              |
| [`8e7b82be`](https://github.com/NixOS/nixpkgs/commit/8e7b82be494070c13229612859ac8f1c3260f6b3) | `nixos/gollum: add option 'user-icons'`                                                           |
| [`fa7cae1b`](https://github.com/NixOS/nixpkgs/commit/fa7cae1bcc691cd1f1ae26ab0536fd561b93a56a) | `gollum: update dependencies`                                                                     |
| [`73fff1e6`](https://github.com/NixOS/nixpkgs/commit/73fff1e6631546f6c13790ce9aa514c5e15286a2) | `gollum: add comments in Gemfile`                                                                 |
| [`8a770f06`](https://github.com/NixOS/nixpkgs/commit/8a770f06a20bd5c6d9e311f165d012aed426deac) | `gollum: refactor package`                                                                        |
| [`aa45e2e3`](https://github.com/NixOS/nixpkgs/commit/aa45e2e3ddb6043543027528aedf87bff799a951) | `bitcoin-classic: compile as c++14`                                                               |
| [`382f65bd`](https://github.com/NixOS/nixpkgs/commit/382f65bd306789c08310d2cf0d0660023bdc7bc5) | `geogebra: 5-0-680-0 -> 5-0-706-0`                                                                |
| [`c0163079`](https://github.com/NixOS/nixpkgs/commit/c01630796cd7e59eb8e4eaf537abf1484020e125) | `maintainers: add imsofi`                                                                         |
| [`9fe3cbef`](https://github.com/NixOS/nixpkgs/commit/9fe3cbef528b9dd2deeec773b4ee247ea23f0b84) | `python310Packages.pdm-pep517: 0.12.3 -> 0.12.5`                                                  |
| [`710918b8`](https://github.com/NixOS/nixpkgs/commit/710918b8fe20a087355b4a8a4241d6b9098319bd) | `html-tidy: fix cross-compilation`                                                                |
| [`a85f00e1`](https://github.com/NixOS/nixpkgs/commit/a85f00e1d881fb70db74a08b0bb4c797cb335bdd) | `python310Packages.pyskyqremote: 0.3.11 -> 0.3.12`                                                |
| [`4d6e6a4c`](https://github.com/NixOS/nixpkgs/commit/4d6e6a4c2ca403aa69cd26d3a184a01d93fafb92) | `python3Packages.fontparts: correct changlelog link`                                              |
| [`6e17b694`](https://github.com/NixOS/nixpkgs/commit/6e17b6945c7224b73f21ec0f390120ba3432978d) | `scantailor-advanced: fix build with qt5.15 by switching to a maintained fork`                    |
| [`593dfc4d`](https://github.com/NixOS/nixpkgs/commit/593dfc4d9d276141cdb0fb65d8839733858b4a50) | `wasmtime: 0.36.0 -> 0.37.0`                                                                      |
| [`39773cc0`](https://github.com/NixOS/nixpkgs/commit/39773cc073737663884c9f3568c314ebf35f1739) | `util-linux: make dependencies on pam and libcap optional`                                        |
| [`821724b1`](https://github.com/NixOS/nixpkgs/commit/821724b18494e5e1bac92542f97e06521672a380) | `nixos/gitlab: support 15.x`                                                                      |
| [`1e95faf0`](https://github.com/NixOS/nixpkgs/commit/1e95faf0b8f492416bcba50929a0bd715f3b2ddf) | `gitlab: 14.10.2 -> 15.0.0`                                                                       |
| [`58aae887`](https://github.com/NixOS/nixpkgs/commit/58aae887506864ef0108fedb1bee34716096c6a8) | `mariadb_108: 10.8.2 -> 10.8.3`                                                                   |
| [`0b100ea3`](https://github.com/NixOS/nixpkgs/commit/0b100ea34378e80f4594e68421d736fb429ca790) | `mariadb_107: 10.7.3 -> 10.7.4`                                                                   |
| [`4d0a7e47`](https://github.com/NixOS/nixpkgs/commit/4d0a7e47047c610b4924936ad74d4e3133ac49ce) | `mariadb_106: 10.6.7 -> 10.6.8`                                                                   |
| [`ad225152`](https://github.com/NixOS/nixpkgs/commit/ad2251525f6e4b9dc5892a98235523e22a38cb5d) | `mariadb_105: 10.5.15 -> 10.5.16`                                                                 |
| [`b2e5c3a0`](https://github.com/NixOS/nixpkgs/commit/b2e5c3a0a04b9660b5d5d8c428c4e53d729155cc) | `mariadb_104: 10.4.24 -> 10.4.25`                                                                 |
| [`27530ba8`](https://github.com/NixOS/nixpkgs/commit/27530ba856d1d5bbd064fcf17e1ab6e43ec6aa77) | `nixos/postfix: make postfix-setup RemainAfterExit`                                               |
| [`02da75e7`](https://github.com/NixOS/nixpkgs/commit/02da75e7ae45a9316a9765ad807878aa08d065ba) | `python310Packages.fontparts: 0.10.4 -> 0.10.5`                                                   |
| [`eb270e84`](https://github.com/NixOS/nixpkgs/commit/eb270e849c5e3d2868816e12f4498304f1a23fb6) | `solr: remove maintainer, mark as vulnerable`                                                     |
| [`24241c7d`](https://github.com/NixOS/nixpkgs/commit/24241c7dedf37e4fb0560850849bb1e5cede8adc) | `miranda: add -fcommon workaround`                                                                |
| [`ac7479cd`](https://github.com/NixOS/nixpkgs/commit/ac7479cd2f5ac4e98938871dbb5d4bec2d08c785) | `python310Packages.yappi: releases are now tagged`                                                |
| [`a4850d6e`](https://github.com/NixOS/nixpkgs/commit/a4850d6ea20e2be75b97467ccbe77e412bc99c9b) | `menu-cache: pull patch pending upstream inclusion for -fno-common toolchains`                    |
| [`266e6656`](https://github.com/NixOS/nixpkgs/commit/266e665668dd3599701a6f071b099bf9492e966b) | `ocamlPackages.irmin-watcher: 0.4.1 -> 0.5.0`                                                     |
| [`edfa19a1`](https://github.com/NixOS/nixpkgs/commit/edfa19a15bb44eb2226be3abff241769aae68c4b) | `cloud-hypervisor: 23.0 -> 23.1`                                                                  |
| [`13c8a677`](https://github.com/NixOS/nixpkgs/commit/13c8a6774d92773a68a756aa9df41ff6706bcc38) | `ocamlPackages.ppx_cstubs: 0.6.1.2 -> 0.7.0`                                                      |
| [`2fa955e2`](https://github.com/NixOS/nixpkgs/commit/2fa955e28c513b21d85de2cfe0c9a488857f968f) | `python310Packages.yappi. 1.3.3 -> 1.3.5`                                                         |
| [`18c617fb`](https://github.com/NixOS/nixpkgs/commit/18c617fb3692c5d176ea1579e2adc33a74b39329) | `python310Packages.embrace: disable on older Python releases`                                     |
| [`82c10e4a`](https://github.com/NixOS/nixpkgs/commit/82c10e4a21150f7e6856c1b7e9ad0e1f82044f91) | `gajim: 1.3.3 → 1.4.1`                                                                            |
| [`63de9746`](https://github.com/NixOS/nixpkgs/commit/63de9746fdf99e31d21a013c6a4ad399fadf9b13) | `Revert "git-blame-ignore-revs: fix typo"`                                                        |
| [`44c68b8a`](https://github.com/NixOS/nixpkgs/commit/44c68b8a89a6e183c4c93340b37dce094774d024) | `python310Packages.faraday-plugins: 1.6.5 -> 1.6.6`                                               |
| [`4c7efec3`](https://github.com/NixOS/nixpkgs/commit/4c7efec3b55f98c10b8d840423d51d40a2ec2434) | `gopass: 1.14.1 → 1.14.2`                                                                         |
| [`9c4c9f58`](https://github.com/NixOS/nixpkgs/commit/9c4c9f588477d86ec4b5ae17c681edd469b19495) | `ocamlPackages.gd4o: init at 1.0a5 (#169226)`                                                     |
| [`896efa26`](https://github.com/NixOS/nixpkgs/commit/896efa265c4cde8a78c21af066be38f77ce2a84d) | `clash: 1.10.0 -> 1.10.6`                                                                         |
| [`d397ef00`](https://github.com/NixOS/nixpkgs/commit/d397ef0010303eba110ff3a352f4434104a99536) | `amberol: 0.6.2 - > 0.6.3`                                                                        |
| [`f7e2353e`](https://github.com/NixOS/nixpkgs/commit/f7e2353e0b03be01b22fb1c01d75a459580eed6c) | `neovim: Pass CoreServices when building on darwin`                                               |
| [`0c546254`](https://github.com/NixOS/nixpkgs/commit/0c5462544c38db5b8a11d7ca0b6cdda7e66bae00) | `pretendard: init at 1.3.0`                                                                       |
| [`e63339fc`](https://github.com/NixOS/nixpkgs/commit/e63339fcba5eac7cae128f07d0656ae99c234d4f) | `maintainers: add sudosubin`                                                                      |
| [`33b706ca`](https://github.com/NixOS/nixpkgs/commit/33b706cacbb0853884c5ced021ad2404765e643c) | `python310Packages.jwcrypto: 1.3 -> 1.3.1`                                                        |
| [`fc6b1aa4`](https://github.com/NixOS/nixpkgs/commit/fc6b1aa4a7a8795605ece7544de7d9434388f135) | `python3Packages.greeclimate: 1.1.1 -> 1.2.0`                                                     |
| [`a936b287`](https://github.com/NixOS/nixpkgs/commit/a936b287130954bcaf224a4c915f92e8e21a8e88) | `git-blame-ignore-revs: fix typo`                                                                 |
| [`125b803e`](https://github.com/NixOS/nixpkgs/commit/125b803e446851520a1a866cb6a657b493973673) | `gecode_6: add patch fixing clang build`                                                          |
| [`6e769a6a`](https://github.com/NixOS/nixpkgs/commit/6e769a6a95676683b3b623adf84a87e7b0624b8c) | `libsForQt5.qtspeech: add speechd dependency`                                                     |
| [`519f0b9e`](https://github.com/NixOS/nixpkgs/commit/519f0b9e582a18c4b7e686b39df9c1c565364940) | `zchaff: use clangStdenv`                                                                         |
| [`d3c580bb`](https://github.com/NixOS/nixpkgs/commit/d3c580bb7262e9660e4fe71a9778caa7ad16d832) | `irpf: 2022-1.4 -> 2022-1.5`                                                                      |
| [`4c559160`](https://github.com/NixOS/nixpkgs/commit/4c5591606cf09d33ef8420d16f9b45f6aa572c6a) | `sparrow: init at 1.6.4`                                                                          |
| [`a6aa0853`](https://github.com/NixOS/nixpkgs/commit/a6aa08532c30e3b009988280f25144a4df23d1ff) | `zchaff: init at 2004.5.13`                                                                       |
| [`39f2cce8`](https://github.com/NixOS/nixpkgs/commit/39f2cce8ca14af5767715a7a8807498d232fe761) | `zeronet: mark as vulnerable`                                                                     |
| [`686d1766`](https://github.com/NixOS/nixpkgs/commit/686d1766379a239f6c0779892b55be7ef36c21f1) | `zeronet-conservancy: init at 0.7.5`                                                              |
| [`6bb9d0ce`](https://github.com/NixOS/nixpkgs/commit/6bb9d0ce3ba3b5c051ed9ae5f9e8c828df3749ef) | `nixos/zeronet: fix systemd after`                                                                |
| [`183e3912`](https://github.com/NixOS/nixpkgs/commit/183e3912568d2afca843f46aaae59cf1691ab8ab) | `nixos/zeronet: add package option`                                                               |
| [`5dbf9487`](https://github.com/NixOS/nixpkgs/commit/5dbf948745f3e9390de339d521b7a2fe9ca41b84) | `python310Packages.ssh-mitm: 2.0.1 -> 2.0.2`                                                      |
| [`31ec3a01`](https://github.com/NixOS/nixpkgs/commit/31ec3a01a1cc8378b53eee007f9d0e15180b08db) | `tfsec: 1.21.1 -> 1.21.2`                                                                         |