### PR TITLE
chore(flake/nixos-hardware): `d6945f0c` -> `dfd91284`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1666850507,
-        "narHash": "sha256-+tP8N4H6nAzTIpOD+D5mBqksmhZ6mUnrrFpJB2SUV88=",
+        "lastModified": 1666851028,
+        "narHash": "sha256-e6DpqCMGzlpkhZDuS2fdDX1DsauFk8NARqQ1DDF42VY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d6945f0ca1c2819a444b324d05b5fe27baeee89d",
+        "rev": "dfd91284332a4882c504b4807b1922e0fe386621",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                     |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`2c27afc7`](https://github.com/NixOS/nixos-hardware/commit/2c27afc7eda8f35327e9a8b7c6c45f4a9b1d602f) | `add lenovo/thinkpad/x1/yoga/7th-gen`              |
| [`ba122332`](https://github.com/NixOS/nixos-hardware/commit/ba122332574dcd08291bb8c81140cfe2d04bf038) | `apple/macbook-pro/14-1: fix service script paths` |
| [`99ed0bc6`](https://github.com/NixOS/nixos-hardware/commit/99ed0bc663445cbb4d7501f120f5628e9e77c836) | `apple/macbook-pro: add support for 14,1`          |