### PR TITLE
chore(flake/home-manager): `324fedcf` -> `8675cfa5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660252108,
-        "narHash": "sha256-fpY8X+eJmClJyVnMQJ7bpsNgn/CxPE9+UkkJ0FRIKQ8=",
+        "lastModified": 1660330190,
+        "narHash": "sha256-RgQUtZGmdb9fRkdBcI8x1KYuykbQCBaeY6ejFls7hFM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "324fedcf9f1c475e2f522d03af029528e65969bc",
+        "rev": "8675cfa549e1240c9d2abb1c878bc427eefcf926",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`8675cfa5`](https://github.com/nix-community/home-manager/commit/8675cfa549e1240c9d2abb1c878bc427eefcf926) | ``gh: add `extensions` option`` |
| [`78f96434`](https://github.com/nix-community/home-manager/commit/78f964347c96b9e72d2176900863c91117f21b02) | ``tests.stubs: set `pname```    |