### PR TITLE
chore(flake/nixos-hardware): `ba8fc4a2` -> `b7ac0a56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1674550341,
-        "narHash": "sha256-1EqP8D1vMm86v5p+ZKvADTdcoZgsomQgHNecObQPJUI=",
+        "lastModified": 1674550793,
+        "narHash": "sha256-ljJlIFQZwtBbzWqWTmmw2O5BFmQf1A/DspwMOQtGXHk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ba8fc4a27927cf6f524e5644246bd9b4a0419b02",
+        "rev": "b7ac0a56029e4f9e6743b9993037a5aaafd57103",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`d25ac8d9`](https://github.com/NixOS/nixos-hardware/commit/d25ac8d999db568b7eb9f831434ac7797df421db) | `` Update lenovo/thinkpad/t440p/default.nix ``                                  |
| [`759a06ec`](https://github.com/NixOS/nixos-hardware/commit/759a06ec4a4dbcb1f33ebab074477a6e49a9dba7) | `` lenovo/thinkpad/t440p: force load thinkpad_acpi ``                           |
| [`906737f5`](https://github.com/NixOS/nixos-hardware/commit/906737f5801d9809e60259f3e54d85728c7fc642) | `` Enable STREAMING_MEDIA kernel option ``                                      |
| [`27b616b6`](https://github.com/NixOS/nixos-hardware/commit/27b616b63ac917583879969d909b673918cc8979) | `` Update repo rev and SHA-256 for linux-surface ``                             |
| [`2316f4cb`](https://github.com/NixOS/nixos-hardware/commit/2316f4cb8cacf78ec0faf827c0f7a5929ff1b316) | `` Configure MS Surface Go to use kernel 6.1.6 ``                               |
| [`86395324`](https://github.com/NixOS/nixos-hardware/commit/863953246fd2e8c21ed8799a26564cfc2ca4a7b7) | `` Update to kernel 6.1.6 ``                                                    |
| [`ab4c0eed`](https://github.com/NixOS/nixos-hardware/commit/ab4c0eedb668a142403b4ea94ce64f401a1a0ab9) | `` Begin updating to kernel 6.1.6 ``                                            |
| [`2933836f`](https://github.com/NixOS/nixos-hardware/commit/2933836fa59d45d897f53a92deb712c77d43325a) | `` Typo: "CONFIG_" prefix in structuredExtraConfig patches ``                   |
| [`5c836a9a`](https://github.com/NixOS/nixos-hardware/commit/5c836a9a365eee0b4d730db70f78bda2fa286e20) | `` Typo: "CONFIG_" prefix in structuredExtraConfig patches ``                   |
| [`05bbf0f0`](https://github.com/NixOS/nixos-hardware/commit/05bbf0f04069eaf515b319606664adc49c1fa55f) | `` Update the rev. and sha256 of linux-surface repo to match latest "master" `` |
| [`321d5ec9`](https://github.com/NixOS/nixos-hardware/commit/321d5ec9f7e862872496f857a5885e56190d3616) | `` Add kernel 6.1.3 ``                                                          |