### PR TITLE
chore(flake/nixpkgs): `d917136f` -> `545c7a31`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676202775,
-        "narHash": "sha256-gV/RnfVZkGLHn+5rmX2GSh5aquVHpWOJw1cnpEV03tQ=",
+        "lastModified": 1676300157,
+        "narHash": "sha256-1HjRzfp6LOLfcj/HJHdVKWAkX9QRAouoh6AjzJiIerU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d917136f550a8c36efb1724390c7245105f79023",
+        "rev": "545c7a31e5dedea4a6d372712a18e00ce097d462",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`d990d1ea`](https://github.com/NixOS/nixpkgs/commit/d990d1ea881a3cf1226ab4dbbf612bc7a01c9c79) | `` python311.pkgs.collections-extended: disable ``                                    |
| [`b2747781`](https://github.com/NixOS/nixpkgs/commit/b274778192ef2d21da3ff281d773fa5908a20dbc) | `` haruna: 0.10.2 -> 0.10.3 ``                                                        |
| [`58ad16c2`](https://github.com/NixOS/nixpkgs/commit/58ad16c22e30209fdc292a3fcc5e5459e290b250) | `` libreddit: 0.29.1 -> 0.29.2 ``                                                     |
| [`e9be28eb`](https://github.com/NixOS/nixpkgs/commit/e9be28ebacfd89a9123d3cc716493fd73479790e) | `` cosmocc: init at 2.2 ``                                                            |
| [`afbdf8c5`](https://github.com/NixOS/nixpkgs/commit/afbdf8c54d71c819f5e7f61cf3cdd492be2dcbdf) | `` cosmoc: drop ``                                                                    |
| [`5596aefd`](https://github.com/NixOS/nixpkgs/commit/5596aefd05f97183bcca7c3d053b084a048e85dd) | `` ferretdb: 0.9.0 -> 0.9.1 ``                                                        |
| [`eed13265`](https://github.com/NixOS/nixpkgs/commit/eed132659295ddc06e81305f1644ecd68bab2ed1) | `` tree-sitter: fix src value ``                                                      |
| [`607a2f9e`](https://github.com/NixOS/nixpkgs/commit/607a2f9e420453889695628dfb4e89c54929648f) | `` sunpaper: 2022-04-01 -> 2.0 ``                                                     |
| [`c4a8d973`](https://github.com/NixOS/nixpkgs/commit/c4a8d9735c490f5e06111fc7844982338615c86e) | `` maintainers: Update email for Zimmi48 ``                                           |
| [`3f794e72`](https://github.com/NixOS/nixpkgs/commit/3f794e72d1a0ae5772119bc25b890f2068a326f3) | `` prometheus-artifactory-exporter: 1.11.0 -> 1.12.0 ``                               |
| [`a1e6a37f`](https://github.com/NixOS/nixpkgs/commit/a1e6a37fcd472c9356cfa1c21d3b027375c1f64a) | `` regextester: 1.0.1 -> 1.1.1 ``                                                     |
| [`fdbf633c`](https://github.com/NixOS/nixpkgs/commit/fdbf633c4851ed0750ec54dedcb0b3be2639c31f) | `` python310Packages.rapt-ble: add changelog to meta ``                               |
| [`106785ff`](https://github.com/NixOS/nixpkgs/commit/106785ff1c3fe493f77f3e373e021169438f2516) | `` python310Packages.airthings-ble: add changelog to meta ``                          |
| [`92c27f38`](https://github.com/NixOS/nixpkgs/commit/92c27f38dc1e2b1e0ae1a3fa8f88913ab085a81e) | `` python310Packages.sensorpro-ble: update rev ``                                     |
| [`5ee9d70e`](https://github.com/NixOS/nixpkgs/commit/5ee9d70e01ddca7bcfbf8a1179f7e5d1a3390671) | `` python310Packages.atc-ble: add changelog to meta ``                                |
| [`8377d07b`](https://github.com/NixOS/nixpkgs/commit/8377d07b258f8e81b6b884a088e47842c57812c1) | `` python310Packages.ibeacon-ble: add changelog to meta ``                            |
| [`9ed5745d`](https://github.com/NixOS/nixpkgs/commit/9ed5745d1250276ccd1fe681022bac36c2aaf521) | `` python310Packages.inkbird-ble: add changelog to meta ``                            |
| [`8867f889`](https://github.com/NixOS/nixpkgs/commit/8867f889a36a41c755aa72bd5e36bede6a590798) | `` python310Packages.pc-ble-driver-py: add changelog to meta ``                       |
| [`b5cdf350`](https://github.com/NixOS/nixpkgs/commit/b5cdf35097603c6c82552bfce3b017b1d934301a) | `` python310Packages.led-ble: add changelog to meta ``                                |
| [`e07fc2f4`](https://github.com/NixOS/nixpkgs/commit/e07fc2f4eb41ada4d228f17fcd2d8b4552572a37) | `` python310Packages.thermopro-ble: add changelog to meta ``                          |
| [`12343b9c`](https://github.com/NixOS/nixpkgs/commit/12343b9cae3e709645f9c32c9d1e82d0c245157f) | `` python310Packages.qingping-ble: add changelog to meta ``                           |
| [`822f076d`](https://github.com/NixOS/nixpkgs/commit/822f076daf05d4070b3ac7cb85b88e6e77b8a2bf) | `` python310Packages.kegtron-ble: add changelog to meta ``                            |
| [`48293adf`](https://github.com/NixOS/nixpkgs/commit/48293adfc53a1cb59ae854844d2847353f3c40dd) | `` python310Packages.moat-ble: add changelog to meta ``                               |
| [`e8b67bd8`](https://github.com/NixOS/nixpkgs/commit/e8b67bd87cbbefebda0cee68728c67da0fe91b6c) | `` sapling: 0.2.20221222-152408-ha6a66d09 -> 0.2.20230124-180750-hf8cd450a ``         |
| [`e939aafb`](https://github.com/NixOS/nixpkgs/commit/e939aafb986d8e8c996e0b049ffdd3f69a9c24f1) | `` python310Packages.hist: init at 2.6.3 ``                                           |
| [`0fe08544`](https://github.com/NixOS/nixpkgs/commit/0fe08544fc548ddf922004e9268c9cc389939857) | `` python310Packages.histoprint: init at 2.4.0 ``                                     |
| [`d4b39b85`](https://github.com/NixOS/nixpkgs/commit/d4b39b856994ce05e657d5f7a3e48c83c0754f78) | `` python310Packages.uhi: init at 0.3.3 ``                                            |
| [`9435a8f4`](https://github.com/NixOS/nixpkgs/commit/9435a8f48e37ea494b01330c3443f77a66bdc5e5) | `` ocaml-top: 1.2.0-rc → 1.2.0 ``                                                     |
| [`1995db3b`](https://github.com/NixOS/nixpkgs/commit/1995db3be345620685d143fe378b62d430fcd5cf) | `` rocm-device-libs: 5.4.2 -> 5.4.3 ``                                                |
| [`8cb1591b`](https://github.com/NixOS/nixpkgs/commit/8cb1591beab1e4b95a089ffc6f7d74ef761bd724) | `` python310Packages.ansible-doctor: 1.4.8 -> 2.0.0 ``                                |
| [`080f42af`](https://github.com/NixOS/nixpkgs/commit/080f42af5cf79c6a9446642565c79ee48f530d0c) | `` python310Packages.google-cloud-container: 2.17.2 -> 2.17.3 ``                      |
| [`d05b9499`](https://github.com/NixOS/nixpkgs/commit/d05b9499061d16245aae6693a7d66cbf93459bc5) | `` python310Packages.awswrangler: don't use SPARQLWrapper alias ``                    |
| [`b5538baf`](https://github.com/NixOS/nixpkgs/commit/b5538baf6e471b4b9a8c6a51dfe3f3e1659dfc05) | `` clhep: 2.4.6.3 -> 2.4.6.4 ``                                                       |
| [`51b444c7`](https://github.com/NixOS/nixpkgs/commit/51b444c7c9b80be13473eaa45ddd7dd22703a392) | `` git-trim: fix build on darwin ``                                                   |
| [`df71f8b2`](https://github.com/NixOS/nixpkgs/commit/df71f8b2a8a8a22a5fca52fc14d95c648781f79f) | `` kanata: 1.1.0 -> 1.2.0 ``                                                          |
| [`4dfbbc07`](https://github.com/NixOS/nixpkgs/commit/4dfbbc07f592e78039d5f51fc3ca668d3dc127cc) | `` example-robot-data: 4.0.3 -> 4.0.4 ``                                              |
| [`d9cf62f0`](https://github.com/NixOS/nixpkgs/commit/d9cf62f01235ebb2af046eaaff786f64e5f82685) | `` wgpu-utils: 0.15.0 -> 0.15.1 ``                                                    |
| [`2aa0edd9`](https://github.com/NixOS/nixpkgs/commit/2aa0edd9ca295d3043ad663382d47a4b5fdf2e6e) | `` httm: 0.21.0 -> 0.21.1 ``                                                          |
| [`352b7c0a`](https://github.com/NixOS/nixpkgs/commit/352b7c0a1485a8e43996397d3547d13ae27e956f) | `` httm: 0.20.5 -> 0.21.0 ``                                                          |
| [`5af91852`](https://github.com/NixOS/nixpkgs/commit/5af91852b822d5129bd98276c0bf52d93587548f) | `` xray: 1.7.2 -> 1.7.5 ``                                                            |
| [`d82beffc`](https://github.com/NixOS/nixpkgs/commit/d82beffc8aa733d1939c7194e90e0d5acf3bc32e) | `` gnome.gnome-contacts: 43.0 → 43.1 ``                                               |
| [`eba74741`](https://github.com/NixOS/nixpkgs/commit/eba74741e8b38ec2cefda492195fa582f2dc740a) | `` fly: 7.9.0 -> 7.9.1 ``                                                             |
| [`da915b8b`](https://github.com/NixOS/nixpkgs/commit/da915b8bdc574ba241725e0884ef7734973abcb6) | `` iosevka-bin: 18.0.0 -> 19.0.0 ``                                                   |
| [`cb32d702`](https://github.com/NixOS/nixpkgs/commit/cb32d70250e9ab6fafca08023389c6f9b9e65864) | `` python310Packages.rapt-ble: init at 0.1.0 ``                                       |
| [`8fb02bc6`](https://github.com/NixOS/nixpkgs/commit/8fb02bc6ff0aeed35f74703fd00bbb31724022c2) | `` python310Packages.pyweatherflowrest: 1.0.8 -> 1.0.9 ``                             |
| [`d62331ef`](https://github.com/NixOS/nixpkgs/commit/d62331efe321f0006e330d585add02ab96ea00a4) | `` python310Packages.pyweatherflowrest: add changelog to meta ``                      |
| [`8e750238`](https://github.com/NixOS/nixpkgs/commit/8e75023890f087872a25670ad7d9c7646273db9c) | `` nfpm: 2.25.0 -> 2.25.1 ``                                                          |
| [`0c2afa94`](https://github.com/NixOS/nixpkgs/commit/0c2afa947b612eb4617d7f23ff4c4a95e4229449) | `` saleae-logic-2: 2.4.3 -> 2.4.6 ``                                                  |
| [`55070e59`](https://github.com/NixOS/nixpkgs/commit/55070e598e0e03d1d116c49b9eff322ef07c6ac6) | `` python3.pkgs.mediapy: fix build ``                                                 |
| [`18c24ee4`](https://github.com/NixOS/nixpkgs/commit/18c24ee413363d5d98b1c2e907b9c3c5015cc886) | `` mirakurun: fix build ``                                                            |
| [`4512a712`](https://github.com/NixOS/nixpkgs/commit/4512a7128157999170871704a3d2594b0e6d12ea) | `` mirakurun: pin to node.js 16.x ``                                                  |
| [`fa5d5ba3`](https://github.com/NixOS/nixpkgs/commit/fa5d5ba318dcbf1986104d0520f023893a80d231) | `` coder: 0.16.0 -> 0.17.1 ``                                                         |
| [`6ab66c74`](https://github.com/NixOS/nixpkgs/commit/6ab66c744ffaf54951a2054f20501fc312a8d02e) | `` imagemagick: 7.1.0-61 -> 7.1.0-62 ``                                               |
| [`91bf862e`](https://github.com/NixOS/nixpkgs/commit/91bf862e3c5c67b69797e9740a41e611f674a5a5) | `` arrow-cpp: fix meta.broken ``                                                      |
| [`d1dd7f8a`](https://github.com/NixOS/nixpkgs/commit/d1dd7f8a8de510c5d67964b8fd67975dc2627579) | `` hilbish: 2.0.1 -> 2.1.0 ``                                                         |
| [`70f4390c`](https://github.com/NixOS/nixpkgs/commit/70f4390c158f43706b359d65c7289a29f69d918b) | `` circleci-cli: 0.1.23334 -> 0.1.23391 ``                                            |
| [`0231b21b`](https://github.com/NixOS/nixpkgs/commit/0231b21bdd39d2327570765cf554352d37e8d62d) | `` julia-mono: 0.047 -> 0.048 ``                                                      |
| [`596ef34e`](https://github.com/NixOS/nixpkgs/commit/596ef34e284f6df07c9647c106584469bc7cb9dd) | `` jbang: 0.102.0 -> 0.103.0 ``                                                       |
| [`d2128e82`](https://github.com/NixOS/nixpkgs/commit/d2128e82eeb1ace7c424a86e035ac9b1ad8451f2) | `` repro-get: 0.2.1 -> 0.3.0 ``                                                       |
| [`af57670e`](https://github.com/NixOS/nixpkgs/commit/af57670e59fcc9b7b219ef38affc1c7820c44100) | `` sapling: remove intermediate package ``                                            |
| [`f24ea245`](https://github.com/NixOS/nixpkgs/commit/f24ea2456e6db912d0bb9a09f3db5fb3b80afe62) | `` jpegoptim: 1.5.1 -> 1.5.2 ``                                                       |
| [`646b9cf7`](https://github.com/NixOS/nixpkgs/commit/646b9cf72f184c045f111e7d7d3ddd67fb2c02cf) | `` papirus-folders: 1.12.0 -> 1.12.1 ``                                               |
| [`e563774f`](https://github.com/NixOS/nixpkgs/commit/e563774fac3af13b5bef77804dcc29147e9b5e4a) | `` libopenshot: improve Python dir specification to fix Darwin ``                     |
| [`f39b7779`](https://github.com/NixOS/nixpkgs/commit/f39b7779870c4128cbd371560bfbeba1aa0a2c69) | `` sage: 9.7 -> 9.8 ``                                                                |
| [`a951a2b7`](https://github.com/NixOS/nixpkgs/commit/a951a2b7b7323ba90149baa430f6cd286629daa4) | `` erosmb: 0.1.4 -> 0.1.5 ``                                                          |
| [`b7b53aec`](https://github.com/NixOS/nixpkgs/commit/b7b53aec79042aee0e8de576803bf2eeb4f8a98c) | `` sage: update readme to reflect trac->gh migration ``                               |
| [`96f13f91`](https://github.com/NixOS/nixpkgs/commit/96f13f91934d82bae8446b1d5650d38549b2e01b) | `` sympow: avoid undefined behaviour by increasing buffer size ``                     |
| [`7371818c`](https://github.com/NixOS/nixpkgs/commit/7371818c6e23aa0a6af1c8a8bde822119084aacc) | `` pari: upstream ellcard fixes ``                                                    |
| [`ccc118b6`](https://github.com/NixOS/nixpkgs/commit/ccc118b6cc9c8eecdd4eb7eff81f33df2a1f2490) | `` gap: sage no longer needs a wrapper ``                                             |
| [`b35c20fb`](https://github.com/NixOS/nixpkgs/commit/b35c20fb30f0b05fa7802aaa2ce7c4e56a34a1d8) | `` pythonPackages.fpylll: 0.5.7 -> 0.5.9 ``                                           |
| [`a2dc4ed8`](https://github.com/NixOS/nixpkgs/commit/a2dc4ed8dbc8608b012baacbe574dec6e6cb88b5) | `` linkerd_edge: 23.1.2 -> 23.2.1 ``                                                  |
| [`d2e047f1`](https://github.com/NixOS/nixpkgs/commit/d2e047f112b459dc2ded9923c388370c893520ae) | `` graalvm-ce: add it to all-packages pointing to graalvm11-ce ``                     |
| [`15f0d4cc`](https://github.com/NixOS/nixpkgs/commit/15f0d4ccd57e88ccadbaa92582f23c25e81fa9e1) | `` ethtool: apply upstream diff to fix build on musl (#216011) ``                     |
| [`8c6ad9ea`](https://github.com/NixOS/nixpkgs/commit/8c6ad9eae1a325619c0b6656ea523a33906be795) | `` foot: disable pgo on musl (#191037) ``                                             |
| [`804349a8`](https://github.com/NixOS/nixpkgs/commit/804349a87a1f11a87a9687e5c0fae8587d42a178) | `` pkgsStatic.stfl: fix build ``                                                      |
| [`69e853f6`](https://github.com/NixOS/nixpkgs/commit/69e853f621a8aeb977fd1e0bf20fba01b129d6c3) | `` bpf-linker: 0.9.4 -> 0.9.5 ``                                                      |
| [`f182923b`](https://github.com/NixOS/nixpkgs/commit/f182923bf097f622a1dbd38ee682375d0dd37219) | `` eyedropper: update description ``                                                  |
| [`718c073c`](https://github.com/NixOS/nixpkgs/commit/718c073c22b85c16f1cef0b9125d9a8cf4873471) | `` go-graft: 0.2.16 -> 0.2.17 ``                                                      |
| [`67d91de4`](https://github.com/NixOS/nixpkgs/commit/67d91de443a3024564b1754240503a6a0a212435) | `` cosmopolitan: 2.1.1 -> 2.2 ``                                                      |
| [`4535a5aa`](https://github.com/NixOS/nixpkgs/commit/4535a5aa356599c065ddcba6a8a4c3a7472af45f) | `` dolphin-emu: 5.0-17995 -> 5.0-18498 ``                                             |
| [`67ffcc85`](https://github.com/NixOS/nixpkgs/commit/67ffcc85bc1ab9c7e9749b0d70dc89a02a2e3b06) | `` dolphin-emu: remove "stable", replace with "beta" ``                               |
| [`21f8a7ca`](https://github.com/NixOS/nixpkgs/commit/21f8a7ca845533d8be50d877de768f72067822a3) | `` mutt: assert relations between configuration options ``                            |
| [`0e2ed40a`](https://github.com/NixOS/nixpkgs/commit/0e2ed40a8b6ccfcefad3fc6f5192ed38a9a9d995) | `` v8_8_x: restrict compiler version check to GCC ``                                  |
| [`ddbc1eb4`](https://github.com/NixOS/nixpkgs/commit/ddbc1eb4c2021ab0ffe49dfdeb371f7aa1149bcf) | `` darkman: 1.4.0 -> 1.5.4 ``                                                         |
| [`10c93d97`](https://github.com/NixOS/nixpkgs/commit/10c93d977d2bee7bd8d24620ffb9a21459bff4a0) | `` last: 1445 -> 1447 ``                                                              |
| [`f541c121`](https://github.com/NixOS/nixpkgs/commit/f541c121c4e6d47e77975cd2d2da7942bf74f07b) | `` python310Packages.effect: fix build ``                                             |
| [`de15b5ff`](https://github.com/NixOS/nixpkgs/commit/de15b5ffc83949d92edf7ae31edd9a1a0af8ef62) | `` jitsi: 2.10.5550 -> 2.11.5633 ``                                                   |
| [`359896bd`](https://github.com/NixOS/nixpkgs/commit/359896bd1bcab22e14f8e26c098831c8844a8d4f) | `` ipset: 7.15 -> 7.17 ``                                                             |
| [`87b7508c`](https://github.com/NixOS/nixpkgs/commit/87b7508c00acced033e7be85189e68b94291cf96) | `` snowflake: 2.5.0 -> 2.5.1 ``                                                       |
| [`b83f032f`](https://github.com/NixOS/nixpkgs/commit/b83f032ffcbc6b1b9f412d50b7a6ba3cfe471d0a) | `` gcc/11: apply upstream fix 103910 so openjdk builds ``                             |
| [`22e8ba35`](https://github.com/NixOS/nixpkgs/commit/22e8ba3516bfc77f023fb740456e89ca647ef820) | `` fizz: 2023.01.30.00 -> 2023.02.06.00 ``                                            |
| [`dd363844`](https://github.com/NixOS/nixpkgs/commit/dd363844d277284af4e64d58a52dd702419b2329) | `` picotool: remove installPhase ``                                                   |
| [`8c60f0d8`](https://github.com/NixOS/nixpkgs/commit/8c60f0d8726bb6d02d0a18b4c88425d92c6dc142) | `` steampipe: 0.18.4 -> 0.18.5 ``                                                     |
| [`a3be4a3e`](https://github.com/NixOS/nixpkgs/commit/a3be4a3ebfacb98e83b52581c571a22de3bb7e00) | `` eksctl: 0.128.0 -> 0.129.0 ``                                                      |
| [`c181fb98`](https://github.com/NixOS/nixpkgs/commit/c181fb980739d08d5ceceaef78ecb2d3303eacde) | `` picotool: 1.1.0 -> 1.1.1 ``                                                        |
| [`542c88f8`](https://github.com/NixOS/nixpkgs/commit/542c88f871e7a443aaf32dea6ecbb21c5493d127) | `` graalvm*-ce: remove old sources file ``                                            |
| [`d0fa8c16`](https://github.com/NixOS/nixpkgs/commit/d0fa8c16b69f35a4e7d8e246681747a9f25dccaa) | `` pico-sdk: 1.4.0 -> 1.5.0 ``                                                        |
| [`e5274ea4`](https://github.com/NixOS/nixpkgs/commit/e5274ea44517d4a95a5709dd49a4e6afa8dd101f) | `` appthreat-depscan: 3.5.3 -> 3.6.0 ``                                               |
| [`96e72302`](https://github.com/NixOS/nixpkgs/commit/96e72302d6b0c3735570fe0d43d5a818aef28b04) | `` gfold: 4.3.0 -> 4.3.1 ``                                                           |
| [`26b9a2f4`](https://github.com/NixOS/nixpkgs/commit/26b9a2f4a1a53e6763aa83590aad0fce5013a458) | `` zig_0_10: switch to baseline cpu target for better compatibility ``                |
| [`543f7fab`](https://github.com/NixOS/nixpkgs/commit/543f7fab956b1ebb6c2d5090e0612c9b66750650) | `` openshot: fix Qt plugin path ``                                                    |
| [`57145917`](https://github.com/NixOS/nixpkgs/commit/571459175404aa43de4db2c6d9049204700b957f) | `` ddrescue: 1.26 -> 1.27 ``                                                          |
| [`add68d4d`](https://github.com/NixOS/nixpkgs/commit/add68d4d3e3017d4c46188a192ccd547c05c76b8) | `` python310Packages.configobj: 5.0.6 -> 5.0.8 ``                                     |
| [`5b8610df`](https://github.com/NixOS/nixpkgs/commit/5b8610dfcc8cb7a36ede4359e32501cb40503f47) | `` python310Packages.configobj: add changelog to meta ``                              |
| [`d381e51f`](https://github.com/NixOS/nixpkgs/commit/d381e51fb567e23039f17fdf28576dd6b341911d) | `` binutils: try to move headers around only when --host/--target differ (#215989) `` |
| [`b5ace1ff`](https://github.com/NixOS/nixpkgs/commit/b5ace1ffc029c4fea5ab2344c0a77e459b3df4ed) | `` furnace, tvheadend: more fallout from gcc upgrade ``                               |
| [`25e334fc`](https://github.com/NixOS/nixpkgs/commit/25e334fc0430a1cec8acb5385ebcfef233362b91) | `` python310Packages.primer3: 0.6.1 -> 1.0.0 ``                                       |
| [`b8ff993f`](https://github.com/NixOS/nixpkgs/commit/b8ff993fef408657c4a0a0ba716b23420cc7d9e3) | `` molly-brown: unstable-2020-08-19 -> unstable-2023-02-10 ``                         |
| [`18d79944`](https://github.com/NixOS/nixpkgs/commit/18d79944ee445db5e85c2cbb1400666fbd622c2a) | `` python310Packages.scmrepo: 0.1.7 -> 0.1.9 ``                                       |
| [`2c0ca012`](https://github.com/NixOS/nixpkgs/commit/2c0ca012755a41bb12700ff99e45b9e240ba2acc) | `` python310Packages.shortuuid: add changelog to meta ``                              |
| [`d5e55b8d`](https://github.com/NixOS/nixpkgs/commit/d5e55b8df91e26d8e3407c4adcdc10c0425a27f2) | `` bash: add pkgsStatic.bash to passthru ``                                           |
| [`049f406e`](https://github.com/NixOS/nixpkgs/commit/049f406eb14c607be931c257d2b844a296d16b60) | `` python310Packages.dulwich: 0.21.0 -> 0.21.2 ``                                     |
| [`9be14782`](https://github.com/NixOS/nixpkgs/commit/9be147826d121d0b280910bf603f931d0e79c5c8) | `` trivy: 0.37.1 -> 0.37.2 ``                                                         |
| [`9cb3857b`](https://github.com/NixOS/nixpkgs/commit/9cb3857bc18d233b66dbf29a4539aed7a85ce938) | `` boxxy: init at 0.2.7 ``                                                            |
| [`73c29761`](https://github.com/NixOS/nixpkgs/commit/73c297616f7dd1be5637e6748a1506fcc3bd4e63) | `` python310Packages.pyipma: 3.0.5 -> 3.0.6 ``                                        |