### PR TITLE
chore(flake/home-manager): `5408e279` -> `5427f3d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1663227421,
-        "narHash": "sha256-8M2ZQPLQw0CUylKbF8pgDMQ5vxOH4i0rxwUhtPIsf7Q=",
+        "lastModified": 1663328500,
+        "narHash": "sha256-7n+J/exp8ky4dmk02y5a9R7CGmJvHpzrHMzfEkMtSWA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5408e27961599b1350b651f88715daf6e67244a7",
+        "rev": "5427f3d1f0ea4357cd4af0bffee7248d640c6ffc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`5427f3d1`](https://github.com/nix-community/home-manager/commit/5427f3d1f0ea4357cd4af0bffee7248d640c6ffc) | `mpd: use XDG music dir if XDG user dirs are enabled` |
| [`b0247cee`](https://github.com/nix-community/home-manager/commit/b0247ceedc72322f77c16fb490c0fdf6373a3f6b) | `xdg.userDirs: avoid using $HOME`                     |