### PR TITLE
chore(flake/nixos-hardware): `11a42a58` -> `062c3cca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1668084757,
-        "narHash": "sha256-/RRIVnNrg1EZkYMaPdQFuxCQ72LPWkVjvWEClR8FqvI=",
+        "lastModified": 1668157555,
+        "narHash": "sha256-s5rt2FSmV4PWt89rjt4cvBGOhPizStsinkIB0BXnKrk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "11a42a580de22355934ffd9235b81b64004a2e98",
+        "rev": "062c3cca468a4b404ddd964fb444b665e4da982e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message        |
| ----------------------------------------------------------------------------------------------------- | --------------------- |
| [`d43d5ad5`](https://github.com/NixOS/nixos-hardware/commit/d43d5ad52aebe85890f27fae34481c10d17e2ef2) | `Latitude 3340: init` |