### PR TITLE
chore(flake/deploy-rs): `a5619f56` -> `8c9ea960`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1672327199,
-        "narHash": "sha256-pFlngSHXKBhAmbaKZ4FYtu57LLunG+vWdL7a5vw1RvQ=",
+        "lastModified": 1674127017,
+        "narHash": "sha256-QO1xF7stu5ZMDLbHN30LFolMAwY6TVlzYvQoUs1RD68=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "a5619f5660a00f58c2b7c16d89058e92327ac9b8",
+        "rev": "8c9ea9605eed20528bf60fae35a2b613b901fd77",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                 |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`8c9ea960`](https://github.com/serokell/deploy-rs/commit/8c9ea9605eed20528bf60fae35a2b613b901fd77) | `` Switch from buildkite CI to github-actions (#190) `` |