### PR TITLE
chore(flake/nixpkgs): `6512b21e` -> `af9e0007`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660485612,
-        "narHash": "sha256-sSLW1KaB1adKTJn9+Ja3h3AaS7QCZyhUKiSUStcLg80=",
+        "lastModified": 1660574513,
+        "narHash": "sha256-nkMQ1TKIIAYIVbbUzjxfjPn3H1zZFW20TrHUFAjwvNU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6512b21eabb4d52e87ea2edcf31a288e67b2e4f8",
+        "rev": "af9e00071d0971eb292fd5abef334e66eda3cb69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                    |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`a29ca0ec`](https://github.com/NixOS/nixpkgs/commit/a29ca0ec205210ff208c5f00d6a5b9d3413f4287) | `cinnamon.cinnamon-common: fix msgfmt path for Spices.py`                         |
| [`07a56496`](https://github.com/NixOS/nixpkgs/commit/07a564964c0dfb1fa15f9be701b2fba55b252a9d) | `git-team: fix build on aarch64-darwin`                                           |
| [`9c69f307`](https://github.com/NixOS/nixpkgs/commit/9c69f307ce6e869b5ff43c242b7cf6d5f5fd9013) | `nixos/cinnamon: install gnome-screenshot`                                        |
| [`342d67be`](https://github.com/NixOS/nixpkgs/commit/342d67be61a28c840c945875908dcedeebd74bec) | `obs-studio: resolve failed wrapping if a plugin has no data path`                |
| [`47b3196a`](https://github.com/NixOS/nixpkgs/commit/47b3196aabdf11b43dafb35960f88885beb825e2) | `python3Packages.flask-appbuilder: fix build`                                     |
| [`77331374`](https://github.com/NixOS/nixpkgs/commit/77331374d3ee76e013e61ac1857ab28314eb9288) | `python310Packages.sensorpush-ble: 1.5.1 -> 1.5.2`                                |
| [`7e44c3c3`](https://github.com/NixOS/nixpkgs/commit/7e44c3c38268ced3292a58f5f43d8aefc9ec6f21) | `python310Packages.bluetooth-sensor-state-data: 1.5.0 -> 1.6.0`                   |
| [`88132767`](https://github.com/NixOS/nixpkgs/commit/88132767ceb5cfdde740a25e4d0f7ce933f588b1) | `git: actually add fetchgit tests to passthru.tests`                              |
| [`eb642f80`](https://github.com/NixOS/nixpkgs/commit/eb642f80f9aecc19312909e08601a3c2020b5ce2) | `m2r: use toPythonApplication`                                                    |
| [`243053e5`](https://github.com/NixOS/nixpkgs/commit/243053e521dc90b825a17bf5ee9f5dfe7f56af84) | `python310Packages.mistune: 0.8.4 -> 2.0.4`                                       |
| [`9f1da18a`](https://github.com/NixOS/nixpkgs/commit/9f1da18a1e9c48d43854811362b75236b61164cc) | `colemak-dh: init at unstable-2022-08-07`                                         |
| [`3ddd0f90`](https://github.com/NixOS/nixpkgs/commit/3ddd0f9002d8630a34a86cc30196a963d0b2c545) | `maintainers: add monaaraj`                                                       |
| [`f1660d80`](https://github.com/NixOS/nixpkgs/commit/f1660d80277fda710668edff8ec5ab05c91422d1) | `aliyun-cli: 3.0.123 -> 3.0.124`                                                  |
| [`e0660190`](https://github.com/NixOS/nixpkgs/commit/e066019096f11ab84b304e2f1e262f692385294e) | `hydra_unstable: 2022-06-30 -> 2022-08-08`                                        |
| [`6737d2cf`](https://github.com/NixOS/nixpkgs/commit/6737d2cfc8987d3b01c2fde5189d3313ef2248e9) | `pipectl: 0.3.0 -> 0.4.1`                                                         |
| [`8a36e147`](https://github.com/NixOS/nixpkgs/commit/8a36e1472b53f7adfaa9267a13967094636401d2) | `swaynotificationcenter: 0.6.1 -> 0.6.3`                                          |
| [`92f6f6b7`](https://github.com/NixOS/nixpkgs/commit/92f6f6b72b6ebd250a3480b59166cc43d959c1df) | `python310Packages.p1monitor: 2.0.0 -> 2.1.0`                                     |
| [`58e5bd56`](https://github.com/NixOS/nixpkgs/commit/58e5bd56d67b46208a6eef2539bb000b7a146580) | `default-crate-overrides.nix: add libevdev for evdev-rs`                          |
| [`2a551f95`](https://github.com/NixOS/nixpkgs/commit/2a551f952089abe8493965db0579f953b25d12eb) | `deluge: 2.0.5 -> 2.1.1`                                                          |
| [`ffd1c042`](https://github.com/NixOS/nixpkgs/commit/ffd1c042421ec9e546cca5b314c1df65ac43930a) | `sticky: 1.11 -> 1.12`                                                            |
| [`53abe2aa`](https://github.com/NixOS/nixpkgs/commit/53abe2aa3e442414a93048e9bec79ff78204a6a4) | `cinnamon.xreader: 3.4.3 -> 3.4.4`                                                |
| [`620175f8`](https://github.com/NixOS/nixpkgs/commit/620175f898f6d7c200ef21803a6d40e30784ec70) | `cinnamon.nemo: 5.4.2 -> 5.4.3`                                                   |
| [`8a19bf49`](https://github.com/NixOS/nixpkgs/commit/8a19bf497c05b009d6040d3d0231baa4c27d57d3) | `cinnamon.cinnamon-common: 5.4.9 -> 5.4.10`                                       |
| [`895a5fa6`](https://github.com/NixOS/nixpkgs/commit/895a5fa6e1b6f690528a96837cee6e355b4012d8) | `python310Packages.homeconnect: 0.7.1 -> 0.7.2`                                   |
| [`cc45fa8d`](https://github.com/NixOS/nixpkgs/commit/cc45fa8d20190b7c591252bccbc9f4321b20eaf1) | `python3Packages.django-statici18n: 2.2.0 -> 2.3.1`                               |
| [`a5c352ed`](https://github.com/NixOS/nixpkgs/commit/a5c352edae438c7bfb9cd90bdab1e8b66518844b) | `python310Packages.databricks-cli: 0.17.0 -> 0.17.1`                              |
| [`680f04a9`](https://github.com/NixOS/nixpkgs/commit/680f04a9930fa0b9572abda5a9429cb2b1c77655) | `dhallPackages.dhall-cloudformation: init at 0.9.64 (#183813)`                    |
| [`25b5181c`](https://github.com/NixOS/nixpkgs/commit/25b5181c2e28bb385bcfa29ece130397f03f63ae) | `zola: 0.16.0 -> 0.16.1`                                                          |
| [`19f152c2`](https://github.com/NixOS/nixpkgs/commit/19f152c2b0318e9cb2232d43d25d44b9eb3f5110) | `neovide: 0.9.0 -> 0.10.0`                                                        |
| [`17cfbb2e`](https://github.com/NixOS/nixpkgs/commit/17cfbb2e32ad13e9bcfd08b50e32a1b34d3f76c2) | `python3Packages.s3fs: unbreak on aarch64-linux`                                  |
| [`48f5dbcd`](https://github.com/NixOS/nixpkgs/commit/48f5dbcd38a22e71400278a9108cad1db3c016dd) | `yt-dlp: 2022.8.8 -> 2022.8.14`                                                   |
| [`104dd5ae`](https://github.com/NixOS/nixpkgs/commit/104dd5ae9c4bcbbdc12b47f2acf6e792b0038c4e) | `python310Packages.dicttoxml2: 2.0.0 -> 2.1.0`                                    |
| [`6e99500f`](https://github.com/NixOS/nixpkgs/commit/6e99500faa4419247a9c14148408b56c67d99c61) | `python310Packages.teslajsonpy: 2.4.0 -> 2.4.1`                                   |
| [`599776d5`](https://github.com/NixOS/nixpkgs/commit/599776d5e627734c03e302e4aafc25bec0b7c668) | `python310Packages.xknx: 0.22.1 -> 1.0.0`                                         |
| [`b2e48228`](https://github.com/NixOS/nixpkgs/commit/b2e48228f94f62c026d859cbfa42882467891ebe) | `python310Packages.twilio: 7.12.0 -> 7.12.1`                                      |
| [`e8453ebb`](https://github.com/NixOS/nixpkgs/commit/e8453ebbac980ac95d9ec5ab3bd6d7c69cb4eabc) | `mpv: add libXpresent dependency`                                                 |
| [`35980a2c`](https://github.com/NixOS/nixpkgs/commit/35980a2c246c12f084dcf724d997087498725424) | `ticker: 4.5.2 -> 4.5.3`                                                          |
| [`38858263`](https://github.com/NixOS/nixpkgs/commit/38858263dae5850f39a4de7b3ece4a82ef549283) | `treewide: fix hashes for sparse checkout`                                        |
| [`419dda4c`](https://github.com/NixOS/nixpkgs/commit/419dda4c60d96e118ba8187eedc119ae48990c36) | `git: add fetchgit tests to passthru.tests`                                       |
| [`dbd18a63`](https://github.com/NixOS/nixpkgs/commit/dbd18a63a7e8bb59efa9e556241786ac2169033a) | `fetchgit: allow disabling cone mode for sparse checkouts, fix test`              |
| [`4929601f`](https://github.com/NixOS/nixpkgs/commit/4929601fe98960014a7b8a9e6bb491432178e398) | `bitwuzla: unstable-2021-07-01 -> unstable-2022-08-07`                            |
| [`d91372de`](https://github.com/NixOS/nixpkgs/commit/d91372dedbb85d56d06050ba1f194300b44ffe23) | `python310Packages.pynetgear: 0.10.6 -> 0.10.7`                                   |
| [`07e72bf7`](https://github.com/NixOS/nixpkgs/commit/07e72bf7f9e9d6a3636f3bd1da783fd8c0624db1) | `python310Packages.pymicrobot: 0.0.1 -> 0.0.3`                                    |
| [`9fc4eb44`](https://github.com/NixOS/nixpkgs/commit/9fc4eb44b178c5d027eb854215adb4dcef17feb7) | `python310Packages.plugwise: 0.21.2 -> 0.21.3`                                    |
| [`f9e63292`](https://github.com/NixOS/nixpkgs/commit/f9e632925e7d19dbfd72f4af4afaaa0f914fbe1c) | `python310Packages.peaqevcore: 4.0.8 -> 5.1.3`                                    |
| [`f4786a9e`](https://github.com/NixOS/nixpkgs/commit/f4786a9e3d17647b96d572356c816ca88d1c4f29) | `python310Packages.aiohomekit: 1.2.9 -> 1.2.10`                                   |
| [`b932bf6f`](https://github.com/NixOS/nixpkgs/commit/b932bf6fc697674c5d53bad8621a6ab15083b85c) | `python310Packages.aiohue: 4.4.2 -> 4.5.0`                                        |
| [`39590e13`](https://github.com/NixOS/nixpkgs/commit/39590e137dd7aaf6a2040e26ce193ee35ebaed74) | `dnsrecon: 1.1.2 -> 1.1.3`                                                        |
| [`dd70ae4c`](https://github.com/NixOS/nixpkgs/commit/dd70ae4c78d16dd6d1174ad12688d6704a148adb) | `metasploit: 6.2.11 -> 6.2.12`                                                    |
| [`1b88241f`](https://github.com/NixOS/nixpkgs/commit/1b88241f7ee3e189642a9eee25cf9eb9f85b7ad2) | `python310Packages.sensor-state-data: 2.1.2 -> 2.2.0`                             |
| [`0f16ca6e`](https://github.com/NixOS/nixpkgs/commit/0f16ca6e7947a71dc0db53e95102e1bf124ad0f8) | `rofi-unwrapped: 1.7.3 -> 1.7.4`                                                  |
| [`f8bfefdb`](https://github.com/NixOS/nixpkgs/commit/f8bfefdb2f5a9778ac7706427fd299d80f4a80a6) | `python310Packages.azure-keyvault-secrets: 4.4.0 -> 4.5.1`                        |
| [`3caeee2e`](https://github.com/NixOS/nixpkgs/commit/3caeee2ec32cd07ccf754900b6c84a222ec2dca0) | `pyinfra: 2.3 -> 2.4`                                                             |
| [`2a8ce2f6`](https://github.com/NixOS/nixpkgs/commit/2a8ce2f681df5f145be67d97852b70b9f6ad4816) | `oq: 1.3.2 -> 1.3.3`                                                              |
| [`f2969007`](https://github.com/NixOS/nixpkgs/commit/f2969007eeead45e7bb1f1e9a51a68826344bd75) | `python310Packages.rapidfuzz: 2.4.3 -> 2.5.0`                                     |
| [`4761f05e`](https://github.com/NixOS/nixpkgs/commit/4761f05e7b1ca94eae696c6dcae177eae24d4718) | `python310Packages.jarowinkler: 1.2.0 -> 1.2.1`                                   |
| [`986a5d59`](https://github.com/NixOS/nixpkgs/commit/986a5d59113a2107ec7dac5de93bf44991eedd49) | `python310Packages.miniaudio: 1.51 -> 1.52`                                       |
| [`16835711`](https://github.com/NixOS/nixpkgs/commit/16835711af55c4175948f5654c02cb098e534f17) | `python310Packages.bluetooth-data-tools: init at 0.1.2`                           |
| [`6b6e2ee0`](https://github.com/NixOS/nixpkgs/commit/6b6e2ee00feaf41dfcb6f62766b470a51674ffb2) | `gnome.eog: 42.2 -> 42.3`                                                         |
| [`593d64f9`](https://github.com/NixOS/nixpkgs/commit/593d64f975e4e7d9439562d3f857d85e8be66012) | `obs-studio: Fix wrapOBS double-including the built-in plugins`                   |
| [`c8e49f8f`](https://github.com/NixOS/nixpkgs/commit/c8e49f8f29471e945cba60ba211919b5e7b943e2) | `minio: 2022-08-11T04-37-28Z -> 2022-08-13T21-54-44Z`                             |
| [`82640adb`](https://github.com/NixOS/nixpkgs/commit/82640adbf00f9ebb5da9c6c47d0b8d242755946e) | `nixos/security: add size option to /run/wrappers`                                |
| [`8180b124`](https://github.com/NixOS/nixpkgs/commit/8180b124bf8690ff3455c7def3832cd68727fb3e) | `oh-my-zsh: 2022-07-26 -> 2022-08-10`                                             |
| [`82a99f1f`](https://github.com/NixOS/nixpkgs/commit/82a99f1ff5e023ecb6225ce5021eb3cbb9240813) | `libnats-c: 3.2.0 -> 3.3.0`                                                       |
| [`96958813`](https://github.com/NixOS/nixpkgs/commit/96958813c322ed90e67ffb0586b653d86bcc3f6f) | `nano: 6.3 -> 6.4`                                                                |
| [`3dde706c`](https://github.com/NixOS/nixpkgs/commit/3dde706c46b9813b449716c45848158b66b1c41b) | `intel-compute-runtime: 22.17.23034 -> 22.31.23852`                               |
| [`374734c5`](https://github.com/NixOS/nixpkgs/commit/374734c52b6086478239143ebbdaf0d422ded711) | `mutt: 2.2.6 -> 2.2.7`                                                            |
| [`90897602`](https://github.com/NixOS/nixpkgs/commit/908976024d009f3bf5976342d02f04680c64ad00) | `trilium-{desktop,server}: 0.53.2 -> 0.54.2`                                      |
| [`dabb2eb9`](https://github.com/NixOS/nixpkgs/commit/dabb2eb9ad962d9e25f900809411e6ab33fe4684) | `grafana_reporter: 2.1.0 -> 2.3.1`                                                |
| [`bb202ec7`](https://github.com/NixOS/nixpkgs/commit/bb202ec7218af0327d8b9b87758a96a35e1e6e7f) | `randomx: 1.1.9 -> 1.1.10`                                                        |
| [`f3a8a894`](https://github.com/NixOS/nixpkgs/commit/f3a8a894a6f9fa7b1f83ce0da27001a00b574ea7) | `kcmutils: drop merged patch`                                                     |
| [`8716fe21`](https://github.com/NixOS/nixpkgs/commit/8716fe21bd356d189c1f222cd09fae8221ea5277) | `kwallet: add missing dependency`                                                 |
| [`937ede3b`](https://github.com/NixOS/nixpkgs/commit/937ede3b165bb7c515122fd743f9e55c20332b8d) | `kconfigwidgets: drop merged patch`                                               |
| [`ffb91d08`](https://github.com/NixOS/nixpkgs/commit/ffb91d08a917b2fb8b74bc7c49b96a5092aa00fa) | `pythonPackages.nix-prefetch-github: v5.2.0 -> v5.2.1`                            |
| [`2934fa32`](https://github.com/NixOS/nixpkgs/commit/2934fa32ea200b45e80da5c2fdc87ee4500cc4cf) | `kde-frameworks: 5.96 -> 5.97`                                                    |
| [`e4b89c06`](https://github.com/NixOS/nixpkgs/commit/e4b89c06c398e3b89730bad725c838dc3ca27816) | `sourcetrail: remove`                                                             |
| [`664b01f0`](https://github.com/NixOS/nixpkgs/commit/664b01f0829987affdaa361207bfd0b698db0ec2) | `nixos/mirakurun: set the LOGO_DATA_DIR_PATH environment variable`                |
| [`3a57080b`](https://github.com/NixOS/nixpkgs/commit/3a57080baad0f09d732fc288ffc7fe0e7626b728) | `upbound: init at 0.12.2`                                                         |
| [`a3fb7cfc`](https://github.com/NixOS/nixpkgs/commit/a3fb7cfc3ab8dd032b74accb767a8b02867bdf51) | `cinny-desktop: 2.1.1 -> 2.1.2`                                                   |
| [`203593e7`](https://github.com/NixOS/nixpkgs/commit/203593e72ee8fa209b1a52a75764275e2801b944) | `pipenv: 2022.7.24 -> 2022.8.14`                                                  |
| [`0dc9748c`](https://github.com/NixOS/nixpkgs/commit/0dc9748c6fecc7abc0f26bda888c3f0019bae0d8) | `starship: 1.9.1 -> 1.10.0`                                                       |
| [`97f7cf06`](https://github.com/NixOS/nixpkgs/commit/97f7cf06d25037b49c18ef4d558d7c191f25d9d8) | `git-cinnabar: 0.5.7 -> 0.5.10`                                                   |
| [`f28b2999`](https://github.com/NixOS/nixpkgs/commit/f28b29999b4351b2ed9dc5f06cd50879bd698da5) | `fishPlugins.fzf-fish: 9.0 -> 9.2`                                                |
| [`e4f2c0b0`](https://github.com/NixOS/nixpkgs/commit/e4f2c0b0c2c92b3589691f6a9d6d452d0badbbfa) | `hyfetch: remove unneeded postPatch`                                              |
| [`c36152b3`](https://github.com/NixOS/nixpkgs/commit/c36152b37999fe34af1379f533b3fef227527061) | `python310Packages.django-maintenance-mode: Fix missing python-fsutil dependency` |
| [`b146c4fc`](https://github.com/NixOS/nixpkgs/commit/b146c4fcfb66c6ee97aefc97ce3c9182e2d79d77) | `hyfetch: 1.3.0 -> 1.4.0`                                                         |
| [`de51cc96`](https://github.com/NixOS/nixpkgs/commit/de51cc960bedabae579480227f178d1b186acce8) | `python310Packages.tabula-py: 2.4.0 -> 2.5.0`                                     |
| [`431d982f`](https://github.com/NixOS/nixpkgs/commit/431d982fa91ef6865fbe3c2fb999efc4aabf0c7e) | `glib-networking: 2.72.1 -> 2.72.2`                                               |
| [`c751554a`](https://github.com/NixOS/nixpkgs/commit/c751554a16dd0bca40d46561da768c1d94830368) | `zsh-completions: remove tmuxp completion`                                        |
| [`c3edf8a2`](https://github.com/NixOS/nixpkgs/commit/c3edf8a264e47d33529eea499425bbf17ab00aca) | `zsh-completions: fix code style`                                                 |
| [`ebf9a4ad`](https://github.com/NixOS/nixpkgs/commit/ebf9a4ad8961ac1ef65b762bf374b42044b174aa) | `miniflux: 2.0.37 → 2.0.38`                                                       |
| [`4b05b28a`](https://github.com/NixOS/nixpkgs/commit/4b05b28a81805cbb4fd3bab6ce6322041c3f240c) | `rabbitmq-server: 3.10.6 -> 3.10.7`                                               |
| [`2affd4e8`](https://github.com/NixOS/nixpkgs/commit/2affd4e8519e73bcc690cecaa65abb8739f82715) | `oci-cli: 3.7.2 -> 3.14.0`                                                        |
| [`9a260b5b`](https://github.com/NixOS/nixpkgs/commit/9a260b5b9f9b8e89ff810ee7d1805ee08bec295b) | `pgloader: 3.6.6 -> 3.6.7`                                                        |
| [`4a572326`](https://github.com/NixOS/nixpkgs/commit/4a57232668a92253a113a4d86d1c2a9305327c88) | `python310Packages.ocifs: init at 1.1.2`                                          |
| [`d0208ead`](https://github.com/NixOS/nixpkgs/commit/d0208eadad300980fff67abc405e7508219df411) | `python310Packages.oci: 2.75.0 -> 2.78.0`                                         |
| [`ce940123`](https://github.com/NixOS/nixpkgs/commit/ce940123eca2052148ba1ea7efcb338d29595186) | `brave: 1.41.100 -> 1.42.88`                                                      |
| [`cfd88c2e`](https://github.com/NixOS/nixpkgs/commit/cfd88c2e74554c7aec3940ff8bef790bbf8a0bf3) | `vivaldi-ffmepg-codecs: 103.0.5060.53 -> 104.0.5112.79`                           |
| [`e611e6d5`](https://github.com/NixOS/nixpkgs/commit/e611e6d598191b1f76f9387c1d6b782e53cdb398) | `vivaldi: 5.3.2679.70-1 -> 5.4.2753.33-1`                                         |
| [`d9a9b87d`](https://github.com/NixOS/nixpkgs/commit/d9a9b87d1d11cabddd6bdb59412e1ef4e6bd832b) | `crowdin-cli: 3.7.9 -> 3.7.10`                                                    |
| [`ce6202a6`](https://github.com/NixOS/nixpkgs/commit/ce6202a6b5bfceb469b344fa376ada1dc9d1afea) | `fheroes2: install localization and other port-specific files`                    |
| [`a33c768d`](https://github.com/NixOS/nixpkgs/commit/a33c768df94209409a01fde588b5bfd31c850281) | `jitsi-meet: 1.0.6260 -> 1.0.6447`                                                |
| [`ae318632`](https://github.com/NixOS/nixpkgs/commit/ae318632bc9e6c8c6faf7bc72a9df338bd31ba94) | `jitsi-videobridge: 2.2-9-g8cded16e -> 2.2-22-g42bc1b99`                          |
| [`73afec56`](https://github.com/NixOS/nixpkgs/commit/73afec56918c41e848ab91ec670d6bb60dec7c6f) | `jicofo: 1.0-900 -> 1.0-911`                                                      |
| [`99ddbdb9`](https://github.com/NixOS/nixpkgs/commit/99ddbdb9fdc521206f7c0063242cf67db2729c6d) | `jitsi-meet-prosody: 1.0.6260 -> 1.0.6447`                                        |
| [`13760b87`](https://github.com/NixOS/nixpkgs/commit/13760b87d2067dec6afa76859f3e69027bc2e139) | `jitsi-videobridge: fix update script`                                            |
| [`0d8b6ec0`](https://github.com/NixOS/nixpkgs/commit/0d8b6ec05e884af0de893adbda4510118baabf4d) | `python310Packages.aiohttp-retry: 2.7.0 -> 2.8.3`                                 |
| [`bb17d4e0`](https://github.com/NixOS/nixpkgs/commit/bb17d4e059e81679aee6dc3f61a7079848f25f4a) | `hyperledger-fabric: 2.4.3 -> 2.4.6`                                              |
| [`36cbcf40`](https://github.com/NixOS/nixpkgs/commit/36cbcf4001726eb66b4da08549a3d2793ae55c06) | `zed: init at 1.2.0`                                                              |
| [`37374347`](https://github.com/NixOS/nixpkgs/commit/373743476c7894d99b643dfd05984e78388f492e) | `vivaldi: fix ffmpeg version extraction`                                          |
| [`20e1a64b`](https://github.com/NixOS/nixpkgs/commit/20e1a64bb80cdb3dfc0f7db539ec3a2f0dede3b2) | `skate: 0.2.0 -> 0.2.1`                                                           |
| [`874c3bba`](https://github.com/NixOS/nixpkgs/commit/874c3bba6be7a7cd7ac5884fa8b0938aa7e3113a) | `sdbus-cpp: 1.1.0 -> 1.2.0`                                                       |
| [`5b3aa061`](https://github.com/NixOS/nixpkgs/commit/5b3aa061f217a2feb3f4af39faeacbe0986e6028) | `charm: 0.12.1 -> 0.12.3`                                                         |
| [`d2e257ce`](https://github.com/NixOS/nixpkgs/commit/d2e257ceb3a01e5447e55739acd5e784409b658d) | `fnott: 1.2.1 -> 1.3.0`                                                           |
| [`c7e3978e`](https://github.com/NixOS/nixpkgs/commit/c7e3978e36d4f2c27e11bc766598ee1ec9672990) | `argo: 3.3.8 -> 3.3.9`                                                            |
| [`f38a47d6`](https://github.com/NixOS/nixpkgs/commit/f38a47d64a95881b889a7bbd91f61321ff84a856) | `opentrack: 2.1.3 → 2022.3.0`                                                     |
| [`10a43777`](https://github.com/NixOS/nixpkgs/commit/10a43777e05970d00ce6b02de161d9d877f88ee5) | `snipe-it: 6.0.8 -> 6.0.9`                                                        |
| [`40ba925d`](https://github.com/NixOS/nixpkgs/commit/40ba925d3ebda1e91a24feed00ffd75a0356215a) | `wails: 2.0.0-beta.42 -> 2.0.0-beta.43`                                           |
| [`9778f081`](https://github.com/NixOS/nixpkgs/commit/9778f0814155b228baa880438cff95ea50e2f622) | `pythonPackages.nix-prefetch-github: 5.1.2 -> 5.2.0`                              |
| [`8edb7f27`](https://github.com/NixOS/nixpkgs/commit/8edb7f27c3730d41f4c3cbcb47ef3e76c23d89b7) | `caffeine-ng: don't double wrap`                                                  |
| [`f3e806ed`](https://github.com/NixOS/nixpkgs/commit/f3e806edf4fd27362dad80a02ac96e3f9f485f51) | `mysql: 8.0.29 -> 8.0.30`                                                         |
| [`42df18cf`](https://github.com/NixOS/nixpkgs/commit/42df18cf76340a657ba54be574e17da243c5c6ec) | `sentencepiece: 0.1.96 -> 0.1.97`                                                 |
| [`52e86e2b`](https://github.com/NixOS/nixpkgs/commit/52e86e2b22997bbe98dd654afe9d48fc2905f645) | `python310Packages.pyperf: 2.4.0 -> 2.4.1`                                        |
| [`c9d01149`](https://github.com/NixOS/nixpkgs/commit/c9d011497d900f85e1a304610be4722545f80ecb) | `hsqldb: 2.6.1 -> 2.7.0`                                                          |
| [`4df9e264`](https://github.com/NixOS/nixpkgs/commit/4df9e2647a8c57f9da2ab8cd332181ac86f28c0a) | `lsp-plugins: 1.2.1 -> 1.2.2`                                                     |
| [`1369d3ed`](https://github.com/NixOS/nixpkgs/commit/1369d3edb72fa17967a0ac465bca6774fc9a6137) | `MMA: 20.12 -> 21.09`                                                             |
| [`976468d6`](https://github.com/NixOS/nixpkgs/commit/976468d6627d9736a1000933cafe804319829837) | `oil: 0.12.0 -> 0.12.3`                                                           |
| [`29fb8273`](https://github.com/NixOS/nixpkgs/commit/29fb8273cc0518a27a54354f964f6d125916ecc0) | `fira-go: init at 1.001`                                                          |
| [`751df2de`](https://github.com/NixOS/nixpkgs/commit/751df2de1f914e962761de7c0612c03ad13cec77) | `pidgin: 2.14.8 -> 2.14.10`                                                       |
| [`99872acd`](https://github.com/NixOS/nixpkgs/commit/99872acdebe5a7799b8e02b9cbeaa3e078a79b8f) | `phoronix-test-suite: 10.8.2 -> 10.8.4`                                           |
| [`82edfabb`](https://github.com/NixOS/nixpkgs/commit/82edfabb2909f52949584a94d4577531d25287d3) | `nss_wrapper: 1.1.11 -> 1.1.12`                                                   |
| [`62b02108`](https://github.com/NixOS/nixpkgs/commit/62b02108c34fad993b970174b7c80929ad4e5b6a) | `libmysqlconnectorcpp: 8.0.28 -> 8.0.29`                                          |
| [`a043195d`](https://github.com/NixOS/nixpkgs/commit/a043195d2cf8c16dd78182577e32a9bb4c0370f9) | `jruby: mark as sourceProvenance binaryBytecode`                                  |
| [`735450e1`](https://github.com/NixOS/nixpkgs/commit/735450e173f8e532d21e4e81ea377b40b04970ac) | `gnomeExtensions.arcmenu: 30 -> 35`                                               |
| [`79d65a88`](https://github.com/NixOS/nixpkgs/commit/79d65a8851703f2111df9ea95632c68e7ac6dab4) | `bind: 9.18.4 -> 9.18.5`                                                          |
| [`f7c4f709`](https://github.com/NixOS/nixpkgs/commit/f7c4f709fd08543705f95b60bc6d0ec77314a649) | `mark: 8.0 -> 8.3`                                                                |