### PR TITLE
chore(flake/nixpkgs): `e1e1b192` -> `4d7c2644`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675183161,
-        "narHash": "sha256-Zq8sNgAxDckpn7tJo7V1afRSk2eoVbu3OjI1QklGLNg=",
+        "lastModified": 1675273418,
+        "narHash": "sha256-tpYc4TEGvDzh9uRf44QemyQ4TpVuUbxb07b2P99XDbM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e1e1b192c1a5aab2960bf0a0bd53a2e8124fa18e",
+        "rev": "4d7c2644dbac9cf8282c0afe68fca8f0f3e7b2db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`2905cb13`](https://github.com/NixOS/nixpkgs/commit/2905cb1353305745b74892d6b8249e318642b2cd) | `` briar-desktop: 0.3.1-beta -> 0.4.0-beta ``                                |
| [`0058cd8e`](https://github.com/NixOS/nixpkgs/commit/0058cd8e69274cb7acc220449cf7aec3cb44c555) | `` gImageReader: 3.4.0 -> 3.4.1 ``                                           |
| [`8f7a2b6b`](https://github.com/NixOS/nixpkgs/commit/8f7a2b6bc5d51ad9a8b438d9158a2a8974e19c11) | `` gitlab: 15.8.0 -> 15.8.1 ``                                               |
| [`e937beee`](https://github.com/NixOS/nixpkgs/commit/e937beeee6ca82f46bd31d104c07acf3e360aa6e) | `` gitlab: 15.7.5 -> 15.8.0 ``                                               |
| [`5dfeef6f`](https://github.com/NixOS/nixpkgs/commit/5dfeef6f195cdff86821cc4999fe422f70d8b450) | `` gitlab: unpin openssl_1_1 (#213970) ``                                    |
| [`245bee6e`](https://github.com/NixOS/nixpkgs/commit/245bee6ef5eff90fb9e18197b194a741cb26ea6c) | `` erlang: 25.2.1 -> 25.2.2 ``                                               |
| [`98c6798b`](https://github.com/NixOS/nixpkgs/commit/98c6798b10247ada432dca92ef5ca47d877ea23a) | `` wallabag: 2.5.2 -> 2.5.3 ``                                               |
| [`d299ad03`](https://github.com/NixOS/nixpkgs/commit/d299ad031f198d344387f157502dc9dbb2545b28) | `` python3Packages.fiona: 1.8.22 -> 1.9.0 ``                                 |
| [`f4bdd4a4`](https://github.com/NixOS/nixpkgs/commit/f4bdd4a42c0e7d4dd2d85b54bdfbe178dfefdacb) | `` python310Packages.django_4: 4.1.5 -> 4.1.6 ``                             |
| [`4304c56b`](https://github.com/NixOS/nixpkgs/commit/4304c56b49c429af2f7fc80e60b56ec950a80052) | `` systeroid: 0.3.0 -> 0.3.1 ``                                              |
| [`55fbb1d2`](https://github.com/NixOS/nixpkgs/commit/55fbb1d20ce4350aae11bba71844796549175ab1) | `` ocamlPackages.ocaml-r: 0.4.0 -> 0.6.0 (#213545) ``                        |
| [`db052900`](https://github.com/NixOS/nixpkgs/commit/db0529000e7ab45a754951170cb94dcb1f5d0a80) | `` wimboot: 2.7.4 -> 2.7.5 ``                                                |
| [`4cebd0b7`](https://github.com/NixOS/nixpkgs/commit/4cebd0b7853ccb88af4ebfd564f8d61c6d8f06a7) | `` pinocchio: 2.6.14 -> 2.6.15 ``                                            |
| [`9a16d03f`](https://github.com/NixOS/nixpkgs/commit/9a16d03fd5569420c82e7cf95d7d11dc36069be8) | `` ugrep: 3.9.6 -> 3.9.7 ``                                                  |
| [`c3520ca4`](https://github.com/NixOS/nixpkgs/commit/c3520ca42c2782340589249604b9222f493bdae9) | `` got: 0.82 -> 0.83 ``                                                      |
| [`d0c423b7`](https://github.com/NixOS/nixpkgs/commit/d0c423b7a96917c13af595ac32a2a3ef5ef49113) | `` python3Packages.eigenpy: 2.9.0 -> 2.9.1 ``                                |
| [`4e77e159`](https://github.com/NixOS/nixpkgs/commit/4e77e1592b61bdc6f441732c3b27ac68f9265248) | `` crun: 1.7.2 -> 1.8 ``                                                     |
| [`92a40c2a`](https://github.com/NixOS/nixpkgs/commit/92a40c2aff549cc676aa867657fb5a3d2a778f7d) | `` python311Packages.amaranth: fix build ``                                  |
| [`15036f26`](https://github.com/NixOS/nixpkgs/commit/15036f26642a53d2144aee78a98b42eb4c5ff5ea) | `` roboto-serif: init at 1.007 ``                                            |
| [`89bd9fcc`](https://github.com/NixOS/nixpkgs/commit/89bd9fcc57e5d2f650ca66abc2f8a8c071fce0f1) | `` ttfb: init at 1.6.0 ``                                                    |
| [`42c048fb`](https://github.com/NixOS/nixpkgs/commit/42c048fb3af82aee71e0ea4fcca5cf690fc7c855) | `` ppsspp: fixup meta.description ``                                         |
| [`793cb6fb`](https://github.com/NixOS/nixpkgs/commit/793cb6fb7d51317126428c1586c580203e332a26) | `` python310Packages.angr: 9.2.35 -> 9.2.36 ``                               |
| [`b919afdd`](https://github.com/NixOS/nixpkgs/commit/b919afddaf10e0019063e5b86323933d2427ebdf) | `` python310Packages.cle: 9.2.35 -> 9.2.36 ``                                |
| [`8c4b2058`](https://github.com/NixOS/nixpkgs/commit/8c4b2058c64ae3c3240b9dead2e2f36cbd600e8b) | `` python310Packages.claripy: 9.2.35 -> 9.2.36 ``                            |
| [`597549b1`](https://github.com/NixOS/nixpkgs/commit/597549b1e9f16b2c95c3c8ee732a0a43ac7c30f2) | `` python310Packages.pyvex: 9.2.35 -> 9.2.36 ``                              |
| [`3e99ca21`](https://github.com/NixOS/nixpkgs/commit/3e99ca213eca05143385bf795dcd6aa637d1621a) | `` python310Packages.ailment: 9.2.35 -> 9.2.36 ``                            |
| [`cd0c45d7`](https://github.com/NixOS/nixpkgs/commit/cd0c45d72cf57fdfab87f3ab282fc5c75f07419a) | `` python310Packages.archinfo: 9.2.35 -> 9.2.36 ``                           |
| [`815d2ab6`](https://github.com/NixOS/nixpkgs/commit/815d2ab6e81f553e27396c69c86e5c214edaefe6) | `` python311Full: use python311 ``                                           |
| [`5aa72229`](https://github.com/NixOS/nixpkgs/commit/5aa722294056e50934e58ab6ed8629de0effba7a) | `` coqPackages_8_17.equations: init at 1.3+8.17 ``                           |
| [`c6b19541`](https://github.com/NixOS/nixpkgs/commit/c6b19541909ca1f512ee640b1f368e4c35064d67) | `` deepin-terminal: init at 5.4.34 ``                                        |
| [`f6822e8b`](https://github.com/NixOS/nixpkgs/commit/f6822e8bb18e43abf6069c0cea1d1f69ad8fb627) | `` ppsspp: fixup after https://github.com/NixOS/nixpkgs/pull/213533 ``       |
| [`47072494`](https://github.com/NixOS/nixpkgs/commit/4707249487d3229b32f5f2a9723c1c1cbe495d64) | `` python310Packages.apycula: 0.6.1 -> 0.6.2 ``                              |
| [`b02da45b`](https://github.com/NixOS/nixpkgs/commit/b02da45b3c0a665e2f5234d1ac60363bfb3c30f7) | `` gcc/common/configure-flags.nix: fix comment ``                            |
| [`ccea3592`](https://github.com/NixOS/nixpkgs/commit/ccea359262173f2d48225ef16fbbb9c71d2fa53d) | `` rymdport: 3.3.0 -> 3.3.1 ``                                               |
| [`f8a38dc4`](https://github.com/NixOS/nixpkgs/commit/f8a38dc4714701fabf90a84b204ca45f25552c24) | `` cloudfox: 1.9.0 -> 1.9.1 ``                                               |
| [`03385e36`](https://github.com/NixOS/nixpkgs/commit/03385e36c83abd48821af2a133532a6caedeac75) | `` terraform-providers.yandex: 0.84.0 → 0.85.0 ``                            |
| [`52303147`](https://github.com/NixOS/nixpkgs/commit/523031475b8a2c018ad0d4348e8101419dd4ce09) | `` terraform-providers.tfe: 0.41.0 → 0.42.0 ``                               |
| [`6cad4ca0`](https://github.com/NixOS/nixpkgs/commit/6cad4ca0fc641f37c21856b58874ffb701e8555a) | `` terraform-providers.snowflake: 0.56.0 → 0.56.1 ``                         |
| [`eb9ecb5d`](https://github.com/NixOS/nixpkgs/commit/eb9ecb5d4af4153503e2a3ca954725cfd8c15259) | `` terraform-providers.signalfx: 6.21.0 → 6.22.0 ``                          |
| [`84a09fb4`](https://github.com/NixOS/nixpkgs/commit/84a09fb41bb39a6e9cf24846d45680dc54d392c8) | `` terraform-providers.exoscale: 0.43.0 → 0.44.0 ``                          |
| [`b7dcdbd7`](https://github.com/NixOS/nixpkgs/commit/b7dcdbd7887aba73ce64055a46e8d0f45b9738eb) | `` terraform-providers.digitalocean: 2.25.2 → 2.26.0 ``                      |
| [`4e2732db`](https://github.com/NixOS/nixpkgs/commit/4e2732db95df97cbe98d3cb73cce69b920094bf8) | `` terraform-providers.bigip: 1.16.1 → 1.16.2 ``                             |
| [`7deeda58`](https://github.com/NixOS/nixpkgs/commit/7deeda580b6d66d78cad0d6ecc555e14d2e4a4e7) | `` terraform-providers.auth0: 0.42.0 → 0.43.0 ``                             |
| [`f1c0758b`](https://github.com/NixOS/nixpkgs/commit/f1c0758be123a93c3137ab4892b6b4804d8eb3d1) | `` mark: 8.6 -> 8.7 ``                                                       |
| [`f86ab9a5`](https://github.com/NixOS/nixpkgs/commit/f86ab9a545f251ca0dcc97b450abf9d566f6e7dd) | `` go-graft: 0.2.15 -> 0.2.16 ``                                             |
| [`0ffde2b3`](https://github.com/NixOS/nixpkgs/commit/0ffde2b3d0acefba21ce201f85a4a9a5ccfaf151) | `` ddosify: 0.13.0 -> 0.13.1 ``                                              |
| [`4f1caea4`](https://github.com/NixOS/nixpkgs/commit/4f1caea48249b8960e954366606dce6a29bde173) | `` wasmer: 3.1.0 -> 3.1.1 ``                                                 |
| [`8dda4278`](https://github.com/NixOS/nixpkgs/commit/8dda4278f721dca70d2af5fdad849002d7fdb072) | `` goa: 3.10.2 -> 3.11.0 ``                                                  |
| [`c7c7e2b0`](https://github.com/NixOS/nixpkgs/commit/c7c7e2b0aed4b2357eb580fcc9e5517227eabb04) | `` musikcube: replace alias libgme with game-music-emu ``                    |
| [`a1c41667`](https://github.com/NixOS/nixpkgs/commit/a1c4166735fb4913f27f76bfa7634623a38aa4f7) | `` dino: fix build on darwin ``                                              |
| [`7a0f0f0a`](https://github.com/NixOS/nixpkgs/commit/7a0f0f0a01c77d89cd1ff7f40b6b549819981e81) | `` ruff: 0.0.238 -> 0.0.239 ``                                               |
| [`fad13825`](https://github.com/NixOS/nixpkgs/commit/fad1382569849f5fe1263853eeaa87fd8fdcaf5a) | `` quick-lint-js: 2.9.0 -> 2.11.0 ``                                         |
| [`ddf5ffa8`](https://github.com/NixOS/nixpkgs/commit/ddf5ffa8cdaa6c2aac355cbd981c8afcde5a4e5f) | `` sublime-merge-dev: 2081 -> 2082 ``                                        |
| [`b68532f4`](https://github.com/NixOS/nixpkgs/commit/b68532f4e618866b079983da70b1aecba21a3525) | `` python310Packages.openstacksdk: 0.103.0 -> 1.0.0 ``                       |
| [`95d1f216`](https://github.com/NixOS/nixpkgs/commit/95d1f216b4e9f874adf9418bd20ae05ca03ab64c) | `` live555: 2022.12.01 -> 2023.01.19 ``                                      |
| [`4567743b`](https://github.com/NixOS/nixpkgs/commit/4567743bcb96e3e321dce999e535925cea6082cc) | `` busybox: 1.35.0 -> 1.36.0 ``                                              |
| [`d0369be5`](https://github.com/NixOS/nixpkgs/commit/d0369be5d3cbb585ba94bb0f365607bb993e8277) | `` roon-server: 2.0-1193 -> 2.0-1202 ``                                      |
| [`f1215fc0`](https://github.com/NixOS/nixpkgs/commit/f1215fc09a42c7d39492469c177d86a1d46222e6) | `` cotp: 1.1.0 -> 1.2.1 ``                                                   |
| [`b4bfe1ba`](https://github.com/NixOS/nixpkgs/commit/b4bfe1badaf523c4b3fac37ee9500d171361af54) | `` proxmark3-rrg: 4.15864 -> 4.16191 ``                                      |
| [`2c7b0a2a`](https://github.com/NixOS/nixpkgs/commit/2c7b0a2ab5b8c677fc21caaba87340f08edbfcbc) | `` tgt: 1.0.84 -> 1.0.85 ``                                                  |
| [`26aadca7`](https://github.com/NixOS/nixpkgs/commit/26aadca7c61d5a9a49ee1e6f1c705516e21bc06d) | `` chromiumBeta: Fix the patch phase ``                                      |
| [`d405afb2`](https://github.com/NixOS/nixpkgs/commit/d405afb2216dc257a8c1bfaffb4d9ee600a9bd97) | `` glmark2: 2021.12 -> 2023.01 ``                                            |
| [`95bf8681`](https://github.com/NixOS/nixpkgs/commit/95bf8681e119033eaf9497448cd2d4c21c0ab630) | `` iotop-c: 1.22 -> 1.23 ``                                                  |
| [`a9f355a4`](https://github.com/NixOS/nixpkgs/commit/a9f355a42a5a6ea46581f9cf8936c5a5dd2563e3) | `` nextdns: 1.38.0 -> 1.39.4 ``                                              |
| [`d64477ea`](https://github.com/NixOS/nixpkgs/commit/d64477ea641dfaf4b28e053998bd2e18c1b284fd) | `` automatic-timezoned: 1.0.60 -> 1.0.61 ``                                  |
| [`db60d9da`](https://github.com/NixOS/nixpkgs/commit/db60d9da382366e89834359250f1bf3c6ecd6b76) | `` protoc-gen-go-vtproto: 0.3.0 -> 0.4.0 ``                                  |
| [`48c973b2`](https://github.com/NixOS/nixpkgs/commit/48c973b2e470dee4c3b7738ff5434711afaa3d00) | `` clusterctl: 1.3.2 -> 1.3.3 ``                                             |
| [`fc7f9a10`](https://github.com/NixOS/nixpkgs/commit/fc7f9a1039648f064aa33705266c5a7d638e2615) | `` home-assistant.intents: 2023.1.25 -> 2023.1.31 ``                         |
| [`2b6a0352`](https://github.com/NixOS/nixpkgs/commit/2b6a0352c5758c7e5125aa80cfc462bd3051fd13) | `` xsane: fix src location ``                                                |
| [`a08e4457`](https://github.com/NixOS/nixpkgs/commit/a08e4457b76d8279e5865325cc82ba02ad78549a) | `` felix-fm: 2.2.3 -> 2.2.4 ``                                               |
| [`6998035e`](https://github.com/NixOS/nixpkgs/commit/6998035ed567d0b5f332199e4ca1fb96cbf42e62) | `` bundler: 2.4.5 -> 2.4.6 ``                                                |
| [`ff7cb263`](https://github.com/NixOS/nixpkgs/commit/ff7cb26327c201050325ef015a7cfb1ec1e0a035) | `` efivar: add musl patch ``                                                 |
| [`a997c219`](https://github.com/NixOS/nixpkgs/commit/a997c219d8e64d8c9a6d77011c959004029ecb82) | `` libsmbios: add musl patch ``                                              |
| [`6e1b4374`](https://github.com/NixOS/nixpkgs/commit/6e1b43747afb6fbdc3cf6d03c0cd67a195e92fe9) | `` punes: 0.109 -> 0.110, add Qt6 variant (#209485) ``                       |
| [`cb0e6935`](https://github.com/NixOS/nixpkgs/commit/cb0e6935af650ef02ef2ce268322589ff6bb7dff) | `` carapace: 0.20.2 -> 0.21.0 ``                                             |
| [`e35051ad`](https://github.com/NixOS/nixpkgs/commit/e35051ad37f117ef27b23cf86c89aad222910445) | `` cppcheck: 2.9.3 -> 2.10 ``                                                |
| [`1dbd1d2c`](https://github.com/NixOS/nixpkgs/commit/1dbd1d2cf25db662896cde68383918955ed87ce9) | `` zprint: 1.2.4 -> 1.2.5 ``                                                 |
| [`74ff8c51`](https://github.com/NixOS/nixpkgs/commit/74ff8c518b4b16938f473b910712a59bf2ee7421) | `` plantuml-server: 1.2023.0 -> 1.2023.1 ``                                  |
| [`678e3270`](https://github.com/NixOS/nixpkgs/commit/678e32701bdddd5fec45b6eab7fe317ca8f5bf24) | `` wayvnc: 0.6.1 -> 0.6.2 ``                                                 |
| [`e5a691df`](https://github.com/NixOS/nixpkgs/commit/e5a691df5493cd552179346853755e0be038dbfb) | `` dinghy: 1.1.0 -> 1.2.0 ``                                                 |
| [`af1c72c7`](https://github.com/NixOS/nixpkgs/commit/af1c72c7a4e934b4ec6501e0303dd5c9e59f2f50) | `` du-dust: install man page and completions ``                              |
| [`6913943e`](https://github.com/NixOS/nixpkgs/commit/6913943ebe6a703e06512261a944d41e75b72ea8) | `` du-dust: fix build on darwin ``                                           |
| [`bf295de4`](https://github.com/NixOS/nixpkgs/commit/bf295de42d433fa2a73481dfc7c06ac5949c7b80) | `` du-dust: 0.8.3 -> 0.8.4 ``                                                |
| [`a60eb7bf`](https://github.com/NixOS/nixpkgs/commit/a60eb7bf542f4719f3ce5161021655165f880a47) | `` prowlarr: 1.1.1.2377 -> 1.1.2.2453 ``                                     |
| [`a4e0f390`](https://github.com/NixOS/nixpkgs/commit/a4e0f390dd8c6ec360b9fe3f453b1827f454523c) | `` lsp-plugins: 1.2.4 -> 1.2.5 ``                                            |
| [`96e7d9fa`](https://github.com/NixOS/nixpkgs/commit/96e7d9fa2a066ed374f138cffaa0591859d48fda) | `` matrix-synapse: 1.75.0 -> 1.76.0 ``                                       |
| [`75247b3a`](https://github.com/NixOS/nixpkgs/commit/75247b3ab4b120b83437b0a57fc90777bf80bef2) | `` arangodb: 3.10.0 -> 3.10.3 ``                                             |
| [`98ef2f63`](https://github.com/NixOS/nixpkgs/commit/98ef2f63c2c5b41ec9eb52b6031fae0fa0e3bd90) | `` rambox: 2.0.9 -> 2.0.10 ``                                                |
| [`4a00abd9`](https://github.com/NixOS/nixpkgs/commit/4a00abd93ac805b09e8241f6cbbb961a26c18b84) | `` iam-policy-json-to-terraform: 1.8.1 -> 1.8.2 ``                           |
| [`10e2cd97`](https://github.com/NixOS/nixpkgs/commit/10e2cd97b5917d1cb959ee88760ea3cf97d0a3d9) | `` panoply: 5.2.2 -> 5.2.3 ``                                                |
| [`eaf43be8`](https://github.com/NixOS/nixpkgs/commit/eaf43be84c13c2efef18f4ea7d2c9eba2e3cd137) | `` linuxPackages.apfs: unstable-2022-10-20 -> 0.3.0 ``                       |
| [`113816d7`](https://github.com/NixOS/nixpkgs/commit/113816d7ebbdc1a6777fd2467ac76edcf389856c) | `` biodiff: 1.0.3 -> 1.0.4 ``                                                |
| [`a5309ae9`](https://github.com/NixOS/nixpkgs/commit/a5309ae9d207817233f9f9a5ba248714c7ec856a) | `` jmusicbot: use headless jdk ``                                            |
| [`eb8cb673`](https://github.com/NixOS/nixpkgs/commit/eb8cb6734fe3f481950e4d1a3fff39884ebd8a70) | `` cargo-zigbuild: 0.14.5 -> 0.15.0 ``                                       |
| [`3bc170ae`](https://github.com/NixOS/nixpkgs/commit/3bc170ae0bb73c87e88439ce84e78baa24c0cf0c) | `` python310Packages.ghrepo-stats: 0.5.0 -> 0.5.1 ``                         |
| [`a2774652`](https://github.com/NixOS/nixpkgs/commit/a2774652aab6c8efb2caba5acccbc0f7d65a075d) | `` ustreamer: 5.20 -> 5.36 ``                                                |
| [`9520feaf`](https://github.com/NixOS/nixpkgs/commit/9520feaf765d232d7455b93c83e077edfd38f7af) | `` Revert "Revert "tests.defaultPkgConfigPackages: Add recurseIntoAttrs"" `` |
| [`5cfdab89`](https://github.com/NixOS/nixpkgs/commit/5cfdab8950f275a8d0370d75bcc7b7f41ce8ee19) | `` eval-release.nix: Tolerate null ``                                        |
| [`6dbf077b`](https://github.com/NixOS/nixpkgs/commit/6dbf077be2a569e44381e756e18c96ae931bdb73) | `` sysdig: remove with lib over entire file ``                               |
| [`f6785fb2`](https://github.com/NixOS/nixpkgs/commit/f6785fb2e944aa88a7d8e2899d8f36c2c1a4ff43) | `` unciv: 4.4.3 -> 4.4.6 ``                                                  |
| [`d4e2930f`](https://github.com/NixOS/nixpkgs/commit/d4e2930fdfa581a89c7c09492b48a54225c75ca0) | `` eid-mw: 5.1.4 -> 5.1.9 ``                                                 |
| [`284c6745`](https://github.com/NixOS/nixpkgs/commit/284c674525dc7e114590d4397643c35dd4793aec) | `` spotify-player: add meta.mainProgram ``                                   |
| [`71cb53d5`](https://github.com/NixOS/nixpkgs/commit/71cb53d553e5077638b94a9d4752ca1fcb4f3799) | `` gdcm: 3.0.20 -> 3.0.21 ``                                                 |
| [`c6fde5b1`](https://github.com/NixOS/nixpkgs/commit/c6fde5b1182cccca93b7b48260ff674fe4d393e7) | `` swayimg: 1.9 -> 1.10 ``                                                   |
| [`05016a8a`](https://github.com/NixOS/nixpkgs/commit/05016a8a2e0a6cdf58eb07452358c355b9283eda) | `` python310Packages.minidb: 2.0.6 -> 2.0.7 ``                               |
| [`2a02032d`](https://github.com/NixOS/nixpkgs/commit/2a02032d9ed7fc94682cb68306a34cd1cc9288bd) | `` python310Packages.plugwise: 0.27.4 -> 0.27.5 ``                           |
| [`2e31258f`](https://github.com/NixOS/nixpkgs/commit/2e31258f222ce638acdab8a129c2fa2580b7b0e8) | `` crispyDoom: 5.11.1 -> 5.12.0 ``                                           |
| [`7c4e72f2`](https://github.com/NixOS/nixpkgs/commit/7c4e72f205729ded6ad2a8a7242685b5e92dbb89) | `` ppsspp: refactor ``                                                       |
| [`978eeec7`](https://github.com/NixOS/nixpkgs/commit/978eeec74ce7bfb9dd7e8bb536522cbad985bdaa) | `` nix-zsh-completions: 0.4.4 -> unstable-2023-01-30 ``                      |
| [`d178a1d7`](https://github.com/NixOS/nixpkgs/commit/d178a1d7a13696376d9439b04571983551221d13) | `` nixos/nginx: update recommended brotli settings ``                        |
| [`ee7e096c`](https://github.com/NixOS/nixpkgs/commit/ee7e096c488cca19f3bceb98339ea00da7329498) | `` nixos/nginx: update recommended gzip settings ``                          |
| [`ed9cb588`](https://github.com/NixOS/nixpkgs/commit/ed9cb58886509f830c7f3ed1974a25005dd54978) | `` nixos/virtualisation/*: replace deprecated types.string with types.str `` |
| [`a6ae9718`](https://github.com/NixOS/nixpkgs/commit/a6ae9718fb9640c8c85ac68d2e0bd12f1628f22d) | `` wrapWatcom: Handle ARM-based hostPlatform ``                              |
| [`d32b1cbc`](https://github.com/NixOS/nixpkgs/commit/d32b1cbc6cfd1a6947901cfd3a680a33e40d1863) | `` open-watcom-v2-unwrapped: unstable-2022-10-03 -> unstable-2023-01-30 ``   |
| [`a151fb2a`](https://github.com/NixOS/nixpkgs/commit/a151fb2ae8f56405e546a7687ee6dfa01c8fbfc8) | `` chia-dev-tools: fix ``                                                    |
| [`6bfba639`](https://github.com/NixOS/nixpkgs/commit/6bfba639f3bd32ae28134cd96755e79a5ab5281f) | `` python310Packages.arcam-fmj: 1.0.1 -> 1.1.0 ``                            |
| [`a90089e3`](https://github.com/NixOS/nixpkgs/commit/a90089e31c053d61ee9ea09933a9af3151878678) | `` ms-python.python: 2022.19.13351014 -> 2023.1.10091012 ``                  |
| [`06a60a56`](https://github.com/NixOS/nixpkgs/commit/06a60a56576f74d07074db5775e9ec23df1c1a97) | `` python310Packages.airtouch4pyapi: 1.0.5 -> 1.0.8 ``                       |
| [`9a8dd449`](https://github.com/NixOS/nixpkgs/commit/9a8dd44914aa7837776d66ddff3f7d8cb8f94cb7) | `` dqlite: add lxd as reverse dependency to passthru.tests ``                |
| [`2b449a12`](https://github.com/NixOS/nixpkgs/commit/2b449a128bf982e1f29d5623b3a75d815c3ac13a) | `` dqlite: 1.13.0 -> 1.14.0 ``                                               |
| [`524a5128`](https://github.com/NixOS/nixpkgs/commit/524a512848a15e49c0e071d78d15ac8913ccf039) | `` raft-canonical: add lxd as reverse dependency to passthru.tests ``        |
| [`b24f64be`](https://github.com/NixOS/nixpkgs/commit/b24f64bef4c8cc814316f711fbb7f66477574c34) | `` raft-canonical: 0.16.0 -> 0.17.1 ``                                       |
| [`26057588`](https://github.com/NixOS/nixpkgs/commit/26057588ae44ffa34b34a7b202c909f110c03105) | `` xfce.xfdesktop: 4.18.0 -> 4.18.1 ``                                       |
| [`85c6464a`](https://github.com/NixOS/nixpkgs/commit/85c6464a2ab44ff2f54763341025c3445f27d4dd) | `` xfce.xfce4-whiskermenu-plugin: 2.7.1 -> 2.7.2 ``                          |
| [`403be179`](https://github.com/NixOS/nixpkgs/commit/403be179ec09e37a252f32ba292aed2bbd3a8c8f) | `` xfce.xfce4-taskmanager: odd minor release numbers are stable ``           |
| [`a8c1e3fa`](https://github.com/NixOS/nixpkgs/commit/a8c1e3fa17701e4a0837a228169f9d14668ebf27) | `` xfce.xfce4-panel: 4.18.0 -> 4.18.1 ``                                     |
| [`8f23070e`](https://github.com/NixOS/nixpkgs/commit/8f23070e1af9e79a41c134cf92cfc38b88c0a5c2) | `` xfce.xfce4-datetime-plugin: 0.8.2 -> 0.8.3 ``                             |
| [`e8dd056b`](https://github.com/NixOS/nixpkgs/commit/e8dd056bfadc27b95176f73674e0a863d6309b72) | `` xfce.thunar: 4.18.1 -> 4.18.3 ``                                          |
| [`f7059afc`](https://github.com/NixOS/nixpkgs/commit/f7059afcf864b1cf63b8270788addbce2bb583be) | `` xfce.libxfce4util: 4.18.0 -> 4.18.1 ``                                    |
| [`8542aa18`](https://github.com/NixOS/nixpkgs/commit/8542aa185d825b9a567b5f6910d280852a4933eb) | `` throttled: fix after recent update ``                                     |
| [`45eff20e`](https://github.com/NixOS/nixpkgs/commit/45eff20ea04bf83b995d53d716c168d0d1b129d7) | `` python310Packages.fastavro: 1.7.0 -> 1.7.1 ``                             |
| [`db76c9e0`](https://github.com/NixOS/nixpkgs/commit/db76c9e04a75599c094d6ffccfcbf40c17004207) | `` zig_0_10: init at 0.10.1 ``                                               |
| [`aea9b201`](https://github.com/NixOS/nixpkgs/commit/aea9b201cbbe9b04bfdf7b5b76f50f8fc9a86ed5) | `` zig: rename to zig_0_9 to prepare for version 0.10 ``                     |
| [`a9156a9c`](https://github.com/NixOS/nixpkgs/commit/a9156a9c2192b5ca181887ce771ae4fae0562e98) | `` dde-account-faces: init at 1.0.12.1 ``                                    |
| [`216ac3a5`](https://github.com/NixOS/nixpkgs/commit/216ac3a5e36b94edc02ec875cfacd67f949e9e5e) | `` deepin-sound-theme: init at 15.10.6 ``                                    |
| [`20a25fc2`](https://github.com/NixOS/nixpkgs/commit/20a25fc288d05df906bca383e57431aaed32bf66) | `` deepin-gtk-theme: init at unstable-2022-07-26 ``                          |
| [`6af5ac7b`](https://github.com/NixOS/nixpkgs/commit/6af5ac7ba5c6aa59d82ce5b7aa291366556a484e) | `` deepin-icon-theme: init at 2021.11.24 ``                                  |
| [`edd316f2`](https://github.com/NixOS/nixpkgs/commit/edd316f2eac32ca76f0c665a1c70510960cc67e1) | `` gnumeric: 1.12.53 → 1.12.54 ``                                            |