### PR TITLE
chore(flake/home-manager): `a993eac1` -> `cbacdaba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672274925,
-        "narHash": "sha256-DpkuoGwEW92zj/3jWKLb1biF4whs9yIc+pQbg67gqGU=",
+        "lastModified": 1672318366,
+        "narHash": "sha256-DBUVFooXtE4boZk1LvJ8sTg3nxMmJvNAJQ4lpjxDH5U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a993eac1065c6ce63a8d724b7bccf624d0e91ca2",
+        "rev": "cbacdaba3c7b361defb36e1cdfa03ae4e74eb4a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                      | Commit Message                          |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`cbacdaba`](https://github.com/nix-community/home-manager/commit/cbacdaba3c7b361defb36e1cdfa03ae4e74eb4a8) | `man: update database cache generation` |
| [`f97f191f`](https://github.com/nix-community/home-manager/commit/f97f191fe7a8c190a59d7f22a0f895ccebc8f0d1) | `kakoune: update hooks (#3418)`         |