### PR TITLE
chore(flake/nixpkgs): `a100acd7` -> `06999209`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675362331,
-        "narHash": "sha256-VmcnKPj5gJLxWK7Bxlhg2LoQvhKRss7Ax+uoFjd3qKY=",
+        "lastModified": 1675454231,
+        "narHash": "sha256-5rgcWq1nFWlbR3NsLqY7i/7358uhkSeMQJ/LEHk3BWA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a100acd7bbf105915b0004427802286c37738fef",
+        "rev": "06999209d7a0043d4372e38f57cffae00223d592",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`ed9478f5`](https://github.com/NixOS/nixpkgs/commit/ed9478f555b612e28fc1e6fecc9e05559d1b35e7) | `` linuxPackages_testing: 6.2-rc2 -> 6.2-rc6 ``                                     |
| [`b974cb21`](https://github.com/NixOS/nixpkgs/commit/b974cb21b7ea01146e728f8e4c5936aece0ee179) | `` vscode: 1.74.3 -> 1.75.0 ``                                                      |
| [`48535137`](https://github.com/NixOS/nixpkgs/commit/485351377f8c1859b61ad20e5c6bc1da163eaf85) | `` python310Packages.oci: 2.90.3 -> 2.90.4 ``                                       |
| [`6df7457d`](https://github.com/NixOS/nixpkgs/commit/6df7457df711df3b1da50716c7607221d5e168d9) | `` broot: 1.19.0 -> 1.20.0 ``                                                       |
| [`85d35677`](https://github.com/NixOS/nixpkgs/commit/85d356774c5754bc09d0d4a9baecfd8d6df5b3b5) | `` vimPlugins.nvim-treesitter: update grammars ``                                   |
| [`12f22755`](https://github.com/NixOS/nixpkgs/commit/12f22755358300ae355663be990b77dca9f3dd6d) | `` vimPlugins.autoclose-nvim: init at 2023-02-03 ``                                 |
| [`5c91a46c`](https://github.com/NixOS/nixpkgs/commit/5c91a46cc09c919061ffc6b7123123b871d86acd) | `` vimPlugins.vim-smartbd: init at 2015-12-20 ``                                    |
| [`35a15c9c`](https://github.com/NixOS/nixpkgs/commit/35a15c9c9a2d06cc8c4eacf0ba1c807985189bef) | `` vimPlugins.vim-smartbw: init at 2015-12-20 ``                                    |
| [`b058d663`](https://github.com/NixOS/nixpkgs/commit/b058d663c838ea426e0848b77eb4c0f397e14bf3) | `` vimPlugins: resolve github repository redirects ``                               |
| [`5032be5b`](https://github.com/NixOS/nixpkgs/commit/5032be5b2914853bf78c3683f7d3acc7b02230db) | `` vimPlugins: update ``                                                            |
| [`805ee2b9`](https://github.com/NixOS/nixpkgs/commit/805ee2b9f6a35a7153bdd4c12696a16f789c4c1b) | `` n8n: 0.213.0 -> 0.214.0 ``                                                       |
| [`00ccca20`](https://github.com/NixOS/nixpkgs/commit/00ccca2017708dbff0f3427dd4a40dc284988845) | `` python310Packages.thinc: 8.1.6 -> 8.1.7 ``                                       |
| [`51f802be`](https://github.com/NixOS/nixpkgs/commit/51f802be9d7450e27e3152966f9a74b8e32395fc) | `` home-assistant: Update dependencies and tests ``                                 |
| [`96128cb7`](https://github.com/NixOS/nixpkgs/commit/96128cb7e42794fb96a92a83fa7b903f91b7e0ac) | `` python310Packages.pyqwikswitch: init at 0.94 ``                                  |
| [`5de540d9`](https://github.com/NixOS/nixpkgs/commit/5de540d9a87955c8e0ad2ddf01e304052dea5da7) | `` python310Packages.gvm-tools: 22.9.0 -> 23.2.0 ``                                 |
| [`cd6acb7f`](https://github.com/NixOS/nixpkgs/commit/cd6acb7f67de3f0f5a22ef904f65e510ecc099f6) | `` python310Packages.pip-tools: 6.12.1 -> 6.12.2 ``                                 |
| [`457aaaa2`](https://github.com/NixOS/nixpkgs/commit/457aaaa2bc0e2739b264075738ae73895c2572f8) | `` home-assistant: 2023.2.0 -> 2023.2.1 ``                                          |
| [`0e3aac13`](https://github.com/NixOS/nixpkgs/commit/0e3aac13d2e4a10c8ec8536aa5d2abcbc91abacb) | `` python310Packages.py-synologydsm-api: 2.1.0 -> 2.1.1 ``                          |
| [`ce693947`](https://github.com/NixOS/nixpkgs/commit/ce693947e1608be208faaf80ed280d70d71c42f7) | `` python310Packages.aiosomecomfort: 0.0.3 -> 0.0.6 ``                              |
| [`adffe5aa`](https://github.com/NixOS/nixpkgs/commit/adffe5aa5fa6ba7ea16b7f3ed379f4f6bd393053) | `` goreleaser: 1.15.0 -> 1.15.1 ``                                                  |
| [`3b638085`](https://github.com/NixOS/nixpkgs/commit/3b6380856e8f26828b0bae92f84b96c4ba043268) | `` evcc: 0.111.1 -> 0.112.1 ``                                                      |
| [`d47aeafc`](https://github.com/NixOS/nixpkgs/commit/d47aeafc75b89e4dac4e7ca58edd8f04bb767ab2) | `` parcellite: enable appindicator support ``                                       |
| [`fd71dab2`](https://github.com/NixOS/nixpkgs/commit/fd71dab20511594264141ef8cb0cdf7c185266de) | `` python310Packages.sqlmap: disable on unsupported Python releases ``              |
| [`40089e9a`](https://github.com/NixOS/nixpkgs/commit/40089e9ac13350355fd878cc156c13af4c510bad) | `` python310Packages.scim2-filter-parser: 0.4.0 -> 0.5.0 ``                         |
| [`ebd2070d`](https://github.com/NixOS/nixpkgs/commit/ebd2070df8e9721e5b66a9bce1e72e820314aa60) | `` python3Packages.leidenalg: init at 0.9.1 ``                                      |
| [`e5224f21`](https://github.com/NixOS/nixpkgs/commit/e5224f21ba2645fe2d644b7898bd717ebd7eb5c2) | `` python310Packages.sqlmap: 1.7 -> 1.7.2 ``                                        |
| [`dfecf2c2`](https://github.com/NixOS/nixpkgs/commit/dfecf2c2655bc6b53c0f6f9ae2f8971a8f500918) | `` python3Packages.aio-pika: init at 8.3.0 ``                                       |
| [`ee0d419d`](https://github.com/NixOS/nixpkgs/commit/ee0d419d3b9741bb0ea8794943a8277b907271a7) | `` python3Packages.aiormq: init at 6.6.4 ``                                         |
| [`8f21d403`](https://github.com/NixOS/nixpkgs/commit/8f21d403f806fe38d57d65db1ea83c243aabdee9) | `` tflint-plugins.tflint-ruleset-aws: 0.17.1 -> 0.21.2 (#214335) ``                 |
| [`1b1d2f4b`](https://github.com/NixOS/nixpkgs/commit/1b1d2f4b3087a4dfb746037c1c239e25a9d5cc5f) | `` python3Packages.pyathena: Add fsspec to propagatedBuildInputs ``                 |
| [`86a6a291`](https://github.com/NixOS/nixpkgs/commit/86a6a291a515765e340f57f9b60dbea2a5c5e8e1) | `` ocamlPackages.lustre-v6: 6.107.1 -> 6.107.3 ``                                   |
| [`3460f500`](https://github.com/NixOS/nixpkgs/commit/3460f50028af7ff248e5ed633f01fa0345c0727e) | `` element-desktop: bump electron to 22.x (#214055) ``                              |
| [`f97172b3`](https://github.com/NixOS/nixpkgs/commit/f97172b31dbe78bd5118ba7c8376514b7979ccea) | `` schildichat-desktop: bump electron to 22.x ``                                    |
| [`0dca8f64`](https://github.com/NixOS/nixpkgs/commit/0dca8f64669ef2ad3db9bdee8eb03a8e57d71771) | `` schildichat-{web,desktop}: 1.11.13-sc.1 -> 1.11.22-sc.1 ``                       |
| [`50c0e318`](https://github.com/NixOS/nixpkgs/commit/50c0e3188c0082e4197d903dc2f8992f374f6f48) | `` knot-resolver: avoid a flaky test ``                                             |
| [`38442e84`](https://github.com/NixOS/nixpkgs/commit/38442e849807920ac27fb8bd44acb0a37c0d4844) | `` emscriptenStdenv: Allow overlay style mkDerivation ``                            |
| [`5af6e6ab`](https://github.com/NixOS/nixpkgs/commit/5af6e6ab55d924f808bf69b9d8769f16a0e2df38) | `` ligolo-ng: 0.3.3 -> 0.4.2 ``                                                     |
| [`fe490425`](https://github.com/NixOS/nixpkgs/commit/fe49042575edd7970d43b8a5e388d59155fc39ae) | `` python3Packages.spacy: 3.4.4 -> 3.5.0 ``                                         |
| [`889febc0`](https://github.com/NixOS/nixpkgs/commit/889febc034f541b74e4ce448f4895c46641797f1) | `` b4: 0.10.1 -> 0.12.1 ``                                                          |
| [`3cd742a4`](https://github.com/NixOS/nixpkgs/commit/3cd742a408606f5edb5b44df95a6c6a4124e6a19) | `` python310Packages.tld: add changelog to meta ``                                  |
| [`6a2dd34e`](https://github.com/NixOS/nixpkgs/commit/6a2dd34edf421d3497071db67c50652f5df08399) | `` shotman: 0.2.0 -> 0.3.0 ``                                                       |
| [`2c7b66f9`](https://github.com/NixOS/nixpkgs/commit/2c7b66f91d811089403b891b174fdd179bc3e448) | `` python310Packages.tld: 0.12.6 -> 0.12.7 ``                                       |
| [`023b0da8`](https://github.com/NixOS/nixpkgs/commit/023b0da8d1627ebb5697dcb6e792518ed95a2c1b) | `` python310Packages.pontos: 23.1.3 -> 23.2.0 ``                                    |
| [`1db0a84b`](https://github.com/NixOS/nixpkgs/commit/1db0a84b4cc0f458a90406a062a55b0121d384ea) | `` cargo-ndk: init at 2.12.6 ``                                                     |
| [`160a3278`](https://github.com/NixOS/nixpkgs/commit/160a3278d8d1b39fa6f8b16997ee5da5eec81ce9) | `` python311Packages.ossfs: 2021.8.0 -> 2023.1.0 ``                                 |
| [`5dc04588`](https://github.com/NixOS/nixpkgs/commit/5dc04588f0d974366cb2fb73f1498c963e335091) | `` python310Packages.ossfs: missing input ``                                        |
| [`ffdb0c7e`](https://github.com/NixOS/nixpkgs/commit/ffdb0c7eb933b52e623028b54c99dbc4994f2d6a) | `` python310Packages.ossfs: add changelog to meta ``                                |
| [`4c7050fb`](https://github.com/NixOS/nixpkgs/commit/4c7050fb40cc4e8f0f9f2b7e17fa83496b0c3e98) | `` netavark: 1.4.0 -> 1.5.0 ``                                                      |
| [`bc881e3a`](https://github.com/NixOS/nixpkgs/commit/bc881e3ae8d2007466cf37e04bc6d69fe87c2da6) | `` aardvark-dns: 1.4.0 -> 1.5.0 ``                                                  |
| [`bff2a5a3`](https://github.com/NixOS/nixpkgs/commit/bff2a5a3178b3737ffcba574a430adbfcebc4bd5) | `` python3Packages.pony: disable on python 3.11 or later ``                         |
| [`f888b4e8`](https://github.com/NixOS/nixpkgs/commit/f888b4e8b9cc694208f188236a720bf9d07e6262) | `` python310Packages.adlfs: 2022.11.2 -> 2023.1.0 ``                                |
| [`2f68abde`](https://github.com/NixOS/nixpkgs/commit/2f68abde90dcf4736ed7f5c34c3fb5fecbd55db0) | `` python310Packages.python-gitlab: add changelog to meta ``                        |
| [`f12b9ea4`](https://github.com/NixOS/nixpkgs/commit/f12b9ea461c3a5c75df219b08f17f9a7856894ae) | `` buildDunePackage: default to strictDeps = true ``                                |
| [`376e9cee`](https://github.com/NixOS/nixpkgs/commit/376e9ceeadc4c4e06f34b33bf347a504a4b3bd65) | `` treewide: add strictDeps = true to most packages depending on ocaml ``           |
| [`c53a63ad`](https://github.com/NixOS/nixpkgs/commit/c53a63adf11330c66d3f0ed0def74e0dacd2cd2a) | `` ocamlPackages treewide: strictDeps all packages ``                               |
| [`cd59cd02`](https://github.com/NixOS/nixpkgs/commit/cd59cd02995012b80f2584919d98eeec472e1228) | `` frink: init at 2023-01-31 ``                                                     |
| [`85e22397`](https://github.com/NixOS/nixpkgs/commit/85e223976b8b4068b92ed088a370e0a8cfdb753a) | `` tempo: 1.5.0 -> 2.0.0 ``                                                         |
| [`e0c78f78`](https://github.com/NixOS/nixpkgs/commit/e0c78f78393643418344d457a3a01a3371c8a581) | `` xrootd: provide fuse support on darwin ``                                        |
| [`d9dec0c4`](https://github.com/NixOS/nixpkgs/commit/d9dec0c4185319d63268d3d6421ae073d6edcdc0) | `` Revert "xrootd: provide fuse support (xrootdfs) for Darwin and fix the tests" `` |
| [`cc86457e`](https://github.com/NixOS/nixpkgs/commit/cc86457eca47411a373547f3f454eec9f14bf0af) | `` pgadmin: pin flask-babel to fix build failure ``                                 |
| [`3f140e02`](https://github.com/NixOS/nixpkgs/commit/3f140e028d3778c940fb31a233ca349ec4dd6eb4) | `` timer: init at unstable-2023-02-01 ``                                            |
| [`61987297`](https://github.com/NixOS/nixpkgs/commit/619872977785608733f85ff4bfef209eaab6621c) | `` terraform-providers.aws: 4.52.0 → 4.53.0 ``                                      |
| [`cdccae31`](https://github.com/NixOS/nixpkgs/commit/cdccae31cd5f62d1b05c0365f96eab9545988d1c) | `` terraform-providers.utils: 1.6.0 → 1.7.0 ``                                      |
| [`f0ae82b5`](https://github.com/NixOS/nixpkgs/commit/f0ae82b54fbfe196bb3591fd1bf0c34b8fb3c3d6) | `` terraform-providers.snowflake: 0.56.2 → 0.56.3 ``                                |
| [`cc10524b`](https://github.com/NixOS/nixpkgs/commit/cc10524b950033e4cb700240f029dc510c7fe13b) | `` terraform-providers.linode: 1.29.4 → 1.30.0 ``                                   |
| [`ea0db3b1`](https://github.com/NixOS/nixpkgs/commit/ea0db3b1e750a4fd92ca8af25949fa6313d1b868) | `` terraform-providers.avi: 22.1.2 → 22.1.3 ``                                      |
| [`373822c5`](https://github.com/NixOS/nixpkgs/commit/373822c5bb04bb909898dbe3ea3cb9540228c85d) | `` terraform-providers.akamai: 3.2.1 → 3.3.0 ``                                     |
| [`bb6c33b6`](https://github.com/NixOS/nixpkgs/commit/bb6c33b6bd7bdfaa6d02705e8b74bdd91cb1b4ea) | `` nodejs-19_x: 19.5.0 -> 19.6.0 ``                                                 |
| [`4a53b3be`](https://github.com/NixOS/nixpkgs/commit/4a53b3bede7a6e2245bf917eec33c052a429604e) | `` nodejs-18_x: 18.13.0 -> 18.14.0 ``                                               |
| [`f4661137`](https://github.com/NixOS/nixpkgs/commit/f4661137e480066b8b6c8f1757856e9664f6dde2) | `` vimPlugins.smart-splits-nvim: init at 2022-12-21 ``                              |
| [`fd8deafa`](https://github.com/NixOS/nixpkgs/commit/fd8deafa8b43bed51f7590bd13570c8bf6df2886) | `` vimPlugins.nvim-treesitter: update grammars ``                                   |
| [`08d7b2cb`](https://github.com/NixOS/nixpkgs/commit/08d7b2cbd6553eb456d5dd118eb0f91ce32c0dff) | `` vimPlugins: update ``                                                            |
| [`8e517baa`](https://github.com/NixOS/nixpkgs/commit/8e517baa88f4a0e52e21b5b72b7e7c536a41d151) | `` palemoon: allow building with gcc 12 ``                                          |
| [`0c601b12`](https://github.com/NixOS/nixpkgs/commit/0c601b12bf4e2a9865375595326221e5a8957c08) | `` nixos/manual: translate manpages to mdoc ``                                      |
| [`82364107`](https://github.com/NixOS/nixpkgs/commit/8236410735c8c2fd74c031fec24794dd4529d99d) | `` agdsn-zsh-config: init at 0.6.0 ``                                               |
| [`70a0d6cd`](https://github.com/NixOS/nixpkgs/commit/70a0d6cd3e00d77860b751317b4c5e4b0e2db664) | `` maintainers: add fugi ``                                                         |
| [`3cf2d77f`](https://github.com/NixOS/nixpkgs/commit/3cf2d77f64b9eeafd2f5ea302594b04621aac6f2) | `` linuxPackages.evdi: 1.12.0 -> 2022-10-13 (#196198) ``                            |
| [`6f5a35be`](https://github.com/NixOS/nixpkgs/commit/6f5a35be63761b88f8d365b880ba13e5cdf38987) | `` wiimms-iso-tools: 3.02a -> 3.05a (#213188) ``                                    |
| [`af84d5bd`](https://github.com/NixOS/nixpkgs/commit/af84d5bdb5dd86c44257006593946a2754e40ec2) | `` steampipe: 0.16.4 -> 0.18.2 ``                                                   |
| [`9dafc0d2`](https://github.com/NixOS/nixpkgs/commit/9dafc0d27e3a7496d453430512e4afd035ddcb61) | `` otel-cli: 0.0.20 -> 0.1.0 ``                                                     |
| [`09d46de7`](https://github.com/NixOS/nixpkgs/commit/09d46de75258066915de1c377b0d5b6f6e773494) | `` py-spy: fix build on darwin ``                                                   |
| [`f8f78204`](https://github.com/NixOS/nixpkgs/commit/f8f7820433f1abc7a0da38a49ab57448baca1ff2) | `` linuxPackages_testing: remove unused options for 6.2 ``                          |
| [`9711de7b`](https://github.com/NixOS/nixpkgs/commit/9711de7b7e46e44a74e584ab7733b5b1108c78f2) | `` nixos-render-docs: improve error messages for multi-title manual chapters ``     |
| [`571682b2`](https://github.com/NixOS/nixpkgs/commit/571682b2270971077d10c7e55faa567e8baecf15) | `` cargo-watch: fix build on x86_64-darwin ``                                       |
| [`b062ec5b`](https://github.com/NixOS/nixpkgs/commit/b062ec5b83a17fd70d910c7f7a6adcc88c84c065) | `` rustpython: unbreak on x86_64-darwin ``                                          |
| [`d1030ac5`](https://github.com/NixOS/nixpkgs/commit/d1030ac53431eb44c00417ca502387bccd5c95e0) | `` httm: fix build on x86_64-darwin ``                                              |
| [`fb3dcdb3`](https://github.com/NixOS/nixpkgs/commit/fb3dcdb31b8a244863f49c0cc0f3b0e3b719e467) | `` python310Packages.pytorch-metric-learning: disable erroring tests on ``          |
| [`9918d594`](https://github.com/NixOS/nixpkgs/commit/9918d594be0fc0a92553801311309b9fb6d16321) | `` bupstash: unbreak on x86_64-darwin ``                                            |
| [`ab368e70`](https://github.com/NixOS/nixpkgs/commit/ab368e702d21d2b6fac50c944f9adf137dec6d3d) | `` darwin.apple_sdk_11_0.rustPlatform: init ``                                      |
| [`781678b7`](https://github.com/NixOS/nixpkgs/commit/781678b78b92f58d1239f964feb242a4a2115415) | `` gnome-builder: 43.4 → 43.5 ``                                                    |
| [`094f3726`](https://github.com/NixOS/nixpkgs/commit/094f3726d98f5eff6439c92ba19f01e4efb689b1) | `` gnome.zenity: 3.43.0 → 3.44.0 ``                                                 |
| [`864ebd79`](https://github.com/NixOS/nixpkgs/commit/864ebd79e2662fae936a95b95294dfd6994adda9) | `` gnome-console: 42.2 → 43.0 ``                                                    |
| [`f3b449e8`](https://github.com/NixOS/nixpkgs/commit/f3b449e8d446196ac5b1f7f0578ba3213a31abf8) | `` gnome.gnome-maps: 43.3 → 43.4 ``                                                 |
| [`0a1e62c5`](https://github.com/NixOS/nixpkgs/commit/0a1e62c5e057e92cfda4bce3e9982026e9c21a05) | `` tracker-miners: 3.4.2 → 3.4.3 ``                                                 |
| [`25f94780`](https://github.com/NixOS/nixpkgs/commit/25f94780dd64de08f9d1d7db714e2969d272a4d3) | `` gvfs: 1.50.2 → 1.50.3 ``                                                         |
| [`b653c21c`](https://github.com/NixOS/nixpkgs/commit/b653c21cd11b24d77d364b069a6289e0a37a92a0) | `` oh-my-zsh: 2023-01-26 -> 2023-02-02 ``                                           |
| [`b5fd12d0`](https://github.com/NixOS/nixpkgs/commit/b5fd12d0d10fab7e60131de8546c868bc1ca28be) | `` python310Packages.rising: disable test on aarch64-linux due to error ``          |
| [`3a6301e9`](https://github.com/NixOS/nixpkgs/commit/3a6301e9ea1c4ae6056342a05b79cad732c57376) | `` renderdoc: 1.24 -> 1.25 ``                                                       |
| [`7bfcfebd`](https://github.com/NixOS/nixpkgs/commit/7bfcfebd3090ff78af765f9d68fd2ab6c8533d10) | `` python310Packages.goodwe: 0.2.22 -> 0.2.23 ``                                    |
| [`3c74b3d7`](https://github.com/NixOS/nixpkgs/commit/3c74b3d749509a2e0253ef5b1c06a394cbe63c37) | `` signal-desktop-beta: 6.4.0-beta.1 -> 6.5.0-beta.2 ``                             |
| [`a3383370`](https://github.com/NixOS/nixpkgs/commit/a338337019eaa78a1b3d0cdcdead6c45ca9f32fd) | `` signal-desktop: 6.3.0 -> 6.4.1 ``                                                |
| [`ec7f2aa3`](https://github.com/NixOS/nixpkgs/commit/ec7f2aa3b39699a7c1cbd66af7e864a2f7578b2c) | `` catch2_3: 3.3.0 -> 3.3.1 ``                                                      |
| [`9aeafd77`](https://github.com/NixOS/nixpkgs/commit/9aeafd777e395fcdfe7b25b1684898e39195972c) | `` python310Packages.robotframework-pythonlibcore: 4.0.0 -> 4.1.0 ``                |
| [`46cb5467`](https://github.com/NixOS/nixpkgs/commit/46cb54671fe8351b072620701849d2b88ba3254a) | `` python310Packages.approvaltests: 5.4.2 -> 8.1.0 ``                               |
| [`2929d62b`](https://github.com/NixOS/nixpkgs/commit/2929d62be756cb4c0fc352ecb9af5a20284acf6d) | `` python310Packages.approval-utilities: init at 8.1.0 ``                           |
| [`f324caf0`](https://github.com/NixOS/nixpkgs/commit/f324caf0ca262b73a121d46163afe7f1689338ae) | `` libreddit: 0.28.0 -> 0.28.1 ``                                                   |
| [`5cc9837b`](https://github.com/NixOS/nixpkgs/commit/5cc9837bb5280d9ba3c58c0ba5a8cc10dede34a3) | `` linuxPackages.lttng-modules: 2.13.4 -> 2.13.8 ``                                 |
| [`91391118`](https://github.com/NixOS/nixpkgs/commit/91391118c7a19c11f9cf2b95f6d0b84dfe04794e) | `` wallabag: Drop swiftmailer patch ``                                              |
| [`1ff7e41b`](https://github.com/NixOS/nixpkgs/commit/1ff7e41b036267d3814f05d702ab919407fda2d6) | `` linuxKernel.rtl8814au: unstable-2022-08-18 -> unstable-2022-11-09 ``             |
| [`2d250b52`](https://github.com/NixOS/nixpkgs/commit/2d250b52f269d456822b779c254a66b784f67203) | `` python310Packages.particle: 0.21.1 -> 0.21.2 ``                                  |
| [`bcb6dc0f`](https://github.com/NixOS/nixpkgs/commit/bcb6dc0fbb614527a1a2e28a58e41bd153fe0836) | `` qovery-cli: 0.48.5 -> 0.48.6 ``                                                  |
| [`0086fdf0`](https://github.com/NixOS/nixpkgs/commit/0086fdf0e926b7e21471e6a390213e83e02829ab) | `` python310Packages.hepunits: 2.3.0 -> 2.3.1 ``                                    |
| [`35662dd7`](https://github.com/NixOS/nixpkgs/commit/35662dd7b65e5540ecfd193a372a4086ebc7d82b) | `` linuxPackages.rtl8821ce: unstable-2022-06-01 -> unstable-2023-01-01 ``           |
| [`82c93e22`](https://github.com/NixOS/nixpkgs/commit/82c93e226618ce543af9a51790794354b3a5ee59) | `` linuxPackages.rtl8812au: unstable-2022-08-22 -> unstable-2023-01-17 ``           |
| [`77206b1a`](https://github.com/NixOS/nixpkgs/commit/77206b1a0c8c4019eabcb09a68fe1759a065a035) | `` python310Packages.pytorch-metric-learning: 1.7.2 -> 2.0.0 ``                     |
| [`c17b502c`](https://github.com/NixOS/nixpkgs/commit/c17b502c17140a0da54cc5462702c213b0c5b1e0) | `` eris-go: 20230123 -> 20230202 ``                                                 |
| [`a80df0a1`](https://github.com/NixOS/nixpkgs/commit/a80df0a1b710865e047c218c5a9167030add17a6) | `` phonemizer: fix build ``                                                         |
| [`49303f2b`](https://github.com/NixOS/nixpkgs/commit/49303f2b5f36426a18ea455f5499b554f7baf4b1) | `` fluidd: 1.23.0 -> 1.23.1 ``                                                      |