### PR TITLE
chore(flake/flake-utils): `bee6a725` -> `7e2a3b3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1656065134,
-        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                       |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`7e2a3b3d`](https://github.com/numtide/flake-utils/commit/7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249) | `check-utils: use the same success derivation (#75)` |