### PR TITLE
chore(flake/nixpkgs): `aa1d7470` -> `c07552f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673226411,
-        "narHash": "sha256-b6cGb5Ln7Zy80YO66+cbTyGdjZKtkoqB/iIIhDX9gRA=",
+        "lastModified": 1673315479,
+        "narHash": "sha256-GNCFRtDHjTygXGJp/H+f2XQPMGxpYSmNiibIqYzihtM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aa1d74709f5dac623adb4d48fdfb27cc2c92a4d4",
+        "rev": "c07552f6f7d4eead7806645ec03f7f1eb71ba6bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`e7fb320d`](https://github.com/NixOS/nixpkgs/commit/e7fb320d60fd721a07824683b548b586e486c1ca) | `` libb2: Use autoreconfHook and build in parallel ``                             |
| [`71ab3109`](https://github.com/NixOS/nixpkgs/commit/71ab3109f28e1719119b55f2f8f5e264061a9605) | `` borgbackup: unbundle xxhash and use pkgconfig ``                               |
| [`c64195df`](https://github.com/NixOS/nixpkgs/commit/c64195df27f0585ab4306f4364fa4f08b70d0157) | `` borgbackup: 1.2.2 -> 1.2.3 ``                                                  |
| [`7af47c98`](https://github.com/NixOS/nixpkgs/commit/7af47c9877dc7d16828152aed027438dc99b9421) | `` ath9k-htc-blobless-firmware: init at 1.4.0 ``                                  |
| [`34dd1761`](https://github.com/NixOS/nixpkgs/commit/34dd176116870d24d6a5b93e263e79edad06fd00) | `` gmsh: enable python bindings ``                                                |
| [`9ad7623e`](https://github.com/NixOS/nixpkgs/commit/9ad7623ebe76c952ee283ec83690bb22ca7cb625) | `` ocamlPackages.biniou: 1.2.1 → 1.2.2 (#208852) ``                               |
| [`3c866e64`](https://github.com/NixOS/nixpkgs/commit/3c866e643ce67ea2c56f4d3d5223b6ac43c46688) | `` uclibc-ng: 1.0.41 -> 1.0.42 ``                                                 |
| [`39d488be`](https://github.com/NixOS/nixpkgs/commit/39d488be760f8f36c8d02751c84ee294c36e0a1f) | `` kirc: 0.3.1 -> 0.3.2 ``                                                        |
| [`656548c4`](https://github.com/NixOS/nixpkgs/commit/656548c44a4252ace3d43a351f772c2513c98cca) | `` build(deps): bump korthout/backport-action from 1.0.0 to 1.0.1 ``              |
| [`21879f90`](https://github.com/NixOS/nixpkgs/commit/21879f901c81bb512d179cdda3bbef8fcefc2dee) | `` jqp: 0.3.0 -> 0.4.0 ``                                                         |
| [`90901235`](https://github.com/NixOS/nixpkgs/commit/90901235c571c53cc79b983c954f5581619495e7) | `` protobuf: fix uses of .override ``                                             |
| [`2eeb34c2`](https://github.com/NixOS/nixpkgs/commit/2eeb34c2737f5eb8a2796701584a7b0551cb053a) | `` treewide: {build,host,target}Platform -> stdenv.{build,host,target}Platform `` |
| [`2c8cc56e`](https://github.com/NixOS/nixpkgs/commit/2c8cc56ebc06256a4470be99fb923da2799c62f5) | `` radare2: apply patch for CVE-2022-4843 ``                                      |
| [`da723790`](https://github.com/NixOS/nixpkgs/commit/da723790c9850111ba6ec9316418bac271600336) | `` home-assistant: 2023.1.1 -> 2023.1.2 ``                                        |
| [`f176841d`](https://github.com/NixOS/nixpkgs/commit/f176841d9842ba3c89849890d0a01f2641c13e61) | `` python310Packages.pybotvac: 0.0.23 -> 0.0.24 ``                                |
| [`df7c7ae7`](https://github.com/NixOS/nixpkgs/commit/df7c7ae7cfd7e4cba7119dba67c18dd87c76ba81) | `` python310Packages.tpm2-pytss: 2.0.0 -> 2.1.0 ``                                |
| [`8c794bcb`](https://github.com/NixOS/nixpkgs/commit/8c794bcbec0f926eaa5042cd370e9ecccb3728c9) | `` python310Packages.pybotvac: add changelog to meta ``                           |
| [`3e8f97fd`](https://github.com/NixOS/nixpkgs/commit/3e8f97fdacd8c8b750f5fddae6d239503fcee5d5) | `` python310Packages.bellows: 0.34.5 -> 0.34.6 ``                                 |
| [`d7f73e40`](https://github.com/NixOS/nixpkgs/commit/d7f73e40c26d99f791dd0aecb3d6cc692721e0ac) | `` python310Packages.zigpy: 0.52.3 -> 0.53.0 ``                                   |
| [`d1d55b34`](https://github.com/NixOS/nixpkgs/commit/d1d55b340279cfe93596a97704c134bd166e3017) | `` python310Packages.graphtage: add changelog to meta ``                          |
| [`900357f3`](https://github.com/NixOS/nixpkgs/commit/900357f355336cec12fe4138ea58599d667e4bbf) | `` duckstation: unstable-2022-12-08 -> unstable-2023-01-01 ``                     |
| [`64a10f0b`](https://github.com/NixOS/nixpkgs/commit/64a10f0b9ba93734231debc0afe2563e98919ebe) | `` python310Packages.tailscale: add changelog to meta ``                          |
| [`ac042c65`](https://github.com/NixOS/nixpkgs/commit/ac042c6545d233711c157e13aca7537b45197ed5) | `` python310Packages.pyswitchbee: 1.7.3 -> 1.7.18 ``                              |
| [`d291b999`](https://github.com/NixOS/nixpkgs/commit/d291b999bd88c6906c666f3a516e1e730ffc80db) | `` python310Packages.oralb-ble: 0.15.0 -> 0.16.1 ``                               |
| [`38d57d2f`](https://github.com/NixOS/nixpkgs/commit/38d57d2fcb337c1259f0d8396b139595e701320d) | `` python310Packages.pyisy: 3.0.11 -> 3.0.12 ``                                   |
| [`1c7c5e95`](https://github.com/NixOS/nixpkgs/commit/1c7c5e95f168be2979d8f633a58bd70bf1192a8d) | `` python310Packages.reolink-aio: 0.1.3 -> 0.2.1 ``                               |
| [`f314b76c`](https://github.com/NixOS/nixpkgs/commit/f314b76c5d942cecfb5a7124380eb4cbebcc0f4e) | `` python310Packages.sfrbox-api: init at 0.0.2 ``                                 |
| [`cc3208a8`](https://github.com/NixOS/nixpkgs/commit/cc3208a83b78fbb9f4672a14aed4c3ac82280fd7) | `` getmail6: 6.18.10 -> 6.18.11 ``                                                |
| [`53947566`](https://github.com/NixOS/nixpkgs/commit/53947566423985111ed0ae6892ed1795081b5063) | `` libsForQt5.mapbox-gl-qml: 2.0.1 -> 2.1.1 ``                                    |
| [`72191b44`](https://github.com/NixOS/nixpkgs/commit/72191b44d719cb799464658fe0dd93c08aa55a89) | `` libsForQt5.maplibre-gl-native: unstable-2022-04-07 -> 2.0.1 ``                 |
| [`eec6aa81`](https://github.com/NixOS/nixpkgs/commit/eec6aa8119a08d6f99a6b352b1fde9a522e7765e) | `` python310Packages.graphtage: 0.2.6 -> 0.2.7 ``                                 |
| [`d5febb8d`](https://github.com/NixOS/nixpkgs/commit/d5febb8d7a68a9b1aac6385d63974408d46ecbe2) | `` strip-nondeterminism: 1.0.0 -> 1.13.0 ``                                       |
| [`89c457d8`](https://github.com/NixOS/nixpkgs/commit/89c457d847d2807a6988efc4c3e16bac32374ba1) | `` build-dotnet-module: fix mktemp ``                                             |
| [`03aa514d`](https://github.com/NixOS/nixpkgs/commit/03aa514de1dc09008e24e8fb4b949b35526a7fee) | `` python310Packages.restrictedpython: 5.2 -> 6.0 ``                              |
| [`1f4c190a`](https://github.com/NixOS/nixpkgs/commit/1f4c190affbd9c2297119e164f6615b876139781) | `` cubicle: 1.1.2 -> 1.2.0 ``                                                     |
| [`2ec805b1`](https://github.com/NixOS/nixpkgs/commit/2ec805b168c9ef754ad488e700d8c05cb948bbfd) | `` v2ray-domain-list-community: 20221223102220 -> 20230106031328 ``               |
| [`e0db41ab`](https://github.com/NixOS/nixpkgs/commit/e0db41ab1aedc2aa8ef5a14ee2ee942c859144c7) | `` ants: 2.4.2 -> 2.4.3 ``                                                        |
| [`72070c11`](https://github.com/NixOS/nixpkgs/commit/72070c1132f175edaf02867d1c9961aa03a412e5) | `` python310Packages.restrictedpython: add changelog to meta ``                   |
| [`84b8063c`](https://github.com/NixOS/nixpkgs/commit/84b8063c468e5ff7681381a3308aae4bdbd0cd24) | `` uxplay: 1.60 -> 1.61.1 ``                                                      |
| [`e674075e`](https://github.com/NixOS/nixpkgs/commit/e674075ed189df704e61d14d6f697369122b5f63) | `` deltachat-desktop: fix build of esbuild ``                                     |
| [`3d831cc1`](https://github.com/NixOS/nixpkgs/commit/3d831cc1a311381a225671581ef0ab4317b6985f) | `` v2ray-geoip: 202212220043 -> 202301050046 ``                                   |
| [`3d461682`](https://github.com/NixOS/nixpkgs/commit/3d4616820ffd3a314eb8597da4072c371831d9ad) | `` subgit: 3.3.15 -> 3.3.16 ``                                                    |
| [`061d7266`](https://github.com/NixOS/nixpkgs/commit/061d7266de2856ad70750710cecf88e0ac854e49) | `` pathvector: 6.0.3 -> 6.1.0 ``                                                  |
| [`fce9f6f8`](https://github.com/NixOS/nixpkgs/commit/fce9f6f8e21a8ad8f29e37c8f9a808e1a67753bf) | `` python310Packages.aioesphomeapi: 13.0.3 -> 13.0.4 ``                           |
| [`da527909`](https://github.com/NixOS/nixpkgs/commit/da527909f106aa9b2eb0ed985c5048f41ad5b6f4) | `` vtm: 0.9.8g -> 0.9.8l ``                                                       |
| [`738029e2`](https://github.com/NixOS/nixpkgs/commit/738029e2a8ce8bbb73d96095913038565d8e681a) | `` zed: 1.3.0 -> 1.4.0 ``                                                         |
| [`16e74638`](https://github.com/NixOS/nixpkgs/commit/16e74638bc1df3f921702b3fb54e69408163dc9f) | `` python310Packages.pontos: 22.12.3 -> 23.1.0 ``                                 |
| [`a2b159c0`](https://github.com/NixOS/nixpkgs/commit/a2b159c0a7ef6d0589a0d1697550c9aa9954b32a) | `` python310Packages.debugpy: 1.6.4 -> 1.6.5 ``                                   |
| [`319fd6bf`](https://github.com/NixOS/nixpkgs/commit/319fd6bf3b1c23fc176e46b88e20ba674331052a) | `` python310Packages.aiorun: 2021.10.1 -> 2022.11.1 ``                            |
| [`18a63fa6`](https://github.com/NixOS/nixpkgs/commit/18a63fa6892a0cdf9ce0c626eafe373a57a17d66) | `` rnote: 0.5.10 -> 0.5.12 ``                                                     |
| [`e86a7d70`](https://github.com/NixOS/nixpkgs/commit/e86a7d700a82552b53eaa64e2e99a2a884f6e39a) | `` darkstat: 3.0.719 -> 3.0.721 (#209861) ``                                      |
| [`bceec861`](https://github.com/NixOS/nixpkgs/commit/bceec861237c11552f9ac34ef3f4b5a2508fcca9) | `` fish: 3.5.1 -> 3.6.0 ``                                                        |
| [`83458290`](https://github.com/NixOS/nixpkgs/commit/83458290b096ab698cd50b5458e1869d739a5c99) | `` cargo-llvm-cov: 0.5.2 -> 0.5.4 (#206233) ``                                    |
| [`52fcfb1d`](https://github.com/NixOS/nixpkgs/commit/52fcfb1de2e4d00175b0fded79a112c3cf518e4e) | `` libquotient: 0.6.11 -> 0.7.0 (#207558) ``                                      |
| [`9c2f3e16`](https://github.com/NixOS/nixpkgs/commit/9c2f3e166b73f48b0779312218b65901a692ef52) | `` waylock: 0.4.2 -> 0.6.0 (#209867) ``                                           |
| [`2394c19b`](https://github.com/NixOS/nixpkgs/commit/2394c19b90132fbb7948eab3f81c02df56b1ebe5) | `` cargo-public-api: 0.24.1 -> 0.26.0 (#206365) ``                                |
| [`0b38e52c`](https://github.com/NixOS/nixpkgs/commit/0b38e52c56066bceeea655a535a03f93bdbcbdee) | `` gfxreconstruct: 0.9.15 -> 0.9.16.1 ``                                          |
| [`87b91aeb`](https://github.com/NixOS/nixpkgs/commit/87b91aebffadd6a8811db3355d838738d07ab3b4) | `` oxker: 0.1.10 -> 0.1.11 ``                                                     |
| [`e015cc41`](https://github.com/NixOS/nixpkgs/commit/e015cc413e76a5413e0057d23c0290c5b1090abc) | `` python310Packages.whois: 0.9.21 -> 0.9.22 ``                                   |
| [`27225a86`](https://github.com/NixOS/nixpkgs/commit/27225a861708ced2e7b0655775b2f59a82924683) | `` python310Packages.spyder: 5.4.0 -> 5.4.1 ``                                    |
| [`e0293da5`](https://github.com/NixOS/nixpkgs/commit/e0293da51a023e3a59b158fd7571057759e4cfb4) | `` python310Packages.python-lsp-server: update postPatch section ``               |
| [`9e9a824a`](https://github.com/NixOS/nixpkgs/commit/9e9a824a70dcb686f7c856ca868187d1be21608e) | `` nix-index: unstable-2022-03-07 -> unstable-2023-01-03 ``                       |
| [`68fa297b`](https://github.com/NixOS/nixpkgs/commit/68fa297be751a6854526ec5c773d1133a695c1e5) | `` python310Packages.mat2: 0.13.0 -> 0.13.1 ``                                    |
| [`c3bb25b4`](https://github.com/NixOS/nixpkgs/commit/c3bb25b47987086516ad4d87f154e474a20978d8) | `` libxlsxwriter: 1.1.4 -> 1.1.5 ``                                               |
| [`d744fdba`](https://github.com/NixOS/nixpkgs/commit/d744fdbab93b048ec24cc7baf7598618d0eb9d3b) | `` python310Packages.polars: 0.13.19 -> 0.15.13: Fix compilation error ``         |
| [`671064a7`](https://github.com/NixOS/nixpkgs/commit/671064a7bfc903bb3475b9dd066da526ec89c52e) | `` klipper: unstable-2022-11-21 -> unstable-2023-01-07 ``                         |
| [`9957ee5f`](https://github.com/NixOS/nixpkgs/commit/9957ee5fd689792ff18194bec2a4bc7f4db70d61) | `` darwin: add usage to generate-sdk-packages.sh ``                               |
| [`2bd3048e`](https://github.com/NixOS/nixpkgs/commit/2bd3048ea4148d9288bbd74bbdf453520c7d78f4) | `` darwin: fix generate-sdk-packages.sh ``                                        |
| [`b199b821`](https://github.com/NixOS/nixpkgs/commit/b199b821c2986ea5ee5e1eb0e2d4baa4ddba1232) | `` nixos/grafana: fix spelling ``                                                 |
| [`46950548`](https://github.com/NixOS/nixpkgs/commit/469505483b6097c23ad3aaaeecbd82bea5b696e7) | `` Fix editorconfig-checker… really annoying on trailing whitespace ``            |
| [`72f79812`](https://github.com/NixOS/nixpkgs/commit/72f79812e5fee3e2c12fa3cd107e329b14b6a01f) | `` Glaxnimate: fix tester ``                                                      |
| [`3be80fbf`](https://github.com/NixOS/nixpkgs/commit/3be80fbf1fc961a7e1cd142bbfdb4edb2f3b5553) | `` Glaxnimate: fix plugins and export to gif ``                                   |
| [`d243b132`](https://github.com/NixOS/nixpkgs/commit/d243b132ad7f1bc2d9afd8b114bf2be2025df68f) | `` Update pkgs/applications/video/glaxnimate/default.nix ``                       |
| [`8b1d3a6d`](https://github.com/NixOS/nixpkgs/commit/8b1d3a6d140c668d4606eb171320a4ba265c606f) | `` Update pkgs/applications/video/glaxnimate/default.nix ``                       |
| [`dfb582da`](https://github.com/NixOS/nixpkgs/commit/dfb582daa7d8b3df6fbeb2c93b0f0776f9858156) | `` Update pkgs/applications/video/glaxnimate/default.nix ``                       |
| [`e8b763c9`](https://github.com/NixOS/nixpkgs/commit/e8b763c9dbed917b9a964413dc40a51b58b03c09) | `` Update pkgs/applications/video/glaxnimate/default.nix ``                       |
| [`5de5cf5a`](https://github.com/NixOS/nixpkgs/commit/5de5cf5a919a560c8c81a066e9bfbcd745e149c3) | `` Update pkgs/applications/video/glaxnimate/default.nix ``                       |
| [`424150e0`](https://github.com/NixOS/nixpkgs/commit/424150e011692d321da3a8194b3acad2997e5ff7) | `` Update pkgs/applications/video/glaxnimate/default.nix ``                       |
| [`517c6617`](https://github.com/NixOS/nixpkgs/commit/517c661748cb409f90d24f701d3bef15308aa618) | `` minor change ``                                                                |
| [`92cbb320`](https://github.com/NixOS/nixpkgs/commit/92cbb320902ed6953a2fb9d001c88670711d9c3e) | `` Glaxnimate: init at 0.5.1 ``                                                   |
| [`bfdd2f6b`](https://github.com/NixOS/nixpkgs/commit/bfdd2f6bfd57502d2b28dcd8897887e05e24d7a6) | `` python3Packages.imageio: 2.23.0 -> 2.24.0 ``                                   |
| [`4102f23e`](https://github.com/NixOS/nixpkgs/commit/4102f23e2d602e81cef029e236c503c56ee085ad) | `` luaPackages.plenary-nvim: 2022-10 -> 2023-01 ``                                |
| [`3078c90a`](https://github.com/NixOS/nixpkgs/commit/3078c90a6eecf118edcd822ecf819df4368a9e7f) | `` python310Packages.spyder-kernels: 2.4.0 -> 2.4.1 ``                            |
| [`dd8026d8`](https://github.com/NixOS/nixpkgs/commit/dd8026d8d5323fd75b298a0418b052f3e16bfdf7) | `` python310Packages.pytoolconfig: init at 1.2.5 ``                               |
| [`c3374273`](https://github.com/NixOS/nixpkgs/commit/c3374273d72546214c1d2a9161d4289baa424ceb) | `` python310Packages.python-lsp-server: 1.6.0 -> 1.7.0 ``                         |
| [`55f9c51b`](https://github.com/NixOS/nixpkgs/commit/55f9c51b62c2f06d2ae7dd4038b1b4536cba47ff) | `` python310Packages.rope: 0.18.0 -> 1.6.0 ``                                     |
| [`df161564`](https://github.com/NixOS/nixpkgs/commit/df161564b52916bfd578138703dac6b7ccea6008) | `` python310Packages.peaqevcore: 10.1.4 -> 10.2.6 ``                              |
| [`91bdfd45`](https://github.com/NixOS/nixpkgs/commit/91bdfd4592afee9df43cb334c4e051c8a0c5d41a) | `` python310Packages.rope: add changelog to meta ``                               |
| [`2f846f43`](https://github.com/NixOS/nixpkgs/commit/2f846f433216234d4d46aff3cc7b34fd77e70b48) | `` python310Packages.python-lsp-server: add changelog to meta ``                  |
| [`72b56e4b`](https://github.com/NixOS/nixpkgs/commit/72b56e4b75cd9f6e75a8f872d93df2bf64f6a1dd) | `` python310Packages.uritools: add changelog to meta ``                           |
| [`f2769fae`](https://github.com/NixOS/nixpkgs/commit/f2769faef69d803d4a66d1ceafcee769a05d59d7) | `` python310Packages.gcal-sync: 4.1.0 -> 4.1.1 ``                                 |
| [`422c9ff8`](https://github.com/NixOS/nixpkgs/commit/422c9ff8178b1b1c2a2602a03c89b35081799247) | `` python310Packages.ical: 4.2.8 -> 4.2.9 ``                                      |
| [`705e1459`](https://github.com/NixOS/nixpkgs/commit/705e1459a98455e08b25a3f5b286cf24e3996471) | `` python310Packages.motioneye-client: 0.3.12 -> 0.3.14 ``                        |
| [`bd979e54`](https://github.com/NixOS/nixpkgs/commit/bd979e542d420ee2d3f060b5e0635faa7dc20b68) | `` python310Packages.pysoma: 0.0.11 -> 0.0.12 ``                                  |
| [`f40e876b`](https://github.com/NixOS/nixpkgs/commit/f40e876bad1e5e8f774d51c393a931b6c028e4b5) | `` python310Packages.pysolcast: 1.0.12 -> 1.0.13 ``                               |
| [`40425f64`](https://github.com/NixOS/nixpkgs/commit/40425f64e2a9968e59896a72f93a355a46e9cb1e) | `` python310Packages.pysolcast: add changelog to meta ``                          |
| [`20f9114b`](https://github.com/NixOS/nixpkgs/commit/20f9114b0269b8be96e7f74ee9f706e6c2b516e0) | `` python310Packages.pylitterbot: 2022.12.0 -> 2023.1.0 ``                        |
| [`e8efaf4a`](https://github.com/NixOS/nixpkgs/commit/e8efaf4a088f29f6fe707d48b62f2592a9107159) | `` python310Packages.meshtastic: 2.0.8 -> 2.0.9 ``                                |
| [`5693944d`](https://github.com/NixOS/nixpkgs/commit/5693944d8c439d71e78d28c55449cba7a189b817) | `` python310Packages.aioridwell: 2022.11.0 -> 2023.01.0 ``                        |
| [`93beab46`](https://github.com/NixOS/nixpkgs/commit/93beab46a47623fed24ae1050c51353e191126d3) | `` python310Oackages.aioridwell: add changelog to meta ``                         |
| [`c750dc1a`](https://github.com/NixOS/nixpkgs/commit/c750dc1a80b31bc1d5af22c844a2b1a7d9777a27) | `` stylish: fix issue NixOS#209708 missing dependencies ``                        |
| [`a17ebb2d`](https://github.com/NixOS/nixpkgs/commit/a17ebb2dfe0fd7a7a6a014318aa3937226764923) | `` colloid-icon-theme: 2022-10-26 -> 2023-01-08 ``                                |
| [`6448ff1d`](https://github.com/NixOS/nixpkgs/commit/6448ff1db20494605888cda350b4f666768cab70) | `` python310Packages.pastescript: disable on unsupported Python releases ``       |
| [`71980951`](https://github.com/NixOS/nixpkgs/commit/719809517df4cf2acceabaad6952c89c3d2ce3b9) | `` ocamlPackages.toml: 7.0.0 → 7.1.0 ``                                           |
| [`81e0a351`](https://github.com/NixOS/nixpkgs/commit/81e0a35156362b1282b61d5e62fcb5b0d6703180) | `` invidious: unstable-2022-11-22 -> unstable-2023-01-08 ``                       |
| [`27ee79c3`](https://github.com/NixOS/nixpkgs/commit/27ee79c38b502bd97da7e30f3ab99a4bdc8306ff) | `` python310Packages.minio: add changelog to meta ``                              |
| [`54611edc`](https://github.com/NixOS/nixpkgs/commit/54611edcc3a02846130551a86897ac5356728139) | `` python310Packages.notify-py: add changelog to meta ``                          |
| [`247090ac`](https://github.com/NixOS/nixpkgs/commit/247090ac0d70f6739d51bda4aca25a59818ac939) | `` python310Packages.uritools: 4.0.0 -> 4.0.1 ``                                  |
| [`c25ead45`](https://github.com/NixOS/nixpkgs/commit/c25ead4522cc3d4d4985027b9db209f579fe6152) | `` python310Packages.soco: add changelog to meta ``                               |
| [`6414a51b`](https://github.com/NixOS/nixpkgs/commit/6414a51b275104de8da77942359f47ce5a80f5f2) | `` python310Packages.doorbirdpy: disable on unsupported Python releases ``        |
| [`164e802e`](https://github.com/NixOS/nixpkgs/commit/164e802e026dc3630fa8daab499604610da023e2) | `` ananicy-cpp: 1.0.1 -> 1.0.2 ``                                                 |
| [`dbfe3bd2`](https://github.com/NixOS/nixpkgs/commit/dbfe3bd2e70ba58935497cf32142981a6c82561e) | `` kasmweb: init at 1.12.0 ``                                                     |
| [`c971f278`](https://github.com/NixOS/nixpkgs/commit/c971f278c30013fd3d20307eb5703d7697694904) | `` tere: 1.3.1 -> 1.4.0 ``                                                        |
| [`3ecc2377`](https://github.com/NixOS/nixpkgs/commit/3ecc2377e39528c6c31304b3e76082c50459828e) | `` python310Packages.pyswitchbot: 0.36.2 -> 0.36.3 ``                             |
| [`cd3bb943`](https://github.com/NixOS/nixpkgs/commit/cd3bb943a06f66a0630d0cf3ed793af3f726f9db) | `` werf: 1.2.193 -> 1.2.195 ``                                                    |
| [`d129e434`](https://github.com/NixOS/nixpkgs/commit/d129e434bae2d5734bc2559e66abfe4577e6199b) | `` acpica-tools: 20220331 → 20221020 ``                                           |
| [`ecab3ede`](https://github.com/NixOS/nixpkgs/commit/ecab3edeb79a5257974d24acd04e5c9b3c245e6c) | `` top-level: move top-level {build,host,target}Platform to aliases ``            |
| [`88633b14`](https://github.com/NixOS/nixpkgs/commit/88633b14ed1ba87eba77619548f458719d5b9baf) | `` python310Packages.notify-py: 0.3.38 -> 0.3.39 ``                               |
| [`a227a506`](https://github.com/NixOS/nixpkgs/commit/a227a506eceb9a80ebfff434efce5d2a519bdab6) | `` seaweedfs: 3.38 -> 3.39 ``                                                     |
| [`8dbd5278`](https://github.com/NixOS/nixpkgs/commit/8dbd527896d02f22231fe907f7d80676fc5e4a28) | `` python310Packages.doorbirdpy: 2.1.0 -> 2.2.0 ``                                |
| [`d2b675a9`](https://github.com/NixOS/nixpkgs/commit/d2b675a9cbf3c9d5021d31cf8d7918017a29dd53) | `` oh-my-posh: 12.26.2 -> 12.35.2 ``                                              |
| [`c7dc63c2`](https://github.com/NixOS/nixpkgs/commit/c7dc63c27f3382558246332cb00259e294558c70) | `` difftastic: 0.40.0 -> 0.41.0 ``                                                |
| [`60445aa4`](https://github.com/NixOS/nixpkgs/commit/60445aa40e5b4c46792f6d1fe4355f09a105b735) | `` libsForQt5.qca-qt5: unbreak on darwin ``                                       |
| [`f3a396db`](https://github.com/NixOS/nixpkgs/commit/f3a396db6d481ef718bb118228cee50e1393a4f1) | `` retry: 1.0.4 -> 1.0.5 ``                                                       |
| [`56103f5f`](https://github.com/NixOS/nixpkgs/commit/56103f5f70bdc38e459a6f7c033809446b7fd7d3) | `` nixos/tests/evcc: Ignore ERROR level messages ``                               |
| [`2e60a420`](https://github.com/NixOS/nixpkgs/commit/2e60a42033aad56148cc9ee3d9aac75763267330) | `` evcc: 0.109.2 -> 0.110.1 ``                                                    |
| [`6601a42c`](https://github.com/NixOS/nixpkgs/commit/6601a42cf34cf318079c708f497261a080ed340b) | `` byacc: 20221106 -> 20221229 ``                                                 |
| [`9245a182`](https://github.com/NixOS/nixpkgs/commit/9245a1823677392444c52b8f9cdd83790342d692) | `` youki: init at 0.0.4 ``                                                        |
| [`9696ca8f`](https://github.com/NixOS/nixpkgs/commit/9696ca8fd9973a243f2a379ba8da82b4b706b4f0) | `` isso: unbreak on aarch64-darwin ``                                             |