### PR TITLE
chore(flake/nixpkgs): `c97e777f` -> `5f326e2a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1662911228,
-        "narHash": "sha256-oJOrB2lEeBLaO8g1DKG5PK9a1zyOWypkscrEfxxEj8A=",
+        "lastModified": 1662996720,
+        "narHash": "sha256-XvLQ3SuXnDMJMpM1sv1ifPjBuRytiDYhB12H/BNTjgY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c97e777ff06fcb8d37dcdf5e21e9eff1f34f0e90",
+        "rev": "5f326e2a403e1cebaec378e72ceaf5725983376d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                         |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`446f8cc5`](https://github.com/NixOS/nixpkgs/commit/446f8cc58969c063c03670234f294626e16871be) | `fluxcd: 0.33.0 -> 0.34.0`                                                             |
| [`be9e813d`](https://github.com/NixOS/nixpkgs/commit/be9e813d762cc138e499ae49a2d43ff27fbfb20d) | `sierra-breeze-enhanced: 1.2.0 -> 1.3.1`                                               |
| [`31f69654`](https://github.com/NixOS/nixpkgs/commit/31f69654820318de1d0cde6c640f82282c56b0ae) | `ibus-engines.m17n: 1.4.10 -> 1.4.11`                                                  |
| [`e449f76a`](https://github.com/NixOS/nixpkgs/commit/e449f76a1f333c96f9494bd28a7fcd3b40b563c6) | `libxmlb: 0.3.9 -> 0.3.10`                                                             |
| [`bc7d278a`](https://github.com/NixOS/nixpkgs/commit/bc7d278ac67666ce98c03152a87062b8f9e17f3c) | `libjcat: 0.1.11 -> 0.1.12`                                                            |
| [`dd22a79c`](https://github.com/NixOS/nixpkgs/commit/dd22a79c0aef00fd6f7c7257b1f785fe91e19480) | `xplr: 0.19.0 -> 0.19.3`                                                               |
| [`f9403831`](https://github.com/NixOS/nixpkgs/commit/f940383130e605332052abd23c9cfe153d63e90d) | `cocogitto: 5.1.0 -> 5.2.0`                                                            |
| [`5b79100c`](https://github.com/NixOS/nixpkgs/commit/5b79100cadb9c802d65a84a278a901343a1c53e7) | ` ledger-live-desktop: 2.46.2 -> 2.47.0`                                               |
| [`33956f6f`](https://github.com/NixOS/nixpkgs/commit/33956f6fdb079ade70493f23da421cf4471cba64) | `ngtcp2-gnutls: 0.7.0 -> 0.8.1`                                                        |
| [`997fb2b5`](https://github.com/NixOS/nixpkgs/commit/997fb2b5709372f893d264e045c7b826e41d7ad4) | `knot-dns: 3.2.0 -> 3.2.1`                                                             |
| [`f085846e`](https://github.com/NixOS/nixpkgs/commit/f085846ed2b1cec849bd27f88f5edbc03b5f5da6) | `knot-dns: add a test for version-sensitive dependencies`                              |
| [`564fb910`](https://github.com/NixOS/nixpkgs/commit/564fb910650c72a9e11aab2e9068aafebcd67564) | `libusb-compat-0_1: remove patchelf from nativeBuildInputs as it is includ… (#190201)` |
| [`f847472d`](https://github.com/NixOS/nixpkgs/commit/f847472df6996c2ec4dd98c459b6734d0729d498) | `neatvnc: 0.5.3 -> 0.5.4`                                                              |
| [`133d72aa`](https://github.com/NixOS/nixpkgs/commit/133d72aa16b4d5f2d2b5c1e841c21a377be93015) | `gopass-jsonapi: 1.14.5 -> 1.14.6`                                                     |
| [`a953aca3`](https://github.com/NixOS/nixpkgs/commit/a953aca3d73cee231c4f852524d6f336d027ece0) | `fclones: 0.27.2 -> 0.27.3`                                                            |
| [`fdead18e`](https://github.com/NixOS/nixpkgs/commit/fdead18e9e7c5f157c572858494b1c292430eede) | `nixos/paperless: use python from pkg for gunicorn`                                    |
| [`121aeadd`](https://github.com/NixOS/nixpkgs/commit/121aeadda77f42fa272fff45518eacbec08bfc3a) | `apache-jena: 4.6.0 -> 4.6.1`                                                          |
| [`fce8e220`](https://github.com/NixOS/nixpkgs/commit/fce8e2200adcfe848f40758190d8be10cea8603f) | `ipinfo: 2.8.1 -> 2.9.0`                                                               |
| [`bbe49339`](https://github.com/NixOS/nixpkgs/commit/bbe49339b81aa7acc13612d78ace0e4cfcaaaa6b) | `.github/workflows: fix permissions`                                                   |
| [`5f1dfe2c`](https://github.com/NixOS/nixpkgs/commit/5f1dfe2c0ffba6cd4615bc46cf5d9a0f3b57deba) | `php80: 8.0.22 -> 8.0.23`                                                              |
| [`d103a918`](https://github.com/NixOS/nixpkgs/commit/d103a9186b98ac92ae601703b7cd3b713d98f772) | `tere: 1.1.0 -> 1.2.0`                                                                 |
| [`eebe8d36`](https://github.com/NixOS/nixpkgs/commit/eebe8d3655a72783d860de78258717fed38c4491) | `just: 1.4.0 -> 1.5.0`                                                                 |
| [`1a20be1a`](https://github.com/NixOS/nixpkgs/commit/1a20be1a312b69c13b40d246358cf7d315d52b60) | `sish: 2.6.0 -> 2.7.0`                                                                 |
| [`01d0040b`](https://github.com/NixOS/nixpkgs/commit/01d0040bac5d9845ff0d842de517bf4254753d2e) | `pure-prompt: 1.20.1 -> 1.20.3`                                                        |
| [`029509e1`](https://github.com/NixOS/nixpkgs/commit/029509e16f3ddce59756dfc3c1023d2ee7289259) | `terraform-providers: update 2022-09-11`                                               |
| [`40f68f68`](https://github.com/NixOS/nixpkgs/commit/40f68f68f7b010024772a84fdaa7828267d78ea6) | `liblqr: fix compilation on x86_64_darwin`                                             |
| [`79ad734f`](https://github.com/NixOS/nixpkgs/commit/79ad734fdf1f541d1fc6ec6d4675f4cd3386fb1b) | `nerdctl: 0.22.2 -> 0.23.0`                                                            |
| [`0c987137`](https://github.com/NixOS/nixpkgs/commit/0c98713750ef9d7e350500cd763c3388bdc0a955) | `nix-prefetch: actually fix prefetching when using the hash key`                       |
| [`6c1c144e`](https://github.com/NixOS/nixpkgs/commit/6c1c144e405a9f5d44f1fb196f4a3a1878093f47) | `sbt-extras: 2022-02-01 -> 2022-07-12 (#190641)`                                       |
| [`0a586cd4`](https://github.com/NixOS/nixpkgs/commit/0a586cd4d5e82bcf949a3734c0cf48b73c03bfe1) | `php: 8.1.9 -> 8.1.10`                                                                 |
| [`cb62326e`](https://github.com/NixOS/nixpkgs/commit/cb62326e36148b60a95898b26c07ab221209cf9a) | `hex: init at 0.4.2`                                                                   |
| [`1599304c`](https://github.com/NixOS/nixpkgs/commit/1599304c49da7520714eadb15bcb5e120832ee68) | `synth: 0.6.5-r1 -> 0.6.8`                                                             |
| [`9383bfaa`](https://github.com/NixOS/nixpkgs/commit/9383bfaa1bf627cec1344be19a42438e2e1c25f4) | `buildah: 1.27.0 -> 1.27.1 (#190779)`                                                  |
| [`1778eb5f`](https://github.com/NixOS/nixpkgs/commit/1778eb5fdc44e1cbcb1620f574d368daa16fa2bd) | `mani: 0.21.0 -> 0.22.0`                                                               |
| [`3c8e7864`](https://github.com/NixOS/nixpkgs/commit/3c8e7864cd8933532a20934eefcfb7eebda73f6d) | `mlib: init at 0.6.0`                                                                  |
| [`fbc23b49`](https://github.com/NixOS/nixpkgs/commit/fbc23b491a3a934517430b49b98ab7119d5185b3) | `cachix-agent: add host option`                                                        |
| [`19cd03d4`](https://github.com/NixOS/nixpkgs/commit/19cd03d456109f4fffa6e848525e4d4fe61243c3) | `clojure: use latest java LTS`                                                         |
| [`a611c674`](https://github.com/NixOS/nixpkgs/commit/a611c674c211fe776588dda9a9df88cb914046da) | ``paperless: use `imagemagickBig```                                                    |
| [`5d3b91f9`](https://github.com/NixOS/nixpkgs/commit/5d3b91f9a039693e536c87f5086cb4730cd5d454) | `packcc: init at 1.8.0`                                                                |
| [`e3be4ad2`](https://github.com/NixOS/nixpkgs/commit/e3be4ad2f06450b43ee723250cb96bb39a1b50a7) | `paperless: fix array formatting`                                                      |
| [`3c3f3a16`](https://github.com/NixOS/nixpkgs/commit/3c3f3a160c2aef45d4bae87e6cd2947af3254a97) | `flake8-bugbear: 22.8.23 -> 22.9.11`                                                   |
| [`f7723d08`](https://github.com/NixOS/nixpkgs/commit/f7723d082d210bb0e7454f4487d379294997fac2) | `baresip: Build the GTK module`                                                        |
| [`71357946`](https://github.com/NixOS/nixpkgs/commit/7135794653b3093b5c90c3926acc693a0613e585) | `got: 0.74 -> 0.75`                                                                    |
| [`1f5aa244`](https://github.com/NixOS/nixpkgs/commit/1f5aa244353e6e2d4bc23c48c5f7d054fa332e0f) | `jql: 5.0.1 -> 5.0.2`                                                                  |
| [`aedf5a31`](https://github.com/NixOS/nixpkgs/commit/aedf5a31db15d470ec51dbb698567911618c2699) | `ghostwriter: 2.1.4 -> 2.1.5`                                                          |
| [`feae5405`](https://github.com/NixOS/nixpkgs/commit/feae5405da2fc6c0f184698ead363e56f9db7bd4) | `luaPackages: update and adding a few neovim plugins`                                  |
| [`cbcb4058`](https://github.com/NixOS/nixpkgs/commit/cbcb40589c1ebcaea8ff741e6431a2050c5e8caf) | `update-luarocks-package: better way to specify lua version`                           |
| [`31d2aff2`](https://github.com/NixOS/nixpkgs/commit/31d2aff2430b978a888c47ea2630e6914078963f) | `borgmatic: Add passthru.tests.version`                                                |
| [`dca7412a`](https://github.com/NixOS/nixpkgs/commit/dca7412a8b050ecf5b7a0fa7efe299c57ae6418a) | `borgmatic: Add bash completion (no other supported shell)`                            |
| [`4b7ab2af`](https://github.com/NixOS/nixpkgs/commit/4b7ab2af395b8dd9745631a6344ced49423810ad) | `grpc-client-cli: 1.13.1 -> 1.14.0`                                                    |
| [`eefbc3da`](https://github.com/NixOS/nixpkgs/commit/eefbc3dad4bcde46b9c6d3804a6c963a03eb29f1) | `mopidy-ytmusic: 0.3.5 -> 0.3.7`                                                       |
| [`8926897c`](https://github.com/NixOS/nixpkgs/commit/8926897c2bde06bf76feaacbb9f9e77af581b865) | `mopidy-iris: 3.60.0 -> 3.64.0`                                                        |
| [`800323c0`](https://github.com/NixOS/nixpkgs/commit/800323c0c069f38976ea73907bf1561d13f037b4) | `doc(vim): take into account plug non-support`                                         |
| [`a27f6b1b`](https://github.com/NixOS/nixpkgs/commit/a27f6b1b0423fbfb37779087b4201f0d7df65ab2) | `gh-dash: 3.2.0 -> 3.3.0`                                                              |
| [`649cd671`](https://github.com/NixOS/nixpkgs/commit/649cd671b515366d04fe025a5c930b79811703f0) | `eksctl: 0.110.0 -> 0.111.0`                                                           |
| [`39442404`](https://github.com/NixOS/nixpkgs/commit/39442404769e526f9bbb99e0cd82e79db83fc37c) | `doc(neovim): remove the mention of plug for neovim`                                   |
| [`584bc20a`](https://github.com/NixOS/nixpkgs/commit/584bc20aa051dedba29d6e7732cab2aacbf8bdcc) | `doc: present how to create a vim-plugin overlay`                                      |
| [`dbdec0ed`](https://github.com/NixOS/nixpkgs/commit/dbdec0edabd2cd0075427bde0160a38379b0e53b) | `starlark: unstable-2022-03-02 -> 2022-08-17`                                          |
| [`61dbc457`](https://github.com/NixOS/nixpkgs/commit/61dbc457e213952e6e875a0e258f180023a90c3e) | `tdfgo: init at git commit 9f0b3325eed3 (#188351)`                                     |
| [`d9038bd6`](https://github.com/NixOS/nixpkgs/commit/d9038bd6e65fa5d919745917990b0d64590ff025) | `zq: remove noop overwrite`                                                            |
| [`b73df284`](https://github.com/NixOS/nixpkgs/commit/b73df28472e2537acfe1f09eb6246f1b0296436d) | `circleci-cli: 0.1.20856 -> 0.1.21041`                                                 |
| [`c3f51d1b`](https://github.com/NixOS/nixpkgs/commit/c3f51d1b55df60cdc724d89b1306e55bd7a3ec0b) | `dotenv: convert CRLF line endings into LF`                                            |
| [`74204a67`](https://github.com/NixOS/nixpkgs/commit/74204a6709a0fa3ffeff63cd3c88b7b2e1d88ac0) | `checkSSLCert: 2.42.0 -> 2.43.0`                                                       |
| [`03870e93`](https://github.com/NixOS/nixpkgs/commit/03870e938a90ce9df600f2442fc576f51227bda6) | `vimPlugins.haskell-with-unicode-vim: init at 2022-09-11`                              |
| [`55d9a2c5`](https://github.com/NixOS/nixpkgs/commit/55d9a2c596f08a355c2adaeb5c3225f71bb7a5d5) | `nixos/paperless: fix time.timeZone setting`                                           |
| [`618883d3`](https://github.com/NixOS/nixpkgs/commit/618883d37c27392975607d08aa295126c5dd8575) | `trafficserver: 9.1.2 -> 9.1.3`                                                        |
| [`241ce7a6`](https://github.com/NixOS/nixpkgs/commit/241ce7a66c0fdb05aad0b8cdd48ad835f831408c) | `yuzu-{ea,mainline}: {2907,1137} -> {2946,1162}`                                       |
| [`563ac874`](https://github.com/NixOS/nixpkgs/commit/563ac87433b7e0139e1ba18ff95a4f3173c16131) | `uniffi-bindgen: 0.19.3 -> 0.19.6`                                                     |
| [`e2840c58`](https://github.com/NixOS/nixpkgs/commit/e2840c584041c7d41ae7abeffd875a28baa35f98) | `trdl-client: init at 0.5.0`                                                           |
| [`2930136b`](https://github.com/NixOS/nixpkgs/commit/2930136b74c428ec9efeedec20930ca8fc8e6c2a) | `tbls: init at 1.56.2`                                                                 |
| [`98359fc9`](https://github.com/NixOS/nixpkgs/commit/98359fc9d91c5af3e0f1f414a71c95c12781beaf) | `python3Packages.discordpy: 2.0.0 -> 2.0.1`                                            |
| [`2a06ce22`](https://github.com/NixOS/nixpkgs/commit/2a06ce227080bae11761fd32bb83ff3cb1d05a73) | `http-prompt: 1.0.0 -> 2.1.0`                                                          |
| [`18a0b41e`](https://github.com/NixOS/nixpkgs/commit/18a0b41ede829c9317a6e5f165ad2a1021249892) | `http-prompt: Fix owner, repo was moved`                                               |
| [`1e40dc11`](https://github.com/NixOS/nixpkgs/commit/1e40dc111773b61e669af1b91cbad2aff9c3155f) | `julia-bin: 1.8.0 -> 1.8.1`                                                            |
| [`0a087095`](https://github.com/NixOS/nixpkgs/commit/0a087095acc040a8cf90c59c649451b642f21e5e) | `envoy: remove remaining nix store references from deps`                               |
| [`259e54c4`](https://github.com/NixOS/nixpkgs/commit/259e54c4fd159ee515e93f9e7b17e4178e76848c) | `jellyfin: migrate lockfile generation to fetch-deps`                                  |
| [`a493fe08`](https://github.com/NixOS/nixpkgs/commit/a493fe08cf842e4892a07ac3cfe4fe406573834c) | `archisteamfarm: migrate update script to fetch-deps, regenerate deps`                 |
| [`f5ede474`](https://github.com/NixOS/nixpkgs/commit/f5ede4745bc1177dc2ee7c83d559bda9026aea54) | `omnisharp-roslyn: migrate lockfile generation to fetch-deps`                          |
| [`12b91225`](https://github.com/NixOS/nixpkgs/commit/12b912258e950b5a40484e3ed97d6ecf78ec63fd) | `osu-lazer: migrate lockfile generation to fetch-deps`                                 |
| [`e19f0768`](https://github.com/NixOS/nixpkgs/commit/e19f0768cce7184c6e275035c093d70324a5824a) | `opentabletdriver: migrate lockfile generation to fetch-deps`                          |
| [`b86d4e16`](https://github.com/NixOS/nixpkgs/commit/b86d4e16e5f3739ae4e2b8938b241c9411787615) | `discordchatexporter-cli: migrate lockfile generation to fetch-deps`                   |
| [`bb025eef`](https://github.com/NixOS/nixpkgs/commit/bb025eefd6897519d1ebba01ba6b7c543234d592) | `python-language-server: migrate lockfile generation to fetch-deps`                    |
| [`2d5e7eac`](https://github.com/NixOS/nixpkgs/commit/2d5e7eac07e003f0f99f1ea48b96e7a738ec7c85) | `jackett: migrate lockfile generation to fetch-deps`                                   |
| [`c68b58fd`](https://github.com/NixOS/nixpkgs/commit/c68b58fdd19f3f9a0518ce520925b279053723c6) | `baget: migrate lockfile generation to fetch-deps`                                     |
| [`efd92e7f`](https://github.com/NixOS/nixpkgs/commit/efd92e7fd779a5636489621f0bafc309cecf59db) | `buildDotnetModule: restore for all platforms in fetch-deps`                           |
| [`0d8a23bf`](https://github.com/NixOS/nixpkgs/commit/0d8a23bfcd0a6dc412a2a911eeb4107ded6e6a2f) | `dotnet-sdk: add passthru attribute to generate a runtime ID`                          |
| [`497b585e`](https://github.com/NixOS/nixpkgs/commit/497b585e10eb4cd5e9d14eb05df6bab521d8a608) | `python310Packages.fastcore: 1.5.25 -> 1.5.26`                                         |
| [`a8cbb4a0`](https://github.com/NixOS/nixpkgs/commit/a8cbb4a0f625432a6e7848993e7c6f5f4cd72d16) | `python310Packages.fastavro: 1.6.0 -> 1.6.1`                                           |
| [`8676f60f`](https://github.com/NixOS/nixpkgs/commit/8676f60f1f301981bb9a7cd347ea2e592c6f6494) | `nheko: 0.10.0 -> 0.10.1-1`                                                            |
| [`3a2a763a`](https://github.com/NixOS/nixpkgs/commit/3a2a763a4265712a972952880933bb2342b0550e) | `python310Packages.tensorflow-datasets: fix tests`                                     |
| [`c1ad7b90`](https://github.com/NixOS/nixpkgs/commit/c1ad7b9056598690422dd13e245350dc1702fb74) | `jetbrains.rider: add raphaelr to maintainers`                                         |
| [`288b8863`](https://github.com/NixOS/nixpkgs/commit/288b886396efd7ae461477485cd8b014557adb34) | `jetbrains.rider: fix startup`                                                         |
| [`033ae6be`](https://github.com/NixOS/nixpkgs/commit/033ae6bee8b831a3a93133cf3cfd4081871a198d) | `mpvc: 2017-03-18 -> 1.3`                                                              |
| [`f0bccada`](https://github.com/NixOS/nixpkgs/commit/f0bccadafeae416dbf5283406e0aafc0445f0b87) | `python310Packages.pyintesishome: 1.8.1 -> 1.8.3`                                      |
| [`8376aee2`](https://github.com/NixOS/nixpkgs/commit/8376aee278a42421cce79141901a6832fd8dcb13) | `libvirt: fix cross compile`                                                           |
| [`0ad4c0f2`](https://github.com/NixOS/nixpkgs/commit/0ad4c0f29cff7821e3ac2cbd1a91bfad8d032d10) | `ngtcp2: switch to cmake build system to fix aarch64-linux build`                      |
| [`51f9cbc4`](https://github.com/NixOS/nixpkgs/commit/51f9cbc44ee42b10cd918148d325a37cedccd684) | `xmind: 8-update8 -> 8-update9`                                                        |
| [`09800d7f`](https://github.com/NixOS/nixpkgs/commit/09800d7f75b2c31820b43ce9287212efba2f523b) | `firefox wrapper: write extraPrefsFiles before extraPrefs`                             |
| [`96398396`](https://github.com/NixOS/nixpkgs/commit/96398396ebf7caea18a9a25e14421f2a67844b4f) | `nginxModules.vts: 0.1.18 -> 0.2.0`                                                    |
| [`4e4e8b52`](https://github.com/NixOS/nixpkgs/commit/4e4e8b529502bc1d72b2ced55529571d07703d5d) | `alfis: 0.7.7 -> 0.8.2`                                                                |
| [`c5fb47d2`](https://github.com/NixOS/nixpkgs/commit/c5fb47d28b604246a7056c3a1cfa6bb95aec3497) | `icingaweb2-ipl: 0.8.1 -> 0.10.0`                                                      |
| [`86bfd157`](https://github.com/NixOS/nixpkgs/commit/86bfd1573244eb68f3965f0fa690c8ab0acba76f) | `nixos/tests/mediatomb: fix test when running with gerbera`                            |
| [`f3e08ac0`](https://github.com/NixOS/nixpkgs/commit/f3e08ac0b1a191856c03e5e89cdd712fc7485f05) | `nixos/mediatomb: wait for network-online.target`                                      |
| [`073d3c1b`](https://github.com/NixOS/nixpkgs/commit/073d3c1b77eaa0de36f064b60e47642469887fbf) | `mavproxy: add lxml dependency`                                                        |
| [`aa9b7694`](https://github.com/NixOS/nixpkgs/commit/aa9b769451c5b65751b4ae6351030e9b34ebd0af) | `btop: reenable stackprotector on aarch64-darwin`                                      |
| [`55759fb8`](https://github.com/NixOS/nixpkgs/commit/55759fb8805d75a126c005aca4eeab2ad4aa6ba0) | `tofi: init at 0.5.0`                                                                  |
| [`a3c3acf7`](https://github.com/NixOS/nixpkgs/commit/a3c3acf76b12a740a42cf255e6efd61a87bcadcc) | `buildbot: 3.5.0 -> 3.6.0`                                                             |
| [`dbfd7543`](https://github.com/NixOS/nixpkgs/commit/dbfd75435938888cff88e8325a006ed5130c8b5d) | `python310Packages.torchgpipe: remove useless pytest-runner, correct disabled`         |
| [`d1be027e`](https://github.com/NixOS/nixpkgs/commit/d1be027e2dd7876441bb5ce209c3f57dc7333d38) | `python310Packages.qiskit-machine-learning: remove package variant`                    |
| [`a97ba67b`](https://github.com/NixOS/nixpkgs/commit/a97ba67bf71b1c35ae87b0d8ecfde80e7a827752) | `python310Packages.rising: remove unused pytest-cov`                                   |
| [`266f00f9`](https://github.com/NixOS/nixpkgs/commit/266f00f92c1c5cb7816c58bce0ea236c62f5a25c) | `maintainers: add fbergroth`                                                           |
| [`2385f028`](https://github.com/NixOS/nixpkgs/commit/2385f0282c1343746c6e7aadd144ff9b1ac227a4) | `python3Packages.pytest-asyncio: fix changelog URL`                                    |
| [`318edf02`](https://github.com/NixOS/nixpkgs/commit/318edf02d1563c3c0dca4c833535972283789215) | `asciidoc: fix changelog url`                                                          |
| [`4ccddf5d`](https://github.com/NixOS/nixpkgs/commit/4ccddf5d9a531a274af335daab0665364f2ef03d) | `xml2rfc: 3.14.1 -> 3.14.2`                                                            |
| [`bcd41f28`](https://github.com/NixOS/nixpkgs/commit/bcd41f289122c4a182f892ee740b37e436daf89e) | `linux: Disable DRM_LEGACY, NOUVEAU_LEGACY_CTX_SUPPORT`                                |
| [`372b94be`](https://github.com/NixOS/nixpkgs/commit/372b94bef67ceab074a1c11f4429018e66fb4fdd) | `krunvm: add support for darwin`                                                       |
| [`7642b506`](https://github.com/NixOS/nixpkgs/commit/7642b5064eeddcf21562733bfde7002f1eedb0aa) | `libkrun: add support for darwin`                                                      |
| [`77525f0f`](https://github.com/NixOS/nixpkgs/commit/77525f0f95505695987411365d9349019ad6e020) | `libkrunfw: add support for darwin`                                                    |
| [`23d21ce9`](https://github.com/NixOS/nixpkgs/commit/23d21ce9c90dc1f2501632e06c02c96fe02d84f9) | `dtc: fix dylib name on darwin`                                                        |
| [`aeb77ea9`](https://github.com/NixOS/nixpkgs/commit/aeb77ea9bd9d2804a0f1c1330df4b4782229b2d9) | `quakespasm: fix darwin build`                                                         |
| [`e7d158d4`](https://github.com/NixOS/nixpkgs/commit/e7d158d4af2bba63e34cbea4154108920d048f54) | `mongodb-4_4: fic-gcc11-optionnal`                                                     |
| [`62748751`](https://github.com/NixOS/nixpkgs/commit/6274875188277800937719de9dc3a89ab69d73cd) | `mongodb: fix build with boost 1.79 on linux`                                          |
| [`2ba2e8d8`](https://github.com/NixOS/nixpkgs/commit/2ba2e8d8b2626704931ea077f6bee464dc22d161) | `mongodb: backport a fix to 5.0 in openssl detection.`                                 |
| [`2a7c1ea4`](https://github.com/NixOS/nixpkgs/commit/2a7c1ea47792b28963e9bacb44f290066eed2a43) | `mongodb: asio-no-experimental-string-view.patch is no longer required on darwin`      |
| [`a0f42fb8`](https://github.com/NixOS/nixpkgs/commit/a0f42fb89924b4a739f2f9101434b0c7de134dd7) | `mongodb: drem doesn't exist after 3.6`                                                |
| [`eedcccd2`](https://github.com/NixOS/nixpkgs/commit/eedcccd2914cdbf08c2854005571d9400c5ca974) | `mongodb: fix double link of isNamedError on darwin.`                                  |
| [`2ddc70dc`](https://github.com/NixOS/nixpkgs/commit/2ddc70dc48634288fe30f9b7207af3c3d6e8f912) | `mongodb: fix build with boost 1.79`                                                   |
| [`12257dbc`](https://github.com/NixOS/nixpkgs/commit/12257dbc8296f8f0813d8846262d4ee00dfba69a) | ``tinyscheme: set `mainProgram```                                                      |
| [`4c958b12`](https://github.com/NixOS/nixpkgs/commit/4c958b12006870b8821410637bd471af052afda3) | `tinyscheme: add some tests`                                                           |
| [`8f0ec826`](https://github.com/NixOS/nixpkgs/commit/8f0ec8269639500be31b2bae37d515388f12b4d8) | `tinyscheme: fix the build on macOS`                                                   |
| [`17fb7518`](https://github.com/NixOS/nixpkgs/commit/17fb7518ffc2e9a13ec6c1ecec2be1d2cac9d0a6) | `tinyscheme: add the changelog link`                                                   |
| [`698cedfa`](https://github.com/NixOS/nixpkgs/commit/698cedfa3c219cf8b8e16077aa215b7d15a2ce2d) | `tinyscheme: don't require the gcc stdenv`                                             |
| [`2746a56f`](https://github.com/NixOS/nixpkgs/commit/2746a56f593437b8b7877b8d27f7ae98795f6849) | `tinyscheme: add the libraries to the outputs`                                         |