### PR TITLE
chore(flake/darwin): `de4d41ee` -> `14a12e9e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1663492236,
-        "narHash": "sha256-KzgrcFVhv/Ca7m83SaijE0W+tLHzjoypHZm9gHGS+cY=",
+        "lastModified": 1663590770,
+        "narHash": "sha256-W08mEkxzHbdrE3xw+x6A/i14P2S4iYpcQ5VsUPnSPU4=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "de4d41ee9fd12a60236c1f35cead7c511dac08eb",
+        "rev": "14a12e9ee72215b5f1e7dcbbff52e21a2e1d688c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                          |
| ------------------------------------------------------------------------------------------------ | --------------------------------------- |
| [`ed4d2d69`](https://github.com/LnL7/nix-darwin/commit/ed4d2d69a03c982f71ffe65b589daf3e6b047e7d) | `karabiner-elements: don't use scripts` |
| [`afcce995`](https://github.com/LnL7/nix-darwin/commit/afcce995bd14cd7b3f15214c9f2a431e24e6e432) | `karabiner-elements: init module`       |
| [`176c446b`](https://github.com/LnL7/nix-darwin/commit/176c446b97d0c784170586cc465f912e08d623a8) | `launchd: add extra KeepAlive options`  |