### PR TITLE
chore(flake/nixpkgs): `c3d95a02` -> `0c4852c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656243367,
-        "narHash": "sha256-8M5D+wpibrAvOcgbe3X13dhYZsGYhExfPnjrn+BA6oo=",
+        "lastModified": 1656370902,
+        "narHash": "sha256-wSJNOh2ODfqHlfjGHjOWDHr3AERIN7bnjU5LYy+9Ob4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c3d95a02e904e1ef9bb78c59d36eadc15e3428b7",
+        "rev": "0c4852c7bc40747e734a84a0d234105a4d5c146f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`1b308228`](https://github.com/NixOS/nixpkgs/commit/1b3082280540b1a06cf9adf9712a8b1e94d62116) | `vscode-extensions.vscode-neovim: 0.0.83 -> 0.0.86`                        |
| [`e6ebe074`](https://github.com/NixOS/nixpkgs/commit/e6ebe074d5843675c216ff9c629765d5e0c4e4e1) | `vscode-extensions.markdown-mermaid: init at 1.14.2`                       |
| [`788fc876`](https://github.com/NixOS/nixpkgs/commit/788fc876f99999ae0e96a64eb6371d892578cff4) | `sorted keys`                                                              |
| [`886bed4c`](https://github.com/NixOS/nixpkgs/commit/886bed4ccc52a7cdfcac41c56b751d545f6fa1fa) | `add 1password extension for vscode`                                       |
| [`6111acd7`](https://github.com/NixOS/nixpkgs/commit/6111acd7e64c8ad248f296db9ca778918299d728) | `vimPlugins.satellite-nvim: init at 2022-06-26`                            |
| [`fcfaac31`](https://github.com/NixOS/nixpkgs/commit/fcfaac31aae133ce4c785048ed002393fa472ed8) | `python310Packages.cachelib: 0.8.0 -> 0.9.0`                               |
| [`7b3018bb`](https://github.com/NixOS/nixpkgs/commit/7b3018bbe2c33f1b51b9a42ee13c155288459bb9) | `python310Packages.mkdocs-material: 8.3.6 -> 8.3.7`                        |
| [`0582290a`](https://github.com/NixOS/nixpkgs/commit/0582290a2fb94722b31795aaf71b25a28b2faa69) | `avro-c: replace lzma with xz`                                             |
| [`7c819053`](https://github.com/NixOS/nixpkgs/commit/7c81905344bd308c62509f93c87274c50ab54092) | `nixos/make-options-doc: Support Nix-provided declaration locations`       |
| [`de50d08d`](https://github.com/NixOS/nixpkgs/commit/de50d08d7395dba80e66cdec0321a070becd6650) | `buildPythonPackage: document why we always propagate python`              |
| [`7b5ee88a`](https://github.com/NixOS/nixpkgs/commit/7b5ee88acbb96e8ad5a06d7823e9b2a1a5be4ee7) | `vintagestory: 1.16.4 -> 1.16.5`                                           |
| [`707772a7`](https://github.com/NixOS/nixpkgs/commit/707772a739d1d860edc25934ebbb3d6a2e51d0a5) | `python310Packages.ormar: 0.11.1 -> 0.11.2`                                |
| [`29e7fe71`](https://github.com/NixOS/nixpkgs/commit/29e7fe71ef2648ec6b3771f96462063a97b63b22) | `vscode-extensions.dracula-theme.theme-dracula: 2.22.3 -> 2.24.2`          |
| [`f66f16c1`](https://github.com/NixOS/nixpkgs/commit/f66f16c103d74df95ccc484b23751ee8251407d8) | `trino-cli: init at 387`                                                   |
| [`0ff3a278`](https://github.com/NixOS/nixpkgs/commit/0ff3a27898457ade5f0f42ca417cdc4ff438a3c5) | `briar: init at 0.2.1-beta`                                                |
| [`2d958456`](https://github.com/NixOS/nixpkgs/commit/2d958456dbf6e7eb3c9fc9c8ddcc5497b8baea9a) | `pika-backup: 0.4.0 -> 0.4.1`                                              |
| [`fb9aa8ce`](https://github.com/NixOS/nixpkgs/commit/fb9aa8ce6174874cc814ce755c8823860c50f49f) | `erlang: remove r16-basho`                                                 |
| [`a0aea1e6`](https://github.com/NixOS/nixpkgs/commit/a0aea1e6c34f47d74f0c1bf0c8d23f911bf9561e) | `python310Packages.nodeenv: enable tests`                                  |
| [`e4c7b303`](https://github.com/NixOS/nixpkgs/commit/e4c7b303df800aecbdd32de98ff3864dad568d4f) | `python310Packages.nodeenv: 1.6.0 -> 1.7.0`                                |
| [`8bff3fef`](https://github.com/NixOS/nixpkgs/commit/8bff3fef401ed3ead39fd42bd581590ed863026e) | `nixos/make-options-doc: Support block quotes`                             |
| [`e04aa1bc`](https://github.com/NixOS/nixpkgs/commit/e04aa1bcd9050ff705b2cb410f6de9520c763b0c) | `nixos/make-options-doc: Escape inline code and code blocks`               |
| [`f900ed17`](https://github.com/NixOS/nixpkgs/commit/f900ed1749f1fd94f86fd0997b85a110be4e6648) | `nixos/make-options-doc: Support newline md node`                          |
| [`bccc3e74`](https://github.com/NixOS/nixpkgs/commit/bccc3e747b125433b92be779e9548586ae5a05ef) | `nixos/make-options-doc: Fix exception handler for arity /= 1 methods`     |
| [`aff2dbbc`](https://github.com/NixOS/nixpkgs/commit/aff2dbbc82c63fa8ad389aad5d78a2fc2461fc36) | `make-options-doc: Make variablelist id configurable`                      |
| [`4a8bc4fd`](https://github.com/NixOS/nixpkgs/commit/4a8bc4fd079b0ea3adf610d2b5ab6a8ceb10d4ce) | `lib/options: Add hint for debugging infinite recursion in docs`           |
| [`49237015`](https://github.com/NixOS/nixpkgs/commit/49237015d6ee97e46b2c4aa48190e2f4c9114535) | `nixos/doc: Make nixos-manual-combined fail easy to inspect`               |
| [`00fe47bc`](https://github.com/NixOS/nixpkgs/commit/00fe47bc0eda6aab90758e0808a6ea2fb1562763) | `intel-ocl: add web archive link since other links 404`                    |
| [`fd6a8fb8`](https://github.com/NixOS/nixpkgs/commit/fd6a8fb8942cc81f39fe6fcfdc404ff4535c7c57) | `openssl_3: rename from openssl_3_0`                                       |
| [`c59d1ebd`](https://github.com/NixOS/nixpkgs/commit/c59d1ebd6eeb2c9a2889e22a2249ad5a1a341375) | `openssl_3_0: fix apparent x86_64 AVX512 RCE`                              |
| [`284ff42c`](https://github.com/NixOS/nixpkgs/commit/284ff42c48771e90d1522ac1885c996687084da4) | `chatty: 0.6.6 -> 0.6.7`                                                   |
| [`284d5486`](https://github.com/NixOS/nixpkgs/commit/284d5486a5155329f9831be8c5f92775260440be) | `weechat-matrix: fix startup crash`                                        |
| [`0e444785`](https://github.com/NixOS/nixpkgs/commit/0e444785a16b0cb278dfd5aaa4d04b7730a269d8) | `installer/tools/get-version-suffix: set --git-dir`                        |
| [`d3d7ea1a`](https://github.com/NixOS/nixpkgs/commit/d3d7ea1acea73cd70aa89f9c04ecc7cbf4ac1643) | `spidermonkey_91: 91.10.0 -> 91.11.0`                                      |
| [`71c17fd1`](https://github.com/NixOS/nixpkgs/commit/71c17fd17f354044548ba045ac50f77bd1ccf259) | `firefox-beta-bin-unwrapped: 102.0b5 -> 102.0b9`                           |
| [`46f9c893`](https://github.com/NixOS/nixpkgs/commit/46f9c893900800f987ee841a945b8333a01f940b) | `firefox-devedition-unwrapped: 102.0b6 -> 102.0b9`                         |
| [`ddc17118`](https://github.com/NixOS/nixpkgs/commit/ddc17118f07f32a967f7deb0a6468a2192df80a1) | `firefox-esr-91-unwrapped: 91.10.0esr -> 91.11.0esr`                       |
| [`18323645`](https://github.com/NixOS/nixpkgs/commit/18323645997925e0b9aa49ad06532e8a8b85549c) | `firefox-esr-102-unwrapped: init at 102.0esr`                              |
| [`32b18b77`](https://github.com/NixOS/nixpkgs/commit/32b18b77bdbc0dbba702474ee514fe0018e96b1f) | `firefox-bin-unwrapped: 101.0.1 -> 102.0`                                  |
| [`736555d0`](https://github.com/NixOS/nixpkgs/commit/736555d08f12e08628374a059f3052a9533acb9e) | `firefox-unwrapped: 101.0.1 -> 102.0`                                      |
| [`0330a06e`](https://github.com/NixOS/nixpkgs/commit/0330a06eea5cf7f6aca59119ed98bd737b940408) | `wlr-randr: upstream moved from GitHub to Sourcehut`                       |
| [`db4d8640`](https://github.com/NixOS/nixpkgs/commit/db4d8640c139bbad0465fc9b2e55e36b14eaf695) | `busybox: patch CVE-2022-30065`                                            |
| [`9790d255`](https://github.com/NixOS/nixpkgs/commit/9790d255837a5117e8f52cbaf93d2cabb57e1971) | `home-assistant: relax requests`                                           |
| [`73996804`](https://github.com/NixOS/nixpkgs/commit/739968042e1b4ab0232054bb9dfdf05030c1f755) | `chain-bench: 0.0.2 -> 0.0.3`                                              |
| [`bba3722a`](https://github.com/NixOS/nixpkgs/commit/bba3722a1ea6815dc56f12d6af731c16d0266bf3) | `bird: 2.0.9 -> 2.0.10`                                                    |
| [`e7b935d2`](https://github.com/NixOS/nixpkgs/commit/e7b935d2d966c82cfc1b55c1ab4b996d24d220d8) | `python310Packages.aiounifi: 32 -> 33`                                     |
| [`54c19e24`](https://github.com/NixOS/nixpkgs/commit/54c19e24083aa577132716873ba26c723cc3eb2c) | `lnd: 0.14.3-beta -> 0.15.0-beta`                                          |
| [`3de3be92`](https://github.com/NixOS/nixpkgs/commit/3de3be92875f32fc4f50dea8b159323e3f644264) | `clightning: 0.11.1 -> 0.11.2`                                             |
| [`b7cea71f`](https://github.com/NixOS/nixpkgs/commit/b7cea71f1bce4b9620b4203c78101ee3b68e6aa4) | `dbeaver: 22.1.0 -> 22.1.1`                                                |
| [`a1c4db68`](https://github.com/NixOS/nixpkgs/commit/a1c4db689c4e9e97557bd657b320d7834d73a794) | `pkgsStatic.jansson: fix build`                                            |
| [`8fb70dee`](https://github.com/NixOS/nixpkgs/commit/8fb70dee32dc0cf86d04b1ae477c0a4ba9a27652) | `gnutls: [darwin] propagate the security framework (#179298)`              |
| [`a2b3b2a1`](https://github.com/NixOS/nixpkgs/commit/a2b3b2a1b6494d46e37c8be0ef998333d15c6f59) | `nixosTests.virtualbox: fix on AMD`                                        |
| [`b9460c15`](https://github.com/NixOS/nixpkgs/commit/b9460c15f51d323ddf489af6643f574fe1dbd33f) | `sheldon: init at 0.6.6`                                                   |
| [`1a0aec09`](https://github.com/NixOS/nixpkgs/commit/1a0aec09050d1e71a10f1cd17388170f16668408) | `python310Packages.awesomeversion: 22.5.2 -> 22.6.0`                       |
| [`7c7dd205`](https://github.com/NixOS/nixpkgs/commit/7c7dd205081734df85a59cfd5c12777e41e165ed) | `checkov: 2.1.7 -> 2.1.9`                                                  |
| [`475a78ca`](https://github.com/NixOS/nixpkgs/commit/475a78ca1d664fce38fecfb4ef5e3c95deaeacad) | `checkov: 2.1.5 -> 2.1.7`                                                  |
| [`4287cc71`](https://github.com/NixOS/nixpkgs/commit/4287cc71bef469c280416e4dd0459c1941e5e049) | `terraform-providers: update 2022-06-27`                                   |
| [`e2251e7c`](https://github.com/NixOS/nixpkgs/commit/e2251e7c3707005200fe1bb3b8d2194b88bfd04e) | `python310Packages.blinkpy: 0.19.0 -> 0.19.1`                              |
| [`6c0aa008`](https://github.com/NixOS/nixpkgs/commit/6c0aa0083cb1be43b31862d00847d0e49210eb63) | `metal-cli: 0.7.4 -> 0.9.0`                                                |
| [`9467dd32`](https://github.com/NixOS/nixpkgs/commit/9467dd32840b89bae9650f83275e70f39f5113f4) | `ocamlPackages.mldoc: init at 1.3.9`                                       |
| [`af1f9a54`](https://github.com/NixOS/nixpkgs/commit/af1f9a541336210cb2e829cc6e7d11700eac7b65) | `tig: fix segmentation on aarch64-darwin`                                  |
| [`f36997dd`](https://github.com/NixOS/nixpkgs/commit/f36997dd77b84c7687ba67d86487f29b5fe2a0d5) | `jellyfin-web: 10.8.0 -> 10.8.1`                                           |
| [`2847e6e6`](https://github.com/NixOS/nixpkgs/commit/2847e6e6915915af8d5c3407e82425e4c9ef09cd) | `bind: 9.18.3 -> 9.18.4`                                                   |
| [`c8c7b963`](https://github.com/NixOS/nixpkgs/commit/c8c7b9631d3f084a001e16b3d1f9ad3e1df08c9a) | `jellyfin: 10.8.0 -> 10.8.1`                                               |
| [`087eeea1`](https://github.com/NixOS/nixpkgs/commit/087eeea133e681e33b02cce3e4f3f7d0b470cff8) | `darwin.iproute2mac: 1.2.1 -> 1.4.0`                                       |
| [`1fa008d2`](https://github.com/NixOS/nixpkgs/commit/1fa008d23be0d2dc4de913508d98acbb7c76b1cc) | `nixos/maintainers: add jiegec`                                            |
| [`853edb8f`](https://github.com/NixOS/nixpkgs/commit/853edb8f61b822ffefc9c7584ed1565d6ecb05b2) | `godns: 2.7.8 -> 2.7.9`                                                    |
| [`83414015`](https://github.com/NixOS/nixpkgs/commit/8341401554ac9db55c6618caf008fbc7f7c6af85) | `hubble: 0.9.0 -> 0.10.0`                                                  |
| [`7a242c5d`](https://github.com/NixOS/nixpkgs/commit/7a242c5d029f129b4c1ecff3836d8e382825501d) | `cilium-cli: enable shell completion`                                      |
| [`aae04767`](https://github.com/NixOS/nixpkgs/commit/aae0476728516c6a2ce78638fbc13436c4f4fa19) | `xmcp: move to X11 directory`                                              |
| [`192ac79d`](https://github.com/NixOS/nixpkgs/commit/192ac79d73d62ef35cad3244faaa3b3a89c62920) | `terraform-providers.equinix: init at 1.5.0`                               |
| [`81b65cc1`](https://github.com/NixOS/nixpkgs/commit/81b65cc1aab4198e403871f521422e8e39afb278) | `python310Packages.nibabel: 4.0.0 -> 4.0.1`                                |
| [`32964dd2`](https://github.com/NixOS/nixpkgs/commit/32964dd23d1b5522015e0c9d5134ff2542156a16) | `pykms: switch to maintained fork, fix PYTHONPATH, add test`               |
| [`a1feff11`](https://github.com/NixOS/nixpkgs/commit/a1feff112bb34f8dfac72e84fd4287400346a23e) | `python310Packages.dremel3dpy: 1.0.1 -> 1.1.1`                             |
| [`2b9bd14b`](https://github.com/NixOS/nixpkgs/commit/2b9bd14ba9574010080f71bab649dc529cd71e4f) | `unrar: 6.1.6 -> 6.1.7`                                                    |
| [`1349b184`](https://github.com/NixOS/nixpkgs/commit/1349b184baee960fa36b82ab8f5dc585881f3963) | `sudo: 1.9.11p1 -> 1.9.11p3`                                               |
| [`d534fa70`](https://github.com/NixOS/nixpkgs/commit/d534fa7085900882da0ca9b5ac0e5ad7c5070c81) | `nixos/i18n: include locales from extraLocaleSettings in supportedLocales` |
| [`efe84746`](https://github.com/NixOS/nixpkgs/commit/efe84746594a04cb4414f87aa53192eab2119398) | `boulder: release-2022-05-31 -> release-2022-06-21`                        |
| [`4a4f0cc4`](https://github.com/NixOS/nixpkgs/commit/4a4f0cc4111a06b102528b90a44dbcdeaf7f39a1) | `chromiumDev: 104.0.5112.12 -> 104.0.5112.20`                              |
| [`57a56ee3`](https://github.com/NixOS/nixpkgs/commit/57a56ee3d56b63d820db30fa18b1595209ab0986) | `chromiumBeta: 103.0.5060.53 -> 104.0.5112.20`                             |
| [`ce6f0bee`](https://github.com/NixOS/nixpkgs/commit/ce6f0bee59f91f174e51dc92bfeb5698ca7da84a) | `bs-platform: workaround -fno-common build failure on aarch64`             |
| [`e6a76ff9`](https://github.com/NixOS/nixpkgs/commit/e6a76ff9ae0472e2b946886218965717bcd760ea) | `_7zz: 21.07 -> 22.00`                                                     |
| [`ac99f604`](https://github.com/NixOS/nixpkgs/commit/ac99f604e72a9e27030c0f977788269a1a4fb960) | `python310Packages.pytibber: 0.22.3 -> 0.23.0`                             |
| [`1b891603`](https://github.com/NixOS/nixpkgs/commit/1b891603df9a1b971ac9df53150a89b60912c827) | `python310Packages.pubnub: 6.3.2 -> 6.3.3`                                 |
| [`137e9a63`](https://github.com/NixOS/nixpkgs/commit/137e9a6316b0dce6b5f6f30cd6979b0706d7956b) | `wiki-js: 2.5.284 -> 2.5.285`                                              |
| [`d6f59779`](https://github.com/NixOS/nixpkgs/commit/d6f59779c60945aafa416c6e6b0fccb91e49f929) | `nixos/nextcloud: remove extraneous nginx config directive`                |
| [`e54ddddd`](https://github.com/NixOS/nixpkgs/commit/e54ddddd2a80a5897d45d2b4bd84e9bdd650d1cd) | `nixos/nextcloud: make all services run after nextcloud-setup`             |
| [`6be3ce36`](https://github.com/NixOS/nixpkgs/commit/6be3ce36b6287f03c758adbdd7d57ea582114b48) | `nixos/nextcloud: use mkOption.default for datadir`                        |
| [`7898af7d`](https://github.com/NixOS/nixpkgs/commit/7898af7d3a134e9741458c335da523f42944d92b) | `ghc: Work around broken pyopenssl on aarch64-darwin`                      |
| [`b75a2042`](https://github.com/NixOS/nixpkgs/commit/b75a20420b72fa7bb433c3722377c7212dbb9b2e) | `sphinx_offline: init`                                                     |
| [`253fa03e`](https://github.com/NixOS/nixpkgs/commit/253fa03ea93550f2c8659cdfcd436e089d8fd78b) | `nixosTests.virtualbox.net-hostonlyif: use dhcpcd`                         |
| [`34ec1172`](https://github.com/NixOS/nixpkgs/commit/34ec11729e4a5a415c10785b79ed1a651a710857) | `nixosTests.virtualbox: fix for blocking stdout`                           |
| [`e2617706`](https://github.com/NixOS/nixpkgs/commit/e2617706ed138e27f912871cf4a3dd30cf6aa079) | `nixosTests.virtualbox: fix logging service`                               |
| [`17b00794`](https://github.com/NixOS/nixpkgs/commit/17b00794360dc3161f5e5a24d7d8f635fea774eb) | `nixosTests.virtualbox: create shared dir before VM`                       |
| [`ecaa6f5c`](https://github.com/NixOS/nixpkgs/commit/ecaa6f5c60db3db0e0080df81663a8f2b1731a2a) | `nixosTests.virtualbox.host-usb-permissions: import sys`                   |
| [`6ce4afce`](https://github.com/NixOS/nixpkgs/commit/6ce4afce638fd7d2033518fa6550a0aba731edf7) | `nixosTests.virtualbox: always use nested KVM`                             |
| [`97a16f52`](https://github.com/NixOS/nixpkgs/commit/97a16f52d718073531ddc3bb3aa038110793ae06) | `linuxPackages.virtualboxGuestAdditions: properly mark platforms`          |
| [`943fd5ea`](https://github.com/NixOS/nixpkgs/commit/943fd5ea4b17b9d7d2be3b2ff9316858fde61270) | `pkgsi686Linux.linuxPackages.virtualboxGuestAdditions: mark broken`        |
| [`2c2d5c38`](https://github.com/NixOS/nixpkgs/commit/2c2d5c386e2169507f0cc6bf1411e495a64164d7) | `python310Packages.pyrogram: 2.0.27 -> 2.0.30`                             |
| [`78fbe407`](https://github.com/NixOS/nixpkgs/commit/78fbe407d7f0a67f7f0d4d0d2f116555e75bbf69) | `yq-go: 4.25.2 -> 4.25.3`                                                  |
| [`a9f91249`](https://github.com/NixOS/nixpkgs/commit/a9f912498f6f415e8f9e3dc9da7565f8c3394e64) | ``Replace use of `testVersion` alias``                                     |
| [`b32c2a71`](https://github.com/NixOS/nixpkgs/commit/b32c2a712bcda04ef8c4abbd28c8dde0cb80e972) | `python310Packages.bimmer-connected: 0.9.6 -> 0.10.0`                      |
| [`1a32663e`](https://github.com/NixOS/nixpkgs/commit/1a32663efcdb2742c440419ee73b6626ae02f5aa) | ``treewide: rename maintainer `earvstedt` -> `erikarvstedt```              |
| [`1e6ba038`](https://github.com/NixOS/nixpkgs/commit/1e6ba0387a5ade65cdeb09fab6810cde4cff94ea) | `python310Packages.geoip2: 4.5.0 -> 4.6.0`                                 |
| [`0cf6e38a`](https://github.com/NixOS/nixpkgs/commit/0cf6e38a676db1aad8ce0559949b6f3868f84798) | `python310Packages.types-setuptools: 57.4.17 -> 57.4.18`                   |
| [`8e0d4648`](https://github.com/NixOS/nixpkgs/commit/8e0d4648a2c10591d191e933c346597cb88872a6) | `python310Packages.channels: 3.0.4 -> 3.0.5`                               |
| [`fb9e656d`](https://github.com/NixOS/nixpkgs/commit/fb9e656d48784ef32353c06330558161abefde60) | `git-autofixup: init as alias`                                             |
| [`e99c8429`](https://github.com/NixOS/nixpkgs/commit/e99c8429400555044c13d0bd39bd6fc945119468) | `python310Packages.gdown: 4.5.0 -> 4.5.1`                                  |
| [`fcc334d7`](https://github.com/NixOS/nixpkgs/commit/fcc334d7d65c9cdf9d5d53f080dd5e45f98f4882) | `micromamba: 0.22.0 -> 0.24.0`                                             |
| [`019bb41b`](https://github.com/NixOS/nixpkgs/commit/019bb41bdce273a06de38cf81420dc3fcd775ec9) | `cli11: 1.9.1 -> 2.2.0`                                                    |
| [`ef0f0603`](https://github.com/NixOS/nixpkgs/commit/ef0f060348ca0732c3d241ff869f1f2e111a1c2a) | `python310Packages.types-tabulate: 0.8.10 -> 0.8.11`                       |
| [`bb5ec462`](https://github.com/NixOS/nixpkgs/commit/bb5ec4625ac3237631c7a0957c78cc79735fd2ad) | `nixos/thunar: init`                                                       |
| [`ca12710b`](https://github.com/NixOS/nixpkgs/commit/ca12710b06449ce3910284ac4c5ff861bddcd4b2) | `extra-container: 0.8 -> 0.10`                                             |
| [`67618864`](https://github.com/NixOS/nixpkgs/commit/676188646f681f142fddc30f74b2c32591a0671d) | `haskellPackages: mark builds failing on hydra as broken`                  |
| [`ee491c53`](https://github.com/NixOS/nixpkgs/commit/ee491c539338c64c4311134d0505967cccfb0062) | `drone: 2.12.0 -> 2.12.1`                                                  |
| [`ec996b2d`](https://github.com/NixOS/nixpkgs/commit/ec996b2d0ce827fe4f046a9c29401092767f62ba) | `malcontent: 0.10.4 → 0.10.5`                                              |
| [`cdecf666`](https://github.com/NixOS/nixpkgs/commit/cdecf66640f2bec6f6cb41dea0c06d416bd8a902) | `ldtk: init at 1.1.3`                                                      |
| [`899a6c99`](https://github.com/NixOS/nixpkgs/commit/899a6c99cdcd043028146f67de38726fb662ba77) | `python310Packages.casbin: 1.16.6 -> 1.16.8`                               |
| [`53c202dc`](https://github.com/NixOS/nixpkgs/commit/53c202dc53b81d88227ba2c60455c47a24dd24d2) | `pixelorama: init at 0.10.1`                                               |