### PR TITLE
chore(flake/nixpkgs): `81ccb110` -> `dd385030`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655269044,
-        "narHash": "sha256-VscxTckDD3wSdXsJxkOrdtDo4h4nVD5GutWQmD2uMlM=",
+        "lastModified": 1655342719,
+        "narHash": "sha256-mUUlNMYXK05X082tuZZr1N2goy8UIFq+LkHa+q/5BCU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "81ccb11016c0e333f6158ec6af965a47c37e5055",
+        "rev": "dd38503071accc7fc9255c431b8acc8623ab58c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`d3f9ba06`](https://github.com/NixOS/nixpkgs/commit/d3f9ba06c2bbab3a10d4c74662734375941bf32b) | `python310Packages.pad4pi: init at 1.1.5`                                                       |
| [`69e36019`](https://github.com/NixOS/nixpkgs/commit/69e36019abd93aee9676d837c2013f665afcda5b) | `python310Packages.rplcd: init at 1.3.0`                                                        |
| [`249a7736`](https://github.com/NixOS/nixpkgs/commit/249a7736f54c5ec9c3e29c9ee55360a8b4f72d2f) | `unifont_upper: 14.0.03 -> 14.0.04`                                                             |
| [`974b4fbe`](https://github.com/NixOS/nixpkgs/commit/974b4fbe487311128355a2786f75ee10cb5aaa6f) | `unifont: 14.0.03 -> 14.0.04`                                                                   |
| [`94c99e1b`](https://github.com/NixOS/nixpkgs/commit/94c99e1b9b138e0c7ec4a8f476e06da59faf09f5) | `pythonPackages.nbxmpp: 3.0.2 → 3.1.0`                                                          |
| [`b5818b7a`](https://github.com/NixOS/nixpkgs/commit/b5818b7a302afca78723035394396c150795b607) | `nixos/pipewire: only add pipewire-pulse.conf conditionally`                                    |
| [`1e3747b9`](https://github.com/NixOS/nixpkgs/commit/1e3747b98b69a9c75edcfdfa4f4e1497aab55789) | `nixos/pipewire: add pkgs.pulseaudio to pipewire-pulse user unit path`                          |
| [`75d21e71`](https://github.com/NixOS/nixpkgs/commit/75d21e713116dd1beac0c3c315f78a54a877f474) | `podman: 4.1.0 -> 4.1.1`                                                                        |
| [`63055de8`](https://github.com/NixOS/nixpkgs/commit/63055de8b7f166846dae728543dfce9822bffffe) | `terraform: 1.2.2 -> 1.2.3`                                                                     |
| [`e59b2e67`](https://github.com/NixOS/nixpkgs/commit/e59b2e676bf7c890fe053ca0fd2437f725ca7728) | `python310Packages.libversion: use pytestCheckHook`                                             |
| [`4e3a6562`](https://github.com/NixOS/nixpkgs/commit/4e3a656282891bb26937bfe128957e24f4f2e05a) | `python310Packages.libversion: fix cross`                                                       |
| [`106506aa`](https://github.com/NixOS/nixpkgs/commit/106506aabeff2f07aa938f0e25a4bfb6f3f306f1) | `python310Packages.pyfuse3: fix cross`                                                          |
| [`ee5946b9`](https://github.com/NixOS/nixpkgs/commit/ee5946b90f257d6ba14d46f5a523e385188978a1) | `python310Packages.anyio: fix cross`                                                            |
| [`e3e09167`](https://github.com/NixOS/nixpkgs/commit/e3e091672ff6cbdc8e8d0be4b355fbab4e5ea69d) | `fetchYarnDeps: support hash in pkg.integrity (#177255)`                                        |
| [`2ba52d31`](https://github.com/NixOS/nixpkgs/commit/2ba52d316c66e1778842c3385ee2b058bf351795) | `dt-shell-color-scripts: init at unstable-2022-02-22`                                           |
| [`b061feb6`](https://github.com/NixOS/nixpkgs/commit/b061feb6d6acb01965b028236134a6969ad3e3da) | `wxcam: Remove`                                                                                 |
| [`28171349`](https://github.com/NixOS/nixpkgs/commit/281713495f7c13ff252b7fe0dd6c33fa291c407d) | `way-displays: init at 1.5.3`                                                                   |
| [`2205b906`](https://github.com/NixOS/nixpkgs/commit/2205b906994c94c88290555829f98227b52c76c8) | `chain-bench: init at 0.0.2`                                                                    |
| [`6b0f4f60`](https://github.com/NixOS/nixpkgs/commit/6b0f4f603c16a15f33566ce4bc3512e9b85159d3) | `scala-cli: 0.1.7 -> 0.1.8`                                                                     |
| [`49673848`](https://github.com/NixOS/nixpkgs/commit/496738486d8a9a53b3774937024863093fd02a32) | `dnsdist: 1.7.1 -> 1.7.2`                                                                       |
| [`efc86c4e`](https://github.com/NixOS/nixpkgs/commit/efc86c4ec3d5fdadff8737fccac84893804ee97c) | `maintainers: add simoneruffini`                                                                |
| [`b1957596`](https://github.com/NixOS/nixpkgs/commit/b1957596ff1c7aa8c55c4512b7ad1c9672502e8e) | `python310Packages.rpi-gpio2: init at 0.3.0a3`                                                  |
| [`63d5e3a7`](https://github.com/NixOS/nixpkgs/commit/63d5e3a70a9a8b256ad6ae3d6ace4bee97a76a13) | `tfsec: 1.24.0 -> 1.25.1`                                                                       |
| [`4dc9f608`](https://github.com/NixOS/nixpkgs/commit/4dc9f608155236418f645792cd2732533003b82b) | `terrascan: 1.15.1 -> 1.15.2`                                                                   |
| [`4cae7db6`](https://github.com/NixOS/nixpkgs/commit/4cae7db647ab7bbddbbcf7cd96ba01090bd8c7dc) | `pip-audit: 2.3.1 -> 2.3.2`                                                                     |
| [`7290fa13`](https://github.com/NixOS/nixpkgs/commit/7290fa1388fad909904e557a179f988398c37c9c) | `exploitdb: 2022-06-11 -> 2022-06-15`                                                           |
| [`157dcd9c`](https://github.com/NixOS/nixpkgs/commit/157dcd9c4183b55919104d2ffff5e81648bc8d9e) | `python3Packages.osmpythontools: 0.3.4 -> 0.3.5`                                                |
| [`fe1f4564`](https://github.com/NixOS/nixpkgs/commit/fe1f4564af61f3e3d3784b89668c61ede998e710) | `nixos/tests/vscodium: skip type check for now`                                                 |
| [`7204dec4`](https://github.com/NixOS/nixpkgs/commit/7204dec4a7265f7183778964042ca896974f4c34) | `python310Packages.discogs-client: 2.3.14 -> 2.3.15`                                            |
| [`7f44a599`](https://github.com/NixOS/nixpkgs/commit/7f44a5991e6175e3713aa0d640fa8be2a8dbccde) | `python310Packages.debian: 0.1.43 -> 0.1.44`                                                    |
| [`04daef00`](https://github.com/NixOS/nixpkgs/commit/04daef001e5612f2cd2b2c497fb837767fb7b87d) | `python310Packages.plugwise: 0.19.1 -> 0.20.0`                                                  |
| [`86b6ea07`](https://github.com/NixOS/nixpkgs/commit/86b6ea079bdf30d2b0ee88d6d08fc241c5cd9a88) | `python310Packages.container-inspector: 31.0.0 -> 31.1.0`                                       |
| [`b88c8dbe`](https://github.com/NixOS/nixpkgs/commit/b88c8dbe07d74b928d3ca301089368cb039e11de) | `watchlog: Remove Darwin from supported platforms.`                                             |
| [`418a67ad`](https://github.com/NixOS/nixpkgs/commit/418a67adb6542b48e30c1ad27834811844f08fe1) | `atom,atom-beta: 1.58.0 -> 1.60.0, 1.59.0-beta0 -> 1.61.0-beta0`                                |
| [`5b4de3cf`](https://github.com/NixOS/nixpkgs/commit/5b4de3cf2d8e931e126cc5f290483f62636d9026) | `e16: 1.0.24 -> 1.0.25`                                                                         |
| [`7817ca4a`](https://github.com/NixOS/nixpkgs/commit/7817ca4aa7aecb6ef36e865423e2b999152026a3) | `sweep-visualizer: Remove`                                                                      |
| [`1c7f2a67`](https://github.com/NixOS/nixpkgs/commit/1c7f2a67a0348517feb8b5d8557cfc225a9582c3) | `grafana-agent: add NixOS passthru test`                                                        |
| [`31b47913`](https://github.com/NixOS/nixpkgs/commit/31b47913f37b6e7b04fe72661383b8371f46b3f1) | `nixos: add grafana-agent module`                                                               |
| [`0d55e8b1`](https://github.com/NixOS/nixpkgs/commit/0d55e8b15c284525b5d45910c64a991c8c745beb) | `lighttable: Remove`                                                                            |
| [`5565f04e`](https://github.com/NixOS/nixpkgs/commit/5565f04e913bcf31a0874d56739899d7c66209e7) | `lightning-loop: 0.18.0-beta -> 0.19.1-beta`                                                    |
| [`06acda14`](https://github.com/NixOS/nixpkgs/commit/06acda149c44fda39d443c2d03be6da9986ca902) | `python310Packages.appthreat-vulnerability-db: 2.0.2 -> 2.0.5`                                  |
| [`6c23535b`](https://github.com/NixOS/nixpkgs/commit/6c23535be76829370f8a6b175c067e26fce695f2) | `slurm: 22.05.0.1 -> 22.05.1.1`                                                                 |
| [`abe07f9c`](https://github.com/NixOS/nixpkgs/commit/abe07f9c2c05ebaa2f9b7c3b8b00d78acd76e1df) | `python310Packages.slack-sdk: 3.17.0 -> 3.17.1`                                                 |
| [`becff585`](https://github.com/NixOS/nixpkgs/commit/becff585796094f75d0ccbe1df5418ef873897ac) | `nixos/hedgedoc: Do not set StateDirectory to an absolute path`                                 |
| [`540e2e03`](https://github.com/NixOS/nixpkgs/commit/540e2e03037acfc9e33b98731cea0b731c33766f) | `python310Packages.aesara: 2.7.1 -> 2.7.2`                                                      |
| [`93d3ee74`](https://github.com/NixOS/nixpkgs/commit/93d3ee74a184a568b5a506ef76e6ffa00866440f) | `vimPlugins.catppuccin-vim: init at 2022-06-06 (#177376)`                                       |
| [`b96b41d2`](https://github.com/NixOS/nixpkgs/commit/b96b41d2a818c4b997b8e6a647b960a01c7f046c) | `discord-sh: init at unstable-2022-05-19`                                                       |
| [`7a289645`](https://github.com/NixOS/nixpkgs/commit/7a2896459ab63c77af7ff7e7faa27235031e865a) | `python310Packages.zeroconf: 0.38.6 -> 0.38.7`                                                  |
| [`84a70844`](https://github.com/NixOS/nixpkgs/commit/84a70844bb18fa5542511a73992e589b8c58e04f) | `plexRaw: 1.26.2.5797-5bd057d2b -> 1.27.0.5897-3940636f2`                                       |
| [`69443b19`](https://github.com/NixOS/nixpkgs/commit/69443b19b8aa329b7f415e2ed6254c1c916254f3) | `ocamlPackages.tsort: 2.0.0 -> 2.1.0`                                                           |
| [`b7d0d741`](https://github.com/NixOS/nixpkgs/commit/b7d0d7411b94dd503543b21c696e25086be4e3f3) | `plasma-workspace: instead of 'query_qmake' CMakeLists.txt is using 'ecm_query_qt' now`         |
| [`bbded419`](https://github.com/NixOS/nixpkgs/commit/bbded419f9f2374c0308155367784a2df83def0c) | `plasma: 5.24.90 -> 5.25.0`                                                                     |
| [`c028f556`](https://github.com/NixOS/nixpkgs/commit/c028f5569b6ce86bef4a84fc73277330fae5a9f2) | `kcheckpass is gone(?)`                                                                         |
| [`56e942b0`](https://github.com/NixOS/nixpkgs/commit/56e942b0ea14727b1da1c7383aec8500ff2b7add) | `plasma-integration: add wayland, wayland-protocols, and plasma-wayland-protocols dependencies` |
| [`08555e82`](https://github.com/NixOS/nixpkgs/commit/08555e82bae3db8bcac909c78120c32dd9f318d8) | `kwin: fix build for 5.24.90`                                                                   |
| [`6cae76a5`](https://github.com/NixOS/nixpkgs/commit/6cae76a505f7a0a5bd536ad4c54771aa77d9f0a2) | `kwayland-server has been integrated into kwin - delete package`                                |
| [`72c3b6c0`](https://github.com/NixOS/nixpkgs/commit/72c3b6c05e27f51b89294e13cf3d1ef76a86e7c9) | `plasma: 5.24.5 -> 5.24.90 (5.25 beta)`                                                         |
| [`e1de560f`](https://github.com/NixOS/nixpkgs/commit/e1de560f7ae93979ab3a19377ebb48c6ba166fc4) | `kde-frameworks: 5.94 -> 5.95`                                                                  |
| [`1d9ba6ae`](https://github.com/NixOS/nixpkgs/commit/1d9ba6ae5339f0213bf01826c2b7d958f2c951bc) | `kde/gear: 22.04.1 -> 22.04.2`                                                                  |
| [`6ddc911b`](https://github.com/NixOS/nixpkgs/commit/6ddc911b9a4f77149d399ecbca566167c1c8ed52) | `gitsign: 0.1.0 -> 0.1.1`                                                                       |
| [`aaba5019`](https://github.com/NixOS/nixpkgs/commit/aaba5019fae6c893ee7f02f63f66bd03f8ef2d4e) | `cargo-nextest: 0.9.16 -> 0.9.20`                                                               |
| [`e1a75c48`](https://github.com/NixOS/nixpkgs/commit/e1a75c484198e85b15531ac4fcb2854de79d8577) | `python310Packages.plaid-python: 9.5.0 -> 9.6.0`                                                |
| [`c841addd`](https://github.com/NixOS/nixpkgs/commit/c841addd7588ec2fafab69ff6dd748ca7fd5047c) | `go-ethereum: 1.10.17 -> 1.10.18`                                                               |
| [`3f55912b`](https://github.com/NixOS/nixpkgs/commit/3f55912bd72765f5bf59cbfd9ce55979c4c8ded9) | `godns: 2.7.7 -> 2.7.8`                                                                         |
| [`9896d3e9`](https://github.com/NixOS/nixpkgs/commit/9896d3e92902cfb8515bba6305bfd0ffc3b3ca0c) | `gnome.gnome-calendar: 42.1 -> 42.2`                                                            |
| [`5a0dfe81`](https://github.com/NixOS/nixpkgs/commit/5a0dfe81c475adae067697185f2deb3eb2a0b446) | `appthreat-depscan: 2.1.3 -> 2.1.5`                                                             |
| [`90d960c1`](https://github.com/NixOS/nixpkgs/commit/90d960c1b4f4ecffbc368030c85ebffe82eb547b) | `vtm: 0.6.0 -> 0.7.6`                                                                           |
| [`d9dccae0`](https://github.com/NixOS/nixpkgs/commit/d9dccae07c638adb2d1eed6a722e01e9063bda97) | `nixos/doc: Hold off on NixOps 2 info until released`                                           |
| [`3c4a49f5`](https://github.com/NixOS/nixpkgs/commit/3c4a49f506575306f8b355e86d2b19cf02c84688) | `lib/modules: Throw earlier when module function does not return attrs`                         |
| [`cc3fa0d7`](https://github.com/NixOS/nixpkgs/commit/cc3fa0d78729f63dfe53d1719f603679f2cd9d85) | `ft2-clone: 1.54 -> 1.55`                                                                       |
| [`dfd98a5d`](https://github.com/NixOS/nixpkgs/commit/dfd98a5da26c341cf3b7e6fe7e2dbbaeb0af519c) | `lib.deferredModule: Make it properly singular`                                                 |
| [`19a069ab`](https://github.com/NixOS/nixpkgs/commit/19a069ab8b17834da249b5ecb507c2eabe76a3e3) | `lib.types: Add deferredModuleWith`                                                             |
| [`781c2e07`](https://github.com/NixOS/nixpkgs/commit/781c2e0789f7f6b75454a8e986c675ad36e6ee36) | `lib.types.deferredModule: Allow path-typed module references`                                  |
| [`a2c29561`](https://github.com/NixOS/nixpkgs/commit/a2c29561e722e9546c61323a91f9faffcc3bf268) | `lib.types.deferredModule: Improve reported location`                                           |
| [`38b7709a`](https://github.com/NixOS/nixpkgs/commit/38b7709a6f02ea33fe67220b7ff14fb21ab08e14) | `lib/test/modules.sh: Test deferredModule error location file`                                  |
| [`4746f6d0`](https://github.com/NixOS/nixpkgs/commit/4746f6d03e4f8dc6e7399f45aaba0ca3aac32761) | `lib.types: Add deferredModule`                                                                 |
| [`685e69f7`](https://github.com/NixOS/nixpkgs/commit/685e69f75ca5ad86c433d6886eba4a243aa6ba0a) | `tree-sitter: add tree-sitter-tiger`                                                            |
| [`d79afaff`](https://github.com/NixOS/nixpkgs/commit/d79afaff6a63623477e0747cb5a839e2bda807b7) | `qtscriptgenerator: remove (Qt4)`                                                               |
| [`4ac196b9`](https://github.com/NixOS/nixpkgs/commit/4ac196b95eca02659341f6553a64d3d5e5d237b8) | `hydrus: 487 -> 488d`                                                                           |
| [`8c3222d8`](https://github.com/NixOS/nixpkgs/commit/8c3222d8357d5a9cdc4f8b2b7d4f2c4b89fa55a8) | `libdbusmenu_qt: Remove (Qt4 version)`                                                          |
| [`e4b89d72`](https://github.com/NixOS/nixpkgs/commit/e4b89d723cc1372b4e8158bd53860744b514a548) | `asleap: init at 06-20-2021`                                                                    |
| [`1197151d`](https://github.com/NixOS/nixpkgs/commit/1197151df47f06bf7944e2b573b36f8df69ca895) | `difftastic: 0.28.0 -> 0.29.1`                                                                  |
| [`9ae248d5`](https://github.com/NixOS/nixpkgs/commit/9ae248d5ba3dba5923c9cdda95ac777bce56f92b) | `freeciv: 2.6.6 -> 3.0.1`                                                                       |
| [`3c25c57c`](https://github.com/NixOS/nixpkgs/commit/3c25c57c81d763d6aa6f026f93d8c255c5d97160) | `gnome.ghex: 42.2 -> 42.3`                                                                      |
| [`5a754bdc`](https://github.com/NixOS/nixpkgs/commit/5a754bdc84e7ba0c9e0b728587707d02656b5fa9) | `e16: add update script`                                                                        |
| [`7cc1f2e8`](https://github.com/NixOS/nixpkgs/commit/7cc1f2e8b08bc845cfef9764b712795f30414484) | `pixinsight: 1.8.9 -> 1.8.9-1`                                                                  |
| [`d9cec7d6`](https://github.com/NixOS/nixpkgs/commit/d9cec7d695285300c5f87d6f6b282a22208c8e35) | `wl-clipboard: 2.0.0 -> 2.1.0`                                                                  |
| [`59182da0`](https://github.com/NixOS/nixpkgs/commit/59182da0c7c65177995754ee727c37a91db4f90e) | `qt6Packages.wrapQtAppsHook: fix cross`                                                         |
| [`857208f2`](https://github.com/NixOS/nixpkgs/commit/857208f207e4d6636b3163a74a6afb001b8c5937) | `nvtop: 2.0.1 -> 2.0.2`                                                                         |
| [`cccfcc84`](https://github.com/NixOS/nixpkgs/commit/cccfcc846f05470afeba694d0e1897055c8b4f62) | `ssm-session-manager-plugin: 1.2.312.0 -> 1.2.331.0`                                            |
| [`208c7656`](https://github.com/NixOS/nixpkgs/commit/208c76560adad339346bfad41f839d953085205e) | `uboot: Add makeOverridable for buildUBoot args`                                                |
| [`5344965f`](https://github.com/NixOS/nixpkgs/commit/5344965f8514a5307396ad85afad11816a812cce) | `libsForQt5.wrapQtAppsHook: fix cross`                                                          |
| [`3b958940`](https://github.com/NixOS/nixpkgs/commit/3b95894025ef191d38dc69b242ec8798dd43abe5) | `gtksourceview5: 5.4.1 -> 5.4.2`                                                                |
| [`434130e2`](https://github.com/NixOS/nixpkgs/commit/434130e202cabce8289fb413aac72d6f4aa36c2d) | `gnome-text-editor: 42.1 -> 42.2`                                                               |
| [`dcd55dbd`](https://github.com/NixOS/nixpkgs/commit/dcd55dbd5b9ada2d4b28ee6e82919210906a30b3) | `librewolf: 100.0.2-1 -> 101.0.1-1`                                                             |
| [`2375fac9`](https://github.com/NixOS/nixpkgs/commit/2375fac93dfbf47bc2d0e7679c38fa0154b6a3db) | `nixos/pantheon: treat evince and file-roller as optional app`                                  |
| [`860781d9`](https://github.com/NixOS/nixpkgs/commit/860781d909d3119b32619d8135598bc40816ab15) | `nixos/pantheon: allow disabling pantheon-agent-geoclue2`                                       |
| [`1097e3e8`](https://github.com/NixOS/nixpkgs/commit/1097e3e80c41b9da193cd0b290735d4cd76c4f78) | `nixos/pantheon: make it possible to remove core packages`                                      |
| [`c1559a07`](https://github.com/NixOS/nixpkgs/commit/c1559a07fe071d2c3bae13042bd16a3b7a8ca0f3) | `nixos/pantheon: switch to xdg.icons.enable`                                                    |
| [`9ca889d0`](https://github.com/NixOS/nixpkgs/commit/9ca889d0fb951356f7ad6b41f95f978a8bff8268) | `nixos/pantheon: switch to xdg.mime.enable`                                                     |
| [`f767bee1`](https://github.com/NixOS/nixpkgs/commit/f767bee1f4f8ed5bbd8509cd33e116dd704f187b) | `replace-dependency: fix a syntax error while generating references.nix`                        |
| [`11cc18cd`](https://github.com/NixOS/nixpkgs/commit/11cc18cddd0a1c7aa7c5e008b91696ed8ac5a04e) | `python310Packages.python-rapidjson: unvendor rapidjson`                                        |
| [`92775fc6`](https://github.com/NixOS/nixpkgs/commit/92775fc62fe541d780d89877345e4cb07637132c) | `rapidjson: run tests`                                                                          |
| [`9b015b6c`](https://github.com/NixOS/nixpkgs/commit/9b015b6c16ae725e1b092fc2dfb61db4962a1aad) | `nodePackages: add aws-cdk`                                                                     |
| [`9a41cd62`](https://github.com/NixOS/nixpkgs/commit/9a41cd6236b46ec45670b6c905fc9ebb0b265547) | `mkvtoolnix: 67.0.0 -> 68.0.0`                                                                  |
| [`0df74af7`](https://github.com/NixOS/nixpkgs/commit/0df74af7a913d8b869ba07a44786bfcb964e403b) | `github-runner: 2.292.0 -> 2.293.0`                                                             |
| [`fae6144d`](https://github.com/NixOS/nixpkgs/commit/fae6144d7deac0e42d69661cdfe88e7d62e0cab8) | `vscodium: 1.67.2 -> 1.68.0`                                                                    |
| [`045b2473`](https://github.com/NixOS/nixpkgs/commit/045b2473c154344559165a5ed83dc37a38049f2a) | `gnome_mplayer: add -fcommon workaround`                                                        |
| [`5c525e6d`](https://github.com/NixOS/nixpkgs/commit/5c525e6db0b32161d4dc104ca3bf8a640f719ee2) | `gmtp: add -fcommon workaround`                                                                 |
| [`d3c99294`](https://github.com/NixOS/nixpkgs/commit/d3c992949ed32e02d2e27d5cfd6feb369b259cb0) | `coriander: add -fcommon workaround`                                                            |
| [`6ab28719`](https://github.com/NixOS/nixpkgs/commit/6ab2871989ea231dd5252e679cc5bdf1f78a17d5) | `python3Packages.rdkit: 2020.09.5 -> 2022.03.3`                                                 |
| [`7850afe2`](https://github.com/NixOS/nixpkgs/commit/7850afe2b4e05265afb929b2586aeb5a5280b1c6) | `watson: patch fixing shell completion`                                                         |
| [`6fd94e99`](https://github.com/NixOS/nixpkgs/commit/6fd94e99329b6f4caa519f8a6fe0e36dc9642bf5) | `gimpPlugins.waveletSharpen: add -fcommon workaround`                                           |
| [`ac8d9e9e`](https://github.com/NixOS/nixpkgs/commit/ac8d9e9e013ebb48d2296d8d1f8654f3109cb4d0) | `gimpPlugins.lqrPlugin: pull upstream fix for -fno-common toolchains`                           |
| [`4995a873`](https://github.com/NixOS/nixpkgs/commit/4995a873a796c54cc49e5dca9e1d20350eceec7b) | ` yubikey-agent: 0.1.5 -> unstable-2022-03-17`                                                  |
| [`2f62b09a`](https://github.com/NixOS/nixpkgs/commit/2f62b09ac8975825cfe9f8f383d48e02f52bb1c4) | `giac-with-xcas: fix command to open help inside browser`                                       |