### PR TITLE
chore(flake/nixpkgs): `a701e4ad` -> `60a08714`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1653576718,
-        "narHash": "sha256-Cpf0WXU8wYxjzv7v5s+M2XyDGW+vVgPVjcIBga5uxMo=",
+        "lastModified": 1653663379,
+        "narHash": "sha256-xzE3+LY0NHk1G7jvJvR6gDu4iNtwpRmHLCiJVVyXUHg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a701e4adbca77736346445a8f5ff930bf4db1b5a",
+        "rev": "60a08714866da907bc9e63e49a157c8d20893520",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                         |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`eb41f632`](https://github.com/NixOS/nixpkgs/commit/eb41f632ff07d5f1ae0416cb768afbeca41ca54c) | `python3Packages.wandb: 0.12.16 -> 0.12.17`                                            |
| [`1e396f98`](https://github.com/NixOS/nixpkgs/commit/1e396f9802ac8f2191c705f44cd49af2c9fa44d5) | `nixos/testing-python.nix: fix typo in warning`                                        |
| [`18e4c7d8`](https://github.com/NixOS/nixpkgs/commit/18e4c7d8d12b2e43a9b4294af212f49d87d2c35b) | `lagrange: 1.13.5 -> 1.13.6`                                                           |
| [`f4812d06`](https://github.com/NixOS/nixpkgs/commit/f4812d06e2e4bfbbf4c8660bf56c2c468af42452) | `libsForQt5.qtforkawesome: Use ttf of fork_awesome`                                    |
| [`089ff89f`](https://github.com/NixOS/nixpkgs/commit/089ff89f49e4417cb42450d70704c7319e36091d) | `lib.systems: drop scaleway-c1`                                                        |
| [`3d6cf755`](https://github.com/NixOS/nixpkgs/commit/3d6cf755ba4a1f021c08f9c3fbe52fee1b86e2fe) | `ocamlPackages.opam-file-format: 2.1.3 -> 2.1.4`                                       |
| [`78bcc665`](https://github.com/NixOS/nixpkgs/commit/78bcc66570cc438d7b2d1ee3b4737c8c2cbbfb8f) | `python310Packages.aioqsw: 0.0.8 -> 0.1.0`                                             |
| [`6ce77e63`](https://github.com/NixOS/nixpkgs/commit/6ce77e631fa8a05b4ac743f0ec6697648d030fdc) | `gnome.gvfs: 1.50.1 -> 1.50.2`                                                         |
| [`f4d905e9`](https://github.com/NixOS/nixpkgs/commit/f4d905e9725a3f695f931c3a8b6ad76d60cea3f8) | `gnome.gnome-initial-setup: 42.1.1 -> 42.2`                                            |
| [`f25d6a64`](https://github.com/NixOS/nixpkgs/commit/f25d6a64ec275bcb8cc9b235de6d7c386cd74215) | `python310Packages.einops: disable failing tests`                                      |
| [`22094b83`](https://github.com/NixOS/nixpkgs/commit/22094b83b9bb537d75d1d0bd7e04d82398eced40) | `dalfox: 2.7.4 -> 2.7.5`                                                               |
| [`28786e10`](https://github.com/NixOS/nixpkgs/commit/28786e1055670386475100633ce86dbec681dfde) | `cpp-utilities: 5.14.0 -> 5.15.0`                                                      |
| [`803b9d63`](https://github.com/NixOS/nixpkgs/commit/803b9d6343a10de2bc102810eb774db28a051ad7) | `syncthingtray: 1.1.3 -> 1.1.20`                                                       |
| [`bf8134d8`](https://github.com/NixOS/nixpkgs/commit/bf8134d8603c6b5b92ea94c48798b9db8f3e1630) | `libsForQt5.qtforkawesome: init at 0.0.4`                                              |
| [`1152adbc`](https://github.com/NixOS/nixpkgs/commit/1152adbc9456b320e2e387cba4ec70f5a2bed464) | `minicom: 2.7.1 -> 2.8`                                                                |
| [`c9924f2b`](https://github.com/NixOS/nixpkgs/commit/c9924f2b269eb50c940b6721b5155fbc88d5576d) | `broadlink-cli: 0.18.1 -> 0.18.2`                                                      |
| [`4d2af291`](https://github.com/NixOS/nixpkgs/commit/4d2af291355b13edc20e40a57a61e17a046c60b6) | `checkmate: 0.5.9 -> 0.6.9`                                                            |
| [`bb9ebb54`](https://github.com/NixOS/nixpkgs/commit/bb9ebb541920de2c6ac4e173519abc061e608b2c) | `checkip: 0.35.2 -> 0.38.0`                                                            |
| [`1070949e`](https://github.com/NixOS/nixpkgs/commit/1070949eeac033ac6367e808a8f0a948ab49c2cf) | `python310Packages.trimesh: 3.12.4 -> 3.12.5`                                          |
| [`4118f601`](https://github.com/NixOS/nixpkgs/commit/4118f60176750c5e068d783ff2e69a999df38828) | `certgraph: 20210224 -> 20220513`                                                      |
| [`489e6c5e`](https://github.com/NixOS/nixpkgs/commit/489e6c5e3a3472284e22e86b702dc21e50ee8b47) | `cariddi: 1.1.6 -> 1.1.7`                                                              |
| [`488f282d`](https://github.com/NixOS/nixpkgs/commit/488f282d4f9c9033984dc05f7b39e396365d6617) | `python310Packages.types-urllib3: 1.26.14 -> 1.26.15`                                  |
| [`5310cea9`](https://github.com/NixOS/nixpkgs/commit/5310cea96532c2eac6f849b7d3e613a53407ddd0) | `python310Packages.pex: 2.1.89 -> 2.1.90`                                              |
| [`729ecda1`](https://github.com/NixOS/nixpkgs/commit/729ecda1c83cfe011aa90de774293fed426b576d) | `python310Packages.pyradios: 1.0.1 -> 1.0.2`                                           |
| [`413fd920`](https://github.com/NixOS/nixpkgs/commit/413fd920dfdacb7f0f9eb05b86a1d6badca71319) | `python310Packages.types-redis: 4.2.5 -> 4.2.6`                                        |
| [`c7acf6a4`](https://github.com/NixOS/nixpkgs/commit/c7acf6a4ac8477b23f97bb51c57b57cc671d206d) | `gnome.gedit: 42.0 -> 42.1`                                                            |
| [`c1fffdff`](https://github.com/NixOS/nixpkgs/commit/c1fffdfffb43b07ce09b14da0af9a856e1e8566e) | `treewide: change some glibc to stdenv.cc.libc`                                        |
| [`03eb4fd7`](https://github.com/NixOS/nixpkgs/commit/03eb4fd7ae049f4db4c196956b33afbe0a9ceaae) | `mastodon: 3.5.2 -> 3.5.3`                                                             |
| [`ec5bc0be`](https://github.com/NixOS/nixpkgs/commit/ec5bc0bec1c0cd39b2a463962e77d7ce513e3e37) | `python310Packages.httpx-socks: 0.7.3 -> 0.7.4`                                        |
| [`6117b71f`](https://github.com/NixOS/nixpkgs/commit/6117b71f31705a351c2f70a650c1ea36a9bef4db) | `python3Packages.wandb: hardcode git path`                                             |
| [`15367160`](https://github.com/NixOS/nixpkgs/commit/15367160c946373660b7517a7eb5179acae00746) | `aliyun-cli: 3.0.119 -> 3.0.121`                                                       |
| [`a64bf222`](https://github.com/NixOS/nixpkgs/commit/a64bf222306eef963fe971d8d979ebd2f1e6fdf9) | `vorta: 0.8.4 -> 0.8.6`                                                                |
| [`d9e295cd`](https://github.com/NixOS/nixpkgs/commit/d9e295cdefe01ac9b447ac5b0b3c30978a2c972b) | `openxcom: build with SDL_compat`                                                      |
| [`1f122262`](https://github.com/NixOS/nixpkgs/commit/1f12226231e5edfeec31d67e6a58c6d0d4afa885) | `rott: build with SDL_compat`                                                          |
| [`579e7221`](https://github.com/NixOS/nixpkgs/commit/579e722117596d27c879e83cfbe975fe2accc363) | `tree-wide: SDL may not have a .dev`                                                   |
| [`3ca3a12f`](https://github.com/NixOS/nixpkgs/commit/3ca3a12ffce22623673dc600312e0999ca1cfc09) | `tree-wide: SDL may not have a .dev`                                                   |
| [`30d5b538`](https://github.com/NixOS/nixpkgs/commit/30d5b538fa5671564d3e0d737d1c017674623006) | `tree-wide: SDL may not have a .dev`                                                   |
| [`112e6456`](https://github.com/NixOS/nixpkgs/commit/112e6456a3003b8faf23aae044244fe93c24b54b) | `tree-wide: SDL may not have a .dev`                                                   |
| [`ce0f3b15`](https://github.com/NixOS/nixpkgs/commit/ce0f3b159db50221588199a4ba0df59e7a9c8eb2) | `tree-wide: SDL may not have a .dev`                                                   |
| [`5f7a454b`](https://github.com/NixOS/nixpkgs/commit/5f7a454b3edc9d725463dff3e47d145d691c2886) | `tree-wide: SDL may not have a .dev`                                                   |
| [`fed7f8de`](https://github.com/NixOS/nixpkgs/commit/fed7f8de86da092da18aae5a84ae580b29fbf2ad) | `tree-wide: SDL may not have a .dev`                                                   |
| [`c9fa7f87`](https://github.com/NixOS/nixpkgs/commit/c9fa7f876d0fa156a81f302b133c93d036f0a35e) | `tree-wide: SDL may not have a .dev`                                                   |
| [`35bed200`](https://github.com/NixOS/nixpkgs/commit/35bed20020c2ceb112307bb65a5414171e87396d) | `tree-wide: SDL may not have a .dev`                                                   |
| [`a0156e70`](https://github.com/NixOS/nixpkgs/commit/a0156e7048cbd8bea5c8774599530c9d23d8da80) | `tree-wide: SDL may not have a .dev`                                                   |
| [`8eacd077`](https://github.com/NixOS/nixpkgs/commit/8eacd0777633e8102e839d98c7a83e9b03068008) | `tree-wide: SDL may not have a .dev`                                                   |
| [`7317302c`](https://github.com/NixOS/nixpkgs/commit/7317302c7775de8094472cd8cfd8a0ee062ae2f2) | `tree-wide: SDL may not have a .dev`                                                   |
| [`47240a3e`](https://github.com/NixOS/nixpkgs/commit/47240a3e310355c7d4f6b852a954eac50c5b3514) | `tree-wide: SDL may not have a .dev`                                                   |
| [`f011faae`](https://github.com/NixOS/nixpkgs/commit/f011faaede09aedd5c768b03c88b45ebffa0cbe5) | `tree-wide: SDL may not have a .dev`                                                   |
| [`658ee2d4`](https://github.com/NixOS/nixpkgs/commit/658ee2d45bd7933850ab629e9ad11477e80f6104) | `tree-wide: SDL may not have a .dev`                                                   |
| [`12f36a7c`](https://github.com/NixOS/nixpkgs/commit/12f36a7cffcd003c3ad93817b16f8426e7d8ba24) | `tree-wide: SDL may not have a .dev`                                                   |
| [`73a4c001`](https://github.com/NixOS/nixpkgs/commit/73a4c001d42c1f924c988c0c5a92f4c1e2388297) | `SDL_compat: init at 1.2.52`                                                           |
| [`5d60882a`](https://github.com/NixOS/nixpkgs/commit/5d60882a1e836656541ac53ec9276fdc8715d71a) | `yubikey-touch-detector: add missing systemd units and docs`                           |
| [`22f3d34c`](https://github.com/NixOS/nixpkgs/commit/22f3d34c933cd86db10bc4886e8dbca473d522a3) | `python3Packages.python-louvain: fix test karate`                                      |
| [`012075c6`](https://github.com/NixOS/nixpkgs/commit/012075c6d65e4ae044997d9f6c3d14019ae7d26b) | `python310Packages.teslajsonpy: 2.2.0 -> 2.2.1`                                        |
| [`2e0c027e`](https://github.com/NixOS/nixpkgs/commit/2e0c027ee32a92e232da61e79ea517fa1b4cfbab) | `btcpayserver: 1.5.1 -> 1.5.3`                                                         |
| [`1a9df113`](https://github.com/NixOS/nixpkgs/commit/1a9df1136a0cf0cbe011bc6839eaab7e3a846a78) | `nbxplorer: 2.3.20 -> 2.3.26`                                                          |
| [`fc5710fd`](https://github.com/NixOS/nixpkgs/commit/fc5710fd62490cf553d50534e5a4ef9ae8cc5185) | `python310Packages.feedparser: 6.0.9 -> 6.0.10`                                        |
| [`429a36f3`](https://github.com/NixOS/nixpkgs/commit/429a36f313f28f294fbecd38d48496bb9741cd4a) | `avrdude: 6.4 -> 7.0`                                                                  |
| [`b79448d4`](https://github.com/NixOS/nixpkgs/commit/b79448d4ee77c85d3b090cc2f2870c5bf2362fa0) | `python3Packages.sanic: disable some tests again`                                      |
| [`09cce3f3`](https://github.com/NixOS/nixpkgs/commit/09cce3f3e2b8bbb63bce0ede6a7c51d7d024a786) | `python3Packages.pykeepass: 4.0.1 -> 4.0.2`                                            |
| [`32ee57e2`](https://github.com/NixOS/nixpkgs/commit/32ee57e27b8a06a04d4f1cea3e0146a45fcfdcbd) | `gajim: update download page`                                                          |
| [`f540cdfd`](https://github.com/NixOS/nixpkgs/commit/f540cdfd078b05c38bbcc61aa917c29c1db54e9c) | `gajim: add dependency on gssapi`                                                      |
| [`566d7a77`](https://github.com/NixOS/nixpkgs/commit/566d7a770730f8bd91ea05abbaabe2b5afb68424) | `gajim: don't vendor old plugin_installer`                                             |
| [`3e178cde`](https://github.com/NixOS/nixpkgs/commit/3e178cde11643603fc4eb5521fd36ba9c1532b39) | `python310Packages.androidtv: 0.0.67 -> 0.0.68`                                        |
| [`58667dbd`](https://github.com/NixOS/nixpkgs/commit/58667dbd536b3c7f439a3929e42e57c141789781) | `python310Packages.uvicorn: 0.17.5 -> 0.17.6`                                          |
| [`0b37294d`](https://github.com/NixOS/nixpkgs/commit/0b37294d9b6c6bb723ba75f387cea5fce7c24272) | `python310Packages.drf-spectacular: init at 0.22.1`                                    |
| [`aaaa7de5`](https://github.com/NixOS/nixpkgs/commit/aaaa7de5bb509f28cf864743cc2812d110eb4748) | `goaccess: 1.5.6 -> 1.5.7`                                                             |
| [`5b062820`](https://github.com/NixOS/nixpkgs/commit/5b062820b68d6ae747b2a5acafa82128066d5a21) | `kind: 0.11.1 -> 0.14.0`                                                               |
| [`d0feef8c`](https://github.com/NixOS/nixpkgs/commit/d0feef8c2a1ed02918e3cda31ae64a7f52da46c7) | `lynis: 3.0.7 -> 3.0.8`                                                                |
| [`14a6c46b`](https://github.com/NixOS/nixpkgs/commit/14a6c46bbea522e028d37942485264086692cb5b) | `python310Packages.types-requests: 2.27.27 -> 2.27.29`                                 |
| [`6f542159`](https://github.com/NixOS/nixpkgs/commit/6f5421591cd51552552b55b313101c41a8356b57) | `python310Packages.hsluv: 5.0.2 -> 5.0.3`                                              |
| [`d145c736`](https://github.com/NixOS/nixpkgs/commit/d145c7367b50cb7188952d91484009800fb88a21) | `pip-audit: 2.3.0 -> 2.3.1`                                                            |
| [`46257a06`](https://github.com/NixOS/nixpkgs/commit/46257a06efe1e24eca5d45cc41ea4f3c158b772f) | `dex-oidc: 2.31.1 -> 2.31.2 (#174763)`                                                 |
| [`a1fb6249`](https://github.com/NixOS/nixpkgs/commit/a1fb6249911fc846874b1cce31bf57d9d7ceb7fb) | `gitleaks: 8.8.4 -> 8.8.5`                                                             |
| [`32bcc243`](https://github.com/NixOS/nixpkgs/commit/32bcc243c45e3536714231a176d2d91583c3756c) | `mailspring 1.10.2 -> 1.10.3 (#173475)`                                                |
| [`3b6fb49f`](https://github.com/NixOS/nixpkgs/commit/3b6fb49f3d00c55169e8178f30669e80f7b952f4) | `scribus: Rename scribus{,Unstable} -> scribus{_1_4,}`                                 |
| [`bc6520ee`](https://github.com/NixOS/nixpkgs/commit/bc6520ee6eb02fa3fb4056948d7ed09fff5b7237) | `python310Packages.flux-led: 0.28.29 -> 0.28.30`                                       |
| [`75f4c627`](https://github.com/NixOS/nixpkgs/commit/75f4c627752abc98bc2e25f9e754856ff864e021) | `linux/hardened/patches/5.4: 5.4.195-hardened1 -> 5.4.196-hardened1`                   |
| [`ec4b2a87`](https://github.com/NixOS/nixpkgs/commit/ec4b2a871ddc77c26d309bb116786bddcd9975dc) | `linux/hardened/patches/5.17: 5.17.9-hardened1 -> 5.17.11-hardened1`                   |
| [`e97b03a7`](https://github.com/NixOS/nixpkgs/commit/e97b03a780de6ae4f877d6c0092258555d713001) | `linux/hardened/patches/5.15: 5.15.41-hardened1 -> 5.15.43-hardened1`                  |
| [`d8d0dd92`](https://github.com/NixOS/nixpkgs/commit/d8d0dd929e55bbbaeb8044fdb7ebe365b1faea68) | `linux/hardened/patches/5.10: 5.10.117-hardened1 -> 5.10.118-hardened1`                |
| [`63192641`](https://github.com/NixOS/nixpkgs/commit/63192641bb82315f5484ace66b6e1c336c73bda2) | `linux/hardened/patches/4.19: 4.19.244-hardened1 -> 4.19.245-hardened1`                |
| [`08daee17`](https://github.com/NixOS/nixpkgs/commit/08daee172eb0143f01656f69d093330fc42ac9a3) | `linux/hardened/patches/4.14: 4.14.280-hardened1 -> 4.14.281-hardened1`                |
| [`d505557a`](https://github.com/NixOS/nixpkgs/commit/d505557a2916803206da007b8d925299eb672d62) | `linux: 5.4.195 -> 5.4.196`                                                            |
| [`c57d757e`](https://github.com/NixOS/nixpkgs/commit/c57d757e1bec95bf22a4b6d5a47ed53f6a8fcc0d) | `linux: 5.17.9 -> 5.17.11`                                                             |
| [`bc0db57d`](https://github.com/NixOS/nixpkgs/commit/bc0db57d5398c6b66c39e15465a51b299e1174ac) | `linux: 5.15.41 -> 5.15.43`                                                            |
| [`ec5629f3`](https://github.com/NixOS/nixpkgs/commit/ec5629f3f2910c4475b7af27c87112a96d32ec00) | `linux: 5.10.117 -> 5.10.118`                                                          |
| [`110b58f7`](https://github.com/NixOS/nixpkgs/commit/110b58f77ef304c23a3cbaf2a06cb92dcd79ca0c) | `linux: 4.9.315 -> 4.9.316`                                                            |
| [`b5c4a60b`](https://github.com/NixOS/nixpkgs/commit/b5c4a60bbec652e964afff309686a38097a21b1d) | `linux: 4.19.244 -> 4.19.245`                                                          |
| [`f2e1f34e`](https://github.com/NixOS/nixpkgs/commit/f2e1f34e4c258e6a41768113252fea6a35d8d30f) | `linux: 4.14.280 -> 4.14.281`                                                          |
| [`835df2ae`](https://github.com/NixOS/nixpkgs/commit/835df2aea7935db33410b789d4f2c80b112853fa) | `nushell: 0.62.0 -> 0.63.0`                                                            |
| [`03128a1f`](https://github.com/NixOS/nixpkgs/commit/03128a1f486eac4d9315622bb8228684c3ed4c04) | `python310Packages.pyprecice: remove whitespaces`                                      |
| [`a88aeb0a`](https://github.com/NixOS/nixpkgs/commit/a88aeb0a247397e7a3b434756de4e8d5dec8304a) | `python310Packages.pybtex-docutils: enable tests`                                      |
| [`a212889d`](https://github.com/NixOS/nixpkgs/commit/a212889d9ab3f50fc4449fa1cacffba10f181509) | `qjson: move to qt5-packages`                                                          |
| [`d3a72e4b`](https://github.com/NixOS/nixpkgs/commit/d3a72e4b3050f25b1a856b2c3b185800249dac80) | `python310Packages.pyprecice: disable on older Python releases`                        |
| [`9c890c48`](https://github.com/NixOS/nixpkgs/commit/9c890c48f571450a8fbedb79b32bccf6954e4ae5) | `python310Packages.dulwich: 0.20.41 -> 0.20.42`                                        |
| [`75e8cf9e`](https://github.com/NixOS/nixpkgs/commit/75e8cf9eec2d4bf9e1582d8e07efe4a67bcfe0ae) | `python310Packages.dulwich: 0.20.40 -> 0.20.41`                                        |
| [`995033c4`](https://github.com/NixOS/nixpkgs/commit/995033c43971043bde754155165e813173996ca6) | `wgcf: init at 2.2.14`                                                                 |
| [`664bd428`](https://github.com/NixOS/nixpkgs/commit/664bd428bddba266190ada12a9f11f406f7df799) | `python3Packages.sanic-auth: disable failing test`                                     |
| [`fcc0c1ac`](https://github.com/NixOS/nixpkgs/commit/fcc0c1acbbb5c88101ef1a18c438987c28504f20) | `python310Packages.aws-lambda-builders: switch to pytestCheckHook`                     |
| [`cfc2985d`](https://github.com/NixOS/nixpkgs/commit/cfc2985dbf51eea0f1269a851a295e3a81bc3440) | `maintainers: add yureien`                                                             |
| [`39e8b8b4`](https://github.com/NixOS/nixpkgs/commit/39e8b8b42fa31ac4325311b265badf909856c220) | `python3Packages.elastic-apm: fix tests with sanic>=22.3.0`                            |
| [`b4bbec83`](https://github.com/NixOS/nixpkgs/commit/b4bbec834a16ba71ab0439e7ea962b607f3f00ee) | `topgrade: 8.3.1 -> 9.0.0`                                                             |
| [`c95ab3cc`](https://github.com/NixOS/nixpkgs/commit/c95ab3cc25cbccdc29487ed9059fd38975356011) | `python3Packages.sanic: 21.12.1 -> 22.3.2`                                             |
| [`1fda6386`](https://github.com/NixOS/nixpkgs/commit/1fda6386408a945d4cd55376d793c704c9053de3) | `python3Packages.sanic-resting: 0.8.2 -> 22.3.0`                                       |
| [`17273c5f`](https://github.com/NixOS/nixpkgs/commit/17273c5fcf796483fecdf4fca7f5ca9cc7f3aec5) | `python3Packages.sanic-routing: 0.7.2 -> 22.3.0`                                       |
| [`fa9766d7`](https://github.com/NixOS/nixpkgs/commit/fa9766d77b8e54e01f73800cc3b83fc5decb3b8b) | `python310Packages.pyprecice: 2.3.0.1 -> 2.4.0.0`                                      |
| [`5331c647`](https://github.com/NixOS/nixpkgs/commit/5331c6475c37612f426d9998ea1ad03783faed6e) | `python310Packages.aws-lambda-builders: 1.16.0 -> 1.17.0`                              |
| [`94026f2b`](https://github.com/NixOS/nixpkgs/commit/94026f2b20855f921e7cbcfbf394f0552a9f391a) | `bootstrap-studio: Use pname and version without declaring name`                       |
| [`e3750679`](https://github.com/NixOS/nixpkgs/commit/e3750679d814a7d73cbf0849124878d3b3dac498) | `kubescape: fix darwin`                                                                |
| [`deb39706`](https://github.com/NixOS/nixpkgs/commit/deb39706a1b30b220a08227505608a04eb18dcbc) | `ghq: 1.2.1 -> 1.3.0`                                                                  |
| [`0bf74b17`](https://github.com/NixOS/nixpkgs/commit/0bf74b17041e419bd027ee6d2d0b6e82b1f37166) | `python310Packages.python-snap7: disable on older Python releases`                     |
| [`22199bf7`](https://github.com/NixOS/nixpkgs/commit/22199bf7aaa5f3170a063497b9b3ce08d681150a) | `python310Packages.pybtex-docutils: 1.0.1 -> 1.0.2`                                    |
| [`fcb339e2`](https://github.com/NixOS/nixpkgs/commit/fcb339e29429da80de9f9e54d0cc13e5673d6725) | `nix-ld: disable build on non-linux platforms`                                         |
| [`d12ae8b7`](https://github.com/NixOS/nixpkgs/commit/d12ae8b736aaaf3fdbef49933e436b53777b4ea8) | `gcsfuse: 0.40.0 -> 0.41.0`                                                            |
| [`7f65ccda`](https://github.com/NixOS/nixpkgs/commit/7f65ccda54e45cc361eea39921f45bd3aa1f2ca7) | `intel-gmmlib: 22.1.2 -> 22.1.3`                                                       |
| [`6a586161`](https://github.com/NixOS/nixpkgs/commit/6a586161100b548f4b161ef93bf79d59a7616ed3) | `go-md2man: 2.0.1 -> 2.0.2`                                                            |
| [`44dd19be`](https://github.com/NixOS/nixpkgs/commit/44dd19be4b1528c8513289defdef92b7c0146b51) | `python310Packages.python-snap7: 1.1 -> 1.2`                                           |
| [`3654935a`](https://github.com/NixOS/nixpkgs/commit/3654935a3ac72bd472f7ff09dfc22f321259f24b) | `libdwarf_0_4: init at 0.4.0`                                                          |
| [`0129fe11`](https://github.com/NixOS/nixpkgs/commit/0129fe117334b61060778b1d8ad997dcda837c40) | `clementine: build without qt4`                                                        |
| [`c2e15baf`](https://github.com/NixOS/nixpkgs/commit/c2e15baf0437c0125286eba7a92a3293eda0cc86) | `libechonest: remove`                                                                  |
| [`d60f81e8`](https://github.com/NixOS/nixpkgs/commit/d60f81e8c10144599d3691ec84f4d46c559dd214) | `qjson: qt4 -> qt5`                                                                    |
| [`30e0227f`](https://github.com/NixOS/nixpkgs/commit/30e0227fde47a5a3314012a122668d70ff06dc96) | `btrfs-progs: 5.17 -> 5.18`                                                            |
| [`3b8b85ba`](https://github.com/NixOS/nixpkgs/commit/3b8b85bac4976a29cf7e0fe9ec8527d61e0437a2) | `textadept: Fix compilation using an older version of gcc`                             |
| [`44107eea`](https://github.com/NixOS/nixpkgs/commit/44107eea55d13622642ba2fd38ae74b106742cdb) | `chromiumDev: 103.0.5060.13 -> 103.0.5060.24`                                          |
| [`8711501e`](https://github.com/NixOS/nixpkgs/commit/8711501e9612199d5a7014303813f8fae52ccb5e) | `sage: fix passthru.kernelspec regression`                                             |
| [`0cdff58b`](https://github.com/NixOS/nixpkgs/commit/0cdff58b3f6e4a8c4e967748253a8bb3bae3c291) | `python3Packages.pot: fix build on darwin`                                             |
| [`0fe8715f`](https://github.com/NixOS/nixpkgs/commit/0fe8715fc62bfd6aa474265f6141d0d45eb88c22) | `flint: 2.8.4 -> 2.8.5`                                                                |
| [`9102b1cc`](https://github.com/NixOS/nixpkgs/commit/9102b1cc65c05edb0ada9b1391c942bb3862dfd4) | `python39Packages.graspologic: mark as broken`                                         |
| [`0c4d65b2`](https://github.com/NixOS/nixpkgs/commit/0c4d65b21efd3ae2fcdec54492cbaa6542352eb9) | `treewide: stdenv.glibc -> glibc`                                                      |
| [`a05b5817`](https://github.com/NixOS/nixpkgs/commit/a05b5817834f553f8eae560c58fed02a59af42b9) | `stdenv: warn about use of stdenv.glibc`                                               |
| [`4b36519d`](https://github.com/NixOS/nixpkgs/commit/4b36519da08dee48cc4a58225a4be2107f961728) | `checkstyle: 10.1 -> 10.2`                                                             |
| [`b28eda04`](https://github.com/NixOS/nixpkgs/commit/b28eda04a241e0a25615e92bcc7c29a37431a6b1) | `abcl: 1.8.0 -> 1.9.0`                                                                 |
| [`1eb6d6e5`](https://github.com/NixOS/nixpkgs/commit/1eb6d6e5a25136f356e8dcd63574b6429d7bdec6) | `gallery-dl: 1.21.2 -> 1.22.0`                                                         |
| [`e81a247c`](https://github.com/NixOS/nixpkgs/commit/e81a247cb6bff134af31cbdcb2b3d1c1634c94af) | `pgmetrics: 1.12.0 -> 1.13.0`                                                          |
| [`2e17187e`](https://github.com/NixOS/nixpkgs/commit/2e17187ebaf5f25427062fb6d869139485acda9a) | `git-lfs: 3.1.4 -> 3.2.0`                                                              |
| [`8075e7a1`](https://github.com/NixOS/nixpkgs/commit/8075e7a172633e5de88a07c76fc4665e4d0add8c) | `stockfish: 14.1 -> 15`                                                                |
| [`c888cdbc`](https://github.com/NixOS/nixpkgs/commit/c888cdbccae9326e0dc8504a57bf6aac1c4886f7) | `dolphin-emu-beta: mark as compatible with aarch64`                                    |
| [`acf69be9`](https://github.com/NixOS/nixpkgs/commit/acf69be9516bf81faaf251e280449ed9854c2106) | `python310Packages.google-cloud-logging: disable on older Python releases`             |
| [`60be290e`](https://github.com/NixOS/nixpkgs/commit/60be290e1f3e198ae04713aa10684b9d8e17b9d2) | `python310Packages.google-cloud-logging: 3.0.0 -> 3.1.1`                               |
| [`ff2a8c60`](https://github.com/NixOS/nixpkgs/commit/ff2a8c6083870e6ffe68bf1d5e705cd6e21ec77a) | `saleae-logic-2: 2.3.52 -> 2.3.53`                                                     |
| [`d7bfa0dc`](https://github.com/NixOS/nixpkgs/commit/d7bfa0dcc49491c7683a84e7edbf24b1c3bddcc6) | `vim/update.py: mark some plugins as neovim ones`                                      |
| [`a2d4d474`](https://github.com/NixOS/nixpkgs/commit/a2d4d474c21a9543192e9c9eb56e67885e73a137) | `vimPlugins.nvim-biscuits: init at 2021-11-12`                                         |
| [`e373b1a7`](https://github.com/NixOS/nixpkgs/commit/e373b1a746317dc089e3dc16e06d5994746cfa78) | `vimPlugins.diffview-nvim: add plenary as dependency`                                  |
| [`80367c8d`](https://github.com/NixOS/nixpkgs/commit/80367c8db877e65ba7727c834fae8ce078295f0d) | `nixos/nextcloud: Remove confusing comment`                                            |
| [`84c3b4f9`](https://github.com/NixOS/nixpkgs/commit/84c3b4f9859770fd411f19a654a8b515dce55ce6) | `maintainers: update khushraj`                                                         |
| [`cf608e1b`](https://github.com/NixOS/nixpkgs/commit/cf608e1b5d5657a61d6678bdec809e30edb278ee) | `bootstrap-studio: init at 6.0.1`                                                      |
| [`ad241745`](https://github.com/NixOS/nixpkgs/commit/ad241745c3d72d13f7c2f2a273fb93a4f181830d) | `mangohud: 0.6.5 -> 0.6.7-1`                                                           |
| [`e9b13758`](https://github.com/NixOS/nixpkgs/commit/e9b1375878a798850457c7c86af2795451b489b1) | `nixos/hedgedoc: fix and add config options`                                           |
| [`1838712a`](https://github.com/NixOS/nixpkgs/commit/1838712a15df62f354993d68187225b8f70cc5dc) | `i3lock-blur: pull patch pending upstream inclusion for -fno-common toolchain support` |
| [`2118173c`](https://github.com/NixOS/nixpkgs/commit/2118173ca4ac0276c261f4c04eb10a2cbafb7ba8) | `.github/stale bot: stop commenting`                                                   |
| [`8e68f3fc`](https://github.com/NixOS/nixpkgs/commit/8e68f3fcfc9eb2a00aae46bfb7f6f27a87f920f0) | `nixos/doc: build manual`                                                              |
| [`9a8b7640`](https://github.com/NixOS/nixpkgs/commit/9a8b7640e010b901fb528cf62cf0bc79e0912ae2) | `nixos/doc/types: note submodules’ default’s behaviour`                                |