### PR TITLE
chore(flake/home-manager): `7fee13eb` -> `be2cade3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665096050,
-        "narHash": "sha256-KghEJisbR1IiBoAkgmIpeWwEFwKNAS53kjYFipeItqM=",
+        "lastModified": 1665098471,
+        "narHash": "sha256-sNy1nfNg/p/q7JqsJtEOWbV3m5i5M89FzAJwbIn6W2Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7fee13eb4c64740261c774a90e43830f7213c57c",
+        "rev": "be2cade373d96b469e5f4bb22c40cac87cf5a6f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message       |
| ----------------------------------------------------------------------------------------------------------- | -------------------- |
| [`be2cade3`](https://github.com/nix-community/home-manager/commit/be2cade373d96b469e5f4bb22c40cac87cf5a6f0) | `havoc: add module`  |
| [`8c297e18`](https://github.com/nix-community/home-manager/commit/8c297e1816c9744da5a90d8b7aef8ff5c3a41bad) | `ledger: add module` |