### PR TITLE
chore(flake/pre-commit-hooks): `7bdf85f6` -> `8539119b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -219,11 +219,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1674550893,
-        "narHash": "sha256-HXI8AB96PP7UZ7iPANACXM8qc9eMz0ljxBEDM8JJKhY=",
+        "lastModified": 1674761200,
+        "narHash": "sha256-v0ypL0eDhFWmgd3f5nnbffaMA5BUoOnYUiEso7fk+q0=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "7bdf85f6bbef581eb687838d19f2b35a4c9d77f0",
+        "rev": "8539119ba0b17b15e60de60da0348d8c73bbfdf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                             |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------- |
| [`a6cf19ab`](https://github.com/cachix/pre-commit-hooks.nix/commit/a6cf19ab7da60a9b0025b53b2e035489bcdb15cf) | `` feat: add settings to yamlint `` |