### PR TITLE
chore(flake/nixpkgs): `5a0e0d73` -> `ce49cb77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658737577,
-        "narHash": "sha256-xosJ5nJT9HX+b6UWsSX6R+ap4AdZOCrl/r+IKFp2ASQ=",
+        "lastModified": 1658826464,
+        "narHash": "sha256-94ZTF0uIX/iZdiD4RJ5f933ak/OM4XLl7hF+gCa4Iuk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a0e0d73b944157328d54c4ded1cf2f0146a86a5",
+        "rev": "ce49cb7792a7ffd65ef352dda1110a4e4a204eac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`ce49cb77`](https://github.com/NixOS/nixpkgs/commit/ce49cb7792a7ffd65ef352dda1110a4e4a204eac) | `neovim: pass the --clean flag to only use wrapped rc`                               |
| [`9f9fc392`](https://github.com/NixOS/nixpkgs/commit/9f9fc392ca1643f18a66485680dc535c32868b4c) | `pip-audit: 2.4.1 -> 2.4.2`                                                          |
| [`5c7881bf`](https://github.com/NixOS/nixpkgs/commit/5c7881bf827ce9f81f4ea20c8908c2eee8af5593) | `python310Packages.pydeps: 1.10.18 -> 1.10.22`                                       |
| [`ae06ec9b`](https://github.com/NixOS/nixpkgs/commit/ae06ec9b28047534ae7a7755b18709d9d376f688) | `python310Packages.parts: 1.4.0 -> 1.5.1`                                            |
| [`8bf1e7ed`](https://github.com/NixOS/nixpkgs/commit/8bf1e7edb32097550e43df469aabcc3e9849fed4) | `hakrawler: 2.0 -> 2.1`                                                              |
| [`5fb6003f`](https://github.com/NixOS/nixpkgs/commit/5fb6003f504523c298a7d74cbd80b6acc93bbdd7) | `python310Packages.fastcore: 1.5.6 -> 1.5.9`                                         |
| [`15551162`](https://github.com/NixOS/nixpkgs/commit/15551162c53100184937169cd2bb6685af3e5cec) | `flexget: 3.3.21 -> 3.3.22`                                                          |
| [`02cdd56b`](https://github.com/NixOS/nixpkgs/commit/02cdd56bc565848fdfda4fc29c4f48854a8658e1) | `python310Packages.pex: 2.1.100 -> 2.1.101`                                          |
| [`77bdbd88`](https://github.com/NixOS/nixpkgs/commit/77bdbd88b5580a532f239b9a11706e15f39979cf) | `irqbalance: 1.8.0 -> 1.9.0`                                                         |
| [`0672e679`](https://github.com/NixOS/nixpkgs/commit/0672e6797feebf553804a037c059ed7036b7421b) | `gitlab-runner: 15.1.0 -> 15.2.0`                                                    |
| [`919b82ba`](https://github.com/NixOS/nixpkgs/commit/919b82bacf59feb8dee2016b2353bacfde285eee) | `prometheus-influxdb-exporter: 0.8.0 -> 0.10.0`                                      |
| [`54f19d3e`](https://github.com/NixOS/nixpkgs/commit/54f19d3ee7de815e317690ed6ef22458ba3cb391) | `matomo: 4.5.0 -> 4.10.1`                                                            |
| [`90b3a5b9`](https://github.com/NixOS/nixpkgs/commit/90b3a5b927570da950a7aec66820cf2b0316ba64) | `lighttpd: link nixosTests.lighttpd to passthru.tests`                               |
| [`9b6965dc`](https://github.com/NixOS/nixpkgs/commit/9b6965dcfcfc10906ee0ca955631a5a82d2a37ee) | `nixos: add lighttpd test`                                                           |
| [`88a9ab2c`](https://github.com/NixOS/nixpkgs/commit/88a9ab2ca902e7cf12c1659c8a5f76e2f8c66039) | `beets: expose enabled plugins in passthru`                                          |
| [`777e914c`](https://github.com/NixOS/nixpkgs/commit/777e914c20f0349d974092b9b35071c488f70bf0) | ``nixos/systemd.network: Add `RequiredFamilyForOnline` to `linkConfig```             |
| [`30c47f20`](https://github.com/NixOS/nixpkgs/commit/30c47f202adbc36458ec05a637f1fdfcdf0fcece) | `linux_lqx: 5.18.14-lqx1 -> 5.18.14-lqx2`                                            |
| [`3e9a15cf`](https://github.com/NixOS/nixpkgs/commit/3e9a15cf57b42d742b4113e177825b8000b32f16) | `python310Packages.pywlroots: 0.15.18 -> 0.15.19`                                    |
| [`15b2d330`](https://github.com/NixOS/nixpkgs/commit/15b2d330fd999640a68653cbd83a9a4005228f0d) | `python310Packages.types-requests: 2.28.3 -> 2.28.4`                                 |
| [`898b8052`](https://github.com/NixOS/nixpkgs/commit/898b80521ff312746c319c28c1928c8aa70adfc2) | `hclfmt: 2.12.0 -> 2.13.0`                                                           |
| [`6e0e1f6d`](https://github.com/NixOS/nixpkgs/commit/6e0e1f6dd0ebe06ec6a069cc3f001e1456bce354) | `gitaly: fix ldflags`                                                                |
| [`63eb0b66`](https://github.com/NixOS/nixpkgs/commit/63eb0b66b74b99e79dafd8ee4fa87d439f05fdf1) | `terraform-providers: update 2022-07-25`                                             |
| [`2082b33c`](https://github.com/NixOS/nixpkgs/commit/2082b33c56d8868e645d7a7e30661be7435042e9) | `intel-media-driver: fix compilation on i686`                                        |
| [`1d73e979`](https://github.com/NixOS/nixpkgs/commit/1d73e9798c7f8eec80b227ef75cf47b02b99757d) | ``zig: use `darwin.apple_sdk_11_0.callPackage```                                     |
| [`9fff1757`](https://github.com/NixOS/nixpkgs/commit/9fff17575cd13a6a6ef5b82bea4ec812fe4ff3bf) | `skopeo: 1.9.0 -> 1.9.1`                                                             |
| [`3556961d`](https://github.com/NixOS/nixpkgs/commit/3556961da9337e2d0bbc134173182af505251d1f) | `conmon: 2.1.2 -> 2.1.3`                                                             |
| [`1068fd42`](https://github.com/NixOS/nixpkgs/commit/1068fd4241b74db7af81edaff891b2012a9e4ae3) | `os-prober: 1.79 -> 1.81`                                                            |
| [`a6467f01`](https://github.com/NixOS/nixpkgs/commit/a6467f01e203ccebc8705ea35c7e3fcc29264178) | `bun: 0.1.2 -> 0.1.5`                                                                |
| [`6808d5e0`](https://github.com/NixOS/nixpkgs/commit/6808d5e09dcee4027ae836965e25dd9660c9f8dc) | `chia: mark as insecure`                                                             |
| [`eb5ea150`](https://github.com/NixOS/nixpkgs/commit/eb5ea1500b4e8a1e9ca6d62b69d6835f80efe3b7) | `hclfmt: init at 2.12.0 (#182472)`                                                   |
| [`3131757b`](https://github.com/NixOS/nixpkgs/commit/3131757b9ff3a3f113304ff44abc168b969bf8af) | `ocamlPackages.omd: 1.3.1 → 1.3.2`                                                   |
| [`79abc2a4`](https://github.com/NixOS/nixpkgs/commit/79abc2a4878823931b15cced9300b1f497198f9d) | `gnome.sushi: Fix video previews`                                                    |
| [`f0f161e2`](https://github.com/NixOS/nixpkgs/commit/f0f161e2879e077c87e9c48dc9d8851484a9f342) | `gegl: 0.4.36 → 0.4.38`                                                              |
| [`3fdefecb`](https://github.com/NixOS/nixpkgs/commit/3fdefecb10752db6f260cf5721390b35ded49ed8) | `pass: add openssh dependency to path`                                               |
| [`3a33ccee`](https://github.com/NixOS/nixpkgs/commit/3a33ccee142058848571abd60939589b9a71d17d) | `micropython: 1.18 -> 1.19`                                                          |
| [`99f5d1c0`](https://github.com/NixOS/nixpkgs/commit/99f5d1c0e7a1ce0574322e63e28e44f1df90da94) | `python3Packages.pywayland: 0.14.13 -> 0.14.14`                                      |
| [`ec92be45`](https://github.com/NixOS/nixpkgs/commit/ec92be456760eee7eff0b2a052c33b6396ad1dd5) | `mu: 1.8.6 -> 1.8.7`                                                                 |
| [`6f8b42bb`](https://github.com/NixOS/nixpkgs/commit/6f8b42bb02e543188bfb8a36f8d2bb47a363be0c) | `linux_lqx: 5.18.13-lqx1 -> 5.18.14-lqx1`                                            |
| [`a829e713`](https://github.com/NixOS/nixpkgs/commit/a829e713d439325f8d2863603faa5755f54ea250) | `linux_zen: 5.18.13-zen1 -> 5.18.14-zen1`                                            |
| [`39a53986`](https://github.com/NixOS/nixpkgs/commit/39a53986576f5b0482206b21f6c84e2dae4857de) | `swap maintainer`                                                                    |
| [`655f414a`](https://github.com/NixOS/nixpkgs/commit/655f414aaef23042127e0925e1bbbd27719bff68) | `Update pkgs/tools/misc/ix/default.nix`                                              |
| [`08d96609`](https://github.com/NixOS/nixpkgs/commit/08d96609a7e33e04199db4b9f571086bade7fb43) | `remove superflous $echo`                                                            |
| [`b8f10c75`](https://github.com/NixOS/nixpkgs/commit/b8f10c75294c9c8255c2f2f69c848acd63a12470) | `ix: resholve so we do not have to wrap`                                             |
| [`59ee5750`](https://github.com/NixOS/nixpkgs/commit/59ee57505a44d179b85fbd9f2e8b77a04f038afb) | `svdtools: 0.1.23 -> 0.2.5`                                                          |
| [`43855336`](https://github.com/NixOS/nixpkgs/commit/4385533655172b8a542f86167839a44a16c87ff0) | `python3Packages.uproot: fix runtime "No module named 'pkg_resources'"`              |
| [`6e0b8a6f`](https://github.com/NixOS/nixpkgs/commit/6e0b8a6f77409db0815312d3f9c3f7815fc75d20) | `python3Packages.awkward: fix runtime "No module named 'setuptools'"`                |
| [`097b07f4`](https://github.com/NixOS/nixpkgs/commit/097b07f427d4cd062797f82c180f3bef444e1988) | `coqPackages.hydra-battles: enable for Coq 8.16`                                     |
| [`81a0991e`](https://github.com/NixOS/nixpkgs/commit/81a0991e2db386d4a966ccb7f06378deb7e2eda1) | `coqPackages_8_16.equations: init at 1.3+8.16`                                       |
| [`d5086eb8`](https://github.com/NixOS/nixpkgs/commit/d5086eb862907827f7e6564ae6a1fac4fb69c65a) | `blesh: init at 2022-07-24 (#181963)`                                                |
| [`1539747c`](https://github.com/NixOS/nixpkgs/commit/1539747c7ebd3c437f481bd4bf196179c7a3ffcc) | `bundlerApp: set meta.mainProgram`                                                   |
| [`518e2f8f`](https://github.com/NixOS/nixpkgs/commit/518e2f8fffc008e96b48507400899fcca9399576) | `opencolorio: 2.0.2 -> 2.1.2 (#182695)`                                              |
| [`f35c51c4`](https://github.com/NixOS/nixpkgs/commit/f35c51c47c58a0301431bf6b6e31c3adefeee9db) | `openexr_3: 3.1.3 -> 3.1.5`                                                          |
| [`e96b070d`](https://github.com/NixOS/nixpkgs/commit/e96b070d899e34ac8bd54321879d30cca3b64c50) | `deepwave: 0.0.11 -> 0.0.12 (#182024)`                                               |
| [`930628f0`](https://github.com/NixOS/nixpkgs/commit/930628f0228a1f69889eb39f4f3809259b7c7fbe) | `midi-trigger: init at 0.0.4 (#182015)`                                              |
| [`0b4437ef`](https://github.com/NixOS/nixpkgs/commit/0b4437efe07211b4a31df2d12ac5eaa08745032c) | `vscode-extensions.james-yu.latex-workshop: 8.27.2 -> 8.28.0`                        |
| [`a660bf0f`](https://github.com/NixOS/nixpkgs/commit/a660bf0f558bf94396abfc9ecf40d757497cb09a) | `eclipses: 2022-03 -> 2022-06`                                                       |
| [`2d8a7597`](https://github.com/NixOS/nixpkgs/commit/2d8a7597784f65d7537763eedbebcb2dfbf50e19) | `headscale: 0.15.0 -> 0.16.0`                                                        |
| [`785b28be`](https://github.com/NixOS/nixpkgs/commit/785b28bee36d41498ff7a2acaf73242b0cd451c6) | `cloudflared: 2022.5.2 -> 2022.7.1 (#182768)`                                        |
| [`a44c9a37`](https://github.com/NixOS/nixpkgs/commit/a44c9a37c7531cdd6fbcf2eec2a34a5494b8d551) | `python310Packages.bsuite: Enable more tests (#181827)`                              |
| [`22d1035a`](https://github.com/NixOS/nixpkgs/commit/22d1035afbb17cb2071af8e0cc054bb472b5a552) | `jc: 1.20.3 -> 1.20.4`                                                               |
| [`8d51502e`](https://github.com/NixOS/nixpkgs/commit/8d51502e8216e363b3ec0f5b10d5bf1b32a9e0a4) | `ipfs: 0.13.1 → 0.14.0`                                                              |
| [`33bf1e61`](https://github.com/NixOS/nixpkgs/commit/33bf1e6127df8e4fecd5f60424cc4161de8cf45b) | `nextcloud: 23.0.6 -> 23.0.7`                                                        |
| [`8e1af69f`](https://github.com/NixOS/nixpkgs/commit/8e1af69fa45d8588b1a7f3bb22c3e4b9f7b4e3f4) | `python310Packages.approvaltests: 5.3.1 -> 5.3.3`                                    |
| [`92d55bde`](https://github.com/NixOS/nixpkgs/commit/92d55bdeabae04fc9009605831a0196d8f766844) | `dbeaver: 22.1.2 -> 22.1.3`                                                          |
| [`4d2359d5`](https://github.com/NixOS/nixpkgs/commit/4d2359d5d6b830d374457f55a9833a119ef6eec8) | `libsForQt5.umbrello: init at 22.04.3`                                               |
| [`a23c7cf2`](https://github.com/NixOS/nixpkgs/commit/a23c7cf2357c007abaed41449195dda598a65353) | `zola: 0.15.2 -> 0.16.0`                                                             |
| [`88415923`](https://github.com/NixOS/nixpkgs/commit/88415923b57851b292d8e74fc9a15d55f29e5a13) | `gopass*: build with Go with CL417615`                                               |
| [`4583d688`](https://github.com/NixOS/nixpkgs/commit/4583d688d70df9cd8e5eb966a573c3c97cb6e05c) | `gau: 2.1.1 -> 2.1.2`                                                                |
| [`9ac13085`](https://github.com/NixOS/nixpkgs/commit/9ac130850aedd0bedad59998165d55868ad9ac35) | `rofi-top: init at unstable-2017-10-16`                                              |
| [`d12b988d`](https://github.com/NixOS/nixpkgs/commit/d12b988d6d96df4d6aed130aa048ef2f4399a08a) | `python310Packages.scrapy: 2.6.1 -> 2.6.2`                                           |
| [`4517d024`](https://github.com/NixOS/nixpkgs/commit/4517d024bb14aa03d3ba97247a44ac119bf216ff) | `iredis: 1.12.0 -> 1.12.1`                                                           |
| [`b116a995`](https://github.com/NixOS/nixpkgs/commit/b116a995fa5a7b4d6edd3b70eda42c2705159a17) | `skaffold: 1.38.0 -> 1.39.1`                                                         |
| [`9acecc69`](https://github.com/NixOS/nixpkgs/commit/9acecc69ed676552ea48655a9ac3c33217168a05) | `python310Packages.yq: 3.0.2 -> 3.1.0`                                               |
| [`c37f4814`](https://github.com/NixOS/nixpkgs/commit/c37f48149d9beb0d745227f5aad09bd78681f963) | `sentry-cli: 1.74.3 -> 2.5.0`                                                        |
| [`5ded7fa4`](https://github.com/NixOS/nixpkgs/commit/5ded7fa44ad861e0f193c0aa19b89b508b57ca01) | `clojure-lsp: 2022.06.29-19.32.13 -> 2022.07.24-18.25.43`                            |
| [`a3c07319`](https://github.com/NixOS/nixpkgs/commit/a3c07319800c10acc65240e835c401d21d794cec) | `Add nsnelson to maintainers and selectdefaultapplication`                           |
| [`67481ad9`](https://github.com/NixOS/nixpkgs/commit/67481ad9293302fdbfc38dc974fbdfca26333234) | `mongodb-compass: 1.32.2 -> 1.32.4`                                                  |
| [`573a164c`](https://github.com/NixOS/nixpkgs/commit/573a164cf1fdedc852d549e025cef06d2c789b30) | `papirus-folders: fix missing dependency`                                            |
| [`8b8ac807`](https://github.com/NixOS/nixpkgs/commit/8b8ac80759b689d4c94676da4d1e1e25b365c4ed) | `androidenv: fix default ndk linking for ndk > 22`                                   |
| [`e8dfc2d7`](https://github.com/NixOS/nixpkgs/commit/e8dfc2d72a7071183dfef4bf720dd65021a61f32) | `androidenv: fix ndk linking for ndk < 23`                                           |
| [`62b8d182`](https://github.com/NixOS/nixpkgs/commit/62b8d182019cf5ea8c97b5e2fee491b947776250) | `whitesur-icon-theme: 2022-03-18 -> 2022-05-11`                                      |
| [`66a6649d`](https://github.com/NixOS/nixpkgs/commit/66a6649dcdfa63cc38c218bca1c9f92e177258c4) | `fluidd: 1.17.2 -> 1.19.0`                                                           |
| [`1653d2e3`](https://github.com/NixOS/nixpkgs/commit/1653d2e3e20ee32dfb0888192806f54c93b3b187) | `hedgedoc: refactor to fix editor crashing, replace inactive maintainer with myself` |
| [`9bbc053f`](https://github.com/NixOS/nixpkgs/commit/9bbc053f1abb8d0b2435a9768a2073bd1452ddd2) | `yarn2nix: change yarnFlags to append by default`                                    |
| [`df575524`](https://github.com/NixOS/nixpkgs/commit/df575524d44d4b64492f67563679fcc7ec8f3e4b) | `podman-tui: 0.4.0 -> 0.5.0`                                                         |
| [`4bf8e97a`](https://github.com/NixOS/nixpkgs/commit/4bf8e97a9e148f2b90309c1d8475ddedc9e11d52) | `git-branchless: add patch for test failures with latest Git`                        |
| [`a67bbc74`](https://github.com/NixOS/nixpkgs/commit/a67bbc746517d6d7028f6f1ba5de33b5406320a9) | `bpf-linker: init at 0.9.4`                                                          |
| [`1319b5a2`](https://github.com/NixOS/nixpkgs/commit/1319b5a2449698f0ba9ffc5282fbd39e48016b9d) | `linuxKernel.packages.linux_5_18.nvidia_x11_legacy390: fix build`                    |
| [`41558f02`](https://github.com/NixOS/nixpkgs/commit/41558f0227b6642d6041840e1a4868a911c9aaa9) | `buku: 4.6 -> 4.7`                                                                   |
| [`985e1520`](https://github.com/NixOS/nixpkgs/commit/985e152050e7e97c55d2da7102492841fd0cb920) | `selectdefaultapplication: init at unstable-2021-08-12`                              |
| [`ee2413c3`](https://github.com/NixOS/nixpkgs/commit/ee2413c326d32b66f316dcd80fce4a7ff94a72ba) | `nixos/crowd: store openid password securely`                                        |
| [`d07f3037`](https://github.com/NixOS/nixpkgs/commit/d07f3037e2f440ff4a059e63681efb2647352da2) | `nixos/security/pam: fix u2f options leakage`                                        |
| [`ddf8182d`](https://github.com/NixOS/nixpkgs/commit/ddf8182d5be8bcd275cfd102fff265547102fc9a) | `sshd: Don't remove symlinks to host key files`                                      |
| [`1f7ab584`](https://github.com/NixOS/nixpkgs/commit/1f7ab584cf86c10466c35046f4880a388f8dcf21) | `ocamlPackages.metrics: 0.2.0 → 0.4.0`                                               |
| [`3c7cb614`](https://github.com/NixOS/nixpkgs/commit/3c7cb614f11ff6ecb7e840e57e33437bcea4385e) | `visidata: add runtime dependency of clipboard commands`                             |
| [`b9962699`](https://github.com/NixOS/nixpkgs/commit/b9962699889e8b61df146edc76d9f740382c8d58) | `nixos/doc: don't advise to build master`                                            |
| [`530cb82b`](https://github.com/NixOS/nixpkgs/commit/530cb82b7fd06851c9404deeaa67428ec0d7add1) | `perlPackages.DBDMariaDB: 1.21 -> 1.22`                                              |
| [`c14ede52`](https://github.com/NixOS/nixpkgs/commit/c14ede52e0b09db74f0e192c86019eeff97ec179) | `perlPackages.SQLAbstractLimit: 0.142 -> 0.143`                                      |
| [`82e8ace0`](https://github.com/NixOS/nixpkgs/commit/82e8ace090c5ec81cee527687b7fda2f7271f8cf) | `perlPackages.MojoIOLoopForkCall: 0.20 -> 0.21`                                      |
| [`bfaae5a6`](https://github.com/NixOS/nixpkgs/commit/bfaae5a65df6610e15ce8af05895746062fe35d8) | `perlPackages.MojoRedis: 3.25 -> 3.29`                                               |
| [`369bd2a9`](https://github.com/NixOS/nixpkgs/commit/369bd2a93a6f04af5ed98d4e5bf8289b0435d8de) | `perlPackages.MojoUserAgentCached: 1.16 -> 1.19`                                     |
| [`188403c7`](https://github.com/NixOS/nixpkgs/commit/188403c7f1432c1c17bfbeed2f381af415bf380b) | `perlPackages.OpenAPIClient: 1.00 -> 1.04`                                           |
| [`ae5eb1ac`](https://github.com/NixOS/nixpkgs/commit/ae5eb1acbe96bfcc0fa519045d0ff8b3fbaf83dc) | `perlPackages.YAMLLibYAML: 0.82 -> 0.83`                                             |
| [`6c165096`](https://github.com/NixOS/nixpkgs/commit/6c1650969d4cecdc39e56f8df9629a7722ca07f1) | `perlPackages.SQLAbstract: 1.87 -> 2.000001`                                         |
| [`988915a1`](https://github.com/NixOS/nixpkgs/commit/988915a17d9743b8c9fb0458c5a1a20ba885daba) | `perlPackages.SQLAbstractPg: init at 1.0`                                            |
| [`27b68fc2`](https://github.com/NixOS/nixpkgs/commit/27b68fc26a8616857de882096ae04be4b3a0a94c) | `perlPackages.MinionBackendmysql: 0.21 -> 1.000`                                     |
| [`33f153db`](https://github.com/NixOS/nixpkgs/commit/33f153db807fa77bc7da245d6c2de9df209803de) | `perlPackages.MinionBackendSQLite: 5.0.4 -> 5.0.6`                                   |
| [`23504a5b`](https://github.com/NixOS/nixpkgs/commit/23504a5b7aaa0f2c059a6bde4de7a6e5b76380ba) | `perlPackages.Minion: 10.14 -> 10.25`                                                |
| [`1fb7198d`](https://github.com/NixOS/nixpkgs/commit/1fb7198d868fdd2330030f153c3ed57094926ecc) | `perlPackages.MojoliciousPluginOpenAPI: 4.02 -> 5.05`                                |
| [`37adafce`](https://github.com/NixOS/nixpkgs/commit/37adafce313646005933421cd14a282951909c06) | `perlPackages.JSONValidator: 4.16 -> 5.08`                                           |
| [`a586fbb7`](https://github.com/NixOS/nixpkgs/commit/a586fbb7d2af73832221c00d3a89017c040a087d) | `perlPackages.MojoPg: 4.22 -> 4.27`                                                  |
| [`5de8c6b0`](https://github.com/NixOS/nixpkgs/commit/5de8c6b05503e412e9cf6a9c652e2a80b4dda999) | `perlPackages.Mojomysql: 1.20 -> 1.25`                                               |
| [`c6a404c7`](https://github.com/NixOS/nixpkgs/commit/c6a404c7e217d27beb4eaa22ed1b26fb91e8daad) | `perlPackages.MojoliciousPluginSyslog: 0.05 -> 0.06`                                 |
| [`47e2cadf`](https://github.com/NixOS/nixpkgs/commit/47e2cadfa1e04d7018652b0a7be8b58e643403e1) | `perlPackages.Mojolicious: 9.19 -> 9.26`                                             |
| [`61b0cd2d`](https://github.com/NixOS/nixpkgs/commit/61b0cd2d13e5a88ea175f762212d24246f3b4ebc) | `mopidy-bandcamp init at 1.1.5`                                                      |
| [`0fa69e9e`](https://github.com/NixOS/nixpkgs/commit/0fa69e9e78f2682db2657ec77da3c00b8e7b40db) | `maintainers: add desttinghim`                                                       |
| [`052d5fae`](https://github.com/NixOS/nixpkgs/commit/052d5faec31031f8c532ab9731c7914bc8a40e49) | `signalbackup-tools: 20220526 -> 20220711`                                           |
| [`922bb560`](https://github.com/NixOS/nixpkgs/commit/922bb56029fdee1ae004e006a59e05c32e49bd91) | `glusterfs: patch around SSL_CERT_PATH detection`                                    |
| [`db4fdd62`](https://github.com/NixOS/nixpkgs/commit/db4fdd6247ec191677ac84e08da274ab88a0682e) | `nixos/filesystems: skip fsck for bind mounts`                                       |
| [`c06a3121`](https://github.com/NixOS/nixpkgs/commit/c06a3121b7c2054a4107e9819b23058ef2b5824f) | `prosody: use lua 5.2`                                                               |
| [`429fcad6`](https://github.com/NixOS/nixpkgs/commit/429fcad615726b2b1fe21e9f9b5ab95b23fe317f) | `{lib}mediainfo{-gui}: 22.03 -> 22.06`                                               |
| [`1be5d0ea`](https://github.com/NixOS/nixpkgs/commit/1be5d0ea4ab86f3e8b54677825a383e69519bed6) | `sumneko-lua-language-server: use Apple SDK 11 for all darwin systems`               |
| [`e4106d47`](https://github.com/NixOS/nixpkgs/commit/e4106d474541d6ab3304f4f8ff03185c769bbe1f) | `signalbackup-tools: use Apple SDK 11 for all darwin systems`                        |
| [`2274a721`](https://github.com/NixOS/nixpkgs/commit/2274a721c7588c5ddc051272b29048e437f96731) | `metabase: 0.43.1 → 0.43.3`                                                          |
| [`3fbc2a43`](https://github.com/NixOS/nixpkgs/commit/3fbc2a433d76115730ef159d712fae78a1e5631a) | `services/nextcloud: impossible error message`                                       |
| [`5f4d5fcf`](https://github.com/NixOS/nixpkgs/commit/5f4d5fcfa4e633682c8e1c06cd4872316fdaac51) | `services/nextcloud: apply suggestions`                                              |
| [`dd9200c0`](https://github.com/NixOS/nixpkgs/commit/dd9200c0a4781a8eaf6e4233bd1d4c60423f8f01) | `services/nextcloud: fix a bug`                                                      |
| [`320e4dbc`](https://github.com/NixOS/nixpkgs/commit/320e4dbcc3e8b9f951ed56ae12da0cff2c17fa61) | `nixos/nginx: fix broken listenAddresses example`                                    |
| [`ef75aab6`](https://github.com/NixOS/nixpkgs/commit/ef75aab6125710231873bc04b9a6507228d4e814) | `services/nextcloud: more consistent code`                                           |
| [`b3702049`](https://github.com/NixOS/nixpkgs/commit/b37020499c314528dc6198e47019fdbd0b671161) | `metabase: only require jdk11_headless to reduce closure size`                       |
| [`8dc48954`](https://github.com/NixOS/nixpkgs/commit/8dc489545df5a335af1c93fb428b1c0ca3d193a7) | `firefox-devedition-bin-unwrapped: 102.0b9 -> 103.0b1`                               |
| [`4e000b4b`](https://github.com/NixOS/nixpkgs/commit/4e000b4b6a03d948eee00e6ed2dcf62c9dd15e27) | `firefox-beta-bin-unwrapped: 102.0b9 -> 103.0b1`                                     |
| [`1c9c4a8e`](https://github.com/NixOS/nixpkgs/commit/1c9c4a8e807703e0414c01a1a05b45cef974e177) | `services/nextcloud: better secretFile test`                                         |
| [`439243d3`](https://github.com/NixOS/nixpkgs/commit/439243d38fe369cadf2481c5e1f759a7b543f4fc) | `services/nextcloud: check redis config`                                             |
| [`095c27c9`](https://github.com/NixOS/nixpkgs/commit/095c27c9d5e6b5d4d8f7a067ee413ca0ca47c56b) | `services/nixos: decode secret file correctly`                                       |
| [`b5af0719`](https://github.com/NixOS/nixpkgs/commit/b5af07194680c15246b5859a6313c028fc8cdd68) | `services/nextcloud: apply suggestions from PR 118093`                               |
| [`6911fefe`](https://github.com/NixOS/nixpkgs/commit/6911fefec185de63a254c2a88f161ce00041971b) | `vscode-extensions.eugleo.magic-racket: 0.5.7 -> 0.6.4`                              |
| [`a8ecb909`](https://github.com/NixOS/nixpkgs/commit/a8ecb909c0774eac06c32a1fa18d7c1c0bc7d142) | `nixos/nextcloud: fixed secretFile example`                                          |
| [`64e943d4`](https://github.com/NixOS/nixpkgs/commit/64e943d4a2d6089bce18c7635b546edeba297278) | `nixos/nextcloud: test for secretFile option`                                        |
| [`164f8c94`](https://github.com/NixOS/nixpkgs/commit/164f8c9457180e50db0c97aaa54cda46d6bdf97f) | `nixos/nextcloud: deduplicate file reading`                                          |
| [`83a669a0`](https://github.com/NixOS/nixpkgs/commit/83a669a0bef463b3202a544b33efc9109605ce83) | `nixos/nextcloud: better json typechecking`                                          |
| [`727bdd73`](https://github.com/NixOS/nixpkgs/commit/727bdd736c3977e17ba3c3051280fe9aa21914da) | `nixos/nextcloud: use array_merge instead of array_push`                             |
| [`fb389cb0`](https://github.com/NixOS/nixpkgs/commit/fb389cb0dbe94b08733d4c875e6c38ae2b25748d) | `nixos/nextcloud: add test for declaratively defined redis`                          |
| [`4ca2f27a`](https://github.com/NixOS/nixpkgs/commit/4ca2f27a60e28504be679204e672756fa9bd9d82) | `nixos/nextcloud: allow more declarative config`                                     |