### PR TITLE
chore(flake/home-manager): `41790ba6` -> `f5e4614c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1663629861,
-        "narHash": "sha256-CjfQUyPfG/hkE4jnMcTvVJ0ubc84u8ySruZL+emXMjw=",
+        "lastModified": 1663798175,
+        "narHash": "sha256-LehJBDs+spXUhLnTO+Out5LLczxdIFBBozXLleHnrHE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "41790ba656bafc023f48ccdbbe7816d30fd52d76",
+        "rev": "f5e4614c1163ffe4a30cfb3cf1b76a72f69c3fda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                    |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`f5e4614c`](https://github.com/nix-community/home-manager/commit/f5e4614c1163ffe4a30cfb3cf1b76a72f69c3fda) | ``yt-dlp: add `settings` option`` |