### PR TITLE
chore(flake/nixpkgs): `f4488406` -> `4bdf4169`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659803779,
-        "narHash": "sha256-+5zkHlbcbFyN5f3buO1RAZ9pH1wXLxCesUJ0vFmLr9Y=",
+        "lastModified": 1659889440,
+        "narHash": "sha256-O8+FsHZzQIqjQjuh+VXbJtGrpPswm5ta2Z/eo72Lz2U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f44884060cb94240efbe55620f38a8ec8d9af601",
+        "rev": "4bdf4169ad2896236895ca607a843f30c9680345",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`2a172dcb`](https://github.com/NixOS/nixpkgs/commit/2a172dcba992f4c19c0cdafafc12cd1e559a3b93) | `libadwaita: Fix API docs`                                             |
| [`e6968544`](https://github.com/NixOS/nixpkgs/commit/e69685449a087951dfcd48595c8c78d497427cb4) | `openasar: 2022-06-27 -> 2022-08-07`                                   |
| [`9c651f79`](https://github.com/NixOS/nixpkgs/commit/9c651f79a236ff8b01683e3eea8f99366061ae1e) | `python310Packages.azure-mgmt-monitor: update disabled`                |
| [`1df57f03`](https://github.com/NixOS/nixpkgs/commit/1df57f03d3a4726f43e4e6c08e4944c7147315b8) | `siege: 4.1.4 -> 4.1.5`                                                |
| [`6aa6f956`](https://github.com/NixOS/nixpkgs/commit/6aa6f9567a2867f1198bbe35bb8999c480263816) | `python310Packages.stripe: 4.0.1 -> 4.0.2`                             |
| [`56f5e7ff`](https://github.com/NixOS/nixpkgs/commit/56f5e7ff8eee16ed3af2629da2b3f9ea5f95e5c2) | `gitlab-runner: 15.2.0 -> 15.2.1 (#183282)`                            |
| [`e840d96e`](https://github.com/NixOS/nixpkgs/commit/e840d96e81e7fa0d0842a07a6b584c83f61c17ba) | `bupc: 2.22.0 -> 2020.12.0 (#185241)`                                  |
| [`d6744506`](https://github.com/NixOS/nixpkgs/commit/d6744506a67b486c142e053d7c7a9f4e14991f34) | `perlPackages.IOAsync: 0.78 -> 0.801`                                  |
| [`46567bb8`](https://github.com/NixOS/nixpkgs/commit/46567bb8a30cbab5400d4118fa0d567ecf35e518) | `python310Packages.azure-mgmt-monitor: 4.0.0 -> 4.0.1`                 |
| [`80fc83ad`](https://github.com/NixOS/nixpkgs/commit/80fc83ad314fe701766ee66ac8286307d65b39e3) | `dagger: 0.2.27 -> 0.2.28`                                             |
| [`c7587eaf`](https://github.com/NixOS/nixpkgs/commit/c7587eaf8b09433db099e19237e3cf72551d636f) | `terraform-providers: update 2022-08-07`                               |
| [`9a49ca9f`](https://github.com/NixOS/nixpkgs/commit/9a49ca9f9aeed500aa3872a94c9f566ec003cfdc) | `buildGo{Module,Package}: move to build-support/go`                    |
| [`621cc6c8`](https://github.com/NixOS/nixpkgs/commit/621cc6c8138347c83859320aafb8c78cfecb871a) | `garble: move to development/tools`                                    |
| [`e1ea3862`](https://github.com/NixOS/nixpkgs/commit/e1ea38626faa553d5cfadbf69f0766dadba2df00) | `etcd_3_5: refactor`                                                   |
| [`4f11333d`](https://github.com/NixOS/nixpkgs/commit/4f11333d802813fa5e8ccdb4025bf35a0b251ffa) | `foot: 1.12.1 -> 1.13.0`                                               |
| [`e679cd0c`](https://github.com/NixOS/nixpkgs/commit/e679cd0cbae5a1f8aaa860810a36029f42a823e5) | `perlPackages.FutureIO: init at 0.11`                                  |
| [`76595601`](https://github.com/NixOS/nixpkgs/commit/76595601ad2dbc91d9d7b40194f72a0cbf314c92) | `pueue: 2.0.0 -> 2.1.0`                                                |
| [`fe91f1a6`](https://github.com/NixOS/nixpkgs/commit/fe91f1a64a80671e34ee9f4b9ec8ad7c5254af62) | `coin3d: 2020-12-07 -> 2022-97-27`                                     |
| [`016de638`](https://github.com/NixOS/nixpkgs/commit/016de638ab0bb33b35135387e43bb139e8460be2) | `apprise: 0.9.9 -> 1.0.0`                                              |
| [`7e28dca8`](https://github.com/NixOS/nixpkgs/commit/7e28dca8310203bb698f219d748c149db0fb941a) | `python310Packages.django-reversion: 5.0.1 -> 5.0.2`                   |
| [`c3aff2b7`](https://github.com/NixOS/nixpkgs/commit/c3aff2b7d798925ee9f0598c5627e9bd09dd5a51) | `qgis, qgis-ltr: fix build`                                            |
| [`0081536c`](https://github.com/NixOS/nixpkgs/commit/0081536ce57bbfc86462358b55bfbf4a27fbb4e9) | `python3Packages.cryptolyzer: init at 0.8.1`                           |
| [`31bf0a45`](https://github.com/NixOS/nixpkgs/commit/31bf0a4523132b5f55edb2cfb2a22237bdac3480) | `python3Packages.cryptoparser: init at 0.8.0`                          |
| [`6f9147cc`](https://github.com/NixOS/nixpkgs/commit/6f9147cc9af5128e715e3ac7bde684d3270b2aa0) | `godns: 2.8.7 -> 2.8.8`                                                |
| [`30b3702b`](https://github.com/NixOS/nixpkgs/commit/30b3702b27ace0846b06fc04d24536538d88b823) | `python310Packages.tesla-wall-connector: allow later backoff releases` |
| [`47a06c0b`](https://github.com/NixOS/nixpkgs/commit/47a06c0b2f7e8f76e32fe31bd357bdd68aeda2cc) | `python310Packages.pydeconz: 101 -> 103`                               |
| [`59e492eb`](https://github.com/NixOS/nixpkgs/commit/59e492ebefed773945fdb90b5d03578a6d386ecb) | `python3Packages.django-storages: enable tests`                        |
| [`cbe630ca`](https://github.com/NixOS/nixpkgs/commit/cbe630ca7a7da95b4d44986f69a79c0edb2520d2) | `home-assistant: update component-packages`                            |
| [`d8e9448e`](https://github.com/NixOS/nixpkgs/commit/d8e9448e9538509bd49174b0ef0919b0ac3a2596) | `python310Packages.nextdns: init at 1.0.2`                             |
| [`350fd004`](https://github.com/NixOS/nixpkgs/commit/350fd0044447ae8712392c6b212a18bdf2433e71) | `josm: 18513 → 18531`                                                  |
| [`5252a32f`](https://github.com/NixOS/nixpkgs/commit/5252a32f663151598be5c7700da8c079272ea21a) | `python310Packages.aiolifx: 0.8.1 -> 0.8.2`                            |
| [`e3a8aeb5`](https://github.com/NixOS/nixpkgs/commit/e3a8aeb5ae90a5408aa0f350161bf604c4b12404) | `bluetuith: 0.0.5 -> 0.0.6`                                            |
| [`1a6018b4`](https://github.com/NixOS/nixpkgs/commit/1a6018b45aa0b5d00547bb75351179e8489c148c) | `python3Packages.dvc-task: init at 0.1.2`                              |
| [`f9b06519`](https://github.com/NixOS/nixpkgs/commit/f9b065190ea4f2fb5c9835fc859ba9a861994caf) | `python310Packages.extractcode: disable failing test`                  |
| [`e2a5ce1f`](https://github.com/NixOS/nixpkgs/commit/e2a5ce1f1c75293ce099a7cb30d4b1fed6149645) | `python310Packages.pytibber: 0.23.0 -> 0.24.0`                         |
| [`5dee143a`](https://github.com/NixOS/nixpkgs/commit/5dee143a809a2e1f3e6f852d1cf9bc3313f84076) | `python310Packages.zeroconf: 0.38.7 -> 0.39.0`                         |
| [`b5cd1707`](https://github.com/NixOS/nixpkgs/commit/b5cd17075c38154bc748fd947e21da859f4917e4) | `cargo-geiger: 0.11.3 -> 0.11.4`                                       |
| [`87e8a176`](https://github.com/NixOS/nixpkgs/commit/87e8a17632dfa1f29948a2d10f7045bf7c8c6ad6) | `python310Packages.pyoverkiz: allow later backoff releases`            |
| [`a5526e46`](https://github.com/NixOS/nixpkgs/commit/a5526e4610abd080d1e49e8b1db7d3a122cdfec9) | `pyupgrade: 2.37.1 -> 2.37.3`                                          |
| [`e5bf8729`](https://github.com/NixOS/nixpkgs/commit/e5bf8729a0c853d6ebff86a8e126b800d2669f46) | `python310Packages.pyunifiprotect: remove pydantic constraint`         |
| [`8463ad5c`](https://github.com/NixOS/nixpkgs/commit/8463ad5cc13b78a891b91efd95c2241d174023a3) | `python310Packages.elastic-apm: 6.10.1 -> 6.10.2`                      |
| [`b175bac0`](https://github.com/NixOS/nixpkgs/commit/b175bac0e397bee33ee4c3f69c4f57a4b5ec11a3) | `python310Packages.json-stream: 1.3.0 -> 1.4.0`                        |
| [`fea9b52d`](https://github.com/NixOS/nixpkgs/commit/fea9b52dd85ae7c1eef55d5dea40a2230cd02227) | `python310Packages.cyclonedx-python-lib: 2.7.0 -> 2.7.1`               |
| [`0fd43998`](https://github.com/NixOS/nixpkgs/commit/0fd439982dcae934363f7b1c164033cf0ec52aa1) | `virt-manager: fix build on darwin`                                    |
| [`130af0ea`](https://github.com/NixOS/nixpkgs/commit/130af0ea2008af87da8b999e20de49053dbd51c1) | `perlPackages.IOAsyncSSL: 0.22 -> 0.23`                                |
| [`fd2feaa9`](https://github.com/NixOS/nixpkgs/commit/fd2feaa9551577bbcbdc948d0a5580f50eab5cf3) | `python310Packages.asyncwhois: 1.0.0 -> 1.0.1`                         |
| [`d4986dcf`](https://github.com/NixOS/nixpkgs/commit/d4986dcf5924a13a44d756a301c2cfd953e8dfa8) | `python310Packages.container-inspector: 31.1.0 -> 32.0.1`              |
| [`2646871f`](https://github.com/NixOS/nixpkgs/commit/2646871f3303133268be8618ea471d008a744c3c) | `python310Packages.dvc-data: 0.1.5 -> 0.1.13`                          |
| [`12024221`](https://github.com/NixOS/nixpkgs/commit/120242210ea1de188723841e81c54f58ec5df9bc) | `python310Packages.dvc-objects: 0.1.5 -> 0.1.7`                        |
| [`7dcae0f5`](https://github.com/NixOS/nixpkgs/commit/7dcae0f5f2f3ae833bd2b94bfd394dcb3c5b66c1) | `davtest: init at 1.0`                                                 |
| [`8be0ce68`](https://github.com/NixOS/nixpkgs/commit/8be0ce68c47bb8beefef5371c056822776cf1df5) | `python310Packages.fakeredis: 1.8.2 -> 1.9.0`                          |
| [`a2987e43`](https://github.com/NixOS/nixpkgs/commit/a2987e43e39bea7d4a2f9e13c0aaa9a13f98e4cf) | `python310Packages.dvclive: 0.9.0 -> 0.10.0`                           |
| [`0ddcba0a`](https://github.com/NixOS/nixpkgs/commit/0ddcba0ae4c20a5e2dd83e025c7879657fc7bd1d) | `python3Packages.sip: add patch fixing QGIS breakage`                  |
| [`5d05d314`](https://github.com/NixOS/nixpkgs/commit/5d05d3144721918f8c12c769e08e1e678fa40215) | `python310Packages.pycep-parser: 0.3.7 -> 0.3.8`                       |
| [`2e92544b`](https://github.com/NixOS/nixpkgs/commit/2e92544bf46dda9b3853648173df66b9a55edd23) | `python310Packages.netutils: 1.2.0 -> 1.2.0`                           |
| [`8ddf4189`](https://github.com/NixOS/nixpkgs/commit/8ddf4189421becf6b8f055027ddb227d532b942d) | `janus-gateway: 1.0.3 -> 1.0.4`                                        |
| [`1bd602ef`](https://github.com/NixOS/nixpkgs/commit/1bd602ef20b5b1aea5549f8621cf041dfd2b6301) | `python310Packages.plugwise: 0.21.0 -> 0.21.1`                         |
| [`e7ef7551`](https://github.com/NixOS/nixpkgs/commit/e7ef75517f8b2943905b6299f7b32ec418584df3) | `python310Packages.pubnub: 6.5.0 -> 6.5.1`                             |
| [`e112ef65`](https://github.com/NixOS/nixpkgs/commit/e112ef65ef5d72855614e59fea053947af004edf) | `python310Packages.pyswitchbot: 0.17.3 -> 0.18.4`                      |
| [`e307de8b`](https://github.com/NixOS/nixpkgs/commit/e307de8b8aa1421d234ffe5ba4bc53dd55cd9a15) | `python310Packages.bleak-retry-connector: 1.3.0 -> 1.4.0`              |
| [`88fbda36`](https://github.com/NixOS/nixpkgs/commit/88fbda364a9a4be56d05a5111bc9e0f300f91b70) | `python310Packages.whodap: 0.1.5 -> 0.1.6`                             |
| [`f988e6df`](https://github.com/NixOS/nixpkgs/commit/f988e6dfb777b6e3ce866b47ad6bd5225a555191) | `python310Packages.yalexs: 1.1.25 -> 1.2.1`                            |
| [`232f82a2`](https://github.com/NixOS/nixpkgs/commit/232f82a2d4b0da897844a93dd074140e1f666d2c) | `python310Packages.pyskyqremote: 0.3.12 -> 0.3.14`                     |
| [`4244408a`](https://github.com/NixOS/nixpkgs/commit/4244408aa6ea264f4b054799bfda7b29632d0fc1) | `python310Packages.pylibmc: remove whitespace`                         |
| [`923c51fa`](https://github.com/NixOS/nixpkgs/commit/923c51fa5aaf98bf7f2c7344c8abdf4b6b03bd2f) | `perlPackages.Imager: 1.012 -> 1.019`                                  |
| [`541de0ee`](https://github.com/NixOS/nixpkgs/commit/541de0ee1c94ddf437dbe2af03fffe7e374f869d) | `python310Packages.teslajsonpy: 2.3.0 -> 2.4.0`                        |
| [`3c3999e2`](https://github.com/NixOS/nixpkgs/commit/3c3999e2ff8c7661dbd6350cce08cd4fafc164a2) | `python310Packages.pylibmc: update disabled`                           |
| [`f5d6209b`](https://github.com/NixOS/nixpkgs/commit/f5d6209b00624b5c6313b912ad68b3f4b54b2fa5) | `gpac: mark with several knownVulnerabilities`                         |
| [`3139ddd3`](https://github.com/NixOS/nixpkgs/commit/3139ddd3d9b712b5a00b43de8d01914a53f4f345) | `perlPackages.CommandRunner: 0.103 -> 0.200`                           |
| [`fb665938`](https://github.com/NixOS/nixpkgs/commit/fb6659387d13d5245d5edde8c52e4be5ac5aaf53) | `python310Packages.pylibmc: add pythonImportsCheck`                    |
| [`629b1829`](https://github.com/NixOS/nixpkgs/commit/629b18292cfbed749b08da3086c595d31a9cb22c) | `pgadmin4: 6.11 -> 6.12`                                               |
| [`db47ade9`](https://github.com/NixOS/nixpkgs/commit/db47ade9dad76279c093c9ca1277d61b0027531a) | `python3Packages.pyvips: add anthonyroussel as maintainer`             |
| [`858f7c24`](https://github.com/NixOS/nixpkgs/commit/858f7c244c69021a035f114a6c6b20689fa5a6d1) | `python3Packages.pyvips: 2.2.0 -> 2.2.1`                               |
| [`3b426306`](https://github.com/NixOS/nixpkgs/commit/3b42630664686e86e6f897f3f8114f758d8e75f0) | `maintainers: add anthonyroussel`                                      |
| [`c8107cf1`](https://github.com/NixOS/nixpkgs/commit/c8107cf185b0b735d13ab7be1e064ca59bd65935) | `retroarch: enable dbus on Linux`                                      |
| [`3f383c75`](https://github.com/NixOS/nixpkgs/commit/3f383c75efbdd390c9c8f900da8b41450bbd32bb) | `libvirt: fix build on x86_64-darwin`                                  |
| [`a65e6b08`](https://github.com/NixOS/nixpkgs/commit/a65e6b08c53f2c2c6c8e6c1af9feea31197dd750) | `nixos/tests/firefox: use pname to identify tested package`            |
| [`46d5c738`](https://github.com/NixOS/nixpkgs/commit/46d5c7389fae716ecd22c2e912ed703cc9fa568e) | `firefox-esr-{91,102}-unwrapped: set proper pname`                     |
| [`24ae5203`](https://github.com/NixOS/nixpkgs/commit/24ae5203be1ad3d6664f54c28a8fc1c8035858c3) | `nss: test individual firefox versions in passthru`                    |
| [`5b9af79d`](https://github.com/NixOS/nixpkgs/commit/5b9af79df3aad3bc842fab971b0f4c788207a3c8) | `nspr: test firefox in passthru`                                       |
| [`ed22adb8`](https://github.com/NixOS/nixpkgs/commit/ed22adb877a861fdfecea83bef7285a89170d173) | `victoriametrics: 1.79.0 -> 1.79.1`                                    |
| [`34450264`](https://github.com/NixOS/nixpkgs/commit/34450264b904d1d2f099a4599735f08a5d8490c5) | `watchexec: 1.20.4 -> 1.20.5`                                          |
| [`b8f3c3fc`](https://github.com/NixOS/nixpkgs/commit/b8f3c3fcfce1517667f052c9f07821b51e172c85) | `uftp: 5.0 -> 5.0.1`                                                   |
| [`2d6965ba`](https://github.com/NixOS/nixpkgs/commit/2d6965baac58e276c50692196af8b02f9dbba868) | `python310Packages.catalogue: 2.1.0 -> 2.0.8`                          |
| [`b9cc2341`](https://github.com/NixOS/nixpkgs/commit/b9cc2341439ef83aea1f512853e018f616397227) | `svt-av1: 1.0.0 -> 1.2.0`                                              |
| [`3f0cefb8`](https://github.com/NixOS/nixpkgs/commit/3f0cefb859ff9f32d3359b611919f064b2bc1321) | `python310Packages.trimesh: 3.12.9 -> 3.13.0`                          |
| [`91434994`](https://github.com/NixOS/nixpkgs/commit/914349940ea274f8b8ffb41756e69ae8288c6f7d) | `python310Packages.svglib: 1.3.0 -> 1.4.1`                             |
| [`94ec8b4c`](https://github.com/NixOS/nixpkgs/commit/94ec8b4c6f654b3d196ace3312877141275344e3) | `python310Packages.pylibmc: 1.6.1 -> 1.6.2`                            |
| [`ca10a690`](https://github.com/NixOS/nixpkgs/commit/ca10a690a41510d7dbff6862cc290fe1d14fc6af) | `python310Packages.django-storages: 1.12.3 -> 1.13`                    |
| [`431c7491`](https://github.com/NixOS/nixpkgs/commit/431c749122f2a2f2f6c43dfff5b4d8cd19696bcd) | `amberol: 0.8.1 -> 0.9.0`                                              |
| [`fd04240f`](https://github.com/NixOS/nixpkgs/commit/fd04240ffe141a69cf823f657eff8b9abeb1886c) | `opam: remove aspcud from runtime`                                     |
| [`f0478cf3`](https://github.com/NixOS/nixpkgs/commit/f0478cf3cfa36a4eccf18a4a938dc945bc89bd16) | `memcached: 1.6.15 -> 1.6.16`                                          |
| [`1b95ba3c`](https://github.com/NixOS/nixpkgs/commit/1b95ba3c9c79fa1b51aeefcdaeaf911ccbf006ec) | `vscodium: 1.69.2 -> 1.70.0`                                           |
| [`b28eb7ae`](https://github.com/NixOS/nixpkgs/commit/b28eb7ae544a66523f248b593184b7f2f8f175b6) | `jquake: 1.6.2 -> 1.7.0`                                               |
| [`487a681b`](https://github.com/NixOS/nixpkgs/commit/487a681bfce4e38aad69b8090aeecf32f8667c13) | `drawio: 19.0.3 -> 20.2.3`                                             |
| [`a43bf95a`](https://github.com/NixOS/nixpkgs/commit/a43bf95ad00bd02311a30c1a102f5a221641d637) | `chromiumBeta: 104.0.5112.79 -> 105.0.5195.19`                         |
| [`195d3850`](https://github.com/NixOS/nixpkgs/commit/195d38508ce4dfb302e815a4a3162c0883122213) | `minecraft-server: 1.19.1 -> 1.19.2`                                   |
| [`e315cc6a`](https://github.com/NixOS/nixpkgs/commit/e315cc6a0e14b0f39bb5ef00ce7c32fdb8718ce9) | `kubebuilder: 3.5.0 -> 3.6.0`                                          |
| [`983fcdf8`](https://github.com/NixOS/nixpkgs/commit/983fcdf8877083ab2107e3b1caadf3a0aff00487) | `cpm: 0.35.3 -> 0.35.4`                                                |
| [`38c7eaac`](https://github.com/NixOS/nixpkgs/commit/38c7eaaca2b336d5b594b9be0808cb3fe9cce0c9) | `cargo-expand: 1.0.28 -> 1.0.29`                                       |
| [`a64f2a79`](https://github.com/NixOS/nixpkgs/commit/a64f2a79bb11b22f7d54314c53e9a33b50619b1f) | `criu: 3.15 -> 3.17.1`                                                 |
| [`f560d604`](https://github.com/NixOS/nixpkgs/commit/f560d604487c3b984eb8ad52264cc58a6117f594) | `credential-detector: 1.7.0 -> 1.11.0`                                 |
| [`041b6843`](https://github.com/NixOS/nixpkgs/commit/041b684369642f8298a59784509368a20ba9d085) | `rl-2211: mention cinnamon update`                                     |
| [`be917263`](https://github.com/NixOS/nixpkgs/commit/be91726358a412da3503c8cadffd2eeec67df439) | `treewide: rename cinnamon.xapps to cinnamon.xapp`                     |
| [`4a50454c`](https://github.com/NixOS/nixpkgs/commit/4a50454cfea56edb806318e409ebd031452457a2) | `hypnotix: 2.8 -> 2.9`                                                 |
| [`ecd8ff8a`](https://github.com/NixOS/nixpkgs/commit/ecd8ff8af3e4d87a8ea30fde0c7799088e941922) | `blueberry: 1.4.7 -> 1.4.8`                                            |
| [`c0520de7`](https://github.com/NixOS/nixpkgs/commit/c0520de7e88890da2abace38149af9ca43d20980) | `cinnamon.mint-artwork: 1.5.4 -> 1.6.0`                                |
| [`20d269ea`](https://github.com/NixOS/nixpkgs/commit/20d269ea81b7429fa519bd8706b949cd2fecaf55) | `nixos/cinnamon: switch to blueman`                                    |
| [`9da9a147`](https://github.com/NixOS/nixpkgs/commit/9da9a1474c44719c58b5f1a788d7888bb2d6d36e) | `cinnamon.cinnamon-common: 5.2.0 -> 5.4.8`                             |
| [`475ad0ff`](https://github.com/NixOS/nixpkgs/commit/475ad0ff72db9129546363da8a50d8fa6631ba9a) | `tutanota-desktop: 3.98.15 -> 3.98.17`                                 |
| [`e480909d`](https://github.com/NixOS/nixpkgs/commit/e480909dd3fed44222add497c68f9d7d3f6015be) | `python310Packages.h5netcdf: 1.0.1 -> 1.0.2`                           |
| [`f12b105f`](https://github.com/NixOS/nixpkgs/commit/f12b105f69322de1b2a61aa49d208bc188ac5e2a) | `nghttp3: 0.5.0 -> 0.6.0`                                              |
| [`e86aac02`](https://github.com/NixOS/nixpkgs/commit/e86aac0222fc0f10795db7777b1c38e9d960f0f9) | `gprojector: 3.0.3 -> 3.0.4`                                           |
| [`5a451c0f`](https://github.com/NixOS/nixpkgs/commit/5a451c0fe27332c99f2cbe8e2bb38b4e60098c27) | `swagger-codegen3: 3.0.33 -> 3.0.34`                                   |
| [`47007b9d`](https://github.com/NixOS/nixpkgs/commit/47007b9d20a4665cdf0706e4cce5797ee7136084) | `postgresql11Packages.repmgr: 5.3.1 -> 5.3.2`                          |
| [`39a00dfd`](https://github.com/NixOS/nixpkgs/commit/39a00dfda5966a3e02e9ad6b92dffaa59a398a8b) | `micro: 2.0.10 → 2.0.11`                                               |
| [`1e64d9a8`](https://github.com/NixOS/nixpkgs/commit/1e64d9a87c0f2f4d82613d5e6c39bd95408ce38c) | `root: 6.26.04 -> 6.26.06`                                             |
| [`b2bbba02`](https://github.com/NixOS/nixpkgs/commit/b2bbba02baba3ae45fd35a4c265028d0ee1c83fe) | `mafft: 7.490 -> 7.505`                                                |
| [`ff9665c3`](https://github.com/NixOS/nixpkgs/commit/ff9665c3beca201f892d74e4feae90176a4257ac) | `fossil: 2.18 -> 2.19`                                                 |
| [`fbfbbc2d`](https://github.com/NixOS/nixpkgs/commit/fbfbbc2d0c06f0334242aae6752bdeca317f16a6) | `cinnamon.muffin: 5.2.0 -> 5.4.4`                                      |
| [`b110dadc`](https://github.com/NixOS/nixpkgs/commit/b110dadc98cb54f656c809c8276aa1bfd5773c6d) | `cinnamon.cjs: 5.2.0 -> 5.4.1`                                         |
| [`a9dd1f9b`](https://github.com/NixOS/nixpkgs/commit/a9dd1f9bc94fc65f3dcdb0f2010bcc8e020fea47) | `cinnamon.cinnamon-control-center: 5.2.0 -> 5.4.4`                     |
| [`969faa42`](https://github.com/NixOS/nixpkgs/commit/969faa4270061244a72d2f0592f1fb7bd2cf92d3) | `cinnamon.cinnamon-settings-daemon: 5.2.0 -> 5.4.3`                    |
| [`6c899ad4`](https://github.com/NixOS/nixpkgs/commit/6c899ad441f1ae10b2c86d6ae68f5ebbb082a6c6) | `python3Packages.xapp: 2.2.1 -> 2.2.2`                                 |
| [`4b98c682`](https://github.com/NixOS/nixpkgs/commit/4b98c682d8a90c68ec70c1f781ca23c53eb782cd) | `cinnamon.cinnamon-desktop: 5.2.0 -> 5.4.2`                            |
| [`52ca18d8`](https://github.com/NixOS/nixpkgs/commit/52ca18d8c65aa2a72aa33c882aaab8eb60c555a7) | `cinnamon.xviewer: 3.2.4 -> 3.2.9`                                     |
| [`9c214387`](https://github.com/NixOS/nixpkgs/commit/9c2143877747b17bae4c88e28619ce087c96add2) | `cinnamon.cinnamon-screensaver: 5.2.0 -> 5.4.1`                        |
| [`4eb1fb33`](https://github.com/NixOS/nixpkgs/commit/4eb1fb33ce8f40ebf7c1fa79c27413ee762e8e77) | `cinnamon.mint-themes: 1.8.8 -> 2.0.3`                                 |
| [`33232565`](https://github.com/NixOS/nixpkgs/commit/33232565ab75f3cfb2dd580c85ec631d0e0b2368) | `sticky: 1.8 -> 1.11`                                                  |
| [`8df09e8f`](https://github.com/NixOS/nixpkgs/commit/8df09e8ff4ee064163ac987a139deef3c5d2e1c2) | `timeshift: 22.06.1 -> 22.06.5`                                        |
| [`b3db7c1d`](https://github.com/NixOS/nixpkgs/commit/b3db7c1d792a368cf5caee5ad2f3ae1741f91a99) | `cinnamon.nemo: 5.2.4 -> 5.4.2`                                        |
| [`1abe15cf`](https://github.com/NixOS/nixpkgs/commit/1abe15cfa5a8f720b7cc4e44d470e57023e13eb1) | `nixos/cinnamon: install xed-editor`                                   |
| [`79a68c38`](https://github.com/NixOS/nixpkgs/commit/79a68c3816823c2c76871f6a2d17259a1031a530) | `xed-editor: 3.2.2 -> 3.2.7`                                           |
| [`890385c2`](https://github.com/NixOS/nixpkgs/commit/890385c26e783e20f3b535b1817ee748b5d642d4) | `cinnamon.warpinator: 1.2.5 -> 1.2.13`                                 |
| [`3d6db4a8`](https://github.com/NixOS/nixpkgs/commit/3d6db4a82324ef90561406b02d273ca9124755b9) | `cinnamon.xapps: 2.2.8 -> 2.2.14`                                      |
| [`d2525282`](https://github.com/NixOS/nixpkgs/commit/d25252822f0dca0210ad86badbcc7f570c8b33ba) | `cinnamon.mint-y-icons: 1.5.8 -> 1.6.0`                                |
| [`68ea6869`](https://github.com/NixOS/nixpkgs/commit/68ea68692af6579a8588106a3416eb3ad90488a8) | `cinnamon.pix: 2.8.4 -> 2.8.7`                                         |
| [`47dd5d87`](https://github.com/NixOS/nixpkgs/commit/47dd5d870757055fd32f0ee07bfa5af3988b6384) | `cinnamon.mint-x-icons: 1.6.3 -> 1.6.4`                                |
| [`408bc40e`](https://github.com/NixOS/nixpkgs/commit/408bc40edba6a786ee3ca767d1a4a0023c6a3189) | `cinnamon.cinnamon-menus: 5.2.0 -> 5.4.0`                              |
| [`56833512`](https://github.com/NixOS/nixpkgs/commit/56833512cad226e9e21dd485f3cc2f7f17992b3b) | `cinnamon.cinnamon-session: 5.2.0 -> 5.4.0`                            |
| [`a170b202`](https://github.com/NixOS/nixpkgs/commit/a170b202de34afe70ba06db852cedf95c939a49e) | `cinnamon.cinnamon-translations: 5.2.0 -> 5.4.2`                       |
| [`5dcca07e`](https://github.com/NixOS/nixpkgs/commit/5dcca07e32ed949f2772d7044ea84b1369cce06e) | `cinnamon.xreader: 3.3.0 -> 3.4.3`                                     |
| [`e34ae7b7`](https://github.com/NixOS/nixpkgs/commit/e34ae7b7f387c5e2016b354de610c6a38b4e53f3) | `xplayer: 2.4.2 -> 2.4.3`                                              |
| [`463b2e35`](https://github.com/NixOS/nixpkgs/commit/463b2e353078c254937031bcba997582fdc1762d) | `cinnamon.bulky: 1.9 -> 2.4`                                           |
| [`3268793e`](https://github.com/NixOS/nixpkgs/commit/3268793e7fc8e8520bb95c12f035d540e5fb8602) | `python310Packages.glyphslib: 6.0.6 -> 6.0.7`                          |
| [`6ef91009`](https://github.com/NixOS/nixpkgs/commit/6ef910097504a5e2d8271b48a865a4fe1ffd6f26) | `noise-repellent: 0.2.1 -> 0.2.3`                                      |
| [`7a77ef96`](https://github.com/NixOS/nixpkgs/commit/7a77ef9687c761747b7fbf8be6eab83826b12b0e) | `libspecbleach: 0.1.2 -> 0.1.6`                                        |
| [`177f1537`](https://github.com/NixOS/nixpkgs/commit/177f15375ec5afdcefa6492b1c71bbc779aaee03) | `python310Packages.mailchecker: 4.1.18 -> 4.1.19`                      |
| [`18dcace7`](https://github.com/NixOS/nixpkgs/commit/18dcace75f16ca4aeb7b58e7b9a30be77e9d38b8) | `intel-cmt-cat: 4.3.0 -> 4.4.0`                                        |
| [`aff20eaa`](https://github.com/NixOS/nixpkgs/commit/aff20eaaff837ba831c17a5ebf5cc67299e782b1) | `globalprotect-openconnect: 1.4.5 -> 1.4.8`                            |
| [`5f446fe1`](https://github.com/NixOS/nixpkgs/commit/5f446fe1a3bf5799b09f2860f4a489386a7070e6) | `git-cliff: 0.7.0 -> 0.8.1`                                            |
| [`6bcc3f23`](https://github.com/NixOS/nixpkgs/commit/6bcc3f23321c1f05e59d356fe600abdef6578b3f) | `python310Packages.blinkpy: 0.19.1 -> 0.19.2`                          |