### PR TITLE
chore(flake/home-manager): `fb49fbc3` -> `fa1bc088`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672264928,
-        "narHash": "sha256-MUs5wf244QQpz8KoiJUbrjZa1vCNX0fT8NmQte3AVRY=",
+        "lastModified": 1672266037,
+        "narHash": "sha256-IgzQJm5khTpmqRRu6RoXZuBHSr1VAR9cruHJ499CJ0Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fb49fbc3684154df979618670ccc55819d4b9759",
+        "rev": "fa1bc088ea7b20c0204e8d5c20fec4be938bd5eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`fa1bc088`](https://github.com/nix-community/home-manager/commit/fa1bc088ea7b20c0204e8d5c20fec4be938bd5eb) | `gitui: update default theme to match upstream` |