### PR TITLE
chore(flake/home-manager): `62cb5bcf` -> `cc58d319`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669328018,
-        "narHash": "sha256-aJRMobnNDEXKwoSZFS4hGjGU1WDNxkQ82BVKAEohOfY=",
+        "lastModified": 1669509444,
+        "narHash": "sha256-LBH4uPrNxJqLpCHw6ZVyjTn8UEtmyENBOVI5EgRb+NA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "62cb5bcf93896e4dd6b4507dac7ba2e2e3abc9d7",
+        "rev": "cc58d3195342fee3574b5544565696a210d5d5ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`cc58d319`](https://github.com/nix-community/home-manager/commit/cc58d3195342fee3574b5544565696a210d5d5ea) | `flake: Expose tests to allow running purely (#3412)`          |
| [`5c98a8d8`](https://github.com/nix-community/home-manager/commit/5c98a8d8609c9a5b3d1df0a153e3d57ce32e2cef) | `flake.lock: Update (#3403)`                                   |
| [`64f7a775`](https://github.com/nix-community/home-manager/commit/64f7a775175bff9f7d4ba31d7ef425fed494df71) | `polybar: don't generate config if no options are set (#3383)` |
| [`bf99255f`](https://github.com/nix-community/home-manager/commit/bf99255fc9a092ef0272df598ab70eeecc93ca78) | `kitty: silently drop darwin-specific options (#3394)`         |