### PR TITLE
chore(flake/home-manager): `931e6105` -> `60b06424`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1655764740,
-        "narHash": "sha256-UyaiT92J+D4/kaVrM/DMMYC78JtokCHItLJ2ESeTCcI=",
+        "lastModified": 1655765732,
+        "narHash": "sha256-HH+B87PV+vHu63H9gqRgXt6wHKUQcMF6DeEdKFDEFF0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "931e6105523a9f4a50967558a896a6987dd99cac",
+        "rev": "60b064249d613eadc9020b146034d946287283f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`60b06424`](https://github.com/nix-community/home-manager/commit/60b064249d613eadc9020b146034d946287283f3) | `treewide: remove trailing white spaces and tabs` |