### PR TITLE
chore(flake/nixpkgs): `1eb875e8` -> `0fc9fca9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672080458,
-        "narHash": "sha256-Ukjn8YUwZevxDPaVUmTx2sf9bCcIJSasmLz+xjGBKrs=",
+        "lastModified": 1672617983,
+        "narHash": "sha256-68WDiCBs631mbDDk4UAKdGURKcsfW6hjb7wgudTAe5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1eb875e811dd59e21e77f6337f2c1592889b48b3",
+        "rev": "0fc9fca9c8d43edd79d33fea0dd8409d7c4580f4",
         "type": "github"
       },
       "original": {

--- a/nix/overlays/sway-scene-graph.nix
+++ b/nix/overlays/sway-scene-graph.nix
@@ -2,15 +2,15 @@ final: prev:
 with final.lib;
 {
   mesa_latest = final.mesa.overrideAttrs (old: rec {
-    version = "22.3.0";
+    version = "22.3.2";
     src = final.fetchurl {
       url = "https://gitlab.freedesktop.org/mesa/mesa/-/archive/mesa-${version}/mesa-mesa-${version}.tar.gz";
-      hash = "sha256-iTJpmr9G0uy26N0gjsK45n6lde8cuW41xFGQVzbhrrA=";
+      hash = "sha256-uG14v6C/2HeAhyAtynncfHee/plsNnRShN2tIvofg0M=";
     };
     mesonFlags = remove "-Dxvmc-libs-path=${placeholder "drivers"}/lib" old.mesonFlags;
   });
 
-  wlroots_0_17 = (final.wlroots_0_15.overrideAttrs (old: {
+  wlroots_0_17 = (final.wlroots_0_16.overrideAttrs (old: {
     version = "unstable-2022-12-09";
     src = final.fetchFromGitLab {
       domain = "gitlab.freedesktop.org";
@@ -19,8 +19,6 @@ with final.lib;
       rev = "8f58c060fd6095e34ede2a2d1c14caea517636e7";
       hash = "sha256-XRBwmO6MbGZ3QEq5Ly+1EUAUMS2wxMfuvH3Ry/dE1E4=";
     };
-    buildInputs = old.buildInputs ++ [ final.hwdata ];
-    dontStrip = true;
   })).override { mesa = final.mesa_latest; };
 
   sway-unwrapped = (prev.sway-unwrapped.overrideAttrs (old: {
@@ -31,7 +29,5 @@ with final.lib;
       rev = "993deff56993dd5565061a73b6ca2d65cfa6e135";
       hash = "sha256-6bN3ux/POQwMeNkN8r/sgg+3p6agbgK+1FKzK9oCxiA=";
     };
-    buildInputs = old.buildInputs ++ (with final; [ pcre2 xorg.xcbutilwm ]);
-    dontStrip = true;
-  })).override { wlroots = final.wlroots_0_17; };
+  })).override { wlroots_0_16 = final.wlroots_0_17; };
 }


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| [`4d80df27`](https://github.com/NixOS/nixpkgs/commit/4d80df27c21b7f4e62f3f8d19f2ea660d85e6998) | `maintainers: update wesleyjrz email`                                                                       |
| [`f534a05a`](https://github.com/NixOS/nixpkgs/commit/f534a05aba33a533dfe6b071905d690a8aa707c3) | `age: 1.0.0 -> 1.1.1`                                                                                       |
| [`89a9ff18`](https://github.com/NixOS/nixpkgs/commit/89a9ff18f14970a8f4138fb6e7874e8a49d08840) | `nanosaur,nanosaur2,otto-matic: cleanup cmake build`                                                        |
| [`d6748dce`](https://github.com/NixOS/nixpkgs/commit/d6748dcee7e397c0f5ea2e8c1ffcac9078ea69df) | `vimPlugins.vim-mediawiki-editor: init at 2022-10-29`                                                       |
| [`79010d72`](https://github.com/NixOS/nixpkgs/commit/79010d72b95adac0969e3a084095d38ff4b4af76) | `vimPlugins: update`                                                                                        |
| [`af62c860`](https://github.com/NixOS/nixpkgs/commit/af62c860ec78e9c211f97ae6c48f7efb306402f0) | `ocamlPackages.imagelib: 20210511 → 20221222`                                                               |
| [`108b7093`](https://github.com/NixOS/nixpkgs/commit/108b709361eea88dc90b319841b4350b1e0fded8) | `nurl: 0.2.1 -> 0.2.2`                                                                                      |
| [`c8104628`](https://github.com/NixOS/nixpkgs/commit/c8104628f4057f2b1842f6e31eaff2fe1d0eeda7) | `nixos/tests/installer/bcachefs: use ocr to type in password`                                               |
| [`13b0e422`](https://github.com/NixOS/nixpkgs/commit/13b0e42202fa3919d551e2e130098c2b14e4b745) | `nixos/tests/installer: disable zfs for bcachefs tests`                                                     |
| [`dda48a50`](https://github.com/NixOS/nixpkgs/commit/dda48a504471e79b25d65491e1dcbeaf8e5609f5) | `linux_testing_bcachefs: 2022-10-31 -> 2022-12-29`                                                          |
| [`5d986f42`](https://github.com/NixOS/nixpkgs/commit/5d986f42d96981402a1e23d31bbce4f11e9db3c3) | `bcachefs-tools: unstable-2022-09-28 -> unstable-2022-12-29`                                                |
| [`655e0725`](https://github.com/NixOS/nixpkgs/commit/655e07253340c2fcc2dbbd894f12362dc7950800) | `nixos/bcachefs: fix boot with systemd enabled initrd`                                                      |
| [`1e6cf6f3`](https://github.com/NixOS/nixpkgs/commit/1e6cf6f3dc967dbf1f20a5a7f3515dcaa316c22d) | `bcachefs-tools: add symlink for mount.bcachefs and fix runtime deps`                                       |
| [`40faf3f2`](https://github.com/NixOS/nixpkgs/commit/40faf3f2d457bbec2ed0d1780b1542233b469875) | `vimPlugins.nvim-treesitter: update grammars`                                                               |
| [`5f7e5eca`](https://github.com/NixOS/nixpkgs/commit/5f7e5ecac6073330775e63848066b7c59811a4b3) | `vimPlugins.mediawiki-vim: init at 2015-11-15`                                                              |
| [`2068a9fe`](https://github.com/NixOS/nixpkgs/commit/2068a9fee3544412bd73d00a877588ce831600d2) | `vimPlugins: update`                                                                                        |
| [`0e9fae2a`](https://github.com/NixOS/nixpkgs/commit/0e9fae2a3d7403e1f13aec610846b9d1d3f4928f) | `nil: 2022-12-01 -> 2023-01-01`                                                                             |
| [`e6221703`](https://github.com/NixOS/nixpkgs/commit/e6221703364a62dc078c439af179bd70445ede46) | `wiki-tui: add changelog to meta`                                                                           |
| [`c9ca13ce`](https://github.com/NixOS/nixpkgs/commit/c9ca13ce9abb2f872c1a24f49fcc027343146a98) | `chromium: Drop passthru.updateScript`                                                                      |
| [`b7431c54`](https://github.com/NixOS/nixpkgs/commit/b7431c54ac3181d602137f677ac89deca5d93ab9) | `chromiumDev: 110.0.5464.2 -> 110.0.5478.4`                                                                 |
| [`3a68bc8b`](https://github.com/NixOS/nixpkgs/commit/3a68bc8b9e92f303691df830b371e3af2b2641b2) | `wiki-tui: 0.6.0 -> 0.6.1`                                                                                  |
| [`26969c3a`](https://github.com/NixOS/nixpkgs/commit/26969c3a819dd44cd15812fb50af8127ce15675a) | `pkgsStatic.lm_sensors: fix build`                                                                          |
| [`6a31f1b3`](https://github.com/NixOS/nixpkgs/commit/6a31f1b36c468e81eb23a60619b63308642594a1) | `python3Packages.django-scim2: init at 0.17.3`                                                              |
| [`4c24f626`](https://github.com/NixOS/nixpkgs/commit/4c24f62648ae848e7d14d3e6ddfc41daff3550d0) | `python3Packages.scim2-filter-parser: init at 0.4.0`                                                        |
| [`bd000ffb`](https://github.com/NixOS/nixpkgs/commit/bd000ffb9dec2933a59a8a9563b7d172441de07b) | `svg2pdf: 0.4.0 -> 0.4.1`                                                                                   |
| [`5a485131`](https://github.com/NixOS/nixpkgs/commit/5a485131fce1c7ab42cc43c3ae8ff8600c710883) | `sleuthkit: add changelog to meta`                                                                          |
| [`545e4f33`](https://github.com/NixOS/nixpkgs/commit/545e4f3375b04313b5f280ce4daf0a5e83d9c2ee) | `python310Packages.pdf2image: add changelog to meta`                                                        |
| [`809a6c15`](https://github.com/NixOS/nixpkgs/commit/809a6c151e57c48a003e02cff9a1fa0480c04846) | `python39Packages.schema-salad: add changelog to meta`                                                      |
| [`192f8444`](https://github.com/NixOS/nixpkgs/commit/192f844477576976f737fad3ace1c9d555d360b9) | `lib/trival: Bump oldestSupportedRelease to 2211`                                                           |
| [`50281bc4`](https://github.com/NixOS/nixpkgs/commit/50281bc4c399f9b8b99e11beb3901031b0c3e7bb) | `python310Packages.beancount-parser: add changelog to emta`                                                 |
| [`4e6337bd`](https://github.com/NixOS/nixpkgs/commit/4e6337bdce10d6912ae031747fdce493399ea5a4) | `workflows/periodic-merge: Remove 22.05 jobs`                                                               |
| [`13d44488`](https://github.com/NixOS/nixpkgs/commit/13d44488ec55a536934d05632ce20732e9ffdf9e) | `python310Packages.hcloud: add changelog to meta`                                                           |
| [`91e936ef`](https://github.com/NixOS/nixpkgs/commit/91e936ef2e5cf4268b2c2a8cf432fedb95ff04e2) | `pwntools: 4.8.0 -> 4.9.0`                                                                                  |
| [`4af22aab`](https://github.com/NixOS/nixpkgs/commit/4af22aab8e239b1ca28da851755c6da1a35fc91b) | `stdenv/check-meta: do deep type checks`                                                                    |
| [`4df10deb`](https://github.com/NixOS/nixpkgs/commit/4df10debe79feba975631347b25f8699b7cd3554) | `lib/customisation.overrideDerivation: propagate evaluation condition`                                      |
| [`2c83122c`](https://github.com/NixOS/nixpkgs/commit/2c83122c1877b20728c8ae97faddbf2166f105cb) | ``treewide: fix broken `meta` attributes``                                                                  |
| [`7e7a2856`](https://github.com/NixOS/nixpkgs/commit/7e7a2856a2527b53edb0adedf1e4849568708e2e) | `python310Packages.pysmbc: add missing input`                                                               |
| [`acee6744`](https://github.com/NixOS/nixpkgs/commit/acee67447e13badbe75a796b0fa7a5040028d9dc) | `python310Packages.pysmbc: disable on unsupported Python releases`                                          |
| [`faf1736d`](https://github.com/NixOS/nixpkgs/commit/faf1736dc409d24016968dd5f7763fa8292ce88f) | `COPYING: 2022 -> 2023`                                                                                     |
| [`8c94b289`](https://github.com/NixOS/nixpkgs/commit/8c94b2899674790edf724fe2991b375aa94909e1) | `ares: fix build on darwin`                                                                                 |
| [`cd3f5375`](https://github.com/NixOS/nixpkgs/commit/cd3f53759d2a4fd72d3c620b1e1764fe27aef98c) | `python310Packages.pysmbc: 1.0.23 -> 1.0.24`                                                                |
| [`1ca08d4c`](https://github.com/NixOS/nixpkgs/commit/1ca08d4c638a89f2c82bec993f9ca4893faf3241) | `treesheets: unstable-2022-12-13 -> unstable-2022-12-30`                                                    |
| [`7e159b1a`](https://github.com/NixOS/nixpkgs/commit/7e159b1a6745f4d00f77aed23f007e134b0e9fb8) | `nixos/cloudflared: systemd dependency fix`                                                                 |
| [`3296813f`](https://github.com/NixOS/nixpkgs/commit/3296813f01a3464420f716c829d96ed5303ebf71) | `python310Packages.pdf2image: 1.16.0 -> 1.16.2`                                                             |
| [`7cead1ff`](https://github.com/NixOS/nixpkgs/commit/7cead1ff76606c66fb9e2108a66b21adede23b44) | `sleuthkit: 4.11.1 -> 4.12.0`                                                                               |
| [`a52297f2`](https://github.com/NixOS/nixpkgs/commit/a52297f256151c9a1334f77eee804b4829378f1b) | `moar: 1.11.1 -> 1.11.2`                                                                                    |
| [`90bd77b1`](https://github.com/NixOS/nixpkgs/commit/90bd77b1df27a238b2d8f862197d26b683d665c9) | `python310Packages.hcloud: 1.18.1 -> 1.18.2`                                                                |
| [`ee8eebcb`](https://github.com/NixOS/nixpkgs/commit/ee8eebcbe4e0a0f7f5b03e1432b53b09f9632355) | `python310Packages.beancount-parser: 0.1.21 -> 0.1.23`                                                      |
| [`cbd1dc1e`](https://github.com/NixOS/nixpkgs/commit/cbd1dc1e725c4661c0ee556b8339b3c50d8a934c) | `nixos-rebuild: Treat any build/target host as non-local`                                                   |
| [`49647234`](https://github.com/NixOS/nixpkgs/commit/49647234f03b3c5d7b5eeefb534bfe61ceb1c74e) | `python39Packages.schema-salad: 8.3.20220913105718 -> 8.3.20221209165047`                                   |
| [`5be120ba`](https://github.com/NixOS/nixpkgs/commit/5be120bac3d30631cd903010b20fbc80a5d81eba) | `kubernetes-controller-tools: 0.10.0 -> 0.11.1`                                                             |
| [`1c9d76c9`](https://github.com/NixOS/nixpkgs/commit/1c9d76c9a185d4248a00c6b831e647d7525258fc) | `benthos: 4.9.0 -> 4.11.0`                                                                                  |
| [`2724b570`](https://github.com/NixOS/nixpkgs/commit/2724b570b366f9fd43c7e8fca359a7ee51df7431) | `metabase: 0.44.5 -> 0.45.1`                                                                                |
| [`aab1077f`](https://github.com/NixOS/nixpkgs/commit/aab1077f0e9cd077decf65309e11e7c2725bf566) | `goresym: 2.0 -> 2.1`                                                                                       |
| [`3d0cfa23`](https://github.com/NixOS/nixpkgs/commit/3d0cfa23e940addb4bdc01ac854b283a4286450b) | `sentry-cli: 2.10.0 -> 2.11.0`                                                                              |
| [`644d7f10`](https://github.com/NixOS/nixpkgs/commit/644d7f100dd144263ec46cb8e8d1192af9cee5f9) | `libsolv: Build without RPM dependency on darwin (#205811)`                                                 |
| [`f294a276`](https://github.com/NixOS/nixpkgs/commit/f294a27605f3d2680c12848cf97b67df1d3f5fc0) | `ssh-to-age: 1.0.3 -> 1.1.0`                                                                                |
| [`9713f75f`](https://github.com/NixOS/nixpkgs/commit/9713f75ffa0caf133adc27a91f1dba833c87c5fe) | `snappymail: 2.24.1 -> 2.24.3`                                                                              |
| [`fad9d559`](https://github.com/NixOS/nixpkgs/commit/fad9d559a3d2a5ed34a1cb841e3d4bc5f7081ae5) | `nurl: 0.1.1 -> 0.2.1`                                                                                      |
| [`e0088016`](https://github.com/NixOS/nixpkgs/commit/e00880169fe1ff27eedcf38b5d94cfe708915743) | `vitess: 15.0.1 -> 15.0.2`                                                                                  |
| [`82319d48`](https://github.com/NixOS/nixpkgs/commit/82319d48dbcbba3648b153842e3119d9fcbf523a) | `whois: 5.5.14 -> 5.5.15`                                                                                   |
| [`69c69246`](https://github.com/NixOS/nixpkgs/commit/69c692467cb4ff3257302f75743aeaa97f13e674) | `flashrom: 1.2 -> 1.2.1`                                                                                    |
| [`ac949b88`](https://github.com/NixOS/nixpkgs/commit/ac949b889280f7258021d7af4e08d619bd7686a8) | `clhep: 2.4.6.2 -> 2.4.6.3`                                                                                 |
| [`51b1d853`](https://github.com/NixOS/nixpkgs/commit/51b1d853951e21200ec6ed5d7dd969cbaf25c0bc) | `tflint: 0.43.0 -> 0.44.1`                                                                                  |
| [`1d63f8c0`](https://github.com/NixOS/nixpkgs/commit/1d63f8c009883643630ef9f3a7986fae721ab201) | `litefs: 0.2.0 -> 0.3.0`                                                                                    |
| [`7741826a`](https://github.com/NixOS/nixpkgs/commit/7741826a4354d428bd9aac2ba9577794607d04e8) | `tippecanoe: 2.16.0 -> 2.17.0`                                                                              |
| [`b75e7815`](https://github.com/NixOS/nixpkgs/commit/b75e7815790b383fccdfca4ba703b16cd0467cf3) | `furnace: 0.6pre2 -> 0.6pre3`                                                                               |
| [`1b17afc8`](https://github.com/NixOS/nixpkgs/commit/1b17afc853d46a9868653110a75591d2e24a0445) | `star-history: 1.0.7 -> 1.0.8`                                                                              |
| [`d6a592c0`](https://github.com/NixOS/nixpkgs/commit/d6a592c02e4b0b6cf0deeff144fe95a866dd6a21) | `mathematica: Add 13.1.0 webdoc=true source hash`                                                           |
| [`bab5a9ca`](https://github.com/NixOS/nixpkgs/commit/bab5a9ca87e0fbbb8a44378ca12b678655273848) | `xnec2c: init at 4.4.12`                                                                                    |
| [`0ded4086`](https://github.com/NixOS/nixpkgs/commit/0ded4086d46062f6990644b393d0ba92e344f48a) | `highlight: fix cross-compilation`                                                                          |
| [`ddcaff2d`](https://github.com/NixOS/nixpkgs/commit/ddcaff2da59cf9a1d2a55084af0e4bc05f1c8392) | `ruff: 0.0.204 -> 0.0.205`                                                                                  |
| [`56c5f3ce`](https://github.com/NixOS/nixpkgs/commit/56c5f3ceeca796382de879dbebc686cbf818c561) | `ruff: 0.0.203 -> 0.0.204`                                                                                  |
| [`c653df75`](https://github.com/NixOS/nixpkgs/commit/c653df755957eb02b879c5d44c91d6d47a5e4b34) | `ghostie: mark broken on x86_64-darwin`                                                                     |
| [`7d6754a3`](https://github.com/NixOS/nixpkgs/commit/7d6754a309f60e82a26c5ad4408fd57a5c5e44f9) | `python39Packages.types-redis: 4.3.21.6 -> 4.3.21.7`                                                        |
| [`5cd84972`](https://github.com/NixOS/nixpkgs/commit/5cd84972531758ec3bb813ba68487cc0132c6a22) | `geoserver: 2.21.2 -> 2.22.0`                                                                               |
| [`e85943f3`](https://github.com/NixOS/nixpkgs/commit/e85943f32e72a94fe88bdaaa9801fa56eed53c22) | `prometheus-xmpp-alerts: Fix broken binary`                                                                 |
| [`ee523770`](https://github.com/NixOS/nixpkgs/commit/ee5237701e9640c0b7d5bebae3fece4ada396e56) | `mathematica: document the command for calculating hashes`                                                  |
| [`9aaf7f19`](https://github.com/NixOS/nixpkgs/commit/9aaf7f19e856818e2c5283101ad10e8fa996cab6) | `rofimoji: 6.0.0 -> 6.1.0`                                                                                  |
| [`54c0e4c4`](https://github.com/NixOS/nixpkgs/commit/54c0e4c4bb095ff374f7a29879a92aa2954e2dd0) | `openai-whisper-cpp: init at 1.0.4`                                                                         |
| [`b2dd8052`](https://github.com/NixOS/nixpkgs/commit/b2dd805235fdd05d4d135f06b8d74e92db434601) | `pt2-clone: 1.55 -> 1.56`                                                                                   |
| [`d005961e`](https://github.com/NixOS/nixpkgs/commit/d005961e237244d42b319f4b8ffd073f6c7919f2) | `wlcs: init at 1.4.0`                                                                                       |
| [`6fdbfe5a`](https://github.com/NixOS/nixpkgs/commit/6fdbfe5abe0e53f54631a489f4b927579d4a7d5c) | `eartag: 0.2.1 -> 0.3.1`                                                                                    |
| [`28044d90`](https://github.com/NixOS/nixpkgs/commit/28044d9042ce1e243e5ac667865c906983f64170) | `texlab: 4.3.2 -> 5.0.0`                                                                                    |
| [`526bd9b6`](https://github.com/NixOS/nixpkgs/commit/526bd9b63ad5f44ff18fc7e52756c4832d36666d) | `python310Packages.thermobeacon-ble: 0.5.0 -> 0.6.0`                                                        |
| [`49255db2`](https://github.com/NixOS/nixpkgs/commit/49255db2db97d17c2b431ef27d4808ae7f8a97bb) | `python310Packages.motionblinds: 0.6.13 -> 0.6.14`                                                          |
| [`d46503e6`](https://github.com/NixOS/nixpkgs/commit/d46503e61b76490b2ecc6b0e659620f1b343faa0) | `python310Packages.motionblinds: add changelog to meta`                                                     |
| [`e875e558`](https://github.com/NixOS/nixpkgs/commit/e875e558bee1b667fca6be55a1fb27b2f2c807fd) | `python310Packages.thermobeacon-ble: 0.4.0 -> 0.5.0`                                                        |
| [`64769690`](https://github.com/NixOS/nixpkgs/commit/64769690ffcbc603a79c0d943ddeb470e1eaf26b) | `python310Packages.hahomematic: 2022.12.11 -> 2022.12.12`                                                   |
| [`63a687ad`](https://github.com/NixOS/nixpkgs/commit/63a687ad75da4e75d7342d522137c3d11cbcb1ad) | ` python310Packages.pytest-tap: fix copy-&-paste error`                                                     |
| [`517ff272`](https://github.com/NixOS/nixpkgs/commit/517ff272eed82b22e3621b7e9a0b9367fb6adf35) | `python3Packages.pytest-tap: add pythonImportsCheck`                                                        |
| [`bb33dedd`](https://github.com/NixOS/nixpkgs/commit/bb33dedd2eda20aaaa114a531db234fa1ef994c7) | `ocamlPackages.git-mirage,ocamlPackages.git-paf,ocamlPackages.git-unix,ocamlPackages.git: 3.10.0 -> 3.10.1` |
| [`89d7a569`](https://github.com/NixOS/nixpkgs/commit/89d7a56919146bdd9820a5fca61528dbd2140b90) | `ocamlPackages.mimic: 0.0.5 -> 0.0.6`                                                                       |
| [`8e041cf4`](https://github.com/NixOS/nixpkgs/commit/8e041cf40c40da7a9b5f50426ae67c7c84480e6f) | `ipscan: add changelog to meta`                                                                             |
| [`128e86cb`](https://github.com/NixOS/nixpkgs/commit/128e86cb93dde5fb9856e97aeaded276aa1f5782) | `python310Packages.wn: add changelog to emta`                                                               |
| [`1c1197c2`](https://github.com/NixOS/nixpkgs/commit/1c1197c2f759a058038b505c52b63e2041253384) | `python310Packages.chess: add changelog to meta`                                                            |
| [`6b20c874`](https://github.com/NixOS/nixpkgs/commit/6b20c8741ec29c720a213c281aeeb770cf5d259c) | `ugrep: add cahngelog to meta`                                                                              |
| [`7f37b4b2`](https://github.com/NixOS/nixpkgs/commit/7f37b4b22a284bca468cfde00eb3dc10077b9061) | `txr: 283 -> 284`                                                                                           |
| [`e999f057`](https://github.com/NixOS/nixpkgs/commit/e999f057050463ae9257cae9336e8e1d29c28e2b) | `obs-studio-plugins.obs-backgroundremoval: remove`                                                          |
| [`d6ec92f8`](https://github.com/NixOS/nixpkgs/commit/d6ec92f8bf9461d83441e2d230906ef1f7582afd) | `onnxruntime: 1.12.1 -> 1.13.1`                                                                             |
| [`53d2a65d`](https://github.com/NixOS/nixpkgs/commit/53d2a65dad16c8d8bd8818978c7041b440fe54be) | `jabcode: unstable-2021-02-16 -> unstable-2022-06-17`                                                       |
| [`3c2b53ed`](https://github.com/NixOS/nixpkgs/commit/3c2b53ed3bcec90ef199c9727b1881779e7c75d9) | `python310Packages.chess: 1.9.3 -> 1.9.4`                                                                   |
| [`bc91954e`](https://github.com/NixOS/nixpkgs/commit/bc91954e2d6a402602773570c599cfeb6fc977ae) | `python310Packages.roonapi: 0.1.1 -> 0.1.2`                                                                 |
| [`0d383507`](https://github.com/NixOS/nixpkgs/commit/0d383507228cd57927c0abb9f35bc4c4936a6d44) | `python310Packages.roonapi: add changelog to meta`                                                          |
| [`76c6349c`](https://github.com/NixOS/nixpkgs/commit/76c6349c9a16dc74c0cbde2dfc5bc9e5fceeb101) | `ghostie: init at 0.2.1`                                                                                    |
| [`6a4468a2`](https://github.com/NixOS/nixpkgs/commit/6a4468a2a69dfd98b631d8e4f2d49c506a96524d) | `libuchardet: 0.0.7 -> 0.0.8`                                                                               |
| [`9a9024f6`](https://github.com/NixOS/nixpkgs/commit/9a9024f6b7cd198b1cb21e5b5caf7a0ea83665e9) | `python310Packages.wn: 0.9.2 -> 0.9.3`                                                                      |
| [`b2e47ddd`](https://github.com/NixOS/nixpkgs/commit/b2e47ddd5c4a19a531e3c8b5069f24309f2c2424) | `ocamlPackages.ppx_tools: enable for OCaml 5 & use dune 3`                                                  |
| [`1b6a2945`](https://github.com/NixOS/nixpkgs/commit/1b6a2945a7cb6f6ed652af417ab9b9f5fe816068) | `mlib: 0.6.0 -> 0.7.0`                                                                                      |
| [`2decd4ef`](https://github.com/NixOS/nixpkgs/commit/2decd4ef94b5d136005e13a093af62ec5546521f) | `tile38: 1.30.1 -> 1.30.2`                                                                                  |
| [`eb96c7ab`](https://github.com/NixOS/nixpkgs/commit/eb96c7ab43872cf26952d4a57d4104cc3619cde3) | `sequoia-chameleon-gnupg: init at 0.1.1`                                                                    |
| [`3dd2e3f6`](https://github.com/NixOS/nixpkgs/commit/3dd2e3f65bd311ccbd4b273b529f59e8e7336cfd) | `cargo-temp: 0.2.13 -> 0.2.14`                                                                              |
| [`d2a9d972`](https://github.com/NixOS/nixpkgs/commit/d2a9d97206a33d8da11df61bf733432bd9f8256d) | `ugrep: 3.9.2 -> 3.9.3`                                                                                     |
| [`9269a0e1`](https://github.com/NixOS/nixpkgs/commit/9269a0e15385ce1a1b007b3c901499eb499549cc) | `awscli2: 2.9.10 -> 2.9.11`                                                                                 |
| [`cdc96736`](https://github.com/NixOS/nixpkgs/commit/cdc96736692642733febb476330b04f81e8b1edb) | `star-history: 1.0.6 -> 1.0.7`                                                                              |
| [`e2d79ecb`](https://github.com/NixOS/nixpkgs/commit/e2d79ecb3077db28812b2b8c41dc79ae954f6a07) | `cargo-tally: 1.0.20 -> 1.0.21`                                                                             |
| [`91f1be8c`](https://github.com/NixOS/nixpkgs/commit/91f1be8c2f54622b2e21fc56c6a7a6510111663a) | `go-mockery: 2.15.0 -> 2.16.0`                                                                              |
| [`9ff694ce`](https://github.com/NixOS/nixpkgs/commit/9ff694ce89028d631f85f183f184bfb1560b85cc) | `terraform-providers.huaweicloud: 1.43.0 → 1.44.0`                                                          |
| [`e14c7030`](https://github.com/NixOS/nixpkgs/commit/e14c7030647acf8783d164f42da2d05cc9067b2a) | `terraform-providers.baiducloud: 1.19.0 → 1.19.1`                                                           |
| [`75fe98c4`](https://github.com/NixOS/nixpkgs/commit/75fe98c4499cd8bf4e42838f33645d2c02afd3ce) | `python310Packages.pulumi-aws: 5.24.0 -> 5.25.0`                                                            |
| [`44089968`](https://github.com/NixOS/nixpkgs/commit/440899686d742821c07b43bf448c19380d9b9da9) | `rust-analyzer-unwrapped: 2022-12-19 -> 2022-12-26`                                                         |
| [`74403e3d`](https://github.com/NixOS/nixpkgs/commit/74403e3d446766bc0d0040d6d72df6a0dffd1598) | `ddosify: 0.10.0 -> 0.11.0`                                                                                 |
| [`ac825c57`](https://github.com/NixOS/nixpkgs/commit/ac825c5763199b756570216182d88354b65a5dc3) | `prometheus-nut-exporter: 2.5.0 -> 2.5.1`                                                                   |
| [`c2ad0e4b`](https://github.com/NixOS/nixpkgs/commit/c2ad0e4b8550713f7f5c493101040ed0ca016fe7) | `ipscan: 3.8.2 -> 3.9.0`                                                                                    |
| [`f8f42c1f`](https://github.com/NixOS/nixpkgs/commit/f8f42c1f05cb0f65486c30291c25bad4dd3d5f33) | `ArchiSteamFarm: 5.3.2.4 -> 5.4.0.3, fix update script (again), little cleanups`                            |
| [`847f2007`](https://github.com/NixOS/nixpkgs/commit/847f20072d3d89a428be8e05682a2426173c4a0d) | `mdds: 2.0.2 -> 2.0.3`                                                                                      |
| [`cb98e26a`](https://github.com/NixOS/nixpkgs/commit/cb98e26aaff781ed48a1885e7a6423708fb564b8) | `lib: Add isStringLike`                                                                                     |
| [`1f8dd05e`](https://github.com/NixOS/nixpkgs/commit/1f8dd05e72adc4e33e43b233bab7c0872119379d) | ``blender: add `libwebp` to `buildInputs` (#208201)``                                                       |
| [`983ae504`](https://github.com/NixOS/nixpkgs/commit/983ae504c9bfd3a7a12cc63991c15e2825522ad8) | `dprint: 0.33.0 -> 0.34.1`                                                                                  |
| [`d1038111`](https://github.com/NixOS/nixpkgs/commit/d103811173b7b608b2639af61d422736bf715a8e) | `lib.isStringLike: Remove use of list`                                                                      |
| [`d0d0f7d0`](https://github.com/NixOS/nixpkgs/commit/d0d0f7d0aaf1ea29f6fe269340186de12d697dea) | `lib: Add isPath`                                                                                           |
| [`23c25d52`](https://github.com/NixOS/nixpkgs/commit/23c25d5231856e8cfd60049582c865da97bc5d44) | `lib.strings.isConvertibleWithToString: Refactor to reuse isStringLike`                                     |
| [`834f0d66`](https://github.com/NixOS/nixpkgs/commit/834f0d660a79e8f08c108237d76fc1b42024289b) | `lib.strings: isMoreCoercibleString -> isConvertibleWithToString`                                           |
| [`872a24eb`](https://github.com/NixOS/nixpkgs/commit/872a24ebbc8056142f7930cc0f775237c4ca83f7) | `lib.strings: isSimpleCoercibleString -> isStringLike`                                                      |
| [`5b8de3d9`](https://github.com/NixOS/nixpkgs/commit/5b8de3d9d85c121fd027608fe0c049356c6eea30) | `nixos/self-deploy: Cleanup after types.path is not allowed to be a list anymore`                           |
| [`29efb2c4`](https://github.com/NixOS/nixpkgs/commit/29efb2c438ba2dd04d545c67a22d1e64576de9f4) | `lib.types.path: Do not allow lists of strings`                                                             |
| [`fed5dc66`](https://github.com/NixOS/nixpkgs/commit/fed5dc66f80ae3a159a2449904ae067f60a04a67) | `treewide: isCoercibleToString -> isMoreCoercibleToString`                                                  |
| [`68b6443e`](https://github.com/NixOS/nixpkgs/commit/68b6443ed635a3e87a62a5a8dcfd05e952c93192) | `lib.strings: Rename isCoercibleToString -> isMoreCoercibleToString`                                        |
| [`3a4c9bdb`](https://github.com/NixOS/nixpkgs/commit/3a4c9bdbe619ed235aab005c5f162879c2ed6039) | `lib.types.anything: Use isSimpleCoercibleToString`                                                         |
| [`03063f65`](https://github.com/NixOS/nixpkgs/commit/03063f65a5d58fc0a72648d475101d86752725ba) | `lib.strings.toShellVar: Use isSimpleCoercibleString`                                                       |