### PR TITLE
chore(flake/home-manager): `960c009c` -> `140aaed3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662378663,
-        "narHash": "sha256-2Dzw5OnHHkwQ6X97bOVMwDQoqfBokTLqEdKVjPIEcKY=",
+        "lastModified": 1662382359,
+        "narHash": "sha256-X8O4fns0XtXkBBzgKQ2+7TUGIdFOvg+TQpCI7wFHP74=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "960c009ce04305ebd52fb2b3c10122ded3146c4e",
+        "rev": "140aaed3dffbe33bb8b2e0cf333c67f36765c85e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                      |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`140aaed3`](https://github.com/nix-community/home-manager/commit/140aaed3dffbe33bb8b2e0cf333c67f36765c85e) | `git: gpg sign tags with signing.signByDefault set` |
| [`de079ec3`](https://github.com/nix-community/home-manager/commit/de079ec3714e7b201c17cbe03b62be8d6dc7b3c0) | `btop: add module`                                  |