### PR TITLE
chore(flake/nixos-hardware): `78e7c2c3` -> `a50513f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1656353817,
-        "narHash": "sha256-UJEzMQcft/0Ilu4LWV7UH51mr5UCo28GL06BGO+djv4=",
+        "lastModified": 1656624504,
+        "narHash": "sha256-EuNui6P5tHk4YkfiYjcRzfc9wxpoTl2OOOgpyF6bWfs=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "78e7c2c397b0376526e83162b58de921362e3399",
+        "rev": "a50513f8a6c470208d7c494439775e62c3f47ce1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                           |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`3d9b6a62`](https://github.com/NixOS/nixos-hardware/commit/3d9b6a6215412a5206dea4edefef6f8edd4d1134) | `Fix Wifi for Lenovo Thinkpad T14s Gen1` |