### PR TITLE
chore(flake/nixpkgs): `5f588eb4` -> `fc076226`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668087632,
-        "narHash": "sha256-T/cUx44aYDuLMFfaiVpMdTjL4kpG7bh0VkN6JEM78/E=",
+        "lastModified": 1668326430,
+        "narHash": "sha256-fJEsHe+lzFf3qcQVTTdK9jqRtUUVXH71tdfgjcKJNpA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5f588eb4a958f1a526ed8da02d6ea1bea0047b9f",
+        "rev": "fc07622617a373a742ed96d4dd536849d4bc1ec6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`dc4c4911`](https://github.com/NixOS/nixpkgs/commit/dc4c49113a6ba6bde9c7b6e674a91f981aa1a9ed) | `terraform-providers.minio: 1.8.0 → 1.9.0`                               |
| [`b47c14bd`](https://github.com/NixOS/nixpkgs/commit/b47c14bd9428543d7e75776122516e47790f4a97) | `terraform-providers.panos: remove`                                      |
| [`0a026eb3`](https://github.com/NixOS/nixpkgs/commit/0a026eb33cd7d141829640553f04b747b9879409) | `zsh-vi-mode: 0.8.5 -> 0.9.0`                                            |
| [`663ab919`](https://github.com/NixOS/nixpkgs/commit/663ab919493796dd9220fb7e9f6de184376c9639) | `pocketbase: 0.7.9 -> 0.7.10`                                            |
| [`89b85f19`](https://github.com/NixOS/nixpkgs/commit/89b85f19f066e823d4d94cd0c7f707e20e3fcec2) | `rathole: 0.4.4 -> 0.4.5`                                                |
| [`8e50b02b`](https://github.com/NixOS/nixpkgs/commit/8e50b02b03157cd87119f117bfa10013b23fa450) | `topgrade: 10.1.1 -> 10.1.2`                                             |
| [`9ebb240f`](https://github.com/NixOS/nixpkgs/commit/9ebb240f58b5a250c0cca4140e0140f74ffde823) | `tofi: 0.6.0 -> 0.7.0`                                                   |
| [`67abaf44`](https://github.com/NixOS/nixpkgs/commit/67abaf44e8eec53cbf78374c77af6fa05df812aa) | `efivar: backport i686 format fix`                                       |
| [`0290de5d`](https://github.com/NixOS/nixpkgs/commit/0290de5d14aa8f25d5fcf7f1c7a7d4dfac8b34a0) | `sumneko-lua-language-server: 3.6.1 -> 3.6.2`                            |
| [`bb0cdad5`](https://github.com/NixOS/nixpkgs/commit/bb0cdad58a9074583c41d8af9dd4592dd92e8d8c) | `castxml: 0.4.6 -> 0.4.7`                                                |
| [`2f506048`](https://github.com/NixOS/nixpkgs/commit/2f506048b13fe69c22cec5e7e5610eabfc537aa7) | `treewide: mark buildGoModule packages broken`                           |
| [`2ed9c40c`](https://github.com/NixOS/nixpkgs/commit/2ed9c40c2c0625d2d5caa1792601d8b69eaa84f4) | `hyprspace: mark broken`                                                 |
| [`618cb7fa`](https://github.com/NixOS/nixpkgs/commit/618cb7fa4656473706fa66ceeddc874712e76a1f) | `go-chromecast: mark broken`                                             |
| [`355ad731`](https://github.com/NixOS/nixpkgs/commit/355ad731e4fa940431f457c8fbca9f9bdf7651bb) | `go_1_17: remove`                                                        |
| [`34e0463c`](https://github.com/NixOS/nixpkgs/commit/34e0463cf462f2c44908fd5ca840af951cd1a8dc) | `superTuxKart: 1.3 -> 1.4`                                               |
| [`5f03b6dd`](https://github.com/NixOS/nixpkgs/commit/5f03b6ddfc27a5cb3b5e851a25db3cf1590f6fc0) | `nixos/console: move enable option out of let in`                        |
| [`0dcdce71`](https://github.com/NixOS/nixpkgs/commit/0dcdce71adeb6c6fb04800a044a754161ec7380c) | `python310Packages.eve: 2.0.3 -> 2.0.4`                                  |
| [`4c41d887`](https://github.com/NixOS/nixpkgs/commit/4c41d887d6fa5ecb0c88eeb84e35ac0ba47a37f7) | `felix-fm: 2.0.0 -> 2.0.1`                                               |
| [`fd942ba2`](https://github.com/NixOS/nixpkgs/commit/fd942ba25150824bd554c07996306255659e7f93) | `ruff: 0.0.113 -> 0.0.115`                                               |
| [`3f6eb10d`](https://github.com/NixOS/nixpkgs/commit/3f6eb10dbdff395a322c1b9f9167784096064278) | `nixos/mastodon: fix definition of mastodon-media-auto-remove`           |
| [`702a4dd0`](https://github.com/NixOS/nixpkgs/commit/702a4dd0e20b80aae468707f4873412be92b657a) | `corrosion: 0.2.1 -> 0.3.0`                                              |
| [`235713b5`](https://github.com/NixOS/nixpkgs/commit/235713b518dd20679447ab96a59b8590b8159dc6) | `invoiceplane: 1.6-beta-1 -> 1.6-beta-3`                                 |
| [`90e70059`](https://github.com/NixOS/nixpkgs/commit/90e7005915f64d92879f9280e7a4f19e682d95cd) | `redpanda: 22.2.7 -> 22.3.1`                                             |
| [`6ca892c4`](https://github.com/NixOS/nixpkgs/commit/6ca892c46eb6e4250cced9ee080c4332eb2b871b) | `yq-go: 4.29.2 -> 4.30.1`                                                |
| [`192d7376`](https://github.com/NixOS/nixpkgs/commit/192d73761f6739149ce6f9e74a7e78e1e96d2dc5) | `bubblewrap: 0.6.2 -> 0.7.0`                                             |
| [`257ec177`](https://github.com/NixOS/nixpkgs/commit/257ec177c8ade6469d3fef9b1871dc87507a1177) | `nixos/syncthing: disallow relative paths`                               |
| [`b0e70048`](https://github.com/NixOS/nixpkgs/commit/b0e700481933b13c0c70395b21830aeb631c489e) | `prs: 0.3.4 -> 0.3.5`                                                    |
| [`7b3beb39`](https://github.com/NixOS/nixpkgs/commit/7b3beb39dfec5305f91c113688f0069f21c7b59c) | `python310Packages.pamqp: 3.1.0 -> 3.2.1`                                |
| [`8a236e24`](https://github.com/NixOS/nixpkgs/commit/8a236e246ab1aceea6e5b181f0d566be6bb3a614) | `gplates: fix failing build`                                             |
| [`e2bb1e77`](https://github.com/NixOS/nixpkgs/commit/e2bb1e774b5f458de166169d2f6cede6aff9d289) | `erigon: module: better secret management`                               |
| [`aa60ac44`](https://github.com/NixOS/nixpkgs/commit/aa60ac44bd4d0eb107a08d616e8e483ebf2e9f2a) | `python310Packages.django-reversion: 5.0.3 -> 5.0.4`                     |
| [`bcb450ce`](https://github.com/NixOS/nixpkgs/commit/bcb450ce97b68ea5785fec28b9237430566ae521) | `python310Packages.tgcrypto: 1.2.4 -> 1.2.5`                             |
| [`91e6d074`](https://github.com/NixOS/nixpkgs/commit/91e6d07432fba9205c0905df873a637fbdb699ac) | `python310Packages.pyrogram: 2.0.30 -> 2.0.59`                           |
| [`ca5cf4de`](https://github.com/NixOS/nixpkgs/commit/ca5cf4de438594458e68d90c380f25dc30d4a5b2) | `python310Packages.imap-tools: 0.56.0 -> 0.57.0`                         |
| [`20bdaba8`](https://github.com/NixOS/nixpkgs/commit/20bdaba8fc1d3ec76e82aabfacfd8710a4208e74) | `nongnu-packages: updated 2022-11-12`                                    |
| [`a94b0cfd`](https://github.com/NixOS/nixpkgs/commit/a94b0cfdc0dbb071726d463f0b6d6687c4296b6e) | `melpa-packages: updated 2022-11-12`                                     |
| [`c15092aa`](https://github.com/NixOS/nixpkgs/commit/c15092aa2b9438208a4ba86989a670811f65d8c7) | `elpa-packages.nix: updated 2022-11-12`                                  |
| [`69c5dcd4`](https://github.com/NixOS/nixpkgs/commit/69c5dcd47a41940e8cf7d2ce1c52187c6bd4f844) | `nongnu-packages: updated 2022-11-08`                                    |
| [`c12fdf7a`](https://github.com/NixOS/nixpkgs/commit/c12fdf7ae5f008176a453c0c7245a9ec452943a3) | `melpa-packages: updated 2022-11-08`                                     |
| [`8e3cf588`](https://github.com/NixOS/nixpkgs/commit/8e3cf5886972857a014ddadec0a46629ad97c0fa) | `elpa-packages: updated 2022-11-08`                                      |
| [`97e51ef8`](https://github.com/NixOS/nixpkgs/commit/97e51ef8d3fed0618ea10c3e94a2459d1ca68c7a) | `manual-packages.nix: cosmetical refactor`                               |
| [`c80c7fd5`](https://github.com/NixOS/nixpkgs/commit/c80c7fd5aa6ac075d9a33be8c9a8a7992af82e51) | `emacs.pkgs.cask: init at 0.8.8`                                         |
| [`69915030`](https://github.com/NixOS/nixpkgs/commit/699150309b024bba669a5a0ded88456b541c3f4d) | `update-from-overlay: cosmetical change`                                 |
| [`39e63f11`](https://github.com/NixOS/nixpkgs/commit/39e63f110e2b8607e4142e1461d08fb20b36497e) | `nixos/man-db: allow man-cache to be fetched from cache`                 |
| [`8b0145bf`](https://github.com/NixOS/nixpkgs/commit/8b0145bf4d0b81e043de91ed7ddae1c1776fe435) | `ytfzf: 2.5.0 -> 2.5.2`                                                  |
| [`b111623c`](https://github.com/NixOS/nixpkgs/commit/b111623c4a56086c895121bfe78a74e0ee44eac3) | `super-tiny-icons: init at 2022-11-07`                                   |
| [`eb58ee10`](https://github.com/NixOS/nixpkgs/commit/eb58ee1066cc67a1b51b218d835f8dbbb37c67dd) | `maintainers: add h7x4`                                                  |
| [`f4ebf395`](https://github.com/NixOS/nixpkgs/commit/f4ebf395f504f12d24fe246bc62cdcaefea3ea34) | `nicotine-plus: fix "Cannot find GTK 3" bug`                             |
| [`2e455882`](https://github.com/NixOS/nixpkgs/commit/2e45588230066b4215ff161c814473d4666bc885) | `erigon: 2.29.0 -> 2.30.0`                                               |
| [`2224c27f`](https://github.com/NixOS/nixpkgs/commit/2224c27f0e523057d63bbfdd084f29dbf13ae496) | `nc4nix: unstable-2022-08-06 -> unstable-2022-11-12`                     |
| [`e78a5590`](https://github.com/NixOS/nixpkgs/commit/e78a5590583d4995f73a7ecbb656764d15e7dd67) | `libsForQt5.mauiPackages.booth: init at 1.0.0`                           |
| [`ef166d7f`](https://github.com/NixOS/nixpkgs/commit/ef166d7ff3062c70ed60c729dac4cd0962910cef) | `python3Packages.rmrl: propagate setuptools`                             |
| [`35a885ec`](https://github.com/NixOS/nixpkgs/commit/35a885ece11738c5b3a3eaead8ad03e7d0672ff5) | `lispPackages_new.sbclPackages.gsll: mark as broken (#200285)`           |
| [`657b767b`](https://github.com/NixOS/nixpkgs/commit/657b767bd1f08ce4c4814ad659f604d365fddccb) | `smbscan: adjust format`                                                 |
| [`10b0ea9f`](https://github.com/NixOS/nixpkgs/commit/10b0ea9fe57fbd2feff214e50709be62fb68b266) | `nixpacks: 0.13.0 -> 0.14.0`                                             |
| [`7c504276`](https://github.com/NixOS/nixpkgs/commit/7c50427687492346bd7b59ee286297a6241b5fe9) | `nfpm: 2.21.0 -> 2.22.0`                                                 |
| [`caafa675`](https://github.com/NixOS/nixpkgs/commit/caafa675311ecdc6886461119f6f87d62ae3d24d) | `jdt-language-server: 1.16.0 -> 1.17.0`                                  |
| [`0c5088d1`](https://github.com/NixOS/nixpkgs/commit/0c5088d12ab28e4b343780d50400e10d51675fd4) | `ncgopher: 0.4.0 -> 0.5.0`                                               |
| [`5ca8e2e9`](https://github.com/NixOS/nixpkgs/commit/5ca8e2e9e1fa5e66a749b39261ad6bd0e07bc87f) | `utf8proc: add relevant revdeps to passthru.tests`                       |
| [`243d044a`](https://github.com/NixOS/nixpkgs/commit/243d044a455e724f547626bf3a196ff7b83efe33) | `utf8proc: 2.7.0 -> 2.8.0`                                               |
| [`790f859e`](https://github.com/NixOS/nixpkgs/commit/790f859ef76762016f8a719aa07aaed2f059fc8f) | `mysql80: fix build on aarch64-linux`                                    |
| [`8d77f855`](https://github.com/NixOS/nixpkgs/commit/8d77f8554682cb283713a6aa0068d1a2e973790e) | `linuxPackages.nvidia_x11: mark as broken on 6.2`                        |
| [`e28df55f`](https://github.com/NixOS/nixpkgs/commit/e28df55ffe1027ba5da0c89ac8056358d82c23f6) | `keycard-cli: 0.6.0 -> 0.7.0 (#200785)`                                  |
| [`d7a7f121`](https://github.com/NixOS/nixpkgs/commit/d7a7f1216331ad8ecaba094fefd73ae5504d57f7) | `hclfmt: 2.14.1 -> 2.15.0 (#200816)`                                     |
| [`149c6197`](https://github.com/NixOS/nixpkgs/commit/149c6197e23045a41c750593dd4cc294137256c3) | `memray: 1.4.0 -> 1.4.1`                                                 |
| [`3d69d4cd`](https://github.com/NixOS/nixpkgs/commit/3d69d4cdcc48638a3849a795bcc3c0baee08e36a) | `python310Packages.heatzypy: set version`                                |
| [`7785d30d`](https://github.com/NixOS/nixpkgs/commit/7785d30d07749bdf1c92ea847d69f8005b062bd2) | `elixir_1_14: 1.14.1 -> 1.14.2`                                          |
| [`5cb74a90`](https://github.com/NixOS/nixpkgs/commit/5cb74a90292cc3c4c5e764f498791dd61253312c) | `maintainers/team-list: add rocm team`                                   |
| [`702820b5`](https://github.com/NixOS/nixpkgs/commit/702820b5b4b39324ea6c2dac61034b4c65bd4b08) | `swaysettings: 0.3.0 -> 0.4.0`                                           |
| [`44a6d60e`](https://github.com/NixOS/nixpkgs/commit/44a6d60e17e5cad29c0a83fbe0c0c6cfc7095ae5) | `python310Packages.deezer-python: 5.6.0 -> 5.7.0`                        |
| [`5be6a3f4`](https://github.com/NixOS/nixpkgs/commit/5be6a3f42cf7fc652f03b28fe47349609f5222f0) | `home-assistant: pin nibe at 0.5.0`                                      |
| [`f04d46ac`](https://github.com/NixOS/nixpkgs/commit/f04d46aca992a15c7f3707d9bce8258c431ccf9b) | `katana: init at 0.0.2`                                                  |
| [`dd96d8ff`](https://github.com/NixOS/nixpkgs/commit/dd96d8ffbb266fee9021e4f985fa0b75a5730e1c) | `home-assistant: update component-packages`                              |
| [`e8536675`](https://github.com/NixOS/nixpkgs/commit/e8536675c986d6e27df751e6ef308885925e9b16) | `python310Packages.nibe: init at 1.2.1`                                  |
| [`228feb70`](https://github.com/NixOS/nixpkgs/commit/228feb709b63a8f0a80b55d9248d8b05dfa70c2e) | `speed-dreams: fixed build`                                              |
| [`14eadb17`](https://github.com/NixOS/nixpkgs/commit/14eadb17dfdcff49b7e6dc766faebc9e8bd928d2) | `python310Packages.async-modbus: init at 0.2.0`                          |
| [`3e93dfa0`](https://github.com/NixOS/nixpkgs/commit/3e93dfa004167d0398c2693677e5fd5a42ac9a4a) | `python310Packages.connio: init at 0.2.0`                                |
| [`6361b788`](https://github.com/NixOS/nixpkgs/commit/6361b788a398894e3f07fbe8a3678527946b9297) | `mangal: 4.0.2 -> 4.0.4`                                                 |
| [`4c15dad4`](https://github.com/NixOS/nixpkgs/commit/4c15dad466d6d938db27af91df765d61c4b99be6) | `python310Packages.serialio: init at 2.4.0`                              |
| [`26640709`](https://github.com/NixOS/nixpkgs/commit/26640709430fb8afa54f82f93f8f7b1f460e49c3) | `python310Packages.sockio: init at 0.15.0`                               |
| [`25ede38d`](https://github.com/NixOS/nixpkgs/commit/25ede38d35a5317b7768fc839faf8951e308b2ba) | `python310Packages.umodbus: init at 1.0.4`                               |
| [`85eb4467`](https://github.com/NixOS/nixpkgs/commit/85eb44670be4a16ebb4f2f3e2fdb25888d332e4c) | `php.extensions.xdebug: 3.1.5 -> 3.1.6`                                  |
| [`9c24dbf8`](https://github.com/NixOS/nixpkgs/commit/9c24dbf8b2c037832c640df4d12f284fa73412c1) | `php.extensions.swoole: 4.8.11 -> 5.0.1`                                 |
| [`70d2a0b3`](https://github.com/NixOS/nixpkgs/commit/70d2a0b389d80af7329598383b77c4afbf890188) | `php.extensions.protobuf: 3.21.6 -> 3.21.9`                              |
| [`77e75248`](https://github.com/NixOS/nixpkgs/commit/77e75248ec3b6dc12251a44979cffd5c9bd6b25b) | `php.extensions.openswoole: 4.11.1 -> 4.12.0`                            |
| [`c168d069`](https://github.com/NixOS/nixpkgs/commit/c168d0692165b1fe444d2d8fc6f5925694492d72) | `php.extensions.mongodb: 1.14.1 -> 1.14.2`                               |
| [`0674e2e8`](https://github.com/NixOS/nixpkgs/commit/0674e2e8438d2381d8f7b7a78e6e41a2ad849607) | `php.extensions.igbinary: 3.2.7 -> 3.2.12`                               |
| [`b293c4ec`](https://github.com/NixOS/nixpkgs/commit/b293c4ec4478247c35f884f4b3f87a0d2e1f1f70) | `elmPackages: update to nodejs 14`                                       |
| [`c1135fc5`](https://github.com/NixOS/nixpkgs/commit/c1135fc57de106496d14bfa4be1329741a705fa6) | `redis: patch for CVE-2022-3647`                                         |
| [`7a146b3b`](https://github.com/NixOS/nixpkgs/commit/7a146b3babc180305b163a0ed8b63f4629e839f3) | `firefox*, thunderbird*: fix the Profile Manager .desktop action`        |
| [`08c9962c`](https://github.com/NixOS/nixpkgs/commit/08c9962cd2f54212c7d5455bf142b90c557d384d) | `libcpuid: 0.6.1 -> 0.6.2`                                               |
| [`3186f1c9`](https://github.com/NixOS/nixpkgs/commit/3186f1c90386a85d9d47144c08e1e466838b1803) | `python310Packages.zha-quirks: 0.0.85 -> 0.0.86`                         |
| [`fb2554c0`](https://github.com/NixOS/nixpkgs/commit/fb2554c037aa9f4c7400b89fbf3537d1d04a7872) | `keycloak: 20.0.0 -> 20.0.1`                                             |
| [`458e1740`](https://github.com/NixOS/nixpkgs/commit/458e174000b33862f9debc59fcb5db6a58dbd217) | `python310Packages.oralb-ble: 0.14.1 -> 0.14.2`                          |
| [`e7564bf2`](https://github.com/NixOS/nixpkgs/commit/e7564bf2f1bdebe02f2659fb03b0563544e4afee) | `jaq: 0.8.2 -> 0.9.0`                                                    |
| [`5a9e29c3`](https://github.com/NixOS/nixpkgs/commit/5a9e29c31863bc56fb6c0cd3b2ba1fb4238d0141) | `jackett: 0.20.2236 -> 0.20.2238`                                        |
| [`804ed31f`](https://github.com/NixOS/nixpkgs/commit/804ed31fe3295329278197031369f84bd98d9b0b) | `infra: 0.16.1 -> 0.17.1`                                                |
| [`8abee3d9`](https://github.com/NixOS/nixpkgs/commit/8abee3d9265cd5f86993571fed742fb6e962435d) | `php81: Enable pcre built with jit sealloc`                              |
| [`c0a1af53`](https://github.com/NixOS/nixpkgs/commit/c0a1af53c6984575c4f3698c66c05ebae6059085) | `php80: Enable pcre built with jit sealloc`                              |
| [`f6df73dc`](https://github.com/NixOS/nixpkgs/commit/f6df73dcd01a1b151d14c1cf64a2ad6ea165f297) | `osm2pgsql: 1.7.1 → 1.7.2`                                               |
| [`83161401`](https://github.com/NixOS/nixpkgs/commit/831614011ad7ad3abf8500549c44c860e8bf51e7) | `hcloud: 1.30.3 -> 1.30.4`                                               |
| [`cef44108`](https://github.com/NixOS/nixpkgs/commit/cef44108c32313b86ca5df4c95d7ea30aed4c238) | `grails: 5.2.4 -> 5.2.5`                                                 |
| [`4922e9c6`](https://github.com/NixOS/nixpkgs/commit/4922e9c628358e0806e2670d6d2e3f0cd9b3475a) | `zim: 0.74.3 -> 0.75.1`                                                  |
| [`0b36a1d2`](https://github.com/NixOS/nixpkgs/commit/0b36a1d27fae26fd78cdc25c1908ff0538b1a747) | `python310Packages.colored: update meta`                                 |
| [`b8ab9d40`](https://github.com/NixOS/nixpkgs/commit/b8ab9d405a18a8db480b9d447acab5f559518022) | `python310Packages.colored: add format and pythonImportsCheck`           |
| [`f004a1ef`](https://github.com/NixOS/nixpkgs/commit/f004a1ef8006294585342c874968f27be3c468f5) | `python310Packages.colored: 1.4.3 -> 1.4.4`                              |
| [`d4c2ef26`](https://github.com/NixOS/nixpkgs/commit/d4c2ef266aff7fd9fe6d6a07750e593a19f85a06) | `python310Packages.cloudscraper: 1.2.64 -> 1.2.65`                       |
| [`28c23de0`](https://github.com/NixOS/nixpkgs/commit/28c23de0e90b4489837821bab393b30b4be66803) | `google-guest-agent: 20221104.00 -> 20221109.00`                         |
| [`21b44e79`](https://github.com/NixOS/nixpkgs/commit/21b44e792e1664db8b2fb41da02468f309361650) | `php.packages: Add back meta attributes`                                 |
| [`2822311c`](https://github.com/NixOS/nixpkgs/commit/2822311c410070b966432d46350405875ead7082) | `python310Packages.python-rapidjson: 1.6 -> 1.9`                         |
| [`94ddacc6`](https://github.com/NixOS/nixpkgs/commit/94ddacc61ccdb8d22c8c7522a311003c76d0ac59) | `gbenchmark: add prometheus-cpp as reverse dependency to passthru.tests` |
| [`9887b5f8`](https://github.com/NixOS/nixpkgs/commit/9887b5f82993f329f576ce89edb7690a85a09759) | `gbenchmark: 1.6.1 -> 1.7.1`                                             |
| [`34e4fefb`](https://github.com/NixOS/nixpkgs/commit/34e4fefbc43322675a85ea62c1462827fda1c147) | `fluent-bit: 2.0.4 -> 2.0.5`                                             |
| [`07960ec7`](https://github.com/NixOS/nixpkgs/commit/07960ec7e58b0f963194d584014f21eb184d8742) | `flyctl: 0.0.429 -> 0.0.430`                                             |
| [`16608b07`](https://github.com/NixOS/nixpkgs/commit/16608b07172233f521b41767f1fad6690932e8df) | `fatrace: 0.16.3 -> 0.17.0`                                              |
| [`3c90832b`](https://github.com/NixOS/nixpkgs/commit/3c90832b982cdb2d71f156118ef8c57fc95ca852) | `eksctl: 0.117.0 -> 0.118.0`                                             |
| [`80771ac6`](https://github.com/NixOS/nixpkgs/commit/80771ac66020b3ec304e5843731ca216488b201c) | `ecs-agent: add ldflags`                                                 |
| [`51aa6ca1`](https://github.com/NixOS/nixpkgs/commit/51aa6ca18e158a2913873754b9af2088a5a083f6) | `ecs-agent: 1.66.1 -> 1.66.2`                                            |
| [`16a812bc`](https://github.com/NixOS/nixpkgs/commit/16a812bc4fe8561e8adc28cc0923dfe2f14a4697) | `ecs-agent: 1.65.1 -> 1.66.1`                                            |
| [`dd4767bf`](https://github.com/NixOS/nixpkgs/commit/dd4767bf613bf9553eee6ff37c0996b9c876e7d8) | `terraform-providers.tencentcloud: 1.78.9 → 1.78.10`                     |
| [`c107dd3c`](https://github.com/NixOS/nixpkgs/commit/c107dd3c00d0ede7fdf10fc58dc79a1459563729) | `terraform-providers.yandex: 0.81.0 → 0.82.0`                            |
| [`684169b5`](https://github.com/NixOS/nixpkgs/commit/684169b5bb111e701f96a775b2b398629f80f109) | `terraform-providers.opsgenie: 0.6.16 → 0.6.17`                          |
| [`7f8be3a7`](https://github.com/NixOS/nixpkgs/commit/7f8be3a7e4f70c9e804eec28ace0f5986289c80d) | `terraform-providers.bitbucket: 2.21.3 → 2.21.4`                         |
| [`91890390`](https://github.com/NixOS/nixpkgs/commit/918903904eb6616b54b1816c04ca31bd949f455a) | `ruff: 0.0.112 -> 0.0.113`                                               |
| [`e4d96a1f`](https://github.com/NixOS/nixpkgs/commit/e4d96a1f37c15e0571424b6cbca027137ad9c2d1) | `python310Packages.dateparser: 1.1.1 -> 1.1.3`                           |
| [`2c2b953b`](https://github.com/NixOS/nixpkgs/commit/2c2b953bf8302d5f3c6251e822a0e14a366e769c) | `bees: 0.7 -> 0.8`                                                       |
| [`548454a1`](https://github.com/NixOS/nixpkgs/commit/548454a1560be9306bf120c2d37fd10679ce7a68) | `dnsperf: 2.9.0 -> 2.10.0`                                               |
| [`7b9e5f42`](https://github.com/NixOS/nixpkgs/commit/7b9e5f423388adbfa2e97267fe0376407baaf31c) | `dgraph: 22.0.0 -> 22.0.1`                                               |
| [`e6559e6a`](https://github.com/NixOS/nixpkgs/commit/e6559e6a5c1116477e97541c2e80c8ddd8e1f2bf) | `datasette: 0.63 -> 0.63.1`                                              |
| [`acbda55c`](https://github.com/NixOS/nixpkgs/commit/acbda55c3a3c7714b096b06eea4195584be6affa) | `vscode-extensions.redhat.vscode-xml: init at 0.22.0`                    |
| [`d6a47add`](https://github.com/NixOS/nixpkgs/commit/d6a47add57df4b159977c63bb372ab98fbaa6084) | `hpccm: 22.8.0 -> 22.10.0`                                               |
| [`c545195c`](https://github.com/NixOS/nixpkgs/commit/c545195ca70bfa43c1059db7cb9859851a0c905a) | `subnetcalc: 2.4.19 -> 2.4.20`                                           |
| [`08a15f5e`](https://github.com/NixOS/nixpkgs/commit/08a15f5e2dd7b203213b44d6e0c41e03529474d8) | `deepwave: 0.0.14 -> 0.0.17`                                             |