### PR TITLE
chore(flake/nixos-hardware): `48745e08` -> `df029cfe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1673307158,
-        "narHash": "sha256-d/HYBkMWqQkhSH3hPtEB+uEEwkk9vsHQJ4J7zXdE1wo=",
+        "lastModified": 1673336835,
+        "narHash": "sha256-HMJ/Nt3+0MtgKfPfJSrC3/6yVAPQvZgv/7V9b49dG/c=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "48745e081cfdcc678633c61dbf47a9bd3dfd93a7",
+        "rev": "df029cfefc7494b399966cbb6b4fd692fa294fa3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`51e3be98`](https://github.com/NixOS/nixos-hardware/commit/51e3be9885b7d095eb1f7ba8a62ef6771e616e28) | `` Remove kernel 6.0.11 from MS Surface profile ``                              |
| [`9020a320`](https://github.com/NixOS/nixos-hardware/commit/9020a320f5bd3c550a427b3a6c945979a68168bf) | `` Install kernel 6.0.17 by default ``                                          |
| [`0ee9d61f`](https://github.com/NixOS/nixos-hardware/commit/0ee9d61fa68486b1b9ff8ddaf9f0dd91662e8766) | `` Update the rev. and sha256 of linux-surface repo to match latest "master" `` |
| [`800786f1`](https://github.com/NixOS/nixos-hardware/commit/800786f11d0d195af558d67db151a33055604087) | `` Add Kernel 6.0.17 ``                                                         |