### PR TITLE
chore(flake/darwin): `2795e05c` -> `adb8ac04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671020882,
-        "narHash": "sha256-nilsez0cjzvWUZzcWI+ZK3gY/wT3RvkQA9qw8GYJmEU=",
+        "lastModified": 1671196037,
+        "narHash": "sha256-2+J98SeczFWonbqFLMEAQC7vZEe6I2gM17XYvEmG52I=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "2795e05cca69bddad989186888175548f4fca33d",
+        "rev": "adb8ac0453c8b2c40f5bffb578453dbaee838952",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                     |
| ------------------------------------------------------------------------------------------------ | ---------------------------------- |
| [`67743447`](https://github.com/LnL7/nix-darwin/commit/6774344719a51d2bfb3a9132d3faec2d86a66286) | `Add option to set 24-hour time`   |
| [`c82b2327`](https://github.com/LnL7/nix-darwin/commit/c82b2327e56f6ca41b8935c22c46853ac5926659) | `add mouse scaling system setting` |