### PR TITLE
chore(flake/pre-commit-hooks): `f66b4ab9` -> `0c9555d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668887252,
-        "narHash": "sha256-3JgsogMPEf5lQPMMmYb4ZNsbUHNlgIxSQmF7Dew6Wek=",
+        "lastModified": 1668960094,
+        "narHash": "sha256-RwSw+hh4Vacceh57gSaquzUoDmBu+ey6rjR+mZ8vsIg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "f66b4ab9c9d831c6302a2afd61df0931fb60499b",
+        "rev": "0c9555d4e0943fec80a9087b8d3855a49533f399",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                         |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
| [`a6fc3ff2`](https://github.com/cachix/pre-commit-hooks.nix/commit/a6fc3ff2b74ef98f86202c53b170995d05857842) | `skip installation if there's no .git` |