### PR TITLE
chore(flake/nixos-hardware): `c8c54d8f` -> `674d05f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1665734422,
-        "narHash": "sha256-v8DMfRyFdulDyCCoOXak+oue1IgVBJZdSY1eXqdMRwQ=",
+        "lastModified": 1665839131,
+        "narHash": "sha256-0KYo13PfwvPw5i/SC+hGy3hsgR++Co7SIzv+0e9YOnM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c8c54d8f0af9f19ed6e929e60f0e1609b89b1240",
+        "rev": "674d05f9ae2249d606a0e6fc63e522d2031a27ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                 |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`821c9f1d`](https://github.com/NixOS/nixos-hardware/commit/821c9f1d35948ca1f8b0b9966b6c1b983d5ba049) | `Add support for ssd to Lenovo ThinkPad T480s` |