### PR TITLE
chore(flake/nixpkgs): `34a7b314` -> `6dd66a05`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,10 @@ jobs:
             .\#checks.x86_64-linux.pre-commit-check
 
   build-shell:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v17
@@ -46,7 +49,7 @@ jobs:
             nix build -L --keep-going \
             .\#devShells.x86_64-linux.default.inputDerivation
 
-  get-hosts:
+  get-linux-hosts:
     runs-on: ubuntu-latest
     outputs:
       hosts: ${{ steps.get-hosts.outputs.hosts }}
@@ -54,16 +57,26 @@ jobs:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v17
       - id: get-hosts
-        run: echo "::set-output name=hosts::$(nix eval --json -f ./nix/hosts.nix all | jq -c 'keys')"
+        run: echo "::set-output name=hosts::$(nix eval --json -f ./nix/hosts.nix linux | jq -c 'keys')"
 
-  build-host:
+  get-darwin-hosts:
+    runs-on: macos-latest
+    outputs:
+      hosts: ${{ steps.get-hosts.outputs.hosts }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v17
+      - id: get-hosts
+        run: echo "::set-output name=hosts::$(nix eval --json -f ./nix/hosts.nix darwin | jq -c 'keys')"
+
+  build-linux-host:
     name: build-${{ matrix.host }}
     runs-on: ubuntu-latest
-    needs: get-hosts
+    needs: get-linux-hosts
     strategy:
       fail-fast: false
       matrix:
-        host: ${{ fromJson(needs.get-hosts.outputs.hosts) }}
+        host: ${{ fromJson(needs.get-linux-hosts.outputs.hosts) }}
     steps:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v17
@@ -111,9 +124,42 @@ jobs:
                 --keep-going \
                 -A packages.x86_64-linux.${{ matrix.host }}
 
+  build-darwin-host:
+    name: build-${{ matrix.host }}
+    runs-on: macos-latest
+    needs: get-darwin-hosts
+    strategy:
+      fail-fast: false
+      matrix:
+        host: ${{ fromJson(needs.get-darwin-hosts.outputs.hosts) }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v17
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            experimental-features = nix-command flakes recursive-nix
+      - uses: cachix/cachix-action@v10
+        with:
+          name: nix-config
+          signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+      - name: add-lite-overlay
+        run: sed -i '/.*overlays\.lite/s/#\s*//g' flake.nix
+      - name: build-host
+        uses: nick-invision/retry@v2
+        with:
+          max_attempts: 2
+          timeout_minutes: 720
+          retry_on: error
+          command: |
+            cachix watch-exec nix-config -- \
+              nix run nixpkgs#nix-build-uncached -- \
+                --keep-going \
+                -A packages.x86_64-darwin.${{ matrix.host }}
+
   check:
     runs-on: ubuntu-latest
-    needs: [ build-host ]
+    needs: [ build-linux-host, build-darwin-host ]
     if: always()
     steps:
       - name: check

--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654414801,
-        "narHash": "sha256-HSzC2kS7zRYfd4qw/IICrcP46jZFdWGgSSR7DtlgOiI=",
+        "lastModified": 1654551152,
+        "narHash": "sha256-i6adciZYD4jOmImciN+qfihBnbjk8xCUrHUXXY98cos=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "34a7b3142e34796133fcb3f9c857d7b17982fdaa",
+        "rev": "6dd66a05930d0ffc11796466cb6dea24945f625e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,7 @@
 
       nixosConfigurations = import ./nix/nixos.nix inputs;
     }
-    // utils.lib.eachSystem [ "aarch64-linux" "x86_64-linux" ] (system: {
+    // utils.lib.eachSystem [ "aarch64-linux" "x86_64-darwin" "x86_64-linux" ] (system: {
       checks = import ./nix/checks.nix inputs system;
 
       devShells.default = import ./nix/dev-shell.nix inputs system;

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -11,7 +11,7 @@ let
         nixpkgs.flake = nixpkgs;
       };
 
