### PR TITLE
chore(flake/nixpkgs): `4bdf4169` -> `39d7f929`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659889440,
-        "narHash": "sha256-O8+FsHZzQIqjQjuh+VXbJtGrpPswm5ta2Z/eo72Lz2U=",
+        "lastModified": 1659981942,
+        "narHash": "sha256-uCFiP/B/NXOWzhN6TKfMbSxtVMk1bVnCrnJRjCF6RmU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bdf4169ad2896236895ca607a843f30c9680345",
+        "rev": "39d7f929fbcb1446ad7aa7441b04fb30625a4190",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                           |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`6efa5c77`](https://github.com/NixOS/nixpkgs/commit/6efa5c77edd931f53f4f68768ec54bbe596c8492) | `nixos/snipe-it: Add private_uploads to tmpfiles`                                        |
| [`d68ba1d7`](https://github.com/NixOS/nixpkgs/commit/d68ba1d746e668865254f03cc4f629d0d1a15f66) | `nixos/plasma5: default runUsingSystemd to on`                                           |
| [`6f38b43c`](https://github.com/NixOS/nixpkgs/commit/6f38b43c8c84c800f93465b2241156419fd4fd52) | `go: minor cleanup`                                                                      |
| [`8bf7be60`](https://github.com/NixOS/nixpkgs/commit/8bf7be6063116e0a38ab61db416e389046c0e942) | `lndhub-go: 0.9.0 -> 0.10.0`                                                             |
| [`09302143`](https://github.com/NixOS/nixpkgs/commit/093021431be41e5026a5da041e68e079e1b94d87) | `audacious-plugins: add qtx11extras`                                                     |
| [`b8dc7a5e`](https://github.com/NixOS/nixpkgs/commit/b8dc7a5e88a82d218fddf6c14a6ccfc830fd296e) | `audacious: migrate to meson build system, refactor`                                     |
| [`0883143d`](https://github.com/NixOS/nixpkgs/commit/0883143d7101758b9491d7a6e526041bc4ed37d2) | `python310Packages.fastcore: 1.5.11 -> 1.5.15`                                           |
| [`eab023c5`](https://github.com/NixOS/nixpkgs/commit/eab023c51614856844bb09ad2970abf4d995ceb9) | `python310Packages.aioshelly: 2.0.1 -> 3.0.0`                                            |
| [`9b3d83d3`](https://github.com/NixOS/nixpkgs/commit/9b3d83d39e0531a33d041ff6e4224bb500f82b13) | `dnsrecon: 1.1.1 -> 1.1.2`                                                               |
| [`81365587`](https://github.com/NixOS/nixpkgs/commit/81365587c22ecec4b52fbbd52cce4f378f044817) | `papirus-icon-theme: 20220710 -> 20220808`                                               |
| [`d8dc3f60`](https://github.com/NixOS/nixpkgs/commit/d8dc3f609c48dca237450da2b85edd4b99418f9c) | `python310Packages.aioairzone: 0.4.6 -> 0.4.8`                                           |
| [`4a501a06`](https://github.com/NixOS/nixpkgs/commit/4a501a0664b92a29b4fe5d46bf7d3ad6ba6ddda1) | `python310Packages.hahomematic: 2022.8.2 -> 2022.8.3`                                    |
| [`bf097721`](https://github.com/NixOS/nixpkgs/commit/bf0977210939b2e46fd245d0687e1bf97390331f) | `gitleaks: 8.9.0 -> 8.10.0`                                                              |
| [`b3b45e6b`](https://github.com/NixOS/nixpkgs/commit/b3b45e6b5fad61521c025abc6eb15218630f6a04) | `v2ray-domain-list-community: 20220708161253 -> 20220808014309`                          |
| [`106d7ac6`](https://github.com/NixOS/nixpkgs/commit/106d7ac603f5523d43ae1be96c788b8639c64750) | `v2ray-geoip: 202207070057 -> 202208040058`                                              |
| [`f51f7225`](https://github.com/NixOS/nixpkgs/commit/f51f722597598eec959df03ea0ffe82444d6609f) | `cinny: 2.0.4 -> 2.1.1`                                                                  |
| [`5e14cac0`](https://github.com/NixOS/nixpkgs/commit/5e14cac0b10359c894ee44158a6cc71227506c55) | `wezterm: 20220624-141144-bd1b7c5d -> 20220807-113146-c2fee766`                          |
| [`053fb006`](https://github.com/NixOS/nixpkgs/commit/053fb00690945ab06650c4508b98659c6a2343b6) | `freerdp: 2.7.0 -> 2.8.0`                                                                |
| [`d17f3678`](https://github.com/NixOS/nixpkgs/commit/d17f36789ba5b68a03d70d59a769f67d008dbeb2) | `bmake: unbreak`                                                                         |
| [`ce83a761`](https://github.com/NixOS/nixpkgs/commit/ce83a76107275404f0825e1d5f6305cc1fdd326d) | `bmake: 20220208 -> 20220726`                                                            |
| [`47a072b9`](https://github.com/NixOS/nixpkgs/commit/47a072b984946d475200d56c93f76deb3bc1d5bb) | `bmake: new recursive style attributes`                                                  |
| [`22880e58`](https://github.com/NixOS/nixpkgs/commit/22880e58edd8be6024daf9e6fa4bae95b1449810) | ``zee: init at `0.3.2```                                                                 |
| [`09ee2456`](https://github.com/NixOS/nixpkgs/commit/09ee24561172180ed662645c2a586b85175acf63) | `python310Packages.volvooncall: 0.10.0 -> 0.10.1`                                        |
| [`2dd1fdec`](https://github.com/NixOS/nixpkgs/commit/2dd1fdecfe2fb6a577fd1f375af3ac167d2904db) | `python310Packages.aiohttp-jinja2: disable tests`                                        |
| [`5d5859df`](https://github.com/NixOS/nixpkgs/commit/5d5859df9b66978da74277df904338b231481bd2) | `sgtpuzzles-mobile: init`                                                                |
| [`df8a4eea`](https://github.com/NixOS/nixpkgs/commit/df8a4eeaf74169b1e0c11e3d3638c9c15292dc97) | `exiv2: update homepage`                                                                 |
| [`4f60e485`](https://github.com/NixOS/nixpkgs/commit/4f60e485091bb8d2132025295220565100afa806) | `go: init 1.17 bootstrap`                                                                |
| [`e4b5fde0`](https://github.com/NixOS/nixpkgs/commit/e4b5fde06b1fb0b77156ac365215cb96cc07a4bc) | `go: version bootstrap`                                                                  |
| [`9d10f943`](https://github.com/NixOS/nixpkgs/commit/9d10f94380060caa62b3bd47f12399688b400fff) | `go: print-hashes script`                                                                |
| [`6716c682`](https://github.com/NixOS/nixpkgs/commit/6716c682c845d523d8540b011fe796449c90b77d) | `btcpayserver: 1.6.1 -> 1.6.6`                                                           |
| [`aecf8393`](https://github.com/NixOS/nixpkgs/commit/aecf8393c54ec73b32c7fb2a3a65c1c25df59fb4) | `nbxplorer: 2.3.28 -> 2.3.33`                                                            |
| [`3da0342d`](https://github.com/NixOS/nixpkgs/commit/3da0342d6dab31c61be5c3dbe92765875d8e0e84) | `nsxiv: 29 → 30`                                                                         |
| [`74f63828`](https://github.com/NixOS/nixpkgs/commit/74f63828c6da110b5d98039b650c900b58708de2) | `tinyxml-2: update homepage (#185586)`                                                   |
| [`b76e46cc`](https://github.com/NixOS/nixpkgs/commit/b76e46ccee3b3f72902c05a3358563fe09ec1715) | `python310Packages.regenmaschine: 2022.07.3 -> 2022.08.0`                                |
| [`a9daa4bd`](https://github.com/NixOS/nixpkgs/commit/a9daa4bd3e6a5e29868e264d4b10b23ca959d07b) | `python310Packages.python-socketio: 5.7.0 -> 5.7.1`                                      |
| [`b64c6c62`](https://github.com/NixOS/nixpkgs/commit/b64c6c62473f1a3d84e703ed62f5c62664ba9901) | `python310Packages.python-engineio: 4.3.3 -> 4.3.4`                                      |
| [`085009b9`](https://github.com/NixOS/nixpkgs/commit/085009b929911cd2412acdb92954ae011e053e6f) | `deltachat-desktop: fix build`                                                           |
| [`e2f44ca5`](https://github.com/NixOS/nixpkgs/commit/e2f44ca570803a75991a39894701d01eb79b3a17) | `geomyidae: 0.50.1 -> 0.51`                                                              |
| [`77c641e1`](https://github.com/NixOS/nixpkgs/commit/77c641e1e76cba317cfee1dc4b4c58f92cdab959) | `fvwm: add pyxdg dependence and enable parallel building`                                |
| [`396bb501`](https://github.com/NixOS/nixpkgs/commit/396bb501a7645bb46379c8a71122d9dbbaf311bd) | `fvwm3: add pyxdg dependence and enable parallel building`                               |
| [`9c16c997`](https://github.com/NixOS/nixpkgs/commit/9c16c997a65b8db262f9a3ddc5d2514233cbbf2a) | `nixos/hadoop.hbase: fix indentation`                                                    |
| [`dffa97f0`](https://github.com/NixOS/nixpkgs/commit/dffa97f03c21f0c45b076eb06740a10e5c679164) | `nixos/hbase-standalone: add mkRenamedOptionModule and rename file`                      |
| [`a92ca626`](https://github.com/NixOS/nixpkgs/commit/a92ca6263af9f05d373bb82fc7edccba9941463e) | `nixos/hadoop.hbase: change mkOption to mkEnableOption`                                  |
| [`2e7c1a9f`](https://github.com/NixOS/nixpkgs/commit/2e7c1a9f23f70fd878a4d0be2f0d06f91c743b0c) | `hadoop: combine per-platforms into one attrset`                                         |
| [`3e212a42`](https://github.com/NixOS/nixpkgs/commit/3e212a42d783230ec87e70dc1ca59fc0a5bb4630) | `nixos/hbase: update release notes`                                                      |
| [`d1af9d15`](https://github.com/NixOS/nixpkgs/commit/d1af9d1517554acd7b891a27f55689a5b8bf6993) | `nixos/hadoop: allow overriding conf files generated by site options with extraconfdirs` |
| [`1285a586`](https://github.com/NixOS/nixpkgs/commit/1285a586c5f0b118931e778764858ee69d10933e) | `nixos/hadoop: fix incorrect merging of yarnSiteInternal`                                |
| [`ac403b83`](https://github.com/NixOS/nixpkgs/commit/ac403b83fb1a8ee53f7889a2fc1987f196b40e63) | `nixos/hadoop: add HBase submodule`                                                      |
| [`cb2576c1`](https://github.com/NixOS/nixpkgs/commit/cb2576c1b6a8b1f3bea840ccf15acae6c4bbfe82) | `hadoop,hbase: better default for HADOOP_CONF_DIR and HBASE_CONF_DIR`                    |
| [`53f2d712`](https://github.com/NixOS/nixpkgs/commit/53f2d71296cb93c1c1b47f12ed7c81abfa1f0b22) | `reredirect: 0.2 -> 0.3`                                                                 |
| [`14bb6740`](https://github.com/NixOS/nixpkgs/commit/14bb6740bf0f5ed39122c1bd1c7d7ce096e8c8fc) | `python310Packages.pysigma-backend-splunk: 0.3.5 -> 0.3.6`                               |
| [`35d5a693`](https://github.com/NixOS/nixpkgs/commit/35d5a693754454795a72fe2c764f241445551886) | `python310Packages.pysigma-pipeline-windows: 0.1.1 -> 1.0.0`                             |
| [`742a1df5`](https://github.com/NixOS/nixpkgs/commit/742a1df5989da75962e80a40b01371e886157c9e) | `python310Packages.pysigma: 0.6.8 -> 0.7.3`                                              |
| [`934b565d`](https://github.com/NixOS/nixpkgs/commit/934b565dd7f7b90ac3b996c64f1270dc0eb13896) | `sigma-cli: 0.4.3 -> 0.5.0`                                                              |
| [`fa2dcbcc`](https://github.com/NixOS/nixpkgs/commit/fa2dcbcc772a2dd484989156982e8f35bbe38601) | `python310Packages.pysigma-backend-qradar: init at 0.1.9`                                |
| [`df699444`](https://github.com/NixOS/nixpkgs/commit/df69944407b78a25f3291153b38e2ecf4e7ad76b) | `python310Packages.pysigma-backend-opensearch: init at 0.1.2`                            |
| [`7c68a4be`](https://github.com/NixOS/nixpkgs/commit/7c68a4bed4a40717b8133c284dc3f1d4033fcc8c) | `python310Packages.pysigma-backend-elasticsearch: init at 0.1.0`                         |
| [`3adc55f3`](https://github.com/NixOS/nixpkgs/commit/3adc55f325c35250d1737c0a2d37564b2061140f) | `nimPackages.flatty: 0.2.3 -> 0.3.4`                                                     |
| [`7a08effb`](https://github.com/NixOS/nixpkgs/commit/7a08effb26f408f0fefd5ad2d94077043792c22a) | `python310Packages.pysigma-pipeline-sysmon: 0.1.6 -> 1.0.0`                              |
| [`6254ae4d`](https://github.com/NixOS/nixpkgs/commit/6254ae4d02fdbdb94edf4f455839b621c8a43299) | `python310Packages.pysigma-pipeline-crowdstrike: 0.1.6 -> 0.1.7`                         |
| [`247d8a1a`](https://github.com/NixOS/nixpkgs/commit/247d8a1a1052ce3bc802f0c7f7ba9849624e8bed) | `python310Packages.pysigma-backend-insightidr: 0.1.6 -> 0.1.7`                           |
| [`538f6f8e`](https://github.com/NixOS/nixpkgs/commit/538f6f8eae3f1d78d83b2d028fcc7c76c5954079) | `libiptcdata: 1.0.4 -> 1.0.5`                                                            |
| [`df9bc0db`](https://github.com/NixOS/nixpkgs/commit/df9bc0dbc502f5b9589533df490ff8fa8af91c34) | `buttercup-desktop: 2.14.2 -> 2.16.0`                                                    |
| [`035bd7ff`](https://github.com/NixOS/nixpkgs/commit/035bd7ff8391d4a9aba02e3270cc25d6effed996) | `python310Packages.aioecowitt: init at 2022.7.0`                                         |
| [`6e1e7853`](https://github.com/NixOS/nixpkgs/commit/6e1e7853356589598567e21fd73a174aba71a122) | `python310Packages.meteocalc: init at 1.1.0`                                             |
| [`6c585155`](https://github.com/NixOS/nixpkgs/commit/6c585155287fd0a088fb5c5f97eed35584fd663f) | `syncthingtray: 1.2.1 -> 1.2.2`                                                          |
| [`ec8c43b3`](https://github.com/NixOS/nixpkgs/commit/ec8c43b35cb65b1f34811fcaf625d031a7b6c713) | `smartdns: 36.1 -> 37`                                                                   |
| [`9f86d199`](https://github.com/NixOS/nixpkgs/commit/9f86d199b4592ca4fd2ffc93fa8e49c024863cc4) | `nginx: bump moreheaders to fix coredump with nginx 1.23`                                |
| [`44c517e7`](https://github.com/NixOS/nixpkgs/commit/44c517e771d31345c0393ea33d50434a757ae539) | `revive: 1.2.1 -> 1.2.2`                                                                 |
| [`917a0d2b`](https://github.com/NixOS/nixpkgs/commit/917a0d2bffaf57913f4e2415ca2a592ce9280a56) | `python310Packages.clustershell: Fix tests`                                              |
| [`f1ad47f4`](https://github.com/NixOS/nixpkgs/commit/f1ad47f4d8a281edb1fbd258d82fb1d11a3021a1) | `mu: 1.8.7 -> 1.8.8`                                                                     |
| [`412fe63c`](https://github.com/NixOS/nixpkgs/commit/412fe63c6b41d4a201c73569a80e0b31f1911359) | `xone: 0.2 -> 0.3`                                                                       |
| [`73a30899`](https://github.com/NixOS/nixpkgs/commit/73a30899b234db1c81e4327567e3414246be312c) | `kid3: 3.9.1 -> 3.9.2`                                                                   |
| [`00b2e45c`](https://github.com/NixOS/nixpkgs/commit/00b2e45cc947a4119562b4b718aac8ae17b07680) | `hwinfo: 21.82 -> 22.0`                                                                  |
| [`58490e24`](https://github.com/NixOS/nixpkgs/commit/58490e244ea66acdee5d22d7b760aac4581106f9) | `bmake: unmark as broken on (aarch64-)darwin`                                            |
| [`4eff4dd2`](https://github.com/NixOS/nixpkgs/commit/4eff4dd2bef54db5c9bbbee9f0faea4fc9c0c720) | `filezilla: 3.60.1 -> 3.60.2`                                                            |
| [`00fd1808`](https://github.com/NixOS/nixpkgs/commit/00fd1808559bf9c76a14c4fed440894fc8d1deb6) | `python3Packages.dvc-render: 0.0.8 -> 0.0.9`                                             |
| [`ee39cb65`](https://github.com/NixOS/nixpkgs/commit/ee39cb65c56e454703322a9bae0aa389698b359b) | `python310Packages.zadnegoale: init at 0.6.5`                                            |
| [`00b05d1f`](https://github.com/NixOS/nixpkgs/commit/00b05d1fe594cbcccbc05975abd521326980e547) | `sile: 0.14.0 → 0.14.1`                                                                  |
| [`4b200c34`](https://github.com/NixOS/nixpkgs/commit/4b200c342c93763ff1dff821caa1af444573bcb2) | `ytfzf: 2.4.0 -> 2.4.1`                                                                  |
| [`ea501443`](https://github.com/NixOS/nixpkgs/commit/ea5014439245b43bc37d4dad23a64ec79e8c4955) | `xschem: 3.0.0 -> 3.1.0`                                                                 |
| [`234eb044`](https://github.com/NixOS/nixpkgs/commit/234eb04495155d1e6d7e297f023f6070c55f1918) | `trino-cli: 390 -> 392`                                                                  |
| [`eb6b78a4`](https://github.com/NixOS/nixpkgs/commit/eb6b78a43b4f6474afb308ab8124fa22eef7f930) | `python310Packages.Wand: 0.6.8 -> 0.6.9`                                                 |
| [`68878c9e`](https://github.com/NixOS/nixpkgs/commit/68878c9e1e73abd83f3120e82445b3dbc63e86df) | `python39Packages.confluent-kafka: 1.9.0 -> 1.9.2`                                       |
| [`45cbde4b`](https://github.com/NixOS/nixpkgs/commit/45cbde4b556635c18628d5d17db0e4d10ab0d103) | `sile: 0.13.3 → 0.14.0`                                                                  |
| [`bb887a64`](https://github.com/NixOS/nixpkgs/commit/bb887a641c94aaee2eba8af8720e8e2a024591e1) | `kics: 1.5.12 -> 1.5.13`                                                                 |
| [`1033d796`](https://github.com/NixOS/nixpkgs/commit/1033d7967d8741939a0aee2f31d6ccb5dbe97aee) | `golangci-lint: 1.47.3 -> 1.48.0`                                                        |
| [`8677058a`](https://github.com/NixOS/nixpkgs/commit/8677058a83e719eda3c5f29878e00571615c5a16) | `mangohud: 0.6.7-1 → 0.6.8`                                                              |
| [`b54e2826`](https://github.com/NixOS/nixpkgs/commit/b54e2826328af101e6f00caa6ec984a314c2536d) | `kubernetes-helmPlugins.helm-diff: 3.1.3 -> 3.5.0`                                       |
| [`f3e8b609`](https://github.com/NixOS/nixpkgs/commit/f3e8b609c30a0d831c7f987274907cdb43e07720) | `kubectx: unpin go 1.17`                                                                 |
| [`4e54f3af`](https://github.com/NixOS/nixpkgs/commit/4e54f3af36185d074ffb13a46704753696633ddd) | `helm-plugins: make links clickable`                                                     |
| [`6271fbc7`](https://github.com/NixOS/nixpkgs/commit/6271fbc73c877774eb29b934753b98717b20de40) | `tachyon: 0.99.4 -> 0.99.5`                                                              |
| [`db204883`](https://github.com/NixOS/nixpkgs/commit/db2048839d4cc9b3c719c7e327109b90807a5c20) | `remind: 04.00.00 -> 04.00.01`                                                           |
| [`297ea976`](https://github.com/NixOS/nixpkgs/commit/297ea976260efca3f74613de79ad95b81c244fbe) | `opkg: 0.4.5 -> 0.6.0`                                                                   |
| [`3b119ba0`](https://github.com/NixOS/nixpkgs/commit/3b119ba0155b7124b9c2bf9a3772bf51127629fc) | `libpulsar: 2.9.1 -> 2.10.1`                                                             |
| [`9aa588ec`](https://github.com/NixOS/nixpkgs/commit/9aa588ecc394f140681a0d68b635b3cf45ade411) | `nixos/documentation: Add unit test`                                                     |
| [`ec3e1c6a`](https://github.com/NixOS/nixpkgs/commit/ec3e1c6a3a19e1eaf14d8697e99922c192129574) | `nixos/documentation: Remove systemd/initrd dependency`                                  |
| [`08e6f457`](https://github.com/NixOS/nixpkgs/commit/08e6f457477042c62629e19fd987b8de95755522) | `nixos: Declare module dependencies`                                                     |
| [`5a98c630`](https://github.com/NixOS/nixpkgs/commit/5a98c630778e71ce0573c12a0b586c9a1dcdb4f4) | `nixos: Move getty helpLine definition to getty module`                                  |
| [`9a0b26b2`](https://github.com/NixOS/nixpkgs/commit/9a0b26b216264d6187b4b5dba5c51c5b50d825a9) | `nixos/documentation: Make extraModules configurable`                                    |
| [`e135c417`](https://github.com/NixOS/nixpkgs/commit/e135c417bbaaaf29184004b132c74ae120ea17e8) | `nixos/documentation: Forward the specialArgs`                                           |
| [`bf5b7586`](https://github.com/NixOS/nixpkgs/commit/bf5b75864dbce1e072ac1c1816f6bda97c096e46) | `lib/modules: Add _module.specialArgs`                                                   |
| [`facbbae4`](https://github.com/NixOS/nixpkgs/commit/facbbae4b7cb818569024a7bd1dbddf1bbdd4c35) | `gcc: Set --with-newlib when using newlib-nano`                                          |
| [`d5fb429c`](https://github.com/NixOS/nixpkgs/commit/d5fb429c7dcaaabde24d4efb8d96c97ecb356a63) | `cc-wrapper: Set correct hardening_unsupported_flags for newlib-nano`                    |
| [`a215794d`](https://github.com/NixOS/nixpkgs/commit/a215794df6119b0bbed13cbaaa2c829804697724) | `unison-ucm: M3 -> M4`                                                                   |
| [`e5af5577`](https://github.com/NixOS/nixpkgs/commit/e5af5577c32ca51591be48d8dd7ebd2a5ee9296a) | `outils: init at 0.10`                                                                   |