### PR TITLE
chore(flake/nixpkgs): `b7d8c687` -> `301aada7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666282307,
-        "narHash": "sha256-O1T2HGLARLKDLfdOmjPBfn3eC4cSIaQD71wUN4I/6/s=",
+        "lastModified": 1666377499,
+        "narHash": "sha256-dZZCGvWcxc7oGnUgFVf0UeNHsJ4VhkTM0v5JRe8EwR8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b7d8c687782c8f9a1d425a7e486eb989654f6468",
+        "rev": "301aada7a64812853f2e2634a530ef5d34505048",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`c075296b`](https://github.com/NixOS/nixpkgs/commit/c075296bff5ab1bc412e43e8a661a61032126040) | `inlyne: 0.2.0 -> 0.2.1`                                                                           |
| [`bd3acf73`](https://github.com/NixOS/nixpkgs/commit/bd3acf7393077b15836816fd9856d16c2ffe6ed9) | `amarok: add breeze-icons to be a fallback for when there are no globally`                         |
| [`c54a2803`](https://github.com/NixOS/nixpkgs/commit/c54a28030f9f0268c7575d1f6a6daa44da75ef34) | `nixos/httpd: Make option adminAddr optional`                                                      |
| [`7987c0b6`](https://github.com/NixOS/nixpkgs/commit/7987c0b6ca182d22179c91a58fa8fe0a0d9f9bd2) | `odo: update meta data`                                                                            |
| [`0eceb37a`](https://github.com/NixOS/nixpkgs/commit/0eceb37a6c6ff38ac9269056ebfd65f6d71d9333) | `hikounomizu: build data in parallel`                                                              |
| [`05bfaaa4`](https://github.com/NixOS/nixpkgs/commit/05bfaaa416fa7afc42f317fd5ced929b282842ef) | `ocaml-lsp: 1.12 -> 1.14`                                                                          |
| [`7eb4d827`](https://github.com/NixOS/nixpkgs/commit/7eb4d82785ac568b84f8261a31ea814dbeb6e30a) | `ligo: 0.47.0 -> 0.53.0`                                                                           |
| [`202ea673`](https://github.com/NixOS/nixpkgs/commit/202ea673438c553ff8868a545d9c41c7c2f7d2c5) | `ocamlPackages.mec: Use dune 3`                                                                    |
| [`dc0be730`](https://github.com/NixOS/nixpkgs/commit/dc0be730765ce529790f4bbe4a69c209ad424e78) | `python310Packages.life360: 5.1.1 -> 5.2.0`                                                        |
| [`834c6241`](https://github.com/NixOS/nixpkgs/commit/834c6241a7bb710c249efba0b0513aaf88c1976a) | `python310Packages.nomadnet: 0.2.4 -> 0.2.5`                                                       |
| [`81437922`](https://github.com/NixOS/nixpkgs/commit/81437922b9da7560a98b5b757f65ae94c7ab617e) | `python310Packages.lxmf: 0.2.0 -> 0.2.1`                                                           |
| [`4d268b7b`](https://github.com/NixOS/nixpkgs/commit/4d268b7b39df9304299000e1affa95b76594dff3) | `python310Packages.rns: 0.3.14 -> 0.3.16`                                                          |
| [`a86e080f`](https://github.com/NixOS/nixpkgs/commit/a86e080fa4639a0ea7c9dc6855367f1266311342) | `nixosTests.nscd: add nsncd specialisation`                                                        |
| [`e7bc3e75`](https://github.com/NixOS/nixpkgs/commit/e7bc3e750410e352dff35f202713aeb11b6ce0db) | `nixosTests.nscd: dump nscd socket info with sockdump`                                             |
| [`aee40c2d`](https://github.com/NixOS/nixpkgs/commit/aee40c2d8a2327248b8f01c824ce0ed0bcf6ba28) | `nixos/nscd: add enableNsncd option`                                                               |
| [`fed3280a`](https://github.com/NixOS/nixpkgs/commit/fed3280a7def7299858be67a822ff6d078b88f5a) | `python310Packages.azure-mgmt-resource: disable on older Python releases`                          |
| [`c38df883`](https://github.com/NixOS/nixpkgs/commit/c38df8834b849cafe65cabe0f2aedb6cb8fc6b5a) | `bindfs: 1.17.0 -> 1.17.1`                                                                         |
| [`4f9a7549`](https://github.com/NixOS/nixpkgs/commit/4f9a754936402099cd0d4ebe30e29c9d654d3d34) | `bdf2psf: 1.210 -> 1.211`                                                                          |
| [`fca35adf`](https://github.com/NixOS/nixpkgs/commit/fca35adf039a582fc0d7f9b80cbb1150d76b2df5) | `calibre-web: don't use the flask_login alias`                                                     |
| [`585392ee`](https://github.com/NixOS/nixpkgs/commit/585392ee2aa5c79ebfb323d470f17537962d7432) | `python310Packages.casbin: 1.17.1 -> 1.17.2`                                                       |
| [`0b8181e2`](https://github.com/NixOS/nixpkgs/commit/0b8181e2640ddb98ac1c4e76cd5e8e68dde4dd79) | `ocamlPackages.torch: 0.14 → 0.15`                                                                 |
| [`3ccff148`](https://github.com/NixOS/nixpkgs/commit/3ccff148e63543187506a4e93402f8d853ffdbc9) | `dsq: 0.22.0 -> 0.23.0`                                                                            |
| [`73892e75`](https://github.com/NixOS/nixpkgs/commit/73892e750c6fc11d382a8550f506540c81968d3a) | `python310Packages.azure-mgmt-resource: 21.2.0 -> 21.2.1`                                          |
| [`494f57ce`](https://github.com/NixOS/nixpkgs/commit/494f57ce057ac8a9d3cd153de9f7177e60f4b9c1) | `checkip: 0.41.0 -> 0.42.0`                                                                        |
| [`66e6323f`](https://github.com/NixOS/nixpkgs/commit/66e6323fc5a9a9e18cea7ccaa9ca5022da665a6f) | `checkSSLCert: 2.53.0 -> 2.54.0`                                                                   |
| [`328c892e`](https://github.com/NixOS/nixpkgs/commit/328c892e1b088d6df09e53ddfd97b7cde7717d70) | `terraform-providers.aws: 4.35.0 → 4.36.0`                                                         |
| [`f496c4a8`](https://github.com/NixOS/nixpkgs/commit/f496c4a8b7ee8e88107e5633e6ffdc230664ee86) | `terraform-providers.yandex: 0.80.0 → 0.81.0`                                                      |
| [`5f360883`](https://github.com/NixOS/nixpkgs/commit/5f3608836a4499432995c779b2ab50a9a550519d) | `terraform-providers.nomad: 1.4.18 → 1.4.19`                                                       |
| [`aeed974b`](https://github.com/NixOS/nixpkgs/commit/aeed974bb538880f0af8dcb2f572baabafdd6f83) | `terraform-providers.aiven: 3.7.0 → 3.8.0`                                                         |
| [`af3779f8`](https://github.com/NixOS/nixpkgs/commit/af3779f819285ba9b082c38b3594b83546dea740) | `nixos/hypr: add module`                                                                           |
| [`49b55099`](https://github.com/NixOS/nixpkgs/commit/49b55099eaf05b693bc1589f21e65c2c9f522ee0) | `hypr: init at unstable-2022-05-25`                                                                |
| [`a8aefa10`](https://github.com/NixOS/nixpkgs/commit/a8aefa107d27361c759f7e755bcef577c10e8079) | `matrix-sdk-crypto-nodejs: fix build`                                                              |
| [`6aea62f9`](https://github.com/NixOS/nixpkgs/commit/6aea62f93862a88a71cf28ca7b5e91500168dbd7) | `v2ray-geoip: 202210130107 -> 202210200105`                                                        |
| [`ec187bf9`](https://github.com/NixOS/nixpkgs/commit/ec187bf90889a4a7c90276bc7cf28de81cb15b1b) | `pantheon.wingpanel-indicator-power: 6.1.0 -> 6.2.0`                                               |
| [`0763b2b9`](https://github.com/NixOS/nixpkgs/commit/0763b2b9570746e5e6dc9437ce19b209e2ef6c13) | `galaxy-buds-client: add desktop file`                                                             |
| [`13eee37e`](https://github.com/NixOS/nixpkgs/commit/13eee37eb734f6e3335d5893cfd3c9c931cbf775) | `home-assistant: update component-packages`                                                        |
| [`d5053942`](https://github.com/NixOS/nixpkgs/commit/d5053942398033564cc40daf6f9f6c5b8eaf4941) | `python310Packages.pyprusalink: init at 1.1.0`                                                     |
| [`2c2cb5d4`](https://github.com/NixOS/nixpkgs/commit/2c2cb5d49700807696abf003d7d544045a01ddc8) | `shapelib: add patch for CVE-2022-0699`                                                            |
| [`26bcd8a5`](https://github.com/NixOS/nixpkgs/commit/26bcd8a598e6402dbbcbe9c30beb4c5007bc25b9) | `signal-cli: 0.11.3 -> 0.11.4`                                                                     |
| [`f6f80b04`](https://github.com/NixOS/nixpkgs/commit/f6f80b0493c449193b06fa5a1101312b8ae61f51) | `cudnn: fix 8.6.0 src url after upstream change`                                                   |
| [`a50504c9`](https://github.com/NixOS/nixpkgs/commit/a50504c96a070c3ceb845967533c626e0622089d) | `plex: 1.29.0.6244-819d3678c -> 1.29.1.6316-f4cdfea9c`                                             |
| [`36c55f76`](https://github.com/NixOS/nixpkgs/commit/36c55f76ff79d5d2e5ea0b2e5337a0f796c88b8c) | `kops: 1.25.1 -> 1.25.2`                                                                           |
| [`440905ae`](https://github.com/NixOS/nixpkgs/commit/440905ae252c796379768950f31d7a906cfb8398) | `flexget: 3.3.37 -> 3.3.38`                                                                        |
| [`41522f66`](https://github.com/NixOS/nixpkgs/commit/41522f66493ef26621aed68366b421688d0af301) | `gnomeExtensions.dash-to-dock: 74 -> 75`                                                           |
| [`2543c202`](https://github.com/NixOS/nixpkgs/commit/2543c202032fcc990a33823d67ad72ab2641b8fb) | `cudatext: 1.173.0 -> 1.173.2`                                                                     |
| [`d1ecca01`](https://github.com/NixOS/nixpkgs/commit/d1ecca017821eb3a8b89ac109f8b673764f62e40) | `netatalk: FreeBSD patchset 3.1.13_3, critical fix`                                                |
| [`748f6d8b`](https://github.com/NixOS/nixpkgs/commit/748f6d8b0090ea111ab102f8d2e73d70d374a5a9) | `python310Packages.plugwise: 0.25.2 -> 0.25.3`                                                     |
| [`9d676cb0`](https://github.com/NixOS/nixpkgs/commit/9d676cb01d8254197d85f4771f924065d14149e5) | `nginxQuic: 3550b00d9dc8 -> 3be953161026`                                                          |
| [`a9cbc65a`](https://github.com/NixOS/nixpkgs/commit/a9cbc65ad0ad7c3059730cffde59cc4322267b07) | `nginxMainline: 1.23.1 -> 1.23.2`                                                                  |
| [`2392241c`](https://github.com/NixOS/nixpkgs/commit/2392241c0b54fba32d02ecac8cdfa8bcca7d2376) | `nginxStable: 1.22.0 -> 1.22.1`                                                                    |
| [`92cd60ad`](https://github.com/NixOS/nixpkgs/commit/92cd60ad5d554e95260cf904327ff28c13e149f9) | `proxify: 0.0.7 -> 0.0.8`                                                                          |
| [`ff443bc6`](https://github.com/NixOS/nixpkgs/commit/ff443bc6e76ad767b41fc7138d6f9754ad583465) | `lemmeknow: add Br1ght0ne to maintainers`                                                          |
| [`818e7c68`](https://github.com/NixOS/nixpkgs/commit/818e7c689f199a37140f51fd953a49bde3a60952) | `shellhub-agent: 0.10.3 -> 0.10.4`                                                                 |
| [`23c1754f`](https://github.com/NixOS/nixpkgs/commit/23c1754fff74ee55ca2fa7188130805a7793c9c0) | `lib/tests/misc: Add tests for charToInt, escapeC, and normalizePath`                              |
| [`3251123a`](https://github.com/NixOS/nixpkgs/commit/3251123a779636d6883032f158ff99ebe98c0da4) | `nixos/lib.escapeSystemdPath: Implement the correct algorithm for escaping names in systemd units` |
| [`4284ac9d`](https://github.com/NixOS/nixpkgs/commit/4284ac9dfb118097eb9e2d5f27e11208f2e715e4) | `lib.strings: Add normalizePath`                                                                   |
| [`4c420ee4`](https://github.com/NixOS/nixpkgs/commit/4c420ee4854d8b0a9d0d224588f0cd033f6b4381) | `lib.strings: Add function to do C-style escaping`                                                 |
| [`373a013c`](https://github.com/NixOS/nixpkgs/commit/373a013cab50605fe0dc8c3dab5c46e09fc9aa26) | `claws-mail: 4.1.0 -> 4.1.1`                                                                       |
| [`bd1966cf`](https://github.com/NixOS/nixpkgs/commit/bd1966cf4e576cb775973c2ebb2098b139a0bf8d) | `vimPlugins.neodev-nvim: properly replace lua-dev-nvim`                                            |
| [`7a0be1b7`](https://github.com/NixOS/nixpkgs/commit/7a0be1b751e490ba7e91a6255e1026cbcdca9c10) | `vimPlugins: resolve github repository redirects`                                                  |
| [`4d1a8c85`](https://github.com/NixOS/nixpkgs/commit/4d1a8c85fbd25415545a9c46240b4a4531cb4908) | `vimPlugins: update`                                                                               |
| [`a08741ff`](https://github.com/NixOS/nixpkgs/commit/a08741ffbdf1adfb8c4acc790120faed8251ee79) | `lib.strings: Add function to convert character to number`                                         |
| [`81239c05`](https://github.com/NixOS/nixpkgs/commit/81239c05fc0b1abf0b445b7339b9cf7f7215527f) | `consul: 1.13.2 -> 1.13.3`                                                                         |
| [`c295f7a4`](https://github.com/NixOS/nixpkgs/commit/c295f7a4d4e11eea82b5fdb4099fac300a926661) | `okteto: 2.8.0 -> 2.8.1`                                                                           |
| [`eb1019b6`](https://github.com/NixOS/nixpkgs/commit/eb1019b60259fba072bc41830d6a893b79081473) | `oh-my-posh: 12.6.1 -> 12.6.5`                                                                     |
| [`3c70d1e6`](https://github.com/NixOS/nixpkgs/commit/3c70d1e68a606bf4fd1491ecb69982383ca8ae04) | `odo: 2.5.1 -> 3.0.0`                                                                              |
| [`075649e8`](https://github.com/NixOS/nixpkgs/commit/075649e87cf424cbbe1d86a94b07ec1de2fb20ec) | `huggle: init at 3.4.10`                                                                           |
| [`f59dde32`](https://github.com/NixOS/nixpkgs/commit/f59dde323997ff5a00ce001b7d91192f4d7309a2) | `libirc: init at 2022-10-16`                                                                       |
| [`7396451d`](https://github.com/NixOS/nixpkgs/commit/7396451d6c5dd28a3ab80ba0b2d68216d3e17eca) | `rPackages.mzR: unpin boost`                                                                       |
| [`66129483`](https://github.com/NixOS/nixpkgs/commit/661294831548257084f2b09ecfe698dd3b4ec00d) | `rfc: init at 0.2.6`                                                                               |
| [`d0852839`](https://github.com/NixOS/nixpkgs/commit/d08528393a13e9f35f06813807329b9771bf6747) | `lfs: 2.5.0 -> 2.6.0`                                                                              |
| [`0e891e83`](https://github.com/NixOS/nixpkgs/commit/0e891e83fd9201da9e507c5ad8e20c966d19252f) | `kubemq-community: 2.3.1 -> 2.3.2`                                                                 |
| [`1fee002c`](https://github.com/NixOS/nixpkgs/commit/1fee002c9b20caed191b1688dbab1a6a790fb711) | `just: 1.5.0 -> 1.6.0`                                                                             |
| [`357600c0`](https://github.com/NixOS/nixpkgs/commit/357600c08f1ea3373aa2bf179d012847f1f599d9) | `unar: fix linker failure`                                                                         |
| [`308548f2`](https://github.com/NixOS/nixpkgs/commit/308548f2533154a2c07e476a7851f9ede4c9db61) | `nsncd: init at unstable-2021-10-20`                                                               |
| [`7987b41d`](https://github.com/NixOS/nixpkgs/commit/7987b41d44b22c865cd4360a4e20c8834ca57872) | `nixos/nscd: nixpkgs-fmt`                                                                          |
| [`a3b07e36`](https://github.com/NixOS/nixpkgs/commit/a3b07e3693462f656e5473e6b1a2a15e20c24c2a) | `nixosTests.nscd: update subtest name and comment`                                                 |
| [`87fa015d`](https://github.com/NixOS/nixpkgs/commit/87fa015d32b4d57ae9264e167b56987f917dc8c8) | `firefox-bin-unwrapped: 106.0 -> 106.0.1`                                                          |
| [`1f6b6f02`](https://github.com/NixOS/nixpkgs/commit/1f6b6f02e9798825f7189c455e59a9dc0c6e8db6) | `firefox-unwrapped: 106.0 -> 106.0.1`                                                              |
| [`1a3a18aa`](https://github.com/NixOS/nixpkgs/commit/1a3a18aa79befe48a0fac6dc6623a02a3f384247) | `thunderbird-bin-unwrapped: 102.3.3 -> 102.4.0`                                                    |
| [`0df09a4a`](https://github.com/NixOS/nixpkgs/commit/0df09a4a4571bedf36d317033eb242d4c23444b7) | `thunderbird-unwrapped: 102.3.3 -> 102.4.0`                                                        |
| [`bf677a72`](https://github.com/NixOS/nixpkgs/commit/bf677a72e88fd4023e6809105aa05acab43f9fd5) | `qt5.qtwebengine: 5.15.8 -> 5.15.11`                                                               |
| [`6d21d0c2`](https://github.com/NixOS/nixpkgs/commit/6d21d0c24f59f5c941e527949137c26c473f6d44) | `datree: 1.6.37 -> 1.6.40`                                                                         |
| [`ba23355e`](https://github.com/NixOS/nixpkgs/commit/ba23355e0deca417d51c455fee89a66c16e1e837) | `credhub-cli: 2.9.5 -> 2.9.6`                                                                      |
| [`b656abb2`](https://github.com/NixOS/nixpkgs/commit/b656abb2329953ed9a3b144f2574376aa49be0fa) | `conftest: 0.34.0 -> 0.35.0`                                                                       |
| [`e00aa39f`](https://github.com/NixOS/nixpkgs/commit/e00aa39f62b00093ae7e7f4667448f017ff64fa6) | `buf: 1.8.0 -> 1.9.0`                                                                              |
| [`6020b60c`](https://github.com/NixOS/nixpkgs/commit/6020b60cfd512a35e7d6d161b8429e562d819072) | `bats: 1.8.0 -> 1.8.2`                                                                             |
| [`b357b3a8`](https://github.com/NixOS/nixpkgs/commit/b357b3a8aa4d215f9f8b0c0eece8c5bf65ef7bfc) | `cauwugo: init at 0.1.0`                                                                           |
| [`dd3d6e6d`](https://github.com/NixOS/nixpkgs/commit/dd3d6e6d661cee4150460b03585d3958597b2b29) | `mailmap: unify sandro.jaeckel@gmail.com`                                                          |
| [`fe9fb739`](https://github.com/NixOS/nixpkgs/commit/fe9fb739a9fef3ffe5de6a935bcd19e710351c89) | `freshrss: fix greader-api`                                                                        |
| [`c9aab9ba`](https://github.com/NixOS/nixpkgs/commit/c9aab9ba9737c0b4601d816792a31cf04a75d651) | `nixos/changedetection-io: init`                                                                   |
| [`eba04bfb`](https://github.com/NixOS/nixpkgs/commit/eba04bfbe8637465797b77da477e09c6c78064a1) | `changedetection-io: init at 0.39.20.4`                                                            |
| [`5d80a512`](https://github.com/NixOS/nixpkgs/commit/5d80a5129d31eb7580b012d8d98a3c6eb9089caf) | `playwright: init at 1.27.1`                                                                       |
| [`d5a5e091`](https://github.com/NixOS/nixpkgs/commit/d5a5e091cb85737beb74b11da279c9603071acff) | `multimon-ng: 1.1.9 -> 1.2.0`                                                                      |
| [`2fcf20a8`](https://github.com/NixOS/nixpkgs/commit/2fcf20a83cf316eb202c20170c83a615f810d750) | `jellyfin-ffmpeg: 5.1.2-1 -> 5.1.2-2`                                                              |
| [`939d2e24`](https://github.com/NixOS/nixpkgs/commit/939d2e24496775c7081ccf0b05970f3b95159795) | `orchis-theme: 2022-09-28 -> 2022-10-19`                                                           |
| [`f185aa12`](https://github.com/NixOS/nixpkgs/commit/f185aa12ab07c98bda00f399b5844a80d5f510b3) | `vscode: 1.72.1 -> 1.72.2`                                                                         |
| [`f4f6322b`](https://github.com/NixOS/nixpkgs/commit/f4f6322b019454ec819aee2c77433a14776fd428) | `linode-cli: 5.23.0 -> 5.24.0`                                                                     |
| [`bbf5ba11`](https://github.com/NixOS/nixpkgs/commit/bbf5ba11b488c43a3b042164de209fcfc6f4a62c) | `nixos/ntfy-sh: init`                                                                              |
| [`bccd6352`](https://github.com/NixOS/nixpkgs/commit/bccd6352d3abc4ca6bfb87c00cc695e92a146181) | `python310Packages.selenium: 4.4.2 -> 4.5.0, add SuperSandro2000 as maintainer`                    |
| [`a2518805`](https://github.com/NixOS/nixpkgs/commit/a25188054f4f3309c6d893f0ba1b8215f8dc4197) | `python310Packages.jsonpath-ng: 1.5.2 -> 1.5.3`                                                    |
| [`05250cc2`](https://github.com/NixOS/nixpkgs/commit/05250cc252880f47f27257733a6cb53a84b4b662) | `python310Packages.inscriptis: init at 2.3.1`                                                      |
| [`a11a2a6d`](https://github.com/NixOS/nixpkgs/commit/a11a2a6d18df7a33d2804803e733f0255c0b0a97) | `python310Packages.flask-login: normalise package name`                                            |
| [`8edb3607`](https://github.com/NixOS/nixpkgs/commit/8edb36074dfe27613feb18c7ab084216ec97b483) | `hikounomizu: init at 0.9.2`                                                                       |
| [`f7adcd67`](https://github.com/NixOS/nixpkgs/commit/f7adcd674cf543938ee31f8cd1dcdccd4080841f) | `lib.licenses: add lal12 and lal13`                                                                |
| [`120f6fec`](https://github.com/NixOS/nixpkgs/commit/120f6fec4200d7f19ef3e1c4029a872853b5f237) | `upnp-router-control: init at 0.3.1`                                                               |
| [`08bb2984`](https://github.com/NixOS/nixpkgs/commit/08bb29847e53c209fd5c632e1e822dd70440a373) | `faircamp: unstable-2022-07-22 -> unstable-2022-10-08`                                             |
| [`6bc50bf7`](https://github.com/NixOS/nixpkgs/commit/6bc50bf728801f828fce2b0a9c10e70f225618a3) | `python3Packages.Nuitka: 0.6.14.5 -> 1.1.5`                                                        |
| [`c6cae19d`](https://github.com/NixOS/nixpkgs/commit/c6cae19d1937c21213bd37127d027365942be850) | `viu: add withSixel option; adopt`                                                                 |
| [`eca87400`](https://github.com/NixOS/nixpkgs/commit/eca87400bd7344c7fe5d42d000e71fd595047b9b) | `wordpressPackages.plugins.gutenberg: init at 14.3.0`                                              |
| [`d1f673e3`](https://github.com/NixOS/nixpkgs/commit/d1f673e3b62964da0f2d88cbd711178e59f51066) | `navidrome: use ffmpeg-headless`                                                                   |
| [`501c5af8`](https://github.com/NixOS/nixpkgs/commit/501c5af829108d0676c1f4152f4c79fdf71dfc95) | `unpaper: use ffmpeg_5-headless`                                                                   |
| [`6145b7c7`](https://github.com/NixOS/nixpkgs/commit/6145b7c77057794c8e8262c24ae2e0819009ca36) | `ffmpeg{,_{4,5}}-headless: init`                                                                   |
| [`af83b0c6`](https://github.com/NixOS/nixpkgs/commit/af83b0c6b11c3227c3e084b2d72871c829245820) | `cudnn: add 8.6.0, set default`                                                                    |
| [`856e04dc`](https://github.com/NixOS/nixpkgs/commit/856e04dc1d17e8baf22450e4d527ca6aa83cb228) | `cudnn: throw error if the default version is not supported`                                       |
| [`ad6aeedf`](https://github.com/NixOS/nixpkgs/commit/ad6aeedf56c6a802a5ddab445811be820824a82b) | `tensorrt: fix false fallback to tensorRTDefaultVersion`                                           |
| [`8a63fb02`](https://github.com/NixOS/nixpkgs/commit/8a63fb0236bfc25a27168a55d2a64377c7fc1b96) | `cuda-samples: 11.8 throw the non-existing tag`                                                    |
| [`6d0f92f8`](https://github.com/NixOS/nixpkgs/commit/6d0f92f82ae3d0886fd1cf3a13e312cf015cd6b6) | `cuddn: 8.5.0`                                                                                     |
| [`3eae0cc0`](https://github.com/NixOS/nixpkgs/commit/3eae0cc0722b14dc0c7ec18c626ddbeb386269ad) | `cudatookit: 11.8 + redistrib manifest`                                                            |
| [`614c3e5d`](https://github.com/NixOS/nixpkgs/commit/614c3e5dc4f50ced1996137132205b7c8baeb387) | `vscode-extensions.sumneko.lua: init at 3.5.6`                                                     |