### PR TITLE
chore(flake/nixos-hardware): `7bd6b87b` -> `4cff4f40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1673803274,
-        "narHash": "sha256-zaJDlHFXewT4KUsidMpRcPE+REymGH1Y3Eoc3Pjv4Xs=",
+        "lastModified": 1674498916,
+        "narHash": "sha256-rKacwgM76ymSu496esvcNPMCV4QX4n+7RvVSBB0zwCg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "7bd6b87b3712e68007823e8dd5c37ee9b114fee3",
+        "rev": "4cff4f40b9db3baddff811ca00bf1aac2c4879cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`320866b9`](https://github.com/NixOS/nixos-hardware/commit/320866b9853a8478e75120cc9ff8796489ad8e54) | `` raspberry-pi/4/dtmerge: fix application of overlays `` |