### PR TITLE
chore(flake/nixpkgs): `854fdc68` -> `10ecda25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664370076,
-        "narHash": "sha256-NDnIo0nxJozLwEw0VPM+RApMA90uTfbvaNNtC5eB7Os=",
+        "lastModified": 1664538465,
+        "narHash": "sha256-EnlC7dDKX7X1wlnXkB1gmn9rBZQ0J9+biVTZHw//8us=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "854fdc68881791812eddd33b2fed94b954979a8e",
+        "rev": "10ecda252ce1b3b1d6403caeadbcc8f30d5ab796",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                          |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`05230d2f`](https://github.com/NixOS/nixpkgs/commit/05230d2f82ec60578f71518d6b57ea3cafbad71c) | `cloud-nuke: 0.19.1 -> 0.20.0`                                          |
| [`088d2ac5`](https://github.com/NixOS/nixpkgs/commit/088d2ac5eb639b6234b375f1f22cfec0092b5293) | `circleci-cli: 0.1.21412 -> 0.1.21812`                                  |
| [`baf2e6d0`](https://github.com/NixOS/nixpkgs/commit/baf2e6d069a0ad3540939c313c8ee9f2de149fdd) | `gemrb: 0.9.0 -> 0.9.1`                                                 |
| [`41b1a470`](https://github.com/NixOS/nixpkgs/commit/41b1a470078114fd1f6b57db7fc25a81b4c30ae1) | `python310Packages.snowflake-connector-python: 2.7.12 -> 2.8.0`         |
| [`78c2c80f`](https://github.com/NixOS/nixpkgs/commit/78c2c80f8233bce50366d623b5e15cca729b12a6) | `python310Packages.slack-sdk: 3.18.3 -> 3.18.4`                         |
| [`e9b62b6c`](https://github.com/NixOS/nixpkgs/commit/e9b62b6c2b92e80058c58f9035d0e2b37d228bce) | `ansible-later: 2.0.20 -> 2.0.21`                                       |
| [`a3c60070`](https://github.com/NixOS/nixpkgs/commit/a3c60070ad0d66c2b318687b560da319fa57fa43) | `python3Packages.canonicaljson: add setuptools dependency`              |
| [`13ce0c05`](https://github.com/NixOS/nixpkgs/commit/13ce0c059d4aac819cad877703ee1c3cfeba44fc) | `ansible-doctor: 1.4.4 -> 1.4.5`                                        |
| [`9cf45de9`](https://github.com/NixOS/nixpkgs/commit/9cf45de9d620c9179781c04428712c3fa0447fc3) | `multimarkdown: Move files from $out/ to $out/share/doc/multimarkdown/` |
| [`6cc28f43`](https://github.com/NixOS/nixpkgs/commit/6cc28f4360f275697d5afc1ab2881839c91266e1) | `python310Packages.schiene: 0.24 -> 0.26`                               |
| [`51ada90c`](https://github.com/NixOS/nixpkgs/commit/51ada90c64bc5133588abe5a8f399f9bd042f72c) | `php81: 8.1.10 -> 8.1.11`                                               |
| [`0d87d223`](https://github.com/NixOS/nixpkgs/commit/0d87d2232ab3403cd055c3abb1d8069790dbc36c) | `php80: 8.0.23 -> 8.0.24`                                               |
| [`3decf9ea`](https://github.com/NixOS/nixpkgs/commit/3decf9eac0a382cce3b3169cf350705b73397948) | `mullvad-vpn: remove myself from maintainers`                           |
| [`d103ec30`](https://github.com/NixOS/nixpkgs/commit/d103ec30c2492177c59e5c13130f25ee6fe029d5) | `python310Packages.pytest-check: 1.0.9 -> 1.0.10`                       |
| [`7398c772`](https://github.com/NixOS/nixpkgs/commit/7398c7728c573090d7f17c64e83fabaeea30f27d) | `python310Packages.pysigma: 0.8.1 -> 0.8.2`                             |
| [`d4eaf0af`](https://github.com/NixOS/nixpkgs/commit/d4eaf0af09ef9f9cf3540935f58cb887219305c4) | `python310Packages.pex: 2.1.105 -> 2.1.106`                             |
| [`55b0f7fa`](https://github.com/NixOS/nixpkgs/commit/55b0f7fa38a034250962b878f8b63b4384b0d417) | `python310Packages.peaqevcore: 5.18.4 -> 6.0.0`                         |
| [`9d6f2945`](https://github.com/NixOS/nixpkgs/commit/9d6f29454b409271bd0f9cb852faa510c7794283) | `python310Packages.nunavut: 1.8.3 -> 1.9.0`                             |
| [`03caab55`](https://github.com/NixOS/nixpkgs/commit/03caab553ca79d84bba5ba6353d2ee0f6d687492) | `python310Packages.myst-nb: 0.16.0 -> 0.17.0`                           |
| [`2867d65d`](https://github.com/NixOS/nixpkgs/commit/2867d65dc185d542173e9a763c2dddb9a9d7c64f) | `v2ray-geoip: 202209220104 -> 202209290111`                             |
| [`8bae00e5`](https://github.com/NixOS/nixpkgs/commit/8bae00e5d1de2de9e7af663a17e6475c81b019e3) | `python310Packages.xxh: 0.8.11 -> 0.8.12`                               |
| [`49ea326b`](https://github.com/NixOS/nixpkgs/commit/49ea326b67f9e095dfe3d57b53fa8a56b0a797da) | `lxd: use buildGoModule`                                                |
| [`230aeef7`](https://github.com/NixOS/nixpkgs/commit/230aeef7a7fe3c7072797bcb096015507f3eaa5b) | `python310Packages.google-cloud-resource-manager: 1.6.1 -> 1.6.2`       |
| [`0bcd3ecd`](https://github.com/NixOS/nixpkgs/commit/0bcd3ecd8665194e4e533fd31e625b3957504c9f) | `python310Packages.google-cloud-language: 2.5.2 -> 2.6.0`               |
| [`541d65a0`](https://github.com/NixOS/nixpkgs/commit/541d65a0275ced7ae453fb10e78f5e5a53910c63) | `python310Packages.google-cloud-iam-logging: 1.0.4 -> 1.0.5`            |
| [`86cb5549`](https://github.com/NixOS/nixpkgs/commit/86cb5549111e65d46527fecadd593b7432600688) | `python310Packages.google-cloud-bigquery-storage: 2.16.0 -> 2.16.1`     |
| [`6619fdab`](https://github.com/NixOS/nixpkgs/commit/6619fdab8e06bb5b3bccc32d586104461e950932) | `python310Packages.google-cloud-bigquery: 3.3.2 -> 3.3.3`               |
| [`c2bd4444`](https://github.com/NixOS/nixpkgs/commit/c2bd444481ad37ac2059580b99281915ab7d5a9c) | `vault: 1.11.3 -> 1.11.4`                                               |
| [`3f8ee365`](https://github.com/NixOS/nixpkgs/commit/3f8ee3651cb68cdc80ed1f95f35831f94a4609a4) | `vault-bin: 1.11.3 -> 1.11.4`                                           |
| [`a2de6389`](https://github.com/NixOS/nixpkgs/commit/a2de638971e74eb6f6ce182eb19f0a275cd19d29) | `trivy: 0.32.0 -> 0.32.1`                                               |
| [`d108a440`](https://github.com/NixOS/nixpkgs/commit/d108a440c139d4d0edbf71af437b69a3fe3912bf) | `python310Packages.furo: 2022.9.15 -> 2022.9.29`                        |
| [`b76d66b4`](https://github.com/NixOS/nixpkgs/commit/b76d66b4fd41351e9265786db74d0c8660e27a99) | `nixos/sachet: replace literalExample with literalExpression`           |
| [`32112b78`](https://github.com/NixOS/nixpkgs/commit/32112b7895fb749ab03e546c2e5fc883d39b9a9e) | `python310Packages.flask-security-too: 5.0.1 -> 5.0.2`                  |
| [`75bacdda`](https://github.com/NixOS/nixpkgs/commit/75bacddae67b07cf3c749fb97a0f8e4f3afe0425) | `git-gone: v0.4.0 -> v0.4.1`                                            |
| [`f837ed4f`](https://github.com/NixOS/nixpkgs/commit/f837ed4f7fdb3cc5d5aa84afc5e7dbd9affd4b29) | `testssl: 3.0.7 -> 3.0.8`                                               |
| [`cd4e2b3b`](https://github.com/NixOS/nixpkgs/commit/cd4e2b3b3c0fe809b521a1921cb85e4d86a20e9b) | `syft: 0.57.0 -> 0.58.0`                                                |
| [`757f542d`](https://github.com/NixOS/nixpkgs/commit/757f542d663fa0d23c65554b1d60af9f0be9551a) | `spicetify-cli: 2.13.1 -> 2.14.0`                                       |
| [`2d3705b1`](https://github.com/NixOS/nixpkgs/commit/2d3705b1419c05a02c83868692112e91ef09c893) | `root: mark broken on aarch64`                                          |
| [`f8913a9e`](https://github.com/NixOS/nixpkgs/commit/f8913a9ed7d0e5536ffb9b6cdb47b4a9e5d77ed3) | `opentelemetry-collector-contrib: 0.60.0 -> 0.61.0`                     |
| [`43812755`](https://github.com/NixOS/nixpkgs/commit/438127551fd0528bc063c83f6a2198dde2102630) | `rekor-cli: 0.12.1 -> 0.12.2`                                           |
| [`1dafc2cd`](https://github.com/NixOS/nixpkgs/commit/1dafc2cd56f9f6aebc60212be36fb5be1ebc342c) | ``novnc: use installed package files as default for `--web```           |
| [`8813bb7a`](https://github.com/NixOS/nixpkgs/commit/8813bb7a48285efbe4e67c9d258f01ba1e4b5704) | `mmtc: 0.2.14 -> 0.2.15`                                                |
| [`18a8af17`](https://github.com/NixOS/nixpkgs/commit/18a8af1730dcdc9b7dbf5e0942989585198160b5) | `opentelemetry-collector: 0.60.0 -> 0.61.0`                             |
| [`141266be`](https://github.com/NixOS/nixpkgs/commit/141266be879bd1063e01085eec69ea1db37607d4) | `nixpacks: 0.7.2 -> 0.8.0`                                              |
| [`ccbff433`](https://github.com/NixOS/nixpkgs/commit/ccbff4333d95f15e4e1d31d6dd6e939db617cf1e) | `metal-cli: 0.9.1 -> 0.10.0`                                            |
| [`e3dde55e`](https://github.com/NixOS/nixpkgs/commit/e3dde55e488e4b60af3c613b10410ff4bc99741f) | `netavark: 1.1.0 -> 1.2.0`                                              |
| [`4c71fd0a`](https://github.com/NixOS/nixpkgs/commit/4c71fd0afa9090432596dd2327f22e15f9cc516b) | `aardvark-dns: 1.1.0 -> 1.2.0`                                          |
| [`3f5bcad9`](https://github.com/NixOS/nixpkgs/commit/3f5bcad9334edd5f949e003314113dfca825966b) | `ruff: 0.0.47 -> 0.0.48`                                                |
| [`18190899`](https://github.com/NixOS/nixpkgs/commit/181908996a31df7fa420ed6ac4e54eeeb710f6d2) | `sourcehut.buildsrht: 0.81.0 -> 0.82.8 (#192450)`                       |
| [`3955ba38`](https://github.com/NixOS/nixpkgs/commit/3955ba389c1156ed862f78cfba77f47c7e2c44d1) | `pc-ble-driver: fix build on aarch64-darwin, little cleanups (#192565)` |
| [`cb1428fc`](https://github.com/NixOS/nixpkgs/commit/cb1428fce688235daee72e655707818ac4759b1e) | `mold: 1.5.0 -> 1.5.1`                                                  |
| [`6609c223`](https://github.com/NixOS/nixpkgs/commit/6609c223b0e707ddfbb552d730e3bef3dc5bea65) | `gitlab: 15.4.0 -> 15.4.1`                                              |
| [`7b397408`](https://github.com/NixOS/nixpkgs/commit/7b3974085ccf2ee4ecfebb495daf1431f62c8739) | `libmaxminddb: 1.6.0 -> 1.7.0`                                          |
| [`5823ddde`](https://github.com/NixOS/nixpkgs/commit/5823dddeb61056de4cb2f625761798a552810698) | `fluxcd: 0.34.0 -> 0.35.0`                                              |
| [`6a41a5d4`](https://github.com/NixOS/nixpkgs/commit/6a41a5d495aaa402264c1967fc8344f4b47db8f8) | `python310Packages.cloudsmith-api: 1.120.3 -> 1.142.3`                  |
| [`419f5ba2`](https://github.com/NixOS/nixpkgs/commit/419f5ba2343e8fdfb3171ada263b0db5eb105fb1) | `treesheets: unstable-2022-03-12 -> unstable-2022-09-26`                |
| [`03a2429a`](https://github.com/NixOS/nixpkgs/commit/03a2429a513f3ee6e7acbd8893751162b917763b) | `kics: 1.6.0 -> 1.6.1`                                                  |
| [`5cac465e`](https://github.com/NixOS/nixpkgs/commit/5cac465ec618cdc6e9077b447b4a5b138e482ddb) | `wayland-proxy-virtwl: unstable-2021-12-05 -> unstable-2022-09-22`      |
| [`2f274314`](https://github.com/NixOS/nixpkgs/commit/2f27431460d4339a5c5c4b0de8ab5e7ac660591a) | `ocamlPackages.wayland: 1.0 -> 1.1`                                     |
| [`5ca3d56b`](https://github.com/NixOS/nixpkgs/commit/5ca3d56bc156d2bec6afd05c0b65d9454c892e30) | `vscode-extensions.jebbs.plantuml: init at 2.17.4`                      |
| [`2844a39d`](https://github.com/NixOS/nixpkgs/commit/2844a39d85adcf235da4137235651b114b2459c2) | `nfpm: 2.19.1 -> 2.19.2`                                                |
| [`e94b2f2a`](https://github.com/NixOS/nixpkgs/commit/e94b2f2a9cea6ce14ffa22567d708371180886d6) | `picom-next: unstable-2022-08-23 -> unstable-2022-09-29`                |
| [`67472810`](https://github.com/NixOS/nixpkgs/commit/674728104464509a26698ba1c7a30943c6846246) | `argc: 0.11.0 -> 0.12.0`                                                |
| [`5f87f6f3`](https://github.com/NixOS/nixpkgs/commit/5f87f6f3a09ac977b4da70d9832bf0211d1282e8) | `maintainers: change victormignot e-mail`                               |
| [`eeb1287c`](https://github.com/NixOS/nixpkgs/commit/eeb1287c060954509e1b4c9aedaf7abf9b8f0b29) | `thunderbird-bin: 102.3.0 -> 102.3.1`                                   |
| [`95f0a5d6`](https://github.com/NixOS/nixpkgs/commit/95f0a5d608945284175f3c7a0661155abc58543c) | `thunderbird: 102.3.0 -> 102.3.1`                                       |
| [`bf012b5f`](https://github.com/NixOS/nixpkgs/commit/bf012b5f48753331f6ee31023299451395215761) | `python3Packages.pytest-astropy-header: remove extra arguments`         |
| [`aedd12c9`](https://github.com/NixOS/nixpkgs/commit/aedd12c96a3349c7f48b9e6388a0b2270533f83f) | `vimUtils.packdir: better merge of plugins`                             |
| [`2bee93e8`](https://github.com/NixOS/nixpkgs/commit/2bee93e8671c9725192a257c36f9d46be78b4d1c) | `gopass-summon-provider: 1.14.7 -> 1.14.9`                              |
| [`5a6780e6`](https://github.com/NixOS/nixpkgs/commit/5a6780e6d964e44034f9981f2234212d934b19cb) | `gopass-jsonapi: 1.14.7 -> 1.14.9`                                      |
| [`c0851e53`](https://github.com/NixOS/nixpkgs/commit/c0851e5332f67254b47e905a25975d1457e46216) | `gopass-hibp: 1.14.7 -> 1.14.9`                                         |
| [`6d16e066`](https://github.com/NixOS/nixpkgs/commit/6d16e066b14bf96d24d26229650a4e278faa6757) | `go-graft: 0.2.11 -> 0.2.13`                                            |
| [`787bdc05`](https://github.com/NixOS/nixpkgs/commit/787bdc050f8a69888a3d3253cf10699e339e4e54) | `git-credential-gopass: 1.14.7 -> 1.14.9`                               |
| [`1da460cb`](https://github.com/NixOS/nixpkgs/commit/1da460cb725bccf6ce3add684f6c3cbde5231c5b) | `github-runner: 2.296.2 -> 2.297.0`                                     |
| [`51f34ccd`](https://github.com/NixOS/nixpkgs/commit/51f34ccd1c72bd3d04e33b138b95bfd39478d0da) | `asnmap: init at 0.0.1`                                                 |
| [`94d99040`](https://github.com/NixOS/nixpkgs/commit/94d990407206e1e3c1e7bc406f01a97abdf84e69) | `cpython: fix stdenv.cc.cc.libllvm`                                     |
| [`407a0457`](https://github.com/NixOS/nixpkgs/commit/407a0457b620a721493df1cdf72b7f8808c5cc28) | `fvwm3: 1.0.4 -> 1.0.5`                                                 |
| [`09ebd033`](https://github.com/NixOS/nixpkgs/commit/09ebd033f61d71f2e914cf9d872a3dbfb645fa33) | `kodelife: 1.0.5.161 -> 1.0.6.163`                                      |
| [`420b1675`](https://github.com/NixOS/nixpkgs/commit/420b1675ddc9f92c8ea5605e86d9e7fe807d4817) | `touchosc: 1.1.4.143 -> 1.1.5.145`                                      |
| [`fe3aeced`](https://github.com/NixOS/nixpkgs/commit/fe3aecedad9b8ffb5bc562b1b3a8b454308d6a5d) | `flow: 0.187.1 -> 0.188.0`                                              |
| [`5dbec778`](https://github.com/NixOS/nixpkgs/commit/5dbec77837b6d1db4f365b3129f66bec184c2096) | `qt6.qtbase: drop a few unused hacks`                                   |
| [`db31db7e`](https://github.com/NixOS/nixpkgs/commit/db31db7e84a0546882e92a4c4d47de286d2a476e) | `bash: give bionic file with comment about "fortify"`                   |
| [`792988c3`](https://github.com/NixOS/nixpkgs/commit/792988c35e6609940909042d2d32ef6ceb6e3149) | `libelf: prevent massive re-build`                                      |
| [`660c9c8a`](https://github.com/NixOS/nixpkgs/commit/660c9c8a1bfbc030e393e6fa4557f917de29ab61) | `firewalld-gui: 1.2.0 -> 1.2.1`                                         |
| [`d3d06877`](https://github.com/NixOS/nixpkgs/commit/d3d06877baa10cd337c1db5c73f3fb275bcf7cf6) | `zint: fix build with qt 6.4`                                           |
| [`de795b62`](https://github.com/NixOS/nixpkgs/commit/de795b62a70c05ff4caf01e046ef8879421b012c) | `mozillavpn: fix build with qt 6.4`                                     |
| [`f1b15aeb`](https://github.com/NixOS/nixpkgs/commit/f1b15aebd249a7e791f04e1906207f485303460c) | `qt6.qtquick3dphysics: init at 6.4.0`                                   |
| [`2b96f0ca`](https://github.com/NixOS/nixpkgs/commit/2b96f0ca6d3a0859e76f07337685973794b27716) | `qt6.qtspeech: init at 6.4.0`                                           |
| [`945ab931`](https://github.com/NixOS/nixpkgs/commit/945ab9315defdbc418d6a61b6ee90c51dfb4dcdd) | `qt6.qthttpserver: init at 6.4.0`                                       |
| [`dabdf220`](https://github.com/NixOS/nixpkgs/commit/dabdf2207c3c652b21aea9203ed3d74ebb7433bc) | `python310Packages.aiolifx: 0.8.5 -> 0.8.6`                             |
| [`eec10b54`](https://github.com/NixOS/nixpkgs/commit/eec10b54a3decacbbf8d5fce259bd6f2606595a9) | `cargo-semver-checks: Add myself as maintainer`                         |
| [`241ce6e4`](https://github.com/NixOS/nixpkgs/commit/241ce6e43388cd62c68ec5ca042e569ae9cbb0bf) | `cargo-semver-checks: 0.9.2 -> 0.12.0`                                  |
| [`9ff8c7fd`](https://github.com/NixOS/nixpkgs/commit/9ff8c7fd8c5c71d1800cb044cd62a1a0d0b98a24) | `coqPackages.hierarchy-builder: 1.3.0 ->  1.4.0`                        |
| [`345f116a`](https://github.com/NixOS/nixpkgs/commit/345f116a20b532bd9995ad97be7974f45d73bc4f) | `dnsx: 1.1.0 -> 1.1.1`                                                  |
| [`771d1340`](https://github.com/NixOS/nixpkgs/commit/771d13407ba561a694a06d29f95b90c98b1eab63) | `dippi: 4.0.0 -> 4.0.2`                                                 |
| [`5169d354`](https://github.com/NixOS/nixpkgs/commit/5169d354b34311aac607dbd8c8fd84962e2b1d75) | `chrysalis: 0.9.4 -> 0.11.5`                                            |
| [`91d1af7d`](https://github.com/NixOS/nixpkgs/commit/91d1af7d8c6498712391bfa5a28a6e7104a814f2) | `docker-credential-helpers: 0.6.3 -> 0.7.0`                             |
| [`e66af0e1`](https://github.com/NixOS/nixpkgs/commit/e66af0e1105d45d2e4869357110d1d3dc88206c3) | `esphome: add update script that includes the dashboard`                |
| [`c5735736`](https://github.com/NixOS/nixpkgs/commit/c57357368c571c8646dec49675700b1a03758607) | `esphome: 2022.9.1 -> 2022.9.2`                                         |
| [`35635e2a`](https://github.com/NixOS/nixpkgs/commit/35635e2a6ab3a6e8a30822b82460d18efbff2cad) | `armcord: 3.0.7 -> 3.0.8`                                               |
| [`e0c3557e`](https://github.com/NixOS/nixpkgs/commit/e0c3557efe0cd05ac533703889e6c035f9f3736e) | `qt6.qtwebengine: fix build`                                            |
| [`86c307d1`](https://github.com/NixOS/nixpkgs/commit/86c307d1f7dc0ab698a6ae8cf873612f8cef24dd) | `qt6.qtbase: drop patch for Xcursor`                                    |
| [`bf24c468`](https://github.com/NixOS/nixpkgs/commit/bf24c468f1f95bbca666287ba8bd21c627490bd9) | `qt6: 6.3.2 -> 6.4.0`                                                   |
| [`4d394c2a`](https://github.com/NixOS/nixpkgs/commit/4d394c2a73a727f6e23d42b429fab35c272b0dc3) | `prometheus-collectd-exporter: use buildGoModule`                       |
| [`57e41975`](https://github.com/NixOS/nixpkgs/commit/57e41975e52e2360c88c0ff1460de958afd2fdd8) | `amazon-ecr-credential-helper: use buildGoModule`                       |
| [`9dfac8fe`](https://github.com/NixOS/nixpkgs/commit/9dfac8fef4a60b72ffdfba6779dfe15f73fd2b6b) | `firefox-devedition-bin-unwrapped: 106.0b3 -> 106.0b5`                  |
| [`3d215f75`](https://github.com/NixOS/nixpkgs/commit/3d215f75b845b45dc8336229927d96ec33b78007) | `firefox-beta-bin-unwrapped: 106.0b2 -> 106.0b5`                        |
| [`8569f6e8`](https://github.com/NixOS/nixpkgs/commit/8569f6e82ed1b8d6cdfaa7a259bfc48a860107d9) | `mmc-utils: unstable-2022-07-13 -> unstable-2022-09-27`                 |
| [`cd766031`](https://github.com/NixOS/nixpkgs/commit/cd7660311ff051eb5341cb8e613c8758b7a975d7) | `codeql: 2.10.5 -> 2.11.0`                                              |
| [`0579b1b8`](https://github.com/NixOS/nixpkgs/commit/0579b1b8a8cd07c594718fe25fb31595f3050081) | `morgen: 2.5.13 -> 2.5.16`                                              |
| [`21c0142a`](https://github.com/NixOS/nixpkgs/commit/21c0142ab90a31f84a6e1ba77648cac217ba9841) | `cinny-desktop: 2.2.0 -> 2.2.2`                                         |
| [`2945ba28`](https://github.com/NixOS/nixpkgs/commit/2945ba28be60e1cb86fd640fe960c1df772c1b44) | `cargo-release: 0.21.1 -> 0.21.2`                                       |
| [`07b5651e`](https://github.com/NixOS/nixpkgs/commit/07b5651e854275e79817ec336d3100975e60e003) | `cargo-expand: 1.0.31 -> 1.0.32`                                        |
| [`b463233f`](https://github.com/NixOS/nixpkgs/commit/b463233ff40b2e429f4ef90871299aecfe7831f1) | `nixos/iso-image: Refactor: apply / unshadow`                           |
| [`f34135a7`](https://github.com/NixOS/nixpkgs/commit/f34135a73bd8ccc4a6e56981838feb5375c5011f) | `nixos/iso-image: Fix eval`                                             |