### PR TITLE
chore(flake/nixpkgs): `4428e233` -> `83b198a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665732960,
-        "narHash": "sha256-WBZ+uSHKFyjvd0w4inbm0cNExYTn8lpYFcHEes8tmec=",
+        "lastModified": 1665848363,
+        "narHash": "sha256-3Jow1YxzPtQnck1bAAvbVxgRH4gNnkIdw871Vm6UtAU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4428e23312933a196724da2df7ab78eb5e67a88e",
+        "rev": "83b198a2083774844962c854f811538323f9f7b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`0ab12ad0`](https://github.com/NixOS/nixpkgs/commit/0ab12ad0af7d8a706cc2035339673ba8a54dd202) | `borgbackup: remove myself from maintainers`                                               |
| [`42c94928`](https://github.com/NixOS/nixpkgs/commit/42c94928296294aeed01e7ac9c77a664a4abddf3) | `nixos/systemd-boot: decrease catch scope for ValueError`                                  |
| [`33db6f2c`](https://github.com/NixOS/nixpkgs/commit/33db6f2c57ee3456c3da04706847b31c70d0bf5f) | `maintainers: add dritter`                                                                 |
| [`e04579e7`](https://github.com/NixOS/nixpkgs/commit/e04579e7cdce875453574a46123b73dfe6db046f) | `nixos/please: init module`                                                                |
| [`be795c6a`](https://github.com/NixOS/nixpkgs/commit/be795c6a84846b0dc98fd0ed7466d91a3ce1c8cd) | `please: init at 0.5.3`                                                                    |
| [`a36ceb86`](https://github.com/NixOS/nixpkgs/commit/a36ceb869d7d5ffa1777cee9f1b2bf2027904b02) | `gnome.seahorse: 42.0 → 43.0`                                                              |
| [`d3d30652`](https://github.com/NixOS/nixpkgs/commit/d3d306528d4375cf28fa9af4c191f21c49e30a1b) | `gupnp-tools: 0.10.3 → 0.12.0`                                                             |
| [`c97716d2`](https://github.com/NixOS/nixpkgs/commit/c97716d23d1e937990b064b80b7a040dfd13762f) | `gcr_4: 3.92.0 → 4.0.0`                                                                    |
| [`fac8273a`](https://github.com/NixOS/nixpkgs/commit/fac8273a4a295a2a2f7d4087b235b374b33010f8) | `dendrite: only include binaries meant for public use (exclude demos)`                     |
| [`44103c67`](https://github.com/NixOS/nixpkgs/commit/44103c67ce07cba3bdebc081fc5fa435c408d103) | `oh-my-posh: 12.2.0 -> 12.3.0`                                                             |
| [`144affc5`](https://github.com/NixOS/nixpkgs/commit/144affc549e74b4b90993cbb4b51ba7cfd00a0f5) | `nsjail: 3.1 -> 3.2`                                                                       |
| [`589863fc`](https://github.com/NixOS/nixpkgs/commit/589863fc0a5f9a4ef14f4300722fed5a297e509c) | `notmuch-addrlookup: 9 -> 10`                                                              |
| [`7d0a8f68`](https://github.com/NixOS/nixpkgs/commit/7d0a8f68cb7e1b2d22d9d8a66a55b41562b83432) | `Update default.nix`                                                                       |
| [`274698dd`](https://github.com/NixOS/nixpkgs/commit/274698ddc9eda8efb2031b0280020cf9a6dee8cf) | `Update pkgs/tools/compression/mozlz4a/default.nix`                                        |
| [`f5ac23ee`](https://github.com/NixOS/nixpkgs/commit/f5ac23ee18b5ab6d7f613e7d23822caaef0212c1) | `mlterm: unbreak on aarch64-linux`                                                         |
| [`f56f67e4`](https://github.com/NixOS/nixpkgs/commit/f56f67e4d5b32ecf9b81972fc7e217ccd6e7e720) | `mlterm: mark as broken on aarch64-darwin`                                                 |
| [`6538ea88`](https://github.com/NixOS/nixpkgs/commit/6538ea88769f084fa0403de0296ded24fff5664c) | `python310Packages.haversine: disable on older Python releases`                            |
| [`f739f30d`](https://github.com/NixOS/nixpkgs/commit/f739f30db31308e2deba044482ea8466c90dc5d3) | `newsflash: 2.1.0 -> 2.1.2`                                                                |
| [`58f404c2`](https://github.com/NixOS/nixpkgs/commit/58f404c2096e6824134b7d75e567a9bde987f02d) | `python310Packages.haversine: 2.6.0 -> 2.7.0`                                              |
| [`e72450d0`](https://github.com/NixOS/nixpkgs/commit/e72450d032e3e6b28124e73400959cef4f064fd4) | `Revert "top-level/aliases: prune old aliases, add missing dates"`                         |
| [`cc403951`](https://github.com/NixOS/nixpkgs/commit/cc403951788a23e4791c30981056dc1bb3e74d9a) | `Revert "top-level/python-aliases: prune old aliases, add missing dates"`                  |
| [`0b6a7a95`](https://github.com/NixOS/nixpkgs/commit/0b6a7a953d7bc7aa453683919c7bbcadad739aa3) | `Revert "utillinux: drop alias, don't throw"`                                              |
| [`f9095022`](https://github.com/NixOS/nixpkgs/commit/f909502274931f60bd3a16783b739a42314e2ad2) | `libosip: 5.3.0 -> 5.3.1`                                                                  |
| [`1b592729`](https://github.com/NixOS/nixpkgs/commit/1b59272940f5f5fec7773b67c9070ffbd9d62cc3) | `kubeseal: 0.18.5 -> 0.19.0`                                                               |
| [`afa3d130`](https://github.com/NixOS/nixpkgs/commit/afa3d1308265dc41a998f68f03032d47b60c2041) | `juicefs: 1.0.0 -> 1.0.2`                                                                  |
| [`af6521df`](https://github.com/NixOS/nixpkgs/commit/af6521df65df5a141f952150ad7dc49f3e95e895) | `python310Packages.youless-api: 0.16 -> 1.0`                                               |
| [`79cf7a94`](https://github.com/NixOS/nixpkgs/commit/79cf7a94d2bccb36cf9541948ac7b29ffb206f26) | `ruler: update license detail`                                                             |
| [`f15fb537`](https://github.com/NixOS/nixpkgs/commit/f15fb53786a87a7cadaa43d8419ba05151c1abe2) | `python310Packages.dinghy: disable on older Python releases`                               |
| [`c86122e5`](https://github.com/NixOS/nixpkgs/commit/c86122e5bd19813b0be4f605722c9530de5b20f3) | `pythonInterpreters: get self from __splicedPackages`                                      |
| [`19d04b5f`](https://github.com/NixOS/nixpkgs/commit/19d04b5f478e876aa1543ce42e3d828286d5a238) | `pythonInterpreters: don't use with pkgs`                                                  |
| [`1b252990`](https://github.com/NixOS/nixpkgs/commit/1b252990d195ab9c8d505b3a2794ca970586d739) | `python310Packages.freebox-api: 0.0.10 -> 1.0.0`                                           |
| [`c9fa012f`](https://github.com/NixOS/nixpkgs/commit/c9fa012f1b8f46615d82383717647c275a98e195) | `linux/hardened/patches/5.4: 5.4.215-hardened1 -> 5.4.217-hardened2`                       |
| [`529e4e43`](https://github.com/NixOS/nixpkgs/commit/529e4e43cdca4e96f2ff401be6c7f875ef532a42) | `linux/hardened/patches/5.19: 5.19.12-hardened1 -> 5.19.15-hardened2`                      |
| [`1fe11469`](https://github.com/NixOS/nixpkgs/commit/1fe114699f24d81406d36152c9a236ff488d33bc) | `linux/hardened/patches/5.15: 5.15.71-hardened1 -> 5.15.73-hardened3`                      |
| [`ac118a1d`](https://github.com/NixOS/nixpkgs/commit/ac118a1d1b18512f99f87c1e963f1bca52f6e9a9) | `linux/hardened/patches/5.10: 5.10.146-hardened1 -> 5.10.147-hardened2`                    |
| [`6d5f9ea6`](https://github.com/NixOS/nixpkgs/commit/6d5f9ea6389a2c7b6ceb728a16a9ed312afd83b1) | `linux/hardened/patches/4.19: 4.19.260-hardened1 -> 4.19.261-hardened1`                    |
| [`7523167e`](https://github.com/NixOS/nixpkgs/commit/7523167edaf4b9437eb396bfc992ab47aa49f7b0) | `linux: 6.0 -> 6.0.2`                                                                      |
| [`202379fa`](https://github.com/NixOS/nixpkgs/commit/202379fa9cbe80ccec2adc7872342076816c91c7) | `linux: 5.4.216 -> 5.4.218`                                                                |
| [`e3bf36cd`](https://github.com/NixOS/nixpkgs/commit/e3bf36cdd37891a204339b69904055c32ddc0ff2) | `linux: 5.19.14 -> 5.19.16`                                                                |
| [`6981bd8f`](https://github.com/NixOS/nixpkgs/commit/6981bd8fda6f1c059d979c2a754318b51a5e3b75) | `linux: 5.15.72 -> 5.15.74`                                                                |
| [`9702319e`](https://github.com/NixOS/nixpkgs/commit/9702319ec12985b817259fccad1d4e624750ed4b) | `linux: 5.10.147 -> 5.10.148`                                                              |
| [`d864745e`](https://github.com/NixOS/nixpkgs/commit/d864745e7cc9fed0ba0dc4ba0043d39b688e2a12) | `python310Packages.pyotgw: update disabled`                                                |
| [`9e208576`](https://github.com/NixOS/nixpkgs/commit/9e20857603091604a710cb4da72338fbff59dbb5) | `python310Packages.pyotgw: 2.0.3 -> 2.1.0`                                                 |
| [`47df0d8b`](https://github.com/NixOS/nixpkgs/commit/47df0d8bc2ec327344564bd6e90920be326d882c) | `python310Packages.ibeacon-ble: 0.7.3 -> 0.7.4`                                            |
| [`020b9c1c`](https://github.com/NixOS/nixpkgs/commit/020b9c1c68352f643315c106056ee04e5e643de3) | `python310Packages.aioairq: 0.2.0 -> 0.2.4`                                                |
| [`46bad55d`](https://github.com/NixOS/nixpkgs/commit/46bad55d5c0bee171d25e07bd638423b03378bb2) | `gobuster: 3.1.0 -> 3.2.0`                                                                 |
| [`95e7454c`](https://github.com/NixOS/nixpkgs/commit/95e7454caaa3026a9a8e8e39793e49cab595e2fc) | `starship: 1.10.3 -> 1.11.0`                                                               |
| [`9d86c39f`](https://github.com/NixOS/nixpkgs/commit/9d86c39f7ae97eba68b3e7e00b5706fc476c5443) | `kubernetes: 1.23.12 -> 1.23.13`                                                           |
| [`bb884d6a`](https://github.com/NixOS/nixpkgs/commit/bb884d6a1e25216945869890b87537dcb0886495) | `nixosTests.traefik: enable on aarch64-linux`                                              |
| [`ff30f8a4`](https://github.com/NixOS/nixpkgs/commit/ff30f8a4295b2079c5cba8bc5385d1d80956eba5) | `nixosTests.podman*: enable on aarch64-linux`                                              |
| [`d50ee203`](https://github.com/NixOS/nixpkgs/commit/d50ee203f77da3c8b727c2a56f108571d7f7c729) | `nixosTests.oci-containers: enable on aarch64-linux`                                       |
| [`0a8746ca`](https://github.com/NixOS/nixpkgs/commit/0a8746ca850425a82d4984e8725c2d72190ca176) | `nixosTests.{docker,docker-rootless}: enable on aarch64-linux`                             |
| [`92864191`](https://github.com/NixOS/nixpkgs/commit/92864191093c8570f8b9ad1fc974ae8e8e24c99b) | `nixosTests.cri-o: enable on aarch64-linux`                                                |
| [`8b4bbd69`](https://github.com/NixOS/nixpkgs/commit/8b4bbd6919fe4e0834aef18905683c7722c87604) | `nixosTests.cfssl: enable on aarch64-linux`                                                |
| [`335e938e`](https://github.com/NixOS/nixpkgs/commit/335e938eb261a3397c68cbd30bb6f4cebb5bdf84) | `terraform-providers.selectel: 3.8.4 → 3.8.5`                                              |
| [`c2d10bb4`](https://github.com/NixOS/nixpkgs/commit/c2d10bb4d6b51b33b6be8d1a76201aaa852c3a09) | `terraform-providers.linode: 1.29.3 → 1.29.4`                                              |
| [`2410d136`](https://github.com/NixOS/nixpkgs/commit/2410d1367e6bdc738010d51a32ab2facb926bb4f) | `terraform-providers.newrelic: 3.4.4 → 3.5.0`                                              |
| [`e7924d83`](https://github.com/NixOS/nixpkgs/commit/e7924d8364eb31a6d547ad52ad664a7036240d3b) | `terraform-providers.gridscale: 1.15.0 → 1.16.0`                                           |
| [`6bb992ae`](https://github.com/NixOS/nixpkgs/commit/6bb992ae546bbb769abe7b1cdd168e1df3597088) | `gatekeeper: 3.9.1 -> 3.9.2`                                                               |
| [`6b695fe1`](https://github.com/NixOS/nixpkgs/commit/6b695fe12179d50aa496de13e5652cc6e6127183) | `flow: 0.189.0 -> 0.190.0`                                                                 |
| [`a67c95c3`](https://github.com/NixOS/nixpkgs/commit/a67c95c3417a16b189a3221d3d07470c739b1d44) | `altcoins.masari: 0.1.4.0 -> latest-2022-10-09`                                            |
| [`bf774f62`](https://github.com/NixOS/nixpkgs/commit/bf774f6296f7519ed5368203c1c96cda9f369311) | `esbuild: 0.15.10 -> 0.15.11`                                                              |
| [`e78914ab`](https://github.com/NixOS/nixpkgs/commit/e78914ab9dd2e3ca2bf103df03edbd85da9872e1) | `tagger: init at 2022.10.3`                                                                |
| [`60645fab`](https://github.com/NixOS/nixpkgs/commit/60645fab967557758d01c570c0ad2d68b8c15780) | `eksctl: 0.114.0 -> 0.115.0`                                                               |
| [`9a9427d9`](https://github.com/NixOS/nixpkgs/commit/9a9427d9bf79d07896c7a78fe9581f43a1e6c429) | `vsmtp: set platforms to platforms.linux`                                                  |
| [`07c7197b`](https://github.com/NixOS/nixpkgs/commit/07c7197b588c5a511b864893197ec8ff2ba19f55) | `db: update meta.homepage`                                                                 |
| [`20c97dbd`](https://github.com/NixOS/nixpkgs/commit/20c97dbdce11ed803dd7d927f79faaddea65a5a4) | `oh-my-zsh: 2022-10-12 -> 2022-10-14`                                                      |
| [`bf450227`](https://github.com/NixOS/nixpkgs/commit/bf4502279231c68103e74fdc6963d8b9e60fb4cd) | `idasen: 0.9.3 -> 0.9.4`                                                                   |
| [`9693a9a2`](https://github.com/NixOS/nixpkgs/commit/9693a9a2e8f826a4c3612e8480d3974617c39624) | `yosys: 0.20 -> 0.22`                                                                      |
| [`2cb6af3e`](https://github.com/NixOS/nixpkgs/commit/2cb6af3eac53ec5ecc2c8082ddd27693bab8f57e) | `abc-verifier: 2022.07.27 -> unstable-2022-09-08`                                          |
| [`0c15753f`](https://github.com/NixOS/nixpkgs/commit/0c15753f5c8a9c9ac9aea5c890a9171f38a267ff) | `bfcal: add platforms`                                                                     |
| [`8a5b2ef1`](https://github.com/NixOS/nixpkgs/commit/8a5b2ef13b2178ade812213fdec00cb9be662c57) | `difftastic: 0.36.1 -> 0.37.0`                                                             |
| [`9b480c27`](https://github.com/NixOS/nixpkgs/commit/9b480c2739ea36b52971ff7f8c8d7246af9f38b5) | `.github/workflows: use ofborg-eval context for pending status`                            |
| [`f9ad9a7f`](https://github.com/NixOS/nixpkgs/commit/f9ad9a7f48913eda706d61e79977728588044008) | `cargo-release: 0.21.2 -> 0.21.4`                                                          |
| [`e11fa657`](https://github.com/NixOS/nixpkgs/commit/e11fa657831684f7708e31ef723684ce95f66e88) | `ripe-atlas-tools: remove usage of lib.trivial.version which triggers unecessary rebuilds` |
| [`87761da9`](https://github.com/NixOS/nixpkgs/commit/87761da9347020e1beb55cfcb45c73e757715cfa) | `python37: 3.7.14 -> 3.7.15`                                                               |
| [`689b960f`](https://github.com/NixOS/nixpkgs/commit/689b960f443b85c9397c35b0986b38bc02b60a40) | `ipopt: 3.14.9 -> 3.14.10`                                                                 |
| [`9f1d6c1c`](https://github.com/NixOS/nixpkgs/commit/9f1d6c1c5d0961c99c67a475148e39f6dcf4fb9d) | `ocamlPackages.mirage-block-unix: 2.14.1 → 2.14.2`                                         |
| [`6a609418`](https://github.com/NixOS/nixpkgs/commit/6a609418031c891510df8a25a806f62534d221a3) | `vector: enable api and api-client features`                                               |
| [`7b88ba8a`](https://github.com/NixOS/nixpkgs/commit/7b88ba8aae9ffd4524893cbe88fa16c3c94af5a0) | `python310Packages.influxdb-client: 1.31.0 -> 1.33.0`                                      |
| [`e6a1dde2`](https://github.com/NixOS/nixpkgs/commit/e6a1dde202941a9fa929f1a2164633b3c42ebb16) | `mdcat: switch back to GitHub`                                                             |
| [`2e27be3a`](https://github.com/NixOS/nixpkgs/commit/2e27be3a0edb8e91e55c198a66152621c8d365b8) | `python310Packages.reactivex: init at 4.0.4`                                               |
| [`668a53a3`](https://github.com/NixOS/nixpkgs/commit/668a53a3b2e8945c79e729b331443daa1f9acb84) | `xq: init at 0.2.39`                                                                       |
| [`da55381e`](https://github.com/NixOS/nixpkgs/commit/da55381e2a07f58c325f14704e3328ad3a3a0d61) | `python310Packages.aiocsv: init at 1.2.2`                                                  |
| [`ed791bc5`](https://github.com/NixOS/nixpkgs/commit/ed791bc57ef55de0d2a7a284e94639c3d337e7aa) | `bfcal: 1.0 -> 1.0.1`                                                                      |
| [`2dd846bb`](https://github.com/NixOS/nixpkgs/commit/2dd846bbabd90f0d75fd1b55d384c7db45ec2a9e) | `python310Packages.dinghy: 0.13.2 -> 0.13.4`                                               |
| [`2f4f8e64`](https://github.com/NixOS/nixpkgs/commit/2f4f8e64f50c7ba1da409a152d88129739fbb9a6) | `teos: init at 0.1.2`                                                                      |
| [`5102109d`](https://github.com/NixOS/nixpkgs/commit/5102109d7d271b61fc7c41e61946ec01ed26d701) | `silicon: add _0x4A6F to maintainers`                                                      |
| [`4d5669ae`](https://github.com/NixOS/nixpkgs/commit/4d5669aedbd4529ad19c84d26503c81d06c34c6e) | `ruff: 0.0.72 -> 0.0.75`                                                                   |
| [`a4d63cf1`](https://github.com/NixOS/nixpkgs/commit/a4d63cf111f445107e80fa4068f3b6f1eddddf93) | `chatty: unbreak by relying on same commit Alpine does`                                    |
| [`31693127`](https://github.com/NixOS/nixpkgs/commit/3169312748882b290bd55ff0c54a384a3ad3cee0) | `mmark: 2.2.28 -> 2.2.30`                                                                  |
| [`66a0bfe0`](https://github.com/NixOS/nixpkgs/commit/66a0bfe0538e3e188ef2810cebf0b779ac5536bd) | `intel-gmmlib: 22.2.0 -> 22.2.1`                                                           |
| [`61c3058b`](https://github.com/NixOS/nixpkgs/commit/61c3058bcb4877cecd4fd2e15ac64b5052b6aab2) | ``all-packages.nix: remove `inherit (*xorg) *`'s``                                         |
| [`a7fa7528`](https://github.com/NixOS/nixpkgs/commit/a7fa7528df492a273359db1311d5a31c76056d77) | `dendrite: 0.10.1 -> 0.10.3`                                                               |
| [`acd30963`](https://github.com/NixOS/nixpkgs/commit/acd30963e8db0fbf9df56d5fc2df6dff878295d2) | `vte: fix build on darwin`                                                                 |