### PR TITLE
chore(flake/home-manager): `9e739452` -> `65b65ce5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664146938,
-        "narHash": "sha256-fIvsJ3qWiD6o3qH9iU66OsL8uG5C1FGXcuaNEctJv8M=",
+        "lastModified": 1664217366,
+        "narHash": "sha256-YsqVv0D4YIXjeaz37V4/aRZrkAtEMZpFTn+tduI5fAM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9e7394523eb4f298528d457e316fc752bdf07151",
+        "rev": "65b65ce5ef08d54bc09336fe3f35e33be487e2fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`65b65ce5`](https://github.com/nix-community/home-manager/commit/65b65ce5ef08d54bc09336fe3f35e33be487e2fe) | `broot: use upstream defaults, allow all config options (#2644)` |