### PR TITLE
chore(flake/home-manager): `684e85d0` -> `20703892`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1654113406,
-        "narHash": "sha256-70esZvhal+FsyU89mJRcAb+cDGHKt0sgZ6MlRr9Cplg=",
+        "lastModified": 1654422613,
+        "narHash": "sha256-ZxkMM13AnrMwYOV99ohzcqeTkAOqD9Q2SBdZ9WoFE9Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "684e85d01d333be91c4875baebb05b93c7d2ffaa",
+        "rev": "20703892473d01c70fb10248442231fe94f4ceb4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`20703892`](https://github.com/nix-community/home-manager/commit/20703892473d01c70fb10248442231fe94f4ceb4) | `htop: add missing fields (#2989)`                |
| [`a3638db0`](https://github.com/nix-community/home-manager/commit/a3638db009f3dbcca5f44b8f858af9d7e22bf2b7) | `Use newer getmail6 over getmail package (#2982)` |