### PR TITLE
chore(flake/pre-commit-hooks): `2e4a7089` -> `11aff801`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1664708386,
-        "narHash": "sha256-aCD8UUGNYb5nYzRmtsq/0yP9gFOQQHr/Lsb5vW+mucw=",
+        "lastModified": 1665395272,
+        "narHash": "sha256-kkV5gfDJWMxKmYq3Y2pgvD7zH/I3WoW/0wr659Stj1Q=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "2e4a708918e14fdbd534cc94aaa9470cd19b2464",
+        "rev": "11aff801aa0ea1fb02ae43e61f7cdf610f5fe2e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message   |
| ------------------------------------------------------------------------------------------------------------ | ---------------- |
| [`a0bb790b`](https://github.com/cachix/pre-commit-hooks.nix/commit/a0bb790b261f7dd1d83b2ed5beaaaa69357b2618) | `Cabal2nix hook` |