### PR TITLE
chore(flake/nixpkgs): `52b2ac8a` -> `690ffff0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668765800,
-        "narHash": "sha256-rC40+/W6Hio7b/RsY8SvQPKNx4WqNcTgfYv8cUMAvJk=",
+        "lastModified": 1668905981,
+        "narHash": "sha256-RBQa/+9Uk1eFTqIOXBSBezlEbA3v5OkgP+qptQs1OxY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "52b2ac8ae18bbad4374ff0dd5aeee0fdf1aea739",
+        "rev": "690ffff026b4e635b46f69002c0f4e81c65dfc2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`3616fab0`](https://github.com/NixOS/nixpkgs/commit/3616fab0172586f6474557c69a601089e9ab035e) | `python310Packages.django-taggit: fix lint issue`                         |
| [`5608b9be`](https://github.com/NixOS/nixpkgs/commit/5608b9beb97165ff5ea15535c63e5af1989c4d71) | `python3Packages.troposphere: init at 4.1.0`                              |
| [`115139ed`](https://github.com/NixOS/nixpkgs/commit/115139edd3bee7961ca0a13cf29181a5fea29d35) | `python3Packages.awacs: init at 2.2.0`                                    |
| [`e5cf903f`](https://github.com/NixOS/nixpkgs/commit/e5cf903f02f76289e217e48ae55d6622f9384a25) | `python310Packages.django-taggit: add changelog to meta`                  |
| [`4fe9988b`](https://github.com/NixOS/nixpkgs/commit/4fe9988b89eb9753543717ab0a460acff7043b05) | `installation-cd: Remove libsForQt5.full`                                 |
| [`82ee8249`](https://github.com/NixOS/nixpkgs/commit/82ee824968003f2a440cb5cc319906fdafe2a4c9) | `surrealdb: module init`                                                  |
| [`4a620712`](https://github.com/NixOS/nixpkgs/commit/4a620712e2ad532467df6832531bf391d563cf66) | `python310Packages.bthome-ble: 2.2.1 -> 2.3.1`                            |
| [`f8fed401`](https://github.com/NixOS/nixpkgs/commit/f8fed401986a67cd56a6ef314eae8df007c88b85) | `python310Packages.bthome-ble: add changelog to meta`                     |
| [`645456c2`](https://github.com/NixOS/nixpkgs/commit/645456c2d523b0eeaf5f21de4b36f83b3ad18fd7) | `ncdu: 2.1.2 -> 2.2.1`                                                    |
| [`ecbaaf10`](https://github.com/NixOS/nixpkgs/commit/ecbaaf10b8b614d28d5a6aedbf6fe172c2d9b946) | `python310Packages.mastodon-py: 1.6.1 -> 1.6.3`                           |
| [`65feea29`](https://github.com/NixOS/nixpkgs/commit/65feea294ffe5269c9de2b70ff2db909e4490fdc) | `python310Packages.fakeredis: 1.10.1 -> 2.0.0`                            |
| [`d24d8b71`](https://github.com/NixOS/nixpkgs/commit/d24d8b71d23796f9921530127efb17c673e0b46b) | `qimgv: drop unused patch`                                                |
| [`ee82feef`](https://github.com/NixOS/nixpkgs/commit/ee82feef516c4d60706da0c83997e74d85f20c07) | `qimgv: 1.0.2 -> 1.0.3-alpha`                                             |
| [`d8508f38`](https://github.com/NixOS/nixpkgs/commit/d8508f380f6387e40a41c63dba50c8548e755a60) | `ocamlPackages.camlidl: 1.05 → 1.11`                                      |
| [`f86d8032`](https://github.com/NixOS/nixpkgs/commit/f86d80320e1fe86e7daa306c521583f972e91151) | `ocamlPackages.mlgmpidl: 1.2.12 → 1.2.15`                                 |
| [`b394f86d`](https://github.com/NixOS/nixpkgs/commit/b394f86dcb1a9d971e58642b19238024e6f0fba0) | `chickenPackages*.eggDerivation: set meta.platforms if not provided`      |
| [`73c0cb7b`](https://github.com/NixOS/nixpkgs/commit/73c0cb7bc3e32ba34ba490c15105c3e384c9bbac) | `gitui: 0.21.0 -> 0.22.0`                                                 |
| [`b02ae769`](https://github.com/NixOS/nixpkgs/commit/b02ae769f4750b1c9714d8c2c7d49d94d6162316) | `python310Packages.django-taggit: 3.0.0 -> 3.1.0`                         |
| [`82147912`](https://github.com/NixOS/nixpkgs/commit/821479126a7415b1f33a1c6489a24570b6f641d4) | `luakit: 2.3 -> 2.3.1`                                                    |
| [`fe7290fc`](https://github.com/NixOS/nixpkgs/commit/fe7290fc4b2c0496dde324ad1929d4b6dcb6468b) | `oh-my-posh: 12.13.3 -> 12.16.0`                                          |
| [`4a3aa6ff`](https://github.com/NixOS/nixpkgs/commit/4a3aa6ff98a08971135819d6ee145a63e1882840) | `tremor-rs: module init`                                                  |
| [`ef945c5e`](https://github.com/NixOS/nixpkgs/commit/ef945c5e88b435cdab34a9cbea7bdedfb92f5fd7) | `sameboy: 0.15.6 -> 0.15.8`                                               |
| [`c0d10e2d`](https://github.com/NixOS/nixpkgs/commit/c0d10e2d1eab91e6258170825b6a0852afb45e11) | `fishPlugins.sponge: init at 1.1.0`                                       |
| [`71a161db`](https://github.com/NixOS/nixpkgs/commit/71a161dbb78f6eef470a63729819c99a68755556) | `maintainers: add quantenzitrone`                                         |
| [`3c98122e`](https://github.com/NixOS/nixpkgs/commit/3c98122ee7d4036a0c2fa885dde63138d6ce8644) | `python310Packages.datasette: 0.63.1 -> 0.63.2`                           |
| [`412144df`](https://github.com/NixOS/nixpkgs/commit/412144dfcc1560f81ec92f144f9e5ebf694e089d) | `metasploit: 6.2.26 -> 6.2.27`                                            |
| [`0d10c31f`](https://github.com/NixOS/nixpkgs/commit/0d10c31f2d8d4d0054d1f32e2bca31ceb642f70f) | `matrix-synapse.tools.rust-synapse-compress-state: Mark broken on darwin` |
| [`2613b5f8`](https://github.com/NixOS/nixpkgs/commit/2613b5f867b5e8945cdb67c0b7eca10f1ea337fb) | `python3Packages.token-bucket: Disable tests on darwin`                   |
| [`56db2b08`](https://github.com/NixOS/nixpkgs/commit/56db2b08aeded6d10548c686f0977f4e9cbd05c4) | `nth: 1.10 -> 1.11.0`                                                     |
| [`b10c95f3`](https://github.com/NixOS/nixpkgs/commit/b10c95f3c4ae83c3ffde49f4ea1aa1763156c415) | `nfpm: 2.22.0 -> 2.22.1`                                                  |
| [`f5110c71`](https://github.com/NixOS/nixpkgs/commit/f5110c71823355b7ec63f4bb171ebf4eba8bf4b9) | `duckstation: remove unneeded rec`                                        |
| [`77393e80`](https://github.com/NixOS/nixpkgs/commit/77393e800b3535158d43d63d79e7a22432f1db98) | `nearcore: 1.29.0 -> 1.29.1`                                              |
| [`e78d5f64`](https://github.com/NixOS/nixpkgs/commit/e78d5f642619e660c54d30f5548a71b18b3ee5d0) | `ghidra: 10.2.1 -> 10.2.2`                                                |
| [`764195c6`](https://github.com/NixOS/nixpkgs/commit/764195c60f0e022af767f82143706ab3152e7ef7) | `bob: 0.6.3 -> 0.7.0`                                                     |
| [`b967e328`](https://github.com/NixOS/nixpkgs/commit/b967e3289a71ce831d8cd6d9ee5dfb99ceb6e9fe) | `kubemq-community: 2.3.4 -> 2.3.5`                                        |
| [`6957c607`](https://github.com/NixOS/nixpkgs/commit/6957c60714625794fa0ca8e3ba80738944807b48) | `basiliskii: fix build on aarch64-linux`                                  |
| [`6f4ec004`](https://github.com/NixOS/nixpkgs/commit/6f4ec004f74d09653968e3807a5fdd66a3645b69) | `python310Packages.ssdeep: 3.4 -> 3.4.1`                                  |
| [`3ecd3175`](https://github.com/NixOS/nixpkgs/commit/3ecd3175456abeade5c73b5eb9ac618efa4c32b1) | `sile: 0.14.4 → 0.14.5`                                                   |
| [`32d0e073`](https://github.com/NixOS/nixpkgs/commit/32d0e073ff7f45ed8b9045ff343dd82b11c63e03) | `python310Packages.ssdeep: add changelog to meta`                         |
| [`80a96e18`](https://github.com/NixOS/nixpkgs/commit/80a96e18c6cce88ab00d3fb1c66fc0e18a49aa6a) | `python310Packages.pysma: 0.7.2 -> 0.7.3`                                 |
| [`7bce1df2`](https://github.com/NixOS/nixpkgs/commit/7bce1df2fc4ed0f2a37a28958415ef753eff00f9) | `python310Packages.dbus-fast: update ordering`                            |
| [`c3f9bd94`](https://github.com/NixOS/nixpkgs/commit/c3f9bd947228fab3ac0d87a431f8dadb492bee02) | `go-neb: Mark broken on darwin`                                           |
| [`17694846`](https://github.com/NixOS/nixpkgs/commit/1769484633a6e7b07fab61a78bf0e9894cea3670) | `photoprism: add valid passthru test`                                     |
| [`78155df2`](https://github.com/NixOS/nixpkgs/commit/78155df21dbdb8bd4c471df69e9352ec3471bf45) | `nixos/users-groups: Warn about deprecated hashes at activation`          |
| [`f391e6db`](https://github.com/NixOS/nixpkgs/commit/f391e6dbccfb8289930a139f2afcfd032c60d89f) | `nixos/user: Don't recommend mkpasswd methods`                            |
| [`55ab131e`](https://github.com/NixOS/nixpkgs/commit/55ab131ee2a1099e7a41a76570365eba72b45159) | `nixos/manual: Don't recommend mkpasswd methods`                          |
| [`a2972fca`](https://github.com/NixOS/nixpkgs/commit/a2972fca8cd5828771ccead2a94a12c6ca6906cd) | `python310Packages.filemagic: remove`                                     |
| [`43f9bceb`](https://github.com/NixOS/nixpkgs/commit/43f9bceb8d71e14800bb44184364955729d97ce1) | `python310Packages.flux-led: 0.28.32 -> 0.28.34`                          |
| [`8a293629`](https://github.com/NixOS/nixpkgs/commit/8a293629709c2e9f7c33f6e3d9a145398a4e2d48) | `python310Packages.flux-led: add changelog to meta`                       |
| [`0e1acfc7`](https://github.com/NixOS/nixpkgs/commit/0e1acfc749f63eb875ead9a67d3d8e5a93ec1556) | `python3Packages.qiskit-terra: mark broken`                               |
| [`bdee2b94`](https://github.com/NixOS/nixpkgs/commit/bdee2b94efd312c0b0ced874b21524c7b71a1443) | `python3Packages.watchdog: Disable failing test on x86_64-darwin`         |
| [`19408d30`](https://github.com/NixOS/nixpkgs/commit/19408d3093668e871e7d533a2480c0172ec56870) | `python3Packages.scikit-learn: disable failing test on darwin`            |
| [`7304cc95`](https://github.com/NixOS/nixpkgs/commit/7304cc95b0aa1815a48240c154c89c66296bc693) | `python310Packages.sentry-sdk: 1.10.1 -> 1.11.0`                          |
| [`50e33fac`](https://github.com/NixOS/nixpkgs/commit/50e33fac9d72a680f00d81cfc9d1c14800ae9618) | `home-assistant: pin aiohttp at 3.8.1`                                    |
| [`030e5d81`](https://github.com/NixOS/nixpkgs/commit/030e5d8153175b6bc8a1eff0ed037d3b2d8b0f06) | `process-compose: init at 0.24.1`                                         |
| [`192f9749`](https://github.com/NixOS/nixpkgs/commit/192f97496feb976ddbaa635fbe80c1c471ec88dc) | `lxd: 5.7 -> 5.8`                                                         |
| [`36931838`](https://github.com/NixOS/nixpkgs/commit/369318383ff288d7623ecbcabf135a0f46c7164a) | `python310Packages.sqlalchemy-jsonfield: add pythonImportsCheck`          |
| [`245f3913`](https://github.com/NixOS/nixpkgs/commit/245f3913e32be3ef9dd62020ed39bd649b576cc4) | `python310Packages.clickhouse-cityhash: disable on older Python releases` |
| [`f08f8825`](https://github.com/NixOS/nixpkgs/commit/f08f8825fb0f688a990aa8bd23b73fa60fa766a7) | `python310Packages.smpplib: pythonImportsCheck`                           |
| [`056796ea`](https://github.com/NixOS/nixpkgs/commit/056796ea9bd879d04d1dcc090d19e93db2519cd1) | `python310Packages.repeated-test: add pythonImportsCheck`                 |
| [`19ec9f1d`](https://github.com/NixOS/nixpkgs/commit/19ec9f1d5f5c07c356abbbf6238c3ed28ee307eb) | `python310Packages.od: add pythonImportsCheck`                            |
| [`7ea97bf4`](https://github.com/NixOS/nixpkgs/commit/7ea97bf4afd8436ab958f7f3fbf32d601fd1f2df) | `python310Packages.sigtools: add pythonImportsCheck`                      |
| [`92ada862`](https://github.com/NixOS/nixpkgs/commit/92ada862b7a1346cb2aa86037e0a5848c7b6c1e9) | `python310Packages.peaqevcore: 7.3.3 -> 7.4.0`                            |
| [`5ea9b453`](https://github.com/NixOS/nixpkgs/commit/5ea9b4531b1499a946d56a01ba15380956ad5315) | `python310Packages.dbus-fast: 1.73.0 -> 1.75.0`                           |
| [`df109d02`](https://github.com/NixOS/nixpkgs/commit/df109d0291d376e8edae58abd524bd219c65c1da) | `go-graft: 0.2.14 -> 0.2.15`                                              |
| [`9971f569`](https://github.com/NixOS/nixpkgs/commit/9971f569a93799dd2dc917d54f7bbf96ec296360) | `goeland: 0.12.1 -> 0.12.3`                                               |
| [`61fc8355`](https://github.com/NixOS/nixpkgs/commit/61fc83558b13329e2d7edbfe79fe0a30f4bd343e) | `python310Packages.django-webpack-loader: add pythonImportsCheck`         |
| [`4bd1aa50`](https://github.com/NixOS/nixpkgs/commit/4bd1aa5006bef573fccde0e1f34e48a02f95d81e) | `python310Packages.serpy: add pythonImportsCheck`                         |
| [`493a0880`](https://github.com/NixOS/nixpkgs/commit/493a08804262a38d5c381b138b37c3703cbd9a15) | `python310Packages.snakebite: add pythonImportsCheck`                     |
| [`29d51a6b`](https://github.com/NixOS/nixpkgs/commit/29d51a6baff3bc52b28cade0fbe60a9bf2d50e1b) | `python3Packages.pypandoc:  add pythonImportsCheck`                       |
| [`3f451c5d`](https://github.com/NixOS/nixpkgs/commit/3f451c5d26aef57c3b84e3e381d76cba0aa90944) | `python3Packages.versioningit: make tomli optional for < 3.11`            |
| [`2209ba9c`](https://github.com/NixOS/nixpkgs/commit/2209ba9ca0ea0f13fd6011ec7baedf2942cbb17a) | `python310Packages.azure-mgmt-security: update disabled`                  |
| [`63649d36`](https://github.com/NixOS/nixpkgs/commit/63649d36868aa017e0e9e48558a6d00d08742909) | `python310Packages.boschshcpy: 0.2.35 -> 0.2.36`                          |
| [`46daf967`](https://github.com/NixOS/nixpkgs/commit/46daf9675f0f79bcf2ccf1a49909b60818a72cf0) | `lefthook: 1.2.0 -> 1.2.1`                                                |
| [`3589f996`](https://github.com/NixOS/nixpkgs/commit/3589f996627f8e8322374da193243e1cf822faa7) | `kubeseal: 0.19.1 -> 0.19.2`                                              |
| [`a04a4bbb`](https://github.com/NixOS/nixpkgs/commit/a04a4bbbeb5476687a5a1444a187c4b2877233ed) | `ocamlPackages.iter: 1.4 → 1.6`                                           |
| [`3d185562`](https://github.com/NixOS/nixpkgs/commit/3d185562b59e0a6cf7559fecf7edb4ef52fa1007) | `nixos/tests/phosh: init`                                                 |
| [`8b2d34fa`](https://github.com/NixOS/nixpkgs/commit/8b2d34fa5eecb1303a3d73679cb6d4c2a43b4442) | `test-driver: Allow configuring delay for send_{key,chars}`               |
| [`1c4a8e04`](https://github.com/NixOS/nixpkgs/commit/1c4a8e049f7198add95f723519678bcf461843bb) | `python310Packages.aioesphomeapi: 11.4.3 -> 11.5.0`                       |
| [`a9d9bc86`](https://github.com/NixOS/nixpkgs/commit/a9d9bc861d5fb80f9bd9b0fe74febe4d2e5a214d) | `python310Packages.aioairzone: 0.4.9 -> 0.5.1`                            |
| [`c4c18661`](https://github.com/NixOS/nixpkgs/commit/c4c1866143ec02016d30eabed22cd6d0de39a10b) | `terraform-providers.tfe: 0.38.0 → 0.39.0`                                |
| [`dd784ef5`](https://github.com/NixOS/nixpkgs/commit/dd784ef5ff6c573674a3b4d3a1e006494f2a3065) | `terraform-providers.kubernetes: 2.15.0 → 2.16.0`                         |
| [`cda9ca91`](https://github.com/NixOS/nixpkgs/commit/cda9ca9176bd61dfe9a2c8053e9c2f001714f79a) | `terraform-providers.github: 5.8.0 → 5.9.0`                               |
| [`fcb5f2c5`](https://github.com/NixOS/nixpkgs/commit/fcb5f2c540b1fc0d721ad7d68eb861ed02a19a28) | `bitwig-studio: 4.4.2 -> 4.4.3`                                           |
| [`33551a31`](https://github.com/NixOS/nixpkgs/commit/33551a317e3f314afb3f7d5d73b2eb076cf59bbf) | `hiredis: 1.0.2 -> 1.1.0`                                                 |
| [`7837e812`](https://github.com/NixOS/nixpkgs/commit/7837e812d2eaed0f6648999a2cf505b69418428e) | `btlejack: 2.0.0 -> 2.1.1`                                                |
| [`4c265c59`](https://github.com/NixOS/nixpkgs/commit/4c265c59ef6c5e339862812b87323235f92e5214) | `ptcollab: 0.6.4.1 -> 0.6.4.5`                                            |
| [`4c1a2d78`](https://github.com/NixOS/nixpkgs/commit/4c1a2d78f4ebde8d125e587b8d654e5e977226dc) | `cloud-init: 22.3.4 -> 22.4`                                              |
| [`e95b16a1`](https://github.com/NixOS/nixpkgs/commit/e95b16a1a890594caadca1ff8db06798ad0a8027) | `praat: 6.2.23 -> 6.3`                                                    |
| [`5b812c17`](https://github.com/NixOS/nixpkgs/commit/5b812c17015573c17ac4d075e4fb16fe3a99dde8) | `gitRepo: 2.29.9 -> 2.30`                                                 |
| [`b8d00497`](https://github.com/NixOS/nixpkgs/commit/b8d004971f7916dc5892d8537b5d884a4e34ce12) | `media-downloader: 2.6.0 -> 2.7.0`                                        |
| [`b4250d2c`](https://github.com/NixOS/nixpkgs/commit/b4250d2c23245e4b2287830a7ad0a6e199e022d9) | `wiki-tui: 0.5.1 -> 0.6.0`                                                |
| [`d35e15d2`](https://github.com/NixOS/nixpkgs/commit/d35e15d28dd4ffcdb20ed9867c796ab086861aa0) | `go-toml: 2.0.5 -> 2.0.6`                                                 |
| [`123bd0f6`](https://github.com/NixOS/nixpkgs/commit/123bd0f6d4d7960ddd2dd7a6220c6dbc7afd7fd5) | `gitoxide: 0.17.0 -> 0.18.0`                                              |
| [`18dddc9b`](https://github.com/NixOS/nixpkgs/commit/18dddc9bbd1ea26ec0e84d9a6ae307e171af8a70) | `ruff: 0.0.127 -> 0.0.128`                                                |
| [`2b924435`](https://github.com/NixOS/nixpkgs/commit/2b9244355981cdb1aa2eabbb78f7b7095b69465f) | `ruff: 0.0.126 -> 0.0.127 (#201795)`                                      |
| [`c0350cbb`](https://github.com/NixOS/nixpkgs/commit/c0350cbb2cabe49599069d1072b801db13c3bdea) | `nncp: 8.8.1 -> 8.8.2`                                                    |
| [`5510fa13`](https://github.com/NixOS/nixpkgs/commit/5510fa13036a59534728f8a93456045f073b0f53) | `duckstation: unstable-2022-07-08 -> 2022-11-18`                          |
| [`8d67c95c`](https://github.com/NixOS/nixpkgs/commit/8d67c95c6f67844e4518f33c2c870ca4f054a871) | `prometheus-kea-exporter: 0.5.0 -> 0.5.1`                                 |
| [`ab47492f`](https://github.com/NixOS/nixpkgs/commit/ab47492f4a01dfb181c2e630a12b875ecfffc8a6) | `python310Packages.twilio: 7.15.2 -> 7.15.3`                              |
| [`48b2a32b`](https://github.com/NixOS/nixpkgs/commit/48b2a32b68fb23932c0031e8fd9f905ec146d49c) | `python310Packages.lupa: 1.13 -> 1.14.1`                                  |
| [`18ab3f0e`](https://github.com/NixOS/nixpkgs/commit/18ab3f0e16bde0c3b03a2cf598e4c4bbb8587262) | `python310Packages.identify: 2.5.8 -> 2.5.9`                              |
| [`2996749e`](https://github.com/NixOS/nixpkgs/commit/2996749e4712fce593aee0185b4dfd864594ffb5) | `python310Packages.types-urllib3: 1.26.25.3 -> 1.26.25.4`                 |
| [`e8d70b73`](https://github.com/NixOS/nixpkgs/commit/e8d70b73ebfd6db858a5a62f21948a6db3bc7254) | `python310Packages.types-toml: 0.10.8 -> 0.10.8.1`                        |
| [`3838aabd`](https://github.com/NixOS/nixpkgs/commit/3838aabd154ba7a679b5cd9f1c35552009f3abb7) | `python310Packages.types-setuptools: 65.5.0.2 -> 65.5.0.3`                |
| [`5d62080a`](https://github.com/NixOS/nixpkgs/commit/5d62080af594463bbfe4dba6f20411a9498c6768) | `python310Packages.types-requests: 2.28.11.4 -> 2.28.11.5`                |
| [`ce50c169`](https://github.com/NixOS/nixpkgs/commit/ce50c16943eadc648832ae4f3b43368983364ee2) | `python310Packages.types-python-dateutil: 2.8.19.3 -> 2.8.19.4`           |
| [`7cda9c28`](https://github.com/NixOS/nixpkgs/commit/7cda9c28168d088ce864ebb1896a52efd59fbb8a) | `python310Packages.types-colorama: 0.4.15.2 -> 0.4.15.3`                  |
| [`1cb6ce98`](https://github.com/NixOS/nixpkgs/commit/1cb6ce9869c13c52147a4569030c053d323dc811) | `lollypop: 1.4.36 -> 1.4.35`                                              |
| [`2b1d62a3`](https://github.com/NixOS/nixpkgs/commit/2b1d62a3caf6843847b5712b1484ed6c35e692f0) | `python310Packages.regenmaschine: 2022.10.1 -> 2022.11.0`                 |
| [`68fd3bf1`](https://github.com/NixOS/nixpkgs/commit/68fd3bf17d04de4f81826fb871d57aa77e1221ab) | `babeltrace: fix cross-compilation`                                       |
| [`9b0e665e`](https://github.com/NixOS/nixpkgs/commit/9b0e665ebb2bb7b623d14f00605a8d56a287aed9) | `python310Packages.vt-py: 0.17.1 -> 0.17.3`                               |
| [`3a7fd7a9`](https://github.com/NixOS/nixpkgs/commit/3a7fd7a91019ab9cf9cafa4c9038434263526eb6) | `prometheus-artifactory-exporter: 1.9.4 -> 1.9.5`                         |
| [`29eceb22`](https://github.com/NixOS/nixpkgs/commit/29eceb2273291308696f64f35a97366765158ca7) | `dump_syms: Add consumers into passthru.tests`                            |
| [`8fcfff73`](https://github.com/NixOS/nixpkgs/commit/8fcfff7387d2b93337b3606f5162d0acd67b6285) | `dump_syms: 2.0.0 -> 2.1.0`                                               |
| [`3096720e`](https://github.com/NixOS/nixpkgs/commit/3096720ecff97183f9f074b8d746d8921975583b) | `python310Packages.neo4j: 5.2.0 -> 5.2.1`                                 |
| [`ea8595a2`](https://github.com/NixOS/nixpkgs/commit/ea8595a22dee1621ca7c3044fb19c8f86cdf1f9d) | `pulumi: 3.46.1 -> 3.47.0`                                                |
| [`27e31f58`](https://github.com/NixOS/nixpkgs/commit/27e31f5879e652d4f26144b68fb8f7757d50aa69) | `metadata-cleaner: 2.2.5 -> 2.2.7`                                        |
| [`bf9ffaa8`](https://github.com/NixOS/nixpkgs/commit/bf9ffaa8b6af3d6a57810b96559a12d6b4a2c9a4) | `python310Packages.pyrogram: 2.0.59 -> 2.0.62`                            |
| [`b4c77162`](https://github.com/NixOS/nixpkgs/commit/b4c771623fc9c573bb7b5cdc7efcf58907f8207f) | `jackett: 0.20.2238 -> 0.20.2264`                                         |
| [`dd1fc37d`](https://github.com/NixOS/nixpkgs/commit/dd1fc37d06e9deddfa02a9f1772d0837f3e2f090) | `tree-sitter-grammars: update`                                            |
| [`de4bf045`](https://github.com/NixOS/nixpkgs/commit/de4bf0452228ce3693fade66a5752ab15f3ab4ef) | `terraria-server: 1.4.4.8.1 -> 1.4.4.9`                                   |
| [`dc179f87`](https://github.com/NixOS/nixpkgs/commit/dc179f87daff7f7430f9aeb52cadc8ccaffbdaef) | `eureka-ideas: fix build on darwin`                                       |
| [`7d0d2a8d`](https://github.com/NixOS/nixpkgs/commit/7d0d2a8d041b63274f19d20679afcf5c73e0cefb) | `whitesur-icon-theme: 2022-08-30 -> 2022-11-17`                           |
| [`35fcc584`](https://github.com/NixOS/nixpkgs/commit/35fcc584e48c0d6820b1c7a0c28ca85bc5cded50) | `muchsync: 5 -> 6`                                                        |