### PR TITLE
chore(flake/templates): `2f865344` -> `af0d5d98`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -257,11 +257,11 @@
     },
     "templates": {
       "locked": {
-        "lastModified": 1649246137,
-        "narHash": "sha256-cbAjf3JPoHlJD5Ayoj1sd1Gz1EZMHrFnZWIxbSGslmU=",
+        "lastModified": 1664891606,
+        "narHash": "sha256-b8zpajTijlXL8GfvCnzICvMKjhX8micxfZkZp6OGE9M=",
         "owner": "NixOS",
         "repo": "templates",
-        "rev": "2f86534428917d96d414964c69a5cfe353500ad5",
+        "rev": "af0d5d98c24323e359b10628665132d2ca241a12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                                |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
| [`1afb35ad`](https://github.com/NixOS/templates/commit/1afb35ade1071921943c14b743ae8726ac8969c8) | `Add haskell.nix template`                                    |
| [`d94056cf`](https://github.com/NixOS/templates/commit/d94056cf62eaaa86e50850b409e89dee8c7926eb) | `Update trivial template with nix 2.7 default package syntax` |
| [`cd093ed1`](https://github.com/NixOS/templates/commit/cd093ed16bf63752e39d22dd43a802a6c4684ffa) | `python: refactor and cleanup`                                |
| [`d7a340cf`](https://github.com/NixOS/templates/commit/d7a340cfe193efcc6511ea459b5800aafd673160) | `trivial: change default package format after 2.7.0`          |