### PR TITLE
chore(flake/home-manager): `f2445620` -> `face4094`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1656927578,
-        "narHash": "sha256-ZSFrM/1PlJOqCb3mN88ZUh9dkQvNLU/nkoQ2tu02/FM=",
+        "lastModified": 1657164980,
+        "narHash": "sha256-6DlmMEN8+Lewfelx11X8nLl0EzwBHLGFeK9HfTQnFps=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f2445620d177e295e711c1b2bc6c01ed6df26c16",
+        "rev": "face4094d499c84c782873464794cb976c94f079",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`face4094`](https://github.com/nix-community/home-manager/commit/face4094d499c84c782873464794cb976c94f079) | ``bspwm: add missing rule setting `rectangle` (#2974)`` |