### PR TITLE
chore(flake/nixpkgs): `97747d32` -> `2da64a81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661931183,
-        "narHash": "sha256-0+2KzcexiJCB3Il5t7cZAM2RXNRfm5/gMCwhcZJxLuQ=",
+        "lastModified": 1662019588,
+        "narHash": "sha256-oPEjHKGGVbBXqwwL+UjsveJzghWiWV0n9ogo1X6l4cw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "97747d3209efde533f7b1b28f1be11619f556a06",
+        "rev": "2da64a81275b68fdad38af669afeda43d401e94b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`84a4b659`](https://github.com/NixOS/nixpkgs/commit/84a4b6598a0e8ca7cadcf427ed5df972a57c159d) | `wibo: 0.2.0 → 0.2.4`                                                                |
| [`f175291c`](https://github.com/NixOS/nixpkgs/commit/f175291ce82b06dcc151d514cc7aea3b20beb299) | `linuxPackages.lttng-modules: mark broken for 5.10`                                  |
| [`e5ada146`](https://github.com/NixOS/nixpkgs/commit/e5ada146869589808d804a3430c5a24a025c9040) | `jellyfin-ffmpeg: 5.1-1 -> 5.1-2`                                                    |
| [`578c731c`](https://github.com/NixOS/nixpkgs/commit/578c731c4d6767a1b5b2f9566ea38650f1a9f16f) | `python310Packages.minikerberos: 0.3.0 -> 0.3.1`                                     |
| [`550179b4`](https://github.com/NixOS/nixpkgs/commit/550179b49da1182c1925b833cb70fbb2fdb11111) | `github-runner: 2.296.0 -> 2.296.1`                                                  |
| [`9c489889`](https://github.com/NixOS/nixpkgs/commit/9c48988907a45f28f6e042e30cac4a79ef8be117) | `maintainers: Update maralorn`                                                       |
| [`d3a91fea`](https://github.com/NixOS/nixpkgs/commit/d3a91fea40f1e536598fb5cab060e70b02a631f2) | `tfsec: 1.27.5 -> 1.27.6`                                                            |
| [`fe9ea556`](https://github.com/NixOS/nixpkgs/commit/fe9ea5561f9b948727ff3d1d7d407bac69da4994) | `temporal: 1.17.4 -> 1.17.5`                                                         |
| [`aba6cd17`](https://github.com/NixOS/nixpkgs/commit/aba6cd17c4785a82e6261cc00316cf97862a1ed2) | `python3Packages.torchvision: 1.13.0 -> 1.13.1`                                      |
| [`5863492c`](https://github.com/NixOS/nixpkgs/commit/5863492c519eeea7f4caabddcefc2617a873a931) | `python3Packages.torchvision-bin: 1.12.0 -> 1.13.1`                                  |
| [`8d3b89d0`](https://github.com/NixOS/nixpkgs/commit/8d3b89d030e6a3d5df80c8f61a8f72f1ba26caa1) | `python3Packages.torchaudio: 0.11.0 -> 0.12.1`                                       |
| [`4b379580`](https://github.com/NixOS/nixpkgs/commit/4b37958011a18e69ba3987cfdca8815258a52172) | `python3Packages.torch-bin: 1.11.0 -> 1.12.1`                                        |
| [`9b183572`](https://github.com/NixOS/nixpkgs/commit/9b183572a7789cd3b271af38ca1ca7245801e9af) | `python3Packages.torch: 1.11.0 -> 1.12.1`                                            |
| [`14d94534`](https://github.com/NixOS/nixpkgs/commit/14d9453469c86e1aa687d562f3201bab4e3f58e9) | `sngrep: 1.5.0 -> 1.6.0`                                                             |
| [`ac455609`](https://github.com/NixOS/nixpkgs/commit/ac455609648554cf2fb40d9d1ce030202b0921b7) | `delta: 0.13.0 -> 0.14.0`                                                            |
| [`889d8e1e`](https://github.com/NixOS/nixpkgs/commit/889d8e1e1cb716b5d91c8e8e8ce886d5365a270a) | `sierra-breeze-enhanced: 1.1.0 -> 1.2.0`                                             |
| [`25e41d25`](https://github.com/NixOS/nixpkgs/commit/25e41d257f7e349e39ddc17a6a3571f30883585f) | `seer: 1.8 -> 1.9`                                                                   |
| [`9a64a6d1`](https://github.com/NixOS/nixpkgs/commit/9a64a6d1ef03e0339e82702856b241d450f6630e) | `ocamlPackages.plotkicadsch: init at 0.9`                                            |
| [`2b2e5df4`](https://github.com/NixOS/nixpkgs/commit/2b2e5df47812fe5d2fc59b260bf422a07c3bf62a) | `ocamlPackages.git-unix: Add git to propagatedBuildInputs`                           |
| [`12756f54`](https://github.com/NixOS/nixpkgs/commit/12756f54134a2c6652499152112889466dcbc2c8) | `ocamlPackages.kicadsch: init at 0.9`                                                |
| [`23028550`](https://github.com/NixOS/nixpkgs/commit/23028550cf3064f519bb302361c9500ebc837f92) | `helix: 22.05 -> 22.08`                                                              |
| [`74ca03fa`](https://github.com/NixOS/nixpkgs/commit/74ca03fa3a13003fcc15dc65e9915e2e67c3f959) | `vault-bin: 1.11.1 -> 1.11.3`                                                        |
| [`a60e0aef`](https://github.com/NixOS/nixpkgs/commit/a60e0aefe66fb70dfcf2f0a69efcc9aa895d951c) | `vault: 1.11.2 -> 1.11.3`                                                            |
| [`f10333f6`](https://github.com/NixOS/nixpkgs/commit/f10333f64bd91e31a92cb8eb5a5e39114f7a7299) | `nomad_1_3: 1.3.4 -> 1.3.5`                                                          |
| [`55d61375`](https://github.com/NixOS/nixpkgs/commit/55d613752a5bd73bb318f7714fde3db8eb9d54e8) | `nomad_1_2: 1.2.11 -> 1.2.12`                                                        |
| [`dc4e50bc`](https://github.com/NixOS/nixpkgs/commit/dc4e50bca13c0207a6d9b811605df841f40bd11e) | `qovery-cli: 0.45.0 -> 0.46.3`                                                       |
| [`f6ad4ffe`](https://github.com/NixOS/nixpkgs/commit/f6ad4ffe0fb2fc3a6d4a077ac1455aed74c805e5) | `pscale: 0.113.0 -> 0.115.0`                                                         |
| [`ce7f1622`](https://github.com/NixOS/nixpkgs/commit/ce7f162232bd68776376c946599abd6a96ae9285) | `drogon: 1.7.5 -> 1.8.0`                                                             |
| [`aab82564`](https://github.com/NixOS/nixpkgs/commit/aab8256413eaba9e836baecf9271c40ab112aa40) | `oh-my-posh: 8.36.4 -> 8.36.6`                                                       |
| [`fbfca3d7`](https://github.com/NixOS/nixpkgs/commit/fbfca3d7feb758f23751b4a5e0ee4c607d19ded2) | `vmware-horizon-client: 2203 -> 2206`                                                |
| [`252244a9`](https://github.com/NixOS/nixpkgs/commit/252244a9fd7b5094ad7806dfb5dc081e1016483a) | `doppler: 3.41.0 -> 3.42.0`                                                          |
| [`0aaca0a6`](https://github.com/NixOS/nixpkgs/commit/0aaca0a6204d5fdd823fda311a91367d2d9d8097) | `fpc: support darwin`                                                                |
| [`5d5aed0c`](https://github.com/NixOS/nixpkgs/commit/5d5aed0cf4c778bb064623939040f959484a9a50) | `mongodb-compass: 1.32.6 -> 1.33.0`                                                  |
| [`8ea56dfc`](https://github.com/NixOS/nixpkgs/commit/8ea56dfc8f678100dbdc8cd35fcb4b6dae77dc3f) | `samba: don't depend on build python3`                                               |
| [`759c2336`](https://github.com/NixOS/nixpkgs/commit/759c2336f90d64225b4450992fb98f729f514569) | `logseq: 0.8.2 -> 0.8.3`                                                             |
| [`e76d384e`](https://github.com/NixOS/nixpkgs/commit/e76d384e47c708d5d8e2c41e5a80ccc7b122ea56) | `python310Packages.aesedb: 0.0.7 -> 0.1.0`                                           |
| [`8c680693`](https://github.com/NixOS/nixpkgs/commit/8c68069328de82e719f3c8f94e7745570664e3e1) | `element-{web,desktop}: 1.11.3 -> 1.11.4`                                            |
| [`5e3c9e7b`](https://github.com/NixOS/nixpkgs/commit/5e3c9e7bb8d9220ab75ec7f0b4057fe2179452d4) | `kubeone: 1.4.7 -> 1.5.0`                                                            |
| [`3305fd81`](https://github.com/NixOS/nixpkgs/commit/3305fd81772270a25d5b5706690c21f845470886) | `koreader: 2022.07 -> 2022.08`                                                       |
| [`0374eda4`](https://github.com/NixOS/nixpkgs/commit/0374eda4da18bc5c20f2040e86513b5313b7ae22) | `kics: 1.5.14 -> 1.5.15`                                                             |
| [`17d6094a`](https://github.com/NixOS/nixpkgs/commit/17d6094ac706ec748ba86bf1680cc74b75492751) | `jsonnet-language-server: 0.7.2 -> 0.8.0`                                            |
| [`5f3beb0c`](https://github.com/NixOS/nixpkgs/commit/5f3beb0cee74798a056cf2a7dfb91405e149e6fb) | `dbeaver: 22.1.4 -> 22.1.5`                                                          |
| [`e5069727`](https://github.com/NixOS/nixpkgs/commit/e50697278bf4ff7a1dfc30cbb44f17832d1d1250) | `mathcomp: 1.14.0 -> 1.15.0`                                                         |
| [`9f3436d2`](https://github.com/NixOS/nixpkgs/commit/9f3436d2fb5c88be4a90749316c9927826abb4e5) | `hugo: 0.102.1 -> 0.102.2`                                                           |
| [`9a3d274d`](https://github.com/NixOS/nixpkgs/commit/9a3d274dd659a456db6cbecc33e4620bcd40afbb) | `boost155: remove`                                                                   |
| [`29a428c1`](https://github.com/NixOS/nixpkgs/commit/29a428c1c3d26f62054da018facb4947b015f2d2) | `spring: unpin boost`                                                                |
| [`de1fb0dd`](https://github.com/NixOS/nixpkgs/commit/de1fb0dddc01c0b968c3877648e01c18437a1125) | `gopsuinfo: 0.1.1 -> 0.1.2`                                                          |
| [`6eab3491`](https://github.com/NixOS/nixpkgs/commit/6eab3491608def855759d778870242c5a2668850) | `globulation2: bump pinned dependency boost155 -> boost168`                          |
| [`28912692`](https://github.com/NixOS/nixpkgs/commit/28912692e18584aae54d2fc7a55cd020301c40f3) | `ginkgo: 2.1.5 -> 2.1.6`                                                             |
| [`9a7bd01e`](https://github.com/NixOS/nixpkgs/commit/9a7bd01e5273ccfff96df172e0df5bb29e34bd1a) | `tailscale: 1.28.0 -> 1.30.0`                                                        |
| [`df58b081`](https://github.com/NixOS/nixpkgs/commit/df58b081ed80de825239300b7a5192a75cb3f8f9) | `goreleaser: 1.11.1 -> 1.11.2`                                                       |
| [`f05c5866`](https://github.com/NixOS/nixpkgs/commit/f05c58665b5f06dc21d23f69a5f38410b12890c0) | `python3.pkgs.sphinxcontrib-openapi: link to upstream PR, add maintainers (#189112)` |
| [`0cdb86a5`](https://github.com/NixOS/nixpkgs/commit/0cdb86a58e28003c500b810f35174b508cc6e31c) | `amberol: 0.9.0 -> 0.9.1`                                                            |
| [`cf571a71`](https://github.com/NixOS/nixpkgs/commit/cf571a71b9125798195664aed4b6c77a9ee50fcd) | `qpdf: fix cross-compilation`                                                        |
| [`5ad2390e`](https://github.com/NixOS/nixpkgs/commit/5ad2390e3dd9c46622191b04f0790b75660efe87) | `dagger: 0.2.31 -> 0.2.32`                                                           |
| [`54fd3e5b`](https://github.com/NixOS/nixpkgs/commit/54fd3e5b7f3eeea588ecd2d1c4a4c7bc14fab6a9) | `python310Packages.flax: 0.5.2 -> 0.6.0`                                             |
| [`b598372f`](https://github.com/NixOS/nixpkgs/commit/b598372fd4b46e41da5b759cdd02b73921b8ad67) | `cbfmt: 0.1.4 -> 0.2.0`                                                              |
| [`3440fb0f`](https://github.com/NixOS/nixpkgs/commit/3440fb0f4aef9dfeff9909b95a78b30a01972145) | `vimPlugins.nvim-surround: init at 2022-08-29`                                       |
| [`eeefc8f7`](https://github.com/NixOS/nixpkgs/commit/eeefc8f733e7a31c385491685719a68834f5bd4b) | `matrix-synapse: 1.65.0 -> 1.66.0`                                                   |
| [`ddc111aa`](https://github.com/NixOS/nixpkgs/commit/ddc111aaa89b60509aaad151499099707266bcf1) | `anytype: 0.27.0 -> 0.28.0`                                                          |
| [`b0eaece3`](https://github.com/NixOS/nixpkgs/commit/b0eaece3d30833ddee187c5ddd40f6200321f680) | `prometheus-sql-exporter: 0.4.4 -> 0.4.5`                                            |
| [`61621f5b`](https://github.com/NixOS/nixpkgs/commit/61621f5b7e552b4c945519a6ef776aefb68bacc9) | `lnd: 0.15.0-beta -> 0.15.1-beta`                                                    |
| [`8611f992`](https://github.com/NixOS/nixpkgs/commit/8611f992231063e5acec00eae65ecacd5d7a825d) | `styx: 0.7.2 -> 0.7.5. Fix build failure`                                            |
| [`e2cc3619`](https://github.com/NixOS/nixpkgs/commit/e2cc36197053c087b16009750fd3e60029600e25) | ``lib.modules: support strings with absolute paths in `disabledModules```            |
| [`2affab6c`](https://github.com/NixOS/nixpkgs/commit/2affab6cf52750cc16cafbe16fbaffbb663be482) | `keycloak: 18.0.0 -> 19.0.1`                                                         |
| [`bacac7cf`](https://github.com/NixOS/nixpkgs/commit/bacac7cf54bdfdb41091a506dd1b158da08a2d78) | `sigal: fix crash when building gallery`                                             |
| [`7ef3d0aa`](https://github.com/NixOS/nixpkgs/commit/7ef3d0aae82c20b29f7f0b25893ac54ebedb8761) | `vimPlugins.{vim-clap,command-t}: fix build`                                         |
| [`169ffddd`](https://github.com/NixOS/nixpkgs/commit/169ffddd364d7b02fb344e19a6f93d869b172515) | `Revert "keycloak: 18.0.0 -> 19.0.1"`                                                |
| [`9b7c605d`](https://github.com/NixOS/nixpkgs/commit/9b7c605de9f7ae83c61ee9d5e3ec45e7e1601282) | `vimPlugins: resolve github repository redirects`                                    |
| [`bdd38052`](https://github.com/NixOS/nixpkgs/commit/bdd3805206f6db82529e744588f5c68af7e446a2) | `vimPlugins: update`                                                                 |
| [`4f805873`](https://github.com/NixOS/nixpkgs/commit/4f805873ffad6309fab726bde0a595b1ed9e7c15) | `nearcore: 1.28.0 -> 1.28.1`                                                         |
| [`2b3ec1d3`](https://github.com/NixOS/nixpkgs/commit/2b3ec1d37a217e690dfd722d0afb90d5c4c156d0) | `lean: 3.47.0 -> 3.48.0`                                                             |
| [`71d2c6c2`](https://github.com/NixOS/nixpkgs/commit/71d2c6c28c7b7677ea3e65c556e596f9ade324cb) | `rootlesskit: 1.0.0 -> 1.0.1`                                                        |
| [`a4537570`](https://github.com/NixOS/nixpkgs/commit/a4537570ec4a77180e37f02ec353ca666e213bba) | `trash-cli: 0.22.8.21 -> 0.22.8.27`                                                  |
| [`9895ba4b`](https://github.com/NixOS/nixpkgs/commit/9895ba4b77ac614a3faba06a53dae5168eaf5c3b) | `tor-browser-bundle-bin: 11.5.1 -> 11.5.2`                                           |
| [`3968c79e`](https://github.com/NixOS/nixpkgs/commit/3968c79e2aa126b1008ccd630adc2c2173b6f563) | `pipenv: 2022.8.24 -> 2022.8.30`                                                     |
| [`7460b17d`](https://github.com/NixOS/nixpkgs/commit/7460b17d29d803cda24f429c918cc1ec5379c8ea) | `fluxctl: 1.25.3 -> 1.25.4`                                                          |
| [`83798399`](https://github.com/NixOS/nixpkgs/commit/83798399409b58958e7e66f2a1ce8800cdf9b397) | `sarasa-gothic: 0.36.8 -> 0.37.0`                                                    |
| [`fac26c08`](https://github.com/NixOS/nixpkgs/commit/fac26c087f012e656efc242422fc25209c4b49e1) | `digikam: 7.7.0 -> 7.8.0`                                                            |
| [`e2ccf511`](https://github.com/NixOS/nixpkgs/commit/e2ccf51126a9b6da0f3ca577382696db09d3bc80) | `fennel: 1.1.0 -> 1.2.0`                                                             |
| [`cd073960`](https://github.com/NixOS/nixpkgs/commit/cd073960275e78625eb20aa0cf1621589d4b61c2) | `wireplumber: backport a fix for bluetooth rescan loops`                             |
| [`0a18a7c0`](https://github.com/NixOS/nixpkgs/commit/0a18a7c0a0ca74c25fdc1eb1dcb4c677efd43f67) | `czkawka: 5.0.1 -> 5.0.2`                                                            |
| [`6b9d1e64`](https://github.com/NixOS/nixpkgs/commit/6b9d1e64bef78d1a1b860f23874addbd4478da13) | `dprint: 0.30.3 -> 0.31.1`                                                           |
| [`2a5171dd`](https://github.com/NixOS/nixpkgs/commit/2a5171ddcc2157078969eb6fe9941c32d0876c82) | `docker-slim: 1.37.6 -> 1.38.0`                                                      |
| [`e38430fb`](https://github.com/NixOS/nixpkgs/commit/e38430fbd0b796e2a57fdd807e6957e9935da057) | `ocamlPackages.resource-pooling: 1.1 → 1.2`                                          |
| [`2439b9b4`](https://github.com/NixOS/nixpkgs/commit/2439b9b438b0a85037e4cf09e60809326fd1b2f0) | `cargo-tarpaulin: 0.20.1 -> 0.21.0`                                                  |
| [`2d85fea0`](https://github.com/NixOS/nixpkgs/commit/2d85fea0e2d99fadb5d2e32eb40d9e5d8e40a9ec) | `python310Packages.jmp: 4b94370 -> 260e5ba`                                          |
| [`a0adbb30`](https://github.com/NixOS/nixpkgs/commit/a0adbb308c6775bed2ea513b24556a4da06fbf87) | `python310Packages.chex: 0.1.3 -> 0.1.4`                                             |
| [`6623fff5`](https://github.com/NixOS/nixpkgs/commit/6623fff5f88f29179c7bd5d37954fe302d900cae) | `alfaview: 8.51.0 -> 8.52.0`                                                         |
| [`69ccd66a`](https://github.com/NixOS/nixpkgs/commit/69ccd66a735d408d991530566c0f558b41ea3e00) | `krita: 5.0.8 -> 5.1.0`                                                              |
| [`1b35942c`](https://github.com/NixOS/nixpkgs/commit/1b35942cbb016de93d59375c4ad3086441dc5b25) | `python310Packages.versioneer: 0.23 -> 0.24`                                         |
| [`5f190380`](https://github.com/NixOS/nixpkgs/commit/5f190380aed4f4394c1d30972a52b6a2cdd63d9e) | `discord-canary: 0.0.136 -> 0.0.137`                                                 |
| [`15884ce8`](https://github.com/NixOS/nixpkgs/commit/15884ce84ac1bf32f7643d9c44ac7a1d994f2ecd) | `gnome-frog: correct build inputs list`                                              |
| [`d4ada975`](https://github.com/NixOS/nixpkgs/commit/d4ada975204705bb70d77bd196d2b969668fc540) | `grafana-image-renderer: 3.4.0 -> 3.6.1 (CVE-2022-31176)`                            |
| [`9f1a83cc`](https://github.com/NixOS/nixpkgs/commit/9f1a83ccc753c498ab30527925a6db6a1f379ecf) | `grafana: 9.1.1 -> 9.1.2 (CVE-2022-31176)`                                           |
| [`2e4e7dd7`](https://github.com/NixOS/nixpkgs/commit/2e4e7dd7eb842d04b85bfa81c48a820220acb5d5) | `python310Packages.python-ironicclient: 5.0.0 -> 5.0.1`                              |
| [`b4c8635e`](https://github.com/NixOS/nixpkgs/commit/b4c8635e39863584bf027ba0a6e3c3e76e095997) | `python310Packages.python-gitlab: 3.8.1 -> 3.9.0`                                    |
| [`6d09a026`](https://github.com/NixOS/nixpkgs/commit/6d09a0268c8082923cbee097ef40af07f6340b13) | `python310Packages.oslo-db: 12.0.0 -> 12.1.0`                                        |
| [`a7951df2`](https://github.com/NixOS/nixpkgs/commit/a7951df278adb5be699603eb960b802ec5713853) | `python310Packages.minikerberos: 0.2.20 -> 0.3.0`                                    |
| [`87414a57`](https://github.com/NixOS/nixpkgs/commit/87414a5738031cba923132172a894fae147cb7c3) | `python310Packages.peaqevcore: 5.16.7 -> 5.18.1`                                     |
| [`3bfe6bfc`](https://github.com/NixOS/nixpkgs/commit/3bfe6bfca2fbe5f7f6c9d640172d482bfdcec815) | `openscad: add patches for CVE-2022-0496 & CVE-2022-0497`                            |
| [`ef49a845`](https://github.com/NixOS/nixpkgs/commit/ef49a84500e0bdcb31668c24fa906008ebe9c821) | `python3Packages.coinmetrics-api-client: init at 2022.8.29.6`                        |
| [`bafce1c7`](https://github.com/NixOS/nixpkgs/commit/bafce1c7cdaed1af39b804a660aa3ce6307886af) | `mmark: 2.2.26 -> 2.2.28`                                                            |
| [`60e0d3d7`](https://github.com/NixOS/nixpkgs/commit/60e0d3d73670ef8ddca24aa546a40283e3838e69) | `k3s: streamline HA setup`                                                           |
| [`2c2a2c63`](https://github.com/NixOS/nixpkgs/commit/2c2a2c6311ac20fe97d7890bddbcdccee220c53a) | `oed: 6.7 -> 7.1`                                                                    |
| [`e645fe7a`](https://github.com/NixOS/nixpkgs/commit/e645fe7a5563cb5cddc78fb6e888b975f0b64b87) | `neatvnc: 0.5.1 -> 0.5.3`                                                            |
| [`c2ca372b`](https://github.com/NixOS/nixpkgs/commit/c2ca372b2dcde0fd6d68dcc1ce5576904024e6e9) | `lightspark: 0.8.6 -> 0.8.6.1`                                                       |
| [`64e9c704`](https://github.com/NixOS/nixpkgs/commit/64e9c7049974389dd8c835dd02f3aa1ac8894822) | `btop: 1.2.8 -> 1.2.9`                                                               |
| [`471ebeef`](https://github.com/NixOS/nixpkgs/commit/471ebeef4e604be21cf30d8d29e5eaa0a3092196) | `keycloak: 18.0.0 -> 19.0.1`                                                         |
| [`560ab4f7`](https://github.com/NixOS/nixpkgs/commit/560ab4f71568d7416a36b23e0b7c00caf718b508) | `pandoc-katex: init at 0.1.9`                                                        |
| [`9ad0551c`](https://github.com/NixOS/nixpkgs/commit/9ad0551cf9bfbfc3cdd282525cd9d46886d4f079) | `glooctl: 1.12.9 -> 1.12.10`                                                         |
| [`ae51ce17`](https://github.com/NixOS/nixpkgs/commit/ae51ce1742a90f4b198613ee0eade9b41168bd4b) | `python3Packages.google-cloud-compute: init at 1.4.0`                                |
| [`01f70337`](https://github.com/NixOS/nixpkgs/commit/01f70337fd58ea9afd1776f1b17154598c6cd108) | `epick: 0.7.0 -> 0.8.0`                                                              |
| [`cad61be2`](https://github.com/NixOS/nixpkgs/commit/cad61be25ef50805176641ad8d702864ad308ef2) | `python3Packages.screeninfo: fix on X11`                                             |
| [`6ae834ea`](https://github.com/NixOS/nixpkgs/commit/6ae834ea905832f197bf2cb64e7dfe385aa15604) | `python310Packages.pypdf2: 2.10.0 -> 2.10.4`                                         |
| [`5f90d904`](https://github.com/NixOS/nixpkgs/commit/5f90d90447d0d4867adf103de55e9893afa62c25) | `verible: init at 0.0-2172-g238b6df6`                                                |
| [`17f69801`](https://github.com/NixOS/nixpkgs/commit/17f698012250efcf22dc593aefa15f253207ac94) | `prometheus-gitlab-ci-pipelines-exporter: 0.5.3 -> 0.5.4`                            |
| [`817413c0`](https://github.com/NixOS/nixpkgs/commit/817413c0425d3e95f0ce5f1c98b7df489c4a1825) | `manga-cli: init at 1.0.5`                                                           |
| [`7f227409`](https://github.com/NixOS/nixpkgs/commit/7f227409836dcdd49024dc76417544b407f99e7c) | `nixos/syncthing: fix path setting for versioning`                                   |
| [`95a66526`](https://github.com/NixOS/nixpkgs/commit/95a6652630e0f72dc41ebec62bb3c88f889823fe) | `maintainers: add baitinq`                                                           |
| [`6c2479f6`](https://github.com/NixOS/nixpkgs/commit/6c2479f6e999a2168dafe1e6ada2dbec4ca4d80a) | `trilium-{desktop,server}: 0.54.2 -> 0.54.3`                                         |
| [`b17757e4`](https://github.com/NixOS/nixpkgs/commit/b17757e458b878b987d9aaddf8a48b0595e01d90) | `knot-dns: add QUIC support`                                                         |
| [`f4356850`](https://github.com/NixOS/nixpkgs/commit/f435685046fc6816cdfc169212c6af441b9db8da) | `ngtcp2-gnutls: init at 0.7.0`                                                       |
| [`e9a09bea`](https://github.com/NixOS/nixpkgs/commit/e9a09beacbca7f9ad33da3934e7c2443a258b429) | `purpur: 1.18.1r1522 -> 1.19.2r1763`                                                 |
| [`189c57aa`](https://github.com/NixOS/nixpkgs/commit/189c57aaa6814e33355122bc6e3d14094071297a) | `mpvacious: 0.15 -> 0.18`                                                            |
| [`ec405741`](https://github.com/NixOS/nixpkgs/commit/ec405741495a8a27edd0a8b16cbbe090778cebc8) | `rubberband: fix build on darwin`                                                    |
| [`c924ea1e`](https://github.com/NixOS/nixpkgs/commit/c924ea1eaa50e2d5bc88affcbf66362616225d3a) | `dlib: add Darwin support`                                                           |
| [`a720c3b2`](https://github.com/NixOS/nixpkgs/commit/a720c3b2acc67ecd124fc94ad0888a5e605ca5e7) | `mutagen-compose: 0.15.1 -> 0.15.2`                                                  |
| [`838d46c0`](https://github.com/NixOS/nixpkgs/commit/838d46c003fd8f60e987cf0444748e5786fc3d34) | `session-desktop: etc`                                                               |
| [`b1f1945e`](https://github.com/NixOS/nixpkgs/commit/b1f1945e3e0dedd6033bf4ae2c5c01319a59be9d) | `ngtcp2: 0.7.0 -> 0.8.0`                                                             |
| [`1e6931da`](https://github.com/NixOS/nixpkgs/commit/1e6931dac85fc1cc8d668bdd9160cbfab247a7cf) | `vopono: 0.10.1 -> 0.10.3`                                                           |
| [`bc3d4bb2`](https://github.com/NixOS/nixpkgs/commit/bc3d4bb2956eadef8452b06542b2d3b9ecdf5a40) | `session-desktop: refactor`                                                          |
| [`44cc09c2`](https://github.com/NixOS/nixpkgs/commit/44cc09c2b492585986eaba093f4ac9b450a5c111) | `utsushi: Fix scanning`                                                              |
| [`03317d0e`](https://github.com/NixOS/nixpkgs/commit/03317d0edb637b3106327f2ac2343dbdd7b9bdda) | `session-desktop-appimage: 1.8.6 -> 1.9.1`                                           |
| [`16f934eb`](https://github.com/NixOS/nixpkgs/commit/16f934eb47c3957653272546dd7ca9e5fbc74c62) | `vimPlugins.vim-isort: fix build`                                                    |
| [`f72c0727`](https://github.com/NixOS/nixpkgs/commit/f72c072710f53d79db5281dc1667b4b279360296) | `webex: 42.8.0.22907 → 42.10.0.23251`                                                |
| [`328448a1`](https://github.com/NixOS/nixpkgs/commit/328448a15306ef65319af532364d33cbe7bdf8cb) | `waydroid: 1.2.1 -> 1.3.0`                                                           |
| [`cd67516d`](https://github.com/NixOS/nixpkgs/commit/cd67516dcf747871b5bd384f15c7074289a6c8a4) | `dhewm3: 1.5.1 -> 1.5.2`                                                             |
| [`c9d8e34f`](https://github.com/NixOS/nixpkgs/commit/c9d8e34fc44c103f402275e13d010ed3febd2424) | `dockerTools: document environment helpers`                                          |
| [`f238aa98`](https://github.com/NixOS/nixpkgs/commit/f238aa983364b2ac8e5cfd7862b5edc19348a105) | `dockerTools: add caCertificates helper`                                             |