### PR TITLE
chore(flake/nixos-hardware): `e2f9c6f7` -> `d7dfd13d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1672322014,
-        "narHash": "sha256-HEYUb2pxm9SUgqvg8eDpFUl6UPXmd7USNWAew115zL4=",
+        "lastModified": 1672471819,
+        "narHash": "sha256-YrHPURo2MjlVxymSDRIHySiNZApCZ5F1AjxfQi/8xqs=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e2f9c6f7360f3e0f7b0bc2a3e7193a290c5d4c81",
+        "rev": "d7dfd13d25ac70cc32c0f0c0d2dff0313ec61894",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                | Commit Message                                              |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`ed291da4`](https://github.com/NixOS/nixos-hardware/commit/ed291da4ab7e14ef3cff9c94a23247fa3cd7e7ae) | `Update flake.nix and root README.md`                       |
| [`0cee3767`](https://github.com/NixOS/nixos-hardware/commit/0cee376703b8e53d9538c2786211dbcd5396c48b) | `Support reloading btusb module after resuming`             |
| [`97900e1e`](https://github.com/NixOS/nixos-hardware/commit/97900e1e7eb3257a037ce5cfc3544787295685d9) | `Support reloading i2c-designware module(s) after resuming` |
| [`b1582825`](https://github.com/NixOS/nixos-hardware/commit/b1582825dda721e4feeeec782b34bf9af9f7f5f3) | `Support for the Dell XPS 13, 9300 model`                   |