### PR TITLE
chore(flake/home-manager): `60c6bfe3` -> `5408e279`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1663099612,
-        "narHash": "sha256-ucokjFDRwCFWbcGiqxz0mfHv82UqwyW7RXY6ZgKSl80=",
+        "lastModified": 1663227421,
+        "narHash": "sha256-8M2ZQPLQw0CUylKbF8pgDMQ5vxOH4i0rxwUhtPIsf7Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "60c6bfe322944d04bb38e76b64effcbd01258824",
+        "rev": "5408e27961599b1350b651f88715daf6e67244a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`5408e279`](https://github.com/nix-community/home-manager/commit/5408e27961599b1350b651f88715daf6e67244a7) | `flake.lock: Update`                       |
| [`6745da6d`](https://github.com/nix-community/home-manager/commit/6745da6dce1ae023e934e1ea17f7209641fcb9ee) | `rtorrent: change settings to extraConfig` |
| [`ebd78308`](https://github.com/nix-community/home-manager/commit/ebd78308144165d65b28f80969a970b8213805b2) | `exa: add package option`                  |