### PR TITLE
chore(flake/pre-commit-hooks): `3eb97d92` -> `b8454857`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667569243,
-        "narHash": "sha256-oJ9zVRE6EFa6Pgh0ZWPAbtDrVu1mxp9lH88LZH6MlfQ=",
+        "lastModified": 1667680128,
+        "narHash": "sha256-bnXYCDzkviKNeYwnh3YW2HpgSgUMnSGVsTtHNLXBXfE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3eb97d920682777005930ebe01797dc54b1ccb32",
+        "rev": "b84548575a627cad3e0b31b2c2b64eb7774c24db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                                            |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`1ee64b85`](https://github.com/cachix/pre-commit-hooks.nix/commit/1ee64b852871d790a49f0b8e17b788f5eeb2d52a) | `Improve docs`                                            |
| [`aa013d6a`](https://github.com/cachix/pre-commit-hooks.nix/commit/aa013d6afcf7d742db12dd889d68637ef3f5bacc) | `.envrc: Fix completions for system commands such as nix` |
| [`06a04338`](https://github.com/cachix/pre-commit-hooks.nix/commit/06a04338a1bbaca242ab9a2cd42ecc9acde98fb2) | `flakeModule: Add check.enable option`                    |
| [`68079e4c`](https://github.com/cachix/pre-commit-hooks.nix/commit/68079e4cb42754873fa2d167282ae682a6543e62) | `Make the docs build`                                     |
| [`59b64996`](https://github.com/cachix/pre-commit-hooks.nix/commit/59b64996544ce0bf3afa2cea7eee2dfdfb2c7e73) | `template/flake.nix: Update`                              |
| [`53df6d32`](https://github.com/cachix/pre-commit-hooks.nix/commit/53df6d3270ab0f4bfc89b8b9a023ed37240d3902) | `flake-modules-core -> flake-parts, decide pkgs source`   |
| [`f77cd609`](https://github.com/cachix/pre-commit-hooks.nix/commit/f77cd6093b9135825309fa6bfd3903dc4a64d8bd) | `Add template`                                            |
| [`be97b3d6`](https://github.com/cachix/pre-commit-hooks.nix/commit/be97b3d6475501b17b610cacfcba72572c1d50dd) | `Add flakeModule`                                         |