### PR TITLE
chore(flake/nixpkgs): `8ea014ac` -> `495b19d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660819943,
-        "narHash": "sha256-TRZV/mlW1eYuojqDC3ueYWj7jsTKXJCtyMLNYX/Ybtw=",
+        "lastModified": 1660908602,
+        "narHash": "sha256-SwZ85IPWvC4NxxFhWhRMTJpApSHbY1u4YK2UFWEBWvY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8ea014acc33da95ea56c902229957d8225005163",
+        "rev": "495b19d5b3e62b4ec7e846bdfb6ef3d9c3b83492",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`f6a079f3`](https://github.com/NixOS/nixpkgs/commit/f6a079f3f87652afcbd531ef9da087af6ba1d7a6) | `prometheus-postgres-exporter: 0.11.0 -> 0.11.1`                       |
| [`eeba9b88`](https://github.com/NixOS/nixpkgs/commit/eeba9b884feb763b9352aa413383f559284d33c5) | `python310Packages.jupyterlab: 3.4.4 -> 3.4.5 (#187390)`               |
| [`329c65f7`](https://github.com/NixOS/nixpkgs/commit/329c65f7144e0259ce06452f4a8f7c7bc3604bae) | `zerotierone: 1.10.0 -> 1.10.1 (#187297)`                              |
| [`98a92cbe`](https://github.com/NixOS/nixpkgs/commit/98a92cbe17e319673a13205176e53eed79f2630e) | `starship: 1.10.1 -> 1.10.2`                                           |
| [`fe548532`](https://github.com/NixOS/nixpkgs/commit/fe5485327e503f86d0153db625549e0908a39668) | `gpsd: fix cross-compilation`                                          |
| [`a90bd928`](https://github.com/NixOS/nixpkgs/commit/a90bd9287f6c484e20b135d8c4224a1ccbe150f9) | `caroline: init at 0.3.1 (#178459)`                                    |
| [`c7f4385e`](https://github.com/NixOS/nixpkgs/commit/c7f4385e84c77917cbdd55c333996213ec452af8) | `cosign: 1.10.1 -> 1.11.0`                                             |
| [`59174d46`](https://github.com/NixOS/nixpkgs/commit/59174d46dbed2b9f316ecc0b93b00b8c8c6f27e9) | `python310Packages.cexprtk: init at 0.4.0`                             |
| [`77c71e63`](https://github.com/NixOS/nixpkgs/commit/77c71e63291bae656c73dc1bf1de582992dbd9db) | `python310Packages.atsim_potentials: Unbreak package`                  |
| [`e9ce9a2b`](https://github.com/NixOS/nixpkgs/commit/e9ce9a2b73e93a66d7dddacc0004a37ffe926815) | `git-blame-ignore-revs: add meteor format commit`                      |
| [`a37a6de8`](https://github.com/NixOS/nixpkgs/commit/a37a6de881ec4c6708e6b88fd16256bbc7f26bbd) | `meteor: formatting`                                                   |
| [`8248b6e7`](https://github.com/NixOS/nixpkgs/commit/8248b6e74157d01c0d7b57b7ee822583ce99154e) | `meteor: 1.12 -> 2.7.3`                                                |
| [`6647988f`](https://github.com/NixOS/nixpkgs/commit/6647988f19269e5cfea349471fae98fa4e7b9033) | `kubernetes: add kubectl to passthru.tests`                            |
| [`afe983cc`](https://github.com/NixOS/nixpkgs/commit/afe983cca33d11fa36fe3f7a737e1a1bcae6d048) | `kubernetes: 1.23.9 -> 1.23.10`                                        |
| [`33313b87`](https://github.com/NixOS/nixpkgs/commit/33313b87e65fc04f5440511f007cf105dc37e63f) | `buildah, cri-o, podman: drop unneeded cni-plugins input from wrapper` |
| [`72a3a868`](https://github.com/NixOS/nixpkgs/commit/72a3a868a029e9814d8ef0860ac0e05449029c8a) | `nixos/{containers,podman}: nixpkgs-fmt`                               |
| [`e95cb8f1`](https://github.com/NixOS/nixpkgs/commit/e95cb8f170b5ca5a8adbcf65613bee28802c56d7) | `skaffold: 1.39.1 -> 1.39.2`                                           |
| [`9d9c6fb8`](https://github.com/NixOS/nixpkgs/commit/9d9c6fb818073b41c9e0b00b2d800443146f4628) | `gitui: 0.20.1 -> 0.21.0`                                              |
| [`fe43521b`](https://github.com/NixOS/nixpkgs/commit/fe43521b326f4c0d25581ef050ac5d11ea8f1fd1) | `argocd: 2.4.9 -> 2.4.10`                                              |
| [`45804be4`](https://github.com/NixOS/nixpkgs/commit/45804be482e9c569b246dd03cfbe605cfa617f4a) | `kubevirt: 0.55.0 -> 0.55.1`                                           |
| [`c5f2d8be`](https://github.com/NixOS/nixpkgs/commit/c5f2d8be81a708d049cbca42e5a99140b04c8e8d) | `python310Packages.google-cloud-audit-log: 0.2.3 -> 0.2.4`             |
| [`6c55578c`](https://github.com/NixOS/nixpkgs/commit/6c55578c7e0a49807671b2e3ddde69cc96594733) | `nixos/komga: add module`                                              |
| [`2d52abcb`](https://github.com/NixOS/nixpkgs/commit/2d52abcbef2f326a9cc9cfa4ee268fd0072c2600) | `yt-dlp: 2022.8.14 -> 2022.8.19`                                       |
| [`4ae5da53`](https://github.com/NixOS/nixpkgs/commit/4ae5da539489d31697a1e163b9de190e150ca63e) | `nixos/network-interfaces-systemd: do not ignore /0 gateway routes`    |
| [`48947b28`](https://github.com/NixOS/nixpkgs/commit/48947b2850fb13178a98e37888516343b297f3e0) | `himitsu-firefox: set HARECACHE`                                       |
| [`e1e4a5e5`](https://github.com/NixOS/nixpkgs/commit/e1e4a5e540114341e97ab390e42aeecb22dec771) | `himitsu: set HARECACHE`                                               |
| [`eedf8904`](https://github.com/NixOS/nixpkgs/commit/eedf89041cc2a909659e5501b98606c50a0cd1e8) | `gcr: fix build on darwin`                                             |
| [`a0f033f1`](https://github.com/NixOS/nixpkgs/commit/a0f033f18182d18e9448e6ca28ab07a7f5c6bdbe) | `metasploit: 6.2.12 -> 6.2.13`                                         |
| [`f04a9770`](https://github.com/NixOS/nixpkgs/commit/f04a9770e504ab92aa0872e2327c3da4d6e3da6d) | `ghr: 0.14.0 -> 0.15.0`                                                |
| [`5e8529d6`](https://github.com/NixOS/nixpkgs/commit/5e8529d6f1da4122fa9f2eaa466e578fdf1c50d8) | `blackfire: 2.8.1 → 2.10.0`                                            |
| [`5cfcb62e`](https://github.com/NixOS/nixpkgs/commit/5cfcb62e178cdf4b25aba15bc3ddee0627f37c6b) | `blackfire.updateScript: fix on different systems`                     |
| [`d6636a5d`](https://github.com/NixOS/nixpkgs/commit/d6636a5de6bb7d261adc2957c4a909ae035aae3b) | `llvmPackages_14.compiler-rt: fix aarch32 patch`                       |
| [`fd36ac32`](https://github.com/NixOS/nixpkgs/commit/fd36ac32c01f34897bbd8d04c2f2828b5e60d3f4) | `Revert "clang_14: drop out-of-date armv7l patch"`                     |
| [`f3cea631`](https://github.com/NixOS/nixpkgs/commit/f3cea6317f9bc27a7093410785f240fdc5121daa) | `hostapd-mana: init at 2.6.5`                                          |
| [`0e790351`](https://github.com/NixOS/nixpkgs/commit/0e790351a047e1d19a3ee7e9aaff6180e2d24927) | `linuxPackages.rtl8188eus: unstable-2021-05-04 -> unstable-2022-03-19` |
| [`7e533d19`](https://github.com/NixOS/nixpkgs/commit/7e533d199f5956f776686439f8006c2aa04b5461) | `hebbot: init at 2.1 (#187178)`                                        |
| [`ecba86f6`](https://github.com/NixOS/nixpkgs/commit/ecba86f62f8db56ddefe15d726a0592e7fa585cf) | `python310Packages.adafruit-platformdetect: 3.27.0 -> 3.27.1`          |
| [`05766cd3`](https://github.com/NixOS/nixpkgs/commit/05766cd33c706c7795e1a8a09635d28ea29575ad) | `pugixml: simplify outputs`                                            |
| [`48eeb5ad`](https://github.com/NixOS/nixpkgs/commit/48eeb5ad17941a8c00247c6bab6d2b37baeec318) | `cpptoml: remove default outputs`                                      |
| [`a8ac0c22`](https://github.com/NixOS/nixpkgs/commit/a8ac0c221a73b53de0aaa44eda9ae4b49e172724) | `ryujinx: Force SDL_VIDEODRIVER to x11`                                |
| [`fef7bfea`](https://github.com/NixOS/nixpkgs/commit/fef7bfea9ffba16cf3f62e4e08f3e70d33b60748) | `ryujinx: 1.1.213 -> 1.1.223`                                          |
| [`34281ff4`](https://github.com/NixOS/nixpkgs/commit/34281ff4791d06b76ad877a73d0ba44d9bafdd16) | `ryujinx: Migrate updater script to fetch-deps in buildDotnetModule`   |
| [`48114aa4`](https://github.com/NixOS/nixpkgs/commit/48114aa4055af5474a4cfa5ae4c00bfde44d245c) | `gitea: 1.17.0 -> 1.17.1`                                              |
| [`7cc1d78d`](https://github.com/NixOS/nixpkgs/commit/7cc1d78d20e3ba41af5167ab811bae4e68220cd5) | `python310Packages.pyskyqremote: 0.3.15 -> 0.3.16`                     |
| [`e0377f4a`](https://github.com/NixOS/nixpkgs/commit/e0377f4a23a3a43f7d1433bc9ab3e0bed9dbcad4) | `cbmc: 5.63.0 -> 5.64.0`                                               |
| [`8711a6f3`](https://github.com/NixOS/nixpkgs/commit/8711a6f35351bea17c6d27e486913aa060600b77) | `vimPlugins.trim-nvim: init at 2022-06-16 (#187295)`                   |
| [`3d07ae8a`](https://github.com/NixOS/nixpkgs/commit/3d07ae8afd3e6ccb2f95e42d898e2eaa271d6f9e) | `build-dotnet-module: Allow specifying the output path of fetch-deps`  |
| [`1528ce30`](https://github.com/NixOS/nixpkgs/commit/1528ce3063f211f809465af1ddc265c9e4e050cd) | `nuget-to-nix: Make exclusion file optional`                           |
| [`b1fb66a6`](https://github.com/NixOS/nixpkgs/commit/b1fb66a624bd19c1ce2558c518d09da84fd27a4e) | `python310Packages.bless: init at 0.2.4`                               |
| [`7d23e75d`](https://github.com/NixOS/nixpkgs/commit/7d23e75d63a9dd8a15c5d5e011a8183f9adf615e) | `python310Packages.aioecowitt: 2022.7.0 -> 2022.08.2`                  |
| [`4b76218d`](https://github.com/NixOS/nixpkgs/commit/4b76218dcb05ec4890c6f3d7b32b950e66ce5c1c) | `python310Packages.fastcore: 1.5.17 -> 1.5.18`                         |
| [`6247b006`](https://github.com/NixOS/nixpkgs/commit/6247b00637c93ae28f2e247cb62dc36e956818de) | `ryujinx: Force display backend to X11`                                |
| [`986c8b28`](https://github.com/NixOS/nixpkgs/commit/986c8b28de192942ba792547e5b0018553b1f7e7) | `python310Packages.atc-ble: init at 0.1.0`                             |
| [`a5c8eb14`](https://github.com/NixOS/nixpkgs/commit/a5c8eb14e27831190687260a8266b881d784583c) | `plex: 1.28.0.5999-97678ded3 -> 1.28.1.6104-788f82488`                 |
| [`e59a9d1b`](https://github.com/NixOS/nixpkgs/commit/e59a9d1bed788d6a53011be17370476836d59007) | `python310Packages.bluetooth-adapters: 0.1.3 -> 0.2.0`                 |
| [`d34f728c`](https://github.com/NixOS/nixpkgs/commit/d34f728c2fc35481a6259e1ad86154db151b63e5) | `numix-icon-theme: 21.10.31 -> 22.08.16 (#187004)`                     |
| [`187ee7a4`](https://github.com/NixOS/nixpkgs/commit/187ee7a4bee8af2ffbacaec97738e8df2a7a0cc9) | `python310Packages.qingping-ble: 0.2.3 -> 0.2.4`                       |
| [`af3c62be`](https://github.com/NixOS/nixpkgs/commit/af3c62be07bfaabd6d658a8cbe5c43856142ab0e) | `xfce.xfce4-screenshooter: 1.9.10 -> 1.9.11 (#186429)`                 |
| [`c454db9d`](https://github.com/NixOS/nixpkgs/commit/c454db9d00083579b49d0d1e21a2652cd0b6a185) | `gcr: 3.41.0 → 3.41.1`                                                 |
| [`fe4c35b4`](https://github.com/NixOS/nixpkgs/commit/fe4c35b4c2f2ebb2f56eb67c53609400e35b4ec0) | `python3Packages.pydmd: fixed missing dependency`                      |
| [`d09eccec`](https://github.com/NixOS/nixpkgs/commit/d09eccecd57c78c7f34774a3cb48fb97edcdc0cf) | `python310Packages.sensor-state-data: 2.2.0 -> 2.3.1`                  |
| [`71617faa`](https://github.com/NixOS/nixpkgs/commit/71617faa487ab0d16b6cad3c20b8c4c79fb328e3) | `vtm: 0.7.6 -> 0.8.0`                                                  |
| [`facd025b`](https://github.com/NixOS/nixpkgs/commit/facd025b944491292dc6cd83a9dbc9e9c847d4cc) | `ldns: 1.8.1 -> 1.8.3`                                                 |
| [`1393dba6`](https://github.com/NixOS/nixpkgs/commit/1393dba6109b8ad62a4fc2cbe144f7daff9d642b) | `nss_latest: 3.81 -> 3.82`                                             |
| [`89f52738`](https://github.com/NixOS/nixpkgs/commit/89f527384b6bea645ad0d8afedb5d2400f0596b3) | `nixos/minio: fix startup issue`                                       |
| [`a3d14cef`](https://github.com/NixOS/nixpkgs/commit/a3d14cefba0e7200269926b401d3ad2fee3e5e9a) | `python310Packages.asdf: 2.12.0 -> 2.12.1`                             |
| [`d7743226`](https://github.com/NixOS/nixpkgs/commit/d77432260ad12ef8af9776c0d4d6ee4f52d21bfe) | `dump_syms: 1.0.1 -> 2.0.0`                                            |
| [`6dc1c73a`](https://github.com/NixOS/nixpkgs/commit/6dc1c73aba11efa3229659bcaf596b21ef6f80bd) | `nixos/libvirtd: Do not add autostart network`                         |
| [`b4de4dc3`](https://github.com/NixOS/nixpkgs/commit/b4de4dc3bfc5dbbd11a506814636969465c9ade4) | `buildDotnetModule: set fetch-deps utils via PATH`                     |
| [`fc6b3c45`](https://github.com/NixOS/nixpkgs/commit/fc6b3c45d5b8fd933e3c91d52ab1df149ca272f4) | `python310Packages.xdis: Fix build`                                    |
| [`c51e1a1f`](https://github.com/NixOS/nixpkgs/commit/c51e1a1fbae2bd14e0df183a50df6f1bd64780a3) | `buildDotnetModule: use coreutils in fetch-deps`                       |
| [`d7728dfc`](https://github.com/NixOS/nixpkgs/commit/d7728dfc671c56a1929665abd1e2fd07d64360e1) | `buildDotnetModule: use platform-agnostic cp format`                   |
| [`0e75512a`](https://github.com/NixOS/nixpkgs/commit/0e75512a1bbac97fb67bfa6bd54a8dd27dec0ce7) | `clickable: init at 7.4.0 (#178760)`                                   |
| [`c6612e92`](https://github.com/NixOS/nixpkgs/commit/c6612e92f888cc8abf0126fc3082a9d2738adf42) | `via: 1.3.1 -> 2.0.5`                                                  |
| [`eb418053`](https://github.com/NixOS/nixpkgs/commit/eb418053b23bd504ef80c55186e50dc974bd45a5) | `python310Packages.typed-settings: Fix build`                          |
| [`51bd7cf0`](https://github.com/NixOS/nixpkgs/commit/51bd7cf0d05f996c74b8fabebc755a2fe253b50e) | `emacs: enable native-comp`                                            |
| [`a4d72ad6`](https://github.com/NixOS/nixpkgs/commit/a4d72ad6289a81b73e000617f9c9efc7f1d17499) | `nixos/keter: init`                                                    |
| [`b77f3507`](https://github.com/NixOS/nixpkgs/commit/b77f3507bb6f9d213c64c3374f70ae953725ea41) | `pferd: 3.4.0 -> 3.4.1`                                                |
| [`936f70de`](https://github.com/NixOS/nixpkgs/commit/936f70de166eb2c6d0a32d53c31bc329477dcea1) | `cvise: add tests back`                                                |
| [`f3c99629`](https://github.com/NixOS/nixpkgs/commit/f3c99629ae26a6fc8963482f34cbd9178aee41b9) | `coinlive: init at 0.2.1`                                              |
| [`a9cd728f`](https://github.com/NixOS/nixpkgs/commit/a9cd728f69a7267d15d004db99ba7e2c0aee89e3) | `python3Packages.discordpy: 1.7.3 -> 2.0.0`                            |
| [`600fb49f`](https://github.com/NixOS/nixpkgs/commit/600fb49fa1213784b66c3663a17263456debba0a) | `signal-cli: 0.10.10 -> 0.10.11`                                       |
| [`06f89fc5`](https://github.com/NixOS/nixpkgs/commit/06f89fc55ec106eb8ee1b28daa34131669638bb8) | `python310Packages.tableaudocumentapi: Fix build`                      |
| [`d31b3a3e`](https://github.com/NixOS/nixpkgs/commit/d31b3a3edd6af89c5a75276a3043048eb8d46a3c) | `python310Packages.pyshark: remove stale comment`                      |
| [`347e5f47`](https://github.com/NixOS/nixpkgs/commit/347e5f473e7de7856d364063d1d46f3b768b0463) | `mc: stop retaining configure arguments in the final binary`           |
| [`6d410435`](https://github.com/NixOS/nixpkgs/commit/6d4104359eb3f9d6a340e8206a8f74a1c04d05be) | `python310Packages.aiocoap: 0.4.3 -> 0.4.4`                            |
| [`7ea5e9dc`](https://github.com/NixOS/nixpkgs/commit/7ea5e9dcab513884f913a3a8b21bc511866947ef) | `python310Packages.censys: 2.1.7 -> 2.1.8`                             |
| [`6ff0b472`](https://github.com/NixOS/nixpkgs/commit/6ff0b472f7fad88777b31c85a3c539101553858a) | `flyctl: fix indentation`                                              |
| [`e2773fb4`](https://github.com/NixOS/nixpkgs/commit/e2773fb42bf8a5144449eb22d6943107514844e7) | `gitoxide: 0.13.0 -> 0.14.0`                                           |
| [`5ec8223e`](https://github.com/NixOS/nixpkgs/commit/5ec8223e637bf89fd6f8e122ce9f0ff7bde36204) | `nixos/sssd: explain why we use EnvironmentFile=`                      |
| [`204d32c5`](https://github.com/NixOS/nixpkgs/commit/204d32c5c1be0d172d7c6a1840334994979eb0d3) | `nixos/sssd-ldap: verify that passing secrets via env works`           |
| [`2f0bd926`](https://github.com/NixOS/nixpkgs/commit/2f0bd926ea9c15b9b76c25410ce3dd7c2bdda869) | `nixos/sssd-ldap: fix eval`                                            |
| [`8d92d42c`](https://github.com/NixOS/nixpkgs/commit/8d92d42c5c6c19e3ef5d9e01f94bde763364c48b) | `nixos/sssd: fix typo`                                                 |
| [`60e47734`](https://github.com/NixOS/nixpkgs/commit/60e47734f65967fefaf64a2a84464c8f067491a9) | `kanboard: correct homepage url`                                       |
| [`4e030e52`](https://github.com/NixOS/nixpkgs/commit/4e030e5221f7a3d2858cab0ae8b22e1a2174a95b) | `flyctl: add "fly" alias`                                              |
| [`10881441`](https://github.com/NixOS/nixpkgs/commit/10881441a5bbde2c7bdcd49ed4aee2b08093dd5d) | `copilot-cli: 1.20.0 -> 1.21.0`                                        |
| [`8cecd7cb`](https://github.com/NixOS/nixpkgs/commit/8cecd7cb82a9a5094d783a6bb447cb5c68d5d0c9) | `git-machete: 3.11.6 -> 3.12.0`                                        |
| [`d0bbad12`](https://github.com/NixOS/nixpkgs/commit/d0bbad1246388649ab824261abeee1012dff51b2) | `chromiumBeta: 105.0.5195.28 -> 105.0.5195.37`                         |
| [`5369167b`](https://github.com/NixOS/nixpkgs/commit/5369167b7dea306772b074756771ce7f15d71e21) | `chromium: 104.0.5112.79 -> 104.0.5112.101`                            |
| [`e5d7d6a7`](https://github.com/NixOS/nixpkgs/commit/e5d7d6a7e436109a8e52d9b7a8a68a2d86e9f612) | `gpg-tui: 0.9.0 -> 0.9.1`                                              |
| [`86f9d4bd`](https://github.com/NixOS/nixpkgs/commit/86f9d4bdcd5a8e7206c86f0fcc6776816cc6681d) | `imagemagick: 7.1.0-45 -> 7.1.0-46`                                    |
| [`d8666c03`](https://github.com/NixOS/nixpkgs/commit/d8666c03281885412c0a07f6699983f9e30f22a1) | `zellij: fix changelog location`                                       |
| [`443ba65c`](https://github.com/NixOS/nixpkgs/commit/443ba65c4faabb1fd6bc1c39b2dccd9cc8ef8dea) | `python310Packages.trytond: 6.4.3 -> 6.4.4`                            |
| [`97b1fe31`](https://github.com/NixOS/nixpkgs/commit/97b1fe315456e50bed39a41949d85cee06453a8f) | `python310Packages.trimesh: 3.13.4 -> 3.13.5`                          |
| [`cb37c6b9`](https://github.com/NixOS/nixpkgs/commit/cb37c6b9d57f097001923e60628705d92307ba4e) | `python310Packages.striprtf: 0.0.20 -> 0.0.21`                         |
| [`9932fab7`](https://github.com/NixOS/nixpkgs/commit/9932fab7c0d03acd5f46fbdf4bea7d774326a299) | `mkp224o: fix typo in amd64-64-24k version`                            |
| [`5e242294`](https://github.com/NixOS/nixpkgs/commit/5e24229488e7968f05a06a07096dd917138d7f27) | `vscode: 1.70.1 -> 1.70.2`                                             |
| [`5da69292`](https://github.com/NixOS/nixpkgs/commit/5da692923a49e26cdf2b3c304a1a8349e494af07) | `python3Packages.grpclib: init at 0.4.3`                               |
| [`7337e729`](https://github.com/NixOS/nixpkgs/commit/7337e729a47f888314b4c26e46003cc8af39bb90) | `jruby: 9.3.6.0 -> 9.3.7.0`                                            |
| [`7002f2f3`](https://github.com/NixOS/nixpkgs/commit/7002f2f3c8c80ee7d0622d18e01e5bd48fa96d92) | `spectra: init at 1.0.1`                                               |
| [`aab926cc`](https://github.com/NixOS/nixpkgs/commit/aab926cc66d4eba2a5cdf0a0a5623873214807af) | `werf: 1.2.154 -> 1.2.160`                                             |
| [`2ea963c9`](https://github.com/NixOS/nixpkgs/commit/2ea963c93075f25ea9cdfd16de476b84c33e2f70) | `tickrs: 0.14.4 -> 0.14.6`                                             |
| [`d2c47ea0`](https://github.com/NixOS/nixpkgs/commit/d2c47ea0173f8310974eb0512819e69e980d49a6) | `temporal: 1.17.2 -> 1.17.4`                                           |
| [`2859855c`](https://github.com/NixOS/nixpkgs/commit/2859855c0da67c14f4dd766d9b8d4421e49f015f) | `python3Packages.related: 0.7.2 -> 0.7.3`                              |
| [`a6c4ffa2`](https://github.com/NixOS/nixpkgs/commit/a6c4ffa26d723af8abf55cbef6ef9742301d8ea0) | `snappymail: 2.17.0 -> 2.17.2`                                         |
| [`f75d7a4a`](https://github.com/NixOS/nixpkgs/commit/f75d7a4a9390de088fa0fc5d30cc72ec0ef447bd) | `sentry-cli: 2.5.1 -> 2.5.2`                                           |
| [`173069fb`](https://github.com/NixOS/nixpkgs/commit/173069fbd25185c0f26916386c5884ae76858370) | `sd-local: 1.0.42 -> 1.0.43`                                           |
| [`d6c2f82f`](https://github.com/NixOS/nixpkgs/commit/d6c2f82fdee3a2369d0c52e59ee1f330fa14e1c0) | `rtsp-simple-server: 0.19.3 -> 0.20.0`                                 |
| [`d7b51601`](https://github.com/NixOS/nixpkgs/commit/d7b51601d810ce7497a55a5085c935648f776263) | `cloud-hypervisor: 25.0 -> 26.0`                                       |
| [`585ceba6`](https://github.com/NixOS/nixpkgs/commit/585ceba6899c2d6ae7e463a33dc1fb3a2384917c) | `redpanda: 22.1.7 -> 22.2.1`                                           |
| [`f0f46e03`](https://github.com/NixOS/nixpkgs/commit/f0f46e03bae6958482fa0e679991331df9634c79) | `q: Init at 0.8.2`                                                     |
| [`e66376b1`](https://github.com/NixOS/nixpkgs/commit/e66376b18a9e07b40d84878643c8731eee50a02f) | `pythonPackages.nbclassic: fix build failure`                          |
| [`7557be55`](https://github.com/NixOS/nixpkgs/commit/7557be5546c8934575e2d423fdaf53d248d49c8d) | `pythonPackages.notebook-shim: init at 0.1.0`                          |
| [`3c4899b2`](https://github.com/NixOS/nixpkgs/commit/3c4899b2e48b62a80f8e7eb9000c841c52c62887) | `python3Packages.humanize: 4.2.3 -> 4.3.0`                             |
| [`b7731c39`](https://github.com/NixOS/nixpkgs/commit/b7731c3997d1bd453ecd8b98532104a334c12dee) | `crosvm: install both .policy and .bpf files`                          |
| [`d57f9048`](https://github.com/NixOS/nixpkgs/commit/d57f90485c5db326d5c1c00ec400ba89feef5bdf) | `python310Packages.azure-mgmt-network: 21.0.0 -> 21.0.1`               |
| [`41a6f90b`](https://github.com/NixOS/nixpkgs/commit/41a6f90b371207e33cb33044b8a6ac0ef1699a0a) | `python310Packages.python-awair: 0.2.3 -> 0.2.4`                       |