### PR TITLE
chore(flake/nixpkgs): `01e4d1a6` -> `dcaa5dca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655385037,
-        "narHash": "sha256-W0vg1Tsaw0yScZYdUvsx9TSZIG/XXtboc9w+BZsSr44=",
+        "lastModified": 1655470244,
+        "narHash": "sha256-BmcE9Y7UYhk9o82+bfN3wG3XF+/iyC0w+vBVhhNGpw4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01e4d1a67f6062a6c59046dbc4461659ccff8031",
+        "rev": "dcaa5dca4f37d777afaa3b3ff55823d909d3b6cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`4d9b321b`](https://github.com/NixOS/nixpkgs/commit/4d9b321b1a9d2049cf872af58ea4c171571622b5) | `ferdium: init at 6.0.0-nightly.40 (#173582)`                               |
| [`7b1e56ac`](https://github.com/NixOS/nixpkgs/commit/7b1e56acf0674cfc777f47386153e6f5ba9b34a8) | `binaryen: 102 -> 105; emscripten: 3.0.0 -> 3.1.10 (#172741)`               |
| [`a45a5ff4`](https://github.com/NixOS/nixpkgs/commit/a45a5ff4bb182491a2c2d6c099033e45ef0da73f) | `cambalache: 0.10.1 -> 0.10.2`                                              |
| [`b8699bb4`](https://github.com/NixOS/nixpkgs/commit/b8699bb45b46d56f98bab3d54837909ef5343e24) | `vimPlugins.vim-go: update tools list`                                      |
| [`b4c6da2e`](https://github.com/NixOS/nixpkgs/commit/b4c6da2ee5b3a623ef4b834376939e59613ac836) | `gromacs: 2022.1 -> 2022.2`                                                 |
| [`904d737d`](https://github.com/NixOS/nixpkgs/commit/904d737dafed3812b36786f7d26210c9c5755b0c) | `jd-diff-patch: 1.5.1 -> 1.5.2`                                             |
| [`ab8b3a1c`](https://github.com/NixOS/nixpkgs/commit/ab8b3a1c073a90e3c2c59bb9840722a52455da1a) | `mautrix-whatsapp: 0.4.0 -> 0.5.0`                                          |
| [`9ad6fdad`](https://github.com/NixOS/nixpkgs/commit/9ad6fdad45c5fe3b49ee7d8ccd3a2caccc03e80e) | `mitmproxy2swagger: 0.6.0 -> 0.6.1`                                         |
| [`3802c98c`](https://github.com/NixOS/nixpkgs/commit/3802c98cffe636d54dc8f2812d143e50b4b07bb0) | `kubernetes: 1.23.7 -> 1.23.8`                                              |
| [`357cc56f`](https://github.com/NixOS/nixpkgs/commit/357cc56fc7dcbf4265f0e358c4c1d1566e538ab8) | `slurm: 22.05.1 -> 22.05.2`                                                 |
| [`e26e051e`](https://github.com/NixOS/nixpkgs/commit/e26e051e80bb4e00824fc6cfe15c3021eab59f3a) | `rancher: 2.6.4 -> 2.6.5`                                                   |
| [`1d734176`](https://github.com/NixOS/nixpkgs/commit/1d734176ef7b3af01e5cffb07cafcfd13aad09b4) | `pgo-client: 4.7.4 -> 4.7.5`                                                |
| [`61c22491`](https://github.com/NixOS/nixpkgs/commit/61c22491f8448b4b15b948337b3c8ff50b9dc473) | `ddosify: 0.7.9 -> 0.8.0`                                                   |
| [`71075c51`](https://github.com/NixOS/nixpkgs/commit/71075c516a13c63ed495d64e97e6592b14b6d632) | `istioctl: 1.13.3 -> 1.14.1`                                                |
| [`5373332f`](https://github.com/NixOS/nixpkgs/commit/5373332f90e6a50abd0f47c34d0f5aecc2c21cf2) | `argocd: 2.3.4 -> 2.4.0`                                                    |
| [`b159c9ee`](https://github.com/NixOS/nixpkgs/commit/b159c9ee48ea767ade87968d50ef5368947a4a51) | `python310Packages.google-cloud-datastore: 2.7.0 -> 2.7.1`                  |
| [`b9a0ec2a`](https://github.com/NixOS/nixpkgs/commit/b9a0ec2ad2523cbe3663220fb87262806327cab6) | `jmeter: 5.4.3 -> 5.5`                                                      |
| [`91f49b14`](https://github.com/NixOS/nixpkgs/commit/91f49b1420ac8b15d9307ee558c0f9e3095ab8d6) | `k6: 0.37.0 -> 0.38.3`                                                      |
| [`71ed2d5b`](https://github.com/NixOS/nixpkgs/commit/71ed2d5b853e37b305a4544efa033700e36fb324) | `abcmidi: 2022.06.07 -> 2022.06.14`                                         |
| [`c9ba04ce`](https://github.com/NixOS/nixpkgs/commit/c9ba04ce8c6d57c9f6d47a462e9d64d0a589f51c) | `gphotos-sync: 2.14.2 -> 3.04`                                              |
| [`39dff39c`](https://github.com/NixOS/nixpkgs/commit/39dff39cf37ac61825e610166faf6082f8e4db1d) | `python3Packages.types-pyyaml: init at 6.0.8`                               |
| [`aa30d0cb`](https://github.com/NixOS/nixpkgs/commit/aa30d0cb20956c6f171d12d04f69db75b3b91d68) | `cypress: 9.6.0 -> 10.0.3 (#176933)`                                        |
| [`523bed76`](https://github.com/NixOS/nixpkgs/commit/523bed764cb6900d86e2de5e9860c71e15323e1e) | `signal-desktop: 5.45.1 -> 5.46.0`                                          |
| [`abc33c65`](https://github.com/NixOS/nixpkgs/commit/abc33c65fce950cd66a42c5fce08ef9e29524e94) | `clojure: 1.11.1.1129 -> 1.11.1.1139`                                       |
| [`135836b3`](https://github.com/NixOS/nixpkgs/commit/135836b31bd68eec6a02205f2056cfc672301494) | `wxsqliteplus: fix Darwin build`                                            |
| [`abff737e`](https://github.com/NixOS/nixpkgs/commit/abff737e36fa4d556eaec1bc9c216508abc11c9d) | `bochs: mark as broken on Darwin`                                           |
| [`9590fedb`](https://github.com/NixOS/nixpkgs/commit/9590fedbf932773b3b40ef8647a1e63b3342acd3) | `amule,amule-gui: mark as broken on Darwin`                                 |
| [`0b06db69`](https://github.com/NixOS/nixpkgs/commit/0b06db69f50d1d0dace7566c3511225fb494ea50) | `wxSVG: unbreak on Darwin`                                                  |
| [`bf08837c`](https://github.com/NixOS/nixpkgs/commit/bf08837cd6d24fa81e58eb1d30abce55b4a42ba6) | `python310Packages.mkdocs-material: 8.3.5 -> 8.3.6`                         |
| [`a5838877`](https://github.com/NixOS/nixpkgs/commit/a58388770eaceaf735d198c848302aa7088ad23f) | `awscli2: 2.7.3 -> 2.7.8`                                                   |
| [`f4a6eb91`](https://github.com/NixOS/nixpkgs/commit/f4a6eb91b99bf3f11feb9ffa84138c0308888d2b) | `google-play-music-desktop-player: Remove`                                  |
| [`f34a05d9`](https://github.com/NixOS/nixpkgs/commit/f34a05d96f09e55dd6f483a2aa1acb6663866a2a) | `graphw00f: init at 1.1.2`                                                  |
| [`5e4ac43f`](https://github.com/NixOS/nixpkgs/commit/5e4ac43fe54f5b26882801b2dbd1c2317e83eea8) | `mpd-discord-rpc: 1.4.1 -> 1.5.1`                                           |
| [`b3ea03c9`](https://github.com/NixOS/nixpkgs/commit/b3ea03c9026fc96ebca9b2019de773dd654aacd8) | `element-{web,desktop}: 1.10.14 -> 1.10.15`                                 |
| [`56b840f0`](https://github.com/NixOS/nixpkgs/commit/56b840f07baedef3f63cbb7632de8067aac8aa2d) | `vde2: 2.3.2 -> 2.3.3`                                                      |
| [`e8f62e99`](https://github.com/NixOS/nixpkgs/commit/e8f62e992d72768fc0a5df22ff902e53c25bae6a) | `networkmanager: 1.38.0 -> 1.38.2`                                          |
| [`fdb7e381`](https://github.com/NixOS/nixpkgs/commit/fdb7e3812c62bcd327e95bfb2fe23e390df5a928) | `checkov: 2.0.1217 -> 2.0.1218`                                             |
| [`c0481158`](https://github.com/NixOS/nixpkgs/commit/c04811587a7b7537b893e24e796e2dc24e8f4539) | `tfsec: 1.25.1 -> 1.26.0`                                                   |
| [`89fdc639`](https://github.com/NixOS/nixpkgs/commit/89fdc63965178d266653d087b02b795c9e892246) | `Apply suggested changes`                                                   |
| [`94f540dd`](https://github.com/NixOS/nixpkgs/commit/94f540dde4a5b1c81c6dd48d1c5d6a7d5ba9148a) | `mercurial: 6.1.3 -> 6.1.4`                                                 |
| [`1f949558`](https://github.com/NixOS/nixpkgs/commit/1f949558617ebb18bbf7005c1c4dc3407d391e93) | `python3Packages.functorch: add pybind11 as dependency`                     |
| [`605ce577`](https://github.com/NixOS/nixpkgs/commit/605ce577fad5bbc661b58d2f3ca5881f04a6a749) | `python3Packages.pytorch: add pybind11 to buildInputs`                      |
| [`4161b3d1`](https://github.com/NixOS/nixpkgs/commit/4161b3d11f1749122fe71ffa670a4b5a45caf625) | `unity3d: Remove`                                                           |
| [`f78d79d5`](https://github.com/NixOS/nixpkgs/commit/f78d79d578fe8b28e7b3000135b9181e91e6da2b) | `gitkraken: 8.5.0 -> 8.6.0`                                                 |
| [`6ca5cccd`](https://github.com/NixOS/nixpkgs/commit/6ca5cccdca82e916b798eed8d3519cf7ec58fec7) | `gnirehtet: add sourceType binaryBytecode`                                  |
| [`61c35da6`](https://github.com/NixOS/nixpkgs/commit/61c35da6077fe044330ef17ace6f343f21a2a835) | `treewide/servers,tools: add sourceType binaryNativeCode for many packages` |
| [`12eea1c6`](https://github.com/NixOS/nixpkgs/commit/12eea1c636c6da2f2cfdfd2a0c9117a8a5b87086) | `treewide/development: add sourceType binaryNativeCode for many packages`   |
| [`a29f64c2`](https://github.com/NixOS/nixpkgs/commit/a29f64c22f331e1a1c650d4289dd891303c3766e) | `powerdevil: fix brightness wonkiness on some laptops`                      |
| [`201b2712`](https://github.com/NixOS/nixpkgs/commit/201b2712137e221f71a4ae1da37968855831c4ab) | `vimPackages: add some coc packages`                                        |
| [`953d77f6`](https://github.com/NixOS/nixpkgs/commit/953d77f67fc2e383ec9674fa3c8f838cbf819c8d) | `delve: remove restriction from platforms (#177722)`                        |
| [`4c031799`](https://github.com/NixOS/nixpkgs/commit/4c031799bfc6ce97837c307ccbda3ff5aa6efc70) | `live555: 2022.02.07 -> 2022.06.16`                                         |
| [`0ab94d8f`](https://github.com/NixOS/nixpkgs/commit/0ab94d8f77cef10388ef848c719985dac087fd9b) | `gnome.gnome-todo: unstable-2022-05-23 -> unstable-2022-06-12`              |
| [`ee9604ed`](https://github.com/NixOS/nixpkgs/commit/ee9604ed283f30154351050b98904c33520d6b27) | `pip-audit: 2.3.2 -> 2.3.3`                                                 |
| [`f756efc1`](https://github.com/NixOS/nixpkgs/commit/f756efc1440707ea6a1535dabbb7f90ec79a7be9) | `cambalache: Fix Adwaita & Handy support`                                   |
| [`03f60a8e`](https://github.com/NixOS/nixpkgs/commit/03f60a8ed0baf763de6203f72f6699efac895618) | `spire: 1.2.3 -> 1.3.1`                                                     |
| [`ccc38178`](https://github.com/NixOS/nixpkgs/commit/ccc38178bae74acba1174669863b3d951f1a07d2) | `python310Packages.compreffor: 0.5.1.post1 -> 0.5.2`                        |
| [`c6bedda7`](https://github.com/NixOS/nixpkgs/commit/c6bedda7751cae2f6724ca09b175e16944af9f38) | `hypnotix: 2.6 -> 2.7`                                                      |
| [`7230a2d3`](https://github.com/NixOS/nixpkgs/commit/7230a2d399e9fdfa171c31c6e984824393ec32b1) | `arcanist: 20220425 -> 20220517`                                            |
| [`55c9d73f`](https://github.com/NixOS/nixpkgs/commit/55c9d73fb202809491ca0612dcb0e83548339475) | `glances: 3.2.5 -> 3.2.6.4`                                                 |
| [`0ea7608e`](https://github.com/NixOS/nixpkgs/commit/0ea7608eee5be83980eef4449291efd6f0834c8c) | `python310Packages.sqlite-utils: 3.26.1 -> 3.27`                            |
| [`1c92c7f1`](https://github.com/NixOS/nixpkgs/commit/1c92c7f1e8d2af09bca5eac9b2822ca2bca2079a) | `cambalache: 0.8.2 -> 0.10.1`                                               |
| [`22e7607d`](https://github.com/NixOS/nixpkgs/commit/22e7607da591bec58a0edb3d710569e4796cbf97) | ` golangci-lint-langserver: init at 0.0.6  (#177692)`                       |
| [`b3e94ffe`](https://github.com/NixOS/nixpkgs/commit/b3e94ffeed7cbca3b8c7297283e2109f8e78c154) | `python3Packages.mkdocs-material: 8.3.5 -> 8.3.6`                           |
| [`97067007`](https://github.com/NixOS/nixpkgs/commit/97067007a985bfcb3509f0e93486df0f1b0062ef) | `libnma: 1.8.38 -> 1.8.40`                                                  |
| [`4a1b7f4a`](https://github.com/NixOS/nixpkgs/commit/4a1b7f4a6da36d9dd0f02fda08ebad08d8a127e3) | `fish: 3.4.1 -> 3.5.0`                                                      |
| [`e6ef6b68`](https://github.com/NixOS/nixpkgs/commit/e6ef6b680f118cf3140a7ab8544b7f2ce69133e1) | `qosmic: enable on darwin`                                                  |
| [`76a93622`](https://github.com/NixOS/nixpkgs/commit/76a936228ac9ac60d727c80c90079eacc04f6124) | `linuxPackages.system76-io: Fix building on newer kernels.`                 |
| [`73b80e83`](https://github.com/NixOS/nixpkgs/commit/73b80e832e8ce548f0825a954822d40b5cc2ff73) | `grafana: 8.5.5 -> 9.0.0`                                                   |
| [`843b9886`](https://github.com/NixOS/nixpkgs/commit/843b9886800a8e78aaaa01989f1d03cdbf907b88) | `python3: fix wrong platform libs when cross-compiling`                     |
| [`f9763428`](https://github.com/NixOS/nixpkgs/commit/f9763428b4d7fe379a5d6b5fa81ca84cec392291) | `flam3: enable on darwin`                                                   |
| [`b0b2bad5`](https://github.com/NixOS/nixpkgs/commit/b0b2bad54154436d67d1ad909b9bbc10e78e8dc0) | `pdns-recursor: 4.6.2 -> 4.7.0`                                             |
| [`42b39784`](https://github.com/NixOS/nixpkgs/commit/42b397842b63b64e8c7326a77c250d001b4861b7) | `broot: 1.12.0 -> 1.13.1`                                                   |
| [`4a07f05a`](https://github.com/NixOS/nixpkgs/commit/4a07f05af12d29e89643225e812e4850c1637945) | `bfs: 2.3.1 -> 2.6`                                                         |
| [`2125bb51`](https://github.com/NixOS/nixpkgs/commit/2125bb51ebfd393cb56df739e5b888a9a46f15c5) | `monitor: switch to gitUpdater`                                             |
| [`58118479`](https://github.com/NixOS/nixpkgs/commit/5811847961dd59104c5c91bf6ea4ac7fd3b7900c) | `monitor: 0.13.0 -> 0.14.0`                                                 |
| [`a6ada039`](https://github.com/NixOS/nixpkgs/commit/a6ada039e162ef407804a4d3bec595413dbb8ddf) | `python310Packages.cloup: 0.14.0 -> 0.15.0`                                 |
| [`8289230b`](https://github.com/NixOS/nixpkgs/commit/8289230b47ca120e72d3d36515fb961e11bea764) | `gama: 2.17 -> 2.19`                                                        |
| [`fb273f21`](https://github.com/NixOS/nixpkgs/commit/fb273f2144f75e0980bc3fd7253ea299eb836905) | `linux/hardened/patches/5.4: 5.4.197-hardened1 -> 5.4.198-hardened1`        |
| [`96aa98b3`](https://github.com/NixOS/nixpkgs/commit/96aa98b34ea727c8744fc9270a25871cc6abc27b) | `linux/hardened/patches/5.17: 5.17.14-hardened1 -> 5.17.15-hardened1`       |
| [`b728110e`](https://github.com/NixOS/nixpkgs/commit/b728110e621853965caa7597adc84621ebd9c6a5) | `linux/hardened/patches/5.15: 5.15.46-hardened1 -> 5.15.47-hardened1`       |
| [`638b8265`](https://github.com/NixOS/nixpkgs/commit/638b826560301d99bea35a3c769d15f88f04dce2) | `linux/hardened/patches/5.10: 5.10.121-hardened1 -> 5.10.122-hardened1`     |
| [`2f5d73c7`](https://github.com/NixOS/nixpkgs/commit/2f5d73c7c826958990aec44aca4dac294560cd98) | `linux/hardened/patches/4.19: 4.19.246-hardened1 -> 4.19.247-hardened1`     |
| [`f66c3eec`](https://github.com/NixOS/nixpkgs/commit/f66c3eec69385459962c99187b0481eb814e6977) | `linux/hardened/patches/4.14: 4.14.282-hardened1 -> 4.14.283-hardened1`     |
| [`47f2c949`](https://github.com/NixOS/nixpkgs/commit/47f2c949b1dbd7e31e8f67bd07c3804c6cac2f1e) | `linux: 5.4.197 -> 5.4.198`                                                 |
| [`c06fe392`](https://github.com/NixOS/nixpkgs/commit/c06fe392cf88878aceec9092598946ffcbc377ad) | `linux: 5.18.3 -> 5.18.4`                                                   |
| [`e58ad1f6`](https://github.com/NixOS/nixpkgs/commit/e58ad1f6c8738d12a8ae95ab2d082cd26b1f9838) | `linux: 5.17.14 -> 5.17.15`                                                 |
| [`66f0feca`](https://github.com/NixOS/nixpkgs/commit/66f0feca1407a939aca93fc54e8651da5ac2bdca) | `linux: 5.15.46 -> 5.15.47`                                                 |
| [`b2f19ab3`](https://github.com/NixOS/nixpkgs/commit/b2f19ab3b567fd46a0f8b45f4b4c88fdbddac72f) | `graalvmXX-ce: use a patched version of zlib`                               |
| [`2aabaf7e`](https://github.com/NixOS/nixpkgs/commit/2aabaf7e8aee4c8ec2a5a36da681667fa9c06e9d) | `linux: 5.10.121 -> 5.10.122`                                               |
| [`685043bb`](https://github.com/NixOS/nixpkgs/commit/685043bbe96cfffd68c491b505ff175a6c375d37) | `linux: 4.9.317 -> 4.9.318`                                                 |
| [`de6b615a`](https://github.com/NixOS/nixpkgs/commit/de6b615add4e88816cd6b5d880f6cc56d657e5ab) | `linux: 4.19.246 -> 4.19.247`                                               |
| [`783c3d65`](https://github.com/NixOS/nixpkgs/commit/783c3d65ef4e4ea481b009053734187f72d08efb) | `linux: 4.14.282 -> 4.14.283`                                               |
| [`dfaff84f`](https://github.com/NixOS/nixpkgs/commit/dfaff84f2009ef429d0f33230b461a371b0e83a8) | `jc: 1.20.0 -> 1.20.1`                                                      |
| [`9cbc088f`](https://github.com/NixOS/nixpkgs/commit/9cbc088f3533c5b6e347d488a38dd11963e67ac0) | `python310Packages.pyenvisalink: 4.4 -> 4.5`                                |
| [`26742b37`](https://github.com/NixOS/nixpkgs/commit/26742b37dc8bdd1e9d1525f51828e0f0894c9be9) | `sketchybar: 2.5.2 -> 2.7.1`                                                |
| [`adb98d3d`](https://github.com/NixOS/nixpkgs/commit/adb98d3d97d7259550819d78d5ad0a4928ad3cf9) | `all-packages: add androguard`                                              |
| [`3eb7835a`](https://github.com/NixOS/nixpkgs/commit/3eb7835a7259332968f0b054111e92a42a0442e4) | `exoscale-cli: 1.56.0 -> 1.57.0`                                            |
| [`651e6fcb`](https://github.com/NixOS/nixpkgs/commit/651e6fcb1635053f74813fa809d40b02c20598c8) | `nix-doc: 0.5.4->0.5.5`                                                     |
| [`a0f7526c`](https://github.com/NixOS/nixpkgs/commit/a0f7526c81aee8b531019abae7ef81bf63bb015c) | `nodejs-18_x: 18.3.0 -> 18.4.0`                                             |
| [`959f75c3`](https://github.com/NixOS/nixpkgs/commit/959f75c31eeb16bf883b208237f06ed1e55d0b93) | `starship: 1.7.1 -> 1.8.0`                                                  |
| [`be59322d`](https://github.com/NixOS/nixpkgs/commit/be59322dae6052732047b2dea449de2c51255a37) | `esphome: 2022.5.1 -> 2022.6.0`                                             |
| [`d3044968`](https://github.com/NixOS/nixpkgs/commit/d304496834944199a1e33973007b144171eea493) | ` wxGTK30-gtk2,wxGTK30-gtk3: add missing buildInput on Darwin`              |
| [`ad692ef6`](https://github.com/NixOS/nixpkgs/commit/ad692ef645e83b63c1e4df19fce9806c5d0fc238) | `quick-lint-js: 2.5.0 -> 2.6.0`                                             |
| [`6c6c83ad`](https://github.com/NixOS/nixpkgs/commit/6c6c83ade904f927679848577d5b5cb84692f4d7) | `terraform-providers.b2: remove`                                            |
| [`d508503f`](https://github.com/NixOS/nixpkgs/commit/d508503f4def68657658e4a96d42cc03216c912f) | `jwt-hack: init at 1.1.2`                                                   |
| [`e7313b22`](https://github.com/NixOS/nixpkgs/commit/e7313b2243afae97843352696bf1eca4fc6a8ef0) | `k3s: 1.23.6+k3s1 -> 1.24.1+k3s1`                                           |
| [`a6a0c447`](https://github.com/NixOS/nixpkgs/commit/a6a0c4476025ed54e26d82f99d36739793b4db3c) | `k3s: remove docker support`                                                |
| [`03ce061c`](https://github.com/NixOS/nixpkgs/commit/03ce061cec6f19e46da3416bac2c2e595ba6fb4d) | `pgcli: make it a package rather than an application`                       |
| [`00fc0c5a`](https://github.com/NixOS/nixpkgs/commit/00fc0c5abaf9532105a9c22e5fa803ce157c9538) | `python310Packages.google-cloud-firestore: 2.5.2 -> 2.5.3`                  |
| [`c07011d3`](https://github.com/NixOS/nixpkgs/commit/c07011d3c01acbc3a0459af6ff05c29347e604e2) | `xlogo: init at 1.0.5`                                                      |
| [`347f24aa`](https://github.com/NixOS/nixpkgs/commit/347f24aa43dbb1a43d9ce43a418d8fd13b951aa9) | `xorg-autoconf: init at 1.19.3`                                             |
| [`00e2f8e6`](https://github.com/NixOS/nixpkgs/commit/00e2f8e63c101b1089611b41eb0b50e52cc39d52) | `haruna: 0.7.3 -> 0.8.0`                                                    |
| [`d4954f4b`](https://github.com/NixOS/nixpkgs/commit/d4954f4bd1b095886ea619efa45075bc4f5b4619) | `stride: Remove`                                                            |
| [`15ba2dcf`](https://github.com/NixOS/nixpkgs/commit/15ba2dcfe81e8ba2277b0c93c95637b4fab7d1ac) | `python310Packages.injector: 0.19.0 -> 0.20.0`                              |
| [`5684a598`](https://github.com/NixOS/nixpkgs/commit/5684a598cd3b225c4d8f6d42712788f46d8b87a3) | `commix: init at 3.4`                                                       |
| [`821ac01d`](https://github.com/NixOS/nixpkgs/commit/821ac01d3d14d8eafcd88d7ea50441ff35d87c6a) | `kstars: 3.5.8 -> 3.5.9`                                                    |
| [`e7c89813`](https://github.com/NixOS/nixpkgs/commit/e7c8981392a62aabc72cbb1dea302f76636fddae) | `git-machete: 3.10.0 -> 3.10.1`                                             |
| [`41cc697f`](https://github.com/NixOS/nixpkgs/commit/41cc697fddda60ec1e7a2de08db1661c00f75cc6) | `sx: migrate to resholve.mkDerivation`                                      |
| [`d705a5c8`](https://github.com/NixOS/nixpkgs/commit/d705a5c8c6ee23db650a986a9b6ad2b6ecb7f6a7) | `snipe-it: 6.0.2 -> 6.0.4`                                                  |
| [`0a8f89e2`](https://github.com/NixOS/nixpkgs/commit/0a8f89e23e278a8314f91295555a618a0e39c22e) | `nginxModules.modsecurity-nginx: 1.0.2 -> 1.0.3`                            |
| [`c64d9a23`](https://github.com/NixOS/nixpkgs/commit/c64d9a23c7e5dd5dc34b5ddd39d73e47089de283) | `libmodsecurity: 3.0.6 -> 3.0.7`                                            |
| [`04f20b92`](https://github.com/NixOS/nixpkgs/commit/04f20b9290308fbe9434fb0221ffdaf5a2b0025f) | `python3Packages.schwifty: init at 2022.6.0`                                |
| [`e2fd1742`](https://github.com/NixOS/nixpkgs/commit/e2fd1742616e5f3c5208e11210dee08b0d977ce4) | `syncthing: 1.20.1 -> 1.20.2`                                               |
| [`9a10ab2b`](https://github.com/NixOS/nixpkgs/commit/9a10ab2b3cac87b483e28fb28c0eec85ae9a0eab) | `blender: 3.1.0 -> 3.2.0`                                                   |
| [`a1f1122a`](https://github.com/NixOS/nixpkgs/commit/a1f1122afb8469d976e2e6af23fe9e50041145ad) | `PageEdit: 1.7.0 -> 1.9.10`                                                 |
| [`bac638e7`](https://github.com/NixOS/nixpkgs/commit/bac638e75b0750f317a19cf0865330b4365b047c) | `knot-resolver: 5.5.0 -> 5.5.1`                                             |
| [`a95a5fa5`](https://github.com/NixOS/nixpkgs/commit/a95a5fa55595d490c6819afcd08211c3f60d454f) | `super-productivity: 7.10.1 -> 7.11.5`                                      |
| [`f97b60d4`](https://github.com/NixOS/nixpkgs/commit/f97b60d47b85e1e7d7752915ef98a2e54336735e) | `jellyfin-media-player: 1.6.1 -> 1.7.0`                                     |
| [`bcc1b276`](https://github.com/NixOS/nixpkgs/commit/bcc1b27645c88202c71531a16e6eebdd2fd576fb) | `partio: 2018-03-01 -> 1.14.6`                                              |
| [`be0081f6`](https://github.com/NixOS/nixpkgs/commit/be0081f66fb62edc6fc236cad8c987c2d2707b68) | `netbeans: 13 -> 14`                                                        |
| [`faacc88c`](https://github.com/NixOS/nixpkgs/commit/faacc88c93086982e2c95708176863f415e03810) | `munge: fix cross compilation`                                              |
| [`3da65d09`](https://github.com/NixOS/nixpkgs/commit/3da65d0955d2e5d76ee9d7e24ada9e6fc86ea60a) | `smpeg2: unstable-2017-10-18 -> unstable-2022-05-26`                        |
| [`ad5243d9`](https://github.com/NixOS/nixpkgs/commit/ad5243d94041b3618c10f51833e7e9e68f45a673) | `smpeg: 390 -> 0.4.5`                                                       |
| [`6449d45e`](https://github.com/NixOS/nixpkgs/commit/6449d45e25661722127fd19819992201c15b79ee) | `Delete unused release-notes.xml`                                           |
| [`9fc90429`](https://github.com/NixOS/nixpkgs/commit/9fc90429c3bdc4c1d800777b0ba61c325dfb8e0f) | `treewide/games,misc: add sourceType binaryNativeCode for many packages`    |
| [`b0a641eb`](https://github.com/NixOS/nixpkgs/commit/b0a641eb0189c4c51f1c039981d15c3ba2d0ce65) | `zotero: 6.0.4 -> 6.0.8`                                                    |
| [`572ffd45`](https://github.com/NixOS/nixpkgs/commit/572ffd4513aefc4c04143f8a6be2c294a06c07c6) | `dendrite: 0.8.7 -> 0.8.8`                                                  |
| [`0a6632d6`](https://github.com/NixOS/nixpkgs/commit/0a6632d654ed220dce1f7eed03e3e13e4a51e0db) | `flacon: 7.0.1 -> 9.0.0`                                                    |
| [`8dd18c10`](https://github.com/NixOS/nixpkgs/commit/8dd18c109013d8cb7ffff5ecbf4a13cd6d02f00b) | `plik: 1.3.4 -> 1.3.6`                                                      |
| [`1661ce82`](https://github.com/NixOS/nixpkgs/commit/1661ce8227f568dbb97c0ee86c755b911e1ac96e) | `vscode-extensions.njpwerner.autodocstring: init at 6.0.1`                  |
| [`c5384006`](https://github.com/NixOS/nixpkgs/commit/c53840067c489898bf34229924de5f0350bd7eee) | `juju: 2.9.27 -> 2.9.31`                                                    |
| [`aa4fe119`](https://github.com/NixOS/nixpkgs/commit/aa4fe119c54e6850e72f236aece4166a3039abaa) | `pipelight: Fix build with wine-7.10`                                       |
| [`d90ca916`](https://github.com/NixOS/nixpkgs/commit/d90ca9162d1216e34ad65ae05547fd1e3bf5393c) | `wine{Unstable,Staging}: 7.9 -> 7.10`                                       |