### PR TITLE
chore(flake/home-manager): `bda2c80b` -> `8f3e2670`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1653937612,
-        "narHash": "sha256-HybwffYKOM3UwlY54ZVCZgX7o5xpp2KhbZyyOnvwFMo=",
+        "lastModified": 1653943687,
+        "narHash": "sha256-xXW9t24HLf89+n/92kOqRRfOBE3KDna+9rAOefs5WSQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bda2c80b4c1a8d85c84c343a25ac7303fbc7999d",
+        "rev": "8f3e26705178cc8c1d982d37d881fc0d5b5b1837",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                               |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`8f3e2670`](https://github.com/nix-community/home-manager/commit/8f3e26705178cc8c1d982d37d881fc0d5b5b1837) | `doc: make documentation links more visible` |