### PR TITLE
chore(flake/darwin): `cfc0125e` -> `4182ad42`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667419884,
-        "narHash": "sha256-oLNw87ZI5NxTMlNQBv1wG2N27CUzo9admaFlnmavpiY=",
+        "lastModified": 1668534244,
+        "narHash": "sha256-8sgzegrEVUZMJUg4jEiC6pokeMPY02BFe49iXnVrXkk=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "cfc0125eafadc9569d3d6a16ee928375b77e3100",
+        "rev": "4182ad42d5fb5001adb1f61bec3a04fae0eecb95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                    |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`6b73d2c6`](https://github.com/LnL7/nix-darwin/commit/6b73d2c605cd1a063931f722151d00dc1157275d) | `Type: TERMINFO_DIRS not TERMINFO`                |
| [`ed993c50`](https://github.com/LnL7/nix-darwin/commit/ed993c5038330c9dc0caf08bef7b64fc2f942f75) | `Add system terminfo to TERMINFO_DIRS by default` |