### PR TITLE
chore(flake/nixos-hardware): `1fec8fda` -> `93580fca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1662714967,
-        "narHash": "sha256-IOTq5tAGGmBFj7tQbkcyLE261JUeTUucEE3p0WLZ4qM=",
+        "lastModified": 1663133271,
+        "narHash": "sha256-juBxlETvfMetD/pUFLtdDLQ8BOayxROra8d5Hg6Zg1M=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "1fec8fda86dac5701146c77d5f8a414b14ed1ff6",
+        "rev": "93580fca1000c37e382d7e2c19c78c1c3852482d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                      |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`bfbc3a18`](https://github.com/NixOS/nixos-hardware/commit/bfbc3a181d28f12e1e8de733b37f10a4686e2b9e) | `Add support for Omen en00015p laptop (#457)`       |
| [`e55c862c`](https://github.com/NixOS/nixos-hardware/commit/e55c862c77791df13fea1e2f237e132e6c425d8c) | `contributing: document how to run a single test`   |
| [`667b40e8`](https://github.com/NixOS/nixos-hardware/commit/667b40e827b3dd58d54eb9ce560fa306809b1f15) | `tests/run: enable experimental nix-command`        |
| [`305bbc24`](https://github.com/NixOS/nixos-hardware/commit/305bbc24424d91e202dfc7bb35e8c29607c4de56) | `tinkpad t14s amd: enable deep sleep`               |
| [`3aaf1fe6`](https://github.com/NixOS/nixos-hardware/commit/3aaf1fe6ee3f360633c3c24c0563d440a7376412) | `Add framework-12th-gen-intel to flake.nix`         |
| [`f0b86473`](https://github.com/NixOS/nixos-hardware/commit/f0b864738dad352be659abd5e486dbb0b64cb3e9) | `Set options specific to the 12th gen Framework`    |
| [`3918f03d`](https://github.com/NixOS/nixos-hardware/commit/3918f03d0debe32ce0062baba67751c3fe88bae9) | `Initial support for Framework 12th Gen Intel Core` |
| [`1f9058d6`](https://github.com/NixOS/nixos-hardware/commit/1f9058d65db2ae0a8d32b05b484c431f339b829e) | `add lenovo ideapad 5 15arh05`                      |
| [`3040e342`](https://github.com/NixOS/nixos-hardware/commit/3040e3422d488f029e855d6429c094f9a1527436) | `CONTRIBUTING.md: rewrite`                          |
| [`bb36cedc`](https://github.com/NixOS/nixos-hardware/commit/bb36cedc0a2a6624264b2ac75d679967717ff7e3) | `README.md: fix dead links, align table`            |
| [`3ed1ae8e`](https://github.com/NixOS/nixos-hardware/commit/3ed1ae8ef7d9f34470a624ea322ca816545dbbfe) | `inspiron-7405: init`                               |