### PR TITLE
chore(flake/pre-commit-hooks): `ce4efeec` -> `5668d079`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -219,11 +219,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1675169698,
-        "narHash": "sha256-C1wFiyJ+4SRvIsFkdMIN1Fa+58APmyTGKWpX9EKOehM=",
+        "lastModified": 1675337566,
+        "narHash": "sha256-jmLBTQcs1jFOn8h1Q5b5XwPfYgFOtcZ3+mU9KvfC6Js=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ce4efeec34c6eb35ba07b8fceaae87d6b46c1c5f",
+        "rev": "5668d079583a5b594cb4e0cc0e6d84f1b93da7ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                          |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`45cc6627`](https://github.com/cachix/pre-commit-hooks.nix/commit/45cc6627190b9c045aebc7e933f284a5d25bfb99) | `` Rewrite `hpack-dir`; include fixes and doc `` |
| [`9d8f7902`](https://github.com/cachix/pre-commit-hooks.nix/commit/9d8f79029d4d781442498c1734839e55604ba91c) | `` Fix `files` pattern for `hpack` ``            |