### PR TITLE
chore(flake/home-manager): `ab25abf9` -> `12d43fd4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674477719,
-        "narHash": "sha256-tciutt7rulypHZfbXp2j+5K6exyVAtsxF2//2J9BSvI=",
+        "lastModified": 1674511629,
+        "narHash": "sha256-e2sc2Pv6z3aLuqXrunGvoKAfOABbWV31txgboIro+GE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ab25abf9e5c07b3c90d78aa06c44a4085ecba003",
+        "rev": "12d43fd40a7658976c18eaa05bba62b6045e5b3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message              |
| ----------------------------------------------------------------------------------------------------------- | -------------------- |
| [`12d43fd4`](https://github.com/nix-community/home-manager/commit/12d43fd40a7658976c18eaa05bba62b6045e5b3e) | `` docs: bump nmd `` |