### PR TITLE
chore(flake/nixpkgs): `dd385030` -> `01e4d1a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655342719,
-        "narHash": "sha256-mUUlNMYXK05X082tuZZr1N2goy8UIFq+LkHa+q/5BCU=",
+        "lastModified": 1655385037,
+        "narHash": "sha256-W0vg1Tsaw0yScZYdUvsx9TSZIG/XXtboc9w+BZsSr44=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dd38503071accc7fc9255c431b8acc8623ab58c2",
+        "rev": "01e4d1a67f6062a6c59046dbc4461659ccff8031",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                          |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`01e4d1a6`](https://github.com/NixOS/nixpkgs/commit/01e4d1a67f6062a6c59046dbc4461659ccff8031) | `texlive.combined.basic-scheme: fix $PATH of wrapped scripts (#177826)` |
| [`772d80a0`](https://github.com/NixOS/nixpkgs/commit/772d80a00e2b30c1b667a956cd0ac3feb273552a) | `oh-my-zsh: 2022-06-12 -> 2022-06-15 (#177850)`                         |
| [`bd3e62e1`](https://github.com/NixOS/nixpkgs/commit/bd3e62e1c49cb819e675d53ecc0022d9398a7a27) | `sickgear: 0.25.31 -> 0.25.35`                                          |
| [`a5c1d546`](https://github.com/NixOS/nixpkgs/commit/a5c1d5469b9d2325969a22f32138c1ccc35ec369) | `python310Packages.browser-cookie3: 0.14.3 -> 0.15.0`                   |
| [`1631ddcc`](https://github.com/NixOS/nixpkgs/commit/1631ddcc7d403f4fdb69fa9208c6e47880d6114d) | `python310Packages.cyclonedx-python-lib: 2.5.1 -> 2.5.2`                |
| [`2b615cea`](https://github.com/NixOS/nixpkgs/commit/2b615cea4aee276303be75c47f06f4ba8a39e7a9) | `python310Packages.growattserver: 1.2.0 -> 1.2.2`                       |
| [`f89f79f8`](https://github.com/NixOS/nixpkgs/commit/f89f79f8d55616f4c7270f46ca6a7fe52e4bedbe) | `python310Packages.twilio: 7.9.2 -> 7.9.3`                              |
| [`b24234a2`](https://github.com/NixOS/nixpkgs/commit/b24234a26bc9c6037c6558e8b3ed44d5728c6ed1) | `python310Packages.google-cloud-bigtable: 2.10.0 -> 2.10.1`             |
| [`2c9e5d89`](https://github.com/NixOS/nixpkgs/commit/2c9e5d89e9aaf3194755156a61c91888373f1eb9) | `python310Packages.trytond: 6.4.1 -> 6.4.2`                             |
| [`f244716e`](https://github.com/NixOS/nixpkgs/commit/f244716e58d77a7379cffa38ca77606f6cefd670) | `python310Packages.types-redis: 4.2.6 -> 4.2.7`                         |
| [`ec4cc61e`](https://github.com/NixOS/nixpkgs/commit/ec4cc61ea0c53d7abad06fa1dd6c95aba39622d9) | `internetarchive: 3.0.1 -> 3.0.2`                                       |
| [`26a224f2`](https://github.com/NixOS/nixpkgs/commit/26a224f271d2df8403ae532faaa82ef201a69bbd) | `deno: 1.22.3 -> 1.23.0`                                                |
| [`49cc2c70`](https://github.com/NixOS/nixpkgs/commit/49cc2c709dbc3d37bb09e53bd34335d5ac86c3e1) | `python310Packages.dropbox: 11.31.0 -> 11.32.0`                         |
| [`6f4e895d`](https://github.com/NixOS/nixpkgs/commit/6f4e895d2b7cfe71d5b3a8133bc6e70457546be0) | `appthreat-depscan: 2.1.5 -> 2.1.6`                                     |
| [`d555368b`](https://github.com/NixOS/nixpkgs/commit/d555368b5bb265b8c9c78cb17c283b5bb502a4a8) | `checkov: 2.0.1212 -> 2.0.1217`                                         |
| [`9bf60ad2`](https://github.com/NixOS/nixpkgs/commit/9bf60ad25ec51e38ccaf24d48a194596c2df3ca7) | `python310Packages.pyupgrade: 2.32.1 -> 2.34.0`                         |
| [`499c8b24`](https://github.com/NixOS/nixpkgs/commit/499c8b248412e9f959a228d8278e8ebe1152695d) | `grype: 0.37.0 -> 0.39.0`                                               |
| [`084294c0`](https://github.com/NixOS/nixpkgs/commit/084294c064051a14a24511e62817fbee6de98e52) | `git-lfs: fix cross compile`                                            |
| [`40280704`](https://github.com/NixOS/nixpkgs/commit/402807041adc40950854a38ee6a850f5812ee7ad) | `matrix-synapse: 1.60.0 -> 1.61.0`                                      |
| [`09930077`](https://github.com/NixOS/nixpkgs/commit/099300771f20ac4ee1f3f01a832cfb438a63c9b2) | `pantheon.elementary-settings-daemon: add updateScript`                 |
| [`859f3ff6`](https://github.com/NixOS/nixpkgs/commit/859f3ff6644b479c53e4ff7448297123423dbf83) | `pantheon.elementary-notifications: add updateScript`                   |
| [`0747c659`](https://github.com/NixOS/nixpkgs/commit/0747c65922ec6a6b6ab5bd1de1e282f50fd21bdd) | `pantheon.switchboard: 6.0.1 -> 6.0.2`                                  |
| [`afbe7575`](https://github.com/NixOS/nixpkgs/commit/afbe75751bcf83917e27474c50b41eaa558f4541) | `pantheon.elementary-tasks: 6.2.0 -> 6.3.0`                             |
| [`f3f26e02`](https://github.com/NixOS/nixpkgs/commit/f3f26e026bea24d083c52cacebc3a42fa43b2b84) | `graphqlmap: init at unstable-2022-01-17`                               |
| [`cddf5092`](https://github.com/NixOS/nixpkgs/commit/cddf5092be3eb656f64a3011d958c4d0d050b87e) | `firejail: Remove unused patches`                                       |
| [`2d9f9073`](https://github.com/NixOS/nixpkgs/commit/2d9f9073a4a549f8b934ad85a2606b3bb08c16a4) | `prometheus-blackbox-exporter: 0.20.0 -> 0.21.0`                        |
| [`208af5a5`](https://github.com/NixOS/nixpkgs/commit/208af5a5995a7c5ab8d8e6148bd1bc88e5eb941c) | `arm-trusted-firmware: 2.6 -> 2.7`                                      |