### PR TITLE
chore(flake/nixpkgs): `93c57a98` -> `f4488406`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659713809,
-        "narHash": "sha256-M4aHuXXVnfprM8xPH2lLkYkkR0fmaG5QmvIc0DT/d4E=",
+        "lastModified": 1659803779,
+        "narHash": "sha256-+5zkHlbcbFyN5f3buO1RAZ9pH1wXLxCesUJ0vFmLr9Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "93c57a988470c1948976b1bb70abbd5855c5b810",
+        "rev": "f44884060cb94240efbe55620f38a8ec8d9af601",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                          |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`603db2cc`](https://github.com/NixOS/nixpkgs/commit/603db2cc147884acd25d0eb02cbf536e68c56bfb) | `spicedb: init at 1.11.0`                                               |
| [`01678c2c`](https://github.com/NixOS/nixpkgs/commit/01678c2c31735137c0585c66b22b88a93c90009b) | `spicedb-zed: init at 0.4.4`                                            |
| [`9f43cb37`](https://github.com/NixOS/nixpkgs/commit/9f43cb37527eb00792cddbf6348f8eb0f364d642) | `nifi: switch src to a working and stable URL`                          |
| [`b6d45f14`](https://github.com/NixOS/nixpkgs/commit/b6d45f1448793e937a81c5d72967b83a23a088e0) | `nixos/kanata: sync with version 1.0.6`                                 |
| [`a4399365`](https://github.com/NixOS/nixpkgs/commit/a43993655a54c3e69ed0145610c7ee26318db7af) | `kanata: 1.0.5 -> 1.0.6`                                                |
| [`5810d94b`](https://github.com/NixOS/nixpkgs/commit/5810d94b5ca6d811aea56873f5d263fcb29c80fb) | `omini-gtk-theme: init at unstable-2021-03-30 (#184020)`                |
| [`c8c7c5d4`](https://github.com/NixOS/nixpkgs/commit/c8c7c5d43f2780465f560e6722edc10884eab9f5) | `poppler: 22.06.0 → 22.08.0`                                            |
| [`21b675e3`](https://github.com/NixOS/nixpkgs/commit/21b675e30bf72784764f90a9d01fedd9232dffe5) | `haskellPackages.reflex-libtelnet: restrict to platforms.linux`         |
| [`07c82deb`](https://github.com/NixOS/nixpkgs/commit/07c82debac4edddec7fb4ac1d6e1c697be5c8c7a) | `haskellPackages.keid-*: restrict to x86_64-linux`                      |
| [`c0eaefb3`](https://github.com/NixOS/nixpkgs/commit/c0eaefb30c15ebb101e8eae8e9dfaadb4cbb8470) | `nixos/yggdrasil: want/before systemd's network.target`                 |
| [`f52b0f1f`](https://github.com/NixOS/nixpkgs/commit/f52b0f1ff45725a4a35a4c8a418a69e802fd424f) | `haskellPackages.HQu: use supported-platforms list`                     |
| [`a466470a`](https://github.com/NixOS/nixpkgs/commit/a466470a2b5433d39b1af59b7a9f89c096eb12ab) | `haskellPackages: mark supported-platfroms reverse deps of scrypt`      |
| [`7060f696`](https://github.com/NixOS/nixpkgs/commit/7060f6960ecfa20855c3221dfb7e3f762b6eae4b) | `perlPackages.Appcpm: 0.997006 -> 0.997011`                             |
| [`830914e7`](https://github.com/NixOS/nixpkgs/commit/830914e78facda93cc20e87709a36fe178ff4b56) | `haskellPackages: mark builds failing on hydra as broken`               |
| [`7e0b4ddb`](https://github.com/NixOS/nixpkgs/commit/7e0b4ddbe3cff353211d0753bb63a2cb831d00f0) | `electrum: 4.2.2 -> 4.3.0`                                              |
| [`08ccdcbc`](https://github.com/NixOS/nixpkgs/commit/08ccdcbc9c6cbfa5b88ddb65d0a3c51a627a54b2) | `wezterm: use apple_sdk_11_0`                                           |
| [`56ca4bb9`](https://github.com/NixOS/nixpkgs/commit/56ca4bb9aca93092f57fd6e38c100f5c28ae3532) | `perlPackages.ParallelPipes: 0.005 -> 0.102`                            |
| [`87de89e2`](https://github.com/NixOS/nixpkgs/commit/87de89e23b7ba5210ab27ecbbdf706b6a3967b21) | `luaPackages.luaunit: init at 3.4-1`                                    |
| [`81e6eaab`](https://github.com/NixOS/nixpkgs/commit/81e6eaab30e58538ef3482fe6607067fa4f6b756) | `vyper: 0.3.3 -> 0.3.5`                                                 |
| [`2270b66d`](https://github.com/NixOS/nixpkgs/commit/2270b66d759f0a9c022576ce42fa5a770a754250) | `pythonPackagesExtensions: override all Python package sets at once`    |
| [`6205cd64`](https://github.com/NixOS/nixpkgs/commit/6205cd64ddcc771f317cd3f400b31d1964041ac2) | `pinegrow: don't auto update`                                           |
| [`907febfc`](https://github.com/NixOS/nixpkgs/commit/907febfc5648206033abc92bcb6f14d291f20089) | `ec2-metadata-mock: 1.11.1 -> 1.11.2`                                   |
| [`62a68d8e`](https://github.com/NixOS/nixpkgs/commit/62a68d8e6f5f64488a78be35292424dfd16cbbe3) | `nfs-ganesha: 4.0 -> 4.0.7`                                             |
| [`a999ed1a`](https://github.com/NixOS/nixpkgs/commit/a999ed1a60b3da2948beb52b5a833a479e807169) | `httm: 0.14.7 -> 0.14.8`                                                |
| [`be430239`](https://github.com/NixOS/nixpkgs/commit/be430239ce4ce4d081502e4d338efa09e2f1b467) | `sommelier: init at 104.0`                                              |
| [`02ed575f`](https://github.com/NixOS/nixpkgs/commit/02ed575f74b8cc7b822f7215893f163df84d5904) | `sqlx-cli: 0.6.0 -> 0.6.1`                                              |
| [`430cfa4d`](https://github.com/NixOS/nixpkgs/commit/430cfa4db054b60e8eae707a977768447f5b24bb) | `python310Packages.sqlmap: 1.6.7 -> 1.6.8`                              |
| [`da8f6865`](https://github.com/NixOS/nixpkgs/commit/da8f6865cd59978657d831bcead8387658db476b) | `libsForQt5.qtutilities: 6.6.2 -> 6.7.0`                                |
| [`a857a541`](https://github.com/NixOS/nixpkgs/commit/a857a541d0931727a1b453eaae6c06c9444c803e) | `python310Packages.types-urllib3: 1.26.19 -> 1.26.22`                   |
| [`7194e6c7`](https://github.com/NixOS/nixpkgs/commit/7194e6c7c93061070e1b764f4817560a63b20d12) | `python310Packages.types-requests: 2.28.6 -> 2.28.8`                    |
| [`0fd69cf8`](https://github.com/NixOS/nixpkgs/commit/0fd69cf8de2cc425142ba8577fff06dcbc64dd00) | `msfpc: init at 1.4.5`                                                  |
| [`61c2aff3`](https://github.com/NixOS/nixpkgs/commit/61c2aff3e321db67613800102dde775fbf4d341b) | `python310Packages.types-setuptools: 63.2.2 -> 63.4.0`                  |
| [`c47e1442`](https://github.com/NixOS/nixpkgs/commit/c47e144237b83f0050daa173227d9991d2db137e) | `polkadot: 0.9.26 -> 0.9.27`                                            |
| [`70b8a329`](https://github.com/NixOS/nixpkgs/commit/70b8a329022e3fcdf2e0163835943a6a1a1554a2) | `python310Packages.sagemaker: 2.101.1 -> 2.103.0`                       |
| [`1d253f97`](https://github.com/NixOS/nixpkgs/commit/1d253f97ca201802da0fac9f3ff66e2d8de26813) | `python310Packages.pyipma: 2.1.5 -> 3.0.0`                              |
| [`e1c33086`](https://github.com/NixOS/nixpkgs/commit/e1c33086c21117e34e694fad8f5665fe112e0a30) | `python310Packages.mediapy: 1.0.3 -> 1.1.0`                             |
| [`27383821`](https://github.com/NixOS/nixpkgs/commit/273838214ea991444e16e2c1367c4b5c3f7bf8c7) | `python310Packages.oslo-concurrency: 4.5.1 -> 5.0.0`                    |
| [`96dda2c9`](https://github.com/NixOS/nixpkgs/commit/96dda2c91dbbf0b5492c5cd32bd1af6e415a9dda) | `python310Packages.plaid-python: 9.8.0 -> 9.9.0`                        |
| [`a84fc905`](https://github.com/NixOS/nixpkgs/commit/a84fc9056d0b97b1002a7cf7397d385fbb21ed96) | `python310Packages.peaqevcore: 4.0.1 -> 4.0.8`                          |
| [`aff433b6`](https://github.com/NixOS/nixpkgs/commit/aff433b6d107055d298b89f9d7d0b6d4fbe89b6d) | `python310Packages.pex: 2.1.102 -> 2.1.103`                             |
| [`07ed3ff3`](https://github.com/NixOS/nixpkgs/commit/07ed3ff369faf94568c31bf41b05f87d82df9ead) | `python3Packages.etils: init at 0.6.0`                                  |
| [`3524da2f`](https://github.com/NixOS/nixpkgs/commit/3524da2f0ab911c9c65ac6fb34e87b9698a4e5fb) | `kerf_1: init at unstable-2022-08-05`                                   |
| [`2c5f5c78`](https://github.com/NixOS/nixpkgs/commit/2c5f5c783e424e641ef0d30f00a2b150d43c8481) | `python3Packages.cupy: mark as broken`                                  |
| [`998bc5d8`](https://github.com/NixOS/nixpkgs/commit/998bc5d86c7263a8de4208af97fe6d8f25c91956) | `redpanda: 22.1.6 -> 22.1.7`                                            |
| [`7727c70a`](https://github.com/NixOS/nixpkgs/commit/7727c70a52fcfe186b7d42581db6307617ec9b6e) | `wargus: fixup path in .desktop file`                                   |
| [`63331281`](https://github.com/NixOS/nixpkgs/commit/633312813703642a14acd042c5a068968978a25d) | `wargus: unpack data in package`                                        |
| [`eb3ac5a7`](https://github.com/NixOS/nixpkgs/commit/eb3ac5a74f30a3dfd3b5e7256e54b028683d9b55) | `wargus: 2.4.3 -> 3.3.1`                                                |
| [`5df71839`](https://github.com/NixOS/nixpkgs/commit/5df71839356aea71eda60b8b8bd12c18c2dce701) | `namecoin: 22.0 -> 23.0`                                                |
| [`eae69ea5`](https://github.com/NixOS/nixpkgs/commit/eae69ea5d4196a80faa7f13e461d2c6d9fc6342c) | `grpc: add arrow-cpp to passthru.tests`                                 |
| [`2a4041b5`](https://github.com/NixOS/nixpkgs/commit/2a4041b58659ad9c1d4f1b49ee05c0ee383b9c9b) | `pokete: 0.8.0 -> 0.8.2`                                                |
| [`307985dd`](https://github.com/NixOS/nixpkgs/commit/307985dd93e58fcd974d6c8e4fdf85e73bc6989b) | `libsForQt5.qtstyleplugin-kvantum: add me as maintainer`                |
| [`5b51b715`](https://github.com/NixOS/nixpkgs/commit/5b51b715027ae711abb9542cdd7662c6e840fccd) | `sipexer: init at 1.0.3 (#185278)`                                      |
| [`006298e9`](https://github.com/NixOS/nixpkgs/commit/006298e99ee7d49a4e85f935ba1b5ca26c106460) | `woodpecker-cli: patch out spurious CA certs errors`                    |
| [`7ddef1b8`](https://github.com/NixOS/nixpkgs/commit/7ddef1b8b884339a449b5aeb4aaaa51a780f631a) | `python3Packages.django-compressor: 4.0 -> 4.1`                         |
| [`33ee10c8`](https://github.com/NixOS/nixpkgs/commit/33ee10c80ec35dabd5296678472f93f216d3ac18) | `python3Packages.django-compressor: rename from django_compressor`      |
| [`90c50579`](https://github.com/NixOS/nixpkgs/commit/90c505790c63e34a72a86efcd248de6c9da58ac6) | `Revert "cudatoolkit_11_7: init at 11.7.0"`                             |
| [`c0bf3e53`](https://github.com/NixOS/nixpkgs/commit/c0bf3e53b16fafb71f1aea11a6c63813b723ccde) | `solaar: fix g-i and double wrapping`                                   |
| [`0a3046da`](https://github.com/NixOS/nixpkgs/commit/0a3046da019ae74a83acca10d706b361b403657a) | `ffmpeg-normalize: 1.23.1 -> 1.24.0`                                    |
| [`72acae55`](https://github.com/NixOS/nixpkgs/commit/72acae5551045ab46ca3328b515cfa0e52e67b4d) | `containerd: 1.6.6 -> 1.6.7`                                            |
| [`99094a22`](https://github.com/NixOS/nixpkgs/commit/99094a220a28f0801b34178e864134efd70495ca) | `cuelsp: init at 0.3.3`                                                 |
| [`79736fde`](https://github.com/NixOS/nixpkgs/commit/79736fde014ea9e37415c5969e584b3a08940e99) | `review fixes`                                                          |
| [`1bbd7431`](https://github.com/NixOS/nixpkgs/commit/1bbd74314566048e540c17a7dc5fcf4722b8d349) | `nerdctl: 0.22.1 -> 0.22.2`                                             |
| [`958dd9a8`](https://github.com/NixOS/nixpkgs/commit/958dd9a8c7c335f7063bb0f73d02e6adb719683f) | `cosign: 1.10.0 -> 1.10.1`                                              |
| [`a7521391`](https://github.com/NixOS/nixpkgs/commit/a7521391b9a944db65e3c0ce561079f12f654666) | `buildah: 1.26.2 -> 1.26.4 (#185295)`                                   |
| [`d17ed7bb`](https://github.com/NixOS/nixpkgs/commit/d17ed7bb641a17eb2fb121e0b8c621af6b80a28e) | `go-task: 3.14.0 -> 3.14.1`                                             |
| [`1d3a3345`](https://github.com/NixOS/nixpkgs/commit/1d3a33455e7fb51e516fe348c0e926dcb5f3ab33) | `ncnn: 20220721 -> 20220729`                                            |
| [`48d3f817`](https://github.com/NixOS/nixpkgs/commit/48d3f8170468433d43dce4a5e58f0b9bc5ad8e7a) | `brutespray: 1.7.0 -> 1.8`                                              |
| [`0cad4b26`](https://github.com/NixOS/nixpkgs/commit/0cad4b26331468f42fdbfeb42875fb0cb6af91d7) | `gitlab: resolve deprecation warning in update.py`                      |
| [`875287b3`](https://github.com/NixOS/nixpkgs/commit/875287b341be6fe862e0160f2beb9507519d1912) | `werf: 1.2.144 -> 1.2.146`                                              |
| [`951a9bdf`](https://github.com/NixOS/nixpkgs/commit/951a9bdfc12be95d87bb8c0cd24f2496a0e7bf06) | `flatbuffers: drop unused fetchpatch`                                   |
| [`cae262a6`](https://github.com/NixOS/nixpkgs/commit/cae262a6e756583bea61e8bdbc6392ec9663c03a) | `usql: 0.11.12 -> 0.12.0`                                               |
| [`580d97c0`](https://github.com/NixOS/nixpkgs/commit/580d97c0854e0854ccf0c45660d7dbcd443f9af1) | `tflint: 0.39.1 -> 0.39.2`                                              |
| [`03119abf`](https://github.com/NixOS/nixpkgs/commit/03119abf6b7de3bb5c36efdeaa18c0fc296dbc87) | `wasmtime: 0.38.0 -> 0.39.1`                                            |
| [`40387846`](https://github.com/NixOS/nixpkgs/commit/40387846db77a78b2a9d02dd3777149c843bdcd6) | `subfinder: 2.5.2 -> 2.5.3`                                             |
| [`e8426b10`](https://github.com/NixOS/nixpkgs/commit/e8426b10b701c5cb9274a60ce00ce14a6ce17fb0) | `ssh-mitm: 2.0.5 -> 2.1.0`                                              |
| [`11835711`](https://github.com/NixOS/nixpkgs/commit/118357114093fb326b2bd116fdcb189db70de3cf) | `soft-serve: 0.3.2 -> 0.3.3`                                            |
| [`c9f7f02b`](https://github.com/NixOS/nixpkgs/commit/c9f7f02bbed1c784fe6308221a5faefaa0555a4f) | `rusty-psn, rusty-psn-gui: init at 0.1.2`                               |
| [`09b8c5ef`](https://github.com/NixOS/nixpkgs/commit/09b8c5efc0c26b33b760523c537b695b776a214f) | `opentelemetry-collector-contrib: 0.56.0 -> 0.57.2`                     |
| [`bf069a68`](https://github.com/NixOS/nixpkgs/commit/bf069a689eb07789706c22e36ee3182a57141fc7) | `opentelemetry-collector: 0.56.0 -> 0.57.2`                             |
| [`ffe4e6d9`](https://github.com/NixOS/nixpkgs/commit/ffe4e6d924a5bda132a0f74b14619b25cd100dba) | `seer: init at 1.7`                                                     |
| [`2ba6470a`](https://github.com/NixOS/nixpkgs/commit/2ba6470a2b4ca91776cc033c7511c7495699273d) | `maintainers: add foolnotion`                                           |
| [`c0da0daa`](https://github.com/NixOS/nixpkgs/commit/c0da0daa080ad5dfcad4b0be13bdcdab07a68433) | `mongodb-compass: 1.32.5 -> 1.32.6`                                     |
| [`a3870b11`](https://github.com/NixOS/nixpkgs/commit/a3870b11e863e39881b5c5b3c18e1cdb7ff84f57) | `kubeone: 1.4.5 -> 1.4.6`                                               |
| [`5c852166`](https://github.com/NixOS/nixpkgs/commit/5c85216634915fcc8d57e4db4c2e22be16d4ca05) | `adguardhome: 0.107.8 - 0.107.9`                                        |
| [`69045148`](https://github.com/NixOS/nixpkgs/commit/69045148b1c32367fdf2f37ca9ae8928638dd827) | `k9s: 0.26.1 -> 0.26.3`                                                 |
| [`39936682`](https://github.com/NixOS/nixpkgs/commit/399366820d482716fc17116dd5e1e2afeff0cff6) | `arti: 0.5.0 -> 0.6.0`                                                  |
| [`d0cb1b38`](https://github.com/NixOS/nixpkgs/commit/d0cb1b38b5ee047b891b4e388620749f529b95a6) | `python310Packages.ansible: 6.1.0 -> 6.2.0`                             |
| [`ed0ce6d5`](https://github.com/NixOS/nixpkgs/commit/ed0ce6d5399273950b12e8260f1272d421e860e4) | `zine: init at 0.6.0`                                                   |
| [`21ef86c2`](https://github.com/NixOS/nixpkgs/commit/21ef86c2d3ff2060f144b524f441f6301d11e0ca) | `esbuild: 0.14.51 -> 0.14.53`                                           |
| [`f876de84`](https://github.com/NixOS/nixpkgs/commit/f876de84c490f7499dc2271fd64974a410899fdc) | `earthly: 0.6.20 -> 0.6.21`                                             |
| [`366b5644`](https://github.com/NixOS/nixpkgs/commit/366b56447d337497cb340061f038f6858b0324e4) | `cilium-cli: 0.12.0 -> 0.12.1`                                          |
| [`a101b20b`](https://github.com/NixOS/nixpkgs/commit/a101b20b2a0da160bff5460e7cafb8207ca9e745) | `civo: 1.0.30 -> 1.0.31`                                                |
| [`a3922768`](https://github.com/NixOS/nixpkgs/commit/a3922768fa673d77f5610c473874bead692ad66c) | `cadvisor: 0.44.1 -> 0.45.0`                                            |
| [`6230c07a`](https://github.com/NixOS/nixpkgs/commit/6230c07a45a5dcede82c30a852e20d95d7c543de) | `python310Packages.nclib: 1.0.1 -> 1.0.2`                               |
| [`ae36fbe7`](https://github.com/NixOS/nixpkgs/commit/ae36fbe7f946b2cef58c5b26ef602242c80ee654) | `ferdi: Note CVE-2022-32320 in knownVulnerabilities`                    |
| [`1ad5e92e`](https://github.com/NixOS/nixpkgs/commit/1ad5e92e8dffe435de63b68af9fcae1ae5318378) | `ungoogled-chromium: 103.0.5060.134 -> 104.0.5112.81`                   |
| [`6abd910e`](https://github.com/NixOS/nixpkgs/commit/6abd910e9a330291c457ebd1a2edd1be29a6adb5) | `argocd-autopilot: 0.4.2 -> 0.4.3`                                      |
| [`953de37e`](https://github.com/NixOS/nixpkgs/commit/953de37eda9cd72063bbd806736007ebe1d32d81) | `python310Packages.zeroc-ice: 3.7.7 -> 3.7.8`                           |
| [`cb1d6d69`](https://github.com/NixOS/nixpkgs/commit/cb1d6d69a12bd05099eb87f337cbb8ca7862fcd4) | `python310Packages.cock: 0.9.0 -> 0.10.0`                               |
| [`744e802b`](https://github.com/NixOS/nixpkgs/commit/744e802bc3d69cc9a27a45f4c92f78efed1a0d32) | `python310Packages.nocaselist: 1.0.5 -> 1.0.6`                          |
| [`34d1f6b4`](https://github.com/NixOS/nixpkgs/commit/34d1f6b43c2c79884e3c139ac941cbed40725f86) | `python310Packages.nocasedict: 1.0.3 -> 1.0.4`                          |
| [`5b6c0cab`](https://github.com/NixOS/nixpkgs/commit/5b6c0cab60bbeb13ab326a08fca74a35b601f17a) | `python310Packages.google-cloud-bigtable: 2.10.1 -> 2.11.0`             |
| [`da6ccfba`](https://github.com/NixOS/nixpkgs/commit/da6ccfbab2bd54f1a925d58abed861ebbc2f247d) | `php81: 8.1.8 -> 8.1.9`                                                 |
| [`2b483c62`](https://github.com/NixOS/nixpkgs/commit/2b483c62db1853f5fad114a771d5a721327ebc79) | `php80: 8.0.21 -> 8.0.22`                                               |
| [`1fafd4b3`](https://github.com/NixOS/nixpkgs/commit/1fafd4b37c3a251549c54940c587122020307630) | `haskellPackages: temporarily test entire package set on Hydra`         |
| [`27351bd3`](https://github.com/NixOS/nixpkgs/commit/27351bd320f0274ecc406e7b63590e4a7d99b51c) | `framesh: 0.5.0-beta.21 -> 0.5.0-beta.22`                               |
| [`0efcd5f1`](https://github.com/NixOS/nixpkgs/commit/0efcd5f16d61f38d0596a4b17e1e2278596463e0) | `python310Packages.weconnect-mqtt: 0.38.2 -> 0.38.3`                    |
| [`05f695c2`](https://github.com/NixOS/nixpkgs/commit/05f695c2e761d3ae42311467dd100701428a1fb2) | `python310Packages.weconnect: 0.45.1 -> 0.46.0`                         |
| [`3e89a864`](https://github.com/NixOS/nixpkgs/commit/3e89a864bd8e953249d3733db7ccd53cd46d6a6b) | `python310Packages.hahomematic: 2022.7.14 -> 2022.8.2`                  |
| [`b2a7d011`](https://github.com/NixOS/nixpkgs/commit/b2a7d0115877627ed55521bded505df183950025) | `python310Packages.identify: 2.5.2 -> 2.5.3`                            |
| [`b2c16a24`](https://github.com/NixOS/nixpkgs/commit/b2c16a24083f9e02919a571519c41f0f0c842352) | `python310Packages.angr: 9.2.11 -> 9.2.12`                              |
| [`f5a24800`](https://github.com/NixOS/nixpkgs/commit/f5a248009617ce49bfa87137d308c8dc7505ee58) | `python310Packages.cle: 9.2.11 -> 9.2.12`                               |
| [`2317534b`](https://github.com/NixOS/nixpkgs/commit/2317534bbc56162e64b0c2f595e2f779d8bf0cef) | `python310Packages.claripy: 9.2.11 -> 9.2.12`                           |
| [`9ec455bd`](https://github.com/NixOS/nixpkgs/commit/9ec455bdabf85320928900c0e20c52fcdca962a4) | `python310Packages.pyvex: 9.2.11 -> 9.2.12`                             |
| [`932b9e8a`](https://github.com/NixOS/nixpkgs/commit/932b9e8a164a922872fa859262142c141a4ea64b) | `python310Packages.ailment: 9.2.11 -> 9.2.12`                           |
| [`a78ef8ff`](https://github.com/NixOS/nixpkgs/commit/a78ef8ffc2a7b61422c2820d9cc022539d328daf) | `python310Packages.archinfo: 9.2.11 -> 9.2.12`                          |
| [`ce39bee9`](https://github.com/NixOS/nixpkgs/commit/ce39bee9dd61d6ea5c336450915d9601f3a26b9b) | `nixos/stage-1-systemd: fix initrd-fstab generation for bind mounts`    |
| [`dd6ffc0f`](https://github.com/NixOS/nixpkgs/commit/dd6ffc0f5247a739f9730a193929ad3b484cb87c) | `plexamp: 4.2.1 -> 4.3.0`                                               |
| [`6476c800`](https://github.com/NixOS/nixpkgs/commit/6476c800c9c80343c370bcb534f11884addda3ab) | `python310Packages.setuptools-declarative-requirements: 1.2.0 -> 1.3.0` |
| [`a43d296d`](https://github.com/NixOS/nixpkgs/commit/a43d296d12cc3b9e77cd1798df22cc4596373541) | `cudnn: add 8.4.0`                                                      |
| [`79bc66ce`](https://github.com/NixOS/nixpkgs/commit/79bc66cea599c89925a7674c59ff5174a44a4c5e) | `redistrib_11.7.0.json: add eol`                                        |
| [`9aaf5daa`](https://github.com/NixOS/nixpkgs/commit/9aaf5daa7eab7db99182081e22a9d38482a8fcb4) | `nsight_compute: qt6 for version 2022.2.0`                              |
| [`b139e331`](https://github.com/NixOS/nixpkgs/commit/b139e331a40bd93e4d35084fe67c40c2c7d5ae3d) | `cudatoolkit: add 11.7`                                                 |
| [`e5a19c9e`](https://github.com/NixOS/nixpkgs/commit/e5a19c9ec939b4fa08deb16b490f2632d545e9d4) | `xmlsec: 1.2.33 -> 1.2.34`                                              |
| [`2ef718e0`](https://github.com/NixOS/nixpkgs/commit/2ef718e01e92370e1097955b02119b3047a805aa) | `wallabag: 2.5.0 -> 2.5.1`                                              |
| [`6cf05444`](https://github.com/NixOS/nixpkgs/commit/6cf054449b58fbdc19c97f0f9f136beb789eae94) | `wordpress: 6.0 -> 6.0.1`                                               |
| [`05b3ee0e`](https://github.com/NixOS/nixpkgs/commit/05b3ee0e454554bac7df4771a4babdcbe1b6e7da) | `strongswan: 5.9.5 -> 5.9.7`                                            |
| [`9f1e8b93`](https://github.com/NixOS/nixpkgs/commit/9f1e8b93b39c22668915e9a81965c5dc04e87f47) | `python310Packages.rjsmin: 1.2.0 -> 1.2.1`                              |
| [`91a9c034`](https://github.com/NixOS/nixpkgs/commit/91a9c034eb561ce50a4b6754abcef56c6f0f6ab6) | `python310Packages.rcssmin: 1.1.0 -> 1.1.1`                             |
| [`827a791b`](https://github.com/NixOS/nixpkgs/commit/827a791b53b8833a26c89ac904d0dd0ca1a167fa) | `python310Packages.pytest-mpl: 0.16.0 -> 0.16.1`                        |
| [`83b80dc8`](https://github.com/NixOS/nixpkgs/commit/83b80dc8b12ccf0ad979e73bbb0e264bdb46f5ab) | `pipecontrol: 0.2.2 -> 0.2.4`                                           |
| [`cc8c4fe2`](https://github.com/NixOS/nixpkgs/commit/cc8c4fe20dbba4a3940ecd2de1a40ccfda165218) | `libsForQt5.qtstyleplugin-kvantum: 1.0.3 -> 1.0.4`                      |
| [`cd015b32`](https://github.com/NixOS/nixpkgs/commit/cd015b32472a3a42bff670c8719e7e42dd4ae131) | `wasabiwallet: 1.1.13.1 -> 2.0.1.3`                                     |
| [`415bafac`](https://github.com/NixOS/nixpkgs/commit/415bafacc15a5eaea853ceecc2260c937f174a22) | `stripe-cli: 1.9.0 -> 1.10.3`                                           |
| [`9f47f06a`](https://github.com/NixOS/nixpkgs/commit/9f47f06a35b477e314e924909fab885cd2ed2c7f) | `stellar-core: 18.5.0 -> 19.3.0`                                        |
| [`7c7dbbfb`](https://github.com/NixOS/nixpkgs/commit/7c7dbbfba8479b12280f59445302125ac11ef538) | `particl-core: 0.19.2.14 -> 0.19.2.20`                                  |
| [`505a2704`](https://github.com/NixOS/nixpkgs/commit/505a2704a03d3fa98d527f4f05b7b7068e582465) | `erigon: 2022.07.02 -> 2022.07.03`                                      |
| [`78d2a858`](https://github.com/NixOS/nixpkgs/commit/78d2a858c61d2ed3e99275f3c0b2c424b0cb3906) | `charge-lnd: 0.2.4 -> 0.2.12`                                           |
| [`3cc2fa21`](https://github.com/NixOS/nixpkgs/commit/3cc2fa21dcc7a3e8f60966168a2d23a61c27bdd3) | `electrum-ltc: 4.0.9.3 -> 4.2.2.1`                                      |
| [`4b1975ac`](https://github.com/NixOS/nixpkgs/commit/4b1975accafc4b65b312d4f53d1be8ed9bc6807b) | `zecwallet-lite: init at 1.7.13`                                        |
| [`df653dcf`](https://github.com/NixOS/nixpkgs/commit/df653dcfbc4a23aa46aeba2f49f81a2d59dd4160) | `cudatoolkit: get redistrib_11.7.0.json`                                |