### PR TITLE
chore(flake/pre-commit-hooks): `6bf7e084` -> `a4548c09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -219,11 +219,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1672907393,
-        "narHash": "sha256-g+wTNiVaS/eCHq9HK7tYGqKCAqvgmCmU6mA9WOO8m+Y=",
+        "lastModified": 1672912243,
+        "narHash": "sha256-QnQeKUjco2kO9J4rBqIBPp5XcOMblIMnmyhpjeaJBYc=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "6bf7e0843e22463b94badaef624f4d38a937323f",
+        "rev": "a4548c09eac4afb592ab2614f4a150120b29584c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                             |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
| [`11c6d36a`](https://github.com/cachix/pre-commit-hooks.nix/commit/11c6d36ab00a67ad02c8a9b2e06568c69cc9cedd) | `` Add option to fail when clippy emits warnings `` |