### PR TITLE
chore(flake/nixpkgs): `fd54651f` -> `b7a6fde1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664780719,
-        "narHash": "sha256-Oxe6la5dSqRfJogjtY4sRzJjDDqvroJIVkcGEOT87MA=",
+        "lastModified": 1664871473,
+        "narHash": "sha256-1LzbW6G6Uz8akWiOdlIi435GAm1ct5jF5tovw/9to0o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fd54651f5ffb4a36e8463e0c327a78442b26cbe7",
+        "rev": "b7a6fde153d9470afdb6aa1da51c4117f03b84ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`b7a6fde1`](https://github.com/NixOS/nixpkgs/commit/b7a6fde153d9470afdb6aa1da51c4117f03b84ed) | `ferium: 4.1.10 -> 4.1.11`                                                           |
| [`2107211a`](https://github.com/NixOS/nixpkgs/commit/2107211a4eab90116b36a5baae28128b6797c24d) | `benthos: 4.8.0 -> 4.9.0`                                                            |
| [`3c8f16a2`](https://github.com/NixOS/nixpkgs/commit/3c8f16a2e221a82012e079fd70318b42cb38217a) | `rust-analyzer-unwrapped: 2022-09-26 -> 2022-10-03`                                  |
| [`c46bdcba`](https://github.com/NixOS/nixpkgs/commit/c46bdcbaf299064ca935438b6704a2f99394966c) | `nixos/lib/qemu-common.nix: set qemuSerialDevice for isMips64`                       |
| [`5e4543e9`](https://github.com/NixOS/nixpkgs/commit/5e4543e9f0ebffdfde9b6a512e9d99924beaa3ad) | `python310Packages.google-cloud-appengine-logging: update disabled`                  |
| [`4a8c795c`](https://github.com/NixOS/nixpkgs/commit/4a8c795c4a8d0d98b3b5e0c2853c3f7c44bd0dd9) | `python310Packages.google-cloud-bigquery-logging: disable on older Python releases`  |
| [`6f8a7852`](https://github.com/NixOS/nixpkgs/commit/6f8a7852e2f70f44e444c272044536800a1f5eda) | `python310Packages.google-cloud-datacatalog: update disabled`                        |
| [`def8bc92`](https://github.com/NixOS/nixpkgs/commit/def8bc92a92df8f461c3758a9cf7ff5a52c7d144) | `python310Packages.google-cloud-iot: disable on older Python releases`               |
| [`0162bd26`](https://github.com/NixOS/nixpkgs/commit/0162bd26aefa2176a1712ad6463c5ea41f183d01) | `python310Packages.google-cloud-redis: update disabled`                              |
| [`c7f2e535`](https://github.com/NixOS/nixpkgs/commit/c7f2e5359babdf02478403a737e479c6f459f99a) | `python310Packages.google-cloud-secret-manager: update disabled`                     |
| [`b2f3292e`](https://github.com/NixOS/nixpkgs/commit/b2f3292ea61cd3093a308af2dced48a56939619a) | `python310Packages.google-cloud-os-config: disable on older Python releases`         |
| [`545de296`](https://github.com/NixOS/nixpkgs/commit/545de296e01d54b995b08361c7a72a517b68acbf) | `python310Packages.google-cloud-speech: update disabled`                             |
| [`b887f96a`](https://github.com/NixOS/nixpkgs/commit/b887f96a41d6fd03895deab203ef1c54628ae33d) | `python310Packages.google-cloud-trace: disable on older Python releases`             |
| [`e0eab822`](https://github.com/NixOS/nixpkgs/commit/e0eab822a7f36d1654dcf46cf759aa6782e43520) | `python310Packages.google-cloud-texttospeech: disable on older Python releases`      |
| [`0a986acd`](https://github.com/NixOS/nixpkgs/commit/0a986acdb60e4b371c6b0bda0e91aa62f8b45a95) | `python310Packages.google-cloud-videointelligence: disable on older Python releases` |
| [`490a05c4`](https://github.com/NixOS/nixpkgs/commit/490a05c4a82236a86e1e1a4822f714c972e8c4f0) | `maestral: add missing dbus dependency`                                              |
| [`6ef43258`](https://github.com/NixOS/nixpkgs/commit/6ef43258cdd11f494425d6950d8f7adcf0ebd283) | `python310Packages.hahomematic: 2022.9.1 -> 2022.10.0`                               |
| [`a63e6225`](https://github.com/NixOS/nixpkgs/commit/a63e6225662abb27fdac613c622dcdc4b572d816) | `python310Packages.google-cloud-websecurityscanner: 1.9.0 -> 1.9.1`                  |
| [`df4acb2c`](https://github.com/NixOS/nixpkgs/commit/df4acb2c9ae5c31a7775ab2b7dfe3ef9b084ef17) | `python310Packages.google-cloud-videointelligence: 2.8.1 -> 2.8.2`                   |
| [`62597fef`](https://github.com/NixOS/nixpkgs/commit/62597fef3169d7637f401e220bbfcc6761190cf6) | `python310Packages.google-cloud-translate: 3.8.2 -> 3.8.3`                           |
| [`c4d202be`](https://github.com/NixOS/nixpkgs/commit/c4d202be1c12304386da8abad1a4c8293394e323) | `python310Packages.google-cloud-trace: 1.7.1 -> 1.7.2`                               |
| [`4e4e9ec3`](https://github.com/NixOS/nixpkgs/commit/4e4e9ec35412b455cc57bb42787a1923a4688626) | `python310Packages.google-cloud-texttospeech: 2.12.1 -> 2.12.2`                      |
| [`75d050a1`](https://github.com/NixOS/nixpkgs/commit/75d050a1d4e4a336d965736960083a2f4843ed79) | `python310Packages.google-cloud-tasks: 2.10.2 -> 2.10.3`                             |
| [`c7d29ada`](https://github.com/NixOS/nixpkgs/commit/c7d29ada46904d79d4dc340101b57658c9d86e35) | `python310Packages.google-cloud-speech: 2.15.1 -> 2.16.0`                            |
| [`5da5e8b2`](https://github.com/NixOS/nixpkgs/commit/5da5e8b220c9c424b5885b788c24c25281bf04b1) | `python310Packages.google-cloud-secret-manager: 2.12.4 -> 2.12.5`                    |
| [`b15043de`](https://github.com/NixOS/nixpkgs/commit/b15043de261fad1ed04ede70832511e6da0bbe3b) | `python310Packages.google-cloud-redis: 2.9.1 -> 2.9.2`                               |
| [`5045ac33`](https://github.com/NixOS/nixpkgs/commit/5045ac3390ea91b8fba203345a71cf56ff2bb7a6) | `python310Packages.google-cloud-os-config: 1.12.2 -> 1.12.3`                         |
| [`b7247cc0`](https://github.com/NixOS/nixpkgs/commit/b7247cc0ca52e2501b771c72997e93b2f95577ac) | `python310Packages.google-cloud-monitoring: 2.11.1 -> 2.11.2`                        |
| [`a1526293`](https://github.com/NixOS/nixpkgs/commit/a1526293a996d648442145b5a4820082239d51fd) | `python310Packages.google-cloud-iot: 2.6.2 -> 2.6.3`                                 |
| [`324f9c20`](https://github.com/NixOS/nixpkgs/commit/324f9c2003145be5345a0a8560e3215804993586) | `python310Packages.google-cloud-datacatalog: 3.9.1 -> 3.9.2`                         |
| [`bdabb67e`](https://github.com/NixOS/nixpkgs/commit/bdabb67e3ef7cb527cde47f907fee20906c4cb98) | `python310Packages.google-cloud-container: 2.12.0 -> 2.12.1`                         |
| [`cbc4dc1a`](https://github.com/NixOS/nixpkgs/commit/cbc4dc1a06d16b2da564cca465b06f63384db8ef) | `python310Packages.google-cloud-bigquery-logging: 1.0.5 -> 1.0.6`                    |
| [`989a9813`](https://github.com/NixOS/nixpkgs/commit/989a9813eeedd0133384f84e54090ac11420acc9) | `python310Packages.google-cloud-automl: 2.8.1 -> 2.8.2`                              |
| [`75a5a66a`](https://github.com/NixOS/nixpkgs/commit/75a5a66ac9751c130eddb875cbf23de05fa99f0e) | `python310Packages.google-cloud-appengine-logging: 1.1.4 -> 1.1.5`                   |
| [`0dd481b2`](https://github.com/NixOS/nixpkgs/commit/0dd481b2ad61effd97d7215046d564953a33e526) | `meilisearch: 0.28.1 -> 0.29.0`                                                      |
| [`da60d463`](https://github.com/NixOS/nixpkgs/commit/da60d463c537d2a3220236f9aa328ca57888b9a4) | `noto-fonts-emoji: 2.034 -> 2.038`                                                   |
| [`01a20540`](https://github.com/NixOS/nixpkgs/commit/01a2054000cff5e12b3902e12a6a8d39782bce1a) | `python3Packages.nototools: 0.2.16 -> 0.2.17`                                        |
| [`525dd957`](https://github.com/NixOS/nixpkgs/commit/525dd957a14b681b6fe35ef12d3a23e349a03ca8) | `nil: 2022-09-26 -> 2022-10-03`                                                      |
| [`1ca2296b`](https://github.com/NixOS/nixpkgs/commit/1ca2296b0391797d4c5e7260f6e02d3d3f33fe83) | `electron_21: init at 21.0.1`                                                        |
| [`388d6c1c`](https://github.com/NixOS/nixpkgs/commit/388d6c1c2f9d69731ec152eec647e1b602df1742) | `hashi-up: init at 0.16.0`                                                           |
| [`1a803657`](https://github.com/NixOS/nixpkgs/commit/1a8036575058f5e788a599cf2ced1f96fe964c3a) | `netbsd.libc: fix build`                                                             |
| [`052662fa`](https://github.com/NixOS/nixpkgs/commit/052662fab431c89e1e8f611aa37983c7bb3cbdac) | `librepcb: 0.1.6 -> 0.1.7`                                                           |
| [`f5b3a4ab`](https://github.com/NixOS/nixpkgs/commit/f5b3a4ab7ccd0723b2e94ca3c7decc6f61890bc8) | `python310Packages.sphinx-book-theme: Mark as broken (#187401)`                      |
| [`934c03e1`](https://github.com/NixOS/nixpkgs/commit/934c03e19d8b926d960ebf1f454b10503974d397) | `pulumi-bin: 3.40.1 -> 3.40.2`                                                       |
| [`29ba4c72`](https://github.com/NixOS/nixpkgs/commit/29ba4c72c9ce8ad5f0c5bcab9158cff5755ae809) | `peertube: 4.2.2 -> 4.3.0`                                                           |
| [`f5355f8a`](https://github.com/NixOS/nixpkgs/commit/f5355f8a3814417490e0dc4783ee8149772ff230) | `pyreadstat: init at 1.1.9`                                                          |
| [`35d5dd79`](https://github.com/NixOS/nixpkgs/commit/35d5dd7989580540453f47dd331bc1975949c7d8) | `readstat: init at 1.1.8`                                                            |
| [`960e4e77`](https://github.com/NixOS/nixpkgs/commit/960e4e772bff4c1900e5730df1d1da9016c17aa5) | `input-remapper: 1.4.2 -> 1.5.0 (#191967)`                                           |
| [`fe271bca`](https://github.com/NixOS/nixpkgs/commit/fe271bcada6f757e7cbdb208c99631db60a7ddc2) | `goreleaser: 1.11.4 -> 1.11.5`                                                       |
| [`4b587a7c`](https://github.com/NixOS/nixpkgs/commit/4b587a7cb8051ffb72fa8a5c2c0b172c41a77dbb) | `python310Packages.pytest-subprocess: 1.4.1 -> 1.4.2`                                |
| [`87447d47`](https://github.com/NixOS/nixpkgs/commit/87447d47760082cb69aa0f05e0f59e23a4eb2037) | `polypane: init at 10.0.1 (#158159)`                                                 |
| [`dfa4024a`](https://github.com/NixOS/nixpkgs/commit/dfa4024ae7145aad3cf3242750bf34ba345cec97) | `oh-my-posh: 11.1.1 -> 11.3.0`                                                       |
| [`aafe8b96`](https://github.com/NixOS/nixpkgs/commit/aafe8b96171b68eeeb21a96f95c0c9c14c859ffa) | `ruff: 0.0.50 -> 0.0.52`                                                             |
| [`92e4b65d`](https://github.com/NixOS/nixpkgs/commit/92e4b65d22e0f47469337e6f7cff58fc3ac4e8fb) | `elisp-packages: fix AOT native-comp for several packages`                           |
| [`bd62717f`](https://github.com/NixOS/nixpkgs/commit/bd62717fd3c263629138fef08897420b2cc673ba) | `libinput: Add tappingButtonMap option (#189612)`                                    |
| [`cbae4c2a`](https://github.com/NixOS/nixpkgs/commit/cbae4c2af6819ea549e6cb2389564030411e9b63) | `minio: 2022-09-25T15-44-53Z -> 2022-10-02T19-29-29Z`                                |
| [`8e652f2f`](https://github.com/NixOS/nixpkgs/commit/8e652f2f5cdb42c38990b550864c745b86e855bc) | `minio-client: 2022-09-16T09-16-47Z -> 2022-10-01T07-56-14Z`                         |
| [`00e30f7a`](https://github.com/NixOS/nixpkgs/commit/00e30f7ae076f6d27d047895b42f133ed02f23fd) | `python3Packages.nbconvert: patch bug that made mkdocs-jupyter failing`              |
| [`22080b7d`](https://github.com/NixOS/nixpkgs/commit/22080b7dc0fd3e0c8ef2f65b12ba1a22125600d1) | `python3Packages.mkdocs-jupyter: init at 0.22.0`                                     |
| [`4e224a9a`](https://github.com/NixOS/nixpkgs/commit/4e224a9a64baf80f2775f7d77dbd8eee6e8887c0) | `maintainers: add net-mist`                                                          |
| [`8240e206`](https://github.com/NixOS/nixpkgs/commit/8240e2069a060412bc90c03164a501feb3ec4914) | `python3Packages.ecos: fix test_interface_bb.py tests`                               |
| [`30cc0cde`](https://github.com/NixOS/nixpkgs/commit/30cc0cde34b5a03652d97bc74867167eb7aab260) | `stdenv: complete the deprecation of stdenv.glibc`                                   |
| [`68df1186`](https://github.com/NixOS/nixpkgs/commit/68df1186376e9c33eab56ca7aa925a4aca751362) | `pythonPackages.pysdl2: fix build by fixing patch`                                   |
| [`4f74ae0d`](https://github.com/NixOS/nixpkgs/commit/4f74ae0d99e7a6299a84c2c782cfc76ecc00c6ba) | `qemu: add canokeySupport`                                                           |
| [`b3ca7c9f`](https://github.com/NixOS/nixpkgs/commit/b3ca7c9f7b75d1d3753ef62a8272e1da2ad1ed46) | `canokey-qemu: init at unstable-2022-06-23`                                          |
| [`0deec20d`](https://github.com/NixOS/nixpkgs/commit/0deec20d46dd26e5fcfc3ce232ea2de94719d75d) | `binutils: drop R_ARM_COPY.patch`                                                    |
| [`42e73857`](https://github.com/NixOS/nixpkgs/commit/42e7385777b3d5513534da2e2f1dce81894b4fd4) | `python310Packages.aiounifi: 35 -> 36`                                               |
| [`f9c2d606`](https://github.com/NixOS/nixpkgs/commit/f9c2d606a1e478daeec4eddb5ecab453e69a5124) | `python310Packages.atomman: 1.4.5 -> 1.4.6`                                          |
| [`0827eed1`](https://github.com/NixOS/nixpkgs/commit/0827eed12918b2fd5b1d99eefae056d4333405fd) | `python310Packages.aioesphomeapi: 11.0.0 -> 11.1.0`                                  |
| [`ef0c3cfd`](https://github.com/NixOS/nixpkgs/commit/ef0c3cfde614aa72b6362b4d3da62a6c3c30a9a9) | `jqp: 0.2.0 -> 0.3.0`                                                                |
| [`b1e552ef`](https://github.com/NixOS/nixpkgs/commit/b1e552ef27aa8e43a4099bcd138fc9f86666460c) | `jaq: 0.8.0 -> 0.8.1`                                                                |
| [`9c87e6e1`](https://github.com/NixOS/nixpkgs/commit/9c87e6e1a64a79698912be7197fabe9e24d4c48e) | `vimPlugins.command-t: fix build on darwin`                                          |
| [`25b70355`](https://github.com/NixOS/nixpkgs/commit/25b70355131d06500cdc0d603563c40ebcef5b3a) | `open-watcom-v2-unwrapped: unstable-2022-08-02 -> unstable-2022-10-03`               |
| [`1085ad55`](https://github.com/NixOS/nixpkgs/commit/1085ad554ffecf098555c77b0a40f4b14b51f940) | `verilator: 4.224 -> 4.226`                                                          |
| [`07400e6c`](https://github.com/NixOS/nixpkgs/commit/07400e6c09c8d5242c3526063b5ec822385d7311) | `oh-my-zsh: 2022-09-10 -> 2022-10-03`                                                |
| [`64eafc25`](https://github.com/NixOS/nixpkgs/commit/64eafc25d69cd84ed9c41e00b9ab8db3e4a02b6e) | `Update source to fix #194116`                                                       |
| [`16fde6b3`](https://github.com/NixOS/nixpkgs/commit/16fde6b3487394644da7e3c830bb99c4f0bf4acf) | `adguardhome: 0.107.12 -> 0.107.14`                                                  |
| [`4ad8209b`](https://github.com/NixOS/nixpkgs/commit/4ad8209b12331a32c779e7f04dc8e60132062b24) | `pocketbase: 0.7.6 -> 0.7.7`                                                         |
| [`18b770c0`](https://github.com/NixOS/nixpkgs/commit/18b770c06b6c8cb78179f638bed8f31f444d4341) | `x42-plugins: 20220714 -> 20220923`                                                  |
| [`e9bd62f6`](https://github.com/NixOS/nixpkgs/commit/e9bd62f650d9ca273d14856bad8bc3326c452f6f) | `simdjson: 2.2.2 -> 2.2.3`                                                           |
| [`ada96976`](https://github.com/NixOS/nixpkgs/commit/ada969769ee4a62125ed27253efe4da9f9d518f5) | `cubiomes-viewer: 2.4.1 -> 2.5.0`                                                    |
| [`397ad93d`](https://github.com/NixOS/nixpkgs/commit/397ad93dd379d33205f7a6522dc3088a135f2ce2) | `Apply suggestions from code review`                                                 |
| [`3d1c9951`](https://github.com/NixOS/nixpkgs/commit/3d1c995185ef4878a21851bc8ad1ab2082f2435d) | `python3Packages.coqui-trainer: unpin protobuf`                                      |
| [`06ed064a`](https://github.com/NixOS/nixpkgs/commit/06ed064a3ed6d8adbec2704e2f90a4fe31823273) | `ibus-engines.mozc: unpin protobuf`                                                  |
| [`0aee8718`](https://github.com/NixOS/nixpkgs/commit/0aee87185d4307fac15902986085b42ed27ac33f) | `rippled: unpin protobuf`                                                            |
| [`a222ca46`](https://github.com/NixOS/nixpkgs/commit/a222ca468ea31c0ebf5ba11488dec4dec4c45b5b) | `python3Packages.tensorboardx: 2.5 -> 2.5.1`                                         |
| [`5f53dac6`](https://github.com/NixOS/nixpkgs/commit/5f53dac66aa7df8d2837b60f87aa1fcefb5f3ad1) | `pkgs/top-level: convert to MD option docs`                                          |
| [`c8841341`](https://github.com/NixOS/nixpkgs/commit/c884134125abd09589cab5cdcae27f791221004c) | `kitty: 0.25.2 -> 0.26.2`                                                            |
| [`0d722e8e`](https://github.com/NixOS/nixpkgs/commit/0d722e8e1b409fddebb33a3d190e32dc89de1d3d) | `wasm-bindgen-cli: 0.2.82 -> 0.2.83 (#194122)`                                       |
| [`dbf1d73c`](https://github.com/NixOS/nixpkgs/commit/dbf1d73cd1a17276196afeee169b4cf7834b7a96) | `perf: fix build with kernel 6.0`                                                    |
| [`0faffb55`](https://github.com/NixOS/nixpkgs/commit/0faffb55310c6ac42b0741b6a52b88482ae41f96) | `linux/6.0: init`                                                                    |
| [`691ce42a`](https://github.com/NixOS/nixpkgs/commit/691ce42a4519e667d83f5f3a46e0584bf955db00) | `cudatext: 1.171.0 -> 1.172.0`                                                       |
| [`4d6abfa6`](https://github.com/NixOS/nixpkgs/commit/4d6abfa6b41713fa39eca871800711713c90152b) | `octopus: 11.4 -> 12.0`                                                              |
| [`ca12fe8f`](https://github.com/NixOS/nixpkgs/commit/ca12fe8fcd60eeb9ad6b866f319292ab728defe2) | `panoply: 5.2.0 -> 5.2.1`                                                            |
| [`7fae1d6f`](https://github.com/NixOS/nixpkgs/commit/7fae1d6f7a1c702040133ee04083f9ee08aa8a4f) | `vdrPlugins: get homepage from src`                                                  |
| [`59bb395f`](https://github.com/NixOS/nixpkgs/commit/59bb395f1c527afa9e5adbd51c3972183ac1d650) | `vdrPlugins.softhddevice: 1.9.0 -> 1.9.2`                                            |
| [`360892ca`](https://github.com/NixOS/nixpkgs/commit/360892caf563ea0c2eb9a86327eb4701775287ac) | `vdrPlugins.vnsiserver: 1.8.0 -> 1.8.1`                                              |
| [`2de6316b`](https://github.com/NixOS/nixpkgs/commit/2de6316bbfc1028309210aac1f608d8629115b84) | `vdrPlugins.epgsearch: switch src`                                                   |
| [`fe181e0f`](https://github.com/NixOS/nixpkgs/commit/fe181e0f943b41060cd90c777d34b69fb73aa0e2) | `vdrPlugins.markad: 3.0.25 -> 3.0.26`                                                |
| [`0aede75e`](https://github.com/NixOS/nixpkgs/commit/0aede75ecf9db5bc07119021fbfb3f51101b5fe3) | `vdrPlugins.femon: switch src`                                                       |
| [`d81b7507`](https://github.com/NixOS/nixpkgs/commit/d81b7507f0b40f3137f3b611b963ea5ddb4b14a3) | ``php: enable `imap` extension by default``                                          |
| [`83f5c2d5`](https://github.com/NixOS/nixpkgs/commit/83f5c2d5ecb08d1aaaae1df0a5d2af02befeea0e) | `tandoor-recipes: add 'passthru.tests'`                                              |
| [`91ba8464`](https://github.com/NixOS/nixpkgs/commit/91ba8464f472250ffebff579a16288321b6ca302) | `nixos/tandoor-recipes: add test`                                                    |
| [`d8b1d348`](https://github.com/NixOS/nixpkgs/commit/d8b1d3480664e226f3d39fa4bae846131f8b9382) | `nixos/tandoor-recipes: init module`                                                 |
| [`6a1359e4`](https://github.com/NixOS/nixpkgs/commit/6a1359e4a236ef32d5f9fcdf6e533d269a659bf1) | `tandoor-recipes: init at 1.4.1`                                                     |
| [`00d53d21`](https://github.com/NixOS/nixpkgs/commit/00d53d212b4cfa317287f3670fd215bdbb5891d3) | `flyctl: 0.0.402 -> 0.0.403`                                                         |
| [`62c7443b`](https://github.com/NixOS/nixpkgs/commit/62c7443beb8221418eba1d987e5d78be85de8a16) | `vdr: Set platform to linux`                                                         |
| [`6428e72f`](https://github.com/NixOS/nixpkgs/commit/6428e72f1a10121cf628446a46ca2a74c75b7e35) | `python310Packages.time-machine: 2.8.1 -> 2.8.2`                                     |
| [`635239b6`](https://github.com/NixOS/nixpkgs/commit/635239b68f20904e1af493c6f4f6872e52abe8d7) | `python310Packages.qcs-api-client: 0.21.1 -> 0.21.2`                                 |
| [`79ab1e63`](https://github.com/NixOS/nixpkgs/commit/79ab1e634b038667be4b089fca75e3c8d60d2eb1) | `python310Packages.yolink-api: 0.0.9 -> 0.1.0`                                       |
| [`b72c3fe1`](https://github.com/NixOS/nixpkgs/commit/b72c3fe1afedbc5876db3c12a91941e7e3d63546) | `python310Packages.venstarcolortouch: 0.18 -> 0.19`                                  |
| [`635a92a2`](https://github.com/NixOS/nixpkgs/commit/635a92a26afecc6be4f90fe4f38768e111296043) | `python310Packages.velbus-aio: 2022.9.1 -> 2022.10.1`                                |
| [`d6a4694b`](https://github.com/NixOS/nixpkgs/commit/d6a4694b65b879941a07f544ca9f7b8dfa766dc2) | `python310Packages.meshtastic: 1.3.36 -> 1.3.37`                                     |
| [`41963339`](https://github.com/NixOS/nixpkgs/commit/41963339b973da3e3782e227aee22e3537f21909) | `pkgsStatic.protobuf: fix installation of protoc`                                    |
| [`a0a570bf`](https://github.com/NixOS/nixpkgs/commit/a0a570bf789c20cc1d7376248c8273500fad6e3a) | `pkgsStatic.lz4: fix build`                                                          |
| [`a4d7d4b0`](https://github.com/NixOS/nixpkgs/commit/a4d7d4b0007079f78238d574725c4b6067c87a45) | `zoom-us: 5.11.{9.10046,10.4400} -> 5.12.0.{11129,4682}`                             |
| [`292aab98`](https://github.com/NixOS/nixpkgs/commit/292aab9822c1f0fcdabdfd81e6dd8db1e39df894) | `nixos/systemd: update extraConfig description`                                      |
| [`e08918e9`](https://github.com/NixOS/nixpkgs/commit/e08918e91dd646e24001dd59fa7999bf39d25981) | ``maintainers/team-list: Extend `enableFeatureFreezePing` documentation``            |
| [`8b920d91`](https://github.com/NixOS/nixpkgs/commit/8b920d919c81ebf563aba7d8bb1e12e294605c95) | `maintainers/team-list: Update feature freeze team selection`                        |
| [`6ba7e643`](https://github.com/NixOS/nixpkgs/commit/6ba7e643cd29bcbf96d11629a7cb98d7d95a36df) | `srain: 1.4.1 -> 1.5.0`                                                              |
| [`abb91732`](https://github.com/NixOS/nixpkgs/commit/abb91732c5f32dfb784c7d2fc6c98465da52296c) | `signal-cli: 0.10.11 -> 0.11.0`                                                      |
| [`85301d07`](https://github.com/NixOS/nixpkgs/commit/85301d07cd52c36fadfc1b83fbebd1d3b4d88bff) | `vimPlugins.vim-clap: fix cargoSha256`                                               |
| [`4607eebf`](https://github.com/NixOS/nixpkgs/commit/4607eebf3a8bd69c2fb0e1dfe1ce7c6090d7346c) | `vimPlugins.auto-save-nvim: init at 2022-08-06`                                      |
| [`eadcfe74`](https://github.com/NixOS/nixpkgs/commit/eadcfe74dd9dabd9f4477f9666568071e2d1d9f2) | `vimPlugins.nvim-highlight-colors: init at 2022-09-28`                               |
| [`3565d556`](https://github.com/NixOS/nixpkgs/commit/3565d5566c399d9625d77efb0e97e1797197c470) | `vimPlugins.nvim-rename-state: init at 2022-09-29`                                   |
| [`7d0d078d`](https://github.com/NixOS/nixpkgs/commit/7d0d078d504a04dc18a303b7e4c29f354dbdbceb) | `vimPlugins.template-string-nvim: init at 2022-08-18`                                |
| [`85710fbd`](https://github.com/NixOS/nixpkgs/commit/85710fbd86ca92f6fcb21fa46a57798c79afab80) | `vimPlugins: resolve github repository redirects`                                    |
| [`34687f1a`](https://github.com/NixOS/nixpkgs/commit/34687f1a5e2bd16a0562bc997987f5dbac6e9623) | `vimPlugins: update`                                                                 |
| [`e22ce12a`](https://github.com/NixOS/nixpkgs/commit/e22ce12a8e4d3e6f1400879cd1925845d760e049) | `apple-music-electron: remove`                                                       |
| [`058a81c3`](https://github.com/NixOS/nixpkgs/commit/058a81c348d86cc1341e0639e02ace6f9eacc742) | `nautilus-open-any-terminal: 0.3.0 -> 0.4.0`                                         |
| [`82d94d1a`](https://github.com/NixOS/nixpkgs/commit/82d94d1aeda2086c92c817ad0486532cb72a5298) | `libcec: remove ? null from inputs, use postPatch`                                   |
| [`ea6b6a46`](https://github.com/NixOS/nixpkgs/commit/ea6b6a46b6ebccd75a178ce7b331accf864e806f) | `coreboot-configurator: init at 2022-08-22`                                          |
| [`cd7bcc91`](https://github.com/NixOS/nixpkgs/commit/cd7bcc91744b8d46b0fb882f5b97ff8f123aa02a) | `nsync: 1.24.0 -> 1.25.0`                                                            |
| [`3f2381e4`](https://github.com/NixOS/nixpkgs/commit/3f2381e4bd9144d01bb2f04c79c6e5e7a566b5b3) | `nsync: fix build on macOS`                                                          |
| [`4c0eb8eb`](https://github.com/NixOS/nixpkgs/commit/4c0eb8eb9e3ad2ea1807a622f359ab1baa1bf9b3) | `nsync: add Luflosi as maintainer`                                                   |
| [`049c5e90`](https://github.com/NixOS/nixpkgs/commit/049c5e902652601f24768af59fc6510e6da5b797) | `diffoscope: revised tests failing`                                                  |
| [`eefaaf41`](https://github.com/NixOS/nixpkgs/commit/eefaaf41d67ea28c3f70150958f6a29533dce709) | `kubo: rename from ipfs`                                                             |
| [`51f5c659`](https://github.com/NixOS/nixpkgs/commit/51f5c65914d2adf62907e3fd95acb5d8da3ee076) | `gnupg: unbreak builds without tpm2-tss`                                             |
| [`919ac6f9`](https://github.com/NixOS/nixpkgs/commit/919ac6f91fe4096aac1526b211ea0c5573bfbebb) | `clairvoyance: init at 2.0.4`                                                        |
| [`c5b04c91`](https://github.com/NixOS/nixpkgs/commit/c5b04c91442728619ec2ac4e192e5400621147c4) | `firefox: address automated review comments`                                         |
| [`767b1fd5`](https://github.com/NixOS/nixpkgs/commit/767b1fd5da953432779e6c684f4b93b7fb4fcac4) | `enlightenment.enlightenment: add update script`                                     |
| [`a15e0833`](https://github.com/NixOS/nixpkgs/commit/a15e083372a19aaa04b4a8ce4c36be52295bfe42) | `httpTwoLevelsUpdater: fix variable default value`                                   |
| [`0b9c39e8`](https://github.com/NixOS/nixpkgs/commit/0b9c39e819f7cd10817ee144cd316d2444e98b6f) | `gitUpdater: fix variable default value`                                             |
| [`19a47178`](https://github.com/NixOS/nixpkgs/commit/19a47178461e509bcd3821cea3b92e8deba20a40) | `directoryListingUpdater: init`                                                      |
| [`918a5d36`](https://github.com/NixOS/nixpkgs/commit/918a5d36a28328c75e37d94456591bd635137e0a) | `sonic-lineup: mark broken`                                                          |
| [`2965d777`](https://github.com/NixOS/nixpkgs/commit/2965d7774d5cbf59c1944d618b426d379e14b75c) | `nix-prefetch-github: 5.2.1 -> 5.2.2`                                                |
| [`8e7161ed`](https://github.com/NixOS/nixpkgs/commit/8e7161ed80a7c70df2d15c6cf37d7e3bf22a5e2d) | `rPackages.rmarkdown: add pandoc as buildInput`                                      |
| [`284e8949`](https://github.com/NixOS/nixpkgs/commit/284e89493f5507c4fa03decaeabf9bd68b980239) | `python310Packages.djangorestframework: fix 'collectstatic' with django 4.1`         |
| [`334ca79a`](https://github.com/NixOS/nixpkgs/commit/334ca79a7b3f0eb8a0e7d6162aae9bbd59a563b5) | `python310Packages.django-oauth-toolkit: relax 'django' dependency`                  |
| [`f2a7a771`](https://github.com/NixOS/nixpkgs/commit/f2a7a77151999ef7aa074318ca7dadc59452da5b) | `python310Packages.django-cors-headers: 3.7.0 -> 3.13.0`                             |
| [`81ab6b59`](https://github.com/NixOS/nixpkgs/commit/81ab6b593ba7e9df0be3378587a425b0576b6a2e) | `python310Packages.drf-writable-nested: init at 0.6.4`                               |
| [`c9185dbf`](https://github.com/NixOS/nixpkgs/commit/c9185dbf9189452c543d93e3888b2cc4445dbc69) | `python310Packages.recipe-scrapers: init at 14.14.0`                                 |
| [`d1710a21`](https://github.com/NixOS/nixpkgs/commit/d1710a21fc463437d6396b481882c86f07f75050) | `python310Packages.language-tags: init at 1.1.0`                                     |