### PR TITLE
chore(flake/pre-commit-hooks): `15f2da96` -> `15830770`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -219,11 +219,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1676233402,
-        "narHash": "sha256-43JNeMD1g4skb5xhq4w6atlIHe7Fb0UOgVNSsif1RVU=",
+        "lastModified": 1676279938,
+        "narHash": "sha256-RDyvVdituVQQZtGA7DNaJruJLDz/pfkREpUcI4ZQvsk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "15f2da96967d4c828ae678af50f75214372fd3ce",
+        "rev": "1583077009b6ef4236d1899c0f43cf1ce1db8085",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                    |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
| [`d3b49e72`](https://github.com/cachix/pre-commit-hooks.nix/commit/d3b49e724549b7a83ae06d37f60a43998f02f453) | `` Add LaTeX pre-commit hooks to README `` |
| [`1e29fe23`](https://github.com/cachix/pre-commit-hooks.nix/commit/1e29fe23a76ccc3a54dcc7526127992737c7c6b2) | `` Add luacheck to README ``               |
| [`6727e1dd`](https://github.com/cachix/pre-commit-hooks.nix/commit/6727e1dd751125a59a60dd017f2649aa497c585c) | `` Add taplo fmt ``                        |