### PR TITLE
chore(flake/home-manager): `9f7fe353` -> `60c6bfe3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662759269,
-        "narHash": "sha256-lt8bAfEZudCQb+MxoNKmenhMTXhu3RCCyLYxU9t5FFk=",
+        "lastModified": 1663099612,
+        "narHash": "sha256-ucokjFDRwCFWbcGiqxz0mfHv82UqwyW7RXY6ZgKSl80=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9f7fe353b613d0e45d7a5cdbd1f13c96c15803dd",
+        "rev": "60c6bfe322944d04bb38e76b64effcbd01258824",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`60c6bfe3`](https://github.com/nix-community/home-manager/commit/60c6bfe322944d04bb38e76b64effcbd01258824) | ``zsh: add option for `zsh-history-substring-search` (#3156)`` |