### PR TITLE
chore(flake/nixpkgs): `fa66e6d4` -> `f6c4da49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1653750779,
-        "narHash": "sha256-yQ5bsgAnUMS/MB2uRi+RANcXtlNENYp5+CZNvDVGxFo=",
+        "lastModified": 1653839487,
+        "narHash": "sha256-UFTixs7vCadS50/J0Q5tIFSeXrDJs7lCKHi+a3V9oVQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa66e6d444f37c80d973d75fd3e0d28e286d8ea4",
+        "rev": "f6c4da49202d79cdab2fdf2bfa3019cde23f007e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`8a6dbc8b`](https://github.com/NixOS/nixpkgs/commit/8a6dbc8b7d4ea08956e651b02a824520fda7aed2) | `yafaray-core: stdenv -> gcc10Stdenv`                                            |
| [`da31172e`](https://github.com/NixOS/nixpkgs/commit/da31172e101780456194a922e6304afb4251f1bb) | `xqilla: stdenv -> gcc10Stdenv`                                                  |
| [`a5739070`](https://github.com/NixOS/nixpkgs/commit/a5739070a074aaca5177ef3392e3f421300dc544) | `xc3sprog: stdenv -> gcc10Stdenv`                                                |
| [`1461ead8`](https://github.com/NixOS/nixpkgs/commit/1461ead834295d5d49e0d29473ee8dfe8fbc29c9) | `wxcam: stdenv -> gcc10Stdenv`                                                   |
| [`1affead2`](https://github.com/NixOS/nixpkgs/commit/1affead2e664e4e98ee2fd8eaa4dcf7e516ed6f8) | `webrtc-audio-processing_1: stdenv -> gcc10Stdenv`                               |
| [`4281581f`](https://github.com/NixOS/nixpkgs/commit/4281581f32b5c8133532e5640607571241b57da9) | `uri: stdenv -> gcc10Stdenv`                                                     |
| [`101927cc`](https://github.com/NixOS/nixpkgs/commit/101927cc4608314b9d1f9af465d9ac0a78b2246e) | `ucg: stdenv -> gcc10Stdenv`                                                     |
| [`17cca505`](https://github.com/NixOS/nixpkgs/commit/17cca50520f19e793ff1a9cb962193c21f4d277b) | `tracebox: stdenv -> gcc10Stdenv`                                                |
| [`bb1a8a87`](https://github.com/NixOS/nixpkgs/commit/bb1a8a87a6f430d26462cdce1bdd72779b217f36) | `tiscamera: stdenv -> gcc10Stdenv`                                               |
| [`7bd4ef28`](https://github.com/NixOS/nixpkgs/commit/7bd4ef283545b3c7a9c190be3bb797ec1f46ee52) | `textadept11: stdenv -> gcc10Stdenv`                                             |
| [`fe9163ba`](https://github.com/NixOS/nixpkgs/commit/fe9163bac70fced8dd9a8c94789229630e3b684c) | `swiftshader: stdenv -> gcc10Stdenv`                                             |
| [`8c379ef3`](https://github.com/NixOS/nixpkgs/commit/8c379ef34fd7e9cf64377f0b0a89ad2fee25dd6a) | `swfmill: stdenv -> gcc10Stdenv`                                                 |
| [`70e3e0d8`](https://github.com/NixOS/nixpkgs/commit/70e3e0d8392e72d58418bbe987bc9797b2207bde) | `stuntrally: stdenv -> gcc10Stdenv`                                              |
| [`38a37662`](https://github.com/NixOS/nixpkgs/commit/38a3766228d556e4effa03b12a4cefe07ea0eb50) | `strelka: stdenv -> gcc10Stdenv`                                                 |
| [`c526e73e`](https://github.com/NixOS/nixpkgs/commit/c526e73ea2e2b985a7d6a6f24f59fe1ebfd95223) | `spring: stdenv -> gcc10Stdenv`                                                  |
| [`b9af2b5a`](https://github.com/NixOS/nixpkgs/commit/b9af2b5afded6f97f1c77e988fd759337e6935b0) | `sonic-lineup: stdenv -> gcc10Stdenv`                                            |
| [`91ef8a2d`](https://github.com/NixOS/nixpkgs/commit/91ef8a2d4e980be9bb4b6d2598b985fadb951655) | `rss-glx: stdenv -> gcc10Stdenv`                                                 |
| [`8297eeac`](https://github.com/NixOS/nixpkgs/commit/8297eeacdacbfe51a757b758da2d2e86cac52380) | `pktgen: stdenv -> gcc10Stdenv`                                                  |
| [`533171bf`](https://github.com/NixOS/nixpkgs/commit/533171bfff38d4d3bf6b5cbb1808441d6802f4ea) | `pianobooster: stdenv -> gcc10Stdenv`                                            |
| [`0655723b`](https://github.com/NixOS/nixpkgs/commit/0655723b231e348eebd5f276daf0c9f787de419e) | `percona-xtrabackup_8_0: stdenv -> gcc10Stdenv`                                  |
| [`5785f832`](https://github.com/NixOS/nixpkgs/commit/5785f8321c360e2b287476a033950f3e758cfdc0) | `percona-xtrabackup_2_4: stdenv -> gcc10Stdenv`                                  |
| [`cbdb85b7`](https://github.com/NixOS/nixpkgs/commit/cbdb85b7431e42bd6cbbf7ade24595f586cb1354) | `percona-server56: stdenv -> gcc10Stdenv`                                        |
| [`32e76212`](https://github.com/NixOS/nixpkgs/commit/32e76212c5d3b08fafbd85cc4c1621f3e5997d90) | `oxen: stdenv -> gcc10Stdenv`                                                    |
| [`edd13b55`](https://github.com/NixOS/nixpkgs/commit/edd13b5528f280e8d49f1d6acc1b764a18f32d7d) | `openvino: stdenv -> gcc10Stdenv`                                                |
| [`28bcbe1a`](https://github.com/NixOS/nixpkgs/commit/28bcbe1ac8341fec2f52e2d8e85b293af213bc33) | `opendbx: stdenv -> gcc10Stdenv`                                                 |
| [`e86878e1`](https://github.com/NixOS/nixpkgs/commit/e86878e1b1b502e6ae73d91c615f5b87921edfa9) | `openclonk: stdenv -> gcc10Stdenv`                                               |
| [`5ec76e1c`](https://github.com/NixOS/nixpkgs/commit/5ec76e1cd6d8b447b845e21025053e2e329c0612) | `olive-editor: stdenv -> gcc10Stdenv`                                            |
| [`2be028e9`](https://github.com/NixOS/nixpkgs/commit/2be028e9433ebad3fd74ee2a19e13c02e7f870cb) | `obliv-c: stdenv -> gcc10Stdenv`                                                 |
| [`15b44bab`](https://github.com/NixOS/nixpkgs/commit/15b44bab797525e200b4fbfc480e25dcb64636b5) | `non: stdenv -> gcc10Stdenv`                                                     |
| [`3eac0002`](https://github.com/NixOS/nixpkgs/commit/3eac0002ecaf7ff6964aae36e1148c084199f3c6) | `nano-wallet: stdenv -> gcc10Stdenv`                                             |
| [`41e537a5`](https://github.com/NixOS/nixpkgs/commit/41e537a5851b4c9d707118172cb88b0ce1d095e1) | `mrustc-bootstrap: stdenv -> gcc10Stdenv`                                        |
| [`c27f7b1b`](https://github.com/NixOS/nixpkgs/commit/c27f7b1b0088a7cfee9e3287bc3abcf6ebc04672) | `mps: stdenv -> gcc10Stdenv`                                                     |
| [`33851c46`](https://github.com/NixOS/nixpkgs/commit/33851c466f24548a12d90759fcbc3ab7138c4eb6) | `mkcue: stdenv -> gcc10Stdenv`                                                   |
| [`7976cdf5`](https://github.com/NixOS/nixpkgs/commit/7976cdf59e6ab91cbab01c8c560847ff19e3772d) | `mitscheme: stdenv -> gcc10Stdenv`                                               |
| [`43494af5`](https://github.com/NixOS/nixpkgs/commit/43494af5eb40c7cde1e9aa99c0a74de05df0dcf0) | `miniaudicle: stdenv -> gcc10Stdenv`                                             |
| [`b31af490`](https://github.com/NixOS/nixpkgs/commit/b31af490cdc25a70c431810c659c2c00b8dc364c) | `mars: stdenv -> gcc10Stdenv`                                                    |
| [`e3746258`](https://github.com/NixOS/nixpkgs/commit/e374625845656b36e7601c7fbf7eeee9c019696f) | `loki: stdenv -> gcc10Stdenv`                                                    |
| [`565851ab`](https://github.com/NixOS/nixpkgs/commit/565851ab191548c160f23f2af7a902a938770f6d) | `v2ray-geoip: 202203310042 -> 202205260055`                                      |
| [`ffaa0a94`](https://github.com/NixOS/nixpkgs/commit/ffaa0a94e989ddd279d50953adcb79e31e7b98ff) | `v2ray-domain-list-community: 20220324104603 -> 20220528180904`                  |
| [`14a2dec5`](https://github.com/NixOS/nixpkgs/commit/14a2dec50d54bcd6db2c346098e5e2d7d94d5912) | `libdynd: stdenv -> gcc10Stdenv`                                                 |
| [`872f4224`](https://github.com/NixOS/nixpkgs/commit/872f42247b166b06bc163ab113fff475cf48e44a) | `jigdo: stdenv -> gcc10Stdenv`                                                   |
| [`fcb1fbf5`](https://github.com/NixOS/nixpkgs/commit/fcb1fbf5fcfb9112f0d97e0522c7d7575c98a7d2) | `isrcsubmit: stdenv -> gcc10Stdenv`                                              |
| [`daa692e4`](https://github.com/NixOS/nixpkgs/commit/daa692e42c78791505b2cb9f04df2721be490021) | `iqueue: stdenv -> gcc10Stdenv`                                                  |
| [`0590c39f`](https://github.com/NixOS/nixpkgs/commit/0590c39ffac4a76facd3c177c16c62677017e6f7) | `idsk: stdenv -> gcc10Stdenv`                                                    |
| [`591dc2fd`](https://github.com/NixOS/nixpkgs/commit/591dc2fdd20604c260d4a83fdf46d238ff7c0e63) | `hobbes: stdenv -> gcc10Stdenv`                                                  |
| [`8dc4d734`](https://github.com/NixOS/nixpkgs/commit/8dc4d7347789bf10e80ff200f898953b15554c50) | `gsmlib: stdenv -> gcc10Stdenv`                                                  |
| [`0e05668d`](https://github.com/NixOS/nixpkgs/commit/0e05668dc3bcae625e9b781cb519923bcd25175b) | `gosmore: stdenv -> gcc10Stdenv`                                                 |
| [`9f22d631`](https://github.com/NixOS/nixpkgs/commit/9f22d631ebe66f4c5daf0b48c1966211309117ff) | `getdp: stdenv -> gcc10Stdenv`                                                   |
| [`feb6162f`](https://github.com/NixOS/nixpkgs/commit/feb6162f839c511d633f8f7363d4a7dc61026888) | `gebaar-libinput: stdenv -> gcc10Stdenv`                                         |
| [`5d8e2a71`](https://github.com/NixOS/nixpkgs/commit/5d8e2a71f170fc73c834c05d188dfaae59e284e9) | `gammy: stdenv -> gcc10Stdenv`                                                   |
| [`77aab56c`](https://github.com/NixOS/nixpkgs/commit/77aab56ca46e69328d0c261398ade4f344fb5af4) | `flwrap: stdenv -> gcc10Stdenv`                                                  |
| [`5e081aea`](https://github.com/NixOS/nixpkgs/commit/5e081aeaa14f7fabc85f3adad8c941695a7b2770) | `fluxus: stdenv -> gcc10Stdenv`                                                  |
| [`5b12d3a8`](https://github.com/NixOS/nixpkgs/commit/5b12d3a80728c018fa4d1fa5b858be8979e244b4) | `ericw-tools: stdenv -> gcc10Stdenv`                                             |
| [`fd26c949`](https://github.com/NixOS/nixpkgs/commit/fd26c9493b7b5312ed2db0925d3750e3ec72b7ed) | `dxx-rebirth: stdenv -> gcc10Stdenv`                                             |
| [`9882ffea`](https://github.com/NixOS/nixpkgs/commit/9882ffead490cfe93a6a41f22ebc01850b384073) | `dl-poly-classic-mpi: stdenv -> gcc10Stdenv`                                     |
| [`f111882b`](https://github.com/NixOS/nixpkgs/commit/f111882b8d155a2d40be82dd052044f940667c4f) | `python310Packages.celery: 5.2.6 -> 5.2.7`                                       |
| [`a484f4f3`](https://github.com/NixOS/nixpkgs/commit/a484f4f331e658b55776ad8577048c19be7427d5) | `djv: stdenv -> gcc10Stdenv`                                                     |
| [`30d46169`](https://github.com/NixOS/nixpkgs/commit/30d46169971537ff99134bb758abc3d7156fc845) | `diopser: stdenv -> gcc10Stdenv`                                                 |
| [`e46b8114`](https://github.com/NixOS/nixpkgs/commit/e46b811478874c17d6041ce70b1e7d00c5970ab4) | `cxxtools: stdenv -> gcc10Stdenv`                                                |
| [`c6af26ac`](https://github.com/NixOS/nixpkgs/commit/c6af26acfc7e15420c288dcc488a79afc816036d) | `clingcon: stdenv -> gcc10Stdenv`                                                |
| [`ff74ad6d`](https://github.com/NixOS/nixpkgs/commit/ff74ad6db307c1045c98eb5b183e9348c68cd42a) | `ocamlPackages.cooltt: unstable-2021-05-25 → unstable-2022-04-28`                |
| [`a1e9a866`](https://github.com/NixOS/nixpkgs/commit/a1e9a866e1cfa5ae02fdf52b2799c185ce24b0f8) | `ocamlPackages.yuujinchou: init at 2.0.0`                                        |
| [`f2be2aa1`](https://github.com/NixOS/nixpkgs/commit/f2be2aa1d5813720c568509a85e4d04eb533c8fc) | `ocamlPackages.bwd: init at 2.0.0`                                               |
| [`5ae182a0`](https://github.com/NixOS/nixpkgs/commit/5ae182a06f4bcc2687eb95df6296e2366d8b78bc) | `python310Packages.brother: 1.2.1 -> 1.2.2`                                      |
| [`8bdc1401`](https://github.com/NixOS/nixpkgs/commit/8bdc1401a2a22602c182f698ecf22a42a3c0fcbf) | `pkgs: added gcc10StdenvCompat`                                                  |
| [`7b0d8aba`](https://github.com/NixOS/nixpkgs/commit/7b0d8aba7eaf23698616942200868a4765b3e35d) | `ghostwriter: 2.1.2 -> 2.1.3`                                                    |
| [`f579f725`](https://github.com/NixOS/nixpkgs/commit/f579f725ed422275d31aa2a5977ddcaa177840ed) | `helix: 22.03 -> 22.05`                                                          |
| [`3f0dea3f`](https://github.com/NixOS/nixpkgs/commit/3f0dea3f05e6b085fa63a1f06595ece9b8d94b07) | `sad: 0.4.20 -> 0.4.21`                                                          |
| [`cf5da031`](https://github.com/NixOS/nixpkgs/commit/cf5da0313beef476d5536fe21e483bed7f393934) | `ipinfo: 2.8.0 -> 2.8.1`                                                         |
| [`a8f20c82`](https://github.com/NixOS/nixpkgs/commit/a8f20c82f5bb183e10eca2414c0072b150558afa) | `fd: 8.3.2 -> 8.4.0`                                                             |
| [`af04d4eb`](https://github.com/NixOS/nixpkgs/commit/af04d4eb146cb3784c883a76997613f2524e310e) | `python310Packages.mlflow: 1.26.0 -> 1.26.1`                                     |
| [`b680431c`](https://github.com/NixOS/nixpkgs/commit/b680431cb725c70f44a953c8ea69cb58bfe35af6) | `python310Packages.python-gitlab: 3.4.0 -> 3.5.0`                                |
| [`1a7c0eac`](https://github.com/NixOS/nixpkgs/commit/1a7c0eac1572f56afa970e5fe6493b85cecf51a5) | `pkgs/config.nix: Fix infinite recursion when freeform config is strict in pkgs` |
| [`523eb4a1`](https://github.com/NixOS/nixpkgs/commit/523eb4a181060ee60240e76512996bcbe5743c4a) | `pkgs.tests: Add regression test for #175196`                                    |
| [`d32a2bf2`](https://github.com/NixOS/nixpkgs/commit/d32a2bf207f41506cbcc86f69e057a47b8a83456) | `nixos/mimir: also expose mimirtool to users`                                    |
| [`a6cdcce0`](https://github.com/NixOS/nixpkgs/commit/a6cdcce08bb18d17819a2a76dfac8da7ce1a6328) | `nixos/mimir: add test`                                                          |
| [`64979024`](https://github.com/NixOS/nixpkgs/commit/64979024070de7a9eab3bd66f54a4680163efa3a) | `nixos/mimir: set workingdirectory`                                              |
| [`94733b13`](https://github.com/NixOS/nixpkgs/commit/94733b13d89372c76e51f9d1c53279d706d6b025) | `grafana-mimir: 2.0.0 -> 2.1.0`                                                  |
| [`c9a2833a`](https://github.com/NixOS/nixpkgs/commit/c9a2833a575b682d97e1f3e2be483414fcd0b787) | `syslinux: add -fcommon workaround`                                              |
| [`ae7e4c0e`](https://github.com/NixOS/nixpkgs/commit/ae7e4c0ef54b63a76bda4dbfefd15127674170fc) | `sniproxy: pull upstream fix for -fno-common toolchain support`                  |
| [`b8186ef9`](https://github.com/NixOS/nixpkgs/commit/b8186ef950ef3360f9306a6c88f3cb218ecb926f) | `ocamlPackages.sedlex: 2.4 → 2.5`                                                |
| [`5637570f`](https://github.com/NixOS/nixpkgs/commit/5637570f510374806019c8bcfe5df2994790b02e) | `ocamlPackages: rename sedlex_2 into sedlex`                                     |
| [`c3e55aa7`](https://github.com/NixOS/nixpkgs/commit/c3e55aa79ac4d856eb8f309ff651173b0ebec7b4) | `ocamlPackages.sedlex: remove at 1.99.5`                                         |
| [`64da60d3`](https://github.com/NixOS/nixpkgs/commit/64da60d311b10c2106dd2e1d05b58e20c6a9a8b3) | `passage: init at unstable-2022-05-01`                                           |
| [`87fd7210`](https://github.com/NixOS/nixpkgs/commit/87fd72101b19775a91228e0c94c31939546d5bd2) | `gnome.gnome-terminal: 3.44.0 -> 3.44.1`                                         |
| [`d64d4c8f`](https://github.com/NixOS/nixpkgs/commit/d64d4c8fcc585abe3dc159a4d7091c0cc6cd5f10) | `gnome.gnome-maps: 42.1 -> 42.2`                                                 |
| [`213cac42`](https://github.com/NixOS/nixpkgs/commit/213cac429ffc20729ac1e47cb5ba0baf701e4160) | `gnome.eog: 42.1 -> 42.2`                                                        |
| [`9344541f`](https://github.com/NixOS/nixpkgs/commit/9344541ff215ee2929767196fb639b0f93d6ad63) | `gnome.aisleriot: 3.22.22 -> 3.22.23`                                            |
| [`9c2dcb5a`](https://github.com/NixOS/nixpkgs/commit/9c2dcb5ac55e5200ad4afc238cec5901e54dcec5) | `ngrok-1: remove`                                                                |
| [`06347116`](https://github.com/NixOS/nixpkgs/commit/063471168d60a9f5f5cf097d845fafc3bdd8404a) | `argocd-autopilot: 0.3.5 -> 0.3.7`                                               |
| [`b9e79f4f`](https://github.com/NixOS/nixpkgs/commit/b9e79f4fc94a8cfb0bb190b529baf2426604b361) | `python310Packages.mkdocs-material: 8.2.15 -> 8.2.16`                            |
| [`65450988`](https://github.com/NixOS/nixpkgs/commit/65450988a59dc253a93148e6d9cd739a0e9e2083) | `python310Packages.ocrmypdf: fix build on Darwin`                                |
| [`ab71980f`](https://github.com/NixOS/nixpkgs/commit/ab71980f5ce9dfae2004cd1b320fcb0166febfd5) | `ocrmypdf: install completions`                                                  |
| [`57436c50`](https://github.com/NixOS/nixpkgs/commit/57436c50ee9f1cb4bb9b6b18220d83f2dd5e4e75) | `python310Packages.miniaudio: fix build on Darwin`                               |
| [`a4de8822`](https://github.com/NixOS/nixpkgs/commit/a4de88225b203d0c78d7b837998eba4b627b5481) | `checkov: 2.0.1161 -> 2.0.1162`                                                  |
| [`f0eb6d20`](https://github.com/NixOS/nixpkgs/commit/f0eb6d2059d307ff1a8fa2758b23bf2cdcde9897) | `python310Packages.pikepdf: fix build on aarch64-darwin`                         |
| [`f83d9e2c`](https://github.com/NixOS/nixpkgs/commit/f83d9e2c743c36ff2469c9661be7a89a89e4d7d1) | `yq-go: 4.25.1 -> 4.25.2`                                                        |
| [`49f2c94e`](https://github.com/NixOS/nixpkgs/commit/49f2c94e0c078afe58627a39c3f2149f68bedaaa) | `rockbox-utility: add -fcommon workaround`                                       |
| [`c3c0dd00`](https://github.com/NixOS/nixpkgs/commit/c3c0dd00d8f2a0bbfb5961be048ccc66dc87b133) | `treewide: fix loss of precision in NixOS systems`                               |
| [`793f99c4`](https://github.com/NixOS/nixpkgs/commit/793f99c48e3a6d6b47e88deb20ff6171e7971977) | `monado: 21.0.0 -> unstable-2022-05-28 (#173907)`                                |
| [`fd86efb8`](https://github.com/NixOS/nixpkgs/commit/fd86efb8c29ca83cbacd579c6318754ad45de360) | `nixos/nextcloud: Fix broken config file`                                        |
| [`9d792ec3`](https://github.com/NixOS/nixpkgs/commit/9d792ec3afb0915dcf97cd94f1527d35c2d2994e) | `nmrpflash: init at 0.9.16`                                                      |
| [`057d5669`](https://github.com/NixOS/nixpkgs/commit/057d5669796ef7b95f5783476dadc299a4aba22c) | `avrdudess: 2.13 -> 2.14`                                                        |
| [`344cbed6`](https://github.com/NixOS/nixpkgs/commit/344cbed64f5846272b7dcb23f489869d9ba9452c) | `postgresqlPackages.rum: 1.3.9 -> 1.3.11`                                        |
| [`ddf27358`](https://github.com/NixOS/nixpkgs/commit/ddf273588e069b5267d116d8539dab09e8bb55ba) | `linuxPackages.digimend: unstable-2019-06-18 -> 10`                              |
| [`d40f59d7`](https://github.com/NixOS/nixpkgs/commit/d40f59d7db27d5dd5ffd8e28b40c6b0069add611) | `hplip: add missing distro dependency`                                           |
| [`6c65b37d`](https://github.com/NixOS/nixpkgs/commit/6c65b37d3ebe3a9b42adacfc078d04a421e7b13d) | `python310Packages.brother: update stale substituteInPlace`                      |
| [`337d4b8a`](https://github.com/NixOS/nixpkgs/commit/337d4b8ad4cf0f88702837805584db164cc8b32d) | `python310Packages.chess: 1.9.0 -> 1.9.1`                                        |
| [`304c67b3`](https://github.com/NixOS/nixpkgs/commit/304c67b3994c10e6f5dd793d152b4fd9cf9931e9) | `python310Packages.brother: 1.2.0 -> 1.2.1`                                      |
| [`8ece1240`](https://github.com/NixOS/nixpkgs/commit/8ece1240d36048a773d13ec2ef0c00efb82541aa) | `mdbook-mermaid: 0.10.0 -> 0.11.0`                                               |
| [`f89bd409`](https://github.com/NixOS/nixpkgs/commit/f89bd409e9e52cb9d1e1a374a9fa54d97c8ac7b0) | `smlnj,smlnjBootstrap: set meta.mainProgram`                                     |
| [`45109ffc`](https://github.com/NixOS/nixpkgs/commit/45109ffcb8c2ef1998129cd52bd9685f0763b11d) | `snowflake: 2.0.1 -> 2.2.0`                                                      |
| [`d0635186`](https://github.com/NixOS/nixpkgs/commit/d0635186fe059a40d1155182bfd33ca0f265c40c) | `eksctl: 0.98.0 -> 0.99.0`                                                       |
| [`b0615fc1`](https://github.com/NixOS/nixpkgs/commit/b0615fc1529b51dd0daf8f8d2a4308f1d04edcec) | `shadowsocks-rust: 1.14.2 -> 1.14.3`                                             |
| [`a302554b`](https://github.com/NixOS/nixpkgs/commit/a302554b9549683c6b9e115f335f9d4aa97cbf69) | `lxd: 5.1 -> 5.2`                                                                |
| [`c87a7d3d`](https://github.com/NixOS/nixpkgs/commit/c87a7d3d312f3ddf0240affedd91d87a11a3211a) | `clair: 4.3.6 -> 4.4.2`                                                          |
| [`6990198e`](https://github.com/NixOS/nixpkgs/commit/6990198ebaf63d11509268c7155199020e4894bb) | `rqbit: 2.1.3 -> 2.1.4`                                                          |
| [`54e5a04e`](https://github.com/NixOS/nixpkgs/commit/54e5a04e8c0f384262b7e2e9a790f58f55e4c1ed) | `diffoscope: 213 -> 214`                                                         |
| [`44f64d32`](https://github.com/NixOS/nixpkgs/commit/44f64d32d71940349e28a209575caae6aff3fc9d) | `shopify-themekit: 1.0.3 -> 1.3.0`                                               |
| [`9e22a360`](https://github.com/NixOS/nixpkgs/commit/9e22a360807e1d09b1a43dc5b8a4a8244a74a7e9) | `pari: 2.13.3 -> 2.13.4`                                                         |
| [`82d40a06`](https://github.com/NixOS/nixpkgs/commit/82d40a0695e5143d2abed55d4c8499f5d9206063) | `nauty: 27r1 -> 2.7r3`                                                           |
| [`73a936af`](https://github.com/NixOS/nixpkgs/commit/73a936afa2b765643a59476e9f190085cb4eadba) | `elliptic_curves: 0.8 -> 0.8.1`                                                  |
| [`4d4ffdea`](https://github.com/NixOS/nixpkgs/commit/4d4ffdeaef3ba881ae653fc0254a65cf2ab76f54) | `planarity: 3.0.0.5 -> 3.0.2.0`                                                  |
| [`9b11851c`](https://github.com/NixOS/nixpkgs/commit/9b11851ccfa28bcdf35c81700c786b5ea1f0d252) | `wiki-js: 2.5.282 -> 2.5.283`                                                    |
| [`09d49591`](https://github.com/NixOS/nixpkgs/commit/09d4959131394829370c41f14109c8ad61051de9) | `python310Packages.cbor2: 5.4.2.post1 -> 5.4.3`                                  |
| [`958cf873`](https://github.com/NixOS/nixpkgs/commit/958cf873dcfe6e6c9d57491dec732fd2906cdd84) | `dvc: 2.9.5 -> 2.10.2`                                                           |
| [`cd078794`](https://github.com/NixOS/nixpkgs/commit/cd07879440037c58de8f9523476abb4516e553b0) | `python3Packages.aioftp: skip pasv-mode test on darwin`                          |
| [`e45d512e`](https://github.com/NixOS/nixpkgs/commit/e45d512ec56c34ab4c61ce8928b6394202d8efd2) | `python310Packages.dvclive: init at 0.8.2`                                       |
| [`5ea24139`](https://github.com/NixOS/nixpkgs/commit/5ea241396e9703dff1d086368d79b40688b5f950) | `python310Packages.dvc-render: init at 0.0.5`                                    |
| [`6a99dc64`](https://github.com/NixOS/nixpkgs/commit/6a99dc64983c320fa2aff49cfddd6fce902198d1) | `python310Packages.pytest-test-utils: init at 0.0.6`                             |
| [`381f5fac`](https://github.com/NixOS/nixpkgs/commit/381f5fac3e7aa9d72349a8d113744764c76aa844) | `sparrow: 1.6.4 -> 1.6.5`                                                        |
| [`80fd3d72`](https://github.com/NixOS/nixpkgs/commit/80fd3d729a3fa96ea9a783350376d196d83920c7) | `bisq-desktop: 1.8.4 -> 1.9.1`                                                   |
| [`1402abc3`](https://github.com/NixOS/nixpkgs/commit/1402abc37bb364f4e3d17ae92824f2a22dcbd4fe) | `protonvpn-gui: 1.8.0 -> 1.9.0`                                                  |
| [`c6bc9815`](https://github.com/NixOS/nixpkgs/commit/c6bc981598ba543ddc9f6f70c9801f72233b5851) | `protonvpn-cli: 3.11.1 -> 3.12.0`                                                |
| [`4ae6a966`](https://github.com/NixOS/nixpkgs/commit/4ae6a966c567b1a3117be4d278a866ba7a6b52a7) | `python3Packages.protonvpn-nm-cli: 3.9.0 -> 3.10.0`                              |
| [`89ade403`](https://github.com/NixOS/nixpkgs/commit/89ade403cd1055905979268c27c8360f2e87103d) | `python310Packages.django-cacheops: 6.0 -> 6.1`                                  |
| [`0a847a12`](https://github.com/NixOS/nixpkgs/commit/0a847a12f07d20209103a8fa4a440d1eb7dca127) | `gcsfuse: 0.41.0 -> 0.41.1`                                                      |
| [`c1ce3a13`](https://github.com/NixOS/nixpkgs/commit/c1ce3a13338d6a6eeca2898b5adbf6d2f26b2cef) | `frugal: 3.15.0 -> 3.15.1`                                                       |
| [`9ba82576`](https://github.com/NixOS/nixpkgs/commit/9ba82576945ab2153f78d980cf3238f8824c5a2e) | `python310Packages.python-telegram-bot: 13.11 -> 13.12`                          |
| [`569e8b5d`](https://github.com/NixOS/nixpkgs/commit/569e8b5df439e5dc7dbe271cfeb6f31044e00989) | `folly: 2022.05.16.00 -> 2022.05.23.00`                                          |
| [`6269ca3e`](https://github.com/NixOS/nixpkgs/commit/6269ca3e43f8263da4ce4f25e41f269b5b719f41) | `flannel: 0.17.0 -> 0.18.0`                                                      |
| [`8c364a8c`](https://github.com/NixOS/nixpkgs/commit/8c364a8cae27b87ab192b609c3156847f5aed06b) | `fits-cloudctl: 0.10.13 -> 0.10.17`                                              |
| [`ddaaad11`](https://github.com/NixOS/nixpkgs/commit/ddaaad11c7a9807e017808b8906afc6c860235d6) | `faustlive: 2.5.8 -> 2.5.10`                                                     |
| [`51e7b88d`](https://github.com/NixOS/nixpkgs/commit/51e7b88dd30233ae516ff715af9dbbf3f728d3d0) | `ergo: 4.0.23 -> 4.0.30`                                                         |
| [`635d185f`](https://github.com/NixOS/nixpkgs/commit/635d185f91c3493a23606b249a7ab380523dd4ba) | `each: 0.1.3 -> 0.2.0`                                                           |
| [`5117a530`](https://github.com/NixOS/nixpkgs/commit/5117a5302643a697bdec6cd40f9982c6413244ce) | `dnsproxy: 0.42.1 -> 0.43.0`                                                     |
| [`9f9301f1`](https://github.com/NixOS/nixpkgs/commit/9f9301f19c20ea48c4161419acbe96936f5a763a) | `datadog-agent: 7.35.1 -> 7.36.0`                                                |