### PR TITLE
chore(flake/home-manager): `a0e7ffe7` -> `586ac1fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1655578791,
-        "narHash": "sha256-/7Sj+kdSmAC1Q7jRwYV4gKjlYFTCQMs/DgDAUqFqnV8=",
+        "lastModified": 1655592318,
+        "narHash": "sha256-OrS7b492Po+DSHd9eW2ufny9Eu+BIe/rHJZrttNwsgE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a0e7ffe7aa6c37b33b80fa7ac03a5327b81bd8d8",
+        "rev": "586ac1fd58d2de10b926ce3d544b3179891e58cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`586ac1fd`](https://github.com/nix-community/home-manager/commit/586ac1fd58d2de10b926ce3d544b3179891e58cb) | ``Move `integration-common.nix` to `nixos/common.nix``` |
| [`69e80483`](https://github.com/nix-community/home-manager/commit/69e804839e0ab067cbdd6f8ba6e60c32c63fd261) | `flake: don't reinstantiate nixpkgs`                    |
| [`2ff38c64`](https://github.com/nix-community/home-manager/commit/2ff38c646f6e22e20f703ad1940a5e5e9faa252b) | `flake: make pkgs required in homeManagerConfiguration` |