### PR TITLE
chore(flake/nixpkgs): `13711c9a` -> `a7855f22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660998696,
-        "narHash": "sha256-N5eDv9THZz5pFn7NR1swaFrAJYByfrA5gU5L7JONItA=",
+        "lastModified": 1661088761,
+        "narHash": "sha256-5DGKX81wIPAAiLwUmUYECpA3vop94AHHR7WmGXSsQok=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13711c9ab9f5a160a44affb7a6221be53318a873",
+        "rev": "a7855f2235a1876f97473a76151fec2afa02b287",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                    |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`272fad73`](https://github.com/NixOS/nixpkgs/commit/272fad732d39b24c4549c475176e0d8cbc8c897a) | `pqrs: 0.1.1 -> 0.2.1 (#183740)`                                  |
| [`b5688a00`](https://github.com/NixOS/nixpkgs/commit/b5688a00bb3bc56a0dadde03b670b42fe935bbfc) | `ffmpeg-normalize: 1.24.1 -> 1.25.0`                              |
| [`bcced38c`](https://github.com/NixOS/nixpkgs/commit/bcced38c385881084ae2ee67b04e315bc4e2e4c8) | `python310Packages.yalexs-ble: 1.6.3 -> 1.6.4`                    |
| [`08e21a46`](https://github.com/NixOS/nixpkgs/commit/08e21a4662d414c8ec4b3dab1c432844f8ca3df7) | `python310Packages.yalexs-ble: 1.6.2 -> 1.6.3`                    |
| [`fd53244b`](https://github.com/NixOS/nixpkgs/commit/fd53244bec9dfa9f28bcb9074decea80ec10e700) | `linux: fix builds for old LTS kernels`                           |
| [`89d19db0`](https://github.com/NixOS/nixpkgs/commit/89d19db0a018e37142d2aad2328b3399a010b4f4) | `python310Packages.pyswitchbot: 0.18.13 -> 0.18.14`               |
| [`71a04092`](https://github.com/NixOS/nixpkgs/commit/71a04092a0644a70a77c7c43b7eeba18db05f389) | `python310Packages.pyswitchbot: 0.18.12 -> 0.18.13`               |
| [`f54e0689`](https://github.com/NixOS/nixpkgs/commit/f54e0689235d518d29d5620d8b5a8641d3ac066a) | `python310Packages.asdf: update disabled`                         |
| [`40819027`](https://github.com/NixOS/nixpkgs/commit/4081902723ba172b069e932c1813c8f97a8269b6) | `python310Packages.pathvalidate: update disabled`                 |
| [`b2834674`](https://github.com/NixOS/nixpkgs/commit/b28346740171ba85992d57cb9072afb7900c821d) | `berry: patch the version in the configure script`                |
| [`dff76dfe`](https://github.com/NixOS/nixpkgs/commit/dff76dfe09cd4d386333f99cb738d418075a6095) | `virt-what: 1.24 -> 1.25`                                         |
| [`b1449798`](https://github.com/NixOS/nixpkgs/commit/b14497986fafc72087a047f3c2924044bd0157c9) | `smartdns: 37 -> 37.1`                                            |
| [`afeb123d`](https://github.com/NixOS/nixpkgs/commit/afeb123d844b70c5df72ccf411dc2fee5e229ded) | `terraform-providers: update 2022-08-21`                          |
| [`e33b9158`](https://github.com/NixOS/nixpkgs/commit/e33b9158e32cb64983e7b3ff55378ada702ef0c8) | `ops: init at 0.1.32`                                             |
| [`57e87cc0`](https://github.com/NixOS/nixpkgs/commit/57e87cc0db82b0e4ed2ec7cfaec8c737e483acb3) | `hyperrogue: 11.3o -> 12.0u`                                      |
| [`cbe0ee62`](https://github.com/NixOS/nixpkgs/commit/cbe0ee62698a3c25b45824fa5376f71a69f69499) | `python3Packages.lizard: init at 1.17.10 (#187155)`               |
| [`5c813b35`](https://github.com/NixOS/nixpkgs/commit/5c813b35c9161a6bb707879449a940d3940e85af) | `python3Packages.bucketstore: init at 0.2.2 (#187194)`            |
| [`d52e5c72`](https://github.com/NixOS/nixpkgs/commit/d52e5c72d389d0099503554b34ac89eda9daa112) | `libcgroup: 0.42.2 -> 2.0.2 (#185260)`                            |
| [`bc04edf2`](https://github.com/NixOS/nixpkgs/commit/bc04edf2b5f09915f1f95b34a506f3928b175dcf) | `python3Packages.ripe-atlas-cousteau: init at 1.5.1 (#155270)`    |
| [`3d8ec1f8`](https://github.com/NixOS/nixpkgs/commit/3d8ec1f8c996b4a8ef70752db6a6f0598c77460e) | `python310Packages.types-redis: 4.3.14 -> 4.3.15`                 |
| [`065ea88f`](https://github.com/NixOS/nixpkgs/commit/065ea88fe6203a21774a92e918f78f1ad3652ab0) | `libbluray: 1.3.1 -> 1.3.2`                                       |
| [`dd4c5e6a`](https://github.com/NixOS/nixpkgs/commit/dd4c5e6afcd535b30a42d2972735075e49c8ef62) | `lhapdf: 6.5.1 -> 6.5.2`                                          |
| [`8bba8d2e`](https://github.com/NixOS/nixpkgs/commit/8bba8d2e12df4d0e329a9a2cde0cf56853c269c6) | `python310Packages.pathvalidate: 2.5.1 -> 2.5.2`                  |
| [`b3b1dd0e`](https://github.com/NixOS/nixpkgs/commit/b3b1dd0e38a3066b074b1c6dcfd268e8d4517f0e) | `zine: add missing Darwin frameworks (#187659)`                   |
| [`4376b54e`](https://github.com/NixOS/nixpkgs/commit/4376b54e768edc4782df2f624dbabaf8333e21c6) | `terra: 1.0.4 -> 1.0.5 (#187065)`                                 |
| [`b38fc30e`](https://github.com/NixOS/nixpkgs/commit/b38fc30e44de24a91f9bfb475b08bee35aacf9af) | `celluloid: 0.23 -> 0.24`                                         |
| [`ad8041c0`](https://github.com/NixOS/nixpkgs/commit/ad8041c08ca8f7498ad2fa363a1e4c43e207c483) | `cataclysm-dda-git: 2021-07-03 -> 2022-08-20 (#187209)`           |
| [`b9b92556`](https://github.com/NixOS/nixpkgs/commit/b9b92556277f2ee55828fff966ba4633e4c87246) | `wofi-emoji: 2021-05-24 -> 2022-08-19 (#187494)`                  |
| [`b05dad54`](https://github.com/NixOS/nixpkgs/commit/b05dad54360d354d6ee7f4f81038d1f11b7638a6) | `ocamlPackages.pyml: 20211015 -> 20220615`                        |
| [`393c375b`](https://github.com/NixOS/nixpkgs/commit/393c375b97a728f8b5707fa589ba344a6d08e822) | `python310Packages.asdf: 2.12.1 -> 2.13.0`                        |
| [`755c8f23`](https://github.com/NixOS/nixpkgs/commit/755c8f230a7fa166a1b61846a7293f9810ae95d5) | `libpkgconf: 1.9.2 -> 1.9.3`                                      |
| [`4d927a17`](https://github.com/NixOS/nixpkgs/commit/4d927a17fbf784b7e1cbaa735fa029cdfaed9bdc) | `python310Packages.sphinx-argparse: Fix tests (#187400)`          |
| [`9e6fd6c8`](https://github.com/NixOS/nixpkgs/commit/9e6fd6c8aad7da7a1b0a7aa346b8e6065f592380) | `pocketbase: init at 0.4.2 (#187024)`                             |
| [`74ed4b5e`](https://github.com/NixOS/nixpkgs/commit/74ed4b5ead62140ec82c5b0eb22446233c966569) | `vimPlugins.legendary-nvim: init at 2022-07-26`                   |
| [`faaf77b1`](https://github.com/NixOS/nixpkgs/commit/faaf77b13ca7060400f3f9cf97c26f90e02af276) | `vimPlugins.lsp-format-nvim: init at 2022-05-21`                  |
| [`27aaf5f4`](https://github.com/NixOS/nixpkgs/commit/27aaf5f45a0f7025c78d82e0f42adf13855304ab) | `vimPlugins.onenord-nvim: init at 2022-07-15`                     |
| [`a9135abe`](https://github.com/NixOS/nixpkgs/commit/a9135abe0aa3d05bf529d635315a90e4bd5c4a50) | `vimPlugins: resolve github repository redirects`                 |
| [`3564c195`](https://github.com/NixOS/nixpkgs/commit/3564c1952ee9b0073c29176b38871897d65d9fb2) | `vimPlugins: update`                                              |
| [`9dcc0f7f`](https://github.com/NixOS/nixpkgs/commit/9dcc0f7f713b3fb6227396548133121837e7f6f4) | `vimPlugins.compe-conjure: fix repo url`                          |
| [`d61bc96d`](https://github.com/NixOS/nixpkgs/commit/d61bc96d16ca288c69b798b8e31eca64050098e3) | `Fix a typo in the lib.foldr docstring`                           |
| [`30536606`](https://github.com/NixOS/nixpkgs/commit/30536606bb2ca1ecc2d8c8e98d020e24abf1b081) | `qgis-ltr: 3.22.9 → 3.22.10`                                      |
| [`e54e97ac`](https://github.com/NixOS/nixpkgs/commit/e54e97acecb93a24b7d8036da9b568be34ef59fc) | `qgis: 3.26.1 → 3.26.2`                                           |
| [`1b0a51cb`](https://github.com/NixOS/nixpkgs/commit/1b0a51cbb72d6c5801407279ddd73c5f5541469f) | `gcc49: mark unsupported on aarch64-darwin`                       |
| [`9c86dfdd`](https://github.com/NixOS/nixpkgs/commit/9c86dfdd611a56757e1a74a08f98302bc60f83a1) | `godot: use wrapProgram instead of makeWrapper`                   |
| [`213d35b0`](https://github.com/NixOS/nixpkgs/commit/213d35b0dd183bc16c568526691a27613db09969) | `zonemaster-cli: init at 4.0.1`                                   |
| [`4a620856`](https://github.com/NixOS/nixpkgs/commit/4a620856a6fd410854e2f4f00de766a65cd9835f) | `osdlyrics: 0.5.10 -> 0.5.11`                                     |
| [`5d99fb61`](https://github.com/NixOS/nixpkgs/commit/5d99fb614b7de5c7fce5f22c56f022bdd3f8fe17) | `nixos/lightdm-greeters/slick: use mkEnableOption`                |
| [`9b10db9d`](https://github.com/NixOS/nixpkgs/commit/9b10db9d355fb0b53fc5c696a90b8e786e0add9b) | `kn: 1.6.0 -> 1.6.1`                                              |
| [`e3c0484a`](https://github.com/NixOS/nixpkgs/commit/e3c0484acd72b45dcfbf82dc0d26d232230ac172) | `neovim: correctly concat single line configs`                    |
| [`2fc50826`](https://github.com/NixOS/nixpkgs/commit/2fc50826ce7066a91d69d194fe7fad16f379ba5c) | `ffmpeg-normalize: 1.24.0 -> 1.24.1`                              |
| [`376625d4`](https://github.com/NixOS/nixpkgs/commit/376625d40f0b17bc742afb4b31c233383c379a08) | `llvmPackages_git: 2022-01-07 -> 2022-25-07, add README`          |
| [`cc36db72`](https://github.com/NixOS/nixpkgs/commit/cc36db72d4397cd6f991d3765f8a8c10f0a57f4e) | `python3Packages.dinghy: init at 0.13.2`                          |
| [`9cd09490`](https://github.com/NixOS/nixpkgs/commit/9cd09490563e59f675bc8eac43d97a9434b64888) | `jadx: 1.4.3 -> 1.4.4`                                            |
| [`5c1e93f2`](https://github.com/NixOS/nixpkgs/commit/5c1e93f2915163e96d51fbb74a1746e64ec4668e) | `translate-shell: 0.9.6.12 -> 0.9.7`                              |
| [`8b709229`](https://github.com/NixOS/nixpkgs/commit/8b7092290c5e2fda3edb6b4dbc95e515c113a621) | `Add myself to Perl CODEOWNERS`                                   |
| [`fcc4037c`](https://github.com/NixOS/nixpkgs/commit/fcc4037cc813722da520df1091b82883778febef) | `python310Packages.jsonlines: add pythonImportsCheck`             |
| [`0dc49ae7`](https://github.com/NixOS/nixpkgs/commit/0dc49ae73e96fd21f28dbf405c0813928f32dc8e) | `python310Packages.cloudflare-dyndns: update description`         |
| [`835642ea`](https://github.com/NixOS/nixpkgs/commit/835642ea366c716421b7f864c5e51b271f111e54) | `python310Packages.cloudflare-dyndns: relax attrs constraint`     |
| [`038526e4`](https://github.com/NixOS/nixpkgs/commit/038526e46dd92b6d36ef792fd1a4443b8610b64f) | `python310Packages.peaqevcore: 5.10.3 -> 5.10.5`                  |
| [`c32f426a`](https://github.com/NixOS/nixpkgs/commit/c32f426ab98ec6933f75a120e2d0c96f2258aec2) | `python310Packages.arc4: 0.2.0 -> 0.3.0`                          |
| [`fcadb8a5`](https://github.com/NixOS/nixpkgs/commit/fcadb8a5dadd8e6dc067d64285a09ecaa5d70b47) | `om4: init at 6.7`                                                |
| [`95de9c23`](https://github.com/NixOS/nixpkgs/commit/95de9c234be19dde1b7543be39c9a3b73feeb997) | `getdns, stubby: update 1.7.0 -> 1.7.2, 0.4.0 -> 0.4.2`           |
| [`a9a7c1e3`](https://github.com/NixOS/nixpkgs/commit/a9a7c1e3d9e320fc41a3583516bfe34cde45c6fb) | `wails: 2.0.0-beta.43 -> 2.0.0-beta.44.2`                         |
| [`c7b7fcf8`](https://github.com/NixOS/nixpkgs/commit/c7b7fcf8379ac4bac4269fab150783e0ef30cb63) | `termusic: 0.7.2 -> 0.7.3`                                        |
| [`9a806c20`](https://github.com/NixOS/nixpkgs/commit/9a806c20162773441f1b4efb852cb79e7a2c45f9) | `python310Packages.pontos: 22.7.2 -> 22.8.1`                      |
| [`b52596ca`](https://github.com/NixOS/nixpkgs/commit/b52596ca68a1c73bd115cb8570aa978df30f5bd1) | `jabref: add gtk3`                                                |
| [`b3ba7da8`](https://github.com/NixOS/nixpkgs/commit/b3ba7da8f2ac566180eed7c69bbd50697e4a6644) | `python310Packages.sentry-sdk: 1.9.4 -> 1.9.5`                    |
| [`312d7920`](https://github.com/NixOS/nixpkgs/commit/312d7920d193e240d470a2b9ab0c0c7683bad9ba) | `python310Packages.sentry-sdk: 1.9.3 -> 1.9.4`                    |
| [`260953cb`](https://github.com/NixOS/nixpkgs/commit/260953cb2a5ee89cf8e4277f99de5d31b6b556aa) | `python310Packages.sentry-sdk: 1.9.2 -> 1.9.3`                    |
| [`f317eed5`](https://github.com/NixOS/nixpkgs/commit/f317eed55c6b948f6a77a5dc462df4c13fadbf69) | `python310Packages.sentry-sdk: 1.9.1 -> 1.9.2`                    |
| [`33d32fc6`](https://github.com/NixOS/nixpkgs/commit/33d32fc639fc2c89ce7586c61629ff10cc111de6) | `python310Packages.sentry-sdk: 1.9.0 -> 1.9.1`                    |
| [`c813975e`](https://github.com/NixOS/nixpkgs/commit/c813975ef5193c44ab3c4fb80ec874f4821d81c3) | `python310Packages.superqt: 0.3.3 -> 0.3.5`                       |
| [`3b42828a`](https://github.com/NixOS/nixpkgs/commit/3b42828a396aeaa8651bb10ce6eacc33711f57f7) | `python310Packages.pyunifiprotect: 4.1.1 -> 4.1.2`                |
| [`6520ef03`](https://github.com/NixOS/nixpkgs/commit/6520ef039d4f3a96a4bf9b4eb84639fd18ff3ff7) | `python310Packages.aioairq: init at 0.1.1`                        |
| [`88f81752`](https://github.com/NixOS/nixpkgs/commit/88f81752c151d3af49cf2f41107ff1ac8c6560cf) | `python310Packages.mahotas: 1.4.12 -> 1.4.13`                     |
| [`efd89e05`](https://github.com/NixOS/nixpkgs/commit/efd89e05a405f6817b48b96f5da3f193d01a46c4) | `eksctl: 0.108.0 -> 0.109.0`                                      |
| [`ba7442e6`](https://github.com/NixOS/nixpkgs/commit/ba7442e6470bf49430dda8f734005615a6569324) | `commitizen: fix build by disabling more tests`                   |
| [`c3a4a7a9`](https://github.com/NixOS/nixpkgs/commit/c3a4a7a9586b7c9b9827c34f8dcc438f39bd6339) | `x-create-mouse-void: init at 0.1`                                |
| [`b0f989a6`](https://github.com/NixOS/nixpkgs/commit/b0f989a6d818705f8ee3d88957ba3a8d8949310e) | `actionlint: 1.6.15 -> 1.6.16`                                    |
| [`bff379e9`](https://github.com/NixOS/nixpkgs/commit/bff379e9ed908e737009038c24d548ba17e81ee2) | `criterion: 2.3.3 -> 2.4.1`                                       |
| [`092b85b9`](https://github.com/NixOS/nixpkgs/commit/092b85b9eb83189220d4ee95462d9667c8f769a9) | `python310Packages.duckdb-engine: update description`             |
| [`f772f4e1`](https://github.com/NixOS/nixpkgs/commit/f772f4e1b2cca10120f0394f6fc9a34a4b65821e) | `python310Packages.chat-downloader: init at 0.2.0`                |
| [`0a0411f9`](https://github.com/NixOS/nixpkgs/commit/0a0411f90eaa87b9376b931dcd28ff72851b36a1) | `_1password: 2.6.1 -> 2.6.2`                                      |
| [`0a8e2d1c`](https://github.com/NixOS/nixpkgs/commit/0a8e2d1cf2385e9a3156860e20b22682238b3839) | `flow: 0.183.1 -> 0.185.1`                                        |
| [`461ce34e`](https://github.com/NixOS/nixpkgs/commit/461ce34ec12a15a844bfaf6f325a7d98c3a0c074) | `postgresqlPackages.postgis: 3.2.2 -> 3.2.3`                      |
| [`a66b1a66`](https://github.com/NixOS/nixpkgs/commit/a66b1a664812c36a3167939bdc8a639597aff59c) | `gifski: 1.7.0 -> 1.7.1`                                          |
| [`e439d0e9`](https://github.com/NixOS/nixpkgs/commit/e439d0e95a151681c574b77daea1275d095e6cbc) | `millet: 0.2.11 -> 0.3.2`                                         |
| [`7753a94a`](https://github.com/NixOS/nixpkgs/commit/7753a94a35438b73a1aa1d8aca233753367ff4d6) | `nodejs: 16.17.0 -> 18.7.0`                                       |
| [`d8a8aa70`](https://github.com/NixOS/nixpkgs/commit/d8a8aa7045b8e91acebe030793032447be206514) | `lxd: 5.4 -> 5.5`                                                 |
| [`dcccf221`](https://github.com/NixOS/nixpkgs/commit/dcccf221043e732268d2b2013a569fd3c8649557) | `nodejs-18_x: add patch to fix npm fail without a HOME directory` |
| [`684a55a2`](https://github.com/NixOS/nixpkgs/commit/684a55a2551cc6d4c513f057729da35860004c6c) | `python3Packages.jaxlib: fix linux build`                         |
| [`458f6bd5`](https://github.com/NixOS/nixpkgs/commit/458f6bd5e7c8eb0c5709be6060c0acfcfedd95e9) | `python310Packages.gsd: 2.5.3 -> 2.6.0`                           |
| [`20b2f595`](https://github.com/NixOS/nixpkgs/commit/20b2f59523a5afaf8f8bc011e945adc754874739) | `anki: build with python 3.9`                                     |
| [`88cc3811`](https://github.com/NixOS/nixpkgs/commit/88cc381139ab3015233dbc3fdec7960ea559804c) | `python310Packages.fastavro: 1.5.3 -> 1.6.0`                      |
| [`17fa3e8c`](https://github.com/NixOS/nixpkgs/commit/17fa3e8c274b782cba92617bca2ddc5cad401fcd) | `python310Packages.duckdb-engine: 0.2.0 -> 0.5.0`                 |
| [`bd0c6768`](https://github.com/NixOS/nixpkgs/commit/bd0c67686d159ac66cfb683e1fce478202d56e2f) | `rofi: 1.7.4 -> 1.7.5`                                            |
| [`cee7417c`](https://github.com/NixOS/nixpkgs/commit/cee7417ce84904b69f8851cc868a2a1b96f1f66f) | `zellij: 0.31.2 -> 0.31.3`                                        |
| [`12c2a982`](https://github.com/NixOS/nixpkgs/commit/12c2a9824a845bb6d1c47b7ba6c82074b6b6459e) | `pythonPackages.rtslib: Add patch to fix import check`            |
| [`5f45f250`](https://github.com/NixOS/nixpkgs/commit/5f45f2506d196a5bc969bd7da9ed6511a4764854) | `linux: better note`                                              |