### PR TITLE
chore(flake/nixpkgs): `74a1793c` -> `c97e777f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1662732537,
-        "narHash": "sha256-iqxa+38SRU+SwNsKDyP8rZt79yPFGSgTe+K4Ujbb/uw=",
+        "lastModified": 1662911228,
+        "narHash": "sha256-oJOrB2lEeBLaO8g1DKG5PK9a1zyOWypkscrEfxxEj8A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "74a1793c659d09d7cf738005308b1f86c90cb59b",
+        "rev": "c97e777ff06fcb8d37dcdf5e21e9eff1f34f0e90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                        |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
| [`3f7ba128`](https://github.com/NixOS/nixpkgs/commit/3f7ba1286875aedff80c09950741742dad05bb72) | `cachix-agent: fix a typo`                                                                                            |
| [`f1c17188`](https://github.com/NixOS/nixpkgs/commit/f1c1718814029c9f765d0fd666f514cb2463bba4) | `fdupes: 2.2.0 -> 2.2.1`                                                                                              |
| [`17352e89`](https://github.com/NixOS/nixpkgs/commit/17352e8995e1409636b0817a7f38d6314ccd73c4) | `nixos/security/wrappers: clarify required format for capabilities`                                                   |
| [`4886df0a`](https://github.com/NixOS/nixpkgs/commit/4886df0aea37cdac9139aee6cf291139c7f0e9b2) | `borgmatic: 1.6.4 -> 1.7.2`                                                                                           |
| [`3e2341b0`](https://github.com/NixOS/nixpkgs/commit/3e2341b08267da2826093652c3e45bf2140ddb7a) | `rubyPackages.sqlite3: fix building for >= 1.5.0`                                                                     |
| [`224da23d`](https://github.com/NixOS/nixpkgs/commit/224da23db257734e493364c44bf5b040efcdbec3) | `sasview: remove unused input`                                                                                        |
| [`a7fb06c2`](https://github.com/NixOS/nixpkgs/commit/a7fb06c2da708e39169059a797ba7c0cb8433256) | `gopass: 1.14.5 -> 1.14.6`                                                                                            |
| [`a1250fe8`](https://github.com/NixOS/nixpkgs/commit/a1250fe8b2b7f84721735c8462fb9ffe8f123f39) | `virt-manager: 4.0.0 -> 4.1.0`                                                                                        |
| [`11bafe6b`](https://github.com/NixOS/nixpkgs/commit/11bafe6b5b0645514d310cfc540dbce18bdd6939) | `nixos/syncthing: remove exit code 2 from exit status success`                                                        |
| [`69063d79`](https://github.com/NixOS/nixpkgs/commit/69063d79d3aa26ff552018b476f7e4d78490f959) | `distrobox: 1.3.1 -> 1.4.0`                                                                                           |
| [`d1061018`](https://github.com/NixOS/nixpkgs/commit/d10610180692407be0a7e457f8d2b029fd9f705b) | `ocamlPackages.lambdapi: init at 2.2.1`                                                                               |
| [`1b327858`](https://github.com/NixOS/nixpkgs/commit/1b327858f9034590e8e039f601f538ed364dde2d) | `ocamlPackages.pratter: init at 2.0.0`                                                                                |
| [`b361e189`](https://github.com/NixOS/nixpkgs/commit/b361e1895f4be7837fe34f023af5fc38b31cba58) | `ocamlPackages.dedukti: init at 2.7`                                                                                  |
| [`4f742d45`](https://github.com/NixOS/nixpkgs/commit/4f742d45353d8aebad90095c4d3cba39e7721a9c) | `ocamlPackages.bindlib: init at 6.0.0`                                                                                |
| [`4fe8af21`](https://github.com/NixOS/nixpkgs/commit/4fe8af2162f6e0068ba8c87364a44e98b9f5ab84) | `ocamlPackages.timed: init at 1.1`                                                                                    |
| [`4873ebf5`](https://github.com/NixOS/nixpkgs/commit/4873ebf5eda528a24d14d648ef993460808f0d7e) | `lightningcss: init at 1.14.0`                                                                                        |
| [`94cd95a3`](https://github.com/NixOS/nixpkgs/commit/94cd95a34631fcffae58cccf1f74a055327bc60c) | `echidna: 2.0.2 -> 2.0.3`                                                                                             |
| [`cbdd52e5`](https://github.com/NixOS/nixpkgs/commit/cbdd52e5b7d41cc96e711ee9e8cffd1dfb7726a9) | `maintainers: add bpaulin`                                                                                            |
| [`fda90822`](https://github.com/NixOS/nixpkgs/commit/fda9082208f1b85646fd5e17904524f1cdc116f9) | `pinniped: init at 0.17.0`                                                                                            |
| [`883f6e0b`](https://github.com/NixOS/nixpkgs/commit/883f6e0bd443bf7de318531e68684568ec2651d2) | `python3Packages.nbclient: 0.6.6 -> 0.6.8`                                                                            |
| [`3096877d`](https://github.com/NixOS/nixpkgs/commit/3096877d3810998ea049f5fe0deeded2baecb169) | `python310Packages.fireflyalgorithm: init at 0.3.2`                                                                   |
| [`e789268a`](https://github.com/NixOS/nixpkgs/commit/e789268a2622b7d0177482dc6527667ef4fc0bb5) | `gdu: 5.16.0 -> 5.17.0`                                                                                               |
| [`8549806f`](https://github.com/NixOS/nixpkgs/commit/8549806fe83fd3120d6d18ebc8ed593b1b786432) | `drawing: 1.0.0 -> 1.0.1`                                                                                             |
| [`ecb8cf9f`](https://github.com/NixOS/nixpkgs/commit/ecb8cf9f68b85b851a2d9c4aae061e7ba056c35e) | `pkgs/top-level: add a type for warnUndeclaredOptions`                                                                |
| [`141b733b`](https://github.com/NixOS/nixpkgs/commit/141b733bf0a3214ff6d6d0f3e87198d9754dc31d) | `pizarra: init at 1.7.3`                                                                                              |
| [`9c98130a`](https://github.com/NixOS/nixpkgs/commit/9c98130a0a29da4652d0b7957c0f558e7cb4d494) | `maintainers: init MGlolenstine`                                                                                      |
| [`d294d2a6`](https://github.com/NixOS/nixpkgs/commit/d294d2a6fd4610cdd447f5cc2d8687aa7383c436) | `sickgear: 0.25.35 -> 0.25.40, add patch to skip python version check, add optional dependencies (lxml & libarchive)` |
| [`189d5ba4`](https://github.com/NixOS/nixpkgs/commit/189d5ba4a44656f806ea730c8afba45d29ecb055) | `python310Packages.pytest-testmon: 1.3.5 -> 1.3.6`                                                                    |
| [`5084667f`](https://github.com/NixOS/nixpkgs/commit/5084667f78b1437c91aa5ad19de4cdfb27ea30fa) | `python310Packages.pytest-pylint: 0.18.0 -> 0.19.0`                                                                   |
| [`fc6f0ea1`](https://github.com/NixOS/nixpkgs/commit/fc6f0ea18877cf7dc2139be54e447eeee8d3cb26) | `workflows: fix manual-rendering.yml`                                                                                 |
| [`fae1a2aa`](https://github.com/NixOS/nixpkgs/commit/fae1a2aa41751fd41266e0d639709be954941b57) | `pcsx2: disable auto updates`                                                                                         |
| [`f864ccfd`](https://github.com/NixOS/nixpkgs/commit/f864ccfdaac5e5b45d30d40593629ce58e7e5b0d) | `nix-prefetch: fix prefetching when using the hash key`                                                               |
| [`d1bc788b`](https://github.com/NixOS/nixpkgs/commit/d1bc788b0d312c174b68cd396fd32e5bcf5bd45e) | `beam: dont use 'with beam' and 'with beam.interpreters'`                                                             |
| [`c4a27e10`](https://github.com/NixOS/nixpkgs/commit/c4a27e106852b8ff6765610d2395b0e53acc8b52) | `python310Packages.nextcord: 2.1.0 -> 2.2.0`                                                                          |
| [`2d2be966`](https://github.com/NixOS/nixpkgs/commit/2d2be966595702d3c91d4c0cfe7ed56154fb9914) | `networkmanager: 1.38.4 -> 1.40.0`                                                                                    |
| [`e7d789c8`](https://github.com/NixOS/nixpkgs/commit/e7d789c810c5c0355d815b417a6649d3806d310b) | `python310Packages.mailchecker: 5.0.0 -> 5.0.1`                                                                       |
| [`34645487`](https://github.com/NixOS/nixpkgs/commit/346454873ef27dc476fcbdab9a6b9188ab1d0fcb) | `coqPackages.lib.overrideCoqDerivation: update documentation for overriding version`                                  |
| [`78758c07`](https://github.com/NixOS/nixpkgs/commit/78758c07b6dd9e01bd8c9fe36ec8465cf1368f38) | `miniplayer: init at 1.7.0`                                                                                           |
| [`f72099e0`](https://github.com/NixOS/nixpkgs/commit/f72099e0cdcd90462ac92bb7d9590bf25a67c1fd) | `nixos/nextcloud: fix a deprecation warning in the tests using redis`                                                 |
| [`b20df24e`](https://github.com/NixOS/nixpkgs/commit/b20df24e2c3af148669d184665ce7deedf5ce289) | `nixos/ausweisapp: init module with firewall option`                                                                  |
| [`ee854934`](https://github.com/NixOS/nixpkgs/commit/ee854934cbc41bbc52fdb2e41c53e867994b55d6) | `python310Packages.goodwe: 0.2.19 -> 0.2.20`                                                                          |
| [`bc968157`](https://github.com/NixOS/nixpkgs/commit/bc96815777168f8450c12d4c3944ecc0e182887a) | `ropgadget: 6.9 -> 7.0`                                                                                               |
| [`3b8f466f`](https://github.com/NixOS/nixpkgs/commit/3b8f466ff04ee2ff3ebc9fd69193be575172ce31) | `yubico-piv-tool: add anthonyroussel to maintainers`                                                                  |
| [`b7cc776e`](https://github.com/NixOS/nixpkgs/commit/b7cc776e4f5c33450d30fa4a97319ec984d0dabc) | `yubico-piv-tool: 2.2.1 -> 2.3.0`                                                                                     |
| [`ff4925ee`](https://github.com/NixOS/nixpkgs/commit/ff4925eeaddc6b472ab76371c4f7976ec625b102) | `bat: 0.22.0 -> 0.22.1`                                                                                               |
| [`8fef18c4`](https://github.com/NixOS/nixpkgs/commit/8fef18c4b7eafcf3e013bfc39628c5441832ed45) | `bun: 0.1.6 -> 0.1.11`                                                                                                |
| [`0ad8b1da`](https://github.com/NixOS/nixpkgs/commit/0ad8b1da22374bc1eb34ad48b1b66e7cf422c361) | `octosql: init at 0.9.3 (#190467)`                                                                                    |
| [`888efa4c`](https://github.com/NixOS/nixpkgs/commit/888efa4cc7959f82305e3da43f5c51ef52c164bc) | `python310Packages.dparse: 0.5.2 -> 0.6.0`                                                                            |
| [`badb13d7`](https://github.com/NixOS/nixpkgs/commit/badb13d79d66852cd5c1d7a84c56f7e786488b90) | `python310Packages.django-extensions: 3.2.0 -> 3.2.1`                                                                 |
| [`23866b9d`](https://github.com/NixOS/nixpkgs/commit/23866b9d44372ea9f789c652abeafc7bab7a2128) | `python310Packages.discogs-client: 2.3.15 -> 2.4`                                                                     |
| [`5e13cdfe`](https://github.com/NixOS/nixpkgs/commit/5e13cdfe70ed72392f9a0bdfccea2ed850767399) | `nix-template: 0.3.0 -> 0.4.0`                                                                                        |
| [`5b124213`](https://github.com/NixOS/nixpkgs/commit/5b1242134cbd728eb3da016e2b9722b4358b75f6) | `pscale: add shell completion and version test`                                                                       |
| [`ecce6bc5`](https://github.com/NixOS/nixpkgs/commit/ecce6bc552a30bc91faaacdb6e7af74188b62940) | `doppler: add version test & shell completion`                                                                        |
| [`686b00be`](https://github.com/NixOS/nixpkgs/commit/686b00be305cd8678ccc87554c026052357f8c6b) | `nongnu-packages: updated 2022-09-10 (from overlay)`                                                                  |
| [`42470f86`](https://github.com/NixOS/nixpkgs/commit/42470f8650b30af41472d1af04db9642088a6316) | `melpa-packages: updated 2022-09-10 (from overlay)`                                                                   |
| [`42cba202`](https://github.com/NixOS/nixpkgs/commit/42cba20252484f7d0bd523dc00d885215852d865) | `elpa-packages: updated 2022-09-10 (from overlay)`                                                                    |
| [`dc4deda1`](https://github.com/NixOS/nixpkgs/commit/dc4deda13571bbf40d945f6fa642466d49336f3d) | `elisp-packages: upgrade update-from-overlay script`                                                                  |
| [`bc64b4d7`](https://github.com/NixOS/nixpkgs/commit/bc64b4d7889e3f64bc6c319e2dd27783dfc9c35a) | `libftdi1: fix cross compilation`                                                                                     |
| [`eaba4069`](https://github.com/NixOS/nixpkgs/commit/eaba40695eeae3e9aeb4492e60d438c111b25f87) | `tor: 0.4.7.8 -> 0.4.7.10 (#190647)`                                                                                  |
| [`cc36652f`](https://github.com/NixOS/nixpkgs/commit/cc36652f8d6cba8d752845435b3d7ef66627d2fe) | `nextcloud-client: 3.5.4 -> 3.6.0 (#190155)`                                                                          |
| [`9bc0d669`](https://github.com/NixOS/nixpkgs/commit/9bc0d6697913529a8ad98302f3fe7a7793ddf591) | `python310Packages.awscrt: 0.14.5 -> 0.14.6`                                                                          |
| [`56184369`](https://github.com/NixOS/nixpkgs/commit/56184369ba1cc069f41cd8663da683a4630dc2f9) | `zellij: 0.31.3 -> 0.31.4`                                                                                            |
| [`c45deeb2`](https://github.com/NixOS/nixpkgs/commit/c45deeb2aa67019d216a3dd1baca4a5157bdf123) | `workflows: add check for docbook/md manual equality`                                                                 |
| [`ec75c8ef`](https://github.com/NixOS/nixpkgs/commit/ec75c8efff8eab18dc8ec7c5016d589c0c705f95) | `workflows: check that nixos manual does not use docbook option docs`                                                 |
| [`d9832283`](https://github.com/NixOS/nixpkgs/commit/d98322834b496876723a529b92c2f80eeae0a60c) | `nixos/*: fix docbook deprecation notices`                                                                            |
| [`767485a0`](https://github.com/NixOS/nixpkgs/commit/767485a0dee24329e2b34cd4af0c08ea21e959ea) | `lib/options: deprecate docbook text and literalDocBook`                                                              |
| [`8c309aa4`](https://github.com/NixOS/nixpkgs/commit/8c309aa43ae9e5e4dbdd542e4e5e49253d3dd763) | `gnome.networkmanager-openvpn: 1.8.18 → 1.10.0`                                                                       |
| [`ad0108d8`](https://github.com/NixOS/nixpkgs/commit/ad0108d803c9e74c08d70061301d8780e428abe5) | `nixos/gollum: add test`                                                                                              |
| [`6a66cf1b`](https://github.com/NixOS/nixpkgs/commit/6a66cf1b901efaf1b711c7d4423fc09e001ad13e) | `nixos/gollum: add package option`                                                                                    |
| [`17c9f2c7`](https://github.com/NixOS/nixpkgs/commit/17c9f2c7b370c0ae810fb12a513765811983e5c4) | `python310Packages.zigpy-deconz: 0.18.0 -> 0.18.1`                                                                    |
| [`07bf4e55`](https://github.com/NixOS/nixpkgs/commit/07bf4e55d13890b3e5407c5f66166625defc4cfa) | `python310Packages.dropbox: 11.33.0 -> 11.34.0`                                                                       |
| [`f46bc2dd`](https://github.com/NixOS/nixpkgs/commit/f46bc2dd02df23719d50b1d334819ceac5977104) | `discord: add infinidoge to maintainers`                                                                              |
| [`04de14ea`](https://github.com/NixOS/nixpkgs/commit/04de14ead39407fa18d195dc9ccb54f6ce8486bd) | `openxr-loader: 1.0.24 -> 1.0.25`                                                                                     |
| [`9ed02a4c`](https://github.com/NixOS/nixpkgs/commit/9ed02a4c598c5b0119abe4ec44ac330818139bba) | `prowlarr: 0.4.4.1947 -> 0.4.5.1960`                                                                                  |
| [`bf3dc2da`](https://github.com/NixOS/nixpkgs/commit/bf3dc2dad06d11f84d7f669a75237bbb15ca36c1) | `python310Packages.pylink-square: 0.14.1 -> 0.14.2`                                                                   |
| [`d26e4612`](https://github.com/NixOS/nixpkgs/commit/d26e46121315b6ba26e0650b0f0ca85b17671ab7) | `python310Packages.zwave-me-ws: 0.2.5.1 -> 0.2.6`                                                                     |
| [`7b6656f6`](https://github.com/NixOS/nixpkgs/commit/7b6656f69a09c74606d69edf74aaecafbfa2832f) | `python310Packages.zope_contenttype: 4.5.0 -> 4.6`                                                                    |
| [`6803f842`](https://github.com/NixOS/nixpkgs/commit/6803f842f6871bf2b1b80c52b3d28f738bfbe977) | `genact: 1.0.1 -> 1.0.2`                                                                                              |
| [`60fb2f50`](https://github.com/NixOS/nixpkgs/commit/60fb2f509d11b8916bffc97ffcfd422d8e2535bb) | `discord: add artturin to maintainers`                                                                                |
| [`93a0067a`](https://github.com/NixOS/nixpkgs/commit/93a0067a9c85c17764f7755947e6ecf52dc47d8a) | `tkrzw: fix building on impure platforms`                                                                             |
| [`7c1e8880`](https://github.com/NixOS/nixpkgs/commit/7c1e8880288511379574ffc8a3beff410a8db8ea) | `papirus-icon-theme: 20220808 -> 20220910`                                                                            |
| [`d8579c81`](https://github.com/NixOS/nixpkgs/commit/d8579c81c7b48a1659e1604d42aedf61441e408d) | `oh-my-zsh: 2022-09-07 -> 2022-09-08`                                                                                 |
| [`da591641`](https://github.com/NixOS/nixpkgs/commit/da591641de51aa938aa1f2454b0e53e4b6bf2e73) | `nil: init at unstable-2022-09-10`                                                                                    |
| [`099df1f9`](https://github.com/NixOS/nixpkgs/commit/099df1f9acb776b45f91570a3d7de642aacd7993) | `v8: fix darwin build`                                                                                                |
| [`382c0364`](https://github.com/NixOS/nixpkgs/commit/382c0364cb14156d8dbea9e4ee40b220f94c4670) | `arc-kde-theme: remove ouputHash`                                                                                     |
| [`9518ee5a`](https://github.com/NixOS/nixpkgs/commit/9518ee5a82d3596a4217e89ef38d4b620cd44f11) | `adapta-kde-theme: remove ouputHash`                                                                                  |
| [`958914fa`](https://github.com/NixOS/nixpkgs/commit/958914fab2e9754b8e17147457515f73a7d8c287) | `nextcloud: drop password regeneration behavior`                                                                      |
| [`06455bca`](https://github.com/NixOS/nixpkgs/commit/06455bca50047ced38da3b993a52c8d372d00384) | `arc-kde-theme: 20220810 -> 20220908`                                                                                 |
| [`fa9a186e`](https://github.com/NixOS/nixpkgs/commit/fa9a186ec3989c86a0790ce0d952547c39521537) | `wdomirror: fix build`                                                                                                |
| [`42e79f01`](https://github.com/NixOS/nixpkgs/commit/42e79f018c32de3c0999cc8112dd8235443ee5c2) | `chicken: fix darwin build`                                                                                           |
| [`80c40aaa`](https://github.com/NixOS/nixpkgs/commit/80c40aaa91f094a08bdea47dadd275d277849204) | `sticky: fix updateScript`                                                                                            |
| [`e3fc2290`](https://github.com/NixOS/nixpkgs/commit/e3fc2290e04a036c44b228324068491485e97bb5) | `trueseeing: 2.1.4 -> 2.1.5`                                                                                          |
| [`3a1bec89`](https://github.com/NixOS/nixpkgs/commit/3a1bec8917a0a1f1ed0f09798fcb85273247a958) | `coqPackages.gappalib: 1.5.1 → 1.5.2`                                                                                 |
| [`725fe60d`](https://github.com/NixOS/nixpkgs/commit/725fe60de069ccdb8ba22da63d740cc572c559cb) | `ocamlPackages.ctypes_stubs_js: init at 0.1`                                                                          |
| [`e6abed6c`](https://github.com/NixOS/nixpkgs/commit/e6abed6cae3d445122155fe62dc969858c0ddc93) | `ocamlPackages.integers_stubs_js: init at 1.0`                                                                        |
| [`38417e0e`](https://github.com/NixOS/nixpkgs/commit/38417e0e291949b8a30923678bc923dedc0a4b70) | `tezos-base58: init at 1.0.0`                                                                                         |
| [`b1075c25`](https://github.com/NixOS/nixpkgs/commit/b1075c25001f83c53f8fbae4d3ef0ce1c5311a48) | `gitRepo: 2.29.1 -> 2.29.2`                                                                                           |
| [`603e7464`](https://github.com/NixOS/nixpkgs/commit/603e7464b7c31b30a92e18dc47b1804055946d59) | `coyim: 0.3.11 -> 0.4`                                                                                                |
| [`56067eed`](https://github.com/NixOS/nixpkgs/commit/56067eed7534ccc1beff8c8b3663bff5e3000a06) | `cinnamon.warpinator: fix updateScript`                                                                               |
| [`3afff7f7`](https://github.com/NixOS/nixpkgs/commit/3afff7f75c0d640c4ee73f72c335dbdd86298a3a) | `flexget: 3.3.25 -> 3.3.26`                                                                                           |
| [`06e4f6fd`](https://github.com/NixOS/nixpkgs/commit/06e4f6fd65963d96bd8078026a793173d4bd615d) | `fava: 1.22.2 -> 1.22.3`                                                                                              |
| [`8362f85e`](https://github.com/NixOS/nixpkgs/commit/8362f85e805f984a3a7d045916ce50c7d7d254a4) | `firefox-devedition-bin-unwrapped: 105.0b7 -> 105.0b9`                                                                |
| [`60d0494f`](https://github.com/NixOS/nixpkgs/commit/60d0494fe825977e92681636ae13f4d645266e4c) | `firefox-beta-bin-unwrapped: 105.0b7 -> 105.0b9`                                                                      |
| [`cd87aef0`](https://github.com/NixOS/nixpkgs/commit/cd87aef066e4bdbb1139845500072bd252d37c5e) | `deno: 1.25.1 -> 1.25.2`                                                                                              |
| [`cb007d18`](https://github.com/NixOS/nixpkgs/commit/cb007d184aaebba8313b9c125aa4509c2e39907f) | `tageditor: 3.3.10 -> 3.7.5`                                                                                          |
| [`33b4303a`](https://github.com/NixOS/nixpkgs/commit/33b4303a8cdada9debcf370e4ac4a3ccb2668afe) | `tagparser: 9.4.0 -> 11.5.0`                                                                                          |
| [`c176cbaa`](https://github.com/NixOS/nixpkgs/commit/c176cbaa19f5df1bef6ca04d613a9a2ad0b458c9) | `prl-tools: 18.0.0-53049 -> 18.0.1-53056`                                                                             |
| [`8edc6b34`](https://github.com/NixOS/nixpkgs/commit/8edc6b340b65f0a82cf368b701a4fdc7fdc5b1e7) | `haskellPackages.{evdev,evdev-streamly}: mark as linux only`                                                          |
| [`c99a9a8f`](https://github.com/NixOS/nixpkgs/commit/c99a9a8fc5c35aac7fb7eb29ae54a2a8c6360a67) | `rpcs3: 0.0.23-13907-cdef752a9 -> 0.0.24-14141-d686b48f6`                                                             |
| [`7c4b5a89`](https://github.com/NixOS/nixpkgs/commit/7c4b5a896f4b863af3284538d2cbce060671990f) | `haskellPackages: mark builds failing on hydra as broken`                                                             |
| [`18015299`](https://github.com/NixOS/nixpkgs/commit/18015299618ba5f628ad6e1f41146e53fabbebfe) | `nextcloud24: 24.0.4 -> 24.0.5`                                                                                       |
| [`0e3e28fe`](https://github.com/NixOS/nixpkgs/commit/0e3e28fef01b076f0206036b65962abac842515d) | `nextcloud23: 23.0.8 -> 23.0.9`                                                                                       |
| [`dc6d551c`](https://github.com/NixOS/nixpkgs/commit/dc6d551c57e4a1b8bd970a7cc8c609485e797b8e) | `home-assistant: 2022.9.0 -> 2022.9.1`                                                                                |
| [`471c9452`](https://github.com/NixOS/nixpkgs/commit/471c94529ca3cffdef5d74d9a5ddbcd68f6aa1a4) | `k6: 0.39.0 -> 0.40.0`                                                                                                |