### PR TITLE
chore(flake/home-manager): `8f3e2670` -> `684e85d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1653943687,
-        "narHash": "sha256-xXW9t24HLf89+n/92kOqRRfOBE3KDna+9rAOefs5WSQ=",
+        "lastModified": 1654113406,
+        "narHash": "sha256-70esZvhal+FsyU89mJRcAb+cDGHKt0sgZ6MlRr9Cplg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8f3e26705178cc8c1d982d37d881fc0d5b5b1837",
+        "rev": "684e85d01d333be91c4875baebb05b93c7d2ffaa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`684e85d0`](https://github.com/nix-community/home-manager/commit/684e85d01d333be91c4875baebb05b93c7d2ffaa) | `docs: set 22.11 as next version`               |
| [`ac2287df`](https://github.com/nix-community/home-manager/commit/ac2287df5a2d6f0a44bbcbd11701dbbf6ec43675) | `docs: set 22.05 as stable version`             |
| [`1808cb66`](https://github.com/nix-community/home-manager/commit/1808cb66aa2134d9e627d4aa868ee95e5fe683ed) | `news: remove a bunch of old (>1 year) entries` |
| [`acad715f`](https://github.com/nix-community/home-manager/commit/acad715f788d07ac320662c52b41d3edae48ec2d) | `docs: update copyright year`                   |