### PR TITLE
chore(flake/nixpkgs): `5823018b` -> `c8f6b47a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655661709,
-        "narHash": "sha256-WkYIFUt+nRcTvAZCw597AG1luNxNGNucfPkBA/wA5Qo=",
+        "lastModified": 1655707439,
+        "narHash": "sha256-pLQHpTFguAtlpKA/iXw4EYKvTUKj4pAa3I/XYf8Yi1U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5823018b1b27b9675a51a84a7fc9cdd44327fa3e",
+        "rev": "c8f6b47ac9ed1e9b7f4672ef108299c8d4046a3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                  |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`80714dc3`](https://github.com/NixOS/nixpkgs/commit/80714dc3ec54612cee1de0e6b6eebad856ccd5e6) | `terraform-providers: update 2022-06-20`                                        |
| [`91206fb7`](https://github.com/NixOS/nixpkgs/commit/91206fb78504cc9d97f445105d1be6157e562c4a) | `python310Packages.peaqevcore: 1.0.19 -> 1.1.1`                                 |
| [`1bb76e9f`](https://github.com/NixOS/nixpkgs/commit/1bb76e9f8bf9b0524474b8e05fc22f4612873fc2) | `python310Packages.pglast: 3.11 -> 3.12`                                        |
| [`48a99192`](https://github.com/NixOS/nixpkgs/commit/48a99192af2deb8155549fde6ff395d8318924c3) | `ventoy-bin: 1.0.76 -> 1.0.77`                                                  |
| [`31f02117`](https://github.com/NixOS/nixpkgs/commit/31f02117dac480c9c9b1899b1ed9fe879d2d1f17) | `lima: 0.11.0 -> 0.11.1`                                                        |
| [`8a2e36cc`](https://github.com/NixOS/nixpkgs/commit/8a2e36cc53fc1e6de663bfd4cfcf3dc9f1b3a21a) | `vimPlugins.vim-go: simplify postPatch`                                         |
| [`2b74ba3e`](https://github.com/NixOS/nixpkgs/commit/2b74ba3ed7c7c38893d1dccf0ca4db5be3f0f738) | `vimPlugins.vim-go: move comment to right place`                                |
| [`beda5e6d`](https://github.com/NixOS/nixpkgs/commit/beda5e6dbad36dfb64f48da691800edc3b6f9830) | `python310Packages.ibm-cloud-sdk-core: disable on older Python releases`        |
| [`183d434b`](https://github.com/NixOS/nixpkgs/commit/183d434b87dd44277fc3490f722ba8ba2f91f625) | `python310Packages.ibm-cloud-sdk-core: 3.15.1 -> 3.15.3`                        |
| [`766aabd4`](https://github.com/NixOS/nixpkgs/commit/766aabd410bd455d5ad6e9e42fc4dc24a9f97b0a) | `python310Packages.google-cloud-spanner: 3.15.0 -> 3.15.1`                      |
| [`045cadf2`](https://github.com/NixOS/nixpkgs/commit/045cadf22b8c6984ce5170f540f1c457c048ae15) | `python3Packages.deal-solver: update disabled`                                  |
| [`2cfa8c20`](https://github.com/NixOS/nixpkgs/commit/2cfa8c207dcd71e0c65ab05cc0c60f6b77dd7e20) | `python310Packages.duckdb-engine: 0.1.8 -> 0.1.10`                              |
| [`b5ad148a`](https://github.com/NixOS/nixpkgs/commit/b5ad148a637e03e02bec67208766d75f55d31707) | `whalebird: 4.5.4 -> 4.6.0; add aarch64 support`                                |
| [`07d6e3fa`](https://github.com/NixOS/nixpkgs/commit/07d6e3fa99e4d8d8cd808599769572a9e18a6d07) | `maintainers: add colinsane`                                                    |
| [`e339c5a0`](https://github.com/NixOS/nixpkgs/commit/e339c5a0416bd87d35dc0c4aa1d1b4cd18cd2682) | `tor: 0.4.7.7 -> 0.4.7.8`                                                       |
| [`c61afdfe`](https://github.com/NixOS/nixpkgs/commit/c61afdfeb15451f999173b1097b375ae261f37aa) | `python310Packages.gidgethub: 5.1.0 -> 5.2.0`                                   |
| [`d63ba51d`](https://github.com/NixOS/nixpkgs/commit/d63ba51d588d406175c73e1084645c4145969b1f) | `python3Packages.httpagentparser: 1.9.2 -> 1.9.3`                               |
| [`c192dd30`](https://github.com/NixOS/nixpkgs/commit/c192dd305200cba292f7590a27c21ac10f02f948) | `python3Packages.deal-solver: 0.1.0 -> 0.1.1`                                   |
| [`c8f918e0`](https://github.com/NixOS/nixpkgs/commit/c8f918e0ef6b4fba6f1d311ae96349c7c0c2d7ab) | `keybase: 5.9.3 -> 6.0.2 https://github.com/keybase/client/releases/tag/v6.0.2` |
| [`9b200575`](https://github.com/NixOS/nixpkgs/commit/9b2005751229d7698a95211ce55bf72eecfa2df3) | `prometheus: 2.35.0 -> 2.36.0`                                                  |