### PR TITLE
chore(flake/nixpkgs): `0886438a` -> `f0db300c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655751746,
-        "narHash": "sha256-93Co5He5xR6L7caReYMy3MqxRONM+AXKJg+iRgFUu9c=",
+        "lastModified": 1655795082,
+        "narHash": "sha256-ijb4A70VG0NQOFkdRkhzAHJCNQVGsuXfKTgMIuJOs64=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0886438a2c906d6f7c1f85929f271e8d9dd73972",
+        "rev": "f0db300ceb72f40dd48e0687f985dfd9040ad9f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                          |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`7eaefc94`](https://github.com/NixOS/nixpkgs/commit/7eaefc94174604ce8b7ccf20dbe72265561019c3) | `vector: 0.22.1 -> 0.22.2`                                              |
| [`7261506c`](https://github.com/NixOS/nixpkgs/commit/7261506c31acc97b4b12ea36e0d4440da8fd2e54) | `wordpress: 5.9.3 -> 6.0`                                               |
| [`b76e4a37`](https://github.com/NixOS/nixpkgs/commit/b76e4a37da9b7c549eb01836b73ff14a8b353d44) | `python310Packages.ocrmypdf: 13.4.7 -> 13.5.0`                          |
| [`d2b165e6`](https://github.com/NixOS/nixpkgs/commit/d2b165e6650c1a9c42769c139734e0a429f8d7a0) | `python310Packages.peaqevcore: 1.1.1 -> 1.2.1`                          |
| [`6fd60538`](https://github.com/NixOS/nixpkgs/commit/6fd60538efbf178a91d5f9e216922a6b747b3be6) | `python310Packages.miniaudio: 1.46 -> 1.50`                             |
| [`07a8ba34`](https://github.com/NixOS/nixpkgs/commit/07a8ba34b405154b1edf11782749b133badc661c) | `python310Packages.types-redis: 4.2.8 -> 4.3.0`                         |
| [`ce83dc76`](https://github.com/NixOS/nixpkgs/commit/ce83dc760cd3428ce9938aa711a0c7c81f55c567) | `python310Packages.gcal-sync: 0.9.0 -> 0.10.0`                          |
| [`89345648`](https://github.com/NixOS/nixpkgs/commit/893456482994ff0a83c4bc0f8165a6f5b5484954) | `clojure: 1.11.1.1139 -> 1.11.1.1145`                                   |
| [`404bfe21`](https://github.com/NixOS/nixpkgs/commit/404bfe212da6a644a907f6c2dc25d4c9f7d90199) | `maintainers/teams: add missing shortName for cosmopolitan`             |
| [`bbb4e423`](https://github.com/NixOS/nixpkgs/commit/bbb4e423e476622c47a55db710887b010a79bd8b) | `nomad: remove dependency on Nvidia (#178287)`                          |
| [`9ed79322`](https://github.com/NixOS/nixpkgs/commit/9ed793229ca8a988f49b2001b13d33f0edc0790d) | `teams/maintainers list: show instructions for validating the contents` |
| [`ff38ee15`](https://github.com/NixOS/nixpkgs/commit/ff38ee15c2762ffeacbfe19a259101c685429060) | `maintainer teams: check them in lib tests`                             |
| [`3ac995a5`](https://github.com/NixOS/nixpkgs/commit/3ac995a5680610000f36c855435062626cde1bed) | `maintainer lib test: extract maintainer module`                        |
| [`9284df58`](https://github.com/NixOS/nixpkgs/commit/9284df58c1c6af7192f7def7e2903d2b88e250ec) | `maintainers: document new maintainers and team changes`                |
| [`c8cebff3`](https://github.com/NixOS/nixpkgs/commit/c8cebff38b598a84466c387f694133585bba1a85) | `maintainers: remove longkeyid`                                         |
| [`79782405`](https://github.com/NixOS/nixpkgs/commit/797824054687f57f9bd3352dbf759d03ae2dcbb8) | `imagemagick: 7.1.0-37 -> 7.1.0-39`                                     |
| [`7a318822`](https://github.com/NixOS/nixpkgs/commit/7a31882201c62568b96e3d0b21a436d155c5c76a) | `wasabibackend: update dependencies`                                    |
| [`6623b825`](https://github.com/NixOS/nixpkgs/commit/6623b82593e172c0a7fe9decb346c90b6d89839e) | `python-language-server: update dependencies`                           |
| [`07c0456c`](https://github.com/NixOS/nixpkgs/commit/07c0456c6dda47faf5f64f0aa6d3a585e856780b) | `dotnet-sdk_3: 3.1.415 -> 3.1.420`                                      |
| [`ba1e8de5`](https://github.com/NixOS/nixpkgs/commit/ba1e8de5dad22a4985e7ff2e88d177c39ba09fbb) | `dnscontrol: 3.16.2 -> 3.17.0`                                          |
| [`0cb43143`](https://github.com/NixOS/nixpkgs/commit/0cb431439f9041caf329f9fa7ab9a5f4fd75856c) | `trivy: 0.29.0 -> 0.29.1`                                               |
| [`fe7d986b`](https://github.com/NixOS/nixpkgs/commit/fe7d986b71ea553656a434392dfc73033f333ef8) | `checkov: 2.0.1218 -> 2.0.1223`                                         |
| [`3573df33`](https://github.com/NixOS/nixpkgs/commit/3573df33e3250e1012a402e78c65bcac9e1f3d95) | `python310Packages.hahomematic: 1.8.5 -> 1.9.0`                         |
| [`118e0791`](https://github.com/NixOS/nixpkgs/commit/118e07917e1fc0617e60b3300d57cdc68aa1ac2b) | `yosys: 0.17 -> 0.18`                                                   |
| [`d1db18bc`](https://github.com/NixOS/nixpkgs/commit/d1db18bc69da8246071b247f12f9e1b84fa83812) | `yosys: 0.16 -> 0.17`                                                   |
| [`f4a768e2`](https://github.com/NixOS/nixpkgs/commit/f4a768e2518487ed3532e8ef108a6a6f2c675684) | `abc-verifier: 2022.03.22 -> 2022.05.06`                                |
| [`c70cbc07`](https://github.com/NixOS/nixpkgs/commit/c70cbc077eefc52061ae75ee858f854e3f75f672) | `brave: 1.38.115 -> 1.39.122`                                           |
| [`0aebaa8c`](https://github.com/NixOS/nixpkgs/commit/0aebaa8c6c7a936fd08ab1e53c8e397443208f61) | `nali: 0.3.2 -> 0.4.2`                                                  |
| [`83bcdb87`](https://github.com/NixOS/nixpkgs/commit/83bcdb870f227281c82158aa7a4dd621559e1534) | `maintainers: add xyenon`                                               |
| [`b14fe900`](https://github.com/NixOS/nixpkgs/commit/b14fe90066ce1a13443db20d0cee4f7a357f6875) | `chromiumDev: 104.0.5110.0 -> 104.0.5112.12`                            |
| [`419fcbb0`](https://github.com/NixOS/nixpkgs/commit/419fcbb05854b085f5b8f528958ec5101f412061) | `vivaldi: 5.3.2679.55-1 -> 5.3.2679.58-1`                               |
| [`646afb6b`](https://github.com/NixOS/nixpkgs/commit/646afb6bf8b9833cb1d10e0c426ce580a24189d6) | `dnsmonster: init at 0.9.3`                                             |
| [`1fc4712f`](https://github.com/NixOS/nixpkgs/commit/1fc4712f15ea60e7a69c79baebf233b23063122d) | `rPackages.gifski: fix build`                                           |
| [`88cefba4`](https://github.com/NixOS/nixpkgs/commit/88cefba441c9e44f94b6f7eab29f46783b04ffef) | `kodi.packages.urllib3: 1.26.8+matrix.1 -> 1.26.9+matrix.1`             |
| [`eb49cf16`](https://github.com/NixOS/nixpkgs/commit/eb49cf168410c8f7e6301ca1b8e71db0e678a7ba) | `gosca: init at 0.4.2`                                                  |
| [`185cf9eb`](https://github.com/NixOS/nixpkgs/commit/185cf9ebd65632ec3e1331ea14f1d7f7228f58bf) | `sad: 0.4.21 -> 0.4.22`                                                 |
| [`41b5af8b`](https://github.com/NixOS/nixpkgs/commit/41b5af8b6595e597f3bd51e85089f9eb44345eb6) | `anime-downloader: init at 5.0.14`                                      |