### PR TITLE
chore(flake/home-manager): `c7283074` -> `1ef0da32`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667618048,
-        "narHash": "sha256-pKgavGAXBiugdKd93Z3A8hGpUmc3wkTSHlzqXd1cTo0=",
+        "lastModified": 1667708081,
+        "narHash": "sha256-FChEy05x4ed/pttjfTeKxjPCnHknMYrUtDyBiYbreT4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c728307482dacc9b2720b8036292b166c7865fa9",
+        "rev": "1ef0da321217c6c19b7a30509631c080a19321e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                           |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`1ef0da32`](https://github.com/nix-community/home-manager/commit/1ef0da321217c6c19b7a30509631c080a19321e5) | `flake.lock: Update`                                     |
| [`c5adf295`](https://github.com/nix-community/home-manager/commit/c5adf29545b553089ccf9c28b68973ce6f812c1c) | `i3: fix reloading when there are several sockets`       |
| [`989d4fa5`](https://github.com/nix-community/home-manager/commit/989d4fa536e9bcd6bc2d42b3ac8b9dc07b1f9d26) | `home-environment: remove no-op commands`                |
| [`ccc9164b`](https://github.com/nix-community/home-manager/commit/ccc9164b76e4167873ed819f0fb014635453ec68) | `home-environment: fix activation on new style profiles` |