### PR TITLE
chore(flake/home-manager): `70824bb5` -> `87d30c16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1654628474,
-        "narHash": "sha256-Llm9X8Af15uC9IMStxqjCfO15WgYTqTnsQq8wMcpp5Q=",
+        "lastModified": 1655199284,
+        "narHash": "sha256-R/g2ZWplGWVOfm2TyB4kR+YcOE/uWkgjkYrl/RYgJ/U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "70824bb5c790b820b189f62f643f795b1d2ade2e",
+        "rev": "87d30c164849a7471d99749aa4d2d28b81564f69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`87d30c16`](https://github.com/nix-community/home-manager/commit/87d30c164849a7471d99749aa4d2d28b81564f69) | `nixos: fix fontconfig mkDefault call (#3021)`                         |
| [`cd3dd218`](https://github.com/nix-community/home-manager/commit/cd3dd2188c19416bc70d9703f84e07a0646af5bf) | `nixos: allow setting fonts.fontconfig.enable without mkForce (#3014)` |
| [`935ecea6`](https://github.com/nix-community/home-manager/commit/935ecea67d59f2af9d9f56d18a8f0dc12fb18cfd) | `neovim: add missing literalExpression in module docs (#3012)`         |