### PR TITLE
chore(flake/nixpkgs): `37bd3983` -> `598f83eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664989420,
-        "narHash": "sha256-Q8IxomUjjmewsoJgO3htkXLfCckQ7HkDJ/ZhdYVf/fA=",
+        "lastModified": 1665081174,
+        "narHash": "sha256-6hsmzdhdy8Kbvl5e0xZNE83pW3fKQvNiobJkM6KQrgA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "37bd39839acf99c5b738319f42478296f827f274",
+        "rev": "598f83ebeb2235435189cf84d844b8b73e858e0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`473e97e4`](https://github.com/NixOS/nixpkgs/commit/473e97e434340625b7d93a5222ebddcf9ba9f36d) | `pkgsMusl.mosh: fix build (#194120)`                                                             |
| [`38eb5ec7`](https://github.com/NixOS/nixpkgs/commit/38eb5ec7ba32815d206f4fedca661e3d50aacf98) | `kubectl-doctor: fix build with go 1.18 (#194693)`                                               |
| [`68ccf81f`](https://github.com/NixOS/nixpkgs/commit/68ccf81f32967bb5fff91996942d4c45431700a6) | `libvirt: 8.8.0 -> 8.8.0`                                                                        |
| [`bc4eb490`](https://github.com/NixOS/nixpkgs/commit/bc4eb490b741f10b585e413e462ce4e942b6e7ca) | `klipper: unstable-2022-09-16 -> unstable-2022-10-06`                                            |
| [`550e3ff1`](https://github.com/NixOS/nixpkgs/commit/550e3ff156ae16e4e0a57014db3bbf67e22bb43c) | `wp4nix: Use makeWrapper instead of patching`                                                    |
| [`d6c658f3`](https://github.com/NixOS/nixpkgs/commit/d6c658f34fee0f1d75592e4420abd4d1100ca8cd) | `wordpress: Add wordpressPackages`                                                               |
| [`e724f20e`](https://github.com/NixOS/nixpkgs/commit/e724f20ed5094faaa94ccfdd2d1f864f294381eb) | `vscode-extensions.jakebecker.elixir-ls: alias to vscode-extensions.elixir-lsp.vscode-elixir-ls` |
| [`a90ada2f`](https://github.com/NixOS/nixpkgs/commit/a90ada2f32ef4c460450e6a916b783d0d28dbed3) | `erigon: 2022.09.03 -> 2022.10.01`                                                               |
| [`5234adef`](https://github.com/NixOS/nixpkgs/commit/5234adeffeba13af694f03aa8ff8f402fae744de) | `nextcloud: 23.0.9 -> 23.0.10, 24.0.5 -> 24.0.6`                                                 |
| [`49c0fd7d`](https://github.com/NixOS/nixpkgs/commit/49c0fd7d6005cab96c597d3c56ab0bade5f436c4) | `nixos/acme: Disable lego renew sleeping`                                                        |
| [`657ecbca`](https://github.com/NixOS/nixpkgs/commit/657ecbca0ece81c5e2a411d7044a3d837f520408) | `nixos/acme: Make account creds check more robust`                                               |
| [`39796cad`](https://github.com/NixOS/nixpkgs/commit/39796cad46f1d0b0a14e84a680ababf5ab1ff86d) | `nixos/acme: Fix cert renewal with built in webserver`                                           |
| [`0198610c`](https://github.com/NixOS/nixpkgs/commit/0198610c3a7bf1f9f318cfb4c820cbe29bdc30e1) | `v2ray-geoip: 202209290111 -> 202210060105`                                                      |
| [`9523480e`](https://github.com/NixOS/nixpkgs/commit/9523480edb5e8aedce5ac4c6c942d309df385bd5) | `python310Packages.slither-analyzer: update disabled`                                            |
| [`fc66934d`](https://github.com/NixOS/nixpkgs/commit/fc66934d729f6ff36f333896b9df64b020609840) | `python310Packages.slither-analyzer: 0.8.3 -> 0.9.0`                                             |
| [`3826e303`](https://github.com/NixOS/nixpkgs/commit/3826e303c687871df85ba46eb8f7a11f572623c6) | `nixos/firefox-syncserver: remove extra add_header`                                              |
| [`f97c9d60`](https://github.com/NixOS/nixpkgs/commit/f97c9d60e4f6a93d63433f99ba1bdf9d7000b5ae) | `nixos/firefox-syncserver: proxyPass singleNode to 127.0.0.1`                                    |
| [`8dc30e9e`](https://github.com/NixOS/nixpkgs/commit/8dc30e9e986eb195db842ff750482891e21179e5) | `nixos/firefox-syncserver: set default for oauth verifier threads`                               |
| [`609a1e80`](https://github.com/NixOS/nixpkgs/commit/609a1e8038745b008ec02528f98a2669bec538c2) | `syncstorage-rs: 0.12.0 -> 0.12.1`                                                               |
| [`56a30322`](https://github.com/NixOS/nixpkgs/commit/56a3032252fb66033fb70dadd68e4cddb90edc08) | `bashate: 2.1.0 -> 2.1.1`                                                                        |
| [`c68dd6cb`](https://github.com/NixOS/nixpkgs/commit/c68dd6cb4dbb991262392f68ba8084a307c9243b) | `fulcrum: 1.8.1 -> 1.8.2`                                                                        |
| [`678fff86`](https://github.com/NixOS/nixpkgs/commit/678fff8616745c5054c801cd83a59584cd224470) | `rectangle: add meta.sourceProvenance`                                                           |
| [`f947cfaa`](https://github.com/NixOS/nixpkgs/commit/f947cfaa1d9d5da1ef4cfab23d0142284cec3520) | `vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.8.0 -> 0.11.0`                                 |
| [`1c2ae3ed`](https://github.com/NixOS/nixpkgs/commit/1c2ae3ed6d5fab6ccb40ff40c5f4cd702bb33189) | `signal-cli: 0.11.0 -> 0.11.1`                                                                   |
| [`57cd0854`](https://github.com/NixOS/nixpkgs/commit/57cd0854c8d8dd0ba19977a4bbd89edabbfac32d) | `detect-secrets: 1.3.0 -> 1.4.0`                                                                 |
| [`376b2161`](https://github.com/NixOS/nixpkgs/commit/376b2161e1163574a3e8f99a3eca251b7d647821) | `_1password-gui: Fix aarch64 source hash`                                                        |
| [`39e8576d`](https://github.com/NixOS/nixpkgs/commit/39e8576db8dc1d71efb97578daecdd3422c82d4b) | `python310Packages.weconnect-mqtt: 0.40.1 -> 0.40.2`                                             |
| [`f550503e`](https://github.com/NixOS/nixpkgs/commit/f550503e68b579daf7c61c9323c49b6696aa6f25) | `wander: 0.7.0 -> 0.8.0`                                                                         |
| [`50858eaf`](https://github.com/NixOS/nixpkgs/commit/50858eaf55a90bd784161f35633164efa40e9534) | `hydrus: 500 -> 501`                                                                             |
| [`d25592be`](https://github.com/NixOS/nixpkgs/commit/d25592be8397d84293e18e6d0cf99ee62bcf6a61) | `python310Packages.types-pytz: 2022.2.1.0 -> 2022.4.0.0`                                         |
| [`a66492cf`](https://github.com/NixOS/nixpkgs/commit/a66492cf0bb4f2738018cdbb174ad785f4f9b66d) | `sd-local: 1.0.43 -> 1.0.45`                                                                     |
| [`4dfbb6bc`](https://github.com/NixOS/nixpkgs/commit/4dfbb6bcc6caf9e2e307561404c5c0695136472a) | `python310Packages.twilio: 7.14.1 -> 7.14.2`                                                     |
| [`1f90cfc6`](https://github.com/NixOS/nixpkgs/commit/1f90cfc6f0e31f85a7c1a801bdbe883c5c94a2ca) | `sentry-cli: 2.5.2 -> 2.7.0`                                                                     |
| [`7c164f4b`](https://github.com/NixOS/nixpkgs/commit/7c164f4bea71d74d98780ab7be4f9105630a2eba) | `argocd: 2.4.12 -> 2.4.14`                                                                       |
| [`e9b43c98`](https://github.com/NixOS/nixpkgs/commit/e9b43c988171b2ea0ead4782125b7634aaf01783) | `brev-cli: 0.6.116 -> 0.6.118`                                                                   |
| [`cdfcbf55`](https://github.com/NixOS/nixpkgs/commit/cdfcbf552e58a04f714f0bea537ea4f206f5bd33) | `simgrid: 3.31 -> 3.32`                                                                          |
| [`adaeeb95`](https://github.com/NixOS/nixpkgs/commit/adaeeb9573e5982b2017cc64d76ad75d039bd31d) | `rustypaste: 0.7.1 -> 0.8.2`                                                                     |
| [`bab7d9d0`](https://github.com/NixOS/nixpkgs/commit/bab7d9d0a830c251ba7d6a10ee033e7a4da611bd) | `tidal-hifi: 4.2.0 -> 4.3.0`                                                                     |
| [`08b9a034`](https://github.com/NixOS/nixpkgs/commit/08b9a03470d1a6ab18767c50762e21a96103a8a4) | `liquidsoap: 2.0.6 -> 2.1.2`                                                                     |
| [`308177bb`](https://github.com/NixOS/nixpkgs/commit/308177bb368ec1dd3fe222ed7d8718c734919bdf) | `ocamlPackages.taglib: 0.3.9 -> 0.3.10`                                                          |
| [`53e40f2e`](https://github.com/NixOS/nixpkgs/commit/53e40f2e95daa9f5531ae542f2dfcc3e70262638) | `google-drive-ocamlfuse: Use ocaml 4.12`                                                         |
| [`7e817a85`](https://github.com/NixOS/nixpkgs/commit/7e817a854f7a3468a311dc7d1de50d1f19ffe189) | `ocamlPackages.ocaml_pcre: 7.4.6 -> 7.5.0`                                                       |
| [`b99c3d23`](https://github.com/NixOS/nixpkgs/commit/b99c3d2386e4cb3fa8ce69207c691d17060a6809) | `ocamlPackages.ffmpeg: 1.1.4 -> 1.1.6`                                                           |
| [`17f64e0a`](https://github.com/NixOS/nixpkgs/commit/17f64e0a42a68d51fdd1863a672e573134715a79) | `heptagon: init at 1.05.00`                                                                      |
| [`2f40f8d4`](https://github.com/NixOS/nixpkgs/commit/2f40f8d4a70e853fed755a0a17191899f14fe2bb) | `python310Packages.ultraheat-api: 0.4.3 -> 0.5.0`                                                |
| [`a483acbd`](https://github.com/NixOS/nixpkgs/commit/a483acbdd52d0917892ba7e40a4bcde5add1e867) | `python310Packages.crytic-compile: add format`                                                   |
| [`ba25a663`](https://github.com/NixOS/nixpkgs/commit/ba25a663fad788b7a7948382313d41fb742b6881) | `python310Packages.phonopy: disable on older Python releases`                                    |
| [`43fad50f`](https://github.com/NixOS/nixpkgs/commit/43fad50fc766fbdc065100796f6b001a9495e86c) | `python310Packages.slack-sdk: 3.18.5 -> 3.19.1`                                                  |
| [`b8b0d222`](https://github.com/NixOS/nixpkgs/commit/b8b0d2224a90e207645ca80dce21de49272dc8d8) | `python310Packages.pebble: disable on older Python releases`                                     |
| [`c6f99778`](https://github.com/NixOS/nixpkgs/commit/c6f99778f9e8532084af2fd0d6fa6177ba852a69) | `clojure-lsp: 2022.09.01-15.27.31 -> 2022.10.05-16.39.51`                                        |
| [`647c2855`](https://github.com/NixOS/nixpkgs/commit/647c285587c87d7d23cbd6532e4a1c1e3696d758) | `clj-kondo: 2022.09.08 -> 2022.10.05`                                                            |
| [`af3d02df`](https://github.com/NixOS/nixpkgs/commit/af3d02dfef9b5be461f67c0d1b6c7b203030d514) | `bzip3: 1.1.5 -> 1.1.6`                                                                          |
| [`18a3d28d`](https://github.com/NixOS/nixpkgs/commit/18a3d28d36be7d712fecb8656ea09c8b8e639998) | `python310Packages.crytic-compile: 0.2.3 -> 0.2.4`                                               |
| [`5a814f2b`](https://github.com/NixOS/nixpkgs/commit/5a814f2bf456a1c1097ee114664697f6036132c2) | `procs: fix intel-darwin build`                                                                  |
| [`6d0224cd`](https://github.com/NixOS/nixpkgs/commit/6d0224cd767039909a4c2294560b1014bf072796) | `goimapnotify: Add darwin to platforms (#193797)`                                                |
| [`96ecbb3a`](https://github.com/NixOS/nixpkgs/commit/96ecbb3aac51240139a428dccfcb53fa2a184c85) | `gup: 0.8.0 -> 0.8.4`                                                                            |
| [`8a6c48da`](https://github.com/NixOS/nixpkgs/commit/8a6c48da51cedb4e6675f292710588a1c982d13c) | `gobgpd: 3.6.0 -> 3.7.0`                                                                         |
| [`d4853a17`](https://github.com/NixOS/nixpkgs/commit/d4853a172eee9be92d128d9769d747902a1bb522) | `gobgp: 3.6.0 -> 3.7.0`                                                                          |
| [`5171cd4f`](https://github.com/NixOS/nixpkgs/commit/5171cd4f798a312359b9ea591ae9b1a22031cd58) | `tectonic: 0.9.0 -> 0.11.0`                                                                      |
| [`801293d6`](https://github.com/NixOS/nixpkgs/commit/801293d6ea297635cccf91441169587245d28a5c) | `nomad_1_4: init at 1.4.0`                                                                       |
| [`19b7aae9`](https://github.com/NixOS/nixpkgs/commit/19b7aae97774ff4161c806447eba84bb67ea44ce) | `nomad_1_3: 1.3.5 -> 1.3.6`                                                                      |
| [`53518d5d`](https://github.com/NixOS/nixpkgs/commit/53518d5d5e691700de3a0b6e944f0957549c0270) | `nomad_1_2: 1.2.12 -> 1.2.13`                                                                    |
| [`946f7ba4`](https://github.com/NixOS/nixpkgs/commit/946f7ba477d0d858fae67177508e428d0a6acad6) | `webkitgtk: set -DENABLE_JOURNALD_LOG=OFF if !systemdSupport`                                    |
| [`08be891a`](https://github.com/NixOS/nixpkgs/commit/08be891a50a607657265b10390224f30497f9b15) | `python310Packages.pyswitchbot: 0.19.13 -> 0.19.14`                                              |
| [`912010e3`](https://github.com/NixOS/nixpkgs/commit/912010e3dd0281c692ff352e13760834c7be5fca) | `python310Packages.pysigma: 0.8.2 -> 0.8.8`                                                      |
| [`f23a5806`](https://github.com/NixOS/nixpkgs/commit/f23a58060d5d56639b8f2890e3e7070c5137d754) | `yq-go: 4.27.5 -> 4.28.1`                                                                        |
| [`796c2baa`](https://github.com/NixOS/nixpkgs/commit/796c2baaf4bc1fe24be2eb3eeb3bc48b452069db) | `python310Packages.pyoverkiz: 1.5.3 -> 1.5.4`                                                    |
| [`15144615`](https://github.com/NixOS/nixpkgs/commit/151446151ea9f219943c19b6394b0dd06f531a70) | `rectangle: init at 0.59`                                                                        |
| [`44c1c988`](https://github.com/NixOS/nixpkgs/commit/44c1c9887a28f07b3c4adc92247b09649292b8e6) | `uriparser: 0.9.6 -> 0.9.7`                                                                      |
| [`1592e21b`](https://github.com/NixOS/nixpkgs/commit/1592e21b44a6c334f048330aba3e3036f595496c) | `tlsx: 0.0.7 -> 0.0.8`                                                                           |
| [`d8e745e8`](https://github.com/NixOS/nixpkgs/commit/d8e745e890b0f298d875e64771fb30ac302aec6a) | `terragrunt: 0.39.0 -> 0.39.1`                                                                   |
| [`00157d95`](https://github.com/NixOS/nixpkgs/commit/00157d95d2cccfce7331f98a3533b82c26857a46) | `t-rec: 0.7.4 -> 0.7.5`                                                                          |
| [`f3e22294`](https://github.com/NixOS/nixpkgs/commit/f3e22294569b359b4d19f68a7a6e7a9cd9822321) | `python310Packages.phonopy: 2.16.2 -> 2.16.3`                                                    |
| [`75a31328`](https://github.com/NixOS/nixpkgs/commit/75a3132819d789585d6fc75b1404393cab824016) | `python310Packages.pex: 2.1.107 -> 2.1.108`                                                      |
| [`099f1e0d`](https://github.com/NixOS/nixpkgs/commit/099f1e0da2a6e31a947c44d8e367f11184c3862d) | `redpanda: 22.2.4 -> 22.2.5`                                                                     |
| [`34f295cb`](https://github.com/NixOS/nixpkgs/commit/34f295cb2abeeaf5383c17d1f1168ea1447dc204) | `python310Packages.pebble: 5.0.0 -> 5.0.1`                                                       |
| [`7ac1f68c`](https://github.com/NixOS/nixpkgs/commit/7ac1f68ce29bf49bc1f235c6868bc75c50b07a9e) | `build2: fix build with gcc11`                                                                   |
| [`748175c0`](https://github.com/NixOS/nixpkgs/commit/748175c0c35e1f813a8b44836f49f56fb4a4ba44) | `vector: build on all platforms`                                                                 |
| [`8e8c1b6c`](https://github.com/NixOS/nixpkgs/commit/8e8c1b6c77c6ee86172958b7426e8fd35214b8b6) | `python310Packages.panel: 0.13.1 -> 0.14.0`                                                      |
| [`1c551329`](https://github.com/NixOS/nixpkgs/commit/1c5513298aefe8d5345293bbb65f71bd84ceaee9) | `home-assistant: 2022.9.7 -> 2022.10.0`                                                          |
| [`336c8f2a`](https://github.com/NixOS/nixpkgs/commit/336c8f2a4c47436b0427c931d6e348a8bdd8ec1a) | `python3Packages.dataclasses-json: Disable failing test`                                         |
| [`3c2e3c56`](https://github.com/NixOS/nixpkgs/commit/3c2e3c568642d6d6c8b9ad10dc2b720f63af2212) | `python3Packages.bellows: 0.33.1 -> 0.34.1`                                                      |
| [`6b4e339e`](https://github.com/NixOS/nixpkgs/commit/6b4e339ef684b766c15789aaeff81102d53101cb) | `python310Packages.bluetooth-adapters: 0.5.2 -> 0.6.0`                                           |
| [`dc6318b1`](https://github.com/NixOS/nixpkgs/commit/dc6318b1f3c98554ca81f55ce09b196f58aef6d2) | `python3Packages.brother: 1.2.3 -> 2.0.0`                                                        |
| [`792b414e`](https://github.com/NixOS/nixpkgs/commit/792b414e246d828b415af90d149e5faa8203488e) | `python310Packages.bthome-ble: 1.0.0 -> 1.2.2`                                                   |
| [`f8d737f4`](https://github.com/NixOS/nixpkgs/commit/f8d737f4cc9cba26d84dd8c9fcce006832cbbd84) | `python310Packages.dbus-fast: 1.17.0 -> 1.24.0`                                                  |
| [`ac5f1357`](https://github.com/NixOS/nixpkgs/commit/ac5f1357c1fcc884b22a8d0031af6aa7e5c1d98e) | `python3Packages.fritzconnection: 1.9.1 -> 1.10.3`                                               |
| [`701aeabc`](https://github.com/NixOS/nixpkgs/commit/701aeabcd982974ddec7d3aa98afcec9e2e73510) | `python3Packages.plugwise: 0.23.0 -> 0.24.0`                                                     |
| [`408617b6`](https://github.com/NixOS/nixpkgs/commit/408617b6282beb38b14eba601eeef5e5a416f1ee) | `python3Packages.zha-quirks: 0.0.80 -> 0.0.82`                                                   |
| [`89b7fb51`](https://github.com/NixOS/nixpkgs/commit/89b7fb516cf2eda3deae89b409e19cb3f0a645a1) | `python3Packages.zwave-js-server-python: 0.41.1 -> 0.43.0`                                       |
| [`3266f9b8`](https://github.com/NixOS/nixpkgs/commit/3266f9b8322b809fbcab21dd067e809f0d8857f5) | `python3Packages.zigpy-znp: 0.8.2 -> 0.9.0`                                                      |
| [`2295be56`](https://github.com/NixOS/nixpkgs/commit/2295be56afedc80341f6b3019c36a622da737423) | `python3Packages.zigpy-zigate: 0.9.2 -> 0.10.0`                                                  |
| [`4bc5b7af`](https://github.com/NixOS/nixpkgs/commit/4bc5b7aff6443bbc59e6727ce88d09ae5280c5b1) | `python3Packages.zigpy-xbee: 0.15.0 -> 0.16.0`                                                   |
| [`b31ec0ee`](https://github.com/NixOS/nixpkgs/commit/b31ec0ee33457b47c36480d49bb2791d4a7dbf67) | `python3Packages.zigpy-deconz: 0.18.1 -> 0.19.0`                                                 |
| [`93babf43`](https://github.com/NixOS/nixpkgs/commit/93babf43bf4f72485459ee948138095ce0de29a6) | `python3Packages.zigpy: 0.50.3 -> 0.51.2`                                                        |
| [`f5f28290`](https://github.com/NixOS/nixpkgs/commit/f5f2829041fdaa8eac9af6770396e7772a4a67e7) | `python3Packages.zigpy: 0.50.3 -> 0.51.2`                                                        |
| [`3e25431f`](https://github.com/NixOS/nixpkgs/commit/3e25431f332bc1031482960f384474a02e2f2386) | `freedv: wxGTK31-gtk3 -> wxGTK32`                                                                |
| [`7b68078e`](https://github.com/NixOS/nixpkgs/commit/7b68078ea7b5b7442336e7fd6fa5b61ff43a16e6) | `freedv: fix build on x86_64-darwin`                                                             |
| [`06b147f6`](https://github.com/NixOS/nixpkgs/commit/06b147f6b3fe4231ef2bfdd96600a7d9853ea696) | `mariadb: remove dangling symlink`                                                               |
| [`8d807a10`](https://github.com/NixOS/nixpkgs/commit/8d807a1026457b4963ba91d24201bf83575cb5dc) | `postgresqlPackages.pg_ivm: 1.2 -> 1.3`                                                          |
| [`f340a344`](https://github.com/NixOS/nixpkgs/commit/f340a34482d5fa2f740f1c95f60e5bd02cc03c6f) | `dhcp: 4.4.3 -> 4.4.3-P1`                                                                        |
| [`e3f7c50a`](https://github.com/NixOS/nixpkgs/commit/e3f7c50a73e3b4a7526bd3099409452063be7fe3) | `safety-cli: 2.2.0 -> 2.2.1`                                                                     |
| [`93e8e4f6`](https://github.com/NixOS/nixpkgs/commit/93e8e4f6213a58762adec05565586419ec7fc8c0) | `python310Packages.minikerberos: 0.3.2 -> 0.3.3`                                                 |
| [`f288df00`](https://github.com/NixOS/nixpkgs/commit/f288df00cb9c3cee955196e176aa788bf061d981) | `libreswan: 4.7 -> 4.8`                                                                          |
| [`a748f63c`](https://github.com/NixOS/nixpkgs/commit/a748f63ca7395046c5856077056fe1033df55018) | `dictd: add dictdDBs.eng2jpn and dictdDBs.jpn2eng`                                               |
| [`bdb7a3b0`](https://github.com/NixOS/nixpkgs/commit/bdb7a3b0d9d21bf3bfb492e05f2b3054e49f5447) | `esphome: 2022.9.2 -> 2022.9.3`                                                                  |
| [`dba3a8a6`](https://github.com/NixOS/nixpkgs/commit/dba3a8a632b715f1608bb72e88b9c833ce84c0c4) | `teleport: Enable libfido2 support`                                                              |
| [`becacf25`](https://github.com/NixOS/nixpkgs/commit/becacf259dc5689e38582489704ddf8063cec8b2) | `teleport: 9.1.2 -> 10.3.1`                                                                      |
| [`3050d34e`](https://github.com/NixOS/nixpkgs/commit/3050d34eb433f586cb79c8c2a4725eb9b33ded80) | `procs: 0.13.1 -> 0.13.2`                                                                        |
| [`ff92f35b`](https://github.com/NixOS/nixpkgs/commit/ff92f35b83f0d92eea7d990c4edb351d99e4cacc) | `chromium: 106.0.5249.61 -> 106.0.5249.91`                                                       |
| [`3d50284b`](https://github.com/NixOS/nixpkgs/commit/3d50284bb23e2a7e5031206e03cabd9e10b8907d) | `chromedriver: Disable on aarch64-darwin`                                                        |
| [`66b35365`](https://github.com/NixOS/nixpkgs/commit/66b353654dbf10df36ae4f0e7f8f5ac8331f83c0) | `oh-my-posh: 11.3.0 -> 11.4.0`                                                                   |
| [`ec50f7a5`](https://github.com/NixOS/nixpkgs/commit/ec50f7a5c3a766dabff1450eb6dc19ba19e4c459) | `chromiumDev: 107.0.5304.10 -> 108.0.5327.0`                                                     |
| [`d8838431`](https://github.com/NixOS/nixpkgs/commit/d88384313a69c68d612a3bef5622d193bcff9209) | `chromiumBeta: 106.0.5249.61 -> 107.0.5304.18`                                                   |
| [`ddccd3a9`](https://github.com/NixOS/nixpkgs/commit/ddccd3a95e4d50255210146464935894906e0ac1) | `python310Packages.homematicip: 1.0.7 -> 1.0.8`                                                  |
| [`e89c5434`](https://github.com/NixOS/nixpkgs/commit/e89c54347760b86848c859a750d95858121a69a2) | `nats-top: 0.5.2 -> 0.5.3`                                                                       |
| [`287084ca`](https://github.com/NixOS/nixpkgs/commit/287084ca5b2b209f357d4cd7eab894c78e4d288f) | `linux/hardened/patches/5.4: 5.4.214-hardened1 -> 5.4.215-hardened1`                             |
| [`5ececd27`](https://github.com/NixOS/nixpkgs/commit/5ececd27afd9493f2dbcb3704c8e3970bd07ed0b) | `linux/hardened/patches/5.19: 5.19.11-hardened1 -> 5.19.12-hardened1`                            |
| [`650325d3`](https://github.com/NixOS/nixpkgs/commit/650325d3453a2fffcf49270a37a1e7e27978d7a7) | `linux/hardened/patches/5.15: 5.15.70-hardened1 -> 5.15.71-hardened1`                            |
| [`e10301dd`](https://github.com/NixOS/nixpkgs/commit/e10301dd2ac9382556f301f5912627799b86ca68) | `linux/hardened/patches/5.10: 5.10.145-hardened1 -> 5.10.146-hardened1`                          |
| [`4bdc6d74`](https://github.com/NixOS/nixpkgs/commit/4bdc6d745cb7273aa3937020830137704a4686e0) | `python310Packages.google-cloud-spanner: 3.22.0 -> 3.22.1`                                       |
| [`b574688f`](https://github.com/NixOS/nixpkgs/commit/b574688f34e97256576960d825c9e85884778f7c) | `python310Packages.google-cloud-securitycenter: 1.16.0 -> 1.16.1`                                |
| [`9ba817f6`](https://github.com/NixOS/nixpkgs/commit/9ba817f60b3a6843e18b06351e944905bb353d99) | `linux/hardened/patches/4.19: 4.19.259-hardened1 -> 4.19.260-hardened1`                          |
| [`6a9fb214`](https://github.com/NixOS/nixpkgs/commit/6a9fb21418dcbd12b4f5e3dd754f7f6a706ed3dc) | `linux/hardened/patches/4.14: 4.14.294-hardened1 -> 4.14.295-hardened1`                          |
| [`1db3d288`](https://github.com/NixOS/nixpkgs/commit/1db3d28892ebbb8f2043b473ee4cff434cae75c0) | `linux_latest-libre: 18916 -> 18950`                                                             |
| [`a8ad1882`](https://github.com/NixOS/nixpkgs/commit/a8ad1882c15512d4f789ca964d3d1a472495649d) | `linux: 5.4.215 -> 5.4.216`                                                                      |
| [`23bda1f2`](https://github.com/NixOS/nixpkgs/commit/23bda1f2db161501a68e119c402df166c35c9545) | `linux: 5.19.12 -> 5.19.14`                                                                      |
| [`addb3998`](https://github.com/NixOS/nixpkgs/commit/addb39984d1e3c2f197fe18517027c810f1aece9) | `linux: 5.15.71 -> 5.15.72`                                                                      |
| [`cabbaee7`](https://github.com/NixOS/nixpkgs/commit/cabbaee762e36dceb8f4e286fbf9832150259e90) | `python310Packages.google-cloud-logging: 3.2.3 -> 3.2.4`                                         |
| [`6ea28520`](https://github.com/NixOS/nixpkgs/commit/6ea285206d64344f3c6eb4e8e0c9c6da5d916896) | `linux: 5.10.146 -> 5.10.147`                                                                    |
| [`d7920e2d`](https://github.com/NixOS/nixpkgs/commit/d7920e2dedc0a58d3f7c280d6ec6faf081ecd811) | `linux: 4.19.260 -> 4.19.261`                                                                    |
| [`59b984c7`](https://github.com/NixOS/nixpkgs/commit/59b984c7fdc9084b3550bc2ebc65977a1905f006) | `ruff: 0.0.52 -> 0.0.56`                                                                         |
| [`b360a94a`](https://github.com/NixOS/nixpkgs/commit/b360a94abbab69c0137d3c802a39350e3e0d0a5f) | `python310Packages.google-cloud-firestore: 2.7.0 -> 2.7.1`                                       |
| [`3295e92e`](https://github.com/NixOS/nixpkgs/commit/3295e92e785fa7e93b88f02e136386f1559f93e5) | `python310Packages.google-cloud-error-reporting: 1.6.1 -> 1.6.2`                                 |
| [`3122c8ad`](https://github.com/NixOS/nixpkgs/commit/3122c8adec2569c0c8b8bb21eb9c240f079c36bc) | `python310Packages.google-cloud-dlp: 3.9.0 -> 3.9.1`                                             |
| [`516d0ef9`](https://github.com/NixOS/nixpkgs/commit/516d0ef9dd439bfc7edf42c6d887a9c6ee7d2af3) | `python310Packages.google-cloud-datastore: 2.8.1 -> 2.8.2`                                       |
| [`5f461bcf`](https://github.com/NixOS/nixpkgs/commit/5f461bcf1ec854c565f0304498aa5f50a3f516b0) | `python310Packages.google-cloud-dataproc: 5.0.1 -> 5.0.2`                                        |
| [`9a7a2229`](https://github.com/NixOS/nixpkgs/commit/9a7a22297d4404f112924ba7a937c1b40490ca3f) | `python310Packages.google-cloud-bigquery-datatransfer: 3.7.1 -> 3.7.2`                           |
| [`17e07bee`](https://github.com/NixOS/nixpkgs/commit/17e07beec6366a387748caac6e085fbb8a866582) | `python310Packages.google-cloud-asset: 3.14.0 -> 3.14.1`                                         |
| [`1e430612`](https://github.com/NixOS/nixpkgs/commit/1e430612dc9d784ab0abe51f05e3ffe356bdafc8) | `jitsi-videobridge: fix link in docs`                                                            |
| [`37abfd38`](https://github.com/NixOS/nixpkgs/commit/37abfd38c1a1ff4b382e4af37032959970d738ea) | `python310Packages.glyphslib: 6.0.7 -> 6.1.0`                                                    |
| [`0826bc33`](https://github.com/NixOS/nixpkgs/commit/0826bc33b694a83a45704c503a0234e9c0c4e091) | `python310Packages.discogs-client: 2.4 -> 2.5`                                                   |
| [`47a05da5`](https://github.com/NixOS/nixpkgs/commit/47a05da59c724fcc95f4ac53bfdec6af73a57806) | `tidall-hifi: remove stray backslash`                                                            |
| [`513426fc`](https://github.com/NixOS/nixpkgs/commit/513426fccdac1a4319f0fd552fd655b57df7bbfe) | `hugo: 0.104.2 -> 0.104.3`                                                                       |
| [`36654791`](https://github.com/NixOS/nixpkgs/commit/366547912ff08769a08c9d1aafc7664b52b3e126) | `python3Packages.psycopg: 3.1.2 -> 3.1.3`                                                        |
| [`bc18570a`](https://github.com/NixOS/nixpkgs/commit/bc18570a74f21f6d5ad4db40870866819663cd92) | `python310Packages.cock: 0.10.0 -> 0.11.0`                                                       |
| [`22ec1813`](https://github.com/NixOS/nixpkgs/commit/22ec1813c59176184f253a2470da1d9ad5d9761a) | `golangci-lint: 1.49.0 -> 1.50.0`                                                                |
| [`48f810bd`](https://github.com/NixOS/nixpkgs/commit/48f810bd79db6ea3d8749f040244ab6da7fbf1e0) | `fs-uae-launcher: fix Qt wrapping issue`                                                         |
| [`0b0a6816`](https://github.com/NixOS/nixpkgs/commit/0b0a6816be262104f476025a370d8ce740d9b433) | `exercism: 3.0.13 -> 3.1.0`                                                                      |
| [`0bb5d570`](https://github.com/NixOS/nixpkgs/commit/0bb5d570d1aa60488f0f22bf9230b2fdc97aafce) | `openasar: unstable-2022-08-07 -> unstable-2022-10-02`                                           |
| [`e98d7906`](https://github.com/NixOS/nixpkgs/commit/e98d79062d4b379f7bb8ea1172290afffa258759) | `adrgen: fix darwin build`                                                                       |
| [`a0e9973e`](https://github.com/NixOS/nixpkgs/commit/a0e9973e64ba3f1277fb10c9ae3ecedf6b0af16a) | `cudatoolkit: use if instead of versionOlder+versionAtLeast`                                     |
| [`11075c26`](https://github.com/NixOS/nixpkgs/commit/11075c265858ba094c49c4bb60e13b922697df7e) | `maigret: 0.4.3 -> 0.4.4`                                                                        |
| [`3ae7efd3`](https://github.com/NixOS/nixpkgs/commit/3ae7efd34aa40bc84ec5d5114c91ba36e0db0ada) | `python310Packages.pytibber: 0.25.2 -> 0.25.3`                                                   |
| [`ce8874a1`](https://github.com/NixOS/nixpkgs/commit/ce8874a16cb9fc5d9d47203745f9250d5cdde1ef) | `eartag: init at 0.2.1`                                                                          |
| [`f94082ba`](https://github.com/NixOS/nixpkgs/commit/f94082ba5240552f9dddeb8a5fd2dfbc6f5abec1) | `python3Packages.wandb: reorder attributes`                                                      |