### PR TITLE
chore(flake/home-manager): `1c6f3054` -> `1d94de56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675202993,
-        "narHash": "sha256-ABb+sCJDzM+iMZqXANRvQj8M5UeEqC+jptfvPsd6Jd0=",
+        "lastModified": 1675203549,
+        "narHash": "sha256-SehK6lTqcB5gv4QpoIHcWcqvwpLzHW42+681ZBg52cE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1c6f3054ca36466a45972bf163fa934c33d69a15",
+        "rev": "1d94de5604935591494eeb6ea80bc34ac84a9f23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`1d94de56`](https://github.com/nix-community/home-manager/commit/1d94de5604935591494eeb6ea80bc34ac84a9f23) | `` pass-secret-service: various improvements `` |