### PR TITLE
chore(flake/nixpkgs): `da6a0581` -> `f677051b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1663357389,
-        "narHash": "sha256-oYA2nVRSi6yhCBqS5Vz465Hw+3BQOVFEhfbfy//3vTs=",
+        "lastModified": 1663494472,
+        "narHash": "sha256-fSowlaoXXWcAM8m9wA6u+eTJJtvruYHMA+Lb/tFi/qM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da6a05816e7fa5226c3f61e285ef8d9dfc868f3c",
+        "rev": "f677051b8dc0b5e2a9348941c99eea8c4b0ff28f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`34b08c6c`](https://github.com/NixOS/nixpkgs/commit/34b08c6c3413bfbbd98453b5b5a298ede27bc084) | `mathematica: 13.0.1 -> 13.1.0`                                            |
| [`192b63e2`](https://github.com/NixOS/nixpkgs/commit/192b63e2250cf015e3c0cb86f271b9732333fe31) | `bpftools: revert version to the one that's fully rebuilt`                 |
| [`f12d2f01`](https://github.com/NixOS/nixpkgs/commit/f12d2f016b6c69b702d89cc29eb50567d1088831) | `bpftools: decouple version from linux_latest`                             |
| [`241f31a0`](https://github.com/NixOS/nixpkgs/commit/241f31a0a7d9318e56af4a2ecbb10011203760ef) | `nixos/matrix-synapse: fix link to install instructions`                   |
| [`01462a9e`](https://github.com/NixOS/nixpkgs/commit/01462a9e8b0183759760cef16922365e79f4b2cc) | `python310Packages.gehomesdk: 0.5.6 -> 0.5.7`                              |
| [`a7a94811`](https://github.com/NixOS/nixpkgs/commit/a7a94811e3eed46aee7c8f8644a2a3737e59bddd) | `nixos/nix-daemon: support machine protocol`                               |
| [`6a149eee`](https://github.com/NixOS/nixpkgs/commit/6a149eeef35471de4466820de236af8ab1724db0) | `python310Packages.crownstone-sse: 2.0.3 -> 2.0.4`                         |
| [`ff44e1f9`](https://github.com/NixOS/nixpkgs/commit/ff44e1f9dd2631be621d32b7ec9fa16ef2ae8e84) | `resholve: use originalSrc for nixpkgs-update bot`                         |
| [`162d4bf6`](https://github.com/NixOS/nixpkgs/commit/162d4bf69f2a75369e32d73ce6e0d2d2e9d6b7f5) | ``mautrix-signal: Use `--prefix` instead of `--set` in wrapper.``          |
| [`ab25e0d3`](https://github.com/NixOS/nixpkgs/commit/ab25e0d3ca02db6f847bf1647ffa464de38f2132) | `python310Packages.aioecowitt: 2022.08.3 -> 2022.09.2`                     |
| [`9025c5f4`](https://github.com/NixOS/nixpkgs/commit/9025c5f406d4f3967191a7a7de65102c4cf0765d) | `pocketbase: 0.7.2 -> 0.7.3`                                               |
| [`fc053586`](https://github.com/NixOS/nixpkgs/commit/fc05358607f15bb0e4704cf926df66a4b7610baf) | `otpauth: 0.4.3 -> 0.5.0`                                                  |
| [`68fcdc4b`](https://github.com/NixOS/nixpkgs/commit/68fcdc4bc6f3dac1f64a45327eae1a0320b9059a) | `python310Packages.pep440: 0.1.1 -> 0.1.2`                                 |
| [`59f8ea7f`](https://github.com/NixOS/nixpkgs/commit/59f8ea7f9623f22ffd5bcf10bd1d2d5ecbac4fd1) | `element-{web,desktop}: 1.11.4 -> 1.11.5`                                  |
| [`9c35dd41`](https://github.com/NixOS/nixpkgs/commit/9c35dd41c98e63ba1e59d1e8dfb45cc6b4ddc751) | `grafana: 9.1.4 -> 9.1.5`                                                  |
| [`98b1b8da`](https://github.com/NixOS/nixpkgs/commit/98b1b8daa78557091cf85a108c5b5fbd21863a44) | `selene: 0.20.0 -> 0.21.0`                                                 |
| [`4de579f8`](https://github.com/NixOS/nixpkgs/commit/4de579f8c8b192e3a875ae84407076423f56953e) | `lnav: 0.10.1 -> 0.11.0`                                                   |
| [`889080f4`](https://github.com/NixOS/nixpkgs/commit/889080f4fd203cd4abfa9d45f4d408d94fb620a4) | `minio-client: 2022-08-28T20-08-11Z -> 2022-09-16T09-16-47Z`               |
| [`97daf5da`](https://github.com/NixOS/nixpkgs/commit/97daf5da8a4e8611f3cb17d5406da3c423f812e2) | `datree: 1.6.19 -> 1.6.29`                                                 |
| [`6b6bb7cd`](https://github.com/NixOS/nixpkgs/commit/6b6bb7cdd37a4e0aee9d2ef873906832eb461640) | `nixos/wiki-js: pin nodejs to v16`                                         |
| [`4f14788d`](https://github.com/NixOS/nixpkgs/commit/4f14788d2051141921e5b39c81159c6a24f5564b) | `python310Packages.atlassian-python-api: 3.28.0 -> 3.28.1`                 |
| [`ad5a3928`](https://github.com/NixOS/nixpkgs/commit/ad5a3928bf04c9058b672df23137ecfa7b303233) | `cpm: 0.35.5 -> 0.35.6`                                                    |
| [`0c0044ea`](https://github.com/NixOS/nixpkgs/commit/0c0044eae7040abd70edb9e08e1646786a0397fd) | `mage: 1.13.0 -> 1.14.0`                                                   |
| [`091a5c32`](https://github.com/NixOS/nixpkgs/commit/091a5c32e468b8b0a82a4eb9a79a05ff4a2f3d2a) | `netbird: 0.9.1 -> 0.9.3`                                                  |
| [`1601abe6`](https://github.com/NixOS/nixpkgs/commit/1601abe66a9a2e78a3b078e41cd604910e2d763e) | `pinniped: make binary smaller and enable shell completions`               |
| [`8280e0ab`](https://github.com/NixOS/nixpkgs/commit/8280e0ab55deb655ffeb405f7f05da2aa14b41c8) | `instaloader: 4.9.3 -> 4.9.4`                                              |
| [`b02d6e37`](https://github.com/NixOS/nixpkgs/commit/b02d6e3754f2a6ed61114d62aa0a2d8d52eab493) | `latte-integrale: init at 1.7.6 (#190683)`                                 |
| [`49ba5a30`](https://github.com/NixOS/nixpkgs/commit/49ba5a30a10424948cf995ad62ed497b468f0c51) | `glooctl: 1.12.17 -> 1.12.18`                                              |
| [`fb2a9c8f`](https://github.com/NixOS/nixpkgs/commit/fb2a9c8fe4d2743042bc58139409ad4fddd92f11) | `gitls: 1.0.3 -> 1.0.4`                                                    |
| [`12cbb4cd`](https://github.com/NixOS/nixpkgs/commit/12cbb4cd549a008a14f654e9f60d047ea4a2d7c0) | `python310Packages.pyvicare: 2.16.4 -> 2.17.0`                             |
| [`68c1cfa9`](https://github.com/NixOS/nixpkgs/commit/68c1cfa988363da564cfbb1e2b2aa772f3be02fd) | `solaar: 1.1.4 -> 1.1.5`                                                   |
| [`ec3b39d5`](https://github.com/NixOS/nixpkgs/commit/ec3b39d5d4b0c74a706b947f3a8f3d34644c9a44) | `python310Packages.qingping-ble: 0.6.1 -> 0.7.0`                           |
| [`854a94aa`](https://github.com/NixOS/nixpkgs/commit/854a94aa19cea0d419c4b616c2be9d0243b91393) | `mlkit: 4.6.1 -> 4.7.1`                                                    |
| [`0cfb3c00`](https://github.com/NixOS/nixpkgs/commit/0cfb3c002b61807ca0bab3efe514476bdf2e5478) | `mongodb-compass: 1.33.0 -> 1.33.1`                                        |
| [`7369283b`](https://github.com/NixOS/nixpkgs/commit/7369283be45b7a568185b4b732eb4b0c920e186a) | `python310Packages.aiosmtplib: 1.1.6 -> 1.1.7`                             |
| [`7f059c03`](https://github.com/NixOS/nixpkgs/commit/7f059c03dd7568ffba0c5b882c653ed7fae7b647) | `railway: 2.0.10 -> 2.0.11`                                                |
| [`ea0f60eb`](https://github.com/NixOS/nixpkgs/commit/ea0f60ebe03dca226dad6aaabb315e98b987ef6a) | `python310Packages.tilt-ble: 0.2.3 -> 0.2.3`                               |
| [`681a8f27`](https://github.com/NixOS/nixpkgs/commit/681a8f27d3c6ce24f82a4cd792cd08750eb77c63) | `rekor-cli: 0.11.0 -> 0.12.0`                                              |
| [`12cefaaa`](https://github.com/NixOS/nixpkgs/commit/12cefaaa665aa36a02d3aa51e4b811b56386d470) | `skeema: 1.8.1 -> 1.8.2`                                                   |
| [`eaa981dc`](https://github.com/NixOS/nixpkgs/commit/eaa981dcdcf2ce3789132ed04cb8d7279854526c) | `mutt-with-sidebar: remove, mutt provides sidebar`                         |
| [`6ba6ece4`](https://github.com/NixOS/nixpkgs/commit/6ba6ece4c309e448dd5b301db44488dad8ba782f) | `mutagen-compose: 0.15.2 -> 0.15.3`                                        |
| [`5af43b5f`](https://github.com/NixOS/nixpkgs/commit/5af43b5f78e20ebd5d6da5d315eed2620007966d) | `python310Packages.furo: update disabled`                                  |
| [`069eed26`](https://github.com/NixOS/nixpkgs/commit/069eed261158f7f3b3e90dd353aa7ad0f98dba03) | `okteto: 2.6.0 -> 2.7.0`                                                   |
| [`73b1c428`](https://github.com/NixOS/nixpkgs/commit/73b1c42875d1387783bdba8c2024c2a964790163) | `protoc-gen-validate: 0.6.7 -> 0.6.8`                                      |
| [`942a922b`](https://github.com/NixOS/nixpkgs/commit/942a922bb8955786215bf7462d0589324bf60365) | `ctlptl: 0.8.7 -> 0.8.8`                                                   |
| [`5dc26301`](https://github.com/NixOS/nixpkgs/commit/5dc2630125007bc3d08381aebbf09ea99ff4e747) | `scope-lite: init at 0.2.0`                                                |
| [`2383d17f`](https://github.com/NixOS/nixpkgs/commit/2383d17fc2e15d79b3b298c9694eaac1cbc0f5f3) | `rofimoji: 5.5.0 -> 5.6.0`                                                 |
| [`f5fdbb3d`](https://github.com/NixOS/nixpkgs/commit/f5fdbb3d96a30970c7fd97a732fbbb6ad8fe5543) | `argocd: 2.4.11 -> 2.4.12`                                                 |
| [`07d165f5`](https://github.com/NixOS/nixpkgs/commit/07d165f54853855fb006f5f9900725e239aa75ec) | `goda: 0.5.1 -> 0.5.2`                                                     |
| [`af69c8a3`](https://github.com/NixOS/nixpkgs/commit/af69c8a3ad53b19813a6d5bca8973fd7b52b174d) | `sx-go: remove line break`                                                 |
| [`cddc669b`](https://github.com/NixOS/nixpkgs/commit/cddc669b0bb16545546b131fcfe8d7d711262bb4) | `prometheus-xmpp-alerts: Fix build by removing unittestCheckHook argument` |
| [`3fda0f64`](https://github.com/NixOS/nixpkgs/commit/3fda0f64a9b78ae08f78e75e746f3dfcee6bc555) | `legendary-gl: 0.20.28 -> 0.20.29`                                         |
| [`5538b8f0`](https://github.com/NixOS/nixpkgs/commit/5538b8f0cc4ada0625bb33de159a190fd52b4813) | `nanovna-saver: 0.5.2 -> 0.5.3`                                            |
| [`fd81c3de`](https://github.com/NixOS/nixpkgs/commit/fd81c3de80d1c98a4fac76c701c90c6a9d35ddd7) | `v2ray-geoip: 202209080101 -> 202209150105`                                |
| [`1129316c`](https://github.com/NixOS/nixpkgs/commit/1129316c97f2b84359463052739f987e6b0c63a1) | `dtrx: 8.3.1 -> 8.4.0`                                                     |
| [`051c789c`](https://github.com/NixOS/nixpkgs/commit/051c789c9b0c10c368d597135518afa88820ac30) | `circup: 1.1.2 -> 1.1.3`                                                   |
| [`cd93f663`](https://github.com/NixOS/nixpkgs/commit/cd93f6632c74bbf062511df10f58e5ad53e64bd5) | `xsecurelock: 1.7.0 -> 1.8.0`                                              |
| [`9e9a243a`](https://github.com/NixOS/nixpkgs/commit/9e9a243aa9e56d5e3cd9cccc7b91b4de384e4af8) | `enlightenment.efl: 1.26.2 -> 1.26.3`                                      |
| [`97daa67d`](https://github.com/NixOS/nixpkgs/commit/97daa67d117f291e1ad417ec67df43454d851b10) | `discordchatexporter-cli: 2.35.2 -> 2.36`                                  |
| [`52ccb59e`](https://github.com/NixOS/nixpkgs/commit/52ccb59ee2488eb8f2489fc4c05e0ce87f4ed066) | `clojure: 1.11.1.1149 -> 1.11.1.1161`                                      |
| [`9cb16609`](https://github.com/NixOS/nixpkgs/commit/9cb166091c3a84df445a83a45da66e08aa142e54) | `clingo: 5.6.0 -> 5.6.1`                                                   |
| [`995927a2`](https://github.com/NixOS/nixpkgs/commit/995927a29022edc98b973bb8e5619d6fe0444133) | `ckbcomp: 1.209 -> 1.210`                                                  |
| [`507e65b5`](https://github.com/NixOS/nixpkgs/commit/507e65b5db1d76b9e5ef777d471144e758ffcf48) | `python310Packages.life360: 5.1.0 -> 5.1.1`                                |
| [`4a48f8e2`](https://github.com/NixOS/nixpkgs/commit/4a48f8e21a1b7cb6a08db331c1ed6fd65cceced9) | `wayout: mark as unsupported rather than broken on darwin`                 |
| [`7462e7a9`](https://github.com/NixOS/nixpkgs/commit/7462e7a9e5437d28d1385f2bcc3fd6d9aedcb81a) | `python310Packages.korean-lunar-calendar: 0.2.1 -> 0.3.1`                  |
| [`a9133913`](https://github.com/NixOS/nixpkgs/commit/a9133913e433a577e6e959dbb0e2970a28513111) | `python310Packages.jwcrypto: 1.3.1 -> 1.4.2`                               |
| [`8cb099e3`](https://github.com/NixOS/nixpkgs/commit/8cb099e355b94cd1fa3264ca94f013eb3f3701fd) | `actionlint: 1.6.17 -> 1.6.18`                                             |
| [`0c8c1d91`](https://github.com/NixOS/nixpkgs/commit/0c8c1d915c5f1036bb1c56c7840a1abd35a5504e) | `tflint: 0.40.0 -> 0.40.1`                                                 |
| [`c85040af`](https://github.com/NixOS/nixpkgs/commit/c85040af5cfcd191afac5db6ec122dcfa65ebc1d) | `pgcli: use psycopg3`                                                      |
| [`e29ef34a`](https://github.com/NixOS/nixpkgs/commit/e29ef34a5678dbb47f64cfe5c9f800366c07d25a) | `ncspot: 0.11.0 -> 0.11.1`                                                 |
| [`fe2c9e2e`](https://github.com/NixOS/nixpkgs/commit/fe2c9e2ec6c8f725fd5227cb421524c4400b52e6) | `python310Packages.json-stream: 1.4.0 -> 1.4.2`                            |
| [`52a8e1e9`](https://github.com/NixOS/nixpkgs/commit/52a8e1e9a082a926c76f236c24e7b27d95c93b4f) | `python310Packages.zodbpickle: 2.3 -> 2.4`                                 |
| [`4afab7d5`](https://github.com/NixOS/nixpkgs/commit/4afab7d55554caa4464259f37da6ff0c050bcd4d) | `python310Packages.netcdf4: 1.6.0 -> 1.6.1`                                |
| [`74d81b49`](https://github.com/NixOS/nixpkgs/commit/74d81b49086d812d6beb2bfaa245ba0d454dbc3f) | `solana-validator: fix eval`                                               |
| [`5b43c0dc`](https://github.com/NixOS/nixpkgs/commit/5b43c0dcd8e515b97f9579b553461496fab77523) | `python310Packages.immutables: 0.18 -> 0.19`                               |
| [`2472a448`](https://github.com/NixOS/nixpkgs/commit/2472a4484e86340246b7a13fff832712126c5899) | `openxcom: fix missing dependency`                                         |
| [`ccff7afc`](https://github.com/NixOS/nixpkgs/commit/ccff7afc7968f18357c34f9ab5814f56c118a4ff) | `SDL_compat: 1.2.52 -> 1.2.56`                                             |
| [`4d6eb52b`](https://github.com/NixOS/nixpkgs/commit/4d6eb52bb70277b4fc0e37088c0e7f61b99e2a26) | `sx-go: fix darwin build`                                                  |
| [`3c252493`](https://github.com/NixOS/nixpkgs/commit/3c2524933266d552ce50f1d2899cab1844224fd0) | `pgcli: 3.4.1 -> 3.5.0`                                                    |
| [`7ade6e70`](https://github.com/NixOS/nixpkgs/commit/7ade6e7023a1ff5cb0e87f5312f66e078268998d) | `python310Packages.fastcore: 1.5.26 -> 1.5.27`                             |
| [`174e579b`](https://github.com/NixOS/nixpkgs/commit/174e579bd529667fddb76b00594d77f4ea614bc7) | `genact: 1.0.2 -> 1.1.1`                                                   |
| [`2c3f33fd`](https://github.com/NixOS/nixpkgs/commit/2c3f33fd7e900d2cac90e8a096d364757f26759e) | `vscode: 1.71.0 -> 1.71.2`                                                 |
| [`9c324780`](https://github.com/NixOS/nixpkgs/commit/9c3247807970266865bdb2f5c915e200a5397c36) | `rizin: enable on darwin`                                                  |
| [`fbccc52f`](https://github.com/NixOS/nixpkgs/commit/fbccc52f83aa9b42894919929d7f2a47fdd1730c) | `capstone: use fixDarwinDylibNames on darwin`                              |
| [`795fbbf5`](https://github.com/NixOS/nixpkgs/commit/795fbbf5ccae482a2f670baeb52cedf2d708eac1) | `ftgl: drop an impure -dylib_file on darwin`                               |
| [`577d2454`](https://github.com/NixOS/nixpkgs/commit/577d2454c2a2d2cf3876a232fd809337e0181ae4) | `rizin: 0.4.0 -> 0.4.1`                                                    |
| [`38f48cfc`](https://github.com/NixOS/nixpkgs/commit/38f48cfc4f060ddfd4c03187ed3f75b702a114c3) | `meson: expose python3 in passthru`                                        |
| [`67633310`](https://github.com/NixOS/nixpkgs/commit/67633310711af4862c5fe89e231bcc9bb3248d6b) | `python310Packages.chess: 1.9.2 -> 1.9.3`                                  |
| [`2912f1cc`](https://github.com/NixOS/nixpkgs/commit/2912f1ccedcef3f7f57017e2e3a9c912b0251351) | `nixpacks: 0.3.12 -> 0.5.6`                                                |
| [`d529e696`](https://github.com/NixOS/nixpkgs/commit/d529e6962d22d13e28439c67adbf1ef7381f7143) | `qt6: 6.3.1 -> 6.3.2`                                                      |
| [`75da5c2a`](https://github.com/NixOS/nixpkgs/commit/75da5c2aa3097b06b78bc803669e7a39e02ca58b) | `waypoint: 0.9.1 -> 0.10.0`                                                |
| [`aac64d54`](https://github.com/NixOS/nixpkgs/commit/aac64d54b44d2a51d994de459b50b43edc3fc929) | `trivy: 0.31.3 -> 0.32.0`                                                  |
| [`6309e712`](https://github.com/NixOS/nixpkgs/commit/6309e71200281b9d44dbe61621a95f486e7fee21) | `sumneko-lua-language-server: 3.5.5 -> 3.5.6`                              |