### PR TITLE
chore(flake/nixpkgs): `fde244a8` -> `79d3ca08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664017330,
-        "narHash": "sha256-919WZKBTxFdTkzIK6uJXE7hwSPQb7e/ekybxxWaotR4=",
+        "lastModified": 1664106353,
+        "narHash": "sha256-HMJP80+DSxFySpWyuxz5+iNozS3+dVt0b4n6YMIU5/8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fde244a8c7655bc28616864e2290ad9c95409c2c",
+        "rev": "79d3ca08920364759c63fd3eb562e99c0c17044a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                    |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`ba331956`](https://github.com/NixOS/nixpkgs/commit/ba3319568df2c6675dbe36478fb3edf16e114ac3) | `utillinux: drop alias, don't throw`                                              |
| [`2239172e`](https://github.com/NixOS/nixpkgs/commit/2239172ea0f49fcf6457361692dac5523187a3d6) | `babashka: 0.9.162 -> 0.10.163`                                                   |
| [`4e9f99e8`](https://github.com/NixOS/nixpkgs/commit/4e9f99e8fac18d0e9e266bade1b4b725a593d957) | `python310Packages.netdata: 1.0.2 -> 1.0.3`                                       |
| [`4d371382`](https://github.com/NixOS/nixpkgs/commit/4d371382c8efec90150a734391e2436a947ce140) | `python310Packages.aiocurrencylayer: 1.0.3 -> 1.0.4`                              |
| [`00f75d8a`](https://github.com/NixOS/nixpkgs/commit/00f75d8a4f6007c8e22cb93902eac30fe686a546) | `bluemail: init at 1.131.4-1795`                                                  |
| [`4afb3c31`](https://github.com/NixOS/nixpkgs/commit/4afb3c31c3319c47719097abe1a49deffe69dd13) | `python310Packages.dj-email-url: disable on older Python releases`                |
| [`a233e59d`](https://github.com/NixOS/nixpkgs/commit/a233e59d190efc4eeee5067484473d2c09a1547b) | `nixos/pam: fix deprecated gnome3 reference`                                      |
| [`8b47f462`](https://github.com/NixOS/nixpkgs/commit/8b47f462d5464be05a64d4bafac79a4f671f2b87) | `haskellPackages: mark builds failing on hydra as broken`                         |
| [`87cfa16c`](https://github.com/NixOS/nixpkgs/commit/87cfa16c707a9be3c8f3a77fc0545e7058bf70f6) | `terraform-providers: update 2022-09-25`                                          |
| [`c88be6d6`](https://github.com/NixOS/nixpkgs/commit/c88be6d6c71549347d135806ae7f1d159c97ac8c) | `mmdoc: 0.10.0 -> 0.12.0`                                                         |
| [`c897c59a`](https://github.com/NixOS/nixpkgs/commit/c897c59a4a4a9e04f3283296c214ae9982fa718b) | `pari: remove myself from maintainers`                                            |
| [`4419927a`](https://github.com/NixOS/nixpkgs/commit/4419927a5cdc178e35ba81d458b1ee8a7ed9f952) | `gp2c: 0.0.12 -> 0.0.13`                                                          |
| [`e5cac189`](https://github.com/NixOS/nixpkgs/commit/e5cac189d4c266d742a44611e019a91b4e3cda72) | `luaPackages: fennel -> luaPackages.fennel`                                       |
| [`237197ef`](https://github.com/NixOS/nixpkgs/commit/237197eff57536b9779579b22dc158d91841c405) | `python310Packages.gaphas: 3.6.0 -> 3.7.0`                                        |
| [`771bd321`](https://github.com/NixOS/nixpkgs/commit/771bd3212ba864941ede0574988b8f6040a1b101) | `python310Packages.fjaraskupan: 2.0.0 -> 2.0.1`                                   |
| [`5ac4f45f`](https://github.com/NixOS/nixpkgs/commit/5ac4f45f728fc44ddc95f7beabbdc0b9102e508f) | `mxnet: patch to fix build on aarch64-darwin`                                     |
| [`56bb9fb2`](https://github.com/NixOS/nixpkgs/commit/56bb9fb23d8f2b31f664d0120d4932a619ed8245) | `python3Packages.vector: init at 0.10.0`                                          |
| [`86f15e11`](https://github.com/NixOS/nixpkgs/commit/86f15e11b5dec57cd6e8c4e6b95e40818f217648) | `python310Packages.dj-email-url: 1.0.5 -> 1.0.6`                                  |
| [`954d0772`](https://github.com/NixOS/nixpkgs/commit/954d07720abcf28ef7cd9152d380ddfb7992db1c) | `muon: init at unstable-2022-09-24`                                               |
| [`952b8517`](https://github.com/NixOS/nixpkgs/commit/952b851746fd0c6d2944d394ffce5c9f2739d4e8) | `openai-whisper: init at unstable-2022-09-23`                                     |
| [`fb0385eb`](https://github.com/NixOS/nixpkgs/commit/fb0385eb6bde2d83c31fb24737287cc140ebe683) | `python310Packages.boschshcpy: 0.2.34 -> 0.2.35`                                  |
| [`0e3a9cae`](https://github.com/NixOS/nixpkgs/commit/0e3a9cae0d7e27bd52ffea141a6c53c3770130e2) | `python310Packages.aiounifi: 34 -> 35`                                            |
| [`75954226`](https://github.com/NixOS/nixpkgs/commit/75954226eb8eb8acfb91840768b647798dce1611) | `home-assistant: update component-packages`                                       |
| [`e51736e9`](https://github.com/NixOS/nixpkgs/commit/e51736e982a9d7c0754121ac9cfb46b3ca0253ec) | `python310Packages.pybravia: init at 0.2.2`                                       |
| [`d1abee22`](https://github.com/NixOS/nixpkgs/commit/d1abee22628eb2a63257edba03695400ec9a0700) | `terraform-providers: switch to hash/vendorHash`                                  |
| [`48f44971`](https://github.com/NixOS/nixpkgs/commit/48f449716d064093a7e5436321d05811777d701a) | `cntr: fix passthru.tests with ofborg`                                            |
| [`de80fd54`](https://github.com/NixOS/nixpkgs/commit/de80fd541f360dfe053fa227e10e338c82122f52) | `cntr: only run nixosTests on aarch64/x86_64`                                     |
| [`d41cac45`](https://github.com/NixOS/nixpkgs/commit/d41cac455b1fb8b8e3682ef1fe5c9f109768d554) | `python310Packages.govee-ble: 0.17.3 -> 0.19.0`                                   |
| [`62afcb75`](https://github.com/NixOS/nixpkgs/commit/62afcb75260520b5cd87eed6273289000362b652) | `python310Packages.json-stream: 1.4.2 -> 1.4.3`                                   |
| [`4580bd4c`](https://github.com/NixOS/nixpkgs/commit/4580bd4cc8c4cf03540a371544ae285dd115d33c) | `python310Packages.msgspec: init at 0.9.0`                                        |
| [`923fae08`](https://github.com/NixOS/nixpkgs/commit/923fae081f6e78256f032f1c1a599f48d64163ff) | `python310Packages.dbus-fast: 1.4.0 -> 1.11.0`                                    |
| [`a43c914b`](https://github.com/NixOS/nixpkgs/commit/a43c914b7f429137244bb6179ebc0823cb3a9852) | `python310Packages.ansible-compat: 2.2.0 -> 2.2.1`                                |
| [`4082476a`](https://github.com/NixOS/nixpkgs/commit/4082476a6eeec17e104ef4e17cf40186d9b38028) | `sigma-cli: relax constraints`                                                    |
| [`699cf88c`](https://github.com/NixOS/nixpkgs/commit/699cf88c65454cd549e7e6f0552500d0a555ef0d) | `python310Packages.pysigma-backend-qradar: 0.1.9 -> 0.2.1`                        |
| [`f0754cfe`](https://github.com/NixOS/nixpkgs/commit/f0754cfe2121a5a0c9667d92323ff6ac79a73558) | `python310Packages.pysigma-backend-qradar: relax pysigma constraint`              |
| [`793a4867`](https://github.com/NixOS/nixpkgs/commit/793a48673cc858eee0f67d577ebd2b2c62dc4c69) | `python310Packages.pysigma-backend-opensearch: 0.1.2 -> 0.1.3`                    |
| [`f43ede11`](https://github.com/NixOS/nixpkgs/commit/f43ede11f9f3e6647f5438af9fa95fd7596a4bee) | `python310Packages.pysigma-backend-elasticsearch: 0.1.0 -> 0.1.1`                 |
| [`1ad53b87`](https://github.com/NixOS/nixpkgs/commit/1ad53b870538a51a28f0ef678679b93d1b143d06) | `python310Packages.pysigma-backend-splunk: 0.3.6 -> 0.3.7`                        |
| [`38b75c35`](https://github.com/NixOS/nixpkgs/commit/38b75c35a19d70dc2def45598e2cbf1c3ee65837) | `python310Packages.pysigma-pipeline-crowdstrike: 0.1.7 -> 0.1.8`                  |
| [`78cee260`](https://github.com/NixOS/nixpkgs/commit/78cee2609958216a7df2a4818c030c738ae11c33) | `python310Packages.pysigma-pipeline-sysmon: 1.0.0 -> 1.0.1`                       |
| [`1d5756be`](https://github.com/NixOS/nixpkgs/commit/1d5756be6a10b6ce559db9f52948ca7011aa0f71) | `python310Packages.pysigma-pipeline-windows: 1.0.0 -> 1.0.1`                      |
| [`f4c03d7d`](https://github.com/NixOS/nixpkgs/commit/f4c03d7dbe512ffcd6d9612abd0d31efe3fcd7df) | `python310Packages.pysigma: 0.8.0 -> 0.8.1`                                       |
| [`636fbbcd`](https://github.com/NixOS/nixpkgs/commit/636fbbcd988ee52d9536dc70aafaedd0ce973261) | `python310Packages.pysigma-backend-insightidr: 0.1.7 -> 0.1.8`                    |
| [`39645c12`](https://github.com/NixOS/nixpkgs/commit/39645c126f5d8578af99a3364ac5a488b681e42a) | `python310Packages.pysigma: 0.7.3 -> 0.8.0`                                       |
| [`c2383288`](https://github.com/NixOS/nixpkgs/commit/c2383288423a34163d38300473f6c1989dd16deb) | `shod: 2.4.0 -> 2.5.0`                                                            |
| [`31d1c1c6`](https://github.com/NixOS/nixpkgs/commit/31d1c1c6ccab786b537dde9f93557ab42456101d) | `rabbitmq-server: 3.10.7 -> 3.10.8`                                               |
| [`6fbc9b6f`](https://github.com/NixOS/nixpkgs/commit/6fbc9b6f93ea492cd5a9ea12fc26c51b5a03decc) | `polaris-web: fix breakage due to nodejs v16->v18 upgrade`                        |
| [`eaad4f9e`](https://github.com/NixOS/nixpkgs/commit/eaad4f9ebb264b63da217894f91528480caf96c2) | `oh-my-posh: install completions`                                                 |
| [`3fee558a`](https://github.com/NixOS/nixpkgs/commit/3fee558a7861e41fe2f498b6394f8be4e681e615) | `oh-my-posh: 9.4.0 -> 10.1.0`                                                     |
| [`48e5acbb`](https://github.com/NixOS/nixpkgs/commit/48e5acbb5bdd88fcf85ab32934375d728bb56400) | `vimPlugins.instant-nvim: init at 2022-06-25`                                     |
| [`2abda141`](https://github.com/NixOS/nixpkgs/commit/2abda141f7ab28c2f242af745e23be9696ac6efe) | `vimPlugins: update`                                                              |
| [`b5c1f91a`](https://github.com/NixOS/nixpkgs/commit/b5c1f91abd4f0559436d9a847cf60ad19afe4925) | `gobject-introspection: gate the wrapper behind emulatorAvailable`                |
| [`4e9d4000`](https://github.com/NixOS/nixpkgs/commit/4e9d4000b32e80330f9c56fa543ef1a32264ac2f) | `pdftk: 3.3.2 -> 3.3.3`                                                           |
| [`4ed5997b`](https://github.com/NixOS/nixpkgs/commit/4ed5997b2a2c0a30839416bac3fb94f5ad5b3ab7) | `glasstty-ttf: init at 2018-08-07`                                                |
| [`10eea65c`](https://github.com/NixOS/nixpkgs/commit/10eea65c29e5a2b1e29ccdf345c81d7b8a7e2fbb) | `maintainers: add pkharvey`                                                       |
| [`943cf363`](https://github.com/NixOS/nixpkgs/commit/943cf36350c74e1448162f285e0870820a693daa) | `nats-server: 2.9.0 -> 2.9.1`                                                     |
| [`d756106b`](https://github.com/NixOS/nixpkgs/commit/d756106b0a0ac7ea095a922b021b9716bb9ce329) | `python310Packages.aiolifx: 0.8.4 -> 0.8.5`                                       |
| [`795eba73`](https://github.com/NixOS/nixpkgs/commit/795eba73fdce43a024f85278b4a65aca7c97b909) | `Revert "sigi: 3.4.2 -> 3.4.3"`                                                   |
| [`f83c3790`](https://github.com/NixOS/nixpkgs/commit/f83c3790b31a55ebfa194deacc0989bea321dad4) | `ldapnomnom: 1.0.5 -> 1.0.6`                                                      |
| [`afa46d5e`](https://github.com/NixOS/nixpkgs/commit/afa46d5e76b93dba25d5a06513a1c8707f018caa) | `ldapnomnom: unstable-2022-09-18 -> 1.0.5`                                        |
| [`9f1fc518`](https://github.com/NixOS/nixpkgs/commit/9f1fc5186fb5a7829ea9c3a14e34b870095d8213) | `minio: 2022-09-17T00-09-45Z -> 2022-09-22T18-57-27Z`                             |
| [`28f4c3d8`](https://github.com/NixOS/nixpkgs/commit/28f4c3d8ee0f4b0f49f5c388862cb43f243ae454) | `listmonk: fix frontend build due to OpenSSL 3.0 deprecations`                    |
| [`e7585fad`](https://github.com/NixOS/nixpkgs/commit/e7585fad462d768f72f1a6d3fd945473655f0fe1) | `yarn2nix-moretea-openssl_1_1: pass openssl for Node.js v18, unbreak this module` |
| [`7db9b6bc`](https://github.com/NixOS/nixpkgs/commit/7db9b6bcad4c68bea3b10414648c68d569655a9f) | `slack: 4.27.154 -> 4.28.182 (darwin), 4.27.156 -> 4.28.171 (linux)`              |
| [`71ea6dd8`](https://github.com/NixOS/nixpkgs/commit/71ea6dd83ed4016037030c5db8f54845793c4b49) | `ttyper: 0.4.3 -> 1.0.0`                                                          |
| [`79152c59`](https://github.com/NixOS/nixpkgs/commit/79152c59d176961b2606ab5ee33d9b75a0f692e4) | `syslog-ng: make the build reproducible`                                          |
| [`71723cd7`](https://github.com/NixOS/nixpkgs/commit/71723cd7488b21a31b63be025469c81f68402b38) | `hugo: 0.103.1 -> 0.104.0`                                                        |
| [`eaaac8f1`](https://github.com/NixOS/nixpkgs/commit/eaaac8f14f2dbb5fbaec01b777aae229670eb6d6) | `hclfmt: 2.14.0 -> 2.14.1`                                                        |
| [`84f81940`](https://github.com/NixOS/nixpkgs/commit/84f8194038f8b03e5a70606ee765ab9d2afe584f) | `gst_all_1.gstreamermm: fix build against glib 2.68`                              |
| [`e9d3dff4`](https://github.com/NixOS/nixpkgs/commit/e9d3dff4d7a50ffc6e226997f5ff57702c29290f) | `gst_all_1.gstreamermm: format nix expression`                                    |
| [`90646adf`](https://github.com/NixOS/nixpkgs/commit/90646adf15cf21436ca4e60312929664f8970843) | `eyedropper: 0.2.0 -> 0.3.1`                                                      |
| [`dd9072b4`](https://github.com/NixOS/nixpkgs/commit/dd9072b4a7901fcc590f6f468992e944ef054894) | `gst_all_1.gstreamermm: mark broken`                                              |
| [`85cefca5`](https://github.com/NixOS/nixpkgs/commit/85cefca55a15437ee13d9dbe770fefd58ac20a68) | `kde-rounded-corners: unstable-2022-06-17 -> unstable-2022-09-17`                 |
| [`640aa41d`](https://github.com/NixOS/nixpkgs/commit/640aa41dfbde69113dfb7428c7ccbfd05862e00e) | `nixos/plasma5: only generate kwinrc/kdeglobals if we have anything to generate`  |
| [`ddb7c7bd`](https://github.com/NixOS/nixpkgs/commit/ddb7c7bd95a25d7c4101ee111d20fe16446d947c) | `top-level/python-aliases: prune old aliases, add missing dates`                  |
| [`d0620738`](https://github.com/NixOS/nixpkgs/commit/d06207386df9a53fe01f8a30130dfc9a839fc8fc) | `top-level/aliases: prune old aliases, add missing dates`                         |
| [`2c9dfa82`](https://github.com/NixOS/nixpkgs/commit/2c9dfa828d7e6141fa66b8fb5dcbd13d8e5316ec) | `_1password-gui-beta: 8.9.0-1 -> 8.9.6-30`                                        |
| [`9c64b91d`](https://github.com/NixOS/nixpkgs/commit/9c64b91d14268cf20ea07ea7930479a75325af9f) | `argo-rollouts: 1.2.2 -> 1.3.0`                                                   |
| [`16052c1c`](https://github.com/NixOS/nixpkgs/commit/16052c1ced48922410ec2e367ab1008c41c0beee) | `boulder: 2022-09-14 -> 2022-09-19`                                               |
| [`8d137f50`](https://github.com/NixOS/nixpkgs/commit/8d137f50b6a6bd8800109ebd62790d84d7e693cd) | `murex: 2.11.2000 -> 2.11.2030`                                                   |
| [`b87405ef`](https://github.com/NixOS/nixpkgs/commit/b87405ef6a9e93f9c8c6e2e8d162ba91cb7fec9f) | `pgo-client: 4.7.5 -> 4.7.7`                                                      |
| [`4ae2e3ae`](https://github.com/NixOS/nixpkgs/commit/4ae2e3aec5dfc5493a38135e2d677f5ca1801835) | `rekor-cli: 0.12.0 -> 0.12.1`                                                     |
| [`397da864`](https://github.com/NixOS/nixpkgs/commit/397da86480b14f176181e245a49d13bb16d58a29) | `trilium-{desktop,server}: 0.54.3 -> 0.55.1`                                      |
| [`fc4a516f`](https://github.com/NixOS/nixpkgs/commit/fc4a516f6e088c2e0de7a2610dc5350a746b9384) | `_1password-gui: 8.8.0 -> 8.9.4`                                                  |
| [`a4b0091e`](https://github.com/NixOS/nixpkgs/commit/a4b0091e4d8f393311a1e45410db8079ade6deb1) | `furnace: 0.6pre1 -> 0.6pre1.5`                                                   |
| [`3bc3c9a8`](https://github.com/NixOS/nixpkgs/commit/3bc3c9a89924285011ca25378b38f78821734b7f) | `circleci-cli: 0.1.21289 -> 0.1.21412`                                            |
| [`b6937cff`](https://github.com/NixOS/nixpkgs/commit/b6937cff13e2afbc74f505fde33090c1ab6a82d5) | `cargo-hack: 0.5.19 -> 0.5.20`                                                    |
| [`9827aa69`](https://github.com/NixOS/nixpkgs/commit/9827aa69044853b9ec53f5c09f826963fcde3b7b) | `flexget: 3.3.29 -> 3.3.30`                                                       |
| [`0e429a17`](https://github.com/NixOS/nixpkgs/commit/0e429a17f20f5f13340216c85670b742ce73adde) | `cargo-update: 8.1.4 -> 9.0.0`                                                    |
| [`a6fe6e96`](https://github.com/NixOS/nixpkgs/commit/a6fe6e968b1384e14c3d00db0e0eb257bc9fb1fd) | `bind: 9.18.6 -> 9.18.7`                                                          |
| [`204df87d`](https://github.com/NixOS/nixpkgs/commit/204df87d14fe54f18c904edb8f85a77296e5b5f6) | `millet: 0.3.8 -> 0.3.9`                                                          |
| [`6d459fd5`](https://github.com/NixOS/nixpkgs/commit/6d459fd53f9b1f72814c2e48dd0e4d9f72df14ab) | `maintainers: bulk update`                                                        |
| [`4aedfa3f`](https://github.com/NixOS/nixpkgs/commit/4aedfa3fc19bf75744fc3d2e57e3efa165ba88ce) | `python310Packages.opuslib: fix on aarch64-darwin`                                |
| [`36002dd5`](https://github.com/NixOS/nixpkgs/commit/36002dd59073bc33b9cc4f73365c0a590c5e5cbc) | `python310Packages.opuslib: nit: use hash property`                               |
| [`5c8e75d7`](https://github.com/NixOS/nixpkgs/commit/5c8e75d7a189e299981a82ff147018fe79f8d10c) | `cargo-depgraph: 1.2.5 -> 1.3.0`                                                  |
| [`a791d405`](https://github.com/NixOS/nixpkgs/commit/a791d4059cd428134c3859f6825c1781bbb85182) | `ngtcp2-gnutls: add passthru.tests`                                               |
| [`14a74990`](https://github.com/NixOS/nixpkgs/commit/14a7499006045d0af6388b9128d47fd19df3e851) | `ngtcp2-gnutls: 0.8.1 -> 0.9.0`                                                   |
| [`de529b10`](https://github.com/NixOS/nixpkgs/commit/de529b107b89f75a6853f83fbbc6948bfbf076dc) | `qcdnum: 17-01-15 -> 18-00-00`                                                    |
| [`2b2622aa`](https://github.com/NixOS/nixpkgs/commit/2b2622aada99060bd828ecdd70c0c7fd6165c984) | `buildbot: 3.6.0 -> 3.6.1`                                                        |
| [`8a45b1fd`](https://github.com/NixOS/nixpkgs/commit/8a45b1fde048f1958a11f62111e5b0299dc5cca0) | `python310Packages.trimesh: 3.15.1 -> 3.15.2`                                     |
| [`7e4923de`](https://github.com/NixOS/nixpkgs/commit/7e4923de25d46afe23553b345dc116739b757576) | `python39Packages.awkward: disabled on older Python releases`                     |
| [`2f04abe9`](https://github.com/NixOS/nixpkgs/commit/2f04abe9467c861451f94df8faf1cf988abc6ba2) | `python310Packages.plantuml-markdown: 3.6.2 -> 3.6.3`                             |
| [`1227325b`](https://github.com/NixOS/nixpkgs/commit/1227325bce11e8488f29b35dff30efaa143f7e26) | `fastlane: 2.210.0 -> 2.210.1`                                                    |
| [`c43baa4e`](https://github.com/NixOS/nixpkgs/commit/c43baa4e38d198f8ec0b2fe76841c0e567e2f228) | `ocamlPackages.mldoc: 1.3.9 -> 1.4.8`                                             |
| [`4db5a118`](https://github.com/NixOS/nixpkgs/commit/4db5a11822a229145c707965b0499b9453a4fc10) | `python310Packages.ezyrb: 1.3.0 -> 1.3.0.post2209`                                |
| [`3852ff1e`](https://github.com/NixOS/nixpkgs/commit/3852ff1e37b2e91f389e47640e0bd3e0881962ad) | `python39Packages.awkward: 1.10.0 -> 1.10.1`                                      |
| [`3834b409`](https://github.com/NixOS/nixpkgs/commit/3834b4091bbdcd0a879781be041c5bae1e870eb1) | `python310Packages.cloup: 1.0.0 -> 1.0.1`                                         |
| [`4aa24eff`](https://github.com/NixOS/nixpkgs/commit/4aa24effc71c4700aefc1213b9e4eca02e870cb0) | `python310Packages.datasets: 2.4.0 -> 2.5.1`                                      |
| [`473a5b09`](https://github.com/NixOS/nixpkgs/commit/473a5b09d16fc7ff5aa1e6159c77ac5c94766afb) | `ocamlPackages.uuidm: 0.9.7 -> 0.9.8`                                             |
| [`d6f45ea6`](https://github.com/NixOS/nixpkgs/commit/d6f45ea6cffab6fa0c9d57c06b2ebddf3629b260) | `ocamlPackages.ca-certs-nss: 3.74 -> 3.77`                                        |
| [`fd112343`](https://github.com/NixOS/nixpkgs/commit/fd11234381a4b19a2e7df65ee9efcc8e333da700) | `ngtcp2: 0.8.1 -> 0.9.0`                                                          |
| [`c1395217`](https://github.com/NixOS/nixpkgs/commit/c13952175c037ea938b9cd0403a76cb288d18d8e) | `mxnet: 1.8.0 -> 1.9.1`                                                           |
| [`d699b100`](https://github.com/NixOS/nixpkgs/commit/d699b1006804051cc950e6d730befef3825d26e3) | `redis: 7.0.4 -> 7.0.5`                                                           |
| [`8f05641d`](https://github.com/NixOS/nixpkgs/commit/8f05641d12be5bf8283af4162eeb4b26f8ac68e1) | `oh-my-posh: Add themes from source package to store`                             |
| [`4e1ac07b`](https://github.com/NixOS/nixpkgs/commit/4e1ac07bd937a09390909504e120a0ea96d10b7b) | `gitlab: 15.3.3 -> 15.4.0`                                                        |
| [`f49e5ecf`](https://github.com/NixOS/nixpkgs/commit/f49e5ecf5ac165b584b228e3947a9a34504d2664) | `nixpacks: 0.5.6 -> 0.6.2`                                                        |
| [`da60f2dc`](https://github.com/NixOS/nixpkgs/commit/da60f2dc9c95692804fa6575fa467e659de5031b) | `haskell.compiler.ghcHEAD: 9.3.20220406 -> 9.5.20220921`                          |
| [`a5009051`](https://github.com/NixOS/nixpkgs/commit/a50090515b3b8b9d80dd664b9211098ac7997413) | `minigalaxy: 1.1.0 -> 1.2.1`                                                      |
| [`ff63870d`](https://github.com/NixOS/nixpkgs/commit/ff63870d277e7ea8dde3edf7461d7452561181e3) | `python310Packages.pyipma: 3.0.2 -> 3.0.5`                                        |
| [`10d2104d`](https://github.com/NixOS/nixpkgs/commit/10d2104dcd36dbe356f5ac83054b38a40f113a91) | `qtile: 0.21.0 -> 0.22.1`                                                         |
| [`a6326117`](https://github.com/NixOS/nixpkgs/commit/a632611783f80a141fd44bdc64c9bd651764297b) | `bluetuith: 0.1.2 -> 0.1.3`                                                       |
| [`733ce794`](https://github.com/NixOS/nixpkgs/commit/733ce794b6e7b68773b654d6d9b00c237accb824) | `litefs: init at 0.2.0`                                                           |
| [`749f0fd1`](https://github.com/NixOS/nixpkgs/commit/749f0fd1f6d3d011fdd37f48bf4dd8f1e7b8c12b) | `python3Packages.apsw: 3.39.2.1 -> 3.39.3.0`                                      |
| [`e8c0a78f`](https://github.com/NixOS/nixpkgs/commit/e8c0a78f47e8d420f92a8ea81f17e02b26a5a8af) | `octoprint: 1.8.2 -> 1.8.3`                                                       |
| [`fc33893a`](https://github.com/NixOS/nixpkgs/commit/fc33893aef4e3edcc3a082c78c298ce8df147e67) | `python310Packages.green: update disabled`                                        |
| [`a2784b94`](https://github.com/NixOS/nixpkgs/commit/a2784b942f8606ef59f3d1cfdf17713144d9f965) | `cosign: 1.12.0 -> 1.12.1`                                                        |
| [`6ec7b528`](https://github.com/NixOS/nixpkgs/commit/6ec7b5282b8d1ee09f7ddb467bc1f35e59792a59) | `vifm-full: 0.12 -> 0.12.1`                                                       |
| [`2994b33b`](https://github.com/NixOS/nixpkgs/commit/2994b33ba05500de3e9396a6b66eed4383b4b297) | `vifm: 0.12 -> 0.12.1`                                                            |
| [`e9165928`](https://github.com/NixOS/nixpkgs/commit/e91659286d16103e9b749fa0a3b4a3978304fa83) | `python310Packages.green: 3.4.2 -> 3.4.3`                                         |
| [`607c97dc`](https://github.com/NixOS/nixpkgs/commit/607c97dc6a3da11ac4180009e1559b785ddecde9) | `scc: 3.0.0 -> 3.1.0`                                                             |
| [`c331842f`](https://github.com/NixOS/nixpkgs/commit/c331842ffc938cebc8ae6ad98b8881a80fbd8092) | `rocksdb: 7.5.3 -> 7.6.0`                                                         |
| [`d1729220`](https://github.com/NixOS/nixpkgs/commit/d1729220e22c6ce3eda50e452604f3b908eb8a53) | `pocketbase: 0.7.3 -> 0.7.5`                                                      |
| [`199294ed`](https://github.com/NixOS/nixpkgs/commit/199294ede0c713516bb8de07ab5ec67330907da4) | `python310Packages.sentry-sdk: 1.9.7 -> 1.9.8`                                    |
| [`a9caeb2c`](https://github.com/NixOS/nixpkgs/commit/a9caeb2c9ec91006c6f6f9572f647f72ff916a5d) | `python310Packages.sentry-sdk: 1.9.6 -> 1.9.7`                                    |