### PR TITLE
chore(flake/home-manager): `ca48fced` -> `9fb1bb97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670141274,
-        "narHash": "sha256-wW1nNEXo79Sw5oWaTK2LDGCc2rGwwcAPJMpQOTPT69Y=",
+        "lastModified": 1670142887,
+        "narHash": "sha256-UPpgl8OUGDyChvvd/4Foko1hJU0pgKmXwf9jeb+Rkbs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ca48fced83b37b4927ee264e54b9fdd5706c4139",
+        "rev": "9fb1bb9794d85c80126e1840a836280f9c83ee71",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                   |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`9fb1bb97`](https://github.com/nix-community/home-manager/commit/9fb1bb9794d85c80126e1840a836280f9c83ee71) | `himalaya: 0.6.x config updates` |
| [`05d71f51`](https://github.com/nix-community/home-manager/commit/05d71f517b6406471e2ebca49980db83e5c7d565) | `email: add signature delimiter` |
| [`9e266ca2`](https://github.com/nix-community/home-manager/commit/9e266ca2a766acb886e0a9da8f34dd3f74455d92) | `maintainers: add toastal`       |