### PR TITLE
chore(flake/nixpkgs): `34c5293a` -> `ba187fbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665349835,
-        "narHash": "sha256-UK4urM3iN80UXQ7EaOappDzcisYIuEURFRoGQ/yPkug=",
+        "lastModified": 1665643254,
+        "narHash": "sha256-IBVWNJxGCsshwh62eRfR6+ry3bSXmulB3VQRzLQo3hk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "34c5293a71ffdb2fe054eb5288adc1882c1eb0b1",
+        "rev": "ba187fbdc5e35322c7dff556ef2c47bddfd6e8d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                    |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`d6185309`](https://github.com/NixOS/nixpkgs/commit/d618530963a0e1d112c2584e2fc1ae9743cf7b08) | `ocamlPackages.ocamlbuild: 0.14.1 → 0.14.2`                                       |
| [`ed50e176`](https://github.com/NixOS/nixpkgs/commit/ed50e17618a0b28196401a3f9d7f707df93b88b8) | `ocamlPackages.lablgtk_2_14: remove at 2.14.0 (broken)`                           |
| [`0671df7f`](https://github.com/NixOS/nixpkgs/commit/0671df7f0299648e5a08b718077ef6406a8cc70b) | `ocamlPackages.uuidm: disable for OCaml < 4.08`                                   |
| [`e1858385`](https://github.com/NixOS/nixpkgs/commit/e1858385ec9730c0120dae4bce1fade16ecdb4ca) | `python310Packages.google-cloud-firestore: 2.7.1 -> 2.7.2`                        |
| [`1f50d35a`](https://github.com/NixOS/nixpkgs/commit/1f50d35aae248ee9ff8bbdf5b499892a16d30362) | `python310Packages.google-cloud-websecurityscanner: 1.9.1 -> 1.9.2`               |
| [`d673432b`](https://github.com/NixOS/nixpkgs/commit/d673432b224558f837382dc32b665f01690be96c) | `python310Packages.google-cloud-iam-logging: 1.0.5 -> 1.0.6`                      |
| [`ea8940ac`](https://github.com/NixOS/nixpkgs/commit/ea8940acebcebde2eae1b13fb369e8823065f370) | `python310Packages.google-cloud-error-reporting: 1.6.2 -> 1.6.3`                  |
| [`b51a278e`](https://github.com/NixOS/nixpkgs/commit/b51a278e7676bc0670534f6bcacdbad78688be07) | `python310Packages.google-cloud-dlp: 3.9.1 -> 3.9.2`                              |
| [`a2f2949c`](https://github.com/NixOS/nixpkgs/commit/a2f2949cdb37e2cf13df4f8249078baa0085dfaf) | `python310Packages.fastapi-mail: 1.1.5 -> 1.2.0`                                  |
| [`cfea568d`](https://github.com/NixOS/nixpkgs/commit/cfea568da97a2668ef3cb3fc42eaacfb0e706807) | `terraform-providers.tencentcloud: 1.78.3 → 1.78.4`                               |
| [`f003f0a6`](https://github.com/NixOS/nixpkgs/commit/f003f0a63bceef55afe75c51d6b5a3876bc304c0) | `terraform-providers.spotinst: 1.84.0 → 1.85.0`                                   |
| [`40dcf2f9`](https://github.com/NixOS/nixpkgs/commit/40dcf2f95b77ab4f54557d6a4e3e26d1823d16b3) | `terraform-providers.helm: 2.7.0 → 2.7.1`                                         |
| [`6dc602a4`](https://github.com/NixOS/nixpkgs/commit/6dc602a4a0d9c8b56291637fd494f2165bdf9701) | `terraform-providers.github: 5.3.0 → 5.4.0`                                       |
| [`8cd5129b`](https://github.com/NixOS/nixpkgs/commit/8cd5129b1a0a5f34dba5d40f5af627a54fb6361b) | `python310Packages.dropbox: 11.34.0 -> 11.35.0`                                   |
| [`82da2bfa`](https://github.com/NixOS/nixpkgs/commit/82da2bfa8eee921b92c30a6753c4496494f6d84c) | `prometheus-kea-exporter: 0.4.4 -> 0.5.0`                                         |
| [`e20908d8`](https://github.com/NixOS/nixpkgs/commit/e20908d82c48d20d1eb96df38ca29d57163ad5bb) | `python310Packages.desktop-notifier: 3.4.0 -> 3.4.1`                              |
| [`13062ca2`](https://github.com/NixOS/nixpkgs/commit/13062ca2d5e11486a9226c71738a808cdf104599) | `python310Packages.hahomematic: 2022.10.4 -> 2022.10.5`                           |
| [`05c08b3f`](https://github.com/NixOS/nixpkgs/commit/05c08b3fc31798a54a1d7ed24dfa89bf19c50b8f) | `python310Packages.yalexs: 1.2.4 -> 1.2.6`                                        |
| [`eff6add8`](https://github.com/NixOS/nixpkgs/commit/eff6add801c59f67cbce6988d8dc1ce072d4200a) | `python310Packages.blebox-uniapi: disable on older Python releases`               |
| [`2601e8bf`](https://github.com/NixOS/nixpkgs/commit/2601e8bf883a1570c39132325c53efb2b9eb2c4a) | `python310Packages.click-option-group: 0.5.3 -> 0.5.5`                            |
| [`d73c7ed6`](https://github.com/NixOS/nixpkgs/commit/d73c7ed622be830fbbb9376ae392f4c1df94497a) | `python310Packages.losant-rest: 1.16.5 -> 1.16.6`                                 |
| [`7a04eea2`](https://github.com/NixOS/nixpkgs/commit/7a04eea25017b182d65f2f8e0eca6e535355a178) | `python310Packages.blebox-uniapi: 2.1.0 -> 2.1.1`                                 |
| [`4ddefe30`](https://github.com/NixOS/nixpkgs/commit/4ddefe300357a5efe23b49d9b9cc4840f2410933) | `python310Packages.peaqevcore: 6.0.3 -> 7.0.8`                                    |
| [`b6bee1b2`](https://github.com/NixOS/nixpkgs/commit/b6bee1b2a0e9eb96072543fe1b989b6eee19d0d5) | `python310Packages.azure-storage-file-share: 12.9.0 -> 12.10.0`                   |
| [`e50c0576`](https://github.com/NixOS/nixpkgs/commit/e50c0576a0595aea7536d0197127ac9249171346) | `python310Packages.neo4j: 5.0.1 -> 5.1.0`                                         |
| [`67c319b7`](https://github.com/NixOS/nixpkgs/commit/67c319b77b90895f5e253c3179c045cf5a7426ff) | `prometheus-kea-exporter: 0.4.2 -> 0.4.4`                                         |
| [`11533d50`](https://github.com/NixOS/nixpkgs/commit/11533d5056089aecb8d0ad25187969d069b47642) | `python310Packages.angr: 9.2.21 -> 9.2.22`                                        |
| [`47a13c0e`](https://github.com/NixOS/nixpkgs/commit/47a13c0e7492c47e953b01275569c5bff0e09dcd) | `python310Packages.cle: 9.2.21 -> 9.2.22`                                         |
| [`6b295a6d`](https://github.com/NixOS/nixpkgs/commit/6b295a6dbfbc2219371d0a7669d5fb1681f63a67) | `python310Packages.claripy: 9.2.21 -> 9.2.22`                                     |
| [`370cf209`](https://github.com/NixOS/nixpkgs/commit/370cf20988bb4b388629f3a38dd74a750a66b6c6) | `python310Packages.pyvex: 9.2.21 -> 9.2.22`                                       |
| [`90133e5f`](https://github.com/NixOS/nixpkgs/commit/90133e5f7437d5a4413108ff616710a19b6f0ad2) | `python310Packages.ailment: 9.2.21 -> 9.2.22`                                     |
| [`fefc598f`](https://github.com/NixOS/nixpkgs/commit/fefc598f2cd6c1c414b77256b62ce0ab3b05644c) | `python310Packages.archinfo: 9.2.21 -> 9.2.22`                                    |
| [`9683bb1e`](https://github.com/NixOS/nixpkgs/commit/9683bb1e37c044cf24166e17cc8f8e8546c7bfd8) | `bitwarden: 2022.8.1 -> 2022.10.0`                                                |
| [`b1dc7b33`](https://github.com/NixOS/nixpkgs/commit/b1dc7b33bc16726d63409a03d4bce2e68013daf2) | `mapcidr: 1.0.2 -> 1.0.3`                                                         |
| [`41f84310`](https://github.com/NixOS/nixpkgs/commit/41f84310f928081e9eac059b1da153b49419fb28) | `python310Packages.azure-mgmt-authorization: 2.0.0 -> 3.0.0`                      |
| [`285dc9c1`](https://github.com/NixOS/nixpkgs/commit/285dc9c1de8f8955beaa619de2d8d7536d7879f6) | `open-watcom-v2: Fix bindir name for Darwin (#191537)`                            |
| [`0f6feea4`](https://github.com/NixOS/nixpkgs/commit/0f6feea49ee7dccb8d501ffdd22edbdca20f7592) | `python310Packages.ansible-core: 2.13.4 -> 2.13.5`                                |
| [`1101dfae`](https://github.com/NixOS/nixpkgs/commit/1101dfae20910c42290246532ca735fe454f924c) | `coq: default to version 8.16`                                                    |
| [`661ee3a2`](https://github.com/NixOS/nixpkgs/commit/661ee3a26903ff58fd57f4f4396a748950ba3570) | `coq_8_16: use OCaml 4.14`                                                        |
| [`d451ea73`](https://github.com/NixOS/nixpkgs/commit/d451ea73dc8b4ed51d2a534f9c7b6e64268c3271) | `coqPackages.coq-elpi: disable OCaml warnings`                                    |
| [`50ecf779`](https://github.com/NixOS/nixpkgs/commit/50ecf779c9804b34332f7ea5fcdc55f85fe1a9d6) | `pkgsMusl.jdk: fix build`                                                         |
| [`8886c89d`](https://github.com/NixOS/nixpkgs/commit/8886c89d0eff3a192ed9f98a13849f76e73c5073) | `{temurin,adoptopenjdk}-bin: use alpine_linux os for musl libc`                   |
| [`d968a99b`](https://github.com/NixOS/nixpkgs/commit/d968a99bc0a40279578145baeb53411afe1cbfe3) | `{temurin,adoptopenjdk}-bin: regenerate sources.json`                             |
| [`f5ba2af2`](https://github.com/NixOS/nixpkgs/commit/f5ba2af2a218d7d490a3b8c7cd7f99e440f9ee4d) | `{temurin,adoptopenjdk}-bin: add alpine_linux os to generate-sources script`      |
| [`7f4fe58f`](https://github.com/NixOS/nixpkgs/commit/7f4fe58f00352359afa09610b9a08e7be57f8bd4) | `wofi: 1.2.4 -> 1.3 (#195595)`                                                    |
| [`58cb56ee`](https://github.com/NixOS/nixpkgs/commit/58cb56ee9cfa87cf00ecac99ccca8ca65f4a2e78) | `influxdb2: fix build with rust 1.54 (#195534)`                                   |
| [`10e5fa68`](https://github.com/NixOS/nixpkgs/commit/10e5fa68de2d259a371b450d9c362d518e9842f2) | `ungoogled-chromium: 106.0.5249.103 -> 106.0.5249.119`                            |
| [`c8d4492a`](https://github.com/NixOS/nixpkgs/commit/c8d4492a8d5e97e155f419cda0fcdc5e18f0e079) | `chromium: 106.0.5249.103 -> 106.0.5249.119`                                      |
| [`284adcab`](https://github.com/NixOS/nixpkgs/commit/284adcab1f31d3c9ddb375e1c4830297a24e234f) | `zeroad: fix build on aarch64-linux`                                              |
| [`37053d45`](https://github.com/NixOS/nixpkgs/commit/37053d45f94e70493cbcd4808f761a797d210701) | `nvidia-texture-tools: unstable-2019-10-27 -> unstable-2020-12-21`                |
| [`bb38470b`](https://github.com/NixOS/nixpkgs/commit/bb38470b969039859fdcfc084485b58fdb7898ad) | `ocamlPackages.ff: 0.4.0 → 0.6.2`                                                 |
| [`76f2f796`](https://github.com/NixOS/nixpkgs/commit/76f2f7968049ac6701b8f9453e96cae3776f6eb0) | `gum: 0.7.0 -> 0.8.0`                                                             |
| [`38d712a2`](https://github.com/NixOS/nixpkgs/commit/38d712a21898424f8953ec268081a9a6ee4a7004) | `goa: 3.7.6 -> 3.10.0`                                                            |
| [`96fa2023`](https://github.com/NixOS/nixpkgs/commit/96fa2023535f2768db28622b056140ee1e8d9d58) | `wordpressPackages.plugins.worker: init at 4.9.14`                                |
| [`81e445e5`](https://github.com/NixOS/nixpkgs/commit/81e445e508f49daabe7fc60f302207eb4555b9d8) | `rubyPackages.*: satisfy pcre* requirements in GTK stack`                         |
| [`dd34f474`](https://github.com/NixOS/nixpkgs/commit/dd34f474ed6c719c094085e24108888761ab2b67) | `nixos/restic: make it possible to use the existing backup cache for prune/check` |
| [`c4105846`](https://github.com/NixOS/nixpkgs/commit/c41058468d91d2fce5835da673845ec5f2a96511) | `n8n: fix build on aarch64`                                                       |
| [`faacc2c5`](https://github.com/NixOS/nixpkgs/commit/faacc2c571d47ca883a75c470c363aa9e1a1f7f9) | `liferea: 1.13.9 -> 1.14-RC1`                                                     |
| [`51c9acf2`](https://github.com/NixOS/nixpkgs/commit/51c9acf26dec754b5a89c52097b30900a31ab040) | `python3Packages.astroquery: fix build`                                           |
| [`f3cdcef7`](https://github.com/NixOS/nixpkgs/commit/f3cdcef7a03c36fa02b3c7af1620353380cdbe1f) | `sockdump: unstable-2022-05-27 -> unstable-2022-10-12`                            |
| [`9673ea73`](https://github.com/NixOS/nixpkgs/commit/9673ea736af82a37bd40243eb10c9557237ea5a6) | `oh-my-zsh: 2022-10-07 → 2022-10-12 (#195666)`                                    |
| [`b468eb86`](https://github.com/NixOS/nixpkgs/commit/b468eb865524252a271cafaf59febc13765a39bb) | `jenkins: 2.361.1 -> 2.361.2 (#195565)`                                           |
| [`790c45e2`](https://github.com/NixOS/nixpkgs/commit/790c45e29ced477c88f6a37078a00b994ba77099) | `wwcd: init at unstable-2022-02-05`                                               |
| [`fca1f750`](https://github.com/NixOS/nixpkgs/commit/fca1f7508b6d4c1077124fa3c51c67e84b1a4078) | `maintainers: add laalsaas`                                                       |
| [`fa2021c7`](https://github.com/NixOS/nixpkgs/commit/fa2021c7b69916754655c525d7ebbc0bc946c003) | `fido2luks: 0.2.20 -> 0.2.21`                                                     |
| [`61a13e2d`](https://github.com/NixOS/nixpkgs/commit/61a13e2dc7a12a6b2a75c994f0f331103da31bf2) | `selfoss: 2.18 → 2.19`                                                            |
| [`9ff71f97`](https://github.com/NixOS/nixpkgs/commit/9ff71f97c885dd46c25dd5927ea24f3bcfd9e9bb) | `python-setup-hook: use buildPackages.callPackage to not change hashes`           |
| [`7fc8453a`](https://github.com/NixOS/nixpkgs/commit/7fc8453a6872573b1f0c75118a09367d1461b3ac) | `libusb1: enable udev support for dynamically linked musl platform (#195351)`     |
| [`af4a69ff`](https://github.com/NixOS/nixpkgs/commit/af4a69ffffddacf8e5b58ca666b6cb9ec6786ef6) | `lxqt.lxqt-build-tools: Fix build failure of libqtxdg with GLib 2.73.1+`          |
| [`16ead09b`](https://github.com/NixOS/nixpkgs/commit/16ead09b5e3ab9b1c7a5dc43bb6ad497ccba8f4d) | `parlatype: sort dependencies and reformat`                                       |
| [`3dae05bb`](https://github.com/NixOS/nixpkgs/commit/3dae05bb9193f3910f1ac0251b1c1eb4f7f07872) | `update-python-libraries: enable nix command`                                     |
| [`6425011e`](https://github.com/NixOS/nixpkgs/commit/6425011efe079f34bb795a1bc192cc0db3590155) | `update-python-libraries: remove old Nix fallback`                                |
| [`07f03615`](https://github.com/NixOS/nixpkgs/commit/07f03615ba871e5f82390db41d2ff511ade7f631) | `dagger: 0.2.35 -> 0.2.36`                                                        |
| [`a0231e8c`](https://github.com/NixOS/nixpkgs/commit/a0231e8ccebfadfc742a9da51cc14c375eeeb682) | `pebble: mark broken on 32bit platforms`                                          |
| [`0310ac43`](https://github.com/NixOS/nixpkgs/commit/0310ac43a5b29b5aad8dd8bc0a9adfc4da8d8dd6) | `python3Packages.mypy: Disable mypy.report import on i686-linux`                  |
| [`710808a8`](https://github.com/NixOS/nixpkgs/commit/710808a82b8b8c955e7d808c69f2584424350170) | `pantheon.elementary-terminal: Fix terminal freeze when closing in GLib 2.73.2+`  |
| [`7d3e7f48`](https://github.com/NixOS/nixpkgs/commit/7d3e7f48903918cc8b1f102e3a2602114fba357e) | `python3Packages.bcrypt: Revert to 3.2.2 on i686-linux`                           |
| [`ca03be95`](https://github.com/NixOS/nixpkgs/commit/ca03be9517b01f7fc2f974b3886efa24c2a9659c) | `devilspie2: update homepage in meta`                                             |
| [`0d0c03fb`](https://github.com/NixOS/nixpkgs/commit/0d0c03fb0bb3b7407243bde95c482831ed9bfa9c) | `coding-conventions.chapter.md: update to account for #89885 (#191378)`           |
| [`334f2a85`](https://github.com/NixOS/nixpkgs/commit/334f2a858424172756222e0270c5a3e88a787792) | `openmm: init at 7.7.0`                                                           |
| [`80f28828`](https://github.com/NixOS/nixpkgs/commit/80f28828c73ae6a2bb3ad667a969fa5527657dc3) | `gerrit: 3.5.1 -> 3.6.2 (#195630)`                                                |
| [`eafbd542`](https://github.com/NixOS/nixpkgs/commit/eafbd542ed0e721c4faae46adbe58419bbaa0f95) | `qutebrowser-qt6: fix help command`                                               |
| [`e1734cb2`](https://github.com/NixOS/nixpkgs/commit/e1734cb2b4670d5e6bfeba9a6728fc76fddbb41f) | `redpanda: 22.2.5 -> 22.2.6`                                                      |
| [`98e5fcb9`](https://github.com/NixOS/nixpkgs/commit/98e5fcb9c784b91342e6f33d8aa0c362b847a995) | `werf: 1.2.177 -> 1.2.178`                                                        |
| [`b2a5c364`](https://github.com/NixOS/nixpkgs/commit/b2a5c364d7ce47254c5777ed4914281dbc1c7add) | ``heroic: don't use the `kdialog` top-level alias``                               |
| [`5c58d4f5`](https://github.com/NixOS/nixpkgs/commit/5c58d4f5ea4192cfc8817f3bab28574b503956c3) | `qutebrowser: fix build`                                                          |
| [`2757fba5`](https://github.com/NixOS/nixpkgs/commit/2757fba524867a4c9de5304f6e5a508ea6ad9019) | `python310Packages.teslajsonpy: 2.4.5 -> 3.0.0`                                   |
| [`93a795a5`](https://github.com/NixOS/nixpkgs/commit/93a795a555000c0e191efe943736c40acdab12ae) | `terraform-providers.utils: 1.4.1 → 1.5.0`                                        |
| [`0d74b078`](https://github.com/NixOS/nixpkgs/commit/0d74b078cefdf642909f2d1600ab3f1c4dc89c34) | `terraform-providers.ucloud: 1.32.3 → 1.32.4`                                     |
| [`3bc6cb1e`](https://github.com/NixOS/nixpkgs/commit/3bc6cb1ef4ef086bb5388f4ce2333661cd515250) | `terraform-providers.time: 0.8.0 → 0.9.0`                                         |
| [`d309f7dc`](https://github.com/NixOS/nixpkgs/commit/d309f7dc3cecb9aaf796b9cc4b6c6b9dca2b95c7) | `terraform-providers.pagerduty: 2.6.2 → 2.6.3`                                    |
| [`638a7e1d`](https://github.com/NixOS/nixpkgs/commit/638a7e1d5198812337648ccf0db234e47bbea559) | `terraform-providers.linode: 1.29.2 → 1.29.3`                                     |
| [`b9b60fad`](https://github.com/NixOS/nixpkgs/commit/b9b60fad403723526fcddfc45abc9ba2a8aa5768) | `terraform-providers.heroku: 5.1.4 → 5.1.5`                                       |
| [`e0039724`](https://github.com/NixOS/nixpkgs/commit/e003972403574285dc4af92e0f90d21c21e46f14) | `free42: 3.0.14 -> 3.0.15`                                                        |
| [`ec70a388`](https://github.com/NixOS/nixpkgs/commit/ec70a388c55fb6e2378dff96d9a72839b77d3cc7) | `onedrive: 2.4.20 -> 2.4.21`                                                      |
| [`58ca4f90`](https://github.com/NixOS/nixpkgs/commit/58ca4f90608cd3a2a3805faed0b71ff1a1166676) | `faas-cli: 0.14.8 -> 0.14.10`                                                     |
| [`7b454732`](https://github.com/NixOS/nixpkgs/commit/7b4547322679f9e70f43d122a427b033d9b7d7df) | `humioctl: 0.30.1 -> 0.30.2`                                                      |
| [`9a8d7bbf`](https://github.com/NixOS/nixpkgs/commit/9a8d7bbfd104b3bff448ec0f4eae5b200d167a72) | `buildkit-nix: 0.0.3 -> 0.1.0`                                                    |
| [`3e08c10e`](https://github.com/NixOS/nixpkgs/commit/3e08c10e68ec36b32ed5fde59e53526a8b386a01) | `elixir_1_14: 1.14.0 -> 1.14.1`                                                   |
| [`10e11a1e`](https://github.com/NixOS/nixpkgs/commit/10e11a1e60aa2ab5fdd288e1108ae5f506e73d22) | `talosctl: 1.2.4 -> 1.2.5`                                                        |
| [`17c13ef8`](https://github.com/NixOS/nixpkgs/commit/17c13ef8862082e5d78ab5aa11fe391498a7fb6e) | `rustpython: unstable-2021-12-09 -> unstable-2022-10-11`                          |
| [`af4dbb9b`](https://github.com/NixOS/nixpkgs/commit/af4dbb9b205ee1047795076096b0d64443580dcc) | `python310Packages.enlighten: 1.10.2 -> 1.11.1`                                   |
| [`cb61e14f`](https://github.com/NixOS/nixpkgs/commit/cb61e14ff832e571a8a89e638a68f0ee579b38e9) | `himalaya: 0.5.10 -> 0.6.0`                                                       |
| [`55edf1a0`](https://github.com/NixOS/nixpkgs/commit/55edf1a08a4db3c68a798353bbd14905d039f844) | `python3Packages.python3-application: 3.0.3 -> 3.0.4`                             |
| [`790a7e44`](https://github.com/NixOS/nixpkgs/commit/790a7e4434e0dbd76a391d556745ba83892592d7) | `gitleaks: 8.13.0 -> 8.14.1`                                                      |
| [`fc266cd0`](https://github.com/NixOS/nixpkgs/commit/fc266cd0072075b0ed264461df0f47837e77ed0b) | `ghorg: 1.8.7 -> 1.8.8`                                                           |
| [`85fa4ac0`](https://github.com/NixOS/nixpkgs/commit/85fa4ac03e9b26420a90512d5bf6e5c2b9a5d423) | `arduino-language-server: init at 0.7.1`                                          |
| [`83a898a4`](https://github.com/NixOS/nixpkgs/commit/83a898a461daad1ff07fa6b04dd042a768aa3637) | `ft2-clone: 1.59 -> 1.60`                                                         |
| [`6a31ff5b`](https://github.com/NixOS/nixpkgs/commit/6a31ff5b30058cbfccdb096e27c566bb6f1e49ed) | `outline: fix not using legacy provided during build`                             |
| [`c362c4c4`](https://github.com/NixOS/nixpkgs/commit/c362c4c440370fc75f2d4cdfc35c5736db80a0ca) | `flyctl: 0.0.407 -> 0.0.409`                                                      |
| [`4c698434`](https://github.com/NixOS/nixpkgs/commit/4c6984346080dca83083bc7063df8fe820a025bc) | `nixos/mullvad-vpn: change dependency for the daemon to pkg mullvad`              |
| [`5c087542`](https://github.com/NixOS/nixpkgs/commit/5c08754283e543071a38d948fda3b50d1bf29a63) | `python310Packages.pylitterbot: 2022.9.6 -> 2022.10.1`                            |
| [`7d62668d`](https://github.com/NixOS/nixpkgs/commit/7d62668da62c1af7c61e1b2a1d7b3a9f32c15bba) | `dnsproxy: 0.45.2 -> 0.45.3`                                                      |
| [`9c32b210`](https://github.com/NixOS/nixpkgs/commit/9c32b210d6eb6f2c5f90eb9355f28bbe029a17e6) | `dnstwist: 20221008 -> 20221011`                                                  |
| [`7548a378`](https://github.com/NixOS/nixpkgs/commit/7548a378a9717937dc20524513dfb5f0d56652b1) | `python3Packages.imageio: 2.22.0 -> 2.22.1`                                       |
| [`85a36f91`](https://github.com/NixOS/nixpkgs/commit/85a36f91469057daaef5c2d64baa4efed1774903) | `writers.writeJS: pass arguments to script`                                       |
| [`7510a656`](https://github.com/NixOS/nixpkgs/commit/7510a656be18d164490757752fc3c6f5c418c562) | `checkip: 0.40.3 -> 0.40.4`                                                       |
| [`bea5ec6f`](https://github.com/NixOS/nixpkgs/commit/bea5ec6f7d97b03e9f412b184ec3d018fd23f651) | `chrysalis: 0.11.5 -> 0.11.8`                                                     |
| [`39f6f5e3`](https://github.com/NixOS/nixpkgs/commit/39f6f5e32e8e46833d9400b37a9fd58b8719a3c0) | `cf-terraforming: 0.8.7 -> 0.8.8 (#194363)`                                       |
| [`a2071cad`](https://github.com/NixOS/nixpkgs/commit/a2071cad5526480efcbd06294bf81fd531843626) | `git-nomad: init at 0.6.0`                                                        |
| [`fe69c269`](https://github.com/NixOS/nixpkgs/commit/fe69c26926424d10e9e7283d82edec7be67ea000) | `python310Packages.plugwise: 0.24.1 -> 0.25.0`                                    |
| [`f88fc14f`](https://github.com/NixOS/nixpkgs/commit/f88fc14fa8075b1a3984ce204e0bf2f0371567c9) | `ruff: 0.0.68 -> 0.0.69`                                                          |
| [`fe130b7a`](https://github.com/NixOS/nixpkgs/commit/fe130b7af4c00bbf628440588d8fb606eafc6ced) | `python310Packages.pex: 2.1.109 -> 2.1.110`                                       |
| [`4d703382`](https://github.com/NixOS/nixpkgs/commit/4d703382f35bee9f69b573eca131362d9a9bcf3a) | `gnome.polari: 42.1 → 43.0`                                                       |
| [`336d270b`](https://github.com/NixOS/nixpkgs/commit/336d270b744ef3a4508685ad3f180dc5da1d17ff) | `vala-language-server: Fix build with GLib 2.74`                                  |
| [`375445ae`](https://github.com/NixOS/nixpkgs/commit/375445aead13312938bcb2565dc22aea452a8a01) | `entangle: Add workaround for old libselinux`                                     |
| [`72ecf256`](https://github.com/NixOS/nixpkgs/commit/72ecf256663bb90032d8388dd0e939409cdd1a58) | `greetd.gtkgreet: Fix build with GLib 2.74`                                       |
| [`bc8b66c2`](https://github.com/NixOS/nixpkgs/commit/bc8b66c2af5aa1ae4decdc9241805289e895ba87) | `pango: 1.50.10 → 1.50.11`                                                        |
| [`357536bf`](https://github.com/NixOS/nixpkgs/commit/357536bf580ca8298269d972c51ed0717eba3814) | `gnome-text-editor: 43.0 → 43.1`                                                  |
| [`6d5da1d8`](https://github.com/NixOS/nixpkgs/commit/6d5da1d8bcd8dde42ba41f7d5034bc8299a67bb2) | `gnome-builder: 43.1 → 43.2`                                                      |
| [`5e5d9256`](https://github.com/NixOS/nixpkgs/commit/5e5d9256e784d43afce44ac55894f2eff4ea869e) | `gnome.metacity: 3.44.0 → 3.46.0`                                                 |
| [`d258f6fe`](https://github.com/NixOS/nixpkgs/commit/d258f6fef875580bbd745c112e69b306e31c46ef) | `gnome.gnome-flashback: 3.45.1 → 3.46.0`                                          |
| [`64c94e66`](https://github.com/NixOS/nixpkgs/commit/64c94e66ac422828fdb6c9e95fa7c2b626eba471) | `gnome.ghex: 43.rc → 43.0`                                                        |
| [`29d57012`](https://github.com/NixOS/nixpkgs/commit/29d570122bdcac89854426fbb671d93f432838e8) | `glade: switch to webkitgtk_4_1`                                                  |
| [`919fc66e`](https://github.com/NixOS/nixpkgs/commit/919fc66e9d4d5b9698bb095fc515734941cc3d8b) | `gnome.yelp: switch to webkitgtk_4_1`                                             |
| [`571d8e44`](https://github.com/NixOS/nixpkgs/commit/571d8e44bf78251cadbc394e65faec75eecc8460) | `tdesktop: switch to webkitgtk_4_1`                                               |