### PR TITLE
chore(flake/darwin): `2f3c9bb3` -> `ef0e7f41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661264599,
-        "narHash": "sha256-TnpHCTTMrINokMH4xUNisp74UcvBAToRSUfCuAOFw/E=",
+        "lastModified": 1661329936,
+        "narHash": "sha256-dafFjAcJPo0SdegK3E+SnTI8CNMgV/bBm/6CeDf82f8=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "2f3c9bb364a3add2a2649f720b359ee9b8012094",
+        "rev": "ef0e7f41cdf8fae1d2390c4df246c90a364ed8d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message             |
| ------------------------------------------------------------------------------------------------ | -------------------------- |
| [`20483453`](https://github.com/LnL7/nix-darwin/commit/20483453b0155bf489a797b390a64867817cf4f7) | `fixup`                    |
| [`0b1502eb`](https://github.com/LnL7/nix-darwin/commit/0b1502ebe24de73364a17ee5c928b087b8b950c6) | `uid/gid/util`             |
| [`1b8ac989`](https://github.com/LnL7/nix-darwin/commit/1b8ac989e6f4afe19c0302fe6abd8b03ff42a378) | `Update gitlab-runner.nix` |
| [`98c09f65`](https://github.com/LnL7/nix-darwin/commit/98c09f6545d0299668db400b24cc7f355b798fc4) | `adds gitlab-runner`       |