### PR TITLE
chore(flake/nixos-hardware): `a0df6cd6` -> `2a7f39aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1663229557,
-        "narHash": "sha256-1uU4nsDLXKG0AHc/VCsNBAEPkTA/07juYhcEWRb1O1E=",
+        "lastModified": 1664355788,
+        "narHash": "sha256-/QOoHlhfesyvDkqkjw1gh7eLFiuLvIT+4alqiQpeBAU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a0df6cd6e199df4a78c833c273781ea92fa62cfb",
+        "rev": "2a7f39aac2c84b7b42cd416464c9f6c170d201a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                            |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`2aa0939a`](https://github.com/NixOS/nixos-hardware/commit/2aa0939a6558b0d740c2bd0eff7d8cb8e052bd36) | `Fixed utillinux package renaming`        |
| [`cc5d5020`](https://github.com/NixOS/nixos-hardware/commit/cc5d50203078bb350737b0b12c90e216c514b71e) | `onenetbook/4: stop using runCommandNoCC` |
| [`3774a528`](https://github.com/NixOS/nixos-hardware/commit/3774a528de7faf9c452e3c02fed4191593d2c585) | `kobol/helios4: init`                     |