### PR TITLE
chore(flake/nixpkgs): `6036dcbd` -> `d64abb97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654957404,
-        "narHash": "sha256-u2nOQH+GUD3yAYE2ETloAuyP5b80iNKYUEWiNAicc+A=",
+        "lastModified": 1655000332,
+        "narHash": "sha256-G4rs6nRox0146D6uI+zLxl8PwKXEO4PngyNXtY82DJI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6036dcbdb930177396012bbe39d8e31201289a14",
+        "rev": "d64abb978cc2fa4b88b074a64d1b456183c8db17",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`f98de352`](https://github.com/NixOS/nixpkgs/commit/f98de352cb25c4ddb5849f954715e571c3034bea) | `python310Packages.pyvesync: 2.0.3 -> 2.0.4`            |
| [`ee4e2ac1`](https://github.com/NixOS/nixpkgs/commit/ee4e2ac16962cbb7a3bbe58d8965660a69fc25fc) | `yarn: 1.22.18 -> 1.22.19`                              |
| [`f42a6bcb`](https://github.com/NixOS/nixpkgs/commit/f42a6bcbf625637f5bca5df5c499323ca8b53969) | `gox: use buildGoModule`                                |
| [`d160efc7`](https://github.com/NixOS/nixpkgs/commit/d160efc709563ed24d43e6103c56c3858f6c8cc6) | `terraform-providers: convert remaining hashes to sri`  |
| [`7550c000`](https://github.com/NixOS/nixpkgs/commit/7550c0002f4d9b6015ed9f30f1a3c4c001cc3491) | `terraform-providers: update 2022-06-11`                |
| [`07da5279`](https://github.com/NixOS/nixpkgs/commit/07da52796aa8428b24677fcbfb423868018d5691) | `terraform-providers.opennebula: 0.4.3 -> 0.5.0`        |
| [`46f92ca4`](https://github.com/NixOS/nixpkgs/commit/46f92ca4da555844ce6bc47278d9ed30c7954a4f) | `xfce.exo: 4.16.3 -> 4.16.4`                            |
| [`c65e990e`](https://github.com/NixOS/nixpkgs/commit/c65e990ed2e50378a26cf10399fe9265fd625fa9) | `openxr-loader: enable wayland`                         |
| [`54c95acb`](https://github.com/NixOS/nixpkgs/commit/54c95acb8a75c8b40d4af8261d5d99129162ec7c) | `openxr-loader: build tests for hello_xr`               |
| [`8ed58587`](https://github.com/NixOS/nixpkgs/commit/8ed585876343b451ac5a730e5b56379eefff0dfd) | `proxysql: fix build by using vendored jemalloc 5.2.0`  |
| [`e9218500`](https://github.com/NixOS/nixpkgs/commit/e9218500bad5fdedbd27e4a6821f81b57a9afc86) | `jemalloc: 5.2.1 -> 5.3.0`                              |
| [`9b2a771b`](https://github.com/NixOS/nixpkgs/commit/9b2a771b8fe6aef77cd0c713ca2736219cea3472) | `monado: use absolute runtime path in manifest`         |
| [`3b7fe79b`](https://github.com/NixOS/nixpkgs/commit/3b7fe79bce5c49a2c40789402e9c674cd51dbdc4) | `monado: enable wayland support`                        |
| [`90986a50`](https://github.com/NixOS/nixpkgs/commit/90986a500bd63124fbdd3c827f180f19d1aa0b3c) | `maintainers: add kfears`                               |
| [`49834aef`](https://github.com/NixOS/nixpkgs/commit/49834aef6c3cbf58dea93e77201eb3d088738bda) | `nixos/openvpn3: add enable option`                     |
| [`445f0e64`](https://github.com/NixOS/nixpkgs/commit/445f0e645e3d9ef72df29a49bb46b3f8d303eb55) | `openvpn3: init at 17_beta`                             |
| [`a57409b1`](https://github.com/NixOS/nixpkgs/commit/a57409b1159b0a6f6b61b799db593889f83e0931) | `tfsec: 1.21.2 -> 1.23.3`                               |
| [`501ec23c`](https://github.com/NixOS/nixpkgs/commit/501ec23c492b1453da2d37f113a132b86f79a0c8) | `distrobox: 1.3.0 -> 1.3.1`                             |
| [`27d4500b`](https://github.com/NixOS/nixpkgs/commit/27d4500b618468790febcdf7991f69bad94687e9) | `gforth: unmark broken on darwin`                       |
| [`b71cff07`](https://github.com/NixOS/nixpkgs/commit/b71cff07a73fc7949c22d045bb74c7ef1e9bbb2d) | `gforth: explicitly set lispdir`                        |
| [`af4b5ffa`](https://github.com/NixOS/nixpkgs/commit/af4b5ffa73c5d9e4484a40a897d260e9945f0ce3) | `vector: 0.22.0 -> 0.22.1`                              |
| [`5b898eb8`](https://github.com/NixOS/nixpkgs/commit/5b898eb8deadc8ba46342c715615af60e62a1e2b) | `sunpaper: init at unstable-2022-04-01`                 |
| [`2a8762a9`](https://github.com/NixOS/nixpkgs/commit/2a8762a9e5f4a1d8ab7b67175941a33e2b72fd8f) | `werf: 1.2.107 -> 1.2.114`                              |
| [`cd07d6c8`](https://github.com/NixOS/nixpkgs/commit/cd07d6c82e9d543bff0759a779df393f2687a98c) | `clang-tools: provide many versions`                    |
| [`24776325`](https://github.com/NixOS/nixpkgs/commit/247763256c6ed9a637b0fa665f83e673dc8dba38) | `clang-tools: don't hardcode list of tools`             |
| [`e0dc568e`](https://github.com/NixOS/nixpkgs/commit/e0dc568e25cf5c937caa082f6ea1ed82c20efb88) | `mutt: 2.2.4 -> 2.2.5`                                  |
| [`0f9a77f5`](https://github.com/NixOS/nixpkgs/commit/0f9a77f5cbcfcd59144f33ace06f1670bfc259e9) | `smpeg: fix handling of pkg-config`                     |
| [`75577189`](https://github.com/NixOS/nixpkgs/commit/7557718913d91c3181f262ba4a366af274f74d41) | `linux-firmware: 20220509 -> 20220610`                  |
| [`87dd8422`](https://github.com/NixOS/nixpkgs/commit/87dd8422384c2c7d2fcba62fd91e55c309a33779) | `bdf2psf: 1.207 -> 1.208`                               |
| [`84e4bf5e`](https://github.com/NixOS/nixpkgs/commit/84e4bf5e0b4ab772e4582ad07761fcc603f4bdc1) | `fclones: 0.25.0 -> 0.26.0`                             |
| [`58037066`](https://github.com/NixOS/nixpkgs/commit/580370666239e426df70ab4996dc5b5512a2c303) | `nixos/tests: fix type mismatch in wait_for_open_port`  |
| [`3aa7a719`](https://github.com/NixOS/nixpkgs/commit/3aa7a7192d929e358ecdaadf3313dd70f0cb05ec) | `exploitdb: 2022-06-04 -> 2022-06-11`                   |
| [`3bdfa1e5`](https://github.com/NixOS/nixpkgs/commit/3bdfa1e5f0d4f0f582b3cb36009c5365800ad1f9) | `python310Packages.whois: 0.9.15 -> 0.9.16`             |
| [`d02648d0`](https://github.com/NixOS/nixpkgs/commit/d02648d09f319a14f984a01074bef1e8c238a08c) | `python310Packages.aurorapy: 0.2.7 -> 0.2.6`            |
| [`26526f02`](https://github.com/NixOS/nixpkgs/commit/26526f02ad016c78fb5bb252d3cd54d4eceb052c) | `nixos/picom: remove deprecated refreshRate option`     |
| [`5a476dcf`](https://github.com/NixOS/nixpkgs/commit/5a476dcfda2796851ff0e866e7c996b3adf393dc) | `python310Packages.tubeup: 0.0.30 -> 0.0.31`            |
| [`2f6b3d48`](https://github.com/NixOS/nixpkgs/commit/2f6b3d48d1d7662ff97fb14f1258cd5ecd41a0aa) | `ugrep: 3.7.9 -> 3.8.2`                                 |
| [`3cd8c2f4`](https://github.com/NixOS/nixpkgs/commit/3cd8c2f4577f86abc95501d96739ec0df7190ae6) | `firefox-devedition-bin-unwrapped: 102.0b5 -> 102.0b6`  |
| [`ec497a13`](https://github.com/NixOS/nixpkgs/commit/ec497a13e313e65ee10083feab2ebcdbc7353c26) | `hound: 0.4.0 -> 0.5.0`                                 |
| [`1f0cd892`](https://github.com/NixOS/nixpkgs/commit/1f0cd892b1dba80f27d260c6b3489a894135cf78) | `home-assistant: 2022.6.4 -> 2022.6.5`                  |
| [`25966837`](https://github.com/NixOS/nixpkgs/commit/25966837e814d8234443a01815dbd6e8a94fe014) | `python3Packages.pyunifiprotect: 3.8.0 -> 3.9.2`        |
| [`8fb0a9c3`](https://github.com/NixOS/nixpkgs/commit/8fb0a9c3db6bec0b1771c5d5a84098c1ed8774f6) | `lndhub-go: 0.7.0 -> 0.8.0`                             |
| [`70b75018`](https://github.com/NixOS/nixpkgs/commit/70b75018609ef468c4c334835ab8bde231565b10) | `fluent-bit: add -fcommon workaround`                   |
| [`42ceb20d`](https://github.com/NixOS/nixpkgs/commit/42ceb20d291c9a63dcdb28a6b127850030b2b457) | `nixos/gnome: make it possible to remove core packages` |
| [`ca23e421`](https://github.com/NixOS/nixpkgs/commit/ca23e4210555f1bcb1a6b628bbe1d5e40f1b9d8d) | `nixos/gnome: Move sessionPath to core-shell group`     |
| [`016b99dc`](https://github.com/NixOS/nixpkgs/commit/016b99dce68d2957cecfbe8ee0a6b328f543cda8) | `nixos/gnome: drop hicolor-icon-theme`                  |
| [`7f0ce26b`](https://github.com/NixOS/nixpkgs/commit/7f0ce26bbd35606fe656c8d9c829bda0aaddc1ad) | `nixos/xdg/icons: Install hicolor-icon-theme`           |
| [`aad39fe4`](https://github.com/NixOS/nixpkgs/commit/aad39fe41a3c9d7fb0dd438748c02f29e08fa15b) | `nixos/gnome: drop shared-mime-info`                    |
| [`5a24bb74`](https://github.com/NixOS/nixpkgs/commit/5a24bb74d6157457e9ba483dc5c1e51924d7a4c6) | `sudo: 1.9.10 -> 1.9.11p1`                              |
| [`53b3ad53`](https://github.com/NixOS/nixpkgs/commit/53b3ad5398fa8aace0714a554fe5435718fe86b5) | `sbsigntool: add hmenke as maintainer`                  |
| [`aa8115c4`](https://github.com/NixOS/nixpkgs/commit/aa8115c447ab23e2c5496134fc20ec5996619421) | `sbsigntool: 0.9.1 -> 0.9.4`                            |
| [`2e3017b2`](https://github.com/NixOS/nixpkgs/commit/2e3017b212e3b7e0ac2f47083d14dd6122e4397e) | `jd: remove`                                            |
| [`4eeafebc`](https://github.com/NixOS/nixpkgs/commit/4eeafebc3c5c2273b53090ebe79db1aede839575) | `maintainers: add Jevin Maltais`                        |
| [`050ca6ef`](https://github.com/NixOS/nixpkgs/commit/050ca6ef8faeb3f3519478efafad94b847bd8177) | `dvc: add overrides for scmrepo and grandalf`           |
| [`093a0036`](https://github.com/NixOS/nixpkgs/commit/093a00363968481243c52cfda6fc66d315674596) | `yarn2nix: allow setting doDist by calling packages`    |
| [`14bc4210`](https://github.com/NixOS/nixpkgs/commit/14bc4210b706d9f58d6dcc13d81d54f79914bba3) | `element-{web,desktop}: compile from source`            |
| [`f280a5db`](https://github.com/NixOS/nixpkgs/commit/f280a5db2b56daeea61e689e48259ca6ca66a365) | `pgweb: 0.11.7 -> 0.11.11`                              |
| [`79b8d186`](https://github.com/NixOS/nixpkgs/commit/79b8d186a8d19097aec002abbfd5dd75c9d65955) | `nixos/fcitx5: add self to QT_PLUGIN_PATH`              |
| [`e6b6a9d2`](https://github.com/NixOS/nixpkgs/commit/e6b6a9d2a2df011dec0ef39774a7bc3cbda7a866) | `fcitx5-qt: add support for qt6 applications`           |
| [`e14aabb3`](https://github.com/NixOS/nixpkgs/commit/e14aabb3f6e12077fa3450b5fb6f1260e70e1e9c) | `awsls: init at 0.11.0`                                 |
| [`9497f081`](https://github.com/NixOS/nixpkgs/commit/9497f081a1031632fee9c915941736b33b111b45) | `nixos/haguichi: init`                                  |
| [`6872544c`](https://github.com/NixOS/nixpkgs/commit/6872544c1becda21a6c878aed8d1c3384c8ec10b) | `haguichi: init at 1.4.5`                               |
| [`e67e81d8`](https://github.com/NixOS/nixpkgs/commit/e67e81d8e383591c9375c26ddf2bcfaa2f74f74d) | `asap: init at 5.2.0`                                   |
| [`4f9d0078`](https://github.com/NixOS/nixpkgs/commit/4f9d0078061391f106a8f0b57dedeefffddc1802) | `mysql57: reduce closure size`                          |