### PR TITLE
chore(flake/deploy-rs): `2a3c5f70` -> `3878dd40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668797197,
-        "narHash": "sha256-0w6iD3GSSQbIeSFVDzAAQZB+hDq670ZTms3d9XI+BtM=",
+        "lastModified": 1672323947,
+        "narHash": "sha256-P88yVbk0h+IbZPEYZ+73l5k3Z0CK7vAGe/rdwXmpA3A=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "2a3c5f70eee04a465aa534d8bd4fcc9bb3c4a8ce",
+        "rev": "3878dd40f622d327ee912e9b4077909834261772",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                              | Commit Message                                                               |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`068372aa`](https://github.com/serokell/deploy-rs/commit/068372aad18f04122bbdb836e36c655c157ebe71) | ``Add new activation strategy `boot` as equivalent to `nixos-rebuild boot``` |