### PR TITLE
chore(flake/nixpkgs): `5f326e2a` -> `9608ace7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1662996720,
-        "narHash": "sha256-XvLQ3SuXnDMJMpM1sv1ifPjBuRytiDYhB12H/BNTjgY=",
+        "lastModified": 1663087123,
+        "narHash": "sha256-cNIRkF/J4mRxDtNYw+9/fBNq/NOA2nCuPOa3EdIyeDs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5f326e2a403e1cebaec378e72ceaf5725983376d",
+        "rev": "9608ace7009ce5bc3aeb940095e01553e635cbc7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`0dde2e22`](https://github.com/NixOS/nixpkgs/commit/0dde2e2206ad4326aeb45caf3a91366b2f1b64a6) | `localstack: init at 1.0.4`                                                      |
| [`abcfb393`](https://github.com/NixOS/nixpkgs/commit/abcfb393f9f572cc8a9e7ed3d7eaa938a577b3b0) | `python3Packages.localstack-ext: init at 1.0.4`                                  |
| [`979bf1eb`](https://github.com/NixOS/nixpkgs/commit/979bf1eb1cd458a0a10a1207b868ed05da11e205) | `python3Packages.localstack-client: init at 1.36`                                |
| [`bb972030`](https://github.com/NixOS/nixpkgs/commit/bb9720304527d74562563e6e13b042090d704445) | `python3Packages.plux: init at 1.3.1`                                            |
| [`1a1cd4b6`](https://github.com/NixOS/nixpkgs/commit/1a1cd4b6cd9c420aa8ed8f1aae23b2cc5833424d) | `python311: 3.11.0rc1 -> 3.11.0rc2`                                              |
| [`5533fe64`](https://github.com/NixOS/nixpkgs/commit/5533fe640deb1ba4d6d2ae4c09eacd7b91415e44) | `kubelogin-oidc: 1.25.2 -> 1.25.3 (#190992)`                                     |
| [`9fa0e55f`](https://github.com/NixOS/nixpkgs/commit/9fa0e55f243d337d6fd7d27191ebbc564c2f34cc) | `rpcsvc-proto: pull patch to follow RPCGEN_CPP env var and replace fallback cpp` |
| [`7704c81e`](https://github.com/NixOS/nixpkgs/commit/7704c81e1225e19f8977229aff04f6eb067201fa) | `routinator: 0.11.2 -> 0.11.3`                                                   |
| [`4a7409fd`](https://github.com/NixOS/nixpkgs/commit/4a7409fd232a3e50cb7c40400cfd72aea3cb8823) | `python310Packages.fastbencode: 0.0.11 -> 0.0.12`                                |
| [`9f6310d6`](https://github.com/NixOS/nixpkgs/commit/9f6310d611bc81bdbcaf2f202607c81c91695b9d) | `resholve: fix mangled pname/meta integrations`                                  |
| [`24d15603`](https://github.com/NixOS/nixpkgs/commit/24d15603add32d3b149bdc95b485fb4163bbecd3) | `matrix-appservice-irc: 0.34.1 -> 0.35.0`                                        |
| [`cc037359`](https://github.com/NixOS/nixpkgs/commit/cc037359a850276c85937fd725100ad31803475b) | `oh-my-zsh: 2022-09-08 -> 2022-09-10 (#190990)`                                  |
| [`c2a69aa5`](https://github.com/NixOS/nixpkgs/commit/c2a69aa59a3b9ed985ed54b9fdc9f8969ad33e05) | `python310Packages.coqui-trainer: 0.0.14 -> 0.0.15`                              |
| [`df2a9eeb`](https://github.com/NixOS/nixpkgs/commit/df2a9eeb1a6b6a051a548080f31006272f63e553) | `rust-analyzer-unwrapped: 2022-08-22 -> 2022-09-12`                              |
| [`61af5d80`](https://github.com/NixOS/nixpkgs/commit/61af5d80833d662560f7a8d5ac67c6bff746d962) | `rnp: 0.16.0 -> 0.16.1`                                                          |
| [`224a4e89`](https://github.com/NixOS/nixpkgs/commit/224a4e89cf1c7ef547c2a0533996c9337ef7fca1) | `k0sctl: 0.13.2 -> 0.14.0`                                                       |
| [`ee38ba4c`](https://github.com/NixOS/nixpkgs/commit/ee38ba4c38c5c902064d06cf7c9b864a9fb197f6) | `syncthingtray: 1.2.2 -> 1.2.3`                                                  |
| [`75e6691b`](https://github.com/NixOS/nixpkgs/commit/75e6691ba7053e8ca0ae395b497426835b72a520) | `spicetify-cli: 2.13.0 -> 2.13.1`                                                |
| [`81abce47`](https://github.com/NixOS/nixpkgs/commit/81abce479c5ae1d4c3bdfd3be2a831e3d23b7d59) | `xed: 12.0.1 -> 2022.08.11`                                                      |
| [`398cb29d`](https://github.com/NixOS/nixpkgs/commit/398cb29dc007166597ea586d1c57670e144c06ac) | `rmview: fix missing wrapper (#175589)`                                          |
| [`38aa9764`](https://github.com/NixOS/nixpkgs/commit/38aa976494cff39d297b98fd301b21570f013fd2) | `elan: 1.4.1 -> 1.4.2`                                                           |
| [`4f07c962`](https://github.com/NixOS/nixpkgs/commit/4f07c962034d929496b460bca69ba10c79c30245) | `libpsl: disable valgrind tests on musl (#191028)`                               |
| [`19686a44`](https://github.com/NixOS/nixpkgs/commit/19686a44521f06a065fad86d9040c3f4864cf20c) | `nixos/systemd: conditionally include systemd-update-utmp upstream unit`         |
| [`48178658`](https://github.com/NixOS/nixpkgs/commit/48178658878ab2de38d7f92172a6b8047b2bd112) | `systemd: add withUtmp flag and inherit in passthru`                             |
| [`723a5645`](https://github.com/NixOS/nixpkgs/commit/723a5645b5b958d7dc9ec515b567d467ea6536b1) | `pkgsStatic.llvm_14: fix build`                                                  |
| [`8c4a8f96`](https://github.com/NixOS/nixpkgs/commit/8c4a8f96cebc8178a38a2fc3d38281bd36aaf356) | `schildichat-web: allow older openssl codecs (#190964)`                          |
| [`657aec38`](https://github.com/NixOS/nixpkgs/commit/657aec38e1a0ea80424468916f284813645ae8d3) | `broot: 1.14.2 -> 1.14.3`                                                        |
| [`9c1bc56f`](https://github.com/NixOS/nixpkgs/commit/9c1bc56fdd74f81c8c390b256abcd45b1cbc74bb) | `angband: add kenran to maintainers`                                             |
| [`d97e7267`](https://github.com/NixOS/nixpkgs/commit/d97e7267f7da2ed21e65e1e7d6a9982e4e90cf51) | `python310Packages.ansible-core: 2.13.2 -> 2.13.4`                               |
| [`48c763e4`](https://github.com/NixOS/nixpkgs/commit/48c763e47364d43ec222c6fac29dd6a6c5cf4e1c) | `oh-my-posh: 9.0.0 -> 9.1.0`                                                     |
| [`408390eb`](https://github.com/NixOS/nixpkgs/commit/408390eb3fece42e432d395e49a4a9e1b865e910) | `nwg-panel: 0.7.4 -> 0.7.8`                                                      |
| [`be3db7e7`](https://github.com/NixOS/nixpkgs/commit/be3db7e78f956a87fbf8f6b967fa48fe3004e215) | `lsd: 0.23.0 -> 0.23.1`                                                          |
| [`0db05edd`](https://github.com/NixOS/nixpkgs/commit/0db05edd090647e244ab28688b804f437bfe0fac) | `hedgewars: 1.0.0 -> 1.0.2`                                                      |
| [`16074f96`](https://github.com/NixOS/nixpkgs/commit/16074f96ce0f86050b5c3733df270cf342e52e77) | `postgresql11Packages.age: 1.0.0-rc1 -> 1.1.0-rc0`                               |
| [`dfcbbdaa`](https://github.com/NixOS/nixpkgs/commit/dfcbbdaa93cd78b8122b2d92e9a921eb223573ca) | `postgresqlPackages.postgis: 3.3.0 -> 3.3.1`                                     |
| [`bfe0a4be`](https://github.com/NixOS/nixpkgs/commit/bfe0a4be229d7ddff93825929f9f807cbf26c2a5) | `mympd: 9.5.3 -> 9.5.4`                                                          |
| [`778ac91f`](https://github.com/NixOS/nixpkgs/commit/778ac91f3545e70b9be072dbca66207a35244e2c) | `fcitx5-mozc: add govanify as maintainer`                                        |
| [`1ee25bd6`](https://github.com/NixOS/nixpkgs/commit/1ee25bd6975e0a4ee61afc86cb170923d4977d60) | `fcitx5-mozc: package ut dictionary`                                             |
| [`54f0e005`](https://github.com/NixOS/nixpkgs/commit/54f0e005de02b1a04894c704bb12d4a1c6cf93e8) | `vector: 0.24.0 -> 0.24.1`                                                       |
| [`22b097e8`](https://github.com/NixOS/nixpkgs/commit/22b097e86b135c253e4eab83309fa7d3ff5811c7) | `nvtop: 2.0.2->2.0.3`                                                            |
| [`662b8da3`](https://github.com/NixOS/nixpkgs/commit/662b8da3f1e6c5bcc7d397e8327f08bb334645b1) | `python310Packages.adafruit-platformdetect: 3.27.3 -> 3.29.0`                    |
| [`60ec6ff7`](https://github.com/NixOS/nixpkgs/commit/60ec6ff76c44b619d61d626307eee03d8a706bbf) | `idasen: 0.9.1 -> 0.9.2`                                                         |
| [`9717e20f`](https://github.com/NixOS/nixpkgs/commit/9717e20f4b8daea22d1dc6bc96477831150512e1) | `blender: 3.2.0 -> 3.3.0 (#190732)`                                              |
| [`77746d1d`](https://github.com/NixOS/nixpkgs/commit/77746d1ddf48ab48136b8952e28b1472dfc5b784) | `rsstail: update repository location`                                            |
| [`4def9649`](https://github.com/NixOS/nixpkgs/commit/4def96490a620e457b10f80efcb9d36172ca686a) | `rsstail: add Necior to maintainers`                                             |
| [`3a818092`](https://github.com/NixOS/nixpkgs/commit/3a818092242b3de9debe9033ef60513e3db10cb4) | `maintainers: add Necior`                                                        |
| [`953918a0`](https://github.com/NixOS/nixpkgs/commit/953918a0f9d7e24b45aefc47cdc6a607fc108767) | `trojita-unstable: unstable-2020-07-06 -> unstable-2022-08-22`                   |
| [`c231a20d`](https://github.com/NixOS/nixpkgs/commit/c231a20d98ec8b7cc521c490ab9d957c9778fa0a) | `nixos/lemmy: move systemd script to serviceConfig`                              |
| [`5519e1b8`](https://github.com/NixOS/nixpkgs/commit/5519e1b89bf02443b056fac9acf5f6d607bb622f) | ``nixos/lemmy: remove `services.lemmy.jwtSecretPath```                           |
| [`ff8aa750`](https://github.com/NixOS/nixpkgs/commit/ff8aa750ae88928917e9508176e3b98d4661b50e) | `giara: 1.0 -> 1.0.1`                                                            |
| [`fdabbea2`](https://github.com/NixOS/nixpkgs/commit/fdabbea239e9bbe723df31fb93adb3fdb0bf3f9a) | `python310Packages.certbot-dns-inwx: init at 2.1.3`                              |
| [`54c911ff`](https://github.com/NixOS/nixpkgs/commit/54c911ff3ba41c4c4a77d4a45b4d3bccb72c073e) | `gdu: 5.17.0 -> 5.17.1`                                                          |
| [`c23686e1`](https://github.com/NixOS/nixpkgs/commit/c23686e115650a9fdf04c3d6e3825379ab4c89d6) | `imagemagick: 7.1.0-47 -> 7.1.0-48`                                              |
| [`25ab59d4`](https://github.com/NixOS/nixpkgs/commit/25ab59d428103b0ca361927849c8dd011885548b) | `glooctl: 1.12.12 -> 1.12.15`                                                    |
| [`cbb33405`](https://github.com/NixOS/nixpkgs/commit/cbb334055707102ed5f762d732420eb6c57cbfc7) | `usql: add platforms`                                                            |
| [`49426793`](https://github.com/NixOS/nixpkgs/commit/49426793cd9422a6bfcaa53bcbdfba8a19e5dd0f) | `usql: add anthonyroussel to maintainers`                                        |
| [`e8db71f5`](https://github.com/NixOS/nixpkgs/commit/e8db71f5f8e95e20e28b735b29afe7b2fe925bad) | `usql: 0.12.0 -> 0.12.13`                                                        |
| [`99e71eee`](https://github.com/NixOS/nixpkgs/commit/99e71eee21a2b8c5b2b0258a4e8d599b763c0b9a) | `dendrite: 0.9.6 -> 0.9.8`                                                       |
| [`fa1c0d87`](https://github.com/NixOS/nixpkgs/commit/fa1c0d87c497359f036e36708aba04eb37420f54) | `numix-icon-theme-square: 22.09.04 -> 22.09.12`                                  |
| [`1090ad11`](https://github.com/NixOS/nixpkgs/commit/1090ad11c8ea50238d46623096cade1c03a11972) | `numix-icon-theme-circle: 22.09.04 -> 22.09.12`                                  |
| [`4fbc5fa7`](https://github.com/NixOS/nixpkgs/commit/4fbc5fa77f4931dbaf062ffafde9e1054039f29c) | `nanovna-saver: 0.5.1 -> 0.5.2`                                                  |
| [`2e3e0081`](https://github.com/NixOS/nixpkgs/commit/2e3e0081e5e843599aaa8f7128d2a139bda7dbca) | `element-web: allow older openssl codecs (#190950)`                              |
| [`141acc16`](https://github.com/NixOS/nixpkgs/commit/141acc16dc907ab426d26a93672cd734734d449c) | `wineasio: init at 1.1.0`                                                        |
| [`070b3966`](https://github.com/NixOS/nixpkgs/commit/070b3966fcb1f514a0e7ea4c7689561321ae3400) | `nixos/cachix-agent: fix type for host option`                                   |
| [`a594429b`](https://github.com/NixOS/nixpkgs/commit/a594429bfa1eda2c909a08d00eb76a83d9a3e907) | `dua: 2.17.8 -> 2.18.0`                                                          |
| [`e7e7e386`](https://github.com/NixOS/nixpkgs/commit/e7e7e386a8b631bfadbb15f6da41e6afbffa5b03) | `doublecmd: 1.0.6 -> 1.0.7`                                                      |
| [`a9c4243e`](https://github.com/NixOS/nixpkgs/commit/a9c4243eec6d0daaf13308662e65a0d5dcce8e23) | `tabnine: 4.4.123 -> 4.4.139`                                                    |
| [`c619f9ca`](https://github.com/NixOS/nixpkgs/commit/c619f9ca0415b4b43dc2f9c51cef10ff18e700b2) | `linuxKernel.kernels.linux_testing: 6.0-rc1 -> 6.0-rc5`                          |
| [`41ab8c0b`](https://github.com/NixOS/nixpkgs/commit/41ab8c0b8a4327debbbdcbe5e1777a27afef9676) | `klipper: unstable-2022-06-18 -> unstable-2022-09-11`                            |
| [`f0f4ad0c`](https://github.com/NixOS/nixpkgs/commit/f0f4ad0cb0723e8962e18d1fa805df6a80029483) | `nixos/self-deploy: add tar to path.`                                            |
| [`e00c1364`](https://github.com/NixOS/nixpkgs/commit/e00c13649f07a0adf62ddd1562aa821ae2991fc3) | `octoprint: fix build error on staging-next`                                     |
| [`7c1a6f0b`](https://github.com/NixOS/nixpkgs/commit/7c1a6f0bc7699ac18b72338e5129f5b20c8fe555) | `libcifpp: 4.2.0 -> 4.2.2`                                                       |
| [`16889211`](https://github.com/NixOS/nixpkgs/commit/1688921199efbf10b785cd787b9282de77a47ab2) | `fheroes2: 0.9.18 -> 0.9.19`                                                     |
| [`344d5219`](https://github.com/NixOS/nixpkgs/commit/344d5219dd8898ba8f05c6bd9e4a374cb287de5f) | `python310Packages.tcxparser: init at 2.3.0`                                     |
| [`d99a622f`](https://github.com/NixOS/nixpkgs/commit/d99a622f7e901e4a2c81033b2217e049199ad9f1) | `cf-vault: 0.0.11 -> 0.0.13`                                                     |
| [`6d36e7b0`](https://github.com/NixOS/nixpkgs/commit/6d36e7b05709eb5ec0049b33c09c6d7fde944f50) | `cinnamon.cinnamon-common: Fix upload-system-info path`                          |
| [`48ff7279`](https://github.com/NixOS/nixpkgs/commit/48ff72799226ddcf8720c3f5c267e6bf5978897b) | `atmos: 1.4.28 -> 1.7.0`                                                         |
| [`5125710c`](https://github.com/NixOS/nixpkgs/commit/5125710c4d0d23895cb3b544d4b5ab3880435d80) | `arkade: 0.8.42 -> 0.8.44`                                                       |
| [`98c04c5d`](https://github.com/NixOS/nixpkgs/commit/98c04c5da214c9f09329484813cccd41f540cb6c) | `libzim: 8.0.0 -> 8.0.1`                                                         |
| [`55e1e9a1`](https://github.com/NixOS/nixpkgs/commit/55e1e9a10419922d2be9bf33730f5108f73c9bbd) | `jmol: 14.32.73 -> 14.32.74`                                                     |
| [`7a02685e`](https://github.com/NixOS/nixpkgs/commit/7a02685e60a5c4fb9c3907edab66b84c2c46a2b3) | `tidal-hifi: 4.1.1 -> 4.1.2`                                                     |
| [`bf0d91a4`](https://github.com/NixOS/nixpkgs/commit/bf0d91a4e2ca1c94597bdf07e403764342cf43aa) | `ppsspp-qt: 1.13.1 -> 1.13.2`                                                    |
| [`fabbaeda`](https://github.com/NixOS/nixpkgs/commit/fabbaedaa24056a0c18d48028f4017744551e5e2) | `openapi-generator-cli: 6.0.1 -> 6.1.0`                                          |
| [`5f4bfbbe`](https://github.com/NixOS/nixpkgs/commit/5f4bfbbe11d5042071b41b9fc361daf24366682c) | `rubyPackages.sqlite3: simplify build flags`                                     |
| [`e3d748a9`](https://github.com/NixOS/nixpkgs/commit/e3d748a92bec86330d1ab86a1836bbf4386cff06) | `hip: fix hip cmake config`                                                      |
| [`949f55c0`](https://github.com/NixOS/nixpkgs/commit/949f55c0dda937f84d0d5c532ebfac1910f9f01a) | `mrustc-bootstrap: pin to openssl_1_1`                                           |
| [`195f1fb5`](https://github.com/NixOS/nixpkgs/commit/195f1fb59aafe80090f74431e541a54109140a4a) | `cargo-raze: pin to openssl_1_1`                                                 |
| [`755e7195`](https://github.com/NixOS/nixpkgs/commit/755e7195b298d3151ab3be4a50d7ffda46b1ad43) | `samba: 4.15.5 -> 4.15.9`                                                        |
| [`75478e09`](https://github.com/NixOS/nixpkgs/commit/75478e097cff0ac2e817b1d3ff9356a17ae754ce) | `postgresqlPackages.rum: 1.3.11 -> 1.3.12`                                       |
| [`1f720955`](https://github.com/NixOS/nixpkgs/commit/1f720955aed5f089d89c5022bd22311a22358a95) | `gopass-summon-provider: 1.14.3 -> 1.14.6`                                       |
| [`95eb1009`](https://github.com/NixOS/nixpkgs/commit/95eb10093a4e06f00de767e9f08f17296c5d8d07) | `gopass-hibp: 1.14.3 -> 1.14.6`                                                  |
| [`ae852f56`](https://github.com/NixOS/nixpkgs/commit/ae852f5692b37c0e4bb409341b7cfc1bd640f2ce) | `datree: 1.6.13 -> 1.6.19`                                                       |
| [`5dc12356`](https://github.com/NixOS/nixpkgs/commit/5dc123563a833c673b4e86c7e46bce1c307fb7e5) | `cyberchef: 9.46.0 -> 9.46.4`                                                    |
| [`a1887683`](https://github.com/NixOS/nixpkgs/commit/a188768396b61029de0573ef4b01dd2f3e1b14ea) | `linode-cli: 5.22.0 -> 5.22.0`                                                   |
| [`cfbf9bd1`](https://github.com/NixOS/nixpkgs/commit/cfbf9bd15c15338bfd4406feb50337590aaa430b) | `nixos/nspawn: Fix configuration name PrivateUsersOwnership`                     |
| [`7a6a8b41`](https://github.com/NixOS/nixpkgs/commit/7a6a8b41fc4eeb26eaf77936470b908230c19965) | `git-credential-gopass: 1.14.3 -> 1.14.6`                                        |
| [`782138c7`](https://github.com/NixOS/nixpkgs/commit/782138c792b2e9c6e5f80ddc7c0b9baa316d492e) | `perl534Packages.ZonemasterLDNS: pin to openssl_1_1`                             |
| [`6449e23d`](https://github.com/NixOS/nixpkgs/commit/6449e23dbc5ab40101e2cc984becf9c9f9eeec96) | `movine: pin to openssl_1_1`                                                     |
| [`7033bc7e`](https://github.com/NixOS/nixpkgs/commit/7033bc7e3bd2726dd5994e831ba0716591bdafb6) | `kore: pin to openssl_1_1`                                                       |
| [`23022b27`](https://github.com/NixOS/nixpkgs/commit/23022b2779ca1d06955069d00ddc349e0d7ca263) | `journaldriver: pin to openssl_1_1`                                              |
| [`0d75ceba`](https://github.com/NixOS/nixpkgs/commit/0d75cebac7cfb847e10e10e43333eb17a3d45544) | `espanso: pin to openssl_1_1`                                                    |
| [`3aa4e012`](https://github.com/NixOS/nixpkgs/commit/3aa4e0127a49e17be590b3c53c7cd33a5d4391ca) | `cfdyndns: pin to openssl_1_1`                                                   |
| [`faa8136e`](https://github.com/NixOS/nixpkgs/commit/faa8136e81f5d485d2e5cd2bbca8836467ae1d40) | `cargo-raze: pin to openssl_1_1`                                                 |
| [`e41500b6`](https://github.com/NixOS/nixpkgs/commit/e41500b6e66b2797c93cef2098552096e73b7587) | `cargo-dephell: pin to openssl_1_1`                                              |
| [`b2a6d7d7`](https://github.com/NixOS/nixpkgs/commit/b2a6d7d7d4ef0595c4b58146139b54a64e017640) | `cargo-bisect-rustc: pin to openssl_1_1`                                         |
| [`69b6d651`](https://github.com/NixOS/nixpkgs/commit/69b6d651fbab83eb1674bd79506bbbf020501e3e) | `break-time: pin to openssl_1_1`                                                 |
| [`3bd60b6f`](https://github.com/NixOS/nixpkgs/commit/3bd60b6f2a27f74d81b7a1ca617801218755dd01) | `bip: pin to openssl_1_1`                                                        |
| [`5311245e`](https://github.com/NixOS/nixpkgs/commit/5311245e0d1f444a2fbb8e66f05762196a49325a) | `archiveopteryx: pin to openssl_1_1`                                             |
| [`3d248461`](https://github.com/NixOS/nixpkgs/commit/3d248461ec3458e68e70026592bc4e2e9dabade6) | `hadoop: pin to openssl_1_1`                                                     |
| [`cc43c149`](https://github.com/NixOS/nixpkgs/commit/cc43c149ce4ae6f21805dde414626eec3f093296) | `mrustc-bootstrap: pin to openssl_1_1`                                           |
| [`76c7f573`](https://github.com/NixOS/nixpkgs/commit/76c7f5739dad79888d96512b513c0b4eb6df90e8) | `nfd: pin to openssl_1_1`                                                        |
| [`954f49b6`](https://github.com/NixOS/nixpkgs/commit/954f49b653af6289c72675344df4771d6ae395eb) | `sslsplit: pin to openssl_1_1`                                                   |
| [`5b3be0c3`](https://github.com/NixOS/nixpkgs/commit/5b3be0c3bfeb6d5dd0352b171bebda2d859303d3) | `tremor-rs: pin to openssl_1_1`                                                  |
| [`7a1078c5`](https://github.com/NixOS/nixpkgs/commit/7a1078c5c0a5c53d31fdf79336cd8d0e26fe0c5e) | `tensorman: pin to openssl_1_1`                                                  |
| [`fdbb3e2b`](https://github.com/NixOS/nixpkgs/commit/fdbb3e2b6a162f1070fccb8c9b90fb3779015456) | `taizen: pin to openssl_1_1`                                                     |
| [`7fae589a`](https://github.com/NixOS/nixpkgs/commit/7fae589af3ad4f1c07131bd1ce559ca803543c03) | `synapse-bt: pin to openssl_1_1`                                                 |
| [`72827e4b`](https://github.com/NixOS/nixpkgs/commit/72827e4b5dc95f9ef506728d91717b88b337bc4d) | `spotify-tui: pin to openssl_1_1`                                                |
| [`cfca6eb1`](https://github.com/NixOS/nixpkgs/commit/cfca6eb1d995587684e5c47526617f89148c038c) | `ndn-tools: pin to openssl_1_1`                                                  |
| [`4c84ab3f`](https://github.com/NixOS/nixpkgs/commit/4c84ab3fa59ac47dfb75bc58a154fa2c12c501a0) | `ndn-cxx: pin to openssl_1_1`                                                    |
| [`ceb1673c`](https://github.com/NixOS/nixpkgs/commit/ceb1673ca7a187471ae071a6fb1af0b7cd070e72) | `shticker-book-unwritten: pin to openssl_1_1`                                    |
| [`a1ce22e7`](https://github.com/NixOS/nixpkgs/commit/a1ce22e7a9846e50f997c64e844e451499625d9b) | `rucredstash: pin to openssl_1_1`                                                |
| [`dee738a1`](https://github.com/NixOS/nixpkgs/commit/dee738a1d0280043d3132c76c37d57d58c2130df) | `quill: pin to openssl_1_1`                                                      |
| [`60283ad9`](https://github.com/NixOS/nixpkgs/commit/60283ad9539d0caaf2d9c913a710239a224bd9fb) | `netease-music-tui: pin to openssl_1_1`                                          |
| [`18ee52ca`](https://github.com/NixOS/nixpkgs/commit/18ee52cae45993d7c5e66d8930e57c49bdcb9d2e) | `paperoni: pin to openssl_1_1`                                                   |
| [`62ee0617`](https://github.com/NixOS/nixpkgs/commit/62ee0617103bffa1e64256684a78f889ac7a15de) | `mdbook-plantuml: pin to openssl_1_1`                                            |
| [`85d62cef`](https://github.com/NixOS/nixpkgs/commit/85d62cef64570cf17314673642757bb8153e856e) | `imag: pin to openssl_1_1`                                                       |
| [`45c8684e`](https://github.com/NixOS/nixpkgs/commit/45c8684e2cc4b15978cfee4ced4177faa73e8838) | `hydra-cli: pin to openssl_1_1`                                                  |
| [`d4e0a8f1`](https://github.com/NixOS/nixpkgs/commit/d4e0a8f1d2a044a65bfdfde5ed2e211927a92572) | `hash_extender: pin to openssl_1_1`                                              |
| [`a0c0a349`](https://github.com/NixOS/nixpkgs/commit/a0c0a349d267de3f7aaa39264f994efad0f2149b) | `habitat: pin to openssl_1_1`                                                    |
| [`12ad2541`](https://github.com/NixOS/nixpkgs/commit/12ad25411d9dcbf2556b1e8aafd54de8fb24db98) | `gmnisrv: pin to openssl_1_1`                                                    |
| [`c9a1beb2`](https://github.com/NixOS/nixpkgs/commit/c9a1beb23895e85beda47b7920962f8eaa9ac194) | `git-series: pin to openssl_1_1`                                                 |
| [`5a57ba3b`](https://github.com/NixOS/nixpkgs/commit/5a57ba3bddf8714641112d39b64d4d69a845d3ba) | `finalfrontier: pin to openssl_1_1`                                              |
| [`ab0cb98d`](https://github.com/NixOS/nixpkgs/commit/ab0cb98d4cba994e893e95adf91defb334c83ba7) | `devserver: pin to openssl_1_1`                                                  |
| [`5765cef3`](https://github.com/NixOS/nixpkgs/commit/5765cef3ae5216f5ea58775d5238c8c38d0362ad) | `cliscord: pin to openssl_1_1`                                                   |
| [`7646a6de`](https://github.com/NixOS/nixpkgs/commit/7646a6defcd647c43c286d407ccaa62d3f8605bf) | `coinlive: pin to openssl_1_1`                                                   |
| [`823d14f3`](https://github.com/NixOS/nixpkgs/commit/823d14f3e53d95e064b7705619e5964a63144241) | `xbps: pin to openssl_1_1`                                                       |
| [`b909c461`](https://github.com/NixOS/nixpkgs/commit/b909c461bf3d90472d7d40ada3cb226a66c15a10) | `eidolon: pin to openssl_1_1`                                                    |
| [`191c4487`](https://github.com/NixOS/nixpkgs/commit/191c4487032452274d46a2feb620fb5762b8b691) | `wkhtmltopdf-bin: pin to openssl_1_1`                                            |
| [`e3755a38`](https://github.com/NixOS/nixpkgs/commit/e3755a384c902dc9ba44ca4488d7e902f62fa5e6) | `tunnelto: pin to openssl_1_1`                                                   |
| [`2a5bb722`](https://github.com/NixOS/nixpkgs/commit/2a5bb722e991d4e1bbfa29b63aef9672ed98d513) | `chit: pin to openssl_1_1`                                                       |
| [`5ed6dd76`](https://github.com/NixOS/nixpkgs/commit/5ed6dd7666568055c3c1f49f5a8fdca6b2597ca1) | `uefitool: A60 -> A61`                                                           |
| [`7083952d`](https://github.com/NixOS/nixpkgs/commit/7083952d2b6c3fc112f3738f94ef6f6fa148fd07) | `python310Packages.flask-wtf: add anthonyroussel to maintainers`                 |
| [`0ad235a4`](https://github.com/NixOS/nixpkgs/commit/0ad235a42b197831030fd54195de979aa3a16390) | `python310Packages.flask-wtf: fix failing build`                                 |