### PR TITLE
chore(flake/home-manager): `bd3efacb` -> `2c29ae48`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1673948101,
-        "narHash": "sha256-cD0OzFfnLFeeaz4jVszH9QiMTn+PBxmcYzrp+xujpwM=",
+        "lastModified": 1674041176,
+        "narHash": "sha256-cMf1BQzI39nHQ0H/mOatthbbI3392qLmJ9gU0u520P4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bd3efacb82c721edad1ce9eda583df5fb62ab00a",
+        "rev": "2c29ae48f9a149151bdd82f429ac61d4412c312a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`2c29ae48`](https://github.com/nix-community/home-manager/commit/2c29ae48f9a149151bdd82f429ac61d4412c312a) | `` docs: bump nmd ``                 |
| [`6c5b08a0`](https://github.com/nix-community/home-manager/commit/6c5b08a0c1fd54e7a5aa8ae088a7d981d441c57b) | `` docs: fetch nmd from sourcehut `` |