### PR TITLE
chore(flake/nixpkgs): `0fe729df` -> `34a7b314`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654374252,
-        "narHash": "sha256-PfsJACqKb6m1abRTZP2MRkQtMjcq5Cw/1FX30XiQDLI=",
+        "lastModified": 1654414801,
+        "narHash": "sha256-HSzC2kS7zRYfd4qw/IICrcP46jZFdWGgSSR7DtlgOiI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0fe729dfae92b676a99067312e1637b3527cb75d",
+        "rev": "34a7b3142e34796133fcb3f9c857d7b17982fdaa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                            |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`96515aa0`](https://github.com/NixOS/nixpkgs/commit/96515aa0c9372474cf1e862f0daf66dfa396b2be) | `python310Packages.hahomematic: 1.8.3 -> 1.8.4`           |
| [`2820464d`](https://github.com/NixOS/nixpkgs/commit/2820464d90331d70e043a330d331b6533503a647) | `gallery-dl: 1.22.0 -> 1.22.1`                            |
| [`b1a7f0ab`](https://github.com/NixOS/nixpkgs/commit/b1a7f0abcdb9a5ad6469763c335ad5ad63b1dae1) | `python310Packages.mkdocs-material: 8.3.0 -> 8.3.1`       |
| [`56d0d4ff`](https://github.com/NixOS/nixpkgs/commit/56d0d4fff6826cfc3cb3a8c2990fa6f7c27ce577) | `containerd: 1.6.4 -> 1.6.5`                              |
| [`213d9cfb`](https://github.com/NixOS/nixpkgs/commit/213d9cfba152fd702170f91c0fc0f00e437ca51e) | `poetry2nix: 1.29.1 -> 1.30.0`                            |
| [`3e51ae86`](https://github.com/NixOS/nixpkgs/commit/3e51ae8666d4e265e8d87a1363c696e20a496483) | `home-assistant: 2022.6.1 -> 2022.6.2`                    |
| [`3a7775df`](https://github.com/NixOS/nixpkgs/commit/3a7775df4d7b2e54d492b24211385fc1cb8e53f0) | `exploitdb: 2022-05-26 -> 2022-06-04`                     |
| [`b111c8aa`](https://github.com/NixOS/nixpkgs/commit/b111c8aa3356f6b2d1d286c0bf2e1eb2f19605a9) | `just: 1.1.3 -> 1.2.0`                                    |
| [`bd7a5533`](https://github.com/NixOS/nixpkgs/commit/bd7a55337741d9e9ccbd46b8e4b9886911c90d24) | `python310Packages.torchinfo: 1.6.5 -> 1.7.0`             |
| [`64a7bd44`](https://github.com/NixOS/nixpkgs/commit/64a7bd4438bd1f58ed83e16025738152453c71e9) | `python310Packages.secp256k1: cleanup`                    |
| [`a2d4b843`](https://github.com/NixOS/nixpkgs/commit/a2d4b843dbdec6b864e4059f6bbce5e8e483e4e2) | `python310Packages.tmb: 0.1.3 -> 0.1.5`                   |
| [`33016756`](https://github.com/NixOS/nixpkgs/commit/33016756d4dd80c1c401f18b1b10f5951708bca2) | `python310Packages.pysnmplib: 5.0.16 -> 5.0.17`           |
| [`95392307`](https://github.com/NixOS/nixpkgs/commit/953923076c0a15bfd5dfabe857d53974a7d9fd30) | `gitleaks: 8.8.6 -> 8.8.7`                                |
| [`411e5070`](https://github.com/NixOS/nixpkgs/commit/411e50709ad0542b62cc16cf3c22c2de430f0c8d) | `mqtt-bench: remove`                                      |
| [`fdd55bbd`](https://github.com/NixOS/nixpkgs/commit/fdd55bbd0f2ac1ac6033cd791e47d464a38a6264) | `fluent-bit: 1.8.11 -> 1.9.3`                             |
| [`6672564b`](https://github.com/NixOS/nixpkgs/commit/6672564b97c97f97d311146e7b92b20fb440479f) | `avro-cpp: 1.10.2 -> 1.11.0`                              |
| [`8d1fe6de`](https://github.com/NixOS/nixpkgs/commit/8d1fe6de8c4c0204294c73041613d24e94f3fd3a) | `zeek: 4.2.1 -> 4.2.2`                                    |
| [`34c19534`](https://github.com/NixOS/nixpkgs/commit/34c19534c7a221c7bd8bd8a9869628aee47db0ae) | `libspng: enable on darwin`                               |
| [`157603f6`](https://github.com/NixOS/nixpkgs/commit/157603f6cfe3cd311f26a0666036084aefb7a647) | `python39Packages.dash: unbreak on darwin`                |
| [`0b0119f1`](https://github.com/NixOS/nixpkgs/commit/0b0119f1ea0c7d367569a68e1c90e2d04968867e) | `git-lfs: use buildGoModule`                              |
| [`b11ee082`](https://github.com/NixOS/nixpkgs/commit/b11ee08240d7bd1b4e4f38bf507e097c27bcbf99) | `consul: 1.12.1 -> 1.12.2`                                |
| [`28fc79da`](https://github.com/NixOS/nixpkgs/commit/28fc79daeefa7636db69ffda5c353199cf0ef667) | `httm: 0.10.15 -> 0.10.16`                                |
| [`af2a52be`](https://github.com/NixOS/nixpkgs/commit/af2a52be50d3fb866129067ad57217afe91ca548) | `pls: 5.0.0 -> 5.1.2`                                     |
| [`5a17895a`](https://github.com/NixOS/nixpkgs/commit/5a17895aea1321febb8a0976645caa61d160166c) | `pythonPackages.f90nml: init at 1.4.1`                    |
| [`85ac5d8c`](https://github.com/NixOS/nixpkgs/commit/85ac5d8c9b6e61e847b246c87aaeb683ea07a4b0) | `cosign: 1.8.0 -> 1.9.0`                                  |
| [`e21c4d67`](https://github.com/NixOS/nixpkgs/commit/e21c4d67d59624859ffde7ca6cffc4aa12fc839f) | `nixos/unifi: change deprecated default for openFirewall` |
| [`2d1188c0`](https://github.com/NixOS/nixpkgs/commit/2d1188c0b1665dece1252d2f400484c2395ef56d) | `pinentry-bemenu: 0.10.0 -> 0.11.0`                       |
| [`c217af10`](https://github.com/NixOS/nixpkgs/commit/c217af103106f843e5982c89bd2174de288f89be) | `ntfy-sh: 1.24.0 -> 1.25.2`                               |
| [`805b3571`](https://github.com/NixOS/nixpkgs/commit/805b35710a37d0a513271ef3fb25ad34a711c306) | `deno: 1.22.1 -> 1.22.2`                                  |
| [`7cf77a91`](https://github.com/NixOS/nixpkgs/commit/7cf77a91dde4799c016afe294c1240722fa0c78c) | `tmux: 3.2a > 3.3, add me as maintainer`                  |
| [`475b2f12`](https://github.com/NixOS/nixpkgs/commit/475b2f1244020e51e6521f208d55072fdc95a272) | `partitionmanager: Wrap once`                             |
| [`c9e173fe`](https://github.com/NixOS/nixpkgs/commit/c9e173fe09e33545ba936a0ee681df5200bae8f1) | `bzip3: init at 1.1.3`                                    |
| [`4647a8f7`](https://github.com/NixOS/nixpkgs/commit/4647a8f70a8c48258babcf4e8bc4117a85d2d6d3) | `rkdeveloptool-pine64: init at unstable-2021-09-04`       |