### PR TITLE
chore(flake/darwin): `267040e7` -> `3db1d870`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671891118,
-        "narHash": "sha256-+GJYiT7QbfA306ex4sGMlFB8Ts297pn3OdQ9kTd4aDw=",
+        "lastModified": 1672753581,
+        "narHash": "sha256-EIi2tqHoje5cE9WqH23ZghW28NOOWSUM7tcxKE1U9KI=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "267040e7a2b8644f1fdfcf57b7e808c286dbdc7b",
+        "rev": "3db1d870b04b13411f56ab1a50cd32b001f56433",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                           | Commit Message                                                              |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
| [`7ec26a90`](https://github.com/LnL7/nix-darwin/commit/7ec26a9042ea3418798a5a486632da1c87826fd4) | `services.hercules-ci-agent: Explain default concurrentTasks is core count` |
| [`5311f8de`](https://github.com/LnL7/nix-darwin/commit/5311f8ded0bccf2a4e5fcafb75a240197c09b959) | `hercules-ci-agent: Remove old nix version check`                           |
| [`3cb5cfa5`](https://github.com/LnL7/nix-darwin/commit/3cb5cfa5f988b6cdc446845c135c50c9cca2388f) | `hercules-ci-agent: init`                                                   |
| [`61760448`](https://github.com/LnL7/nix-darwin/commit/617604488e0b45ce7d156962828f1c69d973930d) | `Add meta.maintainers option`                                               |