### PR TITLE
chore(flake/utils): `04c1b180` -> `1ed9fb19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -254,11 +254,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                  |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`1ed9fb19`](https://github.com/numtide/flake-utils/commit/1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1) | `Fix check-utils template directory name (#70)` |