### PR TITLE
chore(flake/home-manager): `87d30c16` -> `504d6de6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1655199284,
-        "narHash": "sha256-R/g2ZWplGWVOfm2TyB4kR+YcOE/uWkgjkYrl/RYgJ/U=",
+        "lastModified": 1655329498,
+        "narHash": "sha256-9XnQTDr2/byzwrV7h0rFDVW+GYKi/Q8+AgHdqe4PyhA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "87d30c164849a7471d99749aa4d2d28b81564f69",
+        "rev": "504d6de6a061993c3f585f9a86c6a9f68927b1c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                            |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`504d6de6`](https://github.com/nix-community/home-manager/commit/504d6de6a061993c3f585f9a86c6a9f68927b1c0) | `Add translation using Weblate (Finnish)` |
| [`a9b027b8`](https://github.com/nix-community/home-manager/commit/a9b027b826fb9644515f045e115d1466297da958) | `Translate using Weblate (Catalan)`       |
| [`68edbc7f`](https://github.com/nix-community/home-manager/commit/68edbc7f2839bde0abea2bb381d401d813e3adeb) | `Add translation using Weblate (Finnish)` |
| [`1342f4a0`](https://github.com/nix-community/home-manager/commit/1342f4a07c14bc40592b5faaa258736a12bc1327) | `Translate using Weblate (Catalan)`       |
| [`07dbd4c0`](https://github.com/nix-community/home-manager/commit/07dbd4c0dd15718a2a0b4457de7a10f9db0b342f) | `pywal: fixed i3 config (#3002)`          |