### PR TITLE
chore(flake/nixpkgs): `6c8644fc` -> `0f213d0f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673450908,
-        "narHash": "sha256-b8em+kwrNtnB7gR8SyVf6WuTyQ+6tHS6dzt9D9wgKF0=",
+        "lastModified": 1673540789,
+        "narHash": "sha256-xqnxBOK3qctIeUVxecydrEDbEXjsvHCPGPbvsl63M/U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c8644fc37b6e141cbfa6c7dc8d98846c4ff0c2e",
+        "rev": "0f213d0fee84280d8c3a97f7469b988d6fe5fcdf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`0f213d0f`](https://github.com/NixOS/nixpkgs/commit/0f213d0fee84280d8c3a97f7469b988d6fe5fcdf) | `` spyder: remove unneeded extra desktop file ``                               |
| [`fe177468`](https://github.com/NixOS/nixpkgs/commit/fe1774681f466453dacc98ebd8eee834caa7bde8) | `` haskellPackages.sockets: mark as broken ``                                  |
| [`d4bdfa09`](https://github.com/NixOS/nixpkgs/commit/d4bdfa0941b7726ef1bbcfdf04d10c8c945cf0ba) | ``  qq: 3.0.0-565 -> 3.0.0-571 ``                                              |
| [`92f9580a`](https://github.com/NixOS/nixpkgs/commit/92f9580a4c369b4b51a7b6a5e77da43720134c9f) | `` premake5: mark broken on darwin aarch64 ``                                  |
| [`f6c2cbab`](https://github.com/NixOS/nixpkgs/commit/f6c2cbab8472b85e27a7d7de05081f093c665ae5) | `` premake5: 5.0.0-alpha12 -> 5.0.0-beta2 ``                                   |
| [`0bd2ffa2`](https://github.com/NixOS/nixpkgs/commit/0bd2ffa271eaba1677feeeb6c6ada866127cf65e) | `` python310Packages.google-cloud-pubsub: 2.13.11 -> 2.13.12 ``                |
| [`f5b1e933`](https://github.com/NixOS/nixpkgs/commit/f5b1e9334fdb0b3a5cfbc2c06ef5ed91a07c8de0) | `` haskellPackages: mark builds failing on hydra as broken ``                  |
| [`f7791a9f`](https://github.com/NixOS/nixpkgs/commit/f7791a9f7f42d61e1227524ae245aa02ee286910) | `` python310Packages.google-cloud-language: 2.7.0 -> 2.8.0 ``                  |
| [`9faffb2f`](https://github.com/NixOS/nixpkgs/commit/9faffb2f40174c21f6804418961c5b3965b438ea) | `` python310Packages.blebox-uniapi: 2.1.3 -> 2.1.4 ``                          |
| [`51885ece`](https://github.com/NixOS/nixpkgs/commit/51885ecec908a1dbf248b8849c01b66390b23425) | `` abcmidi: 2022.12.09 -> 2023.01.08 ``                                        |
| [`e1bfd33a`](https://github.com/NixOS/nixpkgs/commit/e1bfd33a5d94bff36f9f0cd560449a0780ef4693) | `` libdeltachat: 1.105.0 -> 1.106.0 ``                                         |
| [`e5fb482c`](https://github.com/NixOS/nixpkgs/commit/e5fb482c3a3edb22044606d399e03d25676af9e1) | `` oh-my-posh: 12.36.0 -> 13.0.0 ``                                            |
| [`64f5e939`](https://github.com/NixOS/nixpkgs/commit/64f5e9395c5a9437e887bfed6d30252e8a1228fc) | `` oh-my-posh: 12.35.2 -> 12.36.0 ``                                           |
| [`c0d431ca`](https://github.com/NixOS/nixpkgs/commit/c0d431caff8a561e16be72f2a8919260c03fcd11) | `` bazel-remote: 2.3.9 -> 2.4.0 ``                                             |
| [`6986b50d`](https://github.com/NixOS/nixpkgs/commit/6986b50df9466b95a81eaf8020585e2bf2c23f81) | `` llpp: mark as broken ``                                                     |
| [`586aea4c`](https://github.com/NixOS/nixpkgs/commit/586aea4c8ab1b850d2ecb28ee25720adc8096dee) | `` ocamlPackages.cryptokit: 1.17 → 1.18 ``                                     |
| [`7bab58ec`](https://github.com/NixOS/nixpkgs/commit/7bab58ecd1322f294dea62c07b84ddbc24a9b379) | `` ocamlPackages.async_websocket: use dune 3 ``                                |
| [`d75e38bb`](https://github.com/NixOS/nixpkgs/commit/d75e38bb6ebde568ff9a58dae518f032a41f0fbc) | `` ocamlPackages.cohttp_async_websocket: use dune 3 ``                         |
| [`481df0c2`](https://github.com/NixOS/nixpkgs/commit/481df0c2649e7334ddf60fad75c492c23f24c47c) | `` ocamlPackages.async_rpc_websocket: use dune 3 ``                            |
| [`6bda65e4`](https://github.com/NixOS/nixpkgs/commit/6bda65e481d43385d67b5b0687695c50897e9a71) | `` ocamlPackages.email_message: use dune 3 ``                                  |
| [`e21396d8`](https://github.com/NixOS/nixpkgs/commit/e21396d81c9f596e47559ff9ed76098325e2d19b) | `` ocamlPackages.async_smtp: use dune 3 ``                                     |
| [`6b4546df`](https://github.com/NixOS/nixpkgs/commit/6b4546dfc222d9449999378b729549942b6c7dac) | `` ocamlPackages.gapi-ocaml: use dune 3 ``                                     |
| [`4b7da5f3`](https://github.com/NixOS/nixpkgs/commit/4b7da5f3bee55c266f90483978c039ea441c7a48) | `` ocamlPackages.google-drive-ocamlfuse: use dune 3 ``                         |
| [`91f334c3`](https://github.com/NixOS/nixpkgs/commit/91f334c3dcfb9bf88c09dcf012b350a9cc598271) | `` ocamlPackages.ocsigen_server: use dune 3 ``                                 |
| [`d16a3698`](https://github.com/NixOS/nixpkgs/commit/d16a369880c94977aaf41b1e92eedcc9b80f11ea) | `` terraform-providers.tencentcloud: remove meta.broken ``                     |
| [`7d1eee4a`](https://github.com/NixOS/nixpkgs/commit/7d1eee4a3e190455c9de3cee0d26948e4fe0b640) | `` terraform-providers.pass: remove meta.broken ``                             |
| [`1df446cf`](https://github.com/NixOS/nixpkgs/commit/1df446cf9a34fbd2197310d77f5b0766511701da) | `` terraform-providers.netlify: remove meta.broken ``                          |
| [`fc8deead`](https://github.com/NixOS/nixpkgs/commit/fc8deead30324cc3809d59fe4e80c7b7419690c5) | `` chezmoi: 2.28.0 -> 2.29.1 ``                                                |
| [`41801c0f`](https://github.com/NixOS/nixpkgs/commit/41801c0f7bd061659e5e1a12af2e5d6aad1e08c6) | `` ruff: 0.0.218 -> 0.0.219 ``                                                 |
| [`64f5143e`](https://github.com/NixOS/nixpkgs/commit/64f5143ee763751a1bcaee67fd773fcff62fe497) | `` moar: 1.11.3 -> 1.11.4 ``                                                   |
| [`bacd9d11`](https://github.com/NixOS/nixpkgs/commit/bacd9d11d540e8baf7aaf4e9f9c926cd9fc99397) | `` go_1_18: 1.18.9 -> 1.18.10 ``                                               |
| [`15b8157f`](https://github.com/NixOS/nixpkgs/commit/15b8157fefe8d9ea8aa4d1ba7f69c8a8281dcb73) | `` cri-o: 1.26.0 -> 1.26.1 ``                                                  |
| [`fd524633`](https://github.com/NixOS/nixpkgs/commit/fd52463324e2fcb4336d1beca10ff7d908720446) | `` terraform-providers.tencentcloud: 1.79.4 → 1.79.5 ``                        |
| [`dfa9af71`](https://github.com/NixOS/nixpkgs/commit/dfa9af71817ddce9aa8fcb45abdfcd1774392fdb) | `` terraform-providers.oci: 4.102.0 → 4.103.0 ``                               |
| [`0664976e`](https://github.com/NixOS/nixpkgs/commit/0664976e13962773db06b38ef1ba4ed488a6fa34) | `` terraform-providers.opentelekomcloud: 1.32.1 → 1.32.2 ``                    |
| [`fbdb0a48`](https://github.com/NixOS/nixpkgs/commit/fbdb0a48573f5ce0c0a42d00f32b962adc8b31fb) | `` terraform-providers.local: 2.2.3 → 2.3.0 ``                                 |
| [`a26513da`](https://github.com/NixOS/nixpkgs/commit/a26513da4189862bdf104f7c8ebccba2082f8026) | `` terraform-providers.grafana: 1.32.0 → 1.33.0 ``                             |
| [`462682c1`](https://github.com/NixOS/nixpkgs/commit/462682c1ea631f516313ab30adc15fd98e8222f1) | `` terraform-providers.alicloud: 1.195.0 → 1.196.0 ``                          |
| [`dfd098c6`](https://github.com/NixOS/nixpkgs/commit/dfd098c651702679b1c051c9e84517ea8567b3ae) | `` terraform-providers.github: 5.13.0 → 5.14.0 ``                              |
| [`dfc44440`](https://github.com/NixOS/nixpkgs/commit/dfc444403cbd290832499f6366532bb1b167e87b) | `` terraform-providers.datadog: 3.19.1 → 3.20.0 ``                             |
| [`10e8f381`](https://github.com/NixOS/nixpkgs/commit/10e8f38102d303e36a0e2afd0b433ee19c722c6c) | `` terraform-providers.baiducloud: 1.19.3 → 1.19.4 ``                          |
| [`0eda3803`](https://github.com/NixOS/nixpkgs/commit/0eda3803b47a2f022f54e3acbc604464f7ce1c30) | `` libpg_query: 15-4.0.0 -> 15-4.1.0 ``                                        |
| [`45c2a663`](https://github.com/NixOS/nixpkgs/commit/45c2a66309e6d6ccffebd368c240ed07f78e345d) | `` esbuild: 0.16.15 -> 0.16.17 ``                                              |
| [`9afc5a23`](https://github.com/NixOS/nixpkgs/commit/9afc5a23d5c4fcc2c804207a6614ff2370076c7a) | `` gallery-dl: 1.24.2 -> 1.24.4 ``                                             |
| [`a5dcbfc4`](https://github.com/NixOS/nixpkgs/commit/a5dcbfc488f6cd42677c7afd212fb772135f9403) | `` gnome-secrets: 7.0 -> 7.2 ``                                                |
| [`71c0ce96`](https://github.com/NixOS/nixpkgs/commit/71c0ce962e039ac3f8ce4c1f6cd3bd3bf479470d) | `` nushell: 0.73.0 -> 0.74.0 ``                                                |
| [`fc63c84b`](https://github.com/NixOS/nixpkgs/commit/fc63c84bbf446344935e826af840364d04529ae6) | `` calcium: init at 0.4.1 ``                                                   |
| [`1a24bb1d`](https://github.com/NixOS/nixpkgs/commit/1a24bb1d67226eb927ea8c0553c3a17edf36025b) | `` stratis-cli: 3.4.0 -> 3.4.1 ``                                              |
| [`cbf16349`](https://github.com/NixOS/nixpkgs/commit/cbf163490ee48213eb8fe8e75623fc0aaeade0f5) | `` supermin: init at 5.2.2 ``                                                  |
| [`b7ee536d`](https://github.com/NixOS/nixpkgs/commit/b7ee536dd9d56bf88002882e9e288a8973f58df9) | `` augeas: enable parallel building ``                                         |
| [`257ba60f`](https://github.com/NixOS/nixpkgs/commit/257ba60f559d44e39c37f0b06f74fc6bfcad8a39) | `` augeas: add meta.changelog ``                                               |
| [`5772ed0d`](https://github.com/NixOS/nixpkgs/commit/5772ed0d87df5fd1b1c9cdb3b92655ac0bf37b5f) | `` augeas: use HTTPS for homepage ``                                           |
| [`d9c7c7f9`](https://github.com/NixOS/nixpkgs/commit/d9c7c7f9b4a165f17babe5913432e1401e2752f7) | `` augeas: clarify license ``                                                  |
| [`0c5559cf`](https://github.com/NixOS/nixpkgs/commit/0c5559cf4f2ed17653ba267f3fda1b229033a9c2) | `` promql-cli: 0.2.1 -> 0.3.0 ``                                               |
| [`f9b4295a`](https://github.com/NixOS/nixpkgs/commit/f9b4295a83bea4ada78d27d1dcb2f75e6ab08cfc) | `` vscode: 1.74.2 -> 1.74.3 ``                                                 |
| [`d837321d`](https://github.com/NixOS/nixpkgs/commit/d837321d0952aa8d49f07293e2dca05174c2adb5) | `` doggo: 0.5.4 -> 0.5.5 ``                                                    |
| [`dab251a3`](https://github.com/NixOS/nixpkgs/commit/dab251a32af94e12d67535cf60060e702cec0fdc) | `` julia_18-bin: 1.8.4 -> 1.8.5 ``                                             |
| [`5fe2aa39`](https://github.com/NixOS/nixpkgs/commit/5fe2aa39debf398d0053b0c475de7cf37ef8fece) | `` envoy: fix deps hashes ``                                                   |
| [`f967b6a8`](https://github.com/NixOS/nixpkgs/commit/f967b6a8e60cfaade97bc0181d3b879252859674) | `` gotrue-supabase: 2.35.0 -> 2.40.1 ``                                        |
| [`250e410a`](https://github.com/NixOS/nixpkgs/commit/250e410a922368f47ceb0f706b667dff40b9b4b9) | `` qt-6/modules/qtbase: add systemdSupport parameter (#192057) ``              |
| [`ad9f0782`](https://github.com/NixOS/nixpkgs/commit/ad9f07825f16d4f79dafeb44dab572c27c052c4a) | `` oculante: 0.6.38 -> 0.6.39 ``                                               |
| [`94ba1055`](https://github.com/NixOS/nixpkgs/commit/94ba1055239297f21cdbb275027604d88722cd10) | `` hivex: build OCaml bindings ``                                              |
| [`22f94529`](https://github.com/NixOS/nixpkgs/commit/22f9452996b372325c51b45dbd75cf1ec499d75d) | `` hivex: strictDeps ``                                                        |
| [`39fd1c60`](https://github.com/NixOS/nixpkgs/commit/39fd1c608c5ac7d381c4fde36000ad8c7f800c47) | `` hivex: enable parallel building ``                                          |
| [`49927672`](https://github.com/NixOS/nixpkgs/commit/49927672f7a7bd9d3d514f177c8f3cd860ffe9cc) | `` hivex: clarify license ``                                                   |
| [`4af8ac5e`](https://github.com/NixOS/nixpkgs/commit/4af8ac5eea12a041c37b17e7c7daf441d96f1790) | `` haskellPackages.posix-api: unmark broken (disable tests) ``                 |
| [`9c66fd5c`](https://github.com/NixOS/nixpkgs/commit/9c66fd5c7e176095552d180547b29e678fa9071d) | `` simpleBuildTool: 1.7.3 -> 1.8.2 (#209607) ``                                |
| [`b53f7b3c`](https://github.com/NixOS/nixpkgs/commit/b53f7b3cfeeaf788ff799cb8f7541c53039282be) | `` oh-my-zsh: 2022-11-08 -> 2023-01-09 (#210105) ``                            |
| [`c5b7a74c`](https://github.com/NixOS/nixpkgs/commit/c5b7a74ca1c1aed74e4a7320069b81fc32371888) | `` pgformatter: 5.3 -> 5.4 ``                                                  |
| [`2725cc59`](https://github.com/NixOS/nixpkgs/commit/2725cc59a63f1aa131f2e5e790b8c11f90433936) | `` perlPackages.TextFormat: update homepage ``                                 |
| [`098c6b0b`](https://github.com/NixOS/nixpkgs/commit/098c6b0becdbf0226b359c69fbfa4911b35a77d9) | `` check-meta(hasUnsupportedPlatform): use lib.meta.availableOn ``             |
| [`0b90e548`](https://github.com/NixOS/nixpkgs/commit/0b90e548b5aabea90f01437467467bc73dc61bf1) | `` lib/meta(availableOn): handle missing meta and empty meta.platform ``       |
| [`5d4a45d6`](https://github.com/NixOS/nixpkgs/commit/5d4a45d639a54c37385d043e94578583b5519286) | `` libva-utils: 2.16.0 -> 2.17.0 ``                                            |
| [`a5c2a378`](https://github.com/NixOS/nixpkgs/commit/a5c2a37896e822565d7563c56e8b2e1b05f5c620) | `` mtdutils: add dev output ``                                                 |
| [`fbedeabf`](https://github.com/NixOS/nixpkgs/commit/fbedeabf198c5e17e8779d3ae06234c91bee7de1) | `` mtdutils: enable parallel building ``                                       |
| [`6b16d2c4`](https://github.com/NixOS/nixpkgs/commit/6b16d2c40649c7db3ecd42d2fc4d7118c1e7e155) | `` python3Packages.hassil: 0.1.4 -> 0.2.3 ``                                   |
| [`6200f846`](https://github.com/NixOS/nixpkgs/commit/6200f8466c12bba412c743bbcb23ebe2b5057ffc) | `` cargo-llvm-cov: 0.5.6 -> 0.5.7 ``                                           |
| [`0fcd0bf2`](https://github.com/NixOS/nixpkgs/commit/0fcd0bf2a6637931aad7a0aecc426b89537eb058) | `` evcc: 0.110.1 -> 0.111.0 ``                                                 |
| [`288a8815`](https://github.com/NixOS/nixpkgs/commit/288a8815e07ed5f804c9e9db581ecb5c90f97753) | `` zimfw: init at 1.11.0 ``                                                    |
| [`138ffdea`](https://github.com/NixOS/nixpkgs/commit/138ffdeab989dcd0640f1e3b204e9cad8821c914) | `` python310Packages.google-cloud-monitoring: 2.12.0 -> 2.14.0 ``              |
| [`c96efc9d`](https://github.com/NixOS/nixpkgs/commit/c96efc9d4487d56d5484482d751064588fc650d0) | `` maintainers: add joedevivo ``                                               |
| [`c0ca5a3e`](https://github.com/NixOS/nixpkgs/commit/c0ca5a3efe15e4cbbf7d9bbf1562a6be03857459) | `` cargo-llvm-cov: 0.5.5 -> 0.5.6 ``                                           |
| [`c41e1583`](https://github.com/NixOS/nixpkgs/commit/c41e15834fa2069a98fb716eb53aeea47bd3e7f5) | `` cinnamon.xreader: 3.6.2 -> 3.6.3 ``                                         |
| [`35a8632e`](https://github.com/NixOS/nixpkgs/commit/35a8632ee1d99808e2fbb53930f39f217d0a8406) | `` cinnamon.cinnamon-common: 5.6.5 -> 5.6.6 ``                                 |
| [`ae46fb3c`](https://github.com/NixOS/nixpkgs/commit/ae46fb3cb6b7ea0ba49f58e5d31970d0d49720c7) | `` bzip3: 1.2.1 -> 1.2.2 ``                                                    |
| [`1ab76067`](https://github.com/NixOS/nixpkgs/commit/1ab7606752ab7ba3afb02171f4655384889e1ee8) | `` cargo-flamegraph: 0.5.1 -> 0.6.2 ``                                         |
| [`2528c493`](https://github.com/NixOS/nixpkgs/commit/2528c4931937ba9829c4a7855eea2ed2a3c1ab4a) | `` nix-eval-jobs: 2.11.0 -> 2.12.0 ``                                          |
| [`5e164833`](https://github.com/NixOS/nixpkgs/commit/5e1648330a89eccad2d95c18250c7f61a897d0d5) | `` go-task: 3.19.0 -> 3.19.1 ``                                                |
| [`5aaabe9e`](https://github.com/NixOS/nixpkgs/commit/5aaabe9e5f70b9b5818d4d7dcbabe86d7ebe81c9) | `` martian-mono: 0.9.2 -> 1.0.0 ``                                             |
| [`f2af8bd5`](https://github.com/NixOS/nixpkgs/commit/f2af8bd5327073754a956edbb4a175a450ce907f) | `` jfrog-cli: init at 2.32.0 ``                                                |
| [`be33bb04`](https://github.com/NixOS/nixpkgs/commit/be33bb045e37f57fe503090003e4cabcd4c76d6c) | `` cargo-geiger: 0.11.4 -> 0.11.5 ``                                           |
| [`63f5006d`](https://github.com/NixOS/nixpkgs/commit/63f5006d0f1cba6c5263b3eae03a1c8be2407ec8) | `` ruff: 0.0.217 -> 0.0.218 ``                                                 |
| [`c9e56043`](https://github.com/NixOS/nixpkgs/commit/c9e560430fe43e57ee592e712238c59cbcde5f99) | `` mdbook-katex: 0.2.21 -> 0.3.0 ``                                            |
| [`5bba17c9`](https://github.com/NixOS/nixpkgs/commit/5bba17c9aadf916cf3d81fb0c85307406c72289e) | `` chromium: 108.0.5359.124 -> 109.0.5414.74 ``                                |
| [`8f3de3ef`](https://github.com/NixOS/nixpkgs/commit/8f3de3efd4e06d6ad9a787e65ca90f577df25a6a) | `` topiary: unstable-2022-12-02 -> unstable-2023-01-10 ``                      |
| [`aa1620e1`](https://github.com/NixOS/nixpkgs/commit/aa1620e124d72cae78ff33807654a32f207da2c8) | `` calibre: 6.10.0 -> 6.11.0 ``                                                |
| [`e4c9245e`](https://github.com/NixOS/nixpkgs/commit/e4c9245ea7963adc670f1b61d041d38be3e13e06) | `` maintainers: add Detegr ``                                                  |
| [`0e96ec70`](https://github.com/NixOS/nixpkgs/commit/0e96ec7047eff3282fb5904bb82ead460e5d1fd9) | `` python310Packages.eigenpy: add changelog to meta ``                         |
| [`87b499ad`](https://github.com/NixOS/nixpkgs/commit/87b499adc0ed2ce9a79e2085d87202cb66420983) | `` selene: 0.23.1 -> 0.24.0 ``                                                 |
| [`28ea2c96`](https://github.com/NixOS/nixpkgs/commit/28ea2c96c352429e0f1c6720ebaed70dd6428672) | `` prometheus-nut-exporter: 2.5.1 -> 2.5.2 ``                                  |
| [`81133a2d`](https://github.com/NixOS/nixpkgs/commit/81133a2d7efd18b8384d6f34c6d6e3653aa80571) | `` python3Packages.eigenpy: 2.8.1 -> 2.9.0 ``                                  |
| [`58bc9d9e`](https://github.com/NixOS/nixpkgs/commit/58bc9d9e7d0121d5ec1f6da0f0af0f6c636caff0) | `` namecoin: remove infinisil as a maintainer ``                               |
| [`04acdfd7`](https://github.com/NixOS/nixpkgs/commit/04acdfd75e872a2c3c2a3e11d46a7bd884ef3929) | `` stress-ng: 0.14.06 -> 0.15.01 ``                                            |
| [`4a15f0b4`](https://github.com/NixOS/nixpkgs/commit/4a15f0b45d2d9beaf6ebb8c23333d167f2f0d2f0) | `` namecoin: 23.0 -> 24.0 ``                                                   |
| [`828d44af`](https://github.com/NixOS/nixpkgs/commit/828d44af008c18d615d268614a45f6ccafea2881) | `` utf8cpp: 3.2.2 -> 3.2.3 ``                                                  |
| [`d4dd76f4`](https://github.com/NixOS/nixpkgs/commit/d4dd76f46cafca7f5bf7036e72f4c4daf6542733) | `` apkeep: add changelog to meta ``                                            |
| [`404ef069`](https://github.com/NixOS/nixpkgs/commit/404ef069ce8c9450e70ec28315cc074015db1496) | `` julia_18: 1.8.4 -> 1.8.5 ``                                                 |
| [`d4d8f9e0`](https://github.com/NixOS/nixpkgs/commit/d4d8f9e01840190e7e016fb84793bdd19aaba3be) | `` apkeep: 0.14.1 -> 0.15.0 ``                                                 |
| [`a8fa46a9`](https://github.com/NixOS/nixpkgs/commit/a8fa46a964af409c0bad72dd87d9777d07ca22b1) | `` maintainers/../haskell/mark-broken: Insert eval info in commit msg ``       |
| [`99d50204`](https://github.com/NixOS/nixpkgs/commit/99d50204936d47f9e94a927e52e1027bfcc98cde) | `` python310Packages.launchpadlib: 1.10.18 -> 1.11.0 ``                        |
| [`43af53bc`](https://github.com/NixOS/nixpkgs/commit/43af53bc7f49b3c542604ddae08cbdb61a276c2b) | `` haskellPackages.wstunnel: drop now unnecessary override ``                  |
| [`4e75bbe7`](https://github.com/NixOS/nixpkgs/commit/4e75bbe7688df4a3ff4dd3ed02033e5f5e6d54e3) | `` haskell.packages.ghc94.haskell-language-server: Fix eval ``                 |
| [`8daeaf6e`](https://github.com/NixOS/nixpkgs/commit/8daeaf6e1dc5b2a6be1689ce0fe01fc5ec8b9f58) | `` haskellPackages: regenerate package set based on current config ``          |
| [`65f893aa`](https://github.com/NixOS/nixpkgs/commit/65f893aabfdb99dc21308e60a80e08317dcafef8) | `` all-cabal-hashes: 2023-01-06T18:29:38Z -> 2023-01-08T15:35:40Z ``           |
| [`38477e3d`](https://github.com/NixOS/nixpkgs/commit/38477e3df0a98329abdddb23448ad01da52d002b) | `` exiftool: 12.52 -> 12.54 ``                                                 |
| [`56f3cb52`](https://github.com/NixOS/nixpkgs/commit/56f3cb523ec8224099663f35a0e27a4aabbfc033) | `` timescaledb: 2.9.0 -> 2.9.1 ``                                              |
| [`2d6f90f6`](https://github.com/NixOS/nixpkgs/commit/2d6f90f6679c91ea325660105b75fabf7ddfd3b0) | `` git-bug-migration: init at 0.3.4 ``                                         |
| [`c4682d25`](https://github.com/NixOS/nixpkgs/commit/c4682d250d67b4bea93233b6ac7206ac0816e8c6) | `` git-bug: don't build unneeded packages, misc changes ``                     |
| [`c0c6e925`](https://github.com/NixOS/nixpkgs/commit/c0c6e9252cf598989c9e44ee940ed414054c2c49) | `` python310Packages.email-validator: 1.2.1 -> 1.3.0 ``                        |
| [`974ed2cc`](https://github.com/NixOS/nixpkgs/commit/974ed2cc0764ce906765365b7d97ee957f01a716) | `` usql: 0.13.4 -> 0.13.5 ``                                                   |
| [`7a5b362e`](https://github.com/NixOS/nixpkgs/commit/7a5b362ea10978a00dde812922388db2956dcb09) | `` dynamips: 0.2.22 -> 0.2.23 ``                                               |
| [`3b545660`](https://github.com/NixOS/nixpkgs/commit/3b5456608a680a0cf7e488c7ddd250b6fef3eac1) | `` nixos-version: print error for missing revision to stderr ``                |
| [`c09f6c3d`](https://github.com/NixOS/nixpkgs/commit/c09f6c3db0207702d95f966236c975a49beb29ee) | `` nixos-version: output configurationRevision ``                              |
| [`4fc374b3`](https://github.com/NixOS/nixpkgs/commit/4fc374b314ab097d2105d3705eefdd5520b16ad1) | `` captive-browser: Use buildGoModule ``                                       |
| [`2ee3ad53`](https://github.com/NixOS/nixpkgs/commit/2ee3ad53b22f2b638ab438236f9792311605a628) | `` pyinfra: 2.6 -> 2.6.1 ``                                                    |
| [`4b365604`](https://github.com/NixOS/nixpkgs/commit/4b3656046b2d00fef857d731f871947377392dd0) | `` python3Packages.datatable: 0.11.0 -> unstable-2022-12-15 ``                 |
| [`dfac3e29`](https://github.com/NixOS/nixpkgs/commit/dfac3e29cb489552a308dd422a84f65419d61736) | `` nodePackages.readability-cli: use srcOnly (thanks to @marsam) ``            |
| [`ee2571e8`](https://github.com/NixOS/nixpkgs/commit/ee2571e8fe2222725e74547cd898654429ae7a22) | `` nodePackages.readability-cli: do not patch a deno shebang line ``           |
| [`f68c3579`](https://github.com/NixOS/nixpkgs/commit/f68c35790ec749b72ad0607ab84cae11016fdd1e) | `` nodePackages.readability-cli: add missing build inputs for canvas module `` |