### PR TITLE
chore(flake/nixpkgs): `38e16b19` -> `a63021a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661541451,
-        "narHash": "sha256-LALyT63vpo1sftSmHAbbrj+emfCOo93Jv4xVOIcmnl0=",
+        "lastModified": 1661720780,
+        "narHash": "sha256-AJNGyaB2eKZAYaPNjBZOzap87yL+F9ZLaFzzMkvega0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "38e16b192af13ff6cffc8a35a25f390f1e96b585",
+        "rev": "a63021a330d8d33d862a8e29924b42d73037dd37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`b2190a3c`](https://github.com/NixOS/nixpkgs/commit/b2190a3cce35008d2573c75b97ccb20a000637b7) | `lib/systems/doubles: add ELFvx GNU ABIs`                                |
| [`82ff1f5d`](https://github.com/NixOS/nixpkgs/commit/82ff1f5db12f862e226e84254e54a10879f1629b) | `pkgsStatic: handle ELFv1/2 ABIs`                                        |
| [`345595a8`](https://github.com/NixOS/nixpkgs/commit/345595a8b8defabac41cd61392125f47af322513) | `lib/systems: add convenience isAbiElfv2 function`                       |
| [`cdb0f02a`](https://github.com/NixOS/nixpkgs/commit/cdb0f02a36bb6474c5be13627ce735c9b326c6d0) | `lib/systems/examples: use provided ABIs in PPC64 triple`                |
| [`3fa4274f`](https://github.com/NixOS/nixpkgs/commit/3fa4274ff692c0cff449763b803c46f576e54f95) | `lib/systems/parse: use ELFv2 by default for PPC64 BE`                   |
| [`da2d9a2a`](https://github.com/NixOS/nixpkgs/commit/da2d9a2aca33d628e20b8a8693fb995192d31903) | `lib/systems: add elfv1 / elfv2 ABIs`                                    |
| [`ce357ff2`](https://github.com/NixOS/nixpkgs/commit/ce357ff2b09382700f1362865680ecbf0a4441a1) | `kyverno: 1.7.2 -> 1.7.3`                                                |
| [`b3d71ba9`](https://github.com/NixOS/nixpkgs/commit/b3d71ba9d0a5ebb60662cb789aa78bc713ef0b68) | `kubeseal: 0.18.1 -> 0.18.2`                                             |
| [`bb1f36a2`](https://github.com/NixOS/nixpkgs/commit/bb1f36a214a1106a287165aae5eb8d193506efc6) | `kubecfg: 0.26.0 -> 0.27.0`                                              |
| [`44420879`](https://github.com/NixOS/nixpkgs/commit/444208798aefb1787b8ef0851f5c3d49113bd014) | `qemu: add patch for CVE-2020-14394`                                     |
| [`02ca0640`](https://github.com/NixOS/nixpkgs/commit/02ca06405e814d6967cf741a9588a4f80ae4db8d) | `qemu: add patches for CVE-2022-0216`                                    |
| [`f73bb818`](https://github.com/NixOS/nixpkgs/commit/f73bb818a15e176ff6352fd2db77a425b7d3533a) | `karabiner-elements: init at 14.8.0 (#188129)`                           |
| [`f03ae291`](https://github.com/NixOS/nixpkgs/commit/f03ae29142c8d99869f7d1b30a67560f4e5fb144) | `forge-mtg: init at 1.6.53 (#182053)`                                    |
| [`cbfc31de`](https://github.com/NixOS/nixpkgs/commit/cbfc31de7b3d3bbd58d3ddeca92b6e2dacf255a9) | `asouldocs: rename from peach, asouldocs: 0.9.8 -> 1.0.0 (#188673)`      |
| [`5ba8f7cc`](https://github.com/NixOS/nixpkgs/commit/5ba8f7cc880b26bd44e9712c22d774c03780a6df) | `imagemagick: 7.1.0-46 -> 7.1.0-47`                                      |
| [`670aec28`](https://github.com/NixOS/nixpkgs/commit/670aec28b0e7a82ffbe8a872b393f182c2434886) | `humioctl: 0.29.2 -> 0.30.0`                                             |
| [`51064f5b`](https://github.com/NixOS/nixpkgs/commit/51064f5bfffb1ca5db52326ec91929f241a36b54) | `htslib: 1.15 -> 1.16`                                                   |
| [`126f8a03`](https://github.com/NixOS/nixpkgs/commit/126f8a0394cc6737f8ce7096ccdc8af8a67c676e) | `heimer: 3.5.0 -> 3.6.0`                                                 |
| [`5303f524`](https://github.com/NixOS/nixpkgs/commit/5303f524555f23338d479afcc338fe445ccc493e) | `gocryptfs: 2.2.1 -> 2.3`                                                |
| [`64a1d8da`](https://github.com/NixOS/nixpkgs/commit/64a1d8da4ab23869e56361a9fbbabf640f3d5b3a) | `go-toml: 2.0.3 -> 2.0.5`                                                |
| [`544a6437`](https://github.com/NixOS/nixpkgs/commit/544a643773ab5cd61f54b4e4f19c42092e172555) | `difftastic: 0.32.0 -> 0.34.0`                                           |
| [`b10cf087`](https://github.com/NixOS/nixpkgs/commit/b10cf087c8d558d7569ab6b4323ca3440a7f653d) | `cargo-public-api: 0.14.0 -> 0.15.0`                                     |
| [`3909e303`](https://github.com/NixOS/nixpkgs/commit/3909e303eb7aad5ce569a111bfd44bc9bc31465c) | `qownnotes: 22.8.3 -> 22.8.4`                                            |
| [`c7cbb380`](https://github.com/NixOS/nixpkgs/commit/c7cbb380bea9f33b2e40b5eacc7a7f7006f58026) | `gitolite: fix reference to /bin`                                        |
| [`5bd26ec4`](https://github.com/NixOS/nixpkgs/commit/5bd26ec45c88f30bdfc8b3a6a95e3718f4c555e4) | `flyway: add downloadPage`                                               |
| [`56002bce`](https://github.com/NixOS/nixpkgs/commit/56002bcefcda4fcec5315bffef553e2b127d0a3e) | `python310Packages.json5: 0.9.6 -> 0.9.9`                                |
| [`bdf2706f`](https://github.com/NixOS/nixpkgs/commit/bdf2706f0941d29322fb9adc333bec5e7e07cdd3) | `python310Packages.pyjson5: remove duplicate package`                    |
| [`dbdd8d15`](https://github.com/NixOS/nixpkgs/commit/dbdd8d15e0ea8a6d69249ea59920090162007fbb) | `gitRepo: 2.28 -> 2.29.1`                                                |
| [`498695cf`](https://github.com/NixOS/nixpkgs/commit/498695cf518e41dc1bd872bd80672fd0f1da9f76) | `logseq: 0.8.1 -> 0.8.2`                                                 |
| [`c0f40868`](https://github.com/NixOS/nixpkgs/commit/c0f4086895b6f0b01c7a5de5b3ac26ce040e3a4a) | `netplan: 0.103 -> 0.105`                                                |
| [`1f698f27`](https://github.com/NixOS/nixpkgs/commit/1f698f2718d507ec883b067f5f8d1a59383d922e) | `wvkbd: 0.9 -> 0.10`                                                     |
| [`74798cfa`](https://github.com/NixOS/nixpkgs/commit/74798cfa674961829b6d69d4b8ccd7f31040a4fe) | `flexoptix-app: 5.11.1 -> 5.12.2`                                        |
| [`bb742b2b`](https://github.com/NixOS/nixpkgs/commit/bb742b2bb9675ce527df8a6df13ff47bfedc1be9) | `texstudio: 4.3.0 -> 4.3.1`                                              |
| [`eb1ec411`](https://github.com/NixOS/nixpkgs/commit/eb1ec41120fad4402e70d6f9a320f27ca88a6963) | `super-productivity: 7.11.5 -> 7.11.6`                                   |
| [`d92383b1`](https://github.com/NixOS/nixpkgs/commit/d92383b18de4ec74807e740054ff00e2a3b8bcd9) | `piper: 0.5.1 -> 0.7 (#187758)`                                          |
| [`1425187f`](https://github.com/NixOS/nixpkgs/commit/1425187f57566ad494f8631c4f82c778169107a7) | `python310Packages.cloudscraper: 1.2.60 -> 1.2.63`                       |
| [`26afe025`](https://github.com/NixOS/nixpkgs/commit/26afe025c78608b9671135dbdf5286e5c819a8f5) | `smartmontools: fix lib.optional -> lib.optionals`                       |
| [`34df0045`](https://github.com/NixOS/nixpkgs/commit/34df0045a8bfd5903929a9156c03bd187de65ac7) | `python310Packages.openstacksdk: 0.100.0 -> 0.101.0`                     |
| [`b5df06b9`](https://github.com/NixOS/nixpkgs/commit/b5df06b95c17f8c76890e4a7043b4f3c7ef1a5e9) | `xssproxy: 1.0.1 -> 1.1.0`                                               |
| [`3e80b8d7`](https://github.com/NixOS/nixpkgs/commit/3e80b8d7a2b40772dc88d8ef819751cc498ee1b0) | `godns: 2.8.8 -> 2.8.9`                                                  |
| [`eb928980`](https://github.com/NixOS/nixpkgs/commit/eb92898043049aa043904bb2a2dcabacec6d131b) | `flyway: 9.1.6 -> 9.2.0`                                                 |
| [`a79cfbba`](https://github.com/NixOS/nixpkgs/commit/a79cfbbad816c8c4b76e32ed5127d3d5677bada1) | `flow: 0.185.1 -> 0.185.2`                                               |
| [`b7a2c624`](https://github.com/NixOS/nixpkgs/commit/b7a2c6240e57e98d6e7acaf00e2d9bc8ee326474) | `dsq: 0.21.0 -> 0.22.0`                                                  |
| [`dc619120`](https://github.com/NixOS/nixpkgs/commit/dc61912099b6bfe4b9b8e88ae1b56d3b79f3772e) | `flyctl: 0.0.377 -> 0.0.383`                                             |
| [`8e23e320`](https://github.com/NixOS/nixpkgs/commit/8e23e320281971261787f4d3ca1ca6dc06456532) | `werf: 1.2.164 -> 1.2.165`                                               |
| [`5642de54`](https://github.com/NixOS/nixpkgs/commit/5642de5440127f008ef273337f31bc0fbf4479c9) | `emacs/elisp-packages: Remove manual Emacs package (apheleia)`           |
| [`96833c9e`](https://github.com/NixOS/nixpkgs/commit/96833c9e12aa6ac94d3a40426e6f63d68720945d) | `evans: 0.10.8 -> 0.10.9`                                                |
| [`780c40b6`](https://github.com/NixOS/nixpkgs/commit/780c40b619aab8b3e04e69c1048c2396d9a83301) | `fetchmail: 6.4.32 -> 6.4.33`                                            |
| [`8f3e4106`](https://github.com/NixOS/nixpkgs/commit/8f3e410636e79f6cbae513a5c6c9b6cebd12eac3) | `fclones: 0.27.0 -> 0.27.1`                                              |
| [`bd56129f`](https://github.com/NixOS/nixpkgs/commit/bd56129fbaea85d5cdeccaea4cd28b2f4e30640e) | `vscode-extensions.svelte.svelte-vscode: 105.3.0 -> 105.21.0`            |
| [`7e97189a`](https://github.com/NixOS/nixpkgs/commit/7e97189ac8c73cea1788700d9b6a8058ff60aef3) | `datree: 1.5.25 -> 1.6.13`                                               |
| [`636f3747`](https://github.com/NixOS/nixpkgs/commit/636f3747ae07a0001a73aca73ca4c08dba60746a) | `python310Packages.daemonocle: 1.0.2 -> 1.2.3`                           |
| [`fcdef222`](https://github.com/NixOS/nixpkgs/commit/fcdef222c2bb4db35046f9ef8c15330a071bea35) | `dendrite: 0.9.4 -> 0.9.5`                                               |
| [`b6a96bb5`](https://github.com/NixOS/nixpkgs/commit/b6a96bb583abd342048f19e197fe965f3c3dff32) | `dasel: 1.26.0 -> 1.26.1`                                                |
| [`e723d27a`](https://github.com/NixOS/nixpkgs/commit/e723d27a1c8630853893bac4c722f15f606c6fcd) | `python310Packages.itemloaders: add format`                              |
| [`2de7aa27`](https://github.com/NixOS/nixpkgs/commit/2de7aa27e5e557cb45d971c9144990457f040dad) | `python310Packages.env-canada: 0.5.24 -> 0.5.25`                         |
| [`130d56cf`](https://github.com/NixOS/nixpkgs/commit/130d56cffd6443bb1e3e9e0c6c618c8dd08a3763) | `docker-compose: 2.10.1 -> 2.10.2`                                       |
| [`f8fc6c64`](https://github.com/NixOS/nixpkgs/commit/f8fc6c64f5d043c41b4cd1b604f46d6ab8b5bff1) | `clifm: 1.6 -> 1.7`                                                      |
| [`c5692172`](https://github.com/NixOS/nixpkgs/commit/c5692172b344a37fca263d775924b771c70cffff) | `python310Packages.jellyfin-apiclient-python: adjust inputs`             |
| [`21c18d68`](https://github.com/NixOS/nixpkgs/commit/21c18d68ba25125260cc4215e9b7f2f8102edc3a) | `cilium-cli: 0.12.1 -> 0.12.2`                                           |
| [`5db524ac`](https://github.com/NixOS/nixpkgs/commit/5db524ac69ce3175337cd227e2de9e688c21441f) | `python310Packages.pytest-testmon: add pythonImportsCheck`               |
| [`b5f88642`](https://github.com/NixOS/nixpkgs/commit/b5f886426304b48af81d1fbd14957455a6364e7f) | `cobalt: 0.17.5 -> 0.18.3`                                               |
| [`fb8f5aa4`](https://github.com/NixOS/nixpkgs/commit/fb8f5aa450e340ad869558702fd38d07ff0f9893) | `python310Packages.twitter: add pythonImportsCheck`                      |
| [`39d3ae72`](https://github.com/NixOS/nixpkgs/commit/39d3ae7220673089f3b48bf27ce9eb8ad55b6431) | `arkade: 0.8.34 -> 0.8.36`                                               |
| [`78e9d214`](https://github.com/NixOS/nixpkgs/commit/78e9d21446d27ba54abcd8adeb15c798dc97c1ac) | `terraform-providers: update 2022-08-28`                                 |
| [`26238902`](https://github.com/NixOS/nixpkgs/commit/262389027131d84e9a7cb280a9cd716abe39b9b8) | `ferdium: 6.0.0 -> 6.1.0`                                                |
| [`c5b6df91`](https://github.com/NixOS/nixpkgs/commit/c5b6df912b8eb6fca2e47707ca1562f2018cbc3e) | `nixos/fontconfig: add missing config for Xft.hintstyle`                 |
| [`63845e0c`](https://github.com/NixOS/nixpkgs/commit/63845e0cde2d186603837eeda362f4175587cd05) | `guile_3_0: Enable parallel build when not cross-compiling`              |
| [`66729606`](https://github.com/NixOS/nixpkgs/commit/66729606cff270322be5520562abfb55cf3933b8) | `oha: 0.5.3 -> 0.5.4`                                                    |
| [`01b4f08f`](https://github.com/NixOS/nixpkgs/commit/01b4f08f8506dd397c618264a5588dbb9ce40336) | `python310Packages.django-anymail: Enable more tests`                    |
| [`c882c08f`](https://github.com/NixOS/nixpkgs/commit/c882c08f9c59d907bf860e7a3dfd5e69f1a7426e) | `pulseaudio: remove compat for 15.0`                                     |
| [`ac540bf0`](https://github.com/NixOS/nixpkgs/commit/ac540bf0f996e51d2765c0454f35627e5717ac28) | `ghidra-bin: 10.1.4 -> 10.1.5`                                           |
| [`8f57be61`](https://github.com/NixOS/nixpkgs/commit/8f57be61ac87fabf6ec048225556a45fc44aefed) | `tela-icon-theme: 2022-02-21 -> 2022-08-28`                              |
| [`00a45bc4`](https://github.com/NixOS/nixpkgs/commit/00a45bc41be88dbaa335b891eaf7710144ca4e8a) | `linux: Enable SLAB_FREELIST_HARDENED, SLAB_FREELIST_RANDOM`             |
| [`1104127c`](https://github.com/NixOS/nixpkgs/commit/1104127cf32b740e1ad2a4e404e52ac337318a1a) | `python3Packages.svgwrite: 1.4.1 → 1.4.3`                                |
| [`48ad86aa`](https://github.com/NixOS/nixpkgs/commit/48ad86aa6a954fab59b9e1bcf1c508938555d61e) | `go-ethereum: 1.10.21 -> 1.10.23`                                        |
| [`e607b30a`](https://github.com/NixOS/nixpkgs/commit/e607b30abe8a312676c26bb646325faa3b19c777) | `nixos/tor: convert option descriptions to MD`                           |
| [`5a20c879`](https://github.com/NixOS/nixpkgs/commit/5a20c8797072deee77020389213a546649458fcf) | `nixos/vsftpd: convert option descriptions to MD`                        |
| [`c2e133a4`](https://github.com/NixOS/nixpkgs/commit/c2e133a422f050514b0f3b267af952e5dc2ae01e) | `nixos/thanos: convert option descriptions to MD`                        |
| [`0046b457`](https://github.com/NixOS/nixpkgs/commit/0046b457d582db960b5e7163ecee56a8e29ab6bf) | `nixos/public-inbox: convert option descriptions to MD`                  |
| [`429ae9ff`](https://github.com/NixOS/nixpkgs/commit/429ae9ff3d4b91617af7a964cd53dbf3552b1828) | `nixos/thinkfan: convert descriptions to MD`                             |
| [`9217509e`](https://github.com/NixOS/nixpkgs/commit/9217509ece789e3c8c0651b58330ac131d9e0cbf) | `nixos/network-interfaces: convert option descriptions to MD`            |
| [`65fd6f07`](https://github.com/NixOS/nixpkgs/commit/65fd6f077455a9d16cf73f5c93f65816d0c66616) | `nixos/make-options-doc: eat newlines in MD admonitions`                 |
| [`51a11254`](https://github.com/NixOS/nixpkgs/commit/51a11254a7031ddfaa820e7dec55436f74881da9) | `nixos/*: literalDocBook -> literalMD`                                   |
| [`169072fb`](https://github.com/NixOS/nixpkgs/commit/169072fb6030dfe84b541db77d8705ff8a093a54) | `nixos/prometheus: convert option descriptions to MD`                    |
| [`97b6defb`](https://github.com/NixOS/nixpkgs/commit/97b6defb7b579405c39f519a608e1dfdef93dc98) | `nixos/prometheus: turn markdown in docbook`                             |
| [`7f6d0d16`](https://github.com/NixOS/nixpkgs/commit/7f6d0d1674fc3bbed16fb2b40e89549406fa80ba) | `nixos/users-groups: convert remaining descriptions to MD`               |
| [`a2ceee8f`](https://github.com/NixOS/nixpkgs/commit/a2ceee8ffef315faf9ef54b782e412b7e674b753) | `nixos/strongswan: convert to MD descriptions`                           |
| [`f7e49fae`](https://github.com/NixOS/nixpkgs/commit/f7e49fae0d5f35978314d341b6e6f2a78d157bad) | `nixos/prometheus.sachet: add module`                                    |
| [`6953eca7`](https://github.com/NixOS/nixpkgs/commit/6953eca70de848407939484ff78d1a460b503165) | `prometheus-sachet: init at 0.3.1`                                       |
| [`e8f1b090`](https://github.com/NixOS/nixpkgs/commit/e8f1b09014acf9e1b248a8ddd5cc83e60cceca77) | `nixos/plex: specify PIDFile in systemd service`                         |
| [`9701ad33`](https://github.com/NixOS/nixpkgs/commit/9701ad3399489ca30f5ada669d23c0835a7669ee) | `vscode-extensions.firefox-devtools.vscode-firefox-debug: init at 2.9.8` |
| [`e548e4b3`](https://github.com/NixOS/nixpkgs/commit/e548e4b3bfabead8af89922acb9ac1ee5cebdbc8) | `python310Packages.types-redis: 4.3.15 -> 4.3.18`                        |
| [`9aabd155`](https://github.com/NixOS/nixpkgs/commit/9aabd155bc8d7cb98a3722b26d7186e9b2630ab7) | `python310Packages.twitter: 1.19.3 -> 1.19.4`                            |
| [`270bd248`](https://github.com/NixOS/nixpkgs/commit/270bd248965fb0fef5f7a74e09f67b76ac8ca706) | `python310Packages.swift: 2.29.1 -> 2.30.0`                              |
| [`35ee5a33`](https://github.com/NixOS/nixpkgs/commit/35ee5a337f056d543ced6812c07d11e9ee69c6fb) | `swaycwd: 0.0.2 -> 0.1.0`                                                |
| [`f2dabd93`](https://github.com/NixOS/nixpkgs/commit/f2dabd93e72343b498b003ff4d7d6bdc394e9028) | `lzlib: add shared objects to build`                                     |
| [`868618a4`](https://github.com/NixOS/nixpkgs/commit/868618a4c04fb84dd4bb21cb39c3a31d95ef35d2) | `mympd: 8.0.4 -> 9.5.2`                                                  |
| [`18a89ece`](https://github.com/NixOS/nixpkgs/commit/18a89eced71e66aaca742f240056814622485942) | `python310Packages.python-openstackclient: 5.8.0 -> 6.0.0`               |
| [`3a1b4417`](https://github.com/NixOS/nixpkgs/commit/3a1b4417835ff342c950698cb302d02f45b5b309) | `python310Packages.pytest-testmon: 1.3.4 -> 1.3.5`                       |
| [`4eaef65f`](https://github.com/NixOS/nixpkgs/commit/4eaef65f796d725023934e4d08317b8ee42ba98c) | `python310Packages.pygeos: 0.12.0 -> 0.13`                               |
| [`02e4902d`](https://github.com/NixOS/nixpkgs/commit/02e4902da0d530ef40cb1338c78e5138e3bab344) | `pinegrow: 6.6 -> 6.8`                                                   |
| [`a457ddf7`](https://github.com/NixOS/nixpkgs/commit/a457ddf7f0c3542faf7991f5e3b1834f2edf1bdd) | `linuxPackages.rtl8812au: 5.9.3.2.20210427 -> 5.15.6.20210629`           |
| [`92256cc6`](https://github.com/NixOS/nixpkgs/commit/92256cc68d077970170749402c4d2d0bad868bca) | `python310Packages.py3status: 3.45 -> 3.46`                              |
| [`362cdab1`](https://github.com/NixOS/nixpkgs/commit/362cdab1e0e34c23d5a4d618662c8ec92341b612) | `everspace: don't use pango alias`                                       |