### PR TITLE
chore(flake/nixpkgs): `c07552f6` -> `6c8644fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673315479,
-        "narHash": "sha256-GNCFRtDHjTygXGJp/H+f2XQPMGxpYSmNiibIqYzihtM=",
+        "lastModified": 1673450908,
+        "narHash": "sha256-b8em+kwrNtnB7gR8SyVf6WuTyQ+6tHS6dzt9D9wgKF0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c07552f6f7d4eead7806645ec03f7f1eb71ba6bd",
+        "rev": "6c8644fc37b6e141cbfa6c7dc8d98846c4ff0c2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`6c8644fc`](https://github.com/NixOS/nixpkgs/commit/6c8644fc37b6e141cbfa6c7dc8d98846c4ff0c2e) | `` ath9k-htc-blobless-firmware: fix evaluation with Nix 2.3 ``          |
| [`29953436`](https://github.com/NixOS/nixpkgs/commit/299534368c59c0fa04eb6f597614cad1edcfab3a) | `` spicedb-zed: 0.4.4 -> 0.7.5 ``                                       |
| [`2ff33610`](https://github.com/NixOS/nixpkgs/commit/2ff336107f66ce6c3f89eb36d0b7492b1b9d3c2a) | `` coder: 0.13.3 -> 0.13.6 ``                                           |
| [`28c7ef7f`](https://github.com/NixOS/nixpkgs/commit/28c7ef7f77ad00cf37886d5dde8d9dbe3806d321) | `` rust-analyzer-unwrapped: 2022-12-26 -> 2023-01-09 ``                 |
| [`daef14ab`](https://github.com/NixOS/nixpkgs/commit/daef14ab647c801f395bfcf82be87403c00fcba4) | `` carapace: 0.18.1 -> 0.19.1 ``                                        |
| [`93bc27af`](https://github.com/NixOS/nixpkgs/commit/93bc27af382377635c6f52e215cef976b8dc3426) | `` argocd-autopilot: 0.4.8 -> 0.4.9 ``                                  |
| [`61305872`](https://github.com/NixOS/nixpkgs/commit/61305872f6675c0368e50a819b394b26ba1811da) | `` python3Packages.django-scim2: fix use of deprecated aliases ``       |
| [`24322a75`](https://github.com/NixOS/nixpkgs/commit/24322a7583324af031d3a1bb3a4486dec4c2ed52) | `` python310Packages.google-cloud-resource-manager: 1.7.0 -> 1.8.0 ``   |
| [`635b6df9`](https://github.com/NixOS/nixpkgs/commit/635b6df9aec4e8a70ed0761483bc328cebce86d4) | `` python310Packages.mypy-boto3-builder: 7.12.2 -> 7.12.3 ``            |
| [`cd809740`](https://github.com/NixOS/nixpkgs/commit/cd809740e38c49f8acb4998f8a4ddfef81c92c31) | `` python310Packages.hahomematic: 2023.1.0 -> 2023.1.2 ``               |
| [`96575db0`](https://github.com/NixOS/nixpkgs/commit/96575db0292a1e14e822361a3dc72564446bc13a) | `` python310Packages.plugwise: 0.27.1 -> 0.27.2 ``                      |
| [`fe68f0bc`](https://github.com/NixOS/nixpkgs/commit/fe68f0bc37e513edb8b04804ce647d29f6eb5347) | `` python310Packages.google-cloud-datacatalog: 3.10.0 -> 3.11.0 ``      |
| [`9fa8ace0`](https://github.com/NixOS/nixpkgs/commit/9fa8ace074c76523ae98604067b32787c5a3a70b) | `` python310Packages.google-cloud-asset: 3.14.2 -> 3.16.0 ``            |
| [`a2316343`](https://github.com/NixOS/nixpkgs/commit/a231634393af91b2f1e113ed7cb8019763b6b100) | `` unifi-protect-backup: switch to pythonRelaxDepsHook ``               |
| [`abbb7c53`](https://github.com/NixOS/nixpkgs/commit/abbb7c533718e9bc918845a31a87e846847060f5) | `` python310Packages.aiosqlite: 0.17.0 -> 0.18.0 ``                     |
| [`d9e229a3`](https://github.com/NixOS/nixpkgs/commit/d9e229a3af383ec75453b6cfe57bc73816d15d9a) | `` python310Packages.aiosqlite: add changelog to meta ``                |
| [`c3b9f223`](https://github.com/NixOS/nixpkgs/commit/c3b9f2238fbc7a396e516e93e5fc3e8ee2fbc8b2) | `` dumb-init: fix dynamic compilation (#210030) ``                      |
| [`4e9e5aea`](https://github.com/NixOS/nixpkgs/commit/4e9e5aeafeb41f780932097b6935087793b0ce06) | `` spyder: add patch fix startup error ``                               |
| [`290df59e`](https://github.com/NixOS/nixpkgs/commit/290df59e84517eae482a0c6b2dc47f44f82f3f3a) | `` coqPackages_8_13.smtcoq: fix build by using older make ``            |
| [`670a7823`](https://github.com/NixOS/nixpkgs/commit/670a782340f72208b5b5f79c9a72987206ac9967) | `` coqPackages_8_13.smtcoq.cvc4: fix build by using older make ``       |
| [`b2a819f1`](https://github.com/NixOS/nixpkgs/commit/b2a819f15f3165c08b5902692cfdd058a7e019b3) | `` nixos/kernel: fix docs typo ``                                       |
| [`175396e7`](https://github.com/NixOS/nixpkgs/commit/175396e77d8889ad6848f6e85030129241d22f13) | `` marksman: don't use deprecated alias ``                              |
| [`7148e613`](https://github.com/NixOS/nixpkgs/commit/7148e613d5a3e36f0a5bd0a7d564cac33724de74) | `` ocamlPackages.tar: 2.0.1 → 2.2.2 (#209021) ``                        |
| [`9089ee17`](https://github.com/NixOS/nixpkgs/commit/9089ee1796b8d331d6ddfcb077e8ab0a9fea0288) | `` {libsForQt5.kpmcore,partition-manager}: * -> 22.12.1 ``              |
| [`09696eab`](https://github.com/NixOS/nixpkgs/commit/09696eab5da6dd3769de874ee7f02f5c2a26b279) | `` onedrive: 2.4.22 -> 2.4.23 ``                                        |
| [`6b6acf13`](https://github.com/NixOS/nixpkgs/commit/6b6acf136a2ad2e13c1f0f70eb5943e14c305812) | `` jpeginfo: 1.6.1 -> 1.6.2 ``                                          |
| [`6cb0f3d7`](https://github.com/NixOS/nixpkgs/commit/6cb0f3d70ba06cff5e7f47fd5134b17c89c90291) | `` roslyn: update dependencies ``                                       |
| [`3dde9cb5`](https://github.com/NixOS/nixpkgs/commit/3dde9cb571a2d3632906ebbcb98eadb539c44688) | `` jackett: 0.20.2395 -> 0.20.2608 ``                                   |
| [`177e2f3b`](https://github.com/NixOS/nixpkgs/commit/177e2f3b86746f0312a151d2f3789a35a00c80b3) | `` dotnet-sdk_6.0: 6.0.403 -> 6.0.405 ``                                |
| [`71a885bf`](https://github.com/NixOS/nixpkgs/commit/71a885bf3ba24482a1c582033071a0fc9d71d6d7) | `` terraform-providers.snowflake: 0.54.0 → 0.55.0 ``                    |
| [`83c0d036`](https://github.com/NixOS/nixpkgs/commit/83c0d03629b578cb95c438e472e02206788e503a) | `` terraform-providers.sentry: 0.11.0 → 0.11.1 ``                       |
| [`52f882b4`](https://github.com/NixOS/nixpkgs/commit/52f882b4eb0bf1b5065eea40ef82922131eea5b5) | `` terraform-providers.newrelic: 3.11.0 → 3.12.0 ``                     |
| [`4aa7abe2`](https://github.com/NixOS/nixpkgs/commit/4aa7abe2a28627262fbbc1cf09baacda74816139) | `` terraform-providers.cloudflare: 3.31.0 → 3.32.0 ``                   |
| [`3cd1bd58`](https://github.com/NixOS/nixpkgs/commit/3cd1bd588842b11521ecc7950dad884137b6c97b) | `` nixos/tests/gitlab: Fix a regression introduced in 15.7.0 ``         |
| [`4d41c371`](https://github.com/NixOS/nixpkgs/commit/4d41c371d47bc7f3d20403788bc43793d7c930a2) | `` gitlab: 15.6.2 -> 15.7.2 ``                                          |
| [`52a9d9ad`](https://github.com/NixOS/nixpkgs/commit/52a9d9ad3914dc089d100d3111bb9ad18c801f14) | `` cbqn: fix output on non-Linux platforms ``                           |
| [`67596b5b`](https://github.com/NixOS/nixpkgs/commit/67596b5b194c8540ab2d628710bec5e7b9a18801) | `` home-assistant: 2023.1.2 -> 2023.1.3 ``                              |
| [`45965d9d`](https://github.com/NixOS/nixpkgs/commit/45965d9d47e4ef64cb451089e15cc884cccf19ce) | `` python310Packages.pyunifiprotect: 4.6.0 -> 4.6.1 ``                  |
| [`2f2a2a70`](https://github.com/NixOS/nixpkgs/commit/2f2a2a708509f666a35cc1115adacb287f3cf153) | `` python3Packages.pyopenuv: 2022.10.0 -> 2023.01.0 ``                  |
| [`8ccc4426`](https://github.com/NixOS/nixpkgs/commit/8ccc44260538f9ae98506ff864869dee0f832006) | `` python3Packages.gcal-sync: 4.1.1 -> 4.1.2 ``                         |
| [`eca8f332`](https://github.com/NixOS/nixpkgs/commit/eca8f332a1e15f1a9636379d6656ba7824b355af) | `` python3Packages.hatasmota: 0.6.2 -> 0.6.3 ``                         |
| [`15e2b2e3`](https://github.com/NixOS/nixpkgs/commit/15e2b2e3f0ccc8b70e00eb1e674e10a3171b25eb) | `` qgnomeplatform: fix qt5 build ``                                     |
| [`b0644b46`](https://github.com/NixOS/nixpkgs/commit/b0644b461f97d4f7240b089074084c18f521f497) | `` clusterctl: 1.3.1 -> 1.3.2 ``                                        |
| [`478ce8c1`](https://github.com/NixOS/nixpkgs/commit/478ce8c1e31ed88e01fb404f812ede807ab3ce3f) | `` nurl: 0.3.3 -> 0.3.4 ``                                              |
| [`441c9277`](https://github.com/NixOS/nixpkgs/commit/441c9277efa16c3cc55e002ffe5bddac833ee32b) | `` antic: init at 0.2.5 ``                                              |
| [`aa478e28`](https://github.com/NixOS/nixpkgs/commit/aa478e283bb5c73b2cdd2f891251f0d669517b63) | `` janet: 1.25.1 -> 1.26.0 ``                                           |
| [`bc9dd427`](https://github.com/NixOS/nixpkgs/commit/bc9dd4279a053486428e6dbc6ac48d20b537a53f) | `` strawberry: 1.0.11 -> 1.0.12 ``                                      |
| [`ae50f067`](https://github.com/NixOS/nixpkgs/commit/ae50f0678abca7544308a3337b7f7ede5948c8a1) | `` Revert "bazel_6: 6.0.0-pre.20220720.3 -> 6.0.0" ``                   |
| [`f851fbc1`](https://github.com/NixOS/nixpkgs/commit/f851fbc19fa22fc010cf44c5f03bbb23464cdf40) | `` changedetection-io: remove podman.defaultNetwork.dnsname.enable ``   |
| [`d21017b0`](https://github.com/NixOS/nixpkgs/commit/d21017b0d6c8129edb21ac7eeb855bf6c068d037) | `` remmina: 1.4.28 -> 1.4.29 ``                                         |
| [`39a0eed4`](https://github.com/NixOS/nixpkgs/commit/39a0eed453314e1687db79cd0d0dc2ecbd872525) | `` python310Packages.claripy: adjust inputs ``                          |
| [`95e942aa`](https://github.com/NixOS/nixpkgs/commit/95e942aa8db6c2737840521ae99c79a13a643289) | ``  python310Packages.precis-i18n: add changelog to meta ``             |
| [`b6fbf014`](https://github.com/NixOS/nixpkgs/commit/b6fbf0143acb804f080c438614a5eadcbd4226e2) | `` python310Packages.precis-i18n: 1.0.4 -> 1.0.5 ``                     |
| [`56f69696`](https://github.com/NixOS/nixpkgs/commit/56f69696546ac65d19572271e2b87b4a32a2631c) | `` python310Packages.angr: 9.2.32 -> 9.2.33 ``                          |
| [`ff64d349`](https://github.com/NixOS/nixpkgs/commit/ff64d349b6cc0935c4a397543b0d6ca8dc931ddb) | `` python310Packages.cle: 9.2.32 -> 9.2.33 ``                           |
| [`d5dc370f`](https://github.com/NixOS/nixpkgs/commit/d5dc370ff217617add282c194b3861e3ea41a129) | `` python310Packages.claripy: 9.2.32 -> 9.2.33 ``                       |
| [`d7162909`](https://github.com/NixOS/nixpkgs/commit/d71629096b80c91b04e6d5c0a25a9c6d7a24c7c3) | `` python310Packages.pyvex: 9.2.32 -> 9.2.33 ``                         |
| [`ee8cafa8`](https://github.com/NixOS/nixpkgs/commit/ee8cafa8fbca5b7ca6dba906e82db73a16155f0a) | `` python310Packages.ailment: 9.2.32 -> 9.2.33 ``                       |
| [`32a48c30`](https://github.com/NixOS/nixpkgs/commit/32a48c3038842612c6c76fbf8c10c21c74ab3f9c) | `` python310Packages.archinfo: 9.2.32 -> 9.2.33 ``                      |
| [`5e6aa0aa`](https://github.com/NixOS/nixpkgs/commit/5e6aa0aa4594679a45e400d4f97fbc1259cb5eee) | `` python310Packages.adafruit-platformdetect: 3.38.0 -> 3.39.0 ``       |
| [`cd1c574e`](https://github.com/NixOS/nixpkgs/commit/cd1c574ebe7297c6cb5d21ba0deb7acf5119d766) | `` nixos/kernel: better docs for boot.kernelPatches ``                  |
| [`ca017501`](https://github.com/NixOS/nixpkgs/commit/ca0175017d980c74341cab3e1977b19a2f80bfd0) | `` waagent: update to 2.8.0.11 (#206974) ``                             |
| [`d3a307c8`](https://github.com/NixOS/nixpkgs/commit/d3a307c813cbd209fe1e13ac9246b3fa3ea93c12) | `` assimp: 5.1.3 → 5.2.5 ``                                             |
| [`428bf8fa`](https://github.com/NixOS/nixpkgs/commit/428bf8fa445433e955264b8b44d84e86f6cc6ba8) | `` nix-index-unwrapped: unstable-2023-01-03 -> 0.1.3 ``                 |
| [`2be4208f`](https://github.com/NixOS/nixpkgs/commit/2be4208f0c88e32038b3343713b8f1732c2a69c3) | `` zq: 1.3.0 -> 1.4.0 ``                                                |
| [`322b0f60`](https://github.com/NixOS/nixpkgs/commit/322b0f6046aaf722cced6f34e497707a1ed00a8e) | `` ssh-to-age: 1.1.0 -> 1.1.1 ``                                        |
| [`2249e45a`](https://github.com/NixOS/nixpkgs/commit/2249e45a400e43cb620ce7464e44727e38463a6f) | `` gqrx: build with qt6 ``                                              |
| [`a470682d`](https://github.com/NixOS/nixpkgs/commit/a470682d7d4fec5a50682acf84b6e3423f80b161) | `` atlantis: 0.21.0 -> 0.22.2 ``                                        |
| [`a1cdb52f`](https://github.com/NixOS/nixpkgs/commit/a1cdb52f4a26aa1cc5ef60f0bf4535510aa3f6a5) | `` vimPlugins.nvim-treesitter.builtGrammars.http: fix build ``          |
| [`ead13cf3`](https://github.com/NixOS/nixpkgs/commit/ead13cf337e572b81775a47c6c5b96f1c3010d2c) | `` thunderbird-bin: 102.6.0 -> 102.6.1 ``                               |
| [`46d6a8f0`](https://github.com/NixOS/nixpkgs/commit/46d6a8f05bafb5b260324ccb40c7221bb11faa29) | `` barman: 3.1.0 -> 3.3.0 ``                                            |
| [`03aec194`](https://github.com/NixOS/nixpkgs/commit/03aec194125de1fd6f486d323cee872bb4be88cc) | `` sdrangel: 7.8.3 -> 7.8.5 (#204571) ``                                |
| [`0c3516ed`](https://github.com/NixOS/nixpkgs/commit/0c3516ed926e0d0b5c891e09ad70d9e2130c68c7) | `` mdbook-pdf: add changelog to meta ``                                 |
| [`dea4433a`](https://github.com/NixOS/nixpkgs/commit/dea4433ac6fb19920cf929c5ef087a361d41f9a2) | `` gore: 0.5.5 -> 0.5.6 ``                                              |
| [`2ce07e40`](https://github.com/NixOS/nixpkgs/commit/2ce07e407808c39c649a1edf92ccb34c730a6e46) | `` auth0-cli: add changelog to meta ``                                  |
| [`42bb1114`](https://github.com/NixOS/nixpkgs/commit/42bb111451b88d23cf6361bf5c522985401b4f9b) | `` macchina: update rev ``                                              |
| [`8e6b892e`](https://github.com/NixOS/nixpkgs/commit/8e6b892e320138662c523bd92bf75409a257a327) | `` fastddsgen: 2.2.0 -> 2.3.0 ``                                        |
| [`df2c8fdf`](https://github.com/NixOS/nixpkgs/commit/df2c8fdf58fdd97134f1974befefeed315cfcbeb) | `` k40-whisperer: 0.60 -> 0.62 ``                                       |
| [`adccc873`](https://github.com/NixOS/nixpkgs/commit/adccc873110bbabe71d95d29bb69e54302dbd432) | `` auth0-cli: 0.11.10 -> 0.13.1 ``                                      |
| [`c8bc2f2c`](https://github.com/NixOS/nixpkgs/commit/c8bc2f2c0d4abafe71132097976380e59d14c7c8) | `` bazel_5: 5.3.2 -> 5.4.0 ``                                           |
| [`ebd12da2`](https://github.com/NixOS/nixpkgs/commit/ebd12da21f28ed3039f7ac9c868de165e141e99e) | `` supabase-cli: 1.27.7 -> 1.29.3 ``                                    |
| [`cd51db67`](https://github.com/NixOS/nixpkgs/commit/cd51db6754839e7bae600e57b25ca7cbb19f402e) | `` awscli2: 2.9.11 -> 2.9.13 ``                                         |
| [`4c8cbd8e`](https://github.com/NixOS/nixpkgs/commit/4c8cbd8e0f732e649ed0dd6ba39286a078f0581b) | `` macchina: 6.1.6 -> 6.1.7 ``                                          |
| [`f91681ea`](https://github.com/NixOS/nixpkgs/commit/f91681eafe76c03464c0db8c2034c55f8c6d849f) | `` fastly: 4.5.0 -> 4.6.1 ``                                            |
| [`5212a5c2`](https://github.com/NixOS/nixpkgs/commit/5212a5c2404350723263823e4eb316eaa33f14f4) | `` okteto: 2.10.3 -> 2.11.0 ``                                          |
| [`c6196a22`](https://github.com/NixOS/nixpkgs/commit/c6196a22c84c2581fedbff48e69050bae96cdedd) | `` wabt: 1.0.31 -> 1.0.32 ``                                            |
| [`60164ab8`](https://github.com/NixOS/nixpkgs/commit/60164ab87bb4270ba6728690b5be03e988f48988) | `` cbmc: mark as broken on aarch64-linux ``                             |
| [`b88ca1e7`](https://github.com/NixOS/nixpkgs/commit/b88ca1e7162650afca8d8e6749b99de8b82cd9b9) | `` process-compose: 0.29.1 -> 0.29.7 ``                                 |
| [`f4228593`](https://github.com/NixOS/nixpkgs/commit/f422859340a4a93ab298096044e867b1a5a1e432) | `` mdbook-pdf: 0.1.3 -> 0.1.4 ``                                        |
| [`9c9c1bc9`](https://github.com/NixOS/nixpkgs/commit/9c9c1bc9a91da132c9fb3bfbc9c49d821f8eb75c) | `` python3Packages.django-import-export: add changelog to meta ``       |
| [`9086b530`](https://github.com/NixOS/nixpkgs/commit/9086b530ff84990bb73ac7341f10219ffb4dff47) | `` python310Packages.django-phonenumber-field: add changelog to meta `` |
| [`62fd1cca`](https://github.com/NixOS/nixpkgs/commit/62fd1ccad15eacbb610c90697817857bbffdc9cb) | `` icingaweb2: 2.11.1 -> 2.11.3 ``                                      |
| [`185fb1f8`](https://github.com/NixOS/nixpkgs/commit/185fb1f8e0889008ab5be1147832333c63bf7f74) | `` icingaweb2-ipl: 0.10.0 -> 0.10.1 ``                                  |
| [`51d51889`](https://github.com/NixOS/nixpkgs/commit/51d51889b1970ad749ad36d2d6c85ed0b5feae1c) | `` vscode-extensions.james-yu.latex-workshop: 9.2.1 -> 9.4.4 ``         |
| [`a2571416`](https://github.com/NixOS/nixpkgs/commit/a25714161ad5056831c8c9fc66a960626405574c) | `` dialect: 2.0.2 -> 2.1.1 (#197230) ``                                 |
| [`7e5d00e0`](https://github.com/NixOS/nixpkgs/commit/7e5d00e0ec5ec4e516c4357aa769d4412612df5a) | `` python310Packages.pytest-base-url: add changelog to meta ``          |
| [`342848bb`](https://github.com/NixOS/nixpkgs/commit/342848bb592289e71aa30c97b0f2e2da229a5344) | `` python3Packages.pytest-playwright: add changelog to meta ``          |
| [`71a7045b`](https://github.com/NixOS/nixpkgs/commit/71a7045b3bf34713c9a18268995ddcc16ad32065) | `` python3Packages.django-admin-sortable2: add changelog to meta ``     |
| [`041b044a`](https://github.com/NixOS/nixpkgs/commit/041b044a663a52e1c885c00496b44c5ba5982597) | `` lib/path/tests: Fix property tests when "-n" is generated ``         |
| [`7d4e95ba`](https://github.com/NixOS/nixpkgs/commit/7d4e95ba7527fa7bd5b1f8a1707b7e3ee2bbe82d) | `` polybar: Remove i3-gaps support ``                                   |
| [`38334be6`](https://github.com/NixOS/nixpkgs/commit/38334be6a955bc9d8908543b608d43257d48e89e) | `` python310Packages.django-vite: add changelog to meta ``              |
| [`3f360772`](https://github.com/NixOS/nixpkgs/commit/3f3607724fbe3adbcc7a4142f3224bef73357eed) | `` python3Packages.django-rest-registration: add changelog to meta ``   |
| [`dfa3f144`](https://github.com/NixOS/nixpkgs/commit/dfa3f1449343738c8a5c261cc0770bd74a2cfdb5) | `` cc-wrapper: -march= is not allowed on powerpc ``                     |
| [`ad92b19e`](https://github.com/NixOS/nixpkgs/commit/ad92b19e362ce0be181c616e8c528e571c38926d) | `` glaxnimate: disable failing integration test on darwin ``            |
| [`a2e21c76`](https://github.com/NixOS/nixpkgs/commit/a2e21c76c7d31d8f54a564c49ad3ef54d76fc1e4) | `` rename config.qt5 -> config.qt ``                                    |
| [`16f0d689`](https://github.com/NixOS/nixpkgs/commit/16f0d689deae07f24967d0ab95c014d6d3a317a4) | `` Add gnome theme for qt6 ``                                           |
| [`c6588f1c`](https://github.com/NixOS/nixpkgs/commit/c6588f1cb55770e31b20f12ec8faaaf990e86424) | `` jmol: 14.32.76 -> 14.32.83 ``                                        |
| [`00b56427`](https://github.com/NixOS/nixpkgs/commit/00b56427d392a6f34f03cc6d2f4945bc8ea29822) | `` ea: Fix pname ``                                                     |
| [`12aaafe9`](https://github.com/NixOS/nixpkgs/commit/12aaafe9ebad4c65c5236ad9cfb29f1649894eec) | `` python310Packages.persistent: 4.9.3 -> 5.0 ``                        |
| [`a37c741a`](https://github.com/NixOS/nixpkgs/commit/a37c741a18d3b4379633fce353b1ce0304eca0d7) | `` python310Packages.google-cloud-dataproc: 5.0.3 -> 5.1.0 ``           |
| [`e0dcdc9e`](https://github.com/NixOS/nixpkgs/commit/e0dcdc9ec25f454e34b32091ab38134f566a4c90) | `` thunderbird-unwrapped: 102.6.0 -> 102.6.1 ``                         |
| [`c19fee73`](https://github.com/NixOS/nixpkgs/commit/c19fee73660dfabdb0a9d81dbdda7379cff02c19) | `` nextcloudPackages: init and update various ``                        |
| [`c230ccbd`](https://github.com/NixOS/nixpkgs/commit/c230ccbd70772767e028ad00cfd7b32cccca6d6b) | `` python310Packages.aioshelly: 5.2.0 -> 5.2.1 ``                       |
| [`dad96d3c`](https://github.com/NixOS/nixpkgs/commit/dad96d3c91f4b9594ed1e62090c6db4593a20525) | `` mdbook-cmdrun: init at 2023-01-10 ``                                 |
| [`fc12db0e`](https://github.com/NixOS/nixpkgs/commit/fc12db0e7cf4a3ae047c1173652d8ffa9ef0ca93) | `` spicedb: 1.11.0 -> 1.15.0 ``                                         |
| [`dfdaa0ce`](https://github.com/NixOS/nixpkgs/commit/dfdaa0ce26e1e29967a01e1900aba5b112fc087e) | `` keepass: 2.49 -> 2.52 ``                                             |
| [`64364225`](https://github.com/NixOS/nixpkgs/commit/643642254e9ea69f6a3c6ef6ef4c421951d8de9b) | `` treesheets: unstable-2022-12-30 -> unstable-2023-01-04 ``            |
| [`bc66db93`](https://github.com/NixOS/nixpkgs/commit/bc66db939a67a6778b4ae1c8d8b993f7db6eb049) | `` PR feedback ``                                                       |
| [`51495466`](https://github.com/NixOS/nixpkgs/commit/5149546626c8a4a3ada276f3ca5c1247e138a189) | `` ventoy-bin-full: 1.0.86 -> 1.0.87 ``                                 |
| [`c338d978`](https://github.com/NixOS/nixpkgs/commit/c338d978c55e78d0acb5faae24e93a005218375f) | `` budgie.budgie-screensaver: init at 5.1.0 ``                          |
| [`0e09335d`](https://github.com/NixOS/nixpkgs/commit/0e09335dce8c6f3b43da774463b0b5b833bea1b2) | `` avrdude: 7.0 -> 7.1 ``                                               |
| [`3701b2c1`](https://github.com/NixOS/nixpkgs/commit/3701b2c172845fb5b8e92a7cb61070efffc502b8) | `` just: 1.9.0 -> 1.11.0 ``                                             |
| [`29f6b534`](https://github.com/NixOS/nixpkgs/commit/29f6b53430652e3c3892c934fb9f0147e9259327) | `` cargo-llvm-cov: 0.5.4 -> 0.5.5 ``                                    |
| [`ae69f0cd`](https://github.com/NixOS/nixpkgs/commit/ae69f0cd19242a5a45a573b2d181aebbeea36fc4) | `` python310Packages.ibm-cloud-sdk-core: fix typo ``                    |