### PR TITLE
chore(flake/home-manager): `586ac1fd` -> `5197e5df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1655592318,
-        "narHash": "sha256-OrS7b492Po+DSHd9eW2ufny9Eu+BIe/rHJZrttNwsgE=",
+        "lastModified": 1655594877,
+        "narHash": "sha256-AQ39Vlb6zhsJqIRz2cN923+ESBxHmeHMHoPqA80xOCE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "586ac1fd58d2de10b926ce3d544b3179891e58cb",
+        "rev": "5197e5df7d3a148b1ad080235f70800987bc3549",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                     |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`5197e5df`](https://github.com/nix-community/home-manager/commit/5197e5df7d3a148b1ad080235f70800987bc3549) | `Bump .release file`                               |
| [`931653b9`](https://github.com/nix-community/home-manager/commit/931653b99f876c6ddee0f9b864707cf228d162f1) | `emacs: optionally start service with the session` |