### PR TITLE
chore(flake/nixpkgs): `ce49cb77` -> `2b0dd45a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658826464,
-        "narHash": "sha256-94ZTF0uIX/iZdiD4RJ5f933ak/OM4XLl7hF+gCa4Iuk=",
+        "lastModified": 1658916876,
+        "narHash": "sha256-BG7MCClmy9esk8pZLCtKoggNv91tAMm7P6dGHXMl3zc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ce49cb7792a7ffd65ef352dda1110a4e4a204eac",
+        "rev": "2b0dd45aca6a260762395ca2e94beab247f455a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`2b0dd45a`](https://github.com/NixOS/nixpkgs/commit/2b0dd45aca6a260762395ca2e94beab247f455a7) | `emacsMacport: 27.2-8.3 -> 28.1-9.0`                                     |
| [`afecdcc3`](https://github.com/NixOS/nixpkgs/commit/afecdcc3115c023b29072503e1e8ee671564fcff) | `python310Packages.types-urllib3: 1.26.16 -> 1.26.17`                    |
| [`2227d8a6`](https://github.com/NixOS/nixpkgs/commit/2227d8a696696b1b74a682308183211043a7f1bd) | `python310Packages.peaqevcore: 3.2.0 -> 3.3.0`                           |
| [`9da9722e`](https://github.com/NixOS/nixpkgs/commit/9da9722e432e40d877e07cdee44e896ae426f874) | `Add cargo-profiler package`                                             |
| [`e2ebfa4c`](https://github.com/NixOS/nixpkgs/commit/e2ebfa4c43601da1802e07c1d10e599425a368f5) | `python310Packages.types-requests: 2.28.4 -> 2.28.5`                     |
| [`1bc9503f`](https://github.com/NixOS/nixpkgs/commit/1bc9503fed2009ba77e43381b1d5c2675bf94378) | `talosctl: 1.1.1 -> 1.1.2`                                               |
| [`dd778e78`](https://github.com/NixOS/nixpkgs/commit/dd778e7878fb37b2e65779371d207313444013c9) | `ferdium: 6.0.0-nightly.65 -> 6.0.0`                                     |
| [`41f40771`](https://github.com/NixOS/nixpkgs/commit/41f40771488e99c914a3da5de086cf794242c6d7) | `mobile-broadband-provider-info: 20220511 → 20220725`                    |
| [`308db8f7`](https://github.com/NixOS/nixpkgs/commit/308db8f762477a915f123da987b7a866b49d3178) | `python310Packages.meross-iot: 0.4.4.7 -> 0.4.5.0`                       |
| [`31452e9d`](https://github.com/NixOS/nixpkgs/commit/31452e9d0fec7fac1075f289fceab7d5a8a13343) | `python310Packages.weconnect-mqtt: 0.38.1 -> 0.38.2`                     |
| [`4468d92e`](https://github.com/NixOS/nixpkgs/commit/4468d92eeb6000cb744249c0266d8ed7dd9fab17) | `nuclei: 2.7.4 -> 2.7.5`                                                 |
| [`d30af7ad`](https://github.com/NixOS/nixpkgs/commit/d30af7ad941543392aa5ebf29781e44306ec0b91) | `got: 0.73 -> 0.74`                                                      |
| [`4e3f3235`](https://github.com/NixOS/nixpkgs/commit/4e3f3235a7d4caf34d8cf6118d76202d70da72e4) | `got: enable building on darwin platforms`                               |
| [`b95fa37c`](https://github.com/NixOS/nixpkgs/commit/b95fa37c60d57a087e7799822d8afb56e8301092) | `nnn: 4.5 → 4.6`                                                         |
| [`4cd95597`](https://github.com/NixOS/nixpkgs/commit/4cd955979ca1d418a60a2f1fe5a7c645d11fcc61) | `bluespec: set mainProgram=bsc`                                          |
| [`8613bd99`](https://github.com/NixOS/nixpkgs/commit/8613bd99b1d042ad1d0d53335af7ef21fa871706) | `bitwarden: 2022.5.1 -> 2022.6.2`                                        |
| [`d3f89f58`](https://github.com/NixOS/nixpkgs/commit/d3f89f5891d62c8afbdb9ada44104ce3caee7f77) | `freeradius: 3.0.25 -> 3.2.0`                                            |
| [`65f8c8db`](https://github.com/NixOS/nixpkgs/commit/65f8c8db56a3904037fb7745b3cf7f7b00f2e9d8) | `fornalder: init at unstable-2022-07-23`                                 |
| [`f28e8302`](https://github.com/NixOS/nixpkgs/commit/f28e8302f4216f40d7f13315648f3de6c028f0f7) | `haskellPackages.conduit-aeson: unbreak`                                 |
| [`562795ba`](https://github.com/NixOS/nixpkgs/commit/562795ba314adc6150237b3482026cf2ea83404e) | `cargo-expand: 1.0.27 -> 1.0.28`                                         |
| [`93c4b657`](https://github.com/NixOS/nixpkgs/commit/93c4b657d59689b08ac82d646f19ebd1904c35dc) | `vultr-cli: 2.12.2 -> 2.14.2`                                            |
| [`0577f723`](https://github.com/NixOS/nixpkgs/commit/0577f72388095bea7a8ee4c59b49c63d1b860cd2) | `python310Packages.pydal: 20220721.1 -> 20220725.1`                      |
| [`f2485518`](https://github.com/NixOS/nixpkgs/commit/f24855188b32eb6730cdc4d0c26f294765dd5ca5) | `python310Packages.homematicip: 1.0.6 -> 1.0.7`                          |
| [`b5b10654`](https://github.com/NixOS/nixpkgs/commit/b5b10654c2c27432b31ed446e3b83e64aa72a07f) | ` telegraf: 1.22.4 -> 1.23.3`                                            |
| [`e87aff30`](https://github.com/NixOS/nixpkgs/commit/e87aff30e5bc3de1e4b889bbe0b1455c9c6ed7a5) | `pythonPackages.sfepy: enable darwin`                                    |
| [`8b618c0d`](https://github.com/NixOS/nixpkgs/commit/8b618c0d5ae64c62d3ecd0ef558c46fce4766ca1) | `maintainers: add myself`                                                |
| [`c2f7c090`](https://github.com/NixOS/nixpkgs/commit/c2f7c0902d12ca8e24649915bb563a8dde45cf4c) | `python310Packages.weconnect: 0.45.0 -> 0.45.1`                          |
| [`ef9826a1`](https://github.com/NixOS/nixpkgs/commit/ef9826a13b9499851c62c67d0bc4b40f0bfd34f6) | `haskellPackages: mark builds failing on hydra as broken`                |
| [`b82d1211`](https://github.com/NixOS/nixpkgs/commit/b82d121152833b013b2433c3b51e01b207694e81) | `plan9port: update darwin inputs`                                        |
| [`0ab119a6`](https://github.com/NixOS/nixpkgs/commit/0ab119a6cf77ddb547177ed8adae903aeceab748) | `coqPackages.mathcomp-abel: 1.2.0 → 1.2.1`                               |
| [`da15d8f4`](https://github.com/NixOS/nixpkgs/commit/da15d8f43e4252a6b3afd9405c220e712209da01) | `coqPackages.hierarchy-builder: enable for Coq 8.16`                     |
| [`cd935b2d`](https://github.com/NixOS/nixpkgs/commit/cd935b2d96037d2eee31529d27340c12098d9b07) | `python310Packages.deezer-python: 5.3.3 -> 5.4.0`                        |
| [`126cada5`](https://github.com/NixOS/nixpkgs/commit/126cada5ff081c3901314982a5362bc56dd4a835) | `millet: 0.2.7 -> 0.2.9`                                                 |
| [`b08cdd38`](https://github.com/NixOS/nixpkgs/commit/b08cdd38b45da2a621528fbcaee4dc4ee5cdb565) | `csview: 1.0.1 -> 1.1.0`                                                 |
| [`3a46b467`](https://github.com/NixOS/nixpkgs/commit/3a46b467ace6c1f571e37269055bbbcb0b150cc3) | `emscripten: 3.1.15 -> 3.1.17`                                           |
| [`9483f20d`](https://github.com/NixOS/nixpkgs/commit/9483f20d104893dadc282ac790834686ee3864a1) | `firefox-beta-bin-unwrapped: 103.0b1 -> 103.0b9`                         |
| [`d4c6c0f2`](https://github.com/NixOS/nixpkgs/commit/d4c6c0f252a488e83a27cf96a9a550dc9e47eea9) | `firefox-devediton-bin-unwrapped: 103.0b1 -> 103.0b9`                    |
| [`d361a9f9`](https://github.com/NixOS/nixpkgs/commit/d361a9f90af9fc8d4cf1c71a8f47e595af34f0ed) | `spidermonkey_91: 91.11.0 -> 91.12.0`                                    |
| [`aafd5020`](https://github.com/NixOS/nixpkgs/commit/aafd5020faecb53c9de97dfbe277d1efe8040217) | `firefox-esr-91-unwrapped: 91.11.0esr -> 91.12.0esr`                     |
| [`a2c4eb71`](https://github.com/NixOS/nixpkgs/commit/a2c4eb714d64f62fabe0a86e8f123f112d368f97) | `firefox-esr-102-unwrapped: 102.0.1esr -> 102.1.0esr`                    |
| [`8e3066f4`](https://github.com/NixOS/nixpkgs/commit/8e3066f49f62a0620bc458188b157d080b040646) | `firefox-bin-unwrapped: 102.0.1 -> 103.0`                                |
| [`a168249d`](https://github.com/NixOS/nixpkgs/commit/a168249ddcf1dfe53c323358d8a7de771349a378) | `firefox-unwrapped: 102.0.1 -> 103.0`                                    |
| [`7206899c`](https://github.com/NixOS/nixpkgs/commit/7206899cbf446efd7bd29bfe31e8f32f5d636706) | `nixos/i18n: add en_US.UTF-8 to default locales`                         |
| [`4e7a1d64`](https://github.com/NixOS/nixpkgs/commit/4e7a1d6456fab6c8ea644c116831626b052e9022) | `crabz: 0.7.2 -> 0.7.5`                                                  |
| [`a4d82688`](https://github.com/NixOS/nixpkgs/commit/a4d82688b03b531313151e5d33e823b90c5ef4ba) | `rlaunch: init at 1.3.13`                                                |
| [`8c10a967`](https://github.com/NixOS/nixpkgs/commit/8c10a967f748196308987d8fa041cd1a1e918e07) | `balanceofsatoshis: add shell completion`                                |
| [`35523580`](https://github.com/NixOS/nixpkgs/commit/35523580a9edbe51cc75099ff0acf7fbd943cb4e) | `python310Packages.aesara: 2.7.7 -> 2.7.9`                               |
| [`5da403cc`](https://github.com/NixOS/nixpkgs/commit/5da403cc418250ae45b42eb226e5fff58e9270fb) | `python310Packages.boltons: 20.2.1 -> 21.0.0`                            |
| [`ff7abeab`](https://github.com/NixOS/nixpkgs/commit/ff7abeabe9c2b8e9ef0d47d8ef8cafc64b6d609f) | `haskellPackages.hasql-dynamic-statements: downgrade to 0.3.1.1`         |
| [`98db578a`](https://github.com/NixOS/nixpkgs/commit/98db578afa81422e1fecafbd76195a384fb17989) | `ocamlformat: Support the version override`                              |
| [`1afb5569`](https://github.com/NixOS/nixpkgs/commit/1afb55692d3c5523c4524c0b694c0e535bd22a23) | `ocamlPackages.odoc-parser: 1.0.0 -> 2.0.0`                              |
| [`6ac387a3`](https://github.com/NixOS/nixpkgs/commit/6ac387a3a327970e5838a9c53efd3baef22e4c88) | `ocamlformat_0_24_0: init`                                               |
| [`6d559df8`](https://github.com/NixOS/nixpkgs/commit/6d559df86798cbe99b7de8c94a25a5ac1b240c98) | `ocamlPackages.odoc-parser: init 1.0.1 & 2.0.0`                          |
| [`f201a772`](https://github.com/NixOS/nixpkgs/commit/f201a7722ce266d052188818f6bca7ba2b099f17) | `dune_3: 3.4.0 -> 3.4.1`                                                 |
| [`dc78025c`](https://github.com/NixOS/nixpkgs/commit/dc78025c00e887f823ebb9603ff4208a4286777a) | `cargo-play: 0.5.0 -> 0.5.1`                                             |
| [`f4943b31`](https://github.com/NixOS/nixpkgs/commit/f4943b31bc13d145f33b9dfd599a44cde70e6c00) | `cargo-modules: 0.5.9 -> 0.5.10`                                         |
| [`ae78f717`](https://github.com/NixOS/nixpkgs/commit/ae78f717238970ae9bf5e4dee4bc08ee7177ed1b) | `haskellPackages.{superbuffer,list-t,stm-containers}: reenable tests`    |
| [`b48aef72`](https://github.com/NixOS/nixpkgs/commit/b48aef72e3aea93a6ade39475579b2fd285a64f6) | `python310Packages.omegaconf: 2.1.1 -> 2.2.2`                            |
| [`4d4f2ba1`](https://github.com/NixOS/nixpkgs/commit/4d4f2ba156e1086186439fbb7c7b4531c03c23d0) | `python310Packages.antlr4_9-python3-runtime: init at 4.9`                |
| [`ee31754d`](https://github.com/NixOS/nixpkgs/commit/ee31754de3a7473d54efe78e2b461072aa237f78) | `python310Packages.hydra: 1.1.1 -> 1.2.0`                                |
| [`5f323b1b`](https://github.com/NixOS/nixpkgs/commit/5f323b1b187db8545ce94aaae18a13f6024bdd1f) | `gh: 2.14.2 -> 2.14.3`                                                   |
| [`57055b68`](https://github.com/NixOS/nixpkgs/commit/57055b681f48bdc408753b828e7d5f3ae0e99f07) | `haskellPackages.Spock-core: build with correct reroute version`         |
| [`81c3bae1`](https://github.com/NixOS/nixpkgs/commit/81c3bae1662a6af25b99d8233e2707e546ad294d) | `python310Packages.slack-sdk: 3.18.0 -> 3.18.1`                          |
| [`d7ee40d4`](https://github.com/NixOS/nixpkgs/commit/d7ee40d4ecdf9f0c753bde74435a1a19f8b2ea60) | `cargo-edit: 0.9.0 -> 0.10.2`                                            |
| [`bd7af3c0`](https://github.com/NixOS/nixpkgs/commit/bd7af3c0298badbc24a9a4ad2d8f854cd674d25a) | `pgloader: 3.6.2 -> 3.6.6`                                               |
| [`06208441`](https://github.com/NixOS/nixpkgs/commit/062084413669bbb7e80294cc5384f58f772c1aa1) | `haskellPackages.regex-tdfa: Disable disfunctional tests for older ghcs` |
| [`30981035`](https://github.com/NixOS/nixpkgs/commit/30981035e4dcca9ab7c514e94c9a52d4f3ede995) | `python310Packages.agate: Enable more tests`                             |
| [`f05adf5f`](https://github.com/NixOS/nixpkgs/commit/f05adf5fafa4a794947be298337c18e6944e686f) | `thunderbird-bin: 102.0.2 -> 102.0.3`                                    |
| [`1da61bc1`](https://github.com/NixOS/nixpkgs/commit/1da61bc1a4b44b5483686396398f2db35a982115) | `joshuto: 0.9.3 -> 0.9.4`                                                |
| [`7d84ef8a`](https://github.com/NixOS/nixpkgs/commit/7d84ef8ad9d248bf4dae17dcb35423fef3e2309f) | `thunderbird: 102.0.2 -> 102.0.3`                                        |
| [`26ca9845`](https://github.com/NixOS/nixpkgs/commit/26ca98459e5c65f3c990ad20199517d8c4640f51) | `python310Packages.adb-shell: Enable tests`                              |
| [`e4ab3833`](https://github.com/NixOS/nixpkgs/commit/e4ab3833a4579198d6adde686500b838bd900391) | `python310Packages.faraday-plugins: 1.6.7 -> 1.6.8`                      |
| [`ba47e418`](https://github.com/NixOS/nixpkgs/commit/ba47e418e5729caa3eb73cd66c887179d962ed3d) | `python310Packages.pick: 1.3.0 -> 1.4.0`                                 |
| [`f5c80b0c`](https://github.com/NixOS/nixpkgs/commit/f5c80b0c0f432a87245c1d3375de2d1300bd11c0) | `python310Packages.dominate: switch to pytestCheckHook`                  |
| [`b3dfa02d`](https://github.com/NixOS/nixpkgs/commit/b3dfa02d0016c351d4bd262e4652892a01b094bf) | `wlopm: init at 0.1.0`                                                   |
| [`7add8300`](https://github.com/NixOS/nixpkgs/commit/7add8300394432f28d27f1b855b238d69024de6f) | `linode-cli: 5.21.0 -> 5.21.0`                                           |
| [`5daf9994`](https://github.com/NixOS/nixpkgs/commit/5daf9994369508992edce9efdcb06847b725c422) | `nodejs-18_x: 18.6.0 -> 18.7.0`                                          |
| [`27a02db5`](https://github.com/NixOS/nixpkgs/commit/27a02db5844efce87a03b26fa7f9abd9461a18b4) | `scdl: init at 2.7.2`                                                    |
| [`6e6a5156`](https://github.com/NixOS/nixpkgs/commit/6e6a515607b19eb575ba99d7b002b7d4683a5f8d) | `postgresqlPackages.timescaledb: 2.7.0 -> 2.7.2`                         |
| [`3b450777`](https://github.com/NixOS/nixpkgs/commit/3b450777c3213c010e92b76adb1b364df1943551) | `timescaledb-tune: 0.12.0 -> 0.13.0`                                     |
| [`fefa4ba2`](https://github.com/NixOS/nixpkgs/commit/fefa4ba247767727d6992f400466c2904d1ef467) | `python310Packages.soundcloud-v2: init at 1.3.1`                         |
| [`1ffbd4e7`](https://github.com/NixOS/nixpkgs/commit/1ffbd4e7379a75890116404407a057071262a9f4) | `postman: 9.14.0 -> 9.22.2`                                              |
| [`285575ff`](https://github.com/NixOS/nixpkgs/commit/285575ffa7bcdb3ff897b8a52058191035f4ae94) | `postman: add Crafter as maintainer`                                     |
| [`ecba5562`](https://github.com/NixOS/nixpkgs/commit/ecba5562d0b4063d54dffcf72b396a06eeb47d37) | `cypress: 10.2.0 -> 10.3.1`                                              |
| [`fbda5b90`](https://github.com/NixOS/nixpkgs/commit/fbda5b9059b4832624a607a64163f0973eff2527) | `xcfun: enable on darwin`                                                |
| [`c1eee44c`](https://github.com/NixOS/nixpkgs/commit/c1eee44c97a161e22e994b05eb5af4ee66f69b36) | ``wails: remove superfluous `doCheck = true```                           |
| [`72971389`](https://github.com/NixOS/nixpkgs/commit/72971389b899bea45dde198f254faf07438dde16) | `wails: 2.0.0-beta.38 -> 2.0.0-beta.42`                                  |
| [`6d5fa6bf`](https://github.com/NixOS/nixpkgs/commit/6d5fa6bf8c7ddbf3dad0473aa802449b49f26502) | `liferea: 1.13.8 -> 1.13.9`                                              |
| [`7843e262`](https://github.com/NixOS/nixpkgs/commit/7843e262d8948ac1c72de91b81938e3ebbd3c2b2) | `liferea: add update script`                                             |
| [`f39aee2d`](https://github.com/NixOS/nixpkgs/commit/f39aee2d8b8cf527a4a13f90bd57c8ceb345f3d7) | `haskellPackages.terminfo: not a core pkg if cross compiling`            |
| [`759fed34`](https://github.com/NixOS/nixpkgs/commit/759fed34c0edd7749d394534a5bd1a7f5f8ff9f7) | `haskellPackages.hls-ormolu-plugin: Disable flaky test`                  |
| [`7cfe5b12`](https://github.com/NixOS/nixpkgs/commit/7cfe5b129a8d60652ff8456343db65d48f77b346) | `ithc: init at unstable-2022-06-07`                                      |
| [`b0873c03`](https://github.com/NixOS/nixpkgs/commit/b0873c032d7415fe731ad5e50ba31de7201f6fbf) | `hid-ite8291r3: init at unstable-2022-06-01`                             |
| [`582855a0`](https://github.com/NixOS/nixpkgs/commit/582855a0cf895e39f407f634aa03995f66060072) | `cypress: add Crafter as maintainer`                                     |
| [`b5c72110`](https://github.com/NixOS/nixpkgs/commit/b5c72110b652e6123b4eae5c95a6df682101e47b) | `python310Packages.vallox-websocket-api: 2.11.0 -> 2.12.0`               |
| [`6156f371`](https://github.com/NixOS/nixpkgs/commit/6156f371558791c15eba1b675ea2b36dce7b62f0) | `navi: 2.19.0 -> 2.20.1`                                                 |
| [`86ea7505`](https://github.com/NixOS/nixpkgs/commit/86ea7505dca6b42e7b70baedeb73fc51dc197c51) | `modemmanager: 1.18.8 → 1.18.10`                                         |
| [`650b3f97`](https://github.com/NixOS/nixpkgs/commit/650b3f97cdd5df699b64adf170058aae6e1771b6) | `libmbim: 1.26.2 → 1.26.4`                                               |
| [`e9e726b4`](https://github.com/NixOS/nixpkgs/commit/e9e726b4597104af63531bdee8fa7cc062d6821c) | `libqrtr-glib: 1.0.0 → 1.2.2`                                            |
| [`01ad520d`](https://github.com/NixOS/nixpkgs/commit/01ad520de45feb4fce31186e655776b791685678) | `libqmi: 1.30.4 → 1.30.8`                                                |
| [`3464d0cc`](https://github.com/NixOS/nixpkgs/commit/3464d0cc1927e1f5caa9e8d9ec281375aec42e47) | `modemmanager: 1.18.6 -> 1.18.8`                                         |
| [`5d05bbed`](https://github.com/NixOS/nixpkgs/commit/5d05bbed745b0e33098091a6852e6e7884eeb5de) | `binutils: fix the kernel build for PowerPC`                             |
| [`902aebf6`](https://github.com/NixOS/nixpkgs/commit/902aebf62c265b0dfb9b33f53b407f873706990d) | `golangci-lint: 1.46.2 -> 1.47.2`                                        |
| [`0d7a058a`](https://github.com/NixOS/nixpkgs/commit/0d7a058a1c0931de7218d3d145b0256a22be4936) | `python310Packages.dominate: 2.6.0 -> 2.7.0`                             |
| [`694b7652`](https://github.com/NixOS/nixpkgs/commit/694b7652aabddca3b424dbc2646eeca2363414ca) | `python310Packages.zigpy: 0.47.3 -> 0.48.0`                              |
| [`ce3ffd90`](https://github.com/NixOS/nixpkgs/commit/ce3ffd90358647f0457a08b62a19281c25e1d3fd) | `python310Packages.dvc-objects: 0.1.4 -> 0.1.5`                          |
| [`7ab35bda`](https://github.com/NixOS/nixpkgs/commit/7ab35bdaa6c97c2ef95401841bb241a64d421ca2) | `nuget-to-nix: fallback to default URL for directories`                  |
| [`a65d1a3b`](https://github.com/NixOS/nixpkgs/commit/a65d1a3b892b7e80df0f0e3deccc89d9d8a45fc5) | `joshuto: add totoroot as maintainer`                                    |
| [`a2d88a15`](https://github.com/NixOS/nixpkgs/commit/a2d88a153d8ffb7543d79ce1c81352c4afe4ea9b) | `nbstripout: 0.5.0 -> 0.6.0`                                             |
| [`e8f7667f`](https://github.com/NixOS/nixpkgs/commit/e8f7667f40c9fc6c0f5d159e94b85f2686d87701) | `python310Packages.cssutils: 2.5.0 -> 2.5.1`                             |
| [`5cea73ae`](https://github.com/NixOS/nixpkgs/commit/5cea73ae0d14db3295b5fe9e811b56f258548a3a) | `maintainers: add danc86`                                                |
| [`8d90d114`](https://github.com/NixOS/nixpkgs/commit/8d90d114b2a5639e21531c7f1d0ab1ff7b6feb0e) | `haskellPackages.doctest-parallel: Disable defective doctests`           |
| [`d83e3785`](https://github.com/NixOS/nixpkgs/commit/d83e3785231153397d9b7cbcf7f348efe9d9e73a) | `mdbook: 0.4.20 -> 0.4.21`                                               |
| [`aa41b54e`](https://github.com/NixOS/nixpkgs/commit/aa41b54e51af9683b7f8e60563e6a0642ae2e6fa) | `haskellPackages.aeson-typescript: fix the testsuite and unbreak`        |
| [`28e9634a`](https://github.com/NixOS/nixpkgs/commit/28e9634a9dc5007266e668941b3f3a43dc044732) | `haskellPackages: regenerate package set based on current config`        |
| [`8aeb1d8e`](https://github.com/NixOS/nixpkgs/commit/8aeb1d8ec5787dbadcc418c751247489386d827f) | `all-cabal-hashes: 2022-07-18T21:55:34Z -> 2022-07-21T21:13:45Z`         |
| [`642279ab`](https://github.com/NixOS/nixpkgs/commit/642279ab6fa65cd8207699a5eb7da5a0e0d0a19a) | `haskellPackages: stackage LTS 19.15 -> LTS 19.16`                       |
| [`1c44717f`](https://github.com/NixOS/nixpkgs/commit/1c44717f11ce05c1a41efcab161fc526d41b4cf9) | `httm: 0.12.2 -> 0.13.4`                                                 |
| [`4ec68389`](https://github.com/NixOS/nixpkgs/commit/4ec68389db085461debb5739600d009d22b4cf77) | `feishu: misc updates`                                                   |
| [`e1ed913a`](https://github.com/NixOS/nixpkgs/commit/e1ed913a9ffa7c9cc28067885ad0f70af50b7b4c) | `feishu: fix the missing maintainer`                                     |
| [`f6e06709`](https://github.com/NixOS/nixpkgs/commit/f6e067090dc09950d55db44341c0854e7d27460f) | `closurecompiler: 20220502 -> 20220601`                                  |
| [`2abf031a`](https://github.com/NixOS/nixpkgs/commit/2abf031a476eb38678688a9133a68fcca36a363a) | `txtpbfmt: init at unstable-2022-06-08`                                  |
| [`251b2195`](https://github.com/NixOS/nixpkgs/commit/251b2195f0e407042146f5100792a7524cbe653e) | `jackett: 0.20.709 -> 0.20.915`                                          |
| [`0e857fc1`](https://github.com/NixOS/nixpkgs/commit/0e857fc1d92ab5ce0c8b53e2a1df558892c3b2ff) | `nixos/tests/stunnel: Add mutual authentication test`                    |
| [`131399ef`](https://github.com/NixOS/nixpkgs/commit/131399effb405114449d7777da650d0977931178) | `nixos/stunnel: Make free-form`                                          |
| [`61585d1c`](https://github.com/NixOS/nixpkgs/commit/61585d1cd7f699dd9187ade7c0b21735c96b53ee) | `nixos/tests/stunnel: init`                                              |