### PR TITLE
chore(flake/home-manager): `0b7fd187` -> `0e2f7876`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658822905,
-        "narHash": "sha256-mBngYxNAaFe3Z9qe3aOmSrmVR/NRF9CEKPmG9S7e5Gs=",
+        "lastModified": 1658924727,
+        "narHash": "sha256-Fhh9FK9CvuCLxG1WkWJPoendDeXKI4gHYTfezo1n2Zg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0b7fd187e2dc8364cf31ed69347e4793c2d83a57",
+        "rev": "0e2f7876d2f2ae98a67d89a8bef8c49332aae5af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`0e2f7876`](https://github.com/nix-community/home-manager/commit/0e2f7876d2f2ae98a67d89a8bef8c49332aae5af) | `recoll: add module`                       |
| [`b1394643`](https://github.com/nix-community/home-manager/commit/b13946438f235a002c6a1c966b84b124123b26cf) | `docs: improve contributing documentation` |
| [`119febc4`](https://github.com/nix-community/home-manager/commit/119febc46489fc2b366fb5915667a6eb5d688059) | `vscode: avoid unnecessary IFD (again)`    |