### PR TITLE
chore(flake/darwin): `ef0e7f41` -> `157a3c3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661329936,
-        "narHash": "sha256-dafFjAcJPo0SdegK3E+SnTI8CNMgV/bBm/6CeDf82f8=",
+        "lastModified": 1661762118,
+        "narHash": "sha256-+kQvys2HuLwQBkpN2AoVl4pFQx2MQ7o0jjNdGu2dIV4=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ef0e7f41cdf8fae1d2390c4df246c90a364ed8d9",
+        "rev": "157a3c3c4ea482317a4eb4ea2c41db4f16c82420",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                  |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`09a45c84`](https://github.com/LnL7/nix-darwin/commit/09a45c845873a888d35a7a1b43b80ff3fc6bdd19) | `Add netbird module`                            |
| [`ee4521db`](https://github.com/LnL7/nix-darwin/commit/ee4521db7fbbe3584306688ab0700b0b36f91426) | `fix(gitlab-runner): deprecated literalExample` |
| [`05cab3fc`](https://github.com/LnL7/nix-darwin/commit/05cab3fc91c001403aa954327c0c0f156c200e25) | `Fix copypasta in simple example`               |