### PR TITLE
chore(flake/nixpkgs): `6616de38` -> `81ccb110`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655221618,
-        "narHash": "sha256-ht8HRFthDKzYt+il+sGgkBwrv+Ex2l8jdGVpsrPfFME=",
+        "lastModified": 1655269044,
+        "narHash": "sha256-VscxTckDD3wSdXsJxkOrdtDo4h4nVD5GutWQmD2uMlM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6616de389ed55fba6eeba60377fc04732d5a207c",
+        "rev": "81ccb11016c0e333f6158ec6af965a47c37e5055",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`81ccb110`](https://github.com/NixOS/nixpkgs/commit/81ccb11016c0e333f6158ec6af965a47c37e5055) | `python310Packages.qcelemental: 0.24.0 -> 0.25.0`                      |
| [`07bb4be4`](https://github.com/NixOS/nixpkgs/commit/07bb4be4e12fb06a35a7e645f22cea07b4b71e91) | `python310Packages.dash: 2.5.0 -> 2.5.1`                               |
| [`499e57cf`](https://github.com/NixOS/nixpkgs/commit/499e57cfd1de3ed913f1eeef4f4a1f49aa2576b8) | `python310Packages.pyclipper: 1.3.0.post2 -> 1.3.0.post3`              |
| [`e9b50ec5`](https://github.com/NixOS/nixpkgs/commit/e9b50ec5f56e190183a485a3ea19ed575299860f) | `sabnzbd: 3.5.3 -> 3.6.0`                                              |
| [`1e197cba`](https://github.com/NixOS/nixpkgs/commit/1e197cba9fbf8a00ccecfb025d8928e934e89c86) | `python3Packages.sabyenc3: 5.1.7 -> 5.4.2`                             |
| [`b1c207a4`](https://github.com/NixOS/nixpkgs/commit/b1c207a442f12893e60e489833961efd5f4d7185) | `python310Packages.cssutils: 2.4.0 -> 2.4.2`                           |
| [`eb757bfa`](https://github.com/NixOS/nixpkgs/commit/eb757bfa419bd91c327da3604a27c5224c0c5c9e) | `python310Packages.jaraco-test: init at 5.1.0`                         |
| [`64944a5a`](https://github.com/NixOS/nixpkgs/commit/64944a5a59aeef0fe803e6db8704d61116c644f3) | `python310Packages.cachelib: 0.7.0 -> 0.8.0`                           |
| [`2f40738f`](https://github.com/NixOS/nixpkgs/commit/2f40738f6f94fa4c3775389e1aeb01b277dd42b7) | `python310Packages.mockito: 1.3.0 -> 1.3.1`                            |
| [`1cd4b3d7`](https://github.com/NixOS/nixpkgs/commit/1cd4b3d7658c514c347e73181c967d4d8b5d469d) | `python310Packages.flammkuchen: 0.9.2 -> 1.0.2`                        |
| [`e3141f9a`](https://github.com/NixOS/nixpkgs/commit/e3141f9a324d9452430c4fe7b101b2150e84d46b) | `python310Packages.mkdocs-material: 8.3.4 -> 8.3.5`                    |
| [`0cc236b4`](https://github.com/NixOS/nixpkgs/commit/0cc236b423b92e266299489b0cfd9714b84e1514) | `python310Packages.gnureadline: 8.0.0 -> 8.1.2`                        |
| [`882741f6`](https://github.com/NixOS/nixpkgs/commit/882741f632b57348c5fed07919fcb494d1ee7a76) | `tests.buildRustCrate: add rcgen test`                                 |
| [`a6bbe3f7`](https://github.com/NixOS/nixpkgs/commit/a6bbe3f79452892ef0eabc8c2b72d3d3c015e32c) | `buildRustCrate: pass link flags when building libraries`              |
| [`48480ea4`](https://github.com/NixOS/nixpkgs/commit/48480ea46ad4cb60a78fd02e4fb29eab11502bcf) | `python310Packages.rapidfuzz: use Ninja`                               |
| [`e2d63b0e`](https://github.com/NixOS/nixpkgs/commit/e2d63b0e028a36ef677ebc4e0250fb7b5a55588f) | `jarowinkler-cpp: 1.0.0 -> 1.0.1`                                      |
| [`87aef5e8`](https://github.com/NixOS/nixpkgs/commit/87aef5e85678a12e636b0735ecc8ef8aaee2c6cf) | `rapidfuzz-cpp: 1.0.1 -> 1.0.2`                                        |
| [`01fb64af`](https://github.com/NixOS/nixpkgs/commit/01fb64af34aee0da7cecb791b329ef8256a5c384) | `catch2_3: init at 3.0.1`                                              |
| [`1acbd5cc`](https://github.com/NixOS/nixpkgs/commit/1acbd5cc843f58f4314eec43bd23061c9bced4a6) | `python310Packages.rpi-gpio: init at 0.7.1`                            |
| [`a5c5302d`](https://github.com/NixOS/nixpkgs/commit/a5c5302ddd7b5c62e54a33d56f99bbca50ffd867) | `python311: 3.11.0b1 -> 3.11.0b3`                                      |
| [`2ca29d0b`](https://github.com/NixOS/nixpkgs/commit/2ca29d0bee1c4c04cea804be224f49f832c92910) | `go: remove outdated patch`                                            |
| [`4aae3930`](https://github.com/NixOS/nixpkgs/commit/4aae393064b4c9da2b10275a668683f66e09c63e) | `minica: use buildGoModule`                                            |
| [`b1769606`](https://github.com/NixOS/nixpkgs/commit/b1769606db7d4290b57bd4cf1b2a9f754ded5a83) | `home-assistant: 2022.6.5 -> 2022.6.6`                                 |
| [`dae85d6f`](https://github.com/NixOS/nixpkgs/commit/dae85d6fbc8275ff58aca1ce4fa9507d8bd5657c) | `python310Packages.igraph: 0.9.10 -> 0.9.11`                           |
| [`20ac3479`](https://github.com/NixOS/nixpkgs/commit/20ac3479d4e2ecfa14d58b20b0081db29afed808) | `conmon: 2.1.1 -> 2.1.2`                                               |
| [`8fe35cdf`](https://github.com/NixOS/nixpkgs/commit/8fe35cdfe0a529e8f5e9335646554a86acf7c300) | `checkov: 2.0.1210 -> 2.0.1212`                                        |
| [`bf190d49`](https://github.com/NixOS/nixpkgs/commit/bf190d49455ee1e8e4a1f87700017a940cd39248) | `mojave-gtk-theme: 2022-05-12 -> 2022-06-07 (#177337)`                 |
| [`e84ce3a9`](https://github.com/NixOS/nixpkgs/commit/e84ce3a94a05d9a0c7c8f04070609fb7ce856da8) | `matcha-gtk-theme: 2021-12-25 -> 2022-06-07 (#176703)`                 |
| [`6a88e9a3`](https://github.com/NixOS/nixpkgs/commit/6a88e9a3448760ca16cf99f642b8e3c0cd76c0fb) | `python310Packages.pikepdf: 5.1.4 -> 5.1.5`                            |
| [`c8099f55`](https://github.com/NixOS/nixpkgs/commit/c8099f552f76b0efc14516faed7eaf04c0da6d1c) | `drawio: 19.0.2 -> 19.0.3`                                             |
| [`5d4e5996`](https://github.com/NixOS/nixpkgs/commit/5d4e59968883cfac5a26c620172503ae0e578072) | `python310Packages.pyspcwebgw: 0.5.0 -> 0.6.0`                         |
| [`e91c8a9b`](https://github.com/NixOS/nixpkgs/commit/e91c8a9b94678372e2f8a9a2822a412c4eb46ec6) | `qshowdiff: Remove (Qt4)`                                              |
| [`78d388e6`](https://github.com/NixOS/nixpkgs/commit/78d388e6f60092406360816a34e925c12b9525c0) | `libbluedevil: Remove (Qt4)`                                           |
| [`7aaf277a`](https://github.com/NixOS/nixpkgs/commit/7aaf277a47ed51f1c55232eb152e92a524d9288a) | `dovecot: 2.3.19 -> 2.3.19.1`                                          |
| [`a0bb6c7a`](https://github.com/NixOS/nixpkgs/commit/a0bb6c7a999eacf7eb2f87eb712079729b4d3afc) | `python310Packages.unifi-discovery: 1.1.3 -> 1.1.4`                    |
| [`8899b2c8`](https://github.com/NixOS/nixpkgs/commit/8899b2c8743f5daef7fb4b8ab6133e79fbcd1a17) | `portfolio: 0.58.3 -> 0.58.4`                                          |
| [`a844e351`](https://github.com/NixOS/nixpkgs/commit/a844e3517d4b39c0b212129976a43fd390bd9681) | `asciinema: specify license`                                           |
| [`6bd65099`](https://github.com/NixOS/nixpkgs/commit/6bd65099b6ff15b5f5cd2d56215e1c07628ed3b5) | `kitty: 0.25.1 -> 0.25.2`                                              |
| [`8e97f29c`](https://github.com/NixOS/nixpkgs/commit/8e97f29c01229c424c5ff115178c45fd0349748c) | `ngrok: 2.3.40 -> 3.0.4`                                               |
| [`31207831`](https://github.com/NixOS/nixpkgs/commit/312078319cfcea2c07cbc77bbc47751326903b96) | `sil-q: init at v1.5.0`                                                |
| [`b5b5ae6e`](https://github.com/NixOS/nixpkgs/commit/b5b5ae6e03566709014e4dd0488fa56d709e0fb7) | `maintainers: add kenran`                                              |
| [`8fbe78de`](https://github.com/NixOS/nixpkgs/commit/8fbe78de26590d172f8b4b047a65449d4ebc5736) | `norouter: init at 0.6.4`                                              |
| [`131a40cf`](https://github.com/NixOS/nixpkgs/commit/131a40cf1ba9091b449ef630bbee1b1b68314d01) | `fly: 7.7.1 -> 7.8.0, adopt`                                           |
| [`8acd15d8`](https://github.com/NixOS/nixpkgs/commit/8acd15d8bf96c1f5d3dbb816be89270de503b86a) | `asciinema: 2.1.0 -> 2.2.0`                                            |
| [`3a5bae55`](https://github.com/NixOS/nixpkgs/commit/3a5bae5592b37819e1960ea5890e55d72bf0a5e1) | `python3Packages.wandb: 0.12.17 -> 0.12.18`                            |
| [`eb9f2ac6`](https://github.com/NixOS/nixpkgs/commit/eb9f2ac69d6341e03c72d7d40f6867ebc07d1fc0) | `vivaldi: 5.3.2679.38-1 -> 5.3.2679.55-1`                              |
| [`9c573c08`](https://github.com/NixOS/nixpkgs/commit/9c573c0833285c5337493389e6ba4f8a8519b51e) | `rbspy: 0.11.1 -> 0.12.1`                                              |
| [`5683c6e0`](https://github.com/NixOS/nixpkgs/commit/5683c6e03b4b35227f049b3625fa8e8ce22948c3) | `nixos/vaultwarden: Make example more detailed.`                       |
| [`8886ff1b`](https://github.com/NixOS/nixpkgs/commit/8886ff1be100e4774da368dd3c386d2135a49a1a) | `kube-prompt: use buildGoModule`                                       |
| [`f6e2e3a1`](https://github.com/NixOS/nixpkgs/commit/f6e2e3a1e15a1670a73817f3ef58c561e35ebb40) | `lens: 5.3.4 -> 5.5.3`                                                 |
| [`85dfb119`](https://github.com/NixOS/nixpkgs/commit/85dfb11907c220c042f1372a2f411520e1efe235) | `python311: 3.11.0a7 -> 3.11.0b1`                                      |
| [`50217b01`](https://github.com/NixOS/nixpkgs/commit/50217b01dd68cb4dfc24ecfa568b7f1b69a092cc) | `submitting-changes.chapter.md: avoid being specific`                  |
| [`94c0e088`](https://github.com/NixOS/nixpkgs/commit/94c0e08808ce3529e4ace6584626d94ca07f21ee) | `submitting-changes.chapter.md: explain that purple arrows are manual` |