### PR TITLE
chore(flake/nixpkgs): `ae1dc133` -> `fde244a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1663850217,
-        "narHash": "sha256-tp9nXo1/IdN/xN9m06ryy0QUAEfoN6K56ObM/1QTAjc=",
+        "lastModified": 1664017330,
+        "narHash": "sha256-919WZKBTxFdTkzIK6uJXE7hwSPQb7e/ekybxxWaotR4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ae1dc133ea5f1538d035af41e5ddbc2ebcb67b90",
+        "rev": "fde244a8c7655bc28616864e2290ad9c95409c2c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                    |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`cf5f44e8`](https://github.com/NixOS/nixpkgs/commit/cf5f44e892e243e3fe5951bebe4950db93c1eda0) | `aliyun-cli: 3.0.125 -> 3.0.127`                                                  |
| [`e0ef43b8`](https://github.com/NixOS/nixpkgs/commit/e0ef43b879a9c2e3d80ec92d60bfad34cceb9ab3) | `Revert "abi-dumper: fix cross compilation"`                                      |
| [`5c01f036`](https://github.com/NixOS/nixpkgs/commit/5c01f036ccf3d08a5f2663dd144848e316957c0a) | `checkSSLCert: 2.46.0 -> 2.47.0`                                                  |
| [`a77fb8ec`](https://github.com/NixOS/nixpkgs/commit/a77fb8ecfa52310775ba0db4b021e4407a1a1311) | `pv: remove name override`                                                        |
| [`560d582c`](https://github.com/NixOS/nixpkgs/commit/560d582c060a3a4fe03ec03fcfa04fae7e395a9e) | `amass: 3.19.3 -> 3.20.0`                                                         |
| [`fd62fdca`](https://github.com/NixOS/nixpkgs/commit/fd62fdca5b4e765b80e94be14001648cc91d6781) | `virtualisation.docker: require docker.service for docker-prune.service`          |
| [`d77812e6`](https://github.com/NixOS/nixpkgs/commit/d77812e6497896c6b6a0576c6530d491b178a12b) | `quakespasm: 0.94.7 -> 0.95.0`                                                    |
| [`29fb5972`](https://github.com/NixOS/nixpkgs/commit/29fb59725d2f3507ede8644c8078f9fc5c986ae1) | `qownnotes: 22.9.0 -> 22.9.1`                                                     |
| [`585901a0`](https://github.com/NixOS/nixpkgs/commit/585901a011061af5b7c121333076a741d15f6ebf) | `deadbeef: 1.9.1 -> 1.9.2`                                                        |
| [`5a4cda3a`](https://github.com/NixOS/nixpkgs/commit/5a4cda3af395c93f19cea1d93e9c863878035fb8) | `usbguard: fix cross compilation`                                                 |
| [`5d1f75fa`](https://github.com/NixOS/nixpkgs/commit/5d1f75fa3c43f42f3a69f962abe655157bbd8996) | `apache-directory-studio: fix webkitgtk browser`                                  |
| [`4ca2f7b5`](https://github.com/NixOS/nixpkgs/commit/4ca2f7b56a7c870b7025f1697e3d160b9b8839b8) | `flyway: 9.3.0 -> 9.3.1`                                                          |
| [`93865404`](https://github.com/NixOS/nixpkgs/commit/93865404d45be1f211cc5d035fd01d38c24cd586) | `exploitdb: 2022-09-21 -> 2022-09-22`                                             |
| [`641f6dd3`](https://github.com/NixOS/nixpkgs/commit/641f6dd3d17b1b2e4bd88eec71071e92e64de724) | `pythonDocs: fix eval`                                                            |
| [`77f115c4`](https://github.com/NixOS/nixpkgs/commit/77f115c44b6c58735478a747187c916b333abb5a) | `maintainers: remove my gpg key`                                                  |
| [`1239f609`](https://github.com/NixOS/nixpkgs/commit/1239f60910ee3cfaaa9db7242e46e459297286b7) | `abi-dumper: fix cross compilation`                                               |
| [`ad684297`](https://github.com/NixOS/nixpkgs/commit/ad684297522067ac4cff6e6cf5a15860feeb5d84) | `python310Packages.regenmaschine: 2022.09.1 -> 2022.09.2`                         |
| [`1d39316e`](https://github.com/NixOS/nixpkgs/commit/1d39316e96ee23f4bb55a6ced8afa0f54d85ef9e) | `grv: add missing throw`                                                          |
| [`4bdd6b83`](https://github.com/NixOS/nixpkgs/commit/4bdd6b834d7a4a07a5a921c8e0539b95ce805533) | `lux: init at 0.15.0`                                                             |
| [`cf91580c`](https://github.com/NixOS/nixpkgs/commit/cf91580c8834027edcf77a75ad409bd418339800) | `python310Packages.pycfmodel: 0.20.1 -> 0.20.2`                                   |
| [`ef54ebf0`](https://github.com/NixOS/nixpkgs/commit/ef54ebf0c595affad9d15908c21a58ef60355ff7) | `python310Packages.pontos: 22.9.0 -> 22.9.1`                                      |
| [`fdecf8e9`](https://github.com/NixOS/nixpkgs/commit/fdecf8e9eee8cc5bca94f8deff7df73e1776e87e) | `munin: 2.0.69 -> 2.0.70`                                                         |
| [`8e819696`](https://github.com/NixOS/nixpkgs/commit/8e819696fea32a10916a6bcf70d4798b7bcf56c1) | `libyafaray: 3.5.1 -> unstable-2022-09-17`                                        |
| [`6ea5145a`](https://github.com/NixOS/nixpkgs/commit/6ea5145adca776d0ec5d5f9a70368e15713cfde0) | `gmrender-resurrect: 0.0.9 -> 0.1`                                                |
| [`3028a781`](https://github.com/NixOS/nixpkgs/commit/3028a781ff17f181e2fbb0a70a60031ff4e06a83) | `idasen: 0.9.2 -> 0.9.3`                                                          |
| [`7a41be7b`](https://github.com/NixOS/nixpkgs/commit/7a41be7b2a21976a6677daa732b1c106e737d4b9) | `Python hooks: use spliced packages in hooks`                                     |
| [`f1156eee`](https://github.com/NixOS/nixpkgs/commit/f1156eeee99f32bb53e52f3de6ac198b8e868b54) | `python310Packages.flake8-bugbear: 22.9.11 -> 22.9.23`                            |
| [`8efed077`](https://github.com/NixOS/nixpkgs/commit/8efed0770f7a33c11b1ac4bb863c0f829c1aba18) | `python310Packages.etils: 0.7.1 -> 0.8.0`                                         |
| [`485fe8e9`](https://github.com/NixOS/nixpkgs/commit/485fe8e9ba483a9e5934d931f42de0d4e5eaeff9) | `rustup: use makeBinaryWrapper instead of makeWrapper`                            |
| [`7c0b93f9`](https://github.com/NixOS/nixpkgs/commit/7c0b93f9d4303de2d370674f4b26452b9d2a38cc) | `python310Packages.dash: 2.6.1 -> 2.6.2`                                          |
| [`ad0d2e34`](https://github.com/NixOS/nixpkgs/commit/ad0d2e3453c3b96f2209f637c16c8a1ffe6554e5) | `librevisa: remove because its source is gone`                                    |
| [`865ce728`](https://github.com/NixOS/nixpkgs/commit/865ce728907989c250ebaba49dc58a5c009ccc87) | `pulseview: remove librevisa dependency`                                          |
| [`9c54dd3e`](https://github.com/NixOS/nixpkgs/commit/9c54dd3ee26c8de38127120c75f7e7bf33249bcf) | `libsigrok: remove librevisa dependency`                                          |
| [`dfc6e194`](https://github.com/NixOS/nixpkgs/commit/dfc6e194bcf1c477c71475e4b9151ecc89054d62) | `pythonDocs: bring back pname+version, allow script to be executed from anywhere` |
| [`db3ab776`](https://github.com/NixOS/nixpkgs/commit/db3ab776974cbd9c410c769e9aa7e2ed9715ceac) | `cf-terraforming: 0.8.6 -> 0.8.7 (#192602)`                                       |
| [`9851ea85`](https://github.com/NixOS/nixpkgs/commit/9851ea855ec4c23517303c9c77be35fb6672f286) | `mailnag: mark broken`                                                            |
| [`47f3427c`](https://github.com/NixOS/nixpkgs/commit/47f3427ce424ff5485846ecb7be27ae11f7b36f5) | `openra: use python3`                                                             |
| [`abbcb247`](https://github.com/NixOS/nixpkgs/commit/abbcb2470fa2823b106bb9e5714df0c1afb24bc4) | `gokart: 0.5.0 -> 0.5.1`                                                          |
| [`dc9c45e1`](https://github.com/NixOS/nixpkgs/commit/dc9c45e1caf0f3f9b80139b9c74338da94776e1f) | `openvino: mark broken for linux-x86_64`                                          |
| [`2512dab6`](https://github.com/NixOS/nixpkgs/commit/2512dab60200ad48a423bfd4465733b2d65696a5) | `python310Packages.bibtexparser: 1.3.0 -> 1.4.0`                                  |
| [`a1ba5bd3`](https://github.com/NixOS/nixpkgs/commit/a1ba5bd36da9a83153c229ee9f9d555e95c56c47) | `esbuild: 0.15.8 -> 0.15.9`                                                       |
| [`64bd52c7`](https://github.com/NixOS/nixpkgs/commit/64bd52c78574451eb9295e09e1d8acfd13205e00) | `init .mailmap`                                                                   |
| [`ab40ef4d`](https://github.com/NixOS/nixpkgs/commit/ab40ef4d1902eed3b04a2f26766efc0dea224a3a) | `csview: 1.1.0 -> 1.2.1`                                                          |
| [`61e1baa6`](https://github.com/NixOS/nixpkgs/commit/61e1baa609efeec2c9cc1033efd1209bac0f6dab) | `aws-lambda-rie: 1.3 -> 1.8`                                                      |
| [`05bbb2fd`](https://github.com/NixOS/nixpkgs/commit/05bbb2fd2ed32c22ac8a1503c081587fa4466805) | `tio: 1.35 -> 2.0`                                                                |
| [`6be3357a`](https://github.com/NixOS/nixpkgs/commit/6be3357a74fd9cb8217c299c69888ce06bb50d19) | `nasc: mark broken`                                                               |
| [`9dfe1fe0`](https://github.com/NixOS/nixpkgs/commit/9dfe1fe09d153fa2ee402fcaff26312315dc7c2e) | `ncnn: mark broken`                                                               |
| [`a291f1dc`](https://github.com/NixOS/nixpkgs/commit/a291f1dc264d3492cbfb9dbb8955955bc2daad96) | `maintainers: add candyc1oud`                                                     |
| [`52117cce`](https://github.com/NixOS/nixpkgs/commit/52117cce92412a2b921449e11cd3d4716e56f382) | `pythonDocs: 3.7 -> 3.10`                                                         |
| [`627c3b44`](https://github.com/NixOS/nixpkgs/commit/627c3b44e4c2b5d4654f31c84656b5585dbbd11e) | `python3Packages.deap: remove 2to3-related code`                                  |
| [`e83df5fd`](https://github.com/NixOS/nixpkgs/commit/e83df5fda7a5bec8a6f718baf0ca02cc93d999a0) | `python310Packages.pyglet: 1.5.26 -> 1.5.27`                                      |
| [`b089a5c5`](https://github.com/NixOS/nixpkgs/commit/b089a5c574a58a9cb09be971dea7810a6ef9e82e) | `python3Packages.seaborn: 0.11.2 -> 0.12.0`                                       |
| [`f681d147`](https://github.com/NixOS/nixpkgs/commit/f681d147223f2e40d75955657742cac65dc67b57) | `mmex: mark broken`                                                               |
| [`fb836966`](https://github.com/NixOS/nixpkgs/commit/fb83696690fd575d1841a0f46df7a740d86fbb07) | `cntk: mark broken`                                                               |
| [`9dc1fa37`](https://github.com/NixOS/nixpkgs/commit/9dc1fa3787009c1b03b9fb30f8eb08a2b9b5ab84) | `corrscope: fix build`                                                            |
| [`c68a2f3e`](https://github.com/NixOS/nixpkgs/commit/c68a2f3ebc76917b18ae1f7c0b00b30a4f6cd55a) | `crowdin-cli: 3.8.0 -> 3.8.1`                                                     |
| [`0d95dc96`](https://github.com/NixOS/nixpkgs/commit/0d95dc96d2c5baf378fb59340199f67edc3e928b) | `cinny-desktop: 2.1.3 -> 2.2.0`                                                   |
| [`494c5cd0`](https://github.com/NixOS/nixpkgs/commit/494c5cd03a0d59963b3993d0bdef173cd87f69cb) | `vscode-extensions.github.copilot: 1.7.4812 -> 1.46.6822`                         |
| [`a29b52aa`](https://github.com/NixOS/nixpkgs/commit/a29b52aa4127c126e21638a3b51995e1b9e4193d) | `carapace: 0.15.1 -> 0.16.0`                                                      |
| [`0015531d`](https://github.com/NixOS/nixpkgs/commit/0015531ddc87ee3d79dfa4a51c3ad0c7f29532ba) | `mdbook-man: init at unstable-2021-08-26`                                         |
| [`2076f54b`](https://github.com/NixOS/nixpkgs/commit/2076f54b4a0c9fca5666c499bd6fa8771840a143) | `pythonPackages.black: Move optional deps to passthru`                            |
| [`c3260668`](https://github.com/NixOS/nixpkgs/commit/c3260668006b9b4a0cfee3bbd45a0f61a7512ced) | `k9s: 0.26.3 -> 0.26.5`                                                           |
| [`f0a92533`](https://github.com/NixOS/nixpkgs/commit/f0a9253326b96d52455957c4d3d2af6f686ba388) | `arkade: 0.8.44 -> 0.8.45`                                                        |
| [`b225d54f`](https://github.com/NixOS/nixpkgs/commit/b225d54ffcfe905e45d60292db259dbee04324f9) | `argparse: 2.6 -> 2.9`                                                            |
| [`baa48506`](https://github.com/NixOS/nixpkgs/commit/baa485066e18093d462ccbb739699ce2e4b3c37f) | `swaynotificationcenter: 0.7.1 -> 0.7.2`                                          |
| [`4290640c`](https://github.com/NixOS/nixpkgs/commit/4290640c641f5cf0decb3f91dd97161c3e84ecee) | `flexget: 3.3.28 -> 3.3.29`                                                       |
| [`f87f1d50`](https://github.com/NixOS/nixpkgs/commit/f87f1d501eb8077ebf148779f280c6e5a46efe3b) | `deno: 1.25.3 -> 1.25.4`                                                          |
| [`903a3c32`](https://github.com/NixOS/nixpkgs/commit/903a3c32ab5a39ef69c1fb41c45b1b91756361e5) | `diffoscope: 221 -> 222`                                                          |
| [`c60c8337`](https://github.com/NixOS/nixpkgs/commit/c60c8337a92001eb1f0aa2614875e9b56d5b8349) | `cfripper: 1.13.0 -> 1.13.1`                                                      |
| [`e46430d5`](https://github.com/NixOS/nixpkgs/commit/e46430d50327f9d7bf8d1df61d62987c46f9622b) | `nixos.moonraker: version change fixes`                                           |
| [`00c9eeaa`](https://github.com/NixOS/nixpkgs/commit/00c9eeaa46d61f5f80ca58148504eda5401b5658) | `nix-update: 0.6.0 -> 0.7.0`                                                      |
| [`fe3bbffa`](https://github.com/NixOS/nixpkgs/commit/fe3bbffa179f2b94b42e519e58bc5acbb66e0f9f) | `python310Packages.cronsim: disable on older Python releases`                     |
| [`b8157395`](https://github.com/NixOS/nixpkgs/commit/b81573950ea92eef4ee8ac2e55af4dffd9b5dcbb) | `python310Packages.crossplane: disable on older Python releases`                  |
| [`136a46f2`](https://github.com/NixOS/nixpkgs/commit/136a46f28461dd2acbc173b42da6ca4cf60723ce) | `python310Packages.pykeyatome: 2.0.0 -> 2.1.0`                                    |
| [`52b12584`](https://github.com/NixOS/nixpkgs/commit/52b12584465d23b009caf6c2cd4b705ecb302633) | `sigi: 3.4.2 -> 3.4.3`                                                            |
| [`4c7bfc60`](https://github.com/NixOS/nixpkgs/commit/4c7bfc60006525cf651138d322083a6272b4dd45) | `nodejs-18_x: 18.9.0 -> 18.9.1`                                                   |
| [`e67243f1`](https://github.com/NixOS/nixpkgs/commit/e67243f1cffa7f65a53fb6d1acaa538d8b6c22aa) | `civo: install completions`                                                       |
| [`01af51b7`](https://github.com/NixOS/nixpkgs/commit/01af51b748ff054219497bbb1ab4c14d09c7f1cd) | `tflint: 0.40.1 -> 0.41.0`                                                        |
| [`084295ca`](https://github.com/NixOS/nixpkgs/commit/084295ca0305ded1a9dbecd59bd0768e475d2446) | `lxd: 5.5 -> 5.6`                                                                 |
| [`5b647c67`](https://github.com/NixOS/nixpkgs/commit/5b647c67afce9e3b525867328a14ca4f1bad01b4) | `nodejs-16_x: 16.17.0 -> 16.17.1`                                                 |
| [`7d6fc515`](https://github.com/NixOS/nixpkgs/commit/7d6fc515507987e90c01df3484dee23f360ca39d) | `civo: update ldflags`                                                            |
| [`8b89d8d5`](https://github.com/NixOS/nixpkgs/commit/8b89d8d5bdac93026a13b3ea2469f22c561974d3) | `nodejs-14_x: 14.20.0 -> 14.20.1`                                                 |
| [`b123a0d7`](https://github.com/NixOS/nixpkgs/commit/b123a0d797ca943950d4e37e86784f9c1ebd78ec) | `python310Packages.globus-sdk: 3.11.0 -> 3.12.0`                                  |
| [`9d9b8131`](https://github.com/NixOS/nixpkgs/commit/9d9b8131e9f3716f5e6028864fd733a1ef54c59e) | `python310Packages.google-cloud-pubsub: 2.13.6 -> 2.13.7`                         |
| [`7a7e9921`](https://github.com/NixOS/nixpkgs/commit/7a7e9921354dca215de3da5c50922b3b27503c9f) | `python310Packages.govee-ble: 0.17.2 -> 0.17.3`                                   |
| [`c00c3c2c`](https://github.com/NixOS/nixpkgs/commit/c00c3c2cc05b608806e1c990276f956c1d7f1a00) | `pizarra: fix meta.homepage`                                                      |
| [`d6579bfe`](https://github.com/NixOS/nixpkgs/commit/d6579bfe8d45e7255eb739c045894719a5c69ffc) | `python310Packages.aioaladdinconnect: 0.1.45 -> 0.1.46`                           |
| [`1ff786cd`](https://github.com/NixOS/nixpkgs/commit/1ff786cd889d0118f28061a643eb94a1d818e0d9) | `v2ray-geoip: 202209170841 -> 202209220104`                                       |
| [`cb9bcf88`](https://github.com/NixOS/nixpkgs/commit/cb9bcf8802fca4883775063fbdc292ffe625de21) | `python39Packages.aioairq: 0.1.1 -> 0.2.0`                                        |
| [`2aaefa64`](https://github.com/NixOS/nixpkgs/commit/2aaefa64ecb093a850b3788eb29ffdf4cba194e6) | `python310Packages.coinmetrics-api-client: 2022.8.29.6 -> 2022.9.22.15`           |
| [`c0b004a2`](https://github.com/NixOS/nixpkgs/commit/c0b004a2e35b10641ec1e19e9e651bf9b4f2fb02) | `python310Packages.crossplane: 0.5.7 -> 0.5.8`                                    |
| [`31b03428`](https://github.com/NixOS/nixpkgs/commit/31b034280ccb850b542975f84d9b01a8d9ba58ab) | `python310Packages.cronsim: 2.1 -> 2.2`                                           |
| [`e3d72295`](https://github.com/NixOS/nixpkgs/commit/e3d72295badd1ce12452f577ec1ad57b6c045465) | `php80Extensions.protobuf: 3.21.5 -> 3.21.6`                                      |
| [`307ac425`](https://github.com/NixOS/nixpkgs/commit/307ac4259cef23887e84f17d843505795b0d4b57) | `postgresql11Packages.pgroonga: 2.3.8 -> 2.3.9`                                   |
| [`4da697d2`](https://github.com/NixOS/nixpkgs/commit/4da697d2a08c28bdab0ac2ce3f88eeac3df323fa) | `php80Extensions.mongodb: 1.14.0 -> 1.14.1`                                       |
| [`3c4b51f3`](https://github.com/NixOS/nixpkgs/commit/3c4b51f390c47e2669d3befa6c13b84acb68bfc1) | `postgresql11Packages.plpgsql_check: 2.1.9 -> 2.2.1`                              |
| [`85e8506a`](https://github.com/NixOS/nixpkgs/commit/85e8506aa715c9d0eb74e0c238c0f0d8d3f94dec) | `php80Packages.phpstan: 1.8.3 -> 1.8.5`                                           |
| [`29a5c6e3`](https://github.com/NixOS/nixpkgs/commit/29a5c6e399d4ceef455efeb891582f011e4fb8ff) | `php80Extensions.apcu: 5.1.21 -> 5.1.22`                                          |
| [`70a9cd72`](https://github.com/NixOS/nixpkgs/commit/70a9cd722942dd2add3ef7dc4fc6e0567f9140b4) | `php80Packages.composer: 2.4.1 -> 2.4.2`                                          |
| [`873728ac`](https://github.com/NixOS/nixpkgs/commit/873728aca3883c6fbe51ac55118199142dd11bcf) | `pizarra: 1.7.3 -> 1.7.4`                                                         |
| [`ac82ac55`](https://github.com/NixOS/nixpkgs/commit/ac82ac550e515e831d1b0f01d5bafe89de25bb74) | `nootka: drop unstable package`                                                   |
| [`02334f5b`](https://github.com/NixOS/nixpkgs/commit/02334f5bb7b37175771f6563e8c8f10f78f4192a) | `nootka: 1.4.7 -> 2.0.2`                                                          |
| [`74611c4d`](https://github.com/NixOS/nixpkgs/commit/74611c4dc4a66bb128b505b3664f0b0f121d4ded) | `tcat: init at 1.0.0`                                                             |
| [`4f5da70e`](https://github.com/NixOS/nixpkgs/commit/4f5da70ee69f9136f92f32a13a35a284739ad5b5) | `php80Extensions.mailparse: 3.1.3 -> 3.1.4`                                       |
| [`57db102e`](https://github.com/NixOS/nixpkgs/commit/57db102e99bc4f9ba0f835e7ba429e9447f5f3d0) | `firefox-devedition-bin-unwrapped: 105.0b9 -> 106.0b3`                            |
| [`ea401a6a`](https://github.com/NixOS/nixpkgs/commit/ea401a6ad393f968cc548ea75e9bf3ebdcce68f6) | `firefox-beta-bin-unwrapped: 105.0b9 -> 106.0b2`                                  |
| [`bee18da2`](https://github.com/NixOS/nixpkgs/commit/bee18da2fe5030869d8333bf1260d62eab8d9bf5) | `firefox-bin-unwrapped: 105.0 -> 105.0.1`                                         |
| [`ec248bd5`](https://github.com/NixOS/nixpkgs/commit/ec248bd566ee7138990680f14fb8fbfe5c93cf2d) | `firefox-unwrapped: 105.0 -> 105.0.1`                                             |
| [`54a3b8e5`](https://github.com/NixOS/nixpkgs/commit/54a3b8e5fa420268f75eea93ed25f8a891c244b5) | `firefox-unwrapped: Use https url in update script`                               |
| [`d00cce90`](https://github.com/NixOS/nixpkgs/commit/d00cce907de73a2561dbb43abdde6ea323428b43) | `obs-studio-plugins.obs-pipewire-audio-capture: 1.0.4 -> 1.0.5`                   |
| [`8edf28f4`](https://github.com/NixOS/nixpkgs/commit/8edf28f47402d87dbc109f9275b1675cc9920c91) | `ocenaudio: 3.11.14 -> 3.11.15`                                                   |
| [`e2d40d67`](https://github.com/NixOS/nixpkgs/commit/e2d40d67f122a690587cb3eab2ceffda5a7a4383) | `neo4j: 4.4.10 -> 4.4.11`                                                         |
| [`d948d26a`](https://github.com/NixOS/nixpkgs/commit/d948d26a97dafde706cf1c1aef7ceb3f20981ccb) | `opencv3: 3.4.15 -> 3.4.18`                                                       |
| [`08679c6d`](https://github.com/NixOS/nixpkgs/commit/08679c6d47a6046e0833a9d59547756ffb335f70) | `metabase: 0.44.2 -> 0.44.3`                                                      |
| [`cc2a2481`](https://github.com/NixOS/nixpkgs/commit/cc2a2481253e689947fe1d049d38f0bf2620a6e4) | `kubernetes: 1.23.11 -> 1.23.12`                                                  |
| [`383b0ea9`](https://github.com/NixOS/nixpkgs/commit/383b0ea9a5d5c674cedae7f9faee43da8054082e) | `postgresqlPackages.rum: 1.3.12 -> 1.3.13`                                        |
| [`0a50c1ed`](https://github.com/NixOS/nixpkgs/commit/0a50c1ed3d2247e74bcb73dddb240f007d567ae1) | `mpvScripts.mpris: 0.8.1 -> 0.9`                                                  |
| [`07c02936`](https://github.com/NixOS/nixpkgs/commit/07c02936910a1f5cde55c4da8e9369373ab85edc) | `nfs-ganesha: 4.0.7 -> 4.0.8`                                                     |
| [`cea11116`](https://github.com/NixOS/nixpkgs/commit/cea111161b02f1a823698038bfd01bc93607e391) | `python310Packages.pyatome: disable on older Python releases`                     |
| [`2c88dcf6`](https://github.com/NixOS/nixpkgs/commit/2c88dcf6fffbfc1fb5f322f3e84c2098168536a3) | `tile38: 1.29.0 -> 1.29.1`                                                        |
| [`c03b4fb9`](https://github.com/NixOS/nixpkgs/commit/c03b4fb965f3ae76886ea64a9bf7c609e5c6695c) | `python310Packages.pyatome: 0.1.1 -> 0.1.2`                                       |
| [`1b822ee9`](https://github.com/NixOS/nixpkgs/commit/1b822ee9e04c294d99f166927cf088844d23a66c) | `python310Packages.pylitterbot: 2022.9.5 -> 2022.9.6`                             |
| [`3dca2a87`](https://github.com/NixOS/nixpkgs/commit/3dca2a876c141dfe06dbb835e0c54a991948464a) | `python310Packages.pylutron-caseta: 0.14.0 -> 0.15.2`                             |
| [`bb79bfc2`](https://github.com/NixOS/nixpkgs/commit/bb79bfc2f6113364aabbebdb1c0b1a8624111826) | `python310Packages.motionblinds: 0.6.12 -> 0.6.13`                                |
| [`06500003`](https://github.com/NixOS/nixpkgs/commit/0650000314d6a3bff5d63a74f14a2094946126f6) | `ldmud: init at 3.6.6`                                                            |
| [`7ea88902`](https://github.com/NixOS/nixpkgs/commit/7ea88902ae44f6718c2a576752b44933ea15b2d7) | `streamlit: 1.12.2 -> 1.13.0`                                                     |
| [`86c91dc1`](https://github.com/NixOS/nixpkgs/commit/86c91dc1a407c03c67091afbc1643cb834aab788) | `keyscope: 1.2.2 -> 1.2.3`                                                        |
| [`08c129fd`](https://github.com/NixOS/nixpkgs/commit/08c129fdf343787fbee7dc3dd250b414fa382681) | `pleroma: Add stripDebug=false (#192472)`                                         |