### PR TITLE
chore(flake/nixgl): `3214ffea` -> `a8ea9498`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1653311504,
-        "narHash": "sha256-4/EOfhL9gRAhUlC57DEQyg74RrcXPG8TTUDF8G7l6OY=",
+        "lastModified": 1654714858,
+        "narHash": "sha256-P5k90jPOgRwRO18S+bMUUReKethbEKD05P0pljaTdLQ=",
         "owner": "guibou",
         "repo": "nixgl",
-        "rev": "3214ffead3934d1d8873657fdde4a4527078f9f6",
+        "rev": "a8ea94984e64cf134d1aea66c1e3bbc25bfe1c25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                        | Commit Message                                              |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`9ebdad1c`](https://github.com/guibou/nixGL/commit/9ebdad1c53e78bb7feb1c56f3abfdd54745be61b) | `add support for setting the EGL vendor configuration path` |