### PR TITLE
chore(flake/darwin): `088c98a5` -> `95ba7e54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1663677921,
-        "narHash": "sha256-NfQnUfRrjv8DXeugdbQC5El+MMhShP42ohc8iM+UAdM=",
+        "lastModified": 1664143588,
+        "narHash": "sha256-I1qaa8VMISprKulco2bxiIJUaz1NGiKmlsQuM996yzM=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "088c98a584a38b5f844bb9e9cd32eb28479ca6d7",
+        "rev": "95ba7e548d55e74c36369dbd6a4bfe99a543c835",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                   |
| ------------------------------------------------------------------------------------------------ | -------------------------------- |
| [`07f64058`](https://github.com/LnL7/nix-darwin/commit/07f640580bcae56fee929a1e6e70bdf9128ae290) | `rename the nixFlakes reference` |
| [`a2a9f30f`](https://github.com/LnL7/nix-darwin/commit/a2a9f30fee9d74c7129aa50d638245b62f80d8c6) | `rename runCommandNoCC`          |