### PR TITLE
chore(flake/nixpkgs): `83b198a2` -> `104e8082`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665848363,
-        "narHash": "sha256-3Jow1YxzPtQnck1bAAvbVxgRH4gNnkIdw871Vm6UtAU=",
+        "lastModified": 1665940183,
+        "narHash": "sha256-cPe3F7CtnxU9YbJpc3Adl4d9kX+turqTv5FxM98i8vg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "83b198a2083774844962c854f811538323f9f7b1",
+        "rev": "104e8082de1b20f9d0e1f05b1028795ed0e0e4bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`104e8082`](https://github.com/NixOS/nixpkgs/commit/104e8082de1b20f9d0e1f05b1028795ed0e0e4bc) | `weechatScripts.matrix: fix build`                                                          |
| [`e7e1a4ad`](https://github.com/NixOS/nixpkgs/commit/e7e1a4ad5fbbeb5ceb52972a43265a4e0761269c) | `ledger-live-desktop: 2.47.0 -> 2.48.0`                                                     |
| [`4511f696`](https://github.com/NixOS/nixpkgs/commit/4511f696fbe447d5c145b52eccf283915ec7c72d) | `qolibri: 2019-07-22 -> 2.1.4`                                                              |
| [`d6ba3c97`](https://github.com/NixOS/nixpkgs/commit/d6ba3c97b29f7f5ed35671b7c9932824a2754eab) | `mpvpaper: 1.2.1 -> 1.3`                                                                    |
| [`c97fd6f3`](https://github.com/NixOS/nixpkgs/commit/c97fd6f3bd8cd02160fe4e10d2119e0bd112a6eb) | `gsl-lite: init at 0.40.0`                                                                  |
| [`0ac7157c`](https://github.com/NixOS/nixpkgs/commit/0ac7157c10e1ce1c9c42610c261165e887392466) | `munin: 2.0.70 -> 2.0.71`                                                                   |
| [`a03d51b6`](https://github.com/NixOS/nixpkgs/commit/a03d51b6e9b924aa3f57b45edc66638f98f56fe1) | `basiliskii: unstable-2022-04-05 -> 2022-09-30`                                             |
| [`0114a58f`](https://github.com/NixOS/nixpkgs/commit/0114a58f9ab65e4646aed9f673b5f489a9690d0f) | `sigslot: init at 1.2.1`                                                                    |
| [`5ae08b2a`](https://github.com/NixOS/nixpkgs/commit/5ae08b2aaa43cc2fa074d1cdee1e2405e48586be) | `expected-lite: init at 0.6.2`                                                              |
| [`6e36ee59`](https://github.com/NixOS/nixpkgs/commit/6e36ee59a386eb906e1b783293377b116001f2a0) | `ctre: init at 3.7.1`                                                                       |
| [`e899e67e`](https://github.com/NixOS/nixpkgs/commit/e899e67e919f052dde86e4174d24469b86427986) | `ulauncher: remove always false condition`                                                  |
| [`1087d09d`](https://github.com/NixOS/nixpkgs/commit/1087d09dfbf82e086a54390b09b353365aaf8658) | `smenu: 1.0.0 -> 1.1.0`                                                                     |
| [`4732a768`](https://github.com/NixOS/nixpkgs/commit/4732a7685a9257be9d94f9828e0927ed1faa18e1) | `arcanPackages.durden: 2022-07-16 -> 2022-10-16`                                            |
| [`9121d66a`](https://github.com/NixOS/nixpkgs/commit/9121d66ad621a6492fb8d0f17dfb66272592b7e6) | `arcanPackages.pipeworld: use stdenvNoCC instead of stdenv`                                 |
| [`d37b7eba`](https://github.com/NixOS/nixpkgs/commit/d37b7eba9e8706b3aea6f550c3535d81233924f4) | `arcanPackages.prio: use stdenvNoCC instead of stdenv`                                      |
| [`48b434ab`](https://github.com/NixOS/nixpkgs/commit/48b434ab52ba4c343066f5179ca0eebb8b79aa5d) | `arcanPackages.arcan: cosmetical rewrite`                                                   |
| [`00956781`](https://github.com/NixOS/nixpkgs/commit/009567814bfea842f1bb52e4de2d56a241c4190b) | `steam-run: provide meta (#196273)`                                                         |
| [`751e222a`](https://github.com/NixOS/nixpkgs/commit/751e222a73252ed8c2a0bdc5636d70790356a017) | `imhex: init at 1.19.3`                                                                     |
| [`98919e76`](https://github.com/NixOS/nixpkgs/commit/98919e764f556f6593cc22d46b22856732fead67) | `gemrb: 0.9.1 -> 0.9.1.1`                                                                   |
| [`ffca0e91`](https://github.com/NixOS/nixpkgs/commit/ffca0e9113803497ae0a1fb069743c2c64c08872) | `vscodium: 1.72.1.22284 -> 1.72.2.22286`                                                    |
| [`00b3b4ee`](https://github.com/NixOS/nixpkgs/commit/00b3b4ee248b52fc5588ad2d5cb0d71575938e72) | `gatk: 4.2.6.1 -> 4.3.0.0`                                                                  |
| [`049896ab`](https://github.com/NixOS/nixpkgs/commit/049896ab892130d136c687d082bef509af4de10b) | `binlore: fix eval after nix pr #6530`                                                      |
| [`374dfcb7`](https://github.com/NixOS/nixpkgs/commit/374dfcb770d103acf55c22e2d87c1ea000889c38) | `vimPlugins: update`                                                                        |
| [`a09e24f6`](https://github.com/NixOS/nixpkgs/commit/a09e24f6bea0b1f31f9919a8a3d5b024bfec9e60) | `hydrus: fix package name`                                                                  |
| [`cec68629`](https://github.com/NixOS/nixpkgs/commit/cec6862940c2deb71b599536dc31c5d10a43b5d6) | `qt6.qtdeclarative: reduce closure size by removing reference to qtbase.dev`                |
| [`949c5ef0`](https://github.com/NixOS/nixpkgs/commit/949c5ef0e9361cffec064c48c38bb52a8ec26e6c) | `terraform-providers.statuscake: 2.0.4 → 2.0.5`                                             |
| [`073165d8`](https://github.com/NixOS/nixpkgs/commit/073165d8dd3a390d4167cfdd01785f980b02bbcb) | `terraform-providers.minio: 1.6.0 → 1.7.0`                                                  |
| [`7ea12d1a`](https://github.com/NixOS/nixpkgs/commit/7ea12d1a971d54a199c58c9e90a52dde29f9a6a6) | `terraform-providers.alicloud: 1.187.0 → 1.188.0`                                           |
| [`5dcb41f3`](https://github.com/NixOS/nixpkgs/commit/5dcb41f3801a3656b541fa2a3c01e3d7719b792b) | `terraform-providers.huaweicloud: 1.41.0 → 1.41.1`                                          |
| [`f3bf7e9a`](https://github.com/NixOS/nixpkgs/commit/f3bf7e9a0aa002147b79b664df0126a32e45acfc) | `terraform-providers.hetznerdns: 2.1.0 → 2.2.0`                                             |
| [`4a96ef0a`](https://github.com/NixOS/nixpkgs/commit/4a96ef0aff08a6b9f8297729db455bfe06685dd0) | `cariddi: 1.1.8 -> 1.1.9`                                                                   |
| [`caa50503`](https://github.com/NixOS/nixpkgs/commit/caa50503ca7d8269d6324fd99d5f2cfed750d73e) | `checkip: 0.40.4 -> 0.41.0`                                                                 |
| [`2d586d05`](https://github.com/NixOS/nixpkgs/commit/2d586d05339e4771cf11059880477dbb64342ad8) | `python310Packages.google-cloud-pubsub: 2.13.9 -> 2.13.10`                                  |
| [`984ace9d`](https://github.com/NixOS/nixpkgs/commit/984ace9dc84d64fcd92ed2863eb041f4dfcce2e5) | `python310Packages.gcal-sync: 0.11.0 -> 1.0.0`                                              |
| [`56a5d8ed`](https://github.com/NixOS/nixpkgs/commit/56a5d8ed7d8803c10bc764246e9f679c732a7fc9) | `python310Packages.globus-sdk: 3.12.0 -> 3.13.0`                                            |
| [`8bbbedd5`](https://github.com/NixOS/nixpkgs/commit/8bbbedd5a611c75951006f28ad36ae5d4067b4f2) | `gogdl: 0.3 -> 0.4`                                                                         |
| [`8499c9fa`](https://github.com/NixOS/nixpkgs/commit/8499c9fac80ce1c8fc434dc3fc34f4babd9bb99b) | `aliyun-cli: 3.0.128 -> 3.0.131`                                                            |
| [`7576e40a`](https://github.com/NixOS/nixpkgs/commit/7576e40a87a6ef7612baba3e826eaae1c65e0c3f) | `clj-kondo: 2022.10.05 -> 2022.10.14`                                                       |
| [`0badfc49`](https://github.com/NixOS/nixpkgs/commit/0badfc4936de7a895165ca170b422c443ca7e289) | `qt6.qtwebengine: correct how NIX_BUILD_CORES is propagated to the gn ninja`                |
| [`38ea9bc0`](https://github.com/NixOS/nixpkgs/commit/38ea9bc0834b59f59a7fe99a03f4bdd33e75077d) | `nixos/manual/kubernetes: re-enabling of insecure ports is no longer possible`              |
| [`6ec7298e`](https://github.com/NixOS/nixpkgs/commit/6ec7298ead8d41f44453c219848d2d5255371ec3) | `nixos/kubernetes: modularized tests`                                                       |
| [`ae712870`](https://github.com/NixOS/nixpkgs/commit/ae712870af1210578a7d272180772843640713b3) | `nixos/kubernetes: drop obsolete options/cmdline flags`                                     |
| [`f466f36d`](https://github.com/NixOS/nixpkgs/commit/f466f36d0246000eeb65d6400aeb8fa69d2d23f8) | `kubernetes: 1.23.12 -> 1.25.3`                                                             |
| [`234871ac`](https://github.com/NixOS/nixpkgs/commit/234871ac1ab2345ce01cd866238b09743e68061d) | `cloud-hypervisor: add debug info`                                                          |
| [`091da48c`](https://github.com/NixOS/nixpkgs/commit/091da48c7b3578e937c9b44637c8a365461d1884) | `hydrus: 502 -> 502a`                                                                       |
| [`08846dd6`](https://github.com/NixOS/nixpkgs/commit/08846dd662795b2e4e194727e517324853ab7f82) | `hydrus: add dateutil as dependency`                                                        |
| [`b0213a29`](https://github.com/NixOS/nixpkgs/commit/b0213a2995031f3a8c66983ca6f1c3aa0914364d) | `ruff: 0.0.75 -> 0.0.76`                                                                    |
| [`5f35f701`](https://github.com/NixOS/nixpkgs/commit/5f35f701b7bdec1dfb5bfd1a573ec83fbe61f282) | `gitsign: 0.3.1 -> 0.3.2`                                                                   |
| [`bfc85d53`](https://github.com/NixOS/nixpkgs/commit/bfc85d53af7675c7f9dd32a3954e9eac3a309f46) | `werf: 1.2.178 -> 1.2.180`                                                                  |
| [`6e7982fa`](https://github.com/NixOS/nixpkgs/commit/6e7982faec3b664add1549cb5024247fb6ad12bd) | `yaru-theme: 22.04.4 -> 22.10.3`                                                            |
| [`5caeff96`](https://github.com/NixOS/nixpkgs/commit/5caeff9641fd7517ed07c80746d0c773c342011c) | `linux-zen: 6.0.1-zen2 -> 6.0.2-zen1`                                                       |
| [`84127ced`](https://github.com/NixOS/nixpkgs/commit/84127ced601db76c93f3321f7c6855e77a007f5b) | `linux-lqx: 5.19.15-lqx2 -> 5.19.16-lqx2`                                                   |
| [`1b9ac29a`](https://github.com/NixOS/nixpkgs/commit/1b9ac29a0622d0476350761db7de9f9487583471) | `python310Packages.fakeredis: 1.9.3 -> 1.9.4`                                               |
| [`46769538`](https://github.com/NixOS/nixpkgs/commit/46769538fea0f156e3cd493a1d3d9e5d604236e2) | `vimPlugins.nvim-cmp: follow HEAD and update`                                               |
| [`dadcac57`](https://github.com/NixOS/nixpkgs/commit/dadcac57819f0b4c0e5bf4c0840eb063157838bd) | `jekyll: 4.2.0 -> 4.2.2`                                                                    |
| [`082cb4f7`](https://github.com/NixOS/nixpkgs/commit/082cb4f7666a045f1aa44784e5d79a27c1d5562c) | `cardinal: 22.09 -> 22.10`                                                                  |
| [`84019db8`](https://github.com/NixOS/nixpkgs/commit/84019db8efe1ad5d97c1bf18c29769d1caf631ec) | `muon: unstable-2022-09-24 -> 0.1.0`                                                        |
| [`dc8e74d9`](https://github.com/NixOS/nixpkgs/commit/dc8e74d91f9fe77871dc332bcdf04ca98a5f26f1) | `python310Packages.debian: 0.1.47 -> 0.1.48`                                                |
| [`69010454`](https://github.com/NixOS/nixpkgs/commit/690104549b91382e1e350530f69820f18ebf14c9) | `pulumi-bin: 3.42.0 -> 3.43.1`                                                              |
| [`1e8829c1`](https://github.com/NixOS/nixpkgs/commit/1e8829c1c041ae85e7deffc5ae06167bff8eec66) | `python310Packages.datasets: 2.6.0 -> 2.6.1`                                                |
| [`2d2eb1c0`](https://github.com/NixOS/nixpkgs/commit/2d2eb1c0fc829502590f1021bc970ea2332c1e36) | `coursier: 2.1.0-M5 -> 2.1.0-M7`                                                            |
| [`d8823403`](https://github.com/NixOS/nixpkgs/commit/d88234034d71f53d477a66644345ae9a12d28168) | `libyuv: fix & enable for darwin`                                                           |
| [`716cdd3a`](https://github.com/NixOS/nixpkgs/commit/716cdd3af15c0c1b61ad8510339d080c101be198) | `saml2aws: 2.36.0 -> 2.36.1`                                                                |
| [`b27589e6`](https://github.com/NixOS/nixpkgs/commit/b27589e6d4a90aef4c9300bc19cdd7c8faf88d58) | `rancher: 2.6.7 -> 2.6.9`                                                                   |
| [`8ebb9420`](https://github.com/NixOS/nixpkgs/commit/8ebb942007a5469fd92aa4a907cc3dfe85a5c1f5) | `haskellPackages: mark builds failing on hydra as broken`                                   |
| [`1445c564`](https://github.com/NixOS/nixpkgs/commit/1445c56426e2078a9ee606ca0b0a177589eb9209) | `termonad: remove top-level termonad-with-packages alias`                                   |
| [`f6d8a99f`](https://github.com/NixOS/nixpkgs/commit/f6d8a99ff9cc577a8f6652590f724382406529b7) | `uhttpmock: 0.5.0 → 0.5.5`                                                                  |
| [`100f55ec`](https://github.com/NixOS/nixpkgs/commit/100f55ecab89b8822cda768ecb43c766b64ce75c) | `pt2-clone: 1.51 -> 1.53`                                                                   |
| [`5743cf57`](https://github.com/NixOS/nixpkgs/commit/5743cf57de40f2912af381bca0e35497f369e1b7) | `airwindows-lv2: 5.0 -> 11.0`                                                               |
| [`653e881d`](https://github.com/NixOS/nixpkgs/commit/653e881d1c2b340b4cbdc08ce6bf8a5e8ba5d7c2) | `shticker-book-unwritten: 1.0.3 -> 1.2.0`                                                   |
| [`c76bbaa0`](https://github.com/NixOS/nixpkgs/commit/c76bbaa0f50d4a68213b0fd8150b26bd616b030e) | `nix-output-monitor: 1.1.3.0 -> 2.0.0.0`                                                    |
| [`97564704`](https://github.com/NixOS/nixpkgs/commit/975647043e5dc2237974103b5b485f3a8e71b0d5) | `opentelemetry-collector: 0.62.0 -> 0.62.1`                                                 |
| [`4eb8ac55`](https://github.com/NixOS/nixpkgs/commit/4eb8ac55c91e8ab8b842d1feec9364ae224b9995) | `SoliCurses: init at unstable-2022-02-13`                                                   |
| [`bfd27cde`](https://github.com/NixOS/nixpkgs/commit/bfd27cde5f082b77620f6517760b5a709986e908) | `bitwig-studio: 4.3.8 -> 4.4`                                                               |
| [`a0c27cf4`](https://github.com/NixOS/nixpkgs/commit/a0c27cf42fea076a7d8acaa6497be8c929b4d424) | `psi-plus: 1.5.1640 -> 1.5.1642`                                                            |
| [`4ac6c02f`](https://github.com/NixOS/nixpkgs/commit/4ac6c02fbd2745e44ded2cd6df5d888a56cc15b1) | `netbird: 0.9.7 -> 0.9.8`                                                                   |
| [`4a9250a8`](https://github.com/NixOS/nixpkgs/commit/4a9250a8b21f517d70d0565bc23e39dcc343ccc6) | `freeswitch: 1.10.7 -> 1.10.8`                                                              |
| [`7d1d10dc`](https://github.com/NixOS/nixpkgs/commit/7d1d10dccf939eff89c7b837377b1b390513c0d3) | `libks: 1.7.0 -> 1.8.0`                                                                     |
| [`4bb04a6c`](https://github.com/NixOS/nixpkgs/commit/4bb04a6c192cbef76290b024931b505121296e5f) | `rubyPackages: update`                                                                      |
| [`77a4c843`](https://github.com/NixOS/nixpkgs/commit/77a4c843f72214e74263a5c7ecb8f86eaf0ef59a) | `millet: 0.4.1 -> 0.4.2`                                                                    |
| [`a00b6e2f`](https://github.com/NixOS/nixpkgs/commit/a00b6e2fa6e716660bfeddf3282b64f597dcfa6f) | `gallery-dl: 1.23.2 -> 1.23.3`                                                              |
| [`5e988f3c`](https://github.com/NixOS/nixpkgs/commit/5e988f3c2873238484e4b4c5ae5d6db95e16af38) | `ncspot: 0.11.1 -> 0.11.2`                                                                  |
| [`cde78e0c`](https://github.com/NixOS/nixpkgs/commit/cde78e0cc0695f5da5df2183aa7b0d7e598a861e) | `netpbm: 11.0.0 -> 11.0.1`                                                                  |
| [`dd9882c1`](https://github.com/NixOS/nixpkgs/commit/dd9882c17cb5141abab5e532712b8d6218bfb66f) | `vimPlugins: resolve github repository redirects`                                           |
| [`76408dcd`](https://github.com/NixOS/nixpkgs/commit/76408dcd8870a515469493e05c7d78cc10aea2a8) | `vimPlugins: update`                                                                        |
| [`22ac96ba`](https://github.com/NixOS/nixpkgs/commit/22ac96ba3d7ea442962f60081317bd3b75366328) | `gitleaks: 8.14.1 -> 8.15.0`                                                                |
| [`8d0a5da0`](https://github.com/NixOS/nixpkgs/commit/8d0a5da0072b048c09b240a037b71f7dc249b9f1) | `haskellPackages.sv2v: Do Jailbreak`                                                        |
| [`ceb7570e`](https://github.com/NixOS/nixpkgs/commit/ceb7570e8ecbc13e223d8b63340a99ff182402ce) | `openasar: unstable-2022-10-02 -> unstable-2022-10-10`                                      |
| [`5b0a0774`](https://github.com/NixOS/nixpkgs/commit/5b0a0774819be007ce58eb8b25afe3d46e28a1ba) | `haskellPackages.haskellish: unbreak`                                                       |
| [`bdf18e72`](https://github.com/NixOS/nixpkgs/commit/bdf18e72328f5a1a7d1d3dc048179bcf071cb9ef) | `openjpeg: drop broken supports`                                                            |
| [`466fd143`](https://github.com/NixOS/nixpkgs/commit/466fd1439fe3cdcffd96a77eafdd1955389a2e55) | ``check-meta.nix: fix `checkMetaRecursively` option``                                       |
| [`491d60d4`](https://github.com/NixOS/nixpkgs/commit/491d60d4d46f070062eb396ed4597e5ac6cc02ba) | `nwg-panel: 0.7.8 -> 0.7.11`                                                                |
| [`d13cb238`](https://github.com/NixOS/nixpkgs/commit/d13cb23806895c29d5aefa1af77295a2d461f853) | `maintainers: add laalsaas`                                                                 |
| [`ff920c5f`](https://github.com/NixOS/nixpkgs/commit/ff920c5f7b736a7dd41f71a7d830340499c3df39) | `haskellPackages.cabal2nix-unstable: 2022-07-22 -> 2022-10-10`                              |
| [`da5ca3c2`](https://github.com/NixOS/nixpkgs/commit/da5ca3c24539083f7156103a06ef35f1e759dd00) | `git-annex: update sha256 for 10.20221003`                                                  |
| [`729243d8`](https://github.com/NixOS/nixpkgs/commit/729243d885eee4449a7fb6b6aedab928967f0473) | `vimPlugins.lazy-lsp-nvim: init at 2022-10-10`                                              |
| [`528fcc87`](https://github.com/NixOS/nixpkgs/commit/528fcc87626f1f6fa15fb5c8e8e097f33ebbea6e) | `armTrustedFirmware: Fix bintools 2.39 regression (LOAD segment with RWX)`                  |
| [`88c678ca`](https://github.com/NixOS/nixpkgs/commit/88c678cae81ce989c2c7d37cbeb0cc475cf97fc9) | `haskell.packages.ghc942.cabal2nix: mark as broken on aarch64-linux`                        |
| [`3356bbc3`](https://github.com/NixOS/nixpkgs/commit/3356bbc32a3fcba96337bd9fccda43aaafb04560) | `uboot: 2022.07 -> 2022.10`                                                                 |
| [`903b5751`](https://github.com/NixOS/nixpkgs/commit/903b57513e96a761a3efccdaef1f02f6b83c25ac) | `haskellPackages.snaplet-purescript: GHC9 compatibility`                                    |
| [`5523ff8d`](https://github.com/NixOS/nixpkgs/commit/5523ff8d7a7964485842f5e520c7f8ed42c5b501) | `clanlib: drop unused xlibsWrapper input`                                                   |
| [`26e666d3`](https://github.com/NixOS/nixpkgs/commit/26e666d33ce5351061bff37aafe15d3cb3a365e4) | `haskellPackages.espial: Apply patch to work with GHC 9.X`                                  |
| [`c0f308b7`](https://github.com/NixOS/nixpkgs/commit/c0f308b7872e90700c1e099e08314091275c8a2c) | `conky: use xorg.* packages directly instead of xlibsWrapper indirection`                   |
| [`78fe5b0a`](https://github.com/NixOS/nixpkgs/commit/78fe5b0a4fabb9b7e1bd560b146fde572ebed36d) | `gns3-gui,gns3-server: add anthonyroussel to maintainers`                                   |
| [`1ec792a0`](https://github.com/NixOS/nixpkgs/commit/1ec792a0dcb5ce9cf955d924b23c76574bcef4a2) | `gns3-gui,gns3-server: 2.2.31 -> 2.2.34`                                                    |
| [`9e9b7f4d`](https://github.com/NixOS/nixpkgs/commit/9e9b7f4d99086901f95d856fb8cdd63e7818fc6e) | `haskell.lib.compose.addOptparseApplicativeCompletionScripts: remove`                       |
| [`ac1f1ad0`](https://github.com/NixOS/nixpkgs/commit/ac1f1ad0e0a8cfd35db476529c82354e033a48cc) | `haskell: support cross in generateOptparseApplicativeCompletions`                          |
| [`e7b47a72`](https://github.com/NixOS/nixpkgs/commit/e7b47a72fef2eb23342cd4f395ac305b8afa1ad4) | `haskell.packages.ghc884.cabal-fmt: drop stale override`                                    |
| [`1fdd1a46`](https://github.com/NixOS/nixpkgs/commit/1fdd1a462b530ab7ec61bfcdeae7d1942a4e64e7) | `haskell.packages.ghc924.haskell-language-server: Fix eval by pinning ghc-exactprint`       |
| [`193ffabf`](https://github.com/NixOS/nixpkgs/commit/193ffabf5589d87ff35c32f0d90be11b8c5fd179) | `haskell.packages.ghc942.haskell-language-server: Enable hydra job`                         |
| [`dcda00d4`](https://github.com/NixOS/nixpkgs/commit/dcda00d4ac91823f7dd7ae96ba71f26ec188fbfb) | `haskell.packages.ghc942.haskell-language-server: Disable unsupported plugins to fix build` |
| [`d0474997`](https://github.com/NixOS/nixpkgs/commit/d0474997c548c664ed956af903ec20cb054250c3) | `haskellPackages.gnuidn: unmark as broken`                                                  |
| [`bbd00e86`](https://github.com/NixOS/nixpkgs/commit/bbd00e8632c232da12a610d53b53951c0441b18e) | `haskellPackages: regenerate package set based on current config`                           |
| [`c0078a4d`](https://github.com/NixOS/nixpkgs/commit/c0078a4d3026c687415d0a5511e688494093fde9) | `all-cabal-hashes: 2022-10-01T15:28:21Z -> 2022-10-05T14:24:18Z`                            |
| [`bbcc162a`](https://github.com/NixOS/nixpkgs/commit/bbcc162a42be96579ce25dd67b93f7cfad8b9f5c) | `haskellPackages: stackage LTS 19.25 -> LTS 19.27`                                          |
| [`ee335f7d`](https://github.com/NixOS/nixpkgs/commit/ee335f7dede27ac359c25d87b9346191bb3722a6) | `ffmpeg-full: don't disable rav1e`                                                          |
| [`e19150be`](https://github.com/NixOS/nixpkgs/commit/e19150be4fdc0cfb313560584467208b4117fad7) | `vintagestory: 1.16.5 -> 1.17.4`                                                            |
| [`1bc7c2dc`](https://github.com/NixOS/nixpkgs/commit/1bc7c2dcc93a14a286cad17891e9fe174e7294a8) | `swayr: 0.20.1 -> 0.22.0`                                                                   |
| [`1357f903`](https://github.com/NixOS/nixpkgs/commit/1357f9032706df952345e7f896b6f981ac32c402) | `maintainers: remove mkaito from serokell team`                                             |
| [`9f7e4020`](https://github.com/NixOS/nixpkgs/commit/9f7e40205ee83731c450c034953a067ee724e487) | ` nixos/virtualisation.oci-containers: follow podman-generated systemd units more closely`  |