### PR TITLE
chore(flake/nixos-hardware): `b7ac0a56` -> `16b6928e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1674550793,
-        "narHash": "sha256-ljJlIFQZwtBbzWqWTmmw2O5BFmQf1A/DspwMOQtGXHk=",
+        "lastModified": 1675785029,
+        "narHash": "sha256-EoD3Wgqc0XWkBCwUrAxCIZett64jN/SEPPpXX2mCmrE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b7ac0a56029e4f9e6743b9993037a5aaafd57103",
+        "rev": "16b6928ec622fd2356a80c0a9359eb350a94227d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`48e4621f`](https://github.com/NixOS/nixos-hardware/commit/48e4621f98be9d58e9d5e4eef7be2cf80b0b5df7) | `` Add flake and readme links ``       |
| [`68136fdd`](https://github.com/NixOS/nixos-hardware/commit/68136fdd0a77626de0207c152f8c116ff8da6bb7) | `` Lenovo Y530-15ICH Initial Commit `` |