### PR TITLE
chore(flake/nixpkgs): `fdb531e9` -> `a19f2c68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655556907,
-        "narHash": "sha256-vS41LKTHwDTpUTvVF6SNRszj4WrgwTRvBvzEMUriNfI=",
+        "lastModified": 1655598282,
+        "narHash": "sha256-KJWnQw2L59AGfnZeldVHPHKoVSUVnJOtBR0cSTT+CVQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fdb531e995876debe015712fe4b96464196def58",
+        "rev": "a19f2c688bcd06d89bdc8848918eaff0e0991aa4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                    |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`a19f2c68`](https://github.com/NixOS/nixpkgs/commit/a19f2c688bcd06d89bdc8848918eaff0e0991aa4) | `terraform-providers: update 2022-06-18`                          |
| [`8363c2b0`](https://github.com/NixOS/nixpkgs/commit/8363c2b055d528f8c2b962804b885d8f9aa0fd8d) | `terraform-providers.vsphere: 2.1.1 -> 2.2.0`                     |
| [`095ed303`](https://github.com/NixOS/nixpkgs/commit/095ed303632270ff836c48ac756cf26b8947d73b) | `netdata: 1.34.1 -> 1.35.1`                                       |
| [`3cfdd35f`](https://github.com/NixOS/nixpkgs/commit/3cfdd35ff6f3debac56261d35c06537697e8fe98) | `zeronet-conservancy: add nixos test`                             |
| [`e19d0277`](https://github.com/NixOS/nixpkgs/commit/e19d02771c4830482e8e0fdb22fb392339789be6) | `sile: 0.13.0 → 0.13.1`                                           |
| [`c3b62ce2`](https://github.com/NixOS/nixpkgs/commit/c3b62ce238f62a9b8f1d8f79a24a5f7ec608450b) | `tailscale: 1.26.0 -> 1.26.1`                                     |
| [`0c3b4c87`](https://github.com/NixOS/nixpkgs/commit/0c3b4c878d6b414a6e21b007b130e9fbb4ae2156) | `dnsmon-go: init at unstable-2022-05-13`                          |
| [`295f0ef3`](https://github.com/NixOS/nixpkgs/commit/295f0ef3c21231fbe336bd6d663230f98546730f) | `svtplay-dl: 4.12 -> 4.13`                                        |
| [`6fa26fe3`](https://github.com/NixOS/nixpkgs/commit/6fa26fe3cd0f244d525c75c6895c512fa3a8a6a2) | `vimPlugins: remove any gotags reference`                         |
| [`2c072c20`](https://github.com/NixOS/nixpkgs/commit/2c072c2083badf093c93730f5bd79e0418dea5a3) | `luaPackages.sqlite: init at v1.2.2-0`                            |
| [`011911bc`](https://github.com/NixOS/nixpkgs/commit/011911bc5465d009fcc9f7a92ee741761e091d3a) | `luarocks-check-hook: init`                                       |
| [`d3d7a0b6`](https://github.com/NixOS/nixpkgs/commit/d3d7a0b67e721908c16352c4300faccf565e0f81) | `sacc: 1.05 -> 1.06`                                              |
| [`21d01334`](https://github.com/NixOS/nixpkgs/commit/21d0133416bba05ecf07fae65a58e4ed33bd10a8) | `chroma: 0.10.1 -> 2.2.0`                                         |
| [`e279a722`](https://github.com/NixOS/nixpkgs/commit/e279a72210adbef00cb308d13f80fa4fae57f505) | `secrets-extractor: init at 1.0.1`                                |
| [`3f4d525e`](https://github.com/NixOS/nixpkgs/commit/3f4d525ef7848b626a3889115136d0c74db0caf5) | `lowdown: 0.11.1 -> 1.0.0`                                        |
| [`53cc5a59`](https://github.com/NixOS/nixpkgs/commit/53cc5a59a27c039a071a98e8ec994b6e8ca04b99) | `amberol: 0.7.0 -> 0.8.0`                                         |
| [`004b209e`](https://github.com/NixOS/nixpkgs/commit/004b209ebe2ccbcf242bbcd52e71da1da620cdbf) | `Remove wunderbrick from juniper maintainers`                     |
| [`51e891aa`](https://github.com/NixOS/nixpkgs/commit/51e891aa408416301e8ef90a82bd2219baf98eb5) | `ipget: 0.8.0 -> 0.8.1`                                           |
| [`eb6e5a01`](https://github.com/NixOS/nixpkgs/commit/eb6e5a017e037669ea9f18ba35c212c6343f5d1c) | `microsoft-edge: 100.0.1185.44 -> 102.0.1245.44`                  |
| [`a067372e`](https://github.com/NixOS/nixpkgs/commit/a067372e82ad5dba78fd2e2190c2711535e74541) | `vorta: 0.8.6 -> 0.8.7 (#177986)`                                 |
| [`3ba73151`](https://github.com/NixOS/nixpkgs/commit/3ba7315199a9a8b574acb8a272c4937f7d5c735c) | `arkade: 0.8.25 -> 0.8.28`                                        |
| [`cb47db3e`](https://github.com/NixOS/nixpkgs/commit/cb47db3e59341f53247555885caee5f5bfa0b5fd) | `python3Packages.django-reversion: rename from django_reversion`  |
| [`0c96397e`](https://github.com/NixOS/nixpkgs/commit/0c96397ec30428f00aaa16fce74febfefa50dcaf) | `python310Packages.django_reversion: 5.0.0 -> 5.0.1`              |
| [`88d6f8f4`](https://github.com/NixOS/nixpkgs/commit/88d6f8f42e5b2ede6c56580708847e3623c889e0) | `grype: 0.39.0 -> 0.40.0`                                         |
| [`af888339`](https://github.com/NixOS/nixpkgs/commit/af888339b6c7d1c8c5b8857271d80a23dc849b39) | `mkCoqDerivation: do not set DESTDIR`                             |
| [`34996ac4`](https://github.com/NixOS/nixpkgs/commit/34996ac473cdcc60e3d1d5d14ee27c558b5195d2) | `python310Packages.schwifty: 2022.6.0 -> 2022.6.1`                |
| [`628e2473`](https://github.com/NixOS/nixpkgs/commit/628e2473cd711e626adc758305f95b99bc816e8e) | `joplin-desktop: 2.7.15 -> 2.8.8`                                 |
| [`686f0f74`](https://github.com/NixOS/nixpkgs/commit/686f0f74617667c1eace1ba60bcb14787e0cf25a) | `mkgmap-splitter: 651 -> 652`                                     |
| [`7182c05d`](https://github.com/NixOS/nixpkgs/commit/7182c05da4231e059fa31842a409bbc8c0010d8d) | `libvgm: unstable-2022-05-27 -> unstable-2022-06-17`              |
| [`419e1c95`](https://github.com/NixOS/nixpkgs/commit/419e1c95e2cd8b6d4cff03a6db615cf58b62a2cd) | `rage: 0.8.0 -> 0.8.1`                                            |
| [`7e814a28`](https://github.com/NixOS/nixpkgs/commit/7e814a288c3c9aba57403708a4cd7ded068df32f) | `python3Packages.infinity: init at 1.5`                           |
| [`4720321c`](https://github.com/NixOS/nixpkgs/commit/4720321cd30f660a85ab44026962a67a73a5e860) | `python310Packages.chess: 1.9.1 -> 1.9.2`                         |
| [`046a25e3`](https://github.com/NixOS/nixpkgs/commit/046a25e32edad68e578b5fa3dceebbea16c887c5) | `rust-analyzer: 2022-05-17 -> 2022-06-13`                         |
| [`9794e0c4`](https://github.com/NixOS/nixpkgs/commit/9794e0c4e93f30678eaff4c627eb62a17b1270bc) | `kodiPackages.requests: 2.25.1+matrix.1 -> 2.27.1+matrix.1`       |
| [`5d14e148`](https://github.com/NixOS/nixpkgs/commit/5d14e1487dec13834bcfe385d7946006219b6607) | `kodiPackages.idna: 2.10.0+matrix.1 -> 3.3.0+matrix.1`            |
| [`29312784`](https://github.com/NixOS/nixpkgs/commit/293127848fdb32f336d84de12781b07de1c033f1) | `kodiPackages.certifi: 2020.12.05+matrix.1 -> 2022.5.18+matrix.1` |
| [`0f89a22e`](https://github.com/NixOS/nixpkgs/commit/0f89a22e7034fde7fef6343fa1f8ed9583807507) | `horizon-eda: 2.3.0 -> 2.3.1`                                     |
| [`3e17f00d`](https://github.com/NixOS/nixpkgs/commit/3e17f00d88b38bca56e14842730237bd3c8ac95e) | `gnomeExtensions: auto-update`                                    |
| [`f4876792`](https://github.com/NixOS/nixpkgs/commit/f4876792be6da66b46d99231869884fa7ceca895) | `trivy: 0.28.1 -> 0.29.0`                                         |
| [`db8f61ce`](https://github.com/NixOS/nixpkgs/commit/db8f61ceb327aeaca037c24af058819fa16ed30f) | `git-appraise: 2018-02-26 -> unstable-2022-04-13`                 |
| [`53726902`](https://github.com/NixOS/nixpkgs/commit/53726902c8ec1968c5ad2ce1fadd6e9fe6cedf4f) | `fheroes2: 0.9.15 -> 0.9.16`                                      |
| [`60988fb9`](https://github.com/NixOS/nixpkgs/commit/60988fb96b2143bcea11379def67463e70d4ed24) | `zettlr: 2.2.6 -> 2.3.0`                                          |
| [`67eb7a1d`](https://github.com/NixOS/nixpkgs/commit/67eb7a1d55171c64c81602ebc94696739a9a8862) | `zeronet-conservancy: 0.7.5 -> 0.7.6`                             |
| [`da8d1384`](https://github.com/NixOS/nixpkgs/commit/da8d138459f52ce11f6e4481535682a8e04a4c4c) | `atlantis: 0.19.2 -> 0.19.3`                                      |
| [`e8a77d7c`](https://github.com/NixOS/nixpkgs/commit/e8a77d7c63e1a6ecf937c28f8015afe76a7d0a7d) | `titanion: init at 0.3`                                           |