-      systemd.user.sessionVariables.NIX_PATH = lib.concatStringsSep ":" [
+      home.sessionVariables.NIX_PATH = lib.concatStringsSep ":" [
         "nixpkgs=${config.xdg.dataHome}/nixpkgs"
         "nixpkgs-overlays=${config.xdg.dataHome}/overlays"
       ];

--- a/nix/hosts.nix
+++ b/nix/hosts.nix
@@ -4,6 +4,8 @@ let
   filterAttrs = pred: set:
     listToAttrs (concatMap (name: let value = set.${name}; in if pred name value then [{ inherit name value; }] else [ ]) (attrNames set));
 
+  filterSystem = infix: filterAttrs (_: v: builtins.match ".*${escapeRegex infix}.*" v.localSystem != null);
+
   hosts = {
     aurelius = {
       type = "nixos";
@@ -70,15 +72,34 @@ in
 {
   all = hosts;
 
+  darwin = filterSystem "-darwin" hosts;
+  linux = filterSystem "-linux" hosts;
+
   nixos = rec {
     all = filterAttrs (_: v: v.type == "nixos") hosts;
-    x86_64-linux = filterAttrs (_: v: v.localSystem == "x86_64-linux") all;
-    aarch64-linux = filterAttrs (_: v: v.localSystem == "aarch64-linux") all;
+
+    darwin = filterSystem "-darwin" all;
+    linux = filterSystem "-linux" all;
+
+    aarch64 = filterSystem "aarch64-" all;
+    x86_64 = filterSystem "x86_64" all;
+
+    aarch64-linux = filterSystem "aarch64-linux" all;
+    x86_64-linux = filterSystem "x86_64-linux" all;
   };
 
   homeManager = rec {
     all = filterAttrs (_: v: v.type == "home-manager") hosts;
-    x86_64-linux = filterAttrs (_: v: v.localSystem == "x86_64-linux") all;
-    aarch64-linux = filterAttrs (_: v: v.localSystem == "aarch64-linux") all;
+
+    darwin = filterSystem "-darwin" all;
+    linux = filterSystem "-linux" all;
+
+    aarch64 = filterSystem "aarch64-" all;
+    x86_64 = filterSystem "x86_64" all;
+
+    aarch64-linux = filterSystem "aarch64-linux" all;
+    aarch64-darwin = filterSystem "aarch64-darwin" all;
+    x86_64-darwin = filterSystem "x86_64-darwin" all;
+    x86_64-linux = filterSystem "x86_64-linux" all;
   };
 }

--- a/nix/overlays/darwin-fixes.nix
+++ b/nix/overlays/darwin-fixes.nix
@@ -1,0 +1,9 @@
+_: prev: {
+  python39 = prev.python39.override {
+    packageOverrides = _: pyPrev: {
+      questionary = pyPrev.questionary.overrideAttrs (old: {
+        meta = old.meta // { broken = false; };
+      });
+    };
+  };
+}

--- a/users/bemeurer/core/xdg.nix
+++ b/users/bemeurer/core/xdg.nix
@@ -1,9 +1,9 @@
-{
+{ pkgs, ... }: {
   xdg = {
     enable = true;
-    mimeApps.enable = true;
+    mimeApps.enable = pkgs.stdenv.isLinux;
     userDirs = {
-      enable = true;
+      enable = pkgs.stdenv.isLinux;
       desktop = "$HOME/opt";
       documents = "$HOME/doc";
       download = "$HOME/tmp";

--- a/users/bemeurer/core/zsh.nix
+++ b/users/bemeurer/core/zsh.nix
@@ -9,7 +9,7 @@
     enableAutosuggestions = true;
     enableCompletion = true;
     enableSyntaxHighlighting = true;
-    enableVteIntegration = true;
+    enableVteIntegration = pkgs.stdenv.isLinux;
     autocd = true;
     dotDir = ".config/zsh";
     history = {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                    |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`6dd66a05`](https://github.com/NixOS/nixpkgs/commit/6dd66a05930d0ffc11796466cb6dea24945f625e) | `terraform-providers.remote: init at 0.0.24`                                      |
| [`c08942e1`](https://github.com/NixOS/nixpkgs/commit/c08942e1ad495ec838965a886cb07c42b7e09f75) | `nixos/tests/radarr: fix type of argument in test script`                         |
| [`965c2e12`](https://github.com/NixOS/nixpkgs/commit/965c2e12e74158561080cf7be3d4e3edd4885d5f) | `radarr: 4.0.5.5981 -> 4.1.0.6175`                                                |
| [`0eaa7239`](https://github.com/NixOS/nixpkgs/commit/0eaa72390bacff63a6d2b8f22aeb288a83e53b1f) | `maintainers: rename to leona`                                                    |
| [`e89fea64`](https://github.com/NixOS/nixpkgs/commit/e89fea64d3519a441a8de18675fc56148c131818) | `python310Packages.safety: fix typo`                                              |
| [`3a0ee098`](https://github.com/NixOS/nixpkgs/commit/3a0ee098a1d372bbf6cda961f739fd667b65978f) | `python310Packages.omnilogic: 0.4.5 -> 0.4.6`                                     |
| [`3f82a912`](https://github.com/NixOS/nixpkgs/commit/3f82a9122a4298c9b60cab4528f6f2e9c750b241) | `python310Packages.pywemo: 0.8.1 -> 0.9.0`                                        |
| [`b1b94ab4`](https://github.com/NixOS/nixpkgs/commit/b1b94ab4afc6c3796f01155597b38b05dbb986d4) | `python310Packages.pynx584: 0.7 -> 0.8`                                           |
| [`6cecab9c`](https://github.com/NixOS/nixpkgs/commit/6cecab9cd84f2c01ebeac82c4ed49ea053315d58) | `hydra: create runcommand-logs directory`                                         |
| [`632a8936`](https://github.com/NixOS/nixpkgs/commit/632a8936b3584a3a979d429f03196a6e2e290459) | `Revert "python310Packages.flask-restful: remove condition from patch"`           |
| [`30d1a2f2`](https://github.com/NixOS/nixpkgs/commit/30d1a2f29e9b309533567dbe55d5ea72653cc6f9) | `cfscrape: init at 2.1.1 (#176416)`                                               |
| [`475b0101`](https://github.com/NixOS/nixpkgs/commit/475b010143aa77a584ac51bc4934860cf22d0eb6) | `htop-vim: unstable-2021-10-11 -> unstable-2022-05-24`                            |
| [`03bcd6fd`](https://github.com/NixOS/nixpkgs/commit/03bcd6fd64ce7aead3fd852118267bd69d4eef50) | `nixos/release.nix: Add nixos.tests.allDrivers`                                   |
| [`51224f52`](https://github.com/NixOS/nixpkgs/commit/51224f522f7a7d3a00ac2da4ceeedeea296cd2ed) | `nixosTests.allDrivers: Move logic to all-packages.nix`                           |
| [`9b9faa5b`](https://github.com/NixOS/nixpkgs/commit/9b9faa5bf85be51d158848a8e74a711fa760802f) | `map: rename map-cmd`                                                             |
| [`7f42a6cf`](https://github.com/NixOS/nixpkgs/commit/7f42a6cf572ae77c8264737f06e0b2c2deb74159) | `pySmartDL: init at 1.3.4 (#176421)`                                              |
| [`5a862299`](https://github.com/NixOS/nixpkgs/commit/5a862299e02b49126d44844e60d343c74eff8a9f) | `ocamlPackages.mm: init at 0.8.1`                                                 |
| [`fbfd28e8`](https://github.com/NixOS/nixpkgs/commit/fbfd28e8ac8585dd9cb2e5cadfdfaf8597f9ad0a) | `ocamlPackages.mad: init at 0.5.2`                                                |
| [`5e76c696`](https://github.com/NixOS/nixpkgs/commit/5e76c6961d1b992046781c21c7d7dfd5df60d013) | `ocamlPackages.ao: init at 0.2.4`                                                 |
| [`12254d43`](https://github.com/NixOS/nixpkgs/commit/12254d43883006a66b99089f149296a916e899f0) | `deja-dup: 43.2 → 43.3`                                                           |
| [`e91d6046`](https://github.com/NixOS/nixpkgs/commit/e91d6046b167e119026e83f9f8a1b9f60d0fcdc1) | `map: init at 0.1.1`                                                              |
| [`a42cdc07`](https://github.com/NixOS/nixpkgs/commit/a42cdc07fc27ab4ed58485b927e6edbe1a4900ba) | `sct: unstable-2015-11-16 -> 0.5`                                                 |
| [`3c11b2df`](https://github.com/NixOS/nixpkgs/commit/3c11b2df706c4b8169bb1172035c48060a9188ba) | `maintainers: add somasis`                                                        |
| [`282eeff2`](https://github.com/NixOS/nixpkgs/commit/282eeff2443df29629ff5d23dc6fc7025eca98c1) | `pgadmin4: 6.9 -> 6.10`                                                           |
| [`9e22fffe`](https://github.com/NixOS/nixpkgs/commit/9e22fffe94ecdbdc58d091fe4c891eb9ddafd6da) | `xmppc: init at 0.1.2`                                                            |
| [`a0a517f5`](https://github.com/NixOS/nixpkgs/commit/a0a517f5acc59ae5b149cca9f864905f9eedea04) | `maintainer-list: add jugendhacker`                                               |
| [`5c871cdf`](https://github.com/NixOS/nixpkgs/commit/5c871cdf838ab4479071f3f5f90c2213e321a444) | `conform: init at 0.1.0-alpha.25`                                                 |
| [`85731306`](https://github.com/NixOS/nixpkgs/commit/85731306feba7f9b6cd4e35ee7193f88dca9ab5d) | `htop: 3.2.0 -> 3.2.1`                                                            |
| [`f5bd5bb0`](https://github.com/NixOS/nixpkgs/commit/f5bd5bb0c95dda2f9e7e6d325705da1748bf65df) | `oh-my-zsh: 2022-06-01 -> 2022-06-05 (#176518)`                                   |
| [`f0f1fc49`](https://github.com/NixOS/nixpkgs/commit/f0f1fc4902a438fc1ca64f13c09b4adf2a1e33d2) | `maintainers: add pogobanane`                                                     |
| [`dbe6bb26`](https://github.com/NixOS/nixpkgs/commit/dbe6bb26a4da46a44941bbe1fd09e238173f42d4) | `perlPackages.TextLevenshteinXS: init at 0.03`                                    |
| [`32d43843`](https://github.com/NixOS/nixpkgs/commit/32d43843d62807d169ae3f8a86068a5d7e08ff4e) | `perlPackages.WebServiceValidatorHTMLW3C: init 0.28`                              |
| [`ff7b216d`](https://github.com/NixOS/nixpkgs/commit/ff7b216dcf3b3396b24ebd73204f6841839bdd2a) | `perlPackages: add default meta.mainProgram (#176398)`                            |
| [`135028b6`](https://github.com/NixOS/nixpkgs/commit/135028b610b7c1254617d3092ccbfb5333f56c1c) | `python310Packages.holidays: update disabled`                                     |
| [`a505bdc3`](https://github.com/NixOS/nixpkgs/commit/a505bdc3f94e6daeb4ab5bb5d59df691b5ec4ef5) | `fulcrum: 1.6.0 -> 1.7.0`                                                         |
| [`acfbab28`](https://github.com/NixOS/nixpkgs/commit/acfbab28afab3420276d1b5f6d1368ea0ee6c7ee) | `python310Packages.holidays: 0.13 -> 0.14.2`                                      |
| [`4bfbbe9d`](https://github.com/NixOS/nixpkgs/commit/4bfbbe9d58f94ea5d54bdcad512605e49cab4fe2) | `atuin: 0.9.1 -> 0.10.0`                                                          |
| [`0be108df`](https://github.com/NixOS/nixpkgs/commit/0be108df2e8068e57a8bcf3c2e024ff054963b36) | `nixos/tests/firefox: fix return type typing`                                     |
| [`46712a64`](https://github.com/NixOS/nixpkgs/commit/46712a646107d7b0d76bbb6aeefe7baf93a34ff7) | `python310Packages.aioskybell: init at 22.6.0`                                    |
| [`a1037629`](https://github.com/NixOS/nixpkgs/commit/a1037629f56dddb1cfe877a48e93996c25d6dacc) | `python310Packages.azure-mgmt-batch: disable on older Python releases`            |
| [`d208dd99`](https://github.com/NixOS/nixpkgs/commit/d208dd99f3ce217051299f1d380c7374143f80a1) | `python310Packages.pysensibo: 1.0.16 -> 1.0.17`                                   |
| [`35d751b2`](https://github.com/NixOS/nixpkgs/commit/35d751b2db4e02f0963b76bf92d654fe56f4c7ce) | `python310Packages.meross-iot: 0.4.4.5 -> 0.4.4.7`                                |
| [`96c3ac67`](https://github.com/NixOS/nixpkgs/commit/96c3ac67ea33ad2da031dce560014b96db0c369c) | `python310Packages.azure-mgmt-batch: 16.1.0 -> 16.2.0`                            |
| [`20011937`](https://github.com/NixOS/nixpkgs/commit/2001193711aa0eeef68dfb71d2e2e67fc040ffc9) | `python310Packages.pysptk: add pythonImportsCheck`                                |
| [`eb38504a`](https://github.com/NixOS/nixpkgs/commit/eb38504a7483d93f48b28451f99981e1811c8cf2) | `yersinia: add -fcommon workaround`                                               |
| [`b4857447`](https://github.com/NixOS/nixpkgs/commit/b48574478302062e5b2eb6e94a29320f8a3c3b11) | `snipe-it: 5.4.3 -> 6.0.2`                                                        |
| [`cca70b73`](https://github.com/NixOS/nixpkgs/commit/cca70b73249b0a114d9c3713a16af2bf50b36366) | `python-minimal: don't clean meta.maintainer`                                     |
| [`b45291a2`](https://github.com/NixOS/nixpkgs/commit/b45291a2bce1e95c966542a7ef8a7e95d9ce6b18) | `git-blame-ignore-revs: add python format commit`                                 |
| [`bda47d3e`](https://github.com/NixOS/nixpkgs/commit/bda47d3eab420b37e01cce22e7d05915406d7ca9) | `python310Packages.r2pipe: 1.7.0 -> 1.7.1`                                        |
| [`a487e362`](https://github.com/NixOS/nixpkgs/commit/a487e362a10f318da123083d21df3daeabfc5c2e) | `fish: fix failing test`                                                          |
| [`9c7fe48d`](https://github.com/NixOS/nixpkgs/commit/9c7fe48d8d790de036d47a0288abf3dde40ded21) | `python310Packages.twitchapi: 2.5.3 -> 2.5.4`                                     |
| [`4ffef834`](https://github.com/NixOS/nixpkgs/commit/4ffef8340888dd5c4b7dc748456071e544cca428) | `docker-compose: add $out/bin symlink`                                            |
| [`b7b91880`](https://github.com/NixOS/nixpkgs/commit/b7b91880d3f2358a5eacb31476ab937c0df5562a) | `docker-compose: default to v2`                                                   |
| [`d8cdbde2`](https://github.com/NixOS/nixpkgs/commit/d8cdbde2c94345441235bad1d473b01ec14ca011) | `terraform-providers: update 2022-06-06`                                          |
| [`8ff17155`](https://github.com/NixOS/nixpkgs/commit/8ff17155becf4b2b8dcad32492e5abba3ffc73d9) | `python310Packages.fastcore: 1.4.3 -> 1.4.4`                                      |
| [`046d0253`](https://github.com/NixOS/nixpkgs/commit/046d0253aa88e47e4d424e02bc548897d5eeacfe) | `python310Packages.safety: improve expression`                                    |
| [`d3d975f7`](https://github.com/NixOS/nixpkgs/commit/d3d975f71c4a038984286d3b25fe964125e80bad) | `igraph: 0.9.8 -> 0.9.9`                                                          |
| [`e9f4412e`](https://github.com/NixOS/nixpkgs/commit/e9f4412eb44c543b12bd8dc472ecb953b3aa2f34) | `docker-edge: remove`                                                             |
| [`1ca6d814`](https://github.com/NixOS/nixpkgs/commit/1ca6d814762d1e37ee021807fb94c685fc5b85b4) | `python310Packages.smbus2: 0.4.1 -> 0.4.2`                                        |
| [`a60358be`](https://github.com/NixOS/nixpkgs/commit/a60358bec9b6f89e7ed727c1d88336d8f0379ea1) | `kubernetes: drop obsolete workarounds`                                           |
| [`44e85d3d`](https://github.com/NixOS/nixpkgs/commit/44e85d3d61c55f8a644f14a2defaffae044bcb09) | `python310Packages.pysptk: 0.1.20 -> 0.1.21`                                      |
| [`8dbfd523`](https://github.com/NixOS/nixpkgs/commit/8dbfd523ec9c0dd3c80093875855911666644767) | `python310Packages.nextcord: 2.0.0a10 -> 2.0.0b2`                                 |
| [`d33e96ee`](https://github.com/NixOS/nixpkgs/commit/d33e96ee4a28fda92f9fa159e110a1a825aa85fb) | `metadata-cleaner: 2.2.2 -> 2.2.3`                                                |
| [`d2a9a19e`](https://github.com/NixOS/nixpkgs/commit/d2a9a19e8aee6fad776bf0f43d9d5dda80444ff7) | `borgbackup: set meta.mainProgram`                                                |
| [`36aa013f`](https://github.com/NixOS/nixpkgs/commit/36aa013ff4a84f9316ddc7b9817592cb3e80d12b) | `borgbackup: 1.2.0 -> 1.2.1`                                                      |
| [`b108994c`](https://github.com/NixOS/nixpkgs/commit/b108994c1b0444aa0154657de41098c1fc4c4ad9) | `python310Packages.greeneye-monitor: relax version constraint`                    |
| [`9e762efd`](https://github.com/NixOS/nixpkgs/commit/9e762efdfa11de778a7cc0a305ae36c81fbcec89) | `python310Packages.siobrultech-protocols: 0.5.0 -> 0.6.0`                         |
| [`78ecfd54`](https://github.com/NixOS/nixpkgs/commit/78ecfd54e527c794eea1e3b8d1f6afb9020dc92b) | `xscreensaver: add missing Perl libs`                                             |
| [`e4cb4bdb`](https://github.com/NixOS/nixpkgs/commit/e4cb4bdb05605d691ca31b54703f2866197944ef) | `gnaural: add -fcommon workaround`                                                |
| [`1d5ccbc4`](https://github.com/NixOS/nixpkgs/commit/1d5ccbc42d9a37cb6619bbb7a5feb3f36e98fcc8) | `python310Packages.mkdocs-material: 8.3.1 -> 8.3.2`                               |
| [`1235314d`](https://github.com/NixOS/nixpkgs/commit/1235314d6cc0a239eb15061f8c3a9e28b11dbf39) | `ArchiSteamFarm: normalize file names`                                            |
| [`70a7d055`](https://github.com/NixOS/nixpkgs/commit/70a7d055f5c3e9bc5569e70fffb48a2d78d0a55d) | `ArchiSteamFarm: fix tmp filling up`                                              |
| [`89d5ef12`](https://github.com/NixOS/nixpkgs/commit/89d5ef1295b0b78d23856741ac914f8868550173) | `ArchiSteamFarm: update programm and web-ui in one run`                           |
| [`1841ad02`](https://github.com/NixOS/nixpkgs/commit/1841ad02a3a6ce601b39c1ad5a9a9fb8ca8c9be6) | `ArchiSteamFarm: fix shellcheck problems`                                         |
| [`950a8601`](https://github.com/NixOS/nixpkgs/commit/950a860155b8daf4e65bfe530811b9a5941ec6de) | `iosevka: 14.0.1 → 15.5.0`                                                        |
| [`1935db39`](https://github.com/NixOS/nixpkgs/commit/1935db3988e3e3ed3cd268468092de0a9e1ac93e) | `iosevka: set home directory in build phase`                                      |
| [`7cd27bcc`](https://github.com/NixOS/nixpkgs/commit/7cd27bccabc9b3fe9e1ff538c87709b9a1e1625b) | `python310Packages.snowflake-connector-python: add missing input`                 |
| [`f74ef9f9`](https://github.com/NixOS/nixpkgs/commit/f74ef9f98a726b718259c51396c0cde796dd0e44) | `python310Packages.wheel-inspect: relax entry-points-txt constraint`              |
| [`1c61372d`](https://github.com/NixOS/nixpkgs/commit/1c61372d39caded68a1913d9c3e6250d9512ff92) | `python310Packages.headerparser: enable tests`                                    |
| [`834eeb35`](https://github.com/NixOS/nixpkgs/commit/834eeb35e46f3009ca95954941bf35f73af4ed9d) | `python310Packages.entry-points-txt: 0.1.0 -> 0.2.0`                              |
| [`87de4db5`](https://github.com/NixOS/nixpkgs/commit/87de4db5e66c7b3b0ef34707fdde7af3ffb580c4) | `pkgs/config.nix: Fix missing attribute when no config keys are undeclared`       |
| [`5f4fe18c`](https://github.com/NixOS/nixpkgs/commit/5f4fe18c16eab71e2ebdd35b536c22d30d579106) | `python310Packages.wheel-inspect: 1.7.0 -> 1.7.1`                                 |
| [`5962fe07`](https://github.com/NixOS/nixpkgs/commit/5962fe0782dc36ae4a8fa34f96262c0ff5893dbb) | `python310Packages.wheel-filename: 1.3.0 -> 1.4.1`                                |
| [`d36bc45d`](https://github.com/NixOS/nixpkgs/commit/d36bc45d47fddfa6e387c4efbb0f076a089a04d9) | `goa: 1.4.1 -> 3.7.6`                                                             |
| [`e0f8de61`](https://github.com/NixOS/nixpkgs/commit/e0f8de611640ad5ae015abd69a5e657f3ce1c4be) | `easyjson: use buildGoModule`                                                     |
| [`8487b21f`](https://github.com/NixOS/nixpkgs/commit/8487b21ffbfaad8462dc1b37981d84cdc313a0de) | `memtest86+: 5.01-coreboot-002 -> 6.00-beta2`                                     |
| [`83a02852`](https://github.com/NixOS/nixpkgs/commit/83a028528ce30b3ddbfcbfb6a0d7e3b1e510e73d) | `chromiumDev: 104.0.5083.0 -> 104.0.5098.0`                                       |
| [`813520e6`](https://github.com/NixOS/nixpkgs/commit/813520e62490be7e0657f70982274b4895837300) | `uae: add -fcommon workaround`                                                    |
| [`417ae79c`](https://github.com/NixOS/nixpkgs/commit/417ae79c26cdaa4978077797d63b69f1c4ced245) | `trinity: pull upstream fix for -fno-common toolchains`                           |
| [`7320966b`](https://github.com/NixOS/nixpkgs/commit/7320966be6c4f5b4262a4b511d0af54d7a3e30bb) | `speech-tools: add -fcommon workaround`                                           |
| [`0758a0fa`](https://github.com/NixOS/nixpkgs/commit/0758a0fa275f0d12f3b8ff5daa6e96a2d519ad9f) | `roccat-tools: add -fcommon workaround`                                           |
| [`fc8061da`](https://github.com/NixOS/nixpkgs/commit/fc8061dae4731f7cd8043df9dc1c3bdbd8b10776) | `percona-xtrabackup_2_4: add -fcommon workaround`                                 |
| [`d306eea8`](https://github.com/NixOS/nixpkgs/commit/d306eea857c00d0e67f36ad17a0b281d3d46674d) | `oroborus: add -fcommon workaround`                                               |
| [`a38af493`](https://github.com/NixOS/nixpkgs/commit/a38af4931825722f973ad89e99d8c7e43fe6865a) | `lilo: add -fcommon workaround`                                                   |
| [`2d012163`](https://github.com/NixOS/nixpkgs/commit/2d012163f23495d81116960fae15288db5285ec7) | `nixos/uhub: fix plugins, set CAP_NET_BIND_SERVICE`                               |
| [`cc2548ae`](https://github.com/NixOS/nixpkgs/commit/cc2548ae81ab44d5f15d78a7d414ae90ccee170c) | `ircdog: use buildGoModule`                                                       |
| [`60ff8d23`](https://github.com/NixOS/nixpkgs/commit/60ff8d2306663d08621247b9416351a36183492e) | `ocamlPackages.magic: init at 0.7.3`                                              |
| [`11208c64`](https://github.com/NixOS/nixpkgs/commit/11208c64001f7c0c0073b6fd47c21bd9b1aff8aa) | `ocamlPackages.lo: init at 0.2.0`                                                 |
| [`85665ca9`](https://github.com/NixOS/nixpkgs/commit/85665ca9d489a6cc1352f9c16abe3106ea2f0d2d) | `ocamlPackages.duppy: init at 0.9.2`                                              |
| [`f3c53f43`](https://github.com/NixOS/nixpkgs/commit/f3c53f430f18e5c0a3c5d38669db5b817aabf2a2) | `ocamlPackages.dtools: init at 0.4.4`                                             |
| [`5ddc759a`](https://github.com/NixOS/nixpkgs/commit/5ddc759a4879cec6c87e853eec339dcf5546f6d5) | `dillo: add -fcommon workaround`                                                  |
| [`dcb168b1`](https://github.com/NixOS/nixpkgs/commit/dcb168b10932b1b72396d5ac30ccd9a2394d97ae) | `dieharder: add -fcommon workaround`                                              |
| [`c2e5fbe6`](https://github.com/NixOS/nixpkgs/commit/c2e5fbe6e89598d31a8c61f31a94c05d8a0cbc31) | `soft-serve: 0.3.0 -> 0.3.1`                                                      |
| [`3fcf9f18`](https://github.com/NixOS/nixpkgs/commit/3fcf9f18ddfdbf108b371637410821b6f388ef67) | `python3Packages.black: disable test on aarch64-linux`                            |
| [`74fbade6`](https://github.com/NixOS/nixpkgs/commit/74fbade62f6c9cf492c478a840e2746a5f9b9005) | `qmk: 1.0.0 -> 1.1.0`                                                             |
| [`09e3c120`](https://github.com/NixOS/nixpkgs/commit/09e3c1209172a224d3ca6be2de4466f2612f4a4c) | `mcomix3: remove and alias it to mcomix`                                          |
| [`5a8e7406`](https://github.com/NixOS/nixpkgs/commit/5a8e7406ca7d56b1b1d8590d44ca1966887eb9ed) | `mcomix: init at 2.0.2`                                                           |
| [`7ed01662`](https://github.com/NixOS/nixpkgs/commit/7ed016627f9b7c3a0ab068cb526ad37ec2f8bcc7) | `ocamlPackages.pulseaudio: init at 0.1.5`                                         |
| [`754433d8`](https://github.com/NixOS/nixpkgs/commit/754433d82a58d18a3c492cc84b4eae794766d648) | `ocamlPackages.portaudio: init at 0.2.3`                                          |
| [`e5031b83`](https://github.com/NixOS/nixpkgs/commit/e5031b839b07a5432f12fd2505339c7cbdaabfd4) | `ocamlPackages.gstreamer: init at 0.3.1`                                          |
| [`e5b2c5f4`](https://github.com/NixOS/nixpkgs/commit/e5b2c5f447ff3cadbbaff89ef2d547eee07c250d) | `ocamlPackages.alsa: init at 3.0.0`                                               |
| [`58b3f669`](https://github.com/NixOS/nixpkgs/commit/58b3f6693151d6c3d4a3f542be4f7dfa429519e4) | ``linuxKernels.kernels.linux_xanmod: don't set `-Werror` by default``             |
| [`83171a1d`](https://github.com/NixOS/nixpkgs/commit/83171a1dba143d34c6611d62d30cda2b983cec79) | `linuxKernels.kernels.linux_xanmod: apply patch from review`                      |
| [`2badffbd`](https://github.com/NixOS/nixpkgs/commit/2badffbd9983350effe3a5fae7e46f2644e26d3d) | `imagemagick: 7.1.0-36 -> 7.1.0-37`                                               |
| [`d688ec7d`](https://github.com/NixOS/nixpkgs/commit/d688ec7d80bb790e6c0199a8fc0487140fc91319) | `linuxKernels.kernels.linux_xanmod: import helpers`                               |
| [`ecaaba49`](https://github.com/NixOS/nixpkgs/commit/ecaaba491d483025370857690266c953e2977941) | `linuxKernels.kernels.linux_xanmod: adjust config for 5.18`                       |
| [`61b37a0a`](https://github.com/NixOS/nixpkgs/commit/61b37a0a20413f497c78aefd38d685cfea1fd490) | `linuxKernel.kernels.linux_xanmod_latest: 5.17.8 -> 5.18.1`                       |
| [`3fd61ac5`](https://github.com/NixOS/nixpkgs/commit/3fd61ac55ec27a8eefae188ffa600d568de12067) | `linuxKernels.kernels.linux_xanmod: 5.15.40 -> 5.15.43`                           |
| [`1b467b89`](https://github.com/NixOS/nixpkgs/commit/1b467b894b7dd9c9fc6ceff3f6c7a5ce4c24555e) | `platformio: needs xdg-user-dirs`                                                 |
| [`e366bbf9`](https://github.com/NixOS/nixpkgs/commit/e366bbf9b631b3e54bc829780c4fefd3b21534ff) | `janet: 1.21.2 -> 1.22.0`                                                         |
| [`1acba8b3`](https://github.com/NixOS/nixpkgs/commit/1acba8b3e5d35eb971519785e9dce857b95cbdbc) | `psst: 2022-01-25 -> 2022-05-19 and fix build`                                    |
| [`8422c32d`](https://github.com/NixOS/nixpkgs/commit/8422c32d6903a6d34824c9fef1e51d707996db12) | `python310Packages.pycep-parser: 0.3.6 -> 0.3.7`                                  |
| [`1a82aefe`](https://github.com/NixOS/nixpkgs/commit/1a82aefed87666388380fce418f7ae0117de3fe6) | `gx: 0.14.1 -> 0.14.3 (#176176)`                                                  |
| [`e3b9cba7`](https://github.com/NixOS/nixpkgs/commit/e3b9cba7cb47ec3e09d2e2801873cc834158520e) | `xboard: pull patch pending upstream inclusion for -fno-common toolchain support` |
| [`95f00120`](https://github.com/NixOS/nixpkgs/commit/95f001206fd289959940fa1f6cc10993841818cb) | `sway: Disable strictDeps for wrapper`                                            |
| [`98fd9445`](https://github.com/NixOS/nixpkgs/commit/98fd9445717b684894fb07e415772e459b42ffc0) | `seehecht: init at 3.0.2`                                                         |
| [`fb52e287`](https://github.com/NixOS/nixpkgs/commit/fb52e287c79457f253d3e2c5647d1b8697d1b14b) | `castor: 0.8.18 -> 0.9.0`                                                         |
| [`4b88d42f`](https://github.com/NixOS/nixpkgs/commit/4b88d42f5125b6b97d4991d0f7efac95f18d90c1) | `firefox: disable 'MOZILLA_OFFICIAL=1' on i686`                                   |
| [`81008f02`](https://github.com/NixOS/nixpkgs/commit/81008f02c420a34097f2c612edf08cf298c695c5) | `ocamlPackages.menhir: 20211128 → 20220210`                                       |
| [`c25fceda`](https://github.com/NixOS/nixpkgs/commit/c25fcedaf0997809df52d9861c27d5d0d73ca932) | `liquidsoap: pin menhir dependency`                                               |
| [`1b95daa3`](https://github.com/NixOS/nixpkgs/commit/1b95daa381fa4a0963217a5d386433c20008208a) | `alt-ergo: ensure compatibility with Menhir ≥ 20211215`                           |
| [`0a91054a`](https://github.com/NixOS/nixpkgs/commit/0a91054a94cf4abab1048134cc8066d2a7db4ede) | `oacmlPackages.toml: make compatible with menhir ≥ 20211215`                      |
| [`f6f5188f`](https://github.com/NixOS/nixpkgs/commit/f6f5188f751cdb9821802eef4e5e680e758eca53) | `oacmlPackages.odate: make compatible with menhir ≥ 20211215`                     |