### PR TITLE
chore(flake/pre-commit-hooks): `a4548c09` -> `f3b40283`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -219,11 +219,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1672912243,
-        "narHash": "sha256-QnQeKUjco2kO9J4rBqIBPp5XcOMblIMnmyhpjeaJBYc=",
+        "lastModified": 1673240110,
+        "narHash": "sha256-Em7Eg/qv1QBx1XpIldJz9E9aQohSBtwwxffYS02FPdQ=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "a4548c09eac4afb592ab2614f4a150120b29584c",
+        "rev": "f3b402838c49b0989c07494f6f5db77dfce0ce97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                              |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------ |
| [`4924de75`](https://github.com/cachix/pre-commit-hooks.nix/commit/4924de75039937f316146a7e66df74080498b544) | `` refact: add mkCmdArgs function `` |
| [`6671dda1`](https://github.com/cachix/pre-commit-hooks.nix/commit/6671dda1325fc5df06a4bdc61cf5b2430a5e8827) | `` feat: add new golang hooks ``     |