### PR TITLE
chore(flake/home-manager): `684bdb38` -> `69806e93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673211936,
-        "narHash": "sha256-ba7jhl5BhLtpSooDHllgC0Y29vc0AiYWWsxQVtjlc7o=",
+        "lastModified": 1673265621,
+        "narHash": "sha256-4F5fbx2HvIWqYhEFfiI4WOMs79Ah9jH4PohI66vhOBY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "684bdb386cec7d4f16e0da9f694c8ab50ad2cf2a",
+        "rev": "69806e937881c75269e058daecf49d9c39bd034e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`69806e93`](https://github.com/nix-community/home-manager/commit/69806e937881c75269e058daecf49d9c39bd034e) | `` files: avoid surprises when linking files (#3018) `` |
| [`4f0c1afb`](https://github.com/nix-community/home-manager/commit/4f0c1afba75e2c3910cf4037f2b51025902cab24) | `` firefox: remove https-everywhere from example ``     |