### PR TITLE
chore(flake/nixpkgs): `757b8221` -> `04f574a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671200928,
-        "narHash": "sha256-mZfzDyzojwj6I0wyooIjGIn81WtGVnx6+avU5Wv+VKU=",
+        "lastModified": 1671359686,
+        "narHash": "sha256-3MpC6yZo+Xn9cPordGz2/ii6IJpP2n8LE8e/ebUXLrs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "757b82211463dd5ba1475b6851d3731dfe14d377",
+        "rev": "04f574a1c0fde90b51bf68198e2297ca4e7cccf4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                    |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`04f574a1`](https://github.com/NixOS/nixpkgs/commit/04f574a1c0fde90b51bf68198e2297ca4e7cccf4) | `kapp: 0.54.0 -> 0.54.1`                                          |
| [`b65120b6`](https://github.com/NixOS/nixpkgs/commit/b65120b662a663f997ddc795c3e42fe9218864c4) | `kubemq-community: 2.3.5 -> 2.3.7`                                |
| [`ecca235a`](https://github.com/NixOS/nixpkgs/commit/ecca235a5bdf580ec15cde533f5a95266bbc7fb7) | `mongodb-compass: 1.34.1 -> 1.34.2`                               |
| [`6c3fbca3`](https://github.com/NixOS/nixpkgs/commit/6c3fbca325f6d24504c2c1d5511a3e874617c59c) | `cachix: 1.0.1 -> 1.1`                                            |
| [`95407e7c`](https://github.com/NixOS/nixpkgs/commit/95407e7c09787d8905a12f7072666d579877bd94) | `jc: 1.22.2 -> 1.22.3`                                            |
| [`6b24d975`](https://github.com/NixOS/nixpkgs/commit/6b24d97551481782cdbcf3ddb1918ca48d76ec4e) | `level-zero: 1.8.8 -> 1.8.12`                                     |
| [`afba69bc`](https://github.com/NixOS/nixpkgs/commit/afba69bcb5ce9842df43860ef26ac7ca1d638562) | `devspace: 6.2.1 -> 6.2.2`                                        |
| [`e4157112`](https://github.com/NixOS/nixpkgs/commit/e41571123aa2b11cce1ca152d296d351c7b36613) | `ocamlPackages.ansiterminal: 0.8.2 → 0.8.5`                       |
| [`242fa43f`](https://github.com/NixOS/nixpkgs/commit/242fa43f1042720c94fb45ec96e03cb7ecfbcfc0) | `python310Packages.transformers: 4.24.0 -> 4.25.1`                |
| [`a87ddf11`](https://github.com/NixOS/nixpkgs/commit/a87ddf11992edd7f1ebe7ebf0fabfb5a5d84daad) | `flexget: 3.5.11 -> 3.5.12`                                       |
| [`ee9715db`](https://github.com/NixOS/nixpkgs/commit/ee9715db0d0f56e0dc05caf0e2be288ff98c475d) | `python310Packages.sqlmap: 1.6.11 -> 1.6.12`                      |
| [`ecd5087a`](https://github.com/NixOS/nixpkgs/commit/ecd5087a39e8b03a468eda3d10ea43b538662d34) | `lhapdf: 6.5.2 -> 6.5.3`                                          |
| [`3a12844a`](https://github.com/NixOS/nixpkgs/commit/3a12844afa41655ce908ac51cb23c7138e2164eb) | `datafusion-cli: unstable-2022-04-08 -> 15.0.0`                   |
| [`8735b044`](https://github.com/NixOS/nixpkgs/commit/8735b044f9da2a65ffc40e78e4d4cd6e40d4f231) | `libva1: fix cross compilation`                                   |
| [`16d80744`](https://github.com/NixOS/nixpkgs/commit/16d80744cc6d275e73e5dc710d91a8e1a9d58f08) | `ndppd: fix cross compilation`                                    |
| [`9dc122cf`](https://github.com/NixOS/nixpkgs/commit/9dc122cf90ae64c84e98d632c3a4daeebeb23ef6) | `clifm: 1.7 -> 1.9`                                               |
| [`558544c1`](https://github.com/NixOS/nixpkgs/commit/558544c1b479a55975391a9b8e8ae4715ed393a5) | `smiley-sans: improve code`                                       |
| [`ed7c5566`](https://github.com/NixOS/nixpkgs/commit/ed7c5566398323db48f0d8624a1028c8ef659331) | `nickel: fill meta.changelog`                                     |
| [`3166d3d7`](https://github.com/NixOS/nixpkgs/commit/3166d3d7852c076edcc0a0207c171dafa3154880) | `picom: 10.1 -> 10.2`                                             |
| [`49d58677`](https://github.com/NixOS/nixpkgs/commit/49d586773291ceba7a0c63f00a35efb11e05a84b) | `root: move nlohmann_json to propagatedBuildInputs`               |
| [`4e9e0811`](https://github.com/NixOS/nixpkgs/commit/4e9e0811b6838847bee1795a6a6dcd7a9c617287) | `coinlive: fix build on darwin`                                   |
| [`04a1c0d7`](https://github.com/NixOS/nixpkgs/commit/04a1c0d7add4ebe7a1092b7d22968d26fc0de379) | `treewide: fix quoting of GITHUB_TOKEN in curl`                   |
| [`5b198bd7`](https://github.com/NixOS/nixpkgs/commit/5b198bd79c83ce62e0de82a11766ac2e6709dfa7) | `python310Packages.dnachisel: 3.2.9 -> 3.2.10`                    |
| [`7c3a27db`](https://github.com/NixOS/nixpkgs/commit/7c3a27dba627facfc8f8f27d6e3259db8829a1e6) | `pdns-recursor: 4.7.3 -> 4.8.0`                                   |
| [`0b5c1f33`](https://github.com/NixOS/nixpkgs/commit/0b5c1f336b54540830b5323e28755feb95ca9217) | `jrsonnet: unbreak on darwin, add figsoda as a maintainer`        |
| [`88984cfe`](https://github.com/NixOS/nixpkgs/commit/88984cfeee5bad9175e86113c3357398017d1c29) | `vector: add update  script to derivation`                        |
| [`4e371517`](https://github.com/NixOS/nixpkgs/commit/4e371517033d31305a50509004bd3a7003a26afe) | `mimir: 2.4.0 -> 2.5.0`                                           |
| [`2132ffcb`](https://github.com/NixOS/nixpkgs/commit/2132ffcb74376b2969464ce30f42593b394d2599) | `erigon: add update script to derivation`                         |
| [`d96d425f`](https://github.com/NixOS/nixpkgs/commit/d96d425f7b74cec5898bf194a539265d569eca7f) | `python310Packages.asn1tools: 0.164.0 -> 0.165.0`                 |
| [`4fd61e85`](https://github.com/NixOS/nixpkgs/commit/4fd61e853684ef66d119f03c60ecb089c5bdb980) | `python310Packages.aiolifx-themes: 0.2.1 -> 0.3.0`                |
| [`82c749f2`](https://github.com/NixOS/nixpkgs/commit/82c749f22403d0a39e3083b1ccecebeb307eda6a) | `python310Packages.aliyun-python-sdk-dbfs: 2.0.2 -> 2.0.3`        |
| [`03cfc400`](https://github.com/NixOS/nixpkgs/commit/03cfc40031dfda7c73779048beaf3c446bfc8fdb) | `mdbook-katex: 0.2.17 -> 0.2.21`                                  |
| [`44a3bcca`](https://github.com/NixOS/nixpkgs/commit/44a3bccab9071f62b9d6c451d9e8f4ba2c249d2c) | `nickel: 0.3.0 -> 0.3.1`                                          |
| [`963af963`](https://github.com/NixOS/nixpkgs/commit/963af96386d54297406995a23d0ad67ea75a8a22) | `netbird: 0.11.5 -> 0.11.6`                                       |
| [`fd413df6`](https://github.com/NixOS/nixpkgs/commit/fd413df665f6626a5ef1c2e3ce4fe37a791fac5d) | `nanomq: 0.14.5 -> 0.14.8`                                        |
| [`dfd79a51`](https://github.com/NixOS/nixpkgs/commit/dfd79a513be31733a7082af89246e4bba08fbd9b) | `star-history: 1.0.5 -> 1.0.6`                                    |
| [`a98f1c2a`](https://github.com/NixOS/nixpkgs/commit/a98f1c2a5fae9c1f280678a3def9d4603a1751e3) | `BeatSaberModManager: 0.0.2 -> 0.0.4`                             |
| [`56472fc5`](https://github.com/NixOS/nixpkgs/commit/56472fc512f72039273bb06abc683f745a31e7fe) | `cargo-chef: init at 0.1.50`                                      |
| [`d2085278`](https://github.com/NixOS/nixpkgs/commit/d20852787475c0e4b7078010039029247d659d2f) | `python310Packages.fakeredis: 2.2.0 -> 2.3.0`                     |
| [`b2025f0f`](https://github.com/NixOS/nixpkgs/commit/b2025f0f7f856539a73d6e074c59710ed457e673) | `linuxKernel.kernels.linux_lqx: 6.0.13-lqx2 -> 6.0.13-lqx3`       |
| [`e9c1876e`](https://github.com/NixOS/nixpkgs/commit/e9c1876e9449e742e93584e68afdda63a01b2008) | `python310Packages.aiomisc: 16.2 -> 16.2.10`                      |
| [`2130acfa`](https://github.com/NixOS/nixpkgs/commit/2130acfabdf5a7149ef624c2113f2249b387c5f2) | `python310Packages.nettigo-air-monitor: 1.5.0 -> 1.6.0`           |
| [`deac3ab9`](https://github.com/NixOS/nixpkgs/commit/deac3ab9e71b9617eed58f5879a9ded76ae585d0) | `pyupgrade: 3.1.0 -> 3.3.1`                                       |
| [`b821711e`](https://github.com/NixOS/nixpkgs/commit/b821711e33db15fbdaa8f480179ad6f39a9c24e2) | `python310Packages.zamg: 0.2.0 -> 0.2.1`                          |
| [`a519dea3`](https://github.com/NixOS/nixpkgs/commit/a519dea33528bbc7676e70545ccb49fc43a1d85f) | `python310Packages.sentry-sdk: 1.11.1 -> 1.12.0`                  |
| [`2b748ef0`](https://github.com/NixOS/nixpkgs/commit/2b748ef061b2960c5ebfe74754e96b597ff3030a) | `mcfly: 0.7.0 -> 0.7.1`                                           |
| [`19ac0814`](https://github.com/NixOS/nixpkgs/commit/19ac0814397f5f7ed7a65175e4c489eccad3b2de) | `nix-template: 0.4.0 -> 0.4.1`                                    |
| [`3fbede97`](https://github.com/NixOS/nixpkgs/commit/3fbede97da9e5af7ea65b36a1eed60245157c3bd) | `python310Packages.pytenable: 1.4.10 -> 1.4.11`                   |
| [`4e10c04b`](https://github.com/NixOS/nixpkgs/commit/4e10c04b858c405b6302977559becedfb01c03a9) | `python310Packages.pyezviz: 0.2.0.10 -> 0.2.0.11`                 |
| [`02fb72e1`](https://github.com/NixOS/nixpkgs/commit/02fb72e12dd426030c1d3abb15abfc222c61fbc2) | `logrotate: 3.20.1 -> 3.21.0`                                     |
| [`acc05d05`](https://github.com/NixOS/nixpkgs/commit/acc05d059d913beaf169239ade7848327bfc7089) | `python310Packages.identify: 2.5.9 -> 2.5.10`                     |
| [`137f5d07`](https://github.com/NixOS/nixpkgs/commit/137f5d07bf971d7c99efefa8d61c66be4af0849a) | `python310Packages.jaconv: 0.3 -> 0.3.1`                          |
| [`6b265ea7`](https://github.com/NixOS/nixpkgs/commit/6b265ea769b8fad0c91fae08860cfe0ace7d2151) | `python310Packages.faraday-plugins: 1.8.1 -> 1.9.0`               |
| [`4b81f8cf`](https://github.com/NixOS/nixpkgs/commit/4b81f8cf5b31417bd2f4ef4af72d3be353f4244e) | `python310Packages.dnfile: 0.12.0 -> 0.13.0`                      |
| [`59aec369`](https://github.com/NixOS/nixpkgs/commit/59aec3697e48aee3c57f7f309a18dda38c92dc8f) | `catfs: patch to compile using rust 1.65`                         |
| [`d7ec1a32`](https://github.com/NixOS/nixpkgs/commit/d7ec1a325152b066db4cc4917cab695d4bf80ba6) | `catfs: unstable-2020-03-21 -> 0.9.0`                             |
| [`9956f663`](https://github.com/NixOS/nixpkgs/commit/9956f66315db9ebaa128c7ffe5ea58fa66d3e262) | `protobuf: ensure matching version in buildPackages (#206564)`    |
| [`77822a6a`](https://github.com/NixOS/nixpkgs/commit/77822a6afa212605e61911b5638656a6be380325) | `pkgsMusl.jdk: fix build`                                         |
| [`8a2a9407`](https://github.com/NixOS/nixpkgs/commit/8a2a94078bb4803847e2f685011c7de10a202aee) | `pkgsMusl.javaPackages.compiler.openjdk18: fix build`             |
| [`2a76b36b`](https://github.com/NixOS/nixpkgs/commit/2a76b36b27d3bc31727c94b2290c4b89eec2b153) | `python310Packages.azure-mgmt-network: 22.0.0 -> 22.2.0`          |
| [`b79567b8`](https://github.com/NixOS/nixpkgs/commit/b79567b831169c32200dd991f120b224188adf30) | `python310Packages.logging-journald: 0.6.3 -> 0.6.4`              |
| [`410da1fe`](https://github.com/NixOS/nixpkgs/commit/410da1fec495a68b0935b28338b4931c6e07013f) | `python310Packages.logging-journald: 0.6.2 -> 0.6.3`              |
| [`15046139`](https://github.com/NixOS/nixpkgs/commit/15046139d5475a5fe285575f998698045c65cc06) | `nixos/mmsd: init`                                                |
| [`acac950e`](https://github.com/NixOS/nixpkgs/commit/acac950ef6a5f74db4ff602d234676e644a48c32) | `mmsd: init at 1.12.1`                                            |
| [`fb769ee3`](https://github.com/NixOS/nixpkgs/commit/fb769ee3c30fc5fc8298655e8f26fbd5c03e597f) | `pam-reattach: cleanup (#205509)`                                 |
| [`e9111708`](https://github.com/NixOS/nixpkgs/commit/e91117081e6981f000a4bdd0c58c75b4494f6287) | `libreddit: 0.25.0 -> 0.25.1`                                     |
| [`50d1c2ce`](https://github.com/NixOS/nixpkgs/commit/50d1c2ce19ddd551244d2d295016ec7552b444f2) | `libretro-core-info: 1.13.0 -> 1.14.0`                            |
| [`9ecbb078`](https://github.com/NixOS/nixpkgs/commit/9ecbb0786cece01a2cced450a266a4fe2f6b89c8) | `ldapnomnom: add changelog to meta`                               |
| [`1e71885e`](https://github.com/NixOS/nixpkgs/commit/1e71885e1e7756b9e66f97c2ea13170b644063e7) | `lefthook: 1.2.4 -> 1.2.6`                                        |
| [`9d4c52cf`](https://github.com/NixOS/nixpkgs/commit/9d4c52cfd279f43e25c0e99ae06861b8df65b749) | `ldapnomnom: 1.0.7 -> 1.1.0`                                      |
| [`1865acec`](https://github.com/NixOS/nixpkgs/commit/1865acec019bb2f028e3d2784fadb83d6f06558c) | `ocaml-ng.ocamlPackages_5_0: 5.0.0-rc1 -> 5.0.0`                  |
| [`e1dfd314`](https://github.com/NixOS/nixpkgs/commit/e1dfd3146908b367c85dcf1009c8d19f822a88a2) | `kubergrunt: 0.9.3 -> 0.10.0`                                     |
| [`eec92af0`](https://github.com/NixOS/nixpkgs/commit/eec92af049e398ba43ca4d26ed95597cb0cb77d5) | `nix: Cherry-pick #7473 for sqlite detailed message`              |
| [`a731c6ac`](https://github.com/NixOS/nixpkgs/commit/a731c6acb46e06144da95152cff21d6fb85f1981) | `pulumiPackages.pulumi-language-nodejs: init at 3.47.0`           |
| [`80d60e2e`](https://github.com/NixOS/nixpkgs/commit/80d60e2ee20e7ec912acf84d4ce1dd2a2025d57b) | ` python310Packages.dockerfile-parse: add changelog to meta`      |
| [`4bb97956`](https://github.com/NixOS/nixpkgs/commit/4bb97956ac21b9dfac18b008a767ef4724fe7542) | `python310Packages.pysigma-backend-qradar: 0.2.1 -> 0.3.0`        |
| [`19096d32`](https://github.com/NixOS/nixpkgs/commit/19096d328eac9d03c0efa12cb5f48e641f503b26) | `python310Packages.pysigma-backend-qradar: add changelog to meta` |
| [`f5736556`](https://github.com/NixOS/nixpkgs/commit/f573655698527840d9b1b6b74ae3900dc1ecab58) | `packagekit: update homepage`                                     |
| [`92016199`](https://github.com/NixOS/nixpkgs/commit/920161999c7dffc70845741ca901e21ea4a11778) | `yambar: 1.8.0 -> 1.9.0`                                          |
| [`7af8780d`](https://github.com/NixOS/nixpkgs/commit/7af8780d026dbea7fe60ef8c76564e8e60020512) | `python310Packages.dockerfile-parse: 1.2.0 -> 2.0.0`              |
| [`d0745d7b`](https://github.com/NixOS/nixpkgs/commit/d0745d7b3b1752505cea4815932e53f401bffbf3) | `Update pkgs/development/tools/poac/default.nix`                  |
| [`68e514ed`](https://github.com/NixOS/nixpkgs/commit/68e514ed1cf55451901e8d0edd3e8ee5102d3565) | ``nixos/tailscale: Add `useRoutingFeatures` option``              |
| [`75db60e8`](https://github.com/NixOS/nixpkgs/commit/75db60e84277c5ce076b345203530b92e2b97060) | `python310Packages.brother: 2.0.0 -> 2.1.1`                       |
| [`3dd6b9eb`](https://github.com/NixOS/nixpkgs/commit/3dd6b9ebd46ea372a80aea185fb87e6e91d9feef) | `gleam: 0.25.1 -> 0.25.3`                                         |
| [`105ea988`](https://github.com/NixOS/nixpkgs/commit/105ea9886999437be182f057078fc6aaf2f97508) | `trezor-suite: 22.10.3 -> 22.11.1`                                |
| [`d067d527`](https://github.com/NixOS/nixpkgs/commit/d067d5279fa62629c430c47c7eb0de58f4abe0f7) | `ocamlPackages.lru: 0.3.0 → 0.3.1`                                |
| [`dd0e4947`](https://github.com/NixOS/nixpkgs/commit/dd0e4947998f928772d8421b79a1c5acd3cf8ebb) | `cinnamon.cinnamon-translations: 5.6.0 -> 5.6.1`                  |
| [`2928c77a`](https://github.com/NixOS/nixpkgs/commit/2928c77a5d1ebc491fee79d4bdca3aee2de5bc1f) | `python310Packages.govee-ble: 0.19.1 -> 0.19.3`                   |
| [`9aff4216`](https://github.com/NixOS/nixpkgs/commit/9aff4216e7ab1c596990565b807ce726a123357c) | `python310Packages.pytibber: 0.26.4 -> 0.26.5`                    |
| [`26a94f31`](https://github.com/NixOS/nixpkgs/commit/26a94f31631beb38d7f371c8a195d118ecdc3791) | `python310Packages.bluetooth-auto-recovery: 1.0.0 -> 1.0.3`       |
| [`3155c2fb`](https://github.com/NixOS/nixpkgs/commit/3155c2fb0e126896eedc40c33d892cf9d268cba6) | `python310Packages.pyswitchbot: 0.27.0 -> 0.27.1`                 |
| [`1d360151`](https://github.com/NixOS/nixpkgs/commit/1d36015126d2a4d5ed9fad10af255017d0498d86) | `python310Packages.pyswitchbot: 0.26.0 -> 0.27.0`                 |
| [`522206c4`](https://github.com/NixOS/nixpkgs/commit/522206c4680d72eae745924e7771ee6930a67691) | `python310Packages.pyswitchbot: 0.25.0 -> 0.26.0`                 |
| [`cc3502e3`](https://github.com/NixOS/nixpkgs/commit/cc3502e37def71881cb4a334e5cc1741251b7af9) | `python310Packages.pyswitchbot: 0.24.0 -> 0.25.0`                 |
| [`30cdcf22`](https://github.com/NixOS/nixpkgs/commit/30cdcf22d32650920aa390275657479f2582c526) | `python310Packages.pyswitchbot: 0.23.2 -> 0.24.0`                 |
| [`ce95518d`](https://github.com/NixOS/nixpkgs/commit/ce95518d6441bcfe3b7bdd114cdf394ac4aca579) | `python310Packages.ical: 4.2.2 -> 4.2.3`                          |
| [`706cadc6`](https://github.com/NixOS/nixpkgs/commit/706cadc68b1713a94712ce8a37476e931e95c784) | `python310Packages.yalexs-ble: 0.12.1 -> 1.12.2`                  |
| [`b2bcafc4`](https://github.com/NixOS/nixpkgs/commit/b2bcafc4b753ffccc3d91c857f386f465b46a136) | `python310Packages.yalexs-ble: 0.12.0 -> 0.12.1`                  |
| [`93016af2`](https://github.com/NixOS/nixpkgs/commit/93016af260909ac4dfb88aae6228bb0a45ad1e6d) | `python310Packages.yalexs-ble: 1.11.4 -> 0.12.0`                  |
| [`019f0e90`](https://github.com/NixOS/nixpkgs/commit/019f0e90e0a2dc96528c4b333c4ce7b5e57ee5d8) | `metasploit: 6.2.30 -> 6.2.31`                                    |
| [`c8c93b4d`](https://github.com/NixOS/nixpkgs/commit/c8c93b4d62064668f05291f129d8f09e020d578a) | `clash-geoip: remove old update script`                           |
| [`cf47201d`](https://github.com/NixOS/nixpkgs/commit/cf47201dccd79be624ce328123f8d34b4d36ff2b) | `mubeng: add changelog to meta`                                   |
| [`62fa8fe9`](https://github.com/NixOS/nixpkgs/commit/62fa8fe959b53d021fe549e0b6665aab5d40a48d) | `clash-geoip: use new update script`                              |
| [`accac89d`](https://github.com/NixOS/nixpkgs/commit/accac89d29842a3165259118f07592a222278e90) | `circup: add changelog to meta`                                   |
| [`80c24eeb`](https://github.com/NixOS/nixpkgs/commit/80c24eeb9ff46aa99617844d0c4168659e35175f) | `adguardhome: 0.107.20 -> 0.107.21`                               |
| [`a96a26e9`](https://github.com/NixOS/nixpkgs/commit/a96a26e9b71d006f71262031ccc0a6fe851a14a3) | `python310Packages.azure-mgmt-resource: 21.2.1 -> 22.0.0`         |
| [`565786bb`](https://github.com/NixOS/nixpkgs/commit/565786bb2e3bd0bbfb491a832b29e492ca9e5b59) | `python310Packages.afsapi: add changelog to meta`                 |
| [`b5cca064`](https://github.com/NixOS/nixpkgs/commit/b5cca064692244720ae64c0ead900fbdb993ed28) | `weidu: fixup build by using older make`                          |
| [`99fb246d`](https://github.com/NixOS/nixpkgs/commit/99fb246d724df87be9a153de83addc4825858f6e) | `sile: fixup build by using older make`                           |
| [`9e9b992a`](https://github.com/NixOS/nixpkgs/commit/9e9b992a5b318579a82e3d60cbdbf9108fffb5fa) | `grpc: fixup build on aarch64-linux by using older C++`           |
| [`18273180`](https://github.com/NixOS/nixpkgs/commit/18273180d18d2fbdf5f067b473d15433f9de497d) | `redo-apenwarr: fixup build by using older make`                  |
| [`ac54eb17`](https://github.com/NixOS/nixpkgs/commit/ac54eb177a59b136b1971b4fe6adc67f7597692a) | `ocamlPackages.apron: fixup build by using older make`            |
| [`e5348c1c`](https://github.com/NixOS/nixpkgs/commit/e5348c1c8ccde6ce9dfde854e402e7f3c23b3566) | `qgis: 3.26.2 -> 3.28.2`                                          |
| [`31b315f1`](https://github.com/NixOS/nixpkgs/commit/31b315f1f4c1c5256d7bb9be03cbf8685cd54f0e) | `package-project-cmake: init at 1.10.0`                           |
| [`592d10ec`](https://github.com/NixOS/nixpkgs/commit/592d10ecce619d011b0ef2922699da6e5aa70b94) | `git2-cpp: init at 0.1.1`                                         |
| [`83921582`](https://github.com/NixOS/nixpkgs/commit/8392158289e7d1a801905bc4195983f1b7434770) | `cudaPackages: add cudaFlags (#205351)`                           |
| [`1350869f`](https://github.com/NixOS/nixpkgs/commit/1350869f0ffc23f8be63ca85ace7e6341a881b8e) | `python310Packages.afsapi: 0.2.7 -> 0.2.8`                        |
| [`a2049216`](https://github.com/NixOS/nixpkgs/commit/a204921606d0f282be43a7df04b5b8e1da5fb68d) | `python310Packages.adafruit-platformdetect: 3.37.0 -> 3.38.0`     |
| [`32c1e7d7`](https://github.com/NixOS/nixpkgs/commit/32c1e7d7db94bb07b8ef807df8c32a6a5c8d75ee) | ``androidenv: fix missing `inherit os` in build-tools``           |
| [`762806df`](https://github.com/NixOS/nixpkgs/commit/762806dfef03db6d6921a0806e894205687399e6) | `ruff: 0.0.184 -> 0.0.185`                                        |
| [`f01c9db4`](https://github.com/NixOS/nixpkgs/commit/f01c9db4126e96f4c1a00c491aaaf309ca596cb1) | `librespot: unbreak on darwin`                                    |
| [`067bfc6c`](https://github.com/NixOS/nixpkgs/commit/067bfc6c90a301572cec7da48f09c447a9a8eae0) | `open-stage-control: do not copy node_modules to reduce closure`  |
| [`4a194173`](https://github.com/NixOS/nixpkgs/commit/4a194173b0c2d59cc83c0ab05ee95d7090f02968) | `nixos/katriawm: add module`                                      |
| [`11282edf`](https://github.com/NixOS/nixpkgs/commit/11282edfe7de0c786c6f5ddc1ce5e370c1f08b38) | `katriawm: init at 21.09`                                         |
| [`dc872f38`](https://github.com/NixOS/nixpkgs/commit/dc872f38d2d6ed14239c8c88a780f873eac7d8ac) | `sxhkd: move to tools/X11`                                        |
| [`4ee04d0f`](https://github.com/NixOS/nixpkgs/commit/4ee04d0f1a9eeaa4732d67dc5a96f1c666cd4273) | `module-list: put in ascii-betical ordering`                      |
| [`c9ad861d`](https://github.com/NixOS/nixpkgs/commit/c9ad861d93b7857e418dc84e916dbc5709886e66) | `coder: 0.13.2 -> 0.13.3`                                         |
| [`0c924ec9`](https://github.com/NixOS/nixpkgs/commit/0c924ec948073580a3c3d438746388d05a38028b) | `qemu: 7.1.0 -> 7.2.0`                                            |
| [`aac4134f`](https://github.com/NixOS/nixpkgs/commit/aac4134f430fb15386a174c6556ca0116616d2ea) | `nixos/tests/bootspec: add EFI support for GRUB test`             |