### PR TITLE
chore(flake/nixpkgs): `42ca9bef` -> `e494a908`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658557357,
-        "narHash": "sha256-0gqNef6skYQKJSS2vLojxrXOrc72zoX5VTDKUqEo6Gk=",
+        "lastModified": 1658648081,
+        "narHash": "sha256-RL5nr4Xhp0zQeEGG/I3t3FmqaI9QrBg5PH31NF+7A/A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "42ca9bef09e780eabe84328dd1b730cef978f098",
+        "rev": "e494a908e8895b9cba18e21d5fc83362f64b3f6a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`47f09a22`](https://github.com/NixOS/nixpkgs/commit/47f09a22851fde43c3b690d220449b0dac2935a5) | `terraform-providers: update 2022-07-24`                                  |
| [`422acf32`](https://github.com/NixOS/nixpkgs/commit/422acf32d0e88e2c5e4ab2ae8732b48e7f3e54fa) | `libsolv: replace lzma alias with actual xz attribute`                    |
| [`46cf1b97`](https://github.com/NixOS/nixpkgs/commit/46cf1b978133b993eacf30a3c564df29044df0e5) | `tbb: Fix build for aarch64-darwin (#182367)`                             |
| [`d3515dd4`](https://github.com/NixOS/nixpkgs/commit/d3515dd4a78f041a84c275e7caf9bbb13e9f8922) | `coccinelle: 1.1.0 -> 1.1.1`                                              |
| [`c6b7abc3`](https://github.com/NixOS/nixpkgs/commit/c6b7abc361569ec886b4a89c8b85aace13c2cb76) | `git-machete: 3.11.2 -> 3.11.3`                                           |
| [`60a93661`](https://github.com/NixOS/nixpkgs/commit/60a93661cab3fc9632ad57a464511a68063a2606) | `railway: init at 1.8.3`                                                  |
| [`780ac585`](https://github.com/NixOS/nixpkgs/commit/780ac585679123f1b029d5e443fc57df75316cc4) | `maintainers: add Crafter`                                                |
| [`1acad56b`](https://github.com/NixOS/nixpkgs/commit/1acad56b03fe76bbfe328eb0edf16a3308a90f19) | `python310Packages.pyswitchbot: 0.14.1 -> 0.15.0`                         |
| [`98a24a17`](https://github.com/NixOS/nixpkgs/commit/98a24a173e62e4e715c6ca50f21127259b026f46) | `libsForQt5.kirigami-gallery: init at 22.04.3 (#182339)`                  |
| [`d6ccd006`](https://github.com/NixOS/nixpkgs/commit/d6ccd0064d0d80e753464e6c7448f63c1c2c9ff2) | `slop: add missing libSM dependency (#182506)`                            |
| [`a2b8a949`](https://github.com/NixOS/nixpkgs/commit/a2b8a94988c69dfee49da6fcafd800a82785fbc8) | `browsh: 1.6.4 -> 1.8.0`                                                  |
| [`d4c79927`](https://github.com/NixOS/nixpkgs/commit/d4c799277a2b2a4e40dd4c8a575611cae9058b67) | `time-decode: 4.0.0 -> 4.1.2`                                             |
| [`d383e90a`](https://github.com/NixOS/nixpkgs/commit/d383e90ace6480d6846b6dd3cbe66d30c044bd30) | `_7zz: build on macOS`                                                    |
| [`64e11aab`](https://github.com/NixOS/nixpkgs/commit/64e11aab7f24cee0dafcd7256134a3f67f275a79) | `werf: 1.2.128 -> 1.2.138`                                                |
| [`dd270927`](https://github.com/NixOS/nixpkgs/commit/dd2709275ce5175db2a278ee53f5e360c6850b50) | `fish-irssi: unstable-2013-04-13 -> unstable-2021-04-16`                  |
| [`8ad9860b`](https://github.com/NixOS/nixpkgs/commit/8ad9860b50370b585a248c1b938cbd0d12afe1c2) | `xwayland: 22.1.1 -> 22.1.3 (#174926)`                                    |
| [`ac475518`](https://github.com/NixOS/nixpkgs/commit/ac4755181fed8ac29d992ca22f52c8774ee738f0) | `htmldoc: fix darwin build (#178725)`                                     |
| [`241a178e`](https://github.com/NixOS/nixpkgs/commit/241a178eda8eec81df0acbc4759c1d7c2e25d440) | `python310Packages.apache-beam: Add missing test dependency`              |
| [`e8b1b05a`](https://github.com/NixOS/nixpkgs/commit/e8b1b05acde7285d0926606bbeedf8d4eaa07b25) | `fish: add winter and srapenne as maintainers`                            |
| [`bba36e01`](https://github.com/NixOS/nixpkgs/commit/bba36e0154a3f32ac284d8ac620d6b9ba84bf040) | `grails: mark as sourceProvenance binaryBytecode`                         |
| [`10e96b76`](https://github.com/NixOS/nixpkgs/commit/10e96b76b3a896291016aa55240c63b0a6122495) | `grails: 5.1.7 -> 5.1.9`                                                  |
| [`09c3e368`](https://github.com/NixOS/nixpkgs/commit/09c3e368e99e13c8fb773475e5f8a9577276c2a9) | `xonsh: 0.11.0 -> 0.13.0`                                                 |
| [`f0f07edc`](https://github.com/NixOS/nixpkgs/commit/f0f07edc83403b854b0822f7614ac9a7e3cdd62c) | `thefuck: lib.optional -> lib.optionals`                                  |
| [`6f0279fc`](https://github.com/NixOS/nixpkgs/commit/6f0279fcb5595ad2587153756c0a77f6d8c194fd) | `bear: 3.0.19 -> 3.0.20`                                                  |
| [`013fbaef`](https://github.com/NixOS/nixpkgs/commit/013fbaefe9e56913136258fbab5d48292ddd89b9) | `polymc: 1.3.2 -> 1.4.0`                                                  |
| [`c8504947`](https://github.com/NixOS/nixpkgs/commit/c8504947e4c69f6eeef27c70a93a74214c7346a1) | `waypoint: 0.8.2 -> 0.9.0`                                                |
| [`2714e5db`](https://github.com/NixOS/nixpkgs/commit/2714e5dbc8c7913e4d8f29324ef3009a07fb5fbf) | `python310Packages.sentry-sdk: 1.7.2 -> 1.8.0`                            |
| [`214ea459`](https://github.com/NixOS/nixpkgs/commit/214ea4599f5d8d2a9d49d6c8ee5f4c21aae3abe1) | `irssi: 1.4.1 -> 1.4.2`                                                   |
| [`534c1389`](https://github.com/NixOS/nixpkgs/commit/534c138962a17cbb25725c72115cc1992e42164f) | `python310Packages.zcs: 0.1.17 -> 0.1.18`                                 |
| [`34c3eb5f`](https://github.com/NixOS/nixpkgs/commit/34c3eb5f328b7ddbcdca25c8f5ca930177721d96) | `naabu: 2.0.7 -> 2.0.8`                                                   |
| [`3bfb2046`](https://github.com/NixOS/nixpkgs/commit/3bfb2046fd733d0523352146a8735ba65120d5e9) | `linuxKernel.packages.linux_5_18.mwprocapture: mark broken`               |
| [`05fc9903`](https://github.com/NixOS/nixpkgs/commit/05fc99037caccdaf7212ed55137359204f7ebd99) | `linuxKernel.packages.linux_5_18.can-isotp: mark broken`                  |
| [`0beea3a0`](https://github.com/NixOS/nixpkgs/commit/0beea3a05a520799e01bfb523279efbb5681bbb2) | `bambootracker: 0.5.0 -> 0.5.1`                                           |
| [`c0ec5a04`](https://github.com/NixOS/nixpkgs/commit/c0ec5a04a57f1da2c701f748ff7e8203331f7afc) | `gamemode: 1.6.1 -> 1.7`                                                  |
| [`53d3769f`](https://github.com/NixOS/nixpkgs/commit/53d3769f18ddb401343da83d441add97903f139d) | `python310Packages.glfw: 2.5.3 -> 2.5.4`                                  |
| [`10164a5d`](https://github.com/NixOS/nixpkgs/commit/10164a5de120724033a47cea3b07c70ec100e879) | `upower: 0.99.19 -> 1.90.0`                                               |
| [`2133278f`](https://github.com/NixOS/nixpkgs/commit/2133278f96966989cb7693cc289def2bedfd6c05) | `nixosTests.podgrab: fix failing test`                                    |
| [`b5362aac`](https://github.com/NixOS/nixpkgs/commit/b5362aac78e9a3f2f6edbc7b4dd005457081acf4) | `lxqt.pcmanfm-qt: add libexif dependence`                                 |
| [`7eeaecfa`](https://github.com/NixOS/nixpkgs/commit/7eeaecfaea6f5a76cdd76f6a77f04fbc9bf43556) | `arcanist: pin php to 8.0`                                                |
| [`8c21ef98`](https://github.com/NixOS/nixpkgs/commit/8c21ef98fba4b2560a663345cac6782447a36575) | `ncnn: 20220216 -> 20220721`                                              |
| [`e199adde`](https://github.com/NixOS/nixpkgs/commit/e199adde73bdaec179185debdeeaa0ff36618e92) | `organicmaps: 2022.06.18-2 -> 2022.06.29-3`                               |
| [`ae74cf3b`](https://github.com/NixOS/nixpkgs/commit/ae74cf3bb5b00801c6b34a0d2a6b809ba0d30355) | `mpd: fix 0.23.8 on darwin`                                               |
| [`3fd4bfbe`](https://github.com/NixOS/nixpkgs/commit/3fd4bfbee719ad38d96048e0cb7fc311c698c806) | `faircamp: unstable-2022-03-20 -> unstable-2022-07-22`                    |
| [`69036df9`](https://github.com/NixOS/nixpkgs/commit/69036df904c92bdd73bf3e689956dcbcdd02045c) | `carla: 2.4.3 -> 2.5.0`                                                   |
| [`83e1754b`](https://github.com/NixOS/nixpkgs/commit/83e1754b23c3f9561a0753fc3a9d84d0549a0f8a) | `autotiling-rs: init at 0.1.3`                                            |
| [`65399c47`](https://github.com/NixOS/nixpkgs/commit/65399c47424c7b33d90c6a3b581b38ed2f66b859) | `nixos/syncthing: don't leak the secret API key in process listings`      |
| [`3b1ea472`](https://github.com/NixOS/nixpkgs/commit/3b1ea472d3d535dbaec7a8d62afcb6324d69680f) | `ft2-clone: 1.55 -> 1.56`                                                 |
| [`071f18d7`](https://github.com/NixOS/nixpkgs/commit/071f18d7cd7d05a29c6d4ec105cdfecee6d5dbe5) | `pt2-clone: 1.49 -> 1.50`                                                 |
| [`16108ff7`](https://github.com/NixOS/nixpkgs/commit/16108ff74a5949ab43851be17860a177766feab0) | `nixos/jenkins-job-builder: set serviceConfig.Type = "oneshot"`           |
| [`01d30cca`](https://github.com/NixOS/nixpkgs/commit/01d30cca0e3568f0321205e1e03c83060f6e745d) | `python310Packages.homematicip: 1.0.5 -> 1.0.6`                           |
| [`2458b102`](https://github.com/NixOS/nixpkgs/commit/2458b102be66712cfcd7dccfa46e5de0dc7920cd) | `_7zz: 22.00 -> 22.01`                                                    |
| [`217e40ec`](https://github.com/NixOS/nixpkgs/commit/217e40ec41eee9c115128d80f9ec0c0cee965917) | `_7zz: improve update.sh script`                                          |
| [`29107c38`](https://github.com/NixOS/nixpkgs/commit/29107c388ab49aea062d272fba2ca4bf9b44e3d9) | `rbspy: fix compilation with rust 1.62`                                   |
| [`54173e95`](https://github.com/NixOS/nixpkgs/commit/54173e95c3b09ee85f2cc7fec75740f28a440a69) | `python310Packages.tatsu: 5.8.1 -> 5.8.2`                                 |
| [`e2759f1b`](https://github.com/NixOS/nixpkgs/commit/e2759f1b17b117f4b9c7cf19035d3a6f03b34b8e) | ``uniffi-bindgen: use `cargoLock.lockFile```                              |
| [`a070b2e8`](https://github.com/NixOS/nixpkgs/commit/a070b2e8737b9d481b0b10dccc701e06827d2480) | `uniffi-bindgen: add update script`                                       |
| [`8e4221a1`](https://github.com/NixOS/nixpkgs/commit/8e4221a177eb9cf9fe8ad7135d3557ba39846085) | `minijail: 17 -> 18`                                                      |
| [`c1184b13`](https://github.com/NixOS/nixpkgs/commit/c1184b1383eb82f61f9097b9630e4c1d71484625) | `minijail: add meta.changelog`                                            |
| [`5df33d02`](https://github.com/NixOS/nixpkgs/commit/5df33d021668f7422425e1286c5f6c552314c956) | `crosvm: add support for virgl_renderer{,_next}`                          |
| [`9bbadc1e`](https://github.com/NixOS/nixpkgs/commit/9bbadc1ee409b4a52512a1a1522c13831e7c925b) | `osu-lazer: 2022.719.0 -> 2022.723.0`                                     |
| [`272768d5`](https://github.com/NixOS/nixpkgs/commit/272768d5b8f6d8980c0fb893ca00774c729b82ed) | `python310Packages.adafruit-platformdetect: 3.25.0 -> 3.26.0`             |
| [`d915c374`](https://github.com/NixOS/nixpkgs/commit/d915c3746d707844a2d05ec4cfa8758b72e91ff0) | `cargo-make: 0.35.13 -> 0.35.15`                                          |
| [`dbddcbb2`](https://github.com/NixOS/nixpkgs/commit/dbddcbb2ef6e7e9184d17d230f1221a0fbbc7313) | `_1password: 2.5.1 -> 2.6.0`                                              |
| [`ffdf4f9d`](https://github.com/NixOS/nixpkgs/commit/ffdf4f9d5f127fde5d6b818cea32bb2466e48a8a) | `grafana: 9.0.3 -> 9.0.4`                                                 |
| [`8aebac5e`](https://github.com/NixOS/nixpkgs/commit/8aebac5ecad3f1a68b9f1968345ca7eaf2c0122d) | `watchexec: 1.19.0 -> 1.20.4`                                             |
| [`3a66ca46`](https://github.com/NixOS/nixpkgs/commit/3a66ca46a0f6143b5aa5c29bfef316c0f0eb480c) | `terracognita: 0.7.4 -> 0.7.6`                                            |
| [`c7488029`](https://github.com/NixOS/nixpkgs/commit/c748802922909f902da2b89bf8a2a004218fd0ed) | `postgresqlPackages.pgroonga: 2.3.6 -> 2.3.7`                             |
| [`b6d808aa`](https://github.com/NixOS/nixpkgs/commit/b6d808aa846968acc98afa74c2ff4c456f1ecb8f) | `certigo: 1.15.1 -> 1.16.0`                                               |
| [`8ea2c95a`](https://github.com/NixOS/nixpkgs/commit/8ea2c95ad8bec664a6400084602251696b2945b5) | `postgresqlPackages.postgis: 3.2.1 -> 3.2.2`                              |
| [`d23282a2`](https://github.com/NixOS/nixpkgs/commit/d23282a2f559ff4860e2b58e210cc7779c65d1ee) | `rainloop-{community,standard}: patch CVE-2022-29360`                     |
| [`10385021`](https://github.com/NixOS/nixpkgs/commit/10385021e40f4ef410d6698c752fb02ae9efeeeb) | `godns: 2.8.4 -> 2.8.5`                                                   |
| [`61aeb83a`](https://github.com/NixOS/nixpkgs/commit/61aeb83a5b8edfccf06a148d97978862c56c5a5e) | `python310Packages.twilio: 7.11.0 -> 7.12.0`                              |
| [`c8d7f309`](https://github.com/NixOS/nixpkgs/commit/c8d7f30927e94a80fd4084ea188a68d1efc2bac8) | `python310Packages.hahomematic: 2022.7.11 -> 2022.7.12`                   |
| [`a3aef504`](https://github.com/NixOS/nixpkgs/commit/a3aef504aa0b66eeae2bad25aa32b8046d207f19) | `nheko: 0.9.3 -> 0.10.0`                                                  |
| [`cb608633`](https://github.com/NixOS/nixpkgs/commit/cb608633e866c6cefaedd02eb36d0708938cf50a) | `mtxclient: 0.7.0 -> 0.8.0`                                               |
| [`e4c840d4`](https://github.com/NixOS/nixpkgs/commit/e4c840d4425e2da51155132eaf96fcff1655b019) | `exodus: 22.6.17 -> 22.7.15`                                              |
| [`a1bf8ce8`](https://github.com/NixOS/nixpkgs/commit/a1bf8ce827fdd1996cc75f7971fcdb0f61336cad) | `fava: 1.21 -> 1.22.1`                                                    |
| [`eef8ecf0`](https://github.com/NixOS/nixpkgs/commit/eef8ecf0ab967ac31ad5e453e400a1ddc41f5af2) | `spicetify-cli: 2.10.2 -> 2.11.1`                                         |
| [`3f4624cf`](https://github.com/NixOS/nixpkgs/commit/3f4624cf20e79446b93a71267b62321da0b35490) | `vscode-extensions.wix.vscode-import-cost: 2.15.0 -> 3.3.0`               |
| [`9027613f`](https://github.com/NixOS/nixpkgs/commit/9027613f4ae4d20a189336543df886965a67a398) | `vscode-extensions.streetsidesoftware.code-spell-checker: 2.2.5 -> 2.3.1` |
| [`920fa303`](https://github.com/NixOS/nixpkgs/commit/920fa3031d62d1fde3970efbc8f8d039ec1bc1ce) | `vscode-extensions.pkief.material-icon-theme: 4.16.0 -> 4.19.0`           |
| [`356b0467`](https://github.com/NixOS/nixpkgs/commit/356b04671f92c40339be621e063976d882900f2f) | `vscode-extensions.redhat.vscode-yaml: 1.7.0 -> 1.9.1`                    |
| [`35327dd5`](https://github.com/NixOS/nixpkgs/commit/35327dd5e7132ce4b0c2a9b4ee0aa496e42e8832) | `vscode-extensions.ms-azuretools.vscode-docker: 1.22.0 -> 1.22.1`         |
| [`ad3599c8`](https://github.com/NixOS/nixpkgs/commit/ad3599c8066067e15ccc801bc9f064e7fbfaa311) | `vscode-extensions.jock.svg: 1.4.17 -> 1.4.19`                            |
| [`91e80ce0`](https://github.com/NixOS/nixpkgs/commit/91e80ce0f4b0d0a096f1731abfe0884e42bcebac) | `vscode-extensions.eamodio.gitlens: 12.1.1 -> 12.1.2`                     |
| [`95bf014f`](https://github.com/NixOS/nixpkgs/commit/95bf014f8803e3fd3cb738ad0553bbea109914c8) | `python310Packages.pylink-square: 0.13.0 -> 0.14.1`                       |
| [`28746f92`](https://github.com/NixOS/nixpkgs/commit/28746f92c9853c96531cb4f2894bf5fc42675e9b) | `python310Packages.types-setuptools: 63.2.0 -> 63.2.1`                    |
| [`9ae26e79`](https://github.com/NixOS/nixpkgs/commit/9ae26e798e3cba55d88189fa3023329839b1c9e0) | `python310Packages.mailchecker: 4.1.17 -> 4.1.18`                         |
| [`a4e05bdc`](https://github.com/NixOS/nixpkgs/commit/a4e05bdc8a3742bcf85dde8eb04aae80a105636d) | `jellyfin-ffmpeg: 5.0.1-7 -> 5.0.1-8`                                     |
| [`4f006ccc`](https://github.com/NixOS/nixpkgs/commit/4f006ccc5c975a41d651e3b9805b4ec93c5667c4) | `python310Packages.srsly: 2.4.3 -> 2.4.4`                                 |
| [`24ec38e6`](https://github.com/NixOS/nixpkgs/commit/24ec38e629b038cb99bcdc4f6692298f7b4e8c2f) | `python310Packages.fastprogress: 1.0.2 -> 1.0.3`                          |
| [`f1fb1905`](https://github.com/NixOS/nixpkgs/commit/f1fb190556ae7ed8e43c82dd10fb41de62a02bf9) | `python310Packages.cyclonedx-python-lib: 2.6.0 -> 2.7.0`                  |
| [`5f66ce8d`](https://github.com/NixOS/nixpkgs/commit/5f66ce8d65128738bf07b9d68eb0011ace111a22) | `python310Packages.plugwise: 0.20.1 -> 0.21.0`                            |
| [`a38928f1`](https://github.com/NixOS/nixpkgs/commit/a38928f186c199f8f249cab671acfef9b9c95d56) | `python310Packages.pydal: 20220720.1 -> 20220721.1`                       |
| [`fd3eecd6`](https://github.com/NixOS/nixpkgs/commit/fd3eecd6b0e5d8283b00d8f289ebeed919507d60) | `python310Packages.pyinsteon: 1.1.3 -> 1.2.0`                             |
| [`699484a3`](https://github.com/NixOS/nixpkgs/commit/699484a3dfa61221fc9b94d301908a12b7b1d97c) | `python310Packages.dvc-objects: 0.1.1 -> 0.1.4`                           |
| [`8937f57f`](https://github.com/NixOS/nixpkgs/commit/8937f57f7e26267977b9325f85ca62164cce038d) | `python310Packages.pysigma-backend-splunk: 0.3.4 -> 0.3.5`                |
| [`163e97cf`](https://github.com/NixOS/nixpkgs/commit/163e97cf9b3d86061c00221b8292fb407c9ed020) | `python310Packages.motionblinds: 0.6.10 -> 0.6.11`                        |
| [`9f191401`](https://github.com/NixOS/nixpkgs/commit/9f191401d42511748bee8e0bc1569273e36cd49b) | `wayshot: init at 1.1.9`                                                  |
| [`347c8314`](https://github.com/NixOS/nixpkgs/commit/347c8314795cbfb5ed5dbfae98c74310bd0fe18c) | `millet: fix hash`                                                        |
| [`106a7250`](https://github.com/NixOS/nixpkgs/commit/106a7250f83e6d3741c6ff8144b9126b8e652a47) | `python310Packages.pysigma: 0.6.6 -> 0.6.8`                               |
| [`63297043`](https://github.com/NixOS/nixpkgs/commit/632970438c6b9e4ede220ff21250cd76fcb2c24c) | `dotter: 0.12.11 -> 0.12.13`                                              |
| [`fca7fb83`](https://github.com/NixOS/nixpkgs/commit/fca7fb8305fe9170b4945df3cf17c8bde2727548) | `dcnnt: 0.7.0 -> 0.7.1`                                                   |
| [`0a44f546`](https://github.com/NixOS/nixpkgs/commit/0a44f5469566e1fcfb3334f3726ae1310f617f83) | `ipxe: fix cross-compilation`                                             |
| [`532ed62c`](https://github.com/NixOS/nixpkgs/commit/532ed62cbe8b1bf05a05ae96d02e4f4d3b30ad18) | `python310Packages.plaid-python: 9.7.0 -> 9.8.0`                          |
| [`63c87190`](https://github.com/NixOS/nixpkgs/commit/63c871907375170d97e686d83b4360374231a374) | `python310Packages.plexapi: 4.11.2 -> 4.12.0`                             |
| [`a62e7e74`](https://github.com/NixOS/nixpkgs/commit/a62e7e74ee866d27b9e39865c2a5b346b5bd7666) | `python310Packages.icecream: 2.1.2 -> 2.1.3`                              |
| [`7e0d8135`](https://github.com/NixOS/nixpkgs/commit/7e0d8135dd0877a0ce47d3b17fc055475f4a65ca) | `mate: expose all packages in a scope`                                    |
| [`077f3efe`](https://github.com/NixOS/nixpkgs/commit/077f3efe82baedcc2f2f31876f7d3d566d49ee42) | `python310Packages.types-requests: 2.28.2 -> 2.28.3`                      |
| [`cc18e3ce`](https://github.com/NixOS/nixpkgs/commit/cc18e3ce0ea384905443a23bd0409a3707ebebf1) | `anki-bin: 2.1.52 -> 2.1.54`                                              |
| [`2857f248`](https://github.com/NixOS/nixpkgs/commit/2857f248c41d8a1754dd45c023fc5b48b2bc2c94) | `python310Packages.types-pytz: 2022.1.1 -> 2022.1.2`                      |
| [`ed649931`](https://github.com/NixOS/nixpkgs/commit/ed649931c580efb834cfbe89d320496b3b5444b8) | `python310Packages.aioshelly: 2.0.0 -> 2.0.1`                             |
| [`baa890fc`](https://github.com/NixOS/nixpkgs/commit/baa890fcedd70ce0f1979f265277d05c936c412d) | `python310Packages.pip-api: 0.0.29 -> 0.0.30`                             |
| [`13580965`](https://github.com/NixOS/nixpkgs/commit/135809658f2b2d23d25011c730c9e7501c83e066) | `python310Packages.asf-search: 5.0.1 -> 5.0.2`                            |
| [`f18b419a`](https://github.com/NixOS/nixpkgs/commit/f18b419aa1ce0da1a01e0b1549aa310acddf200c) | `slowhttptest: 1.8.2 -> 1.9.0`                                            |
| [`19326e45`](https://github.com/NixOS/nixpkgs/commit/19326e453b1174aa5d494acb5bc2eaef5d6ef187) | `roswell: change platform to unix`                                        |
| [`0c2efbe5`](https://github.com/NixOS/nixpkgs/commit/0c2efbe5b6275a1d0c3e67494e86eea068b7e064) | `vscode-extensions.prisma.prisma: 3.14.0 -> 4.1.0`                        |
| [`f22c5e38`](https://github.com/NixOS/nixpkgs/commit/f22c5e38e74a28ea6049ec8beabeb0d19d2b647c) | `uniffi-bindgen: 0.17.0 -> 0.19.3`                                        |
| [`17585ec0`](https://github.com/NixOS/nixpkgs/commit/17585ec0dc5a608857852a7fbc522f0a99817dba) | `barman: 3.0.0 -> 3.0.1`                                                  |
| [`ffd3da44`](https://github.com/NixOS/nixpkgs/commit/ffd3da44f346f8b7fa2c07761459389904098b1c) | `defaultGemConfig.grpc: Fix build on v1.48.0+`                            |
| [`75c93468`](https://github.com/NixOS/nixpkgs/commit/75c934681c7bcf3975f7d0200bd953554d3c6bf7) | `gnome-frog: init at 1.1.3`                                               |
| [`1da8ad17`](https://github.com/NixOS/nixpkgs/commit/1da8ad17259f42d7b086fc8f2e26f6b02c6e3e28) | `maintainers: add foo-dogsquared`                                         |