### PR TITLE
chore(flake/nixpkgs): `12363fb6` -> `168d1c57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659487974,
-        "narHash": "sha256-CVGOtR/Wyq3TVCjf8/kdnYD5G2JwUKUQVtd+5WIDTuY=",
+        "lastModified": 1659522808,
+        "narHash": "sha256-HBcM19nGhI3IWwPNVlYb0MZ8VW6iKp4JbAVkeIHVykc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "12363fb6d89859a37cd7e27f85288599f13e49d9",
+        "rev": "168d1c578909dc143ba52dbed661c36e76b12b36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                        |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`23b63f6e`](https://github.com/NixOS/nixpkgs/commit/23b63f6e341df7691514318151f8f9cb6716f6a8) | `partition-manager: 22.04.0 -> 22.04.3`                               |
| [`00f984ff`](https://github.com/NixOS/nixpkgs/commit/00f984fffa624483498542643aea7683e46fd426) | `linux_5_19: add missing package alias`                               |
| [`436cc654`](https://github.com/NixOS/nixpkgs/commit/436cc6549fd7dd5edb080f895fa19ab681e03287) | `python310Packages.ffmpeg-progress-yield: 0.2.0 -> 0.3.0`             |
| [`c40047e5`](https://github.com/NixOS/nixpkgs/commit/c40047e56527d0190135351ae5aebc1cfa06520b) | `syslogng: 3.36.1 -> 3.37.1`                                          |
| [`f5c24d18`](https://github.com/NixOS/nixpkgs/commit/f5c24d18121299d21380829ea2ed6b9dc4239182) | `ncmpc: 0.46 -> 0.47`                                                 |
| [`b020f316`](https://github.com/NixOS/nixpkgs/commit/b020f316b6b2678af08501177a01cdd5140ba2e9) | `prometheus-blackbox-exporter: 0.21.1 -> 0.22.0`                      |
| [`20ab6771`](https://github.com/NixOS/nixpkgs/commit/20ab6771fb985ec3462a3d91c37f825842a1a8a5) | `libwpe: 1.12.0 -> 1.12.2`                                            |
| [`d5e7f6a6`](https://github.com/NixOS/nixpkgs/commit/d5e7f6a6135e2ee4395122a93bc22f389dc4a06b) | `add Promiscuous as valid value for linkConfig`                       |
| [`1f3dfdd3`](https://github.com/NixOS/nixpkgs/commit/1f3dfdd3ef6010b0d036aed76d248135b16c9727) | `lollypop: 1.4.31 -> 1.4.34`                                          |
| [`4b709d69`](https://github.com/NixOS/nixpkgs/commit/4b709d6920d69b027d4b0188bb616d881f37a2c6) | `gum: 0.1.0 -> 0.2.0`                                                 |
| [`bea08cad`](https://github.com/NixOS/nixpkgs/commit/bea08cad450c543d8807efa0f13e0b0b249f5c8a) | `resolve-march-native: init @ unstable-2022-07-29`                    |
| [`f8be1ed1`](https://github.com/NixOS/nixpkgs/commit/f8be1ed140eac7afb82796792a7fa449ed929e1d) | `k9s: 0.26.0 -> 0.26.1`                                               |
| [`600b36b1`](https://github.com/NixOS/nixpkgs/commit/600b36b117abc4d7a6bf41e63abc0f4ba47e4cd1) | `linuxPackages.xpadneo: fix license`                                  |
| [`dcbe29d1`](https://github.com/NixOS/nixpkgs/commit/dcbe29d119564582006e1eb500c8d73250b4ae57) | `linuxPackages.xpadneo: 0.9.1 -> 0.9.4`                               |
| [`1c33ec8a`](https://github.com/NixOS/nixpkgs/commit/1c33ec8a5342e2eee49f150b934e34e725e7e5b8) | `the-powder-toy: expand platforms to unix`                            |
| [`eaeb0900`](https://github.com/NixOS/nixpkgs/commit/eaeb09002a2f6cc2a4bd946488926d9e93e747a8) | `libvirt-glib: add darwin support`                                    |
| [`32b6f46e`](https://github.com/NixOS/nixpkgs/commit/32b6f46ec035996dbc6f1fce5d9c353376888f8a) | `libvirt: fix build on darwin`                                        |
| [`0e335003`](https://github.com/NixOS/nixpkgs/commit/0e3350035ecd9fc52aa09401f9638b6e5d04b9f5) | `rawtherapee: add darwin support`                                     |
| [`1e8102cd`](https://github.com/NixOS/nixpkgs/commit/1e8102cd580e4c968af839aae007943f1c3de70d) | `nixos/openldap: fix option description markdown`                     |
| [`b25c092d`](https://github.com/NixOS/nixpkgs/commit/b25c092de49c204d09f83e46fa9b7c9a8528d5ec) | `gnomeExtensions: auto-update`                                        |
| [`c65ecd7d`](https://github.com/NixOS/nixpkgs/commit/c65ecd7d21c4ab7c2ff3b1bb343085abb671924c) | `gopass: 1.14.3 -> 1.14.4`                                            |
| [`11a6b7ea`](https://github.com/NixOS/nixpkgs/commit/11a6b7ea4a1681c0c9713f075c4c10c7cca6d201) | `kubernetes-helmPlugins.helm-push: init at 0.10.3`                    |
| [`32f98060`](https://github.com/NixOS/nixpkgs/commit/32f980605efb171a45eaf1e39816a7065c2942d3) | `go_1_19: init at 1.19`                                               |
| [`c40b0147`](https://github.com/NixOS/nixpkgs/commit/c40b01473023667e4a3f7594cf0b6960c20cb801) | `textadept: 11.3 -> 11.4`                                             |
| [`213cf26f`](https://github.com/NixOS/nixpkgs/commit/213cf26f5e77b176dad4f22ebc29e7880b8e8394) | `textadept: 11.3 -> 11.4`                                             |
| [`8e4c74ff`](https://github.com/NixOS/nixpkgs/commit/8e4c74ff17bd61be72696dae560cb3a7c5152433) | `kdash: 0.3.2 -> 0.3.3`                                               |
| [`5b99fa89`](https://github.com/NixOS/nixpkgs/commit/5b99fa89865d84de88f4777ad98e0df80fd38150) | `jellyfin-ffmpeg: 5.0.1-8 -> 5.1-1`                                   |
| [`6c0a5d84`](https://github.com/NixOS/nixpkgs/commit/6c0a5d84e5ec923c292bc2e15d30f40bf7111637) | `Maintain Boogie 2.4.1 for use with Dafny`                            |
| [`149349a4`](https://github.com/NixOS/nixpkgs/commit/149349a4f082a460c81aa433416e53d76a91c08a) | `Drop an unneeded pkgs.`                                              |
| [`01fc8962`](https://github.com/NixOS/nixpkgs/commit/01fc89623bb608e10d57faa7862b816bc276c3a7) | `pkgs.boogie: 2.4.1 -> 2.15.7`                                        |
| [`3c2cd351`](https://github.com/NixOS/nixpkgs/commit/3c2cd351d49041373a74897472e905b38697489f) | `Add example error message.`                                          |
| [`6596bd54`](https://github.com/NixOS/nixpkgs/commit/6596bd54b9f4c831e96d0203ca39dd0d614b56a8) | `infracost: 0.10.8 -> 0.10.9`                                         |
| [`9c292dd0`](https://github.com/NixOS/nixpkgs/commit/9c292dd02ee67c47b15789a5709d9a544ed392b7) | `Updating sha256 to more realistic example`                           |
| [`0e91d53c`](https://github.com/NixOS/nixpkgs/commit/0e91d53cc541bc4676e993f4d841cab1457402f9) | `Update doc/builders/fetchers.chapter.md`                             |
| [`0685e4a9`](https://github.com/NixOS/nixpkgs/commit/0685e4a92984b7831a4256cc7e5463668f20e45c) | `Update doc/builders/fetchers.chapter.md`                             |
| [`6d0bf6ae`](https://github.com/NixOS/nixpkgs/commit/6d0bf6ae0549c37caae3f337219e622701b30402) | `Update doc/builders/fetchers.chapter.md`                             |
| [`0444078d`](https://github.com/NixOS/nixpkgs/commit/0444078dabdef0a4fdb64e9a607cf48a431c598c) | `Update doc/builders/fetchers.chapter.md`                             |
| [`53ffebbe`](https://github.com/NixOS/nixpkgs/commit/53ffebbe1ff7985875796b32fc2f0432a5ec0464) | `Update doc/builders/fetchers.chapter.md`                             |
| [`b8fc7ecb`](https://github.com/NixOS/nixpkgs/commit/b8fc7ecb902e4ff233feed2b498207a3536bf380) | `grpc-client-cli: 1.13.0 -> 1.13.1`                                   |
| [`263ccc48`](https://github.com/NixOS/nixpkgs/commit/263ccc48e0117047ce274e3597bb4c39f1d2cc9f) | `glooctl: 1.11.25 -> 1.12.0`                                          |
| [`4cb8aa13`](https://github.com/NixOS/nixpkgs/commit/4cb8aa1324fae075ea4acf74c9a2e4b316cab2a8) | ``doc: Add anchor to Recursive attributes in `mkDerivation```         |
| [`f6033c37`](https://github.com/NixOS/nixpkgs/commit/f6033c3769a6b37db74975db9ebb1cdc75a9f271) | `copilot-cli: 1.19.0 -> 1.20.0`                                       |
| [`e8fb2021`](https://github.com/NixOS/nixpkgs/commit/e8fb2021e92ad8764dcbe57e8842366a4b71abde) | `fclones: 0.26.0 -> 0.27.0`                                           |
| [`173ac388`](https://github.com/NixOS/nixpkgs/commit/173ac38875aabc3d6e286f7a06ceda81c5902fbc) | `zita-alsa-pcmi: 0.4.0 -> 0.5.1`                                      |
| [`4ca25557`](https://github.com/NixOS/nixpkgs/commit/4ca25557ee17a097ff21193694950084ed022a19) | `victoriametrics: 1.77.2 -> 1.79.0`                                   |
| [`158a2ad7`](https://github.com/NixOS/nixpkgs/commit/158a2ad7ab30634fb569049c8ddad2e491da7cc0) | `squirrel-sql: 4.3.0 -> 4.4.0`                                        |
| [`4a29ae4b`](https://github.com/NixOS/nixpkgs/commit/4a29ae4b3fec042ad576b38d18072654af6fdde9) | `sndio: 1.8.1 -> 1.9.0`                                               |
| [`e69070f0`](https://github.com/NixOS/nixpkgs/commit/e69070f04b3694d4e73f1b025fb5c20664a8c33c) | `simpleitk: 2.1.1.1 -> 2.1.1.2`                                       |
| [`a90393ee`](https://github.com/NixOS/nixpkgs/commit/a90393eef84c7dd410b70c782428b135d1239b3e) | `rust-analyzer: 2022-07-11 -> 2022-08-01`                             |
| [`357ae167`](https://github.com/NixOS/nixpkgs/commit/357ae167e2374454a5463222ab60782114b59148) | `crystal_1_0, crystal_1_1: fix build`                                 |
| [`257db1dd`](https://github.com/NixOS/nixpkgs/commit/257db1dd4a2dc4569ba5bfeb9d89f40cd891410c) | `nixos: systemd-coredump: improve disabled state`                     |
| [`b9ded7f4`](https://github.com/NixOS/nixpkgs/commit/b9ded7f417b4ddaa8a54c9d0109bc4b8015dd07d) | `zigbee2mqtt: 1.26.0 -> 1.27.0`                                       |
| [`f5a4d9be`](https://github.com/NixOS/nixpkgs/commit/f5a4d9be8d97e1784e29a976cbefbf253b63dafe) | `lv2lint: 0.14.0 -> 0.16.2`                                           |
| [`0893e1f0`](https://github.com/NixOS/nixpkgs/commit/0893e1f0e593472b6f8f209959960a165c9bd48a) | `webex: use non-aliased alsa-lib`                                     |
| [`1172cdc6`](https://github.com/NixOS/nixpkgs/commit/1172cdc65fd4e20c0e9c1934e8f90041867fe4a9) | `k40-whisperer: 0.59 -> 0.60`                                         |
| [`b003abde`](https://github.com/NixOS/nixpkgs/commit/b003abde0586fcc6ce2c021ed0b024a38d203316) | `system76-keyboard-configurator: use non-aliased pkg-config`          |
| [`79e590ca`](https://github.com/NixOS/nixpkgs/commit/79e590cac00ef0e0464bc70398fe03e77a02f9ae) | `libfilezilla: 0.37.2 -> 0.38.1`                                      |
| [`67145620`](https://github.com/NixOS/nixpkgs/commit/671456209756f5669b1930b012f14b04f25d2be5) | `kstars: 3.5.9 -> 3.6.0`                                              |
| [`be194e39`](https://github.com/NixOS/nixpkgs/commit/be194e390fee5f358040f6b667677e6ce5480685) | `nixos/ncdns: replace shortened link`                                 |
| [`886d7b7b`](https://github.com/NixOS/nixpkgs/commit/886d7b7be369c5449225b9447ef1298e7ac0b8ed) | `haproxy: 2.5.5 -> 2.6.2`                                             |
| [`e922c5ee`](https://github.com/NixOS/nixpkgs/commit/e922c5ee0f96062367a9addcec4a9e741ea2ea18) | `perlPackages.NetMQTTSimple: init at 1.26`                            |
| [`1ca70381`](https://github.com/NixOS/nixpkgs/commit/1ca70381190c014fa0a5d113442a82ea5d594d8f) | `ytt: set version`                                                    |
| [`2b2ddb65`](https://github.com/NixOS/nixpkgs/commit/2b2ddb655fb35470c835f7cbc204c47e0c3cb98d) | `pixiewps: 1.2.2 -> 1.4.2`                                            |
| [`ec8caf1e`](https://github.com/NixOS/nixpkgs/commit/ec8caf1ea118cbc0499205a5740f9bc937374682) | `pixiewps: change owner's github username`                            |
| [`550f8b9d`](https://github.com/NixOS/nixpkgs/commit/550f8b9ddd9821a62213523cef094c8fc0c7c355) | `glances: 3.2.6.4 -> 3.2.7`                                           |
| [`38a95ba7`](https://github.com/NixOS/nixpkgs/commit/38a95ba7649407631a3a26b872a50450dcccf1be) | `ytt: 0.41.1 -> 0.42.0`                                               |
| [`83ae3791`](https://github.com/NixOS/nixpkgs/commit/83ae379197da5ab2e98b3c1c11a62415ceb69c87) | `waypoint: 0.9.0 -> 0.9.1`                                            |
| [`9c547ce6`](https://github.com/NixOS/nixpkgs/commit/9c547ce61fd7ae4088d05cf8c804673271b85b06) | `python3Packages.jaxlib: provide non-alias default of cudnn`          |
| [`3f245408`](https://github.com/NixOS/nixpkgs/commit/3f2454080d47eb23755f70fa5b977f3454e63d84) | `opencpn: use non-aliased libusb1`                                    |
| [`8268080b`](https://github.com/NixOS/nixpkgs/commit/8268080b9c7253b167c79ea045f8e27dd3439635) | `nanotts: use non-aliased alsa-lib`                                   |
| [`3b4a2063`](https://github.com/NixOS/nixpkgs/commit/3b4a2063b6803ed0fef0a0a81323bdfa017dbdcf) | `gnubg: use non-aliased python`                                       |
| [`fc1fba2b`](https://github.com/NixOS/nixpkgs/commit/fc1fba2b09569f4fd7ebe3c914daa593ea6f6cae) | `dbx: update reference of path package`                               |
| [`6d77dfe1`](https://github.com/NixOS/nixpkgs/commit/6d77dfe185d00baf4b6a9df891adcb5a85f0a993) | `rss-bridge: 2022-01-20 -> 2022-06-14`                                |
| [`7b0abced`](https://github.com/NixOS/nixpkgs/commit/7b0abced8df1276663e978c31e80f941c8de6417) | `Update .git-blame-ignore-revs with typos-fix commit`                 |
| [`feddd5e7`](https://github.com/NixOS/nixpkgs/commit/feddd5e7f8c6f8167b48a077fa2a5394dc008999) | `manual: fix typos`                                                   |
| [`ef45bf38`](https://github.com/NixOS/nixpkgs/commit/ef45bf389af10c34dac1769e9e83bc3f204449c4) | `python3Packages.prompt-toolkit: Add note to failing test (#183337)`  |
| [`1b667eb4`](https://github.com/NixOS/nixpkgs/commit/1b667eb47eee09bd13aaa93c17eaaffc2c611fe2) | `libwacom: 2.2.0 -> 2.4.0`                                            |
| [`e2f6ee2b`](https://github.com/NixOS/nixpkgs/commit/e2f6ee2bf5ddfe333758fedf4d60b33d673a42e8) | `apt: 2.4.4 -> 2.5.2`                                                 |
| [`4e3764f4`](https://github.com/NixOS/nixpkgs/commit/4e3764f4714a64c362c049dc92e87892076a806f) | `ncgopher: 0.3.0 -> 0.4.0`                                            |
| [`0e16aa7b`](https://github.com/NixOS/nixpkgs/commit/0e16aa7b56aa10ab66399b61463a620dbb7223bc) | `bintools-wrapper: symlink ar too`                                    |
| [`ce7e1189`](https://github.com/NixOS/nixpkgs/commit/ce7e118975b96cbb0e2f7a2402bc661bc7fc5c28) | `libbpf: 0.8.0 -> 0.8.1`                                              |
| [`98b734d2`](https://github.com/NixOS/nixpkgs/commit/98b734d22ced0310390a34e59db22b336f85fe32) | `lightdm: fix cross`                                                  |
| [`73ee7eeb`](https://github.com/NixOS/nixpkgs/commit/73ee7eeb32e865586b0c601dacfc05c4c173b2db) | `accountsservice: fix cross`                                          |
| [`441c922a`](https://github.com/NixOS/nixpkgs/commit/441c922aa456b0b29629bbf5dd9d7de7a8d7ad5f) | `hcxtools: 6.2.5 -> 6.2.7`                                            |
| [`cd3a4609`](https://github.com/NixOS/nixpkgs/commit/cd3a46094b6c0a32d05aa724104463146cf0ab24) | `go-swag: 1.8.0 -> 1.8.4`                                             |
| [`2bfcdf64`](https://github.com/NixOS/nixpkgs/commit/2bfcdf649ce57eea2529c427cf02309d2e47c9d1) | `fluidsynth: 2.2.7 -> 2.2.8`                                          |
| [`94f3b464`](https://github.com/NixOS/nixpkgs/commit/94f3b464eee40b0119b8a673cd2ab8c4b4981683) | `k6: 0.38.3 -> 0.39.0`                                                |
| [`b0ffabde`](https://github.com/NixOS/nixpkgs/commit/b0ffabde2c38939fe00efd24394c7ab93a24a839) | `python3Packages.tomlkit: 0.10.1 -> 0.11.1`                           |
| [`7a182f54`](https://github.com/NixOS/nixpkgs/commit/7a182f54f512f0c1b31c742159ed5e2901669afc) | `debootstrap: 1.0.126 -> 1.0.127`                                     |
| [`c77d922e`](https://github.com/NixOS/nixpkgs/commit/c77d922e9ceb5d6b99eff8cd1de8f4eaa2292f69) | `libqrtr-glib: fix cross`                                             |
| [`da1ea54a`](https://github.com/NixOS/nixpkgs/commit/da1ea54ad82fee3b3f5a825cb4f7151457c87f01) | `gobject-introspection: use objdump -p instead of prelink-rtld`       |
| [`d776e7bc`](https://github.com/NixOS/nixpkgs/commit/d776e7bc6517c6ab78aec5f86579d84d750f1dc1) | `prelink: disable tests`                                              |
| [`b21e1b5d`](https://github.com/NixOS/nixpkgs/commit/b21e1b5d1abcafa1b6e020e8b0338d307b624dc1) | `opencv: Use OpenJPEG from nixpkgs instead of vendored copy`          |
| [`8532168f`](https://github.com/NixOS/nixpkgs/commit/8532168fd7c975b7e492bbfae7f9448c60323938) | `nixos/tests/convos: fix tests`                                       |
| [`011f472b`](https://github.com/NixOS/nixpkgs/commit/011f472b2990dfd7a875c9408e27393861870e91) | `convos: 6.42 -> 7.02`                                                |
| [`10d61fb5`](https://github.com/NixOS/nixpkgs/commit/10d61fb56dbd017412dd72d408a919965a7f4829) | `perlPackages.MojoliciousPluginSyslog: 0.05 -> 0.06`                  |
| [`6bbb68c7`](https://github.com/NixOS/nixpkgs/commit/6bbb68c7bc7ee34ed1918c2b1490cac1c4e3516e) | `perlPackages.XSParseKeyword: 0.12 -> 0.25`                           |
| [`6c1c59cc`](https://github.com/NixOS/nixpkgs/commit/6c1c59cc2ed7d87d2ef579a9a3aca0ed1dfe6367) | `perlPackages.SyntaxKeywordTry: 0.25 -> 0.27`                         |
| [`8e10e401`](https://github.com/NixOS/nixpkgs/commit/8e10e4018042c4c432c20d13af6f375ac3bfaf5b) | `perlPackages.XSParseSublike: 0.12 -> 0.16`                           |
| [`b43e6d67`](https://github.com/NixOS/nixpkgs/commit/b43e6d672efe47c667067a3e6531300c3875ea12) | `perlPackages.FutureAsyncAwait: 0.52 -> 0.58`                         |
| [`af01368b`](https://github.com/NixOS/nixpkgs/commit/af01368b758a9f85aa225307aa25d973387a2ae8) | `perlPackages.Future: 0.47 -> 0.48`                                   |
| [`21f4acba`](https://github.com/NixOS/nixpkgs/commit/21f4acbacecb9415c9c6621d3ecaf4602b20ea07) | `goreman: 0.3.11 -> 0.3.13`                                           |
| [`05a57534`](https://github.com/NixOS/nixpkgs/commit/05a57534dfae8bb110059267a0c5af7e136c1a11) | `openal: 1.22.0 -> 1.22.2`                                            |
| [`020ca659`](https://github.com/NixOS/nixpkgs/commit/020ca659d7fd00f117c6aa308d1aaa276480f1f8) | `alsa-lib: 1.2.7.1 -> 1.2.7.2`                                        |
| [`3ac326a9`](https://github.com/NixOS/nixpkgs/commit/3ac326a93b5ebdd9d76e0a3728d069b61de70aca) | `Revert "gopass*: build with Go with CL417615"`                       |
| [`4d1e04c0`](https://github.com/NixOS/nixpkgs/commit/4d1e04c00fe2ab1dd485ae198be56f97b7fff41f) | `go_1_18: backport CL417615`                                          |
| [`47c3a3e4`](https://github.com/NixOS/nixpkgs/commit/47c3a3e4407c765abcf891ef760a28b6661429f7) | `SDL2: restore udev support by default on linux`                      |
| [`65b9c178`](https://github.com/NixOS/nixpkgs/commit/65b9c1784276b2a0ca5b082420b8971e29a0bc33) | `kmod: drop darwin support`                                           |
| [`ccac7fd6`](https://github.com/NixOS/nixpkgs/commit/ccac7fd6ff4ea4bf3bff6e3808b723936e33728d) | `linux-wifi-hotspot: fix path`                                        |
| [`5f72e170`](https://github.com/NixOS/nixpkgs/commit/5f72e1707afb964e43c295903f284134ae9bb02b) | `nettle: 3.7.3 -> 3.8`                                                |
| [`eece5d0d`](https://github.com/NixOS/nixpkgs/commit/eece5d0dc0bbd7eaab1f09e608f89449f745003b) | `gcc: enable stripping for cross-compilers`                           |
| [`05077250`](https://github.com/NixOS/nixpkgs/commit/05077250615fa33003eada31a76b36c0717d8ca4) | `setup-hooks/strip.sh: run RANLIB on static archives after stripping` |
| [`0f45ce6e`](https://github.com/NixOS/nixpkgs/commit/0f45ce6e777e2cca2ade01176c19bc66cfe4b5c7) | `setup-hooks/strip.sh: add strip{All,Debug}ListTarget variables`      |
| [`ab4d64dd`](https://github.com/NixOS/nixpkgs/commit/ab4d64dd741d39a1c3eb4f2a607fadf2897ef92d) | ``pciutils, ntfs3g: don't pull in `kmod` on darwin``                  |
| [`30a8dc71`](https://github.com/NixOS/nixpkgs/commit/30a8dc7198518f2cfce14190a06c115a17eccc27) | `libva: 2.14.0 -> 2.15.0`                                             |
| [`16e8c116`](https://github.com/NixOS/nixpkgs/commit/16e8c11629f73ae80b7b2fdcd6ea74bf07dcbc94) | `harfbuzz: 3.3.2 → 5.0.1`                                             |
| [`ea8e1240`](https://github.com/NixOS/nixpkgs/commit/ea8e1240009ed947066387fd8fd17e481c7ec480) | `gcc: always enable inhibit_libc=true for --without-headers builds`   |
| [`64e6cc1a`](https://github.com/NixOS/nixpkgs/commit/64e6cc1a1d5fc565f2f503b7b6347f6641ff2610) | `go-(modules|packages): don't set trimpath for tests`                 |