### PR TITLE
chore(flake/pre-commit-hooks): `ab608394` -> `15f2da96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -219,11 +219,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1675688762,
-        "narHash": "sha256-oit/SxMk0B380ASuztBGQLe8TttO1GJiXF8aZY9AYEc=",
+        "lastModified": 1676233402,
+        "narHash": "sha256-43JNeMD1g4skb5xhq4w6atlIHe7Fb0UOgVNSsif1RVU=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ab608394886fb04b8a5df3cb0bab2598400e3634",
+        "rev": "15f2da96967d4c828ae678af50f75214372fd3ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                         |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`2df88654`](https://github.com/cachix/pre-commit-hooks.nix/commit/2df88654ab016e36fbe99018dc2768a2256cfff5) | `` chore(deps): bump cachix/install-nix-action from 18 to 19 `` |
| [`dc1c6013`](https://github.com/cachix/pre-commit-hooks.nix/commit/dc1c60138d190fecb08e306dda19ae1851194ba0) | `` Typo ``                                                      |
| [`4a7e21d5`](https://github.com/cachix/pre-commit-hooks.nix/commit/4a7e21d5a9fa7a4a5fc4c13d8dfcbaefccbea147) | `` Add a `dune/opam sync` hook ``                               |
| [`9c637c9f`](https://github.com/cachix/pre-commit-hooks.nix/commit/9c637c9fe4d993c0ad77fa9658826273368140c6) | `` Add an `ocp-indent` hook ``                                  |
| [`57dd8898`](https://github.com/cachix/pre-commit-hooks.nix/commit/57dd88987b6b78a5013b7956fdcfc866ba69758b) | `` Mention `opam-lint` hook in README ``                        |
| [`ee2ee47b`](https://github.com/cachix/pre-commit-hooks.nix/commit/ee2ee47bd77b98576ecea31c528d385c7a377ea1) | `` Add `opam lint` hook ``                                      |