### PR TITLE
chore(flake/darwin): `ef56fd89` -> `8be7f197`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665392861,
-        "narHash": "sha256-bCd8fYJMAb0LzabsiXl4nxECDoz483bJOCa2hjox7N0=",
+        "lastModified": 1666519227,
+        "narHash": "sha256-z74lSCJE5BzxCeE2r9FU4tvHkQXQyz70zmJ3coLP10w=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ef56fd8979b5f4e800c4716f62076e00600b1172",
+        "rev": "8be7f197120739b3ec15f994bdc48116726c6159",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                              |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------- |
| [`115ab9a0`](https://github.com/LnL7/nix-darwin/commit/115ab9a0b127e2cc07e2c7f45897f269f66b62f8) | ``Fix manual by escaping `&quot;` as well`` |