### PR TITLE
chore(flake/home-manager): `2e41a1ba` -> `340ec22f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662626397,
-        "narHash": "sha256-NPvTkf2eD86PIkRmwlSGzFmzoajs6JW6+M47hXzGfpM=",
+        "lastModified": 1662627907,
+        "narHash": "sha256-eKgAeloXr7gAjKjcOaiywAuVe9M4f73lMHDKuAZW1XE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2e41a1bab32e49568a037ddd962ebbe01c8c2f40",
+        "rev": "340ec22f6f2e9c52e2b555e48ab44ee8c53e0275",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                     |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`340ec22f`](https://github.com/nix-community/home-manager/commit/340ec22f6f2e9c52e2b555e48ab44ee8c53e0275) | `git: add config helper for hooks` |