### PR TITLE
chore(flake/home-manager): `ce8266de` -> `3d8265c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1655678104,
-        "narHash": "sha256-Cs7uvIJawhfE6Jw2Ej68imE228ip4ALxKL8/byLJycI=",
+        "lastModified": 1655679417,
+        "narHash": "sha256-rUM/VDIQAMm0pLAVBizQoR9I8TELRmak7SsJLaO/NBg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ce8266dedcba66155624eca88280ee425f4d3611",
+        "rev": "3d8265c5efd5e4d3ad8a90686bc81d49353fdb08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`3d8265c5`](https://github.com/nix-community/home-manager/commit/3d8265c5efd5e4d3ad8a90686bc81d49353fdb08) | `email: minor formatting fix` |