### PR TITLE
chore(flake/nixpkgs): `dcaa5dca` -> `b2537dc4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655470244,
-        "narHash": "sha256-BmcE9Y7UYhk9o82+bfN3wG3XF+/iyC0w+vBVhhNGpw4=",
+        "lastModified": 1655509053,
+        "narHash": "sha256-cnAi69IwgyDFyP9fg6UaDYCfQLs6GNZb1juflVVrq8Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dcaa5dca4f37d777afaa3b3ff55823d909d3b6cf",
+        "rev": "b2537dc4307c79b5ec21bf699a6892ba65057250",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`2a8bf977`](https://github.com/NixOS/nixpkgs/commit/2a8bf9777d790bc4a0bc77e523609f1d40694d5b) | `nixos/ipfs: do not leak config to journal on startup`                                     |
| [`e449ba23`](https://github.com/NixOS/nixpkgs/commit/e449ba23baeb934a645fa1b791e704c0db0fc9db) | `groovy: 3.0.7 -> 3.0.11`                                                                  |
| [`f597e7e9`](https://github.com/NixOS/nixpkgs/commit/f597e7e9fcf37d8ed14a12835ede0a7d362314bd) | `alarm-clock-applet: remove (#177921)`                                                     |
| [`34c91d44`](https://github.com/NixOS/nixpkgs/commit/34c91d44c8acc52a6b0eefbf378df48250590494) | `kdigger: init at 1.2.0`                                                                   |
| [`add5c4f4`](https://github.com/NixOS/nixpkgs/commit/add5c4f47032737a8c9c5bbbb36722b004826e7b) | `python310Packages.xhtml2pdf: 0.2.7 -> 0.2.8`                                              |
| [`391a9229`](https://github.com/NixOS/nixpkgs/commit/391a92291002228396cea579524d2fe30b96c63d) | `python310Packages.google-cloud-spanner: 3.14.1 -> 3.15.0`                                 |
| [`bce0ac2d`](https://github.com/NixOS/nixpkgs/commit/bce0ac2d35868933232196308e5d5425672dfbb9) | `linuxPackages.system76-io: 1.0.1 -> 1.0.2`                                                |
| [`c9507b99`](https://github.com/NixOS/nixpkgs/commit/c9507b994f39b69635ed43b918ebc75ac84e707b) | ``iam-policy-json-to-terraform: Init at `1.8.0` (#178035)``                                |
| [`892470bb`](https://github.com/NixOS/nixpkgs/commit/892470bb4e5dee0c4efd3190a4505250a8086e95) | `python310Packages.sagemaker: 2.94.0 -> 2.95.0`                                            |
| [`64a5efe9`](https://github.com/NixOS/nixpkgs/commit/64a5efe9fa5f0f18c9c388b61e49bdcf51c68009) | `python310Packages.qiskit-finance: 0.3.1 -> 0.3.2`                                         |
| [`9428de37`](https://github.com/NixOS/nixpkgs/commit/9428de37607cddb3a0a1aa66a6649eecae65224c) | `python310Packages.yfinance: 0.1.70 -> 0.1.72`                                             |
| [`a78297f5`](https://github.com/NixOS/nixpkgs/commit/a78297f569a8910f3fd104519f5400aa53673d93) | `wxmaxima: 22.03.0 -> 22.05.0 (#177610)`                                                   |
| [`157c09a6`](https://github.com/NixOS/nixpkgs/commit/157c09a642f4c5f5cf94420bf0de53bed832914b) | `open-policy-agent: 0.40.0 -> 0.41.0`                                                      |
| [`15b3e885`](https://github.com/NixOS/nixpkgs/commit/15b3e88502c65b43f3a9ebd4fbbcfbdfa88991e8) | `python310Packages.apycula: 0.3.1 -> 0.4`                                                  |
| [`7e2a357e`](https://github.com/NixOS/nixpkgs/commit/7e2a357edbea07debf27703d713c900fc6e8654c) | `nixos/tests/fcitx: disable`                                                               |
| [`92d877ae`](https://github.com/NixOS/nixpkgs/commit/92d877aec36df7cb10326151c12f5e2287749590) | `nmap-formatter: 0.3.0 -> 1.0.2`                                                           |
| [`103a4c0a`](https://github.com/NixOS/nixpkgs/commit/103a4c0ae46afa9cf008c30744175315ca38e9f9) | `python310Packages.django-filter: 21.1 -> 22.1`                                            |
| [`0ff099b5`](https://github.com/NixOS/nixpkgs/commit/0ff099b544015e1d6fe7047a6547ab7bba05a461) | `python310Packages.pysigma-pipeline-windows: 0.1.0 -> 0.1.1`                               |
| [`2e090e0d`](https://github.com/NixOS/nixpkgs/commit/2e090e0d601fa758ed403471ac29032e1e6bd39b) | `nixos/lxc-container: improve template example`                                            |
| [`47fa54a9`](https://github.com/NixOS/nixpkgs/commit/47fa54a96ce321dc53cba99ed5dfbb4880a097d0) | `sublime-merge-dev: 2070 → 2073`                                                           |
| [`12c0242d`](https://github.com/NixOS/nixpkgs/commit/12c0242db8dacceb05061dd83a67d77104e1c402) | `sublime-merge: 2071 → 2074`                                                               |
| [`0659ae11`](https://github.com/NixOS/nixpkgs/commit/0659ae1113cea87fd0fe652afe17469e29c1f0ab) | `ntfy-sh: 1.25.2 -> 1.26.0`                                                                |
| [`4f04c969`](https://github.com/NixOS/nixpkgs/commit/4f04c969ace9c235f972ad6877019aa407973c64) | `kubescape: 2.0.156 -> 2.0.158`                                                            |
| [`3b11bd88`](https://github.com/NixOS/nixpkgs/commit/3b11bd8857a639372ca34d0a13f6b5145e024e09) | `awless: remove`                                                                           |
| [`8dd255b8`](https://github.com/NixOS/nixpkgs/commit/8dd255b886d2bd73ec41ebc671966dea8578a68f) | `gimp: 2.10.30 → 2.10.32`                                                                  |
| [`206a9575`](https://github.com/NixOS/nixpkgs/commit/206a9575b873efc47d03a2f3804ae323079637b7) | `python3Packages.pytorch: unbreak on Darwin (#177812)`                                     |
| [`9426ebcb`](https://github.com/NixOS/nixpkgs/commit/9426ebcb82817975c49d97b5508a69a5bdef3459) | `intel-media-driver: 22.4.2 -> 22.4.3`                                                     |
| [`c74e472c`](https://github.com/NixOS/nixpkgs/commit/c74e472c014bb07c4b2036377dda0e6f7984225c) | `fly: 7.8.0 -> 7.8.1`                                                                      |
| [`1f95c493`](https://github.com/NixOS/nixpkgs/commit/1f95c49331340a06553ff78a12031a291113a23c) | `RStudio: 1.4.1717 -> 2022.02.3+492 (#177021)`                                             |
| [`b9360e09`](https://github.com/NixOS/nixpkgs/commit/b9360e09aa110e0d5b566e64dc68e4d99c1d5fc2) | `n8n: 0.181.2 → 0.182.1`                                                                   |
| [`e7688930`](https://github.com/NixOS/nixpkgs/commit/e768893052bcba2f85c41f30cfbdbd647f76b590) | `mailmanPackages.hyperkitty: fix build`                                                    |
| [`2a1fddab`](https://github.com/NixOS/nixpkgs/commit/2a1fddab4774c509cd883ac14557156f1eb4fce0) | `upower: Add test dependencies`                                                            |
| [`86378514`](https://github.com/NixOS/nixpkgs/commit/863785142fba44a03b78bb852dcc5612bb010194) | `haskellPackages: mark builds failing on hydra as broken`                                  |
| [`acddbace`](https://github.com/NixOS/nixpkgs/commit/acddbacee4ccffb0bcd86ccfbacf4df78f0dbddb) | `conftest: 0.32.0 -> 0.32.1`                                                               |
| [`0ada41cd`](https://github.com/NixOS/nixpkgs/commit/0ada41cd5266dbe98cfdee2780707a6c20355c29) | `HentaiAtHome: use default JDK with ZGC support`                                           |
| [`1a3b6f20`](https://github.com/NixOS/nixpkgs/commit/1a3b6f206d8c5ff2770c4e6d02638c1844d5555f) | `haskellPackages: mark builds failing on hydra as broken`                                  |
| [`d0af7c06`](https://github.com/NixOS/nixpkgs/commit/d0af7c06ac557e3bd12bc9b73ea8ed68f65b1da2) | `gollum: fix shebang in bin/gollum`                                                        |
| [`432ddab2`](https://github.com/NixOS/nixpkgs/commit/432ddab26f5499b6fd6ac10bcaebbc0904d3ed4b) | `openmolcas: 22.02 -> 22.06`                                                               |
| [`be0e2db8`](https://github.com/NixOS/nixpkgs/commit/be0e2db8b9770f6fabdfca41eb9a0cd8b47b049d) | `nixos/gollum: add option local-time`                                                      |
| [`9434ac09`](https://github.com/NixOS/nixpkgs/commit/9434ac09635cd569733f1320c287ff7371f5b2a5) | `nixos/gollum: improve description of user-icons option`                                   |
| [`bed5ba35`](https://github.com/NixOS/nixpkgs/commit/bed5ba3529343adf26f510afceb50beefa50c818) | `gollum: 5.2.3 → 5.3.0`                                                                    |
| [`3624bb53`](https://github.com/NixOS/nixpkgs/commit/3624bb535f6982e83893f78a57a0770ebb8c672b) | `nixosTests.convos: Fix missing port variable`                                             |
| [`2c8bbf33`](https://github.com/NixOS/nixpkgs/commit/2c8bbf33fd84d2fd9de70d66c1f50ac1b6123dd8) | `nixos/test-driver: Support mypy through regular mechanisms`                               |
| [`529de76e`](https://github.com/NixOS/nixpkgs/commit/529de76e8aae5a94ed217117c0f1b532dbf692cd) | `tamarin-prover: remove darwin from hydraPlatforms`                                        |
| [`152736d3`](https://github.com/NixOS/nixpkgs/commit/152736d39eeee7ff91274cb3cfe506b4611a37ac) | `nixosTests.acme: Fix typechecking, avoiding type reassignment`                            |
| [`9d037cf4`](https://github.com/NixOS/nixpkgs/commit/9d037cf43f6cffc12f8277d0209840424b9d9541) | `haskellPackages.jsaddle-hello: mark broken on darwin`                                     |
| [`d88758ce`](https://github.com/NixOS/nixpkgs/commit/d88758ce702e5f32107a28d4d3f18dc6ab1de0e4) | `linkerd_edge: 22.2.4 -> 22.6.1`                                                           |
| [`f318e8f0`](https://github.com/NixOS/nixpkgs/commit/f318e8f0746f1a875445fa7f9a008c1eb74b76d8) | `linkerd: 2.11.1 -> 2.11.2`                                                                |
| [`f967570b`](https://github.com/NixOS/nixpkgs/commit/f967570b615d325388cbef618df572df6bd8cac2) | `haskellPackages: mark builds failing on hydra as broken`                                  |
| [`f6c8e961`](https://github.com/NixOS/nixpkgs/commit/f6c8e9619d199cf6bb6e336677f9d20f7a239f17) | `kn: 1.4.0 -> 1.5.0`                                                                       |
| [`43748389`](https://github.com/NixOS/nixpkgs/commit/4374838973661df59bbb1d4586f90fe0e8614493) | `haskellPackages: regenerate package set based on current config`                          |
| [`58a089bf`](https://github.com/NixOS/nixpkgs/commit/58a089bf4a6bf9a3cdfff81092a8d0dd2b34334f) | `haskellPackages.hnix: small refactoring of overrides`                                     |
| [`72d13e64`](https://github.com/NixOS/nixpkgs/commit/72d13e648d37ef23e3855daa49bd53304cef26e0) | `image_optim: 0.26.3 -> 0.31.1`                                                            |
| [`31a2d6b5`](https://github.com/NixOS/nixpkgs/commit/31a2d6b55857e2904c6505bca5c2c94d1fc912f9) | `haskellPackages: use hnix-store 0.5 for hnix`                                             |
| [`268caaa8`](https://github.com/NixOS/nixpkgs/commit/268caaa8effb27228beed37824b690cd0c6c9749) | `haskellPackages: update packages maintained by sorki`                                     |
| [`4f2e1f2e`](https://github.com/NixOS/nixpkgs/commit/4f2e1f2e748994d56e17812a3465a537e08f0e8a) | `mongodb-compass: 1.31.2 -> 1.32.2`                                                        |
| [`902603d5`](https://github.com/NixOS/nixpkgs/commit/902603d50f45e2ba1f96b90bb9f6eae9d339a7be) | `mongodb-tools: 100.5.2 -> 100.5.3`                                                        |
| [`a77271aa`](https://github.com/NixOS/nixpkgs/commit/a77271aae717e8813097e1c5469ee2de1d96a083) | ``swayidle: fix the path to `sh```                                                         |
| [`eb746128`](https://github.com/NixOS/nixpkgs/commit/eb7461286a3c9b28f3d969e3f87c5a3ae8c29eae) | `saleae-logic-2: 2.3.53 -> 2.3.55`                                                         |
| [`089d7e39`](https://github.com/NixOS/nixpkgs/commit/089d7e3941cb7baccfb3f1c9cd6ec8fd8f703d14) | `linux_zen: 5.18.1-zen1 -> 5.18.5-zen1`                                                    |
| [`1a0d8eeb`](https://github.com/NixOS/nixpkgs/commit/1a0d8eebd7d0322343985768e8526513e883e8ea) | `vscodium: 1.68.0 -> 1.68.1`                                                               |
| [`d6b6545c`](https://github.com/NixOS/nixpkgs/commit/d6b6545c9b2f6491d822c07a5e9ef632f566c329) | `sokol: init at unstable-2022-06-13`                                                       |
| [`3e4d46ba`](https://github.com/NixOS/nixpkgs/commit/3e4d46ba0abbfeed91f0aa8478ec480cafe1e758) | `dawn: init at 3.91a`                                                                      |
| [`1ec563dd`](https://github.com/NixOS/nixpkgs/commit/1ec563dd0a9daa2731d5daf5685ccb0e685420a4) | `monocypher: init at 3.1.3`                                                                |
| [`6d1ce6d1`](https://github.com/NixOS/nixpkgs/commit/6d1ce6d1fdc5390a92d93d79e1bd0a15a6bb3c9b) | `adenum: init at unstable-2022-04-01`                                                      |
| [`95961f89`](https://github.com/NixOS/nixpkgs/commit/95961f8927ba83bcba907b0fc1b59ffad879f2ee) | `rivercarro: 0.1.2 -> 0.1.4`                                                               |
| [`beb073b4`](https://github.com/NixOS/nixpkgs/commit/beb073b41fb3db83d2e3c758e65f1df6082448ba) | `maintainers: add jonnybolton`                                                             |
| [`d1daa641`](https://github.com/NixOS/nixpkgs/commit/d1daa6417e201747b25354a4cb10ee22f57d7a37) | `waydroid: 1.2.0 -> 1.2.1`                                                                 |
| [`7bdd443f`](https://github.com/NixOS/nixpkgs/commit/7bdd443f38c4112efcc197e75ea8747a30e490c0) | `haskellPackages: unbreak autodocoded, validity-aeson`                                     |
| [`715166e0`](https://github.com/NixOS/nixpkgs/commit/715166e09d02f53d89acdaa5bb4ebcc945436b44) | `python310Packages.azure-mgmt-netapp: 7.0.0 -> 8.0.0`                                      |
| [`0157a871`](https://github.com/NixOS/nixpkgs/commit/0157a871033eb0227ac1ef6803f3ae99a5bdef0d) | `plasma-overdose-kde-theme: init at unstable-2022-05-30`                                   |
| [`7d883da2`](https://github.com/NixOS/nixpkgs/commit/7d883da22ad7c804fbc138652f868abfe60b0300) | `calibre: fix chm processing dependency`                                                   |
| [`a07a6083`](https://github.com/NixOS/nixpkgs/commit/a07a6083423962a27c936940e6f6c75be9fac469) | `pythonPackages.pychm,python3Packages.pychm: init at 0.8.6`                                |
| [`bdf134d0`](https://github.com/NixOS/nixpkgs/commit/bdf134d02e5d1ebb9d04b42712c86c106f262d29) | `gotktrix: add desktop file`                                                               |
| [`8f138ea9`](https://github.com/NixOS/nixpkgs/commit/8f138ea937396a4ece4ae2cb977c06e50502eff9) | `dagger: 0.2.18 -> 0.2.19`                                                                 |
| [`58b2655b`](https://github.com/NixOS/nixpkgs/commit/58b2655b4c2dfe990aa8147e247e617ad5dae085) | `vscode: 1.68.0 -> 1.68.1`                                                                 |
| [`2457c2ab`](https://github.com/NixOS/nixpkgs/commit/2457c2ab9a725ee319317b434ea2d3449f8c6e08) | `linuxPackages.rtw88: 2022-05-08 to 2022-06-03`                                            |
| [`088aa5b0`](https://github.com/NixOS/nixpkgs/commit/088aa5b021ce36bbeeecfbf18e9834c9b5319448) | `authenticator: 4.1.4 -> 4.1.6`                                                            |
| [`386a1ed0`](https://github.com/NixOS/nixpkgs/commit/386a1ed0752d3cb885a34b4c91d6500b06caf552) | `haskellPackages.large-hashable: 2021-11-01 -> 2022-06-10`                                 |
| [`8c77993d`](https://github.com/NixOS/nixpkgs/commit/8c77993daf675ca3fb00ee0bd85a8ab95f27fc93) | `haskell.packages.ghcjs.ghcjs-base: 0.2.0.3 → 0.2.1.0`                                     |
| [`80798d3a`](https://github.com/NixOS/nixpkgs/commit/80798d3a6d0ca9b4105ba43e9a92c6de599199c9) | `certbot: 1.24.0 -> 1.28.0`                                                                |
| [`6a7744bc`](https://github.com/NixOS/nixpkgs/commit/6a7744bc4166eb65ea9d606582ec55c345118c66) | `haskellPackages.jsaddle-warp: no longer broken`                                           |
| [`a0c9b8b4`](https://github.com/NixOS/nixpkgs/commit/a0c9b8b4fae3e56c1ed7ae6a45d5a3979aca763b) | `gnome.nautilus-python: add -fcommon workaround`                                           |
| [`742dfb63`](https://github.com/NixOS/nixpkgs/commit/742dfb63ae8e17dd51a5090bf5f1b1d56a61498a) | `haskellPackages.lvmrun: mark as proken`                                                   |
| [`ae2d8278`](https://github.com/NixOS/nixpkgs/commit/ae2d8278061209e7fa14fe8767c9e9a99927b22b) | `spaceFM: add -fcommon workaround`                                                         |
| [`8fc1c425`](https://github.com/NixOS/nixpkgs/commit/8fc1c4255f383937ef60c06a3365b2bce427befe) | `garden-of-coloured-lights: add -fcommon workaround`                                       |
| [`1cc20264`](https://github.com/NixOS/nixpkgs/commit/1cc2026421f1d31079bc94bb1cce16fdc4bb032c) | `upower: 0.99.17 → 0.99.19`                                                                |
| [`7593e005`](https://github.com/NixOS/nixpkgs/commit/7593e005e12013734a6db87b38bafa5aedcfbc56) | `vinagre: pull fix pending upstream inclusiong for -fno-common toolchain support`          |
| [`27d3d3bb`](https://github.com/NixOS/nixpkgs/commit/27d3d3bb04718ba356e758a4329774f1df237594) | `megaglest: pull upstream fix for -fno-common toolchains`                                  |
| [`81b8cb86`](https://github.com/NixOS/nixpkgs/commit/81b8cb86244a877304c0a066bce688c9db52950f) | `haskell.packages.ghcjs.ghcjs-base: fix build`                                             |
| [`24fc52a1`](https://github.com/NixOS/nixpkgs/commit/24fc52a14b89d2f24b440b9745f4bbc568e66142) | `haskellPackages.ghc-lib-parser-ex_9_2_1_0: update overrides for this version`             |
| [`47728bde`](https://github.com/NixOS/nixpkgs/commit/47728bdeb050bd558f697be1b0dd8ee71031dc15) | `klystrack: add -fcommon workaround`                                                       |
| [`4c33f198`](https://github.com/NixOS/nixpkgs/commit/4c33f198e31bd6c95ae7b063bda6a0d6c233946e) | `fped: add -fcommon workaround`                                                            |
| [`f7862834`](https://github.com/NixOS/nixpkgs/commit/f7862834d88ef4ced6e615a908d4eeacf734e969) | `haskellPackages.highlight: unbreak`                                                       |
| [`c9eb5b7a`](https://github.com/NixOS/nixpkgs/commit/c9eb5b7acd8fff8a0e104ed6416194b1debf37e4) | `haskellPackages: regenerate package set based on current config`                          |
| [`bf5ada3d`](https://github.com/NixOS/nixpkgs/commit/bf5ada3db15c4bbd09931edf5d815fc4bb6d7402) | `all-cabal-hashes: 2022-06-04T09:01:11Z -> 2022-06-07T15:13:17Z`                           |
| [`8c9b8d03`](https://github.com/NixOS/nixpkgs/commit/8c9b8d03b06804e24c01f2897bb9f24c6914f1b0) | `haskellPackages: stackage LTS 19.9 -> LTS 19.10`                                          |
| [`8f482ad9`](https://github.com/NixOS/nixpkgs/commit/8f482ad98f6c25954afb4ddeee81b0f7f520a0b1) | `plocate: 1.1.15 -> 1.1.16`                                                                |
| [`ec00b4bb`](https://github.com/NixOS/nixpkgs/commit/ec00b4bb1186719bbee30a89ca7f519c30001abd) | `nixos/network-interfaces-scripted: remove network-setup unit if unused`                   |
| [`6959d265`](https://github.com/NixOS/nixpkgs/commit/6959d265b8c9cca53a9f5dafd435afec242d2c62) | `linuxPackages.nvidia_x11_open: remove temporarily due to evaluation`                      |
| [`e84828b9`](https://github.com/NixOS/nixpkgs/commit/e84828b973364de21a18a9bab50e9399abdd7e43) | `nixos/nvidia: add option hardware.nvidia.open for selecting the opensource kernel driver` |
| [`94f5bd20`](https://github.com/NixOS/nixpkgs/commit/94f5bd2051f59e9e9cdb3f0db1ad88680370117a) | `nvidia_x11: init opensource kernel driver`                                                |
| [`f1142c5a`](https://github.com/NixOS/nixpkgs/commit/f1142c5a20ef36b8c26be76c52bce4c0c092a757) | `nvidia_x11: vulkan_beta: mark as broken on linux 5.17`                                    |
| [`c0822338`](https://github.com/NixOS/nixpkgs/commit/c082233850baf2232ef377fc649172d273675970) | `python3Packages.mkdocs-gitlab-plugin: init at 0.1.4`                                      |
| [`24b40a25`](https://github.com/NixOS/nixpkgs/commit/24b40a255c6adc6ab32c69737e8b4cfc50d8c8b4) | `umoria: init at 5.7.15`                                                                   |