### PR TITLE
chore(flake/pre-commit-hooks): `200790e9` -> `67d98f02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -219,11 +219,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1671452357,
-        "narHash": "sha256-HqzXiQEegpRQ4VEl9pEPgHSIxhJrNJ27HfN1wOc7w2E=",
+        "lastModified": 1672050129,
+        "narHash": "sha256-GBQMcvJUSwAVOpDjVKzB6D5mmHI7Y4nFw+04bnS9QrM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "200790e9c77064c53eaf95805b013d96615ecc27",
+        "rev": "67d98f02443b9928bc77f1267741dcfdd3d7b65c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                       | Commit Message               |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------- |
| [`1d71c50b`](https://github.com/cachix/pre-commit-hooks.nix/commit/1d71c50b9daa2d1ce0a6439d9c004066c3f84f10) | `Add phpcs and phpcbf hooks` |