### PR TITLE
chore(flake/ragenix): `3e0cfbba` -> `e2bcfcf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1653750898,
-        "narHash": "sha256-2u9t/GLPbZ8YDnMkq+z0FgDJjVpzXMK66yFEiQhOJIE=",
+        "lastModified": 1654412551,
+        "narHash": "sha256-hoIZKaMy2NWQJwrGQEiCuDp8yyGHH9LhW9FX78RsqQ8=",
         "owner": "yaxitech",
         "repo": "ragenix",
-        "rev": "3e0cfbbaf9ab0c8876a4433325bd9361efe5f24a",
+        "rev": "e2bcfcf52480825ef90e7d23693f5e65388399f0",
         "type": "github"
       },
       "original": {
@@ -224,11 +224,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1653705363,
-        "narHash": "sha256-pSURjLmfeE9zMRzrxzWn4WPx3cGvcTSJB58LRFSZY74=",
+        "lastModified": 1654310165,
+        "narHash": "sha256-5TWkZMKnrLQVGsWrcDabJX7E502qoi0+vP1RReJp0/Y=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0be302358da0f8ea3d3cc24a0639b6354fc45e7c",
+        "rev": "e64770eac18a1983232a5bc55fa443d9f15cc489",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                            | Commit Message                                      |
| ------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`e2bcfcf5`](https://github.com/yaxitech/ragenix/commit/e2bcfcf52480825ef90e7d23693f5e65388399f0) | `Update flake inputs and Cargo dependencies (#106)` |