### PR TITLE
chore(flake/nixpkgs): `724bfc08` -> `e5530aba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675942811,
-        "narHash": "sha256-/v4Z9mJmADTpXrdIlAjFa1e+gkpIIROR670UVDQFwIw=",
+        "lastModified": 1676110339,
+        "narHash": "sha256-kOS/L8OOL2odpCOM11IevfHxcUeE0vnZUQ74EOiwXcs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "724bfc0892363087709bd3a5a1666296759154b1",
+        "rev": "e5530aba13caff5a4f41713f1265b754dc2abfd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`96c05ed3`](https://github.com/NixOS/nixpkgs/commit/96c05ed392d5f292e24e17926198665a9a61b0db) | `` qbittorrent-nox: fix build on darwin ``                                  |
| [`51f387be`](https://github.com/NixOS/nixpkgs/commit/51f387beffc5cb9a37d2b5cb3d25ea9594e5525e) | `` nushell: fix build on x86_64-darwin ``                                   |
| [`b43835bf`](https://github.com/NixOS/nixpkgs/commit/b43835bff722a86b4fb37f7f278b28d6464d4f2d) | `` python310Packages.huey: use pyproject format ``                          |
| [`e68d888d`](https://github.com/NixOS/nixpkgs/commit/e68d888d5069124bd0f30c164945f54d5cfc6710) | `` python310Packages.huey: add meta.changelog ``                            |
| [`7921b2d4`](https://github.com/NixOS/nixpkgs/commit/7921b2d453891973914f43391013880cdf4d16a5) | `` abcmidi: 2023.02.07 -> 2023.02.08 ``                                     |
| [`60cfeaf5`](https://github.com/NixOS/nixpkgs/commit/60cfeaf546dc97b1f983bf73da8ba100cf57c8a2) | `` oh-my-posh: 14.2.4 -> 14.2.5 ``                                          |
| [`d83d7bd8`](https://github.com/NixOS/nixpkgs/commit/d83d7bd84b83a7d251045fbc32b6c25fbf87f71f) | `` forgejo: 1.18.3-0 -> 1.18.3-1 ``                                         |
| [`ce83955b`](https://github.com/NixOS/nixpkgs/commit/ce83955b9ebf58cf871c1f33af2f6936e9532408) | `` reuse: 1.1.1 -> 1.1.2 ``                                                 |
| [`ff42c8f5`](https://github.com/NixOS/nixpkgs/commit/ff42c8f525bf7623e1e64e8a6c4187a87ff4148e) | `` linkerd: 2.12.3 -> 2.12.4 ``                                             |
| [`84c20a3d`](https://github.com/NixOS/nixpkgs/commit/84c20a3d0c10f663f3d91d192b7ed438436c3681) | `` gcc-arm-embedded-12: support aarch64-darwin ``                           |
| [`acb06289`](https://github.com/NixOS/nixpkgs/commit/acb0628924c0a68537a67b870480ff64a64784df) | `` unciv: 4.4.11 -> 4.4.13-gp ``                                            |
| [`59101f53`](https://github.com/NixOS/nixpkgs/commit/59101f53e21ed7e5db5ab566701936bf426015bc) | `` terraform-providers.tencentcloud: 1.79.8 → 1.79.9 ``                     |
| [`663a1894`](https://github.com/NixOS/nixpkgs/commit/663a1894ee08d94785528376cadbbab060049671) | `` terraform-providers.vultr: 2.12.0 → 2.12.1 ``                            |
| [`b137d166`](https://github.com/NixOS/nixpkgs/commit/b137d166fa8ff4d9b8bd67ad7bbaa688a5575abc) | `` terraform-providers.okta: 3.41.0 → 3.42.0 ``                             |
| [`681319eb`](https://github.com/NixOS/nixpkgs/commit/681319eba7389c2b95037c0606a7b9991be91f69) | `` terraform-providers.equinix: 1.11.1 → 1.12.0 ``                          |
| [`9c4947b5`](https://github.com/NixOS/nixpkgs/commit/9c4947b54a45b2fec445e6335c7ff2566501a201) | `` python310Packages.huey: 2.4.2 -> 2.4.5 ``                                |
| [`d742d614`](https://github.com/NixOS/nixpkgs/commit/d742d614effa92789d6dd18e582728eac1eee0b1) | `` qbittorrent: 4.4.5 -> 4.5.0 ``                                           |
| [`58006feb`](https://github.com/NixOS/nixpkgs/commit/58006feb6fd891dd284ecd65868d0cc0c476fa80) | `` flyway: 9.12.0 -> 9.14.1 ``                                              |
| [`ba795630`](https://github.com/NixOS/nixpkgs/commit/ba7956304ab932264eceac27fa79f4fa748fc905) | `` suricata: 6.0.8 -> 6.0.10 ``                                             |
| [`e44cac10`](https://github.com/NixOS/nixpkgs/commit/e44cac10e95dc9898e8e3bda11ae8f820c161c2a) | `` biodiff: 1.0.4 -> 1.1.0 ``                                               |
| [`97c6b5e6`](https://github.com/NixOS/nixpkgs/commit/97c6b5e65d0f1d592e90e7231d1874bab89e67fd) | `` mdl: 0.11.0 → 0.12.0 ``                                                  |
| [`95cb1a90`](https://github.com/NixOS/nixpkgs/commit/95cb1a90b23e870bf3defccc8eedd4a371614999) | `` python310Packages.pyrogram: 2.0.97 -> 2.0.98 ``                          |
| [`2f431d19`](https://github.com/NixOS/nixpkgs/commit/2f431d194940bcced4469187ee3e031b276f0542) | `` jackett: 0.20.3004 -> 0.20.3017 ``                                       |
| [`2f5623dd`](https://github.com/NixOS/nixpkgs/commit/2f5623dda2c0ada35a86ba0e075f77dcdb3cd6d4) | `` jira-cli-go: fix darwin build ``                                         |
| [`5dd8bf81`](https://github.com/NixOS/nixpkgs/commit/5dd8bf8146d12fd0f0b39bf3481a65742bfb8d1b) | `` kubernetes-helm: fix darwin build ``                                     |
| [`3d23945d`](https://github.com/NixOS/nixpkgs/commit/3d23945d491f2605fa0d3a7699304988cf77b2ed) | `` bun: 0.5.5 -> 0.5.6 ``                                                   |
| [`63a2b227`](https://github.com/NixOS/nixpkgs/commit/63a2b2278f7556cfa092cd1b9429c121168c4693) | `` extra-cmake-modules: use a better homepage ``                            |
| [`0b8e02e7`](https://github.com/NixOS/nixpkgs/commit/0b8e02e744aa8cfa504d516035d4f070895a1621) | `` plasma5Packages.kguiaddons: use a better homepage ``                     |
| [`809c0e97`](https://github.com/NixOS/nixpkgs/commit/809c0e97b661a168d693948174981abfc55eceeb) | `` mdbook: 0.4.25 -> 0.4.26 ``                                              |
| [`54e414a2`](https://github.com/NixOS/nixpkgs/commit/54e414a270badfe03ccf28ebf58897cae849bb11) | `` stylua: 0.16.0 -> 0.16.1 ``                                              |
| [`446187c2`](https://github.com/NixOS/nixpkgs/commit/446187c22c9acd3d15f287c1ab4110f3a25e9366) | `` vimPlugins.nvim-osc52: init at 2023-01-10 ``                             |
| [`13504907`](https://github.com/NixOS/nixpkgs/commit/13504907e0d2a9e3bf9f848ef3574bdae29e3d6b) | `` python310Packages.pytapo: init at 2.9.2 ``                               |
| [`54cb9661`](https://github.com/NixOS/nixpkgs/commit/54cb9661f3b74931695524cf25078c23d9784d02) | `` godot_4: 4.0-beta16 -> 4.0-rc1 & use “hash =” instead of “sha256 =” ``   |
| [`65b9a4a9`](https://github.com/NixOS/nixpkgs/commit/65b9a4a973663069a9d23311cfe94a458c12efa3) | `` afterburn: 5.4.0 -> 5.4.1 ``                                             |
| [`ada4e200`](https://github.com/NixOS/nixpkgs/commit/ada4e200eeac8a341d6b897be7425a4a27bb2f78) | `` zef: 0.15.0 -> 0.16.0 ``                                                 |
| [`7b3bd00a`](https://github.com/NixOS/nixpkgs/commit/7b3bd00a19bd4c6640b81de366dcbd0b2e79038c) | `` flyctl: 0.0.451 -> 0.0.456 ``                                            |
| [`cc1a2322`](https://github.com/NixOS/nixpkgs/commit/cc1a23222b1d5bebe62c0b7a1c88eb7e97b789c4) | `` cudatext: fix gtk2 build ``                                              |
| [`2323698c`](https://github.com/NixOS/nixpkgs/commit/2323698c942ca1d7bd17b673f08235558444c7a4) | `` kubelogin: 0.0.25 -> 0.0.26 ``                                           |
| [`057adb42`](https://github.com/NixOS/nixpkgs/commit/057adb42c7d2edc2d6cf3ea66f8f9ff8e9bfcd9e) | `` otpclient: 2.5.1 -> 3.1.4 ``                                             |
| [`1dad98b0`](https://github.com/NixOS/nixpkgs/commit/1dad98b003f262e3fed3a2878d15a28f898e9780) | `` python310Packages.pymodbus: 3.1.2 -> 3.1.3 ``                            |
| [`cc69e312`](https://github.com/NixOS/nixpkgs/commit/cc69e31283353336028ac3e3e103f713b34d9ee9) | `` mjolnir: fix build on darwin ``                                          |
| [`b07f6071`](https://github.com/NixOS/nixpkgs/commit/b07f6071a37ed751489a1a14d7b0a870691b15a9) | `` python310Packages.oslo-concurrency: 5.0.1 -> 5.1.0 ``                    |
| [`405984ac`](https://github.com/NixOS/nixpkgs/commit/405984ac1329482fd1bab2840fcd7d5be2ffbc26) | `` nixos/onlyoffice: Fix initial permissions for the documentserver data `` |
| [`e10746b7`](https://github.com/NixOS/nixpkgs/commit/e10746b77b07b64f2c901aa38a2652bb49e2a079) | `` tts: 0.10.2 -> 0.11.1 ``                                                 |
| [`736d02b4`](https://github.com/NixOS/nixpkgs/commit/736d02b424f5b831f6840c2a7a681bc0cd78d822) | `` n8n: 0.214.3 -> 0.215.0 ``                                               |
| [`319b4981`](https://github.com/NixOS/nixpkgs/commit/319b4981cfdd4aa5cd5ac4888094a64a0a0abebf) | `` python310Packages.motionblinds: 0.6.15 -> 0.6.16 ``                      |
| [`e1536321`](https://github.com/NixOS/nixpkgs/commit/e15363219e3b19e5425aa14970e72912e3aef839) | `` python310Packages.aiowinreg: 0.0.8 -> 0.0.9 ``                           |
| [`0a598d6e`](https://github.com/NixOS/nixpkgs/commit/0a598d6ea5574d4ddbb35ce1c655304bcc06bed6) | `` doc: add a simpler explanation of dependencies (#213403) ``              |
| [`036be33a`](https://github.com/NixOS/nixpkgs/commit/036be33aa353c634150c989e16b202620c70878a) | `` python310Packages.argh: 0.27.1 -> 0.27.2 ``                              |
| [`a7434576`](https://github.com/NixOS/nixpkgs/commit/a7434576da6951d19668a4ffa967b4a04e02a797) | `` gpt2tc: fix url switching to web.archive.org ``                          |
| [`eab4818c`](https://github.com/NixOS/nixpkgs/commit/eab4818cab203901d72ea8bcbf171e40c98b7194) | `` python310Packages.snowflake-sqlalchemy: 1.4.5 -> 1.4.6 ``                |
| [`7d923076`](https://github.com/NixOS/nixpkgs/commit/7d9230761a4ce8c4c33b0ed4cd4107f3356560bb) | `` rpcs3: add aarch64-linux support ``                                      |
| [`bfa26a07`](https://github.com/NixOS/nixpkgs/commit/bfa26a077b2149e0211ea65e24e8695ba5dc9e32) | `` python310Packages.ansible-lint: 6.12.1 -> 6.12.2 ``                      |
| [`4648012e`](https://github.com/NixOS/nixpkgs/commit/4648012ed8aeddda993d660299a137c52ec9a92f) | `` cargo-zigbuild: 0.15.0 -> 0.16.0 ``                                      |
| [`9f4afc1d`](https://github.com/NixOS/nixpkgs/commit/9f4afc1dcab1b2a294999d90342d0f336e2d541d) | `` jpcre2: init at 10.32.01 ``                                              |
| [`d949f948`](https://github.com/NixOS/nixpkgs/commit/d949f9487527541d6a8e5622a83e0d661a8a0d58) | `` rnm: init at 4.0.9 ``                                                    |
| [`35dd3a52`](https://github.com/NixOS/nixpkgs/commit/35dd3a523a4986315f4c1485c1e0b06e50a3e846) | `` rocm-comgr: 5.4.2 -> 5.4.3 ``                                            |
| [`b1e0eafe`](https://github.com/NixOS/nixpkgs/commit/b1e0eafe47d87f6a43eabe1f7539d04a3332a795) | `` python310Packages.lupupy: 0.2.7 -> 0.2.8 ``                              |
| [`61219651`](https://github.com/NixOS/nixpkgs/commit/61219651fe0cdc5f3d06b98de41feaca8acf325c) | `` nixos/udisks2: add mountOnMedia option ``                                |
| [`a8543f1b`](https://github.com/NixOS/nixpkgs/commit/a8543f1b20cc98548d9e7b8e91a033015b05690b) | `` rocminfo: 5.4.2 -> 5.4.3 ``                                              |
| [`05bbf5e5`](https://github.com/NixOS/nixpkgs/commit/05bbf5e5834556c8ffd1c26d56d864c63aca10e0) | `` nss_latest: 3.87 -> 3.88.1 ``                                            |
| [`47001986`](https://github.com/NixOS/nixpkgs/commit/4700198654affcca0a76915e083b857e7e605cf5) | `` nixos/systemd-repart: init ``                                            |
| [`80c5fe46`](https://github.com/NixOS/nixpkgs/commit/80c5fe46e8457841d27c80651788eb2dad302942) | `` python310Packages.oci: 2.90.4 -> 2.91.0 ``                               |
| [`98e4c1f8`](https://github.com/NixOS/nixpkgs/commit/98e4c1f8cf7af271edecc60f0b5f7a8236068d49) | `` linux/hardened/patches/6.1: 6.1.8-hardened1 -> 6.1.10-hardened1 ``       |
| [`85947aa9`](https://github.com/NixOS/nixpkgs/commit/85947aa9dd7c1e20cc8ec590f0d8681054e3ae8d) | `` linux/hardened/patches/5.4: 5.4.230-hardened1 -> 5.4.231-hardened1 ``    |
| [`2acd1ca6`](https://github.com/NixOS/nixpkgs/commit/2acd1ca6dc84e44919a6e73ae0bd154a91dac8d1) | `` linux/hardened/patches/5.15: 5.15.91-hardened1 -> 5.15.92-hardened1 ``   |
| [`b1033b4a`](https://github.com/NixOS/nixpkgs/commit/b1033b4ae4c6fc9dfa315befa3434c78fce6aa69) | `` linux/hardened/patches/5.10: 5.10.166-hardened1 -> 5.10.167-hardened1 `` |
| [`aa27dcf0`](https://github.com/NixOS/nixpkgs/commit/aa27dcf0cbb23dd6193fe8fb7f6428e26f1861d0) | `` linux/hardened/patches/4.19: 4.19.271-hardened1 -> 4.19.272-hardened1 `` |
| [`e094af5a`](https://github.com/NixOS/nixpkgs/commit/e094af5a4c89a510d30b393e9984271d5f620481) | `` linux/hardened/patches/4.14: 4.14.304-hardened1 -> 4.14.305-hardened1 `` |
| [`b43216c9`](https://github.com/NixOS/nixpkgs/commit/b43216c9230c8f0eb69f343032206f7bd4a18a07) | `` linux_latest-libre: 19044 -> 19049 ``                                    |
| [`91bf1a86`](https://github.com/NixOS/nixpkgs/commit/91bf1a86ceb1165845822f1754038d663f136457) | `` linux-rt_5_15: 5.15.86-rt56 -> 5.15.92-rt57 ``                           |
| [`e684fcd4`](https://github.com/NixOS/nixpkgs/commit/e684fcd4842991c1dc29cb15b8ef0edc67d342a9) | `` linux: 6.1.10 -> 6.1.11 ``                                               |
| [`2b45841a`](https://github.com/NixOS/nixpkgs/commit/2b45841a0cfeacbcbba0c820014f7aed7119bbdb) | `` linux: 5.15.92 -> 5.15.93 ``                                             |
| [`3364d76c`](https://github.com/NixOS/nixpkgs/commit/3364d76c0b4df219ddbdc13bb6e84af78d67c496) | `` circt: fix build with non clang stdenv ``                                |
| [`d7700c6c`](https://github.com/NixOS/nixpkgs/commit/d7700c6c6daa9f6aa1b5d10b7cd83cccf6a98ed8) | `` python310Packages.stripe: 5.1.0 -> 5.1.1 ``                              |
| [`b6c2a01e`](https://github.com/NixOS/nixpkgs/commit/b6c2a01ecd3be397983c4005fda0f5ec8204f318) | `` list-git-tags: fix for tags with / in the tag name ``                    |
| [`2845cb66`](https://github.com/NixOS/nixpkgs/commit/2845cb6608269c0e899fd0e6556f602971f0eeef) | `` python310Packages.pontos: 23.2.4 -> 23.2.8 ``                            |
| [`faab5d47`](https://github.com/NixOS/nixpkgs/commit/faab5d47a896ef3c40fa678588607b107cac0dc5) | `` logseq: 0.8.16 -> 0.8.17 ``                                              |
| [`bf8cb6a3`](https://github.com/NixOS/nixpkgs/commit/bf8cb6a3d4bfb32543982530226eb05ea2f07f09) | `` n8n: 0.214.2 -> 0.214.3 ``                                               |
| [`e21542bd`](https://github.com/NixOS/nixpkgs/commit/e21542bd7e236d6f20d3b15c4a65a4ea1d78c53d) | `` nextcloud-client: 3.7.1 -> 3.7.3 ``                                      |
| [`dd44da47`](https://github.com/NixOS/nixpkgs/commit/dd44da475464fa3e2a1f958b1b5389ee29304a2a) | `` commitizen: 2.39.1 -> 2.41.0 ``                                          |
| [`cb886816`](https://github.com/NixOS/nixpkgs/commit/cb88681631e57de52828dfccc8e9092801b70f62) | `` pre-commit: fix build on aarch64-linux ``                                |
| [`c87fde0d`](https://github.com/NixOS/nixpkgs/commit/c87fde0d719893dcc9d4906d044834cce42b363b) | `` denaro: 2023.1.1 -> 2023.2.0 ``                                          |
| [`06972ea1`](https://github.com/NixOS/nixpkgs/commit/06972ea1fe235d6214cf5f4316e3d24a3c36a73b) | `` nixos/nitter: add replaceReddit option ``                                |
| [`a4bfed4f`](https://github.com/NixOS/nixpkgs/commit/a4bfed4f6d756bfc40ca965387098f5cbdfb1d5c) | `` fheroes2: 1.0.0 -> 1.0.1 ``                                              |
| [`a344af4c`](https://github.com/NixOS/nixpkgs/commit/a344af4c2404f701da6e29792478b2688b22f2fa) | `` php: add `meta.mainProgram` ``                                           |
| [`be8dcd6b`](https://github.com/NixOS/nixpkgs/commit/be8dcd6bbf07d90568d36caa57b77be50418f3ee) | `` emacs.pkgs.melpaStablepackages.epkg: Add sqlite as dependency ``         |
| [`eb8d94f1`](https://github.com/NixOS/nixpkgs/commit/eb8d94f194e1fa25df608d8307a22ee339ac96af) | `` gotrue-supabase: 2.44.0 -> 2.47.0 ``                                     |
| [`d82a1178`](https://github.com/NixOS/nixpkgs/commit/d82a11785893f1756c835322458c690961c41895) | `` python310Packages.trimesh: 3.18.3 -> 3.19.3 ``                           |
| [`15f8fd53`](https://github.com/NixOS/nixpkgs/commit/15f8fd53dd3d2eccc7aa6157c19009ebdb974318) | `` rocm-thunk: 5.4.2 -> 5.4.3 ``                                            |
| [`d041641b`](https://github.com/NixOS/nixpkgs/commit/d041641b1abc901191947cd9d7676cd803ccd00b) | `` nixos/manual: remove md-to-db ``                                         |
| [`652a283e`](https://github.com/NixOS/nixpkgs/commit/652a283e51d57ed294cb07774ebf7b95b1a7e59c) | `` nixos-render-docs: render manual chapters during manual build ``         |
| [`67917ac1`](https://github.com/NixOS/nixpkgs/commit/67917ac102507cde972131a03779d78980fb96c4) | `` nixos-render-docs: rename manual docbook converter to docbook-section `` |
| [`b59b0230`](https://github.com/NixOS/nixpkgs/commit/b59b0230ae1e9a7707ba03955e4bbe068da01cd9) | `` nixos-render-docs: add example blocks ``                                 |
| [`bb6526e0`](https://github.com/NixOS/nixpkgs/commit/bb6526e0de3d2d5da24218827b43d867dae3752d) | `` nixos-render-docs: add generic attributed-block parsing ``               |
| [`36b0f53f`](https://github.com/NixOS/nixpkgs/commit/36b0f53f85c639f6c0c0948b0fe34528df1e29f1) | `` nixos-render-docs: promote compact-list attrs to core rule ``            |
| [`6cd36887`](https://github.com/NixOS/nixpkgs/commit/6cd368870ba596daf09536b1d04ed68cd0a4bbca) | `` nixos-render-docs: allow dots in heading ids ``                          |
| [`fd9f6c75`](https://github.com/NixOS/nixpkgs/commit/fd9f6c75012355a24c628f6f50e6486acf5c625f) | `` nixos-render-docs: promote heading id extraction to a core rule ``       |
| [`4b06b821`](https://github.com/NixOS/nixpkgs/commit/4b06b8213047c90965abe5f247dc8dbedb26a17b) | `` nixos-render-docs: add the .keycap class ``                              |
| [`67086639`](https://github.com/NixOS/nixpkgs/commit/67086639e086a6766fcde8bfda8a9be6f2b6b8d9) | `` nixos-render-docs: add support for full attributed spans ``              |
| [`1c9f55ec`](https://github.com/NixOS/nixpkgs/commit/1c9f55ec640741fb8d4484c09802cd02636e67bb) | `` nixos/manual: convert <kbd> elements to bracketed spans ``               |
| [`65d749c8`](https://github.com/NixOS/nixpkgs/commit/65d749c80b8d868a2c1e6aad7e431917a80fe99a) | `` nixos/manual: inline the single footnote ``                              |
| [`2ad93ab1`](https://github.com/NixOS/nixpkgs/commit/2ad93ab199efb85842bf29187f18bf9538012846) | `` nixos/manual: remove remaining docbook tags ``                           |
| [`bb34d5d6`](https://github.com/NixOS/nixpkgs/commit/bb34d5d6d493ac1b032e836cecfc70aea4334502) | `` nixos/manual: replace ids on blocks with inline anchors ``               |
| [`2e3d9e8d`](https://github.com/NixOS/nixpkgs/commit/2e3d9e8d74fdcbcea364923f0ba6537774894865) | `` nixos/manual: remove .unnumbered section attributes ``                   |
| [`a15d7335`](https://github.com/NixOS/nixpkgs/commit/a15d7335a55e3a2726a2962767b0927367db1ebc) | `` nixos/manual: remove .title fenced divs ``                               |
| [`81636513`](https://github.com/NixOS/nixpkgs/commit/816365133831b90b0f5c883e4a1b43fdeb2db054) | `` nixos/manual: fix option-declarations sections ``                        |
| [`ba4bcdc5`](https://github.com/NixOS/nixpkgs/commit/ba4bcdc5e4999c5657063399f76dedf5c84fa56e) | `` nixos/manual: remove some newlines from deflists ``                      |
| [`861ebec7`](https://github.com/NixOS/nixpkgs/commit/861ebec769dd0b05bff1a36e0fb5b1e06f9a5bf8) | `` nixos/manual: don't use multi-definitions in installer chapter ``        |
| [`70983153`](https://github.com/NixOS/nixpkgs/commit/70983153422d53f303c0d94cb76dd565f056d0bf) | `` nixos/manual: delete disabled xincludes ``                               |
| [`f1e888a5`](https://github.com/NixOS/nixpkgs/commit/f1e888a53c6dfdb9ecdbebf0eb4178bb2f935931) | `` nixos/manual: moving contributing chapter toc entry ``                   |
| [`10f2c3ca`](https://github.com/NixOS/nixpkgs/commit/10f2c3cacfb713f460623aa4fff0e90cafb91b66) | `` nixos/manual: remove sources input from manpages drv ``                  |
| [`65b4c3de`](https://github.com/NixOS/nixpkgs/commit/65b4c3de4d55ca45a56da90adf878f344e367aed) | `` terraform-providers.pagerduty: 2.9.3 → 2.10.2 ``                         |
| [`8395006c`](https://github.com/NixOS/nixpkgs/commit/8395006cdfaa187b8e555ca98990b855bdc0f869) | `` terraform-providers.ovh: 0.26.0 → 0.27.0 ``                              |
| [`4a1afe03`](https://github.com/NixOS/nixpkgs/commit/4a1afe0365c23ae7975d47f156c983fc95fe0bdb) | `` terraform-providers.aws: 4.53.0 → 4.54.0 ``                              |
| [`3b683a98`](https://github.com/NixOS/nixpkgs/commit/3b683a98d7bc69cbd773f7b57b0a350d13462d51) | `` terraform-providers.opentelekomcloud: 1.32.3 → 1.33.0 ``                 |
| [`d052d4b9`](https://github.com/NixOS/nixpkgs/commit/d052d4b9301262bde1cd65f6f63dd50863b16ebb) | `` terraform-providers.datadog: 3.20.0 → 3.21.0 ``                          |
| [`601c8363`](https://github.com/NixOS/nixpkgs/commit/601c8363a02a12e3ecc0e49e3e00e602ec25f1a3) | `` terraform-providers.azurerm: 3.42.0 → 3.43.0 ``                          |