### PR TITLE
chore(flake/nixpkgs): `598f83eb` -> `c5924154`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665081174,
-        "narHash": "sha256-6hsmzdhdy8Kbvl5e0xZNE83pW3fKQvNiobJkM6KQrgA=",
+        "lastModified": 1665259268,
+        "narHash": "sha256-ONFhHBLv5nZKhwV/F2GOH16197PbvpyWhoO0AOyktkU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "598f83ebeb2235435189cf84d844b8b73e858e0f",
+        "rev": "c5924154f000e6306030300592f4282949b2db6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                               |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`d00db576`](https://github.com/NixOS/nixpkgs/commit/d00db576d4c3dd2c32592a198e67af29694a989a) | `python310Packages.strictyaml: 1.6.1 -> 1.6.2`                               |
| [`3d675948`](https://github.com/NixOS/nixpkgs/commit/3d675948c56b4557885be70ec3d00e4200809759) | `treesheets: add darwin support`                                             |
| [`729189ee`](https://github.com/NixOS/nixpkgs/commit/729189eee8cd504aa4fc1f54799e8ec5dc1b93c5) | `nim_builder: enable parallel building`                                      |
| [`1471e0c7`](https://github.com/NixOS/nixpkgs/commit/1471e0c73968d2062baade43ee2262044eb95e67) | `nim: unescape "\ " before splitting NIX_LDFLAGS`                            |
| [`c1184a3f`](https://github.com/NixOS/nixpkgs/commit/c1184a3f8c11162ff554dbadbe896af9c095ee0b) | `nim: 1.6.6 -> 1.6.8`                                                        |
| [`b4bb571f`](https://github.com/NixOS/nixpkgs/commit/b4bb571fa076bdcd60033d05a943e7ea3df0aac6) | `iwd: remove myself as maintainer`                                           |
| [`dcd82ae5`](https://github.com/NixOS/nixpkgs/commit/dcd82ae5d9f55b74c7d650c15b29539e838c9a0e) | `maeparser: refresh meta`                                                    |
| [`8bed3364`](https://github.com/NixOS/nixpkgs/commit/8bed3364f02d671fb76bc74227103b6921d8f5be) | `wasm-pack: Update LibreSSL to 3.5`                                          |
| [`52d9fd78`](https://github.com/NixOS/nixpkgs/commit/52d9fd78e29eb844eefa4d294a6f46b9959fd842) | `sarasa-gothic: 0.37.0 -> 0.37.4`                                            |
| [`9c9c818f`](https://github.com/NixOS/nixpkgs/commit/9c9c818f46761f539ee0fb7b9aace6483cfd4163) | `python310Packages.pysigma: 0.8.8 -> 0.8.9`                                  |
| [`ffd9fc28`](https://github.com/NixOS/nixpkgs/commit/ffd9fc281188d873dac77049d271372365876b83) | `grim: disable -Werror so compiler updates can't break the build`            |
| [`c02b06d6`](https://github.com/NixOS/nixpkgs/commit/c02b06d612c164d4915675080516a4c43068f2a4) | `chromedriver: fix darwin aarch64`                                           |
| [`9542fd2d`](https://github.com/NixOS/nixpkgs/commit/9542fd2dc524a55d90fbc10fe574c85a94ef0e13) | `rocketchat-desktop: 3.8.9 -> 3.8.11`                                        |
| [`a07f22f2`](https://github.com/NixOS/nixpkgs/commit/a07f22f26fcd3c0087f06a7a91b402c894b6486f) | `phrase-cli: 2.5.1 -> 2.5.2`                                                 |
| [`4e44672a`](https://github.com/NixOS/nixpkgs/commit/4e44672a0ae4df762dd76a7afa9e6082c7fbd775) | `shipyard: 0.4.10 -> 0.4.12`                                                 |
| [`043641f5`](https://github.com/NixOS/nixpkgs/commit/043641f58a167759dfb9e21f1871b9ea5b21d7b8) | `twitterBootstrap: 5.2.1 -> 5.2.2`                                           |
| [`c51e91db`](https://github.com/NixOS/nixpkgs/commit/c51e91dbbb76bfff78902b02439117ad1d3aadf3) | `python310Packages.pydata-sphinx-theme: 0.10.1 -> 0.11.0`                    |
| [`9b16f08a`](https://github.com/NixOS/nixpkgs/commit/9b16f08a95589022e3ebc3e3642013d98bc5a1f0) | `yosys-ghdl: 2021.01.25 -> 2022.01.11`                                       |
| [`cd3fc9ea`](https://github.com/NixOS/nixpkgs/commit/cd3fc9ea27f8448f45cf27a8b1e77caa7788f92d) | `yosys-ghdl: Formatting - new lines between inputs and arguments`            |
| [`0d3debe5`](https://github.com/NixOS/nixpkgs/commit/0d3debe506ae86a201019fb8abb3e9876218aaae) | `ghdl: 1.0.0 -> 2.0.0`                                                       |
| [`40fe2e89`](https://github.com/NixOS/nixpkgs/commit/40fe2e891387131dc3e2b6fed4cfd21001c1be13) | `python310Packages.pyatmo: 7.1.0 -> 7.1.1`                                   |
| [`bdcdd675`](https://github.com/NixOS/nixpkgs/commit/bdcdd675da8c819aaa081e569a8b20ccf3ee596c) | `exact-audio-copy: init at 1.6.0 (#194019)`                                  |
| [`6c5808b9`](https://github.com/NixOS/nixpkgs/commit/6c5808b9621bde97f1e38e7585b919a0e5ed2002) | `grim: patch for 32bit platforms`                                            |
| [`25f50e37`](https://github.com/NixOS/nixpkgs/commit/25f50e3770d809cc47d6cd463ba839d5b3f5883a) | `imgproxy: 3.7.2 -> 3.8.0`                                                   |
| [`4d573bd7`](https://github.com/NixOS/nixpkgs/commit/4d573bd7e4e60026c780249592685f7a8dd87253) | `iam-policy-json-to-terraform: 1.8.0 -> 1.8.1`                               |
| [`68138bfb`](https://github.com/NixOS/nixpkgs/commit/68138bfb280de7ad1ec99b8e54fcbc58cea453b6) | `nixosTests.spark: give worker node 2G of memory`                            |
| [`0215ef1a`](https://github.com/NixOS/nixpkgs/commit/0215ef1a1d5b92db7ce4f0f5f25f25094bc850d5) | `scli: fix build`                                                            |
| [`8d05bf52`](https://github.com/NixOS/nixpkgs/commit/8d05bf52e08b3f9bd937df302d159fb5d6914199) | `tytools: 0.9.7 -> 0.9.8`                                                    |
| [`3ffe9266`](https://github.com/NixOS/nixpkgs/commit/3ffe9266e521f0b540cbb1b69a4d00ee8d6e87b3) | `yacreader: 9.9.1 -> 9.9.2`                                                  |
| [`85c0e1bb`](https://github.com/NixOS/nixpkgs/commit/85c0e1bb3d2512ed035a97f0d50c7be5e18b78e9) | `flex-ncat: 0.1-20220505.0 -> 0.1-20221007.1`                                |
| [`c266918b`](https://github.com/NixOS/nixpkgs/commit/c266918b2336eecf5001163f32e02d0ca7ac8300) | `flex-ndax: 0.2-20220427 -> 0.2-20221007.1`                                  |
| [`552ab32c`](https://github.com/NixOS/nixpkgs/commit/552ab32c71114a19e84b68ddaefc0e787bc227d7) | `cg3: 1.3.7 -> 1.3.9`                                                        |
| [`f9d7ba16`](https://github.com/NixOS/nixpkgs/commit/f9d7ba16eeab12f24e1ace7154d33dfeec43da39) | `python310Packages.pex: 2.1.108 -> 2.1.109`                                  |
| [`412cb986`](https://github.com/NixOS/nixpkgs/commit/412cb9861b28040122cddea10e55869836c95b66) | `python310Packages.pyquil: 3.3.1 -> 3.3.2`                                   |
| [`148f8a02`](https://github.com/NixOS/nixpkgs/commit/148f8a027b640f87ad956344e05d125bb58edb86) | `python310Packages.types-python-dateutil: init at 2.8.19`                    |
| [`b5e07bd3`](https://github.com/NixOS/nixpkgs/commit/b5e07bd34ead5453f1efae3f035f3ab97be732a7) | `flexget: 3.3.30 -> 3.3.31`                                                  |
| [`6c8cf1e3`](https://github.com/NixOS/nixpkgs/commit/6c8cf1e3686669ef23c4d62e622b744889889a78) | `python310Packages.types-retry: init at 0.9.9`                               |
| [`82ed11ae`](https://github.com/NixOS/nixpkgs/commit/82ed11aef0426c05040d758181ec6cd5b334b018) | `python310Packages.plugwise: 0.24.0 -> 0.24.1`                               |
| [`d14aa797`](https://github.com/NixOS/nixpkgs/commit/d14aa797be489dda1a8e997b5bb1643d75115e6f) | `python310Packages.hahomematic: 2022.10.1 -> 2022.10.2`                      |
| [`43d10b66`](https://github.com/NixOS/nixpkgs/commit/43d10b6690b80eb1aa900398513191b7e5fbafdd) | `python310Packages.cairo-lang: use pythonRelaxDepsHook`                      |
| [`6c2364b1`](https://github.com/NixOS/nixpkgs/commit/6c2364b16041edc71dc64a38b4318ed28229a55f) | `python310Packages.web3: 5.30.0 -> 5.31.1`                                   |
| [`06a23ead`](https://github.com/NixOS/nixpkgs/commit/06a23eade308f16dcb0d0b9c5e45a52b7add40a0) | `ergo: 4.0.103 -> 4.0.104`                                                   |
| [`42482146`](https://github.com/NixOS/nixpkgs/commit/4248214624599d05a135bc97be83547ea520415e) | `doctl: 1.82.2 -> 1.83.0`                                                    |
| [`82e9715b`](https://github.com/NixOS/nixpkgs/commit/82e9715be8b9d388e578fe729c9482668df9f7b9) | `libdwarf: use latest version by default`                                    |
| [`8e4d39a0`](https://github.com/NixOS/nixpkgs/commit/8e4d39a07f1b1be928a834b6c47b3c0c1e9dfed5) | `cosign: 1.12.1 -> 1.13.0`                                                   |
| [`9d9071ae`](https://github.com/NixOS/nixpkgs/commit/9d9071ae6266f771cab4a99ed2267e8e28ef0b02) | `cri-o: 1.25.0 -> 1.25.1 (#195047)`                                          |
| [`870ad88b`](https://github.com/NixOS/nixpkgs/commit/870ad88b6c2451a0ccd470dbd70bd34b9684e384) | `libbpf: disable auto updates for 0.8 branch`                                |
| [`aeff75a5`](https://github.com/NixOS/nixpkgs/commit/aeff75a5f97c1c0353fefe10a7d0573310dada6b) | `buildkit-nix: 0.0.2 -> 0.0.3`                                               |
| [`1c12d6de`](https://github.com/NixOS/nixpkgs/commit/1c12d6decfcbd386ddd574d72a70b788977ec4fd) | `catclock: use xorg.* packages directly instead of xlibsWrapper indirection` |
| [`e979c208`](https://github.com/NixOS/nixpkgs/commit/e979c208469c4fff8aef01a1aeefdf07c3c7b0e9) | `eksctl: 0.113.0 -> 0.114.0`                                                 |
| [`dfb27d69`](https://github.com/NixOS/nixpkgs/commit/dfb27d69925bd8c865753e34be19eb12f3b476bb) | `git-branchless: 0.5.0 -> 0.5.1`                                             |
| [`e596b04c`](https://github.com/NixOS/nixpkgs/commit/e596b04c5707086804f1e692e135f5ebfb22f448) | `python310Packages.msal: 1.19.0 -> 1.20.0`                                   |
| [`be3f8c0e`](https://github.com/NixOS/nixpkgs/commit/be3f8c0eab1b36328f4576afa6bb6ce70581937b) | `cpm: 0.35.6 -> 0.36.0`                                                      |
| [`226dbe03`](https://github.com/NixOS/nixpkgs/commit/226dbe039093d1d1f60552b9b4354a5ba2689237) | `protoc-gen-connect-go: 0.1.1 -> 1.0.0`                                      |
| [`7175d5f2`](https://github.com/NixOS/nixpkgs/commit/7175d5f2672985e6ef88f278b0a0aa9e27446a3a) | `cubiomes-viewer: 2.5.0 -> 2.5.1`                                            |
| [`c845ce13`](https://github.com/NixOS/nixpkgs/commit/c845ce135c728023448c00fe7c9439c40e03c26b) | `python310Packages.ledgerblue: 0.1.42 -> 0.1.43`                             |
| [`a070b3c4`](https://github.com/NixOS/nixpkgs/commit/a070b3c46b348e3c68e33ea233c18dd5582f3e29) | `ocamlPackages.ppx_tools: 6.5 → 6.6`                                         |
| [`308b2350`](https://github.com/NixOS/nixpkgs/commit/308b23503e2495926552b0bc0e8587a8c0fe31d5) | `python310Packages.json-stream: 1.4.3 -> 1.5.1`                              |
| [`77ca053f`](https://github.com/NixOS/nixpkgs/commit/77ca053fe88b79f40711e87784a88e8a1428d797) | `snappymail: 2.18.4 -> 2.18.5`                                               |
| [`3122b77e`](https://github.com/NixOS/nixpkgs/commit/3122b77ee4d4dab165cf2a1309d2093e417d4524) | `signal-cli: 0.11.1 -> 0.11.3`                                               |
| [`9a1efc49`](https://github.com/NixOS/nixpkgs/commit/9a1efc4981f82c5f2f5c9be4829e5fec6af4295c) | `sensu-go-agent: 6.8.1 -> 6.8.2`                                             |
| [`8f3fd35f`](https://github.com/NixOS/nixpkgs/commit/8f3fd35f10247de053218a0e48d4bd707124abec) | `matrix-appservice-slack: 1.11.0 -> 2.0.1`                                   |
| [`61e0cd11`](https://github.com/NixOS/nixpkgs/commit/61e0cd11c35a95fd92719fc777cb8a52bbce33d5) | `matrix-appservice-slack: fix build`                                         |
| [`40a04c11`](https://github.com/NixOS/nixpkgs/commit/40a04c1178b2508b1d971a341f5e889c680b45e7) | `ntfy-sh: set version number and strip binary`                               |
| [`0b2e48b4`](https://github.com/NixOS/nixpkgs/commit/0b2e48b4c1bb115a6294b9a0c98f82c3a56c35e4) | `ntfy-sh: build and package web UI and docs`                                 |
| [`5b97db5b`](https://github.com/NixOS/nixpkgs/commit/5b97db5b4a10ff6f7d98ac1569f9f056f60a58ee) | `firefox-bin-unwrapped: 105.0.2 -> 105.0.3`                                  |
| [`5255c541`](https://github.com/NixOS/nixpkgs/commit/5255c541a6b3830d121fae2b440e104206d9761d) | `firefox-unwrapped: 105.0.2 -> 105.0.3`                                      |
| [`fd03aab9`](https://github.com/NixOS/nixpkgs/commit/fd03aab973f16bd0848b63e5c28489cbc365a399) | `rocksdb: 7.6.0 -> 7.7.2`                                                    |
| [`91c20089`](https://github.com/NixOS/nixpkgs/commit/91c200896e2122e0be8dcbf43256aad465d96e47) | `railway: 2.0.12 -> 2.0.13`                                                  |
| [`b9e2097a`](https://github.com/NixOS/nixpkgs/commit/b9e2097a74316083c1a21e472ba0cc57fc269e30) | `sigdigger: init at 0.3.0`                                                   |
| [`49584052`](https://github.com/NixOS/nixpkgs/commit/49584052fedc12ce54c988402978aced61acfbf0) | `suscan: init at unstable-2022-07-05`                                        |
| [`e5359286`](https://github.com/NixOS/nixpkgs/commit/e53592866269bf2bddc2bd13e82759e432b9776a) | `sigutils: init at unstable-2022-07-05`                                      |
| [`846c7540`](https://github.com/NixOS/nixpkgs/commit/846c75400ecf5e43c333496844443891ac31a826) | `suwidgets: init at unstable-2022-04-03`                                     |
| [`fc7905c9`](https://github.com/NixOS/nixpkgs/commit/fc7905c977bd9422a5f59674938ab54139c26ba0) | `open-policy-agent: 0.44.0 -> 0.45.0`                                        |
| [`f439af5c`](https://github.com/NixOS/nixpkgs/commit/f439af5ce6d91934e877c75f8f308c12016b99b9) | `nixopsUnstable: fix build`                                                  |
| [`8710df5d`](https://github.com/NixOS/nixpkgs/commit/8710df5d269537479834db0f5bac67b947ef5cfd) | `nixopsUnstable: update`                                                     |
| [`aa463a0d`](https://github.com/NixOS/nixpkgs/commit/aa463a0d1dcc495202049a16a59c8b70269bdcfe) | `poetry2nix: 1.31.0 -> 1.33.0`                                               |
| [`eb525821`](https://github.com/NixOS/nixpkgs/commit/eb5258213edb874d9f31ee1b5a8069d94dc0bfcf) | `maintainers: add oxapentane`                                                |
| [`0193ab23`](https://github.com/NixOS/nixpkgs/commit/0193ab23492dee3e9e6074d455f0774db657fd8c) | `python310Packages.hahomematic: 2022.10.0 -> 2022.10.1`                      |
| [`92e6db1b`](https://github.com/NixOS/nixpkgs/commit/92e6db1bb9e24109f35dbf5895613333f9a8a19e) | `ruff: 0.0.57 -> 0.0.60`                                                     |
| [`bcf071d5`](https://github.com/NixOS/nixpkgs/commit/bcf071d514f012ec8aa6dd6a8d64d1a21c2a9ec0) | `python310Packages.dbus-fast: 1.24.0 -> 1.29.1 (#194711)`                    |
| [`e47dc783`](https://github.com/NixOS/nixpkgs/commit/e47dc7832840d6a6874f0f27d3166c47733f7a2d) | `nodePackages.auto-changelog: init at 2.4.0`                                 |
| [`5e1fb1c3`](https://github.com/NixOS/nixpkgs/commit/5e1fb1c3ad2efb36a718b03dca2669b41909adc4) | `terraform-providers.utils: 1.2.0 → 1.3.0`                                   |
| [`6b95f05c`](https://github.com/NixOS/nixpkgs/commit/6b95f05c9b0c0584fb11d1c9987304aa9cc3a12b) | `terraform-providers.venafi: 0.16.0 → 0.16.1`                                |
| [`b085d3c9`](https://github.com/NixOS/nixpkgs/commit/b085d3c9ae317281c03325b946ac94f4b215beb5) | `terraform-providers.sumologic: 2.19.0 → 2.19.1`                             |
| [`216591bb`](https://github.com/NixOS/nixpkgs/commit/216591bb27cf3888e0808348923b9e784a5cfccb) | `terraform-providers.scaleway: 2.3.0 → 2.4.0`                                |
| [`3c1a417f`](https://github.com/NixOS/nixpkgs/commit/3c1a417f96c36e1d76ede003f2e01339ddc281d6) | `terraform-providers.ovh: 0.21.0 → 0.22.0`                                   |
| [`b3b22da4`](https://github.com/NixOS/nixpkgs/commit/b3b22da461b06f817794bee90dcec0806e2ad81e) | `terraform-providers.oci: 4.95.0 → 4.96.0`                                   |
| [`be19d7aa`](https://github.com/NixOS/nixpkgs/commit/be19d7aabbf97d074ea7d3958dc9230415b61116) | `terraform-providers.opentelekomcloud: 1.31.4 → 1.31.5`                      |
| [`399dd534`](https://github.com/NixOS/nixpkgs/commit/399dd53414dbbb4c229e399c3867030d1e6eeb2c) | `terraform-providers.opennebula: 1.0.0 → 1.0.1`                              |
| [`8773a78e`](https://github.com/NixOS/nixpkgs/commit/8773a78e6445f5ba05547be8f5abd9648563546d) | `terraform-providers.okta: 3.36.0 → 3.37.0`                                  |
| [`9278931a`](https://github.com/NixOS/nixpkgs/commit/9278931a657092b17905e43cb5dd329b5ef5fd90) | `terraform-providers.newrelic: 3.3.0 → 3.4.4`                                |
| [`0aabed02`](https://github.com/NixOS/nixpkgs/commit/0aabed0288edb5dfb32a824b31dbeac0bf7601ff) | `terraform-providers.ibm: 1.45.1 → 1.46.0`                                   |
| [`032faa64`](https://github.com/NixOS/nixpkgs/commit/032faa64dc50ed62151b09c9623ccf894a8868c3) | `terraform-providers.launchdarkly: 2.9.2 → 2.9.3`                            |
| [`52bfcf7d`](https://github.com/NixOS/nixpkgs/commit/52bfcf7d114213c68280421d66f548a1ef11beb2) | `terraform-providers.kafka-connect: 0.2.4 → 0.3.0`                           |
| [`ad910c92`](https://github.com/NixOS/nixpkgs/commit/ad910c927d26d422594cb4b878154f92f15f9767) | `terraform-providers.google-beta: 4.38.0 → 4.39.0`                           |
| [`2dcf03aa`](https://github.com/NixOS/nixpkgs/commit/2dcf03aaf056e2ef6668c400f1c67fe7bd3d68ac) | `terraform-providers.google: 4.38.0 → 4.39.0`                                |
| [`7050653c`](https://github.com/NixOS/nixpkgs/commit/7050653caaa29759be3f61b4658ea529b3159e4a) | `terraform-providers.fastly: 2.3.2 → 2.3.3`                                  |
| [`83aba4b6`](https://github.com/NixOS/nixpkgs/commit/83aba4b6458021593af155097ead0bb83d36fe0d) | `terraform-providers.elasticsearch: 2.0.4 → 2.0.5`                           |
| [`ecd5f45a`](https://github.com/NixOS/nixpkgs/commit/ecd5f45a566a4ca0569572648bd38f1d86f73dd4) | `terraform-providers.aws: 4.33.0 → 4.34.0`                                   |
| [`66294803`](https://github.com/NixOS/nixpkgs/commit/6629480308d1056245e8ef26deb456c78748b2fc) | `terraform-providers.dme: 1.0.5 → 1.0.6`                                     |
| [`5d51d8a5`](https://github.com/NixOS/nixpkgs/commit/5d51d8a5d10ed06f6803aba14e46aadd8740c139) | `terraform-providers.cloudflare: 3.24.0 → 3.25.0`                            |
| [`15b8cb25`](https://github.com/NixOS/nixpkgs/commit/15b8cb259e2e6d5abb0a80aa26e0fb88202ac907) | `terraform-providers.cloudamqp: 1.19.2 → 1.19.3`                             |
| [`7dd9f501`](https://github.com/NixOS/nixpkgs/commit/7dd9f5018c54024aee3b6f5a46a8015ff691635e) | `terraform-providers.bitbucket: 2.21.2 → 2.21.3`                             |
| [`1ef73994`](https://github.com/NixOS/nixpkgs/commit/1ef739942d42bcf8684cd711520f9b2504d9514f) | `terraform-providers.azurerm: 3.25.0 → 3.26.0`                               |
| [`086d7788`](https://github.com/NixOS/nixpkgs/commit/086d7788c09e22ecebbfa0ebaed17f27af8e8757) | `terraform-providers.akamai: 2.4.1 → 2.4.2`                                  |
| [`13525c09`](https://github.com/NixOS/nixpkgs/commit/13525c0955f727dd9cefb8a565cd89a456fbe113) | `pyupgrade: 2.38.1 -> 3.0.0`                                                 |
| [`416ecfee`](https://github.com/NixOS/nixpkgs/commit/416ecfeee846942e27765551bc82e65db16d2b68) | `python310Packages.sensor-state-data: 2.9.0 -> 2.9.1`                        |
| [`a3f854ae`](https://github.com/NixOS/nixpkgs/commit/a3f854aef368fb5c13fdf1477a546f93c20b683c) | `linux_mptcp,linux_mptcp_95: remove out-of-tree mptcp kernel`                |
| [`afaf39dd`](https://github.com/NixOS/nixpkgs/commit/afaf39ddc5024ce46a33fe6adf1f94bc1a8438f6) | `python310Packages.velbus-aio: 2022.10.2 -> 2022.10.3`                       |
| [`9769c4bd`](https://github.com/NixOS/nixpkgs/commit/9769c4bd2e2514befec4515b97815af14a42e10f) | `python310Packages.acquire: init at 3.2`                                     |
| [`73ed5118`](https://github.com/NixOS/nixpkgs/commit/73ed51181f9cbc06b6ab04e0238e9f9395454068) | `python310Packages.dissect: init at 3.3`                                     |
| [`74c11f39`](https://github.com/NixOS/nixpkgs/commit/74c11f391c2e3f958bd740b0632b4fb2816d356d) | `broot: 1.15.0 -> 1.16.0`                                                    |
| [`b549f5d1`](https://github.com/NixOS/nixpkgs/commit/b549f5d1d1787c808cd59d7c8018e4388b4ffbb6) | `python310Packages.dissect-esedb: 3.1 -> 3.2`                                |
| [`88585ff9`](https://github.com/NixOS/nixpkgs/commit/88585ff9a09fdd09db154cec971cac2616904f5e) | `python310Packages.dissect-hypervisor: 3.1 -> 3.2`                           |
| [`f9211529`](https://github.com/NixOS/nixpkgs/commit/f92115294813f37802d4c7c0844f57bf6488cf00) | `python310Packages.dissect-target: 3.1 -> 3.3`                               |
| [`df8017a8`](https://github.com/NixOS/nixpkgs/commit/df8017a8f58ae965f245ee1cdd83eb45616a7c15) | `python310Packages.dissect-target: init at 3.1`                              |
| [`ffcb18c2`](https://github.com/NixOS/nixpkgs/commit/ffcb18c2edc0024b479dd4972067553b49bf1d62) | `python310Packages.flow-record: init at 3.5`                                 |
| [`e899352e`](https://github.com/NixOS/nixpkgs/commit/e899352e76fa93d3acf69f2e305d6f8f320478f2) | `python310Packages.dissect-sql: init at 3.1`                                 |
| [`8dd36fad`](https://github.com/NixOS/nixpkgs/commit/8dd36fad3023a3db3ecae6b017b77beeccb0cab5) | `python310Packages.dissect-shellitem: init at 3.1`                           |
| [`113ee120`](https://github.com/NixOS/nixpkgs/commit/113ee1205f755ffa15591f8c26fc617bab4b0bd8) | `python310Packages.dissect-regf: init at 3.1`                                |
| [`62f245f1`](https://github.com/NixOS/nixpkgs/commit/62f245f18e47c1c9e244832588c3c07761d82b21) | `python310Packages.dissect-ole: init at 3.1`                                 |
| [`d061a07d`](https://github.com/NixOS/nixpkgs/commit/d061a07d427d58c8141a064dd0302937a2e12b42) | `python310Packages.dissect-hypervisor: init at 3.1`                          |
| [`f9e1399e`](https://github.com/NixOS/nixpkgs/commit/f9e1399e8d30814bec512362931e4881ed8197ce) | `python310Packages.dissect-esedb: init at 3.1`                               |
| [`6ff6cd4d`](https://github.com/NixOS/nixpkgs/commit/6ff6cd4dab1921506e89729c31cc7bf6f43baf92) | `python310Packages.dissect-ntfs: init at 3.1`                                |
| [`41173fb2`](https://github.com/NixOS/nixpkgs/commit/41173fb24d73742f80a49309468135ee946cc070) | `.github/workflows/update-terraform-providers.yml: set max-workers to 2`     |
| [`2d0a7da0`](https://github.com/NixOS/nixpkgs/commit/2d0a7da097131b9c0cbb80ea610d83052a0c734a) | `python310Packages.dissect-fat: init at 3.1`                                 |
| [`5862dabe`](https://github.com/NixOS/nixpkgs/commit/5862dabeedff399d925d1844a389376dcd60ce57) | `linuxPackages.nvidia_x11: mark firmware as not compressible`                |
| [`309ea5a1`](https://github.com/NixOS/nixpkgs/commit/309ea5a1af3b551eb991cfd93580c5f0bc893326) | `nixos/udev: allow marking firmware as not compressible`                     |
| [`5f847e50`](https://github.com/NixOS/nixpkgs/commit/5f847e50b8bd48d0495ed5053a466e452a63474b) | `pulumi-bin: 3.41.1 -> 3.42.0`                                               |
| [`2100fd29`](https://github.com/NixOS/nixpkgs/commit/2100fd293ad918b23b1df876df242bc7a930dbb6) | `svd2rust: 0.25.1 -> 0.26.0`                                                 |
| [`6fb37700`](https://github.com/NixOS/nixpkgs/commit/6fb37700bd0694ccfb9cbed150bd6695d3dc1013) | `python3Packages.sphinx-automodapi: enable tests`                            |
| [`67fb68dc`](https://github.com/NixOS/nixpkgs/commit/67fb68dc28e39c150f0f25a71bf02c3f0721c489) | `imgproxy: 3.7.2 -> 3.8.0`                                                   |
| [`3e2353ce`](https://github.com/NixOS/nixpkgs/commit/3e2353ce2e79dbbc3bd38afaec35614e14a8f57b) | `python310Packages.dissect-extfs: init at 3.1`                               |
| [`5917e6da`](https://github.com/NixOS/nixpkgs/commit/5917e6da8cd3eb0656411493a7a8baafea86e72b) | `grpc-client-cli: 1.14.0 -> 1.15.0`                                          |
| [`ef7c7149`](https://github.com/NixOS/nixpkgs/commit/ef7c7149be755162f1fd8b1645b8f0e24aa1f8c7) | `python310Packages.dissect-vmfs: init at 3.1`                                |
| [`64c0c52d`](https://github.com/NixOS/nixpkgs/commit/64c0c52df48ac133f4bcb9522b63789df2906ce2) | `goresym: 1.4 -> 1.5`                                                        |
| [`f02656d9`](https://github.com/NixOS/nixpkgs/commit/f02656d900b3a1815a0d07395612cd14c9769d1b) | `python310Packages.dissect-xfs: init at 3.1`                                 |
| [`c79d57a9`](https://github.com/NixOS/nixpkgs/commit/c79d57a94bffa2289f3cb1e7deba65b28374d1c0) | `python310Packages.dissect-ffs: init at 3.1`                                 |
| [`2b3e41fd`](https://github.com/NixOS/nixpkgs/commit/2b3e41fd03bac0638931e3c97ef92daa63191d4e) | `bemenu: 0.6.10 -> 0.6.11`                                                   |
| [`4b15d1a3`](https://github.com/NixOS/nixpkgs/commit/4b15d1a30c4c03adf4ee70db47e71212232c801e) | `gatekeeper: 3.9.0 -> 3.9.1`                                                 |
| [`0b49fc77`](https://github.com/NixOS/nixpkgs/commit/0b49fc77333cd4f69dc0e25a3b41caab2f08c892) | `python310Packages.dissect-eventlog: init at 3.1`                            |
| [`d4fecc38`](https://github.com/NixOS/nixpkgs/commit/d4fecc383e009bfc62ecfa17bbb7843ff623b19b) | `python310Packages.dissect-evidence: init at 3.1`                            |
| [`035c8381`](https://github.com/NixOS/nixpkgs/commit/035c8381664c8971e39dbc9b5f9b56f9aac50b2b) | `kubectl-images: init at 0.5.2`                                              |
| [`e50554a4`](https://github.com/NixOS/nixpkgs/commit/e50554a427c84c3cdb6a61170b00f2a50c06e1dc) | `Insync: mark broken (#193488)`                                              |
| [`49c0279c`](https://github.com/NixOS/nixpkgs/commit/49c0279c2d931d815f61489ea27b2c3190a309a8) | `anytype: 0.28.0 -> 0.29.0`                                                  |