### PR TITLE
chore(flake/darwin): `80cec511` -> `3b69bf3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661882940,
-        "narHash": "sha256-4LaVFnV22WrOA0aolqqk9dXrM8crikcrLQt29G18F7M=",
+        "lastModified": 1662478528,
+        "narHash": "sha256-Myjd0HPL5lXri3NXOcJ6gP7IKod2eMweQBKM4uxgEGw=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "80cec5115aae74accc4ccfb9f84306d7863f0632",
+        "rev": "3b69bf3cc26ae19de847bfe54d6ab22d7381a90a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                                                       |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
| [`9b3104f9`](https://github.com/LnL7/nix-darwin/commit/9b3104f90d67c233f8f9c212ef31750d0ccd6bf9) | `Update changelog`                                                                   |
| [`2ddebb31`](https://github.com/LnL7/nix-darwin/commit/2ddebb3189ccd54c7741f6feaaa9d131685a62c5) | ``Improve documentation of `homebrew` module``                                       |
| [`7710d1d7`](https://github.com/LnL7/nix-darwin/commit/7710d1d7d64e67a90571828d10957d200f793127) | ``Add `global` into a submodule``                                                    |
| [`b547a7ac`](https://github.com/LnL7/nix-darwin/commit/b547a7acb09d03bb6a41c6235c1d7f380981073d) | ``Create submodule for activation related `homebrew` options``                       |
| [`55e198cf`](https://github.com/LnL7/nix-darwin/commit/55e198cf5adf1d8e5c99fad1f7472669a8454d4f) | ``Add somes tests for `homebrew` module``                                            |
| [`46032bad`](https://github.com/LnL7/nix-darwin/commit/46032bad426557be99cfbe2ad045d573814f69c9) | ``Cleanup/improve `homebrew` module's code, documentation, and option descriptions`` |
| [`02a38c6a`](https://github.com/LnL7/nix-darwin/commit/02a38c6a8921fc78e868f499b020334b0b3963ad) | ``Enable defining options for `casks` using submodule``                              |
| [`56031db9`](https://github.com/LnL7/nix-darwin/commit/56031db9c130f577f25a9bccbfc6d13e99c14b5f) | ``Enable defining options for `brews` using submodule``                              |
| [`bd93329d`](https://github.com/LnL7/nix-darwin/commit/bd93329d6c9b28178e551b9f92538097209d1138) | ``Enable defining options for `taps` using submodule``                               |
| [`92da7697`](https://github.com/LnL7/nix-darwin/commit/92da7697d19d72a58bd672a511c48f69f45606cc) | ``Add `homebrew.caskArgs` option``                                                   |