### PR TITLE
chore(flake/nixpkgs): `fad51abd` -> `1eb875e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671983799,
-        "narHash": "sha256-Z2Ro6hFPZHkBqkVXY5/aBUzxi5xizQGvuHQ9+T5B/ks=",
+        "lastModified": 1672080458,
+        "narHash": "sha256-Ukjn8YUwZevxDPaVUmTx2sf9bCcIJSasmLz+xjGBKrs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fad51abd42ca17a60fc1d4cb9382e2d79ae31836",
+        "rev": "1eb875e811dd59e21e77f6337f2c1592889b48b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`2d3cf010`](https://github.com/NixOS/nixpkgs/commit/2d3cf010fe48694a53897ad248ecb95dc458d9f9) | `Revert "treewide: use nativeBuildInputs with runCommand instead of inlining"` |
| [`b06eba97`](https://github.com/NixOS/nixpkgs/commit/b06eba978ee1445345e47a5a46a391069b63cb09) | `python310Packages.statmake: 0.5.1 -> 0.6.0`                                   |
| [`417b645b`](https://github.com/NixOS/nixpkgs/commit/417b645ba5dd3475382dc78d6bad6f81fcc82c74) | `python310Packages.ansible-later: 3.0.1 -> 3.0.2`                              |
| [`89f4a5ab`](https://github.com/NixOS/nixpkgs/commit/89f4a5ab26ccf534a10a0e856f9e41ffc396fb20) | `libvirtd: add parallelShutdown option`                                        |
| [`b6d94e39`](https://github.com/NixOS/nixpkgs/commit/b6d94e39628736ad6dd7668d39789d84c5e784d7) | `nixos/xastir: init`                                                           |
| [`cdd6bf80`](https://github.com/NixOS/nixpkgs/commit/cdd6bf809b32a6dc9ab681b417279341d3087c48) | `xastir: add support for ax25 interfaces`                                      |
| [`fb376978`](https://github.com/NixOS/nixpkgs/commit/fb376978aa821efec76c5f9561584da7398f5c2b) | `edid-decode: unstable-2022-04-06 -> unstable-2022-12-14`                      |
| [`6ea73d83`](https://github.com/NixOS/nixpkgs/commit/6ea73d8313935423e6f84a638243d4a31ae8b8db) | `ansible-lint: 6.9.0 → 6.10.0`                                                 |
| [`de6cfb7a`](https://github.com/NixOS/nixpkgs/commit/de6cfb7a9a24ea5a384fa91be1b7856ec9be6d43) | `getdns 1.7.2 -> 1.7.4, stubby 0.4.2 -> 0.4.3`                                 |
| [`d9628cfd`](https://github.com/NixOS/nixpkgs/commit/d9628cfd3860b9fccb20e1d572968417525f85a0) | `mtools: 4.0.41 -> 4.0.42`                                                     |
| [`85d29c64`](https://github.com/NixOS/nixpkgs/commit/85d29c643d135f3daaac2f0f029cb151c1016775) | `mimalloc: 2.0.7 -> 2.0.9`                                                     |
| [`00f3a18c`](https://github.com/NixOS/nixpkgs/commit/00f3a18c7070ffa6edc082fe1c64ae6c41c5b656) | `stellarium: 1.1 -> 1.2`                                                       |
| [`8b4fd747`](https://github.com/NixOS/nixpkgs/commit/8b4fd7478261c464632a0e99e5b3c1ae836a4768) | `nixos/filesystems: require fstab options list be non-empty`                   |
| [`997937c4`](https://github.com/NixOS/nixpkgs/commit/997937c409a06e0ac76a443e2d6c120a1b2186c2) | `python310Packages.globus-sdk: 3.15.0 -> 3.15.1`                               |
| [`4c20b48e`](https://github.com/NixOS/nixpkgs/commit/4c20b48ed96471f212a401919c2b0e0ac9004b93) | `protoc-gen-connect-go: 1.3.1 -> 1.4.1`                                        |
| [`955da5b7`](https://github.com/NixOS/nixpkgs/commit/955da5b711837f11bd7a3c0c3b5e709f60c9f86e) | `ferretdb: 0.7.0 -> 0.7.1`                                                     |
| [`7c1eeef9`](https://github.com/NixOS/nixpkgs/commit/7c1eeef919affdd564a01ef0631891d5428eb8f2) | `electrum-grs: move to electrum/grs`                                           |
| [`a09b4ff7`](https://github.com/NixOS/nixpkgs/commit/a09b4ff7f82b55cb78bc43610e0e3955973a8c02) | `python3Packages.groestlcoin_hash: change license to MIT`                      |
| [`4d7160e6`](https://github.com/NixOS/nixpkgs/commit/4d7160e615dce09555fa578bddc49710a5766ccc) | `electrum-ltc: remove passthru.updateScript`                                   |
| [`85f08cc5`](https://github.com/NixOS/nixpkgs/commit/85f08cc5e7d0b6d62885110f79d2a3e3b58561d2) | `electrum: fix description`                                                    |
| [`cd66de88`](https://github.com/NixOS/nixpkgs/commit/cd66de888cc1cd7629d04d15cf4b19b77c919687) | `furnace: 0.6pre1.5 -> 0.6pre2`                                                |
| [`92a13179`](https://github.com/NixOS/nixpkgs/commit/92a131796b726e80503dc31cc4281b9cab62ee84) | `vtm: 0.9.6a -> 0.9.8g`                                                        |
| [`58387066`](https://github.com/NixOS/nixpkgs/commit/58387066c535913556f087b20bb740a1aad1d44c) | `vimPlugins.vim-dadbod-ui: add vim-dadbod as a dependency`                     |
| [`5d2364a4`](https://github.com/NixOS/nixpkgs/commit/5d2364a41dfec99f870c97c5f9c491cc06badaa7) | `starfetch: 0.0.3 -> 0.0.4`                                                    |
| [`98004726`](https://github.com/NixOS/nixpkgs/commit/98004726a03b90464e27089f89f07158c4482f97) | `kdash: 0.3.5 -> 0.3.6`                                                        |
| [`805dde27`](https://github.com/NixOS/nixpkgs/commit/805dde27d64ca4155c4a0aa295f66688dc6a8b77) | `symfony-cli: 5.4.19 -> 5.4.20`                                                |
| [`82e178a6`](https://github.com/NixOS/nixpkgs/commit/82e178a6881b436427f423ab0d77e432973e3998) | `okteto: 2.10.2 -> 2.10.3`                                                     |
| [`bf2919dd`](https://github.com/NixOS/nixpkgs/commit/bf2919dd7b832ce9e0b9ffdb419e59c987e4aa36) | `hackgen-nf-font: 2.7.1 -> 2.8.0`                                              |
| [`e2dfc9a7`](https://github.com/NixOS/nixpkgs/commit/e2dfc9a72db790fc0065a0ead3685cf4f983ec8d) | `vhd2vl: unstable-2018-09-01 -> unstable-2022-12-26`                           |
| [`e941262b`](https://github.com/NixOS/nixpkgs/commit/e941262b0f48bc8c059201906133956ed5a7a47e) | `verilog: bump tests, enable tests on darwin`                                  |
| [`66301ae6`](https://github.com/NixOS/nixpkgs/commit/66301ae6d160d3d93261671ecb73f92ec2e84e05) | `vimPlugins.nvim-teal-maker: init at 2022-04-09`                               |
| [`555ba584`](https://github.com/NixOS/nixpkgs/commit/555ba5840809bb5842e115877f80901162b618d6) | `samba: 4.17.3 -> 4.17.4`                                                      |
| [`475e7fa8`](https://github.com/NixOS/nixpkgs/commit/475e7fa8027530682bd19d8b97f1a2f29b848eea) | `pulseview: fix build`                                                         |
| [`b5f0db7d`](https://github.com/NixOS/nixpkgs/commit/b5f0db7d48c2b66b9c11b8133c2c3bf731bb5da0) | ` python310Packages.gaphas: add changelog to meta`                             |
| [`dab02514`](https://github.com/NixOS/nixpkgs/commit/dab0251470982e930d59aa7840ab5180e24abdb7) | `prometheus-alertmanager: add changelog to meta`                               |
| [`87cc3de3`](https://github.com/NixOS/nixpkgs/commit/87cc3de39b432740f48987a5dff72c6a5e6595ce) | `python310Packages.hahomematic: 2022.12.8 -> 2022.12.9`                        |
| [`233eb18d`](https://github.com/NixOS/nixpkgs/commit/233eb18d26d9aced2e1de5ff4a8e3e23384ca20d) | `python310Packages.garminconnect: add changelog to meta`                       |
| [`aa08b9f2`](https://github.com/NixOS/nixpkgs/commit/aa08b9f2d0be36ef0dad666adb7785d8699af91b) | ` python310Packages.vispy: add changelog to meta`                              |
| [`38a1e971`](https://github.com/NixOS/nixpkgs/commit/38a1e971f863e115b57f4fbd3d789dce7bf1ced6) | `python310Packages.telegraph: add changelog to meta`                           |
| [`8312881a`](https://github.com/NixOS/nixpkgs/commit/8312881a1b6a3b7ed39795ee1286983aa56050d2) | ` python310Packages.doc8: add changelog to meta`                               |
| [`5d883659`](https://github.com/NixOS/nixpkgs/commit/5d8836594230bfbf14ca7246aa59eb311d06933e) | `python39Packages.pyreadstat: add changelog to meta`                           |
| [`78afbf2b`](https://github.com/NixOS/nixpkgs/commit/78afbf2b9e2c42e37a50eb2638a501cade628139) | `python310Packages.zcs: disable on older Python releases`                      |
| [`2b3965ea`](https://github.com/NixOS/nixpkgs/commit/2b3965ea95b2f058decff26644388f3e1e308d25) | `python310Packages.gaphas: 3.8.4 -> 3.9.2`                                     |
| [`401d4287`](https://github.com/NixOS/nixpkgs/commit/401d428786af826b5bca293ff0e9378f9a0ab880) | `ocamlPackages.paf: 0.2.0 → 0.3.0`                                             |
| [`bdd401e6`](https://github.com/NixOS/nixpkgs/commit/bdd401e65baa35db2bf5a029ea4a54b16c0a8397) | `julia_18: 1.8.3 -> 1.8.4`                                                     |
| [`881d6b70`](https://github.com/NixOS/nixpkgs/commit/881d6b709a0388b2af0d12abc8b387f4178fd22b) | `prometheus-alertmanager: 0.24.0 -> 0.25.0`                                    |
| [`62214749`](https://github.com/NixOS/nixpkgs/commit/62214749d51f3a5502ada436b824df221935fb4f) | `lndhub-go: 0.11.0 -> 0.12.0`                                                  |
| [`599c04d1`](https://github.com/NixOS/nixpkgs/commit/599c04d1e0235ad6cc1b73ace3a072b247859569) | `python310Packages.zcs: 0.1.22 -> 0.1.25`                                      |
| [`8fafe485`](https://github.com/NixOS/nixpkgs/commit/8fafe48549f4f44d3d99626b328425fe89abab38) | `terraform-providers: update 2022-12-26`                                       |
| [`d04582ff`](https://github.com/NixOS/nixpkgs/commit/d04582ffe752bf270032a4edaa7dfdfb25dac789) | `python39Packages.pyreadstat: 1.1.9 -> 1.2.0`                                  |
| [`f8496038`](https://github.com/NixOS/nixpkgs/commit/f8496038b54e092d4a5c0233187ab868b0baa1b3) | `supabase-cli: 1.27.4 -> 1.27.7`                                               |
| [`5e9e436e`](https://github.com/NixOS/nixpkgs/commit/5e9e436e7646704483750823d8aceb80940e66e1) | `kubernetes: 1.25.5 -> 1.26.0`                                                 |
| [`afaa9e79`](https://github.com/NixOS/nixpkgs/commit/afaa9e79cd6afe6da88b543f128c1360172ebd2f) | `particl-core: 0.19.2.20 -> 23.0.3.0`                                          |
| [`40ce918d`](https://github.com/NixOS/nixpkgs/commit/40ce918da364940198901bcbe533124662a4c10a) | `julia_18-bin: 1.8.3 -> 1.8.4`                                                 |
| [`57f832c6`](https://github.com/NixOS/nixpkgs/commit/57f832c655f0d688ad1dbc2b286cde6bf0ec2d38) | `svd2rust: 0.27.2 -> 0.28.0`                                                   |
| [`881e0490`](https://github.com/NixOS/nixpkgs/commit/881e0490ee13d75b36a2129079673cb99affa153) | `sqlite-replication: add throw`                                                |
| [`69bc0b64`](https://github.com/NixOS/nixpkgs/commit/69bc0b64ab9d5900abd6f8f0aa26e9d31ff17521) | `sqlite-replication: drop`                                                     |
| [`2ab6b4d9`](https://github.com/NixOS/nixpkgs/commit/2ab6b4d95c719c7e2b567dd52ff87b4693713a33) | `gvproxy: 0.4.0 -> 0.5.0`                                                      |
| [`bd8c376d`](https://github.com/NixOS/nixpkgs/commit/bd8c376d2b83ca8f8e83beb603958c6f5e6738e9) | `cri-tools: 1.25.0 -> 1.26.0`                                                  |
| [`becdf0ed`](https://github.com/NixOS/nixpkgs/commit/becdf0edefcd52c13a60994f264f779b89bdf708) | `terraform-providers.newrelic: 3.9.0 → 3.11.0`                                 |
| [`71137582`](https://github.com/NixOS/nixpkgs/commit/71137582d9da2ab85eca8e60029779aa244a913d) | `terraform-providers.lxd: 1.8.0 → 1.9.0`                                       |
| [`b0902388`](https://github.com/NixOS/nixpkgs/commit/b090238864f439716e6e3940aea12f1ee0735be7) | `terraform-providers.ksyun: 1.3.59 → 1.3.60`                                   |
| [`5f335d53`](https://github.com/NixOS/nixpkgs/commit/5f335d531a73995972134559fa6774f21fae821c) | `terraform-providers.hcloud: 1.36.1 → 1.36.2`                                  |
| [`6da3758a`](https://github.com/NixOS/nixpkgs/commit/6da3758a1dfb01aa68b3398dc8af8d796183613f) | `terraform-providers.google-beta: 4.46.0 → 4.47.0`                             |
| [`13e01c04`](https://github.com/NixOS/nixpkgs/commit/13e01c04ffc3fe73dbb69217ca5907cf8149ec21) | `terraform-providers.google: 4.46.0 → 4.47.0`                                  |
| [`f695b684`](https://github.com/NixOS/nixpkgs/commit/f695b68472435343bf551c2d14ac6b8415367217) | `terraform-providers.flexibleengine: 1.35.0 → 1.35.1`                          |
| [`c7b2956e`](https://github.com/NixOS/nixpkgs/commit/c7b2956efd06ea8318d5da7946851b77693263c0) | `terraform-providers.gitlab: 3.20.0 → 15.7.1`                                  |
| [`cbf097ad`](https://github.com/NixOS/nixpkgs/commit/cbf097adac83293139962d8eb49470f57ddce29b) | `terraform-providers.gandi: 2.2.0 → 2.2.1`                                     |
| [`475cc05d`](https://github.com/NixOS/nixpkgs/commit/475cc05d2886a36fd176b27fe3660b2b51b65e19) | `terraform-providers.datadog: 3.18.0 → 3.19.1`                                 |
| [`c02f6f94`](https://github.com/NixOS/nixpkgs/commit/c02f6f9473f51873db4ff56b92039f9dd01752a7) | `terraform-providers.docker: 2.23.1 → 2.24.0`                                  |
| [`6842027c`](https://github.com/NixOS/nixpkgs/commit/6842027c4050fdf018e9c91806fb8c958322677b) | `terraform-providers.cloudfoundry: 0.50.2 → 0.50.3`                            |
| [`6e02ea09`](https://github.com/NixOS/nixpkgs/commit/6e02ea09d15b0eccd7d5b493026a7d5c8e6d6f5e) | `terraform-providers.cloudscale: 4.0.0 → 4.1.0`                                |
| [`899b94a9`](https://github.com/NixOS/nixpkgs/commit/899b94a9bbb1566e4a59de5eb9183a627c0270b6) | `terraform-providers.cloudflare: 3.29.0 → 3.30.0`                              |
| [`ab48c7e6`](https://github.com/NixOS/nixpkgs/commit/ab48c7e6786ce5bf1091a723d79946bccd120c7b) | `terraform-providers.cloudamqp: 1.20.1 → 1.21.0`                               |
| [`85386059`](https://github.com/NixOS/nixpkgs/commit/85386059e6ce9fcdef7ffdbca600aa53574f124e) | `terraform-providers.brightbox: 3.0.6 → 3.2.0`                                 |
| [`9c2c41ca`](https://github.com/NixOS/nixpkgs/commit/9c2c41cace994aaf025a97de26ac13a5bed82206) | `terraform-providers.bitbucket: 2.24.0 → 2.26.0`                               |
| [`c846f22e`](https://github.com/NixOS/nixpkgs/commit/c846f22ea7834a1650f1341e1d0d1d420c2e57ad) | `terraform-providers.aws: 4.46.0 → 4.48.0`                                     |
| [`7c23ca44`](https://github.com/NixOS/nixpkgs/commit/7c23ca4471bfaf2ed9c1eb4dac8cdca73d620109) | `terraform-providers.bigip: 1.16.0 → 1.16.1`                                   |
| [`6dee08fa`](https://github.com/NixOS/nixpkgs/commit/6dee08faec349ffb31e0c637d73c76edfe301242) | `terraform-providers.baiducloud: 1.18.3 → 1.18.4`                              |
| [`33e5e943`](https://github.com/NixOS/nixpkgs/commit/33e5e943a3205c1a52429139e515e4d45a196cea) | `terraform-providers.azurerm: 3.35.0 → 3.37.0`                                 |
| [`ed19b5b8`](https://github.com/NixOS/nixpkgs/commit/ed19b5b80a60836b1ce565f9b5b50f32065747c0) | `terraform-providers.alicloud: 1.194.0 → 1.194.1`                              |
| [`d014fc77`](https://github.com/NixOS/nixpkgs/commit/d014fc77619af55815b4c3eb5c08e3273370ce88) | `terraform-providers.auth0: 0.40.0 → 0.41.0`                                   |
| [`f1b317d9`](https://github.com/NixOS/nixpkgs/commit/f1b317d926dfe32f27672f1dabbc81be72414736) | `terraform-providers.acme: 2.11.1 → 2.12.0`                                    |
| [`cba258b9`](https://github.com/NixOS/nixpkgs/commit/cba258b9523b90a12644a40beb9608810dbbcc8a) | `terraform-providers.akamai: 3.1.0 → 3.2.1`                                    |
| [`a2f2e038`](https://github.com/NixOS/nixpkgs/commit/a2f2e0383276b5036952a3d9198fd0410c8ba7ed) | `terraform-providers.aiven: 3.9.0 → 3.10.0`                                    |
| [`c6256de7`](https://github.com/NixOS/nixpkgs/commit/c6256de7590634fdf3dc87740f76ac8f386121be) | `gh: 2.20.2 -> 2.21.1`                                                         |
| [`fc3859a0`](https://github.com/NixOS/nixpkgs/commit/fc3859a07dc09668118575e25520c32a3b484278) | `containerd: 1.6.12 -> 1.6.14`                                                 |
| [`0a2b4687`](https://github.com/NixOS/nixpkgs/commit/0a2b4687ef81a4a3367478374c9ddcba4d3a2da7) | `etcd_3_4: 3.4.22 -> 3.4.23`                                                   |
| [`2e8df73e`](https://github.com/NixOS/nixpkgs/commit/2e8df73ed818f2584b26b0b12a359ae4b9b853c6) | `ventoy-bin-full: 1.0.85 -> 1.0.86`                                            |
| [`4fc89627`](https://github.com/NixOS/nixpkgs/commit/4fc896279df52294960483a65842c5940d2bd1bd) | `gh-eco: 0.1.2 -> 0.1.3`                                                       |
| [`fd7fff21`](https://github.com/NixOS/nixpkgs/commit/fd7fff2151846df13ec7f9aac8cad7697074aaf4) | `vimPlugins: cleanup unused inherit`                                           |
| [`1e4b8117`](https://github.com/NixOS/nixpkgs/commit/1e4b811793cda222eef4962b7d2dead7b19b6941) | `aws-lambda-rie: 1.8 -> 1.10`                                                  |
| [`4cf6ae22`](https://github.com/NixOS/nixpkgs/commit/4cf6ae2245d9161fc49d16c91a80bb1e1d0276f4) | `python310Packages.patiencediff: 0.2.11 -> 0.2.12`                             |
| [`31cfb512`](https://github.com/NixOS/nixpkgs/commit/31cfb512e819714f6df2137356dd1208ff45beec) | `python39Packages.aiobotocore: 2.4.1 -> 2.4.2`                                 |
| [`83c85adf`](https://github.com/NixOS/nixpkgs/commit/83c85adfc08019c70e283b7ac5f6ce02d351fe86) | `python310Packages.doc8: 1.0.0 -> 1.1.1`                                       |
| [`15c05750`](https://github.com/NixOS/nixpkgs/commit/15c057509980369c5458e6a9ea04c34490bcff86) | `ryujinx: 1.1.373 -> 1.1.489`                                                  |
| [`ba9bf076`](https://github.com/NixOS/nixpkgs/commit/ba9bf076d552be100598f950fe5d13e803f7aee9) | `python310Packages.vispy: 0.12.0 -> 0.12.1`                                    |
| [`e3337a60`](https://github.com/NixOS/nixpkgs/commit/e3337a6055e6b2c30fd83d5884c81e0b6fdce230) | `python39Packages.telegraph: 2.1.0 -> 2.2.0`                                   |
| [`e2ab671c`](https://github.com/NixOS/nixpkgs/commit/e2ab671cc992fee6f81d71f5d4b5847914a95e4b) | `svlint: 0.6.0 -> 0.6.1`                                                       |
| [`d1eea42a`](https://github.com/NixOS/nixpkgs/commit/d1eea42a230935fa83304829c703d3e100519221) | `cargo-bolero: 0.6.2 -> 0.8.0`                                                 |
| [`03b71034`](https://github.com/NixOS/nixpkgs/commit/03b71034639e9d965c61028e32eaa432e7878e7a) | `cargo-bolero: clean up`                                                       |
| [`58abb21b`](https://github.com/NixOS/nixpkgs/commit/58abb21bbe7fbd5df0b6cc09441ad3c21fe5be6b) | `nginxModules.lua: replace all occurences`                                     |
| [`2cfb9ab1`](https://github.com/NixOS/nixpkgs/commit/2cfb9ab1268806616dbf07ae2fc8d72e66837237) | `ax25-tools: init at 0.0.10-rc5`                                               |
| [`b3a5cb19`](https://github.com/NixOS/nixpkgs/commit/b3a5cb190489eb4f088198ac1d2ff7f5ea358706) | `python310Packages.ssh-mitm: 2.1.0 -> 3.0.1 (#207694)`                         |
| [`d79b8695`](https://github.com/NixOS/nixpkgs/commit/d79b86954f2fd97fe27180c6619d5f9df49b73e4) | `open-pdf-sign: 0.1.1 -> 0.1.1`                                                |
| [`6e8dd6c3`](https://github.com/NixOS/nixpkgs/commit/6e8dd6c35beba5e8259bd59038c1af6e7e26aeb5) | `gnome-builder: fix test after gtk4 4.8.3 bump`                                |
| [`63f21939`](https://github.com/NixOS/nixpkgs/commit/63f21939fc989a2dd3561ef1ad799005c44762e0) | `python310Packages.tablib: 3.2.1 -> 3.3.0`                                     |
| [`dfd83839`](https://github.com/NixOS/nixpkgs/commit/dfd83839ca371143e7e15599270c8f02dd09320c) | `vimPlugins.nvim-treesitter: update grammars`                                  |
| [`eb09bb3c`](https://github.com/NixOS/nixpkgs/commit/eb09bb3cfe7d748f2a97ea4cc026aeac2c2391bc) | `xfsdump: 3.1.10 → 3.1.12`                                                     |
| [`3a1028d3`](https://github.com/NixOS/nixpkgs/commit/3a1028d3e935fb734163d2fdfad60ed7d4a6f96a) | `vimPlugins.copilot-lua: init at 2022-12-20`                                   |
| [`eaf55670`](https://github.com/NixOS/nixpkgs/commit/eaf55670f18a7ae48e7a48dea7577e47938b526a) | `vimPlugins: update`                                                           |
| [`cafe7509`](https://github.com/NixOS/nixpkgs/commit/cafe75093013e40b709400f0b350574acb6d456f) | `cargo-hack: 0.5.24 -> 0.5.25`                                                 |
| [`e2f0061b`](https://github.com/NixOS/nixpkgs/commit/e2f0061b7e71103c45e517f0d8fc52fcfa82895f) | `python310Packages.fakeredis: 2.3.0 -> 2.4.0`                                  |
| [`49c8bc02`](https://github.com/NixOS/nixpkgs/commit/49c8bc02d127e2b0427ea1cec7eaffb35cdba984) | `fish: omit attrPath in nix-update-script`                                     |
| [`cb219cb6`](https://github.com/NixOS/nixpkgs/commit/cb219cb6d71955f9c14a19f59ec7e57be72d0271) | `nix-update-script: make attrPath optional`                                    |
| [`00138927`](https://github.com/NixOS/nixpkgs/commit/001389279cfd2cde7f0c6b5c39a087119079d9ec) | `nix-update: 0.11.0 -> 0.12.0`                                                 |
| [`bd78a2ba`](https://github.com/NixOS/nixpkgs/commit/bd78a2ba7735192a357f8cbbcb7b087dbf0ec247) | `eaglemode: fix zoneinfo, 0.94.2 -> 0.96.0, adopt`                             |
| [`5f95e2ad`](https://github.com/NixOS/nixpkgs/commit/5f95e2ad3d5752448cc76f3a708a55eab3d09e7a) | `Revert "oneDNN: 2.7.1 -> 3.0", fixes #207551`                                 |
| [`641352ae`](https://github.com/NixOS/nixpkgs/commit/641352ae4c76073de86cc5b31fbeca1ec8f4d4d4) | `python310Packages.tablib: 3.2.1 -> 3.3.0`                                     |
| [`1b3d0a36`](https://github.com/NixOS/nixpkgs/commit/1b3d0a36f9fdf098cca477efdb7e963349423c83) | `python310Packages.bleak-retry-connector: 2.12.0 -> 2.13.0`                    |
| [`6e15d9d6`](https://github.com/NixOS/nixpkgs/commit/6e15d9d65c5ba2d758e32c21f362d1d5b42d813c) | `python310Packages.bleak-retry-connector: 2.11.0 -> 2.12.0`                    |
| [`ad4dd952`](https://github.com/NixOS/nixpkgs/commit/ad4dd95237f7100747d09d0658faeb350cf124f8) | `python310Packages.bleak-retry-connector: 2.10.2 -> 2.11.0`                    |
| [`96842d71`](https://github.com/NixOS/nixpkgs/commit/96842d71957848eff61859687d75f42ad567edbb) | `python310Packages.bluetooth-adapters: 0.15.1 -> 0.15.2`                       |
| [`2d69b371`](https://github.com/NixOS/nixpkgs/commit/2d69b37126550edd13ef2edf1439c6cd519ef814) | `python310Packages.bluetooth-adapters: 0.15.0 -> 0.15.1`                       |
| [`4ced352f`](https://github.com/NixOS/nixpkgs/commit/4ced352fb4d184daa3407454164d409969514d24) | `python310Packages.bluetooth-adapters: 0.14.1 -> 0.15.0`                       |
| [`6efa81ba`](https://github.com/NixOS/nixpkgs/commit/6efa81ba1c1b2e89df5a9886591a78709d958833) | `xfce: remove legacy aliases`                                                  |
| [`8527df4f`](https://github.com/NixOS/nixpkgs/commit/8527df4f20040d023f46efcb9a042eeb5663f9bb) | `libtorch-bin: add sourceProvenance binaryNativeCode`                          |
| [`ed09ac1f`](https://github.com/NixOS/nixpkgs/commit/ed09ac1fe5889a9b27c0b88fe97b50ffcdfa12aa) | `libtorch-bin: 1.12.1 -> 1.13.1`                                               |
| [`eebe2f49`](https://github.com/NixOS/nixpkgs/commit/eebe2f49200e2fea6b536a8b93a330d2927cde15) | `gfold: 4.0.1 -> 4.2.0`                                                        |
| [`59338184`](https://github.com/NixOS/nixpkgs/commit/593381845f9155dfcdc2e177fbaeee3582b89f0b) | `doc/contributing/coding-conventions: add subsection for language servers`     |
| [`e4d0f455`](https://github.com/NixOS/nixpkgs/commit/e4d0f455fa2df56d852385196c377765e3758118) | `treewide: move language servers to pkgs/development/tools/language-servers`   |
| [`54998cb9`](https://github.com/NixOS/nixpkgs/commit/54998cb9d4ab1d09eed437d359cd9881e4435624) | `circleci-cli: 0.1.22770 -> 0.1.22924`                                         |
| [`8b3e8abe`](https://github.com/NixOS/nixpkgs/commit/8b3e8abeec23263d1dac8942705d2ddb6feb9619) | `python310Packages.supervisor: add changelog to meta`                          |
| [`fd284bf4`](https://github.com/NixOS/nixpkgs/commit/fd284bf461a394dd577461d4dff775a1fde6061b) | `tesseract5: 5.2.0 -> 5.3.0`                                                   |
| [`0824ebc4`](https://github.com/NixOS/nixpkgs/commit/0824ebc49a7561b0dae2c56432b2b49681dcc7e6) | `vscode-extensions.waderyan.gitblame: init at 10.1.0`                          |
| [`328e0ab4`](https://github.com/NixOS/nixpkgs/commit/328e0ab47cc5f0400b0ca460bd303a5a10dbbc11) | `python310Packages.supervisor: 4.2.4 -> 4.2.5`                                 |
| [`7def7250`](https://github.com/NixOS/nixpkgs/commit/7def7250bea58985ce8d9bbb9f5b567b4ad2a7e8) | `nixos/nix-daemon: fix isCoercibleToString typo`                               |
| [`22adcaa4`](https://github.com/NixOS/nixpkgs/commit/22adcaa4491dde18442a234252e1d7ed8c098672) | `nixos/lib/make-disk-image: docs, UEFI vars recording, more determinism`       |
| [`c025ec18`](https://github.com/NixOS/nixpkgs/commit/c025ec185f8b53e57997e1fd0a172a285ec97e67) | `nixos/lib/make-disk-image: make raitobezarius code owner of this primitive`   |
| [`1708bbf5`](https://github.com/NixOS/nixpkgs/commit/1708bbf53faf191dda5b4b5337ce000b6725b719) | `faust2: 2.41.1 -> 2.54.9`                                                     |
| [`e592f7a1`](https://github.com/NixOS/nixpkgs/commit/e592f7a11c191f353e55ed540f778ebd0997807c) | `haven-cli: 2.2.3 -> 3.0.0`                                                    |
| [`a8153ecb`](https://github.com/NixOS/nixpkgs/commit/a8153ecbd869ea42b54786db7064562da68c95f2) | `wasmtime: 3.0.1 -> 4.0.0`                                                     |
| [`315bfc4b`](https://github.com/NixOS/nixpkgs/commit/315bfc4bb59e10f4aaf62a9d0d55b8ebedddd669) | `ledger-live-desktop: 2.50.0 -> 2.51.0`                                        |
| [`2342d96a`](https://github.com/NixOS/nixpkgs/commit/2342d96a36edb34a9c304f0e8c0cb7725818703c) | `xfsprogs: 5.19.0 -> 6.1.0`                                                    |
| [`32b35888`](https://github.com/NixOS/nixpkgs/commit/32b35888d6e20e97e22d16c0e9c6e716f6f247d4) | `nixos/dex: fix ssl cert validation`                                           |
| [`71a448e4`](https://github.com/NixOS/nixpkgs/commit/71a448e4695b205e31a9eb0bc5af2e90ab8b119e) | `sundials: 6.4.1 -> 6.5.0`                                                     |
| [`8a00c83c`](https://github.com/NixOS/nixpkgs/commit/8a00c83c49452133635e174c259137b261b30084) | `faustPhysicalModeling: 2.50.6 -> 2.54.9`                                      |
| [`a43c7b2a`](https://github.com/NixOS/nixpkgs/commit/a43c7b2a70da8e7ed82749daf4c13543876b44cf) | `nixos/{firewall, nat}: add a nftables based implementation`                   |
| [`6e2e7c19`](https://github.com/NixOS/nixpkgs/commit/6e2e7c1931279e71e397a98db4a615e1d1a91bd9) | `rmapi: 0.0.22.1 -> 0.0.23`                                                    |
| [`6dbe665d`](https://github.com/NixOS/nixpkgs/commit/6dbe665d2a1ab47196c51c20220d0a4648b25e84) | `deadnix: 0.1.8 -> 1.0.0`                                                      |
| [`b3748800`](https://github.com/NixOS/nixpkgs/commit/b3748800270090094701bbd3b74c5990f9b9a8cc) | `interpreters/lua: replace sourceVersion with lib.versions`                    |
| [`f77ffa5f`](https://github.com/NixOS/nixpkgs/commit/f77ffa5fbe652ef4c2d5a1ee956ee6dcecc2d0e8) | `mdbook: 0.4.24 -> 0.4.25`                                                     |
| [`ab9cdc00`](https://github.com/NixOS/nixpkgs/commit/ab9cdc00727eef4e24b9dad96bf0f528d707e485) | `x42-plugins: 20220923 -> 20221119`                                            |
| [`914b07da`](https://github.com/NixOS/nixpkgs/commit/914b07da7df75d17ee6287fd69a2f42ad28898d5) | `Mathematica: Allow overriding src directly.`                                  |
| [`1f69d192`](https://github.com/NixOS/nixpkgs/commit/1f69d1926eb979b8af0776408d2e0b83f3f5c77c) | `python3Packages.torchvision-bin: 0.14.0 -> 0.14.1`                            |
| [`48014ddf`](https://github.com/NixOS/nixpkgs/commit/48014ddf2f3b3a74505b870846f50507668f9d6c) | `python3Packages.torchvision: 0.14.0 -> 0.14.1`                                |
| [`65c05428`](https://github.com/NixOS/nixpkgs/commit/65c054288be422a41779a01137610a56187e3879) | `python3Packages.torchaudio-bin: 0.13.0 -> 0.13.1`                             |
| [`dc2c52d0`](https://github.com/NixOS/nixpkgs/commit/dc2c52d06c16b07fe0f6e8b1a6f55c9fcb169309) | `python3Packages.torch-bin: 1.13.0 -> 1.13.1`                                  |
| [`c06ef5a7`](https://github.com/NixOS/nixpkgs/commit/c06ef5a7371d0c772a68a67ddc5986ccc76632da) | `python3Packages.torch: 1.13.0 -> 1.13.1`                                      |
| [`63754031`](https://github.com/NixOS/nixpkgs/commit/63754031ca7ce6193c05f6a69205ba03c834c835) | `vscode-fhs: allow editing /etc/nixos`                                         |
| [`0e25cc73`](https://github.com/NixOS/nixpkgs/commit/0e25cc73c831e8af11b72aa6a84f99ef21dd4de7) | `nginxModules.lua: 0.10.15 -> 0.10.22`                                         |
| [`c2b2f29d`](https://github.com/NixOS/nixpkgs/commit/c2b2f29d2b96b9d9bde49f522c4cb9b9a06f4adb) | `nginxModules.pagespeed: cleanup`                                              |
| [`a7f34992`](https://github.com/NixOS/nixpkgs/commit/a7f34992d54982d2ee7951b99b6218dd9f012a95) | `nginxModules: make single packages overridable`                               |
| [`c8c538f2`](https://github.com/NixOS/nixpkgs/commit/c8c538f2ab2432f2dd1eb637657c1bf5b54a147f) | `lib/types: remove loaOf`                                                      |
| [`26f704b5`](https://github.com/NixOS/nixpkgs/commit/26f704b545838084e334f37d434a648c0c564ffd) | `treewide: use nativeBuildInputs with runCommand instead of inlining`          |
| [`0ccdbb39`](https://github.com/NixOS/nixpkgs/commit/0ccdbb399ab6562cc760d27585046b809e9068a8) | `epkowa: add plugin for GT-X750, Perfection 4490`                              |
| [`41299467`](https://github.com/NixOS/nixpkgs/commit/41299467cc70cb45cc414a3b885e5194bb9d6c29) | `gitkraken: 8.9.1 -> 9.0.0`                                                    |
| [`a946e186`](https://github.com/NixOS/nixpkgs/commit/a946e186c571d8f542ac6d00750f2944c958aaf8) | `lxd: 5.8 -> 5.9`                                                              |
| [`cce3dc63`](https://github.com/NixOS/nixpkgs/commit/cce3dc63a02b34d61326dc155a933a91d6937ccc) | `rustPlatform.importCargoLock: add allowBuiltinFetchGit option`                |
| [`f2a5bc37`](https://github.com/NixOS/nixpkgs/commit/f2a5bc37a0d0e4d01e5ada9053fd968ec27587fe) | `gtkcord4: install desktop item and icons, optional libadwaita`                |
| [`cd05f871`](https://github.com/NixOS/nixpkgs/commit/cd05f8718a8f7a33e97a6fbe08f2c686bbeab05d) | `intel-media-driver: build i686 variant on hydra`                              |
| [`8f99f341`](https://github.com/NixOS/nixpkgs/commit/8f99f34194330846742f9fca77eb3d6295455801) | `nixos/opengl: cleanup suggestions for extraPackages`                          |