### PR TITLE
chore(flake/nixos-hardware): `8252035d` -> `0cab18a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -120,11 +120,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1654030195,
-        "narHash": "sha256-jTkn9mvvmLITy+TUIoxvPFxrafBKz3gjLyq3wkVNCso=",
+        "lastModified": 1654057797,
+        "narHash": "sha256-mXo7C4v7Jj2feBzcReu1Eu/3Rnw5b023E9kOyFsHZQw=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "8252035d61aabffe05f49f7e05a6381bd5e4b40f",
+        "rev": "0cab18a48de7914ef8cad35dca0bb36868f3e1af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`03fd7b6b`](https://github.com/NixOS/nixos-hardware/commit/03fd7b6bd0724c71fe21c200f94bf6c2c4d2a011) | `msi/gl62: also include basic README` |
| [`0543980b`](https://github.com/NixOS/nixos-hardware/commit/0543980bd62216ed625301bc1221fe55265d8dd7) | `msi/gl62: init`                      |