### PR TITLE
chore(flake/nixos-hardware): `0099253a` -> `7883883d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1669146234,
-        "narHash": "sha256-HEby7EG1yaq1oT2Ze6Cvok9CFju1XHkSvVHmkptLW9U=",
+        "lastModified": 1669650994,
+        "narHash": "sha256-uwASLUfedIQ5q01TtMwZDEV2HCZr5nVPZjzVgCG+D5I=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0099253ad0b5283f06ffe31cf010af3f9ad7837d",
+        "rev": "7883883d135ce5b7eae5dce4bfa12262b85c1c46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`b441875a`](https://github.com/NixOS/nixos-hardware/commit/b441875a5068472e8ee25e3ed237c0be271fa4e7) | `Apply suggestion`                    |
| [`776287c4`](https://github.com/NixOS/nixos-hardware/commit/776287c48330090d26d51c0f0d7dcedd9aeedf98) | `Add some data about the device used` |
| [`56bb7c93`](https://github.com/NixOS/nixos-hardware/commit/56bb7c93b35ffb0d6a6f8dde01bc30d029893825) | `Add Lenovo Legion 5 Pro Gen 6`       |