### PR TITLE
chore(flake/nixpkgs): `27ccd290` -> `a115bb9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669320964,
-        "narHash": "sha256-EBFw+ge12Pcr3qCk8If3/eMBAoQLR7ytndXZoRevUtM=",
+        "lastModified": 1669542132,
+        "narHash": "sha256-DRlg++NJAwPh8io3ExBJdNW7Djs3plVI5jgYQ+iXAZQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "27ccd29078f974ddbdd7edc8e38c8c8ae003c877",
+        "rev": "a115bb9bd56831941be3776c8a94005867f316a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                         |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`94d6c732`](https://github.com/NixOS/nixpkgs/commit/94d6c732d1d11df8916ef17406ae0827d29e94fa) | `dockerTools: fixup evaluation without allowed aliases`                                |
| [`0e3813f4`](https://github.com/NixOS/nixpkgs/commit/0e3813f46eb12b1b5aaa061e571b57dcfb8d1da5) | `maestral-qt: set mainProgram and changelog meta attributes`                           |
| [`81b938da`](https://github.com/NixOS/nixpkgs/commit/81b938da81e0480cbf37cce6cab5085603c79bf3) | `python310Packages.flake8-import-order: switch to pytestCheckHook`                     |
| [`0167b310`](https://github.com/NixOS/nixpkgs/commit/0167b31088dd2d763cdb9986d3b70b8387daddb2) | `python310Packages.flake8-import-order: add changelog to meta`                         |
| [`fcb17f33`](https://github.com/NixOS/nixpkgs/commit/fcb17f332dd1dad6b19d66dbbeab7f61da34116c) | `python310Packages.geomet: add changelog to meta`                                      |
| [`91e5b08e`](https://github.com/NixOS/nixpkgs/commit/91e5b08e071d7903d863e031c432c4485aca7c48) | `python310Packages.hvplot: add changelog to meta`                                      |
| [`44bdf18f`](https://github.com/NixOS/nixpkgs/commit/44bdf18ff03657594b985479c56fc43e203c37ed) | `python310Packages.globus-sdk: add changelog to meta`                                  |
| [`ea5f3981`](https://github.com/NixOS/nixpkgs/commit/ea5f398131d14d11b8b8d602f262bfd7a8b1a947) | `python310Packages.holidays: add changelog to meta`                                    |
| [`d6b142e5`](https://github.com/NixOS/nixpkgs/commit/d6b142e587033d77acc26fa2950a3255fa152d85) | `python310Packages.homematicip: update disabled`                                       |
| [`486bdc8c`](https://github.com/NixOS/nixpkgs/commit/486bdc8c5fd8e203ac28e2bc2abc3660fa756798) | `python310Packages.homematicip: add changelog to meta`                                 |
| [`7c424020`](https://github.com/NixOS/nixpkgs/commit/7c424020f4091068b169ce40f75408f4bb760762) | `home-assistant.python.pkgs.arcam-fmj: fix tests`                                      |
| [`3441f255`](https://github.com/NixOS/nixpkgs/commit/3441f255db276969373b589ed54e5df8b0bcdf02) | `python310Packages.cryptography: remove unused patch`                                  |
| [`57624eb2`](https://github.com/NixOS/nixpkgs/commit/57624eb28bb5653d528071ffc986b2d1d215cc02) | `simdjson: 3.0.0 -> 3.0.1`                                                             |
| [`456c5a49`](https://github.com/NixOS/nixpkgs/commit/456c5a49fb0e9c993444fa90bc7a3f2b1a15e2d3) | `python310Packages.hvplot: 0.8.1 -> 0.8.2`                                             |
| [`05198111`](https://github.com/NixOS/nixpkgs/commit/05198111c2b7ba69f105f0526b2e826bfaf9e1e6) | `nats-server: 2.9.7 -> 2.9.8`                                                          |
| [`864961cd`](https://github.com/NixOS/nixpkgs/commit/864961cdd0d03c64e9882c551401302c14f3d727) | `netbird: 0.10.9 -> 0.11.1`                                                            |
| [`dac7bf35`](https://github.com/NixOS/nixpkgs/commit/dac7bf3553bc811d0b854f83e85e348fe8623550) | `python310Packages.homematicip: 1.0.9 -> 1.0.10`                                       |
| [`039d874f`](https://github.com/NixOS/nixpkgs/commit/039d874f0b93ad10e77995a340b2d3ee55497562) | `perf-linux: tweak make flags to supress build warnings`                               |
| [`143d998c`](https://github.com/NixOS/nixpkgs/commit/143d998c5080c5e477a97c7e1922afe0c2646331) | `python310Packages.holidays: 0.17 -> 0.17.2`                                           |
| [`adf495bd`](https://github.com/NixOS/nixpkgs/commit/adf495bd32734b99d78d46af48be4ee656574a37) | `oh-my-posh: 12.17.2 -> 12.20.0`                                                       |
| [`104ba49a`](https://github.com/NixOS/nixpkgs/commit/104ba49a93e1d01e6779e82bb4856f5821d0315b) | `luaPackages.sqlite: fix build on darwin`                                              |
| [`03694db5`](https://github.com/NixOS/nixpkgs/commit/03694db503b7e1710813ef4e89751868ef7729b7) | `moodle: reference nixos test in passthru.tests`                                       |
| [`5193b878`](https://github.com/NixOS/nixpkgs/commit/5193b8781ed24da4a19a4f3b3cc8e366cd79e296) | `picom: 10 -> 10.1`                                                                    |
| [`1b4e26ff`](https://github.com/NixOS/nixpkgs/commit/1b4e26ffd1ecef5cf2d09263ec100e4fe4f38644) | `ostree: 2022.6 -> 2022.7`                                                             |
| [`9e6b0545`](https://github.com/NixOS/nixpkgs/commit/9e6b054555c9b10310543cd213ce7c70bb0cbc5f) | `lxpanel: don't use alias libwnck3`                                                    |
| [`8d4f1b71`](https://github.com/NixOS/nixpkgs/commit/8d4f1b71ed0f0569eae5bff9648ebbe8af47bb9d) | `python310Packages.globus-sdk: 3.14.0 -> 3.15.0`                                       |
| [`405d6cc4`](https://github.com/NixOS/nixpkgs/commit/405d6cc4c952a374b11bea3b0aa19382a6204380) | `python310Packages.geomet: 0.3.1 -> 1.0.0`                                             |
| [`fdcf31c5`](https://github.com/NixOS/nixpkgs/commit/fdcf31c5087695a425d5338729ab57e1b2f851ec) | `nixpacks: 0.14.0 -> 0.15.0`                                                           |
| [`46189b54`](https://github.com/NixOS/nixpkgs/commit/46189b54a8d86df8604e8990221b4f200427d5dd) | `python310Packages.pygmars: 0.7.0 -> 0.8.0`                                            |
| [`3490efd2`](https://github.com/NixOS/nixpkgs/commit/3490efd24580dff7842e6ded16bb63a110183aae) | `python310Packages.pygmars: add changelog to meta`                                     |
| [`272ac9ec`](https://github.com/NixOS/nixpkgs/commit/272ac9ec64020808b88a1ddeee13f38cb929c22b) | `kanidm: add release not for tls requirement`                                          |
| [`887020f3`](https://github.com/NixOS/nixpkgs/commit/887020f39cca2dc5464ff2a6350d8681543dc769) | `nixos/kanidm: Add tls options`                                                        |
| [`72779c7b`](https://github.com/NixOS/nixpkgs/commit/72779c7b0f882c4e0dcfc375b723802437caefba) | `kanidm: 1.1.0-alpha.9 -> 1.1.0-alpha.10`                                              |
| [`5c919060`](https://github.com/NixOS/nixpkgs/commit/5c919060187996255e56212f2c8e737fead9eadb) | `python310Packages.flake8-import-order: 0.18.1 -> 0.18.2`                              |
| [`03bf7734`](https://github.com/NixOS/nixpkgs/commit/03bf773416a07b6586c1d76864f2d782a462ea70) | `shellhub-agent: 0.10.4 -> 0.10.8`                                                     |
| [`a548967a`](https://github.com/NixOS/nixpkgs/commit/a548967a87091df02afcc87ca088a9139812a801) | `screenfetch: update pname to reflect attribute path and executable name`              |
| [`c516529a`](https://github.com/NixOS/nixpkgs/commit/c516529ad36112e4ce5ccd35ac73d62f0bce3d2b) | ` python310Packages.discord.py: add changelog to meta`                                 |
| [`9c2970e8`](https://github.com/NixOS/nixpkgs/commit/9c2970e8fc1a93cb21742949b118469b6fa8268e) | ` python310Packages.diff-cover: add changelog to meta`                                 |
| [`41dbacdc`](https://github.com/NixOS/nixpkgs/commit/41dbacdcd87ae38cf4e5f0273691b066b48c748b) | `linuxKernel.kernels.linux_zen: 6.0.8-zen1 -> 6.0.10-zen2`                             |
| [`55a5d40e`](https://github.com/NixOS/nixpkgs/commit/55a5d40e4813912e2e44ebcdf966aa926f11b7bf) | `miniplayer: 1.7.3 -> 1.8.1`                                                           |
| [`1b5ad594`](https://github.com/NixOS/nixpkgs/commit/1b5ad5946f42dd41abcf6c88de1670c96ebd271d) | `linuxKernel.kernels.linux_lqx: 6.0.8 -> 6.0.10`                                       |
| [`c14f1f71`](https://github.com/NixOS/nixpkgs/commit/c14f1f71b1da47c660569e4de50c09eba909869c) | `nsis: mark broken on Darwin`                                                          |
| [`d1b6d2d0`](https://github.com/NixOS/nixpkgs/commit/d1b6d2d0ab89b4a5e58d0020500445b0c9c73a4e) | `haskellPackages.callHackage: updating all-cabal-hashes do not invalidate callHackage` |
| [`68d4c769`](https://github.com/NixOS/nixpkgs/commit/68d4c769dac457843f923f63cbe4c9ccee53b8d7) | `blitz: 1.0.1 -> 1.0.2`                                                                |
| [`2b149526`](https://github.com/NixOS/nixpkgs/commit/2b149526b66650bc77e4ffcb1906c882edd55ebd) | `discord.py: 2.0.1 -> 2.1.0`                                                           |
| [`9d44d086`](https://github.com/NixOS/nixpkgs/commit/9d44d08620474ecc8be6aaf7dfe6020693551229) | `python310Packages.diff-cover: 7.0.2 -> 7.1.0`                                         |
| [`ee382fe4`](https://github.com/NixOS/nixpkgs/commit/ee382fe49f25e3913483769bd05ea54dbd8b4a40) | `moodle: 4.0.4 -> 4.0.5`                                                               |
| [`a39a869c`](https://github.com/NixOS/nixpkgs/commit/a39a869cac6d40c301affca3b54b3b48ea2a1b19) | `multipath-tools: 0.8.3 -> 0.9.3`                                                      |
| [`0ec9112c`](https://github.com/NixOS/nixpkgs/commit/0ec9112cf45a7f18eb8a64b92604dc80d7e9e94d) | `  python310Packages.cloudscraper: add changelog to meta`                              |
| [`1f10a3cd`](https://github.com/NixOS/nixpkgs/commit/1f10a3cd02f04fd6436cc7bb2df76c22b35f1aad) | `python310Packages.pydeps: 1.10.24 -> 1.11.0`                                          |
| [`804a42b1`](https://github.com/NixOS/nixpkgs/commit/804a42b1da2b919492c00cf17bd4f7f7eaca7d6e) | `python310Packages.pydeps: add changelog to meta`                                      |
| [`cfc3633d`](https://github.com/NixOS/nixpkgs/commit/cfc3633d9ec85292cdd8f84d3f8a99154aa3e9bd) | `python310Packages.cloudscraper: 1.2.65 -> 1.2.66`                                     |
| [`ae03537f`](https://github.com/NixOS/nixpkgs/commit/ae03537f743a9535a59f3b2d3566f0c96e65dd8b) | `libreddit: add changelog to meta`                                                     |
| [`2abf4e59`](https://github.com/NixOS/nixpkgs/commit/2abf4e596782dfd9b96e3abe1c9cb7bc4091ed59) | `python3Packages.acoustics: fix build`                                                 |
| [`59a3d645`](https://github.com/NixOS/nixpkgs/commit/59a3d645276e3c8a0611a42b1c50c2de74ca010c) | `gopass-summon-provider: 1.14.9 -> 1.14.11`                                            |
| [`9cdfa2c7`](https://github.com/NixOS/nixpkgs/commit/9cdfa2c7b39f94362353390a5541b12ce361eb83) | `gopass-jsonapi: 1.14.9  -> 1.14.11`                                                   |
| [`0caee1f0`](https://github.com/NixOS/nixpkgs/commit/0caee1f096f51a76bf6d2049eba306abbf762844) | `gopass-hibp: 1.14.9 -> 1.14.11`                                                       |
| [`2322d20c`](https://github.com/NixOS/nixpkgs/commit/2322d20caae21113bfd0a5911307b68eaa564f2a) | `git-credential-gopass: 1.14.9 -> 1.14.11`                                             |
| [`bb943eae`](https://github.com/NixOS/nixpkgs/commit/bb943eae8f65d84cd19f71108ab300c1d82b4ce5) | `gleam: 0.24.0 -> 0.25.0`                                                              |
| [`17c497d2`](https://github.com/NixOS/nixpkgs/commit/17c497d2e04f0e7aa77708a9545cb403d3881d2f) | `mkpasswd: enable on darwin`                                                           |
| [`260d2c71`](https://github.com/NixOS/nixpkgs/commit/260d2c71447bf1ec197b9cb743d40953cbd7b82d) | `python310Packages.pytest-mypy-plugins: disable faling tests`                          |
| [`dbf1f2fc`](https://github.com/NixOS/nixpkgs/commit/dbf1f2fcee6907e0b4a6277b69791cd73a4b1a78) | `python310Packages.jaxlib-bin: add support for x86_64 on macos`                        |
| [`12f096b3`](https://github.com/NixOS/nixpkgs/commit/12f096b354bc8ef7a3e76b4036e041e8c8a6364e) | `python310Packages.fastapi-mail: 1.2.1 -> 1.2.2`                                       |
| [`26efe9da`](https://github.com/NixOS/nixpkgs/commit/26efe9da92e0f482d4b93a251b5857f68d0dcfa4) | `python310Packages.aioquic: fix build`                                                 |
| [`54434fef`](https://github.com/NixOS/nixpkgs/commit/54434fef794d0de57b6f02fbfc7239b250900617) | `python310Packages.python-utils: don't run mypy`                                       |
| [`57041d44`](https://github.com/NixOS/nixpkgs/commit/57041d44e8d42ac173ecf061472171c14aa6cc32) | `lagrange: 1.13.8 → 1.14.1`                                                            |
| [`318bfb70`](https://github.com/NixOS/nixpkgs/commit/318bfb7018723cdc529aca8a1aa98e1cced2e84c) | `libreddit: 0.24.0 -> 0.24.1`                                                          |
| [`9da870c4`](https://github.com/NixOS/nixpkgs/commit/9da870c45d82307e05838cf91c57372deaf10e20) | `python310Packages.types-colorama: 0.4.15.3 -> 0.4.15.4`                               |
| [`f0036c0c`](https://github.com/NixOS/nixpkgs/commit/f0036c0c1ce429fe93d14b23aae483e9ad35c22a) | `python310Packages.types-setuptools: 65.5.0.3 -> 65.6.0.0`                             |
| [`7b9b2227`](https://github.com/NixOS/nixpkgs/commit/7b9b222763f3ab3046fe3d2759e14535e080a0bc) | `nixos/doc: update RL entry for GNAT update`                                           |
| [`a4631004`](https://github.com/NixOS/nixpkgs/commit/a4631004dc0a1ae3d296b5660168c7782b8aa8d5) | `python310Packages.pyskyqremote: 0.3.20 -> 0.3.21`                                     |
| [`95f11588`](https://github.com/NixOS/nixpkgs/commit/95f1158868c91d98414ac0ab95419a130e1528ee) | `python310Packages.pyskyqremote: add changelog to meta`                                |
| [`a63ffb18`](https://github.com/NixOS/nixpkgs/commit/a63ffb18cbea25f8dbe7d7f83600d293842d8176) | `asc: 2.6.0.0 -> 2.6.3.0`                                                              |
| [`283ec701`](https://github.com/NixOS/nixpkgs/commit/283ec701d914dcb651e2618929bb67f21b0a1c59) | `graphinder: add changelog to meta`                                                    |
| [`0e8992eb`](https://github.com/NixOS/nixpkgs/commit/0e8992eb4fcb96369f3272d23c3322629e86908f) | `python310Packages.ansible-doctor: add changelog to meta`                              |
| [`f94c2bbf`](https://github.com/NixOS/nixpkgs/commit/f94c2bbff477c51c066e1745697d608792036157) | `gostatic: 2.34 -> 2.35`                                                               |
| [`fd257cf0`](https://github.com/NixOS/nixpkgs/commit/fd257cf0246982297bce13109044050cc99d9dc9) | `kops: 1.25.2 -> 1.25.3 (#203024)`                                                     |
| [`cc53a6e0`](https://github.com/NixOS/nixpkgs/commit/cc53a6e072cbb0d1af9f0ba8054771814cf78ed8) | `libsidplayfp: 2.4.0 -> 2.4.1`                                                         |
| [`402a7d17`](https://github.com/NixOS/nixpkgs/commit/402a7d1791a97bec87462d4c4530b1a995c8060e) | `llama: 1.1.1 -> 1.2.0`                                                                |
| [`c4668743`](https://github.com/NixOS/nixpkgs/commit/c466874324316748652e9818e4c77ffbcfe1035b) | `phrase-cli: 2.5.4 -> 2.6.0`                                                           |
| [`fc88f71d`](https://github.com/NixOS/nixpkgs/commit/fc88f71dfe3409207d23a336b29d54008bc289e3) | `ascii-image-converter: 1.13.0 -> 1.13.1`                                              |
| [`bc74a90a`](https://github.com/NixOS/nixpkgs/commit/bc74a90ab97cc511bd99397eeb8374f9fa2be9ce) | `pandoc-katex: 0.1.9 -> 0.1.10`                                                        |
| [`a7cc99f1`](https://github.com/NixOS/nixpkgs/commit/a7cc99f1cd2105dc126df563c096223bd32f59be) | `fluxcd: 0.36.0 -> 0.37.0`                                                             |
| [`d37b3593`](https://github.com/NixOS/nixpkgs/commit/d37b3593d00ae27c0aedbc755063fc0327fd334f) | `charge-lnd: 0.2.12 -> 0.2.13`                                                         |
| [`5775813f`](https://github.com/NixOS/nixpkgs/commit/5775813f70bfd509eb1cb3896e1574c3bbbfa6b3) | `httping: pull upstream fix for darwin`                                                |
| [`47813a32`](https://github.com/NixOS/nixpkgs/commit/47813a3214efbfac32fc09e491e32d95d1b9cb32) | `nixos/tests: Make pure`                                                               |
| [`2cd3223e`](https://github.com/NixOS/nixpkgs/commit/2cd3223ea2554f95b51b50b02ae733ab93f7ba6f) | `opensnitch: Fix build with Go > 1.17`                                                 |
| [`f7297a58`](https://github.com/NixOS/nixpkgs/commit/f7297a58ec07ce1cb3afb8f40f8d6bac878428f9) | `python310Packages.skodaconnect: 1.1.26 -> 1.1.27`                                     |
| [`ae466ee0`](https://github.com/NixOS/nixpkgs/commit/ae466ee0acf8da56e5b47c9f88f48982223d0424) | `phosh-mobile-settings: init at 0.21.1`                                                |
| [`ce2661d4`](https://github.com/NixOS/nixpkgs/commit/ce2661d427022e982a988e8eb17658837355e383) | `python310Packages.skodaconnect: add changelog to meta`                                |
| [`c446feba`](https://github.com/NixOS/nixpkgs/commit/c446feba9b44a08681a110418195564921de7954) | `pcm: 202112 -> 202211`                                                                |
| [`b3e4d33a`](https://github.com/NixOS/nixpkgs/commit/b3e4d33aa2e0825157426b4da45027060983192d) | `phosh: 0.21.1 -> 0.22.0`                                                              |
| [`cc16ce59`](https://github.com/NixOS/nixpkgs/commit/cc16ce5945a58c207f13b67256b58433f1c1f576) | `nixos/tests/phosh: add subtest to check the on-screen keyboard`                       |
| [`6e51090e`](https://github.com/NixOS/nixpkgs/commit/6e51090efdd911078659d4e8ade8966c2e8f4edc) | `graphinder: 1.11.5 -> 1.11.6`                                                         |
| [`a3b440bc`](https://github.com/NixOS/nixpkgs/commit/a3b440bccbab102604639b227fb9cdc9ca4ccb74) | `python310Packages.ansible-doctor: 1.4.6 -> 1.4.7`                                     |
| [`6b01bd96`](https://github.com/NixOS/nixpkgs/commit/6b01bd9625ab356bbe37b56c90c90c8277a0272f) | `python310Packages.python-mystrom: 2.0.0 -> 2.1.0`                                     |
| [`9d3cb250`](https://github.com/NixOS/nixpkgs/commit/9d3cb2503780701c13313f050f930760d08ed3dd) | `python310Packages.python-mystrom: add changelog to meta`                              |
| [`ff883d25`](https://github.com/NixOS/nixpkgs/commit/ff883d2557013b5cc1dad788eba5abf4e4975da5) | `the-foundation: 1.4.0 → 1.5.0`                                                        |
| [`af93fbde`](https://github.com/NixOS/nixpkgs/commit/af93fbdeb3845b1b290886a99797fe0a5d20801a) | `python310Packages.appthreat-vulnerability-db: 3.0.2 -> 4.0.0`                         |
| [`f5afc031`](https://github.com/NixOS/nixpkgs/commit/f5afc0316f00a46c66beac7cf9a384a482f72b46) | `gdown: add changelog to meta`                                                         |
| [`41ad2282`](https://github.com/NixOS/nixpkgs/commit/41ad2282d50aa84149a1c13fb014a592dfe4d823) | `python310Packages.aioesphomeapi: add changelog to meta`                               |
| [`5126917d`](https://github.com/NixOS/nixpkgs/commit/5126917dd1816c16f9ef7966f02f71dd832b2ae5) | `python310Packages.aioesphomeapi: 11.5.0 -> 12.0.0`                                    |
| [`6b867596`](https://github.com/NixOS/nixpkgs/commit/6b86759692b80e2b563e7f6c608f753de4aad3a7) | `pkgsMusl.libavc1394: fix build (#202848)`                                             |
| [`941bfb19`](https://github.com/NixOS/nixpkgs/commit/941bfb199752ee56f2e1c091661aec534aa2d0ae) | `gdown: 4.5.3 -> 4.5.4`                                                                |
| [`d879df2d`](https://github.com/NixOS/nixpkgs/commit/d879df2d3c39a3410198613dafb635bc9e6577e4) | `firecracker: 1.1.2 -> 1.1.3`                                                          |
| [`553446fd`](https://github.com/NixOS/nixpkgs/commit/553446fdd356d0aeaf84280f74863e744a41ec4c) | `gostatic: init at 2.34`                                                               |
| [`8277e100`](https://github.com/NixOS/nixpkgs/commit/8277e100670482a6751a7cb46358fc9507d2a42b) | `fluent-bit: 2.0.5 -> 2.0.6`                                                           |
| [`8aa0e6b8`](https://github.com/NixOS/nixpkgs/commit/8aa0e6b874bb76a080b13763e3530fd64a620581) | `pmbootstrap: 1.45.0 -> 1.50.0`                                                        |
| [`8da3d1fd`](https://github.com/NixOS/nixpkgs/commit/8da3d1fdf1d90828861e1941b6086384c6a6c8b6) | `evcc: 0.107.1 -> 0.108.0`                                                             |
| [`760fc381`](https://github.com/NixOS/nixpkgs/commit/760fc381fffad133908545bab32201c848290cf0) | `python310Packages.catboost: don't depend on python2`                                  |
| [`be1fe08f`](https://github.com/NixOS/nixpkgs/commit/be1fe08f79c0589452bf50a4fb36bbe2af5d24b8) | `surelog: use latest OpenJDK`                                                          |
| [`6d5896b6`](https://github.com/NixOS/nixpkgs/commit/6d5896b6476873ff3aaa39461d05aeabce99d7c7) | `swiften: 4.0.2 -> 4.0.3`                                                              |
| [`cc4a9ced`](https://github.com/NixOS/nixpkgs/commit/cc4a9cedba6a5a8f6ffd60727f66597fee53a73c) | `python310Packages.svg2tikz: 1.0.0 -> unstable-2021-01-12`                             |
| [`1710b52c`](https://github.com/NixOS/nixpkgs/commit/1710b52c6eefdb8434a63951d0e3a35bde4adb02) | `rubyPackages.libv8: use python3`                                                      |
| [`26c8738f`](https://github.com/NixOS/nixpkgs/commit/26c8738f3a76e2bb675979c1dbf474c8dae726eb) | `reptyr: run tests using python3`                                                      |
| [`1029d3a6`](https://github.com/NixOS/nixpkgs/commit/1029d3a644e2fe6616c72960bb64e6aa230432ea) | `nsis: build using python3`                                                            |
| [`2afac7a2`](https://github.com/NixOS/nixpkgs/commit/2afac7a20c199d8cbd2645597c02beb5edfa7614) | `terraform-providers.vcd: 3.7.0 → 3.8.0`                                               |
| [`f6c8b816`](https://github.com/NixOS/nixpkgs/commit/f6c8b8160a23c0cdec79440ff69b3ec1c3776afc) | `terraform-providers.gitlab: 3.19.0 → 3.20.0`                                          |
| [`bfd0306a`](https://github.com/NixOS/nixpkgs/commit/bfd0306a32c5422257ef1c7b8d6a8fbbce43b71a) | `mucommander: use latest JDK`                                                          |
| [`e61cc2ab`](https://github.com/NixOS/nixpkgs/commit/e61cc2ab0265dbc52f4a8ec7b019710545e6d577) | `lxpanel: use gtk3 by default`                                                         |
| [`01fbceac`](https://github.com/NixOS/nixpkgs/commit/01fbceac87d6eca4b23a932bdabe28343eb7e6af) | `kotlin-language-server: use latest OpenJDK`                                           |
| [`1c9df7e8`](https://github.com/NixOS/nixpkgs/commit/1c9df7e848341fe52f4bce80f945f5073425e14b) | `klipper-flash: use python3`                                                           |
| [`02677fc1`](https://github.com/NixOS/nixpkgs/commit/02677fc1e182a5d0611eea043265e9fdf5d54c27) | `klipper-firmware: use python3 only`                                                   |
| [`03ecfc46`](https://github.com/NixOS/nixpkgs/commit/03ecfc4682421cc4f06c2db1ab3e8a1342de3831) | `klipper-genconf: use python3`                                                         |
| [`693f50b9`](https://github.com/NixOS/nixpkgs/commit/693f50b9bde524c56eeb5e41430c70c21f203b54) | `purple-plugin-pack: 2.7.0 -> 2.8.0`                                                   |
| [`e2b62ea7`](https://github.com/NixOS/nixpkgs/commit/e2b62ea76cb8ae2f57bcdfd72b4497634c2f8860) | `appimageTools.wrapType2: passthru src to make nix-update work`                        |
| [`de41c714`](https://github.com/NixOS/nixpkgs/commit/de41c7145ccda790fe2a7cffb3fb6e5b28e2e190) | `appthreat-depscan: 3.1.1 -> 3.2.0`                                                    |
| [`b99f5f53`](https://github.com/NixOS/nixpkgs/commit/b99f5f5301c588149454b0c8538ca15cff52c8ae) | `pipewire: remove unused inputs`                                                       |
| [`ad21b6fc`](https://github.com/NixOS/nixpkgs/commit/ad21b6fcf87f49c28383e79a9f693a0533f6f6e2) | `mypy: 0.981 -> 0.991`                                                                 |
| [`9e6b1e8c`](https://github.com/NixOS/nixpkgs/commit/9e6b1e8cb4a3fda9518a133a856ecc370122cb8c) | `marwaita: 15.0 -> 16.0`                                                               |
| [`ddf17cf3`](https://github.com/NixOS/nixpkgs/commit/ddf17cf31466060e52713922d6a314b87d140533) | `pythonPackages.types-psutil: init at 5.9.5.5`                                         |