### PR TITLE
chore(flake/home-manager): `e7eba9cc` -> `0f8bf4f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671459164,
-        "narHash": "sha256-RbkDnvLV7WjbiF4Dpiezrf8kXxwieQXAVtY8ciRQj6Q=",
+        "lastModified": 1671578428,
+        "narHash": "sha256-YmbpBcPaGz9KE2bC4xPvSdgCSMk0BmS/L3ePvy9TR/M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e7eba9cc46547ae86642ad3c6a9a4fb22c07bc26",
+        "rev": "0f8bf4f92efa3c6168705b49a6788abb3612033a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`b44f56df`](https://github.com/nix-community/home-manager/commit/b44f56dfcdc5eabbc5be9094c1db1251fb761483) | `nushell: support darwin config file locations` |
| [`47bb9e75`](https://github.com/nix-community/home-manager/commit/47bb9e756937a2609a62b192ba06780f865f7e03) | `herbstluftwm: Reset mousebinds on (re)load`    |
| [`1a0a5f50`](https://github.com/nix-community/home-manager/commit/1a0a5f50376e2c3b0df9728befc59f07da44be21) | `herbstluftwm: Fix error when no tags set`      |