### PR TITLE
chore(flake/nixos-hardware): `f9d8dff4` -> `99e33a57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -143,11 +143,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1655789751,
-        "narHash": "sha256-DbL2gn7YwkuX10OdlWfZ/A7zEJztwHh9NMeau1JMTdk=",
+        "lastModified": 1656241064,
+        "narHash": "sha256-+jWwBt515aFGukeX8WSafg9CM3Ju3FD0XrF+X4ph0mU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f9d8dff4e621f2d7f2b84d9e84bc6359715f971c",
+        "rev": "99e33a57149916ebede78ec13edd9ba310c10f2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                         |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`9194b8e9`](https://github.com/NixOS/nixos-hardware/commit/9194b8e949bed0be52729de9c1ed96674c0d3758) | ``nvidia: remove `-a` flag from exec`` |
| [`9ec5f52e`](https://github.com/NixOS/nixos-hardware/commit/9ec5f52ea235cdafa93f6fa69bf4183e8d8c1b23) | `Add lenovo legion 7 16ITHg6`          |