### PR TITLE
chore(flake/nixpkgs): `4a01ca36` -> `8f485713`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657802959,
-        "narHash": "sha256-9+JWARSdlL8KiH3ymnKDXltE1vM+/WEJ78F5B1kjXys=",
+        "lastModified": 1658015103,
+        "narHash": "sha256-mO+23f3SO+fBzEvbxRe6GkSB5Xp43CT2sV8Rs8MYdz8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4a01ca36d6bfc133bc617e661916a81327c9bbc8",
+        "rev": "8f485713f5e6b6883a9b6959afa98688360a3ecb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                    |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`099062bd`](https://github.com/NixOS/nixpkgs/commit/099062bd368098303e3eebcb6d90bfc38c92372e) | `rocksdb: 6.29.3 -> 7.3.1 (#179399)`                              |
| [`5e941caa`](https://github.com/NixOS/nixpkgs/commit/5e941caa0d75b2488efe5880b1b0093b7e1ec3bc) | `nixos/cri-o: removed defaultText of internal package-option`     |
| [`f3cfdc2f`](https://github.com/NixOS/nixpkgs/commit/f3cfdc2f310303e78fc208ef94713f672b2f42dd) | `jack-autoconnect: init at unstable-2021-02-01 (#181678)`         |
| [`7a5b3262`](https://github.com/NixOS/nixpkgs/commit/7a5b32624216b9b6e752386b45e6abce5258be8c) | `check_smartmon: init at 1.0.1`                                   |
| [`fa3d1dc9`](https://github.com/NixOS/nixpkgs/commit/fa3d1dc94bf690b41ec12f12d56d87ee4bc90adc) | `libgit2: enable static build`                                    |
| [`4164bb14`](https://github.com/NixOS/nixpkgs/commit/4164bb146e1f993b77a6dc51b9c91766160da142) | `python310Packages.trfl: init at 0.1.2`                           |
| [`b306581d`](https://github.com/NixOS/nixpkgs/commit/b306581d1056dd3f0b4afb9c79783c75170cf28d) | `python310Packages.distrax: init at 0.1.2`                        |
| [`f22a2437`](https://github.com/NixOS/nixpkgs/commit/f22a2437f3d401a207456fa731665f1cade9a121) | `python310Packages.rlax: init at 0.1.2`                           |
| [`197c12d4`](https://github.com/NixOS/nixpkgs/commit/197c12d4da453fbe9d650000f9e36cf224a41790) | `python310Packages.apache-beam: 2.37.0 -> 2.40.0`                 |
| [`e4983ba5`](https://github.com/NixOS/nixpkgs/commit/e4983ba583b370ce944904efe5183b451d4092bc) | `python310Packages.dm-sonnet: init at 2.0.0`                      |
| [`6d2e664e`](https://github.com/NixOS/nixpkgs/commit/6d2e664e8fbd1783c2fedaa2c717c91fa6dd5333) | `python310Packages.plotnine: init at 0.9.0`                       |
| [`80756c01`](https://github.com/NixOS/nixpkgs/commit/80756c01c661ac1a0421fadde673e39632708652) | `python310Packages.dm-env: init at 1.5`                           |
| [`c693205c`](https://github.com/NixOS/nixpkgs/commit/c693205c03fcc9c99e4957b835b731457374789e) | `python310Packages.bsuite: init at 0.3.5`                         |
| [`3c7534f2`](https://github.com/NixOS/nixpkgs/commit/3c7534f21a33a1bde44cefd6721c2124fbe9b39c) | `python310Packages.dm-haiku: 0.0.6 -> 0.0.7`                      |
| [`1b0ff5bb`](https://github.com/NixOS/nixpkgs/commit/1b0ff5bba2d2cf8eb8f9860ecd938c7c3f93a9d1) | `python310Packages.pytest-unordered: init at 0.4.1`               |
| [`63232692`](https://github.com/NixOS/nixpkgs/commit/6323269208f036bc6c4140fc72251f8505bf8073) | `baserow: init at 1.10.1`                                         |
| [`5d15ee68`](https://github.com/NixOS/nixpkgs/commit/5d15ee68642c0eec8b7b5002eb67faf9c7a2aa45) | `python310Packages.pyinstrument: init at 4.1.1`                   |
| [`9621dbfb`](https://github.com/NixOS/nixpkgs/commit/9621dbfbd083588cc9da02d02c3d9cf1d12ff1f7) | `python310Packages.django-timezone-field: 4.2.3 -> 5.0`           |
| [`14d6f394`](https://github.com/NixOS/nixpkgs/commit/14d6f394fd53ea389189934c10d41aefc6128675) | `python310Packages.django-celery-beat: init at 2.3.0`             |
| [`b5ddb31b`](https://github.com/NixOS/nixpkgs/commit/b5ddb31b520ccb899e687704a4e27760a8eb1eb6) | `python310Packages.django-health-check: init at 3.16.5`           |
| [`67258a89`](https://github.com/NixOS/nixpkgs/commit/67258a89dd8e92d124ee57924074cfedff143be5) | `python310Packages.celery-redbeat: init at 2.0.0`                 |
| [`4e7b10b2`](https://github.com/NixOS/nixpkgs/commit/4e7b10b2668690f02a693ae82676c2cafb977445) | `python310Packages.django-celery-email: init at 3.0.0`            |
| [`a8b27f7f`](https://github.com/NixOS/nixpkgs/commit/a8b27f7fd36d24d79913bf8c08933829ee426e29) | `boron: init at 2.0.8`                                            |
| [`93ccde43`](https://github.com/NixOS/nixpkgs/commit/93ccde433cf16f5cbcbde9b715a98723bdfd095d) | `python310Packages.google-cloud-pubsub: 2.13.3 -> 2.13.4`         |
| [`6f195dc9`](https://github.com/NixOS/nixpkgs/commit/6f195dc999a7477ab810503f4023e24994a10808) | `elpa-packages manual fixup`                                      |
| [`2ec06514`](https://github.com/NixOS/nixpkgs/commit/2ec065149d2ca08d76b60f6b7a5e3e0b97bdc116) | `elpa-packages 2022-07-16`                                        |
| [`0c0bb0bb`](https://github.com/NixOS/nixpkgs/commit/0c0bb0bb79162cf4b9b162d0885e4e030d1816f2) | `melpa-packages 2022-07-16`                                       |
| [`dac7c5b3`](https://github.com/NixOS/nixpkgs/commit/dac7c5b38def6355576d5a7ec7b4aaababa4d95b) | `nongnu-packages 2022-07-15`                                      |
| [`43c06b91`](https://github.com/NixOS/nixpkgs/commit/43c06b91b3c7803caf45f65e54dabc641d85b9cb) | `nyxt: disable webkit sandbox to workaround crash`                |
| [`c196a813`](https://github.com/NixOS/nixpkgs/commit/c196a8136a6f00c64c0e093b2115ee3f01d0842f) | `nyxt: 2.2.3 -> 2.2.4`                                            |
| [`65cbf4ba`](https://github.com/NixOS/nixpkgs/commit/65cbf4ba1b4627627c4838412df2772fddee060a) | `kubectl-node-shell: add jocelynthode as maintainer`              |
| [`a1ef6fff`](https://github.com/NixOS/nixpkgs/commit/a1ef6fff999ded36d860cb95312c044c4cbbde70) | `python310Packages.pydantic: fix build on darwin`                 |
| [`bfae31c8`](https://github.com/NixOS/nixpkgs/commit/bfae31c89d4e2d46c0addcda97d242d79609435c) | `erlang: 25.0.2 -> 25.0.3`                                        |
| [`e6349895`](https://github.com/NixOS/nixpkgs/commit/e6349895cf8bd410b78e4c4a4a8f77e5fc184976) | `erlang: 25.0 -> 25.0.2`                                          |
| [`6d7bfc94`](https://github.com/NixOS/nixpkgs/commit/6d7bfc948c941074801935fd259c9beb3a13bdbe) | `python310Packages.pydantic: fix using lib.optionalString`        |
| [`d4a98a76`](https://github.com/NixOS/nixpkgs/commit/d4a98a7649599992df9c0186da6dfc0f024483d0) | `check-zfs: init at 2.0`                                          |
| [`d65010ea`](https://github.com/NixOS/nixpkgs/commit/d65010ea48a18b4a02a2d1ac6255e3cb0f8a0a6c) | `python310Packages.panflute: 2.1.5 -> 2.2.3`                      |
| [`ff2e597e`](https://github.com/NixOS/nixpkgs/commit/ff2e597e9a553d2cffdfe56bed8a1368efbc2a8a) | `zen-kernels: retire myself as a maintainer`                      |
| [`9a5f8de3`](https://github.com/NixOS/nixpkgs/commit/9a5f8de353f5a0cc5e04238ce1d03c6c06570b05) | `bindfs: 1.16.1 -> 1.17.0 (#181305)`                              |
| [`6c36b381`](https://github.com/NixOS/nixpkgs/commit/6c36b381db7cd68c20d671f4c3b04679d3167fb4) | `zen-kernels: 5.18.11 -> 5.18.12`                                 |
| [`24576499`](https://github.com/NixOS/nixpkgs/commit/245764990f8c15ddef7757bf6c1159b1ccb2c5a9) | `tor-browser-bundle-bin: 11.0.15 -> 11.5`                         |
| [`f5625fbe`](https://github.com/NixOS/nixpkgs/commit/f5625fbe4a6cd46f80454cee09f5dca3c6022ae5) | `grails: 5.1.6 -> 5.1.7`                                          |
| [`69710e00`](https://github.com/NixOS/nixpkgs/commit/69710e00e27464f68fd121aaed0846d60cbf29fe) | `mattermost: 7.1.0 -> 7.1.1`                                      |
| [`d6df226c`](https://github.com/NixOS/nixpkgs/commit/d6df226c53d46821bd4773bd7ec3375f30238edb) | `fpart: 1.4.0 -> 1.5.1`                                           |
| [`67b02d98`](https://github.com/NixOS/nixpkgs/commit/67b02d983e09ef2d5f0984d6ad60e54faf976429) | `python310Packages.pyodbc: 4.0.32 -> 4.0.34`                      |
| [`f2dba019`](https://github.com/NixOS/nixpkgs/commit/f2dba019c6617db6299b2f3138e19344daf730fd) | `coqPackages.gaia: 1.13 → 1.14`                                   |
| [`8d7b235c`](https://github.com/NixOS/nixpkgs/commit/8d7b235ce69d3aeff9102f7d4498bfb64ab8fa8a) | `python310Packages.python-keystoneclient: 4.5.0 -> 5.0.0`         |
| [`191beef2`](https://github.com/NixOS/nixpkgs/commit/191beef260756f16ce6d6160cd7ab7bc90f8280a) | `linux-rt_5_10: 5.10.120-rt70 -> 5.10.131-rt72`                   |
| [`00ec9cf1`](https://github.com/NixOS/nixpkgs/commit/00ec9cf1128d2e7859063e44aec5b21c38ea05cd) | `linux: 5.4.205 -> 5.4.206`                                       |
| [`70ce5e51`](https://github.com/NixOS/nixpkgs/commit/70ce5e51c7436061bbfe9170092acb086a1ed3cb) | `linux: 5.18.11 -> 5.18.12`                                       |
| [`aa6f3618`](https://github.com/NixOS/nixpkgs/commit/aa6f361841b4f65855fa316ca8f4a77c5036e769) | `linux: 5.15.54 -> 5.15.55`                                       |
| [`d6f05776`](https://github.com/NixOS/nixpkgs/commit/d6f057760ac0d10b365a78750ee8df03eccfbfaf) | `linux: 5.10.130 -> 5.10.131`                                     |
| [`3a4ea089`](https://github.com/NixOS/nixpkgs/commit/3a4ea08942255b92cbef5800efed748e2c5c80e3) | `imagemagick: 7.1.0-39 -> 7.1.0.43`                               |
| [`dbb17b39`](https://github.com/NixOS/nixpkgs/commit/dbb17b39ba62667ceb050f9a0a08c607f39aea58) | `nixos/tests/jenkins: improve jenkins-job-builder subtest`        |
| [`50eaf82b`](https://github.com/NixOS/nixpkgs/commit/50eaf82b6f848d2411552c043bd51d0debfefab4) | `nixos/jenkins-job-builder: fix jenkins authentication`           |
| [`f30ad2ff`](https://github.com/NixOS/nixpkgs/commit/f30ad2ff33949fd8a9042643a9d34fb1128ccd4d) | `python310Packages.python-benedict: 0.25.1 -> 0.25.2`             |
| [`dbd75e32`](https://github.com/NixOS/nixpkgs/commit/dbd75e3229ba71210e60b32f36958fdbc4f50f3b) | `doc: update cmake doc for better readability`                    |
| [`690024c7`](https://github.com/NixOS/nixpkgs/commit/690024c78cca0aba501f7676f8f810df1d92ce3e) | `python310Packages.peaqevcore: 3.1.6 -> 3.2.0`                    |
| [`7e7aa63d`](https://github.com/NixOS/nixpkgs/commit/7e7aa63d3b8714488d15e12f08c297a28b2f4158) | `crosvm: enable debug info`                                       |
| [`c4897824`](https://github.com/NixOS/nixpkgs/commit/c4897824b4d870b8b6ce2250b4c33d12a2a70e3e) | `wine{Unstable,Staging}: 7.12 -> 7.13`                            |
| [`026ab5c8`](https://github.com/NixOS/nixpkgs/commit/026ab5c82d7e6c6e4db09965d928b4df1bc245e5) | `gammu: 1.40.0 -> 1.42.0`                                         |
| [`9e89778c`](https://github.com/NixOS/nixpkgs/commit/9e89778c774b1186692d4db39c364ec79389ea6d) | `python310Packages.fastcore: 1.5.0 -> 1.5.5`                      |
| [`26de13a4`](https://github.com/NixOS/nixpkgs/commit/26de13a45c5b70b3958b7d1b62b69c0a62b7f7b5) | ``cpm: add missing `runHook` for `installPhase```                 |
| [`e1a25434`](https://github.com/NixOS/nixpkgs/commit/e1a2543485913e923abb696e1a91e0e8aa434072) | `python310Packages.python-ironicclient: 4.11.0 -> 5.0.0`          |
| [`5b1cecd9`](https://github.com/NixOS/nixpkgs/commit/5b1cecd9dc59abc526419826cbf34cb7fe82d28a) | `python310Packages.nexia: 2.0.1 -> 2.0.2`                         |
| [`46a8c616`](https://github.com/NixOS/nixpkgs/commit/46a8c61603b2f82a85c8e213747ef9dbbdc923bb) | `python310Packages.pytest-test-utils: 0.0.7 -> 0.0.8`             |
| [`d6673a51`](https://github.com/NixOS/nixpkgs/commit/d6673a51bc974753373714c15a9a8f5c191e1336) | `python3Packages.nextcord: fix issue with loading libopus`        |
| [`dc7cb428`](https://github.com/NixOS/nixpkgs/commit/dc7cb428fdde68c68eb906ac47a97635fd982d7e) | `libmaxminddb.meta.maintainers: add ajs124`                       |
| [`9fa82868`](https://github.com/NixOS/nixpkgs/commit/9fa828687a3168e22646f2d03d432d141255bf38) | `traefik: 2.7.2 -> 2.8.1`                                         |
| [`703266a8`](https://github.com/NixOS/nixpkgs/commit/703266a81686195394fec7b3f05445ef3c0207bf) | `terraform-providers: update 2022-07-16`                          |
| [`b775740b`](https://github.com/NixOS/nixpkgs/commit/b775740ba263bd9a8eb5137b5edc1b92a24770af) | `inkscape: 1.2 → 1.2.1`                                           |
| [`93e08139`](https://github.com/NixOS/nixpkgs/commit/93e0813942738dcf331f0c505069b12add2be0ba) | `lndmanage: 0.14.1 -> 0.14.2`                                     |
| [`036b52f8`](https://github.com/NixOS/nixpkgs/commit/036b52f824eb2aa8013860eddc7cdc31d2fd680d) | `maintainers: add aiotter`                                        |
| [`98ee1029`](https://github.com/NixOS/nixpkgs/commit/98ee102955153fa7e5c222a5a2c7d7cb946644a0) | `zig: build for darwin`                                           |
| [`1aed9441`](https://github.com/NixOS/nixpkgs/commit/1aed94416a43f72eda6d70202749485cdf545c1b) | `python310Packages.vowpalwabbit: 9.0.1 -> 9.2.0`                  |
| [`02572b04`](https://github.com/NixOS/nixpkgs/commit/02572b048e0519d815b3badc06aca5320643070e) | ``grype: build on `x86_64-darwin```                               |
| [`99da6a84`](https://github.com/NixOS/nixpkgs/commit/99da6a84e316a3b6e49ec407eeb30c613e43adab) | ``gitsign: build on `x86_64-darwin```                             |
| [`c1d1aebd`](https://github.com/NixOS/nixpkgs/commit/c1d1aebda48467ce55d8d40f45e1fda75401dbc4) | ``dsq: build on `x86_64-darwin```                                 |
| [`f66faf95`](https://github.com/NixOS/nixpkgs/commit/f66faf954cb4a58c9fe575af939b44ce89b19fcf) | ``trivy: build on `x86_64-darwin```                               |
| [`5ebea633`](https://github.com/NixOS/nixpkgs/commit/5ebea6334f34ab50dbc1e19b044342da5cd1b118) | ``syft: build on `x86_64-darwin```                                |
| [`f7741bf9`](https://github.com/NixOS/nixpkgs/commit/f7741bf93c5e2490b2e88a7c170e954429c99639) | ``tilt: build on `x86_64-darwin```                                |
| [`1182fa23`](https://github.com/NixOS/nixpkgs/commit/1182fa23393491aed975d789e46de17321d772a4) | `cppcheck: 2.8.1 -> 2.8.2`                                        |
| [`57a0185e`](https://github.com/NixOS/nixpkgs/commit/57a0185e88dafb00cbf993459433de221c735540) | `python310Packages.jarowinkler: 1.1.1 -> 1.1.2`                   |
| [`736f280e`](https://github.com/NixOS/nixpkgs/commit/736f280e372407e0a38177da2693a0b124753d6a) | `rustup: 1.24.3 -> 1.25.1`                                        |
| [`c69996ef`](https://github.com/NixOS/nixpkgs/commit/c69996ef5726642af17af58fdfaa2e19a5b7eb38) | `boringtun: 0.5.0 -> 0.5.1`                                       |
| [`0281c65c`](https://github.com/NixOS/nixpkgs/commit/0281c65cafb8c8d4630a1c89826e1809880d02cb) | `python310Packages.zigpy: 0.47.2 -> 0.47.3`                       |
| [`2b72b2d2`](https://github.com/NixOS/nixpkgs/commit/2b72b2d26187558f4a74497b7f572a84f3247aca) | ``golangci-lint: build on `x86_64-darwin```                       |
| [`ed548c26`](https://github.com/NixOS/nixpkgs/commit/ed548c26d2358de47e01d2583804cdfc5f23124e) | ``hugo: build on `x86_64-darwin```                                |
| [`eb4056ba`](https://github.com/NixOS/nixpkgs/commit/eb4056baf9fc90507b3953a8834269b07707a1e5) | ``talosctl: build on `x86_64-darwin```                            |
| [`cb766051`](https://github.com/NixOS/nixpkgs/commit/cb766051ee06a0944e6bde2ad375908f07f9493d) | ``podman: build on `x86_64-darwin```                              |
| [`270fe36b`](https://github.com/NixOS/nixpkgs/commit/270fe36bd8f64a1cac625ef6aac3d2bcb25ef2f9) | `gallery-dl: 1.22.3 -> 1.22.4`                                    |
| [`3ea3f3b5`](https://github.com/NixOS/nixpkgs/commit/3ea3f3b5571d03404f18bfe9e13c77f43a155add) | `python310Packages.openstacksdk: 0.99.0 -> 0.100.0`               |
| [`777ce154`](https://github.com/NixOS/nixpkgs/commit/777ce154a684c341572a8308e27440fb6ff780f1) | `python310Packages.python-cinderclient: 8.3.0 -> 9.0.0`           |
| [`2f6b104a`](https://github.com/NixOS/nixpkgs/commit/2f6b104a39433f043a315554414f3c4aec6ff51c) | `diffoscope: 218 -> 219`                                          |
| [`4fddc3c9`](https://github.com/NixOS/nixpkgs/commit/4fddc3c9ea6431805374e36ccb7b5e9d1eae2094) | `python310Packages.nbdime: fix build on darwin`                   |
| [`dd218acc`](https://github.com/NixOS/nixpkgs/commit/dd218acc6680dc26d526dd1a84868010001c1294) | `python310Packages.nbdime: refactor derivation`                   |
| [`9f80c748`](https://github.com/NixOS/nixpkgs/commit/9f80c7486b81c874994e4300fb4d6b29ab4f4a71) | `jellyfin-media-player: add optional dbus dependency`             |
| [`6a455d00`](https://github.com/NixOS/nixpkgs/commit/6a455d0082f505bab5d5ee779a1a84925f1a52c3) | `python310Packages.pyunifiprotect: 4.0.9 -> 4.0.11`               |
| [`5dba1015`](https://github.com/NixOS/nixpkgs/commit/5dba1015171c072893b31d99bf0ba25c4bbb1d7e) | `mdbook: add nix to passthru.tests`                               |
| [`e050f614`](https://github.com/NixOS/nixpkgs/commit/e050f61496a9f0fd3a3a994acfb122ad66547f5b) | ``maintainers: remove `longkeyid```                               |
| [`29f863f3`](https://github.com/NixOS/nixpkgs/commit/29f863f3fca683e6e81df2f0fa41b5065c720f8d) | `python310Packages.spacy-loggers: 1.0.2 -> 1.0.3`                 |
| [`877edc57`](https://github.com/NixOS/nixpkgs/commit/877edc57d56809cbcfce293482abb39a375eee54) | `jflap: refactoring, add xdg desktop item (#173905)`              |
| [`0d1222ad`](https://github.com/NixOS/nixpkgs/commit/0d1222ad692c33409e4948248cafdb5fde6ddd0e) | `trino-cli: 387 -> 390`                                           |
| [`7d85a182`](https://github.com/NixOS/nixpkgs/commit/7d85a1821ee668bfb0cf43ad542ce80dfd97f36d) | `maintainers: add mariaa144`                                      |
| [`bd2d654f`](https://github.com/NixOS/nixpkgs/commit/bd2d654f81f2defb78751c0fbeae6a561795a832) | `treewide: add a comment explaining to buildGo117Module override` |
| [`4ddd633b`](https://github.com/NixOS/nixpkgs/commit/4ddd633b5abce21f381245f8f78c8f350df1bc17) | `ncdns: mark broken`                                              |
| [`e371e8b9`](https://github.com/NixOS/nixpkgs/commit/e371e8b9ea03217ec4159b4222e009de39db4863) | `kcli: pin to go 1.17`                                            |
| [`3bed988f`](https://github.com/NixOS/nixpkgs/commit/3bed988feffaaa20d54ebf9c16bb506e05f5eb2c) | `zrepl: pin to go 1.17`                                           |
| [`3ea65022`](https://github.com/NixOS/nixpkgs/commit/3ea65022ae657d74145b8f39fe14a7e33bf2e293) | `deepsea: pin to go 1.17`                                         |
| [`4982ae78`](https://github.com/NixOS/nixpkgs/commit/4982ae785af539455ae1e5e4e805531e7af67dc3) | `magnetico: pin to go 1.17`                                       |
| [`429b1064`](https://github.com/NixOS/nixpkgs/commit/429b10640639c1c8dec083ac35851e8bd0c9ba1a) | `kubectl-doctor: pin to go 1.17`                                  |