### PR TITLE
chore(flake/nixpkgs): `0fc9fca9` -> `9813adc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672617983,
-        "narHash": "sha256-68WDiCBs631mbDDk4UAKdGURKcsfW6hjb7wgudTAe5o=",
+        "lastModified": 1672791794,
+        "narHash": "sha256-mqGPpGmwap0Wfsf3o2b6qHJW1w2kk/I6cGCGIU+3t6o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0fc9fca9c8d43edd79d33fea0dd8409d7c4580f4",
+        "rev": "9813adc7f7c0edd738c6bdd8431439688bb0cb3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`d629799a`](https://github.com/NixOS/nixpkgs/commit/d629799adb8f8738c7a7b9be6d0c73ec4804502d) | `` gh: 2.21.1 -> 2.21.2 ``                                                   |
| [`197eafd6`](https://github.com/NixOS/nixpkgs/commit/197eafd66071960a14138777cfdd3a99e3342cea) | `` CODEOWNERS: Add myself to python language documentation ``                |
| [`e8397aa6`](https://github.com/NixOS/nixpkgs/commit/e8397aa6826db50d8adb7e8f5e78349b6de07caa) | `` karmor: init at 0.11.1 (#207794) ``                                       |
| [`5f40e9e1`](https://github.com/NixOS/nixpkgs/commit/5f40e9e178ca5ab04e7342c35193990ca638dd0f) | `` samba: add darwin support (#207465) ``                                    |
| [`6e1f2baf`](https://github.com/NixOS/nixpkgs/commit/6e1f2baf4ae08fc59589940315d60046eb236983) | `` chromiumBeta: 109.0.5414.46 -> 109.0.5414.61 ``                           |
| [`b708a352`](https://github.com/NixOS/nixpkgs/commit/b708a3523a6e365d4c69e3c2d4aebd6b5ca199d5) | `` python3Packages.gym: remove unnecessary string interpolation (#208846) `` |
| [`3251e0fa`](https://github.com/NixOS/nixpkgs/commit/3251e0faa80df0b3c2a1ace6115cd67234773213) | `` ledger-live-desktop: remove unused systemd package parameter ``           |
| [`6ae1c53d`](https://github.com/NixOS/nixpkgs/commit/6ae1c53d725b4a58c40a3d00817b51f7a40d5168) | `` melonDS: 0.9.4 -> 0.9.5 (#208738) ``                                      |
| [`d5b94c4d`](https://github.com/NixOS/nixpkgs/commit/d5b94c4dba35df534ef51e6f895c0c8ea10d3a1a) | `` nimPackages.taps: init at 20221228 ``                                     |
| [`68f6c618`](https://github.com/NixOS/nixpkgs/commit/68f6c618a33e1749583906099cbe44c0e79b95d7) | `` nimPackages.base32: init at 0.1.3 ``                                      |
| [`c3469043`](https://github.com/NixOS/nixpkgs/commit/c34690433faf033cf67988fe98e688f88633e41f) | `` nimPackages.tkrzw: init at 20220922 ``                                    |
| [`5a39dd58`](https://github.com/NixOS/nixpkgs/commit/5a39dd58c746f40055d8fa152ba3db7ef2e7b56e) | `` nimPackages.nimSHA2: init at unstable-2021-09-09 ``                       |
| [`ead4a0fb`](https://github.com/NixOS/nixpkgs/commit/ead4a0fb43ababddc62352c1010f008edc1afd5b) | `` nimPackages.npeg: init at 1.0.1 ``                                        |
| [`4c585b7b`](https://github.com/NixOS/nixpkgs/commit/4c585b7b6bf768c6f5a70b8b1069178ee9b0790c) | `` nimPackages.cbor: init at 20221007 ``                                     |
| [`7724ff07`](https://github.com/NixOS/nixpkgs/commit/7724ff0721356aa421e063a0c0a44b1fd1fd5dd8) | `` deepgit: init at 4.3 ``                                                   |
| [`83481b87`](https://github.com/NixOS/nixpkgs/commit/83481b87082efe630b6bcd3c5089f488d90be51f) | `` doc: python: Run hooks in checkPhase ``                                   |
| [`99b715f3`](https://github.com/NixOS/nixpkgs/commit/99b715f39d0dbf003fd5e8f04209dfcd6f88ae34) | `` waydroid: cleanup inputs ``                                               |
| [`2628f000`](https://github.com/NixOS/nixpkgs/commit/2628f0003c708c20191022dbe911002c17ec5203) | `` waydroid: 1.3.3 -> 1.3.4 (#206833) ``                                     |
| [`25987436`](https://github.com/NixOS/nixpkgs/commit/2598743628254f298ef2e770087affe6f47e6ad0) | `` openvdb: 9.1.0 -> 10.0.1 ``                                               |
| [`fc9b47c5`](https://github.com/NixOS/nixpkgs/commit/fc9b47c5d5d5700f52d4cfdb586b43fcde0cac00) | `` openvdb: refactor for split outputs ``                                    |
| [`9cc1e97f`](https://github.com/NixOS/nixpkgs/commit/9cc1e97f615b66e3f89fe0d1b7277fce44bd07aa) | `` nixos/gnupg: (fix) use runtimeShell to call updatestartuptty ``           |
| [`b0f6cc81`](https://github.com/NixOS/nixpkgs/commit/b0f6cc813f4fb116274df28bffbc258106b05f6d) | `` mpv: use ffmpeg_5 ``                                                      |
| [`5dc86f23`](https://github.com/NixOS/nixpkgs/commit/5dc86f23a189b3344ce6a529f9216b4ac7ba5d53) | `` gtksourceview5: Add Nix syntax highlighting ``                            |
| [`a72e226b`](https://github.com/NixOS/nixpkgs/commit/a72e226b04c008ccc499e9e19dcda9dae493a8c9) | `` spark2014: fix incomplete install (#208830) ``                            |
| [`b943fb24`](https://github.com/NixOS/nixpkgs/commit/b943fb24b7bb827677fb7dad0de1562c13db27c5) | `` chrony: update sandboxing options ``                                      |
| [`5e96eb14`](https://github.com/NixOS/nixpkgs/commit/5e96eb14ce38fe9067fe5d8545379560a0c331c4) | `` nixos/snipe-it: Fix a bug in the setup script (#206869) ``                |
| [`0667ef5d`](https://github.com/NixOS/nixpkgs/commit/0667ef5dd5cc7aa00e7d5ebf4391b7ee1d414a0c) | `` lib.path.subpath.normalise: add property tests ``                         |
| [`63dd6d20`](https://github.com/NixOS/nixpkgs/commit/63dd6d20db8ac4b5576b48a58fe434319791a7d7) | `` lib.path.subpath.normalise: init ``                                       |
| [`98fbcf17`](https://github.com/NixOS/nixpkgs/commit/98fbcf17888872f5ebdf9fb6247266929f4308db) | `` lib.path.subpath.isValid: init ``                                         |
| [`ba7ed22f`](https://github.com/NixOS/nixpkgs/commit/ba7ed22f844b984a1da0031da736d13a11509bb7) | `` lib.path: init README.md document ``                                      |
| [`e3539cdd`](https://github.com/NixOS/nixpkgs/commit/e3539cdd2c53683ce9afd259bd8db9105eff97d5) | `` nixos/i3: update doc for gaps merge ``                                    |
| [`b2a3c6bd`](https://github.com/NixOS/nixpkgs/commit/b2a3c6bd6a7695e21170c640e657c18bf9d3ec0c) | `` i3-gaps: drop ``                                                          |
| [`9701c2e9`](https://github.com/NixOS/nixpkgs/commit/9701c2e9a0acfe07db588c2f47299b853c8e20e5) | `` i3: 4.21.1 -> 4.22 ``                                                     |
| [`aad971f3`](https://github.com/NixOS/nixpkgs/commit/aad971f342e54dbc9a8a11f2b868977756839d49) | `` release-cross.nix: nixCrossStatic: do not burden *-darwin builders ``     |
| [`18d4d822`](https://github.com/NixOS/nixpkgs/commit/18d4d8224abe9334a30f81d07e62537349f8d054) | `` gcc-arm-embedded-12: init at 12.2.rel1 ``                                 |
| [`9e949edd`](https://github.com/NixOS/nixpkgs/commit/9e949edd9a34b3b7ca3b6ee0470f7fac2a286470) | `` julia_18: fix typo in JULIA_CPU_TARGET ``                                 |
| [`7b0c8a83`](https://github.com/NixOS/nixpkgs/commit/7b0c8a8318624f01a47a968ac9678c9c9e3f788a) | `` ispc: Add aarch64-linux and aarch64-darwin platforms ``                   |
| [`1659dab0`](https://github.com/NixOS/nixpkgs/commit/1659dab09854b3338a38da318582d153a0bd8db5) | `` nixpacks: 0.16.0 -> 1.0.3 ``                                              |
| [`5ace5a33`](https://github.com/NixOS/nixpkgs/commit/5ace5a33b9dbe2e9fbb97771574da6e06f99e292) | `` eudev: remove glib from buildInputs ``                                    |
| [`4df597f4`](https://github.com/NixOS/nixpkgs/commit/4df597f4272b5c22f63cc80fba1770bfd6949558) | `` spek: unstable-2018-12-29 -> 0.8.4 ``                                     |
| [`605d013a`](https://github.com/NixOS/nixpkgs/commit/605d013aac535336042ff2a1b0151475978ba1cb) | `` igv: 2.15.1 -> 2.15.4 ``                                                  |
| [`de3d5787`](https://github.com/NixOS/nixpkgs/commit/de3d57875d85f7e2a912571fde70569e71a69d19) | `` llvmPackages_9.lldb: fix darwin build ``                                  |
| [`a8f6f128`](https://github.com/NixOS/nixpkgs/commit/a8f6f12879130b94088f6ca50c994d0d0f54ad0a) | `` llvmPackages_8.lldb: fix darwin build ``                                  |
| [`f67ff98a`](https://github.com/NixOS/nixpkgs/commit/f67ff98a1125cb40dda05b8635b2724fe11b4aae) | `` timescaledb-tune: 0.14.2 -> 0.14.3 ``                                     |
| [`1b3bbd48`](https://github.com/NixOS/nixpkgs/commit/1b3bbd48d9ff782d703329342d0582a6f9b52a13) | `` grip: 4.2.3 -> 4.2.4 ``                                                   |
| [`f78178fc`](https://github.com/NixOS/nixpkgs/commit/f78178fcc6215d71357332702992123030968710) | `` rosegarden: 20.12 -> 22.12.1 ``                                           |
| [`4a2446fc`](https://github.com/NixOS/nixpkgs/commit/4a2446fcf565b0de22a7426b0255f7932b6b57ca) | `` nv-codec-headers-11: 11.1.5.1 -> 11.1.5.2 ``                              |
| [`a38f5235`](https://github.com/NixOS/nixpkgs/commit/a38f523576c095191c080a3d2843f4998e7822fe) | `` eyedropper: 0.4.0 -> 0.5.0 ``                                             |
| [`20fceb75`](https://github.com/NixOS/nixpkgs/commit/20fceb750c83c9b5ecd7a6e831e6cd82751f1922) | `` vmagent: 1.85.0 -> 1.85.3 ``                                              |
| [`b76efd73`](https://github.com/NixOS/nixpkgs/commit/b76efd73ca0964876b9ec19ad171428909ea6341) | `` signalbackup-tools: 20221208 -> 20221227-1 ``                             |
| [`e873cafe`](https://github.com/NixOS/nixpkgs/commit/e873cafe2c3e8d7cb1e8dc92abaa7750d301f140) | `` ocamlPackages.base64: add missing dependency ``                           |
| [`730e0573`](https://github.com/NixOS/nixpkgs/commit/730e057313e507061cb9b03bfea827ef42fb7438) | `` ocamlPackages.ppx_deriving: disable test with OCaml ≥ 5.0 ``              |
| [`bfdedc36`](https://github.com/NixOS/nixpkgs/commit/bfdedc362f5b22772558342bbf006fca9d251881) | `` ocamlPackages.mrmime: small improvements ``                               |
| [`ea993dd1`](https://github.com/NixOS/nixpkgs/commit/ea993dd1fcba4e2e3ee4b146b9b4f1023a2331fc) | `` ocamlPackages.piaf: disable for OCaml ≥ 5.0 ``                            |
| [`57e6253b`](https://github.com/NixOS/nixpkgs/commit/57e6253b8c03e3bbf95e798085ee0fcf73fa6870) | `` librecad: 2.2.0-rc2 -> 2.2.0 ``                                           |
| [`08ce0ded`](https://github.com/NixOS/nixpkgs/commit/08ce0ded5106cc0a87c7f3dae8164b79a611d703) | `` python3Packages.django_4: 4.1.4 -> 4.1.5 ``                               |
| [`53cbb123`](https://github.com/NixOS/nixpkgs/commit/53cbb123f5772e2fe26fceeab96ee06ea65fd7c3) | `` chrony: update build configuration ``                                     |
| [`c0a40bee`](https://github.com/NixOS/nixpkgs/commit/c0a40bee00461f2b4999cbec319d1e54baa9d87f) | `` nss: set -DNS_PTR_LE_32=1 if isILP32 ``                                   |
| [`784d85d2`](https://github.com/NixOS/nixpkgs/commit/784d85d2c51ebadb28fcb437dced258f33474969) | `` millet: 0.6.0 -> 0.6.7 ``                                                 |
| [`76cf05c3`](https://github.com/NixOS/nixpkgs/commit/76cf05c317a18cd6a5d103766334cdb6b8f33b8a) | `` zsv: 0.3.3-alpha -> 0.3.4-alpha ``                                        |
| [`8d82e8ea`](https://github.com/NixOS/nixpkgs/commit/8d82e8eacce932df2296c3453d7addd3b394f27f) | `` shadowsocks-rust: add changelog to meta ``                                |
| [`e389394c`](https://github.com/NixOS/nixpkgs/commit/e389394c71fa4c55070aa277de022a1b43d61160) | `` flexget: 3.5.15 -> 3.5.16 ``                                              |
| [`c1c7ae2d`](https://github.com/NixOS/nixpkgs/commit/c1c7ae2d6cff390a2babec789c4761ab595f4ece) | `` postgresqlPackages.plpgsql_check: 2.2.5 -> 2.2.6 ``                       |
| [`8dcc2da3`](https://github.com/NixOS/nixpkgs/commit/8dcc2da332e90925e5d02ae352d4881b811ad737) | `` esbuild: 0.16.12 -> 0.16.13 ``                                            |
| [`1c6497ec`](https://github.com/NixOS/nixpkgs/commit/1c6497ec05b6ee767920bc9b4905a42fc4d3874a) | `` shadowsocks-rust: 1.15.1 -> 1.15.2 ``                                     |
| [`198d5225`](https://github.com/NixOS/nixpkgs/commit/198d522594c4ba14443f81f18e7608f67202cb1c) | `` darwin.apple_sdk.frameworks.DebugSymbols: init ``                         |
| [`a735faaa`](https://github.com/NixOS/nixpkgs/commit/a735faaa3a6417c9152c54b51e496c68bb6ce9e0) | `` terraform-providers.alicloud: 1.194.1 → 1.195.0 ``                        |
| [`51f7e84f`](https://github.com/NixOS/nixpkgs/commit/51f7e84f60dec9cfb012fbc5888c94d873476cba) | `` terraform-providers.bitbucket: 2.27.0 → 2.29.0 ``                         |
| [`493f17de`](https://github.com/NixOS/nixpkgs/commit/493f17de944c9e38886b36a24006a8658d0d3db1) | `` woodpecker: 0.15.5 -> 0.15.6 ``                                           |
| [`3302bc3d`](https://github.com/NixOS/nixpkgs/commit/3302bc3ddda5b1f72f7382b259d25856ed763a5e) | `` crc: 2.6.0 -> 2.11.0 (#205126) ``                                         |
| [`54f1ef62`](https://github.com/NixOS/nixpkgs/commit/54f1ef62b94bb88b7777a106cc39d89509245151) | `` iosevka-bin: 16.8.2 -> 17.0.2 ``                                          |
| [`f914350e`](https://github.com/NixOS/nixpkgs/commit/f914350e81dc038d518dd58c442beb8bfc38f5a1) | `` loccount: 1.2 -> 2.14 ``                                                  |
| [`4ad0355b`](https://github.com/NixOS/nixpkgs/commit/4ad0355b576ed38f81056c5328531ae2d348b81d) | `` filegive: 0.7.4 -> unstable-2022-05-29 ``                                 |
| [`bef8f34b`](https://github.com/NixOS/nixpkgs/commit/bef8f34bb7bde96b279df0734cf48839cd1b0b17) | `` python310Packages.reolink-aio: init at 0.1.1 ``                           |
| [`9144942a`](https://github.com/NixOS/nixpkgs/commit/9144942aa343ed8317ab1a48497dcf4315791d9d) | `` tinycc: unbreak on x86_64-darwin ``                                       |
| [`1b02ac34`](https://github.com/NixOS/nixpkgs/commit/1b02ac3476226dd45eca0db6fcfc7f43f0d9fece) | `` python310Packages.reolink: add changelog to meta ``                       |
| [`a6663bad`](https://github.com/NixOS/nixpkgs/commit/a6663badb1c373241b9c89e2eed55ed2bf2d413d) | `` libmilter: 8.15.2 -> 8.17.1 ``                                            |
| [`838589af`](https://github.com/NixOS/nixpkgs/commit/838589af3096d2d47e09237f8f569f02e8331e87) | `` python310Packages.aioaladdinconnect: 0.1.48 -> 0.1.50 ``                  |
| [`794e1a0e`](https://github.com/NixOS/nixpkgs/commit/794e1a0e029f511fc0482c31422f018f3113d0f8) | `` python310Packages.motionblinds: 0.6.14 -> 0.6.15 ``                       |
| [`b932ae4d`](https://github.com/NixOS/nixpkgs/commit/b932ae4d76b6c886cef70e93b1edd402ec2bca7f) | `` python310Packages.pytibber: 0.26.6 -> 0.26.7 ``                           |
| [`062e14b5`](https://github.com/NixOS/nixpkgs/commit/062e14b5617f6804973957e7fbe7273a9dc8da0b) | `` stdenv/linux: document some tips in debugging stdenv bootstrap tower ``   |
| [`70aa373a`](https://github.com/NixOS/nixpkgs/commit/70aa373a5d46352df1078311e410ddbfc8c5870f) | `` home-assistant: update component-packages ``                              |
| [`c514b093`](https://github.com/NixOS/nixpkgs/commit/c514b093bca599176061ac7a386564f2066fe1a6) | `` python310Packages.pykaleidescape: init at 1.0.1 ``                        |
| [`8877cc28`](https://github.com/NixOS/nixpkgs/commit/8877cc2874efffe3663934cbfe5d0fce1d4d4bbc) | `` build(deps): bump zeebe-io/backport-action from 0.0.9 to 1.0.0 ``         |
| [`0c23e817`](https://github.com/NixOS/nixpkgs/commit/0c23e81752c01c9bc76f1ce368eb415343dec9ea) | `` yt-dlp: 2022.11.11 -> 2023.1.2 ``                                         |
| [`390c68c9`](https://github.com/NixOS/nixpkgs/commit/390c68c9d29dd3b88808a1b55887901e670e5bf4) | `` frawk: 0.4.6 -> 0.4.7 ``                                                  |
| [`1d9743d8`](https://github.com/NixOS/nixpkgs/commit/1d9743d8cd3440bde0f8720f0111bedd2e2b5e55) | `` vimPlugins.glance-nvim: init at 2022-12-05 ``                             |
| [`3bfb8d1f`](https://github.com/NixOS/nixpkgs/commit/3bfb8d1f5e9f58e4909eb4715535cf9e4c31fde2) | `` vimPlugins: update ``                                                     |
| [`eae9a092`](https://github.com/NixOS/nixpkgs/commit/eae9a09270fe24991b7b6f47f7cfad57458d4fae) | `` keepass-diff: init at 1.1.3 ``                                            |
| [`fe57d3bb`](https://github.com/NixOS/nixpkgs/commit/fe57d3bb42d4fa74bda66510034cc5a2f410ef71) | `` ruff: 0.0.206 -> 0.0.207 ``                                               |
| [`ca34a788`](https://github.com/NixOS/nixpkgs/commit/ca34a788fe4bb96b8bb14a9db195fb33eb7fe11f) | `` molsketch: init at 0.7.3 ``                                               |
| [`88d6c7c7`](https://github.com/NixOS/nixpkgs/commit/88d6c7c7a7a25a4025d99f7800ee6bbc18c418b3) | `` yubioath-flutter: package and set path to icon ``                         |
| [`778f2785`](https://github.com/NixOS/nixpkgs/commit/778f278579934823969f6c3fae25a9328a9f0f7d) | `` home-assistant: update component-packages ``                              |
| [`0b9f76a8`](https://github.com/NixOS/nixpkgs/commit/0b9f76a8d37cfd3b457efe37d2ab7930722de016) | `` nixos/nix-ld: fix example texts ``                                        |
| [`d40732c5`](https://github.com/NixOS/nixpkgs/commit/d40732c5ee5f53580690b648b9911e0a2185985c) | `` python310Packages.kiwiki-client: init at 0.1.2 ``                         |
| [`b84a4ccb`](https://github.com/NixOS/nixpkgs/commit/b84a4ccb9f93bfd06c0aead31a7bc9fa0f0bcb6b) | `` redis: 7.0.5 -> 7.0.7 ``                                                  |
| [`10b497b1`](https://github.com/NixOS/nixpkgs/commit/10b497b1ea1d121f9ec8c10c2a13c71d0fe93715) | `` sanjuuni: init at 0.2 ``                                                  |
| [`c2e4d92a`](https://github.com/NixOS/nixpkgs/commit/c2e4d92a650215a7808d02a7dfebd1e43c760ab4) | `` maintainers: add tomodachi94 ``                                           |
| [`d7637635`](https://github.com/NixOS/nixpkgs/commit/d7637635d96b5be0ff63a83bded0a236a72ea2b3) | `` inspircd, inspircdMinimal: 3.14.0 -> 3.15.0 ``                            |
| [`aee464fa`](https://github.com/NixOS/nixpkgs/commit/aee464fa94e90c61cc3b848ebc3b744d48379dd2) | `` river: 0.1.3 -> 0.2.0 ``                                                  |
| [`be69096e`](https://github.com/NixOS/nixpkgs/commit/be69096ee6bffc38d3e02008d6cef708cfe4c957) | `` python310Packages.whois: 0.9.19 -> 0.9.20 ``                              |
| [`4a9b4b7e`](https://github.com/NixOS/nixpkgs/commit/4a9b4b7eaff27b5c8971bdb82136ad08b0e9d893) | `` river: add adamcstephens as maintainer ``                                 |
| [`1d168df1`](https://github.com/NixOS/nixpkgs/commit/1d168df13a12585bca57a198e3131e3172bd3d4b) | `` pkgsStatic.libgpg-error: make tests pass ``                               |
| [`93b0ea3c`](https://github.com/NixOS/nixpkgs/commit/93b0ea3c352be4af75d632326f4c42af94e33278) | `` xray: 1.6.6-2 -> 1.7.0 ``                                                 |
| [`e4604fb4`](https://github.com/NixOS/nixpkgs/commit/e4604fb4e62e9d3732d95d569b6957f040f35e5d) | `` nwg-dock: 0.3.2 -> 0.3.3 ``                                               |
| [`13f2d0a2`](https://github.com/NixOS/nixpkgs/commit/13f2d0a2b8ab2b287f215a3188d4ed7cde2e0277) | `` pocketbase: 0.10.1 -> 0.10.4 ``                                           |
| [`667ab43f`](https://github.com/NixOS/nixpkgs/commit/667ab43f311f59d5a003ebae1bdcb9251a4f0687) | `` barcode: add darwin support ``                                            |
| [`3d3f42e0`](https://github.com/NixOS/nixpkgs/commit/3d3f42e06a33ea3346459a870fef4bc9af51e35f) | `` kubent: 0.6.0 -> 0.7.0 ``                                                 |
| [`ac2fe938`](https://github.com/NixOS/nixpkgs/commit/ac2fe9388c89b93c87bc53ad8fe2f3157a8ee587) | `` kube-score: 1.16.0 -> 1.16.1 ``                                           |
| [`15013b30`](https://github.com/NixOS/nixpkgs/commit/15013b305466fdd0a52222ed2a3ff87bf9e41af9) | `` darwin.builder: prefer shutting down over halting VM (#208450) ``         |
| [`f6d575cc`](https://github.com/NixOS/nixpkgs/commit/f6d575cc22a2084bef6a2c3327e3e80d37ea2aac) | `` hans: 1.0 -> 1.1 ``                                                       |
| [`501848c7`](https://github.com/NixOS/nixpkgs/commit/501848c755f35480e59f4054ba43bc6bf56415d5) | `` unit: 1.28.0 -> 1.29.0 ``                                                 |
| [`b406baea`](https://github.com/NixOS/nixpkgs/commit/b406baead835cbc5e0bb4e316b89c8ddab2211fa) | `` nixos/paperless-ngx: reorder "after" keyword ``                           |
| [`57b21b39`](https://github.com/NixOS/nixpkgs/commit/57b21b39ea0b893d17aa0411c64a85228b3b4b29) | `` python3Packages.afdko: disable test broken by the new year ``             |
| [`78e43c3d`](https://github.com/NixOS/nixpkgs/commit/78e43c3df1efe30d7d2a5d6479587574ce774bd3) | `` syncthing: 1.22.2 -> 1.23.0 ``                                            |
| [`71df3d7f`](https://github.com/NixOS/nixpkgs/commit/71df3d7fb9a8fe99b06eadcb4d69fbaa08396276) | `` ssh-askpass-fullscreen: 1.2 -> 1.3 ``                                     |