### PR TITLE
chore(flake/nixos-hardware): `a50513f8` -> `c5308381`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1656624504,
-        "narHash": "sha256-EuNui6P5tHk4YkfiYjcRzfc9wxpoTl2OOOgpyF6bWfs=",
+        "lastModified": 1656702262,
+        "narHash": "sha256-BdVdx6LoGgAeIYrHnzk+AgbtkaVlV3JNcC6+vltLuh0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a50513f8a6c470208d7c494439775e62c3f47ce1",
+        "rev": "c5308381432cdbf14d5b1128747a2845f5c6871e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`c3aa1fae`](https://github.com/NixOS/nixos-hardware/commit/c3aa1fae79e684bf0aba290b45c2f688c3ea5af1) | `lenovo/thinkpad/x1-extreme/gen4: add module` |