### PR TITLE
chore(flake/home-manager): `6311f4ad` -> `45ef70cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657619258,
-        "narHash": "sha256-YaGKliHV0zXsTB9MQJD6nUpP2sU31jvmZKbTSwdp5XA=",
+        "lastModified": 1657620121,
+        "narHash": "sha256-/F1KpOMy3FISxS7lEyQuDBUQB6cBFeR4ajQwhBepHCQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6311f4adc39fc8ce77f7b80212024fe4286280d1",
+        "rev": "45ef70cc73540fbf9718cce5da65e2aa6e7ab2f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`45ef70cc`](https://github.com/nix-community/home-manager/commit/45ef70cc73540fbf9718cce5da65e2aa6e7ab2f7) | `swayidle: remove unnecessary config wrapper` |
| [`43ea4c51`](https://github.com/nix-community/home-manager/commit/43ea4c5123d9d335ff4eba6341509d45f60ceeec) | `swayidle: fix systemd service`               |