### PR TITLE
chore(flake/darwin): `db543d32` -> `80cec511`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661882186,
-        "narHash": "sha256-JLdKBtTXWB09DEtzkvbF6bJrOKUb+W8Oeu2whqtpJUM=",
+        "lastModified": 1661882940,
+        "narHash": "sha256-4LaVFnV22WrOA0aolqqk9dXrM8crikcrLQt29G18F7M=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "db543d325f916154d394b374a02a0cb6ec3313f6",
+        "rev": "80cec5115aae74accc4ccfb9f84306d7863f0632",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                    |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`42cc9d2c`](https://github.com/LnL7/nix-darwin/commit/42cc9d2c2704c47b786af7cd43b32275b3249bb9) | `Update readme to point to Matrix instead of IRC` |
| [`5fa362c3`](https://github.com/LnL7/nix-darwin/commit/5fa362c32f7a20ee1fb4baf7f23dc5128da6affe) | `Transition to using native floats`               |