### PR TITLE
chore(flake/nixpkgs): `49a2bcc6` -> `c54145c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654012153,
-        "narHash": "sha256-In+gfoH2Tnf/UmpzeuGlfuexU2EC4QIelBsm2zMK5AE=",
+        "lastModified": 1654057061,
+        "narHash": "sha256-6xvCl+FbMTUnAGDKYnp5v/y/wORbQ0aa5SrmdQfxVpU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "49a2bcc6e2065909c701f862f9a1a62b3082b40a",
+        "rev": "c54145c7cfa7961995f389fd038db60cd6943e0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                    |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`affd0fc3`](https://github.com/NixOS/nixpkgs/commit/affd0fc3e4b3f37c389864d949f8a924f02ec495) | `python3Packages.pywlroots: 0.15.14 -> 0.15.15`                                   |
| [`21c2e9d0`](https://github.com/NixOS/nixpkgs/commit/21c2e9d069e22da92c4f1e144eeb763131aacdd3) | `gnustep.base: Remove duplicated giflib input`                                    |
| [`21443080`](https://github.com/NixOS/nixpkgs/commit/21443080ad69b4d0b43258abf235bd332ebd4141) | `GNUcash: 4.9 -> 4.10 (#172445)`                                                  |
| [`2f18afa9`](https://github.com/NixOS/nixpkgs/commit/2f18afa90c84f9a8201f944a03085a8a3901f658) | `system76 firmware: 1.0.31 -> 1.0.39 (#175640)`                                   |
| [`aff15c41`](https://github.com/NixOS/nixpkgs/commit/aff15c41fc902d06410897d968fe61c6f83211f2) | `dmarc-metrics-exporter: rename from prometheus-dmarc-exporter`                   |
| [`fedeef0f`](https://github.com/NixOS/nixpkgs/commit/fedeef0ff65b1e18ade8c5f44f7995367c3a0100) | `python310Packages.types-setuptools: 57.4.15 -> 57.4.17`                          |
| [`a0af6bfe`](https://github.com/NixOS/nixpkgs/commit/a0af6bfe42880013b4fdedeb87a86495c036484a) | `glpaper: unstable-2020-10-11 -> unstable-2022-05-15`                             |
| [`0835ac53`](https://github.com/NixOS/nixpkgs/commit/0835ac53cfc7387ef8de43bafc36ede6f61461a9) | `linuxPackages.kvmfr: fix for linux 5.18`                                         |
| [`4c6448bb`](https://github.com/NixOS/nixpkgs/commit/4c6448bbe63fb0298c5536d7205b3d5605e11c96) | `portfolio: 0.57.2 -> 0.58.3`                                                     |
| [`cfce5cc0`](https://github.com/NixOS/nixpkgs/commit/cfce5cc04cc8843cd22e15630c64792d2be8c42a) | `python310Packages.gspread: 5.3.2 -> 5.4.0`                                       |
| [`f1f2f783`](https://github.com/NixOS/nixpkgs/commit/f1f2f78340eeb738054dcd955e83065dcdc4d591) | `python310Packages.llfuse: 1.4.1 -> 1.4.2`                                        |
| [`0f44989a`](https://github.com/NixOS/nixpkgs/commit/0f44989a6c7cf2465ab911b22b4966a4be933d22) | `nixui: remove`                                                                   |
| [`9e807c4a`](https://github.com/NixOS/nixpkgs/commit/9e807c4adea504cb9cddfea115e781943c0b7f1a) | `python310Packages.gpsoauth: 1.0.0 -> 1.0.1`                                      |
| [`aed49b42`](https://github.com/NixOS/nixpkgs/commit/aed49b42fac2a6b466650f7f115cdf16b483d44e) | `python310Packages.google-re2: 0.2.20220401 -> 0.2.20220601`                      |
| [`d7ccd36a`](https://github.com/NixOS/nixpkgs/commit/d7ccd36aa0a38c9c6d8d30e3afd5fae7505e2cdd) | `libreoffice: run the update-script's side-effect at runtime instead of eval`     |
| [`d43373cd`](https://github.com/NixOS/nixpkgs/commit/d43373cdd60488e93f78dc8a8e2160995c02cdcd) | `dnscontrol: 3.16.1 -> 3.16.2`                                                    |
| [`eebbc152`](https://github.com/NixOS/nixpkgs/commit/eebbc1525af5b7261a11a714e55497d1a8f66a54) | `vimPlugins.nvim-config-local: init at 2022-03-26`                                |
| [`f0e0734f`](https://github.com/NixOS/nixpkgs/commit/f0e0734f6132276a9fa8ccaef97b5e2cec8b30bb) | `Fix: make pyarrow buildable on darwin`                                           |
| [`c8474bca`](https://github.com/NixOS/nixpkgs/commit/c8474bca5455d1a34fa99fbba497a3f4a488cd8e) | `zsh: remove versioned binary`                                                    |
| [`e87f16b2`](https://github.com/NixOS/nixpkgs/commit/e87f16b25d3e3792f1f58ab491360c2666399728) | `python310Packages.sphinxcontrib-spelling: 7.4.1 -> 7.5.0`                        |
| [`e0903ce6`](https://github.com/NixOS/nixpkgs/commit/e0903ce6aaea2fa1f783ed658f37c2e106b47510) | `gnome-obfuscate: 0.0.4 -> 0.0.7`                                                 |
| [`1910aeba`](https://github.com/NixOS/nixpkgs/commit/1910aeba407b22330cf2b4f6651cbd8ebe23261e) | `leocad: enable povray support`                                                   |
| [`05135c97`](https://github.com/NixOS/nixpkgs/commit/05135c973d03f1bbc645ced9da2804a7d99afe76) | `cloudflared: isn't broken after all`                                             |
| [`9b46fd9b`](https://github.com/NixOS/nixpkgs/commit/9b46fd9ba06c2ef388361b000724359799d03c9f) | `borgbackup: cython is only required at build-time`                               |
| [`43337d4f`](https://github.com/NixOS/nixpkgs/commit/43337d4f93da9348d744112fa351e110986e3113) | `borgbackup: need either pyfuse3 or llfuse`                                       |
| [`a3859b79`](https://github.com/NixOS/nixpkgs/commit/a3859b796fea622e4173fa18500842e70b74f2af) | `python310Packages.pyfuse3: cythonize before building`                            |
| [`156532fd`](https://github.com/NixOS/nixpkgs/commit/156532fdc0ff066af6b0ad442bdda2649077bd90) | `Move geospatial servers into its own folder`                                     |
| [`9075eec2`](https://github.com/NixOS/nixpkgs/commit/9075eec2a76c7d4d963a023f1b715bbc681d22c9) | `mkgmap: 4902 -> 4904`                                                            |
| [`84065e32`](https://github.com/NixOS/nixpkgs/commit/84065e32ba502d521d8a750b05f68bf37198350b) | `python310Packages.sunpy: 3.1.6 -> 4.0.0`                                         |
| [`4729707e`](https://github.com/NixOS/nixpkgs/commit/4729707e40d212f9b794c9ca49e34c1efdc01429) | `nix-doc: 0.5.3->0.5.4 to support nix 2.9.0`                                      |
| [`09350ff7`](https://github.com/NixOS/nixpkgs/commit/09350ff7d4243e81fcab99cdd5f2c696075de42e) | `nixos/atop: Convert log format to fix service start`                             |
| [`bd1d3d24`](https://github.com/NixOS/nixpkgs/commit/bd1d3d243a48bb58d21dcd4a244b986b32b3a662) | `imagemagick: 7.1.0-35 -> 7.1.0-36`                                               |
| [`5b314280`](https://github.com/NixOS/nixpkgs/commit/5b314280b05938086854ca178e023ca44bdb52b5) | ``magic-wormhole-rs: Add alias `wormhole-rs```                                    |
| [`4c23cbcc`](https://github.com/NixOS/nixpkgs/commit/4c23cbcc15034e043ab522815af020254c2472da) | `libreoffice: add impure functions comment`                                       |
| [`e18ca9a9`](https://github.com/NixOS/nixpkgs/commit/e18ca9a9108d1ab5a080139cd4657e29722a1299) | `pulseaudio: fix !bluetoothSupport build`                                         |
| [`a5c1d43a`](https://github.com/NixOS/nixpkgs/commit/a5c1d43a31d6eb4a2f0a463b2cc9349a9ce20da3) | `qogir-theme: 2022-04-29 -> 2022-05-29`                                           |
| [`654856e8`](https://github.com/NixOS/nixpkgs/commit/654856e8dffe7188217ed089211e2f37c6c58be6) | `xplr: 0.17.6 -> 0.18.0`                                                          |
| [`0287ef10`](https://github.com/NixOS/nixpkgs/commit/0287ef1019a15356ad2a6d20fe1e566d2c9a3795) | `flat-remix-gnome: update 20220510 -> 20220524`                                   |
| [`68b6a3d7`](https://github.com/NixOS/nixpkgs/commit/68b6a3d71b2d541c211063417563c2bfdec0fa1b) | `python310Packages.ocrmypdf: 13.4.5 -> 13.4.6`                                    |
| [`fe949d64`](https://github.com/NixOS/nixpkgs/commit/fe949d64ef417ec254fea7d2ae022b1f78f4ad1e) | `libreoffice: rename libreoffice -> libreoffice-bin`                              |
| [`39478cbe`](https://github.com/NixOS/nixpkgs/commit/39478cbeffb2a9044112a070db46652d5efbffaf) | `leocad: 21.03 -> 21.06`                                                          |
| [`56ce01ec`](https://github.com/NixOS/nixpkgs/commit/56ce01eca397ece27f5073f7eee3e637e90b4d2a) | `libreoffice: pass explicit file to update-source-version function and`           |
| [`106bfcaf`](https://github.com/NixOS/nixpkgs/commit/106bfcaf8a916650f01df5498020e273905c2172) | `nixos/openconnect: add autoStart option`                                         |
| [`8315cf27`](https://github.com/NixOS/nixpkgs/commit/8315cf274bf02124dbdea8106d6cd7ccefbd9484) | `libreoffice: add darwin to meta platforms and extract to common.nix`             |
| [`b9a5485a`](https://github.com/NixOS/nixpkgs/commit/b9a5485aa5ebe0547de52f04603831d74f00e1f8) | `Revert "libreoffice: move darwin to separate libreoffice-darwin package"`        |
| [`d4dd3f5f`](https://github.com/NixOS/nixpkgs/commit/d4dd3f5f7e2f1df1e57f933504f942404e8eca9c) | `libreoffice: move darwin to separate libreoffice-darwin package`                 |
| [`2fb0615a`](https://github.com/NixOS/nixpkgs/commit/2fb0615a66d2d7bd4745aeec995645e7cb01411b) | ``libreoffice: add integration test and use `lib.fakeSha256```                    |
| [`d679ccc9`](https://github.com/NixOS/nixpkgs/commit/d679ccc970b7847a3bf216a1456c99ec5a52f774) | `libreoffice: apply suggestions from code review`                                 |
| [`ccfd4255`](https://github.com/NixOS/nixpkgs/commit/ccfd4255bb77f3769345e6e1799eb2f00168e05a) | `libreoffice: 7.2.5 -> 7.3.3`                                                     |
| [`ed52a449`](https://github.com/NixOS/nixpkgs/commit/ed52a4493459ee51f9e8d0bf31b707b5a8598693) | `libreoffice: general darwin improvements`                                        |
| [`9f80b6d8`](https://github.com/NixOS/nixpkgs/commit/9f80b6d8fe87eccd39e7018512de6998c2765551) | `libreoffice: refactor and document version reset workaround`                     |
| [`8395d7a4`](https://github.com/NixOS/nixpkgs/commit/8395d7a4d390dad584ebc3f31c14c67f71e9c591) | `libreoffice: add update-script for darwin`                                       |
| [`d88f9f6a`](https://github.com/NixOS/nixpkgs/commit/d88f9f6a3be6833c0bf0925c6521f02ee64a7d20) | `python3Packages.more-properties: init at 1.1.1`                                  |
| [`74625634`](https://github.com/NixOS/nixpkgs/commit/746256345f12f2278632217fa9ec13d6de8dd9b4) | `python3Packages.docformatter: init at 1.4`                                       |
| [`2c942c0e`](https://github.com/NixOS/nixpkgs/commit/2c942c0eaf570cdf946c4568b2ed45b29007c2e2) | `python3Packages.dataclasses-serialization: init at 1.3.1`                        |
| [`e2860780`](https://github.com/NixOS/nixpkgs/commit/e28607802d925d57fb8fb2fd0cf0917dabb0840d) | `python3Packages.more-properties: init at 1.1.1`                                  |
| [`1a16b511`](https://github.com/NixOS/nixpkgs/commit/1a16b5113edd1391847f22331a92e9ab1324aa50) | `python3Packages.bite-parser: init at 0.1.1`                                      |
| [`19dd9236`](https://github.com/NixOS/nixpkgs/commit/19dd92369e27197002e8c0b03ff3538dfd843276) | `zsh: 5.8.1 -> 5.9 && add artturin to maintainers`                                |
| [`2cdd54c2`](https://github.com/NixOS/nixpkgs/commit/2cdd54c279b563fac6b658b35c214ab1936d7109) | `linuxPackages.openrazer: enable parallel building`                               |
| [`08280046`](https://github.com/NixOS/nixpkgs/commit/0828004641db1dc111f7d14004a7101626980e30) | `openrazer-daemon,linuxPackages.openrazer,python3.pkgs.openrazer: 3.1.0 -> 3.3.0` |
| [`298e2ce3`](https://github.com/NixOS/nixpkgs/commit/298e2ce302c3d4eeacaca4bf4d0437253a8cafbc) | `nixos/grafana: add disableLoginForm option`                                      |
| [`ea8f7e7b`](https://github.com/NixOS/nixpkgs/commit/ea8f7e7bbdea64e693fc09f0a68d55d5a260020f) | `nixos/grafana: add serveFromSubPath option`                                      |
| [`e13ec872`](https://github.com/NixOS/nixpkgs/commit/e13ec87217c949d0aea368fafb2808578e2ced05) | `nixos/grafana: add Azure AD OAuth options`                                       |
| [`c047171d`](https://github.com/NixOS/nixpkgs/commit/c047171df6b1790d0a8776099cfe55059c8ac4e2) | `python39Packages.nbclient.passthru.tests.check: fix tests`                       |
| [`29bcdaad`](https://github.com/NixOS/nixpkgs/commit/29bcdaade355680132add66fc676ca86e2aaf88d) | `nixos/libreddit: remove redirect option`                                         |
| [`f04ef2a2`](https://github.com/NixOS/nixpkgs/commit/f04ef2a25b292144ba7856c96b2a96fee99639dc) | `nixos/libreddit: do not test an error`                                           |
| [`d68f731b`](https://github.com/NixOS/nixpkgs/commit/d68f731ba246add4c4e456d829eb19136e65290e) | `nixos/libreddit: systemd unit hardening`                                         |