### PR TITLE
chore(flake/nixos-hardware): `3024c67a` -> `47fd7028`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1664628729,
-        "narHash": "sha256-A1J0ZPhBfZZiWI6ipjKJ8+RpMllzOMu/An/8Tk3t4oo=",
+        "lastModified": 1665040200,
+        "narHash": "sha256-glqL6yj3aUm40y92inzRmowGt9aIrUrpBX7eBAMic4I=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3024c67a2e9a35450558426c42e7419ab37efd95",
+        "rev": "47fd70289491c1f0c0d9a1f44fb5a9e2801120c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`d5de1c72`](https://github.com/NixOS/nixos-hardware/commit/d5de1c72cfcee3dfaeacc5878f7a77ccc9270897) | `Update README & flake.nix`                                       |
| [`1c535dc0`](https://github.com/NixOS/nixos-hardware/commit/1c535dc0497f7f4f92a562f8d033abf944bfc3e2) | `gpd/pocket-3: Only workaround hidpi module bug on NixOS < 22.11` |
| [`de2ea2be`](https://github.com/NixOS/nixos-hardware/commit/de2ea2beee098e96baafd7cc3250e1e768294994) | `Add GPD Pocket 3 module to nixos-hardware`                       |
| [`32ee2e60`](https://github.com/NixOS/nixos-hardware/commit/32ee2e607094cc640c9ee6161aa25d2f20b0275c) | `framework-12th-gen-intel: workaround iGPU hangs`                 |
| [`1788d8f7`](https://github.com/NixOS/nixos-hardware/commit/1788d8f74ef890442f883c95cd37efeb2d61e375) | `lenovo/thinkpad/x1-extreme: remove acpi_call`                    |