### PR TITLE
chore(flake/home-manager): `d89bdff4` -> `5bd66dc6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661573386,
-        "narHash": "sha256-pBEg8iY00Af/SAtU2dlmOAv+2x7kScaGlFRDjNoVJO8=",
+        "lastModified": 1661824092,
+        "narHash": "sha256-nSWLWytlXbeLrx5A+r5Pso7CvVrX5EgmIIXW/EXvPHQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d89bdff445eadff03fe414e9c30486bc8166b72b",
+        "rev": "5bd66dc6cd967033489c69d486402b75d338eeb6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                               |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`5bd66dc6`](https://github.com/nix-community/home-manager/commit/5bd66dc6cd967033489c69d486402b75d338eeb6) | `email: fix the office365 smtp host (#3191)` |