### PR TITLE
chore(flake/nixos-hardware): `4387a4b5` -> `78f56d8e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -158,11 +158,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1660291349,
-        "narHash": "sha256-zKw0xj3OYyE4EIhcXo+rGrPTbV/okwSsyyEZ/HMy2G0=",
+        "lastModified": 1660291411,
+        "narHash": "sha256-9UfJMJeCl+T/DrOJMd1vLCoV8U3V7f9Qrv/QyH0Nn28=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "4387a4b5b0a9f9d0b0a406bf39b246240df85fc0",
+        "rev": "78f56d8ec2c67a1f80f2de649ca9aadc284f65b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                     |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`128bfab1`](https://github.com/NixOS/nixos-hardware/commit/128bfab1ffe63629e3c91bcd9363fd94e50c4ccd) | `pine64-pinebook-pro: remove unused firmware blob` |