### PR TITLE
chore(flake/home-manager): `e0baf8ee` -> `1dbac84b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1656150467,
-        "narHash": "sha256-IJcYUzBfHhk0bklnWROwvw3P4txsfas+EzPb3fD+dvw=",
+        "lastModified": 1656199469,
+        "narHash": "sha256-17t4qc016C1p6oNSKOrYbOCErWhQI4dr4nzJKrGO8VE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e0baf8ee0c3578ea158df99f4443fdd30b9bfe14",
+        "rev": "1dbac84b846e4bfa21a08e31e95e11f0965ed042",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`1dbac84b`](https://github.com/nix-community/home-manager/commit/1dbac84b846e4bfa21a08e31e95e11f0965ed042) | `mpd-discord-rpc: restart on failure` |
| [`f2694685`](https://github.com/nix-community/home-manager/commit/f26946858e07384860bf288f20e39a8d32ed5b71) | `flake: remove superfluous arguments` |