### PR TITLE
chore(flake/home-manager): `cd2a826f` -> `3b0a446b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669724748,
-        "narHash": "sha256-lXt0GnHogW63B8EQGME9ERkoCPqwUQtOG/qF20clfUw=",
+        "lastModified": 1669740584,
+        "narHash": "sha256-rHxz/olYeCx9GHjJTZElkVCVo4aXaP9FNaQ8oyCLz9A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cd2a826f33ee96f705e8c07b01fd1346b2eccbc0",
+        "rev": "3b0a446bbf29cfeb78e0d1a8210bdf6fae8efccd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                          |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`3b0a446b`](https://github.com/nix-community/home-manager/commit/3b0a446bbf29cfeb78e0d1a8210bdf6fae8efccd) | `ci: autolabel more programs to 'mail'` |
| [`63cef13e`](https://github.com/nix-community/home-manager/commit/63cef13e495776a0e4d8da0cb69554ed4fe70c37) | `pueue: fix for empty settings`         |