### PR TITLE
chore(flake/home-manager): `7bfe3cd9` -> `17bbfcb8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670156965,
-        "narHash": "sha256-TyKW3TaY3PRH+9bBLTiffZP0/Nt5yLeWtmQZKhJ4Boo=",
+        "lastModified": 1670157315,
+        "narHash": "sha256-GMeuuDKTaqnYFGQA3ZqlLoeeWi30RdJZV+ukOnTCu+w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7bfe3cd9b0c2feae04ceed52bbc0b64222ed4b7e",
+        "rev": "17bbfcb82458ac2270dec71ce1f7044deb4f1ca3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message       |
| ----------------------------------------------------------------------------------------------------------- | -------------------- |
| [`17bbfcb8`](https://github.com/nix-community/home-manager/commit/17bbfcb82458ac2270dec71ce1f7044deb4f1ca3) | `flake.lock: Update` |