### PR TITLE
chore(flake/nixos-hardware): `d5bacd34` -> `18934557`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1667221253,
-        "narHash": "sha256-PGGT7D/qmi1E8D1Z32SLrzq7PJO5CajD64GfCCdslk0=",
+        "lastModified": 1667283320,
+        "narHash": "sha256-qHvB/6XBKVjjJJCUM+z6/t9HzUC7J55wdY3KJ/ZWSHo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d5bacd34f54328f31bef9237098fdeaad83074be",
+        "rev": "18934557eeba8fa2e575b0fd4ab95186e2e3bde3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`c9c1a529`](https://github.com/NixOS/nixos-hardware/commit/c9c1a5294e4ec378882351af1a3462862c61cb96) | `raspberry-pi/4: add pcie_brcmstb and reset-raspberrypi to kernelParams` |