### PR TITLE
chore(flake/home-manager): `618ab0f8` -> `8cbc6500`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665654744,
-        "narHash": "sha256-SMu4OghfRN2I9MoxJJ0oclHBZHp7DFJS5/CRsmpGY60=",
+        "lastModified": 1665655007,
+        "narHash": "sha256-34ZMJlgqJb73RY/gJz8B4cjdM5ukas2crMYQpmyRGeQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "618ab0f882167361108475a9f1404fb4c638b73d",
+        "rev": "8cbc6500dfca22d907054f68c564019b3b6cf295",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                               |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`8cbc6500`](https://github.com/nix-community/home-manager/commit/8cbc6500dfca22d907054f68c564019b3b6cf295) | `lib/bash: make call to tput more robust`    |
| [`8eaa3ba5`](https://github.com/nix-community/home-manager/commit/8eaa3ba56edaf89138549d0854e3a94c0dbad060) | `lib/bash: remove unused Bash library files` |