### PR TITLE
chore(flake/nixpkgs): `39d7f929` -> `36cc29d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659981942,
-        "narHash": "sha256-uCFiP/B/NXOWzhN6TKfMbSxtVMk1bVnCrnJRjCF6RmU=",
+        "lastModified": 1660071133,
+        "narHash": "sha256-XX6T9wcvEZIVWY4TO5O1d2MgFyFrF2v4TpCFs7fjdn8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "39d7f929fbcb1446ad7aa7441b04fb30625a4190",
+        "rev": "36cc29d837e7232e3176e4651e8e117a6f231793",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
| [`2f69e982`](https://github.com/NixOS/nixpkgs/commit/2f69e982ace00128c0641c368aee171cb56fb13e) | `fwupd: drop unnecessary GTK dependency`                                                                 |
| [`d42f6128`](https://github.com/NixOS/nixpkgs/commit/d42f6128c7075a5babf21e4716f0d071724359e1) | `bats: Add library test`                                                                                 |
| [`b336a98f`](https://github.com/NixOS/nixpkgs/commit/b336a98f7320077f9dcd8fccb4560f5be43906ff) | `gcc-arm-embedded-11: init at 11.3.rel1`                                                                 |
| [`567448c3`](https://github.com/NixOS/nixpkgs/commit/567448c3d93904311b8586060bfe621573a1e415) | `python310Packages.pyunifiprotect: 4.0.11 -> 4.0.12`                                                     |
| [`e17fa76b`](https://github.com/NixOS/nixpkgs/commit/e17fa76bdb3740e32440046216626a3a3746b048) | `nix-bisect: add patch from upstream to fix crashes`                                                     |
| [`748a0872`](https://github.com/NixOS/nixpkgs/commit/748a08728e64cedca5520eceb117eee8de282cf9) | `touchosc: init at 1.1.4.143`                                                                            |
| [`b03d2f61`](https://github.com/NixOS/nixpkgs/commit/b03d2f610319547fb83ab10b96e68ac57abd4999) | `python310Packages.azure-mgmt-servicebus: 7.1.0 -> 8.0.0`                                                |
| [`0f456ce6`](https://github.com/NixOS/nixpkgs/commit/0f456ce6277333ea2d2f20eab8f910ac36c4d292) | `pkgsStatic.gdb: Fix compile`                                                                            |
| [`9dc35afd`](https://github.com/NixOS/nixpkgs/commit/9dc35afd5f91ed9524af5c5b0eaed2d06fa12b9a) | `kodelife: 0.9.8.143 -> 1.0.5.161`                                                                       |
| [`d691e894`](https://github.com/NixOS/nixpkgs/commit/d691e8945bbef5bb43abf89f84e2d662657a586b) | `python310Packages.plugwise: 0.21.1 -> 0.21.2`                                                           |
| [`1c201db2`](https://github.com/NixOS/nixpkgs/commit/1c201db2695cf1d558154c16fb1b636bfd1c5e83) | `python310Packages.jsbeautifier: 1.14.4 -> 1.14.5`                                                       |
| [`f018c335`](https://github.com/NixOS/nixpkgs/commit/f018c33574ec3d1f387c3a8adc89528d06cbbf57) | `python310Packages.aiohomekit: 1.2.5 -> 1.2.6`                                                           |
| [`11896e7e`](https://github.com/NixOS/nixpkgs/commit/11896e7e219ada95d9368fc97b49d68283625431) | `python310Packages.aioairzone: 0.4.8 -> 0.4.9`                                                           |
| [`58cda945`](https://github.com/NixOS/nixpkgs/commit/58cda94562ed5a182d040d920b35219f4148051a) | `python310Packages.azure-mgmt-network: 20.0.0 -> 21.0.0`                                                 |
| [`e9831074`](https://github.com/NixOS/nixpkgs/commit/e9831074efb92b0f9314e1d2ff34e3d8b3a830c0) | `ocamlPackages_4_06.num: fix after #110571`                                                              |
| [`72a551c1`](https://github.com/NixOS/nixpkgs/commit/72a551c13f167558a7a364a84594695e1335dfa2) | `python310Packages.bleak-retry-connector: 1.4.0 -> 1.5.0`                                                |
| [`65f39b91`](https://github.com/NixOS/nixpkgs/commit/65f39b913d0910907ea22be29f108402924644c2) | `prometheus-zfs-exporter: init at 2.2.5`                                                                 |
| [`6898b758`](https://github.com/NixOS/nixpkgs/commit/6898b758b69222959b16a96412a572bd341a4bc7) | `luaPackages.lua-subprocess: init at scm-1`                                                              |
| [`5c8d55cc`](https://github.com/NixOS/nixpkgs/commit/5c8d55cc72b77713977773a9eee3317739e4d8e4) | `cheat: 4.2.6 -> 4.3.1`                                                                                  |
| [`b1a72782`](https://github.com/NixOS/nixpkgs/commit/b1a72782cf8dd874c298ea067d933e254b78ce3b) | `haskellPackages.hb3sum: disable on aarch64-linux because of dep`                                        |
| [`2c84638d`](https://github.com/NixOS/nixpkgs/commit/2c84638d2b848f6b096036a72928097f0c6ec79f) | `yt-dlp: 2022.07.18 -> 2022.8.8`                                                                         |
| [`e94f52c3`](https://github.com/NixOS/nixpkgs/commit/e94f52c385b5154d1edd536478553967c900c1c7) | `haskellPackages.stripeapi: mark as dontDistribute because output exceeds Hydras maximum allowable size` |
| [`6e8c590e`](https://github.com/NixOS/nixpkgs/commit/6e8c590ec8ab7029ecc2ea0485c02116e730b9f6) | `haskellPackages: mark builds failing on hydra as broken`                                                |
| [`aa832eed`](https://github.com/NixOS/nixpkgs/commit/aa832eedd765c9bfce570d3e73117c4dfaaee33b) | `haskellPackages: mark builds timing-out on hydra as broken`                                             |
| [`534146ea`](https://github.com/NixOS/nixpkgs/commit/534146ea00ce7ea63a357c59b0dfffb5814f9507) | `x16-emulator: mark as broken on aarch64-darwin`                                                         |
| [`8b4479cf`](https://github.com/NixOS/nixpkgs/commit/8b4479cf28ff6dfd2ba1518691d06b278ec3c4f7) | `x16-emulator: 40 -> 41`                                                                                 |
| [`326a0fda`](https://github.com/NixOS/nixpkgs/commit/326a0fda17218da1bb8bc72039871547549980aa) | `x16-rom: mark as broken on aarch64-darwin`                                                              |
| [`ddc57cfc`](https://github.com/NixOS/nixpkgs/commit/ddc57cfc0c2bfc0e5bb47dd6a7697c534080f213) | `_3mux: fix build on Darwin`                                                                             |
| [`9f61e20a`](https://github.com/NixOS/nixpkgs/commit/9f61e20a68ceaa8e5a9dcf59eb4c7f04b00cd027) | `x16-rom: 40 -> 41`                                                                                      |
| [`7e901eea`](https://github.com/NixOS/nixpkgs/commit/7e901eeae0da1f2a4342e9773021e8131d54319f) | `kernel: only enable PINCTRL_AMD on 5.19+`                                                               |
| [`8243b319`](https://github.com/NixOS/nixpkgs/commit/8243b319494f2d56e0bdf96133642fb86d481469) | `ameba: 0.14.3 -> 1.0.1`                                                                                 |
| [`70220e79`](https://github.com/NixOS/nixpkgs/commit/70220e79b1b413a9c1e50aab24922b345f839c1a) | `WIP`                                                                                                    |
| [`603b6f6b`](https://github.com/NixOS/nixpkgs/commit/603b6f6be133a5e36d509e047ce0b05f37de7446) | `msmtp: resholve queue scripts`                                                                          |
| [`fae17c4f`](https://github.com/NixOS/nixpkgs/commit/fae17c4fe00ad935d8c512221615af1493253651) | `p910nd: cleanups`                                                                                       |
| [`a90b5091`](https://github.com/NixOS/nixpkgs/commit/a90b50917c084c067ac64b22762d2ec55f8be193) | `libdazzle: fix build on darwin`                                                                         |
| [`534b168e`](https://github.com/NixOS/nixpkgs/commit/534b168eaad40e3684aaf0379bf453b997fcca78) | `python310Packages.pyipma: 3.0.0 -> 3.0.2`                                                               |
| [`078ecdaf`](https://github.com/NixOS/nixpkgs/commit/078ecdaf985ee6f3f6a26100e4b4fec484e0f980) | `kitty: fix tests on darwin`                                                                             |
| [`ace70575`](https://github.com/NixOS/nixpkgs/commit/ace70575142bc977d1e2405f856649bdfc6131fb) | `python310Packages.pyprosegur: 0.0.7 -> 0.0.8`                                                           |
| [`2623306a`](https://github.com/NixOS/nixpkgs/commit/2623306a5d699dc6053d4c6767269045fe906d33) | `wl-mirror: 0.11.2 -> 0.12.1`                                                                            |
| [`cf3216ab`](https://github.com/NixOS/nixpkgs/commit/cf3216ab2c62c18811fcd9133b025ca9e3feb230) | `python310Packages.python-heatclient: disable failing test`                                              |
| [`f0734d72`](https://github.com/NixOS/nixpkgs/commit/f0734d72fc03fb7a997db5eaa7906db98ecac9d7) | `python310Packages.aiohttp-retry: 2.5.6 -> 2.7.0`                                                        |
| [`4df3ae78`](https://github.com/NixOS/nixpkgs/commit/4df3ae78dde81f0d3a817e489bae2f73da711ab4) | `dvc: add anthonyroussel to maintainers`                                                                 |
| [`5756220a`](https://github.com/NixOS/nixpkgs/commit/5756220adab4ee628a75a74bd846042d3c0cb5d1) | `dvc: 2.12.0 -> 2.17.0`                                                                                  |
| [`14c05dc6`](https://github.com/NixOS/nixpkgs/commit/14c05dc6ac860cbed9b13524cb6adc8f79003c90) | `libjwt-typed: unbreak with minor changes`                                                               |
| [`2bec83a3`](https://github.com/NixOS/nixpkgs/commit/2bec83a3ed42bf3f6e9f738175bd86b835da3262) | `python3Packages.python-benedict: fix broken build`                                                      |
| [`b5a62999`](https://github.com/NixOS/nixpkgs/commit/b5a62999aa16227194d2f0afd9bf323bee806813) | `expliot: don't run tests of cmd2 override`                                                              |
| [`7363ab9e`](https://github.com/NixOS/nixpkgs/commit/7363ab9ebb2d3f3ce617abd2420ed922647c85de) | `python311: 3.11.0b5 -> 3.11.0rc1`                                                                       |
| [`6d4b71e6`](https://github.com/NixOS/nixpkgs/commit/6d4b71e6ba823bfd1ad908c62f4b641d7f9ec066) | `faraday-agent-dispatcher: disable TLS/SSL tests`                                                        |
| [`2abddece`](https://github.com/NixOS/nixpkgs/commit/2abddece9643fc05ac33782b45de461cfa8cc81b) | `geant4: 11.0.0 -> 11.0.2 (#184349)`                                                                     |
| [`17819194`](https://github.com/NixOS/nixpkgs/commit/17819194f7e2524216f480422c333ba127be8548) | `hysteria: init at 1.1.0`                                                                                |
| [`27ddc618`](https://github.com/NixOS/nixpkgs/commit/27ddc618ca29e9690f59c1be1154cb74ccc8523f) | `python310Packages.hstspreload: 2021.12.1 -> 2022.8.1`                                                   |
| [`b6854d64`](https://github.com/NixOS/nixpkgs/commit/b6854d6475d4e868af85bf40bcbf050b28d5fd36) | `python310Packages.hahomematic: 2022.8.3 -> 2022.8.4`                                                    |
| [`de42430f`](https://github.com/NixOS/nixpkgs/commit/de42430fa79467ff2139cffb3c4442cdc6b1f97b) | `home-assistant: 2022.8.1 -> 2022.8.2`                                                                   |
| [`575bab3e`](https://github.com/NixOS/nixpkgs/commit/575bab3e78da896558edfa0e516cf18c19e7c762) | `python310Packages.casbin: 1.16.9 -> 1.17.0`                                                             |
| [`93ac320d`](https://github.com/NixOS/nixpkgs/commit/93ac320de69e314519161e0dc85c3d823445b315) | `electron_20: init at 20.0.1`                                                                            |
| [`748145d0`](https://github.com/NixOS/nixpkgs/commit/748145d0828fc16c029ddc4fa7853a70213b865c) | `hypnotix: rename imdbpy to cinemagoer`                                                                  |
| [`fb520531`](https://github.com/NixOS/nixpkgs/commit/fb520531bbed31c8f4adbc9aa87a786eec2f51f7) | `ptex: 2.4.1 -> 2.4.2 (#185348)`                                                                         |
| [`904648c8`](https://github.com/NixOS/nixpkgs/commit/904648c847171a887c78c26dad872ef35623b3d1) | `python3Packages.cinemagoer: init 2022.2.11`                                                             |
| [`c5b05190`](https://github.com/NixOS/nixpkgs/commit/c5b051905c8838a9f2ecd4918b40e7dcab9c8377) | `xpra: fix launch`                                                                                       |
| [`9e10ba3e`](https://github.com/NixOS/nixpkgs/commit/9e10ba3ee8b8fb43b7419e90144c530a62876527) | `factorio-experimental: 1.1.61 -> 1.1.65`                                                                |
| [`0b62bc1e`](https://github.com/NixOS/nixpkgs/commit/0b62bc1e217bdd7f7d80bd1c6abace15d45d3dfd) | `fzf: 0.32.0 -> 0.32.1`                                                                                  |
| [`51bd91d8`](https://github.com/NixOS/nixpkgs/commit/51bd91d8443be925e47295932d25f81dc5f9c069) | `sonarr: 3.0.8.1507 -> 3.0.9.1549`                                                                       |
| [`fbe194fd`](https://github.com/NixOS/nixpkgs/commit/fbe194fdf6e577468bc38a5ee0bd77d130ddca49) | `bats: Add library wrapper`                                                                              |
| [`d1949b73`](https://github.com/NixOS/nixpkgs/commit/d1949b739a57845d0c4a4d4a79ef41620269edd3) | `bats: init libraries`                                                                                   |
| [`5e268c85`](https://github.com/NixOS/nixpkgs/commit/5e268c85a072c7ea469c197393b2b495d9efccc6) | `vulkan-caps-viewer: init at 3.24`                                                                       |
| [`bd0a5ce3`](https://github.com/NixOS/nixpkgs/commit/bd0a5ce380fee429032a70b75160b1261d38c868) | `beets: test to validate gstreamer interop`                                                              |
| [`b938b491`](https://github.com/NixOS/nixpkgs/commit/b938b4917c01819afcb614a69f39470c81e06c2e) | `python310Packages.pyquil: 3.1.0 -> 3.2.1`                                                               |
| [`f7c98059`](https://github.com/NixOS/nixpkgs/commit/f7c980599e10b9cc53852359a039d54ac60161c9) | `kernel: fix touchpads on AMD laptops`                                                                   |
| [`fd6eedeb`](https://github.com/NixOS/nixpkgs/commit/fd6eedeb04279be9f03fdc4f51aa93279ad68d36) | `maintainers: add oluceps`                                                                               |
| [`81dab0a3`](https://github.com/NixOS/nixpkgs/commit/81dab0a302e748f0adfcdaed018e9209000229f0) | `python310Packages.pescea: 1.0.10 -> 1.0.11`                                                             |
| [`ae62769e`](https://github.com/NixOS/nixpkgs/commit/ae62769e6f8458c5053bbc27c3ade35270e1dd87) | `python310Packages.plexapi: 4.12.0 -> 4.12.1`                                                            |
| [`7b6ad60a`](https://github.com/NixOS/nixpkgs/commit/7b6ad60ab4cd0661c5aa515a7de28ddda73a3e70) | `hackedbox: init at 0.8.5.1`                                                                             |
| [`58567142`](https://github.com/NixOS/nixpkgs/commit/585671427ea3dec2ecf2e6030495a9b208ebfbe4) | `haskellPackages.text-format: add comment about patch`                                                   |
| [`2056075f`](https://github.com/NixOS/nixpkgs/commit/2056075fdba17f66fefe456526418d36c48e3519) | `haskellPackages.text-format: fix GHC 9.2 build`                                                         |
| [`eab827c6`](https://github.com/NixOS/nixpkgs/commit/eab827c6eeb46cc52a24a285dcc88bddfc787707) | `python3Packages.zigpy-zigate: 0.9.0 -> 0.9.1`                                                           |
| [`3a8f3937`](https://github.com/NixOS/nixpkgs/commit/3a8f3937a3a21eb5644acaf4f139eee6927d5677) | `python3Packages.gpiozero: init at 1.6.2`                                                                |
| [`76e7ca2c`](https://github.com/NixOS/nixpkgs/commit/76e7ca2cfc1737582623564cd6a886db52f0c7b2) | `python3Packages.colorzero: init at 2.0`                                                                 |
| [`ffbeb99b`](https://github.com/NixOS/nixpkgs/commit/ffbeb99b896d3a5557fecb8422a8f1c6193fa356) | `python3Packages.zigpy: 0.48.0 -> 0.49.0`                                                                |
| [`bf0cdfc8`](https://github.com/NixOS/nixpkgs/commit/bf0cdfc8ab9cf3a4bedfa0b195311ef583125670) | `python3Packages.greeclimate: 1.2.1 -> 1.3.0`                                                            |
| [`4cb2de4c`](https://github.com/NixOS/nixpkgs/commit/4cb2de4c49bcde8f6c472ccc958bb2e2c4f302db) | `python3Packages.bellows: 0.31.2 -> 0.31.3`                                                              |
| [`79277c3f`](https://github.com/NixOS/nixpkgs/commit/79277c3fd5ab394627f40e242189901b4a3edc40) | `vips: 8.12.2 -> 8.13.0`                                                                                 |
| [`00d73d53`](https://github.com/NixOS/nixpkgs/commit/00d73d5385b63e868bd11282fb775f6fe4921fb5) | `haskellPackages: regenerate package set based on current config`                                        |
| [`5e377ca0`](https://github.com/NixOS/nixpkgs/commit/5e377ca0125ff8337a9fa759462079ec59c17301) | `all-cabal-hashes: 2022-08-06T12:01:14Z -> 2022-08-07T14:05:30Z`                                         |
| [`6771519b`](https://github.com/NixOS/nixpkgs/commit/6771519bf3c5cdfa05ee9c912af0807392ded55b) | `tidal-hifi: 4.0.1 -> 4.1.0`                                                                             |
| [`8787835f`](https://github.com/NixOS/nixpkgs/commit/8787835fe3821e47b4e0043d96be329f44416604) | `flyway: 9.0.4 -> 9.1.2`                                                                                 |
| [`d05755d9`](https://github.com/NixOS/nixpkgs/commit/d05755d90bb7cd9c3770a1328999fba7c5a8c091) | `haskellPackages: adapt to hspec updates`                                                                |
| [`3d6e5457`](https://github.com/NixOS/nixpkgs/commit/3d6e54576b99c45eaa7361cd2abf64b8fce5e775) | `haskell.packages.ghc924: adapt to ormolu update`                                                        |
| [`b30a82ca`](https://github.com/NixOS/nixpkgs/commit/b30a82caa8d6e02bbf65b00e67b7285efb0979c2) | `realvnc-vnc-viewer: 6.22.207 -> 6.22.515`                                                               |
| [`9aa722d1`](https://github.com/NixOS/nixpkgs/commit/9aa722d1507a8ea1f1ab6fe4def61720a17bdd9f) | `haskellPackages.keid-{frp-banana,resource-gltf}: set platforms`                                         |
| [`d3fbc5df`](https://github.com/NixOS/nixpkgs/commit/d3fbc5dfba716633f44399733ace3e322f2e97c5) | `all-cabal-hashes: 2022-07-31T09:12:37Z -> 2022-08-06T12:01:14Z`                                         |
| [`a567b45e`](https://github.com/NixOS/nixpkgs/commit/a567b45ef61810966ab4b71006b72835dd0fd969) | `libguestfs: 1.48.0 -> 1.48.4`                                                                           |
| [`98ba23d0`](https://github.com/NixOS/nixpkgs/commit/98ba23d04346c36eb359bd254834dad132e88434) | `python310Packages.mailchecker: 4.1.18 -> 5.0.0`                                                         |
| [`00859ef4`](https://github.com/NixOS/nixpkgs/commit/00859ef4d00988e528a597f889d951af2e0bd8bb) | `saleae-logic-2: 2.3.56 -> 2.3.58`                                                                       |
| [`84f573b9`](https://github.com/NixOS/nixpkgs/commit/84f573b9d17cc86cc68973c907d216ec735d06cf) | `temporal: 1.17.1 -> 1.17.2`                                                                             |
| [`ab0af326`](https://github.com/NixOS/nixpkgs/commit/ab0af3267feab9fa636d65a9b3ff64ad0784af6f) | `Revert "qemu: fix build w/glibc-2.33"`                                                                  |
| [`b6ee99e0`](https://github.com/NixOS/nixpkgs/commit/b6ee99e0c92b1a8aa0204aa9146be3eed854f4a4) | `radioboat: 0.2.1 -> 0.2.2`                                                                              |
| [`2fe88023`](https://github.com/NixOS/nixpkgs/commit/2fe88023bcb56f89614fe63706df5218f29d0818) | `mold: 1.3.1 -> 1.4.0`                                                                                   |
| [`4c2764c6`](https://github.com/NixOS/nixpkgs/commit/4c2764c69c094d6917ff857aa4667f8886ef8d5e) | `nixos/switch-to-configuration: replace Net::DBus with busctl`                                           |
| [`141ec34c`](https://github.com/NixOS/nixpkgs/commit/141ec34c9a8c3b6ec04324d18b624abec981c5f4) | `beets: fix pygobject issues`                                                                            |
| [`566d1258`](https://github.com/NixOS/nixpkgs/commit/566d1258d1edfc01499a1a3f693aa64c951f12cd) | `scala-cli: 0.1.10 -> 0.1.11`                                                                            |
| [`c2c7a1bd`](https://github.com/NixOS/nixpkgs/commit/c2c7a1bd6e4cb63165859e8222513cb743243001) | `railway: 1.8.4 -> 2.0.0`                                                                                |
| [`128a3b10`](https://github.com/NixOS/nixpkgs/commit/128a3b10a696a1d29a6f71fad0033520cbd063c5) | `libguestfs: format using nixpkgs-fmt`                                                                   |
| [`313205f8`](https://github.com/NixOS/nixpkgs/commit/313205f8cdf96a41ca3a506cd3581405744e2237) | `clevis: add various packages to wrapper`                                                                |
| [`1ac68fd2`](https://github.com/NixOS/nixpkgs/commit/1ac68fd225721bb7319bb6f51aaa6f2147d3bad2) | `megapixels: 1.5.0 -> 1.5.2`                                                                             |
| [`a5123553`](https://github.com/NixOS/nixpkgs/commit/a5123553534f81e3163943b70eb4f22283a74823) | `libpsm2: 11.2.206 -> 11.2.229`                                                                          |
| [`9a59b1b0`](https://github.com/NixOS/nixpkgs/commit/9a59b1b0fed320fef681f0f3a19590b39c8d840c) | `libosmocore: fix version in pkg-config file`                                                            |
| [`7826c54c`](https://github.com/NixOS/nixpkgs/commit/7826c54c05592429ec912dced39ce64dd8c4aff8) | `libosmocore: 1.6.0 -> 1.7.0`                                                                            |
| [`3c78886a`](https://github.com/NixOS/nixpkgs/commit/3c78886a42c5fc82d70c773d5a5c28809958e6a8) | `python3Packages.botocore: 1.27.31 -> 1.27.42`                                                           |
| [`e38f4a75`](https://github.com/NixOS/nixpkgs/commit/e38f4a75f6c284ec2548854060e55926bbab34db) | `python3Packages.boto3: 1.24.31 -> 1.24.42`                                                              |
| [`321f94fb`](https://github.com/NixOS/nixpkgs/commit/321f94fb46bad176d852daa7be9c345f69921716) | `awscli: 1.25.31 -> 1.25.42`                                                                             |
| [`c8ea776a`](https://github.com/NixOS/nixpkgs/commit/c8ea776a5408b2281582a81f0e90526c5b0ec5fe) | `libfabric: 1.14.0 -> 1.15.1`                                                                            |
| [`dba33e2a`](https://github.com/NixOS/nixpkgs/commit/dba33e2ac805ab78e9c5335edc306967f3b89afc) | `python310Packages.pyroute2: 0.7.1 -> 0.7.2`                                                             |
| [`afda1666`](https://github.com/NixOS/nixpkgs/commit/afda1666364dcfcd820d59b6999fadc2e1b3f776) | `python311: 3.11.0b4 -> 3.11.0b5`                                                                        |
| [`7e8e00d6`](https://github.com/NixOS/nixpkgs/commit/7e8e00d656a145a8c72aae94c7d244f25e8f3594) | ``nixos/restic: use postStop for `backupCleanupCommand```                                                |
| [`cec55883`](https://github.com/NixOS/nixpkgs/commit/cec55883678b1e47863b5f46304bce8b8850fea7) | `mss-mdns: 0.10.0 -> 0.15.1`                                                                             |
| [`07d2943f`](https://github.com/NixOS/nixpkgs/commit/07d2943f1a7ffdd16f78b119a16c0254b7dfc385) | `olive-editor: use qt514's overridden glibc++`                                                           |