### PR TITLE
chore(flake/home-manager): `f9a35cac` -> `960c009c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662375009,
-        "narHash": "sha256-07MocEDz6A5kJlSemjKy+3uArxBUYzP4I7mjjRywll4=",
+        "lastModified": 1662378663,
+        "narHash": "sha256-2Dzw5OnHHkwQ6X97bOVMwDQoqfBokTLqEdKVjPIEcKY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f9a35cacdc63678e9ace8acd8886ed798d93dc55",
+        "rev": "960c009ce04305ebd52fb2b3c10122ded3146c4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`960c009c`](https://github.com/nix-community/home-manager/commit/960c009ce04305ebd52fb2b3c10122ded3146c4e) | `git-sync: minor test cleanup` |
| [`66cc5c7e`](https://github.com/nix-community/home-manager/commit/66cc5c7ef9cae94f41dd52860a69911be33112e6) | `git-sync: add ssh to path`    |