### PR TITLE
chore(flake/nixpkgs): `013fcdd1` -> `52b2ac8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668417584,
-        "narHash": "sha256-yeuEyxKPwsm5fIHN49L/syn9g5coxnPp3GsVquhrv5A=",
+        "lastModified": 1668765800,
+        "narHash": "sha256-rC40+/W6Hio7b/RsY8SvQPKNx4WqNcTgfYv8cUMAvJk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "013fcdd106823416918004bb684c3c186d3c460f",
+        "rev": "52b2ac8ae18bbad4374ff0dd5aeee0fdf1aea739",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                          |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`79c81777`](https://github.com/NixOS/nixpkgs/commit/79c817774c25cef4ed27af5890830afc4560c42b) | `traefik: 2.9.4 -> 2.9.5`                                                               |
| [`c3b773d8`](https://github.com/NixOS/nixpkgs/commit/c3b773d802f0987f2f2f670aa6bc695d47c6ae52) | `git-absorb: 0.6.7 -> 0.6.9`                                                            |
| [`bcb2de44`](https://github.com/NixOS/nixpkgs/commit/bcb2de4443268e009b82f22570567b2b013d5523) | `renameutils: fix package on darwin (#195807)`                                          |
| [`6e44c96a`](https://github.com/NixOS/nixpkgs/commit/6e44c96a5dcad9baf037177b5017e805f5c692f6) | `soupault: 4.3.0 → 4.3.1`                                                               |
| [`3ca85508`](https://github.com/NixOS/nixpkgs/commit/3ca855084a6a016c5d5e361a544025a1d860afdd) | `catch2_3: 3.1.1 -> 3.2.0`                                                              |
| [`6b72268e`](https://github.com/NixOS/nixpkgs/commit/6b72268ea8c7cbb525a284e205203e5f4b0b5d3c) | `terraform-providers.tencentcloud: 1.78.11 → 1.78.12`                                   |
| [`7b90772d`](https://github.com/NixOS/nixpkgs/commit/7b90772d1328da5b3dbb70e51225bc1bdccea137) | `terraform-providers.snowflake: 0.51.0 → 0.52.0`                                        |
| [`b70c4433`](https://github.com/NixOS/nixpkgs/commit/b70c44331bead2d1071b05058941c6b2b85924d9) | `terraform-providers.selectel: 3.8.5 → 3.9.0`                                           |
| [`4353672e`](https://github.com/NixOS/nixpkgs/commit/4353672e75286109bc2e8db026059b4b989d6678) | `terraform-providers.opennebula: 1.0.1 → 1.0.2`                                         |
| [`0ef22f55`](https://github.com/NixOS/nixpkgs/commit/0ef22f55eb90ae1e38bb23b52b889cd99daea027) | `terraform-providers.null: 3.2.0 → 3.2.1`                                               |
| [`88e8f180`](https://github.com/NixOS/nixpkgs/commit/88e8f180a474de001ef0ee5ee50f23479567c610) | `terraform-providers.mongodbatlas: 1.5.0 → 1.6.0`                                       |
| [`81e91041`](https://github.com/NixOS/nixpkgs/commit/81e91041a10269837f172308704465196d741bd9) | `terraform-providers.aws: 4.39.0 → 4.40.0`                                              |
| [`2c091502`](https://github.com/NixOS/nixpkgs/commit/2c091502a80047fb28985e3a87bc315831bc2310) | `terraform-providers.minio: 1.9.0 → 1.9.1`                                              |
| [`d045c23a`](https://github.com/NixOS/nixpkgs/commit/d045c23ae097ab109d48fedef22fcf8e22d36a29) | `terraform-providers.exoscale: 0.41.0 → 0.41.1`                                         |
| [`9276a552`](https://github.com/NixOS/nixpkgs/commit/9276a552387c55a96ba365cf7210913d51d7a089) | `terraform-providers.bitbucket: 2.21.4 → 2.22.0`                                        |
| [`1d119562`](https://github.com/NixOS/nixpkgs/commit/1d1195626d4a0d82fa66002b21a6751f56d93dbe) | `terraform-providers.azurerm: 3.31.0 → 3.32.0`                                          |
| [`b39bb37e`](https://github.com/NixOS/nixpkgs/commit/b39bb37ec2dc650b963e20d052e95402a088aae9) | `blas-reference: 3.10.0 -> 3.11.0`                                                      |
| [`4324d95b`](https://github.com/NixOS/nixpkgs/commit/4324d95bf9a7c596a6e4667d3731a8a109874e99) | `nodejs-19_x: 19.0.1 -> 19.1.0`                                                         |
| [`72ff99d0`](https://github.com/NixOS/nixpkgs/commit/72ff99d064c51ffcce3fd6099c213d5d2be1c532) | `python310Packages.pydata-sphinx-theme: 0.11.0 -> 0.12.0`                               |
| [`1525fc3a`](https://github.com/NixOS/nixpkgs/commit/1525fc3a1f359756d5e4b7d32dcaafc77c791f06) | `python310Packages.sphinxcontrib_httpdomain: 1.8.0 -> 1.8.1`                            |
| [`5d539b62`](https://github.com/NixOS/nixpkgs/commit/5d539b62a2418a8ef823f64146588542dce23ca9) | `python310Packages.huggingface-hub: 0.10.1 -> 0.11.0`                                   |
| [`8f8b6e37`](https://github.com/NixOS/nixpkgs/commit/8f8b6e37db334a6edfdecf2da015493416096b59) | `python310Packages.gspread: 5.6.2 -> 5.7.1`                                             |
| [`03e7eabb`](https://github.com/NixOS/nixpkgs/commit/03e7eabb5868b72d9230172bb487cc2f04d62ead) | `python3Packages.clip: init at unstable-2022-11-17`                                     |
| [`ef5ded20`](https://github.com/NixOS/nixpkgs/commit/ef5ded2009ab41c9aa828f941ec42912a66fa216) | `python3Packages.termgraph: init at 0.5.3`                                              |
| [`e7f13761`](https://github.com/NixOS/nixpkgs/commit/e7f13761d4ffb27f0e3f95d159f75ae6d8a96e69) | `fnm: 1.31.1 -> 1.32.0`                                                                 |
| [`89763f5d`](https://github.com/NixOS/nixpkgs/commit/89763f5da8da39d85a110124cb0570483fdf205e) | `ytt: 0.43.0 -> 0.44.0`                                                                 |
| [`4a731bc8`](https://github.com/NixOS/nixpkgs/commit/4a731bc888a8c41ceeeb8c56cab3723d5f4432fa) | `maintainers: add maxux`                                                                |
| [`c3e81d96`](https://github.com/NixOS/nixpkgs/commit/c3e81d966284e61f4b327c56fb051c0ca417672b) | `sentry-cli: 2.8.1 -> 2.9.0`                                                            |
| [`e27b8127`](https://github.com/NixOS/nixpkgs/commit/e27b8127dd1dd30b390e206883e87e41839e0678) | `ruplacer: 0.8.0 -> 0.8.1`                                                              |
| [`13b6f07b`](https://github.com/NixOS/nixpkgs/commit/13b6f07b87bd2b3117cd965c3372049ef2e50a01) | `esbuild: 0.15.13 -> 0.15.14`                                                           |
| [`4be4e691`](https://github.com/NixOS/nixpkgs/commit/4be4e691e2b27a0f57313a2ec4c071ffaf0459ea) | `sccache: 0.3.0 -> 0.3.1`                                                               |
| [`f3465641`](https://github.com/NixOS/nixpkgs/commit/f34656418c2208c5aebc7e2e3693883f6410d5d1) | `cargo-make: 0.36.2 -> 0.36.3`                                                          |
| [`dfa38332`](https://github.com/NixOS/nixpkgs/commit/dfa3833276f2de2b58042b79beb0398bdd0aab96) | `cargo-release: 0.23.0 -> 0.23.1`                                                       |
| [`c3f650c3`](https://github.com/NixOS/nixpkgs/commit/c3f650c367b6a1311164e61f9fb5a355f0be63ca) | `google-fonts: add font selection parameter (#201556)`                                  |
| [`4bd2de6e`](https://github.com/NixOS/nixpkgs/commit/4bd2de6ec4d3ee5a13e214e63393d985900a6371) | `python310Packages.hahomematic: 2022.11.1 -> 2022.11.2`                                 |
| [`8819f633`](https://github.com/NixOS/nixpkgs/commit/8819f6338b662593674849998db2a85b13b80801) | `open-stage-control: 1.18.3 -> 1.20.0`                                                  |
| [`b491cf37`](https://github.com/NixOS/nixpkgs/commit/b491cf37844f86e3eab570aa38948f645e1a6788) | `eksctl: 0.118.0 -> 0.119.0`                                                            |
| [`32292827`](https://github.com/NixOS/nixpkgs/commit/322928278ac0d8ec72c2de139d9d093cf74a4791) | `deno: 1.28.0 -> 1.28.1`                                                                |
| [`57c6bb1b`](https://github.com/NixOS/nixpkgs/commit/57c6bb1b89c4be06e5f97d1711707e330e28d97c) | `ruff: 0.0.125 -> 0.0.126`                                                              |
| [`fd2e3968`](https://github.com/NixOS/nixpkgs/commit/fd2e3968aeff866f408abe37d40a29de6f274848) | `crowdin-cli: 3.9.0 -> 3.9.1`                                                           |
| [`b94d3579`](https://github.com/NixOS/nixpkgs/commit/b94d3579aeb1669beb937271b58cbe7da4eb33b8) | `rclone: 1.60.0 -> 1.60.1`                                                              |
| [`4ddf92d8`](https://github.com/NixOS/nixpkgs/commit/4ddf92d84519d7a327ab2280649e42aa4eebdc1a) | `cilium-cli: 0.12.6 -> 0.12.7`                                                          |
| [`29bafee1`](https://github.com/NixOS/nixpkgs/commit/29bafee188ca9ba4ea9a9482dd72bac7a2065f10) | `checkip: 0.42.1 -> 0.43.0`                                                             |
| [`48c69a13`](https://github.com/NixOS/nixpkgs/commit/48c69a13e87f96c5aeddedea23e7e34554460405) | `cariddi: 1.1.9 -> 1.2.1`                                                               |
| [`f423b345`](https://github.com/NixOS/nixpkgs/commit/f423b34570a098644ce0c876e27e4a7d04985c3e) | `brev-cli: 0.6.176 -> 0.6.179`                                                          |
| [`6ee815dc`](https://github.com/NixOS/nixpkgs/commit/6ee815dcfeedcb1082bc87749d1cbfc772f4461d) | `terraform: 1.3.4 -> 1.3.5`                                                             |
| [`85259e37`](https://github.com/NixOS/nixpkgs/commit/85259e37d8fa8b9f1c3b3086bf125d7b79068ad3) | `hugo: 0.105.0 -> 0.106.0`                                                              |
| [`23f765df`](https://github.com/NixOS/nixpkgs/commit/23f765df131eb2bff9cdb89c34ad4c9282e4501d) | `elixir-ls: 0.11.0 -> 0.12.0`                                                           |
| [`af447367`](https://github.com/NixOS/nixpkgs/commit/af447367ec02414cf16ef95054545a7854b34f00) | `nixos/mastodon: Add turion as maintainer`                                              |
| [`d35c9e04`](https://github.com/NixOS/nixpkgs/commit/d35c9e04e67e8c8c22f0a212cba8066b7cd79352) | `mastodon: 3.5.3 -> 4.0.2`                                                              |
| [`77187201`](https://github.com/NixOS/nixpkgs/commit/7718720149735af0e9ed8b770c2aaf67dfc64fc3) | `nixos/mastodon: increase RAM for NixOS test vm`                                        |
| [`bcb09940`](https://github.com/NixOS/nixpkgs/commit/bcb099400699ed76c655c0755ba36ef2f6ed4e8c) | `librewolf: drop upstreamed patch`                                                      |
| [`0df2046f`](https://github.com/NixOS/nixpkgs/commit/0df2046fc06aba0b54bcd54305cf5dd9fafbbbd2) | `anytype: 0.29.0 -> 0.29.1`                                                             |
| [`6b5448d7`](https://github.com/NixOS/nixpkgs/commit/6b5448d7e7a23e8da3ecc0952e03ba42d6c625e1) | `tabnine: 4.4.139 -> 4.4.169`                                                           |
| [`aa9bbf6f`](https://github.com/NixOS/nixpkgs/commit/aa9bbf6fcff564f8de811286fac174e19026d042) | `pkgsStatic.procps: disable systemd support on static build`                            |
| [`4c233af4`](https://github.com/NixOS/nixpkgs/commit/4c233af423f85f7e3ae72ea3ab14b84ff11152ac) | `lokinet: 0.9.9 -> 0.9.10`                                                              |
| [`6aa94133`](https://github.com/NixOS/nixpkgs/commit/6aa9413328297c0b283a856025201e3a3c65fd6f) | `liquidctl: 1.10.0 -> 1.11.1`                                                           |
| [`1184ce89`](https://github.com/NixOS/nixpkgs/commit/1184ce89cecd0323cef0fc5708b16221a37b9217) | `vimPlugins.nvim-treesitter: update grammars`                                           |
| [`b76f72a4`](https://github.com/NixOS/nixpkgs/commit/b76f72a467e30928a7ade5955d463f36874173f2) | `vimPlugins.nvim-dap-go: init at 2022-11-04`                                            |
| [`935a3b86`](https://github.com/NixOS/nixpkgs/commit/935a3b86986e6aa9ecc8c0692bb796f1f7f9a1e5) | `vimPlugins: update`                                                                    |
| [`bae8a2c9`](https://github.com/NixOS/nixpkgs/commit/bae8a2c9f20485f78c92d330dc00dd6241b8b39c) | `ruff: 0.0.122 -> 0.0.125`                                                              |
| [`f5148df5`](https://github.com/NixOS/nixpkgs/commit/f5148df5a65b3d7f00f196c8da7d06a0c486b65d) | `taxi: add tests and remove application/backends`                                       |
| [`66c7c0b1`](https://github.com/NixOS/nixpkgs/commit/66c7c0b178eeb65bc68f3008d4640515780cb67d) | `onefetch: fix build on darwin`                                                         |
| [`b0c6f4ae`](https://github.com/NixOS/nixpkgs/commit/b0c6f4ae0537804b24fdd1b9580d7eb1e7ff6a83) | `nixos/mullvad-vpn: add mullvad-exclude wrapper & systemPackage`                        |
| [`8a4a8302`](https://github.com/NixOS/nixpkgs/commit/8a4a83024212f0e91cb2564f759b419a18040fdd) | `cargo-public-api: 0.22.0 -> 0.23.0`                                                    |
| [`a5bd3325`](https://github.com/NixOS/nixpkgs/commit/a5bd33250a65331bf74e98fdf62c76904434a914) | `bundletool: 1.13.0 -> 1.13.1`                                                          |
| [`9a89d0de`](https://github.com/NixOS/nixpkgs/commit/9a89d0dea0108fd9dd609e0b0bdd25fcfc2e912f) | `vulkan-utils: remove empty package`                                                    |
| [`631baf26`](https://github.com/NixOS/nixpkgs/commit/631baf26e9b964464bde2c0c7403bb48f9ce6f1e) | `hw-probe: vulkan-utils -> vulkan-tools to fix incorrect dependency`                    |
| [`2fcba75c`](https://github.com/NixOS/nixpkgs/commit/2fcba75c19b9bae8f99b9d9eca43243571a8bf33) | `onefetch: install shell completions`                                                   |
| [`39185677`](https://github.com/NixOS/nixpkgs/commit/3918567776379a38cb883daf88244eb72a305743) | `gbinder-python: 1.0.0 -> 1.1.1 (#200878)`                                              |
| [`9edba069`](https://github.com/NixOS/nixpkgs/commit/9edba069adac709b3407221fcc28f6afe92c8317) | `vscodium: 1.73.0.22306 -> 1.73.1.22314`                                                |
| [`c0d9e956`](https://github.com/NixOS/nixpkgs/commit/c0d9e956e60af8c9d1387b443bd694c15f7c156c) | `ckan: 1.31.0 -> 1.31.2`                                                                |
| [`aea5f56b`](https://github.com/NixOS/nixpkgs/commit/aea5f56b83881a9094b21cbd61c33dd4e00fee63) | `ascii-image-converter: 1.12.0 -> 1.13.0`                                               |
| [`4510157b`](https://github.com/NixOS/nixpkgs/commit/4510157b4cc9b1558868b831ff2f839afe1503b0) | `tagger: 2022.10.6 -> 2022.11.1-f1`                                                     |
| [`cbbb6463`](https://github.com/NixOS/nixpkgs/commit/cbbb646333299bd5f2f6b91f3e47b759617452ca) | `python310Packages.azure-mgmt-storage: 20.1.0 -> 21.0.0`                                |
| [`4fbb0244`](https://github.com/NixOS/nixpkgs/commit/4fbb0244d282a20d1903778e2162b97d3f873fa9) | `peertube: 4.3.0 -> 4.3.1`                                                              |
| [`c156bdf4`](https://github.com/NixOS/nixpkgs/commit/c156bdf40d2f0e64b574ade52c5611d90a0b6273) | `firefox, thunderbird, librewolf: Enable wayland support by default`                    |
| [`a4aa5b7f`](https://github.com/NixOS/nixpkgs/commit/a4aa5b7fe7a0fd05594541e1d7813f39c74e9079) | `python310Packages.arviz: 0.13.0 -> 0.14.0`                                             |
| [`979532e8`](https://github.com/NixOS/nixpkgs/commit/979532e81ba0c25a89976a8d8e048ba118e4f070) | `python310Packages.aiohomekit: 2.2.19 -> 2.3.0`                                         |
| [`54be84c3`](https://github.com/NixOS/nixpkgs/commit/54be84c3ac0122c2b2272fc68a9015304bc0bb73) | `pass2csv: 0.3.2 -> 1.0.0`                                                              |
| [`0b3c49e5`](https://github.com/NixOS/nixpkgs/commit/0b3c49e57a26a9cdfa492c1ca5545373987b0ade) | `lisgd: 0.3.5 -> 0.3.6`                                                                 |
| [`c981c2a4`](https://github.com/NixOS/nixpkgs/commit/c981c2a4c1b4e977aa5f6313694b79bcf132531d) | `wabt: 1.0.30 -> 1.0.31`                                                                |
| [`396ba2dd`](https://github.com/NixOS/nixpkgs/commit/396ba2dd17956d991bd0eb97f91e7f0a234401ff) | `rootlesskit: 1.0.1 -> 1.1.0`                                                           |
| [`ebf34bdb`](https://github.com/NixOS/nixpkgs/commit/ebf34bdb533f61cfd364a3082e5913a5e094204a) | `terraform-providers.vault: 3.10.0 → 3.11.0`                                            |
| [`edfd1a3a`](https://github.com/NixOS/nixpkgs/commit/edfd1a3af100ac8fd531ed6c7fb758fd6947e61a) | `terraform-providers.oci: 4.99.0 → 4.100.0`                                             |
| [`21e97bb3`](https://github.com/NixOS/nixpkgs/commit/21e97bb3dc38df96382757a4005cbcdd8ef534a7) | `terraform-providers.opentelekomcloud: 1.31.7 → 1.31.8`                                 |
| [`4412d8b2`](https://github.com/NixOS/nixpkgs/commit/4412d8b2b569d8948fa8255fc9c2d109fda3e729) | `terraform-providers.google-beta: 4.43.0 → 4.43.1`                                      |
| [`61c0b1fb`](https://github.com/NixOS/nixpkgs/commit/61c0b1fb68214fe83d9f815b97039d7d6ae105e2) | `terraform-providers.google: 4.43.0 → 4.43.1`                                           |
| [`0cf52fa9`](https://github.com/NixOS/nixpkgs/commit/0cf52fa9fff50be20d294ff39a2beef8fb4a4330) | `terraform-providers.fastly: 2.4.0 → 3.0.0`                                             |
| [`9f8fd12a`](https://github.com/NixOS/nixpkgs/commit/9f8fd12a1c093d8a2a0e1011e095a0362b6d6aa9) | `terraform-providers.digitalocean: 2.23.0 → 2.24.0`                                     |
| [`bbbf3c45`](https://github.com/NixOS/nixpkgs/commit/bbbf3c45d5a8350f28f35e5234ebdecfa44d7ec1) | `sumneko-lua-language-server: 3.6.2 -> 3.6.3`                                           |
| [`8d3254af`](https://github.com/NixOS/nixpkgs/commit/8d3254afaf432a3d9861e90cebdbd049699270e6) | `ssh-to-age: 1.0.2 -> 1.0.3`                                                            |
| [`14f30827`](https://github.com/NixOS/nixpkgs/commit/14f30827a0b5adff297e8bfda6c42c9a25eb9b96) | `sn0int: 0.24.2 -> 0.24.3`                                                              |
| [`3a86856a`](https://github.com/NixOS/nixpkgs/commit/3a86856a13c88c8c64ea32082a851fefc79aa700) | `gh-dash: 3.4.2 -> 3.5.1`                                                               |
| [`c089e2b9`](https://github.com/NixOS/nixpkgs/commit/c089e2b91735c3ef073f0909e240289cccc1e488) | `melt: 0.4.1 -> 0.5.0`                                                                  |
| [`e26059fb`](https://github.com/NixOS/nixpkgs/commit/e26059fb71886b42d92591a431e4c2afacf9ae7a) | `brev-cli: 0.6.170 -> 0.6.176`                                                          |
| [`62fcb867`](https://github.com/NixOS/nixpkgs/commit/62fcb86736ae64958a866dfe09ecbe860445ec3c) | `datree: 1.7.3 -> 1.8.0`                                                                |
| [`b9d8e648`](https://github.com/NixOS/nixpkgs/commit/b9d8e64847e41fe7c73f027d56846eaa03a03307) | `goeland: 0.11.0 -> 0.12.1`                                                             |
| [`3ac91d27`](https://github.com/NixOS/nixpkgs/commit/3ac91d2719a982c9a92d01e55b36250ba06542d2) | `libplctag: 2.5.3 -> 2.5.4`                                                             |
| [`7b70b812`](https://github.com/NixOS/nixpkgs/commit/7b70b8122483ab7f30cd0ec35c586e693bbfb30a) | `ferium: 4.2.1 -> 4.2.2`                                                                |
| [`47a678b5`](https://github.com/NixOS/nixpkgs/commit/47a678b594dff84761b08558d73d87dcfa4b52aa) | `redli: 0.6.0 -> 0.7.0`                                                                 |
| [`a0cea97e`](https://github.com/NixOS/nixpkgs/commit/a0cea97ebe27ab1c8f6ee159c2fffa67cae4b0cd) | `netbird: 0.10.7 -> 0.10.8`                                                             |
| [`bd713dae`](https://github.com/NixOS/nixpkgs/commit/bd713daea62313358aa2c8cddd2f354fd98e1f82) | `oxker: 0.1.6 -> 0.1.7`                                                                 |
| [`f209de7e`](https://github.com/NixOS/nixpkgs/commit/f209de7ef2e4c205eb3c2c24fafb678ac2bcc6e6) | `operator-sdk: 1.25.1 -> 1.25.2`                                                        |
| [`c3571072`](https://github.com/NixOS/nixpkgs/commit/c35710721b2923689d82baa8ac1c538bc1fdfbc9) | `cava: 0.8.2 -> 0.8.3`                                                                  |
| [`02210afe`](https://github.com/NixOS/nixpkgs/commit/02210afe4faa6f921a02620fe3247402c07a7aeb) | `imgui: 1.88 -> 1.89`                                                                   |
| [`e216dbeb`](https://github.com/NixOS/nixpkgs/commit/e216dbebfdd8d193a402e3efd5316d19722471b5) | `radioboat: 0.2.2 -> 0.2.3`                                                             |
| [`5f4cfa67`](https://github.com/NixOS/nixpkgs/commit/5f4cfa67e6f7e92d8acddeebd8f56d1098ffa81e) | `ipcalc: add patch to disable tests failing in Darwin sandbox`                          |
| [`47709a98`](https://github.com/NixOS/nixpkgs/commit/47709a986a4630fa8580db245c33a66aa7d60eb3) | `psst: unstable-2022-05-19 -> 2022-10-13`                                               |
| [`87d5df13`](https://github.com/NixOS/nixpkgs/commit/87d5df13d7380f793dcc6ca35698d7bf944bf508) | `home-assistant: 2022.11.2 -> 2022.11.3`                                                |
| [`29b5192b`](https://github.com/NixOS/nixpkgs/commit/29b5192b08744a6ff52484950384dd206368bc2e) | `automatic-timezoned: init at 1.0.41`                                                   |
| [`f2b994a3`](https://github.com/NixOS/nixpkgs/commit/f2b994a384c1161a14947f36fe15e485226767e1) | `chromiumBeta: 108.0.5359.40 -> 108.0.5359.48`                                          |
| [`1d6f6c0e`](https://github.com/NixOS/nixpkgs/commit/1d6f6c0ec656835191a2970b360fb3558c522f76) | `buildah: refactor wrapper`                                                             |
| [`a0c079f6`](https://github.com/NixOS/nixpkgs/commit/a0c079f6521934632ec023a9f1a72855c452ea19) | `podman: refactor wrapper`                                                              |
| [`684ffc10`](https://github.com/NixOS/nixpkgs/commit/684ffc109ebf4f611cc2b91a37a39541eff4c166) | `cri-o: refactor wrapper`                                                               |
| [`4dabd9c3`](https://github.com/NixOS/nixpkgs/commit/4dabd9c39b217ed2798ca9780ce27afd5bf738e3) | `linux: 6.0.8 -> 6.0.9`                                                                 |
| [`63adc7fa`](https://github.com/NixOS/nixpkgs/commit/63adc7fafe7dfbfdc96754ebe65bdb6cf3a65ec8) | `linux: 5.15.78 -> 5.15.79`                                                             |
| [`bd9a5606`](https://github.com/NixOS/nixpkgs/commit/bd9a5606b4773948e699b6fe98622dfe69a2a7b1) | `linux: 5.10.154 -> 5.10.155`                                                           |
| [`efeb5c43`](https://github.com/NixOS/nixpkgs/commit/efeb5c4363b2bc497fe937a52b83521b1f161997) | `python3Packages.pyswitchbot: 0.20.4 -> 0.20.5`                                         |
| [`667767d4`](https://github.com/NixOS/nixpkgs/commit/667767d439515f62bb1c45cb6abc281095c6a98f) | `samba4: 4.17.2 -> 4.17.3`                                                              |
| [`3875db56`](https://github.com/NixOS/nixpkgs/commit/3875db56f6d2f03b318a74f2fd3cdea3e41a2c4e) | `python310Packages.bleak-retry-connector: 2.8.3 -> 2.8.4`                               |
| [`185a04dc`](https://github.com/NixOS/nixpkgs/commit/185a04dc3e5d97b1278383e610194d3a993b4b67) | `vimPlugins.nvim-treesitter: add plugins to dependencies to avoid extending vimPlugins` |
| [`eb8b2d71`](https://github.com/NixOS/nixpkgs/commit/eb8b2d71428eb6ad5c7b9a56fe28b01ce434894c) | `nixos/docs: document picom module changes`                                             |
| [`6785dae7`](https://github.com/NixOS/nixpkgs/commit/6785dae7483bfd5ef3596ddee74726fa541cb850) | `nixos/picom: remove experimentalBackends option`                                       |
| [`a29510ba`](https://github.com/NixOS/nixpkgs/commit/a29510ba1a8d4f347d6ebabe850626a61fade2ea) | `duckdb: 0.5.1 -> 0.6.0`                                                                |
| [`2fcfc5f3`](https://github.com/NixOS/nixpkgs/commit/2fcfc5f3c136467d4154399cd7af500e702b5d06) | `picom: 9.1 -> 10`                                                                      |
| [`80e1bfb0`](https://github.com/NixOS/nixpkgs/commit/80e1bfb0347f04b14d8f0c28e4f1dad66d8b7e9c) | `zfp: 0.5.5 -> 1.0.0, fix issues`                                                       |
| [`5df86d63`](https://github.com/NixOS/nixpkgs/commit/5df86d63053f0c95d06693dcbdbe27b64131a72a) | `vscode-extensions.bmalehorn.vscode-fish: init at 1.0.31`                               |
| [`7cef955f`](https://github.com/NixOS/nixpkgs/commit/7cef955fab4c08130d36634e7e2e89bdecddad62) | `vscode-extensions.thenuprojectcontributors.vscode-nushell-lang: init at 0.7.0`         |
| [`7eac2c13`](https://github.com/NixOS/nixpkgs/commit/7eac2c13e6f1a3a9efe7606c7c90029f2cef48e8) | `python310Packages.git-annex-adapter: fix tests`                                        |
| [`a8d318b5`](https://github.com/NixOS/nixpkgs/commit/a8d318b5728fbb038bc097688b9140874c3f60cd) | `vscode-extensions.matangover.mypy: init at 0.2.2`                                      |
| [`7cb62293`](https://github.com/NixOS/nixpkgs/commit/7cb6229334cecda7592a6df2a23a2d19549044f1) | `python310Packages.graphviz: 0.20 -> 0.20.1`                                            |
| [`6995b471`](https://github.com/NixOS/nixpkgs/commit/6995b471b4a212028ea32e7f2bddef0e6c6b846f) | `python310Packages.huawei-lte-api: 1.6.6 -> 1.6.7`                                      |
| [`646ca73d`](https://github.com/NixOS/nixpkgs/commit/646ca73d81e28b421fba64d97a7b8998906ea6d6) | `python310Packages.aprslib: 0.7.1 -> 0.7.2`                                             |
| [`8db07f35`](https://github.com/NixOS/nixpkgs/commit/8db07f3546873e36d70eb1d1ed2df4396620505e) | `exploitdb: 2022-10-18 -> 2022-11-12`                                                   |
| [`8a1e1572`](https://github.com/NixOS/nixpkgs/commit/8a1e1572089b254583a9b5e5fcb80ce7f7e13bf0) | `exempi: remove gcc6Stdenv override on i686`                                            |
| [`216e161b`](https://github.com/NixOS/nixpkgs/commit/216e161b69cf9909b1e263dc8694ca7e20898a93) | `meilisearch: 0.29.1 -> 0.29.2`                                                         |
| [`b88a8ae8`](https://github.com/NixOS/nixpkgs/commit/b88a8ae8eaf89f264f640b230b36e99ed3dd6944) | `libdeltachat: 1.100.0 -> 1.101.0`                                                      |
| [`f0a73a2a`](https://github.com/NixOS/nixpkgs/commit/f0a73a2a02a5402168f00e797222a1bb9068ba5d) | `python310Packages.keyring: 23.9.3 -> 23.11.0`                                          |
| [`b60a96d0`](https://github.com/NixOS/nixpkgs/commit/b60a96d063dcd4d229c0891b4aef99374a4952b5) | `clojure: 1.11.1.1189 -> 1.11.1.1200`                                                   |
| [`432467df`](https://github.com/NixOS/nixpkgs/commit/432467df113250aa9fa77653c1607c7e527d2199) | `python310Packages.check-manifest: fix tests`                                           |
| [`dcfe88be`](https://github.com/NixOS/nixpkgs/commit/dcfe88be5c7e5552d26bb6468fe6ba8f81d98c4e) | `oh-my-posh: 12.13.0 -> 12.13.3`                                                        |
| [`529ced40`](https://github.com/NixOS/nixpkgs/commit/529ced40735a80499cd12e33b8f9d3a80a95a7a4) | `odpic: 4.5.0 -> 4.6.0`                                                                 |
| [`c0b9fec0`](https://github.com/NixOS/nixpkgs/commit/c0b9fec0d750530c30616190fd6a0648a5c126f1) | `mastodon-archive: 1.3.1 -> 1.4.2`                                                      |
| [`6c4166cc`](https://github.com/NixOS/nixpkgs/commit/6c4166ccb9a468b5423859110a9a0aa29840fcab) | `python3Packages.latexify-py: init at 0.2.0`                                            |
| [`3313844e`](https://github.com/NixOS/nixpkgs/commit/3313844e4e30b9542cee8e35ececa8bd54d946bd) | `adw-gtk3: 4.0 -> 4.1`                                                                  |
| [`0e332ecb`](https://github.com/NixOS/nixpkgs/commit/0e332ecb95b7e82a1796d534fe501a3288ea28de) | `meerk40t: 0.8.0031 -> 0.8.1000`                                                        |
| [`a110f08f`](https://github.com/NixOS/nixpkgs/commit/a110f08f12eb10a25e1e0c7545c13e1246d0da25) | `ocamlPackages.extlib: rename from ocaml_extlib`                                        |
| [`a834cc84`](https://github.com/NixOS/nixpkgs/commit/a834cc840fddf422d8b8ba6c2b06726cdacf2eec) | `ocamlPackages.ocaml_extlib: 1.7.8 -> 1.7.9`                                            |