### PR TITLE
chore(flake/home-manager): `ce563f59` -> `e622bad1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1655766296,
-        "narHash": "sha256-Tw0/LXocQpcouU2/EKTsWQhU9/UUMJwFN3TiJdBoJCw=",
+        "lastModified": 1655928858,
+        "narHash": "sha256-qVOcb7WVDiqs2yseZwCZRsKT0be8bF3NZufdBZVvZXU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ce563f591195cf363bca382fe02ea5ca87754773",
+        "rev": "e622bad16372aa5ada79a7fa749ec78715dffc54",
         "type": "github"
       },
       "original": {
@@ -173,10 +173,10 @@
       "flake": false,
       "locked": {
         "lastModified": 1653339422,
-        "narHash": "sha256-8nc7lcYOgih3YEmRMlBwZaLLJYpLPYKBlewqHqx8ieg=",
+        "narHash": "sha256-RNLq09vfj21TyYuUCeD6BNTNC6Ew8bLhQULZytN4Xx8=",
         "owner": "rycee",
         "repo": "nmd",
-        "rev": "9e7a20e6ee3f6751f699f79c0b299390f81f7bcd",
+        "rev": "91dee681dd1c478d6040a00835d73c0f4a4c5c29",
         "type": "gitlab"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`e622bad1`](https://github.com/nix-community/home-manager/commit/e622bad16372aa5ada79a7fa749ec78715dffc54) | ``neovim/coc: fix `withNodeJs` value when enabling coc (#3048)`` |
| [`06bb67ab`](https://github.com/nix-community/home-manager/commit/06bb67ab24bd6e6c6d2bc97ecbcddd6c8b07ac18) | `flake.lock: use SRI hash for nmd`                               |
| [`77f1c763`](https://github.com/nix-community/home-manager/commit/77f1c7636a92973be913ec21be5203edba017100) | `docs: bump nmd`                                                 |
| [`d059b944`](https://github.com/nix-community/home-manager/commit/d059b9448a04100cdd231872254283dc278a4ea0) | `mujmap: add module`                                             |
| [`46761794`](https://github.com/nix-community/home-manager/commit/467617947d25077d178fe060c841d8a92b9c3c2f) | `email: add support for JMAP`                                    |
| [`1ebbef86`](https://github.com/nix-community/home-manager/commit/1ebbef8642c511b289730e3985ec1d53c5c48908) | ``barrier: change `enableCrypto` behaviour``                     |
| [`206ded40`](https://github.com/nix-community/home-manager/commit/206ded407eb8cc80104fae41252705a67037f137) | `dunst: fix settings example`                                    |