### PR TITLE
chore(flake/nixpkgs): `79d3ca08` -> `62228ccc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664106353,
-        "narHash": "sha256-HMJP80+DSxFySpWyuxz5+iNozS3+dVt0b4n6YMIU5/8=",
+        "lastModified": 1664195620,
+        "narHash": "sha256-/0V1a1gAR+QbiQe4aCxBoivhkxss0xyt2mBD6yDrgjw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "79d3ca08920364759c63fd3eb562e99c0c17044a",
+        "rev": "62228ccc672ed000f35b1e5c82e4183e46767e52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                        |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`cc8cb2ee`](https://github.com/NixOS/nixpkgs/commit/cc8cb2ee8eeae3e3280317bb9d760bc03609b647) | `matrix-appservice-irc: 0.35.0 -> 0.35.1`                             |
| [`dcc7610b`](https://github.com/NixOS/nixpkgs/commit/dcc7610bb11ffa1fb75801071c55b5cfca640957) | `awscli: Set meta.mainProgram`                                        |
| [`36f373dd`](https://github.com/NixOS/nixpkgs/commit/36f373ddca35b06b3543e2fd1d69c0b659e9b146) | `nil: unstable-2022-09-19 -> 2022-09-26`                              |
| [`78c4c13e`](https://github.com/NixOS/nixpkgs/commit/78c4c13ee555c302ea5a6a3c7a71277c00eaa46c) | `atmos: 1.8.0 -> 1.8.2`                                               |
| [`9b239527`](https://github.com/NixOS/nixpkgs/commit/9b239527d36c2931f0c8c8b71b83368b0aca1a0e) | `ptcollab: 0.6.2.0 -> 0.6.3.0`                                        |
| [`5483e610`](https://github.com/NixOS/nixpkgs/commit/5483e61017947e00cafb3128dc6601717fb96366) | `got: 0.75.1 -> 0.76`                                                 |
| [`c98e3b76`](https://github.com/NixOS/nixpkgs/commit/c98e3b76f6ebd5933132b4c63db789c838d2ac86) | `plantuml: 1.2022.7 -> 1.2022.8`                                      |
| [`46108446`](https://github.com/NixOS/nixpkgs/commit/4610844682acf9459fc5bcf05e76af91712c61a3) | `Split coqPackages.mathcomp-analysis`                                 |
| [`a59d71c8`](https://github.com/NixOS/nixpkgs/commit/a59d71c826bed0b35ef2502b0519ff50d527d95b) | `python310Packages.distutils_extra: remove blank line`                |
| [`f7bd4443`](https://github.com/NixOS/nixpkgs/commit/f7bd44436a7164d7ba51c1fa66a5d4ad610013dc) | `pyupgrade: 2.38.0 -> 2.38.1`                                         |
| [`bcf0c3a8`](https://github.com/NixOS/nixpkgs/commit/bcf0c3a882ec0de665f2bb3b3419d3497e5eb24c) | `tensorrt: provide default version fallback`                          |
| [`35425566`](https://github.com/NixOS/nixpkgs/commit/35425566b8873311ec9ef80609728040a6097ce1) | `cudnn: provide default version fallback`                             |
| [`4c4aaf0e`](https://github.com/NixOS/nixpkgs/commit/4c4aaf0ea46708e0d90a9bc588caa3315bc1c72a) | `python310Packages.siosocks: 0.2.0 -> 0.3.0`                          |
| [`aeb4b74c`](https://github.com/NixOS/nixpkgs/commit/aeb4b74c5abaf30a67811fa1a59aff4218990639) | `python310Packages.pypdf2: 2.10.9 -> 2.11.0`                          |
| [`a6a2762f`](https://github.com/NixOS/nixpkgs/commit/a6a2762fbaf235a9a92c05666bb6b03e79f5256a) | `python310Packages.rq: 1.11 -> 1.11.1`                                |
| [`d6fab542`](https://github.com/NixOS/nixpkgs/commit/d6fab5422168c5b3d4e5a11d3e81df74cd92b359) | `python310Packages.dunamai: 1.13.0 -> 1.13.1`                         |
| [`6f3ce7a6`](https://github.com/NixOS/nixpkgs/commit/6f3ce7a6209a0aa65fe42a21add7ecad469389ea) | `backport-action: 0.0.5 -> 0.0.8`                                     |
| [`c0ee929a`](https://github.com/NixOS/nixpkgs/commit/c0ee929a7dcde08996b0f56d97f619fc73319bb5) | `python310Packages.jarowinkler: 1.2.1 -> 1.2.2`                       |
| [`81489719`](https://github.com/NixOS/nixpkgs/commit/81489719f799ecb6a7407c37c61fb9501568ea96) | `godot-export-templates: strip export template file`                  |
| [`f6e3a8e5`](https://github.com/NixOS/nixpkgs/commit/f6e3a8e51241cea5cf994a6c9644589c47ba3c26) | `scraper: init at 0.13.0`                                             |
| [`67f82b05`](https://github.com/NixOS/nixpkgs/commit/67f82b05269e8faa2a4d7e84683495e1886b24e1) | `php80Packages.phpstan: 1.8.5 -> 1.8.6`                               |
| [`b1d7a2d1`](https://github.com/NixOS/nixpkgs/commit/b1d7a2d1a73d3d804492b8e2e8da22aa96fcb567) | `swiProlog: 8.3.29 -> 8.5.17`                                         |
| [`70168c4f`](https://github.com/NixOS/nixpkgs/commit/70168c4fde028ec5f7876da7c662cd9a7854c267) | `crun: drop criu workaround`                                          |
| [`4177a5d7`](https://github.com/NixOS/nixpkgs/commit/4177a5d748f85f7c903115fcf2c4a4ac43b1c7c0) | `ffmpeg_5: 5.1.1 -> 5.1.2`                                            |
| [`2beb26b4`](https://github.com/NixOS/nixpkgs/commit/2beb26b45be73dff0e80341b9e2de200c610a32f) | `seqtk: init at 1.3`                                                  |
| [`cc1685cf`](https://github.com/NixOS/nixpkgs/commit/cc1685cf0f2a212716e1831e6312941e9cc72cc1) | `maintainers: adds bwlang`                                            |
| [`eb687f6a`](https://github.com/NixOS/nixpkgs/commit/eb687f6a27608d7c1a117805ee162b908129dded) | `dum: init at 0.1.19`                                                 |
| [`a8b721d4`](https://github.com/NixOS/nixpkgs/commit/a8b721d4960189a6366f77baa3fd75b5673fac08) | `python310Packages.fastapi: 0.79.1 -> 0.85.0`                         |
| [`f225c0c5`](https://github.com/NixOS/nixpkgs/commit/f225c0c5c740ba9823bb2113d3e2fb14aefbf312) | `python310Packages.skodaconnect: 1.1.23 -> 1.1.25`                    |
| [`93c3dec0`](https://github.com/NixOS/nixpkgs/commit/93c3dec06bb303b7c5d6d25c5f7125750a80df75) | `vimPlugins.nvim-moonwalk: init at 2022-04-12`                        |
| [`623d50b2`](https://github.com/NixOS/nixpkgs/commit/623d50b213e458a78fc1bf61540c2b6bf3317e17) | `gnucash: 4.11 -> 4.12`                                               |
| [`cf49501b`](https://github.com/NixOS/nixpkgs/commit/cf49501b2197568ae226c34ee839b8a65772a4cd) | `uefi-run: init at 0.5.0 (#184200)`                                   |
| [`92400557`](https://github.com/NixOS/nixpkgs/commit/924005575b1e8023047fbe88a148a57711f7777a) | `python310Packages.geopandas: 0.11.0 -> 0.11.1`                       |
| [`8a60b7fb`](https://github.com/NixOS/nixpkgs/commit/8a60b7fbc438f4e8c6552264a5233086d09d2ba1) | `jmol: 14.32.74 -> 14.32.75`                                          |
| [`65f1654d`](https://github.com/NixOS/nixpkgs/commit/65f1654de2c36add85ebab7bcb70dd112ff2df2c) | `mastodon: Fix compatibility for openssl 3`                           |
| [`81231a82`](https://github.com/NixOS/nixpkgs/commit/81231a82dea880804977160cddfc2b8ee33110b5) | `fire: init at 1.0.0.3 (#188515)`                                     |
| [`e7a66a4a`](https://github.com/NixOS/nixpkgs/commit/e7a66a4a2200ee37703f90c104c716f8b1b18e70) | `quarto: fix formatting`                                              |
| [`8740c5fd`](https://github.com/NixOS/nixpkgs/commit/8740c5fd32a653db399ba614cb574df91e172e98) | `_3mux: update patch URL`                                             |
| [`a1d5c22e`](https://github.com/NixOS/nixpkgs/commit/a1d5c22e959a2422ff96f0aaf83068dd40a73317) | `gdlv: init at 1.8.0`                                                 |
| [`7c49c851`](https://github.com/NixOS/nixpkgs/commit/7c49c85106aceb05960f4ad8320c425c555d9180) | `python310Packages.luftdaten: 0.7.2 -> 0.7.3`                         |
| [`469b4280`](https://github.com/NixOS/nixpkgs/commit/469b42802d0a5f6380386d1cc00fab6284c82ef2) | `fractal-next: unstable-2022-07-21 -> 5-alpha1`                       |
| [`b0c9efc8`](https://github.com/NixOS/nixpkgs/commit/b0c9efc83620660122f54c370ace2bacc38c1732) | `mangal: init at version 3.10.0`                                      |
| [`c9fdfaa9`](https://github.com/NixOS/nixpkgs/commit/c9fdfaa9334ab71ed00bb4ed23214908ffee4778) | `python310Packages.canonicaljson: 1.6.2 -> 1.6.3`                     |
| [`5bb957a3`](https://github.com/NixOS/nixpkgs/commit/5bb957a3c56dbf25cc8c8e2ea5aa15df7bf27bb6) | `websocat: 1.9.0 -> 1.11.0`                                           |
| [`9460046d`](https://github.com/NixOS/nixpkgs/commit/9460046dbfc26c869670691a0a376ddfd1e4986e) | `unciv: 4.2.6 -> 4.2.11`                                              |
| [`c0fe1c0e`](https://github.com/NixOS/nixpkgs/commit/c0fe1c0eaeb21e4e5112d2754ff0cd2b0a21df0f) | `ruff: init at 0.0.46`                                                |
| [`5a938469`](https://github.com/NixOS/nixpkgs/commit/5a93846946dddcc99eac92a6278bb202943d4a9f) | `nixos/kthxbye: init`                                                 |
| [`cd709a06`](https://github.com/NixOS/nixpkgs/commit/cd709a0659c370a084b048ac3b58cd0a138e3477) | `tidal-hifi: 4.1.2 -> 4.2.0`                                          |
| [`84bcdf9b`](https://github.com/NixOS/nixpkgs/commit/84bcdf9b771c67d80bb25499fc6b00de9a28b98d) | `texlab: 4.2.2 -> 4.3.0`                                              |
| [`855db46b`](https://github.com/NixOS/nixpkgs/commit/855db46b9db5012e6f4056037d7630da1f6cc8f2) | `openscad: add support for exporting PDFs`                            |
| [`324655f4`](https://github.com/NixOS/nixpkgs/commit/324655f468232b43eeb08d1157f67e67f3826b65) | `pdfarranger: 1.9.0 -> 1.9.1`                                         |
| [`dca39dc8`](https://github.com/NixOS/nixpkgs/commit/dca39dc8616d18984ace60c223e1ab5070d7a06f) | `exploitdb: 2022-09-22 -> 2022-09-24`                                 |
| [`60f34d39`](https://github.com/NixOS/nixpkgs/commit/60f34d39195a63b0f0c91772f2e7130ab8869116) | `coqPackages.serapi: init at 8.16.0+0.16.0 for Coq 8.16`              |
| [`dbf8bba9`](https://github.com/NixOS/nixpkgs/commit/dbf8bba95bea7255565d6f4862ac515944f45254) | `nixos/yggdrasil: services.yggdrasil.config renamed to settings`      |
| [`05d2c86f`](https://github.com/NixOS/nixpkgs/commit/05d2c86f06bca6fb25f41a38e134a28c5ab66ebe) | `markdown-anki-decks: 1.0.0 -> 1.1.1`                                 |
| [`58c774d7`](https://github.com/NixOS/nixpkgs/commit/58c774d72754472cc981b637664d40490bb5e641) | `python310Packages.rstcheck: 6.0.0.post1 -> 6.1.0`                    |
| [`d1f77549`](https://github.com/NixOS/nixpkgs/commit/d1f77549784162e455d06535611610727ca908f3) | `streamdeck-ui: 2.0.4 -> 2.0.6`                                       |
| [`d614292a`](https://github.com/NixOS/nixpkgs/commit/d614292a030f854c873bdef7c52d05d52bcb2359) | `python310Packages.dbus-fast: 1.11.0 -> 1.13.0`                       |
| [`3c009ec9`](https://github.com/NixOS/nixpkgs/commit/3c009ec99894f6c0913fa7d91f5fdc4e65f9a371) | `python310Packages.pyunifiprotect: 4.2.0 -> 4.3.3`                    |
| [`031d152c`](https://github.com/NixOS/nixpkgs/commit/031d152c4a43dab6cc7cc52836cb7ec1bf4417c5) | `cadical: 1.5.0 -> 1.5.3`                                             |
| [`b49efa01`](https://github.com/NixOS/nixpkgs/commit/b49efa0116e274465ec2e98e59f3ffe2f4ad19ab) | `linux-lqx: 5.19.10 -> 5.19.11`                                       |
| [`88a97a22`](https://github.com/NixOS/nixpkgs/commit/88a97a22c4032885bf0736f79aa3c2f7b15f87e9) | `miniplayer: 1.7.0 -> 1.7.1`                                          |
| [`408d220f`](https://github.com/NixOS/nixpkgs/commit/408d220f0e9f5fbce66bcbaa03da24f355bb8820) | `linux-zen: 5.19.10 -> 5.19.11`                                       |
| [`4bb26cf7`](https://github.com/NixOS/nixpkgs/commit/4bb26cf7a17844158b1eacb156aaea012443cc6d) | `python310Packages.typer: add optional-dependencies`                  |
| [`916a8308`](https://github.com/NixOS/nixpkgs/commit/916a8308d16f05b2592fe3c1a33daca9f548d8dc) | `remote-touchpad: 1.2.1 -> 1.2.2`                                     |
| [`6762de9a`](https://github.com/NixOS/nixpkgs/commit/6762de9a28e248f46bd0810e03c9666289de8e1d) | `check-meta.nix: type checking changes`                               |
| [`254a6aad`](https://github.com/NixOS/nixpkgs/commit/254a6aada9af000d6d34789564c6ee2c4df3a25b) | `CODEOWNERS: add piegames to check-meta.nix`                          |
| [`0ada9fff`](https://github.com/NixOS/nixpkgs/commit/0ada9fff8a86dc582ebee158107d4f942e865ab0) | `lib/types.nix: Document that it should not be used`                  |
| [`2da151f5`](https://github.com/NixOS/nixpkgs/commit/2da151f56acae6743d85416ea7bc9a61581dc7eb) | `python310Packages.nats-py: exclude tests for darwin`                 |
| [`6d032933`](https://github.com/NixOS/nixpkgs/commit/6d032933823d6bb88b15b6ba975fa627ec96ae0d) | `python310Packages.nats-py: 2.1.6 -> 2.1.7`                           |
| [`35e8308d`](https://github.com/NixOS/nixpkgs/commit/35e8308d98eca72b1fb4e806f847ef89d5a192ef) | `python310Packages.nats-py: 2.1.5 -> 2.1.6`                           |
| [`46d35852`](https://github.com/NixOS/nixpkgs/commit/46d35852e94bce9381877bcb44032e0c39da0bb1) | `python310Packages.nats-py: 2.1.4 -> 2.1.5`                           |
| [`4e03ac8e`](https://github.com/NixOS/nixpkgs/commit/4e03ac8e7008357e98537cf63950705cc405dfe0) | `python310Packages.aiopg: 1.3.4 -> 1.3.5`                             |
| [`0ed54c5e`](https://github.com/NixOS/nixpkgs/commit/0ed54c5ecf5f18e5ac9c14b44f5a6f97e3922309) | `mautrix-telegram: fix tulir-telethon override`                       |
| [`c0118dcb`](https://github.com/NixOS/nixpkgs/commit/c0118dcbbb70bcdf64f4227d8c62851531eced6b) | `python310Packages.telethon: 1.25.0 -> 1.25.1`                        |
| [`57b30390`](https://github.com/NixOS/nixpkgs/commit/57b303909207336077a3173f45e7203e803b2a42) | `libmpack: build with config=release`                                 |
| [`728044b2`](https://github.com/NixOS/nixpkgs/commit/728044b22ce94d19e8e62e645b8e48a1d2b09c88) | `python310Packages.xsdata: 22.8 -> 22.9`                              |
| [`9a1edca2`](https://github.com/NixOS/nixpkgs/commit/9a1edca21486bcc686c2216c55fad318c3eaff26) | `libtensorflow-bin: drop`                                             |
| [`eba37cb4`](https://github.com/NixOS/nixpkgs/commit/eba37cb48d476a16c3bd65ed7a2938c8b9c4775e) | `discordchatexporter-cli: 2.36 -> 2.36.1`                             |
| [`872c7674`](https://github.com/NixOS/nixpkgs/commit/872c7674ed60c935c8501cc3878ca5dba584043a) | `broot: 1.14.3 -> 1.15.0`                                             |
| [`cea54589`](https://github.com/NixOS/nixpkgs/commit/cea5458966902d059573b3b2361aff22f54ee21b) | `julia_18: init at 1.8.1`                                             |
| [`035cca50`](https://github.com/NixOS/nixpkgs/commit/035cca50b7dc3c1d281756b64b9c91f8e479884d) | `gallia: mark as broken on darwin`                                    |
| [`a9da0a7d`](https://github.com/NixOS/nixpkgs/commit/a9da0a7de2023363f4d67c96278374832ff90033) | `gallia: init at 1.0.3`                                               |
| [`3be64031`](https://github.com/NixOS/nixpkgs/commit/3be64031269cd1b384bcf0afca8151805ab8b497) | `quarto: init at 1.1.189`                                             |
| [`2bc8cde5`](https://github.com/NixOS/nixpkgs/commit/2bc8cde50872937b3e2629bf13ad2835f25d2004) | `Add me as a maintainer of the package`                               |
| [`acf5b5d7`](https://github.com/NixOS/nixpkgs/commit/acf5b5d79d8c6046b24b9b38353402709c4aecdf) | `add therishidesai to the maintainers`                                |
| [`63d54a85`](https://github.com/NixOS/nixpkgs/commit/63d54a85c19b55df8a05c76210bd862b338af62b) | `humility: init at unstable-2022-09-15`                               |
| [`dd76aebb`](https://github.com/NixOS/nixpkgs/commit/dd76aebb98123e2064f8a1f657db449d8af193b3) | `trealla: 1.20.31 -> 2.2.6`                                           |
| [`c87abaa0`](https://github.com/NixOS/nixpkgs/commit/c87abaa0f77effca6757145631be78fd5cc93a11) | `jaq: init at 0.8.0`                                                  |
| [`e4b57b14`](https://github.com/NixOS/nixpkgs/commit/e4b57b1481e0ad56f5c196ccb880e2f8ddecfc44) | `maintainers: add meain`                                              |
| [`0a564318`](https://github.com/NixOS/nixpkgs/commit/0a564318e84a720f2139a3927e622e85583102e1) | `nixos/onlyoffice: fix database upgrades`                             |
| [`1dded5d8`](https://github.com/NixOS/nixpkgs/commit/1dded5d888a31995bcf4de1dc8a8ffc02dd9a381) | `python310Packages.sensor-state-data: 2.7.0 -> 2.8.0`                 |
| [`5243f0ca`](https://github.com/NixOS/nixpkgs/commit/5243f0cacaf49ea13c52a068ec7955fd61e3ac8c) | `python310Packages.sensor-state-data: 2.6.0 -> 2.7.0`                 |
| [`1fad65c5`](https://github.com/NixOS/nixpkgs/commit/1fad65c54227da9c29a7a39dd5e8a2d8c9157cbb) | `railway: 2.0.11 -> 2.0.12`                                           |
| [`96de24ef`](https://github.com/NixOS/nixpkgs/commit/96de24efbad1e3f766251341db332133971913fa) | `onlyoffice-documentserver: 7.1.1-23 -> 7.2.0`                        |
| [`ed457457`](https://github.com/NixOS/nixpkgs/commit/ed4574574a74da80ae324d5f6acfeea115583e49) | `xdg-ninja: init at 0.2.0.1`                                          |
| [`64483994`](https://github.com/NixOS/nixpkgs/commit/6448399431cb958d10e16b9112f7cb4762ab6e9c) | `defaultbrowser: init at unstable-2020-07-23`                         |
| [`ba914d79`](https://github.com/NixOS/nixpkgs/commit/ba914d792561486c60dc13b8bbebfa99b587f34d) | `pcsx2: 1.7.3165 -> 1.7.3331`                                         |
| [`cc5159e5`](https://github.com/NixOS/nixpkgs/commit/cc5159e589d1e60d1c0d4212c9b3d448d20a2e70) | `vscode-extensions.chenglou92.rescript-vscode: 1.3.0 -> 1.6.0`        |
| [`6178a38b`](https://github.com/NixOS/nixpkgs/commit/6178a38b3d2ff7c10d0a15971826eb4d1bd5d283) | `libblockdev: 2.26 -> 2.27`                                           |
| [`499aebcf`](https://github.com/NixOS/nixpkgs/commit/499aebcf340f48ef02211700b39512c429bf88bb) | `portableService: tooling to create portable service images`          |
| [`1327c48b`](https://github.com/NixOS/nixpkgs/commit/1327c48bb7805806cdc90832a0551b8eed2d93a4) | `kubebuilder: add shell completion, version test`                     |
| [`2d582d64`](https://github.com/NixOS/nixpkgs/commit/2d582d641b52fad9386880118c618fb58c4c2a32) | `oven-media-engine: 0.13.2 -> 0.14.10`                                |
| [`10086519`](https://github.com/NixOS/nixpkgs/commit/100865193104bd579903e94fae9a04f4dbfed929) | `last: 1409 -> 1411`                                                  |
| [`07a9b7b1`](https://github.com/NixOS/nixpkgs/commit/07a9b7b1d83f1cde5544063351d6886a2ca9607c) | `nixos/{test/,}v2ray: fix for new CLI and use upstream systemd units` |
| [`4f962f65`](https://github.com/NixOS/nixpkgs/commit/4f962f65c4294267574801c986d61ece84c8ff8d) | `v2ray: 4.45.0 -> 5.1.0 and refactor`                                 |
| [`6f363379`](https://github.com/NixOS/nixpkgs/commit/6f363379466965b095b8eb4db92901ca5946a6b2) | `v2ray-domain-list-community: 20220908131416 -> 20220921050909`       |
| [`f6037721`](https://github.com/NixOS/nixpkgs/commit/f60377210e92df7dbd4d89682e476d6cb17e747d) | `knot-*: set .meta.mainProgram`                                       |
| [`ec4e9c37`](https://github.com/NixOS/nixpkgs/commit/ec4e9c3763439eeac49680a6bc2615742977343d) | `ooniprobe-cli: 3.16.0 -> 3.16.3`                                     |
| [`2443294b`](https://github.com/NixOS/nixpkgs/commit/2443294b32c667fc2d922177bce0168ae2165bbf) | `tortoisehg: 6.1->6.2.2`                                              |
| [`e8743bf6`](https://github.com/NixOS/nixpkgs/commit/e8743bf62d00b05c3cc8d177895d0762e9bad0aa) | `dolphin-emu-beta: cleanup`                                           |
| [`5c9d47e2`](https://github.com/NixOS/nixpkgs/commit/5c9d47e225841b6d124b59fbe82da3786da98e00) | `dolphin-emu-beta: fix darwin build`                                  |
| [`bf5ddca4`](https://github.com/NixOS/nixpkgs/commit/bf5ddca465f1022d74a5a3120e72ab1c421bfe72) | `kthxbye: init at 0.15`                                               |
| [`150e5d9f`](https://github.com/NixOS/nixpkgs/commit/150e5d9f4591191484ca8416b6ffb8c9594eeb73) | `activemq: 5.17.1 -> 5.17.2`                                          |
| [`c9c906c8`](https://github.com/NixOS/nixpkgs/commit/c9c906c8a2f6634092f4524e18c135eddb919553) | `earthly: 0.6.22 -> 0.6.23`                                           |
| [`dabaf5d7`](https://github.com/NixOS/nixpkgs/commit/dabaf5d73e253fcf24f62adfb18b8ae4d4004b3c) | `memcached: 1.6.16 -> 1.6.17`                                         |
| [`3b3fa4f1`](https://github.com/NixOS/nixpkgs/commit/3b3fa4f1da03ea8008540206dca796f21c10144c) | `xrootd: 5.4.3 -> 5.5.0`                                              |
| [`18a92116`](https://github.com/NixOS/nixpkgs/commit/18a921164008757a3da16aa0a940e6f06be62ad9) | `appimage-run: add vulkan-loader and libpulseaudio`                   |
| [`142d1598`](https://github.com/NixOS/nixpkgs/commit/142d15987a23338177a244f4eac1b52b398ba56e) | `python310Packages.distutils_extra: 2.45 -> 2.47`                     |
| [`d2416b5f`](https://github.com/NixOS/nixpkgs/commit/d2416b5f18b4e78fc6100fdcc7f8763c5af48daf) | `python310Packages.qcs-api-client: 0.21.0 -> 0.21.1`                  |
| [`6ee81c6c`](https://github.com/NixOS/nixpkgs/commit/6ee81c6c143c24aa8fc8765c35f8c70a58caf02a) | `libdmtx: 0.7.5 -> 0.7.7`                                             |
| [`39e4cd93`](https://github.com/NixOS/nixpkgs/commit/39e4cd93539911faf214c1cd2e1fe3414bccbee9) | `libblockdev: 2.26 -> 2.27`                                           |
| [`bfc6898d`](https://github.com/NixOS/nixpkgs/commit/bfc6898da5d156e202dfd21f7e9d72d765cbbaa4) | `libbytesize: 2.6 -> 2.7`                                             |