### PR TITLE
chore(flake/home-manager): `688e5c85` -> `0160a0ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660574517,
-        "narHash": "sha256-Lp5D2pAPrM3iAc1eeR0iGwz5rM+SYOWzVxI3p17nlrU=",
+        "lastModified": 1661201353,
+        "narHash": "sha256-hee34c72DNz1Otj86b2NEc4s1JQ+qnIb1XyWuUD4v6o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "688e5c85b7537f308b82167c8eb4ecfb70a49861",
+        "rev": "0160a0cef076294127f8cc0750019410ab94370d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`0160a0ce`](https://github.com/nix-community/home-manager/commit/0160a0cef076294127f8cc0750019410ab94370d) | `Add flake.lock & workflow to update it (#1934)` |