### PR TITLE
chore(flake/deploy-rs): `b011f13b` -> `be408237`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668166163,
-        "narHash": "sha256-XCuM+n98KcG0v+DT1HolGCO3j5FOBUjV4K8YcZsVeQw=",
+        "lastModified": 1668453806,
+        "narHash": "sha256-rDyF0essyFdCIo336gI6nPjWhjoczGn701D1JID5wl8=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "b011f13bc577b978f52aaefde5605332f7bca7e9",
+        "rev": "be40823735bbdc40c1f6b7725c8b74d5a85d8023",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                            |
| --------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`38d9005a`](https://github.com/serokell/deploy-rs/commit/38d9005a7334d45749dcfecb924f7ff1444e8699) | `More unique names for the checks generated by deploy-rs` |