### PR TITLE
chore(flake/nixpkgs): `f677051b` -> `d6490a0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1663494472,
-        "narHash": "sha256-fSowlaoXXWcAM8m9wA6u+eTJJtvruYHMA+Lb/tFi/qM=",
+        "lastModified": 1663761423,
+        "narHash": "sha256-bDLXl2BVq7eIQz/8CduZI1SLyhG9u/CrckHd6f7bwPE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f677051b8dc0b5e2a9348941c99eea8c4b0ff28f",
+        "rev": "d6490a0bd9dfb298fcd8382d3363b86870dc7340",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                         |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`a0e39047`](https://github.com/NixOS/nixpkgs/commit/a0e390471362e27349abc1090197e09fe8c59d16) | `buildah: 1.27.1 -> 1.27.2 (#192229)`                                                  |
| [`cbcdc23b`](https://github.com/NixOS/nixpkgs/commit/cbcdc23b9d1811f16b02e2ae38c75cb4f61ede7e) | `elements: apply fixes from bitcoin package`                                           |
| [`28830d30`](https://github.com/NixOS/nixpkgs/commit/28830d30e645d3c506f4e6b63e896b8455dbb4fe) | `thunderbird-91-unwrapped: 91.13.0 -> 91.13.1`                                         |
| [`a18e1bba`](https://github.com/NixOS/nixpkgs/commit/a18e1bba42c18b110500bc4c8ef72b5a18529029) | `coercer: init at 1.6`                                                                 |
| [`dfa4a330`](https://github.com/NixOS/nixpkgs/commit/dfa4a33001413341638d53bf0dd9bd70ae59e82e) | `dismember: init at 0.0.1`                                                             |
| [`9e4208c8`](https://github.com/NixOS/nixpkgs/commit/9e4208c8c74275f89def993348fa9ff51e9f5e72) | `crackql: init at unstable-20220821`                                                   |
| [`848d647c`](https://github.com/NixOS/nixpkgs/commit/848d647c389834b45795301adccc1cc55508f508) | `python310Packages.sqlobject: specify license`                                         |
| [`97c2dc14`](https://github.com/NixOS/nixpkgs/commit/97c2dc147ee48d417a1bb5b84c2b4b4745756c0b) | `terraform-providers: update 2022-09-21`                                               |
| [`d3270d6b`](https://github.com/NixOS/nixpkgs/commit/d3270d6b32c6a5404c2429e20ab75969d8376d1d) | `.github/workflows/update-terraform-providers.yml: add nixpkgs-unstable for nix-shell` |
| [`8302b9e9`](https://github.com/NixOS/nixpkgs/commit/8302b9e9b3917846aa792c501d2d1f618db52649) | `python310Packages.sqlobject: 3.9.1 -> 3.10.0`                                         |
| [`490f918f`](https://github.com/NixOS/nixpkgs/commit/490f918fe65e5f53c48e509582f489e1e2d522e7) | `popcorntime: init at 0.4.9`                                                           |
| [`8e848152`](https://github.com/NixOS/nixpkgs/commit/8e848152c37ff7ceb48cc46837467013ad1cb18d) | `gleam: 0.22.1 -> 0.23.0`                                                              |
| [`b48aaab0`](https://github.com/NixOS/nixpkgs/commit/b48aaab0870cff1232bf5d521c6ca4cbf950826c) | `python310Packages.pytorch-metric-learning: 1.6.0 -> 1.6.2`                            |
| [`07270e63`](https://github.com/NixOS/nixpkgs/commit/07270e6356cf294697429fc957438d610c4e482e) | `python310Packages.pytenable: 1.4.7 -> 1.4.8`                                          |
| [`4b048a08`](https://github.com/NixOS/nixpkgs/commit/4b048a08c3e52c165dbeddcb07f763598392f620) | `micropad: 3.30.6 -> 4.0.0`                                                            |
| [`54f56559`](https://github.com/NixOS/nixpkgs/commit/54f565593144c866e7deda41249fdf6dd572a6cb) | `micropad: Add updateScript`                                                           |
| [`b36f96da`](https://github.com/NixOS/nixpkgs/commit/b36f96dac4955a83e08ca8ee051225686fa2aa38) | `python310Packages.pydeps: 1.10.22 -> 1.10.24`                                         |
| [`420a421e`](https://github.com/NixOS/nixpkgs/commit/420a421e7d9872aa53827b5d86516548c7b47aad) | `python310Packages.plaid-python: 9.9.0 -> 10.0.0`                                      |
| [`19727ac3`](https://github.com/NixOS/nixpkgs/commit/19727ac36e1496180180266c2eab37c9a24fa2eb) | `python310Packages.pick: 2.0.0 -> 2.0.2`                                               |
| [`ec297ae1`](https://github.com/NixOS/nixpkgs/commit/ec297ae16b83c790dee2035bea5d84bd44241452) | `python310Packages.pex: 2.1.104 -> 2.1.105`                                            |
| [`cbb1f392`](https://github.com/NixOS/nixpkgs/commit/cbb1f39264ee2748595d21586e7110ff5ccf2d03) | `nixosTests.docker-tools: Add image-with-certs`                                        |
| [`63ac6e5d`](https://github.com/NixOS/nixpkgs/commit/63ac6e5d89756cec8425aee0dfaf3c002934468a) | `python310Packages.mypy-boto3-s3: 1.24.36.post1 -> 1.24.76`                            |
| [`814026db`](https://github.com/NixOS/nixpkgs/commit/814026db2ded64af1526843a774478c3ece3d748) | `maintainers/scripts/update.nix: exit with nonzero exit code when script fails`        |
| [`a97749c6`](https://github.com/NixOS/nixpkgs/commit/a97749c624142e5e39615c9a1a8d01a33cb1af5e) | `talosctl: 1.2.2 -> 1.2.3`                                                             |
| [`3ff7fd3b`](https://github.com/NixOS/nixpkgs/commit/3ff7fd3b86e2d9b0b2f7e884175c5ca3758d4b00) | `python310Packages.google-cloud-spanner: 3.20.0 -> 3.21.0`                             |
| [`94496af3`](https://github.com/NixOS/nixpkgs/commit/94496af3aa930683c664767c93df7d965608c5c7) | `python310Packages.twilio: 7.13.0 -> 7.14.0`                                           |
| [`25b760f3`](https://github.com/NixOS/nixpkgs/commit/25b760f361eaf6c1addec80cf89d1f11056859fd) | `python310Packages.google-cloud-firestore: 2.6.1 -> 2.7.0`                             |
| [`0bd404bd`](https://github.com/NixOS/nixpkgs/commit/0bd404bd82eec755c30d5777dfc5b625b360b4c4) | `python310Packages.google-cloud-container: 2.11.2 -> 2.12.0`                           |
| [`845538f6`](https://github.com/NixOS/nixpkgs/commit/845538f685297f52b1e8c995b7c9c235070534fa) | `python310Packages.google-cloud-bigquery-storage: 2.15.0 -> 2.16.0`                    |
| [`879dda19`](https://github.com/NixOS/nixpkgs/commit/879dda199e706d5ab9c24856eedf6bf6557698e0) | `python310Packages.google-cloud-asset: 3.13.1 -> 3.14.0`                               |
| [`9cc9ec0e`](https://github.com/NixOS/nixpkgs/commit/9cc9ec0e52d79b90b5cd5a695bcb62431ff33cd9) | `python310Packages.starkbank-ecdsa: 2.0.3 -> 2.1.0`                                    |
| [`12f19731`](https://github.com/NixOS/nixpkgs/commit/12f19731ed409d1f5d1eabd5944106b640207264) | `python310Packages.plugwise: 0.22.0 -> 0.22.1`                                         |
| [`b4eecb4a`](https://github.com/NixOS/nixpkgs/commit/b4eecb4a9388b4993b34551c8398081df5339f90) | `python310Packages.peaqevcore: 5.18.3 -> 5.18.4`                                       |
| [`d83c776e`](https://github.com/NixOS/nixpkgs/commit/d83c776ee2f1a2c355f20c7a2af26f7c84d41441) | `python310Packages.neo4j: 5.0.0 -> 5.0.1`                                              |
| [`34374ee6`](https://github.com/NixOS/nixpkgs/commit/34374ee641852c96021570b3282541d7fbd4f097) | `python310Packages.hahomematic: 2022.9.0 -> 2022.9.1`                                  |
| [`e5cffe7d`](https://github.com/NixOS/nixpkgs/commit/e5cffe7d7c40df623056a3f0780c6ed9b36b7c27) | `python310Packages.evtx: 0.7.3 -> 0.8.1`                                               |
| [`36988db2`](https://github.com/NixOS/nixpkgs/commit/36988db25a5bbc6ebb06846018c7311246042784) | `python310Packages.cyclonedx-python-lib: 2.7.1 -> 3.1.0`                               |
| [`c6e5c833`](https://github.com/NixOS/nixpkgs/commit/c6e5c83346e58e0288ad5dccaffef65d19fc431c) | `python310Packages.atenpdu: 0.3.4 -> 0.3.5`                                            |
| [`75239879`](https://github.com/NixOS/nixpkgs/commit/75239879b7c0344ed5f8717fdc35424e39e7832c) | `python310Packages.dparse: add pythonImportsCheck`                                     |
| [`8647c626`](https://github.com/NixOS/nixpkgs/commit/8647c626a56e13b23ae57c5f6cad07f09ce9ea8a) | `python310Packages.dparse: update disabled`                                            |
| [`268a4329`](https://github.com/NixOS/nixpkgs/commit/268a43292cad3a6b1b8bc50fdf024d0650400120) | `python310Packages.boost-histogram: update disabled`                                   |
| [`6873f0b7`](https://github.com/NixOS/nixpkgs/commit/6873f0b7b8e7b81b0195e78f5a79fe0bdfa98d65) | `python310Packages.diff-cover: update disabled`                                        |
| [`87e49745`](https://github.com/NixOS/nixpkgs/commit/87e497452178831c5d5679ab476d60735987fd67) | `python310Packages.azure-keyvault-administration: disable on older Python releases`    |
| [`1a7ea5d9`](https://github.com/NixOS/nixpkgs/commit/1a7ea5d9c1f68722c46a7422e10cd2a0625d6e9e) | `python310Packages.dparse: 0.6.0 -> 0.6.2`                                             |
| [`3b9c1a03`](https://github.com/NixOS/nixpkgs/commit/3b9c1a03de9696868c7102ad02729f1b48cceceb) | `mpv: enable rubberbandSupport even if not linux`                                      |
| [`cfdcdf2b`](https://github.com/NixOS/nixpkgs/commit/cfdcdf2b60b0061ae84e6f3e7931f5cdbec45ccf) | `python310Packages.diff-cover: 6.5.1 -> 7.0.1`                                         |
| [`a76272d5`](https://github.com/NixOS/nixpkgs/commit/a76272d5aefc3ee3a22bfd7cbe0fc070d0593131) | `python310Packages.db-dtypes: 1.0.3 -> 1.0.4`                                          |
| [`052d8838`](https://github.com/NixOS/nixpkgs/commit/052d88386c06abbcd7b4b5e69b6773c01f12d128) | `caddy: 2.5.2 -> 2.6.0`                                                                |
| [`0eb4f831`](https://github.com/NixOS/nixpkgs/commit/0eb4f8311cf6d7ad80861f4cb33fd4d11e3e6fe8) | `wasmtime: 0.40.1 -> 1.0.0`                                                            |
| [`e637769f`](https://github.com/NixOS/nixpkgs/commit/e637769fc94262ca2cd8ea8615cd37bebfc63c52) | `libsForQt5.qtstyleplugin-kvantum: reformat nix expression`                            |
| [`b95d5204`](https://github.com/NixOS/nixpkgs/commit/b95d52045b4f28892e5adc0541e2019c49324b7b) | `libsForQt5.qtstyleplugin-kvantum: 1.0.4 -> 1.0.5`                                     |
| [`dacbfc29`](https://github.com/NixOS/nixpkgs/commit/dacbfc29af3f469bce50781578dcf5d2be2fceb5) | `python310Packages.boost-histogram: 1.3.1 -> 1.3.2`                                    |
| [`460b4b8c`](https://github.com/NixOS/nixpkgs/commit/460b4b8c1a8f75dd8b065e06a82e04b5d2604820) | `nixos/modules/sway: Remove unsupported flag in doc`                                   |
| [`d4717ad1`](https://github.com/NixOS/nixpkgs/commit/d4717ad12898f9c36f9b9538da0ca9df175ee05e) | `ncmpcpp: fix cross compile`                                                           |
| [`702ae09c`](https://github.com/NixOS/nixpkgs/commit/702ae09ca911c9bd828cbff4c6dc0644a217454e) | `ncmpcpp: remove ? null from inputs, remove with lib over entire scope`                |
| [`22510348`](https://github.com/NixOS/nixpkgs/commit/225103487a8f2ba013584d689844cca3e80ecc0b) | `webkitgtk: 2.37.90 → 2.38.0`                                                          |
| [`57e596a8`](https://github.com/NixOS/nixpkgs/commit/57e596a8651417107220c320bf39fec37d4066f1) | `webkitgtk: Display ABI version in name`                                               |
| [`ccc127b3`](https://github.com/NixOS/nixpkgs/commit/ccc127b3dae7a632bacb4b212cd8a7eeeaef0ee8) | `webkitgtk: 2.37.1 → 2.37.90`                                                          |
| [`f5d6f8b5`](https://github.com/NixOS/nixpkgs/commit/f5d6f8b560f7a8b929d6856917e99ff1518568f0) | `webkitgtk: 2.36.7 → 2.37.1`                                                           |
| [`b66c75e1`](https://github.com/NixOS/nixpkgs/commit/b66c75e1e8c942b6245a695e9e748bb5bac18703) | `webkitgtk_5_0: init`                                                                  |
| [`e7b20e5c`](https://github.com/NixOS/nixpkgs/commit/e7b20e5c1c20d31b62eca624ad822f579604259f) | `python310Packages.azure-keyvault-secrets: 4.5.1 -> 4.6.0`                             |
| [`226426a4`](https://github.com/NixOS/nixpkgs/commit/226426a4dc7d0bfb1f7ea0ab5040b2c440f4709d) | `python310Packages.azure-keyvault-keys: 4.6.1 -> 4.7.0`                                |
| [`cbc99852`](https://github.com/NixOS/nixpkgs/commit/cbc998521bcddc74f74cd19d1d119449b82911ce) | `vimPlugins.vim-clap: fix cargoSha256`                                                 |
| [`1f624bb0`](https://github.com/NixOS/nixpkgs/commit/1f624bb0ec3fca7d8c99c7e9f116388c63c076d1) | `python310Packages.azure-keyvault-certificates: 4.5.1 -> 4.6.0`                        |
| [`cb3bdf1c`](https://github.com/NixOS/nixpkgs/commit/cb3bdf1c63d29de856b504a8a163a1337b31ba69) | `python310Packages.azure-keyvault-administration: 4.1.1 -> 4.2.0`                      |
| [`314931d4`](https://github.com/NixOS/nixpkgs/commit/314931d4b9c14b979ccd6cf33a6d79ae12f3de45) | `python310Packages.awkward: 1.9.0 -> 1.10.0`                                           |
| [`d38b131b`](https://github.com/NixOS/nixpkgs/commit/d38b131b70b11cfae4a4bbfe19d2ad834e689a6f) | `vimPlugins.vim-caddyfile: init at 2022-05-09`                                         |
| [`cdb672a4`](https://github.com/NixOS/nixpkgs/commit/cdb672a439e01a5f8ee3a0f5acd68ab1c1390142) | `vimPlugins: update`                                                                   |
| [`4b3f728f`](https://github.com/NixOS/nixpkgs/commit/4b3f728f6d6ccbc4669d645298fedbca28af6827) | `mynewt-newtmgr: update descriptions`                                                  |
| [`79359cc1`](https://github.com/NixOS/nixpkgs/commit/79359cc1e298582aadf4744ecf3e47c7317b60e4) | `linux-zen: 5.19.9 -> 5.19.10`                                                         |
| [`7c03f6b1`](https://github.com/NixOS/nixpkgs/commit/7c03f6b13a0354a98cdfd1219705a47af4f18985) | `linux-lqx: 5.19.9 -> 5.19.10`                                                         |
| [`93eae42f`](https://github.com/NixOS/nixpkgs/commit/93eae42f02f347e7e0540409dd0e7076bd863c07) | `getmail6: Fix FHS reference`                                                          |
| [`9d8130c4`](https://github.com/NixOS/nixpkgs/commit/9d8130c408722a9890fcb35e5d163d3181661200) | `hitch: 1.7.2 -> 1.7.3`                                                                |
| [`514fecc9`](https://github.com/NixOS/nixpkgs/commit/514fecc96d8238eeca4fcee5dff2883674cd4216) | `weechatScripts.wee-slack: 2.8.0 -> 2.9.0`                                             |
| [`44738ee0`](https://github.com/NixOS/nixpkgs/commit/44738ee079bf4e301844befc69c3e66bf6b73d2e) | `python310Packages.wcmatch: 8.4 -> 8.4.1`                                              |
| [`17db09f6`](https://github.com/NixOS/nixpkgs/commit/17db09f61706d94f8af5cfefb48e138672b014be) | `ibus-engines.libpinyin: 1.13.0 -> 1.13.1`                                             |
| [`f140b549`](https://github.com/NixOS/nixpkgs/commit/f140b5491638c3cbcce079f56b46982428fb7b93) | `dockerTools: add missing mkdir to caCertificates derivation`                          |
| [`00c49ccc`](https://github.com/NixOS/nixpkgs/commit/00c49ccce94574f4d0ced4e4dc8bb5a9d084226f) | `docker-compose: 2.11.0 -> 2.11.1`                                                     |
| [`07e9c317`](https://github.com/NixOS/nixpkgs/commit/07e9c317b4739a7c2337f58191dcb853c6a46a49) | `firefox-bin: 104.0.2 -> 105.0`                                                        |
| [`ab24bf4d`](https://github.com/NixOS/nixpkgs/commit/ab24bf4de24b207be970f3c0449f3ab0999fc6ce) | `xidel: fix openssl connections`                                                       |
| [`047c16f6`](https://github.com/NixOS/nixpkgs/commit/047c16f61f6dcf5a7468787db0a09508577d6ff2) | `libgit2: drop flag that was renamed`                                                  |
| [`58ba2835`](https://github.com/NixOS/nixpkgs/commit/58ba28355501849635bc5d41c11bc07f55a3f9ab) | `freeswitch: Fix build error`                                                          |
| [`f559d89c`](https://github.com/NixOS/nixpkgs/commit/f559d89cd03c7fa9cea1b534e97a20d1f9b1fb13) | `firefox-esr-102-unwrapped: 102.2.0esr -> 102.3.0esr`                                  |
| [`11b3d696`](https://github.com/NixOS/nixpkgs/commit/11b3d696526c97246a9cc5b2aaa42a0acf7bed8d) | `firefox-unwrapped: 104.0.2 -> 105.0`                                                  |
| [`d8299e68`](https://github.com/NixOS/nixpkgs/commit/d8299e685555a0744ddcddaa993153d4e3fe44c7) | `checkSSLCert: 2.44.0 -> 2.45.0`                                                       |
| [`bfdba53e`](https://github.com/NixOS/nixpkgs/commit/bfdba53e1e23cc0792dede26c5bb93168de0b9cd) | `cdk-go: 1.4.0 -> 1.4.1`                                                               |
| [`e14c5632`](https://github.com/NixOS/nixpkgs/commit/e14c56324b72616e5567c9bd06ca6ddc50481c38) | `python310Packages.ocifs: 1.1.2 -> 1.1.3`                                              |
| [`434f4306`](https://github.com/NixOS/nixpkgs/commit/434f4306860d51e602413b0eecfc90737d1f14f1) | `python310Packages.pynx584: 0.8 -> 0.8.1`                                              |
| [`d8646a70`](https://github.com/NixOS/nixpkgs/commit/d8646a704e06c298738eab6bdc9e0361a98d816b) | `klipper: patchPhase -> postPatch, little cleanups`                                    |
| [`c96dd1d3`](https://github.com/NixOS/nixpkgs/commit/c96dd1d30a9a245b15800b1abb5128af1bbe3e30) | `dyff: add jceb as maintainer`                                                         |
| [`11804e7a`](https://github.com/NixOS/nixpkgs/commit/11804e7aeba177dd239487af8e4d7fdc329be45d) | `python310Packages.overpy: init at 0.6`                                                |
| [`e15bc1fa`](https://github.com/NixOS/nixpkgs/commit/e15bc1fadd20ea3a17d23f06dbc1df14b4b73bd5) | `prl-tools: 18.0.1-53056 -> 18.0.2-53077`                                              |
| [`5783f096`](https://github.com/NixOS/nixpkgs/commit/5783f096f38521e7021fe13c0f024a5fee446941) | `explain: init at 1.4`                                                                 |
| [`f76ab1db`](https://github.com/NixOS/nixpkgs/commit/f76ab1db42acb4b11243121564aa538c606dcf12) | `RStudio: 2022.02.3+492 -> 2022.07.1.+554 (#185154)`                                   |
| [`575d83db`](https://github.com/NixOS/nixpkgs/commit/575d83db506213021948b7a4530b579883c35eac) | `silenthound: init at unstable-2022-09-02`                                             |
| [`bb20be09`](https://github.com/NixOS/nixpkgs/commit/bb20be09df5938565ddb4d3175b8f4a951b1d1fc) | `python310Packages.pyxbe: 1.0.0 -> 1.0.1`                                              |
| [`7fe7d865`](https://github.com/NixOS/nixpkgs/commit/7fe7d86527c92b6c946c9c504272d13d506830ae) | `python310Packages.velbus-aio: 20212.6.2 -> 2022.9.1`                                  |
| [`d3169ad4`](https://github.com/NixOS/nixpkgs/commit/d3169ad410a80c96bafc40b3438903e236a76aef) | `intel-gmmlib: 22.1.8 -> 22.2.0`                                                       |
| [`d55f0d21`](https://github.com/NixOS/nixpkgs/commit/d55f0d2103fe25b6e457d8dd46bdb37719006ffb) | `esbuild: 0.15.7 -> 0.15.8`                                                            |
| [`ff39fdaa`](https://github.com/NixOS/nixpkgs/commit/ff39fdaa72bf312a16b77a4f4d656bf4f9733c68) | `pyupgrade: 2.37.3 -> 2.38.0`                                                          |
| [`00e586af`](https://github.com/NixOS/nixpkgs/commit/00e586af2da0b0c1bbd1b20acc25722cc58eacb5) | `buf: 1.7.0 -> 1.8.0`                                                                  |