### PR TITLE
chore(flake/nixpkgs): `db25c4da` -> `b7d8c687`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666198336,
-        "narHash": "sha256-VTrWD8Bb48h2pi57P1++LuvZIgum3gSLiRzZ/8q3rg0=",
+        "lastModified": 1666282307,
+        "narHash": "sha256-O1T2HGLARLKDLfdOmjPBfn3eC4cSIaQD71wUN4I/6/s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "db25c4da285c5989b39e4ce13dea651a88b7a9d4",
+        "rev": "b7d8c687782c8f9a1d425a7e486eb989654f6468",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                          |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`f14d4f4d`](https://github.com/NixOS/nixpkgs/commit/f14d4f4df26e3fed9ec9b012116fc81e95165410) | `ocamlPackages.findlib: 1.9.3 → 1.9.6`                                                  |
| [`fd15a97e`](https://github.com/NixOS/nixpkgs/commit/fd15a97ef6254675c143b184f77f4ad934e7e3be) | `ocamlPackages.mlgmp: remove at 20120224 (broken)`                                      |
| [`8920ea68`](https://github.com/NixOS/nixpkgs/commit/8920ea683ba9b60dbc01f7e2b409266ef6ae6da3) | `ocamlPackages.zed: 3.1.0 -> 3.2.0, ocamlPackages.lambdaterm: 3.2.0 -> 3.3.1 (#196362)` |
| [`62cc7966`](https://github.com/NixOS/nixpkgs/commit/62cc7966120a8cb873e6ff1e4c8a0314e948e419) | `gitAndTools.gex: init at 0.3.3`                                                        |
| [`3ab965d8`](https://github.com/NixOS/nixpkgs/commit/3ab965d8871d50e007e0f8b474128273f2cd8a56) | `mbtileserver: 0.8.2 -> 0.9.0`                                                          |
| [`5a1a454d`](https://github.com/NixOS/nixpkgs/commit/5a1a454d366d84f98b8d2ee6537fdf2f16b79037) | `gh: 2.18.0 -> 2.18.1`                                                                  |
| [`87be8c22`](https://github.com/NixOS/nixpkgs/commit/87be8c2279b6cdcc0fbbdedf3e0ef722e39fd115) | `podman: 4.2.1 -> 4.3.0`                                                                |
| [`d7e3fc52`](https://github.com/NixOS/nixpkgs/commit/d7e3fc529be9845ce99aa3dbe3f0da20d466f2ae) | `k9s: 0.26.6 -> 0.26.7`                                                                 |
| [`4cb785c1`](https://github.com/NixOS/nixpkgs/commit/4cb785c1dce703a1695719f90209b92a8f3bc6c8) | `vmagent: 1.82.0 -> 1.82.1`                                                             |
| [`4eb9655f`](https://github.com/NixOS/nixpkgs/commit/4eb9655f71b5698847256cdd2ab3cbb3eea56abc) | `bossa-arduino: init at 1.9.1-arduino2`                                                 |
| [`d5d9c085`](https://github.com/NixOS/nixpkgs/commit/d5d9c085f837728068f3730808bace6dc3788db8) | `python310Packages.scmrepo: 0.1.1 -> 0.1.2`                                             |
| [`0f4dad21`](https://github.com/NixOS/nixpkgs/commit/0f4dad21198723a22aba7bb28b259ad71ee64ea5) | `ocamlPackages.reason: 3.8.1 → 3.8.2`                                                   |
| [`dce82561`](https://github.com/NixOS/nixpkgs/commit/dce82561f75e7dad34d3bae947c19127327d7334) | `ocamlPackages.graphql_ppx: use dune 3`                                                 |
| [`edc4feb4`](https://github.com/NixOS/nixpkgs/commit/edc4feb452380ac8d0b6d4a7913e949d2e03294a) | `python310Packages.httpagentparser: disable on older Python releases`                   |
| [`ed1ad8c6`](https://github.com/NixOS/nixpkgs/commit/ed1ad8c6542a03295ecbc6a93487f67d76cbb292) | `python310Packages.portalocker: add pythonImportsCheck`                                 |
| [`c19ad106`](https://github.com/NixOS/nixpkgs/commit/c19ad1063f09ef0b3d74a64f335d9ef6327f9d46) | `topgrade: 9.0.1 -> 9.1.1`                                                              |
| [`1e9864c8`](https://github.com/NixOS/nixpkgs/commit/1e9864c85ebe6cf2fcc4dd0a7e5307a491ab549b) | `nixos/nixpkgs: Only error when nixpkgs options are actually used`                      |
| [`9487528b`](https://github.com/NixOS/nixpkgs/commit/9487528bab5cc1f8636657fde35c668aaa2c6cbd) | `gatekeeper: 3.9.2 -> 3.10.0`                                                           |
| [`cfe77e5d`](https://github.com/NixOS/nixpkgs/commit/cfe77e5de2c4ef23ff18116d99172c72f77988a5) | `bossa: 1.8 -> 1.9.1`                                                                   |
| [`29ab7ca3`](https://github.com/NixOS/nixpkgs/commit/29ab7ca398dc30462e33be9570f3889a2fa9bd67) | `esbuild: 0.15.11 -> 0.15.12`                                                           |
| [`49c46352`](https://github.com/NixOS/nixpkgs/commit/49c463523c04dcd118daf2a1cfb62088162195c4) | `ecs-agent: 1.64.0 -> 1.65.0`                                                           |
| [`34ee9229`](https://github.com/NixOS/nixpkgs/commit/34ee922953ddac321398b72c495f155c20f49fc3) | `drone-cli: 1.5.0 -> 1.6.0`                                                             |
| [`d82ac25f`](https://github.com/NixOS/nixpkgs/commit/d82ac25f9e584d2faa6d6fd5f144c5b125ea0d79) | `dnsproxy: 0.46.0 -> 0.46.1`                                                            |
| [`5bb9b0ac`](https://github.com/NixOS/nixpkgs/commit/5bb9b0ac517f51e907a2f00073a0b920961ba316) | `gnome.pomodoro: 0.21.1 -> 0.22.0`                                                      |
| [`e01eb5e5`](https://github.com/NixOS/nixpkgs/commit/e01eb5e52db0368615820515e3f735d7fb3ef79a) | `terrascan: 1.15.2 -> 1.16.0`                                                           |
| [`aaeaaa9e`](https://github.com/NixOS/nixpkgs/commit/aaeaaa9e28d3c78d2aad0fe7e8c42627ba9528bc) | `pantheon.wingpanel-indicator-keyboard: 2.4.0 -> 2.4.1`                                 |
| [`6fbde143`](https://github.com/NixOS/nixpkgs/commit/6fbde1430e1becc4ae028cf3f2c4ec4518623f96) | `python310Packages.async-upnp-client: 0.31.2 -> 0.32.0`                                 |
| [`52fb09e2`](https://github.com/NixOS/nixpkgs/commit/52fb09e26bf5ebc0b64783f5252e8e461a48b39d) | `python310Packages.patiencediff: enable tests`                                          |
| [`c235f8ea`](https://github.com/NixOS/nixpkgs/commit/c235f8eacdfdc2af5222e7326ae0df0634a05113) | `cloudfox: 1.7.2 -> 1.8.1`                                                              |
| [`f52d456f`](https://github.com/NixOS/nixpkgs/commit/f52d456fe25c65a5be1f217c29e064eefe9974ad) | `python310Packages.mne-python: disable on older Python releases`                        |
| [`b477d037`](https://github.com/NixOS/nixpkgs/commit/b477d037e66cf5e059b48ebb619b1eebc8561da9) | `ocamlPackages.tezos-bls12-381-polynomial: init at 0.1.2`                               |
| [`c948b4f0`](https://github.com/NixOS/nixpkgs/commit/c948b4f02bd2912a2d5850dc50b42b1bc5481251) | `checkSSLCert: 2.52.0 -> 2.53.0`                                                        |
| [`ad8236b4`](https://github.com/NixOS/nixpkgs/commit/ad8236b4357423ea7435073918a1c4d890937b78) | `bundletool: 1.11.2 -> 1.12.1`                                                          |
| [`6b25dc76`](https://github.com/NixOS/nixpkgs/commit/6b25dc763309707cb34f315a47bfc33b3a2c8de3) | `bun: 0.2.0 -> 0.2.1`                                                                   |
| [`7c36e0ee`](https://github.com/NixOS/nixpkgs/commit/7c36e0eeb82ac5de4b01087ba4ba5d55972a8aab) | `python310Packages.jupyter-repo2docker: update order`                                   |
| [`40cc6d49`](https://github.com/NixOS/nixpkgs/commit/40cc6d4969382ae3fc2154079df605d0bb01c412) | `python310Packages.google-cloud-datastore: disable on older Python releases`            |
| [`af0ffb8b`](https://github.com/NixOS/nixpkgs/commit/af0ffb8b0ceb30ace643b4c1e4d2595e0a25a408) | `python310Packages.pyatmo: 7.1.1 -> 7.2.0`                                              |
| [`083e8ed0`](https://github.com/NixOS/nixpkgs/commit/083e8ed0a72958e52ebfbe9a7c2b655d98800545) | `terraform-providers.spotinst: 1.85.0 → 1.85.1`                                         |
| [`3cc5127a`](https://github.com/NixOS/nixpkgs/commit/3cc5127a8dfe0942f69d83b818541e362b9b5d14) | `terraform-providers.opentelekomcloud: 1.31.5 → 1.31.6`                                 |
| [`6f519c1a`](https://github.com/NixOS/nixpkgs/commit/6f519c1aeed7f5d65918ec8f358af15b32894970) | `terraform-providers.newrelic: 3.5.0 → 3.5.1`                                           |
| [`0aaa7d56`](https://github.com/NixOS/nixpkgs/commit/0aaa7d56844e32f6f4d85bda1f65b11fb5f48fc0) | `terraform-providers.gridscale: 1.16.0 → 1.16.1`                                        |
| [`4b6d3203`](https://github.com/NixOS/nixpkgs/commit/4b6d32030f3849b4ffbfe2fa55f2d6ddf6b2978c) | `terraform-providers.auth0: 0.38.0 → 0.39.0`                                            |
| [`90529fc6`](https://github.com/NixOS/nixpkgs/commit/90529fc6198baeef65d84ceeda245af56670f8b2) | `python310Packages.pulumi-aws: 5.17.0 -> 5.18.0`                                        |
| [`bcbc1bd0`](https://github.com/NixOS/nixpkgs/commit/bcbc1bd0ec9d1cb5283678231a90a5e1c182063d) | `python310Packages.portalocker: 2.5.1 -> 2.6.0`                                         |
| [`895c3e37`](https://github.com/NixOS/nixpkgs/commit/895c3e3756f73121db46c90e594dbd53a81e849f) | `dioxus-cli: fix darwin build`                                                          |
| [`16e73cb9`](https://github.com/NixOS/nixpkgs/commit/16e73cb914bf7e1c732cef510e92d9c6af531ec6) | `python310Packages.pika: 1.3.0 -> 1.3.1`                                                |
| [`560c1ead`](https://github.com/NixOS/nixpkgs/commit/560c1eada8ccdaad87628b9e01a22b40a6d40a8d) | `python310Packages.pex: 2.1.110 -> 2.1.111`                                             |
| [`b17d484c`](https://github.com/NixOS/nixpkgs/commit/b17d484c7e556060c4945cdf34e2e439349ca4ea) | `python310Packages.patiencediff: 0.2.3 -> 0.2.6`                                        |
| [`9c1c9af5`](https://github.com/NixOS/nixpkgs/commit/9c1c9af5ede45bb5ea8ba2f4e6e38478263c66c1) | `zine: 0.6.0 -> 0.7.0`                                                                  |
| [`aba97b74`](https://github.com/NixOS/nixpkgs/commit/aba97b7409b05706997ba9bd85e728992532daf9) | `dirstalk: fix darwin build`                                                            |
| [`0c8ace38`](https://github.com/NixOS/nixpkgs/commit/0c8ace38c2336fea85b760f1383302ddd6d1d9f5) | `diffsitter: remove comment`                                                            |
| [`56f6d633`](https://github.com/NixOS/nixpkgs/commit/56f6d6337ed5d1227d63558318c4d5da211ba338) | `diffsitter: init at 0.7.1`                                                             |
| [`04580165`](https://github.com/NixOS/nixpkgs/commit/04580165b399da72144c02f7b11dff93e69191f9) | `python310Packages.mne-python: 1.2.0 -> 1.2.1`                                          |
| [`ce304a40`](https://github.com/NixOS/nixpkgs/commit/ce304a40be5c12a64f1c12e5cb7b321b46212e77) | `python310Packages.jupyterlab_server: 2.16.0 -> 2.16.1`                                 |
| [`142781c7`](https://github.com/NixOS/nixpkgs/commit/142781c701febaa62dbbcc8fb0ccb9fe8d5358cc) | `cyberchef: 9.46.5 -> 9.48.0`                                                           |
| [`7ef74d47`](https://github.com/NixOS/nixpkgs/commit/7ef74d47f83e9895943b30397a04a0f23746abb8) | `grpc-gateway: 2.11.3 -> 2.12.0`                                                        |
| [`cd68145f`](https://github.com/NixOS/nixpkgs/commit/cd68145f491561c3d94707dd7b340b4db3ff4dd4) | `python310Packages.jupyter-repo2docker: 2022.02.0 -> 2022.10.0`                         |
| [`742243f0`](https://github.com/NixOS/nixpkgs/commit/742243f041605ca091100958db31f9f1af051fc8) | `wesnoth: 1.16.5 -> 1.16.6`                                                             |
| [`374fdff1`](https://github.com/NixOS/nixpkgs/commit/374fdff12832a15d27818a6c26b452ddbde41d40) | `cilium-cli: 0.12.4 -> 0.12.5`                                                          |
| [`ab454567`](https://github.com/NixOS/nixpkgs/commit/ab454567ac66b2ecb7d9d8b6f29e25cd5d128b52) | `buildkit: 0.10.4 -> 0.10.5`                                                            |
| [`1a79b152`](https://github.com/NixOS/nixpkgs/commit/1a79b1529cbc259467cb5e79c9b7489c7be5be36) | `riot-redis: 2.18.1 -> 2.18.5`                                                          |
| [`73da0677`](https://github.com/NixOS/nixpkgs/commit/73da0677e783fa4a97d85bb346f1d4d8c095b569) | `argocd: 2.4.14 -> 2.4.15`                                                              |
| [`7f625a2b`](https://github.com/NixOS/nixpkgs/commit/7f625a2b52a677dc0062012bac9120450a16870b) | `glooctl: 1.12.21 -> 1.12.31`                                                           |
| [`072df9d7`](https://github.com/NixOS/nixpkgs/commit/072df9d737efaaeb15245046e2b95aebcf3518ff) | `mob: 3.2.0 -> 4.0.0`                                                                   |
| [`81674fb5`](https://github.com/NixOS/nixpkgs/commit/81674fb5651f53b2423d662a988ea8bdaa2fbaaf) | `micropad: 4.0.0 -> 4.1.0`                                                              |
| [`1e3fded1`](https://github.com/NixOS/nixpkgs/commit/1e3fded1cbbaaf33a7c78cac19bf99efab92a2f3) | `mold: 1.5.1 -> 1.6.0`                                                                  |
| [`f2792bef`](https://github.com/NixOS/nixpkgs/commit/f2792befd848418784a4c7d3f1082a326aafa745) | `roxctl: 3.72.0 -> 3.72.1`                                                              |
| [`1e714bc8`](https://github.com/NixOS/nixpkgs/commit/1e714bc88b5a7ddb5e288a855bf531b69d0e676b) | `desync: 0.9.2 -> 0.9.3`                                                                |
| [`6a1a5b4b`](https://github.com/NixOS/nixpkgs/commit/6a1a5b4b3a4dd366c2b13aa54aadf6387ad4bda5) | `jetty: 11.0.8 -> 11.0.12`                                                              |
| [`53c71f0c`](https://github.com/NixOS/nixpkgs/commit/53c71f0cc85e4b209f60bdd1d86ba59e052054eb) | `terraform: 1.3.2 -> 1.3.3`                                                             |
| [`ab411f16`](https://github.com/NixOS/nixpkgs/commit/ab411f16f1499bf0e300662d917f3c8f6447ecad) | `deno: 1.26.1 -> 1.26.2`                                                                |
| [`097aeaa9`](https://github.com/NixOS/nixpkgs/commit/097aeaa976cb9959423e3b68269f4a6ede71300c) | `python310Packages.google-cloud-datastore: 2.8.3 -> 2.9.0`                              |
| [`bda92092`](https://github.com/NixOS/nixpkgs/commit/bda9209265a08016e07dfc9e03c21a771c9549ea) | `hydrus: 502a -> 503`                                                                   |
| [`7809910f`](https://github.com/NixOS/nixpkgs/commit/7809910fd6c7bc5c19967b82ed7631a49fbd9463) | `python310Packages.types-setuptools: 65.5.0.0 -> 65.5.0.1`                              |
| [`bf3b90ba`](https://github.com/NixOS/nixpkgs/commit/bf3b90baa954fc7c838bf5b5e4e77300bb59d88c) | `python310Packages.twilio: 7.14.2 -> 7.15.0`                                            |
| [`34cc7ef1`](https://github.com/NixOS/nixpkgs/commit/34cc7ef1687cdb26912e3a4a71e5fe386a30d33c) | `python310Packages.httpagentparser: 1.9.3 -> 1.9.5`                                     |
| [`dfcb1937`](https://github.com/NixOS/nixpkgs/commit/dfcb1937b11cf2f514e04f28ff15580ed6af84ce) | `rnnoise-plugin: 0.91 -> 1.03`                                                          |
| [`c698ac40`](https://github.com/NixOS/nixpkgs/commit/c698ac409043e1cffdff3627d6c176294b4fd033) | `python310Packages.devolo-plc-api: 0.8.0 -> 0.8.1`                                      |
| [`58f578b1`](https://github.com/NixOS/nixpkgs/commit/58f578b1f01c49d0cfde3d1b11c630d5dfb90dc3) | `python310Packages.mypy-boto3-s3: 1.24.76 -> 1.24.94`                                   |
| [`d19c0a65`](https://github.com/NixOS/nixpkgs/commit/d19c0a65e46ac85e7a02cfb8cb37e1e8e98ef207) | `top-level/aliases: make mpv-with-scripts migration easier to understand`               |
| [`28726fad`](https://github.com/NixOS/nixpkgs/commit/28726fadc08fe5b5174a7b8429f94706333bbaa1) | `pdisk: init at 0.9`                                                                    |
| [`24c428a5`](https://github.com/NixOS/nixpkgs/commit/24c428a583ed596aafbd69c3a48ce5009246433b) | `mac-fdisk: init at 0.1.16`                                                             |
| [`b622a51a`](https://github.com/NixOS/nixpkgs/commit/b622a51a58e08265cda4bb6d096da15d31ab041b) | `home-assistant: update component-packages`                                             |
| [`08803b1c`](https://github.com/NixOS/nixpkgs/commit/08803b1c1e82b6bf8d62b1bc8698d678a9222f64) | `python310Packages.python-fullykiosk: init at 0.0.11`                                   |
| [`55708226`](https://github.com/NixOS/nixpkgs/commit/55708226401904b76c6b5d0c9b819d4b1d0a3e37) | `python310Packages.gdown: 4.5.2 -> 4.5.3`                                               |
| [`ecc04fdd`](https://github.com/NixOS/nixpkgs/commit/ecc04fdd85e632809ccdd89825677afecc388b5d) | `yq-go: 4.28.1 -> 4.28.2`                                                               |
| [`da669a62`](https://github.com/NixOS/nixpkgs/commit/da669a6281b509f68d1f5cd092f8cd495edc782a) | `goreleaser: 1.12.1 -> 1.12.2`                                                          |
| [`fba19d02`](https://github.com/NixOS/nixpkgs/commit/fba19d0290ca8a17fc595fbc4eb15d947a171931) | `maintainers: add mktip`                                                                |
| [`2122fc67`](https://github.com/NixOS/nixpkgs/commit/2122fc67adcf7977aca7c60fbb2cd3313ceed1be) | `circumflex: init at 2.6`                                                               |
| [`7d8cc18d`](https://github.com/NixOS/nixpkgs/commit/7d8cc18d2b81f56ad2861ada0076865dc5891736) | `protoc-gen-connect-go: 1.0.0 -> 1.1.0`                                                 |
| [`6b5ef072`](https://github.com/NixOS/nixpkgs/commit/6b5ef0729f743910b9cce1d3a28ceb03bdbd7886) | `oh-my-posh: 12.3.3 -> 12.6.1`                                                          |
| [`bf3412c2`](https://github.com/NixOS/nixpkgs/commit/bf3412c2c91a19d4d49e8887260c8cfb2bee9cb0) | `python310Packages.nbclassic: fix input name`                                           |
| [`2df2b528`](https://github.com/NixOS/nixpkgs/commit/2df2b52806129828a1dafaa093027f10817e5b3b) | `boost/generic.nix: reference commit-hash in comment`                                   |
| [`ac92b409`](https://github.com/NixOS/nixpkgs/commit/ac92b409b36f75fc2772c3333346174cb42d5352) | `boost: if isMips use the "cross compile" codepath unconditionally`                     |
| [`5e838fa9`](https://github.com/NixOS/nixpkgs/commit/5e838fa9ac7e635410de2cfbeb03d336db7e6347) | `netplan: fix cross compilation by replacing hardcoded pkg-config with`                 |
| [`49c81f00`](https://github.com/NixOS/nixpkgs/commit/49c81f001cf25561e512f0f0ba7c2bd81dd3a018) | `release-notes: state that PolyMC has been replaced`                                    |
| [`fcbbc69f`](https://github.com/NixOS/nixpkgs/commit/fcbbc69f132e4de3577c8f5114d0d841c55bcfcd) | `release-notes-2205: suggest using prismlauncher`                                       |
| [`879c2dff`](https://github.com/NixOS/nixpkgs/commit/879c2dffe14d82e5bd6b9e0fdcd7cba0d1ddffa0) | `polymc: remove`                                                                        |
| [`290d7b28`](https://github.com/NixOS/nixpkgs/commit/290d7b281960b1ff4ba5b63302978b5b75b097e6) | `prismlauncher: init at 5.0`                                                            |
| [`1adaf54c`](https://github.com/NixOS/nixpkgs/commit/1adaf54c9f0fa0f8c7ffdcf762df21579efc8e5b) | `snapper-gui: ValueError: Namespace Gtk not available`                                  |
| [`14c5caba`](https://github.com/NixOS/nixpkgs/commit/14c5cabab139ea6f83e5016fa2d8b6021e5f8928) | `python310Packages.niaarm: update disabled`                                             |
| [`9d109443`](https://github.com/NixOS/nixpkgs/commit/9d109443d644820a23cbf836ff40673f64c6badd) | `gosec: 2.13.1 -> 2.14.0`                                                               |
| [`83728a5c`](https://github.com/NixOS/nixpkgs/commit/83728a5c43b430ac8e733c25ad8abe37003e4502) | `python310Packages.aioswitcher: disable on older Python releases`                       |
| [`a3995cc7`](https://github.com/NixOS/nixpkgs/commit/a3995cc70206cc6fce6687e4b34fd298141f420c) | `python310Packages.fastbencode: 0.0.13 -> 0.0.15`                                       |
| [`c4444888`](https://github.com/NixOS/nixpkgs/commit/c44448888c840de947d19f33839c13f8ffc508d6) | `python310Packages.clize: add missing input`                                            |
| [`5e679251`](https://github.com/NixOS/nixpkgs/commit/5e679251a950e101d67a7c6495dee84c49180fec) | `python310Packages.django-celery-beat: disable on older Python releases`                |
| [`0492580b`](https://github.com/NixOS/nixpkgs/commit/0492580befa44c58e63c36d48ea99049c996d6f7) | `python310Packages.clize: remove postPatch`                                             |
| [`ec5d7e68`](https://github.com/NixOS/nixpkgs/commit/ec5d7e687a46f74493d752888c59f0baca3df289) | `python310Packages.azure-storage-file-share: adjust input`                              |
| [`d9236f98`](https://github.com/NixOS/nixpkgs/commit/d9236f98ea5146c30250fc22d873f7d1eff2eedb) | `python310Packages.azure-mgmt-containerservice: update disabled`                        |
| [`17b8bc63`](https://github.com/NixOS/nixpkgs/commit/17b8bc63eb2effe7796a7685f88cd649022e9605) | `python310Packages.atom: disable on older Python releases`                              |
| [`e0f2f2b6`](https://github.com/NixOS/nixpkgs/commit/e0f2f2b676c3d9ffadcb0a05b84328a4c0da0f99) | `ormolu/fourmolu: Fix build on aarch64-darwin`                                          |
| [`ce97b101`](https://github.com/NixOS/nixpkgs/commit/ce97b1017af497c45c2af0cd8ab5b4ecef607149) | `python310Packages.django-celery-beat: 2.3.0 -> 2.4.0`                                  |
| [`b362f100`](https://github.com/NixOS/nixpkgs/commit/b362f100ac6b0f4d0d20722478b48d91a84357a6) | `python310Packages.clize: 4.2.1 -> 5.0.0`                                               |
| [`a9bb6408`](https://github.com/NixOS/nixpkgs/commit/a9bb64088d0e3738b5ba88a1bb6879399590c3b6) | `python310Packages.azure-storage-file-share: 12.10.0 -> 12.10.1`                        |
| [`f1a6f374`](https://github.com/NixOS/nixpkgs/commit/f1a6f374f5123e9d884ff312647da2494ca48734) | `python310Packages.azure-mgmt-containerservice: 20.4.0 -> 20.5.0`                       |
| [`7b92f76b`](https://github.com/NixOS/nixpkgs/commit/7b92f76b27d056fa4a01a02ed386aecfe864db41) | `cargo-about: unbreak on darwin`                                                        |
| [`0516d23a`](https://github.com/NixOS/nixpkgs/commit/0516d23a627fa8d059f8d44ab7d62b6182b5a549) | `python310Packages.atom: 0.8.1 -> 0.8.2`                                                |
| [`3819d5f7`](https://github.com/NixOS/nixpkgs/commit/3819d5f7c09b8474985c1bc8eeb18faa09b13375) | `python310Packages.nc-dnsapi: init at 0.1.5`                                            |
| [`a835de25`](https://github.com/NixOS/nixpkgs/commit/a835de257813f0198069fff7d56c8fbf12b85a37) | `lemmeknow: 0.6.0 -> 0.7.0`                                                             |
| [`0f2a12df`](https://github.com/NixOS/nixpkgs/commit/0f2a12dffd7a057213ef0e38fc8bea04f1a7059a) | `python310Packages.aioswitcher: 3.0.3 -> 3.1.0`                                         |
| [`991732fe`](https://github.com/NixOS/nixpkgs/commit/991732fe47efc034869c484fc2dcb1d1aa7683ee) | `flyctl: 0.0.414 -> 0.0.415`                                                            |
| [`c04184ba`](https://github.com/NixOS/nixpkgs/commit/c04184ba16990165d76f678a78f4d4dc7f68dd4b) | `mkvtoolnix: 70.0.0 -> 71.1.0`                                                          |
| [`01027ad0`](https://github.com/NixOS/nixpkgs/commit/01027ad07d3089bdda10afe2c5672e431f0d9aa7) | `faas-cli: 0.14.10 -> 0.14.11`                                                          |
| [`6aa99d48`](https://github.com/NixOS/nixpkgs/commit/6aa99d482b28885ece42d9a62fbd29629aceba22) | `ddcutil: 1.3.0 -> 1.3.2`                                                               |
| [`13bd270b`](https://github.com/NixOS/nixpkgs/commit/13bd270b74e8aa03434be4a5d7f507c6dc5baf02) | `libebml: 1.4.2 -> 1.4.4`                                                               |
| [`9bfaebda`](https://github.com/NixOS/nixpkgs/commit/9bfaebda3e120fe4a72b91151afb9c057cd06e01) | `libmatroska: 1.6.3 -> 1.7.1`                                                           |
| [`b75b6bd8`](https://github.com/NixOS/nixpkgs/commit/b75b6bd8cb6b746bed07e4f87a99df618573e11a) | `python3Packages.aiounifi: 39 -> 40`                                                    |
| [`ea8a9631`](https://github.com/NixOS/nixpkgs/commit/ea8a9631c4c46fd1ffa9e91c2488a93b7d9a9642) | `sc-controller: 0.4.8.7 -> 0.4.8.9`                                                     |
| [`53580d9f`](https://github.com/NixOS/nixpkgs/commit/53580d9f09d24c749c4fce323888bd7df8b4b6b3) | `389-ds-base: 2.0.7 -> 2.3.0`                                                           |
| [`2b44223d`](https://github.com/NixOS/nixpkgs/commit/2b44223dff38ff42bce44945e5df0138f60d5519) | `dupe-krill: init at 1.4.8`                                                             |
| [`0cda744e`](https://github.com/NixOS/nixpkgs/commit/0cda744e43987ffda1963fba33663a70d230279b) | `pantheon.wingpanel: 3.0.2 -> 3.0.3`                                                    |
| [`b6910964`](https://github.com/NixOS/nixpkgs/commit/b6910964819e1c068a956aa2b71b0cad886efd83) | `maintainers: add wentam`                                                               |
| [`46539f80`](https://github.com/NixOS/nixpkgs/commit/46539f80fd65bd1007ed090129533959f312eb6f) | `proycon-wayout: init at 0.1.3`                                                         |
| [`43026e02`](https://github.com/NixOS/nixpkgs/commit/43026e022da38fe5f457e284aeff185b66292ba9) | `pantheon.wingpanel-indicator-datetime: 2.4.0 -> 2.4.1`                                 |
| [`9a497478`](https://github.com/NixOS/nixpkgs/commit/9a497478d20be52b521b7e95c0cbc167621ad5c9) | `pantheon.wingpanel-indicator-network: 2.3.3 -> 2.3.4`                                  |
| [`0bd004a9`](https://github.com/NixOS/nixpkgs/commit/0bd004a96a4819bad73a7a747a2616e0afbbe398) | `pantheon.wingpanel-indicator-nightlight: 2.1.0 -> 2.1.1`                               |
| [`7e18864e`](https://github.com/NixOS/nixpkgs/commit/7e18864e17987d2238eeec6ea4d145fbbd896e96) | `pantheon.wingpanel-indicator-notifications: 6.0.6 -> 6.0.7`                            |
| [`ddf4773d`](https://github.com/NixOS/nixpkgs/commit/ddf4773de88282d1720de82002749853f11c9b14) | `pantheon.wingpanel-indicator-session: 2.3.0 -> 2.3.1`                                  |
| [`dbd20144`](https://github.com/NixOS/nixpkgs/commit/dbd2014438fc4780648222cd2cce1ea3a90150a2) | `pantheon.wingpanel-indicator-a11y: 1.0.0 -> 1.0.1`                                     |
| [`27f0fec4`](https://github.com/NixOS/nixpkgs/commit/27f0fec421a01c987763d79287fe697f751cfb34) | `python310Packages.niaarm: 0.2.0 -> 0.2.2`                                              |
| [`05a899f4`](https://github.com/NixOS/nixpkgs/commit/05a899f4c70cbb84bec437a7878e0677da7e8b3b) | `doctl: 1.83.0 -> 1.84.0`                                                               |
| [`b32db0ec`](https://github.com/NixOS/nixpkgs/commit/b32db0ec02694e481190a603785e948bc84f8a51) | `dovecot: build with openssl 3.0`                                                       |
| [`e3e4dbd7`](https://github.com/NixOS/nixpkgs/commit/e3e4dbd72eb56cefa8e6938a4e7201bc77edb16e) | `cargo-ui: unbreak on darwin`                                                           |
| [`7c0cf03e`](https://github.com/NixOS/nixpkgs/commit/7c0cf03e64f99f2bc123a005578b01e21f8865f9) | `matrix-synapse: 1.68.0 -> 1.69.0`                                                      |
| [`544a7f35`](https://github.com/NixOS/nixpkgs/commit/544a7f3577f1b5124e0ef678cbc433f453b6dfb0) | `vtm: 0.9.3 -> 0.9.6a`                                                                  |
| [`e5cc6e7c`](https://github.com/NixOS/nixpkgs/commit/e5cc6e7c0697ad4b092d38924241d6e3bb39dc4c) | `kde/gear: 22.08.1 -> 22.08.2`                                                          |
| [`b044727e`](https://github.com/NixOS/nixpkgs/commit/b044727ea9452bc1342811c39d29ca52dea60b68) | `terragrunt: 0.39.1 -> 0.39.2`                                                          |