### PR TITLE
chore(flake/pre-commit-hooks): `61b1a82f` -> `6a9402e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -197,11 +197,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659628163,
-        "narHash": "sha256-3CfFGtc1FstAAF4Az9Ws67a9fxGuzsy2eKbjycGRtz0=",
+        "lastModified": 1659629599,
+        "narHash": "sha256-c9rvaqaH3HZo/C70E7rB18YSywa4ryTtN7CZ3cuCmoA=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "61b1a82fbe6df3570fd0691bd6e25516ddf70d3c",
+        "rev": "6a9402e8f233de16536349d1dd3f4595c23386a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message           |
| ------------------------------------------------------------------------------------------------------------ | ------------------------ |
| [`8e484ac0`](https://github.com/cachix/pre-commit-hooks.nix/commit/8e484ac0e43c69ddead06950e9bc11d19bb5a59a) | `simplify flake testing` |
| [`4085e5b1`](https://github.com/cachix/pre-commit-hooks.nix/commit/4085e5b1917a25e2959faaef191cf8d310d81fa7) | `bump deps`              |