### PR TITLE
chore(flake/nixpkgs): `32096899` -> `db25c4da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666109165,
-        "narHash": "sha256-BMLyNVkr0oONuq3lKlFCRVuYqF75CO68Z8EoCh81Zdk=",
+        "lastModified": 1666198336,
+        "narHash": "sha256-VTrWD8Bb48h2pi57P1++LuvZIgum3gSLiRzZ/8q3rg0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "32096899af23d49010bd8cf6a91695888d9d9e73",
+        "rev": "db25c4da285c5989b39e4ce13dea651a88b7a9d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`c6fba7c2`](https://github.com/NixOS/nixpkgs/commit/c6fba7c2def99bb0b9d024b52e980e4f5badfd70) | `beam-modules/fetch-rebar-deps: Fix incorrect usage of 'prePhases' attribute`    |
| [`b143fcf2`](https://github.com/NixOS/nixpkgs/commit/b143fcf25ce10d0c53be4fa2d176b903e25d55cb) | `python310Packages.runway-python: rename input`                                  |
| [`cd0efc8a`](https://github.com/NixOS/nixpkgs/commit/cd0efc8a4ca4d171c6ed720d342b1aaa01d77d14) | `python310Packages.aws-lambda-builders: 1.19.0 -> 1.20.0`                        |
| [`17970631`](https://github.com/NixOS/nixpkgs/commit/179706319fbdcbd78d916845073a4c0706dea086) | `oh-my-zsh: 2022-10-14 -> 2022-10-19 (#196736)`                                  |
| [`ec43390b`](https://github.com/NixOS/nixpkgs/commit/ec43390b8953785320899faa4ecf95694f4970c9) | `sbt-extras: 2022-10-03 -> 2022-10-17 (#196694)`                                 |
| [`d66de449`](https://github.com/NixOS/nixpkgs/commit/d66de449fc264e2ccfcdbeeca09564cfa2709e6f) | `python310Packages.dask-jobqueue: 0.8.0 -> 0.8.1`                                |
| [`ea8cf2e4`](https://github.com/NixOS/nixpkgs/commit/ea8cf2e486ab38e92c809891aa5de1be57a1e497) | `nixos/github-runners: support fine-grained personal access tokens`              |
| [`3937c0c4`](https://github.com/NixOS/nixpkgs/commit/3937c0c474fc2b945687933fcc8bafa3bf34f559) | `nextcloud-client: 3.6.0 -> 3.6.1`                                               |
| [`6e37ec0c`](https://github.com/NixOS/nixpkgs/commit/6e37ec0c483ec3e98f4122a58453db2507721667) | `sil-abyssinica: 1.500 → 2.100`                                                  |
| [`78be5507`](https://github.com/NixOS/nixpkgs/commit/78be5507bda1ffe2ee294c866f3e01d666651e8d) | `sil-padauk: 3.003 → 5.001`                                                      |
| [`11b3a26e`](https://github.com/NixOS/nixpkgs/commit/11b3a26ede1d578910d0a735a1784dbe3da94bfa) | `python3Packages.pyupgrade: update disabled`                                     |
| [`cd2ee5e1`](https://github.com/NixOS/nixpkgs/commit/cd2ee5e19edaf89d77070344553d79fb633a2b03) | `python3Packages.pyupgrade: 3.0.0 -> 3.1.0`                                      |
| [`c2cc9aea`](https://github.com/NixOS/nixpkgs/commit/c2cc9aeafdc4cc04b62da83bc93dd407e7a5f799) | `Use config name by default, falling back to attr name`                          |
| [`5dbd9c8e`](https://github.com/NixOS/nixpkgs/commit/5dbd9c8e021f100c13795d047abf7b1c63d125bb) | `hy.withPackages: override meta.mainProgram`                                     |
| [`fcd27dd0`](https://github.com/NixOS/nixpkgs/commit/fcd27dd0c331e613538fc8db1c466bd3f9aa2719) | `metasploit: 6.2.16 -> 6.2.22`                                                   |
| [`c20aed5e`](https://github.com/NixOS/nixpkgs/commit/c20aed5e61e3d7eba6b19d7794e674f350a5f894) | `postfix: add support for linux-6`                                               |
| [`cb5ff5fb`](https://github.com/NixOS/nixpkgs/commit/cb5ff5fbe23e1d23443d3820c54799ef561fdcaa) | `libreswan: 4.8 -> 4.9`                                                          |
| [`5acb61b4`](https://github.com/NixOS/nixpkgs/commit/5acb61b47e5fe30b6557c87fb1e7feda4c91eacf) | `yggdrasil: 0.4.4 -> 0.4.5`                                                      |
| [`eb34d4be`](https://github.com/NixOS/nixpkgs/commit/eb34d4bea199ce5118dad2ca3e6fca06bf2f238d) | `python310Packages.progressbar2: 4.0.0 -> 4.1.1`                                 |
| [`a2677804`](https://github.com/NixOS/nixpkgs/commit/a267780401e451ae8c693d961ccefb10a9b5e304) | `dnsproxy: 0.45.4 -> 0.46.0`                                                     |
| [`eaa3b795`](https://github.com/NixOS/nixpkgs/commit/eaa3b795f8c0b5a90807ccfd3bf18f57578e1138) | `python310Packages.adlfs: 2022.9.1 -> 2022.10.0`                                 |
| [`1bafb328`](https://github.com/NixOS/nixpkgs/commit/1bafb328311c95b38e1ffb7a9599938daea056c7) | `python310Packages.pylutron-caseta: 0.16.0 -> 0.17.0`                            |
| [`2d4d6124`](https://github.com/NixOS/nixpkgs/commit/2d4d61244a2ccb0ba6bb824e33d26fef78a147dc) | `crd2pulumi: 1.2.2 -> 1.2.3`                                                     |
| [`083295f6`](https://github.com/NixOS/nixpkgs/commit/083295f6e93d83203058368dfb498dbb3bb20fc0) | `python310Packages.pyotgw: 2.1.0 -> 2.1.1`                                       |
| [`9331c0c7`](https://github.com/NixOS/nixpkgs/commit/9331c0c772ebbc02179d56976a9778706c223a50) | `FHSEnv: export /etc/shells`                                                     |
| [`fb52eefb`](https://github.com/NixOS/nixpkgs/commit/fb52eefbe3f3e6583a2ba823091cd09d765790a4) | `python310Packages.sphinxcontrib-spelling: 7.6.1 -> 7.6.2`                       |
| [`22b0340d`](https://github.com/NixOS/nixpkgs/commit/22b0340d119656e88fd287c41fe7db37134c00d3) | `python310Packages.streamdeck: 0.9.2 -> 0.9.3`                                   |
| [`eac0db7c`](https://github.com/NixOS/nixpkgs/commit/eac0db7c6b9e8f00cd976e7012ebce62de3f35a4) | `python310Packages.spacy-pkuseg: 0.0.31 -> 0.0.32`                               |
| [`c9636e08`](https://github.com/NixOS/nixpkgs/commit/c9636e085b1d81c02487dc30432a2b7c8078a37d) | `python310Packages.snowflake-sqlalchemy: 1.4.2 -> 1.4.3`                         |
| [`27d41797`](https://github.com/NixOS/nixpkgs/commit/27d41797d8f5e8269cb742384ad25ef1309fcf1c) | `python310Packages.sigtools: 4.0.0 -> 4.0.1`                                     |
| [`8d3f1920`](https://github.com/NixOS/nixpkgs/commit/8d3f1920cfcb3730b43c9db945f0c01fee134dad) | `python310Packages.pyx: 0.15 -> 0.16`                                            |
| [`fbf83cda`](https://github.com/NixOS/nixpkgs/commit/fbf83cda379ff47cb7c9dbde72bbdce1fc1cf92e) | `build-fhs-userenv-bubblewrap: use -m not -f for readlink`                       |
| [`67c3fe62`](https://github.com/NixOS/nixpkgs/commit/67c3fe62d326b2ea70afc50e0521070f3de5da17) | `python310Packages.vowpalwabbit: 9.3.0 -> 9.5.0`                                 |
| [`669a364b`](https://github.com/NixOS/nixpkgs/commit/669a364bfc0ed6666c475f56247540524e8fdf28) | `python310Packages.types-pytz: 2022.4.0.0 -> 2022.5.0.0`                         |
| [`127724fc`](https://github.com/NixOS/nixpkgs/commit/127724fcfcd0668c6cc445a21625e91038835def) | `vimPlugins.scope-nvim: init at 2022-06-27`                                      |
| [`43ddc41d`](https://github.com/NixOS/nixpkgs/commit/43ddc41dfa8c25bcbc2299eb9229a3c1293a9d40) | `vimPlugins: resolve github repository redirects`                                |
| [`fd142f16`](https://github.com/NixOS/nixpkgs/commit/fd142f16232a0258c753f23b53301678f41b770f) | `vimPlugins: update`                                                             |
| [`e9dbf057`](https://github.com/NixOS/nixpkgs/commit/e9dbf057c838751ee37b85b267f13315283b6cdd) | `python310Packages.types-redis: 4.3.21.1 -> 4.3.21.2`                            |
| [`d7a40c4f`](https://github.com/NixOS/nixpkgs/commit/d7a40c4f0e4bd2f433771493b38c4494941549a0) | `python310Packages.types-dateutil: 2.8.19 -> 2.8.19.2`                           |
| [`5ae6fbdb`](https://github.com/NixOS/nixpkgs/commit/5ae6fbdbac090a1bd461c9cfb6e0bf8e78ddc02c) | `python310Packages.trimesh: 3.15.4 -> 3.15.5`                                    |
| [`8c19be78`](https://github.com/NixOS/nixpkgs/commit/8c19be78c9d8722c0384daa861cfcf0f400ce1a8) | `cargo-make: 0.36.1 -> 0.36.2`                                                   |
| [`744c68ec`](https://github.com/NixOS/nixpkgs/commit/744c68ec33dd792901a88dd9a86bee72c968f85e) | `discord-canary: 0.0.139 -> 0.0.140`                                             |
| [`cce8ccaa`](https://github.com/NixOS/nixpkgs/commit/cce8ccaa64bcd62ed32c3457c6aaf6fe8b056df0) | `babashka: 0.10.163 -> 1.0.164`                                                  |
| [`8227cccf`](https://github.com/NixOS/nixpkgs/commit/8227cccf9c234d1f31451146f655860b913aa2af) | `terraform-providers.cloudflare: 3.25.0 → 3.26.0`                                |
| [`22659c50`](https://github.com/NixOS/nixpkgs/commit/22659c50cf1cebd25c4ebf8f373785767d786377) | `cargo-show-asm: add tests`                                                      |
| [`72565864`](https://github.com/NixOS/nixpkgs/commit/725658648f8f2296c0e3d20e9cdc2b46399ac3cd) | `cargo-show-asm: init at 0.1.24`                                                 |
| [`1aa7d4e6`](https://github.com/NixOS/nixpkgs/commit/1aa7d4e6c61526606d9e26f939cdb60ec8f45fcd) | `octosql: 0.11.0 -> 0.11.1`                                                      |
| [`4ab06e32`](https://github.com/NixOS/nixpkgs/commit/4ab06e3223f4e543dc5ac11eaea9bc9d3170f3e9) | `ants: 2.4.1 -> 2.4.2`                                                           |
| [`69ccacbe`](https://github.com/NixOS/nixpkgs/commit/69ccacbea8eb0868e41bdaea972b391b0cf23c3d) | `warpd: 1.3.3 -> 1.3.4`                                                          |
| [`edba6d1a`](https://github.com/NixOS/nixpkgs/commit/edba6d1a861692598b3bad93c0475cffc6773976) | `jetbrains: update IDEs`                                                         |
| [`0c244fd4`](https://github.com/NixOS/nixpkgs/commit/0c244fd4cb18baa40b71458fa34bcd0f3c2a1108) | `nix-output-monitor: 2.0.0.1 -> 2.0.0.2`                                         |
| [`43ff8990`](https://github.com/NixOS/nixpkgs/commit/43ff899052f0d5e02812d7430cd79966ae548dd7) | `python310Packages.pytibber: 0.25.3 -> 0.25.4`                                   |
| [`6d758d08`](https://github.com/NixOS/nixpkgs/commit/6d758d08261781baf286a9db9be30e942d1f3afe) | `python310Packages.restfly: 1.4.6 -> 1.4.7`                                      |
| [`1d2bd9a1`](https://github.com/NixOS/nixpkgs/commit/1d2bd9a13b11b863648b6bfd8c34b513bebffd1b) | `netbird: add gtk3 to buildInputs`                                               |
| [`6279ab9c`](https://github.com/NixOS/nixpkgs/commit/6279ab9cba26c47d2a9578906f91277470b3c093) | `tree-wide: libayatana-{app,}indicator-gtk3 -> libayatana-{app,}indicator`       |
| [`ad5766dc`](https://github.com/NixOS/nixpkgs/commit/ad5766dca82a324b63fbc38c065ac94bd0829a35) | `libayatana-appindicator: 0.5.5 -> 0.5.91, convert to cmake, cleanup`            |
| [`24561142`](https://github.com/NixOS/nixpkgs/commit/24561142442800d633f251ccb568f7f7e00d182e) | `libayatana-indicator: 0.8.2 -> 0.9.2, convert to cmake, cleanup`                |
| [`07ba1649`](https://github.com/NixOS/nixpkgs/commit/07ba16496be853d9ee26e42b0d2159c6bd4e51cc) | `ayatana-ido: 0.8.2 -> 0.9.2, convert to cmake, cleanup`                         |
| [`5771d5c2`](https://github.com/NixOS/nixpkgs/commit/5771d5c234695f4cfcd840f90c36d36253246f48) | `python310Packages.elegy: remove constraint on Python and disable failing tests` |
| [`d86ccab2`](https://github.com/NixOS/nixpkgs/commit/d86ccab260800bac5fbcfc8ff15a6515b241bd74) | `wine: remove unrecognized flag --with-vkd3d`                                    |
| [`a1ad8f4e`](https://github.com/NixOS/nixpkgs/commit/a1ad8f4e0c9c39681bf73ebd4308f518544dbb1f) | `python310Packages.pyunifiprotect: 4.3.3 -> 4.3.4`                               |
| [`4a4b445f`](https://github.com/NixOS/nixpkgs/commit/4a4b445f4a103c0c51f95c45b7f34f74599096f7) | `libretro: unstable-2022-10-01 -> unstable-2022-10-18`                           |
| [`8dc48de2`](https://github.com/NixOS/nixpkgs/commit/8dc48de2752b6e19cc9ced838b084e3aea8a97f6) | `retroarch: 1.11.0 -> 1.12.0`                                                    |
| [`219aa8ff`](https://github.com/NixOS/nixpkgs/commit/219aa8ff22f467869628b2bd9d725e7d5509aa7a) | `gitlab: 15.4.1 -> 15.4.2 (#194767)`                                             |
| [`0801990c`](https://github.com/NixOS/nixpkgs/commit/0801990cff0f753777e3c487a9e4c279dc8fc9a5) | `python310Packages.face: switch to pytestCheckHook`                              |
| [`48627433`](https://github.com/NixOS/nixpkgs/commit/4862743392f7f9039de50de17277c1e99ea392d7) | `python310Packages.nbclassic: update disabled`                                   |
| [`36fd12ad`](https://github.com/NixOS/nixpkgs/commit/36fd12ad76a195a7a21d760984610bc0f106093e) | `python310Packages.libpyfoscam: disable on older Python releases`                |
| [`954a90c7`](https://github.com/NixOS/nixpkgs/commit/954a90c7d2bcdf8c539321eda3f8853f854fc296) | `python310Packages.azure-mgmt-datafactory: update disabled`                      |
| [`d93b5950`](https://github.com/NixOS/nixpkgs/commit/d93b59509cfbbdaec39896f7c19e61b9a033aba5) | `python3Packages.nvidia-ml-py: init 11.515.48 (#189028)`                         |
| [`01d2fab7`](https://github.com/NixOS/nixpkgs/commit/01d2fab7432373b6a658835b7674a58327bad495) | `harmonia: init at 0.2.0`                                                        |
| [`8c803180`](https://github.com/NixOS/nixpkgs/commit/8c803180cb9a104a884a056d6a1378966f4214dd) | `python310Packages.pykira: remove whitespace`                                    |
| [`12f072da`](https://github.com/NixOS/nixpkgs/commit/12f072da8ac12de161213e3999a0a4835da3f0b0) | `python310Packages.pykira: disable on older Python releases`                     |
| [`82a25672`](https://github.com/NixOS/nixpkgs/commit/82a25672575a1d724036260b9916b5cf464bc012) | `pleroma: fix captcha (#196626)`                                                 |
| [`d0f67f42`](https://github.com/NixOS/nixpkgs/commit/d0f67f4266a25ac02603409e17ff46c01e7c5f4f) | `pleroma: 2.4.3 -> 2.4.4 (#196625)`                                              |
| [`0bde74ad`](https://github.com/NixOS/nixpkgs/commit/0bde74adf077df5ca5a2276a33628034e0531157) | `python310Packages.pykira: 0.1.2 -> 0.1.3`                                       |
| [`0c116092`](https://github.com/NixOS/nixpkgs/commit/0c1160921e52592cf6be22442a88d062be235f06) | `wails: 2.0.0 -> 2.1.0`                                                          |
| [`5a5ab139`](https://github.com/NixOS/nixpkgs/commit/5a5ab13978390d2b98109b26cb7375886b21ff7c) | `pypiserver: 1.5.0 -> 1.5.1`                                                     |
| [`3d28d922`](https://github.com/NixOS/nixpkgs/commit/3d28d9229403845fed58893773d31373343e160b) | `purescript: 0.15.5 -> 0.15.6`                                                   |
| [`57bd8144`](https://github.com/NixOS/nixpkgs/commit/57bd8144bb89b17652461aa669e26eb81a19e75a) | `procs: 0.13.2 -> 0.13.3`                                                        |
| [`553c2a60`](https://github.com/NixOS/nixpkgs/commit/553c2a60385d0309b7e1db5e98585605290b4cbb) | `python310Packages.isbnlib: disable on older Python releases`                    |
| [`a8c12681`](https://github.com/NixOS/nixpkgs/commit/a8c126810cc7204d35f54d60ee395dabe815eeea) | `goreleaser: 1.11.5 -> 1.12.1`                                                   |
| [`9332419a`](https://github.com/NixOS/nixpkgs/commit/9332419a1d5840be380e10821f3d78538a5ac7c8) | `python310Packages.gdown: disable on older Python releases`                      |
| [`8646e61e`](https://github.com/NixOS/nixpkgs/commit/8646e61e1eb77f91438c171f057ad8a70ec6d89e) | `ddrescueview: 0.4alpha4 -> 0.4.5 (#195580)`                                     |
| [`0696229f`](https://github.com/NixOS/nixpkgs/commit/0696229f841bf8e59f70145dfbd02b522fd8658e) | `python310Packages.fastbencode: disable on older Python releases`                |
| [`1f126b2a`](https://github.com/NixOS/nixpkgs/commit/1f126b2a8606fe72bc477a3945d9cd2b04685753) | `python310Packages.angr: 9.2.22 -> 9.2.23`                                       |
| [`63916475`](https://github.com/NixOS/nixpkgs/commit/639164750174661b3a6bde49cc572a62e1a5330d) | `python310Packages.cle: 9.2.22 -> 9.2.23`                                        |
| [`2e7f4324`](https://github.com/NixOS/nixpkgs/commit/2e7f43244a597fbc08b20b9a6c740e3c861a80d4) | `python310Packages.claripy: 9.2.22 -> 9.2.23`                                    |
| [`66fa7183`](https://github.com/NixOS/nixpkgs/commit/66fa7183df1b48c2d31a63342438d34cdf7a0936) | `python310Packages.pyvex: 9.2.22 -> 9.2.23`                                      |
| [`0959ba3f`](https://github.com/NixOS/nixpkgs/commit/0959ba3fac4b236dedfe09da1cd15ce0049483a8) | `python310Packages.ailment: 9.2.22 -> 9.2.23`                                    |
| [`3be0b0fd`](https://github.com/NixOS/nixpkgs/commit/3be0b0fdc1bd1091b12bbba5a05e824c49c06fa6) | `python310Packages.archinfo: 9.2.22 -> 9.2.23`                                   |
| [`cebf59e9`](https://github.com/NixOS/nixpkgs/commit/cebf59e9f0d0d599d53918d55e36288f599acc9d) | `rebar3WithPlugins: update patches`                                              |
| [`749115d5`](https://github.com/NixOS/nixpkgs/commit/749115d59a971dbf6cac37756d23b24fe27bc0fa) | `okteto: 2.7.0 -> 2.8.0`                                                         |
| [`0b620e1c`](https://github.com/NixOS/nixpkgs/commit/0b620e1c2889dbd553b7f6727ba6095a91fdf542) | `python310Packages.isbnlib: 3.10.10 -> 3.10.12`                                  |
| [`c9dc6fb0`](https://github.com/NixOS/nixpkgs/commit/c9dc6fb0254b817cf6680cef9702996525ee0a88) | `nodePackages.prisma: 4.4.0 -> 4.5.0`                                            |
| [`329a651d`](https://github.com/NixOS/nixpkgs/commit/329a651d73447d6cac16b41a5de510e272a3a5f0) | `prisma-engines: 4.4.0 -> 4.5.0`                                                 |
| [`0c711688`](https://github.com/NixOS/nixpkgs/commit/0c711688ff985b881ae2bb088564246f2b6ece72) | `git-machete: 3.12.4 -> 3.12.5`                                                  |
| [`af411622`](https://github.com/NixOS/nixpkgs/commit/af411622fd0eea4d0485d1a0588fb53274c9bbde) | `tomlplusplus: init at 3.2.0`                                                    |
| [`fca080ea`](https://github.com/NixOS/nixpkgs/commit/fca080ea78379f0aaf3c0e15df05bef7b37023aa) | `dasel: 1.27.2 -> 1.27.3`                                                        |
| [`105e8974`](https://github.com/NixOS/nixpkgs/commit/105e8974c06bf299974d17c09c54800350cfdebe) | `broadcom_sta: fix build on linux 6.0 (#195392)`                                 |
| [`ab62aac6`](https://github.com/NixOS/nixpkgs/commit/ab62aac6bb414270685faed7914d4bf807fbff42) | `kind2: 0.2.77 -> 0.2.79`                                                        |
| [`380ae16a`](https://github.com/NixOS/nixpkgs/commit/380ae16a3a395fa5a2865d605fef881087a184c6) | `python3Packages.dnspythonchia: drop`                                            |
| [`e49db01d`](https://github.com/NixOS/nixpkgs/commit/e49db01d2069ef3ed78d557c6ad6bd426b86d806) | `gnomeExtensions.pop-shell: unstable-2022-03-25 -> unstable-2022-10-11`          |
| [`a8506443`](https://github.com/NixOS/nixpkgs/commit/a8506443eb9ff24225c567611ce2a49d9d3a4210) | `gnomeExtensions: run update-extensions.py`                                      |
| [`b18e4988`](https://github.com/NixOS/nixpkgs/commit/b18e4988e8e6e5251fb02311d4aaf0da35d00db0) | `pkgs.gnome43Extensions: expose GNOME 43 extensions`                             |
| [`e425499d`](https://github.com/NixOS/nixpkgs/commit/e425499d6189ac4d0e2341bb728276c9ddca0019) | `python310Packages.pglast: 3.14 -> 3.15`                                         |
| [`91f81838`](https://github.com/NixOS/nixpkgs/commit/91f81838a08a267ae5b2d71d5f1586ce8389b831) | `hvm: 1.0.88 -> 1.0.89`                                                          |
| [`a2474ce4`](https://github.com/NixOS/nixpkgs/commit/a2474ce493d33b9439f6b0170ce28a50b2ac518c) | `cargo-modules: 0.5.11 -> 0.5.12`                                                |
| [`6eb8e4e3`](https://github.com/NixOS/nixpkgs/commit/6eb8e4e31c3ccd44696b131e9d89517b5f2c4344) | `plasma5: 5.26.0 -> 5.26.1`                                                      |
| [`3f9ef2d4`](https://github.com/NixOS/nixpkgs/commit/3f9ef2d400c9faf8f143b4cab556fc4938cd9fff) | `python310Packages.packageurl-python: 0.10.3 -> 0.10.4`                          |
| [`41bd9d67`](https://github.com/NixOS/nixpkgs/commit/41bd9d6706bc9a90abe5a3eea0963df20525936d) | `gnomeExtensions.gsconnect: 50 -> 54`                                            |
| [`79829a7d`](https://github.com/NixOS/nixpkgs/commit/79829a7dcabc9a64ef433d1ecfe380c767976e33) | `go-swag: 1.8.6 -> 1.8.7`                                                        |
| [`26a338bb`](https://github.com/NixOS/nixpkgs/commit/26a338bbfd069b3f274ef3956e033bbfabbf3ad1) | `python3Packages.solo-python: 0.0.31 -> 0.1.1`                                   |
| [`35bd7ecf`](https://github.com/NixOS/nixpkgs/commit/35bd7ecf251591476917a7b6c99056ca5dda3288) | `hyprpaper: mark as broken on Aarch64`                                           |
| [`432b07e2`](https://github.com/NixOS/nixpkgs/commit/432b07e220698c5ae09511b62f9b65198e303622) | `hyprpaper: move to hyprwm/hyprpaper`                                            |
| [`ba041288`](https://github.com/NixOS/nixpkgs/commit/ba04128823cc719cbaea96cc8d98d7eecc51ac07) | `hyprpaper: unstable-2022-07-24 -> unstable-2022-09-30`                          |
| [`5cbb3a13`](https://github.com/NixOS/nixpkgs/commit/5cbb3a13776d4e86fe9190054b38d0d2dd668f54) | `hyprland: mark as broken on Aarch64`                                            |
| [`cb58081f`](https://github.com/NixOS/nixpkgs/commit/cb58081fae1805f79efa2a5f914ea390a140d955) | `python310Packages.libpyfoscam: 1.1 -> 1.2.1`                                    |
| [`77c96388`](https://github.com/NixOS/nixpkgs/commit/77c96388986106b4b40d1d158aa60bd08a332aa4) | `klipper: add numpy to buildInputs`                                              |
| [`aa7fc78e`](https://github.com/NixOS/nixpkgs/commit/aa7fc78e6c8f9263bd44ba16a1c372e18837b335) | `croc: 9.6.0 -> 9.6.1`                                                           |
| [`d5045a00`](https://github.com/NixOS/nixpkgs/commit/d5045a00255d8c1f03eb8e32ae9ff4002d9bb3d4) | `cloudfox: 1.7.1 -> 1.7.2`                                                       |
| [`71be0934`](https://github.com/NixOS/nixpkgs/commit/71be0934bb38ebde4ca926389ee78376b1699e1b) | `python310Packages.huawei-lte-api: 1.6.3 -> 1.6.4`                               |
| [`1f89b89e`](https://github.com/NixOS/nixpkgs/commit/1f89b89ec8867da75c8165d232240601cb49568f) | ``wrapFish: use `writeShellApplication` and add `runtimeInputs```                |
| [`b2c1a651`](https://github.com/NixOS/nixpkgs/commit/b2c1a651fac68ffdcdb5d82988bd0666c644a9ce) | `python310Packages.py-libzfs: init at 22.02.4`                                   |
| [`3e3301db`](https://github.com/NixOS/nixpkgs/commit/3e3301db787b57df5f2b9d03646531220b97d3cd) | `libreoffice: fix test and cleanup`                                              |
| [`321b031b`](https://github.com/NixOS/nixpkgs/commit/321b031b1499ae311a72904d0d809625284dd401) | `python310Packages.gdown: 4.5.1 -> 4.5.2`                                        |
| [`97537587`](https://github.com/NixOS/nixpkgs/commit/9753758728dce90796efedc1a11be702840e7523) | `python310Packages.gcal-sync: 1.0.0 -> 1.1.0`                                    |
| [`601989d4`](https://github.com/NixOS/nixpkgs/commit/601989d40d38a8a4c501fa385d9eebe3022acd4b) | `qalculate-qt: 4.3.0 -> 4.4.0`                                                   |
| [`8da5fd6e`](https://github.com/NixOS/nixpkgs/commit/8da5fd6e9659fb7da3577598e179fcf99de4db3c) | `polkadot: 0.9.29 -> 0.9.30`                                                     |
| [`87356efb`](https://github.com/NixOS/nixpkgs/commit/87356efbeab46f38376ceda667cb0108cf7be1a4) | `python310Packages.fastbencode: 0.0.12 -> 0.0.13`                                |
| [`36a0e92e`](https://github.com/NixOS/nixpkgs/commit/36a0e92ed37b10b539f26f20d6c04aa124de6e20) | `python310Packages.face: 20.1.1 -> 22.0.0`                                       |
| [`7db45269`](https://github.com/NixOS/nixpkgs/commit/7db45269d61846f1b4361e5a8f7a5ed976aa195f) | `nix-output-monitor: 2.0.0.0 -> 2.0.0.1`                                         |
| [`dd3cffe5`](https://github.com/NixOS/nixpkgs/commit/dd3cffe5417097ddd8f996219bf1991a9e7268a7) | `operator-sdk: 1.24.0 -> 1.24.1`                                                 |
| [`d5e1a54f`](https://github.com/NixOS/nixpkgs/commit/d5e1a54ffcb658e9c7705ff768695e650f2b942d) | `netbsd.uudecode: fix build on darwin`                                           |
| [`475107ae`](https://github.com/NixOS/nixpkgs/commit/475107ae6145311915bb0ccaa2f7b717ffe757aa) | `python310Packages.blebox-uniapi: 2.1.1 -> 2.1.2`                                |
| [`a3446c30`](https://github.com/NixOS/nixpkgs/commit/a3446c300ab1429c8b459171bf080b489f60ded1) | `gnomeExtensions.argos: init at 20220930`                                        |
| [`a99ab1fb`](https://github.com/NixOS/nixpkgs/commit/a99ab1fbc16dfdbe4922aa30357886fd5e09e7a0) | `nixos/printing: add services.printing.stateless option`                         |
| [`715ebc71`](https://github.com/NixOS/nixpkgs/commit/715ebc712b2abb5bd8210db794ab88777c8519fb) | `python310Packages.azure-mgmt-datafactory: 2.8.0 -> 2.8.1`                       |
| [`0d9ae0c8`](https://github.com/NixOS/nixpkgs/commit/0d9ae0c80620a54b386d3c1e0bace8654a2316ce) | `python310Packages.flask-restful: add comment to patch`                          |
| [`af01b6b7`](https://github.com/NixOS/nixpkgs/commit/af01b6b7660cd12912de8b34480f25d276d59a57) | `python310Packages.auth0-python: 3.23.1 -> 3.24.0`                               |
| [`d4e625df`](https://github.com/NixOS/nixpkgs/commit/d4e625df3f059d999604488afebc9bfaf9cd12a2) | `python310Packages.asana: 1.0.0 -> 2.0.0`                                        |
| [`2b690476`](https://github.com/NixOS/nixpkgs/commit/2b690476d2ff3191a86d8070d0171b246c297d69) | `libreoffice-fresh: 7.4.0.3 -> 7.4.2.3`                                          |
| [`e39db15a`](https://github.com/NixOS/nixpkgs/commit/e39db15a4b8852587b5d014d7d3881ad8835e8e3) | `libreoffice-still: 7.4.0.3 -> 7.4.2.3`                                          |
| [`7be2ecc9`](https://github.com/NixOS/nixpkgs/commit/7be2ecc97301907eb8ddfa194478d73e0193a2c8) | `libreoffice-*: drop poppler patches`                                            |
| [`001dd426`](https://github.com/NixOS/nixpkgs/commit/001dd426a075d3da0ad40fa84b85d1d87b497632) | `libreoffice-still: 7.2.6.2 -> 7.3.5.2`                                          |
| [`c4785c56`](https://github.com/NixOS/nixpkgs/commit/c4785c567e6b5c2ad330dc2f5d0e7333fe78a69a) | `libreoffice-fresh: 7.3.3.2 -> 7.4.0.3`                                          |
| [`d42ffcfd`](https://github.com/NixOS/nixpkgs/commit/d42ffcfd01567c8c35f07e8e184ebe97182e12fa) | `flexget: 3.3.35 -> 3.3.37`                                                      |
| [`06f1cdf5`](https://github.com/NixOS/nixpkgs/commit/06f1cdf56ce95b4cc47a35249e5dd62b43f8746b) | `peertube: create static gzip and brotli files`                                  |
| [`ba6bcaca`](https://github.com/NixOS/nixpkgs/commit/ba6bcacacca1725c1582e6be91f27c59cb54fe2b) | `gdlv: fix darwin build`                                                         |
| [`4862363a`](https://github.com/NixOS/nixpkgs/commit/4862363a179e6b5d23bfdff9811e015bec1b5cfc) | `cie-middleware-linux: init at 1.4.3.3`                                          |
| [`d3818bf8`](https://github.com/NixOS/nixpkgs/commit/d3818bf821ea4a6e297e03315834d9d37b19adbb) | `python310Packages.types-python-dateutil: 2.8.19 -> 2.8.19.1`                    |
| [`54bfd511`](https://github.com/NixOS/nixpkgs/commit/54bfd51169737bb43be7af2f217016153ca24908) | `cve: init at 1.0.0`                                                             |