### PR TITLE
chore(flake/nixpkgs): `762b0033` -> `8ea014ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660646295,
-        "narHash": "sha256-V4G+egGRc3elXPTr7QLJ7r7yrYed0areIKDiIAlMLC8=",
+        "lastModified": 1660819943,
+        "narHash": "sha256-TRZV/mlW1eYuojqDC3ueYWj7jsTKXJCtyMLNYX/Ybtw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "762b003329510ea855b4097a37511eb19c7077f0",
+        "rev": "8ea014acc33da95ea56c902229957d8225005163",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                        |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`69ce8a09`](https://github.com/NixOS/nixpkgs/commit/69ce8a09493860112ed0447023418a82132977f0) | `mc, pkgsCross.ppc64.mc: fixx cross-build by adding PERL_FOR_BUILD`   |
| [`5f06e7ac`](https://github.com/NixOS/nixpkgs/commit/5f06e7ac034a2bebcbd625c55af2bb1839b90fd1) | `libportal: update patches`                                           |
| [`4789b923`](https://github.com/NixOS/nixpkgs/commit/4789b92366957e910e9c1e654d2e7a964b0a7cc4) | `linux/hardened/patches/5.4: 5.4.208-hardened1 -> 5.4.210-hardened1`  |
| [`7413d509`](https://github.com/NixOS/nixpkgs/commit/7413d509cd3821ebc211645800e4e45b0ddf7a28) | `linux: 5.19.1 -> 5.19.2`                                             |
| [`636c6b3f`](https://github.com/NixOS/nixpkgs/commit/636c6b3fade74cbf9fdf66f6bebcd62930a89a64) | `linux: 5.18.17 -> 5.18.18`                                           |
| [`7aeb316e`](https://github.com/NixOS/nixpkgs/commit/7aeb316e7e6884aa4aa4291106f775fd07ab0598) | `linux: 5.15.60 -> 5.15.61`                                           |
| [`19b9cb7c`](https://github.com/NixOS/nixpkgs/commit/19b9cb7ce0ee247cc390a020e4d5c4458c5a706c) | `lldpd: 1.0.14 -> 1.0.15`                                             |
| [`e54bfd3e`](https://github.com/NixOS/nixpkgs/commit/e54bfd3ed3159bfccdec20356d6b25889f572628) | `coqPackages.coq-record-update: 0.3.0 → 0.3.1`                        |
| [`8be789f7`](https://github.com/NixOS/nixpkgs/commit/8be789f7f121f140a86cfe7e3d28983835fee6a0) | `checkSSLCert: 2.36.0 -> 2.37.0`                                      |
| [`994890bf`](https://github.com/NixOS/nixpkgs/commit/994890bfe6b4da65ad2670fa780527d478d14c70) | `tempo: 1.4.1 -> 1.5.0`                                               |
| [`1f6892c3`](https://github.com/NixOS/nixpkgs/commit/1f6892c38ab5a5f08d224cc42cd667cbb921ca51) | `python310Packages.papermill:  add pythonImportsCheck`                |
| [`ec8d3bc3`](https://github.com/NixOS/nixpkgs/commit/ec8d3bc39b8c9b805a15ded2ce2b5e153d0736fe) | `ocamlPackages.crunch: 3.1.0 → 3.3.1`                                 |
| [`a06e854f`](https://github.com/NixOS/nixpkgs/commit/a06e854f239c0cafc9e35cdaa233568fb3affeab) | `ocamlPackages.cmdliner_1_1: disable for OCaml < 4.08`                |
| [`d2a0defa`](https://github.com/NixOS/nixpkgs/commit/d2a0defa04d490db7c0cd0c72448ef5273b1093d) | `ungoogled-chromium: 104.0.5112.81 -> 104.0.5112.102`                 |
| [`198a940c`](https://github.com/NixOS/nixpkgs/commit/198a940c6190da94acdbe5c7f4ba2b8c6ee98748) | `glibc: add a few TODOs aroung libgcc_s.so hack`                      |
| [`1c66729c`](https://github.com/NixOS/nixpkgs/commit/1c66729c007789e54478322e0c98f0361b93281b) | `pax-utils: fix cross-compilation (missing native C compiler)`        |
| [`da87f771`](https://github.com/NixOS/nixpkgs/commit/da87f771027c5fe2db7d93d4e56197849236dc5a) | `cbmc: init at 5.63.0`                                                |
| [`a6d96a70`](https://github.com/NixOS/nixpkgs/commit/a6d96a709a1d0c64e361ae6a824ec4f62c426ad5) | `python310Packages.qcengine: 0.24.0 -> 0.24.1`                        |
| [`7ce46dd7`](https://github.com/NixOS/nixpkgs/commit/7ce46dd74dc7bd2b6ba6619eaa8bdc5e1da9e79c) | `python310Packages.pysma: 0.6.11 -> 0.6.12`                           |
| [`bcd52eca`](https://github.com/NixOS/nixpkgs/commit/bcd52ecae0bdffba406ef9d18ec0451c1a687492) | `python310Packages.pymavlink: 2.4.31 -> 2.4.34`                       |
| [`44b1a399`](https://github.com/NixOS/nixpkgs/commit/44b1a399b1180327e7a8035c1d2051ad32eaead2) | `python310Packages.pypoolstation: 0.4.8 -> 0.4.9`                     |
| [`a1c20c10`](https://github.com/NixOS/nixpkgs/commit/a1c20c103503389bc1cc3c8e2c1ff6feb84080ab) | `python310Packages.peaqevcore: 5.2.0 -> 5.4.3`                        |
| [`802ea456`](https://github.com/NixOS/nixpkgs/commit/802ea456991723a936e302b91d004345482b569a) | `janet: 1.23.0 -> 1.24.0`                                             |
| [`12e34e00`](https://github.com/NixOS/nixpkgs/commit/12e34e003f6bf50868740113b40806659a7b0dbe) | `libzip: 1.8.0 -> 1.9.2`                                              |
| [`90c6f12f`](https://github.com/NixOS/nixpkgs/commit/90c6f12f46168866cf7d9ee1a37dbace28a200b4) | `python310Packages.papermill: 2.3.4 -> 2.4.0`                         |
| [`3e43b5e4`](https://github.com/NixOS/nixpkgs/commit/3e43b5e4bc1d80da0a39bf0155357d9bd4495cae) | `python310Packages.pymupdf: 1.20.1 -> 1.20.2`                         |
| [`4db63c2d`](https://github.com/NixOS/nixpkgs/commit/4db63c2da16c9bac08d42f993d9fc8cc05f6705c) | `zellij: 0.31.1 -> 0.31.2`                                            |
| [`ee0fedf7`](https://github.com/NixOS/nixpkgs/commit/ee0fedf7c2b8197ff39eab858ec721d4f6e084cb) | `python310Packages.hahomematic: 2022.8.9 -> 2022.8.10`                |
| [`42ca2379`](https://github.com/NixOS/nixpkgs/commit/42ca2379ba38a09bd740ae2fad7d95d32b907c35) | `python310Packages.hahomematic: 2022.8.8 -> 2022.8.9`                 |
| [`d17a7fb1`](https://github.com/NixOS/nixpkgs/commit/d17a7fb13de9ffb9b220ec65e3b311b94682f519) | `python310Packages.hahomematic: 2022.8.7 -> 2022.8.8`                 |
| [`2e8dc051`](https://github.com/NixOS/nixpkgs/commit/2e8dc051ebd58ca27c4f3e429bc1eaa4c3e6c347) | `python310Packages.iminuit: 2.15.2 -> 2.16.0`                         |
| [`f766110c`](https://github.com/NixOS/nixpkgs/commit/f766110c2058332247d38ef4bec6bf4da35bbd20) | `python310Packages.hcloud: 1.17.0 -> 1.18.0`                          |
| [`59888d22`](https://github.com/NixOS/nixpkgs/commit/59888d2218772b7bfde2929be29e586de418beb5) | `build-fhs-userenv-bubblewrap: fix eval`                              |
| [`bdf889ce`](https://github.com/NixOS/nixpkgs/commit/bdf889ce6daadb9425157351b7927ae380062857) | `libjaylink: 0.2.0 -> 0.3.0`                                          |
| [`bab6fd31`](https://github.com/NixOS/nixpkgs/commit/bab6fd31cddf59760c86a620124fe064ef43fea3) | `cvise: drop tests broken by pytest-flake8 update`                    |
| [`881512e2`](https://github.com/NixOS/nixpkgs/commit/881512e23f51f0c00f5adb58788998aca65ebea3) | `x11: Source .profile and .xprofile`                                  |
| [`d3e5bd02`](https://github.com/NixOS/nixpkgs/commit/d3e5bd022862cc1bcae505ddf746531269d51dd4) | `nixos: Don't enable packagekit by default`                           |
| [`d61d4e71`](https://github.com/NixOS/nixpkgs/commit/d61d4e71ba9a8f56e9f2092b7cfa9cffa4253971) | `mupdf: 1.19.0 -> 1.20.3`                                             |
| [`96021cfb`](https://github.com/NixOS/nixpkgs/commit/96021cfb7198217b49aca8f7d342deb2df55dee6) | `spacebar: 1.2.1 -> 1.4.0`                                            |
| [`f0f76224`](https://github.com/NixOS/nixpkgs/commit/f0f76224f47976f49fa591523e6e395a3445f29f) | `drop commit text`                                                    |
| [`8e35fb01`](https://github.com/NixOS/nixpkgs/commit/8e35fb01ab30474be53e2b269f0e3a19113cb7f2) | `msmtp: 1.8.20 -> 1.8.22`                                             |
| [`3b2da12a`](https://github.com/NixOS/nixpkgs/commit/3b2da12acb516d8c892385bf641f415964286b6f) | `minio-certgen: 1.2.0 -> 1.2.1`                                       |
| [`9bb0d53a`](https://github.com/NixOS/nixpkgs/commit/9bb0d53a4a2a3b38ee17ea84f584772b736f7688) | `alt-ergo: 2.4.1 → 2.4.2`                                             |
| [`2e1e0b51`](https://github.com/NixOS/nixpkgs/commit/2e1e0b51c28d62b2454906406bd60abdb9c9b1a9) | `obs-studio-plugins.obs-vkcapture: 1.1.5 -> 1.1.6`                    |
| [`c68e496f`](https://github.com/NixOS/nixpkgs/commit/c68e496f8e21d71e8613be1e4f354854006e3228) | `python310Packages.angr: 9.2.13 -> 9.2.14`                            |
| [`e094abb0`](https://github.com/NixOS/nixpkgs/commit/e094abb0023c858438f460be2479294fea7cbf9d) | `python310Packages.cle: 9.2.13 -> 9.2.14`                             |
| [`b324a8a0`](https://github.com/NixOS/nixpkgs/commit/b324a8a0ccc7ea4e5365dc7c544c6a7cdfebea87) | `python310Packages.claripy: 9.2.13 -> 9.2.14`                         |
| [`e7e8cbff`](https://github.com/NixOS/nixpkgs/commit/e7e8cbffebdbf3beac09df540e14ec787d9845c0) | `python310Packages.pyvex: 9.2.13 -> 9.2.14`                           |
| [`d9e7c010`](https://github.com/NixOS/nixpkgs/commit/d9e7c010510b4f1084fc9ca4a067717b37a9c8e3) | `python310Packages.ailment: 9.2.13 -> 9.2.14`                         |
| [`435d3c17`](https://github.com/NixOS/nixpkgs/commit/435d3c17ed4031070ef4b804e403d926a795e62e) | `python310Packages.archinfo: 9.2.13 -> 9.2.14`                        |
| [`fe5e97d2`](https://github.com/NixOS/nixpkgs/commit/fe5e97d2b8b45f4aa240c9b9e1fbfa70b35f1341) | `dnstwist: 20220131 -> 20220815`                                      |
| [`9e773ac1`](https://github.com/NixOS/nixpkgs/commit/9e773ac11fcab22a8ce17cf967a15f3d576ef7b6) | `nuclei: 2.7.5 -> 2.7.6`                                              |
| [`45e6c607`](https://github.com/NixOS/nixpkgs/commit/45e6c607d6fe601905354cb743e6070265b9dde8) | `nvidia_x11: add conditional overrides`                               |
| [`d58caed4`](https://github.com/NixOS/nixpkgs/commit/d58caed42b260ce54b33f7af517bef5cab25b1dc) | `n8n: 0.190.0 → 0.191.0`                                              |
| [`9184a681`](https://github.com/NixOS/nixpkgs/commit/9184a6819290cb164cd70d2a87d5e60fe7133c6f) | `libdnf: 0.67.0 -> 0.68.0`                                            |
| [`ab223b25`](https://github.com/NixOS/nixpkgs/commit/ab223b256df93eafc241568f8803abdd6cb66e63) | `coqPackages.coq-ext-lib: 0.11.6 → 0.11.7`                            |
| [`36af4fe4`](https://github.com/NixOS/nixpkgs/commit/36af4fe49e8a15db26461eb408cb9d9cb9a4adc6) | `python310Packages.jupyterlab-lsp: remove unused input`               |
| [`8d05ef51`](https://github.com/NixOS/nixpkgs/commit/8d05ef51d11dcaa32dc37e38c563674f579bbc5b) | `python310Packages.nbconvert: use mistune 2.x`                        |
| [`1c318448`](https://github.com/NixOS/nixpkgs/commit/1c318448a5713fa74e4b201c041b440ed50564d1) | `esphome: 2022.6.2 -> 2022.8.0`                                       |
| [`97bcc3a2`](https://github.com/NixOS/nixpkgs/commit/97bcc3a2e01a78539f16fc0e07fa1603937f7e5a) | `omnisharp-roslyn: 1.38.2 -> 1.39.1 (#182409)`                        |
| [`2ff9f7d1`](https://github.com/NixOS/nixpkgs/commit/2ff9f7d156c4bf24dc04127dc968547f5c155a4b) | `git-cliff: 0.8.1 -> 0.9.0`                                           |
| [`7d959092`](https://github.com/NixOS/nixpkgs/commit/7d959092b6905231a5e30b18271e1fded39fb7f3) | `gitleaks: 8.10.3 -> 8.11.0`                                          |
| [`d6bbf7d2`](https://github.com/NixOS/nixpkgs/commit/d6bbf7d2d15a2935d30e46a23e77acabd2c0668d) | `pynitrokey: 0.4.9 -> 0.4.26`                                         |
| [`f06e9ce0`](https://github.com/NixOS/nixpkgs/commit/f06e9ce0364fa0f8130d869d010fb598f434b902) | `python3Packages.spsdk: init at 1.6.3`                                |
| [`c400724f`](https://github.com/NixOS/nixpkgs/commit/c400724f94d0294ca285bcd63792fb81b886d0bf) | `python3Packages.oscrypto: patch ctypes call`                         |
| [`3820a027`](https://github.com/NixOS/nixpkgs/commit/3820a027141bb0623b86e23a172af64812839176) | `python3Packages.pypemicro: init at 0.1.9`                            |
| [`2e61922f`](https://github.com/NixOS/nixpkgs/commit/2e61922fc25591dc9ea475db6dd08288a149be5b) | `pyocd: init at 0.34.1`                                               |
| [`beeffa24`](https://github.com/NixOS/nixpkgs/commit/beeffa2453ecf81a0c76cd9daed6bad4e7198d83) | `python3Packages.hexdump: init at 3.3`                                |
| [`7a7f1ae4`](https://github.com/NixOS/nixpkgs/commit/7a7f1ae4540e4da505eb609dd9f95c018033ccc2) | `python3Packages.cmsis-pack-manager: init at 0.4.0`                   |
| [`45206b20`](https://github.com/NixOS/nixpkgs/commit/45206b2012c479f8fb73759b0f4d0d8740437c43) | `python3Packages.libusbsio: init`                                     |
| [`1a941b4b`](https://github.com/NixOS/nixpkgs/commit/1a941b4b5f4940d3082d3042c3c5b3add8333369) | `libusbsio: init at 2.1.11`                                           |
| [`af149e56`](https://github.com/NixOS/nixpkgs/commit/af149e56ef63d127c9beeb76f5fa2a01d7bf9cbb) | `python3Packages.bincopy: init at 17.10.2`                            |
| [`a2859007`](https://github.com/NixOS/nixpkgs/commit/a2859007976e49d5f7f60046cd483c39d1f6bb45) | `python3Packages.argparse_addons: init at 0.8.0`                      |
| [`a1bc7b4d`](https://github.com/NixOS/nixpkgs/commit/a1bc7b4dbe4f0f979d810e71b40e1ab6c1768d33) | `python310Packages.marshmallow-enum: don't use pytest-flake8`         |
| [`12163dff`](https://github.com/NixOS/nixpkgs/commit/12163dff9f6922a26ce2444755ca505088e959f6) | `vulnix: don't use pytest-flake8`                                     |
| [`19acadab`](https://github.com/NixOS/nixpkgs/commit/19acadab73869fab9db6a77fc68cb32438e0e250) | `python310Packages.openapi-schema-validator: don't use pytest-flake8` |
| [`47e7f78f`](https://github.com/NixOS/nixpkgs/commit/47e7f78fcb4eb96aedeee430a0c4922bdf61d751) | `python310Packages.pytest-flake8: 1.0.7 -> 1.1.1 and mark broken`     |
| [`b52e388c`](https://github.com/NixOS/nixpkgs/commit/b52e388cb3379a26ac459c46260b4a5710327219) | `python310Packages.flake8: 4.0.1 -> 5.0.4`                            |
| [`a6b0f5fa`](https://github.com/NixOS/nixpkgs/commit/a6b0f5faaa2ea543868af8e67e39960dc0c672f4) | `python310Packages.pylama: 8.3.8 -> 8.4.1`                            |
| [`6d3a1b00`](https://github.com/NixOS/nixpkgs/commit/6d3a1b00f6fc1ccb99dfac69ae8ca3073680a757) | `python310Packages.pycodestyle: 2.8.0 -> 2.9.1`                       |
| [`b2422f6a`](https://github.com/NixOS/nixpkgs/commit/b2422f6a3ab66bc0b7479e2f9a76f5317d73680d) | `python310Packages.pyflakes: 2.4.0 -> 2.5.0`                          |
| [`6ccc885f`](https://github.com/NixOS/nixpkgs/commit/6ccc885f06d513f7a91ca17ee1db3db1c0a2247b) | `vouch-proxy: 0.37.0 -> 0.37.3`                                       |
| [`7ed0a6f8`](https://github.com/NixOS/nixpkgs/commit/7ed0a6f85f4f86acd0fde7ba91f7cea4b9d7c0a9) | `ocamlPackages.graphql: 0.13.0 → 0.14.0`                              |
| [`96276600`](https://github.com/NixOS/nixpkgs/commit/962766009d79d151579d102efbecf2425a39fec8) | `grafana: 9.0.7 -> 9.1.0`                                             |
| [`cc4f3421`](https://github.com/NixOS/nixpkgs/commit/cc4f3421ad640228a24fcfa5fd4059e7c4f8c5df) | `home-assistant: add aiolifx-connection dependency`                   |
| [`372af7ed`](https://github.com/NixOS/nixpkgs/commit/372af7edf6b452928461ba9b4294ad735b9e7d9f) | `aiolifx-connection: init at 1.0.0`                                   |
| [`f3b982df`](https://github.com/NixOS/nixpkgs/commit/f3b982df76b368a5ad5f2bec4f0fb789e2f767d9) | `patchelf: drop patch due to version bump`                            |
| [`f4eec8f9`](https://github.com/NixOS/nixpkgs/commit/f4eec8f9ae4a6ee223019804175ccbc4d690cb5f) | `matrix-synapse: 1.64.0 -> 1.65.0`                                    |
| [`c7af7831`](https://github.com/NixOS/nixpkgs/commit/c7af7831338f90966115b7931fbd47fbf7f73c62) | `faas-cli: add git wrapper`                                           |
| [`9fa27cd4`](https://github.com/NixOS/nixpkgs/commit/9fa27cd43ef82ce8704cbf06356f9cc8010fe486) | `docker-buildx: 0.8.2 -> 0.9.0`                                       |
| [`ace5332d`](https://github.com/NixOS/nixpkgs/commit/ace5332dcb78675cf21d7219b1d628614be21697) | `buildah: drop GIT_COMMIT`                                            |
| [`03e32b70`](https://github.com/NixOS/nixpkgs/commit/03e32b7093afd6afd1cd63c54ae522328e453354) | `buildah: support build for darwin`                                   |
| [`e95f913c`](https://github.com/NixOS/nixpkgs/commit/e95f913cb1dec92df15180eef7cb34d5cc67d956) | `dolt: 0.40.25 -> 0.40.26`                                            |
| [`829d1993`](https://github.com/NixOS/nixpkgs/commit/829d19938cf6a3e5f05d53941dad25e40fc40320) | `cloud-nuke: 0.16.4 -> 0.17.0`                                        |
| [`04c14274`](https://github.com/NixOS/nixpkgs/commit/04c142749cce5f7bd13d9b09175e72ae2c6e35d8) | `wireless-regdb: 2022.06.06 -> 2022.08.12`                            |
| [`fb1a44c7`](https://github.com/NixOS/nixpkgs/commit/fb1a44c7804975fcd1020a59f4f3c2f343c9f64c) | `batsignal: 1.5.1 -> 1.6.0`                                           |
| [`817f5c4a`](https://github.com/NixOS/nixpkgs/commit/817f5c4a8a91264eb287591962db7e23c626568f) | `terraform-providers: update 2022-08-17`                              |
| [`50be8adf`](https://github.com/NixOS/nixpkgs/commit/50be8adfef2d6eb9a6996d451a307ac3b9073df9) | `terraform-providers.ncloud: remove`                                  |
| [`738dcf66`](https://github.com/NixOS/nixpkgs/commit/738dcf6608aa4860d9ef348a5a863d2d1310f413) | `terraform-providers.dome9: remove`                                   |
| [`c9af8982`](https://github.com/NixOS/nixpkgs/commit/c9af8982551f903e634084b35b2597c98beed0ab) | `dockerTools.buildImage: make VM memSize configurable`                |
| [`da9cf977`](https://github.com/NixOS/nixpkgs/commit/da9cf977b7d2c0ee780277d26664628a7c087712) | `onnxruntime: 1.10.0 -> 1.12.1`                                       |
| [`579237db`](https://github.com/NixOS/nixpkgs/commit/579237dbf5fa9722b204b62406d2e1a21516df51) | `onnxruntime: init at 1.10.0 (resurrected)`                           |
| [`953213ab`](https://github.com/NixOS/nixpkgs/commit/953213ab851f20c33c2e71e7cad13367ebc36d80) | `oneDDN: 2.3.2 -> 2.6.1`                                              |
| [`3c5c3ce1`](https://github.com/NixOS/nixpkgs/commit/3c5c3ce1aad4e3b7ec6c349718262e4d91b3af33) | `xcp: 0.9.0 -> 0.9.1`                                                 |
| [`1cd743eb`](https://github.com/NixOS/nixpkgs/commit/1cd743eb8ae80e746f101dddd5059fda7cfc8ff8) | `zotero: 6.0.10 -> 6.0.12`                                            |
| [`ab2905f4`](https://github.com/NixOS/nixpkgs/commit/ab2905f473e91062d6cf6fb918020868fa4e1fca) | `vscodium: 1.70.1 -> 1.70.1.22228`                                    |
| [`f2c42a58`](https://github.com/NixOS/nixpkgs/commit/f2c42a583b19183be047b28482adf1403a86f108) | `swayr: 0.20.0 -> 0.20.1`                                             |
| [`c784cdbf`](https://github.com/NixOS/nixpkgs/commit/c784cdbf6b98e3e3aefb678b6ee8309cbb8bee15) | `biber: import patch for Perl 5.36.0 compat`                          |
| [`b9b7c80f`](https://github.com/NixOS/nixpkgs/commit/b9b7c80f7a76ffdc3e20e5208d3acfff0904227a) | `cataclysm-dda: update locale path patch`                             |
| [`e714f357`](https://github.com/NixOS/nixpkgs/commit/e714f357fd1f9632329751a8c0e1c68cdf19fec5) | `symfony-cli: 5.4.12 -> 5.4.13`                                       |
| [`1af6f5a2`](https://github.com/NixOS/nixpkgs/commit/1af6f5a2220b2d1a88a1a8c8bf7e9972b3315c89) | `hmat-oss: init at 1.7.1`                                             |
| [`2a122411`](https://github.com/NixOS/nixpkgs/commit/2a122411d0d938fe4b5389bc49964b4442eb1dc4) | `tracy: 0.8.1 -> 0.8.2.1`                                             |
| [`cec14458`](https://github.com/NixOS/nixpkgs/commit/cec14458becf95cd3269b98b5dd5ff311c1ecc34) | `swagger-codegen3: 3.0.34 -> 3.0.35`                                  |
| [`d14d17e0`](https://github.com/NixOS/nixpkgs/commit/d14d17e0f103ab03cd9fbe0f883569f19c36f6e7) | `swaynotificationcenter: compile schema`                              |
| [`e6ec81b3`](https://github.com/NixOS/nixpkgs/commit/e6ec81b396f020a8b35f57b1df3e24a7a81a01cd) | `sentry-cli: 2.5.0 -> 2.5.1`                                          |
| [`1d7fa645`](https://github.com/NixOS/nixpkgs/commit/1d7fa64523f882c2017e930cefae4b6fab4ed083) | `skypeforlinux: 8.87.0.403 -> 8.87.0.406`                             |
| [`8630ef79`](https://github.com/NixOS/nixpkgs/commit/8630ef79dd4286221da7c01e0c8568bc896ba441) | `qt5, libsForQt5: 5.14 -> 5.15 on darwin (#184560)`                   |
| [`fb5bceb3`](https://github.com/NixOS/nixpkgs/commit/fb5bceb3ff3b99f6531908f46526cb55c7d29eac) | `nixos/fwupd: enable udisks2`                                         |
| [`a3d5cf1d`](https://github.com/NixOS/nixpkgs/commit/a3d5cf1dd2853306d50397d8bfdee0d7566704e4) | `python310Packages.recoll: 1.32.5 -> 1.32.7`                          |
| [`0b73b43a`](https://github.com/NixOS/nixpkgs/commit/0b73b43a942d4f264036c74d03758194ba0b5855) | `lilypond-unstable and lilypond-unstable-with-fonts: init at 2.23.11` |
| [`a09957f9`](https://github.com/NixOS/nixpkgs/commit/a09957f96b56d9eccbbb3835511d7779e96676d9) | `numix-icon-theme-square: 22.08.07 -> 22.08.15`                       |