### PR TITLE
chore(flake/darwin): `02d2551c` -> `ef56fd89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664210064,
-        "narHash": "sha256-df6nKVZe/yAhmJ9csirTPahc0dldwm3HBhCVNA6qWr0=",
+        "lastModified": 1665392861,
+        "narHash": "sha256-bCd8fYJMAb0LzabsiXl4nxECDoz483bJOCa2hjox7N0=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "02d2551c927b7d65ded1b3c7cd13da5cc7ae3fcf",
+        "rev": "ef56fd8979b5f4e800c4716f62076e00600b1172",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                    |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`d0121790`](https://github.com/LnL7/nix-darwin/commit/d0121790d4aac7a7b4b6bace63c26ef53e8c7e13) | `nix: fix mandatoryFeatures in nix.buildMachines` |