### PR TITLE
chore(flake/nixpkgs): `f0db300c` -> `e5bb9775`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655795082,
-        "narHash": "sha256-ijb4A70VG0NQOFkdRkhzAHJCNQVGsuXfKTgMIuJOs64=",
+        "lastModified": 1655967145,
+        "narHash": "sha256-ViPJ2Dit65OAiXwxmJXMre7e5XoMY6nuV28aC6BiGzw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f0db300ceb72f40dd48e0687f985dfd9040ad9f7",
+        "rev": "e5bb97751cbc401d769e3a1962f7cd05cf97e08a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`3f72ea86`](https://github.com/NixOS/nixpkgs/commit/3f72ea8615f27f64cf55fc4c0fe26e88c3911405) | `haskellPackages: mark builds failing on hydra as broken`                                  |
| [`3df217cf`](https://github.com/NixOS/nixpkgs/commit/3df217cf4de1ac1fc5bb3502d61631ec488d604b) | `clojure-lsp: 2022.05.31-17.35.50 -> 2022.06.22-14.09.50`                                  |
| [`6cd5486a`](https://github.com/NixOS/nixpkgs/commit/6cd5486acc0edc0afda16732e443bdf35f185e1e) | `radare2: unbreak on Darwin`                                                               |
| [`2573b8bc`](https://github.com/NixOS/nixpkgs/commit/2573b8bcc587eedc196d017bbf1d31acb66ee298) | `gnome.aisleriot: update source sha256`                                                    |
| [`bab3fd7c`](https://github.com/NixOS/nixpkgs/commit/bab3fd7c37ee8a5cfd4af960799f08360a3a96aa) | `harvid: fix pending upstream inclusion to support parallel builds`                        |
| [`bc575b10`](https://github.com/NixOS/nixpkgs/commit/bc575b1041fb714ea8b84ac0efe47371a3e7a47b) | `direnv: 2.32.0 -> 2.32.1`                                                                 |
| [`ff38a57a`](https://github.com/NixOS/nixpkgs/commit/ff38a57aa8ffe05b785099b45489df1db3c9a70a) | `gh: 2.12.1 -> 2.13.0`                                                                     |
| [`ef49524e`](https://github.com/NixOS/nixpkgs/commit/ef49524ebb050887e8466962f2db7b2b602f606a) | `thunderbird-bin-unwrapped: 91.9.1 -> 91.10.0`                                             |
| [`ef22f5fd`](https://github.com/NixOS/nixpkgs/commit/ef22f5fd93c754d433e1bdc5c9dba5c8b211d465) | `veriT: Fix build on macos`                                                                |
| [`3a0fa6aa`](https://github.com/NixOS/nixpkgs/commit/3a0fa6aabe1d4f25d18d89c340e00792c87f71ee) | `thunderbird-unwrapped: 91.9.1 -> 91.10.0`                                                 |
| [`fbf49431`](https://github.com/NixOS/nixpkgs/commit/fbf49431d7c1ae0c8f42c6c886138d6839d49974) | `vultr: use buildGoModule`                                                                 |
| [`39e6ebdf`](https://github.com/NixOS/nixpkgs/commit/39e6ebdfe1552028cd33eec26678a54d2f848f52) | `buildDhallUrl: fix impure proxy variable passing (#178544)`                               |
| [`73258f34`](https://github.com/NixOS/nixpkgs/commit/73258f3468039869c6a4fdeaf518a3ae937dc7ea) | `python310Packages.tensorflow-metadata: 1.8.0 -> 1.9.0`                                    |
| [`05180cfb`](https://github.com/NixOS/nixpkgs/commit/05180cfb01ffae135499007a1f85f186a70dfe4c) | `python310Packages.azure-mgmt-eventhub: disable on older Python releases`                  |
| [`59bd6ce4`](https://github.com/NixOS/nixpkgs/commit/59bd6ce4c86db54f207f15684fe445848fcfa707) | `python310Packages.azure-mgmt-eventhub: 10.0.0 -> 10.1.0`                                  |
| [`6cbcd261`](https://github.com/NixOS/nixpkgs/commit/6cbcd261f3a3797604fd9b14b781ac4e2667db72) | `python310Packages.cloudflare: 2.9.10 -> 2.9.11`                                           |
| [`a4ec26f6`](https://github.com/NixOS/nixpkgs/commit/a4ec26f67054e4f8cbd0d420c4fa5e9d249a6d43) | `nearcore: 1.26.1 -> 1.27.0`                                                               |
| [`d26a6e37`](https://github.com/NixOS/nixpkgs/commit/d26a6e377dbac403f02bdb43400615906049acb2) | `nixos/tests/home-assistant: stop printing log`                                            |
| [`cfbcf381`](https://github.com/NixOS/nixpkgs/commit/cfbcf381c27f0494f86f97056f43d1101ada715a) | `nixos/home-assistant: reload the daemon when configuration changed`                       |
| [`6a2dad3a`](https://github.com/NixOS/nixpkgs/commit/6a2dad3a376454f3979982a0e00aa2d89fe55fef) | `python3Packages.tensorflow-bin: fix for darwin`                                           |
| [`56e02acb`](https://github.com/NixOS/nixpkgs/commit/56e02acbb221bf7de7fc955b26a88e28181e9c7f) | `python3Packages.python-jenkins: remove deprecated unittest2`                              |
| [`e53c4b92`](https://github.com/NixOS/nixpkgs/commit/e53c4b9205b91525afd42507c39319342561c435) | `crun: Don't use hard-coded /usr/bin paths`                                                |
| [`6614cd8b`](https://github.com/NixOS/nixpkgs/commit/6614cd8b2bacf4f808f8ccbd9a8febe347b2107f) | `linuxPackages.ax99100: init at 1.8.0`                                                     |
| [`6cfccb56`](https://github.com/NixOS/nixpkgs/commit/6cfccb5648d9c94f4baaa68a3fa2a6d1f48d1a2d) | `etesync-dav: update dependencies`                                                         |
| [`9191e226`](https://github.com/NixOS/nixpkgs/commit/9191e226dba97ca2a32b7312fbdecb5fbf7b765a) | `python3Packages.aesara: 2.7.2 -> 2.7.3`                                                   |
| [`c3ef5cdc`](https://github.com/NixOS/nixpkgs/commit/c3ef5cdc082971bf3d54fa7affaa2eadfc1829c1) | `python3Packages.ducc0: 0.23.0 -> 0.24.0`                                                  |
| [`f3e7e834`](https://github.com/NixOS/nixpkgs/commit/f3e7e834b3a7eeb550be9d401ad7b5a9c2c562c7) | `home-assistant: 2022.6.6 -> 2022.6.7`                                                     |
| [`c9b79ecf`](https://github.com/NixOS/nixpkgs/commit/c9b79ecf8807d3be209244bafbe208ff1d1fc21f) | `python3Packages.nexia: 1.0.1 -> 1.0.2`                                                    |
| [`f18ee7aa`](https://github.com/NixOS/nixpkgs/commit/f18ee7aabd1b10bd6d4ef428b71bb609a9cad7a1) | `python310Packages.casbin: 1.16.5 -> 1.16.6`                                               |
| [`fc46e63a`](https://github.com/NixOS/nixpkgs/commit/fc46e63a8ad5f81c4f28c4d698fa9a78f6da6f1b) | `python310Packages.bitlist: 0.7.0 -> 0.8.0`                                                |
| [`85ab2e42`](https://github.com/NixOS/nixpkgs/commit/85ab2e42569b6ee0cf4dc934cd9576a26ec29e67) | `python3Packages.furo: 2022.4.7 -> 2022.6.21`                                              |
| [`cf78484d`](https://github.com/NixOS/nixpkgs/commit/cf78484db0f9be10aa0440a0d8d106f3f1d3f746) | `python3Packages.sphinx-basic-ng: init at 0.0.1.a11`                                       |
| [`485c4ca9`](https://github.com/NixOS/nixpkgs/commit/485c4ca93d675e6310bbf007c609cdb65d078fec) | `python310Packages.PyChromecast: 12.1.3 -> 12.1.4`                                         |
| [`829ef235`](https://github.com/NixOS/nixpkgs/commit/829ef23506d30f9a07a5d26242322ab82a036234) | `python310Packages.pysigma: 0.6.2 -> 0.6.3`                                                |
| [`addc764e`](https://github.com/NixOS/nixpkgs/commit/addc764e69fb45a5d6d9d79e9f7bf0692880d414) | `nuclei: 2.7.2 -> 2.7.3`                                                                   |
| [`6f5f69f1`](https://github.com/NixOS/nixpkgs/commit/6f5f69f11f5d4b849ca78796dece490e58c35d9f) | `gmtp: apply -fcommon workaround for real`                                                 |
| [`609d0d12`](https://github.com/NixOS/nixpkgs/commit/609d0d12d369e267e59019d265dd9c34370a0e2f) | `python3Packages.tensorflow-bin: 2.8.0 -> 2.9.0`                                           |
| [`a0edeb02`](https://github.com/NixOS/nixpkgs/commit/a0edeb02ae5b92eda6efbee4e26d8c33c15063fd) | `python310Packages.insteon-frontend-home-assistant: 0.1.0 -> 0.1.1`                        |
| [`e8a726fe`](https://github.com/NixOS/nixpkgs/commit/e8a726fec854e77da3c5c55a0bdcfd4becf5a932) | `python310Packages.pyoverkiz: 1.4.1 -> 1.4.2`                                              |
| [`e8768e4d`](https://github.com/NixOS/nixpkgs/commit/e8768e4d49b5823114ec7ecba2136fe5301a7c0a) | `python310Packages.pex: 2.1.92 -> 2.1.93`                                                  |
| [`d5e2ff64`](https://github.com/NixOS/nixpkgs/commit/d5e2ff64515b8e64f1e04ad9387b1ee7a9d1e58b) | `mattermost-desktop: 5.0.3 -> 5.1.0`                                                       |
| [`5eb6b335`](https://github.com/NixOS/nixpkgs/commit/5eb6b3350b87d195f80e38b4b7608f145e594b2b) | `python310Packages.peaqevcore: 1.2.1 -> 2.0.0`                                             |
| [`057fb309`](https://github.com/NixOS/nixpkgs/commit/057fb30998bb513f2f6bbc185b0e26b4b9124ba6) | `liquidsoap: 2.0.5 -> 2.0.6`                                                               |
| [`c355dfa9`](https://github.com/NixOS/nixpkgs/commit/c355dfa974a56cbdb1bdb91999ed05a08f08a707) | `clojure: 1.11.1.1145 -> 1.11.1.1149`                                                      |
| [`cbbc9759`](https://github.com/NixOS/nixpkgs/commit/cbbc9759b6c448227105a2a65367c09191a61279) | `yt-dlp: 2022.05.18 -> 2022.6.22.1`                                                        |
| [`d642e9d1`](https://github.com/NixOS/nixpkgs/commit/d642e9d16ed870214918d6fa56cd718a0a224f7a) | `python310Packages.types-requests: 2.27.30 -> 2.27.31`                                     |
| [`b148187d`](https://github.com/NixOS/nixpkgs/commit/b148187d654e8bff3d701448ce74e33fa9ab599d) | `appthreat-depscan: 2.1.6 -> 2.1.7`                                                        |
| [`a276ef6f`](https://github.com/NixOS/nixpkgs/commit/a276ef6f1ba72e2dea60d7181c71ca7f18928f81) | `mpd-discord-rpc: 1.5.1 -> 1.5.2`                                                          |
| [`588c4f21`](https://github.com/NixOS/nixpkgs/commit/588c4f214ee5c98d3925666d84555025e5e6ea5c) | `unvanquished: fix sdl event overflow (#178106)`                                           |
| [`587c6869`](https://github.com/NixOS/nixpkgs/commit/587c6869266d1e6b2471d50fa2cd7d2564a5835f) | `python310Packages.vyper: mark insecure`                                                   |
| [`701b918d`](https://github.com/NixOS/nixpkgs/commit/701b918dc3ce1565cb440ed792b0b8813c3576ea) | `python310Packages.waitress: 2.1.1 -> 2.1.2`                                               |
| [`2447fc09`](https://github.com/NixOS/nixpkgs/commit/2447fc09ec68ebfc6b1c1de9931ec8deffdabb68) | `python310Packages.rencode: 1.0.6 -> unstable-2021-08-10`                                  |
| [`a1b860e6`](https://github.com/NixOS/nixpkgs/commit/a1b860e67a25f4609b2ab17dbb297cb74a323a73) | `python310Packages.pypdf2: 1.26.0 -> 1.28.4`                                               |
| [`7b3c3d6c`](https://github.com/NixOS/nixpkgs/commit/7b3c3d6cedc5864f5fe20c03ff2ad27c06544d94) | `python310Packages.notebook: 6.4.10 -> 6.4.12`                                             |
| [`c8dbbe5c`](https://github.com/NixOS/nixpkgs/commit/c8dbbe5c3236dbc5445b31c69e5bf8251f172c0d) | `python310Packages.kerberos: mark insecure`                                                |
| [`b9f50b78`](https://github.com/NixOS/nixpkgs/commit/b9f50b7803a0d85bea6ef51ab3a75ec43add7a57) | `python310Packages.jupyter_server: 1.11.2 -> 1.17.1`                                       |
| [`af1bf5dc`](https://github.com/NixOS/nixpkgs/commit/af1bf5dc715da311163012c33fd4d4ad79f0f0ee) | `python310Packages.jupyterhub: 1.3.0 -> 1.5.0`                                             |
| [`cb8ab777`](https://github.com/NixOS/nixpkgs/commit/cb8ab777b86338badbb9b4ed9ffd0490a760cf9a) | `python310Packages.flower: mark insecure`                                                  |
| [`be19a33c`](https://github.com/NixOS/nixpkgs/commit/be19a33c51f09b5bcad64554a64d51e3b5beea4b) | `python310Packages.flask-caching: 1.10.1 -> 1.11.1`                                        |
| [`68ead458`](https://github.com/NixOS/nixpkgs/commit/68ead458d39660e346f05276c890184d4ec7ea68) | `python310Packages.cookiecutter: 1.7.3 -> 2.1.1`                                           |
| [`6683007e`](https://github.com/NixOS/nixpkgs/commit/6683007e3fd7cb33c0edb51f8c18ca079191102a) | `python310Packages.azure-mgmt-eventgrid: disable on older Python releases`                 |
| [`23983371`](https://github.com/NixOS/nixpkgs/commit/23983371b12e39303906d41c9da036ac9ef21f06) | `checkov: 2.0.1223 -> 2.0.1226`                                                            |
| [`7fb750c4`](https://github.com/NixOS/nixpkgs/commit/7fb750c431f588c71780cbd2c69ab0b651af46d1) | `python310Packages.http-sfv: 0.9.7 -> 0.9.8`                                               |
| [`de0f40f3`](https://github.com/NixOS/nixpkgs/commit/de0f40f35b78999d3dcfbef9650a34c57c044d64) | `chromium: 102.0.5005.115 -> 103.0.5060.53`                                                |
| [`c3cecf09`](https://github.com/NixOS/nixpkgs/commit/c3cecf09fa2186bce9aeb9a8846d45e06d34df2e) | `salt: 3004.1 -> 3004.2`                                                                   |
| [`671aeb27`](https://github.com/NixOS/nixpkgs/commit/671aeb2769fa164f0e6639e09e6c7d55657c7d26) | `snakemake: 7.8.2 -> 7.8.3`                                                                |
| [`9ece9628`](https://github.com/NixOS/nixpkgs/commit/9ece9628f6c37779865447d05bee9fbb0ff2baab) | `openipmi: fix build`                                                                      |
| [`b66a4b22`](https://github.com/NixOS/nixpkgs/commit/b66a4b22acbc153aadcbeb9f4e79a5bb8106f061) | `dagger: 0.2.19 -> 0.2.20`                                                                 |
| [`58a59bc5`](https://github.com/NixOS/nixpkgs/commit/58a59bc5fac36c5006a78bc8b492fab0a6f2cd21) | `moreutils: fix depends for strictDeps = true`                                             |
| [`c534d056`](https://github.com/NixOS/nixpkgs/commit/c534d056feceec34ddefc41adbc4a355e5c89ec9) | `pkgs/stdenv/generic/make-derivation.nix: add a bug reference to strictDepsByDefault TODO` |
| [`ef938d18`](https://github.com/NixOS/nixpkgs/commit/ef938d1800ddb799a6e6767222a98aed867896f3) | `python310Packages.pulumi-aws: 5.8.0 -> 5.9.0`                                             |
| [`ed60f38a`](https://github.com/NixOS/nixpkgs/commit/ed60f38a3b9f04ba8fbcfe5389712c1629e47f57) | `tradcpp: move autoconf to nativeBuildInputs`                                              |
| [`0553925b`](https://github.com/NixOS/nixpkgs/commit/0553925be6f81db483d6246c1d9333a5f88cd9b6) | `python310Packages.huggingface-hub: 0.7.0 -> 0.8.1`                                        |
| [`a0d48a15`](https://github.com/NixOS/nixpkgs/commit/a0d48a151571165567a2d45df82e9791d7d239de) | `duckdb: use upstream patch and name patch derivation`                                     |
| [`16f1c3ea`](https://github.com/NixOS/nixpkgs/commit/16f1c3ea1ef5f757508bf333141bfa1ef0defdd3) | `python3Packages.duckdb: add checkInputs`                                                  |
| [`78d4dc26`](https://github.com/NixOS/nixpkgs/commit/78d4dc263993aa683d9b056f7785bfb3d5c1f7b0) | `duckdb: 0.3.4 -> 0.4.0`                                                                   |
| [`2e9bdb61`](https://github.com/NixOS/nixpkgs/commit/2e9bdb6140db3e1046a48052646e59221ea1e64d) | `signal-cli: 0.10.2 -> 0.10.8`                                                             |
| [`e0c5c47a`](https://github.com/NixOS/nixpkgs/commit/e0c5c47aa89cf4d4e3b3c58c535b463b39785c3d) | `linuxPackages: use 5_15 kernel on 32-bit platforms`                                       |
| [`b0e0bdb8`](https://github.com/NixOS/nixpkgs/commit/b0e0bdb88037d98ba111c16459038e2e0257c0d9) | `Revert "linux_5_15: mark as broken on i686"`                                              |
| [`79e05fb1`](https://github.com/NixOS/nixpkgs/commit/79e05fb16b1af292e50cc0c479809cc66b47b087) | `linux-kernel: disable BTF on 32-bit platforms on kernels 5.15+`                           |
| [`b4a12c27`](https://github.com/NixOS/nixpkgs/commit/b4a12c2771f14e5b7ac79726da549d76952f61f6) | `act: 0.2.27 -> 0.2.28`                                                                    |
| [`409b6b79`](https://github.com/NixOS/nixpkgs/commit/409b6b79b506d54db281e503710a95d0c4e8e419) | `python310Packages.sagemaker: 2.95.0 -> 2.96.0`                                            |
| [`1be40195`](https://github.com/NixOS/nixpkgs/commit/1be40195913e568eb5d88d3a62dde65f06845418) | `maintainers: update ncfavier's keys`                                                      |
| [`e1c1fdd8`](https://github.com/NixOS/nixpkgs/commit/e1c1fdd8c222f646ce50e8b04469a238b59f0590) | ``nixos/networkd: add `IPv6PrivacyExtensions=kernel` for default networks``                |
| [`f8a83b42`](https://github.com/NixOS/nixpkgs/commit/f8a83b426000494c9b2fee5532f6b98beeeb8743) | ``nixos/networkd: make default networks `RequiredForOnline` when possible``                |
| [`2ddd1e92`](https://github.com/NixOS/nixpkgs/commit/2ddd1e920d2d1c5d28cda3fa54f895e985b357f3) | `tabnine: 4.0.60 -> 4.4.40`                                                                |
| [`15c3a47a`](https://github.com/NixOS/nixpkgs/commit/15c3a47a749259739a079511b4c411f17286e498) | `python310Packages.jsbeautifier: 1.14.3 -> 1.14.4`                                         |
| [`8aaa8582`](https://github.com/NixOS/nixpkgs/commit/8aaa8582ceb671cbc2974b9244a24df3b01c6553) | `python310Packages.fontparts: 0.10.5 -> 0.10.6`                                            |
| [`61209928`](https://github.com/NixOS/nixpkgs/commit/61209928e633b66676edfe628c612ad3428a7f4c) | `python310Packages.pysnmp-pysmi: 1.1.8 -> 1.1.10`                                          |
| [`263ff104`](https://github.com/NixOS/nixpkgs/commit/263ff104e5f185774436b577f1b12b29d59666f5) | `dterm: init at 0.5`                                                                       |
| [`4592f007`](https://github.com/NixOS/nixpkgs/commit/4592f00769b6e50cd8ddf1ba8e683f3854c47ab1) | `maintainers: add auchter`                                                                 |
| [`97532e05`](https://github.com/NixOS/nixpkgs/commit/97532e058740d19b13864311f92f23542339c1ff) | `python310Packages.aurorapy: 0.2.6 -> 0.2.7`                                               |
| [`6863e6a2`](https://github.com/NixOS/nixpkgs/commit/6863e6a229662af0ffb1bcd192448928e943d88f) | `dsq: 0.16.0 -> 0.20.1`                                                                    |
| [`ba2f31b6`](https://github.com/NixOS/nixpkgs/commit/ba2f31b6db0d71969bb1fcbeaed30925a935a5b0) | `buildDotnetModule: allow passing derivations to nugetDeps`                                |
| [`f822cc91`](https://github.com/NixOS/nixpkgs/commit/f822cc9113306a4549c85b473d5e5837d428f701) | `python310Packages.duckdb-engine: 0.1.10 -> 0.1.11`                                        |
| [`e1b9c01d`](https://github.com/NixOS/nixpkgs/commit/e1b9c01d0392464048f5f8a39ff319e94ae33ecc) | `act: 0.2.26 -> 0.2.27`                                                                    |
| [`a40cc0e3`](https://github.com/NixOS/nixpkgs/commit/a40cc0e39991003c0cf4e67be9fd48002cf6c301) | `eclipse.plugins.bytecode-outline: 2.5.0.201711011753-5a57fdf -> 1.0.1.202006062100`       |
| [`1367f89a`](https://github.com/NixOS/nixpkgs/commit/1367f89a7332aa9ab52fe3307c3175056bfd6d60) | `eclipse.plugins.anyedittools: 2.7.1.201709201439 -> 2.7.2.202006062100`                   |
| [`6b5f16d2`](https://github.com/NixOS/nixpkgs/commit/6b5f16d2f3fcaa6f7cb4007b1028425819eee5f8) | `python310Packages.datashader: 0.14.0 -> 0.14.1`                                           |
| [`ddea1ac9`](https://github.com/NixOS/nixpkgs/commit/ddea1ac91f2056a4d4d7b5de14c0dbd085d3c4e1) | `broot: 1.13.1 -> 1.13.3`                                                                  |
| [`1863bc87`](https://github.com/NixOS/nixpkgs/commit/1863bc8786eb1eb435c5d54b57951c0ef126172d) | `vscode-extensions.vscodevim.vim: 1.21.5 -> 1.22.2`                                        |
| [`86a41a8e`](https://github.com/NixOS/nixpkgs/commit/86a41a8ea2b100b748614b09136899ce8c5d82c8) | `papirus-icon-theme: 20220302 -> 20220606`                                                 |
| [`7ae2073b`](https://github.com/NixOS/nixpkgs/commit/7ae2073bfb14f06f55db3a7e11a3f78a9f554675) | `vscode-extensions.james-yu.latex-workshop: 8.23.0 -> 8.27.2`                              |
| [`a72d7811`](https://github.com/NixOS/nixpkgs/commit/a72d7811be1162dd6804c4e36e5402d76fb6e921) | `gnome.aisleriot: 3.22.23 -> 3.22.24`                                                      |
| [`d19e78af`](https://github.com/NixOS/nixpkgs/commit/d19e78af5fafcfb9c3b666dd486b30133dabe6dc) | `onionshare-gui: add pysocks dependency`                                                   |
| [`65af1629`](https://github.com/NixOS/nixpkgs/commit/65af162956a9ad49a20970e2c7432c14f6d1a2bf) | `python3Packages.boost169: remove`                                                         |
| [`1730a1e6`](https://github.com/NixOS/nixpkgs/commit/1730a1e637a88a810ea36c49ddc07390c6785827) | `shiboken2: unmark broken for Python 3.10`                                                 |
| [`baf4c35b`](https://github.com/NixOS/nixpkgs/commit/baf4c35b88a56e3eb55573558a4e9bd01af5331c) | `pyside2: 5.15.2 -> 5.15.5`                                                                |
| [`5b7f8d2e`](https://github.com/NixOS/nixpkgs/commit/5b7f8d2e436d3c196ae1b505eaf1cd26b6dc75b2) | `buildDotnetModule: use src-only in fetch-deps script`                                     |
| [`fb94bb0b`](https://github.com/NixOS/nixpkgs/commit/fb94bb0b208f32c391c74dd7b82df79c59771d4f) | `src-only: pass all arguments`                                                             |
| [`465d355e`](https://github.com/NixOS/nixpkgs/commit/465d355e5b3737b5f5d3c81fa06ca4df8c29b103) | `omnisharp-dotnet: use buildDotnetModule`                                                  |
| [`c277bd86`](https://github.com/NixOS/nixpkgs/commit/c277bd86a5d6ad89f927adde4d490912a6e1a61e) | `make-nuget-deps: support an url field in fetchNuGet`                                      |
| [`2f07f578`](https://github.com/NixOS/nixpkgs/commit/2f07f578b264bd90fb16d58744016d92ef3e412b) | `nuget-to-nix: support custom package sources`                                             |
| [`6c99b09a`](https://github.com/NixOS/nixpkgs/commit/6c99b09ac10593bcd1278791c1c157bebb15c735) | `python310Packages.azure-mgmt-eventgrid: 10.1.0 -> 10.2.0`                                 |
| [`3ff0d89a`](https://github.com/NixOS/nixpkgs/commit/3ff0d89af332bb69f5391b1bee85b1094b88e0ab) | `tdesktop: 3.7.3 -> 4.0.0`                                                                 |