### PR TITLE
chore(flake/nixpkgs): `42337aad` -> `27ccd290`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669230746,
-        "narHash": "sha256-+rU3DixJnygpJsGhhp6OvViruJux4TaiCz4IO+DdtZU=",
+        "lastModified": 1669320964,
+        "narHash": "sha256-EBFw+ge12Pcr3qCk8If3/eMBAoQLR7ytndXZoRevUtM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "42337aad353c5efff4382d7bf99deda491459845",
+        "rev": "27ccd29078f974ddbdd7edc8e38c8c8ae003c877",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`5bdbc364`](https://github.com/NixOS/nixpkgs/commit/5bdbc3642a353a5fccb43a9aafe611ca7b7de5a9) | `mautrix-facebook: Use default Python platforms`                                              |
| [`aab14dc7`](https://github.com/NixOS/nixpkgs/commit/aab14dc76955382e5f76cae40c292c39dbcfc506) | `sapling: simplify dependency generation script`                                              |
| [`e31777a1`](https://github.com/NixOS/nixpkgs/commit/e31777a12c0d9ae08fbe4d15a3ed2c2df451e18e) | `coqPackages.mathcomp-algebra-tactics: init at 1.0.0`                                         |
| [`24435b43`](https://github.com/NixOS/nixpkgs/commit/24435b435df0fd0bc53cb4181cb21a83c98d353d) | `svtplay-dl: 4.14 -> 4.15`                                                                    |
| [`e4168845`](https://github.com/NixOS/nixpkgs/commit/e4168845c752fdea46baf96e9c6f35fd590019f5) | `ocamlPackages.ptime: 0.8.6 → 1.0.0`                                                          |
| [`45e17a1e`](https://github.com/NixOS/nixpkgs/commit/45e17a1e7acfccccd9897fbeb2c06f6c979f1779) | `bitcoin: 23.0 -> 24.0`                                                                       |
| [`a01b299c`](https://github.com/NixOS/nixpkgs/commit/a01b299c59216fcef5dc313d4e04dd3df522d8b0) | `git-cinnabar: don't set GIT_CINNABAR_EXPERIMENTS`                                            |
| [`bb4677b8`](https://github.com/NixOS/nixpkgs/commit/bb4677b80c5c07da7324436c1f045e9b93bc7375) | `asmjit: init at unstable-2022-11-10`                                                         |
| [`93c50a28`](https://github.com/NixOS/nixpkgs/commit/93c50a28f6b913b2fce0ae38c54a85eacf245df4) | `mlv-app: remove -march=native`                                                               |
| [`3dcbb57a`](https://github.com/NixOS/nixpkgs/commit/3dcbb57adbd32ce721b55663ffa068675731cefc) | `glava: remove -march=native`                                                                 |
| [`ea91c637`](https://github.com/NixOS/nixpkgs/commit/ea91c637fb586d49b772525fcdd9b59b966dab11) | `opentrack: remove -march=native`                                                             |
| [`8a5a2190`](https://github.com/NixOS/nixpkgs/commit/8a5a21905d95a6aa2e03a4c5f19175bc0ad58291) | `vertcoin: 0.15.0.1 -> 0.18.0`                                                                |
| [`333f2ef7`](https://github.com/NixOS/nixpkgs/commit/333f2ef7636cd70b56e839587fdf4d56d6ccc132) | `digibyte: remove`                                                                            |
| [`02f81170`](https://github.com/NixOS/nixpkgs/commit/02f81170c492604a7e5641cb0ee4fb4b654c2f43) | `bitcoin-unlimited: build with latest Qt`                                                     |
| [`ce270b33`](https://github.com/NixOS/nixpkgs/commit/ce270b33efba5dfce560412a63a6c98ef1b95293) | `bitcoin-gold: remove`                                                                        |
| [`e341cd3b`](https://github.com/NixOS/nixpkgs/commit/e341cd3ba4c5505c5b6e96ac29ade3d84b3a1c1d) | `netlify-cli.tests.test: Add ps on darwin`                                                    |
| [`2ff4e9ea`](https://github.com/NixOS/nixpkgs/commit/2ff4e9ea8463bff0f7646b17a6028d7b20a2ec1f) | `netlify-cli: refactor`                                                                       |
| [`c97cd4f4`](https://github.com/NixOS/nixpkgs/commit/c97cd4f4a84646deb6cb13664f645c622a265380) | `chain-bench: 0.1.6 -> 0.1.7`                                                                 |
| [`c1254eeb`](https://github.com/NixOS/nixpkgs/commit/c1254eebab9a7257e978af1009d9ba2133befcec) | `linuxPackages.nvidia_x11_vulkan_beta: 515.49.24 -> 515.49.25`                                |
| [`7331988b`](https://github.com/NixOS/nixpkgs/commit/7331988b07d48241ebd4e4f9bc8ade37e199a4bb) | `linuxPackages.nvidia_x11: 515.76 -> 515.86.01, 470.141.03 -> 470.161.03, 390.154 -> 390.157` |
| [`9fff86f3`](https://github.com/NixOS/nixpkgs/commit/9fff86f3eba18c1370e47485a2758611d3dda237) | `bitcoin-classic: remove`                                                                     |
| [`0676b5af`](https://github.com/NixOS/nixpkgs/commit/0676b5af6964518cc6c6820da7ccf83843b08572) | `mlt: Add rubberband support`                                                                 |
| [`62323057`](https://github.com/NixOS/nixpkgs/commit/62323057043baabd7aecd4829c8a208f64140075) | `opcr-policy: 0.1.42 -> 0.1.43`                                                               |
| [`47dfc53f`](https://github.com/NixOS/nixpkgs/commit/47dfc53feab971ef125444fd9981c6340c1a8f0b) | `sapling: init at 0.1.20221118-210929-cfbb68aa (#201798)`                                     |
| [`ca44edf1`](https://github.com/NixOS/nixpkgs/commit/ca44edf11cf58dde99350c9ce125c761d438a899) | `devbox: 0.1.0 -> 0.1.1 (#202607)`                                                            |
| [`09565dad`](https://github.com/NixOS/nixpkgs/commit/09565dad814964d676a3a3ac25b7830277c6e9af) | `python310Packages.python-homewizard-energy: 1.2.0 -> 1.3.1`                                  |
| [`aee1facf`](https://github.com/NixOS/nixpkgs/commit/aee1facf771de55b8f556b2598d0af631e03dd08) | `python310Packages.mitmproxy-wireguard: 0.1.18 -> 0.1.19`                                     |
| [`8d1f580a`](https://github.com/NixOS/nixpkgs/commit/8d1f580ade6eaea61ec9c291eab7ff87f18a784e) | `unifi-poller: 2.1.9 -> 2.2.0`                                                                |
| [`16ce635d`](https://github.com/NixOS/nixpkgs/commit/16ce635de479a0a1f9c73b550adf8624a017debe) | `python310Packages.boschshcpy: 0.2.36 -> 0.2.37`                                              |
| [`11fc0c7d`](https://github.com/NixOS/nixpkgs/commit/11fc0c7dd64e19339613edee81dd137a5b08ba40) | `python310Packages.plaid-python: 11.1.0 -> 11.2.0`                                            |
| [`44c09ae9`](https://github.com/NixOS/nixpkgs/commit/44c09ae9811acf061c30930b4eb346dbcf2ddc3b) | `python310Packages.adafruit-platformdetect: 3.34.0 -> 3.35.0`                                 |
| [`d1f2d1a6`](https://github.com/NixOS/nixpkgs/commit/d1f2d1a60fb31c84762b5af22511b59e015ff627) | `mitmproxy2swagger: 0.7.0 -> 0.7.1`                                                           |
| [`dab1673e`](https://github.com/NixOS/nixpkgs/commit/dab1673e9f4dcb19999ed188fb94d5f2ead66e8d) | `mitmproxy2swagger: add changelog to meta`                                                    |
| [`c25a9f03`](https://github.com/NixOS/nixpkgs/commit/c25a9f03f370188785518dc2717768db2dee50ac) | `python310Packages.persistent: add changelog to meta`                                         |
| [`68caf32b`](https://github.com/NixOS/nixpkgs/commit/68caf32ba7abe5aec62cd5659735c6d4ca5a5bb1) | `python310Packages.optax: add changelog to meta`                                              |
| [`19b83bd0`](https://github.com/NixOS/nixpkgs/commit/19b83bd016e436f3f0cec6e737bc3b3d7fd4c2f7) | `python310Packages.pex: add changelog to meta`                                                |
| [`54939cde`](https://github.com/NixOS/nixpkgs/commit/54939cdeda11de9ad8d9376f50fb198677261b11) | `python310Packages.pex: 2.1.113 -> 2.1.114`                                                   |
| [`88ce3dfe`](https://github.com/NixOS/nixpkgs/commit/88ce3dfe202834c5319c9951db4ce4462887a3d1) | `python310Packages.persistent: 4.9.2 -> 4.9.3`                                                |
| [`db27456a`](https://github.com/NixOS/nixpkgs/commit/db27456a925305c222f3e68432de8b70ac912577) | `cmdstan: 2.30.1 -> 2.31.0`                                                                   |
| [`a914e20f`](https://github.com/NixOS/nixpkgs/commit/a914e20f8be75beab0ec80472bfd47c8c4b7e367) | `cmctl: 1.10.0 -> 1.10.1`                                                                     |
| [`8e8b5f3b`](https://github.com/NixOS/nixpkgs/commit/8e8b5f3b1e899bf5d250279578c0283705b8cdb4) | `terraform-providers.tencentcloud: 1.78.13 → 1.78.14`                                         |
| [`3e85b631`](https://github.com/NixOS/nixpkgs/commit/3e85b631812b7984d38c24ae94069c09d40778a2) | `terraform-providers.opsgenie: 0.6.17 → 0.6.18`                                               |
| [`831394a8`](https://github.com/NixOS/nixpkgs/commit/831394a8daa89a3a5bd9bc699fcda1e5f69978ac) | `terraform-providers.docker: 2.23.0 → 2.23.1`                                                 |
| [`8c037af9`](https://github.com/NixOS/nixpkgs/commit/8c037af94ca44a2139ab1ddad595d4e72e94106d) | `terraform-providers.fastly: 3.0.1 → 3.0.2`                                                   |
| [`0f5f6db0`](https://github.com/NixOS/nixpkgs/commit/0f5f6db01ffe7ecec858943b51795e2f2d4b73d8) | `python310Packages.peaqevcore: 8.0.2 -> 8.2.0`                                                |
| [`e7a1f844`](https://github.com/NixOS/nixpkgs/commit/e7a1f8449869c64d0e333bf711dc28c7abb9bfd6) | `gitui: 0.22.0 -> 0.22.1`                                                                     |
| [`63fa4df6`](https://github.com/NixOS/nixpkgs/commit/63fa4df63c735c37b56bbf5f995668830d26bb65) | `qrcp: mark broken on darwin`                                                                 |
| [`0f56f1ef`](https://github.com/NixOS/nixpkgs/commit/0f56f1ef549d1726b9350982b6300627e0fb04d2) | `python310Packages.optax: 0.1.3 -> 0.1.4`                                                     |
| [`9e279b7b`](https://github.com/NixOS/nixpkgs/commit/9e279b7bd3d89850d21b2cbfc876f9cac1157241) | `ouch: 0.3.1 -> 0.4.0`                                                                        |
| [`af5c172f`](https://github.com/NixOS/nixpkgs/commit/af5c172fabf634d6cb1366cc0c0570af6e0812d5) | `writefreely: remove myself from maintainers`                                                 |
| [`3d97d9cc`](https://github.com/NixOS/nixpkgs/commit/3d97d9cc46096e853efd0c7622d096a458b31552) | `senv: mark broken on darwin`                                                                 |
| [`6af34d90`](https://github.com/NixOS/nixpkgs/commit/6af34d90cafd78732edd78f16b7b7893addf03d9) | `python310Packages.regenmaschine: 2022.11.0 -> 2022.11.1`                                     |
| [`de485793`](https://github.com/NixOS/nixpkgs/commit/de4857930b919d33b3de9e140782876bda6704b2) | `python310Packages.regenmaschine: add changelog to meta`                                      |
| [`9a5dc3a7`](https://github.com/NixOS/nixpkgs/commit/9a5dc3a76008f68ebba2d6ccfbdfbdffd471cf0b) | `etcd_3_5: 3.5.5 -> 3.5.6`                                                                    |
| [`21ef1b91`](https://github.com/NixOS/nixpkgs/commit/21ef1b91290fb033376e1b4a0162f99332e86b63) | `zlint: 3.4.0 -> 3.4.1`                                                                       |
| [`b9c24877`](https://github.com/NixOS/nixpkgs/commit/b9c24877d0271b1fe122e65579fa4e9bb33f65a9) | `prometheus: 2.40.0 -> 2.40.2`                                                                |
| [`b8ffc572`](https://github.com/NixOS/nixpkgs/commit/b8ffc572d27ec671366ef4937ed0f90b73638a42) | `nixos/patroni: only run tests on x86_64-linux`                                               |
| [`cfa112c8`](https://github.com/NixOS/nixpkgs/commit/cfa112c8355b754c9eb39fd2f0fa046504ba98ad) | `cargo-nextest: 0.9.43 -> 0.9.44`                                                             |
| [`c99cfce6`](https://github.com/NixOS/nixpkgs/commit/c99cfce6ad59b83f111fa124f3f876e3a157a1e2) | `tor-browser-bundle-bin: 11.5.7 -> 11.5.8`                                                    |
| [`eed28ead`](https://github.com/NixOS/nixpkgs/commit/eed28ead0c1ea5cea8f592d16c93f9391b21f6d4) | `Workaround for upstream crash when !datadog`                                                 |
| [`e83efab6`](https://github.com/NixOS/nixpkgs/commit/e83efab60db3e597635255332047b110b862eb19) | `chaos: add changelog to meta`                                                                |
| [`40c27fe2`](https://github.com/NixOS/nixpkgs/commit/40c27fe25b4fb5a512b26fead90dd063abbfb122) | `clair: 4.5.0 -> 4.5.1`                                                                       |
| [`5ad8ce4b`](https://github.com/NixOS/nixpkgs/commit/5ad8ce4b97b0f359a242c3642975a55f5a31b46f) | `cilium-cli: 0.12.7 -> 0.12.8`                                                                |
| [`2507b02a`](https://github.com/NixOS/nixpkgs/commit/2507b02a1c3de3ee1cd65d4503cc8a248041a97b) | `chaos: 0.3.0 -> 0.4.0`                                                                       |
| [`a22a9603`](https://github.com/NixOS/nixpkgs/commit/a22a960374e13063c69e88b3a37e19847350afaf) | `python310Packages.meshtastic: 2.0.3 -> 2.0.4`                                                |
| [`9fdc90c6`](https://github.com/NixOS/nixpkgs/commit/9fdc90c65dfd4734a2e787f8311d639c746f1ebe) | `python310Packages.meshtastic: add changelog to meta`                                         |
| [`476ffc08`](https://github.com/NixOS/nixpkgs/commit/476ffc0880965d0c8f7585b08d500ad280438629) | `brev-cli: 0.6.179 -> 0.6.181`                                                                |
| [`e7f761fe`](https://github.com/NixOS/nixpkgs/commit/e7f761fe60905081166a0bc07474a64683574754) | `Fix executable name`                                                                         |
| [`16fa9150`](https://github.com/NixOS/nixpkgs/commit/16fa9150c6f541cf90f863ec08f3c834578ab11d) | `pulumi: 3.47.0 -> 3.47.2`                                                                    |
| [`5a166bbb`](https://github.com/NixOS/nixpkgs/commit/5a166bbbc3058583bf4d69a21946dec4849b36ce) | `winbox: fix startup of the application`                                                      |
| [`a29584f0`](https://github.com/NixOS/nixpkgs/commit/a29584f0d4a8ed247a5fb230e3b51cb9f431ff03) | `kubectx: show version fix`                                                                   |
| [`12cadc9f`](https://github.com/NixOS/nixpkgs/commit/12cadc9f1147200a13914468ddeb7c11705d049c) | `rustic-rs: 0.3.2 -> 0.4.0`                                                                   |
| [`639d80dd`](https://github.com/NixOS/nixpkgs/commit/639d80dd828a5dda21fe84c044e877d7059e4be2) | `kubo: 0.16.0 -> 0.17.0`                                                                      |
| [`05f0b061`](https://github.com/NixOS/nixpkgs/commit/05f0b0614b61010b71a81211bf6cab210a032c73) | `echidna: 2.0.3 -> 2.0.4`                                                                     |
| [`71a4ac6d`](https://github.com/NixOS/nixpkgs/commit/71a4ac6d8b00fb40815fcd0532149ff6b7fb1a39) | `zq: 1.2.0 -> 1.3.0`                                                                          |
| [`962c8cba`](https://github.com/NixOS/nixpkgs/commit/962c8cba72d074a907f7739fd17f125421cb2112) | `tmux: enable utf8proc everywhere`                                                            |
| [`8f2f7589`](https://github.com/NixOS/nixpkgs/commit/8f2f7589a5702acb66b407a92141235a0fa3ed22) | `unciv: 4.2.20 -> 4.3.1`                                                                      |
| [`7c8d7b8d`](https://github.com/NixOS/nixpkgs/commit/7c8d7b8d1c3387dbf04f12f73aac1254dd36e780) | `texlab: 4.3.1 -> 4.3.2`                                                                      |
| [`e16488c5`](https://github.com/NixOS/nixpkgs/commit/e16488c50eb2595aee5156d07b5f616b4f0b938c) | `itd: 0.0.9 -> 1.0.0`                                                                         |
| [`3732d9e3`](https://github.com/NixOS/nixpkgs/commit/3732d9e3677395d094ed4c4480ab82333cc0e759) | `stochas: 1.3.5 -> 1.3.8`                                                                     |
| [`764fb93f`](https://github.com/NixOS/nixpkgs/commit/764fb93f3746caa16ce21131c658d171671a446e) | `postgresqlPackages.pgvector: 0.3.0 -> 0.3.2`                                                 |
| [`81830797`](https://github.com/NixOS/nixpkgs/commit/8183079716e67518a8fc62f701f280924374bf67) | `comma: add marsam to maintainers`                                                            |
| [`70158e0b`](https://github.com/NixOS/nixpkgs/commit/70158e0be06201707f855fc2cede524e5403905c) | `scdl: 2.7.2 -> 2.7.3`                                                                        |
| [`a0a8d47f`](https://github.com/NixOS/nixpkgs/commit/a0a8d47f2cbc3aca20169f3319fb1582c208c220) | `python310Packages.patiencediff: 0.2.6 -> 0.2.8`                                              |
| [`1ef34b5a`](https://github.com/NixOS/nixpkgs/commit/1ef34b5ae875a9bbb81bb6e1f12703b7d20fca22) | `comma: use nix from environment`                                                             |
| [`ed2c0adb`](https://github.com/NixOS/nixpkgs/commit/ed2c0adb45d63f73c943bf174e3d470ef49eba3b) | `comma: 1.3.0 -> 1.4.0`                                                                       |
| [`247840af`](https://github.com/NixOS/nixpkgs/commit/247840af626f8b16216b1fa6408b53585dc30ce2) | `safety-cli: 2.3.1 -> 2.3.2`                                                                  |
| [`4800b30f`](https://github.com/NixOS/nixpkgs/commit/4800b30f39e1fa333e57cd74ff8daee07a8ef655) | `csdr: fix build on aarch64`                                                                  |
| [`30709c15`](https://github.com/NixOS/nixpkgs/commit/30709c1574ccf9bdb957241682ef11b029f24f37) | `pspg: 5.5.9 -> 5.5.12`                                                                       |
| [`22bee934`](https://github.com/NixOS/nixpkgs/commit/22bee934d07ff4d494492f2bd9747ef2c4928349) | `mitschemeX11: use xorg.* packages directly instead of xlibsWrapper indirection`              |
| [`ab27a2c6`](https://github.com/NixOS/nixpkgs/commit/ab27a2c699032756c308616972da7da37728cbf5) | `ananicy-cpp: unstable-2021-10-13 -> 1.0.1`                                                   |
| [`41f6bb83`](https://github.com/NixOS/nixpkgs/commit/41f6bb837b2ffc7acc7a73f20d202778560f099d) | `python3Packages.ariadne: init at 0.16.1`                                                     |
| [`7bc4b766`](https://github.com/NixOS/nixpkgs/commit/7bc4b7661a6938d3ae35d04fc05093e31e5c9597) | `picard: 2.8.3 -> 2.8.4`                                                                      |
| [`3fcd17d1`](https://github.com/NixOS/nixpkgs/commit/3fcd17d197ebcbc3ee0003a931516e167fc205be) | ``signalbackup-tools: use new `--config` option in build script``                             |
| [`7430ccc8`](https://github.com/NixOS/nixpkgs/commit/7430ccc824d9a248fa76f21485e0460c5a9b2172) | `signalbackup-tools: 20221025 -> 20221122`                                                    |
| [`7a62174d`](https://github.com/NixOS/nixpkgs/commit/7a62174dc21ba7538856a00a095eccd575f9694d) | `python310Packages.pycmarkgfm: add changelog to meta`                                         |
| [`3296a4be`](https://github.com/NixOS/nixpkgs/commit/3296a4be033fcc9632973e0aee496cbf08c236f5) | `python310Packages.pycmarkgfm: add format attribute`                                          |
| [`b44ad252`](https://github.com/NixOS/nixpkgs/commit/b44ad252a54bb1bbeb803bac798e488c3b2feb27) | `python310Packages.pycmarkgfm: 1.1.0 -> 1.2.0`                                                |
| [`48026590`](https://github.com/NixOS/nixpkgs/commit/48026590202f3b79e4b66909a2d16ab1778e3fad) | `sub-batch: 1.0.0 -> 1.0.1`                                                                   |
| [`e0e86de3`](https://github.com/NixOS/nixpkgs/commit/e0e86de33fd671db6e589783babfe25829345333) | `plantuml-server: 1.2022.12 -> 1.2022.13`                                                     |
| [`b6bc6d08`](https://github.com/NixOS/nixpkgs/commit/b6bc6d08d0a9943cdc27228e9e59124dca97c333) | `pgbackrest: 2.41 -> 2.42`                                                                    |
| [`81f5aad3`](https://github.com/NixOS/nixpkgs/commit/81f5aad3e4532e36c856eb5e3a52146376a2297e) | `factorio: 1.1.70 -> 1.1.72`                                                                  |
| [`ca063690`](https://github.com/NixOS/nixpkgs/commit/ca063690208864c0b7ba9fc8c04f607f81cd65c5) | `yubioath-desktop: drop as has been replaced by upstream`                                     |
| [`78162b12`](https://github.com/NixOS/nixpkgs/commit/78162b12ca39b075fa35c2bbd1757f50d0d5f4e1) | `opentelemetry-collector-contrib: 0.64.0 -> 0.65.0`                                           |
| [`7ee71825`](https://github.com/NixOS/nixpkgs/commit/7ee71825071e8a370698f68a68ac743742213c69) | `libretro: unstable-2022-10-18 -> unstable-2022-11-21`                                        |
| [`cdcb7946`](https://github.com/NixOS/nixpkgs/commit/cdcb7946baf70b37b81c3579e0827d9138142502) | `veryfasttree: init at 3.1.1`                                                                 |
| [`0582bcd3`](https://github.com/NixOS/nixpkgs/commit/0582bcd382067102617c38438253af7ba3e1882d) | `python310Packages.generic: 1.1.0 -> 1.1.1`                                                   |
| [`5ca57377`](https://github.com/NixOS/nixpkgs/commit/5ca573772c30154f5c912edfd51951aa811fa34f) | `filtron: converted to goPackage.`                                                            |
| [`35d3a6fa`](https://github.com/NixOS/nixpkgs/commit/35d3a6fa79a1a7bee909db00734392a0d657d817) | `muscle: add myself to maintainers`                                                           |
| [`d7c8595f`](https://github.com/NixOS/nixpkgs/commit/d7c8595f622939bdbd70e1aaf3989cdb21f3d764) | `muscle: 3.8.31 -> 5.1.0`                                                                     |
| [`433ba342`](https://github.com/NixOS/nixpkgs/commit/433ba342ee7f86bd7c928861aca091460d4c9590) | `moq: 0.2.7 -> 0.3.0`                                                                         |
| [`700aa487`](https://github.com/NixOS/nixpkgs/commit/700aa487d5714c6098e7ec2974a679ebbcd7e4a2) | `miniplayer: 1.7.1 -> 1.7.3`                                                                  |
| [`5b9b6dee`](https://github.com/NixOS/nixpkgs/commit/5b9b6dee86550b483ac4af6c31cd1b935db85858) | `seahub: fix build`                                                                           |
| [`b42d97f5`](https://github.com/NixOS/nixpkgs/commit/b42d97f572ed427bb420652015378541164e18dd) | `emacs: build pgtk variant with full image support`                                           |
| [`669067ed`](https://github.com/NixOS/nixpkgs/commit/669067ed047e1a1f5c1ee7f17f4055e7b1d3c99d) | `netlify-cli: update release note for updating netlify-cli`                                   |
| [`b04fe397`](https://github.com/NixOS/nixpkgs/commit/b04fe397c6183f4749d4d8d0f853179051808bee) | `esbuild_netlify: fix trailing space in esbuild_netlify`                                      |
| [`ae83b9c7`](https://github.com/NixOS/nixpkgs/commit/ae83b9c7c656f4556ff2af3115d13aa90742d527) | `netlify-cli: 6.13.2 -> 12.2.4`                                                               |
| [`63a66fc2`](https://github.com/NixOS/nixpkgs/commit/63a66fc2ff036710a4b4bbf3511e69a09fcbb6f6) | `esbuild_netlify: 0.13.6 -> 0.14.39`                                                          |
| [`f904a646`](https://github.com/NixOS/nixpkgs/commit/f904a646c3f85147ef48e70a8d241cbf7a1b1a69) | `do-agent: 3.13.1 -> 3.14.1`                                                                  |
| [`6492d646`](https://github.com/NixOS/nixpkgs/commit/6492d64628390ea421829b15e6f19626657df01d) | `chromiumDev: 109.0.5410.0 -> 109.0.5414.10`                                                  |
| [`3fbd8b76`](https://github.com/NixOS/nixpkgs/commit/3fbd8b76110b587cd04678e3f43b83b40dda7ce7) | `libretro-core-info: 1.12.0 -> 1.13.0`                                                        |
| [`a2387066`](https://github.com/NixOS/nixpkgs/commit/a238706683907dbd009f1ebf5788e13508db77ea) | `retroarchBare: 1.12.0 -> 1.13.0`                                                             |
| [`3520a6df`](https://github.com/NixOS/nixpkgs/commit/3520a6df8fb34dd01e4e70f87bf4a1f500daef53) | `python310Packages.imap-tools: 0.57.0 -> 1.0.0`                                               |
| [`4a1f0598`](https://github.com/NixOS/nixpkgs/commit/4a1f0598b26907a445d9facc36b3a795072fa664) | `python310Packages.fiona: disable failing test`                                               |
| [`50f24d3b`](https://github.com/NixOS/nixpkgs/commit/50f24d3b9798d7e063df4d2a8178b88b3a9635c0) | `gdal: 3.5.2 -> 3.6.0.1`                                                                      |
| [`7295e4a7`](https://github.com/NixOS/nixpkgs/commit/7295e4a728a8c1934981795a461b95ddc94ef2f2) | `lerc: 3.0 -> 4.0.0`                                                                          |
| [`2beff937`](https://github.com/NixOS/nixpkgs/commit/2beff9375cda53f2ab42844eb85d9c60175f3434) | ``nixos/picom: add `egl` backend to options``                                                 |
| [`51119b87`](https://github.com/NixOS/nixpkgs/commit/51119b8759e18fc6bf2ecfab16120d90fa156d4a) | `minio-client: 2022-11-07T23-47-39Z -> 2022-11-17T21-20-39Z`                                  |
| [`e872c300`](https://github.com/NixOS/nixpkgs/commit/e872c30015a6427a6d5e926889616ec3644cfcf4) | `linuxPackages.nvidia_x11_vulkan_beta: 515.49.24 -> 515.49.25`                                |
| [`339f7258`](https://github.com/NixOS/nixpkgs/commit/339f72586a39bbffb5b149bd5367d971349796a4) | `giac: 1.9.0-5 -> 1.9.0-29`                                                                   |
| [`a9db54b7`](https://github.com/NixOS/nixpkgs/commit/a9db54b790ad3f0631c618db02084bfb346d7661) | `hyprland, hyprpaper: fix build on aarch64-linux`                                             |
| [`78c09ae1`](https://github.com/NixOS/nixpkgs/commit/78c09ae1423b4fc663d35874d61307ecfcd13d24) | `python310Packages.sgp4: remove tox`                                                          |
| [`f88afab6`](https://github.com/NixOS/nixpkgs/commit/f88afab66348db57290e953a8d7c9a84b7d2d8af) | `pulumiPackages.pulumi-azure-native: 1.81.0 -> 1.85.0`                                        |
| [`5452a260`](https://github.com/NixOS/nixpkgs/commit/5452a260774ac78d71232896aa69734ed1e9607a) | `nixos/lvm: replace boot.isContainer with services.lvm.enable`                                |
| [`faa599ce`](https://github.com/NixOS/nixpkgs/commit/faa599ced67936ce4746b549a8b6dde8af3e003c) | `springLobby: reformat`                                                                       |
| [`dd9aa5d6`](https://github.com/NixOS/nixpkgs/commit/dd9aa5d6c948fc9f6955d9d271e868beee773840) | `dolphin-emu: add aarch64-linux support`                                                      |
| [`c985936c`](https://github.com/NixOS/nixpkgs/commit/c985936c3949f840c99f13b4a7e9a890ea0e342c) | `pwsafe: migrate to wxGTK30-gtk3`                                                             |
| [`827ea229`](https://github.com/NixOS/nixpkgs/commit/827ea229e7b55d3c0eb7fddd1429519979798d29) | `sooperlooper: migrate to wxGTK30-gtk3`                                                       |
| [`ac92d9c5`](https://github.com/NixOS/nixpkgs/commit/ac92d9c5b924026b4a73fe09b464e7aea4ea4c79) | `urbackup-client: 2.4.11 -> 2.5.20`                                                           |
| [`b2c5490f`](https://github.com/NixOS/nixpkgs/commit/b2c5490fdfdc6127d212e2c9890fd51a6e6824ed) | `flamerobin: 0.9.3.1 -> 0.9.3.12`                                                             |
| [`6760c8b4`](https://github.com/NixOS/nixpkgs/commit/6760c8b488cebb19b80ddbed0d2b1f5d71398913) | `lenmus: unbreak on aarch64-linux`                                                            |
| [`e0e6444e`](https://github.com/NixOS/nixpkgs/commit/e0e6444e5058a9de3d555df5be9dc15e52b9a924) | `boinc: unbreak on aarch64-linux`                                                             |
| [`62104560`](https://github.com/NixOS/nixpkgs/commit/62104560c436896e5d06d531c5d1033b63c0ee5f) | `jetbrains.mps: Fix build`                                                                    |
| [`78452c78`](https://github.com/NixOS/nixpkgs/commit/78452c78f37c63cff11886a3a198a286e5803950) | `jetbrains.mps: 2021.3.1 -> 2022.2`                                                           |
| [`8b0f29d8`](https://github.com/NixOS/nixpkgs/commit/8b0f29d8bb6b5fa3f83dfee1d00bd02c63feb771) | `python310Packages.fireflyalgorithm: 0.3.2 -> 0.3.3`                                          |
| [`7f0b7f4c`](https://github.com/NixOS/nixpkgs/commit/7f0b7f4cf3c1bee6f1b2bc20d117ebc13daa04f2) | `fityk: migrate to wxGTK32`                                                                   |
| [`b20b3bde`](https://github.com/NixOS/nixpkgs/commit/b20b3bde80a6455bcd60dfe805883b4a8622e9d7) | `xylib: migrate to wxGTK32`                                                                   |
| [`d0a03f4c`](https://github.com/NixOS/nixpkgs/commit/d0a03f4c6892d857fc82935d2915568a21613b98) | `xchm: migrate to wxGTK32`                                                                    |
| [`0a2b4e72`](https://github.com/NixOS/nixpkgs/commit/0a2b4e72f9846e9b3ba4a4fed65110d9663337f0) | `electricsheep: migrate to wxGTK32`                                                           |
| [`906c2a94`](https://github.com/NixOS/nixpkgs/commit/906c2a94866bb8685100f040fcd5c549fc5f7e63) | `odamex: migrate to wxGTK32`                                                                  |
| [`24b4cfb8`](https://github.com/NixOS/nixpkgs/commit/24b4cfb8800e56b3fb092430e70e030af52a9e57) | `vexctl: init at 0.0.2`                                                                       |
| [`ff81b059`](https://github.com/NixOS/nixpkgs/commit/ff81b059498dc691464906478a6608c8c9d7c150) | `furtherance: init at 1.6.0`                                                                  |
| [`d0e7f4d5`](https://github.com/NixOS/nixpkgs/commit/d0e7f4d5ed44b1676ca7152918f05308f865c142) | `maintainers: add CaptainJawZ`                                                                |