### PR TITLE
chore(flake/nixpkgs): `04f574a1` -> `fad51abd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671359686,
-        "narHash": "sha256-3MpC6yZo+Xn9cPordGz2/ii6IJpP2n8LE8e/ebUXLrs=",
+        "lastModified": 1671983799,
+        "narHash": "sha256-Z2Ro6hFPZHkBqkVXY5/aBUzxi5xizQGvuHQ9+T5B/ks=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "04f574a1c0fde90b51bf68198e2297ca4e7cccf4",
+        "rev": "fad51abd42ca17a60fc1d4cb9382e2d79ae31836",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`bd0e5c29`](https://github.com/NixOS/nixpkgs/commit/bd0e5c293a8ffc76569ec68beac793c1bc376544) | `vscodium: 1.74.1.22349 -> 1.74.2.22355`                                             |
| [`4ec86b13`](https://github.com/NixOS/nixpkgs/commit/4ec86b13c9bf2112ced4111a420c2c800729112f) | `pleroma: 2.4.4 -> 2.5.0 (#207521)`                                                  |
| [`34605944`](https://github.com/NixOS/nixpkgs/commit/34605944af1b7504fcde8b665bc75e4e6c5f624c) | `memtester: 4.5.1 -> 4.6.0`                                                          |
| [`d5cd7d7d`](https://github.com/NixOS/nixpkgs/commit/d5cd7d7d478b0845ac0db4641afcb6e1a14cb76c) | `joplin-desktop: 2.8.8 -> 2.9.17`                                                    |
| [`d366e7ea`](https://github.com/NixOS/nixpkgs/commit/d366e7ea1eda205661fcdef923449c8a18677190) | `spice-gtk: unbreak on darwin`                                                       |
| [`c61ed5bf`](https://github.com/NixOS/nixpkgs/commit/c61ed5bf6c40f0543036bf42bd38f8c66cb1a1e4) | `python310Packages.skodaconnect: 1.1.27 -> 1.2.2`                                    |
| [`8691fe91`](https://github.com/NixOS/nixpkgs/commit/8691fe91dd936707c3b71a0e304b992bf059d705) | `python310Packages.screenlogicpy: 0.5.5 -> 0.6.0`                                    |
| [`700adb32`](https://github.com/NixOS/nixpkgs/commit/700adb32e9cef98c1acddfd8ef4967471c44faa6) | `nixos/sane: point SANE_CONFIG_DIR away from /etc/sane.d`                            |
| [`62ee7bfa`](https://github.com/NixOS/nixpkgs/commit/62ee7bfa4571fa04c016d9b2075ecc631798b07a) | `python310Packages.screenlogicpy: add changelog to meta`                             |
| [`72581175`](https://github.com/NixOS/nixpkgs/commit/72581175ac91800726ec0cb88dac92f15d6e2678) | `python310Packages.nibe: 1.5.0 -> 1.6.0`                                             |
| [`d70cee46`](https://github.com/NixOS/nixpkgs/commit/d70cee46ab9b0908157613ab6f27fc38f12aec69) | `python310Packages.pyvmomi: add changelog to meta`                                   |
| [`927a8d2e`](https://github.com/NixOS/nixpkgs/commit/927a8d2e9716e0b3bc82a1c626f149e3efc9c0e6) | `python310Packages.pyvmomi: 7.0.3 -> 8.0.0.1`                                        |
| [`6c7ee71a`](https://github.com/NixOS/nixpkgs/commit/6c7ee71a3669b1f944caf08ba7d3289fcfe2377d) | `paperless-ngx: 1.9.2 -> 1.10.2`                                                     |
| [`c946e0b9`](https://github.com/NixOS/nixpkgs/commit/c946e0b9c8c8c7be952938a4d7ac4dd65f1a0793) | `django-celery-results: init at 2.4.0`                                               |
| [`c79f6e7f`](https://github.com/NixOS/nixpkgs/commit/c79f6e7f949f05d6086f06060ca145bbd7f8861f) | `maintainers: update babariviere`                                                    |
| [`57b0ac48`](https://github.com/NixOS/nixpkgs/commit/57b0ac48c781e14c939651571ec741125fa10463) | `sentry-native: add changelog to meta`                                               |
| [`5c460637`](https://github.com/NixOS/nixpkgs/commit/5c4606376cbcdaa455d3d662e9159d034d9ae1ff) | `sentry-native: 0.5.2 -> 0.5.3`                                                      |
| [`16ddcfeb`](https://github.com/NixOS/nixpkgs/commit/16ddcfeb9ecf8bcbebbc9f7b00f52dfadeef399e) | `python310Packages.fire: switch to pytestCheckHook`                                  |
| [`4e60551c`](https://github.com/NixOS/nixpkgs/commit/4e60551c73ba34b98e701a433ba9df920d084e1f) | `python310Packages.fire: update meta`                                                |
| [`13b70d97`](https://github.com/NixOS/nixpkgs/commit/13b70d97fd2d879a6a8e23fbd0dc9eabfae752f1) | `python310Packages.fire: 0.4.0 -> 0.5.0`                                             |
| [`07b31549`](https://github.com/NixOS/nixpkgs/commit/07b3154972fe2d1870e658022a83cdb27efe0b93) | `python39Packages.arabic-reshaper: disable on older Python releases`                 |
| [`4dec038e`](https://github.com/NixOS/nixpkgs/commit/4dec038e127fdc36677022896b11283ba7e543bb) | `python39Packages.arabic-reshaper: 2.1.3 -> 2.1.4`                                   |
| [`c4d3b3a8`](https://github.com/NixOS/nixpkgs/commit/c4d3b3a8daba499532d57049ed2be2d2ef926323) | `bind: 9.18.8 -> 9.18.9`                                                             |
| [`d66e9116`](https://github.com/NixOS/nixpkgs/commit/d66e9116b3faf7ef2350a2f1fc16eafa1e2edf1e) | `kubebuilder: add changelog to meta`                                                 |
| [`e07118b7`](https://github.com/NixOS/nixpkgs/commit/e07118b744d7f616c1d324e23b66f2a203dc2c94) | `kubebuilder: 3.7.0 -> 3.8.0`                                                        |
| [`91044734`](https://github.com/NixOS/nixpkgs/commit/91044734918d9c80945178121bc24019cc56af58) | `python310Packages.sphinxcontrib-plantuml: disable on older Python releases`         |
| [`ef996d7e`](https://github.com/NixOS/nixpkgs/commit/ef996d7e588f83d9a44cbc93becbffa4dac4ab3a) | `python310Packages.sphinxcontrib-plantuml: 0.24 -> 0.24.1`                           |
| [`72d694c3`](https://github.com/NixOS/nixpkgs/commit/72d694c3054eeacd08841243e3b7aa431ee22b04) | `nb: 6.11.2 -> 7.2.0`                                                                |
| [`f28015a8`](https://github.com/NixOS/nixpkgs/commit/f28015a8e0d3dc944f114d22bf33aafd5a0e8ab7) | `python310Packages.dparse2: 0.6.1 -> 0.7.0`                                          |
| [`bdd86588`](https://github.com/NixOS/nixpkgs/commit/bdd86588f75ca35cb1fdd29d08a3de69be96659f) | `sqlcipher: add changelog to meta`                                                   |
| [`1d28b658`](https://github.com/NixOS/nixpkgs/commit/1d28b6582f643c06688259c9f0b0ce10bab15710) | `sqlcipher: 4.5.2 -> 4.5.3`                                                          |
| [`d9eb3889`](https://github.com/NixOS/nixpkgs/commit/d9eb3889c6964cff82007d05dd8729423690019a) | `checkmate: add changelog to meta`                                                   |
| [`1be98390`](https://github.com/NixOS/nixpkgs/commit/1be983909e343c8cf6b7ba730569272674681de8) | `checkmate: 0.8.2 -> 0.8.4`                                                          |
| [`d6f16bc8`](https://github.com/NixOS/nixpkgs/commit/d6f16bc87409e34b6c9e0df6640ffda8f9f69374) | `ropgadget: 7.1 -> 7.2`                                                              |
| [`841b83ec`](https://github.com/NixOS/nixpkgs/commit/841b83ec7870f83d0fe4f5b6f22b6ffbb2f3ade5) | `saml2aws: 2.36.1 -> 2.36.2`                                                         |
| [`c4bd8ae5`](https://github.com/NixOS/nixpkgs/commit/c4bd8ae568b65ae916cce46a032c429fc9398aa1) | `ipv6calc: 4.0.1 -> 4.0.2`                                                           |
| [`3ce8c9d0`](https://github.com/NixOS/nixpkgs/commit/3ce8c9d0896732f5b4042d3b16066824e5f6709f) | `activemq: 5.17.2 -> 5.17.3`                                                         |
| [`8cf13ddc`](https://github.com/NixOS/nixpkgs/commit/8cf13ddc646e86b4db0ebf2f8b2cbc55bb11fde7) | `picard: 2.8.4 -> 2.8.5`                                                             |
| [`b7fee99e`](https://github.com/NixOS/nixpkgs/commit/b7fee99eb8e157c93892d52e0a4d7ae1b170e469) | `fnotifystat: 0.02.08 -> 0.02.09`                                                    |
| [`cea1922f`](https://github.com/NixOS/nixpkgs/commit/cea1922f6167ccaade6f0843326b190bd7812c84) | `cve-bin-tool: 3.1.1 -> 3.1.2`                                                       |
| [`c101a263`](https://github.com/NixOS/nixpkgs/commit/c101a26373afe5183bbda6d50f52bd608ca57b21) | `pachyderm: 2.4.1 -> 2.4.2`                                                          |
| [`04a2aa7b`](https://github.com/NixOS/nixpkgs/commit/04a2aa7b805807745f3f6d8193a3869444ab09ca) | `pacemaker: 2.1.4 -> 2.1.5`                                                          |
| [`b22404c7`](https://github.com/NixOS/nixpkgs/commit/b22404c7c2582b3c7b46190476e0682d0777346b) | `jftui: 0.6.0 -> 0.6.1`                                                              |
| [`541c3cad`](https://github.com/NixOS/nixpkgs/commit/541c3cadd98ce27d9ebd5d49cb8cb39d8bb17294) | `karate: 1.3.0 -> 1.3.1`                                                             |
| [`9f0997c2`](https://github.com/NixOS/nixpkgs/commit/9f0997c249eaf6aea92d2236ed56235a0800bfc7) | `aocd: 1.3.1 -> 1.3.2`                                                               |
| [`dc95c902`](https://github.com/NixOS/nixpkgs/commit/dc95c9023abfc97ffb16e4adb1faefb6f5fda59b) | `python310Packages.packvers: init at 21.5`                                           |
| [`12877380`](https://github.com/NixOS/nixpkgs/commit/1287738059ada2889f811129c3ac74675f69effb) | `go-swag: 1.8.8 -> 1.8.9`                                                            |
| [`c198d829`](https://github.com/NixOS/nixpkgs/commit/c198d8298c5a6f3b02a62f87c2e719ee900637d4) | `ansible-doctor: 1.4.7 -> 1.4.8`                                                     |
| [`d365e6b2`](https://github.com/NixOS/nixpkgs/commit/d365e6b2e04d4229c139350cbe3411ccf4bfdfd3) | `fits-cloudctl: 0.11.3 -> 0.11.4`                                                    |
| [`a24ca432`](https://github.com/NixOS/nixpkgs/commit/a24ca432f227b07042b77eb6e2ef4c75298262bc) | `bundletool: 1.13.1 -> 1.13.2`                                                       |
| [`f976a446`](https://github.com/NixOS/nixpkgs/commit/f976a446e6fbf51719898c6e90518c8fa97b4b6f) | `bitwig-studio: 4.4.3 -> 4.4.6`                                                      |
| [`d0e5ff55`](https://github.com/NixOS/nixpkgs/commit/d0e5ff5545cae234313284d13f5684ef4c111170) | `ckbcomp: 1.210 -> 1.212`                                                            |
| [`569148a9`](https://github.com/NixOS/nixpkgs/commit/569148a9349c331a368673bda645da9ab166d47e) | `terragrunt: 0.42.4 -> 0.42.5`                                                       |
| [`bd24f46f`](https://github.com/NixOS/nixpkgs/commit/bd24f46f04b1f1fdc18293d1a6176a77f2df959c) | `flexget: 3.5.12 -> 3.5.13`                                                          |
| [`146d29f7`](https://github.com/NixOS/nixpkgs/commit/146d29f75a065abf39581c842f173c6cc548e6b1) | `python310Packages.dparse2: add changelog to meta`                                   |
| [`52a54cea`](https://github.com/NixOS/nixpkgs/commit/52a54cea51c41934d564fb06a2721bae666b9ccf) | `python310Packages.pyswitchbot: 0.30.0 -> 0.30.1`                                    |
| [`cf85570a`](https://github.com/NixOS/nixpkgs/commit/cf85570a70289a45f99ca10e5218602a63a17244) | `metasploit: 6.2.31 -> 6.2.32`                                                       |
| [`e7d1021e`](https://github.com/NixOS/nixpkgs/commit/e7d1021ed9c4273a28fc6bb5320896c6d71fe832) | `jellyfin-ffmpeg: enable chromaprint`                                                |
| [`526e0163`](https://github.com/NixOS/nixpkgs/commit/526e0163736e055d985c4ded5598a5061c8c7b2b) | `mangal: 4.0.4 -> 4.0.5`                                                             |
| [`4abe83ef`](https://github.com/NixOS/nixpkgs/commit/4abe83ef30bb0d9351da47c74d73cf61cd11b7e8) | `bitwarden: 2022.10.0 -> 2022.12.0`                                                  |
| [`295d4a76`](https://github.com/NixOS/nixpkgs/commit/295d4a76f2ffc55523a3b2371c2f36b302880073) | `k0sctl: 0.14.0 -> 0.15.0`                                                           |
| [`7b591237`](https://github.com/NixOS/nixpkgs/commit/7b5912374d98f3425dd877981dfd3ef7b7e9c81d) | `opencc: 1.1.4 -> 1.1.6`                                                             |
| [`efad60ce`](https://github.com/NixOS/nixpkgs/commit/efad60ce24504ad65fa47597b7788f68efbb7b31) | `python310Packages.opensensemap-api: 0.2.0 -> 0.3.0`                                 |
| [`f6cf2ae8`](https://github.com/NixOS/nixpkgs/commit/f6cf2ae8a5ed3e21cc88a856fb302790f69f081c) | `python310Packages.opensensemap-api: add changelog to meta`                          |
| [`c6491faf`](https://github.com/NixOS/nixpkgs/commit/c6491faf0ecb8217557ed620d93686b70da6c2a9) | `python310Packages.yalexs-ble: 1.12.2 -> 1.12.5`                                     |
| [`0d2096bf`](https://github.com/NixOS/nixpkgs/commit/0d2096bf9c22a9c0e48f53e04a3c58e3438c2d80) | `ngtcp2: 0.11.0 -> 0.12.0`                                                           |
| [`a0afe54f`](https://github.com/NixOS/nixpkgs/commit/a0afe54f43498d4a18bdeed1fcd9ba213c7a70af) | `nghttp3: 0.7.1 -> 0.8.0`                                                            |
| [`f93d6e7e`](https://github.com/NixOS/nixpkgs/commit/f93d6e7e0bacaff20cf9497879ee02604a5e260a) | `vengi-tools: unbreak on x86_64-darwin`                                              |
| [`45fb93f9`](https://github.com/NixOS/nixpkgs/commit/45fb93f966ce968be3f54a73cade646361808fae) | `python3Packages.weasyprint: fix fontconfig error on darwin`                         |
| [`c2291093`](https://github.com/NixOS/nixpkgs/commit/c2291093750e0f10cdcbb4f1ed1e5e3e14e32a6c) | `ruff: 0.0.192 -> 0.0.193`                                                           |
| [`ff9dbe90`](https://github.com/NixOS/nixpkgs/commit/ff9dbe90d7911cafd5ca853aa5db87c701a805f4) | `services.pixiecore: add quick option`                                               |
| [`087f870c`](https://github.com/NixOS/nixpkgs/commit/087f870c3c7177aeec0fa58ae02cd6a85ced1406) | `python310Packages.urlextract: add changelog to meta`                                |
| [`e419aa82`](https://github.com/NixOS/nixpkgs/commit/e419aa82837d755174fdfdb94038d30b3b383a91) | `cc-wrapper-test: add workaround for asan allocation error`                          |
| [`42cd6aeb`](https://github.com/NixOS/nixpkgs/commit/42cd6aebe4465564b0fff7fdc19cc7daed0380e1) | `cc-wrapper-test: do not test sanitizers when cross compiling`                       |
| [`8643dbc5`](https://github.com/NixOS/nixpkgs/commit/8643dbc57e2d529eb4020b10d590ca3019e83d7c) | `cc-wrapper-test: do not test sanitizers on darwin`                                  |
| [`57ff6191`](https://github.com/NixOS/nixpkgs/commit/57ff6191af7821cef3dddc12ca5a373ea015c7bf) | `cc-wrapper-test: support cross compilers`                                           |
| [`86313e73`](https://github.com/NixOS/nixpkgs/commit/86313e7339ec7430a6faed05fc48bdfcffe0a08a) | `cargo-mommy: init at 0.1.1`                                                         |
| [`59c0fde9`](https://github.com/NixOS/nixpkgs/commit/59c0fde967ee940a087d8d6bdf57b35bc261acf5) | `maintainers: add GoldsteinE`                                                        |
| [`3468d13f`](https://github.com/NixOS/nixpkgs/commit/3468d13fce4776757797205ef66183c46f08fc1a) | `python310Packages.urlextract: 1.7.1 -> 1.8.0`                                       |
| [`ec0d31c7`](https://github.com/NixOS/nixpkgs/commit/ec0d31c7fd76286a491e3bb832c05dab246bf50e) | `python310Packages.pysmart: 1.2.1 -> 1.2.2`                                          |
| [`e4445d3f`](https://github.com/NixOS/nixpkgs/commit/e4445d3fa49340a4f9c36e596d4466a0675bd7b8) | `cirrus-cli: 0.93.0 -> 0.94.4`                                                       |
| [`c06060c5`](https://github.com/NixOS/nixpkgs/commit/c06060c5fb273b58b48d422f7ef43ebefdf852c9) | `python310Packages.zamg: 0.2.1 -> 0.2.2`                                             |
| [`0c7efbb0`](https://github.com/NixOS/nixpkgs/commit/0c7efbb01a0e05cacb03f3d986c43de311fa2af6) | `squashfs-tools-ng: unbreak on x86_64-darwin`                                        |
| [`29e09b1d`](https://github.com/NixOS/nixpkgs/commit/29e09b1d0c0d3abab49898d71db345ad8335252f) | `hydron: 3.3.5 -> 3.3.6`                                                             |
| [`7ddfb722`](https://github.com/NixOS/nixpkgs/commit/7ddfb722dcd5474afb42ab7c2beb92715707aec9) | `ocamlPackages.lwt_ppx: 2.0.2 → 2.1.0`                                               |
| [`ca1c902e`](https://github.com/NixOS/nixpkgs/commit/ca1c902e58e3928f0d1edc39ea6b8581f3b1902a) | `ocamlPackages.ocsipersist: use dune 3`                                              |
| [`cbaeba7e`](https://github.com/NixOS/nixpkgs/commit/cbaeba7e44ca33268a40dae0aea4f3d09e6d6758) | `ocamlPackages.dap: use dune 3`                                                      |
| [`ebbb00a8`](https://github.com/NixOS/nixpkgs/commit/ebbb00a8a8013e54f1094a911753d7071c321311) | `ocamlPackages.earlybird: use dune 3`                                                |
| [`a7e55238`](https://github.com/NixOS/nixpkgs/commit/a7e55238ff4de3096df869eba31ab1f8b223892b) | `flitter: use dune 3`                                                                |
| [`0a736fa8`](https://github.com/NixOS/nixpkgs/commit/0a736fa88f7727a1a0499a512e2bb3d68d7a1889) | `chatty: unstable-2022-09-20 -> 0.7.0_rc4`                                           |
| [`77775ad7`](https://github.com/NixOS/nixpkgs/commit/77775ad730c36b790db83160e3017d1ac266c65b) | `python310Packages.pyvisa: drop support for python 3.7`                              |
| [`3020a394`](https://github.com/NixOS/nixpkgs/commit/3020a3946212cf6ec72e5de1105bf841b781166d) | `rtsp-simple-server: 0.20.3 -> 0.21.0`                                               |
| [`d70f2169`](https://github.com/NixOS/nixpkgs/commit/d70f2169f2961ffe3c93d38ddae298e5ad3eb441) | `vimPlugins.ai-vim: init at 2022-12-16`                                              |
| [`a504bf3f`](https://github.com/NixOS/nixpkgs/commit/a504bf3f6872e5b702075de339b4816623ed52bb) | `vimPlugins.godbolt-nvim: init at 2022-12-17`                                        |
| [`0f4a3ff8`](https://github.com/NixOS/nixpkgs/commit/0f4a3ff83f5d754b062a558dc430d89083d02e00) | `libxklavier: add darwin support`                                                    |
| [`4053a8da`](https://github.com/NixOS/nixpkgs/commit/4053a8dab14246f6e889732eb829a490593af80c) | `haven-cli: unbreak on aarch64-darwin`                                               |
| [`39ce2d9c`](https://github.com/NixOS/nixpkgs/commit/39ce2d9c1fc9340bd010904c30407aa2c27118cb) | `dia: unbreak on aarch64-darwin`                                                     |
| [`2a6c2b68`](https://github.com/NixOS/nixpkgs/commit/2a6c2b682da61e2cfa78858b747bde3bfdaf268c) | `foxotron: unbreak on aarch64-darwin`                                                |
| [`efcc85ed`](https://github.com/NixOS/nixpkgs/commit/efcc85edb35eba0c8f91030ff461964fff19d569) | `ocm: 0.1.64 -> 0.1.65`                                                              |
| [`b96f08ea`](https://github.com/NixOS/nixpkgs/commit/b96f08ead62085216ed7b0746c7259995decc545) | `fulcrum: 1.8.2 -> 1.9.0`                                                            |
| [`e897471e`](https://github.com/NixOS/nixpkgs/commit/e897471eee6efcabea6195ddf39765e386144caf) | `ghc-api-compat: unmarkBroken on older ghcs`                                         |
| [`b1a9ae8d`](https://github.com/NixOS/nixpkgs/commit/b1a9ae8dfd85d144ff1b268d6c7b47934358c9a1) | `percona-xtrabackup_2_4: drop`                                                       |
| [`a8283231`](https://github.com/NixOS/nixpkgs/commit/a82832314f3fc9c172f38ffdfed22360fba0a881) | `libredwg: unbreak on aarch64-darwin`                                                |
| [`65d6fc55`](https://github.com/NixOS/nixpkgs/commit/65d6fc555b310ea392b249a7f168f828593d7088) | `haskell-language-server: Enable reenable dependencies for older ghcs`               |
| [`6452a34b`](https://github.com/NixOS/nixpkgs/commit/6452a34b550320ebb2b7e61c8ae5d58b645b5158) | `broot: 1.17.1 -> 1.18.0`                                                            |
| [`d76cdd7b`](https://github.com/NixOS/nixpkgs/commit/d76cdd7b8b993ace92085d55cb164b0bbff77b0a) | `coqPackages.Verdi: preemptive fix for removal of configure in future versions`      |
| [`365f7f34`](https://github.com/NixOS/nixpkgs/commit/365f7f342fdc3fccfc22b57e7974e7d1eaf615cd) | `coqPackages.StructTact: preemptive fix for removal of configure in future versions` |
| [`6bd604b3`](https://github.com/NixOS/nixpkgs/commit/6bd604b37c7292772ba7285abe5b56e0f2d9c8c9) | `coqPackages.InfSeqExt: preemptive fix for removal of configure in future versions`  |
| [`f061c452`](https://github.com/NixOS/nixpkgs/commit/f061c452a62b83c1442264b14369be92359d934b) | `coqPackages.Cheerios: preemptive fix for removal of configure in future versions`   |
| [`e6cc2d4a`](https://github.com/NixOS/nixpkgs/commit/e6cc2d4aa7d1329f06f15fd9f818ae13cb81927d) | `oxipng: 7.0.0 -> 8.0.0`                                                             |
| [`1e964dcf`](https://github.com/NixOS/nixpkgs/commit/1e964dcf2e77e5a7038b7d88ef8c4bfe7f1f335d) | `python310Packages.rfcat: 1.9.6 -> 1.9.7`                                            |
| [`79b2a5bb`](https://github.com/NixOS/nixpkgs/commit/79b2a5bb3a6131eb4e20b47c1c4a58717b516fec) | `sonobuoy: 0.56.13 -> 0.56.14`                                                       |
| [`bfeee6fa`](https://github.com/NixOS/nixpkgs/commit/bfeee6fa3dae22e2f49b2d7df0461d3907d5f75e) | `v2ray-geoip: 202212150047 -> 202212220043`                                          |
| [`7fca6564`](https://github.com/NixOS/nixpkgs/commit/7fca6564e6f2727a5098812086fa2b54b2332289) | `fastly: update cli-config to latest version`                                        |
| [`95cfb3ad`](https://github.com/NixOS/nixpkgs/commit/95cfb3ad3626eaa4b495da3ac16303ac3d6ff59e) | `oven-media-engine: 0.14.17 -> 0.14.18`                                              |
| [`0ac48ac9`](https://github.com/NixOS/nixpkgs/commit/0ac48ac9327cd30cbb2c9301806df409c5d6e4b8) | `cinnamon.cinnamon-screensaver: Fix crash with virtual keyboard`                     |
| [`d5510e9e`](https://github.com/NixOS/nixpkgs/commit/d5510e9e9e3e9db3d35fea2af012c76d6af1c173) | `cinnamon.cinnamon-common: Fix settings theme thumbnail path`                        |
| [`799491fe`](https://github.com/NixOS/nixpkgs/commit/799491febaadffbe37d0bbc6803cbd27cafcda22) | ``darwin.builder: Fix `system` for `install-credentials```                           |
| [`0bbb3b7d`](https://github.com/NixOS/nixpkgs/commit/0bbb3b7d2e6abda2231ed68f0be32c40d53b9edf) | `jove: 4.17.4.8 -> 4.17.4.9`                                                         |
| [`b1707aa1`](https://github.com/NixOS/nixpkgs/commit/b1707aa13b3cee5cd5b1988eb1c45e8402668344) | `enum4linux-ng: 1.2.0 -> 1.3.0`                                                      |
| [`5ff21bfc`](https://github.com/NixOS/nixpkgs/commit/5ff21bfc73f59efd3e61776964f7b7f1863a3136) | `attrsets: fix and add some doc types`                                               |
| [`56243113`](https://github.com/NixOS/nixpkgs/commit/562431130592150c9910b1abd5019c16c6d6fcb0) | `nixosTests.keymap: Remove unnecessary sleep`                                        |
| [`2b5677ca`](https://github.com/NixOS/nixpkgs/commit/2b5677caa342629ee42743ac92556ac8bf5e8ef9) | `nixosTests.keymap: Reorder test cases to make setup more reliable`                  |
| [`d9c3fbfc`](https://github.com/NixOS/nixpkgs/commit/d9c3fbfcdcffd2e6b8bf2f59cffcce5507c304b7) | `erlangR25: 25.1.2 -> 25.2`                                                          |
| [`b40050ba`](https://github.com/NixOS/nixpkgs/commit/b40050bad1a99fa9a0455ea5318792d915d2e146) | `gccgo: track latest gcc (#144467)`                                                  |
| [`755d5259`](https://github.com/NixOS/nixpkgs/commit/755d5259c7ab46a3fa726f97b9a2e0084382cd66) | `maintainers/scripts/haskell: fix regenerate-transitive-broken`                      |
| [`094c0253`](https://github.com/NixOS/nixpkgs/commit/094c0253cdd0d9f288625a9505764b22b921ee9e) | `talosctl: 1.2.7 -> 1.2.8`                                                           |
| [`f5e81d80`](https://github.com/NixOS/nixpkgs/commit/f5e81d80c9387a8244d6a20825e8dc140a418693) | `python310Packages.striprtf: add changelog to meta`                                  |
| [`980ab5c7`](https://github.com/NixOS/nixpkgs/commit/980ab5c74c0429b2ae5bc8b4f1a4e63f2181823f) | `python310Packages.apycula: 0.5.1 -> 0.6.1`                                          |
| [`cab81591`](https://github.com/NixOS/nixpkgs/commit/cab81591bce1f781cf893d768d2d1848b760f65a) | `v2ray-domain-list-community: 20221130032508 -> 20221223102220`                      |
| [`5851a072`](https://github.com/NixOS/nixpkgs/commit/5851a072a5bafb1c48223f57069468cf3811593f) | `gtksourceview5: Fix test after gtk4 4.8.3 bump`                                     |
| [`ead87baa`](https://github.com/NixOS/nixpkgs/commit/ead87baa84f0b5c2ee8e7095208bd861073dea74) | `libshumate: Fix test after gtk4 4.8.3 bump`                                         |
| [`f0e6dd2e`](https://github.com/NixOS/nixpkgs/commit/f0e6dd2e8300058232e514e5c5a223d62ea4a8d4) | `python310Packages.dacite: re-enable test`                                           |
| [`1bd7c66e`](https://github.com/NixOS/nixpkgs/commit/1bd7c66e6418ff3b92d96d800ad758ccfda94898) | `python310Packages.dacite: add changelog to meta`                                    |
| [`4adb6747`](https://github.com/NixOS/nixpkgs/commit/4adb674709e97f8bc0abfbbbc475929b6d7a498d) | `python310Packages.volkszaehler: 0.3.2 -> 0.4.0`                                     |
| [`1c0c5af3`](https://github.com/NixOS/nixpkgs/commit/1c0c5af346680334e09bc30d36b3396727d128ef) | `aliases: fix typo`                                                                  |
| [`b8230ffa`](https://github.com/NixOS/nixpkgs/commit/b8230ffa2eeff41c31b8deb753d40504ad67908b) | `mod_wsgi3: refactor derivation`                                                     |
| [`dd404560`](https://github.com/NixOS/nixpkgs/commit/dd40456033a498005bdc03c6344a02edb598ebe0) | `python310Packages.volkszaehler: add changelog to meta`                              |
| [`7ba34e66`](https://github.com/NixOS/nixpkgs/commit/7ba34e662a8211877e82ba874085c29fc1d97c19) | `mod_wsgi2: remove`                                                                  |
| [`66175112`](https://github.com/NixOS/nixpkgs/commit/661751120058a4d28229750e2118aa04fee19a0e) | `nixos/podman: add autoPrune option`                                                 |
| [`93a9d945`](https://github.com/NixOS/nixpkgs/commit/93a9d945b395ba5fde71cd3574850eb0aa2a81b5) | `heimer: 3.6.3 -> 3.6.4`                                                             |
| [`f7667eed`](https://github.com/NixOS/nixpkgs/commit/f7667eed3d54f15b79e54cfe116c55d29b07c5f8) | `drawio: 20.6.2 -> 20.7.4`                                                           |