### PR TITLE
chore(flake/darwin): `95ba7e54` -> `02d2551c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664143588,
-        "narHash": "sha256-I1qaa8VMISprKulco2bxiIJUaz1NGiKmlsQuM996yzM=",
+        "lastModified": 1664210064,
+        "narHash": "sha256-df6nKVZe/yAhmJ9csirTPahc0dldwm3HBhCVNA6qWr0=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "95ba7e548d55e74c36369dbd6a4bfe99a543c835",
+        "rev": "02d2551c927b7d65ded1b3c7cd13da5cc7ae3fcf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message             |
| ------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2ee7b84e`](https://github.com/LnL7/nix-darwin/commit/2ee7b84e6bd90fa8efeea70cb77f436c56104c7d) | `remove duplicate "to be"` |
| [`3e28ca91`](https://github.com/LnL7/nix-darwin/commit/3e28ca913f5a3ab4d2b4e7530d56f9816f0730f3) | `Add comma for clarity`    |