### PR TITLE
chore(flake/pre-commit-hooks): `8e5d2ccc` -> `a7cbf54c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667390517,
-        "narHash": "sha256-VHjuxX5b4ZAX2a3lNRFEYxr5XcA62XUObF9NkQm0WxU=",
+        "lastModified": 1667392064,
+        "narHash": "sha256-dD1uFtvjrYKkzdVjzu/x6S5GUKrCq33/AxY/DNs4ER8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "8e5d2ccca05e1d40226d5f2b3cf9e30e7b467325",
+        "rev": "a7cbf54c1ffe46e1a1112a1f55047263c9af06b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------------- |
| [`20c551bb`](https://github.com/cachix/pre-commit-hooks.nix/commit/20c551bbd9202a30b0a4f604a5c066b24b92ee5b) | `reduce closure size`     |
| [`d61dcf26`](https://github.com/cachix/pre-commit-hooks.nix/commit/d61dcf26beb76161e227a15924b7faabea70837c) | `bump to nixpkg-unstable` |
| [`50b276f7`](https://github.com/cachix/pre-commit-hooks.nix/commit/50b276f7f5adc565d8f037145d8f92f6ddaa4b4e) | `add mdsh`                |