### PR TITLE
chore(flake/home-manager): `e3e2abae` -> `6ce326ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670041200,
-        "narHash": "sha256-5ZU1+D8RaXjBHuBbPRRJq1OQJEVjrX8vDGPyQzarAQg=",
+        "lastModified": 1670233134,
+        "narHash": "sha256-2bha+zYVlLybIrpCXskC3tiaE5xgyHM02IF/Tk84Zq4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e3e2abaef5c56620680201ebeb84d18fe43c813d",
+        "rev": "6ce326cef9798c6275882954b11cd824b6e31df2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`6ce326ce`](https://github.com/nix-community/home-manager/commit/6ce326cef9798c6275882954b11cd824b6e31df2) | `treewide: use liberachat and OFTC in examples` |