### PR TITLE
chore(flake/nixos-hardware): `3bf48d35` -> `14e9f729`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -158,11 +158,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1656933710,
-        "narHash": "sha256-SVG8EqY1OTJWBRY4hpct2ZR2Rk0L8hCFkug3m0ABoZE=",
+        "lastModified": 1657738886,
+        "narHash": "sha256-lmAcczi6xyyNhrUcOaStekilDcS8e5tWB9ycwUFv/mQ=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3bf48d3587d3f34f745a19ebc968b002ef5b5c5a",
+        "rev": "14e9f7298c4201566a4597560d7e141d9ff402cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                                                                                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
| [`66f8f007`](https://github.com/NixOS/nixos-hardware/commit/66f8f007d07f6e32b1cb08ac10a75045b7eb0310) | `add comment about normalizing dpi between sync and offload mode`                                                               |
| [`e8e0e7dc`](https://github.com/NixOS/nixos-hardware/commit/e8e0e7dc37a2e768ef19adcfde4d8f98da33e405) | `conditionally turn on power management and modesetting when we are in sync mode`                                               |
| [`fd08b05a`](https://github.com/NixOS/nixos-hardware/commit/fd08b05aed34178156174264ef9cb5af9a6b913b) | `comment about acpi errors`                                                                                                     |
| [`116ae977`](https://github.com/NixOS/nixos-hardware/commit/116ae977abe00cbe19fcbc66484e1c93eba7da0c) | `throttled consistency`                                                                                                         |
| [`6bd8ae54`](https://github.com/NixOS/nixos-hardware/commit/6bd8ae54091b42d270b9400bd89805dc8e01166b) | `flake changes`                                                                                                                 |
| [`c2295916`](https://github.com/NixOS/nixos-hardware/commit/c2295916b3280e342eaaab168fe886dcba9341fc) | `mkDefault consistency`                                                                                                         |
| [`f5d9dd11`](https://github.com/NixOS/nixos-hardware/commit/f5d9dd114fff730f96236bbea733cc37947391fc) | `cannot replicate findings for sleep not working when system has no usb or external video plugged in to it, make wireless work` |
| [`e36b0c40`](https://github.com/NixOS/nixos-hardware/commit/e36b0c4022ddd6ac69cdd8ed5d798bc0fd8d938e) | `add p52`                                                                                                                       |