### PR TITLE
chore(flake/pre-commit-hooks): `b7a131d0` -> `a2ce896c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -211,11 +211,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1655906603,
-        "narHash": "sha256-wwyJc0VPm7NQlQRspMrFFQQak1hHJwRfcNgGTL2onDA=",
+        "lastModified": 1656084831,
+        "narHash": "sha256-aLeUbXAu7FV/A04MfxbBig37/82XeoLmPqU3An0c6vc=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "b7a131d06a23b02ab8eaa12d249d282f3590cbf9",
+        "rev": "a2ce896cf922091e2588ca016805f50f12c82f48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                  |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------- |
| [`0bc0f69a`](https://github.com/cachix/pre-commit-hooks.nix/commit/0bc0f69ad509721917c3efb07f470aeae871e5f6) | `Add support for markdownlint`  |
| [`011e950a`](https://github.com/cachix/pre-commit-hooks.nix/commit/011e950a645652366676826481c26252a795b2f5) | `Lint README with markdownlint` |