### PR TITLE
chore(flake/nixpkgs): `412b9917` -> `d40fea9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667142599,
-        "narHash": "sha256-OLJxsg9VqfKjFkerOxWtNIkibsCvxsv5A8wNWO1MeWk=",
+        "lastModified": 1667231093,
+        "narHash": "sha256-RERXruzBEBuf0c7OfZeX1hxEKB+PTCUNxWeB6C1jd8Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "412b9917cea092f3d39f9cd5dead4effd5bc4053",
+        "rev": "d40fea9aeb8840fea0d377baa4b38e39b9582458",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| [`3d5035f8`](https://github.com/NixOS/nixpkgs/commit/3d5035f8f55ffb495b5afba2e5057dd40c1710e1) | `python3Packages: use toPythonModule on packages that are modules`                                          |
| [`06e2c42a`](https://github.com/NixOS/nixpkgs/commit/06e2c42ae411d57087217096cacb409ade96ac74) | `xpra: fix application icon location`                                                                       |
| [`19d9ac28`](https://github.com/NixOS/nixpkgs/commit/19d9ac28cc04047b2a7b9ed8a0c509f2d1d3d8d2) | `raylib-games: init at 2022-10-14`                                                                          |
| [`7aa48a0d`](https://github.com/NixOS/nixpkgs/commit/7aa48a0dd39ac66c850ccc123c3608fca6bca4ee) | `raylib: propagate GL and X11 libraries`                                                                    |
| [`80c63fbb`](https://github.com/NixOS/nixpkgs/commit/80c63fbba6b5febba1b1b53c0434f46e73ab3585) | `ooniprobe-cli: 3.16.3 -> 3.16.4`                                                                           |
| [`b28f6cc8`](https://github.com/NixOS/nixpkgs/commit/b28f6cc8a34598ba7b9528f07c2ba814aef4ec82) | `mame: general improvements`                                                                                |
| [`7e5af951`](https://github.com/NixOS/nixpkgs/commit/7e5af95176894a256613b887731d5b7ca9cff84f) | `fits-cloudctl: 0.10.22 -> 0.11.1`                                                                          |
| [`0426b36f`](https://github.com/NixOS/nixpkgs/commit/0426b36f9fcf18a73be034797699a0bbae7c60ac) | `doc/vim: update docs for nvim-treesitter`                                                                  |
| [`ca846a34`](https://github.com/NixOS/nixpkgs/commit/ca846a348f8a112498082f06372fdb966cfb60b5) | `vimPlugins.nvim-treesitter: add tree sitter grammars`                                                      |
| [`6c346e3f`](https://github.com/NixOS/nixpkgs/commit/6c346e3fa5e819c85449c910201d27699c2f7e3d) | `dpdk: update kernel version constraint.`                                                                   |
| [`1a15be69`](https://github.com/NixOS/nixpkgs/commit/1a15be699b935816762e98d8346c2769fa26708f) | `dpdk-kmods: fix build against 5.18`                                                                        |
| [`9d220f50`](https://github.com/NixOS/nixpkgs/commit/9d220f506756cf405d6ceda3706ff068a479954f) | `dpdk: 22.03 -> 22.07`                                                                                      |
| [`a8f36d57`](https://github.com/NixOS/nixpkgs/commit/a8f36d5717d293d0680a9330109e4273d7ae6a6a) | `xprite-editor: mark as broken for all platforms`                                                           |
| [`49ae64fb`](https://github.com/NixOS/nixpkgs/commit/49ae64fb607da5dbfb6df4995877be0f0445c0ca) | `terraform-providers.argocd: init at 4.1.0`                                                                 |
| [`d4013213`](https://github.com/NixOS/nixpkgs/commit/d40132138b215d4562a116c63ec30ab499bbbb3f) | `keepassxc: 2.7.3 -> 2.7.4`                                                                                 |
| [`b43605fb`](https://github.com/NixOS/nixpkgs/commit/b43605fb031248ddb615b7caf562ccfcb49f910d) | `nixos/merecat: init`                                                                                       |
| [`ada312b3`](https://github.com/NixOS/nixpkgs/commit/ada312b3c41a24dd8a5c78903a09281857fecb55) | `merecat: add version test`                                                                                 |
| [`9f50ee94`](https://github.com/NixOS/nixpkgs/commit/9f50ee94a54a6b8d08dfc397fac3f4624a640e74) | `merecat: init at 2.31`                                                                                     |
| [`31f8cc8e`](https://github.com/NixOS/nixpkgs/commit/31f8cc8ea159e5c7bc0ef1227244212032212815) | `python310Packages.pytile: 2022.02.0 -> 2022.10.0`                                                          |
| [`ffc1db5a`](https://github.com/NixOS/nixpkgs/commit/ffc1db5a97ba476bf09cef8e98937b15138e2333) | `komga: 0.157.2 -> 0.157.3`                                                                                 |
| [`4c33f7db`](https://github.com/NixOS/nixpkgs/commit/4c33f7db6a6d58e5ff1825f81814488caf243b58) | `python310Packages.levenshtein: 0.20.3 -> 0.20.8`                                                           |
| [`1f80e27a`](https://github.com/NixOS/nixpkgs/commit/1f80e27aa7048b2e34893edc4d50fc6a18e8ac37) | `python310Packages.rapidfuzz: 2.6.0 -> 2.13.0`                                                              |
| [`84600b6b`](https://github.com/NixOS/nixpkgs/commit/84600b6b7ee8253b214e37b940623dc756da20fb) | `rapidfuzz-cpp: 1.3.0 -> 1.10.0`                                                                            |
| [`041135e4`](https://github.com/NixOS/nixpkgs/commit/041135e417346082d0eef82709626109b161f7c6) | `hyfetch: 1.4.2 -> 1.4.3`                                                                                   |
| [`78c370ae`](https://github.com/NixOS/nixpkgs/commit/78c370aed744d6943162bfbe60e239278e337b1a) | `pythonPackages.dbus-next: Ignore tcp_connection_with_forwarding test`                                      |
| [`a995997c`](https://github.com/NixOS/nixpkgs/commit/a995997c68c005530bf32b72adbcfec62fb3c9d6) | `odo: 3.0.0 -> 3.1.0`                                                                                       |
| [`54cf191a`](https://github.com/NixOS/nixpkgs/commit/54cf191a16f67d4904dacdce8a6722dfc86fe42a) | `tengine: 2.3.3 -> 2.3.4`                                                                                   |
| [`41cd71f3`](https://github.com/NixOS/nixpkgs/commit/41cd71f33878879f4979d9590b09afebea2fb46d) | `xq: 0.2.39 -> 0.2.40`                                                                                      |
| [`83018dd5`](https://github.com/NixOS/nixpkgs/commit/83018dd5d795a7f0729c94c2d234986f2858c300) | `cava: 0.7.4 -> 0.8.2`                                                                                      |
| [`b5520a27`](https://github.com/NixOS/nixpkgs/commit/b5520a2726dcec8e30d649ce9a4c3feacc08cf49) | `bambootracker: 0.5.2 -> 0.5.3`                                                                             |
| [`e641cfb7`](https://github.com/NixOS/nixpkgs/commit/e641cfb78e5241cdde733d79d9973246d1724fec) | `ruff: 0.0.91 -> 0.0.92`                                                                                    |
| [`71d12f69`](https://github.com/NixOS/nixpkgs/commit/71d12f6934142af967880dceb15684dcda5bbaab) | `firefox-bin-unwrapped: 106.0.2 -> 106.0.3`                                                                 |
| [`0fad4307`](https://github.com/NixOS/nixpkgs/commit/0fad4307e8040fa5c0939e51df7e96b5a9624f55) | `firefox-unwrapped: 106.0.2 -> 106.0.3`                                                                     |
| [`41004f4e`](https://github.com/NixOS/nixpkgs/commit/41004f4e0ea36afca9b6edd88c8d23f7e2c3ac86) | `hyfetch: 1.4.1 -> 1.4.2`                                                                                   |
| [`b2bb7c13`](https://github.com/NixOS/nixpkgs/commit/b2bb7c13488b78dbae93396cdf7de4624ab0ae64) | `cemu-ti: update license`                                                                                   |
| [`026f99d8`](https://github.com/NixOS/nixpkgs/commit/026f99d83dd3ac00ddf499c389ee2622f903b129) | `go-font: avoid .gitignore and .gitattributes in output`                                                    |
| [`025ba5cc`](https://github.com/NixOS/nixpkgs/commit/025ba5cc19af6ef8443ae27e684e8c60a0bbe5b1) | `bundlewrap: init at 4.15.0 (#197904)`                                                                      |
| [`d1e9d8fb`](https://github.com/NixOS/nixpkgs/commit/d1e9d8fb2e693242dd76e186f7683c3682fd1b13) | `python310Packages.editdistance: disable on older Python releases`                                          |
| [`1a6c366b`](https://github.com/NixOS/nixpkgs/commit/1a6c366b80e41219fddf67ddac1d7b360e6e02b5) | `python310Packages.editdistance: 0.6.0 -> 0.6.1`                                                            |
| [`2dea2607`](https://github.com/NixOS/nixpkgs/commit/2dea2607a96fa047859a06aed3e21e669a927c90) | `python310Packages.meshtastic: 1.3.43 -> 1.3.44`                                                            |
| [`1f876826`](https://github.com/NixOS/nixpkgs/commit/1f8768261cd903eb1910d06bcbdc461f1bb0de0b) | `python310Packages.pyswitchbee: 1.6.0 -> 1.6.1`                                                             |
| [`5310040d`](https://github.com/NixOS/nixpkgs/commit/5310040d3f7c9d4b59116e9df853a14e56e212f4) | `flyctl: 0.0.424 -> 0.0.425`                                                                                |
| [`685b0daf`](https://github.com/NixOS/nixpkgs/commit/685b0daf363ae3f92896fcb2982af1eddf8e409f) | `python310Packages.ge25519: add setuptools`                                                                 |
| [`aaaad710`](https://github.com/NixOS/nixpkgs/commit/aaaad710c135c1fe432f100c95d3f2285ce3801f) | `ruff: 0.0.89 -> 0.0.91`                                                                                    |
| [`4dec4ce1`](https://github.com/NixOS/nixpkgs/commit/4dec4ce11eec7e1cea552778c6eacae5c40cfcab) | `python310Packages.asyncmy: add setuptools`                                                                 |
| [`2fd858d0`](https://github.com/NixOS/nixpkgs/commit/2fd858d0a2063da6acc9185f2815e959fb97ef74) | `python3Packages.scapy: build with libpcap`                                                                 |
| [`72e230af`](https://github.com/NixOS/nixpkgs/commit/72e230af141ee70109ddb64d95b70be036c54005) | `haskellPackages: mark builds failing on hydra as broken`                                                   |
| [`c6cbeab8`](https://github.com/NixOS/nixpkgs/commit/c6cbeab8bc163454b4c07f83be734287064429b3) | `bochs: cosmetical rewrite`                                                                                 |
| [`1cd7d0b2`](https://github.com/NixOS/nixpkgs/commit/1cd7d0b232d5cd2d04f4edaa58e856d27c17ab79) | `gamescope: 3.11.47 -> 3.11.48`                                                                             |
| [`49728da5`](https://github.com/NixOS/nixpkgs/commit/49728da5421b2bae8c42ae611f39a83184ba73ce) | `vscode-extensions.jnoortheen.nix-ide: 0.1.23 -> 0.2.1 (#198007)`                                           |
| [`97cba633`](https://github.com/NixOS/nixpkgs/commit/97cba63343af69f0c7fe422e3d5e994d6130cc2d) | `python310Packages.python-utils: disable on older Python releases`                                          |
| [`26d5ac5e`](https://github.com/NixOS/nixpkgs/commit/26d5ac5eeeaa53c3bcb527b6264e360a3ff69bc1) | `python3Packages.ducc0: 0.26 -> 0.27`                                                                       |
| [`a2144b36`](https://github.com/NixOS/nixpkgs/commit/a2144b36c7f394f89b82b3f6a83841458c8e1076) | `python310Packages.python-gitlab: add optional-dependencies`                                                |
| [`b8930547`](https://github.com/NixOS/nixpkgs/commit/b893054798674bb7fc66e00285abee66a12b8af7) | `python310Packages.python-box: update disabled`                                                             |
| [`fcf81f91`](https://github.com/NixOS/nixpkgs/commit/fcf81f91a3a90c2ee009d180368d9ecdca178334) | `nixos/jenkins-job-builder: better defaults for accessUser/accessTokenFile`                                 |
| [`ea809481`](https://github.com/NixOS/nixpkgs/commit/ea809481a465249215d9f42857862ffebb9d3a85) | `python310Packages.robotframework-requests: add pythonImportsCheck`                                         |
| [`3df7f95b`](https://github.com/NixOS/nixpkgs/commit/3df7f95b0dd350288261b1edf404d63328ef08c2) | `python310Packages.spotipy: disable on older Python releases`                                               |
| [`4abe8dcd`](https://github.com/NixOS/nixpkgs/commit/4abe8dcd616ad752b20cffd29269948b1db4cf14) | `nixos/mautrix-telegram: fix link to example config`                                                        |
| [`8e803f43`](https://github.com/NixOS/nixpkgs/commit/8e803f436457fffca2c8a5a721a9488105eccf4e) | `nixos/mautrix-telegram: add new required config option`                                                    |
| [`0590d6d0`](https://github.com/NixOS/nixpkgs/commit/0590d6d01c4b35434a1943a3eddc4c9486ee56e5) | `ungoogled-chromium: 107.0.5304.68 -> 107.0.5304.88`                                                        |
| [`1cd6b2c7`](https://github.com/NixOS/nixpkgs/commit/1cd6b2c7f4cbabe9cbcf82409c4522f29341359a) | `chromium: 107.0.5304.68 -> 107.0.5304.87`                                                                  |
| [`4add137b`](https://github.com/NixOS/nixpkgs/commit/4add137b0d5ac88847050134fee357ba723ca91e) | `haskell.packages.ghc942.cabal-install*: drop unnecessary jailbreak`                                        |
| [`5fa41df4`](https://github.com/NixOS/nixpkgs/commit/5fa41df499a53aeb56ab9bf3cb9b7578a47e1513) | `chromiumBeta: 107.0.5304.68 -> 108.0.5359.22`                                                              |
| [`1e999fae`](https://github.com/NixOS/nixpkgs/commit/1e999fae15b986212d1c60b7a6f6062128d5ce1e) | `chromiumDev: 108.0.5359.19 -> 109.0.5384.0`                                                                |
| [`566fb969`](https://github.com/NixOS/nixpkgs/commit/566fb969874e342598a8d81bc2b30c08344ff21a) | `frei: init at 0.1.0`                                                                                       |
| [`502531cb`](https://github.com/NixOS/nixpkgs/commit/502531cb2dbfba40d6f1a2912149aac6717adf51) | `haskell.packages.ghc924.purescript: allow building and test on Hydra`                                      |
| [`a0383f7a`](https://github.com/NixOS/nixpkgs/commit/a0383f7ad9c2c7550ce34907fe6dc62dba1b3457) | `haskellPackages.xdg-basedir-compliant: work around missing test data`                                      |
| [`a4340923`](https://github.com/NixOS/nixpkgs/commit/a434092372a6c12b010e475f78e24a8b1b90b31b) | `haskellPackages.xlsx: work around missing test data`                                                       |
| [`1761c5d0`](https://github.com/NixOS/nixpkgs/commit/1761c5d08504cd3736acc3a85cd05a8d2b824069) | `python310Packages.types-pyyaml: 6.0.12 -> 6.0.12.1`                                                        |
| [`a53a14bc`](https://github.com/NixOS/nixpkgs/commit/a53a14bc2df5e9975fd8352cddb5b343d62daa72) | `haskellPackages: mark builds failing on hydra as broken`                                                   |
| [`41ed7ae5`](https://github.com/NixOS/nixpkgs/commit/41ed7ae5d285dfe6c4ad63eb325ab6d5152c5149) | `python310Packages.tweepy: 4.11.0 -> 4.12.0`                                                                |
| [`9d697a3b`](https://github.com/NixOS/nixpkgs/commit/9d697a3be3d1a36599a3c820dbe413760637c0a1) | `haskellPackages.*: disable postgresql tests on darwin`                                                     |
| [`311881f5`](https://github.com/NixOS/nixpkgs/commit/311881f51c0f96e57435f179328937cfc7097d9f) | `python310Packages.trimesh: 3.15.7 -> 3.15.8`                                                               |
| [`3fa15c35`](https://github.com/NixOS/nixpkgs/commit/3fa15c357033b1c7bdb88f34c1fb9f6427b4754c) | `freeglut: use xorg.* packages directly instead of xlibsWrapper indirection`                                |
| [`da9574e4`](https://github.com/NixOS/nixpkgs/commit/da9574e43153ac3eb245eeaa684657a5b04458a4) | `nedit: use xorg.* packages directly instead of xlibsWrapper indirection`                                   |
| [`1be66b24`](https://github.com/NixOS/nixpkgs/commit/1be66b246c4a74adf458883e428e2f578a84e795) | `ccache: 4.7.1 -> 4.7.2`                                                                                    |
| [`4ac5076d`](https://github.com/NixOS/nixpkgs/commit/4ac5076d75da8af6f83fcf948a406fc802927ccc) | `cargo-tally: 1.0.16 -> 1.0.17`                                                                             |
| [`4941d433`](https://github.com/NixOS/nixpkgs/commit/4941d433fa77557a3f7d5151d519b8e90c5d47a7) | `ngspice: add darwin to platforms`                                                                          |
| [`d10131aa`](https://github.com/NixOS/nixpkgs/commit/d10131aa3b9bc7c9cc1af468430e56780e05c8b4) | `python310Packages.spotipy: 2.20.0 -> 2.21.0`                                                               |
| [`b2f1884d`](https://github.com/NixOS/nixpkgs/commit/b2f1884dd85b55a63ae05fb84bea65082aece223) | `kicad: 6.0.8 -> 6.0.9`                                                                                     |
| [`f6ddbf25`](https://github.com/NixOS/nixpkgs/commit/f6ddbf25240c5b6f49229153b9060e87b7a66286) | `python310Packages.robotframework-requests: 0.9.3 -> 0.9.4`                                                 |
| [`2eb47b27`](https://github.com/NixOS/nixpkgs/commit/2eb47b274f1fab1588dbee2dc77fe41b95401764) | `python310Packages.python-utils: 3.3.3 -> 3.4.5`                                                            |
| [`ffdd42b7`](https://github.com/NixOS/nixpkgs/commit/ffdd42b7af97bb7f772dd0408df24275af361b37) | `python310Packages.python-gitlab: 3.10.0 -> 3.11.0`                                                         |
| [`04c151b9`](https://github.com/NixOS/nixpkgs/commit/04c151b9e35c1cd7ba6f03426d97a17aea251436) | `python310Packages.python-box: 6.0.2 -> 6.10.0`                                                             |
| [`02a83732`](https://github.com/NixOS/nixpkgs/commit/02a8373229448a6df8c7318628b64816c2698318) | `python310Packages.pytest-mypy-plugins: 1.10.0 -> 1.10.1`                                                   |
| [`425810dc`](https://github.com/NixOS/nixpkgs/commit/425810dc193d15ae9c3625878280d153d2a3539f) | `python310Packages.pysqueezebox: 0.6.0 -> 0.6.1`                                                            |
| [`b3ed8ba1`](https://github.com/NixOS/nixpkgs/commit/b3ed8ba167c1f6210e58aa1b44033a5fe53e0e2f) | `python310Packages.mitmproxy-wireguard: init at 0.1.15`                                                     |
| [`2575f0fc`](https://github.com/NixOS/nixpkgs/commit/2575f0fc36cc591e4519f4faa2cddafb49634b86) | `wiki-js: 2.5.289 -> 2.5.290`                                                                               |
| [`32441349`](https://github.com/NixOS/nixpkgs/commit/32441349518013cbb2750a4d90fb36f34333ad25) | `python310Packages.django_silk: disable on older Python releases`                                           |
| [`908b9d70`](https://github.com/NixOS/nixpkgs/commit/908b9d7041e0aec0c7480c449e79897b1e6e8219) | `gallery-dl: 1.23.4 -> 1.23.4`                                                                              |
| [`4f9179c1`](https://github.com/NixOS/nixpkgs/commit/4f9179c1f6d5c92a8012a6a89f86cd6c7b756ef1) | `cargo-lambda: init at 0.11.2`                                                                              |
| [`daeb280f`](https://github.com/NixOS/nixpkgs/commit/daeb280fa52dbdec4baedecd1bebd8ac0341985e) | `maintainers: add taylor1791`                                                                               |
| [`a4ab3efe`](https://github.com/NixOS/nixpkgs/commit/a4ab3efe8689ecf0c27e27e328b0939cc66ee991) | `opentelemetry-collector: 0.62.1 -> 0.63.1`                                                                 |
| [`92d3455a`](https://github.com/NixOS/nixpkgs/commit/92d3455a7a29f02ff6e677333f33b0b6913a3f31) | `oauth2-proxy: 7.3.0 -> 7.4.0`                                                                              |
| [`c177c9ad`](https://github.com/NixOS/nixpkgs/commit/c177c9adae65b009281246a29e8189c0914c3214) | `msrtool: Make the tool available only on x86 Linux`                                                        |
| [`437ae8df`](https://github.com/NixOS/nixpkgs/commit/437ae8dfd5f21294df966dfd885238cfba5c3c3e) | `jd-cli: init at 1.2.1`                                                                                     |
| [`d95d9632`](https://github.com/NixOS/nixpkgs/commit/d95d9632e1791928f66660f6d5f07cac8c48b517) | `python310Packages.django_silk: 5.0.1 -> 5.0.2`                                                             |
| [`ba465855`](https://github.com/NixOS/nixpkgs/commit/ba465855277cd4c8307dfb822ab24fbd28044b15) | `vimPlugins: update`                                                                                        |
| [`a84e2492`](https://github.com/NixOS/nixpkgs/commit/a84e2492acf38f0d3dfaa7687130eae9d9b91614) | `tree-sitter: update grammars`                                                                              |
| [`6451493a`](https://github.com/NixOS/nixpkgs/commit/6451493ab523743825c6df08f70d3e74d7b1a6a9) | `haskellPackages.citeproc: enable executable installed to bin output`                                       |
| [`84beab6d`](https://github.com/NixOS/nixpkgs/commit/84beab6d45cc32618e977fa7a815769bf53d8ef1) | `evcxr: 0.14.0 -> 0.14.1`                                                                                   |
| [`0b9ef60d`](https://github.com/NixOS/nixpkgs/commit/0b9ef60d38ba4f2731be07c2b6fe700285cc189c) | `xivlauncher: set meta.mainProgram`                                                                         |
| [`78f009c3`](https://github.com/NixOS/nixpkgs/commit/78f009c3bdb972c256e1e368c66f9786a416f130) | `ctlptl: 0.8.10 -> 0.8.11`                                                                                  |
| [`94da83f4`](https://github.com/NixOS/nixpkgs/commit/94da83f419af2380db922991e78f6b73e8d48708) | `haskellPackages.extensions: remove stale override and unbreak`                                             |
| [`6f82315b`](https://github.com/NixOS/nixpkgs/commit/6f82315b74522a3f4490584d1f5d1e76c622f05d) | `xplr: 0.19.4 -> 0.20.0`                                                                                    |
| [`58c8940e`](https://github.com/NixOS/nixpkgs/commit/58c8940e7bbbdb8b886fc72b9741968bb9211d18) | `trilium-desktop: 0.56.1 -> 0.56.2`                                                                         |
| [`f62ab879`](https://github.com/NixOS/nixpkgs/commit/f62ab8794155218d339c0566c4ab9e99ad1f86a8) | `intel-gmmlib: 22.2.1 -> 22.3.0`                                                                            |
| [`51901d04`](https://github.com/NixOS/nixpkgs/commit/51901d0479afcfbe9a7ef8fd44a9f0d6fe17d154) | `rmfakecloud: 0.0.10 -> 0.0.11`                                                                             |
| [`be033245`](https://github.com/NixOS/nixpkgs/commit/be033245871e6297b181f4d7a1501a006b34c8ce) | `metal-cli: 0.10.3 -> 0.11.0`                                                                               |
| [`5d773b2a`](https://github.com/NixOS/nixpkgs/commit/5d773b2a50cb57920c06770c58c5e431309c2a42) | `typescript: add to top-level`                                                                              |
| [`03472891`](https://github.com/NixOS/nixpkgs/commit/03472891ee3b062fc40f9daa59b8d01100e7bbc5) | `saleae-logic-2: 2.4.1 -> 2.4.2`                                                                            |
| [`627246f4`](https://github.com/NixOS/nixpkgs/commit/627246f4f923490ffe152f5dcaee268d9eda0bca) | `python3Packages.tensorflow-bin: relax protobuf, tensorboard version constraints to fix build`              |
| [`3e80adde`](https://github.com/NixOS/nixpkgs/commit/3e80adde814ecef8e8d776248107c1723750d616) | `python310Packages.azure-mgmt-redis: 14.0.0 -> 14.1.0`                                                      |
| [`109714a9`](https://github.com/NixOS/nixpkgs/commit/109714a9cb0f7efeeeef7e8b939b9978e374edb2) | `prometheus-node-exporter: drop already-applied patch on darwin`                                            |
| [`96f7444b`](https://github.com/NixOS/nixpkgs/commit/96f7444bc8ede288c34d7a3ff4f740054f6c4154) | `nixos/xray: init service`                                                                                  |
| [`0264a930`](https://github.com/NixOS/nixpkgs/commit/0264a930875eff93253a2095d8765116452d5fc3) | `xray: init at 1.6.1`                                                                                       |
| [`9173f1c5`](https://github.com/NixOS/nixpkgs/commit/9173f1c5b4fdfd655f0c1eb2494ffc8c454f57bb) | `matrix-synapse: 1.70.0 -> 1.70.1`                                                                          |
| [`3c4c38a7`](https://github.com/NixOS/nixpkgs/commit/3c4c38a7993ec0b8ac12c6f221dda4083f017238) | `nixos/tests/healthchecks: update test for auto user change in healthchecks-manage`                         |
| [`d89cbdcb`](https://github.com/NixOS/nixpkgs/commit/d89cbdcbe4386829e89596e0b0d790732f1a39b1) | `zfsUnstable: 2.1.6 → 2.1.7-staging`                                                                        |
| [`e46efbe7`](https://github.com/NixOS/nixpkgs/commit/e46efbe793274d58b77d1a6b519f3d4359567480) | `physfs: update meta`                                                                                       |
| [`7abe3608`](https://github.com/NixOS/nixpkgs/commit/7abe36086df93c57602634f1ae2330b66cf176d5) | `physfs: 3.0.2 -> 3.2.0`                                                                                    |
| [`60c47593`](https://github.com/NixOS/nixpkgs/commit/60c4759306c6ea78bf848edcb20fbe2f50cbc0cc) | `physfs_2: 2.0.3 -> 2.1.1`                                                                                  |
| [`130c9c88`](https://github.com/NixOS/nixpkgs/commit/130c9c8866d64a0e06815c4e70f12cefddbb03b7) | `maintainers: add iopq`                                                                                     |
| [`4ed7e2a8`](https://github.com/NixOS/nixpkgs/commit/4ed7e2a8669dda9cf6abac113264b563657c1949) | `recoll: fix no/bad configuration error on darwin`                                                          |
| [`ed531547`](https://github.com/NixOS/nixpkgs/commit/ed531547ffbd66342f6c6224191046e54577bcbc) | `haskellPackages.implicit-hie: Remove assertion to fix eval on ghc 9.4`                                     |
| [`fc886ef1`](https://github.com/NixOS/nixpkgs/commit/fc886ef1fc62693029222d610388c6dfee5845c7) | `haskell-language-server: Tune overrides to increase dependency sharing`                                    |
| [`6e49dfc7`](https://github.com/NixOS/nixpkgs/commit/6e49dfc7549d3d93f5538cfe776df647bbb01b3f) | `element-{web,desktop}: 1.11.10 -> 1.11.12`                                                                 |
| [`44cdc610`](https://github.com/NixOS/nixpkgs/commit/44cdc6104a0221de676dc1c2ab7db5223058b433) | `nixos/nextcloud: allow changing logType`                                                                   |
| [`09cf8c3f`](https://github.com/NixOS/nixpkgs/commit/09cf8c3f30a9f548c27beaa1ac9ca1ac72305577) | `haskellPackages.implici-hie: Override dependency to fix build`                                             |
| [`5e906acf`](https://github.com/NixOS/nixpkgs/commit/5e906acf263d067de3df83c3fd6f13adf490624e) | `haskell.packages.ghc942.co-log-core: ignore bounds on base, doctest`                                       |
| [`887462db`](https://github.com/NixOS/nixpkgs/commit/887462db03f59656db92038c65bf87981d69b35b) | `nixos/healthchecks: allow appending to EnvironmentFile to easily and securely setting EMAIL_HOST_PASSWORD` |
| [`37e9e677`](https://github.com/NixOS/nixpkgs/commit/37e9e677d6366ef97d9d0753f403e001f47a3f90) | `taffybar: build using GHC 9.0`                                                                             |
| [`6b562fb7`](https://github.com/NixOS/nixpkgs/commit/6b562fb70b5d3b60268c8abf910ec471368d4e51) | `haskell.packages.ghc924.dbus: 1.2.26 -> 1.2.27`                                                            |
| [`270246dd`](https://github.com/NixOS/nixpkgs/commit/270246ddd9be86e8267f8a82f459bf8455a9582d) | `haskellPackages: adapt to process 1.6.15.0 -> 1.6.16.0`                                                    |
| [`4ae75bcf`](https://github.com/NixOS/nixpkgs/commit/4ae75bcfdbaae784d8e53fbeebc104538d132136) | `haskell.packages.ghc942.{distribution-nixpkgs,cabal2nix}: run tests`                                       |
| [`26ec809a`](https://github.com/NixOS/nixpkgs/commit/26ec809a99c306268b7d12bd71b823832c8de0bd) | `haskell.packages.ghc942: adapt to now-working doctest 0.20.1`                                              |
| [`0d48e7b0`](https://github.com/NixOS/nixpkgs/commit/0d48e7b01974457ab0108f436ba0375cb21a29c0) | `haskellPackages: regenerate package set based on current config`                                           |
| [`725918a7`](https://github.com/NixOS/nixpkgs/commit/725918a71f040df24c72260202a2e8dbab3e9183) | `grafana: 9.2.1 -> 9.2.2`                                                                                   |
| [`7cead090`](https://github.com/NixOS/nixpkgs/commit/7cead0906992aa0b5054b6b92c982925ca4fcf22) | `haskellPackages: stackage LTS 19.28 -> LTS 19.30`                                                          |
| [`863feb52`](https://github.com/NixOS/nixpkgs/commit/863feb52a215dfd6a1507e0e203f12fd1a324d0f) | `all-cabal-hashes: 2022-10-11T19:16:50Z -> 2022-10-27T19:26:33Z`                                            |
| [`897044e4`](https://github.com/NixOS/nixpkgs/commit/897044e435e481c824bc197699dbbabee226548a) | `nixos/healthchecks: automatically invoke sudo in the wrapper`                                              |
| [`e8988ff1`](https://github.com/NixOS/nixpkgs/commit/e8988ff1501b4a710de63de824a2aefde92a4bd8) | `opentelemetry-collector-contrib: 0.62.0 -> 0.63.0`                                                         |
| [`0db2db35`](https://github.com/NixOS/nixpkgs/commit/0db2db3577dd3dfc2d8f6ac0d1f06c7e66d866af) | `python310Packages.aiopg: 1.3.5 -> 1.4.0`                                                                   |
| [`e3a905b7`](https://github.com/NixOS/nixpkgs/commit/e3a905b73f7e7deb4af3b34d081b4480ab4fd243) | `python310Packages.psycopg2: 2.9.3 -> 2.9.5`                                                                |
| [`bacd02c3`](https://github.com/NixOS/nixpkgs/commit/bacd02c315af77656c759b549854d5beed305b28) | `dwarf-fortress: misc cleanup`                                                                              |
| [`1d67cf2d`](https://github.com/NixOS/nixpkgs/commit/1d67cf2daf13a12831fa3761b95e7e55a1f18ed1) | `dwarf-fortress-packages.dwarf-fortress: set meta for versioned packages`                                   |
| [`5b291004`](https://github.com/NixOS/nixpkgs/commit/5b291004c518cf85d75c77ecdfcdf89f73fef1cf) | `dwarf-fortress: make meta.homepage independent from download page`                                         |