### PR TITLE
chore(flake/nixos-hardware): `99e33a57` -> `78e7c2c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1656241064,
-        "narHash": "sha256-+jWwBt515aFGukeX8WSafg9CM3Ju3FD0XrF+X4ph0mU=",
+        "lastModified": 1656353817,
+        "narHash": "sha256-UJEzMQcft/0Ilu4LWV7UH51mr5UCo28GL06BGO+djv4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "99e33a57149916ebede78ec13edd9ba310c10f2f",
+        "rev": "78e7c2c397b0376526e83162b58de921362e3399",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message               |
| ----------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`a3dfc310`](https://github.com/NixOS/nixos-hardware/commit/a3dfc3100b26fe664214e37a8eeb171af2f50b99) | `flake.nix: add macbook-pro` |