### PR TITLE
chore(flake/pre-commit-hooks): `15830770` -> `5f0cba88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -219,11 +219,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1676279938,
-        "narHash": "sha256-RDyvVdituVQQZtGA7DNaJruJLDz/pfkREpUcI4ZQvsk=",
+        "lastModified": 1676513100,
+        "narHash": "sha256-MK39nQV86L2ag4TmcK5/+r1ULpzRLPbbfvWbPvIoYJE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "1583077009b6ef4236d1899c0f43cf1ce1db8085",
+        "rev": "5f0cba88ac4d6dd8cad5c6f6f1540b3d6a21a798",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                            |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
| [`071c0ebe`](https://github.com/cachix/pre-commit-hooks.nix/commit/071c0ebed5c2b89b16090fea8d909084c2ad25fd) | `` latexindent: fix unknown command line option `` |