### PR TITLE
chore(flake/nixpkgs): `690ffff0` -> `af50806f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668905981,
-        "narHash": "sha256-RBQa/+9Uk1eFTqIOXBSBezlEbA3v5OkgP+qptQs1OxY=",
+        "lastModified": 1668994630,
+        "narHash": "sha256-1lqx6HLyw6fMNX/hXrrETG1vMvZRGm2XVC9O/Jt0T6c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "690ffff026b4e635b46f69002c0f4e81c65dfc2e",
+        "rev": "af50806f7c6ab40df3e6b239099e8f8385f6c78b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`fd6f02ed`](https://github.com/NixOS/nixpkgs/commit/fd6f02ed5b72daecf5564d50fa5f684af2f1fb73) | `werf: 1.2.188 -> 1.2.190`                                                                  |
| [`0a732598`](https://github.com/NixOS/nixpkgs/commit/0a732598cf10b91702888368463e852796b00c4b) | `mutagen-compose: 0.16.1 -> 0.16.2`                                                         |
| [`57dcd38b`](https://github.com/NixOS/nixpkgs/commit/57dcd38be45061d846f63d36e15f2024e2d1189f) | `notepadqq: 1.4.8 -> 2.0.0-beta (#202075)`                                                  |
| [`df7a332c`](https://github.com/NixOS/nixpkgs/commit/df7a332cdc6ba4af2b85530ac0e419250acb7dab) | `lscolors: 0.12.0 -> 0.13.0`                                                                |
| [`a4bdbb70`](https://github.com/NixOS/nixpkgs/commit/a4bdbb7073ee59555576fd866c6359de4e15ed70) | `go2tv: init at 1.13.0`                                                                     |
| [`405187ba`](https://github.com/NixOS/nixpkgs/commit/405187ba419726d08dfea31ee132975fbddfda73) | `tumpa: mark broken`                                                                        |
| [`419e261c`](https://github.com/NixOS/nixpkgs/commit/419e261c1b1a9593cf2b8afcecd0f5c0e4b3e7e8) | `openshot-qt: update dependencies`                                                          |
| [`711afefb`](https://github.com/NixOS/nixpkgs/commit/711afefbd17b5cbe4cb64334d14221eae99facad) | `ocamlPackages.flac: 0.3.0 → 0.3.1`                                                         |
| [`1eb3a69e`](https://github.com/NixOS/nixpkgs/commit/1eb3a69e3988d1a02c7aae43ce3f66eaa7325144) | `nix-update: 0.8.0 -> 0.9.0`                                                                |
| [`ffa2351f`](https://github.com/NixOS/nixpkgs/commit/ffa2351fb4d4e7c810bae894cc135a826856df01) | `ruff: add changelog to meta`                                                               |
| [`46f309cf`](https://github.com/NixOS/nixpkgs/commit/46f309cf2741bcc6297e8ea82b6b2f79597c56f2) | `python310Packages.teslajsonpy: 3.1.0 -> 3.2.0`                                             |
| [`973bd58a`](https://github.com/NixOS/nixpkgs/commit/973bd58a62b50fd4af8ba52bec12630cb90ac819) | `python310Packages.teslajsonpy: add changelog to meta`                                      |
| [`797e763e`](https://github.com/NixOS/nixpkgs/commit/797e763ef19b0b0d94c727791784beaab4a805a3) | `remove sleepyhead`                                                                         |
| [`4a73fad5`](https://github.com/NixOS/nixpkgs/commit/4a73fad5155245e66323d422a373e3377da747aa) | `nixos/doc: also note that external YAML files for grafana will end up in the store`        |
| [`bdc11efa`](https://github.com/NixOS/nixpkgs/commit/bdc11efaf2f6321350bcc20620f3036f9423c039) | `ruff: 0.0.129 -> 0.0.131`                                                                  |
| [`98cadbcf`](https://github.com/NixOS/nixpkgs/commit/98cadbcf7004fb103e7e8701c4f496f3b3d6564e) | `nixos/grafana: review fixes`                                                               |
| [`ae959406`](https://github.com/NixOS/nixpkgs/commit/ae959406820bafddf96cd2445f98137043c5a67e) | `tumpa: remove from pythonPackages`                                                         |
| [`7852ff5b`](https://github.com/NixOS/nixpkgs/commit/7852ff5b9a664394f5343ed92fce1dad23cf21c0) | `python310Packages.johnnycanencrypt: 0.6.0 -> 0.11.0`                                       |
| [`996b3332`](https://github.com/NixOS/nixpkgs/commit/996b3332419fe68dbacd6448caac4ce15e9f120a) | `python310Packages.manimpango: add changelog to meta`                                       |
| [`7a68a5d6`](https://github.com/NixOS/nixpkgs/commit/7a68a5d617dba0c75d16edc07ae2883d32c37715) | `python310Packages.mautrix: add changelog to meta`                                          |
| [`2073ee4b`](https://github.com/NixOS/nixpkgs/commit/2073ee4b6e962656bc3475e9fa3de71a3afc2729) | ` appthreat-depscan: add changelog to meta`                                                 |
| [`47c23595`](https://github.com/NixOS/nixpkgs/commit/47c235956b564c0f304dcc27ba3945bbc1205c6d) | `python310Packages.lsassy: add changelog to meta`                                           |
| [`15f5602d`](https://github.com/NixOS/nixpkgs/commit/15f5602de83c2a6c9be3a4f51932572c41ab88cd) | `argocd-autopilot: 0.4.7 -> 0.4.8`                                                          |
| [`72e8f024`](https://github.com/NixOS/nixpkgs/commit/72e8f024d81840de6219e09b78a0747df055f2a0) | `appthreat-depscan: 3.0.0 -> 3.0.2`                                                         |
| [`9959b6bb`](https://github.com/NixOS/nixpkgs/commit/9959b6bba05ee0a0df268db48fb8f8c3203fd24e) | `aliyun-cli: 3.0.134 -> 3.0.135`                                                            |
| [`de997f4d`](https://github.com/NixOS/nixpkgs/commit/de997f4d0c0378d571dcbcdd19c558a2a6b4f133) | `rocminfo: mark broken on aarch64`                                                          |
| [`404ef709`](https://github.com/NixOS/nixpkgs/commit/404ef7091b064592eeceb4cb7fa9e418e0eedfb9) | `ddh: init at 0.13.0`                                                                       |
| [`a17ea3aa`](https://github.com/NixOS/nixpkgs/commit/a17ea3aa437f8b934ff399f2fb542b7e4603f4ee) | `python310Packages.mautrix: 0.18.7 -> 0.18.8`                                               |
| [`6ee5ae3e`](https://github.com/NixOS/nixpkgs/commit/6ee5ae3e48512344e4ebed043cb62ce17417a33a) | `nixos/grafana: make warning more clear`                                                    |
| [`9d7e9c59`](https://github.com/NixOS/nixpkgs/commit/9d7e9c5965c72f516285fe52af14ceeefb315fdc) | `nixos/grafana: allow using both directories or single YAML files for non-Nix provisioning` |
| [`2f1dfb0d`](https://github.com/NixOS/nixpkgs/commit/2f1dfb0db379c1bf13785a5c7d94ad31bd0eb46b) | `nixos/grafana: fix w/o datasources or dashboard provisioning`                              |
| [`4ec456b7`](https://github.com/NixOS/nixpkgs/commit/4ec456b7252a8afabff87fc40eab613c138f43d6) | `nixos/grafana: fix secret-related warnings`                                                |
| [`b300ec34`](https://github.com/NixOS/nixpkgs/commit/b300ec349cf7ae63b3e2335cab673658b67c335e) | `nixos/doc: wording fix`                                                                    |
| [`febc8a43`](https://github.com/NixOS/nixpkgs/commit/febc8a43076c247beb3c868662a14cbb98b55f68) | `nixos/tests/grafana: demonstrate how to use the file provider`                             |
| [`03b34e85`](https://github.com/NixOS/nixpkgs/commit/03b34e85d43249d6b990b28b99bf0e72e93302a4) | `nixos/grafana: we only support single YAML files for provisioning`                         |
| [`45e1ce7e`](https://github.com/NixOS/nixpkgs/commit/45e1ce7e3a3a6c69762d1892382d2dabeec02726) | ``nixos/grafana: get rid of unnecessary `flatten` for warnings``                            |
| [`afd6199c`](https://github.com/NixOS/nixpkgs/commit/afd6199cff2d5b50c1b9458b0f3dcf35f63d16ae) | `nixos/grafana: re-add legacy notifiers test, mention notifiers in release notes`           |
| [`25b58246`](https://github.com/NixOS/nixpkgs/commit/25b582469606561ff47aeda84ca71ea572126a00) | ``nixos/grafana: mark `services.grafana.extraOptions` as removed``                          |
| [`252785fd`](https://github.com/NixOS/nixpkgs/commit/252785fd9cce3474c6167d98b57e64509b1da37e) | `nixos/doc: improve release-notes for services.grafana`                                     |
| [`957e368f`](https://github.com/NixOS/nixpkgs/commit/957e368f3d822a7892d18da9493a8c1d48ee8bef) | ``nixos/grafana: `provision.{datasources,dashboards}` can't be a list anymore``             |
| [`dde2c623`](https://github.com/NixOS/nixpkgs/commit/dde2c6235817ed8f97cedbadb7e6be116d0c53bc) | `python310Packages.manimpango: 0.4.1 -> 0.4.2`                                              |
| [`db3f86f9`](https://github.com/NixOS/nixpkgs/commit/db3f86f9203cf3b6a6cb73f269bc6eff4fe588a7) | `python310Packages.lsassy: 3.1.4 -> 3.1.6`                                                  |
| [`72156f4e`](https://github.com/NixOS/nixpkgs/commit/72156f4e1fe65797e9c6a47b3762d58d6d132377) | `libheif: add some key reverse dependencies to passthru.tests`                              |
| [`7ce12e6f`](https://github.com/NixOS/nixpkgs/commit/7ce12e6fc0943eda8b7e04d778dd450966330ffd) | `pythonPackages.python-xmp-toolkit: disable some failing tests from unmaintained package`   |
| [`626e8b67`](https://github.com/NixOS/nixpkgs/commit/626e8b67fa595a4c1f0a466dce335f06c28fb357) | `nixos/tests/acme/server: regenerate certs`                                                 |
| [`217cf995`](https://github.com/NixOS/nixpkgs/commit/217cf995216ae8797079fdfd41e6398455d4a4ed) | `openvswitch: generalize builder`                                                           |
| [`92097927`](https://github.com/NixOS/nixpkgs/commit/92097927de79f25e165e9e24a7a7a75b9206d18c) | `openvswitch: 2.7.12 -> 3.0.1`                                                              |
| [`7105c088`](https://github.com/NixOS/nixpkgs/commit/7105c088a186e8f95d03b920cbd4eaa74b895522) | `openvswitch-lts: 2.5.12 -> 2.17.3`                                                         |
| [`18ab6d06`](https://github.com/NixOS/nixpkgs/commit/18ab6d062bbaa2af7b99e4493d4baff85b6c8f09) | `sphinxHook: inherit from python3Packages`                                                  |
| [`623fd2cc`](https://github.com/NixOS/nixpkgs/commit/623fd2cc57a23be02ab358e26749ac0450bbacaf) | `worker-build: 0.0.11 -> 0.0.12`                                                            |
| [`4f0a9675`](https://github.com/NixOS/nixpkgs/commit/4f0a9675b3079748ebdb6ac313844e4355672bb0) | `rtl_433: 21.12 -> 22.11`                                                                   |
| [`46ff0fbe`](https://github.com/NixOS/nixpkgs/commit/46ff0fbe6f92f59f71443b28080b7712011318ef) | `wvkbd: 0.11 -> 0.12`                                                                       |
| [`8d9eab43`](https://github.com/NixOS/nixpkgs/commit/8d9eab433a0c23f25a7bdeb9e56b6170b0eeb9fb) | `kdewebkit: remove`                                                                         |
| [`89739b5f`](https://github.com/NixOS/nixpkgs/commit/89739b5f6adb3f22656c8ba30b7e6aca64ee9477) | `kmymoney: switch from kdewebkit to qtwebengine`                                            |
| [`8262b08d`](https://github.com/NixOS/nixpkgs/commit/8262b08df041b4284d5408d90af0834495af8c72) | ``github-runner: support `aarch64-darwin```                                                 |
| [`d14c42b9`](https://github.com/NixOS/nixpkgs/commit/d14c42b9d410b6614641747130b508eb8035c039) | `sdrangel: 7.7.0 -> 7.8.3`                                                                  |
| [`83ac8be4`](https://github.com/NixOS/nixpkgs/commit/83ac8be43cc87f2dc392335e9ab0829a402fcf94) | ``github-runner: support `x86_64-darwin```                                                  |
| [`959df5f2`](https://github.com/NixOS/nixpkgs/commit/959df5f2b2519c5ae6c743a0b7a2dbf75b250da2) | `openxr-loader: 1.0.25 -> 1.0.26`                                                           |
| [`732f0048`](https://github.com/NixOS/nixpkgs/commit/732f0048612f0341c51476e67acc59da31e48932) | `symfony-cli: 5.4.18 -> 5.4.19`                                                             |
| [`6976207a`](https://github.com/NixOS/nixpkgs/commit/6976207a6c58ecea03dfb62aa0b8f82039d977ef) | `pscale: 0.122.0 -> 0.124.0`                                                                |
| [`991053d8`](https://github.com/NixOS/nixpkgs/commit/991053d8a0e1543475d09cb8272c42e8ebe66755) | `v2ray-geoip: 202211100058 -> 202211170054`                                                 |
| [`c4dca743`](https://github.com/NixOS/nixpkgs/commit/c4dca7438cd60b69edd08e337b6a1fef535a3a27) | `fatsort: fix build, cleanup, enable on darwin`                                             |
| [`d2068fdd`](https://github.com/NixOS/nixpkgs/commit/d2068fdd5d425e0e724df7a13764672c597d8f6e) | `ventoy-bin: 1.0.81 -> 1.0.82`                                                              |
| [`f4994c86`](https://github.com/NixOS/nixpkgs/commit/f4994c862cf812303d23b6f30d925e0c4cb8c977) | `newsflash: 2.1.2 -> 2.2.2`                                                                 |
| [`115a8853`](https://github.com/NixOS/nixpkgs/commit/115a8853c4590dbdab22c7c34e35f0bd4b5ea558) | `tty-share: enable on darwin`                                                               |
| [`a8ab6540`](https://github.com/NixOS/nixpkgs/commit/a8ab6540fdd68f426832e539c5141771e93656a2) | `tty-share: 2.2.1 -> 2.3.0`                                                                 |
| [`0a84f787`](https://github.com/NixOS/nixpkgs/commit/0a84f7879f8bd7922bef9822365997f2ebb376d5) | `prometheus-nats-exporter: 0.10.0 -> 0.10.1`                                                |
| [`6bd8620d`](https://github.com/NixOS/nixpkgs/commit/6bd8620d06bc330870bd6150ae94c475a76438fc) | `haskellPackages.hsqml: disable new packages`                                               |
| [`06d3d727`](https://github.com/NixOS/nixpkgs/commit/06d3d727c5a8795484f36c7c79bc981638da95ef) | `haskellPackages: stop evaluating hyper-haskell-server-with-packages in jobset`             |
| [`3827a60a`](https://github.com/NixOS/nixpkgs/commit/3827a60a7f48d4012fc515a3edff5f167d367182) | `plasma-framework, kconfig: 5.100.0 -> 5.100.1`                                             |
| [`38d81f21`](https://github.com/NixOS/nixpkgs/commit/38d81f21326497c7f1833b7e7f395aa8f8c6ab17) | `haskellPackages: mark builds failing on hydra as broken`                                   |
| [`6b3c6dc8`](https://github.com/NixOS/nixpkgs/commit/6b3c6dc85f6632af10158f8a87cc725978689f9c) | `tippecanoe: 2.11.0 -> 2.13.0`                                                              |
| [`d0c6333f`](https://github.com/NixOS/nixpkgs/commit/d0c6333f1fee0413f68432ae563aba27474865a1) | `texstudio: 4.3.1 -> 4.4.0`                                                                 |
| [`8cfb8db3`](https://github.com/NixOS/nixpkgs/commit/8cfb8db3987e0347280695ec8fa4be49fbb216f9) | `terrascan: 1.16.0 -> 1.17.0`                                                               |
| [`c85bc3d2`](https://github.com/NixOS/nixpkgs/commit/c85bc3d20b81bccb5d839455d6a0f002d5e40119) | `doppler: 3.45.0 -> 3.52.1`                                                                 |
| [`ad948687`](https://github.com/NixOS/nixpkgs/commit/ad948687d5079f6116c0bd9d47bb1b46cf023e08) | `helmsman: 3.15.0 -> 3.15.1`                                                                |
| [`11adfafd`](https://github.com/NixOS/nixpkgs/commit/11adfafdee3c05a3b52781d63fc306f3d1fd8a72) | `mycorrhiza: 1.12.1 -> 1.13.0`                                                              |
| [`6ba0d204`](https://github.com/NixOS/nixpkgs/commit/6ba0d204871319a430b584fed30e9b0c605c66bf) | `igv: 2.14.1 -> 2.15.1`                                                                     |
| [`d63fe42e`](https://github.com/NixOS/nixpkgs/commit/d63fe42e911db769e5dbdbabdf8728647f789cd0) | `commonsCompress: 1.21 -> 1.22`                                                             |
| [`14066b1c`](https://github.com/NixOS/nixpkgs/commit/14066b1ce1be3287c3e6d1800c220ffcc0f32b0b) | `appstream-glib: 0.8.1 -> 0.8.2`                                                            |
| [`1cd38dd6`](https://github.com/NixOS/nixpkgs/commit/1cd38dd6c7078aff5c3cb5950d97099f25768aa6) | `buck: 2021.05.05.01 -> 2022.05.05.01`                                                      |
| [`212a3d80`](https://github.com/NixOS/nixpkgs/commit/212a3d80a544ef42e78b22157a8bfdca712753ef) | `pritunl-client: 1.3.3329.81 -> 1.3.3343.50`                                                |
| [`53e8108d`](https://github.com/NixOS/nixpkgs/commit/53e8108d3a5bd695f4703a4adc8524581b607025) | `syft: 0.60.3 -> 0.62.0`                                                                    |
| [`c2dde4bc`](https://github.com/NixOS/nixpkgs/commit/c2dde4bc46a035f7541d7d4885d197c486d68f7c) | `bluejeans-gui: 2.30.1.18 -> 2.31.0.83`                                                     |
| [`7ebbfa7b`](https://github.com/NixOS/nixpkgs/commit/7ebbfa7b02d99043fc4fd7eb524050d7042c3376) | `imath: 3.1.5 -> 3.1.6`                                                                     |
| [`d1bd4516`](https://github.com/NixOS/nixpkgs/commit/d1bd45165c58fafb6776ec069fff94f6b99b035b) | `subfinder: 2.5.4 -> 2.5.5`                                                                 |
| [`613ab461`](https://github.com/NixOS/nixpkgs/commit/613ab461ba974d43248e8835d51cb51af6d72a27) | `paperless-ngx: test channels in asyncio auto mode`                                         |
| [`3c77bae4`](https://github.com/NixOS/nixpkgs/commit/3c77bae4c3c7c2530ef82f4d31e2e14eca722c00) | `entt: remove unused substituteInPlace`                                                     |
| [`ea76cad3`](https://github.com/NixOS/nixpkgs/commit/ea76cad34d64ce213de5992154031bf0c9b75ace) | `unciv: 4.2.16 -> 4.2.20`                                                                   |
| [`160f4ebc`](https://github.com/NixOS/nixpkgs/commit/160f4ebc8f12cebbb495d55e38c78569b0793d41) | `gallery-dl: 1.23.5 -> 1.24.0`                                                              |
| [`fe5e9cea`](https://github.com/NixOS/nixpkgs/commit/fe5e9cea338818a24f1522fbeae055109fbb8def) | `fits-cloudctl: 0.11.1 -> 0.11.2`                                                           |
| [`49e27d15`](https://github.com/NixOS/nixpkgs/commit/49e27d15c0cf5f60be16377fd88f4e6a9b48d89e) | `timg: 1.4.4 -> 1.4.5`                                                                      |
| [`c9543015`](https://github.com/NixOS/nixpkgs/commit/c9543015d02271ee41890f72d551a3872e8b4f8f) | `nixos/firewall: remove stray quote from package option`                                    |
| [`03f59d7f`](https://github.com/NixOS/nixpkgs/commit/03f59d7fa8d1ef4b1e7d193cbdc53ff8904e1bfb) | `bore-cli: 0.4.0 -> 0.4.1`                                                                  |
| [`b85bfd11`](https://github.com/NixOS/nixpkgs/commit/b85bfd1186e269c9b57c1d35c27baa33f2eca392) | `chezmoi: 2.27.0 -> 2.27.1`                                                                 |
| [`313c4032`](https://github.com/NixOS/nixpkgs/commit/313c4032fc9f3f7f5c43630345bc1366a4bceaca) | `go-task: 3.17.0 -> 3.18.0`                                                                 |
| [`e2c5cc59`](https://github.com/NixOS/nixpkgs/commit/e2c5cc595887683b90f73c63c648fe08297fce85) | `inadyn: 2.9.1 -> 2.10.0`                                                                   |
| [`2a70e632`](https://github.com/NixOS/nixpkgs/commit/2a70e6321d040100998a34e4f809bda1b36c73c2) | `kubeaudit: 0.20.0 -> 0.21.0`                                                               |
| [`1f9973a1`](https://github.com/NixOS/nixpkgs/commit/1f9973a1a2d56399f6984497987ebf25b880928a) | `heimer: 3.6.1 -> 3.6.2`                                                                    |
| [`5ec7d46d`](https://github.com/NixOS/nixpkgs/commit/5ec7d46d92bfc0267bfcf01ad1cb9054b218bf04) | `leo-editor: 6.6.4 -> 6.7.1`                                                                |
| [`149ac1b9`](https://github.com/NixOS/nixpkgs/commit/149ac1b96fbc17fdb276e63640f3650138cbc61e) | `ergo: 4.0.104 -> 5.0.3`                                                                    |
| [`03d0809f`](https://github.com/NixOS/nixpkgs/commit/03d0809f1a72154804ca98b7612188558f16e967) | `micronaut: 3.7.2 -> 3.7.4`                                                                 |
| [`862277ac`](https://github.com/NixOS/nixpkgs/commit/862277ac9d34273cd953f42061e23d488d6b7e8b) | `kstars: 3.6.0 -> 3.6.1`                                                                    |
| [`fece6776`](https://github.com/NixOS/nixpkgs/commit/fece6776ae87abe82fc86c887ed1adacf223c8e8) | `snappymail: 2.21.0 -> 2.21.3`                                                              |
| [`7bc7b886`](https://github.com/NixOS/nixpkgs/commit/7bc7b886df2fbbde604f6807f8f810f7dd40bc2b) | `nats-server: 2.9.6 -> 2.9.7`                                                               |
| [`ac31d8ef`](https://github.com/NixOS/nixpkgs/commit/ac31d8ef99304acb256c13909230b942c5177f79) | `skaffold: 2.0.1 -> 2.0.2`                                                                  |
| [`56721bd3`](https://github.com/NixOS/nixpkgs/commit/56721bd3878a4010eec853b3b535990de094465b) | `krane: 3.0.0 → 3.0.1`                                                                      |
| [`ca267996`](https://github.com/NixOS/nixpkgs/commit/ca2679963460afe35ad9b88c9a40363778c8fad8) | `python3Packages.numba: 0.56.2 -> 0.56.4, fix tests and CUDA`                               |
| [`a7a4375e`](https://github.com/NixOS/nixpkgs/commit/a7a4375ed5faad9feb61816acf19a28d5de2f0aa) | `ruff: 0.0.128 -> 0.0.129`                                                                  |
| [`1d288267`](https://github.com/NixOS/nixpkgs/commit/1d28826768518837140e2d8b6d7badb9abea7985) | `python310Packages.pyunifiprotect: 4.4.1 -> 4.4.2`                                          |
| [`2fedbbab`](https://github.com/NixOS/nixpkgs/commit/2fedbbab9cc09897d1e95dd5272c3100f8a7ed6f) | `nixos/gnome/at-spi2-core: force GTK_A11Y=none when disabled`                               |
| [`07b8a2a0`](https://github.com/NixOS/nixpkgs/commit/07b8a2a0eaf0a7bc25b5215093c0f54a9a9f3c7d) | `python310Packages.pyunifiprotect: add changelog to meta`                                   |
| [`99f2e528`](https://github.com/NixOS/nixpkgs/commit/99f2e5281e2ad1f9dd23085a9e7e271dc902ddf5) | `python310Packages.pyvicare: 2.17.0 -> 2.19.0`                                              |
| [`df158fc9`](https://github.com/NixOS/nixpkgs/commit/df158fc990618c52e74cd75bd0f92ed15dd15f93) | `python310Packages.thermobeacon-ble: 0.3.2 -> 0.4.0`                                        |
| [`a1328909`](https://github.com/NixOS/nixpkgs/commit/a1328909586493419ba1bce0be75dbdc8c904560) | `python310Packages.thermobeacon-ble: add changelog to meta`                                 |
| [`aaca0938`](https://github.com/NixOS/nixpkgs/commit/aaca09386b0c8bf0a81ef28df296cadf1fc3fb8e) | `python310Packages.django-webpack-loader: add missing input`                                |
| [`3d06bcf3`](https://github.com/NixOS/nixpkgs/commit/3d06bcf39994c2d810fc07b292036334612ac0fa) | `python310Packages.shtab: 1.5.7 -> 1.5.8`                                                   |
| [`dee33b1e`](https://github.com/NixOS/nixpkgs/commit/dee33b1edd02b4cd81b10d681aa97e2430a94708) | `python310Packages.shtab: add changelog to meta`                                            |
| [`bc3c3334`](https://github.com/NixOS/nixpkgs/commit/bc3c333427720f6fbb9b951d83f8b6bf0d6940c7) | `python310Packages.python-homewizard-energy: 1.1.1 -> 1.2.0`                                |
| [`9f2103f3`](https://github.com/NixOS/nixpkgs/commit/9f2103f390b25a3b13301009879dbe0a133ccd40) | `python310Packages.python-homewizard-energy: add changelog to meta`                         |
| [`a32e171a`](https://github.com/NixOS/nixpkgs/commit/a32e171a627e57122cebab171498be55012fd3c7) | `python310Packages.bluetooth-data-tools: add changelog to meta`                             |
| [`488dec35`](https://github.com/NixOS/nixpkgs/commit/488dec359cd3d07161383a5bbfccb8a4fa8e09f3) | `python310Packages.bluetooth-auto-recovery: add changelog to meta`                          |
| [`c0ca69f7`](https://github.com/NixOS/nixpkgs/commit/c0ca69f7cfc081bf2837660a04b79a29ba21e51d) | `python310Packages.bluetooth-adapters: update changelog entry`                              |
| [`74463508`](https://github.com/NixOS/nixpkgs/commit/744635089aa329813434cb93ead04780fa503bae) | `python310Packages.bluetooth-data-tools: 0.2.0 -> 0.3.0`                                    |
| [`aa377124`](https://github.com/NixOS/nixpkgs/commit/aa3771243ab6589d2f43aacd841204132211bdb0) | `python310Packages.bluetooth-auto-recovery: 0.3.6 -> 0.4.0`                                 |
| [`e31de6dc`](https://github.com/NixOS/nixpkgs/commit/e31de6dc172758b565e789181bc8768103b7f2fb) | `python310Packages.bluetooth-adapters: 0.7.0 -> 0.8.0`                                      |
| [`f20402f8`](https://github.com/NixOS/nixpkgs/commit/f20402f8e3d8bd4c9ccf3c36718c9922d5c4d82d) | `nixos/tests/deluge: fix test`                                                              |