### PR TITLE
chore(flake/nixpkgs): `2b0dd45a` -> `7b9be38c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658916876,
-        "narHash": "sha256-BG7MCClmy9esk8pZLCtKoggNv91tAMm7P6dGHXMl3zc=",
+        "lastModified": 1659219666,
+        "narHash": "sha256-pzYr5fokQPHv7CmUXioOhhzDy/XyWOIXP4LZvv/T7Mk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2b0dd45aca6a260762395ca2e94beab247f455a7",
+        "rev": "7b9be38c7250b22d829ab6effdee90d5e40c6e5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                               |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`7b9be38c`](https://github.com/NixOS/nixpkgs/commit/7b9be38c7250b22d829ab6effdee90d5e40c6e5c) | `treewide: remove myself as maintainer`                                      |
| [`f5910772`](https://github.com/NixOS/nixpkgs/commit/f5910772e59efe2bb28e5fb60457978614ebc8e8) | `pulumi-bin: install shell completion`                                       |
| [`eabe2192`](https://github.com/NixOS/nixpkgs/commit/eabe2192ea8b277a4aaf438c8b39858230ae31a0) | `pulumi-bin: 3.35.2 -> 3.37.2`                                               |
| [`f5a14e16`](https://github.com/NixOS/nixpkgs/commit/f5a14e169e305b9295e4c63b0dbc5d561e923649) | `python3Packages.protonvpn-nm-lib: 3.10.0 -> 3.11.0`                         |
| [`b6da1d81`](https://github.com/NixOS/nixpkgs/commit/b6da1d8198e47033027750440551b4ff427068dd) | `nixos/tests/k3s: add multi-node test`                                       |
| [`aa579635`](https://github.com/NixOS/nixpkgs/commit/aa579635b9ded3164dd592b709a8c64aa67eaa0e) | `nixos/tests/k3s: wait for default service account in test`                  |
| [`d5b1e257`](https://github.com/NixOS/nixpkgs/commit/d5b1e25711c3451de8f6df7cb4c9148d7aed64c6) | `nixos/tests/k3s: reorganize test into a subdirectory`                       |
| [`717f05b6`](https://github.com/NixOS/nixpkgs/commit/717f05b6ce2885c8fbb422305f94af20554ce442) | `wapm-cli: init at 0.5.5 (#183477)`                                          |
| [`ecdacf3d`](https://github.com/NixOS/nixpkgs/commit/ecdacf3d46d69f48d3df0f5b9bdeb4fbafb9c451) | `pgadmin: remove all version constraints`                                    |
| [`745dcc42`](https://github.com/NixOS/nixpkgs/commit/745dcc426ceae8ae8de583aa7f5840b623d2ab5d) | `greenfoot: 3.7.0 -> 3.7.1`                                                  |
| [`f8f42834`](https://github.com/NixOS/nixpkgs/commit/f8f428346e5162c404d624f65809225188ee0972) | `flyway: 9.0.2 -> 9.0.4`                                                     |
| [`cc8cefb0`](https://github.com/NixOS/nixpkgs/commit/cc8cefb0a8e467a5b2233220358b5d841b91b22c) | `free42: 3.0.9 -> 3.0.13`                                                    |
| [`8e078933`](https://github.com/NixOS/nixpkgs/commit/8e078933f10fe8bed636f9d613fcc0ff974f69c5) | `zen-kernels: 5.18.14 -> 5.18.15`                                            |
| [`f6d7bf03`](https://github.com/NixOS/nixpkgs/commit/f6d7bf0315b59728ea4c6329287a2c2a5cd71223) | `stunnel: 5.64 -> 5.65 (#183617)`                                            |
| [`153bfc99`](https://github.com/NixOS/nixpkgs/commit/153bfc996609745cd8996400575b0ec3033036dd) | `treewide: use isx86 where appropriate`                                      |
| [`5330c0a1`](https://github.com/NixOS/nixpkgs/commit/5330c0a1afe9d97d6f6366157cf0d3da9a8e7c31) | `treewide: use isAarch where appropriate`                                    |
| [`b62eadf3`](https://github.com/NixOS/nixpkgs/commit/b62eadf3b1d4d6ff1a40dce0e5eb59d93886b39d) | `dxa: 0.1.4 -> 0.1.5`                                                        |
| [`096731db`](https://github.com/NixOS/nixpkgs/commit/096731dbb6f8f9dfb0b638a14a82b0f42dc40dc0) | `redis-plus-plus: remove linux-only restriction`                             |
| [`7efdfc2a`](https://github.com/NixOS/nixpkgs/commit/7efdfc2a593457210e6ea0f378db8d990f7c8249) | `proot: 5.3.0 -> 5.3.1, drop libarchive dependency (#183747)`                |
| [`57627e47`](https://github.com/NixOS/nixpkgs/commit/57627e479ee321defba08b121c1def371ba9cdea) | `closurecompiler: 20220601 -> 20220719`                                      |
| [`c54facc0`](https://github.com/NixOS/nixpkgs/commit/c54facc0ffa39c6d1d176bb73e1e9ac6e33206a9) | `checkSSLCert: 2.35.0 -> 2.36.0`                                             |
| [`62af94c2`](https://github.com/NixOS/nixpkgs/commit/62af94c2ce5b43e4d56d3817f801cb87807b3660) | `astroid: patch to fix missing icon bug`                                     |
| [`c3980a57`](https://github.com/NixOS/nixpkgs/commit/c3980a57329fe2240bab8bc54fe8cb66431d7af9) | `seaweedfs: drop myself as maintainer`                                       |
| [`db127e82`](https://github.com/NixOS/nixpkgs/commit/db127e82d85a3b899665e6be1776df389e52849a) | `sfz: init at 0.7.0 (#183911)`                                               |
| [`0426ccf7`](https://github.com/NixOS/nixpkgs/commit/0426ccf7845d48cf49008446871e1636a0a63fd0) | `virtualbox: 6.1.34 -> 6.1.36`                                               |
| [`ff519d50`](https://github.com/NixOS/nixpkgs/commit/ff519d504c7469b36ddffd5bc04c4ff485cbb7df) | `sonic-pi: 3.3.1 -> 4.0.3`                                                   |
| [`bd95ace2`](https://github.com/NixOS/nixpkgs/commit/bd95ace2d31564c0caceda68a8c2ec1b97f7116e) | `bitcoin: fix broken build on aarch64-darwin`                                |
| [`e6550076`](https://github.com/NixOS/nixpkgs/commit/e6550076a6c693993a0737a09a7f7c6f28414338) | `python310Packages.statmake: Enable more tests`                              |
| [`33c199ae`](https://github.com/NixOS/nixpkgs/commit/33c199aee4b3bbb31b2d7fb12b20c6419e9f2455) | `babashka: 0.9.159 -> 0.9.160`                                               |
| [`07eeb8eb`](https://github.com/NixOS/nixpkgs/commit/07eeb8ebc7860f96eae8702871ea34cab56ea96d) | `oauth2-proxy: 7.2.1 -> 7.3.0`                                               |
| [`02c8d522`](https://github.com/NixOS/nixpkgs/commit/02c8d5228f67b341974cb8812444e9d061208dcc) | `git-delete-merged-branches: 6.4.0 -> 7.0.0`                                 |
| [`ebe63d81`](https://github.com/NixOS/nixpkgs/commit/ebe63d812d21488ca241429bc300c66c8ced7eab) | `ssh-to-age: 1.0.1 -> 1.0.2`                                                 |
| [`98a3b6c4`](https://github.com/NixOS/nixpkgs/commit/98a3b6c413f2902313cf4d56732806a71dfcfaed) | `sqlc: 1.13.0 -> 1.14.0`                                                     |
| [`a09121aa`](https://github.com/NixOS/nixpkgs/commit/a09121aaa6abd2339c37f39562f725890c49096f) | `spaceship-prompt: 3.16.4 -> 3.16.7`                                         |
| [`d400dbc9`](https://github.com/NixOS/nixpkgs/commit/d400dbc9310cacf93f447933ee51f3e036175834) | `rednotebook: 2.24 -> 2.25`                                                  |
| [`38e38584`](https://github.com/NixOS/nixpkgs/commit/38e3858441611ab80159a66a6f4c9c743736a379) | `pacemaker: 2.1.2 -> 2.1.4`                                                  |
| [`f0fd5760`](https://github.com/NixOS/nixpkgs/commit/f0fd5760e1b9ab8bb14d82bb93b2576476564d51) | `overmind: 2.2.2 -> 2.3.0`                                                   |
| [`2d773c5a`](https://github.com/NixOS/nixpkgs/commit/2d773c5afdafc34336741a13623beb430e316df4) | `open-policy-agent: 0.42.0 -> 0.43.0`                                        |
| [`3f507855`](https://github.com/NixOS/nixpkgs/commit/3f50785567b4d1cdc4b2ae452a1a4ea4fe6aa652) | `txtpbfmt: drop redundant override`                                          |
| [`1ed5b7f9`](https://github.com/NixOS/nixpkgs/commit/1ed5b7f95ae10cabab83136286e7eabbe190077b) | `argocd: 2.4.4 -> 2.4.8`                                                     |
| [`19412639`](https://github.com/NixOS/nixpkgs/commit/194126399daa0d32c6bb9da155c57f0f9833cb46) | `godns: 2.8.5 -> 2.8.6`                                                      |
| [`2e9d50ef`](https://github.com/NixOS/nixpkgs/commit/2e9d50ef42bc10d0300f7c411a5fc3df482f3d33) | `flyctl: 0.0.362 -> 0.0.363`                                                 |
| [`0d6e1152`](https://github.com/NixOS/nixpkgs/commit/0d6e1152c83093ca59fc42341ae954c24489f1bc) | `verco: 6.8.0 -> 6.12.0`                                                     |
| [`9ebb6689`](https://github.com/NixOS/nixpkgs/commit/9ebb6689f6dd24c49dfc6a1eedb706983c42d951) | `tidy-viewer: 1.4.3 -> 1.4.6`                                                |
| [`f3eec660`](https://github.com/NixOS/nixpkgs/commit/f3eec660cd76c9863dde1dd3152e4efa71a1e277) | `levant: 0.3.0 -> 0.3.1`                                                     |
| [`3593043f`](https://github.com/NixOS/nixpkgs/commit/3593043f4b5764977d3edbcec32ea544f7e94ee7) | `gifski: 1.6.4 -> 1.7.0`                                                     |
| [`e7ed54d4`](https://github.com/NixOS/nixpkgs/commit/e7ed54d44ef244e742e175e8ab449c09371348c9) | `python310Packages.rx: use fetchPypi`                                        |
| [`d88d65b1`](https://github.com/NixOS/nixpkgs/commit/d88d65b1756d684d6f96304b3c71bc5e95fcb023) | `flow: 0.176.3 -> 0.183.1`                                                   |
| [`3ed2e755`](https://github.com/NixOS/nixpkgs/commit/3ed2e7552f16433e4b4690293c9ea981b736368a) | `lefthook: update meta`                                                      |
| [`7bc2ac64`](https://github.com/NixOS/nixpkgs/commit/7bc2ac64896d80fe21a7288988271f500d4f5f99) | `Revert "python3Packages.rx: 3.2.0 -> 4.0.4"`                                |
| [`a06500c7`](https://github.com/NixOS/nixpkgs/commit/a06500c7feb9cac7308ef294a341b26fb3b0c023) | `lefthook: install completions`                                              |
| [`b7a98b85`](https://github.com/NixOS/nixpkgs/commit/b7a98b858b2a6392a31713b308f5ad41e456a46b) | `python310Packages.sphinxcontrib-confluencebuilder: init at 1.8.0 (#182857)` |
| [`5bf5bdcd`](https://github.com/NixOS/nixpkgs/commit/5bf5bdcd8ae6fc3a9257dd56daa9985e000a1924) | `showmethekey: init at 1.7.3`                                                |
| [`08d517ed`](https://github.com/NixOS/nixpkgs/commit/08d517ed895153a3f9fd01381efb6091efdb858a) | `grpc-gateway: 2.11.0 -> 2.11.1`                                             |
| [`f42dbbdf`](https://github.com/NixOS/nixpkgs/commit/f42dbbdfe202d764ec85335ee9910e861c49c2d7) | `poke: mark aarch64-darwin as broken instead of a bad platform`              |
| [`3cd15405`](https://github.com/NixOS/nixpkgs/commit/3cd154051017bd0f795f534fbd21a2458aa44838) | `openmsx: 17.0 -> 18.0`                                                      |
| [`7e84744a`](https://github.com/NixOS/nixpkgs/commit/7e84744ad78bfee50a70abb0de1cead963a58040) | `cargo-edit: 0.10.3 -> 0.10.4`                                               |
| [`09abddcb`](https://github.com/NixOS/nixpkgs/commit/09abddcb9f64c8e42ed98dde9266e645d7b7998f) | `purple-signald: init at 0.11.0`                                             |
| [`93aa15ce`](https://github.com/NixOS/nixpkgs/commit/93aa15cebe1ecce6cc3123921f10d4fc04254157) | `python310Packages.mediapy: init at 1.0.3`                                   |
| [`a792c4e8`](https://github.com/NixOS/nixpkgs/commit/a792c4e86efb4f94e7673b962edf30b7868cd911) | `gum: init at 0.1.0 (#183396)`                                               |
| [`90492e30`](https://github.com/NixOS/nixpkgs/commit/90492e30ec5f7571fb72d6b9301f0c3c79c334ec) | `signal-cli: 0.10.8 -> 0.10.9`                                               |
| [`68354795`](https://github.com/NixOS/nixpkgs/commit/68354795449a00a3f25a32b82edea84f003f3b2f) | `openxray: Remove multiplayer option, fix license URL`                       |
| [`8d76b232`](https://github.com/NixOS/nixpkgs/commit/8d76b2329018701e6ee0c1beed7bc8a080af4d07) | `fishPlugins.autopair-fish: init at 1.0.4 (#176884)`                         |
| [`a95e402d`](https://github.com/NixOS/nixpkgs/commit/a95e402d3f6d33b24af05fce9813bf4da82c2f17) | `simpleitk: 2.1.1 -> 2.1.1.1`                                                |
| [`a65d9a7a`](https://github.com/NixOS/nixpkgs/commit/a65d9a7a894ff647dfe5ed342c2048641ca49d3c) | `redpanda: 22.1.3 -> 22.1.6`                                                 |
| [`61c04739`](https://github.com/NixOS/nixpkgs/commit/61c0473909646eebf0ceb5bbc2510a1bfeb1fca0) | `sof-firmware: 2.1.1 -> 2.2`                                                 |
| [`af8de190`](https://github.com/NixOS/nixpkgs/commit/af8de1904ee5d05e4fda75548e63697d7451918a) | `simdjson: 2.2.0 -> 2.2.2`                                                   |
| [`1372c754`](https://github.com/NixOS/nixpkgs/commit/1372c7546f45e33d2ef523f7c642b39de5dc0296) | `pythonPackages.oscpy: fix flaky tests`                                      |
| [`02319abb`](https://github.com/NixOS/nixpkgs/commit/02319abb81da8ee5d661f9b30fb0502b5d186c25) | `sccache: 0.2.15 -> 0.3.0`                                                   |
| [`d31b00de`](https://github.com/NixOS/nixpkgs/commit/d31b00dea130058770bdbc40570164b18b9c14d9) | `somebar: init at 1.0.0 (#183164)`                                           |
| [`432e0097`](https://github.com/NixOS/nixpkgs/commit/432e00979e7d7f9eaf0dff9fcdb42fbf1edd49a3) | `s5cmd: 1.4.0 -> 2.0.0`                                                      |
| [`3aaf1525`](https://github.com/NixOS/nixpkgs/commit/3aaf1525adab553482baa7dfd5f570c1190c489c) | `rtsp-simple-server: 0.17.17 -> 0.19.3`                                      |
| [`cde95b8a`](https://github.com/NixOS/nixpkgs/commit/cde95b8a3e47b2780a180aa64aae503a0d432bbe) | `inkcut: fixes for use with newer inkscape and python`                       |
| [`dd4867bb`](https://github.com/NixOS/nixpkgs/commit/dd4867bbd726c63210d5ce2d3ba64342f996e000) | `docker-compose: 2.7.0 -> 2.8.0`                                             |
| [`4061da85`](https://github.com/NixOS/nixpkgs/commit/4061da8538a890563b0466f8ff5500db36f682a9) | `rocksdb: 7.3.1 -> 7.4.4`                                                    |
| [`d4e80af0`](https://github.com/NixOS/nixpkgs/commit/d4e80af0ff6e7b2e5c9fc5ba4a8f89bf0d0206d8) | `maintainers: add hufman`                                                    |
| [`8790490c`](https://github.com/NixOS/nixpkgs/commit/8790490c4e2c3f1632cb6afe9cc31a2ab401b5d0) | `renderdoc: 1.18 -> 1.21`                                                    |
| [`f4837742`](https://github.com/NixOS/nixpkgs/commit/f4837742642848a5d0aa2a81a529ae0acc97978c) | `wget: remove ? null from inputs`                                            |
| [`a6ea80e4`](https://github.com/NixOS/nixpkgs/commit/a6ea80e48a53ce197b794022a8676e1cdf41aba5) | `rmfakecloud: 0.0.7 -> 0.0.8`                                                |
| [`a92f292d`](https://github.com/NixOS/nixpkgs/commit/a92f292d3b59a94928e4ddaad3b195b4b94c5a2f) | `relic: 7.3.0 -> 7.4.0`                                                      |
| [`0309e44a`](https://github.com/NixOS/nixpkgs/commit/0309e44af577afb20b170401dc3e57b9cb98cc1f) | `lychee: fix build on darwin`                                                |
| [`5d2cb0d1`](https://github.com/NixOS/nixpkgs/commit/5d2cb0d178bd4aaddb8d4ba2cf7fd06e32f8bc16) | `redis-plus-plus: 1.3.3 -> 1.3.5`                                            |
| [`e5d584fc`](https://github.com/NixOS/nixpkgs/commit/e5d584fcbeb2bd34268e5af17d1615e53f819d85) | `rcm: 1.3.4 -> 1.3.5`                                                        |
| [`41a762d8`](https://github.com/NixOS/nixpkgs/commit/41a762d8586ea8171a74880bcb156cbec2cce33d) | `python3Packages.plantuml-markdown: init at 3.6.2 (#183637)`                 |
| [`45c19a65`](https://github.com/NixOS/nixpkgs/commit/45c19a65c5decb23130c6fe6d6302478d999c093) | `python310Packages.sentry-sdk: 1.8.0 -> 1.9.0`                               |
| [`e046e5b5`](https://github.com/NixOS/nixpkgs/commit/e046e5b5f03310508d8ae138153b4e26c0dd9e37) | `rapidfuzz-cpp: 1.0.4 -> 1.1.0`                                              |
| [`ecdd1778`](https://github.com/NixOS/nixpkgs/commit/ecdd17788b00e84bd71c2fad85c9e589c1477b1d) | `railway: 1.8.3 -> 1.8.4`                                                    |
| [`b8907211`](https://github.com/NixOS/nixpkgs/commit/b89072119bbb139572ef6dfb54a3e3c1f5ef502c) | `python310Packages.types-setuptools: 63.2.1 -> 63.2.2`                       |
| [`af8ece72`](https://github.com/NixOS/nixpkgs/commit/af8ece72d575864921b86ee041dddc69bf6da765) | `qrcodegen: 1.7.0 -> 1.8.0`                                                  |
| [`10137212`](https://github.com/NixOS/nixpkgs/commit/101372127a3c34d3da0420c827641c0cf3c114f7) | `pass-secret-service: unstable-2022-03-21 -> unstable-2022-07-18`            |
| [`43d945c0`](https://github.com/NixOS/nixpkgs/commit/43d945c05fd3abf37d8b225c88ebd9eb4d608d63) | `qmplay2: 22.03.19 -> 22.06.16`                                              |
| [`e4ff6fa1`](https://github.com/NixOS/nixpkgs/commit/e4ff6fa16ed39102b421f6d09512fc7bc6350008) | `qFlipper: 1.1.0 -> 1.1.1`                                                   |
| [`5b731dbc`](https://github.com/NixOS/nixpkgs/commit/5b731dbc6784dcb5a4c374fe78223dccb1daed51) | `python3Packages.pygls: 0.11.3 -> 0.12`                                      |
| [`d9e557dc`](https://github.com/NixOS/nixpkgs/commit/d9e557dc3f7085864f967762b26ad5627e00a5a2) | `exportarr: init at 1.1.0`                                                   |
| [`46332708`](https://github.com/NixOS/nixpkgs/commit/463327086db22fc62540532ae43d933e3e0caf29) | `lib/systems/inspect.nix: add isAarch`                                       |