### PR TITLE
chore(flake/nixpkgs): `9813adc7` -> `a518c771`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672791794,
-        "narHash": "sha256-mqGPpGmwap0Wfsf3o2b6qHJW1w2kk/I6cGCGIU+3t6o=",
+        "lastModified": 1672953546,
+        "narHash": "sha256-oz757DnJ1ITvwyTovuwG3l9cX6j9j6/DH9eH+cXFJmc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9813adc7f7c0edd738c6bdd8431439688bb0cb3d",
+        "rev": "a518c77148585023ff56022f09c4b2c418a51ef5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`590e1b4b`](https://github.com/NixOS/nixpkgs/commit/590e1b4b3b26375d6418f9d658b2da3ac8049567) | `` vimPlugins.lsp-zero-nvim: init at 2023-01-05 ``                                             |
| [`eafd1479`](https://github.com/NixOS/nixpkgs/commit/eafd1479e76b33cad59bfaa155f2185149d458d2) | `` vimPlugins.nvim-ts-rainbow2: init at 2023-01-05 ``                                          |
| [`b827a50e`](https://github.com/NixOS/nixpkgs/commit/b827a50e25fe99bdde9a002b0695ad494da585c8) | `` rustic-rs: 0.4.1 -> 0.4.2 ``                                                                |
| [`6260b69b`](https://github.com/NixOS/nixpkgs/commit/6260b69b747a50b29310ad2fce603d5c4873df31) | `` gnomeExtensions: auto-update ``                                                             |
| [`8822e962`](https://github.com/NixOS/nixpkgs/commit/8822e9620cb2da9681613620fa7c61535e3114d6) | `` nixos/iay: use `mkPackageOptionMD` ``                                                       |
| [`fb1cb44b`](https://github.com/NixOS/nixpkgs/commit/fb1cb44b6814629061695ccd8d549bbe70a4d923) | `` thepeg: unbreak on aarch64-darwin (#209017) ``                                              |
| [`d374964c`](https://github.com/NixOS/nixpkgs/commit/d374964cb3d575ced4222b912ca9d03bd45d7e3d) | `` kubelogin-oidc: 1.25.4 -> 1.26.0 (#208309) ``                                               |
| [`5e8b7993`](https://github.com/NixOS/nixpkgs/commit/5e8b7993b9dda4990215d983b6d2cc93ae8766d8) | `` nlojet: unbreak on aarch64-darwin (#209016) ``                                              |
| [`6f74a1bd`](https://github.com/NixOS/nixpkgs/commit/6f74a1bd5925522ec46ac8d4c867867b136696c1) | `` roon-server: 2.0-1169 -> 2.0-1182 ``                                                        |
| [`ad491fec`](https://github.com/NixOS/nixpkgs/commit/ad491fec884b5d335890e0154d8bf464077e0b29) | `` opentabletdriver: remove hardcoded config path ``                                           |
| [`45d27d43`](https://github.com/NixOS/nixpkgs/commit/45d27d43c4dfc0eb6f6b55aa9fbdfb90513271df) | `` nixos/unifi: fix mongodb to a stable version ``                                             |
| [`142ac0ba`](https://github.com/NixOS/nixpkgs/commit/142ac0ba91bfb20873082957568dbd8a547e8aba) | `` php: add `updateScript` ``                                                                  |
| [`3234c203`](https://github.com/NixOS/nixpkgs/commit/3234c2031ec66d44bd414cf600a5d4186ab32c1b) | `` tailscale: 1.34.1 -> 1.34.2 ``                                                              |
| [`c61f554c`](https://github.com/NixOS/nixpkgs/commit/c61f554c1aa9fbec38b73cb7bbb205572673a5ba) | `` modules.gitlab-runner: accept space in names ``                                             |
| [`1ccd0887`](https://github.com/NixOS/nixpkgs/commit/1ccd088796a6757d2f20483e8f970bb39a83d52e) | `` obs-studio-plugins.droidcam-obs: init at 2.0.1 ``                                           |
| [`19a8a0ad`](https://github.com/NixOS/nixpkgs/commit/19a8a0ad21f9168d358abc36dea35c3a10081fd5) | `` go_1_20: 1.20rc1 -> 1.20rc2 ``                                                              |
| [`0118c319`](https://github.com/NixOS/nixpkgs/commit/0118c319c4f5bb51a0fc70418e432e85ab04100a) | `` devspace: 6.2.2 -> 6.2.3 ``                                                                 |
| [`de49ddab`](https://github.com/NixOS/nixpkgs/commit/de49ddabaea028aec44225424c1a3be8279e9162) | `` nixosTests.wordpress: iterate over versions ``                                              |
| [`c26f0014`](https://github.com/NixOS/nixpkgs/commit/c26f00141b4b7e4011a1848640a2ca2c119c8fff) | `` ocamlPackages.inotify: 2.3 → 2.4.1 ``                                                       |
| [`673cd10e`](https://github.com/NixOS/nixpkgs/commit/673cd10e59b098d12c19f3a696a1166acd551c1a) | `` ocamlPackages.ocamlnet: disable for OCaml ≥ 5.0 ``                                          |
| [`b4b8b7b0`](https://github.com/NixOS/nixpkgs/commit/b4b8b7b0d763b481273a3e94f60dbea427d89d25) | `` ocamlPackages.xml-light: disable for OCaml ≥ 5.0 ``                                         |
| [`2270d5b2`](https://github.com/NixOS/nixpkgs/commit/2270d5b2e3da065dde01f5aa4cd5b38a14620dc1) | `` cargo-semver-checks: 0.14.0 -> 0.15.0 ``                                                    |
| [`1e94e914`](https://github.com/NixOS/nixpkgs/commit/1e94e9146fedff1092346e69e3928bbc4a721e44) | `` radicale: Drop self (aneeshusa) from maintainership ``                                      |
| [`7ef0a612`](https://github.com/NixOS/nixpkgs/commit/7ef0a612f2c417078ff1c8e8bdb7ef4aca729626) | `` ruff: 0.0.210 -> 0.0.211 ``                                                                 |
| [`3339892d`](https://github.com/NixOS/nixpkgs/commit/3339892da9b4bb31adf67459f9a3e6ef4f113d57) | `` nixos/plasma5: use mkPackageOptionMD ``                                                     |
| [`431b8704`](https://github.com/NixOS/nixpkgs/commit/431b87041ac7a6809967b7f78fdd8ec28378b6d0) | `` terraform-providers.ibm: 1.48.0 → 1.49.0 ``                                                 |
| [`8c2458b8`](https://github.com/NixOS/nixpkgs/commit/8c2458b87f35eca252ba21cdca81dae99e88af43) | `` terraform-providers.tfe: 0.40.0 → 0.41.0 ``                                                 |
| [`eed0f3a7`](https://github.com/NixOS/nixpkgs/commit/eed0f3a77fc985b9b0bdd032c1f4acc71d0fc042) | `` terraform-providers.cloudfoundry: 0.50.3 → 0.50.4 ``                                        |
| [`56f107cf`](https://github.com/NixOS/nixpkgs/commit/56f107cf7ac99c1291df7ed883f6008d26958261) | `` freerdp: apply suggestions provided by upstream (#208832) ``                                |
| [`5c63f329`](https://github.com/NixOS/nixpkgs/commit/5c63f3299551a41c6643834d192a6213a61f7e1b) | `` python3Packages.pytest-unordered: 0.4.1 -> 0.5.2 ``                                         |
| [`afb7fbe6`](https://github.com/NixOS/nixpkgs/commit/afb7fbe6975d7994c56f1b29f4a535c239cb8583) | `` expliot: Relax zeroconf constraint ``                                                       |
| [`eab16a70`](https://github.com/NixOS/nixpkgs/commit/eab16a708092851b6edcb0b630f16a34ce30950e) | `` home-assistant: 2022.12.9 -> 2023.1.0 ``                                                    |
| [`983ec889`](https://github.com/NixOS/nixpkgs/commit/983ec889b3a83d1ed80173bdb10a35bc3b857c95) | `` pantheon.elementary-wallpapers: 6.1.0 -> 7.0.0 ``                                           |
| [`1d06a932`](https://github.com/NixOS/nixpkgs/commit/1d06a93281dd633846f178c9e120546c621e7465) | `` python3Packages.odp-amsterdam: init at 5.0.0 ``                                             |
| [`4920c825`](https://github.com/NixOS/nixpkgs/commit/4920c82507516619d95c105df497068dedb12572) | `` home-assistant: relax ciso8601, overrride astral ``                                         |
| [`f7344bdd`](https://github.com/NixOS/nixpkgs/commit/f7344bdd9aa16ebf1bf668d7a92e2620a110fc44) | `` python3Packages.zwave-js-server-python: 0.43.1 -> 0.44.0 ``                                 |
| [`85031c93`](https://github.com/NixOS/nixpkgs/commit/85031c93345540355f9ab621afb4d638271737b8) | `` python3Packages.zeroconf: 0.39.4 -> 0.47.1 ``                                               |
| [`1e536008`](https://github.com/NixOS/nixpkgs/commit/1e5360086446b8cd30c423344e53ddb7cb66fd7a) | `` python3Packages.xknx: 2.1.0 -> 2.2.0 ``                                                     |
| [`8003208e`](https://github.com/NixOS/nixpkgs/commit/8003208e5e852e2ae1c4da61fd38d846d950eeac) | `` python3Packages.vallox-websocket-api: 2.12.0 -> 3.0.0 ``                                    |
| [`2fce4aac`](https://github.com/NixOS/nixpkgs/commit/2fce4aacf962ad98415a7cf031c403d200f61eca) | `` python3Packages.pyswitchbot: 0.30.1 -> 0.36.1 ``                                            |
| [`579e3476`](https://github.com/NixOS/nixpkgs/commit/579e34761fbf6b4cab30e51f27912c6cd5e3037d) | `` python310Packages.pyswitchbee: 1.6.2 -> 1.7.3 ``                                            |
| [`7d7fb2d1`](https://github.com/NixOS/nixpkgs/commit/7d7fb2d1ae3e2bd497c70b440f11e67babc7c59a) | `` python310Packages.pynina: 0.1.8 -> 0.2.0 ``                                                 |
| [`3db8d109`](https://github.com/NixOS/nixpkgs/commit/3db8d1093c1b6fe97478916e0c734af160268e60) | `` python3Packages.pyisy: 3.0.9 -> 3.0.10 ``                                                   |
| [`c8f87304`](https://github.com/NixOS/nixpkgs/commit/c8f87304cb7410d591638ad8d71637a5e25df36e) | `` python3Packages.pydeconz: 105 -> 106 ``                                                     |
| [`0c1f9a78`](https://github.com/NixOS/nixpkgs/commit/0c1f9a789dcb451d5bf6b09668b5ae917e0ec14d) | `` python3Packages.govee-ble: 0.19.3 -> 0.21.0 ``                                              |
| [`10140fc7`](https://github.com/NixOS/nixpkgs/commit/10140fc79f5a79d9d4b71b7bdadc5b87a7593191) | `` python3Packages.bthome-ble: 2.3.1 -> 2.4.0 ``                                               |
| [`98c92e79`](https://github.com/NixOS/nixpkgs/commit/98c92e795050e2484f07f91b4387500a95472281) | `` python3Packages.async-upnp-client: 0.32.3 -> 0.33.0 ``                                      |
| [`057b6e8c`](https://github.com/NixOS/nixpkgs/commit/057b6e8c5a93550775e63dc8688220794bf10f75) | `` python310Packages.adguardhome: 0.5.1 -> 0.6.1 ``                                            |
| [`a6a2c086`](https://github.com/NixOS/nixpkgs/commit/a6a2c08632df3800b42b18ff04a0f1be440331bd) | `` python310Packages.adguardhome: add changelog to meta ``                                     |
| [`e912c7bf`](https://github.com/NixOS/nixpkgs/commit/e912c7bfe93426c91d54662b1d98a18a08a50e57) | `` lib/modules: hide _module.args docs ``                                                      |
| [`9da5f12e`](https://github.com/NixOS/nixpkgs/commit/9da5f12ecffa60f7a4712516177ede318b608f0d) | `` modules: add mkPackageOptionMD ``                                                           |
| [`4c1cfbdb`](https://github.com/NixOS/nixpkgs/commit/4c1cfbdb844babe1054c7f365eac337396092d60) | `` modules: add mkAliasOptionModuleMD ``                                                       |
| [`94f852b9`](https://github.com/NixOS/nixpkgs/commit/94f852b9e60fc6bd0e8f28dc408b55f014b02859) | `` ocamlPackages.wodan: remove broken (at 2020-11-20) ``                                       |
| [`ca7101f5`](https://github.com/NixOS/nixpkgs/commit/ca7101f5d423de44eb971f4c424dc4cea0596e3a) | `` josm: 18621 -> 18622 ``                                                                     |
| [`4045943b`](https://github.com/NixOS/nixpkgs/commit/4045943b6411536f9c0484b7cb3772200895e97d) | `` haskellPackages: mark builds failing on hydra as broken ``                                  |
| [`504f2de4`](https://github.com/NixOS/nixpkgs/commit/504f2de46c3484f3ff0f67a7585384105e6688da) | `` nuclei: 2.8.3 -> 2.8.5 ``                                                                   |
| [`2f0f80b7`](https://github.com/NixOS/nixpkgs/commit/2f0f80b7fe025e59a50fb20c08c35e32d25c2364) | `` broot: 1.18.0 -> 1.19.0 ``                                                                  |
| [`8b8f9e9a`](https://github.com/NixOS/nixpkgs/commit/8b8f9e9a8890beffced1d4ce8e65b03a29a1823e) | `` gdu: 5.20.0 -> 5.21.0 ``                                                                    |
| [`a4fb0985`](https://github.com/NixOS/nixpkgs/commit/a4fb09854a11cb9eb6844317dd48238fbc0f0010) | `` python310Packages.aliyun-python-sdk-iot: 8.47.0 -> 8.48.0 ``                                |
| [`ab61130f`](https://github.com/NixOS/nixpkgs/commit/ab61130f75daee8a556bb74861a19751e0255698) | `` python310Packages.aliyun-python-sdk-dbfs: 2.0.3 -> 2.0.4 ``                                 |
| [`b0ac5300`](https://github.com/NixOS/nixpkgs/commit/b0ac5300077ee8ad1486be004d8575b51004f12f) | `` python27: 2.7.18.5 -> 2.7.18.6 ``                                                           |
| [`bc7d5cea`](https://github.com/NixOS/nixpkgs/commit/bc7d5cea0aa5e24c097d301630a105b8938ee9ed) | `` add overrides for vimPlugins.mason-tool-install-nvim and vimPlugins.mason-lspconfig-nvim `` |
| [`8ea667c3`](https://github.com/NixOS/nixpkgs/commit/8ea667c3f1a5a3a82b60ced067353b0d34593502) | `` vimPlugins.mason-tool-installer-nvim: init at 2022-07-26 ``                                 |
| [`e3200298`](https://github.com/NixOS/nixpkgs/commit/e320029847a89320aa7600b57c29c1c8985717bc) | `` apcupsd: add nixosTests.apcupsd to passthru.tests ``                                        |
| [`1b80fc42`](https://github.com/NixOS/nixpkgs/commit/1b80fc420475319a7f518a130a649fb37146e22f) | `` nixos/tests/apcupsd.nix: init ``                                                            |
| [`295c552d`](https://github.com/NixOS/nixpkgs/commit/295c552dc92ac63ff9d0a979f723c8dfa058fb5f) | `` nixos/apcupsd: wrap CLI with "-f ${configFile}" ``                                          |
| [`f7e12765`](https://github.com/NixOS/nixpkgs/commit/f7e12765607f7756835ab5be59be62d5124eaab0) | `` pinta: 2.0.2 -> 2.1 ``                                                                      |
| [`9e2070e1`](https://github.com/NixOS/nixpkgs/commit/9e2070e1e59972e43990a992b7d31622ce9684a0) | `` chromiumBeta: 109.0.5414.61 -> 109.0.5414.74 ``                                             |
| [`39e73874`](https://github.com/NixOS/nixpkgs/commit/39e738746b9b13b61dcc7237f524efad63ee075e) | `` terraform: 1.3.6 -> 1.3.7 ``                                                                |
| [`72a4c545`](https://github.com/NixOS/nixpkgs/commit/72a4c545f098e96647ed5e9ebba771d7e27e10e9) | `` tup: avoid vendoring sqlite3 ``                                                             |
| [`26c2e0b4`](https://github.com/NixOS/nixpkgs/commit/26c2e0b4f1604cdbbd7d256c27952c0a14162a38) | `` sigi: 3.5.0 -> 3.6.0 ``                                                                     |
| [`2f2e7f88`](https://github.com/NixOS/nixpkgs/commit/2f2e7f8842770c3bf82fb285c14e82a2642f0337) | `` vimPlugins.mason-nvim: init at 2022-07-27 ``                                                |
| [`040bf815`](https://github.com/NixOS/nixpkgs/commit/040bf815ef15ed5a7a5b34ee2d8a05a624ccb05a) | `` seaweedfs: 3.34 -> 3.38 ``                                                                  |
| [`120269fe`](https://github.com/NixOS/nixpkgs/commit/120269fe5c10e95d590cf97d62561228f049f0dd) | `` pkgsStatic.tup: fix build ``                                                                |
| [`5464e0a0`](https://github.com/NixOS/nixpkgs/commit/5464e0a0182603b13d9d8779bffb417e01b1273f) | `` nixos/misc: add VARIANT_ID in /etc/os-release for identifying nixos installer ``            |
| [`733bc1fb`](https://github.com/NixOS/nixpkgs/commit/733bc1fb0a6868c8b0b2c0231e1ec6bef6671882) | `` haskell.packages.ghc944.blaze-textual: Remove obsolete override ``                          |
| [`60ad4239`](https://github.com/NixOS/nixpkgs/commit/60ad423963e839838c72cd7a299eed0bf1ca00ff) | `` mpdecimal: init at 2.5.1 ``                                                                 |
| [`83e22ed4`](https://github.com/NixOS/nixpkgs/commit/83e22ed4a8ac6af3ce7a1f16284dc3c4f396a9b5) | `` licensee: 9.15.3 -> 9.16.0 ``                                                               |
| [`cbaf3173`](https://github.com/NixOS/nixpkgs/commit/cbaf3173f126857c590450c87c0ece3e53d0dc3c) | `` nfdump: add changelog to meta ``                                                            |
| [`394d2ac3`](https://github.com/NixOS/nixpkgs/commit/394d2ac3924c7a808d50b6f7ffe0c39200b43d07) | `` python310Packages.ghrepo-stats: 0.4.0 -> 0.5.0 ``                                           |
| [`986a0c57`](https://github.com/NixOS/nixpkgs/commit/986a0c57bf0a13e351b8aee7462ede78ecbe9aea) | `` routinator: 0.12.0 -> 0.12.1 ``                                                             |
| [`2af7e9a3`](https://github.com/NixOS/nixpkgs/commit/2af7e9a30b92d38c8c7ecd487bdd7e041cbd918a) | `` linux_testing: 6.1-rc8 -> 6.2-rc2 ``                                                        |
| [`05912cd5`](https://github.com/NixOS/nixpkgs/commit/05912cd5a4c7447aa130fe7fa04b93469d23538f) | `` linux/hardened/patches/6.0: 6.0.15-hardened1 -> 6.0.16-hardened1 ``                         |
| [`fab20a5d`](https://github.com/NixOS/nixpkgs/commit/fab20a5d508e13df8aa8f2ef595d8c00f2d4c22b) | `` linux/hardened/patches/5.15: 5.15.85-hardened1 -> 5.15.86-hardened1 ``                      |
| [`a5432552`](https://github.com/NixOS/nixpkgs/commit/a54325524c7b7edf4d4464f4bc31513b7f30ec96) | `` linux: 6.1.2 -> 6.1.3 ``                                                                    |
| [`4f65c169`](https://github.com/NixOS/nixpkgs/commit/4f65c169c126b48c17c55174675c4c2e688d47c5) | `` linux: 6.0.16 -> 6.0.17 ``                                                                  |
| [`0679b212`](https://github.com/NixOS/nixpkgs/commit/0679b21257279dcc7eeefaf2dd50a3906819ff5b) | `` linux: 5.10.161 -> 5.10.162 ``                                                              |
| [`7818f94c`](https://github.com/NixOS/nixpkgs/commit/7818f94c3137af43c36983de92bd80115415df91) | `` ruff: 0.0.209 -> 0.0.210 ``                                                                 |
| [`92e9905a`](https://github.com/NixOS/nixpkgs/commit/92e9905a79bd87c9819d21ba56a6f9e8706e3e22) | `` maestro: 1.18.2 -> 1.18.3 ``                                                                |
| [`56af04d0`](https://github.com/NixOS/nixpkgs/commit/56af04d0699d15f1bf13f5ede40ec4620b28c7e0) | `` todoist: 0.17.0 -> 0.18.0 ``                                                                |
| [`da5b6312`](https://github.com/NixOS/nixpkgs/commit/da5b6312bf1fc5984e765aafe43a484119094a44) | `` maintainer-list: add farcaller as a maintainer ``                                           |
| [`a26efdfa`](https://github.com/NixOS/nixpkgs/commit/a26efdfa2f563d473f7453cc843fd671b18f3d83) | `` python310Packages.meross-iot: 0.4.5.3 -> 0.4.5.4 ``                                         |
| [`56456688`](https://github.com/NixOS/nixpkgs/commit/564566885ccf2acaaba6d592f780a91dbf7ba9a3) | `` python310Packages.meross-iot: 0.4.5.2 -> 0.4.5.3 ``                                         |
| [`d9e1cee0`](https://github.com/NixOS/nixpkgs/commit/d9e1cee0e939caabf5c95b2e27defec5447a12a9) | `` python310Packages.pypck: 0.7.15 -> 0.7.16 ``                                                |
| [`5a1ffcef`](https://github.com/NixOS/nixpkgs/commit/5a1ffcef5af0af8eccc10ebd6cc3c02ad528cd64) | `` release-cross.nix: fix error: undefined variable 'platforms' ``                             |
| [`13433d2f`](https://github.com/NixOS/nixpkgs/commit/13433d2f4dd9fd4dd162036d1412417c40ab148c) | `` python310Packages.pypck: add changelog to meta ``                                           |
| [`e79e069e`](https://github.com/NixOS/nixpkgs/commit/e79e069e1579cb76da7a812d45edcefed25e48f2) | `` python310Packages.python-fsutil: 0.8.0 -> 0.9.1 ``                                          |
| [`1a9d89fe`](https://github.com/NixOS/nixpkgs/commit/1a9d89fe38c58abe77bebbb114a39aaf16277b2b) | `` yubioath-flutter: fix QR scanning ``                                                        |
| [`6c3cc735`](https://github.com/NixOS/nixpkgs/commit/6c3cc7358e217246419a9bdb7a2334c4b6462581) | `` python310Packages.socialscan: 1.4.2 -> 2.0.0 ``                                             |
| [`83ac7724`](https://github.com/NixOS/nixpkgs/commit/83ac77245983706ad845f86f5efa3b9475de59f3) | `` python310Packages.socialscan: add changelog to meta ``                                      |
| [`28afc5f3`](https://github.com/NixOS/nixpkgs/commit/28afc5f35a59b9bfb73ed958e4e306b731b14e49) | `` python310Packages.skodaconnect: 1.2.5 -> 1.3.0 ``                                           |
| [`10c8aeeb`](https://github.com/NixOS/nixpkgs/commit/10c8aeeb4e08fbb3e71935a03488fdc49cdedfe9) | `` python310Packages.roonapi: 0.1.2 -> 0.1.3 ``                                                |
| [`db03610a`](https://github.com/NixOS/nixpkgs/commit/db03610a3e6702b6eb676320d32bd26281e82b1b) | `` python310Packages.python-ipmi: 0.5.2 -> 0.5.3 ``                                            |
| [`e480c997`](https://github.com/NixOS/nixpkgs/commit/e480c997dfee196bee2ca1fe94d5a86c9fdfb7da) | `` maintainers: add _3JlOy-PYCCKUi ``                                                          |
| [`fc50f868`](https://github.com/NixOS/nixpkgs/commit/fc50f868a00d95acbba04077115df569130ca458) | `` wireproxy: init at 1.0.5 ``                                                                 |
| [`7deab23a`](https://github.com/NixOS/nixpkgs/commit/7deab23a756905fcbcc6fb13e7a27b0c0f3acdbf) | `` rmapi: 0.0.23 -> 0.0.25 (#208737) ``                                                        |
| [`0319a561`](https://github.com/NixOS/nixpkgs/commit/0319a561eca36eb99379fc000fad82f8ee71f74f) | `` pkgsMusl.gccgo: fix build ``                                                                |
| [`4f463dec`](https://github.com/NixOS/nixpkgs/commit/4f463decc80e674686800959fcdb34af49ff6083) | `` libucontext: init at 1.2 ``                                                                 |
| [`f9d1f800`](https://github.com/NixOS/nixpkgs/commit/f9d1f80045d3ae01741896127837eba9f1559603) | `` wordpress6_1: init at 6.1.1 ``                                                              |
| [`2ad09632`](https://github.com/NixOS/nixpkgs/commit/2ad09632e7b1f70fddcfaed06426b7b6f43e592f) | `` sbcl: 2.2.11 -> 2.3.0 ``                                                                    |
| [`05f6dd4d`](https://github.com/NixOS/nixpkgs/commit/05f6dd4dc685ed874c20195792907ecf71d5ef00) | `` nixos/mailman: fix hyperkitty css/js when virtualRoot is `/` ``                             |
| [`5df41c21`](https://github.com/NixOS/nixpkgs/commit/5df41c21f3840f71a212e41df952d002599f7313) | `` haruna: 0.9.3 -> 0.10.0 ``                                                                  |
| [`04b8fc70`](https://github.com/NixOS/nixpkgs/commit/04b8fc708819af8e324460a0bf9758804f0f8af3) | `` libreddit: 0.25.1 -> 0.27.0 ``                                                              |
| [`81af5f82`](https://github.com/NixOS/nixpkgs/commit/81af5f82eb56ea51dbc31106d023600377611c14) | `` etebase-server: add changelog to meta ``                                                    |
| [`b6e1ee2c`](https://github.com/NixOS/nixpkgs/commit/b6e1ee2c3343a419a0fb0f09146fba3ce21891e1) | `` liboil: unbreak on aarch64-darwin ``                                                        |
| [`e87b2421`](https://github.com/NixOS/nixpkgs/commit/e87b24218b2b395ec09e68085da970a9f4a857f5) | `` terraform-providers.github: 5.12.0 → 5.13.0 ``                                              |
| [`d0783970`](https://github.com/NixOS/nixpkgs/commit/d0783970df75d231f2f46a67d1ad180e40e45307) | `` terraform-providers.baiducloud: 1.19.1 → 1.19.2 ``                                          |
| [`b2266ed0`](https://github.com/NixOS/nixpkgs/commit/b2266ed09bad9c8688615be3f580b991629f7400) | `` wordpressPackages.plugins.civicrm: init at 5.56.0 ``                                        |
| [`d0cbd321`](https://github.com/NixOS/nixpkgs/commit/d0cbd3214ab719a73e8a80edc59f4bba5f046456) | `` passExtensions.pass-checkup: 0.2.1 -> 0.2.2 ``                                              |
| [`113b3cb3`](https://github.com/NixOS/nixpkgs/commit/113b3cb395d711ba746b15afe0907842dd7e5dd9) | `` imlib: drop ``                                                                              |
| [`8cf8dc23`](https://github.com/NixOS/nixpkgs/commit/8cf8dc233a3edeef8e33748cd9926bc0f5e4785b) | `` sawfish: drop unused imlib ``                                                               |
| [`e245f991`](https://github.com/NixOS/nixpkgs/commit/e245f99133da5a24260a3ca90722bdffa493726b) | `` fvwm: drop unused imlib ``                                                                  |
| [`81ba6e99`](https://github.com/NixOS/nixpkgs/commit/81ba6e9905a9a7aae003f0f06b44fb63b0a2bcba) | `` wordpressPackages.plugins.wp-statistics: 13.2.10 -> 13.2.11 ``                              |
| [`cd5a85fb`](https://github.com/NixOS/nixpkgs/commit/cd5a85fbe8fbbd693eff59eee98d17792fbe9a98) | `` wordpressPackages.plugins.mailpoet: 4.3.0 -> 4.3.1 ``                                       |
| [`9e8e0ef3`](https://github.com/NixOS/nixpkgs/commit/9e8e0ef31a98958821ba22d52c0401c588c1e7c5) | `` wordpressPackages.plugins.wpforms-lite: init at 1.7.8 ``                                    |
| [`aa371581`](https://github.com/NixOS/nixpkgs/commit/aa371581dd110352b217e214867dd2a83660fa3c) | `` ocamlPackages.fileutils: 0.6.3 → 0.6.4 ``                                                   |
| [`3fdc7bc9`](https://github.com/NixOS/nixpkgs/commit/3fdc7bc916ebc6b08c6855314bc8e1ebef37f26f) | `` mitmproxy2swagger: 0.7.1 -> 0.7.2 ``                                                        |
| [`de21dd1c`](https://github.com/NixOS/nixpkgs/commit/de21dd1cd0f494813490849c91b7ab18b5c6fde2) | `` trufflehog: add changelog to meta ``                                                        |
| [`0f1e6565`](https://github.com/NixOS/nixpkgs/commit/0f1e65656d43369ec2f477f33122f4039c2d9922) | `` gcsfuse: add changelog to meta ``                                                           |
| [`1586fdfd`](https://github.com/NixOS/nixpkgs/commit/1586fdfda1baa96032fa8f958615dd8d538c5ca4) | `` python310Packages.ansible-lint: add changelog to meta ``                                    |
| [`d73083e0`](https://github.com/NixOS/nixpkgs/commit/d73083e05966ba8da1efea752a5272d2794a072f) | `` python310Packages.tubeup: add changelog to meta ``                                          |
| [`6d89aa8f`](https://github.com/NixOS/nixpkgs/commit/6d89aa8f1d238cc5ed97215f7e229b8283bef027) | `` darwin.builder: auto-login as the `builder` user (#208772) ``                               |
| [`469aec90`](https://github.com/NixOS/nixpkgs/commit/469aec905bab3be98838c7eb996ceffb2ea44404) | `` nixos/podman, podman: switch to `netavark` network stack ``                                 |
| [`17c7ccb1`](https://github.com/NixOS/nixpkgs/commit/17c7ccb1abc2972a749faa841d7d04fa7f64f14c) | `` netavark: add podman to passthru.tests ``                                                   |