### PR TITLE
chore(flake/nixos-hardware): `0fbf27af` -> `1f606727`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1670959777,
-        "narHash": "sha256-9nQJWL7S77YZERxairPLFO6TUuF1RgQmdZO6dKRCHz4=",
+        "lastModified": 1671106796,
+        "narHash": "sha256-moAUZMJeGmZAccpZYbAbNVTsmLTkhNU3CdatGg1oKUE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0fbf27af51a7c9bc68a168fdcd63513c4f100b15",
+        "rev": "1f6067272161d03d1c9f0b46fbf7cb090d016a9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`f1731625`](https://github.com/NixOS/nixos-hardware/commit/f17316259fb4fcda31513e4d46568746644b9fb7) | `fixup! Add support for GA402` |
| [`56566dc4`](https://github.com/NixOS/nixos-hardware/commit/56566dc47f906eda44b3622c11b75d40dc619e68) | `fixup! Add support for GA402` |
| [`e18b759b`](https://github.com/NixOS/nixos-hardware/commit/e18b759b1bc093e08c69f9ce1086b990d8d3baa8) | `Add support for GA402`        |