### PR TITLE
chore(flake/nixpkgs): `0f213d0f` -> `befc8390`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673540789,
-        "narHash": "sha256-xqnxBOK3qctIeUVxecydrEDbEXjsvHCPGPbvsl63M/U=",
+        "lastModified": 1673631141,
+        "narHash": "sha256-AprpYQ5JvLS4wQG/ghm2UriZ9QZXvAwh1HlgA/6ZEVQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0f213d0fee84280d8c3a97f7469b988d6fe5fcdf",
+        "rev": "befc83905c965adfd33e5cae49acb0351f6e0404",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`9297b538`](https://github.com/NixOS/nixpkgs/commit/9297b5382f6b38e58cb636909d2d3a48760e765f) | `` default-crate-overrides.nix: add graphene-sys ``                             |
| [`e40de94c`](https://github.com/NixOS/nixpkgs/commit/e40de94c4266c3c21f6c7e8f2e85c9fef25078d2) | `` default-crate-overrides: add pkg-config to evdev-sys ``                      |
| [`62d57114`](https://github.com/NixOS/nixpkgs/commit/62d571148a24889811b8f4cdb69c05eb00d260ba) | `` default-crate-overrides: servo-fontconfig-sys needs fontconfig ``            |
| [`566d6acb`](https://github.com/NixOS/nixpkgs/commit/566d6acb96884cde4c4d2a6120eb1252d8d28a36) | `` kluctl: 2.18.3 -> 2.18.4 ``                                                  |
| [`225ff463`](https://github.com/NixOS/nixpkgs/commit/225ff463a78ba256426121421ae36ab39484c27d) | `` lagrange: 1.14.1 -> 1.14.2 ``                                                |
| [`5a6019fc`](https://github.com/NixOS/nixpkgs/commit/5a6019fc8312b11b38a37eefa287a12db34c8823) | `` lensfun: fix build on x86_64-darwin ``                                       |
| [`9f87711f`](https://github.com/NixOS/nixpkgs/commit/9f87711f0ddedc8291090b244fbfdd3848a0fde7) | `` seatd: broaden platforms ``                                                  |
| [`4aab9ea3`](https://github.com/NixOS/nixpkgs/commit/4aab9ea39d7a6e6710f4fa1ac23546e5d6b7789f) | `` jc: 1.22.4 → 1.22.5 ``                                                       |
| [`907dbb74`](https://github.com/NixOS/nixpkgs/commit/907dbb741bccb9533a9a50453508a9b10543bd5b) | `` elpa: 2022.05.001 -> 2022.11.001 ``                                          |
| [`5c7fa218`](https://github.com/NixOS/nixpkgs/commit/5c7fa218c12a7a15685b0bb123c75201837e2503) | `` nixos/flexget: add package option ``                                         |
| [`04bbb6fb`](https://github.com/NixOS/nixpkgs/commit/04bbb6fb78fbb5d69bb51fb4e9029ee11c74972f) | `` smlfmt: init at 1.0.0 ``                                                     |
| [`d9124688`](https://github.com/NixOS/nixpkgs/commit/d912468885f9d61d5ebf4fb3546f88e9b5bd0567) | `` maintainers: add munksgaard ``                                               |
| [`37b97ae3`](https://github.com/NixOS/nixpkgs/commit/37b97ae3dd714de9a17923d004a2c5b5543dfa6d) | `` nheko: 0.10.2 -> 0.11.0 ``                                                   |
| [`02440496`](https://github.com/NixOS/nixpkgs/commit/02440496496b6cda5af164ef48dcc453ca83d46e) | `` mtxclient: 0.8.2 -> 0.9.0 ``                                                 |
| [`e51ff0d5`](https://github.com/NixOS/nixpkgs/commit/e51ff0d56c651a555722e4e6c6d76c5956061b34) | `` coeurl: 0.2.1 -> 0.3.0 ``                                                    |
| [`b88913fb`](https://github.com/NixOS/nixpkgs/commit/b88913fb113c5da9e1eb73d448fed2d4cfc08635) | `` nixos/gitlab: set gitaly runtime dir ``                                      |
| [`33d1f3a4`](https://github.com/NixOS/nixpkgs/commit/33d1f3a4e6615f29fda1b64c5888850a8d497c11) | `` maestro: 1.18.3 -> 1.18.5 ``                                                 |
| [`b3f11c60`](https://github.com/NixOS/nixpkgs/commit/b3f11c60ed7df91cfb91771ac3d7236b37c6a1a6) | `` ripes: 2.2.5 -> 2.2.6 ``                                                     |
| [`fc073483`](https://github.com/NixOS/nixpkgs/commit/fc0734833df097e07186fa1397f7ff0b165924b8) | `` vhs: 0.1.1 -> 0.2.0 ``                                                       |
| [`9c140e94`](https://github.com/NixOS/nixpkgs/commit/9c140e9482aa86f941c88e2d6d166a8df8e36c87) | `` kustomize-sops: 3.0.2 -> 3.1.0 ``                                            |
| [`2a763a27`](https://github.com/NixOS/nixpkgs/commit/2a763a27e2edf710cbad133ab48e94d65e9e6c09) | `` pspg: 5.6.4 -> 5.7.1 ``                                                      |
| [`c8978dde`](https://github.com/NixOS/nixpkgs/commit/c8978ddee4d51cab71b81afe363fa1be3f9a3e73) | `` brillo: 1.4.11 -> 1.4.12 ``                                                  |
| [`8bf85668`](https://github.com/NixOS/nixpkgs/commit/8bf856688221ea108211656259d588a2981a0173) | `` xl2tpd: update homepage ``                                                   |
| [`f2145c47`](https://github.com/NixOS/nixpkgs/commit/f2145c47c856961a4d72517c51272394be9a532e) | `` python310Packages.google-cloud-dataproc: 5.1.0 -> 5.2.0 ``                   |
| [`a6373b55`](https://github.com/NixOS/nixpkgs/commit/a6373b5538bec407e21acbd76fb49cb8e598f1e4) | `` v2ray-geoip: 202301050046 -> 202301120046 ``                                 |
| [`bdfee7b3`](https://github.com/NixOS/nixpkgs/commit/bdfee7b3b07a8bc32ab40492e91ecbd37adf6f76) | `` journaldriver: 1.1.0 -> 5656.0.0; new upstream ``                            |
| [`99c80897`](https://github.com/NixOS/nixpkgs/commit/99c80897e938604d678663ac36935398e0dd5ea3) | `` python310Packages.google-cloud-tasks: 2.11.0 -> 2.12.0 ``                    |
| [`15e1f407`](https://github.com/NixOS/nixpkgs/commit/15e1f407885dc3757d3ec42ef2d7cba36c750db3) | `` python310Packages.google-cloud-texttospeech: 2.13.0 -> 2.14.0 ``             |
| [`3a5d557d`](https://github.com/NixOS/nixpkgs/commit/3a5d557d03906ebfc7992987850f9dfd3044d450) | `` lttng-tools: 2.13.8 -> 2.13.9 ``                                             |
| [`f45dd595`](https://github.com/NixOS/nixpkgs/commit/f45dd59576c3d5e03074c6c6f19c184bd368c8e8) | `` kiwix-tools: init at 3.4.0 ``                                                |
| [`fa9cc1b2`](https://github.com/NixOS/nixpkgs/commit/fa9cc1b2a0f60805ced5e66367f4210cb43b1806) | `` kiwix: split libkiwix out its own toplevel package ``                        |
| [`10c2c7c7`](https://github.com/NixOS/nixpkgs/commit/10c2c7c7b9c4246fda7849fcb58719007ca227d4) | `` terraform-providers.vcd: 3.8.1 → 3.8.2 ``                                    |
| [`c3dab747`](https://github.com/NixOS/nixpkgs/commit/c3dab74711e1875357e49afc67dfe30996d4d0f8) | `` terraform-providers.spotinst: 1.90.0 → 1.91.0 ``                             |
| [`889e40a8`](https://github.com/NixOS/nixpkgs/commit/889e40a8a060049aa190adfa31126978cc81a8ed) | `` terraform-providers.azurerm: 3.38.0 → 3.39.0 ``                              |
| [`e3b2f113`](https://github.com/NixOS/nixpkgs/commit/e3b2f11371c4a3d3c1758f39ee70ad440b40a38d) | `` terraform-providers.snowflake: 0.55.0 → 0.55.1 ``                            |
| [`191f00e4`](https://github.com/NixOS/nixpkgs/commit/191f00e4723a781b5375985b62ea01131e2a4b91) | `` terraform-providers.scaleway: 2.9.0 → 2.9.1 ``                               |
| [`b59f8c01`](https://github.com/NixOS/nixpkgs/commit/b59f8c0119fa88add1bf52a2dcc430ccdd4de271) | `` terraform-providers.okta: 3.39.0 → 3.40.0 ``                                 |
| [`d96f9582`](https://github.com/NixOS/nixpkgs/commit/d96f9582ea60118581f3476a346a4bf7dd3c49c7) | `` terraform-providers.azuread: 2.31.0 → 2.32.0 ``                              |
| [`2fb6a877`](https://github.com/NixOS/nixpkgs/commit/2fb6a87759781b7841d6bf4ea5e387f907773620) | `` python310Packages.google-cloud-redis: 2.10.0 -> 2.11.0 ``                    |
| [`735ab17d`](https://github.com/NixOS/nixpkgs/commit/735ab17d436b8ba68b2967969aa3d0e790bcacca) | `` zimg: broaden platforms ``                                                   |
| [`3452c10b`](https://github.com/NixOS/nixpkgs/commit/3452c10bb477a606e00d1eb31d8c24749c15c53c) | `` z3_4_4_0: remove, z3_4_7: remove ``                                          |
| [`1592c7e4`](https://github.com/NixOS/nixpkgs/commit/1592c7e4d4207a704244d11b529ed96a74be838c) | `` refurb: 1.8.0 -> 1.10.0 ``                                                   |
| [`0b71f973`](https://github.com/NixOS/nixpkgs/commit/0b71f973527514b7c5fba09482c16eefc3ad1756) | `` arkade: 0.8.52 -> 0.8.56 ``                                                  |
| [`57f81019`](https://github.com/NixOS/nixpkgs/commit/57f8101959a07c85f9bc32781263dae09d45c471) | `` pocketbase: 0.10.4 -> 0.11.0 ``                                              |
| [`61113a73`](https://github.com/NixOS/nixpkgs/commit/61113a7325ac9023b38ea43b4de95c6d53800e9f) | `` glooctl: 1.13.1 -> 1.13.2 ``                                                 |
| [`d08c24e5`](https://github.com/NixOS/nixpkgs/commit/d08c24e52954fc3a97a0f98be75897c3d73f80ac) | `` auth0-cli, macchina: fix erroneous rev ``                                    |
| [`751c4644`](https://github.com/NixOS/nixpkgs/commit/751c4644d58f78dc43a7b9acd9cc4da71ee4fb05) | `` tinygltf: 2.7.0 -> 2.8.0 ``                                                  |
| [`ee7e9da5`](https://github.com/NixOS/nixpkgs/commit/ee7e9da5b98bf4cf32a28baebca8852fd1f0d18a) | `` borgbackup: cherry-pick patch to fix tests ``                                |
| [`e7a795e8`](https://github.com/NixOS/nixpkgs/commit/e7a795e82b9f6dca6d68117d62b8b2da76d3add7) | `` ruff: 0.0.219 -> 0.0.220 ``                                                  |
| [`1d852d7b`](https://github.com/NixOS/nixpkgs/commit/1d852d7bcd6ca7c5c45b02e15382e01f9f345344) | `` capitaine-cursors-themed: init at r5 ``                                      |
| [`f77ade48`](https://github.com/NixOS/nixpkgs/commit/f77ade489b706cdfd52a0af22a7ddbe59c3d33d7) | `` checkstyle: 10.5.0 -> 10.6.0 ``                                              |
| [`0eece733`](https://github.com/NixOS/nixpkgs/commit/0eece73358dee8031e07be7ee17b42e84e9715f1) | `` grig: init at 0.9.0 ``                                                       |
| [`4c6b7d41`](https://github.com/NixOS/nixpkgs/commit/4c6b7d41c0f1d22020dc1624a73d7717079905ba) | `` restic: 0.14.0 -> 0.15.0 ``                                                  |
| [`fec6e19f`](https://github.com/NixOS/nixpkgs/commit/fec6e19fd1a32d7dce6cf63b85a535ea4555809f) | `` nixos/tests/acme/generate-certs: deprecate phases ``                         |
| [`94911f82`](https://github.com/NixOS/nixpkgs/commit/94911f820e96c5bd634e03d74f04c0eafeb0a60c) | `` automatic-timezoned: 1.0.53 -> 1.0.55 ``                                     |
| [`66fac9b1`](https://github.com/NixOS/nixpkgs/commit/66fac9b1cf4ac50a5578bc484410bf1e7e8d2898) | `` ferium: 4.2.2 -> 4.3.3 ``                                                    |
| [`bbb6af88`](https://github.com/NixOS/nixpkgs/commit/bbb6af88eb51061ff6256f4ad7c96df5517e3fec) | `` agda: pass through meta ``                                                   |
| [`100ee47e`](https://github.com/NixOS/nixpkgs/commit/100ee47ee8488b0fd5dab22a5a2f96a976e952e6) | `` vimPlugins.b64-nvim: init at 2022-08-22 ``                                   |
| [`154c2734`](https://github.com/NixOS/nixpkgs/commit/154c27342e7624169f5989d269c31e3b78afb8d7) | `` home-assistant: 2023.1.3 -> 2023.1.4 ``                                      |
| [`90770d97`](https://github.com/NixOS/nixpkgs/commit/90770d9744f8c5faeb9a166256efe17aea9ba411) | `` python310Packages.pytibber: 0.26.7 -> 0.26.8 ``                              |
| [`d64d4a57`](https://github.com/NixOS/nixpkgs/commit/d64d4a57880fa502fc89511c509ca498dbdf11b1) | `` python3Packages.pylitterbot: 2023.1.0 -> 2023.1.1 ``                         |
| [`2963534f`](https://github.com/NixOS/nixpkgs/commit/2963534f975d3b12e12f1451df3f2df81b2a06ab) | `` python3Packages.aiowebostv: 0.2.1 -> 0.3.0 ``                                |
| [`675330d2`](https://github.com/NixOS/nixpkgs/commit/675330d2091c583440e8e2373350b8f47a239e50) | `` hwi: 2.1.1 -> 2.2.0 ``                                                       |
| [`d6adb0f0`](https://github.com/NixOS/nixpkgs/commit/d6adb0f0c5e0788f755f4161ca258ffcecc66c0d) | `` go-cqhttp: init at 1.0.0-rc4 ``                                              |
| [`5d2936b3`](https://github.com/NixOS/nixpkgs/commit/5d2936b3da2d5d5aae2e0c43516d770d43463477) | `` dcmkt: Fix build ``                                                          |
| [`79a26e0c`](https://github.com/NixOS/nixpkgs/commit/79a26e0c7020aad5e81f7e6b7d2ffe372e7d746f) | `` ungoogled-chromium: 108.0.5359.125 -> 109.0.5414.87 ``                       |
| [`df4b8ca2`](https://github.com/NixOS/nixpkgs/commit/df4b8ca2ef45f9f690779d935ff4b95d5350b59e) | `` libreddit: 0.27.0 -> 0.27.1 ``                                               |
| [`10199957`](https://github.com/NixOS/nixpkgs/commit/10199957aff53dee472bd18d6c81ee0a671a60ed) | `` star-history: 1.0.9 -> 1.0.10 ``                                             |
| [`7e9cfd1b`](https://github.com/NixOS/nixpkgs/commit/7e9cfd1bc7b4d49e7fafbf28379046e914c9c51b) | `` python310Packages.python-decouple: 3.6 -> 3.7 ``                             |
| [`5338ab8f`](https://github.com/NixOS/nixpkgs/commit/5338ab8f13d1a7b27af5814f7ae97729059abd9e) | `` python310Packages.python-fsutil: 0.9.1 -> 0.9.3 ``                           |
| [`149b48db`](https://github.com/NixOS/nixpkgs/commit/149b48dbc165d3742392d2e97674aec706358a76) | `` python310Packages.cyclonedx-python-lib: 3.1.2 -> 3.1.5 ``                    |
| [`c74317ca`](https://github.com/NixOS/nixpkgs/commit/c74317ca23df1e6d62da0ff78c11d4b6d91c5c8f) | `` python310Packages.confection: 0.0.3 -> 0.0.4 ``                              |
| [`20d9f671`](https://github.com/NixOS/nixpkgs/commit/20d9f671252e260adc5061e3693a992f34d57ac5) | `` python310Packages.confection: add changelog to meta ``                       |
| [`e4be43c6`](https://github.com/NixOS/nixpkgs/commit/e4be43c6d007921355b335921adaac9b2b291e6a) | `` charls: init at 2.4.1 ``                                                     |
| [`e2ba4093`](https://github.com/NixOS/nixpkgs/commit/e2ba4093d19a8e068c8a05257be0d4664df1c68b) | `` git-machete: 3.13.2 -> 3.14.0 ``                                             |
| [`0bbb9414`](https://github.com/NixOS/nixpkgs/commit/0bbb9414d400f5000985d6481f1b63a20e9f14b7) | `` river: 0.2.0 -> 0.2.1 ``                                                     |
| [`e2f0148a`](https://github.com/NixOS/nixpkgs/commit/e2f0148a2052cb6d948d7f5326cde18391f48f5f) | `` ocamlPackages.dns: 6.3.0 → 6.4.1 ``                                          |
| [`ebe4402d`](https://github.com/NixOS/nixpkgs/commit/ebe4402d0a42452da47486254463995c0ed232a9) | `` ocamlPackages.conduit: use dune 3 ``                                         |
| [`d3491557`](https://github.com/NixOS/nixpkgs/commit/d3491557ef2b3c06263430bb1828fb0780d5eb83) | `` ocamlPackages.cohttp: use dune 3 ``                                          |
| [`4ad9083f`](https://github.com/NixOS/nixpkgs/commit/4ad9083feeba5d0453e859fce23756c63df7ea5a) | `` ocamlPackages.telegraml: use dune 3 ``                                       |
| [`389bbb0c`](https://github.com/NixOS/nixpkgs/commit/389bbb0c8478a7c30713e822d468004a108cb7cd) | `` ocamlPackages.webmachine: use dune 3 ``                                      |
| [`5f73c562`](https://github.com/NixOS/nixpkgs/commit/5f73c562d0ac5092fa31e073f7dc2a26bb48587c) | `` ocamlPackages.resto: use dune 3 ``                                           |
| [`373aa5e8`](https://github.com/NixOS/nixpkgs/commit/373aa5e812a0b1a4dc61b1207a12e8cf33b48a0c) | `` ocamlPackages.curly: use dune 3 ``                                           |
| [`0c17d9ac`](https://github.com/NixOS/nixpkgs/commit/0c17d9acac514ffe647b5be40b3c9bdb43fedb93) | `` ocamlPackages.dune-release: use dune 3 ``                                    |
| [`589e4a2b`](https://github.com/NixOS/nixpkgs/commit/589e4a2bb246f08b083beecb383172f2529b7f42) | `` ocamlPackages.graphql: use dune 3 ``                                         |
| [`aa339b23`](https://github.com/NixOS/nixpkgs/commit/aa339b2365f8df1858bf8c65bb11d68ea0572c36) | `` ocamlPackages.mimic: use dune 3 ``                                           |
| [`4d86aa6b`](https://github.com/NixOS/nixpkgs/commit/4d86aa6b507ec80795ba9d7e8baa8f71300d0374) | `` ocamlPackages.git: use dune 3 ``                                             |
| [`90a21f47`](https://github.com/NixOS/nixpkgs/commit/90a21f4771906aa2bd5729a3a23b151fb9e8c422) | `` ocamlPackages.letsencrypt: use dune 3 ``                                     |
| [`0390e61b`](https://github.com/NixOS/nixpkgs/commit/0390e61b6e8d113d0d826641f3a90b83b8b62d4f) | `` vscode-extensions.maximedenes.vscoq: 0.3.6 -> 0.3.7 ``                       |
| [`84a30dfd`](https://github.com/NixOS/nixpkgs/commit/84a30dfdb916675306fe9baadb02c446b1cb4117) | `` python310Packages.datasette: 0.63.3 -> 0.64.1 ``                             |
| [`b2aae06b`](https://github.com/NixOS/nixpkgs/commit/b2aae06ba1fb6ff329e48d8d9d05b87e9e1845e0) | `` n8n: 0.210.1 -> 0.210.2 ``                                                   |
| [`f7670281`](https://github.com/NixOS/nixpkgs/commit/f7670281600aa3fd46b087dbee7938fd5e680959) | `` spaceship-prompt: 4.12.0 -> 4.13.1 ``                                        |
| [`ae2732ba`](https://github.com/NixOS/nixpkgs/commit/ae2732babb9d4295f5c856912645345cb37da97d) | `` fend: 1.1.3 -> 1.1.4 ``                                                      |
| [`63f96b8e`](https://github.com/NixOS/nixpkgs/commit/63f96b8e028fa93e63722a41e13d8d35b059a388) | `` logseq: 0.8.15 -> 0.8.16 ``                                                  |
| [`32ba93e3`](https://github.com/NixOS/nixpkgs/commit/32ba93e3672b9e4b75d401921a0b5d5dbc8f72b6) | `` signal-desktop: 6.1.0 -> 6.2.0 ``                                            |
| [`a7500527`](https://github.com/NixOS/nixpkgs/commit/a7500527bdaf45069c2606156bfc816c2a305a78) | `` outline: 0.67.0 -> 0.67.1 ``                                                 |
| [`1eec181e`](https://github.com/NixOS/nixpkgs/commit/1eec181eaf51a94971fc9470a1c0bf9abc8c4450) | `` ghostie: 0.2.1 -> 0.3.0 ``                                                   |
| [`b249be80`](https://github.com/NixOS/nixpkgs/commit/b249be805eae83dc0b3e4df572ce63a585dbcd15) | `` helmsman: 3.15.1 -> 3.16.0 ``                                                |
| [`f254d152`](https://github.com/NixOS/nixpkgs/commit/f254d1522885b8eba982265ed2e48dd2ad61341b) | `` devspace: 6.2.3 -> 6.2.4 ``                                                  |
| [`adb2126c`](https://github.com/NixOS/nixpkgs/commit/adb2126c7a1cf89abe787b0e055161de74fbef79) | `` jira-cli-go: 1.2.0 -> 1.3.0 ``                                               |
| [`c7990a51`](https://github.com/NixOS/nixpkgs/commit/c7990a51392e77067643c4eb1f815e9ad51a2a59) | `` rdma-core: 43.0 -> 44.0 ``                                                   |
| [`64eb3f16`](https://github.com/NixOS/nixpkgs/commit/64eb3f16ce5fa61635a55e3e069683d5f9ec80f5) | `` rar2fs: 1.29.5 -> 1.29.6 ``                                                  |
| [`eb4891d2`](https://github.com/NixOS/nixpkgs/commit/eb4891d2d3331a0a1c06098f7af1574fa671f363) | `` nixos/vaultwarden: fix test ``                                               |
| [`722a260c`](https://github.com/NixOS/nixpkgs/commit/722a260c8a17711cd6fb6b27ab874165b1bcdbd9) | `` vsmtp: 1.3.3 -> 2.0.0 ``                                                     |
| [`e8878d4e`](https://github.com/NixOS/nixpkgs/commit/e8878d4ebc1e14d5b5f3c0ea4a4d350c95bd8491) | `` plex: 1.30.0.6486-629d58034 -> 1.30.1.6562-915986d62 ``                      |
| [`a0d2fa17`](https://github.com/NixOS/nixpkgs/commit/a0d2fa17bee251db0b74f7f8df2907b1aaf9398d) | `` julia_19: init at 1.9.0-beta2 ``                                             |
| [`1f8f2ca1`](https://github.com/NixOS/nixpkgs/commit/1f8f2ca19a51c768eda06e3ebd6f1b16eaa633c5) | `` python310Packages.ansible-later: 3.0.2 -> 3.1.0 ``                           |
| [`0206a083`](https://github.com/NixOS/nixpkgs/commit/0206a083136cbb1f319fc0c1b6517d2916b31a5a) | `` aoc-cli: init at 0.11.0 ``                                                   |
| [`a9fca3ec`](https://github.com/NixOS/nixpkgs/commit/a9fca3ece2b129d68bfeccca573121858c0f3691) | `` twilio-cli: 5.3.1 -> 5.3.2 ``                                                |
| [`493fe01d`](https://github.com/NixOS/nixpkgs/commit/493fe01d9f00257654ee346f6b039cda8d960a35) | `` ocamlPackages.mldoc: 1.4.9 -> 1.5.2 ``                                       |
| [`70759f9c`](https://github.com/NixOS/nixpkgs/commit/70759f9cf72b5c38e984521e11ca8280a601efbe) | `` vale: 2.21.3 -> 2.22.0 ``                                                    |
| [`9731fff1`](https://github.com/NixOS/nixpkgs/commit/9731fff13e13340a982b451c0c3ea40af232070c) | `` buildkit: 0.10.6 -> 0.11.0 ``                                                |
| [`c08a7c06`](https://github.com/NixOS/nixpkgs/commit/c08a7c06eb19a9997ea06a4eb3cd8afd1e99e368) | `` evcc: 0.111.0 -> 0.111.1 ``                                                  |
| [`2d430021`](https://github.com/NixOS/nixpkgs/commit/2d430021f1a143a5557fbf15b2f71c4e5e73ae22) | `` portfolio: 0.60.1 -> 0.60.2 ``                                               |
| [`9408fdff`](https://github.com/NixOS/nixpkgs/commit/9408fdff46d9e71c1f59adaebb5ef0e0ba24ece3) | `` python310Packages.pook: 1.0.2 -> 1.1.0 ``                                    |
| [`d4617c31`](https://github.com/NixOS/nixpkgs/commit/d4617c31bb927221105c257d64b5b380592f3ee6) | `` python310Packages.pook: add changelog to meta ``                             |
| [`9493405d`](https://github.com/NixOS/nixpkgs/commit/9493405d546419cb4975eefab0b66a8d3a0796a9) | `` python310Packages.aioaladdinconnect: 0.1.50 -> 0.1.52 ``                     |
| [`0dee0eec`](https://github.com/NixOS/nixpkgs/commit/0dee0eec6aaa6c8dcff19bb1408f6cc1800dd3d7) | `` typescript-language-server: include typescript ``                            |
| [`d20cccd1`](https://github.com/NixOS/nixpkgs/commit/d20cccd120df98c03cc7fe4e7ed31974c8dade76) | `` cargo-hack: 0.5.25 -> 0.5.26 ``                                              |
| [`520dd560`](https://github.com/NixOS/nixpkgs/commit/520dd5604ff73c473d3d06a9413e26d64f1bc6b3) | `` cargo-deny: 0.13.5 -> 0.13.7 ``                                              |
| [`1ee7fa38`](https://github.com/NixOS/nixpkgs/commit/1ee7fa3882cd250e8447ee8fb8ea36ce6715f72d) | `` invidious: unstable-2023-01-08 -> unstable-2023-01-10 ``                     |
| [`93923837`](https://github.com/NixOS/nixpkgs/commit/93923837b5cbfe3a21c4c0043ac23f063be8e3a5) | `` pkgsMusl.wxGTK32: fix build ``                                               |
| [`e4e64ad6`](https://github.com/NixOS/nixpkgs/commit/e4e64ad6ade6353e32d69d2bf3b4656ba41b31db) | `` pulumictl: 0.0.38 -> 0.0.39 ``                                               |
| [`7eabf29b`](https://github.com/NixOS/nixpkgs/commit/7eabf29b98470c8f918d79e280a9669b72e578e3) | `` vscode-extensions.streetsidesoftware.code-spell-checker: 2.12.0 -> 2.14.0 `` |
| [`c7ce0c86`](https://github.com/NixOS/nixpkgs/commit/c7ce0c86a69f976b7dfb5f80221f02a18d15c706) | `` gnat12: Fix GNAT Darwin dylib install names ``                               |
| [`9ff579f6`](https://github.com/NixOS/nixpkgs/commit/9ff579f6ea97aceea2e70874e0f115bb3f9c41d1) | `` gobgp: 3.9.0 -> 3.10.0 ``                                                    |
| [`d792f00a`](https://github.com/NixOS/nixpkgs/commit/d792f00a19e7f4dfae73803b602dc2d35e8bb102) | `` python310Packages.gitpython: 3.1.29 -> 3.1.30 ``                             |
| [`654b3afa`](https://github.com/NixOS/nixpkgs/commit/654b3afaf85dc5d3523df61a16190cbf403e80e2) | `` terraspace: init at 2.2.3 ``                                                 |
| [`5a8bcb2a`](https://github.com/NixOS/nixpkgs/commit/5a8bcb2a73ea8179bd650f85e4071da9c6cd9733) | `` maintainers: add mislavzanic ``                                              |
| [`d0e4c10d`](https://github.com/NixOS/nixpkgs/commit/d0e4c10df522e82ade423ea3a2d15a3d39030e61) | `` mariadb: fix darwin build ``                                                 |
| [`0525d149`](https://github.com/NixOS/nixpkgs/commit/0525d149504201b9d05e121847eb7883ce98a66a) | `` mariadb_109: 10.9.3 -> 10.9.4 ``                                             |
| [`91b70ce7`](https://github.com/NixOS/nixpkgs/commit/91b70ce7aaa6ca6d400dfb88ae2377d4dffbe35b) | `` mariadb_108: 10.8.5 -> 10.8.6 ``                                             |
| [`4a6b0747`](https://github.com/NixOS/nixpkgs/commit/4a6b0747ed79496fff7e6c764e32b98355bbdd41) | `` mariadb_106: 10.6.10 -> 10.6.11 ``                                           |
| [`b217e7df`](https://github.com/NixOS/nixpkgs/commit/b217e7dfcb3e6d5747eedf4d40060a0f26e3bd61) | `` mariadb_105: 10.5.17 -> 10.5.18 ``                                           |
| [`7952d7bc`](https://github.com/NixOS/nixpkgs/commit/7952d7bc14c97c4b8e1c81e837e38853249947c0) | `` mariadb_104: 10.4.26 -> 10.4.27 ``                                           |
| [`c0796f71`](https://github.com/NixOS/nixpkgs/commit/c0796f7158d05e1868f217d608ee78927fa4aba6) | `` vaultwarden.webvault: 2022.10.0 -> 2022.12.0 ``                              |
| [`dc837121`](https://github.com/NixOS/nixpkgs/commit/dc837121ca314e05bdb3e98b121d3ab5c0c27487) | `` vaultwarden: 1.26.0 -> 1.27.0 ``                                             |
| [`53fc8875`](https://github.com/NixOS/nixpkgs/commit/53fc887582fba4fd4938ce1b647d6152ea374ed1) | `` nixos/manual: move "edit the MD file" comments to generated XML ``           |
| [`b15f4d0f`](https://github.com/NixOS/nixpkgs/commit/b15f4d0f9735f3dbce30b7d8c490627f5d9394e5) | `` nixos/akkoma: auto-generate module chapter from MD ``                        |
| [`bf92eaeb`](https://github.com/NixOS/nixpkgs/commit/bf92eaebe4afd03f029292f8cf5efa333fd0078a) | `` nixos/manual: generate module chapters with md-to-db.sh ``                   |
| [`dc7788ef`](https://github.com/NixOS/nixpkgs/commit/dc7788efb8bcbe68d1183cf7ee281186315802ca) | `` nixos/manual: regenerate chapter xml files ``                                |