### PR TITLE
chore(flake/nixpkgs): `2caf4ef5` -> `e1e1b192`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675115703,
-        "narHash": "sha256-4zetAPSyY0D77x+Ww9QBe8RHn1akvIvHJ/kgg8kGDbk=",
+        "lastModified": 1675183161,
+        "narHash": "sha256-Zq8sNgAxDckpn7tJo7V1afRSk2eoVbu3OjI1QklGLNg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2caf4ef5005ecc68141ecb4aac271079f7371c44",
+        "rev": "e1e1b192c1a5aab2960bf0a0bd53a2e8124fa18e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`59dbe319`](https://github.com/NixOS/nixpkgs/commit/59dbe319cec232cf2604fa2ca8f018a05a0eb88a) | `` nixos/gitea: update SystemCallFilter ``                                     |
| [`239a93f2`](https://github.com/NixOS/nixpkgs/commit/239a93f205ee51368fe3e42f3cdeae705a69bfa8) | `` chrony: add gkleen as maintainer for nixos test for ptp_kvm ``              |
| [`b355be2d`](https://github.com/NixOS/nixpkgs/commit/b355be2d91cc63d723793791657561e23f7703d8) | `` chrony: add nixos test for ptp_kvm ``                                       |
| [`48ecda09`](https://github.com/NixOS/nixpkgs/commit/48ecda096288c2d1a7c9eb5cca1cedc54afd7223) | `` nixos/chrony: disable PrivateDevices setting ``                             |
| [`a7d112b3`](https://github.com/NixOS/nixpkgs/commit/a7d112b30a36fd4f0500fed41c62249461624c98) | `` nixos/paperless: Reindex documents after updating to 1.12.x ``              |
| [`eb7c0a38`](https://github.com/NixOS/nixpkgs/commit/eb7c0a38dbcd494e53ef93c3b500194b77bd2d4a) | `` goreleaser: 1.14.1 -> 1.15.0 ``                                             |
| [`c4597fef`](https://github.com/NixOS/nixpkgs/commit/c4597fef1d0a0cde255f75754382f6311edcefa4) | `` deterministic-uname: add missing whitespace ``                              |
| [`b52ae04b`](https://github.com/NixOS/nixpkgs/commit/b52ae04b634f585e01ff60e18e00a52722969e4b) | `` glooctl: 1.13.3 -> 1.13.4 ``                                                |
| [`870c4429`](https://github.com/NixOS/nixpkgs/commit/870c44295afdcbd979d27f288a39487f4f6a903a) | `` t-rec: 0.7.5 -> 0.7.6 ``                                                    |
| [`f9a1d83c`](https://github.com/NixOS/nixpkgs/commit/f9a1d83cdbf4154b71bf2eb817c94060b304929b) | `` criu: support cross-compile for armv7l and aarch64 ``                       |
| [`6616e693`](https://github.com/NixOS/nixpkgs/commit/6616e69312ec69c0c7246e6cb150928f662466b0) | `` praat: 6.3.04 -> 6.3.05 ``                                                  |
| [`1c17da51`](https://github.com/NixOS/nixpkgs/commit/1c17da5148c3c40e4c9cb26bb34960400fafc242) | `` fluxcd: add superherointj as maintainer ``                                  |
| [`2fa6c099`](https://github.com/NixOS/nixpkgs/commit/2fa6c099249727c5229d4c70cdb0b2aaa262200b) | `` k3s: add superherointj as maintainer ``                                     |
| [`4a3a31a7`](https://github.com/NixOS/nixpkgs/commit/4a3a31a70d893bc1aa7ad0cb5c30f2ba601a2715) | `` maintainers: add superherointj ``                                           |
| [`5bc42e95`](https://github.com/NixOS/nixpkgs/commit/5bc42e957ce015f2bd36ed6d3def80216945d57e) | `` python311Packages.bip_utils: fix build ``                                   |
| [`3d80075d`](https://github.com/NixOS/nixpkgs/commit/3d80075d544ab02fa9d9eaecad4dbfb0a258445d) | `` conmon-rs: 0.4.0 -> 0.5.0 ``                                                |
| [`ffe90311`](https://github.com/NixOS/nixpkgs/commit/ffe90311294ae0867e1fd64ee30bcf726d1a53f8) | `` Use buitins.currentSystem ``                                                |
| [`3b088460`](https://github.com/NixOS/nixpkgs/commit/3b088460594c88c70520613a0fe93c8200acbc00) | `` jackett: 0.20.2732 -> 0.20.2782 ``                                          |
| [`59ea6693`](https://github.com/NixOS/nixpkgs/commit/59ea6693001af385bcb3f464b507355012366d15) | `` syft: 0.68.1 -> 0.69.0 ``                                                   |
| [`b76807be`](https://github.com/NixOS/nixpkgs/commit/b76807be004ee5a0155db130e8c811078818aa9e) | `` liboqs: init at 0.7.2 ``                                                    |
| [`8429858c`](https://github.com/NixOS/nixpkgs/commit/8429858c5700ea8acfca4aa76fd0aee99937b6fd) | `` python310Packages.azure-mgmt-recoveryservicesbackup: 5.0.0 -> 5.1.0 ``      |
| [`71f864b4`](https://github.com/NixOS/nixpkgs/commit/71f864b4e98d8a3e8044c9a2a046282f463f9796) | `` nerdctl: 1.1.0 -> 1.2.0 ``                                                  |
| [`34554cb4`](https://github.com/NixOS/nixpkgs/commit/34554cb4c2faa7e02df35143294451c07bd48535) | `` mdbook-open-on-gh: 2.3.0 -> 2.3.1 ``                                        |
| [`8fdaf00e`](https://github.com/NixOS/nixpkgs/commit/8fdaf00e8c692ffb3d5e8d9545e6af32b1f14171) | `` minikube: 1.28.0 -> 1.29.0 ``                                               |
| [`d2aec8b2`](https://github.com/NixOS/nixpkgs/commit/d2aec8b2200713d39dccbf9f695078b2664da300) | `` prometheus-redis-exporter: 1.45.0 -> 1.46.0 ``                              |
| [`b4cb0093`](https://github.com/NixOS/nixpkgs/commit/b4cb00932f8047e385cb262cb04bb2121c329c56) | `` maintainers/teams: remove andir from rust ``                                |
| [`feba9a45`](https://github.com/NixOS/nixpkgs/commit/feba9a453383b1e266758cf63b4151981cd7e8e1) | `` CODEOWNERS: add new Rust team members, re-add Rust build support/docs ``    |
| [`1e814042`](https://github.com/NixOS/nixpkgs/commit/1e814042af43346c995fedd41d467032c4fd0d25) | `` rustc, cargo: add rust team to maintainers ``                               |
| [`aa9b2e83`](https://github.com/NixOS/nixpkgs/commit/aa9b2e830cbf2120176d197f643e1c84360bc6fc) | `` maintainers/teams: add figsoda, tjni, and winter to rust ``                 |
| [`fc218da6`](https://github.com/NixOS/nixpkgs/commit/fc218da605f878999379751cc68d7e64abebfe05) | `` python310Packages.magic-wormhole-mailbox-server: add changelog to meta ``   |
| [`f3325d28`](https://github.com/NixOS/nixpkgs/commit/f3325d28b978172caefffe33e4b850a3e647403a) | `` itchiodl: 2.1.2 -> 2.2.0 ``                                                 |
| [`2f44a314`](https://github.com/NixOS/nixpkgs/commit/2f44a31490567dbf66922b4e8d1e897cf082ed5c) | `` python311Packages.pyramid: update meta ``                                   |
| [`599bf84f`](https://github.com/NixOS/nixpkgs/commit/599bf84f38ec4bd39fb44c1480421b15be039071) | `` python310Packages.humanize: add changelog to meta ``                        |
| [`9248c818`](https://github.com/NixOS/nixpkgs/commit/9248c818167224593495dcd005907e7b5f2fe25d) | `` igrep: 1.0.0 -> 1.1.0 ``                                                    |
| [`383016f0`](https://github.com/NixOS/nixpkgs/commit/383016f034c05719bcc5c003c78f42b9ed8de8a6) | `` marksman: 2022-12-28 -> 2023-01-29 ``                                       |
| [`63f02835`](https://github.com/NixOS/nixpkgs/commit/63f028357a6713ae4078bd25e1636c4d4034112b) | `` leftwm: 0.4.0 -> 0.4.1 ``                                                   |
| [`783c88bf`](https://github.com/NixOS/nixpkgs/commit/783c88bfb44d1935d11cea04206870989f249932) | `` kafkactl: 3.0.1 -> 3.0.2 ``                                                 |
| [`9abbbc59`](https://github.com/NixOS/nixpkgs/commit/9abbbc5979d7ddff0e479737460e725fb33f1b50) | `` nixos/plasma5: add tool needed for kinfocenter ``                           |
| [`f265af55`](https://github.com/NixOS/nixpkgs/commit/f265af55c584fe7786e35e3dbd15de28c0d74c3a) | `` kinfocenter: add a bunch of tools for additional info ``                    |
| [`89ef9ef2`](https://github.com/NixOS/nixpkgs/commit/89ef9ef2956b1a3f6e9b78ec2ab7fa5de1766244) | `` usql: 0.13.6 -> 0.13.8 ``                                                   |
| [`5bc114b1`](https://github.com/NixOS/nixpkgs/commit/5bc114b1b20ead4bec4c1a9153d695a79bfa78e8) | `` eyedropper: 0.5.0 -> 0.5.1 ``                                               |
| [`741e9a67`](https://github.com/NixOS/nixpkgs/commit/741e9a679adee5d7b734427c6b045f57857b0aeb) | `` open-stage-control: 1.21.0 -> 1.22.0 ``                                     |
| [`f2cd0189`](https://github.com/NixOS/nixpkgs/commit/f2cd0189ec04db6227d8e5f927b6500f0e538444) | `` mautrix-googlechat: 0.4.0 -> unstable-2023-01-25 ``                         |
| [`f6b1aa61`](https://github.com/NixOS/nixpkgs/commit/f6b1aa61ea8bf95396f163db7486914c2798d2aa) | `` argocd: 2.5.8 -> 2.5.9 ``                                                   |
| [`ac64ad4c`](https://github.com/NixOS/nixpkgs/commit/ac64ad4c5ae3b7f072ceeac69e3d909d876407c3) | `` picoprobe-udev-rules: init at unstable-2023-01-31 ``                        |
| [`80247dcc`](https://github.com/NixOS/nixpkgs/commit/80247dccc56a0a4a423868a109dd3200b85fe5a3) | `` brev-cli: 0.6.197 -> 0.6.199 ``                                             |
| [`e139718d`](https://github.com/NixOS/nixpkgs/commit/e139718d5f109e24e4ba4fea5120fc7708f8e2ea) | `` mautrix-signal: use pythonRelaxDepsHook ``                                  |
| [`54468447`](https://github.com/NixOS/nixpkgs/commit/54468447bbab6ff86df09ed2aa5c857b6dc2fb00) | `` mautrix-telegram: 0.12.2 -> unstable-2023-01-28 ``                          |
| [`20725055`](https://github.com/NixOS/nixpkgs/commit/20725055e0aedeb00906161a527de3e7d41e9fb6) | `` xarchiver: 0.5.4.19 -> 0.5.4.20 ``                                          |
| [`382cad7a`](https://github.com/NixOS/nixpkgs/commit/382cad7adffe297a402e82f7ca8e4cc2d6619199) | `` gremlin-console: 3.6.1 -> 3.6.2 ``                                          |
| [`7a382a6b`](https://github.com/NixOS/nixpkgs/commit/7a382a6b5822401a82555556a3ebfd77628c6583) | `` heisenbridge: rework packaging ``                                           |
| [`fbbaf6d8`](https://github.com/NixOS/nixpkgs/commit/fbbaf6d8448e122b70e44532d566a33c3501ef5f) | `` procs: 0.13.3 -> 0.13.4 ``                                                  |
| [`40b0c100`](https://github.com/NixOS/nixpkgs/commit/40b0c1000a3b8ff0c36a2738c6c83c6f1dcbbe2a) | `` jql: 5.1.4 -> 5.1.6 ``                                                      |
| [`037f121c`](https://github.com/NixOS/nixpkgs/commit/037f121cad4dec686a9cae6b83010fcc5dc974de) | `` prometheus-zfs-exporter: 2.2.5 -> 2.2.7 ``                                  |
| [`25b838ca`](https://github.com/NixOS/nixpkgs/commit/25b838ca26a71c15e8a73ca91ac499981d86df23) | `` komga: 0.160.0 -> 0.161.0 ``                                                |
| [`e33dc05e`](https://github.com/NixOS/nixpkgs/commit/e33dc05e71fa547aff374296049618514b7cf82b) | `` python3Packages.mautrix: 0.18.9 -> 0.19.3 ``                                |
| [`34457c02`](https://github.com/NixOS/nixpkgs/commit/34457c02bfdfb55a91a30ed4efe1ec07f6513a4d) | `` k9s: 0.26.7 -> 0.27.0 ``                                                    |
| [`2843cd43`](https://github.com/NixOS/nixpkgs/commit/2843cd434ead9020f0b400397cb2659fca53be9d) | `` w_scan2: init at 1.0.14 ``                                                  |
| [`5d731bf3`](https://github.com/NixOS/nixpkgs/commit/5d731bf306589acca55ac11986eafde5550e5d52) | `` terraform-providers.ibm: 1.49.0 → 1.50.0 ``                                 |
| [`c1348f9f`](https://github.com/NixOS/nixpkgs/commit/c1348f9fa0cd1ca1b87ddd83fa53c2441003511f) | `` terraform-providers.opsgenie: 0.6.19 → 0.6.20 ``                            |
| [`8ba6eaad`](https://github.com/NixOS/nixpkgs/commit/8ba6eaad44fb66b117b081d90af81f177e10e8de) | `` terraform-providers.opennebula: 1.1.0 → 1.1.1 ``                            |
| [`a7652000`](https://github.com/NixOS/nixpkgs/commit/a7652000de7786804aa8fadf83104ecd3f6ef107) | `` terraform-providers.google-beta: 4.50.0 → 4.51.0 ``                         |
| [`3459a157`](https://github.com/NixOS/nixpkgs/commit/3459a15742c8c0dda98ca52cc4b24d80810ce4e4) | `` terraform-providers.google: 4.50.0 → 4.51.0 ``                              |
| [`a4cdaffd`](https://github.com/NixOS/nixpkgs/commit/a4cdaffd23e9142a42b3586dba68e68a7f45c9ec) | `` acorn: 0.4.2 -> 0.5.0 ``                                                    |
| [`06fa0286`](https://github.com/NixOS/nixpkgs/commit/06fa028600ec655c944988228bf443d2ba1a3740) | `` mpvScripts.mpvacious: 0.18 -> 0.20 ``                                       |
| [`bd8129db`](https://github.com/NixOS/nixpkgs/commit/bd8129db33fad5ea274002240e8ac29d82958df5) | `` haven-cli: 3.0.3 -> 3.0.7 ``                                                |
| [`7215603c`](https://github.com/NixOS/nixpkgs/commit/7215603cb915cf27036b413cfadade37763715a9) | `` discourse.plugins.discourse-reactions: Init ``                              |
| [`b5158dec`](https://github.com/NixOS/nixpkgs/commit/b5158decda218c38b7c3d79747e6fb1586e1c1bd) | `` go-musicfox: init at 3.6.1 ``                                               |
| [`26c0de25`](https://github.com/NixOS/nixpkgs/commit/26c0de25951b738aab1dea077d8f8f717bac4cca) | `` undefined-medium: 1.0 -> 1.1 ``                                             |
| [`8370e7c7`](https://github.com/NixOS/nixpkgs/commit/8370e7c78e31f8e4ba52cf8f195de525d26e54aa) | `` pgbackrest: 2.43 -> 2.44 ``                                                 |
| [`94edb149`](https://github.com/NixOS/nixpkgs/commit/94edb149a581a6bc67b89c9d70cb02c8e3935894) | `` hashlink: 1.12 -> 1.13 ``                                                   |
| [`c27ef743`](https://github.com/NixOS/nixpkgs/commit/c27ef7433db133555935eb2e99663dd55ede5069) | `` ocamlPackages.pyml: fix test on darwin ``                                   |
| [`4da97f27`](https://github.com/NixOS/nixpkgs/commit/4da97f27d9b13afffe663f74352776364273ef0d) | `` ctlptl: 0.8.15 -> 0.8.16 ``                                                 |
| [`b408516f`](https://github.com/NixOS/nixpkgs/commit/b408516f977a22740439730571e87720bc31bbf7) | `` deltachat-desktop: 1.34.2 -> 1.34.3 ``                                      |
| [`f67de03b`](https://github.com/NixOS/nixpkgs/commit/f67de03b0a92f3b46343fc19731177cf6515cba2) | `` libdeltachat: 1.106.0 -> 1.107.0 ``                                         |
| [`3da9df34`](https://github.com/NixOS/nixpkgs/commit/3da9df34040cb79c264dff562e1a03c0c5f1d673) | `` scarab: 1.19.0.0 -> 1.20.0.0 ``                                             |
| [`2432a70c`](https://github.com/NixOS/nixpkgs/commit/2432a70ca9d47b0e0d58d63eff89dd06c096c28c) | `` python311Packages.pyramid: 2.0 -> 2.0.1 ``                                  |
| [`5d6f025f`](https://github.com/NixOS/nixpkgs/commit/5d6f025f102ff4fabb711d16632e5c313fcca753) | `` topgrade: 10.2.4 -> 10.3.0 ``                                               |
| [`10c516b2`](https://github.com/NixOS/nixpkgs/commit/10c516b2b6c9e388c56937dec7fc34526c5cb631) | `` python3Packages.magic-wormhole-mailbox-server: add patch for Python 3.11 `` |
| [`ce47ede7`](https://github.com/NixOS/nixpkgs/commit/ce47ede70bb0ab9fedf2d48e3fab9fa8b37dcef8) | `` icewm: 3.3.0 -> 3.3.1 ``                                                    |
| [`eaaaf921`](https://github.com/NixOS/nixpkgs/commit/eaaaf92166091103cf0740918e501fb3a337fd9b) | `` wakapi: init at 2.6.1 ``                                                    |
| [`562582ac`](https://github.com/NixOS/nixpkgs/commit/562582ac5fd5c2874b1f14c3a73cbd8bead52bfa) | `` oxker: 0.1.11 -> 0.2.1 ``                                                   |
| [`488f7cb5`](https://github.com/NixOS/nixpkgs/commit/488f7cb589b557fc2842ff004f4b9bf26b2e348a) | `` cargo-semver-checks: 0.17.0 -> 0.17.1 ``                                    |
| [`0718d09d`](https://github.com/NixOS/nixpkgs/commit/0718d09ddc8ff1575c854d76cffc749907531ce8) | `` redpanda: 22.3.5 -> 22.3.11 ``                                              |
| [`9d81d8fa`](https://github.com/NixOS/nixpkgs/commit/9d81d8fab92f521446b74976e10661e4afe9c330) | `` azure-storage-azcopy: 10.16.2 -> 10.17.0 ``                                 |
| [`d9da7eee`](https://github.com/NixOS/nixpkgs/commit/d9da7eeef155f3cae040419320c7ee66f2f4fbc9) | `` mold: 1.9.0 -> 1.10.1 ``                                                    |
| [`993a57e7`](https://github.com/NixOS/nixpkgs/commit/993a57e705c1d7566bc37160b3ac89315654ab97) | `` micronaut: 3.8.2 -> 3.8.3 ``                                                |
| [`dea1ccc2`](https://github.com/NixOS/nixpkgs/commit/dea1ccc281368b3abbba3dc1aaca36a1c96c0e89) | `` standardnotes: 3.139.0 -> 3.142.1 ``                                        |
| [`cb346103`](https://github.com/NixOS/nixpkgs/commit/cb34610386c4113567713adf57793689e577e690) | `` cpm-cmake: 0.36.0 -> 0.37.0 ``                                              |
| [`e60870a8`](https://github.com/NixOS/nixpkgs/commit/e60870a807caccbb6bd5713879d4a8f792a3c542) | `` doc/nixos: ``                                                               |
| [`ea43ffa1`](https://github.com/NixOS/nixpkgs/commit/ea43ffa1107c83842a8bdab22a5a42a97314414c) | `` python311Packages.eth-hash: fix build ``                                    |
| [`bb6eb8c4`](https://github.com/NixOS/nixpkgs/commit/bb6eb8c44e4eddae34ad3556478c99db61fad666) | `` altair: 5.0.10 -> 5.0.13 ``                                                 |
| [`1f8d2fac`](https://github.com/NixOS/nixpkgs/commit/1f8d2facf8230c7689301ba3830924741d4c6584) | `` ruff: 0.0.237 -> 0.0.238 ``                                                 |
| [`e8cc8889`](https://github.com/NixOS/nixpkgs/commit/e8cc88899e349d12b955b94b6fc8a0fe9ae43ef6) | `` comfortaa: convert to stdenvNoCC.mkDerivation ``                            |
| [`4fc0f241`](https://github.com/NixOS/nixpkgs/commit/4fc0f24120eec931c5c7ea95dcfad327563c048f) | `` paperless-ngx: Reduce output size ``                                        |
| [`1b3a601b`](https://github.com/NixOS/nixpkgs/commit/1b3a601be2c06913a48d65992df61da8ef370ffc) | `` paperless-ngx: 1.11.3 -> 1.12.2 ``                                          |
| [`03ce4db8`](https://github.com/NixOS/nixpkgs/commit/03ce4db8ea250941e6dbe0cd1f7bbc1751ec905b) | `` hassil: 0.2.5 -> 0.2.6 ``                                                   |
| [`7018ef58`](https://github.com/NixOS/nixpkgs/commit/7018ef588677057eae83b611fd63bc6ebcd4b3ae) | `` python3Packages.redis: fix hiredis extra name ``                            |
| [`d18eea69`](https://github.com/NixOS/nixpkgs/commit/d18eea69350a28cbce748c05b5fe03a465dfbd94) | `` paperless-ngx: Build frontend from source ``                                |