### PR TITLE
chore(flake/nixpkgs): `8a8a0ad0` -> `86de228c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656455637,
-        "narHash": "sha256-3T1yEc9TvL4LcA2QXLPVA3d85pNgfeKije9uQtwEL9s=",
+        "lastModified": 1657140017,
+        "narHash": "sha256-SIIxfx0yNb7BEXi2VuXBMnbo/IMJsAywX0o/a/M3m6Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a8a0ad0aa31e09d129025be7b69525fbd7307b1",
+        "rev": "86de228c5d52954a2cfdad943a8793f04f626dc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`bcd5ad6d`](https://github.com/NixOS/nixpkgs/commit/bcd5ad6d83f89e2f0b16137cfc280a952dba9406) | `libwebsockets: remove generic function, format`                                    |
| [`fbdffd67`](https://github.com/NixOS/nixpkgs/commit/fbdffd67ff40b082cb607aaed0ff9515b0861120) | `kube-linter: 0.3.0 -> 0.4.0`                                                       |
| [`9674356b`](https://github.com/NixOS/nixpkgs/commit/9674356b09aa50d5a92f79e3bde0ba08b87d4b36) | `ddnet 16.1 -> 16.2`                                                                |
| [`ff494fa0`](https://github.com/NixOS/nixpkgs/commit/ff494fa028e7e982bb17d50f8abae34a51284bcb) | `ocamlPackages.hxd: 0.3.1 -> 0.3.2`                                                 |
| [`6be62ba2`](https://github.com/NixOS/nixpkgs/commit/6be62ba201b3d9a16aa042edece140931977e1b1) | `mako: 1.7 -> 1.7.1`                                                                |
| [`78d0a068`](https://github.com/NixOS/nixpkgs/commit/78d0a0688cfe05d820f197bc50d95dce8ea25519) | `ocamlPackages.xmlm: 1.3.0 -> 1.4.0`                                                |
| [`f0658798`](https://github.com/NixOS/nixpkgs/commit/f065879806938152be1adca5b5999130a8462dad) | `broot: 1.14.0 -> 1.14.1`                                                           |
| [`79453546`](https://github.com/NixOS/nixpkgs/commit/7945354659cfa0b9aeea729fd925d2c3151ffd0c) | `kubesec: 2.11.4 -> 2.11.5`                                                         |
| [`dd10dbfc`](https://github.com/NixOS/nixpkgs/commit/dd10dbfc5be3b4edf7609da892a7564be4b8252a) | `python310Packages.plugwise: 0.20.0 -> 0.20.1`                                      |
| [`9f31bcc4`](https://github.com/NixOS/nixpkgs/commit/9f31bcc45b56649e978c512fe4f2d675adcf32c6) | `tailscale: 1.26.1 -> 1.26.2`                                                       |
| [`1bf922e0`](https://github.com/NixOS/nixpkgs/commit/1bf922e038ec816ba7238c786e4c89e216933308) | `cdogs-sdl: 0.13.0 -> 1.3.1`                                                        |
| [`ba60ee5d`](https://github.com/NixOS/nixpkgs/commit/ba60ee5dc3c4393a438c187724d6f28e5c0dedad) | `kiln: 0.3.0 → 0.3.2`                                                               |
| [`c7d14520`](https://github.com/NixOS/nixpkgs/commit/c7d145203852f706e587b78cd6e4416343632857) | `python310Packages.aesara: 2.7.4 -> 2.7.5`                                          |
| [`ae555af6`](https://github.com/NixOS/nixpkgs/commit/ae555af60a87b55e2ac209cc1c58b7aeff9169e0) | `virtiofsd: 1.2.0 -> 1.3.0`                                                         |
| [`c39e2068`](https://github.com/NixOS/nixpkgs/commit/c39e2068119f54cb09e72317999dc055a0db3dbd) | `linux_logo: init at 6.0`                                                           |
| [`8b491055`](https://github.com/NixOS/nixpkgs/commit/8b4910551355999a45b665991da2a5f3fc553ae0) | `python310Packages.aioslimproto: 2.0.1 -> 2.1.1`                                    |
| [`39d53920`](https://github.com/NixOS/nixpkgs/commit/39d53920becb0ca3f91938119321688c8b7610bc) | `python310Packages.browser-cookie3: 0.15.0 -> 0.16.0`                               |
| [`c4dee2fd`](https://github.com/NixOS/nixpkgs/commit/c4dee2fd10d0e551cbb91ad8200db23521b949ed) | `python310Packages.aioconsole: 0.4.1 -> 0.5.0`                                      |
| [`b6236dbd`](https://github.com/NixOS/nixpkgs/commit/b6236dbddb6852a9567588f1a87ba2521bb71e58) | `ocamlPackages.chacha: 1.0.0 → 1.1.0`                                               |
| [`eea01cd1`](https://github.com/NixOS/nixpkgs/commit/eea01cd11db90c1b6e6c7ad89d452e69cc89ba5c) | `ocamlPackages.netchannel: 2.0.0 → 2.1.1`                                           |
| [`6e7b75c2`](https://github.com/NixOS/nixpkgs/commit/6e7b75c2f53d61c62bb9897920bc025504896ef3) | `mako: 1.6 -> 1.7`                                                                  |
| [`f009b690`](https://github.com/NixOS/nixpkgs/commit/f009b690eb96b595c4a4251427ab2cb73bc1fa30) | `dolphin-emu-primehack: 1.0.6 -> 1.0.6a`                                            |
| [`7e5afad9`](https://github.com/NixOS/nixpkgs/commit/7e5afad992702fade5879a7a18fe1ae6abb5dce3) | `vivaldi-ffmepg-codecs: 102.0.5005.49 -> 103.0.5060.53`                             |
| [`f25ae922`](https://github.com/NixOS/nixpkgs/commit/f25ae9227e06e528bd162ad309049f731aa10c62) | `vivaldi: 5.3.2679.61-1 -> 5.3.2679.68-1`                                           |
| [`c1f05af6`](https://github.com/NixOS/nixpkgs/commit/c1f05af680f2a1de3abaf1ecc34f1100932b60f7) | `conftest: 0.32.1 -> 0.33.0`                                                        |
| [`d50fffb0`](https://github.com/NixOS/nixpkgs/commit/d50fffb079e484a68dcf8d117103016060e1996e) | `maintainers: update email for squalus`                                             |
| [`b511382c`](https://github.com/NixOS/nixpkgs/commit/b511382c95f3f0d7fbaba1edb8968bf71f941134) | `vimPlugins.vim-printer: init at 2022-03-01`                                        |
| [`38139e46`](https://github.com/NixOS/nixpkgs/commit/38139e464a745a9bfa457344b11dcd041c036c39) | `vimPlugins: resolve github repository redirects`                                   |
| [`137caea3`](https://github.com/NixOS/nixpkgs/commit/137caea3fbf9ed6b45bea2ab1529185642fe006a) | `vimPlugins.vim-substrata: init at 2021-03-23`                                      |
| [`efc92be1`](https://github.com/NixOS/nixpkgs/commit/efc92be1f7b947b6fc7e2b645bc6b04912344d2f) | `vimPlugins: update`                                                                |
| [`55f6f6c6`](https://github.com/NixOS/nixpkgs/commit/55f6f6c60ae5e8f45a5f825d2a1279b9d20349e1) | `vimPlugins.substrata-nvim: init at 2022-06-21`                                     |
| [`44d4627e`](https://github.com/NixOS/nixpkgs/commit/44d4627e1aadd0ae842d659e613521aa110b04bb) | `vimPlugins: resolve github repository redirects`                                   |
| [`5e59efd7`](https://github.com/NixOS/nixpkgs/commit/5e59efd70e90ad35a2705c0e3e1b89a19f1c1cc7) | `vimPlugins: update`                                                                |
| [`5ee41500`](https://github.com/NixOS/nixpkgs/commit/5ee415007381c4bcd5775f8262afa717844d95eb) | `sonic-pi: use supercollider with sc3-plugins (#169851)`                            |
| [`6870d49f`](https://github.com/NixOS/nixpkgs/commit/6870d49feace5011d1ada61ce6600a141dca35fd) | `dovecot: fix CVE-2022-30550`                                                       |
| [`1fe8edb6`](https://github.com/NixOS/nixpkgs/commit/1fe8edb6ddfd23c99822d268b6cf27e19f16a588) | `onlyoffice-bin: 6.3.1 -> 7.1.0`                                                    |
| [`da4602bf`](https://github.com/NixOS/nixpkgs/commit/da4602bf6bc710817ba4a8a1465a4ed6c79805b6) | `zafiro-icons: 1.1 -> 1.2`                                                          |
| [`3d6de3db`](https://github.com/NixOS/nixpkgs/commit/3d6de3dba02f3ffdcde8f95af5937e3acb35065f) | `python310Packages.dvc-objects: 0.0.18 -> 0.0.19`                                   |
| [`85998e36`](https://github.com/NixOS/nixpkgs/commit/85998e36ce88c628c2fa0399006f8200a32c0b99) | `butane: 0.14.0 -> 0.15.0`                                                          |
| [`f447c0ca`](https://github.com/NixOS/nixpkgs/commit/f447c0cad89455b4096131830dede19b5e2213a3) | `python310Packages.azure-eventgrid: 4.8.0 -> 4.9.0`                                 |
| [`4622c4e1`](https://github.com/NixOS/nixpkgs/commit/4622c4e103312c25d50d7864a9766d1475de7d6d) | `goda: init at 0.5.1`                                                               |
| [`e332ad7a`](https://github.com/NixOS/nixpkgs/commit/e332ad7a33e4815fe730514598bea98d8ddd32d4) | `tagainijisho: 1.0.3 -> 1.2.0`                                                      |
| [`a96092b6`](https://github.com/NixOS/nixpkgs/commit/a96092b642d1506c782866a8672ed7d44cbd3ba4) | `jc: 1.20.1 -> 1.20.2`                                                              |
| [`3248f322`](https://github.com/NixOS/nixpkgs/commit/3248f32201edaae264bc746e7992d22bdc81bfaf) | `Revert "amdvlk: 2022.Q2.2 -> 2022.Q2.3"`                                           |
| [`6496c250`](https://github.com/NixOS/nixpkgs/commit/6496c250ce843c2d1339f96a0b1aa60f85751462) | `furnace: 0.5.8 -> 0.6pre1`                                                         |
| [`3bd20fe6`](https://github.com/NixOS/nixpkgs/commit/3bd20fe6f718860930c94d36da069366db5d410d) | `luna-icons: 2.0 -> 2.1`                                                            |
| [`a5c867d9`](https://github.com/NixOS/nixpkgs/commit/a5c867d9fe9e4380452628e8f171c26b69fa9d3d) | `libschrift: 0.10.1 -> 0.10.2`                                                      |
| [`0c0cb9db`](https://github.com/NixOS/nixpkgs/commit/0c0cb9dbe5466dc44de97d7821320f70a8360e38) | `musescore: 2.1 -> 3.6.2.548020600 on darwin`                                       |
| [`1d5a0c0f`](https://github.com/NixOS/nixpkgs/commit/1d5a0c0f4a0b7db109adf484b953fd9921ea0877) | `mu: 1.8.3 -> 1.8.5`                                                                |
| [`452c0ddf`](https://github.com/NixOS/nixpkgs/commit/452c0ddf8ac095fcc950a6326878c3ec1570fd77) | `cardinal: 22.04 -> 22.06`                                                          |
| [`72e26a9f`](https://github.com/NixOS/nixpkgs/commit/72e26a9f5b2bebec3ca84036ac532e9ccd73ffab) | `hcloud: 1.29.5 -> 1.30.0`                                                          |
| [`8ef7523c`](https://github.com/NixOS/nixpkgs/commit/8ef7523c8e11da7fd23e6b87371e7aa1eab718bb) | `pineapple-pictures: init at 0.6.1 (#178583)`                                       |
| [`21e22c7f`](https://github.com/NixOS/nixpkgs/commit/21e22c7f6be273a9083cdec47910425b5688babf) | `plex: 1.27.1.5916-6b0e31a64 -> 1.27.2.5929-a806c5905`                              |
| [`ec9ce3c9`](https://github.com/NixOS/nixpkgs/commit/ec9ce3c94bb763973bde1b860d217c1d16e3d5e8) | `python310Packages.levenshtein: 0.18.1 -> 0.18.2`                                   |
| [`07f1d6ba`](https://github.com/NixOS/nixpkgs/commit/07f1d6bab7586bbdf0e1e94ebdfe031b32946724) | `python310Packages.rapidfuzz: 2.1.0 -> 2.1.2`                                       |
| [`ed40dba1`](https://github.com/NixOS/nixpkgs/commit/ed40dba171076f270b4958ca7c9e0b0570882fda) | `python310Packages.jarowinkler: 1.0.5 -> 1.1.0`                                     |
| [`934a622f`](https://github.com/NixOS/nixpkgs/commit/934a622f7ecf9bc18940e799bdc5f2b7c0c213a5) | `qemu-utils: ensure we cut off qemu dependency`                                     |
| [`fef6723f`](https://github.com/NixOS/nixpkgs/commit/fef6723f9bea16c6530beefd20349e0e10a8d1ff) | `qemu-utils: remove qemu dependency`                                                |
| [`21d9b20b`](https://github.com/NixOS/nixpkgs/commit/21d9b20b035ef2870d3121c3238f6cce87de5479) | `godns: 2.7.9 -> 2.8.1`                                                             |
| [`3b1cbcc9`](https://github.com/NixOS/nixpkgs/commit/3b1cbcc92bbd97b890dde90805e5cae347846f9c) | `ocamlPackages.yaml: 3.0.0 -> 3.1.0 (#180139)`                                      |
| [`25c4a062`](https://github.com/NixOS/nixpkgs/commit/25c4a062c63fb7bf4448e040bd79593353008a8d) | `puddletag: 2.1.1 -> 2.2.0`                                                         |
| [`f4b885df`](https://github.com/NixOS/nixpkgs/commit/f4b885df97aafe36fd08637cb2d770463f1997aa) | `xosview2: remove spurious doCheck = false`                                         |
| [`c2c8e8fd`](https://github.com/NixOS/nixpkgs/commit/c2c8e8fdd2e30937fc746c54a7b76c6ee87417b1) | `xosview: init at 1.23`                                                             |
| [`4066f82a`](https://github.com/NixOS/nixpkgs/commit/4066f82a4de90e25b41451486bdcbf2c45805a48) | `all-packages.nix: cosmetic formatting of some comments`                            |
| [`bf35d801`](https://github.com/NixOS/nixpkgs/commit/bf35d8018738ad3b4bf871dfd64f1ae7e83c5997) | `python310Packages.skodaconnect: 1.1.20 -> 1.1.21`                                  |
| [`17c42e33`](https://github.com/NixOS/nixpkgs/commit/17c42e33b087b652218a69defa60f692de445ace) | `crlfsuite: 2.0 -> 2.1.1`                                                           |
| [`069be5d4`](https://github.com/NixOS/nixpkgs/commit/069be5d42791b21d02e0c3da980cefab46271de6) | `python310Packages.ics: 0.7 -> 0.7.1`                                               |
| [`41e0ebb9`](https://github.com/NixOS/nixpkgs/commit/41e0ebb94d075e287e11a9fd1089c92ef3d003a2) | `python310Packages.pytest-test-utils: 0.0.6 -> 0.0.7`                               |
| [`14a84624`](https://github.com/NixOS/nixpkgs/commit/14a846241865ad63780e0be63379ff8584eeffcc) | `python310Packages.islpy: 2022.1.2 -> 2022.2`                                       |
| [`33cda578`](https://github.com/NixOS/nixpkgs/commit/33cda5786fe4dcba66603e2feb93d254f3890182) | `libvirt: 8.4.0 -> 8.5.0`                                                           |
| [`2f12a8d2`](https://github.com/NixOS/nixpkgs/commit/2f12a8d2b8247f3cf62e024132314dc352cb6597) | `python310Packages.pygmt: 0.6.1 -> 0.7.0`                                           |
| [`42db1e66`](https://github.com/NixOS/nixpkgs/commit/42db1e66f3cf7026cdfdc341d13f8ba12e9fad4d) | `python310Packages.yq: 2.14.0 -> 3.0.2`                                             |
| [`597db2e3`](https://github.com/NixOS/nixpkgs/commit/597db2e3b443f417ca71f5158d1031f08e83bd7d) | `python310Packages.spacy-transformers: 1.1.6 -> 1.1.7`                              |
| [`00b2db64`](https://github.com/NixOS/nixpkgs/commit/00b2db645cea9941d8c2bafc7fdd509dbf5a908c) | `python310Packages.vispy: 0.10.0 -> 0.11.0`                                         |
| [`8558ab08`](https://github.com/NixOS/nixpkgs/commit/8558ab08b6258d2964442d447527082d3c0cc081) | `vscode-extensions.ms-python.vscode-pylance: 2022.6.30 -> 2022.7.11`                |
| [`14af83b8`](https://github.com/NixOS/nixpkgs/commit/14af83b82a6a1eb9aec9049a94b25b098d4c312d) | `vscode-extensions.ms-python.vscode-pylance: 2022.1.5 -> 2022.6.30`                 |
| [`aeb97834`](https://github.com/NixOS/nixpkgs/commit/aeb97834a8052814fdaf078adf4befbfb03aed37) | `werf: 1.2.117 -> 1.2.120`                                                          |
| [`6785b339`](https://github.com/NixOS/nixpkgs/commit/6785b339ccdab11cc44ae971077969b513b46f43) | `python3Packages.gradient_statsd: propagate chardet`                                |
| [`336cc168`](https://github.com/NixOS/nixpkgs/commit/336cc1683a4199f25310f7a4b7a2c6b04f25cc89) | `mars: fix build on gcc-10`                                                         |
| [`d47f646d`](https://github.com/NixOS/nixpkgs/commit/d47f646d16e5db553b6a30a218dbf0337ab23c42) | `python3Packages.progressbar2: re-enable check since the issue was solved upstream` |
| [`002e147b`](https://github.com/NixOS/nixpkgs/commit/002e147b103041e8ac2a0785a8232796f6451714) | `python3Packages.python-utils: 3.1.0 → 3.3.3`                                       |
| [`2169ff54`](https://github.com/NixOS/nixpkgs/commit/2169ff54f191e4cd7a47c80207d9b58b7e50202a) | `cloc: 1.92 -> 1.94`                                                                |
| [`9f97d67c`](https://github.com/NixOS/nixpkgs/commit/9f97d67c3a9093cbc0c2119ecacf043c766022a7) | `oil: 0.10.1 -> 0.11.0 (#179637)`                                                   |
| [`183b236e`](https://github.com/NixOS/nixpkgs/commit/183b236eef3004945512d0ac507faf9828b53244) | `nebula: 1.5.2 -> 1.6.0`                                                            |
| [`a2642faa`](https://github.com/NixOS/nixpkgs/commit/a2642faaead939295d279b64abb50c45f1b12b93) | `virtctl: 0.53.0 -> 0.54.0`                                                         |
| [`a2012c49`](https://github.com/NixOS/nixpkgs/commit/a2012c49fc3e34581cf4b302513319c8cd45cbfe) | `hyprpaper: init at unstable-2022-07-04 (#180192)`                                  |
| [`d1dd3b2a`](https://github.com/NixOS/nixpkgs/commit/d1dd3b2aad2030f76fee68928b6718320664b232) | `Add remaining extension metadata`                                                  |
| [`1dd5fa64`](https://github.com/NixOS/nixpkgs/commit/1dd5fa64c1b8cf372523380e6719ca6ab468343b) | `Add lucperkins to list of maintainers`                                             |
| [`2da5797c`](https://github.com/NixOS/nixpkgs/commit/2da5797ca521e3b62ab3262b38a0fb09bfa066b9) | `Add vrl-vscode extension for Visual Studio Code`                                   |
| [`94053017`](https://github.com/NixOS/nixpkgs/commit/94053017142fdbd44579375b495e4e4035413879) | `python310Packages.rns: 0.3.8 -> 0.3.9`                                             |
| [`23ee5ac4`](https://github.com/NixOS/nixpkgs/commit/23ee5ac46ad942208b82f3631d891cdb60bb8409) | `vscode-extensions.piousdeer.adwaita-theme: init at 1.0.7`                          |
| [`af7323d1`](https://github.com/NixOS/nixpkgs/commit/af7323d1a8ca96d2cd623e628407223c2fad92a2) | `discord: fix override`                                                             |
| [`838e78a8`](https://github.com/NixOS/nixpkgs/commit/838e78a8a602456d01d4590aa209b75daca6a926) | `firefox-bin-unwrapped: 102.0 -> 102.0.1`                                           |
| [`e3e78bb4`](https://github.com/NixOS/nixpkgs/commit/e3e78bb4095ea946d507fa5ee8ec7f5a43628565) | `firefox-unwrapped: 102.0 -> 102.0.1`                                               |
| [`83562c61`](https://github.com/NixOS/nixpkgs/commit/83562c61752b398dabe88be79ab03c914ff901af) | `k9s: 0.25.18 -> 0.25.21`                                                           |
| [`e2a624dd`](https://github.com/NixOS/nixpkgs/commit/e2a624ddc6644c84cbff5283b25f43267d7e3775) | `circup: 1.1.0 -> 1.1.2`                                                            |
| [`0c564ffe`](https://github.com/NixOS/nixpkgs/commit/0c564ffe7876338179c32ff9a6b63c36eb0c6a25) | `python3Packages.pyuv: backport python3.10 build fix`                               |
| [`cbc4d517`](https://github.com/NixOS/nixpkgs/commit/cbc4d51711102e80013917eea84705cc471febdb) | `zen-kernels: 5.18.7 -> 5.18.9`                                                     |
| [`000d72eb`](https://github.com/NixOS/nixpkgs/commit/000d72eb7fc02d116fe27fe2cf58f46b29d83b1e) | `nixos/privacyidea: pin python to 3.9`                                              |
| [`1360dd9d`](https://github.com/NixOS/nixpkgs/commit/1360dd9d71eed35465e46318e3b4a26af466827d) | `privacyidea: 3.7.1 -> 3.7.2`                                                       |
| [`20f5ebdd`](https://github.com/NixOS/nixpkgs/commit/20f5ebdd3cec7df91fc4e9805a7d002d0f7fc0ae) | `maintainers/mdize-module: Add known limitations`                                   |
| [`eded0d65`](https://github.com/NixOS/nixpkgs/commit/eded0d654ceffd5d29113c396af268bcbfea0b8d) | `octomap: 1.9.7 -> 1.9.8`                                                           |
| [`d10999d7`](https://github.com/NixOS/nixpkgs/commit/d10999d7335191ec644cf89ba81624a73300f893) | `Add knownVulnerabilities to libdwarf`                                              |
| [`89100132`](https://github.com/NixOS/nixpkgs/commit/89100132771105e851d4f9e43207ef8f59dcb9b9) | `dendrite: 0.8.8 -> 0.8.9`                                                          |
| [`2a478c94`](https://github.com/NixOS/nixpkgs/commit/2a478c942a672d588e33daef7c5ae4d9a7b83265) | `broot: 1.13.3 -> 1.14.0`                                                           |
| [`68cc57cc`](https://github.com/NixOS/nixpkgs/commit/68cc57cce147e52f382802c8b257c8f319aac173) | `nixos/qt5ct: remove enable option and suggests qt5.platformTheme`                  |
| [`097b70ec`](https://github.com/NixOS/nixpkgs/commit/097b70ec5c3aede047a2c3322933bf3c2fb075f5) | ``wtf: Set `meta.mainProgram` to "wtfutil"``                                        |
| [`2f19bff1`](https://github.com/NixOS/nixpkgs/commit/2f19bff1b14cf94472c871a164b10123c1d5115e) | `kopia: 0.11.0 -> 0.11.1`                                                           |
| [`47ba8cdc`](https://github.com/NixOS/nixpkgs/commit/47ba8cdcc7096242bd98f9d9631fa9dd4974cf53) | `nixos/qt5: add maintainer`                                                         |
| [`04d6b89b`](https://github.com/NixOS/nixpkgs/commit/04d6b89bcc7b21f06259b040659b60d918a5df70) | `_1password-gui-beta: 8.8.0-119.BETA -> 8.8.0-165.BETA`                             |
| [`11c38f0a`](https://github.com/NixOS/nixpkgs/commit/11c38f0a6bdc5baebadd903049f43b76c7b3b953) | `_1password-gui: 8.7.1 -> 8.7.3`                                                    |
| [`b28aebf8`](https://github.com/NixOS/nixpkgs/commit/b28aebf8bbdbc5ea135683c17d064488565bf58b) | `python310Packages.splinter: 0.18.0 -> 0.18.1`                                      |
| [`4b3793e0`](https://github.com/NixOS/nixpkgs/commit/4b3793e092a0cb181b71c619d2968097e8077446) | `python310Packages.rflink: 0.0.62 -> 0.0.63`                                        |
| [`a7111548`](https://github.com/NixOS/nixpkgs/commit/a71115488920ce212479a012ba241200826faaeb) | `blueman: 2.2.5 -> 2.3`                                                             |
| [`a264a86d`](https://github.com/NixOS/nixpkgs/commit/a264a86d935fae69558f363881d65a19a4f4d735) | `nixos/qt5: add qt5ct as a possible platform theme`                                 |
| [`8c5079ef`](https://github.com/NixOS/nixpkgs/commit/8c5079ef3e3d77692d0f127b3ae8b8a120ed71d0) | `matrix-synapse: 1.61.1 -> 1.62.0`                                                  |
| [`5139952b`](https://github.com/NixOS/nixpkgs/commit/5139952befe5f8f90b88e69f8dd3fe4592d758ac) | `matrix-common: 1.1.0 -> 1.2.1`                                                     |
| [`df23b42a`](https://github.com/NixOS/nixpkgs/commit/df23b42a9aca5ef4abbd50b53cdfd5a301f9a489) | `udocker: fix build failure`                                                        |
| [`75ec318b`](https://github.com/NixOS/nixpkgs/commit/75ec318b8000e5adfe27015607afffab346d72b5) | `wireplumber: 0.4.10 -> 0.4.11`                                                     |
| [`70dc91a4`](https://github.com/NixOS/nixpkgs/commit/70dc91a415ab21cdaacb431abbfdfe313300f211) | `libsForQt5.bismuth: 3.1.1 -> 3.1.2`                                                |
| [`a238ca28`](https://github.com/NixOS/nixpkgs/commit/a238ca2853b59b81fb3f2e4d7151295a0fd3935c) | `webkitgtk: 2.36.3 → 2.36.4`                                                        |
| [`568d2e77`](https://github.com/NixOS/nixpkgs/commit/568d2e77f43efd26b387ae43ddc4c3352920ab10) | `nixos.redis: Fix disabling of RDB persistence.`                                    |
| [`9dc9efef`](https://github.com/NixOS/nixpkgs/commit/9dc9efefc458309fceab286c5a2fae8dd0f65372) | `jsonnet-language-server: init at 0.7.2`                                            |
| [`919bd2f3`](https://github.com/NixOS/nixpkgs/commit/919bd2f364b493d9996b18a4a5c967291e9f8cc8) | `n8n: 0.184.0 → 0.185.0`                                                            |
| [`8b0bc7ce`](https://github.com/NixOS/nixpkgs/commit/8b0bc7ce83bf2d39af03e1f2803eccfb04409e8d) | `slirp4netns: set strictDeps`                                                       |
| [`fb8e8ac9`](https://github.com/NixOS/nixpkgs/commit/fb8e8ac918a79d73bd43e23c36631822cf5ca9b8) | `fuse-overlayfs: set enableParallelBuilding/strictDeps`                             |
| [`8de4ffe8`](https://github.com/NixOS/nixpkgs/commit/8de4ffe811527569b0eb0d118c8f27794edcfe5b) | `crun: set strictDeps`                                                              |
| [`b71ee18b`](https://github.com/NixOS/nixpkgs/commit/b71ee18bfd0c01b119b450a32cbfa84e152427cf) | `conmon: set enableParallelBuilding/strictDeps`                                     |
| [`58aad4ee`](https://github.com/NixOS/nixpkgs/commit/58aad4ee0322b6a1173056124c29513dcda0116a) | `catatonit: set enableParallelBuilding/strictDeps`                                  |
| [`01660583`](https://github.com/NixOS/nixpkgs/commit/01660583c015a330a77e0dde4f5609db60af8cb7) | `topgrade: fix build on darwin`                                                     |
| [`c30f978f`](https://github.com/NixOS/nixpkgs/commit/c30f978f233f7adace4e8fffff12745486008751) | `trace-cmd: 3.0.3->3.1.1`                                                           |
| [`369ab300`](https://github.com/NixOS/nixpkgs/commit/369ab30030d8c56fe87a06c1fe3b2c0e85ba6253) | `syncthing: 1.20.2 -> 1.20.3`                                                       |
| [`fd92b928`](https://github.com/NixOS/nixpkgs/commit/fd92b928276798535889a983f161ea23504e4148) | `python3.pkgs.xarray: add missing packaging dependency`                             |
| [`826c20dc`](https://github.com/NixOS/nixpkgs/commit/826c20dcae34f7e3be4d1a638b07fb7d95570ba0) | `nixos/vault: add option to start in dev mode. (#180114)`                           |
| [`d819f155`](https://github.com/NixOS/nixpkgs/commit/d819f155032abaa4752122d184d21ed1beec09de) | `libwebsockets: 4.3.1 -> 4.3.2`                                                     |
| [`f5522fb7`](https://github.com/NixOS/nixpkgs/commit/f5522fb775353e6858d33b4986d344d1ba4adb83) | `nextcloud-client: 3.5.1 -> 3.5.2`                                                  |
| [`8fed4ee6`](https://github.com/NixOS/nixpkgs/commit/8fed4ee6bbf18d5cb1e7086d2f5d9fd8304943dd) | `chain-bench: 0.0.3 -> 0.1.0`                                                       |
| [`4dcf4a23`](https://github.com/NixOS/nixpkgs/commit/4dcf4a23199f07e8f5e0d713ff01f685df96bba2) | `python310Packages.typer: 0.4.1 -> 0.4.2`                                           |
| [`95325c17`](https://github.com/NixOS/nixpkgs/commit/95325c17936468c12027f3b2aca10cb60ee5b962) | `gnome.polari: 42.0 -> 42.1`                                                        |
| [`95ffdc6b`](https://github.com/NixOS/nixpkgs/commit/95ffdc6b7386103936a4d8c153a15aefb3de44e9) | `gnome.mutter: 42.2 -> 42.3`                                                        |
| [`042db7e1`](https://github.com/NixOS/nixpkgs/commit/042db7e16cab47374eef343e46a4b7e395aa5a13) | `gnome.gnome-shell-extensions: 42.2 -> 42.3`                                        |
| [`1468b339`](https://github.com/NixOS/nixpkgs/commit/1468b339d0f3d577f0a3cd1662b9050358672a78) | `gnome.gnome-shell: 42.2 -> 42.3.1`                                                 |
| [`52d499ba`](https://github.com/NixOS/nixpkgs/commit/52d499ba29fa9c894a7064c7651fdf5cead2b974) | `python310Packages.python-whois: 0.7.3 -> 0.8.0`                                    |
| [`dff0428a`](https://github.com/NixOS/nixpkgs/commit/dff0428a45de0523860e783d4d2db7e5fdf61c5c) | `kubectl: override kubernetes`                                                      |
| [`5ae098c5`](https://github.com/NixOS/nixpkgs/commit/5ae098c5a024bf87bb00f491a8a9e6a1138b36fa) | `clusterctl: 1.1.4 -> 1.1.5`                                                        |
| [`6a9e4bd1`](https://github.com/NixOS/nixpkgs/commit/6a9e4bd161f5bd821611f976a00ec32cf00073d5) | `vimv-rs: init at 1.7.5`                                                            |
| [`141e3f04`](https://github.com/NixOS/nixpkgs/commit/141e3f04af8a5cdabefc99b5608fc85ad75aaa02) | `kopia: 0.10.7 -> 0.11.0`                                                           |
| [`295656a4`](https://github.com/NixOS/nixpkgs/commit/295656a45ae179886c78b232442200e21eb7d747) | `mullvad: 2022.1 -> 2022.2`                                                         |
| [`5556ee0e`](https://github.com/NixOS/nixpkgs/commit/5556ee0ed63c04113146b037b76097887199b5bd) | `python3Packages.ua-parser: fix hash`                                               |