### PR TITLE
chore(flake/nixpkgs): `9b97ad7b` -> `2caf4ef5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674641431,
-        "narHash": "sha256-qfo19qVZBP4qn5M5gXc/h1MDgAtPA5VxJm9s8RUAkVk=",
+        "lastModified": 1675115703,
+        "narHash": "sha256-4zetAPSyY0D77x+Ww9QBe8RHn1akvIvHJ/kgg8kGDbk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b97ad7b4330aacda9b2343396eb3df8a853b4fc",
+        "rev": "2caf4ef5005ecc68141ecb4aac271079f7371c44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`4b55a1d1`](https://github.com/NixOS/nixpkgs/commit/4b55a1d1f65816d3c35e4ea66183cef8ddf4d98e) | `` ani-cli: 3.4 -> 4.0 ``                                                            |
| [`2bb3898d`](https://github.com/NixOS/nixpkgs/commit/2bb3898d95b9cdc66a2b5a522125f44b2279d150) | `` Revert "ani-cli: 3.4 -> 4.0" ``                                                   |
| [`45197efd`](https://github.com/NixOS/nixpkgs/commit/45197efd4007c1a67e98e168eebebc714ae2bc00) | `` metal-cli: 0.12.0 -> 0.13.0 ``                                                    |
| [`2d3efd33`](https://github.com/NixOS/nixpkgs/commit/2d3efd330141b14ff8ba6133768ea44b65d660dd) | `` nixos/nginx: clear clients Connection headers ``                                  |
| [`29ab6bb3`](https://github.com/NixOS/nixpkgs/commit/29ab6bb3b95293351aa8d7c8e20d497bebbd6c48) | `` libde265: drop imagemagick6 from passthru.tests ``                                |
| [`d9c12e56`](https://github.com/NixOS/nixpkgs/commit/d9c12e56948c0f0bd26794fd44d1513d74fb2d70) | `` ginkgo: 2.7.0 -> 2.7.1 ``                                                         |
| [`baa2dbef`](https://github.com/NixOS/nixpkgs/commit/baa2dbef97af7c8e1a59ddd8c54af87d416c268a) | `` coder: 0.14.3 -> 0.15.3 ``                                                        |
| [`2d2e0c4d`](https://github.com/NixOS/nixpkgs/commit/2d2e0c4d78e27ad7835570326909769a9417b4a8) | `` pscale: 0.127.0 -> 0.128.0 ``                                                     |
| [`d9cde244`](https://github.com/NixOS/nixpkgs/commit/d9cde24420919e95236e8e06cc30180ed80d007d) | `` cwltool: 3.1.20221201130942 -> 3.1.20230127121939 ``                              |
| [`da07b466`](https://github.com/NixOS/nixpkgs/commit/da07b466233ff8812ab7dfee8bf40263124fef8a) | `` flyctl: 0.0.450 -> 0.0.451 ``                                                     |
| [`7656cb8e`](https://github.com/NixOS/nixpkgs/commit/7656cb8ef722d575fe39165acd665bfb07b9bdb7) | `` ani-cli: 3.4 -> 4.0 ``                                                            |
| [`deed04ab`](https://github.com/NixOS/nixpkgs/commit/deed04ab81207cf769af23d6f31b62afc2df0ec8) | `` Revert "tests.defaultPkgConfigPackages: Add recurseIntoAttrs" ``                  |
| [`3601988c`](https://github.com/NixOS/nixpkgs/commit/3601988caeb14d2d8c8762504060a85f81a55ac3) | `` eksctl: 0.126.0 -> 0.127.0 ``                                                     |
| [`27a9f28f`](https://github.com/NixOS/nixpkgs/commit/27a9f28f54cac9e65ab7f9d2ca957133428965b2) | `` tidal-hifi: 4.3.1 -> 4.4.0 ``                                                     |
| [`7bce426a`](https://github.com/NixOS/nixpkgs/commit/7bce426a3e754097e805a76a7eef600b403838ae) | `` grub2_pvgrub_image: fix evaluation on armv7l-linux and riscv{32,64}-linux ``      |
| [`4e48d6ec`](https://github.com/NixOS/nixpkgs/commit/4e48d6eca4f8b704330c745ca54cf43fb7b002eb) | `` python310Packages.agate-sql: 0.5.8 -> 0.5.9 ``                                    |
| [`742ba56e`](https://github.com/NixOS/nixpkgs/commit/742ba56e7bffddb714be4719996185f037a32be2) | `` lilypond, lilypond-unstable: bump version, add passthru.updateScript (#207727) `` |
| [`92929e2c`](https://github.com/NixOS/nixpkgs/commit/92929e2cfeb4326f2765b40c00bc1e913d1199a8) | `` qgis: 3.22.14 -> 3.22.15 ``                                                       |
| [`ffc15c70`](https://github.com/NixOS/nixpkgs/commit/ffc15c70603cff0e7bc7d9089964238aa2c42f3c) | `` spotify-player: init at 0.10.0 ``                                                 |
| [`23ce77d7`](https://github.com/NixOS/nixpkgs/commit/23ce77d76e3f679146eb3bde92c90bd5223067dc) | `` Revert #178290: nixos/virtualisation: add option ``                               |
| [`c442c458`](https://github.com/NixOS/nixpkgs/commit/c442c458862db2ac9d05f16530dabc152a41d891) | `` cargo-semver-checks: 0.16.2 -> 0.17.0 ``                                          |
| [`62535d9c`](https://github.com/NixOS/nixpkgs/commit/62535d9cd59eb8c5e612c9b554082a07fa5057f7) | `` runescape-launcher: 2.2.9 -> 2.2.10 ``                                            |
| [`f4796ac6`](https://github.com/NixOS/nixpkgs/commit/f4796ac68ba24dc94ecbae3a2f4461571c6860d8) | `` vimPlugins.nvim-treesitter: update grammars ``                                    |
| [`eddfcac9`](https://github.com/NixOS/nixpkgs/commit/eddfcac986ce7b3e08ca02519a89cf78b06f0d78) | `` vimPlugins.vim-clap: fix cargo hash ``                                            |
| [`0cf99049`](https://github.com/NixOS/nixpkgs/commit/0cf990491cf52c50f61cb24ce0a960c23d736e7a) | `` vimPlugins.sg-nvim: fix cargo hash ``                                             |
| [`a92f046f`](https://github.com/NixOS/nixpkgs/commit/a92f046faf8426151c0cf5413f94fbc46e38b142) | `` sbt-extras: 2022-11-11 -> 2023-01-05 (#209432) ``                                 |
| [`a945d73e`](https://github.com/NixOS/nixpkgs/commit/a945d73ec66987df47d245df9b43c18ab8bff766) | `` vimPlugins.nvim-FeMaco-lua: init at 2022-10-10 ``                                 |
| [`22ebaedc`](https://github.com/NixOS/nixpkgs/commit/22ebaedc73f3c221cba2ea12cc3e6a688bbe3457) | `` tracee: 0.9.2 -> 0.10.0 ``                                                        |
| [`a737e433`](https://github.com/NixOS/nixpkgs/commit/a737e433aaf90fb9a0605933e4af5fa42f801b8e) | `` soupault: 4.3.1 → 4.4.0 ``                                                        |
| [`44f4d1c8`](https://github.com/NixOS/nixpkgs/commit/44f4d1c8bba811a839a003be0b1c71c1d5235734) | `` vimPlugins: update ``                                                             |
| [`ddaadba2`](https://github.com/NixOS/nixpkgs/commit/ddaadba2d5008132188b31d5617cf06ccb6c080e) | `` python3Packages.py-sr25519-bindings: fix build ``                                 |
| [`743e8d1c`](https://github.com/NixOS/nixpkgs/commit/743e8d1cbfaab6695332a15b787e5d84b477450d) | `` Update pkgs/development/tools/continuous-integration/drone/default.nix ``         |
| [`cb15fbd7`](https://github.com/NixOS/nixpkgs/commit/cb15fbd72eafe6f4600e235d3ed8be88bf351327) | `` obsidian: electron_18 -> electron_21 ``                                           |
| [`1ec241e1`](https://github.com/NixOS/nixpkgs/commit/1ec241e150aaeaee4bd38b657b9ee912962e0eff) | `` wgpu-utils: 0.14.1 -> 0.15.0 ``                                                   |
| [`c9620640`](https://github.com/NixOS/nixpkgs/commit/c9620640e8730535d5e401e09abdcff36a7028d7) | `` maestro: 1.21.2 -> 1.21.3 ``                                                      |
| [`a81e8eb7`](https://github.com/NixOS/nixpkgs/commit/a81e8eb7f7a1fa62a6662c0254e0a30e14cb51d0) | `` tela-circle-icon-theme: 2022-11-06 -> 2023-01-29 ``                               |
| [`e9761195`](https://github.com/NixOS/nixpkgs/commit/e976119521258b4c6995d692ba22bd94912c43a4) | `` grandorgue: update metadata ``                                                    |
| [`1c906ccc`](https://github.com/NixOS/nixpkgs/commit/1c906ccc36dc88a45437a4249b9157f2ce3b4158) | `` burpsuite: add desktop item and icon ``                                           |
| [`7022cb76`](https://github.com/NixOS/nixpkgs/commit/7022cb768a7f0c02ea365af9bb1da217cfbaddfa) | `` burpsuite: 2021.12 -> 2022.12.7 ``                                                |
| [`d694e0b0`](https://github.com/NixOS/nixpkgs/commit/d694e0b0f6ed11a73fb1aae3f4d8b5134651f7dc) | `` treewide: convert 17 fonts to stdenvNoCC.mkDerivation ``                          |
| [`d7f5414a`](https://github.com/NixOS/nixpkgs/commit/d7f5414af7a3f91e0a026cd715badf49afef92f3) | `` firefox-bin-unwrapped: 109.0 -> 109.0.1 ``                                        |
| [`ff72ea32`](https://github.com/NixOS/nixpkgs/commit/ff72ea325652a9190a005986d386277a4bafa7b4) | `` firefox-unwrapped: 109.0 -> 109.0.1 ``                                            |
| [`359ab2f7`](https://github.com/NixOS/nixpkgs/commit/359ab2f78b1282bb34a80a3ed45fa756203a8af2) | `` ls-lint: init at 1.11.2 ``                                                        |
| [`fa077510`](https://github.com/NixOS/nixpkgs/commit/fa0775101f111274bd1b3fce0b0284a929d923d1) | `` nim: make gdb optional to fix aarch64-darwin build ``                             |
| [`880161ef`](https://github.com/NixOS/nixpkgs/commit/880161efe12c0b27e41fd1a45bb74a20c2877021) | `` Revert "burpsuite: 2021.12 -> 2022.12.7" ``                                       |
| [`6fc3dfa9`](https://github.com/NixOS/nixpkgs/commit/6fc3dfa9d1f3386a239f2abfbdf0e77fb7d40918) | `` burpsuite: 2021.12 -> 2022.12.7 ``                                                |
| [`66b6fd2f`](https://github.com/NixOS/nixpkgs/commit/66b6fd2fd85bcbc1ea7e2736e389626c456cc1df) | `` python310Packages.blinkpy: add changelog to meta ``                               |
| [`b0e43748`](https://github.com/NixOS/nixpkgs/commit/b0e43748ef199c52c89f4c40c7224d86ed14315e) | `` python310Packages.evdev: 1.6.0 -> 1.6.1 ``                                        |
| [`0339a7d8`](https://github.com/NixOS/nixpkgs/commit/0339a7d8752014bcdd6d7ea46863336868e4222b) | `` python310Packages.evdev: add changelog to meta ``                                 |
| [`53ee47ab`](https://github.com/NixOS/nixpkgs/commit/53ee47abfdca892080af78ab68b9a5f456841938) | `` python310Packages.p1monitor: 2.2.0 -> 2.2.1 ``                                    |
| [`656c8760`](https://github.com/NixOS/nixpkgs/commit/656c876003743e8e53dc8ba94e17e8d548809db1) | `` invidious: unstable-2023-01-22 -> unstable-2023-01-26 ``                          |
| [`298da4e2`](https://github.com/NixOS/nixpkgs/commit/298da4e26cd5274d68dc9de3501c471ab24493e3) | `` python310Packages.pyswitchbot: 0.37.0 -> 0.37.1 ``                                |
| [`8c11fe37`](https://github.com/NixOS/nixpkgs/commit/8c11fe37b0c3a16c1d1ef15a758dc4492e43819c) | `` libreddit: 0.27.1 -> 0.28.0 ``                                                    |
| [`229ef302`](https://github.com/NixOS/nixpkgs/commit/229ef3021c27511f3b765058e0d6eeafd24467f6) | `` ocamlPackages.psmt2-frontend: minor cleaning ``                                   |
| [`7f42f285`](https://github.com/NixOS/nixpkgs/commit/7f42f2852980166a4488c82e666253b0d30c01e5) | `` treewide: convert 43 fonts to stdenvNoCC.mkDerivation ``                          |
| [`6b3986df`](https://github.com/NixOS/nixpkgs/commit/6b3986df94f19ccc5c8802044049a927b073f7f6) | `` qgis: 3.28.2 -> 3.28.3 ``                                                         |
| [`ee303854`](https://github.com/NixOS/nixpkgs/commit/ee303854a07309a8dcfd6c89cfe72fcba2442824) | `` micromamba: 1.0.0 -> 1.2.0 ``                                                     |
| [`ffe1ba89`](https://github.com/NixOS/nixpkgs/commit/ffe1ba89853cee12c75cf98f620022a758fc7818) | `` alt-ergo: fix src URL ``                                                          |
| [`9b32c3b2`](https://github.com/NixOS/nixpkgs/commit/9b32c3b2047a805f1373a7cdeabd7ec8a9457049) | `` python310Packages.meshtastic: 2.0.9 -> 2.0.10 ``                                  |
| [`d1a36980`](https://github.com/NixOS/nixpkgs/commit/d1a3698076d912caef3206493dfe133553c71879) | `` python310Packages.hahomematic: 2023.1.7 -> 2023.1.8 ``                            |
| [`605704fa`](https://github.com/NixOS/nixpkgs/commit/605704fa22255fa2f64348cf2fe083d1a1140fca) | `` ocamlPackages.tsdl: fix build on darwin ``                                        |
| [`4f266763`](https://github.com/NixOS/nixpkgs/commit/4f266763f34f30a715c474a3d188f413e5c00ef3) | `` python310Packages.enlighten: add changelog to meta ``                             |
| [`35760ef7`](https://github.com/NixOS/nixpkgs/commit/35760ef789e2fbd742a930bcb499e913adc9a673) | `` python310Packages.getmac: add changelog to meta ``                                |
| [`ae855d1c`](https://github.com/NixOS/nixpkgs/commit/ae855d1c76d2e1355e1a465009325da0889da73b) | `` uutils-coreutils: 0.0.16 -> 0.0.17 ``                                             |
| [`fed3e4cc`](https://github.com/NixOS/nixpkgs/commit/fed3e4cc87ac65e2a2cf4231ccec937e5edc8d8c) | `` connman: add NixOS tests to passthru ``                                           |
| [`fc211dec`](https://github.com/NixOS/nixpkgs/commit/fc211deccf85739831181adf5b74be1ca811c653) | `` nixos/tests/connman: init ``                                                      |
| [`9dc19ace`](https://github.com/NixOS/nixpkgs/commit/9dc19ace3a66d8f6369f2394ae2501506b32b8da) | `` qpdfview: 0.4.18 -> 0.5.0 ``                                                      |
| [`f697326b`](https://github.com/NixOS/nixpkgs/commit/f697326b03f3bc8246914dd3aab7faf1ba64bd73) | `` ocamlPackages.decompress: 1.5.1 → 1.5.2 ``                                        |
| [`7e0272c7`](https://github.com/NixOS/nixpkgs/commit/7e0272c78ed8e3440e398fabd942906f890bcdcb) | `` ocamlPackages.carton: use Dune 3 ``                                               |
| [`8303bef3`](https://github.com/NixOS/nixpkgs/commit/8303bef3872bf20194f464eb222ae10ffb5a7ba4) | `` ocamlPackages.pbkdf: use Dune 3 ``                                                |
| [`a6deb6e9`](https://github.com/NixOS/nixpkgs/commit/a6deb6e9518ec5f5ecd3805f60c6f07dceb79661) | `` qpdfview: move to pkgs/applications/office ``                                     |
| [`ffaae978`](https://github.com/NixOS/nixpkgs/commit/ffaae97867dc2f351e2ea3738bbecd9e84a4eef4) | `` nixos/pipewire: add myself as maintainer ``                                       |
| [`5666e3ef`](https://github.com/NixOS/nixpkgs/commit/5666e3ef3a372cdd5456f824b4d59fb5ff48eb2e) | `` pipewire: add myself as maintainer ``                                             |
| [`16b32fe8`](https://github.com/NixOS/nixpkgs/commit/16b32fe811ee2b440119fb1d76d73d694afa7822) | `` skopeo: 1.10.0 -> 1.11.0 ``                                                       |
| [`f2c346f4`](https://github.com/NixOS/nixpkgs/commit/f2c346f4cf700954853ad55563a7a3e6fb74072c) | `` awscli2: 2.9.18 -> 2.9.19 ``                                                      |
| [`473312a1`](https://github.com/NixOS/nixpkgs/commit/473312a171c662f06eaa3f9f783e5f8322984ade) | `` cargo-outdated: 0.11.1 -> 0.11.2 ``                                               |
| [`f731c133`](https://github.com/NixOS/nixpkgs/commit/f731c133ba50d600af12b652f6c9177362f40bce) | `` slint-lsp: 0.3.3 -> 0.3.4 ``                                                      |
| [`5f3c2b74`](https://github.com/NixOS/nixpkgs/commit/5f3c2b74541851006be26fff1bf917203832376f) | `` terraform-providers.minio: 1.10.0 → 1.11.0 ``                                     |
| [`aa3e98ca`](https://github.com/NixOS/nixpkgs/commit/aa3e98ca07bfd2185b83ab7f9ec0d115efd9ed77) | `` simple-http-server: 0.6.5 -> 0.6.6 ``                                             |
| [`859f7664`](https://github.com/NixOS/nixpkgs/commit/859f76642a4e755a535733da0e476f1ad3b21836) | `` python310Packages.google-cloud-logging: 3.4.0 -> 3.5.0 ``                         |
| [`ce389aa7`](https://github.com/NixOS/nixpkgs/commit/ce389aa7c608d0ad3c060b9272c251e09329aa99) | `` python310Packages.enlighten: 1.11.1 -> 1.11.2 ``                                  |
| [`0d31ee45`](https://github.com/NixOS/nixpkgs/commit/0d31ee45ccf9c1b6dc5587ca94a9f031ec57bbf2) | `` python310Packages.pynamodb: 5.3.4 -> 5.3.5 ``                                     |
| [`6f1d04bd`](https://github.com/NixOS/nixpkgs/commit/6f1d04bdb55d6160958430f594022b73b7e20711) | `` llvmPackages_15: add attributes ``                                                |
| [`b431ac2f`](https://github.com/NixOS/nixpkgs/commit/b431ac2fd98ac95f64c8fa28d16c4e4c2314541e) | `` programmer-calculator: 2.2 -> 3.0 ``                                              |
| [`17784aa2`](https://github.com/NixOS/nixpkgs/commit/17784aa2721f390ae6b4ecc9956042d3d3ef9805) | `` miniflux: 2.0.41 -> 2.0.42 ``                                                     |
| [`aa49baac`](https://github.com/NixOS/nixpkgs/commit/aa49baac70e5ff48e43216b000766e014917c50b) | `` python310Packages.moku: 2.5.1 -> 2.6.0 ``                                         |
| [`259cc790`](https://github.com/NixOS/nixpkgs/commit/259cc7903c78d48d10c930b019bea049a5471884) | `` nixos/roon-bridge: fix exec name ``                                               |
| [`b6a8a230`](https://github.com/NixOS/nixpkgs/commit/b6a8a230dbf737b656dba728131823e0653933d2) | `` labwc: 0.6.0 -> 0.6.1 ``                                                          |
| [`6308d4b6`](https://github.com/NixOS/nixpkgs/commit/6308d4b6f6b02fd89aa1f6103ad154b7e195e782) | `` linphone: 4.4.10 -> 5.0.8 ``                                                      |
| [`61096171`](https://github.com/NixOS/nixpkgs/commit/6109617190bcd944636ab9b52f8d9741be8ac8d4) | `` firefox-beta-bin-unwrapped: 110.0b5 -> 110.0b7 ``                                 |
| [`f2eacd10`](https://github.com/NixOS/nixpkgs/commit/f2eacd10815fa4cafb5b3fb3828b4581344bafa8) | `` python310Packages.pyhiveapi: 0.5.14 -> 0.5.15 ``                                  |
| [`aaafff21`](https://github.com/NixOS/nixpkgs/commit/aaafff21756e623115eec9672adf577d41948559) | `` pekwm: add changelog ``                                                           |
| [`e03dc541`](https://github.com/NixOS/nixpkgs/commit/e03dc5413303b7ebf3a3e8e01e2395adc1a8b041) | `` pixinsight: remove qtwebkit ``                                                    |
| [`4c0008ac`](https://github.com/NixOS/nixpkgs/commit/4c0008ac4b9340d2c50dad27f842595c456b3591) | `` pyradio: 0.8.9.36 -> 0.9.0 ``                                                     |
| [`d8a21780`](https://github.com/NixOS/nixpkgs/commit/d8a217801e21d561e47a91ea60ec086397fc7466) | `` defaultPkgConfigPackages: Add dontRecurseIntoAttrs ``                             |
| [`b6bec17e`](https://github.com/NixOS/nixpkgs/commit/b6bec17eb9b8f256151c396282ad76db255fff91) | `` testers.hasPkgConfigModule: Extract and add tests, docs ``                        |
| [`f192e96d`](https://github.com/NixOS/nixpkgs/commit/f192e96d0771a9c8fa8e8c73e6ef66af56a548f8) | `` tests.defaultPkgConfigPackages: Add recurseIntoAttrs ``                           |
| [`473ac969`](https://github.com/NixOS/nixpkgs/commit/473ac9692e09451ef6025e50ccfa19efe5ae69a9) | `` lib.hydraJob: Tolerate null ``                                                    |
| [`6900c444`](https://github.com/NixOS/nixpkgs/commit/6900c444a7968ec5423530cb5988330354922c89) | `` python310Packages.ffmpeg-progress-yield: 0.6.1 -> 0.7.0 ``                        |
| [`bf2c8a1b`](https://github.com/NixOS/nixpkgs/commit/bf2c8a1b17c534c11d0aa55b4cec049da74fb459) | `` yamlfix: 1.5.0 -> 1.6.0 ``                                                        |
| [`1a9b449f`](https://github.com/NixOS/nixpkgs/commit/1a9b449f14be2e1c0605604c29ee1b26a70bdc85) | `` python310Packages.nocasedict: 1.0.4 -> 1.1.0 ``                                   |
| [`fb910900`](https://github.com/NixOS/nixpkgs/commit/fb9109003295e7e139172642716b9f9d69bd7d88) | `` python310Packages.devpi-common: 3.7.1 -> 3.7.2 ``                                 |
| [`e81afd88`](https://github.com/NixOS/nixpkgs/commit/e81afd887eff1be3648ed051ceced90792728ed7) | `` python310Packages.getmac: 0.8.3 -> 0.9.1 ``                                       |
| [`06a02ebb`](https://github.com/NixOS/nixpkgs/commit/06a02ebb37d49b4566830de468f33ea2630fc114) | `` cargo-flash: 0.14.2 -> 0.16.0 ``                                                  |
| [`89a0a924`](https://github.com/NixOS/nixpkgs/commit/89a0a924743ec4b7de365ab1e03fc0520ecaa0a2) | `` mpich: 4.0.3 -> 4.1 ``                                                            |
| [`692e6f24`](https://github.com/NixOS/nixpkgs/commit/692e6f241a9a8f003b7dc11a2be06d5239be65f2) | `` cargo-embed: 0.14.2 -> 0.16.0 ``                                                  |
| [`9bd108ca`](https://github.com/NixOS/nixpkgs/commit/9bd108ca804a28cda91d81362c4651d8ed6b4832) | `` probe-rs-cli: 0.14.2 -> 0.16.0 ``                                                 |
| [`7a0b9d66`](https://github.com/NixOS/nixpkgs/commit/7a0b9d667de36600c3a01d6e34e1217a79c449d7) | `` python311Packages.safe-pysha3: init at 1.0.3 ``                                   |
| [`bd900722`](https://github.com/NixOS/nixpkgs/commit/bd9007229472cac18311a3e572278d501d15c717) | `` drone: add website ``                                                             |
| [`0c20db8f`](https://github.com/NixOS/nixpkgs/commit/0c20db8f0cb31f1810f3cb482946dc0c76469bce) | `` python3Packages.cvxopt: use openblas for darwin ``                                |
| [`4bac8529`](https://github.com/NixOS/nixpkgs/commit/4bac8529efed76fa6461bb39cfc6b97ab84fa8da) | `` marathi-cursive: 2.0 -> 2.1 ``                                                    |
| [`465b5127`](https://github.com/NixOS/nixpkgs/commit/465b51277703489e6ccadda049a1ee2e70833a83) | `` resholve: 0.8.5 -> 0.9.0 ``                                                       |
| [`7f35c8b2`](https://github.com/NixOS/nixpkgs/commit/7f35c8b2ac51c9c93abaa4eaa23f4ac39e5db5a5) | `` nixos/systemd/coredump: fix kernel.core_pattern truncation ``                     |
| [`c60c7287`](https://github.com/NixOS/nixpkgs/commit/c60c72872b9b1c7abc0e24e78201fc2c0835e7ce) | `` maintainers: add comment at the end of the file ``                                |