### PR TITLE
chore(flake/nixpkgs): `2d372784` -> `42ca9bef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658465217,
-        "narHash": "sha256-f2Zyt7TsDZ1TK3Cu6ZtzWoWQ4nnQq07uXTPxW26rIQY=",
+        "lastModified": 1658557357,
+        "narHash": "sha256-0gqNef6skYQKJSS2vLojxrXOrc72zoX5VTDKUqEo6Gk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2d372784634e224c5a629d80a19705af655fbc7d",
+        "rev": "42ca9bef09e780eabe84328dd1b730cef978f098",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                     |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`0b696d8a`](https://github.com/NixOS/nixpkgs/commit/0b696d8ad792ee8de955f2c4e94f2ba14e3a66c4) | `biodiff: 1.0.1 -> 1.0.3`                                                          |
| [`c25543b5`](https://github.com/NixOS/nixpkgs/commit/c25543b55415ac0a32415d0bbc6d33193a465d22) | `wineWowPackages: default mainProgram to "wine64"`                                 |
| [`f861ecf2`](https://github.com/NixOS/nixpkgs/commit/f861ecf285e3e5dac7346dee50c79b445129159a) | `fzf: 0.30.0 -> 0.31.0`                                                            |
| [`c2dbbe70`](https://github.com/NixOS/nixpkgs/commit/c2dbbe706b8199efbfefb4c835a1c4a572b1ee02) | `wine64Packages: fix mainProgram`                                                  |
| [`92bb481c`](https://github.com/NixOS/nixpkgs/commit/92bb481cd710e367cf3b7efa8fe54dc112f9dd83) | `chromiumDev: 105.0.5176.3 -> 105.0.5191.2`                                        |
| [`308b5776`](https://github.com/NixOS/nixpkgs/commit/308b5776a28e456750c423c697991ecf98d944d3) | `cnijfilter2: 6.10 -> 6.40 (#180681)`                                              |
| [`62ab1e3d`](https://github.com/NixOS/nixpkgs/commit/62ab1e3d0b65ea630245545c8b289cec32c2dab3) | `kaitai-struct-compiler: 0.9 -> 0.10`                                              |
| [`f0fd10ed`](https://github.com/NixOS/nixpkgs/commit/f0fd10edeace908bd5c299b4128a0f6e48dc41ea) | `pythonPackages.kaitaistruct: 0.9 -> 0.10`                                         |
| [`6b4900c1`](https://github.com/NixOS/nixpkgs/commit/6b4900c1f19295fbf734848fd7a7f6aa56195a42) | `vimPlugins.marks-nvim: update owner's name`                                       |
| [`b4d0cb44`](https://github.com/NixOS/nixpkgs/commit/b4d0cb44975e069e926a2c8963aded9557040541) | `kernel: port randstruct patch to 5.19`                                            |
| [`01d57f09`](https://github.com/NixOS/nixpkgs/commit/01d57f09ee16fd20734f0b84d469ebf4b16503e1) | `linux_testing: 5.15-rc6 -> 5.19-rc5`                                              |
| [`2913507a`](https://github.com/NixOS/nixpkgs/commit/2913507a7a6bd1b9da25bed7dc0fa02fb1d4e56b) | `zen-kernels: 5.18.12 -> 5.18.13`                                                  |
| [`88070572`](https://github.com/NixOS/nixpkgs/commit/88070572962d2e1045f72ac28302884b24c2e952) | `nixos/openldap: drop myself as maintainer`                                        |
| [`07bcc1e1`](https://github.com/NixOS/nixpkgs/commit/07bcc1e1ef76d0f6e14ac8a6593eb5d89c1f43c4) | `herwig: 7.2.2 -> 7.2.3`                                                           |
| [`dac092e0`](https://github.com/NixOS/nixpkgs/commit/dac092e086649907be07aff1acfbee8b419a302a) | `thepeg: 2.2.2 -> 2.2.3`                                                           |
| [`8b683873`](https://github.com/NixOS/nixpkgs/commit/8b6838735ec35a0c493b6db2c1bc0c274d3d3b28) | `eget: init at 1.1.0 (#182166)`                                                    |
| [`c8fc8933`](https://github.com/NixOS/nixpkgs/commit/c8fc89334dea58c3d4ffa2756790b79bb8c72d1d) | `avalonia-ilspy: Init at 7.2-rc (#182196)`                                         |
| [`c0bdd3b9`](https://github.com/NixOS/nixpkgs/commit/c0bdd3b9aed752df60913692828548cf2ab03d83) | `xfce.catfish: 4.16.3 -> 4.16.4 (#182252)`                                         |
| [`e0e2c0cb`](https://github.com/NixOS/nixpkgs/commit/e0e2c0cbc5569273ed539fa239f3a2e6254202d8) | `qogir-icon-theme: 2022-01-12 -> 2022-07-20 (#182121)`                             |
| [`0d3d66c7`](https://github.com/NixOS/nixpkgs/commit/0d3d66c72d94c3f57157eb6a898dbb484a1af407) | `ijq: 0.3.8 -> 0.4.0`                                                              |
| [`da849f7b`](https://github.com/NixOS/nixpkgs/commit/da849f7b303aec8211e0602b90720502fdafec3c) | `docker-compose: 2.6.1 -> 2.7.0`                                                   |
| [`7a3f99fa`](https://github.com/NixOS/nixpkgs/commit/7a3f99fa70188fd53823a4063cb6692d1271d66d) | `linux/hardened/patches/5.4: 5.4.205-hardened1 -> 5.4.206-hardened1`               |
| [`5d94d154`](https://github.com/NixOS/nixpkgs/commit/5d94d1543da30c51caf0fcc6b789848e5a442744) | `linux/hardened/patches/5.18: 5.18.11-hardened1 -> 5.18.12-hardened1`              |
| [`fec96c54`](https://github.com/NixOS/nixpkgs/commit/fec96c54354b658263b32fb8fee4667c0b96429f) | `linux/hardened/patches/5.15: 5.15.54-hardened1 -> 5.15.55-hardened1`              |
| [`cef3263d`](https://github.com/NixOS/nixpkgs/commit/cef3263da6b97dc43f725a017d6ac5d113eb6236) | `linux/hardened/patches/5.10: 5.10.130-hardened1 -> 5.10.131-hardened1`            |
| [`61fa7509`](https://github.com/NixOS/nixpkgs/commit/61fa750911c1b489f5d28e4bfab3073bc893f3fd) | `linux: 5.4.206 -> 5.4.207`                                                        |
| [`a368cce1`](https://github.com/NixOS/nixpkgs/commit/a368cce1a5e79f2724bfd33541b5083aa630b1b7) | `linux: 5.18.12 -> 5.18.13`                                                        |
| [`98215a7f`](https://github.com/NixOS/nixpkgs/commit/98215a7f78828d01d7db30485679adf742404454) | `linux: 5.15.55 -> 5.15.56`                                                        |
| [`d91bda3b`](https://github.com/NixOS/nixpkgs/commit/d91bda3b8303d6f7a86a5c5819c7cfbddfc7f6a0) | `linux: 5.10.131 -> 5.10.132`                                                      |
| [`225a653b`](https://github.com/NixOS/nixpkgs/commit/225a653b7d1a3ec8dfef403798431d5b77cf8a00) | `linux: 4.9.323 -> 4.9.324`                                                        |
| [`ae6aa45e`](https://github.com/NixOS/nixpkgs/commit/ae6aa45e319300789df41f89679e6056b71f8904) | `linux: 4.19.252 -> 4.19.253`                                                      |
| [`9e6fcd6f`](https://github.com/NixOS/nixpkgs/commit/9e6fcd6f07c62a787693a7779d93a1a4c9df2cf3) | `linux: 4.14.288 -> 4.14.289`                                                      |
| [`75feaefc`](https://github.com/NixOS/nixpkgs/commit/75feaefc59ead1d5ecf5f993050c0d52c08cb9ce) | `python310Packages.jupyterlab: 3.4.3 -> 3.4.4 (#182435)`                           |
| [`ca9bddbb`](https://github.com/NixOS/nixpkgs/commit/ca9bddbb8c9b8d63968b091781ede80b7d4f40aa) | `surge: Fix build`                                                                 |
| [`42c017bc`](https://github.com/NixOS/nixpkgs/commit/42c017bcbf2ee499e0173755a7c59fcaab6a1c55) | `sta: unstable-2020-05-10 -> unstable-2021-11-30`                                  |
| [`6c0501dd`](https://github.com/NixOS/nixpkgs/commit/6c0501dd428cb227b4b5285cd3806e0f2fa0c8d5) | `pdftoipe: Fix build with latest poppler version`                                  |
| [`b8ed1e8c`](https://github.com/NixOS/nixpkgs/commit/b8ed1e8c4f59f4fa469d0d321b25551f58804bd0) | `exploitdb: 2022-07-12 -> 2022-07-22`                                              |
| [`a2a60528`](https://github.com/NixOS/nixpkgs/commit/a2a60528eb0c1366f3407897053ae7a5e6979b5d) | `okteto: 2.4.0 -> 2.5.0`                                                           |
| [`f2e43c14`](https://github.com/NixOS/nixpkgs/commit/f2e43c14dfd711ea627c6d39f432542a8e991d5a) | `python310Packages.python-manilaclient: 3.4.0 -> 4.0.0 (#182438)`                  |
| [`51169259`](https://github.com/NixOS/nixpkgs/commit/51169259a087780b0deb7a28416dc19cad5d7b3e) | `duktape: force link shared library against libm`                                  |
| [`f8e84d0a`](https://github.com/NixOS/nixpkgs/commit/f8e84d0a08b75bbb9453b54f3bc44d4b09e08af4) | `lightning-loop: 0.19.1-beta -> 0.20.0-beta`                                       |
| [`709a19ad`](https://github.com/NixOS/nixpkgs/commit/709a19ad38028cf4c4a16752752e78a257424ccb) | `tut: 1.0.13 -> 1.0.14`                                                            |
| [`d0617a58`](https://github.com/NixOS/nixpkgs/commit/d0617a58e226a267eebeef431b8f3eb45c04f949) | `services/web-apps/lemmy.nix: Remove space that causes a type error`               |
| [`9cb7efc4`](https://github.com/NixOS/nixpkgs/commit/9cb7efc496c4a0ff307601f8e4265f8d0bdbb8be) | `weechatScripts.weechat-autosort: set license to gpl3Plus`                         |
| [`3a3cfc0d`](https://github.com/NixOS/nixpkgs/commit/3a3cfc0d66d0fad7fe39cc59be4993a1f36a29b0) | `Update pkgs/development/libraries/libdigidocpp/default.nix`                       |
| [`e5e213af`](https://github.com/NixOS/nixpkgs/commit/e5e213afb892fab056dfd4fdc3f8ef71fe35b37d) | `Update pkgs/applications/networking/irc/weechat/scripts/weechat-grep/default.nix` |
| [`5d380b2f`](https://github.com/NixOS/nixpkgs/commit/5d380b2f7e60a28ea06cfebce6beb76ca3ff22d1) | `vimv-rs: 1.7.5 -> 1.7.7`                                                          |
| [`3705020d`](https://github.com/NixOS/nixpkgs/commit/3705020d970627dbb3fc312cf834e2277973bfd6) | `mangohud: Build mangoapp and mangohudctl for gamescope integration`               |
| [`fcee3737`](https://github.com/NixOS/nixpkgs/commit/fcee37371e715075e22450b9a2ae6a09122ef078) | `python310Packages.snowflake-sqlalchemy: 1.3.4 -> 1.4.0`                           |
| [`5432a590`](https://github.com/NixOS/nixpkgs/commit/5432a59094cdcc285c08524d9572d5de7aa007ba) | `millet: 0.2.5 -> 0.2.7`                                                           |
| [`37580d61`](https://github.com/NixOS/nixpkgs/commit/37580d6187057ee9a8fbce185f4b6e6e708a2316) | `nodejs-16_x: 16.15.0 -> 16.16.0`                                                  |
| [`d2e484db`](https://github.com/NixOS/nixpkgs/commit/d2e484dba21e930c97bc6ae5ad2bb0be4cf28021) | `gobject-introspection: fix .override when the wrapper is in use`                  |
| [`5fd3be65`](https://github.com/NixOS/nixpkgs/commit/5fd3be651158fa10c1bd9f8108cf3a32516dfd17) | `visidata: 2.8 -> 2.9.1`                                                           |
| [`93132dc0`](https://github.com/NixOS/nixpkgs/commit/93132dc09c36aefb3d2f883901493103e5af985f) | `nixos/pam: refactor pam_mount unmounting fix`                                     |
| [`9786fb4c`](https://github.com/NixOS/nixpkgs/commit/9786fb4cc7d97c39aa232d091129a0e2e822178e) | `zk: 0.9.0 -> 0.11.1`                                                              |
| [`dfec7542`](https://github.com/NixOS/nixpkgs/commit/dfec7542b42ed54d442030d5c349e83d023e7eb5) | `python310Packages.afsapi: 0.2.6 -> 0.2.7`                                         |
| [`443ce157`](https://github.com/NixOS/nixpkgs/commit/443ce157a86a85b82f11050b0b5fad97551b217a) | `maintainers: ihatethefrench -> not-my-segfault`                                   |
| [`98367d2c`](https://github.com/NixOS/nixpkgs/commit/98367d2c61d1b3c144ae818c07125104d3867dd7) | `ncdu: default to v2`                                                              |
| [`c2d91c4d`](https://github.com/NixOS/nixpkgs/commit/c2d91c4d018c8fca437b22bb46823b5f2936d66c) | `stylua: 0.14.0 -> 0.14.1`                                                         |
| [`44d5286b`](https://github.com/NixOS/nixpkgs/commit/44d5286b0d1b86fabfdb239d8917aaf2952af375) | `intel-gmmlib: 22.1.5 -> 22.1.7`                                                   |
| [`3c695f15`](https://github.com/NixOS/nixpkgs/commit/3c695f159a7124f5355c1b2ee58b39f7b594218c) | `binocle: fix build on Darwin`                                                     |
| [`3580e419`](https://github.com/NixOS/nixpkgs/commit/3580e419eae9db9357b02ea35da0a0a7430abdbd) | `google-amber: fix build on Darwin`                                                |
| [`8087d356`](https://github.com/NixOS/nixpkgs/commit/8087d356681521850227fc5ad6c90eaa426b74e9) | `libplacebo: fix build on Darwin`                                                  |
| [`249e904a`](https://github.com/NixOS/nixpkgs/commit/249e904af0e93a1ee1e614f895b1f3d927268886) | `realesrgan-ncnn-vulkan: fix build on aarch64-darwin`                              |
| [`a88ca055`](https://github.com/NixOS/nixpkgs/commit/a88ca0557741c7a193490d803ad448695c5f9b70) | `wgpu-utils: fix build on Darwin`                                                  |
| [`c92d1a55`](https://github.com/NixOS/nixpkgs/commit/c92d1a55d368dc71cbfd4a17065e22a1032454f0) | `moltenvk: 1.1.9 -> 1.1.10`                                                        |
| [`9d2b95ee`](https://github.com/NixOS/nixpkgs/commit/9d2b95eef3d1284d728af4ea10aba21aed3a0806) | `moltenvk: refactor to build without Xcode`                                        |
| [`d6a7358e`](https://github.com/NixOS/nixpkgs/commit/d6a7358e721123502ea66930a75ecf7471d4738b) | `oh-my-git: 0.6.4 -> 0.6.5`                                                        |
| [`df5c71b0`](https://github.com/NixOS/nixpkgs/commit/df5c71b008ca914712c1f9c73f51f722f1ca12c3) | `noti: bump golang.org/x/sys`                                                      |
| [`1131c38b`](https://github.com/NixOS/nixpkgs/commit/1131c38b3b9bb49c0ad8ffed7c83708544852ab6) | `dive: fix build on aarch64-darwin`                                                |
| [`270d040c`](https://github.com/NixOS/nixpkgs/commit/270d040cdc4bdf6136a4f55c0b6cffa63c021215) | `libdigidocpp: 3.14.8 -> 3.14.10`                                                  |
| [`16719027`](https://github.com/NixOS/nixpkgs/commit/16719027bd6906394ca4ae2d531904b415892814) | `dialect: 2.0.1 -> 2.0.2`                                                          |
| [`fa02e1d4`](https://github.com/NixOS/nixpkgs/commit/fa02e1d4de710a107758be7a1da6f4b9ccef56aa) | `logseq: 0.7.7 -> 0.7.8`                                                           |
| [`a4965808`](https://github.com/NixOS/nixpkgs/commit/a4965808cfacf5fff7b7c74484b980b5d4129b5b) | `brave: 1.41.96 -> 1.41.99`                                                        |
| [`1975e320`](https://github.com/NixOS/nixpkgs/commit/1975e320a69314e02d68246595159e38ed1640ea) | `atkmm_2_36: 2.36.1 -> 2.36.2`                                                     |
| [`e5424deb`](https://github.com/NixOS/nixpkgs/commit/e5424debbe79f8f17fc8496377e031d7d058a32c) | `atkmm: 2.28.2 -> 2.28.3`                                                          |
| [`38461d10`](https://github.com/NixOS/nixpkgs/commit/38461d1034e7b1a72dd4e44f8eb4d6a400d1efd6) | `onlyoffice-documentserver: remove refernce to deb file`                           |
| [`bed33cb4`](https://github.com/NixOS/nixpkgs/commit/bed33cb4a5a7fdaa17fd534e3a4f1e3adefbfb62) | `hydrus: 491 -> 492`                                                               |
| [`258060c3`](https://github.com/NixOS/nixpkgs/commit/258060c37d1f4b973aa6293485ad3594a9e88233) | `nixos/confluence: store crowd SSO password securely`                              |
| [`db9937b5`](https://github.com/NixOS/nixpkgs/commit/db9937b57823e53848e5b245cff6744ad0bef0fb) | `nixos/mailman: don't leak MAILMAN_REST_API_PASS into the store`                   |
| [`1b3291d4`](https://github.com/NixOS/nixpkgs/commit/1b3291d45a0e2d6d96b34eb4d45a907346be6507) | `framesh: 0.5.0-beta.20 -> 0.5.0-beta.21`                                          |
| [`3934afb8`](https://github.com/NixOS/nixpkgs/commit/3934afb8b1bd478e2355f9a6937288fb9ec0c192) | `onedrive: 2.4.19 -> 2.14.20`                                                      |
| [`f5a6f2e3`](https://github.com/NixOS/nixpkgs/commit/f5a6f2e302042c311c2e3cee18d57d06318256c5) | `jadx: 1.4.2 -> 1.4.3`                                                             |
| [`f9b5d5dc`](https://github.com/NixOS/nixpkgs/commit/f9b5d5dcbf84ac377405cfa82395e58bf4a4328e) | `netcoredbg: fix build`                                                            |
| [`f0b82935`](https://github.com/NixOS/nixpkgs/commit/f0b82935f5697e15a478380aac73faea9b8d84f7) | `qogir-kde: init at unstable-2022-07-08`                                           |
| [`dc39d8da`](https://github.com/NixOS/nixpkgs/commit/dc39d8da2718d9a6d1ca5229f6670df11b110a4a) | `tailscale: 1.26.2 -> 1.28.0`                                                      |
| [`d7af5642`](https://github.com/NixOS/nixpkgs/commit/d7af5642a8845b7acffee3ba7aca51aea80ce0ca) | `python3Packages.plantuml: init at 0.3.0`                                          |
| [`c1c0ad50`](https://github.com/NixOS/nixpkgs/commit/c1c0ad50e60dc96c25ec1ef8f952144e16494077) | `maintainers: add nikstur`                                                         |
| [`17c9b72a`](https://github.com/NixOS/nixpkgs/commit/17c9b72ab84c4770c5fd97106b1f14d8e46ee4b2) | `orchis-theme: 2022-05-29 -> 2022-07-20`                                           |
| [`9f86e929`](https://github.com/NixOS/nixpkgs/commit/9f86e929b081ae4dfaf4ef9a6919a1943b1bda55) | `openroad: 2.0 -> unstable-2022-07-19`                                             |
| [`5bcec704`](https://github.com/NixOS/nixpkgs/commit/5bcec70433a8ef270f27d98cd23b9b35ad8a86b3) | `fmt_8: 8.0.1 -> 8.1.1`                                                            |
| [`9b79ff3a`](https://github.com/NixOS/nixpkgs/commit/9b79ff3a1034f87c27ed7b616127e60aa1595340) | `Revert "noti: fix build"`                                                         |
| [`55ce7255`](https://github.com/NixOS/nixpkgs/commit/55ce7255bcdec7fbbce26271fe9e6484cec012bf) | `Revert "dive: fix build"`                                                         |
| [`0c4eb785`](https://github.com/NixOS/nixpkgs/commit/0c4eb785f647ca4bda9938ce361f48f3f64ecac5) | `colloid-gtk-theme: init at 2022-07-18`                                            |
| [`4a13ac89`](https://github.com/NixOS/nixpkgs/commit/4a13ac89587c2ec8c313538689264d1fa05267e1) | `hub: 2.14.2 -> unstable-2022-04-04`                                               |
| [`0a71372a`](https://github.com/NixOS/nixpkgs/commit/0a71372a900a2d028f279fa27c18afdd7c8273c5) | `nixos-rebuild: Don't create out-link in PWD with test/dry-activate`               |
| [`575da896`](https://github.com/NixOS/nixpkgs/commit/575da89648efd9de9fde5ad02f8a545c223d7e4e) | `corefonts: rename fonts to standard names`                                        |
| [`d5eb8cea`](https://github.com/NixOS/nixpkgs/commit/d5eb8cea6163e268dc380ba03dbbf55cff211f1c) | `netbox: build documentation as part of build`                                     |
| [`db93e37f`](https://github.com/NixOS/nixpkgs/commit/db93e37fa34fe839f468d9a8754e1fd0c843450a) | `netbox: add new dependencies (bleach, sentry-sdk)`                                |
| [`bcd9dc12`](https://github.com/NixOS/nixpkgs/commit/bcd9dc120e5c7377bb46e77143ffa121d08a9f5f) | `griffe: 0.21.0 -> 0.22.0`                                                         |
| [`39fe6414`](https://github.com/NixOS/nixpkgs/commit/39fe64148386171f2f95b203a7b4de495dbe4410) | `polylith: 0.2.13-alpha -> 0.2.14-alpha`                                           |
| [`8d750db5`](https://github.com/NixOS/nixpkgs/commit/8d750db596eb3e9601ac5734febe2b7d19300c3a) | `python3Packages.debugpy: 1.6.0 → 1.6.2`                                           |
| [`e637c304`](https://github.com/NixOS/nixpkgs/commit/e637c304e6936ca6f9f8ed4d0ef73e46ab3e7eb8) | `mediawiki: 1.37.2 -> 1.38.1, adopt`                                               |
| [`5e297d07`](https://github.com/NixOS/nixpkgs/commit/5e297d07aa2d6047c130d14403d256a0912a78fe) | `nixos/onlyoffice: init`                                                           |
| [`de935756`](https://github.com/NixOS/nixpkgs/commit/de93575623a90f78480f4d2df2cf12cd9101c09a) | `onlyoffice-documentserver: init at 7.1.1-23`                                      |
| [`035c191a`](https://github.com/NixOS/nixpkgs/commit/035c191ae12d614e83b52a0cc813c5703dd35efe) | `netbox: 3.2.3 -> 3.2.6`                                                           |
| [`0c07aac7`](https://github.com/NixOS/nixpkgs/commit/0c07aac78b1227517137fd37e7a9d1b886f78ff3) | `weechatScripts.weechat-grep: init at 0.8.5`                                       |
| [`52ebfe07`](https://github.com/NixOS/nixpkgs/commit/52ebfe07490a49046ec6c7a226d57086808e4204) | `weechatScripts.weechat-autosort: 3.8 -> 3.9`                                      |
| [`82ba6157`](https://github.com/NixOS/nixpkgs/commit/82ba6157fb04b30ed25e0ec9cdfa127c83103280) | `weechatScripts.weechat-autosort: add myself to maintainers`                       |
| [`122db56f`](https://github.com/NixOS/nixpkgs/commit/122db56f1472481435432b546521e930a70782c5) | `musikcube: Replace local patch with upstream patch`                               |
| [`512d30b8`](https://github.com/NixOS/nixpkgs/commit/512d30b8a07d335203df533912b2b12629c6f50e) | `python3Packages.debugpy: remove unnecessary arch specifiers`                      |
| [`220238e2`](https://github.com/NixOS/nixpkgs/commit/220238e223d89488fb3fdd9a6a8113c18714f8ca) | `musikcube: 0.97.0 -> 0.98.0`                                                      |
| [`73094a00`](https://github.com/NixOS/nixpkgs/commit/73094a006e4c0a7085d93439d2a8a0ab38a09211) | `drush: 8.4.10 -> 8.4.11`                                                          |
| [`b2224764`](https://github.com/NixOS/nixpkgs/commit/b2224764eeaab6792054e98780cf05be6baec601) | `nixos-generate-config: substitute nix-instantiate`                                |
| [`757ab933`](https://github.com/NixOS/nixpkgs/commit/757ab9339d7b5fe2fad692d4398a0a9bd59a0071) | `beyond-identity: 2.49.0-0 -> 2.60.0-0`                                            |
| [`b729ef3d`](https://github.com/NixOS/nixpkgs/commit/b729ef3ddde4cd90d16f3be0304c3e8b71491efe) | `nvpy: 2.1.0 -> 2.2.0`                                                             |
| [`435959ce`](https://github.com/NixOS/nixpkgs/commit/435959ce6fd6588f7f7ecd5c2bf48773ae79aa96) | `jpegoptim: 1.4.6 -> 1.4.7`                                                        |
| [`403e4336`](https://github.com/NixOS/nixpkgs/commit/403e43366cbaaa164116327de27474f8fab36a85) | `yubikey-manager-qt: fix application icons`                                        |
| [`30c36b47`](https://github.com/NixOS/nixpkgs/commit/30c36b47062f5cab53da07d9ed4ff1bd2b98ce36) | `nixos/systemd-stage-1: use types.passwdEntry in emergencyAccess`                  |
| [`574a9077`](https://github.com/NixOS/nixpkgs/commit/574a90771f3c0eeeeab798c38fea5f7bf6b44066) | `lib.types, nixos/users: Make passwdEntry available`                               |