### PR TITLE
chore(flake/nixpkgs): `68c63e60` -> `4a01ca36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657624652,
-        "narHash": "sha256-rFJNM0X/dxekT6EESSh80mlBGqztfN/XOF/oRL6in68=",
+        "lastModified": 1657802959,
+        "narHash": "sha256-9+JWARSdlL8KiH3ymnKDXltE1vM+/WEJ78F5B1kjXys=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68c63e60b8413260605efbe1ac5addaa099cdfb3",
+        "rev": "4a01ca36d6bfc133bc617e661916a81327c9bbc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                               |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`4a01ca36`](https://github.com/NixOS/nixpkgs/commit/4a01ca36d6bfc133bc617e661916a81327c9bbc8) | `python3Packages.jupyterlab_server: fix build on darwin (#181426)`           |
| [`4fe4be1b`](https://github.com/NixOS/nixpkgs/commit/4fe4be1b971e70b36f52783e8ffb2dcf7d65a321) | `xmonadctl: init at 0.17.0`                                                  |
| [`fdbcbdab`](https://github.com/NixOS/nixpkgs/commit/fdbcbdab948463c86a35f7345508d6cbaa8df82e) | `haskellPackages: mark builds failing on hydra as broken`                    |
| [`6e643696`](https://github.com/NixOS/nixpkgs/commit/6e6436963d558d89c5fb902f4b7a831323ecb9dc) | `gnatboot: 4.1 -> 11.2.0-4 (#177579)`                                        |
| [`c5e304a4`](https://github.com/NixOS/nixpkgs/commit/c5e304a480d759b5447f5973ec2165257323caa9) | `haskellPackages: mark builds failing on hydra as broken`                    |
| [`71f758e6`](https://github.com/NixOS/nixpkgs/commit/71f758e61653fab7a815ec06205047385c22bca5) | `gnome-console: 42.0 -> 42.2`                                                |
| [`ca03b94d`](https://github.com/NixOS/nixpkgs/commit/ca03b94dd7c842a34999c13eed8684a25a1df9ef) | `python310Packages.levenshtein: 0.19.1 -> 0.19.2`                            |
| [`5ad0643e`](https://github.com/NixOS/nixpkgs/commit/5ad0643e1c0b6ec442754b34316814ea212a76a3) | `nodejs-18_x: 18.5.0 -> 18.6.0`                                              |
| [`647e5317`](https://github.com/NixOS/nixpkgs/commit/647e5317eb55c53094e7d7377b0f6a65c13161f6) | `sqlfluff: 1.1.0 -> 1.2.0`                                                   |
| [`5eb9bf55`](https://github.com/NixOS/nixpkgs/commit/5eb9bf5565c1aa2b375613ed22bdf55f1fd58e29) | `alejandra: 1.5.0 -> 2.0.0`                                                  |
| [`3973b7d8`](https://github.com/NixOS/nixpkgs/commit/3973b7d82670713f0b7df1e0abee604d986b11c5) | `kubernetes: 1.23.8 -> 1.23.9`                                               |
| [`28010c8d`](https://github.com/NixOS/nixpkgs/commit/28010c8de42d1f79399bb57d72a875c6ed974a97) | `signal-desktop: 5.49.0 -> 5.50.0`                                           |
| [`12ea6c11`](https://github.com/NixOS/nixpkgs/commit/12ea6c11ba9e4df01e455ae395ecf44b4d9e0b38) | `godns: 2.8.3 -> 2.8.4`                                                      |
| [`ed781ecb`](https://github.com/NixOS/nixpkgs/commit/ed781ecbeada8359b86f6c4b4fd6ed5b19dc61e5) | `meta`                                                                       |
| [`b52679fe`](https://github.com/NixOS/nixpkgs/commit/b52679fe88c811131078e8297567ebe3fedd6be1) | `keyd: init at 2.4.1`                                                        |
| [`e4f3664e`](https://github.com/NixOS/nixpkgs/commit/e4f3664e623e8d2a2e1adf0e28fbaf6f2e281999) | `go_1_18: 1.18.3 -> 1.18.4`                                                  |
| [`0ae92922`](https://github.com/NixOS/nixpkgs/commit/0ae92922a1c7a4bd709a9342f978013615c85661) | `nixos/tests/home-assistant: improve reload/restart test cases`              |
| [`9e0e2fda`](https://github.com/NixOS/nixpkgs/commit/9e0e2fdad00642694b83c70e2148f5f13df236b5) | `home-assistant: 2022.7.3 -> 2022.7.4`                                       |
| [`38f8a4d7`](https://github.com/NixOS/nixpkgs/commit/38f8a4d71c05f41bbe6193d340777a317bed5171) | `openscad: fix on wayland systems`                                           |
| [`12388840`](https://github.com/NixOS/nixpkgs/commit/12388840906c5ba261a35d9a0142e706f4616dbd) | `redis: 7.0.2 -> 7.0.3`                                                      |
| [`6d5c66a9`](https://github.com/NixOS/nixpkgs/commit/6d5c66a9d9db12ae588713de356c5e32240f02ac) | `python3Packages.bellows: 0.31.0 -> 0.31.1`                                  |
| [`a85aa567`](https://github.com/NixOS/nixpkgs/commit/a85aa567efd90e8807d5d890f7724468971b4ffe) | `skopeo: 1.8.0 -> 1.9.0`                                                     |
| [`32566323`](https://github.com/NixOS/nixpkgs/commit/32566323e3391cd64eeba138aec84d73c4d8ff45) | `metasploit: 6.2.4 -> 6.2.6`                                                 |
| [`ca39f38e`](https://github.com/NixOS/nixpkgs/commit/ca39f38e8e523d3593ff1fa726191b5028ce16e5) | `vault-bin: 1.10.4 -> 1.11.0`                                                |
| [`89c6711d`](https://github.com/NixOS/nixpkgs/commit/89c6711d3408c41b3a6f7c5cfe52167dccf09c61) | `vault: 1.10.4 -> 1.11.0`                                                    |
| [`e2105ec0`](https://github.com/NixOS/nixpkgs/commit/e2105ec0e0aa872c48ac2cd0afb753a3d1f6a87b) | `python310Packages.oslo-context: 4.1.0 -> 5.0.0`                             |
| [`c6cb233b`](https://github.com/NixOS/nixpkgs/commit/c6cb233b4a63c08c49dc9287d9af689c477de03a) | `python310Packages.pyinsteon: 1.1.2 -> 1.1.3`                                |
| [`f9418f4e`](https://github.com/NixOS/nixpkgs/commit/f9418f4eabdc1a32bbc2a16c6a4b36606dddfa5d) | `nushell: 0.64.0 -> 0.65.0`                                                  |
| [`c92c7065`](https://github.com/NixOS/nixpkgs/commit/c92c70652ead073dd1e39874de1e7510b3f18264) | `python310Packages.google-cloud-websecurityscanner: 1.8.0 -> 1.8.1`          |
| [`279a69aa`](https://github.com/NixOS/nixpkgs/commit/279a69aaf17a3451c5ce98fc26788aa9d3c47baa) | `hadolint: build with language-docker 11.0.0`                                |
| [`9154aee3`](https://github.com/NixOS/nixpkgs/commit/9154aee3bc3e527c7f052d7eea607ad883443cac) | `python310Packages.google-cloud-os-config: 1.12.0 -> 1.12.1`                 |
| [`9b98f352`](https://github.com/NixOS/nixpkgs/commit/9b98f352034f0c8b82c3b741e4510c4a99623b30) | `python310Packages.google-cloud-pubsub: 2.13.2 -> 2.13.3`                    |
| [`755bd306`](https://github.com/NixOS/nixpkgs/commit/755bd306f538d142667580eeefbe1565d60670d4) | `python310Packages.google-cloud-resource-manager: 1.5.1 -> 1.6.0`            |
| [`3076da65`](https://github.com/NixOS/nixpkgs/commit/3076da658ebd9eb80c44e4b3d79904eb99f8672e) | `grype: 0.41.0 -> 0.42.0`                                                    |
| [`b90ee0a3`](https://github.com/NixOS/nixpkgs/commit/b90ee0a3dce06d438e6c27b80cd2ba5d6ecf13c8) | `python310Packages.google-cloud-bigquery-storage: 2.14.0 -> 2.14.1`          |
| [`7e0832c5`](https://github.com/NixOS/nixpkgs/commit/7e0832c5f9d72d6e687551937800e552d2be4ea2) | `python310Packages.google-cloud-org-policy: 1.3.3 -> 1.4.0`                  |
| [`64f2b31d`](https://github.com/NixOS/nixpkgs/commit/64f2b31d87fcdf6af9aef9660b536aa91ce79f3d) | `python310Packages.google-cloud-language: 2.4.3 -> 2.5.1`                    |
| [`d68d84d7`](https://github.com/NixOS/nixpkgs/commit/d68d84d7934bc0ec6bd998b556ab274e1210d0c0) | `python310Packages.google-cloud-redis: 2.8.1 -> 2.9.0`                       |
| [`d7aeec46`](https://github.com/NixOS/nixpkgs/commit/d7aeec462c63ded1ec468543b193033db81348f9) | `python310Packages.django: fix build with gdal and use correct geos version` |
| [`b76bd25a`](https://github.com/NixOS/nixpkgs/commit/b76bd25aca5458a9ecc674afb7fc122c5c66e8ee) | `gopls: 0.9.0 -> 0.9.1`                                                      |
| [`f66649b4`](https://github.com/NixOS/nixpkgs/commit/f66649b41e597d95e2d24c7d5dbde55c27ade5f0) | `syft: 0.50.0 -> 0.51.0`                                                     |
| [`80045fe5`](https://github.com/NixOS/nixpkgs/commit/80045fe5693e2c65c367015f966d69e6ae742269) | `python310Packages.pyruckus: 0.14 -> 0.16`                                   |
| [`38134efc`](https://github.com/NixOS/nixpkgs/commit/38134efc76345f43efd8792ce4dc4a16f5621452) | `glibcLocales, glibcLocalesUtf8: only define non-null on linux-glibc`        |
| [`01ba1ceb`](https://github.com/NixOS/nixpkgs/commit/01ba1ceb0e27ffa8ff7faf2ee5735a0d7fc9b7a1) | `hadoop: fix failing evaluation on platforms other than x86_64-linux`        |
| [`c46a3dc5`](https://github.com/NixOS/nixpkgs/commit/c46a3dc50aa7c89cca3fd7245d84c0dcb7f4de1c) | `cachix-agent: allow restarts now that deployments are subprocesses`         |
| [`18348a5e`](https://github.com/NixOS/nixpkgs/commit/18348a5e4d1e4654f2bc7e6e5c9746ca56c1dd5e) | `deno: 1.23.3 -> 1.23.4`                                                     |
| [`62db62f6`](https://github.com/NixOS/nixpkgs/commit/62db62f6913c4166c875c8b4f189dc46df0947b7) | `bisu: mark with sourceProvenance binaryBytecode`                            |
| [`65f330a8`](https://github.com/NixOS/nixpkgs/commit/65f330a83dc90d7960fcd7c1ab32904aabfcc2e4) | `Update doc/languages-frameworks/coq.section.md`                             |
| [`0afe768a`](https://github.com/NixOS/nixpkgs/commit/0afe768a917d2e4082e43fce09e05a2b23d62a67) | `python310Packages.types-decorator: 5.1.7 -> 5.1.8`                          |
| [`3e5fba73`](https://github.com/NixOS/nixpkgs/commit/3e5fba739b6c8785dc8ba696af79cbab176c3204) | `vmware-horizon-client: use legacy UI`                                       |
| [`d69641d0`](https://github.com/NixOS/nixpkgs/commit/d69641d01231200c72885ad745b2087480eef053) | `python310Packages.circuitbreaker: 1.3.2 -> 1.4.0`                           |
| [`e7d9b66a`](https://github.com/NixOS/nixpkgs/commit/e7d9b66a0484c2afca43edc5327bba58b73be4eb) | `matterhorn: build with brick 0.73`                                          |
| [`1fea3efe`](https://github.com/NixOS/nixpkgs/commit/1fea3efe7abd9128775ddf6b76f61f10171ccaf1) | `haskellPackages.brick_0_71_1: fix eval`                                     |
| [`5e6ec193`](https://github.com/NixOS/nixpkgs/commit/5e6ec193f8fe1bdd61d85424c350818d76095ab8) | `python3Packages.trezor: 0.13.2 -> 0.13.3`                                   |
| [`9e716bf9`](https://github.com/NixOS/nixpkgs/commit/9e716bf99b779e09cfbedb01adec7d08c29d5876) | `python310Packages.types-toml: 0.10.7 -> 0.10.8`                             |
| [`41048f0b`](https://github.com/NixOS/nixpkgs/commit/41048f0b463e415eb97df2bbbdf25548b6e32ff6) | `haskell.packages.ghc923.servant-server: drop obsolete override`             |
| [`ef4bc1ef`](https://github.com/NixOS/nixpkgs/commit/ef4bc1efdd88a79acadfaaa9945fbb1df991d88d) | `haskell.packages.ghc923.cryptonite: 0.29 -> 0.30`                           |
| [`fcba3d3e`](https://github.com/NixOS/nixpkgs/commit/fcba3d3e5073dbedba3e578486bfb5d40bfa6cdd) | `haskell.packages.ghc923.hlint: reflect 3.4 -> 3.4.1 update`                 |
| [`0133c313`](https://github.com/NixOS/nixpkgs/commit/0133c313c4a229b80157b343b275e48b8db567b8) | `haskell.packages.ghc923.dbus: reflect 1.2.24 -> 1.2.25 update`              |
| [`f2f8e3ca`](https://github.com/NixOS/nixpkgs/commit/f2f8e3ca95569eea5f54ba70ec3a438a04799851) | `haskellPackages: reflect ghc-lib, ghc-lib-parser updates`                   |
| [`5476ab31`](https://github.com/NixOS/nixpkgs/commit/5476ab31caf26e585dd03487f6c47152f5d8db8a) | `aws-sso-cli: format with nixpkgs-fmt`                                       |
| [`c308cc97`](https://github.com/NixOS/nixpkgs/commit/c308cc97348bbd875fa0f3967c81e1ffd1987e97) | `aws-sso-cli: add xdg-utils dependency`                                      |
| [`bfa3e73c`](https://github.com/NixOS/nixpkgs/commit/bfa3e73c9542258c636c587b5269b24243b56c2d) | `python310Packages.jupyterlab: 3.3.4 -> 3.4.3 (#181231)`                     |
| [`f3eb585d`](https://github.com/NixOS/nixpkgs/commit/f3eb585dad2ac96e2b54167f8d34d01284d98d3e) | `terraform: 1.2.4 -> 1.2.5 (#181343)`                                        |
| [`b27f418b`](https://github.com/NixOS/nixpkgs/commit/b27f418b91310893703608305e8697e990f332d1) | `librest_1_0: 0.9.0 → 0.9.1`                                                 |
| [`96ac2fd3`](https://github.com/NixOS/nixpkgs/commit/96ac2fd32e34f472ce61f84e391190d573dec6d0) | `gnome-desktop: 42.2 → 42.3`                                                 |
| [`2f038ea7`](https://github.com/NixOS/nixpkgs/commit/2f038ea7376e09eab2a72fc128c059f62dca8e1d) | `gjs: 1.72.0 → 1.72.1`                                                       |
| [`5a635bdf`](https://github.com/NixOS/nixpkgs/commit/5a635bdff99a65fb067d18a398b20b4450831689) | `d-spy: 1.2.0 → 1.2.1`                                                       |
| [`ac37f487`](https://github.com/NixOS/nixpkgs/commit/ac37f4873a64054c81c8a32ac662ab58b3a661cc) | `gnome-console: 42.beta -> 42.0`                                             |
| [`96e7dc4f`](https://github.com/NixOS/nixpkgs/commit/96e7dc4f245c6a99d725dd5a6e8c3b2fb9c8e5e2) | `n8n: 0.185.0 → 0.186.0`                                                     |
| [`0b61d53b`](https://github.com/NixOS/nixpkgs/commit/0b61d53bd02e695df61bafe9794a02e0c9458329) | `python310Packages.pymc: 4.0.1 -> 4.1.2`                                     |
| [`8c77dc96`](https://github.com/NixOS/nixpkgs/commit/8c77dc967f04ec0a9a65bae634a0935aa2d2b0ed) | `python310Packages.aioaladdinconnect: 0.1.21 -> 0.1.23`                      |
| [`3d1205de`](https://github.com/NixOS/nixpkgs/commit/3d1205de9120ea72392b28d89fc5d0ec9ba04e7e) | `doc: clarify coq override`                                                  |
| [`79aebd3e`](https://github.com/NixOS/nixpkgs/commit/79aebd3e05e08d5207aea674e4441cfbc3201a1e) | `btcpayserver: enable build on darwin`                                       |
| [`b45e4a00`](https://github.com/NixOS/nixpkgs/commit/b45e4a004e89af399cbccac684745d33cb4b1e46) | `btcpayserver: 1.5.4 -> 1.6.1`                                               |
| [`43b37c60`](https://github.com/NixOS/nixpkgs/commit/43b37c60c077e1e4279617474486be15e055fd46) | `nbxplorer: 2.3.26 -> 2.3.28`                                                |
| [`a8c2b4f0`](https://github.com/NixOS/nixpkgs/commit/a8c2b4f0e4d79d7676f00aa4b143a6687b607016) | `python310Packages.aesara: 2.7.6 -> 2.7.7`                                   |
| [`83a35abf`](https://github.com/NixOS/nixpkgs/commit/83a35abff566f9b04f15f7e9a9c049bac90896f4) | `python310Packages.pex: 2.1.95 -> 2.1.97`                                    |
| [`b7b86c4f`](https://github.com/NixOS/nixpkgs/commit/b7b86c4f548d8c127902406c7c51d6922c2cff81) | `add stable anchor`                                                          |
| [`82d1ed89`](https://github.com/NixOS/nixpkgs/commit/82d1ed89d144e09a388f11207398290fbee71e44) | `python310Packages.hahomematic: 2022.7.5 -> 2022.7.7`                        |
| [`26c66bc7`](https://github.com/NixOS/nixpkgs/commit/26c66bc7c8cec6008427d10a2e97b2862f4a3475) | `nixos/release: add proxmox LXC and VMA`                                     |
| [`f60f1655`](https://github.com/NixOS/nixpkgs/commit/f60f16550174e9772b5285795face7397dca1139) | `nixos/proxmox-image: use qemu 6.2 for building VMA`                         |
| [`f88533ec`](https://github.com/NixOS/nixpkgs/commit/f88533ec37fca4cce90fe6ddf50f5b817b089ce8) | `neovim-remote: disable tests on Darwin`                                     |
| [`c0c767ee`](https://github.com/NixOS/nixpkgs/commit/c0c767ee26405e1d5837f2832ef6297622e72471) | `python310Packages.howdoi: disable failing test`                             |
| [`7c6a8f0b`](https://github.com/NixOS/nixpkgs/commit/7c6a8f0b38c34aaba938d2bf68438c857310c0ec) | `tig: 2.5.5 -> 2.5.6`                                                        |
| [`2d123c3c`](https://github.com/NixOS/nixpkgs/commit/2d123c3c4bd55763e558cd4e752f5bc7722789c6) | `coqPackages.coqeal: 1.1.0 → 1.1.1`                                          |
| [`88d388d1`](https://github.com/NixOS/nixpkgs/commit/88d388d168886c665b4ab88158760837b87e9ec7) | `kde/plasma5: 5.25.2 -> 5.25.3`                                              |
| [`1e2c77eb`](https://github.com/NixOS/nixpkgs/commit/1e2c77eb4c8449c599f9be9d4e5dbd511055a154) | `pciutils: update homepage`                                                  |
| [`5ded7b6d`](https://github.com/NixOS/nixpkgs/commit/5ded7b6dc2b86311d57dd25afc81d1539ff8e90f) | `redux: 1.2.2 -> 1.3.2`                                                      |
| [`3489b30c`](https://github.com/NixOS/nixpkgs/commit/3489b30c06a18a0fe35ff5007fcc97c018850c92) | `python310Packages.types-requests: 2.28.0 -> 2.28.1`                         |
| [`32a83dc8`](https://github.com/NixOS/nixpkgs/commit/32a83dc8402bfd44b736f1500e59116b59762371) | `kyverno: init at 1.7.0`                                                     |
| [`0b91cc09`](https://github.com/NixOS/nixpkgs/commit/0b91cc0961012d721731467b3e0aea966da105f7) | `firefox-esr-102-unwrapped: 102.0esr -> 102.0.1esr`                          |
| [`47947882`](https://github.com/NixOS/nixpkgs/commit/479478822b57a4c892e56c3e81bc8abc719a5ba1) | `velero: added v prefix to version to fix client/server version validation`  |
| [`6e5dd2a2`](https://github.com/NixOS/nixpkgs/commit/6e5dd2a2cab4f8a009f7b8b94bd0ea7047f805eb) | `ffmpeg-normalize: 1.23.0 -> 1.23.1`                                         |
| [`972106f9`](https://github.com/NixOS/nixpkgs/commit/972106f90f3c10680bcb0818c3936aa5dd27b33d) | `curtail: 1.3.0 -> 1.3.1`                                                    |
| [`dcfd1b02`](https://github.com/NixOS/nixpkgs/commit/dcfd1b027ffd7f2976b48908dd9b467d1807a3cd) | `python310Packages.pulumi-aws: 5.9.2 -> 5.10.0`                              |
| [`74a366bd`](https://github.com/NixOS/nixpkgs/commit/74a366bdbb3912f1caffb4d98d6c84e71a5896a6) | `ncdu: 1.16 -> 1.17`                                                         |
| [`c17e97b1`](https://github.com/NixOS/nixpkgs/commit/c17e97b121c6b4e0850f456c2cb2c1fc249d67de) | `wakeonlan: 0.41 -> 0.42`                                                    |
| [`6eba1980`](https://github.com/NixOS/nixpkgs/commit/6eba1980d725fe652a96111330ca0aef8eebbf33) | `haskellPackages: regenerate package set based on current config`            |
| [`3cc72663`](https://github.com/NixOS/nixpkgs/commit/3cc7266312b627047daab6f8a9b4dce0cd4bcb68) | `haskellPackages: stackage LTS 19.14 -> LTS 19.15`                           |
| [`2733e996`](https://github.com/NixOS/nixpkgs/commit/2733e996eaa74583a86f01ed6afa4098eea930a8) | `all-cabal-hashes: 2022-07-07T10:54:07Z -> 2022-07-12T21:40:07Z`             |
| [`dbe13377`](https://github.com/NixOS/nixpkgs/commit/dbe1337750f324137ca2ba78f20a3be00e16481a) | `gh: 2.14.0 -> 2.14.1`                                                       |
| [`2c9984a4`](https://github.com/NixOS/nixpkgs/commit/2c9984a471897b5fae4242fa9bdac120b6ac5276) | `framac: 24.0 (Chromium) → 25.0 (Manganese)`                                 |
| [`567fd7b1`](https://github.com/NixOS/nixpkgs/commit/567fd7b18497a04fe5e86627f55ecb9559b8fb51) | `python310Packages.pyruckus: 0.14 -> 0.16`                                   |
| [`2f5e7982`](https://github.com/NixOS/nixpkgs/commit/2f5e7982ec58226ab4beaed0282dad1dfe6efaec) | `haskellPackages.postgrest: mark as broken`                                  |
| [`0d1e99de`](https://github.com/NixOS/nixpkgs/commit/0d1e99decbfb16d8749a4ffc64ceec23bd8d7cb7) | `haskellPackages.hspec-wai-json: unbreak`                                    |
| [`4cd2df0a`](https://github.com/NixOS/nixpkgs/commit/4cd2df0a47f54ffefcc3e95557783ad2d7b716a2) | `haskellPackages.hasql-dynamic-statements: skip db dependent tests`          |
| [`85dfc90f`](https://github.com/NixOS/nixpkgs/commit/85dfc90f5ab26de13ae4f80456f4b3ecd2c57bb1) | `haskellPackages: collect hasql test overrides in one place`                 |
| [`a3748c82`](https://github.com/NixOS/nixpkgs/commit/a3748c82fd663e067c5509568d40d06f8d83cb50) | `haskellPackages: mark builds failing on hydra as broken`                    |
| [`8b4718e7`](https://github.com/NixOS/nixpkgs/commit/8b4718e7365e7a912e604d0342c2a6363bab7036) | `zig_0_8_1: remove`                                                          |
| [`05285cab`](https://github.com/NixOS/nixpkgs/commit/05285cab55df12e71edd5b41c7b5991d420e07c5) | `zls: unstable-2021-06-06 -> 0.9.0`                                          |
| [`5f87d1e5`](https://github.com/NixOS/nixpkgs/commit/5f87d1e5bdf6be1986e822a57e89a72d77f1fac3) | `python310Packages.google-cloud-runtimeconfig: 0.33.1 -> 0.33.2`             |
| [`5646dd47`](https://github.com/NixOS/nixpkgs/commit/5646dd4747382efa56a3d84328da1eb956e23a06) | `python310Packages.google-cloud-logging: 3.1.2 -> 3.2.0`                     |
| [`011e5efc`](https://github.com/NixOS/nixpkgs/commit/011e5efc598156d76c770dcd2f8abc431a3a68c6) | `python310Packages.yolink-api: 0.0.8 -> 0.0.9`                               |
| [`133476a8`](https://github.com/NixOS/nixpkgs/commit/133476a8d5818f40267349716a10d573f5c7d3aa) | `zafiro-icons: 1.2 -> 1.3 (#181014)`                                         |
| [`5f2c50c7`](https://github.com/NixOS/nixpkgs/commit/5f2c50c7df5e5c8eef6c323e719aa9b4f94b2c63) | `python310Packages.google-cloud-iot: 2.5.1 -> 2.6.0`                         |
| [`34edeadd`](https://github.com/NixOS/nixpkgs/commit/34edeaddec3f98d945fbbbbf9df97d077ee2bc0d) | `python310Packages.pytraccar: 0.10.0 -> 0.10.1`                              |
| [`d75b12e2`](https://github.com/NixOS/nixpkgs/commit/d75b12e2c47c6ad00455739b36787e32442297f8) | `python310Packages.angr: 9.2.9 -> 9.2.10`                                    |
| [`9b89244b`](https://github.com/NixOS/nixpkgs/commit/9b89244b24b8c3ae29b7529d8c0863e0379d4ae3) | `python310Packages.cle: 9.2.9 -> 9.2.10`                                     |
| [`bfa99e47`](https://github.com/NixOS/nixpkgs/commit/bfa99e4705f3764fb8b9572a8eff94503bf70f80) | `python310Packages.claripy: 9.2.9 -> 9.2.10`                                 |
| [`7fac31ca`](https://github.com/NixOS/nixpkgs/commit/7fac31ca95ce8bca3c5f945a5833e7a8d86ee9ee) | `python310Packages.pyvex: 9.2.9 -> 9.2.10`                                   |
| [`d136a481`](https://github.com/NixOS/nixpkgs/commit/d136a4817fc6b72c66e260802c807dcdd07fc8d2) | `python310Packages.ailment: 9.2.9 -> 9.2.10`                                 |
| [`b110339b`](https://github.com/NixOS/nixpkgs/commit/b110339bdf776535271783030ee3c4dc9bd11a9a) | `python310Packages.archinfo: 9.2.9 -> 9.2.10`                                |
| [`c2fa5569`](https://github.com/NixOS/nixpkgs/commit/c2fa5569a0a575e9ac3f8551f20bbcc6e9eb18be) | `zen-kernels: add pedrohlc as maintainer`                                    |
| [`c1f94c40`](https://github.com/NixOS/nixpkgs/commit/c1f94c40dfa3efcf7568f5c24c36c005260d1b38) | `linux_lqx: 5.18.10-lqx1 -> 5.18.11-lqx1`                                    |
| [`2c994cf1`](https://github.com/NixOS/nixpkgs/commit/2c994cf1c73698ea343d74b8eb1fe1b25a2ceb1f) | `linux_zen: 5.18.10-zen1 -> 5.18.11-zen1`                                    |
| [`7373f4ac`](https://github.com/NixOS/nixpkgs/commit/7373f4ac1613e839448b3ef90337ecb33d3b4f21) | `python310Packages.homematicip: 1.0.3 -> 1.0.4`                              |
| [`45c4f3b4`](https://github.com/NixOS/nixpkgs/commit/45c4f3b422498a081631ab715c937e720d9bd705) | `python310Packages.yfinance: 0.1.72 -> 0.1.74`                               |
| [`03a9bec4`](https://github.com/NixOS/nixpkgs/commit/03a9bec472bd9a180288305c446da1fc2636e38e) | `python310Packages.aeppl: 0.0.31 -> 0.0.33`                                  |
| [`7e30ebb2`](https://github.com/NixOS/nixpkgs/commit/7e30ebb2c2b90dc866643c6409e1424f7e651baa) | `nixos/lxqt: add a module for the lxqt portal`                               |