### PR TITLE
chore(flake/nixpkgs): `06999209` -> `0591d6b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675454231,
-        "narHash": "sha256-5rgcWq1nFWlbR3NsLqY7i/7358uhkSeMQJ/LEHk3BWA=",
+        "lastModified": 1675545634,
+        "narHash": "sha256-TbQeQcM5TA/wIho6xtzG+inUfiGzUXi8ewwttiQWYJE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "06999209d7a0043d4372e38f57cffae00223d592",
+        "rev": "0591d6b57bfeb55dfeec99a671843337bc2c3323",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`cc0ff310`](https://github.com/NixOS/nixpkgs/commit/cc0ff310fdf4242c8fd4b74a0edd09d703d480fe) | `` python310Packages.pylutron-caseta: 0.18.0 -> 0.18.1 ``                     |
| [`c3204430`](https://github.com/NixOS/nixpkgs/commit/c3204430bc297090a6528f2347e874e642d9d76e) | `` python310Packages.oralb-ble: 0.17.1 -> 0.17.2 ``                           |
| [`b9bf82a6`](https://github.com/NixOS/nixpkgs/commit/b9bf82a647116a46530282074036d08c2f92a9a0) | `` python310Packages.hahomematic: 2023.2.1 -> 2023.2.1.1 ``                   |
| [`0ca39c30`](https://github.com/NixOS/nixpkgs/commit/0ca39c30e76d300aebabc71c61fe4cdf84374544) | `` yarn2nix-moretea-openssl_1_1: drop ``                                      |
| [`67ae50ad`](https://github.com/NixOS/nixpkgs/commit/67ae50adeec71ca64624366f75cb3ed316d7ca5e) | `` python310Packages.aioswitcher: 3.2.1 -> 3.2.2 ``                           |
| [`aa035e94`](https://github.com/NixOS/nixpkgs/commit/aa035e940895cb75b06c845a45b922ae646748e8) | `` python310Packages.stripe: add changelog to meta ``                         |
| [`717b60a4`](https://github.com/NixOS/nixpkgs/commit/717b60a43c42e8438fa2febd9a9823fa3a626e2e) | `` plasma5Packages.kimageformats: enable JPEG XL ``                           |
| [`70a5088c`](https://github.com/NixOS/nixpkgs/commit/70a5088ca705e24840559c80f3fcc6aaca6071b0) | `` python310Packages.elementpath: add changelog to meta ``                    |
| [`9ebdf804`](https://github.com/NixOS/nixpkgs/commit/9ebdf804b3577185c00519235e76321bde8d6666) | `` python310Packages.fastapi-mail: 1.2.4 -> 1.2.5 ``                          |
| [`ade88e37`](https://github.com/NixOS/nixpkgs/commit/ade88e374d388aa2e6f216cf13c3ba3e1e0ff8f8) | `` vimPlugins.unison: init at 2023-02-03 ``                                   |
| [`d3bb4752`](https://github.com/NixOS/nixpkgs/commit/d3bb475232cc332605e58c6bb74741bb057f6257) | `` ecwolf: fix executable not being added to PATH ``                          |
| [`774420e4`](https://github.com/NixOS/nixpkgs/commit/774420e45690b5b3fc46e93e1752ee101fdc455e) | `` ecwolf: add jayman2000 as maintainer ``                                    |
| [`33bcd301`](https://github.com/NixOS/nixpkgs/commit/33bcd301cd3cfe37c185806390aae6ccc8d07f1a) | `` maintainers: add jayman2000 ``                                             |
| [`1aa9ce67`](https://github.com/NixOS/nixpkgs/commit/1aa9ce67f0b9fffa2a38daefa85f26abf3fa6540) | `` ecwolf: remove obsolete build steps ``                                     |
| [`549f211d`](https://github.com/NixOS/nixpkgs/commit/549f211d02fa867be45be395382b5015785ad26d) | `` python310Packages.pulumi-aws: 5.28.0 -> 5.29.1 ``                          |
| [`2cc36838`](https://github.com/NixOS/nixpkgs/commit/2cc36838edf6d4230c53ef90c03f73fd5849e06a) | `` python310Packages.wand: 0.6.10 -> 0.6.11 ``                                |
| [`d4fffad6`](https://github.com/NixOS/nixpkgs/commit/d4fffad6236ee35c58f0c3ddd76cc3fa64ae8578) | `` perlPackages.ImageMagick: 7.0.11-3 -> 7.1.0-0 ``                           |
| [`5a8562ac`](https://github.com/NixOS/nixpkgs/commit/5a8562ac9f1b8ec9ed6005e6bf13e0746447d2c3) | `` opencv4: unpin vtk ``                                                      |
| [`e2e9dc92`](https://github.com/NixOS/nixpkgs/commit/e2e9dc92d86acf3a480202371d9ce0c77bc20c26) | `` tvbrowser: update meta.license and add other meta attributes ``            |
| [`62c02911`](https://github.com/NixOS/nixpkgs/commit/62c02911b982f7341ae280f3378cda17b8655d17) | `` tvbrowser: use upstream wrapper script ``                                  |
| [`2efdb48f`](https://github.com/NixOS/nixpkgs/commit/2efdb48f8ee323bee09fb63225f94e33beb9027f) | `` tvbrowser: use upstream desktop file ``                                    |
| [`f530d505`](https://github.com/NixOS/nixpkgs/commit/f530d505d4b95c8b836431974e8774972a67b073) | `` tvbrowser: move installation directory to /share/tvbrowser ``              |
| [`2d8e156a`](https://github.com/NixOS/nixpkgs/commit/2d8e156a59f1806c12017a864bde8ed5fdcb7bfa) | `` tvbrowser: add simple test ``                                              |
| [`b2fdba82`](https://github.com/NixOS/nixpkgs/commit/b2fdba820a868d805f05562feb07e19960b9ea1d) | `` tvbrowser: build from source ``                                            |
| [`17abe6d2`](https://github.com/NixOS/nixpkgs/commit/17abe6d26a37ee533158353e9db0940002f2fbcb) | `` tvbrowser: add {pre,post}Install decoration hooks ``                       |
| [`8e0c4773`](https://github.com/NixOS/nixpkgs/commit/8e0c477357e537abfc8751c2ab53ec05dacfc577) | `` tvbrowser: 4.0.1 -> 4.2.7 ``                                               |
| [`efc015d2`](https://github.com/NixOS/nixpkgs/commit/efc015d28a872476a8cf8f1c1ebb2e5aa857e5a0) | `` tvbrowser: track required JDK version ``                                   |
| [`00c8e192`](https://github.com/NixOS/nixpkgs/commit/00c8e19293cfaf0a7fc2d3d270b9a5968f25c603) | `` rustypaste: 0.8.2 -> 0.8.4 ``                                              |
| [`b9c9c8b6`](https://github.com/NixOS/nixpkgs/commit/b9c9c8b67606825be4e20ae6fb1692db4b19c03f) | `` gpxsee: 11.11 -> 11.12 ``                                                  |
| [`72d1c11b`](https://github.com/NixOS/nixpkgs/commit/72d1c11b1e11971723a24e77e456241bd7f44170) | `` dump_syms: 2.1.1 -> 2.2.0 ``                                               |
| [`779b7ffb`](https://github.com/NixOS/nixpkgs/commit/779b7ffb5192274a86a66b3ff4605d3a6dc16d6d) | `` python310Packages.elementpath: 3.0.2 -> 4.0.1 ``                           |
| [`ad277668`](https://github.com/NixOS/nixpkgs/commit/ad277668c6e079477c8d8b982e06deef833f96fd) | `` alex, happy, hscolour: add top-level executable-only bindings ``           |
| [`4d9eaf89`](https://github.com/NixOS/nixpkgs/commit/4d9eaf89f7ff2375e30dbf574f85d5f269530260) | `` tvbrowser: add myself (Yarny) as maintainer ``                             |
| [`da842f72`](https://github.com/NixOS/nixpkgs/commit/da842f72882db7b213c4ca06e84f652f80f3cd41) | `` python310Packages.python-crfsuite: 0.9.8 -> 0.9.9 ``                       |
| [`b2d76c24`](https://github.com/NixOS/nixpkgs/commit/b2d76c243e875e87ae6b1a0258c0f7ce5f999ca8) | `` mimir: 2.5.0 -> 2.6.0 ``                                                   |
| [`8717b14f`](https://github.com/NixOS/nixpkgs/commit/8717b14fff27ec6f554c90089b1e4d1883a485d5) | `` nats-server: 2.9.11 -> 2.9.12 ``                                           |
| [`bf22adff`](https://github.com/NixOS/nixpkgs/commit/bf22adffaba1f2b4952c2c39ddefecf50214e4c0) | `` fail2ban: add manpages to output ``                                        |
| [`46248670`](https://github.com/NixOS/nixpkgs/commit/4624867084758aea1e4c75504934a2c1d1ebf09d) | `` prometheus-influxdb-exporter: 0.11.1 -> 0.11.2 ``                          |
| [`858e9e36`](https://github.com/NixOS/nixpkgs/commit/858e9e36fb30ec88060ce979e5df8a347133ac68) | `` nvidia_x11: don't leak the kernel reference into nvidia-settings ``        |
| [`2da2c865`](https://github.com/NixOS/nixpkgs/commit/2da2c865150f2da36f09013a37637a860cf400bb) | `` plantuml: 1.2023.0 -> 1.2023.1 ``                                          |
| [`0a68564e`](https://github.com/NixOS/nixpkgs/commit/0a68564e2a9ad1529f75d38c02fea2939426dddc) | `` typos: 1.13.9 -> 1.13.10 ``                                                |
| [`b74b3cb8`](https://github.com/NixOS/nixpkgs/commit/b74b3cb87088d573e9aae46d9f0463709bfc39e0) | `` xeus: init at 3.0.5 ``                                                     |
| [`97825936`](https://github.com/NixOS/nixpkgs/commit/978259361b723ffe808a0c4a35dd45b9f9c4b402) | `` nixos/tests/multipass: init ``                                             |
| [`63e3f8da`](https://github.com/NixOS/nixpkgs/commit/63e3f8da0977526c783839c1ed3854d5681a80ad) | `` nixos/multipass: init ``                                                   |
| [`db9d730b`](https://github.com/NixOS/nixpkgs/commit/db9d730b1ecaf9db00d519d91d9572dd115c0320) | `` multipass: init at 1.11.0 ``                                               |
| [`370295f1`](https://github.com/NixOS/nixpkgs/commit/370295f107a1f49848bb92952f3a16dd08574db9) | `` vimPlugins.indent-o-matic: init at 2023-01-24 ``                           |
| [`84cceaa2`](https://github.com/NixOS/nixpkgs/commit/84cceaa2969bae6a3f75fab6397a08720896a469) | `` vimPlugins: update ``                                                      |
| [`32ec41a6`](https://github.com/NixOS/nixpkgs/commit/32ec41a6726d57e539acea7ac57f94266d8d8d1a) | `` nixos/virtualbox-image: Allow SCSI storage controller for vSphere ``       |
| [`4009f60d`](https://github.com/NixOS/nixpkgs/commit/4009f60d0ba7efec0200b1d5f7311693c008c172) | `` nixos/virtualbox-image: Allow running extra commands after OVA creation `` |
| [`6556ccb8`](https://github.com/NixOS/nixpkgs/commit/6556ccb8c9b7a851f550a161d45d6204835e79ba) | `` kaufkauflist: 1.0.0 → 2.0.0 ``                                             |
| [`5faafda7`](https://github.com/NixOS/nixpkgs/commit/5faafda79923bb8b6097e2f4409aea71bc0239e1) | `` ddosify: 0.13.1 -> 0.13.2 ``                                               |
| [`ce310d1e`](https://github.com/NixOS/nixpkgs/commit/ce310d1e4a614d7d0b24c9cc1ef172214a637d37) | `` terraform-providers.lxd: drop proxyVendor ``                               |
| [`cf07dcd8`](https://github.com/NixOS/nixpkgs/commit/cf07dcd8eec79e10102749ae896bfaf46474ad31) | `` terraform-providers.baiducloud: drop deleteVendor ``                       |
| [`dc541760`](https://github.com/NixOS/nixpkgs/commit/dc541760a76edb34e5078f3ebbdbd7b70470b050) | `` terraform-providers.tencentcloud: 1.79.6 → 1.79.7 ``                       |
| [`8b58d450`](https://github.com/NixOS/nixpkgs/commit/8b58d4507b9ae38e3f5f801a32876d2a878107cf) | `` terraform-providers.utils: 1.7.0 → 1.7.1 ``                                |
| [`a6980e3c`](https://github.com/NixOS/nixpkgs/commit/a6980e3cd4c024802129162d169da3b0a1a4da10) | `` terraform-providers.azurerm: 3.41.0 → 3.42.0 ``                            |
| [`6e3a85d0`](https://github.com/NixOS/nixpkgs/commit/6e3a85d048ad6dadfa2caee656b1489f69391ec1) | `` terraform-providers.scaleway: 2.9.1 → 2.10.0 ``                            |
| [`1ef93650`](https://github.com/NixOS/nixpkgs/commit/1ef93650fa9294ee9caca0cad127f0379ca55822) | `` terraform-providers.github: 5.16.0 → 5.17.0 ``                             |
| [`7650f5bf`](https://github.com/NixOS/nixpkgs/commit/7650f5bfbc9f9c847a643a721d6cff3e466f2ab2) | `` terraform-providers.aci: 2.6.0 → 2.6.1 ``                                  |
| [`90d05cbd`](https://github.com/NixOS/nixpkgs/commit/90d05cbd9e8e340a87082f69f7c3d8be8227e5b7) | `` sequoia-chameleon-gnupg: 0.1.1 -> 0.2.0 ``                                 |
| [`6a08edd4`](https://github.com/NixOS/nixpkgs/commit/6a08edd4d0725a21490716cc2935d545f0b6592a) | `` nodejs-16_x-openssl_1_1: drop ``                                           |
| [`b07da972`](https://github.com/NixOS/nixpkgs/commit/b07da97238aaf6053ae03e0f6a2a536c9da5196e) | `` python310Packages.stripe: 5.0.0 -> 5.1.0 ``                                |
| [`98773c6c`](https://github.com/NixOS/nixpkgs/commit/98773c6cb2681f24e24f12f6d92d673839088c08) | `` python310Packages.dataset: 1.5.2 -> 1.6.0 ``                               |
| [`5d3fd82b`](https://github.com/NixOS/nixpkgs/commit/5d3fd82b14164a753856ed43b29dfe5b90ad709b) | `` okteto: 2.11.1 -> 2.12.0 ``                                                |
| [`a66e0d29`](https://github.com/NixOS/nixpkgs/commit/a66e0d29e2ec396c3a64c416fee446685f7c2f6b) | `` terragrunt: 0.43.0 -> 0.43.2 ``                                            |
| [`fff150e3`](https://github.com/NixOS/nixpkgs/commit/fff150e3c12a85afa168fc1e2222a4ab40429313) | `` fetchmail: 6.4.35 -> 6.4.36 ``                                             |
| [`2e985bbc`](https://github.com/NixOS/nixpkgs/commit/2e985bbc510e8d04b9d9401d6b9a144cdce5f6ac) | `` ruff: 0.0.240 -> 0.0.241 ``                                                |
| [`959609d9`](https://github.com/NixOS/nixpkgs/commit/959609d970fc70e2ee0d169dbfd3d521d5664d46) | `` aspectj: 1.9.9.1 -> 1.9.19 ``                                              |
| [`7dd92b04`](https://github.com/NixOS/nixpkgs/commit/7dd92b04dd3ce8285eb354f945af37b640e8d89e) | `` python310Packages.twitchapi: 3.4.1 -> 3.7.0 ``                             |
| [`a7f66352`](https://github.com/NixOS/nixpkgs/commit/a7f66352cd2555c05a6aea45aec37404787a02ad) | `` python310Packages.trove-classifiers: 2023.1.12 -> 2023.1.20 ``             |
| [`16160781`](https://github.com/NixOS/nixpkgs/commit/16160781e3049d5aa84cd45300da0e08577d6b1a) | `` python310Packages.trimesh: 3.18.1 -> 3.18.3 ``                             |
| [`d8d4faf9`](https://github.com/NixOS/nixpkgs/commit/d8d4faf904ab803511ac0a3d2deee2c691f422c8) | `` python310Packages.pyrogram: 2.0.62 -> 2.0.97 ``                            |
| [`93d674bf`](https://github.com/NixOS/nixpkgs/commit/93d674bf3171f5b85ec45146557b1ef1c05f6be8) | `` python310Packages.pikepdf: 6.2.8 -> 6.2.9 ``                               |
| [`7ef7d9e2`](https://github.com/NixOS/nixpkgs/commit/7ef7d9e26818955dc4bf011fa469718d52179eef) | `` nixos/miriway: add test ``                                                 |
| [`84f2d3ec`](https://github.com/NixOS/nixpkgs/commit/84f2d3ec224b1efc153bbea69a38a2016a73b0dc) | `` python310Packages.ansible-compat: 2.2.7 -> 3.0.1 ``                        |
| [`3baab783`](https://github.com/NixOS/nixpkgs/commit/3baab7835faaf5f0e531bfa3321c252612ef6a8a) | `` python310Packages.webauthn: 1.6.0 -> 1.7.0 ``                              |
| [`f4ba1f56`](https://github.com/NixOS/nixpkgs/commit/f4ba1f56adc18d7857ef53a6981efce3a537374a) | `` tdesktop: 4.5.3 -> 4.6.0 ``                                                |
| [`d1917579`](https://github.com/NixOS/nixpkgs/commit/d191757957c8f2780b1f343269b874bbdfea4dfe) | `` faudio: 23.01 -> 23.02 ``                                                  |
| [`bb225cbe`](https://github.com/NixOS/nixpkgs/commit/bb225cbed75d41f4df8c856693b7c4753de4dc58) | `` samim-fonts: 4.0.4 -> 4.0.5 ``                                             |
| [`36029571`](https://github.com/NixOS/nixpkgs/commit/360295719000f42c6db23bd98cd0c1ef759ce55a) | `` fastly: 5.1.0 -> 5.1.1 ``                                                  |
| [`c3c19586`](https://github.com/NixOS/nixpkgs/commit/c3c195864772d9f56fe045ad9a68e7a030092a8e) | `` mdsh: 0.6.0 -> 0.7.0 ``                                                    |
| [`e1bb4292`](https://github.com/NixOS/nixpkgs/commit/e1bb429272abf7925226f0f87f1bf6387e5ee813) | `` avalanchego: 1.9.7 -> 1.9.8 ``                                             |
| [`98e5bdd0`](https://github.com/NixOS/nixpkgs/commit/98e5bdd02ed4d7f61fc851ad36bc29863731dcdd) | `` werf: 1.2.198 -> 1.2.199 ``                                                |
| [`0f40f4f8`](https://github.com/NixOS/nixpkgs/commit/0f40f4f89196b7957bc3352a1abeb2dc9e0fb05f) | `` vimPlugins.nvim-treesitter: update grammars ``                             |
| [`ebd497b7`](https://github.com/NixOS/nixpkgs/commit/ebd497b7cd33a628b82fe0f5abd9b08c64ba4c10) | `` vimPlugins: update ``                                                      |
| [`92ced8ef`](https://github.com/NixOS/nixpkgs/commit/92ced8ef6dc57d45bb18c0e214bb9f4ea877a8ae) | `` vimPlugins.barbecue-nvim: fix incorrect override ``                        |
| [`2d09ecef`](https://github.com/NixOS/nixpkgs/commit/2d09ecef6ca327f3503080cd90dd4dce58e09978) | `` zed: 1.4.0 -> 1.5.0 ``                                                     |
| [`95215354`](https://github.com/NixOS/nixpkgs/commit/95215354d61339ea8e654873a68521a5543f23a8) | `` abcmidi: 2023.01.08 -> 2023.01.21 ``                                       |
| [`a0b535dd`](https://github.com/NixOS/nixpkgs/commit/a0b535ddc0dd8e5bb40fb860a91357b69dc52f16) | `` python3Packages.peewee-migrate: init at 1.6.6 ``                           |
| [`32d066dc`](https://github.com/NixOS/nixpkgs/commit/32d066dce3e443459148fcd003927f00362d8f26) | `` channel: add --show-trace to nix-env command ``                            |
| [`93238163`](https://github.com/NixOS/nixpkgs/commit/93238163e4692cc5c0e2ea7d86310edceb36ef58) | `` evcc: 0.112.0 -> 0.112.1 ``                                                |
| [`fd5d7b25`](https://github.com/NixOS/nixpkgs/commit/fd5d7b258694c1ef5d499cba37693ebd21fbc13f) | `` tests/bpf: add module BTF test ``                                          |
| [`c1fd7598`](https://github.com/NixOS/nixpkgs/commit/c1fd7598cf66cd5c653d081bd92f787e1ffa9a9f) | `` bpftrace: 0.16.0 -> 0.17.0 ``                                              |
| [`e694229b`](https://github.com/NixOS/nixpkgs/commit/e694229bb69a6860dbe3ee8c6a71e5be8136d8e4) | `` v2ray-geoip: 202301260045 -> 202302020047 ``                               |
| [`72fc45dc`](https://github.com/NixOS/nixpkgs/commit/72fc45dc80320a01eada4ccb81262991551e5edd) | `` poetryPlugins.poetry-audit-plugin: init at 0.3.0 ``                        |
| [`0349728e`](https://github.com/NixOS/nixpkgs/commit/0349728efbdbb92e6880a560fc9ab82a8824d7bf) | `` poetryPlugins.poetry-plugin-up: init at 0.2.1 ``                           |
| [`01959f61`](https://github.com/NixOS/nixpkgs/commit/01959f61f0fda94a9d85a01c777ae69568c8c311) | `` poetry: add withPlugins ``                                                 |
| [`ee03c866`](https://github.com/NixOS/nixpkgs/commit/ee03c8669f9122171453d0106ef28ae4c1584a8c) | `` winePackages.{unstable,staging}: 8.0 -> 8.1 ``                             |
| [`fb476bc2`](https://github.com/NixOS/nixpkgs/commit/fb476bc28baeab4c9da7110e701c982633432415) | `` yabridge: work around broken version check for wine ``                     |
| [`a7085b02`](https://github.com/NixOS/nixpkgs/commit/a7085b026f7948a57096db1451b6803990e5b82a) | `` airwave: fix build ``                                                      |
| [`b0ec519e`](https://github.com/NixOS/nixpkgs/commit/b0ec519e3da593424b4112601968e7b8d77f92c8) | `` wine: fix for updateScript ``                                              |
| [`cf692195`](https://github.com/NixOS/nixpkgs/commit/cf692195c5875ecc6935a4b9062e44b3bb1d4f7b) | `` wine: replace sha256 fetcher arguments with hash ``                        |
| [`1e14a900`](https://github.com/NixOS/nixpkgs/commit/1e14a900a59e9f1d550d26182f2573765bbe5af3) | `` wine: remove vkd3dSupport ``                                               |
| [`3dbfc39a`](https://github.com/NixOS/nixpkgs/commit/3dbfc39ac5f517f7158e5c5c4e9d7e385f36a861) | `` wine: remove ldapSupport ``                                                |
| [`55b08c0d`](https://github.com/NixOS/nixpkgs/commit/55b08c0d56766b0bc5b560e531fd1b43fb7396eb) | `` wine: remove openalSupport ``                                              |
| [`45af4636`](https://github.com/NixOS/nixpkgs/commit/45af4636b3903a56286b7c3542b49318fc3895be) | `` winePackages.stable: 7.0.1 -> 8.0 ``                                       |
| [`003b4c59`](https://github.com/NixOS/nixpkgs/commit/003b4c59d46aac016af4707ade0bcf26d9809890) | `` winePackages.{unstable,staging,wayland}: 7.22 -> 8.0 ``                    |
| [`daf0b112`](https://github.com/NixOS/nixpkgs/commit/daf0b1129703fb12b5a28d744b7e88074e9e57b8) | `` winePackages.{unstable,staging,wayland}: 7.21 -> 7.22 ``                   |
| [`c8a6c65d`](https://github.com/NixOS/nixpkgs/commit/c8a6c65d97ac5c22681bbf96bd6a136527e640b1) | `` winePackages.{unstable,staging,wayland}: 7.20 -> 7.21 ``                   |
| [`7cf57324`](https://github.com/NixOS/nixpkgs/commit/7cf57324c6c2bedcd58eec56050a7a18f3696d8e) | `` stork 1.5.0 -> 1.6.0 ``                                                    |
| [`983950d5`](https://github.com/NixOS/nixpkgs/commit/983950d550b801a6848bc0009c0126f3a611abfc) | `` nurl: 0.3.6 -> 0.3.7 ``                                                    |
| [`9b9a5b6d`](https://github.com/NixOS/nixpkgs/commit/9b9a5b6d5fc602c09d8f3534f89161c1730383b0) | `` openboardview: macos support ``                                            |
| [`6f158854`](https://github.com/NixOS/nixpkgs/commit/6f15885434d121efcf026c160e47013090080eb2) | `` swayrbar: init at 0.3.4 ``                                                 |
| [`09edc1bf`](https://github.com/NixOS/nixpkgs/commit/09edc1bf5b6a6f791e0c126400a17b300fe907c2) | `` uasm: 2.55 -> 2.56.2 ``                                                    |
| [`5094b5f6`](https://github.com/NixOS/nixpkgs/commit/5094b5f659430f6b9ae7a1818856ee9139fb526c) | `` diffuse: macos support ``                                                  |
| [`21556bbb`](https://github.com/NixOS/nixpkgs/commit/21556bbb2a235d501d7d48caaad23a6d48717772) | `` mdbook-emojicodes: init at 0.1.3 ``                                        |
| [`c47337a5`](https://github.com/NixOS/nixpkgs/commit/c47337a5ebb94bf266a2085337ec59c647d9f888) | `` deno: 1.30.0 -> 1.30.2 ``                                                  |
| [`9827f080`](https://github.com/NixOS/nixpkgs/commit/9827f080e0a0dc11f6648a639c63e81fb62906b6) | `` cwltool: 3.1.20230127121939 -> 3.1.20230201130431 ``                       |
| [`8c3d7340`](https://github.com/NixOS/nixpkgs/commit/8c3d73408971b8e3cbaca3841e24f9501f91c3ea) | `` vcmi: 1.1.0 -> 1.1.1 ``                                                    |
| [`d9e4080d`](https://github.com/NixOS/nixpkgs/commit/d9e4080d1523246d1dab9755ad9eaffbbe7a5a93) | `` pre-commit: Disable check on i686-linux ``                                 |
| [`967988fe`](https://github.com/NixOS/nixpkgs/commit/967988fe79f70615aa2e3a9098d0bafb27120e7d) | `` python310Packages.swift: 2.30.0 -> 2.31.0 ``                               |
| [`7fdbf909`](https://github.com/NixOS/nixpkgs/commit/7fdbf909208e42bc190ba10972f837682e102526) | `` limesurvey: add knownVulnerabilities CVE-2022-48008 & CVE-2022-48010 ``    |
| [`2021045e`](https://github.com/NixOS/nixpkgs/commit/2021045e4ccdf8b0d9c78dec3548f1540826d6b7) | `` openvscode-server: 1.73.1 -> 1.74.3 ``                                     |
| [`a11a5070`](https://github.com/NixOS/nixpkgs/commit/a11a5070d2e2d0e469c91ce36f8f7b275e09b2e3) | `` prismlauncher: 6.1 -> 6.3 ``                                               |
| [`a1066c41`](https://github.com/NixOS/nixpkgs/commit/a1066c41c43a5f08ff5cb87aba1b2d7ffa878e13) | `` discord-canary: 0.0.145 -> 0.0.146 ``                                      |
| [`56ef7f8e`](https://github.com/NixOS/nixpkgs/commit/56ef7f8e5f8868da55ae843b1d2d8113562e9ba9) | `` ton: init at 2023.01 ``                                                    |
| [`9d1833a0`](https://github.com/NixOS/nixpkgs/commit/9d1833a072c66ea23137ba637b600fcead8792f2) | `` python310Packages.ansible: 7.1.0 -> 7.2.0 ``                               |
| [`016822b0`](https://github.com/NixOS/nixpkgs/commit/016822b0b0390187201cd69864df63ce6ec0aa3f) | `` maintainers: update PGP key for Scrumplex ``                               |
| [`617158ea`](https://github.com/NixOS/nixpkgs/commit/617158eaf6ad8f79e5789b0e184ab03a770e1804) | `` arduino-cli: Install shell completion files ``                             |
| [`cc4da379`](https://github.com/NixOS/nixpkgs/commit/cc4da379917810b2f0708011e55ed4cd6c205577) | `` difftastic: 0.42.0 -> 0.43.0 ``                                            |
| [`03882dbc`](https://github.com/NixOS/nixpkgs/commit/03882dbc22fe33dfe105457bb4825c50fc54f8c7) | `` nil: 2023-01-01 -> 2023-02-03 ``                                           |
| [`7238b35c`](https://github.com/NixOS/nixpkgs/commit/7238b35c40e0591e96dcffeaa8f5544673bdcaca) | `` obsidian: make electron version overridable ``                             |
| [`aa48f9f3`](https://github.com/NixOS/nixpkgs/commit/aa48f9f3ce81d249fafe40ff409d6376b659994b) | `` firefox-devedition-bin-unwrapped: 110.0b7 -> 110.0b9 ``                    |
| [`1dd83858`](https://github.com/NixOS/nixpkgs/commit/1dd838585c5c4bad67f8c379d870886a26a5495f) | `` python3Packages.qpageview: init at 0.6.2 ``                                |
| [`eca30e77`](https://github.com/NixOS/nixpkgs/commit/eca30e7730f7cb8c83472e2c2b2d9733ecce3083) | `` nixos/miriway: init ``                                                     |
| [`8c3ca262`](https://github.com/NixOS/nixpkgs/commit/8c3ca2627c6011130644bd83cfe940af95eb1ad8) | `` scriv: init at 1.2.0 ``                                                    |
| [`3c6e6ce6`](https://github.com/NixOS/nixpkgs/commit/3c6e6ce6f1c33b9be417649259285524fdfcb50e) | `` deepin.qt5integration: 5.6.3 -> 5.6.4 ``                                   |
| [`e34a5459`](https://github.com/NixOS/nixpkgs/commit/e34a54597ba97f79cdf62587000d1e96de08570e) | `` rocfft: actually fix hydra caching ``                                      |
| [`5545f930`](https://github.com/NixOS/nixpkgs/commit/5545f930a2c328aea3e59e8b403167e8d0eea966) | `` fava: support flask-babel 3 ``                                             |
| [`84bfd941`](https://github.com/NixOS/nixpkgs/commit/84bfd9416c1099758f7eccd763a25e5674546e5c) | `` maintainers: add jnsgruk ``                                                |
| [`3c24ba1e`](https://github.com/NixOS/nixpkgs/commit/3c24ba1ef05a581c5c3f40c6b2e397172a48c9a3) | `` calibre-web: support flask-babel 3 ``                                      |
| [`ee77bfd0`](https://github.com/NixOS/nixpkgs/commit/ee77bfd0ae9687cb3536db5414f47cf602f31638) | `` dnscrypt-proxy2: 2.1.2 -> 2.1.3 ``                                         |
| [`8fa5bbca`](https://github.com/NixOS/nixpkgs/commit/8fa5bbcae74b6554938253ffac8a6a493177597d) | `` octoprint: pin flask-babel to 2.0.0 ``                                     |