### PR TITLE
chore(flake/pre-commit-hooks): `2a4f1cfa` -> `2e4a7089`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664573419,
-        "narHash": "sha256-bVjsFPOF4t5/G9ir/qNqmQWxRKooG86ctOH78yaarkc=",
+        "lastModified": 1664708386,
+        "narHash": "sha256-aCD8UUGNYb5nYzRmtsq/0yP9gFOQQHr/Lsb5vW+mucw=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "2a4f1cfaa01b8b31edc7d3004454c4a0c38d50d8",
+        "rev": "2e4a708918e14fdbd534cc94aaa9470cd19b2464",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                               |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
| [`1d9721d0`](https://github.com/cachix/pre-commit-hooks.nix/commit/1d9721d04974f738b12ca5e9748bd683518785ed) | ``Run nixpkgs-fmt on `modules/hooks.nix```   |
| [`4884c714`](https://github.com/cachix/pre-commit-hooks.nix/commit/4884c714d67ea89ed6adf49601adf6b2c64eeab0) | `Add support for deadnix`                    |
| [`efcbfd78`](https://github.com/cachix/pre-commit-hooks.nix/commit/efcbfd78c7ec5748114b33cb48a6b26ddb7e29dd) | `Add dhall-format for formatting Dhall code` |