### PR TITLE
chore(flake/nixpkgs): `d8916eae` -> `6616de38`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655177799,
-        "narHash": "sha256-DrSYqguHb8GQNTrybNqFU/cozz8c/7ot+WllDEtpuE8=",
+        "lastModified": 1655221618,
+        "narHash": "sha256-ht8HRFthDKzYt+il+sGgkBwrv+Ex2l8jdGVpsrPfFME=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d8916eaeaf7080aa0642122d34d04f683ccf1f17",
+        "rev": "6616de389ed55fba6eeba60377fc04732d5a207c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                          |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`9dead556`](https://github.com/NixOS/nixpkgs/commit/9dead5565a9ce7e25d9dfb7230b885bdaf634177) | `lib/types, lib/modules: Remove unused extensionOffset`                 |
| [`d4a84aee`](https://github.com/NixOS/nixpkgs/commit/d4a84aeecaa765022a03c3ec03d214b93f46e804) | `lib/types: Use map instead of imap1 in submoduleWith`                  |
| [`907627f6`](https://github.com/NixOS/nixpkgs/commit/907627f6563546c6304703cab94b8cc60b06a12d) | `lib/types: Simplify submoduleWith shorthandOnlyDefinesConfig handling` |
| [`79441600`](https://github.com/NixOS/nixpkgs/commit/79441600c28c755a302f1e78eceb3c452c3bc7c9) | `lib/tests: Add submodule file propagation test`                        |
| [`726e2f79`](https://github.com/NixOS/nixpkgs/commit/726e2f79e35405dc09580b847e12d972b2aab6bf) | `vale: 2.17.0 -> 2.18.0`                                                |
| [`66edc724`](https://github.com/NixOS/nixpkgs/commit/66edc7241fb61c9b11ff598282b8298853cfb7be) | `python310Packages.enaml: 0.15.0 -> 0.15.1`                             |
| [`6813740d`](https://github.com/NixOS/nixpkgs/commit/6813740dc74cdc8bdf0d819d4df794428bf9c239) | `rnix-lsp: 0.2.4 -> 0.2.5`                                              |
| [`60ba9d65`](https://github.com/NixOS/nixpkgs/commit/60ba9d65d326687bfec3a68f2c734a32cbbdd038) | `vimPlugins.cmp-*: Add overrides`                                       |
| [`36b54d33`](https://github.com/NixOS/nixpkgs/commit/36b54d333db5928a841d49fccc09b13b999ca004) | `logstash: fix sha256`                                                  |
| [`54d4a1db`](https://github.com/NixOS/nixpkgs/commit/54d4a1db73d19985c128005ca472c1edb56a429a) | `gowitness: init at 2.4.0`                                              |
| [`d12ff557`](https://github.com/NixOS/nixpkgs/commit/d12ff5572571544989aa30abda50136dca81cf4a) | `webanalyze: init at 0.3.6`                                             |
| [`822b8e59`](https://github.com/NixOS/nixpkgs/commit/822b8e59e60d6b6522161a9bfbca8dc673beb5a4) | `homebank: 5.5.4 -> 5.5.5`                                              |
| [`76d82cd7`](https://github.com/NixOS/nixpkgs/commit/76d82cd78a9ac5a766ec74ff3a0c589692242848) | `python310Packages.social-auth-core: handle optional dependencies`      |
| [`bb77639d`](https://github.com/NixOS/nixpkgs/commit/bb77639d025689f4dcab1b09dd54cc8c3f0aa71a) | `python310Packages.social-auth-core: 4.2.0 -> 4.3.0`                    |
| [`c350fd89`](https://github.com/NixOS/nixpkgs/commit/c350fd89201962257e30b98eb404def5c9df671b) | `httm: 0.11.1 -> 0.11.6`                                                |
| [`bd1a7eec`](https://github.com/NixOS/nixpkgs/commit/bd1a7eec9bdf47a5a226e91fd77c0ab9657ed4d4) | `resvg: 0.22.0 -> 0.23.0`                                               |
| [`452ec5da`](https://github.com/NixOS/nixpkgs/commit/452ec5da7ac4787585ab39deebb294b923ec263b) | `python310Packages.ghapi: 0.1.20 -> 0.1.21`                             |
| [`06393550`](https://github.com/NixOS/nixpkgs/commit/06393550ccb0c8b03cc984d46ab46743cf629e8f) | `python310Packages.peaqevcore: 1.0.11 -> 1.0.14`                        |
| [`f6a39b8d`](https://github.com/NixOS/nixpkgs/commit/f6a39b8d7fef428d553668677069f9c466ea3a1a) | `python310Packages.atom: 0.8.0 -> 0.8.1`                                |
| [`4067b82a`](https://github.com/NixOS/nixpkgs/commit/4067b82a9be3d24899b7def609b39a5190adb25b) | `flexget: 3.3.16 -> 3.3.17`                                             |
| [`de77c035`](https://github.com/NixOS/nixpkgs/commit/de77c035c47c1cefc5b252e27b911cffb12e1240) | `tor-browser-bundle-bin: 11.0.13 -> 11.0.14`                            |
| [`2e4aac81`](https://github.com/NixOS/nixpkgs/commit/2e4aac819f8418be158f8a1f6708b2efe636ef21) | `ldapmonitor: init at 1.3`                                              |
| [`0631bf95`](https://github.com/NixOS/nixpkgs/commit/0631bf9509f1afcf02edba3ef51326093229ee23) | `liblouis: 3.21.0 → 3.22.0`                                             |
| [`40067617`](https://github.com/NixOS/nixpkgs/commit/40067617d66fe795a821d1b97bb99b1c5d5e8436) | `python310Packages.velbus-aio: 2022.6.1 -> 20212.6.2`                   |
| [`49eab7a5`](https://github.com/NixOS/nixpkgs/commit/49eab7a5a52626497bfabd532c5656f74c059e37) | `tfsec: 1.23.3 -> 1.24.0`                                               |
| [`e05dc87e`](https://github.com/NixOS/nixpkgs/commit/e05dc87e4153d1435e24629d5a8aea847ae2aa5c) | `vimPlugins.fuzzy-nvim: init at 2022-02-20`                             |
| [`fdaa8fc6`](https://github.com/NixOS/nixpkgs/commit/fdaa8fc610c001173a29642b363e363b60f3c659) | `vimPlugins.nvim-snippy: init at 2022-05-01`                            |
| [`dafc5add`](https://github.com/NixOS/nixpkgs/commit/dafc5addaad24eb734cb6fbc47af63cf0c0286a2) | `vimPlugins.cmp-dap: init at 2022-04-27`                                |
| [`843fd830`](https://github.com/NixOS/nixpkgs/commit/843fd83017b4ba38a4ec511916688aba2dd12323) | `vimPlugins.cmp-vimwiki-tags: init at 2022-04-25`                       |
| [`36e86164`](https://github.com/NixOS/nixpkgs/commit/36e86164d985d1244e606be07ff40f2e917a7ca8) | `vimPlugins.cmp-pandoc-nvim: init at 2022-05-03`                        |
| [`dd378843`](https://github.com/NixOS/nixpkgs/commit/dd3788435ae42fb6fe20c649345fdde72766de04) | `vimPlugins.cmp-look: init at 2022-03-21`                               |
| [`cbaec802`](https://github.com/NixOS/nixpkgs/commit/cbaec802b4c39b8388136a6bc1de7c2b945e4ab3) | `vimPlugins.cmp-greek: init at 2022-01-10`                              |
| [`028ad31f`](https://github.com/NixOS/nixpkgs/commit/028ad31f5d3fa70688d62ba2fabf509dbe0d28ae) | `vimPlugins.cmp-nvim-tags: init at 2022-03-31`                          |
| [`4704008b`](https://github.com/NixOS/nixpkgs/commit/4704008b8b65bd6673881cc9ce6c618a2a11e693) | `vimPlugins.cmp-copilot: init at 2022-04-11`                            |
| [`12e88c59`](https://github.com/NixOS/nixpkgs/commit/12e88c597712e3529d8782206032449aa1ef8ef2) | `vimPlugins.cmp-clippy: init at 2021-10-24`                             |
| [`f8459245`](https://github.com/NixOS/nixpkgs/commit/f845924568b3cc4a6b05c85ec881c2632b1f3d16) | `vimPlugins.cmp-npm: init at 2021-10-27`                                |
| [`82e3d312`](https://github.com/NixOS/nixpkgs/commit/82e3d3122b371b5d5390aa8c7e3add845f7796a4) | `vimPlugins.cmp-zsh: init at 2022-01-18`                                |
| [`b6e370d2`](https://github.com/NixOS/nixpkgs/commit/b6e370d29140b55fd11ec4b08074d4d0b940b21a) | `vimPlugins.cmp-fish: init at 2022-02-17`                               |
| [`586ed454`](https://github.com/NixOS/nixpkgs/commit/586ed4541b6ffdb38d5e7ab53efa074acb66235a) | `vimPlugins.cmp-rg: init at 2022-01-13`                                 |
| [`61446044`](https://github.com/NixOS/nixpkgs/commit/6144604447a3c32eac51b17a298f86752b8fc787) | `vimPlugins.cmp-fuzzy-path: init at 2022-05-08`                         |
| [`010ef3dc`](https://github.com/NixOS/nixpkgs/commit/010ef3dc36ff05ec033d1a75635b3eedacc28de6) | `vimPlugins.cmp-fuzzy-buffer: init at 2022-01-13`                       |
| [`aa87d478`](https://github.com/NixOS/nixpkgs/commit/aa87d4786964b66b51c11b749c6685f374a43431) | `vimPlugins.cmp-cmdline-history: init at 2022-05-04`                    |
| [`96fcb504`](https://github.com/NixOS/nixpkgs/commit/96fcb504d1f586908d20b95e49ca6781a5c9205c) | `vimPlugins.cmp-conventionalcommits: init at 2021-10-28`                |
| [`14d7a9c4`](https://github.com/NixOS/nixpkgs/commit/14d7a9c473d41869e3e5a7d31d6a2a37acedccfa) | `vimPlugins.cmp-git: init at 2022-05-11`                                |
| [`68dd2e5c`](https://github.com/NixOS/nixpkgs/commit/68dd2e5c8a5277c4ca2ea6ab253064d48abdfcee) | `vimPlugins.cmp-vim-lsp: init at 2021-10-26`                            |
| [`9782b816`](https://github.com/NixOS/nixpkgs/commit/9782b8161e8bd63dfa4e0f4da35a7145db010bf2) | `vimPlugins.cmp-nvim-lsp-signature-help: init at 2022-03-29`            |
| [`bcb28592`](https://github.com/NixOS/nixpkgs/commit/bcb285921bc134b18468452998bb114a88e93415) | `vimPlugins.cmp-digraphs: init at 2021-12-13`                           |
| [`0d921381`](https://github.com/NixOS/nixpkgs/commit/0d921381b640c30323432f8a4dcb0c272a83ca0e) | `vimPlugins.cmp-dictionary: init at 2022-05-04`                         |
| [`43c23c91`](https://github.com/NixOS/nixpkgs/commit/43c23c919e592d79943011b9a8a992b9edd58076) | `vimPlugins.cmp-snippy: init at 2021-09-20`                             |
| [`865a32dd`](https://github.com/NixOS/nixpkgs/commit/865a32dd51fa796ec105ff7fa72735b3a5529e5b) | `vimPlugins.cmp-neosnippet: init at 2022-01-06`                         |
| [`09757c2b`](https://github.com/NixOS/nixpkgs/commit/09757c2b254a67568858ac3ef6b5538f1cb413d8) | `haveged: 1.9.17 -> 1.9.18`                                             |
| [`d7fa12bd`](https://github.com/NixOS/nixpkgs/commit/d7fa12bd189895b0510a9087b2e89899fd07892f) | `hash-slinger: 3.1 -> 3.2`                                              |
| [`6ca8a394`](https://github.com/NixOS/nixpkgs/commit/6ca8a3944f8f80d3850d2fac95e7bc0bd07104b4) | `checksec: 2.5.0 -> 2.6.0`                                              |
| [`d22931cf`](https://github.com/NixOS/nixpkgs/commit/d22931cf0541895330b2d295a7be563e7a572231) | `raven-reader: 1.0.72 -> 1.0.73`                                        |
| [`e25d3634`](https://github.com/NixOS/nixpkgs/commit/e25d36346f77491ce35b81d4e53368e2f9dc1007) | `xdg-desktop-portal-wlr: 0.5.0 -> 0.6.0`                                |
| [`1210f3c2`](https://github.com/NixOS/nixpkgs/commit/1210f3c24c796bda2889849975081930a225fa26) | `python310Packages.pyroute2-ipset: 0.6.11 -> 0.6.12`                    |
| [`0d462f55`](https://github.com/NixOS/nixpkgs/commit/0d462f55f3f9e4472e47b29a940b86a25cd33728) | `python310Packages.pyroute2: 0.6.11 -> 0.6.12`                          |
| [`985d6dd9`](https://github.com/NixOS/nixpkgs/commit/985d6dd96e943ecd6a9fe1155b3362bb98f8be54) | `python310Packages.pyroute2-protocols: 0.6.11 -> 0.6.12`                |
| [`d85e4c28`](https://github.com/NixOS/nixpkgs/commit/d85e4c28730447a78c44a7c25d68207346892502) | `python310Packages.pyroute2-nslink: 0.6.11 -> 0.6.12`                   |
| [`f6301f1a`](https://github.com/NixOS/nixpkgs/commit/f6301f1ac5d4bfcaaba0bffcaf5fa6b205b7e60c) | `python310Packages.pyroute2-nftables: 0.6.11 -> 0.6.12`                 |
| [`002a5c99`](https://github.com/NixOS/nixpkgs/commit/002a5c995517125cff49539591461bd52d4355a6) | `python310Packages.pyroute2-ndb: 0.6.11 -> 0.6.12`                      |
| [`3341e2c5`](https://github.com/NixOS/nixpkgs/commit/3341e2c570534a734882187a94d53ca6032ad996) | `python310Packages.pyroute2-ipdb: 0.6.11 -> 0.6.12`                     |
| [`5fb659f6`](https://github.com/NixOS/nixpkgs/commit/5fb659f697125a6e3ba50f033821348087d45dbd) | `python310Packages.pyroute2-ethtool: 0.6.11 -> 0.6.12`                  |
| [`02bd9fcc`](https://github.com/NixOS/nixpkgs/commit/02bd9fccc35e6eb1c90a565246685a64bb48691c) | `python310Packages.pyroute2-core: 0.6.11 -> 0.6.12`                     |
| [`4532226e`](https://github.com/NixOS/nixpkgs/commit/4532226e4dc038217e83e5eaf80f17a983a25ae5) | `tree-sitter: init tree-sitter-sql`                                     |
| [`7b4b39cb`](https://github.com/NixOS/nixpkgs/commit/7b4b39cbc1d8d70c9d94f884130a9a4adc4d6e75) | `tree-sitter: init tree-sitter-rego`                                    |
| [`cd5793da`](https://github.com/NixOS/nixpkgs/commit/cd5793da838c9719d9862286d213403fe968942a) | `tree-sitter: update grammars`                                          |
| [`47cbc38f`](https://github.com/NixOS/nixpkgs/commit/47cbc38f087ddecb4feb68ac19a0d1b07422b3aa) | `tree-sitter: init tree-sitter-go-work`                                 |
| [`68c360c5`](https://github.com/NixOS/nixpkgs/commit/68c360c518091f0e2d355dd3aa7186f4e8da0935) | `polymc: 1.3.1 -> 1.3.2`                                                |
| [`fa01afcf`](https://github.com/NixOS/nixpkgs/commit/fa01afcf7f4d98dc7953fb3ac22f68108d4a57d7) | `doc: Promote config Options Reference to sub-chapter section`          |
| [`b661c34a`](https://github.com/NixOS/nixpkgs/commit/b661c34a10aacb5dd4ec957655d2f9a0288aa3b3) | `redis: 7.0.0 -> 7.0.2`                                                 |
| [`63174f9b`](https://github.com/NixOS/nixpkgs/commit/63174f9b6f650f511cf05689c85e33588ba5f85a) | `_1password: 2.3.1 -> 2.4.1`                                            |
| [`25cdb44f`](https://github.com/NixOS/nixpkgs/commit/25cdb44ff0312f7f4fbccde4850401fd5d66b5a8) | `jellyfin-mpv-shim: 2.0.2 -> 2.1.0`                                     |
| [`1eca09a8`](https://github.com/NixOS/nixpkgs/commit/1eca09a8a139354702eb90f0bd85670067eb71ed) | `mlton: 20180207 → 20210107`                                            |