### PR TITLE
chore(flake/nixpkgs): `f6f44561` -> `aa1d7470`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673134516,
-        "narHash": "sha256-mAZQKqkNQbBmJnmUU0blOfkKlgMSSVyPHdeWeuKad8U=",
+        "lastModified": 1673226411,
+        "narHash": "sha256-b6cGb5Ln7Zy80YO66+cbTyGdjZKtkoqB/iIIhDX9gRA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f6f44561884c3470e2b783683d5dbac42dfc833b",
+        "rev": "aa1d74709f5dac623adb4d48fdfb27cc2c92a4d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`e08a5396`](https://github.com/NixOS/nixpkgs/commit/e08a5396478de611233202adae1c07751fe32dee) | `` tut: 1.0.30 -> 1.0.34 ``                                                  |
| [`3bc50ffb`](https://github.com/NixOS/nixpkgs/commit/3bc50ffbb02a42676855f0f433c33f74ebc98a7e) | `` eternal-terminal: unmark broken on darwin (#208833) ``                    |
| [`42ed6597`](https://github.com/NixOS/nixpkgs/commit/42ed6597033ad9e7ed218ca592188cd6dcd116bf) | `` python3Packages.google-auth-oauthlib: fix build on darwin (#204589) ``    |
| [`b5e025bb`](https://github.com/NixOS/nixpkgs/commit/b5e025bb2a386bbf441240e02b803e74e6595aab) | `` gnu-shepherd: 0.8.1 -> 0.9.3 (#206317) ``                                 |
| [`16212c03`](https://github.com/NixOS/nixpkgs/commit/16212c03f5544593785ce902dec5a88185a5c468) | `` mcron: 1.0.6 -> 1.2.1 (#206300) ``                                        |
| [`b97a37fe`](https://github.com/NixOS/nixpkgs/commit/b97a37fe7e22c2c0bde7f2d575be1ebabe1c4e62) | `` nix-update: 0.12.0 -> 0.13.0 ``                                           |
| [`27a9e338`](https://github.com/NixOS/nixpkgs/commit/27a9e338cb64c92f11c5bf5fc12a328ac712ac5a) | `` xfsprogs: fix src url ``                                                  |
| [`4b74c3c3`](https://github.com/NixOS/nixpkgs/commit/4b74c3c3d1cba8d25c6aa2313218959100cd9d8c) | `` pypy39: fix pypy3 symlink ``                                              |
| [`c04fc211`](https://github.com/NixOS/nixpkgs/commit/c04fc21156a5ef5212faff83807ec2a5c8861239) | `` pythonInterpreters.pypy39_prebuilt: remove global with lib ``             |
| [`eddcc1c0`](https://github.com/NixOS/nixpkgs/commit/eddcc1c01c73e8744f77bff999a1d7503bda33d0) | `` pythonInterpreters.pypy27_prebuilt: remove global with lib ``             |
| [`a7ffcced`](https://github.com/NixOS/nixpkgs/commit/a7ffcced44625f1c2406ce1fc24a4bc4a2add966) | `` pypy{27,38,39}: remove global with lib ``                                 |
| [`92f01732`](https://github.com/NixOS/nixpkgs/commit/92f01732131eae253baac0a6910e5c33d90e706f) | `` pypy{27,38,39}: refactor derivation ``                                    |
| [`940f5a5b`](https://github.com/NixOS/nixpkgs/commit/940f5a5b7277ac4a8f78bd9ae702ec187baf4da6) | `` pokemon-colorscripts-mac: init at stable=2021-08-10 ``                    |
| [`06c338f9`](https://github.com/NixOS/nixpkgs/commit/06c338f91814ffedb76942a0af78272df8910444) | `` nixops_unstable: 2022-10-07 -> 2023-01-03 ``                              |
| [`22eb959f`](https://github.com/NixOS/nixpkgs/commit/22eb959f37d4dc44f354f262769f40f793f91fce) | `` nixos/amazon-option: Tolerate harmless ec2.hvm for compatibility ``       |
| [`9d10b68a`](https://github.com/NixOS/nixpkgs/commit/9d10b68a8562e154141a56e228e8f6ac55c2bf29) | `` pypy27: unbreak on aarch64-darwin ``                                      |
| [`b872208f`](https://github.com/NixOS/nixpkgs/commit/b872208f2630d94878a940f6499a8d3412774c3f) | `` typos: 1.13.0 -> 1.13.6 ``                                                |
| [`b41cc7cf`](https://github.com/NixOS/nixpkgs/commit/b41cc7cfba205ba8aec7f75942ee30e73ed74527) | `` pw-viz: 0.1.0 -> 0.2.0 ``                                                 |
| [`186a0b45`](https://github.com/NixOS/nixpkgs/commit/186a0b45757c69e2408c6ed239e517695ec6a303) | `` pulseview: fix hash of the patch ``                                       |
| [`ab370f9e`](https://github.com/NixOS/nixpkgs/commit/ab370f9ea9bbb3ad1f66f22cc297884c4646b729) | `` buildkite-agent: 3.41.0 -> 3.42.0 (#209637) ``                            |
| [`2bb9946e`](https://github.com/NixOS/nixpkgs/commit/2bb9946e05032650374ae169c46129ec55580e04) | `` doh-proxy-rust: 0.9.4 -> 0.9.6 ``                                         |
| [`c3ec444a`](https://github.com/NixOS/nixpkgs/commit/c3ec444a612d33027c9629b83b9faaf1fd6ddedc) | `` nixos/gitlab-runner: fix style issues flagged by statix ``                |
| [`d5cb89b0`](https://github.com/NixOS/nixpkgs/commit/d5cb89b024a347d3f27e45f6f1f5332ff22905c6) | `` nixos/gitlab-runner: fix problems introduced by last #209716 ``           |
| [`021a1331`](https://github.com/NixOS/nixpkgs/commit/021a1331f9dac9a070805ce6c8a44a2de9e8607f) | `` quarto: 1.2.280 -> 1.2.313 ``                                             |
| [`194b1690`](https://github.com/NixOS/nixpkgs/commit/194b1690e7a94880b74abe538f43a371ec8b4f37) | `` nautilus-open-any-terminal: remove unused NAUTILUS_EXTENSION_DIR ``       |
| [`5a245ecf`](https://github.com/NixOS/nixpkgs/commit/5a245ecfd6a755381fa32110104761da5ae5008c) | `` marwaita: 16.1 -> 16.2 ``                                                 |
| [`8ee21406`](https://github.com/NixOS/nixpkgs/commit/8ee214066de807ae8e77cb1d45f78927cbccb4d8) | `` python310Packages.google-cloud-secret-manager: 2.13.0 -> 2.14.0 ``        |
| [`356f88f8`](https://github.com/NixOS/nixpkgs/commit/356f88f80143ac3465b159a0db39ad38ea31abe7) | `` lighttpd: 1.4.67 -> 1.4.68 ``                                             |
| [`3911ced0`](https://github.com/NixOS/nixpkgs/commit/3911ced090b963d67525e45e80261477948e3809) | `` jellyfin-ffmpeg: 5.1.2-5 -> 5.1.2-6 ``                                    |
| [`7a33b394`](https://github.com/NixOS/nixpkgs/commit/7a33b394481b7d62dea1711a180a4810dd3c1e23) | `` gopass-summon-provider: 1.15.2 → 1.15.3 ``                                |
| [`37f69823`](https://github.com/NixOS/nixpkgs/commit/37f698230bdba167a43dcbbe9cc1a59084c07315) | `` git-credential-gopass: 1.15.2 → 1.15.3 ``                                 |
| [`c672a264`](https://github.com/NixOS/nixpkgs/commit/c672a264e1112ea0796c46f3ee0b7ecd358be8c2) | `` sad: fix build on aarch64 ``                                              |
| [`611eff0b`](https://github.com/NixOS/nixpkgs/commit/611eff0b21471c252570ce73c90373acac20132c) | `` gopass-jsonapi: 1.15.2 → 1.15.3 ``                                        |
| [`878ec0f3`](https://github.com/NixOS/nixpkgs/commit/878ec0f3d04d07e12de0724b0326939c6adfed2d) | `` gopass-hibp: 1.15.2 → 1.15.3 ``                                           |
| [`3673b74f`](https://github.com/NixOS/nixpkgs/commit/3673b74fc9dcc458bd66a739edb25b163c2c6148) | `` gopass: 1.15.2 → 1.15.3 ``                                                |
| [`dfe8d8e5`](https://github.com/NixOS/nixpkgs/commit/dfe8d8e58de8cb58d31c393010b04cd0ab63cbd5) | `` uncover: 1.0.1 -> 1.0.2 ``                                                |
| [`bf4c6758`](https://github.com/NixOS/nixpkgs/commit/bf4c675866ed8c0d5e4a05d699a9a42a6050633b) | `` d2: 0.1.4 -> 0.1.5 ``                                                     |
| [`5828698d`](https://github.com/NixOS/nixpkgs/commit/5828698df607f2a30882c482d63e40a4b357f636) | `` cachix: fix build on darwin ``                                            |
| [`27e9a107`](https://github.com/NixOS/nixpkgs/commit/27e9a1075c2549c052ad5c1b7b657f4c62a19322) | `` swaycons: init at unstable-2023-01-05 ``                                  |
| [`f099ce6b`](https://github.com/NixOS/nixpkgs/commit/f099ce6bf8c3a62dd73eecb45b9027cf3cb5ac33) | `` conftest: 0.36.0 -> 0.37.0 ``                                             |
| [`eae63548`](https://github.com/NixOS/nixpkgs/commit/eae63548c343ce83ad5f51142e30a61bfcff445b) | `` meilisearch: 0.30.2 -> 0.30.5 ``                                          |
| [`06690fd5`](https://github.com/NixOS/nixpkgs/commit/06690fd5ad57d81857fe19ab96bf443b99156321) | `` termusic: 0.7.5 -> 0.7.7 ``                                               |
| [`337d3583`](https://github.com/NixOS/nixpkgs/commit/337d358300af21530f78e2572953b0f309a5f338) | `` nixos/n8n: disable telemetry by default ``                                |
| [`32b88691`](https://github.com/NixOS/nixpkgs/commit/32b88691bf36e69dccb197d0e88e9b49f80a8245) | `` tdesktop: 4.4.1 -> 4.5.3 ``                                               |
| [`6ae53e4c`](https://github.com/NixOS/nixpkgs/commit/6ae53e4cca6ceb603d108a6b7fcaf52960d972bb) | `` grype: 0.54.0 -> 0.55.0 ``                                                |
| [`4f74287d`](https://github.com/NixOS/nixpkgs/commit/4f74287d0548586d58c1c65ad9b2580b69033ce1) | `` n8n: 0.209.3 → 0.210.1 ``                                                 |
| [`4b2f36fc`](https://github.com/NixOS/nixpkgs/commit/4b2f36fc9f95f4ed095314ab741482dad10fc489) | `` crowdsec: 1.4.3 -> 1.4.4 ``                                               |
| [`81c7ba81`](https://github.com/NixOS/nixpkgs/commit/81c7ba8120d704bc82a15bfe108009215642d608) | `` flyctl: 0.0.441 -> 0.0.443 ``                                             |
| [`6a501c3e`](https://github.com/NixOS/nixpkgs/commit/6a501c3ea15944f0659bf4666b02350966415efd) | `` llama: 1.2.0 -> 1.4.0 ``                                                  |
| [`5c334952`](https://github.com/NixOS/nixpkgs/commit/5c3349529fcb4a45df6c107fbca2aa5faa137c54) | `` karmor: 0.11.1 -> 0.11.4 ``                                               |
| [`bcb0831a`](https://github.com/NixOS/nixpkgs/commit/bcb0831a1c8289118f79b5d65d6d1f373fd5ff4f) | `` tinyssh: 20220801 -> 20230101 ``                                          |
| [`e909be25`](https://github.com/NixOS/nixpkgs/commit/e909be256e0a45f2563e504a1f6e2fa532b07cc1) | `` tellico: 3.4.4 -> 3.4.5 ``                                                |
| [`f38eb6de`](https://github.com/NixOS/nixpkgs/commit/f38eb6de8f80bd27fbe31613c1bba5d2d17c1525) | `` git-cola: 4.0.4 -> 4.1.0 ``                                               |
| [`adcf9112`](https://github.com/NixOS/nixpkgs/commit/adcf91124ce933af41fe9ab24a399a2ace9c75e2) | `` zsh-prezto: unstable-2022-04-05 -> unstable-2022-10-26 ``                 |
| [`08d2994f`](https://github.com/NixOS/nixpkgs/commit/08d2994fe25ac12e0f33cbbea22012b6267bf9f6) | `` tageditor: 3.7.5 -> 3.7.7 ``                                              |
| [`5a597a0a`](https://github.com/NixOS/nixpkgs/commit/5a597a0a920e2e631e76f7a4212ca3ce4735338e) | `` cargo-chef: 0.1.50 -> 0.1.51 ``                                           |
| [`b343f252`](https://github.com/NixOS/nixpkgs/commit/b343f252c06fb02f8e329fdff67a57b1d1f83d64) | `` pmacct: 1.7.7 -> 1.7.8 ``                                                 |
| [`681b13bf`](https://github.com/NixOS/nixpkgs/commit/681b13bfccc2440a2c2dd169bea0041c6d7ecb35) | `` python310Packages.aioblescan: 0.2.13 -> 0.2.14 ``                         |
| [`c80a4199`](https://github.com/NixOS/nixpkgs/commit/c80a419995cefc084c268d528255cc9204cc1701) | `` python310Packages.aioblescan: add changelog to meta ``                    |
| [`55883b4e`](https://github.com/NixOS/nixpkgs/commit/55883b4e116409a248c028cee25c559852d662a7) | `` python310Packages.posix_ipc: normalize pname ``                           |
| [`2cc11109`](https://github.com/NixOS/nixpkgs/commit/2cc11109b20deffe526aa47ddd5a0934d4635337) | `` python310Packages.posix_ipc: disable on unsupported Python releasese ``   |
| [`1d0c72fe`](https://github.com/NixOS/nixpkgs/commit/1d0c72fe99cc4c3171785d2688adc60b4acce929) | `` python310Packages.pydmd: add changelog to meta ``                         |
| [`18df33f5`](https://github.com/NixOS/nixpkgs/commit/18df33f5bc99d32e1312439cf670f0f4c580290b) | `` nixos/make-options-doc: skip re-escaping strings ``                       |
| [`0874afef`](https://github.com/NixOS/nixpkgs/commit/0874afef464c6e95f1a2b66a212b920785a724a9) | `` keycloak: add scim-keycloak-user-storage-spi plugin ``                    |
| [`0ceafc13`](https://github.com/NixOS/nixpkgs/commit/0ceafc13c92cd5db4665b49f56f56e39174c42fb) | `` mold: add changelog to meta ``                                            |
| [`d28a772f`](https://github.com/NixOS/nixpkgs/commit/d28a772f64c8c41b6974da717f5a9dd8d58ac75c) | `` terragrunt: update rev ``                                                 |
| [`6e082f22`](https://github.com/NixOS/nixpkgs/commit/6e082f222c02b64c528637f82596f348ddf60e1c) | `` cachix,hercules-ci-{agent,cnix-expr,cnix-store}: bump nix pin to 2_12 ``  |
| [`9d6385a2`](https://github.com/NixOS/nixpkgs/commit/9d6385a23a233c3aa9fc06c9f646005517542b38) | `` python310Packages.pydmd: 0.4.0.post2212 -> 0.4.0.post2301 ``              |
| [`724146b9`](https://github.com/NixOS/nixpkgs/commit/724146b99b6f8c03717604a3af236d04a283552a) | `` tbls: 1.56.9 -> 1.57.1 ``                                                 |
| [`faf46928`](https://github.com/NixOS/nixpkgs/commit/faf469285661bd63a1285eec2fdd7c0192235d53) | `` python310Packages.posix_ipc: 1.1.0 -> 1.1.1 ``                            |
| [`b8272de4`](https://github.com/NixOS/nixpkgs/commit/b8272de4e71b52689f674c0bf6f38040596ffb59) | `` gotestfmt: init at 2.4.1 ``                                               |
| [`46ee37ca`](https://github.com/NixOS/nixpkgs/commit/46ee37ca1d9cd3bb18633b4104ef21d9035aac89) | `` rustPlatform.bindgenHook: use the same clang/libclang as rustc ``         |
| [`1fed657f`](https://github.com/NixOS/nixpkgs/commit/1fed657ff841c622f702a830cebdfda93cd1b003) | `` ruff: 0.0.214 -> 0.0.215 ``                                               |
| [`76766f8b`](https://github.com/NixOS/nixpkgs/commit/76766f8bcdec74729f6e95e2b28694166b3a2e93) | `` tintin: 2.02.20 -> 2.02.30 ``                                             |
| [`310e69d7`](https://github.com/NixOS/nixpkgs/commit/310e69d7c0914ee93311d52bf09b9149800bc3a7) | `` _1password: 2.11.0 -> 2.12.0 ``                                           |
| [`c81f27bf`](https://github.com/NixOS/nixpkgs/commit/c81f27bf8f1ea0cbc93bc316ade8dc9a8c05f3c1) | `` esbuild: 0.16.13 -> 0.16.15 ``                                            |
| [`f5476f74`](https://github.com/NixOS/nixpkgs/commit/f5476f74bcb325f3ea2dda7b3516ebbfaf409ae8) | `` luau: 0.555 -> 0.558 ``                                                   |
| [`45451652`](https://github.com/NixOS/nixpkgs/commit/454516526fd66ab33353f47abc967ca99cef238d) | `` python310Packages.sphinxcontrib-katex: 0.9.3 -> 0.9.4 ``                  |
| [`dc19944c`](https://github.com/NixOS/nixpkgs/commit/dc19944c8c2a88bca61437b71150d97a9a31483d) | `` python310Packages.pulumi-aws: 5.25.0 -> 5.26.0 ``                         |
| [`74640b81`](https://github.com/NixOS/nixpkgs/commit/74640b818ed128160aab92ce68dd7aac135f6527) | `` terraform-providers.sops: 0.7.1 → 0.7.2 ``                                |
| [`2d72d477`](https://github.com/NixOS/nixpkgs/commit/2d72d4775e7896f54db0739f1ca044cae9afe558) | `` cri-o: 1.25.1 -> 1.26.0 ``                                                |
| [`448dc91d`](https://github.com/NixOS/nixpkgs/commit/448dc91db4f17b5e6e1f5c247eb8a847d1378f56) | `` nixos/cri-o: source cni and crictl from package ``                        |
| [`5da87a8c`](https://github.com/NixOS/nixpkgs/commit/5da87a8c7bba28d80312e061d34be6f54efbb695) | `` nixos/containers: source policy from separate skopeo output ``            |
| [`86d55aa6`](https://github.com/NixOS/nixpkgs/commit/86d55aa6678f7b0dc9952c001fada76a50d374de) | `` skopeo: install default policy to separate passthru package ``            |
| [`4a8663e6`](https://github.com/NixOS/nixpkgs/commit/4a8663e6d2b0c980ff29753a3ad70cdccea63236) | `` cri-o: install cni and crictl files ``                                    |
| [`2bedf9ff`](https://github.com/NixOS/nixpkgs/commit/2bedf9ffc5c80905a0049d3b71a139c59c579db3) | `` blackfire: 2.13.1 -> 2.13.2 ``                                            |
| [`8e586a27`](https://github.com/NixOS/nixpkgs/commit/8e586a2757e3e52fc76b7f49d18f60945876ee34) | `` mold: 1.8.0 -> 1.9.0 ``                                                   |
| [`7d3409f8`](https://github.com/NixOS/nixpkgs/commit/7d3409f8a792d1a3d16558fd6d0a3aab6d5d8d57) | `` terragrunt: 0.42.5 -> 0.42.7 ``                                           |
| [`092a78bb`](https://github.com/NixOS/nixpkgs/commit/092a78bb7f5e4dfae99197ca8c9d97164f4ce3eb) | `` Revert "xidel: unpin to openssl_1_1" ``                                   |
| [`0206d6a7`](https://github.com/NixOS/nixpkgs/commit/0206d6a73592c8042b13f8dd1060868166f3e3ea) | `` firefox-bin-unwrapped: 108.0.1 -> 108.0.2 ``                              |
| [`4073a140`](https://github.com/NixOS/nixpkgs/commit/4073a140611bc23fa35d83007d719efaeb23333d) | `` firefox-unwrapped: 108.0.1 -> 108.0.2 ``                                  |
| [`f9f90b4b`](https://github.com/NixOS/nixpkgs/commit/f9f90b4b88763e9c113ae9ce194e7568a3688a80) | `` zoxide: 0.8.3 -> 0.9.0 ``                                                 |
| [`0c1e1e4e`](https://github.com/NixOS/nixpkgs/commit/0c1e1e4e254bc1210f6ebabac68cb48beb2f7e9a) | `` smiley-sans: 1.1.0 -> 1.1.1 ``                                            |
| [`fd6ddd99`](https://github.com/NixOS/nixpkgs/commit/fd6ddd9923adbb8739dad3a3512dbf44934ec76a) | `` pythonInterpreters.pypy39_prebuilt: add darwin support ``                 |
| [`a2012d83`](https://github.com/NixOS/nixpkgs/commit/a2012d833a18f200c8ab5458c1d61dc3e1d973fa) | `` python310Packages.pyisy: 3.0.10 -> 3.0.11 ``                              |
| [`e380607d`](https://github.com/NixOS/nixpkgs/commit/e380607d078c172482cfa0bbb34bf697911a92ec) | `` pythonInterpreters.pypy27_prebuilt: fix install check on darwin ``        |
| [`c05b9ccd`](https://github.com/NixOS/nixpkgs/commit/c05b9ccd825861c1d8e31e71f926f9d8dc72f6f5) | `` retroarch: add qtbase/spirv-tools as deps ``                              |
| [`467e2a23`](https://github.com/NixOS/nixpkgs/commit/467e2a2397f974f116ccfa9295b511a8b5604784) | `` dia: 0.97.3.20170622 -> unstable-2022-12-14 ``                            |
| [`356befdc`](https://github.com/NixOS/nixpkgs/commit/356befdc42ea173954be3e0cf0f241ff8d0a5674) | `` python310Packages.internetarchive: add format attribute ``                |
| [`82911d7e`](https://github.com/NixOS/nixpkgs/commit/82911d7e5ff9dea61320f83e14dbc69927a78390) | `` internetarchive: 3.0.2 -> 3.2.0 ``                                        |
| [`ebd1b2eb`](https://github.com/NixOS/nixpkgs/commit/ebd1b2eb181193c350216b7aeab5042f0d801f4c) | `` python310Packages.archspec: 0.1.4 -> 0.2.0 ``                             |
| [`caf74767`](https://github.com/NixOS/nixpkgs/commit/caf7476762680166ec3a10cc1bc39a2fbe494138) | `` python310Packages.archspec: add changelog to meta ``                      |
| [`35f40565`](https://github.com/NixOS/nixpkgs/commit/35f40565b4399d03bc01034023bf7872dbae2294) | `` python310Packages.md-toc: 8.1.7 -> 8.1.8 ``                               |
| [`678a5e26`](https://github.com/NixOS/nixpkgs/commit/678a5e260945d8a2e47538bfdc5310b777747182) | `` python310Packages.accuweather: 0.4.0 -> 0.5.0 ``                          |
| [`c09b89c2`](https://github.com/NixOS/nixpkgs/commit/c09b89c293e63c7eaa2e85483c022217e1f85ce8) | `` python310Packages.accuweather: add changelog to meta ``                   |
| [`68d1ff59`](https://github.com/NixOS/nixpkgs/commit/68d1ff59220d0c0a2c84c036fce650b91e227e48) | `` python310Packages.mkdocstrings-python: 0.8.2 -> 0.8.3 ``                  |
| [`8489ca69`](https://github.com/NixOS/nixpkgs/commit/8489ca69fa5a26450a07bc56cd785c0d4953440c) | `` python310Packages.pysigma-backend-opensearch: 0.1.3 -> 0.1.4 ``           |
| [`4c09fd81`](https://github.com/NixOS/nixpkgs/commit/4c09fd8159c8558dbfcf93c96f1f535cbc00384c) | `` python310Packages.pysigma-backend-elasticsearch: 0.1.1 -> 0.1.2 ``        |
| [`a3db6ac9`](https://github.com/NixOS/nixpkgs/commit/a3db6ac9e21d49d7b7757ab1a27fe6fcc139df80) | `` python310Packages.pysigma-backend-opensearch: add changelog to meta ``    |
| [`12bd9377`](https://github.com/NixOS/nixpkgs/commit/12bd93770060b3cb24c6f659e544afa282e7ee96) | `` python310Packages.pysigma-backend-elasticsearch: add changelog to meta `` |
| [`8299bfb6`](https://github.com/NixOS/nixpkgs/commit/8299bfb61db3116b4d171b1b58898b1282504581) | `` python310Packages.pysigma: 0.8.9 -> 0.8.12 ``                             |
| [`08f1a3ee`](https://github.com/NixOS/nixpkgs/commit/08f1a3ee4044ebe8b6e89629c406a82ed6feabfe) | `` python310Packages.pysigma: add changelog to meta ``                       |
| [`182f5cd3`](https://github.com/NixOS/nixpkgs/commit/182f5cd35ed3a1596c8f71054d99b70d047fad43) | `` python310Packages.pysigma-pipeline-windows: add changelog to meta ``      |
| [`7721cd11`](https://github.com/NixOS/nixpkgs/commit/7721cd11e047d1d5c8307038d1dbe4c3ec0672e5) | `` python310Packages.debuglater: 1.4.3 -> 1.4.4 ``                           |
| [`45fc1f18`](https://github.com/NixOS/nixpkgs/commit/45fc1f185f6b74884d50dbf17bd044aa22eb3069) | `` rustPlatform.fetchCargoTarball: default outputHashAlgo to sha256 ``       |
| [`c3921dca`](https://github.com/NixOS/nixpkgs/commit/c3921dca5b6f7d9ce057d234a6138098086bfd19) | `` python310Packages.debuglater: add changelog to meta ``                    |
| [`dd3cc02d`](https://github.com/NixOS/nixpkgs/commit/dd3cc02d7ddfc449818b80f71622cd138d64ec0c) | `` csound-qt: 0.9.6-beta3 -> 1.1.1 ``                                        |
| [`016283c5`](https://github.com/NixOS/nixpkgs/commit/016283c5bd8f62d915ab3929f5f12bd3c1e2bde5) | `` python-qt: 3.2 -> 3.3.0 ``                                                |
| [`f04951a4`](https://github.com/NixOS/nixpkgs/commit/f04951a467f8ee3d4c41d053ea60b133210d51d3) | `` cdk-go: add changelog to meta ``                                          |
| [`dc9ff73d`](https://github.com/NixOS/nixpkgs/commit/dc9ff73d2b33fe904a70d79dc9e72132e1064315) | `` cargo-modules: 0.7.2 -> 0.7.3 ``                                          |
| [`af49b294`](https://github.com/NixOS/nixpkgs/commit/af49b294e1062591cb058c719b9f27d92e9ee8f3) | `` s2n-tls: 1.3.31 -> 1.3.32 ``                                              |
| [`a9b660b5`](https://github.com/NixOS/nixpkgs/commit/a9b660b5342e9da9d63e01d9457d1e25eef3326e) | `` cdk-go: 1.5.0 -> 1.5.1 ``                                                 |