### PR TITLE
chore(flake/home-manager): `d6b1d426` -> `edb36453`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675802839,
-        "narHash": "sha256-3R85GWs1xJr9HExuLnTy6uADWJMt1d6rZKKmBBJuCkk=",
+        "lastModified": 1675803265,
+        "narHash": "sha256-FBd2PLeIyv7XNetS+ctq+XrnYRM2picMWFULA2R5LHA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d6b1d426826a437b9da00a1197837e690e4bc8e1",
+        "rev": "edb364538383a54528ef485e182ee4105ebda532",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`edb36453`](https://github.com/nix-community/home-manager/commit/edb364538383a54528ef485e182ee4105ebda532) | `` systemd: remove platform assertion `` |
| [`17dc5939`](https://github.com/nix-community/home-manager/commit/17dc5939309bb24c02133d67341fe9a791523c6f) | `` modules: add platform assertions ``   |