### PR TITLE
chore(flake/pre-commit-hooks): `756cc26a` -> `3e42a775`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,16 +190,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1671271954,
-        "narHash": "sha256-cSvu+bnvN08sOlTBWbBrKaBHQZq8mvk8bgpt0ZJ2Snc=",
+        "lastModified": 1673800717,
+        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d513b448cc2a6da2c8803e3c197c9fc7e67b19e3",
+        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -219,11 +219,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1674046351,
-        "narHash": "sha256-vNErPj4gfO/G1vHuOh5/IbjLaydwePcRlD0fXlnUbmI=",
+        "lastModified": 1674075316,
+        "narHash": "sha256-0uZuAcYBpNJLxr7n5O0vhwn3rSLpUTm9M5WGgmNQ+wM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "756cc26afb75b0f8bfec48bbc54a8836a04953fb",
+        "rev": "3e42a77571cc0463efa470dbcffa063977a521ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                   |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`3e42a775`](https://github.com/cachix/pre-commit-hooks.nix/commit/3e42a77571cc0463efa470dbcffa063977a521ab) | `` README: mention first-class integration into devenv `` |
| [`ebff638f`](https://github.com/cachix/pre-commit-hooks.nix/commit/ebff638f3b6f89ab3eb98eaab7a9fda7b65c5198) | `` revert nixpkgs-unstable bump and cleanup ``            |
| [`2904e3d9`](https://github.com/cachix/pre-commit-hooks.nix/commit/2904e3d90f092209c4ba59530703496ecc83942e) | `` remove nix-linter as it's unmaintained ``              |
| [`40185412`](https://github.com/cachix/pre-commit-hooks.nix/commit/401854129b442c3999f8616353ed7827614d808f) | `` brittany: remove as it's deprecated ``                 |
| [`6beacee6`](https://github.com/cachix/pre-commit-hooks.nix/commit/6beacee69601abb32ae0cb038f701cffc527dec7) | `` nixos: 22.05 -> 22.11 ``                               |