### PR TITLE
chore(flake/nixos-hardware): `504b32ca` -> `1fec8fda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1662458987,
-        "narHash": "sha256-hcDwRlsXZMp2Er3vQk1JEUZWhBPLVC9vTT4xHvhpcE0=",
+        "lastModified": 1662714967,
+        "narHash": "sha256-IOTq5tAGGmBFj7tQbkcyLE261JUeTUucEE3p0WLZ4qM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "504b32caf83986b7e6b9c79c1c13008f83290f19",
+        "rev": "1fec8fda86dac5701146c77d5f8a414b14ed1ff6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                                                                   |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
| [`33642d33`](https://github.com/NixOS/nixos-hardware/commit/33642d338f6b3a047a128b5ba574d18e34994da9) | `apple/macbook-pro/11-5: add a note about switching between integrated and discrete graphics`                    |
| [`a4345da2`](https://github.com/NixOS/nixos-hardware/commit/a4345da27ed2ac532b60078cdb4d0093303b14d0) | `apple/macbook-pro/11-5: driver choice should be optional since si_support is experimental`                      |
| [`fd68d655`](https://github.com/NixOS/nixos-hardware/commit/fd68d65507fc362f763bc8e6127e322b6e63e864) | `apple/macbook-pro/11-5: add to top-level README`                                                                |
| [`821ddbaf`](https://github.com/NixOS/nixos-hardware/commit/821ddbaf1cb6ff5ecfdf12cf51759f6605a7dad7) | `apple/macbook-pro/11-5: make enableRedistributableFirmware an optional default (uniformity with other configs)` |
| [`1d100017`](https://github.com/NixOS/nixos-hardware/commit/1d100017018efb0d79022dfe8c010f14250f9117) | `apple/macbook-pro/11-5: Links to hardware probes`                                                               |
| [`a930f438`](https://github.com/NixOS/nixos-hardware/commit/a930f43803c1c7111cd53445b552437da5e8866d) | `apple/macbook-pro/11-5: document amdgpu driver choice`                                                          |
| [`c38ec641`](https://github.com/NixOS/nixos-hardware/commit/c38ec64187c534bcb6d1d99ec40269ea33fa080e) | `apple/macbook-pro/11-5: Use the newer amdgpu driver`                                                            |
| [`a318b2eb`](https://github.com/NixOS/nixos-hardware/commit/a318b2ebfae401ab3adecb88641d0da2111d0a4a) | `apple/macbook-pro/11-5: explicitly turn on redistributable firmware`                                            |