### PR TITLE
chore(flake/pre-commit-hooks): `607521be` -> `1303a1a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -219,11 +219,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1670405695,
-        "narHash": "sha256-240KGbqtLKBOfJGRgbvLjkJiIquPubpst9WMHfyHhDA=",
+        "lastModified": 1670413394,
+        "narHash": "sha256-M7sWqrKtOqUv9euX1t3HCxis8cPy9MNiZxQmUf0KF1o=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "607521bec0cd1e8483b8d4ead7f23433ff19c0a6",
+        "rev": "1303a1a76e9eb074075bfe566518c413f6fc104e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message                   |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------- |
| [`5f7721dd`](https://github.com/cachix/pre-commit-hooks.nix/commit/5f7721ddc71ba9fce55186100d27d041310785ea) | `Disable Commitizen build tests` |
| [`49ffc6f9`](https://github.com/cachix/pre-commit-hooks.nix/commit/49ffc6f976de18792ec73f3af5a5c7bd54a555b6) | `Add Commitizen`                 |