### PR TITLE
chore(flake/nixpkgs): `d6490a0b` -> `ae1dc133`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1663761423,
-        "narHash": "sha256-bDLXl2BVq7eIQz/8CduZI1SLyhG9u/CrckHd6f7bwPE=",
+        "lastModified": 1663850217,
+        "narHash": "sha256-tp9nXo1/IdN/xN9m06ryy0QUAEfoN6K56ObM/1QTAjc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d6490a0bd9dfb298fcd8382d3363b86870dc7340",
+        "rev": "ae1dc133ea5f1538d035af41e5ddbc2ebcb67b90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                               |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`9e02095f`](https://github.com/NixOS/nixpkgs/commit/9e02095f4ebf30eaf3291bca1e495e475e0a0784) | `Python docs: document attribute to use for non-PyPI projects`                               |
| [`a14d81d4`](https://github.com/NixOS/nixpkgs/commit/a14d81d4df78b40558a5d3d0754690dbc0821a54) | `esphome: 2022.8.3 -> 2022.9.1`                                                              |
| [`0b8f8145`](https://github.com/NixOS/nixpkgs/commit/0b8f8145afb89212b526255217f8b17693bcf23f) | `python310Packages.pontos: 22.8.1 -> 22.9.0`                                                 |
| [`16bb7a83`](https://github.com/NixOS/nixpkgs/commit/16bb7a838f85e21516acca9da7f2b0b3221fe0c6) | `gradle: cleanup (#169566)`                                                                  |
| [`584a111f`](https://github.com/NixOS/nixpkgs/commit/584a111fe1e81b44b56df6ab2cbc2fc46d39555c) | `quickemu: 4.0 -> 4.3`                                                                       |
| [`29a549ed`](https://github.com/NixOS/nixpkgs/commit/29a549ed5eeef0d893f63c5aa9709b3b0efccb3e) | `python310Packages.mwdblib: 4.3.0 -> 4.3.1`                                                  |
| [`0ea6aaa1`](https://github.com/NixOS/nixpkgs/commit/0ea6aaa12d58ffdf1dafa63642be8b2192f5f8f8) | `python310Packages.pyfritzhome: 0.6.5 -> 0.6.7`                                              |
| [`9e1ae4de`](https://github.com/NixOS/nixpkgs/commit/9e1ae4de0d4cc36940b7ed1df80fa9d46937c81a) | `zef: 0.13.8 -> 0.14.2`                                                                      |
| [`e21f62e0`](https://github.com/NixOS/nixpkgs/commit/e21f62e0998e12fb6dc9c3d18b95b3a3b2bed46a) | `nearcore: 1.28.1 -> 1.29.0`                                                                 |
| [`161cd657`](https://github.com/NixOS/nixpkgs/commit/161cd6572bb3a8da8dcd3e3ee61fc1655d0de25b) | `ventoy-bin: 1.0.79 -> 1.0.80`                                                               |
| [`2bf91a61`](https://github.com/NixOS/nixpkgs/commit/2bf91a61574f2ea6353080b4abc824606af52e72) | `stylua: 0.14.3 -> 0.15.0 (#192279)`                                                         |
| [`f586d35a`](https://github.com/NixOS/nixpkgs/commit/f586d35a11ec07ced41d9d62c125c6ca0006141f) | `mimir: 2.2.0 -> 2.3.0`                                                                      |
| [`86fcecb2`](https://github.com/NixOS/nixpkgs/commit/86fcecb236b8afa855b3155a45f8263dffdeae3e) | `redpanda: 22.2.2 -> 22.2.3`                                                                 |
| [`f806bb1a`](https://github.com/NixOS/nixpkgs/commit/f806bb1aaf33fe65da55526d6e59d134fdba5fa2) | `snappymail: 2.17.3 -> 2.18.1`                                                               |
| [`c79ebd3a`](https://github.com/NixOS/nixpkgs/commit/c79ebd3a9d8105191b3f063f6aad967ca1fbf2a5) | `regbot: 0.4.4 -> 0.4.5`                                                                     |
| [`ee495c93`](https://github.com/NixOS/nixpkgs/commit/ee495c933a2995e801dbfd22ae5e6c99daf00740) | `sgtpuzzles: 20220802 -> 20220913`                                                           |
| [`c8554deb`](https://github.com/NixOS/nixpkgs/commit/c8554deb5003c55a197effbad4b515420415e7b4) | `gvisor: 20220905.0 -> 20220919.0`                                                           |
| [`9c8c7f4d`](https://github.com/NixOS/nixpkgs/commit/9c8c7f4dd9b4efb0ae0c00df3c7770154bc47d7b) | `.github/labeler.yml: add vscode label`                                                      |
| [`2b6c72e1`](https://github.com/NixOS/nixpkgs/commit/2b6c72e17306cb57b97ab1e26bb4c7a42ba1e430) | `python3Packages.shapely: 1.8.2 -> 1.8.4`                                                    |
| [`8ca03000`](https://github.com/NixOS/nixpkgs/commit/8ca030000ab44ada208dd41ae7ea04efdd7ed9c0) | `mpd-discord-rpc: 1.5.2 -> 1.5.3`                                                            |
| [`85e38189`](https://github.com/NixOS/nixpkgs/commit/85e38189c25dad2ec9c7dd7c3ba6c0d81328cb13) | `monero-cli: 0.18.1.0 -> 0.18.1.1`                                                           |
| [`2bd070cb`](https://github.com/NixOS/nixpkgs/commit/2bd070cbacd3b488ca34eef7d1df3cbb968351ee) | `monero-gui: 0.18.1.0 -> 0.18.1.1`                                                           |
| [`2e6a924b`](https://github.com/NixOS/nixpkgs/commit/2e6a924b5a37d352f5a816756c958e5a434a1ff0) | `metal-cli: install completion`                                                              |
| [`57d7a93a`](https://github.com/NixOS/nixpkgs/commit/57d7a93a14e9435279b9d046b761aed5a6d5d29a) | `python310Packages.ormar: 0.11.2 -> 0.11.3`                                                  |
| [`e49d3e15`](https://github.com/NixOS/nixpkgs/commit/e49d3e152f3368b953c4b7791914fe10c38072ef) | `modsecurity-crs: 3.3.2 -> 3.3.4`                                                            |
| [`62941552`](https://github.com/NixOS/nixpkgs/commit/6294155267077ac0bcd8e698640516f5dc3eadc6) | `mod: 0.4.2 -> 0.4.3`                                                                        |
| [`2c3ba347`](https://github.com/NixOS/nixpkgs/commit/2c3ba347fe76d7df9f9de3c1e83915b88203e6af) | `python310Packages.adlfs: 2022.7.0 -> 2022.9.1`                                              |
| [`05360e42`](https://github.com/NixOS/nixpkgs/commit/05360e421735c8cf411c350eb6d1d15f2b2a16c8) | `python310Packages.aliyun-python-sdk-iot: 8.42.0 -> 8.44.0`                                  |
| [`2a22e452`](https://github.com/NixOS/nixpkgs/commit/2a22e4526f27b7200713b7379ef4432fb805519b) | `python310Packages.aliyun-python-sdk-cdn: 3.7.2 -> 3.7.5`                                    |
| [`e325cbda`](https://github.com/NixOS/nixpkgs/commit/e325cbdaa284e056b256a7ad113340285901a192) | `metal-cli: 0.9.0 -> 0.9.1`                                                                  |
| [`85318cd6`](https://github.com/NixOS/nixpkgs/commit/85318cd6365cddaedaf9b59c63dc35b865ed9013) | `macchina: 6.1.4 -> 6.1.5`                                                                   |
| [`ce187489`](https://github.com/NixOS/nixpkgs/commit/ce18748983e21a51de91a1648263fc2d30dd1d1c) | `lightningcss: 1.15.1 -> 1.16.0`                                                             |
| [`cb7b71a6`](https://github.com/NixOS/nixpkgs/commit/cb7b71a6b671a8838dfeeefe1e6a88bf5ced0336) | `kapp: 0.52.0 -> 0.53.0`                                                                     |
| [`86c51f68`](https://github.com/NixOS/nixpkgs/commit/86c51f68bccbdd89a16a179c661e02ec7d2b544e) | `nixos/neovim: fix remote plugin manifest generation (#191852)`                              |
| [`25bb19c0`](https://github.com/NixOS/nixpkgs/commit/25bb19c0202bba53cb0bf78aee706186d4f02093) | `gh: 2.15.0 -> 2.16.0`                                                                       |
| [`ccc3fc3b`](https://github.com/NixOS/nixpkgs/commit/ccc3fc3b52bd7683cb188d3f79286d162695ee5e) | `exploitdb: 2022-09-16 -> 2022-09-21`                                                        |
| [`b80dc365`](https://github.com/NixOS/nixpkgs/commit/b80dc365f0cdb9f3102e30ef0e826a5f0fbca6d5) | `gitstatus: set platforms.all`                                                               |
| [`8badd47c`](https://github.com/NixOS/nixpkgs/commit/8badd47ce9935a4e2784a39147004c6500bdc036) | `libamqpcpp: 4.3.17 -> 4.3.18`                                                               |
| [`d7962fe1`](https://github.com/NixOS/nixpkgs/commit/d7962fe15ca9aa8f21f06c9bc6681c23deea6ab1) | `kubernetes-controller-tools: 0.9.2 -> 0.10.0`                                               |
| [`d7c17f17`](https://github.com/NixOS/nixpkgs/commit/d7c17f1721f3559a07b2b32012438ff0d9761367) | `krapslog: 0.4.0 -> 0.4.1`                                                                   |
| [`ef6303dc`](https://github.com/NixOS/nixpkgs/commit/ef6303dc92ab9c5acaec7705e4d96fe00677fc47) | `konf: 0.2.0 -> 0.3.0`                                                                       |
| [`9da04518`](https://github.com/NixOS/nixpkgs/commit/9da04518972fd061ecddd8616381f7727a12b0b9) | `interactsh: 1.0.6 -> 1.0.7`                                                                 |
| [`1dbdb423`](https://github.com/NixOS/nixpkgs/commit/1dbdb423375f2a3949a9b25133d9cdd6020a0da8) | `tfsec: 1.27.6 -> 1.28.0`                                                                    |
| [`fee7c835`](https://github.com/NixOS/nixpkgs/commit/fee7c835876b8b899d8858cdfbf6b4ebbd5681fa) | `cctz: fix static build`                                                                     |
| [`24e576a7`](https://github.com/NixOS/nixpkgs/commit/24e576a7f5786cb710168ff34efd9a2baff3e1ac) | `python310Packages.deep-translator: 1.8.3 -> 1.9.0`                                          |
| [`e2f9df09`](https://github.com/NixOS/nixpkgs/commit/e2f9df093a9c5cead7b0f38ef937bd2f81677716) | `ocamlPackages.mimic: 0.0.4 -> 0.0.5`                                                        |
| [`666ed16e`](https://github.com/NixOS/nixpkgs/commit/666ed16e091d80d6dfdb6e4c5e3bc56b3a0fea94) | `ocamlPackages.happy-eyeballs: 0.1.2 -> 0.3.0`                                               |
| [`69a8546f`](https://github.com/NixOS/nixpkgs/commit/69a8546f6b8114a44245a2f29cd12a9ad0d91069) | `gokart: 0.4.0 -> 0.5.0`                                                                     |
| [`5f992ee5`](https://github.com/NixOS/nixpkgs/commit/5f992ee55e57f1ef5e48c2aa2b9221ec0afaf48c) | `gitoxide: 0.15.0 -> 0.16.0`                                                                 |
| [`304bde44`](https://github.com/NixOS/nixpkgs/commit/304bde447e925d51957c2a478b56a662a3f77997) | `glooctl: 1.12.20 -> 1.12.21`                                                                |
| [`718d77d3`](https://github.com/NixOS/nixpkgs/commit/718d77d3b84ab78ec92899bb818d061eb6e269bc) | `git-cliff: 0.9.0 -> 0.9.1`                                                                  |
| [`aa05eb75`](https://github.com/NixOS/nixpkgs/commit/aa05eb75d607e8284ebca15536dbc95631ed0767) | `flow: 0.187.0 -> 0.187.1`                                                                   |
| [`f7f334cb`](https://github.com/NixOS/nixpkgs/commit/f7f334cb156c742a43825f4a861276e130f6e964) | `kubernetes-helm: 3.9.4 -> 3.10.0`                                                           |
| [`0e1b0bdf`](https://github.com/NixOS/nixpkgs/commit/0e1b0bdfa89f458bb03156bb9b65daa5d81ca32c) | `cargo-vet: init at 0.3.0`                                                                   |
| [`bac3ea77`](https://github.com/NixOS/nixpkgs/commit/bac3ea7729eef04fdf4174f891a1327b1d96be6d) | `faas-cli: 0.14.6 -> 0.14.7`                                                                 |
| [`6b891f47`](https://github.com/NixOS/nixpkgs/commit/6b891f4788a302f9e847e808b32780066b268864) | `nixos/listmonk: init module`                                                                |
| [`944c6691`](https://github.com/NixOS/nixpkgs/commit/944c6691fc7e7a49f3980f252eb8c184a534a4b2) | ``aws: remove, recommend `awscli` / `awscli2` (#176707)``                                    |
| [`7e058ceb`](https://github.com/NixOS/nixpkgs/commit/7e058ceb6f232275ed95820b31329e67969cce16) | `haskellPackages: mark builds failing on hydra as broken`                                    |
| [`7cc305fa`](https://github.com/NixOS/nixpkgs/commit/7cc305fa594353ef5084dae6329d2646d6789513) | `pdns-recursor: 4.7.2 -> 4.7.3`                                                              |
| [`c4bb5315`](https://github.com/NixOS/nixpkgs/commit/c4bb5315d3c7b8a2c48cfff0b489efb8928510dc) | `lighttpd: 1.4.66 -> 1.4.67`                                                                 |
| [`b2532132`](https://github.com/NixOS/nixpkgs/commit/b2532132fdc5ab4afcf9d39fbc7fb9cba2d966d2) | `pythonPackages.elasticsearch: Remove notice about breakage`                                 |
| [`bc5a8468`](https://github.com/NixOS/nixpkgs/commit/bc5a8468514170cac588c2ece88af7411674f90c) | `haskellPackages.ghcide-bench: dontCheck`                                                    |
| [`0ba6b83d`](https://github.com/NixOS/nixpkgs/commit/0ba6b83dd3200858f0ea2860e54248de2129a0c8) | `maintainers: add quasigod-io`                                                               |
| [`b0e0e80d`](https://github.com/NixOS/nixpkgs/commit/b0e0e80ddc637603482cebe4c17d7ea87b765a8c) | `nitch: init at 0.1.6`                                                                       |
| [`c8608fa5`](https://github.com/NixOS/nixpkgs/commit/c8608fa54024d3d441fea0c42febc6778283f678) | `terraform: 1.2.9 -> 1.3.0`                                                                  |
| [`39a02ce0`](https://github.com/NixOS/nixpkgs/commit/39a02ce041750f27bc55ad4d38125f40fc7793eb) | `haskell.compiler: Don‘t filter redundant major version jobs`                                |
| [`122c0829`](https://github.com/NixOS/nixpkgs/commit/122c082943c204516c86187ad5a61de894befa10) | `haskell.pkgsStatic: Fix missing minor version for hydr checks`                              |
| [`413c67c9`](https://github.com/NixOS/nixpkgs/commit/413c67c96d3802941d3d1443813df9b7fad170b8) | `haskell.compiler.native-bignum: Readd missing minor versions`                               |
| [`9cb8ee31`](https://github.com/NixOS/nixpkgs/commit/9cb8ee31ef408077f46b4e4f8469ef4769512323) | `mapserver: 7.6.4 -> 8.0.0`                                                                  |
| [`188ea7b8`](https://github.com/NixOS/nixpkgs/commit/188ea7b8c83d2b66ebdbabfca1e560da895ff25a) | `haskell.packages: Revert to minor version test names`                                       |
| [`7c0e02bf`](https://github.com/NixOS/nixpkgs/commit/7c0e02bfe73477e6093f659d1939e86bcbab6a87) | `erigon: 2022.09.02 -> 2022.09.03`                                                           |
| [`26ffd2dc`](https://github.com/NixOS/nixpkgs/commit/26ffd2dc0ae4cf685e45fb204508bc199119309b) | `ergo: 4.0.42 -> 4.0.45`                                                                     |
| [`1ef96c2f`](https://github.com/NixOS/nixpkgs/commit/1ef96c2f2453385f543a8042f63afe48e58183f5) | `ocamlPackages.dns: 6.1.4 -> 6.3.0`                                                          |
| [`bdcbbc7b`](https://github.com/NixOS/nixpkgs/commit/bdcbbc7bd29cbd7f1ad3abc039e506b3991aaf28) | `haskell-language-server: Default toplevel attribute to dynamic linking and one ghc version` |
| [`2cd8c29a`](https://github.com/NixOS/nixpkgs/commit/2cd8c29a758383d5fbe831193dff30c0defc06ec) | `eventstore: add updateScript`                                                               |
| [`49c63622`](https://github.com/NixOS/nixpkgs/commit/49c6362244b5791b1f242b155ceea09ce6bccd77) | `eventstore: 21.10.5 -> 22.6.0`                                                              |
| [`b6f1e6a1`](https://github.com/NixOS/nixpkgs/commit/b6f1e6a1b26174624e1ef9127710b4d96a74ee53) | `haskell.packages: Show minor version in test names`                                         |
| [`371ae1a0`](https://github.com/NixOS/nixpkgs/commit/371ae1a052165d5efade459bb0ce3148c81a9c2f) | `doctl: 1.79.0 -> 1.81.0`                                                                    |
| [`8a624023`](https://github.com/NixOS/nixpkgs/commit/8a62402394ec38e43d8030ff7735bb533f96b8f7) | `dnsproxy: 0.44.0 -> 0.45.0`                                                                 |
| [`8f6f79f4`](https://github.com/NixOS/nixpkgs/commit/8f6f79f43783b8c600382797798070194db4a8a4) | `microsoft-edge: 104.0.1293.54 -> 105.0.1343.42`                                             |
| [`54ce4e4e`](https://github.com/NixOS/nixpkgs/commit/54ce4e4eaaa5796f11149f18f927d8cea8bb7464) | `game-music-emu: to pkgs/development/libraries`                                              |
| [`e5f798f3`](https://github.com/NixOS/nixpkgs/commit/e5f798f3b98ad370c9b7c8380de54c86549bbf18) | `nixos/lemmy: use PostgreSQL module to ensure database/user existence`                       |
| [`3de898f2`](https://github.com/NixOS/nixpkgs/commit/3de898f26272c261b4e186bc8744080e22019068) | `nixos/lemmy: inline localPostgres into database assertion`                                  |
| [`7afd5b20`](https://github.com/NixOS/nixpkgs/commit/7afd5b20b2d6c9e32ecc02d72b91eec4685ae395) | `python310Packages.aioprocessing: 2.0.0 -> 2.0.1`                                            |
| [`10e8e2b3`](https://github.com/NixOS/nixpkgs/commit/10e8e2b32241d958c71fd35b3ddb152f0b51d4ad) | `python310Packages.angr: 9.2.18 -> 9.2.19`                                                   |
| [`dd5bce02`](https://github.com/NixOS/nixpkgs/commit/dd5bce02f32f9d2e6a609ddd7f97f245697fd5cc) | `python310Packages.cle: 9.2.18 -> 9.2.19`                                                    |
| [`9c8760fd`](https://github.com/NixOS/nixpkgs/commit/9c8760fd90becf4ad84687887e6b2c953c180d1c) | `python310Packages.claripy: 9.2.18 -> 9.2.19`                                                |
| [`b2dd2e66`](https://github.com/NixOS/nixpkgs/commit/b2dd2e66ca716c76a9df9599a4f8de8da81b5f57) | `python310Packages.pyvex: 9.2.18 -> 9.2.19`                                                  |
| [`4a697885`](https://github.com/NixOS/nixpkgs/commit/4a697885ea58022092a9ffdefcc912843c117318) | `python310Packages.ailment: 9.2.18 -> 9.2.19`                                                |
| [`e5625ffe`](https://github.com/NixOS/nixpkgs/commit/e5625ffe447feb7c0ae647d04c3352b1327fbfdf) | `python310Packages.archinfo: 9.2.18 -> 9.2.19`                                               |
| [`14384cf3`](https://github.com/NixOS/nixpkgs/commit/14384cf3cae6bbd85224e438ffead3136ae36eb6) | `knot-resolver: 5.5.2 -> 5.5.3`                                                              |
| [`9b454809`](https://github.com/NixOS/nixpkgs/commit/9b454809d3e59e6073a614a21f339b8d38824967) | `infra: init at 0.15.1`                                                                      |
| [`e6b5dc2e`](https://github.com/NixOS/nixpkgs/commit/e6b5dc2eeb72eeee43bdc2f06679a1e1de6bbc5b) | `checkSSLCert: 2.45.0 -> 2.46.0`                                                             |
| [`0e40d1f4`](https://github.com/NixOS/nixpkgs/commit/0e40d1f469838fd692b2e572035bcd7b92e4032c) | `changie: 1.9.0 -> 1.9.1`                                                                    |
| [`cabf66ee`](https://github.com/NixOS/nixpkgs/commit/cabf66eefaffdc3e2faf63e081934f2c5587125a) | `pkgsMusl.game-music-emu: fix build`                                                         |
| [`21bc002b`](https://github.com/NixOS/nixpkgs/commit/21bc002b61377b2603c18a47ecf922c747934951) | `pkgsMusl.python3.pkgs.watchdog: fix build`                                                  |
| [`88cb8dd0`](https://github.com/NixOS/nixpkgs/commit/88cb8dd07d5a124afdc494d48b87e882a10558dc) | `thunderbird-bin: 102.2.2 -> 102.3.0`                                                        |
| [`7286bad3`](https://github.com/NixOS/nixpkgs/commit/7286bad3a91710bbc64b3b4ec07fcfe236b6984f) | `kubebuilder: 3.6.0 -> 3.7.0`                                                                |
| [`9fd75b45`](https://github.com/NixOS/nixpkgs/commit/9fd75b45a0e47f72c04c24ca1d8b730d90d3606b) | `kubevirt: 0.56.1 -> 0.57.0`                                                                 |
| [`6cf481e2`](https://github.com/NixOS/nixpkgs/commit/6cf481e230d1738e49e064ae354b1ea3c8452a28) | `jython: 2.7.2b3 -> 2.7.3`                                                                   |
| [`51204ac6`](https://github.com/NixOS/nixpkgs/commit/51204ac656e14ab04b1346b7e6578e977496fb37) | `jruby: 9.3.7.0 -> 9.3.8.0`                                                                  |
| [`44d3703d`](https://github.com/NixOS/nixpkgs/commit/44d3703d62e635ea0b39f8a25c60d179c3217b67) | `thunderbird-unwrapped: 102.2.2 -> 102.3.0`                                                  |
| [`b6d0414b`](https://github.com/NixOS/nixpkgs/commit/b6d0414b229541c79597b0abdfb302412897f3d9) | `ldapnomnom: init at unstable-2022-09-18`                                                    |
| [`6de2d274`](https://github.com/NixOS/nixpkgs/commit/6de2d274fb51accc8a4ad2b8cf30b74c7f29e4e2) | `optifinePackages: update versions, refactor version generation`                             |
| [`7b145aaf`](https://github.com/NixOS/nixpkgs/commit/7b145aaf9bac7e19655ddf42019a7ac6abd0a961) | `gopass-summon-provider: 1.14.6 → 1.14.7`                                                    |
| [`71392911`](https://github.com/NixOS/nixpkgs/commit/71392911b0d3aaad142911f381182ffd12c0617c) | `gopass-jsonapi: 1.14.6 → 1.14.7`                                                            |
| [`e1d61de7`](https://github.com/NixOS/nixpkgs/commit/e1d61de7a8f7d6fc531a30f51ba224bd34fb9b9c) | ``yubikey-manager: set `meta.mainProgram```                                                  |
| [`60b61935`](https://github.com/NixOS/nixpkgs/commit/60b61935ad6be949e4272429653299e1529b2e18) | `linuxPackages.nvidia_x11: 515.65.01 -> 515.76`                                              |
| [`ea93f058`](https://github.com/NixOS/nixpkgs/commit/ea93f058d1c4ab10885f76b51ceddd4570e73de8) | `hugo: 0.103.0 -> 0.103.1`                                                                   |
| [`b2b29930`](https://github.com/NixOS/nixpkgs/commit/b2b29930cc5b7379d9ce4e9e2be0c1fc9defaf42) | `grcov: 0.8.11 -> 0.8.12`                                                                    |
| [`772ea71e`](https://github.com/NixOS/nixpkgs/commit/772ea71e2c603f3d0ba05e962651fbf6c2746f26) | `haskellPackages: mark builds failing on hydra as broken`                                    |
| [`0c94297c`](https://github.com/NixOS/nixpkgs/commit/0c94297c2b05d32fe478c81193fdde917f549f9b) | `gopass-hibp: 1.14.6 → 1.14.7`                                                               |
| [`84df22f6`](https://github.com/NixOS/nixpkgs/commit/84df22f64031e0189ceb9f8d863c3e7a121bd411) | `git-credential-gopass: 1.14.6 → 1.14.7`                                                     |
| [`dd8c6e41`](https://github.com/NixOS/nixpkgs/commit/dd8c6e41d1811da009b7f98b22c3c2d417ec7603) | `gopass: 1.14.6 → 1.14.7`                                                                    |
| [`352da0ce`](https://github.com/NixOS/nixpkgs/commit/352da0ce3117965dc5b2c460ceddd520549b99d2) | `haskellPackages.hlint: Fix plugin and ghc924 jobs`                                          |
| [`fae2ff5c`](https://github.com/NixOS/nixpkgs/commit/fae2ff5c035231ea858f9fa6f712e50143db0899) | `haskell.{compiler,packages}: Add aliases without minor versions`                            |
| [`7c2fda45`](https://github.com/NixOS/nixpkgs/commit/7c2fda45cc67990994ee160309fb5ed2e8425ff3) | `haskell-language-server: 1.7.0.0 -> 1.8.0.0`                                                |
| [`a7d50b4e`](https://github.com/NixOS/nixpkgs/commit/a7d50b4e0988e4f53d2d3629c7b5f57c2736480f) | `haskellPackages.ghcup: Remove override for defunct package`                                 |
| [`6a3d7aeb`](https://github.com/NixOS/nixpkgs/commit/6a3d7aeb8e05683be2902fc3aff553ce9c78dfe4) | `k3s: fix cross compilation`                                                                 |
| [`e678b769`](https://github.com/NixOS/nixpkgs/commit/e678b769bc88738c70db57befba5c08075e391d3) | `hedgewars: disable on darwin`                                                               |
| [`2a5b10b8`](https://github.com/NixOS/nixpkgs/commit/2a5b10b81d625fb4f57bc499e9d0db654306ba86) | `stack: get 2.9.1 building`                                                                  |
| [`357e6335`](https://github.com/NixOS/nixpkgs/commit/357e6335ed33f85e3c2a7897e2fb7085eac39f30) | `superTux: set meta.mainProgram`                                                             |
| [`33944d5d`](https://github.com/NixOS/nixpkgs/commit/33944d5ddd7ddfb841248c77f45c46d2228d21a8) | `openssl: fix static cross compilation`                                                      |
| [`b160e51c`](https://github.com/NixOS/nixpkgs/commit/b160e51cc82059a793cd40b276b7fdfa0336b92c) | `linode-cli: 5.22.0 -> 5.23.0`                                                               |
| [`fcfdc8b5`](https://github.com/NixOS/nixpkgs/commit/fcfdc8b58e4f3ede82b63721ceec4b8d3d7ca853) | `ginac: 1.8.3 -> 1.8.4`                                                                      |
| [`f0c3d89c`](https://github.com/NixOS/nixpkgs/commit/f0c3d89c03b902f2cb5f405f348ae49f3cb7903d) | `teams: 1.5.00.10453 -> 1.5.00.23861 (linux), 1.5.00.22362 (darwin)`                         |
| [`161a30b7`](https://github.com/NixOS/nixpkgs/commit/161a30b76a660091ecb6cbc988e9fbb79f9f8430) | `haskellPackages: regenerate package set based on current config`                            |
| [`cbb22921`](https://github.com/NixOS/nixpkgs/commit/cbb22921dbf0b48ede636d816ad1b64cef13ce1c) | `haskellPackages.hie-bios: Remove unused 0.5.0 override`                                     |
| [`6f241f7c`](https://github.com/NixOS/nixpkgs/commit/6f241f7cec70bbacd6cb3e4c672987e09fb74e9d) | `haskellPackages: Move permanent overrides to configuration.nix`                             |
| [`2d4bd889`](https://github.com/NixOS/nixpkgs/commit/2d4bd8892f169f1755920bd5407c9c1a4dad14e9) | `haskellPackages: Bump hspec versions`                                                       |
| [`25cb4918`](https://github.com/NixOS/nixpkgs/commit/25cb49180fac6c5efc59a98baa00fcdb8e342f24) | `all-cabal-hashes: 2022-09-18T11:31:48Z -> 2022-09-19T12:29:18Z`                             |
| [`89ce25ef`](https://github.com/NixOS/nixpkgs/commit/89ce25efe9f942e2d77d477a6a7f0c8377342bdc) | `mariadb: also use openssl_3 for 10.7 and 10.6`                                              |
| [`1b875554`](https://github.com/NixOS/nixpkgs/commit/1b8755548c5c77ef4cd8246eb0fffaee7f61aa9c) | `mariadb_106: 10.6.9 -> 10.6.10`                                                             |
| [`0f1042de`](https://github.com/NixOS/nixpkgs/commit/0f1042dec114f587a44f4eb59cc04794e1143215) | `mariadb_107: 10.7.5 -> 10.7.6`                                                              |
| [`d563e5c1`](https://github.com/NixOS/nixpkgs/commit/d563e5c1e0a8cb6ecf40243f17e0bca433911c43) | `mariadb_108: 10.8.4 -> 10.8.5`                                                              |
| [`137d846c`](https://github.com/NixOS/nixpkgs/commit/137d846cbb4095c58a69486434d0942b421a9cdf) | `mariadb_109: 10.9.2 -> 10.9.3`                                                              |
| [`f604bbc9`](https://github.com/NixOS/nixpkgs/commit/f604bbc9cef2ff7b9013330e1c9fd744a0d6af70) | `haskellPackages: regenerate package set based on current config`                            |
| [`284e415b`](https://github.com/NixOS/nixpkgs/commit/284e415ba044bf0946df510e219019c0a9c16c9e) | `all-cabal-hashes: 2022-09-11T02:31:18Z -> 2022-09-18T11:31:48Z`                             |
| [`7a40af75`](https://github.com/NixOS/nixpkgs/commit/7a40af75d634c9f349408b7109b3e82264bdbc3d) | `haskellPackages: stackage LTS 19.22 -> LTS 19.23`                                           |
| [`dd6727e7`](https://github.com/NixOS/nixpkgs/commit/dd6727e7b8a346f573770b5f9916914ccf919068) | `linux/hardened/5.19: fix build`                                                             |
| [`073f7b17`](https://github.com/NixOS/nixpkgs/commit/073f7b179c18ec771d3a3bd06aba16a8de70dfcc) | `nixos/kernel-generic: build linux_5_19_hardened`                                            |
| [`80228b73`](https://github.com/NixOS/nixpkgs/commit/80228b73e9cf9f8dd266ae58c2eeb7b554a2ddd2) | `linux-hardened: fix update script`                                                          |
| [`c2d301f7`](https://github.com/NixOS/nixpkgs/commit/c2d301f7af8c9dd1cca195540a2132c0693687ea) | `linux/hardened/patches/5.19: 5.19.8-hardened1 -> 5.19.8-hardened2`                          |
| [`b3dc6e35`](https://github.com/NixOS/nixpkgs/commit/b3dc6e35e018328a654f8669767e064f9fd7d00d) | `linux_latest-libre: 18911 -> 18916`                                                         |
| [`a8ed6141`](https://github.com/NixOS/nixpkgs/commit/a8ed6141128502fc806de13e57d2982199a4a261) | `tdesktop: update maintainers`                                                               |
| [`d7ecc086`](https://github.com/NixOS/nixpkgs/commit/d7ecc08655164f169d540e329cced7b4b9679021) | `tdesktop: 4.1.1 -> 4.2.0`                                                                   |
| [`71c0edef`](https://github.com/NixOS/nixpkgs/commit/71c0edefedada04459a807043df9c66e80df7c1d) | `qt6Packages.kcoreaddons: init`                                                              |
| [`d6496a13`](https://github.com/NixOS/nixpkgs/commit/d6496a13efd317a41ab795e1abecfeb850e42db4) | `rr-unstable: remove`                                                                        |
| [`f0cb5389`](https://github.com/NixOS/nixpkgs/commit/f0cb53892fddcdc33407ce5be94bbaadd08bd548) | `xfce.xfce4-windowck-plugin: 0.4.10 -> 0.5.0`                                                |
| [`2fcdcc75`](https://github.com/NixOS/nixpkgs/commit/2fcdcc75bf2218a457220d860931c07e8a6ab48b) | `python3Packages.apache-airflow: remove costrouc as a maintainer`                           |
| [`ccdacae5`](https://github.com/NixOS/nixpkgs/commit/ccdacae5a8d52ee9081851c3c0e8fe0592d060fd) | `python3Packages.apache-airflow: add experimental update script`                             |
| [`053f9a8f`](https://github.com/NixOS/nixpkgs/commit/053f9a8f32ee28efc96c8d5b22808d233996121d) | `python3Packages.apache-airflow: generated provider metadata`                                |