### PR TITLE
chore(flake/home-manager): `0e9e86b1` -> `d744c2bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671202909,
-        "narHash": "sha256-82bLIOpdI+UE9OMs97n0YiYOvQ3Ul2DkFEp+4x4hLkI=",
+        "lastModified": 1671205051,
+        "narHash": "sha256-YeFiaeePGlIWRpAeRdK9yZ8ac1i5ltXGuRAJZ/de2vI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0e9e86b1794c1003db38ee77437b2522d700174e",
+        "rev": "d744c2bb9b055040a6d7c659bd1578c1308e65c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                       |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`d744c2bb`](https://github.com/nix-community/home-manager/commit/d744c2bb9b055040a6d7c659bd1578c1308e65c5) | `Translate using Weblate (Italian)`                  |
| [`3f0d04ae`](https://github.com/nix-community/home-manager/commit/3f0d04aeca4ca51d3b1c2e008067b71b6eb31fee) | `treewide: replace replaceChars with replaceStrings` |
| [`b3565b34`](https://github.com/nix-community/home-manager/commit/b3565b34477b2e8dbea174cfc9020ac248644731) | `java: remove IFD`                                   |