### PR TITLE
chore(flake/nixpkgs): `5857574d` -> `12363fb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659305579,
-        "narHash": "sha256-SFeQTmh7hc9Y2fSkooHaoS8mDfPa04sfmUCtQ8MA6Pg=",
+        "lastModified": 1659487974,
+        "narHash": "sha256-CVGOtR/Wyq3TVCjf8/kdnYD5G2JwUKUQVtd+5WIDTuY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5857574d45925585baffde730369414319228a84",
+        "rev": "12363fb6d89859a37cd7e27f85288599f13e49d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`12363fb6`](https://github.com/NixOS/nixpkgs/commit/12363fb6d89859a37cd7e27f85288599f13e49d9) | `virt-what: 1.21 -> 1.24`                                                                   |
| [`60195670`](https://github.com/NixOS/nixpkgs/commit/601956706d88f53876f183787d1e460f6c812cb7) | `etcd_3_3: mark broken on darwin`                                                           |
| [`a0ae107c`](https://github.com/NixOS/nixpkgs/commit/a0ae107c1204dfa377f90dd625a31058084f6e0d) | `gdu: 5.14.0 -> 5.15.0`                                                                     |
| [`d70639d3`](https://github.com/NixOS/nixpkgs/commit/d70639d38ccd39155c0eeaf387f7141e48be51a9) | `unihan-database: 12.1.0 -> 14.0.0`                                                         |
| [`93c6488a`](https://github.com/NixOS/nixpkgs/commit/93c6488a8a971857800f46ef5e6630cf03a3e3b8) | `rpm-ostree: 2022.3 → 2022.12`                                                              |
| [`e76cdaaf`](https://github.com/NixOS/nixpkgs/commit/e76cdaaf82a5acf8dee013aa4fe20475ea8ec147) | `ostree: 2022.2 → 2022.5`                                                                   |
| [`fbf4f7dc`](https://github.com/NixOS/nixpkgs/commit/fbf4f7dcc07259be84cb1c20e30ec3cedac2c324) | `vscode-extensions.ms-vscode.PowerShell: init at 2022.7.2`                                  |
| [`0f0e63ff`](https://github.com/NixOS/nixpkgs/commit/0f0e63ff114ee5dc092063d21c8fbeab58a58ba1) | `lscolors: 0.11.0 -> 0.11.1`                                                                |
| [`dc42c671`](https://github.com/NixOS/nixpkgs/commit/dc42c6719788944bec8d02e6e14fbe6e650e1994) | `vault: 1.11.1 -> 1.11.2`                                                                   |
| [`3daef516`](https://github.com/NixOS/nixpkgs/commit/3daef5163eac9c8ef1aeb5eef1160398a18296d1) | `plex: 1.27.2.5929-a806c5905 -> 1.28.0.5999-97678ded3`                                      |
| [`d3ddb52c`](https://github.com/NixOS/nixpkgs/commit/d3ddb52c7582de3bfcc3e2d2c15c6ad5e5a4abcd) | `python3Packages.jupyter-repo2docker: add chardet dependency`                               |
| [`200224cc`](https://github.com/NixOS/nixpkgs/commit/200224cc83545dc73b4e709083643250a91ca256) | `luaPackages.serpent: add maintainer`                                                       |
| [`8efa6d18`](https://github.com/NixOS/nixpkgs/commit/8efa6d181cf0fb180f542f24d7ef06cd1bc2a411) | `luaPackages.serpent: init -> 0.30-2`                                                       |
| [`488056a4`](https://github.com/NixOS/nixpkgs/commit/488056a418afdeeb73f583aae73b1e369912b363) | `steam: fix opengl inside pressure-vessel`                                                  |
| [`4d6bee68`](https://github.com/NixOS/nixpkgs/commit/4d6bee687bf0bb60d4755b32f0b03dbc8a32408d) | `python3Packages.trezor, python3Packages.shamir-mnemonic: remove _1000101 from maintainers` |
| [`96be7f5a`](https://github.com/NixOS/nixpkgs/commit/96be7f5a908ab85b765308665d7f0fa26d4d9d1e) | `lib2geom: 1.1 → 1.2`                                                                       |
| [`5d1f3726`](https://github.com/NixOS/nixpkgs/commit/5d1f3726b2f8d9406c9fb06821621faad7ad4daa) | `skopeo: 1.9.1 -> 1.9.2`                                                                    |
| [`91706b1a`](https://github.com/NixOS/nixpkgs/commit/91706b1a3f9c4decef07a54a7b0c5bf06cdfcf80) | `coqPackages_8_13.smtcoq: build cvc4 with gcc10`                                            |
| [`99abca2c`](https://github.com/NixOS/nixpkgs/commit/99abca2c664d55b6a3945c8a4d2822eb07d59272) | `way-displays 1.5.3 -> 1.6.0`                                                               |
| [`5d5350c8`](https://github.com/NixOS/nixpkgs/commit/5d5350c85e965d5a1794fc0aab7f2ceb1fd47f34) | `libadwaita: add darwin support`                                                            |
| [`cf885915`](https://github.com/NixOS/nixpkgs/commit/cf885915b321c17fd569198f94b016d6b73e8302) | `iaito: 5.7.0 -> 5.7.2`                                                                     |
| [`937944cb`](https://github.com/NixOS/nixpkgs/commit/937944cbbc448ba4293049de4d264a791b10a3c4) | `tkrzw: 1.0.21 -> 1.0.24`                                                                   |
| [`e53c3110`](https://github.com/NixOS/nixpkgs/commit/e53c311042b3d9c486987f43609f76e8611516e5) | `nextcloud-client: 3.5.3 -> 3.5.4`                                                          |
| [`269c5e21`](https://github.com/NixOS/nixpkgs/commit/269c5e21cbe63d9907e2b17c9c2eb18b653696ec) | `grafana: 9.0.5 -> 9.0.6`                                                                   |
| [`25b464c8`](https://github.com/NixOS/nixpkgs/commit/25b464c8b318448d007957892923b4867f1ff6c7) | `terraform-full: remove (#184649)`                                                          |
| [`5c0e18a6`](https://github.com/NixOS/nixpkgs/commit/5c0e18a6bb553e692f276b7dafcd8058d5460046) | `nixos/soju: add defaults and assertions for TLS`                                           |
| [`be673c1a`](https://github.com/NixOS/nixpkgs/commit/be673c1a5b415124ef66e5531d23ceecf3d88aa4) | `istioctl: 1.14.1 -> 1.14.3`                                                                |
| [`f0cb1db5`](https://github.com/NixOS/nixpkgs/commit/f0cb1db5ffc6380e0c32b7b016a73339bd10a421) | `ssm-session-manager-plugin: Add aarch64-linux`                                             |
| [`305eb886`](https://github.com/NixOS/nixpkgs/commit/305eb886a37ecd08e496ec02266181be43b94460) | `imagemagick: 7.1.0-44 -> 7.1.0-45`                                                         |
| [`1d86e567`](https://github.com/NixOS/nixpkgs/commit/1d86e567527d433ef8b9e4829d61d3a0fcb19ec7) | `abcmidi: 2022.06.14 -> 2022.08.01`                                                         |
| [`b717ec92`](https://github.com/NixOS/nixpkgs/commit/b717ec92055bbd1654aa6696d7f9801e48537b4b) | `tpm2-pkcs11: fix build`                                                                    |
| [`5877d8e0`](https://github.com/NixOS/nixpkgs/commit/5877d8e072d382ec5da6d83219e52df0a90f9f52) | `samtools: Fix cross-compilation`                                                           |
| [`b693f928`](https://github.com/NixOS/nixpkgs/commit/b693f928f0c924736c6e958064a170d3e130e19c) | `raft-canonical: ignore broken test`                                                        |
| [`f73b6e98`](https://github.com/NixOS/nixpkgs/commit/f73b6e98b1e89810700c610c4c76c4715e1e63bc) | `python310Packages.validobj: 0.5.1 -> 0.6`                                                  |
| [`70e7bf37`](https://github.com/NixOS/nixpkgs/commit/70e7bf379bc04da94d737f05efbf61911d11cd29) | `python3Packages.tpm2-pytss: add missing pyyaml dependency`                                 |
| [`7e7b9616`](https://github.com/NixOS/nixpkgs/commit/7e7b96164de1e29f8f38485fd6960c1d7e6c3d0d) | `gnome.accerciser: 3.38.0 -> 3.40.0`                                                        |
| [`463fe0db`](https://github.com/NixOS/nixpkgs/commit/463fe0db3d511b6b13d42263c565162d0604d4b7) | `matrix-synapse: 1.63.1 -> 1.64.0`                                                          |
| [`630aff8a`](https://github.com/NixOS/nixpkgs/commit/630aff8aabaef04ce0019c29192bdd4b3c92df0f) | `gitlab-pages: 1.59.0 -> 1.62.0`                                                            |
| [`9ce6a0c7`](https://github.com/NixOS/nixpkgs/commit/9ce6a0c7dc6a1a7a5af1266343d0d7405d34fc37) | `yoda: 1.9.5 -> 1.9.6 (#184778)`                                                            |
| [`6213fe5f`](https://github.com/NixOS/nixpkgs/commit/6213fe5f7fcebad3149e61f5166367125715f63f) | `twiggy: init at 0.7.0`                                                                     |
| [`80602db3`](https://github.com/NixOS/nixpkgs/commit/80602db395b13be833133f762d17c8e34a21d579) | `linuxPackages.nvidia_x11_legacy390.settings: fix build`                                    |
| [`b3e03a8a`](https://github.com/NixOS/nixpkgs/commit/b3e03a8a0f8ca703fb1d6dbd45f5341c28041584) | `sgt-puzzles: 20220613 -> 20220802 (#184804)`                                               |
| [`20a30834`](https://github.com/NixOS/nixpkgs/commit/20a308341e6ee0255009a3a1359eefcb7c0e2658) | `fzf: 0.31.0 -> 0.32.0`                                                                     |
| [`bbc08180`](https://github.com/NixOS/nixpkgs/commit/bbc08180e5ba5846ff22b373153d65ca27f06069) | `python3Packages.pipx: fix build`                                                           |
| [`2e50f028`](https://github.com/NixOS/nixpkgs/commit/2e50f02809062a25c56f404b60ca6e2ae03b2f2d) | `jrnl: 2.8.4 -> 3.0.0`                                                                      |
| [`244864ac`](https://github.com/NixOS/nixpkgs/commit/244864acdc03060179deaa1418a536bc17a4d9f0) | `syncthing: 1.20.3 -> 1.20.4`                                                               |
| [`5959e283`](https://github.com/NixOS/nixpkgs/commit/5959e283cd9ce7dc8d08afcd22d62a6168d4bbbd) | `syncthing: also link nixosTests.syncthing in passthru.tests`                               |
| [`ad7f0678`](https://github.com/NixOS/nixpkgs/commit/ad7f06781bdc41b3c4c54526084ea41d81f4733e) | `crosvm: precompile seccomp policy files`                                                   |
| [`eb38d95b`](https://github.com/NixOS/nixpkgs/commit/eb38d95b8aa707888250bc121c7fc6002e4c9761) | `minijail-tools: move constants.json from minijail`                                         |
| [`196b1eab`](https://github.com/NixOS/nixpkgs/commit/196b1eabcdb8a0758ce6e434087f7942cf806e37) | `nodePackages.prisma: 4.0.0 -> 4.1.1`                                                       |
| [`80cc01a3`](https://github.com/NixOS/nixpkgs/commit/80cc01a3e03ac72bf3fa680d0841a4b95b14ed8b) | `prisma-engines: 4.0.0 -> 4.1.1`                                                            |
| [`364b4f09`](https://github.com/NixOS/nixpkgs/commit/364b4f09bbf3c89872a76aa63fe7ec66417a0639) | `prisma-engines: add tomhoule maintainer`                                                   |
| [`6d9bfcf7`](https://github.com/NixOS/nixpkgs/commit/6d9bfcf7087963f8d8d96cb46194f1c803c6f6de) | `exploitdb: 2022-07-27 -> 2022-08-02`                                                       |
| [`48f4befd`](https://github.com/NixOS/nixpkgs/commit/48f4befd440d272d8405d06f5ef0867300eebc64) | `trilium: 0.51.2 -> 0.53.2 + update script (#177484)`                                       |
| [`952610b3`](https://github.com/NixOS/nixpkgs/commit/952610b343bad303f2002630e3e40d7095387248) | ` maintainers: add joshvanl`                                                                |
| [`4517d73a`](https://github.com/NixOS/nixpkgs/commit/4517d73a9eaaead2d3901d79aa4f24429f248584) | `cmctl: 1.8.2 -> 1.9.1`                                                                     |
| [`d5f7213a`](https://github.com/NixOS/nixpkgs/commit/d5f7213a2a6e0ccd626f6e78055d247a28f2be11) | `maintainers: add tomhoule`                                                                 |
| [`73570ddb`](https://github.com/NixOS/nixpkgs/commit/73570ddb89ad28f8815e61aceb2f12f2df686175) | `dwarfs: init at 0.6.1`                                                                     |
| [`628c8afb`](https://github.com/NixOS/nixpkgs/commit/628c8afb5ab8d7874c22f72f9bd8a9743ea6aeed) | `docker-compose: 2.8.0 -> 2.9.0`                                                            |
| [`17b51351`](https://github.com/NixOS/nixpkgs/commit/17b513517b4286c9bfa36595d7842275435d8601) | `blueman: 2.3.1 -> 2.3.2`                                                                   |
| [`699c72e9`](https://github.com/NixOS/nixpkgs/commit/699c72e92c33beea2477a869815f4d68cf55f592) | `conftest: 0.33.2 -> 0.34.0`                                                                |
| [`c9ef570f`](https://github.com/NixOS/nixpkgs/commit/c9ef570ff8fd431bc1fc085d8f4ef4bdfd3d7b54) | `cargo-nextest: 0.9.30 -> 0.9.33`                                                           |
| [`1628f142`](https://github.com/NixOS/nixpkgs/commit/1628f1420e7754b4f9015e5da2472d725d268bce) | `beauty-line-icon-theme: fix src hash`                                                      |
| [`5e1a0eb1`](https://github.com/NixOS/nixpkgs/commit/5e1a0eb192cad8dcfae96dbe91f2365668976511) | `uncrustify: 0.75.0 -> 0.75.1`                                                              |
| [`e27543b1`](https://github.com/NixOS/nixpkgs/commit/e27543b15a357b05e61eac72e53e6e8a4b6466f2) | `maestral(-qt): add myself as maintainer`                                                   |
| [`da4f6c24`](https://github.com/NixOS/nixpkgs/commit/da4f6c24ae511082f4ef718aa6ffd63ff945c383) | `maestral-qt: (temporarily) override maestral version to fix build error`                   |
| [`7c862944`](https://github.com/NixOS/nixpkgs/commit/7c8629447b8b585e62bd8397c9f62f1b151dc8aa) | `yabasic: 2.90.1 -> 2.90.2`                                                                 |
| [`e1df6b94`](https://github.com/NixOS/nixpkgs/commit/e1df6b9433841eac301edbb42baaedfc7d3a7b20) | `vscode-extensions.xadillax.viml: 1.0.1 -> 2.1.2`                                           |
| [`6069b4b1`](https://github.com/NixOS/nixpkgs/commit/6069b4b144628c5cfae6e5bef7fa423833a3fac5) | `vscode-extensions.vscodevim.vim: 1.23.1 -> 1.23.2`                                         |
| [`ba126dbc`](https://github.com/NixOS/nixpkgs/commit/ba126dbc8711a067dc3ac5c65dfa40bb7d0e9934) | `vscode-extensions.asvetliakov.vscode-neovim: 0.0.86 -> 0.0.89`                             |
| [`740b5183`](https://github.com/NixOS/nixpkgs/commit/740b51832063248b477374d0a51bfc4fc4b5b2e9) | `zchunk: 1.2.0 -> 1.2.2`                                                                    |
| [`7af7eb8f`](https://github.com/NixOS/nixpkgs/commit/7af7eb8f1385321fd34f31dd82d459c8596a43c5) | `epick: 0.6.0 -> 0.7.0`                                                                     |
| [`2ad144ef`](https://github.com/NixOS/nixpkgs/commit/2ad144ef8955083e09788f71f9601e9578878ff2) | `beauty-line-icon-theme: 0.0.1 -> 0.0.4`                                                    |
| [`efae2911`](https://github.com/NixOS/nixpkgs/commit/efae29119a6327450a74511c194a11070a3e94e0) | `linuxPackages.nvidia_x11_beta_open: mark broken on 5.19`                                   |
| [`6aad09eb`](https://github.com/NixOS/nixpkgs/commit/6aad09eb5ff9f11ce15841a7c38f222c131c3304) | `linuxPackages.apfs: mark broken on 5.19`                                                   |
| [`cb802fc0`](https://github.com/NixOS/nixpkgs/commit/cb802fc08f02a8dd55644200e673c76bc06f5e09) | `whois: 5.5.12 -> 5.5.13`                                                                   |
| [`eea38ee7`](https://github.com/NixOS/nixpkgs/commit/eea38ee7157f95959baf87c606382ec62f98997c) | `xa: 2.3.12 -> 2.3.13`                                                                      |
| [`d2042f91`](https://github.com/NixOS/nixpkgs/commit/d2042f91c1ad953825556be3ec2e53cf9a91fc77) | `gpick: ensure GSettings schemas are available`                                             |
| [`700f2bc9`](https://github.com/NixOS/nixpkgs/commit/700f2bc99f925753a4a1975c8681889699349b7e) | `resholve: 0.8.0 -> 0.8.1; update readme`                                                   |
| [`04663d62`](https://github.com/NixOS/nixpkgs/commit/04663d62ac08dfa729936d200abeb1efb8835e7a) | `saleae-logic-2: 2.3.55 -> 2.3.56`                                                          |
| [`b2bb3f5a`](https://github.com/NixOS/nixpkgs/commit/b2bb3f5a256669daddd5de8b7ce62497303fcea4) | `telepresence2: 2.5.4 -> 2.6.4`                                                             |
| [`1c56d4f5`](https://github.com/NixOS/nixpkgs/commit/1c56d4f53949b8dea213e9cd612ec1e0768b7a99) | `termcolor: 2.0.0 -> 2.1.0`                                                                 |
| [`c4b4d404`](https://github.com/NixOS/nixpkgs/commit/c4b4d404611731094c230b5718fabc57f116c8a3) | `ustreamer: 4.11 -> 5.17`                                                                   |
| [`32cd729f`](https://github.com/NixOS/nixpkgs/commit/32cd729fbade41bd1610e448a9af5a8c162b1a81) | `squid: 5.4.1 -> 5.6`                                                                       |
| [`8a023dc8`](https://github.com/NixOS/nixpkgs/commit/8a023dc82ee1402eef9ed47ed8a89354982c8a78) | `skypeforlinux: 8.82.0.403 -> 8.86.0.407`                                                   |
| [`88a181b7`](https://github.com/NixOS/nixpkgs/commit/88a181b7d4e41a4a8386ee17d62ea1ccfd0ba88b) | `snowflake: 2.2.0 -> 2.3.0`                                                                 |
| [`a97e22cf`](https://github.com/NixOS/nixpkgs/commit/a97e22cff152e500b9963f41fe8287236023205d) | `sope: 5.5.1 -> 5.7.0`                                                                      |
| [`935c41b1`](https://github.com/NixOS/nixpkgs/commit/935c41b1192432c85cd8d3b38ad049a59a8760df) | `postman: 9.22.2 -> 9.25.2`                                                                 |
| [`71aeec00`](https://github.com/NixOS/nixpkgs/commit/71aeec004410bef995e659d0621884ff55675e01) | `sslmate: 1.9.0 -> 1.9.1`                                                                   |
| [`84f5edfc`](https://github.com/NixOS/nixpkgs/commit/84f5edfc93d8404e29f291f93db39c35bce90ef9) | `bun: 0.1.5 -> 0.1.6`                                                                       |
| [`055b22ee`](https://github.com/NixOS/nixpkgs/commit/055b22eeeb7d8e9813b190c2440f1456422f2b69) | `signald: 0.18.5 -> 0.19.1`                                                                 |
| [`c86625c0`](https://github.com/NixOS/nixpkgs/commit/c86625c0693511f8a2b5c638d591cdf71cf2912c) | `spoofer: 1.4.7 -> 1.4.8`                                                                   |
| [`2dc5ed7c`](https://github.com/NixOS/nixpkgs/commit/2dc5ed7cdd7d7ac12c9c06d4ab5839b6392c7d28) | `Update pkgs/development/tools/wizer/default.nix`                                           |
| [`9765a3f6`](https://github.com/NixOS/nixpkgs/commit/9765a3f6415b0558cb1520412d6c0e9ec29ebbda) | `Update pkgs/development/tools/wizer/default.nix`                                           |
| [`3e7e63e3`](https://github.com/NixOS/nixpkgs/commit/3e7e63e3e4dabb677cc95fd5d383c95a95ad712f) | `sstp: 1.0.16 -> 1.0.17`                                                                    |
| [`1104c057`](https://github.com/NixOS/nixpkgs/commit/1104c057ec2e1e74e9859ba2fb09f9380795f672) | `sanctity: 1.2.1 -> 1.3.1`                                                                  |