### PR TITLE
chore(flake/home-manager): `60b06424` -> `ce563f59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1655765732,
-        "narHash": "sha256-HH+B87PV+vHu63H9gqRgXt6wHKUQcMF6DeEdKFDEFF0=",
+        "lastModified": 1655766296,
+        "narHash": "sha256-Tw0/LXocQpcouU2/EKTsWQhU9/UUMJwFN3TiJdBoJCw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "60b064249d613eadc9020b146034d946287283f3",
+        "rev": "ce563f591195cf363bca382fe02ea5ca87754773",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`ce563f59`](https://github.com/nix-community/home-manager/commit/ce563f591195cf363bca382fe02ea5ca87754773) | `mopidy: add support for extraConfigFiles` |