### PR TITLE
chore(flake/darwin): `54a24f04` -> `80871c71`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657835815,
-        "narHash": "sha256-CnZszAYpNKydh6N7+xg+eRtWNVoAAGqc6bg+Lpgq1xc=",
+        "lastModified": 1660649317,
+        "narHash": "sha256-16sWaj3cTZOQQgrmzlvBSRaBFKLrHJrfYh1k7/sSWok=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "54a24f042f93c79f5679f133faddedec61955cf2",
+        "rev": "80871c71edb3da76d40bdff9cae007a2a035c074",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                               |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------- |
| [`0ed84cbf`](https://github.com/LnL7/nix-darwin/commit/0ed84cbf72c2bb9b40c96c9758242a31abb71e9b) | `Update install-nix-action and nix to 22.05` |
| [`7d37b790`](https://github.com/LnL7/nix-darwin/commit/7d37b79015d497c0d192aa07fb3053881cf889d8) | `[github] Use macos-12`                      |