### PR TITLE
chore(flake/nixpkgs): `af9e0007` -> `762b0033`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660574513,
-        "narHash": "sha256-nkMQ1TKIIAYIVbbUzjxfjPn3H1zZFW20TrHUFAjwvNU=",
+        "lastModified": 1660646295,
+        "narHash": "sha256-V4G+egGRc3elXPTr7QLJ7r7yrYed0areIKDiIAlMLC8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af9e00071d0971eb292fd5abef334e66eda3cb69",
+        "rev": "762b003329510ea855b4097a37511eb19c7077f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                  |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`b03fb171`](https://github.com/NixOS/nixpkgs/commit/b03fb171e8c9a5268fad8e8dc1130682a80a4019) | `unifi7: 7.1.68 -> 7.2.92`                                                      |
| [`e326bc9b`](https://github.com/NixOS/nixpkgs/commit/e326bc9b3f7d7ffa45ab0b71e2fdbecb71d2ed6b) | `signalbackup-tools: 20220711 -> 20220810 (#185963)`                            |
| [`6bc8523e`](https://github.com/NixOS/nixpkgs/commit/6bc8523e85262862f969fb29d541123238b781e7) | `messagelib: use older cmake for now`                                           |
| [`8334328f`](https://github.com/NixOS/nixpkgs/commit/8334328f11ef140f5915cf974e4608649525d8cf) | `cmake_3_23: bring this version back (temporarily, I hope)`                     |
| [`5fc1769d`](https://github.com/NixOS/nixpkgs/commit/5fc1769d14bb3b6e738af2d821cd5856c8a658f4) | `rancher: 2.6.5 -> 2.6.7`                                                       |
| [`86beff8c`](https://github.com/NixOS/nixpkgs/commit/86beff8c1e2c29c252448c9d3e3e0a60fd027c3f) | ``kubernetes-helm: use `src.rev```                                              |
| [`b525a228`](https://github.com/NixOS/nixpkgs/commit/b525a2289dbf4a257eac450ccdba63fee4e834cf) | `kubernetes-helm: 3.9.1 -> 3.9.3`                                               |
| [`8d2fd875`](https://github.com/NixOS/nixpkgs/commit/8d2fd875b789a34b1e27f335df93a51d9c6cd576) | `nixos/test/systemd-machinectl: Add auto-start test`                            |
| [`c6103264`](https://github.com/NixOS/nixpkgs/commit/c6103264a196bc53ed092b551c74bedf73790035) | `python310Packages.types-dateutil: 2.8.18 -> 2.8.19`                            |
| [`3e96a3f6`](https://github.com/NixOS/nixpkgs/commit/3e96a3f6b9460eade50777eba679adab6e09c79b) | `didyoumean: 1.1.0 -> 1.1.3`                                                    |
| [`2ede2cbc`](https://github.com/NixOS/nixpkgs/commit/2ede2cbc2109b98e2bd5428f6687986de2adcc93) | `epick: fix build`                                                              |
| [`a4f6ea89`](https://github.com/NixOS/nixpkgs/commit/a4f6ea89947e087d570b81bbce66f3107cd29b0c) | `qt6.qtwebengine: fix build`                                                    |
| [`2c3f6055`](https://github.com/NixOS/nixpkgs/commit/2c3f6055fbaec233ff46447cff526e4443aace02) | `syncoid: handle syncing dataset without a parent`                              |
| [`a948fb27`](https://github.com/NixOS/nixpkgs/commit/a948fb27371e50da1036df679cbebf5b23a66f2a) | `universal-ctags: 5.9.20220710.0 -> 5.9.20220814.0`                             |
| [`1142380b`](https://github.com/NixOS/nixpkgs/commit/1142380b3f20ab82558f2e5a6279749906adbe8b) | `python3.pkgs.pymanopt: add pre and post check`                                 |
| [`7afc6dc7`](https://github.com/NixOS/nixpkgs/commit/7afc6dc7bed1e97ef803989bd847a97c3e0f25cc) | `pymanopt: fix build`                                                           |
| [`8da0cb8c`](https://github.com/NixOS/nixpkgs/commit/8da0cb8c1c012f68efc46f35edbc418a8864c337) | `rustcat: 2.0.0 -> 3.0.0`                                                       |
| [`3e26073b`](https://github.com/NixOS/nixpkgs/commit/3e26073b69e3efb06254521a8d501dcca16156d8) | `refinery-cli: 0.8.5 -> 0.8.6`                                                  |
| [`09cb3b8f`](https://github.com/NixOS/nixpkgs/commit/09cb3b8fc07438dd9e7fbb908e5951a1bdc6a2f9) | `gopls: 0.9.3 -> 0.9.4`                                                         |
| [`a92aae64`](https://github.com/NixOS/nixpkgs/commit/a92aae643e5b822d9b3e2dbde70f1f9cad2ade68) | `netdata: 1.36.0 -> 1.36.1`                                                     |
| [`2f2c8966`](https://github.com/NixOS/nixpkgs/commit/2f2c8966d3c8f971950bc849d290a902e5279401) | `pantheon.switchboard-plug-pantheon-shell: 6.2.0 -> 6.3.0`                      |
| [`38f9a57c`](https://github.com/NixOS/nixpkgs/commit/38f9a57c3b3fe2e50da3175fd98e545e27b3ac0e) | `osm2pgsql: 1.6.0 → 1.7.0`                                                      |
| [`3ec310d5`](https://github.com/NixOS/nixpkgs/commit/3ec310d5201fb231b1626787e203165441f0705d) | `micro: fix syntax highlighting`                                                |
| [`dc2d94a3`](https://github.com/NixOS/nixpkgs/commit/dc2d94a32999357566857a05f29bd6c544116431) | `python310Packages.python-gitlab: 3.6.0 -> 3.8.1`                               |
| [`b4745995`](https://github.com/NixOS/nixpkgs/commit/b474599529b4572e0e07088e15e6e7818231a9f1) | `nomad: default to nomad_1_3, add to release notes`                             |
| [`07730a7b`](https://github.com/NixOS/nixpkgs/commit/07730a7b4992a3c7e1b637cc24bb5fbc47b6bad8) | `nomad_1_3: 1.3.2 -> 1.3.3`                                                     |
| [`8138a92a`](https://github.com/NixOS/nixpkgs/commit/8138a92a2af2b5071e8d2b8e5e066dd4f7c10dbf) | `clusterctl: 1.2.0 -> 1.2.1`                                                    |
| [`96e643e8`](https://github.com/NixOS/nixpkgs/commit/96e643e8d6f6368cee969dc523b517ac53b6c723) | `python310Packages.pyathena: 2.13.0 -> 2.14.0`                                  |
| [`22775563`](https://github.com/NixOS/nixpkgs/commit/2277556362e175af2715062a9a17170fb2ae8984) | `capnproto: add optional deps, cleanup cmakeFlags`                              |
| [`a1e1e5b2`](https://github.com/NixOS/nixpkgs/commit/a1e1e5b2a7115454e50751fbbe6382addf232b95) | `lunatic: fix hydra build`                                                      |
| [`a8b05f0e`](https://github.com/NixOS/nixpkgs/commit/a8b05f0e61a7b80a87c4473cd6bdb7cf62216e38) | `Revert "mullvad-vpn: 2022.2 -> 2022.3"`                                        |
| [`c667ead4`](https://github.com/NixOS/nixpkgs/commit/c667ead423b7d2a3130400f9f6c248068992812a) | `python310Packages.time-machine: 2.7.1 -> 2.8.0`                                |
| [`6a4213ff`](https://github.com/NixOS/nixpkgs/commit/6a4213ff8cff1b23455d47e8390482397d2988e6) | `latex2html: 2022 -> 2022.2`                                                    |
| [`8069c9c8`](https://github.com/NixOS/nixpkgs/commit/8069c9c802832adea30ca020e3aef6f750772753) | `python310Packages.peaqevcore: 5.1.3 -> 5.2.0`                                  |
| [`928eb9fc`](https://github.com/NixOS/nixpkgs/commit/928eb9fc0b1ffee6d1a2facc8b97467aec66c473) | ` starship: 1.10.0 -> 1.10.1`                                                   |
| [`09d5adcc`](https://github.com/NixOS/nixpkgs/commit/09d5adccb75b151a1bee0bce7b8bfc9d3c832bca) | `python310Packages.weconnect-mqtt: 0.39.0 -> 0.39.1`                            |
| [`fddb4533`](https://github.com/NixOS/nixpkgs/commit/fddb453352f20ffddd3fce75a3da04682d5a25ff) | `patchelfUnstable: unstable-2022-02-21 -> unstable-2022-07-16`                  |
| [`cf87c044`](https://github.com/NixOS/nixpkgs/commit/cf87c044567f3a3a030a4dd6a3f31f5d6414b115) | ``radicle-cli: correct license to `gpl3Plus```                                  |
| [`b6dad2af`](https://github.com/NixOS/nixpkgs/commit/b6dad2afe6684c6db2b33d7a5b0191eff2a2a5a4) | `moq: init at 0.2.7`                                                            |
| [`785ca266`](https://github.com/NixOS/nixpkgs/commit/785ca266b69a4aa343fe67c9255d178203557023) | `libbluray: fix build failure on 1.3.1 with java`                               |
| [`99bc6920`](https://github.com/NixOS/nixpkgs/commit/99bc6920c216d97434ba358395f20d0512cc936b) | `proxysql: 2.3.2 -> 2.4.3`                                                      |
| [`d8039076`](https://github.com/NixOS/nixpkgs/commit/d8039076287525f47d8b4ec4105d2fd363badfc7) | `python310Packages.aiohomekit: 1.2.10 -> 1.2.11`                                |
| [`212c683d`](https://github.com/NixOS/nixpkgs/commit/212c683dee102fa3b56cacd0e0d8aa171bbc0b86) | `jira-cli-go: 1.0.0 -> 1.1.0`                                                   |
| [`5e502ceb`](https://github.com/NixOS/nixpkgs/commit/5e502ceb4f0c1e8f22e7f0ce0b24601f955ab842) | `theharvester: 4.0.3 -> 4.2.0`                                                  |
| [`786f72c3`](https://github.com/NixOS/nixpkgs/commit/786f72c32e2a05528ae546ce48da2db2dc7facce) | ``nixos/github-runner: start `Runner.Listener` directly in `ExecStart=```       |
| [`006d9d2d`](https://github.com/NixOS/nixpkgs/commit/006d9d2dfbc192257890f7d85c129f40b631b34f) | `release-notes: add github-runner support for PAT and ephemeral`                |
| [`987a4b42`](https://github.com/NixOS/nixpkgs/commit/987a4b42317a52426d25357bc98b5f97b4082cb2) | `nixos/github-runner: add support for ephemeral runners`                        |
| [`3f075e5b`](https://github.com/NixOS/nixpkgs/commit/3f075e5bb1ea2e74923b43a2203123fbd1514535) | `nixos/github-runner: add PAT support`                                          |
| [`65542a63`](https://github.com/NixOS/nixpkgs/commit/65542a6348b50d62198a1a992723cdd6dbaaa137) | ``nixos/github-runner: use state instead of runtime dir as `RUNNER_ROOT```      |
| [`e2dd5729`](https://github.com/NixOS/nixpkgs/commit/e2dd5729e03c178f0f3713bd0ce6054b0050af07) | `python310Packages.google-cloud-access-context-manager: 0.1.13 -> 0.1.14`       |
| [`e2329a87`](https://github.com/NixOS/nixpkgs/commit/e2329a8786bfb2ff8318325278980ac71b7f8b69) | `python310Packages.bleak-retry-connector: 1.7.2 -> 1.8.0`                       |
| [`73216024`](https://github.com/NixOS/nixpkgs/commit/73216024d1669bedfd5e41371ead35ec97c043a5) | `dex-oidc: 2.32.0 -> 2.33.0 (#186589)`                                          |
| [`dbf97a4f`](https://github.com/NixOS/nixpkgs/commit/dbf97a4f55844aab09ec0fb5f0ae315611ee3fe4) | `kubelogin-oidc: 1.25.1 -> 1.25.2 (#186641)`                                    |
| [`50500713`](https://github.com/NixOS/nixpkgs/commit/50500713c37b40c570cd6a8cefcda713d5e43688) | `python310Packages.flask-jwt-extended: 4.4.2 -> 4.4.4`                          |
| [`3b1f5eab`](https://github.com/NixOS/nixpkgs/commit/3b1f5eab31b33fb1621ba7823317990951bf45e6) | `firefox: add application actions to .desktop file`                             |
| [`b6fcfe82`](https://github.com/NixOS/nixpkgs/commit/b6fcfe826ce875696066b68649b88d8e9467686c) | `listmonk: init at 2.2.0`                                                       |
| [`4fb53a56`](https://github.com/NixOS/nixpkgs/commit/4fb53a5647b71266107020d6a9cdb84e01d87ff0) | `python310Packages.iminuit: 2.13.0 -> 2.15.2`                                   |
| [`8f72f03e`](https://github.com/NixOS/nixpkgs/commit/8f72f03e07173fcdfad861e67c2fc6e19873d76b) | `werf: 1.2.153 -> 1.2.154`                                                      |
| [`e2115fec`](https://github.com/NixOS/nixpkgs/commit/e2115fec63d7dab7e333ccc01768f0444ea61aad) | `gnomeExtensions: auto-update`                                                  |
| [`37ef4030`](https://github.com/NixOS/nixpkgs/commit/37ef4030062204ca0ba1bfd316f18d773aacc789) | `python3Packages.ibis-framework: 3.0.2 -> 3.1.0`                                |
| [`27e6c747`](https://github.com/NixOS/nixpkgs/commit/27e6c7477b4069023c00518cb939dbfd5d7edfeb) | `neovide: 0.10.0 -> 0.10.1`                                                     |
| [`ea677891`](https://github.com/NixOS/nixpkgs/commit/ea677891fd18d793cd76280e85c4753637a00245) | `nali: 0.5.0 -> 0.5.3`                                                          |
| [`1e00dcc8`](https://github.com/NixOS/nixpkgs/commit/1e00dcc8f03d18ceb5abda3380befa7efca74dad) | `mozjpeg: 4.0.3 -> 4.1.1`                                                       |
| [`ff1dce12`](https://github.com/NixOS/nixpkgs/commit/ff1dce127b2a2f98beeeb81199e649f18a48ff37) | `monolith: 2.6.1 -> 2.6.2`                                                      |
| [`67272ce2`](https://github.com/NixOS/nixpkgs/commit/67272ce26850f3137ea2b0115844287d48502726) | `xprintidle: 0.2.4 -> 0.2.5`                                                    |
| [`04d4ab51`](https://github.com/NixOS/nixpkgs/commit/04d4ab516f835d43012e404e033c842c9fa2029a) | `k4dirstat: 3.4.0 -> 3.4.2`                                                     |
| [`c3860d32`](https://github.com/NixOS/nixpkgs/commit/c3860d32dcb8cc5dbe589f04b2c801a1d12db489) | `folly: 2022.08.08.00 -> 2022.08.15.00`                                         |
| [`52dad0c5`](https://github.com/NixOS/nixpkgs/commit/52dad0c5bda1caae1a3fc03bba020635cbac390e) | `esbuild: 0.15.2 -> 0.15.3`                                                     |
| [`b75502a9`](https://github.com/NixOS/nixpkgs/commit/b75502a971f9ba28d1347990eb1f12636c54344d) | `maigret: ignore DeprecationWarning`                                            |
| [`53149fe1`](https://github.com/NixOS/nixpkgs/commit/53149fe1311fcd9aa2470b3376e39435875797cb) | `python310Packages.Wand: 0.6.9 -> 0.6.10`                                       |
| [`7001e052`](https://github.com/NixOS/nixpkgs/commit/7001e052e99e35e8d77272a361d3045402f167ce) | `ioccheck: fix build`                                                           |
| [`2ad332f6`](https://github.com/NixOS/nixpkgs/commit/2ad332f6250934c0cb4db49e7bd6fbd5b6dcfb85) | `ugrep: 3.9.0 -> 3.9.1`                                                         |
| [`f253ea72`](https://github.com/NixOS/nixpkgs/commit/f253ea7289d9beaa3fb8e72d3f99a2e5ca443977) | `headscale: 0.16.1 -> 0.16.2`                                                   |
| [`387f876b`](https://github.com/NixOS/nixpkgs/commit/387f876b2d1db0beba775fa6ac917aaeda4edd03) | `backblaze-b2: add tomhoule to maintainers`                                     |
| [`7aeffe56`](https://github.com/NixOS/nixpkgs/commit/7aeffe56b0ebb903dfd2711dc47f4f581238d9c4) | `backblaze-b2: 3.2.0 -> 3.5.0`                                                  |
| [`13203f81`](https://github.com/NixOS/nixpkgs/commit/13203f81c0c7c4ca9a04727fc1adfe1e16dffc95) | `python310Packages.genpy: 2021.1 -> 2022.1`                                     |
| [`7fcd6a54`](https://github.com/NixOS/nixpkgs/commit/7fcd6a542741b78d7bf3a0d521b83f717430bed2) | `python310Packages.mailsuite: 1.9.4 -> 1.9.5`                                   |
| [`dd05ebc5`](https://github.com/NixOS/nixpkgs/commit/dd05ebc58a2611b76e65552cd959a949b8ae4290) | `python310Packages.limnoria: 2022.6.23 -> 2022.8.7`                             |
| [`4ad43e6b`](https://github.com/NixOS/nixpkgs/commit/4ad43e6b4712a6620453c9d1aecf17a628571db5) | `python3Packages.stim: init at 1.9.0`                                           |
| [`219c2c79`](https://github.com/NixOS/nixpkgs/commit/219c2c7942dc38e9d83f4e4bc708c185b4ecde31) | `prl-tools: 17.1.4-51567 -> 18.0.0-53049`                                       |
| [`08e9805a`](https://github.com/NixOS/nixpkgs/commit/08e9805a36264312f793cb99bcae3871d4a51388) | `tilt: 0.30.6 -> 0.30.7`                                                        |
| [`9afb8af2`](https://github.com/NixOS/nixpkgs/commit/9afb8af2525f395faa73f3402516831f03011db8) | `python3Packages.cattrs: fix build by upstreamed patch`                         |
| [`44a7c41b`](https://github.com/NixOS/nixpkgs/commit/44a7c41b57a5d4f0208baba466f30d66c1e0008a) | `geeqie: 1.7.3 -> 2.0.1`                                                        |
| [`c37112d2`](https://github.com/NixOS/nixpkgs/commit/c37112d2d017bec5556fc2b12aa394aaca356958) | `messer-slim: 3.7.1 -> 4.0`                                                     |
| [`ef5c9a32`](https://github.com/NixOS/nixpkgs/commit/ef5c9a329db7ac3dab78a52d01dbc17c94a2eab3) | `zim: 0.74.2 -> 0.74.3`                                                         |
| [`8a40257c`](https://github.com/NixOS/nixpkgs/commit/8a40257c734bbeb3199c89d9e3c43ccd99703e1d) | `gcl_2_6_13_pre: 2.6.13pre50 -> 2.6.13pre124 (fix build)`                       |
| [`8650da69`](https://github.com/NixOS/nixpkgs/commit/8650da694bd505c8e6d46dd60f8a4289fe204484) | `kubie: 0.17.2 -> 0.18.0`                                                       |
| [`4e868821`](https://github.com/NixOS/nixpkgs/commit/4e8688215ff5ef090fddbe63b9b8b365a707c6bf) | `kubernetes-controller-tools: 0.8.0 -> 0.9.2`                                   |
| [`32733dc5`](https://github.com/NixOS/nixpkgs/commit/32733dc51e67cd750a7d90188cb8b89a6f8cbbb0) | `google-guest-agent: 20220104.00 -> 20220713.00`                                |
| [`a3cdf49d`](https://github.com/NixOS/nixpkgs/commit/a3cdf49dbf5483656a22e5f7481892022b59e577) | `ppsspp: add SDL and headless`                                                  |
| [`6dc3ef5e`](https://github.com/NixOS/nixpkgs/commit/6dc3ef5e1a99bdb9a1bb0f5136b67fadab92c122) | `php8*: disable PCRE2 JIT SEAlloc to avoid crashes`                             |
| [`7153a7ca`](https://github.com/NixOS/nixpkgs/commit/7153a7caca4e40e43e58755a3a9c11cc48747dd2) | `backward-cpp: 1.3 -> 1.6`                                                      |
| [`83519fe9`](https://github.com/NixOS/nixpkgs/commit/83519fe97684e52bac2a82c2457ed934bff2dfb0) | `iosevka: fix build`                                                            |
| [`b518a7d8`](https://github.com/NixOS/nixpkgs/commit/b518a7d877a52a78d4411026538718daf72f2b38) | `python310Packages.loguru: fix failing tests`                                   |
| [`1c395dba`](https://github.com/NixOS/nixpkgs/commit/1c395dbabe0bef15698c10959b82752f29facbdf) | `zynaddsubfx: 3.0.5 → 3.0.6`                                                    |
| [`6aff16d2`](https://github.com/NixOS/nixpkgs/commit/6aff16d259f1773c27f83a3e151987fe50a9626d) | `cage: fix cross`                                                               |
| [`938ea3de`](https://github.com/NixOS/nixpkgs/commit/938ea3de88533910e50355b82ab185d8e7d47ecb) | `libbluray: fix broken BDJ patch`                                               |
| [`cedffc07`](https://github.com/NixOS/nixpkgs/commit/cedffc07f545c6556394511f775b6b612ba2f986) | `mpvScripts.thumbnail: switch to maintained fork, unstable-2020-01-16 -> 0.4.9` |
| [`6f67f850`](https://github.com/NixOS/nixpkgs/commit/6f67f8505181672ac2e29af6e8ef8763f63ada54) | `python3Packages.univers: init at 30.7.0`                                       |
| [`e777ee8b`](https://github.com/NixOS/nixpkgs/commit/e777ee8b0f1e85da66fd79284bf3001b88571d29) | `perlPackages.Sereal: 4.018 -> 4.025`                                           |
| [`21e025e1`](https://github.com/NixOS/nixpkgs/commit/21e025e18d36c7f3b46d53e2e76db84b57711679) | `perlPackages.SerealEncoder: 4.018 -> 4.025`                                    |
| [`cab3b516`](https://github.com/NixOS/nixpkgs/commit/cab3b5169adc13ffd02aaa31020e8c40971f7ef3) | `perlPackages.SerealDecoder: 4.018 -> 4.025`                                    |
| [`fe082eac`](https://github.com/NixOS/nixpkgs/commit/fe082eacee0dbf110b142f104b63a38ff630b545) | `perlPackages.CpanelJSONXS: 4.25 -> 4.31`                                       |
| [`7a48520c`](https://github.com/NixOS/nixpkgs/commit/7a48520c7bf50e59af492c39eda01d4939bd058b) | `perlPackages.ScopeUpper: 0.32 -> 0.33`                                         |
| [`676ff15d`](https://github.com/NixOS/nixpkgs/commit/676ff15d5a3e11b3634cf60e9ab22fa03db4b856) | `perlPackages.CryptX: 0.069 -> 0.076`                                           |
| [`00f0d306`](https://github.com/NixOS/nixpkgs/commit/00f0d306d42e18aa082dbc5a93921c084dd6171d) | `perlPackages.Encode: 3.08 -> 3.19`                                             |
| [`894f16c3`](https://github.com/NixOS/nixpkgs/commit/894f16c36e50ab4cc7f0ee52109b72e1f85b46a2) | `prometheus-pihole-exporter: 0.2.0 -> 0.3.0`                                    |
| [`8f9ef1c3`](https://github.com/NixOS/nixpkgs/commit/8f9ef1c30eb211a7cee99b8621d6cff4980fbd79) | `headscale: fix tls challengeType enum possible values`                         |
| [`fad97868`](https://github.com/NixOS/nixpkgs/commit/fad978682576b329cd79063c08157542eb5bc0d4) | `python3Packages.ipython: patch test after python update`                       |
| [`433dcfc2`](https://github.com/NixOS/nixpkgs/commit/433dcfc215d8d99cce265441a94c9fa99d60ed43) | `iosevka-bin: 15.6.1 -> 15.6.3`                                                 |
| [`4cbdad20`](https://github.com/NixOS/nixpkgs/commit/4cbdad20ee3661cfffab491aa48cf06519da3520) | `iosevka: 15.5.2 -> 15.6.3`                                                     |
| [`2ea1a7a7`](https://github.com/NixOS/nixpkgs/commit/2ea1a7a7c953efd0c6bf01df99ee6ade4c88980f) | `rr: 5.5.0 -> 5.6.0`                                                            |
| [`9fce7523`](https://github.com/NixOS/nixpkgs/commit/9fce752330987d73a304b9fbf3759aced9e41d0d) | `texstudio: 4.2.3 -> 4.3.0`                                                     |
| [`c49c7a94`](https://github.com/NixOS/nixpkgs/commit/c49c7a94954dc7c361e88075a919cc2d2371264c) | `python3Packages.uvloop: disable hanging test`                                  |
| [`ea345cd9`](https://github.com/NixOS/nixpkgs/commit/ea345cd9bc31843585a9dd3b63dbf878bb66fc5c) | `python3Packages.eventlet: disable failing test`                                |
| [`22c9c6cb`](https://github.com/NixOS/nixpkgs/commit/22c9c6cb712e42a36bc00cb562e5bb866a866858) | `unbound: add comment clarifying unbound's python support`                      |
| [`62e6c1a5`](https://github.com/NixOS/nixpkgs/commit/62e6c1a561ec39ca23145f25263a5f86aad727da) | `unbound: add gnutls to passthru.tests`                                         |
| [`9d8e6c29`](https://github.com/NixOS/nixpkgs/commit/9d8e6c29d2fb517e05d5b14f3c758f8e59e66356) | `python3Packages.pyunbound: inherit patches from unbound if present`            |