### PR TITLE
chore(flake/nixpkgs): `a115bb9b` -> `b72b8b94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669542132,
-        "narHash": "sha256-DRlg++NJAwPh8io3ExBJdNW7Djs3plVI5jgYQ+iXAZQ=",
+        "lastModified": 1669969257,
+        "narHash": "sha256-mOS13sK3v+kfgP+1Mh56ohiG8uVhLHAo7m/q9kqAehc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a115bb9bd56831941be3776c8a94005867f316a7",
+        "rev": "b72b8b94cf0c012b0252a9100a636cad69696666",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                  |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`642519fe`](https://github.com/NixOS/nixpkgs/commit/642519fe8e4e57a90579287fc7a06864f17b5ecd) | `terraform-providers.utils: 1.5.0 → 1.6.0`                                      |
| [`123764dd`](https://github.com/NixOS/nixpkgs/commit/123764dd8fa94376fca7ed130e7907729fa8d829) | `terraform-providers.tencentcloud: 1.78.15 → 1.78.16`                           |
| [`6ae4eac7`](https://github.com/NixOS/nixpkgs/commit/6ae4eac7fd290af91504dd29924a50e696018762) | `terraform-providers.ucloud: 1.32.5 → 1.33.0`                                   |
| [`6f53ca69`](https://github.com/NixOS/nixpkgs/commit/6f53ca69535db10748397b1cfa64d2eafb23e18d) | `terraform-providers.spotinst: 1.87.0 → 1.87.1`                                 |
| [`4f4a3168`](https://github.com/NixOS/nixpkgs/commit/4f4a3168122f34e3ee098566490097c480ca9bd0) | `terraform-providers.postgresql: 1.17.1 → 1.18.0`                               |
| [`0b71bb7d`](https://github.com/NixOS/nixpkgs/commit/0b71bb7db6d74be267fc1cc763907cc63c23433a) | `terraform-providers.newrelic: 3.7.1 → 3.8.0`                                   |
| [`13a57fb6`](https://github.com/NixOS/nixpkgs/commit/13a57fb6e0d6253c44ebed697520c50ccfab529a) | `terraform-providers.ibm: 1.47.1 → 1.48.0`                                      |
| [`f648ba02`](https://github.com/NixOS/nixpkgs/commit/f648ba020263aef9188c59656cd039149acaadab) | `terraform-providers.mailgun: 0.7.2 → 0.7.3`                                    |
| [`68612bfb`](https://github.com/NixOS/nixpkgs/commit/68612bfb3f77eeb5a5d4556c47e943d30867281d) | `terraform-providers.huaweicloud: 1.42.0 → 1.43.0`                              |
| [`4a522499`](https://github.com/NixOS/nixpkgs/commit/4a5224991feedcc98539a1721135da22ac146192) | `terraform-providers.aws: 4.41.0 → 4.44.0`                                      |
| [`39ee29e9`](https://github.com/NixOS/nixpkgs/commit/39ee29e92f8815ffe3bb862efd15c45cebea8249) | `terraform-providers.hcloud: 1.36.0 → 1.36.1`                                   |
| [`426c4936`](https://github.com/NixOS/nixpkgs/commit/426c4936d2242ee2187afcf81faf4e319a014ba3) | `terraform-providers.github: 5.9.1 → 5.11.0`                                    |
| [`dc7289e0`](https://github.com/NixOS/nixpkgs/commit/dc7289e08863f0e72ac0ab28b6f20ffb6fc86047) | `terraform-providers.flexibleengine: 1.34.0 → 1.35.0`                           |
| [`dfa4dee6`](https://github.com/NixOS/nixpkgs/commit/dfa4dee620fd5c77b3a7ceeeff7914e58d725de4) | `terraform-providers.equinix: 1.11.0 → 1.11.1`                                  |
| [`a1224ebb`](https://github.com/NixOS/nixpkgs/commit/a1224ebbcce760369bfe213841c630b9416fee17) | `terraform-providers.cloudflare: 3.28.0 → 3.29.0`                               |
| [`ec6b8443`](https://github.com/NixOS/nixpkgs/commit/ec6b8443dda613d4bb5983e26490ab0481b94357) | `terraform-providers.azuread: 2.30.0 → 2.31.0`                                  |
| [`f2a3d97c`](https://github.com/NixOS/nixpkgs/commit/f2a3d97c1e5307a51c856cb6e6c4470b371ed990) | `terraform-providers.alicloud: 1.192.0 → 1.193.0`                               |
| [`77be06f8`](https://github.com/NixOS/nixpkgs/commit/77be06f89f45d84c67e071faeb22a2c731db105c) | `terraform-providers.aiven: 3.8.1 → 3.9.0`                                      |
| [`9ce190c3`](https://github.com/NixOS/nixpkgs/commit/9ce190c30639927b8264d631b53d583c5e5cfa31) | `terraform-providers.akamai: 3.0.0 → 3.1.0`                                     |
| [`a50b78b5`](https://github.com/NixOS/nixpkgs/commit/a50b78b535007c3f809c0188f170e67671b083a6) | `dar: use fetchzip`                                                             |
| [`dade319b`](https://github.com/NixOS/nixpkgs/commit/dade319b303f6ee6365b9f97a27fd1643e2f27f7) | `dar: one list item per line`                                                   |
| [`5b2d084e`](https://github.com/NixOS/nixpkgs/commit/5b2d084e4da4410225882e1d17bfb4b60eb08697) | `dar: cleanup`                                                                  |
| [`58710ad3`](https://github.com/NixOS/nixpkgs/commit/58710ad37d50b420654bb3d1ce50adffe643a6e4) | `dar: use llvmPackages_12 rather than gcc on Darwin`                            |
| [`6242ca0d`](https://github.com/NixOS/nixpkgs/commit/6242ca0d36deda3d36326df6c68dc516ea9fe453) | `babashka: 1.0.166 -> 1.0.167`                                                  |
| [`2a047233`](https://github.com/NixOS/nixpkgs/commit/2a04723331864b6d472bc9cc6c1d7e3e7ba9d319) | `nixos/rl-2211: remove reference to nowhere`                                    |
| [`b22e868d`](https://github.com/NixOS/nixpkgs/commit/b22e868d22b029931d775493aeeab383e21df056) | `sourcehut.dispatchsrht: move removal notice to 23.05 release notes`            |
| [`4d8e6982`](https://github.com/NixOS/nixpkgs/commit/4d8e6982cce46b318778f4a3466d466353ec1e24) | `terraform-providers: fix broken meta`                                          |
| [`1dfeed64`](https://github.com/NixOS/nixpkgs/commit/1dfeed64ce6e03ebb08734613f1813dab2037c34) | `hr: 1.3 -> 1.4`                                                                |
| [`fd0f8233`](https://github.com/NixOS/nixpkgs/commit/fd0f82330f7c373af512ca2e45f3f82bd2283942) | `mdcat: 0.29.0 -> 0.30.3`                                                       |
| [`7163503e`](https://github.com/NixOS/nixpkgs/commit/7163503e90b12a35bbe47c7e657a140cd14c5b0c) | `acl2: remove python2 usage`                                                    |
| [`bf02009f`](https://github.com/NixOS/nixpkgs/commit/bf02009f8a9952bcde1d306888e3e6b726d41ed8) | `github-backup: 0.41.0 -> 0.42.0`                                               |
| [`99e637da`](https://github.com/NixOS/nixpkgs/commit/99e637da5e2d04b541e182313ce8c129b52f8722) | `goreleaser: 1.13.0 -> 1.13.1`                                                  |
| [`8f88cd3f`](https://github.com/NixOS/nixpkgs/commit/8f88cd3f7a96689f9cb41fd87999364c5dfe0b73) | `emacs: drop unused xlibsWrapper`                                               |
| [`fe09222b`](https://github.com/NixOS/nixpkgs/commit/fe09222b33966cea0f5eda9c2875230538a955b7) | `python310Packages.clevercsv: fix build on darwin`                              |
| [`9f05b9d6`](https://github.com/NixOS/nixpkgs/commit/9f05b9d63451d37130d9958f26a3655bc8b274da) | `libtorrent-rasterbar-1_2_x: use python3 by default`                            |
| [`c1d7d635`](https://github.com/NixOS/nixpkgs/commit/c1d7d635dba9475f9f325a2f255b5ad86a0967c6) | `firewalld: 1.2.1 -> 1.2.2`                                                     |
| [`501a9450`](https://github.com/NixOS/nixpkgs/commit/501a9450ac80fee4deb9a04e491cd68e20d27c2d) | `werf: 1.2.190 -> 1.2.191`                                                      |
| [`2abf40d9`](https://github.com/NixOS/nixpkgs/commit/2abf40d9b5bfaa49898af7b18b69a86247c29f2c) | `terraform-providers.yandex: 0.82.0 → 0.83.0`                                   |
| [`af4452b5`](https://github.com/NixOS/nixpkgs/commit/af4452b505d1bd1f6a9eaba34af375f2df000aef) | `terraform-providers.equinix: 1.10.0 → 1.11.0`                                  |
| [`2c90cb93`](https://github.com/NixOS/nixpkgs/commit/2c90cb930422165072f611aa0168727b2fa86e0f) | `ec2-amis: add release 22.11`                                                   |
| [`f25d7194`](https://github.com/NixOS/nixpkgs/commit/f25d71940b53caa1c678f265dab290a2e307ecbb) | `gcc-arm-embedded-{6,7,8,9,10}: drop python27 from dependencies`                |
| [`2f685ba8`](https://github.com/NixOS/nixpkgs/commit/2f685ba86f859872be88426a983964fe29f9ec00) | `lesstif: use xorg.* packages directly instead of xlibsWrapper indirection`     |
| [`7d7e8155`](https://github.com/NixOS/nixpkgs/commit/7d7e8155f1a824a52e89e0b2d5a5c33691d49df7) | `conduktor: update sha256`                                                      |
| [`7b16c6ed`](https://github.com/NixOS/nixpkgs/commit/7b16c6ed61dff729e30c964365c3a4a49e671ec4) | `evcc: 0.108.2 -> 0.108.3`                                                      |
| [`4f72a025`](https://github.com/NixOS/nixpkgs/commit/4f72a0257b976b9772d66a16d785166439f8eb07) | ``charles4: pass `--user-agent` to `curlOptsList```                             |
| [`c9ba8b00`](https://github.com/NixOS/nixpkgs/commit/c9ba8b002f10b3995a41684f1ade3663d8d8c2f4) | `bisq-desktop: enableJavaFX in openjdk11 input`                                 |
| [`9063accd`](https://github.com/NixOS/nixpkgs/commit/9063accddd2e68dcc71032459a58399e977374c9) | `nomad: refactor`                                                               |
| [`e0975233`](https://github.com/NixOS/nixpkgs/commit/e09752334cba82b1cf7f29c9080ada0538e0b076) | `terraform-providers: remove providers with unclear licensing`                  |
| [`4ceb008a`](https://github.com/NixOS/nixpkgs/commit/4ceb008a8ce6a9b2b07a513841b137d49c402781) | `terraform-providers: add license/spdx`                                         |
| [`d0594d56`](https://github.com/NixOS/nixpkgs/commit/d0594d563c203745e6552fa76f8b447d827cfc73) | `terraform-providers: simplify update script`                                   |
| [`b18d379a`](https://github.com/NixOS/nixpkgs/commit/b18d379a91fddadc986bf57e2889d7478b196ce7) | `terraform-providers: add homepage that can be used as provider-source-address` |
| [`70f59224`](https://github.com/NixOS/nixpkgs/commit/70f59224049341cf18fb9dff3e95ea1b8687a5b8) | `terraform-providers: remove explicit version`                                  |
| [`562a9b80`](https://github.com/NixOS/nixpkgs/commit/562a9b807de69b3c05b0fa439f9f5d0685720ad0) | `youtube-music: fix trayicon and source provenance`                             |
| [`a4892c68`](https://github.com/NixOS/nixpkgs/commit/a4892c68405e01f09e9c0f93927786cf6a7f0287) | `jfmt: 1.2.0 -> 1.2.1`                                                          |
| [`473328a5`](https://github.com/NixOS/nixpkgs/commit/473328a5e038f7865867b50a5b5ce19a627141c6) | `python310Packages.ptpython: add changelog to meta`                             |
| [`a80f8fe1`](https://github.com/NixOS/nixpkgs/commit/a80f8fe1a37c7e5719091210ef81c2c86b16c081) | `python310Packages.prefixed: add changelog to meta`                             |
| [`95b21e5e`](https://github.com/NixOS/nixpkgs/commit/95b21e5eeabac42449675b806df7af73645637c4) | `python310Packages.moderngl: add changelog to meta`                             |
| [`427a6d3a`](https://github.com/NixOS/nixpkgs/commit/427a6d3a048de8b37cb478dac9128c89cbe271a2) | `python310Packages.pymediainfo: add changelog to meta`                          |
| [`067d0d4f`](https://github.com/NixOS/nixpkgs/commit/067d0d4f173955d7df30110d3d3f35fefe5a4601) | ` python310Packages.pyodbc: add changelog to meta`                              |
| [`ca271f29`](https://github.com/NixOS/nixpkgs/commit/ca271f298814974b08e7e84f379604820f40ffa6) | `python310Packages.pyodbc: 4.0.34 -> 4.0.35`                                    |
| [`c35afb9a`](https://github.com/NixOS/nixpkgs/commit/c35afb9aeb2952b443ccd352d27ab2d47c755162) | `python310Packages.weakrefmethod: remove`                                       |
| [`821c943d`](https://github.com/NixOS/nixpkgs/commit/821c943d1b51753e901d5bfd3050626e89c12c43) | `python310Packages.signalslot: remove weakrefmethod`                            |
| [`e35603d8`](https://github.com/NixOS/nixpkgs/commit/e35603d8b26876a87ed298a044242f4d1c647965) | `fastddsgen: upgrade to openjdk17`                                              |
| [`8bbfbdc4`](https://github.com/NixOS/nixpkgs/commit/8bbfbdc480fac4725a93f52393f37737bedad623) | `python310Packages.pyoverkiz: 1.7.0 -> 1.7.1`                                   |
| [`6edf855c`](https://github.com/NixOS/nixpkgs/commit/6edf855c1a38185c028c5eb1fe555c5533823c0a) | `buildkite-agent: 3.40.0 -> 3.41.0 (#203803)`                                   |
| [`aacfe97e`](https://github.com/NixOS/nixpkgs/commit/aacfe97e55d81a1f658bfd915a37ed62e1502b9b) | `  python310Packages.pyomo: add changelog to meta`                              |
| [`ab3035c4`](https://github.com/NixOS/nixpkgs/commit/ab3035c461f2259e28652e01abbb9954c455a909) | `python310Packages.pyomo: 6.4.2 -> 6.4.3`                                       |
| [`fcdc8aee`](https://github.com/NixOS/nixpkgs/commit/fcdc8aee87bdb9413ae9bae09d519366b5166b9a) | `python310Packages.pyface: add changelog to meta`                               |
| [`abc0cf60`](https://github.com/NixOS/nixpkgs/commit/abc0cf6076f6da364b7a0cbd7e578cee72384608) | `python310Packages.pyoctoprintapi: add changelog to meta`                       |
| [`094532b6`](https://github.com/NixOS/nixpkgs/commit/094532b6194179364e6f5d1493ddcaa910e79eaa) | `python310Packages.pyoctoprintapi: 0.1.9 -> 0.1.10`                             |
| [`cd73eb0b`](https://github.com/NixOS/nixpkgs/commit/cd73eb0b88d2e82311ff3f4249b22cc8d45e7f91) | `python310Packages.teslajsonpy: 3.2.2 -> 3.3.0`                                 |
| [`eacec3f9`](https://github.com/NixOS/nixpkgs/commit/eacec3f905caa660994339a3820b5ad74fcd5f48) | `python310Packages.scmrepo: 0.1.3 -> 0.1.4`                                     |
| [`d57353e1`](https://github.com/NixOS/nixpkgs/commit/d57353e122a4b4c6ec3d09932195e41f21380554) | `openjdk14: disable JavaFX by default`                                          |
| [`f24ea1f7`](https://github.com/NixOS/nixpkgs/commit/f24ea1f792444f5a312647fef6f95b5e509c0d9f) | `openjdk13: disable JavaFX by default`                                          |
| [`76f20f79`](https://github.com/NixOS/nixpkgs/commit/76f20f79c69c2e3717791298395f7ad9a271d8f7) | `openjdk12: disable JavaFX by default`                                          |
| [`94491ad9`](https://github.com/NixOS/nixpkgs/commit/94491ad9fc1f784d44f4cff567aeffba6fd98d7a) | `openjdk11: disable JavaFX by default`                                          |
| [`b92b329d`](https://github.com/NixOS/nixpkgs/commit/b92b329d25c448100f92555c53defd1958ef955c) | `papirus-icon-theme: 20221101 -> 20221201`                                      |
| [`87adfff3`](https://github.com/NixOS/nixpkgs/commit/87adfff3cf067edcb3ee790980511a6fe4170737) | `python310Packages.scmrepo: add changelog to meta`                              |
| [`6de9ec59`](https://github.com/NixOS/nixpkgs/commit/6de9ec5969cad20e5deebc7d60a37737b1382fa9) | `nixos/octoprint: add openFirewall option`                                      |
| [`40b71c3e`](https://github.com/NixOS/nixpkgs/commit/40b71c3e937620ae8dcfad69d5dfa343a8918d6d) | `nixos/redmine: add missing lib.mdDoc (#203952)`                                |
| [`1f244f16`](https://github.com/NixOS/nixpkgs/commit/1f244f1625b32436e7076c2b823a481af2792074) | `gitlab: 15.6.0 -> 15.6.1 (#203868)`                                            |
| [`7df62d0f`](https://github.com/NixOS/nixpkgs/commit/7df62d0fe67b75bd9ddec1588fa4d07f88935fe1) | `python310Packages.neo4j: 5.2.1 -> 5.3.0`                                       |
| [`6065d768`](https://github.com/NixOS/nixpkgs/commit/6065d768e145ca5782e961774b5f06f0a0520729) | `sapling: fix on macOS`                                                         |
| [`49c247fe`](https://github.com/NixOS/nixpkgs/commit/49c247fe59c5d237e7a0a0a97d947b721868b89d) | `python310Packages.neo4j: add changelog to meta`                                |
| [`7f4559c5`](https://github.com/NixOS/nixpkgs/commit/7f4559c57c83b538d0853b11e6f7e9368a86ade6) | `obs-vkcapture: 1.2.1 -> 1.2.2`                                                 |
| [`fd962eab`](https://github.com/NixOS/nixpkgs/commit/fd962eab8eeb3e41d22fc5f94e9d7fab6fd9fbcc) | `volctl: 0.8.2 -> 0.9.2`                                                        |
| [`a4952c81`](https://github.com/NixOS/nixpkgs/commit/a4952c81d73d1561e463be1876cf38b87547facb) | `mpd: 0.23.9 -> 0.23.11`                                                        |
| [`b2996de2`](https://github.com/NixOS/nixpkgs/commit/b2996de2a7af35ed8e263acc3f5ef4f3e48f75a7) | `blobby: repair`                                                                |
| [`bd2f80ea`](https://github.com/NixOS/nixpkgs/commit/bd2f80eaf97b34c880ec934f2597cfd757e08c6f) | `mantainers: update portothree email`                                           |
| [`c54ab98e`](https://github.com/NixOS/nixpkgs/commit/c54ab98eb0eb22b5eb302614ffecf7d9ed34a7b5) | `vimPlugins.nvim-treesitter: update grammars`                                   |
| [`55464801`](https://github.com/NixOS/nixpkgs/commit/554648019bf3bf69b1027c33f56d8df3aac7c63e) | `deno: 1.28.2 -> 1.28.3`                                                        |
| [`2f5be039`](https://github.com/NixOS/nixpkgs/commit/2f5be0392c12d4dfdae3a90b3ccb84e3908220f7) | `python310Packages.pyface: 7.4.2 -> 7.4.3`                                      |
| [`b00e6f2a`](https://github.com/NixOS/nixpkgs/commit/b00e6f2a137ff6929ee5100f6d1fdfb260e1a9db) | `python310Packages.pycfdns: add changelog to meta`                              |
| [`bcb6dbbe`](https://github.com/NixOS/nixpkgs/commit/bcb6dbbe30ce7631e5a0865dff1ab9b63d92977d) | `manylinux: use libxcrypt for libcrypt.so.1`                                    |
| [`6060f126`](https://github.com/NixOS/nixpkgs/commit/6060f1268ca7b44d62304564eadb0b0667ea8b84) | `clusterctl: 1.2.7 -> 1.3.0`                                                    |
| [`c5a09271`](https://github.com/NixOS/nixpkgs/commit/c5a092710299c3ccfb3fce0877bf3d5fd46bd9c7) | `python310Packages.pycfdns: 2.0.0 -> 2.0.1`                                     |
| [`4e42a0ba`](https://github.com/NixOS/nixpkgs/commit/4e42a0ba0f59b4e00b6be3c12395f3453bf87a2c) | `esphome: 2022.11.3 -> 2022.11.4`                                               |
| [`9855c146`](https://github.com/NixOS/nixpkgs/commit/9855c146a2ed8e8846c8aa9f835f9411d31e0748) | `home-assistant: 2022.11.4 -> 2022.11.5`                                        |
| [`3e8534f3`](https://github.com/NixOS/nixpkgs/commit/3e8534f333ebf1ce71405629cd594a4265e36cc7) | ` python310Packages.bellows: add changelog to meta`                             |
| [`5f33a76d`](https://github.com/NixOS/nixpkgs/commit/5f33a76d16d1de6f3c37ae0814ae3690d06d0e28) | `python310Packages.zha-quirks: 0.0.86 -> 0.0.87`                                |
| [`b2cc0315`](https://github.com/NixOS/nixpkgs/commit/b2cc0315e3d8b01106b8eeb63c9fa32677f4ebbd) | `python310Packages.zha-quirks: add changelog to meta`                           |
| [`e2ba5b66`](https://github.com/NixOS/nixpkgs/commit/e2ba5b66cd3670352ac606dd4f24b3b329d38f16) | `python310Packages.zigpy-deconz: 0.19.0 -> 0.19.1`                              |
| [`19105c66`](https://github.com/NixOS/nixpkgs/commit/19105c66f2f5fdcd78be47c9641b290d0599b097) | `python310Packages.zigpy-deconz: add changelog to meta`                         |
| [`4ec822f4`](https://github.com/NixOS/nixpkgs/commit/4ec822f4b7bdbc84b682625e513ce6c372b1a605) | `python310Packages.zigpy: 0.51.5 -> 0.51.6`                                     |
| [`adb15eda`](https://github.com/NixOS/nixpkgs/commit/adb15eda59db7cdd65dc54ee5be533cf3e7dba82) | `python310Packages.zigpy: add changelog to meta`                                |
| [`962bc1a7`](https://github.com/NixOS/nixpkgs/commit/962bc1a79d27e64a6278bee6df4eddc2a1cb98f3) | `python3Packages.simplisafe-python: 2022.11.0 -> 2022.11.2`                     |
| [`267c1835`](https://github.com/NixOS/nixpkgs/commit/267c1835862c54189c2820fc88e05023f39cf6d6) | `python3Packages.pytibber: 0.25.6 -> 0.26.1`                                    |
| [`028bf68d`](https://github.com/NixOS/nixpkgs/commit/028bf68df177ee0d06a2152613d9b82cdda8f51f) | `home-assistant: use headless ffmpeg variant`                                   |
| [`b1b68058`](https://github.com/NixOS/nixpkgs/commit/b1b680584e382a27f62a5227d2a26dff80ab84cf) | `vimPlugins.treesj: init at 2022-12-01`                                         |
| [`6bbe5e0d`](https://github.com/NixOS/nixpkgs/commit/6bbe5e0dc25cb37820baf672b9fb5175fd246983) | `vimPlugins: update`                                                            |
| [`3e534cfd`](https://github.com/NixOS/nixpkgs/commit/3e534cfde55bfd5a2e1348d25bd27bfe9c615746) | `tayga: correct license to GPL2+`                                               |
| [`8d47058b`](https://github.com/NixOS/nixpkgs/commit/8d47058b32f1f0fb1b21d73392f3b4e96d139a81) | `nixos/tests/tayga: init`                                                       |
| [`16b78928`](https://github.com/NixOS/nixpkgs/commit/16b789287654273d696f3fec2f1890a9fe3e9948) | `nixos/tayga: init`                                                             |
| [`d6e589c0`](https://github.com/NixOS/nixpkgs/commit/d6e589c0235eb681d0b9626467b7d0a28f31bcf6) | `cargo-apk: init at 0.9.6`                                                      |
| [`59695cfb`](https://github.com/NixOS/nixpkgs/commit/59695cfb7361bd13bacabe9c324ca0eb81118e1f) | `python310Packages.prefixed: 0.4.2 -> 0.5.0`                                    |
| [`10b0af8f`](https://github.com/NixOS/nixpkgs/commit/10b0af8f45c6cafbd8e87c5baa5be87accbb2db3) | `libreddit: 0.24.1 -> 0.24.2`                                                   |
| [`bbca72b0`](https://github.com/NixOS/nixpkgs/commit/bbca72b00d44906020c5f32ffd7fcd9fc6fce2a6) | `python310Packages.pip-tools: add changelog to meta`                            |
| [`083a6cfa`](https://github.com/NixOS/nixpkgs/commit/083a6cfa96eaf770480462a93a7512b5349f3007) | `poetry2nix: 1.36.0 -> 1.37.0`                                                  |
| [`d45a8a05`](https://github.com/NixOS/nixpkgs/commit/d45a8a0586fddec8eecb8cd2ecfa017269e505a0) | `fuse-overlayfs: 1.9 -> 1.10`                                                   |
| [`2875fd52`](https://github.com/NixOS/nixpkgs/commit/2875fd523fb6297ad6899e57a604d1396ac929ff) | `xterm: drop redundant '# #' comment`                                           |
| [`f898cc1f`](https://github.com/NixOS/nixpkgs/commit/f898cc1f6b6d376d002706edbc90f147c28c3c09) | `python310Packages.pip-tools: 6.8.0 -> 6.11.0`                                  |
| [`d4db6421`](https://github.com/NixOS/nixpkgs/commit/d4db6421dbc964db77a17ee2b9a65abf6ba6e941) | `python310Packages.pyunifiprotect: 4.4.2 -> 4.5.1`                              |
| [`96a4ece1`](https://github.com/NixOS/nixpkgs/commit/96a4ece1450c6427b22704b08c15510334061cd9) | `python310Packages.peaqevcore: 8.2.0 -> 9.0.1`                                  |
| [`d8535833`](https://github.com/NixOS/nixpkgs/commit/d8535833919d9515112d36f90b3f9d1574eba559) | `python310Packages.homematicip: 1.0.10 -> 1.0.12`                               |
| [`2c391710`](https://github.com/NixOS/nixpkgs/commit/2c3917100519ac3c8d91889db64eb7990618035b) | `python310Packages.hahomematic: 2022.11.2 -> 2022.12.0`                         |
| [`a77da404`](https://github.com/NixOS/nixpkgs/commit/a77da40458190b74d1ad049f75733ffe0a6b4666) | `python310Packages.hahomematic: add changelog to meta`                          |
| [`404fa921`](https://github.com/NixOS/nixpkgs/commit/404fa921bf657dfaea6793dbd2403fde647400d0) | `python310Packages.patiencediff: 0.2.8 -> 0.2.9`                                |
| [`d420e866`](https://github.com/NixOS/nixpkgs/commit/d420e8666fa0a9c81de01d8203d8f4ea781823e6) | `python310Packages.p1monitor: add changelog to meta`                            |
| [`02b00498`](https://github.com/NixOS/nixpkgs/commit/02b00498cb6de1c4a3722bbb097c23aec5ac9148) | `python310Packages.faraday-plugins: 1.8.0 -> 1.8.1`                             |
| [`000c92e4`](https://github.com/NixOS/nixpkgs/commit/000c92e412d2d7d18711d95dd9a4afbf1b9deee4) | `python310Packages.faraday-agent-parameters-types: 1.1.0 -> 1.2.0`              |
| [`aa64219c`](https://github.com/NixOS/nixpkgs/commit/aa64219c89424021e23a2979b73d207bc17f4db9) | `python310Packages.faraday-agent-parameters-types: add changelog to meta`       |
| [`6ef6b68c`](https://github.com/NixOS/nixpkgs/commit/6ef6b68c8e1b0f82a06e489927d29470aff38780) | `python310Packages.aiohomekit: 2.3.1 -> 2.3.3`                                  |
| [`6d268aa7`](https://github.com/NixOS/nixpkgs/commit/6d268aa75b0369bc896f6592dee92011daa7ef03) | `python310Packages.p1monitor: 2.1.1 -> 2.2.0`                                   |
| [`a355f181`](https://github.com/NixOS/nixpkgs/commit/a355f18159bad04e0e4a4b66f8c438173785698e) | `eksctl: 0.121.0 -> 0.122.0`                                                    |
| [`17533e40`](https://github.com/NixOS/nixpkgs/commit/17533e40a493e16a6e42bbec2ddfd39de5385947) | `eget: 1.3.0 -> 1.3.1`                                                          |
| [`722cfb65`](https://github.com/NixOS/nixpkgs/commit/722cfb65078aa13fb665d3394fddef889c11cd22) | `dolibarr: 16.0.1 -> 16.0.3`                                                    |
| [`0f418c4b`](https://github.com/NixOS/nixpkgs/commit/0f418c4b878118fb5827e0e7e8e2d94210e3e61d) | `do-agent: 3.14.1 -> 3.15.1`                                                    |
| [`01db863c`](https://github.com/NixOS/nixpkgs/commit/01db863cef57db8d5164fc624cda8004eae0b64d) | `diffsitter: 0.7.1 -> 0.7.2`                                                    |