### PR TITLE
chore(flake/nixpkgs): `4d7c2644` -> `a100acd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675273418,
-        "narHash": "sha256-tpYc4TEGvDzh9uRf44QemyQ4TpVuUbxb07b2P99XDbM=",
+        "lastModified": 1675362331,
+        "narHash": "sha256-VmcnKPj5gJLxWK7Bxlhg2LoQvhKRss7Ax+uoFjd3qKY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4d7c2644dbac9cf8282c0afe68fca8f0f3e7b2db",
+        "rev": "a100acd7bbf105915b0004427802286c37738fef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`81dc0f8c`](https://github.com/NixOS/nixpkgs/commit/81dc0f8c949014d0ace8c74c4bd82222947e2ea8) | `` python3Packages.zipfile36: no longer used nor usable by any supported interpreter `` |
| [`a0acf943`](https://github.com/NixOS/nixpkgs/commit/a0acf943cc65d56e6708c6a63731473a5752dedb) | `` python3Packages.zipfile36: fixup meta ``                                             |
| [`059556ab`](https://github.com/NixOS/nixpkgs/commit/059556ab3ea6fe5e23d1bb84d8bf7f6e54cd216a) | `` gmic-qt-krita: drop ``                                                               |
| [`c5b108d8`](https://github.com/NixOS/nixpkgs/commit/c5b108d8b5d6431053d073983e42af6b5cb253aa) | `` sope: 5.7.0 -> 5.8.0 ``                                                              |
| [`2d2bbe40`](https://github.com/NixOS/nixpkgs/commit/2d2bbe40a4ff989014ab1d932eced5c2fa7a2774) | `` sogo: 5.7.0 -> 5.8.0 ``                                                              |
| [`dd49386f`](https://github.com/NixOS/nixpkgs/commit/dd49386fbb87ad344ac339cb3ed4fc6906bca8f8) | `` unrar: 6.2.3 -> 6.2.5 ``                                                             |
| [`e7d6bb28`](https://github.com/NixOS/nixpkgs/commit/e7d6bb28a1a520235caf8acab0e70410ae618e8e) | `` linuxKernel.kernels.linux_zen: 6.1.8-zen1 -> 6.1.9-zen1 ``                           |
| [`001bb997`](https://github.com/NixOS/nixpkgs/commit/001bb99794935fa7cfecf234bfea3a4177a719b1) | `` linuxKernel.kernels.linux_lqx: 6.1.8-lqx1 -> 6.1.9-lqx1 ``                           |
| [`e6638023`](https://github.com/NixOS/nixpkgs/commit/e6638023aa7d87f38e1d410f653ead0e31be6043) | `` home-assistant: support abode component ``                                           |
| [`f7ff88d7`](https://github.com/NixOS/nixpkgs/commit/f7ff88d7952c106d0c5bb617d82412b4a2796897) | `` python310Packages.jaraco-abode: init at 3.2.1 ``                                     |
| [`bc0ad760`](https://github.com/NixOS/nixpkgs/commit/bc0ad76074b1e95d5f4e4d5ce7910a0051742fe0) | `` python310Packages.findpython: 0.2.3 -> 0.2.4 ``                                      |
| [`d608fbb9`](https://github.com/NixOS/nixpkgs/commit/d608fbb9f61f91d018e2a778df21373f0f340186) | `` buildPython*: allow overriding disabled packages ``                                  |
| [`c24932a4`](https://github.com/NixOS/nixpkgs/commit/c24932a453505546891ffeddf461e89b57e3c858) | `` python310Packages.ovoenergy: 1.3.0 -> 1.3.1 ``                                       |
| [`ab158ca8`](https://github.com/NixOS/nixpkgs/commit/ab158ca8d7d28c64ffb7fdce74d18df66006e307) | `` suricata: update homepage ``                                                         |
| [`4da213e4`](https://github.com/NixOS/nixpkgs/commit/4da213e4f8f26f8b4a671cf001a03b9dbdb8fb61) | `` texlab: 5.1.0 -> 5.2.0 ``                                                            |
| [`6cd07afb`](https://github.com/NixOS/nixpkgs/commit/6cd07afbb8e400dc075145a881dcbd50df4821fb) | `` edwin: 0.52 -> 0.54 ``                                                               |
| [`653fa9d4`](https://github.com/NixOS/nixpkgs/commit/653fa9d492fae31d9641fd2c61391a97bb2b8b4c) | `` ginkgo: 2.7.1 -> 2.8.0 ``                                                            |
| [`ce03e686`](https://github.com/NixOS/nixpkgs/commit/ce03e686a7143ac1b7dd07d6b44218372caa124e) | `` aaxtomp3: drop osh patch ``                                                          |
| [`5eb4e3c0`](https://github.com/NixOS/nixpkgs/commit/5eb4e3c0e8d56cd3fd98757ee67436f1674f206c) | `` cinny-desktop: 2.2.3 -> 2.2.4 ``                                                     |
| [`35a07d6c`](https://github.com/NixOS/nixpkgs/commit/35a07d6c1d3928d30de240e3be514f692c40416a) | `` kde/gear: 22.12.1 -> 22.12.2 ``                                                      |
| [`ba6facd1`](https://github.com/NixOS/nixpkgs/commit/ba6facd1c6a9dc890f4d8f8ec837750250cd870c) | `` circleci-cli: 0.1.23241 -> 0.1.23272 ``                                              |
| [`6997aefc`](https://github.com/NixOS/nixpkgs/commit/6997aefc84d092acf94ef0b7d97e1fe6e01af7d2) | `` cinnamon.cinnamon-common: use correct python for scrollbar-test-widget.py ``         |
| [`53c73eb7`](https://github.com/NixOS/nixpkgs/commit/53c73eb77df7c83487c68e5962f34b3fcd61e2f4) | `` govc: 0.30.1 -> 0.30.2 ``                                                            |
| [`0c37de67`](https://github.com/NixOS/nixpkgs/commit/0c37de676104abb8b871761cecea9d3ca36760c1) | `` hclfmt: 2.15.0 -> 2.16.0 ``                                                          |
| [`08e31a56`](https://github.com/NixOS/nixpkgs/commit/08e31a56813a26a4f6da98aa0ca95cb50acf5f33) | `` datree: 1.8.20 -> 1.8.21 ``                                                          |
| [`adb08f56`](https://github.com/NixOS/nixpkgs/commit/adb08f565f933e65327470be92c49c8e0bcf8468) | `` ctre: 3.7.1 -> 3.7.2 ``                                                              |
| [`9789b646`](https://github.com/NixOS/nixpkgs/commit/9789b646178924e694e5f585d643776bbac2be81) | `` golangci-lint: 1.50.1 -> 1.51.0 ``                                                   |
| [`a2780dc5`](https://github.com/NixOS/nixpkgs/commit/a2780dc543d24f33d7a2d7fa5b2bf609ed8c1849) | `` Docs/fix: make doc-strings nixdoc compliant (#213570) ``                             |
| [`ccb23e07`](https://github.com/NixOS/nixpkgs/commit/ccb23e076aa6384300e159880ac3f1352a9ff832) | `` mir: 2.11.0 -> 2.12.0 ``                                                             |
| [`fbfe2907`](https://github.com/NixOS/nixpkgs/commit/fbfe2907af640ba3fb3528ab5e75d9dcd150a0e0) | `` nixos/nscd: use nsncd by default ``                                                  |
| [`1d400a8f`](https://github.com/NixOS/nixpkgs/commit/1d400a8f6327e5b6a9222b9e431cc138044f24a4) | `` spicetify-cli: 2.14.3 -> 2.16.1 ``                                                   |
| [`148dae7b`](https://github.com/NixOS/nixpkgs/commit/148dae7b4c90fe0f1c286a43534e8de87b5f4eb9) | `` ansi: init at 0.1.4 ``                                                               |
| [`bdcaa990`](https://github.com/NixOS/nixpkgs/commit/bdcaa990de758a33a457c4170312d5d287948492) | `` zenith: unbreak on aarch64 platforms ``                                              |
| [`2f228729`](https://github.com/NixOS/nixpkgs/commit/2f2287295fcde3fdc29b7107c581f18c0085f400) | `` sing-box: 1.1.4 -> 1.1.5 ``                                                          |
| [`0bd808ee`](https://github.com/NixOS/nixpkgs/commit/0bd808eebbc977254abe907df4a23e7728c8165b) | `` haskell.packages.ghc944.X11-xft: add missing build-time dependencies ``              |
| [`a090dee5`](https://github.com/NixOS/nixpkgs/commit/a090dee5eaa1fca66f4bbfe7d653eb5a783b249c) | `` rojo: fix build on darwin ``                                                         |
| [`4664292c`](https://github.com/NixOS/nixpkgs/commit/4664292ca1c37cd015a8856d2063ec6ccc18ba03) | `` coqPackages_8_17.paramcoq: init at 1.1.3+coq8.17 ``                                  |
| [`a4dcf491`](https://github.com/NixOS/nixpkgs/commit/a4dcf491ee13ad5f56e7a7d195151c302cf7d77c) | `` fastly: 5.0.0 -> 5.1.0 ``                                                            |
| [`606efffd`](https://github.com/NixOS/nixpkgs/commit/606efffdee6fe5d06774fecf22ab76750141e853) | `` cargo-tarpaulin: 0.24.0 -> 0.25.0 ``                                                 |
| [`31e95b73`](https://github.com/NixOS/nixpkgs/commit/31e95b73877141c712b9cddd531df149b6292584) | `` devbox: 0.2.3 -> 0.2.4 ``                                                            |
| [`b0a2512d`](https://github.com/NixOS/nixpkgs/commit/b0a2512d1f27602911b9acc27bf3feca15c72f1f) | `` act: 0.2.40 -> 0.2.41 ``                                                             |
| [`892c8137`](https://github.com/NixOS/nixpkgs/commit/892c8137360c4c5fda81e68ab759dd9a7054a8c3) | `` vimPlugins.heirline-nvim: init at 2023-01-30 ``                                      |
| [`0bfbf10d`](https://github.com/NixOS/nixpkgs/commit/0bfbf10d459460e80af91bd103b52c32c756f8e5) | `` comma: 1.4.0 -> 1.4.1 ``                                                             |
| [`87732924`](https://github.com/NixOS/nixpkgs/commit/87732924fe6f92a84e329b47bc46b07de7dad5ac) | `` vimPlugins.nvim-treesitter: update grammars ``                                       |
| [`e191b8dd`](https://github.com/NixOS/nixpkgs/commit/e191b8dd525588f4d5cd90900fa840cc941b87ab) | `` vimPlugins: update ``                                                                |
| [`3168323c`](https://github.com/NixOS/nixpkgs/commit/3168323c61467373b7d01fa66621335974439823) | `` python310Packages.bx-py-utils: init at 75 ``                                         |
| [`f4746147`](https://github.com/NixOS/nixpkgs/commit/f47461478d1877079f8ed143dbc5713fbdfb09bb) | `` python310Packages.jaraco-net: init at 9.3.0 ``                                       |
| [`aa2112a7`](https://github.com/NixOS/nixpkgs/commit/aa2112a7f1fdd0e109748097ffba1acae28f24f4) | `` python310Packages.jaraco-email: init at 3.1.0 ``                                     |
| [`b84ba7b1`](https://github.com/NixOS/nixpkgs/commit/b84ba7b1ab0b68edc3401bb0697fd21f9d2e20ef) | `` terraform-providers.snowflake: 0.56.1 → 0.56.2 ``                                    |
| [`6e945ac1`](https://github.com/NixOS/nixpkgs/commit/6e945ac1294145d15ba1a56e46d51153d62763b3) | `` python310Packages.glfw: 2.5.5 -> 2.5.6 ``                                            |
| [`33ef4f2f`](https://github.com/NixOS/nixpkgs/commit/33ef4f2fab2b492b32dc2751313ea8dab46b22b0) | `` python3Packages.home-assistant-chip-core: Fix aarch64-linux hash ``                  |
| [`df8007c3`](https://github.com/NixOS/nixpkgs/commit/df8007c30fd7f281e5f68f670b595e7802b5ad6a) | `` nixos/home-assistant: Update bluetooth components ``                                 |
| [`d520a5af`](https://github.com/NixOS/nixpkgs/commit/d520a5af4456385e4bdb3e7eae494ccd7e79f08a) | `` home-assistant: 2023.1.7 -> 2023.2.0 ``                                              |
| [`23025f98`](https://github.com/NixOS/nixpkgs/commit/23025f98ec2d2798d3b514ae98e8acc12f63388a) | `` python3Packages.pysensibo: 1.0.24 -> 1.0.25 ``                                       |
| [`5d27d700`](https://github.com/NixOS/nixpkgs/commit/5d27d7008c7286fee84f43a98ee51721f01b4aaa) | `` python310Packages.somecomfort: drop ``                                               |
| [`89e37e05`](https://github.com/NixOS/nixpkgs/commit/89e37e0515fa42b7c9c0876674efd678b4ca61bf) | `` home-assistant.intents: Fix data location ``                                         |
| [`c459b2df`](https://github.com/NixOS/nixpkgs/commit/c459b2df128ecd5b3f9d06e5c5d1b5dc1c6184cc) | `` python310Packages.aiosomecomfort: init at 0.0.3 ``                                   |
| [`e86685b9`](https://github.com/NixOS/nixpkgs/commit/e86685b9a8ca22d8bcdb8e20e1089e54262c52dd) | `` python3Packages.pyalmond: drop ``                                                    |
| [`75d8cecf`](https://github.com/NixOS/nixpkgs/commit/75d8cecf141d6005ba43b9263ce6a644b17a66a7) | `` python3Packages.aioruuvigateway: init at 0.0.2 ``                                    |
| [`44122ce2`](https://github.com/NixOS/nixpkgs/commit/44122ce292e7664aaaefb717d36635ff8d25f6bb) | `` python3Packages.esphome-dashboard-api: init at 1.2.3 ``                              |
| [`c77badc9`](https://github.com/NixOS/nixpkgs/commit/c77badc9677894a4f1c05a1d6359b0d849cb4433) | `` python3Packages.devolo-plc-api: 1.0.0 -> 1.1.0 ``                                    |
| [`7a4afbf5`](https://github.com/NixOS/nixpkgs/commit/7a4afbf5a6ad6dc783ae8d8f1a513b3cbbdd6f43) | `` python310Packages.xknx: 2.2.0 -> 2.3.0 ``                                            |
| [`9352802f`](https://github.com/NixOS/nixpkgs/commit/9352802f6acb1902aac29e2188c5cbee813b5165) | `` python310Packages.whirlpool-sixth-sense: 0.18 -> 0.18.2 ``                           |
| [`4f9b60ea`](https://github.com/NixOS/nixpkgs/commit/4f9b60ea65a14ea98291dba2eb8270182cdf421d) | `` python3Packages.reolink-aio: 0.2.2 -> 0.3.1 ``                                       |
| [`0bb68110`](https://github.com/NixOS/nixpkgs/commit/0bb6811092d66110b32cac6b508e161b27570d94) | `` python3Packages.python-matter-server: 1.0.8 -> 2.0.2 ``                              |
| [`d2a02f88`](https://github.com/NixOS/nixpkgs/commit/d2a02f88496ea259b5fd577fe73b4d68b226a18b) | `` python3Packages.home-assistant-chip-core: 2022.12.0 -> 2023.1.0 ``                   |
| [`337c2c49`](https://github.com/NixOS/nixpkgs/commit/337c2c495f74db080a1f60a1cacd399af151f4a2) | `` python3Packages.home-assistant-chip-clusters: 2022.12.0 -> 2023.1.0 ``               |
| [`a0042b45`](https://github.com/NixOS/nixpkgs/commit/a0042b45f0e1f868dfce07e8ba6cfbee5e9fafce) | `` python310Packages.python-homewizard-energy: 1.3.1 -> 1.8.0 ``                        |
| [`f2898ed0`](https://github.com/NixOS/nixpkgs/commit/f2898ed00ad78f92feefe5a214314f3d2894e2c8) | `` python3Packages.pymodbus: 3.0.2 -> 3.1.2 ``                                          |
| [`53e22a71`](https://github.com/NixOS/nixpkgs/commit/53e22a71db03bde56344f7abadd46b97c2bb61fe) | `` python3Packages.pyisy: 3.1.9 -> 3.1.11 ``                                            |
| [`d826df08`](https://github.com/NixOS/nixpkgs/commit/d826df08cc1015f6cbbcfb23d82289ecef1fc219) | `` python310Packages.pybravia: 0.2.5 -> 0.3.1 ``                                        |
| [`3a2e5cbd`](https://github.com/NixOS/nixpkgs/commit/3a2e5cbd82a5b913a01f2dd15fc16543278b95bf) | `` python3Packages.ndms2-client: 0.1.1 -> 0.1.2 ``                                      |
| [`e2980436`](https://github.com/NixOS/nixpkgs/commit/e2980436461daa721f75a46b5d345d185eb62317) | `` python3Packages.google-api-python-client: 2.70.0 -> 2.75.0 ``                        |
| [`aec5591a`](https://github.com/NixOS/nixpkgs/commit/aec5591a37e21082f3f499e2b6c3c718476ef29b) | `` python310Packages.env-canada: 0.5.26 -> 0.5.27 ``                                    |
| [`70539541`](https://github.com/NixOS/nixpkgs/commit/70539541e26eb12aacd7c44f58799f1b2ada18dd) | `` python310Packages.devolo-plc-api: 0.9.0 -> 1.0.0 ``                                  |
| [`81b19fe0`](https://github.com/NixOS/nixpkgs/commit/81b19fe09254ae09026c9f046e76e9ea3c3fbcfc) | `` python310Packages.devolo-plc-api: add changelog to meta ``                           |
| [`74040676`](https://github.com/NixOS/nixpkgs/commit/740406766f2bbab7f7609aa343c29a7260d7ee0e) | `` python3Packages.bellows: 0.34.6 -> 0.34.7 ``                                         |
| [`c0156b1c`](https://github.com/NixOS/nixpkgs/commit/c0156b1cc8075a6e0361848d5f04b9867bc44e57) | `` python3Packages.axis: 44 -> 46 ``                                                    |
| [`83e7b317`](https://github.com/NixOS/nixpkgs/commit/83e7b31732033552ba15b666e3681c164933f7ea) | `` python3Packages.async-upnp-client: 0.33.0 -> 0.33.1 ``                               |
| [`121ec6d5`](https://github.com/NixOS/nixpkgs/commit/121ec6d50597c8e51a1687561cbe0feedd500f31) | `` python310Packages.aiounifi: 43 -> 44 ``                                              |
| [`f7732397`](https://github.com/NixOS/nixpkgs/commit/f7732397309f77546df2fda8031f56f98d11916e) | `` python310Packages.aiopvpc: 3.0.0 -> 4.0.1 ``                                         |
| [`2aee105c`](https://github.com/NixOS/nixpkgs/commit/2aee105cba7013f3e6e1b812689d4abd935b7dfb) | `` python310Packages.aiopvpc: add changelog to meta ``                                  |
| [`2e6e8821`](https://github.com/NixOS/nixpkgs/commit/2e6e8821041397f1b0e1ac230a47572436e225d4) | `` python3Packages.aiomusiccast: 0.14.6 -> 0.14.7 ``                                    |
| [`86d4641b`](https://github.com/NixOS/nixpkgs/commit/86d4641beb8a58e6453b11af2c5ab0e95511b8d3) | `` python310Packages.aiohue: add changelog to meta ``                                   |
| [`84ecf368`](https://github.com/NixOS/nixpkgs/commit/84ecf368670ccf2f0f5f96a4cdd1d260b1678aee) | `` python310Packages.aiohue: 4.5.0 -> 4.6.1 ``                                          |
| [`d36aef4e`](https://github.com/NixOS/nixpkgs/commit/d36aef4ed418341bc1eeb2fb6d0312a106bb0a12) | `` python3Packages.aioaladdinconnect: 0.1.54 -> 0.1.55 ``                               |
| [`34e00107`](https://github.com/NixOS/nixpkgs/commit/34e001078aa15dde4ca58f10d4b4cb02a90d02b5) | `` acorn: 0.5.0 -> 0.5.1 ``                                                             |
| [`dbfc3e7f`](https://github.com/NixOS/nixpkgs/commit/dbfc3e7f2ff4805048a3566ca41e8dfc1f42d116) | `` gobgp: 3.10.0 -> 3.11.0 ``                                                           |
| [`55df49ae`](https://github.com/NixOS/nixpkgs/commit/55df49ae73c3144350f131c1f3c86b61c4b5c881) | `` sanjuuni: add changelog ``                                                           |
| [`66a4cc6a`](https://github.com/NixOS/nixpkgs/commit/66a4cc6a23506fe14aa453aec0fb67c9eabc5310) | `` sanjuuni: 0.2 -> 0.3 ``                                                              |
| [`4ed5e94f`](https://github.com/NixOS/nixpkgs/commit/4ed5e94f9d381eb33e5c5713f245e3a02c416b4e) | `` zram-generator: add updateScript ``                                                  |
| [`4a034a7d`](https://github.com/NixOS/nixpkgs/commit/4a034a7d00ca45c99376c167bf1ea4fcd95e8cb0) | `` python310Packages.mobly: 1.12 -> 1.12.1 ``                                           |
| [`0788429c`](https://github.com/NixOS/nixpkgs/commit/0788429c7a4bdf95b7b394c71cb45f2566cbd42b) | `` lisgd: 0.3.6 -> 0.3.7 ``                                                             |
| [`22031d5a`](https://github.com/NixOS/nixpkgs/commit/22031d5ab84d3cfcf0a0772e25ef9fba7afa2d80) | `` python310Packages.aemet-opendata: 0.2.1 -> 0.2.2 ``                                  |
| [`97b3ca86`](https://github.com/NixOS/nixpkgs/commit/97b3ca8685947932a9d4642e962e8816be93944e) | `` nextflow: 22.04.5 -> 22.10.6 ``                                                      |
| [`57a9c1f8`](https://github.com/NixOS/nixpkgs/commit/57a9c1f8e90053fc3f74f7063571356bc5b5f45c) | `` mdbook-epub: init at unstable-2022-12-25 ``                                          |
| [`b7a2f2fc`](https://github.com/NixOS/nixpkgs/commit/b7a2f2fcc34da62dcb6f9b92dd810b59263fa7fa) | `` ddccontrol-db: 20220903 -> 20230124 ``                                               |
| [`0daf3608`](https://github.com/NixOS/nixpkgs/commit/0daf3608fc5003ac86b59efe1323e96aadea87bc) | `` pcsctools: 1.6.0 -> 1.6.2 ``                                                         |
| [`74cc92f9`](https://github.com/NixOS/nixpkgs/commit/74cc92f93b51170af8fa4a34734d1d5a851c1848) | `` rpcemu: init at 0.9.4 ``                                                             |
| [`69889038`](https://github.com/NixOS/nixpkgs/commit/6988903887f3b5087bda73e29a221caaec40e048) | `` python310Packages.timm: init at 0.6.12 ``                                            |
| [`93f0dfda`](https://github.com/NixOS/nixpkgs/commit/93f0dfda5b66c6f9ba986dcc644e6dc9145e59a0) | `` python3Packages.tensorflow-probability: 0.15.0 -> 0.19.0 (#212421) ``                |
| [`28a96e10`](https://github.com/NixOS/nixpkgs/commit/28a96e106ea024801d19c3a11e992e0937a5a2c6) | `` pods: 1.0.3 -> 1.0.4 ``                                                              |
| [`a66af6ba`](https://github.com/NixOS/nixpkgs/commit/a66af6ba3a3bfe40ca746487fa343662f1907744) | `` locate-dominating-file: fix Darwin build ``                                          |
| [`d3a2d248`](https://github.com/NixOS/nixpkgs/commit/d3a2d24853ce2971ee3685c58b0ef8949460f807) | `` python3Packages.eigenpy: 2.9.1 -> 2.9.2 ``                                           |
| [`025f11f5`](https://github.com/NixOS/nixpkgs/commit/025f11f55ccb6efa2677a17e85e0c9594391591e) | `` python310Packages.ansible-core: 2.14.0 -> 2.14.2 ``                                  |
| [`2d00a794`](https://github.com/NixOS/nixpkgs/commit/2d00a794343d1f137bd8fbfc6b97574728edfb4e) | `` cargo-about: 0.5.3 -> 0.5.4 ``                                                       |
| [`43f2ae7d`](https://github.com/NixOS/nixpkgs/commit/43f2ae7d87145cc00e2c896107cbbcd16eb200c7) | `` mysql-workbench: fix build on aarch64-linux ``                                       |
| [`b2c8b539`](https://github.com/NixOS/nixpkgs/commit/b2c8b539ac490f1e9c0e45efd65afd909fe41bbc) | `` nixos/doc: fix typo in python.section.md ``                                          |
| [`133255bd`](https://github.com/NixOS/nixpkgs/commit/133255bd776e6f2dbbf3bb894b228a6b92f2802c) | `` py-spy: 0.3.12 -> 0.3.14 ``                                                          |
| [`e51ca96d`](https://github.com/NixOS/nixpkgs/commit/e51ca96d642b2ba27eec6f9621c6d40112615b37) | `` cmark-gfm: 0.29.0.gfm.8 -> 0.29.0.gfm.9 ``                                           |
| [`d45406c7`](https://github.com/NixOS/nixpkgs/commit/d45406c7aff24b74fd2242de7ba092bf2f6c04cb) | `` doppler: 3.53.0 -> 3.53.1 ``                                                         |
| [`98cc3358`](https://github.com/NixOS/nixpkgs/commit/98cc33580fe34ffc1ffd3a6017619c58450bcfa0) | `` element-{web,desktop}: 1.11.20 -> 1.11.22 (#214043) ``                               |
| [`d8fc10ca`](https://github.com/NixOS/nixpkgs/commit/d8fc10cad3194578ce8afca51d964748e4eb3562) | `` go_1_20: 1.20rc3 -> 1.20 ``                                                          |
| [`60c67903`](https://github.com/NixOS/nixpkgs/commit/60c67903844d7c867a6e502ac08a2a500b469d5d) | `` systemd stage 1: Fix gzip wrapping ``                                                |
| [`64122c75`](https://github.com/NixOS/nixpkgs/commit/64122c7563ba6baa70c16964ec959c2e958ff4c4) | `` gdal: allow overriding libmysqlclient with mysql80 ``                                |
| [`e6143a1b`](https://github.com/NixOS/nixpkgs/commit/e6143a1b4eb4edc244e7cbf0a38b7853334cc4c8) | `` imv: 4.3.1 -> 4.4.0 ``                                                               |
| [`f531b17f`](https://github.com/NixOS/nixpkgs/commit/f531b17f7d85cefa1aec97de78caea04b886d050) | `` avahi-daemon: add ConfigurationDirectory to ensure "avahi/services" exists ``        |
| [`63a72c29`](https://github.com/NixOS/nixpkgs/commit/63a72c29ca76c06674fe441d5e2a26e0e871d686) | `` python310Packages.asyncmy: 0.2.5 -> 0.2.6 ``                                         |
| [`cf217d2f`](https://github.com/NixOS/nixpkgs/commit/cf217d2f858e5717186e003416a3bf8661a6979d) | `` cargo-tally: 1.0.21 -> 1.0.22 ``                                                     |
| [`f96c8fff`](https://github.com/NixOS/nixpkgs/commit/f96c8fff5fdf4e199d344e5af33e1bfa5f7cf132) | `` adguardhome: 0.107.22 -> 0.107.23 ``                                                 |
| [`23ff5009`](https://github.com/NixOS/nixpkgs/commit/23ff5009822133e34e458c3df7899b8e99ba917d) | `` firefox-beta-bin-unwrapped: 110.0b7 -> 110.0b8 ``                                    |
| [`5c80430c`](https://github.com/NixOS/nixpkgs/commit/5c80430c37a50d5936a62feb81c59b8d8110b5b8) | `` rl-2305: Mention QDMR addition ``                                                    |
| [`fe776684`](https://github.com/NixOS/nixpkgs/commit/fe776684583f74a7fe4817271fd30e95ffcd50ca) | `` wasm-bindgen-cli: 0.2.83 -> 0.2.84 ``                                                |
| [`9f17e032`](https://github.com/NixOS/nixpkgs/commit/9f17e032e7e7c34ddf8c04472bee9d627951fc44) | `` prometheus-shelly-exporter: add NixOS module ``                                      |