### PR TITLE
chore(flake/nixpkgs): `495b19d5` -> `13711c9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660908602,
-        "narHash": "sha256-SwZ85IPWvC4NxxFhWhRMTJpApSHbY1u4YK2UFWEBWvY=",
+        "lastModified": 1660998696,
+        "narHash": "sha256-N5eDv9THZz5pFn7NR1swaFrAJYByfrA5gU5L7JONItA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "495b19d5b3e62b4ec7e846bdfb6ef3d9c3b83492",
+        "rev": "13711c9ab9f5a160a44affb7a6221be53318a873",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`392c8349`](https://github.com/NixOS/nixpkgs/commit/392c83491dcc21d17ab8ea1f809f8f7bd567a5a3) | `nixos/lightdm-greeters/slick: disable slick greeter by default`                 |
| [`e584956d`](https://github.com/NixOS/nixpkgs/commit/e584956de9667cddc7c6b48e34c663f2e9d17b01) | `python310Packages.cometblue-lite: 0.4.1 -> 0.5.2`                               |
| [`d18f214c`](https://github.com/NixOS/nixpkgs/commit/d18f214cbb7fcc315dcc559a3e5d87dfdf489da4) | `python310Packages.rfcat: add missing input`                                     |
| [`a982b54b`](https://github.com/NixOS/nixpkgs/commit/a982b54b9d204896db273cb5c0fa3c43d64de663) | `python310Packages.mdformat: 0.7.14 -> 0.7.15`                                   |
| [`1abc195e`](https://github.com/NixOS/nixpkgs/commit/1abc195e6bd824a947e63114aef219ee9fa02e0c) | `python310Packages.influxdb-client: add extra dependencies`                      |
| [`3a03893a`](https://github.com/NixOS/nixpkgs/commit/3a03893a6a2293ae8d299c26e1003e5c8e9c6e20) | `python310Packages.geomet: add missing input`                                    |
| [`221542bd`](https://github.com/NixOS/nixpkgs/commit/221542bdfe6786d249c062e37ec305d605daf0e9) | `python310Packages.yalexs-ble: 1.6.1 -> 1.6.2`                                   |
| [`4f99936a`](https://github.com/NixOS/nixpkgs/commit/4f99936a34dbd866e015fe85610e0010373e6a15) | `python310Packages.yalexs-ble: 1.6.0 -> 1.6.1`                                   |
| [`460754f5`](https://github.com/NixOS/nixpkgs/commit/460754f583e50b5ee9ad3c7f439c11ff8b68cfa9) | `python310Packages.yalexs-ble: 1.5.0 -> 1.6.0`                                   |
| [`e1f2f200`](https://github.com/NixOS/nixpkgs/commit/e1f2f200f34257ac8b458725298a33493b3f6dd9) | `python310Packages.yalexs-ble: 1.4.0 -> 1.5.0`                                   |
| [`c968faad`](https://github.com/NixOS/nixpkgs/commit/c968faaddf305996d213fd95da0341e3cb89a651) | `python310Packages.geomet: add pythonImportsCheck`                               |
| [`a58d0d62`](https://github.com/NixOS/nixpkgs/commit/a58d0d62da44a623f0addcfd2d6cc3dcb21dcda7) | `python310Packages.rfcat: disable on older Python releases`                      |
| [`289cbd9b`](https://github.com/NixOS/nixpkgs/commit/289cbd9b66f4d0d5f0c1b2519eea190804fbcfca) | `python310Packages.sphinxcontrib-katex: disable on older Python releases`        |
| [`78182194`](https://github.com/NixOS/nixpkgs/commit/78182194c652df7bdcfa0a6a788d17895188b777) | `Revert Merge #184360: json-glib: add installed tests`                           |
| [`7e3fd698`](https://github.com/NixOS/nixpkgs/commit/7e3fd698581fb9d1828f13e02739c6ec98066244) | `python310Packages.pyswitchbot: 0.18.11 -> 0.18.12`                              |
| [`9a63fc1b`](https://github.com/NixOS/nixpkgs/commit/9a63fc1ba6eb5d2f8ecc4fc2c3ebfed3633a1479) | `python310Packages.pyswitchbot: 0.18.10 -> 0.18.11`                              |
| [`ab7c062a`](https://github.com/NixOS/nixpkgs/commit/ab7c062a74ca1ba63a0ad5e28b024afd5be1d4ef) | `python310Packages.bleak-retry-connector: 1.10.1 -> 1.11.0`                      |
| [`6d716c70`](https://github.com/NixOS/nixpkgs/commit/6d716c70bebb0200054649a42455cef11e933cd1) | `python310Packages.stripe: 4.0.2 -> 4.1.0`                                       |
| [`330ede2f`](https://github.com/NixOS/nixpkgs/commit/330ede2f6d82c4be35b0986a0a5c5d3c8985f23a) | `python310Packages.sphinxcontrib-katex: 0.8.6 -> 0.9.0`                          |
| [`c40f4111`](https://github.com/NixOS/nixpkgs/commit/c40f411195ec674a559e2ca8368bcb27bf26eb65) | `python310Packages.influxdb-client: 1.30.0 -> 1.31.0`                            |
| [`21c6fcc9`](https://github.com/NixOS/nixpkgs/commit/21c6fcc91af92a8a9946db56ae9b7fae37ed192a) | `python310Packages.ibm-watson: 6.0.0 -> 6.1.0`                                   |
| [`275923f7`](https://github.com/NixOS/nixpkgs/commit/275923f7aed945608e608d8d86c065b5f21f0b93) | `python310Packages.geomet: 0.3.0 -> 0.3.1`                                       |
| [`155bcc03`](https://github.com/NixOS/nixpkgs/commit/155bcc037c551d295717e3e477cfba3a31f1ac2d) | `python310Packages.rfcat: 1.9.5 -> 1.9.6`                                        |
| [`9b0252fd`](https://github.com/NixOS/nixpkgs/commit/9b0252fd50b19cfaa6c0c52102437b1500f30ccb) | `python310Packages.enaml: 0.15.1 -> 0.15.2`                                      |
| [`6039648c`](https://github.com/NixOS/nixpkgs/commit/6039648c50c7c0858b5e506c6298773a98e0f066) | `nixos/*: automatically convert option docs`                                     |
| [`7e7d68a2`](https://github.com/NixOS/nixpkgs/commit/7e7d68a250f75678451cd44f8c3d585bf750461e) | `nixos/*: mark pre-existing markdown descriptions as mdDoc`                      |
| [`b51f8036`](https://github.com/NixOS/nixpkgs/commit/b51f8036c2c4e887ce45372dc6b7a4c4a54a0ea0) | `nixos/*: use properly indented strings for option docs`                         |
| [`72b507d5`](https://github.com/NixOS/nixpkgs/commit/72b507d5a20d9eec76addd4b812dbf11b95264a9) | `nixos/*: convert some markdown in docbook to tags`                              |
| [`b0e56ace`](https://github.com/NixOS/nixpkgs/commit/b0e56acef90e1726c588aac13fe7e5fae0ed1a95) | `nixos/*: remove links to options in code blocks`                                |
| [`275a34e0`](https://github.com/NixOS/nixpkgs/commit/275a34e0d8a937a81b267e47302dd8a92fa781df) | `nixos/nix-daemon: replace <uri> with <literal>`                                 |
| [`d0ba463f`](https://github.com/NixOS/nixpkgs/commit/d0ba463fcf013556f02816a90ae92f63ab5f6d71) | `nixos/*: replace <quote> with actual quotes`                                    |
| [`f1d39b6d`](https://github.com/NixOS/nixpkgs/commit/f1d39b6d6187997b630647400c5efe5b01e06a23) | `nixos/postgresql: replace <function> with <literal>`                            |
| [`b7327e96`](https://github.com/NixOS/nixpkgs/commit/b7327e966bd8bac3c1a53f8013cd5dad4fe83997) | `nixos/*: normalize links with #TEXT=href`                                       |
| [`2646fd7c`](https://github.com/NixOS/nixpkgs/commit/2646fd7c1b79fe6c332dbe4078677f0d2f7c897b) | `nixos/*: remove <productname>`                                                  |
| [`a4fdff51`](https://github.com/NixOS/nixpkgs/commit/a4fdff515b59e3fd97537625f31044e00b6c71ab) | `nixos/*: turn inline code blocks into more appropriate things`                  |
| [`e4ed177f`](https://github.com/NixOS/nixpkgs/commit/e4ed177f828337062662983e15434525dd168c7d) | `nixos/* eliminate inner whitespace in tags that was missed earlier`             |
| [`8f8e1015`](https://github.com/NixOS/nixpkgs/commit/8f8e1015275bc1be12ffe3055ffe5e15f80dd1cd) | `nixos/*: normalize <package> to <literal>`                                      |
| [`b1ae09ba`](https://github.com/NixOS/nixpkgs/commit/b1ae09baa094a48ed8d8c1214d2178269dd4f7ff) | `tfsec: 1.27.1 -> 1.27.2`                                                        |
| [`b09dfb30`](https://github.com/NixOS/nixpkgs/commit/b09dfb30fe9da5a8a15ea952aaed6f3df8e69490) | `python310Packages.vt-py: 0.14.0 -> 0.15.0`                                      |
| [`54b9b9de`](https://github.com/NixOS/nixpkgs/commit/54b9b9de66fe47c1db7e1b91172cf66f10cdbb8c) | `python310Packages.fastapi-mail: 1.0.9 -> 1.1.4`                                 |
| [`2ae3c22c`](https://github.com/NixOS/nixpkgs/commit/2ae3c22cd0dbcf269125d75a87d9a24261ff7f96) | `mid2key: trivial fixup after commit e0476d93fe71d`                              |
| [`aa236f56`](https://github.com/NixOS/nixpkgs/commit/aa236f56aea40f2493885a9f69742d594148a0b0) | `werf: 1.2.160 -> 1.2.163`                                                       |
| [`ae978f07`](https://github.com/NixOS/nixpkgs/commit/ae978f07c5a6d187ed4a69616292e791306f7008) | `godot: 3.4.4 -> 3.5 (#186692)`                                                  |
| [`299cf6a3`](https://github.com/NixOS/nixpkgs/commit/299cf6a3338777acad1a2f6e9f79578f48c38c0f) | `linuxPackages.rtl8814au: unstable-2022-05-23 -> unstable-2022-08-18`            |
| [`519f50b6`](https://github.com/NixOS/nixpkgs/commit/519f50b6ea38393f2e8e693d5f39c83246e63f76) | `variety: 0.8.7 -> 0.8.9`                                                        |
| [`6984bd00`](https://github.com/NixOS/nixpkgs/commit/6984bd009bd82218a83679198ad630c0ff09506a) | `v2ray-geoip: 202208040058 -> 202208180100`                                      |
| [`3fbeb338`](https://github.com/NixOS/nixpkgs/commit/3fbeb338b44a0e7994a6b04503704d5efa03cedc) | `trillian: 1.4.2 -> 1.5.0`                                                       |
| [`a3c401f3`](https://github.com/NixOS/nixpkgs/commit/a3c401f35e2a6d887c7dded993ede77c2e59d09c) | `blender-hip: add blender with hip support (#187241)`                            |
| [`a1dc0e04`](https://github.com/NixOS/nixpkgs/commit/a1dc0e04a89acb42c37e503d41ba280d0ececece) | `ghz: init at 0.109.0 (#183514)`                                                 |
| [`2e8ee595`](https://github.com/NixOS/nixpkgs/commit/2e8ee595cdbb6ecbbc11e610132da6a1385fa370) | `python310Packages.glances-api: 0.3.6 -> 0.4.0`                                  |
| [`16eb45c6`](https://github.com/NixOS/nixpkgs/commit/16eb45c655f453e7a84d6a98927dc7b3b8dea05c) | `doc: add note about makeWrapper and PATH modification`                          |
| [`b5526585`](https://github.com/NixOS/nixpkgs/commit/b5526585c2de2e66c9111a5484dee65806acbcf5) | `treewide: inject xdg-open into wrappers as $PATH suffix`                        |
| [`ff69a9ad`](https://github.com/NixOS/nixpkgs/commit/ff69a9ad9d8ed121b5cd16f058043002b9e326a0) | `discourse.plugins.discourse-oauth2-basic: init`                                 |
| [`0a3b5c8b`](https://github.com/NixOS/nixpkgs/commit/0a3b5c8b82336548715664763c6ed3712cd4641c) | `sockdump: init at unstable-2022-05-27`                                          |
| [`7e234e5a`](https://github.com/NixOS/nixpkgs/commit/7e234e5a1a9f11dcd7fcf7ab2053c609cabf952b) | `btrfs-progs: add udevSupport arg (#174323)`                                     |
| [`58c4d8ad`](https://github.com/NixOS/nixpkgs/commit/58c4d8ad86e1cffe18acdbb2091aeaaf1a30199b) | `pythonPackages.uamqp: fix build on Darwin`                                      |
| [`d5509f68`](https://github.com/NixOS/nixpkgs/commit/d5509f68e5d5f52ed46e995860e43bf7ab39faf2) | `python310Packages.pyviz-comms: 2.2.0 -> 2.2.1`                                  |
| [`6b3f341e`](https://github.com/NixOS/nixpkgs/commit/6b3f341eab6dbc44c2918d1da9c8061bb45272ae) | `writedisk 1.2.0 -> 1.3.0`                                                       |
| [`7b0b92f5`](https://github.com/NixOS/nixpkgs/commit/7b0b92f5a99b359e89262d999e24b0e9183d3a60) | `Revert "nixos/fwupd: enable udisks2"`                                           |
| [`9754c6d3`](https://github.com/NixOS/nixpkgs/commit/9754c6d33258b7800dcb1187a0951128ab86b319) | `nixos/fwupd: migrate to uefi_capsule.conf`                                      |
| [`f9d47f6c`](https://github.com/NixOS/nixpkgs/commit/f9d47f6c6bc984a18a883d5cb08a20d3b519602b) | `python310Packages.amarna: init at 0.1.2`                                        |
| [`97f1bb2f`](https://github.com/NixOS/nixpkgs/commit/97f1bb2f9906deedc36013d64df1d210c3ca429c) | `p4c: init at 1.2.2.1`                                                           |
| [`a62e8655`](https://github.com/NixOS/nixpkgs/commit/a62e8655016da2f4c2d4143a0ce7ec6d5e241ffd) | `portunus: 1.1.0-beta.2 -> 1.1.0`                                                |
| [`98e6eddd`](https://github.com/NixOS/nixpkgs/commit/98e6eddd835bd8efbacaa1625144c93f9f92969b) | `python3Packages.pep8-naming: fix tests for flake8 => 5`                         |
| [`aacd650a`](https://github.com/NixOS/nixpkgs/commit/aacd650ab141586d89de431b5a23a78347ed4641) | `python310Packages.approvaltests: 5.3.3 -> 5.4.2`                                |
| [`e5f96e75`](https://github.com/NixOS/nixpkgs/commit/e5f96e7551ea33f765068bc92dd61313492c0e6f) | `rtl88x2bu: 2022-05-23 -> 2022-08-18`                                            |
| [`37681056`](https://github.com/NixOS/nixpkgs/commit/37681056c20e48fdbca2e0c4701fe4d09d2afbc6) | `sgrep: add smoke test`                                                          |
| [`8d9ea37e`](https://github.com/NixOS/nixpkgs/commit/8d9ea37e808595ccf70da2aeb3e8849574a6cbc2) | `sgrep: init at 1.94a`                                                           |
| [`4e7b4a53`](https://github.com/NixOS/nixpkgs/commit/4e7b4a533248c5a47eae337453f53a6adab413fe) | `maintainers: add eigengrau`                                                     |
| [`c6cdd921`](https://github.com/NixOS/nixpkgs/commit/c6cdd9216a12d79e0134180023ce2af337747623) | `hydrus: 495 -> 496`                                                             |
| [`d7569a92`](https://github.com/NixOS/nixpkgs/commit/d7569a9223b8f710b7aa2df9af0feda45c96385d) | `humioctl: 0.29.1 -> 0.29.2`                                                     |
| [`3648f4a6`](https://github.com/NixOS/nixpkgs/commit/3648f4a6fb54c24b782e7505da2b584d65522eb3) | `home-assistant: 2022.8.5 -> 2022.8.6`                                           |
| [`2aac29e2`](https://github.com/NixOS/nixpkgs/commit/2aac29e2925d333e49c9a698dd33c60c12492107) | `btcpayserver: 1.6.6 -> 1.6.9`                                                   |
| [`371816f2`](https://github.com/NixOS/nixpkgs/commit/371816f2a55c493286059ba855a7bdb958090f40) | `nixpacks: 0.2.13 -> 0.3.2`                                                      |
| [`8750040d`](https://github.com/NixOS/nixpkgs/commit/8750040d37378f4bab43545af5f574c13b349aa0) | `gosec: 2.12.0 -> 2.13.0`                                                        |
| [`9fd235b4`](https://github.com/NixOS/nixpkgs/commit/9fd235b40a992d33c3e30956485a7a893ed093bc) | `sysbench: add macOS support (#185750)`                                          |
| [`36083716`](https://github.com/NixOS/nixpkgs/commit/36083716c2c1b45af9c98c6de70bd4f0d13f6615) | `nanomsg: fix pkgconfig file`                                                    |
| [`280a0f86`](https://github.com/NixOS/nixpkgs/commit/280a0f86005770d321a8c3be5670a7c5d7a149d3) | `kitty-themes: 2022-05-04 -> 2022-08-11`                                         |
| [`16b2c217`](https://github.com/NixOS/nixpkgs/commit/16b2c2170b179d23fd50f3dd3222292c7a6d47b9) | `cargo-tauri: init at 1.0.5 (#186252)`                                           |
| [`11d8a148`](https://github.com/NixOS/nixpkgs/commit/11d8a148a10a54322df21431a861908c805342b0) | `obs-backgroundremoval: init at 0.4.0`                                           |
| [`f36d79dc`](https://github.com/NixOS/nixpkgs/commit/f36d79dcb743d9c5be13721c1b10424cde4639ed) | `python3Packages.django_4: patch in zoneinfo directory`                          |
| [`d00b39e1`](https://github.com/NixOS/nixpkgs/commit/d00b39e1747295b6be6b3dce7a64a80c6e3503da) | `cinnamon.cinnamon-common: ensure xapp is available for cinnamon-desktop-editor` |
| [`3de049f7`](https://github.com/NixOS/nixpkgs/commit/3de049f71d83be9c22d360408dc266d8da0c4893) | `cinnamon.cinnamon-common: ensure caribou is in XDG_DATA_DIRS`                   |
| [`cf7ef522`](https://github.com/NixOS/nixpkgs/commit/cf7ef522ee5ff88b7e21ad073fb068a3637d1c1b) | `python310Packages.types-urllib3: 1.26.22 -> 1.26.23`                            |
| [`5283c2b8`](https://github.com/NixOS/nixpkgs/commit/5283c2b8918d708f50bc505e6af84f19c88bb2dd) | `python310Packages.types-setuptools: 64.0.1 -> 65.1.0`                           |
| [`1f5f7712`](https://github.com/NixOS/nixpkgs/commit/1f5f7712921e4759057f7e90a5f63e2a326cc538) | `python310Packages.types-requests: 2.28.8 -> 2.28.9`                             |
| [`3f236703`](https://github.com/NixOS/nixpkgs/commit/3f23670311f468eb3b737ae940093c3f67868722) | `python310Packages.types-pytz: 2022.1.2 -> 2022.2.1.0`                           |
| [`8c340008`](https://github.com/NixOS/nixpkgs/commit/8c3400088e893c7fdf374f65cd445dee2d5a79b0) | `python310Packages.bleak-retry-connector: 1.10.0 -> 1.10.1`                      |
| [`50782967`](https://github.com/NixOS/nixpkgs/commit/5078296741a8bf10f825f17717ebaa0a71a60d87) | `python310Packages.bleak-retry-connector: 1.9.0 -> 1.10.0`                       |
| [`11e0d0c3`](https://github.com/NixOS/nixpkgs/commit/11e0d0c3f85f2a37c119c52b0fee941eb6ae9cdf) | `python310Packages.bleak-retry-connector: 1.8.0 -> 1.9.0`                        |
| [`f4e93a3d`](https://github.com/NixOS/nixpkgs/commit/f4e93a3ded837ea8b49e7dec899bc8e19ff2690f) | `thunderbird*: 102.0.3 -> 102.1.2`                                               |
| [`d1843b43`](https://github.com/NixOS/nixpkgs/commit/d1843b4338f1bbaa43c9c4a45dcf836fd3718b06) | `memray: 1.2.0 -> 1.3.0`                                                         |
| [`cf5cf4ac`](https://github.com/NixOS/nixpkgs/commit/cf5cf4acf64798fc13cd23bc6feeecaf08755f9e) | `python310Packages.pymicrobot: 0.0.3 -> 0.0.4`                                   |
| [`a95e48cd`](https://github.com/NixOS/nixpkgs/commit/a95e48cd9ccda42154366574baab7703d7cb1822) | `python310Packages.peaqevcore: 5.4.3 -> 5.10.3`                                  |
| [`5b788319`](https://github.com/NixOS/nixpkgs/commit/5b788319a86196fe06af81399269843a78db1829) | `python310Packages.teslajsonpy: 2.4.1 -> 2.4.2`                                  |
| [`541d973f`](https://github.com/NixOS/nixpkgs/commit/541d973f263486abef38231e0a54ee753e6f787c) | `python310Packages.bthome-ble: init at 0.2.2`                                    |
| [`89d3d54f`](https://github.com/NixOS/nixpkgs/commit/89d3d54fbed455530f6b9af06ad27481854c3bc1) | `python310Packages.sensor-state-data: 2.2.0 -> 2.3.1`                            |
| [`1f0e19b6`](https://github.com/NixOS/nixpkgs/commit/1f0e19b63889d4504070204c2dd21c9e72c2fa54) | `rdma-core: 41.0 -> 42.0`                                                        |
| [`e49778ef`](https://github.com/NixOS/nixpkgs/commit/e49778efefd68f67edda3215d54544d62e60bee6) | `python310Packages.mockito: 1.3.4 -> 1.3.5`                                      |
| [`cd3591f5`](https://github.com/NixOS/nixpkgs/commit/cd3591f562d507782697887b03abace44e383a0f) | `ballerina: add smoke test`                                                      |
| [`1be38595`](https://github.com/NixOS/nixpkgs/commit/1be3859507a2ffd57a30349d3aac9ff8507b5dec) | `ballerina: init at 2201.1.0`                                                    |
| [`c0c9ca57`](https://github.com/NixOS/nixpkgs/commit/c0c9ca57c35f426bff6496ca694d7880fdcce40f) | `maintainers: add eigengrau`                                                     |
| [`a4c8d130`](https://github.com/NixOS/nixpkgs/commit/a4c8d1308d8004efb96f7ecb1d5c35427aeece9e) | `tasktimer: init at 1.9.4`                                                       |
| [`f605bbb8`](https://github.com/NixOS/nixpkgs/commit/f605bbb84511b8c630c8caff6b0b9ed773a5e7b9) | `python310Packages.knack: 0.9.0 -> 0.10.0`                                       |
| [`280fa198`](https://github.com/NixOS/nixpkgs/commit/280fa1988e5f758a9430469ccf1159554fbd8380) | `pixelorama: 0.10.1 -> 0.10.2`                                                   |
| [`ac1400be`](https://github.com/NixOS/nixpkgs/commit/ac1400be005106e6ece93f6db390b1635371c129) | `oq: 1.3.3 -> 1.3.4`                                                             |
| [`97c5787f`](https://github.com/NixOS/nixpkgs/commit/97c5787fad8362d6535a6b598b10d025a10daa2a) | `haskellPackages: mark builds failing on hydra as broken`                        |
| [`f303875b`](https://github.com/NixOS/nixpkgs/commit/f303875b7ed45cf5389934ea499c6567528ffe14) | `hedgewars: don't build on hydra`                                                |
| [`09efc9ce`](https://github.com/NixOS/nixpkgs/commit/09efc9ceef15c05021633cc77bf2217b36c7eaf3) | `dillo: 3.0.5 -> 2021-02-09`                                                     |
| [`f7480d66`](https://github.com/NixOS/nixpkgs/commit/f7480d66e973d1477899c59783e481d84cf22ec3) | `kdash: 0.3.3 -> 0.3.4`                                                          |
| [`76e45461`](https://github.com/NixOS/nixpkgs/commit/76e45461faab9808f1e37dc1689d36430499a7fa) | `matrix-synapse.tools.synadm: 0.34 -> 0.35`                                      |
| [`9f585d72`](https://github.com/NixOS/nixpkgs/commit/9f585d722b5b51d72c90614570a6e308c3c06a77) | `python3Packages.arnparse: init at 0.0.2`                                        |
| [`10295ccb`](https://github.com/NixOS/nixpkgs/commit/10295ccb167f390165be9a3a48927f428aa8a311) | `python310Packages.chart-studio: 5.9.0 -> 5.10.0`                                |
| [`b9b9d3c9`](https://github.com/NixOS/nixpkgs/commit/b9b9d3c98c9096b394b93923a5b429b945864673) | `python310Packages.cement: 3.0.6 -> 3.0.8`                                       |
| [`54046d3f`](https://github.com/NixOS/nixpkgs/commit/54046d3f71dcda1b3192328e638cceadf589c136) | `python310Packages.atlassian-python-api: 3.25.0 -> 3.26.0`                       |
| [`ded34e3d`](https://github.com/NixOS/nixpkgs/commit/ded34e3d1014572471690ecaaa2adfd6b1ec19f1) | `python310Packages.blebox-uniapi: 2.0.2 -> 2.1.0`                                |
| [`02de6593`](https://github.com/NixOS/nixpkgs/commit/02de659303f8a5178a377238bcdbcd58eb4fc6a4) | `colmena: 0.3.0 -> 0.3.1`                                                        |
| [`53c3aee2`](https://github.com/NixOS/nixpkgs/commit/53c3aee2c3c5801ee023d4b105ae30ea3af9b26d) | `libdeltachat: 1.87.0 -> 1.93.0`                                                 |
| [`f3b645eb`](https://github.com/NixOS/nixpkgs/commit/f3b645eb39bf4f7aacb989e0671b4ebfdb6ab3c1) | `git-delete-merged-branches: 7.0.0 -> 7.2.0`                                     |
| [`66cac689`](https://github.com/NixOS/nixpkgs/commit/66cac6896c456750ff9c6957484d475131349ae6) | `linux_lqx: 5.18.17-lqx1 -> 5.19.2-lqx1`                                         |
| [`6c1af96c`](https://github.com/NixOS/nixpkgs/commit/6c1af96c06e2fde12dc95aa20f7f0154edf2c5b2) | `linux_zen: 5.19.1 -> 5.19.2`                                                    |
| [`302ced16`](https://github.com/NixOS/nixpkgs/commit/302ced168573ef5b7f7fc154925a546fc8c70022) | `python310Packages.pyhaversion: 22.4.1 -> 22.8.0`                                |
| [`70cf130c`](https://github.com/NixOS/nixpkgs/commit/70cf130cf0e6ece75a858fee9d2def449a094de2) | `pt2-clone: 1.50 -> 1.51`                                                        |
| [`a631855b`](https://github.com/NixOS/nixpkgs/commit/a631855b0b82304ed2b2910f3661ef33fcd1e2ff) | `arkade: 0.8.32 -> 0.8.34`                                                       |
| [`3f9a9450`](https://github.com/NixOS/nixpkgs/commit/3f9a94502571257b56b761bd5be6d68897f34fb0) | `gopsuinfo: mark package as Linux-only`                                          |
| [`887e9eb5`](https://github.com/NixOS/nixpkgs/commit/887e9eb57871bdba93449d78a6af92773f3ce6f7) | `okteto: 2.5.2 -> 2.5.3`                                                         |
| [`c425f2d1`](https://github.com/NixOS/nixpkgs/commit/c425f2d11a99000a93b6eb29d4a6d47ef86a7624) | `nfpm: 2.18.0 -> 2.18.1`                                                         |
| [`dc594280`](https://github.com/NixOS/nixpkgs/commit/dc594280fd18dc5f0f2be1039e2375711327f8a3) | `haskell-language-server: fix with ghc-lib >= 9.0 and ghc <= 8.10.7`             |
| [`a33b4a55`](https://github.com/NixOS/nixpkgs/commit/a33b4a55393db31e7c099b12a433c5b420bd326e) | `cinnamon.mint-artwork: drop unused sed`                                         |
| [`038d91ed`](https://github.com/NixOS/nixpkgs/commit/038d91ed4171d5f310f2c30c8f522fcf5e2df818) | `rl-2211: mention blueman & slick-greeter switch`                                |
| [`e2ddd98c`](https://github.com/NixOS/nixpkgs/commit/e2ddd98cc91cc7736e9299d0f560164629ac7a98) | `nixos/cinnamon: default to slick-greeter`                                       |
| [`f2f9e31e`](https://github.com/NixOS/nixpkgs/commit/f2f9e31e428d3f84b807c1b51020bcbeee459b78) | `glooctl: 1.12.6 -> 1.12.7`                                                      |
| [`ddd6ed5c`](https://github.com/NixOS/nixpkgs/commit/ddd6ed5c3c3c1f1c9fae3176748b3a84b5c005b0) | `headscale: 0.16.2 -> 0.16.3`                                                    |
| [`1a6ae529`](https://github.com/NixOS/nixpkgs/commit/1a6ae5294766cd47246c9b949ffa16f1e04136e6) | `bazelisk: 1.12.0 -> 1.12.2`                                                     |
| [`fdac82a3`](https://github.com/NixOS/nixpkgs/commit/fdac82a307201be6ee1e27fa24fd04e8e8b2c711) | `nixos/lightdm-greeters/slick: init`                                             |
| [`7f92320f`](https://github.com/NixOS/nixpkgs/commit/7f92320f6667ce823d4f5cfe17813f0a9f98999b) | `make-bootstrap-tools.nix: drop libelf.so from tootstrap tarballs`               |
| [`81e4c5cc`](https://github.com/NixOS/nixpkgs/commit/81e4c5cc151b20e6a6dcec153a089b72f7b29d35) | `lightdm-slick-greeter: init at 1.5.9`                                           |
| [`e5cc482c`](https://github.com/NixOS/nixpkgs/commit/e5cc482c7f8b825edaaaac2ebe54234c996ff444) | `rathole: init at 0.4.3`                                                         |
| [`60f7d277`](https://github.com/NixOS/nixpkgs/commit/60f7d2774145a52a0292f3b8f38d0432d487148b) | `hedgewars: mark broken`                                                         |
| [`fef6c10b`](https://github.com/NixOS/nixpkgs/commit/fef6c10b5cb404f1c772c118289a698ef396a654) | `maintainers: add water-sucks`                                                   |
| [`f9047f47`](https://github.com/NixOS/nixpkgs/commit/f9047f4745ae02115b67e7b3becb9dfc92aac1b4) | `linux_xanmod: remove unused kernel configs`                                     |
| [`356f21b2`](https://github.com/NixOS/nixpkgs/commit/356f21b2e00b9537bce7d0d43a3abbd33d76d230) | `linux_xanmod: only apply fix for removed options on tt variant`                 |
| [`665bef82`](https://github.com/NixOS/nixpkgs/commit/665bef8266a4c7bc1db75aa48fd8298b38e75e56) | `vivaldi: 5.4.2753.33-1 -> 5.4.2753.37-1`                                        |
| [`07d0d5b7`](https://github.com/NixOS/nixpkgs/commit/07d0d5b704929a0d029ea3be2d6e8694f07a9b91) | `AusweisApp2: 1.22.7 -> 1.24.0`                                                  |
| [`a10b7b89`](https://github.com/NixOS/nixpkgs/commit/a10b7b89713e1f160ebf41d2f200537afbda0378) | `go-toml: 2.0.2 -> 2.0.3`                                                        |
| [`ead58a31`](https://github.com/NixOS/nixpkgs/commit/ead58a312fca0bc3c644d06adc84df0792fd4ea1) | `freedv: 1.8.3 -> 1.8.3.1`                                                       |
| [`d39e508e`](https://github.com/NixOS/nixpkgs/commit/d39e508e036dfc0ca6df395a9cf6476911130d04) | `python310Packages.bimmer-connected: 0.10.1 -> 0.10.2`                           |