### PR TITLE
chore(flake/nixpkgs): `fab09085` -> `724bfc08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675763311,
-        "narHash": "sha256-bz0Q2H3mxsF1CUfk26Sl9Uzi8/HFjGFD/moZHz1HebU=",
+        "lastModified": 1675942811,
+        "narHash": "sha256-/v4Z9mJmADTpXrdIlAjFa1e+gkpIIROR670UVDQFwIw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fab09085df1b60d6a0870c8a89ce26d5a4a708c2",
+        "rev": "724bfc0892363087709bd3a5a1666296759154b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`6ccc4a59`](https://github.com/NixOS/nixpkgs/commit/6ccc4a59c3f1b56d039d93da52696633e641bc71) | `` rabbitmq-server: 3.11.7 -> 3.11.8 ``                                     |
| [`a2404f38`](https://github.com/NixOS/nixpkgs/commit/a2404f38a06404698c7d4a79069c04a11413027f) | `` oh-my-posh: 14.2.3 -> 14.2.4 ``                                          |
| [`fa977bd0`](https://github.com/NixOS/nixpkgs/commit/fa977bd060e4117e4850ce94c51637b8fbf72eca) | `` btcpayserver: 1.7.5 -> 1.7.7 ``                                          |
| [`8720c907`](https://github.com/NixOS/nixpkgs/commit/8720c907ca0aefe5161c5f13b5449937c0af6216) | `` nbxplorer: 2.3.57 -> 2.3.60 ``                                           |
| [`7069b96b`](https://github.com/NixOS/nixpkgs/commit/7069b96b91362bbadd4e239cf653c3ee77675625) | `` pscale: 0.128.0 -> 0.129.0 ``                                            |
| [`d67c9376`](https://github.com/NixOS/nixpkgs/commit/d67c93762e6817fb684279f77779adceed15db4b) | `` libreddit: 0.28.1 -> 0.29.0 ``                                           |
| [`01518852`](https://github.com/NixOS/nixpkgs/commit/015188525a1d48f903ff893d4986a216e7b82391) | `` podman: 4.4.0 -> 4.4.1 ``                                                |
| [`1db7bd28`](https://github.com/NixOS/nixpkgs/commit/1db7bd2880297056fc3f98a62197f32023ebb7dd) | `` skaffold: 2.0.4 -> 2.1.0 ``                                              |
| [`e004f773`](https://github.com/NixOS/nixpkgs/commit/e004f773e76c71b96f14b56f05b53c2499da078a) | `` afterburn: relax platforms ``                                            |
| [`a380674d`](https://github.com/NixOS/nixpkgs/commit/a380674d85f465c581b0b8a5a9c2df5d8aad9cae) | `` pgadmin4: add option to enable desktop mode ``                           |
| [`e892d33d`](https://github.com/NixOS/nixpkgs/commit/e892d33da30c9d6e38de64816ee1ebb114765398) | `` cargo-insta: 1.20.0 -> 1.26.0 ``                                         |
| [`2b63943b`](https://github.com/NixOS/nixpkgs/commit/2b63943be41006ae3e656a76670b3b5e718437a3) | `` nixosTests.pgadmin4-standalone: format ``                                |
| [`e4488f5e`](https://github.com/NixOS/nixpkgs/commit/e4488f5efe4ee6fd401894e96abc44153d70b1d4) | `` pgadmin4: move package tests back into the package ``                    |
| [`ae9fec21`](https://github.com/NixOS/nixpkgs/commit/ae9fec21409ec92c1a77bbc2dbd5e267101265e9) | `` draco: 1.5.5 -> 1.5.6 ``                                                 |
| [`d5196ae0`](https://github.com/NixOS/nixpkgs/commit/d5196ae0eb604e0f213c7f0576826fe5b0249cc9) | `` afterburn: 5.3.0 -> 5.4.0 ``                                             |
| [`4c4184ef`](https://github.com/NixOS/nixpkgs/commit/4c4184ef92a17f0f946b4d2b96a400f4a70e0655) | `` xmrig: add darwin support ``                                             |
| [`a15990c0`](https://github.com/NixOS/nixpkgs/commit/a15990c0612d6bebaad72aa2a879a35a35c786d0) | `` backblaze-b2: 3.6.0 -> 3.7.0 ``                                          |
| [`2aaffd2a`](https://github.com/NixOS/nixpkgs/commit/2aaffd2a75db7e9ac1323780d778c8fd03f20fee) | `` pythonPackages.b2sdk: 1.18.0 -> 1.19.0 ``                                |
| [`5525cdd7`](https://github.com/NixOS/nixpkgs/commit/5525cdd7b3bd8fdece52dd42afcf5a46182e724f) | `` tfswitch: 0.13.1300 -> 0.13.1308 ``                                      |
| [`fc192817`](https://github.com/NixOS/nixpkgs/commit/fc1928175266611fe76062895e816880f0c492d0) | `` terraform-providers.vsphere: 2.2.0 → 2.3.1 ``                            |
| [`82f69264`](https://github.com/NixOS/nixpkgs/commit/82f69264a3a2918b490fd32b0f7f05ad31f84e5f) | `` terraform-providers.oci: 4.106.0 → 4.107.0 ``                            |
| [`b0d19493`](https://github.com/NixOS/nixpkgs/commit/b0d194937faeb9ffea67dc86d47131ffeeb71986) | `` terraform-providers.selectel: 3.9.0 → 3.9.1 ``                           |
| [`d8abb4de`](https://github.com/NixOS/nixpkgs/commit/d8abb4de2479073bbba3242273e8f917d16aa704) | `` terraform-providers.alicloud: 1.197.0 → 1.198.0 ``                       |
| [`c78c0eaa`](https://github.com/NixOS/nixpkgs/commit/c78c0eaaaf21995cdce5da1a317778efa9dc12bd) | `` terraform-providers.newrelic: 3.13.0 → 3.14.0 ``                         |
| [`275c67a3`](https://github.com/NixOS/nixpkgs/commit/275c67a37dcc781e612365eb464c8a9bc5d03622) | `` ligolo-ng: 0.4.2 -> 0.4.3 ``                                             |
| [`7f23b8cd`](https://github.com/NixOS/nixpkgs/commit/7f23b8cdc0bccbf1da6cf2d78fe9eda93ee011a9) | `` subnetcalc: 2.4.20 -> 2.4.21 ``                                          |
| [`f5a06f71`](https://github.com/NixOS/nixpkgs/commit/f5a06f7150d534ab3a849ca500164b9707e1bb69) | `` nixos/caddy: fix `caddy fmt` for caddy v2.6.3 ``                         |
| [`e6b4796a`](https://github.com/NixOS/nixpkgs/commit/e6b4796a340d07b00860f6a4836ae31505cf525e) | `` anytype: 0.29.1 -> 0.30.0 ``                                             |
| [`f446d272`](https://github.com/NixOS/nixpkgs/commit/f446d27253311cfd5cf27a2d91f9bd6f71be1919) | `` caddy: 2.6.2 -> 2.6.3 ``                                                 |
| [`ff7add2d`](https://github.com/NixOS/nixpkgs/commit/ff7add2d60ac720d43ce9d7bb1a4a76aafb9d2ac) | `` caddy: add indeednotjames as maintainer ``                               |
| [`1cbf2286`](https://github.com/NixOS/nixpkgs/commit/1cbf2286b9e8abf123b4a0f2de573cda547b3ad1) | `` python310Packages.cmaes: init at 0.9.1 ``                                |
| [`44191eca`](https://github.com/NixOS/nixpkgs/commit/44191eca5f5c7477b30cb1c7ba5d1afa8732d7bb) | `` pantheon.appcenter: 7.1.0 -> 7.2.0 ``                                    |
| [`9ab88547`](https://github.com/NixOS/nixpkgs/commit/9ab885479e1b9a2cda467ef182385f789f7e1df7) | `` python310Packages.argh: 0.26.2 -> 0.27.1 ``                              |
| [`906c97b3`](https://github.com/NixOS/nixpkgs/commit/906c97b357759ef39033355fd38caeae20fe69a1) | `` python310Packages.trove-classifiers: 2023.1.20 -> 2023.2.8 ``            |
| [`bbdc8e54`](https://github.com/NixOS/nixpkgs/commit/bbdc8e5414f4b18228fce8cbc80539df8fae5954) | `` abcmidi: 2023.01.21 -> 2023.02.07 ``                                     |
| [`e5e0fa3e`](https://github.com/NixOS/nixpkgs/commit/e5e0fa3ef8ec7c32256f76c73c5d8856a7ec3128) | `` python310Packages.robotstatuschecker: 2.1.0 -> 3.0.0 ``                  |
| [`4b6fe282`](https://github.com/NixOS/nixpkgs/commit/4b6fe282c437da14e135ed46c9b2c14c59d96bed) | `` ruff: 0.0.243 -> 0.0.244 ``                                              |
| [`f4d975f3`](https://github.com/NixOS/nixpkgs/commit/f4d975f357ac3e8162622242db0df44895e2b13a) | `` automatic-timezoned: 1.0.61 -> 1.0.62 ``                                 |
| [`530af6b5`](https://github.com/NixOS/nixpkgs/commit/530af6b5b99b2dbdb039c55092ad118a8d35d115) | `` python3Packages.riscof: init at 1.25.2 ``                                |
| [`6f2d5c58`](https://github.com/NixOS/nixpkgs/commit/6f2d5c582b489efa2b52585fe8754e18b3fe1ee5) | `` sail-riscv-*: init at 0.5 ``                                             |
| [`fc508076`](https://github.com/NixOS/nixpkgs/commit/fc50807657bc1820e2a857f5d67c97a273523a5e) | `` ocamlPackages.sail: init at 0.15 ``                                      |
| [`8205f9ac`](https://github.com/NixOS/nixpkgs/commit/8205f9ac2f9153b1622c393628f8833d99637b1c) | `` ocamlPackages.linksem: init at 0.8 ``                                    |
| [`7ff1dcdf`](https://github.com/NixOS/nixpkgs/commit/7ff1dcdf744a3bb7c41780b3902b25ba15cb1416) | `` ocamlPackages.lem: init at 2022-12-10 ``                                 |
| [`dcf4487f`](https://github.com/NixOS/nixpkgs/commit/dcf4487fc79fcdc1b3adba6e9b3d70eeec27f527) | `` python310Packages.xsdata: use docformatter 1.5.1 ``                      |
| [`5a2b689d`](https://github.com/NixOS/nixpkgs/commit/5a2b689d2549748e6b4c4e863788d8b5d4ffe7f2) | `` python310Packages.docformatter: 1.5.0 -> 1.5.1 ``                        |
| [`bc58d744`](https://github.com/NixOS/nixpkgs/commit/bc58d7444f846e4452487cc7dd361e79617a0bab) | `` chromiumDev: 111.0.5563.8 -> 111.0.5563.19 ``                            |
| [`f12ae788`](https://github.com/NixOS/nixpkgs/commit/f12ae788334fbcc6a018f0504a04e985acb9338f) | `` python3Packages.apache-beam: skip failing tests ``                       |
| [`b2336a91`](https://github.com/NixOS/nixpkgs/commit/b2336a910aba837f1a17a52fa14af1321c2ca2bc) | `` python3Packages.apache-beam: relaxing pyarrow dep no longer necessary `` |
| [`2829e696`](https://github.com/NixOS/nixpkgs/commit/2829e696e283ac4cef88edd717e1df2c73512c6f) | `` ffuf: 1.5.0 -> 2.0.0 ``                                                  |
| [`f9b7e743`](https://github.com/NixOS/nixpkgs/commit/f9b7e743fe715262064ac9e838891d6ee9ef32c2) | `` python3Packages.apache-beam: 2.43.0 -> 2.44.0 ``                         |
| [`f0c8b8d4`](https://github.com/NixOS/nixpkgs/commit/f0c8b8d469257763416b4c9abf0da14942c66bfb) | `` python310Packages.pyorthanc: init at 1.11.4 ``                           |
| [`0500164f`](https://github.com/NixOS/nixpkgs/commit/0500164fcff779435f75d698f9a7a1fd4e495397) | `` iaito: 5.8.0 -> 5.8.2 ``                                                 |
| [`ea41744b`](https://github.com/NixOS/nixpkgs/commit/ea41744b5ca62b7f1e9dfc38e9b69735fc3b5416) | `` ttdl: init at 3.6.3 ``                                                   |
| [`fc36e212`](https://github.com/NixOS/nixpkgs/commit/fc36e212fbe0e58020ef3300fb0cd89d1514ddf8) | `` bliss: build on aarch64-linux ``                                         |
| [`b9f5ac39`](https://github.com/NixOS/nixpkgs/commit/b9f5ac39ee000744cdc91bb694fd254e6c6f959d) | `` kubernetes-helm: 3.11.0 -> 3.11.1 ``                                     |
| [`8b343f63`](https://github.com/NixOS/nixpkgs/commit/8b343f6355d298c41b6d59a3895e01f20e5cf0b5) | `` snappymail: 2.25.2 -> 2.25.3 ``                                          |
| [`dac585b9`](https://github.com/NixOS/nixpkgs/commit/dac585b9b7d360a34c7da9e5a471009b7b7d5609) | `` xmrig: 6.18.1 -> 6.19.0 ``                                               |
| [`4d81d715`](https://github.com/NixOS/nixpkgs/commit/4d81d715159697dc2c4f7c31793c869ffce06d56) | `` texstudio: 4.4.1 -> 4.5.1 ``                                             |
| [`ebc58683`](https://github.com/NixOS/nixpkgs/commit/ebc58683192cef317d556a7d24366ba3365adc4f) | `` moosefs: 3.0.116 -> 3.0.117 ``                                           |
| [`9a5395c4`](https://github.com/NixOS/nixpkgs/commit/9a5395c4769d5b2faf0debd361af9d7fad6cc6a1) | `` zint: 2.11.1 -> 2.12.0 ``                                                |
| [`17970a6a`](https://github.com/NixOS/nixpkgs/commit/17970a6ad96b117589e9514fd9b6fea0152988d6) | `` oxker: 0.2.1 -> 0.2.3 ``                                                 |
| [`f4a93aa8`](https://github.com/NixOS/nixpkgs/commit/f4a93aa86fb3cccf91de7831b7a49707674d770f) | `` gfold: 4.2.0 -> 4.3.0 ``                                                 |
| [`9599df6f`](https://github.com/NixOS/nixpkgs/commit/9599df6f37dbd80ea66b00dac4ce5d1decf06ee6) | `` resvg: 0.28.0 -> 0.29.0 ``                                               |
| [`e02fd871`](https://github.com/NixOS/nixpkgs/commit/e02fd871e26f143cd29cb1414d3377690a975e53) | `` civo: 1.0.47 -> 1.0.48 ``                                                |
| [`4f5c1ae4`](https://github.com/NixOS/nixpkgs/commit/4f5c1ae47af660512f487ee04af7d62299db91c3) | `` gss: 1.0.3 -> 1.0.4 ``                                                   |
| [`16117b1b`](https://github.com/NixOS/nixpkgs/commit/16117b1b2dbf556561bedb640afad8b3e8aa39e3) | `` kubernetes-controller-tools: 0.11.2 -> 0.11.3 ``                         |
| [`3be23b1e`](https://github.com/NixOS/nixpkgs/commit/3be23b1e13c85396a48685be1ad696a1633325c3) | `` brave: 1.47.186 -> 1.48.158 ``                                           |
| [`01a0a019`](https://github.com/NixOS/nixpkgs/commit/01a0a0199b3f0534d1195a5d26c0c975c509caf5) | `` arkade: 0.8.60 -> 0.8.62 ``                                              |
| [`6b9583e5`](https://github.com/NixOS/nixpkgs/commit/6b9583e5e121b26468d880bdb65302a9172fc041) | `` nixos/systemd-coredump: fix group id ``                                  |
| [`a0ca3075`](https://github.com/NixOS/nixpkgs/commit/a0ca307578ac07c0d7df4812c151875efe654a18) | `` go-mockery: 2.16.0 -> 2.18.0 ``                                          |
| [`561e6f59`](https://github.com/NixOS/nixpkgs/commit/561e6f59cbf7db49811958bb0904543a1d862139) | `` pgmetrics: 1.14.0 -> 1.14.1 ``                                           |
| [`dfd3e6e1`](https://github.com/NixOS/nixpkgs/commit/dfd3e6e1e56043ede66463aceb2e9c3bffdcb537) | `` home-assistant: 2022.2.2 -> 2022.2.3 ``                                  |
| [`c1c48c02`](https://github.com/NixOS/nixpkgs/commit/c1c48c028975dca7d88f70841760b3d26c12c896) | `` python310Packages.pyrainbird: 1.1.1 -> 2.0.0 ``                          |
| [`acf02f40`](https://github.com/NixOS/nixpkgs/commit/acf02f40d83d2bf5de4c60c13e55c2975cf68404) | `` python310Packages.jaraco-abode: 3.2.1 -> 3.3.0 ``                        |
| [`9a11fad3`](https://github.com/NixOS/nixpkgs/commit/9a11fad34fa16831beae989e3255b0adb3ef2ec6) | `` python310Packages.inkbird-ble: 0.5.5 -> 0.5.6 ``                         |
| [`d884d3d4`](https://github.com/NixOS/nixpkgs/commit/d884d3d4cac0be623c0d2bfedde56702f9e7ea62) | `` nali: 0.7.0 -> 0.7.1 ``                                                  |
| [`f5b9d5d0`](https://github.com/NixOS/nixpkgs/commit/f5b9d5d0e210351d6023acf81ff0497cb2e9f6eb) | `` pulumi-bin: 3.53.1 -> 3.54.0 ``                                          |
| [`b88f8c97`](https://github.com/NixOS/nixpkgs/commit/b88f8c9713b7083ea06d6e4b5c45b5fa5f0b5dbe) | `` python310Packages.py-synologydsm-api: 2.1.2 -> 2.1.4 ``                  |
| [`5494775b`](https://github.com/NixOS/nixpkgs/commit/5494775bb3b134b1cd3ae7e92b7e8e50ba4efaf0) | `` python310Packages.pyisy: 3.1.11 -> 3.1.13 ``                             |
| [`ea4693ba`](https://github.com/NixOS/nixpkgs/commit/ea4693ba9157746f64f3e8ef28b232998c2556b0) | `` git-machete: 3.14.3 -> 3.15.0 ``                                         |
| [`7da5418f`](https://github.com/NixOS/nixpkgs/commit/7da5418f1d20665113c1530f3bb72a65ca008ac7) | `` torq: build frontend ``                                                  |
| [`a8ffe916`](https://github.com/NixOS/nixpkgs/commit/a8ffe9162466325733a0bc0ff1b0e22cbbfb0b80) | `` python310Packages.browser-cookie3: 0.16.5 -> 0.17.0 ``                   |
| [`1c664bef`](https://github.com/NixOS/nixpkgs/commit/1c664befd4c198db2c6993f8afde709024bcec6d) | `` nixos/envfs: add extraFallbackPathCommands options ``                    |
| [`79553c2d`](https://github.com/NixOS/nixpkgs/commit/79553c2d0d56992f304b9ed411f16c509f1d0cc3) | `` v2ray-geoip: 202302020047 -> 202302081046 ``                             |
| [`cc08236d`](https://github.com/NixOS/nixpkgs/commit/cc08236d06867feba6f382ca30910fff8c27bfe0) | `` oh-my-posh: 13.8.0 -> 14.2.3 ``                                          |
| [`5e9d0077`](https://github.com/NixOS/nixpkgs/commit/5e9d0077cdf4f6a360b27d17a3c3d5ebc127c44b) | `` python310Packages.azure-mgmt-datalake-store: 0.5.0 -> 1.0.0 ``           |
| [`702e1fc7`](https://github.com/NixOS/nixpkgs/commit/702e1fc743cfe66f9ccb38ca7bfcc1f5aae8279b) | `` nixos-render-docs: add all-features manpage renderer test ``             |
| [`78052a22`](https://github.com/NixOS/nixpkgs/commit/78052a22cbd1d33a88b1a46461b3b7f7ad41ac63) | `` nixos-render-docs: track links in manpages ``                            |
| [`3c7fd940`](https://github.com/NixOS/nixpkgs/commit/3c7fd940ba22a735cfc267bb641e0bce4e23677e) | `` nixos-render-docs: indent and embolden list item heads in manpages ``    |
| [`f47adfcb`](https://github.com/NixOS/nixpkgs/commit/f47adfcb6f8bdb617c78579d51bc3e0dc25ac74a) | `` nixos-render-docs: make manpage deflists a little nicer ``               |
| [`1e4bafdb`](https://github.com/NixOS/nixpkgs/commit/1e4bafdbc5dbdad9542be6aa42febb7766dea918) | `` nixos-render-docs: style file literals in manpages ``                    |
| [`29252d14`](https://github.com/NixOS/nixpkgs/commit/29252d1477dd224e88af915ff7e13cadd52838fb) | `` nixos-render-docs: add quotes to inline code in manpages ``              |
| [`f33e360f`](https://github.com/NixOS/nixpkgs/commit/f33e360f675949751c85bec50eb692ae1b74b8b3) | `` nixos-render-docs: remove the ... escape in manpages ``                  |
| [`3a327423`](https://github.com/NixOS/nixpkgs/commit/3a3274231ef6b8febbf72b9e5fb04dc0b59aeaa2) | `` nixos-render-docs: always render links bold in manpages ``               |
| [`5c5dadd3`](https://github.com/NixOS/nixpkgs/commit/5c5dadd382c983cc626c930fc14df798f957d72c) | `` nixos-render-docs: support compact lists in manpages ``                  |
| [`10a4f0da`](https://github.com/NixOS/nixpkgs/commit/10a4f0daca909e580df687426ced8e0d39056297) | `` nixos-render-docs: add options manpage converter ``                      |
| [`56f1d99b`](https://github.com/NixOS/nixpkgs/commit/56f1d99b161a8665b7df57984af5f76dc842be9b) | `` nixos-render-docs: factor out sorting of options list ``                 |
| [`b2a5b4d7`](https://github.com/NixOS/nixpkgs/commit/b2a5b4d7899138eb9cc8af31fc1f296af582a4ce) | `` nixos-render-docs: move list-is-compact attr to meta ``                  |
| [`09411102`](https://github.com/NixOS/nixpkgs/commit/09411102f60e241a65d5ce708d369fdfcad3e977) | `` nixos-render-docs: add option block separators ``                        |
| [`32136b1b`](https://github.com/NixOS/nixpkgs/commit/32136b1b01e1766737884fe48d8b0b035e0cb994) | `` nixos-render-docs: don't render empty descriptions at all ``             |
| [`11daebd2`](https://github.com/NixOS/nixpkgs/commit/11daebd2d92e972ead541cdfa04afc8f191379cb) | `` nixos-render-docs: add block and inline joiners ``                       |
| [`5a525598`](https://github.com/NixOS/nixpkgs/commit/5a5255983bcd9fdb95697f93f21a0582d0dde4a0) | `` nixos-render-docs: calculate list end indices ``                         |
| [`8fe19590`](https://github.com/NixOS/nixpkgs/commit/8fe19590c36dc4c5a9409c55ec466321203d5c54) | `` nixos/make-options-doc: fix related packages link label ``               |
| [`bf4c0c19`](https://github.com/NixOS/nixpkgs/commit/bf4c0c19002fc2fa88d64b585497ae5a1c36287f) | `` nixos/*: remove trailing period in mkEnableOptions ``                    |
| [`2f9d71af`](https://github.com/NixOS/nixpkgs/commit/2f9d71afdb892f399d78d454d3de8188caf259fa) | `` nixos/x11: fix some docs links ``                                        |
| [`edccae73`](https://github.com/NixOS/nixpkgs/commit/edccae739ac95d97b29bbedb164241a3d0c956a7) | `` nixos-render-docs: add a test for running mypy ``                        |
| [`0e52a562`](https://github.com/NixOS/nixpkgs/commit/0e52a5627ecfeaf036323cfa8c8e590c7fb105ea) | `` python310Packages.deep-translator: relicense to asl20 ``                 |
| [`7932c9c0`](https://github.com/NixOS/nixpkgs/commit/7932c9c05598aff843295215c53e2c54c4e0419f) | `` python310Packages.pontos: 23.2.0 -> 23.2.4 ``                            |
| [`85dac16f`](https://github.com/NixOS/nixpkgs/commit/85dac16ffb10ba0f848c056c54d855d6e0f53cdd) | `` kio-admin: add meta ``                                                   |
| [`162dcb9b`](https://github.com/NixOS/nixpkgs/commit/162dcb9b00ca13b22ffa11328f0b19b52e550753) | `` toppler: pin SDL2_image to 2.0.5 ``                                      |
| [`9c30624f`](https://github.com/NixOS/nixpkgs/commit/9c30624f1a8aee562ebf4b6d62f0948b4c7db5f2) | `` python310Packages.pygame: pin SDL2_image to 2.0.5 ``                     |
| [`ba0b9791`](https://github.com/NixOS/nixpkgs/commit/ba0b9791c0f26ac4de79840a431c581bf3c70fc4) | `` mvapich: 2.3.6 -> 2.3.7 ``                                               |
| [`655b5be0`](https://github.com/NixOS/nixpkgs/commit/655b5be0ceafea054bda74d63a3fdfef6c9d890f) | `` python310Packages.requests-aws4auth: 1.2.1 -> 1.2.2 ``                   |
| [`2379d34a`](https://github.com/NixOS/nixpkgs/commit/2379d34aa028ea79f0e7ce805669007650b57aa3) | `` gromacs: 2022.4 -> 2023 ``                                               |
| [`dbe669d8`](https://github.com/NixOS/nixpkgs/commit/dbe669d8fb8be4d1a5262a624cd368a6279e93eb) | `` SDL2_image: 2.0.5 -> 2.6.3 ``                                            |
| [`4d89637b`](https://github.com/NixOS/nixpkgs/commit/4d89637b5d8870c62032c5484c0e0552e2a45669) | `` python3Packages.watchfiles: fix build on Darwin ``                       |
| [`b4b4d8db`](https://github.com/NixOS/nixpkgs/commit/b4b4d8db8d43329c23b7f92348683c8ac50c314c) | `` exploitdb: 2022-11-22 -> 2023-02-03 ``                                   |
| [`9347d7d2`](https://github.com/NixOS/nixpkgs/commit/9347d7d26588710d7c8277cb97bf394b67d7f7b2) | `` polymake: 4.8 -> 4.9 ``                                                  |
| [`84d8894b`](https://github.com/NixOS/nixpkgs/commit/84d8894b2b9de245ffa3f14fafb935cbe6c755de) | `` yubico-piv-tool: 2.3.0 -> 2.3.1 ``                                       |
| [`3c178e21`](https://github.com/NixOS/nixpkgs/commit/3c178e21d78fe8053e88c78b11d5147fb4ea1a56) | `` hyperrogue: 12.1h -> 12.1i ``                                            |
| [`4db65d13`](https://github.com/NixOS/nixpkgs/commit/4db65d131e0d54105bf66475ca584362e5f2104b) | `` fend: 1.1.4 -> 1.1.5 ``                                                  |
| [`ee0eef3c`](https://github.com/NixOS/nixpkgs/commit/ee0eef3c84967939a3a9d9bc9fd2d2a81976b938) | `` quickemu: 4.5 -> 4.6 ``                                                  |
| [`bd09beae`](https://github.com/NixOS/nixpkgs/commit/bd09beae9e9ce65b61fd445c976316ef1df3017a) | `` meep: init at 1.25.0 ``                                                  |
| [`4c45a5f8`](https://github.com/NixOS/nixpkgs/commit/4c45a5f874b50df05ae812afea91e0c7311c5b85) | `` libGDSII: init at 0.21 ``                                                |
| [`09d1372c`](https://github.com/NixOS/nixpkgs/commit/09d1372cb900186ac865132b1ac6f0125c4026fd) | `` harminv: init at 1.4.2 ``                                                |
| [`88b656ca`](https://github.com/NixOS/nixpkgs/commit/88b656ca8acaeaeea315d10ba7627fae97f839e2) | `` python310Packages.screenlogicpy: 0.7.0 -> 0.7.1 ``                       |
| [`d35f5c26`](https://github.com/NixOS/nixpkgs/commit/d35f5c2695ee27e69229b870e74b7fb0c5e976e8) | `` apptainer-overriden-nixos,singularity-overriden-nixos: init ``           |
| [`71a89291`](https://github.com/NixOS/nixpkgs/commit/71a89291ee0643b23b87aba090c885324d30bc45) | `` apptainer, singularity: enable non-FHS --fakeroot support ``             |
| [`50788d2f`](https://github.com/NixOS/nixpkgs/commit/50788d2fb00e79c3f3ef720edbb5218d561c8ce7) | `` apptainer, singularity: fix defaultPath and reflect upstream changes ``  |
| [`9819ff90`](https://github.com/NixOS/nixpkgs/commit/9819ff90674d381007103d90b106837d016a74c2) | `` python310Packages.peaqevcore: 11.1.2 -> 11.2.0 ``                        |
| [`b1e672e6`](https://github.com/NixOS/nixpkgs/commit/b1e672e63943ff0e60b65330e98f8378b3dc597d) | `` python310Packages.aiohomekit: 2.4.6 -> 2.5.0 ``                          |
| [`498a1c28`](https://github.com/NixOS/nixpkgs/commit/498a1c28a0f96318a7d7a917417ae91ff32f9099) | `` python310Packages.angr: 9.2.36 -> 9.2.37 ``                              |
| [`af2d3b2e`](https://github.com/NixOS/nixpkgs/commit/af2d3b2e91c8ea95d6112c6f74f79c111c7c1d35) | `` python310Packages.cle: 9.2.36 -> 9.2.37 ``                               |