### PR TITLE
chore(flake/home-manager): `8957d531` -> `183a62f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667328200,
-        "narHash": "sha256-INjKAogrfp1Jo+XlkZV2Y+jIx4rpUEsBDRdsoE6BrDU=",
+        "lastModified": 1667346356,
+        "narHash": "sha256-gfXoBPV7gVD1HH9Q1NoShL/CHJc2HQsQ51XMW8zJu3o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8957d531997a2b1f4562a7e6313a78a450d5074b",
+        "rev": "183a62f356f16d12ac60f0e4e5d54f0bd78f6ba6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                       |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`183a62f3`](https://github.com/nix-community/home-manager/commit/183a62f356f16d12ac60f0e4e5d54f0bd78f6ba6) | `targets/generic-linux: use the correct nix package` |
| [`824202b4`](https://github.com/nix-community/home-manager/commit/824202b4c4feb02e11fa1a44b140d5b0f218702c) | `readme: add inofficial option search`               |