### PR TITLE
chore(flake/nixpkgs): `a65b5b3f` -> `2d372784`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658380158,
-        "narHash": "sha256-DBunkegKWlxPZiOcw3/SNIFg93amkdGIy2g0y/jDpHg=",
+        "lastModified": 1658465217,
+        "narHash": "sha256-f2Zyt7TsDZ1TK3Cu6ZtzWoWQ4nnQq07uXTPxW26rIQY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a65b5b3f5504b8b89c196aba733bdf2b0bd13c16",
+        "rev": "2d372784634e224c5a629d80a19705af655fbc7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`2d372784`](https://github.com/NixOS/nixpkgs/commit/2d372784634e224c5a629d80a19705af655fbc7d) | `dart: 2.17.0 -> 2.17.3 (#177104)`                                                              |
| [`91f9185d`](https://github.com/NixOS/nixpkgs/commit/91f9185dfbd63a0f65cda3217f89e2c41e2195df) | `sshs: 3.2.0 -> 3.3.0`                                                                          |
| [`d99563cd`](https://github.com/NixOS/nixpkgs/commit/d99563cd78b5dee34bbe42f25817bfa974c7bd94) | `Add oil to packages before invoking shell,`                                                    |
| [`fa8de765`](https://github.com/NixOS/nixpkgs/commit/fa8de76521f2de93b6b4bf6e79b0c4a3d90e6d60) | `Revert "openldap: load client config from /etc, not the nix store"`                            |
| [`b4d18728`](https://github.com/NixOS/nixpkgs/commit/b4d18728854341c38783206bf3f881017843a5cc) | `maintainers/scripts/haskell/hydra-report: Add hint about eval errors`                          |
| [`8fc4df04`](https://github.com/NixOS/nixpkgs/commit/8fc4df0415a862c4636bb1e2b25c0efa056d5d1b) | `haskellPackages: mark builds failing on hydra as broken`                                       |
| [`b3d53dee`](https://github.com/NixOS/nixpkgs/commit/b3d53dee19d3d5f9afc376fa3ba6c618e07df604) | `xanmod-kernels: move kernelPatches to xanmodKernels`                                           |
| [`3b740fe8`](https://github.com/NixOS/nixpkgs/commit/3b740fe8ab3871b5ca7441d66ff3145c60283fa7) | `python310Packages.structlog: 21.5.0 -> 22.1.0`                                                 |
| [`40e28a7d`](https://github.com/NixOS/nixpkgs/commit/40e28a7df44c87735cc59e599caf2b8b740ced5d) | `vault: 1.11.0 -> 1.11.1`                                                                       |
| [`a79ea27f`](https://github.com/NixOS/nixpkgs/commit/a79ea27f16b71853587a311ca4bf57bac5672f03) | `taler-exchange: 0.8.1 -> unstable-2022-07-17 and taler-merchant: 0.8.0 -> unstable-2022-07-11` |
| [`9459bcdc`](https://github.com/NixOS/nixpkgs/commit/9459bcdc130624ded13aabdcfcfe883b44d8f900) | `linux_xanmod_tt: init at 5.15.54`                                                              |
| [`d726818c`](https://github.com/NixOS/nixpkgs/commit/d726818c37f747124097311e72cf794f5a802dfe) | `xanmod-kernels: set suffix to a default value`                                                 |
| [`b0cfccd5`](https://github.com/NixOS/nixpkgs/commit/b0cfccd50a089f86999da9a4773561d5ca73ec55) | `linux_xanmod_latest: 5.18.10 -> 5.18.11`                                                       |
| [`ac93fd31`](https://github.com/NixOS/nixpkgs/commit/ac93fd31770aff659dd78e0db55835d026a9d67a) | `linux_xanmod: 5.15.53 -> 5.15.54`                                                              |
| [`e5d17fcc`](https://github.com/NixOS/nixpkgs/commit/e5d17fcc91cb7c6b110174027eb2234c7a6a8269) | `xanmod-kernels: remove explicit WERROR=n`                                                      |
| [`9d0769d4`](https://github.com/NixOS/nixpkgs/commit/9d0769d4e7ca42bc64da6cc8c1b7454977b02df8) | `linux_xanmod: rename stable to lts`                                                            |
| [`e2b34f0f`](https://github.com/NixOS/nixpkgs/commit/e2b34f0f11ed8ad83d9ec9c14260192c3bcccb0d) | `nixos/minecraft-server: let server shutdown cleanly (#182149)`                                 |
| [`d4ca6ff3`](https://github.com/NixOS/nixpkgs/commit/d4ca6ff3f4250e322da1f4397bea6d1567725b9e) | `linuxPackages.rtl88x2bu: unstable-2022-02-22 -> unstable-2022-05-23`                           |
| [`b273c33c`](https://github.com/NixOS/nixpkgs/commit/b273c33cb2dff3f3aa1f757be7b8f60f060dcedd) | `crosvm.updateScript: update repo URL`                                                          |
| [`c83e38c4`](https://github.com/NixOS/nixpkgs/commit/c83e38c40d80dea676bf9e0eedd550b0f6b6851a) | `crosvm: 100.14526.0.0-rc1 -> 103.3`                                                            |
| [`c01c68bf`](https://github.com/NixOS/nixpkgs/commit/c01c68bf1c2d08503ef5975da931ba9ca05a4b48) | `crosvm.updateScript: stop trying manifest-versions`                                            |
| [`acdfec90`](https://github.com/NixOS/nixpkgs/commit/acdfec904d141744461a8afe93c20caa89e4fd26) | `crosvm.updateScript: update for new serving dash`                                              |
| [`931ae3ee`](https://github.com/NixOS/nixpkgs/commit/931ae3ee7b329a70408f65cece61cbfcff1caca2) | `crosvm.updateScript: check for . in buildspec name`                                            |
| [`11ffcf0f`](https://github.com/NixOS/nixpkgs/commit/11ffcf0fdf25afe8c177e788994c19c4271251bb) | `crosvm.updateScript: remove unused import`                                                     |
| [`2646dae1`](https://github.com/NixOS/nixpkgs/commit/2646dae16ea56f9dfadfe11cc482de2219d3c7e0) | `lean: 3.44.1 -> 3.45.0`                                                                        |
| [`34e76196`](https://github.com/NixOS/nixpkgs/commit/34e761962bae1c8d642443078bc888b73b1e5dce) | `cxx-rs: init at 1.0.72`                                                                        |
| [`b394165a`](https://github.com/NixOS/nixpkgs/commit/b394165a8adf8e40875281194f69fcc7021cd560) | `lean: 3.44.0 -> 3.44.1`                                                                        |
| [`f1fe61ba`](https://github.com/NixOS/nixpkgs/commit/f1fe61ba70513f2ec6ff46773d11538c750fc517) | `lean: 3.43.0 -> 3.44.0`                                                                        |
| [`7a5b52ff`](https://github.com/NixOS/nixpkgs/commit/7a5b52ff2616b13ecbe692839aabc2ff9031dad5) | `snakemake: 7.8.5 -> 7.9.0`                                                                     |
| [`5ae65804`](https://github.com/NixOS/nixpkgs/commit/5ae6580474d0c0eba6441ca554d5a81e120a73a4) | `add hub mode comment`                                                                          |
| [`df52d556`](https://github.com/NixOS/nixpkgs/commit/df52d556bba6ff989a6d91e180053512ba5be417) | `wip: add vlan-ping test`                                                                       |
| [`539b61ea`](https://github.com/NixOS/nixpkgs/commit/539b61ea378cbdf0e99fc5467312714e4fd05cc3) | `nixos/github-runner: fix capset syscall filtering`                                             |
| [`20ada9a6`](https://github.com/NixOS/nixpkgs/commit/20ada9a6c75ab9a904a0629d3900d43af06722f5) | `nss_latest: 3.80 -> 3.81`                                                                      |
| [`d0f3691a`](https://github.com/NixOS/nixpkgs/commit/d0f3691ae1230261ab064a3a5024a60031a723c1) | `obs-vkcapture: 1.1.3 -> 1.1.4`                                                                 |
| [`66686641`](https://github.com/NixOS/nixpkgs/commit/6668664128cb355098b2f1e3d6354724b1f28a30) | `tmuxinator: 3.0.1 -> 3.0.5`                                                                    |
| [`43928998`](https://github.com/NixOS/nixpkgs/commit/4392899832862e716d2f681d256168f937a7e54d) | `cargo-nextest: 0.9.24 -> 0.9.26 (#182284)`                                                     |
| [`a174de16`](https://github.com/NixOS/nixpkgs/commit/a174de16edfc6aa0893530b9a95d0bd0c2a952b7) | `hedgedoc: 1.9.0 -> 1.9.4 (#178129)`                                                            |
| [`f6a29093`](https://github.com/NixOS/nixpkgs/commit/f6a290932e773b7412978f29fc50c6a8f3dce222) | `use vde switch in hubmode by default`                                                          |
| [`0536bedc`](https://github.com/NixOS/nixpkgs/commit/0536bedcc9689007f00a52533b429adc5e19e6c9) | `python310Packages.angr: 9.2.10 -> 9.2.11`                                                      |
| [`90387e03`](https://github.com/NixOS/nixpkgs/commit/90387e03cd8b8972ed39cb821fc4cb9ce363b18c) | `python310Packages.cle: 9.2.10 -> 9.2.11`                                                       |
| [`ed146875`](https://github.com/NixOS/nixpkgs/commit/ed146875b635c9477d1f7dcfea3f8d65c1507e3e) | `python310Packages.claripy: 9.2.10 -> 9.2.11`                                                   |
| [`6e13df71`](https://github.com/NixOS/nixpkgs/commit/6e13df71070c5246b72e49412130f29b09a49426) | `python310Packages.pyvex: 9.2.10 -> 9.2.11`                                                     |
| [`d5d18639`](https://github.com/NixOS/nixpkgs/commit/d5d186398a62508c8442783065d0f6c71cf67348) | `python310Packages.ailment: 9.2.10 -> 9.2.11`                                                   |
| [`b286ed37`](https://github.com/NixOS/nixpkgs/commit/b286ed37332e75b5b2c2d46cdb265343198889a1) | `python310Packages.archinfo: 9.2.10 -> 9.2.11`                                                  |
| [`53c614ee`](https://github.com/NixOS/nixpkgs/commit/53c614ee54ae86b2d92e43d401f1b5bfb01d9d3e) | `xdg-desktop-portal: 1.14.4 -> 1.14.5`                                                          |
| [`fbb839c5`](https://github.com/NixOS/nixpkgs/commit/fbb839c5621628e36fd7365c7bde112cc9b27087) | `ocamlPackages.cohttp-async: Remove redundant patch that doesn't apply`                         |
| [`d2b32502`](https://github.com/NixOS/nixpkgs/commit/d2b3250200e51d9b5557488dd73446abba5a98f3) | `ocamlPackages.mariadb: 1.1.4 → 1.1.6`                                                          |
| [`c42d8070`](https://github.com/NixOS/nixpkgs/commit/c42d8070119230a853d2bf5a2a24d759e9e691bb) | `python310Packages.pydal: 20220609.1 -> 20220720.1`                                             |
| [`4bf0af2e`](https://github.com/NixOS/nixpkgs/commit/4bf0af2efdba7a8d9e524a86af99d1a457ffe09e) | `minio: 2022-05-08T23-50-31Z -> 2022-07-17T15-43-14Z`                                           |
| [`c796935a`](https://github.com/NixOS/nixpkgs/commit/c796935aa57f0b9b4643661a80bee31655dee993) | `gvproxy: 0.3.0 -> 0.4.0`                                                                       |
| [`7663700f`](https://github.com/NixOS/nixpkgs/commit/7663700f1b41d88a438c1206a7f8db2c920964ab) | `sequoia: 0.26.0 -> 0.27.0`                                                                     |
| [`1e81606c`](https://github.com/NixOS/nixpkgs/commit/1e81606cd83983c92fe612f23cfbce265ebf0c5d) | `python310Packages.dvc-objects: 0.0.26 -> 0.1.1`                                                |
| [`fa917a6f`](https://github.com/NixOS/nixpkgs/commit/fa917a6f8c3629e356cdc2304afe6c2d4b1cb310) | `cvc3: unbreak on aarch64-darwin`                                                               |
| [`e9c1d81b`](https://github.com/NixOS/nixpkgs/commit/e9c1d81bf340242b661c8387876aa596f1f00552) | `arpack: unbreak on aarch64-darwin`                                                             |
| [`dc59b7cd`](https://github.com/NixOS/nixpkgs/commit/dc59b7cdbe1a61f7f63529072119402591d2188e) | `sqlx-cli: 0.5.13 -> 0.6.0`                                                                     |
| [`2e86faf1`](https://github.com/NixOS/nixpkgs/commit/2e86faf11a830fa12d210d5f0591359c9253106f) | `ferium: add shell completions`                                                                 |
| [`c5eb9af9`](https://github.com/NixOS/nixpkgs/commit/c5eb9af9c9b9e002ff5de111d2524f9df85e6e59) | `ferium: 4.1.5 -> 4.1.8`                                                                        |
| [`44a67dc0`](https://github.com/NixOS/nixpkgs/commit/44a67dc05717d3a1e6dbda23e5d8cfc4c69cedc7) | `ferium: add imsofi as maintainer`                                                              |
| [`8cc5d3f3`](https://github.com/NixOS/nixpkgs/commit/8cc5d3f34e2e0da0fc40dcbb6fee064a367bda4b) | `python310Packages.pysigma: 0.6.5 -> 0.6.6`                                                     |
| [`f6c47e50`](https://github.com/NixOS/nixpkgs/commit/f6c47e501ae829de15efe74df87a8de7c73e752e) | `_1password-gui-beta: 8.8.0-165.BETA -> 8.8.0-215.BETA`                                         |
| [`2c19f93f`](https://github.com/NixOS/nixpkgs/commit/2c19f93f089a3399aea74b0de84b9bc99afee9d0) | `gnomeExtensions: auto-update`                                                                  |
| [`1edbe752`](https://github.com/NixOS/nixpkgs/commit/1edbe7528b57a868b6883067b7884e39b02d3f37) | `python310Packages.google-cloud-spanner: 3.16.0 -> 3.17.0`                                      |
| [`ae5feae3`](https://github.com/NixOS/nixpkgs/commit/ae5feae3445e6044b1053af4354918669224b8f0) | `python310Packages.identify: 2.5.1 -> 2.5.2`                                                    |
| [`51532baa`](https://github.com/NixOS/nixpkgs/commit/51532baaf31ad5bc9853e45acca891ef5fe5719d) | `nuclei: 2.7.3 -> 2.7.4`                                                                        |
| [`fe35161c`](https://github.com/NixOS/nixpkgs/commit/fe35161c635f2db2c636db3b40b1ef49b4c450ce) | `python310Packages.google-cloud-access-context-manager: update disabled`                        |
| [`d66067f8`](https://github.com/NixOS/nixpkgs/commit/d66067f854a8dee9a03784c4f74a1b5ba4939c62) | `haskellPackages: regenerate package set based on current config`                               |
| [`a88da924`](https://github.com/NixOS/nixpkgs/commit/a88da924d7ecda630dea2ed29c57bcc8d918f2e3) | `json-directory: mark unbroken`                                                                 |
| [`c386f865`](https://github.com/NixOS/nixpkgs/commit/c386f8658b817b3627011b60381f5fd2616f8bb3) | `(k)vdo: 8.1.1.360 -> 8.2.0.2`                                                                  |
| [`bc1ae7cf`](https://github.com/NixOS/nixpkgs/commit/bc1ae7cff8b0ced795ac5ba20dc1db7338176a26) | `haskellPackages.cryptonite: disable tests on aarch32`                                          |
| [`8080821e`](https://github.com/NixOS/nixpkgs/commit/8080821eeefa6360535dac3a5b920401c992f1b0) | `haskellPackages.distribution-nixpkgs: 1.6.2 -> 1.7.0`                                          |
| [`be577d0d`](https://github.com/NixOS/nixpkgs/commit/be577d0da6ea034020af140754cab731753f95f8) | `qFlipper: 1.0.2 -> 1.1.0`                                                                      |
| [`9187401e`](https://github.com/NixOS/nixpkgs/commit/9187401eb87f581a71ee160cd4ec922712cb75b2) | `python310Packages.google-cloud-access-context-manager: 0.1.12 -> 0.1.13`                       |
| [`481ad5b3`](https://github.com/NixOS/nixpkgs/commit/481ad5b3c3411056941f28e3437883e3da813999) | `re-Isearch: init at unstable-2022-03-24`                                                       |
| [`be2175dc`](https://github.com/NixOS/nixpkgs/commit/be2175dc949a34334f1ad9a81d95279ead470bb1) | `openldap: load client config from /etc, not the nix store`                                     |
| [`77320bf8`](https://github.com/NixOS/nixpkgs/commit/77320bf820ebc0acaa3687054a2996a179764136) | `sqlint: 0.2.0 -> 0.2.1`                                                                        |
| [`08d6da16`](https://github.com/NixOS/nixpkgs/commit/08d6da16d0a677ebe95274f5680e6440beef4171) | `haskellPackages.monad-control-identity: mark as unbroken`                                      |
| [`91fa6405`](https://github.com/NixOS/nixpkgs/commit/91fa64052e575bc9e0eeb67b1f75f76753abf7a1) | `haskellPackages: regenerate package set based on current config`                               |
| [`9771f28b`](https://github.com/NixOS/nixpkgs/commit/9771f28b6fa77abd3be83851aa44c45cbefb4c58) | `all-cabal-hashes: 2022-07-17T05:56:49Z -> 2022-07-18T21:55:34Z`                                |
| [`bf27ab82`](https://github.com/NixOS/nixpkgs/commit/bf27ab825e45bdc45322bc75a637bfe81f589b0c) | `boinc: 7.20.1 -> 7.20.2`                                                                       |
| [`bf3e5034`](https://github.com/NixOS/nixpkgs/commit/bf3e5034bb0803f0cbb6104a3ed9795d905ea175) | `portfolio: 0.58.5 -> 0.59.0`                                                                   |
| [`a65e19e0`](https://github.com/NixOS/nixpkgs/commit/a65e19e0da2b4377a1e1f226eb156dd8a2ed1223) | `libproxy: spidermonkey_78 -> duktape`                                                          |
| [`62763da4`](https://github.com/NixOS/nixpkgs/commit/62763da4c3a8c543e1ceda06ea07666758eccadb) | `libproxy: 0.4.17 -> 0.4.18`                                                                    |
| [`3920bb41`](https://github.com/NixOS/nixpkgs/commit/3920bb41f2e7a3f0e8ac042ae985117f95e10fae) | `nixos/searx: improve searxng compatibility`                                                    |
| [`17bba9f1`](https://github.com/NixOS/nixpkgs/commit/17bba9f16b1d5f21bfd202e7bfdec04ba4c71507) | `searxng: unstable-2022-06-29 -> unstable-2022-07-15`                                           |
| [`0c0befe2`](https://github.com/NixOS/nixpkgs/commit/0c0befe2c33874c2e65fb2b2e1cc6ba6790cdbdb) | `epson-escpr2: 1.1.48 -> 1.1.49`                                                                |
| [`a36dbed1`](https://github.com/NixOS/nixpkgs/commit/a36dbed1b81cb14b41ef32eb32bfc6e98ba09fc5) | `home-assistant: 2022.7.4 -> 2022.7.5`                                                          |
| [`d5642e34`](https://github.com/NixOS/nixpkgs/commit/d5642e3491ff5d79e6836e86944bead8fb7f6022) | `pivy: 0.6.6 -> 0.6.7`                                                                          |
| [`aaa43b77`](https://github.com/NixOS/nixpkgs/commit/aaa43b771959e89a1eb2463d2272fd0f551d6629) | `trivy: 0.29.2 -> 0.30.0`                                                                       |
| [`371db36e`](https://github.com/NixOS/nixpkgs/commit/371db36e5602bbd579d6ef75aba6d2507e64bd49) | `nvidia: improve robustness of udev rules`                                                      |
| [`c56b9f8b`](https://github.com/NixOS/nixpkgs/commit/c56b9f8bad1a63273fc5ad3f7ee9936df04f0341) | `wolfssl: 5.3.0 -> 5.4.0`                                                                       |
| [`d58cc561`](https://github.com/NixOS/nixpkgs/commit/d58cc561037eeeca0e185caafac78c50cccf564c) | `i3lock: 2.13 -> 2.14.1`                                                                        |
| [`b2a65251`](https://github.com/NixOS/nixpkgs/commit/b2a6525191bc7a3a2f5f98588cc57dcacc1b4e17) | `gnunet: 0.17.1 -> 0.17.2`                                                                      |
| [`99047f1f`](https://github.com/NixOS/nixpkgs/commit/99047f1f141637bfa0108f5624b022091e4e86bf) | `bash_unit: 1.9.1 -> 2.0.0`                                                                     |
| [`f0100c6f`](https://github.com/NixOS/nixpkgs/commit/f0100c6fa7095afdacd956b6f616997ef5e5565e) | `doc/contributing: replace outdated 'nix run' commands`                                         |
| [`06ea5e78`](https://github.com/NixOS/nixpkgs/commit/06ea5e780b08bd4a4254f83e90168bb76cbd0ee1) | `nixos/glusterfs: exclude hook "S10selinux-label-brick.sh"`                                     |