### PR TITLE
chore(flake/nixpkgs): `e5530aba` -> `d917136f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676110339,
-        "narHash": "sha256-kOS/L8OOL2odpCOM11IevfHxcUeE0vnZUQ74EOiwXcs=",
+        "lastModified": 1676202775,
+        "narHash": "sha256-gV/RnfVZkGLHn+5rmX2GSh5aquVHpWOJw1cnpEV03tQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e5530aba13caff5a4f41713f1265b754dc2abfd8",
+        "rev": "d917136f550a8c36efb1724390c7245105f79023",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`0c63aa16`](https://github.com/NixOS/nixpkgs/commit/0c63aa163021755cd59262db4cf2b2348d85cf49) | `` paraview: fix Python shell ``                                                              |
| [`a61aa829`](https://github.com/NixOS/nixpkgs/commit/a61aa829abd21472ce540122085b9154177deecb) | `` allure: 2.20.1 -> 2.21.0 ``                                                                |
| [`d0b037d3`](https://github.com/NixOS/nixpkgs/commit/d0b037d3328752dbaf27ff1b09ac3ebe57a0b713) | `` intermodal: install shell completions ``                                                   |
| [`c939301d`](https://github.com/NixOS/nixpkgs/commit/c939301d72c20860c4ddc777106675d228fd1efa) | `` intermodal: add `xrelkd` as maintainer ``                                                  |
| [`f63e4f4e`](https://github.com/NixOS/nixpkgs/commit/f63e4f4e5fe236b5cca13e07d9a0fa7e3c78c660) | `` mubeng: 0.13.0 -> 0.13.2 ``                                                                |
| [`6a20d4fa`](https://github.com/NixOS/nixpkgs/commit/6a20d4fa4d0b44e24119de6951e25cdc92449227) | `` seaweedfs: 3.41 -> 3.42 ``                                                                 |
| [`945bb282`](https://github.com/NixOS/nixpkgs/commit/945bb282f02e08d071c90ced78d7982ab8d610fa) | `` step-cli: 0.23.1 -> 0.23.2 ``                                                              |
| [`869b5216`](https://github.com/NixOS/nixpkgs/commit/869b5216f2f180ac500210cd9621bc23e4bb8487) | `` fastly: 6.0.0 -> 6.0.3 ``                                                                  |
| [`e2f518f6`](https://github.com/NixOS/nixpkgs/commit/e2f518f6058ddfe0d57949ef4db138ac4bc70ea3) | `` trufflehog: 3.27.0 -> 3.27.1 ``                                                            |
| [`8ed22ab8`](https://github.com/NixOS/nixpkgs/commit/8ed22ab805651eb672cf3d28b29aaf3146c18908) | `` argocd: 2.5.10 -> 2.6.1 ``                                                                 |
| [`8ef7a3b8`](https://github.com/NixOS/nixpkgs/commit/8ef7a3b83fdd90c307582a39764792c07b0b9ca1) | `` terraform-providers.grafana: 1.34.0 → 1.35.0 ``                                            |
| [`577831fd`](https://github.com/NixOS/nixpkgs/commit/577831fdcf3889192e4deabefb5ab43e3c9f7b10) | `` n8n: 0.215.0 -> 0.215.1 ``                                                                 |
| [`3ba3e203`](https://github.com/NixOS/nixpkgs/commit/3ba3e203479686fa3c6506f9a48acaa28b154756) | `` nixos/virtualisation/linode-image: Migrate to new openssh options. ``                      |
| [`97363e45`](https://github.com/NixOS/nixpkgs/commit/97363e459d08a40db408cc9ecd9e3776777385dd) | `` cargo-binstall: 0.19.3 -> 0.20.1 ``                                                        |
| [`19ccc514`](https://github.com/NixOS/nixpkgs/commit/19ccc514a1c9775459555a1c7ceadf3ce5f87b79) | `` python310Packages.casbin: 1.17.5 -> 1.17.6 ``                                              |
| [`bcbb17dc`](https://github.com/NixOS/nixpkgs/commit/bcbb17dc0820d00ce8b859c2cef72e5453e7d015) | `` age-plugin-yubikey: 0.3.2 -> 0.3.3 ``                                                      |
| [`32eecc6c`](https://github.com/NixOS/nixpkgs/commit/32eecc6cc96ba426cda9a8e7ab66d931eb141cee) | `` haskellPackages.heystone: fix darwin dylibs ``                                             |
| [`10cf86b6`](https://github.com/NixOS/nixpkgs/commit/10cf86b6351a13ad1287fe267236a130e4b635ef) | `` nix-your-shell: init at 1.0.1 ``                                                           |
| [`493b9dc6`](https://github.com/NixOS/nixpkgs/commit/493b9dc63199a8ceb98372f39f0c4f72385aff15) | `` flexget: 3.5.21 -> 3.5.22 ``                                                               |
| [`92321a72`](https://github.com/NixOS/nixpkgs/commit/92321a724921c6218e85b1e82d5730a82507616d) | `` python310Packages.asteval: 0.9.28 -> 0.9.29 ``                                             |
| [`ff0d83d3`](https://github.com/NixOS/nixpkgs/commit/ff0d83d39b64aec7c7a1712dfaf7372ee601ba86) | `` python310Packages.aioesphomeapi: 13.1.0 -> 13.2.0 ``                                       |
| [`547d08cb`](https://github.com/NixOS/nixpkgs/commit/547d08cb2e67f3e5aeef36ebe176d24ba47d43e8) | `` python310Packages.fakeredis: 2.7.1 -> 2.8.0 ``                                             |
| [`ad9d1171`](https://github.com/NixOS/nixpkgs/commit/ad9d11710eba30a92fcd01ddc120a8426adf0c22) | `` python310Packages.govee-ble: 0.22.0 -> 0.23.0 ``                                           |
| [`d87401bb`](https://github.com/NixOS/nixpkgs/commit/d87401bb137f05f6feb27eb6cf557e1c44f28067) | `` python310Packages.goodwe: 0.2.24 -> 0.2.25 ``                                              |
| [`8f2b5310`](https://github.com/NixOS/nixpkgs/commit/8f2b53105151afc64a742f8b7927e7a0525e14fa) | `` trufflehog: 3.26.0 -> 3.27.0 ``                                                            |
| [`969b740b`](https://github.com/NixOS/nixpkgs/commit/969b740bada1175df247765e26aeb1258b0559cb) | `` qovery-cli: 0.48.6 -> 0.49.0 ``                                                            |
| [`21f31725`](https://github.com/NixOS/nixpkgs/commit/21f3172576e237e792d9115ef385c7f365e834ee) | `` nuclei: 2.8.8 -> 2.8.9 ``                                                                  |
| [`a6a71a30`](https://github.com/NixOS/nixpkgs/commit/a6a71a301a75f0a78981b7ab5de74260f33dafd9) | `` httpx: 1.2.6 -> 1.2.7 ``                                                                   |
| [`66cf322e`](https://github.com/NixOS/nixpkgs/commit/66cf322e315b67d70b5f04047de77a4e2807dea4) | `` python310Packages.fastbencode: 0.1 -> 0.2 ``                                               |
| [`73ef1248`](https://github.com/NixOS/nixpkgs/commit/73ef12485825a2d793a5241cd9602b30a4bb21d2) | `` python310Packages.vertica-python: 1.2.0 -> 1.3.0 ``                                        |
| [`e62bf5d9`](https://github.com/NixOS/nixpkgs/commit/e62bf5d95328f6dd64f1d0a3a45903e9c01c86c2) | `` jackett: 0.20.3017 -> 0.20.3035 ``                                                         |
| [`0492d670`](https://github.com/NixOS/nixpkgs/commit/0492d670913ebec88564b2f99e8a32a480db9340) | `` python310Packages.aiolifx: 0.8.7 -> 0.8.9 ``                                               |
| [`db43cf90`](https://github.com/NixOS/nixpkgs/commit/db43cf90f71fc12a47bae199fac01c6924cc691d) | `` felix-fm: 2.2.4 -> 2.2.5 ``                                                                |
| [`78367ae5`](https://github.com/NixOS/nixpkgs/commit/78367ae5cbc49899e69c3d58ed83df264e583528) | `` ocaml-ng.ocamlPackages_4_09.ocaml: fix with GCC 12 ``                                      |
| [`092a6d7f`](https://github.com/NixOS/nixpkgs/commit/092a6d7fc7239bb206cf4724efac07f7de2b0275) | `` lhapdf: fix python module on darwin ``                                                     |
| [`6615030d`](https://github.com/NixOS/nixpkgs/commit/6615030dddd11222fc54e61f2f128793d5a72ad0) | `` python310Packages.torchvision-bin: correct meta.platforms ``                               |
| [`e93108d0`](https://github.com/NixOS/nixpkgs/commit/e93108d02724d8455818fea6736c64f8d4074a64) | `` python310Packages.torchaudio-bin: correct meta.platforms ``                                |
| [`debd6867`](https://github.com/NixOS/nixpkgs/commit/debd68673f06dfd19498a44df8af8b1be2f71b1f) | `` standardnotes: 3.144.3 -> 3.148.0 ``                                                       |
| [`b9acfcab`](https://github.com/NixOS/nixpkgs/commit/b9acfcab07bb0d3d8b50152a9cfd2e7e5e2d970b) | `` python310Packages.home-assistant-chip-core: correct meta.platforms ``                      |
| [`829b777f`](https://github.com/NixOS/nixpkgs/commit/829b777f5309827eb22e5044fa24c7bb5c9a0ea2) | `` python310Packages.torch-bin: correct meta.platforms ``                                     |
| [`c2a0dc78`](https://github.com/NixOS/nixpkgs/commit/c2a0dc782d5036dd71302d83ea9e79109442dd17) | `` pjsip: enable building shared libraries ``                                                 |
| [`237abc78`](https://github.com/NixOS/nixpkgs/commit/237abc78ec6bd915207a481f7b8f1f8941a9624f) | `` pythonPackages: pjsua2: init pjsua2 from pjsip ``                                          |
| [`cbff2010`](https://github.com/NixOS/nixpkgs/commit/cbff2010dec85ec733dd243b077a25b9f09ab20e) | `` pjsip: add pythonSupport option ``                                                         |
| [`77dbe93d`](https://github.com/NixOS/nixpkgs/commit/77dbe93d0d2c56e129fcb99255929131fb816cfb) | `` python310Packages.pyvisa-py: 0.6.1 -> 0.6.2 ``                                             |
| [`519f9b3d`](https://github.com/NixOS/nixpkgs/commit/519f9b3d298e84a6ad2efda06d166203681cac33) | `` v8_8_x: mark broken with GCC 12 ``                                                         |
| [`43659969`](https://github.com/NixOS/nixpkgs/commit/43659969168b73cf525279484f058351456585f3) | `` mirakurun: add license ``                                                                  |
| [`dba17088`](https://github.com/NixOS/nixpkgs/commit/dba170886f8d20cb05632e842a7e84f721ca7a8e) | `` gnutls: add some key reverse dependencies to passthru.tests ``                             |
| [`b5afd592`](https://github.com/NixOS/nixpkgs/commit/b5afd5924dbda626d1c70902bfaa21a74fd3766d) | `` dino: 0.3.1 -> 0.4.0 (#215211) ``                                                          |
| [`3631a8f4`](https://github.com/NixOS/nixpkgs/commit/3631a8f43796993c34f63750e8243e93094ca437) | `` maintainers: add _9999years ``                                                             |
| [`4e5dac05`](https://github.com/NixOS/nixpkgs/commit/4e5dac05750620ef5d96c5b6e02d352d815710f5) | `` v8: add homepage ``                                                                        |
| [`4734c1fc`](https://github.com/NixOS/nixpkgs/commit/4734c1fce6b123dd65bf5d3cd11debb48932e3d9) | `` cwltool: 3.1.20230201130431 -> 3.1.20230209161050 (#215856) ``                             |
| [`f831445c`](https://github.com/NixOS/nixpkgs/commit/f831445c5d645fb37027a1fbfd8548f5fb490bb6) | `` gometer: remove ``                                                                         |
| [`8ae3db15`](https://github.com/NixOS/nixpkgs/commit/8ae3db151aae7e061d4acd3620701014f0c07370) | `` mastodon: 4.0.2 -> 4.1.0 ``                                                                |
| [`8dade1f7`](https://github.com/NixOS/nixpkgs/commit/8dade1f713c7f64f0514ba4c00fa6e2bb1be8d79) | `` nixos/envoy: add option `requireValidConfig` to make config validation errors non-fatal `` |
| [`84220a70`](https://github.com/NixOS/nixpkgs/commit/84220a70983948dd611f0cfdecb70ffe02556312) | `` nixos/envoy: add `package` option ``                                                       |
| [`3c3da876`](https://github.com/NixOS/nixpkgs/commit/3c3da8768be059beae12c87173146666c81c55ca) | `` nixos/envoy: further service hardening ``                                                  |
| [`a36fc1d7`](https://github.com/NixOS/nixpkgs/commit/a36fc1d72afcb5cba99c516432a1a26240aa0be8) | `` nixosTests.envoy: use port 80 to test `CAP_NET_BIND_SERVICE` ``                            |
| [`8fff553f`](https://github.com/NixOS/nixpkgs/commit/8fff553f7efbcc0a065c2e494274013731016ffe) | `` nixos/envoy: sort `serviceConfig` entries ``                                               |
| [`989a1a6e`](https://github.com/NixOS/nixpkgs/commit/989a1a6ef5cb048daecc0101d438b26f7684f0f1) | `` nixos/envoy: use lists in `serviceConfig` where appropriate ``                             |
| [`45d1e007`](https://github.com/NixOS/nixpkgs/commit/45d1e00708a24558adf3da3c86bf18be61799d15) | `` harePackages.hare: mark as broken on ARM64 ``                                              |
| [`ad966da3`](https://github.com/NixOS/nixpkgs/commit/ad966da3478fd7c9ad6327565b7cabb37de33d0c) | `` harePackages.hare: 2022-07-30 -> 2023-02-10 ``                                             |
| [`4c4ce6a0`](https://github.com/NixOS/nixpkgs/commit/4c4ce6a06850691ca9137ac7b886db4fbb278784) | `` harePackages.harec: 2022-07-02 -> 2023-02-08 ``                                            |
| [`fb7ddb66`](https://github.com/NixOS/nixpkgs/commit/fb7ddb6681ada2bacc2e70e6e985abab240cd9e7) | `` harePackages: refactor ``                                                                  |
| [`bb69864c`](https://github.com/NixOS/nixpkgs/commit/bb69864c554805b54751550e010df67cea77d29b) | `` dev86: 0.16.21 -> unstable-2022-07-19 ``                                                   |
| [`68bfdaec`](https://github.com/NixOS/nixpkgs/commit/68bfdaec5737cbd68703dc8a4e3a5f4c70ac6d73) | `` solo5: fix tests ``                                                                        |
| [`6dc06cb2`](https://github.com/NixOS/nixpkgs/commit/6dc06cb28234e73ce14c30d291b1bf9bd8802aa4) | `` synology-drive-client: 3.2.0 -> 3.2.1 ``                                                   |
| [`3927f4fc`](https://github.com/NixOS/nixpkgs/commit/3927f4fcbd1016ed57f96db869accc5b1423da70) | `` ydotool: 1.0.3 -> 1.0.4 ``                                                                 |
| [`03c5c0a2`](https://github.com/NixOS/nixpkgs/commit/03c5c0a2c47261383efe01acd09f4bd7cfc02b08) | `` gtksourceview: Add `meta.pkgConfigModules` and test ``                                     |
| [`4180befa`](https://github.com/NixOS/nixpkgs/commit/4180befaaf1ebfccae53fccfbaf1ba779fd849fe) | `` gstreamer: Add `meta.pkgConfigModules` and test ``                                         |
| [`81655d43`](https://github.com/NixOS/nixpkgs/commit/81655d432d0b7a27f70e35cd56878c0aece04551) | `` gobject-introspection: Add `meta.pkgConfigModules` and test ``                             |
| [`a938c505`](https://github.com/NixOS/nixpkgs/commit/a938c505f388f25c120a99287923648101db0c37) | `` gnome2.gnome_vfs: Add `meta.pkgConfigModules` and test ``                                  |
| [`9808e6d8`](https://github.com/NixOS/nixpkgs/commit/9808e6d89116d4d3eb55ce001280afd5bb54f206) | `` libgnome-keyring{,3}: Add `meta.pkgConfigModules` and test ``                              |
| [`68326eb1`](https://github.com/NixOS/nixpkgs/commit/68326eb1f4009c10072161033b10589bbf735e1c) | `` freeglut: Add `meta.pkgConfigModules` and test ``                                          |
| [`5fd449df`](https://github.com/NixOS/nixpkgs/commit/5fd449df4162fd1f17fffd42be51230305769603) | `` glew: Add `meta.pkgConfigModules` and test ``                                              |
| [`b58f0d0f`](https://github.com/NixOS/nixpkgs/commit/b58f0d0fa51f502a1a3f9d8d206fe6106ffd2643) | `` libGLU: Add `meta.pkgConfigModules` and test ``                                            |
| [`b1aa0e9f`](https://github.com/NixOS/nixpkgs/commit/b1aa0e9f2a7d126eba37a7d6dc5f162be9716459) | `` glib: Add `meta.pkgConfigModules` and test ``                                              |
| [`5df263bd`](https://github.com/NixOS/nixpkgs/commit/5df263bdc01163b684cd2c5f8f2c99636d4bc3fd) | `` geos: Add `meta.pkgConfigModules` and test ``                                              |
| [`36b60279`](https://github.com/NixOS/nixpkgs/commit/36b6027957c729e4a4bb786fa130212a29f98a5e) | `` gdk-pixbuf: Add `meta.pkgConfigModules` and test ``                                        |
| [`d43e540f`](https://github.com/NixOS/nixpkgs/commit/d43e540f891eb804513683b0393b1bf1e0d8d372) | `` gtk: Add `meta.pkgConfigModules` and test ``                                               |
| [`6861492a`](https://github.com/NixOS/nixpkgs/commit/6861492a22ab6ebe8bd1ca4a2c234efc26d5db65) | `` freetype: Add `meta.pkgConfigModules` and test ``                                          |
| [`3d239f2b`](https://github.com/NixOS/nixpkgs/commit/3d239f2b76dee2c530482f406193e08ade807c62) | `` freeault: Add `meta.pkgConfigModules` and test ``                                          |
| [`e7d06f4b`](https://github.com/NixOS/nixpkgs/commit/e7d06f4b0c6fa035b4b4a1f12aabe410d9d8f58e) | `` cairo: Fix `cairo-pdf` in `meta.pkgConfigModules` ``                                       |
| [`0c9a9dd4`](https://github.com/NixOS/nixpkgs/commit/0c9a9dd4551488687db0ee4d05a803a0a09ea91b) | `` libzip: Add `meta.pkgConfigModules` and test ``                                            |
| [`8e24bfb3`](https://github.com/NixOS/nixpkgs/commit/8e24bfb36aebbdbdf5a30dcaebbb34e5e9cb2b12) | `` bzip2_1_1: Add `meta.pkgConfigModules` and test ``                                         |
| [`839288b5`](https://github.com/NixOS/nixpkgs/commit/839288b52affdf9177c168df0dacf16e967f56df) | `` bzip3: Add `meta.pkgConfigModules` and test ``                                             |
| [`6ff065a4`](https://github.com/NixOS/nixpkgs/commit/6ff065a44ccb9b91ee42cfebcd787330fb373384) | `` qt5.qtbase: Add `meta.pkgConfigModules` and test ``                                        |
| [`5b7d66bc`](https://github.com/NixOS/nixpkgs/commit/5b7d66bc32ce6d89df5af4f880435137804bef64) | `` license-generator: 0.8.1 -> 1.0.0 ``                                                       |
| [`524ebdd7`](https://github.com/NixOS/nixpkgs/commit/524ebdd7e1b6aaf90a21372911778c732d994c44) | `` python310Packages.globus-sdk: 3.15.1 -> 3.16.0 ``                                          |
| [`0d4a49af`](https://github.com/NixOS/nixpkgs/commit/0d4a49af8670cf2adf2e23a65830ca4e0bdbe4b2) | `` ldb: fix cross & add libxcrypt ``                                                          |
| [`30826d60`](https://github.com/NixOS/nixpkgs/commit/30826d6035ffff0ccc16b53f5f42111661214882) | `` tevent: copy cross fix from talloc & add libxcrypt ``                                      |
| [`aebc7637`](https://github.com/NixOS/nixpkgs/commit/aebc76376ca2da5ee4524326e6f83a3a18587d54) | `` wlroots_0_16: 0.16.1 -> 0.16.2 ``                                                          |
| [`e6611180`](https://github.com/NixOS/nixpkgs/commit/e6611180eac8a32b0681e19bea2f8057675ad255) | `` lispPackages_new.sbclPackages.classimp: mark broken ``                                     |
| [`50668ca3`](https://github.com/NixOS/nixpkgs/commit/50668ca3f2130b56904be767f17782f9fbe6b7c3) | `` helmfile: 0.145.2 -> 0.150.0 ``                                                            |
| [`785cd824`](https://github.com/NixOS/nixpkgs/commit/785cd824a36b7c9b1e90f1c12eefe2484632fff3) | `` nixos/yubikey-agent: Add dependency to pcsd.service ``                                     |
| [`f08bb600`](https://github.com/NixOS/nixpkgs/commit/f08bb600991179d631882ddf65b2bbb9ca622a6d) | `` lispPackages_new.sbclPackages.cl-freeimage: fix build ``                                   |
| [`c0380c7b`](https://github.com/NixOS/nixpkgs/commit/c0380c7bff694c7102c7425d7869901a4d40d628) | `` netbird: 0.12.0 -> 0.13.0 ``                                                               |
| [`8845d70a`](https://github.com/NixOS/nixpkgs/commit/8845d70a9afbd32162891800597cb71b6e2dfad6) | `` wasilibc: 17 -> 19 ``                                                                      |
| [`2ea402c3`](https://github.com/NixOS/nixpkgs/commit/2ea402c369ca7dc3c7c97863daa3d831a4151c44) | `` mmark: 2.2.30 -> 2.2.31 ``                                                                 |
| [`b67383f2`](https://github.com/NixOS/nixpkgs/commit/b67383f279d59761f0d8d51e8adc6b8178acb114) | `` snappymail: 2.25.3 -> 2.25.5 ``                                                            |
| [`12f5b04c`](https://github.com/NixOS/nixpkgs/commit/12f5b04c83e8d5ddba1ac4ef63ca522ec8f22a96) | `` ocamlPackages.cfstream: 1.3.1 → 1.3.2 ``                                                   |
| [`b96ced6d`](https://github.com/NixOS/nixpkgs/commit/b96ced6d9ae5992460747c03b9096bf5695a158b) | `` ocamlPackages.biocaml: use Dune 3 ``                                                       |
| [`7473ac95`](https://github.com/NixOS/nixpkgs/commit/7473ac950e0968d46d07b9867bce54cd38e2aa62) | `` ocamlPackages.phylogenetics: use Dune 3 ``                                                 |
| [`4981f6a4`](https://github.com/NixOS/nixpkgs/commit/4981f6a40e350c99c385fe6276503280727cb81b) | `` python310Packages.renault-api: 0.1.11 -> 0.1.12 ``                                         |
| [`0eaace8c`](https://github.com/NixOS/nixpkgs/commit/0eaace8c1229536df8a19b150881014fddd3fcd2) | `` python310Packages.renault-api: add changelog to meta ``                                    |
| [`cb2f6885`](https://github.com/NixOS/nixpkgs/commit/cb2f6885116c9ab28b42998055e83f3c0d6d42d1) | `` python3Packages.blis: enable non-x86_64 platforms ``                                       |
| [`e107a769`](https://github.com/NixOS/nixpkgs/commit/e107a769e7d5e36090a38c2f5415e3aef4d09d28) | `` python310Packages.pydanfossair: 0.1.0 -> 0.2.0 ``                                          |
| [`73d3af87`](https://github.com/NixOS/nixpkgs/commit/73d3af8712dd3c7f1e2fd906f13ee3030fa12271) | `` beret: remove leftover file ``                                                             |
| [`4fb80600`](https://github.com/NixOS/nixpkgs/commit/4fb806003b0c6a6a2ecc4cd6803c48e58be49089) | `` theme-obsidian2: 2.21 -> 2.22 ``                                                           |
| [`1d204295`](https://github.com/NixOS/nixpkgs/commit/1d204295889d275cf7cdfbc9799a17a1d980a514) | `` theme-obsidian2: add update script ``                                                      |
| [`7b4ed5fc`](https://github.com/NixOS/nixpkgs/commit/7b4ed5fc89ab0783c223bcdfac93ea676c3e4df9) | `` theme-obsidian2: reformat nix expression ``                                                |
| [`7cee38c2`](https://github.com/NixOS/nixpkgs/commit/7cee38c2f0d6ec4c1a93be6903a43d9748cc4c48) | `` python310Packages.incomfort-client: 0.4.5 -> 0.5.0 ``                                      |
| [`8b55a288`](https://github.com/NixOS/nixpkgs/commit/8b55a288c075765a42cc90eb8d28827b0caff91e) | `` python310Packages.netutils: 1.4.0 -> 1.4.1 ``                                              |
| [`98700e48`](https://github.com/NixOS/nixpkgs/commit/98700e481e02b9b8eea91ea7afbd4e0385e9208e) | `` python310Packages.aliyun-python-sdk-iot: 8.49.0 -> 8.50.0 ``                               |
| [`9a0e8279`](https://github.com/NixOS/nixpkgs/commit/9a0e82797e4687926d2cd548ea46d100df525189) | `` python310Packages.aliyun-python-sdk-cdn: 3.8.1 -> 3.8.2 ``                                 |
| [`a8b1e8d7`](https://github.com/NixOS/nixpkgs/commit/a8b1e8d7b121b98f7a823e0a1f92e0dfb4b42917) | `` python310Packages.md-toc: 8.1.8 -> 8.1.9 ``                                                |
| [`aa680bde`](https://github.com/NixOS/nixpkgs/commit/aa680bde642889b2decd1187f4ace6cfc74ea292) | `` python310Packages.peaqevcore: 11.2.0 -> 12.0.1 ``                                          |
| [`b4120fb1`](https://github.com/NixOS/nixpkgs/commit/b4120fb17f3e8f349a29fdb923e296c3c7862650) | `` python310Packages.boschshcpy: 0.2.53 -> 0.2.54 ``                                          |
| [`5c41e01e`](https://github.com/NixOS/nixpkgs/commit/5c41e01e2ed3d56f71cb0f3b91ad5410b081f17c) | `` python310Packages.msgspec: 0.13.0 -> 0.13.1 ``                                             |
| [`1518b4cd`](https://github.com/NixOS/nixpkgs/commit/1518b4cd0b974bf9e8c934a127b67c280d6006a2) | `` python310Packages.meshtastic: 2.0.11 -> 2.0.12 ``                                          |
| [`edc2be2e`](https://github.com/NixOS/nixpkgs/commit/edc2be2e51992b9a8ac503a5acb7bef14a9111fa) | `` python310Packages.django-webpack-loader: 1.8.0 -> 1.8.1 ``                                 |
| [`21b68892`](https://github.com/NixOS/nixpkgs/commit/21b68892429601e69240952e70f542a9b7ddd142) | `` python311Packages.pyflunearyou: fix build ``                                               |
| [`98d25342`](https://github.com/NixOS/nixpkgs/commit/98d253427b8c169c4b07b5bb434a730cccaa0673) | `` tellico: 3.4.5 -> 3.4.6 ``                                                                 |
| [`08ba92ee`](https://github.com/NixOS/nixpkgs/commit/08ba92eedc8dd5c48f7c76eebe62d41b21a75294) | `` python310Packages.dissect: 3.3 -> 3.4 ``                                                   |
| [`ff889517`](https://github.com/NixOS/nixpkgs/commit/ff88951714ed966aa34dd311a5dad467ad0d0b79) | `` python310Packages.dissect-squashfs: init at 1.0 ``                                         |
| [`dfae8e61`](https://github.com/NixOS/nixpkgs/commit/dfae8e615ac27ac470731dd7430abb4b50c40687) | `` python310Packages.dissect-executable: init at 1.1 ``                                       |
| [`e8b59a1e`](https://github.com/NixOS/nixpkgs/commit/e8b59a1e2ed7d0523ba1ad55bfe296bfaadab923) | `` nixos/dokuwiki: remove last reference to aclUse ``                                         |
| [`88e0332e`](https://github.com/NixOS/nixpkgs/commit/88e0332e0a52139b7682472bcd6e7f8106299f34) | `` python310Packages.dissect: add changelog to meta ``                                        |
| [`4cdbe5bb`](https://github.com/NixOS/nixpkgs/commit/4cdbe5bb03fad5aea978c240def7c1c0ec5b912e) | `` python310Packages.dissect-target: 3.4 -> 3.7 ``                                            |
| [`fe256a56`](https://github.com/NixOS/nixpkgs/commit/fe256a560ec54712038b3c12fd59b9d59eb2eed1) | `` python310Packages.flow-record: 3.7 -> 3.9 ``                                               |
| [`8c889fe2`](https://github.com/NixOS/nixpkgs/commit/8c889fe25a38ce68a3c1a567eac263dbb0e0084e) | `` python310Packages.flow-record: add changelog to meta ``                                    |
| [`f93506e3`](https://github.com/NixOS/nixpkgs/commit/f93506e3870f727cd82de5bd9da84edb5c705b71) | `` python310Packages.dissect-target: add changelog to meta ``                                 |
| [`3f9a63cb`](https://github.com/NixOS/nixpkgs/commit/3f9a63cbb98e377fa8726d9d3651343e7701679b) | `` python310Packages.dissect-eventlog: 3.2 -> 3.3 ``                                          |
| [`e45ad177`](https://github.com/NixOS/nixpkgs/commit/e45ad177bb287de49c7f4af8148d2e30f53c58dd) | `` python310Packages.dissect-eventlog: add changelog to meta ``                               |
| [`02a74fca`](https://github.com/NixOS/nixpkgs/commit/02a74fcab82e97225a4dd6089b30903ffcc763a9) | `` python310Packages.dissect-thumbcache: 1.1 -> 1.2 ``                                        |
| [`ad079972`](https://github.com/NixOS/nixpkgs/commit/ad079972ea607c72b21277620d65ee7c0c615731) | `` python310Packages.dissect-thumbcache: add changelog to meta ``                             |
| [`3c6db894`](https://github.com/NixOS/nixpkgs/commit/3c6db8941cc1552ff3e83b59203769befe2aac82) | `` python310Packages.dissect-shellitem: 3.2 -> 3.3 ``                                         |
| [`c95d428a`](https://github.com/NixOS/nixpkgs/commit/c95d428a25c5848bed804a398082d5f502df882c) | `` python310Packages.dissect-shellitem: add changelog to meta ``                              |
| [`93186a15`](https://github.com/NixOS/nixpkgs/commit/93186a15afea23f0d164de941ecf7c8e98ad517c) | `` python310Packages.dissect-evidence: 3.2 -> 3.3 ``                                          |
| [`ce04ef0e`](https://github.com/NixOS/nixpkgs/commit/ce04ef0e7b78abef2713f780596c495ea75aab46) | `` python310Packages.dissect-evidence: add changelog to meta ``                               |
| [`f3372ce0`](https://github.com/NixOS/nixpkgs/commit/f3372ce00b30125bfe06c146d30e58f8e1817ff1) | `` python310Packages.dissect-esedb: 3.3 -> 3.5 ``                                             |
| [`1d4007ae`](https://github.com/NixOS/nixpkgs/commit/1d4007ae507a68104a5ee8bac70bf328adf3878a) | `` python310Packages.ibm-cloud-sdk-core: 3.16.1 -> 3.16.2 ``                                  |
| [`b375c129`](https://github.com/NixOS/nixpkgs/commit/b375c12994d0a118cfcd364e208fa46cbff2f512) | `` python310Packages.dissect-esedb: add changelog to meta ``                                  |
| [`7cdefbce`](https://github.com/NixOS/nixpkgs/commit/7cdefbce835cdef0058b5e43c2a9772033e9c373) | `` python310Packages.dissect-cim: 3.3 -> 3.4 ``                                               |
| [`1005a9c6`](https://github.com/NixOS/nixpkgs/commit/1005a9c615799d17d49263669b8b4356cfe2d93f) | `` python310Packages.dissect-cim: add changelog to meta ``                                    |