### PR TITLE
chore(flake/nixpkgs): `36cc29d8` -> `3a11db5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660071133,
-        "narHash": "sha256-XX6T9wcvEZIVWY4TO5O1d2MgFyFrF2v4TpCFs7fjdn8=",
+        "lastModified": 1660162369,
+        "narHash": "sha256-pZukMP4zCA1FaBg0xHxf7KdE/Nv/C5YbDID7h2L8O7A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "36cc29d837e7232e3176e4651e8e117a6f231793",
+        "rev": "3a11db5f408095b8f08b098ec2066947f4b72ce2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`8149ba4d`](https://github.com/NixOS/nixpkgs/commit/8149ba4d974eb2ea87f201b0de4e4bca2ad0dc64) | `python3Packages.diskcache: disable test with django 4.1 issue`           |
| [`b514c3ab`](https://github.com/NixOS/nixpkgs/commit/b514c3ab731c69e07c48f2bb187e76428e861fde) | `python3Packages.django-js-asset: 2021-06-07 -> 2.0`                      |
| [`91c80fae`](https://github.com/NixOS/nixpkgs/commit/91c80faea0dcbc3d8199f57d4794c645a3a4a66f) | `luaPackages.nfd: init at scm-1`                                          |
| [`ba0aeaf4`](https://github.com/NixOS/nixpkgs/commit/ba0aeaf42907151c4f2dfc8ebef092c3a10692a3) | `python310Packages.django_4: 4.0.7 -> 4.1`                                |
| [`ac27a3cd`](https://github.com/NixOS/nixpkgs/commit/ac27a3cd321a10b82a7c0cc6d423c40f929cfc86) | `gh-dash: init at 3.2.0`                                                  |
| [`5d1fdcce`](https://github.com/NixOS/nixpkgs/commit/5d1fdccef119ddea1db90a84e87377ec18db0990) | `maintainers: add amesgen`                                                |
| [`bf742b9b`](https://github.com/NixOS/nixpkgs/commit/bf742b9b98e70d59eb05afaff03ec08d27c78a90) | `gnutls: officially adopt the package`                                    |
| [`8ea30d9a`](https://github.com/NixOS/nixpkgs/commit/8ea30d9aae2e26e42df132ce2d14a1943262ca86) | `n8n: 0.189.0 → 0.190.0`                                                  |
| [`b4015471`](https://github.com/NixOS/nixpkgs/commit/b4015471b94f47389451eaca231596edaa32d409) | `gitleaks: 8.10.0 -> 8.10.2`                                              |
| [`633eb5e6`](https://github.com/NixOS/nixpkgs/commit/633eb5e6506fcac36f058aa0b13b2eca206df756) | `vulkan-caps-viewer: add meta.mainProgram`                                |
| [`771c7cdb`](https://github.com/NixOS/nixpkgs/commit/771c7cdb48ba416a1827e3310da54cb692719f7a) | `exploitdb: 2022-08-04 -> 2022-08-10`                                     |
| [`47d03c0a`](https://github.com/NixOS/nixpkgs/commit/47d03c0a3f82c8cadf4c1af01f7e8ea31ce123ef) | `mozphab: 0.1.99 -> 1.1.0; rename from moz-phab`                          |
| [`3e1faec7`](https://github.com/NixOS/nixpkgs/commit/3e1faec7b0b98205ea8fa4df5d025e24a4d8d39f) | `faas-cli: 0.14.4 -> 0.14.5`                                              |
| [`cdbf0d5d`](https://github.com/NixOS/nixpkgs/commit/cdbf0d5d673ed2475f29a440f3079588d3123aa6) | `varnish: add myself as maintainer`                                       |
| [`1b6c66d3`](https://github.com/NixOS/nixpkgs/commit/1b6c66d38c9aa842b3987b5c9e36699e44c6bf46) | `varnish71: 7.1.0 -> 7.1.1`                                               |
| [`56a3a71d`](https://github.com/NixOS/nixpkgs/commit/56a3a71d36d58cfe00cbcec8ef8157dfcd887979) | `varnish: sha256 -> hash`                                                 |
| [`019bb00f`](https://github.com/NixOS/nixpkgs/commit/019bb00f7b2787850d25432d16b1a29c87ed160d) | `dyff: 1.5.4 -> 1.5.5`                                                    |
| [`f2f95b12`](https://github.com/NixOS/nixpkgs/commit/f2f95b120bda675c3eba6d6bf01360c5b9a78e9c) | `cri-o: 1.24.1 -> 1.24.2`                                                 |
| [`9ff5c9d1`](https://github.com/NixOS/nixpkgs/commit/9ff5c9d18ed47c4485b2e98cce648efc9e712a23) | `buildah: 1.26.4 -> 1.27.0`                                               |
| [`c19121e3`](https://github.com/NixOS/nixpkgs/commit/c19121e39a200d8c96874690c15ed8d180693fd6) | `bluetuith: 0.0.6 -> 0.0.7`                                               |
| [`daf243ba`](https://github.com/NixOS/nixpkgs/commit/daf243ba05536603111092bb153f2e64b92a8c50) | `containerd: 1.6.7 -> 1.6.8`                                              |
| [`4d51d66e`](https://github.com/NixOS/nixpkgs/commit/4d51d66e2ef62a9b4338ab5931f2f807b05388da) | `perlPackages.BioPerl: init at 1.7.8`                                     |
| [`71db5eae`](https://github.com/NixOS/nixpkgs/commit/71db5eaee8471294b971b15827201d60599304da) | `Add myself to maintainers`                                               |
| [`e3fdbde5`](https://github.com/NixOS/nixpkgs/commit/e3fdbde57ed3adb317ef8fd3625e91c1a0970ca5) | `avro-c: 1.11.0 -> 1.11.1`                                                |
| [`eb6a50aa`](https://github.com/NixOS/nixpkgs/commit/eb6a50aa1467d8660b048c97f6c89b2b0be065f9) | `Revert "Update preface.xml (#185868)"`                                   |
| [`4d81022d`](https://github.com/NixOS/nixpkgs/commit/4d81022d2ce6738fc7150d28f1e688b5f46a5ddc) | `gnome.gnome-system-monitor: Fix privileged operations`                   |
| [`aaffb6fc`](https://github.com/NixOS/nixpkgs/commit/aaffb6fcf92992def7043b137252331796d28615) | `ocamlPackages.tls-async: disable for OCaml < 4.11`                       |
| [`603568ed`](https://github.com/NixOS/nixpkgs/commit/603568edcab1e4b9b9d68b791406b58717697d55) | `rnote: 0.5.3 -> 0.5.4`                                                   |
| [`b7c97484`](https://github.com/NixOS/nixpkgs/commit/b7c97484d224af4970cd849b85ef8347195a2e0e) | `home-assistant: 2022.8.2 -> 2022.8.3`                                    |
| [`e4af4a87`](https://github.com/NixOS/nixpkgs/commit/e4af4a87464839ec70f856c78fc084c50881c948) | `python3Packages.pyotgw: 2.0.1 -> 2.0.2`                                  |
| [`3824d369`](https://github.com/NixOS/nixpkgs/commit/3824d36999836193247046fcf31cbc6476a41b7a) | `python3Packages.aiohomekit: 1.2.6 -> 1.2.8`                              |
| [`1c9931da`](https://github.com/NixOS/nixpkgs/commit/1c9931da1ed3235a481c3300d8a9f64294922850) | `git-branchless: 0.3.12 -> 0.4.0`                                         |
| [`80bfe830`](https://github.com/NixOS/nixpkgs/commit/80bfe83082d187b9a91872fff0111ff44cc604fb) | `vscode-extensions.piousdeer.adwaita-theme: 1.0.7 -> 1.0.8`               |
| [`9bbdfff8`](https://github.com/NixOS/nixpkgs/commit/9bbdfff80c3ffde6c2d183185bec1a8013ad161b) | `Update preface.xml (#185868)`                                            |
| [`161ea79c`](https://github.com/NixOS/nixpkgs/commit/161ea79c15e300e671edf4e5cfd294d221a2e766) | `python3.pkgs.tensorflow: 2.9.1 -> 2.10.0-rc0`                            |
| [`41c5b671`](https://github.com/NixOS/nixpkgs/commit/41c5b671d6fc7368da3625b24e8ee24b526c5b77) | `lunatic: 0.9.0 -> 0.10.0`                                                |
| [`5d42df57`](https://github.com/NixOS/nixpkgs/commit/5d42df5739b9172c627dcfaa14f7b16c121ed15b) | `awsebcli: fix build, update botocore to match upstream`                  |
| [`b4e86d9b`](https://github.com/NixOS/nixpkgs/commit/b4e86d9baa7fb8feff8eec6be00a4848317db2fd) | `elpa-packages: manual fixup`                                             |
| [`ee0b8a7e`](https://github.com/NixOS/nixpkgs/commit/ee0b8a7eaa96a0b4462870c2367aa96121d565bf) | `nixos/geoclue2: wait for network to be up when wifi provider is enabled` |
| [`e6e7b96f`](https://github.com/NixOS/nixpkgs/commit/e6e7b96fda8511a75befba8594c131a22e8620f8) | `hqplayerd: 4.32.2-92 -> 4.32.4-94`                                       |
| [`7e20517a`](https://github.com/NixOS/nixpkgs/commit/7e20517af0ec68beea2036ae3d78929c51e6012b) | `elisp packages updates 2022-08-10`                                       |
| [`08051c14`](https://github.com/NixOS/nixpkgs/commit/08051c14e490c1988af0ce812d0927ce1305c9b4) | `gomplate: 3.10.0 -> 3.11.2`                                              |
| [`f7d6f6f5`](https://github.com/NixOS/nixpkgs/commit/f7d6f6f54c815fd29b633b88d0ec955fd8939607) | `signal-desktop: 5.53.0 -> 5.54.0`                                        |
| [`9ba8b938`](https://github.com/NixOS/nixpkgs/commit/9ba8b938a46fa4abbc8952d7e32c5621c5a41677) | `pythonPackages.pythonefl: does not install egg`                          |
| [`fbecd4da`](https://github.com/NixOS/nixpkgs/commit/fbecd4daec0040b5a943fc53b0731f78e9d2dea7) | `libproxy: fix build on darwin`                                           |
| [`c7dcd543`](https://github.com/NixOS/nixpkgs/commit/c7dcd543bef243ee3952e6fcd12792fc9b227652) | `gcovr: 5.1 -> 5.2`                                                       |
| [`4fc8bd3d`](https://github.com/NixOS/nixpkgs/commit/4fc8bd3d877a5705226266e93b48e800e1ee6756) | `python310Packages.tubeup: 0.0.32 -> 0.0.33`                              |
| [`29e7fcfb`](https://github.com/NixOS/nixpkgs/commit/29e7fcfbbf7a9a9c40a9285243f15f0bf66151bc) | ``maintainers/teams: remove inactive maintainers from `golang```          |
| [`263b0365`](https://github.com/NixOS/nixpkgs/commit/263b0365db9d78025bbd387c485ab42bfeb2e800) | `micropad: remove special case for electron on darwin`                    |
| [`6877e896`](https://github.com/NixOS/nixpkgs/commit/6877e896fc728e0a09c26954a5ea56e4bfc2a0f6) | `schildichat-desktop: remove special case for electron on darwin`         |
| [`2c035ca8`](https://github.com/NixOS/nixpkgs/commit/2c035ca89fa444e8ef492976678de84ac189241d) | `element-desktop: remove special case for electron on darwin`             |
| [`45a58291`](https://github.com/NixOS/nixpkgs/commit/45a58291de50d9587fcfaa2e75a3f162282bad9f) | `deltachat-desktop: remove special case for electron on darwin`           |
| [`9f980dee`](https://github.com/NixOS/nixpkgs/commit/9f980dee7f3a386fd5df9348a9330b1e6999da9f) | `pkgsStatic.rapidjson: disable checks`                                    |
| [`4c476e1c`](https://github.com/NixOS/nixpkgs/commit/4c476e1c70636614637a4c8fc0a1a90c4dee46f4) | `electron: use wrapper instead of symlink for bin on darwin`              |
| [`3b71c50a`](https://github.com/NixOS/nixpkgs/commit/3b71c50a22807b29708c2163c6f7da16b2ae06b3) | `python310Packages.pglast: 3.13 -> 3.14`                                  |
| [`fb30d118`](https://github.com/NixOS/nixpkgs/commit/fb30d1182da2afd2c08e0a9e2b6c5b6badd986e5) | `python310Packages.deap: 1.3.1 -> 1.3.3`                                  |
| [`0795afcc`](https://github.com/NixOS/nixpkgs/commit/0795afcc1dd01c62e83e991caab4a7dde518fb27) | `anybadge: 1.9.0 -> 1.11.1`                                               |
| [`14c1f2e1`](https://github.com/NixOS/nixpkgs/commit/14c1f2e10448443e6a84d739c6e26e64c21be770) | `linux_lqx: 5.18.16-lqx1 -> 5.18.16-lqx2`                                 |
| [`22eae24d`](https://github.com/NixOS/nixpkgs/commit/22eae24df0986d32c1f9658bf8498241309697c4) | `chromiumDev: 105.0.5195.19 -> 106.0.5216.6`                              |
| [`0501066c`](https://github.com/NixOS/nixpkgs/commit/0501066c2328c68635bcfeed05741cdbee2b89d3) | `python310Packages.karton-core: 4.4.1 -> 5.0.0`                           |
| [`8f39ebba`](https://github.com/NixOS/nixpkgs/commit/8f39ebbaf98abfa39880714278d95cfe4f6dffc0) | `python310Packages.karton-classifier: 1.3.0 -> 1.4.0`                     |
| [`5c953fb7`](https://github.com/NixOS/nixpkgs/commit/5c953fb7af849bbb49e87233f9c899c733299aaa) | `python310Packages.karton-autoit-ripper: 1.1.0 -> 1.2.0`                  |
| [`3076092b`](https://github.com/NixOS/nixpkgs/commit/3076092b4c04ea7b8f2a6273c19c53ffb62770b5) | `python310Packages.karton-config-extractor: 2.0.2 -> 2.1.1`               |
| [`b2c965d8`](https://github.com/NixOS/nixpkgs/commit/b2c965d8a0a96b98c2f2a7f11156c32c55d5156e) | `python310Packages.karton-mwdb-reporter: 1.1.0 -> 1.2.0`                  |
| [`f720fd57`](https://github.com/NixOS/nixpkgs/commit/f720fd57d3f14fd0db085cd6453a769c32235b4f) | `python310Packages.karton-yaramatcher: 1.1.1 -> 1.2.0`                    |
| [`00c76bcb`](https://github.com/NixOS/nixpkgs/commit/00c76bcb34ef6481ba0cd937155a8805af9e8b80) | `python310Packages.karton-asciimagic: 1.1.0 -> 1.2.0`                     |
| [`519235db`](https://github.com/NixOS/nixpkgs/commit/519235db37ed6903c02edc48fbb864f966b667ab) | `python310Packages.karton-dashboard: 1.3.0 -> 1.4.0`                      |
| [`79c27cce`](https://github.com/NixOS/nixpkgs/commit/79c27cceda1b9b66ea5980b696cf093ad0905a7c) | `python3Packages.callee: init at 0.3.1`                                   |
| [`70ea3de6`](https://github.com/NixOS/nixpkgs/commit/70ea3de629d36afc35addd648a773a69355a0ba8) | `remind: 04.00.01 -> 04.00.02`                                            |
| [`bcad6625`](https://github.com/NixOS/nixpkgs/commit/bcad662517eca96758f92580cdcd0fb5e3fe5e45) | `python3Packages.glean-sdk: 50.1.2 -> 51.1.0`                             |
| [`640409c4`](https://github.com/NixOS/nixpkgs/commit/640409c4d65571af96d22519ef56ed84219080af) | `python310Packages.yara-python: 4.2.0 -> 4.2.3`                           |
| [`5816d322`](https://github.com/NixOS/nixpkgs/commit/5816d32249440044097631dce3891f65fdd6fb16) | `yara: 4.2.2 -> 4.2.3`                                                    |
| [`8bfd38f6`](https://github.com/NixOS/nixpkgs/commit/8bfd38f610493c8184cfdc34466f014dee01b9dd) | `microcode-intel: 20220510 -> 20220809`                                   |
| [`b8a64b36`](https://github.com/NixOS/nixpkgs/commit/b8a64b360437544cd426639b5d7f9c6182c47fd7) | `python310Packages.angr: 9.2.12 -> 9.2.13`                                |
| [`eff09241`](https://github.com/NixOS/nixpkgs/commit/eff09241807be41ca61582e967579849f0e7472f) | `python310Packages.cle: 9.2.12 -> 9.2.13`                                 |
| [`cacf1c0d`](https://github.com/NixOS/nixpkgs/commit/cacf1c0dc09fd06f564a89b0d225c7c2a6c43b1a) | `python310Packages.claripy: 9.2.12 -> 9.2.13`                             |
| [`703e415f`](https://github.com/NixOS/nixpkgs/commit/703e415fcd9f2d6494fef4be20da5337b45310f2) | `python310Packages.pyvex: 9.2.12 -> 9.2.13`                               |
| [`4dc1f74e`](https://github.com/NixOS/nixpkgs/commit/4dc1f74e105757773e2acc05c2ce6d08636af544) | `python310Packages.ailment: 9.2.12 -> 9.2.13`                             |
| [`c7bad4ee`](https://github.com/NixOS/nixpkgs/commit/c7bad4ee0983a745465758298fe5b1f866708856) | `python310Packages.archinfo: 9.2.12 -> 9.2.13`                            |
| [`a72636c7`](https://github.com/NixOS/nixpkgs/commit/a72636c7401dee0a92b7fc0c9bea4ab014759088) | `python310Packages.annoy: add pythonImportsCheck`                         |
| [`c5229435`](https://github.com/NixOS/nixpkgs/commit/c52294359c012f330ee7e9a2e2cacf8ef9c6ffc8) | `pkgsStatic.rapidjson: fix build`                                         |
| [`0b98d77f`](https://github.com/NixOS/nixpkgs/commit/0b98d77ff50b49d1fe073d17dcf18aa3895ee9fd) | `nixos/peertube: fix start service`                                       |
| [`43449503`](https://github.com/NixOS/nixpkgs/commit/4344950312ae0b0775efdd112412b787a1c73bb2) | `peertube: 4.2.1 -> 4.2.2`                                                |
| [`e75ba1ab`](https://github.com/NixOS/nixpkgs/commit/e75ba1ab1766bbcdd6976f0eaf00710c79d16994) | `cargo-make: 0.35.15 -> 0.35.16`                                          |
| [`9233f74a`](https://github.com/NixOS/nixpkgs/commit/9233f74a3c5a2b33bf6b1faed7b2f05e248d5417) | `python310Packages.annoy: 1.17.0 -> 1.17.1`                               |
| [`3c2b21cc`](https://github.com/NixOS/nixpkgs/commit/3c2b21ccf859b43800459a10ae36b251dfe56e14) | `pkgsStatic.re2: fix build`                                               |
| [`ab2e77ea`](https://github.com/NixOS/nixpkgs/commit/ab2e77ea829c20eeb4f451b751b5ddd85e1307c6) | `nixos/zfs: scrub synchronously`                                          |
| [`1f720644`](https://github.com/NixOS/nixpkgs/commit/1f720644d8511221eda33ba5f1b722ad4b331d25) | `difftastic: 0.31.0 -> 0.32.0`                                            |
| [`a3f954f9`](https://github.com/NixOS/nixpkgs/commit/a3f954f99146a2502083cb7b2a72461556af58c7) | `gamescope init at 3.11.33-jupiter-3.3-2`                                 |
| [`780343cc`](https://github.com/NixOS/nixpkgs/commit/780343cc776996e28b64650578150e32bc92008f) | `firefox-devedition-bin-unwrapped: 104.0b4 -> 104.0b7`                    |
| [`59b3d273`](https://github.com/NixOS/nixpkgs/commit/59b3d2738bb843ba319447b421d205a13ebdcf8a) | `firefox-beta-bin-unwrapped: 104.0b4 -> 104.0b7`                          |
| [`39b4f099`](https://github.com/NixOS/nixpkgs/commit/39b4f0994edfab71769f0eadefd840c3a838fe88) | `firefox-bin-unwrapped: 103.0.1 -> 103.0.2`                               |
| [`52aef90b`](https://github.com/NixOS/nixpkgs/commit/52aef90bc679c4b99691221d0780e5b8eb69e895) | `firefox-unwrapped: 103.0.1 -> 103.0.2`                                   |
| [`9a195f05`](https://github.com/NixOS/nixpkgs/commit/9a195f05ffdd637315d5618302357c2f6d8de68e) | `python310Packages.ge25519: 1.2.0 -> 1.3.0`                               |
| [`49e5fbba`](https://github.com/NixOS/nixpkgs/commit/49e5fbba0bc7faee9a15540a1be4b314f687ed8e) | `python310Packages.fe25519: 1.2.0 -> 1.3.0`                               |
| [`b8819a95`](https://github.com/NixOS/nixpkgs/commit/b8819a95b6cea9321056e6e5395e42920bbd7aa1) | `logseq: 0.7.9 -> 0.8.0`                                                  |
| [`76889bfa`](https://github.com/NixOS/nixpkgs/commit/76889bfa9fa296a47892eacfb4e82cfcff296938) | `deploy-rs: 2022-05-26 -> 2022-08-05`                                     |
| [`228a897a`](https://github.com/NixOS/nixpkgs/commit/228a897afd190012b9a32fba096c4a057fa2a7f9) | `Update nitter.nix`                                                       |
| [`31513846`](https://github.com/NixOS/nixpkgs/commit/31513846001c75d6c1a93acc1eb439c1fae6ee96) | `grab-site: 2.2.2 -> 2.2.7`                                               |
| [`33f22536`](https://github.com/NixOS/nixpkgs/commit/33f225361cf255feba808053e1c919039a12e8a3) | `tidy-viewer: 1.4.6 -> 1.4.30`                                            |
| [`6ce9c9ad`](https://github.com/NixOS/nixpkgs/commit/6ce9c9ad4de880823afca5f00a877ec1447d8bd3) | `python310Packages.fountains: 1.3.0 -> 2.0.0`                             |
| [`a335e915`](https://github.com/NixOS/nixpkgs/commit/a335e915e1609584d3114cebefd5007d4d83bd50) | `python310Packages.bitlist: 0.8.0 -> 1.0.1`                               |
| [`944a4663`](https://github.com/NixOS/nixpkgs/commit/944a46637360c0235fb9e338bdc8349fefac1ab0) | `fix whitespace`                                                          |
| [`cc477fb3`](https://github.com/NixOS/nixpkgs/commit/cc477fb34d8924c88d29e77b5101070c907a7aac) | `zfs: Make zpool available for zpool-expand-pools`                        |
| [`f71d32da`](https://github.com/NixOS/nixpkgs/commit/f71d32da64f46e5ed7d9d6c0d412943636e8d83a) | `shellnoob: init at unstable-2022-03-16`                                  |
| [`409e17a9`](https://github.com/NixOS/nixpkgs/commit/409e17a9b5ff2de3ac5158cd6bb49ab0539a3744) | `python310Packages.python-gvm: 22.6.1 -> 22.7.0`                          |
| [`4e4028d0`](https://github.com/NixOS/nixpkgs/commit/4e4028d0d8a21d1a4bc789d8cb9a231f6d29914c) | `padbuster: init at 0.3.3`                                                |
| [`c4dc43a8`](https://github.com/NixOS/nixpkgs/commit/c4dc43a8fabad0bdde012207e9055b2c36f1141b) | `apfsprogs: unstable-2022-02-23 -> unstable-2022-07-21`                   |
| [`8ed1d4bf`](https://github.com/NixOS/nixpkgs/commit/8ed1d4bf2ab38f3d79d6f08a4b138edf529231ae) | `arkade: 0.8.29 -> 0.8.30`                                                |
| [`88437fc6`](https://github.com/NixOS/nixpkgs/commit/88437fc62ebaa7d52141275c705b28cc72061eea) | `ArchiSteamFarm: 5.2.7.7 -> 5.2.8.3`                                      |
| [`18d2c12d`](https://github.com/NixOS/nixpkgs/commit/18d2c12d1d57a4b893fd46e936cca2aba1878888) | `cargo-deny: 0.12.1 -> 0.12.2`                                            |
| [`38e3c1e9`](https://github.com/NixOS/nixpkgs/commit/38e3c1e9669bf9daf2e4a63cfbd24ed10bf0cc90) | `cargo-modules: 0.5.10 -> 0.5.11`                                         |
| [`6132fda0`](https://github.com/NixOS/nixpkgs/commit/6132fda0205b5549ccc35d091ce9fa0955375da5) | `oha: 0.5.0 -> 0.5.3`                                                     |
| [`82c64d15`](https://github.com/NixOS/nixpkgs/commit/82c64d154b2743f34092bc1be519845c4496142d) | `nixos/nixos-containers: Fix ineffective warning`                         |
| [`018acd1e`](https://github.com/NixOS/nixpkgs/commit/018acd1e677e7c4cf5e629ad31d559506715218a) | `cmake-language-server: 0.1.5 → 0.1.6`                                    |
| [`1c1e0e03`](https://github.com/NixOS/nixpkgs/commit/1c1e0e03536de9df23bd4ffe7c343d88dcd43795) | `cmake-language-server: remove pyparsing dependency`                      |
| [`ff6a0037`](https://github.com/NixOS/nixpkgs/commit/ff6a0037d96b3f3cf864aeac8422bea6bb603f5a) | `offpunk: Add passthru.tests.version`                                     |
| [`7b5cf21d`](https://github.com/NixOS/nixpkgs/commit/7b5cf21d2e5f69eb39c444c7296151125673d1c4) | `offpunk: 1.4 -> 1.5`                                                     |
| [`bda6036d`](https://github.com/NixOS/nixpkgs/commit/bda6036d2e7d6f9bd475727f861b3bede3c342ae) | `nixos/xpadneo: don't disable ertm on kernel 5.12 or later`               |
| [`15978c5c`](https://github.com/NixOS/nixpkgs/commit/15978c5cd91a485e80aa9f21f2d90d5d63d2378c) | `krane: 2.4.7 → 2.4.9`                                                    |
| [`98ed62e4`](https://github.com/NixOS/nixpkgs/commit/98ed62e4eb1dc5e24d9fcfaddd2e5938d5ad6864) | `cryptomator: 1.6.10 -> 1.6.12`                                           |
| [`650a88e3`](https://github.com/NixOS/nixpkgs/commit/650a88e301b8a6cb777fabfa9953b7a273109725) | `xlockmore: 5.69 -> 5.70`                                                 |
| [`13b3f844`](https://github.com/NixOS/nixpkgs/commit/13b3f8442ed233c2bc91b72bcc3fd2133df85750) | `minio: 2022-07-26T00-53-03Z -> 2022-07-30T05-21-40Z`                     |
| [`071eff7a`](https://github.com/NixOS/nixpkgs/commit/071eff7a61f814a8ac6798dae962cacd5cc933ed) | `minio-client: 2022-07-24T02-25-13Z -> 2022-07-29T19-17-16Z`              |
| [`6057821d`](https://github.com/NixOS/nixpkgs/commit/6057821dd59b3f97f8e57698c2eed5ea45b0f9ff) | `randoop: 4.3.0 -> 4.3.1`                                                 |
| [`e937b6e3`](https://github.com/NixOS/nixpkgs/commit/e937b6e3ba1954d7fac3165f17e432d46985db7c) | `openjdk17: Remove default java.library.path`                             |
| [`3fa1b317`](https://github.com/NixOS/nixpkgs/commit/3fa1b317ac92d2d2cb9148ddf2d17e7850a2aea7) | `heatshrink: init at 0.4.1`                                               |
| [`1a322c85`](https://github.com/NixOS/nixpkgs/commit/1a322c85b75cf2af2f1f2684c93f44147a9bc1b4) | `termscp: 0.8.2 -> 0.9.0`                                                 |
| [`abf573a0`](https://github.com/NixOS/nixpkgs/commit/abf573a0c77e36362b55aa0e5c6589580a7d9ef4) | `metis-prover: 2.3.20160713 -> 2.4.20200713`                              |