### PR TITLE
chore(flake/home-manager): `724395e6` -> `478610aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669780754,
-        "narHash": "sha256-Qy/GG+DVqJNDosrdu6oPUJULfKI5A7FZfI2b4B2Bt3Q=",
+        "lastModified": 1669825171,
+        "narHash": "sha256-HxlZHSiRGXnWAFbIJMeujqBe2KgACYx5XDRY0EA9P+4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "724395e653ca6a917a58587f4587269d17386a44",
+        "rev": "478610aa37c8339eacabfa03f07dacf5574edd47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`478610aa`](https://github.com/nix-community/home-manager/commit/478610aa37c8339eacabfa03f07dacf5574edd47) | `neovim: Source neovimRcContent directly from store (#3444)` |
| [`e38ce0ae`](https://github.com/nix-community/home-manager/commit/e38ce0ae16b68515c913ab50177bc7624f65f569) | `direnv: fix direnv configuration path`                      |