### PR TITLE
chore(flake/nixpkgs): `168d1c57` -> `93c57a98`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659522808,
-        "narHash": "sha256-HBcM19nGhI3IWwPNVlYb0MZ8VW6iKp4JbAVkeIHVykc=",
+        "lastModified": 1659713809,
+        "narHash": "sha256-M4aHuXXVnfprM8xPH2lLkYkkR0fmaG5QmvIc0DT/d4E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "168d1c578909dc143ba52dbed661c36e76b12b36",
+        "rev": "93c57a988470c1948976b1bb70abbd5855c5b810",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`af98bacb`](https://github.com/NixOS/nixpkgs/commit/af98bacbe014021172b75e608187fa84937a99ce) | `Revert "nixos/docs: cache mergeJSON md conversion on baseOptionsJSON"`    |
| [`cdd80e17`](https://github.com/NixOS/nixpkgs/commit/cdd80e17ef7e57b39f4d66b1e8eb21bfa6650d06) | `ddosify: 0.8.0 -> 0.8.1`                                                  |
| [`4ee298da`](https://github.com/NixOS/nixpkgs/commit/4ee298daf7108b96fe6538cb6507c6e2e9783297) | `linuxPackages.bbswitch: 0.8 -> unstable-2021-11-29 (#179644)`             |
| [`208b7619`](https://github.com/NixOS/nixpkgs/commit/208b7619727aa7db570a1996c5886d0ee4256288) | `vikunja-api: 0.18.1 → 0.19.0`                                             |
| [`cfe2bb74`](https://github.com/NixOS/nixpkgs/commit/cfe2bb74708e4d81c3f72e96d309268ec666aace) | `vikunja-frontend: 0.18.1 → 0.19.0`                                        |
| [`9f041684`](https://github.com/NixOS/nixpkgs/commit/9f041684de9ff47b731a41c88ed3c7a079c4ecb4) | `dont use common names as password in test`                                |
| [`d236188f`](https://github.com/NixOS/nixpkgs/commit/d236188fa6d9308aa222300cca496c7e9d86a444) | `grails: 5.2.1 -> 5.2.2`                                                   |
| [`70c49766`](https://github.com/NixOS/nixpkgs/commit/70c49766aff96c3c2957bb44a3e16fe84019f5c1) | `zeroad: apply patch to fix build with gcc 11 and glibc 2.35`              |
| [`02e32729`](https://github.com/NixOS/nixpkgs/commit/02e32729c36e095539bbb8003c29b5dcac6dcd6a) | `nixosTests.prometheus-exporters.smartctl: fix type mismatch`              |
| [`f5e7b38c`](https://github.com/NixOS/nixpkgs/commit/f5e7b38c82bfd2a45cfb4997557b9cbf39ebfb38) | `or consistency use bob in tests instead of john`                          |
| [`de0c7343`](https://github.com/NixOS/nixpkgs/commit/de0c7343004c476611101c1b6447d78fa0041f67) | `for consistency use bob in example instead of joe`                        |
| [`4e13c1f9`](https://github.com/NixOS/nixpkgs/commit/4e13c1f95819c46e929d6c95f2786dbc6f31ac96) | `for consistency use bob in tests instead of joe`                          |
| [`5a6853b3`](https://github.com/NixOS/nixpkgs/commit/5a6853b3bfb741303a956363a4b80cd20332628b) | `use consistently user alice for examples`                                 |
| [`04f73efb`](https://github.com/NixOS/nixpkgs/commit/04f73efbdd766b0bc987be5f6e844cb0950fff49) | `ghorg: 1.8.0 -> 1.8.1`                                                    |
| [`d33f4a26`](https://github.com/NixOS/nixpkgs/commit/d33f4a26a10cc590ad5d8fd9883065ed09ef8309) | `Revert "neovim: pass the --clean flag to only use wrapped rc"`            |
| [`c4447eee`](https://github.com/NixOS/nixpkgs/commit/c4447eee1cf077033fd650fa5f858bdba4034966) | `dwdiff: init at 2.1.4`                                                    |
| [`9c48ac1b`](https://github.com/NixOS/nixpkgs/commit/9c48ac1b36fd8294657c4a67d71a8fcc2838aeb6) | `linuxPackages.dddvb: 0.9.38-pre.4 -> 0.9.38-pre.6`                        |
| [`df89f90c`](https://github.com/NixOS/nixpkgs/commit/df89f90c4a93518227e610fbcf7af30473dbbfab) | `dvc: remove setuptools_scm_git_archive pin, mark broken`                  |
| [`1e93a026`](https://github.com/NixOS/nixpkgs/commit/1e93a026d1f1aa338c524532d7227fa192650801) | `elpa: 2021.11.002 -> 2022.05.001`                                         |
| [`07af4e3e`](https://github.com/NixOS/nixpkgs/commit/07af4e3ecee764287a2329d09ab82b77ed70bee2) | `python310Packages.num2words: 0.5.10 -> 0.5.11`                            |
| [`105b7a81`](https://github.com/NixOS/nixpkgs/commit/105b7a814c72d7b4c4a546242e124a182e2a5632) | `luaPackages.protobuf: add maintainer`                                     |
| [`16559154`](https://github.com/NixOS/nixpkgs/commit/16559154a6af6cbaf4dce48e486e98afd8195cbf) | `luaPackages.protobuf: init at 0.4.0`                                      |
| [`901a4af2`](https://github.com/NixOS/nixpkgs/commit/901a4af249696c25028ffd6c517681b3d030eb6c) | `hd-idle: 1.16 -> 1.17`                                                    |
| [`ca83a26c`](https://github.com/NixOS/nixpkgs/commit/ca83a26c350607de1bb7a002d1a242a16785ab6b) | `cpp-utilities: 5.17.0 -> 5.18.0`                                          |
| [`aaf37bfa`](https://github.com/NixOS/nixpkgs/commit/aaf37bfa535566db498a25f8496dd5b04fa39667) | `clj-kondo: 2022.06.22 -> 2022.08.03`                                      |
| [`cca7dead`](https://github.com/NixOS/nixpkgs/commit/cca7deada4055d8ea81d912b20aeecff544bdb57) | `deckmaster: init at 0.8.0`                                                |
| [`e1573a9b`](https://github.com/NixOS/nixpkgs/commit/e1573a9bb30ee50810e00d2a120815f4c75ef7ab) | `cheat: 4.2.3 -> 4.2.6`                                                    |
| [`79136ca8`](https://github.com/NixOS/nixpkgs/commit/79136ca8a639f2709e1e5afbe2894b2275e09fbf) | `cargo-llvm-lines: 0.4.16 -> 0.4.17`                                       |
| [`7ab6ab28`](https://github.com/NixOS/nixpkgs/commit/7ab6ab2870d61c6b90c68f3436c883381a74d4ef) | `czkawka: 4.1.0 -> 5.0.1`                                                  |
| [`d20fae6f`](https://github.com/NixOS/nixpkgs/commit/d20fae6ff891ea01ed21bd8aac372670b0851ca0) | `twitch-tui: init at 1.6.0`                                                |
| [`93b3eb81`](https://github.com/NixOS/nixpkgs/commit/93b3eb81f4236cc0e2413946cf8024bcc4e383a8) | `terraform-providers: update 2022-08-05`                                   |
| [`0889899f`](https://github.com/NixOS/nixpkgs/commit/0889899f0476756d7bb380d443169dc224ae24bb) | `navidrome: fix darwin build, version numbering, enable tests`             |
| [`2c6b87b8`](https://github.com/NixOS/nixpkgs/commit/2c6b87b861e18b5492a3c00dce0cc0a612abb4ba) | `vscode: 1.69.2 -> 1.70.0`                                                 |
| [`3a194300`](https://github.com/NixOS/nixpkgs/commit/3a194300e27fda266d71a04831eaa62a920f4636) | `gum: 0.2.0 -> 0.4.0`                                                      |
| [`11c219a3`](https://github.com/NixOS/nixpkgs/commit/11c219a3ff9afd62da7b6cba8274ecb53db9a764) | `home-assistant: 2022.8.0 -> 2022.8.1`                                     |
| [`3f78fb96`](https://github.com/NixOS/nixpkgs/commit/3f78fb960544b3d92c859d68e11d29044e7e56fa) | `python3Packages.aioaladdinconnect: 0.1.34 -> 0.1.41`                      |
| [`7dc20c30`](https://github.com/NixOS/nixpkgs/commit/7dc20c30d8fb23ccfaeec057999ff45fa2556708) | `python3Packages.pyrisco: 0.5.1 -> 0.5.2`                                  |
| [`54804bb8`](https://github.com/NixOS/nixpkgs/commit/54804bb8451609556cfd93b6cdd0ad09375b2773) | `terraform-providers: drop go 1.17 overrides`                              |
| [`6edfe86b`](https://github.com/NixOS/nixpkgs/commit/6edfe86b1ad2a7d956c00032c7adc88f2fd253e4) | `python3Packages.aiohomekit: 1.2.3 -> 1.2.5`                               |
| [`b9dca59a`](https://github.com/NixOS/nixpkgs/commit/b9dca59a85e67d3c0b853467f395917e519de716) | `python3Packages.bleak: 0.15.0 -> 0.15.1`                                  |
| [`1083e507`](https://github.com/NixOS/nixpkgs/commit/1083e507452455cf1487ac7a37071430bc7f4b9f) | `python3Packages.bleak-retry-connector: 1.2.0 -> 1.3.0`                    |
| [`944a51a7`](https://github.com/NixOS/nixpkgs/commit/944a51a7a5cc6a3b7c430cbad7fffa3d785a686d) | `libportal: add darwin support`                                            |
| [`ec0058d6`](https://github.com/NixOS/nixpkgs/commit/ec0058d69ead58609565e511ab5294b1683a0a5c) | `flare-floss: 1.7.0 -> 2.0.0`                                              |
| [`2a12c578`](https://github.com/NixOS/nixpkgs/commit/2a12c578f44331c6c8a2321bb8c255c6b72237b8) | `python3Packages.viv-utils: add flirt feature`                             |
| [`647d05a3`](https://github.com/NixOS/nixpkgs/commit/647d05a3213831aff5edaa1197406c1c9f5ba5e1) | `python3Packages.python-flirt: init at 0.7.0`                              |
| [`f0a2ed7c`](https://github.com/NixOS/nixpkgs/commit/f0a2ed7ca502ed6635b770d3e163386f1590b0db) | `python3Packages.viv-utils: 0.3.17 -> 0.7.5`                               |
| [`4e7c3b98`](https://github.com/NixOS/nixpkgs/commit/4e7c3b982831bc209072fc0a31cd3e11f9ac7b56) | `haskell.compiler.ghc941: apply fix for racy build system`                 |
| [`53b33eee`](https://github.com/NixOS/nixpkgs/commit/53b33eee255deecc35cdb5ee452dfc460ac2a0f1) | `nixos/xmonad: don't reference nonexistent package sets in docs`           |
| [`531ff521`](https://github.com/NixOS/nixpkgs/commit/531ff521d42a8c0473cb997855b6e2ad542d5978) | `nixos/xmonad: rename NIX_GHC env var to XMONAD_GHC`                       |
| [`e0bf3468`](https://github.com/NixOS/nixpkgs/commit/e0bf346845a9f770574e4e76fe07b8cc1ebf2ee2) | `maintainers: move my Matrix account`                                      |
| [`f1b4bba5`](https://github.com/NixOS/nixpkgs/commit/f1b4bba5ac6c422cf85d73968b8d158ff97b89b1) | `palemoon: 31.1.1 -> 31.2.0.1`                                             |
| [`10ec6b81`](https://github.com/NixOS/nixpkgs/commit/10ec6b818bc56c886c8931f3f57ece3a3977f157) | `dxvk: 1.10.1 -> 1.10.3`                                                   |
| [`b2367dbd`](https://github.com/NixOS/nixpkgs/commit/b2367dbdd10f025e793df41f25bb5a94d2325268) | `nixos/home-assistant: update hardening for bluetooth components`          |
| [`4f2dd9e0`](https://github.com/NixOS/nixpkgs/commit/4f2dd9e0ab47b7571b0c161e2fb3b5446a3d0abb) | `slurm: remove gtk2 null override`                                         |
| [`282052f1`](https://github.com/NixOS/nixpkgs/commit/282052f1dd11e27a60e691c6167ac80d04c952e3) | `linuxPackages.lttng-modules: 2.13.2 -> 2.13.4`                            |
| [`da26caad`](https://github.com/NixOS/nixpkgs/commit/da26caad101efbd1e5c9e807f7f272e08cef94ae) | `nixos/luksroot: allow discards with fido2luks`                            |
| [`7aad0871`](https://github.com/NixOS/nixpkgs/commit/7aad0871d55e8fd4ebd75022522d8b9cadf8befb) | `fido2luks: 0.2.19 → 0.2.20`                                               |
| [`a1bd4e3d`](https://github.com/NixOS/nixpkgs/commit/a1bd4e3df7c3715acf9cc608a212d53a2896ef27) | `python3Packages.myst-parser: relax docutils constraint`                   |
| [`f5a6b487`](https://github.com/NixOS/nixpkgs/commit/f5a6b487661a1220086a7daffdf6109fbc47ec3e) | `idasen: 0.8.3 -> 0.9.0`                                                   |
| [`e370a1d9`](https://github.com/NixOS/nixpkgs/commit/e370a1d9bec4ee72fd5b2d8174ab83c32e99bb34) | `python3Packages.traccar: 0.10.1 -> 1.0.0`                                 |
| [`8f85662d`](https://github.com/NixOS/nixpkgs/commit/8f85662df0854336d48998f2855b71067ca8a214) | `python3Packages.pyswitchbot: 0.15.2 -> 0.17.3`                            |
| [`55fa3990`](https://github.com/NixOS/nixpkgs/commit/55fa39903e7ca4d56ffdcb261a234ad214c5f1ba) | `home-assistant: pin plugwise at 0.20.1`                                   |
| [`c2732c85`](https://github.com/NixOS/nixpkgs/commit/c2732c85e1a68514a81ca1ea7ba9a1ddbc79dd2b) | `python3Packages.cattrs: propagate exceptiongroup for python<3.11`         |
| [`16518f39`](https://github.com/NixOS/nixpkgs/commit/16518f39fc3bc10d734790b87b8b9c847d2e74bf) | `lightdm-gtk-greeter: 2.0.7 -> 2.0.8`                                      |
| [`3039c243`](https://github.com/NixOS/nixpkgs/commit/3039c243cf7a85ee4264b502925dffa2da112549) | `lightdm-gtk-greeter: refresh meta, format`                                |
| [`3db246ad`](https://github.com/NixOS/nixpkgs/commit/3db246ad9dbfe9ccf5afee1149867df19bb37d11) | `kapp: 0.50.0 -> 0.51.0`                                                   |
| [`62c8d2fa`](https://github.com/NixOS/nixpkgs/commit/62c8d2fa62b31666fd176a8d1be16929ca64cf0b) | `exploitdb: 2022-08-02 -> 2022-08-04`                                      |
| [`e83d4143`](https://github.com/NixOS/nixpkgs/commit/e83d414364a3665e2256539af722aa91a4380c91) | `vgo2nix: mark as not broken as it builds correctly`                       |
| [`2e6e7db0`](https://github.com/NixOS/nixpkgs/commit/2e6e7db0d7adb670a97a6738e91d34bad0a6abcc) | `python310Packages.pyarr: init at 4.1.0`                                   |
| [`d763334c`](https://github.com/NixOS/nixpkgs/commit/d763334cb3744e02db3dfe92af8a802b7de6bf27) | `nodePackages: pin webassemblyjs to 1.11.1`                                |
| [`f7c5adbd`](https://github.com/NixOS/nixpkgs/commit/f7c5adbd3eaf65e5e51031d0c0c8184cd61eab59) | `python310Packages.pydevd: init at 2.8.0`                                  |
| [`f23ac403`](https://github.com/NixOS/nixpkgs/commit/f23ac4035cba5b5a35e86f343c99c3fa81f9fc81) | `linux/hardened/patches/5.4: 5.4.206-hardened1 -> 5.4.208-hardened1`       |
| [`86bccf10`](https://github.com/NixOS/nixpkgs/commit/86bccf10b9ab0e4fec85993c8423d4a5291448d0) | `linux/hardened/patches/5.18: 5.18.12-hardened1 -> 5.18.15-hardened1`      |
| [`e9c8925f`](https://github.com/NixOS/nixpkgs/commit/e9c8925f98429585e7b10f45d627666fe3ecc57a) | `linux/hardened/patches/5.15: 5.15.55-hardened1 -> 5.15.58-hardened1`      |
| [`fca28ee0`](https://github.com/NixOS/nixpkgs/commit/fca28ee089b58e6e5662b6cf9f66eb3ec5942ebe) | `linux/hardened/patches/5.10: 5.10.131-hardened1 -> 5.10.134-hardened1`    |
| [`b588944c`](https://github.com/NixOS/nixpkgs/commit/b588944c55fb305490afdea2cabe6101f220741d) | `linux/hardened/patches/4.19: 4.19.252-hardened1 -> 4.19.254-hardened1`    |
| [`941b70fb`](https://github.com/NixOS/nixpkgs/commit/941b70fb70a6ceb87beb24e931d353cc7ea55b8c) | `linux/hardened/patches/4.14: 4.14.288-hardened1 -> 4.14.290-hardened1`    |
| [`e4be613a`](https://github.com/NixOS/nixpkgs/commit/e4be613a8bb2e73acf810c37ca0bec6d4436d34c) | `linux_latest-libre: 18825 -> 18837`                                       |
| [`6f5368cf`](https://github.com/NixOS/nixpkgs/commit/6f5368cff93d7e6bffef63b8e725c9f614c57ebd) | `linux: 5.4.208 -> 5.4.209`                                                |
| [`f4372465`](https://github.com/NixOS/nixpkgs/commit/f4372465427aa3a939d1be91349426100e7d0a73) | `linux: 5.18.15 -> 5.18.16`                                                |
| [`b7b3e0bd`](https://github.com/NixOS/nixpkgs/commit/b7b3e0bd51d00397bee6a3dbff3790336ab384ad) | `linux: 5.15.58 -> 5.15.59`                                                |
| [`20249152`](https://github.com/NixOS/nixpkgs/commit/20249152ced3c8dfc8c6c0966ef3fa8f6b178bbb) | `linux: 5.10.134 -> 5.10.135`                                              |
| [`77bbde1b`](https://github.com/NixOS/nixpkgs/commit/77bbde1b72a60a329dcabb58d82de3b7b0a2bf87) | `ntfy: add patch for emoji 2.0 compatibility`                              |
| [`7f77ad52`](https://github.com/NixOS/nixpkgs/commit/7f77ad524407a6a943fc6a487747b40bf6791d1c) | `urlscan: 0.9.9 -> 0.9.10`                                                 |
| [`9769e1b2`](https://github.com/NixOS/nixpkgs/commit/9769e1b28a45d44d0841d8eb5d83c761dca437d5) | `arcanPackages.arcan: use new style for recursive attributes`              |
| [`d61e4954`](https://github.com/NixOS/nixpkgs/commit/d61e4954ba7f25d2cad32b5e2ed76daa0a1d8445) | `arcanPackages.prio: use old version format`                               |
| [`99836653`](https://github.com/NixOS/nixpkgs/commit/99836653a91e68c3f9c5cf9ebfe1591d7efd1702) | `arcanPackages.pipeworld: use old version format`                          |
| [`cfda4e3c`](https://github.com/NixOS/nixpkgs/commit/cfda4e3c62461aa71a8885ccf5218d96f37ec79a) | `arcanPackages.durden: 2022-05-23 -> 2022-07-16`                           |
| [`1465e096`](https://github.com/NixOS/nixpkgs/commit/1465e096ec84e6e07b4758b55dde7eab83edf9c0) | `arcanPackages.xarcan: 2021-08-26 -> 2022-06-14`                           |
| [`f32f8e2a`](https://github.com/NixOS/nixpkgs/commit/f32f8e2a5703fddc01090ebb306234715eacb46c) | `python3Packages.jax: fix build`                                           |
| [`459e0412`](https://github.com/NixOS/nixpkgs/commit/459e041236e04abd7a52058b806ecc4282894897) | `python3Packages.python-language-server: remove`                           |
| [`157a6c26`](https://github.com/NixOS/nixpkgs/commit/157a6c26137f79349ca02746fcb4565c75b1c2a8) | `mitmproxy: add SuperSandro2000 as maintainer`                             |
| [`880a1076`](https://github.com/NixOS/nixpkgs/commit/880a1076b248197ff4919fd8be0756074f3e491a) | `qownnotes: 22.7.6 -> 22.8.0`                                              |
| [`e0a5ce3f`](https://github.com/NixOS/nixpkgs/commit/e0a5ce3f064db0264e5bde2784efd480edf48f7e) | `linuxKernel.packages.linux_hardened.oci-seccomp-bpf-hook: 1.2.5 -> 1.2.6` |
| [`0e4b730d`](https://github.com/NixOS/nixpkgs/commit/0e4b730d638fc54eabca93428f8ff7ef12bb0c63) | `python3Packages.pygls: 0.12 → 0.12.1`                                     |
| [`f0f5be95`](https://github.com/NixOS/nixpkgs/commit/f0f5be951d07729dddbbcf8988c24d0d60c95865) | `cdo: 1.9.10 -> 2.0.5 and add eccodes dependency for GRIB files (#167743)` |
| [`0ff5e21e`](https://github.com/NixOS/nixpkgs/commit/0ff5e21ea2f5c1f50fcf150309ac533ba8ef3300) | `Correct instructions to obtain a hash for git repos`                      |
| [`4d422b32`](https://github.com/NixOS/nixpkgs/commit/4d422b322635d67a0a42592b0c4ac55333d66412) | `bumblebee: mark broken`                                                   |
| [`2210891a`](https://github.com/NixOS/nixpkgs/commit/2210891a585828873d1abfdfd1198cdd57d0de34) | `wasmedge: init at 0.10.1 (#184801)`                                       |
| [`9623e322`](https://github.com/NixOS/nixpkgs/commit/9623e3221b39c8ed73db7d3d2457801e806ec734) | `usql: 0.9.3 -> 0.11.12`                                                   |
| [`24298916`](https://github.com/NixOS/nixpkgs/commit/24298916897bd698bfdd481bc207b8fdab995b44) | `minikube: 1.26.0 -> 1.26.1`                                               |
| [`e098228d`](https://github.com/NixOS/nixpkgs/commit/e098228dc4cc5b7bef2032aae4deb405c9adaed8) | `lima: 0.11.2 -> 0.11.3`                                                   |
| [`81a0ad41`](https://github.com/NixOS/nixpkgs/commit/81a0ad4165f6c403f42e9605a2fd2a1bbab8b96c) | `refinery-cli: init at 0.8.5`                                              |
| [`c69eeb2c`](https://github.com/NixOS/nixpkgs/commit/c69eeb2c499a026335166a19fb369f8d5f57d6d3) | `signal-desktop: 5.52.0 -> 5.53.0`                                         |
| [`a15af572`](https://github.com/NixOS/nixpkgs/commit/a15af5725edc3b03cb072206b704121b6c242ce7) | `python310Packages.jarowinkler: 1.1.2 -> 1.2.0`                            |
| [`b2d3dbd8`](https://github.com/NixOS/nixpkgs/commit/b2d3dbd806238b49f40a78ab72e0b53aab445625) | `python310Packages.rapidfuzz: 2.1.3 -> 2.4.2`                              |
| [`d866e4cb`](https://github.com/NixOS/nixpkgs/commit/d866e4cbbdf9808659095f2e3ea232d45dd5341d) | `rapidfuzz-cpp: 1.1.0 -> 1.1.1`                                            |
| [`140d955e`](https://github.com/NixOS/nixpkgs/commit/140d955ebab3c6671fca4faabaec87c037f80b7f) | `zen-kernels: 5.18.15 -> 5.18.16`                                          |
| [`4a67b036`](https://github.com/NixOS/nixpkgs/commit/4a67b03684868e56d329c885fa48b65a41c73c19) | `python3Packages.typer: reenable by disabling test on aarch64-linux`       |
| [`b9fee1ce`](https://github.com/NixOS/nixpkgs/commit/b9fee1ce63325a1ce2b7413c3dc3be07e25b489c) | `home-assistant: 2022.7.7 -> 2022.8.0`                                     |
| [`65aac059`](https://github.com/NixOS/nixpkgs/commit/65aac0591f699c2492651f1e30d7b358fc276fba) | `python3Packages.zha-quirks: 0.0.77 -> 0.0.78`                             |
| [`68be3cfc`](https://github.com/NixOS/nixpkgs/commit/68be3cfc67663f76c14331dee49fad75e43e569d) | `python3Packages.xknx: 0.21.5 -> 0.22.1`                                   |
| [`3eb12f34`](https://github.com/NixOS/nixpkgs/commit/3eb12f34ed83ff10cc66689108553bbab4bc4955) | `python3Packages.python-miio: 0.5.11 -> 0.5.12`                            |