### PR TITLE
chore(flake/home-manager): `68ea28d3` -> `864ff685`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664446012,
-        "narHash": "sha256-3j7fQ3Kkw955pKcHjvROWYUDpLtYcNfXwz/rs+UetHc=",
+        "lastModified": 1664449551,
+        "narHash": "sha256-iTStJtZB1+MppkT+95Ckqy2NDaISb+QcUkOAa0DS0io=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "68ea28d330f2e1ef3fb2c653da42b558f14a1efd",
+        "rev": "864ff685fe6443101a0a8f3950d21bcb4330e56a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`864ff685`](https://github.com/nix-community/home-manager/commit/864ff685fe6443101a0a8f3950d21bcb4330e56a) | `lib: add two new gvariant types`             |
| [`9da6c023`](https://github.com/nix-community/home-manager/commit/9da6c0232e22b7fff358db633f6bbc8f97a891e1) | `docs: explain how to enable flakes on NixOS` |