### PR TITLE
chore(flake/darwin): `2f2bdf65` -> `54a24f04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1651916036,
-        "narHash": "sha256-UuD9keUGm4IuVEV6wdSYbuRm7CwfXE63hVkzKDjVsh4=",
+        "lastModified": 1657835815,
+        "narHash": "sha256-CnZszAYpNKydh6N7+xg+eRtWNVoAAGqc6bg+Lpgq1xc=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "2f2bdf658d2b79bada78dc914af99c53cad37cba",
+        "rev": "54a24f042f93c79f5679f133faddedec61955cf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                   |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`2c6b9d91`](https://github.com/LnL7/nix-darwin/commit/2c6b9d9144e0b8e860c97a7c18cb758227c56a53) | `Add option to set com.apple.screencapture type` |