### PR TITLE
chore(flake/home-manager): `7bb4576f` -> `4c8c1c99`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661461765,
-        "narHash": "sha256-SsguXWPNbD7Oy1jtfXuQtHciHjqYuCCnbyf5iSm/IPs=",
+        "lastModified": 1661465825,
+        "narHash": "sha256-bMrD8ZR4TSqGLjMWnmg4+ZIlSOoYXTSK9++HK0dPtmA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7bb4576f46f7f7590347e21b14d2f6a2dbc76638",
+        "rev": "4c8c1c99770494027599d73c30423d8257a224ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`4c8c1c99`](https://github.com/nix-community/home-manager/commit/4c8c1c99770494027599d73c30423d8257a224ef) | `kitty: produce fewer empty lines`                     |
| [`76fbb1b1`](https://github.com/nix-community/home-manager/commit/76fbb1b15e83a9243efa7efe39d1d0fdd5a4d103) | `treewide: replace <link> by <xref> where appropriate` |