### PR TITLE
chore(flake/home-manager): `f5e9879e` -> `c1addfda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1659878744,
-        "narHash": "sha256-81a9Mx5pDMBGN4WnVhcQVkW5mXNTZOt8DZOSI8bVKpU=",
+        "lastModified": 1659978484,
+        "narHash": "sha256-VkErPc8pXcuFQG7jkkaUOEMORe81oweRNlAYZJ2+aRI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f5e9879e74e6202e2dbb3628fad2d20eac0d8be4",
+        "rev": "c1addfdad3825f75a66f8d73ec7d2f68c78ba6f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                     |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`c1addfda`](https://github.com/nix-community/home-manager/commit/c1addfdad3825f75a66f8d73ec7d2f68c78ba6f8) | `gammastep: wait on geoclue-agent when configured` |
| [`389f2b20`](https://github.com/nix-community/home-manager/commit/389f2b20371b7c0c7e52ceb817d7c8bbc63435a4) | `bashmount: add module`                            |