### PR TITLE
chore(flake/home-manager): `916811c8` -> `f520832a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667386877,
-        "narHash": "sha256-CP8CbIiykhevS9KsFO5kKP7CfrnGjORhvkHV6PMyh90=",
+        "lastModified": 1667410913,
+        "narHash": "sha256-5+S65dpXaIyMDeoPy823BzNH5HYY1wvZ6G+rzTnO8kY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "916811c8f9ef37beb7705150d76cc88ce79466fd",
+        "rev": "f520832a47dbc24d1e2c4e4b9a3dbe910777d1a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                      |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`f520832a`](https://github.com/nix-community/home-manager/commit/f520832a47dbc24d1e2c4e4b9a3dbe910777d1a2) | `darwin: re-enable ~/Applications symlinks (#3139)` |