### PR TITLE
chore(flake/nixpkgs): `a19f2c68` -> `5823018b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655598282,
-        "narHash": "sha256-KJWnQw2L59AGfnZeldVHPHKoVSUVnJOtBR0cSTT+CVQ=",
+        "lastModified": 1655661709,
+        "narHash": "sha256-WkYIFUt+nRcTvAZCw597AG1luNxNGNucfPkBA/wA5Qo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a19f2c688bcd06d89bdc8848918eaff0e0991aa4",
+        "rev": "5823018b1b27b9675a51a84a7fc9cdd44327fa3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
| [`b4706074`](https://github.com/NixOS/nixpkgs/commit/b4706074bac9f7d9ceee868d8a2a0f88883555fd) | `lefthook: 0.8.0 -> 1.0.0`                                                                                               |
| [`1580cb15`](https://github.com/NixOS/nixpkgs/commit/1580cb15d8bcf632746e731402428266ff535dce) | `python310Packages.weconnect-mqtt: 0.34.0 -> 0.35.0`                                                                     |
| [`6bd1025a`](https://github.com/NixOS/nixpkgs/commit/6bd1025a28f7dddf18d1bc22ac3a185471ab1cd9) | `nixos-shell: 0.2.2 -> 1.0.0`                                                                                            |
| [`ce505a39`](https://github.com/NixOS/nixpkgs/commit/ce505a39845b93e48f125ededeaaec6f597df43f) | `vimPlugins: use lua derivation if it exists (#178180)`                                                                  |
| [`970cd264`](https://github.com/NixOS/nixpkgs/commit/970cd2643dea85034ad8e658e16fa946439f345b) | `statix: 0.5.4 -> 0.5.6`                                                                                                 |
| [`90bb7129`](https://github.com/NixOS/nixpkgs/commit/90bb71296939da76cc530322ef50b9d52e606ce9) | `deadnix: 0.1.5 -> 0.1.6`                                                                                                |
| [`0725c074`](https://github.com/NixOS/nixpkgs/commit/0725c07445a66204279941761cd89b49b4acbdfe) | `editorconfig-checker: 2.4.0 -> 2.5.0`                                                                                   |
| [`8b926cad`](https://github.com/NixOS/nixpkgs/commit/8b926cad93f2b5a6d265312d415918cd80bed3f6) | `nixos/tests/grafana-agent: update port`                                                                                 |
| [`cdbc6e64`](https://github.com/NixOS/nixpkgs/commit/cdbc6e64e4d988184b83c25d46387f11d274b991) | `treewide: reduce maintenance workload for ma27`                                                                         |
| [`5f297c16`](https://github.com/NixOS/nixpkgs/commit/5f297c164eed6f4b72ca0337698037a003354d28) | `nixos/grafana-agent: add myself as maintainer`                                                                          |
| [`b0983659`](https://github.com/NixOS/nixpkgs/commit/b09836593ede3de62cf2caf0351501a9575bbd06) | `nixos/grafana-agent: move remote write config from integrations.prometheus_remote_write to metrics.global.remote_write` |
| [`e578b4d3`](https://github.com/NixOS/nixpkgs/commit/e578b4d3ed8068b85a27c5c7b9e135f2af2d7f21) | `nixos/grafana-agent: drop server.{grpc,http}_listen_address,http_listen_port`                                           |
| [`2cca676e`](https://github.com/NixOS/nixpkgs/commit/2cca676e6962cb3618c91ba4103b6a03ff66d9e8) | ``nixos/grafana-agent: replace `settings.prometheus` with `settings.metrics```                                           |
| [`42ff489d`](https://github.com/NixOS/nixpkgs/commit/42ff489d5393629b3ac06f865adc3e5c87c8a33b) | `pokete: drop default platform`                                                                                          |
| [`e85af734`](https://github.com/NixOS/nixpkgs/commit/e85af7341a210f7cc301daa40d92c6ec98badb0f) | `pulumi-bin: 3.31.0 -> 3.34.1 (#178006)`                                                                                 |
| [`4462f3dc`](https://github.com/NixOS/nixpkgs/commit/4462f3dc537e285261b496103581599ee59f3e9b) | `python310Packages.ansible-lint: 6.2.2 -> 6.3.0`                                                                         |
| [`3e1b42d9`](https://github.com/NixOS/nixpkgs/commit/3e1b42d9e7b62343afd2ccbcdcf406ba6a0ef497) | `python310Packages.aiomusiccast: 0.14.3 -> 0.14.4`                                                                       |
| [`a62e864c`](https://github.com/NixOS/nixpkgs/commit/a62e864c810e91182b7c7bc2aecdfcda9e3858c5) | `strace: 5.17 -> 5.18`                                                                                                   |
| [`2f002a96`](https://github.com/NixOS/nixpkgs/commit/2f002a966778cdec8b51e0e6aa3c699c21bdad42) | `Revert "graalvmXX-ce: use a patched version of zlib"`                                                                   |
| [`b21933fa`](https://github.com/NixOS/nixpkgs/commit/b21933faab008b01e010e453ff738f5e56befd9f) | `cpython: have powerpc64le use "ppc64le" to follow PEP600`                                                               |
| [`9cf7759f`](https://github.com/NixOS/nixpkgs/commit/9cf7759f910074dcebfb4542ad6adc669445d2b0) | `sherlock: init at 0.14.0`                                                                                               |
| [`fe505147`](https://github.com/NixOS/nixpkgs/commit/fe50514741341007e4f0f2a6699463f95e4284e3) | `mongodb-tools: use buildGoModule`                                                                                       |
| [`c164921d`](https://github.com/NixOS/nixpkgs/commit/c164921d8935731eb1588eef665392c1261f0dc1) | `python310Packages.types-redis: 4.2.7 -> 4.2.8`                                                                          |
| [`754005bf`](https://github.com/NixOS/nixpkgs/commit/754005bf485d31384e1905a9af1ad2293a64be20) | `nixos/device-tree: preprocess overlays before compiling`                                                                |
| [`8e4b3323`](https://github.com/NixOS/nixpkgs/commit/8e4b3323d1a6ae7911ae29bd319cd75f1d41b8aa) | `nixos/device-tree: use new overlay syntax in example`                                                                   |
| [`33163bd0`](https://github.com/NixOS/nixpkgs/commit/33163bd0ef1a2c3338c9f55471609d8b93f806fc) | `nixos/pipewire: fix wireplumber with system-wide`                                                                       |
| [`1477172e`](https://github.com/NixOS/nixpkgs/commit/1477172ead7ff98c969e9ff6a1a10be46c21a3ba) | `maintainers: add alkasm`                                                                                                |
| [`68e989d3`](https://github.com/NixOS/nixpkgs/commit/68e989d3809b55d87a2cc3feef7d3fda23b5c016) | `spr: init at 1.3.2`                                                                                                     |
| [`b1f4b549`](https://github.com/NixOS/nixpkgs/commit/b1f4b54968191f7dbdd813292d27ec1a8bf4d7e8) | `yubikey-manager: 4.0.8 -> 4.0.9`                                                                                        |
| [`11c5f738`](https://github.com/NixOS/nixpkgs/commit/11c5f738289e335e72aa5d206a67fc6d15739e5e) | `pokete: init at 0.7.2`                                                                                                  |
| [`1a983571`](https://github.com/NixOS/nixpkgs/commit/1a983571758cd2beb8fad47a770f590a6d8dca6b) | `got: 0.69 -> 0.70`                                                                                                      |
| [`bd19b743`](https://github.com/NixOS/nixpkgs/commit/bd19b743395ce633bc61d98dad431ed9a68818f2) | `maintainers: add sven-of-cord`                                                                                          |
| [`306d5b86`](https://github.com/NixOS/nixpkgs/commit/306d5b860a5cade127f820f127c1c57856fdfe55) | `pwdsafety: 0.1.4 -> 0.3`                                                                                                |
| [`e4c6c49c`](https://github.com/NixOS/nixpkgs/commit/e4c6c49cf7406e4e7f973488ca60cc7744d4c0da) | `GameHub: better description from @AnsersonTorres`                                                                       |
| [`10260ad3`](https://github.com/NixOS/nixpkgs/commit/10260ad3ec8dd0159371cc3df43acb6a07da595a) | `zerotierone: 1.8.9 -> 1.10.0`                                                                                           |
| [`fc8516ff`](https://github.com/NixOS/nixpkgs/commit/fc8516ff562462d888bf20d62cd0d25ea54207be) | `gitls: init at 1.0.3`                                                                                                   |
| [`207a128a`](https://github.com/NixOS/nixpkgs/commit/207a128a69c4d5e6d5e7f60cb4f8b530eacb111b) | `GameHub: init at 0.16.3-2`                                                                                              |
| [`ad24ab01`](https://github.com/NixOS/nixpkgs/commit/ad24ab01de8953993732f15431f07866ab3da152) | `makeDBusConf: reduce build closure`                                                                                     |
| [`ac86fdf4`](https://github.com/NixOS/nixpkgs/commit/ac86fdf42efe6382f9d62205d922ee3628cc24c5) | `Revert "python3Packages.certbot: 1.24.0 -> 1.27.0"`                                                                     |
| [`f22126fe`](https://github.com/NixOS/nixpkgs/commit/f22126fe9a21cb2c19f95a4c178092371ea37b4d) | `ocamlPackages.ppx_yojson_conv_lib: 0.14.0 -> 0.15.0`                                                                    |
| [`3e550d5c`](https://github.com/NixOS/nixpkgs/commit/3e550d5cd2bb37062d8fa1dbb8a81de490553721) | `pantheon.elementary-files: 6.1.2 -> 6.1.3`                                                                              |
| [`b8f1cd1e`](https://github.com/NixOS/nixpkgs/commit/b8f1cd1e97c06953eeb0883a74d91a89b64576cb) | `zsh: split documentation into separate outputs`                                                                         |
| [`7dc14475`](https://github.com/NixOS/nixpkgs/commit/7dc14475ce5f3da4456ef85665324f9219ecf2f7) | `matrix-commander: 2.36.0 -> 2.37.3`                                                                                     |
| [`e36d99a5`](https://github.com/NixOS/nixpkgs/commit/e36d99a5df9e4d0a706ca28d7c0ca10a1cc57537) | `python310Packages.scrap-engine: init at 1.2.0`                                                                          |
| [`20972d65`](https://github.com/NixOS/nixpkgs/commit/20972d657edef0cab6f1ef2d6e99d88fd93bed16) | `xxHash: add pkg-config file fix, clean up a bit`                                                                        |
| [`1cbc35fb`](https://github.com/NixOS/nixpkgs/commit/1cbc35fb871683b9c3d402bda670c21985589e9c) | `python310Packages.pyspark: 3.2.1 -> 3.3.0`                                                                              |
| [`c772b13e`](https://github.com/NixOS/nixpkgs/commit/c772b13ee74e9cea7e2f26ad05fdeff7d819f891) | `nixos/navidrome: fixes missing ssl certficates`                                                                         |
| [`b9feda3c`](https://github.com/NixOS/nixpkgs/commit/b9feda3c0bc5c0226ac6c3e22333f07799d79772) | `home-assistant: fix parse-requirements.py`                                                                              |
| [`fe8a3f1f`](https://github.com/NixOS/nixpkgs/commit/fe8a3f1ff8d3a5f378aa2e5134647e7193d5d692) | `conan: 1.47.0 -> 1.49.0`                                                                                                |
| [`1e1539c2`](https://github.com/NixOS/nixpkgs/commit/1e1539c281879fa7ac4b1e2ad5cfba42a78963f9) | `cacert: Drop python3Minimal`                                                                                            |
| [`4ff1ad17`](https://github.com/NixOS/nixpkgs/commit/4ff1ad170fbbde7a3a6e735ad79cfc93066419ed) | `python310Packages.django-jinja: run tests`                                                                              |
| [`067314d8`](https://github.com/NixOS/nixpkgs/commit/067314d87fef67f713a06b64042da4e7442c851f) | `archivebox: mark insecure`                                                                                              |
| [`aedd39d8`](https://github.com/NixOS/nixpkgs/commit/aedd39d86911adb45ea06fa0bb8153282f37c0b3) | `archivebox: update Django to 3.1.14`                                                                                    |
| [`0af7e9c4`](https://github.com/NixOS/nixpkgs/commit/0af7e9c4075119bd0b9e2c912604c2ab084dd99f) | `Revert "nss: 3.68.4 -> 3.79"`                                                                                           |
| [`63576fb5`](https://github.com/NixOS/nixpkgs/commit/63576fb5c33a3e7cb2d826799f17cc336bafab9a) | `awsebcli: fixup, use python.pkgs.six from nixpkgs`                                                                      |
| [`e8573094`](https://github.com/NixOS/nixpkgs/commit/e8573094f3495d29790b6e8761b70ba2cf31a32c) | `matrix-commander: 2.30.0 -> 2.36.0`                                                                                     |
| [`806da9d0`](https://github.com/NixOS/nixpkgs/commit/806da9d0294aab969c705a793b574a9f0fc4e9ab) | `v8_8_x: use python39`                                                                                                   |
| [`eb3469e5`](https://github.com/NixOS/nixpkgs/commit/eb3469e52624fbe1204b22effa8aa084a42fe771) | `mesa: revert to 22.0 on darwin`                                                                                         |
| [`edc88086`](https://github.com/NixOS/nixpkgs/commit/edc8808603be2e13cf5b6ec3cbcca61de3de3ba0) | `ceph: use python39`                                                                                                     |
| [`edfc49fb`](https://github.com/NixOS/nixpkgs/commit/edfc49fbcf9e0884754f8a2cc406ba731e29baff) | `python310Packages.ledger: use default boost`                                                                            |
| [`207e649a`](https://github.com/NixOS/nixpkgs/commit/207e649ab90fce65db78e89eab956c8567348cc5) | `kiwix: 2.0.5 -> 2.2.1`                                                                                                  |
| [`8320da21`](https://github.com/NixOS/nixpkgs/commit/8320da218e04e672a64873b949bf2578373da308) | `zimwriterfs 1.0 -> zim-tools 3.1.1`                                                                                     |
| [`b9495cc3`](https://github.com/NixOS/nixpkgs/commit/b9495cc30f5cbb32cf2b6243ce775361dc31bf52) | `zimlib: 6.3.2 -> 7.2.2`                                                                                                 |
| [`2300d831`](https://github.com/NixOS/nixpkgs/commit/2300d8312dc1b9d9bb2d7ad2f8007b3ca69f71c1) | `.gitignore: prepend slash to result and source`                                                                         |
| [`8335c466`](https://github.com/NixOS/nixpkgs/commit/8335c46632910d9b9dc13c0701b2755311b62ea9) | `zlib: backport upstream fix on CRC validation`                                                                          |
| [`bcf29733`](https://github.com/NixOS/nixpkgs/commit/bcf29733e9367d2c3a1da2d6bfdb9afa553d23ec) | `hwdata: 0.347 -> 0.360`                                                                                                 |
| [`d7f012f3`](https://github.com/NixOS/nixpkgs/commit/d7f012f33ce5ee308f75f3f53a1e8189c6dc15d8) | `mobile-broadband-provider-info: 20220315 -> 20220511`                                                                   |
| [`938f2ce1`](https://github.com/NixOS/nixpkgs/commit/938f2ce1017ff1fdb25abec3f22a0821618af8cb) | `jansson: enable shared library installation`                                                                            |
| [`efb6d291`](https://github.com/NixOS/nixpkgs/commit/efb6d291612c08e7e9dd1934beff0d5bbc95617f) | `tracker: 3.3.0 → 3.3.1`                                                                                                 |
| [`ba8a998c`](https://github.com/NixOS/nixpkgs/commit/ba8a998c1841a7b2b81e255c5864f4fc26a9ba0e) | `boost: 1.77.0 -> 1.79.0`                                                                                                |
| [`1c76a270`](https://github.com/NixOS/nixpkgs/commit/1c76a270d2d0331aaed02a308acb607e81e5c414) | `nss: 3.68.4 -> 3.79`                                                                                                    |
| [`6e7fb72f`](https://github.com/NixOS/nixpkgs/commit/6e7fb72f0f91273f308285347128915025eb58c1) | `go_1_18: 1.18.2 -> 1.18.3`                                                                                              |
| [`47016de7`](https://github.com/NixOS/nixpkgs/commit/47016de7effddab56c374598de8de7c704543c84) | `go_1_17: 1.17.10 -> 1.17.11`                                                                                            |
| [`299b9a1b`](https://github.com/NixOS/nixpkgs/commit/299b9a1b59d43ff157cd2e9579a6fc588feff1a9) | `buildMozillaMach: add patch for rust-cbindgen 0.24 compat`                                                              |
| [`48275dbd`](https://github.com/NixOS/nixpkgs/commit/48275dbd5617b55d98f6def9792b3ee95bcf6664) | `python3Packages.dropbox: Re-add setuptools to propagatedBuildInputs`                                                    |
| [`74ffc379`](https://github.com/NixOS/nixpkgs/commit/74ffc379504d21d031e559d37bb1c43d399ea6e1) | `oak: init at 0.2`                                                                                                       |
| [`98ff4139`](https://github.com/NixOS/nixpkgs/commit/98ff4139d1cf6a235e92a041b48abedf6b623dee) | `maintainers: add tejasag`                                                                                               |
| [`7e2f6fa1`](https://github.com/NixOS/nixpkgs/commit/7e2f6fa137c0f4ecb53922fd54f666a91c9c2e09) | `calibre-web: add missing input`                                                                                         |
| [`3b754ded`](https://github.com/NixOS/nixpkgs/commit/3b754ded2098664c5307e708b97c983dd52c86b3) | `python310Packages.graphite-web: remove patch`                                                                           |
| [`4f1fa2f3`](https://github.com/NixOS/nixpkgs/commit/4f1fa2f3fea2ddc2c7db6c706058d42b1ef5be26) | `python310Packages.graphite-web: 1.1.8 -> 1.1.10`                                                                        |
| [`66bb79f6`](https://github.com/NixOS/nixpkgs/commit/66bb79f6409d3f598e5a85b3a36dcdea2ff87881) | `python39Packages.rokuecp: disable failing tests`                                                                        |
| [`7770164a`](https://github.com/NixOS/nixpkgs/commit/7770164a072968dc6373beb1763082b7c1061796) | `python310Packages.qutip: 4.6.3 -> 4.7.0`                                                                                |
| [`d0ee55d6`](https://github.com/NixOS/nixpkgs/commit/d0ee55d6d303adb6283a983b8e47707ace722f6d) | `thrift: disable failing tests`                                                                                          |
| [`53c8f97a`](https://github.com/NixOS/nixpkgs/commit/53c8f97a537abb85fb35e88cb4801fa62692813f) | `autoflake: switch to pytestCheckHook`                                                                                   |
| [`1a3ff178`](https://github.com/NixOS/nixpkgs/commit/1a3ff178aaadfb3525242cb90f12bf0802d37752) | `rust-cbindgen: 0.23.0 -> 0.24.2`                                                                                        |
| [`d1720612`](https://github.com/NixOS/nixpkgs/commit/d172061281406669cd7b820c9f566a8784b3c21d) | `makeDBusConf: use upstream XML catalog`                                                                                 |
| [`caf6e09b`](https://github.com/NixOS/nixpkgs/commit/caf6e09b7066022ba4f24560b41141787579c203) | `dbus: fix paths in catalog`                                                                                             |
| [`c422b656`](https://github.com/NixOS/nixpkgs/commit/c422b6566c9665de0e3406c2d9c6856256445c3e) | `pip-audit: adjust inputs`                                                                                               |
| [`209c3faf`](https://github.com/NixOS/nixpkgs/commit/209c3fafde2b571ceb06553f839523a056cd8415) | `python310Packages.pytest-annotate: relax pytest constraint`                                                             |
| [`9af97d30`](https://github.com/NixOS/nixpkgs/commit/9af97d300480c9d4b448d9f1850bca62496706eb) | `python310Packages.pyannotate: switch to pytestCheckHook`                                                                |
| [`069f9a07`](https://github.com/NixOS/nixpkgs/commit/069f9a077ed3cc885ee781dd92cc32a7a1e0f37f) | `python310Packages.netifaces: add format`                                                                                |
| [`13a4a870`](https://github.com/NixOS/nixpkgs/commit/13a4a8702cf72010efedd4e7cb52cd9c5b76f88b) | `python310Packages.jsonpatch: enable tests`                                                                              |
| [`0dbb26a3`](https://github.com/NixOS/nixpkgs/commit/0dbb26a3914d086b06ade061f920239a562de645) | `python310Packages.configobj: switch to pytestCheckHook`                                                                 |
| [`0031ccab`](https://github.com/NixOS/nixpkgs/commit/0031ccab55e72a1ca59128882f9f98de2a049226) | `python310Packages.pyserial: add pythonImportsCheck`                                                                     |
| [`7f8d28e9`](https://github.com/NixOS/nixpkgs/commit/7f8d28e99bb43316e8b8d57edb02bd84ac3e2376) | `libusb1: 1.0.25 -> 1.0.26`                                                                                              |
| [`a0aeec7e`](https://github.com/NixOS/nixpkgs/commit/a0aeec7e43d0e162070340e5986f6e8caa22f4a6) | `portaudio: set strictDeps`                                                                                              |
| [`499c5044`](https://github.com/NixOS/nixpkgs/commit/499c5044ffc457687d1edc2b50eb45bd26d0215d) | `python310Packages.pylint: 2.14.0 -> 2.14.1`                                                                             |
| [`daad0beb`](https://github.com/NixOS/nixpkgs/commit/daad0beb4207882d485b23560b1c20acdb449ad8) | `fixup! azure-cli: 2.34.1 -> 2.37.0`                                                                                     |
| [`77cdee19`](https://github.com/NixOS/nixpkgs/commit/77cdee19460acb111ed280ffd4b966b2cbaff2b9) | `fixup! python3Packages.azure-data-tables: init at 12.4.0`                                                               |
| [`ce0ebc2e`](https://github.com/NixOS/nixpkgs/commit/ce0ebc2e1599b20b46baacc3094d2e9cda317d66) | `azure-cli: 2.34.1 -> 2.37.0`                                                                                            |
| [`40e0a8d9`](https://github.com/NixOS/nixpkgs/commit/40e0a8d9d5e499a9fbe4cd9ffd366c1e85c56ff6) | `azure-cli: remove blanket python2 compat logic`                                                                         |
| [`c055b9b7`](https://github.com/NixOS/nixpkgs/commit/c055b9b796d532b2ccfa22190551d6c03a728b59) | `python3Packages.antlr4-python3-runtime: fix tests for 4.9+`                                                             |
| [`c9b86a26`](https://github.com/NixOS/nixpkgs/commit/c9b86a269bc453f2326ebd7509f4249821ea25c6) | `python3Packages.azure-data-tables: init at 12.4.0`                                                                      |
| [`8b040682`](https://github.com/NixOS/nixpkgs/commit/8b04068283db099cecf44427d0c6aff460e6eced) | `python310Packages.pymemcache: 3.5.1 -> 3.5.2`                                                                           |
| [`cb93a026`](https://github.com/NixOS/nixpkgs/commit/cb93a026a55dd996b918861155d21ef68808c630) | `python310Packages.glances-api: 0.3.5 -> 0.3.6`                                                                          |
| [`7c16cc8c`](https://github.com/NixOS/nixpkgs/commit/7c16cc8c54913f0d8ad5950ebd377c17662ab8c9) | `python3Packages.azure-storage-blob: 12.11.0 -> 12.12.0`                                                                 |
| [`42caf48c`](https://github.com/NixOS/nixpkgs/commit/42caf48cd0800838b18e3585384194ccc2d4f99b) | `python3Packages.azure-mgmt-containerregistry: 9.1.0 -> 10.0.0`                                                          |
| [`c2aa1074`](https://github.com/NixOS/nixpkgs/commit/c2aa1074c140b82f8ff9327d14260faed98792cc) | `python3Packages.azure-mgmt-containerinstance: 9.1.0 -> 9.2.0`                                                           |
| [`37cc04e7`](https://github.com/NixOS/nixpkgs/commit/37cc04e721e677e556e0fb6c4aa6287f2b003dfd) | `odoo: use python39`                                                                                                     |
| [`b0451997`](https://github.com/NixOS/nixpkgs/commit/b045199796dea02c2aa206506f930e0a058efa5e) | `privacyidea: use python39`                                                                                              |
| [`e18f93ca`](https://github.com/NixOS/nixpkgs/commit/e18f93caedc2946ea3d5b4973a5d7574a8617290) | `python310Packages.dask: 2022.05.0 -> 2022.05.2`                                                                         |
| [`e3873e7f`](https://github.com/NixOS/nixpkgs/commit/e3873e7f7e182fd71564f522721b6234ba71befa) | `python310Packages.dask-ml: handle optional dependencies`                                                                |
| [`fc78ec96`](https://github.com/NixOS/nixpkgs/commit/fc78ec96796fc371f5851d792e9f8ca1fc5a232c) | `python310Packages.dask-glm: handle optional dependencies`                                                               |
| [`077cf7c7`](https://github.com/NixOS/nixpkgs/commit/077cf7c76be38b0ae63c932e2bc2d70143bdcbd8) | `Python310Packages.sparse: disable on older Python releases`                                                             |
| [`ea658301`](https://github.com/NixOS/nixpkgs/commit/ea658301e1c0fe55f82489d05ecc84b887b7d762) | `python310Packages.s3fs: disable on older Python releases`                                                               |
| [`32a2f6fe`](https://github.com/NixOS/nixpkgs/commit/32a2f6fe6f9bfe0be84e126e712b56633eb21330) | `python310Packages.fastparquet: add optional dependency`                                                                 |
| [`b352fc55`](https://github.com/NixOS/nixpkgs/commit/b352fc55435afa66ca338c6a0a9da1f8cc2a9232) | `python310Packages.dask: 2022.02.1 -> 2022.05.0`                                                                         |
| [`e35789db`](https://github.com/NixOS/nixpkgs/commit/e35789db92dcfa13456cde8d179184fb7f72d693) | `python310Packages.fsspec: 2022.3.0 -> 2022.5.0`                                                                         |
| [`792e5af4`](https://github.com/NixOS/nixpkgs/commit/792e5af45bb43455d5096f88ba7ba9a9767b3272) | `python310Packages.intake: 0.6.4 -> 0.6.5`                                                                               |
| [`0220a623`](https://github.com/NixOS/nixpkgs/commit/0220a623b414975e624dde56bfa30fe951d3dbd3) | `python310Packages.pyarrow: disable flaky test`                                                                          |
| [`ddb88d2e`](https://github.com/NixOS/nixpkgs/commit/ddb88d2ea46c01ac08ba98aee9b2e93d39ae43d0) | `python310Packages.streamz: disable flaky tests`                                                                         |
| [`71d5ec64`](https://github.com/NixOS/nixpkgs/commit/71d5ec64ffc00157c29ddc3deb21ecf7afc95e53) | `python310Packages.distributed: 2022.5.0 -> 2022.5.2`                                                                    |
| [`15b67040`](https://github.com/NixOS/nixpkgs/commit/15b67040bb14c12b3e4d47efac7a2ad2885cd2c2) | `python310Packages.dask: 2022.05.0 -> 2022.05.2`                                                                         |