### PR TITLE
chore(flake/darwin): `f6648ca0` -> `b7177030`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666776005,
-        "narHash": "sha256-HwSMF19PpczfqNHKcFsA6cF4PVbG00uUSdbq6q3jB5o=",
+        "lastModified": 1667294277,
+        "narHash": "sha256-YhVGYUpPZNpJZ8z3Sq9aT6n1/B8vKtfRfwaCtbsosxk=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "f6648ca0698d1611d7eadfa72b122252b833f86c",
+        "rev": "b7177030643374e698c29e993c2808efa7b85aaf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                    |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`64fbf13a`](https://github.com/LnL7/nix-darwin/commit/64fbf13a8f10527568fb722c6609c8ac724bff1d) | `Correct capitalisation of NixOS`                 |
| [`ed1e73d0`](https://github.com/LnL7/nix-darwin/commit/ed1e73d01e439c80cb2088e0190410236beb5826) | `applications: Drop store prefix to generalize`   |
| [`fbe795f3`](https://github.com/LnL7/nix-darwin/commit/fbe795f39dbcc242ddc6f7ab01689617746d9402) | `applications: Symlink Nix Apps to /Applications` |
| [`9c76fbf2`](https://github.com/LnL7/nix-darwin/commit/9c76fbf20ff48f8d08ebe12e564c86e9ebd4a9b3) | `Disable taking control of ~/Applications folder` |