### PR TITLE
chore(flake/nixpkgs): `09326850` -> `872fceee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667901915,
-        "narHash": "sha256-IkSou5ox/yZ2YUhGpk8vxd2TNU2pwRlYtir5k55NaxE=",
+        "lastModified": 1667991831,
+        "narHash": "sha256-DHgEsLZI044B9T4AjA3K6+yB9/DqLr4dyA7OIx0FG7o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "093268502280540a7f5bf1e2a6330a598ba3b7d0",
+        "rev": "872fceeed60ae6b7766cc0a4cd5bf5901b9098ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`148c33b8`](https://github.com/NixOS/nixpkgs/commit/148c33b88d087453ce9641739f817a4b1e6bc5ec) | `python3Packages.pescea: unbreak on aarch64-linux`                                    |
| [`6963a4eb`](https://github.com/NixOS/nixpkgs/commit/6963a4eb3c9d3cb35ad198591ec3b85849c1770f) | `python310Packages.hyrule: 0.2 -> 0.2.1`                                              |
| [`0d99e96f`](https://github.com/NixOS/nixpkgs/commit/0d99e96fc9cb8df8ead7e9648871330c6ae51283) | `python310Packages.hy: 0.24.0 -> 0.25.0`                                              |
| [`bbf77421`](https://github.com/NixOS/nixpkgs/commit/bbf77421ac51a7c93f5f0f760da99e4dbce614fa) | `terraform-providers.*: mark broken on darwin`                                        |
| [`6f05cdda`](https://github.com/NixOS/nixpkgs/commit/6f05cdda61db1eb66170f2e3b23bdd9b81e01e25) | `terraform-providers.checkpoint: remove`                                              |
| [`dd85f32d`](https://github.com/NixOS/nixpkgs/commit/dd85f32dddab59dda8be171df37bf7304a786f16) | `terraform-providers.ibm: 1.47.0 → 1.47.1`                                            |
| [`240ccc2d`](https://github.com/NixOS/nixpkgs/commit/240ccc2d63d541480c70703a6056dc701c3e7c51) | `terraform-providers.ksyun: 1.3.56 → 1.3.57`                                          |
| [`51204e7d`](https://github.com/NixOS/nixpkgs/commit/51204e7dd0c59f588abe666d7819b3b4f1435b08) | `terraform-providers.alicloud: 1.190.0 → 1.191.0`                                     |
| [`f3138b62`](https://github.com/NixOS/nixpkgs/commit/f3138b629e088562cd35a2b4ceeb6a26817b3906) | `terraform-providers.github: 5.7.0 → 5.8.0`                                           |
| [`1824bbfc`](https://github.com/NixOS/nixpkgs/commit/1824bbfc3440941fbefc5353f0404df43355a931) | `terraform-providers.bigip: 1.15.2 → 1.16.0`                                          |
| [`e94ca86f`](https://github.com/NixOS/nixpkgs/commit/e94ca86f391cf48afef2a2b0c86f3eaff4994d9d) | `terraform-providers.baiducloud: 1.17.1 → 1.18.0`                                     |
| [`1fc779be`](https://github.com/NixOS/nixpkgs/commit/1fc779bedba4f15da9e1cb7f1283dd62766845d1) | `python310Packages.fakeredis: 1.10.0 -> 1.10.1`                                       |
| [`db046f0e`](https://github.com/NixOS/nixpkgs/commit/db046f0ef35897db3a4f2c311829312d09898fb6) | `python310Packages.rapidfuzz: 2.13.0 -> 2.13.2`                                       |
| [`b46e0d23`](https://github.com/NixOS/nixpkgs/commit/b46e0d23ba95e6a6084ae6a66d9a9d3b928ade34) | `rapidfuzz-cpp: 1.10.0 -> 1.10.1`                                                     |
| [`7667dba1`](https://github.com/NixOS/nixpkgs/commit/7667dba1c62bbb9200e35aa56ddbf1e9f0095210) | `lychee: 0.10.1 -> 0.10.2`                                                            |
| [`06e61dbe`](https://github.com/NixOS/nixpkgs/commit/06e61dbed3c89cb61636d003bc06043dbd64adca) | `python310Packages.transitions: fix darwin build`                                     |
| [`d3ea3da7`](https://github.com/NixOS/nixpkgs/commit/d3ea3da740fbd8bd085895a846f4ca73a6c06fa0) | `catch2_3: 3.1.0 -> 3.1.1`                                                            |
| [`61dcd8ab`](https://github.com/NixOS/nixpkgs/commit/61dcd8abc40fe6cef48e61ad6974a1d93fe3b761) | `audacity: add wrapGAppsHook (#200290)`                                               |
| [`450f613d`](https://github.com/NixOS/nixpkgs/commit/450f613d0a62c3b314a0677a13aa05a6e3f827eb) | `python310Packages.qiling: 1.4.3 -> 1.4.4`                                            |
| [`385e9c23`](https://github.com/NixOS/nixpkgs/commit/385e9c23ff2cda793367bdedc0b6f02bc87a02ea) | `python39Packages.uvloop: fix hydra darwin build`                                     |
| [`6e92f67a`](https://github.com/NixOS/nixpkgs/commit/6e92f67a7e247665527729cb269a600b8d3eb6c6) | `icewm: 3.2.0 -> 3.2.1`                                                               |
| [`6fd104a8`](https://github.com/NixOS/nixpkgs/commit/6fd104a8adccfc7095faaf55941546955d123226) | `pkgsStatic.doas: fix build`                                                          |
| [`16eda690`](https://github.com/NixOS/nixpkgs/commit/16eda690a3474657d4c7bfb26c43c3cc3f066933) | `home-assistant: 2022.11.1 -> 2022.11.2`                                              |
| [`cd57ed50`](https://github.com/NixOS/nixpkgs/commit/cd57ed5016bb549261cdf44ef591be8dfe771f0a) | `python310Packages.hahomematic: 2022.11.0 -> 2022.11.1`                               |
| [`fd9224f6`](https://github.com/NixOS/nixpkgs/commit/fd9224f6e8980357f920ddb560d39d648e602af6) | `skim: 0.10.1 -> 0.10.2`                                                              |
| [`652160f7`](https://github.com/NixOS/nixpkgs/commit/652160f77ba65cfc560ccef1ccbc396b15209cea) | `python310Packages.pyunifiprotect: 4.4.0 -> 4.4.1`                                    |
| [`01acd9b5`](https://github.com/NixOS/nixpkgs/commit/01acd9b50b91464883b39001e72702b150e8f805) | `grafana-agent: 0.28.1 -> 0.29.0`                                                     |
| [`68eee311`](https://github.com/NixOS/nixpkgs/commit/68eee311ff3a1b8517f113a4caa49d1cd225bd3e) | `gvisor: 20220919.0 -> 20221102.1`                                                    |
| [`f1ab23b1`](https://github.com/NixOS/nixpkgs/commit/f1ab23b10e45395926626c846489454b48552457) | `clusterctl: 1.2.4 -> 1.2.5`                                                          |
| [`1e354b8d`](https://github.com/NixOS/nixpkgs/commit/1e354b8d0b3c549fa37b3acec764db2d4e2880ee) | `gh: 2.19.0 -> 2.20.0`                                                                |
| [`807cf8fa`](https://github.com/NixOS/nixpkgs/commit/807cf8fa9d7f89de27658823de75ed046cd2496e) | `python3Packages.zha-quirks: 0.0.84 -> 0.0.85`                                        |
| [`81ebd974`](https://github.com/NixOS/nixpkgs/commit/81ebd9749ed2a958c4f52229b393c4b96a4b4da2) | `python3Packages.pyairvisual: 2022.07.0 -> 2022.11.1`                                 |
| [`c398f1e1`](https://github.com/NixOS/nixpkgs/commit/c398f1e140cc4ab913b118249a0a1adb6368777b) | `python3Packages.async-upnp-client: 0.32.1 -> 0.32.2`                                 |
| [`00f5ffe9`](https://github.com/NixOS/nixpkgs/commit/00f5ffe96bc04899f5ea6e3fee8e13948047ac4e) | `python310Packages.types-urllib3: 1.26.25.1 -> 1.26.25.2`                             |
| [`0e084186`](https://github.com/NixOS/nixpkgs/commit/0e084186bc1dc8edcfa34c9e899526edd7da10f4) | `python310Packages.types-requests: 2.28.11.2 -> 2.28.11.3`                            |
| [`fb7f4cac`](https://github.com/NixOS/nixpkgs/commit/fb7f4cac91380d9547676cbea245dd85237c9d04) | `python310Packages.types-python-dateutil: 2.8.19.2 -> 2.8.19.3`                       |
| [`fbc4961b`](https://github.com/NixOS/nixpkgs/commit/fbc4961be9be1958a587e3840c21fd8d704de0fe) | `nixos/doc: mention signald update in release-notes and related upgrade instructions` |
| [`6c447343`](https://github.com/NixOS/nixpkgs/commit/6c44734327da569e222db1ed50d33d6be1f0ae19) | `ft2-clone: 1.60 -> 1.61`                                                             |
| [`a5a95102`](https://github.com/NixOS/nixpkgs/commit/a5a95102ad403282f9f7da2d9a79242a7c0983db) | `cargo-audit: 0.17.3 -> 0.17.4`                                                       |
| [`38d01120`](https://github.com/NixOS/nixpkgs/commit/38d011206871b864662bd1172857b50c640f2c93) | `python310Packages.azure-identity: 1.11.0 -> 1.12.0`                                  |
| [`09ee41e6`](https://github.com/NixOS/nixpkgs/commit/09ee41e6ade9caaf63804d81e1307d84d8401d27) | `python310Packages.awkward: 1.10.1 -> 1.10.2`                                         |
| [`3f4f4f51`](https://github.com/NixOS/nixpkgs/commit/3f4f4f51ddb519b3c1fc2a0c127ad2a560dab339) | `roundcubePlugins.carddav: 4.4.3 -> 4.4.4`                                            |
| [`5e666ed5`](https://github.com/NixOS/nixpkgs/commit/5e666ed584de652a5eca76b4f58541e7b013b99d) | `python310Packages.luftdaten: 0.7.3 -> 0.7.4`                                         |
| [`2f2eb1af`](https://github.com/NixOS/nixpkgs/commit/2f2eb1afdc30e8ee8335aae199010551b41c6c16) | `nncp: cleanup darwin.apple_sdk_11_0.callPackage usage`                               |
| [`8fcbcba6`](https://github.com/NixOS/nixpkgs/commit/8fcbcba6cb4ee76af2c1078ff761fcfb23ac4681) | `python310Packages.asteval: 0.9.27 -> 0.9.28`                                         |
| [`f9654f45`](https://github.com/NixOS/nixpkgs/commit/f9654f451e5a0f25cc7d454d982108dc9c9ac959) | `hdr-plus: Drop`                                                                      |
| [`0e7aa2ac`](https://github.com/NixOS/nixpkgs/commit/0e7aa2ac040caf5edf5dc43fa90827b240bc68c4) | `dotnet-sdk_7: 7.0.100-rc.2.22477.23 -> 7.0.100`                                      |
| [`6412c1e4`](https://github.com/NixOS/nixpkgs/commit/6412c1e483cdf5ba87ee5f9a4d0e76d1dd9f98cf) | `roundcubePlugins.thunderbird_labels: init at 1.6.0`                                  |
| [`33675155`](https://github.com/NixOS/nixpkgs/commit/3367515582cc17a70202243b59d1b3ea3a830286) | `ruff: 0.0.107 -> 0.0.108`                                                            |
| [`ec912ab1`](https://github.com/NixOS/nixpkgs/commit/ec912ab1dda065810d3f8344de58d0012aefe156) | `yosys-symbiflow: 2022.09.27 -> 2022.11.07`                                           |
| [`50c509ec`](https://github.com/NixOS/nixpkgs/commit/50c509ecf31818d39abdec57c3df4243bb2e4274) | `surelog: 1.40 -> 1.45`                                                               |
| [`568398e3`](https://github.com/NixOS/nixpkgs/commit/568398e3381b55b6ac2b5d8a49f04a7e9c2f16a1) | `uhdm: 0.9.1.40 -> 1.45`                                                              |
| [`7f651a9c`](https://github.com/NixOS/nixpkgs/commit/7f651a9c447cd5fb3dfa6c3c25be4116ceec4e62) | `python3Packages.python-lsp-server: add missing setuptools`                           |
| [`7cd98460`](https://github.com/NixOS/nixpkgs/commit/7cd98460eb14cee970fcbd85be5371f6e9f811b0) | `cargo-deny: 0.13.4 -> 0.13.5`                                                        |
| [`7d300a1e`](https://github.com/NixOS/nixpkgs/commit/7d300a1e48ca8413622083b2329a533536790bc7) | `discocss: 0.2.0 -> 0.2.1`                                                            |
| [`e85548d4`](https://github.com/NixOS/nixpkgs/commit/e85548d41bf7f5c7531c6fc97ecf4f9fddf0afc4) | `pixman: add some key reverse dependencies to passthru.tests`                         |
| [`65294fcf`](https://github.com/NixOS/nixpkgs/commit/65294fcfb579287e692eab214613064a1b471d7b) | `goreplay: Add patch to fix build on arm64-linux`                                     |
| [`255c80e1`](https://github.com/NixOS/nixpkgs/commit/255c80e19173c0257c5883f73615330fc03bcaba) | `b2sum: Prefer finalAttrs over rec`                                                   |
| [`25617e3d`](https://github.com/NixOS/nixpkgs/commit/25617e3def389af5e94011f0cab98cb5b00cd35e) | `nixos/blocky: fix description`                                                       |
| [`b8bea4eb`](https://github.com/NixOS/nixpkgs/commit/b8bea4ebc02d4f2a5597c42631c45151470b00d8) | `elements: 22.0 -> 22.0.2`                                                            |
| [`0cf708bd`](https://github.com/NixOS/nixpkgs/commit/0cf708bd638113402892d5de91d7f40d9131d5f2) | `kde/plasma: 5.26.2 -> 5.26.3`                                                        |
| [`49e5e473`](https://github.com/NixOS/nixpkgs/commit/49e5e473182a44fd0cd9048e4a3a99ba1d47da37) | `flake.nix: simplify forAllSystems (#190527)`                                         |
| [`c4ba130a`](https://github.com/NixOS/nixpkgs/commit/c4ba130a43d716a2e042222231471e2d60790aa6) | `oh-my-zsh: 2022-11-07 -> 2022-11-08`                                                 |
| [`8f6a4e47`](https://github.com/NixOS/nixpkgs/commit/8f6a4e47c2e049a46806b7ead301aa2a87d5caa1) | `dnsmonster: 0.9.6 -> 0.9.7`                                                          |
| [`353d9cc9`](https://github.com/NixOS/nixpkgs/commit/353d9cc9bd107c792fdfba2ae4fcd36a6b24487a) | `dnscontrol: 3.21.0 -> 3.22.0`                                                        |
| [`c7ba9b45`](https://github.com/NixOS/nixpkgs/commit/c7ba9b459c8a47291e64cf5cfb937170f1a1ca11) | `delly: 1.1.5 -> 1.1.6`                                                               |
| [`938795bf`](https://github.com/NixOS/nixpkgs/commit/938795bf0ed1a247bfaac7bf50fca52d81e05316) | `ddccontrol: 0.6.0 -> 0.6.1`                                                          |
| [`daf509d0`](https://github.com/NixOS/nixpkgs/commit/daf509d06ab81cd4f9cbecfa3ff4aea745d0bf81) | `python310Packages.nexia: 2.0.5 -> 2.0.6`                                             |
| [`815fabe0`](https://github.com/NixOS/nixpkgs/commit/815fabe01ac1f70be5151b3432b72c880c020af4) | `marwaita: 14.0 -> 15.0`                                                              |
| [`dcb32bed`](https://github.com/NixOS/nixpkgs/commit/dcb32beda093ce80e80f30b53ec0832d306fe248) | `nixos/prometheus: fix startup w/hardened service`                                    |
| [`990ab561`](https://github.com/NixOS/nixpkgs/commit/990ab561479560a990785285c345d00bc382ebd2) | `python310Packages.apprise: 1.0.0 -> 1.1.0`                                           |
| [`f3d0e1d5`](https://github.com/NixOS/nixpkgs/commit/f3d0e1d5c3faa36c1c6ecf0e73004648e2c9d75c) | `nixpkgs/doc: fix admonition syntax`                                                  |
| [`2c5abd89`](https://github.com/NixOS/nixpkgs/commit/2c5abd89c7e917acde9077fc4d12596e35b73e17) | `rmem_max: define merge function`                                                     |
| [`0ea6f4c9`](https://github.com/NixOS/nixpkgs/commit/0ea6f4c9749d9bc9c079b901279613b441103aa2) | `ghidra: 10.1.2 -> 10.2`                                                              |
| [`b17dcdfb`](https://github.com/NixOS/nixpkgs/commit/b17dcdfb87822eb066a88c3e8b2780c786572e7b) | `discord-ptb: 0.0.34 -> 0.0.35`                                                       |
| [`76b655e4`](https://github.com/NixOS/nixpkgs/commit/76b655e438c0352c52703daa505f8aea3e1cbe1f) | `nncp: 8.8.0 -> 8.8.1`                                                                |
| [`9f9c9306`](https://github.com/NixOS/nixpkgs/commit/9f9c9306aefcd56bec432f54a3b5fc0618034fe0) | `cargo-llvm-lines: 0.4.19 -> 0.4.20`                                                  |
| [`fd76db7c`](https://github.com/NixOS/nixpkgs/commit/fd76db7cb42ec0347a0d72e69734da4722405e1d) | `nixos/invoiceplane: Add cron option`                                                 |
| [`ccd94ad1`](https://github.com/NixOS/nixpkgs/commit/ccd94ad132eee7bde210aa85956beed121840a0f) | `matrix-synapse: 1.70.1 -> 1.71.0`                                                    |
| [`a5cfc0e5`](https://github.com/NixOS/nixpkgs/commit/a5cfc0e571772dff5012979424419b332fcb6091) | `solo5: 0.7.3 -> 0.7.4`                                                               |
| [`2d676a12`](https://github.com/NixOS/nixpkgs/commit/2d676a12ef71e348f0c33fa13a0b55caeabc871a) | `git-machete: 3.12.5 -> 3.13.0`                                                       |
| [`e88ea968`](https://github.com/NixOS/nixpkgs/commit/e88ea96813b099bc68f22235fa0158440e085f06) | `python310Packages.ansible-doctor: 1.4.5 -> 1.4.6`                                    |
| [`e702dff0`](https://github.com/NixOS/nixpkgs/commit/e702dff003c9ec4dd63aa8db2c827900facb8cd9) | `python310Packages.dm-sonnet: add missing input`                                      |
| [`f9c4148b`](https://github.com/NixOS/nixpkgs/commit/f9c4148be7114a2def69fa39611db95780469d0f) | `varnish60: 6.0.10 -> 6.0.11`                                                         |
| [`807220b9`](https://github.com/NixOS/nixpkgs/commit/807220b9f9efc1d755eba836f4d4ddea92d9b725) | `varnish72: 7.2.0 -> 7.2.1`                                                           |
| [`47cbd610`](https://github.com/NixOS/nixpkgs/commit/47cbd610ce81dd5288eb9894533ffbd71f508c65) | `varnish71: drop`                                                                     |
| [`1df1e119`](https://github.com/NixOS/nixpkgs/commit/1df1e119f2d7529d2e87edcb4c80276bb78dd05d) | `vcsh: 2.0.4 → 2.0.5`                                                                 |
| [`025f32f7`](https://github.com/NixOS/nixpkgs/commit/025f32f705d171fe63a71a907bd9700f8c1c1f33) | ``lib/types: add `descriptionClass` for `path```                                      |
| [`b3d01ee8`](https://github.com/NixOS/nixpkgs/commit/b3d01ee88555827c5e2125ce0d457da7960ab737) | `litebrowser: init at unstable-2022-10-31`                                            |
| [`5606ae7a`](https://github.com/NixOS/nixpkgs/commit/5606ae7a27a29ca670487f74eeeaaea22b8db0cb) | `litehtml: init at 0.6`                                                               |
| [`f6072a8d`](https://github.com/NixOS/nixpkgs/commit/f6072a8d7b1520194453e27be1fd59a28c751a7f) | `fastddsgen: init at 2.2.0 (#186326)`                                                 |
| [`cad704eb`](https://github.com/NixOS/nixpkgs/commit/cad704eb95f5d4b7a283cd8d7498fa05672d4f20) | `toil: 5.6.0 -> 5.7.1`                                                                |
| [`cc62af32`](https://github.com/NixOS/nixpkgs/commit/cc62af324647288d7e3e10fedbae3292da4efc7c) | `btop: move hash`                                                                     |
| [`3287eaae`](https://github.com/NixOS/nixpkgs/commit/3287eaaef4ff5bd356b4bbef46b39a55bb4a2672) | `python310Packages.datasette-publish-fly: init at 1.2`                                |
| [`4e6dd2e7`](https://github.com/NixOS/nixpkgs/commit/4e6dd2e77851a9e1f186728951d2a61079c0d193) | ``fwbuilder: disable blanket `-Werror```                                              |
| [`92dbff97`](https://github.com/NixOS/nixpkgs/commit/92dbff970f10cf97cc33b1a52cb19b05bd58f578) | `davix: fix on darwin`                                                                |
| [`3dfbc6f5`](https://github.com/NixOS/nixpkgs/commit/3dfbc6f54eaf41c864aaeb82c31b1e06feb23172) | `btop: 1.2.12 -> 1.2.13`                                                              |
| [`763dd452`](https://github.com/NixOS/nixpkgs/commit/763dd452165b66f0d0440db604007f67b8fdbb72) | `python310Packages.whispers: 1.5.3 -> 2.1.5`                                          |
| [`a8f46aa8`](https://github.com/NixOS/nixpkgs/commit/a8f46aa8476e0a414d87742b80fc6e0375ca99dd) | `python310Packages.stevedore: 4.0.1 -> 4.1.0`                                         |
| [`7adddf53`](https://github.com/NixOS/nixpkgs/commit/7adddf537f0039336ee5a57d0204048ceb4449fc) | `python310Packages.slack-sdk: 3.19.2 -> 3.19.3`                                       |
| [`eb31990b`](https://github.com/NixOS/nixpkgs/commit/eb31990b051bbaf36259f1d6b44a275ee7562a85) | `python310Packages.pysolcast: 1.0.11 -> 1.0.12`                                       |
| [`e94c88da`](https://github.com/NixOS/nixpkgs/commit/e94c88da1463e28691e929582d5eae6a7b00de9c) | `python310Packages.bthome-ble: 2.2.0 -> 2.2.1`                                        |
| [`6c5872ec`](https://github.com/NixOS/nixpkgs/commit/6c5872ec475580eb47a2dd786ce41b7b6549ba6c) | `nuclei: 2.7.8 -> 2.7.9`                                                              |
| [`c479fab9`](https://github.com/NixOS/nixpkgs/commit/c479fab9204238615969aa0496aae11ba04c49ce) | `portfolio: 0.59.2 -> 0.59.3`                                                         |
| [`d7981c87`](https://github.com/NixOS/nixpkgs/commit/d7981c878884b107a864690844756ada3542fb35) | `inframap: init at 0.6.7`                                                             |
| [`03c9ceeb`](https://github.com/NixOS/nixpkgs/commit/03c9ceeb55d61a0d914861cda040f4422015c6f5) | `python310Packages.moderngl: 5.7.0 -> 5.7.2`                                          |
| [`2f9d6a03`](https://github.com/NixOS/nixpkgs/commit/2f9d6a033cb92d8c7524e59548f990cc02087ad8) | `python310Packages.gql: use optional-dependencies`                                    |
| [`5160daf9`](https://github.com/NixOS/nixpkgs/commit/5160daf97925551b014576c894d7e4f0ad99350d) | `davix: never use vendored curl`                                                      |
| [`0ae850e1`](https://github.com/NixOS/nixpkgs/commit/0ae850e1ca14627cd7ae338e35179c99da81efc0) | `eva: 0.3.0-2 -> 0.3.1`                                                               |
| [`8819081e`](https://github.com/NixOS/nixpkgs/commit/8819081eeb01143b0d00b34e02216a4ba0f60067) | `millet: 0.5.12 -> 0.5.13`                                                            |
| [`ee47da83`](https://github.com/NixOS/nixpkgs/commit/ee47da83d178913d0f425fad5971c6baa2c6a9d0) | `luau: 0.551 -> 0.552`                                                                |
| [`e18c1528`](https://github.com/NixOS/nixpkgs/commit/e18c1528d0d1908884e39b11b5d8edc358aa08a4) | `emoji-picker: init at 0.2.0`                                                         |
| [`bafe84ca`](https://github.com/NixOS/nixpkgs/commit/bafe84ca6244e44c00f6fc967a692b93325d4607) | `linuxkit: 1.0.0 -> 1.0.1`                                                            |
| [`27d20670`](https://github.com/NixOS/nixpkgs/commit/27d20670578efbe918d8ef53773d6fc4ecc43e52) | `kubie: 0.19.0 -> 0.19.1`                                                             |
| [`a7597701`](https://github.com/NixOS/nixpkgs/commit/a75977016b3469bb9df30714158ed56316ffc2dd) | `bzip3: 1.1.8 -> 1.2.0`                                                               |
| [`5d3d98a1`](https://github.com/NixOS/nixpkgs/commit/5d3d98a18653308245a3c5ad5ec43c6b20208fee) | `fluent-bit: support PostgreSQL output`                                               |
| [`ed6c74e8`](https://github.com/NixOS/nixpkgs/commit/ed6c74e81f8d9729867f2b7e2156b47c9728ebc7) | `libiio: allow build on systems without avahi`                                        |
| [`962a8105`](https://github.com/NixOS/nixpkgs/commit/962a81051315a8a9506778f13f04295ced8017c1) | `nixpkgs/doc/stdenv: fix admonition class`                                            |
| [`9cf5bc9f`](https://github.com/NixOS/nixpkgs/commit/9cf5bc9fc06aedd2ada291b1214f86cfdee582b7) | `ghz: 0.110.0 -> 0.111.0`                                                             |
| [`5d3c4579`](https://github.com/NixOS/nixpkgs/commit/5d3c45798e0c5e0e2724518b4c4b29bde142d4ba) | `torrenttools: init at 0.6.2`                                                         |
| [`a8cc51be`](https://github.com/NixOS/nixpkgs/commit/a8cc51be4dbf21834284b08d488fe0cddb709f76) | `coder: init at 0.12.4`                                                               |
| [`0b9d587d`](https://github.com/NixOS/nixpkgs/commit/0b9d587d923e984f7f4cf5a83c3520eba56d3a06) | `devbox: init at 0.1.0`                                                               |
| [`07761139`](https://github.com/NixOS/nixpkgs/commit/07761139b73296117dfb2a9d9718374105037d58) | `kde/gear: 22.08.2 -> 22.08.3`                                                        |
| [`41b1a58f`](https://github.com/NixOS/nixpkgs/commit/41b1a58f40664a4422144d505cc5bc774758696b) | `python310Packages.stubserver: init at 1.1`                                           |
| [`d284ffaa`](https://github.com/NixOS/nixpkgs/commit/d284ffaa15bde72742ea78b01f88496ce6e56500) | `trueseeing: relax docker contraint`                                                  |
| [`ce752bc6`](https://github.com/NixOS/nixpkgs/commit/ce752bc694f87fb3967967536c076099e95e13c3) | `python310Packages.docker: 6.0.0 -> 6.0.1`                                            |
| [`73264125`](https://github.com/NixOS/nixpkgs/commit/73264125a2132ccff657195eabbe8f5a68c26590) | `ashuffle: 3.12.5 -> 3.13.4`                                                          |
| [`de717369`](https://github.com/NixOS/nixpkgs/commit/de717369b02a71988186198dbab10a059fd850c3) | `fio: 3.32 -> 3.33`                                                                   |
| [`4925b7cd`](https://github.com/NixOS/nixpkgs/commit/4925b7cd80dbdc655feda8ef2f1b716703d7e744) | `cargo-nextest: skip breaking tests`                                                  |
| [`d16405fb`](https://github.com/NixOS/nixpkgs/commit/d16405fb97fac9903a1592e0e838913d39bae248) | `xfce: run nixpkgs-fmt`                                                               |
| [`ea062f45`](https://github.com/NixOS/nixpkgs/commit/ea062f45ec6aa64f38da9e6433ec18c617a31c73) | `google-cloud-sdk: 405.0.0 -> 408.0.1`                                                |
| [`88f085e9`](https://github.com/NixOS/nixpkgs/commit/88f085e96eeb2b26c92d092d20a265c694506adb) | `python310Packages.deep-translator: 1.9.0 -> 1.9.1`                                   |
| [`5568a4d2`](https://github.com/NixOS/nixpkgs/commit/5568a4d25ca406809530420996d57e0876ca1a01) | `xfce: fix cross-compilation by using makeScopeWithSplicing`                          |
| [`00479e2d`](https://github.com/NixOS/nixpkgs/commit/00479e2d5a153337309abd68e550768216c2c4a2) | `python3.packages.pyshark: fix build with wireshark4`                                 |
| [`735ab198`](https://github.com/NixOS/nixpkgs/commit/735ab1984b84b5fce9447d4643026981128f8534) | `wireshark: 3.6.5 -> 4.0.1`                                                           |
| [`c95706ac`](https://github.com/NixOS/nixpkgs/commit/c95706ac44ffa749779bace03b115eab89c66cae) | `vimPlugins: also update nvim-treesitter grammars in the update script`               |
| [`46a21956`](https://github.com/NixOS/nixpkgs/commit/46a219568818797a547a3ffd92280bb0f65dc5dc) | `wxGTK28, wxGTK29: drop`                                                              |
| [`de64530f`](https://github.com/NixOS/nixpkgs/commit/de64530f8d9850c9c0ae3d19367a01cd93f93fcf) | `pkgsStatic.c-ares: fix build`                                                        |
| [`afe3ad49`](https://github.com/NixOS/nixpkgs/commit/afe3ad49e5da82c86d02c71508007400c3ea3949) | `kpmcore: patch trustedprefixes`                                                      |
| [`02adfe68`](https://github.com/NixOS/nixpkgs/commit/02adfe681e59b4006a080a78fe5e4fe3d9d2fa60) | `apksigcopier: 1.0.1 -> 1.1.0`                                                        |
| [`54bd7f6c`](https://github.com/NixOS/nixpkgs/commit/54bd7f6c53721eda95a409f36f0bfff435e2d6e0) | `python310Packages.av: 9.2.0 -> 10.0.0`                                               |
| [`2cd9eb8d`](https://github.com/NixOS/nixpkgs/commit/2cd9eb8daf4173a14a35f05e6ad8dcba65ea2b9f) | `sunshine: 0.14.1 -> 0.15.0`                                                          |
| [`21b06b57`](https://github.com/NixOS/nixpkgs/commit/21b06b57bc19648fe8a2dbe11979b2fd662f1e60) | `arduino-cli: 0.27.1 -> 0.28.0`                                                       |
| [`723523d0`](https://github.com/NixOS/nixpkgs/commit/723523d07d6b07c3452bbd38aacf8e20e32bb12f) | `b2sum: unstable-2018-06-11 -> 20190724`                                              |
| [`7e5832d0`](https://github.com/NixOS/nixpkgs/commit/7e5832d0039e51bb4b85d62b66212881abc4ccdf) | `python310Packages.mpmath: fix CVE-2021-29063`                                        |
| [`4f28fea3`](https://github.com/NixOS/nixpkgs/commit/4f28fea37e6638c6f9e4030843028836242bec61) | `open-vm-tools: compile vgauth tool`                                                  |