### PR TITLE
chore(flake/nixpkgs): `fc076226` -> `013fcdd1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668326430,
-        "narHash": "sha256-fJEsHe+lzFf3qcQVTTdK9jqRtUUVXH71tdfgjcKJNpA=",
+        "lastModified": 1668417584,
+        "narHash": "sha256-yeuEyxKPwsm5fIHN49L/syn9g5coxnPp3GsVquhrv5A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fc07622617a373a742ed96d4dd536849d4bc1ec6",
+        "rev": "013fcdd106823416918004bb684c3c186d3c460f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                             |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`defcd6b6`](https://github.com/NixOS/nixpkgs/commit/defcd6b623a8956a9780895cbccddc01fb8edd91) | `python3Packages.geometric: 0.9.7.2 -> 1.0`                                |
| [`a0212e0f`](https://github.com/NixOS/nixpkgs/commit/a0212e0f8ebb5731d48b41e32dba1cc7e918c1ad) | `fd: 8.5.2 -> 8.5.3`                                                       |
| [`4f34f4a8`](https://github.com/NixOS/nixpkgs/commit/4f34f4a8633e1f63c1c18c370d63589527f4afd5) | `pam_ussh: fix build with go > 1.17`                                       |
| [`ee015169`](https://github.com/NixOS/nixpkgs/commit/ee015169b775c88ee7f76a996cf601161abf4a68) | `awscli2: 2.8.11 -> 2.8.12`                                                |
| [`b0b25854`](https://github.com/NixOS/nixpkgs/commit/b0b258544faf3843a97db362bc28b2f3f3fbcc1d) | `python310Packages.pytorch-pfn-extras: 0.6.1 -> 0.6.2`                     |
| [`ff7f75df`](https://github.com/NixOS/nixpkgs/commit/ff7f75dfccec524e33f472e27fad2ca8742d873b) | `perf-linux: fix build on linux 5.4`                                       |
| [`2c09426b`](https://github.com/NixOS/nixpkgs/commit/2c09426bcb544db300410dbb1bf8fefd3e498587) | `python310Packages.ua-parser: 0.15.0 -> 0.16.1`                            |
| [`a0bf7e25`](https://github.com/NixOS/nixpkgs/commit/a0bf7e251c9e830157475684e19ca6ae129102a4) | `python310Packages.xsdata: 22.9 -> 22.11`                                  |
| [`a3bd0182`](https://github.com/NixOS/nixpkgs/commit/a3bd01822330f9cdc25c62f061ac088d5d35a1e2) | `python310Packages.safety: 2.2.1 -> 2.3.1`                                 |
| [`47728c43`](https://github.com/NixOS/nixpkgs/commit/47728c4392cd05839d01037beeac7f6104e77ee2) | `manim: fix build`                                                         |
| [`41eb952b`](https://github.com/NixOS/nixpkgs/commit/41eb952bbbe1558dc44a5f801443a73770a4c5bd) | `python310Packages.prefixed: 0.4.0 -> 0.4.2`                               |
| [`92ad187a`](https://github.com/NixOS/nixpkgs/commit/92ad187a934f82e5a38e7959bd22104ee10fd73f) | `influxdb2: 2.4.0 -> 2.5.1`                                                |
| [`b016e85f`](https://github.com/NixOS/nixpkgs/commit/b016e85f39d5945c855df7cf7073f97c0e899a5e) | `audacity: add x86_64-darwin support (#201104)`                            |
| [`766ad4f6`](https://github.com/NixOS/nixpkgs/commit/766ad4f624a1bcffb8e4b0ef5f1a7ac16fd12a62) | `python310Packages.pyosmium: 3.4.1 -> 3.5.0`                               |
| [`177732bd`](https://github.com/NixOS/nixpkgs/commit/177732bd36ec4e640f4c893247329967ad5ed1dd) | `perf: add libbabeltrace dependency`                                       |
| [`92eaf16a`](https://github.com/NixOS/nixpkgs/commit/92eaf16a759808cbb38a5b2deb5c8b50ac9c681b) | `argocd: 2.5.1 -> 2.5.2`                                                   |
| [`2f52d4fa`](https://github.com/NixOS/nixpkgs/commit/2f52d4fae237d03ac98718e9279c075fdf85e622) | `harfbuzz: rewrite mesonFeatureFlag`                                       |
| [`1405f8a9`](https://github.com/NixOS/nixpkgs/commit/1405f8a944547109f1031a97c93c02ef96e590da) | `fcft: rewrite mesonFeatureFlag`                                           |
| [`a2bca809`](https://github.com/NixOS/nixpkgs/commit/a2bca8092c2cf0d0408c2af43d7652338a652a96) | `wbg: rewrite mesonFeatureFlag`                                            |
| [`81ada634`](https://github.com/NixOS/nixpkgs/commit/81ada634ea14e4e16b0e30795d69117a3342001d) | `barrage: 1.0.5 -> 1.0.6 (#199266)`                                        |
| [`63a7d5b3`](https://github.com/NixOS/nixpkgs/commit/63a7d5b3fb72a7dac5116e10dd7d9c9b3ec6b148) | `gmp: fixup license of v6 (#199052)`                                       |
| [`d070a17b`](https://github.com/NixOS/nixpkgs/commit/d070a17bb12aaed2f43f84d4146ccbec4f2e91bf) | `blocky: 0.19 -> 0.20 (#201009)`                                           |
| [`e054caea`](https://github.com/NixOS/nixpkgs/commit/e054caeaae2c3534bde830eda5957d7b1f010e4d) | `python310Packages.asyncpg: 0.26.0 -> 0.27.0 (#199918)`                    |
| [`c47fe07a`](https://github.com/NixOS/nixpkgs/commit/c47fe07aaafa4e44cdf125b8f4d2857c1bef920d) | `appflowy: 0.0.4 -> 0.0.6.2 (#192921)`                                     |
| [`a715b68d`](https://github.com/NixOS/nixpkgs/commit/a715b68d99c8a3bcc425a203c0fd519796309291) | `python310Packages.miniaudio: 1.53 -> 1.54`                                |
| [`d627858e`](https://github.com/NixOS/nixpkgs/commit/d627858e17368cc6f1db874d4cd9b7f789eee267) | `miniaudio: unstable-2020-04-20 -> 0.11.11`                                |
| [`057860ff`](https://github.com/NixOS/nixpkgs/commit/057860fff9771cca624ae1240e729ac3681b898b) | `flow: 0.192.0 -> 0.193.0`                                                 |
| [`41aac0c5`](https://github.com/NixOS/nixpkgs/commit/41aac0c57b4d2b9c50786a5f52dac1b03d9169a7) | `flexget: 3.5.4 -> 3.5.5`                                                  |
| [`c4627f35`](https://github.com/NixOS/nixpkgs/commit/c4627f3540f0b05bca803166010cc140834585a3) | `fheroes2: 0.9.20 -> 0.9.21`                                               |
| [`1750e7cf`](https://github.com/NixOS/nixpkgs/commit/1750e7cfeb663d675b7567240fb60b6017b60338) | `python310Packages.plexapi: update disabled`                               |
| [`62314d21`](https://github.com/NixOS/nixpkgs/commit/62314d2169731828284e23b449f4fd6e635a7619) | `radare2: drop unused useFlag and fix cross compilation`                   |
| [`3d16a81b`](https://github.com/NixOS/nixpkgs/commit/3d16a81bad31940b92b6a5ec6f7290dddfbf320f) | `radare2: fix macos build`                                                 |
| [`50e6fbee`](https://github.com/NixOS/nixpkgs/commit/50e6fbee57689836b4ff03991638b0ef51779cd6) | `mold: 1.6.0 -> 1.7.0`                                                     |
| [`37e4b8ac`](https://github.com/NixOS/nixpkgs/commit/37e4b8ac68789a89c8eaa74cbc940ac526fdf523) | `python310Packages.plexapi: 4.13.0 -> 4.13.1`                              |
| [`d204d44c`](https://github.com/NixOS/nixpkgs/commit/d204d44cc81ae801137b117e71ccb2b773bafcc5) | `ike: remove`                                                              |
| [`8c72bf53`](https://github.com/NixOS/nixpkgs/commit/8c72bf531313ae6885437dc37fd2369be98d18b3) | `python310Packages.plaid-python: 10.0.0 -> 11.1.0`                         |
| [`5d0540cf`](https://github.com/NixOS/nixpkgs/commit/5d0540cfe96e3e767462f9818605dc16b4d94c90) | `python310Packages.persistent: 4.9.1 -> 4.9.2`                             |
| [`8b2612f8`](https://github.com/NixOS/nixpkgs/commit/8b2612f87b7297a40227bc93c186ebc62345bf28) | `python310Packages.pdfposter: update licence`                              |
| [`9e41bb77`](https://github.com/NixOS/nixpkgs/commit/9e41bb775529f8641f7da84667c22117d9327d39) | `python310Packages.pdfposter: add format attribute and pythonImportsCheck` |
| [`8627d1e3`](https://github.com/NixOS/nixpkgs/commit/8627d1e3e9a04a8933d443a92380d2e3dc849291) | `python310Packages.pdfposter: 0.8 -> 0.8.1`                                |
| [`f933aea9`](https://github.com/NixOS/nixpkgs/commit/f933aea9e194bca9f63e36cae699634b4d90b28c) | `bobcat: Fix build on aarch64-linux`                                       |
| [`d85d8b7e`](https://github.com/NixOS/nixpkgs/commit/d85d8b7eef991118c970451ad5ac91358fb51517) | `python310Packages.nextcord: 2.2.0 -> 2.3.2`                               |
| [`cd00072e`](https://github.com/NixOS/nixpkgs/commit/cd00072eeb6ca71e6f30831385ce9d613508ad1d) | `vector: 0.25.0 -> 0.25.1`                                                 |
| [`4742b0b9`](https://github.com/NixOS/nixpkgs/commit/4742b0b90f4a425175902caa50cde3178f0c7881) | `sbclPackages.magicl: mark as broken`                                      |
| [`0fab17bc`](https://github.com/NixOS/nixpkgs/commit/0fab17bc0f50ac45dd48d5366da2a3cbdf67c637) | `python310Packages.nbsphinx: add format attribute`                         |
| [`f1b67d05`](https://github.com/NixOS/nixpkgs/commit/f1b67d05401364c712fe2a37cbb5a321b56425aa) | `python310Packages.nbsphinx: 0.8.9 -> 0.8.10`                              |
| [`1381c2a7`](https://github.com/NixOS/nixpkgs/commit/1381c2a7a98e0412c9b3b43d6e16be42bea22041) | `python310Packages.nbclassic: 0.4.7 -> 0.4.8`                              |
| [`68efd929`](https://github.com/NixOS/nixpkgs/commit/68efd9293be6d150e1b322c0a200fda548e6579e) | `qdrant: 0.9.1 -> 0.11.2`                                                  |
| [`a5d8197f`](https://github.com/NixOS/nixpkgs/commit/a5d8197fa56983830dadad42dc7833170fd16a64) | `abcmidi: 2022.08.23 -> 2022.09.01`                                        |
| [`aae6250c`](https://github.com/NixOS/nixpkgs/commit/aae6250cdb849b0ecd1c35146ff19496363ca932) | `lisgd: 0.3.4 -> 0.3.5`                                                    |
| [`fa01101d`](https://github.com/NixOS/nixpkgs/commit/fa01101d4360dbf8f9cf3a0ad3b632e845c2ac81) | `python310Packages.mypy-protobuf: 3.3.0 -> 3.4.0`                          |
| [`d36e0be2`](https://github.com/NixOS/nixpkgs/commit/d36e0be2eafaf8c217472bc0425256f5679c7671) | `xyce: 7.4.0 -> 7.6.0`                                                     |
| [`d2eb448e`](https://github.com/NixOS/nixpkgs/commit/d2eb448e600d5f30b7dcc8beda7e1e9e6693ab59) | `Revert "oneDNN: 2.3.2 -> 2.5.2"`                                          |
| [`1b9e259e`](https://github.com/NixOS/nixpkgs/commit/1b9e259e0a25968e2288e2ea214dbc0352c69941) | `maintainers/maintainer-list.nix: update info for AndersonTorres`          |
| [`fba9db4f`](https://github.com/NixOS/nixpkgs/commit/fba9db4f724ba66ed41bc3c69b061a5f21f3078b) | `maintainer-list.nix: remove flexw`                                        |
| [`cb9e4b5e`](https://github.com/NixOS/nixpkgs/commit/cb9e4b5e56d50f86d6c8ff90d67c841d4e79211a) | `apitrace: 7.1.old -> 11.1`                                                |
| [`69218416`](https://github.com/NixOS/nixpkgs/commit/6921841682aaca6de11bc285c9c79453e98ccc44) | `coqPackages.interval: 4.5.2 → 4.6.0`                                      |
| [`ecf9e160`](https://github.com/NixOS/nixpkgs/commit/ecf9e1600e2afa87d61a18200357c2677a006b67) | `docui: mark as broken on darwin`                                          |
| [`4518440a`](https://github.com/NixOS/nixpkgs/commit/4518440a5ef147e040d574170eb8907a0b198320) | `neardal: mark as broken`                                                  |
| [`fb56af45`](https://github.com/NixOS/nixpkgs/commit/fb56af45a096e1f1dc39558070406b17ffafc16d) | `ghidra-bin: 10.1.5 -> 10.2.1`                                             |
| [`86b27c13`](https://github.com/NixOS/nixpkgs/commit/86b27c138d062c203d389ae1303dfe4b890ac06c) | `meerk40t-camera: extract to top-level`                                    |
| [`fd9d20ec`](https://github.com/NixOS/nixpkgs/commit/fd9d20eccdb9225cdfe0e8b1aa4f5066ec06baa1) | `tridactyl: fix typo`                                                      |
| [`9fca6518`](https://github.com/NixOS/nixpkgs/commit/9fca65181cdd59c5cf42ae1a27151cd6e1bae6f9) | `enhanced-ctorrent: move to p2p/`                                          |
| [`2db0ddb9`](https://github.com/NixOS/nixpkgs/commit/2db0ddb968357051237915256b7a1fc841492762) | `php80.packages.php-parallel-lint: Mark as broken`                         |
| [`d0952837`](https://github.com/NixOS/nixpkgs/commit/d09528373d7cbb0418e752405cac51bdae676a0c) | `emacs.pkgs.ada-mode: fix build for version 7.3.1`                         |
| [`fed3699e`](https://github.com/NixOS/nixpkgs/commit/fed3699eb5255e662898db1ca2131aecf968a0db) | `tree-sitter-langs: fixup update-defaults.py`                              |
| [`03fa9cdd`](https://github.com/NixOS/nixpkgs/commit/03fa9cdde9bf21ed7f518193d60f131cd254856d) | `treewide: move all ad-hoc elisp packages to manual-packages/`             |
| [`c47cbf3a`](https://github.com/NixOS/nixpkgs/commit/c47cbf3acaff10179b418c216bb5e6e1cd63c2c4) | `emacs.pkgs.prisma-mode: move to a dedicated directory`                    |
| [`d19c5a23`](https://github.com/NixOS/nixpkgs/commit/d19c5a23845a22df1da778c41c501b42438dc0f8) | `emacs.pkgs.matrix-client: move to a dedicated directory`                  |
| [`022ffab4`](https://github.com/NixOS/nixpkgs/commit/022ffab437d64bd9469a323ca4a9aeec3af3fdf4) | `emacs.pkgs.haskell-unicode-input-method: move to a dedicated directory`   |
| [`96b0956a`](https://github.com/NixOS/nixpkgs/commit/96b0956aeefa40741b65dcf5d57deb741ec3bba0) | `emacs.pkgs.ghc-mod: move to a dedicated directory`                        |
| [`19fcf502`](https://github.com/NixOS/nixpkgs/commit/19fcf50295353329c899eeaa439667a62a9f9c15) | `brev-cli: 0.6.160 -> 0.6.170`                                             |
| [`affef01d`](https://github.com/NixOS/nixpkgs/commit/affef01d4ab6e27b5597f6abba167cad82612673) | `treesheets: unstable-2022-10-20 -> unstable-2022-11-11`                   |
| [`ec860f90`](https://github.com/NixOS/nixpkgs/commit/ec860f905d6aaec9dc19b1757c457ba36e10ca84) | `chromiumDev: 109.0.5396.2 -> 109.0.5410.0`                                |
| [`159d73f7`](https://github.com/NixOS/nixpkgs/commit/159d73f7a3b69841ccd587d439341d78f8c859c6) | `nixos/chisel-server: add module`                                          |
| [`c4201890`](https://github.com/NixOS/nixpkgs/commit/c42018900a1072eb4a642166ca90cc25d3f374eb) | `maintainers: add clerie`                                                  |
| [`364a7d29`](https://github.com/NixOS/nixpkgs/commit/364a7d29200602a7ea564cc6e20d96154a03005f) | ``php: switch to `nts` by default``                                        |
| [`72d4bd54`](https://github.com/NixOS/nixpkgs/commit/72d4bd54af8cf0039b6389ccaa893de3b0139e3f) | `mautrix-signal: 0.4.0 -> 0.4.1`                                           |
| [`aef38a98`](https://github.com/NixOS/nixpkgs/commit/aef38a9881795627ceca9bc0e408b3036d9677b0) | `mautrix-signal: 0.3.0 -> 0.4.0`                                           |
| [`0e2aa82a`](https://github.com/NixOS/nixpkgs/commit/0e2aa82aa73dd4d15136a614ccaa844024bae2ac) | `python310Packages.mautrix: 0.18.4 -> 0.18.7`                              |
| [`cac2d43a`](https://github.com/NixOS/nixpkgs/commit/cac2d43a7f58078233f4f9c998dc18a65b0c6c95) | `python310Packages.googlemaps: add format`                                 |
| [`5c575e70`](https://github.com/NixOS/nixpkgs/commit/5c575e70702062da6c6c1da98be9ed6d25ebd9f9) | `python310Packages.gcal-sync: 4.0.1 -> 4.0.2`                              |
| [`2b021863`](https://github.com/NixOS/nixpkgs/commit/2b021863d1fc5adfdcf3d3cf35be4d9c407fa688) | `python310Packages.pysensibo: 1.0.20 -> 1.0.21`                            |
| [`807dd234`](https://github.com/NixOS/nixpkgs/commit/807dd234b51e00ea09eb62cd1aea67940bdbc651) | `polaris-web: build-54 -> build-55`                                        |
| [`937db834`](https://github.com/NixOS/nixpkgs/commit/937db83412d3877fb74e05b3560f02237c6e24e5) | `podman-tui: 0.6.0 -> 0.7.0`                                               |
| [`399293b4`](https://github.com/NixOS/nixpkgs/commit/399293b4e7df1cc7c14be4ee6f06bfc064ba97d9) | `python310Packages.jupyterlab_server: 2.16.2 -> 2.16.3`                    |
| [`443bb04d`](https://github.com/NixOS/nixpkgs/commit/443bb04d2c99d8070caea92b83e9c42289af4a59) | `wakatime: 1.55.2 -> 1.57.0`                                               |
| [`aaf29c01`](https://github.com/NixOS/nixpkgs/commit/aaf29c0198726d46380d072210546d263bbb9935) | `webp-pixbuf-loader: 0.0.6 -> 0.0.7`                                       |
| [`61c20755`](https://github.com/NixOS/nixpkgs/commit/61c207555ba1b893cdc728ae983e1cba7c7cb854) | `hal-hardware-analyzer: use igraph 0.9`                                    |
| [`1c811a8c`](https://github.com/NixOS/nixpkgs/commit/1c811a8ce80248c3478634470ff10c2b9ba9aaa5) | `python310Packages.googlemaps: 4.6.0 -> 4.7.0`                             |
| [`c0aa21b4`](https://github.com/NixOS/nixpkgs/commit/c0aa21b4472dfe7c221a19a8a1882e48575beb99) | `python310Packages.google-cloud-pubsub: 2.13.10 -> 2.13.11`                |
| [`82294b4a`](https://github.com/NixOS/nixpkgs/commit/82294b4a998a4e391fa29a1cf0953d8cf14252a0) | `terragrunt: 0.40.1 -> 0.40.2`                                             |
| [`457efcd3`](https://github.com/NixOS/nixpkgs/commit/457efcd3520907e5d1a304632fd308558359958e) | `emacs.pkgs.elisp-ffi: move to a dedicated directory`                      |
| [`1d0df163`](https://github.com/NixOS/nixpkgs/commit/1d0df163497cf8d80f3df8a0ab55fbf045f28465) | `step-cli: 0.22.0 -> 0.23.0`                                               |
| [`672f0ddb`](https://github.com/NixOS/nixpkgs/commit/672f0ddbb17253d01237961e1454fddbac4748d1) | `step-ca: 0.22.1 -> 0.23.0`                                                |
| [`f5093f3e`](https://github.com/NixOS/nixpkgs/commit/f5093f3eb64ca27d5425580e234b2ce4a49e70f0) | `dolphin-emu-beta: small cleanup`                                          |
| [`7f2df6d7`](https://github.com/NixOS/nixpkgs/commit/7f2df6d79d66d7cda43f83af80d98d0133471f71) | `snappymail: 2.20.6 -> 2.21.0`                                             |
| [`5c134e63`](https://github.com/NixOS/nixpkgs/commit/5c134e63424000d65b571a0bc917150830e568c8) | `python310Packages.tplink-omada-client: init at 1.0.1`                     |
| [`abdb82c0`](https://github.com/NixOS/nixpkgs/commit/abdb82c04cfc6e96a178db975e7f8939fc38f98c) | `python310Packages.aeppl: 0.0.38 -> 0.0.39`                                |
| [`6656fe85`](https://github.com/NixOS/nixpkgs/commit/6656fe857900634cd38c5b85cc657004ea3dd6d4) | `python310Packages.aesara: 2.8.4 -> 2.8.9`                                 |
| [`34beb3f2`](https://github.com/NixOS/nixpkgs/commit/34beb3f22b60afcc51f44913475af24a8a22da7a) | `python310Packages.graphql-subscription-manager: 0.7.0 -> 0.7.1`           |
| [`12a208a4`](https://github.com/NixOS/nixpkgs/commit/12a208a4c065ecb59186a634505d7c5f1110d6b9) | `python310Packages.praw: 7.6.0 -> 7.6.1`                                   |
| [`cd74512c`](https://github.com/NixOS/nixpkgs/commit/cd74512c68203cdc2cb88188263785800d5c430b) | `opentelemetry-collector: 0.64.0 -> 0.64.1`                                |
| [`e05177dd`](https://github.com/NixOS/nixpkgs/commit/e05177ddebdb773ebfc17916a19d399f5dffda01) | `st: 0.8.5 → 0.9`                                                          |
| [`8a702c2d`](https://github.com/NixOS/nixpkgs/commit/8a702c2d1dc0a8c197953899c753deeb3b184c52) | `python310Packages.pyrisco: 0.5.5 -> 0.5.6`                                |
| [`fb559700`](https://github.com/NixOS/nixpkgs/commit/fb5597009a679637ae3d8e49f3e9cb5ce25a80f8) | `python310Packages.pynuki: 1.5.2 -> 1.6.0`                                 |
| [`75439716`](https://github.com/NixOS/nixpkgs/commit/75439716e4b42db1993dbc106034346e5db65858) | `python310Packages.twilio: 7.15.1 -> 7.15.2`                               |
| [`abb6e9a4`](https://github.com/NixOS/nixpkgs/commit/abb6e9a474bdb0892d6e992f816ed49fbe476c5a) | `python310Packages.wsgidav: 4.0.2 -> 4.1.0`                                |
| [`48715326`](https://github.com/NixOS/nixpkgs/commit/4871532691908e2fa545d63e642dd8ca70a57a63) | `python310Packages.pyskyqremote: 0.3.19 -> 0.3.20`                         |
| [`f4e9e74e`](https://github.com/NixOS/nixpkgs/commit/f4e9e74e9fb55ba27df59644811f500885e42ce9) | `tabbed: unstable-2018-03-10 → 0.7`                                        |
| [`a30fac9d`](https://github.com/NixOS/nixpkgs/commit/a30fac9db7fb895c7e047d93a5fc0134d6fc519a) | `python310Packages.crownstone-core: 3.2.0 -> 3.2.1`                        |
| [`0d3428cd`](https://github.com/NixOS/nixpkgs/commit/0d3428cd75d877d16cf126b8a6229744185b8b57) | `pkgsStatic.libxslt: fix build`                                            |
| [`2acd1aca`](https://github.com/NixOS/nixpkgs/commit/2acd1aca5ac40e18c5727dd503b45bb6fa1e2bff) | `monolith: 2.6.2 -> 2.7.0`                                                 |
| [`35084139`](https://github.com/NixOS/nixpkgs/commit/35084139ec4793f1f046088f7ca0922ddb09cede) | `python310Packages.aioweenect: init at 1.1.1`                              |
| [`d81027ce`](https://github.com/NixOS/nixpkgs/commit/d81027ce10c9c2409f541d8413a31b80d5004ae0) | `ghidra: 10.2 -> 10.2.1`                                                   |
| [`953852df`](https://github.com/NixOS/nixpkgs/commit/953852df26006b6eeb92ec21cd72bd4243f8934c) | `python310Packages.dbus-fast: 1.72.0 -> 1.73.0`                            |
| [`3ab2c73e`](https://github.com/NixOS/nixpkgs/commit/3ab2c73e5b84824ab3a4cbd116b1950d579a5ff9) | `kubeone: 1.5.2 -> 1.5.3`                                                  |
| [`966d9b95`](https://github.com/NixOS/nixpkgs/commit/966d9b95e51e44dd42e0961d1a2c34dd627a437e) | `nlohmann_json: 3.10.5 → 3.11.2`                                           |
| [`bdd3a9a2`](https://github.com/NixOS/nixpkgs/commit/bdd3a9a26d7fbc10773a89277bfee1b9404c88ef) | `tran: init at 0.1.43`                                                     |
| [`c0dab102`](https://github.com/NixOS/nixpkgs/commit/c0dab102f9203bd71497fd1d785e0db3bacdc222) | `r3ctl: init at a82cb5b3123224e706835407f21acea9dc7ab0f0`                  |
| [`595d7f91`](https://github.com/NixOS/nixpkgs/commit/595d7f91f1dfead6dc286ae75b3014557d627a71) | `python310Packages.aioapns: disable for Python<3.6`                        |
| [`a83f6a41`](https://github.com/NixOS/nixpkgs/commit/a83f6a418a4ad46157b938a684dfc2f6a246e1b3) | `python310Packages.aioapns: add format attribute`                          |
| [`db2e8444`](https://github.com/NixOS/nixpkgs/commit/db2e8444a27a957ee2740ce794da2381e6b7f6e8) | `python310Packages.aioapns: 2.1 -> 2.2`                                    |
| [`9bf9f83d`](https://github.com/NixOS/nixpkgs/commit/9bf9f83df597a707e39b9a5386c98289bd3e81d4) | `urdfdom: 1.0.4 -> 3.1.0`                                                  |
| [`c87af387`](https://github.com/NixOS/nixpkgs/commit/c87af38741793415d674e8696c824efc5c2ca8af) | `lean: 3.48.0 -> 3.49.0`                                                   |
| [`005798c9`](https://github.com/NixOS/nixpkgs/commit/005798c998d4d0be480984a7f8929af698c89782) | `obs-studio-plugins.input-overlay: init at 5.0.0`                          |
| [`f046cc09`](https://github.com/NixOS/nixpkgs/commit/f046cc092332d3b5d3d58736c83abc4dac68b579) | `nixos/pam: support fscrypt login protectors`                              |
| [`5a2f9d21`](https://github.com/NixOS/nixpkgs/commit/5a2f9d213ab1829781f651ae95459a060f2caca4) | `senpai: unstable-2022-10-19 → unstable-11-04`                             |
| [`a10509b9`](https://github.com/NixOS/nixpkgs/commit/a10509b9d58adb01605218b1b60d8d28b52abbff) | `python310Packages.pyswitchbot: 0.20.2 -> 0.20.3`                          |
| [`8bfbedd3`](https://github.com/NixOS/nixpkgs/commit/8bfbedd3c81b1be75ffeb699ae748574b8869772) | `git-subrepo: 0.4.1 -> 0.4.5`                                              |
| [`2ff815c0`](https://github.com/NixOS/nixpkgs/commit/2ff815c01f2ad31e5cbcaf49fdcd60ef32930cd4) | `zsv: init at 2022-11-12`                                                  |
| [`91b42a6f`](https://github.com/NixOS/nixpkgs/commit/91b42a6f6f4c60d119fc8cd7222afe32bcf90c3c) | `millet: 0.5.13 -> 0.5.16`                                                 |
| [`f160036b`](https://github.com/NixOS/nixpkgs/commit/f160036b3bf8b9c5dc4c9018559228f5e9906317) | `fastlane: 2.210.1 -> 2.211.0`                                             |
| [`be3799a6`](https://github.com/NixOS/nixpkgs/commit/be3799a61f98fcc6da80978b9908d3c01d68e2f5) | `okteto: 2.8.2 -> 2.9.0`                                                   |
| [`7cb733df`](https://github.com/NixOS/nixpkgs/commit/7cb733df46434684cfa9b5194e897e32c6631aea) | `flat-remix-gnome: update 20220622 -> 20221107.`                           |
| [`fbd4f787`](https://github.com/NixOS/nixpkgs/commit/fbd4f7875d04bedb7eb37fee26ddbde1241b7fd3) | `dinghy: 0.14.0 -> 0.15.0`                                                 |
| [`d82f5251`](https://github.com/NixOS/nixpkgs/commit/d82f52519a3a9bd3bc646bb1c9fe380b802cc8fd) | `nixos/libvirtd: always start libvirtd`                                    |
| [`b2dd9af9`](https://github.com/NixOS/nixpkgs/commit/b2dd9af97bcf1264a5f676087e75d0e1f609809e) | `python310Packages.aioridwell: 2022.10.0 -> 2022.11.0`                     |
| [`bc0e4395`](https://github.com/NixOS/nixpkgs/commit/bc0e439506fc3524738a5e7b1aaf55893e0af7a0) | `radare2: 5.7.2 -> 5.7.8`                                                  |
| [`711f3ddb`](https://github.com/NixOS/nixpkgs/commit/711f3ddbdbc9e63d291641a2e8d6f728986e4583) | `oneDNN: 2.3.2 -> 2.5.2`                                                   |
| [`74cf3d84`](https://github.com/NixOS/nixpkgs/commit/74cf3d8455b4daa196a8bc60d11e76a2891afb4d) | `python310Packages.azure-batch: disable on older Python releases`          |
| [`fdddc8ba`](https://github.com/NixOS/nixpkgs/commit/fdddc8baedc04adc4611059a18c2d026947db48a) | `jump: 0.41.0 -> 0.51.0`                                                   |
| [`49beacfe`](https://github.com/NixOS/nixpkgs/commit/49beacfe5c459f1f0ef76848371d31d9066aa925) | `python310Packages.azure-batch: 12.0.0 -> 13.0.0`                          |
| [`e83a0461`](https://github.com/NixOS/nixpkgs/commit/e83a04619d095d155b57d516cee3cef761b5293e) | `oak: 0.2 -> 0.3`                                                          |
| [`3db5d748`](https://github.com/NixOS/nixpkgs/commit/3db5d748a7d2344b5818cad35d378115a8706e64) | `chart-testing: add runtimeInputs`                                         |
| [`37517fd1`](https://github.com/NixOS/nixpkgs/commit/37517fd1271a05694fd6bb9761f1fa8b735fdc61) | `lingot: 1.0.1 -> 1.1.1`                                                   |