### PR TITLE
chore(flake/nixpkgs): `2e3f6efd` -> `e4d49de4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658103945,
-        "narHash": "sha256-1/kQlzKGt1563JZ+gIlNHU6rEbaDh2KopZLJ4CzraWI=",
+        "lastModified": 1658161305,
+        "narHash": "sha256-X/nhnMCa1Wx4YapsspyAs6QYz6T/85FofrI6NpdPDHg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2e3f6efdeda4cfff0259912495761885d8bee74a",
+        "rev": "e4d49de45a3b5dbcb881656b4e3986e666141ea9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                               |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`0005ee60`](https://github.com/NixOS/nixpkgs/commit/0005ee6060ba02bee022d06117a49d6ee0d9a7cd) | `josh: init at 22.06.22`                                                                     |
| [`c286a8f8`](https://github.com/NixOS/nixpkgs/commit/c286a8f8c25db8d31178a874886c892a2ecebad7) | `rt: 5.0.2 -> 5.0.3`                                                                         |
| [`55a28029`](https://github.com/NixOS/nixpkgs/commit/55a280290d9016d252edbf1055b9283d8a653b1e) | `sgtpuzzles: add tomfitzhenry@ as co-maintainer`                                             |
| [`59cc4254`](https://github.com/NixOS/nixpkgs/commit/59cc4254df4d727bf2048ee44bb68d4173c23aca) | `sgtpuzzles: Use higher resolution icons: 48x48 -> 96x96`                                    |
| [`61bf2a9c`](https://github.com/NixOS/nixpkgs/commit/61bf2a9c6879496ae9bbbe59c7c3b169728f1516) | `sgtpuzzles: 20200610.9aa7b7c -> 20220613.387d323`                                           |
| [`34aa48f5`](https://github.com/NixOS/nixpkgs/commit/34aa48f5784ab6fe748df1062e46a43683cd5082) | `sgtpuzzles: Fix Icon path.`                                                                 |
| [`b3b78ce3`](https://github.com/NixOS/nixpkgs/commit/b3b78ce3ef66e838dbbabfbdb5162b6a551b5a32) | `sgt-puzzles: update sgt-puzzles.menu to a working URL`                                      |
| [`d9a59b22`](https://github.com/NixOS/nixpkgs/commit/d9a59b22ee0a61cc59bd21d0a2f748fe3fd6af26) | `Group GIS applications`                                                                     |
| [`75fdfe76`](https://github.com/NixOS/nixpkgs/commit/75fdfe76cd4fb7ccf00647ba487bfe470cf23498) | `qgis-ltr: 3.22.8 → 3.22.9`                                                                  |
| [`83841f8b`](https://github.com/NixOS/nixpkgs/commit/83841f8bf7fe66931aff44d94f89f7a14aebdc6c) | `qgis: 3.26.0 → 3.26.1`                                                                      |
| [`949c334e`](https://github.com/NixOS/nixpkgs/commit/949c334ea9b9a506cb8644a356f64c30a92ef307) | `nixos/privacyidea-ldap-proxy: use list for EnvironmentFile for mergeability`                |
| [`c2c82fbe`](https://github.com/NixOS/nixpkgs/commit/c2c82fbe43c6f793b3e4999eaa5775b5f1c07508) | `nixos/mxisd: use a list for env file for mergeability`                                      |
| [`04b1ada5`](https://github.com/NixOS/nixpkgs/commit/04b1ada50ec096bfe0541428c1500895f8e6e8c9) | `etcd_3_4: 3.4.18 -> 3.4.19`                                                                 |
| [`dcb0d8e9`](https://github.com/NixOS/nixpkgs/commit/dcb0d8e968aa51643b3107d7f7bc0293a42df4bb) | `python310Packages.optax: 0.1.1 -> 0.1.3`                                                    |
| [`e9995a5a`](https://github.com/NixOS/nixpkgs/commit/e9995a5aded046f2a4440b68f06e0833fd8bb35c) | `rspamd: fix crashes by switching pcre2 -> pcre1`                                            |
| [`aaaedf2c`](https://github.com/NixOS/nixpkgs/commit/aaaedf2c7e1a402ca542c90c27988239e012089a) | `python310Packages.scikit-misc: init at 0.1.4`                                               |
| [`86631b44`](https://github.com/NixOS/nixpkgs/commit/86631b4428ca7ada142f6fab95a579827bd99251) | `python310Packages.plotnine: Add missing test dependencies`                                  |
| [`533140b7`](https://github.com/NixOS/nixpkgs/commit/533140b7bf12ffdcdb4deaf48db9d4469c9901e7) | `python310Packages.django-sampledatahelper: Drop package`                                    |
| [`c03fbc7d`](https://github.com/NixOS/nixpkgs/commit/c03fbc7db8099365a1c9034f5fa663b11954cdb0) | `p4est: fixed versioning (#180737)`                                                          |
| [`a170fbe7`](https://github.com/NixOS/nixpkgs/commit/a170fbe73a2d83532747ff3c79f36cc3a1567ac3) | `zls: set platforms`                                                                         |
| [`9eddb61d`](https://github.com/NixOS/nixpkgs/commit/9eddb61dcffc7602a1a88e858d695fad956af89d) | `ocaml-ng.ocamlPackages_4_14.ocaml-lsp: 1.11 -> 1.12`                                        |
| [`caa3cefe`](https://github.com/NixOS/nixpkgs/commit/caa3cefeb5082fe770c0e62984d52bc742810f79) | `ocamlPackages.chrome-trace: init at ${dune.version}`                                        |
| [`09e68b85`](https://github.com/NixOS/nixpkgs/commit/09e68b853589a194ad0e83bae457856c1ca954cc) | `fzf-obc: init at 1.3.0`                                                                     |
| [`622952b4`](https://github.com/NixOS/nixpkgs/commit/622952b45e2fd9c9c4e0f8420dede900fff7a933) | `purescript: 0.15.2 -> 0.15.4`                                                               |
| [`ae0b8a01`](https://github.com/NixOS/nixpkgs/commit/ae0b8a01b10a689d0d33e9024b8480069e5c854d) | `ocamlPackages.gapi-ocaml: 0.4.2 → 0.4.3`                                                    |
| [`950a258b`](https://github.com/NixOS/nixpkgs/commit/950a258b9ef24ca4346bbf722a694c2ab54e4654) | `protobuf3_21: init at 3.21.2`                                                               |
| [`436f9e14`](https://github.com/NixOS/nixpkgs/commit/436f9e14b11fbd46accc45dbf844524db3639cfe) | `protobuf3_20: init at 3.20.1`                                                               |
| [`5c38e6b3`](https://github.com/NixOS/nixpkgs/commit/5c38e6b3d27fa613087a2245e82f07ccd1f8c8a3) | `protobuf: add cmake generic builder`                                                        |
| [`2c184fc2`](https://github.com/NixOS/nixpkgs/commit/2c184fc2002a9765e4f4e6e86402b8cb550156c0) | `python3Packages.protobuf: allow for buildPackages.protobuf to be passed`                    |
| [`586a0b59`](https://github.com/NixOS/nixpkgs/commit/586a0b593b5848b2ba41b53be4cdd28edeb52c4d) | `prometheus-domain-exporter: 1.11.0 -> 1.17.1`                                               |
| [`dd927c3f`](https://github.com/NixOS/nixpkgs/commit/dd927c3f52aaaf73ee4d01958d85704d90c71dea) | `adcli: init at 0.9.1`                                                                       |
| [`618e446e`](https://github.com/NixOS/nixpkgs/commit/618e446ed1f49967e47306478ec9257742ec6b03) | `openbangla-keyboard: init at 2.0.0`                                                         |
| [`637c882d`](https://github.com/NixOS/nixpkgs/commit/637c882de775313fbc8df44cdbf2e8d90e9f8f5e) | `page: 3.1.0 -> 3.1.2`                                                                       |
| [`4f82bcc8`](https://github.com/NixOS/nixpkgs/commit/4f82bcc8225467540bba162db548f4d19ead1204) | `libuiohook: init at 1.2.2`                                                                  |
| [`28778e05`](https://github.com/NixOS/nixpkgs/commit/28778e05a0e00ec7f6a0efb80f988c197df86943) | `maintainers: add anoa`                                                                      |
| [`4396fd61`](https://github.com/NixOS/nixpkgs/commit/4396fd615c4c5061c690b03e0b278ff73bc509e2) | `nixos/systemd-boot: remove default log message if nothing changes`                          |
| [`bafaa05b`](https://github.com/NixOS/nixpkgs/commit/bafaa05bf1cdb00030b8f4303eb1f976cf728793) | `yuzu-{ea,mainline}: {2725,1088} -> {2841,1092}`                                             |
| [`fcd75613`](https://github.com/NixOS/nixpkgs/commit/fcd75613ea1f8ae73ad6c0f70b18197584a94e2e) | `opam2json: init at v0.2`                                                                    |
| [`4adf26f0`](https://github.com/NixOS/nixpkgs/commit/4adf26f01893ed98f9ebbc55cbf87cb1be57a54a) | `nixos/privacyidea-ldap-proxy: always run envsubst`                                          |
| [`765cc350`](https://github.com/NixOS/nixpkgs/commit/765cc35042d9153bc067e785a2eb90fb6ca3f8ff) | `nixos/atlassian-jira: allow to store SSO password for crowd outside of the Nix store`       |
| [`1be882bc`](https://github.com/NixOS/nixpkgs/commit/1be882bca94ac36e42f04a424f11376e3a5a66ee) | `yt-dlp: 2022.6.29 -> 2022.07.18`                                                            |
| [`077dc1f8`](https://github.com/NixOS/nixpkgs/commit/077dc1f8527909a2094524c8780b4d1a9dd4c732) | `electrum: 4.2.1 -> 4.2.2`                                                                   |
| [`ef73f1a1`](https://github.com/NixOS/nixpkgs/commit/ef73f1a15652fa33cd8478cab87fcdf0c889c21d) | `gtk-vnc: 1.3.0 -> 1.3.1`                                                                    |
| [`bccaac95`](https://github.com/NixOS/nixpkgs/commit/bccaac95357abafe114ee20a39a5d9c91253d5bc) | `nixos/privacyidea: better secret-handling ldap-proxy & RFC42-style settings for ldap-proxy` |
| [`d54d70f1`](https://github.com/NixOS/nixpkgs/commit/d54d70f16615992b8005e7bec4b0d77954a95346) | `nixos/mxisd: allow passing secrets`                                                         |
| [`02906974`](https://github.com/NixOS/nixpkgs/commit/02906974ec37d5a85bcdfe023f50b9a86ff9a391) | `polaris: fix Os error 24: 'Too many open files' in checkPhase`                              |
| [`fa748c2e`](https://github.com/NixOS/nixpkgs/commit/fa748c2e5d509a30b3c7fbcc1f21de7668250048) | `gajim: 1.4.3 → 1.4.6`                                                                       |
| [`b9854d66`](https://github.com/NixOS/nixpkgs/commit/b9854d669e0bf71c9874933544082da0d975eaed) | `nauty: 2.7r3 -> 2.7r4`                                                                      |
| [`55a53e1d`](https://github.com/NixOS/nixpkgs/commit/55a53e1dec01d618a5f448b6a774fc0a05d813a5) | `sage: apply eclib 20220621 update patch`                                                    |
| [`d7f5c978`](https://github.com/NixOS/nixpkgs/commit/d7f5c97885e46c91bd870a56b8b179ad25dd61df) | `eclib: 20210625 -> 20220621`                                                                |
| [`190a8c32`](https://github.com/NixOS/nixpkgs/commit/190a8c326c5c7ce8bc8d28d4909a2f5e86d49fda) | `sshs: init at 3.2.0`                                                                        |
| [`602e9830`](https://github.com/NixOS/nixpkgs/commit/602e9830e9a3b0f7f4cfacbc599d4714a9ac126a) | `maintainers: add ihatethefrench`                                                            |
| [`04eb893b`](https://github.com/NixOS/nixpkgs/commit/04eb893beb851563010cd3158fac617e5d2ff123) | `weechat: 3.5 -> 3.6`                                                                        |
| [`d09303b3`](https://github.com/NixOS/nixpkgs/commit/d09303b31d762378db24546fa862aead93241906) | `Update nixos/modules/services/misc/jellyfin.nix`                                            |
| [`2408ef3c`](https://github.com/NixOS/nixpkgs/commit/2408ef3c6faa0ba0d513257378563ddc886f1020) | `androidndk: remove legacy ndks`                                                             |
| [`539222e8`](https://github.com/NixOS/nixpkgs/commit/539222e8d4bafaf783814c747e0ace40affa3761) | `canExecute: check for android`                                                              |
| [`2a914f02`](https://github.com/NixOS/nixpkgs/commit/2a914f022c533d78a86a23d99fe72952af1be990) | `update android targets to recommended ones`                                                 |
| [`0aded46f`](https://github.com/NixOS/nixpkgs/commit/0aded46f0838502361356497fc37825a9c3f9410) | `androidenv: update packages`                                                                |
| [`5f1923d6`](https://github.com/NixOS/nixpkgs/commit/5f1923d67e1ecdc2176f017d7d2008aa1c908baf) | `androidenv: fix android cross-compilers`                                                    |
| [`4258952d`](https://github.com/NixOS/nixpkgs/commit/4258952dc69ea2b2063b53c584d2d285b9423abe) | `nixos/jellyfin: sync up with hardening provided in upstream`                                |
| [`16ad8ea5`](https://github.com/NixOS/nixpkgs/commit/16ad8ea53c95f9f9902a0c3a8c5d3968f9b88128) | `s/sourceTypes/source-types/`                                                                |
| [`360b3170`](https://github.com/NixOS/nixpkgs/commit/360b31707a08803bd54a44a078e95e4c539450c2) | `purescript: mark meta.sourceProvenance`                                                     |
| [`a1ba737c`](https://github.com/NixOS/nixpkgs/commit/a1ba737c5ee13938f9d4208b2c67073caed14a2b) | `folly: enable jemalloc`                                                                     |
| [`87f831c3`](https://github.com/NixOS/nixpkgs/commit/87f831c382113e79d3e1a62c15d8ba048347fd57) | `patool: remove unused compression utilities`                                                |
| [`d6dbe070`](https://github.com/NixOS/nixpkgs/commit/d6dbe0703566c8d6baa2246a6eb79a53365199c9) | `patool: fix the non-use of hard-coded binary`                                               |