### PR TITLE
chore(flake/nixpkgs): `c5924154` -> `34c5293a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665259268,
-        "narHash": "sha256-ONFhHBLv5nZKhwV/F2GOH16197PbvpyWhoO0AOyktkU=",
+        "lastModified": 1665349835,
+        "narHash": "sha256-UK4urM3iN80UXQ7EaOappDzcisYIuEURFRoGQ/yPkug=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5924154f000e6306030300592f4282949b2db6c",
+        "rev": "34c5293a71ffdb2fe054eb5288adc1882c1eb0b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                              |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`1c6a1eef`](https://github.com/NixOS/nixpkgs/commit/1c6a1eefe8188723f903ef218e368e706a188d1f) | `python3Packages.pymicrobot: 0.0.6 -> 0.0.8`                                |
| [`2fcfc5d0`](https://github.com/NixOS/nixpkgs/commit/2fcfc5d061a66ad68256836c6d17e7bd95b0c03e) | `josm: 18565 -> 18570`                                                      |
| [`4ad043f5`](https://github.com/NixOS/nixpkgs/commit/4ad043f5f19d4ed913cee4980947984a01be031d) | `home-assistant: 2022.10.1 -> 2022.10.2`                                    |
| [`6992b0d1`](https://github.com/NixOS/nixpkgs/commit/6992b0d15ec072518fdeb0e752b7aeea59667385) | `python3Packages.pyoverkiz: 1.5.4 -> 1.5.5`                                 |
| [`06c4dbb4`](https://github.com/NixOS/nixpkgs/commit/06c4dbb4cdcbd0ed7046dde3c655d228d6fe2fa5) | `python3Packages.pyhumps: Fix regression in symbols export`                 |
| [`6359a05f`](https://github.com/NixOS/nixpkgs/commit/6359a05f4d6e9116d361f775e708cbccdd479fdb) | `python310Packages.zigpy-znp: 0.9.0 -> 0.9.1`                               |
| [`a6e08695`](https://github.com/NixOS/nixpkgs/commit/a6e0869512a850e3d7e6ea296ed2a1184d63ec4c) | `python310Packages.zigpy-zigate: 0.10.0 -> 0.10.1`                          |
| [`3c86ff13`](https://github.com/NixOS/nixpkgs/commit/3c86ff131f97a7780fd7b44c1c668099c3e239e2) | `python310Packages.zigpy-xbee: 0.16.0 -> 0.16.1`                            |
| [`82f5c8d1`](https://github.com/NixOS/nixpkgs/commit/82f5c8d144c1083c88da125c1f611abab7bae240) | `python310Packages.zigpy: 0.51.2 -> 0.51.3`                                 |
| [`ffee5992`](https://github.com/NixOS/nixpkgs/commit/ffee5992374d3df89775f24f378a7f38af8d79cc) | `python310Packages.pydaikin: 2.7.0 -> 2.7.2`                                |
| [`070c93d1`](https://github.com/NixOS/nixpkgs/commit/070c93d16e81302430f33e7a9a9ac5d7955d4be8) | `sickgear: 0.25.40 -> 0.25.44`                                              |
| [`9ddb8eea`](https://github.com/NixOS/nixpkgs/commit/9ddb8eead167fc3d06d0bdd1c0e380a256995179) | `python310Packages.bellows: 0.34.1 -> 0.34.2`                               |
| [`627c1199`](https://github.com/NixOS/nixpkgs/commit/627c1199b5ea7d9788582420ed330db677785ea1) | `python310Packages.aiounifi: 37 -> 38`                                      |
| [`1a615dc4`](https://github.com/NixOS/nixpkgs/commit/1a615dc4ac20953d9f98e5e7101fe00bc71e9dae) | `process-viewer: set meta.mainProgram`                                      |
| [`987d2f57`](https://github.com/NixOS/nixpkgs/commit/987d2f575aff1da36d964a6e3fd3e4ba42445a76) | `nixos/seafile: avoid sleep in tests`                                       |
| [`2189b95e`](https://github.com/NixOS/nixpkgs/commit/2189b95ebf4ddeb7b0397df7de8719f998020d47) | `seahub: fix build`                                                         |
| [`6471cff5`](https://github.com/NixOS/nixpkgs/commit/6471cff5ddc7d85ee037f5ee8f0590325141a1db) | `exiv2: drop a test on darwin, really now`                                  |
| [`c0972c16`](https://github.com/NixOS/nixpkgs/commit/c0972c16dcbdce1b7505751e1ce537142071bb15) | `update-python-libraries: add missing dependency nix`                       |
| [`8f292e36`](https://github.com/NixOS/nixpkgs/commit/8f292e361367bddbdab3f6c89359041519f126e8) | `retroarch: mark as broken in macOS`                                        |
| [`fc75cc94`](https://github.com/NixOS/nixpkgs/commit/fc75cc94f4abea666d9b76a2c9dfdbef88d0c080) | `praat: 6.2.22 -> 6.2.23`                                                   |
| [`92437299`](https://github.com/NixOS/nixpkgs/commit/924372998beaa8f8964a15e925666871f25852dc) | `open-watcom-v2-unwrapped: opt-out of nixpkgs-update`                       |
| [`b31c4283`](https://github.com/NixOS/nixpkgs/commit/b31c42831f1b99544f81bc27f9da183d3276e9aa) | `conntrack-tools: 1.4.6 -> 1.4.7`                                           |
| [`329f5980`](https://github.com/NixOS/nixpkgs/commit/329f59805f466db154245f2ff4b6783e6b1aaf67) | `flyctl: 0.0.404 -> 0.0.406`                                                |
| [`74fc4924`](https://github.com/NixOS/nixpkgs/commit/74fc4924fb2d678ff4fdf49b38040e635ebee5c2) | `xmonadctl: use xmonad-contrib's src`                                       |
| [`4836d085`](https://github.com/NixOS/nixpkgs/commit/4836d085e453cb460afa16d26da9057f45513852) | `audacity: deprecate wxGTK31 and gtk2`                                      |
| [`aafc60e4`](https://github.com/NixOS/nixpkgs/commit/aafc60e4c2526e56e642768c6dc62617e17f7421) | `audacity: 3.1.3 -> 3.2.1`                                                  |
| [`17b9d619`](https://github.com/NixOS/nixpkgs/commit/17b9d61957bcd2bfb26d86f65121b63d955afaaf) | `mediathekview: 13.8.0 -> 13.9.1 (#194125)`                                 |
| [`ef72b5f8`](https://github.com/NixOS/nixpkgs/commit/ef72b5f86e3a5cbded3694b4a4e250e2d02dba4d) | `freefilesync: update license`                                              |
| [`ec947b13`](https://github.com/NixOS/nixpkgs/commit/ec947b13cd678b4a08f0289ccda6bba71ac025a0) | `gdal_2: drop`                                                              |
| [`df229a80`](https://github.com/NixOS/nixpkgs/commit/df229a80c24788fe7b66b1d39022d78652aa937e) | `libssh2: update license`                                                   |
| [`7eef7379`](https://github.com/NixOS/nixpkgs/commit/7eef7379fe3b5caae95083ebbdb81f9b3534d409) | `licenses: add libssh2 license`                                             |
| [`cc1dbce2`](https://github.com/NixOS/nixpkgs/commit/cc1dbce261847370fb8a787972a22693b233c72e) | `yaws: 2.0.6 -> 2.1.1`                                                      |
| [`daf5a09d`](https://github.com/NixOS/nixpkgs/commit/daf5a09d375c1a7b8d74742972aa45a287483c5b) | `gajim: 1.5.1 → 1.5.2`                                                      |
| [`9755cb84`](https://github.com/NixOS/nixpkgs/commit/9755cb848a9e33594d99567a1be948a15710aa9c) | `pythonPackages.nbxmpp: 3.2.2 → 3.2.4`                                      |
| [`0e211108`](https://github.com/NixOS/nixpkgs/commit/0e211108227518c4f841425145a822a76e0e05b0) | `ocamlPackages.caqti: 1.8.0 → 1.9.1`                                        |
| [`9927b2f2`](https://github.com/NixOS/nixpkgs/commit/9927b2f2c3da285077877e3d445336dc3472f72d) | `exiv2: drop a test on darwin`                                              |
| [`4fd75277`](https://github.com/NixOS/nixpkgs/commit/4fd75277dd383abfa0d8719306b1fbe18c024366) | `nixos/coturn: refactor secret injection`                                   |
| [`17c43ab2`](https://github.com/NixOS/nixpkgs/commit/17c43ab2c8ab39c4de7cc65943a01a589caf0cd5) | `colima: 0.4.5 -> 0.4.6`                                                    |
| [`fae653de`](https://github.com/NixOS/nixpkgs/commit/fae653deb4af085526163467e73f2d26b2220b52) | `nixos/gitlab: Configure ActionCable`                                       |
| [`9b3ff51c`](https://github.com/NixOS/nixpkgs/commit/9b3ff51c777d51f3aa0f23e3a6c956504ccd2f7e) | `nixos/gitlab: Set a more appropriate type for extraConfig`                 |
| [`58158100`](https://github.com/NixOS/nixpkgs/commit/58158100f766214a9493ca32afc6e8bfc6c8b10e) | `nixos/gitlab: Make sure docker-registry starts after cert generation`      |
| [`8e8253dd`](https://github.com/NixOS/nixpkgs/commit/8e8253ddb4b5b0488e476a1a1c50b340990bd516) | `nixos/gitlab: Create registry state path`                                  |
| [`3dedfb3f`](https://github.com/NixOS/nixpkgs/commit/3dedfb3fa03c5a4eda64bdb1dfd9a39fa587bc8a) | `nixos/gitlab: Connect to redis through a unix socket by default`           |
| [`843082eb`](https://github.com/NixOS/nixpkgs/commit/843082eb3af6a453b3aeb6c3c6724e508aa44478) | `nixos/gitlab: Add findutils to runtime dependencies`                       |
| [`bee6e1da`](https://github.com/NixOS/nixpkgs/commit/bee6e1dafa55df37ac4a6199cd8b0c00ac73ed07) | `nixos/gitlab: Deduplicate runtime dependency listing`                      |
| [`0211edd1`](https://github.com/NixOS/nixpkgs/commit/0211edd1ff005575c5b2061f25d73fccb6271252) | `nixos/gitlab: Add workhorse.config option`                                 |
| [`4df4d2a8`](https://github.com/NixOS/nixpkgs/commit/4df4d2a8eac999e47f973911857b9756281f8273) | `genJqSecretsReplacementSnippet: Allow dots in attribute names...`          |
| [`de25676c`](https://github.com/NixOS/nixpkgs/commit/de25676c9f0954c9fdbb703cdb9326af9301ad50) | `promtail: move alongside grafana-loki`                                     |
| [`bd97c7ab`](https://github.com/NixOS/nixpkgs/commit/bd97c7ab87994a268a3096af14c53a16efdd8eea) | `terraform-providers.mongodbatlas: drop workaround`                         |
| [`b4d431bb`](https://github.com/NixOS/nixpkgs/commit/b4d431bbd2e9ee953a95fc0ddde8b80edcb0dc12) | `terraform-providers.baiducloud: drop workaround`                           |
| [`0e9f1a02`](https://github.com/NixOS/nixpkgs/commit/0e9f1a027c9a7d4c66ab2dbc353c0c2dd1820ceb) | `terraform-providers.alicloud: drop workaround`                             |
| [`5ba91d79`](https://github.com/NixOS/nixpkgs/commit/5ba91d79fef463f17551b9fd28e00ec43a5e2f40) | `werf: switch to go 1.19`                                                   |
| [`c2db0129`](https://github.com/NixOS/nixpkgs/commit/c2db012912c80d284e0e0d2fc6a3530681e00834) | `wails: switch to go 1.19`                                                  |
| [`7a4a8bae`](https://github.com/NixOS/nixpkgs/commit/7a4a8baee52a4a277b10052a6c4261a335d3ef10) | `trivy: switch to go 1.19`                                                  |
| [`a03716e5`](https://github.com/NixOS/nixpkgs/commit/a03716e5476397c7dfe005c5bf143360f1a089c5) | `telegraf: switch to go 1.19`                                               |
| [`1e1e7dea`](https://github.com/NixOS/nixpkgs/commit/1e1e7dea1d006b4ac048724148dc9b44aff6d420) | `opentelemetry-collector-contrib: switch to go 1.19`                        |
| [`3f2a8cbb`](https://github.com/NixOS/nixpkgs/commit/3f2a8cbb98fd3e623a6adea62eeccf17209edf5b) | `argocd-autopilot: switch to go 1.19`                                       |
| [`ea57902e`](https://github.com/NixOS/nixpkgs/commit/ea57902e29a41bcbb6dcab1d18f9aa5df13b5d86) | `gotop: switch to go 1.19`                                                  |
| [`27407ada`](https://github.com/NixOS/nixpkgs/commit/27407adae9d602581737f1848c17b647f79f4edb) | `hysteria: switch to go 1.19`                                               |
| [`9e044493`](https://github.com/NixOS/nixpkgs/commit/9e0444931cd465b9776e5edd95415a8b02896b26) | `mangal: switch to go 1.19`                                                 |
| [`8b4a4570`](https://github.com/NixOS/nixpkgs/commit/8b4a4570abc8b3a64d32c33dee8220dfc3924717) | `hugo: switch to go 1.19`                                                   |
| [`165e181f`](https://github.com/NixOS/nixpkgs/commit/165e181f5d83d9f506a4e49677c53bab50f048f8) | `erigon: switch to go 1.19`                                                 |
| [`2f814ff7`](https://github.com/NixOS/nixpkgs/commit/2f814ff713272093bfa220aa3b5fdafc504a6809) | `terraform-providers: switch to go 1.19`                                    |
| [`e1e561d0`](https://github.com/NixOS/nixpkgs/commit/e1e561d0d16a6cf15683bbd3e1326d52de48547f) | `bacon: 2.2.3 -> 2.2.5`                                                     |
| [`e848fcc2`](https://github.com/NixOS/nixpkgs/commit/e848fcc292596b63a419405471d4aff0630ac039) | `cargo-zigbuild: 0.12.3 -> 0.13.0`                                          |
| [`00e90def`](https://github.com/NixOS/nixpkgs/commit/00e90defe5f98f36d7dc5110c2ac9c21d6661594) | `flexget: 3.3.31 -> 3.3.32`                                                 |
| [`a5c7d3b0`](https://github.com/NixOS/nixpkgs/commit/a5c7d3b021fe2d1df9118a338577d33a525d32b1) | `genact: 1.1.1 -> 1.2.0`                                                    |
| [`441788b7`](https://github.com/NixOS/nixpkgs/commit/441788b712ec18c3dfc1995543b10ded9250b570) | `vimPlugins.flit-nvim: init at 2022-09-23`                                  |
| [`da7676ec`](https://github.com/NixOS/nixpkgs/commit/da7676ecd6949cce6031be5db9e43960f7c186c3) | `vimPlugins.leap-ast-nvim: init at 2022-08-02`                              |
| [`342dd0bf`](https://github.com/NixOS/nixpkgs/commit/342dd0bf48a50b8f90993934d811b8a1f4bba0a6) | `vimPlugins.leap-nvim: init at 2022-10-01`                                  |
| [`804fb8e1`](https://github.com/NixOS/nixpkgs/commit/804fb8e11b221e9a16fa82aa160b6be0f7db8604) | `vimPlugins.dial-nvim: init at 2022-08-29`                                  |
| [`232f8d1e`](https://github.com/NixOS/nixpkgs/commit/232f8d1ea0ca8234822de3e18e47de91d626661b) | `vimPlugins.live-command-nvim: init at 2022-10-06`                          |
| [`d1a8b129`](https://github.com/NixOS/nixpkgs/commit/d1a8b12916d4aa4d741d147198c60f026a414a03) | `vimPlugins: update`                                                        |
| [`8bf050c4`](https://github.com/NixOS/nixpkgs/commit/8bf050c4956c1ce222ae2f38e0c57d66d4334aaf) | `ruff: 0.0.61 -> 0.0.63`                                                    |
| [`64fb9479`](https://github.com/NixOS/nixpkgs/commit/64fb94794f70a0e05319a05fc8931e8fdd01b934) | `dnstwist: 20220815 -> 20221008`                                            |
| [`6a62a6e8`](https://github.com/NixOS/nixpkgs/commit/6a62a6e8e4dfc027c143f2f365d2093a49c56a38) | `gvproxy: pin to go 1.18`                                                   |
| [`fdbb7e87`](https://github.com/NixOS/nixpkgs/commit/fdbb7e87aee736d6474500a34e6d72237b966acc) | `gojq: remove unnecessary proxyVendor`                                      |
| [`9731c061`](https://github.com/NixOS/nixpkgs/commit/9731c06199112275ca35a9abdb592df0a382d75f) | `apprise: 1.0.0 -> 1.1.0`                                                   |
| [`990828dc`](https://github.com/NixOS/nixpkgs/commit/990828dcfdbf76b36edb4c7df921a3bdf0c291e7) | `p4c: correct native/buildInputs mistake`                                   |
| [`1af64ac2`](https://github.com/NixOS/nixpkgs/commit/1af64ac23eafaaa01de42b0d6772470bb5c9bdc2) | `cargo-edit: 0.11.4 -> 0.11.5`                                              |
| [`72a72547`](https://github.com/NixOS/nixpkgs/commit/72a72547566813fd019c1c6b72f2de9f6622a77f) | `snazy: install shell completions, add figsoda as a maintainer`             |
| [`61309fba`](https://github.com/NixOS/nixpkgs/commit/61309fba90d7a9e989b800878d6f254468456545) | `oxker: init at 0.1.5`                                                      |
| [`f97ac9e8`](https://github.com/NixOS/nixpkgs/commit/f97ac9e87cdb39385b17c8c27a082a120b43f914) | `ruff: 0.0.60 -> 0.0.61`                                                    |
| [`23075ec2`](https://github.com/NixOS/nixpkgs/commit/23075ec21a926c2759a3dfe002551c34c9680b49) | `python310Packages.types-tabulate: 0.8.11 -> 0.9.0.0`                       |
| [`47fc6c2f`](https://github.com/NixOS/nixpkgs/commit/47fc6c2f82635fa0bff36bb7fed0e2c5ba086b1e) | `python310Packages.types-requests: 2.28.11.1 -> 2.28.11.2`                  |
| [`7e959388`](https://github.com/NixOS/nixpkgs/commit/7e959388cddd24a46cbeff8e62214bb79248e76a) | `pcem: migrate to wxGTK32`                                                  |
| [`968f9d2d`](https://github.com/NixOS/nixpkgs/commit/968f9d2d767713f7bc3faeceba07d982b6a7fbd7) | `hedgedoc: fix package name in update script help text`                     |
| [`327a4e1c`](https://github.com/NixOS/nixpkgs/commit/327a4e1ce0d570f219e2b4cedf03f16fac099416) | `keytar: fix package name in update script help text`                       |
| [`ae28acab`](https://github.com/NixOS/nixpkgs/commit/ae28acabb0884a1f46b4b741a8f51e303b75042d) | `webengine: fix github crashes with upstream patch`                         |
| [`c6c52c52`](https://github.com/NixOS/nixpkgs/commit/c6c52c521f50457e48f3e6c0f8b0b1b65a72da51) | `qutebrowser: init qt6 variant`                                             |
| [`0875c04f`](https://github.com/NixOS/nixpkgs/commit/0875c04f15e4d197d770ce690d7ba4e26b7db8ba) | `cosmopolitan: 2.1 -> 2.1.1`                                                |
| [`801580d9`](https://github.com/NixOS/nixpkgs/commit/801580d934a427927347c027701fc074c7adff5e) | `python310Packages.sumo: 2.3.4 -> 2.3.5`                                    |
| [`4a4300ea`](https://github.com/NixOS/nixpkgs/commit/4a4300eae49622868868999f773b72d3e4598d59) | `wxhexeditor: add darwin support`                                           |
| [`b206c7d0`](https://github.com/NixOS/nixpkgs/commit/b206c7d019517276f22761b515509382d139499b) | `bitcoin-abc: 0.21.13 -> 0.26.2`                                            |
| [`e27e1885`](https://github.com/NixOS/nixpkgs/commit/e27e1885c5065088b62620648e7ba47db759af61) | `python310Packages.sqlmap: 1.6.9 -> 1.6.10`                                 |
| [`7d943230`](https://github.com/NixOS/nixpkgs/commit/7d94323083a759d2fe84eb9aadd491b6a6516d84) | `aegisub: migrate to wxGTK32`                                               |
| [`679cd346`](https://github.com/NixOS/nixpkgs/commit/679cd3462fab51ba0534532d5a28b96659cc8b63) | `sget: init at unstable-2022-10-04`                                         |
| [`c856e2c3`](https://github.com/NixOS/nixpkgs/commit/c856e2c30601caa5eca85d8b591af16c04191eeb) | `duckstation: unstable-2022-08-22 -> unstable-2022-07-08`                   |
| [`d21043c4`](https://github.com/NixOS/nixpkgs/commit/d21043c4659a2f8e09783860471fdab35ed7f067) | `exploitdb: 2022-09-24 -> 2022-10-07`                                       |
| [`2733d9b3`](https://github.com/NixOS/nixpkgs/commit/2733d9b328f107f66c250672960bf6b577cc5b2e) | `nuclei: 2.7.7 -> 2.7.8`                                                    |
| [`10843480`](https://github.com/NixOS/nixpkgs/commit/108434803ac0e482a7a333e2cbf4ba494bd9e038) | `maintainers: add siph`                                                     |
| [`b5460566`](https://github.com/NixOS/nixpkgs/commit/b54605669c24511d48dd52681b621b0c7f707abf) | `minikube: 1.27.0 -> 1.27.1`                                                |
| [`a369a550`](https://github.com/NixOS/nixpkgs/commit/a369a5502b762908be3bfc399ffcfd4b8a2177e4) | `python310Packages.pytrafikverket: 0.2.0.1 -> 0.2.1`                        |
| [`c1af7320`](https://github.com/NixOS/nixpkgs/commit/c1af7320e6c10ce22bbda1bf626112b59b3a48e9) | `vdpauinfo: 1.3 -> 1.5`                                                     |
| [`b110b996`](https://github.com/NixOS/nixpkgs/commit/b110b99666514cc62fcc878d5af74b7c5c789447) | `qogir-icon-theme: 2022-07-20 -> 2022-10-08`                                |
| [`5ec24ce0`](https://github.com/NixOS/nixpkgs/commit/5ec24ce090a82ee341cbdca458aec72f0f0f4a5a) | `janusgraph: init at 0.6.2`                                                 |
| [`2c5c2399`](https://github.com/NixOS/nixpkgs/commit/2c5c239958bc9f9e7fda9f37c3515586f793f7b9) | `apache-directory-server: init at 2.0.0.AM26`                               |
| [`9766d612`](https://github.com/NixOS/nixpkgs/commit/9766d6127ab52253174ff5989d6054745ba1b7bf) | `maintainers: add ners`                                                     |
| [`ac8ffafa`](https://github.com/NixOS/nixpkgs/commit/ac8ffafa401fd353911d45d26f35e5b708ed4be0) | `adcli: cleanup`                                                            |
| [`1b6aa43a`](https://github.com/NixOS/nixpkgs/commit/1b6aa43a6a9b4f61adc6a3f8b357a306c3c7f918) | `adcli: add anthonyroussel to maintainers`                                  |
| [`6a094475`](https://github.com/NixOS/nixpkgs/commit/6a09447568d2100f660b8f337ef3cf7f6218a26e) | `adcli: 0.9.1 -> 0.9.2`                                                     |
| [`cacae901`](https://github.com/NixOS/nixpkgs/commit/cacae901e4e73552328cb47df1cfc7eeeb4ca0bb) | `1password-gui: add macOS builds and unify beta`                            |
| [`0fbaf1ae`](https://github.com/NixOS/nixpkgs/commit/0fbaf1aeeebb564a3dfc4201c42b1db36a653024) | ``mkvtoolnix-gui: set `meta.mainProgram```                                  |
| [`4c749f11`](https://github.com/NixOS/nixpkgs/commit/4c749f11c9b29b74c020cc7a4f7751edb592e017) | `wordpressPackages: add static-mail-sender-configurator`                    |
| [`e35e3836`](https://github.com/NixOS/nixpkgs/commit/e35e3836c5a935c6a14e810c2ec97df5986d76b8) | `thunderbird-bin: 102.3.1 -> 102.3.2`                                       |
| [`d25c4975`](https://github.com/NixOS/nixpkgs/commit/d25c4975cf1ef5666d8b7e74d6631fa93d9c4f1b) | `thunderbird: 102.3.1 -> 102.3.2`                                           |
| [`55cbc2ad`](https://github.com/NixOS/nixpkgs/commit/55cbc2addbc9b58813a36b3cbfa8a1fe9700aa39) | `galene: 0.5.5 -> 0.6.1`                                                    |
| [`9fa29b92`](https://github.com/NixOS/nixpkgs/commit/9fa29b92f76bffc83aaa2cba306015b378c0bd01) | `victoriametrics: 1.81.2 -> 1.82.0`                                         |
| [`93ae4413`](https://github.com/NixOS/nixpkgs/commit/93ae441356f212016b9172be96f02597ef135da1) | `tektoncd-cli: 0.24.0 -> 0.24.1`                                            |
| [`4da3e6d5`](https://github.com/NixOS/nixpkgs/commit/4da3e6d548576a6fdeca5aa18795fc57ae3729be) | `snazy: 0.10.1 -> 0.50.0`                                                   |
| [`fb18ec0a`](https://github.com/NixOS/nixpkgs/commit/fb18ec0af6cacacc13d5c2e2c9a0df3d6aabe7e8) | `python310Packages.home-assistant-bluetooth: 1.4.0 -> 1.5.1`                |
| [`0fac4b58`](https://github.com/NixOS/nixpkgs/commit/0fac4b58c495a7896ebf4419e5ea2ffc43f5ba4b) | `leftwm: 0.3.0 -> 0.4.0`                                                    |
| [`8c128f80`](https://github.com/NixOS/nixpkgs/commit/8c128f803e95a46450b7b23baa0cf012fbf1e673) | `kubent: 0.5.1 -> 0.6.0`                                                    |
| [`1bf1b018`](https://github.com/NixOS/nixpkgs/commit/1bf1b018c6bb2c19d1af9a417f3d407cfd858667) | `jaq: 0.8.1 -> 0.8.2`                                                       |
| [`ae830d54`](https://github.com/NixOS/nixpkgs/commit/ae830d5410dd3b7011e6b3bf63fb080cc27a7d94) | `init: pyqt6-webengine at 6.4.0`                                            |
| [`8b091f7c`](https://github.com/NixOS/nixpkgs/commit/8b091f7c247a5057d3f31aaf07759021d1782a16) | `python-modules/pyqt-builder: 1.13.0 -> 1.14.0`                             |
| [`9ab91690`](https://github.com/NixOS/nixpkgs/commit/9ab916905a5cd0bb4f47ada93f81b587d1fc8565) | `python-modules/sip: 6.6.2 -> 6.7.1`                                        |
| [`902b9559`](https://github.com/NixOS/nixpkgs/commit/902b95598efbc7d2f4d4624eeab81a9e3b1e8964) | `cli11: 2.2.0 -> 2.3.0`                                                     |
| [`dfe88a09`](https://github.com/NixOS/nixpkgs/commit/dfe88a09d1929f43fa296d113b9cc2ae93a0e744) | `rust-motd: modernize`                                                      |
| [`f598f311`](https://github.com/NixOS/nixpkgs/commit/f598f3117947b3b0922626444b63ab03bdbe4a24) | `surf-display: unstable-2019-04-15 -> unstable-2022-10-07`                  |
| [`6b8eee90`](https://github.com/NixOS/nixpkgs/commit/6b8eee90f0ca521ab1fedc48c24d81bd1c43155c) | `vtm: 0.8.0 -> 0.9.2`                                                       |
| [`7be27f52`](https://github.com/NixOS/nixpkgs/commit/7be27f5247ef866bf7fc33fbbb29f57bc796d2db) | `libretro.beetle-supafaust: init at unstable-2022-10-01`                    |
| [`3d66e783`](https://github.com/NixOS/nixpkgs/commit/3d66e783dbf496ac7080155baf7e36a4d0fde66e) | `rust-motd: 0.2.1 -> 1.0.0`                                                 |
| [`3a690e98`](https://github.com/NixOS/nixpkgs/commit/3a690e9833067561943a0016ce40406b8b5fc16f) | `libressl: 3.5.3 -> 3.6.0`                                                  |
| [`2e466755`](https://github.com/NixOS/nixpkgs/commit/2e4667552573d58485627936ea1cd902b5776c10) | `librist: init at v0.2.7`                                                   |
| [`15914eba`](https://github.com/NixOS/nixpkgs/commit/15914eba855c306a397595b83810d9894c34f41b) | `nixos/privacyidea: fix manual build`                                       |
| [`1c7728df`](https://github.com/NixOS/nixpkgs/commit/1c7728df2a46a783023779187f6573ca9a90ad9b) | `privacyidea: fix build`                                                    |
| [`ecaf6aed`](https://github.com/NixOS/nixpkgs/commit/ecaf6aed02da7cc72721567fe85387e4bdd9948d) | ``nixos/privacyidea: add proper support for `privacyidea-token-janitor```   |
| [`30b0c8fe`](https://github.com/NixOS/nixpkgs/commit/30b0c8fec939fd648be77aed5f155e4e5fbb0039) | `pcb: use xorg.* packages directly instead of xlibsWrapper`                 |
| [`a94ea348`](https://github.com/NixOS/nixpkgs/commit/a94ea3486da532f88e87e698b2f0e6b87aea321e) | `languagetool: 5.8 -> 5.9`                                                  |
| [`087eb0a0`](https://github.com/NixOS/nixpkgs/commit/087eb0a0aa6d325330bee2227ce2aacbc2f6ce59) | `python310Packages.datasets: 2.5.1 -> 2.5.2`                                |
| [`3ad46d4b`](https://github.com/NixOS/nixpkgs/commit/3ad46d4bda267a0e16cb27e73efb9370b55eb23b) | `ferium: 4.1.11 -> 4.2.0`                                                   |
| [`2830aa02`](https://github.com/NixOS/nixpkgs/commit/2830aa0212ddc42181d55757711b1f1f243e77ed) | `cfssl: 1.6.2 -> 1.6.3`                                                     |
| [`0d3a23d2`](https://github.com/NixOS/nixpkgs/commit/0d3a23d218e69f830d48457ad489ebce391fa5d8) | `python310Packages.timetagger: 22.6.6 -> 22.9.3`                            |
| [`1374dc16`](https://github.com/NixOS/nixpkgs/commit/1374dc16e87cb4a7b8572b02f11ecd5420f05703) | `python310Packages.sphinx-argparse: 0.3.1 -> 0.3.2`                         |
| [`10c02745`](https://github.com/NixOS/nixpkgs/commit/10c02745ab7f9d324107ecfd557905677fd04322) | `scheme-bytestructures: add make flags and tests`                           |
| [`826fd759`](https://github.com/NixOS/nixpkgs/commit/826fd7598402596f27548877f5689d2e83a5c783) | `guile-git: add make flags and tests`                                       |
| [`d4cf2b81`](https://github.com/NixOS/nixpkgs/commit/d4cf2b811e3c4af5a44803d7a6ca3b5192f4c073) | `guile-json: add make flags and tests`                                      |
| [`49e9431c`](https://github.com/NixOS/nixpkgs/commit/49e9431c2af188836ba25b8127e281bdc06313b2) | `guile-gcrypt: add make flags and tests`                                    |
| [`fb9afbf0`](https://github.com/NixOS/nixpkgs/commit/fb9afbf070543919c44f262e782547e8f51ae94e) | `python310Packages.potentials: 0.3.4 -> 0.3.5`                              |
| [`da857912`](https://github.com/NixOS/nixpkgs/commit/da8579121945d7f6ce2d7cb816837cc52000a3b3) | `ihp-new: init at 0.20.0`                                                   |
| [`f1243822`](https://github.com/NixOS/nixpkgs/commit/f12438228599942236dcc12e8eec069b315a4f7c) | `wabt: 1.0.29 -> 1.0.30`                                                    |
| [`9b22789d`](https://github.com/NixOS/nixpkgs/commit/9b22789d628f93d813defd93a28bed45518e4bbc) | `argo: 3.3.9 -> 3.4.1`                                                      |
| [`b752a370`](https://github.com/NixOS/nixpkgs/commit/b752a370b1f5911cd6f85fd4c501840c4d17082d) | `synapse-admin: fix build after 7753a94a354`                                |
| [`53256fcd`](https://github.com/NixOS/nixpkgs/commit/53256fcdb5a0dfb6e3c27eb7d73bf2527342a625) | `openjfx17: use ffmpeg_4`                                                   |
| [`99dc9b9c`](https://github.com/NixOS/nixpkgs/commit/99dc9b9c164af3bc6c08ff4a4db4c2b58e368160) | `nixos/endlessh-go: init module`                                            |
| [`3a3d66f9`](https://github.com/NixOS/nixpkgs/commit/3a3d66f9ff213024a720a72b3639bd62ec63a52a) | `python310Packages.devito: fix darwin build`                                |
| [`1e7fbc02`](https://github.com/NixOS/nixpkgs/commit/1e7fbc02b1dd183f841761143dc42f4d64804341) | `prowlarr: 0.4.5.1960 -> 0.4.6.1969`                                        |
| [`0cfbf813`](https://github.com/NixOS/nixpkgs/commit/0cfbf8139d96c05e1a217bbfef3c9941d6e2d7e4) | `polkadot: 0.9.28 -> 0.9.29`                                                |
| [`b1a1cb51`](https://github.com/NixOS/nixpkgs/commit/b1a1cb51eaca023fb664f090e2de45e80908ed5e) | `moodle: 4.0.2 -> 4.0.4`                                                    |
| [`8a9ffb1b`](https://github.com/NixOS/nixpkgs/commit/8a9ffb1b0bb94a31760b2443a08f8c0baa08c63f) | `nixosTests.paperless: check if /metadata/ can be accessed`                 |
| [`95df3315`](https://github.com/NixOS/nixpkgs/commit/95df3315f2c0c91b29690db23131766a92994e14) | `mpvScripts.mpv-playlistmanager: unstable-2021-09-27 → unstable-2022-08-26` |