### PR TITLE
chore(flake/nixos-hardware): `7a1b9419` -> `25010a04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1671455302,
-        "narHash": "sha256-4nqEGeNviqPJy9IBd6Bi21ABz5z3Rdgo7IhbwBAmwYE=",
+        "lastModified": 1671467847,
+        "narHash": "sha256-eIeZIQbbW0QYDW0nhDaieokw6VakPO3TyJ3RmxqGHOs=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "7a1b9419c9430558481d8cc117e9906fd272eaa5",
+        "rev": "25010a042c23695ae457a97aad60e9b1d49f2ecc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                       |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`ab165ab1`](https://github.com/NixOS/nixos-hardware/commit/ab165ab191793e277dd2ce1e3a77cc621f4600b5) | `Add standalone hybrid only and nvidia only modules` |
| [`b53fc0a7`](https://github.com/NixOS/nixos-hardware/commit/b53fc0a7858871e58332ee02ffbc0f256a0d5afe) | `Add specialisation for “DDG" mode is enabled`       |
| [`dea6ef85`](https://github.com/NixOS/nixos-hardware/commit/dea6ef85a18bcd66bb4dfcf5a649d9404f2377cd) | `Enable hardware.nvidia.modesetting`                 |
| [`dc8f1fd6`](https://github.com/NixOS/nixos-hardware/commit/dc8f1fd6a8696e700a2ac4c5057a8b7975a26a84) | `Enable hardware.nvidia.powerManagement`             |
| [`262146dc`](https://github.com/NixOS/nixos-hardware/commit/262146dc7631b962b515e7e972930f6e12607d7f) | `Override edid of built-in display`                  |