### PR TITLE
chore(flake/darwin): `157a3c3c` -> `db543d32`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661762118,
-        "narHash": "sha256-+kQvys2HuLwQBkpN2AoVl4pFQx2MQ7o0jjNdGu2dIV4=",
+        "lastModified": 1661882186,
+        "narHash": "sha256-JLdKBtTXWB09DEtzkvbF6bJrOKUb+W8Oeu2whqtpJUM=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "157a3c3c4ea482317a4eb4ea2c41db4f16c82420",
+        "rev": "db543d325f916154d394b374a02a0cb6ec3313f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                            |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`241d88ed`](https://github.com/LnL7/nix-darwin/commit/241d88ed20b1abcb344d68074af37400e518b79d) | `Fix launchd options description oddities`                |
| [`1da877d2`](https://github.com/LnL7/nix-darwin/commit/1da877d28c740357b3449af4bb6e34875e2e4459) | ``Add `-H` to `sudo nix-env [...]` to deal with warning`` |