### PR TITLE
chore(flake/pre-commit-hooks): `84dc0bda` -> `471c7f1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -219,11 +219,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1669807480,
-        "narHash": "sha256-MwIcNG1xqkqQSNcQC5x6bFb78/H3r+hc+p7U+Kf3BxM=",
+        "lastModified": 1669829516,
+        "narHash": "sha256-laWMD/TZzyrulu8xLNoSPertXOxjRD7BrcAVwKl+NyQ=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "84dc0bdabbcabf6617797fc43342429bf5bf663f",
+        "rev": "471c7f1ecace25e39099206431300322632d25c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message               |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------- |
| [`5c36747c`](https://github.com/cachix/pre-commit-hooks.nix/commit/5c36747c631083f45984cce3e8bf411183e25ada) | `Add Prettier output option` |
| [`923e4f1f`](https://github.com/cachix/pre-commit-hooks.nix/commit/923e4f1ffde27765c562870735d3c679b8b4f2b6) | `Add typos`                  |