### PR TITLE
chore(flake/nixpkgs): `60a08714` -> `cce06677`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1653663379,
-        "narHash": "sha256-xzE3+LY0NHk1G7jvJvR6gDu4iNtwpRmHLCiJVVyXUHg=",
+        "lastModified": 1653704018,
+        "narHash": "sha256-3kQ96fOzxcLDE1WyimGrwf7buN0pvnveGgijzG1uNf8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "60a08714866da907bc9e63e49a157c8d20893520",
+        "rev": "cce0667703fce3a1162dd252cf0864fdf83466ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                               |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`f4825e5e`](https://github.com/NixOS/nixpkgs/commit/f4825e5e9fc71ac5c682b82f70a93025111d8d55) | `libdwarf: 20181024 -> 20210528 (#174977)`                                   |
| [`dbd004ea`](https://github.com/NixOS/nixpkgs/commit/dbd004ea9bee830402aa410c6b8a0a493efa454b) | `xkcd-font: fix build (#174776)`                                             |
| [`2be2461a`](https://github.com/NixOS/nixpkgs/commit/2be2461a98380707dcd3858f927f4fa090b84682) | `qutebrowser: 2.5.0 -> 2.5.1`                                                |
| [`108dea5c`](https://github.com/NixOS/nixpkgs/commit/108dea5cdacd5f8fb221f051c06f7078aa8a3b49) | `vkdisplayinfo: init at 0.1`                                                 |
| [`01e26ef2`](https://github.com/NixOS/nixpkgs/commit/01e26ef209f1dabca18efa8905936394171ccd22) | `honggfuzz: remove unused let in`                                            |
| [`bc0d3c4b`](https://github.com/NixOS/nixpkgs/commit/bc0d3c4b470f0ec78898269a7172f9139afb4ac6) | `Revert "cln: fix build on darwin"`                                          |
| [`7ef1df63`](https://github.com/NixOS/nixpkgs/commit/7ef1df63740abb68b834337a3ff8a545e7834112) | `megatools: 1.10.3 -> 1.11.0`                                                |
| [`0f45ffa2`](https://github.com/NixOS/nixpkgs/commit/0f45ffa21be63cf363de393941b4ebfe2884fad6) | `megatools: fmt`                                                             |
| [`870d43c5`](https://github.com/NixOS/nixpkgs/commit/870d43c5aaea49b33166bbc7c3a3b35ca469606d) | `terraform-providers.template: archived`                                     |
| [`030abdb3`](https://github.com/NixOS/nixpkgs/commit/030abdb3776a4d73cdf61e9bf580a610ee61e4ba) | `terraform-providers.oraclepass: archived`                                   |
| [`df490e46`](https://github.com/NixOS/nixpkgs/commit/df490e463487249b6ca2b393aa1b63c79bb8f4cc) | `terraform-providers.opc: archived`                                          |
| [`f7ba0283`](https://github.com/NixOS/nixpkgs/commit/f7ba0283cb48fa885baffb83a743ebbb945beda3) | `terraform-providers: drop outdated aliases`                                 |
| [`463d470a`](https://github.com/NixOS/nixpkgs/commit/463d470ad1241a821de4a8fd1952fd4a315bf6c0) | `terraform-providers.snowflake: 0.33.1 -> 0.34.0`                            |
| [`20db324c`](https://github.com/NixOS/nixpkgs/commit/20db324c17b7c4bdc08655368a1405d4793cd66c) | `terraform-providers.auth0: 0.26.2 -> 0.30.2`                                |
| [`a2fd5a0c`](https://github.com/NixOS/nixpkgs/commit/a2fd5a0c232cf55cf613357cb83f64a19ad9f460) | `python310Packages.django-otp: init at 1.1.3`                                |
| [`89a3bd29`](https://github.com/NixOS/nixpkgs/commit/89a3bd293cc07a1ed28f0819f13585cdb94e75d4) | `python310Packages.djangorestframework-guardian: init at 0.3.0`              |
| [`515a09d3`](https://github.com/NixOS/nixpkgs/commit/515a09d3559184abc273a24dad62712e32a74709) | `python310Packages.xmlsec: fix comment position`                             |
| [`2a5bbbc6`](https://github.com/NixOS/nixpkgs/commit/2a5bbbc6e92867a3aeb3c07d86b297b56300cc6c) | `python310Packages.service-identity: normalise directory name`               |
| [`625c3daa`](https://github.com/NixOS/nixpkgs/commit/625c3daaf97b794a3bb5701afb0749d92529cc72) | `python310Packages.brother: relax pysnmplib constraint`                      |
| [`66c6c914`](https://github.com/NixOS/nixpkgs/commit/66c6c914a8a4f72b66686f7d4946cb4792636b3e) | `python310Packages.pysnmplib: 5.0.10 -> 5.0.15`                              |
| [`5ea1301e`](https://github.com/NixOS/nixpkgs/commit/5ea1301e11367af3c2782fad3b6d03e57713124e) | `python310Packages.asteval: 0.9.26 -> 0.9.27`                                |
| [`202d40b9`](https://github.com/NixOS/nixpkgs/commit/202d40b9a98b77baecacfaa47d312ed4af86856a) | `python310Packages.google-cloud-org-policy: 1.3.1 -> 1.3.2`                  |
| [`cd97b40f`](https://github.com/NixOS/nixpkgs/commit/cd97b40fac8bfb0ebc5893dc6f803fcce1342f00) | `python310Packages.google-cloud-datastore: 2.6.0 -> 2.6.1`                   |
| [`8d5481d0`](https://github.com/NixOS/nixpkgs/commit/8d5481d01c8ab2840f50f31b88e195b1cc30bd54) | `pulseview: hotfix build`                                                    |
| [`24903b5d`](https://github.com/NixOS/nixpkgs/commit/24903b5de2e07cc7b65eae8c850d6204981953de) | `python39Packages.phik: fix tests`                                           |
| [`41d4a169`](https://github.com/NixOS/nixpkgs/commit/41d4a169616531a090f8ed15bc5b754a3245f8a0) | `kitty: 0.24.4 -> 0.25.0`                                                    |
| [`6ff6d35a`](https://github.com/NixOS/nixpkgs/commit/6ff6d35a6978d376483f4268ce6b0e01c514c4c6) | `binocle: init at 0.3.0`                                                     |
| [`47d7ecfc`](https://github.com/NixOS/nixpkgs/commit/47d7ecfcea24ce6c4806fe4edae4cba3c324313c) | `python310Packages.testing-postgresql: disable on older Python releases`     |
| [`41098225`](https://github.com/NixOS/nixpkgs/commit/41098225dd67945ae907c726f6dd7fa0a35d0e67) | `cshatag: 2019-12-03 -> 2.0 (#174927)`                                       |
| [`3c6a6e5e`](https://github.com/NixOS/nixpkgs/commit/3c6a6e5eed857fa704c4a3cc21085cf80a9b2552) | `python310Packages.pg8000: 1.28.3 -> 1.29.1`                                 |
| [`59908bbe`](https://github.com/NixOS/nixpkgs/commit/59908bbe2ad6c993552818f4f76a04cf876dcde7) | `kubescape: 2.0.155 -> 2.0.156`                                              |
| [`b26794a3`](https://github.com/NixOS/nixpkgs/commit/b26794a3fd651954950c6adb437d818694ba39c2) | `python310Packages.pysensibo: 1.0.14 -> 1.0.15`                              |
| [`9b7d990c`](https://github.com/NixOS/nixpkgs/commit/9b7d990c70b289fa66ec0faaf51536d50d05cb36) | `Revert "btrfs-progs: fix musl build"`                                       |
| [`98dd1835`](https://github.com/NixOS/nixpkgs/commit/98dd18352c5795a3cb3629aab072b53fd25036e6) | `python310Packages.qcs-api-client: 0.20.14 -> 0.20.17`                       |
| [`fce9ee2a`](https://github.com/NixOS/nixpkgs/commit/fce9ee2aec91e15d28a2ba663c8b4590de25550c) | `python310Packages.qcs-api-client: 0.20.12 -> 0.20.14`                       |
| [`dfbfacd2`](https://github.com/NixOS/nixpkgs/commit/dfbfacd2c1c5ab70ac2ac4c621f0c6b32e96beac) | `python310Packages.nats-py: 2.1.2 -> 2.1.3`                                  |
| [`1a5566bd`](https://github.com/NixOS/nixpkgs/commit/1a5566bde2d1cabf3a53d6822fb0220e271d2b74) | `procs: 0.12.1 -> 0.12.3, mark borken on darwin, remove inactive maintainer` |
| [`b57d56e0`](https://github.com/NixOS/nixpkgs/commit/b57d56e0356e6edc71c06e33a6dc6edd90d448d5) | `python310Packages.slack-sdk: 3.16.2 -> 3.17.0`                              |
| [`0f0fc06e`](https://github.com/NixOS/nixpkgs/commit/0f0fc06e56ab4ab1d5eab7c1b60e47d50f9d9bfd) | `python310Packages.http-sfv: 0.9.6 -> 0.9.7`                                 |
| [`77664ba0`](https://github.com/NixOS/nixpkgs/commit/77664ba070226069790f7942e7ff10c89ce4c926) | `python310Packages.libcloud: 3.5.1 -> 3.6.0`                                 |
| [`70ac5aea`](https://github.com/NixOS/nixpkgs/commit/70ac5aea7f316b3fc3f3f627ca8b78d6f5112376) | `matrix-appservice-discord: unquote ${nodejs.src}`                           |
| [`991dbd65`](https://github.com/NixOS/nixpkgs/commit/991dbd65f11ac0eaa2b12423fd4c51368261a53c) | `protonvpn-gui: remove networkmanager, add gdk-pixbuf and librsvg`           |
| [`89d3b0a2`](https://github.com/NixOS/nixpkgs/commit/89d3b0a21a4bf785b3c17d053b5cc8e3608985b8) | `python310Packages.snowflake-connector-python: update disable`               |
| [`b6e35916`](https://github.com/NixOS/nixpkgs/commit/b6e359166917a7d400c9bb02714ad1d8500c58ae) | `plantuml: 1.2022.3 -> 1.2022.5`                                             |
| [`52beb63f`](https://github.com/NixOS/nixpkgs/commit/52beb63f4ea7297b5945337c0442a96c35abd86f) | `xfce: move legacy aliases outside the scope of xfce`                        |
| [`2361dc9f`](https://github.com/NixOS/nixpkgs/commit/2361dc9f4a00e7424627857e1406705845d466cb) | `python3Packages.protonvpn-nm-cli: add dependencies`                         |
| [`e32a078b`](https://github.com/NixOS/nixpkgs/commit/e32a078b5eb4e79501a1a3070c516cc1add15a25) | `nodePackages.purs-tidy: init at 0.9.0`                                      |
| [`afc4caf2`](https://github.com/NixOS/nixpkgs/commit/afc4caf22f65d7d23f55bd7eac770528d1204c44) | `unconvert: unstable-2018-07-03 -> unstable-2020-02-28`                      |
| [`2fdd23c1`](https://github.com/NixOS/nixpkgs/commit/2fdd23c154e28d3d735c84585914fb9f2277eac6) | `release-notes: don't encourage people to copy secrets to the store`         |
| [`30aa1e15`](https://github.com/NixOS/nixpkgs/commit/30aa1e15124b6f9ed311b817fe17de5fbe5d1f55) | `json2hcl: 0.0.6 -> 0.0.7`                                                   |
| [`37671518`](https://github.com/NixOS/nixpkgs/commit/376715187c66b5957bc2290575be56fa6c148222) | `fishPlugins.grc: init at unstable-2022-05-24`                               |
| [`01e74c5a`](https://github.com/NixOS/nixpkgs/commit/01e74c5aca70f9b531e16d64d2ba242149b80672) | `python310Packages.snowflake-connector-python: 2.7.7 -> 2.7.8`               |
| [`41a3ed66`](https://github.com/NixOS/nixpkgs/commit/41a3ed669bdddac58cee3d0c3425714a45f5c72c) | `qtile: added dbus-next as a dependency`                                     |
| [`1fa0039f`](https://github.com/NixOS/nixpkgs/commit/1fa0039f7529f246bc69998a88eacd7510801ed5) | `rekor-cli, rekor-server: 0.6.0 -> 0.7.0`                                    |
| [`95c78375`](https://github.com/NixOS/nixpkgs/commit/95c78375c22bcb41d5dfbcdf405332e3e3bc84ec) | `dagger: 0.2.7 -> 0.2.12`                                                    |
| [`825e13a4`](https://github.com/NixOS/nixpkgs/commit/825e13a47c098b7b8b0b0307f18deac88c7be249) | `stripe-cli: 1.8.11 -> 1.9.0`                                                |
| [`4e48da4c`](https://github.com/NixOS/nixpkgs/commit/4e48da4cc259c94ccb81eab517428236b2de1b7f) | `deno: 1.22.0 -> 1.22.1`                                                     |
| [`a14ca09c`](https://github.com/NixOS/nixpkgs/commit/a14ca09c6497f25783ef7ab2ee1bbc071f01e760) | `clickhouse-backup: 1.3.2 -> 1.4.0`                                          |
| [`bc1da43a`](https://github.com/NixOS/nixpkgs/commit/bc1da43a85404666b241fa15d211d62363f69805) | `cbatticon: 1.6.12 -> 1.6.13`                                                |
| [`4a0a6218`](https://github.com/NixOS/nixpkgs/commit/4a0a6218a5258d79cbf32626fbbdb80cf6b8d099) | `metamorphose2: 0.9.0 -> 0.10.0`                                             |
| [`4b4115df`](https://github.com/NixOS/nixpkgs/commit/4b4115df70a1b6aa8358ae727dfd855a06bef0a8) | `purescript: update script only considers full releases`                     |
| [`ca2dc3ca`](https://github.com/NixOS/nixpkgs/commit/ca2dc3cac3cca8b7ed371d8ff5b303ecb0b2c259) | `librewolf: 100.0-3 -> 100.0.2-1`                                            |
| [`fa0bb44c`](https://github.com/NixOS/nixpkgs/commit/fa0bb44c7cf2e2f5c3bfac54caa93c2403a1c452) | `python310Packages.google-cloud-access-context-manager: 0.1.10 -> 0.1.11`    |
| [`de6fbbdf`](https://github.com/NixOS/nixpkgs/commit/de6fbbdf1680e5b42efbdc4b2862ade4b2578bc8) | `checkmake: 0.1.0-2020.11.30 -> 0.2.1`                                       |
| [`bbf24b73`](https://github.com/NixOS/nixpkgs/commit/bbf24b73054f45c193a48039ba68952847b30789) | `okteto: init at 2.3.1`                                                      |
| [`f01cef99`](https://github.com/NixOS/nixpkgs/commit/f01cef9982c7a8782df1ca7df0fabcb02db7a822) | `python3Packages.nitime: disable test test_FilterAnalyzer`                   |
| [`2d0f97be`](https://github.com/NixOS/nixpkgs/commit/2d0f97be21750797ff946c644202b12cd317397d) | `ansible: drop maintainership`                                               |
| [`df97614d`](https://github.com/NixOS/nixpkgs/commit/df97614d21c1c78afafb0d3a4c82862ef2eb9512) | `ansible, ansible_2_12: add meta.changelog`                                  |
| [`c7d07eca`](https://github.com/NixOS/nixpkgs/commit/c7d07ecaa2e132d39675059c24009403b501eff4) | `ansible_2_12: 2.12.5 -> 2.12.6`                                             |
| [`e9a0f109`](https://github.com/NixOS/nixpkgs/commit/e9a0f109e5208f589c0bf9c05d4e93a25f595edc) | `curl: deduplicate definition of passthru.tests`                             |
| [`dd41e383`](https://github.com/NixOS/nixpkgs/commit/dd41e3832af963dc7f6f2b579e8d64ed5f33990f) | `gecode_3: fix on darwin using same patch as gecode_6`                       |
| [`c115aee8`](https://github.com/NixOS/nixpkgs/commit/c115aee8ff802e577ebae0c9e10ca2edf3ddf58f) | `python310Packages.webcolors: 1.11.1 -> 1.12`                                |
| [`9b3553d1`](https://github.com/NixOS/nixpkgs/commit/9b3553d1c4f685c0654a3b8043814eb458f2faa1) | `python310Packages.numba: 0.55.1 -> 0.55.2`                                  |
| [`cd229374`](https://github.com/NixOS/nixpkgs/commit/cd22937423fc5c97f45677dc8af0895096a3df72) | `python310Packages.arviz: 0.12.0 -> 0.12.1`                                  |
| [`c18e7de0`](https://github.com/NixOS/nixpkgs/commit/c18e7de036625a81b8266cf41ed755fb8b4d69d3) | `python39Packages.umap-learn: disable flaky test`                            |
| [`7f38d0a1`](https://github.com/NixOS/nixpkgs/commit/7f38d0a148a5222026929e2b0f79f04ebb3890dd) | `python310Packages.datashader: 0.13.0 -> 0.14.0`                             |
| [`5af41eba`](https://github.com/NixOS/nixpkgs/commit/5af41eba18d0c1623836293b4c777910e47bfd0a) | `python310Packages.pynndescent: 0.5.6 -> 0.5.7`                              |
| [`91824e31`](https://github.com/NixOS/nixpkgs/commit/91824e319240fc6e9a0cc0bcb0bbfaa80aac32fb) | `python310Packages.aeppl: init at 0.0.31`                                    |
| [`0fb3b8bd`](https://github.com/NixOS/nixpkgs/commit/0fb3b8bddfcb7ddc59693451c7027914035bb730) | `python310Packages.numdifftools: init at 0.9.40`                             |
| [`d69a2ffc`](https://github.com/NixOS/nixpkgs/commit/d69a2ffcea2fec72eb24c8ce202151cb3adfc992) | `python310Packages.persim: disable failing tests on Python 3.10`             |
| [`b7874eee`](https://github.com/NixOS/nixpkgs/commit/b7874eee051c6a194935e8b18745a7b9455df419) | `python39Packages.aesara: 2.5.3 -> 2.6.6`                                    |
| [`2e32938d`](https://github.com/NixOS/nixpkgs/commit/2e32938d54c380289eb9d19e61d3da793821daa8) | `python310Packages.numba: update disable`                                    |
| [`8278f5c3`](https://github.com/NixOS/nixpkgs/commit/8278f5c3b03c3992078ecc9b768c0606fc2e42a9) | `python39Packages.numba-scipy: update stale substituteInPlace`               |
| [`8e1ee177`](https://github.com/NixOS/nixpkgs/commit/8e1ee1775754fb284c381985648deea097e281a9) | `signalbackup-tools: 20220517 -> 20220526`                                   |
| [`43e661da`](https://github.com/NixOS/nixpkgs/commit/43e661da405cb916977c4a91bd6567ba6f1bb641) | `awscli2: 2.5.6 -> 2.7.3`                                                    |
| [`d75f202c`](https://github.com/NixOS/nixpkgs/commit/d75f202ce494f56a5f40cbb5dc0bf81611afb003) | `honggfuzz: Add chivay to maintainers`                                       |
| [`4a2d1f78`](https://github.com/NixOS/nixpkgs/commit/4a2d1f78402dec9da19e2a3429446ffcef245db9) | `strawberry: 1.0.3 -> 1.0.4`                                                 |
| [`4c2940b6`](https://github.com/NixOS/nixpkgs/commit/4c2940b68a9ce6ae7049879bb1a91dd47526c04a) | `jotta-cli: 0.13.55213 -> 0.14.58899`                                        |
| [`3af642c1`](https://github.com/NixOS/nixpkgs/commit/3af642c13aaa701f4de1d7b82b7e432cba8dd166) | `sysstat: Do not compress manual pages with xz(1)`                           |
| [`24bd72fd`](https://github.com/NixOS/nixpkgs/commit/24bd72fd836b1a9475ca3931d3c04b884082d437) | `release: Slightly adjust release-critical packages`                         |
| [`4476408d`](https://github.com/NixOS/nixpkgs/commit/4476408d2416c429cf7725a762e16b118d9eb90b) | `libsForQt5.fcitx5-qt: 5.0.11 -> 5.0.12`                                     |
| [`100cb5e4`](https://github.com/NixOS/nixpkgs/commit/100cb5e47e562217f8e7f4b29326c345f2d1d25b) | `fcitx5: 5.0.15 -> 5.0.16`                                                   |
| [`9008a98b`](https://github.com/NixOS/nixpkgs/commit/9008a98b32816395482cca95f2eee098290d5477) | `termusic: 0.6.15 -> 0.6.16`                                                 |
| [`29978394`](https://github.com/NixOS/nixpkgs/commit/29978394637e6a63c3c40172157e5d558bbfe021) | `perl*Packages: Fix all packages`                                            |
| [`a15a4f72`](https://github.com/NixOS/nixpkgs/commit/a15a4f72366877e5e63fcf06a8bf236a1619ca71) | `pantheon.elementary-onboarding: 6.1.0 -> 7.0.0`                             |
| [`81de602a`](https://github.com/NixOS/nixpkgs/commit/81de602ac58f8280ac680accf28554b47678cc86) | `pantheon.elementary-dock: unstable-2021-12-08 -> unstable-2022-05-07`       |
| [`e4cff324`](https://github.com/NixOS/nixpkgs/commit/e4cff3246433e3a0608fd2acdb74cc52d44bb20e) | `pantheon.appcenter: 3.9.1 -> 3.10.0`                                        |
| [`0abae979`](https://github.com/NixOS/nixpkgs/commit/0abae979a96c4fe0c038e83183e9003c4e3674d7) | `powershell: 7.2.3 -> 7.2.4`                                                 |
| [`aaf94256`](https://github.com/NixOS/nixpkgs/commit/aaf942564a2586751e3a4ef5288ca73b982ee249) | `julia_17-bin: 1.7.2 -> 1.7.3`                                               |
| [`237f5820`](https://github.com/NixOS/nixpkgs/commit/237f5820ac7f33c011da7d9fffd78b2e2fceec5c) | `termius: 7.40.2 -> 7.41.2`                                                  |
| [`0f1871de`](https://github.com/NixOS/nixpkgs/commit/0f1871de006ea7e7437e8472f3992416b488e837) | `google-cloud-sdk: 385.0.0 -> 387.0.0`                                       |
| [`3d64bf8c`](https://github.com/NixOS/nixpkgs/commit/3d64bf8c568d36dcf90f2a18ec0583b4b260da5c) | `oh-my-zsh: 2022-05-15 -> 2022-05-25`                                        |
| [`3b533276`](https://github.com/NixOS/nixpkgs/commit/3b533276121bd77c14b1af807eae1d6c95ef62cf) | `python310Packages.atlassian-python-api: 3.24.0 -> 3.25.0`                   |
| [`4a8b1f3a`](https://github.com/NixOS/nixpkgs/commit/4a8b1f3a22eb4f55a6752a640627a51336162c1c) | `warp: init at 0.1.2`                                                        |
| [`933a7b06`](https://github.com/NixOS/nixpkgs/commit/933a7b06bc514d507c579a2aad3bebd651aa10b0) | `consul: 1.12.0 -> 1.12.1`                                                   |
| [`fb26e615`](https://github.com/NixOS/nixpkgs/commit/fb26e61593db2de429a5b9c873123e317edd4dca) | `python310Packages.transformers: 4.16.2 -> 4.19.2`                           |
| [`699a31f9`](https://github.com/NixOS/nixpkgs/commit/699a31f98bb3203b73bc0e8789df93f633bf717e) | `nvidia-vaapi-driver: 0.0.5 -> 0.0.6`                                        |
| [`eb67fa3b`](https://github.com/NixOS/nixpkgs/commit/eb67fa3b586bed4ef020452bc17d8e6d8d516d13) | `qt6.qtwebengine: fix resource search paths`                                 |
| [`369ced9b`](https://github.com/NixOS/nixpkgs/commit/369ced9bae0f2f56adc34ad3975764699b6bcf2f) | `fcitx5-gtk: 5.0.13 -> 5.0.14`                                               |
| [`e41c423b`](https://github.com/NixOS/nixpkgs/commit/e41c423b01bb803c5745b8b296b2d898a3e5f798) | `nixos/version: add trailing newline to os-release`                          |
| [`0dae74a0`](https://github.com/NixOS/nixpkgs/commit/0dae74a028cd733b11f2d6f9848c1d673eda8bf7) | `telescope: 0.7.1 → 0.8.1`                                                   |
| [`208fd4f1`](https://github.com/NixOS/nixpkgs/commit/208fd4f17325cf506eea151e3614ae2081fa8b6c) | `linuxKernel.kernels.linux_zen: 5.17.7-zen1 -> 5.18.0-zen1`                  |
| [`3c4e372c`](https://github.com/NixOS/nixpkgs/commit/3c4e372c3f5a7ad8ff1182120a4ee99f9042abc4) | `kernel/update-zen.sh: add support to .0 patch versions`                     |
| [`dcd7915d`](https://github.com/NixOS/nixpkgs/commit/dcd7915d177acd0ce63ef3b54fe61d23c6733e0f) | `ostinato: fix desktop file`                                                 |
| [`c69a1a76`](https://github.com/NixOS/nixpkgs/commit/c69a1a7670c38f276dbe2f309cefd551cc9ce976) | `fcitx5-configtool: 5.0.12 -> 5.0.13`                                        |
| [`92d4e91a`](https://github.com/NixOS/nixpkgs/commit/92d4e91aaf1431c0655840493ea23ba0961b8071) | `fcitx5-chewing: 5.0.10 -> 5.0.11`                                           |
| [`61f655cc`](https://github.com/NixOS/nixpkgs/commit/61f655ccec8decd3df9efad56ec9756350a330cd) | `Revert "metamorphose2: drop"`                                               |
| [`bc11ff0c`](https://github.com/NixOS/nixpkgs/commit/bc11ff0cbc4ac9f4ae0d2ee535eaa0abc116fdc5) | `ocamlPackages.cppo: 1.6.8 -> 1.6.9`                                         |
| [`56e1d67f`](https://github.com/NixOS/nixpkgs/commit/56e1d67f0f016c367d845548485274f2eb473c4e) | `pyradio: install manpage`                                                   |
| [`e9fc987d`](https://github.com/NixOS/nixpkgs/commit/e9fc987d8d669391c9786890e442c9b49e0110d6) | `dask-xgboost: remove`                                                       |
| [`92413909`](https://github.com/NixOS/nixpkgs/commit/924139096a8064b4959c7e314c19293459741b37) | `honggfuzz: Use LLVM 12`                                                     |
| [`10f1d293`](https://github.com/NixOS/nixpkgs/commit/10f1d293c4a754785140358717c414b1847c3028) | `session-desktop-appimage: wayland support`                                  |
| [`6238d2fe`](https://github.com/NixOS/nixpkgs/commit/6238d2fe76bb2dcdc0af05ab6eacf9ac15d4a7ec) | `libsForQt5.qtstyleplugin-kvantum: add update script`                        |
| [`c1aec215`](https://github.com/NixOS/nixpkgs/commit/c1aec2157fe753de9f057fc7f940f2fbb6c31e3a) | `libsForQt5.qtstyleplugin-kvantum: 1.0.1 -> 1.0.2`                           |
| [`c2261bce`](https://github.com/NixOS/nixpkgs/commit/c2261bce535eb7e8887c8134a0d4f5c499eac8a6) | `python310Packages.pg8000: 1.28.2 -> 1.28.3`                                 |
| [`695b93b0`](https://github.com/NixOS/nixpkgs/commit/695b93b0795da031baeb0d46319d7b5710d40842) | `python310Packages.pg8000: 1.28.0 -> 1.28.2`                                 |
| [`1c884fb5`](https://github.com/NixOS/nixpkgs/commit/1c884fb5bd1ceae9e73220a8edb92c968142e223) | `lxqt.lxqt-session: 1.1.0 -> 1.1.1`                                          |
| [`6a693179`](https://github.com/NixOS/nixpkgs/commit/6a693179007f5b432559cd06859d7e1fd3488b55) | `lxqt.qtxdg-tools: init at 3.9.1`                                            |
| [`3ab2cf22`](https://github.com/NixOS/nixpkgs/commit/3ab2cf227936d71d8f22eedd4242610515b31c36) | `lxqt.libqtxdg: 3.9.0 -> 3.9.1`                                              |