### PR TITLE
chore(flake/home-manager): `95559181` -> `df79df8b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1663617778,
-        "narHash": "sha256-uXjoNxbIhTtQ+X3m2FAukWDmmmfnmx3IU4tMhiBtQdE=",
+        "lastModified": 1663619079,
+        "narHash": "sha256-xdv2knlxIHIlOMqaSXhvJlMoruE13ZV5WpNfRmKUk1E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "95559181518533741c516826ae377a51814569c3",
+        "rev": "df79df8be10bc54d79118ac6167a92b779344228",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                           |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`df79df8b`](https://github.com/nix-community/home-manager/commit/df79df8be10bc54d79118ac6167a92b779344228) | `Translate using Weblate (Danish)`       |
| [`22ef57a5`](https://github.com/nix-community/home-manager/commit/22ef57a54c6ec3a0465c84cc3fbba8eabd446bab) | `Add translation using Weblate (Danish)` |
| [`b4bfe3b2`](https://github.com/nix-community/home-manager/commit/b4bfe3b2d955f31d6983b4f11ac4095997a11710) | `Translate using Weblate (Danish)`       |