### PR TITLE
chore(flake/nixpkgs): `d7705c01` -> `5ed48194`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674120619,
-        "narHash": "sha256-xLT1FQl7/jNPOEq5q/vmc3AExt1V9LtcjM+QY2+MUpA=",
+        "lastModified": 1674211260,
+        "narHash": "sha256-xU6Rv9sgnwaWK7tgCPadV6HhI2Y/fl4lKxJoG2+m9qs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d7705c01ef0a39c8ef532d1033bace8845a07d35",
+        "rev": "5ed481943351e9fd354aeb557679624224de38d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`59a8503c`](https://github.com/NixOS/nixpkgs/commit/59a8503c6ce84cdeedf59146d870a605b900cee5) | `` memray: 1.5.0 -> 1.6.0 ``                                                |
| [`9c1a0160`](https://github.com/NixOS/nixpkgs/commit/9c1a01601f186bd9ecfbaaa476e450aa690cac6e) | `` python310Packages.asyauth: 0.0.10 -> 0.0.11 ``                           |
| [`5354b758`](https://github.com/NixOS/nixpkgs/commit/5354b758193ce9f3e0ab933455f5e8e06db0243c) | `` python310Packages.asysocks: 0.2.3 -> 0.2.5 ``                            |
| [`4f6cc496`](https://github.com/NixOS/nixpkgs/commit/4f6cc496ba5e8532fe5bdbe019ad7713422be622) | `` python310Packages.atenpdu: 0.4.0 -> 0.5.0 ``                             |
| [`fdea32ea`](https://github.com/NixOS/nixpkgs/commit/fdea32eab1a8cf44595ad0a70fadfea193762258) | `` python310Packages.pysoma: 0.0.12 -> 0.0.13 ``                            |
| [`48a96282`](https://github.com/NixOS/nixpkgs/commit/48a9628207806f57b563090ccb67088ff89f520c) | `` kubernetes: 1.26.0 -> 1.26.1 ``                                          |
| [`bb2b9506`](https://github.com/NixOS/nixpkgs/commit/bb2b9506a3baf9d2dadcb4e59ba0094e1b46699f) | `` python310Packages.pyoctoprintapi: 0.1.10 -> 0.1.11 ``                    |
| [`bddd68ac`](https://github.com/NixOS/nixpkgs/commit/bddd68ac46a93818f202765896d47e88126c6a97) | `` terraform-providers.spotinst: 1.94.0 → 1.95.1 ``                         |
| [`05277dd2`](https://github.com/NixOS/nixpkgs/commit/05277dd276dae0a056ce5d780fb6059aa1049ddf) | `` terraform-providers.aws: 4.50.0 → 4.51.0 ``                              |
| [`c0776f77`](https://github.com/NixOS/nixpkgs/commit/c0776f77e141ae834932b5bfb0b97b087ed1b64d) | `` terraform-providers.sentry: 0.11.1 → 0.11.2 ``                           |
| [`f191ad0f`](https://github.com/NixOS/nixpkgs/commit/f191ad0f3e49d7c9c3591a181ddc482ebe952d62) | `` terraform-providers.newrelic: 3.12.0 → 3.13.0 ``                         |
| [`2a4408cd`](https://github.com/NixOS/nixpkgs/commit/2a4408cdb40673cf5abf97c9cad218e2ab398040) | `` terraform-providers.azuread: 2.32.0 → 2.33.0 ``                          |
| [`71aab733`](https://github.com/NixOS/nixpkgs/commit/71aab73352a716213aae0ab11005fc0432f8df38) | `` terraform-providers.alicloud: 1.196.0 → 1.197.0 ``                       |
| [`d949e698`](https://github.com/NixOS/nixpkgs/commit/d949e698241675e47c0500c4b3844729351548f2) | `` strawberry: 1.0.13 -> 1.0.14 ``                                          |
| [`b3bf6dc1`](https://github.com/NixOS/nixpkgs/commit/b3bf6dc11212f56e9ad5bd6ab73f9ae940620e37) | `` python3Packages.cryptg: fix build on darwin ``                           |
| [`d1a7d176`](https://github.com/NixOS/nixpkgs/commit/d1a7d1769beab676796dbf2669ec2face1816844) | `` infracost: 0.10.15 -> 0.10.16 ``                                         |
| [`94d3d94a`](https://github.com/NixOS/nixpkgs/commit/94d3d94a57cfa9077500116e7bf72174f1b563b6) | `` vsmtp: fix build ``                                                      |
| [`3c0bdfb5`](https://github.com/NixOS/nixpkgs/commit/3c0bdfb5391aa18ac5a65914c08e0ed9097bae14) | `` zinc: 0.3.5 -> 0.3.6 ``                                                  |
| [`94f05c26`](https://github.com/NixOS/nixpkgs/commit/94f05c26057978eac06daf3919a4591cbf8e5e86) | `` sage: backport intermittent test fix ``                                  |
| [`af036885`](https://github.com/NixOS/nixpkgs/commit/af036885aa5a69527b1b45aa04e7f4adcb29803f) | `` chamber: 2.11.0 -> 2.11.1 ``                                             |
| [`899efc4b`](https://github.com/NixOS/nixpkgs/commit/899efc4b921afb20166e10d1c6ada644321f03be) | `` unpackerr: 0.10.1 -> 0.11.1 ``                                           |
| [`5c0d5541`](https://github.com/NixOS/nixpkgs/commit/5c0d5541111b556c7985f8e7e02037a3723dc46b) | `` mdbook-mermaid: 0.12.1 -> 0.12.6 ``                                      |
| [`4b9dbcd0`](https://github.com/NixOS/nixpkgs/commit/4b9dbcd0b7597bca8b8eba6b687984012b624ba2) | `` aoc-cli: 0.11.0 -> 0.12.0 ``                                             |
| [`e1202ddc`](https://github.com/NixOS/nixpkgs/commit/e1202ddc56534fc93a6c3ff2dc6beaef4474546d) | `` stern: 1.21.0 -> 1.22.0 ``                                               |
| [`f47d1ee9`](https://github.com/NixOS/nixpkgs/commit/f47d1ee9afd472cd89006d67600a7623b8bf124e) | `` ddosify: 0.11.0 -> 0.12.0 ``                                             |
| [`332d83e8`](https://github.com/NixOS/nixpkgs/commit/332d83e8e36e20444ef984767de35f9c329d29ab) | `` hyfetch: 1.4.4 -> 1.4.6 ``                                               |
| [`5ace1140`](https://github.com/NixOS/nixpkgs/commit/5ace114066b68cd0f5718a3e3f7f5448774e2c40) | `` carapace: 0.19.1 -> 0.20.2 ``                                            |
| [`847db1b6`](https://github.com/NixOS/nixpkgs/commit/847db1b6a9b857db3d2c2381b688344fae2b9b24) | `` coder: 0.13.6 -> 0.14.3 ``                                               |
| [`1fb820a1`](https://github.com/NixOS/nixpkgs/commit/1fb820a1f41785bbdfe5e0d0766b496b7c7c37c9) | `` katana: 0.0.2 -> 0.0.3 ``                                                |
| [`bae68672`](https://github.com/NixOS/nixpkgs/commit/bae68672016437cdbca4beb494249daea0c1ce12) | `` nix-direnv: 2.2.0 -> 2.2.1 ``                                            |
| [`a462421d`](https://github.com/NixOS/nixpkgs/commit/a462421d5088b8c5e3039cd7248b4bffd9b1791a) | `` python310Packages.igraph: 0.10.2 -> 0.10.3 ``                            |
| [`d57ec2ef`](https://github.com/NixOS/nixpkgs/commit/d57ec2ef092bd5e3dade2923a03a5fa12c2a7a3c) | `` igraph: 0.10.2 -> 0.10.3 ``                                              |
| [`1f1d1cf5`](https://github.com/NixOS/nixpkgs/commit/1f1d1cf5a5854bf709b8382f138e6f4af329b2c1) | `` Explain why unit tests are disabled. ``                                  |
| [`bdf87c66`](https://github.com/NixOS/nixpkgs/commit/bdf87c666798c1795b5c52b99ff5711443507074) | `` python310Packages.pycaption: 1.0.1 -> 2.1.0 ``                           |
| [`8955106b`](https://github.com/NixOS/nixpkgs/commit/8955106b1ef6eb988ec1101c0ed25f29ecb9b0e1) | `` erigon: 2.34.0 -> 2.35.2 ``                                              |
| [`3526abb3`](https://github.com/NixOS/nixpkgs/commit/3526abb3e144d0e08ef72da972b1a641b9e4c7d6) | `` python310Packages.flake8-bugbear: 22.12.6 -> 23.1.17 ``                  |
| [`65cdb52a`](https://github.com/NixOS/nixpkgs/commit/65cdb52a66c84f7f89e2e31335798b4bda6470a8) | `` valgrind-light: fix build for FreeBSD ``                                 |
| [`89820d60`](https://github.com/NixOS/nixpkgs/commit/89820d60970716b50bd839d5f1e134fd6384b15d) | `` vimPlugins.dirbuf-nvim: init at 2022-08-28 ``                            |
| [`564ed06f`](https://github.com/NixOS/nixpkgs/commit/564ed06fb66713373ad4fcc8749fcc36e2a46371) | `` vimPlugins: update ``                                                    |
| [`938b7ae1`](https://github.com/NixOS/nixpkgs/commit/938b7ae18411ba3d57bce6498f9c31c7d9b1a46e) | `` python3Packages.dm-env: Fix tests ``                                     |
| [`0bf42f0b`](https://github.com/NixOS/nixpkgs/commit/0bf42f0b9bf6e445cff905c77efe73df00898bcf) | `` python3Packages.dm-tree: Fix build ``                                    |
| [`0e69342b`](https://github.com/NixOS/nixpkgs/commit/0e69342bad98c23bbd136bc9331f69fc85cd8169) | `` vector: 0.26.0 -> 0.27.0 ``                                              |
| [`0e2f756d`](https://github.com/NixOS/nixpkgs/commit/0e2f756d95807c5f5df5fb0a2e542f5652717695) | `` lighthouse: fix darwin ``                                                |
| [`305cec3e`](https://github.com/NixOS/nixpkgs/commit/305cec3e7ed4899fada9fcebfbb14928fe3e07c6) | `` git-trim: 0.4.2 -> 0.4.4 ``                                              |
| [`4141729d`](https://github.com/NixOS/nixpkgs/commit/4141729d9c97e3beab8ef95d9ad0420226e27401) | `` souffle: add darwin support (#208373) ``                                 |
| [`a8480b03`](https://github.com/NixOS/nixpkgs/commit/a8480b03a3148ca79ad89b03ed30ae583453a02c) | `` klaus: 2.0.1 -> 2.0.2 ``                                                 |
| [`90fb934f`](https://github.com/NixOS/nixpkgs/commit/90fb934fec1bde7c9ce998f12f89bd83f8e825ff) | `` erlangR25: 25.2 -> 25.2.1 ``                                             |
| [`36c6a989`](https://github.com/NixOS/nixpkgs/commit/36c6a9899bcc43467734506e508d6fb8da9702eb) | `` python310Packages.johnnycanencrypt: 0.11.0 -> 0.12.0 ``                  |
| [`a08c3c99`](https://github.com/NixOS/nixpkgs/commit/a08c3c9961048e8894ae22daeaecaee418748352) | `` vimPlugins.oil-nvim: init at 2023-01-19 ``                               |
| [`550a2f72`](https://github.com/NixOS/nixpkgs/commit/550a2f72a2b3f6a83549e485fb66b771e03a10d6) | `` vimPlugins: update ``                                                    |
| [`afdcfa28`](https://github.com/NixOS/nixpkgs/commit/afdcfa28cccc84f35007379917dde518b8916a27) | `` pureref: init at 1.11.1 ``                                               |
| [`bfbb8b3d`](https://github.com/NixOS/nixpkgs/commit/bfbb8b3d3781471aac9dc716ce6001990fc25b0e) | `` python310Packages.timezonefinder: add meta.changelog ``                  |
| [`586a2865`](https://github.com/NixOS/nixpkgs/commit/586a2865866baebf1eb54b2053ff7918aeeee0f7) | `` python310Packages.timezonefinder: update dependencies ``                 |
| [`e3fb7c33`](https://github.com/NixOS/nixpkgs/commit/e3fb7c3314dacd9927b889daed5deed31e61ca98) | `` rsbkb: init at 1.1 ``                                                    |
| [`1557cc41`](https://github.com/NixOS/nixpkgs/commit/1557cc41603d550e934016a54af0ebcb62a741fa) | `` linuxPackages.nvidia_x11_production: 525.78.01 -> 525.85.05 ``           |
| [`6c358997`](https://github.com/NixOS/nixpkgs/commit/6c35899785ffb5dd1e05dfdfac89a42ce74c0f76) | `` torq: 0.16.9 -> 0.16.15 ``                                               |
| [`d19bb2a2`](https://github.com/NixOS/nixpkgs/commit/d19bb2a22aa374a25ee787036be9598ce0090eec) | `` kubernetes-helm: enable fish completion ``                               |
| [`4f50411c`](https://github.com/NixOS/nixpkgs/commit/4f50411cfc6cb793479818dec6b88732474a4afe) | `` bmon: unbreak on aarch64-darwin ``                                       |
| [`9c04fcb2`](https://github.com/NixOS/nixpkgs/commit/9c04fcb25f633980b7cb4484d5138fe6fb11583f) | `` valgrind: make meta.platforms more accurate ``                           |
| [`6d165a94`](https://github.com/NixOS/nixpkgs/commit/6d165a94740e6c1bd1e7a701cf0c2bc66d007fc5) | `` lib.platforms.s390x: init ``                                             |
| [`541a2a5e`](https://github.com/NixOS/nixpkgs/commit/541a2a5e9170a6f633e24513359cfe92d8ba50af) | `` lib.platforms.power: init ``                                             |
| [`48f3fd2d`](https://github.com/NixOS/nixpkgs/commit/48f3fd2d49c59c1bc46d5a83ff353e25aecbf4be) | `` lib.platforms.armv7: init ``                                             |
| [`8f0bc388`](https://github.com/NixOS/nixpkgs/commit/8f0bc3884df7b37c63894ea112041ae374fca125) | `` lgogdownloader: enable GUI ``                                            |
| [`888cd653`](https://github.com/NixOS/nixpkgs/commit/888cd6534604d7c43bf1f29c37f5687e20935a04) | `` github-runner: 2.300.2 -> 2.301.1 ``                                     |
| [`da647926`](https://github.com/NixOS/nixpkgs/commit/da6479267a21fa03070a2b2a00e1854b5f61b78b) | `` vimPlugins.vim-clap: fix cargo hash ``                                   |
| [`486c5318`](https://github.com/NixOS/nixpkgs/commit/486c53183dc25dd62601af90d6af3aa44151bad2) | `` libvpx: fix build for BSD ``                                             |
| [`afed8825`](https://github.com/NixOS/nixpkgs/commit/afed8825031952fdf391c80f0062e32326430d98) | `` mullvad: fix build ``                                                    |
| [`3a62853d`](https://github.com/NixOS/nixpkgs/commit/3a62853dfe2618d9a7501ae63cb28c3700f08314) | `` terminal-stocks: init at 1.0.14 ``                                       |
| [`efdbe575`](https://github.com/NixOS/nixpkgs/commit/efdbe575db6f5e1e37c81bf5e6fca849a8ab71f1) | `` upwork: 5.6.10.13 -> 5.8.0.24, use requireFile ``                        |
| [`b0d02ef8`](https://github.com/NixOS/nixpkgs/commit/b0d02ef8bad6524dcf00cbecd748128c7c4eef76) | `` pcem: fix file dialog crash ``                                           |
| [`2b434901`](https://github.com/NixOS/nixpkgs/commit/2b434901218814319574899e47c5a90b19e448c8) | `` python: improve ABI name detection ``                                    |
| [`29aecf0a`](https://github.com/NixOS/nixpkgs/commit/29aecf0a5845acc40de55b422b6229d81857d157) | `` jpeginfo: 1.6.2 -> 1.7.0 ``                                              |
| [`77d99717`](https://github.com/NixOS/nixpkgs/commit/77d99717a6ca9e1686597d383d8954244a912dfd) | `` kotatogram-desktop: fix build on Darwin after #210062 ``                 |
| [`82bb67ad`](https://github.com/NixOS/nixpkgs/commit/82bb67adb9c905de330927ad9e83e4114767093e) | `` prisma-engines: add missing dependency ``                                |
| [`0ec84310`](https://github.com/NixOS/nixpkgs/commit/0ec843104a57acd6d02013bcaf91b55fdb6e5463) | `` qovery-cli: 0.48.3 -> 0.48.4 ``                                          |
| [`7383ecc1`](https://github.com/NixOS/nixpkgs/commit/7383ecc1debe64c04df4aa2bc4d7329b22bde115) | `` python310Packages.pontos: 23.1.1 -> 23.1.3 ``                            |
| [`54ad73f8`](https://github.com/NixOS/nixpkgs/commit/54ad73f8ba7540cd7489f24aac0946f60edeaa91) | `` python310Packages.bpython: 0.23 -> 0.24 ``                               |
| [`4f1ebdd5`](https://github.com/NixOS/nixpkgs/commit/4f1ebdd51a0236d85067a118ba5a14afa255ef35) | `` vimPlugins.nvim-treesitter: update grammars ``                           |
| [`a4de7678`](https://github.com/NixOS/nixpkgs/commit/a4de7678dcc41bd973767f2ab4db3a1d1a023acb) | `` vimPlugins.boole-nvim: init at 2023-01-14 ``                             |
| [`b527f25b`](https://github.com/NixOS/nixpkgs/commit/b527f25bf058613775c1fbdb2e6f766565f9d2c1) | `` vimPlugins: update ``                                                    |
| [`e59b23d0`](https://github.com/NixOS/nixpkgs/commit/e59b23d062fa282d6aec29572b709af48113b881) | `` treewide: remove accidentally introduced -l ``                           |
| [`38eb013d`](https://github.com/NixOS/nixpkgs/commit/38eb013da022127161dad544554a06fa51a06d34) | `` pjsip-jami: add CVE patches ``                                           |
| [`b0850654`](https://github.com/NixOS/nixpkgs/commit/b0850654ecef24f3fb5e8b3047b0152fad8815b4) | `` emacsPackages.control-lock: use trivialBuild and correct src ``          |
| [`3a0d3ccb`](https://github.com/NixOS/nixpkgs/commit/3a0d3ccb2b2bfdd001742ca1329a45a66736afe3) | `` cinny-desktop: 2.2.2 -> 2.2.3 ``                                         |
| [`0de23a66`](https://github.com/NixOS/nixpkgs/commit/0de23a66e725615d9598b5d007a1075a4771113a) | `` pkgsMusl.zfs: fix build ``                                               |
| [`0ab7681f`](https://github.com/NixOS/nixpkgs/commit/0ab7681f04178550af840aa2e027d018f8dd7904) | `` python3Packages.dask-gateway: 2022.6.1 -> 2023.1.1 ``                    |
| [`67d658c4`](https://github.com/NixOS/nixpkgs/commit/67d658c420d449eaee0e191ee4f30e4360e18319) | `` python3Packages.distributed: 2022.12.1 -> 2023.1.0 ``                    |
| [`43ed3951`](https://github.com/NixOS/nixpkgs/commit/43ed3951fe4f17c4f6ad8788d4fafa75f7fdeaf4) | `` vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.12.0 -> 0.13.0 ``       |
| [`95ab55f8`](https://github.com/NixOS/nixpkgs/commit/95ab55f851da3c65d4953c7346dd2f749fd91e40) | `` vscode-extensions.davidanson.vscode-markdownlint: 0.48.1 -> 0.49.0 ``    |
| [`5b8a8810`](https://github.com/NixOS/nixpkgs/commit/5b8a88106f8d1a4eb341a46048b4742198bc454a) | `` vscode-extensions.esbenp.prettier-vscode: 9.10.3 -> 9.10.4 ``            |
| [`e29ebee3`](https://github.com/NixOS/nixpkgs/commit/e29ebee38d7c26472e01540f2b4e495792b160ed) | `` ffmpeg-normalize: 1.26.0 -> 1.26.1 ``                                    |
| [`1472d6a3`](https://github.com/NixOS/nixpkgs/commit/1472d6a372ceea131f128719451b8a129ca8c136) | `` python310Packages.thespian: 3.10.6 -> 3.10.7 ``                          |
| [`99141a8d`](https://github.com/NixOS/nixpkgs/commit/99141a8dbd67babd17a1ff19ae42763ea1eb3036) | `` pgf3: 3.1.9a -> 3.1.10 ``                                                |
| [`e369dcea`](https://github.com/NixOS/nixpkgs/commit/e369dceace0a70a855f32b98e3d626ff03251763) | `` frr: 8.4.1 -> 8.4.2 ``                                                   |
| [`8d45acc8`](https://github.com/NixOS/nixpkgs/commit/8d45acc8367ffd105bfba7be8c6ecceb44a7bc00) | `` python310Packages.azure-mgmt-compute: 29.0.0 -> 29.1.0 ``                |
| [`f8aa3c0f`](https://github.com/NixOS/nixpkgs/commit/f8aa3c0fcf393ea26fdf725459b10a0942a7d2c8) | `` python310Packages.tesla-powerwall: add changelog to meta ``              |
| [`92355593`](https://github.com/NixOS/nixpkgs/commit/92355593ce58fd0f2cfcb9b88802f4db6e2772a0) | `` python3Packages.sure: add changelog to meta ``                           |
| [`304639a0`](https://github.com/NixOS/nixpkgs/commit/304639a052d153659cf859da8bec8c349cb70d11) | `` go-swagger: fix lint issue ``                                            |
| [`947e4c0b`](https://github.com/NixOS/nixpkgs/commit/947e4c0bca4354126e897531a73815eff40cf093) | `` go-swagger: add changelog to meta ``                                     |
| [`1f5ce9e0`](https://github.com/NixOS/nixpkgs/commit/1f5ce9e0b09026f2d88f550bcdbbe119be71d4b5) | `` python3Packages.sure: disable test on python 3.11 or later ``            |
| [`0ba61c36`](https://github.com/NixOS/nixpkgs/commit/0ba61c36fc46fe77c6aaf6b79ea1956ea9614735) | `` python310Packages.tesla-powerwall: 0.3.18 -> 0.3.19 ``                   |
| [`90a77296`](https://github.com/NixOS/nixpkgs/commit/90a7729670064efc8c2c062b4296d37153cfbf0d) | `` tangram: 1.3.2 -> 2.0 ``                                                 |
| [`6735aa23`](https://github.com/NixOS/nixpkgs/commit/6735aa230d4e6ad9b3b55e2af426f7256066a2fb) | `` go-swagger: 0.30.3 -> 0.30.4 ``                                          |
| [`d6a65139`](https://github.com/NixOS/nixpkgs/commit/d6a65139cce084d1a66cbd351d6d38f72ab511b4) | `` snappymail: 2.24.4 -> 2.24.5 ``                                          |
| [`7584d9fb`](https://github.com/NixOS/nixpkgs/commit/7584d9fbf87e68c28f167af84d66688086b1de96) | `` zstd: fix cross-compilation on darwin ``                                 |
| [`ec5432af`](https://github.com/NixOS/nixpkgs/commit/ec5432af8cf8e71f894a162c2e33facb81cbf8ad) | `` jami-daemon: 20221031.1308.130cc26 -> 20221220.0956.79e1207 ``           |
| [`301924d0`](https://github.com/NixOS/nixpkgs/commit/301924d09c3b8f0122bf91d4bc95dc109e0621f6) | `` python310Packages.twitchapi: 3.2.1 -> 3.4.1 ``                           |
| [`753dca62`](https://github.com/NixOS/nixpkgs/commit/753dca6267ada0b37eaeaf9601b88b39be2da8d4) | `` ruff: 0.0.225 -> 0.0.226 ``                                              |
| [`f2cb9ee5`](https://github.com/NixOS/nixpkgs/commit/f2cb9ee5ff1c87aee9fc61f7b77eb73ad4db2189) | `` python3Packages.dateparser: 1.1.5 -> 1.1.6 ``                            |
| [`f1317611`](https://github.com/NixOS/nixpkgs/commit/f131761150001e5377f1c78c53b77c0891f5cca2) | `` home-assistant-component-tests.homeassistant_hardware: Mark broken ``    |
| [`861852a4`](https://github.com/NixOS/nixpkgs/commit/861852a4230d770ade25ce4ba2341940fe8a18a5) | `` home-assistant: Pin advantage-air at 0.4.1 ``                            |
| [`18ffe124`](https://github.com/NixOS/nixpkgs/commit/18ffe124b9850eca9ed1bc6ddc0c9503bbc78f8a) | `` home-assistant: Pin pyjwt at 2.5.0 ``                                    |
| [`9d02a0e4`](https://github.com/NixOS/nixpkgs/commit/9d02a0e4411268bb26e6d4774ced64be9b747062) | `` python3Packages.dask: 2022.10.2 -> 2023.1.0 ``                           |
| [`ece7dce2`](https://github.com/NixOS/nixpkgs/commit/ece7dce2270c96683b6f123caff71787a87d77ac) | `` python3Packages.fastparquet: 0.8.1 -> 2022.12.0 ``                       |
| [`51dadc07`](https://github.com/NixOS/nixpkgs/commit/51dadc07646d482ccdcb45452f7de217fead5675) | `` python3Packages.pyhon-miio: Fix tests with pytest 7.2 ``                 |
| [`a72680c7`](https://github.com/NixOS/nixpkgs/commit/a72680c75b07802da6a7ce7785dbb1080bf6c472) | `` home-assistant: Pin aiowatttime at 0.1.1 ``                              |
| [`df68015d`](https://github.com/NixOS/nixpkgs/commit/df68015dd5f8b4e10d6b6d4e03bfddec1d44f7b4) | `` home-assistant: Pin vsure at 1.8.1 ``                                    |
| [`e5c1c070`](https://github.com/NixOS/nixpkgs/commit/e5c1c070b1b7cc7a029156fb55e89dc53df3119d) | `` home-assistant: Pin pysensibo at 1.0.22 ``                               |
| [`ace50687`](https://github.com/NixOS/nixpkgs/commit/ace5068784a372f91cf50a8207da036c17ddb295) | `` home-assistant: Pin ovoenergy at 1.2.0 ``                                |
| [`373f78c6`](https://github.com/NixOS/nixpkgs/commit/373f78c6baca13f5f6eae70369108a07aac93d12) | `` home-assistant: Pin mcstatus at 9.3.0 ``                                 |
| [`4f08b3bb`](https://github.com/NixOS/nixpkgs/commit/4f08b3bbdd80673427f030cb61bbe33e93564316) | `` home-assistant: Pin dsmr_parser at 0.33 ``                               |
| [`caca015d`](https://github.com/NixOS/nixpkgs/commit/caca015dc18fb8d279d9f955960ae75c86b81929) | `` home-assistant: 2023.1.4 -> 2023.1.5 ``                                  |
| [`21f6a59e`](https://github.com/NixOS/nixpkgs/commit/21f6a59e4e42d20b46c77c0efb2e2b396d4fc362) | `` python310Packages.pyswitchbot: 0.36.3 -> 0.36.4 ``                       |
| [`e51dba99`](https://github.com/NixOS/nixpkgs/commit/e51dba991ee1baeff3e714ac88c57646a18526fe) | `` python310Packages.google-nest-sdm: 2.1.2 -> 2.2.2 ``                     |
| [`a2ffe67f`](https://github.com/NixOS/nixpkgs/commit/a2ffe67f3d7a9fe41cebf8a4d5efe407ebbb8c26) | `` python3Packages.aiowebostv: 0.3.1 -> 0.3.2 ``                            |
| [`5b648722`](https://github.com/NixOS/nixpkgs/commit/5b6487220c91cd82ccb07519b281b0d89d0dfae1) | `` linux/hardened/patches/6.1: 6.1.6-hardened1 -> 6.1.7-hardened1 ``        |
| [`54114c19`](https://github.com/NixOS/nixpkgs/commit/54114c19f242f66c6c7fd2e5a5af18d5b257fe0a) | `` linux/hardened/patches/5.4: 5.4.228-hardened1 -> 5.4.229-hardened1 ``    |
| [`ad4ece95`](https://github.com/NixOS/nixpkgs/commit/ad4ece95ba4f6deedf191b8d78e09a96f074e77b) | `` linux/hardened/patches/5.15: 5.15.88-hardened1 -> 5.15.89-hardened1 ``   |
| [`8d305660`](https://github.com/NixOS/nixpkgs/commit/8d3056606c56adc1c612c8b7894ed4893545f8bc) | `` linux/hardened/patches/5.10: 5.10.163-hardened1 -> 5.10.164-hardened1 `` |
| [`88b9e6a5`](https://github.com/NixOS/nixpkgs/commit/88b9e6a5b479a8e2e841bf9520b04e42918a93d0) | `` linux/hardened/patches/4.19: 4.19.269-hardened1 -> 4.19.270-hardened1 `` |
| [`60f3c919`](https://github.com/NixOS/nixpkgs/commit/60f3c91908dc37fe94815041b6c945c970e9f452) | `` linux/hardened/patches/4.14: 4.14.302-hardened1 -> 4.14.303-hardened1 `` |
| [`e7b8fdc5`](https://github.com/NixOS/nixpkgs/commit/e7b8fdc5e5a036b023508132dd1ce45bc2a3507c) | `` linux-rt_5_10: 5.10.158-rt77 -> 5.10.162-rt78 ``                         |
| [`ba974313`](https://github.com/NixOS/nixpkgs/commit/ba974313f4727da01530087f3777e028753a9728) | `` linux: 6.1.6 -> 6.1.7 ``                                                 |
| [`0ff2406f`](https://github.com/NixOS/nixpkgs/commit/0ff2406f4b56e51bd93263a8115f138345358f5f) | `` linux: 5.4.228 -> 5.4.229 ``                                             |
| [`5d77617a`](https://github.com/NixOS/nixpkgs/commit/5d77617ad671853537d96a1ba66f32e87fac7441) | `` linux: 5.15.88 -> 5.15.89 ``                                             |
| [`210407fd`](https://github.com/NixOS/nixpkgs/commit/210407fd348ee13370a1d91bb40734876a2dc67e) | `` linux: 5.10.163 -> 5.10.164 ``                                           |
| [`97b01fdb`](https://github.com/NixOS/nixpkgs/commit/97b01fdbd5a76dc061ee5d303493fcdef9d9eeac) | `` linux: 4.19.269 -> 4.19.270 ``                                           |
| [`24016a8c`](https://github.com/NixOS/nixpkgs/commit/24016a8cc91a3b09cac130e734de5e9cebb5f066) | `` linux: 4.14.302 -> 4.14.303 ``                                           |
| [`86bc14aa`](https://github.com/NixOS/nixpkgs/commit/86bc14aaac22bfd6a71a8780625f07b0a76b3e61) | `` cinnamon.nemo: 5.6.2 -> 5.6.3 ``                                         |
| [`4ffcd454`](https://github.com/NixOS/nixpkgs/commit/4ffcd4540ac472cb7b505d977d994ec8db722ffb) | `` eksctl: 0.124.0 -> 0.125.0 ``                                            |