### PR TITLE
chore(flake/home-manager): `d7a3c268` -> `3ad22341`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672256959,
-        "narHash": "sha256-pSS5bDNUjUj2y3CsaRZJz/D08jBR8rFmSZbNaf2GF5M=",
+        "lastModified": 1672258171,
+        "narHash": "sha256-Z5oobxfWDDQK8KnTPtfGBCA1zpoh4hqe+pn9Hpuv9Q4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d7a3c268542eadfc480c0dd362cd7d4b6eb2a536",
+        "rev": "3ad22341a27c856a8dd390ef7a036e0007153acf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`3ad22341`](https://github.com/nix-community/home-manager/commit/3ad22341a27c856a8dd390ef7a036e0007153acf) | `direnv: enable nushell integration` |
| [`5a570962`](https://github.com/nix-community/home-manager/commit/5a570962a918050e63aeb168d70fd2eaaf32588b) | `flake.lock: Update`                 |