### PR TITLE
chore(flake/home-manager): `f7641a3f` -> `62cb5bcf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669071065,
-        "narHash": "sha256-KBpgj3JkvlPsJ3duOZqFJe6tgr+wc75t8sFmgRbBSbw=",
+        "lastModified": 1669328018,
+        "narHash": "sha256-aJRMobnNDEXKwoSZFS4hGjGU1WDNxkQ82BVKAEohOfY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f7641a3ff398ccce952e19a199d775934e518c1d",
+        "rev": "62cb5bcf93896e4dd6b4507dac7ba2e2e3abc9d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                          |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`62cb5bcf`](https://github.com/nix-community/home-manager/commit/62cb5bcf93896e4dd6b4507dac7ba2e2e3abc9d7) | `Switch master branch version to 23.05` |