### PR TITLE
chore(flake/nixpkgs): `c11d9597` -> `a701e4ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1653315696,
-        "narHash": "sha256-7tLCnzCz/fq86NEoF9+g/NkQRA2J+nkgytc7l2HuWnY=",
+        "lastModified": 1653576718,
+        "narHash": "sha256-Cpf0WXU8wYxjzv7v5s+M2XyDGW+vVgPVjcIBga5uxMo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c11d9597c1b3cdc4fb44cbab48deec2cfbaa5281",
+        "rev": "a701e4adbca77736346445a8f5ff930bf4db1b5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                  |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`de21e357`](https://github.com/NixOS/nixpkgs/commit/de21e3579b934d75bf446f28436dd8434a663ff4) | `redpanda: 21.11.15 -> 22.1.3; fix linux build`                                 |
| [`1557e0a3`](https://github.com/NixOS/nixpkgs/commit/1557e0a3e4e5b10339dfc07110c720a6436bcf75) | `asuka: 0.8.3 -> 0.8.5`                                                         |
| [`f92a357c`](https://github.com/NixOS/nixpkgs/commit/f92a357cb194a8692fca7185611f07dc41e11fbe) | `fselect: 0.8.0 -> 0.8.1`                                                       |
| [`eb7b907d`](https://github.com/NixOS/nixpkgs/commit/eb7b907d6e4f0b84cbf47db026b6ea668437c665) | `dprint: 0.28.0 -> 0.29.1`                                                      |
| [`14b3f6f5`](https://github.com/NixOS/nixpkgs/commit/14b3f6f5c6dd167cd50d4c5c288431b402b73a7e) | `choose: 1.3.3 -> 1.3.4`                                                        |
| [`84bb2b1c`](https://github.com/NixOS/nixpkgs/commit/84bb2b1cb50fed54519de57b06ef31a315629821) | `cargo-insta: 1.13.0 -> 1.14.0`                                                 |
| [`8445bf5f`](https://github.com/NixOS/nixpkgs/commit/8445bf5f63a4e814128a565e52856bd5d550b5c2) | `fish: split doc`                                                               |
| [`03ee1bb5`](https://github.com/NixOS/nixpkgs/commit/03ee1bb584f43da8cf40a0211d69d7934c0667b6) | `exploitdb: 2022-05-18 -> 2022-05-26`                                           |
| [`17b7fbf7`](https://github.com/NixOS/nixpkgs/commit/17b7fbf7e69e5c4f7e05db801671e88c731c15b3) | `syft: 0.46.2 -> 0.46.3`                                                        |
| [`ec5c98e9`](https://github.com/NixOS/nixpkgs/commit/ec5c98e943162e4b96e6016c79150be51b6f9508) | `vscode-extensions.rust-lang-rust-analyzer: update publisher`                   |
| [`f81c763c`](https://github.com/NixOS/nixpkgs/commit/f81c763c1de3fc0d2f746b82891684e3c08c919a) | `nixos/appvm: init at unstable-2021-12-20`                                      |
| [`87d9910c`](https://github.com/NixOS/nixpkgs/commit/87d9910cefec95a47f2fac7f0b7db89c8f69c4b9) | `gleam: 0.20.1 -> 0.21.0`                                                       |
| [`2675b0e2`](https://github.com/NixOS/nixpkgs/commit/2675b0e23de175d523e94cfcb765d36e6dab2cdf) | `python39Packages.numpyro: remove whitespace`                                   |
| [`71c69919`](https://github.com/NixOS/nixpkgs/commit/71c69919a0165df2fd336bdf15efc361d92a634c) | `tridactyl-native: init new Nim rewrite at 0.3.6`                               |
| [`92e2e3b3`](https://github.com/NixOS/nixpkgs/commit/92e2e3b3f414bb421240b98145eb65089b637bbe) | `breitbandmessung: don't use bundled electron`                                  |
| [`e55dfef9`](https://github.com/NixOS/nixpkgs/commit/e55dfef9205997a60d44487dd9ed14206011ab16) | `python310Packages.pymc3: 3.11.5 -> unstable-2022-05-23`                        |
| [`27d3429a`](https://github.com/NixOS/nixpkgs/commit/27d3429a3f7c272f8d784a52c66e46aa3dcc491d) | `python3Packages.pyfronius: add patch for python310 compat`                     |
| [`df64a670`](https://github.com/NixOS/nixpkgs/commit/df64a670aef586b7207bc59afefc27fd4d390d44) | `python3Packages.sentry-sdk: stop testing integrations`                         |
| [`9c295d34`](https://github.com/NixOS/nixpkgs/commit/9c295d34e17acb4b43a9bff6f427b6347db8a418) | `python3Packages.lomond: disable tornado_4 tests on python3.10`                 |
| [`21de8883`](https://github.com/NixOS/nixpkgs/commit/21de888352eb79b819c701c051a20ceecf9adacb) | `mariadb/texlive: Lowercase nixos.org`                                          |
| [`97b7f3bc`](https://github.com/NixOS/nixpkgs/commit/97b7f3bc1ad168e5a7bf36efd0e6a1c1e8ca05c4) | `python39Packages.arviz: refactor`                                              |
| [`ef8ab484`](https://github.com/NixOS/nixpkgs/commit/ef8ab484ac78b0efe92f73b0bd2de5e2d53fc0bb) | `python3Packages.weconnect: 0.40.0 -> 0.41.0`                                   |
| [`3b76ec3d`](https://github.com/NixOS/nixpkgs/commit/3b76ec3d7d6ba6eb4f215fbf7a7a9c79303c3c5e) | `python310Packages.weconnect-mqtt: update dependency constraint`                |
| [`df81c464`](https://github.com/NixOS/nixpkgs/commit/df81c4642da41a97a0cf32da08168bf44de154f7) | `python310Packages.sphinxcontrib-spelling: 7.3.3 -> 7.4.0`                      |
| [`e16e360a`](https://github.com/NixOS/nixpkgs/commit/e16e360a90aa375b3e6746bce19c69a95490c4c9) | `trivy: 0.28.0 -> 0.28.1`                                                       |
| [`b3fe9c32`](https://github.com/NixOS/nixpkgs/commit/b3fe9c32f8f92e63889e52f188c07b7b14004ed9) | `ber_metaocaml: n107 -> n111`                                                   |
| [`76405e30`](https://github.com/NixOS/nixpkgs/commit/76405e3077eaf84e33fb61e11292d859fa1d0d9c) | `compressFirmwareXz: fix with empty lib/firmware`                               |
| [`4307907d`](https://github.com/NixOS/nixpkgs/commit/4307907d725fce04207f7f092d43c7481e3f7ec0) | `python39Packages.pdfminer-six: add alias to pdfminer`                          |
| [`dc50a81c`](https://github.com/NixOS/nixpkgs/commit/dc50a81c79e85281b5e72d541e99aa7f1844f408) | `python39Packages.pdfminer: 20220506 -> 20220524`                               |
| [`68f5159e`](https://github.com/NixOS/nixpkgs/commit/68f5159e308deeea3da8ee060d8b1af7941ccf16) | `python39Packages.numpyro: init at 0.9.2`                                       |
| [`65adaf2c`](https://github.com/NixOS/nixpkgs/commit/65adaf2c68ddbbd8104050ee575fb1bb57d1363a) | `telegraf: 1.22.1 -> 1.22.4`                                                    |
| [`dae03289`](https://github.com/NixOS/nixpkgs/commit/dae03289beda7beba9f698c48b25dc945a65fb8f) | `go-task: 3.12.0 -> 3.12.1`                                                     |
| [`83433a10`](https://github.com/NixOS/nixpkgs/commit/83433a101fdd2d9df061bea80df07682e2fee481) | `flexget: 3.3.13 -> 3.3.14`                                                     |
| [`9687b5e6`](https://github.com/NixOS/nixpkgs/commit/9687b5e62e9179467a49fbfcc7a6517bcc2649ca) | `packwiz: init`                                                                 |
| [`59d8283b`](https://github.com/NixOS/nixpkgs/commit/59d8283b1c5aa9435255abf10cb8fd782061389d) | `ferm: 2.6 -> 2.7`                                                              |
| [`c46512f2`](https://github.com/NixOS/nixpkgs/commit/c46512f20c6274dd7e156f6632c41daf13fa33ed) | `python310Packages.trimesh: 3.12.3 -> 3.12.4`                                   |
| [`fcdfeb70`](https://github.com/NixOS/nixpkgs/commit/fcdfeb70f0e505b4fc51bf99bf29215156989514) | `fcitx5-table-other: 5.0.8 -> 5.0.9`                                            |
| [`027ad63b`](https://github.com/NixOS/nixpkgs/commit/027ad63b0cf1250683cab1caeaa044c305d20d3e) | `python310Packages.hahomematic: 1.5.3 -> 1.5.4`                                 |
| [`5e1c5afd`](https://github.com/NixOS/nixpkgs/commit/5e1c5afd9445bf67bc841cfb9ac0e5ea076b7abb) | `fcitx5-m17n: 5.0.8 -> 5.0.9`                                                   |
| [`5266b39e`](https://github.com/NixOS/nixpkgs/commit/5266b39e8a33844e4ca699ec73a6c6d42f79da2a) | `esbuild: 0.14.38 -> 0.14.39`                                                   |
| [`d86133f2`](https://github.com/NixOS/nixpkgs/commit/d86133f2e096ce27710388ef7b1808f514b72dc1) | `ffuf: 1.4.1 -> 1.5.0`                                                          |
| [`711c980c`](https://github.com/NixOS/nixpkgs/commit/711c980c11cb2f96f08bea82bbf4a2825daffe1a) | `fcitx5-table-extra: 5.0.9 -> 5.0.10`                                           |
| [`29777bb0`](https://github.com/NixOS/nixpkgs/commit/29777bb048a72132def87e5aa42b82d5522cea98) | `metersLv2: 0.9.10 -> 0.9.20`                                                   |
| [`357ed682`](https://github.com/NixOS/nixpkgs/commit/357ed68213b459856795e8852821abc6ede6aee5) | `python310Packages.pygit2: add missing input`                                   |
| [`a6d35e3b`](https://github.com/NixOS/nixpkgs/commit/a6d35e3b7c99ad1baf84c4cb1d9f0e9b18a5b8b6) | `python310Packages.pygit2: disable on older Python releases`                    |
| [`6226fc5c`](https://github.com/NixOS/nixpkgs/commit/6226fc5cf05b14c81517a1ea7119564efcdfb9b9) | `ungoogled-chromium: 101.0.4951.64 -> 102.0.5005.61`                            |
| [`9b103fac`](https://github.com/NixOS/nixpkgs/commit/9b103fac08e1cd89e5699bf9a2b4b137369ade9c) | `elinks: disable perl support on darwin`                                        |
| [`863ecea7`](https://github.com/NixOS/nixpkgs/commit/863ecea7083c117cc23ca9836169a8f509151525) | `gdu: 5.13.2 -> 5.14.0`                                                         |
| [`c408f01b`](https://github.com/NixOS/nixpkgs/commit/c408f01b6949b7b00e5799060c6195f460573ddc) | `gh: 2.11.2 -> 2.11.3`                                                          |
| [`54415600`](https://github.com/NixOS/nixpkgs/commit/5441560049e92d465e43786f700657351849193d) | `fetchmail: 6.4.27 -> 6.4.30`                                                   |
| [`61cef85d`](https://github.com/NixOS/nixpkgs/commit/61cef85d71c2f1741949dcdb9785f3bff6b9bf5e) | `evtest: 1.34 -> 1.35`                                                          |
| [`e9c36e2d`](https://github.com/NixOS/nixpkgs/commit/e9c36e2d767018dab98db4a864edb9f9d220fbef) | `coredns: fix tests on darwin`                                                  |
| [`4be2ce0d`](https://github.com/NixOS/nixpkgs/commit/4be2ce0d4d349a33639d6a21b70df0c50cf102eb) | `sov: init as 0.71 (#174492)`                                                   |
| [`8d9afe3d`](https://github.com/NixOS/nixpkgs/commit/8d9afe3d3bd3d794eef473fb0a3e62d198551ead) | `doc: rework notable changes`                                                   |
| [`8a8c0df8`](https://github.com/NixOS/nixpkgs/commit/8a8c0df898afebd9e1c75651137027eab5913cfd) | `flat-remix-gtk: 20220412 -> 20220427`                                          |
| [`1e2fcc63`](https://github.com/NixOS/nixpkgs/commit/1e2fcc635f5c7814d59e1d36c6053288a1015e76) | `python310Packages.pot: 0.8.1.0 -> 0.8.2`                                       |
| [`a7f10476`](https://github.com/NixOS/nixpkgs/commit/a7f104763d978514f7a32a974a4dd558f56a6279) | `python39Packages.xarray-einstats: init at 0.2.2`                               |
| [`8fe16d15`](https://github.com/NixOS/nixpkgs/commit/8fe16d153afb5eca7d39b5dc991e9c1ff6d49b45) | `linuxPackages.rtw88: 2021-04-19 to 2022-05-08, removed broken mark. (#174222)` |
| [`9da2f480`](https://github.com/NixOS/nixpkgs/commit/9da2f48064b6d5a454698fcb51fb89537e256658) | `python310Packages.pyro-ppl: move extras dependencies`                          |
| [`be3b5867`](https://github.com/NixOS/nixpkgs/commit/be3b5867934fdd616ebf03d8d92dbdfc2fa709cd) | `buildkite-cli: fix shebangs (#173311)`                                         |
| [`da9a0f0f`](https://github.com/NixOS/nixpkgs/commit/da9a0f0f1b9182807124c46a55d29c3bdd3f60cd) | `folly: 2022.02.28.00 -> 2022.05.16.00`                                         |
| [`37b04e54`](https://github.com/NixOS/nixpkgs/commit/37b04e54e3dabcb7b27a0cf81ea231bd52c719ce) | `feedbackd: 0.0.0+git20211018 -> 0.0.0+git20220520`                             |
| [`1f3ba910`](https://github.com/NixOS/nixpkgs/commit/1f3ba910b3d8233c4a3f02482eccedb9ac8b1d55) | `fcitx5-lua: 5.0.7 -> 5.0.8`                                                    |
| [`9cbb75f3`](https://github.com/NixOS/nixpkgs/commit/9cbb75f315bce539b6c7acb9190324989bbd004b) | `doc: fix docker/maddy in changelog`                                            |
| [`5936d939`](https://github.com/NixOS/nixpkgs/commit/5936d939cef1a7460706ec8e445a1fb463b8b9dd) | `doc: sort service list`                                                        |
| [`355e97e1`](https://github.com/NixOS/nixpkgs/commit/355e97e1fc1fcec4ecbb77f545e7cbfc679cb31e) | `maintainers: add infinidoge`                                                   |
| [`9ae4a910`](https://github.com/NixOS/nixpkgs/commit/9ae4a910e482c05080f02acae31522ecbf263dda) | `nixos/timetagger: drop non-evaluating service files`                           |
| [`78f5129a`](https://github.com/NixOS/nixpkgs/commit/78f5129aa69355c297d6444511974c855de0208a) | `doc: add missing new services to release-notes`                                |
| [`7275bd17`](https://github.com/NixOS/nixpkgs/commit/7275bd17fd7dee53b37dc28ce3de0b1e35b018e9) | `libqalculate, qalculate-gtk: 4.1.1 -> 4.2.0`                                   |
| [`e004ecff`](https://github.com/NixOS/nixpkgs/commit/e004ecff1c69b2d7a031b0731842333431463b55) | `python310Packages.djangorestframework-recursive: init at 0.1.2`                |
| [`ea1b9689`](https://github.com/NixOS/nixpkgs/commit/ea1b96897565a0b7d04775654b8dabd518441879) | `fcitx5-rime: 5.0.12 -> 5.0.13`                                                 |
| [`96ce7903`](https://github.com/NixOS/nixpkgs/commit/96ce7903e86ce0f0d1d586fc63d2f86ab50cc844) | `python310Packages.dj-rest-auth: init at 2.2.4`                                 |
| [`d1136611`](https://github.com/NixOS/nixpkgs/commit/d113661156581c835df4fe5521ffc64128772f18) | `coqPackages: etc`                                                              |
| [`06fc427d`](https://github.com/NixOS/nixpkgs/commit/06fc427d0d791d723024dc19b80183cc0d2c4e55) | `python310Packages.djangorestframework-camel-case: init at 1.3.0`               |
| [`0b17f1cf`](https://github.com/NixOS/nixpkgs/commit/0b17f1cf02ec5ab75b09339f0cafa91ec3fc65c8) | `python310Packages.django-rest-polymorphic: init at 0.1.9`                      |
| [`0e006cd8`](https://github.com/NixOS/nixpkgs/commit/0e006cd850af4cee9d6f1c223c53d34eccf9bfb5) | `logrotate: 3.19.0 -> 3.20.1`                                                   |
| [`dbed75d1`](https://github.com/NixOS/nixpkgs/commit/dbed75d12d0b78cdc7b486160648839a10ce0317) | `go-camo: remove tests which require network`                                   |
| [`a7702c31`](https://github.com/NixOS/nixpkgs/commit/a7702c3153635a4eef608c01de872119612c0b39) | `python3Packages.pyrogram: 2.0.24 -> 2.0.25`                                    |
| [`ccc69171`](https://github.com/NixOS/nixpkgs/commit/ccc69171b2b495f29063cfbcc5a1ac718b325f5e) | `fcitx5-hangul: 5.0.8 -> 5.0.9`                                                 |
| [`faf5052a`](https://github.com/NixOS/nixpkgs/commit/faf5052a23a0057385b0afbc2815a3995f337bf5) | `clboss: init at 0.12`                                                          |
| [`fecd0b1e`](https://github.com/NixOS/nixpkgs/commit/fecd0b1e0d06d3ad0ec42896e3403288cc9c5ff3) | `ddccontrol-db: 20220216 -> 20220414`                                           |
| [`c571a647`](https://github.com/NixOS/nixpkgs/commit/c571a647c1f868e53fbf01a868906ec72c9aeaa2) | `curl: fix curl-gnutls build on darwin`                                         |
| [`7c51c90b`](https://github.com/NixOS/nixpkgs/commit/7c51c90bb7264c3be6acd78b4d790ad083c68560) | `checkov: 2.0.1160 -> 2.0.1161`                                                 |
| [`f322eee4`](https://github.com/NixOS/nixpkgs/commit/f322eee4c4b60fc6aa12d4ebc3488545474abb2a) | `python310Packages.bc-python-hcl2: 0.3.40 -> 0.3.41`                            |
| [`f21fb944`](https://github.com/NixOS/nixpkgs/commit/f21fb9441f7fdb48fb5ee4463a082d9fda3474c9) | `docker: 20.10.15 -> 20.10.16`                                                  |
| [`15fc26bb`](https://github.com/NixOS/nixpkgs/commit/15fc26bb3e2002e6ad401fd46fc2f99f164df96b) | `slack: 4.25.1 -> 4.26.1 (#174085)`                                             |
| [`0f4803bd`](https://github.com/NixOS/nixpkgs/commit/0f4803bd7096e5839fc44977e61adb198cd51779) | `cpu-x: 4.3.0 -> 4.3.1`                                                         |
| [`df1f9ecd`](https://github.com/NixOS/nixpkgs/commit/df1f9ecd9b83a1a3cb440d771f644f1a88416bc1) | `python3Packages.aiohttp: remove trustme test dependency on aarch64-darwin`     |
| [`ab32ed0c`](https://github.com/NixOS/nixpkgs/commit/ab32ed0caef848bb578d22c41bd382494c8d0efc) | `python310Packages.panel: 0.13.0 -> 0.13.1`                                     |
| [`d3564429`](https://github.com/NixOS/nixpkgs/commit/d3564429d51f8bb822b19066d1addf6af3299afe) | `dump_syms: 1.0.0 -> 1.0.1`                                                     |
| [`da43dc7d`](https://github.com/NixOS/nixpkgs/commit/da43dc7d1ffd567cfeb9bcffe792b01c1ae55da3) | `dgoss: 0.3.16 -> 0.3.18`                                                       |
| [`5e880240`](https://github.com/NixOS/nixpkgs/commit/5e880240cddf43a67012b8331bfcd2d3a784b1a4) | `picard: 2.7.3 -> 2.8`                                                          |
| [`3bb35474`](https://github.com/NixOS/nixpkgs/commit/3bb35474b69085e10886a399d53434f9b9a97ce6) | `transmission-remote-gtk: 1.4.1 -> 1.5.1`                                       |
| [`035a5226`](https://github.com/NixOS/nixpkgs/commit/035a5226701d744ea70695c2214fcde30759a638) | `dapr-cli: 1.7.0 -> 1.7.1`                                                      |
| [`6ce10976`](https://github.com/NixOS/nixpkgs/commit/6ce1097662b5b574701a46d934342276a48d99d2) | `unifi7: 7.1.65 -> 7.1.66`                                                      |
| [`2836cfa1`](https://github.com/NixOS/nixpkgs/commit/2836cfa1b14937cbc9eb100ff29b1059942d478c) | `gh: 2.11.1 -> 2.11.2`                                                          |
| [`7d39042a`](https://github.com/NixOS/nixpkgs/commit/7d39042ac24f22960271b9e6b8eb85e441b819f5) | `python310Packages.pygit2: 1.9.1 -> 1.9.2`                                      |
| [`ff7d60fd`](https://github.com/NixOS/nixpkgs/commit/ff7d60fdcfc64347d1d512b3d5efb820ca095121) | `coredns: 1.9.1 -> 1.9.2`                                                       |
| [`40c107a1`](https://github.com/NixOS/nixpkgs/commit/40c107a1b3f8da34271fd2ba090422d39454e4e9) | `goss: 0.3.16 -> 0.3.18`                                                        |
| [`22fabb8e`](https://github.com/NixOS/nixpkgs/commit/22fabb8e1f8aa9bdfbe3abe6d9e3eb73fc5ea256) | `difftastic: 0.27.0 -> 0.28.0`                                                  |
| [`d28ceeff`](https://github.com/NixOS/nixpkgs/commit/d28ceeff90a056663275848c7328be4d1b2d1a20) | `driftctl: 0.30.0 -> 0.31.0`                                                    |
| [`2b22a409`](https://github.com/NixOS/nixpkgs/commit/2b22a409c36807d453fe2b27444441acc5b6833e) | `linuxPackages.netatop: fix build with Linux 5.18`                              |
| [`d28b794e`](https://github.com/NixOS/nixpkgs/commit/d28b794ef09fc7794fb61c0e1cfc140662b41297) | `linuxPackages.pktgen: 21.11.0 -> 22.04.1`                                      |
| [`78cf42b9`](https://github.com/NixOS/nixpkgs/commit/78cf42b90dae40c5525d1b8dd2c004ba9ac124ea) | `cgiserver: init at 1.0.0`                                                      |
| [`dd41452d`](https://github.com/NixOS/nixpkgs/commit/dd41452db472a650a44c20b4ce78aa28b3ad9cc8) | `python310Packages.ansible-compat: 2.0.4 -> 2.1.0`                              |
| [`4c83012f`](https://github.com/NixOS/nixpkgs/commit/4c83012f83eecaa1d052dafe00e903d384e1163d) | `linuxPackages.openafs: mark broken on Linux 5.18`                              |
| [`3aa1b446`](https://github.com/NixOS/nixpkgs/commit/3aa1b44629a80feb98a83c327bc573465b97e59c) | `linuxPackages.vmware: mark broken on Linux 5.18`                               |
| [`bd1aebae`](https://github.com/NixOS/nixpkgs/commit/bd1aebae22e51872669894a30af7c697d200e437) | `linuxPackages.virtualbox: mark broken on Linux 5.18`                           |
| [`3557c0f4`](https://github.com/NixOS/nixpkgs/commit/3557c0f450dd7cf59ffce62541000fd1e41e18ad) | `linuxPackages.rtl88xxau-aircrack: mark broken on Linux 5.18`                   |
| [`651ee5ec`](https://github.com/NixOS/nixpkgs/commit/651ee5ecf53321d849d32fdcad6cc576a72e39c1) | `linuxPackages.rtl8821ce: mark broken on Linux 5.18`                            |
| [`b3f626f6`](https://github.com/NixOS/nixpkgs/commit/b3f626f6a06bc16f35ddd228f713c075b984f0a8) | `linuxPackages.rtl8192eu: mark broken on Linux 5.18`                            |
| [`d156a9ec`](https://github.com/NixOS/nixpkgs/commit/d156a9eca3f2dbd2defb917889c2aaca7941485a) | `linuxPackages.nvidiabl: mark broken on Linux 5.18`                             |
| [`5b5c1f8c`](https://github.com/NixOS/nixpkgs/commit/5b5c1f8cd11efd878111aca815dd2e731b320480) | `linuxPackages.lttng-modules: mark broken on Linux 5.18`                        |
| [`93212d08`](https://github.com/NixOS/nixpkgs/commit/93212d08c796d1b46d4bf3c4565004c8bdbfc4ff) | `linuxPackages.kvmfr: mark broken on Linux 5.18`                                |
| [`d4ee5c65`](https://github.com/NixOS/nixpkgs/commit/d4ee5c657190a02eb71bd8b5262035809d73d28d) | `linuxPackages.kvdo: mark broken on Linux 5.17+`                                |
| [`791ef2e3`](https://github.com/NixOS/nixpkgs/commit/791ef2e3eb4d8f4605cab8316f41b66f29102a2f) | `linuxPackages.intel-speed-select: mark broken on Linux 5.18`                   |
| [`5bf6048f`](https://github.com/NixOS/nixpkgs/commit/5bf6048f372c462bc4b56521ee7aaa7258999597) | `linuxPackages.facetimehd: mark broken on Linux 5.18`                           |
| [`9aa6f61d`](https://github.com/NixOS/nixpkgs/commit/9aa6f61df9a1551e27c245fa9fff402f834fee60) | `linuxPackages.dpdk: mark broken on Linux 5.18`                                 |
| [`fefb777b`](https://github.com/NixOS/nixpkgs/commit/fefb777b3868d51ef2cc20baf44c0d8cad057b9c) | `linuxPackages.dpdk-kmods: mark broken on Linux 5.18`                           |
| [`515938fe`](https://github.com/NixOS/nixpkgs/commit/515938fed67bfb4cd57e51729d1f09f2387fa6b9) | `linuxPackages.dddvb: mark broken on Linux 5.18`                                |
| [`fe564f56`](https://github.com/NixOS/nixpkgs/commit/fe564f56b4311cec381bfb9b1c1c6b3e387aa344) | `linuxPackages.bbswitch: mark broken on Linux 5.18`                             |
| [`3bd018e6`](https://github.com/NixOS/nixpkgs/commit/3bd018e6b00696a35222f4f0ac2635ff693617b5) | `linuxPackages.akvcam: mark broken on Linux 5.18`                               |
| [`76024420`](https://github.com/NixOS/nixpkgs/commit/76024420f236299e6bc02fbafa0c90e66d4eaa8b) | `hwi: 2.1.0 -> 2.1.1`                                                           |
| [`1901bf46`](https://github.com/NixOS/nixpkgs/commit/1901bf46b3dda051ad512bba7cd9c0f49792913a) | `dnscontrol: 3.15.0 -> 3.16.0`                                                  |
| [`7519523f`](https://github.com/NixOS/nixpkgs/commit/7519523f8364e3ecd16cb378afa428e7e3917f91) | `linuxPackages.vendor-reset: enable parallel building`                          |
| [`b36ba49e`](https://github.com/NixOS/nixpkgs/commit/b36ba49e88271d475a902360c9c4aab4b8a22ee9) | `linuxPackages.vendor-reset: patch for Linux 5.18`                              |
| [`9ea03e0b`](https://github.com/NixOS/nixpkgs/commit/9ea03e0b68e4f3d3edb4635e0d15172eaffa5066) | `delve: 1.8.2 -> 1.8.3`                                                         |
| [`e0cd6799`](https://github.com/NixOS/nixpkgs/commit/e0cd6799b74d7e9222dcd3d607628395f474195f) | `python310Packages.PyChromecast: 12.1.2 -> 12.1.3`                              |