### PR TITLE
chore(flake/pre-commit-hooks): `ebcbfe09` -> `364568e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1667992213,
-        "narHash": "sha256-8Ens8ozllvlaFMCZBxg6S7oUyynYx2v7yleC5M0jJsE=",
+        "lastModified": 1668880995,
+        "narHash": "sha256-1pohNJx6MIVeYpXmsugZG3fUKPSIKpQouttWFVfqsNU=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ebcbfe09d2bd6d15f68de3a0ebb1e4dcb5cd324b",
+        "rev": "364568e63556045ea9d08d29fafa46febbdb015b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                  |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------- |
| [`364568e6`](https://github.com/cachix/pre-commit-hooks.nix/commit/364568e63556045ea9d08d29fafa46febbdb015b) | `deadnix: fix broken reference` |