### PR TITLE
chore(flake/nixpkgs): `e494a908` -> `5a0e0d73`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658648081,
-        "narHash": "sha256-RL5nr4Xhp0zQeEGG/I3t3FmqaI9QrBg5PH31NF+7A/A=",
+        "lastModified": 1658737577,
+        "narHash": "sha256-xosJ5nJT9HX+b6UWsSX6R+ap4AdZOCrl/r+IKFp2ASQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e494a908e8895b9cba18e21d5fc83362f64b3f6a",
+        "rev": "5a0e0d73b944157328d54c4ded1cf2f0146a86a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`5a0e0d73`](https://github.com/NixOS/nixpkgs/commit/5a0e0d73b944157328d54c4ded1cf2f0146a86a5) | `libsForQt5.plasmaMobileGear: 22.04 -> 22.06`                                    |
| [`e823fb4f`](https://github.com/NixOS/nixpkgs/commit/e823fb4f4fb4423deb96c0afb62799bef27aa26e) | `lighttpd: 1.4.64 -> 1.4.65`                                                     |
| [`27eba8bf`](https://github.com/NixOS/nixpkgs/commit/27eba8bf13c0817d771d2aa6403a5bd079134cf4) | `ocamlPackages.camlp4: init at 4.14+1`                                           |
| [`ba12210b`](https://github.com/NixOS/nixpkgs/commit/ba12210b09d92830e3b4133fa8592a6e5e5715c1) | `python310Packages.mypy-boto3-s3: 1.24.0 -> 1.24.36.post1`                       |
| [`3707cc5a`](https://github.com/NixOS/nixpkgs/commit/3707cc5a0d6339811ca6a525ea0d69b65879839b) | `Revert "backport-action: 0.0.5 -> 0.0.8"`                                       |
| [`6e666342`](https://github.com/NixOS/nixpkgs/commit/6e6663423988d780011288e26a1ad9ec54db5c63) | `xrootd: fix missing etc contents and default externalEtc to "/etc" (#181971)`   |
| [`c51440bf`](https://github.com/NixOS/nixpkgs/commit/c51440bf8bd7e45b245f9220c690c98fd6ebcfe8) | `soapyrtlsdr: add luizribeiro as maintainer`                                     |
| [`55fdc0ce`](https://github.com/NixOS/nixpkgs/commit/55fdc0ce3c933a1115e6c627f8883fe0baf3e5ad) | `maintainers: add luizribeiro`                                                   |
| [`b03edd85`](https://github.com/NixOS/nixpkgs/commit/b03edd851cff4c7d47023ad1757b674b0f492ddc) | `soapyrtlsdr: fix build on Darwin`                                               |
| [`09bfd170`](https://github.com/NixOS/nixpkgs/commit/09bfd170e066ec58f1daa0e7d57a24730d9ba6fb) | `python310Packages.pex: 2.1.99 -> 2.1.100`                                       |
| [`b4e5d045`](https://github.com/NixOS/nixpkgs/commit/b4e5d045184f7bcac6260fbea51606d5c39b7dec) | `soapyrtlsdr: use overlay-style mkDerivation`                                    |
| [`6fb81340`](https://github.com/NixOS/nixpkgs/commit/6fb81340dff7a24377134b27be040779b04f4c52) | `python310Packages.hahomematic: 2022.7.12 -> 2022.7.13`                          |
| [`b22383a4`](https://github.com/NixOS/nixpkgs/commit/b22383a415d9c5d3ddd64a245eda8333c5eb2576) | `soapyrtlsdr: 0.3.0 -> 0.3.3`                                                    |
| [`2d80354d`](https://github.com/NixOS/nixpkgs/commit/2d80354d7f6828403784449c84200953b1eb6f62) | `heroku: 7.50.2 -> 7.60.2`                                                       |
| [`16bc1830`](https://github.com/NixOS/nixpkgs/commit/16bc1830e522a2a77be956960affee4adb966251) | `tiler: init at 0.5.7`                                                           |
| [`6bc63d94`](https://github.com/NixOS/nixpkgs/commit/6bc63d94a6fe79afbe42e3de89ef0723b8a614b4) | `popeye: 0.10.0 -> 0.10.1`                                                       |
| [`15e86066`](https://github.com/NixOS/nixpkgs/commit/15e860664e1e0d43de740888328f88e4ca24eab5) | `mongodb-tools: 100.5.3 -> 100.5.4`                                              |
| [`bcc31c98`](https://github.com/NixOS/nixpkgs/commit/bcc31c9869b8ee051bbfca60ec046bae8330f815) | `jd-diff-patch: 1.5.2 -> 1.6.0`                                                  |
| [`17434433`](https://github.com/NixOS/nixpkgs/commit/174344338ca8722b03e129520c8efa4f0e6982a1) | `rtl8189fs: init at 2022-05-20`                                                  |
| [`3510c633`](https://github.com/NixOS/nixpkgs/commit/3510c633c8d3e0560056e3be6cf3d0cde48c6fc8) | `ffmpeg_5-full: fix build`                                                       |
| [`b29670fb`](https://github.com/NixOS/nixpkgs/commit/b29670fbf8f31633204fa7dc865601686db3b5a6) | `ffmpeg_5: 5.0.1 -> 5.1`                                                         |
| [`bf182e4d`](https://github.com/NixOS/nixpkgs/commit/bf182e4decd7214ea735f06ad86d60f465d75b8c) | `tere: init at 1.1.0`                                                            |
| [`83322150`](https://github.com/NixOS/nixpkgs/commit/83322150b0f91f9a555d4b91a912a4854355b16f) | `maintainers: add ProducerMatt`                                                  |
| [`fee30801`](https://github.com/NixOS/nixpkgs/commit/fee30801b2ca2166772c61e797604828addd4afe) | `backport-action: 0.0.5 -> 0.0.8`                                                |
| [`1e079ca5`](https://github.com/NixOS/nixpkgs/commit/1e079ca5ce554a8d54e5ef714f4d06870c47f627) | `kanata: init at 1.0.5 (#182358)`                                                |
| [`6795d5c3`](https://github.com/NixOS/nixpkgs/commit/6795d5c3e81fef18bbf4f4b11de32f7eec139fb2) | `cw: init at 4.1.1`                                                              |
| [`20e9eb66`](https://github.com/NixOS/nixpkgs/commit/20e9eb6606928bdf73bf88c468723d7ce2210e9e) | `maintainers: add onthestairs`                                                   |
| [`df10a2d0`](https://github.com/NixOS/nixpkgs/commit/df10a2d05568a75f36709995f06f90d86204015c) | `python310Packages.fakeredis: 1.8.1 -> 1.8.2`                                    |
| [`764a1481`](https://github.com/NixOS/nixpkgs/commit/764a14817a44b29fd2bf91c65e35e0fc6967dc18) | `qownnotes: Remove dtzWill as maintainer`                                        |
| [`37022883`](https://github.com/NixOS/nixpkgs/commit/370228834d94bc6cbb61a527bb58a93acd298182) | `qownnotes: 22.7.1 -> 22.7.6`                                                    |
| [`b1d98133`](https://github.com/NixOS/nixpkgs/commit/b1d98133c0974f939922cc68726fec8d087ab439) | `benthos: init at 4.3.0`                                                         |
| [`2484f579`](https://github.com/NixOS/nixpkgs/commit/2484f57981183660cda0202bfd0531fa233020d4) | `qc71_laptop: init at unstable-2022-06-01`                                       |
| [`8d14baf3`](https://github.com/NixOS/nixpkgs/commit/8d14baf37d73b31e32b89e5286f8d8542484a4ad) | `boringtun: 0.5.1 -> 0.5.2`                                                      |
| [`997c1258`](https://github.com/NixOS/nixpkgs/commit/997c1258bc25589fe4c87b6099bbd3fbf62fc8cf) | `miniscript: unstable-2020-12-01 -> unstable-2022-07-19`                         |
| [`c55fac77`](https://github.com/NixOS/nixpkgs/commit/c55fac773bf0c5885feab6616def3780d46d68aa) | `ocamlPackages.qcheck: 0.18 → 0.19.1`                                            |
| [`8e9bab03`](https://github.com/NixOS/nixpkgs/commit/8e9bab032d8e6c4c84ea4c39a1e24c5fa7bd62d0) | `bitcoin-unlimited: 1.9.2.0 -> 1.10.0.0`                                         |
| [`42542b2e`](https://github.com/NixOS/nixpkgs/commit/42542b2e49e12bfc604f3fbb04c4f5b1ee7863ef) | `lldpd: 1.0.13 -> 1.0.14`                                                        |
| [`fadb0b83`](https://github.com/NixOS/nixpkgs/commit/fadb0b83412e3a5c886160a67987527b1437fb0e) | `smplayer: 22.2.0 → 22.7.0`                                                      |
| [`17e93b09`](https://github.com/NixOS/nixpkgs/commit/17e93b090e5c1470b2c45617c48f85b41df7e224) | `services.murmur: add openFirewall option`                                       |
| [`a1537064`](https://github.com/NixOS/nixpkgs/commit/a15370643d6c539bdb782a9e02d37082248d8297) | `editorconfig-checker: 2.5.0 -> 2.6.0`                                           |
| [`51c9f4c3`](https://github.com/NixOS/nixpkgs/commit/51c9f4c338b3618fe5791465aa41d686270c59ef) | `jc: 1.20.2 -> 1.20.3`                                                           |
| [`f6c3d27a`](https://github.com/NixOS/nixpkgs/commit/f6c3d27a13103e8a58e7a256e535bfad3c1508e2) | `facetimehd: unstable-2020-04-16 -> 0.5.18`                                      |
| [`a102efba`](https://github.com/NixOS/nixpkgs/commit/a102efba924d87452e507bb304be81fb0b7f8ee2) | `qremotecontrol-server: 2.4.2 -> unstable-2014-11-05, use Qt5`                   |
| [`969f5256`](https://github.com/NixOS/nixpkgs/commit/969f5256830f1397a7894e36add77681240306c5) | `qremotecontrol-server: 2.4.1 -> 2.4.2`                                          |
| [`c4d6c900`](https://github.com/NixOS/nixpkgs/commit/c4d6c900f490b82d252540cc5a79e51516a924cb) | `iosevka-bin: 15.6.0 -> 15.6.1`                                                  |
| [`329c52b4`](https://github.com/NixOS/nixpkgs/commit/329c52b41633ede32cb005f1e02a4c2f21442008) | `parsedmarc: expose as an application`                                           |
| [`cdd0cde3`](https://github.com/NixOS/nixpkgs/commit/cdd0cde3051ccf87967085cd5c55e2be62c15dec) | `python3Packages.grpcio: add patch to fix armv6l build`                          |
| [`98f180b0`](https://github.com/NixOS/nixpkgs/commit/98f180b0e33328d7a30991bd99d295dd9348c82e) | `nixos/hedgedoc: set good default for ldap.tlsca`                                |
| [`1a7f6b40`](https://github.com/NixOS/nixpkgs/commit/1a7f6b407040ff521a958d8ff7872ddee0dfeb1d) | `nixos/hedgedoc: do not require to set searchAttributes when ldap login is used` |
| [`c661586c`](https://github.com/NixOS/nixpkgs/commit/c661586c95354c7a5563dcc664a86a2d86eb60ea) | `python310Packages.ghapi: 0.1.21 -> 1.0.0`                                       |
| [`0d5b71d7`](https://github.com/NixOS/nixpkgs/commit/0d5b71d7904e6f96277ab32d4fdcabe2cdb6250f) | `libsForQt5.qtstyleplugin-kvantum: add xdg dirs support`                         |
| [`8ccaffe2`](https://github.com/NixOS/nixpkgs/commit/8ccaffe21a33506bf3d7ca817cdd57ed101bf036) | `python3Packages.reorder-python-imports: 3.1.0 -> 3.8.1`                         |
| [`dd107ca5`](https://github.com/NixOS/nixpkgs/commit/dd107ca580b590ccd25d6961c93a34cc71425799) | `lua5_4: add patch for CVE-2022-33099`                                           |
| [`43f35306`](https://github.com/NixOS/nixpkgs/commit/43f353062037030a956c3ac6911f1e0613824fe5) | `pikchr: unstable-2022-01-30 -> unstable-2022-06-20`                             |
| [`d078ac5c`](https://github.com/NixOS/nixpkgs/commit/d078ac5c8abb68a1f1f4ae7a5f79a9ee2025cd79) | `dagger: add myself as maintainer`                                               |
| [`74d7b781`](https://github.com/NixOS/nixpkgs/commit/74d7b7810ed25386902fabed3193bc52e32f8ac1) | `cpm: download from GitHub releases instead of GitHub source code`               |
| [`4ccc2c23`](https://github.com/NixOS/nixpkgs/commit/4ccc2c2397a0b64e74781cb9730fd0c5a76be813) | `eksctl: 0.105.0 -> 0.106.0`                                                     |
| [`7d9ba084`](https://github.com/NixOS/nixpkgs/commit/7d9ba084b9ea7910bdeb64ba282e5e138171f1e0) | `winbox: 3.35 -> 3.37`                                                           |
| [`cd4f98d0`](https://github.com/NixOS/nixpkgs/commit/cd4f98d03fe7718a7f6af93dd99270dff1553fa9) | `lxd: 5.3 -> 5.4`                                                                |
| [`953bc968`](https://github.com/NixOS/nixpkgs/commit/953bc968a9b345b35d45471c1a21aa682f6c01f2) | `cloud-nuke: 0.12.2 -> 0.16.1`                                                   |
| [`54b1758d`](https://github.com/NixOS/nixpkgs/commit/54b1758da4100eb58f3fd0db155d2ac2eafae263) | `ytcc: 2.5.5 -> 2.6.0`                                                           |
| [`7a6e1aa6`](https://github.com/NixOS/nixpkgs/commit/7a6e1aa612a9217fb6ec23a54103ecf2e7fdc72a) | `eget: 1.1.0 -> 1.2.0`                                                           |
| [`418eded8`](https://github.com/NixOS/nixpkgs/commit/418eded8c3149571142578880dffaaa1e4f7186d) | `brave: 1.41.99 -> 1.41.100`                                                     |
| [`5f564536`](https://github.com/NixOS/nixpkgs/commit/5f564536bb640b24c9e7aa39ac75cf1d20aacd7a) | `zcash: 5.0.0 -> 5.1.0`                                                          |
| [`59de06d0`](https://github.com/NixOS/nixpkgs/commit/59de06d0933a8fa74c5641041f1ce1308e632751) | `nixos/tests/signal-desktop: Fix the sqlite3 part of the test (regressed)`       |
| [`51721af3`](https://github.com/NixOS/nixpkgs/commit/51721af3197e4502eb234ac73ce3c03f8ed5efa2) | `wasynth: 0.11.0 -> 0.12.0`                                                      |
| [`5444bc1f`](https://github.com/NixOS/nixpkgs/commit/5444bc1f9a31649ee54d3a63929d2410106b7eea) | `scala-cli: 0.1.9 -> 0.1.10`                                                     |
| [`ac5294fe`](https://github.com/NixOS/nixpkgs/commit/ac5294fe01a119db689668be0fdf4c1aff65b4de) | `python310Packages.reqif: python3 -> python`                                     |
| [`c06b43df`](https://github.com/NixOS/nixpkgs/commit/c06b43dfefbb6a69cfcf46ca4d8161f267ce4acd) | `colloid-kde: init at unstable-2022-07-13`                                       |
| [`940e9e00`](https://github.com/NixOS/nixpkgs/commit/940e9e002ee800664d0ceaacc3192d9be0cb3ced) | `colloid-icon-theme: init at 2022-04-22`                                         |
| [`76ce833f`](https://github.com/NixOS/nixpkgs/commit/76ce833f804c4bb87511b1c35b9d4f8f77861480) | `wsl-open: 2.1.1 -> 2.2.1`                                                       |
| [`ee7dc5f5`](https://github.com/NixOS/nixpkgs/commit/ee7dc5f5f62fb88b42f4a58eae5e36aafe43ddc2) | `intel-media-driver: 22.4.3 -> 22.5.0`                                           |
| [`331c54c7`](https://github.com/NixOS/nixpkgs/commit/331c54c75a5cc8a795893c1f31524520a9dadb4d) | `fly: 7.8.1 -> 7.8.2`                                                            |
| [`f7f2e41d`](https://github.com/NixOS/nixpkgs/commit/f7f2e41dd177d0adb25978f9211e4ec34aa84a94) | `siglo: init at 0.9.9`                                                           |
| [`f07e1733`](https://github.com/NixOS/nixpkgs/commit/f07e1733af1babfe3f4a9ff2cabcb5e0bbb54233) | `gatt: init at 0.2.6`                                                            |
| [`42d07984`](https://github.com/NixOS/nixpkgs/commit/42d07984ea86513ca79a6d09909e26687a2032cd) | `dagger: 0.2.20->0.2.25`                                                         |
| [`2c9c33f1`](https://github.com/NixOS/nixpkgs/commit/2c9c33f1360ad1c9fbafd5d2f0bf55e583d01d1f) | `mprime: 29.8b7 → 30.8b15`                                                       |
| [`d97a0394`](https://github.com/NixOS/nixpkgs/commit/d97a0394dcecf7813de1e8359d6a987ce0af73b8) | `python310Packages.pyaudio: 0.2.11 -> 0.2.12`                                    |
| [`3e10c3cf`](https://github.com/NixOS/nixpkgs/commit/3e10c3cfa7a5c77947e656c5b0bcec5971a833c2) | `citrix_workspace: 22.05.0 -> 22.07.0`                                           |
| [`714182c2`](https://github.com/NixOS/nixpkgs/commit/714182c27ef985ffb59631fa70359ac7497b86a0) | `didu: init at 2.5.2`                                                            |
| [`73887113`](https://github.com/NixOS/nixpkgs/commit/7388711363b43ef97959020a0bd6195bc90b3630) | `nixos/resolved: convert option docs to MD`                                      |
| [`3fdde458`](https://github.com/NixOS/nixpkgs/commit/3fdde458259a25526e9ab2a7bd4840e4a6f4400a) | `nixos/oci-containers: convert option docs to MD`                                |
| [`875acd1c`](https://github.com/NixOS/nixpkgs/commit/875acd1c2b2deb460fddc0afaae93cdb07041f07) | `nixos/qt5: convert option docs to MD`                                           |
| [`e445ccc5`](https://github.com/NixOS/nixpkgs/commit/e445ccc5aa25bb9bd154b426974c504b13ba5d1a) | `python310Packages.google-cloud-videointelligence: 2.7.1 -> 2.8.0`               |
| [`717ca91a`](https://github.com/NixOS/nixpkgs/commit/717ca91ade6b0f7f9eb93405786228f9d546c2a4) | `spdlog: enable static build through arguments`                                  |
| [`bfdb0b8a`](https://github.com/NixOS/nixpkgs/commit/bfdb0b8abeb4e06fc216c8aa4c6f9e30d02b7e22) | `maintainers: add hhydraa`                                                       |
| [`30508465`](https://github.com/NixOS/nixpkgs/commit/30508465d5aa11c174229c8fe053093ade417adc) | `warpd: init at 1.3.2`                                                           |
| [`b75199fa`](https://github.com/NixOS/nixpkgs/commit/b75199faf03a932c8a517f92fe35a2d722de7852) | `electron-mail: 4.14.0 -> 5.0.1`                                                 |
| [`231e13ab`](https://github.com/NixOS/nixpkgs/commit/231e13abb9cedc246da43b64a546dd0a0703d3f3) | `displaylink: 5.5.0-59.151 -> 5.6.0-59.176`                                      |
| [`abe093eb`](https://github.com/NixOS/nixpkgs/commit/abe093ebf6cd0d2a41e3aa7c45d83739b5d4b82f) | `mandelbulber: 2.27 -> 2.28`                                                     |
| [`2e40126e`](https://github.com/NixOS/nixpkgs/commit/2e40126eff24c0e539679e850034ba16effe40de) | `mmc-utils: unstable-2022-04-26 -> unstable-2022-07-13`                          |
| [`51be699b`](https://github.com/NixOS/nixpkgs/commit/51be699b02483deb1340f43743f5fed9b92c667a) | `manim: 0.15.2 -> 0.16.0`                                                        |
| [`6c6dd0e3`](https://github.com/NixOS/nixpkgs/commit/6c6dd0e32b6419ed1bc1c938185c41fe13149b66) | `python3Packages.classify-imports: init at 4.1.0`                                |
| [`cecee2a6`](https://github.com/NixOS/nixpkgs/commit/cecee2a6d90c2147d3b60f06f6b26a3c133bbabf) | `tautulli: 2.10.1 -> 2.10.2`                                                     |
| [`16a1651a`](https://github.com/NixOS/nixpkgs/commit/16a1651a4affd59157722e5488091d5e267d3465) | `gephi: 0.9.2 -> 0.9.6`                                                          |
| [`ef6d6d4c`](https://github.com/NixOS/nixpkgs/commit/ef6d6d4c4ae396b9cd4b3a7cb9d61067ff5dcb11) | ``Add `bash` to netdata service path``                                           |
| [`3e2996c3`](https://github.com/NixOS/nixpkgs/commit/3e2996c31e071ccedfebbe2c072aafac019a35b4) | `libstrophe: 0.12.0 -> 0.12.1`                                                   |
| [`549c0e99`](https://github.com/NixOS/nixpkgs/commit/549c0e99714911e6034dcf396703a6e50393d462) | `carp: 0.5.4 -> 0.5.5`                                                           |
| [`f1485955`](https://github.com/NixOS/nixpkgs/commit/f1485955248e4776febff40edcc95311649955f8) | `mopidy-youtube: 3.5 -> 3.6`                                                     |
| [`82dc6d63`](https://github.com/NixOS/nixpkgs/commit/82dc6d6354ca74c1a926ce63e0db23fb33be0d8e) | `frugal: 3.15.1 -> 3.15.4`                                                       |
| [`f276a443`](https://github.com/NixOS/nixpkgs/commit/f276a4435be2b497048c92fbe7d98a4fd32223ef) | `ergo: 4.0.30 -> 4.0.34`                                                         |
| [`2cc04cca`](https://github.com/NixOS/nixpkgs/commit/2cc04ccafe7775b498ac9fbf33e828ec2a098059) | `palemoon: Further limit build cores count`                                      |
| [`b17f5220`](https://github.com/NixOS/nixpkgs/commit/b17f522053dbd627bc599f9cab3a7f63200778de) | `palemoon: 31.1.0 -> 31.1.1`                                                     |
| [`5b70697f`](https://github.com/NixOS/nixpkgs/commit/5b70697f7ba0a3484c756a2544012d91082ef28d) | `lexend: init at 0.pre+date=2022-01-27`                                          |