### PR TITLE
chore(flake/home-manager): `2dce7f1a` -> `da72e6fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675935446,
-        "narHash": "sha256-WajulTn7QdwC7QuXRBavrANuIXE5z+08EdxdRw1qsNs=",
+        "lastModified": 1676367705,
+        "narHash": "sha256-un5UbRat9TwruyImtwUGcKF823rCEp4fQxnsaLFL7CM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2dce7f1a55e785a22d61668516df62899278c9e4",
+        "rev": "da72e6fc6b7dc0c3f94edbd310aae7cd95c678b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`da72e6fc`](https://github.com/nix-community/home-manager/commit/da72e6fc6b7dc0c3f94edbd310aae7cd95c678b5) | `` keychain: add nushell integration `` |