### PR TITLE
chore(flake/home-manager): `d1c677ac` -> `77648a07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659371922,
-        "narHash": "sha256-lzHe7LN7reblaonfkemzfmB0aRZDt7QJ/Vbp7iyghnU=",
+        "lastModified": 1659398318,
+        "narHash": "sha256-5wovS14I/DNXwfiMP402Ut2kxI58CO1wD943fboWMDw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d1c677ac257affed8d026f418b81ed5de2c8d963",
+        "rev": "77648a07e459adff69b2c4033a77b2cababb5843",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`77648a07`](https://github.com/nix-community/home-manager/commit/77648a07e459adff69b2c4033a77b2cababb5843) | `hyfetch: prevent writing config with default/empty settings (#3124)` |