### PR TITLE
chore(flake/home-manager): `bc90de24` -> `fe85cc4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668332334,
-        "narHash": "sha256-YT1qcE/MCqBO1Bi/Yr6GcFpNKsvmzrBKh8juyXDbxQc=",
+        "lastModified": 1668716823,
+        "narHash": "sha256-e6d2SIIiJOvTzItUbp+GJVhPD6AzSm823XAyPvPlpvo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bc90de24d898655542589237cc0a6ada7564cb6c",
+        "rev": "fe85cc4c37d5f37104e349c5553029417e3833d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`fe85cc4c`](https://github.com/nix-community/home-manager/commit/fe85cc4c37d5f37104e349c5553029417e3833d1) | `udiskie: add note about needing to enable system-wide config (#3424)` |