### PR TITLE
chore(flake/home-manager): `782cb855` -> `4a958524`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675247113,
-        "narHash": "sha256-+YcXjfCP4hNu8A68b/UoXFCTDwKLuLV+x/7dQnM5U/o=",
+        "lastModified": 1675303228,
+        "narHash": "sha256-dHJbFg7gTuTyEUdJoNDp6l2bac6HXAT/bz9cVEqL+Uw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "782cb855b2f23c485011a196c593e2d7e4fce746",
+        "rev": "4a958524903e6019f5f69a23e0c0f16e5af01eb0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`4a958524`](https://github.com/nix-community/home-manager/commit/4a958524903e6019f5f69a23e0c0f16e5af01eb0) | `` flake.lock: Update (#3619) ``                        |
| [`2f62da98`](https://github.com/nix-community/home-manager/commit/2f62da9837f6f38c329c9d763df2fc152a97a49b) | `` git: unset `pager` while using difftastic (#3633) `` |