### PR TITLE
chore(flake/darwin): `80871c71` -> `5af1aa51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660649317,
-        "narHash": "sha256-16sWaj3cTZOQQgrmzlvBSRaBFKLrHJrfYh1k7/sSWok=",
+        "lastModified": 1661154924,
+        "narHash": "sha256-zwkShc4VZ9feLeIrWjdm6YkZBoobzXETF5xIIgi++Ec=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "80871c71edb3da76d40bdff9cae007a2a035c074",
+        "rev": "5af1aa51f63d734284bf6728a21d2c9c31eb7492",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                                                |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
| [`fbca12e5`](https://github.com/LnL7/nix-darwin/commit/fbca12e524fc8bae0dffbcd97fe2be196a9a3e8c) | `feat: provide option to display the appswitcher on all displays`             |
| [`796a72f0`](https://github.com/LnL7/nix-darwin/commit/796a72f0fe2c8df0e37f0febda3b6aad3b351a68) | `Update changelog`                                                            |
| [`8e2c71d1`](https://github.com/LnL7/nix-darwin/commit/8e2c71d1ca85461c6295dba31481eadb07fdbb19) | ``Tweak `nix.gc` module to more closely match NixOS module``                  |
| [`c027fb5e`](https://github.com/LnL7/nix-darwin/commit/c027fb5ee5df3c33f9a2ce088b30100cdf3fa028) | ``Update `nix.gc` module with same indenting/formatting as NixOS module``     |
| [`f75b461a`](https://github.com/LnL7/nix-darwin/commit/f75b461ae2da5de249359b17996805199e919ca7) | `Fix tests failing due to Nix version check`                                  |
| [`ffc8ec5c`](https://github.com/LnL7/nix-darwin/commit/ffc8ec5c9ae6cf7b3bb95866432e30e46e7cc731) | `Add .nix-defexpr to NIX_PATH the way the NixOS module does`                  |
| [`2120245f`](https://github.com/LnL7/nix-darwin/commit/2120245fc210af504686da80ea3dfff27ef22b9e) | `Fix #387 nix-rebuild --flake without XCode tools`                            |
| [`08edc0e1`](https://github.com/LnL7/nix-darwin/commit/08edc0e19ac33435bd2b5dede373a2bea9f13b49) | ``Update/adapt daemon CPU/IO priority options in `nix` module``               |
| [`7e74c1c9`](https://github.com/LnL7/nix-darwin/commit/7e74c1c9fbb19638d95933b8bcac1757a184519e) | ``Move build user options to `nix` module to improve overlap with NixOS``     |
| [`f88286ed`](https://github.com/LnL7/nix-darwin/commit/f88286eda079b404da179efa86b907b166b878e3) | ``Update `nix.registry` definition to match NixOS module``                    |
| [`7648c9be`](https://github.com/LnL7/nix-darwin/commit/7648c9befcc011091eccdf48a61a819cc835f2f8) | ``Refactor `nix.nixPath` to make diff easier to compare with NixOS module``   |
| [`c3bdd6d9`](https://github.com/LnL7/nix-darwin/commit/c3bdd6d95f605a8248768ba43338ef8269173d57) | ``Update `nix.buildMachines` def and implementation to match NixOS module``   |
| [`39cf1e6f`](https://github.com/LnL7/nix-darwin/commit/39cf1e6fbe24c1e8fce9d9618ca964b4ef486ed2) | ``Minor tweaks to `nix` module options defs``                                 |
| [`d44b8be3`](https://github.com/LnL7/nix-darwin/commit/d44b8be38ce5e021bf3a280fa63087b4d79c26ee) | ``Reorder `nix` module implementation to better match order of NixOS module`` |
| [`5786c079`](https://github.com/LnL7/nix-darwin/commit/5786c079f8c095a77d6c8fb72d06a093bfdfa9d3) | ``Make `nix.settings` docs specific to (nix-)darwin where applicable``        |
| [`a00b3836`](https://github.com/LnL7/nix-darwin/commit/a00b3836a5c60efc652bcbed83393bae13fab2af) | ``Update `nix.settings` def and implementation to match NixOS module``        |
| [`5f141365`](https://github.com/LnL7/nix-darwin/commit/5f141365afa8fcdd7fc7aee65031b850118f1bc0) | ``Update def and implementation of `nix.package` to match NixOS module``      |
| [`490ef804`](https://github.com/LnL7/nix-darwin/commit/490ef804858936eab2def7b0564f68a2e777d7d9) | ``Reindent/format `nix` module to more closely match NixOS module``           |
| [`9a5fb50e`](https://github.com/LnL7/nix-darwin/commit/9a5fb50ea91631c2862b0c917ea2b4e1d37ef3ac) | ``Reorder `nix` module options to match order in NixOS module``               |
| [`f729a09a`](https://github.com/LnL7/nix-darwin/commit/f729a09a28043159d6221df04b343260b1314644) | ``Update `nix` module to use `settings` sub options like in NixOS module``    |
| [`a3cab812`](https://github.com/LnL7/nix-darwin/commit/a3cab812ac424ce6115c66d441ceaa454f59f3ae) | `add escape to shell aliases`                                                 |