### PR TITLE
chore(flake/nixpkgs): `0f5996b5` -> `757b8221`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671108576,
-        "narHash": "sha256-6ggOL6KoaELNA1562tnPjtAnQ9SwsKRTgeuaXvPzCwI=",
+        "lastModified": 1671200928,
+        "narHash": "sha256-mZfzDyzojwj6I0wyooIjGIn81WtGVnx6+avU5Wv+VKU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0f5996b524c91677891a432cc99c7567c7c402b1",
+        "rev": "757b82211463dd5ba1475b6851d3731dfe14d377",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`6dc49aaf`](https://github.com/NixOS/nixpkgs/commit/6dc49aaf88603d5bf8b388ce2cfdbff808fa3971) | `esphome: 2022.12.0 -> 2022.12.1`                                                                    |
| [`7a3f450e`](https://github.com/NixOS/nixpkgs/commit/7a3f450e4af7c015a78d5d182499c8c6170418e5) | `python310Packages.pikepdf: 6.2.5 -> 6.2.6`                                                          |
| [`137d6bc1`](https://github.com/NixOS/nixpkgs/commit/137d6bc10f93869b45ff1af71b841441c3db1dfa) | `abcmidi: 2022.12.05 -> 2022.12.09`                                                                  |
| [`b630ee2c`](https://github.com/NixOS/nixpkgs/commit/b630ee2ca11ebac6ba324c80d06d4324982fbfe3) | `signalbackup-tools: 20221130 -> 20221208`                                                           |
| [`6a2f790f`](https://github.com/NixOS/nixpkgs/commit/6a2f790f7a285f03a7f818cee8af89e145e20362) | `xwayland: 22.1.5 -> 22.1.6`                                                                         |
| [`b8ce7fd5`](https://github.com/NixOS/nixpkgs/commit/b8ce7fd59dcf28cccabfcf5f6407ea042b30fc1a) | `trilium-{desktop,server}: 0.57.3 -> 0.57.5`                                                         |
| [`81f5dc54`](https://github.com/NixOS/nixpkgs/commit/81f5dc544c42ac4a58bdfb83eb561c3b80d2de4d) | `jackett: 0.20.2365 -> 0.20.2395`                                                                    |
| [`c737ee25`](https://github.com/NixOS/nixpkgs/commit/c737ee25f3cec6a4c6a93f4eb85c0deb80724ff5) | `iosevka-bin: 16.4.0 -> 16.7.0`                                                                      |
| [`8bc6f346`](https://github.com/NixOS/nixpkgs/commit/8bc6f346d4d17469205ab23ec92f0222311fc354) | `uxplay: 1.58 -> 1.59`                                                                               |
| [`eb04be00`](https://github.com/NixOS/nixpkgs/commit/eb04be00dc0c082dacb1ee644b72b52d9fad72d6) | `coder: 0.13.1 -> 0.13.2`                                                                            |
| [`4e4b2f8f`](https://github.com/NixOS/nixpkgs/commit/4e4b2f8f2f25a92bc5cccb42d9965cfd5c093be5) | `volatility3: add changelog to meta`                                                                 |
| [`f0c1df31`](https://github.com/NixOS/nixpkgs/commit/f0c1df314b7b5fc64603bb07a50759267b285149) | `argo: 3.4.3 -> 3.4.4`                                                                               |
| [`2dfee2cc`](https://github.com/NixOS/nixpkgs/commit/2dfee2cc51ac86415bfc95815f0f218fbc2f61c4) | `vmagent: 1.84.0 -> 1.85.0`                                                                          |
| [`01a598b5`](https://github.com/NixOS/nixpkgs/commit/01a598b567f85b7c5625126f013cedce642f61b5) | `enum4linux-ng: ad changelog to meta`                                                                |
| [`ac355072`](https://github.com/NixOS/nixpkgs/commit/ac35507202ed87bb8f80c68dc1a8ddb8cc5662ce) | `hostapd: update homepage`                                                                           |
| [`0f84dcb7`](https://github.com/NixOS/nixpkgs/commit/0f84dcb7cc158cebacc9e68d011eaef8e11e66b1) | `scummvm: unbreak on aarch64-darwin`                                                                 |
| [`20337a95`](https://github.com/NixOS/nixpkgs/commit/20337a958f1c910a2e868284a783fd3e22fdf02e) | `opendungeons: unbreak on aarch64-linux`                                                             |
| [`c7c950be`](https://github.com/NixOS/nixpkgs/commit/c7c950be8900e7ea5d2af4a5dfa58905ac612f84) | `python310Packages.smart-open: 6.2.0 -> 6.3.0`                                                       |
| [`b8aa847f`](https://github.com/NixOS/nixpkgs/commit/b8aa847fa5539bcd0d70436323758409b0f96c2c) | `python310Packages.rpyc: 5.2.3 -> 5.3.0`                                                             |
| [`dd5571b6`](https://github.com/NixOS/nixpkgs/commit/dd5571b62b7128b7fada6ad8ed0d76405bfb5ab4) | `python310Packages.spacy-loggers: 1.0.3 -> 1.0.4`                                                    |
| [`ed665412`](https://github.com/NixOS/nixpkgs/commit/ed6654123003549dcdc7d65abbbd0d0c650e93b2) | `vscode-extensions.vadimcn.vscode-lldb: Fix eval`                                                    |
| [`3efb5277`](https://github.com/NixOS/nixpkgs/commit/3efb52773061716556bffcbda5ada76dc7cf28f4) | `vscode-extensions.rust-lang.rust-analyzer: Fix eval`                                                |
| [`1c8399a2`](https://github.com/NixOS/nixpkgs/commit/1c8399a2b641ad9deacf272f88ce6e8f80524573) | `vscodium: 1.73.1.22314 -> 1.74.1.22349`                                                             |
| [`574aa59d`](https://github.com/NixOS/nixpkgs/commit/574aa59d1bcdf7ac79a19a87f23326861a66cd8d) | `vscode: 1.73.1 -> 1.74.1`                                                                           |
| [`66a6cd1d`](https://github.com/NixOS/nixpkgs/commit/66a6cd1d5191af8d3ad3dfd7c31f49d930696b68) | `vscode-with-extensions: define extensions.json`                                                     |
| [`41de073c`](https://github.com/NixOS/nixpkgs/commit/41de073c824749f1ede71943f5a94a6af325ae1b) | `python310Packages.snowflake-connector-python: 2.8.2 -> 2.9.0`                                       |
| [`1bc21f3a`](https://github.com/NixOS/nixpkgs/commit/1bc21f3a533208b06a51238603538505ecc03c6d) | `python310Packages.snowflake-sqlalchemy: 1.4.4 -> 1.4.5`                                             |
| [`9406ff97`](https://github.com/NixOS/nixpkgs/commit/9406ff97d1874bebadae801a6692d89ac33d625d) | `flexget: 3.5.10 -> 3.5.11`                                                                          |
| [`0a21b163`](https://github.com/NixOS/nixpkgs/commit/0a21b163eac3d59e2f1089ffae6c2f51528fa27f) | `volatility3: 2.0.1 -> 2.4.0`                                                                        |
| [`9575b9ad`](https://github.com/NixOS/nixpkgs/commit/9575b9ad90d567f66ee5c7af88db57a8c762e44d) | `lapce: 0.2.4 -> 0.2.5`                                                                              |
| [`66204376`](https://github.com/NixOS/nixpkgs/commit/662043766042340eda9e079cfe18663a81869672) | `lapce: Correct passthru.updateScript`                                                               |
| [`6c61c436`](https://github.com/NixOS/nixpkgs/commit/6c61c436cf8f9e5f03fc40facbbdb0bf16034b78) | `nginx: detect duplicate modules`                                                                    |
| [`60797a3b`](https://github.com/NixOS/nixpkgs/commit/60797a3bfe8b65b85a53cc29bff1d81e2c6056d9) | `surrealdb: add package option`                                                                      |
| [`4b4e899f`](https://github.com/NixOS/nixpkgs/commit/4b4e899fdd48d8a7387fed6811b8887bde7f01cb) | `enum4linux-ng: 1.1.0 -> 1.2.0`                                                                      |
| [`ec099a9f`](https://github.com/NixOS/nixpkgs/commit/ec099a9f72e0f9fecefcfc72dd73723f148f10e9) | `dua: 2.18.0 -> 2.19.0`                                                                              |
| [`02d6ae97`](https://github.com/NixOS/nixpkgs/commit/02d6ae971280bd39329a0fa1412faac39298fa88) | `signal-desktop-beta: 6.1.0-beta.1 -> 6.2.0-beta.1`                                                  |
| [`24ba7dcc`](https://github.com/NixOS/nixpkgs/commit/24ba7dcc2f63e6b419462b63bf6704560f6ff63b) | `doctl: 1.88.0 -> 1.90.0`                                                                            |
| [`91396133`](https://github.com/NixOS/nixpkgs/commit/91396133100bdf9348c813c7b2571088929ef501) | `dnsproxy: 0.46.4 -> 0.46.5`                                                                         |
| [`f1806aa7`](https://github.com/NixOS/nixpkgs/commit/f1806aa78784b64216c760b92b674d7a3cb8952f) | `deno: 1.28.3 -> 1.29.1`                                                                             |
| [`497daee7`](https://github.com/NixOS/nixpkgs/commit/497daee731a746d70d5c8a8a008b6556c5b5f1a2) | `chromiumDev: 110.0.5449.0 -> 110.0.5464.2`                                                          |
| [`ecf38ccd`](https://github.com/NixOS/nixpkgs/commit/ecf38ccd11c91b10199c1d4be1a3cb54d185a007) | `chromiumBeta: 109.0.5414.36 -> 109.0.5414.46`                                                       |
| [`22450a3c`](https://github.com/NixOS/nixpkgs/commit/22450a3c2ee017eae9321439e32ba3af9a722328) | `libsForQt5.station: init at 2.2.1`                                                                  |
| [`a8df04c7`](https://github.com/NixOS/nixpkgs/commit/a8df04c79009a9e00f263999a2b896c700dde7be) | `python310Packages.rapidfuzz: 2.13.4 -> 2.13.6`                                                      |
| [`7490e056`](https://github.com/NixOS/nixpkgs/commit/7490e056277813da4342969316df45821fed2029) | `pulumi-bin: 3.46.0 -> 3.49.0`                                                                       |
| [`05a2dfd6`](https://github.com/NixOS/nixpkgs/commit/05a2dfd6744cdc6ab0b57f8ab866cc686b05f519) | `lib.replaceChars: warn about being a deprecated alias`                                              |
| [`a2f85e0f`](https://github.com/NixOS/nixpkgs/commit/a2f85e0fa8d22a8ab42173344ce8a96b028e018a) | `androidenv: use callPackage instead of import & fix infinite recursion`                             |
| [`d0312232`](https://github.com/NixOS/nixpkgs/commit/d0312232ef626e3b9e8a8c1e896243f08ea3adea) | `clusterctl: 1.3.0 -> 1.3.1`                                                                         |
| [`e62f497a`](https://github.com/NixOS/nixpkgs/commit/e62f497a2f8c1ef4143ac9dac06bb66ea2e7cd2d) | `pythonPackages.{awkward0,uproot3}: remove`                                                          |
| [`3018e5d3`](https://github.com/NixOS/nixpkgs/commit/3018e5d392b1939525094327e54dd7aec4effd20) | `python3Packages.uproot: 4.3.6 -> 5.0.0`                                                             |
| [`d8f20f1c`](https://github.com/NixOS/nixpkgs/commit/d8f20f1cebb9fce148f4f568c96775b971075add) | `python3Packages.scikit-hep-testdata: 0.4.21 -> 0.4.24`                                              |
| [`d014abb5`](https://github.com/NixOS/nixpkgs/commit/d014abb57400655d311e9602049b00d0ef995f66) | `python3Packages.awkward: 1.10.2 -> 2.0.0`                                                           |
| [`02ba62f8`](https://github.com/NixOS/nixpkgs/commit/02ba62f8f37eee351dce1417cd2317ee3b3db1e8) | `python3Packages.awkward-cpp: init at 2`                                                             |
| [`a0b0a4ac`](https://github.com/NixOS/nixpkgs/commit/a0b0a4ac298264e9e712a32bbe39006ed4aa537e) | `python3Packages.scikit-build-core: init at 0.1.3`                                                   |
| [`2ce4eabb`](https://github.com/NixOS/nixpkgs/commit/2ce4eabb037cc97f6a01c5750e7216fe614331f7) | `python310Packages.python-telegram-bot: 13.14 -> 13.15`                                              |
| [`e2bdcb8f`](https://github.com/NixOS/nixpkgs/commit/e2bdcb8f1f80d6fc7811165d2a14bb30ccd28bdf) | `vscode-extensions.bmewburn.vscode-intelephense-client: init at 1.8.2`                               |
| [`f2eaf135`](https://github.com/NixOS/nixpkgs/commit/f2eaf1356c5774d17c0eb76b248d81b346298034) | `mdbook: add Frostman to maintainers`                                                                |
| [`8d42c003`](https://github.com/NixOS/nixpkgs/commit/8d42c003b460d2e6e1aee2ef171883969dea0b43) | `mdbook: 0.4.21 -> 0.4.24`                                                                           |
| [`ccaaee60`](https://github.com/NixOS/nixpkgs/commit/ccaaee60411e3b462b2006fd6efa56cd649da259) | `linuxKernel.kernels.linux_lqx: 6.0.12-lqx1 -> 6.0.13-lqx2`                                          |
| [`b2d1abd6`](https://github.com/NixOS/nixpkgs/commit/b2d1abd60db042980915fc0af3473e8d418d0e7c) | `linuxKernel.kernels.linux_zen: 6.0.12-zen1 -> 6.1-zen1`                                             |
| [`3a4c97ca`](https://github.com/NixOS/nixpkgs/commit/3a4c97caa0d40eaf95140cf97b8afc4baa5a6e32) | `thunderbird*: 102.5.1 -> 102.6.0`                                                                   |
| [`768c73fa`](https://github.com/NixOS/nixpkgs/commit/768c73fa8c17e1260421404b707cf905e3c832df) | `zine: 0.8.1 -> 0.9.0`                                                                               |
| [`bd80e76d`](https://github.com/NixOS/nixpkgs/commit/bd80e76deff50e285cf3da9a50d20149648da5bb) | `chamber: 2.10.12 -> 2.11.0`                                                                         |
| [`41698c76`](https://github.com/NixOS/nixpkgs/commit/41698c76aeb540ee8391a14928b18772911cb5a3) | `castxml: 0.5.0 -> 0.5.1`                                                                            |
| [`25c7f56c`](https://github.com/NixOS/nixpkgs/commit/25c7f56c726f13efa4ac7dbd044a1bdf8ac6f4d3) | `cargo-release: 0.24.0 -> 0.24.1`                                                                    |
| [`234c9883`](https://github.com/NixOS/nixpkgs/commit/234c9883745d7630768225d976784a81b3556694) | `nc4nix: unstable-2022-11-30 -> unstable-2022-12-07`                                                 |
| [`8eb516c3`](https://github.com/NixOS/nixpkgs/commit/8eb516c3da0717856e41f782c1005eea1fd5e39b) | `cinnamon.cinnamon-common: 5.6.4 -> 5.6.5`                                                           |
| [`aaef197f`](https://github.com/NixOS/nixpkgs/commit/aaef197f5724882bfb23b82a07c4f1d104ef5156) | `cinnamon.xreader: 3.6.0 -> 3.6.2`                                                                   |
| [`fa16b0da`](https://github.com/NixOS/nixpkgs/commit/fa16b0da3179d10be7f8d0a403c5fb17c29db18a) | `python310Packages.r2pipe: disable on older Python releases`                                         |
| [`9eebb01f`](https://github.com/NixOS/nixpkgs/commit/9eebb01ff536bee57466769e446dc23f934479ea) | `vbam: add netali to maintainers`                                                                    |
| [`42c2f2f2`](https://github.com/NixOS/nixpkgs/commit/42c2f2f252b3e2ce2e6665a7e00810ecc2ea3510) | `vbam: 2.1.4 -> 2.1.5 + enable GUI`                                                                  |
| [`897891c7`](https://github.com/NixOS/nixpkgs/commit/897891c73dbfbf4b32fde94f37b64d6bbb85753c) | `python310Packages.r2pipe: 1.7.3 -> 1.7.4`                                                           |
| [`88ca1ffa`](https://github.com/NixOS/nixpkgs/commit/88ca1ffae92674da7d6636d6e298ed42cc6d46c1) | `cargo-tauri: 1.0.5 -> 1.2.2`                                                                        |
| [`4cbba917`](https://github.com/NixOS/nixpkgs/commit/4cbba917e0df63e03be4b1f41ae1221f95856c0b) | `dataexplorer: 3.6.2 -> 3.7.3`                                                                       |
| [`6e37cb64`](https://github.com/NixOS/nixpkgs/commit/6e37cb64b2edad6c595257778ce424f246ecea8a) | `bacon: 2.2.5 -> 2.2.7`                                                                              |
| [`bfed0203`](https://github.com/NixOS/nixpkgs/commit/bfed02034d2b17c75f31e01d77f7c0bc3ad2d45e) | `appthreat-depscan: 3.3.0 -> 3.4.0`                                                                  |
| [`fba7ac35`](https://github.com/NixOS/nixpkgs/commit/fba7ac35adfd118a13c71a266f22d694fdb7d108) | `signal-desktop: 6.0.1 -> 6.1.0`                                                                     |
| [`db840aca`](https://github.com/NixOS/nixpkgs/commit/db840acad5cd7622834abfd994101dcff16e1853) | `esphome: 2022.11.4 -> 2022.12.0`                                                                    |
| [`7131caca`](https://github.com/NixOS/nixpkgs/commit/7131caca18fb77055f2cbc78fd70e6fd36782498) | `python310Packages.pytorch-pfn-extras: 0.6.2 -> 0.6.3`                                               |
| [`6e530b9e`](https://github.com/NixOS/nixpkgs/commit/6e530b9edaca212cca79f1e389f2c365886acbff) | `prometheus: Adds an option for web.config.file which can specity settings including authorization.` |
| [`470247d4`](https://github.com/NixOS/nixpkgs/commit/470247d433ddcb527e18b556660c13f7632779b3) | `prometheus: Use yaml format generator instaed json for prometheus.yml`                              |
| [`9adfad5e`](https://github.com/NixOS/nixpkgs/commit/9adfad5eaab1f4a0b544fbd33e11c10c1b195854) | `ungoogled-chromium: 108.0.5359.99 -> 108.0.5359.125`                                                |
| [`0ef35886`](https://github.com/NixOS/nixpkgs/commit/0ef358869c93d6998a594e7c71c8bca68e20554f) | `home-assistant: support here_travel_time component`                                                 |
| [`883d08f1`](https://github.com/NixOS/nixpkgs/commit/883d08f11617e532a51c1c156daa599ce2687ea4) | `python310Packages.here-transit: init at 1.2.0`                                                      |
| [`1cc979c2`](https://github.com/NixOS/nixpkgs/commit/1cc979c20fcd89f5aead923fca87e036b03b0e35) | `python310Packages.here-routing: init at 0.2.0`                                                      |
| [`082b1a5a`](https://github.com/NixOS/nixpkgs/commit/082b1a5a8ba7191b98c2b09fcbadcd67bbf942cc) | ``fcitx5-configtool: set `meta.mainProgram```                                                        |
| [`88b3cc8e`](https://github.com/NixOS/nixpkgs/commit/88b3cc8eccfa18585f8d82b25bf2a3adea1e681e) | `wasmer: 3.0.2 -> 3.1.0`                                                                             |
| [`50b615b5`](https://github.com/NixOS/nixpkgs/commit/50b615b57d13373aa8b43002569682e0ce660689) | `ruff: 0.0.181 -> 0.0.182`                                                                           |
| [`446bfd74`](https://github.com/NixOS/nixpkgs/commit/446bfd7430b1768b4102fa56a13c7c5774da3875) | `jumpy: 0.4.3 -> 0.5.1`                                                                              |
| [`c370a151`](https://github.com/NixOS/nixpkgs/commit/c370a1512910b09ec0c9baeeaf4c8e1797857009) | `morty: 0.2.0 -> unstable-2021-04-22, adopt`                                                         |
| [`821f4baa`](https://github.com/NixOS/nixpkgs/commit/821f4baa8c4e900e9ee016167402334be7283613) | `felix-fm: 2.2.0 -> 2.2.1`                                                                           |
| [`473a23da`](https://github.com/NixOS/nixpkgs/commit/473a23dae7d54c16c0d8ec79d41430b78f426de7) | `python310Packages.eth-keys: disable timing sensitive test`                                          |
| [`0ea5aa9d`](https://github.com/NixOS/nixpkgs/commit/0ea5aa9de24f7745bc57de627c7a674bd6dfa155) | `openrgb: 0.7 -> 0.8`                                                                                |
| [`25241d52`](https://github.com/NixOS/nixpkgs/commit/25241d52291c4feb5bccd8b487e53cf3077ebce4) | `ruff: 0.0.179 -> 0.0.181`                                                                           |
| [`1f40b119`](https://github.com/NixOS/nixpkgs/commit/1f40b119d8f4ce15c2acfea639ab71e91aa607c7) | `black: 22.10.0 -> 22.12.0`                                                                          |
| [`1ee4f9c1`](https://github.com/NixOS/nixpkgs/commit/1ee4f9c11e5acb22000a696a23477484cddac003) | `symfony-cli: add missing compilation flags`                                                         |
| [`4c4e900a`](https://github.com/NixOS/nixpkgs/commit/4c4e900a03392bd3c10bb24cecab58c2edf1f33d) | `python310Packages.ujson: 5.5.0 -> 5.6.0`                                                            |
| [`57ff5c65`](https://github.com/NixOS/nixpkgs/commit/57ff5c653030c686d5a30fada9a5adc042bd743e) | `python310Packages.isort: 5.10.1 -> 5.11.2`                                                          |
| [`c8528b82`](https://github.com/NixOS/nixpkgs/commit/c8528b82d289c86011eff65fbcb3e93568b33b15) | `coturn: don't build against openssl_1_1 anymore`                                                    |
| [`6f6dbe2d`](https://github.com/NixOS/nixpkgs/commit/6f6dbe2dcdc16467c64e9eae4d4344f396390119) | `coturn: override libevent openssl`                                                                  |
| [`6601875e`](https://github.com/NixOS/nixpkgs/commit/6601875eab31f5defd2a476b135536827f9a210e) | `plex: 1.29.2.6364-6d72b0cf6 -> 1.30.0.6486-629d58034`                                               |
| [`1a8db5b1`](https://github.com/NixOS/nixpkgs/commit/1a8db5b10655ea450ec38ac13f1891c59875ca01) | `nanomq: 0.14.1 -> 0.14.5`                                                                           |
| [`06137551`](https://github.com/NixOS/nixpkgs/commit/06137551e649c1c435a6279c38c7e75d2aa07b26) | `boinc: 7.20.2 -> 7.20.5`                                                                            |
| [`a79359b9`](https://github.com/NixOS/nixpkgs/commit/a79359b974b7aff7072430c2b04d92a191655c69) | `watchlog: 1.152.0 →  1.197.0`                                                                       |
| [`051fa105`](https://github.com/NixOS/nixpkgs/commit/051fa1056dfb833166768f11bd74885b4c343162) | `crystfel: fix symlib hard-coding`                                                                   |
| [`1d3a9a96`](https://github.com/NixOS/nixpkgs/commit/1d3a9a9601021f1a81a6d22f3dd83c3e47b70f30) | `invidious: fix build on aarch64-darwin`                                                             |
| [`74c12f3e`](https://github.com/NixOS/nixpkgs/commit/74c12f3e47568076bfe202a81e5574190aafef06) | `prowlarr: 0.4.9.2083 -> 0.4.10.2111`                                                                |
| [`0e41778c`](https://github.com/NixOS/nixpkgs/commit/0e41778ce25a585c8dd4247fd363cd9d1644912f) | `newman: 5.2.2 -> 5.3.2`                                                                             |
| [`732b59e3`](https://github.com/NixOS/nixpkgs/commit/732b59e37016f247a62819163b85f120e7c79b11) | `linuxPackages.apfs: unstable-2022-08-15 -> unstable-2022-10-20`                                     |
| [`be874693`](https://github.com/NixOS/nixpkgs/commit/be874693ce486078ab019a6e9221f5cdab67e457) | `linuxPackages.apfs: add passthru.tests`                                                             |
| [`f6ca99b8`](https://github.com/NixOS/nixpkgs/commit/f6ca99b86d2e75b4fc416f04ad138aef3c747aae) | `semgrep{,-core}: 0.112.1 -> 1.0.0`                                                                  |
| [`3a2124dd`](https://github.com/NixOS/nixpkgs/commit/3a2124ddabc8def85af4fed4703636945a170fff) | `xgboost: add headers from dmlc-core and rabit`                                                      |