### PR TITLE
chore(flake/nixpkgs): `5a350a8f` -> `fab09085`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675673983,
-        "narHash": "sha256-8hzNh1jtiPxL5r3ICNzSmpSzV7kGb3KwX+FS5BWJUTo=",
+        "lastModified": 1675763311,
+        "narHash": "sha256-bz0Q2H3mxsF1CUfk26Sl9Uzi8/HFjGFD/moZHz1HebU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a350a8f31bb7ef0c6e79aea3795a890cf7743d4",
+        "rev": "fab09085df1b60d6a0870c8a89ce26d5a4a708c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`fab09085`](https://github.com/NixOS/nixpkgs/commit/fab09085df1b60d6a0870c8a89ce26d5a4a708c2) | `` doc/nixos: prefer the verb 'log in' (#214616) ``                                        |
| [`f1d41d28`](https://github.com/NixOS/nixpkgs/commit/f1d41d287484f96a8e6f9c5a6eb88c7fa93b4ce3) | `` pbpctrl: init at unstable-2023-02-07 ``                                                 |
| [`e375feff`](https://github.com/NixOS/nixpkgs/commit/e375feffbefce4961fc6b97aef83e60f9ed0e705) | `` gnupg: add NixOS tests to passthru ``                                                   |
| [`fe34d10e`](https://github.com/NixOS/nixpkgs/commit/fe34d10e57b76696738b3a4a4352480d4e0ffd2f) | `` nixos/tests/gnupg: init ``                                                              |
| [`067d688b`](https://github.com/NixOS/nixpkgs/commit/067d688b1687b731007ddfe58a399f466492efe4) | `` nixos/test-driver: handle decoding errors in Machine.execute ``                         |
| [`f2929eb9`](https://github.com/NixOS/nixpkgs/commit/f2929eb949dadce3c195fc67f742c0f56710976c) | `` nixos/test-driver: drop logging from Machine.send_monitor_command ``                    |
| [`5381c53a`](https://github.com/NixOS/nixpkgs/commit/5381c53ab12bd6adcef94b9829422b52e3d8de9e) | `` anki-bin: 2.1.56 -> 2.1.57 ``                                                           |
| [`a6c1d83f`](https://github.com/NixOS/nixpkgs/commit/a6c1d83fd463f5d798cab557f473e655fd4567fb) | `` lazygit: 0.36 -> 0.37.0 ``                                                              |
| [`68081ec1`](https://github.com/NixOS/nixpkgs/commit/68081ec1711eb3aee80d0d515a24fabfacd7944a) | `` zulip: 5.9.4 → 5.9.5 ``                                                                 |
| [`458c1628`](https://github.com/NixOS/nixpkgs/commit/458c1628ee0a33af9439584f2cb4021366b63c33) | `` fix logic ``                                                                            |
| [`20794e7c`](https://github.com/NixOS/nixpkgs/commit/20794e7c3827821f0ffa07ebd1532b9d2c746f92) | `` terraform-providers.google-beta: 4.51.0 → 4.52.0 ``                                     |
| [`d93725aa`](https://github.com/NixOS/nixpkgs/commit/d93725aad67cb1d02a6bca633a62a5b0a4c9505c) | `` terraform-providers.google: 4.51.0 → 4.52.0 ``                                          |
| [`3d034c27`](https://github.com/NixOS/nixpkgs/commit/3d034c279d5b28ba7025b7a397980341a219b4e2) | `` terraform-providers.dns: 3.2.3 → 3.2.4 ``                                               |
| [`70d75c24`](https://github.com/NixOS/nixpkgs/commit/70d75c24e41b82ee8ff9cd0d9e64115f67c7ff78) | `` deepin-turbo: init at 0.0.6.3 ``                                                        |
| [`1cedc22d`](https://github.com/NixOS/nixpkgs/commit/1cedc22d83c26028f5983d3e97f8010b6d00f1ca) | `` shortwave: 3.1.0 -> 3.2.0 ``                                                            |
| [`e2b092fc`](https://github.com/NixOS/nixpkgs/commit/e2b092fc52c7d28a15241ae78bf10b7b66b4f405) | `` Revert "rustPlatform.bindgenHook: use the same clang/libclang as rustc" ``              |
| [`ab367c31`](https://github.com/NixOS/nixpkgs/commit/ab367c312c7c29fdac944a0d3ed8c796517f5b8e) | `` eget: 1.3.1 -> 1.3.2 ``                                                                 |
| [`bf9771c9`](https://github.com/NixOS/nixpkgs/commit/bf9771c95fcf8241b9f2a6d00ccb3afe6ddd078c) | `` python310Packages.pikepdf: 6.2.9 -> 7.0.0 ``                                            |
| [`2e82629b`](https://github.com/NixOS/nixpkgs/commit/2e82629b56a10d9c07ae765b1f3dd615af6f8a0a) | `` python310Packages.lupupy: 0.2.5 -> 0.2.7 ``                                             |
| [`8aee03fe`](https://github.com/NixOS/nixpkgs/commit/8aee03feff838c4b4264794bdab2c08622a2c1b8) | `` deepin-image-viewer: fix build with libraw 0.21.1 ``                                    |
| [`291887ff`](https://github.com/NixOS/nixpkgs/commit/291887ff6e0ac84488afa27641c894620dc50718) | `` lua-language-server: rename from sumneko-lua-language-server ``                         |
| [`dfc0ceec`](https://github.com/NixOS/nixpkgs/commit/dfc0ceece39e8d294c0661c24cbc49ca65d77c4d) | `` sumneko-lua-language-server: 3.6.7 -> 3.6.10 ``                                         |
| [`527539fd`](https://github.com/NixOS/nixpkgs/commit/527539fd2d6a9bef8922b35069912391fd84a103) | `` python310Packages.desktop-notifier: 3.4.2 -> 3.4.3 ``                                   |
| [`3ac97f85`](https://github.com/NixOS/nixpkgs/commit/3ac97f85ff8b9a5351d67efbb80203b4e54a1276) | `` moolticute: add hughobrien as maintainer ``                                             |
| [`b61b079b`](https://github.com/NixOS/nixpkgs/commit/b61b079b880a4bf4da6c4ef56f68cfb086c1e558) | `` maintainers: add hughobrien ``                                                          |
| [`61eaaa6b`](https://github.com/NixOS/nixpkgs/commit/61eaaa6b556fa2f19333221b05e79156dfddf565) | `` moolicute: 1.00.1 -> 1.01.0 ``                                                          |
| [`3c7e81d4`](https://github.com/NixOS/nixpkgs/commit/3c7e81d4254aa84f634fffd9052f9338c2aaa48b) | `` nearcore: 1.30.0 -> 1.30.1 ``                                                           |
| [`31f57de7`](https://github.com/NixOS/nixpkgs/commit/31f57de7dd85b7575a01e20b0be2ae7b7fbd70df) | `` devbox: 0.3.2 -> 0.3.3 ``                                                               |
| [`3c3343ec`](https://github.com/NixOS/nixpkgs/commit/3c3343ec9db334099e2c8dfaa4c9052cbea22957) | `` gnome-builder: 43.5 → 43.6 ``                                                           |
| [`fb37015c`](https://github.com/NixOS/nixpkgs/commit/fb37015c452e75237b6879986bfd3e81ca96db6e) | `` nixpacks: 1.1.1 -> 1.3.1 ``                                                             |
| [`b8e06daa`](https://github.com/NixOS/nixpkgs/commit/b8e06daabf43b13deecc257148b28dfa6dc6a7b6) | `` python310Packages.volvooncall: 0.10.1 -> 0.10.2 ``                                      |
| [`99d36b86`](https://github.com/NixOS/nixpkgs/commit/99d36b860d93df93c9938b4f95f5ef4863313464) | `` steampipe: 0.18.3 -> 0.18.4 ``                                                          |
| [`0ada458c`](https://github.com/NixOS/nixpkgs/commit/0ada458c6827b528c9efcfb270cbc9282a46e873) | `` ruff: 0.0.242 -> 0.0.243 ``                                                             |
| [`0e48bebe`](https://github.com/NixOS/nixpkgs/commit/0e48bebe62300c1ceea8d60cc6f494b9e0105033) | `` touchegg: 2.0.15 -> 2.0.16 ``                                                           |
| [`4946fa90`](https://github.com/NixOS/nixpkgs/commit/4946fa902d173a31b6d7196625903cdf5891897b) | `` pandoc-katex: 0.1.10 -> 0.1.11 ``                                                       |
| [`c37fedf9`](https://github.com/NixOS/nixpkgs/commit/c37fedf985c2f9aa9a1e8c827c5f4314d421d550) | `` verilator: 5.002 -> 5.006 ``                                                            |
| [`0b426cd8`](https://github.com/NixOS/nixpkgs/commit/0b426cd8e235f1e3ab1261ed5c064f766fca24db) | `` nixos/pykms: rename systemd deprecated `MemoryLimit` to `MemoryMax`. ``                 |
| [`a90c233d`](https://github.com/NixOS/nixpkgs/commit/a90c233d6ed372d468520fe252b8d317b89cd72b) | `` evcc: 0.112.2 -> 0.112.5 ``                                                             |
| [`557a9c14`](https://github.com/NixOS/nixpkgs/commit/557a9c1492d3e7e1dbda5f6cb330dc5492cfd4ae) | `` vassal: 3.6.10 -> 3.6.11 ``                                                             |
| [`0e2512a9`](https://github.com/NixOS/nixpkgs/commit/0e2512a9ff65bea06233945e1ee3250494845faa) | `` mediaelch-qt6: 2.8.18 -> 2.10.0 ``                                                      |
| [`59e79c10`](https://github.com/NixOS/nixpkgs/commit/59e79c106d2aa9c83b3796a74dd47509c8ec9147) | `` clifm: 1.9 -> 1.10 ``                                                                   |
| [`341770d3`](https://github.com/NixOS/nixpkgs/commit/341770d3f1b7d78b6bff71e306567171187b48a8) | `` nixos/zram: fix default swapDevices ``                                                  |
| [`2d44668c`](https://github.com/NixOS/nixpkgs/commit/2d44668ce6af760c592d03cb18e7c3a30534c71a) | `` phrase-cli: 2.6.5 -> 2.6.6 ``                                                           |
| [`67e898c1`](https://github.com/NixOS/nixpkgs/commit/67e898c12e0d70b19cd699cf87ef4890c0295bec) | `` nng: 1.5.2 -> 1.6.0-prerelease and rPackages.nanonext dependency ``                     |
| [`6ea7ec8a`](https://github.com/NixOS/nixpkgs/commit/6ea7ec8ac14b02f1b59a37aa0c13a7e3200e3ebb) | `` dnscontrol: 3.25.0 -> 3.26.0 ``                                                         |
| [`50e0012f`](https://github.com/NixOS/nixpkgs/commit/50e0012f9d576aed3765b0c540167513fa8c2fda) | `` treewide: cleanup some unused bindings ``                                               |
| [`41e734a7`](https://github.com/NixOS/nixpkgs/commit/41e734a755cf8e1cbe2f9d33e26113dd32ee8ac0) | `` python310Packages.meilisearch: 0.23.0 -> 0.24.0 ``                                      |
| [`b6dcd6bd`](https://github.com/NixOS/nixpkgs/commit/b6dcd6bdc95111ec81820ae16a4de2bf4c66b01b) | `` python310Packages.python-gvm: 22.9.1 -> 23.2.0 ``                                       |
| [`00f5c6f3`](https://github.com/NixOS/nixpkgs/commit/00f5c6f33218f99a1fcc9bb4aab375253700d551) | `` perlPackages.ZonemasterCLI: 4.0.1 -> 5.0.1 ``                                           |
| [`c216e896`](https://github.com/NixOS/nixpkgs/commit/c216e89616c9aac11f117004d26c390fa3ddbf86) | `` perlPackages.ZonemasterEngine: 4.5.1 -> 4.6.1 ``                                        |
| [`aba3b5d8`](https://github.com/NixOS/nixpkgs/commit/aba3b5d8cd1772b3eba9f664a9087339567128ef) | `` perlPackages.ZonemasterLDNS: 2.2.2 -> 3.1.0 ``                                          |
| [`8e47596d`](https://github.com/NixOS/nixpkgs/commit/8e47596d38462320f889007d158470070b263d52) | `` perlPackages.NetIPXS: init at 0.22 ``                                                   |
| [`3299517e`](https://github.com/NixOS/nixpkgs/commit/3299517e6b24e3767496797ad63d41049c4ceff4) | `` pipenv: 2022.11.25 -> 2023.2.4 ``                                                       |
| [`1adcc3be`](https://github.com/NixOS/nixpkgs/commit/1adcc3be90422309ccb0351eeda846017f8eb7af) | `` tdesktop: 4.6.0 -> 4.6.1 ``                                                             |
| [`413115bb`](https://github.com/NixOS/nixpkgs/commit/413115bb0da85ec4efcff17452e3b3b936654be1) | `` rnote: 0.5.12 -> 0.5.13 ``                                                              |
| [`fdf6e37d`](https://github.com/NixOS/nixpkgs/commit/fdf6e37dc0cfbd4d1437ace3af0bddf5e609aa0b) | `` advi: init at 2.0.0 (#214814) ``                                                        |
| [`ef5da70d`](https://github.com/NixOS/nixpkgs/commit/ef5da70d669321d482523ba64d331e7b09d6933b) | `` services.openssh: rename several settings (#211991) ``                                  |
| [`87208cc7`](https://github.com/NixOS/nixpkgs/commit/87208cc7daf6542a9be4701a97db7a42d02ec951) | `` mapcache: fix build on darwin ``                                                        |
| [`ddc5eecd`](https://github.com/NixOS/nixpkgs/commit/ddc5eecd7ae52cf1d911d02e75148448ecc6ff08) | `` lagrange: 1.14.2 → 1.15.2 ``                                                            |
| [`003e6784`](https://github.com/NixOS/nixpkgs/commit/003e6784a113f6a8eae6f15a21f2ff1ecdcd7a7e) | `` chromiumDev: 111.0.5562.0 -> 111.0.5563.8 ``                                            |
| [`3b25f6d7`](https://github.com/NixOS/nixpkgs/commit/3b25f6d75d2d00988e82beaf95abd82bd4b9b8e9) | `` chromiumBeta: 110.0.5481.52 -> 110.0.5481.77 ``                                         |
| [`8ebfc5a4`](https://github.com/NixOS/nixpkgs/commit/8ebfc5a4a41901d0f426c821c028467cd3208467) | `` sealcurses: 2022-05-18 → 2023-02-06 ``                                                  |
| [`2a7130d1`](https://github.com/NixOS/nixpkgs/commit/2a7130d13a032093f5394ef0961842d1e1928789) | `` nvidia: Reverse Prime Sync ``                                                           |
| [`3f5c9df6`](https://github.com/NixOS/nixpkgs/commit/3f5c9df6511c5e9ed4a6e5242be74bce12b18533) | `` rPackages: added libiconv to darwin builds and removed redundant package level calls `` |
| [`6cdec6d1`](https://github.com/NixOS/nixpkgs/commit/6cdec6d1b8e5160cbb11eeb3821e6edaf38212f8) | `` nixos/nginx: add comment about clearing Connection header (#214211) ``                  |
| [`5cb68d16`](https://github.com/NixOS/nixpkgs/commit/5cb68d1645cd93bc51b91e4ca1ee1c1739a5a892) | `` shotman: 0.3.0 -> 0.4.0 ``                                                              |
| [`96b055cb`](https://github.com/NixOS/nixpkgs/commit/96b055cbe734e2b99bb40adc42cbb3aefb444a6d) | `` iptsd: 1.0.0 -> 1.0.1 ``                                                                |
| [`c4269e49`](https://github.com/NixOS/nixpkgs/commit/c4269e49a680b375e6bf613f6d3b646502afb719) | `` iptsd: correctly install udev rule and systemd service file ``                          |
| [`bd351b76`](https://github.com/NixOS/nixpkgs/commit/bd351b76488279a36c77e0429ba45cd92ce25604) | `` ruff: 0.0.241 -> 0.0.242 ``                                                             |
| [`06eb99ff`](https://github.com/NixOS/nixpkgs/commit/06eb99ffa2a9933651b5116f888dec20a74b7b12) | `` chromiumBeta: Fix the build ``                                                          |
| [`2da6994e`](https://github.com/NixOS/nixpkgs/commit/2da6994e17d885d953b2009f4c7ac56244cb813e) | `` mapcache: 1.12.1 -> 1.14.0 ``                                                           |
| [`91c5117c`](https://github.com/NixOS/nixpkgs/commit/91c5117c1b5d220ca6e5cebb3ab513fe647f6b43) | `` prowlarr: 1.1.2.2453 -> 1.1.3.2521 ``                                                   |
| [`89595c2d`](https://github.com/NixOS/nixpkgs/commit/89595c2d6327116f6168ddbacdf9c779447148ee) | `` the-foundation: 1.5.0 -> 1.6.0 ``                                                       |
| [`6a1c0b75`](https://github.com/NixOS/nixpkgs/commit/6a1c0b75e650c7b6c874e8848aaf93788d8dbcf4) | `` kernelshark: 2.1.1 -> 2.2.0 ``                                                          |
| [`f8a7e5cf`](https://github.com/NixOS/nixpkgs/commit/f8a7e5cf2b8a21d19b079a100c94771b72b7bdee) | `` yamlfmt: init at 0.7.1 ``                                                               |
| [`4bd50031`](https://github.com/NixOS/nixpkgs/commit/4bd500317e0ff99d8dc0bbdcf18c87dcb4ad3916) | `` iosevka-bin: 17.1.0 -> 18.0.0 ``                                                        |
| [`f329e5f5`](https://github.com/NixOS/nixpkgs/commit/f329e5f50682ce27e66490567881bb1e146b04ed) | `` wasmtime: 4.0.0 -> 5.0.0 ``                                                             |
| [`a2cc6437`](https://github.com/NixOS/nixpkgs/commit/a2cc64378f15cccf46ea95a5f304e1301e0d2335) | `` sftpgo: 2.4.3 -> 2.4.4 ``                                                               |
| [`80e2e282`](https://github.com/NixOS/nixpkgs/commit/80e2e282c0e4b60f5d4645e34feffd810dcd8065) | `` maintainers: add sno2wman ``                                                            |
| [`6fe61041`](https://github.com/NixOS/nixpkgs/commit/6fe61041dc03d0347325e95fb9214b43b0a9fc77) | `` pv-migrate: init at 1.0.1 (#210373) ``                                                  |
| [`7767f842`](https://github.com/NixOS/nixpkgs/commit/7767f842c4cba5a9c556f14d3777ac2d6e1bf61b) | `` ssldump: 1.5 -> 1.6 (#214992) ``                                                        |
| [`acf0a7d9`](https://github.com/NixOS/nixpkgs/commit/acf0a7d9fdd2bf63328b795e49db750ac52dc442) | `` nix-init: 0.1.0 -> 0.1.1 ``                                                             |
| [`251d9a37`](https://github.com/NixOS/nixpkgs/commit/251d9a370748a11f281952c6ca12b88c04a4e0b7) | `` buildah: 1.28.2 -> 1.29.0 ``                                                            |
| [`38e3d218`](https://github.com/NixOS/nixpkgs/commit/38e3d2182426f57256f68b6409705c1b5eb04b8b) | `` stacks: 2.60 -> 2.62 ``                                                                 |
| [`e1e68ae0`](https://github.com/NixOS/nixpkgs/commit/e1e68ae08b5e8c0373f8dc6d4590435d1a630c29) | `` conmon: 2.1.5 -> 2.1.6 ``                                                               |
| [`047202f1`](https://github.com/NixOS/nixpkgs/commit/047202f1e13dd42da28ab56349179d8dfeace3c7) | `` lnch: remove empty go vendor hash ``                                                    |
| [`a83fd920`](https://github.com/NixOS/nixpkgs/commit/a83fd920d8088921512ba1f44dbdcebab957c1b8) | `` phylactery: remove empty go vendor hash ``                                              |
| [`c4fff891`](https://github.com/NixOS/nixpkgs/commit/c4fff89150ced57dfcf87671eece38a82ba55ba8) | `` statik: remove empty go vendor hash ``                                                  |
| [`6879bec5`](https://github.com/NixOS/nixpkgs/commit/6879bec5175b517daedbfba503fe1c74a53b0425) | `` evmdis: remove empty go vendor hash ``                                                  |
| [`3ed6f9d6`](https://github.com/NixOS/nixpkgs/commit/3ed6f9d67932847523909460b96241a153c4b3f7) | `` vimPlugins.vim-hexokinase: remove empty go vendor hash ``                               |
| [`3feeedb5`](https://github.com/NixOS/nixpkgs/commit/3feeedb5e2dd1a21bbbf72bdbca58c86b229f882) | `` buildGoModule: make the vendor fetcher error if it is empty ``                          |
| [`eceae845`](https://github.com/NixOS/nixpkgs/commit/eceae845cdd56e064195475fa21abf6592ebd95a) | `` darwin.openwith: init at unstable-2022-10-28 ``                                         |
| [`cd3c4f00`](https://github.com/NixOS/nixpkgs/commit/cd3c4f00f7f6d7cf29dc4de2733b52f5c6e86d34) | `` terraform-providers.gandi: 2.2.2 -> 2.2.3 (#214956) ``                                  |
| [`66444200`](https://github.com/NixOS/nixpkgs/commit/66444200f4946c6ca30f2fb138358f668ec71521) | `` metricbeat7: fix `passthru.tests` ``                                                    |
| [`7c4abbf8`](https://github.com/NixOS/nixpkgs/commit/7c4abbf80e1471d7844aae825f6d1015ce315a48) | `` lib.lists: add `replicate` ``                                                           |
| [`e7e447a1`](https://github.com/NixOS/nixpkgs/commit/e7e447a185483de1126d1dc92253db6eb8d420ce) | `` meilisearch: 0.30.5 -> 1.0.0 ``                                                         |
| [`918c22bd`](https://github.com/NixOS/nixpkgs/commit/918c22bd5f2a754542a115c2d1178adf830abd12) | `` privacyidea: fix build ``                                                               |
| [`e2402814`](https://github.com/NixOS/nixpkgs/commit/e24028141f278590407dd5389330f23d01c89cff) | `` qdmr: fixup ``                                                                          |
| [`8a1ff26d`](https://github.com/NixOS/nixpkgs/commit/8a1ff26db46df02c7606dd854c0878575acf5da9) | `` breath-theme: init at unstable-2022-12-22 ``                                            |
| [`349748a7`](https://github.com/NixOS/nixpkgs/commit/349748a7e19f0792fd8baf5c5d930ca03d445bc9) | `` portfolio: 0.60.2 -> 0.61.0 ``                                                          |
| [`7c193be7`](https://github.com/NixOS/nixpkgs/commit/7c193be7f389474514be260fe7b2f8077cc22df5) | `` simple-mtpfs: init at 0.4.0 ``                                                          |
| [`9e436141`](https://github.com/NixOS/nixpkgs/commit/9e4361412af7ab83ba40a13886dcc698c641669b) | `` pdfsam-basic: 4.3.4 -> 5.0.2 ``                                                         |
| [`6ee7b97e`](https://github.com/NixOS/nixpkgs/commit/6ee7b97efea6905a5f414c14be0cb5baeff49ecf) | `` dua: 2.19.0 -> 2.19.1 ``                                                                |
| [`fe6ab315`](https://github.com/NixOS/nixpkgs/commit/fe6ab31520740494da524df4464649d6dfd48381) | `` tbls: 1.60.0 -> 1.61.0 ``                                                               |
| [`179f987d`](https://github.com/NixOS/nixpkgs/commit/179f987de7e2c44bb07b87dc8b5373b134bfa277) | `` xchm: 1.33 -> 1.35 ``                                                                   |
| [`64c4077f`](https://github.com/NixOS/nixpkgs/commit/64c4077f92dc27b8796739af6b802572e2cc0c7f) | `` timescaledb: 2.9.2 -> 2.9.3 ``                                                          |
| [`dedb550c`](https://github.com/NixOS/nixpkgs/commit/dedb550ce642e09341fcead3e8960c4f948752c6) | `` bencode-py: init at 4.0.0 ``                                                            |
| [`c6007f7c`](https://github.com/NixOS/nixpkgs/commit/c6007f7c61510c6c30eaa49be9f3331b3e280543) | `` maintainers: add vamega ``                                                              |
| [`cd10a33b`](https://github.com/NixOS/nixpkgs/commit/cd10a33b63dcb543953d86a4a3a2104379cfc8ac) | `` qt6.qtbase: fix regression ``                                                           |
| [`73599b38`](https://github.com/NixOS/nixpkgs/commit/73599b389c1f19de6474a0dffaa61824de27fadf) | `` coq: remove undefined attribute `ocamlPropagatedNativeBuildInputs` in `passthru` ``     |
| [`de3d46fa`](https://github.com/NixOS/nixpkgs/commit/de3d46fa52cf0d8776ab1533f6492ea290936ed5) | `` stress-ng: 0.15.01 -> 0.15.03 ``                                                        |
| [`d6128620`](https://github.com/NixOS/nixpkgs/commit/d61286201d37c7b2d44be7745d6dae241ccc95b9) | `` python310Packages.cmsis-pack-manager: 0.5.1 -> 0.4.0 ``                                 |
| [`f4c1ef09`](https://github.com/NixOS/nixpkgs/commit/f4c1ef09d8bb2754acab930528853125832def9b) | `` freshrss: fix `passthru.tests` ``                                                       |
| [`f1db792d`](https://github.com/NixOS/nixpkgs/commit/f1db792d8a5866a929329fb93cec66b82ff6d6fd) | `` bambootracker-qt6: init at 0.6.1 ``                                                     |
| [`610af777`](https://github.com/NixOS/nixpkgs/commit/610af7778b04ebfe3c8ed715cc2b77af30c17304) | `` bambootracker: 0.6.0 -> 0.6.1 ``                                                        |
| [`35840330`](https://github.com/NixOS/nixpkgs/commit/35840330133dd0746ab2f4c6abb97bceace30e83) | `` pdns-recursor: 4.8.1 -> 4.8.2 ``                                                        |
| [`ffd4bf73`](https://github.com/NixOS/nixpkgs/commit/ffd4bf730f81d0d56e8549a3fb0790148963416b) | `` privacyidea: fix hash ``                                                                |
| [`f6c8d04d`](https://github.com/NixOS/nixpkgs/commit/f6c8d04d11fe58b52844a626c87575e0c2e09c34) | `` nixos/privacyidea: fix db uri ``                                                        |
| [`8116f965`](https://github.com/NixOS/nixpkgs/commit/8116f9653cc82c62aa5ca98fe2b232c40cf6ca58) | `` privacyidea: 3.7.4 -> 3.8 ``                                                            |
| [`d4dafcbb`](https://github.com/NixOS/nixpkgs/commit/d4dafcbb896746d473e87da32d3937992b531aaa) | `` geckodriver: 0.32.0 -> 0.32.1 ``                                                        |
| [`789fe86e`](https://github.com/NixOS/nixpkgs/commit/789fe86ea7b45939106ebf7b5c042783ec10698f) | `` linuxKernel.kernels.linux_lqx: 6.1.9-lqx1 -> 6.1.10-lqx1 ``                             |