### PR TITLE
chore(flake/home-manager): `da3b8049` -> `04f53999`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665949352,
-        "narHash": "sha256-zqy93cQosUIrs/EKdZw8As7G/aWNEwSG/zlb2q+R6/8=",
+        "lastModified": 1665949912,
+        "narHash": "sha256-NAp+YHTxgnpEaIJanOmtUx9XAnhKTCzG8LlFyZIAz7M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "da3b8049fd3a98fbe5d2e82d217f415e6f01d45e",
+        "rev": "04f53999788cd47c6ce932d6cbd7cbfd3998712f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message          |
| ----------------------------------------------------------------------------------------------------------- | ----------------------- |
| [`04f53999`](https://github.com/nix-community/home-manager/commit/04f53999788cd47c6ce932d6cbd7cbfd3998712f) | `borgmatic: add module` |