### PR TITLE
chore(flake/nixpkgs): `befc8390` -> `d7705c01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673631141,
-        "narHash": "sha256-AprpYQ5JvLS4wQG/ghm2UriZ9QZXvAwh1HlgA/6ZEVQ=",
+        "lastModified": 1674120619,
+        "narHash": "sha256-xLT1FQl7/jNPOEq5q/vmc3AExt1V9LtcjM+QY2+MUpA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "befc83905c965adfd33e5cae49acb0351f6e0404",
+        "rev": "d7705c01ef0a39c8ef532d1033bace8845a07d35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`8d45d82c`](https://github.com/NixOS/nixpkgs/commit/8d45d82c71b91872e853f0bce3ed69993508ec5e) | `` Revert "nixos/tests/installer: test relative paths in initrd secrets" ``                  |
| [`5f1c4f33`](https://github.com/NixOS/nixpkgs/commit/5f1c4f33a8c42a1b5b5fb72e5a21c14fae2feb8d) | `` python310Packages.trove-classifiers: add changelog to meta ``                             |
| [`f724cc32`](https://github.com/NixOS/nixpkgs/commit/f724cc32b28405e595c4672a4b30a379149a8ea5) | `` python310Packages.asn1: 2.6.0 -> 2.7.0 ``                                                 |
| [`715e04a7`](https://github.com/NixOS/nixpkgs/commit/715e04a72a9b2f7f0e92b24cdce03b4b5d802894) | `` python310Packages.asn1: add changelog to meta ``                                          |
| [`38b32693`](https://github.com/NixOS/nixpkgs/commit/38b326931ee5901fb67e2d3bbece27545b11e423) | `` python310Packages.aiowebostv: 0.3.1 -> 0.3.2 ``                                           |
| [`b5a3f795`](https://github.com/NixOS/nixpkgs/commit/b5a3f795c33ac28c1e403766f1582e117b5c1bd3) | `` nixos/nomad: fix multi-plugin-dir path ``                                                 |
| [`0b9f9e86`](https://github.com/NixOS/nixpkgs/commit/0b9f9e8621e2bc5b98bb396e7a1740f9aaf22bf4) | `` mldonkey: migrate to OCaml 4.13 ``                                                        |
| [`16ef918b`](https://github.com/NixOS/nixpkgs/commit/16ef918b424e3456d809d50109e8605a9969db5f) | `` ekrhyper: migrate to OCaml 4.14 ``                                                        |
| [`67e26d3d`](https://github.com/NixOS/nixpkgs/commit/67e26d3df7f371a59991f2e708c12c7be68ed5d5) | `` weidu: use unsafe string settings ``                                                      |
| [`64a4e05f`](https://github.com/NixOS/nixpkgs/commit/64a4e05f0d2932619fa8b4642d89ea97512771e8) | `` ocaml: add unsafe string support ``                                                       |
| [`a841e262`](https://github.com/NixOS/nixpkgs/commit/a841e262264e48722dccc8469f066068146e406b) | `` terraform-providers.archive: 2.2.0 → 2.3.0 ``                                             |
| [`9d86c34f`](https://github.com/NixOS/nixpkgs/commit/9d86c34f8c603509ef8943ebda6759b0cd07a9dc) | `` terraform-providers.oci: 4.103.0 → 4.104.0 ``                                             |
| [`967d6520`](https://github.com/NixOS/nixpkgs/commit/967d6520d4b331f063683f9fb103a26eb85116c2) | `` scaleway-cli: 2.8.0 -> 2.9.0 ``                                                           |
| [`676c80dc`](https://github.com/NixOS/nixpkgs/commit/676c80dcc2f0ba780c8ab204f92c5abd69fa1245) | `` nix-doc: 0.5.6 -> 0.5.7 ``                                                                |
| [`c1db6e9b`](https://github.com/NixOS/nixpkgs/commit/c1db6e9b0c2882386a107b33ed72a84ec9d02a15) | `` clj-kondo: 2023.01.12 -> 2023.01.16 ``                                                    |
| [`e8da6850`](https://github.com/NixOS/nixpkgs/commit/e8da68509757a130f1b6a791b1dee627d4a66a36) | `` act: 0.2.35 -> 0.2.40 ``                                                                  |
| [`d0a62506`](https://github.com/NixOS/nixpkgs/commit/d0a6250668d0e794308bee853617bea77865d768) | `` git-nomad: fix build ``                                                                   |
| [`f0705939`](https://github.com/NixOS/nixpkgs/commit/f070593940bf77d37766a2ae1c27d15fda34bc4d) | `` home-assistant: pin icalendar at 4.1.0 ``                                                 |
| [`556a4a79`](https://github.com/NixOS/nixpkgs/commit/556a4a7951a80bb73f395aedd105ffe80329fadb) | `` nixos/installation-cd-minimal: include HTML doc ``                                        |
| [`62e3072d`](https://github.com/NixOS/nixpkgs/commit/62e3072db680bc19d143cc19eed58bdc5b47f0aa) | `` onefetch: fix build ``                                                                    |
| [`c9755191`](https://github.com/NixOS/nixpkgs/commit/c975519101eb452c9453b98f048f9b64262c8614) | `` python310Packages.losant-rest: 1.17.0 -> 1.17.1 ``                                        |
| [`1ac1ac2a`](https://github.com/NixOS/nixpkgs/commit/1ac1ac2a80c026f123b3b08dd12b4d15f0c5302c) | `` python310Packages.trove-classifiers: 2022.12.22 -> 2023.1.12 ``                           |
| [`210c48b4`](https://github.com/NixOS/nixpkgs/commit/210c48b466ba60d2be685c9d6a767d5e6e27f2d9) | `` emacsPackages.perl-completion: fix evaluation and mark as broken ``                       |
| [`e1368b80`](https://github.com/NixOS/nixpkgs/commit/e1368b802cd170b4557ac6a77c888bbe50bfe570) | `` python310Packages.caldav: 0.11.0 -> 1.0.1 ``                                              |
| [`244bdb85`](https://github.com/NixOS/nixpkgs/commit/244bdb85ea4c9c94d127f03da3d59f44be101d13) | `` python310Packages.bthome-ble: 2.4.1 -> 2.5.0 ``                                           |
| [`dc7e470e`](https://github.com/NixOS/nixpkgs/commit/dc7e470ecab688631f00184b50220be14415675e) | `` python310Packages.pylutron-caseta: 0.17.1 -> 0.18.0 ``                                    |
| [`ea764588`](https://github.com/NixOS/nixpkgs/commit/ea76458891e07edbbb6a9114c6d6d945823ab69b) | `` python310Packages.pylutron-caseta: add changelog to meta ``                               |
| [`fe0fbe3d`](https://github.com/NixOS/nixpkgs/commit/fe0fbe3d7ba0dcc9a884a97e80a98c0f19dfec7f) | `` ytfzf: 2.5.3 -> 2.5.4 ``                                                                  |
| [`96d3e170`](https://github.com/NixOS/nixpkgs/commit/96d3e1705361ac71d7419aa891316c257ade4d65) | `` python310Packages.aliyun-python-sdk-cdn: 3.7.11 -> 3.8.0 ``                               |
| [`84e9c90d`](https://github.com/NixOS/nixpkgs/commit/84e9c90ddeca3228fdd684d4033f0f6cd65afc17) | `` python310Packages.airthings-ble: 0.5.3 -> 0.5.4 ``                                        |
| [`af3ecb53`](https://github.com/NixOS/nixpkgs/commit/af3ecb534234ece5d4630ca0ee0270e08b7cae43) | `` python310Packages.bthome-ble: 2.4.1 -> 2.5.0 ``                                           |
| [`82b68fc6`](https://github.com/NixOS/nixpkgs/commit/82b68fc6cb8907502628083024513e20eb1b9e85) | `` python310Packages.hahomematic: 2023.1.3 -> 2023.1.4 ``                                    |
| [`91a78140`](https://github.com/NixOS/nixpkgs/commit/91a781402dc03fdb2564e6d20e91495411d9e705) | `` python310Packages.aioaladdinconnect: 0.1.52 -> 0.1.53 ``                                  |
| [`3dc0164c`](https://github.com/NixOS/nixpkgs/commit/3dc0164c15350b1d9616adccbbb34e148d6d0d02) | `` oh-my-posh: 13.0.0 -> 13.1.2 ``                                                           |
| [`2a2c4beb`](https://github.com/NixOS/nixpkgs/commit/2a2c4bebe0e9b383334027c9dad1397cb00fc4c5) | `` flyctl: 0.0.447 -> 0.0.450 ``                                                             |
| [`259703ab`](https://github.com/NixOS/nixpkgs/commit/259703abb8ecee5c11c3c1a54138d17f4a0ce6f8) | `` gh-dash: 3.5.1 -> 3.6.0 ``                                                                |
| [`367b935e`](https://github.com/NixOS/nixpkgs/commit/367b935e96a84eae0fb6261f70710ab905b84755) | `` gotrue-supabase: 2.40.2 -> 2.41.0 ``                                                      |
| [`f5915c6a`](https://github.com/NixOS/nixpkgs/commit/f5915c6a0e0ba9ac54470053df5816df5475f7a7) | `` h5utils: 1.13.1 -> 1.13.2 ``                                                              |
| [`62ee0748`](https://github.com/NixOS/nixpkgs/commit/62ee07482e38942f6310fa6a971af7249e05355d) | `` ogdf: 2020.02 -> 2022.02 (#205164) ``                                                     |
| [`4bde58a2`](https://github.com/NixOS/nixpkgs/commit/4bde58a2241c665336323ab847078498d72d9b8e) | `` haskellPackages.curl: fix build with curl >= 7.87 ``                                      |
| [`4743258d`](https://github.com/NixOS/nixpkgs/commit/4743258d43e3a67bef5b031cc579c22c3c9161d1) | `` python310Packages.azure-mgmt-media: 10.1.0 -> 10.2.0 ``                                   |
| [`f4fe2837`](https://github.com/NixOS/nixpkgs/commit/f4fe2837d75d7c28bd5e1d0e1f233ec8c133a41f) | `` kubernetes-helm: 3.10.3 -> 3.11.0 ``                                                      |
| [`2eb3417f`](https://github.com/NixOS/nixpkgs/commit/2eb3417f757ec217c659c93d6910e49e6d45959b) | `` vikunja-frontend: 0.20.1 -> 0.20.2 ``                                                     |
| [`7d3b30c5`](https://github.com/NixOS/nixpkgs/commit/7d3b30c57e58a5c19ce46820b1e2c36b77b8dfa9) | `` sumneko-lua-language-server: 3.6.4 -> 3.6.5 ``                                            |
| [`daec4d1d`](https://github.com/NixOS/nixpkgs/commit/daec4d1def6eb8a1a508902cdf7de891e17314c8) | `` perlPackages.Tk: 804.035 -> 804.036 ``                                                    |
| [`4e567d77`](https://github.com/NixOS/nixpkgs/commit/4e567d779f4b7e374f165438db7837642cc2dbcf) | `` perlPackages.TclpTk: 1.09 -> 1.10 ``                                                      |
| [`b2816206`](https://github.com/NixOS/nixpkgs/commit/b2816206ff5e47ec6e981e932ca9d6142222a29b) | `` sudo: 1.9.12p1 -> 1.9.12p2 ``                                                             |
| [`7f145286`](https://github.com/NixOS/nixpkgs/commit/7f145286ed2e439efe0d5265ac39cc28b084dfb2) | `` openshot-qt: 2.6.1 -> 3.0.0 ``                                                            |
| [`cf207b25`](https://github.com/NixOS/nixpkgs/commit/cf207b25f4be1bc12a4fba122c44001408106717) | `` libopenshot: 0.2.7 -> 0.3.0 ``                                                            |
| [`a89dae74`](https://github.com/NixOS/nixpkgs/commit/a89dae74dd9b6e19e055ceb51d5b137c69e48f8f) | `` sage: paper over ipywidgets deprecation warning ``                                        |
| [`dbfad6fc`](https://github.com/NixOS/nixpkgs/commit/dbfad6fca82ab191a8f1b59591b353bf57989325) | `` rpiboot: add flokli to maintainers ``                                                     |
| [`c667f030`](https://github.com/NixOS/nixpkgs/commit/c667f030692a7dfdf0aacef0e80c9803d772b76f) | `` wslu: 4.1.0 -> 4.1.1 (#211396) ``                                                         |
| [`7c745e17`](https://github.com/NixOS/nixpkgs/commit/7c745e170acfcf918e04ae895cc2040c0c69939b) | `` rpiboot: 2021.07.01 -> 20221215-105525 ``                                                 |
| [`3998d525`](https://github.com/NixOS/nixpkgs/commit/3998d52508f357451c4e1b40fbd8b1ecc4b2097f) | `` gitlab: 15.7.3 -> 15.7.5 (#211392) ``                                                     |
| [`2c68314e`](https://github.com/NixOS/nixpkgs/commit/2c68314eb1ef45ca96227d002f965522b0c86509) | `` python310Packages.mistletoe: add changelog to meta ``                                     |
| [`59fc1d36`](https://github.com/NixOS/nixpkgs/commit/59fc1d36478ed22292197bd7413402450db215f0) | `` sageWithDoc: import sphinx 5.1->5.3 upgrade patches ``                                    |
| [`f51c543b`](https://github.com/NixOS/nixpkgs/commit/f51c543b8b2b369efd9956839c3e5059d141186a) | `` datovka: 4.15.6 -> 4.21.1 ``                                                              |
| [`ab4f0e71`](https://github.com/NixOS/nixpkgs/commit/ab4f0e71e8a85787ef4338aa4217dbdef1d7e809) | `` libdatovka: init at 0.2.1 ``                                                              |
| [`7f23fce6`](https://github.com/NixOS/nixpkgs/commit/7f23fce6f45d77332213c9a268f94b345a90511e) | `` maintainers: add ovlach ``                                                                |
| [`6bd0eb8b`](https://github.com/NixOS/nixpkgs/commit/6bd0eb8bb678af02f07b78564faac4f72cd39856) | `` argo-rollouts: 1.3.2 -> 1.4.0 ``                                                          |
| [`03f9d6ac`](https://github.com/NixOS/nixpkgs/commit/03f9d6ac4227f780dd6214d682150d749712386d) | `` yamlpath: 3.6.9 -> 3.7.0 ``                                                               |
| [`9249c4bf`](https://github.com/NixOS/nixpkgs/commit/9249c4bfbfe6bc174d6868c512704bdb8349d304) | `` linkerd_edge: 22.12.1 -> 23.1.1 ``                                                        |
| [`de21b184`](https://github.com/NixOS/nixpkgs/commit/de21b184d9d4a52a8db94a7edca589b3c7b89fc7) | `` rust-analyzer-unwrapped: 2023-01-09 -> 2023-01-16 ``                                      |
| [`fa00de16`](https://github.com/NixOS/nixpkgs/commit/fa00de165065ebf0172481db768878cb2bd53053) | `` symfony-cli: 5.4.20 -> 5.4.21 ``                                                          |
| [`3199fa60`](https://github.com/NixOS/nixpkgs/commit/3199fa608483daef5722a31f9dc586889655df22) | `` karmor: 0.11.4 -> 0.11.5 ``                                                               |
| [`846e4de6`](https://github.com/NixOS/nixpkgs/commit/846e4de6e8b5e9942ced078410b452fb546d1d9b) | `` darwin.apple_sdk_11_0.libpm: init ``                                                      |
| [`6fbe9c5d`](https://github.com/NixOS/nixpkgs/commit/6fbe9c5daa8d4a3f8b910075629ab9fadb3fab4f) | `` plantuml-server: 1.2022.14 -> 1.2023.0 ``                                                 |
| [`b97988db`](https://github.com/NixOS/nixpkgs/commit/b97988db6798fb0af58491178748c341244b662f) | `` snac2: 2.12 -> 2.15 ``                                                                    |
| [`6692659c`](https://github.com/NixOS/nixpkgs/commit/6692659ce6d73262463d28d271f8a1ad4c1c43ef) | `` sage: matplotlib 3.6 upgrade fixes ``                                                     |
| [`ba469ed1`](https://github.com/NixOS/nixpkgs/commit/ba469ed1361466711dc92a5cd91f8e46251feee3) | `` qtrvsim: 0.9.4 -> 0.9.5 ``                                                                |
| [`094b6a2f`](https://github.com/NixOS/nixpkgs/commit/094b6a2f63fd6f6cc5fc5ba69627395ae2edb084) | `` python310Packages.pyskyqremote: 0.3.23 -> 0.3.24 ``                                       |
| [`57c1e959`](https://github.com/NixOS/nixpkgs/commit/57c1e9599ade166b1610b8f7ba49c144106013c8) | `` snowflake: 2.4.3 -> 2.5.0 ``                                                              |
| [`1a355ae7`](https://github.com/NixOS/nixpkgs/commit/1a355ae7514c8095a19c296883f4465c84152cec) | `` libcddb: broaden platforms ``                                                             |
| [`e8b42ea1`](https://github.com/NixOS/nixpkgs/commit/e8b42ea1ca9937835b9a8eb48c9ee5ceb1ad6eae) | `` libcddb: depend on libiconv unconditionally ``                                            |
| [`d01e46db`](https://github.com/NixOS/nixpkgs/commit/d01e46db3c45c72cdda1572ee2037fd0fb2898a6) | `` fzf: only wrap perl on Linux ``                                                           |
| [`e88859c5`](https://github.com/NixOS/nixpkgs/commit/e88859c53cade58687b851749887cf701e49bd89) | `` postgresql: fix enableSystemd on other Unixes ``                                          |
| [`3aaa00b4`](https://github.com/NixOS/nixpkgs/commit/3aaa00b468c4b09a3fa891dc1f3f57ed389f5de1) | `` python310Packages.mistletoe: 0.9.0 -> 1.0.0 ``                                            |
| [`dd8a787d`](https://github.com/NixOS/nixpkgs/commit/dd8a787d4a7eef385a02ef9795a4d28108bc4051) | `` udev: set to libudev-zero on static linux ``                                              |
| [`b0997077`](https://github.com/NixOS/nixpkgs/commit/b0997077e77465b0773339b0bd643d424c771fa5) | `` perl: don't use libxcrypt on FreeBSD ``                                                   |
| [`817fd4c1`](https://github.com/NixOS/nixpkgs/commit/817fd4c1a838ab37733b9e0a1680c40a856826b9) | `` nerdfonts: 2.2.2 -> 2.3.0 ``                                                              |
| [`a5e13632`](https://github.com/NixOS/nixpkgs/commit/a5e136325868d6439b405dffbe782f5abbd0ee1a) | `` llvmPackages.bintools: remove as -> llvm-as symlink ``                                    |
| [`3d1e0393`](https://github.com/NixOS/nixpkgs/commit/3d1e0393328d3c9128b32fbcb00f88e87af25c7c) | `` llvmPackages.bintools-unwrapped: add missing symlinks ``                                  |
| [`4fea5e46`](https://github.com/NixOS/nixpkgs/commit/4fea5e46aa876d817487ff2c2247ecbe34999d20) | `` python3Packages.poetry-dynamic-versioning: fix build after last version bump (#211155) `` |
| [`2dfd7d22`](https://github.com/NixOS/nixpkgs/commit/2dfd7d22c668751ee3d8152e8de1783d27ad0551) | `` torq: init at 0.16.9 ``                                                                   |
| [`2b988c76`](https://github.com/NixOS/nixpkgs/commit/2b988c76fd3b6f1f1117b419a83589fb7cea14bf) | `` Revert "nixosTests.installer: bump memorySize" ``                                         |
| [`e58acc31`](https://github.com/NixOS/nixpkgs/commit/e58acc31d6f5d817dc2ee604c2d04679f9362e25) | `` armadillo: 11.4.2 -> 11.4.3 ``                                                            |
| [`ff330ceb`](https://github.com/NixOS/nixpkgs/commit/ff330ceb76519e3603e9c593c647ff30e5006714) | `` chezmoi: 2.29.1 -> 2.29.2 ``                                                              |
| [`b1bc13a1`](https://github.com/NixOS/nixpkgs/commit/b1bc13a1622c8d2fee0a475708ad1ea23f8f94ac) | `` rustic-rs: 0.4.2 -> 0.4.3 ``                                                              |
| [`eda69033`](https://github.com/NixOS/nixpkgs/commit/eda69033eb3279847ccdfbc60f43f88c6dedee65) | `` doc/haskell: nits ``                                                                      |
| [`541af71f`](https://github.com/NixOS/nixpkgs/commit/541af71fbc78557fa4ee7651c27edf1bc5589ee7) | `` mpvScripts.thumbnail: 0.5.1 -> 0.5.2 ``                                                   |
| [`7b19e25b`](https://github.com/NixOS/nixpkgs/commit/7b19e25b87c3e6a4cdbc36607c9c99edac62fd0e) | `` qmake2cmake: init at 1.0.2 ``                                                             |
| [`7d96b447`](https://github.com/NixOS/nixpkgs/commit/7d96b4474df2584642bce02783fd0f07c0423092) | `` ov: 0.13.0 -> 0.14.0 ``                                                                   |
| [`c7c5251a`](https://github.com/NixOS/nixpkgs/commit/c7c5251a2ceb9546c6588b7bdc4586118f66cae1) | `` terraform-providers.spotinst: 1.92.0 → 1.94.0 ``                                          |
| [`6180cb37`](https://github.com/NixOS/nixpkgs/commit/6180cb3707c717614890525e014579c9d506be03) | `` terraform-providers.pagerduty: 2.9.1 → 2.9.2 ``                                           |
| [`a33035b9`](https://github.com/NixOS/nixpkgs/commit/a33035b984ff2b4034126c08d4a98378145df7df) | `` terraform-providers.google-beta: 4.48.0 → 4.49.0 ``                                       |
| [`8acbfd29`](https://github.com/NixOS/nixpkgs/commit/8acbfd29b6f4c3fe7de83be931795e4328d03791) | `` terraform-providers.google: 4.48.0 → 4.49.0 ``                                            |
| [`c0adf187`](https://github.com/NixOS/nixpkgs/commit/c0adf187c6bbafc9422eaf541c3cee7f7be02a00) | `` terraform-providers.github: 5.14.0 → 5.15.0 ``                                            |
| [`e881ff3f`](https://github.com/NixOS/nixpkgs/commit/e881ff3f79c57d3d2a3f4b833d29743c419a4d1f) | `` terraform-providers.cloudamqp: 1.22.0 → 1.22.1 ``                                         |
| [`b6a1d3f9`](https://github.com/NixOS/nixpkgs/commit/b6a1d3f93500e16c600041846a0863739437c140) | `` cinnamon.mint-themes: 2.0.8 -> 2.0.9 ``                                                   |
| [`c7e7050d`](https://github.com/NixOS/nixpkgs/commit/c7e7050dadffcee0b53bbd2b916bb4949b52bd1d) | `` nix-doc: 0.5.5 -> 0.5.6 ``                                                                |
| [`3bf0de1e`](https://github.com/NixOS/nixpkgs/commit/3bf0de1ee9f850a00945c3b88eb222e9a07677d7) | `` fastly: 4.6.1 -> 4.6.2 ``                                                                 |
| [`c35354ec`](https://github.com/NixOS/nixpkgs/commit/c35354ecb2e821eeab66eb6aafb8829ca1947cb3) | `` yq-go: 4.30.6 -> 4.30.8 ``                                                                |
| [`776e0f60`](https://github.com/NixOS/nixpkgs/commit/776e0f600a84eb78d1429a637435fe40fb7755d6) | `` termusic: 0.7.7 -> 0.7.8 ``                                                               |
| [`766b04b1`](https://github.com/NixOS/nixpkgs/commit/766b04b1188922236c95c142836900f64da3c756) | `` datree: 1.8.12 -> 1.8.14 ``                                                               |
| [`c8b20e1c`](https://github.com/NixOS/nixpkgs/commit/c8b20e1c4168642f9fc92fb8d7fa465eb7a18c5c) | `` apk-tools: don't pin to openssl_1_1 ``                                                    |
| [`86470064`](https://github.com/NixOS/nixpkgs/commit/86470064922b18e7e6245a2e3afe54d6a5409906) | `` rustPlatform.importCargoLock: pass allRefs to builtins.fetchGit (#211298) ``              |
| [`d8047358`](https://github.com/NixOS/nixpkgs/commit/d804735878ad86e05cafe6b051c7bf4fafca0991) | `` ursadb: 1.5.0 -> 1.5.1 ``                                                                 |
| [`415504e8`](https://github.com/NixOS/nixpkgs/commit/415504e8679960580660f220249ce0c2878fe95d) | `` lib/tests/release.nix: Make nix a parameter + strictDeps ``                               |
| [`2e7c15c7`](https://github.com/NixOS/nixpkgs/commit/2e7c15c76fbd4aa74e659e6b0759e224d4d5c467) | `` fcitx5-anthy: init at 5.0.13 ``                                                           |
| [`4376bafd`](https://github.com/NixOS/nixpkgs/commit/4376bafd1e52b738b4d2b5ab136f2d68b969a81c) | `` nuclei: 2.8.6 -> 2.8.7 ``                                                                 |
| [`db0f039c`](https://github.com/NixOS/nixpkgs/commit/db0f039c7904d3762dad7352bb3e539539293a29) | `` the-way: 0.18.0 -> 0.19.0 ``                                                              |
| [`4d49da62`](https://github.com/NixOS/nixpkgs/commit/4d49da629f70db4d11eb4d993685f1a8d9bb5c30) | `` Revert "pythonPackages.nbxmpp: 4.0.0 → 4.0.1; gajim: 1.6.0 → 1.6.1" ``                    |
| [`bc7386de`](https://github.com/NixOS/nixpkgs/commit/bc7386def270088ea11b6f6170bd60d948cd7ce1) | `` liferea: 1.14-RC3 -> 1.14.0 ``                                                            |
| [`cdd8bd07`](https://github.com/NixOS/nixpkgs/commit/cdd8bd07994bb00d6e08ff26ab71eba03249eec1) | `` fzf: 0.35.1 -> 0.36.0 ``                                                                  |