### PR TITLE
chore(flake/home-manager): `bd83eab6` -> `de3758e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1663835995,
-        "narHash": "sha256-XNHQ+mdHbjNR1Oit00SFAEcrAZoCS08E7uAFcVMtwhM=",
+        "lastModified": 1663932797,
+        "narHash": "sha256-IH8ZBW99W2k7wKLS+Sat9HiKX1TPZjFTnsPizK5crok=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bd83eab6220226085c82e637931a7ae3863d9893",
+        "rev": "de3758e31a3a1bc79d569f5deb5dac39791bf9b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`de3758e3`](https://github.com/nix-community/home-manager/commit/de3758e31a3a1bc79d569f5deb5dac39791bf9b6) | `neovim: fix a typo in the generated init.lua (#3252)` |