### PR TITLE
chore(flake/nixpkgs): `2417363a` -> `60801d44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656156292,
-        "narHash": "sha256-uMJUyysMgf1PKI9BpwaZCgCFRdJWCnkGvMOJTlKwx0E=",
+        "lastModified": 1656199433,
+        "narHash": "sha256-/J6xArOrqBHnXZcVAeITlgSLNASocBFiYHi8UL/gqCo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2417363ae2de5169338f3ec502d50ea9aaaa4b2e",
+        "rev": "60801d44897a49a07190dee82ddd2d05192bd057",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                       |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`2c1c79dc`](https://github.com/NixOS/nixpkgs/commit/2c1c79dce66571f97ba5c2a2b1c1175745ec7d79) | `vapoursynth: Add to pythonPackages (#175770)`                       |
| [`b3449fdd`](https://github.com/NixOS/nixpkgs/commit/b3449fddb39c39dcd96f9dc0235a344092bd6052) | `python310Packages.rapidfuzz: 2.0.11 -> 2.0.15`                      |
| [`ade62d2d`](https://github.com/NixOS/nixpkgs/commit/ade62d2d44d2d722f9cfdd5aa7ba4f253e372a82) | `rapidfuzz-cpp: 1.0.2 -> 1.0.3`                                      |
| [`d828f4db`](https://github.com/NixOS/nixpkgs/commit/d828f4dbf14df7af990dcbdf4490385deb2792cb) | `jless: remove maintainer`                                           |
| [`8f2e02be`](https://github.com/NixOS/nixpkgs/commit/8f2e02bee70660df0a1827cc4142502ab5a37fb8) | `synfigstudio.synfig,synfigstudio.ETL: expose`                       |
| [`378a8a69`](https://github.com/NixOS/nixpkgs/commit/378a8a69065b029f0128ec86540d4de2ab5e4d5b) | `synfigstudio: 1.0.2 -> 1.5.1, unbreak`                              |
| [`5f4f5c7c`](https://github.com/NixOS/nixpkgs/commit/5f4f5c7c2d8010b32eb0037087b18c7d56fc5393) | `flyctl: 0.0.330 -> 0.0.335`                                         |
| [`a27fe8a9`](https://github.com/NixOS/nixpkgs/commit/a27fe8a92f628e5cdc35375b8662df65ab71adb8) | `python310Packages.jarowinkler: 1.0.2 -> 1.0.4`                      |
| [`b86d7fc9`](https://github.com/NixOS/nixpkgs/commit/b86d7fc99b4c6fde61e8c31f5ce9ef99c81ae40d) | `jarowinkler-cpp: 1.0.1 -> 1.0.2`                                    |
| [`ad09daca`](https://github.com/NixOS/nixpkgs/commit/ad09dacadb82fc425b00fbf867b9bd79c03c6827) | `cargo-nextest: fix darwin build`                                    |
| [`d8caea9a`](https://github.com/NixOS/nixpkgs/commit/d8caea9adae9959b49107de22228d65c7fd06b4e) | `python310Packages.xmlschema: 1.11.2 -> 1.11.3`                      |
| [`5ae3d0e4`](https://github.com/NixOS/nixpkgs/commit/5ae3d0e495e7edbb31b3fce84a2fbd7ec2962e8b) | `esbuild: add marsam to maintainers`                                 |
| [`a6a9b537`](https://github.com/NixOS/nixpkgs/commit/a6a9b537e7d4472307c51bf0a9dbdded7f2087cc) | `esbuild: add ldflags`                                               |
| [`8e29a6b4`](https://github.com/NixOS/nixpkgs/commit/8e29a6b45e2b9ad89ecbae198bc771ef275b0550) | `esbuild: 0.14.39 -> 0.14.47`                                        |
| [`ce4ba2a0`](https://github.com/NixOS/nixpkgs/commit/ce4ba2a0f5cab9546211f9bef39aea286e667126) | `tidal-hifi: 4.0.0 -> 4.0.1`                                         |
| [`e64e3865`](https://github.com/NixOS/nixpkgs/commit/e64e386589c5e9b43f9c61e6feef0dcac5c24902) | `zoxide: 0.8.1 -> 0.8.2`                                             |
| [`ef147f9a`](https://github.com/NixOS/nixpkgs/commit/ef147f9a45c9872e48163f422364f5893f9712df) | `dua: 2.17.5 -> 2.17.7`                                              |
| [`dc4e352c`](https://github.com/NixOS/nixpkgs/commit/dc4e352c7426491cd80c25b74db46df27d46e9ba) | `cargo-make: 0.35.12 -> 0.35.13`                                     |
| [`7fa173c9`](https://github.com/NixOS/nixpkgs/commit/7fa173c938ef583841c3934356dfa9a367a18766) | `cargo-depgraph: 1.2.4 -> 1.2.5`                                     |
| [`21f75d65`](https://github.com/NixOS/nixpkgs/commit/21f75d65c5cb77f92e74d8eef87176ad787f006c) | `python310Packages.param: 1.12.1 -> 1.12.2`                          |
| [`3c2ece4a`](https://github.com/NixOS/nixpkgs/commit/3c2ece4a307b517bede287c7ec8b1d6a7c0e9564) | `cargo-nextest: 0.9.20 -> 0.9.22`                                    |
| [`7ac6886d`](https://github.com/NixOS/nixpkgs/commit/7ac6886d866b44a398aabfd6feb686e69535d214) | `fend: 1.0.1 -> 1.0.3`                                               |
| [`7d1a3b11`](https://github.com/NixOS/nixpkgs/commit/7d1a3b110f63b84da50b41776739e48b1d066c1a) | `ferium: init at 4.1.1`                                              |
| [`de4e1960`](https://github.com/NixOS/nixpkgs/commit/de4e1960d8c7d256a53af1475dd5f2704b9824cb) | `httm: 0.12.1 -> 0.12.2`                                             |
| [`fc658c86`](https://github.com/NixOS/nixpkgs/commit/fc658c86f70e45d238c404e0686cf4ed905b8382) | `riak, nixos/riak: remove`                                           |
| [`5710bac2`](https://github.com/NixOS/nixpkgs/commit/5710bac2b4bfece46ac10f08ada69f08c3831cab) | `nixos/gitlab: Use Git 2.35.x to work around git bug (#177776)`      |
| [`0a4e9dfd`](https://github.com/NixOS/nixpkgs/commit/0a4e9dfda2a239b86a2cc9e0ac57b874618102b8) | `gitlab: 15.0.2 -> 15.1.0 (#178651)`                                 |
| [`092994ab`](https://github.com/NixOS/nixpkgs/commit/092994ab7287233cef4e6f10dc175ebc95a520a3) | `ts3: disable native wayland support`                                |
| [`3eeeeb28`](https://github.com/NixOS/nixpkgs/commit/3eeeeb283288d365c4d495a82b6e66c2b57d864b) | `fn-cli: 0.6.17 -> 0.6.20`                                           |
| [`2d66c91a`](https://github.com/NixOS/nixpkgs/commit/2d66c91a51b6000b8590e13736fdc28e00b630e8) | `hollywood: init at 1.22`                                            |
| [`07328220`](https://github.com/NixOS/nixpkgs/commit/07328220b6a1c49db261f5ea342f1a38d45f2662) | `mathematica: set QT_QPA_PLATFORM to xcb (#178991)`                  |
| [`a610f830`](https://github.com/NixOS/nixpkgs/commit/a610f830e031ac18e109aff278155b52b5d95938) | `eksctl: 0.99.0 -> 0.104.0`                                          |
| [`b200beb1`](https://github.com/NixOS/nixpkgs/commit/b200beb1961ab91a969385ddfda129abefa386f5) | `peertube: 4.2.0 -> 4.2.1`                                           |
| [`0cbcfe8c`](https://github.com/NixOS/nixpkgs/commit/0cbcfe8c304948ed322da93fc9b314f2e6afc016) | `wezterm: 20220408-101518-b908e2dd -> 20220624-141144-bd1b7c5d`      |
| [`c3d58e6f`](https://github.com/NixOS/nixpkgs/commit/c3d58e6f32aee3264b87c21af227afd52ae7a478) | `vlc: add libplacebo as dependency`                                  |
| [`5efa54db`](https://github.com/NixOS/nixpkgs/commit/5efa54db61ec1360c8998884bd08ff520d5790f8) | `regpg: init at 1.11`                                                |
| [`d6f9b499`](https://github.com/NixOS/nixpkgs/commit/d6f9b499b2302759bb1283f1459ea7eb687ab911) | `python310Packages.gdown: 4.4.0 -> 4.5.0`                            |
| [`18f6ea9a`](https://github.com/NixOS/nixpkgs/commit/18f6ea9a12d0e520ae816125aa00269590dfa8b4) | `cmctl: 1.8.0 -> 1.8.1`                                              |
| [`cc35c652`](https://github.com/NixOS/nixpkgs/commit/cc35c6523f8484f7d4b6e41d15498b4e43e20806) | `dyff: 1.5.3 -> 1.5.4`                                               |
| [`34b7a468`](https://github.com/NixOS/nixpkgs/commit/34b7a4685f7c73ae1a8b9dcb7ca93606df0aaa74) | `doctest: 2.4.8 -> 2.4.9`                                            |
| [`2b3a93f6`](https://github.com/NixOS/nixpkgs/commit/2b3a93f65bb31cc1a82805256a48f26fff53d92d) | `maintainers: add 0xC45`                                             |
| [`43cb516e`](https://github.com/NixOS/nixpkgs/commit/43cb516e9efbfce750a4ae5d8c6aab505b0715e2) | `commonsDaemon: 1.3.0 -> 1.3.1`                                      |
| [`2fc3f8df`](https://github.com/NixOS/nixpkgs/commit/2fc3f8df4958ac87b0959b26fc9bb655b88a7d14) | `dar: 2.7.5 -> 2.7.6`                                                |
| [`6b29acef`](https://github.com/NixOS/nixpkgs/commit/6b29acef6ee9b207d1ea4be31be38953c62aca4f) | `mu: 1.6.11 -> 1.8.0`                                                |
| [`6f7bcb36`](https://github.com/NixOS/nixpkgs/commit/6f7bcb3671dc1a08cc3e7c47388a08149e427449) | `easyeffects: 6.2.5 -> 6.2.6`                                        |
| [`dbf01024`](https://github.com/NixOS/nixpkgs/commit/dbf01024e470d252fc7bee5ee688268cf517ef3e) | `cpp-utilities: 5.15.0 -> 5.16.0`                                    |
| [`40325047`](https://github.com/NixOS/nixpkgs/commit/403250473e359d048833050f4a98abcafeef7c3a) | `python310Packages.manuel: 1.11.2 -> 1.12.4`                         |
| [`16d3546a`](https://github.com/NixOS/nixpkgs/commit/16d3546a4b6685ec72ac429dcc26dfc3bd471063) | `dos2unix: 7.4.2 -> 7.4.3`                                           |
| [`73e0e7fe`](https://github.com/NixOS/nixpkgs/commit/73e0e7fe79cb244630e3697cd99335f276a9c07b) | `doctl: 1.76.0 -> 1.77.0`                                            |
| [`db265966`](https://github.com/NixOS/nixpkgs/commit/db2659669281f3a8c9b7418f4fbd640bc08cfbb6) | `update(logseq): 0.7.0 -> 0.7.5`                                     |
| [`5b2a0e90`](https://github.com/NixOS/nixpkgs/commit/5b2a0e9049843f8a8e7823c34f9536e646f0b2c7) | `feat(logseq): ignore prereleases on update check`                   |
| [`03be8485`](https://github.com/NixOS/nixpkgs/commit/03be8485b1b051dbd0b0ee19de94d8d181487338) | `syncthing-gtk: Remove leftovers`                                    |
| [`e36bf246`](https://github.com/NixOS/nixpkgs/commit/e36bf246271b83b5c601f810e21881bf2f4c15ce) | `dateutils: 0.4.9 -> 0.4.10`                                         |
| [`42287fc8`](https://github.com/NixOS/nixpkgs/commit/42287fc8d6fc9567a502762c9c3ad9f0b35df233) | `borgmatic: 1.6.3 -> 1.6.4`                                          |
| [`4f99ed85`](https://github.com/NixOS/nixpkgs/commit/4f99ed85e7d88d432f4e4aee7b883963a10cbf59) | `blueman: 2.2.4 -> 2.2.5`                                            |
| [`8d353ae5`](https://github.com/NixOS/nixpkgs/commit/8d353ae5fb8e005c460c3461b205fc48aa41de6e) | `cargo-insta: 1.14.0 -> 1.15.0`                                      |
| [`d06c9d47`](https://github.com/NixOS/nixpkgs/commit/d06c9d47d17ecb57390947e6de5c24473ac17917) | `chezmoi: 2.16.0 -> 2.18.1`                                          |
| [`63c7dfcb`](https://github.com/NixOS/nixpkgs/commit/63c7dfcbfe688c7fb20c136073ff326d798cb8ce) | `cargo-crev: 0.23.1 -> 0.23.2`                                       |
| [`43cbf5ef`](https://github.com/NixOS/nixpkgs/commit/43cbf5ef36aab241e71614e65317eaf14c709745) | `python310Packages.bimmer-connected: 0.9.4 -> 0.9.6`                 |
| [`f5d0c515`](https://github.com/NixOS/nixpkgs/commit/f5d0c5152a9d6eaf411373702a813f99002583f2) | `clash: 1.10.6 -> 1.11.0`                                            |
| [`4e7059cf`](https://github.com/NixOS/nixpkgs/commit/4e7059cf4f6c83260a97f4ffb5d0cfa77bc2f714) | `focus: init at unstable-2021-02-23`                                 |
| [`6d877c3b`](https://github.com/NixOS/nixpkgs/commit/6d877c3b43a7490962cc7deed97f0927224a7883) | `pmenu: init at 3.0.1`                                               |
| [`427c8e57`](https://github.com/NixOS/nixpkgs/commit/427c8e576cf7d83e069624d70dbf20e1f4589d90) | `cargo-expand: 1.0.21 -> 1.0.27`                                     |
| [`8424535d`](https://github.com/NixOS/nixpkgs/commit/8424535d209a8220e8c81bc7bea482a8058d19ee) | `python310Packages.types-requests: 2.27.31 -> 2.28.0`                |
| [`208389a8`](https://github.com/NixOS/nixpkgs/commit/208389a81efaf8d919aa0e562995ecffecfc6085) | `cloud-nuke: 0.11.6 -> 0.11.8`                                       |
| [`a47d96ca`](https://github.com/NixOS/nixpkgs/commit/a47d96ca1c55c11583acf907d844841c0290d979) | `python310Packages.snowflake-connector-python: 2.7.8 -> 2.7.9`       |
| [`25600b7b`](https://github.com/NixOS/nixpkgs/commit/25600b7b838be1ffe589d5d42d241364a3be8110) | `python310Packages.pysigma-backend-splunk: 0.3.3 -> 0.3.4`           |
| [`9e4cb79a`](https://github.com/NixOS/nixpkgs/commit/9e4cb79affe944fc01a70bf3929ced49f94a2b67) | `cilium-cli: 0.11.7 -> 0.11.10`                                      |
| [`86505325`](https://github.com/NixOS/nixpkgs/commit/8650532598b77e3be4e287285862ef793aa526bb) | `cargo-bloat: 0.11.0 -> 0.11.1`                                      |
| [`47d3acc8`](https://github.com/NixOS/nixpkgs/commit/47d3acc8b0fa2f7f23a64e737922ad4662b7cf24) | `cadvisor: 0.40.0 -> 0.44.1`                                         |
| [`69fe5e35`](https://github.com/NixOS/nixpkgs/commit/69fe5e35f7eb066cc289108584d30f0bed876d5e) | `python310Packages.aioswitcher: disable failing test`                |
| [`fbd2b865`](https://github.com/NixOS/nixpkgs/commit/fbd2b865eb2a1a8258ab42845a0da23f01338935) | `metasploit: 6.2.3 -> 6.2.4`                                         |
| [`a86c78d0`](https://github.com/NixOS/nixpkgs/commit/a86c78d0616a253d0b447a823d0fb00ccfa602a1) | `victor-mono: 1.5.2 -> 1.5.3`                                        |
| [`91357720`](https://github.com/NixOS/nixpkgs/commit/9135772075d8b114980fae5a2cd9031fef2f7cd4) | `python310Packages.time-machine: 2.7.0 -> 2.7.1`                     |
| [`ed7596a6`](https://github.com/NixOS/nixpkgs/commit/ed7596a60d0acbd643afe07609f2d3a7a881206e) | `pip-audit: 2.3.3 -> 2.3.4`                                          |
| [`e26fca28`](https://github.com/NixOS/nixpkgs/commit/e26fca28ae5279112024d308bbc9d15fdd30dfa5) | `chamber: 2.10.10 -> 2.10.12`                                        |
| [`9bc4144f`](https://github.com/NixOS/nixpkgs/commit/9bc4144fa9134b455196b5b0039773cce453bf0c) | `brook: 20220515 -> 20220707`                                        |
| [`43902236`](https://github.com/NixOS/nixpkgs/commit/43902236e09aefeb37cb30a9c6fb2508bb4711ba) | `cargo-llvm-lines: 0.4.15 -> 0.4.16`                                 |
| [`2f74b535`](https://github.com/NixOS/nixpkgs/commit/2f74b5358ce231ace5b50da335af1b9314623bb9) | `tdesktop: 4.0.0 -> 4.0.2`                                           |
| [`deab8d65`](https://github.com/NixOS/nixpkgs/commit/deab8d654d050721848fa1049d2f30e72f74a38a) | `helm-docs: 1.8.1 -> 1.10.0`                                         |
| [`22e2d3d6`](https://github.com/NixOS/nixpkgs/commit/22e2d3d6b4d975d2603bd1a6e1970bf1f32ad1bc) | `legendary-gl: 0.20.26 -> 0.20.27`                                   |
| [`d08919a5`](https://github.com/NixOS/nixpkgs/commit/d08919a511d1938902e3b23427a6b7d461a61ec1) | `heisenbridge: 1.13.0 -> 1.13.1`                                     |
| [`20429f32`](https://github.com/NixOS/nixpkgs/commit/20429f3274072805d2ebc0820a1ab3b1af770a02) | `_1password: 2.4.1 -> 2.5.1`                                         |
| [`eeb3e707`](https://github.com/NixOS/nixpkgs/commit/eeb3e707ff42721675a535deb74ef11ce8f7c35f) | `apko: 0.3.3 -> 0.4.0`                                               |
| [`ed0e7ad7`](https://github.com/NixOS/nixpkgs/commit/ed0e7ad72ef9c88fc738f2d1a5e8cd2099970620) | `mongodb-4_2: fixed`                                                 |
| [`eaebf07d`](https://github.com/NixOS/nixpkgs/commit/eaebf07d5c5eaacaf8cff8a819fc3a6fcc962c97) | `mongodb-4_0: fixed`                                                 |
| [`9f7b0d8f`](https://github.com/NixOS/nixpkgs/commit/9f7b0d8f0c876d8a1d5da98397bf64c9ab964097) | ``nixos/systemd-networkd-vrf: check routing tables via `ip --json``` |
| [`a60c23a2`](https://github.com/NixOS/nixpkgs/commit/a60c23a214f76a1dc87b5f2e0bd661f8d3b95316) | `uim: pull upstream fix for -fno-common toolchains`                  |
| [`e215af71`](https://github.com/NixOS/nixpkgs/commit/e215af71134261d31d9ff175999bfa051847bb48) | `nixos/tests/matrix-appservice-irc: fix typing mismatch`             |
| [`6c1f44b3`](https://github.com/NixOS/nixpkgs/commit/6c1f44b3f17fc2a4610d4565ea609b8cf5bfe8d9) | `nixos/matrix-appservice-irc: wait for postgres to start`            |
| [`48134305`](https://github.com/NixOS/nixpkgs/commit/48134305bb9f1839542cd5b5de2dbb15a5d489d7) | `ffsend: add marsam to maintainers`                                  |
| [`dbff0b87`](https://github.com/NixOS/nixpkgs/commit/dbff0b876ae713a83f0dcc2ac0f84010386ea753) | `libkqueue: 2.6.1 -> 2.6.2`                                          |
| [`278934a4`](https://github.com/NixOS/nixpkgs/commit/278934a4c8237b5dcd651ff007cc719abbd3feea) | `ffsend: 0.2.74 -> 0.2.76`                                           |
| [`3f328a51`](https://github.com/NixOS/nixpkgs/commit/3f328a5108746708201815f6515d700dadc94f21) | `python3.pkgs.systemd: Fix compatibility with Python 3.10`           |
| [`e6eaafff`](https://github.com/NixOS/nixpkgs/commit/e6eaafffffea036b31e427699c0edb7bc9393761) | `python3.pkgs.systemd: clean up`                                     |
| [`69efa4c2`](https://github.com/NixOS/nixpkgs/commit/69efa4c25351b9ceb7ee642ac6cacec7ca5bd4ab) | `i3status-rust: 0.21.10 -> 0.22.0`                                   |
| [`9e57dde1`](https://github.com/NixOS/nixpkgs/commit/9e57dde15b86a9dd3069f9a90fd7be96b5352876) | `nomachine-client: 7.9.2 -> 7.10.1`                                  |
| [`d4b3d027`](https://github.com/NixOS/nixpkgs/commit/d4b3d027b08dfde8abce1e59f944d04f4ad7b0ee) | `ocamlPackages.pbkdf: 1.1.0 → 1.2.0`                                 |
| [`ab7a6a51`](https://github.com/NixOS/nixpkgs/commit/ab7a6a51e09fde777ac8ee1ec4576eda2a6dde17) | `Revert "duplicity: S3 backups fail with "boto" not being found."`   |
| [`3e5042d4`](https://github.com/NixOS/nixpkgs/commit/3e5042d4ff4bb069cc506abea13ac50d0d4c03a1) | `octoprint.python.pkgs.stlviewer: fix build`                         |
| [`7da3e7fa`](https://github.com/NixOS/nixpkgs/commit/7da3e7fa2eb65bfb117c136de8f14ad76002e9b5) | `organicmaps: 2022.05.31-10 -> 2022.06.18-2`                         |
| [`44feda00`](https://github.com/NixOS/nixpkgs/commit/44feda004bda00a55a3d5d496756e4f5f1544e6c) | `sil-q: add a test`                                                  |
| [`3876d532`](https://github.com/NixOS/nixpkgs/commit/3876d5324247a47545f8c82a7826ec93933ee87f) | `sil: clean up a bit and add a test`                                 |
| [`6080c1e2`](https://github.com/NixOS/nixpkgs/commit/6080c1e20b258783afe6990ad96e6a66bbcd5a00) | `josm: 18427 → 18463`                                                |
| [`46c025be`](https://github.com/NixOS/nixpkgs/commit/46c025be1514723c8d477db8e45c7f3403500603) | `olm: 3.2.11 -> 3.2.12`                                              |
| [`e9af7d15`](https://github.com/NixOS/nixpkgs/commit/e9af7d1551294850757430c468ec3ac48a9b82f1) | `cvehound: 1.0.9 -> 1.1.0`                                           |
| [`bc588218`](https://github.com/NixOS/nixpkgs/commit/bc5882186725ab95194d2d26bd50c694ed3efa8b) | `grpc-client-cli: init at 1.12.0`                                    |