### PR TITLE
chore(flake/nixpkgs): `0c82c6d2` -> `f49fe4a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657180868,
-        "narHash": "sha256-pRGoBUIn35fa2ptlMiJ+0Tb4GhC0SQXMQLuIhIt7SHo=",
+        "lastModified": 1657226321,
+        "narHash": "sha256-E0kfDH47CN/vW1SUfFUUA2nRdmZOb6z0cjeETqN0xxU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c82c6d29482b4e08c264288e0a4bc14d5d84e8e",
+        "rev": "f49fe4a120ac01b6157d91bf1c733319fec21459",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                       |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`abc00789`](https://github.com/NixOS/nixpkgs/commit/abc007896b255bb80e9cbdef00bd558f72eb168c) | `maintainers: add matrix for thiagokokada`                           |
| [`9b3ec85d`](https://github.com/NixOS/nixpkgs/commit/9b3ec85d58665024ffd4f31f9c8009a48a2f6d67) | `ocamlPackages.mirage-random: 2.0.0 -> 3.0.0`                        |
| [`e3f26208`](https://github.com/NixOS/nixpkgs/commit/e3f26208bcee2d133c30de725b2aa7e6f63e40ae) | `anime-downloader: fix missing runtime dependencies`                 |
| [`30744e35`](https://github.com/NixOS/nixpkgs/commit/30744e35e0463ba94653d6ec3dcfdbaa08f5d4e5) | `maintainers: add kilimnik`                                          |
| [`a508339b`](https://github.com/NixOS/nixpkgs/commit/a508339bc649d64e8e0cb7f13d53785253c0d02f) | `protoc-gen-connect-go: init at 0.1.1`                               |
| [`a8406971`](https://github.com/NixOS/nixpkgs/commit/a8406971c3ef3438cf2511c5d59a7579f601d6b9) | `ocamlPackages.dns: 5.0.1 → 6.1.4`                                   |
| [`26a6c659`](https://github.com/NixOS/nixpkgs/commit/26a6c659f0b239048f8e33a8a8a8b70c6e95e123) | `ocamlPackages.happy-eyeballs: init at 0.1.3`                        |
| [`41c19456`](https://github.com/NixOS/nixpkgs/commit/41c194565f48e26d3efc6d1fd1857a826253128b) | `wireplumber: backport a fix for no sound in VMs`                    |
| [`4eeaca86`](https://github.com/NixOS/nixpkgs/commit/4eeaca86fdc4158db8fb5677d48149675a61929e) | `nixosTests.installed-tests.flatpak-builder: fix tests`              |
| [`d2773000`](https://github.com/NixOS/nixpkgs/commit/d277300000989a3b0645462af749c2ff30015074) | `gitlab-triage: 1.20.0 -> 1.23.1`                                    |
| [`95f9a70b`](https://github.com/NixOS/nixpkgs/commit/95f9a70b481464e3d64743ad5f4c481cc1a77e9e) | `flatpak-builder: remove libdwarf dependency`                        |
| [`db356849`](https://github.com/NixOS/nixpkgs/commit/db3568499d9eb31c446245c6c7d29137fbb5009d) | `apacheHttpdPackages.mod_mbtiles: init at 2022-05-25`                |
| [`e9177aba`](https://github.com/NixOS/nixpkgs/commit/e9177abaacdfe7ca9e65c57ce80581b1ccf06b0b) | `arb: 2.22.1 -> 2.23.0`                                              |
| [`4950cb01`](https://github.com/NixOS/nixpkgs/commit/4950cb01e533fc7d46c5e5f17fcee9260987c891) | `bookletimposer: init at 0.3.1`                                      |
| [`abe756d6`](https://github.com/NixOS/nixpkgs/commit/abe756d691637199ef9968466c2035600e16da45) | `wcpg: init at 0.9`                                                  |
| [`9fbc67d6`](https://github.com/NixOS/nixpkgs/commit/9fbc67d63ec3730e116e6be64b8029e10c640377) | `opensoldat: rename from soldat-unstable`                            |
| [`1812c19e`](https://github.com/NixOS/nixpkgs/commit/1812c19e369727beb0f7bbc8cc5f3a13914be855) | `soldat-unstable: 2021-11-01 -> 2022-07-02`                          |
| [`e2859ee1`](https://github.com/NixOS/nixpkgs/commit/e2859ee197c3aa394a4a60d0f1370470f565bc5b) | `gamenetworkingsockets: 1.3.0 -> 1.4.1`                              |
| [`007c4341`](https://github.com/NixOS/nixpkgs/commit/007c4341fe6a37ad70a584f78f0cc837edf8d0d1) | `blender: fix on darwin`                                             |
| [`46e67b80`](https://github.com/NixOS/nixpkgs/commit/46e67b80435730e358bf52b7b9b560d32ad0f8bf) | `maintainers: update email for leo60228, add matrix and keys`        |
| [`05c85f96`](https://github.com/NixOS/nixpkgs/commit/05c85f967dccb8f41814361bd65724c4d2927423) | `gopls: 0.8.4 -> 0.9.0 (#180530)`                                    |
| [`0874b00c`](https://github.com/NixOS/nixpkgs/commit/0874b00cd83335f760b9f6dac9b7f5c7b44a3d57) | `tgswitch: 0.5.389 -> 0.6.0 (#179718)`                               |
| [`6e1b0ef6`](https://github.com/NixOS/nixpkgs/commit/6e1b0ef6b71e3052aaac94127a6dff1a071ef80e) | `python310Packages.ocrmypdf: 13.5.0 -> 13.6.0`                       |
| [`3aa678fd`](https://github.com/NixOS/nixpkgs/commit/3aa678fde28c93dd9c394664f07d7d72820224b1) | `python310Packages.pikepdf: 5.2.0 -> 5.3.1`                          |
| [`38c59e60`](https://github.com/NixOS/nixpkgs/commit/38c59e60bf10e84ab2f518f99853baa9e1769e77) | `flyctl: 0.0.346 -> 0.0.348`                                         |
| [`d89c89c0`](https://github.com/NixOS/nixpkgs/commit/d89c89c0638c1cf1b04e058ea056bb188415f35a) | `python310Packages.sphinx-jinja: 2.0.1 -> 2.0.2`                     |
| [`48fb865e`](https://github.com/NixOS/nixpkgs/commit/48fb865e6a382188412a5f5e079729e6ce6af601) | `python310Packages.omnilogic: 0.4.6 -> 0.4.9`                        |
| [`34d26c15`](https://github.com/NixOS/nixpkgs/commit/34d26c15f8d61538a19dfc71963dc18c3b89d702) | `python310Packages.pysensibo: 1.0.17 -> 1.0.18`                      |
| [`9a08be84`](https://github.com/NixOS/nixpkgs/commit/9a08be84267a13a15cc9be2b2724e0629859a131) | `python310Packages.gphoto2: 2.3.3 -> 2.3.4`                          |
| [`60353621`](https://github.com/NixOS/nixpkgs/commit/6035362129b85d18a98242f8a4b5b9fbc7b80a66) | `gt: 2021-09-30 -> 2022-05-08`                                       |
| [`1b1684c2`](https://github.com/NixOS/nixpkgs/commit/1b1684c21f0bb449d53cddb81b5dabb528b377da) | `open-stage-control: init at 1.17.0`                                 |
| [`2dc17021`](https://github.com/NixOS/nixpkgs/commit/2dc170210f3e56e2a73a1ee426b879a8b89030bb) | `fnlfmt: remove gpanders from maintainers`                           |
| [`8f620026`](https://github.com/NixOS/nixpkgs/commit/8f62002673be953cc8175c290ac9260baca8c20f) | `archisteamfarm.ui: format, inherit maintainers from asf, too`       |
| [`dbf41bb6`](https://github.com/NixOS/nixpkgs/commit/dbf41bb61478283a3e1adc2f2d87d54723af445f) | `openvdb: 7.0.0 -> 9.1.0 (#180144)`                                  |
| [`715b7691`](https://github.com/NixOS/nixpkgs/commit/715b7691f2c4826d9c8b709beccda8b917540bca) | `electron_19: init at 19.0.7`                                        |
| [`6802686d`](https://github.com/NixOS/nixpkgs/commit/6802686d6920023b6c15c39575ae4293175d7508) | `python3Packages.pyialarmxr-homeassistant: drop`                     |
| [`fc4b3a84`](https://github.com/NixOS/nixpkgs/commit/fc4b3a846d54254e628d05614cfa2d182c772f38) | `klee: 2.2 -> 2.3`                                                   |
| [`17caac62`](https://github.com/NixOS/nixpkgs/commit/17caac62885d12df7e920d0626662a307a29ca45) | `python3Packages.spacy_models: 3.0.0 -> 3.3.0`                       |
| [`6593595e`](https://github.com/NixOS/nixpkgs/commit/6593595ee50c029de45c205665c73d8fb088e64d) | `nixos/qt5: add lxqt platform theme`                                 |
| [`2b01fc08`](https://github.com/NixOS/nixpkgs/commit/2b01fc0862267e3fd8acc468e49dbe7cb2f0566f) | `firewalld: 1.1.1 -> 1.2.0`                                          |
| [`1c755103`](https://github.com/NixOS/nixpkgs/commit/1c755103fe8eda13ac58aa34f63ee7a331c8b9f4) | `ferium: 4.1.1 -> 4.1.5`                                             |
| [`2ad5262c`](https://github.com/NixOS/nixpkgs/commit/2ad5262cba9e737ff06c3ae80dd2c524a0c72b09) | `elementary-xfce-icon-theme: 0.16 -> 0.17`                           |
| [`72c332c0`](https://github.com/NixOS/nixpkgs/commit/72c332c0d8699ef7c0b209e05f34d40eaba43cb3) | `earthly: 0.6.16 -> 0.6.19`                                          |
| [`d7997bee`](https://github.com/NixOS/nixpkgs/commit/d7997beea24d8ae304c51d3eec4805a29b301590) | `dsp: 1.8 -> 1.9`                                                    |
| [`0a0baa89`](https://github.com/NixOS/nixpkgs/commit/0a0baa8935a79ad07c1b14b6283d5b4ffd2b042e) | `haskellPackages.futhark: 0.21.12 -> 0.21.13`                        |
| [`3014367d`](https://github.com/NixOS/nixpkgs/commit/3014367d9eda9f1337adbbf8bac4899016638564) | `btop: 1.2.7 -> 1.2.8`                                               |
| [`8dc427a8`](https://github.com/NixOS/nixpkgs/commit/8dc427a8c0713c0b84ffd37bf6f480b47f965ce7) | `dunst: 1.8.1 -> 1.9.0`                                              |
| [`947314d7`](https://github.com/NixOS/nixpkgs/commit/947314d7be1bf4863aea307a4536ffc7cade3b6d) | `cpp-utilities: 5.16.0 -> 5.17.0`                                    |
| [`d4299341`](https://github.com/NixOS/nixpkgs/commit/d42993419c75e0cdbd666d257ece67e1445fb30b) | `doctl: 1.77.0 -> 1.78.0`                                            |
| [`2be2a78f`](https://github.com/NixOS/nixpkgs/commit/2be2a78f422f4eda8edef93832416828ddb71c63) | `git-annex: update sha256 for 10.20220624`                           |
| [`0ff49576`](https://github.com/NixOS/nixpkgs/commit/0ff495768ced9e8fb5e35aedccc1bf3d1a2c604c) | `delve: 1.8.3 -> 1.9.0`                                              |
| [`632f3059`](https://github.com/NixOS/nixpkgs/commit/632f30598552878d00041eab62452c24d2802c80) | `matterhorn: provide brick 0.70.*`                                   |
| [`61dc821a`](https://github.com/NixOS/nixpkgs/commit/61dc821aacc149909d8135425dad54adff56cc75) | `cmctl: 1.8.1 -> 1.8.2`                                              |
| [`1b967531`](https://github.com/NixOS/nixpkgs/commit/1b967531ecf2e1021827dbc303ccd4a3d8fabe84) | `chafa: 1.10.3 -> 1.12.3`                                            |
| [`a5172bfb`](https://github.com/NixOS/nixpkgs/commit/a5172bfbf2b345d33a0bd746cfc96ec238069524) | `cargo-whatfeatures: 0.9.6 -> 0.9.7`                                 |
| [`39401993`](https://github.com/NixOS/nixpkgs/commit/39401993df0dd92ab1b9f5a1971cec253232d5ab) | `haskellPackages: mark builds failing on hydra as broken`            |
| [`5c0ddf82`](https://github.com/NixOS/nixpkgs/commit/5c0ddf82c5b23cc5f9f4192aa54b4c8420bda63d) | `mate.caja: 1.26.0 -> 1.26.1`                                        |
| [`465728b2`](https://github.com/NixOS/nixpkgs/commit/465728b266f1106373f5690a98b4c8e3821803f1) | `cilium-cli: 0.11.10 -> 0.11.11`                                     |
| [`b19cb885`](https://github.com/NixOS/nixpkgs/commit/b19cb885f364d37461668e0e921579cd21cae7c5) | `chromiumBeta: 104.0.5112.20 -> 104.0.5112.29`                       |
| [`c16deed1`](https://github.com/NixOS/nixpkgs/commit/c16deed1a6aead1c531a21b0f95a7a29e5a46e4c) | `haskellPackages: mark builds failing on hydra as broken`            |
| [`9b7bd914`](https://github.com/NixOS/nixpkgs/commit/9b7bd914d246b9db0a317163e026fcfbd426784f) | `home-assistant: 2022.6.7 -> 2022.7.0`                               |
| [`9d51787b`](https://github.com/NixOS/nixpkgs/commit/9d51787b536d843926dfd232f806ca0f5b5f5546) | `codec2: fix build`                                                  |
| [`a49a073f`](https://github.com/NixOS/nixpkgs/commit/a49a073fc0bcc1382382d15dfed0bbd36daa5cab) | `haskellPackages.patch: back-pin patch to fix build`                 |
| [`10565fcc`](https://github.com/NixOS/nixpkgs/commit/10565fccde3cacd75e6ba0ed6ad6496265041f7b) | `m17-cxx-demod: init at 2.3, add to nixos/openwebrx`                 |
| [`08ac808b`](https://github.com/NixOS/nixpkgs/commit/08ac808bb3c8ac66c844ab631dcc2dbd20cc8937) | `python3Packages.zwave-js-server-python: 0.37.2 -> 0.39.0`           |
| [`d550d69c`](https://github.com/NixOS/nixpkgs/commit/d550d69c5eb931dfc9821de53e26bc13554bfbb9) | `python3Packages.spotipy: 2.19.0 -> 2.20.0`                          |
| [`05cf713a`](https://github.com/NixOS/nixpkgs/commit/05cf713a5bf3fb8b8e5a1b48ea84292ddfb7d18a) | `python3Packages.pyunifiprotect: 4.0.8 -> 4.0.9`                     |
| [`5724ddfc`](https://github.com/NixOS/nixpkgs/commit/5724ddfc4a89a281aefa2e6cb3bf5495df1e8ed1) | `python310Packages.zigpy-znp: 0.7.0 -> 0.8.0`                        |
| [`c2127eae`](https://github.com/NixOS/nixpkgs/commit/c2127eaef0b7c8a40c3ae071b2c95783cebff674) | `python310Packages.zigpy-cc: disable failing test`                   |
| [`9e355454`](https://github.com/NixOS/nixpkgs/commit/9e355454e64ed0a66e81333f7c35bb74492d3677) | `python310Packages.bellows: 0.30.0 -> 0.31.0`                        |
| [`2b7af387`](https://github.com/NixOS/nixpkgs/commit/2b7af3878c0754e04d3fd04649c931e38e732aac) | `python310Packages.zigpy-zigate: 0.8.0 -> 0.9.0`                     |
| [`c75cc76c`](https://github.com/NixOS/nixpkgs/commit/c75cc76caa38869524fc3c0f993409d979805d4d) | `python310Packages.zigpy-xbee: 0.14.0 -> 0.15.0`                     |
| [`29d80716`](https://github.com/NixOS/nixpkgs/commit/29d807166298f95d94ffad11f34827716823e96c) | `python310Packages.zigpy-deconz: 0.16.0 -> 0.18.0`                   |
| [`f3466e51`](https://github.com/NixOS/nixpkgs/commit/f3466e515b319b09f5f24345857375d5c6bd2e16) | `python310Packages.zigpy: 0.46.0 -> 0.47.2`                          |
| [`dadd1fe5`](https://github.com/NixOS/nixpkgs/commit/dadd1fe5993fb9ad2397fa6373d4fda82491b45d) | `python310Packages.pyunifiprotect: 3.9.2 -> 4.0.8`                   |
| [`606022d3`](https://github.com/NixOS/nixpkgs/commit/606022d3990fcaefd736bf8d57a8b4f6e363e593) | `python310Packages.pyhiveapi: 0.5.11 -> 0.5.13`                      |
| [`2406e2ea`](https://github.com/NixOS/nixpkgs/commit/2406e2ea3d98fa4956f4c73f882f635aa5e4567b) | `python3Packages.pydeconz: 92 -> 96`                                 |
| [`382f8d6a`](https://github.com/NixOS/nixpkgs/commit/382f8d6a09a827e50c40762f23b863e103d8ee1e) | `python3Packages.pyatv: 0.10.0 -> 0.10.2`                            |
| [`0b246ce0`](https://github.com/NixOS/nixpkgs/commit/0b246ce0d5181d71871f07f87b28916c50da3318) | `python3Packages.nexia: 1.0.2 -> 2.0.1`                              |
| [`17658626`](https://github.com/NixOS/nixpkgs/commit/176586261efd4c78b9eab7c3d5499dee3d287ad1) | `python310Packages.py-canary: 0.5.2 -> 0.5.3`                        |
| [`dc1a8000`](https://github.com/NixOS/nixpkgs/commit/dc1a8000ef0866341b4bf1616fc7efe23017f162) | `python310Packages.intellifire4py: 1.0.5 -> 2.0.1 (#174986)`         |
| [`68040ff2`](https://github.com/NixOS/nixpkgs/commit/68040ff2c6166fd11ac37feaa6e97042e63074b6) | `python3Packages.homematicip: 1.0.2 -> 1.0.3`                        |
| [`db537d13`](https://github.com/NixOS/nixpkgs/commit/db537d13e1e7de2e7cb8fd49cdcdbb256d39597a) | `python3Packages.async-upnp-client: 0.31.1 -> 0.31.2`                |
| [`c462805a`](https://github.com/NixOS/nixpkgs/commit/c462805a47ac648dc067d45ac6705970c73af139) | `python3Packages.aiounifi: 33 -> 34`                                 |
| [`eff6a8d4`](https://github.com/NixOS/nixpkgs/commit/eff6a8d480c60e3a238de038453228517bac8f4d) | `python3Packages.aioimaplib: 0.9.0 -> 1.0.0`                         |
| [`e233468d`](https://github.com/NixOS/nixpkgs/commit/e233468d9fa78b1f34e4da3447c5bb7d5d67e2ab) | `haskellPackages.purescript: adjust for 0.15.4`                      |
| [`485a3dd6`](https://github.com/NixOS/nixpkgs/commit/485a3dd64c0c6fd2406115b021d50ed16d37f0bf) | `python3Packages.aiohomekit: 0.7.17 -> 0.7.20`                       |
| [`98e651e8`](https://github.com/NixOS/nixpkgs/commit/98e651e89148eab0afbe420e58fd80c9545f370c) | `python3Packages.chacha20poly1305-reusable: init at 0.0.4`           |
| [`44a21779`](https://github.com/NixOS/nixpkgs/commit/44a2177997c0f3a641956e169dc0628f3b6746ba) | `limitcpu: init at 2.7`                                              |
| [`d0cdd897`](https://github.com/NixOS/nixpkgs/commit/d0cdd897c347d73f98031f5143b0cd872e57874f) | `cpulimit: use github sources at 0.2`                                |
| [`759cf488`](https://github.com/NixOS/nixpkgs/commit/759cf488a87ed74b5d7ab0c2ec7eee8b95686eb8) | `maintainers: add jsoo1`                                             |
| [`63b81ee7`](https://github.com/NixOS/nixpkgs/commit/63b81ee7fd7244888e91185c211a36050a36b832) | `bloop: 1.5.0 -> 1.5.2`                                              |
| [`d2184ac8`](https://github.com/NixOS/nixpkgs/commit/d2184ac8686da08f294b875e9a0ec0121c3a8b1d) | `electron: fix headers location`                                     |
| [`7ea869f7`](https://github.com/NixOS/nixpkgs/commit/7ea869f74ccf4b414f397fb77756ac5aa2df8785) | `deno: 1.23.2 -> 1.23.3`                                             |
| [`c29d8a06`](https://github.com/NixOS/nixpkgs/commit/c29d8a06e1338fbec4fdb665bbf62e7ab36999ed) | `haskellPackages.powerdns: unbreak`                                  |
| [`5ee14a73`](https://github.com/NixOS/nixpkgs/commit/5ee14a73f75d03aa61cc666a9c00bb612fb949cf) | `slurm: move perl to nativeBuildInputs`                              |
| [`273dce6c`](https://github.com/NixOS/nixpkgs/commit/273dce6c32f322bd6ab59bf1fc259d34c1031d93) | `goreleaser: 1.9.2 -> 1.10.1`                                        |
| [`493c076e`](https://github.com/NixOS/nixpkgs/commit/493c076ec6103bfc9bcf7663ce54859e28545333) | `vscode-extensions.ms-vscode.cpptools: 1.9.1 -> 1.11.0`              |
| [`0fc7b58c`](https://github.com/NixOS/nixpkgs/commit/0fc7b58cdb293b5ba13ccfb2070ae7145d9a5e7b) | `pijul: 1.0.0-beta.1 -> 1.0.0-beta.2`                                |
| [`3a96c0a4`](https://github.com/NixOS/nixpkgs/commit/3a96c0a4f289c19e5d366658f034d434d7b8a17d) | `autokey: fix No GSettings schemas are installed and clean wrapping` |
| [`9996eae4`](https://github.com/NixOS/nixpkgs/commit/9996eae4da616c68c381fd884e3604732896e7ac) | `arkade: 0.8.28 -> 0.8.29`                                           |
| [`0ad873b4`](https://github.com/NixOS/nixpkgs/commit/0ad873b44b73ab2fde8c378470cd1b75b7a3c4d2) | `virtualbox: update patch linux-5.18 -> linux-5.19`                  |
| [`72bd7c85`](https://github.com/NixOS/nixpkgs/commit/72bd7c85b0a055b1f3a3c42b759116cc3809d3e6) | `logseq: 0.7.5 -> 0.7.6`                                             |
| [`24209086`](https://github.com/NixOS/nixpkgs/commit/242090860a2d2f9d665d5b1629402996c12af4b1) | `nixos/openwebrx: add codec2, js8call`                               |
| [`9435afe2`](https://github.com/NixOS/nixpkgs/commit/9435afe202ba907d9273066abc13adbe73743f30) | `python310Packages.cron-descriptor: 1.2.27 -> 1.2.30`                |
| [`3f4d5f2c`](https://github.com/NixOS/nixpkgs/commit/3f4d5f2cf8794f09892b73b786447ee8bb0b6173) | `haskellPackages.rio: skip a broken test on aarch64-darwin`          |
| [`72b001fd`](https://github.com/NixOS/nixpkgs/commit/72b001fd68cff13d000a3f1e8be57722cb4a1284) | `pyradio: 0.8.9.21 -> 0.8.9.22`                                      |
| [`c996ce44`](https://github.com/NixOS/nixpkgs/commit/c996ce44157e11713b4b6fd588f09becc2252ab0) | `haskellPackages.misfortune: remove patch`                           |
| [`3865a901`](https://github.com/NixOS/nixpkgs/commit/3865a901725e316fe0a98d1df025527ef7348f8f) | `haskellPackages: regenerate package set based on current config`    |
| [`98365428`](https://github.com/NixOS/nixpkgs/commit/98365428b067485a32f23fcf70552c9882203f18) | `all-cabal-hashes: 2022-07-02T15:59:48Z -> 2022-07-02T15:59:48Z`     |
| [`c96e95f5`](https://github.com/NixOS/nixpkgs/commit/c96e95f5867919431021211a45b48747b4028bca) | `archisteamfarm.ui: update`                                          |
| [`322472c5`](https://github.com/NixOS/nixpkgs/commit/322472c5fea968ec5ed5e98dca81a7752ff0cb5b) | `archisteamfarm: 5.2.6.3 -> 5.2.7.7`                                 |
| [`3d6c926c`](https://github.com/NixOS/nixpkgs/commit/3d6c926c4f6464ba73a176686d65536f3ce17da4) | `treewide/servers,shells,tools: add sourceType for more packages`    |
| [`70daeea1`](https://github.com/NixOS/nixpkgs/commit/70daeea1c01e1531135db8cab53dc2dbee376e8c) | `surf: enable audio & video support`                                 |
| [`c15e73a0`](https://github.com/NixOS/nixpkgs/commit/c15e73a012d48fb4f1eee463b161a333add587b7) | `hercules-ci-{agent,cnix-expr,cnix-store}: pin to nix_2_9`           |
| [`956dd00d`](https://github.com/NixOS/nixpkgs/commit/956dd00dc73e2e3fe12d0f803a7c1151004adfd0) | `cachix: pin to nix_2_9`                                             |
| [`352c7eaf`](https://github.com/NixOS/nixpkgs/commit/352c7eaf9d4582462e06ca0c4bc2b27eed7234db) | `haskellPackages: regenerate package set based on current config`    |
| [`8d49c0ba`](https://github.com/NixOS/nixpkgs/commit/8d49c0ba6d5ddae5eba45d39a7e66b9b6200adb6) | `all-cabal-hashes: 2022-06-26T16:08:53Z -> 2022-06-28T01:15:54Z`     |
| [`7cc8942e`](https://github.com/NixOS/nixpkgs/commit/7cc8942e14a3fc4f7be49277d04803bb66fecf35) | `haskellPackages: regenerate package set based on current config`    |
| [`b5ea8072`](https://github.com/NixOS/nixpkgs/commit/b5ea807275040d364a22c6e96383e53b8e485914) | `all-cabal-hashes: 2022-06-23T03:01:47Z -> 2022-06-26T16:08:53Z`     |
| [`caea0835`](https://github.com/NixOS/nixpkgs/commit/caea0835e4448ba2af01c22b4726c40df346578c) | `haskellPackages: stackage LTS 19.12 -> LTS 19.13`                   |
| [`2cf08210`](https://github.com/NixOS/nixpkgs/commit/2cf08210fd98a99dbe0ac59eb58ecbda3d5d7795) | `ghc8107-ghc923: patch haddock to generate correct source links`     |
| [`1a170493`](https://github.com/NixOS/nixpkgs/commit/1a170493e56b5a322317d2d70798e5dbce213e20) | `fsverity-utils: init at 1.5`                                        |