### PR TITLE
chore(flake/home-manager): `b0a36898` -> `176e4553`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673306306,
-        "narHash": "sha256-wV99VV4kn0SIN1XeEIfnD0X7dZD9H5prk19XeFQKhso=",
+        "lastModified": 1673343300,
+        "narHash": "sha256-5Xdj6kpXYMie0MlnGwqK5FaMdsedxvyuakWtyKB3zaQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b0a3689878d4c2e8a1b02cecf8319ba8c53da519",
+        "rev": "176e455371a8371586e8a3ff0d56ee9f3ca2324e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`176e4553`](https://github.com/nix-community/home-manager/commit/176e455371a8371586e8a3ff0d56ee9f3ca2324e) | `` home-manager: Add home-manager search path to EXTRA_NIX_PATH (#3241) `` |
| [`950aace4`](https://github.com/nix-community/home-manager/commit/950aace44e23327a9df1c93fa799a0421091f04a) | `` i3: Do not set i3 package (#3585) ``                                    |