### PR TITLE
chore(flake/home-manager): `2c29ae48` -> `866a4ddc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674041176,
-        "narHash": "sha256-cMf1BQzI39nHQ0H/mOatthbbI3392qLmJ9gU0u520P4=",
+        "lastModified": 1674080704,
+        "narHash": "sha256-nOJjN7ZnqUMGB/SnArIK2VCxCTc5f2GDv1/TbeNp3TE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2c29ae48f9a149151bdd82f429ac61d4412c312a",
+        "rev": "866a4ddcb3d3f21b1a0ce9dc1accd1704ecabbb9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`866a4ddc`](https://github.com/nix-community/home-manager/commit/866a4ddcb3d3f21b1a0ce9dc1accd1704ecabbb9) | `` firefox: refactor search.json.mozlz4 generation `` |