### PR TITLE
chore(flake/pre-commit-hooks): `94b0f300` -> `e6c8efee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665584211,
-        "narHash": "sha256-Qc9zn43UjLpP823BP416hAsoaXugwWw+nKPVqsNhqdY=",
+        "lastModified": 1666160137,
+        "narHash": "sha256-8bQu+6poMzUyS2n3C1v3hkO6ZhRzj8Pf3CDCNckqQE4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "94b0f300dd9a23d4e851aa2a947a1511d3410e2d",
+        "rev": "e6c8efee1c108bb27522b9fd25b1cd0eb3288681",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                              |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
| [`48298faa`](https://github.com/cachix/pre-commit-hooks.nix/commit/48298faa3cba195b264e6cc92a4b054284489b37) | `chore(deps): bump cachix/install-nix-action from 17 to 18` |
| [`71d0c678`](https://github.com/cachix/pre-commit-hooks.nix/commit/71d0c678c3e0e527fbd6574838160f2eab04aa1a) | `chore(deps): bump cachix/cachix-action from 10 to 11`      |