### PR TITLE
chore(flake/pre-commit-hooks): `8cb8ea5f` -> `60cad1a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660830093,
-        "narHash": "sha256-HUhx3a82C7bgp2REdGFeHJdhEAzMGCk3V8xIvfBqg1I=",
+        "lastModified": 1663082609,
+        "narHash": "sha256-lmCCIu4dj59qbzkGKHQtolhpIEQMeAd2XUbXVPqgPYo=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "8cb8ea5f1c7bc2984f460587fddd5f2e558f6eb8",
+        "rev": "60cad1a326df17a8c6cf2bb23436609fdd83024e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message |
| ------------------------------------------------------------------------------------------------------------ | -------------- |
| [`bb7a22b4`](https://github.com/cachix/pre-commit-hooks.nix/commit/bb7a22b4bde48916b70af1f482e3b9c65cd51dd9) | `fix rustfmt`  |