### PR TITLE
chore(flake/nixos-hardware): `f6483e0d` -> `909f0259`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1667768008,
-        "narHash": "sha256-PGbX0s2hhXGnZDFVE6UIhPSOf5YegpWs5dUXpT/14F0=",
+        "lastModified": 1668005176,
+        "narHash": "sha256-1Z6ysp8I7NvK8ccL0+r8GI5mxzVqhPLVCI01uPg1ul4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f6483e0def85efb9c1e884efbaff45a5e7aabb34",
+        "rev": "909f0259470f6e9edea71f281410ef25bfa274ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`191d3ca9`](https://github.com/NixOS/nixos-hardware/commit/191d3ca91d7275b32c059b96c5e8808f832311d0) | `Changed asus battery script to work with multiple battery names.` |