### PR TITLE
chore(flake/nixpkgs): `a1ab62da` -> `b83c8874`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654596000,
-        "narHash": "sha256-KEsNCD0IPGaONtz6FxgaRpJO/yyJ+C559TmgXvXrO5o=",
+        "lastModified": 1654641387,
+        "narHash": "sha256-x2HnWQYpHCuW86nTSTSV/N2+DTeqmoXr0fBvP0jIDH0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a1ab62da271128de091642e5737a6e8ea1634746",
+        "rev": "b83c88740dbf88ce9ee9b18bf0b5947786e069ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`fa1d382b`](https://github.com/NixOS/nixpkgs/commit/fa1d382bd6944b7b2d9f753b455b08ae99b075f1) | `python3Packages.validphys2: add missing dependencies`                                |
| [`cf68deab`](https://github.com/NixOS/nixpkgs/commit/cf68deab17fde49169ff8d8217d936f7d235385d) | `terraform-providers.hetznerdns: init at 2.1.0`                                       |
| [`ff71240d`](https://github.com/NixOS/nixpkgs/commit/ff71240d2e5cbb634b42b4bdb05f5a3cd9622493) | `containerd: 1.6.5 -> 1.6.6`                                                          |
| [`9ad297f4`](https://github.com/NixOS/nixpkgs/commit/9ad297f457fad9aa0d9684a5086b27646a414b85) | `python310Packages.adb-shell: 0.4.2 -> 0.4.3`                                         |
| [`3910b36a`](https://github.com/NixOS/nixpkgs/commit/3910b36a708b9e05bab14568bce61c7118ebf9ef) | `haskellPackages: mark builds failing on hydra as broken`                             |
| [`436bb2e6`](https://github.com/NixOS/nixpkgs/commit/436bb2e60e26919a7b9c6a0d75205a60564c63e1) | `efficient-compression-tool: init at 0.9.1`                                           |
| [`d826ebc5`](https://github.com/NixOS/nixpkgs/commit/d826ebc5a8e06dd89fbb82589d0f6fc07d52eba3) | `haskellPackages.aws-sns-verify: disable network dependent tests`                     |
| [`a05afc66`](https://github.com/NixOS/nixpkgs/commit/a05afc66e8adf1c960e276fe91f83c6b21a45a9c) | `haskellPackages.NGLess: disable incomplete test suite`                               |
| [`55cadbcf`](https://github.com/NixOS/nixpkgs/commit/55cadbcfa313f4e160fbcf0fa751a6dc4e95e205) | `mujmap: 0.1.1 -> 0.2.0 (#176648)`                                                    |
| [`43fa64fc`](https://github.com/NixOS/nixpkgs/commit/43fa64fc984ec2a8a45a75f8c21bbe09d2250687) | `python3Packages.questionary: not broken on darwin`                                   |
| [`165602b8`](https://github.com/NixOS/nixpkgs/commit/165602b8016e4c3ca2c8a2e15086bfb84991b2b5) | `python310Packages.google-cloud-translate: 3.7.3 -> 3.7.4`                            |
| [`049ce2a9`](https://github.com/NixOS/nixpkgs/commit/049ce2a9ec2cd065ae92643a29fec4ac3c31a6a3) | `python310Packages.google-cloud-trace: 1.6.1 -> 1.6.2`                                |
| [`38463851`](https://github.com/NixOS/nixpkgs/commit/384638512ca91a098c513ea5a1fcac2f304e4135) | `python310Packages.google-cloud-speech: 2.14.0 -> 2.14.1`                             |
| [`ca3260b2`](https://github.com/NixOS/nixpkgs/commit/ca3260b2dfb0579ea928a708e29e62b3506a0793) | `python310Packages.google-cloud-securitycenter: 1.11.0 -> 1.11.1`                     |
| [`3410785b`](https://github.com/NixOS/nixpkgs/commit/3410785b9b30c622e8ec1c3a86f6f4aefb1a8b31) | `python310Packages.google-cloud-secret-manager: 2.11.0 -> 2.11.1`                     |
| [`bb9bd12c`](https://github.com/NixOS/nixpkgs/commit/bb9bd12c1547617f5d1fa20b587221023c012efb) | `python310Packages.google-cloud-redis: 2.8.0 -> 2.8.1`                                |
| [`f9aab9fe`](https://github.com/NixOS/nixpkgs/commit/f9aab9fed00fa7fa8cf3c698d9201d4ea399b183) | `python310Packages.google-cloud-pubsub: 2.12.1 -> 2.13.0`                             |
| [`3f1ec25f`](https://github.com/NixOS/nixpkgs/commit/3f1ec25f902bf6cb93db3600d3f6cd69234e4b9d) | `persistent-evdev: init at unstable-2022-01-14`                                       |
| [`2925dab8`](https://github.com/NixOS/nixpkgs/commit/2925dab822fc9b43dd718fc74cb671bbd9785ac5) | `python310Packages.google-cloud-os-config: 1.11.1 -> 1.11.2`                          |
| [`79b681ed`](https://github.com/NixOS/nixpkgs/commit/79b681ed5d1ac3163b3ca3dd803d125f29b1a71c) | `python310Packages.google-cloud-org-policy: 1.3.2 -> 1.3.3`                           |
| [`edba69ae`](https://github.com/NixOS/nixpkgs/commit/edba69aee54544a38cb24476436f8107f554865d) | `drawio: 19.0.1 -> 19.0.2`                                                            |
| [`c5d1acd5`](https://github.com/NixOS/nixpkgs/commit/c5d1acd593e0ee894445d129815e45da5476d4d3) | `python310Packages.google-cloud-bigquery-datatransfer: fix editorconfig check`        |
| [`2ad850d2`](https://github.com/NixOS/nixpkgs/commit/2ad850d21ff13198cf0f88e176a87897a11ff694) | `python310Packages.google-cloud-language: 2.4.2 -> 2.4.3`                             |
| [`764dff48`](https://github.com/NixOS/nixpkgs/commit/764dff4833642c7b6a3cc839d7eb1e713ff18f91) | `python310Packages.google-cloud-kms: 2.11.1 -> 2.11.2`                                |
| [`0fa2f72a`](https://github.com/NixOS/nixpkgs/commit/0fa2f72a8f68d6d34c7053644277d60b90e0565d) | `python310Packages.google-cloud-iot: 2.5.0 -> 2.5.1`                                  |
| [`d06a2c8e`](https://github.com/NixOS/nixpkgs/commit/d06a2c8e25cfb7af3949b38631140bb0b304dfb9) | `python310Packages.google-cloud-iam-logging: 1.0.1 -> 1.0.2`                          |
| [`41d0c6f0`](https://github.com/NixOS/nixpkgs/commit/41d0c6f080ca4a71ede96f0ba6de77c7c937af88) | `python310Packages.deezer-python: update disabled`                                    |
| [`e5dcb4ef`](https://github.com/NixOS/nixpkgs/commit/e5dcb4efd2ad2b376949676da1a5203fa7c90603) | `python2Packages.lpod: remove`                                                        |
| [`f9c76fba`](https://github.com/NixOS/nixpkgs/commit/f9c76fbaec24afba2797130217c97f962374d742) | `python2Packages.libcloud: remove`                                                    |
| [`c769a566`](https://github.com/NixOS/nixpkgs/commit/c769a566617a55355252c0c35294d52d439aadc6) | `python2Packages.ipaddr: remove`                                                      |
| [`3367f6e4`](https://github.com/NixOS/nixpkgs/commit/3367f6e4e69c06a5063d14e62211a8705af8188e) | `python2Packages.wsproto: remove`                                                     |
| [`a9aba22c`](https://github.com/NixOS/nixpkgs/commit/a9aba22cdc612c4c704ae1f3173c232e63ecaa89) | `python2Packages.freezegun: remove`                                                   |
| [`2a54a835`](https://github.com/NixOS/nixpkgs/commit/2a54a8357363dce49e3635979eff471cad66cf2f) | `python2Packages.decorator: remove`                                                   |
| [`c1c11045`](https://github.com/NixOS/nixpkgs/commit/c1c11045961909ccc876ab0ca25c8c9820b8f410) | `python2Packages.cryptography: remove`                                                |
| [`2f3c0f9a`](https://github.com/NixOS/nixpkgs/commit/2f3c0f9a41d9685ddf9ac638621c784ec6f9b090) | `python2Packages.click: remove`                                                       |
| [`6f432760`](https://github.com/NixOS/nixpkgs/commit/6f432760f6764c40934878aa32384eed3697abd7) | `haxor-news: use click 7.1.2`                                                         |
| [`ddcb0e56`](https://github.com/NixOS/nixpkgs/commit/ddcb0e566a627cae763d2e54427a48bdedeb05fe) | `csvs-to-sqlite: use click 7.1.2`                                                     |
| [`8ceaa66b`](https://github.com/NixOS/nixpkgs/commit/8ceaa66b5a953cd0f69cfc73a52d7580bdaf5b7c) | `python2Packages.itsdangerous: remove`                                                |
| [`162b4c10`](https://github.com/NixOS/nixpkgs/commit/162b4c10065bb716d09b48ddaa717fe22046c46c) | `python2Packages.werkzeug: remove`                                                    |
| [`b566290c`](https://github.com/NixOS/nixpkgs/commit/b566290cdbd987d5117c4e955ef85ba4786233b1) | `python2Packages.flask: remove`                                                       |
| [`ed4ec186`](https://github.com/NixOS/nixpkgs/commit/ed4ec1862bcc7d68e9d70579457fb699561d61d5) | `privacyidea: update overrides`                                                       |
| [`608ec38f`](https://github.com/NixOS/nixpkgs/commit/608ec38f08a807bbe441e02b8feb2433d9477113) | `python2Packages.pyjwt: remove`                                                       |
| [`ed806bb6`](https://github.com/NixOS/nixpkgs/commit/ed806bb62747da88316c7924898616dbbaec7db0) | `python2Packages.urllib3: remove`                                                     |
| [`93f430c1`](https://github.com/NixOS/nixpkgs/commit/93f430c1562ecc1a11383ae03df3eab50991b6a7) | `python2Packages.vcrpy: remove`                                                       |
| [`137d5546`](https://github.com/NixOS/nixpkgs/commit/137d55460ada649ea2703a81a0ffc85dc064e692) | `python2Packages.wxPython: remove`                                                    |
| [`2cbf885d`](https://github.com/NixOS/nixpkgs/commit/2cbf885d3085fcaf47a2c66996ff524001c27217) | `plover.stable: remove`                                                               |
| [`fa289b54`](https://github.com/NixOS/nixpkgs/commit/fa289b54cb1164e5d7531329f59e515558c62bd1) | `cura_stable: remove`                                                                 |
| [`4fcb482c`](https://github.com/NixOS/nixpkgs/commit/4fcb482cf33fb7175703e1b3ffed825188e2e420) | `salut_a_toi: remove`                                                                 |
| [`20f251ff`](https://github.com/NixOS/nixpkgs/commit/20f251ffc862891dd971ec850622e5d3c9648b54) | `torchat: remove`                                                                     |
| [`6dd563f9`](https://github.com/NixOS/nixpkgs/commit/6dd563f949e844a6d5935b60f410f1d3581cc84a) | `python310Packages.google-cloud-iam: 2.6.1 -> 2.6.2`                                  |
| [`c2d7efbc`](https://github.com/NixOS/nixpkgs/commit/c2d7efbc09691c456c65ef2fd6ce27b5f93d014e) | `textadept11: add alias to textadept`                                                 |
| [`879a7280`](https://github.com/NixOS/nixpkgs/commit/879a72800537ee5fef99ec7e8955f6ac43675c57) | `python310Packages.google-cloud-error-reporting: 1.5.2 -> 1.5.3`                      |
| [`771ec20c`](https://github.com/NixOS/nixpkgs/commit/771ec20c06de11939bfe86426aa420fa4d6778a1) | `python310Packages.google-cloud-dlp: 3.7.0 -> 3.7.1`                                  |
| [`a3bd84cd`](https://github.com/NixOS/nixpkgs/commit/a3bd84cddeb5107def7242950896a1f091341740) | `python310Packages.google-cloud-datastore: 2.6.1 -> 2.6.2`                            |
| [`f43b2572`](https://github.com/NixOS/nixpkgs/commit/f43b25729d7bb4bfb4077468a9e99f99af00de7f) | `oh-my-zsh: 2022-06-05 -> 2022-06-06 (#176675)`                                       |
| [`fac18419`](https://github.com/NixOS/nixpkgs/commit/fac18419430ebf3da016be13bdee23e175960b1e) | `python310Packages.google-cloud-dataproc: 4.0.2 -> 4.0.3`                             |
| [`cc7252bc`](https://github.com/NixOS/nixpkgs/commit/cc7252bc3f21b43fa60835630505c5682da40f6b) | `python310Packages.google-cloud-datacatalog: 3.8.0 -> 3.8.1`                          |
| [`0d1a2359`](https://github.com/NixOS/nixpkgs/commit/0d1a23594c00e0ec9da12fda282d324564178aef) | `python310Packages.google-cloud-container: 2.10.7 -> 2.10.8`                          |
| [`bafb8c89`](https://github.com/NixOS/nixpkgs/commit/bafb8c89c2e93826ad98a78277a95390541f3a94) | `python310Packages.google-cloud-bigquery-storage: 2.13.1 -> 2.13.2`                   |
| [`c383e4e4`](https://github.com/NixOS/nixpkgs/commit/c383e4e4d9001ef0939add3bcc4229f56e247834) | `python310Packages.google-cloud-bigquery-logging: 1.0.2 -> 1.0.3`                     |
| [`bda2cc91`](https://github.com/NixOS/nixpkgs/commit/bda2cc918684680a4cc6783c741b5fbd311b78aa) | `python310Packages.google-cloud-bigquery-datatransfer: 3.6.1 -> 3.6.2`                |
| [`44ad98c7`](https://github.com/NixOS/nixpkgs/commit/44ad98c77b4c2f80ae30904d0f92623ec2462bd4) | `python310Packages.google-cloud-asset: 3.9.0 -> 3.9.1`                                |
| [`d55e3439`](https://github.com/NixOS/nixpkgs/commit/d55e34392a6bafb78e83d839d374b1263321b131) | `python310Packages.google-cloud-texttospeech: 2.11.0 -> 2.11.1`                       |
| [`0922df19`](https://github.com/NixOS/nixpkgs/commit/0922df19a0129eaf345e8c578409024758ab266f) | `python310Packages.sagemaker: 2.93.0 -> 2.93.1`                                       |
| [`7881466e`](https://github.com/NixOS/nixpkgs/commit/7881466e3a9a9a13ac7bd02e4c092fc570929503) | `gnome-secrets: 6.4 -> 6.5`                                                           |
| [`b46f168b`](https://github.com/NixOS/nixpkgs/commit/b46f168b21b5568134ec389f6be35c4a05ecf632) | `python310Packages.google-cloud-tasks: 2.9.0 -> 2.9.1`                                |
| [`43d4ddf2`](https://github.com/NixOS/nixpkgs/commit/43d4ddf28e0facf1e5b8e8cb3cd86871d250ab03) | `treewide: remove usage of runCommandNoCC aliases`                                    |
| [`ee3b1e9a`](https://github.com/NixOS/nixpkgs/commit/ee3b1e9a42b4024581fa2233529d06177137e2a5) | `python310Packages.google-cloud-os-config: 1.11.1 -> 1.11.2`                          |
| [`e9382340`](https://github.com/NixOS/nixpkgs/commit/e93823409f9e6b8e878edf060b430a14353a28f9) | `wireshark: 3.6.3 -> 3.6.5`                                                           |
| [`570d347c`](https://github.com/NixOS/nixpkgs/commit/570d347c2ebf515bce37450bfd0e3bbf3746a9c1) | `python310Packages.fakeredis: 1.8 -> 1.8.1`                                           |
| [`5c43c429`](https://github.com/NixOS/nixpkgs/commit/5c43c429b7ac1d006749c10e05a4a5e132885c64) | `glances: 3.2.4.2 -> 3.2.5`                                                           |
| [`e78c2d05`](https://github.com/NixOS/nixpkgs/commit/e78c2d05da0cd52fecc82db63a3002ae76859fce) | `hedgedoc: ensure upload directory exists`                                            |
| [`92e24425`](https://github.com/NixOS/nixpkgs/commit/92e2442544007ab5c341ee7ad31282344f60d2cc) | `Point changelog to tag instead of master`                                            |
| [`2247e925`](https://github.com/NixOS/nixpkgs/commit/2247e925d697cdfe529ccdbb021fc6ac90fe8b92) | `Add homepage URL instead of variable`                                                |
| [`47d633a9`](https://github.com/NixOS/nixpkgs/commit/47d633a96803e6095012b10e16d7bfd50a34a245) | `Remove obvious comments from ldflags`                                                |
| [`55b2904c`](https://github.com/NixOS/nixpkgs/commit/55b2904c5ad89529365d957460f5558095ee9937) | `Maintainers: add cimm`                                                               |
| [`6f0b4a92`](https://github.com/NixOS/nixpkgs/commit/6f0b4a92dc262f68cdf235ebe231cabff6ef4c5d) | `bluewalker: init at 0.3.0`                                                           |
| [`cd4f6555`](https://github.com/NixOS/nixpkgs/commit/cd4f6555edd34e95d4427efb51ff6589e68cb0be) | `goresym: init at 1.2`                                                                |
| [`0907dc85`](https://github.com/NixOS/nixpkgs/commit/0907dc851fa2e56db75ae260a8ecc9880dc7b492) | `slack-term: use buildGoModule`                                                       |
| [`83ad4f2f`](https://github.com/NixOS/nixpkgs/commit/83ad4f2f938ec5daf2cc8d285f28c3ab2857e543) | `python310Packages.deezer-python: 5.3.2 -> 5.3.3`                                     |
| [`1d4bfa2a`](https://github.com/NixOS/nixpkgs/commit/1d4bfa2a9d06ed73f415e8a8e1ad838771f63b9a) | `python310Packages.oauthenticator: add format`                                        |
| [`f5ef819e`](https://github.com/NixOS/nixpkgs/commit/f5ef819e24c45331636ad28861bce952f25b2fae) | `mimir: switch pname to mimir`                                                        |
| [`d6ade044`](https://github.com/NixOS/nixpkgs/commit/d6ade044a4c6befabe7cd6084609c3d28372057d) | `oil: 0.9.9 -> 0.10.1`                                                                |
| [`3c89903a`](https://github.com/NixOS/nixpkgs/commit/3c89903ac88953f8cfeef52f2de6319d367d2fcf) | `python310Packages.asdf: 2.11.1 -> 2.12.0`                                            |
| [`be830ea4`](https://github.com/NixOS/nixpkgs/commit/be830ea4f7be96141e6ea4108538014f6b9447f3) | `python310Packages.google-cloud-runtimeconfig: 0.33.0 -> 0.33.1`                      |
| [`6d70d415`](https://github.com/NixOS/nixpkgs/commit/6d70d415da5470a1672f3b653ed37559c54b0103) | `python310Packages.aioairzone: 0.4.4 -> 0.4.5`                                        |
| [`ed2c6d7e`](https://github.com/NixOS/nixpkgs/commit/ed2c6d7efbac9179a7cadf93f1fb5ad7e17dd4fa) | `python310Packages.oauthenticator: 14.2.0 -> 15.0.0`                                  |
| [`7c3c0f12`](https://github.com/NixOS/nixpkgs/commit/7c3c0f1223680d4891df2178860415af3afa34aa) | `python310Packages.browser-cookie3: 0.14.1 -> 0.14.2`                                 |
| [`d2941088`](https://github.com/NixOS/nixpkgs/commit/d29410881e176c7cec7b2cbdcba3251cfe04accc) | `cargo-generate: 0.12.0 -> 0.14.0`                                                    |
| [`1ee7ec89`](https://github.com/NixOS/nixpkgs/commit/1ee7ec898a9bff60589e9cfdecd7d9de00e1f3d0) | `python310Packages.google-cloud-websecurityscanner: 1.7.1 -> 1.7.2`                   |
| [`22f30538`](https://github.com/NixOS/nixpkgs/commit/22f30538f29181226cfd6e90cb1b75fd73f95c9b) | `scala-cli: 0.1.6 -> 0.1.7`                                                           |
| [`1f9c7f33`](https://github.com/NixOS/nixpkgs/commit/1f9c7f33930a657c0c7b0500a097f8c38d474832) | `runitor: 0.10.0 -> 0.10.1`                                                           |
| [`826bef9b`](https://github.com/NixOS/nixpkgs/commit/826bef9b514bd5ceb5af55ccd79592778de03277) | `prometheus-unifi-exporter: remove`                                                   |
| [`aa080353`](https://github.com/NixOS/nixpkgs/commit/aa080353cf5a41e29ada832da99a957e869a80ac) | `macopix: add -fcommon workaround`                                                    |
| [`430a0e27`](https://github.com/NixOS/nixpkgs/commit/430a0e277ac536f1a41fb26c5bfab9e9bd452894) | `ifm: add -fcommon workaround`                                                        |
| [`d8b2dd91`](https://github.com/NixOS/nixpkgs/commit/d8b2dd91e0bf7aba7328f268b20058e281be443e) | `gargoyle: add -fcommon workaround`                                                   |
| [`5a0bdf69`](https://github.com/NixOS/nixpkgs/commit/5a0bdf69987fb65178952c6c01b1c6e329c9268c) | `adguardhome: 0.107.6 - 0.107.7`                                                      |
| [`113f2048`](https://github.com/NixOS/nixpkgs/commit/113f20488ce644858959c77d58e11d8579e715be) | `roxctl: 3.69.1 -> 3.70.0`                                                            |
| [`109e13db`](https://github.com/NixOS/nixpkgs/commit/109e13db243249e26b8b8d861424578400aae882) | `dragonflydb: init at 0.1.0`                                                          |
| [`3586c258`](https://github.com/NixOS/nixpkgs/commit/3586c258e8dfd305b8a6c65dd5c98efabd288e59) | `haskell.packages.ghc923: pin fourmolu to 0.6.0.0`                                    |
| [`c7104a2e`](https://github.com/NixOS/nixpkgs/commit/c7104a2e5d6334f76a54a20beaae14e68cd09bc1) | `libagar_test: add -fcommon workaround`                                               |
| [`82bb52db`](https://github.com/NixOS/nixpkgs/commit/82bb52db8f3f8cb90911e6cb194b5e9602a49c15) | `eresi: pull fix pending upstream inclusion for -fno-common toolchains`               |
| [`46e4f3bd`](https://github.com/NixOS/nixpkgs/commit/46e4f3bd77559fe6edb366551530fe50a774849f) | `cernlib: add -fcommon workaround`                                                    |
| [`b9dcfbbd`](https://github.com/NixOS/nixpkgs/commit/b9dcfbbd4dc4a4ca4c40c3a0042e1d121e459eb7) | `cdesktopenv: add -fcommon workaround`                                                |
| [`d3805f8d`](https://github.com/NixOS/nixpkgs/commit/d3805f8df5dec0e18fdf983734cfb728476e6dd5) | `darwin.dtrace: add -fcommon workaround`                                              |
| [`70d95b25`](https://github.com/NixOS/nixpkgs/commit/70d95b25b6c7130563522aed285374b2b20d7464) | `haskellPackages.protolude: drop upstreamed patches`                                  |
| [`a0809c02`](https://github.com/NixOS/nixpkgs/commit/a0809c029330540e35ff5a8cd4295b68271e1e19) | `haskellPackages.hoogleLocal: allow substitutes again`                                |
| [`4537ba53`](https://github.com/NixOS/nixpkgs/commit/4537ba53c00ce2bc072f5c2981f737ed254757be) | `rmfuse: Re-lock dependencies`                                                        |
| [`2aa6ee92`](https://github.com/NixOS/nixpkgs/commit/2aa6ee92a627fdd39fcf81d7ec6003015d192742) | `glirc: 2.38 -> 2.39`                                                                 |
| [`28e96668`](https://github.com/NixOS/nixpkgs/commit/28e9666850a6c7ce2512316d7dec38f878b26560) | `haskell.packages.ghc923.fourmolu: 0.6.0.0 -> 0.7.0.1`                                |
| [`30558578`](https://github.com/NixOS/nixpkgs/commit/305585788bfc5fac4ae1340b144316b9acb942db) | `haskellPackages: regenerate package set based on current config`                     |
| [`f2af2587`](https://github.com/NixOS/nixpkgs/commit/f2af2587970769d5985eab5a0189dc2160014814) | `haskellPackages: stackage LTS 19.8 -> LTS 19.9`                                      |
| [`c198b6e7`](https://github.com/NixOS/nixpkgs/commit/c198b6e76e8d00b565f815bb377cc3d11bfd65d2) | `all-cabal-hashes: 2022-05-29T17:05:02Z -> 2022-06-04T09:01:11Z`                      |
| [`473bca4b`](https://github.com/NixOS/nixpkgs/commit/473bca4bd27738f487d134e0b3f79305dca09ef0) | `linuxPackages_hardkernel_latest.usbip: pull upstream fix for -fno-common toolchains` |
| [`c9a10a58`](https://github.com/NixOS/nixpkgs/commit/c9a10a58f33ff927d066df4735a3c057cf7ee2af) | `libmediaart: 1.9.5 -> 1.9.6`                                                         |
| [`58d2ebb2`](https://github.com/NixOS/nixpkgs/commit/58d2ebb2831fa3236598398c7dbba8e205d4e91c) | `ntfs3g: 2021.8.22 -> 2022.5.17`                                                      |
| [`efec6c02`](https://github.com/NixOS/nixpkgs/commit/efec6c02d593856c3b433fd2b7480b161b0c4684) | `glpk: 4.65 -> 5.0`                                                                   |
| [`0757b37a`](https://github.com/NixOS/nixpkgs/commit/0757b37a5395bbda2ab5e4a0e5126ac243110637) | `kubernetes-controller-tools: 0.6.2 -> 0.8.0`                                         |
| [`d76f600c`](https://github.com/NixOS/nixpkgs/commit/d76f600c92e9a0d58f94267d3bd3e9cc77a3b4ab) | `atomEnv: remove libgnome-keyring dependency`                                         |
| [`9f719ade`](https://github.com/NixOS/nixpkgs/commit/9f719ade9c65ef04e4622c9268cdcedbf3bdda1c) | `atomEnv: remove pointless GConf dependency`                                          |