### PR TITLE
chore(flake/home-manager): `1ef0da32` -> `88667599`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667708081,
-        "narHash": "sha256-FChEy05x4ed/pttjfTeKxjPCnHknMYrUtDyBiYbreT4=",
+        "lastModified": 1667830176,
+        "narHash": "sha256-TNm8W88Jf9qELqKI8rGMr0sZWlTV9WKIlqN4dzvuKUA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1ef0da321217c6c19b7a30509631c080a19321e5",
+        "rev": "886675991b643b701a33f533443db165c70692d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                      |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`88667599`](https://github.com/nix-community/home-manager/commit/886675991b643b701a33f533443db165c70692d1) | `home-environment: reset PATH in activation script` |
| [`d6777656`](https://github.com/nix-community/home-manager/commit/d67776563ec1f11df401837aa800c212417a6ca6) | ``systemd: fix `systemctlPath` default text``       |
| [`5dd3ce3f`](https://github.com/nix-community/home-manager/commit/5dd3ce3f1eb83cb6d45c27ef7d19fc9913681a82) | `mu: use absolute path to mu in activation block`   |