### PR TITLE
chore(flake/home-manager): `176e4553` -> `2827b530`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673343300,
-        "narHash": "sha256-5Xdj6kpXYMie0MlnGwqK5FaMdsedxvyuakWtyKB3zaQ=",
+        "lastModified": 1673737886,
+        "narHash": "sha256-hNTqD0uIgpbtTI2Nuj/Q1lEFOOdZqqXpxoc8rMno2F0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "176e455371a8371586e8a3ff0d56ee9f3ca2324e",
+        "rev": "2827b5306462d91edec16a3d069b2d6e54c3079f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message              |
| ----------------------------------------------------------------------------------------------------------- | -------------------- |
| [`2827b530`](https://github.com/nix-community/home-manager/commit/2827b5306462d91edec16a3d069b2d6e54c3079f) | `` docs: bump nmd `` |