### PR TITLE
chore(flake/home-manager): `3bf16c0f` -> `f2445620`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1656367977,
-        "narHash": "sha256-0hV17V9Up9pnAtPJ+787FhrsPnawxoTPA/VxgjRMrjc=",
+        "lastModified": 1656927578,
+        "narHash": "sha256-ZSFrM/1PlJOqCb3mN88ZUh9dkQvNLU/nkoQ2tu02/FM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3bf16c0fd141c28312be52945d1543f9ce557bb1",
+        "rev": "f2445620d177e295e711c1b2bc6c01ed6df26c16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`f2445620`](https://github.com/nix-community/home-manager/commit/f2445620d177e295e711c1b2bc6c01ed6df26c16) | `redshift: remove petabyteboy from maintainers` |