### PR TITLE
chore(flake/nixpkgs): `13f08d71` -> `d8916eae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655130522,
-        "narHash": "sha256-5dzlxE4okyu+M39yeVtHWQXzDZQxFF5rUB1iY9R6Lb4=",
+        "lastModified": 1655177799,
+        "narHash": "sha256-DrSYqguHb8GQNTrybNqFU/cozz8c/7ot+WllDEtpuE8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13f08d71ceff5101321e0291854495a1ec153a5e",
+        "rev": "d8916eaeaf7080aa0642122d34d04f683ccf1f17",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`08318d0a`](https://github.com/NixOS/nixpkgs/commit/08318d0ab7730d7424face713bec4936cfd7be5a) | `strawberry: 1.0.4 -> 1.0.5`                                              |
| [`99647e7a`](https://github.com/NixOS/nixpkgs/commit/99647e7a12b870c97303d437898cd33562183b7c) | `direnv: 2.31.0 -> 2.32.0`                                                |
| [`a6da7aad`](https://github.com/NixOS/nixpkgs/commit/a6da7aad396e24fc103f4d47ec0da5798d6e2463) | `python310Packages.azure-mgmt-logic: disable on older Python releases`    |
| [`afb6182f`](https://github.com/NixOS/nixpkgs/commit/afb6182f9a3f3b14eb63a250e4b6fb2f4ad7efd3) | `libnfc: specify license`                                                 |
| [`222fe563`](https://github.com/NixOS/nixpkgs/commit/222fe563b95464cea880334603dc313ae79b759b) | `palemoon: Limit build cores count`                                       |
| [`b1ff292b`](https://github.com/NixOS/nixpkgs/commit/b1ff292b1a9f3d875388455ae4eff4858f6dcc69) | `nixos/tests/jellyfin: fix type errors in test script`                    |
| [`1f31dbf1`](https://github.com/NixOS/nixpkgs/commit/1f31dbf1ec76d986d56c7c5391245e7bf0ba44d6) | `ocamlPackages.cry: 0.6.5 -> 0.6.7`                                       |
| [`38c776b6`](https://github.com/NixOS/nixpkgs/commit/38c776b6799195fae58808b19d9b19d198ca2896) | `stdenv/check-meta: support NIXPKGS_ALLOW_NONSOURCE=0`                    |
| [`df9425f1`](https://github.com/NixOS/nixpkgs/commit/df9425f1b2071837a7212cfd199b2caf99eda9cf) | `etcher: mark meta.sourceProvenance`                                      |
| [`cce03bad`](https://github.com/NixOS/nixpkgs/commit/cce03bad2d18f7912c0ce9ca2b8c819c3a8d464e) | `signal-desktop: mark meta.sourceProvenance`                              |
| [`0ca71677`](https://github.com/NixOS/nixpkgs/commit/0ca71677b4dd036f6294da21b0d34543cf2ae294) | `electron: mark meta.sourceProvenance`                                    |
| [`2c7a74c9`](https://github.com/NixOS/nixpkgs/commit/2c7a74c9925187476c7cd4f5dd227742b0c9a19a) | `vimPlugins.lspcontainers: init`                                          |
| [`8722479f`](https://github.com/NixOS/nixpkgs/commit/8722479fd45611b9827850965653c49ddfdc79e8) | `aws-iam-authenticator: fix ldflags`                                      |
| [`41d033fc`](https://github.com/NixOS/nixpkgs/commit/41d033fc50f59caeb58f1facdf5cd6ddb3947e48) | `watchlog: init at 1.152.0`                                               |
| [`4ecbbe38`](https://github.com/NixOS/nixpkgs/commit/4ecbbe38052e2d99884c4ac2422905c0032cdb7c) | `atomic-operator: init at 0.8.5`                                          |
| [`ee4b07bd`](https://github.com/NixOS/nixpkgs/commit/ee4b07bdd0f05059a0c2c12870d08ee70574dfc2) | `python310Packages.pick. init at 1.2.0`                                   |
| [`9e603ba5`](https://github.com/NixOS/nixpkgs/commit/9e603ba5f13c6da2948fd949f51dd7e47ba18a0f) | `mitmproxy2swagger: init at 0.6.0`                                        |
| [`64305297`](https://github.com/NixOS/nixpkgs/commit/64305297adc748610ac3b3e75ce6303e9622101e) | `python310Packages.json-stream: init at 1.3.0`                            |
| [`3cd7e5c7`](https://github.com/NixOS/nixpkgs/commit/3cd7e5c783945d4246e2e58f2c5e827cc3f97d3e) | `python310Packages.dvclive: 0.8.2 -> 0.9.0`                               |
| [`07ab3e4d`](https://github.com/NixOS/nixpkgs/commit/07ab3e4dc885040fc099102e8cd072e1f2d4f598) | `python310Packages.dvc-render: 0.0.5 -> 0.0.6`                            |
| [`b8df14ae`](https://github.com/NixOS/nixpkgs/commit/b8df14aec0a7ee98eb54dd8e476910cce7718f0c) | `tests/terminal-emulators: comply with mypy typecheck`                    |
| [`f74debc9`](https://github.com/NixOS/nixpkgs/commit/f74debc95fcca5f7a9b0ae3e31335e5bdefe062d) | `dnsdist: 1.7.0 -> 1.7.1`                                                 |
| [`44248105`](https://github.com/NixOS/nixpkgs/commit/442481052a4819cdba2c7acce0f9e6ac45ae1475) | `libnfc: fix build on darwin`                                             |
| [`3cf3911f`](https://github.com/NixOS/nixpkgs/commit/3cf3911f79abb0c1db989f0c2d8da3b6cea57bc5) | `python310Packages.azure-mgmt-logic: 9.0.0 -> 10.0.0`                     |
| [`d339c458`](https://github.com/NixOS/nixpkgs/commit/d339c458150b99b47769c7ca163fd65b5d3af06c) | `catt: 0.12.2 -> 0.12.7`                                                  |
| [`5e7840d6`](https://github.com/NixOS/nixpkgs/commit/5e7840d676d48d9a57a93b3115cdebe7317c46a9) | `clair: 4.4.2 -> 4.4.4`                                                   |
| [`accc92f0`](https://github.com/NixOS/nixpkgs/commit/accc92f06057c8653969d77389a39fe7bfaebde0) | `element-{web,desktop}: 1.10.13 -> 1.10.14`                               |
| [`695fe7d2`](https://github.com/NixOS/nixpkgs/commit/695fe7d25305da01262482bb2c6fc62abc81ac06) | `kubeaudit: 0.17.0 -> 0.18.0`                                             |
| [`edd50437`](https://github.com/NixOS/nixpkgs/commit/edd50437bdc9603c6318543162a607e1ff6fb0fa) | `checkov: 2.0.1209 -> 2.0.1210`                                           |
| [`fa733534`](https://github.com/NixOS/nixpkgs/commit/fa7335347aee4351b91fe144376fbcc0c0795e61) | `httpx: 1.2.1 -> 1.2.2`                                                   |
| [`75a0709f`](https://github.com/NixOS/nixpkgs/commit/75a0709f6733ae627998eb718f2a4602c0cff1b7) | `luaPackages.busted: install shell completion via installShellCompletion` |
| [`dd9df750`](https://github.com/NixOS/nixpkgs/commit/dd9df750ba87f19b3f3b205caf9011d1447d59b9) | `luaPackages.readline: fix build`                                         |
| [`83313fee`](https://github.com/NixOS/nixpkgs/commit/83313fee5c44199ad96f4cac9526f5b514f9f93b) | `luaPackages.lua-lsp: fixed build`                                        |
| [`98f9f1f0`](https://github.com/NixOS/nixpkgs/commit/98f9f1f05447a3fd97af44c2702ca71554ddfac2) | `luaPackages.luv: fix build`                                              |
| [`98a90f08`](https://github.com/NixOS/nixpkgs/commit/98a90f08913202940121d0e7e85cdf11c5a1bc0e) | `luaPackages: update`                                                     |
| [`fb6f9ee2`](https://github.com/NixOS/nixpkgs/commit/fb6f9ee28ff6c57f4ab697a1db782e89a744f547) | `update-luarocks-package: fix mirrors`                                    |
| [`77a0e5f3`](https://github.com/NixOS/nixpkgs/commit/77a0e5f36e758ec62354919bd4dcc28b9eeebe3c) | `luarocks: 3.8.0 -> 3.9.0`                                                |
| [`022562fc`](https://github.com/NixOS/nixpkgs/commit/022562fcf01b5e4abdf1018e7f0eab401c0d9258) | `offensive-azure: init at 0.4.10`                                         |
| [`ee0c2902`](https://github.com/NixOS/nixpkgs/commit/ee0c29026ad4f5fa88ff1e1c4f358bb6b07a9d45) | `crlfsuite: init at 2.0`                                                  |
| [`1cd4b21e`](https://github.com/NixOS/nixpkgs/commit/1cd4b21e0744ffa775b50d7c76e36cff761d6496) | `smbscan: init at unstable-2022-05-26`                                    |
| [`77248491`](https://github.com/NixOS/nixpkgs/commit/772484911ca7a5cc71eac4a30395b8bf62f71d9e) | `python310Packages.aiohue: 4.4.1 -> 4.4.2`                                |
| [`d7500fd8`](https://github.com/NixOS/nixpkgs/commit/d7500fd8ef428c3c13b5e35644c0590b9e124eec) | `dnsrecon: 1.1.0 -> 1.1.1`                                                |
| [`1f980689`](https://github.com/NixOS/nixpkgs/commit/1f9806891d18c3f984e41f56fe0cc4458ee01e29) | `dnsrecon: 1.0.0 -> 1.1.0`                                                |
| [`d8ba6b40`](https://github.com/NixOS/nixpkgs/commit/d8ba6b400be7cfd4a1a6ae6bc3de7cba7f215d51) | `dynamips: 0.2.21 -> 0.2.22`                                              |
| [`172a1d93`](https://github.com/NixOS/nixpkgs/commit/172a1d93973a7ac6371ad63f8fe2e46f7e7ef3d9) | `bundler-audit: 0.9.0.1 -> 0.9.1`                                         |
| [`85213b6b`](https://github.com/NixOS/nixpkgs/commit/85213b6b412e00b3f37c6a2e81dd5e43a4e28e71) | `python3Packages.aws-adfs: fix build`                                     |
| [`b0e09fde`](https://github.com/NixOS/nixpkgs/commit/b0e09fdea3ec0eb9b1a273a01a830a7677808f44) | `jellyfin: 10.7.7 -> 10.8.0`                                              |
| [`be8ccf1b`](https://github.com/NixOS/nixpkgs/commit/be8ccf1bf251b4123051d3217a504539f034119a) | `jellyfin-web: 10.7.7 -> 10.8.0`                                          |
| [`4e38070d`](https://github.com/NixOS/nixpkgs/commit/4e38070d6ae8bda38b7ac03cb5ca0849761c7c2d) | `diffoscope: 215 -> 216`                                                  |
| [`7da38d0f`](https://github.com/NixOS/nixpkgs/commit/7da38d0f4a2b03dc5182e65a5bd87c45837ef55d) | `pythonPackages.myst-parser: init at 0.18.0`                              |
| [`737da091`](https://github.com/NixOS/nixpkgs/commit/737da0915746fa4a297e7cd6d66e34126d190ee1) | `pythonPackages.pytest-param-files: init at 0.3.4`                        |
| [`eafcfbf6`](https://github.com/NixOS/nixpkgs/commit/eafcfbf6e5af2916cb5689d4927647a57ce71175) | `pythonPackages.sphinx-pytest: init at 0.0.3`                             |
| [`35f3cb8c`](https://github.com/NixOS/nixpkgs/commit/35f3cb8c6e2e08fec29209d096733d7cc68dc655) | `xorg.xf86videoxgi: pull upstream fix for -fno-common toolchains`         |
| [`dfbb9600`](https://github.com/NixOS/nixpkgs/commit/dfbb960094c6136dd7fe2829427bd5af6d97f7ce) | `tvheadend: pull upstream fix for -fno-common toolchains`                 |
| [`ce5eca92`](https://github.com/NixOS/nixpkgs/commit/ce5eca92f157e9f4fc7c2f5566fc2f8beff14d0a) | `rocksndiamonds: pull upstream fix for -fno-common toolchains`            |
| [`1ee09a25`](https://github.com/NixOS/nixpkgs/commit/1ee09a25e808abf4d8d65f3900ba6aef2cd028b6) | `neverball: pull upstream fix for -fno-common toolchains`                 |
| [`7762092a`](https://github.com/NixOS/nixpkgs/commit/7762092a32b66f53ee828a99f5d192a81acf24af) | `vimPlugins.nvim-lastplace: init at 2021-10-15`                           |
| [`e5a1277c`](https://github.com/NixOS/nixpkgs/commit/e5a1277cf6e50263834fa5cfff430bc9173f1acc) | `vimPlugins: update`                                                      |