### PR TITLE
chore(flake/nixpkgs): `104e8082` -> `32096899`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665940183,
-        "narHash": "sha256-cPe3F7CtnxU9YbJpc3Adl4d9kX+turqTv5FxM98i8vg=",
+        "lastModified": 1666109165,
+        "narHash": "sha256-BMLyNVkr0oONuq3lKlFCRVuYqF75CO68Z8EoCh81Zdk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "104e8082de1b20f9d0e1f05b1028795ed0e0e4bc",
+        "rev": "32096899af23d49010bd8cf6a91695888d9d9e73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                      |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`ac9cbf99`](https://github.com/NixOS/nixpkgs/commit/ac9cbf999d69f59dc6fa04af58339285ccf9d4b7) | `dasel: 1.27.1 -> 1.27.2`                                           |
| [`b5934423`](https://github.com/NixOS/nixpkgs/commit/b593442345ecbdf689a749a68bc89d5ec1cfe397) | `ocamlPackages.semver: init at 0.1.0`                               |
| [`4d9e7484`](https://github.com/NixOS/nixpkgs/commit/4d9e748454dbe09367def8a5ae02636d5059e063) | `imagemagick: 7.1.0-49 -> 7.1.0-51`                                 |
| [`5b000479`](https://github.com/NixOS/nixpkgs/commit/5b000479841ee5722061dd2980d5d3f66a28a208) | `ttmkfdir: fix cross`                                               |
| [`b4cce939`](https://github.com/NixOS/nixpkgs/commit/b4cce939b66baca81661489d7cc0ab2aef8fe190) | `waynergy: init at 0.0.13`                                          |
| [`58c51521`](https://github.com/NixOS/nixpkgs/commit/58c515211f1862ce73853042fb0a7aa264188ee8) | `rpcs3: 0.0.24-14241-92b08a4fa -> 0.0.24-14263-0737c788f`           |
| [`5c77b290`](https://github.com/NixOS/nixpkgs/commit/5c77b29073f0d679aee8056da3ced1cfb3d3aecb) | `arkade: 0.8.45 -> 0.8.46`                                          |
| [`a85d3675`](https://github.com/NixOS/nixpkgs/commit/a85d36756de44a0a4ea7d64ff6b19a8cf0bcccea) | `butane: 0.15.0 -> 0.16.0`                                          |
| [`eaa2608a`](https://github.com/NixOS/nixpkgs/commit/eaa2608a12c155bfa2432ef88f33159559ee28c0) | `horizon-eda: 2.3.1 -> 2.4.0`                                       |
| [`5c184f72`](https://github.com/NixOS/nixpkgs/commit/5c184f72db36bd193537c328b258bdf0ec2a523e) | `nali: 0.5.3 -> 0.6.0`                                              |
| [`e8f55b95`](https://github.com/NixOS/nixpkgs/commit/e8f55b9585878cfc45574157e908657a59bd5e0e) | `netbird: 0.9.8 -> 0.10.0`                                          |
| [`b0182138`](https://github.com/NixOS/nixpkgs/commit/b0182138bb97e71170bbabcbb4e01aff7a624865) | `sickgear: 0.25.46 -> 0.25.47`                                      |
| [`534b2ac6`](https://github.com/NixOS/nixpkgs/commit/534b2ac62731071463a57f9dde8355d47ed01523) | `nvc: 1.7.1 -> 1.7.2`                                               |
| [`c321a3bf`](https://github.com/NixOS/nixpkgs/commit/c321a3bf252a8f919306d66a12326577f4802314) | `gh: 2.17.0 -> 2.18.0`                                              |
| [`e97d77d4`](https://github.com/NixOS/nixpkgs/commit/e97d77d4023ffc8036e5d0ee23dcc57e57996c49) | `tree-sitter-grammars: update cpp grammar`                          |
| [`22b60461`](https://github.com/NixOS/nixpkgs/commit/22b6046192abd318d6d9a5b140144dbbe77abdad) | `glibc: Don't inject CoreFoundation RUNPATH on Darwin`              |
| [`e2627a7a`](https://github.com/NixOS/nixpkgs/commit/e2627a7af726c7ecbf243e959bec6f55b5b31d4c) | `flyctl: 0.0.413 -> 0.0.414`                                        |
| [`dafe0938`](https://github.com/NixOS/nixpkgs/commit/dafe0938f1f45cf2f71667f2858f69243cee5afa) | `felix-fm: 1.2.0 -> 1.3.0`                                          |
| [`46872026`](https://github.com/NixOS/nixpkgs/commit/46872026bdb05e1487923f66607c6d90c3f1cdea) | `dconf2nix: 0.0.11 -> 0.0.12`                                       |
| [`b9feca47`](https://github.com/NixOS/nixpkgs/commit/b9feca473080ee0ff3f176bf525d174e2251ed95) | `rekor-cli: 0.12.2 -> 1.0.0`                                        |
| [`c08efaf0`](https://github.com/NixOS/nixpkgs/commit/c08efaf08b427bc3d47d3b256d3e82b80279efbe) | `firefox: fix build on aarch64-linux by upstream patch`             |
| [`5d301014`](https://github.com/NixOS/nixpkgs/commit/5d30101409789a5dbc92068bf85d47a220e0661f) | `tflint: add withPlugins passthru`                                  |
| [`6f4f07d3`](https://github.com/NixOS/nixpkgs/commit/6f4f07d3b7f42137466f3fd4a6a976e0c3786703) | `ocamlPackages.class_group_vdf: init at 0.0.4 (#196366)`            |
| [`f8ec59a8`](https://github.com/NixOS/nixpkgs/commit/f8ec59a855b03ad92dbee8b263c7536b4cf393f6) | `ocamlPackages.bls12-381: 3.0.0 -> 4.0.0`                           |
| [`a7f9b63b`](https://github.com/NixOS/nixpkgs/commit/a7f9b63b5d48784474f1ba9669b14be92f51c15a) | `tflint-plugins, tflint-plugins.tflint-ruleset-aws: init at 0.17.1` |
| [`9b0a850c`](https://github.com/NixOS/nixpkgs/commit/9b0a850c57cad9f0beec43cfab3fed0c756d432f) | `crowdin-cli: 3.8.1 -> 3.9.0`                                       |
| [`1e007a29`](https://github.com/NixOS/nixpkgs/commit/1e007a2989a3803a95e86e06fae7f8f8a1e67b0b) | `checkinstall: fix build`                                           |
| [`ad63c266`](https://github.com/NixOS/nixpkgs/commit/ad63c266adfe6a11f12d7cf244c2e81ecef432be) | `autorestic: 1.7.3 -> 1.7.4`                                        |
| [`8d72d191`](https://github.com/NixOS/nixpkgs/commit/8d72d191cbb1168daf6d7e2d28e0f5b8f73584c6) | `gnome-weather: add darwin support`                                 |
| [`6be69c4f`](https://github.com/NixOS/nixpkgs/commit/6be69c4fd4f41b6f9566c40d83010cf5708008f5) | `vendir: 0.31.0 -> 0.32.0`                                          |
| [`16104523`](https://github.com/NixOS/nixpkgs/commit/16104523f445303137c150f5f81aae86aa5f1426) | `vaultwarden: 1.25.2 -> 1.26.0`                                     |
| [`7019a41b`](https://github.com/NixOS/nixpkgs/commit/7019a41bde414095cf840ff2f2ea130cc91f05fe) | `terraform-providers.tencentcloud: 1.78.4 → 1.78.5`                 |
| [`c6378950`](https://github.com/NixOS/nixpkgs/commit/c6378950db3c1e058e2ab2a12eb8fb9a63215b54) | `terraform-providers.aws: 4.34.0 → 4.35.0`                          |
| [`1876e0b4`](https://github.com/NixOS/nixpkgs/commit/1876e0b4d3e13e2befc7eb6cac94c2077e9892e7) | `terraform-providers.grafana: 1.29.0 → 1.30.0`                      |
| [`f2aef6e4`](https://github.com/NixOS/nixpkgs/commit/f2aef6e412906dc069d5e6f1934caad00ba9953b) | `terraform-providers.google-beta: 4.40.0 → 4.41.0`                  |
| [`9da52bf6`](https://github.com/NixOS/nixpkgs/commit/9da52bf6bdc91c551354e8b596df71c28deec8ea) | `terraform-providers.google: 4.40.0 → 4.41.0`                       |
| [`a0288320`](https://github.com/NixOS/nixpkgs/commit/a02883208ac461d89e9a8cbf40b84d697517de6f) | `terraform-providers.baiducloud: 1.15.10 → 1.15.11`                 |
| [`8af1ea6e`](https://github.com/NixOS/nixpkgs/commit/8af1ea6e9536259f5152161440b77235edcecb16) | `syft: 0.58.0 -> 0.59.0`                                            |
| [`fdf26804`](https://github.com/NixOS/nixpkgs/commit/fdf268048b8906c33ff14516c6ec95ed2982087e) | `subfinder: 2.5.3 -> 2.5.4`                                         |
| [`e56980b0`](https://github.com/NixOS/nixpkgs/commit/e56980b08cd447739b34d411c08a0fa90af9ae82) | `ccache: 4.6.3 -> 4.7`                                              |
| [`be7b4d9f`](https://github.com/NixOS/nixpkgs/commit/be7b4d9f3c6cb7a7ee2a31a1f661d6b78bfda87e) | `ruff: 0.0.79 -> 0.0.81`                                            |
| [`bb9c3f4d`](https://github.com/NixOS/nixpkgs/commit/bb9c3f4d17b576b1005b208ce137b739820339aa) | `python310Packages.fido2: 1.0.0 -> 1.1.0`                           |
| [`88eab1e4`](https://github.com/NixOS/nixpkgs/commit/88eab1e431cabd0ed621428d8b40d425a07af39f) | `lxqt.lxqt-policykit: fix missing meta.mainProgram`                 |
| [`0eaba988`](https://github.com/NixOS/nixpkgs/commit/0eaba988ebbafe17838c583c1113493f9b0bac63) | `oh-my-posh: 12.3.0 -> 12.3.3`                                      |
| [`f158817e`](https://github.com/NixOS/nixpkgs/commit/f158817e707486594e896b46e1067d7ce72428be) | `kcat: 1.7.0 -> 1.7.1`                                              |
| [`87bc633f`](https://github.com/NixOS/nixpkgs/commit/87bc633f7d1d01cb3c643b86bd5f42404f091594) | `o: 2.56.0 -> 2.57.0`                                               |
| [`9b8abf76`](https://github.com/NixOS/nixpkgs/commit/9b8abf76982ac508b3c6146d73bed7e9c992422d) | `python310Packages.coqui-trainer: 0.0.15 -> 0.0.16`                 |
| [`96f83a97`](https://github.com/NixOS/nixpkgs/commit/96f83a977bb326f1fbdf47b957761be40bb67f11) | `vimPlugins.vim-clap: fix cargoSha256`                              |
| [`d92142fd`](https://github.com/NixOS/nixpkgs/commit/d92142fdd4ae96dd8c5c60ba237a36e274344a91) | `vimPlugins.nvim-navic: init at 2022-09-30`                         |
| [`19b871dd`](https://github.com/NixOS/nixpkgs/commit/19b871dd867554eca0d28cda7af4d7e3becd94f4) | `vimPlugins: resolve github repository redirects`                   |
| [`890c8b70`](https://github.com/NixOS/nixpkgs/commit/890c8b7098d3e3469af057ebed135fad04454558) | `vimPlugins: update`                                                |
| [`011e3c19`](https://github.com/NixOS/nixpkgs/commit/011e3c19c86a51b1583cd364c49364471b08d59d) | `bibata-cursors-translucent: 1.1.1 -> 1.1.2`                        |
| [`ea762aca`](https://github.com/NixOS/nixpkgs/commit/ea762acac26c0c61ae50801210326c17ead94fac) | `clusterctl: 1.2.3 -> 1.2.4`                                        |
| [`143f42db`](https://github.com/NixOS/nixpkgs/commit/143f42db3bebdd330aefecd14657924da65cfd65) | `minio-client: 2022-10-09T21-10-59Z -> 2022-10-12T18-12-50Z`        |
| [`d5755584`](https://github.com/NixOS/nixpkgs/commit/d57555845e086a76c2c9ca6123ef70ed8ce019e8) | `fetchmail: add v7 and fix fetchmalconf`                            |
| [`56da918e`](https://github.com/NixOS/nixpkgs/commit/56da918ec58499865b38bf3550cd54a9d90bbed9) | `maintainers: add maxhero`                                          |
| [`9d27de81`](https://github.com/NixOS/nixpkgs/commit/9d27de8105d5f9493695711a574542bc051ae005) | `polymc: mark knownVulnerabilities OVE-20221017-0001`               |
| [`c164f7c0`](https://github.com/NixOS/nixpkgs/commit/c164f7c021e632614d0a95957cd4b3f795995dbf) | `ocamlPackages.re: 1.9.0 -> 1.10.4`                                 |
| [`86642cdb`](https://github.com/NixOS/nixpkgs/commit/86642cdb896a7899039b6152df2183ce12b04f09) | `python310Packages.asyauth: 0.0.5 -> 0.0.6`                         |
| [`d94984ca`](https://github.com/NixOS/nixpkgs/commit/d94984ca36404a5d7bc4f666477cc1f04d83a6b5) | `lefthook: 1.1.2 -> 1.1.3`                                          |
| [`6d442d21`](https://github.com/NixOS/nixpkgs/commit/6d442d2174ccbf4d3330c652f9633beb8c0eb755) | `linux-firmware: 20220913 -> 20221012`                              |
| [`c1d932f5`](https://github.com/NixOS/nixpkgs/commit/c1d932f54c17c5975acf2c664c5d641477004463) | `gnome-maps: add darwin support`                                    |
| [`7d2764c6`](https://github.com/NixOS/nixpkgs/commit/7d2764c6107964ee74046c170a9ea4cd2816090d) | `gjs: add darwin support`                                           |
| [`c9be470b`](https://github.com/NixOS/nixpkgs/commit/c9be470b34718e829714a2bf8a766064754f4e7d) | `picom-jonaburg: init at unstable-2022-03-19`                       |
| [`223c8b16`](https://github.com/NixOS/nixpkgs/commit/223c8b1644e5621e5a7a5b5aae1fafa47d1b0cad) | `gnunet: 0.17.2 -> 0.17.6`                                          |
| [`24de4fbc`](https://github.com/NixOS/nixpkgs/commit/24de4fbc1c840b12e9d1f63d80b475a7c0288e11) | `oxker: 0.1.5 -> 0.1.6`                                             |
| [`4435512d`](https://github.com/NixOS/nixpkgs/commit/4435512d97d84ca703a2adec42739b950c812d35) | `numix-icon-theme-square: 22.10.05 -> 22.10.17`                     |
| [`af3398a1`](https://github.com/NixOS/nixpkgs/commit/af3398a1c3a6b7ef6732a044e8c18f41e902aa36) | `numix-icon-theme-circle: 22.10.05 -> 22.10.17`                     |
| [`91d76738`](https://github.com/NixOS/nixpkgs/commit/91d76738b4009e6e1925eb600c82eb80aea6157e) | `klipper: unstable-2022-10-06 -> unstable-2022-10-17`               |
| [`dc529302`](https://github.com/NixOS/nixpkgs/commit/dc529302fecd1a4cfec568524135da1a49f5640b) | `nixos: add cachix watch-store service`                             |
| [`51f219b5`](https://github.com/NixOS/nixpkgs/commit/51f219b526a2b189a3c562291edf8849722bc869) | `jdt-language-server: 1.13.0 -> 1.16.0`                             |
| [`359901c3`](https://github.com/NixOS/nixpkgs/commit/359901c3abaf867c112b9640d543f81db0d2f890) | `todoman: disable failing test`                                     |
| [`a5366c28`](https://github.com/NixOS/nixpkgs/commit/a5366c287b92d9a76bb2bcba575a7523077d9d7d) | `xournalpp: 1.1.1 -> 1.1.2`                                         |
| [`d0e73c70`](https://github.com/NixOS/nixpkgs/commit/d0e73c7030f9bd89ec0de02a03f9c68fe6bd857b) | `duckscript: 0.8.15 -> 0.8.16`                                      |
| [`d5794f10`](https://github.com/NixOS/nixpkgs/commit/d5794f1085db9cdafe17b8bc5c911a658fd168ec) | `{libqalculate, qalculate-gtk}: add alyaeanyx as maintainer`        |
| [`5e45d969`](https://github.com/NixOS/nixpkgs/commit/5e45d96906d2faeb6b0a1809fad1c884ed0a54d1) | `tio: 2.0 -> 2.1`                                                   |
| [`12b49920`](https://github.com/NixOS/nixpkgs/commit/12b49920fc243aa314d5929a76d16f208fa0ad06) | `{libqalculate, qalculate-gtk}: 4.3.0 -> 4.4.0`                     |
| [`5a61f445`](https://github.com/NixOS/nixpkgs/commit/5a61f4450b06e32780350cb717f0911d07541cd4) | `unciv: 4.2.11 -> 4.2.13`                                           |
| [`76e1e908`](https://github.com/NixOS/nixpkgs/commit/76e1e908c1cbcf54b5a328af6e62a483f0637a60) | `nixos/modules/virtualisation: fix oci-containers with docker`      |
| [`dcc3f721`](https://github.com/NixOS/nixpkgs/commit/dcc3f7216fc08eab83adf070913212fe0f4ea65c) | `airwindows-lv2: 11.0 -> 12.0`                                      |
| [`4cced6b6`](https://github.com/NixOS/nixpkgs/commit/4cced6b69136b5429fd3f2747c02e36acdc3b63a) | `cypress: 10.8.0 -> 10.10.0`                                        |
| [`75104079`](https://github.com/NixOS/nixpkgs/commit/7510407930213de4dd34c1def536dc99ba891463) | `twitch-tui: fix darwin build`                                      |
| [`08481e8f`](https://github.com/NixOS/nixpkgs/commit/08481e8fda20e18851077ec455955e197a6af066) | `miniflux: 2.0.38 -> 2.0.39`                                        |
| [`7f094872`](https://github.com/NixOS/nixpkgs/commit/7f094872dca4db1707ef9dba2bf65fddeb8d2f7b) | `p910nd: fix darwin build`                                          |
| [`abbf922e`](https://github.com/NixOS/nixpkgs/commit/abbf922ed219e8137fe3d5529a155c803d698a98) | `libgrss: fix darwin build`                                         |
| [`8ab9072e`](https://github.com/NixOS/nixpkgs/commit/8ab9072e02fd28d8130c7ea7bf757df6aec50a5d) | `libfreefare: fix darwin build`                                     |
| [`0d7a8e28`](https://github.com/NixOS/nixpkgs/commit/0d7a8e28d06f1a63b6a48069bc3ba75a043e129a) | `pypy: fix executable name for 3.9`                                 |
| [`8619305e`](https://github.com/NixOS/nixpkgs/commit/8619305e150e2168e29be7445deb97323ef09677) | `fsql: 0.4.0 -> 0.5.0`                                              |
| [`176cfb2c`](https://github.com/NixOS/nixpkgs/commit/176cfb2c1c084a5ac9eca4d7649a8cea5c2686a1) | `nixpacks: 0.9.2 -> 0.10.3`                                         |
| [`cef3d09c`](https://github.com/NixOS/nixpkgs/commit/cef3d09c6e3baed5ae96002b4fa23b1afa4915e4) | `victoriametrics: 1.82.0 -> 1.82.1`                                 |
| [`1546bf64`](https://github.com/NixOS/nixpkgs/commit/1546bf64ad7f856f7c3c08c9b2f8d6e3ecdd9257) | `carapace: 0.17.0 -> 0.17.1`                                        |
| [`d0f98574`](https://github.com/NixOS/nixpkgs/commit/d0f9857448e77df50d1e0b518ba0e835b797532a) | `victoriametrics: enable on all platforms supported by go`          |
| [`bff138f4`](https://github.com/NixOS/nixpkgs/commit/bff138f49d8a14ece74a0ff65808232b6b702291) | `thunderbird-bin-unwrapped: 102.3.2 -> 102.3.3`                     |
| [`99034b20`](https://github.com/NixOS/nixpkgs/commit/99034b201cd0c9c87cbd2ef87e531ee87972992d) | `thunderbird-unwrapped: 102.3.2 -> 102.3.3`                         |
| [`aceb5cd6`](https://github.com/NixOS/nixpkgs/commit/aceb5cd69e9a5c4199098e07b936bc30f68ab192) | `rubyPackages.grpc: fix darwin build`                               |
| [`43c3a9fd`](https://github.com/NixOS/nixpkgs/commit/43c3a9fdf60266e7cbf268bcc86d62c49d6c2ac0) | `firefox-esr-102-unwrapped: 102.3.0esr -> 102.4.0esr`               |
| [`1268636e`](https://github.com/NixOS/nixpkgs/commit/1268636efb5f0061bd8bfd70ea04efc012427221) | `git-nomad: fix darwin build`                                       |
| [`31de4467`](https://github.com/NixOS/nixpkgs/commit/31de446787121dce2aa5f9cf2c3d57ef1df7b122) | `firefox-bin-unwrapped: 105.0.3 -> 106.0`                           |
| [`5ac348c7`](https://github.com/NixOS/nixpkgs/commit/5ac348c7f3a3451c2a4a30a84dce7010566aab2b) | `firefox-unwrapped: 105.0.3 -> 106.0`                               |
| [`138543af`](https://github.com/NixOS/nixpkgs/commit/138543af5e66be0a7a25623baa08ec3a90baa7c5) | `git-cinnabar: fix darwin build`                                    |
| [`ff3ab5b3`](https://github.com/NixOS/nixpkgs/commit/ff3ab5b325128ec55512831710cfa77740f07e56) | `rebar3: 3.18.0 -> 3.20.0`                                          |
| [`0149ddf7`](https://github.com/NixOS/nixpkgs/commit/0149ddf7a0988eba0a9c3a6fd1a32f90d2e6fc15) | `faiss: fix darwin build`                                           |
| [`b80a8e34`](https://github.com/NixOS/nixpkgs/commit/b80a8e34c7cd6e6432d4567d2fad1f22fbf354b4) | `fondu: fix darwin build`                                           |
| [`01e7ccf2`](https://github.com/NixOS/nixpkgs/commit/01e7ccf2c0b5f649a6ccd0f850a2ce762fd5b599) | `fetchmail: 6.4.33 -> 6.4.34`                                       |
| [`c6490c8b`](https://github.com/NixOS/nixpkgs/commit/c6490c8bfacfe214f55410c4a90edfdcc51b7f48) | `cproto: 4.7t -> 4.7u`                                              |
| [`8d7e9093`](https://github.com/NixOS/nixpkgs/commit/8d7e9093df88e0828523431d3815726112e29357) | `eclib: 20220621 -> 20221012`                                       |
| [`b9f3d3d3`](https://github.com/NixOS/nixpkgs/commit/b9f3d3d3ac2e9aad7b684da3c69d813b1723d2ae) | `ocamlPackages.mec: init at 0.1.0`                                  |
| [`a08de07a`](https://github.com/NixOS/nixpkgs/commit/a08de07a1f90da4683fbff21883df0133ce53d9a) | `ddosify: 0.8.3 -> 0.9.0`                                           |
| [`38064f1b`](https://github.com/NixOS/nixpkgs/commit/38064f1b4f56d06122024feb2e575832d23d7df5) | `cudatext: 1.172.5 -> 1.173.0`                                      |
| [`6fa94e7e`](https://github.com/NixOS/nixpkgs/commit/6fa94e7ea706caffd31f545504aaf13448fbbd52) | `janus-gateway: 1.0.4 -> 1.1.0`                                     |
| [`8e82f822`](https://github.com/NixOS/nixpkgs/commit/8e82f8228e4fbbc0ec9e1d0d930a9d9f493a8f24) | `cargo-nextest: 0.9.38 -> 0.9.39`                                   |
| [`1a23dc7f`](https://github.com/NixOS/nixpkgs/commit/1a23dc7fab2c810ba21b72165d72989eb7dc634d) | `python310Packages.twitterapi: 2.7.13 -> 2.8.1`                     |
| [`ea13f7cd`](https://github.com/NixOS/nixpkgs/commit/ea13f7cd4c08f578ab0a3d1db5993b29e6e83cbc) | `pypy: 7.3.7 -> 7.3.9`                                              |
| [`c4700249`](https://github.com/NixOS/nixpkgs/commit/c47002498ddafe450ac423109737161c1ef8469f) | `python310Packages.psygnal: enable tests`                           |
| [`c823391b`](https://github.com/NixOS/nixpkgs/commit/c823391b0332825cfba218745b17041dc60bf953) | `amiri: 0.117 → 0.900`                                              |
| [`fc6517a5`](https://github.com/NixOS/nixpkgs/commit/fc6517a55b5049156ebf92bb0e1ad7fc40fc22f4) | `ballerina: 2201.1.0 -> 2201.2.1`                                   |
| [`9e87c0b3`](https://github.com/NixOS/nixpkgs/commit/9e87c0b3764db6f9bb93b27dc7f0241d303b0264) | `python310Packages.jupyterlab_server: update disabled`              |
| [`d2af28d9`](https://github.com/NixOS/nixpkgs/commit/d2af28d94f13322a3c4bf4ed5c3917921040fcf5) | `python310Packages.flask-admin: disable failing tests`              |
| [`983480b9`](https://github.com/NixOS/nixpkgs/commit/983480b9de28adc9cdfc7d4fe6bc5636bf09f68f) | `python310Packages.pulumi-aws: 5.16.2 -> 5.17.0`                    |
| [`4a532389`](https://github.com/NixOS/nixpkgs/commit/4a53238964cf56abc30585a6f4d5edf37a146d43) | `python310Packages.psygnal: 0.3.5 -> 0.5.0`                         |
| [`8ccede8f`](https://github.com/NixOS/nixpkgs/commit/8ccede8feb6563c48eb6876a7d047448d6254dc4) | `terraform-providers.minio: 1.7.0 → 1.7.1`                          |
| [`cc1368a9`](https://github.com/NixOS/nixpkgs/commit/cc1368a92f4afbb0e719f5d22152e808d2462ac5) | `gringo: fix darwin build`                                          |
| [`c19e36ff`](https://github.com/NixOS/nixpkgs/commit/c19e36ff21870cac51a33dec83133cb949ab216d) | `folks: Remove unused dependencies`                                 |
| [`4db165bd`](https://github.com/NixOS/nixpkgs/commit/4db165bd2f32e1d346dee3bcd1fe583189e45613) | `gnome.gnome-tweaks: Drop libsoup dependency`                       |
| [`ae621db1`](https://github.com/NixOS/nixpkgs/commit/ae621db1ccc06381ef8b3a0b440e3823d496c1fb) | `gnome.gitg: drop libsoup dependency`                               |
| [`d5e64d13`](https://github.com/NixOS/nixpkgs/commit/d5e64d13f16efec0fa3b5429dab895d5a14020da) | `rpm: remove darwin from supported platforms`                       |
| [`66d7d0cb`](https://github.com/NixOS/nixpkgs/commit/66d7d0cbe4fa5f3488436721d96fc9bfc26b89bf) | `applgrid: fix darwin build`                                        |
| [`bc791b77`](https://github.com/NixOS/nixpkgs/commit/bc791b77b9753cbf1ceb0225cd281e45a0d85e7f) | `remove whitespace`                                                 |
| [`d5ae32c8`](https://github.com/NixOS/nixpkgs/commit/d5ae32c83ff28aedd7a6922631aad30684ec8316) | `Update pkgs/tools/misc/tere/default.nix`                           |
| [`5b6b539f`](https://github.com/NixOS/nixpkgs/commit/5b6b539f4fd81179e06f0720ee39e2faf97a1de5) | `gnome.sushi: Switch to libsoup 3`                                  |
| [`fbcf914c`](https://github.com/NixOS/nixpkgs/commit/fbcf914cf60d81757454214dc0e955dbdd775f14) | `cpu-x: 4.4.0 -> 4.5.0`                                             |
| [`b789ab3c`](https://github.com/NixOS/nixpkgs/commit/b789ab3c2497496f80819d1c1d7c8da1a498b306) | `gnome.gnome-software: Switch to libsoup 3`                         |
| [`7d254361`](https://github.com/NixOS/nixpkgs/commit/7d254361827af3181e3f7c090f83a8435b975d3b) | `ostree: Do not depend on GTK`                                      |
| [`453f5994`](https://github.com/NixOS/nixpkgs/commit/453f59940bf259fa85a9aa2795a5b60ef6512766) | `cargo-hf2: remove patch and unnecessary dependency`                |