### PR TITLE
chore(flake/nixpkgs): `b83c8874` -> `6b946293`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654641387,
-        "narHash": "sha256-x2HnWQYpHCuW86nTSTSV/N2+DTeqmoXr0fBvP0jIDH0=",
+        "lastModified": 1654687877,
+        "narHash": "sha256-46TN18Iri3vC6ySdd3Y0HrYjD5SL+OAlMCrtieb9Zfo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b83c88740dbf88ce9ee9b18bf0b5947786e069ad",
+        "rev": "6b94629394148771699231cbac523deedd7c64ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`80755988`](https://github.com/NixOS/nixpkgs/commit/80755988848e1ab4b08fb026e1652ff50ab54b65) | `terraform: add passthru.tests`                                             |
| [`cb6b9659`](https://github.com/NixOS/nixpkgs/commit/cb6b96591e3c9857ae4f0acebd1261daa6fd57cd) | `vend: remove`                                                              |
| [`b246d546`](https://github.com/NixOS/nixpkgs/commit/b246d54635583a058e31c8d28a552d7723669560) | ``buildGoModule: remove `runVend```                                         |
| [`e0d8c562`](https://github.com/NixOS/nixpkgs/commit/e0d8c56200fd7ec9a325dd80a8f4ef5a8de9209b) | `python310Packages.dash: add input`                                         |
| [`08ff8db9`](https://github.com/NixOS/nixpkgs/commit/08ff8db9b984aeda984e232b18d6cfbbc69d2dd3) | `python310Packages.spacy: 3.3.0 -> 3.3.1`                                   |
| [`788a347a`](https://github.com/NixOS/nixpkgs/commit/788a347a174df3c1a0bc3710e45b5d053ef6a817) | `stuntrally: 2.6.1 -> 2.6.2`                                                |
| [`e6b4eb3b`](https://github.com/NixOS/nixpkgs/commit/e6b4eb3b78c949d7e3e05badbe90cc792d9d5c52) | `qarte: 4.15.1 → 4.17.1`                                                    |
| [`9dfb8403`](https://github.com/NixOS/nixpkgs/commit/9dfb84032067505dba8f5771e8cf6090c19c3083) | `python310Packages.dash: add extra dependencies`                            |
| [`b383999d`](https://github.com/NixOS/nixpkgs/commit/b383999d5034dc6041e61b81a762c3d762dd6d7b) | `python310Packages.yolink-api: 0.0.7 -> 0.0.8`                              |
| [`cf924c74`](https://github.com/NixOS/nixpkgs/commit/cf924c74c7f83ffadad77f3258d6986f84af3771) | `python310Packages.quantum-gateway: 0.0.6 -> 0.0.8`                         |
| [`66a53225`](https://github.com/NixOS/nixpkgs/commit/66a532257d8ede0a0bb425bb412a96692415e920) | `coqPackages.coq-elpi: 1.13.0 → 1.14.0`                                     |
| [`f7373e49`](https://github.com/NixOS/nixpkgs/commit/f7373e4932d73da83f6c59b8d28bf53faf97ca2f) | `ocamlPackages.elpi: 1.15.0 → 1.15.2`                                       |
| [`18aaa33f`](https://github.com/NixOS/nixpkgs/commit/18aaa33f07a5193c18448d6f382a3c6662842ffc) | `ocamlPackages.elpi: 1.14.1 → 1.15.0`                                       |
| [`321e60b2`](https://github.com/NixOS/nixpkgs/commit/321e60b24bc477e80b5b7266953cfefe256e1396) | `python310Packages.dash: 2.4.1 -> 2.5.0`                                    |
| [`ee8a4e36`](https://github.com/NixOS/nixpkgs/commit/ee8a4e36152edef4599e7475c86bcb4171acc12a) | `python310Packages.databricks-connect: 9.1.16 -> 9.1.17`                    |
| [`36962c4c`](https://github.com/NixOS/nixpkgs/commit/36962c4c397e7a00a39616cad40641498ae2f769) | `python310Packages.xknx: 0.21.3 -> 0.21.4`                                  |
| [`63a13dba`](https://github.com/NixOS/nixpkgs/commit/63a13dba06c8a44b0cf83dc278ea442e9c67cb45) | `inotify-tools: 3.22.1.0 -> 3.22.6.0`                                       |
| [`09570ee4`](https://github.com/NixOS/nixpkgs/commit/09570ee4a943b5b3e686f71fa93e4745e33316d3) | ``goa: remove unnecessary `deps.nix```                                      |
| [`fad47110`](https://github.com/NixOS/nixpkgs/commit/fad47110258f30a43492c288f33bc52412ee7fd0) | ``easyjson: remove unnecessary `deps.nix```                                 |
| [`e94f0231`](https://github.com/NixOS/nixpkgs/commit/e94f0231b72af69410b6715a2973bf108e3aa655) | `python310Packages.mkdocs-material: 8.3.2 -> 8.3.3`                         |
| [`712272f8`](https://github.com/NixOS/nixpkgs/commit/712272f895ddb626727ed4049603f4725a935f7a) | `kodestudio: Remove. The nix package was way out of date and unmaintained.` |
| [`835be707`](https://github.com/NixOS/nixpkgs/commit/835be707da447620d2684160782b8283104b2551) | `bzip3: fix build on darwin`                                                |
| [`273f614b`](https://github.com/NixOS/nixpkgs/commit/273f614b44d99e29f48b62a93505522b90e1aa85) | `authy: 2.1.0 -> 2.2.0 (#175206)`                                           |
| [`7fc4e3b8`](https://github.com/NixOS/nixpkgs/commit/7fc4e3b858bb2ab17353f419f9a1587fa3993726) | `python310Packages.pyfxa: switch to pytestCheckHook`                        |
| [`87807925`](https://github.com/NixOS/nixpkgs/commit/87807925c47ed18e3e595d75ea6a91eef6443ba8) | `python310Packages.webexteamssdk: disable on obsolete Python releases`      |
| [`659e7a48`](https://github.com/NixOS/nixpkgs/commit/659e7a4807121278a5a9b0d2fc63d60ff0916710) | `python310Packages.webexteamssdk: 1.6 -> 1.6.1`                             |
| [`1eae6a3c`](https://github.com/NixOS/nixpkgs/commit/1eae6a3c3a01963f6cc8500fd37ad7f2a40785ad) | `python310Packages.pyroute2-ipset: 0.6.10 -> 0.6.11`                        |
| [`4d10c2ce`](https://github.com/NixOS/nixpkgs/commit/4d10c2ce7f8893cd14abcc001b73ae6b91a0508a) | `python310Packages.pyroute2: 0.6.10 -> 0.6.11`                              |
| [`61332648`](https://github.com/NixOS/nixpkgs/commit/61332648485146fa10263d959d000f915dbb9d8c) | `python310Packages.pyroute2-protocols: 0.6.10 -> 0.6.11`                    |
| [`14368fc6`](https://github.com/NixOS/nixpkgs/commit/14368fc622ab66b91493874837a5677efe5ae88f) | `python310Packages.pyroute2-nslink: 0.6.10 -> 0.6.11`                       |
| [`aacc1079`](https://github.com/NixOS/nixpkgs/commit/aacc1079c7d7f3546cc4e02f0f84fd45024dd0ee) | `python310Packages.pyroute2-nftables: 0.6.10 -> 0.6.11`                     |
| [`93eb7f89`](https://github.com/NixOS/nixpkgs/commit/93eb7f89b8b96e063fd1ef8c9647bed6ddd8698e) | `python310Packages.pyroute2-ndb: 0.6.10 -> 0.6.11`                          |
| [`a529fd4c`](https://github.com/NixOS/nixpkgs/commit/a529fd4c2fac012dc9f1166663f7d11ef02ba0b1) | `python310Packages.pyroute2-ipdb: 0.6.10 -> 0.6.11`                         |
| [`49da7da0`](https://github.com/NixOS/nixpkgs/commit/49da7da0b427be4d5b4d4f420a11eea2f429beda) | `python310Packages.pyroute2-ethtool: 0.6.10 -> 0.6.11`                      |
| [`5cc98c37`](https://github.com/NixOS/nixpkgs/commit/5cc98c37ad2f2258f7ad4d0cce00617ef853ca2e) | `python310Packages.pyroute2-core: 0.6.10 -> 0.6.11`                         |
| [`278423ab`](https://github.com/NixOS/nixpkgs/commit/278423ab654dd742386ca4e911c9b76774ff19ae) | `python310Packages.plugwise: 0.19.0 -> 0.19.0`                              |
| [`7c825060`](https://github.com/NixOS/nixpkgs/commit/7c82506085269926301086ff96cb4184e0e52da4) | `python3Packages.pyfxa: fix fxa-client`                                     |
| [`6232c43e`](https://github.com/NixOS/nixpkgs/commit/6232c43e4da390007e8ddb787562c3040533dc11) | `deltachat-desktop: 1.30.0 -> 1.30.1`                                       |
| [`c7658a87`](https://github.com/NixOS/nixpkgs/commit/c7658a87ac3e867dc1ea0e11ffc0cf10bb750553) | `python310Packages.dulwich: 0.20.42 -> 0.20.43`                             |
| [`a0378c15`](https://github.com/NixOS/nixpkgs/commit/a0378c15e25ada553df654258475c5b11ad56410) | `libdeltachat: 1.85.0 -> 1.86.0`                                            |
| [`b0e0d8db`](https://github.com/NixOS/nixpkgs/commit/b0e0d8db46b23971a5426104e438daa5f4ef0040) | `webhook: use buildGoModule`                                                |
| [`ae9f904e`](https://github.com/NixOS/nixpkgs/commit/ae9f904eb26abb6b0ff871437bf8015a80f32e9f) | `gajim: 1.4.2 → 1.4.3`                                                      |
| [`3e762139`](https://github.com/NixOS/nixpkgs/commit/3e7621390c2f59a54fef2222f4bfab46cb534936) | `maintainers: mrhedgehog -> thehedgeh0g`                                    |
| [`56d2f848`](https://github.com/NixOS/nixpkgs/commit/56d2f848b141e3c458e8da826e57be974afe420b) | `obsidian: 0.14.6 -> 0.14.15`                                               |
| [`311f2101`](https://github.com/NixOS/nixpkgs/commit/311f2101d900befde5ff41b4fb71bfc99cf618ba) | `sigma-cli: relax pysigma constraint`                                       |
| [`887e366f`](https://github.com/NixOS/nixpkgs/commit/887e366f5380e57809f48d2b143a85dbbefc55b9) | `python310Packages.pysigma-pipeline-sysmon: 0.1.5 -> 0.1.6`                 |
| [`387cb3f8`](https://github.com/NixOS/nixpkgs/commit/387cb3f84d7cf075fd9686ffc4a8ef1f6c054ed4) | `python310Packages.pysigma-pipeline-crowdstrike: 0.1.5 -> 0.1.6`            |
| [`90946525`](https://github.com/NixOS/nixpkgs/commit/90946525f3380bdc03bb8a1f98fc3b5fcb12bc9a) | `python310Packages.pysigma-backend-splunk: 0.3.2 -> 0.3.3`                  |
| [`1fb02d2e`](https://github.com/NixOS/nixpkgs/commit/1fb02d2eec4e980553bd4766ff7074ed260962f8) | `python310Packages.pysigma-backend-insightidr: 0.1.5 -> 0.1.6`              |
| [`0e11ec9a`](https://github.com/NixOS/nixpkgs/commit/0e11ec9a23d6132d86c45deb88b2a32813c48b43) | `python310Packages.pysigma-pipeline-windows: relax pysigma constraint`      |
| [`1a3924b8`](https://github.com/NixOS/nixpkgs/commit/1a3924b8585d08135245df975e182249f8fea925) | `python310Packages.pysigma: 0.5.2 -> 0.6.2`                                 |
| [`cf594d1f`](https://github.com/NixOS/nixpkgs/commit/cf594d1f6e2dc1beea416d007b70c38a5e54ba7f) | `cloud-init: fix missing pyserial dependency`                               |
| [`0e222cc4`](https://github.com/NixOS/nixpkgs/commit/0e222cc4ec42d8257bae6745fe79903829f41145) | `checkov: 2.0.1195 -> 2.0.1201`                                             |
| [`8abfb3fb`](https://github.com/NixOS/nixpkgs/commit/8abfb3fbc60046ab98e8c164991d85d429eb39e4) | `ltex-ls: init at 15.2.0`                                                   |
| [`411f38ef`](https://github.com/NixOS/nixpkgs/commit/411f38ef26f6936a5ecabe1b0edbcfb42045947b) | `btrfs-progs: 5.18 -> 5.18.1`                                               |
| [`5970407d`](https://github.com/NixOS/nixpkgs/commit/5970407d19b5f836fe74b9ff427309f63d27e0f1) | `certigo: patch tests and enable checks on Darwin`                          |
| [`c8f5b17a`](https://github.com/NixOS/nixpkgs/commit/c8f5b17a98b357e24fe0eb5a117820899b363750) | `nixos/nix-daemon: set LimitNOFILE to 1048576`                              |
| [`20749fc8`](https://github.com/NixOS/nixpkgs/commit/20749fc886cf6ade0726d0ab51a6c08428e51c73) | `hidapi: 0.11.2 -> 0.12.0`                                                  |
| [`d7c6d3d0`](https://github.com/NixOS/nixpkgs/commit/d7c6d3d063d0671e2ce7fd1c5bc4d93771ec6883) | `coturn: add -fcommon workaround`                                           |
| [`e827840a`](https://github.com/NixOS/nixpkgs/commit/e827840ae56079e55d198f42049da6912506f5b0) | `elasticsearch-plugins: 7.16.1 -> 7.17.4`                                   |
| [`39a1aded`](https://github.com/NixOS/nixpkgs/commit/39a1adedec043464338a8831b5175b81dbd229d8) | `python310Packages.bitbox02: 5.3.0 -> 6.0.0`                                |