### PR TITLE
chore(flake/nixpkgs): `1b1f5064` -> `9b97ad7b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674459583,
-        "narHash": "sha256-L0UZl/u2H3HGsrhN+by42c5kNYeKtdmJiPzIRvEVeiM=",
+        "lastModified": 1674641431,
+        "narHash": "sha256-qfo19qVZBP4qn5M5gXc/h1MDgAtPA5VxJm9s8RUAkVk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1b1f50645af2a70dc93eae18bfd88d330bfbcf7f",
+        "rev": "9b97ad7b4330aacda9b2343396eb3df8a853b4fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`5a6308c8`](https://github.com/NixOS/nixpkgs/commit/5a6308c80e6c75775597456eeb47ec0dd774f59d) | `` ocamlPackages.lutils: add changelog link ``                                |
| [`1cbd2b55`](https://github.com/NixOS/nixpkgs/commit/1cbd2b55c71eb7a18f27fa8d4f8afe0db1833c81) | `` smartgithg: add changelog link ``                                          |
| [`79ecd28b`](https://github.com/NixOS/nixpkgs/commit/79ecd28b0c064f1032da5a3c3f81733b3069ff9b) | `` python310Packages.hahomematic: 2023.1.6 -> 2023.1.7 ``                     |
| [`9094b288`](https://github.com/NixOS/nixpkgs/commit/9094b2889432eccd1c300be8d72559f84d5c3a15) | `` python310Packages.bthome-ble: 2.5.0 -> 2.5.1 ``                            |
| [`8e2e31f7`](https://github.com/NixOS/nixpkgs/commit/8e2e31f77c251512ad5e13e7fd09de1067433e71) | `` python311Packages.graphene-django: disable failing tests on Python 3.11 `` |
| [`d56f7d9f`](https://github.com/NixOS/nixpkgs/commit/d56f7d9fe4920e85092c36fa191ef05b58929774) | `` go: various gccgo changes (#211850) ``                                     |
| [`df8af6cd`](https://github.com/NixOS/nixpkgs/commit/df8af6cd1a5a526b1075eef9042253cffe3d3ef6) | `` python310Packages.graphene-django: add changelog to meta ``                |
| [`c8d74eaf`](https://github.com/NixOS/nixpkgs/commit/c8d74eaf3c917637a588c3bf296b1f01044565ab) | `` python310Packages.google-cloud-bigquery-datatransfer: 3.10.0 -> 3.10.1 ``  |
| [`4ef98ebc`](https://github.com/NixOS/nixpkgs/commit/4ef98ebcc1610b0a4ab3d455a0d987a95761bc6d) | `` python311Packages.promise: add patch to remove @asyncio.coroutine ``       |
| [`efce80c3`](https://github.com/NixOS/nixpkgs/commit/efce80c33ab28538eabfcd191bbd223e03c6d674) | `` eternal-terminal: add changelog to meta ``                                 |
| [`5a2d98d6`](https://github.com/NixOS/nixpkgs/commit/5a2d98d6b2d1a78d17acd0213ac2b84a4072b7a6) | `` awstats: add changelog to meta ``                                          |
| [`32e9ef30`](https://github.com/NixOS/nixpkgs/commit/32e9ef301d44e2c0a3e3faddba3810f9ce217343) | `` python310Packages.jupyterlab: add changelog to meta ``                     |
| [`8aa14c8a`](https://github.com/NixOS/nixpkgs/commit/8aa14c8a8d889eb4cc1ab54c56cd12ca307e9bbb) | `` python310Packages.requests-aws4auth: fix typo ``                           |
| [`a9842234`](https://github.com/NixOS/nixpkgs/commit/a9842234c8a417f95332a64c3a49c09dac853ceb) | `` python310Packages.lightgbm: add changelog to meta ``                       |
| [`de71f7cc`](https://github.com/NixOS/nixpkgs/commit/de71f7ccdd82b1321fb74a5b0e2f36fa4f367b2a) | `` python310Packages.denonavr: add changelog to meta ``                       |
| [`5e3079f2`](https://github.com/NixOS/nixpkgs/commit/5e3079f21aa2aa897c5ae3b870f4b289e22c8a15) | `` python310Packages.types-pyyaml: 6.0.12.2 -> 6.0.12.3 ``                    |
| [`cf14c0cb`](https://github.com/NixOS/nixpkgs/commit/cf14c0cbbd7a465deb95be59a2c0b133a9a40b92) | `` compdb: init at 0.2.0 ``                                                   |
| [`a0aeaab6`](https://github.com/NixOS/nixpkgs/commit/a0aeaab62361d7efc74696e74928228a2979ffed) | `` python310Packages.google-cloud-datastore: 2.11.0 -> 2.13.2 ``              |
| [`13a6aa45`](https://github.com/NixOS/nixpkgs/commit/13a6aa4571befa4f012e6ce804ea65b3a96e2dc0) | `` ocamlPackages.ca-certs: 0.2.2 → 0.2.3 ``                                   |
| [`7513e9fd`](https://github.com/NixOS/nixpkgs/commit/7513e9fdc2ab07b9f3d524b591677b6370749439) | `` python310Packages.pynetbox: 7.0.0 -> 7.0.1 ``                              |
| [`88d2ca01`](https://github.com/NixOS/nixpkgs/commit/88d2ca01d0486695fe96c8bf7129ad0deb5763db) | `` pantheon.appcenter: 4.0.0 -> 7.0.0 ``                                      |
| [`b30e0c15`](https://github.com/NixOS/nixpkgs/commit/b30e0c15781ad01b7a2f3467526a50ac3dc61b14) | `` python310Packages.google-cloud-videointelligence: 2.10.0 -> 2.10.1 ``      |
| [`c52e9218`](https://github.com/NixOS/nixpkgs/commit/c52e921894b8817d68fa88db3429e6119d8f55d7) | `` maestro: 1.19.5 -> 1.20.0 ``                                               |
| [`a5d2865e`](https://github.com/NixOS/nixpkgs/commit/a5d2865e622a93f2a92949eaf002fd62a50147af) | `` terraform-providers.spotinst: 1.95.2 → 1.96.0 ``                           |
| [`c367b917`](https://github.com/NixOS/nixpkgs/commit/c367b917a529ef1bc0eac2aab225949fc43ad63a) | `` terraform-providers.cloudflare: 3.32.0 → 3.33.1 ``                         |
| [`1e41cbe2`](https://github.com/NixOS/nixpkgs/commit/1e41cbe2bd91b3b458ee76aefe867f972cd18ed5) | `` python310Packages.google-cloud-org-policy: 1.7.0 -> 1.7.1 ``               |
| [`91bd7af0`](https://github.com/NixOS/nixpkgs/commit/91bd7af0a516c39d07f0de5dcf753a641486b2e6) | `` classicube: 1.3.4 -> 1.3.5 ``                                              |
| [`be383724`](https://github.com/NixOS/nixpkgs/commit/be3837249cc65f397d586047761cca22efffe636) | `` python310Packages.google-cloud-asset: 3.17.0 -> 3.17.1 ``                  |
| [`61202db8`](https://github.com/NixOS/nixpkgs/commit/61202db804d52d24aa2edcd82ed4bca4244f4729) | `` cargo-hack: 0.5.26 -> 0.5.27 ``                                            |
| [`a4e3e162`](https://github.com/NixOS/nixpkgs/commit/a4e3e16258210b3300aaf247033f941d36b58c28) | `` Update lib/attrsets.nix ``                                                 |
| [`52351987`](https://github.com/NixOS/nixpkgs/commit/52351987d61583ad150dc63a4e0ca08d62b45f96) | `` treesheets: unstable-2023-01-20 -> unstable-2023-01-23 ``                  |
| [`c72d62af`](https://github.com/NixOS/nixpkgs/commit/c72d62afa2defef10e44bc4f679e56bda01ece34) | `` trashy: 1.0.3 -> 2.0.0 ``                                                  |
| [`a2aee0de`](https://github.com/NixOS/nixpkgs/commit/a2aee0de1e62cf4f9b9a3df0c143413a251277c7) | `` python310Packages.whois: 0.9.23 -> 0.9.24 ``                               |
| [`c287407e`](https://github.com/NixOS/nixpkgs/commit/c287407e07294ff85200ced6099d401b0a59ab7f) | `` python310Packages.lightgbm: 3.3.3 -> 3.3.5 ``                              |
| [`fe16808b`](https://github.com/NixOS/nixpkgs/commit/fe16808b32d88a8f522cd653aa3c90271ff48483) | `` python310Packages.denonavr: 0.10.12 -> 0.11.0 ``                           |
| [`5fd6c846`](https://github.com/NixOS/nixpkgs/commit/5fd6c8467bcb2340e9e8490ddfc7541e033755ea) | `` srvc: 0.10.1 -> 0.13.0 ``                                                  |
| [`0f29dab4`](https://github.com/NixOS/nixpkgs/commit/0f29dab46a8ed974963fd469bc1d2e3263da025a) | `` python310Packages.requests-aws4auth: add changelog to meta ``              |
| [`1f89ea23`](https://github.com/NixOS/nixpkgs/commit/1f89ea230f5e3a7d847db4aed7651af7c46e48e0) | `` python310Packages.requests-aws4auth: 1.1.2 -> 1.2.0 ``                     |
| [`58c9ba22`](https://github.com/NixOS/nixpkgs/commit/58c9ba22536a13bcf2b416b65f056e9003ab6c03) | `` python310Packages.jupyterlab: 3.5.2 -> 3.5.3 ``                            |
| [`9064fe2b`](https://github.com/NixOS/nixpkgs/commit/9064fe2bd099d49818295f38a6d245b6151bae4f) | `` cargo-semver-checks: 0.15.2 -> 0.16.2 ``                                   |
| [`3470711e`](https://github.com/NixOS/nixpkgs/commit/3470711e51585457cb43664e078ba6211be3f749) | `` apacheHttpd: 2.4.54 -> 2.4.55 ``                                           |
| [`f7ccfb91`](https://github.com/NixOS/nixpkgs/commit/f7ccfb9191d6b6f334eab817b007f377893aa5bb) | `` scaleway-cli: 2.9.0 -> 2.10.0 (#212458) ``                                 |
| [`74545607`](https://github.com/NixOS/nixpkgs/commit/745456072a079a6b256233b0c68e14abda569ffa) | `` nix-update: 0.13.0 -> 0.14.0 ``                                            |
| [`f45624e4`](https://github.com/NixOS/nixpkgs/commit/f45624e43d990ce8415c12688aaf1f0cc5c40bba) | `` eternal-terminal: 6.2.1 -> 6.2.4 ``                                        |
| [`e673e907`](https://github.com/NixOS/nixpkgs/commit/e673e90753079c0c52f60affe19981046bac1c6c) | `` nixos/no-x-libs: add qtbase (#212460) ``                                   |
| [`50b8f8fa`](https://github.com/NixOS/nixpkgs/commit/50b8f8fa2b8490f77d2db4c438f14bd2881a7f5e) | `` awstats: 7.8 -> 7.9 ``                                                     |
| [`2ae30c9f`](https://github.com/NixOS/nixpkgs/commit/2ae30c9f45a82bae0e8a41be1ff75858801765ce) | `` llvmPackages: use libcxxrt on FreeBSD ``                                   |
| [`c672de30`](https://github.com/NixOS/nixpkgs/commit/c672de30802d685811fd2ea4eaf95d7dceda2f05) | `` libcxxrt: init at unstable-2022-08-08 ``                                   |
| [`ee036ed5`](https://github.com/NixOS/nixpkgs/commit/ee036ed5a49547acefe6f70365f9df64068c7d8c) | `` llvmPackages: don't exclude FreeBSD from -lunwind ``                       |
| [`039cace1`](https://github.com/NixOS/nixpkgs/commit/039cace1a6396f8f22f35ecc7e18c78ba4b44c3d) | `` awscli2: 2.9.15 -> 2.9.17 ``                                               |
| [`18616e48`](https://github.com/NixOS/nixpkgs/commit/18616e4869ceb28021515f2942ad9d944cc3ec57) | `` parsec-bin: 150_28 -> 150_86e ``                                           |
| [`90134980`](https://github.com/NixOS/nixpkgs/commit/9013498050af5e0cd8be40c9ecafb96b96144733) | `` pkgconf-unwrapped: 1.9.3 -> 1.9.4 ``                                       |
| [`46faa4a1`](https://github.com/NixOS/nixpkgs/commit/46faa4a1731027411b4b4f6c78e406493a27296b) | `` python310Packages.google-cloud-error-reporting: 1.8.0 -> 1.8.1 ``          |
| [`8643480e`](https://github.com/NixOS/nixpkgs/commit/8643480e48da9f19928c17833be02cdaa9d2a649) | `` fzf: 0.36.0 -> 0.37.0 ``                                                   |
| [`3731fb16`](https://github.com/NixOS/nixpkgs/commit/3731fb1645d0ea0a04cef696e37af6413487c952) | `` treewide: convert 14 fonts ``                                              |
| [`53fe843d`](https://github.com/NixOS/nixpkgs/commit/53fe843d31741ba128e901a4247eebb88a42b16c) | `` python310Packages.stone: replace inspect.getargspec ``                     |
| [`3c86e6f2`](https://github.com/NixOS/nixpkgs/commit/3c86e6f249181d80c53fa5ca1db974523ffcfb77) | `` python310Packages.python-stdnum: remove coverage ``                        |
| [`c73fbbd7`](https://github.com/NixOS/nixpkgs/commit/c73fbbd79ee5875eea13d80b1cae00f6e8db44e3) | `` python310Packages.python-stdnum: add changelog to meta ``                  |
| [`df5c1f0d`](https://github.com/NixOS/nixpkgs/commit/df5c1f0d3e23afcee4dda1e83f5b9a0b2add3056) | `` treewide: fonts: remove dontBuild in stdenvNoCC ``                         |
| [`921664da`](https://github.com/NixOS/nixpkgs/commit/921664da3fdfd60ac9a5a144559e2d928371b29e) | `` vmm_clock: 0.1.0 -> 0.2.0 ``                                               |
| [`12b6fb86`](https://github.com/NixOS/nixpkgs/commit/12b6fb8670331848b490a40ef606dba0dc4528e1) | `` python310Packages.python-redis-lock: adjust inputs ``                      |
| [`c7330bfb`](https://github.com/NixOS/nixpkgs/commit/c7330bfb287888b0a4f9ce8735da75e4e4088ac8) | `` eris-go: 20230114 -> 20230123 ``                                           |
| [`9af21018`](https://github.com/NixOS/nixpkgs/commit/9af21018cec6a2f29de73b20773acc62e5d9a9df) | `` python311Packages.python-engineio: add patch for mocking issue ``          |
| [`e51e1027`](https://github.com/NixOS/nixpkgs/commit/e51e10271dfc2ba524d20346e0cbb302ed032b5b) | `` nurl: 0.3.5 -> 0.3.6 ``                                                    |
| [`d737af5d`](https://github.com/NixOS/nixpkgs/commit/d737af5de8759fc835e54b339bed703cb1198856) | `` python310Packages.particle: 0.21.0 -> 0.21.1 ``                            |
| [`2c3e1e15`](https://github.com/NixOS/nixpkgs/commit/2c3e1e15271759534b7b4a8d569c93fb2fe5c1ba) | `` python310Packages.particle: add changelog to meta ``                       |
| [`61eba16e`](https://github.com/NixOS/nixpkgs/commit/61eba16e9a8bec2702ec2d4a39eb30a3e741a22e) | `` bibata-extra-cursors: mark as broken ``                                    |
| [`18fc8858`](https://github.com/NixOS/nixpkgs/commit/18fc8858b740b00554ef6b916ff0b7c21e49a21a) | `` python310Packages.pip-tools: update format ``                              |
| [`b45a4612`](https://github.com/NixOS/nixpkgs/commit/b45a461291ed8d50343c7fa8583a3fe61d3dde8e) | `` nfs-ganesha: 4.2 -> 4.3 ``                                                 |
| [`71a632d9`](https://github.com/NixOS/nixpkgs/commit/71a632d90e9afc20465c89c738f9a4d6d1ce4c81) | `` ntirpc: 4.2 -> 4.3 ``                                                      |
| [`133fa5f8`](https://github.com/NixOS/nixpkgs/commit/133fa5f86741d2af5ea4dc50ab98c0f23b7c2a6a) | `` treewide: remove global with lib; in pkgs/tools ``                         |
| [`0a1dd3ce`](https://github.com/NixOS/nixpkgs/commit/0a1dd3ced1d7a0d7d611c9f64e02fa9cd3ba3c6d) | `` treewide: remove global with lib; in pkgs/{misc,networking} ``             |
| [`af3cc3cc`](https://github.com/NixOS/nixpkgs/commit/af3cc3cc6c2f654393ee9fe3c18e177857769de0) | `` python310Packages.google-cloud-iot: 2.8.0 -> 2.8.1 ``                      |
| [`676b3875`](https://github.com/NixOS/nixpkgs/commit/676b38754cc271239ca8e0bc5fb0a39ddddff92b) | `` eggdrop: 1.9.3 -> 1.9.4 ``                                                 |
| [`9010749a`](https://github.com/NixOS/nixpkgs/commit/9010749a26700a48c0c49c93b9addffd7b710f5f) | `` ruff: 0.0.232 -> 0.0.233 ``                                                |
| [`4197cbd9`](https://github.com/NixOS/nixpkgs/commit/4197cbd946e6dbe6067d0fbc7dc70a46a297ffac) | `` pantheon.switchboard-plug-onlineaccounts: try-catch GLib.Uri.parse ``      |
| [`9cf3592d`](https://github.com/NixOS/nixpkgs/commit/9cf3592d15d148df8f9674bcc1857f10d051e908) | `` pantheon.elementary-mail: try-catch GLib.Uri.parse ``                      |
| [`6fe502f5`](https://github.com/NixOS/nixpkgs/commit/6fe502f5bc5f8577ebd2401a32fdfe2d55a9b046) | `` flexoptix-app: 5.13.1 -> 5.13.3 ``                                         |
| [`74b082f8`](https://github.com/NixOS/nixpkgs/commit/74b082f8b757f4107df39e7bf44030f1f3511f0c) | `` lxgw-wenkai: 1.245.1 -> 1.250 ``                                           |
| [`27d45e60`](https://github.com/NixOS/nixpkgs/commit/27d45e604a1849e47fdb4205d0a2d17943f47bcd) | `` ruff: 0.0.231 -> 0.0.232 ``                                                |
| [`37cab2f8`](https://github.com/NixOS/nixpkgs/commit/37cab2f8e793e2038ea6019d5787482b09f01a37) | `` panamax: 1.0.3 -> 1.0.6 ``                                                 |
| [`dfd1bf80`](https://github.com/NixOS/nixpkgs/commit/dfd1bf80ad829c05537a9f3909c10b87c26f9515) | `` dqlite: 1.9.0 -> 1.13.0 ``                                                 |
| [`ea0e8794`](https://github.com/NixOS/nixpkgs/commit/ea0e8794bd4dd6a22419614ca4d04b73a3714b95) | `` dqlite: add adamcstephens as maintainer ``                                 |
| [`753281ea`](https://github.com/NixOS/nixpkgs/commit/753281ea0a5f792ac34cabeb249eb39becba8285) | `` python310Packages.flowlogs_reader: 4.0.0 -> 5.0.0 ``                       |
| [`cda9a804`](https://github.com/NixOS/nixpkgs/commit/cda9a804aae6474a88fd3370f71797d095a12253) | `` pokemon-colorscrips-mac: fix version name ``                               |
| [`226ee6f3`](https://github.com/NixOS/nixpkgs/commit/226ee6f33fcb85dcd95cf4424d3fe4c3efeb5ffb) | `` nano: 7.1 -> 7.2 (#212038) ``                                              |
| [`bbcbc252`](https://github.com/NixOS/nixpkgs/commit/bbcbc2529ce1f6e073f0ec529cbaf717ad21837e) | `` lukesmithxyz-bible-kjv: move to misc/kjv ``                                |
| [`ef8d1d3b`](https://github.com/NixOS/nixpkgs/commit/ef8d1d3be0fc8f71867a25a085eda95710d5271d) | `` pulumictl: 0.0.39 -> 0.0.41 ``                                             |
| [`bb2097d7`](https://github.com/NixOS/nixpkgs/commit/bb2097d7c8ce30c3a0ca8a33e590581aefe25404) | `` osmium-tool: 1.14.0 -> 1.15.0 ``                                           |
| [`33b99510`](https://github.com/NixOS/nixpkgs/commit/33b995109751b496e22021abc863cb3b15f964a2) | `` python310Packages.Pyro5: add pythonImportsCheck ``                         |
| [`744ce872`](https://github.com/NixOS/nixpkgs/commit/744ce872f1e6ed6af6f5f30d56d456021feacb3a) | `` python310Packages.Pyro4: disable on Python >= 3.11 ``                      |
| [`d60cd15d`](https://github.com/NixOS/nixpkgs/commit/d60cd15dfc776f62e6758593daf543b386068d2f) | `` kube-linter: 0.5.1 -> 0.6.0 ``                                             |
| [`64a104b5`](https://github.com/NixOS/nixpkgs/commit/64a104b504001bf827db9f9972a89465409a0c59) | `` python310Packages.google-cloud-pubsub: 2.13.12 -> 2.14.0 ``                |
| [`06062919`](https://github.com/NixOS/nixpkgs/commit/06062919733cb29519d3bf0621fa2bc6ac21bf50) | `` python310Packages.pyro4: add changelog to meta ``                          |
| [`c1739aca`](https://github.com/NixOS/nixpkgs/commit/c1739aca57fa7dfffe911c67466fa8048eaed90c) | `` mate.marco: 1.26.0 -> 1.26.1 ``                                            |
| [`a2b16c5a`](https://github.com/NixOS/nixpkgs/commit/a2b16c5a3a147aada68d4f027a38a39b66254f73) | `` python310Packages.anybadge: add missing inputs ``                          |
| [`17368ed4`](https://github.com/NixOS/nixpkgs/commit/17368ed4a478290466ae2091a35e05b720910cd1) | `` python310Packages.anybadge: add changelog to meta ``                       |
| [`6676ae88`](https://github.com/NixOS/nixpkgs/commit/6676ae8874261ef31c58db3e84ff605f8e7566c2) | `` bird: 2.0.11 -> 2.0.12 ``                                                  |
| [`9e0cb393`](https://github.com/NixOS/nixpkgs/commit/9e0cb39391860fe2a41107539ef7bd6d811f00e2) | `` timescaledb: 2.9.1 -> 2.9.2 ``                                             |
| [`3c5425bf`](https://github.com/NixOS/nixpkgs/commit/3c5425bf932ef9181917f60cdb17734616ec0d21) | `` treewide: use hash instead of sha256 ``                                    |
| [`4580a660`](https://github.com/NixOS/nixpkgs/commit/4580a6608dac93ada25b0921135752f3704ce3b3) | `` doc: fix broken links ``                                                   |
| [`94022acc`](https://github.com/NixOS/nixpkgs/commit/94022accb0af2cedf7288a5e95fbdb15167c891f) | `` hylafaxplus: 7.0.6 -> 7.0.7 ``                                             |
| [`2c29e8b3`](https://github.com/NixOS/nixpkgs/commit/2c29e8b34f8b41f2288984025e1a7e0dcbd5e30a) | `` typos: 1.13.7 -> 1.13.8 ``                                                 |
| [`64a1ce91`](https://github.com/NixOS/nixpkgs/commit/64a1ce910c3c56bdc4f4732fe54da8f11e8831c1) | `` python310Packages.google-cloud-texttospeech: 2.14.0 -> 2.14.1 ``           |
| [`a146de83`](https://github.com/NixOS/nixpkgs/commit/a146de830d8791c7c0f8177fd9f68b5745e49fcc) | `` imapsync: fix license ``                                                   |
| [`9b792452`](https://github.com/NixOS/nixpkgs/commit/9b7924523595c98b38e1f607b652ba3b16312e54) | `` licenses: add NLPL ``                                                      |