### PR TITLE
chore(flake/nixpkgs): `7b9be38c` -> `5857574d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659219666,
-        "narHash": "sha256-pzYr5fokQPHv7CmUXioOhhzDy/XyWOIXP4LZvv/T7Mk=",
+        "lastModified": 1659305579,
+        "narHash": "sha256-SFeQTmh7hc9Y2fSkooHaoS8mDfPa04sfmUCtQ8MA6Pg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7b9be38c7250b22d829ab6effdee90d5e40c6e5c",
+        "rev": "5857574d45925585baffde730369414319228a84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`bb0c4894`](https://github.com/NixOS/nixpkgs/commit/bb0c489414ae5f7d70ed2d5a621724fa50596165) | `remodel: init at 0.10.0`                                          |
| [`b2ac3b41`](https://github.com/NixOS/nixpkgs/commit/b2ac3b41b6fe183b69bca6636ae1958e08636e42) | `links2: 2.25 -> 2.27`                                             |
| [`c2472d03`](https://github.com/NixOS/nixpkgs/commit/c2472d03bc8b59c87281789b578b10e7e54082b9) | `dogecoin: cleanup and fix darwin build`                           |
| [`95ba3d1e`](https://github.com/NixOS/nixpkgs/commit/95ba3d1e69e4e9be0681a46dcdb4ef0c50f3678a) | `ocamlPackages.ssl: 0.5.10 -> 0.5.11`                              |
| [`ac35f25d`](https://github.com/NixOS/nixpkgs/commit/ac35f25d0d9f91e5cf37b4ec1a00471f431d89a5) | `vimPlugins.hare-vim: init at 2022-07-02`                          |
| [`01098c4d`](https://github.com/NixOS/nixpkgs/commit/01098c4dbd85045322093dcf349bd4008ce6b44b) | `jmol: 14.32.45 -> 14.32.66`                                       |
| [`70fa299e`](https://github.com/NixOS/nixpkgs/commit/70fa299edfec2ea62d60aadae8fe4a3434a2421e) | `signal-cli: 0.10.9 -> 0.10.10`                                    |
| [`8e31bf7b`](https://github.com/NixOS/nixpkgs/commit/8e31bf7beb67a94fa9fbfa8a7a157c3229c44372) | `python310Packages.pytest-subtesthack: 0.1.2 -> 0.2.0`             |
| [`f3b0df8a`](https://github.com/NixOS/nixpkgs/commit/f3b0df8ab83c1590932f46831a579ea2708133d5) | `python3Packages.opensimplex: 0.4.2 -> 0.4.3`                      |
| [`4c3caca9`](https://github.com/NixOS/nixpkgs/commit/4c3caca96dc1b7fa9f0fce9e1a3285f748fb94a4) | `snakemake: 7.9.0 -> 7.12.0`                                       |
| [`64b836ef`](https://github.com/NixOS/nixpkgs/commit/64b836ef3c64a2662473303c1aac8029c32372d6) | `homebank: 5.5.5 -> 5.5.6`                                         |
| [`dd1ee65b`](https://github.com/NixOS/nixpkgs/commit/dd1ee65bff79d7db34e22005e5464519b652efa5) | `hwloc: 2.7.1 -> 2.8.0`                                            |
| [`6ff577cc`](https://github.com/NixOS/nixpkgs/commit/6ff577cce96c5cfb8705d7c93b0535fed100b75c) | `hevea: 2.35 -> 2.36`                                              |
| [`98ef7782`](https://github.com/NixOS/nixpkgs/commit/98ef77824c5ecdd0d571fc524527b15619048d76) | `httm: 0.13.4 -> 0.14.7`                                           |
| [`2cd793dd`](https://github.com/NixOS/nixpkgs/commit/2cd793dda0dfd3723947d8817bfd75b64e1e7a03) | `worker-build: 0.0.9 -> 0.0.10`                                    |
| [`56a0b09f`](https://github.com/NixOS/nixpkgs/commit/56a0b09f9bae3c232ea504351cf92d9f11da47a5) | `vcluster: add berryp as maintainer`                               |
| [`4f2f0ac6`](https://github.com/NixOS/nixpkgs/commit/4f2f0ac6ee823e82ddb333f6715a9f9b8bcdd722) | `neil: 0.0.31 -> 0.1.36`                                           |
| [`24678493`](https://github.com/NixOS/nixpkgs/commit/2467849361a7be63724495e1e83afd5299481642) | `vim: 9.0.0057 -> 9.0.0115`                                        |
| [`ea836299`](https://github.com/NixOS/nixpkgs/commit/ea836299d64582ea12bbdeb89dfa0c09dd008061) | `protoc-gen-rust: init at 3.1.0`                                   |
| [`33c5f1b8`](https://github.com/NixOS/nixpkgs/commit/33c5f1b8315d2edec8f02f6bf337ee85b146e896) | `taskwarrior-tui: 0.22.0 -> 0.23.5`                                |
| [`b5a565c9`](https://github.com/NixOS/nixpkgs/commit/b5a565c95160a2dd36c5bfe954972d5ca9231621) | `unison: 2.52.0 -> 2.52.1`                                         |
| [`9dd6ec45`](https://github.com/NixOS/nixpkgs/commit/9dd6ec456b934e1cc3452f001d4f4ef32a774a39) | `gscrabble: mark as broken`                                        |
| [`3de6a330`](https://github.com/NixOS/nixpkgs/commit/3de6a330bcd434d59901c9c7f8fbe252e2207e22) | `go, buildGo{Module,Package}: put top-level attributes together`   |
| [`06e270fd`](https://github.com/NixOS/nixpkgs/commit/06e270fd51daaf872382ad75a5f7a5607d9a87a8) | `buildGoModule: prefer verbose output when NIX_DEBUG set`          |
| [`a36984e1`](https://github.com/NixOS/nixpkgs/commit/a36984e191f106db35d49b132fb6d113bb1699c4) | `gama: 2.19 -> 2.21`                                               |
| [`439b1479`](https://github.com/NixOS/nixpkgs/commit/439b147934954e9fe178d81af6d524b06daacfae) | `awscli2: 2.7.14 -> 2.7.20`                                        |
| [`8f585b65`](https://github.com/NixOS/nixpkgs/commit/8f585b658b619c77566eb7d1be1620f2aba404c7) | `geoserver: 2.21.0 -> 2.21.1`                                      |
| [`acbab233`](https://github.com/NixOS/nixpkgs/commit/acbab233f94a5c34f610dd69d4c558b85eea5f76) | `dbx: use non-aliased variant of library`                          |
| [`cb83d392`](https://github.com/NixOS/nixpkgs/commit/cb83d392fe8490454a1c4a5b6be1da88f0d921ff) | `dbx: 0.5.0 -> 0.6.8`                                              |
| [`32833c81`](https://github.com/NixOS/nixpkgs/commit/32833c81c26284dc5d9b1d169b8852261cde7a5e) | `php80Extensions.grpc: 1.45.0 -> 1.48.0`                           |
| [`2099b754`](https://github.com/NixOS/nixpkgs/commit/2099b7545c90ae5962690db04e95280cd013b17f) | `gmime3: 3.2.11 -> 3.2.12`                                         |
| [`7f0dd61e`](https://github.com/NixOS/nixpkgs/commit/7f0dd61eb7e2955f9b50e8dc81f133d64d4e6bce) | `pip-audit: 2.4.2 -> 2.4.3`                                        |
| [`776957cd`](https://github.com/NixOS/nixpkgs/commit/776957cd890ea3189cb8786431b92242ea4e8399) | `python310Packages.nose2: 0.11.0 -> 0.12.0`                        |
| [`137e5dbe`](https://github.com/NixOS/nixpkgs/commit/137e5dbe10096f51c7ff718c5439b73a599ab1d4) | `python310Packages.azure-mgmt-recoveryservices: 2.0.0 -> 2.1.0`    |
| [`1fa5fdc8`](https://github.com/NixOS/nixpkgs/commit/1fa5fdc89890157005ea06b0b5378f6489afdd67) | `grails: 5.1.9 -> 5.2.1`                                           |
| [`762e2106`](https://github.com/NixOS/nixpkgs/commit/762e2106982340407263c6d3d86a7f33de2616ea) | `z88dk: 2.1 -> 2.2`                                                |
| [`9bb7a4d0`](https://github.com/NixOS/nixpkgs/commit/9bb7a4d0e9e7e649b9a0d23e9641b3eed64e9557) | `zsh-nix-shell: 0.4.0 -> 0.5.0`                                    |
| [`0cbb2d14`](https://github.com/NixOS/nixpkgs/commit/0cbb2d14a93642a570f80421869f3a08d2e813bd) | `kapp: 0.46.0 -> 0.50.0`                                           |
| [`d3401db6`](https://github.com/NixOS/nixpkgs/commit/d3401db627b847055093720bf78cdbf44985bf6b) | `z-lua: 1.8.14 -> 1.8.16`                                          |
| [`b417540d`](https://github.com/NixOS/nixpkgs/commit/b417540d5a5e1c51223b68193fdf61d3debb88ad) | `xmrig-mo: 6.16.5-mo1 -> 6.18.0-mo1`                               |
| [`9e158f95`](https://github.com/NixOS/nixpkgs/commit/9e158f95539e946190a1e905721ca540ee9f3d84) | `xmrig: 6.17.0 -> 6.18.0`                                          |
| [`75e6f8eb`](https://github.com/NixOS/nixpkgs/commit/75e6f8eb6f42aa75e4ae31db33c65715a0c106bd) | `xssproxy: 1.0.0 -> 1.0.1`                                         |
| [`fcc7cbce`](https://github.com/NixOS/nixpkgs/commit/fcc7cbce72b83f0e6656451b75e7760017867cec) | `wrangler: 1.19.11 -> 1.19.12`                                     |
| [`c3757625`](https://github.com/NixOS/nixpkgs/commit/c37576257bbf832d3857863b1cefaa7ce6528ead) | `workcraft: 3.3.6 -> 3.3.8`                                        |
| [`cf5b108a`](https://github.com/NixOS/nixpkgs/commit/cf5b108ae72c62ebd2a2c0024494c8e2feaad96f) | `werf: 1.2.140 -> 1.2.144`                                         |
| [`b40fa676`](https://github.com/NixOS/nixpkgs/commit/b40fa67604b71b6e1113af1606e42b55be185c2f) | `wasmer: 2.1.1 -> 2.3.0`                                           |
| [`f148e260`](https://github.com/NixOS/nixpkgs/commit/f148e260488ab7a6ac3a643b479f0b287e880d16) | `wasm-pack: 0.10.2 -> 0.10.3`                                      |
| [`e835aaa7`](https://github.com/NixOS/nixpkgs/commit/e835aaa789af70e466ba6e0304d1eab18a8d16d3) | `vale: 2.20.0 -> 2.20.1`                                           |
| [`4de14540`](https://github.com/NixOS/nixpkgs/commit/4de14540751c3603b88cffd9690d2df677e152e8) | `unpackerr: 0.10.0 -> 0.10.1`                                      |
| [`b2544f13`](https://github.com/NixOS/nixpkgs/commit/b2544f1301520be456fc33d296e6c9a5f6126391) | `terraform-providers: update 2022-07-31`                           |
| [`784a28af`](https://github.com/NixOS/nixpkgs/commit/784a28af407e51f37abe3a076a7c60bbf7ca0fe9) | `strawberry: 1.0.5 -> 1.0.7`                                       |
| [`7db1e3ba`](https://github.com/NixOS/nixpkgs/commit/7db1e3ba67a33d553c26878ec30f32fa9965c358) | `ucx: 1.12.1 -> 1.13.0`                                            |
| [`e22e418e`](https://github.com/NixOS/nixpkgs/commit/e22e418eca18ee5a799ea0aeefa9f8fa8adce600) | `tut: 1.0.14 -> 1.0.15`                                            |
| [`5e02a062`](https://github.com/NixOS/nixpkgs/commit/5e02a06208eddf8d92d175cf53fd61df7f98c604) | `ttyper: 0.4.1 -> 0.4.3`                                           |
| [`4c7fff30`](https://github.com/NixOS/nixpkgs/commit/4c7fff307d3439bf56413860f03faf58dd295588) | `trivy: 0.30.0 -> 0.30.4`                                          |
| [`1f1ba53b`](https://github.com/NixOS/nixpkgs/commit/1f1ba53b11d6200f8eb06aba2cf950be9681cd53) | `trinsic-cli: 1.5.0 -> 1.6.0`                                      |
| [`a071ead1`](https://github.com/NixOS/nixpkgs/commit/a071ead1ae8fe5698315e281d6a3a18259a09a04) | `trillian: 1.4.0 -> 1.4.2`                                         |
| [`953ed258`](https://github.com/NixOS/nixpkgs/commit/953ed2586a5b2dbed2578dcd0974b4b1053f8e5c) | `ticker: 4.5.1 -> 4.5.2`                                           |
| [`ac869ded`](https://github.com/NixOS/nixpkgs/commit/ac869dedaf56800c85f0c9f930fc654156260b28) | `thanos: 0.25.2 -> 0.27.0`                                         |
| [`eabdeadc`](https://github.com/NixOS/nixpkgs/commit/eabdeadceaee1000a7378143a426d6f8df999cf4) | `tfswitch: 0.13.1275 -> 0.13.1288`                                 |
| [`bf4cd8c2`](https://github.com/NixOS/nixpkgs/commit/bf4cd8c2c1cfc56f3b35dbbdee0815b33aa29942) | `tfplugindocs: 0.9.0 -> 0.13.0`                                    |
| [`d26a815c`](https://github.com/NixOS/nixpkgs/commit/d26a815cc0caf8883e75bd00c8928e97c3eaa69b) | `tflint: 0.39.0 -> 0.39.1`                                         |
| [`3cc01e78`](https://github.com/NixOS/nixpkgs/commit/3cc01e7860ccba3eb8d3df695e072b35591c2797) | `terraformer: 0.8.19 -> 0.8.21`                                    |
| [`dd121d6b`](https://github.com/NixOS/nixpkgs/commit/dd121d6b8f64d203e4ecd00444a99e0242cbfe8e) | `temporal: 1.16.2 -> 1.17.1`                                       |
| [`9b3be9e3`](https://github.com/NixOS/nixpkgs/commit/9b3be9e3d1c8a3154d0321808f9926c03d842e6e) | `syncthingtray: 1.1.20 -> 1.2.1`                                   |
| [`cfdd884e`](https://github.com/NixOS/nixpkgs/commit/cfdd884efd10042127ed7c12c1df8ff2b0f6698c) | `symfony-cli: 5.4.5 -> 5.4.12`                                     |
| [`a5c0e67e`](https://github.com/NixOS/nixpkgs/commit/a5c0e67ed47a51d0f68b2536af00be42b1d41273) | `stella: 6.6 -> 6.7`                                               |
| [`d1c11328`](https://github.com/NixOS/nixpkgs/commit/d1c11328a42446fa78b141a6ba72062cc278e9d0) | `python3Packages.ansible-runner: avoid test coverage`              |
| [`79d2a9f6`](https://github.com/NixOS/nixpkgs/commit/79d2a9f62ffdd292f2addf22ad6ad8e37751acfb) | `python39Packages.ansible-core: 2.13.1 -> 2.13.2`                  |
| [`98d75d6d`](https://github.com/NixOS/nixpkgs/commit/98d75d6d58fdb9237d7888ee04348bb9353047ca) | `spire: 1.3.1 -> 1.3.3`                                            |
| [`f7f301f0`](https://github.com/NixOS/nixpkgs/commit/f7f301f0fb36c72f22d34aa2f58d31b5178c7dfd) | `pythonPackage.liblarch: 3.0.1 -> 3.2.0`                           |
| [`3aaf8bb3`](https://github.com/NixOS/nixpkgs/commit/3aaf8bb3e57000685a56409496e7948ac9414d3b) | `python3Packages.mistune_2_0: 2.0.2 -> 2.0.4`                      |
| [`f7599cdb`](https://github.com/NixOS/nixpkgs/commit/f7599cdb3729fed8075c11365f1cb4370229a212) | `python310Packages.pyperf: 2.3.1 -> 2.4.0`                         |
| [`f6e857bc`](https://github.com/NixOS/nixpkgs/commit/f6e857bccb571719684a22b35b3b78f7d67a8804) | `maestral: fix tests`                                              |
| [`40d72b38`](https://github.com/NixOS/nixpkgs/commit/40d72b38c5eb2cf79ad2a53dc23a177582674caa) | `python310Packages.pudb: 2022.1.1 -> 2022.1.2`                     |
| [`dd91058d`](https://github.com/NixOS/nixpkgs/commit/dd91058dd6c33aab8de94bc206c6f836ccafdb2c) | `ares: 128 -> 129`                                                 |
| [`b4136b66`](https://github.com/NixOS/nixpkgs/commit/b4136b66e77543010ddfae49abb839040cc5c49f) | `okteto: 2.5.1 -> 2.5.2`                                           |
| [`6de6568b`](https://github.com/NixOS/nixpkgs/commit/6de6568b66a9956575a11f12d8c7dfa4ae00751c) | `nfpm: 2.16.0 -> 2.17.0`                                           |
| [`8a441125`](https://github.com/NixOS/nixpkgs/commit/8a4411252e9efcf19b5bad51bdf868d7fff776a6) | `catch2_3: skip test ApprovalTests on darwin`                      |
| [`fc9e5536`](https://github.com/NixOS/nixpkgs/commit/fc9e553653b9becaf4f678cd5d5eed493397e020) | `gitea: 1.16.9 -> 1.17.0`                                          |
| [`68973d60`](https://github.com/NixOS/nixpkgs/commit/68973d60a29a84310febc3988373c5f174ef4323) | `nixos/tests/systemd-machinectl: Fix resolved and UID shift check` |
| [`befaa616`](https://github.com/NixOS/nixpkgs/commit/befaa6164a92a8a655ac0801c7f145b99181dbe6) | `godns: 2.8.6 -> 2.8.7`                                            |
| [`21aeda0e`](https://github.com/NixOS/nixpkgs/commit/21aeda0e3783a80033cb91a8611fbe7842ca2d38) | `fwupd-efi: 1.2 -> 1.3`                                            |
| [`d49fe728`](https://github.com/NixOS/nixpkgs/commit/d49fe72888413ed73c9e2973c549ceba50821451) | `obsidian: 0.14.15 -> 0.15.9`                                      |
| [`070ce98d`](https://github.com/NixOS/nixpkgs/commit/070ce98ddaa40c86aa0d72f868b155a62bc2d360) | `seahub: build python path from overridden python`                 |
| [`c2d6628a`](https://github.com/NixOS/nixpkgs/commit/c2d6628ae97439b92a15ff2c3b0757add493a267) | `seahub: add passthru.tests`                                       |
| [`dd8386c4`](https://github.com/NixOS/nixpkgs/commit/dd8386c453dfa97be3f3a61892da6dc7e9685e53) | `nixos/seafile: version 9.0x compatibility`                        |
| [`8d6df4d0`](https://github.com/NixOS/nixpkgs/commit/8d6df4d03279ae49b09001abfe86bd5fbbad4a60) | `seahub: 8.0.8 -> 9.0.6`                                           |
| [`bc9ec95b`](https://github.com/NixOS/nixpkgs/commit/bc9ec95b3609e6655c38ff09cfa340b671b1c634) | `seafile-server: 8.0.8 -> 9.0.6`                                   |
| [`b25178c7`](https://github.com/NixOS/nixpkgs/commit/b25178c77eed916713267ff0b7cb8c171c85402b) | `ccls: 0.20210330 -> 0.20220729`                                   |
| [`7cf711c4`](https://github.com/NixOS/nixpkgs/commit/7cf711c4e045ad5dbd77bc07bcd30db7807a2298) | `catch2_3: 3.0.1 -> 3.1.0`                                         |
| [`cc95d8a7`](https://github.com/NixOS/nixpkgs/commit/cc95d8a7225d8346b7b1a18fc8633df0df29790f) | `fava: 1.22.1 -> 1.22.2`                                           |
| [`1372f30f`](https://github.com/NixOS/nixpkgs/commit/1372f30f9af35f8633fdeafa1d286612046114a5) | `herbstluftwm: 0.9.4 -> 0.9.5`                                     |
| [`fafa29f6`](https://github.com/NixOS/nixpkgs/commit/fafa29f6e4da919334c44baf6e6296e6fdb93bd5) | `sssd: 2.7.0 -> 2.7.3`                                             |
| [`75d6a6a7`](https://github.com/NixOS/nixpkgs/commit/75d6a6a7fbc30a658685b25630982c3917caca44) | `bazel_5: get libtool from path`                                   |
| [`e517b841`](https://github.com/NixOS/nixpkgs/commit/e517b841291e9cb28bf4c0f729a60dc88f75c385) | `taplo: rename from taplo-{cli,lsp}, 0.6.2 -> 0.6.9`               |
| [`bf3dadf8`](https://github.com/NixOS/nixpkgs/commit/bf3dadf8bd184eec8ff625112afd796a3ed52001) | `crlfsuite: 2.1.1 -> 2.1.2`                                        |
| [`0ee39172`](https://github.com/NixOS/nixpkgs/commit/0ee39172153cf15ec30bf5ff749c09ec4daa9098) | `python310Packages.grpcio-status: 1.47.0 -> 1.48.0`                |
| [`e8998f3e`](https://github.com/NixOS/nixpkgs/commit/e8998f3eb76d7879c56f71a82a6a258310e53071) | `python310Packages.grpcio-tools: 1.47.0 -> 1.48.0`                 |
| [`dcf37076`](https://github.com/NixOS/nixpkgs/commit/dcf370765968839fa6c395ea445e348191af183c) | `checkip: 0.40.0 -> 0.40.1`                                        |
| [`0d4a364e`](https://github.com/NixOS/nixpkgs/commit/0d4a364e48666d18b1028c4d422090452f844793) | `brial: 1.2.10 -> 1.2.11`                                          |
| [`5c90b02d`](https://github.com/NixOS/nixpkgs/commit/5c90b02dfc7b00b31354e9bbe5ebc232086dcc7a) | `sish: 2.1.0 -> 2.5.0`                                             |
| [`b0cb65de`](https://github.com/NixOS/nixpkgs/commit/b0cb65de662fcabb46d9c58d0a3806c3860a9f8f) | `scilla: 1.2.1 -> 1.2.2`                                           |
| [`e08ba682`](https://github.com/NixOS/nixpkgs/commit/e08ba682fed92b0ab7ccaac1f0cd7ad706ac0c9b) | `ryzenadj: 0.9.0 -> 0.10.0`                                        |
| [`1d4775f5`](https://github.com/NixOS/nixpkgs/commit/1d4775f551070e93a7e2f9a13c0f9d88ea2295ee) | `rocketchat-desktop: 3.8.5 -> 3.8.7`                               |
| [`3989d02f`](https://github.com/NixOS/nixpkgs/commit/3989d02f0029c7dba3835a5f58d81dd1dee99c06) | `rdma-core: 40.0 -> 41.0`                                          |
| [`da84b8be`](https://github.com/NixOS/nixpkgs/commit/da84b8be5588c3c634d8768004401226cf645dff) | `python310Packages.pyotgw: 2.0.0 -> 2.0.1`                         |
| [`7a22d92f`](https://github.com/NixOS/nixpkgs/commit/7a22d92feaa407609091e5e0074ce11377977c6f) | `protonmail-bridge: 2.1.1 -> 2.1.3`                                |
| [`ecb30421`](https://github.com/NixOS/nixpkgs/commit/ecb304215811f6d1b3fdeeccc13285617196c919) | `polkadot: 0.9.21 -> 0.9.26`                                       |
| [`0d82ebcf`](https://github.com/NixOS/nixpkgs/commit/0d82ebcfeeacf5c223337d722558a50d8325b6e1) | `plantuml-server: 1.2022.2 -> 1.2022.6`                            |
| [`317dc424`](https://github.com/NixOS/nixpkgs/commit/317dc424b89c432c79a471bd5f96e7121707ea28) | `pangolin: 0.6 -> 0.8`                                             |
| [`bcec0293`](https://github.com/NixOS/nixpkgs/commit/bcec029310f95fcdaaf52bb413518e3764888b48) | `glooctl: 1.10.10 -> 1.11.25`                                      |
| [`13690f79`](https://github.com/NixOS/nixpkgs/commit/13690f792170b4d67110ecb86ebcddde51fff5b3) | `codec2: 1.0.3 -> 1.0.5`                                           |
| [`28dae620`](https://github.com/NixOS/nixpkgs/commit/28dae620b2132d836f998a83b98e4b59ba5c5e4c) | `nixos-rebuild: always set flakeFlags`                             |
| [`8457d927`](https://github.com/NixOS/nixpkgs/commit/8457d9277a5346360480eeeb9319567ad94fe1e7) | `system.autoUpgrade: add boot option.`                             |
| [`ec5b8c16`](https://github.com/NixOS/nixpkgs/commit/ec5b8c16b92db00600f280334a36a5ca7253c297) | `nixpacks: 0.1.7 -> 0.2.11`                                        |
| [`a6a4aba0`](https://github.com/NixOS/nixpkgs/commit/a6a4aba059fb0757778bb0b32b575f2d2fb86b76) | `nimlsp: 0.4.0 -> 0.4.1`                                           |
| [`c4b15410`](https://github.com/NixOS/nixpkgs/commit/c4b1541021e71a4934b1d71bd6db75afb7064f85) | `nilfs-utils: 2.2.8 -> 2.2.9`                                      |
| [`210ef663`](https://github.com/NixOS/nixpkgs/commit/210ef6638ef5da5cdf287f9ad75d099942ac10f2) | `mcfly: 0.6.0 -> 0.6.1`                                            |
| [`788c272c`](https://github.com/NixOS/nixpkgs/commit/788c272cffea76a0be7813cd1fba173915d95405) | `mamba: 2.2 -> 2.3`                                                |
| [`157e5568`](https://github.com/NixOS/nixpkgs/commit/157e5568b3fa3cb39ef8fc349bbddef622153ef0) | `lychee: 0.9.0 -> 0.10.1`                                          |
| [`a3d3b9e7`](https://github.com/NixOS/nixpkgs/commit/a3d3b9e7ee7855df970e8b568dfbfb7ea8b6fccd) | `kubergrunt: 0.8.0 -> 0.9.1`                                       |
| [`6cd68fad`](https://github.com/NixOS/nixpkgs/commit/6cd68fad73f9cd975449bed160290d5ee3751355) | `kubebuilder: 3.3.0 -> 3.5.0`                                      |
| [`87648bc9`](https://github.com/NixOS/nixpkgs/commit/87648bc9d2f571d606156607193757b66673642a) | `kube3d: 5.4.1 -> 5.4.4`                                           |
| [`708ffc82`](https://github.com/NixOS/nixpkgs/commit/708ffc82e88c7b62df6423aed2b635a7d15c6042) | `gobgpd: 3.0.0 -> 3.4.0`                                           |
| [`a801f4a9`](https://github.com/NixOS/nixpkgs/commit/a801f4a91938b6b2ab1e4268f478232bc75a1811) | `gobgp: 3.0.0 -> 3.4.0`                                            |
| [`34bbc6b5`](https://github.com/NixOS/nixpkgs/commit/34bbc6b5f499f7d48a781b387f347539486bbf47) | `confluent-platform: 7.2.0 -> 7.2.1`                               |
| [`f8e9b39c`](https://github.com/NixOS/nixpkgs/commit/f8e9b39cdbd7aa125db88e60409022706147103b) | `postgresql: less confusing argument organization`                 |
| [`037dd369`](https://github.com/NixOS/nixpkgs/commit/037dd369231d2cb6b262b41723021d84a69fb807) | `postgresql: disable systemd support for static builds`            |
| [`77b84010`](https://github.com/NixOS/nixpkgs/commit/77b84010cd333c2ae1255b2fcc84435957583473) | `ocamlPackages.biocaml: disable for OCaml < 4.11`                  |
| [`a0de6591`](https://github.com/NixOS/nixpkgs/commit/a0de659121490d7e8f75fbdc8e854853a383d352) | `goawk: 1.18.0 -> 1.20.0`                                          |
| [`133ebbe4`](https://github.com/NixOS/nixpkgs/commit/133ebbe46a431374b7d2025444cfd0643ec28c5b) | `nixos/sssd: add an option to enable KCM support`                  |
| [`9c6b1fbc`](https://github.com/NixOS/nixpkgs/commit/9c6b1fbce39382b152f068f364af85dad96b7eab) | `grpc: 1.47.0 -> 1.48.0`                                           |
| [`ee63b2cd`](https://github.com/NixOS/nixpkgs/commit/ee63b2cd5ff502818db1547a90b9dfe957d61013) | `steampipe: 0.15.0 -> 0.15.3`                                      |
| [`b4a0bdcf`](https://github.com/NixOS/nixpkgs/commit/b4a0bdcf924ee4ab02954493cfeca44b8edf8b17) | `rpm: compile --with-cap`                                          |