### PR TITLE
chore(flake/home-manager): `747e3647` -> `2af0d076`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670245450,
-        "narHash": "sha256-SSHD2iuPw7dKpAHX7DMTBKCm+/drigwC5//xkf+v/AM=",
+        "lastModified": 1670280307,
+        "narHash": "sha256-3x+0whP1nCz5adQMIsBA3L9fI/ABOpRUJdbw0AmxBnU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "747e36476f341720404bd0d14d687a135a4ce5bf",
+        "rev": "2af0d07678fc15612345e0dd55337550dcf6465f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`2af0d076`](https://github.com/nix-community/home-manager/commit/2af0d07678fc15612345e0dd55337550dcf6465f) | ``home-manager: use `hostname` from Nixpkgs`` |
| [`7e81e7ae`](https://github.com/nix-community/home-manager/commit/7e81e7ae2b66d3d059c75914b867575921a0b05a) | `fish: always run fish_indent`                |