### PR TITLE
chore(flake/nixpkgs): `5e804cd8` -> `f034b569`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661239211,
-        "narHash": "sha256-pNJzBlSNpWEiFJZnLF2oETYq8cGWx1DJPW33aMtG6n8=",
+        "lastModified": 1661328374,
+        "narHash": "sha256-GGMupfk/lGzPBQ/dRrcQEhiFZ0F5KPg0j5Q4Fb5coxc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5e804cd8a27f835a402b22e086e36e797716ef8b",
+        "rev": "f034b5693a26625f56068af983ed7727a60b5f8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                        |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`9b8a61ad`](https://github.com/NixOS/nixpkgs/commit/9b8a61ad323ee265a8ebfc16ba08cf1eea6750c6) | `gh: 2.14.5 -> 2.14.6`                                                |
| [`83874827`](https://github.com/NixOS/nixpkgs/commit/83874827314ff1093518b2ab71d052a6adeefb6b) | `python310Packages.aioaladdinconnect: 0.1.41 -> 0.1.42`               |
| [`bc604481`](https://github.com/NixOS/nixpkgs/commit/bc604481802fd3b54bd5d880b20daab64d259a59) | `solfege: build manpages`                                             |
| [`4827266c`](https://github.com/NixOS/nixpkgs/commit/4827266cd796ae5c2393d4d25631e93e02251d2f) | `vgo2nix: drop package`                                               |
| [`0305391f`](https://github.com/NixOS/nixpkgs/commit/0305391fb65b5bdaa8af3c48275ec0df1cdcc34e) | `chia: 1.5.0 -> 1.5.1`                                                |
| [`8db8aa92`](https://github.com/NixOS/nixpkgs/commit/8db8aa92acb6c8bc95ce59840de16a5a5d8e0f5a) | `clvm-tools: 0.4.4 -> 0.4.5`                                          |
| [`a280a2b3`](https://github.com/NixOS/nixpkgs/commit/a280a2b3ccd42f288dcb2841bb168b0882120d40) | `xml2rfc: 3.14.0 -> 3.14.1`                                           |
| [`93ed660e`](https://github.com/NixOS/nixpkgs/commit/93ed660eca73ee6d1aff18a583dd519772c2415d) | `dotnetCorePackages.combinePackages: fix bug introduced in #187118`   |
| [`02b699e9`](https://github.com/NixOS/nixpkgs/commit/02b699e99bc21d8b70acb958ffc763b1f7c7d6fa) | `keepass: minor refactor`                                             |
| [`1678d87a`](https://github.com/NixOS/nixpkgs/commit/1678d87ac4b84e61d38c27546b736a1284a3b01b) | `python310Packages.omegaconf: 2.2.2 -> 2.2.3`                         |
| [`75f48d93`](https://github.com/NixOS/nixpkgs/commit/75f48d93530037372143ed2e8cc3781783d45959) | `plantuml: 1.2022.6 -> 1.2022.7`                                      |
| [`273d186e`](https://github.com/NixOS/nixpkgs/commit/273d186e32d6a2479ad88757673ca4fd7febe756) | `gamescope: 3.11.33-jupiter-3.3-2 -> 3.11.39`                         |
| [`adeb76bc`](https://github.com/NixOS/nixpkgs/commit/adeb76bc57ec8eccd2e713815e865d3fc9e1c9b9) | `libliftoff: 0.2.0 -> 0.3.0`                                          |
| [`fe568f41`](https://github.com/NixOS/nixpkgs/commit/fe568f415d03d230e69985c72c995943915bc6a7) | `sabnzbd: 3.6.0 -> 3.6.1`                                             |
| [`744963c2`](https://github.com/NixOS/nixpkgs/commit/744963c24aa1121e461aa6f0a64184905916ae0b) | `borgbackup: move manpages into man output`                           |
| [`ebdc70bf`](https://github.com/NixOS/nixpkgs/commit/ebdc70bf24080f0777da65ff8dcc8c94608b1250) | `borgbackup: 1.2.1 -> 1.2.2`                                          |
| [`490296d9`](https://github.com/NixOS/nixpkgs/commit/490296d928b17dc030be2ab6144e33b36391bc3c) | `mpd: 0.23.8 -> 0.23.9`                                               |
| [`08a27f78`](https://github.com/NixOS/nixpkgs/commit/08a27f789cb4990beaf640559b24218fc953c40b) | `libmysqlconnectorcpp: 8.0.29 -> 8.0.30`                              |
| [`2f1ecd13`](https://github.com/NixOS/nixpkgs/commit/2f1ecd13c27a772f4d1bb43f0b597bf11028e799) | `headscale: 0.16.3 -> 0.16.4`                                         |
| [`dc607cf6`](https://github.com/NixOS/nixpkgs/commit/dc607cf67ba53ac7733f4b642520e49898f4577d) | `writeShellApplication: don't prefix empty PATH`                      |
| [`fa066dd7`](https://github.com/NixOS/nixpkgs/commit/fa066dd74ef4228f71388be45fb98cb6cc8a1729) | `ccache: 4.6.1 -> 4.6.2`                                              |
| [`ce603c2d`](https://github.com/NixOS/nixpkgs/commit/ce603c2d308109ee7f79e397250b7fdb59f5cef6) | `pavucontrol: enable parallel building`                               |
| [`8492b34b`](https://github.com/NixOS/nixpkgs/commit/8492b34bcb291e96af9504deda35c18b8429f879) | `python310Packages.jsbeautifier: 1.14.5 -> 1.14.6`                    |
| [`eedfe6b7`](https://github.com/NixOS/nixpkgs/commit/eedfe6b7ffa88324938d0260e1230d77c570626d) | `python310Packages.phone-modem: 0.1.1 -> 0.1.2`                       |
| [`70ddb598`](https://github.com/NixOS/nixpkgs/commit/70ddb59877eb0221f39e1005009534a9a57a0d33) | `python310Packages.sounddevice: 0.4.4 -> 0.4.5`                       |
| [`cbaf7297`](https://github.com/NixOS/nixpkgs/commit/cbaf7297049cb202355d6373fe6ddc3210a34dce) | `minizinc: 2.6.2 -> 2.6.4`                                            |
| [`62f71008`](https://github.com/NixOS/nixpkgs/commit/62f71008da03576fa3185e0f59a72218ccdeba3b) | `circleci-cli: 0.1.20500 -> 0.1.20688`                                |
| [`4f9602ee`](https://github.com/NixOS/nixpkgs/commit/4f9602ee9a8b71a7d7927da4aee5c89303782e2d) | `borgbackup: install shell completions via helper script`             |
| [`f9d09359`](https://github.com/NixOS/nixpkgs/commit/f9d093592be073fdc53798f0930b5d0580c1e168) | `python310Packages.pycm: 3.5 -> 3.6`                                  |
| [`cfea934d`](https://github.com/NixOS/nixpkgs/commit/cfea934df118e1cc45e46d8962792d1e1db85c86) | `argocd: 2.4.10 -> 2.4.11`                                            |
| [`8ccab1a5`](https://github.com/NixOS/nixpkgs/commit/8ccab1a56d305a5c3bbc90654f51622d4409de2a) | `wcslib: 7.9 -> 7.11`                                                 |
| [`db99daa7`](https://github.com/NixOS/nixpkgs/commit/db99daa790fd6299db0d055d4558f0d390dd88fb) | `python310Packages.preshed: 3.0.6 -> 3.0.7`                           |
| [`05cd6895`](https://github.com/NixOS/nixpkgs/commit/05cd689592554540328ac08588c548a891ac6b96) | `netbootxyz-efi: 2.0.53 -> 2.0.60`                                    |
| [`958b6553`](https://github.com/NixOS/nixpkgs/commit/958b6553eab33f098c97832297539b279c5bf15c) | `gh: 2.14.4 -> 2.14.5`                                                |
| [`7fe41f92`](https://github.com/NixOS/nixpkgs/commit/7fe41f922e9f987def3d9a248289acc03b18d2d2) | `libbfd_2_38, libopcodes_2_38: create held back release`              |
| [`dc178ae2`](https://github.com/NixOS/nixpkgs/commit/dc178ae28e592ac05e5fb92d620709f725c5dcc8) | `thunderbird*: 102.1.2 -> 102.2.0`                                    |
| [`a4a167f5`](https://github.com/NixOS/nixpkgs/commit/a4a167f5b7e099f60b6acd0fe91abf6dce95ba38) | `python310Packages.python-benedict: 0.25.2 -> 0.25.3`                 |
| [`233e7d59`](https://github.com/NixOS/nixpkgs/commit/233e7d5971a63283bd6825ab87c94459e3a14623) | `python310Packages.peaqevcore: 5.11.2 -> 5.12.0`                      |
| [`f8210044`](https://github.com/NixOS/nixpkgs/commit/f82100441e1cbed4ac6648325185cb571b21bbe3) | `python310Packages.peaqevcore: 5.11.1 -> 5.11.2`                      |
| [`4ddd233a`](https://github.com/NixOS/nixpkgs/commit/4ddd233afb9fc6de7e85fb69082488965ba1463f) | `python310Packages.peaqevcore: 5.11.0 -> 5.11.1`                      |
| [`13d86416`](https://github.com/NixOS/nixpkgs/commit/13d864166a2412d0ce10a1d2746e6bbf18d77386) | `python310Packages.peaqevcore: 5.10.6 -> 5.11.0`                      |
| [`bbb29356`](https://github.com/NixOS/nixpkgs/commit/bbb29356f3f64546ae63290676c985870c6afd91) | `python310Packages.peaqevcore: 5.10.5 -> 5.10.6`                      |
| [`d4ebb556`](https://github.com/NixOS/nixpkgs/commit/d4ebb556546b3d6832066639fbc51a8d565206a9) | `ps3-disc-dumper: init at 3.2.3`                                      |
| [`6e4e00a1`](https://github.com/NixOS/nixpkgs/commit/6e4e00a1015fd6874225456c46d2fe30f7d18e2c) | `python310Packages.hahomematic: 2022.8.12 -> 2022.8.13`               |
| [`4c59b1b5`](https://github.com/NixOS/nixpkgs/commit/4c59b1b54723f9b54e90f1953a27abfb0232d154) | `python310Packages.hahomematic: 2022.8.11 -> 2022.8.12`               |
| [`4f06aab3`](https://github.com/NixOS/nixpkgs/commit/4f06aab36507b68899fde4eaa525ba4b169a2227) | `python310Packages.debuglater: 1.4.2 -> 1.4.3`                        |
| [`287ed7ed`](https://github.com/NixOS/nixpkgs/commit/287ed7eddc1afc4f154e49b2441cffc190d28979) | `home-assistant: update component-packages`                           |
| [`cf1f301a`](https://github.com/NixOS/nixpkgs/commit/cf1f301a1e20ddfc37183828c33e893d35ac2d60) | `python310Packages.tank-utility: init at 1.4.1`                       |
| [`639d4e61`](https://github.com/NixOS/nixpkgs/commit/639d4e610301baf25564e5db240d6fbfc02a988c) | `redwax-tool: init at 0.9.1`                                          |
| [`e07fa705`](https://github.com/NixOS/nixpkgs/commit/e07fa7050e48124a14daf8c7d286e9db60785441) | `fcft: 3.1.2 -> 3.1.3`                                                |
| [`58e0d95c`](https://github.com/NixOS/nixpkgs/commit/58e0d95c3a80e29b657cfce1dbea182c13ae6451) | `smartmontools: fix missing sed w/o enableMail`                       |
| [`37363a6c`](https://github.com/NixOS/nixpkgs/commit/37363a6cbcbf6c06cf3b8da4096fb28fa86ef5e7) | `pax-utils: add python3 to propagatedBuildInputs for lddtree`         |
| [`520c6941`](https://github.com/NixOS/nixpkgs/commit/520c6941836092327d77973232169102127b4454) | `python310Packages.autarco: 0.1.0 -> 0.2.0`                           |
| [`36b8fc61`](https://github.com/NixOS/nixpkgs/commit/36b8fc61cd46cdea082d0ed5d6da8cb115316e9f) | `python310Packages.Nikola: Disable Python older 3.7`                  |
| [`02cb054c`](https://github.com/NixOS/nixpkgs/commit/02cb054cf4a2c7573331c146dee8230b041e2aa5) | `firefox-devedition-bin-unwrapped: 104.0b7 -> 104.b10`                |
| [`e07f2519`](https://github.com/NixOS/nixpkgs/commit/e07f2519b9e378276b541c649a4b40cc1b9947ba) | `firefox-beta-bin-unwrapped: 104.0b7 -> 104.b09`                      |
| [`1c98a4b6`](https://github.com/NixOS/nixpkgs/commit/1c98a4b64bbef9e697577b9c5bdfc4b2b7023210) | `firefox-esr-102-unwrapped: 102.1.0esr -> 102.2.0esr`                 |
| [`d50d54a0`](https://github.com/NixOS/nixpkgs/commit/d50d54a0fe5149f864cf899e420744b803b8d311) | `firefox-esr-91-unwrapped: 91.12.0esr -> 91.13.0esr`                  |
| [`77d59491`](https://github.com/NixOS/nixpkgs/commit/77d59491fecd81dd27a645a1982f04021c3d7121) | `firefox-bin-unwrapped: 103.0.2 -> 104.0`                             |
| [`097a4730`](https://github.com/NixOS/nixpkgs/commit/097a473056489260b24f04d4e4367d1e90f4db47) | `firefox-unwrapped: 103.0.2 -> 104.0`                                 |
| [`aeb48f34`](https://github.com/NixOS/nixpkgs/commit/aeb48f34047c932c0525a61354ff6a71c74e68e5) | `python310Packages.allure-python-commons: 2.9.45 -> 2.10.0 (#187848)` |
| [`b5d8f6ea`](https://github.com/NixOS/nixpkgs/commit/b5d8f6eaba4455d51e2472b0b74b677e1592bcd8) | `gtkmm4: skip check on darwin`                                        |
| [`f9564f4f`](https://github.com/NixOS/nixpkgs/commit/f9564f4f02815937a1d630377d1c96ab22154174) | `basex: 10.0 -> 10.1`                                                 |
| [`5c4f0bde`](https://github.com/NixOS/nixpkgs/commit/5c4f0bdedf63c344aa42bf3da7d586358c0204d3) | `scala-cli: 0.1.11 -> 0.1.12`                                         |
| [`319c0bb6`](https://github.com/NixOS/nixpkgs/commit/319c0bb69d9c90b631710cc833b76f058a20c29b) | `python310Packages.paranoid-crypto: init at unstable-20220819`        |
| [`14dc1c40`](https://github.com/NixOS/nixpkgs/commit/14dc1c40fd48ad653480bb3c207e86a6dbe68268) | `linuxPackages.rtl8821ce: patch for 5.19.2 compatibility`             |
| [`6cd3e192`](https://github.com/NixOS/nixpkgs/commit/6cd3e1921d0e0c87b837a8662d958ea19f2f6a02) | `fits-cloudctl: 0.10.17 -> 0.10.21`                                   |
| [`b0cbfe7e`](https://github.com/NixOS/nixpkgs/commit/b0cbfe7eff65923bb4b40ac1fb5349dd792f8377) | `babl: 0.1.92 -> 0.1.94`                                              |
| [`9f9a3ec8`](https://github.com/NixOS/nixpkgs/commit/9f9a3ec8b3efe37d40eb246420e271068413640a) | `python310Packages.asdf-transform-schemas: 0.2.2 -> 0.3.0`            |
| [`f930cab9`](https://github.com/NixOS/nixpkgs/commit/f930cab9a1faead46522907d6f51a62d6a722f5c) | `ocamlPackages.domain-name: 0.3.0 → 0.4.0`                            |
| [`835ee238`](https://github.com/NixOS/nixpkgs/commit/835ee238e4896f7c41bcfefeff697817b1331267) | `i2p: 1.8.0 -> 1.9.0`                                                 |
| [`7e1072f6`](https://github.com/NixOS/nixpkgs/commit/7e1072f6e57127165d17a34366ee3fcddd097024) | `linuxPackages.rtl8821au: unstable-2022-03-08 -> unstable-2022-08-22` |
| [`173523fa`](https://github.com/NixOS/nixpkgs/commit/173523fafc6c0674ffaa709c5c0a105155d3ee9f) | `python310Packages.aesedb: 0.0.5 -> 0.0.7`                            |
| [`a40f80c6`](https://github.com/NixOS/nixpkgs/commit/a40f80c66fbf456123eb43ed9875d9c181cf13a1) | `nng: init at 1.5.2 (#187950)`                                        |
| [`c91d0713`](https://github.com/NixOS/nixpkgs/commit/c91d0713ac476dfb367bbe12a7a048f6162f039c) | `ovmf: expose EFI prefixes and refactor qemu-vm with it`              |
| [`c195e880`](https://github.com/NixOS/nixpkgs/commit/c195e88007bc9fe95c254b3165e5d61952a621f0) | `obs-studio-plugins.obs-ndi: use NDI SDK headers directly`            |
| [`87b25db2`](https://github.com/NixOS/nixpkgs/commit/87b25db2ac940756e6c8f5208ad8f1dad6085533) | `ndi: 4 -> 5.5.1`                                                     |
| [`19c81496`](https://github.com/NixOS/nixpkgs/commit/19c8149641c98c513ed5aec68f9fbd24621df278) | `python3Packages.ripe-atlas-sagan: add optional dependency`           |
| [`0afbc696`](https://github.com/NixOS/nixpkgs/commit/0afbc6967c476c98ab422e229b5419f580f21aee) | `cargo-wipe: 0.3.2 -> 0.3.3`                                          |
| [`829e4a1e`](https://github.com/NixOS/nixpkgs/commit/829e4a1e514bbddb5424435b914db5300ba7bb66) | `gitlab: 15.2.2 -> 15.3.1 (#187946)`                                  |
| [`11a293f3`](https://github.com/NixOS/nixpkgs/commit/11a293f30030634825eadb418497f760b4bba32b) | `tfsec: 1.27.4 -> 1.27.5`                                             |
| [`463e7abe`](https://github.com/NixOS/nixpkgs/commit/463e7abefd78cbb4d87599ad177e0919b5d74d49) | `tfsec: 1.27.3 -> 1.27.4`                                             |
| [`e6b00eed`](https://github.com/NixOS/nixpkgs/commit/e6b00eed6f5a18e0b1ae2184f0c2ca265d19246f) | `tfsec: 1.27.2 -> 1.27.3`                                             |
| [`ac9b28a4`](https://github.com/NixOS/nixpkgs/commit/ac9b28a4a22a4705c97ea6adc8d2bfb8d985aa22) | `python310Packages.tabula-py: 2.5.0 -> 2.5.1`                         |
| [`936d831a`](https://github.com/NixOS/nixpkgs/commit/936d831abc4e6e95f9aa17ac2ca5a41b9ab77815) | `tlsx: 0.0.5 -> 0.0.6`                                                |
| [`72c6cc87`](https://github.com/NixOS/nixpkgs/commit/72c6cc879e373a589db32da2b4be8b7315ca0394) | `libbfd, libopcodes: moves closer to binutils nix expressions`        |
| [`d8d0f089`](https://github.com/NixOS/nixpkgs/commit/d8d0f08910895ddbf90aa2cdde876d58358474fb) | `python310Packages.aliyun-python-sdk-dbfs: 2.0.1 -> 2.0.2`            |
| [`6eaa3ad9`](https://github.com/NixOS/nixpkgs/commit/6eaa3ad9b9f5f41bd68323133e338a700324c644) | `python310Packages.aliyun-python-sdk-dbfs: 2.0.0 -> 2.0.1`            |
| [`0ab18607`](https://github.com/NixOS/nixpkgs/commit/0ab186073d64025e74d1a6a1fabfe44bc579f79b) | `python310Packages.amarna: 0.1.2 -> 0.1.3`                            |
| [`45bc6744`](https://github.com/NixOS/nixpkgs/commit/45bc6744b2f2c70d03f073769fddcb408a0bdce0) | `oh-my-posh: init at 8.25.0`                                          |
| [`4f274860`](https://github.com/NixOS/nixpkgs/commit/4f274860272d8e0b568a2dc131975be6a6577ec2) | `bdf2psf: 1.209 -> 1.210`                                             |
| [`f4d11afb`](https://github.com/NixOS/nixpkgs/commit/f4d11afb6784901f909af0361c17b0d9af114ffe) | `rpm: 4.17.0 -> 4.17.1`                                               |
| [`ce907408`](https://github.com/NixOS/nixpkgs/commit/ce907408b8e0d1f0da46388fadfc06c174aff076) | `edk2: support new functional mkDerivation-style`                     |
| [`c1ba9c9c`](https://github.com/NixOS/nixpkgs/commit/c1ba9c9c8bbd14378871254126d67e921e118a8b) | `nixosTests.netbird: init`                                            |
| [`5fcdceb0`](https://github.com/NixOS/nixpkgs/commit/5fcdceb0b2edf283c4bd041e751a380b45bd2243) | `nixos/netbird: init`                                                 |
| [`fea7af99`](https://github.com/NixOS/nixpkgs/commit/fea7af99d9a2fdc22023b7e79ab476c921a9b5cf) | `netbird: init at 0.8.9`                                              |
| [`259c2e33`](https://github.com/NixOS/nixpkgs/commit/259c2e336ff6af8f474a15e92098ef59ed124120) | `kubepug: 1.3.4 -> 1.4.0`                                             |
| [`94b4e8ff`](https://github.com/NixOS/nixpkgs/commit/94b4e8ff7a824c0264454741222a7de6c9ccc098) | `zen-kernels: 5.19.2 -> 5.19.3`                                       |
| [`2e8d06be`](https://github.com/NixOS/nixpkgs/commit/2e8d06bedeb29d3f2e002e3c4b4b15479809af54) | `jc: 1.20.4 -> 1.21.0`                                                |
| [`6a692612`](https://github.com/NixOS/nixpkgs/commit/6a6926129fc224869d7170ae1d670aa17bbd0adc) | `python310Packages.bc-python-hcl2: 0.3.45 -> 0.3.46`                  |
| [`371d3f6e`](https://github.com/NixOS/nixpkgs/commit/371d3f6e0f49fbd19cbece718b79af0b2541e7a1) | `hip: 5.2.1 → 5.2.3`                                                  |
| [`2987efca`](https://github.com/NixOS/nixpkgs/commit/2987efca0955a0eb024f898fc196fb23568788ce) | `llvmPackages_rocm.llvm: 5.2.1 → 5.2.3`                               |
| [`a83a4594`](https://github.com/NixOS/nixpkgs/commit/a83a4594adf1157fb00def283298733ee34ed240) | `rocclr: 5.2.1 → 5.2.3`                                               |
| [`ed5dbbc7`](https://github.com/NixOS/nixpkgs/commit/ed5dbbc7189494a0b249fdc5f277da8ca74ab5a4) | `rocm-smi: 5.2.0 → 5.2.3`                                             |
| [`92f22ae0`](https://github.com/NixOS/nixpkgs/commit/92f22ae0b49c18c61dfcd85b617163e1e5df053f) | `cubiomes-viewer: 2.2.2 -> 2.3.3`                                     |
| [`921d7b7a`](https://github.com/NixOS/nixpkgs/commit/921d7b7a7864bac83dca75eb5c4c6a5a6552bde6) | `python310Packages.textdistance: 4.3.0 -> 4.4.0`                      |
| [`ee08b8ce`](https://github.com/NixOS/nixpkgs/commit/ee08b8ce6a702bdc19cb0e6bd10af93326e328cf) | `python310Packages.robotsuite: fix deprecated gpl3 license`           |
| [`96a8cd2b`](https://github.com/NixOS/nixpkgs/commit/96a8cd2bd337d31589bd2999f0ad3e5d9d1913b6) | `python310Packages.robotsuite: fix stale substitute`                  |
| [`aef84a79`](https://github.com/NixOS/nixpkgs/commit/aef84a7987026fad03dc27f3c01cec7922a50158) | `python310Packages.robotsuite: fix failing build`                     |
| [`8dac0eef`](https://github.com/NixOS/nixpkgs/commit/8dac0eefc1df108bb39e916624731b4fdc700d66) | `lightspark: 0.8.5 -> 0.8.6`                                          |
| [`d9e979ee`](https://github.com/NixOS/nixpkgs/commit/d9e979ee2d96d69d454ef8e5817a5e9e34f09c33) | `qpwgraph: 0.3.4 -> 0.3.5`                                            |
| [`c17520f2`](https://github.com/NixOS/nixpkgs/commit/c17520f298d230c68343832f677460c867fda2f6) | `ktlint: 0.46.1 -> 0.47.0`                                            |
| [`916ca8f2`](https://github.com/NixOS/nixpkgs/commit/916ca8f2b0c208def051f8ea9760c534a40309db) | `nixos/hardware/device-tree: make overlays more reliable`             |
| [`40cefe17`](https://github.com/NixOS/nixpkgs/commit/40cefe1733f98f96ab9b36bdeb217f2f9fae5b81) | `manim: fix build failure due to failing tests`                       |
| [`0af28a74`](https://github.com/NixOS/nixpkgs/commit/0af28a74e00e9b32105251bf1443e846a81440aa) | `ecs-agent: 1.62.1 -> 1.62.2`                                         |
| [`6f1e8c31`](https://github.com/NixOS/nixpkgs/commit/6f1e8c316001b997d553aca000fcb80737ae9406) | `python3Packages.ripe-atlas-sagan: init at 1.3.1`                     |
| [`8ba9b8be`](https://github.com/NixOS/nixpkgs/commit/8ba9b8bed612b9624d0cc03b532a879aebc2b7ce) | `node-packages.json: unformat file`                                   |
| [`8a03bcaa`](https://github.com/NixOS/nixpkgs/commit/8a03bcaa1bd6ef8d61fe1f5df9d5e6c734004f4b) | `nodePackages.orval: init at 6.9.6`                                   |
| [`c53649f2`](https://github.com/NixOS/nixpkgs/commit/c53649f2f2ebd203d74be4df8b243f40318bbe25) | `python310Packages.zcs: 0.1.18 -> 0.1.21`                             |
| [`22f88666`](https://github.com/NixOS/nixpkgs/commit/22f88666343154dc36bce43db9e8d1cc36725028) | `python310Packages.scikit-fmm: 2022.3.26 -> 2022.8.15`                |
| [`b632dba0`](https://github.com/NixOS/nixpkgs/commit/b632dba0985cf840358cbec6b0444b97c4f23821) | `charm: 0.12.3 -> 0.12.4`                                             |
| [`181ab967`](https://github.com/NixOS/nixpkgs/commit/181ab9671ad666514afdff216ac13ad60e8c6dd2) | `kubelogin: 0.0.11 -> 0.0.20`                                         |
| [`0e775e7c`](https://github.com/NixOS/nixpkgs/commit/0e775e7c0163582c649192556ba90d67a843d76f) | `kube-router: 1.4.0 -> 1.5.1`                                         |
| [`8dc61765`](https://github.com/NixOS/nixpkgs/commit/8dc617656b5071253730fadcdb3d097375c7cb7d) | `konstraint: 0.20.0 -> 0.23.0`                                        |
| [`a65ad5de`](https://github.com/NixOS/nixpkgs/commit/a65ad5de3101b26877d6bf62aa72cda2409fd21e) | `keycloak: 18.0.0 -> 19.0.1`                                          |
| [`96c5cdbe`](https://github.com/NixOS/nixpkgs/commit/96c5cdbefe26d8f9c3459d7f36afd42ee97d6836) | `kak-lsp: 12.2.0 -> 13.0.0`                                           |
| [`55cb9c8b`](https://github.com/NixOS/nixpkgs/commit/55cb9c8bffb9b3770b985f8b8d23d95565e0b119) | `jftui: 0.5.1 -> 0.6.0`                                               |
| [`dc78b636`](https://github.com/NixOS/nixpkgs/commit/dc78b6368e1fe0e5ff9e718540209c80f322024e) | `jbang: 0.92.2 -> 0.97.0`                                             |
| [`8ff6f668`](https://github.com/NixOS/nixpkgs/commit/8ff6f668888503babab8737ccdf8db8d16f0c3c7) | `heimer: 3.2.0 -> 3.5.0`                                              |
| [`358b1aa4`](https://github.com/NixOS/nixpkgs/commit/358b1aa4f31923aeab48c903b7133a9f64be79e1) | `invidious: unstable-2022-07-10 -> unstable-2022-08-13`               |
| [`4e817e1d`](https://github.com/NixOS/nixpkgs/commit/4e817e1d1a7f1e4c794e2a485feab9c1e04bb7ce) | `fetchmail: 6.4.30 -> 6.4.32`                                         |
| [`1557ff44`](https://github.com/NixOS/nixpkgs/commit/1557ff44fd1b86232742c5bdf423733236a12a15) | `cifs-utils: 6.15 -> 7.0`                                             |
| [`aba6e724`](https://github.com/NixOS/nixpkgs/commit/aba6e72405707fd4c857d72cd5ff54b84c648455) | `memtier-benchmark: 1.3.0 -> 1.4.0`                                   |
| [`1ed23120`](https://github.com/NixOS/nixpkgs/commit/1ed23120107c6b4bb36a8c8b8ddd3aafc543ffeb) | `onetun: init at 0.3.3`                                               |
| [`f4012060`](https://github.com/NixOS/nixpkgs/commit/f4012060a37b8b5c897e08b724334aa9f649cf0e) | `ibus-engines.m17n: 1.4.9 -> 1.4.10`                                  |
| [`6d774530`](https://github.com/NixOS/nixpkgs/commit/6d7745301842659de7a36e907a3974b9bd48df1c) | `plecost: init at 1.1.4`                                              |
| [`eb99d7f9`](https://github.com/NixOS/nixpkgs/commit/eb99d7f93727026e710f773809b2e8239b33fbc8) | `ymuse: init at 0.20`                                                 |
| [`61a1465e`](https://github.com/NixOS/nixpkgs/commit/61a1465e26dbcf9941c6e035b7d9a3b476b315a1) | `buku: fix check inputs and remove PYTHONIOENCODING hack`             |
| [`86a160ea`](https://github.com/NixOS/nixpkgs/commit/86a160ea18b661c8bc59c0e359dc1cb13241c675) | `buku: fix build failing for bukuserver`                              |
| [`c7b38c87`](https://github.com/NixOS/nixpkgs/commit/c7b38c877b74ec690336f582c4eaa2cabaa1206a) | `zprint: 1.2.3 -> 1.2.4`                                              |
| [`fde348bb`](https://github.com/NixOS/nixpkgs/commit/fde348bb4adc3b45299cadb59a94e725319ad462) | `vtm: 0.7.6 -> 0.8.0`                                                 |
| [`64164a5b`](https://github.com/NixOS/nixpkgs/commit/64164a5b3806b7c94f6fa68a9111c0780ff6e07a) | `python310Packages.Nikola: 8.2.2 -> 8.2.3`                            |
| [`bc569904`](https://github.com/NixOS/nixpkgs/commit/bc569904fe9e47a8c029c19102f3a28506a73de8) | `yquake2: 8.01 -> 8.10`                                               |
| [`ab7fd187`](https://github.com/NixOS/nixpkgs/commit/ab7fd187bcedcbb1febe0ba253b16098958887e9) | `vmpk: 0.8.6 -> 0.8.7`                                                |
| [`921b8174`](https://github.com/NixOS/nixpkgs/commit/921b81745d34d07c767d2d0c32623b83126314e8) | `SPAdes: 3.15.4 -> 3.15.5`                                            |