### PR TITLE
chore(flake/home-manager): `de3758e3` -> `9b917098`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1663932797,
-        "narHash": "sha256-IH8ZBW99W2k7wKLS+Sat9HiKX1TPZjFTnsPizK5crok=",
+        "lastModified": 1664139685,
+        "narHash": "sha256-wa29YJU0U1QTECHgSTiDiUTQXm1Q45iO5HpLiI7vnuU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "de3758e31a3a1bc79d569f5deb5dac39791bf9b6",
+        "rev": "9b91709899ddf20cbead93e4af622bd0a501dd0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message              |
| ----------------------------------------------------------------------------------------------------------- | --------------------------- |
| [`9b917098`](https://github.com/nix-community/home-manager/commit/9b91709899ddf20cbead93e4af622bd0a501dd0b) | `safeeyes: add module`      |
| [`3eaadd82`](https://github.com/nix-community/home-manager/commit/3eaadd82b8fb646a6779839c4f276b810e0354a5) | `maintainers: add Rosuavio` |