### PR TITLE
chore(flake/nixos-hardware): `9577ab1e` -> `e2f9c6f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1671631481,
-        "narHash": "sha256-LP6NvQQNKdqDpXngECo6oCiWfYRb0KPGM5+D5lu7mPw=",
+        "lastModified": 1672322014,
+        "narHash": "sha256-HEYUb2pxm9SUgqvg8eDpFUl6UPXmd7USNWAew115zL4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9577ab1eaf01a738b015a7a7ab2a4616e158b6cd",
+        "rev": "e2f9c6f7360f3e0f7b0bc2a3e7193a290c5d4c81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                                                                     |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`49485f55`](https://github.com/NixOS/nixos-hardware/commit/49485f5569f290bf9d3daf893d9df3daf4d016be) | `Update lenovo/yoga/6/13ALC6/default.nix`                                                          |
| [`c1a38081`](https://github.com/NixOS/nixos-hardware/commit/c1a38081fa17eb4d1692f4df27bd48e59ac12b01) | `Update lenovo/yoga/6/13ALC6/default.nix`                                                          |
| [`993e6c87`](https://github.com/NixOS/nixos-hardware/commit/993e6c8726f6c75bab73236d1bce94a2e79160f2) | `removo TLP`                                                                                       |
| [`114881dd`](https://github.com/NixOS/nixos-hardware/commit/114881dd3dc7de292625886995f23d5b35fb715a) | `Minimum required version is 5.16 based on https://linux-hardware.org/?id=pci:10ec-8852-17aa-4852` |
| [`a30c4834`](https://github.com/NixOS/nixos-hardware/commit/a30c4834f48a8d4da5c5d46926287cda4665078a) | `set a minimum kernel`                                                                             |
| [`2e8fce47`](https://github.com/NixOS/nixos-hardware/commit/2e8fce47c8bd3a0936ac9e4e5d7983fc96caa25e) | `Reusing modules`                                                                                  |
| [`485f3bc2`](https://github.com/NixOS/nixos-hardware/commit/485f3bc2f27b63c558bee579b6a0d5c10291c1ec) | `Add LENOVO Yoga 6 13ALC6 82ND`                                                                    |