### PR TITLE
chore(flake/home-manager): `37713c6b` -> `e7eba9cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671335968,
-        "narHash": "sha256-V7mjlh7brp70elokmml6XzHinpTilkQJjiYIGjEmSGs=",
+        "lastModified": 1671459164,
+        "narHash": "sha256-RbkDnvLV7WjbiF4Dpiezrf8kXxwieQXAVtY8ciRQj6Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "37713c6b04b963d41664e03576f73a18c9b0d224",
+        "rev": "e7eba9cc46547ae86642ad3c6a9a4fb22c07bc26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                          |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`e7eba9cc`](https://github.com/nix-community/home-manager/commit/e7eba9cc46547ae86642ad3c6a9a4fb22c07bc26) | `home-manager: refine flake URI lookup` |