### PR TITLE
chore(flake/nixos-hardware): `0cab18a4` -> `f9d8dff4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1654057797,
-        "narHash": "sha256-mXo7C4v7Jj2feBzcReu1Eu/3Rnw5b023E9kOyFsHZQw=",
+        "lastModified": 1655789751,
+        "narHash": "sha256-DbL2gn7YwkuX10OdlWfZ/A7zEJztwHh9NMeau1JMTdk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0cab18a48de7914ef8cad35dca0bb36868f3e1af",
+        "rev": "f9d8dff4e621f2d7f2b84d9e84bc6359715f971c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                    |
| ----------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`26291dec`](https://github.com/NixOS/nixos-hardware/commit/26291dec5bc0ea4ed1534fddbb4debc9b08d9e90) | `flake.nix: add common-gpu-intel` |