### PR TITLE
chore(flake/nixpkgs): `a7855f22` -> `5e804cd8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661088761,
-        "narHash": "sha256-5DGKX81wIPAAiLwUmUYECpA3vop94AHHR7WmGXSsQok=",
+        "lastModified": 1661239211,
+        "narHash": "sha256-pNJzBlSNpWEiFJZnLF2oETYq8cGWx1DJPW33aMtG6n8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a7855f2235a1876f97473a76151fec2afa02b287",
+        "rev": "5e804cd8a27f835a402b22e086e36e797716ef8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`a7fef462`](https://github.com/NixOS/nixpkgs/commit/a7fef462bfda3dc36b848d1acf083f30c3c659db) | `python310Packages.bthome-ble: 0.3.1 -> 0.3.2`                           |
| [`46a8074b`](https://github.com/NixOS/nixpkgs/commit/46a8074b81803ceeb97161afc749f601582147e6) | `python310Packages.bthome-ble: 0.3.0 -> 0.3.1`                           |
| [`b1ef6042`](https://github.com/NixOS/nixpkgs/commit/b1ef60428b7a66de5718294983d1d3ad34b94fe1) | `python310Packages.bthome-ble: 0.2.2 -> 0.3.0`                           |
| [`05aa6c10`](https://github.com/NixOS/nixpkgs/commit/05aa6c10269bf4e988e9f69c3633d69247311747) | `xyce: fix eval after #187842`                                           |
| [`ee636eca`](https://github.com/NixOS/nixpkgs/commit/ee636eca3a06893abbec3165df4016cd1a68e501) | `nixVersions.nix_2_7: reinit at 2.7.0`                                   |
| [`f36a8ff7`](https://github.com/NixOS/nixpkgs/commit/f36a8ff7b8f97b4278492821e707e955efd5c422) | `meilisearch: 0.23.1 -> 0.28.1`                                          |
| [`63de0bd0`](https://github.com/NixOS/nixpkgs/commit/63de0bd0d9f462d10dc29d8ab16fa1e916cffb87) | `dbus-broker: search in /etc/dbus-1`                                     |
| [`f0165512`](https://github.com/NixOS/nixpkgs/commit/f0165512bc473ce7821db7b6fcac2545e5a23a3f) | `dbus-broker: 29 -> 32`                                                  |
| [`ca69d21d`](https://github.com/NixOS/nixpkgs/commit/ca69d21dd9ed4c3cb780f07f9727deacaa841527) | `kernelPackages.rtl8821cu: bump to add support for 5.19.2`               |
| [`56fd857a`](https://github.com/NixOS/nixpkgs/commit/56fd857a3404154431bd2319cf6eb3a05175e25c) | `mmv-go: remove maintainer`                                              |
| [`8ce6fdf5`](https://github.com/NixOS/nixpkgs/commit/8ce6fdf581b191d67c62590ec73a22cbf8797ae8) | `.github/CODEOWNERS: remove rust docs/packaging`                         |
| [`38c67944`](https://github.com/NixOS/nixpkgs/commit/38c67944cbcaa9ba5c0c52ee7260da4f845ca914) | `nixos/tests/libvirtd: init`                                             |
| [`1588178f`](https://github.com/NixOS/nixpkgs/commit/1588178f28d57f17e6237d58a76cbd6ef8170fc4) | `solfege: fix failing build`                                             |
| [`0edd143c`](https://github.com/NixOS/nixpkgs/commit/0edd143cb8fddcd98ca645a1e7fd79787f27df30) | `solfege: add anthonyroussel to maintainers`                             |
| [`65381877`](https://github.com/NixOS/nixpkgs/commit/6538187715881728fa30ef65de69cf06dc73a197) | `solfege: fix bad meta.homepage url`                                     |
| [`22638247`](https://github.com/NixOS/nixpkgs/commit/22638247757e023b1f8418f3eaaadff4ecb9185c) | `solfege: replace deprecated gpl3 license by gpl3Only`                   |
| [`af9dc831`](https://github.com/NixOS/nixpkgs/commit/af9dc83153a5f4e2b591bb5e5cac88b77f158fc7) | `python310Packages.sphinxcontrib-bibtex: 2.4.2 -> 2.5.0`                 |
| [`e2f83430`](https://github.com/NixOS/nixpkgs/commit/e2f8343087e0b131562a7c1fef220abccb6d1981) | `uade: rename from uade123, 3.01 -> 3.02`                                |
| [`d6dbe27e`](https://github.com/NixOS/nixpkgs/commit/d6dbe27eb4665320d1bd22d31e43eca2304b9d51) | `bencodetools: rename from libbencodetools, enable tests`                |
| [`9cf89797`](https://github.com/NixOS/nixpkgs/commit/9cf89797e6ca0e1f978c31d73f76aec756eadffb) | `nixos/proxmox-image: add hydra-build-products definition`               |
| [`265e6a66`](https://github.com/NixOS/nixpkgs/commit/265e6a668e97e00e2189d24bc57f66540cdb4b1d) | `nixos/proxmox-image: qemu 6.2.0 -> 7.0.0 and fix failing build`         |
| [`568b598a`](https://github.com/NixOS/nixpkgs/commit/568b598a9a86f9107e754672b373038db53e4bdc) | `github-runner: fix package layout, script patches, default state dir`   |
| [`fef694f7`](https://github.com/NixOS/nixpkgs/commit/fef694f706cd858a5b3a5fe24af7673b934b35b9) | `python3Packages.aioesphomeapi: 10.11.0 -> 10.13.0`                      |
| [`e0c4bbce`](https://github.com/NixOS/nixpkgs/commit/e0c4bbce9035d2837d7b76b25890aff05dd6c840) | `python310Packages.ipympl: 0.9.1 -> 0.9.2`                               |
| [`e99329eb`](https://github.com/NixOS/nixpkgs/commit/e99329eb02194e2750078cce0bd4c92726149088) | `elan: overwrite llvm-ar with stdenv ar`                                 |
| [`2acbedd3`](https://github.com/NixOS/nixpkgs/commit/2acbedd334a67569f24487d06ea53cb7d256b0a7) | `promise_jsoo: init at 0.3.1 (#172194)`                                  |
| [`61b47c36`](https://github.com/NixOS/nixpkgs/commit/61b47c361c3ce2e12ddfb26691f2ffc0f6e46681) | `{libqalculate, qalculate-gtk}: 4.2.0 -> 4.3.0`                          |
| [`27c4968f`](https://github.com/NixOS/nixpkgs/commit/27c4968f2d16f5046c47e58a1224382ba292cc48) | `yuzu-ea: rename to yuzu-early-access`                                   |
| [`ee1674cf`](https://github.com/NixOS/nixpkgs/commit/ee1674cfcc400be82d51fa97b50f0b404aaec581) | `ocaml-vdom: init at 0.2 (#187622)`                                      |
| [`65fa585e`](https://github.com/NixOS/nixpkgs/commit/65fa585e7850c10ed2240f9dd2ff51df67a3d884) | `python310Packages.cssutils: 2.5.1 -> 2.6.0`                             |
| [`957b36c7`](https://github.com/NixOS/nixpkgs/commit/957b36c74f45d7430337b95282be9d27f1a9af27) | `maintainers: add bobby285271 to cinnamon maintainer`                    |
| [`8087e296`](https://github.com/NixOS/nixpkgs/commit/8087e29640f033b30bc92edca08a38c25baade3f) | `cinnamon.xreader: 3.4.4 -> 3.4.5`                                       |
| [`605c59d3`](https://github.com/NixOS/nixpkgs/commit/605c59d38da8e994cb398f4cf96aa592c6dd859a) | `cinnamon.muffin: 5.4.5 -> 5.4.6`                                        |
| [`201a4065`](https://github.com/NixOS/nixpkgs/commit/201a4065a6a0693e40679ec35db5107847c006bd) | `cinnamon.mint-themes: 2.0.4 -> 2.0.5`                                   |
| [`78ed716f`](https://github.com/NixOS/nixpkgs/commit/78ed716f331e66f137bf0d465204e675e5894931) | `cinnamon.cinnamon-screensaver: 5.4.2 -> 5.4.4`                          |
| [`140a3863`](https://github.com/NixOS/nixpkgs/commit/140a38633ac5e23a80b71f78eb2584f5e274237d) | `python310Packages.restview: disable tests which compare console output` |
| [`74704d8c`](https://github.com/NixOS/nixpkgs/commit/74704d8ca25f5fabdec730a2cd343ae2a8eb3355) | `findomain: 8.2.0 -> 8.2.1`                                              |
| [`1f66bcb6`](https://github.com/NixOS/nixpkgs/commit/1f66bcb6911a98c073f858e20a7e89e1b8b58159) | `python310Packages.allure-python-commons-test: 2.9.45 -> 2.10.0`         |
| [`2f7d56ef`](https://github.com/NixOS/nixpkgs/commit/2f7d56ef22cc7ac97952afc19217c2619c731066) | `python310Packages.readme_renderer: 36.0 -> 37.0`                        |
| [`5c2ed8f3`](https://github.com/NixOS/nixpkgs/commit/5c2ed8f381b48c8b706b43e22bdd43b5d627b4a4) | `perlPackages: Fix eval`                                                 |
| [`2a1349f1`](https://github.com/NixOS/nixpkgs/commit/2a1349f14f3f38dbc41f7734056acd41b8ebc302) | `perlPackages: Clarify BSD licenses`                                     |
| [`c070a09e`](https://github.com/NixOS/nixpkgs/commit/c070a09e7660b4dc373ca82f73242eb6e006e1c2) | `perlPackages: Re-add Gtk2GladeXML`                                      |
| [`1dc6b668`](https://github.com/NixOS/nixpkgs/commit/1dc6b668734b0ebb2a4518157694daca8a4e5214) | `sqlfluff: 1.2.1 -> 1.3.0`                                               |
| [`933e90b9`](https://github.com/NixOS/nixpkgs/commit/933e90b94aec2181037894a9465a58b103424421) | `perlPackages: Get rid of deprecated licenses`                           |
| [`14fa34e9`](https://github.com/NixOS/nixpkgs/commit/14fa34e9ad49453fb1040f7bd6dde5a01d6191e0) | `trivy: fix on darwin`                                                   |
| [`8f8b184c`](https://github.com/NixOS/nixpkgs/commit/8f8b184c454863885448ba0b0dc0b26f19531308) | `perlPackages: Clarify free licenses`                                    |
| [`e6b89a5a`](https://github.com/NixOS/nixpkgs/commit/e6b89a5a52398c41f9fe49025acd6f9f8688c42a) | `perlPackages: Clarify all unfree licenses`                              |
| [`ba6cf1cc`](https://github.com/NixOS/nixpkgs/commit/ba6cf1cc5dfc0e76ea95a2e46fd4a62e8ee9dc28) | `python310Packages.diff-cover: update check section`                     |
| [`42928915`](https://github.com/NixOS/nixpkgs/commit/42928915a9192317591c33550a7e4082f5246c81) | `perlPackages: Add descriptions to all packages`                         |
| [`59356f11`](https://github.com/NixOS/nixpkgs/commit/59356f11c1fc07e51758198640b4f91f77d1066e) | `perlPackages: Ensure all packages have a license`                       |
| [`b655b616`](https://github.com/NixOS/nixpkgs/commit/b655b6161ef186e052bbd113d7c75dad63f2699e) | `freetds: 1.3.9 -> 1.3.13`                                               |
| [`5342f0ba`](https://github.com/NixOS/nixpkgs/commit/5342f0baeab2ce3de7cb451396055ffdb228920e) | `python310Packages.jedi-language-server: 0.36.1 -> 0.37.0`               |
| [`a9bd62f8`](https://github.com/NixOS/nixpkgs/commit/a9bd62f88c5918afb48044118780413f3f42d9ed) | `python310Packages.holidays: 0.14.2 -> 0.15`                             |
| [`1a6cfb69`](https://github.com/NixOS/nixpkgs/commit/1a6cfb6980aa88e660f8dbf62a6e7b636bff2bd8) | `python310Packages.hahomematic: 2022.8.10 -> 2022.8.11`                  |
| [`e88d6cf4`](https://github.com/NixOS/nixpkgs/commit/e88d6cf49cb0a85f8db8f16c33a12bcc893ade2a) | `python310Packages.jira: 3.3.0 -> 3.4.0`                                 |
| [`a2cd5706`](https://github.com/NixOS/nixpkgs/commit/a2cd57069d78bce6bef4a8b85f422bb4d0e91ecb) | `sysstat: 12.4.5 -> 12.6.0`                                              |
| [`3e373de3`](https://github.com/NixOS/nixpkgs/commit/3e373de30151f03ce839aabbf2c62d5e767b5dd3) | `nixos/libvirtd: point qemu-bridge-helper to store path`                 |
| [`602fcc86`](https://github.com/NixOS/nixpkgs/commit/602fcc8608cb270d53adc97dc4db3e955e6192c9) | `libvirt: hardcode path to parted`                                       |
| [`e0b24053`](https://github.com/NixOS/nixpkgs/commit/e0b240532775e966307f59494c1f1f04e990ba56) | `redpanda: 22.2.1 -> 22.2.2`                                             |
| [`ba3564f7`](https://github.com/NixOS/nixpkgs/commit/ba3564f74bb944ef279d6f5ec94f89ee4f3b5b5f) | `rPackages.s2: fix openssl linking`                                      |
| [`7a501e1f`](https://github.com/NixOS/nixpkgs/commit/7a501e1f874826db855d4562bfec0550816a0cc2) | `rubber: 1.5.1 -> 1.6.0 (#187738)`                                       |
| [`4625114a`](https://github.com/NixOS/nixpkgs/commit/4625114ad447a70cadf5e0e38d3ac268a03cbbca) | `zathuraPkgs.zathura_pdf_mupdf: 0.3.7 -> 0.3.8`                          |
| [`5094590a`](https://github.com/NixOS/nixpkgs/commit/5094590ad5d97581c4b0c283250d4b2863fd0182) | `python3Packages.flask-basicauth: init at 0.2.0`                         |
| [`2bdcc9e5`](https://github.com/NixOS/nixpkgs/commit/2bdcc9e537c50e0feee28d9f1c0e2f72887f3c44) | `libvirt: 8.5.0 -> 8.6.0`                                                |
| [`4dcc74ff`](https://github.com/NixOS/nixpkgs/commit/4dcc74ff1ff635d81059b7944ead3a97a19fbed2) | `python310Packages.jupytext: 1.14.0 -> 1.14.1`                           |
| [`883654c7`](https://github.com/NixOS/nixpkgs/commit/883654c7abfb55a1488014f7f7dd69560a861e3e) | `unifi-protect-backup: 0.7.1 -> 0.7.4`                                   |
| [`20c9a9e8`](https://github.com/NixOS/nixpkgs/commit/20c9a9e87ddef74a21cce000e6a20a10c7171333) | `Remove kiyengar from maintainers (#187781)`                             |
| [`42a51b5c`](https://github.com/NixOS/nixpkgs/commit/42a51b5cc6592fe00bbbf29ae966414c51ed49b6) | `python310Packages.gigalixir: 1.2.6 -> 1.3.0`                            |
| [`9a46ea09`](https://github.com/NixOS/nixpkgs/commit/9a46ea093e2367150900bff7b872d72ad8754df8) | `vimPlugins: resolve github repository redirects`                        |
| [`5d7631e3`](https://github.com/NixOS/nixpkgs/commit/5d7631e327f79ff6a643326d1007d412a9153753) | `vimPlugins: update`                                                     |
| [`7912cc11`](https://github.com/NixOS/nixpkgs/commit/7912cc116f7427daf95f7f61bb8f13f291e8437c) | `riot-redis: init at 2.17.0`                                             |
| [`8546d723`](https://github.com/NixOS/nixpkgs/commit/8546d723f3bfb01ef23b2207d9eea4a75a529cc3) | `shellhub-agent: 0.9.5 -> 0.9.6`                                         |
| [`e8e435cf`](https://github.com/NixOS/nixpkgs/commit/e8e435cf715385b4f0f231fd8eb6caed70c5b982) | `prometheus-nats-exporter: 0.9.3 -> 0.10.0`                              |
| [`0c5b09e1`](https://github.com/NixOS/nixpkgs/commit/0c5b09e106fe542d978a4c08c96208396320df5c) | `plzip: init at 1.10 (#187539)`                                          |
| [`9c8890f2`](https://github.com/NixOS/nixpkgs/commit/9c8890f2e51d1df74a784d7fd884accf55bd48d2) | `nixos/terraria: set primary group`                                      |
| [`2507e7c6`](https://github.com/NixOS/nixpkgs/commit/2507e7c69f520e519dd3cb289931c0b16133ec82) | `daemontools: add manpages from Debian`                                  |
| [`e834ca87`](https://github.com/NixOS/nixpkgs/commit/e834ca87fffd376042d8ac4fef0dbca2f773ff7f) | `banana-accounting: init at 10.0.12 (#179112)`                           |
| [`6b45d2a1`](https://github.com/NixOS/nixpkgs/commit/6b45d2a1d2c68a437b28b2a0bdfc28dcd7ae4485) | `video-trimmer: init at 0.7.1`                                           |
| [`e2b04b01`](https://github.com/NixOS/nixpkgs/commit/e2b04b01574d7b9d831a4bf39f54df29fa558dae) | `tuifeed: init at 0.2.1`                                                 |
| [`9e0494b3`](https://github.com/NixOS/nixpkgs/commit/9e0494b3d1a8d9a8d4d3b8d0eea20cff32cb610e) | `nixos/mautrix-facebook: set verification levels`                        |
| [`3a08b9ac`](https://github.com/NixOS/nixpkgs/commit/3a08b9acabca38b6ecffc6afd844f80b17c73afa) | `nixos/mautrix-facebook: create group`                                   |
| [`87f8b1d6`](https://github.com/NixOS/nixpkgs/commit/87f8b1d685feb0ee8ea3015ec8db741fcf1d2505) | `asn: init at 0.72.1`                                                    |
| [`6bc379f6`](https://github.com/NixOS/nixpkgs/commit/6bc379f63597bf4809d18af40655032560ed08df) | `perlPackages: Use https where possible`                                 |
| [`758aeebf`](https://github.com/NixOS/nixpkgs/commit/758aeebf418be84b5f1d9d26f8f280fb6ce94939) | `python310Packages.dunamai: 1.12.0 -> 1.13.0`                            |
| [`a8a3e722`](https://github.com/NixOS/nixpkgs/commit/a8a3e7225d1c257ff263e5b776fadf29cb7246bc) | `perlPackages: Regenerate metadata (phase 3)`                            |
| [`98716fb2`](https://github.com/NixOS/nixpkgs/commit/98716fb27113517c8547e1a6a4e5b4c9d7ddacd8) | `perlPackages: Regenerate metadata (phase 2)`                            |
| [`5de8b611`](https://github.com/NixOS/nixpkgs/commit/5de8b6115c0f0a15e9fd1398ce6268f87c71e2aa) | `ncspot: 0.10.1 -> 0.11.0`                                               |
| [`6e81e1b4`](https://github.com/NixOS/nixpkgs/commit/6e81e1b473456bbb3f6613a18f415dd93e5ab5fe) | `openvpn3: 17_beta -> 18_beta`                                           |
| [`b29a6d38`](https://github.com/NixOS/nixpkgs/commit/b29a6d38c0f54b6aa10964295170a66e30976964) | `python310Packages.napari: adjust inputs`                                |
| [`9704e9c8`](https://github.com/NixOS/nixpkgs/commit/9704e9c85620593c31eca5e3b216d038b1389ccf) | `nixos/nextcloud: add option to set fastcgi timeout`                     |
| [`32aa10f0`](https://github.com/NixOS/nixpkgs/commit/32aa10f0972b9a8bc8ad6e6bc831cca4e4789885) | `ubootTools: Fix after update of uboot to 2022.07`                       |
| [`1a23c871`](https://github.com/NixOS/nixpkgs/commit/1a23c871f3dfb37623519f34a09427abfe088104) | `python310Packages.ipyparallel: adjust input and build system`           |
| [`73f0398e`](https://github.com/NixOS/nixpkgs/commit/73f0398efdd7937662d4c0d77ed456b3d9167292) | `svdtools: 0.2.5 -> 0.2.6`                                               |