### PR TITLE
chore(flake/nixos-hardware): `12f905b7` -> `3024c67a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1664452918,
-        "narHash": "sha256-SfnQ2t5b9RTSIqO3PQBDlwrWn4l3t0F65sZtCKTl8eA=",
+        "lastModified": 1664628729,
+        "narHash": "sha256-A1J0ZPhBfZZiWI6ipjKJ8+RpMllzOMu/An/8Tk3t4oo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "12f905b731494bc59010f05a7467df8abdcf8d63",
+        "rev": "3024c67a2e9a35450558426c42e7419ab37efd95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`a2dab346`](https://github.com/NixOS/nixos-hardware/commit/a2dab346f9e4da7cf2298bef1c973152f76a4f42) | `CONTRIBUTING.md: mention bors` |
| [`3a5dd128`](https://github.com/NixOS/nixos-hardware/commit/3a5dd128e410097d5b2538382b636f52c746798a) | `add bors configuration`        |