### PR TITLE
chore(flake/home-manager): `e4e639dd` -> `1a8e35d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664783440,
-        "narHash": "sha256-KlMwR7mUf5h8MPnzV7nGFUAt6ih/euW5xgvZ5x+hwvI=",
+        "lastModified": 1664983332,
+        "narHash": "sha256-KyQvgFRwk3qW3Qr+lO5UDqfpST/HaCJY1yB7wPgPUqo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e4e639dd4dc3e431aa5b5f95325f9a66ac7e0dd9",
+        "rev": "1a8e35d2e53ed2ccd9818fad9c9478d56c655661",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                          |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`1a8e35d2`](https://github.com/nix-community/home-manager/commit/1a8e35d2e53ed2ccd9818fad9c9478d56c655661) | `mpd: add package to home path (#3303)` |