### PR TITLE
chore(flake/pre-commit-hooks): `e6c8efee` -> `1b436f36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666160137,
-        "narHash": "sha256-8bQu+6poMzUyS2n3C1v3hkO6ZhRzj8Pf3CDCNckqQE4=",
+        "lastModified": 1666604592,
+        "narHash": "sha256-Bxy7xeVAwC0yxFaeYZM7N9Us/ebxpMC9TCceKEFeay4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e6c8efee1c108bb27522b9fd25b1cd0eb3288681",
+        "rev": "1b436f36e2812c589e6d830e3223059ea9661100",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                            |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
| [`364f8c3c`](https://github.com/cachix/pre-commit-hooks.nix/commit/364f8c3c66f4326992264fac489a0d4e634248d6) | `README: elaborate on closure size check` |
| [`34b86a5c`](https://github.com/cachix/pre-commit-hooks.nix/commit/34b86a5c64299f5c621e05556a6788e0fe8c1621) | `feat: add govet hook`                    |