### PR TITLE
chore(flake/nixpkgs): `34a7b314` -> `a1ab62da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654414801,
-        "narHash": "sha256-HSzC2kS7zRYfd4qw/IICrcP46jZFdWGgSSR7DtlgOiI=",
+        "lastModified": 1654596000,
+        "narHash": "sha256-KEsNCD0IPGaONtz6FxgaRpJO/yyJ+C559TmgXvXrO5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "34a7b3142e34796133fcb3f9c857d7b17982fdaa",
+        "rev": "a1ab62da271128de091642e5737a6e8ea1634746",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                               |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`ab7173f6`](https://github.com/NixOS/nixpkgs/commit/ab7173f6db30fcffe01a23d85138449fa990cabf) | `ocamlPackages.srt: 0.1.1 -> 0.2.1`                                          |
| [`4ac4c526`](https://github.com/NixOS/nixpkgs/commit/4ac4c526996d6be5d02a609765c37f94d23e20fc) | `liquidsoap: pin srt dependency`                                             |
| [`5b9de4e2`](https://github.com/NixOS/nixpkgs/commit/5b9de4e2bba96d26dcd23071ed33a17f47ddc1ff) | `python310Packages.bravado-core: add input`                                  |
| [`aa9b237e`](https://github.com/NixOS/nixpkgs/commit/aa9b237e5d206735924c04a31b496c980b988764) | `python310Packages.luxtronik: 0.3.13 -> 0.3.14`                              |
| [`cb268456`](https://github.com/NixOS/nixpkgs/commit/cb26845685076ac02be9b9972a712d500fec9384) | `ocamlPackages.posix-time2: init at 2.0.0`                                   |
| [`50cac6ed`](https://github.com/NixOS/nixpkgs/commit/50cac6ed5ed534f8a1539349863599ade91295e7) | `ocamlPackages.unix-errno: init at 0.6.1`                                    |
| [`17b53760`](https://github.com/NixOS/nixpkgs/commit/17b53760f61e2f158024aef79d9aa29e65986301) | `fluxcd: 0.30.2 -> 0.31.0`                                                   |
| [`f9b9e8b1`](https://github.com/NixOS/nixpkgs/commit/f9b9e8b16f26ffd7985a1b4987cd417d295e04cd) | `rwc: init at 0.2`                                                           |
| [`d82ca8d4`](https://github.com/NixOS/nixpkgs/commit/d82ca8d422b30ff50505ac99eae0b95775e4dcd6) | `home-assistant: 2022.6.2 -> 2022.6.3`                                       |
| [`fd326d0d`](https://github.com/NixOS/nixpkgs/commit/fd326d0d8c73404fc4bba1a299ac64cf81dfc7fb) | `python3Packages.pyialarmxr-homeassistant: rename from pyialarmxr`           |
| [`9a8ae4d7`](https://github.com/NixOS/nixpkgs/commit/9a8ae4d72ecbb2c6bc341146a5caebfd8844cf9f) | `gitlab: 15.0.1 -> 15.0.2 (#176629)`                                         |
| [`84883861`](https://github.com/NixOS/nixpkgs/commit/84883861f9f2dd8e85b56e4892072710829be4b6) | `httm: 0.10.16 -> 0.11.1`                                                    |
| [`7708f1e4`](https://github.com/NixOS/nixpkgs/commit/7708f1e48c77d663659b4b961f5976376820293f) | `cri-o: 1.24.0 -> 1.24.1`                                                    |
| [`6dd66a05`](https://github.com/NixOS/nixpkgs/commit/6dd66a05930d0ffc11796466cb6dea24945f625e) | `terraform-providers.remote: init at 0.0.24`                                 |
| [`31dc1991`](https://github.com/NixOS/nixpkgs/commit/31dc19919ae1546fb2237169e51114651c73ee9d) | `textadept: Merge back into a single version.`                               |
| [`26b1b6a6`](https://github.com/NixOS/nixpkgs/commit/26b1b6a6c60f7d185b460c8643d9c7241c75de4d) | `perlPackages.TclpTk: init at 1.09`                                          |
| [`9029cf19`](https://github.com/NixOS/nixpkgs/commit/9029cf19cb2b4190af19590426cf15c720eda0c9) | `maintainers: add patricksjackson`                                           |
| [`a6f86e33`](https://github.com/NixOS/nixpkgs/commit/a6f86e33fffb211210b19fabefd68f84c0d4ed7c) | `python310Packages.pyeight: 0.2.0 -> 0.3.0`                                  |
| [`c08942e1`](https://github.com/NixOS/nixpkgs/commit/c08942e1ad495ec838965a886cb07c42b7e09f75) | `nixos/tests/radarr: fix type of argument in test script`                    |
| [`965c2e12`](https://github.com/NixOS/nixpkgs/commit/965c2e12e74158561080cf7be3d4e3edd4885d5f) | `radarr: 4.0.5.5981 -> 4.1.0.6175`                                           |
| [`58219392`](https://github.com/NixOS/nixpkgs/commit/5821939268111b756473c531af325a509df219a3) | `python310Packages.twitterapi: 2.7.12 -> 2.7.13`                             |
| [`602e1cf7`](https://github.com/NixOS/nixpkgs/commit/602e1cf735128404f2e3312154c07fd6e464419d) | `python310Packages.yolink-api: 0.0.6 -> 0.0.7`                               |
| [`0eaa7239`](https://github.com/NixOS/nixpkgs/commit/0eaa72390bacff63a6d2b8f22aeb288a83e53b1f) | `maintainers: rename to leona`                                               |
| [`ac719acb`](https://github.com/NixOS/nixpkgs/commit/ac719acb8a3d8fb6996d7ddf01399934834321bb) | `python310Packages.atenpdu: 0.3.2 -> 0.3.3`                                  |
| [`eaecf427`](https://github.com/NixOS/nixpkgs/commit/eaecf427885347b61618a4e826a0ba100d8e21a5) | `terraform-lsp: use buildGoModule`                                           |
| [`e89fea64`](https://github.com/NixOS/nixpkgs/commit/e89fea64d3519a441a8de18675fc56148c131818) | `python310Packages.safety: fix typo`                                         |
| [`3a0ee098`](https://github.com/NixOS/nixpkgs/commit/3a0ee098a1d372bbf6cda961f739fd667b65978f) | `python310Packages.omnilogic: 0.4.5 -> 0.4.6`                                |
| [`3f82a912`](https://github.com/NixOS/nixpkgs/commit/3f82a9122a4298c9b60cab4528f6f2e9c750b241) | `python310Packages.pywemo: 0.8.1 -> 0.9.0`                                   |
| [`b1b94ab4`](https://github.com/NixOS/nixpkgs/commit/b1b94ab4afc6c3796f01155597b38b05dbb986d4) | `python310Packages.pynx584: 0.7 -> 0.8`                                      |
| [`6cecab9c`](https://github.com/NixOS/nixpkgs/commit/6cecab9cd84f2c01ebeac82c4ed49ea053315d58) | `hydra: create runcommand-logs directory`                                    |
| [`632a8936`](https://github.com/NixOS/nixpkgs/commit/632a8936b3584a3a979d429f03196a6e2e290459) | `Revert "python310Packages.flask-restful: remove condition from patch"`      |
| [`60d0be36`](https://github.com/NixOS/nixpkgs/commit/60d0be36a11c3471ca8fee0ededa17944d187a29) | `drawio: 19.0.0 -> 19.0.1`                                                   |
| [`30d1a2f2`](https://github.com/NixOS/nixpkgs/commit/30d1a2f29e9b309533567dbe55d5ea72653cc6f9) | `cfscrape: init at 2.1.1 (#176416)`                                          |
| [`475b0101`](https://github.com/NixOS/nixpkgs/commit/475b010143aa77a584ac51bc4934860cf22d0eb6) | `htop-vim: unstable-2021-10-11 -> unstable-2022-05-24`                       |
| [`03bcd6fd`](https://github.com/NixOS/nixpkgs/commit/03bcd6fd64ce7aead3fd852118267bd69d4eef50) | `nixos/release.nix: Add nixos.tests.allDrivers`                              |
| [`51224f52`](https://github.com/NixOS/nixpkgs/commit/51224f522f7a7d3a00ac2da4ceeedeea296cd2ed) | `nixosTests.allDrivers: Move logic to all-packages.nix`                      |
| [`e2d15bd6`](https://github.com/NixOS/nixpkgs/commit/e2d15bd6fed9a7d2d29599ccf98115090cc53c85) | `galculator: pull fix pending upstream inclusion for -fno-common toolchains` |
| [`9b9faa5b`](https://github.com/NixOS/nixpkgs/commit/9b9faa5bf85be51d158848a8e74a711fa760802f) | `map: rename map-cmd`                                                        |
| [`dae2fec8`](https://github.com/NixOS/nixpkgs/commit/dae2fec8a756f659e8f4affe42fb1de818e0ff1a) | `cubiomes-viewer: 2.1.1 -> 2.2.2`                                            |
| [`7f42a6cf`](https://github.com/NixOS/nixpkgs/commit/7f42a6cf572ae77c8264737f06e0b2c2deb74159) | `pySmartDL: init at 1.3.4 (#176421)`                                         |
| [`5a862299`](https://github.com/NixOS/nixpkgs/commit/5a862299e02b49126d44844e60d343c74eff8a9f) | `ocamlPackages.mm: init at 0.8.1`                                            |
| [`fbfd28e8`](https://github.com/NixOS/nixpkgs/commit/fbfd28e8ac8585dd9cb2e5cadfdfaf8597f9ad0a) | `ocamlPackages.mad: init at 0.5.2`                                           |
| [`5e76c696`](https://github.com/NixOS/nixpkgs/commit/5e76c6961d1b992046781c21c7d7dfd5df60d013) | `ocamlPackages.ao: init at 0.2.4`                                            |
| [`12254d43`](https://github.com/NixOS/nixpkgs/commit/12254d43883006a66b99089f149296a916e899f0) | `deja-dup: 43.2 → 43.3`                                                      |
| [`e91d6046`](https://github.com/NixOS/nixpkgs/commit/e91d6046b167e119026e83f9f8a1b9f60d0fcdc1) | `map: init at 0.1.1`                                                         |
| [`a42cdc07`](https://github.com/NixOS/nixpkgs/commit/a42cdc07fc27ab4ed58485b927e6edbe1a4900ba) | `sct: unstable-2015-11-16 -> 0.5`                                            |
| [`3c11b2df`](https://github.com/NixOS/nixpkgs/commit/3c11b2df706c4b8169bb1172035c48060a9188ba) | `maintainers: add somasis`                                                   |
| [`282eeff2`](https://github.com/NixOS/nixpkgs/commit/282eeff2443df29629ff5d23dc6fc7025eca98c1) | `pgadmin4: 6.9 -> 6.10`                                                      |
| [`9e22fffe`](https://github.com/NixOS/nixpkgs/commit/9e22fffe94ecdbdc58d091fe4c891eb9ddafd6da) | `xmppc: init at 0.1.2`                                                       |
| [`a0a517f5`](https://github.com/NixOS/nixpkgs/commit/a0a517f5acc59ae5b149cca9f864905f9eedea04) | `maintainer-list: add jugendhacker`                                          |
| [`5c871cdf`](https://github.com/NixOS/nixpkgs/commit/5c871cdf838ab4479071f3f5f90c2213e321a444) | `conform: init at 0.1.0-alpha.25`                                            |
| [`85731306`](https://github.com/NixOS/nixpkgs/commit/85731306feba7f9b6cd4e35ee7193f88dca9ab5d) | `htop: 3.2.0 -> 3.2.1`                                                       |
| [`f5bd5bb0`](https://github.com/NixOS/nixpkgs/commit/f5bd5bb0c95dda2f9e7e6d325705da1748bf65df) | `oh-my-zsh: 2022-06-01 -> 2022-06-05 (#176518)`                              |
| [`f0f1fc49`](https://github.com/NixOS/nixpkgs/commit/f0f1fc4902a438fc1ca64f13c09b4adf2a1e33d2) | `maintainers: add pogobanane`                                                |
| [`7b3ac6e3`](https://github.com/NixOS/nixpkgs/commit/7b3ac6e3f97cbff22387f0638d896ae7de6af73e) | `perlPackages.Tcl: init at 1.27`                                             |
| [`dbe6bb26`](https://github.com/NixOS/nixpkgs/commit/dbe6bb26a4da46a44941bbe1fd09e238173f42d4) | `perlPackages.TextLevenshteinXS: init at 0.03`                               |
| [`32d43843`](https://github.com/NixOS/nixpkgs/commit/32d43843d62807d169ae3f8a86068a5d7e08ff4e) | `perlPackages.WebServiceValidatorHTMLW3C: init 0.28`                         |
| [`27723a19`](https://github.com/NixOS/nixpkgs/commit/27723a19429b2525939543091bbb85fd0e592331) | `python310Packages.pyroute2-ipset: 0.6.9 -> 0.6.10`                          |
| [`ea3223f6`](https://github.com/NixOS/nixpkgs/commit/ea3223f6f840a1139c609d37944dce1261096452) | `python310Packages.pyroute2: 0.6.9 -> 0.6.10`                                |
| [`b6bae6fc`](https://github.com/NixOS/nixpkgs/commit/b6bae6fcb2d7a18586d1685aae848f758532ae16) | `python310Packages.pyroute2-protocols: 0.6.9 -> 0.6.10`                      |
| [`c2a30780`](https://github.com/NixOS/nixpkgs/commit/c2a307802e8f957fa92079311c3cef6a055e27cc) | `python310Packages.pyroute2-nslink: 0.6.9 -> 0.6.10`                         |
| [`b38ab26b`](https://github.com/NixOS/nixpkgs/commit/b38ab26b582da5a48bdd2f948ee58576f2a730d0) | `python310Packages.pyroute2-nftables: 0.6.9 -> 0.6.10`                       |
| [`f6742c5c`](https://github.com/NixOS/nixpkgs/commit/f6742c5cf71fd22e22caff0646d1c470674cc6b8) | `python310Packages.pyroute2-ndb: 0.6.9 -> 0.6.10`                            |
| [`dfbb3544`](https://github.com/NixOS/nixpkgs/commit/dfbb3544b616dad5f8d0750939d8beb8da5a279c) | `python310Packages.pyroute2-ipdb: 0.6.9 -> 0.6.10`                           |
| [`b9bbe8bf`](https://github.com/NixOS/nixpkgs/commit/b9bbe8bfd872bdd0459b7c73f5c5277652eb262f) | `python310Packages.pyroute2-ethtool: 0.6.9 -> 0.6.10`                        |
| [`6b7b3858`](https://github.com/NixOS/nixpkgs/commit/6b7b3858d6e2dd27eab7f0e63a22410a9fbf9218) | `python310Packages.pyroute2-core: 0.6.9 -> 0.6.10`                           |
| [`ff7b216d`](https://github.com/NixOS/nixpkgs/commit/ff7b216dcf3b3396b24ebd73204f6841839bdd2a) | `perlPackages: add default meta.mainProgram (#176398)`                       |
| [`135028b6`](https://github.com/NixOS/nixpkgs/commit/135028b610b7c1254617d3092ccbfb5333f56c1c) | `python310Packages.holidays: update disabled`                                |
| [`a505bdc3`](https://github.com/NixOS/nixpkgs/commit/a505bdc3f94e6daeb4ab5bb5d59df691b5ec4ef5) | `fulcrum: 1.6.0 -> 1.7.0`                                                    |
| [`acfbab28`](https://github.com/NixOS/nixpkgs/commit/acfbab28afab3420276d1b5f6d1368ea0ee6c7ee) | `python310Packages.holidays: 0.13 -> 0.14.2`                                 |
| [`4bfbbe9d`](https://github.com/NixOS/nixpkgs/commit/4bfbbe9d58f94ea5d54bdcad512605e49cab4fe2) | `atuin: 0.9.1 -> 0.10.0`                                                     |
| [`0be108df`](https://github.com/NixOS/nixpkgs/commit/0be108df2e8068e57a8bcf3c2e024ff054963b36) | `nixos/tests/firefox: fix return type typing`                                |
| [`46712a64`](https://github.com/NixOS/nixpkgs/commit/46712a646107d7b0d76bbb6aeefe7baf93a34ff7) | `python310Packages.aioskybell: init at 22.6.0`                               |
| [`6f0681dd`](https://github.com/NixOS/nixpkgs/commit/6f0681dd6bb3e3029b78bfc74a812326121bfad6) | `checkov: 2.0.1188 -> 2.0.1195`                                              |
| [`a1037629`](https://github.com/NixOS/nixpkgs/commit/a1037629f56dddb1cfe877a48e93996c25d6dacc) | `python310Packages.azure-mgmt-batch: disable on older Python releases`       |
| [`d208dd99`](https://github.com/NixOS/nixpkgs/commit/d208dd99f3ce217051299f1d380c7374143f80a1) | `python310Packages.pysensibo: 1.0.16 -> 1.0.17`                              |
| [`35d751b2`](https://github.com/NixOS/nixpkgs/commit/35d751b2db4e02f0963b76bf92d654fe56f4c7ce) | `python310Packages.meross-iot: 0.4.4.5 -> 0.4.4.7`                           |
| [`96c3ac67`](https://github.com/NixOS/nixpkgs/commit/96c3ac67ea33ad2da031dce560014b96db0c369c) | `python310Packages.azure-mgmt-batch: 16.1.0 -> 16.2.0`                       |
| [`20011937`](https://github.com/NixOS/nixpkgs/commit/2001193711aa0eeef68dfb71d2e2e67fc040ffc9) | `python310Packages.pysptk: add pythonImportsCheck`                           |
| [`eb38504a`](https://github.com/NixOS/nixpkgs/commit/eb38504a7483d93f48b28451f99981e1811c8cf2) | `yersinia: add -fcommon workaround`                                          |
| [`b4857447`](https://github.com/NixOS/nixpkgs/commit/b48574478302062e5b2eb6e94a29320f8a3c3b11) | `snipe-it: 5.4.3 -> 6.0.2`                                                   |
| [`cca70b73`](https://github.com/NixOS/nixpkgs/commit/cca70b73249b0a114d9c3713a16af2bf50b36366) | `python-minimal: don't clean meta.maintainer`                                |
| [`b45291a2`](https://github.com/NixOS/nixpkgs/commit/b45291a2bce1e95c966542a7ef8a7e95d9ce6b18) | `git-blame-ignore-revs: add python format commit`                            |
| [`bda47d3e`](https://github.com/NixOS/nixpkgs/commit/bda47d3eab420b37e01cce22e7d05915406d7ca9) | `python310Packages.r2pipe: 1.7.0 -> 1.7.1`                                   |
| [`a487e362`](https://github.com/NixOS/nixpkgs/commit/a487e362a10f318da123083d21df3daeabfc5c2e) | `fish: fix failing test`                                                     |
| [`9c7fe48d`](https://github.com/NixOS/nixpkgs/commit/9c7fe48d8d790de036d47a0288abf3dde40ded21) | `python310Packages.twitchapi: 2.5.3 -> 2.5.4`                                |
| [`4ffef834`](https://github.com/NixOS/nixpkgs/commit/4ffef8340888dd5c4b7dc748456071e544cca428) | `docker-compose: add $out/bin symlink`                                       |
| [`b7b91880`](https://github.com/NixOS/nixpkgs/commit/b7b91880d3f2358a5eacb31476ab937c0df5562a) | `docker-compose: default to v2`                                              |
| [`d8cdbde2`](https://github.com/NixOS/nixpkgs/commit/d8cdbde2c94345441235bad1d473b01ec14ca011) | `terraform-providers: update 2022-06-06`                                     |
| [`8ff17155`](https://github.com/NixOS/nixpkgs/commit/8ff17155becf4b2b8dcad32492e5abba3ffc73d9) | `python310Packages.fastcore: 1.4.3 -> 1.4.4`                                 |
| [`046d0253`](https://github.com/NixOS/nixpkgs/commit/046d0253aa88e47e4d424e02bc548897d5eeacfe) | `python310Packages.safety: improve expression`                               |
| [`d3d975f7`](https://github.com/NixOS/nixpkgs/commit/d3d975f71c4a038984286d3b25fe964125e80bad) | `igraph: 0.9.8 -> 0.9.9`                                                     |
| [`e6299e53`](https://github.com/NixOS/nixpkgs/commit/e6299e53681576838fb13380e088afbee3ff7a3d) | `ruby: move jemalloc to propagatedBuildInputs`                               |
| [`e9f4412e`](https://github.com/NixOS/nixpkgs/commit/e9f4412eb44c543b12bd8dc472ecb953b3aa2f34) | `docker-edge: remove`                                                        |
| [`1ca6d814`](https://github.com/NixOS/nixpkgs/commit/1ca6d814762d1e37ee021807fb94c685fc5b85b4) | `python310Packages.smbus2: 0.4.1 -> 0.4.2`                                   |
| [`a60358be`](https://github.com/NixOS/nixpkgs/commit/a60358bec9b6f89e7ed727c1d88336d8f0379ea1) | `kubernetes: drop obsolete workarounds`                                      |
| [`44e85d3d`](https://github.com/NixOS/nixpkgs/commit/44e85d3d61c55f8a644f14a2defaffae044bcb09) | `python310Packages.pysptk: 0.1.20 -> 0.1.21`                                 |
| [`8dbfd523`](https://github.com/NixOS/nixpkgs/commit/8dbfd523ec9c0dd3c80093875855911666644767) | `python310Packages.nextcord: 2.0.0a10 -> 2.0.0b2`                            |
| [`d33e96ee`](https://github.com/NixOS/nixpkgs/commit/d33e96ee4a28fda92f9fa159e110a1a825aa85fb) | `metadata-cleaner: 2.2.2 -> 2.2.3`                                           |
| [`d2a9a19e`](https://github.com/NixOS/nixpkgs/commit/d2a9a19e8aee6fad776bf0f43d9d5dda80444ff7) | `borgbackup: set meta.mainProgram`                                           |
| [`36aa013f`](https://github.com/NixOS/nixpkgs/commit/36aa013ff4a84f9316ddc7b9817592cb3e80d12b) | `borgbackup: 1.2.0 -> 1.2.1`                                                 |
| [`b108994c`](https://github.com/NixOS/nixpkgs/commit/b108994c1b0444aa0154657de41098c1fc4c4ad9) | `python310Packages.greeneye-monitor: relax version constraint`               |
| [`9e762efd`](https://github.com/NixOS/nixpkgs/commit/9e762efdfa11de778a7cc0a305ae36c81fbcec89) | `python310Packages.siobrultech-protocols: 0.5.0 -> 0.6.0`                    |
| [`78ecfd54`](https://github.com/NixOS/nixpkgs/commit/78ecfd54e527c794eea1e3b8d1f6afb9020dc92b) | `xscreensaver: add missing Perl libs`                                        |
| [`535900e9`](https://github.com/NixOS/nixpkgs/commit/535900e91dab642100660cdecc966dd164b134e3) | `jpegexiforient: fix cross-compilation`                                      |
| [`e4cb4bdb`](https://github.com/NixOS/nixpkgs/commit/e4cb4bdb05605d691ca31b54703f2866197944ef) | `gnaural: add -fcommon workaround`                                           |
| [`1d5ccbc4`](https://github.com/NixOS/nixpkgs/commit/1d5ccbc42d9a37cb6619bbb7a5feb3f36e98fcc8) | `python310Packages.mkdocs-material: 8.3.1 -> 8.3.2`                          |
| [`1235314d`](https://github.com/NixOS/nixpkgs/commit/1235314d6cc0a239eb15061f8c3a9e28b11dbf39) | `ArchiSteamFarm: normalize file names`                                       |
| [`70a7d055`](https://github.com/NixOS/nixpkgs/commit/70a7d055f5c3e9bc5569e70fffb48a2d78d0a55d) | `ArchiSteamFarm: fix tmp filling up`                                         |
| [`89d5ef12`](https://github.com/NixOS/nixpkgs/commit/89d5ef1295b0b78d23856741ac914f8868550173) | `ArchiSteamFarm: update programm and web-ui in one run`                      |
| [`1841ad02`](https://github.com/NixOS/nixpkgs/commit/1841ad02a3a6ce601b39c1ad5a9a9fb8ca8c9be6) | `ArchiSteamFarm: fix shellcheck problems`                                    |
| [`950a8601`](https://github.com/NixOS/nixpkgs/commit/950a860155b8daf4e65bfe530811b9a5941ec6de) | `iosevka: 14.0.1 → 15.5.0`                                                   |
| [`1935db39`](https://github.com/NixOS/nixpkgs/commit/1935db3988e3e3ed3cd268468092de0a9e1ac93e) | `iosevka: set home directory in build phase`                                 |
| [`7cd27bcc`](https://github.com/NixOS/nixpkgs/commit/7cd27bccabc9b3fe9e1ff538c87709b9a1e1625b) | `python310Packages.snowflake-connector-python: add missing input`            |
| [`f74ef9f9`](https://github.com/NixOS/nixpkgs/commit/f74ef9f98a726b718259c51396c0cde796dd0e44) | `python310Packages.wheel-inspect: relax entry-points-txt constraint`         |
| [`1c61372d`](https://github.com/NixOS/nixpkgs/commit/1c61372d39caded68a1913d9c3e6250d9512ff92) | `python310Packages.headerparser: enable tests`                               |
| [`834eeb35`](https://github.com/NixOS/nixpkgs/commit/834eeb35e46f3009ca95954941bf35f73af4ed9d) | `python310Packages.entry-points-txt: 0.1.0 -> 0.2.0`                         |
| [`87de4db5`](https://github.com/NixOS/nixpkgs/commit/87de4db5e66c7b3b0ef34707fdde7af3ffb580c4) | `pkgs/config.nix: Fix missing attribute when no config keys are undeclared`  |
| [`5f4fe18c`](https://github.com/NixOS/nixpkgs/commit/5f4fe18c16eab71e2ebdd35b536c22d30d579106) | `python310Packages.wheel-inspect: 1.7.0 -> 1.7.1`                            |
| [`5962fe07`](https://github.com/NixOS/nixpkgs/commit/5962fe0782dc36ae4a8fa34f96262c0ff5893dbb) | `python310Packages.wheel-filename: 1.3.0 -> 1.4.1`                           |
| [`d36bc45d`](https://github.com/NixOS/nixpkgs/commit/d36bc45d47fddfa6e387c4efbb0f076a089a04d9) | `goa: 1.4.1 -> 3.7.6`                                                        |
| [`e0f8de61`](https://github.com/NixOS/nixpkgs/commit/e0f8de611640ad5ae015abd69a5e657f3ce1c4be) | `easyjson: use buildGoModule`                                                |
| [`8487b21f`](https://github.com/NixOS/nixpkgs/commit/8487b21ffbfaad8462dc1b37981d84cdc313a0de) | `memtest86+: 5.01-coreboot-002 -> 6.00-beta2`                                |
| [`83a02852`](https://github.com/NixOS/nixpkgs/commit/83a028528ce30b3ddbfcbfb6a0d7e3b1e510e73d) | `chromiumDev: 104.0.5083.0 -> 104.0.5098.0`                                  |
| [`813520e6`](https://github.com/NixOS/nixpkgs/commit/813520e62490be7e0657f70982274b4895837300) | `uae: add -fcommon workaround`                                               |
| [`417ae79c`](https://github.com/NixOS/nixpkgs/commit/417ae79c26cdaa4978077797d63b69f1c4ced245) | `trinity: pull upstream fix for -fno-common toolchains`                      |
| [`7320966b`](https://github.com/NixOS/nixpkgs/commit/7320966be6c4f5b4262a4b511d0af54d7a3e30bb) | `speech-tools: add -fcommon workaround`                                      |
| [`0758a0fa`](https://github.com/NixOS/nixpkgs/commit/0758a0fa275f0d12f3b8ff5daa6e96a2d519ad9f) | `roccat-tools: add -fcommon workaround`                                      |
| [`fc8061da`](https://github.com/NixOS/nixpkgs/commit/fc8061dae4731f7cd8043df9dc1c3bdbd8b10776) | `percona-xtrabackup_2_4: add -fcommon workaround`                            |
| [`d306eea8`](https://github.com/NixOS/nixpkgs/commit/d306eea857c00d0e67f36ad17a0b281d3d46674d) | `oroborus: add -fcommon workaround`                                          |
| [`a38af493`](https://github.com/NixOS/nixpkgs/commit/a38af4931825722f973ad89e99d8c7e43fe6865a) | `lilo: add -fcommon workaround`                                              |
| [`2d012163`](https://github.com/NixOS/nixpkgs/commit/2d012163f23495d81116960fae15288db5285ec7) | `nixos/uhub: fix plugins, set CAP_NET_BIND_SERVICE`                          |
| [`cc2548ae`](https://github.com/NixOS/nixpkgs/commit/cc2548ae81ab44d5f15d78a7d414ae90ccee170c) | `ircdog: use buildGoModule`                                                  |
| [`60ff8d23`](https://github.com/NixOS/nixpkgs/commit/60ff8d2306663d08621247b9416351a36183492e) | `ocamlPackages.magic: init at 0.7.3`                                         |