### PR TITLE
chore(flake/nixos-hardware): `9d87bc03` -> `0fbf27af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1670174919,
-        "narHash": "sha256-XdQr3BUnrvVLRFunLWrZORhwYHDG0+9jUUe0Jv1pths=",
+        "lastModified": 1670959777,
+        "narHash": "sha256-9nQJWL7S77YZERxairPLFO6TUuF1RgQmdZO6dKRCHz4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9d87bc030a0bf3f00e953dbf095a7d8e852dab6b",
+        "rev": "0fbf27af51a7c9bc68a168fdcd63513c4f100b15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`cd760508`](https://github.com/NixOS/nixos-hardware/commit/cd760508241d2bfe18c2aed64cee04043694ac14) | `Update for code refactor`                                                         |
| [`be728899`](https://github.com/NixOS/nixos-hardware/commit/be728899cfc9c9c53910b5f1bb928c06fd6688ff) | `Tidy-up`                                                                          |
| [`e84ab225`](https://github.com/NixOS/nixos-hardware/commit/e84ab22523d77f340594282b130ebcfbbdb93a5b) | `Extract the kernel patches out`                                                   |
| [`e37520e4`](https://github.com/NixOS/nixos-hardware/commit/e37520e48b3882f4ec773d2e56d41dd914cae34d) | `Rearrange the kernels to make them self-defining`                                 |
| [`f99c9d5b`](https://github.com/NixOS/nixos-hardware/commit/f99c9d5b1f537f60ec371a2105b7dae8073ff735) | `Tidy-up`                                                                          |
| [`d2b7a0fb`](https://github.com/NixOS/nixos-hardware/commit/d2b7a0fb9a62feb21e98ea43da2cda787132bd92) | `Kernel 6.0.11 for MS Surface Devices`                                             |
| [`b01a6d58`](https://github.com/NixOS/nixos-hardware/commit/b01a6d58df799cd87ba9cf9a2b23ecb114d5e221) | `Remove obsolete file`                                                             |
| [`87597ab3`](https://github.com/NixOS/nixos-hardware/commit/87597ab307c5eaae6142f9adcfb1e47dac472eec) | `Remove obsolete files`                                                            |
| [`87adbffa`](https://github.com/NixOS/nixos-hardware/commit/87adbffa11fc633470fe8411b477b77975c0a8f3) | `Fix-ups`                                                                          |
| [`a51973c9`](https://github.com/NixOS/nixos-hardware/commit/a51973c994d614f8af069394064966ef8b7237b0) | `Add linux-surface patches for 5.19.2`                                             |
| [`d93d29bd`](https://github.com/NixOS/nixos-hardware/commit/d93d29bdc980a80eb1643184d4429e84046b162d) | `Add-back linux-surface/linux-surface repo, for easy access to the kernel patches` |
| [`5d0ade69`](https://github.com/NixOS/nixos-hardware/commit/5d0ade69589d2d53397137ef900322a43947b416) | `Add-back linux-surface/linux-surface repo, for easy access to the kernel patches` |
| [`50ce82cc`](https://github.com/NixOS/nixos-hardware/commit/50ce82cc84b7fd4394c1387f3155bc7c100d7bdf) | `Fix for unexpected recursion error`                                               |
| [`3de7b6e0`](https://github.com/NixOS/nixos-hardware/commit/3de7b6e0c58abe80fa5bdab87be66464898639ee) | `Use the newly refactored code`                                                    |
| [`158f86bb`](https://github.com/NixOS/nixos-hardware/commit/158f86bb326dd3529f288bb476464f61679a41c3) | `DRY the MS Surface kernel module`                                                 |
| [`35e317a2`](https://github.com/NixOS/nixos-hardware/commit/35e317a280f6457c5ba085d985175346fa6694b7) | `Use new repos.linux-surface-kernel function`                                      |
| [`b32b1881`](https://github.com/NixOS/nixos-hardware/commit/b32b188154bda2f0b430afac19e404216aaded23) | `Convert the repos.linux-surface-kernel set to a function`                         |