### PR TITLE
chore(flake/nixpkgs): `3a11db5f` -> `c4a0efdd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660162369,
-        "narHash": "sha256-pZukMP4zCA1FaBg0xHxf7KdE/Nv/C5YbDID7h2L8O7A=",
+        "lastModified": 1660305968,
+        "narHash": "sha256-r0X1pZCSEA6mzt5OuTA7nHuLmvnbkwgpFAh1iLIx4GU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3a11db5f408095b8f08b098ec2066947f4b72ce2",
+        "rev": "c4a0efdd5a728e20791b8d8d2f26f90ac228ee8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`ebf7f864`](https://github.com/NixOS/nixpkgs/commit/ebf7f864891802213f32cde2a613bd8a5c30a89c) | `nixos/tests/prometheus-exporters/systemd: Update for 0.5.0 release`     |
| [`bb4f3a50`](https://github.com/NixOS/nixpkgs/commit/bb4f3a501f9c1c7323087bc5545881c9247110f9) | `headscale: 0.16.0 -> 0.16.1`                                            |
| [`b0f8d893`](https://github.com/NixOS/nixpkgs/commit/b0f8d89333630f9652a1bb8669f2e4bb605cd01b) | `libwpe-fdo: 1.12.0 -> 1.12.1`                                           |
| [`d6c4de3e`](https://github.com/NixOS/nixpkgs/commit/d6c4de3e0ae90dac89ebedafbb5299d6d6a86ba8) | `flyctl: 0.0.366 -> 0.0.370`                                             |
| [`2c0fb1e8`](https://github.com/NixOS/nixpkgs/commit/2c0fb1e813ba07969bcd303832ed967fd8c6a399) | `python310Packages.yalexs-ble: 1.2.0 -> 1.3.1`                           |
| [`247f6538`](https://github.com/NixOS/nixpkgs/commit/247f653862195e8617ccc0e4cae227c507f84acd) | `python310Packages.pyswitchbot: 0.18.5 -> 0.18.6`                        |
| [`db572a52`](https://github.com/NixOS/nixpkgs/commit/db572a52519fb2e6a402ac6f14b2502a87449e10) | `python310Packages.bleak-retry-connector: 1.7.0 -> 1.7.1`                |
| [`9ba8f7d8`](https://github.com/NixOS/nixpkgs/commit/9ba8f7d8b3446e7534875ada648227c75f865503) | `services/klipper: add CPUScheduling and IOScheduling tuning`            |
| [`1410d893`](https://github.com/NixOS/nixpkgs/commit/1410d8939830767e9edba0f824e4f3b1cb8d6ee4) | `nixos/klipper: add OOMScoreAdjust -999`                                 |
| [`8b6a599b`](https://github.com/NixOS/nixpkgs/commit/8b6a599b7c4f9fc8984ea6cfe9704c23efc919fd) | `basex: 9.7.3 -> 10.0`                                                   |
| [`ecdab702`](https://github.com/NixOS/nixpkgs/commit/ecdab70205309463e58b5404c9d9662927a2d618) | `python310Packages.azure-mgmt-servicebus: update disabled`               |
| [`5cfd83f1`](https://github.com/NixOS/nixpkgs/commit/5cfd83f19680bab7735de8f075c412938cf0dc64) | `python310Packages.azure-mgmt-storage: update disabled`                  |
| [`3df339c5`](https://github.com/NixOS/nixpkgs/commit/3df339c50114bad9e8787e0c7fd4ddc559714040) | `python310Packages.google-cloud-pubsub: update disabled`                 |
| [`e3884e3c`](https://github.com/NixOS/nixpkgs/commit/e3884e3c677a4235285cede0cf04ab4ec75b53a5) | `python310Packages.defcon: update disabled`                              |
| [`3c049508`](https://github.com/NixOS/nixpkgs/commit/3c0495082a2daea518f728908e8d104b4adb59e8) | `slurm: 22.05.2 -> 22.05.3`                                              |
| [`65d41c0f`](https://github.com/NixOS/nixpkgs/commit/65d41c0f3ca618e64aa2f523d7f3178d6f467e73) | `python310Packages.google-cloud-vision: update disabled`                 |
| [`3a108e45`](https://github.com/NixOS/nixpkgs/commit/3a108e4580530432722740ef1c166690c7cba432) | `python310Packages.google-cloud-monitoring: update disabled`             |
| [`3345718a`](https://github.com/NixOS/nixpkgs/commit/3345718a60dc6c958db30048878316a0527cb8ea) | `python310Packages.google-cloud-tasks: disable on older Python releases` |
| [`b42f3cc0`](https://github.com/NixOS/nixpkgs/commit/b42f3cc0f3b64c53e865deb2a2ac24527c6860cd) | `python310Packages.yalexs-ble: 1.2.0 -> 1.2.0`                           |
| [`548b9f5a`](https://github.com/NixOS/nixpkgs/commit/548b9f5a0b33d4c84e66eebdb3bc27bdc546e742) | `python310Packages.pyswitchbot: 0.18.4 -> 0.18.5`                        |
| [`94cbcedf`](https://github.com/NixOS/nixpkgs/commit/94cbcedfcb6079abf40e169013c86a2a72b651aa) | `python310Packages.bleak-retry-connector: 1.5.0 -> 1.7.0`                |
| [`f85bbdf2`](https://github.com/NixOS/nixpkgs/commit/f85bbdf2d752b6691e99e47138a1eeb1e289a700) | `crosvm: don't repeat the path to Cargo.lock`                            |
| [`290039f8`](https://github.com/NixOS/nixpkgs/commit/290039f8cd769fe0daf073e8e87b9a6a75420a4a) | `crosvm: get rid of upstream-info.json`                                  |
| [`7f417260`](https://github.com/NixOS/nixpkgs/commit/7f4172608ec8e0d535dd18ef53c3ae94d8281340) | `crosvm: drop code for running integration tests`                        |
| [`a4e92143`](https://github.com/NixOS/nixpkgs/commit/a4e921432faa9b375b83e3b719945c451da12424) | `crosvm: use cpu arch name to find seccomp files`                        |
| [`de662ab3`](https://github.com/NixOS/nixpkgs/commit/de662ab315676d3b9c26081ae34f5075f13fcf1c) | `crosvm: reindent`                                                       |
| [`5ec4191d`](https://github.com/NixOS/nixpkgs/commit/5ec4191da71bae2679544fb7b32492ab5311a37c) | `flyway: 9.1.2 -> 9.1.3`                                                 |
| [`2db29e2d`](https://github.com/NixOS/nixpkgs/commit/2db29e2df54bf8cc28ce8b39bf31fb6c9d7c8bfd) | `cinny: 2.1.1 -> 2.1.2`                                                  |
| [`df92ee91`](https://github.com/NixOS/nixpkgs/commit/df92ee91528a1d27ec4c5ad95eb5f679423525c5) | `bitwarden: 2022.6.2 -> 2022.8.1`                                        |
| [`3b0595c3`](https://github.com/NixOS/nixpkgs/commit/3b0595c39bd002a673992f94ae48246bef60860c) | `argocd: 2.4.8 -> 2.4.9`                                                 |
| [`eb519a28`](https://github.com/NixOS/nixpkgs/commit/eb519a28637e82ebbf8c7e70008984d707d38da1) | `pgformatter: 5.2 -> 5.3`                                                |
| [`35b284ab`](https://github.com/NixOS/nixpkgs/commit/35b284aba5639357249fda0e2373e4dfbc205f6b) | `postgresqlPackages.pgvector: 0.2.6 -> 0.2.7`                            |
| [`12cecbc5`](https://github.com/NixOS/nixpkgs/commit/12cecbc5fdaa8cdd9057407e823efbbf97692cad) | `victoriametrics: 1.79.1 -> 1.80.0`                                      |
| [`d977d658`](https://github.com/NixOS/nixpkgs/commit/d977d658816cb84d3a38065846e3f2d7e96dccb2) | `discord: remove ldesgoui from maintainers`                              |
| [`72ea3d4f`](https://github.com/NixOS/nixpkgs/commit/72ea3d4fa49af08dfa629e5eaa182be8b44a75b9) | `pika-backup: 0.4.1 -> 0.4.2`                                            |
| [`90c26b87`](https://github.com/NixOS/nixpkgs/commit/90c26b87a96d3f0ea50bdd8ff01e93927a15c046) | `github-runner: 2.294.0 -> 2.295.0`                                      |
| [`ce63730d`](https://github.com/NixOS/nixpkgs/commit/ce63730df8af7b04d3b674eee44ed81bdac34a7e) | `Update nixos/modules/services/misc/tautulli.nix`                        |
| [`feba3403`](https://github.com/NixOS/nixpkgs/commit/feba3403147903d848f5e76f30315f4f04fb280d) | `nixos/tautulli: add option to open firewall`                            |
| [`822a9fd0`](https://github.com/NixOS/nixpkgs/commit/822a9fd0e8d742d326ca32a752c61bea426d5952) | `udns: fix darwin build`                                                 |
| [`28baad77`](https://github.com/NixOS/nixpkgs/commit/28baad77337490612d3b258fdda30632ae26fcff) | `rsyslog: 8.2206.0 -> 8.2208.0`                                          |
| [`f760c820`](https://github.com/NixOS/nixpkgs/commit/f760c8204948219f0c7d3dc7ca423821273a80e3) | `libnfs: 5.0.1 -> 5.0.2`                                                 |
| [`b6c148e9`](https://github.com/NixOS/nixpkgs/commit/b6c148e9b00605251726fa277883522f19acdb0f) | `python310Packages.trimesh: 3.13.0 -> 3.13.4`                            |
| [`139bc51a`](https://github.com/NixOS/nixpkgs/commit/139bc51a5c1b36244f8d5841e062db0c7a2decfe) | `python39Packages.types-redis: 4.3.13 -> 4.3.14`                         |
| [`7ba22311`](https://github.com/NixOS/nixpkgs/commit/7ba223112389b2dc64a7975b3efbb35a76c07303) | `python310Packages.sunpy: 4.0.3 -> 4.0.4`                                |
| [`77acc4f6`](https://github.com/NixOS/nixpkgs/commit/77acc4f67da44378f42346db5dfd9288d6a74180) | `python310Packages.pydal: 20220725.1 -> 20220807.1`                      |
| [`34398988`](https://github.com/NixOS/nixpkgs/commit/3439898888da83027db56dbe3414f3c850f5d981) | `telepresence: fix homepage link`                                        |
| [`0ec10650`](https://github.com/NixOS/nixpkgs/commit/0ec1065039199ae2fb30d590a5eff92f419aa7ad) | `python310Packages.dparse: 0.5.1 -> 0.5.2`                               |
| [`f78bb87b`](https://github.com/NixOS/nixpkgs/commit/f78bb87b1f6f13dbea79da95d71d6458325096e6) | `python310Packages.hahomematic: 2022.8.4 -> 2022.8.5`                    |
| [`eba8f86a`](https://github.com/NixOS/nixpkgs/commit/eba8f86a8c6c0d01f2b5bae120715c9a41b2cd75) | `python310Packages.google-cloud-pubsub: 2.13.4 -> 2.13.5`                |
| [`e33d514d`](https://github.com/NixOS/nixpkgs/commit/e33d514d087e229bd827c5e7e8d01961fc0ef5cc) | `python310Packages.django-storages: 1.13 -> 1.13.1`                      |
| [`7761ae9e`](https://github.com/NixOS/nixpkgs/commit/7761ae9ec0568f3c87837b0b80737cbdfcc20871) | `python310Packages.defcon: 0.10.1 -> 0.10.2`                             |
| [`8ed129be`](https://github.com/NixOS/nixpkgs/commit/8ed129bef9d824b0f184aa6ac82c1c025056a8b0) | `python310Packages.etils: 0.6.0 -> 0.7.1`                                |
| [`100815e4`](https://github.com/NixOS/nixpkgs/commit/100815e4a6cc3fb6ddad5250aee4d6700cf2b668) | `python310Packages.google-cloud-bigtable: 2.11.0 -> 2.11.1`              |
| [`b501c45b`](https://github.com/NixOS/nixpkgs/commit/b501c45b210688b81af3c026b5fdedcf5c6bd774) | `python310Packages.findpython: 0.2.0 -> 0.2.1`                           |
| [`22151e35`](https://github.com/NixOS/nixpkgs/commit/22151e355236218072fcac346cdb9dcbdb2547ad) | `python310Packages.google-cloud-vision: 3.0.0 -> 3.1.0`                  |
| [`d65060b9`](https://github.com/NixOS/nixpkgs/commit/d65060b9ad477c586447c5c21381c439f8c09055) | `python310Packages.google-cloud-monitoring: 2.10.1 -> 2.11.0`            |
| [`b6edb4f4`](https://github.com/NixOS/nixpkgs/commit/b6edb4f49cc5e2e43d5676c4ed3efda9fd585f6b) | `python310Packages.google-cloud-tasks: 2.10.0 -> 2.10.1`                 |
| [`f81b9746`](https://github.com/NixOS/nixpkgs/commit/f81b9746801edfb04a4469cc3e350937244e2af7) | `aefs: mark as broken on Darwin`                                         |
| [`03aa461a`](https://github.com/NixOS/nixpkgs/commit/03aa461ae1df5f44e72fb8a8c470dd1551673bfe) | `aefs: "update" to unstable-2015-05-06`                                  |
| [`a249c653`](https://github.com/NixOS/nixpkgs/commit/a249c653774ea881882335ff3067d8ec03c40706) | `fixedsys-excelsior: remove reference to tarballs.nixos.org`             |
| [`30fc9269`](https://github.com/NixOS/nixpkgs/commit/30fc9269c185e9a5e4b449a587438b382edd49f7) | `ec2-api-tools: remove reference to tarballs.nixos.org`                  |
| [`e08a50cc`](https://github.com/NixOS/nixpkgs/commit/e08a50ccdac6dd1c77541f65b0d878722c451386) | `python310Packages.types-setuptools: 63.4.0 -> 63.4.1`                   |
| [`91243c87`](https://github.com/NixOS/nixpkgs/commit/91243c871e9ffc9071b878b69990a2fc7302f045) | `python310Packages.google-cloud-secret-manager: 2.12.1 -> 2.12.2`        |
| [`22661f08`](https://github.com/NixOS/nixpkgs/commit/22661f082f8566ecf38e63e7bb593e17bcdf08da) | `python310Packages.google-cloud-asset: 3.10.0 -> 3.11.0`                 |
| [`a9b941e5`](https://github.com/NixOS/nixpkgs/commit/a9b941e5a010b331ffdaca7dca268054a5d96981) | `python310Packages.google-cloud-container: 2.11.0 -> 2.11.1`             |
| [`db7de997`](https://github.com/NixOS/nixpkgs/commit/db7de997dbda2fa3321c7df032e26bdc7c137e2a) | `python310Packages.azure-mgmt-storage: 20.0.0 -> 20.1.0`                 |
| [`4c8b65bf`](https://github.com/NixOS/nixpkgs/commit/4c8b65bf9a0f41c3f819c3520a80c18d4b443de4) | `python310Packages.asyncssh: 2.11.0 -> 2.12.0`                           |
| [`a58142e1`](https://github.com/NixOS/nixpkgs/commit/a58142e12cc7167e7f23f4f8bc12d8c74facfc2a) | `python310Packages.azure-mgmt-servicebus: 8.0.0 -> 8.1.0`                |
| [`bd1978e9`](https://github.com/NixOS/nixpkgs/commit/bd1978e911776c85370d853f324289b5c243670a) | `nixos/firefox-syncserver: init`                                         |
| [`915abcf8`](https://github.com/NixOS/nixpkgs/commit/915abcf8a79552adeca969f3c1a3e191b101be98) | `php80Extensions.ast: 1.0.16 -> 1.1.0`                                   |
| [`c32b08f4`](https://github.com/NixOS/nixpkgs/commit/c32b08f41f58ddfbb6aa435e23d77d5dcc93859d) | `postgresql11Packages.pg_partman: 4.6.2 -> 4.7.0`                        |
| [`8606eca1`](https://github.com/NixOS/nixpkgs/commit/8606eca1d3bc70dbd6ce2fc6c91ca78f33617351) | `imlib: remove reference to tarballs.nixos.org`                          |
| [`2b0e7e57`](https://github.com/NixOS/nixpkgs/commit/2b0e7e5724a023cd5ae083766524e9e0d0c6e146) | `catppuccin-gtk: unstable-2022-02-24 -> unstable-2022-08-01`             |
| [`300c5c98`](https://github.com/NixOS/nixpkgs/commit/300c5c98c6e1558ec977c0f6f0b8a8af71fbd0e8) | `nixos/yggdrasil: rename "config" option to "settings"`                  |
| [`bcf715a1`](https://github.com/NixOS/nixpkgs/commit/bcf715a147d9f4ee7f478610a64b27f545d48ba5) | `acme-client: 1.3.0 -> 1.3.1`                                            |
| [`fc9ec357`](https://github.com/NixOS/nixpkgs/commit/fc9ec357383b4fe715cb75c7873089185111589e) | `sile: 0.14.1 → 0.14.2`                                                  |
| [`a6641909`](https://github.com/NixOS/nixpkgs/commit/a6641909e4538c492d14d54789ed40ead58fae4c) | `python310Packages.aioblescan: init at 0.2.13`                           |
| [`19fb5cd0`](https://github.com/NixOS/nixpkgs/commit/19fb5cd0274efdb880d25f5e52bb602475938807) | `webanalyze: 0.3.6 -> 0.3.7`                                             |
| [`144d7eb0`](https://github.com/NixOS/nixpkgs/commit/144d7eb0ef698ae2a8c73bea544bac2dc5e6454f) | `python310Packages.debuglater: init at 1.4.1`                            |
| [`a0165ee1`](https://github.com/NixOS/nixpkgs/commit/a0165ee168c2f945b367261164e657b43956c7f2) | `hare: do not set HARECACHE on the setup hook`                           |
| [`33a863fa`](https://github.com/NixOS/nixpkgs/commit/33a863fa5f948fcaf37ac300f8cdeb472fe25498) | `gopls: 0.9.1 -> 0.9.3`                                                  |
| [`cb49bfbf`](https://github.com/NixOS/nixpkgs/commit/cb49bfbfef37e36812bd52318ebf8c9fa6999967) | `traefik: 2.8.1 -> 2.8.2`                                                |
| [`f19fb951`](https://github.com/NixOS/nixpkgs/commit/f19fb9514afc80bb5b523e42f3276434a77e67fa) | `python310Packages.pyquil: 3.2.1 -> 3.3.0`                               |
| [`68118416`](https://github.com/NixOS/nixpkgs/commit/6811841612eaac74f5d6d846ea4d1cc66ec490f9) | `systeroid: 0.1.1 -> 0.2.0`                                              |
| [`fb270678`](https://github.com/NixOS/nixpkgs/commit/fb270678672686f69728f20948a84984eb75ecd0) | `python310Packages.pyskyqremote: 0.3.14 -> 0.3.15`                       |
| [`44ef7875`](https://github.com/NixOS/nixpkgs/commit/44ef78759ebedf06ddb9d1266acc6a04656e83dd) | `solo5: 0.6.9 -> 0.7.3`                                                  |
| [`b21fb9e1`](https://github.com/NixOS/nixpkgs/commit/b21fb9e1066a5ef69a86b8c9c3e812978549853c) | `python310Packages.weconnect-mqtt: 0.39.0 -> 0.39.0`                     |
| [`f2bd2f2f`](https://github.com/NixOS/nixpkgs/commit/f2bd2f2ff160869e70f4c2e0aeab9ef6f2293459) | `python310Packages.weconnect: 0.46.0 -> 0.47.0`                          |
| [`e80ea65c`](https://github.com/NixOS/nixpkgs/commit/e80ea65c25e83f13e9cf81dc721647f8ea749aa3) | `python310Packages.elastic-apm: 6.10.2 -> 6.11.0`                        |
| [`26a57279`](https://github.com/NixOS/nixpkgs/commit/26a5727935cc63b746dbb96921ee39e8ea8a08cb) | `kora-icon-theme: 1.5.2 -> 1.5.3 (#185814)`                              |
| [`7b7966a3`](https://github.com/NixOS/nixpkgs/commit/7b7966a3b2bdbb3ffb132e578eb7a0a9fd0d9211) | `asciidoctor-with-extensions: add Java dependency`                       |
| [`43ab32c8`](https://github.com/NixOS/nixpkgs/commit/43ab32c80ef9828617ac71ad71786b9db304177a) | `python310Packages.fastcore: 1.5.15 -> 1.5.17`                           |
| [`f8d20713`](https://github.com/NixOS/nixpkgs/commit/f8d207135a6a1a954f277caf5bbbf4366fe64029) | `python310Packages.justnimbus: init at 0.6.0`                            |
| [`44419307`](https://github.com/NixOS/nixpkgs/commit/44419307f0555e6b8cc635e505afcace5a06d386) | `jenkins: add meta.changelog`                                            |
| [`22384877`](https://github.com/NixOS/nixpkgs/commit/22384877eaaa66f01a2a81de685af25d88af0b59) | `jenkins: add myself to maintainers`                                     |
| [`391bf479`](https://github.com/NixOS/nixpkgs/commit/391bf479f206c1544be701f8674577ef0fe05c28) | `react-native-debugger: 0.12.1 -> 0.13.0`                                |
| [`58bb8ab0`](https://github.com/NixOS/nixpkgs/commit/58bb8ab012e4ca5edf90b8e00a262eb0bd7ffb94) | `gitlab: 15.1.4 -> 15.2.2`                                               |
| [`8fb9c2cd`](https://github.com/NixOS/nixpkgs/commit/8fb9c2cdd7c3b3145cd8fe1f299b9c6c74bf0416) | `bundlerEnv: allow copying additional paths alongside config files`      |
| [`f2c28f66`](https://github.com/NixOS/nixpkgs/commit/f2c28f668c4b622fba7a5b8362dbe9df7d7eb264) | `intel-media-sdk: 22.3.0 -> 22.5.1`                                      |
| [`a37dd32a`](https://github.com/NixOS/nixpkgs/commit/a37dd32ab6a512a8f3c06b8ea1868a7122ef3105) | `cargo-pgx: init at 0.4.5`                                               |
| [`f35f4a28`](https://github.com/NixOS/nixpkgs/commit/f35f4a28a64fdf04354467572cd8089d4484da52) | `Remove myself as a maintainer`                                          |
| [`8c4a87a9`](https://github.com/NixOS/nixpkgs/commit/8c4a87a9f2792f1edc63f88671895e142b2d7f03) | `Clear maintainer of pc-ble-driver`                                      |
| [`c0607b39`](https://github.com/NixOS/nixpkgs/commit/c0607b398b2ccb89baf59a53c4d7d4b617461cbf) | `python310Packages.streamz: 0.6.3 -> 0.6.4`                              |
| [`862dee7c`](https://github.com/NixOS/nixpkgs/commit/862dee7c9c369760fa1113f4793def8eba5306f9) | `python310Packages.levenshtein: 0.19.3 -> 0.20.2`                        |
| [`361b4004`](https://github.com/NixOS/nixpkgs/commit/361b400464f66ef6e3ffeba6fcff9f8f9cf04196) | `python310Packages.rapidfuzz: 2.4.2 -> 2.4.3`                            |
| [`dc8cd700`](https://github.com/NixOS/nixpkgs/commit/dc8cd700673615e56d4ebb091f2fe3ee2dc927be) | `xml2rfc: 3.13.1 -> 3.14.0`                                              |
| [`76793268`](https://github.com/NixOS/nixpkgs/commit/76793268a0001c26e8e50462d4872839a6fdb8b5) | `python310Packages.datashader: 0.14.1 -> 0.14.2`                         |
| [`8e4b0734`](https://github.com/NixOS/nixpkgs/commit/8e4b07340d7b23c96923283168daa3d5e9bb3bb7) | `mlflow-server: 1.27.0 -> 1.28.0`                                        |
| [`cfb653e4`](https://github.com/NixOS/nixpkgs/commit/cfb653e47f57a0b64674258ceca93c19dd6153c1) | `python310Packages.pytorch-metric-learning: 1.5.0 -> 1.5.1`              |
| [`e16d071f`](https://github.com/NixOS/nixpkgs/commit/e16d071f023c0b3ddd9a50cada69d1f9a916fdad) | `python310Packages.xsdata: 22.5 -> 22.7`                                 |
| [`090e8341`](https://github.com/NixOS/nixpkgs/commit/090e83412b40f2f619ea5217ba77f3bcd82e3d08) | `ooniprobe-cli: 3.15.1 -> 3.15.3`                                        |
| [`4c531627`](https://github.com/NixOS/nixpkgs/commit/4c531627b81eae1a6fb30d1800324c75d325a53a) | `nodePackages.pnpm: 7.8.0 -> 7.9.1`                                      |
| [`15858dfd`](https://github.com/NixOS/nixpkgs/commit/15858dfdba3cb45bef35b578da79f2b234b6bb01) | `otpauth: 0.4.2 -> 0.4.3`                                                |
| [`712af312`](https://github.com/NixOS/nixpkgs/commit/712af312579dd80a88329ebeafd89bfa7f2a63f5) | `cinny-desktop: init at 2.1.1`                                           |
| [`5edc4b5e`](https://github.com/NixOS/nixpkgs/commit/5edc4b5e3adb34a5c089031de5ce73c60c6dffc6) | `maintainers: add aveltras`                                              |
| [`83d9fd99`](https://github.com/NixOS/nixpkgs/commit/83d9fd99c284eb765e96ee10ba47a9df39be4ff6) | `spire: 1.3.3 -> 1.4.0`                                                  |
| [`17f96089`](https://github.com/NixOS/nixpkgs/commit/17f96089877ba2b6d3107ecc819f39ab42543cfb) | `netdata: 1.35.1 -> 1.36.0`                                              |
| [`6c6a6c16`](https://github.com/NixOS/nixpkgs/commit/6c6a6c163f8615aa7a05102e5545630d9be8ffb0) | `libadwaita: 1.1.3 -> 1.1.4`                                             |
| [`d3462c92`](https://github.com/NixOS/nixpkgs/commit/d3462c92f9e8bd09c03ed9620bcfb2ccef62ee3b) | `python310Packages.automat: don't depend on m2r`                         |
| [`f8ec6c6c`](https://github.com/NixOS/nixpkgs/commit/f8ec6c6c85f79342edab12fd59fc101426c6e3ad) | `nixos-generators: 1.6.0 -> 1.7.0`                                       |
| [`6bfdf1f0`](https://github.com/NixOS/nixpkgs/commit/6bfdf1f074dcf0fd053a688c133c6c7b3de39a71) | `grafana: 9.0.6 -> 9.0.7`                                                |
| [`5aa47e11`](https://github.com/NixOS/nixpkgs/commit/5aa47e11622bcebdf380395fb6c2c2333e1b304e) | `python310Packages.pykostalpiko: init at 1.1.1-1`                        |