### PR TITLE
chore(flake/nixos-hardware): `93580fca` -> `a0df6cd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1663133271,
-        "narHash": "sha256-juBxlETvfMetD/pUFLtdDLQ8BOayxROra8d5Hg6Zg1M=",
+        "lastModified": 1663229557,
+        "narHash": "sha256-1uU4nsDLXKG0AHc/VCsNBAEPkTA/07juYhcEWRb1O1E=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "93580fca1000c37e382d7e2c19c78c1c3852482d",
+        "rev": "a0df6cd6e199df4a78c833c273781ea92fa62cfb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`7aac946a`](https://github.com/NixOS/nixos-hardware/commit/7aac946a06f2f9c8846260fa036a64d2d1f26eb0) | `Add thinkpad t14 amd gen3 to flake` |
| [`1cf38622`](https://github.com/NixOS/nixos-hardware/commit/1cf38622653249a4b5f843107f6b4b3d29e41463) | `Add lenovo/thinkpad/p16s/amd/gen1`  |
| [`f6f318b5`](https://github.com/NixOS/nixos-hardware/commit/f6f318b52a189f9e510f5bc85fe52656260c6e39) | `Add thinkpad t14 amd gen3`          |