### PR TITLE
chore(flake/nixpkgs): `a7c9f34b` -> `0fe729df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654244685,
-        "narHash": "sha256-wrOIDka35lIaYWHAEPZdNAbUZDewKXrjJoQkkyhSIFw=",
+        "lastModified": 1654374252,
+        "narHash": "sha256-PfsJACqKb6m1abRTZP2MRkQtMjcq5Cw/1FX30XiQDLI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a7c9f34b0b660b0950a23ff80c5d9f42cc5e8532",
+        "rev": "0fe729dfae92b676a99067312e1637b3527cb75d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`7156139d`](https://github.com/NixOS/nixpkgs/commit/7156139d289dcd7ef0ab20c786978a59411cefe5) | `perlPackages.Gtk3: 0.037 -> 0.038`                                                                  |
| [`be5f2f37`](https://github.com/NixOS/nixpkgs/commit/be5f2f37f5e3087858f32ee4f077ba4c5c46a48d) | `perlPackages.Gtk3: Fix darwin build`                                                                |
| [`c2a661ad`](https://github.com/NixOS/nixpkgs/commit/c2a661ad6220fabf2d4c01ce2b0fe830b51d8a8c) | `lndhub-go: init at 0.7.0`                                                                           |
| [`2a97f41d`](https://github.com/NixOS/nixpkgs/commit/2a97f41dd0ed0685c6c71ee10b2d8829bb26a88e) | `marp: drop`                                                                                         |
| [`9e2d1c84`](https://github.com/NixOS/nixpkgs/commit/9e2d1c849242a6c26902230ae292464dd27f0f69) | `goofys: unstable-2021-03-26 -> unstable-2022-04-21`                                                 |
| [`9684c0fa`](https://github.com/NixOS/nixpkgs/commit/9684c0fa4ebbf36a56a740b03df14829ab0c671d) | `vimPlugins: update and add new (#176207)`                                                           |
| [`2b71239b`](https://github.com/NixOS/nixpkgs/commit/2b71239bb27383a3af93b38db6d376c4242bfa11) | `sticky: init at 1.8`                                                                                |
| [`9d80c2f6`](https://github.com/NixOS/nixpkgs/commit/9d80c2f6821d2bacbe127b7a9cbe18a26426cf3d) | `docker-slim: use buildGoModule`                                                                     |
| [`9b96eef8`](https://github.com/NixOS/nixpkgs/commit/9b96eef86e7d8d60e2f7a2a45ef604079282e0d5) | `python310Packages.meross-iot: 0.4.4.4 -> 0.4.4.5`                                                   |
| [`10bef0e2`](https://github.com/NixOS/nixpkgs/commit/10bef0e28f16eaa77bd710c58679b9360205f97e) | `texlab: remove unused dylib of human_name`                                                          |
| [`c53e1cc6`](https://github.com/NixOS/nixpkgs/commit/c53e1cc67499e155b48b19276124125402576e5b) | `btops: remove`                                                                                      |
| [`c0bc75a4`](https://github.com/NixOS/nixpkgs/commit/c0bc75a4a9e29ec061186b99f4f3a2cf0d3046dc) | `gnome.rygel: 0.40.3 -> 0.40.4`                                                                      |
| [`b460156c`](https://github.com/NixOS/nixpkgs/commit/b460156c25bd244ac37624cbc5d330aec7040a03) | `evolution: 3.44.1 -> 3.44.2`                                                                        |
| [`6caae0f9`](https://github.com/NixOS/nixpkgs/commit/6caae0f901d45b523bfb377bf453061a9e4eba9b) | `python310Packages.pypck: 0.7.14 -> 0.7.15`                                                          |
| [`6b34e58f`](https://github.com/NixOS/nixpkgs/commit/6b34e58f80f2d68993fb885575c4e54de1b250d9) | `python310Packages.aws-adfs: 2.0.5 -> 2.2.1`                                                         |
| [`c428ad43`](https://github.com/NixOS/nixpkgs/commit/c428ad43d1c6cb00bdfdbd5d03d24a98544e0760) | `pkgs/test/cuda/cuda-samples/generic.nix: use new SRI hash format`                                   |
| [`71834a1a`](https://github.com/NixOS/nixpkgs/commit/71834a1a26fb7e76d75356b537efb86cd0d7d78d) | `buildDhallUrl: use new SRI hash format`                                                             |
| [`5842fde3`](https://github.com/NixOS/nixpkgs/commit/5842fde37aa31df8aa713b2016dc8a1ac8cb8972) | `yash: use new SRI hash format`                                                                      |
| [`a9853d7a`](https://github.com/NixOS/nixpkgs/commit/a9853d7a0a201828413c4e354bfdfc099ba62c07) | `python310Packages.pyunifiprotect: handle optional dependencies`                                     |
| [`d88f4721`](https://github.com/NixOS/nixpkgs/commit/d88f472124142f67fc6d4ba9ecccc679a617dd28) | `python310Packages.pyunifiprotect: 3.7.0 -> 3.8.0`                                                   |
| [`4d0cfc2d`](https://github.com/NixOS/nixpkgs/commit/4d0cfc2d832ecefff2fe6db71ddae64edf9636d3) | `gitlab: 15.0.0 -> 15.0.1 (#175836)`                                                                 |
| [`28d7b25d`](https://github.com/NixOS/nixpkgs/commit/28d7b25d5b8260c0120618bd9381c6bbea1ca788) | `python310Packages.skodaconnect: 1.1.19 -> 1.1.20`                                                   |
| [`4f250bc4`](https://github.com/NixOS/nixpkgs/commit/4f250bc45a2d275cfb78cca484adc9ffbed349e3) | `atlassian-confluence: 7.17.1 -> 7.18.1`                                                             |
| [`af027830`](https://github.com/NixOS/nixpkgs/commit/af0278308ae5ec73e17d4e7778f0af461f5b624a) | `sile: Add passthru, and change some pre/post hooks.`                                                |
| [`eddf1d11`](https://github.com/NixOS/nixpkgs/commit/eddf1d114351a1cec4d6cc338538524cafec05c6) | `home-assistant: update component-packages`                                                          |
| [`59ff2493`](https://github.com/NixOS/nixpkgs/commit/59ff2493f78646dcbf7a0e718ee9806513823750) | `python310Packages.messagebird: init at 2.1.0`                                                       |
| [`a5225551`](https://github.com/NixOS/nixpkgs/commit/a5225551bfba8d376bd95c94f91ddf2357aba578) | `home-assistant: update component-packages`                                                          |
| [`e5e3e74d`](https://github.com/NixOS/nixpkgs/commit/e5e3e74d14cedc4c60a372249fa69198cbfc22ed) | `python310Packages.pymailgunner: init at 1.5`                                                        |
| [`2a2bb553`](https://github.com/NixOS/nixpkgs/commit/2a2bb553e7ceee1325ff4323c7fb191b5222bcfe) | `haskellPackages.{glade,webkitgtk3}: mark as broken`                                                 |
| [`1824ea95`](https://github.com/NixOS/nixpkgs/commit/1824ea95a3f90a7b58cdb76569d99ad96e0d3c96) | `home-assistant: update component-packages`                                                          |
| [`bd49b88b`](https://github.com/NixOS/nixpkgs/commit/bd49b88ba4670d90f96dee7e4d02510be9291626) | `python310Packages.pykwb: init at 0.0.10`                                                            |
| [`9b5dc169`](https://github.com/NixOS/nixpkgs/commit/9b5dc169b3b721c21a5c75bf2babf7731da60f71) | `python310Packages.skytemple-dtef: enable tests`                                                     |
| [`c7f28e35`](https://github.com/NixOS/nixpkgs/commit/c7f28e35282e9bbad2a93df0e0880cff5f8080ca) | `python310Packages.r2pipe: 1.6.5 -> 1.7.0`                                                           |
| [`cc467871`](https://github.com/NixOS/nixpkgs/commit/cc467871044f4d9f5b4bb277fc7ac19cebd14ce0) | `python310Packages.yte: 1.4.0 -> 1.5.1`                                                              |
| [`25f24876`](https://github.com/NixOS/nixpkgs/commit/25f248766048d2e6378bd093923493ac5eee1ca6) | `python3Packages.skytemple-dtef: 1.1.4 -> 1.1.5`                                                     |
| [`2c90bada`](https://github.com/NixOS/nixpkgs/commit/2c90bada3dc7b56f317dc6f5112f7542c98b8beb) | `mimic: pull upstream fix for -fno-common toolchains`                                                |
| [`60ba187b`](https://github.com/NixOS/nixpkgs/commit/60ba187b0fbfcce2d4dd5484814398415d9da27a) | `gravit: pull fix pending upstream inclusion for -fno-common toolchains`                             |
| [`eee8c0c6`](https://github.com/NixOS/nixpkgs/commit/eee8c0c66c2b92bce9bb94e33d3fd8c2a03e454c) | `python310Packages.sqlmap: 1.6.5 -> 1.6.6`                                                           |
| [`41cd411c`](https://github.com/NixOS/nixpkgs/commit/41cd411c03541663a59c95b1ecee598ee6d3d90c) | `nixos/tests/sway: skip type check for now`                                                          |
| [`6f86eabf`](https://github.com/NixOS/nixpkgs/commit/6f86eabf6d48afb2d8de263c202c409aa854679e) | `eli: add -fcommon workaround`                                                                       |
| [`f396869c`](https://github.com/NixOS/nixpkgs/commit/f396869ce681ab80211934308df21643ecaecc0d) | `python310Packages.hahomematic: 1.8.0 -> 1.8.3`                                                      |
| [`27d4a645`](https://github.com/NixOS/nixpkgs/commit/27d4a6453f6f056e47bab9f6ea9f23a80871917a) | `crackxls: pull patch pending upstream inclusion for -fno-common toolchains`                         |
| [`d872f697`](https://github.com/NixOS/nixpkgs/commit/d872f69758caa9af18e8dc11c8dfdc9c0490b1ba) | `haste-server: 68f6fe2b96ad02e21645480448113954bc87e1f5 -> 9e921d59098c1093050201942f71d357fa89ffee` |
| [`704de9fa`](https://github.com/NixOS/nixpkgs/commit/704de9fa1b90ae480ca5fd191ff4dbee80384c87) | `python310Packages.trytond: 6.4.0 -> 6.4.1`                                                          |
| [`906b0b2e`](https://github.com/NixOS/nixpkgs/commit/906b0b2e873d216881bb146c3353e76f1da132c2) | `nixos/tests: fix all tests that uses wait_until_tty_matches`                                        |
| [`c3321ad0`](https://github.com/NixOS/nixpkgs/commit/c3321ad06305a10e12e371643e9d980eae0beb65) | `git-absorb: 0.6.6 -> 0.6.7`                                                                         |
| [`9d2a8e31`](https://github.com/NixOS/nixpkgs/commit/9d2a8e31902241842c290bd82de9df82ad2d91a8) | `nixos/test-driver: fix type hint for send_chars`                                                    |
| [`63c45dda`](https://github.com/NixOS/nixpkgs/commit/63c45ddaf871f30a48009244346be64c10445938) | `pantheon.elementary-camera: 6.0.3 -> 6.1.0`                                                         |
| [`c5b06df6`](https://github.com/NixOS/nixpkgs/commit/c5b06df6a47ab7ba5b7df8af2472dc08e2336adc) | `font-awesome,mplus-fonts: fix build`                                                                |
| [`417419a5`](https://github.com/NixOS/nixpkgs/commit/417419a5c996e451243fa153a9bb50d9651c3687) | `nixos/tests/home-assistant: assert regex match`                                                     |
| [`0c77eaeb`](https://github.com/NixOS/nixpkgs/commit/0c77eaeba4448c76251b57f62474b0977ed02c25) | `krita: Fix python plugins, add missing dependencies`                                                |
| [`1a931f6e`](https://github.com/NixOS/nixpkgs/commit/1a931f6eca1503bcd5ce8340850a7879f9155abd) | `signal-desktop: 5.44.1 -> 5.45.0`                                                                   |
| [`8dd00555`](https://github.com/NixOS/nixpkgs/commit/8dd005558cd28db606b6b271e14bcf2b693b1eab) | `python310Packages.graphene-django: fix tests`                                                       |
| [`628d7a80`](https://github.com/NixOS/nixpkgs/commit/628d7a800c19958a9919d1aea4bc498559ee65bc) | `terraform-providers.brightbox: 2.2.0 -> 3.0.4`                                                      |
| [`f0bab70e`](https://github.com/NixOS/nixpkgs/commit/f0bab70ef9a3f78c8e8c8663b2323358f79621d5) | `clusterctl: 1.1.3 -> 1.1.4`                                                                         |
| [`fa586707`](https://github.com/NixOS/nixpkgs/commit/fa5867073f5f911322d1627b7413f474c9d1556f) | `pkgs/shells/fish: Fix completion file generator`                                                    |
| [`cfb09121`](https://github.com/NixOS/nixpkgs/commit/cfb09121486ef5eeaebcc6cd32d361047dcbc5bc) | `nanotts: init at 2021-02-22`                                                                        |
| [`48a663bf`](https://github.com/NixOS/nixpkgs/commit/48a663bff4b20878792d92c26cd3d9abf790c9a0) | `maintainers: add strikerlulu`                                                                       |
| [`2fe03c07`](https://github.com/NixOS/nixpkgs/commit/2fe03c07c9f3c19a433f1a8a7c485495737c422c) | `python310Packages.sagemaker: 2.91.1 -> 2.93.0`                                                      |
| [`dd61f287`](https://github.com/NixOS/nixpkgs/commit/dd61f287f405507bd4051940ed9e114bb2891202) | `home-assistant: update component-packages`                                                          |
| [`9f5c1221`](https://github.com/NixOS/nixpkgs/commit/9f5c12212de93154a45ad5adf4665dbbf63e9076) | `python310Packages.unifi-discovery: init at 1.1.3`                                                   |
| [`12930206`](https://github.com/NixOS/nixpkgs/commit/12930206aba954b614ca995613a83226a150df06) | `python310Packages.pyunifiprotect: init at 3.7.0`                                                    |
| [`46a5513a`](https://github.com/NixOS/nixpkgs/commit/46a5513ab8b67f9fd0487e83f5c21fff10f78d72) | `python310Packages.aioshutil: init at 1.1`                                                           |
| [`1922caf3`](https://github.com/NixOS/nixpkgs/commit/1922caf3f499e65f216a52d4b1a8e02bbc1368b8) | `python310Packages.ocrmypdf: 13.4.6 -> 13.4.7`                                                       |
| [`0e6a4538`](https://github.com/NixOS/nixpkgs/commit/0e6a4538412758c2fb3ea7b119b978ead3c51056) | `python3Packages.pylint: don't run benchmarks`                                                       |
| [`2e0c733d`](https://github.com/NixOS/nixpkgs/commit/2e0c733dbff32912e35cf10436264bbb4f966ac4) | `deltachat-desktop: use build4production`                                                            |
| [`7b8daf06`](https://github.com/NixOS/nixpkgs/commit/7b8daf06044825c72647956591187509a32a7667) | `idevicerestore: 1.0.0 -> 1.0.0+date=2022-05-22, cleanup`                                            |
| [`3eb7843e`](https://github.com/NixOS/nixpkgs/commit/3eb7843e6ee02320e505b9db5237af1164536473) | `libirecovery: 1.0.0 -> 1.0.0+date=2022-04-04, cleanup`                                              |
| [`f5138bc9`](https://github.com/NixOS/nixpkgs/commit/f5138bc9e59165916b998d1819fec03295748d75) | `ifuse: 1.1.4 -> 1.1.4+date=2022-04-04, cleanup`                                                     |
| [`3a6216a5`](https://github.com/NixOS/nixpkgs/commit/3a6216a5e269ba6b30c5f5eb7d61d83a4a445a0d) | `ideviceinstaller: 1.1.1 -> 1.1.1+date=2022-05-09, cleanup`                                          |
| [`d56d8c46`](https://github.com/NixOS/nixpkgs/commit/d56d8c4669748cb4d50a94a5b60066b09458aa92) | `libimobiledevice: unstable-2021-06-02 -> 1.3.0+date=2022-05-22, cleanup`                            |
| [`6cee98c8`](https://github.com/NixOS/nixpkgs/commit/6cee98c8e59be03fa2a574eaf0dc1196c5bf61cb) | `libusbmuxd: unstable-2021-02-06 -> 2.0.2+date=2022-05-04, cleanup`                                  |
| [`de887d4f`](https://github.com/NixOS/nixpkgs/commit/de887d4f2c668c723930f69b70f09e91e1223df4) | `usbmuxd: unstable-2021-05-08 -> 1.1.1+date=2022-04-04, cleanup`                                     |
| [`742dc5ea`](https://github.com/NixOS/nixpkgs/commit/742dc5ea13c3b90a8baa1ce886f4f85eadccb764) | `libplist: 2.2.0 -> 2.2.0+date=2022-04-05, cleanup, use Python 3`                                    |
| [`f758d33d`](https://github.com/NixOS/nixpkgs/commit/f758d33d274063a694f0d1a9db43150639f9a7de) | `libimobiledevice-glue: init at 0.pre+date=2022-05-22`                                               |
| [`31b6c732`](https://github.com/NixOS/nixpkgs/commit/31b6c7322d47673ad66718e25d549f3e1eb5e3f3) | `python310Packages.pyrogram: 2.0.25 -> 2.0.26`                                                       |
| [`5bf496fc`](https://github.com/NixOS/nixpkgs/commit/5bf496fc778602412daf411a2b1f3c072ba5bc8f) | `deltachat-cursed: 0.6.0 -> 0.7.1`                                                                   |
| [`80a7bf95`](https://github.com/NixOS/nixpkgs/commit/80a7bf95cb6ed7163fb107b519f7d3ce1b6e2132) | `libdeltachat: 1.84.0 -> 1.85.0`                                                                     |
| [`11c7d480`](https://github.com/NixOS/nixpkgs/commit/11c7d480161716db3e880fe69b2a564ada07ea4a) | `libdigidocpp: Fix crashes due to newer OpenSSL`                                                     |
| [`b1dd7c63`](https://github.com/NixOS/nixpkgs/commit/b1dd7c639d235b8dd0bfc57e9301557c2f93d871) | `libipfix: add -fcommon workaround`                                                                  |
| [`068e9864`](https://github.com/NixOS/nixpkgs/commit/068e986440054ab5b2d8312b51d5ce50447d1a30) | `python310Packages.pypoolstation: 0.4.4 -> 0.4.5`                                                    |
| [`9f3eb797`](https://github.com/NixOS/nixpkgs/commit/9f3eb7979986a12e6740c594dc089b2a0c60cecf) | `python3Packages.pep8-naming: 0.12.1 -> 0.13.0`                                                      |
| [`46f3e453`](https://github.com/NixOS/nixpkgs/commit/46f3e453dc637915f371c76a8db68a953f10df84) | `pycoin: 0.92.20220213 -> 0.92.20220529`                                                             |
| [`65f56d25`](https://github.com/NixOS/nixpkgs/commit/65f56d25d735b20bef6e892add130ed4bef2c3ce) | `spicetify-cli: 2.9.4 -> 2.10.1`                                                                     |
| [`d7e27d92`](https://github.com/NixOS/nixpkgs/commit/d7e27d92b12979cb4a1218dd92eddf69574f72e1) | `python310Packages.aws-adfs: 2.0.3 -> 2.0.5`                                                         |
| [`256443ed`](https://github.com/NixOS/nixpkgs/commit/256443ed3074bf3f84fb7218652a8633e708a0b3) | `python310Packages.autopage: 0.5.0 -> 0.5.1`                                                         |
| [`2328ab13`](https://github.com/NixOS/nixpkgs/commit/2328ab136905db6f20af4fef22e48548085d8479) | `python310Packages.pytorch-lightning: 1.6.3 -> 1.6.4`                                                |
| [`fa94463d`](https://github.com/NixOS/nixpkgs/commit/fa94463df4f9a93ca0c39d12be62b4876315d707) | `python310Packages.gradient: 2.0.3 -> 2.0.4`                                                         |
| [`52792a07`](https://github.com/NixOS/nixpkgs/commit/52792a0751dc4f3387a841b34c396699472e99ff) | `python310Packages.tempest: 30.1.0 -> 31.0.0`                                                        |
| [`9b2c55ac`](https://github.com/NixOS/nixpkgs/commit/9b2c55ac952449215910b631c2b3fd69e75972dd) | `python310Packages.gpsoauth: 1.0.1 -> 1.0.2`                                                         |
| [`b1ea6ec8`](https://github.com/NixOS/nixpkgs/commit/b1ea6ec8f2baf9e94553b222474bbcc67dbec61c) | `python39Packages.internetarchive: 3.0.0 -> 3.0.1`                                                   |
| [`9bbfdd6a`](https://github.com/NixOS/nixpkgs/commit/9bbfdd6aabe089b8a5096a5f8ef00947d709fd2e) | `python310Packages.apprise: 0.9.8.3 -> 0.9.9`                                                        |
| [`dfe24b92`](https://github.com/NixOS/nixpkgs/commit/dfe24b923e83e5d547f0e7ff078d04378497c8a0) | `python310Packages.pynetgear: 0.10.3 -> 0.10.4`                                                      |
| [`9373b2f5`](https://github.com/NixOS/nixpkgs/commit/9373b2f504a6b807930527a127a7c1dba46ad6a0) | `python310Packages.bimmer-connected: 0.9.3 -> 0.9.4`                                                 |
| [`f6df8821`](https://github.com/NixOS/nixpkgs/commit/f6df882131aa4de5e6282925321864f81681184e) | `xorg.xf86videoopenchrome: pull upstream fix for -fno-common toolchain (#176074)`                    |
| [`8b4c4bf3`](https://github.com/NixOS/nixpkgs/commit/8b4c4bf34fbefcdd49b13324bac1833832bf635f) | `elk7: 7.16.1 -> 7.17.4`                                                                             |
| [`d9e3b1fa`](https://github.com/NixOS/nixpkgs/commit/d9e3b1fafe3c1509a886fb8795b3438c7caa07f5) | `nixos/restic: add backup{Prepare,Cleanup}Command options`                                           |
| [`deae887c`](https://github.com/NixOS/nixpkgs/commit/deae887c5a497a978b55b205dff9c517eb0df55e) | `nixos/restic: add new repositoryFile option`                                                        |
| [`f783fcba`](https://github.com/NixOS/nixpkgs/commit/f783fcba13fcc759ce010ae4c6994783f3e806ba) | `xbursttools: add -fcommon workaround`                                                               |
| [`71f478f6`](https://github.com/NixOS/nixpkgs/commit/71f478f6e7e3fcaf2c246edebca368570c2522ed) | `metasploit: 6.2.0 -> 6.2.1`                                                                         |
| [`ea4b2370`](https://github.com/NixOS/nixpkgs/commit/ea4b237090b28d0987121dfdecb40997ef346ef6) | `cargo-nextest: 0.9.14 -> 0.9.16 (#176103)`                                                          |
| [`440bd602`](https://github.com/NixOS/nixpkgs/commit/440bd6022c648df81357545780ae9be7810d8bdc) | `checkov: 2.0.1186 -> 2.0.1188`                                                                      |
| [`d1f54d60`](https://github.com/NixOS/nixpkgs/commit/d1f54d60aacab4b8fa1f6559eb1186bf9410dff7) | `gnome-firmware: 42.1 → 42.2`                                                                        |
| [`5f36ed3f`](https://github.com/NixOS/nixpkgs/commit/5f36ed3f87c90faeba3ccb581874fe2264167d0c) | `gnome-firmware: add update script`                                                                  |
| [`c0d4a1bf`](https://github.com/NixOS/nixpkgs/commit/c0d4a1bfe4f9bea0ec55586cf43281c0c8711eab) | `webos.novacomd: add -fcommon workaround`                                                            |
| [`338484a7`](https://github.com/NixOS/nixpkgs/commit/338484a75e756e7430d3edec20dcf8c3fff13992) | `zynaddsubfx: pull upstream fix for -fno-common (mruby-zest)`                                        |
| [`0e5d12d6`](https://github.com/NixOS/nixpkgs/commit/0e5d12d65c5cb5260c2f1b00d7bf90fba213cba2) | `haskellPackages: mark builds failing on hydra as broken`                                            |
| [`3c233ac9`](https://github.com/NixOS/nixpkgs/commit/3c233ac911050f99387356af131e04a9be470252) | `appimagekit.squashfuse: add -fcommon workaround`                                                    |
| [`c2608d3e`](https://github.com/NixOS/nixpkgs/commit/c2608d3ea065c66064c9429c8d0c3042e1cc066d) | `wpscan: 3.8.20 → 3.8.22`                                                                            |
| [`e9e734bf`](https://github.com/NixOS/nixpkgs/commit/e9e734bf1710f2bd38e7a63b0f098873139a11b4) | `openjfx11, openjfx15: add -fcommon workaround`                                                      |
| [`1cefcfab`](https://github.com/NixOS/nixpkgs/commit/1cefcfab2d3eb9274f4627a178a59d6f980f7f3b) | `nixos/doc: move fetchpatch documentation to fetcher documentation`                                  |
| [`4ff8da59`](https://github.com/NixOS/nixpkgs/commit/4ff8da59b8e717212037b48efaac3bad4f3fbbe8) | `javaPackages.jogl_2_3_2: add -fcommon workaround`                                                   |
| [`537fc890`](https://github.com/NixOS/nixpkgs/commit/537fc890adfd1b0255bc36dad5cb5e1c208b186e) | `k0sctl: 0.12.6 -> 0.13.0`                                                                           |
| [`df2a5eb5`](https://github.com/NixOS/nixpkgs/commit/df2a5eb5cbaa6c57f48cc7520ae6734c983bc67b) | `cmake-language-server: 0.1.3 -> 0.1.4`                                                              |
| [`fd4ebd89`](https://github.com/NixOS/nixpkgs/commit/fd4ebd89909f181b2f88be5ba44a4eb7b6a903ab) | `add opt out flag for type checking`                                                                 |
| [`99720ed1`](https://github.com/NixOS/nixpkgs/commit/99720ed1c9576d08598b9cd4df0337a866d3680b) | `gitsign: init at 0.1.0`                                                                             |
| [`0c7387d8`](https://github.com/NixOS/nixpkgs/commit/0c7387d81766fc2ed6d06342e626c3c3bf73cf85) | `panoply: init at 5.0.6`                                                                             |
| [`07b16fb0`](https://github.com/NixOS/nixpkgs/commit/07b16fb04785ba0c0a1db3337a9ad6c6bb39737e) | `python310Packages.thinc: 8.0.16 -> 8.0.17`                                                          |
| [`d20c2ae1`](https://github.com/NixOS/nixpkgs/commit/d20c2ae15fccf0eb6807773010f68f0ec8798317) | `terraform-providers: allow go version override in mkProvider (#175943)`                             |
| [`99aebae9`](https://github.com/NixOS/nixpkgs/commit/99aebae94fc404f3c3b31c94ebc13319ecd0038d) | `kops: use buildGoModule (#176050)`                                                                  |
| [`43f65db1`](https://github.com/NixOS/nixpkgs/commit/43f65db139bed9f13d665fe24420feb8a0719745) | `python3Packages.django_4: fix geos_gdal patch syntax error`                                         |
| [`c3027239`](https://github.com/NixOS/nixpkgs/commit/c302723969ab4509b3600024b326c9895be9fdaa) | `libdigidoc: remove`                                                                                 |
| [`d1252d40`](https://github.com/NixOS/nixpkgs/commit/d1252d4082d76bfa22e59bf54a40bd346a6c57f6) | `perlPackages.MathPari: add -fcommon workaround`                                                     |