### PR TITLE
chore(flake/home-manager): `0e2f7876` -> `7146638e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658924727,
-        "narHash": "sha256-Fhh9FK9CvuCLxG1WkWJPoendDeXKI4gHYTfezo1n2Zg=",
+        "lastModified": 1659232160,
+        "narHash": "sha256-RYKbKAYooiART2RUEpUnP7tAYM6+2i1m9+QI14wljZU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0e2f7876d2f2ae98a67d89a8bef8c49332aae5af",
+        "rev": "7146638e9ef74aba6736cbbf12dbe60e1ed24c1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message      |
| ----------------------------------------------------------------------------------------------------------- | ------------------- |
| [`7146638e`](https://github.com/nix-community/home-manager/commit/7146638e9ef74aba6736cbbf12dbe60e1ed24c1e) | `Fix typo. (#3118)` |