### PR TITLE
chore(flake/nixpkgs): `a518c771` -> `f6f44561`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672953546,
-        "narHash": "sha256-oz757DnJ1ITvwyTovuwG3l9cX6j9j6/DH9eH+cXFJmc=",
+        "lastModified": 1673134516,
+        "narHash": "sha256-mAZQKqkNQbBmJnmUU0blOfkKlgMSSVyPHdeWeuKad8U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a518c77148585023ff56022f09c4b2c418a51ef5",
+        "rev": "f6f44561884c3470e2b783683d5dbac42dfc833b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`b3091f77`](https://github.com/NixOS/nixpkgs/commit/b3091f774ee9406053e73f9791265a216642ba8c) | `` pax: fix build with musl (#193195) ``                                   |
| [`5b58dc8d`](https://github.com/NixOS/nixpkgs/commit/5b58dc8d9b1892d71f18e39e06d4626861786a9c) | `` python310Packages.lightwave: 0.20 -> 0.21 ``                            |
| [`c70d40aa`](https://github.com/NixOS/nixpkgs/commit/c70d40aa02b95cc8cb24d35ac7c07b13ef703037) | `` python310Packages.aiosmtplib: 2.0.0 -> 2.0.1 ``                         |
| [`656e8b13`](https://github.com/NixOS/nixpkgs/commit/656e8b1388235b39524da6b9c2e569d627c10ffa) | `` python310Packages.oralb-ble: 0.14.3 -> 0.15.0 ``                        |
| [`d49f5d69`](https://github.com/NixOS/nixpkgs/commit/d49f5d692b0bb7e0146c50737d1878df2a1b0cf5) | `` python310Packages.pyezviz: 0.2.0.11 -> 0.2.0.12 ``                      |
| [`347ecbc8`](https://github.com/NixOS/nixpkgs/commit/347ecbc8b7e92790897eed618732c1542f6d5de2) | `` qovery-cli: 0.48.2 -> 0.48.3 ``                                         |
| [`b84d36a0`](https://github.com/NixOS/nixpkgs/commit/b84d36a09aabd62af4d272e6c212039495498cd2) | `` gdu: 5.21.0 -> 5.21.1 ``                                                |
| [`52123952`](https://github.com/NixOS/nixpkgs/commit/521239525fe86ca8ddb77352370e21823ce1885f) | `` gdu: add changelog to meta ``                                           |
| [`eabbe8b9`](https://github.com/NixOS/nixpkgs/commit/eabbe8b96f6db963a23943bda2b653122d96a0eb) | `` bpfmon: add changelog to meta ``                                        |
| [`d9fbb33f`](https://github.com/NixOS/nixpkgs/commit/d9fbb33f9296d7ee11ac40be190f0d739b3f1f58) | `` python27: mark as vulnerable/insecure due to EOL on 2020-01-01 ``       |
| [`d709fd7e`](https://github.com/NixOS/nixpkgs/commit/d709fd7e4e9411869413053bd178682935528b79) | `` sftpgo: add changelog to meta ``                                        |
| [`d9f0b554`](https://github.com/NixOS/nixpkgs/commit/d9f0b554cdb7a60d4751f76419c50139fb46835d) | `` btdu: add changelog to meta ``                                          |
| [`01dfccde`](https://github.com/NixOS/nixpkgs/commit/01dfccdeac701b0ddd891509b24e5024bd160c50) | `` jackline: 2021-12-28 → 2022-05-27 ``                                    |
| [`2f9b6bef`](https://github.com/NixOS/nixpkgs/commit/2f9b6bef94f6834438b18d8158be8b439b8aeaa1) | `` robin-map: add changelog to meta ``                                     |
| [`2eb019b7`](https://github.com/NixOS/nixpkgs/commit/2eb019b74fcb13baf86253b83d3512708d209023) | `` twitch-tui: add changelog to meta ``                                    |
| [`faa57a8d`](https://github.com/NixOS/nixpkgs/commit/faa57a8d0d4f5bf6752ba5c69ebcb8d19699f443) | `` cargo-release: add changelog to meta ``                                 |
| [`389fce69`](https://github.com/NixOS/nixpkgs/commit/389fce69cb611ff3064e11ca7766fde1efee17da) | `` gobgpd: update rev ``                                                   |
| [`8fc3a165`](https://github.com/NixOS/nixpkgs/commit/8fc3a165ee7a741eafc75d2547e2984b285dfd15) | `` bacon: add changelog to meta ``                                         |
| [`4bfbe830`](https://github.com/NixOS/nixpkgs/commit/4bfbe8301aafe194442fadb8246f4078b367cc17) | `` datree: add changelog to meta ``                                        |
| [`aa0c474f`](https://github.com/NixOS/nixpkgs/commit/aa0c474f4bf0d177ca79b05655bc0484c8a3c463) | `` pypy{27,38,39}: mark as broken in aarch64-darwin ``                     |
| [`997a09e6`](https://github.com/NixOS/nixpkgs/commit/997a09e6124f7a8a61f0dd138d64ecc9c15beff4) | `` pypy39: fix build in darwin ``                                          |
| [`4645ec9d`](https://github.com/NixOS/nixpkgs/commit/4645ec9de69d63200588c4a11cc399edcac33730) | `` pypy{27,38,39}: remove i686-linux, add aarch64-darwin ``                |
| [`40db51d5`](https://github.com/NixOS/nixpkgs/commit/40db51d5631c28bf8ea7dc44505333b848e860d2) | `` pythonInterpreters.pypy27_prebuilt: add support to darwin ``            |
| [`3d440c1c`](https://github.com/NixOS/nixpkgs/commit/3d440c1c1eaae24cf6de05ac9a14569708817adc) | `` pythonInterpreters.pypy39_prebuilt: use autoPatchelfHook ``             |
| [`c89380b0`](https://github.com/NixOS/nixpkgs/commit/c89380b0c4ca9db893995669e012a63b587f9263) | `` pythonInterpreters.pypy27_prebuilt: use autoPatchelfHook ``             |
| [`a49d01ce`](https://github.com/NixOS/nixpkgs/commit/a49d01ce3f77ba8eb1eebfaf677e2645466b7925) | `` pythonInterpreters.pypy27_prebuilt: add support for aarch64-linux ``    |
| [`be456598`](https://github.com/NixOS/nixpkgs/commit/be456598db9e4ce72684686683210f11da232efb) | `` pypy38: 7.3.9 -> 7.3.11 ``                                              |
| [`797e62d5`](https://github.com/NixOS/nixpkgs/commit/797e62d5038171e8a75a918a058ab11339b44fde) | `` pypy39: 7.3.9 -> 7.3.11 ``                                              |
| [`284d9a10`](https://github.com/NixOS/nixpkgs/commit/284d9a1067bc0714017659d294bcf260421e4ef7) | `` pypy27: 7.3.9 -> 7.3.11 ``                                              |
| [`6339c297`](https://github.com/NixOS/nixpkgs/commit/6339c29710b71c2f575d1a4e67385b3b1ca02734) | `` pypy37: remove ``                                                       |
| [`5dbf9ca2`](https://github.com/NixOS/nixpkgs/commit/5dbf9ca20c482c4d2ef63c680516a0a90e00c202) | `` pythonInterpreters.pypy39_prebuilt: 7.3.9 -> 7.3.11 ``                  |
| [`52558844`](https://github.com/NixOS/nixpkgs/commit/525588440a47d6f779135b45aede07fe3f2b130b) | `` pythonInterpreters.pypy27_prebuilt: 7.3.9 -> 7.3.11 ``                  |
| [`9f1b2b8e`](https://github.com/NixOS/nixpkgs/commit/9f1b2b8e2a7cad0487331021034dca65bb78fb30) | `` mdcat: 0.30.3 -> 1.0.0 ``                                               |
| [`d2c57d44`](https://github.com/NixOS/nixpkgs/commit/d2c57d447f12ab7d3f851343fa737dacdfa5188b) | `` the-legend-of-edgar: 1.35 -> 1.36 ``                                    |
| [`e636d6b8`](https://github.com/NixOS/nixpkgs/commit/e636d6b835db9ec8c6d8aa079879a8371ffe9b33) | `` vimPlugins.bat-vim: init at 2022-11-14 ``                               |
| [`fea406ef`](https://github.com/NixOS/nixpkgs/commit/fea406ef2f1562b23e290f6c2d469ad099f0ec8a) | `` vimPlugins: resolve github repository redirects ``                      |
| [`c37b518a`](https://github.com/NixOS/nixpkgs/commit/c37b518a6059ea558714d595fc633457aee9d01d) | `` vimPlugins: update ``                                                   |
| [`690eb0d4`](https://github.com/NixOS/nixpkgs/commit/690eb0d43e51ec138454c2d6b689d7b697a3399f) | `` libreoffice-bin: 7.3.3 -> 7.4.3 ``                                      |
| [`6523f373`](https://github.com/NixOS/nixpkgs/commit/6523f3738cfed06116c6d4e9ce36d4274a4748e7) | `` python310Packages.sense-energy: 0.11.0 -> 0.11.1 ``                     |
| [`013b1f79`](https://github.com/NixOS/nixpkgs/commit/013b1f79bfdc2b8610fd4aa9bcd6e0b4b6d0f92b) | `` gobgpd: 3.9.0 -> 3.10.0 ``                                              |
| [`2dfa3896`](https://github.com/NixOS/nixpkgs/commit/2dfa3896175ae10560eab86b9566675e8eeb14a2) | `` bacon: 2.2.8 -> 2.3.0 ``                                                |
| [`2d59a949`](https://github.com/NixOS/nixpkgs/commit/2d59a949831f1f66ebe5afa08e5d083dec68825d) | `` datree: 1.8.8 -> 1.8.12 ``                                              |
| [`e913d17a`](https://github.com/NixOS/nixpkgs/commit/e913d17a4ba1849704846ee9af87794a31abc93c) | `` cargo-release: 0.24.1 -> 0.24.3 ``                                      |
| [`d526cb1b`](https://github.com/NixOS/nixpkgs/commit/d526cb1b5e3e23740175e0d446b5fa02464dc2be) | `` twitch-tui: 1.6.0 -> 2.0.2 ``                                           |
| [`f85087fd`](https://github.com/NixOS/nixpkgs/commit/f85087fdcbffb16e013a8a7b47033dedfa3ab44d) | `` robin-map: 1.0.1 -> 1.2.1 ``                                            |
| [`89a4f211`](https://github.com/NixOS/nixpkgs/commit/89a4f211aea4b3270da19579492b0fc52471fc89) | `` python310Packages.sqlmap: 1.6.12 -> 1.7 ``                              |
| [`490f2750`](https://github.com/NixOS/nixpkgs/commit/490f2750f99b69e929b738dc5d914c7fc60eb96d) | `` btdu: 0.4.1 -> 0.5.0 ``                                                 |
| [`f08d1cb7`](https://github.com/NixOS/nixpkgs/commit/f08d1cb7e97ac5a1565c45dcf917da1433d9d900) | `` python310Packages.google-cloud-bigquery-storage: 2.16.2 -> 2.17.0 ``    |
| [`755864ab`](https://github.com/NixOS/nixpkgs/commit/755864aba04941be5b0c6ae47b4c09615502d2d7) | `` graalvm*-ce: add meta.mainProgram ``                                    |
| [`3085ef40`](https://github.com/NixOS/nixpkgs/commit/3085ef40d99390a0f391b57ff7429a5492ffdbb9) | `` graalvm*-ce: add meta.sourceProvenance ``                               |
| [`0e94cfb6`](https://github.com/NixOS/nixpkgs/commit/0e94cfb6930cc17e112ade81a965b31cf79ce3a2) | `` leiningen: 2.9.10 -> 2.10.0 ``                                          |
| [`980a070e`](https://github.com/NixOS/nixpkgs/commit/980a070e8db75a0c173fd369add46642562ccfb8) | `` leiningen: remove thiagokokada from maintainers ``                      |
| [`8f8d93f7`](https://github.com/NixOS/nixpkgs/commit/8f8d93f75315a84bdd9580afc276492d863a0dfb) | `` sftpgo: 2.4.0 -> 2.4.2 ``                                               |
| [`ecc06edd`](https://github.com/NixOS/nixpkgs/commit/ecc06edd9801b147837374cf9ebc2ca28904e6f0) | `` mame: 0.250 -> 0.251 ``                                                 |
| [`7b13deb5`](https://github.com/NixOS/nixpkgs/commit/7b13deb5c183ea3d5d7e3c72a237aa9fb5b02350) | `` sc68: unstable-2021-08-23 -> unstable-2022-11-24 ``                     |
| [`f6ab472c`](https://github.com/NixOS/nixpkgs/commit/f6ab472c7d48438aeea38122fd6f7b6fc8b2ccd9) | `` pamixer: 1.5 -> 1.6 ``                                                  |
| [`dced285c`](https://github.com/NixOS/nixpkgs/commit/dced285cf696d9887bf6952f58d4a89843e9aaa3) | `` mcomix: 2.0.2 -> 2.1.0 ``                                               |
| [`e0487171`](https://github.com/NixOS/nixpkgs/commit/e0487171e34611501a9c73e0f8f3e612877b9c49) | `` sconsPackages.scons_3_1_2: default to python3 ``                        |
| [`fd2805dc`](https://github.com/NixOS/nixpkgs/commit/fd2805dcbd787499ae1161c7a757fc0c66ad55c0) | `` sconsPackages.scons_3_0_1: drop ``                                      |
| [`9fb83711`](https://github.com/NixOS/nixpkgs/commit/9fb83711c2c5c11a1e8a895ab98a268ee68a40ea) | `` ocamlPackages.brr: init at 0.0.4 ``                                     |
| [`54d363b0`](https://github.com/NixOS/nixpkgs/commit/54d363b012e32c0918b2af05fb7673ff08c7e781) | `` ocamlPackages.js_of_ocaml-toplevel: init at 4.1.0 ``                    |
| [`d1934479`](https://github.com/NixOS/nixpkgs/commit/d1934479baf0f74db3f2126d11fd8183862c116c) | `` ocamlPackages.note: init at 0.0.2 ``                                    |
| [`f29b1646`](https://github.com/NixOS/nixpkgs/commit/f29b1646daeffbe9ace129a178445d4f7f8b782e) | `` numix-icon-theme-circle: 22.11.26 -> 23.01.02 ``                        |
| [`ac7445e7`](https://github.com/NixOS/nixpkgs/commit/ac7445e754463cfcf3942c537dc31425bf9b26b6) | `` rmview: 3.1.1 -> 3.1.2 (#209463) ``                                     |
| [`411a708a`](https://github.com/NixOS/nixpkgs/commit/411a708ac5e92a9d2525516ba3e75bf75f73fcef) | `` python310Packages.asyauth: 0.0.9 -> 0.0.10 ``                           |
| [`2fc85042`](https://github.com/NixOS/nixpkgs/commit/2fc85042238006704f6203c14814ca9da1f49b64) | `` nixos/etebase-server: Leverage $PATH ``                                 |
| [`4372f03a`](https://github.com/NixOS/nixpkgs/commit/4372f03a9dbd8c64342ac6c0c5a7426062649f6a) | `` bpfmon: 2.50 -> 2.51 ``                                                 |
| [`057cd925`](https://github.com/NixOS/nixpkgs/commit/057cd925c81f9b025f638fdbe82488671716f7bc) | `` python310Packages.aliyun-python-sdk-dbfs: 2.0.4 -> 2.0.5 ``             |
| [`2638c1f4`](https://github.com/NixOS/nixpkgs/commit/2638c1f4c16157ba8f1a22ff74945e070b210cea) | `` butane: 0.16.0 -> 0.17.0 ``                                             |
| [`e273a92e`](https://github.com/NixOS/nixpkgs/commit/e273a92e474ea7fc82cce686d4790ceafcb85e41) | `` python310Packages.aiortm: 0.5.0 -> 0.6.0 ``                             |
| [`94a7d3f9`](https://github.com/NixOS/nixpkgs/commit/94a7d3f930d52ae09cf5399b9eb03986650b8dd2) | `` python310Packages.aiortm: 0.4.0 -> 0.5.0 ``                             |
| [`d1b5f56a`](https://github.com/NixOS/nixpkgs/commit/d1b5f56a79d0166844a323cca4ee32e67f82fcdd) | `` python310Packages.aioesphomeapi: 13.0.2 -> 13.0.3 ``                    |
| [`2fd1b407`](https://github.com/NixOS/nixpkgs/commit/2fd1b407d104fd03c1359d4be465d04dedc42e59) | `` python310Packages.cyclonedx-python-lib: 3.1.1 -> 3.1.2 ``               |
| [`92db726a`](https://github.com/NixOS/nixpkgs/commit/92db726a3eaf5ee58118b2f328839796dc8249d0) | `` sarasa-gothic: 0.37.4 -> 0.38.0 ``                                      |
| [`0cdebad8`](https://github.com/NixOS/nixpkgs/commit/0cdebad845742d119a63b26d7469788244a3adb8) | `` python310Packages.django_treebeard: enable tests ``                     |
| [`cd08c518`](https://github.com/NixOS/nixpkgs/commit/cd08c5186af2837cae1301fe0e2d21c32afebd1c) | `` glooctl: 1.12.37 -> 1.13.1 ``                                           |
| [`da03a99d`](https://github.com/NixOS/nixpkgs/commit/da03a99da5977f50a8505f2aa0ddf72569911c98) | `` python310Packages.django_treebeard: add changelog to meta ``            |
| [`61766793`](https://github.com/NixOS/nixpkgs/commit/61766793f1a2d7ff20d66aeeb93ffba001b4739e) | `` python310Packages.google-cloud-dlp: 3.10.0 -> 3.10.1 ``                 |
| [`ab7b7d45`](https://github.com/NixOS/nixpkgs/commit/ab7b7d4514707df346c44277285efa2324fa1faa) | `` python310Packages.pyduke-energy: fix lint issue ``                      |
| [`1d16ee35`](https://github.com/NixOS/nixpkgs/commit/1d16ee353fdcab2b52508412c757ed944ba2c270) | `` python310Packages.pyduke-energy: add changelog to meta ``               |
| [`ef5d3e33`](https://github.com/NixOS/nixpkgs/commit/ef5d3e33dc5d57b5bcebc0e85431b91253ebfa61) | `` kde/gear: 22.12.0 -> 22.12.1 ``                                         |
| [`3b898e72`](https://github.com/NixOS/nixpkgs/commit/3b898e7270dfd75c434d85f713e533ebebd8330a) | `` python310Packages.sqlalchemy-continuum: normalize pname ``              |
| [`65ea5279`](https://github.com/NixOS/nixpkgs/commit/65ea52793a8f0afde364f64f321a0e343229cb11) | `` python310Packages.sqlalchemy-continuum: add changelog ``                |
| [`61d3c76d`](https://github.com/NixOS/nixpkgs/commit/61d3c76d583394c254830f4c2eac762820ba9fa2) | `` python310Packages.google-cloud-bigquery-datatransfer: 3.8.0 -> 3.9.0 `` |
| [`b4e082b2`](https://github.com/NixOS/nixpkgs/commit/b4e082b2e7db3a3a82a14c54904641e0e2439ed5) | `` python310Packages.sqlalchemy-continuum: 1.3.13 -> 1.3.14 ``             |
| [`12ebab84`](https://github.com/NixOS/nixpkgs/commit/12ebab84bd69c7e86adaa8e684cc6da3e4b642c4) | `` python310Packages.aws-lambda-builders: 1.23.1 -> 1.24.0 ``              |
| [`77d8ad02`](https://github.com/NixOS/nixpkgs/commit/77d8ad0273e5a0a21e0a36e7f2b6a45b8d088cad) | `` tcsh: 6.24.06 -> 6.24.07 ``                                             |
| [`b27befbb`](https://github.com/NixOS/nixpkgs/commit/b27befbb8c4b0afa7cf44c57cf748ef39d112d23) | `` plasma: 5.26.4 -> 5.26.5 ``                                             |
| [`259f9d75`](https://github.com/NixOS/nixpkgs/commit/259f9d759581f9467c59992c527b3fb9d53b682d) | `` python310Packages.ansible-lint: 6.10.1 -> 6.10.2 ``                     |
| [`95b6bbf1`](https://github.com/NixOS/nixpkgs/commit/95b6bbf1924bb4e9b4471ba9c38640fe08ff9000) | `` flexget: 3.5.16 -> 3.5.17 ``                                            |
| [`06e2cce2`](https://github.com/NixOS/nixpkgs/commit/06e2cce29afa803e1fdbe2a34692fe2dc5df8401) | `` python310Packages.cloudscraper: 1.2.66 -> 1.2.67 ``                     |
| [`c73f29c7`](https://github.com/NixOS/nixpkgs/commit/c73f29c723c2dce97e8789c6cf96b36a1b158176) | `` classicube: move runHook postInstall ``                                 |
| [`23579912`](https://github.com/NixOS/nixpkgs/commit/235799128bfccb6048f36a86e9d32545efca0372) | `` classicube: use makeDesktopItem ``                                      |
| [`52519fd1`](https://github.com/NixOS/nixpkgs/commit/52519fd12e639abdc4dbc8e054f73d68c923a505) | `` classicube: add .desktop file ``                                        |
| [`0166341b`](https://github.com/NixOS/nixpkgs/commit/0166341b2c8bffdfa7c6aff252c887c7fb834124) | `` babashka: 1.0.168 -> 1.0.169 ``                                         |
| [`c27ddaaf`](https://github.com/NixOS/nixpkgs/commit/c27ddaaf2ecc4db8b8c530632d54ba2701452d84) | `` terraform-providers.signalfx: 6.18.0 → 6.20.0 ``                        |
| [`d37c0bca`](https://github.com/NixOS/nixpkgs/commit/d37c0bcaeb5def02dbda0902e6b57e9e4646a98a) | `` terraform-providers.azurerm: 3.37.0 → 3.38.0 ``                         |
| [`e1e086a6`](https://github.com/NixOS/nixpkgs/commit/e1e086a69b421e0db8678f981e7b2b0e9251a946) | `` terraform-providers.scaleway: 2.8.0 → 2.9.0 ``                          |
| [`a466f2e4`](https://github.com/NixOS/nixpkgs/commit/a466f2e45091ca683f315cfd23f8174232b3abaf) | `` terraform-providers.bitbucket: 2.29.0 → 2.29.1 ``                       |
| [`4bddc2da`](https://github.com/NixOS/nixpkgs/commit/4bddc2da0831cc41db5aa878de0e3e3610c4f93b) | `` terraform-providers.baiducloud: 1.19.2 → 1.19.3 ``                      |
| [`4075c197`](https://github.com/NixOS/nixpkgs/commit/4075c1974ccd937794082f42faf1906328efe129) | `` edlin: init at 2.21 ``                                                  |
| [`248efc2b`](https://github.com/NixOS/nixpkgs/commit/248efc2b1792b8db75138bf36ff779778674e6ed) | `` pkgsStatic.gsasl: fix build ``                                          |
| [`7a6fed4c`](https://github.com/NixOS/nixpkgs/commit/7a6fed4c4a9fcd5591bafa3f927781ae44c236c1) | `` numix-icon-theme-square: 22.11.26 -> 23.01.02 ``                        |
| [`d74e0d32`](https://github.com/NixOS/nixpkgs/commit/d74e0d32bd1d97854844e3245bf7554fb07fede0) | `` python3Packages.charset-normalizer: add downstream tests ``             |
| [`39cbf0b7`](https://github.com/NixOS/nixpkgs/commit/39cbf0b76ff069352480814223782c366d82b3ab) | `` python310Packages.django_treebeard: 4.5.1 -> 4.6.0 ``                   |
| [`4df5fac0`](https://github.com/NixOS/nixpkgs/commit/4df5fac096886287e9114689410a01c5cb157377) | `` python310Packages.pyduke-energy: 1.0.2 -> 1.0.5 ``                      |
| [`64454713`](https://github.com/NixOS/nixpkgs/commit/64454713981e59cdf755fcf178539866493c3538) | `` smiley-sans: add update script ``                                       |
| [`e7800b4e`](https://github.com/NixOS/nixpkgs/commit/e7800b4ed06931b559e33bee3178e372613c3180) | `` yt-dlp: 2023.1.2 -> 2023.1.6 ``                                         |
| [`cb507f84`](https://github.com/NixOS/nixpkgs/commit/cb507f84706b7edaaa81c09d480a767c2b9a6409) | `` btrfs-progs: 6.0.2 -> 6.1.2 ``                                          |
| [`361dd1f0`](https://github.com/NixOS/nixpkgs/commit/361dd1f0d8678ed2e3f149aff04b15ee7a7f08c2) | `` smiley-sans: 1.0.0 -> 1.1.0 ``                                          |
| [`7fbf1dc7`](https://github.com/NixOS/nixpkgs/commit/7fbf1dc790110cea845ce56d3693a370a98b6beb) | `` electrs: 0.9.10 -> 0.9.11 ``                                            |
| [`d0178489`](https://github.com/NixOS/nixpkgs/commit/d0178489812e5d8edcc8d82bc1440ddbc0a745a2) | `` bdf2psf: 1.211 -> 1.215 ``                                              |
| [`8d4251f4`](https://github.com/NixOS/nixpkgs/commit/8d4251f4916c0f87cf00096372b51d46d00d647b) | `` nixos/dokuwiki: Add e1mo as maintainer ``                               |
| [`ddb5f5bf`](https://github.com/NixOS/nixpkgs/commit/ddb5f5bff928ce04592a40ee09fdcfa33eb896e7) | `` star-history: 1.0.8 -> 1.0.9 ``                                         |
| [`2a69c789`](https://github.com/NixOS/nixpkgs/commit/2a69c78928a0a7db5bba23627bee9fb819293eb7) | `` maintainers: add e1mo ``                                                |
| [`913ac1f2`](https://github.com/NixOS/nixpkgs/commit/913ac1f243afcb902515cd4f556a916499b38b09) | `` jpegoptim: 1.5.0 -> 1.5.1 ``                                            |
| [`9729c491`](https://github.com/NixOS/nixpkgs/commit/9729c49162d88ff9b3b17b7a1c930782ddfa0bef) | `` gnomeExtensions.pano: patch missing dependencies ``                     |
| [`2f84082d`](https://github.com/NixOS/nixpkgs/commit/2f84082de7cb5e0de57f02332c82a9dce73b1e5e) | `` ruff: 0.0.211 -> 0.0.212 (#209261) ``                                   |
| [`4d974808`](https://github.com/NixOS/nixpkgs/commit/4d974808239059e9fe12c33a824b1743b14fd2aa) | `` vopono: 0.10.3 -> 0.10.4 ``                                             |
| [`09864251`](https://github.com/NixOS/nixpkgs/commit/09864251a2cef6170f4a2f40fe2074ed56ebde6c) | `` bundler: 2.4.2 -> 2.4.3 ``                                              |
| [`3ebd0fae`](https://github.com/NixOS/nixpkgs/commit/3ebd0fae2a4bc9f5ff89b7fea8ba643374fb57d7) | `` cppcms: 1.2.1 -> 2.0.0.beta2 ``                                         |
| [`8f894d95`](https://github.com/NixOS/nixpkgs/commit/8f894d950c40802d32b7a4903add716f13f2e610) | `` python310Packages.pyvicare: 2.22.0 -> 2.23.0 ``                         |
| [`0a0861c9`](https://github.com/NixOS/nixpkgs/commit/0a0861c9a815819c8264845f36994e5d616d9f2e) | `` mkvtoolnix: 72.0.0 -> 73.0.0 ``                                         |
| [`6bab6fb6`](https://github.com/NixOS/nixpkgs/commit/6bab6fb6f91105ef3a82e4a7a8c0ea8878e245d7) | `` nova-filters: migrate to scons_latest ``                                |
| [`236d90fd`](https://github.com/NixOS/nixpkgs/commit/236d90fde0b376f00e8eea32ea6af37ec3de4766) | `` nixos/dokuwiki: Overhaul for structured settings ``                     |
| [`10862710`](https://github.com/NixOS/nixpkgs/commit/108627107dbfb7ed1906de3760a8dc995947a28e) | `` cloud-hypervisor: 28.0 -> 28.1 ``                                       |
| [`b611b87a`](https://github.com/NixOS/nixpkgs/commit/b611b87a335760ff12ca501fb6786150507c4607) | `` swift-im: drop ``                                                       |
| [`fa908526`](https://github.com/NixOS/nixpkgs/commit/fa908526f3858e5f6d321d7f242db47e1776d60e) | `` uefi-run: 0.5.0 -> 0.6.0 ``                                             |
| [`c8739dd4`](https://github.com/NixOS/nixpkgs/commit/c8739dd43c6cf4e7d0be7d23443003805b421474) | `` containerd: 1.6.14 -> 1.6.15 ``                                         |
| [`0e278788`](https://github.com/NixOS/nixpkgs/commit/0e2787884e7d6c60e51da9e1c158e75406cac7a9) | `` nixos/freshrss: fix permissions and add database test ``                |
| [`c7ce5dbe`](https://github.com/NixOS/nixpkgs/commit/c7ce5dbe157969321c0533c506dcd3bf098bc953) | `` python310Packages.scmrepo: 0.1.5 -> 0.1.6 ``                            |
| [`59473445`](https://github.com/NixOS/nixpkgs/commit/5947344587d182512a4a1e31abcc1dd42a99476d) | `` libyafaray: remove boost from dependencies ``                           |
| [`2876f802`](https://github.com/NixOS/nixpkgs/commit/2876f8026fa2aef5143f18e564379dba890cc3e0) | `` sumokoin: 0.2.0.0 -> 0.8.1.0 ``                                         |
| [`d3275da5`](https://github.com/NixOS/nixpkgs/commit/d3275da53d3a4ace07a9aef6fe2a32cfa8355193) | `` jabref: fix license (#209336) ``                                        |