### PR TITLE
chore(flake/nixos-hardware): `16b6928e` -> `44ae00e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1675785029,
-        "narHash": "sha256-EoD3Wgqc0XWkBCwUrAxCIZett64jN/SEPPpXX2mCmrE=",
+        "lastModified": 1675933606,
+        "narHash": "sha256-y427VhPQHOKkYvkc9MMsL/2R7M11rQxzsRdRLM3htx8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "16b6928ec622fd2356a80c0a9359eb350a94227d",
+        "rev": "44ae00e02e8036a66c08f4decdece7e3bbbefee2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
| [`445db26b`](https://github.com/NixOS/nixos-hardware/commit/445db26b8864bf34c236f936a9330272f232cd51) | `` Update lenovo/legion/16ach6h/nvidia/default.nix ``                                                  |
| [`b45bd035`](https://github.com/NixOS/nixos-hardware/commit/b45bd0353ae2857ca6d0990860c0bf5c4bdb6f53) | `` Change lib.mkDefault to lib.mkOverride 990 for  hardware.nvidia.prime.offload.enable ``             |
| [`be60a34c`](https://github.com/NixOS/nixos-hardware/commit/be60a34c1a6c3aa3e878fb5030e44c6d0f316af9) | `` 16ach6h: disable amdvlk and rocm-opencl for nvidia-only mode ``                                     |
| [`5af4dc5d`](https://github.com/NixOS/nixos-hardware/commit/5af4dc5d52a306272f4d4a97079aeef3888ae210) | `` Add the option of whether to install the opencl environment and whether to use amdvlk for amdgpu `` |