### PR TITLE
chore(flake/home-manager): `e622bad1` -> `e0baf8ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1655928858,
-        "narHash": "sha256-qVOcb7WVDiqs2yseZwCZRsKT0be8bF3NZufdBZVvZXU=",
+        "lastModified": 1656150467,
+        "narHash": "sha256-IJcYUzBfHhk0bklnWROwvw3P4txsfas+EzPb3fD+dvw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e622bad16372aa5ada79a7fa749ec78715dffc54",
+        "rev": "e0baf8ee0c3578ea158df99f4443fdd30b9bfe14",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                             |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`e0baf8ee`](https://github.com/nix-community/home-manager/commit/e0baf8ee0c3578ea158df99f4443fdd30b9bfe14) | `docs: disable _module.check for nixos/nix-darwin modules` |
| [`da55d18b`](https://github.com/nix-community/home-manager/commit/da55d18ba2412d7102a915955dce0c916546447a) | `docs: fix typo in nix-darwin flake`                       |
| [`223b9dee`](https://github.com/nix-community/home-manager/commit/223b9deeaddb9b8e2a6325fb661d2f62abe8450d) | `pistol: add module`                                       |
| [`65bcfacc`](https://github.com/nix-community/home-manager/commit/65bcfaccc5584e3c04ac883dc0501faf1ec9025f) | `micro: add module`                                        |
| [`fd047c84`](https://github.com/nix-community/home-manager/commit/fd047c84f705442f04105e363ed450f54309591e) | `mcfly: add fuzzy search factor option`                    |