### PR TITLE
chore(flake/nixos-hardware): `3975d515` -> `4387a4b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -158,11 +158,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1660030916,
-        "narHash": "sha256-KeVTmST6vAS85uUaSYlzv6OWhveawfIGhqX1SMq+L30=",
+        "lastModified": 1660291349,
+        "narHash": "sha256-zKw0xj3OYyE4EIhcXo+rGrPTbV/okwSsyyEZ/HMy2G0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3975d5158f00accda15a11180b2c08654cfb2807",
+        "rev": "4387a4b5b0a9f9d0b0a406bf39b246240df85fc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`45f23f33`](https://github.com/NixOS/nixos-hardware/commit/45f23f335e4310764af3b5fbf5126e874e622412) | `pine64-pinebook-pro: remove inappropriate overriding of min_freq` |
| [`18575b96`](https://github.com/NixOS/nixos-hardware/commit/18575b969ceb9f89c5f4327ac6a0f5b5cf9623de) | `pine64-pinebook-pro: remove superfluous bright/sleep keys`        |