### PR TITLE
chore(flake/nixgl): `a8ea9498` -> `1cce2dd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1654714858,
-        "narHash": "sha256-P5k90jPOgRwRO18S+bMUUReKethbEKD05P0pljaTdLQ=",
+        "lastModified": 1654775507,
+        "narHash": "sha256-NPkQiaz6Oo5EuWj5hRXMKebAhAfiVtnklii0imR85dE=",
         "owner": "guibou",
         "repo": "nixgl",
-        "rev": "a8ea94984e64cf134d1aea66c1e3bbc25bfe1c25",
+        "rev": "1cce2dd704829504d057dacc71daf1c00951460d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                        | Commit Message                                 |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`e61a5f58`](https://github.com/guibou/nixGL/commit/e61a5f58294685b6b5b15422c41d5d63a7aa4629) | `Add tests for nvidio 510 packages`            |
| [`546b626b`](https://github.com/guibou/nixGL/commit/546b626b422b9c6528137cac289143c186433cf2) | `fix: correct version for our nvidia driver`   |
| [`fd7712ce`](https://github.com/guibou/nixGL/commit/fd7712cee8a623fed1ef99a08578b111e93a533c) | `fix: find nvidia icd files thank to wildcard` |
| [`ccfbb79e`](https://github.com/guibou/nixGL/commit/ccfbb79eca537036bcc851c17e6fd5f89d1b3ef5) | `chore: bump github actions`                   |