### PR TITLE
chore(flake/nixos-hardware): `dfd91284` -> `419dcc0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1666851028,
-        "narHash": "sha256-e6DpqCMGzlpkhZDuS2fdDX1DsauFk8NARqQ1DDF42VY=",
+        "lastModified": 1666873549,
+        "narHash": "sha256-a6Eu1Qv/EndjepSMja5SvcG+4vM5Rl2gzJD7xscRHss=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "dfd91284332a4882c504b4807b1922e0fe386621",
+        "rev": "419dcc0ec767803182ed01a326f134230578bf60",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                           |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`37977367`](https://github.com/NixOS/nixos-hardware/commit/379773671e481acf71dcfdc760c81c65da6ba25c) | `.github/PULL_REQUEST_TEMPLATE.md: init` |