### PR TITLE
chore(flake/darwin): `3b69bf3c` -> `de4d41ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662478528,
-        "narHash": "sha256-Myjd0HPL5lXri3NXOcJ6gP7IKod2eMweQBKM4uxgEGw=",
+        "lastModified": 1663492236,
+        "narHash": "sha256-KzgrcFVhv/Ca7m83SaijE0W+tLHzjoypHZm9gHGS+cY=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "3b69bf3cc26ae19de847bfe54d6ab22d7381a90a",
+        "rev": "de4d41ee9fd12a60236c1f35cead7c511dac08eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                   |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`4eed79d4`](https://github.com/LnL7/nix-darwin/commit/4eed79d4ac19a6166595b73d601a3810b35a228b) | `yabai: set default package`                     |
| [`c5a241fc`](https://github.com/LnL7/nix-darwin/commit/c5a241fc64da913883a02b5ad4e2090a08f7e85f) | `fix: adapt fonts tests to use newer module api` |
| [`7698ffce`](https://github.com/LnL7/nix-darwin/commit/7698ffce98b0535de3f1de25a7a3ab1249eef46e) | `Remove lib.mdDoc usage`                         |
| [`cfd60e8c`](https://github.com/LnL7/nix-darwin/commit/cfd60e8c54072a572bd5a805b1d68108b8ee4100) | `Add tailscale service module`                   |
| [`a498eb06`](https://github.com/LnL7/nix-darwin/commit/a498eb069579719980620657ad7baed8792e62f4) | `docs: add short introduction`                   |
| [`ad36f9fa`](https://github.com/LnL7/nix-darwin/commit/ad36f9fa0657a5dc234ca6c6762d38cb93f1559c) | `docs: extend documentation`                     |