### PR TITLE
chore(flake/home-manager): `bc7432fb` -> `e901c8d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665970136,
-        "narHash": "sha256-S5fCFz9mfHPU62aF+hybaU4BPNstyBACqesYSZEqzzI=",
+        "lastModified": 1665991686,
+        "narHash": "sha256-VbhugQ+NhybgCfU1gpbEQ6QFYrVQ3jRioYIYFVZ+KPs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bc7432fbcc5bdd15f90109ac32fc4c7b75b968af",
+        "rev": "e901c8d86082be74a8be70773bbb6d401ff21e49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`e901c8d8`](https://github.com/nix-community/home-manager/commit/e901c8d86082be74a8be70773bbb6d401ff21e49) | `ci: bump cachix/cachix-action from 10 to 11`   |
| [`a50c0c6f`](https://github.com/nix-community/home-manager/commit/a50c0c6fe0e87d999022e5ce840aa3700ca58ce7) | `dependabot: switch target from 21.11 to 22.05` |