### PR TITLE
chore(flake/nixpkgs): `667e5581` -> `09326850`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667811565,
-        "narHash": "sha256-HYml7RdQPQ7X13VNe2CoDMqmifsXbt4ACTKxHRKQE3Q=",
+        "lastModified": 1667901915,
+        "narHash": "sha256-IkSou5ox/yZ2YUhGpk8vxd2TNU2pwRlYtir5k55NaxE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "667e5581d16745bcda791300ae7e2d73f49fff25",
+        "rev": "093268502280540a7f5bf1e2a6330a598ba3b7d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`09326850`](https://github.com/NixOS/nixpkgs/commit/093268502280540a7f5bf1e2a6330a598ba3b7d0) | `netbird: 0.10.4 -> 0.10.6`                                                                     |
| [`693d8798`](https://github.com/NixOS/nixpkgs/commit/693d87982737c4819c73303db8b079c9d184240f) | `fwbuilder: fix build`                                                                          |
| [`0402e1f0`](https://github.com/NixOS/nixpkgs/commit/0402e1f00b59eaf2f9108e3b558f51ed25bef430) | `pgmetrics: 1.13.1 -> 1.14.0`                                                                   |
| [`3cf71169`](https://github.com/NixOS/nixpkgs/commit/3cf711696e4075b5198a03d46e75f24bb9a2bf1c) | `python310Packages.mastodon-py: 1.5.1 -> 1.5.2`                                                 |
| [`6acfc788`](https://github.com/NixOS/nixpkgs/commit/6acfc788cc93f6e79a2dee1faf4328df208835f0) | `buildMozillaMach: add curl into crashreporter rpath`                                           |
| [`894f2bfd`](https://github.com/NixOS/nixpkgs/commit/894f2bfdcd57ef335e46b7a339108d12e5f1e6c1) | `imagemagick: 7.1.0-51 -> 7.1.0-52`                                                             |
| [`f0e84b66`](https://github.com/NixOS/nixpkgs/commit/f0e84b668fc0a588f8958d4d2fdaec83a7fb7785) | `python310Packages.huawei-lte-api: 1.6.4 -> 1.6.6`                                              |
| [`e09f6f4f`](https://github.com/NixOS/nixpkgs/commit/e09f6f4fa12da17d8692af0b865f6e6fe9aa7aa7) | `verible: add newAM to maintainers`                                                             |
| [`2424f83a`](https://github.com/NixOS/nixpkgs/commit/2424f83ab748c8d78606f9346529236df68543ca) | `oh-my-posh: 12.12.1 -> 12.13.0`                                                                |
| [`15048810`](https://github.com/NixOS/nixpkgs/commit/150488101f3f86e7e4168cd4a9da474ce04e6c90) | `terraform-providers.ucloud: 1.32.4 → 1.32.5`                                                   |
| [`2fcd4677`](https://github.com/NixOS/nixpkgs/commit/2fcd46776cf3dec20b4eac1bef22a68724a07dbd) | `terraform-providers.snowflake: 0.50.0 → 0.51.0`                                                |
| [`f5da6461`](https://github.com/NixOS/nixpkgs/commit/f5da646112cf75163e37906c1eaf8829e5291239) | `terraform-providers.scaleway: 2.5.0 → 2.6.0`                                                   |
| [`42dfb67b`](https://github.com/NixOS/nixpkgs/commit/42dfb67bb0d777397e657a827627d5ec947e46c5) | `terraform-providers.mongodbatlas: 1.4.6 → 1.5.0`                                               |
| [`ae3df9e9`](https://github.com/NixOS/nixpkgs/commit/ae3df9e9df965deaec2ef5f5cff19eea87052a21) | `terraform-providers.http: 3.2.0 → 3.2.1`                                                       |
| [`782c8381`](https://github.com/NixOS/nixpkgs/commit/782c83817695602baef09247902e6610516162fa) | `terraform-providers.gridscale: 1.16.1 → 1.16.2`                                                |
| [`474b97d7`](https://github.com/NixOS/nixpkgs/commit/474b97d748f94c3a47b2fbc70449607b64e7ee98) | `terraform-providers.google-beta: 4.42.1 → 4.43.0`                                              |
| [`003025aa`](https://github.com/NixOS/nixpkgs/commit/003025aa3c1bd84c370ce8fd203cc6cf41abbb7a) | `terraform-providers.google: 4.42.1 → 4.43.0`                                                   |
| [`f293a4f4`](https://github.com/NixOS/nixpkgs/commit/f293a4f4871ec5a5819ff817072806c53b8f9757) | `terraform-providers.baiducloud: 1.17.0 → 1.17.1`                                               |
| [`b59a8cf7`](https://github.com/NixOS/nixpkgs/commit/b59a8cf7862370c968f3a82a8df345468b1dfb9a) | `terraform-providers.auth0: 0.39.0 → 0.40.0`                                                    |
| [`403af417`](https://github.com/NixOS/nixpkgs/commit/403af417dfed28510c5a8aa5abdf34a151191603) | `nixpacks: 0.12.2 -> 0.12.3`                                                                    |
| [`88caa3b5`](https://github.com/NixOS/nixpkgs/commit/88caa3b5381619706c563fa20a68201cb43c4096) | `python310Packages.graphql-subscription-manager: 0.6.1 -> 0.7.0`                                |
| [`d54da1f2`](https://github.com/NixOS/nixpkgs/commit/d54da1f2ff2434d193b884d5f680d3bc41cfc5f7) | `python310Packages.google-cloud-spanner: 3.22.2 -> 3.23.0`                                      |
| [`c4c025e2`](https://github.com/NixOS/nixpkgs/commit/c4c025e250a966a976d6d262b13e0f71fd5d3ff3) | `verible: 0.0-2172-g238b6df60 -> 0.0-2472-ga80124e1`                                            |
| [`4078ed75`](https://github.com/NixOS/nixpkgs/commit/4078ed7536c84fcabe62d70afd6b0f3b43812cb0) | `janet: 1.24.1 -> 1.25.1`                                                                       |
| [`b27746b8`](https://github.com/NixOS/nixpkgs/commit/b27746b804ac69f36e397a73baf5eefeef72ce6f) | `ruff: 0.0.105 -> 0.0.107`                                                                      |
| [`21621146`](https://github.com/NixOS/nixpkgs/commit/21621146c498cb9e4713d6712fa58d432e013ec2) | `owofetch: mark as x86_64 only`                                                                 |
| [`7c3d2e6c`](https://github.com/NixOS/nixpkgs/commit/7c3d2e6cca58bd1fabc83d5f7a3af4ff69c977bd) | `cargo-guppy: unstable-2022-10-29 -> unstable-2022-11-07`                                       |
| [`b7a3d4bb`](https://github.com/NixOS/nixpkgs/commit/b7a3d4bb11ad8cf8ca6e8a023704fd0370612098) | `verible: fix build for aarch64-linux`                                                          |
| [`ec1dd542`](https://github.com/NixOS/nixpkgs/commit/ec1dd542530a8856e527c5c9970ca31135a359d4) | `cargo-hakari: 0.9.15 -> 0.9.16`                                                                |
| [`25f3b1cb`](https://github.com/NixOS/nixpkgs/commit/25f3b1cbcbe3165986c6691fe6fbe7187bf4eb3b) | `python310Packages.pyspellchecker: init at 0.7.0`                                               |
| [`683f25a6`](https://github.com/NixOS/nixpkgs/commit/683f25a6af6e5642cd426c69a4de1d434971a695) | `tdesktop: 4.3.0 -> 4.3.1`                                                                      |
| [`034d8b4e`](https://github.com/NixOS/nixpkgs/commit/034d8b4e52b82814c81cd5eb8dd9e082c7768b94) | `python310Packages.oslo-concurrency: disable tests`                                             |
| [`1e3628c0`](https://github.com/NixOS/nixpkgs/commit/1e3628c0e17609402f3f153ed96f87f20bd6aaf5) | `sheldon: fix build missing Security`                                                           |
| [`cacb8033`](https://github.com/NixOS/nixpkgs/commit/cacb803367e1914edc41f569411787ef65e61c55) | `lux: 0.15.0 -> 0.16.0`                                                                         |
| [`3368f48d`](https://github.com/NixOS/nixpkgs/commit/3368f48dec91a4092b3cac1ca223ece33b5e7cde) | `python310Packages.s3-credentials: disable failing tests`                                       |
| [`e777028c`](https://github.com/NixOS/nixpkgs/commit/e777028c53f89b9c48261f11004f18e716fe9776) | `lefthook: 1.1.4 -> 1.2.0`                                                                      |
| [`110c34d3`](https://github.com/NixOS/nixpkgs/commit/110c34d3b77299ff339d9bbef9c1a39e7cabed74) | `python3Packages.scikit-fuzzy: unstable-2021-03-31 -> unstable-2022-11-07`                      |
| [`8ec25278`](https://github.com/NixOS/nixpkgs/commit/8ec252784ed0a348c2a752bee96f23a7a81c5755) | `zrepl: 0.5.0 -> 0.6.0`                                                                         |
| [`c0615ec2`](https://github.com/NixOS/nixpkgs/commit/c0615ec21ac51960368b9b4379f16f4300a41060) | `xvidcap: remove`                                                                               |
| [`085101b0`](https://github.com/NixOS/nixpkgs/commit/085101b00fb01f5de398fa7a4c441630674816a3) | `gnome2.scrollkeeper: remove`                                                                   |
| [`fda57931`](https://github.com/NixOS/nixpkgs/commit/fda57931f6a36f802c4576fe37f9f7410a341c0e) | `synfigstudio: add missing intltool to nativeBuildInputs`                                       |
| [`e697aa47`](https://github.com/NixOS/nixpkgs/commit/e697aa47b5fb654146d2138ee5bf1c1c1a9926bf) | `werf: 1.2.184 -> 1.2.187`                                                                      |
| [`78a694ff`](https://github.com/NixOS/nixpkgs/commit/78a694fff420f5bcd52dbc266d5df96e60cf05a5) | `clipqr: mark broken on darwin`                                                                 |
| [`1172afbe`](https://github.com/NixOS/nixpkgs/commit/1172afbef14e8dbeed4c930be001b46eb121e6ca) | `python310Packages.pymunk: 6.2.1 -> 6.3.0`                                                      |
| [`6008f4ec`](https://github.com/NixOS/nixpkgs/commit/6008f4ec11e00dfc1e9020f6e757d0822d265c5f) | `zigbee2mqtt: enable nixpkgs-update to find update script`                                      |
| [`a9531a1a`](https://github.com/NixOS/nixpkgs/commit/a9531a1a270f5b4c4b300999827aa21963427c57) | `folly: 2022.09.05.00 -> 2022.11.07.00`                                                         |
| [`8490af63`](https://github.com/NixOS/nixpkgs/commit/8490af631e9aa17090e6a3829560bee5b75fcf91) | `ferretdb: 0.6.0 -> 0.6.1`                                                                      |
| [`f0c8df5c`](https://github.com/NixOS/nixpkgs/commit/f0c8df5cb6f31e9490381edcb017b7b58fa78370) | `python310Packages.pycfdns: 1.2.2 -> 2.0.0`                                                     |
| [`6298f5fa`](https://github.com/NixOS/nixpkgs/commit/6298f5fa1d158851f55e194981c31c6734d655e1) | `Revert ".github/dependabot.yml: disable"`                                                      |
| [`22ec8cd8`](https://github.com/NixOS/nixpkgs/commit/22ec8cd807e867d7678f41e9e6e705c0775b1da5) | `ffmpeg: fix cross`                                                                             |
| [`2abc0277`](https://github.com/NixOS/nixpkgs/commit/2abc0277f01dd09dfcf250cd371256df249dba7a) | `glib-networking: fix cross and enable strictDeps`                                              |
| [`5f07247a`](https://github.com/NixOS/nixpkgs/commit/5f07247a07387d29e2323e4856d5992b67efdac6) | `mepo: init module`                                                                             |
| [`e6b77730`](https://github.com/NixOS/nixpkgs/commit/e6b77730725277ce96284c715ac26d0c10215876) | `mepo: 0.4.2 -> 1.1`                                                                            |
| [`2aa5c8d3`](https://github.com/NixOS/nixpkgs/commit/2aa5c8d3abd627a871619260bc5cd83defa6c042) | `nixos/teamviewer: fix for non-NetworkManager environments`                                     |
| [`891dfb1b`](https://github.com/NixOS/nixpkgs/commit/891dfb1b636737be2f4d8d235233b08e4d2ffb67) | `nixos/mastodon: add option mediaAutoRemove`                                                    |
| [`ae5ed8ce`](https://github.com/NixOS/nixpkgs/commit/ae5ed8ce226db3913adf7b1107487f53bd8c69da) | `mudlet: 4.15.1 -> 4.16.0`                                                                      |
| [`e6aec927`](https://github.com/NixOS/nixpkgs/commit/e6aec927b4fdbe5984835e1c59e680fcc3fa8220) | `python310Packages.aiopyarr: 22.10.0 -> 22.11.0`                                                |
| [`ffefe17d`](https://github.com/NixOS/nixpkgs/commit/ffefe17d31c8cd219a83991b5e978fd15954f6af) | `element-web: add wrapper`                                                                      |
| [`eb33bec8`](https://github.com/NixOS/nixpkgs/commit/eb33bec8b3e515e63859f3751aa23e0e1684f44d) | `nixos/less: fix spacing`                                                                       |
| [`4493598d`](https://github.com/NixOS/nixpkgs/commit/4493598d4b0e6cd13a40a297cd01d6222665a68c) | `php.packages.php-parallel-lint: fix build`                                                     |
| [`5b5ed0d9`](https://github.com/NixOS/nixpkgs/commit/5b5ed0d9a491a6165d837850437e795d4e87e715) | `scaleway-cli: 2.6.1 -> 2.6.2`                                                                  |
| [`b1959a11`](https://github.com/NixOS/nixpkgs/commit/b1959a116bdcd248aadd66cd1491046c49dcd739) | `python310Packages.aiohomekit: 2.2.17 -> 2.2.18`                                                |
| [`e357df00`](https://github.com/NixOS/nixpkgs/commit/e357df0063b76e99268602e49c204e03714380e1) | `nanodbc: 2.13.0 -> 2.14.0 and fix build`                                                       |
| [`ee436f94`](https://github.com/NixOS/nixpkgs/commit/ee436f945a50c2f0943fed50e0b23841cb83ae13) | `python310Packages.bleak-retry-connector: 2.8.2 -> 2.8.3`                                       |
| [`26ac2781`](https://github.com/NixOS/nixpkgs/commit/26ac27810ebf747744bebecee643c8440fbccc57) | `python310Packages.bleak: 0.19.1 -> 0.19.4`                                                     |
| [`caed6c00`](https://github.com/NixOS/nixpkgs/commit/caed6c004d52649e5c4a80d247c62289b67e0d6a) | `oh-my-zsh: 2022-11-06 -> 2022-11-07`                                                           |
| [`f6260b00`](https://github.com/NixOS/nixpkgs/commit/f6260b00baa812e13e8235cf47459d7d52ed3431) | `dillong: init at unstable-2021-12-13`                                                          |
| [`7a509caa`](https://github.com/NixOS/nixpkgs/commit/7a509caabd7a21c508b6e9233ad0131ab3febf37) | `qt6.qtwebengine: unmark broken on aarch64-linux`                                               |
| [`996fa2bc`](https://github.com/NixOS/nixpkgs/commit/996fa2bca21a1bde349cf02f76a807a564c8e565) | `fdroidserver: 2.1 -> 2.1.1`                                                                    |
| [`6a01d889`](https://github.com/NixOS/nixpkgs/commit/6a01d889b387d2b0212c1d2ccb14a8b2724f1eaa) | `platformio: unmark as broken on aarch64-linux`                                                 |
| [`91a82f14`](https://github.com/NixOS/nixpkgs/commit/91a82f14d2c22f9c606c8c3df5579549796e393f) | `endeavour: 42.0 → 43.0`                                                                        |
| [`82e844aa`](https://github.com/NixOS/nixpkgs/commit/82e844aad1688d071429140d6307d23a888c4501) | `endeavour: move to pkgs/applications/office`                                                   |
| [`427e4959`](https://github.com/NixOS/nixpkgs/commit/427e49595b477a911b97253e6c17be70070a77f9) | `mangal: 4.0.1 -> 4.0.2`                                                                        |
| [`37171a5d`](https://github.com/NixOS/nixpkgs/commit/37171a5d906a609ca593b3a47965b4cae941e3c4) | `yamlpath: 3.6.8 -> 3.6.9`                                                                      |
| [`3384acc1`](https://github.com/NixOS/nixpkgs/commit/3384acc17a6421ccaceddb1b29f7f54cb3c88bc8) | `hurl: 1.7.0 -> 1.8.0, add figsoda as a maintainer`                                             |
| [`6b94441f`](https://github.com/NixOS/nixpkgs/commit/6b94441f88d051332367539413ecd16aad6dfc67) | `lightningcss: 1.16.0 → 1.16.1`                                                                 |
| [`6d7127b1`](https://github.com/NixOS/nixpkgs/commit/6d7127b1765578183ad428b5d99e4d113f13fe4c) | `lzlib: fix darwin build`                                                                       |
| [`1ef74a78`](https://github.com/NixOS/nixpkgs/commit/1ef74a785480396ba179200196cac8256a67cfce) | `lighthouse: module add defaults`                                                               |
| [`c777fbab`](https://github.com/NixOS/nixpkgs/commit/c777fbabdb98195ee58d32e620921dfd162387ad) | `EBTKS: fix build on aarch64-darwin`                                                            |
| [`5d959cdf`](https://github.com/NixOS/nixpkgs/commit/5d959cdfdbb8da186a2942f8dd86c90d99b87f1f) | `python310Packages.pyunifiprotect: 4.3.4 -> 4.4.0`                                              |
| [`4222a3f7`](https://github.com/NixOS/nixpkgs/commit/4222a3f727cac4d0d999fbd80fdef1e56707b882) | `python310Packages.tensorboard: widen version pinning (again)`                                  |
| [`2d1dc67f`](https://github.com/NixOS/nixpkgs/commit/2d1dc67fe1d2abbd86051c59eaa597ef85c09129) | `aspellDicts.is, aspellDicts.nb: fix build on darwin`                                           |
| [`ed9998cf`](https://github.com/NixOS/nixpkgs/commit/ed9998cf2a5ebb181ee604d2f0a2b0c64718c082) | ``nixos/lightdm: add `greeters.mobile` config option``                                          |
| [`32b67fe0`](https://github.com/NixOS/nixpkgs/commit/32b67fe06229fb39023fd8ca4b6d8ed3342e2df4) | `lightdm-mobile-greeter: init at 2022-10-30`                                                    |
| [`0778d6e0`](https://github.com/NixOS/nixpkgs/commit/0778d6e0c447a7f8ee3e579af97a0cab04954a88) | `metasploit: 6.2.24 -> 6.2.25`                                                                  |
| [`17c25013`](https://github.com/NixOS/nixpkgs/commit/17c250135f8c9dd74771db3537bf9657a6badf88) | ``sumneko-lua-language-server: set logpath and metapath to `$XDG_CACHE_HOME` if set``           |
| [`ddc69ddd`](https://github.com/NixOS/nixpkgs/commit/ddc69ddd7756534ba78a8835e7d4367ee0ecabd6) | `nodePackages.elm-test: init at 0.19.1-revision10`                                              |
| [`f4ff9c26`](https://github.com/NixOS/nixpkgs/commit/f4ff9c26499a600fcc2459cfc6d8bbc5c1dfc5ea) | `lighthouse: init module`                                                                       |
| [`f9c04d85`](https://github.com/NixOS/nixpkgs/commit/f9c04d85570252777530fe2495b96352cbac7f3c) | `neovide: 0.10.1 -> 0.10.3`                                                                     |
| [`92cb304f`](https://github.com/NixOS/nixpkgs/commit/92cb304f3be713edb9cb02da9dbaec1d018fc0bb) | `python310Packages.pick: 2.0.2 -> 2.1.0`                                                        |
| [`1528a7ca`](https://github.com/NixOS/nixpkgs/commit/1528a7ca86b19830e87590113e9db15955fbffe9) | `cinnamon.cinnamon-gsettings-overrides: Override gnome-terminal settings with Fedora's default` |
| [`acc4e8eb`](https://github.com/NixOS/nixpkgs/commit/acc4e8eb237f83d0e85463722c9411ee0de44f8a) | `btcd: init at 0.23.3`                                                                          |
| [`ac4ed49f`](https://github.com/NixOS/nixpkgs/commit/ac4ed49fa5ff12e6eb6aac72b17f5df01088d4b4) | `crun: 1.6 -> 1.7`                                                                              |
| [`b234d4f0`](https://github.com/NixOS/nixpkgs/commit/b234d4f06d75dc2ac2caafb6e3be83d940715a96) | `esbuild_netlify: Add netlify-cli to tests`                                                     |
| [`4cf3912d`](https://github.com/NixOS/nixpkgs/commit/4cf3912d54fa82b22a6f8ac32d907fe0d31063b5) | `nix-du: 0.6.0 -> 1.0.0`                                                                        |
| [`590a40e1`](https://github.com/NixOS/nixpkgs/commit/590a40e13423cf7f575fc140a54cebeaff9819cd) | `android-studio: 2021.3.1.16 -> 2021.3.1.17`                                                    |
| [`dd947cf3`](https://github.com/NixOS/nixpkgs/commit/dd947cf33a9fd2ebbd056690e1783c4869690c38) | `grype: fix for darwin`                                                                         |
| [`286e7fbb`](https://github.com/NixOS/nixpkgs/commit/286e7fbbe9ef8c5ea930f7f6ad535dc8e26f5d81) | `lispPackages_new.sbclPackages.pgloader: add`                                                   |
| [`a8ed4be9`](https://github.com/NixOS/nixpkgs/commit/a8ed4be9a67c98770dceb00b52f7caa2d0c73eca) | `gmsh: 4.10.5 -> 4.11.0`                                                                        |
| [`ab0ae8f5`](https://github.com/NixOS/nixpkgs/commit/ab0ae8f5e11bacdf249c27c49f1fe30a3bf8b77f) | `nixos/pam: add option failDelay`                                                               |
| [`66d4d937`](https://github.com/NixOS/nixpkgs/commit/66d4d937948f435505939ffcaf32291d2748a224) | `python310Packages.lightwave2: 0.8.15 -> 0.8.16`                                                |
| [`6704831a`](https://github.com/NixOS/nixpkgs/commit/6704831a47c7d57b7d8773a63edb9791973d46c0) | `fuzzel: 1.7.0 -> 1.8.2`                                                                        |
| [`cd5c84e8`](https://github.com/NixOS/nixpkgs/commit/cd5c84e886f34520a088e92cc8379454c985cb97) | `nodePackages.localtunnel: init at 2.0.2`                                                       |
| [`574f3838`](https://github.com/NixOS/nixpkgs/commit/574f38381636b7abc37f96fd69a87cc9d180e75f) | `python3Packages.trezor: 0.13.3 -> 0.13.4`                                                      |
| [`ad83bff0`](https://github.com/NixOS/nixpkgs/commit/ad83bff0088bcefd621fcf16b0db5d34f0cebf1c) | `nixos/binfmt: restart systemd-binfmt when registrations change`                                |
| [`9519670e`](https://github.com/NixOS/nixpkgs/commit/9519670e6f3441c54dbdf85339632ef8c3a7abcf) | `pyinfra: 2.5.1 -> 2.5.2`                                                                       |
| [`29ea368e`](https://github.com/NixOS/nixpkgs/commit/29ea368e3c5924d83344e614dd42cf81301097dd) | `python3Packages.construct-classes: init at 0.1.2`                                              |
| [`762fcbb8`](https://github.com/NixOS/nixpkgs/commit/762fcbb80b5ec8746d4c0f9c41b90e0556905870) | `python310Packages.rpi-gpio: only build on Linux`                                               |
| [`9185b136`](https://github.com/NixOS/nixpkgs/commit/9185b136d3e211a1f2237a8074698eb8e08a5af5) | `discord-canary: 0.0.142 -> 0.0.143`                                                            |
| [`e0f93084`](https://github.com/NixOS/nixpkgs/commit/e0f93084f7d45421a91a6bd2d2f92ff51d9c61cb) | `ccache: 4.7.2 -> 4.7.3`                                                                        |
| [`0738e162`](https://github.com/NixOS/nixpkgs/commit/0738e1622cad4cf7db86a6ea3ed66cb0b82df864) | `nil: 2022-10-03 -> 2022-11-07`                                                                 |
| [`3138f960`](https://github.com/NixOS/nixpkgs/commit/3138f960513761cf938824a1716e87726d7d9f99) | `tor-browser-bundle-bin: 11.5.6 -> 11.5.7`                                                      |
| [`b40b8b92`](https://github.com/NixOS/nixpkgs/commit/b40b8b92e200373f85854d197bc3d1687c43d38f) | `nixos/wordpress: ensure that fonts already exists`                                             |
| [`83ecc90d`](https://github.com/NixOS/nixpkgs/commit/83ecc90d1012eeb3dc379c737edc42974ddb41b1) | `nixos/mdevctl: init module`                                                                    |
| [`ea396831`](https://github.com/NixOS/nixpkgs/commit/ea396831fa5d6bc6ad5ded7447d5e2d17a79c4c1) | `mdevctl: init at 1.2.0`                                                                        |
| [`e844d8ad`](https://github.com/NixOS/nixpkgs/commit/e844d8adbd0cb29298f24e489feea5d5dbe0743f) | `closurecompiler: 20221004 -> 20221102`                                                         |
| [`24c0592e`](https://github.com/NixOS/nixpkgs/commit/24c0592e58f2846ac3d2022732fbb986de05b80d) | `isync: Fix "Buffer too small" error`                                                           |
| [`24323d10`](https://github.com/NixOS/nixpkgs/commit/24323d103cd20a6b665eab03c2ec324caccb99b8) | `electron: mark versions < 18 as EOL`                                                           |
| [`e8805267`](https://github.com/NixOS/nixpkgs/commit/e8805267fe7f1bb6a688a16765a3b368472479e5) | `hedgedoc: 1.9.5 -> 1.9.6`                                                                      |
| [`cef7cd60`](https://github.com/NixOS/nixpkgs/commit/cef7cd60607d0f3a291bf68e961469269ac5b5f3) | `aws-c-mqtt: 0.7.12 -> 0.7.13`                                                                  |
| [`61f87a8d`](https://github.com/NixOS/nixpkgs/commit/61f87a8dc31587ea7738c9e14f46f8a3199874e5) | `eww: add gdk-pixbuf dependency`                                                                |
| [`d327e408`](https://github.com/NixOS/nixpkgs/commit/d327e40814a4867edcbfd1328d142c541acd9bd6) | `python3Packages.zeroconf: disable tests on darwin`                                             |
| [`f5823fd5`](https://github.com/NixOS/nixpkgs/commit/f5823fd5244a8f03a2606825a2a653d90cfee8e1) | `aws-c-sdkutils: 0.1.4 -> 0.1.6`                                                                |
| [`b5aecf9c`](https://github.com/NixOS/nixpkgs/commit/b5aecf9c5ed431a3810ce0fbbccc028c2f6101f6) | `gajim: 1.5.2 → 1.5.3`                                                                          |
| [`29702a30`](https://github.com/NixOS/nixpkgs/commit/29702a307c6fa06a43350b18720c4302d025a82d) | `pythonPackages.nbxmpp: 3.2.4 → 3.2.5`                                                          |
| [`7442928e`](https://github.com/NixOS/nixpkgs/commit/7442928ed30285cfe2745900b2dcc66c0de8bcf7) | `atuin: 11.0.0 -> 12.0.0`                                                                       |
| [`9d1e84f7`](https://github.com/NixOS/nixpkgs/commit/9d1e84f7125d4477b546a638cb26cc937e687be7) | `python310Packages.amaranth: make compatible with newer setuptools`                             |
| [`41892731`](https://github.com/NixOS/nixpkgs/commit/41892731bd3ea6b9b27e0693b8e332b1e48eb7dd) | `gitoxide: 0.16.0 -> 0.17.0`                                                                    |
| [`0f0224f7`](https://github.com/NixOS/nixpkgs/commit/0f0224f7e8e9ba5735966aab2dcec5cbc99f34e9) | `ghorg: 1.8.8 -> 1.9.0`                                                                         |