### PR TITLE
chore(flake/nixpkgs): `b2537dc4` -> `fdb531e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655509053,
-        "narHash": "sha256-cnAi69IwgyDFyP9fg6UaDYCfQLs6GNZb1juflVVrq8Q=",
+        "lastModified": 1655556907,
+        "narHash": "sha256-vS41LKTHwDTpUTvVF6SNRszj4WrgwTRvBvzEMUriNfI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b2537dc4307c79b5ec21bf699a6892ba65057250",
+        "rev": "fdb531e995876debe015712fe4b96464196def58",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`fdb531e9`](https://github.com/NixOS/nixpkgs/commit/fdb531e995876debe015712fe4b96464196def58) | `execline-man-pages: 2.8.1.0.4 -> 2.8.3.0.2`                       |
| [`fd52adc9`](https://github.com/NixOS/nixpkgs/commit/fd52adc9a243d6ddf33d9a4943f1c1af400a5585) | `lazarus: 2.0.12 -> 2.2.2-0`                                       |
| [`d7a3b964`](https://github.com/NixOS/nixpkgs/commit/d7a3b9644063eb67a0ec267f51ccece0e1684e77) | `fpc: 3.2.0 -> 3.2.2`                                              |
| [`4cda2869`](https://github.com/NixOS/nixpkgs/commit/4cda2869252639ad19d57bc9bdb3d486ae7108a1) | `chromiumBeta: 103.0.5060.42 -> 103.0.5060.53`                     |
| [`cb058dc7`](https://github.com/NixOS/nixpkgs/commit/cb058dc7ea65b3f853672386433ca628a1fced1f) | `buildDhallUrl: Respect proxy environment variables`               |
| [`04234fdd`](https://github.com/NixOS/nixpkgs/commit/04234fdd1af86f99b7bc6bc195b58cd604a9359e) | `metasploit: 6.2.2 -> 6.2.3`                                       |
| [`c6b6e4fc`](https://github.com/NixOS/nixpkgs/commit/c6b6e4fc8523169be20ab81c2eefcc578144e29e) | `update davidtwco's maintainer email`                              |
| [`2b45f46c`](https://github.com/NixOS/nixpkgs/commit/2b45f46cf92078b27818402e3552b7696f6415f1) | `python310Packages.svg-path: 6.1 -> 6.2`                           |
| [`06db9922`](https://github.com/NixOS/nixpkgs/commit/06db9922c9ac6cc106da27551ada2dfbab9c80f2) | `python310Packages.stripe: 3.3.0 -> 3.4.0`                         |
| [`ba3a49ff`](https://github.com/NixOS/nixpkgs/commit/ba3a49ff88898e71fc5734481e1baecdaeddf357) | `python310Packages.scmrepo: 0.0.24 -> 0.0.25`                      |
| [`5150052f`](https://github.com/NixOS/nixpkgs/commit/5150052f3aa5f171abc59be0de8b3b0a1a9c66fb) | `python310Packages.fastcore: 1.4.4 -> 1.4.5`                       |
| [`4f16be72`](https://github.com/NixOS/nixpkgs/commit/4f16be72cb1ba70c4fbabdc70167e44c8e9920b8) | `Revert "ruby: enable O3 optimization"`                            |
| [`64e09fac`](https://github.com/NixOS/nixpkgs/commit/64e09fac3d6b74da210f6b09aeb947f9ba2e8f16) | `ruby: enable O3 optimization`                                     |
| [`b0cb4942`](https://github.com/NixOS/nixpkgs/commit/b0cb49426e2428e1d1761feb68f273bd1fa3a0f2) | `python310Packages.peaqevcore: 1.0.14 -> 1.0.19`                   |
| [`23873962`](https://github.com/NixOS/nixpkgs/commit/2387396258eb6ff2c436a6a1a5ba5bd05c6862d3) | `nixpkgs-fmt: 1.2.0 -> 1.3.0`                                      |
| [`d5e616a3`](https://github.com/NixOS/nixpkgs/commit/d5e616a3f410e082e7dd362b1548b1b322633205) | `calamares-nixos-extensions: 0.3.8 -> 0.3.10`                      |
| [`5feabf39`](https://github.com/NixOS/nixpkgs/commit/5feabf3992a512dd6385fd1026bcbcb18c2a003e) | `python310Packages.ssh-mitm: 2.0.4 -> 2.0.5`                       |
| [`2b250e04`](https://github.com/NixOS/nixpkgs/commit/2b250e04df7f72f1016e48cd3546351d1f2787ba) | `python310Packages.pytenable: 1.4.6 -> 1.4.7`                      |
| [`8d07ad4d`](https://github.com/NixOS/nixpkgs/commit/8d07ad4db407536532e6d30936a20125e0eb5a9d) | `tinyalsa: 2.0.0 -> unstable-2022-06-05`                           |
| [`6e73e6e6`](https://github.com/NixOS/nixpkgs/commit/6e73e6e66883bd9dbb22d0829881c4eeb72e48d0) | `tinyalsa: init at 2.0.0`                                          |
| [`698402ea`](https://github.com/NixOS/nixpkgs/commit/698402ea6a91f6c3928791d39046a1d300170dee) | `sqlfluff: 0.13.2 -> 1.0.0`                                        |
| [`eb6cce7d`](https://github.com/NixOS/nixpkgs/commit/eb6cce7d6f0e981a9b6187fc8ff07a43e0770307) | `treewide/misc: add sourceType binaryNativeCode for more packages` |
| [`6a50f500`](https://github.com/NixOS/nixpkgs/commit/6a50f500e3454f5676058eb31a302906898673de) | `vcv-rack: 1.1.6 -> 2.0.6`                                         |
| [`a6037ef4`](https://github.com/NixOS/nixpkgs/commit/a6037ef47dd0945f066a2e12d59cda329fca133d) | `openiscsi: 2.1.4 -> 2.1.7`                                        |
| [`d82e1663`](https://github.com/NixOS/nixpkgs/commit/d82e1663c7e4d3beea77d3d98ba8defa2f937caa) | `fpm2: push 'with lib' down from top level to 'meta' definition`   |
| [`edccdfd9`](https://github.com/NixOS/nixpkgs/commit/edccdfd9583d4158dfd84b6026506d7e6df056bb) | `gosec: 2.11.0 -> 2.12.0`                                          |
| [`d90da234`](https://github.com/NixOS/nixpkgs/commit/d90da2340198313259b4a974928a7d11c7b7db8b) | `gvm-tools: 21.10.0 -> 22.6.0`                                     |
| [`6cb0c166`](https://github.com/NixOS/nixpkgs/commit/6cb0c166400f816ef6de9741aa03952bc1c37d0c) | `routersploit: init at unstable-2021-02-06`                        |
| [`91d0bd07`](https://github.com/NixOS/nixpkgs/commit/91d0bd076efee5824023c474d858d9cd299d61b2) | `python310Packages.threat9-test-bed: init at 0.6.0`                |
| [`aa095641`](https://github.com/NixOS/nixpkgs/commit/aa0956415eec884de67f76c34e4048691e9734dc) | `fpm2: 0.79 -> 0.90`                                               |
| [`efac9dab`](https://github.com/NixOS/nixpkgs/commit/efac9dabcacaaf7dfad80b281c22a11c510855df) | `ipfs: 0.12.2 -> 0.13.0`                                           |
| [`1a602dda`](https://github.com/NixOS/nixpkgs/commit/1a602dda633179d90803fe149c9a7309d235e608) | `python310Packages.hahomematic: 1.8.4 -> 1.8.5`                    |
| [`b7526918`](https://github.com/NixOS/nixpkgs/commit/b7526918cbf9a4819010c877f56355593be8cb8e) | `vulkan-tools: fix Hydra breakage on Darwin`                       |
| [`54fcba5b`](https://github.com/NixOS/nixpkgs/commit/54fcba5b3bb4d77dd58aa08a489aced93ff5da18) | `installation-cd: prevent gnome from sleeping`                     |
| [`4b863a02`](https://github.com/NixOS/nixpkgs/commit/4b863a0256a24517caad65400bc6664407e10a73) | `calamares: increase default verbosity`                            |
| [`c50f620c`](https://github.com/NixOS/nixpkgs/commit/c50f620c3351e87b84eea8159673a6ca4081005a) | `calamares: 3.2.57 -> 3.2.59`                                      |