### PR TITLE
chore(flake/nixpkgs): `c4a0efdd` -> `e105167e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -173,11 +173,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660305968,
-        "narHash": "sha256-r0X1pZCSEA6mzt5OuTA7nHuLmvnbkwgpFAh1iLIx4GU=",
+        "lastModified": 1660396586,
+        "narHash": "sha256-ePuWn7z/J5p2lO7YokOG1o01M0pDDVL3VrStaPpS5Ig=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c4a0efdd5a728e20791b8d8d2f26f90ac228ee8d",
+        "rev": "e105167e98817ba9fe079c6c3c544c6ef188e276",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`9d97ed0d`](https://github.com/NixOS/nixpkgs/commit/9d97ed0d5747ec0957a55920f1716823724b7ff1) | `solo5: fix paths detection in compiler and linker wrappers.`                 |
| [`1dd26648`](https://github.com/NixOS/nixpkgs/commit/1dd266483b82fc7ae26e3cd26a2b381103941da5) | `sqlitecpp: move gtest from checkInputs to buildInputs, fix cross`            |
| [`c6db4ad1`](https://github.com/NixOS/nixpkgs/commit/c6db4ad1626e14bc554f155a3bba984b9e427013) | `wayout: init at 1.1.2`                                                       |
| [`ce29c9f8`](https://github.com/NixOS/nixpkgs/commit/ce29c9f8eb25523126d970273c7e878daf425126) | `offpunk: don't use alias for testVersion`                                    |
| [`39f67006`](https://github.com/NixOS/nixpkgs/commit/39f67006192a4c6b66424dd5c282e1d9b0633d6d) | `minetest: 5.5.1 -> 5.6.0`                                                    |
| [`0edab34d`](https://github.com/NixOS/nixpkgs/commit/0edab34d9c41aac44c2794cebe2ad3ad64a0721c) | `krunvm: init at 0.2.1`                                                       |
| [`412a17da`](https://github.com/NixOS/nixpkgs/commit/412a17da665c76f2d0818ed10976ca459bd2fcf1) | `libkrun: init at 1.3.0`                                                      |
| [`f2eeeae3`](https://github.com/NixOS/nixpkgs/commit/f2eeeae35ed3854ac5005c41a3b66a769a3cf394) | `libkrunfw: init at 3.3.0`                                                    |
| [`939999e9`](https://github.com/NixOS/nixpkgs/commit/939999e9871a1b4588dfaf4c6918fb7ecd184de5) | `perlPackages.ObjectPad: init at 0.68`                                        |
| [`7a162bf3`](https://github.com/NixOS/nixpkgs/commit/7a162bf379c632b4992754f1db29f696acbe5a84) | `htpdate: 1.3.5 -> 1.3.6`                                                     |
| [`b7f66b4a`](https://github.com/NixOS/nixpkgs/commit/b7f66b4a4315ba970134ca373b0690143a7e43e8) | `flyctl: 0.0.370 -> 0.0.372`                                                  |
| [`f0924b94`](https://github.com/NixOS/nixpkgs/commit/f0924b9416f1b8fe9d8fa9217e89aa0de40973d2) | `ugrep: 3.8.3 -> 3.9.0`                                                       |
| [`f3135084`](https://github.com/NixOS/nixpkgs/commit/f3135084fa2efdb1c0a1716b0ad6afcf07af26c7) | `esbuild: 0.15.0 -> 0.15.2`                                                   |
| [`93964ae5`](https://github.com/NixOS/nixpkgs/commit/93964ae51fdf8acbdb0ca455e923023e29f8e8b2) | `colordiff: use w3m-batch instead of w3m`                                     |
| [`2b977593`](https://github.com/NixOS/nixpkgs/commit/2b97759350d6a1b3d6f71a1135503035a760124d) | `cloud-nuke: 0.16.2 -> 0.16.4`                                                |
| [`f401b58f`](https://github.com/NixOS/nixpkgs/commit/f401b58ff67c5a31a8778f6fa93bbf7acda1f360) | `tmuxp: update meta`                                                          |
| [`0aa1c743`](https://github.com/NixOS/nixpkgs/commit/0aa1c74387b4111aff74f00861ec0506f81557b6) | `tmuxp: install completions`                                                  |
| [`e6430611`](https://github.com/NixOS/nixpkgs/commit/e64306119cede2bdde3560a09f6c5a9cff71ee48) | `tmuxp: 1.11.0 -> 1.12.1`                                                     |
| [`c088cf36`](https://github.com/NixOS/nixpkgs/commit/c088cf36823eb28d25a8b43623e1219dd1e18b7b) | `python310Packages.libtmux: update meta`                                      |
| [`eb33604c`](https://github.com/NixOS/nixpkgs/commit/eb33604cffdfa992c8a54d2c639621b9553f4a95) | `python310Packages.libtmux: fix build on darwin`                              |
| [`878db861`](https://github.com/NixOS/nixpkgs/commit/878db861024f89f5a8c952e0d6bae4c68e7661d3) | `python310Packages.libtmux: 0.11.0 -> 0.13.0`                                 |
| [`0cf24070`](https://github.com/NixOS/nixpkgs/commit/0cf240704c57e5fadda627ad73adc2f315104b1d) | `cargo-public-api: 0.12.4 -> 0.13.0`                                          |
| [`3f5777d8`](https://github.com/NixOS/nixpkgs/commit/3f5777d82157f8d910eaa99bcc6be2f49b7ad42b) | `tdesktop: 4.0.2 -> 4.1.0`                                                    |
| [`72c7711a`](https://github.com/NixOS/nixpkgs/commit/72c7711a6496bf170073822dff326be8837b8567) | `python310Packages.doit-py: init at 0.5.0`                                    |
| [`43f11056`](https://github.com/NixOS/nixpkgs/commit/43f11056794d6bf5aeebc560fc61099aef17868c) | `python310Packages.configclass: init at 0.2.0`                                |
| [`f792a3b3`](https://github.com/NixOS/nixpkgs/commit/f792a3b3654ac737e8bca29652eda478708f9f4b) | `python310Packages.mergedict: init at 1.0.0`                                  |
| [`bfa48293`](https://github.com/NixOS/nixpkgs/commit/bfa48293343638cececf6373de514fc1d6b7b187) | `python310Packages.doit: 0.35.0 -> 0.36.0`                                    |
| [`5f816932`](https://github.com/NixOS/nixpkgs/commit/5f8169320c74990dfb92f8cee36f2d90b2db3155) | `allure: 2.18.1 -> 2.19.0`                                                    |
| [`eca83bbb`](https://github.com/NixOS/nixpkgs/commit/eca83bbb577349c96edf734b2bbaeaf87f0e40d9) | `ledger-live-desktop: 2.45.0 -> 2.45.1`                                       |
| [`93d50fe9`](https://github.com/NixOS/nixpkgs/commit/93d50fe946deddf1456f1aa989211a43395d23cd) | `gnome.gnome-chess: 42.0 → 42.1`                                              |
| [`0848d3c8`](https://github.com/NixOS/nixpkgs/commit/0848d3c8ab771501b1846e4336de2b39c5cdc172) | `localtime: separate buildPhase from installPhase`                            |
| [`2b335364`](https://github.com/NixOS/nixpkgs/commit/2b33536432ac958680e722302f8940993db1d0a2) | `xdg-desktop-portal: 1.14.6 -> 1.15.0`                                        |
| [`aa6a8bd8`](https://github.com/NixOS/nixpkgs/commit/aa6a8bd8dd878f2571559981bbe80ecf60e54497) | `nixos/neo4j: HTTP connector toggling`                                        |
| [`8d6f4552`](https://github.com/NixOS/nixpkgs/commit/8d6f4552cd5c6089475f8696c821f39fe3b2cda1) | `nixos/neo4j: fix typo`                                                       |
| [`051a99cc`](https://github.com/NixOS/nixpkgs/commit/051a99ccd9b05c75b6bf7f932f3312698cbf3dc2) | `neo4j: 4.3.3 -> 4.4.8`                                                       |
| [`a20d9889`](https://github.com/NixOS/nixpkgs/commit/a20d9889321c799fa1c8810a01f975dd99fe87b1) | `nixos/neo4j: use full systemd unit name`                                     |
| [`a22112e8`](https://github.com/NixOS/nixpkgs/commit/a22112e88a81f192cde555562d326f938cb4b57b) | `neo4j: remove deprecated config`                                             |
| [`9b609319`](https://github.com/NixOS/nixpkgs/commit/9b6093198622fb6a3d7d0bda174573df4b515217) | `neo4j: add erictapen as maintainer`                                          |
| [`5d150037`](https://github.com/NixOS/nixpkgs/commit/5d1500374d87b2c0677a09d804559a9f1fe0b3a6) | `neo4j: change homepage`                                                      |
| [`5f2ae2e4`](https://github.com/NixOS/nixpkgs/commit/5f2ae2e43f7db43afb6285572d3155e1f26580fb) | `neo4j: add release notes about version bump`                                 |
| [`b653d62a`](https://github.com/NixOS/nixpkgs/commit/b653d62a00aee51aa3d8297db8f675d9f157702f) | `nixos/neo4j: increase memorySize in NixOS test`                              |
| [`60b6ad6f`](https://github.com/NixOS/nixpkgs/commit/60b6ad6f3789dea667332a31050fbd93a453a157) | `nixos/neo4j: set some settings so warnings at startup disappear`             |
| [`c94200e8`](https://github.com/NixOS/nixpkgs/commit/c94200e87f087be31c8e923d30a15cf9c754ef31) | `neo4j: 4.1.1 -> 4.3.3`                                                       |
| [`6dcbcb3a`](https://github.com/NixOS/nixpkgs/commit/6dcbcb3a53eb02b8191e8617fc56783a44f123fc) | `increase diskSize for neo4j test to avoid No space left on device exception` |
| [`d5bd8527`](https://github.com/NixOS/nixpkgs/commit/d5bd85278d81f6d6bd177a2c84ab7df1cea3eafb) | `neo4j: add nixosTest to passthru`                                            |
| [`0fbce251`](https://github.com/NixOS/nixpkgs/commit/0fbce25144c1ddcd766203f6946dac11056edb7e) | `neo4j: 3.5.14 -> 4.1.1`                                                      |
| [`663e41e6`](https://github.com/NixOS/nixpkgs/commit/663e41e6df4df274014c3447c1996c83af33deef) | `python310Packages.pyte: 0.8.0 -> 0.8.1`                                      |
| [`a79c16c3`](https://github.com/NixOS/nixpkgs/commit/a79c16c397f19b243d2028f877da993e788f1baf) | `python310Packages.Kajiki: 0.9.0 -> 0.9.1`                                    |
| [`ece53aed`](https://github.com/NixOS/nixpkgs/commit/ece53aed8b28a584c048a31f4c8626b6f4de35fd) | `ffmpeg_5,ffmpeg_5-full: cherry-pick IPFS default gateway removal`            |
| [`6445755b`](https://github.com/NixOS/nixpkgs/commit/6445755b9782b954a0c33e261af3b5d3cf6e43ce) | `cpuid: 20220620 -> 20220812`                                                 |
| [`170bb5f0`](https://github.com/NixOS/nixpkgs/commit/170bb5f0d5278c240a47301374bbe1fad94df9ca) | `_1password-gui-beta: 8.8.0-215.BETA -> 8.9.0-1.BETA`                         |
| [`dea432ca`](https://github.com/NixOS/nixpkgs/commit/dea432cab0bafe234ae83382f79703d3f4714225) | `_1password-gui: 8.7.3 -> 8.8.0`                                              |
| [`421d8d63`](https://github.com/NixOS/nixpkgs/commit/421d8d63744e7d7bac4fd4aef9c114ccfc376226) | `hwinfo: 22.0 -> 22.1`                                                        |
| [`824ac982`](https://github.com/NixOS/nixpkgs/commit/824ac982991e580a12ce3e806868aad89e3785ee) | `networkmanager: 1.38.2 -> 1.38.4`                                            |
| [`83c531f7`](https://github.com/NixOS/nixpkgs/commit/83c531f736322e0e91e926ae5d3bc31d7c7c2c20) | `infracost: 0.10.9 -> 0.10.10`                                                |
| [`39ffe4d6`](https://github.com/NixOS/nixpkgs/commit/39ffe4d6af4e227c6666cf99ce8815b203d285a7) | `home-assistant: 2022.8.3 -> 2022.8.4`                                        |
| [`e04ce09c`](https://github.com/NixOS/nixpkgs/commit/e04ce09c6119c75e919d58656ee67f2890763fc4) | `python3Packages.zigpy: 0.49.0 -> 0.49.1`                                     |
| [`4a844a7f`](https://github.com/NixOS/nixpkgs/commit/4a844a7fd300392f6a01871eaa6b8fafac00a54e) | `cirrusgo: init at 0.1.0`                                                     |
| [`1bfd675b`](https://github.com/NixOS/nixpkgs/commit/1bfd675b554e73142b8e1b9f0e59130b73b5658c) | `python3Packages.govee-ble: 0.14.0 -> 0.14.1`                                 |
| [`0abcce04`](https://github.com/NixOS/nixpkgs/commit/0abcce043238c13c509d4b99d7b22cf3968c69d0) | `python310Packages.bellows: 0.31.3 -> 0.32.0`                                 |
| [`3f3a62a7`](https://github.com/NixOS/nixpkgs/commit/3f3a62a7f9268a5232ddd882a2f4a3ba08c3c9a8) | `kvmtool: unstable-2022-04-04 -> unstable-2022-06-09`                         |
| [`47c9da05`](https://github.com/NixOS/nixpkgs/commit/47c9da058daa35f4109f3ea389327a856b56b4f0) | `python310Packages.pyswitchbot: 0.18.6 -> 0.18.7`                             |
| [`6f2273d5`](https://github.com/NixOS/nixpkgs/commit/6f2273d532499a7c299f995522c8dbfeb879d08b) | `python310Packages.bleak-retry-connector: 1.7.1 -> 1.7.2`                     |
| [`c65a6e11`](https://github.com/NixOS/nixpkgs/commit/c65a6e11a79c08366753f43ca0ed4434f4a6ce67) | `python310Packages.pyoverkiz: 1.4.2 -> 1.5.0`                                 |
| [`224fc9d1`](https://github.com/NixOS/nixpkgs/commit/224fc9d138b7eccf31da551ee035367740299adb) | `editorconfig-core-c: 0.12.1 → 0.12.5`                                        |
| [`28d23a54`](https://github.com/NixOS/nixpkgs/commit/28d23a540ecb7913869496952cff755929bdd863) | `linux_zen: 5.18.16 -> 5.19.1; linux_lqx: 5.18.16-lqx2 -> 5.18.17-lqx1`       |
| [`5b93ac11`](https://github.com/NixOS/nixpkgs/commit/5b93ac113cf117eea5ef064651d980509174e6d2) | `yosys: 0.18 -> 0.20`                                                         |
| [`e9e5f127`](https://github.com/NixOS/nixpkgs/commit/e9e5f1278d25d6edc52efd5307f20377bf089e70) | `werf: 1.2.151 -> 1.2.153`                                                    |
| [`074c21e2`](https://github.com/NixOS/nixpkgs/commit/074c21e2d312fd78553e2fe197322451cb348a60) | `nvidia-x11-beta: mark broken for linux 5.19`                                 |
| [`e8529ae8`](https://github.com/NixOS/nixpkgs/commit/e8529ae84a1825a0679bd785429e60bd5932c43f) | `tflint: 0.39.2 -> 0.39.3`                                                    |
| [`0167b05d`](https://github.com/NixOS/nixpkgs/commit/0167b05d6386747b3d9a8de7308e42934928eec1) | `python310Packages.aqipy-atmotech: init at 0.1.5`                             |
| [`365557e0`](https://github.com/NixOS/nixpkgs/commit/365557e0431c60cba097e678fd7c0ddbb3afd9db) | `xxe-pe: 10.1.0 → 10.2.0`                                                     |
| [`480814e2`](https://github.com/NixOS/nixpkgs/commit/480814e21a334aaf39ec5505e2d8ac52871d563b) | `termusic: 0.7.1 -> 0.7.2`                                                    |
| [`371b6e15`](https://github.com/NixOS/nixpkgs/commit/371b6e15615072c21bfc21ac8b8aeb7cb3c8408e) | `review fixes`                                                                |
| [`a99d6e25`](https://github.com/NixOS/nixpkgs/commit/a99d6e2556f984ce5a75ec2dbe051a0804dbe635) | `avalonia-ilspy: fix copyDesktopItems use missing from initial review`        |
| [`3489a2a4`](https://github.com/NixOS/nixpkgs/commit/3489a2a40f5f39066f80520a59a154309afc96dc) | `python310Packages.motionblinds: 0.6.11 -> 0.6.12`                            |
| [`56f992c3`](https://github.com/NixOS/nixpkgs/commit/56f992c3a4ba6beab7201bad1ad969932cb7b9a9) | `python310Packages.json-schema-for-humans: 0.41.6 -> 0.41.8`                  |
| [`214c291f`](https://github.com/NixOS/nixpkgs/commit/214c291f556430763dc0621a6226917e13fcc1bd) | `rain: init at 1.2.0`                                                         |
| [`f8beb343`](https://github.com/NixOS/nixpkgs/commit/f8beb34357423c36f41b4dd5528e0809be8544f0) | `opentelemetry-collector-contrib: 0.57.2 -> 0.58.0`                           |
| [`98a5be62`](https://github.com/NixOS/nixpkgs/commit/98a5be62a20fd326eab4d169b7a6c62a1d3cd8c1) | `nomino: 1.2.1 -> 1.2.2`                                                      |
| [`4b7dbc98`](https://github.com/NixOS/nixpkgs/commit/4b7dbc98f7175e6ed843393c1013956bb0c89f82) | `alpine-make-vm-image: 0.8.0 -> 0.9.0`                                        |
| [`b8182071`](https://github.com/NixOS/nixpkgs/commit/b81820713f911dfea4ae10356629d1d69c2043f5) | `micro: install icon`                                                         |
| [`26dbb2ea`](https://github.com/NixOS/nixpkgs/commit/26dbb2ea4a14f077d0e050c6953b62fd5a9c7f4e) | `crow-translate: 2.9.8 -> 2.9.10`                                             |
| [`711cf12b`](https://github.com/NixOS/nixpkgs/commit/711cf12bab79006c253ae865f6d4a79da6a79e13) | `python310Packages.importmagic: Enable more tests`                            |
| [`d351fcb8`](https://github.com/NixOS/nixpkgs/commit/d351fcb816c2332daf5d8c54794041ec8d3a0c5b) | `minio: 2022-08-08T18-34-09Z -> 2022-08-11T04-37-28Z`                         |
| [`042ecbec`](https://github.com/NixOS/nixpkgs/commit/042ecbec9939227bd5dc92760945bac90640bec8) | `minio-client: 2022-08-05T08-01-28Z -> 2022-08-11T00-30-48Z`                  |
| [`f6dc229d`](https://github.com/NixOS/nixpkgs/commit/f6dc229d10d96bcbb353621597bbf1835f9b5130) | `fluxcd: 0.31.5 -> 0.32.0`                                                    |
| [`18a98dcd`](https://github.com/NixOS/nixpkgs/commit/18a98dcd567f05d484cbf5a86215bf031b03a78b) | `python310Packages.deezer-python: 5.4.0 -> 5.5.0`                             |
| [`d2622644`](https://github.com/NixOS/nixpkgs/commit/d262264480ce3501bf401a07ff8de0327dfaa6ee) | `zsh-fzf-tab: unstable-2022-04-15 -> unstable-2022-08-11`                     |
| [`42946d89`](https://github.com/NixOS/nixpkgs/commit/42946d89e7eb06674532c95b6d46e0705c0743be) | `python310Packages.types-setuptools: 63.4.1 -> 64.0.0`                        |
| [`633d0afe`](https://github.com/NixOS/nixpkgs/commit/633d0afe3eb9476a9c0b385364ce8b18d2186a8a) | `python310Packages.hahomematic: 2022.8.6 -> 2022.8.7`                         |
| [`673f2fff`](https://github.com/NixOS/nixpkgs/commit/673f2fffc4b6525a1bb27a29cf34ecfebf1695de) | `python310Packages.hahomematic: 2022.8.5 -> 2022.8.6`                         |
| [`5965f1b4`](https://github.com/NixOS/nixpkgs/commit/5965f1b44c7d5d08120275e9d9c0b8e440c8a9d2) | `pantheon.elementary-terminal: 6.0.2 -> 6.1.0`                                |
| [`cf4f1331`](https://github.com/NixOS/nixpkgs/commit/cf4f1331f9beab27ef0d66720a36a47525ff9851) | `grpc-gateway: 2.11.1 -> 2.11.2`                                              |
| [`eff1269a`](https://github.com/NixOS/nixpkgs/commit/eff1269a525df0ad5a5cd4e30e738495b15a4560) | `gdcm: 3.0.14 -> 3.0.15`                                                      |
| [`2464f69c`](https://github.com/NixOS/nixpkgs/commit/2464f69c9482365a61eef824b8f6a0cdb50f0e79) | `scalapack: add gdinh to maintainers`                                         |
| [`fb24dd71`](https://github.com/NixOS/nixpkgs/commit/fb24dd718f63abe5f723508aa600a9cc2c2ce270) | `scalapack: add darwin support`                                               |
| [`b6a68f8f`](https://github.com/NixOS/nixpkgs/commit/b6a68f8f42c4a1b7878d12ca0d3c187a5c880260) | `memray: init at 1.2.0`                                                       |
| [`7a0d7f15`](https://github.com/NixOS/nixpkgs/commit/7a0d7f15709179181ec833a81e87a3994252cb30) | `cpm: 0.35.4 -> 0.35.5`                                                       |
| [`6ea4ce11`](https://github.com/NixOS/nixpkgs/commit/6ea4ce1184238d0a1d76ffb79b31470edee5759e) | `maintainers: add gdinh`                                                      |
| [`05708816`](https://github.com/NixOS/nixpkgs/commit/05708816093402c40198e58caf0bb52a6c4d408d) | `nodePackages.prisma: 4.1.1 -> 4.2.1`                                         |
| [`0cbc6f2f`](https://github.com/NixOS/nixpkgs/commit/0cbc6f2f67c1080f78b2db7c102fa0c0fba456b3) | `prisma-engines: 4.1.1 -> 4.2.1`                                              |
| [`e94c62f9`](https://github.com/NixOS/nixpkgs/commit/e94c62f9a16028fb843c80fced864a0723f9f969) | `dapr-cli: 1.8.0 -> 1.8.1`                                                    |
| [`e7efdf12`](https://github.com/NixOS/nixpkgs/commit/e7efdf128e6250284a0eb41278c90e31f91ebb07) | `0x: init at unstable-2022-07-11`                                             |
| [`454730f0`](https://github.com/NixOS/nixpkgs/commit/454730f02a3ef507d22fff495c516b8958828202) | `_1password: fix hashes`                                                      |
| [`bdd963f3`](https://github.com/NixOS/nixpkgs/commit/bdd963f323db1382475a837a810ae6c0e6160c5d) | `smug: install completions`                                                   |
| [`0579df5e`](https://github.com/NixOS/nixpkgs/commit/0579df5eb85ec722749a6bf04df02ac415c80727) | `brakeman: 5.2.3 -> 5.3.1`                                                    |
| [`545b691e`](https://github.com/NixOS/nixpkgs/commit/545b691e4eeaec530ac54002ceb2cb52e3c514d8) | `postgresqlPackages.pgroonga: 2.3.7 -> 2.3.8`                                 |
| [`a95655b7`](https://github.com/NixOS/nixpkgs/commit/a95655b7f5991c3de8f964164b25112f8229bb2d) | `opam: 2.1.2 -> 2.1.3`                                                        |
| [`b7a9b9e1`](https://github.com/NixOS/nixpkgs/commit/b7a9b9e1ae257c173d2f9b1b62f1881499aab074) | `odyssey: build with compression support`                                     |
| [`f1abfc7e`](https://github.com/NixOS/nixpkgs/commit/f1abfc7ec3c991d8f41c70643f267bd6f75cc515) | `fastlane: 2.208.0 -> 2.209.0`                                                |
| [`359c6e9a`](https://github.com/NixOS/nixpkgs/commit/359c6e9a0129f401776d1bb65aef42e926f29b5b) | `racket: 8.5 -> 8.6`                                                          |
| [`6926852c`](https://github.com/NixOS/nixpkgs/commit/6926852cf0805016dd85fd54e699c2c8d0bb7de3) | `millet: 0.2.9 -> 0.2.11`                                                     |
| [`67c54e77`](https://github.com/NixOS/nixpkgs/commit/67c54e77bed789951f9175aa7c2e0901017a8e81) | `groonga: 12.0.5 -> 12.0.6`                                                   |
| [`9951ffc0`](https://github.com/NixOS/nixpkgs/commit/9951ffc06eaa0ab9f04693bed628a047a6f4be5c) | `freetube: 0.17.0 -> 0.17.1`                                                  |
| [`749e42f1`](https://github.com/NixOS/nixpkgs/commit/749e42f16d8fbaa1b5c814c4a7dc17b937d2f67d) | `monero-gui: 0.17.3.2 -> 0.18.1.0`                                            |
| [`0ec615c4`](https://github.com/NixOS/nixpkgs/commit/0ec615c46b67a1c300fce032fce433dfd2bc3ec3) | `monero: 0.17.3.2 -> 0.18.1.0`                                                |
| [`ad4f9e84`](https://github.com/NixOS/nixpkgs/commit/ad4f9e84a94e7a27dc034d4f2e89c3932c5132d5) | `pls: 5.3.0 -> 5.4.0`                                                         |
| [`fc22cbb0`](https://github.com/NixOS/nixpkgs/commit/fc22cbb081fa86c3cb8cbfbaef7f1bc6fed2b779) | `qFlipper: 1.1.1 -> 1.1.2`                                                    |
| [`89c9e5f5`](https://github.com/NixOS/nixpkgs/commit/89c9e5f5b6cc5804179d72841ce0241fb3ce0dd1) | `anytype: 0.26.1 -> 0.27.0`                                                   |
| [`b09ab93d`](https://github.com/NixOS/nixpkgs/commit/b09ab93d600747af3d8e72a443eabc476b3527de) | `squeezelite: 1.9.9.1401 -> 1.9.9.1403`                                       |
| [`08bd25a3`](https://github.com/NixOS/nixpkgs/commit/08bd25a37ad2ee830c7c19b94541fbccf251a65f) | `vscode: 1.70.0 -> 1.70.1`                                                    |
| [`db409828`](https://github.com/NixOS/nixpkgs/commit/db4098283bb7f11f67c3b219716561e1abbedc23) | `sq: 0.15.4 -> 0.15.6`                                                        |
| [`27cca60c`](https://github.com/NixOS/nixpkgs/commit/27cca60cba708ea6b9f24095fc397c689121e374) | `_1password: 2.6.0 -> 2.6.1`                                                  |
| [`7e276013`](https://github.com/NixOS/nixpkgs/commit/7e2760130b0015ace19d168cdd681f17e7465ede) | `steamPackages.steam-runtime: 0.20211102.0 -> 0.20220601.1`                   |
| [`1b803751`](https://github.com/NixOS/nixpkgs/commit/1b8037517127978727bd494bc1fd90807716b0bf) | `seer: 1.7 -> 1.8`                                                            |
| [`6b5e730e`](https://github.com/NixOS/nixpkgs/commit/6b5e730e7895e0a30cf01e15f8a07663f7f99d61) | `sbt: 1.6.2 -> 1.7.1`                                                         |
| [`358dcd9d`](https://github.com/NixOS/nixpkgs/commit/358dcd9dc692a7095d683802b8f326e16bbc08fa) | `sane-backends: install hwdb file`                                            |
| [`fc497efb`](https://github.com/NixOS/nixpkgs/commit/fc497efb780802d2df568f0591674755645519a3) | `sioyek: unbreak on darwin`                                                   |
| [`b0a02108`](https://github.com/NixOS/nixpkgs/commit/b0a02108e6d5a5ff5acda2665b1bceb148f4cffc) | `trenchbroom: 2021.1 -> 2022.1`                                               |
| [`1015914b`](https://github.com/NixOS/nixpkgs/commit/1015914bdc785a67e539bd61bc06d98f00380a02) | `python310Packages.readme_renderer: 35.0 -> 36.0`                             |
| [`04e0c8f5`](https://github.com/NixOS/nixpkgs/commit/04e0c8f5f4ec0f7872faca87cfa0c01caa2c68ac) | `miniz: init at 2.2.0`                                                        |
| [`a2bbcde7`](https://github.com/NixOS/nixpkgs/commit/a2bbcde74ebd76b54b1297bf8b71f81c88fb8ed7) | `vtk_9: 9.0.3 -> 9.1.0`                                                       |
| [`087472b1`](https://github.com/NixOS/nixpkgs/commit/087472b1e5230ffc8ba642b1e4f9218adf4634a2) | `nixos/*: automatically convert option docs`                                  |
| [`d6905d06`](https://github.com/NixOS/nixpkgs/commit/d6905d065a6521653488b8f7ad96198d1072e27c) | `pcsx2: 1.7.3128 -> 1.7.3165`                                                 |
| [`d08254b9`](https://github.com/NixOS/nixpkgs/commit/d08254b9dd43962ae5ea94255d4cd9b233cc63ca) | `dendrite: unpin go version`                                                  |
| [`d3bbe7fa`](https://github.com/NixOS/nixpkgs/commit/d3bbe7fab6c8fc92b58e8dbdb87f3bd1b2bde55e) | `fcitx5-gtk: 5.0.16 -> 5.0.17`                                                |
| [`423545fe`](https://github.com/NixOS/nixpkgs/commit/423545fe4865d126e86721ba30da116e29c65004) | `nixos/*: normalize manpage references to single-line form`                   |
| [`82dc1edf`](https://github.com/NixOS/nixpkgs/commit/82dc1edf5904ad1a8c0d71cf630ca4dd55949220) | `system76-keyboard-configurator: 1.0.0 -> 1.2.0`                              |
| [`46c35072`](https://github.com/NixOS/nixpkgs/commit/46c3507238b11412cee70d5edbcb9d187836d776) | `rocksdb: 7.4.4 -> 7.4.5`                                                     |