### PR TITLE
chore(flake/nixpkgs): `0591d6b5` -> `5a350a8f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675545634,
-        "narHash": "sha256-TbQeQcM5TA/wIho6xtzG+inUfiGzUXi8ewwttiQWYJE=",
+        "lastModified": 1675673983,
+        "narHash": "sha256-8hzNh1jtiPxL5r3ICNzSmpSzV7kGb3KwX+FS5BWJUTo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0591d6b57bfeb55dfeec99a671843337bc2c3323",
+        "rev": "5a350a8f31bb7ef0c6e79aea3795a890cf7743d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`8b031cac`](https://github.com/NixOS/nixpkgs/commit/8b031cac44ae8fb02b6017863aeefe727806ad41) | `` podman: 4.3.1 -> 4.4.0 ``                                                       |
| [`29464cd1`](https://github.com/NixOS/nixpkgs/commit/29464cd170b7c15057a0fdad09c347354af27005) | `` racket: wrap with LOCALE_ARCHIVE iff Linux ``                                   |
| [`e72e3101`](https://github.com/NixOS/nixpkgs/commit/e72e3101421567821b0ad300efa31658e8a41907) | `` forgejo: 1.18.2-1 -> 1.18.3-0 ``                                                |
| [`3ae9f673`](https://github.com/NixOS/nixpkgs/commit/3ae9f6738caaefadf0df15a102ab108a579d83b0) | `` forgejo: add `passthru.updateScript` ``                                         |
| [`c2300ed0`](https://github.com/NixOS/nixpkgs/commit/c2300ed0cba8fa7c3d77f6ab01914bea27316454) | `` bibtex-tidy: init at 1.8.5 ``                                                   |
| [`8030c645`](https://github.com/NixOS/nixpkgs/commit/8030c64577a7973d07537e2bb446c14ccedaa14c) | `` Revert Merge #214786: libvmaf: fix build for BSD ``                             |
| [`c114f447`](https://github.com/NixOS/nixpkgs/commit/c114f447eca95fb29ca3c5404d55efcb319ca3d1) | `` python310Packages.pyodbc: add unixODBC to nativeBuildInputs ``                  |
| [`2bbc46b2`](https://github.com/NixOS/nixpkgs/commit/2bbc46b29169af6529f7d27f264d68023a582dfd) | `` python310Packages.apycula: 0.6.2 -> 0.7 ``                                      |
| [`64f21e16`](https://github.com/NixOS/nixpkgs/commit/64f21e162080aac06a69e7fe4c123329927ac2fe) | `` circt: init at 1.29.0 ``                                                        |
| [`8d4ebc8e`](https://github.com/NixOS/nixpkgs/commit/8d4ebc8e5db726e5e431e6f84d5e1b684c8d25f8) | `` python310Packages.aioconsole: fix tests on Darwin ``                            |
| [`13351c3d`](https://github.com/NixOS/nixpkgs/commit/13351c3d9ec7fb5fd2db5d3caf8386e885ac99ba) | `` python310Packages.aioconsole: 0.5.1 -> 0.6.0 ``                                 |
| [`bad653db`](https://github.com/NixOS/nixpkgs/commit/bad653dbc2727562d7db27e8dd1c52b536536fa2) | `` deepin-compressor: init at 5.12.9 ``                                            |
| [`7a0b564c`](https://github.com/NixOS/nixpkgs/commit/7a0b564c30bdbc8db0096c2b3bc033dd5f7e5fd1) | `` clickable: 7.4.0 -> 7.11.0 ``                                                   |
| [`008469a6`](https://github.com/NixOS/nixpkgs/commit/008469a60095f493d12f529ac60098dde0532758) | `` tokodon: 22.11.2 -> 23.01.0 ``                                                  |
| [`3aa003ad`](https://github.com/NixOS/nixpkgs/commit/3aa003ad21fec641a0ee1b4b55b40dfb90a03b11) | `` plasma5Packages.plasmaMobileGear: 22.11 -> 23.01.0 ``                           |
| [`ac68ce8b`](https://github.com/NixOS/nixpkgs/commit/ac68ce8b847e9061572573a43d414d7f6695ef12) | `` mullvad-vpn: add libGL dependency to fix hardware accel ``                      |
| [`516a9816`](https://github.com/NixOS/nixpkgs/commit/516a9816a39b0b378e3bb5eef34f5af75d6683cb) | `` nixos/manual/manpages: add description on previewing manpage files (#214833) `` |
| [`930d4df5`](https://github.com/NixOS/nixpkgs/commit/930d4df5120449c968bd1190ec72b4783c755cb3) | `` uefitool: remove myself as maintainer ``                                        |
| [`36f00365`](https://github.com/NixOS/nixpkgs/commit/36f003654e676903e3e34bfa820aacbb980278df) | `` pods: 1.0.4 -> 1.0.5 ``                                                         |
| [`c046cf01`](https://github.com/NixOS/nixpkgs/commit/c046cf01c05d8659e4f7ac2602a3a8e7ad07967c) | `` python310Packages.pytradfri: 12.0.1 -> 13.0.0 ``                                |
| [`0a6dd026`](https://github.com/NixOS/nixpkgs/commit/0a6dd02620e291bf2e88ac583b8ba56340e43ae6) | `` nixos/firefox-syncserver: enable recommendedProxySettings ``                    |
| [`9401837d`](https://github.com/NixOS/nixpkgs/commit/9401837d22a77468fab610d2c441bb77ee340f60) | `` changie: 1.11.0 -> 1.11.1 ``                                                    |
| [`44fc5d7b`](https://github.com/NixOS/nixpkgs/commit/44fc5d7bda8d1b06acd63c0bef1b0b3dcbbc8f71) | `` python310Packages.env-canada: 0.5.27 -> 0.5.28 ``                               |
| [`5758bc5e`](https://github.com/NixOS/nixpkgs/commit/5758bc5e9a80b31db8480b8ece064498419634cb) | `` enum4linux-ng: 1.3.0 -> 1.3.1 ``                                                |
| [`85757c2d`](https://github.com/NixOS/nixpkgs/commit/85757c2d1b0c75d3489ecfffca372f99a88b0d55) | `` openvino: 2021.2 -> 2022.3.0 ``                                                 |
| [`1c561baa`](https://github.com/NixOS/nixpkgs/commit/1c561baac632b589a07ad2119aeb5acde4490e24) | `` Revert "wayland: mark as broken on darwin" ``                                   |
| [`5f5d853f`](https://github.com/NixOS/nixpkgs/commit/5f5d853fa801104b9d29e1ee70aba11d01a98b53) | `` tig: 2.5.7 -> 2.5.8 ``                                                          |
| [`fa428c17`](https://github.com/NixOS/nixpkgs/commit/fa428c17dba8f31c9bd93aa3cf2333037d3a57dc) | `` joystickwake: 0.3 -> 0.4 ``                                                     |
| [`d4feba66`](https://github.com/NixOS/nixpkgs/commit/d4feba663308f0b33340292b3eda60ad9c08950d) | `` mutagen-compose: 0.16.3 -> 0.16.4 ``                                            |
| [`9b668e07`](https://github.com/NixOS/nixpkgs/commit/9b668e0734a0d02be4e78dff768a5a2a012d85e6) | `` magic-enum: init at 0.8.2 ``                                                    |
| [`97de73f2`](https://github.com/NixOS/nixpkgs/commit/97de73f2a90c8f2d150d9c0ebf834e519ec65e1f) | `` librime: 1.8.3 -> 1.8.4 ``                                                      |
| [`fe4f28b8`](https://github.com/NixOS/nixpkgs/commit/fe4f28b807beeee8576fada03838ab8bfffcdc79) | `` syft: 0.69.1 -> 0.70.0 ``                                                       |
| [`5e609b2a`](https://github.com/NixOS/nixpkgs/commit/5e609b2a026d9956448b7c1dd1dcab1d003348bf) | `` syft: 0.69.0 -> 0.69.1 ``                                                       |
| [`f820d8b4`](https://github.com/NixOS/nixpkgs/commit/f820d8b4ebef17581e25c760ca5c3ca34891a6ce) | `` nfpm: 2.24.0 -> 2.25.0 ``                                                       |
| [`b6622a43`](https://github.com/NixOS/nixpkgs/commit/b6622a43c25d2ed853d7a3e538c6146e871c8007) | `` pachyderm: 2.4.4 -> 2.4.5 ``                                                    |
| [`cc5e3266`](https://github.com/NixOS/nixpkgs/commit/cc5e3266d09bb94e502bc73ea47f74e4c5d53740) | `` standardnotes: 3.142.1 -> 3.144.3 ``                                            |
| [`b126f231`](https://github.com/NixOS/nixpkgs/commit/b126f231af93fe87ef67df265470a1b7860e3ca0) | `` ocamlPackages.ounit2: fix tests with OCaml < 4.07 ``                            |
| [`9413ef67`](https://github.com/NixOS/nixpkgs/commit/9413ef6725d167989bdb014eb712b120ab12dee5) | `` python311Packages.rflink: fix build ``                                          |
| [`66581ee3`](https://github.com/NixOS/nixpkgs/commit/66581ee394354e5e4507c46fcd05e8f68b418a6d) | `` libdeltachat: 1.107.0 -> 1.107.1 ``                                             |
| [`6a08a48b`](https://github.com/NixOS/nixpkgs/commit/6a08a48b6e360f35539f0872cf2f22dc85db5c0b) | `` exempi: 2.6.2 -> 2.6.3 ``                                                       |
| [`443148f6`](https://github.com/NixOS/nixpkgs/commit/443148f6db451668c8869dc427578de6d8f5e417) | `` altair: 5.0.13 -> 5.0.14 ``                                                     |
| [`65ef7b3f`](https://github.com/NixOS/nixpkgs/commit/65ef7b3f80ab432dfdd0abee727e2986a2f4a350) | `` maintainers: add sharzy ``                                                      |
| [`50a68df7`](https://github.com/NixOS/nixpkgs/commit/50a68df712be34f6f408b9ae566e4babb03a5681) | `` kanboard: remove ``                                                             |
| [`aafbe479`](https://github.com/NixOS/nixpkgs/commit/aafbe47972cfbbc6901775489c7e89976b8d4b1c) | `` libvmaf: fix build for BSD ``                                                   |
| [`273297d8`](https://github.com/NixOS/nixpkgs/commit/273297d84bbbe3e6d1ceac0214649f9792c51937) | `` firefox-beta-bin-unwrapped: 110.0b8 -> 110.0b9 ``                               |
| [`0478ec60`](https://github.com/NixOS/nixpkgs/commit/0478ec60f2cf715200ade2fb500f7a1043311d8d) | `` arc_unpacker: depend on libiconv unconditionally ``                             |
| [`a4764363`](https://github.com/NixOS/nixpkgs/commit/a4764363a2d256669c2fce2c9a202eba66d6a387) | `` Revert "wallabag: Drop swiftmailer patch" ``                                    |
| [`c9c80287`](https://github.com/NixOS/nixpkgs/commit/c9c802872e531038f2bc363cef8d20ef381bba61) | `` unvanquished: 0.53.2 -> 0.54.0 ``                                               |
| [`b34c81ce`](https://github.com/NixOS/nixpkgs/commit/b34c81ce6868db91555c65fcd10ef53530ad75f2) | `` openai-whisper-cpp: 1.0.4 -> 1.2.0 ``                                           |
| [`2d9ce2b1`](https://github.com/NixOS/nixpkgs/commit/2d9ce2b132c83c329b207ddc28f0611b7cbd6bd9) | `` jackett: 0.20.2782 -> 0.20.2916 ``                                              |
| [`d6778203`](https://github.com/NixOS/nixpkgs/commit/d6778203deba459c477a43bc0d5501b332fe7daf) | `` python310Packages.pdoc: 12.0.2 -> 12.3.1 ``                                     |
| [`2e88127a`](https://github.com/NixOS/nixpkgs/commit/2e88127a0d68317f3627f47c8e112c2e69ddb836) | `` fetchers: document requireFile ``                                               |
| [`d47ea2e7`](https://github.com/NixOS/nixpkgs/commit/d47ea2e7f0419b750655730bb7bdc9dd489cd390) | `` kalendar: Update maintainers ``                                                 |
| [`b200b3f2`](https://github.com/NixOS/nixpkgs/commit/b200b3f2d7130e8002551509e3345891d080ca86) | `` python310Packages.flax: mark broken ``                                          |
| [`aa5ccc2b`](https://github.com/NixOS/nixpkgs/commit/aa5ccc2b2f4a23d892a2e29f98aa5dec65c8abe5) | `` mpd-discord-rpc: 1.5.3 -> 1.5.4b ``                                             |
| [`3449f836`](https://github.com/NixOS/nixpkgs/commit/3449f8361880baedb2fa080dde09d689f31f8020) | `` maintainers/malvo: update information ``                                        |
| [`b397c8b2`](https://github.com/NixOS/nixpkgs/commit/b397c8b2161626c0a843058e90699e140eb9b7b6) | `` swc: init at 0.91.19 ``                                                         |
| [`eed37a84`](https://github.com/NixOS/nixpkgs/commit/eed37a84270d43e9b619f5dd46745f08380b96db) | `` cbmc: 5.74.0 -> 5.76.1 ``                                                       |
| [`a08fa5c9`](https://github.com/NixOS/nixpkgs/commit/a08fa5c988bf507b9a1524fccdbada3e7a1cf692) | `` act: 0.2.41 -> 0.2.42 ``                                                        |
| [`cdab1c28`](https://github.com/NixOS/nixpkgs/commit/cdab1c28507209332cc064ddfa724e7b418c1ba1) | `` musescore: meta.mainProgram = "mscore" ``                                       |
| [`2424197b`](https://github.com/NixOS/nixpkgs/commit/2424197be29411c485c1a5ecd507d8c5b08e5002) | `` python310Packages.gensim: mark broken ``                                        |
| [`0fd2901e`](https://github.com/NixOS/nixpkgs/commit/0fd2901e31614a80cb5ba309ab4d5f656d8f533b) | `` varscan: 2.4.4 -> 2.4.5 ``                                                      |
| [`224c0b6c`](https://github.com/NixOS/nixpkgs/commit/224c0b6c15b85f552ef31a6964899f189a2d1747) | `` partclone: 0.3.22 -> 0.3.23 ``                                                  |
| [`f6486cc9`](https://github.com/NixOS/nixpkgs/commit/f6486cc987638eca002f2b5f615758ae44fd0298) | `` python310Packages.wiffi: 1.1.0 -> 1.1.2 ``                                      |
| [`82bfd500`](https://github.com/NixOS/nixpkgs/commit/82bfd50061f2c0d1a0812b92595a60adb42c48df) | `` python310Packages.wiffi: add changelog to meta ``                               |
| [`9744fb4b`](https://github.com/NixOS/nixpkgs/commit/9744fb4b26976cbc963a181874d95653284099ea) | `` variety: 0.8.9 -> 0.8.10 ``                                                     |
| [`aed8d534`](https://github.com/NixOS/nixpkgs/commit/aed8d53425349e9fb6c368a8736b4813522fbbbc) | `` slurm: 22.05.7.1 -> 22.05.8.1 ``                                                |
| [`4bb112a8`](https://github.com/NixOS/nixpkgs/commit/4bb112a84af38d391d641e28328f7ab4246232cc) | `` initool: init at 0.10.0 ``                                                      |
| [`1286ee1e`](https://github.com/NixOS/nixpkgs/commit/1286ee1e761140874df490fa05f646da6866171e) | `` python3Packages.azure-mgmt-msi: 6.1.0 -> 7.0.0 ``                               |
| [`2037544d`](https://github.com/NixOS/nixpkgs/commit/2037544d3c1f0a9159c6a26f785f92db7d2ee11d) | `` python3Packages.azure-core: 1.26.2 -> 1.26.3 ``                                 |
| [`3d706f5b`](https://github.com/NixOS/nixpkgs/commit/3d706f5bd84601f180c21a4f89960a185caa5cdf) | `` python3Packages.azure-servicebus: 7.8.1 -> 7.8.2 ``                             |
| [`10b0cef0`](https://github.com/NixOS/nixpkgs/commit/10b0cef09dd65912de9f5d9f050ccd7fd41f9d1d) | `` python3Packages.azure-mgmt-datalake-store: 1.0.0 -> 0.5.0 ``                    |
| [`d4f5c1b4`](https://github.com/NixOS/nixpkgs/commit/d4f5c1b4fc07ebcfc3b69a542eeabcd593193be3) | `` python3Packages.azure-core: 1.26.1 -> 1.26.2 ``                                 |
| [`a66e5df6`](https://github.com/NixOS/nixpkgs/commit/a66e5df6b3e88b8a8014f20d1807d2cb4328dc5e) | `` python3Packages.azure-storage: drop due to being deprecated ``                  |
| [`29fae13a`](https://github.com/NixOS/nixpkgs/commit/29fae13a946a53062e96ec43117118bd66f00808) | `` mblaze: depend on libiconv unconditionally ``                                   |
| [`f2ff928c`](https://github.com/NixOS/nixpkgs/commit/f2ff928ccd5f4c94c7937d56aff2829a2ce9db13) | `` paper-note: add meta.mainProgram ``                                             |
| [`bfd813b8`](https://github.com/NixOS/nixpkgs/commit/bfd813b8eacc443d989ddf312d8f59de8122bfd0) | `` libcdio-paranoia: broaden platforms ``                                          |
| [`8025367c`](https://github.com/NixOS/nixpkgs/commit/8025367cd689fa68ee56495c1c88649a5f3e1c36) | `` digital: 0.29 -> 0.30 ``                                                        |
| [`b9533b23`](https://github.com/NixOS/nixpkgs/commit/b9533b23d53ef1ae2bfc53b518e5397089978c36) | `` kubernetes-controller-tools: 0.11.1 -> 0.11.2 ``                                |
| [`489843ea`](https://github.com/NixOS/nixpkgs/commit/489843eab769bc0d77c9bf1e67a0daa4b30c6a11) | `` armcord: wayland screen sharing support ``                                      |
| [`1a184f4b`](https://github.com/NixOS/nixpkgs/commit/1a184f4b87744aa91c3fb6cf174e8f904a3ff334) | `` certipy: 2.0.9 -> 4.3.0 ``                                                      |
| [`bccc8d15`](https://github.com/NixOS/nixpkgs/commit/bccc8d15721dc8d3b670ca97fccda3a4adb64453) | `` certipy: add changelog to meta ``                                               |
| [`ddaf60cf`](https://github.com/NixOS/nixpkgs/commit/ddaf60cf6f4e877507b1c1d832a203eaefde43e1) | `` ngtcp2: 0.12.1 -> 0.13.0 ``                                                     |
| [`fa59d8e4`](https://github.com/NixOS/nixpkgs/commit/fa59d8e45cbf5acce6dfcea7fa464633c072402b) | `` cobra-cli: fix the build ``                                                     |
| [`44b7b37b`](https://github.com/NixOS/nixpkgs/commit/44b7b37b73476061c1358de5bbfca23c36f94277) | `` pari: 2.15.1 -> 2.15.2 ``                                                       |
| [`85a8663d`](https://github.com/NixOS/nixpkgs/commit/85a8663d5cf661b7a0a36912130c6cefb2504171) | `` makemkv 1.17.2 -> 1.17.3 ``                                                     |
| [`d08e2fa8`](https://github.com/NixOS/nixpkgs/commit/d08e2fa87c689e2dc6796264d505b7a910c787e9) | `` yatas: init at 1.3.3 ``                                                         |
| [`ca9285e5`](https://github.com/NixOS/nixpkgs/commit/ca9285e5f0bd89b41ca21d175fe3044b36c98fa1) | `` flightgear: 2020.3.13 -> 2020.3.17 ``                                           |
| [`d1bb936c`](https://github.com/NixOS/nixpkgs/commit/d1bb936cf77cc132d35bd9c974de5c451c458ec8) | `` symlinkJoin: print warning when keeping existing file ``                        |
| [`bb792493`](https://github.com/NixOS/nixpkgs/commit/bb792493dee9b5ed9d7c9be54a7197cc5386c036) | `` topgrade: 10.3.0 -> 10.3.1 ``                                                   |
| [`2692bb85`](https://github.com/NixOS/nixpkgs/commit/2692bb8570e09a255a2e81a6f2f911df9d6b9ef4) | `` wallabag: fix source file for 2.5.3 ``                                          |
| [`23168520`](https://github.com/NixOS/nixpkgs/commit/231685202018d8a98ff48f20ba8f880ecfd2fdb7) | `` gridtracker: 1.23.0110 -> 1.23.0206 ``                                          |
| [`0ac11773`](https://github.com/NixOS/nixpkgs/commit/0ac1177357506a5732069de1c9e4a22a4281cb12) | `` gridtracker: add passthru update script ``                                      |
| [`dbceded4`](https://github.com/NixOS/nixpkgs/commit/dbceded4f9d6d5d3f6de2ae102d11ee6b70f6f15) | `` python310Packages.django_silk: don't depend on contextlib2 ``                   |
| [`cda06aa9`](https://github.com/NixOS/nixpkgs/commit/cda06aa9b4f81aed0186795afec48c8008513a8f) | `` python310Packages.duecredit: don't depend on setuptools ``                      |
| [`7e551214`](https://github.com/NixOS/nixpkgs/commit/7e5512144f5ced29b9c14ba45f5c15558e052d18) | `` python310Packages.duecredit: don't depend on contextlib2 ``                     |
| [`fe20983f`](https://github.com/NixOS/nixpkgs/commit/fe20983f251321befa2df37a7671b22fad99f9bd) | `` python310Packages.bedup: drop ``                                                |
| [`caa3af9f`](https://github.com/NixOS/nixpkgs/commit/caa3af9fc9e36791a0d2945490d713435f19c50e) | `` python310Packages.llfuse: don't depend on contextlib2 ``                        |
| [`d589f54c`](https://github.com/NixOS/nixpkgs/commit/d589f54cded5f81dbcb8c9d8aa0fe615c1b27417) | `` python310Packages.parametrize-from-file: don't depend on contextlib2 ``         |
| [`8494b92f`](https://github.com/NixOS/nixpkgs/commit/8494b92f768f42d1a24764f646810c1c617671f6) | `` tvbrowser: fix source download url ``                                           |
| [`ce919991`](https://github.com/NixOS/nixpkgs/commit/ce91999174a07d3a5a3e3316cdb9fb1b126a35ca) | `` google-guest-oslogin: 20220721.00 -> 20230202.00 ``                             |
| [`feb549ff`](https://github.com/NixOS/nixpkgs/commit/feb549ff50c8a98790d22da3bebd6ae95a6bd136) | `` python310Packages.schema: don't depend on contextlib2 ``                        |
| [`c85857de`](https://github.com/NixOS/nixpkgs/commit/c85857de4a9f70e33030d36577f52197150df98c) | `` python310Packages.aiofile: don't depend on asynctest ``                         |
| [`e50ff857`](https://github.com/NixOS/nixpkgs/commit/e50ff85762264d2ef9f66ff92832951f86f149b1) | `` Revert "python310Packages.elementpath: 3.0.2 -> 4.0.1" ``                       |
| [`bd0c2217`](https://github.com/NixOS/nixpkgs/commit/bd0c2217500b4c572aaf25358191dd15a451093f) | `` openmm: 7.7.0 -> 8.0.0 ``                                                       |
| [`a22928fb`](https://github.com/NixOS/nixpkgs/commit/a22928fba973c48bb96806b642994bc3e493c5b8) | `` evdevremapkeys: 68fb618 -> 9b6f372 ``                                           |
| [`35be4db9`](https://github.com/NixOS/nixpkgs/commit/35be4db93607e519ac23472ec1f99c0bf92f803c) | `` process-compose: 0.40.0 -> 0.40.1 ``                                            |
| [`09e03655`](https://github.com/NixOS/nixpkgs/commit/09e0365549d079de027b0746400262e8232e9cc2) | `` google-guest-agent: 20230112.00 -> 20230202.00 ``                               |
| [`fe44f278`](https://github.com/NixOS/nixpkgs/commit/fe44f278fcc96c9a31854d921ccc74b68d0aa916) | `` k9s: 0.27.0 -> 0.27.2 ``                                                        |
| [`dc1103e1`](https://github.com/NixOS/nixpkgs/commit/dc1103e11d6f2cea60b9435969653c8b36bfb2dc) | `` civo: 1.0.45 -> 1.0.47 ``                                                       |
| [`2b2a5980`](https://github.com/NixOS/nixpkgs/commit/2b2a5980e068519d27f2282406cb122d5bfe4f7c) | `` xmrig-proxy: 6.18.0 -> 6.19.0 ``                                                |
| [`977008b7`](https://github.com/NixOS/nixpkgs/commit/977008b7561cbb9cfff730c4f6bda5a63516b172) | `` keepass: 2.52 -> 2.53 ``                                                        |
| [`887c2c0f`](https://github.com/NixOS/nixpkgs/commit/887c2c0f6f361f69866ffcf64b8df9d82574b674) | `` ansible-lint: 6.11.0 -> 6.12.1 ``                                               |
| [`527831c1`](https://github.com/NixOS/nixpkgs/commit/527831c1e34ae43db6d2df8fe28ded1d68ed201d) | `` kitty: fix GOFLAGS typo to resolve go runtime dependency ``                     |