### PR TITLE
chore(flake/home-manager): `6427ae95` -> `7fee13eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665078757,
-        "narHash": "sha256-J2zUFgChtwuHgN+qgOdfjsTH2R0NddCGMDk9qx6bDxg=",
+        "lastModified": 1665096050,
+        "narHash": "sha256-KghEJisbR1IiBoAkgmIpeWwEFwKNAS53kjYFipeItqM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6427ae95789c04534363d2b68289996f08077c0c",
+        "rev": "7fee13eb4c64740261c774a90e43830f7213c57c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`7fee13eb`](https://github.com/nix-community/home-manager/commit/7fee13eb4c64740261c774a90e43830f7213c57c) | ``sbt: cache `passwordCommand` output``                |
| [`599e22b1`](https://github.com/nix-community/home-manager/commit/599e22b1c76dc56172c7bb97bc3cd04266869bd6) | ``sbt: allow managing the `~/.sbt/repositories` file`` |