### PR TITLE
chore(flake/nixpkgs): `6b946293` -> `6036dcbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654687877,
-        "narHash": "sha256-46TN18Iri3vC6ySdd3Y0HrYjD5SL+OAlMCrtieb9Zfo=",
+        "lastModified": 1654957404,
+        "narHash": "sha256-u2nOQH+GUD3yAYE2ETloAuyP5b80iNKYUEWiNAicc+A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6b94629394148771699231cbac523deedd7c64ed",
+        "rev": "6036dcbdb930177396012bbe39d8e31201289a14",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                          |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`e329b995`](https://github.com/NixOS/nixpkgs/commit/e329b995f260ac8e134dfe95565a7dc312afa0db) | `hoard: init at 1.0.1`                                                                  |
| [`feff6ddb`](https://github.com/NixOS/nixpkgs/commit/feff6ddbe7b9139dd7287dfaa379682bf46c8d3f) | `expressvpn: init at 3.25.0.13`                                                         |
| [`f53b2517`](https://github.com/NixOS/nixpkgs/commit/f53b2517bb2b40e0ff1267619292bfa079fc1703) | `gspell: 1.10.0 -> 1.11.1`                                                              |
| [`5e8d7cb7`](https://github.com/NixOS/nixpkgs/commit/5e8d7cb7569d4fcfddcf59fed556cf2a3c928f69) | `angband: add SDL2 frontend`                                                            |
| [`ca6798b6`](https://github.com/NixOS/nixpkgs/commit/ca6798b66b1531f3eea2ca2c3200b75f9e3e60ac) | `dbeaver: 22.0.5 -> 22.1.0`                                                             |
| [`1b8803fa`](https://github.com/NixOS/nixpkgs/commit/1b8803fa19d950875e8fcfeffb114261e36a2fdb) | `python310Packages.awscrt: 0.13.11 -> 0.13.13`                                          |
| [`02224725`](https://github.com/NixOS/nixpkgs/commit/022247259a88c5c9933174479a21341402d4e317) | `python310Packages.peaqevcore: 0.3.14 -> 0.4.2`                                         |
| [`2f7a870a`](https://github.com/NixOS/nixpkgs/commit/2f7a870a4c6e364937cfbb2e1ae78a5d15bf1ae9) | `signal-desktop: 5.45.0 -> 5.45.1`                                                      |
| [`fdbfdc44`](https://github.com/NixOS/nixpkgs/commit/fdbfdc443cf902b5e8f0e4a3ec7c0aa1c5063026) | `postgresqlPackages.pg_hint_plan: init at 14-1.4.0`                                     |
| [`a58c728d`](https://github.com/NixOS/nixpkgs/commit/a58c728d5f9f01c283eb2e25dd54c049dab7533c) | `fwupd: 1.8.0 -> 1.8.1`                                                                 |
| [`c0a672b3`](https://github.com/NixOS/nixpkgs/commit/c0a672b343939549b9dc63118d0b839631218819) | `docker: 20.10.16 -> 20.10.17`                                                          |
| [`e286e80e`](https://github.com/NixOS/nixpkgs/commit/e286e80e52742ae2a621240b83e4c59008b145bb) | `fuse-overlayfs: 1.8.2 -> 1.9`                                                          |
| [`2d997b63`](https://github.com/NixOS/nixpkgs/commit/2d997b63ae5c54019018c5f3704ba52a100cc77e) | `firefox-devedition-bin-unwrapped: 102.0b1 -> 102.0b5`                                  |
| [`f9efe722`](https://github.com/NixOS/nixpkgs/commit/f9efe7221975ed53e9de9dfc0e8b09ab7a5e8ae9) | `firefox-beta-bin-unwrapped: 102.0b1 -> 102.0b5`                                        |
| [`2ce75137`](https://github.com/NixOS/nixpkgs/commit/2ce7513786a6b6e1fc3e4e597e23ce949bf57ca3) | `firefox-bin-unwrapped: 101.0 -> 101.0.1`                                               |
| [`4b582932`](https://github.com/NixOS/nixpkgs/commit/4b582932fbcf3a21a5381aacb02271648d856750) | `firefox-unwrapped: 101.0 -> 101.0.1`                                                   |
| [`690125bd`](https://github.com/NixOS/nixpkgs/commit/690125bd0aa0abc1e7380d577a6b27d941cb3c01) | `treewide: update git.kernel.org/cgit homepage URLs`                                    |
| [`b8190f93`](https://github.com/NixOS/nixpkgs/commit/b8190f93d5a175cdea9037f7342a9d4bc3f5d137) | `chromiumDev: 104.0.5098.0 -> 104.0.5110.0`                                             |
| [`a4471b3a`](https://github.com/NixOS/nixpkgs/commit/a4471b3a974ba52cbee4d0f25a6da391db854a4a) | `chromiumBeta: 103.0.5060.33 -> 103.0.5060.42`                                          |
| [`41c362c9`](https://github.com/NixOS/nixpkgs/commit/41c362c9d16c623b5b4b936832a96a34b61595be) | `chromium: 102.0.5005.61 -> 102.0.5005.115`                                             |
| [`1851e682`](https://github.com/NixOS/nixpkgs/commit/1851e682ce84b52b4a8cc5cbe1123573ffeecfa7) | `Remove kvark from the maintainers list`                                                |
| [`d154aea9`](https://github.com/NixOS/nixpkgs/commit/d154aea93a5b283dae07751dc928789bac6f7a3c) | `Remove kvark from maintaining Mozilla packages`                                        |
| [`d868f89f`](https://github.com/NixOS/nixpkgs/commit/d868f89f0d005a1205279064a9464bf2e63b5303) | `python310Packages.msgpack-numpy: 0.4.7.1 -> 0.4.8`                                     |
| [`e0dbdded`](https://github.com/NixOS/nixpkgs/commit/e0dbdded6e63b66fdd0eb22268fda29e52e2ba7a) | `python310Packages.azure-mgmt-compute: disable on older Python releases`                |
| [`6bd02ded`](https://github.com/NixOS/nixpkgs/commit/6bd02ded1626c6f56091c78283fed7c0cb90b71c) | `python310Packages.azure-mgmt-compute: 27.0.0 -> 27.1.0`                                |
| [`b4d6c7a4`](https://github.com/NixOS/nixpkgs/commit/b4d6c7a42e8115d76640b5b49263caee1b93dcb1) | `insomnia: 2022.1.1 -> 2022.3.0, fix build`                                             |
| [`6f3caa12`](https://github.com/NixOS/nixpkgs/commit/6f3caa12bbea31a5c23b650f8567a5fae4d244f6) | `fsrx: init at 1.0.0 (#177065)`                                                         |
| [`29474261`](https://github.com/NixOS/nixpkgs/commit/294742618e5348c54b6eb2cbc77fa783699835de) | `tinystatus: init at unstable-2021-07-09`                                               |
| [`dc2f09c8`](https://github.com/NixOS/nixpkgs/commit/dc2f09c87914281c7b7f0456c3724ea53b1f2a68) | `python3Packages.snapcast: add missing packaging dependency`                            |
| [`4b872b35`](https://github.com/NixOS/nixpkgs/commit/4b872b35984169477c5be03f43b83d555043c266) | `python310Packages.timetagger: 22.4.2 -> 22.6.2`                                        |
| [`c4182b80`](https://github.com/NixOS/nixpkgs/commit/c4182b8047a24630c9ef7dddf09bfb40ec2149cd) | `buildNimPackage: use depsBuildBuild for nim_builder`                                   |
| [`676d99ff`](https://github.com/NixOS/nixpkgs/commit/676d99ff218fddf594731942f370b23d9a84b08e) | `nixVersions.unstable: pre20220530 -> pre20220610`                                      |
| [`936239f6`](https://github.com/NixOS/nixpkgs/commit/936239f665401a97be3832ce69eec06ff35cc5de) | `tracker-miners: 3.3.0 → 3.3.1`                                                         |
| [`9a71f92d`](https://github.com/NixOS/nixpkgs/commit/9a71f92d96c26481fed33ced58a1c75f1c030fde) | `tepl: 6.0.1 → 6.0.2`                                                                   |
| [`b0124395`](https://github.com/NixOS/nixpkgs/commit/b01243956733805b34cf131d806c21f84cf7f4f1) | `networkmanagerapplet: 1.26.0 → 1.28.0`                                                 |
| [`559dae14`](https://github.com/NixOS/nixpkgs/commit/559dae140f92a090b648d88392874a020f1e9d0b) | `gupnp-av: 0.14.0 → 0.14.1`                                                             |
| [`497b4af9`](https://github.com/NixOS/nixpkgs/commit/497b4af9f04f237cb53f5def57790b44d9ea4fac) | `gnome-desktop: 42.1 → 42.2`                                                            |
| [`67de7b4e`](https://github.com/NixOS/nixpkgs/commit/67de7b4eb28d61fc301a83d1d98cc2970720eb78) | `gnome.gnome-bluetooth: 42.0 → 42.1`                                                    |
| [`835b46f0`](https://github.com/NixOS/nixpkgs/commit/835b46f081e6022cc5036a215329c257155d6d3b) | `amtk: 5.4.0 → 5.4.1`                                                                   |
| [`071ac270`](https://github.com/NixOS/nixpkgs/commit/071ac2706d63a151a40220baaf17202da7eacda9) | `gopass: 1.14.2 -> 1.14.3`                                                              |
| [`35c7173c`](https://github.com/NixOS/nixpkgs/commit/35c7173cf5392522d632cb6469298e1e73360929) | `apacheHttpd: 2.4.53 -> 2.4.54`                                                         |
| [`612a0224`](https://github.com/NixOS/nixpkgs/commit/612a022454769efbd1452f726a7977fc958ad1f3) | `goaccess: 1.5.7 -> 1.6`                                                                |
| [`f9c45cdd`](https://github.com/NixOS/nixpkgs/commit/f9c45cdd685554aac9b64f8afeb2991b1cf38652) | `sile: 0.12.5 → 0.13.0 (#177079)`                                                       |
| [`590f97d2`](https://github.com/NixOS/nixpkgs/commit/590f97d2313bb496e53779565fba0d721c7148e5) | `libvirt: 8.1.0 -> 8.4.0`                                                               |
| [`33d84e02`](https://github.com/NixOS/nixpkgs/commit/33d84e02ee99fbb5254ad0daadfdc5ddad1d4241) | `xdgmenumaker: 1.5 -> 1.6 (#176568)`                                                    |
| [`f381ffee`](https://github.com/NixOS/nixpkgs/commit/f381ffeed4870eb1130c9c7a5697933b25ceb6fc) | `wslu: 3.2.3 -> 3.2.4`                                                                  |
| [`66756aea`](https://github.com/NixOS/nixpkgs/commit/66756aeab9f783d1c1dc3f70257b6f005992dfcc) | `php80Packages.composer: 2.3.5 -> 2.3.7`                                                |
| [`5d890c08`](https://github.com/NixOS/nixpkgs/commit/5d890c086aa288a7dd93f1de87573391d2e82717) | `php81: 8.1.6 -> 8.1.7`                                                                 |
| [`24e9824d`](https://github.com/NixOS/nixpkgs/commit/24e9824ddbe1e065f0582f0aabbb56dd3aef5d93) | `php80: 8.0.19 -> 8.0.20`                                                               |
| [`07f1979a`](https://github.com/NixOS/nixpkgs/commit/07f1979a11f436adc67ce126c42e253dd45b520f) | `python310Packages.azure-mgmt-containerservice: 19.1.0 -> 20.0.0`                       |
| [`d9e71531`](https://github.com/NixOS/nixpkgs/commit/d9e71531a0ed03d296e56dd38f5f1864a55c64c1) | `lib/modules: Fix missing prefix in extendModules when unset in both eval- and extend-` |
| [`85e4c47d`](https://github.com/NixOS/nixpkgs/commit/85e4c47d2f0ad91625a33f5aad70c6461646056e) | `assh: 2.12.2 -> 2.14.0`                                                                |
| [`8333e7da`](https://github.com/NixOS/nixpkgs/commit/8333e7da369f1cda1aec472ec992044524d549ff) | `metasploit: 6.2.1 -> 6.2.2`                                                            |
| [`d9b980c9`](https://github.com/NixOS/nixpkgs/commit/d9b980c98e218658d365482265fe4ac8fcacf130) | `linux: enable vc4 HDMI-CEC by default (#176762)`                                       |
| [`45d5aef1`](https://github.com/NixOS/nixpkgs/commit/45d5aef19275288f13748183142f865e5035cef1) | `python310Packages.oauthenticator: 15.0.0 -> 15.0.1`                                    |
| [`6c425b17`](https://github.com/NixOS/nixpkgs/commit/6c425b1778c2af676e8c632ed90dfbad069bf477) | `datalad: init at 0.16.5`                                                               |
| [`f6af6472`](https://github.com/NixOS/nixpkgs/commit/f6af64726754c634b619e1d24d58acb1e464652e) | `python310Packages.exceptiongroup: 1.0.0rc7 -> 1.0.0rc8`                                |
| [`3d019eaf`](https://github.com/NixOS/nixpkgs/commit/3d019eaff7caca6610db913726f89223787e370d) | `python310Packages.fpyutils: 2.1.0 -> 2.2.0`                                            |
| [`73238a42`](https://github.com/NixOS/nixpkgs/commit/73238a4242568596f5cb89fa845c094a19e81bb0) | `buildkite-test-collector-rust: fix vendor sha`                                         |
| [`9632bc06`](https://github.com/NixOS/nixpkgs/commit/9632bc06aeadd1265d454f8f7068775ed2ab46a4) | ``buildkite-test-collector-rust: init at version `0.1.0` (#176118)``                    |
| [`2cdf082b`](https://github.com/NixOS/nixpkgs/commit/2cdf082b90b61e0cb9055a2bf1c99301535d3962) | `python310Packages.unicrypto: 0.0.5 -> 0.0.7`                                           |
| [`18ad5579`](https://github.com/NixOS/nixpkgs/commit/18ad5579c4fd3dbb4dbc864a5d11ab8eeffbd6a5) | `mmc-utils: clarify license`                                                            |
| [`0d504876`](https://github.com/NixOS/nixpkgs/commit/0d5048765fa2f9a266f6e743b3a6e0769783dd79) | `mmc-utils: enable parallel building`                                                   |
| [`77d0ed11`](https://github.com/NixOS/nixpkgs/commit/77d0ed11f6e13f08837972cac7833ff20680801e) | `mmc-utils: don't manually run make`                                                    |
| [`dc08e07e`](https://github.com/NixOS/nixpkgs/commit/dc08e07e7c40f3fe6b704ed58fcc178a5a92602e) | `mmc-utils: 2021-05-11 -> unstable-2022-04-26`                                          |
| [`0bbe5103`](https://github.com/NixOS/nixpkgs/commit/0bbe51030e6e891c012ed251053c038cff27eeb6) | `mmc-utils: fetchgit -> fetchzip`                                                       |
| [`134b8fc0`](https://github.com/NixOS/nixpkgs/commit/134b8fc0d49a2fd1e3f5aeb8f207a02ae38438fe) | `mmc-utils: update homepage and src URL`                                                |
| [`6130c92d`](https://github.com/NixOS/nixpkgs/commit/6130c92db65606145f7d7f869f08f59f37af5edf) | `retroarchBare: add -fcommon workaround`                                                |
| [`ab4e0fc1`](https://github.com/NixOS/nixpkgs/commit/ab4e0fc110eb4850da9eb410d0d81920641b7456) | `python310Packages.pulumi-aws: use sourceRoot`                                          |
| [`31042291`](https://github.com/NixOS/nixpkgs/commit/310422912295630de7f752bc7c12af3c9905ab03) | `checkov: 2.0.1206 -> 2.0.1209`                                                         |
| [`e6a8399c`](https://github.com/NixOS/nixpkgs/commit/e6a8399cafcadd3f44e59db8487d9ee44190e727) | `python310Packages.bc-python-hcl2: 0.3.42 -> 0.3.43`                                    |
| [`f905d9d9`](https://github.com/NixOS/nixpkgs/commit/f905d9d9bde4eddd3c3e0ae917df45a857cf207b) | `n8n: 0.181.0 → 0.181.2`                                                                |
| [`0aa9eac9`](https://github.com/NixOS/nixpkgs/commit/0aa9eac9c95310dc627e0d763475fb1e16d4b3d6) | `python310Packages.svg-path: 6.0 -> 6.1`                                                |
| [`a5f36314`](https://github.com/NixOS/nixpkgs/commit/a5f36314c769d8df0321b3b84d642d15c9bbcaf3) | `python310Packages.transformers: 4.19.2 -> 4.19.3`                                      |
| [`a824be79`](https://github.com/NixOS/nixpkgs/commit/a824be79d863add368b73d7d444745f9913f1076) | `python310Packages.types-freezegun: 1.1.9 -> 1.1.10`                                    |
| [`4b4376cd`](https://github.com/NixOS/nixpkgs/commit/4b4376cded662b1430e5afad7ee03e4e3fe2cf07) | `python310Packages.trimesh: 3.12.5 -> 3.12.6`                                           |
| [`6667e367`](https://github.com/NixOS/nixpkgs/commit/6667e3670fcbdc5f4c8a5b29601f48035f922e67) | `pantheon.elementary-notifications: 6.0.1 -> 6.0.2`                                     |
| [`44f2769f`](https://github.com/NixOS/nixpkgs/commit/44f2769f055b00606fbb6e14ce2f8a5dc3134f8d) | `ncspot: 0.9.8 -> 0.10.0`                                                               |
| [`a7e4a928`](https://github.com/NixOS/nixpkgs/commit/a7e4a928522c6a7de67627906fc7fc7d77ab96ed) | `python39Packages.eve: disable on python 2`                                             |
| [`22e80680`](https://github.com/NixOS/nixpkgs/commit/22e8068097cf022d8f2d212d3f8b2a7ebfb6c035) | `pantheon.elementary-videos: 2.8.3 -> 2.8.4`                                            |
| [`63eead4a`](https://github.com/NixOS/nixpkgs/commit/63eead4a4fa5f3bc65323dd79628d2b2e9cd74ef) | `python310Packages.pynetgear: 0.10.4 -> 0.10.5`                                         |
| [`1de09605`](https://github.com/NixOS/nixpkgs/commit/1de09605f2e0fc36f8c65fc49449138ffa7b6fd0) | `python310Packages.peaqevcore: 0.3.4 -> 0.3.14`                                         |
| [`a7b8b68b`](https://github.com/NixOS/nixpkgs/commit/a7b8b68ba96dbcead84b6a630c79ef01bf9f0586) | `python310Packages.twitchapi: 2.5.4 -> 2.5.5`                                           |
| [`19e8b063`](https://github.com/NixOS/nixpkgs/commit/19e8b063a968b4d8e25f2f9edaf78808f7503e19) | `python310Packages.pyrogram: 2.0.26 -> 2.0.27`                                          |
| [`8bc1f617`](https://github.com/NixOS/nixpkgs/commit/8bc1f617dd3e1faa2d55d80d06895bb5a08aea0b) | `squeak: add -fcommon workaround`                                                       |
| [`3f953478`](https://github.com/NixOS/nixpkgs/commit/3f953478bee6771a8ce5c86540b1fda451df1808) | `unvanquished: use SRI hash format`                                                     |
| [`2275593f`](https://github.com/NixOS/nixpkgs/commit/2275593fe8a3c577ddf79c46207cfefa7a0f5133) | `openttd/nml.nix: use SRI hash format`                                                  |
| [`3b224dcc`](https://github.com/NixOS/nixpkgs/commit/3b224dccc3306043d1f7ee4dc1229a95e464d665) | `zoom: use SRI hash format`                                                             |
| [`ce51fe80`](https://github.com/NixOS/nixpkgs/commit/ce51fe80f8e91b1dec219d21f3184cfad30087cc) | `zdoom: use SRI hash format`                                                            |
| [`95390a3e`](https://github.com/NixOS/nixpkgs/commit/95390a3e1334421e67e44343ab33caf70b6ee7af) | `zandronum/sqlite.nix: use SRI hash format`                                             |
| [`494ef5a6`](https://github.com/NixOS/nixpkgs/commit/494ef5a68c632cc24f68c78ce9dd2e51945a62cb) | `vectoroids: use SRI hash format`                                                       |
| [`5b6c9db8`](https://github.com/NixOS/nixpkgs/commit/5b6c9db8109797eece80a590890107e8aa744b21) | `performous: use SRI hash format`                                                       |
| [`8e41788c`](https://github.com/NixOS/nixpkgs/commit/8e41788cba33409cf2e1113b14cc7b19f97f5adf) | `leela-zero: use SRI hash format`                                                       |
| [`d2ebaafd`](https://github.com/NixOS/nixpkgs/commit/d2ebaafd9081c26a5da581898e562b348ecf4a95) | `koules: use SRI hash format`                                                           |
| [`e28fc76d`](https://github.com/NixOS/nixpkgs/commit/e28fc76d2cdb785ef46c8fe0344bb5a814ad83d0) | `julius: use SRI hash format`                                                           |
| [`0036078a`](https://github.com/NixOS/nixpkgs/commit/0036078a21f199a0a17e4a0e66928986fd52cf26) | `gshogi: use SRI hash format`                                                           |
| [`1404529e`](https://github.com/NixOS/nixpkgs/commit/1404529e1dfc07bf4bc163fe9d131ffffa65e858) | `fairymax: use SRI hash format`                                                         |
| [`eb900ded`](https://github.com/NixOS/nixpkgs/commit/eb900ded42e95632bcc06f3b19238c9222c2ba8c) | `refind: Fix possible NULL dereference`                                                 |
| [`233e380f`](https://github.com/NixOS/nixpkgs/commit/233e380f3b09efc4fb67d80898a59e494c1b6baa) | `tworld2: use SRI hash format`                                                          |
| [`2922710c`](https://github.com/NixOS/nixpkgs/commit/2922710cb57981ac90f09d66791c6637bbb0e1e7) | `otto-matic: use SRI hash format`                                                       |
| [`bdbfd5ce`](https://github.com/NixOS/nixpkgs/commit/bdbfd5cead25a9bacdd956a41a2df666626124ce) | `whitebox-tools: use SRI hash format`                                                   |
| [`0965a514`](https://github.com/NixOS/nixpkgs/commit/0965a514043a76f4495ae564a9a669f5db4ccf08) | `udig: use SRI hash format`                                                             |
| [`254a8238`](https://github.com/NixOS/nixpkgs/commit/254a82389d1e6ec2bb4b25673f361d6bd57bdfc0) | `openorienteering-mapper: use SRI hash format`                                          |
| [`8f3e98cf`](https://github.com/NixOS/nixpkgs/commit/8f3e98cf282fa02879a7d10cb9f8ebe0b5ed8deb) | `bugdom: use SRI hash format`                                                           |
| [`96188399`](https://github.com/NixOS/nixpkgs/commit/96188399399fda479dd75a6263283385f4e035ff) | `gnome-todo: use SRI hash format`                                                       |
| [`3ddf13a6`](https://github.com/NixOS/nixpkgs/commit/3ddf13a66e06427a87f1105233ebc49fa0fe4ce7) | `deno: 1.22.2 -> 1.22.3`                                                                |
| [`056e7bc9`](https://github.com/NixOS/nixpkgs/commit/056e7bc946cf931bc6d69cebb84b0b4b284744af) | `clojure: 1.11.1.1113 -> 1.11.1.1119`                                                   |
| [`90f443a1`](https://github.com/NixOS/nixpkgs/commit/90f443a17b6c2b7eab033eef1fc558c1c23a2e77) | `speed-dreams: 2.2.2 -> 2.2.3`                                                          |
| [`e86e7ee1`](https://github.com/NixOS/nixpkgs/commit/e86e7ee1a8931b98c6f3fa5c8f09ca57864998a0) | `libvirt: add passthru update script`                                                   |
| [`c8b8ea82`](https://github.com/NixOS/nixpkgs/commit/c8b8ea8232f9b0f454d2614a9200858e38c7ef25) | `libvirt: drop tarball fetching`                                                        |
| [`3abb144e`](https://github.com/NixOS/nixpkgs/commit/3abb144ebf3b2e18c8ef8a80ca7265628054d241) | `python310Packages.sunpy: 4.0.0 -> 4.0.1`                                               |
| [`df118d7a`](https://github.com/NixOS/nixpkgs/commit/df118d7a7a3fbe365673be84d54bf400c6dbb3a9) | `vscode: 1.67.2 -> 1.68.0`                                                              |
| [`1d8b8365`](https://github.com/NixOS/nixpkgs/commit/1d8b8365a02efbf668311dc9db06cb98d49e7302) | `oksh: 7.0 -> 7.1`                                                                      |
| [`660ac5bf`](https://github.com/NixOS/nixpkgs/commit/660ac5bf602ae820a3239842e292a8b168b952f9) | `pythonPackages.asf_search: init at 3.0.6 (#157504)`                                    |
| [`c55d70a2`](https://github.com/NixOS/nixpkgs/commit/c55d70a21ac01de93a2d3da2330b93d6d46d251f) | `python310Packages.pikepdf: 5.1.3 -> 5.1.4`                                             |
| [`99fcf0ee`](https://github.com/NixOS/nixpkgs/commit/99fcf0ee74957231ff0471228e9a59f976a0266b) | `subversion: enable darwin keychain support (#176730)`                                  |
| [`559ee726`](https://github.com/NixOS/nixpkgs/commit/559ee726a62f58fd85ad24b641c86bfa5214bf52) | `gh: 2.12.0 -> 2.12.1`                                                                  |
| [`f063970e`](https://github.com/NixOS/nixpkgs/commit/f063970e50f9c8460398988c0fe3b3e96082c8eb) | `nixos/podman: add user socket/service`                                                 |
| [`6400298c`](https://github.com/NixOS/nixpkgs/commit/6400298c786d57018a6e1d75abb26ff00861f5c2) | `python310Packages.pywizlight: 0.5.13 -> 0.5.14`                                        |
| [`fc909087`](https://github.com/NixOS/nixpkgs/commit/fc909087cc3386955f21b4665731dbdaceefb1d8) | `polychromatic: init at 0.7.3 (#176932)`                                                |
| [`f84dbdd7`](https://github.com/NixOS/nixpkgs/commit/f84dbdd78eba7a7bf955086180d223c60240a229) | `apc-temp-fetch: init at 0.0.1`                                                         |
| [`805007dc`](https://github.com/NixOS/nixpkgs/commit/805007dc7dd97b985925c17c0c50282ffda4c4fa) | `dagger: 0.2.12 -> 0.2.18`                                                              |
| [`b64c3d38`](https://github.com/NixOS/nixpkgs/commit/b64c3d388590b72172b90cf4a58e70251d306599) | `arrow-cpp: pin jemalloc tarball (#177037)`                                             |
| [`acf23020`](https://github.com/NixOS/nixpkgs/commit/acf23020f04182974d820526801a54912e619603) | `snakemake: 7.8.1 -> 7.8.2`                                                             |
| [`f3d9f4f1`](https://github.com/NixOS/nixpkgs/commit/f3d9f4f15a8d001234913aff26461a090c5ab3d4) | `vimPlugins.alpha-nvim: init at 2022-04-22 (#177049)`                                   |
| [`d3a5201b`](https://github.com/NixOS/nixpkgs/commit/d3a5201bb52b07c9243ff01810b81b8c1d22ef74) | `python310Packages.google-cloud-spanner: 3.14.0 -> 3.14.1`                              |