### PR TITLE
chore(flake/home-manager): `6d95d98b` -> `d7a5a28f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675811720,
-        "narHash": "sha256-WXWChFo1DAUK+/YkeLwzZQDsH43y7c1JWozRuVNQYg8=",
+        "lastModified": 1675850427,
+        "narHash": "sha256-iRo253KS8vooK5NxtNXiIK4WXpTw16qJS74Cjx6j4LI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6d95d98b6b4876c9ab589327331196b2893581c5",
+        "rev": "d7a5a28fc30d7576061ccfdd3e8382e7ab56ce19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`d7a5a28f`](https://github.com/nix-community/home-manager/commit/d7a5a28fc30d7576061ccfdd3e8382e7ab56ce19) | `` vscode: add extensions.json file in extensions dir (#3588) `` |