### PR TITLE
chore(flake/darwin): `caea6653` -> `088c98a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1663677862,
-        "narHash": "sha256-XaZf+YZ3GSpZE6wOcz4qkcz81V8Cl/ECIn5IfTxwVfg=",
+        "lastModified": 1663677921,
+        "narHash": "sha256-NfQnUfRrjv8DXeugdbQC5El+MMhShP42ohc8iM+UAdM=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "caea6653b1acc4f3cf709830e4af32dbbb2b39f0",
+        "rev": "088c98a584a38b5f844bb9e9cd32eb28479ca6d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                   |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`f12f0f30`](https://github.com/LnL7/nix-darwin/commit/f12f0f3095b0e641cb5b737bd9f4c6cef3dfb73a) | `environment: support installing terminfo files` |
| [`74a0e71f`](https://github.com/LnL7/nix-darwin/commit/74a0e71ff2aee5ea905382b13f7635bd371b369e) | `eval-config: make lib overridable`              |