### PR TITLE
chore(flake/nixpkgs): `545c7a31` -> `5a3b04e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676300157,
-        "narHash": "sha256-1HjRzfp6LOLfcj/HJHdVKWAkX9QRAouoh6AjzJiIerU=",
+        "lastModified": 1676391076,
+        "narHash": "sha256-t2Awu5Aucb5kVan9BniyIHn2gqDy1muzQTox9MQl09A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "545c7a31e5dedea4a6d372712a18e00ce097d462",
+        "rev": "5a3b04e58b86d885bb441ee52ed2d23128fc9156",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`5517737e`](https://github.com/NixOS/nixpkgs/commit/5517737e6e892d09e4532329704f9a801ad9c1c0) | `` clojure: 1.11.1.1208 -> 1.11.1.1224 ``                              |
| [`5c55ee6e`](https://github.com/NixOS/nixpkgs/commit/5c55ee6e74f8bc3974d198b7fc836b553c857a30) | `` gthumb: Fix build with libraw 0.21 ``                               |
| [`84bb907e`](https://github.com/NixOS/nixpkgs/commit/84bb907ec291b1860152baccdd9531537f314bd9) | `` matrix-synapse: 1.76.0 -> 1.77.0 ``                                 |
| [`0ca947e1`](https://github.com/NixOS/nixpkgs/commit/0ca947e125c56e01d2b0471eaebb60902a2c412a) | `` k3s: dynamic detection of all k3s packages ``                       |
| [`1ed45bde`](https://github.com/NixOS/nixpkgs/commit/1ed45bded000e0760bbf6593ae73a170c4fa416f) | `` pcloud: 1.10.0 -> 1.10.1 ``                                         |
| [`0094bc42`](https://github.com/NixOS/nixpkgs/commit/0094bc42f209d7454815d9925ead597abb5a951b) | `` python311.pkgs.pyvo: backport Python 3.11 support ``                |
| [`e65ce4a2`](https://github.com/NixOS/nixpkgs/commit/e65ce4a29ed500cc367e3a433b421fc80576020b) | `` bear: 3.0.21 -> 3.1.0 ``                                            |
| [`121184ae`](https://github.com/NixOS/nixpkgs/commit/121184ae3bdaeef9fc7f57f02cd10405881ca64a) | `` vscode-extensions.zhwu95.riscv: init at 0.0.8 ``                    |
| [`b160281f`](https://github.com/NixOS/nixpkgs/commit/b160281fe91ff054dda7405b1ef17d7e664a0f96) | `` brev-cli: 0.6.204 -> 0.6.206 ``                                     |
| [`87691eb9`](https://github.com/NixOS/nixpkgs/commit/87691eb9efe95110cb23a598eb2a2dc86e8f3e4f) | `` terraform-providers.google-beta: 4.52.0 → 4.53.0 ``                 |
| [`e068e211`](https://github.com/NixOS/nixpkgs/commit/e068e211c87a89bc8a70188fbc44fe1bc04e1143) | `` terraform-providers.google: 4.52.0 → 4.53.0 ``                      |
| [`a06c1b67`](https://github.com/NixOS/nixpkgs/commit/a06c1b670c28554218d1da7dc8b8c26603e69a9e) | `` terraform-providers.exoscale: 0.44.0 → 0.45.0 ``                    |
| [`5ecc72cb`](https://github.com/NixOS/nixpkgs/commit/5ecc72cb5b5e78b30cf10e9510c8e2a82bed1dfa) | `` podman: add version test for all platforms ``                       |
| [`02f92550`](https://github.com/NixOS/nixpkgs/commit/02f92550441de39d0e42b39b538ac5529714ed41) | `` podman: remove wrapper ``                                           |
| [`04b9fcca`](https://github.com/NixOS/nixpkgs/commit/04b9fcca931dbbf0e9d4861498dbf341d08fa52f) | `` nixos/podman: wrap /run/wrappers for setuid shadow binaries ``      |
| [`22df30d7`](https://github.com/NixOS/nixpkgs/commit/22df30d78e3c43a6f31ab09b8854d0a21106b63f) | `` vtm: 0.9.8r -> 0.9.8t ``                                            |
| [`b80c55a8`](https://github.com/NixOS/nixpkgs/commit/b80c55a80042400be4046df550aaa31beb2d6e71) | `` python310Packages.asana: 3.0.0 -> 3.1.0 ``                          |
| [`8b952137`](https://github.com/NixOS/nixpkgs/commit/8b95213736651d625cd431960394c0db6267225c) | `` python310Packages.BTrees: 4.11.3 -> 5.0 ``                          |
| [`4a37a591`](https://github.com/NixOS/nixpkgs/commit/4a37a5911b55f568ca65ea4fa7cf7754b82d437b) | `` sonixd: package icon and desktop file ``                            |
| [`b4fb7ad9`](https://github.com/NixOS/nixpkgs/commit/b4fb7ad95ce9282b43d395e1d8bbab4a60608b60) | `` cudatext: 1.183.0 -> 1.184.0 ``                                     |
| [`2c27b33e`](https://github.com/NixOS/nixpkgs/commit/2c27b33ec2f70a9606afea6362ba0a138d634bb3) | `` python3Packages.pyls-black: remove ``                               |
| [`ff4f390d`](https://github.com/NixOS/nixpkgs/commit/ff4f390d24b0dd07dc8e1a561cb40dc0fb861fab) | `` pingu: 0.0.3 -> 0.0.5 ``                                            |
| [`28fe8687`](https://github.com/NixOS/nixpkgs/commit/28fe8687bdc8d9cc0a9066b475dc92a70585b6eb) | `` python310Packages.home-assistant-bluetooth: 1.9.2 -> 1.9.3 ``       |
| [`c00a89a7`](https://github.com/NixOS/nixpkgs/commit/c00a89a773b0bd36425e273aefe81ca1e2fade4a) | `` python310Packages.pyoverkiz: 1.7.3 -> 1.7.4 ``                      |
| [`42e8afc5`](https://github.com/NixOS/nixpkgs/commit/42e8afc55ca2a02c7bde939811e31216936de2a3) | `` python310Packages.identify: 2.5.17 -> 2.5.18 ``                     |
| [`bcd04274`](https://github.com/NixOS/nixpkgs/commit/bcd042748009baa354cab5046aa89952b96b9458) | `` python310Packages.hahomematic: 2023.2.7 -> 2023.2.8 ``              |
| [`a4f6d3f4`](https://github.com/NixOS/nixpkgs/commit/a4f6d3f4ec0339b2438b36118dd37a0bf84bfde6) | `` lightningcss: 1.18.0 → 1.19.0 ``                                    |
| [`a7fb18c8`](https://github.com/NixOS/nixpkgs/commit/a7fb18c80422580b4d305fbe90a4b6508bf91b2a) | `` beam/fetchMixDeps: disable --only flag when mixEnv is empty ``      |
| [`6ae8fe3a`](https://github.com/NixOS/nixpkgs/commit/6ae8fe3a2ca1af6f13a3e2a0e6678608c85077c5) | `` qtstyleplugin-kvantum-qt4: 1.0.7 -> 1.0.9 ``                        |
| [`d6c97c41`](https://github.com/NixOS/nixpkgs/commit/d6c97c41df34e3cf2b08bf34893e56ee74efda96) | `` konstraint: 0.24.0 -> 0.25.0 ``                                     |
| [`6f6fba99`](https://github.com/NixOS/nixpkgs/commit/6f6fba9917ae8a06d513f75bac9b877af4fd53ac) | `` StormLib: fix darwin build ``                                       |
| [`156d3598`](https://github.com/NixOS/nixpkgs/commit/156d35986f565ceb856e5764eb4da219722b6a1d) | `` circumflex: 2.8 -> 2.8.1 ``                                         |
| [`c5474e15`](https://github.com/NixOS/nixpkgs/commit/c5474e15f1be71c7648d104ce3ed20d538f61630) | `` d2: 0.1.6 -> 0.2.0 ``                                               |
| [`0a25e2c8`](https://github.com/NixOS/nixpkgs/commit/0a25e2c87e784bf7e06e7833ec0e06d34836959a) | `` arrow-cpp: mark as unbroken on darwin (#216219) ``                  |
| [`5dcc912f`](https://github.com/NixOS/nixpkgs/commit/5dcc912f1143208df8d8bb7a75c969a592e54718) | `` mozillavpn: 0.13.0 → 0.13.1 ``                                      |
| [`af6061ef`](https://github.com/NixOS/nixpkgs/commit/af6061ef1e81aed8c821db95d9957a9a7da73b8c) | `` xgboost: R package support ``                                       |
| [`206da520`](https://github.com/NixOS/nixpkgs/commit/206da520053caa6022fc3dbbc6847939df9c8c42) | `` squawk: init at 0.20.0 ``                                           |
| [`6ad79de7`](https://github.com/NixOS/nixpkgs/commit/6ad79de7cf306a5fe07a84223f7abfafbfb1052c) | `` chromiumDev: 111.0.5563.19 -> 112.0.5582.0 ``                       |
| [`f1787f39`](https://github.com/NixOS/nixpkgs/commit/f1787f39a53c078519aed75aa9ac511479e537b1) | `` build(deps): bump cachix/install-nix-action from 18 to 19 ``        |
| [`a143b486`](https://github.com/NixOS/nixpkgs/commit/a143b4868fbe700357a1c8fa38575a6bce7c9dbc) | `` linux-firmware: actually set updateScript ``                        |
| [`58901b13`](https://github.com/NixOS/nixpkgs/commit/58901b138946c4d8a5c967ee80f1d9eb2127e81c) | `` radicle-cli: add version test ``                                    |
| [`1a6b5135`](https://github.com/NixOS/nixpkgs/commit/1a6b5135e8f91c14aa86892d85dfd1f67208e27d) | `` python3Packages.onnx: use github source & enable many more tests `` |
| [`015ba1e8`](https://github.com/NixOS/nixpkgs/commit/015ba1e833641a18b6d55c3f97a04bc54db75911) | `` gtest: add static option ``                                         |
| [`06b3819a`](https://github.com/NixOS/nixpkgs/commit/06b3819a151de8b63a47c48a35d741cb2d0e934d) | `` wireguard-tools: add bash to patchShebang .wg-quick-wrapped ``      |
| [`49c92de8`](https://github.com/NixOS/nixpkgs/commit/49c92de87a84182a683275600047c955e794eea7) | `` radicle-cli: fix build by re-adding git to nativeCheckInputs ``     |
| [`2bbb49f1`](https://github.com/NixOS/nixpkgs/commit/2bbb49f1d77ebad274f32625ca839763fd41e764) | `` python3.pkgs.validobj: 0.6 -> 0.7 ``                                |
| [`f6ba6620`](https://github.com/NixOS/nixpkgs/commit/f6ba6620ea81ed302aa80d1e38d17fb7b8b2f06e) | `` python311.pkgs.mox3: disable ``                                     |
| [`3deb8bdf`](https://github.com/NixOS/nixpkgs/commit/3deb8bdf1378082731d89607732bfea7a757fddc) | `` pythonPackages.versioningit: 2.1.0 -> 2.2.0 ``                      |
| [`d9eb9d49`](https://github.com/NixOS/nixpkgs/commit/d9eb9d4958536eee7f93c288d3c991dc61c88636) | `` python3.pkgs.hangups: drop ``                                       |
| [`03ae3799`](https://github.com/NixOS/nixpkgs/commit/03ae3799c49b0d8e757c0950f71fa4c241745907) | `` vault: 1.12.2 -> 1.12.3 ``                                          |
| [`3b8a32d1`](https://github.com/NixOS/nixpkgs/commit/3b8a32d1e5afdff4353adafd17847fa977531076) | `` flexget: 3.5.22 -> 3.5.23 ``                                        |
| [`641fb6ab`](https://github.com/NixOS/nixpkgs/commit/641fb6ab8437b87f96d07fb85263575c6d0b99f2) | `` texlive: use looping in tl2nix (#216066) ``                         |
| [`25f34241`](https://github.com/NixOS/nixpkgs/commit/25f34241cdf15ef3b48d02d5ca880a7fbb34a0ec) | `` vulkan-cts: 1.3.4.1 -> 1.3.5.0 ``                                   |
| [`f3ff97d4`](https://github.com/NixOS/nixpkgs/commit/f3ff97d4c7d5537e6125b0bba0eff829fbdef177) | `` gopass-hibp: 1.15.3 → 1.15.4 ``                                     |
| [`d20bc9b6`](https://github.com/NixOS/nixpkgs/commit/d20bc9b646bc930abc5de84a6aacb1490fcd4629) | `` gopass-summon-provider: 1.15.3 → 1.15.4 ``                          |
| [`6904ee78`](https://github.com/NixOS/nixpkgs/commit/6904ee78fd59a94c6724167860a383978623701d) | `` gopass-jsonapi: 1.15.3 → 1.15.4 ``                                  |
| [`99b2bfa5`](https://github.com/NixOS/nixpkgs/commit/99b2bfa51d80ed8628709442725adc575237f01a) | `` git-credential-gopass: 1.15.3 → 1.15.4 ``                           |
| [`c7ddec6e`](https://github.com/NixOS/nixpkgs/commit/c7ddec6e176d19ec2d6369806e6b42ef63606ce1) | `` gopass: 1.15.3 → 1.15.4 ``                                          |
| [`6a26f81a`](https://github.com/NixOS/nixpkgs/commit/6a26f81ad761da8c95f462b50e87488b7454c8e8) | `` mdbook-pdf: 0.1.4 -> 0.1.5 ``                                       |
| [`7d13ae28`](https://github.com/NixOS/nixpkgs/commit/7d13ae285193734b10bfbf7ceec584da0bbc2345) | `` pspg: install manpage ``                                            |
| [`f3648fbd`](https://github.com/NixOS/nixpkgs/commit/f3648fbddfe3484b3c0db73163dc08c8954fa091) | `` pspg: 5.7.3 -> 5.7.4 ``                                             |
| [`354bf3f2`](https://github.com/NixOS/nixpkgs/commit/354bf3f208d402857c75190afc67e1de516ddabc) | `` pspg: 5.7.2 -> 5.7.3 ``                                             |
| [`59db4617`](https://github.com/NixOS/nixpkgs/commit/59db4617e5bd17f73384bed7a6de199ea527f461) | `` nix-index: 0.1.4 -> 0.1.5 ``                                        |
| [`85cdc2a7`](https://github.com/NixOS/nixpkgs/commit/85cdc2a7ff3d2583f2a0ceafd638b50a96007e8a) | `` qdmr: fix eval with aliases disabled ``                             |
| [`11867c6e`](https://github.com/NixOS/nixpkgs/commit/11867c6ee3a6833109d640ae77a6a78d7409a7ce) | `` wordpressPackages.themes.geist: init 2.0.3 ``                       |
| [`3b1f5860`](https://github.com/NixOS/nixpkgs/commit/3b1f5860ba4baed7b141c21f650de76deb7760fb) | `` liburing: 2.2 -> 2.3 ``                                             |
| [`35ea0592`](https://github.com/NixOS/nixpkgs/commit/35ea05920e449935c383deaa713987a895b89f38) | `` whitesur-gtk-theme: 2022-10-27 -> 2023-02-07 ``                     |
| [`0eed8951`](https://github.com/NixOS/nixpkgs/commit/0eed8951acec06e303ddfcf5e8150d0483514d43) | `` cargo-semver-checks: 0.17.1 -> 0.18.0 ``                            |
| [`a6318970`](https://github.com/NixOS/nixpkgs/commit/a63189702073db9079b0db765253de92a1b232ce) | `` python310Packages.aio-geojson-usgs-earthquakes: drop asynctest ``   |
| [`475b5144`](https://github.com/NixOS/nixpkgs/commit/475b5144fb374454b07c483dc7b05686102561fe) | `` maintainers: Fix github account names/ids ``                        |
| [`70fb5ec4`](https://github.com/NixOS/nixpkgs/commit/70fb5ec4cb8c5acac048cec7a593830b2feb6b75) | `` python310Packages.aio-geojson-generic-client: drop asynctest ``     |
| [`032b2cf7`](https://github.com/NixOS/nixpkgs/commit/032b2cf74af9098f60c23ca2154209d1782bb91b) | `` python3.pkgs.quantiphy: 2.18 -> 2.19 ``                             |
| [`1069dbc6`](https://github.com/NixOS/nixpkgs/commit/1069dbc604de80eccfdd2f19b3ecc7e6311b45bc) | `` python310Packages.raincloudy: Fix build ``                          |
| [`b421e2a0`](https://github.com/NixOS/nixpkgs/commit/b421e2a0a3998939d9cdba2f791a253a2f10a570) | `` home-assistant: 2023.2.3 -> 2023.2.4 ``                             |
| [`22b11b3b`](https://github.com/NixOS/nixpkgs/commit/22b11b3bb82810fd58f6347cd18757f95c0f332c) | `` python310Packages.yalexs-ble: 1.12.8 -> 1.12.12 ``                  |
| [`18a3b21d`](https://github.com/NixOS/nixpkgs/commit/18a3b21de225ac26ec1beed1fbd8fcefcc956923) | `` python310Packages.xiaomi-ble: 0.16.1 -> 0.16.3 ``                   |
| [`a3526481`](https://github.com/NixOS/nixpkgs/commit/a3526481a6617daa2fb38a7285a2356ea66d3260) | `` python310Packages.oralb-ble: 0.17.4 -> 0.17.5 ``                    |
| [`c1cf9a0f`](https://github.com/NixOS/nixpkgs/commit/c1cf9a0fe63637dbe9b4c65896feb140079c05aa) | `` python310Packages.aioesphomeapi: 13.2.0 -> 13.3.1 ``                |
| [`98380ca5`](https://github.com/NixOS/nixpkgs/commit/98380ca5d12ea8b2b63060b839031675b1e436d5) | `` mdbook-katex: 0.3.7 -> 0.3.8 ``                                     |
| [`4ec05165`](https://github.com/NixOS/nixpkgs/commit/4ec05165a3afb988fc82aadd017fd2539e96e1a4) | `` wxGTK32: 3.2.2 -> 3.2.2.1 ``                                        |
| [`a554e68a`](https://github.com/NixOS/nixpkgs/commit/a554e68a1cabed627ffd3e31b1e89fc0d7c94295) | `` hoard: 1.3.0 -> 1.3.1 ``                                            |
| [`fd34bbb0`](https://github.com/NixOS/nixpkgs/commit/fd34bbb0adccf16d34d4b758ac5868cb2f43f2e3) | `` icu: Add `meta.pkgConfigModules` and test ``                        |
| [`d0e78671`](https://github.com/NixOS/nixpkgs/commit/d0e7867130f192a17c63d93ee47dc1e5d077d781) | `` openssl: Add `meta.pkgConfigModules` and test ``                    |
| [`d488c432`](https://github.com/NixOS/nixpkgs/commit/d488c432fb8dec5b5eaa264bd20e735313bfdf1c) | `` brotli: Add `meta.pkgConfigModules` and test ``                     |
| [`bbed2700`](https://github.com/NixOS/nixpkgs/commit/bbed27008402bb2331e45edaac8a9d7830399ced) | `` libb2: Add `meta.pkgConfigModules` and test ``                      |
| [`79631365`](https://github.com/NixOS/nixpkgs/commit/796313656cd9b5e2d0915f89f41c129d3f58f193) | `` ffmpeg: Add `meta.pkgConfigModules` and test ``                     |
| [`ee2fd1e5`](https://github.com/NixOS/nixpkgs/commit/ee2fd1e5108433cc5bba3d0bc9d7667ed1346014) | `` R: Add `meta.pkgConfigModules` and test ``                          |
| [`3f8b1578`](https://github.com/NixOS/nixpkgs/commit/3f8b15788f73b33ca1d08cd3a4e6eca8f8a9e283) | `` liblapack: Add `meta.pkgConfigModules` and test ``                  |
| [`b7e9a15a`](https://github.com/NixOS/nixpkgs/commit/b7e9a15ab9eaf13cc2b39879ab741c7ac6104d80) | `` webkitgtk: Add `meta.pkgConfigModules` and test ``                  |
| [`c733f0bf`](https://github.com/NixOS/nixpkgs/commit/c733f0bf8ad39186b9d14d4fb4d0bc1394b93940) | `` jack: Add `meta.pkgConfigModules` and test ``                       |
| [`dc327861`](https://github.com/NixOS/nixpkgs/commit/dc3278615ec0cf70bc0e6c42e01a88130f5500f9) | `` imlib2: Add `meta.pkgConfigModules` and test ``                     |
| [`205293d8`](https://github.com/NixOS/nixpkgs/commit/205293d8a97e10576119f1424e87382ab82c888c) | `` hidapi: Add `meta.pkgConfigModules` and test ``                     |
| [`e13d49d6`](https://github.com/NixOS/nixpkgs/commit/e13d49d686aaa6a582c8b8c76fa1b3032d80c83e) | `` wgo: init at 0.5.1 ``                                               |
| [`c23273af`](https://github.com/NixOS/nixpkgs/commit/c23273af54eecd78f5edf758e6ea401e839c844b) | `` lua-language-server: 3.6.10 -> 3.6.11 ``                            |
| [`8e27e6d8`](https://github.com/NixOS/nixpkgs/commit/8e27e6d83f690511ba6fcc88e922c5f2ee9a64da) | `` kluctl: 2.18.4 -> 2.19.0 ``                                         |
| [`a098dc81`](https://github.com/NixOS/nixpkgs/commit/a098dc81ae2107a7c911783c65bca9de8cbe08ce) | `` helvum: 0.3.4 -> 0.4.0 ``                                           |
| [`3af4729a`](https://github.com/NixOS/nixpkgs/commit/3af4729a3291de4f35df7af986f8a4fc52589f8f) | `` python3.pkgs.certomancer: 0.8.2 -> 0.9.1 ``                         |
| [`bb62992d`](https://github.com/NixOS/nixpkgs/commit/bb62992d4e3a50d590c27c8bbdc480b63b35f20a) | `` torq: 0.17.3 -> 0.18.17 ``                                          |
| [`8c9a8fa6`](https://github.com/NixOS/nixpkgs/commit/8c9a8fa6e37b7f4c941362a9190ba251d712788c) | `` torq: copy frontend instead of linking ``                           |
| [`e2d5eeee`](https://github.com/NixOS/nixpkgs/commit/e2d5eeeee0aa5159db1afdb7ef8d13fea2e9f703) | `` maintainers: add CardboardTurkey ``                                 |
| [`5414b4fc`](https://github.com/NixOS/nixpkgs/commit/5414b4fcd2fab250aeff5723bd302422329b5693) | `` uptime-kuma: 1.19.6 -> 1.20.0 ``                                    |
| [`f60c069a`](https://github.com/NixOS/nixpkgs/commit/f60c069a2b56d1e088d54f752cd1c681a5962eaa) | `` jellyfin-media-player: 1.7.1 -> 1.8.1 ``                            |
| [`832acbd7`](https://github.com/NixOS/nixpkgs/commit/832acbd7434c69b6c602251240d61b6a754ba17e) | `` python311.pkgs.validobj: disable ``                                 |
| [`60838304`](https://github.com/NixOS/nixpkgs/commit/60838304dd8fc5c99995b7ef2488a738ef477189) | `` signald: 0.23.0 -> 0.23.2 ``                                        |
| [`0fb0adfe`](https://github.com/NixOS/nixpkgs/commit/0fb0adfe7b5f7ab124a09343736ff70c4e0518cf) | `` enc: init at 1.1.0 ``                                               |
| [`b84ac254`](https://github.com/NixOS/nixpkgs/commit/b84ac25469743d433553d2037b9c60759b4f1c43) | `` jellyfin-mpv-shim: 2.2.0 -> 2.3.1 ``                                |
| [`87cb243d`](https://github.com/NixOS/nixpkgs/commit/87cb243dcb74cdb27e1d52023d3b2b3e338834ae) | `` python3Packages.python-mpv-jsonipc: 1.1.11 -> 1.1.14 ``             |
| [`6e9ce51d`](https://github.com/NixOS/nixpkgs/commit/6e9ce51dcea5bc070ef9f42aad3ef638c88d1877) | `` vscode-extensions.eamodio.gitlens: 2022.12.604 -> 2023.2.1204 ``    |
| [`f0a6595f`](https://github.com/NixOS/nixpkgs/commit/f0a6595fe5bebfa033c0fc1fc91d85d5f5f5c2cd) | `` k3s: add passthru.tests to all derivations ``                       |
| [`04b686d4`](https://github.com/NixOS/nixpkgs/commit/04b686d4d61ad45146212818601763a931d572da) | `` python310Packages.holoviews: 1.15.3 -> 1.15.4 ``                    |
| [`a9898979`](https://github.com/NixOS/nixpkgs/commit/a9898979dde654944719267cef74b1aa7777147f) | `` python310Packages.python-utils: fix build on darwin ``              |
| [`be4000d5`](https://github.com/NixOS/nixpkgs/commit/be4000d572ea9d384d9b705242298779fe6fb9ef) | `` python310Packages.python-utils: 3.4.5 -> 3.5.2 ``                   |
| [`0d48da7e`](https://github.com/NixOS/nixpkgs/commit/0d48da7e29148184fcb8372a1fd76a92d08ebd06) | `` python310Packages.vowpalwabbit: 9.6.0 -> 9.7.0 ``                   |
| [`af90082c`](https://github.com/NixOS/nixpkgs/commit/af90082c6130624f0c2e45d602e40f47bb445396) | `` esbuild: 0.17.7 -> 0.17.8 ``                                        |
| [`ceab3fb5`](https://github.com/NixOS/nixpkgs/commit/ceab3fb5f4ae430845e93c457b5353dc8b019e2b) | `` noti: 3.6.0 -> 3.7.0 ``                                             |
| [`bf9ab610`](https://github.com/NixOS/nixpkgs/commit/bf9ab6107e996c7937965244189ff849735de90a) | `` python311.pkgs.nipy: fix build ``                                   |
| [`0620523d`](https://github.com/NixOS/nixpkgs/commit/0620523d943c60528e7a9ffbc0e5e9cfe868ffda) | `` vsmtp: 2.1.0 -> 2.1.1 ``                                            |
| [`08834266`](https://github.com/NixOS/nixpkgs/commit/08834266e1f49e824a2057f1c7b6eb06d8409a68) | `` opencryptoki: 3.8.2 -> 3.19.0 ``                                    |
| [`5ba7fac7`](https://github.com/NixOS/nixpkgs/commit/5ba7fac716ba49bf41b154e7d15a9e10fc0ab007) | `` burpsuite: 2022.12.7 -> 2023.1.2 ``                                 |
| [`1280a27b`](https://github.com/NixOS/nixpkgs/commit/1280a27bbd5d48a6b3b015ef5ad1d229f41faa12) | `` python3.pkgs.lightning: drop ``                                     |
| [`b792e544`](https://github.com/NixOS/nixpkgs/commit/b792e5449534d8e706497af4bfe94b353de6b9a8) | `` vimPlugins.vim-clap: fix cargoSha256 ``                             |
| [`d9cebc9d`](https://github.com/NixOS/nixpkgs/commit/d9cebc9d9ed50460158a9ed046974308fd24b0b1) | `` vimPlugins.nvim-treesitter: update grammars ``                      |
| [`667b12fb`](https://github.com/NixOS/nixpkgs/commit/667b12fbcdc99ae44d077b455bede7a3450b6fa2) | `` vimPlugins.telescope-undo-nvim: init at 2023-01-29 ``               |
| [`31ec341b`](https://github.com/NixOS/nixpkgs/commit/31ec341b3c51bfc17ced17f80cc2e837cf82a4b7) | `` vimPlugins: update ``                                               |
| [`db348eb0`](https://github.com/NixOS/nixpkgs/commit/db348eb0d638ff0297411132061de10cc9ad43bf) | `` inormalize/minc-widgets/gimp-plugins: use pname & version ``        |
| [`3c881d48`](https://github.com/NixOS/nixpkgs/commit/3c881d4887a5ebcedb9441215f290106605b1ad7) | `` sway: 1.8 -> 1.8.1 ``                                               |
| [`a81a9cbf`](https://github.com/NixOS/nixpkgs/commit/a81a9cbf1226039ab9dc5d410be36a415cd4fbe7) | `` openconnect: disable useDefaultExternalBrowser when cross ``        |
| [`989dfc7c`](https://github.com/NixOS/nixpkgs/commit/989dfc7c2eef1c5e962dba4345fe2938e42e1d58) | `` python310Packages.pefile: 2022.5.30 -> 2023.2.7 ``                  |
| [`76a47699`](https://github.com/NixOS/nixpkgs/commit/76a476994ca61153399ad1675fdeb714daf4b2d6) | `` python310Packages.pefile: add changelog to meta ``                  |
| [`b512908f`](https://github.com/NixOS/nixpkgs/commit/b512908f99b5bdadd5f666f23220a82b4a672a44) | `` python310Packages.drf-yasg: 1.21.4 -> 1.21.5 ``                     |
| [`4ea38729`](https://github.com/NixOS/nixpkgs/commit/4ea38729b3e9e7b1738ed433971a099d2b14ebbc) | `` python310Packages.iminuit: 2.18.0 -> 2.19.0 ``                      |
| [`a6081aed`](https://github.com/NixOS/nixpkgs/commit/a6081aedf809e850b5b9eadaa0565ce968df3a72) | `` python310Packages.clustershell: 1.9 -> 1.9.1 ``                     |
| [`98c1d7eb`](https://github.com/NixOS/nixpkgs/commit/98c1d7eb6747db65eab6c8112d35f618141f8079) | `` awscli2: 2.9.21 -> 2.9.23 ``                                        |
| [`34ccf74c`](https://github.com/NixOS/nixpkgs/commit/34ccf74c23cdcf6013c841a2575ebb8c12875680) | `` python3Packages.n3fit: init at 4.0 ``                               |
| [`ede042f5`](https://github.com/NixOS/nixpkgs/commit/ede042f54dbc9dbfdb846b7203c5f23e5a5d17e4) | `` nnpdf: 4.0.4 -> 4.0.6 ``                                            |
| [`3dc2e4d0`](https://github.com/NixOS/nixpkgs/commit/3dc2e4d016178ccbac480f98a33f40bd27806a46) | `` python310Packages.oslo-log: 5.0.2 -> 5.1.0 ``                       |
| [`6f7a553d`](https://github.com/NixOS/nixpkgs/commit/6f7a553d0a3c3dd59a4203afe97cf8e45a734afa) | `` maintainers: add andrewsmith ``                                     |
| [`571de380`](https://github.com/NixOS/nixpkgs/commit/571de3804ff764e3b37a578853e83589fa4f552b) | `` maintainers: add rvnstn ``                                          |
| [`52a153aa`](https://github.com/NixOS/nixpkgs/commit/52a153aae20d999854d7ece49b865e95b929e490) | `` k3s: test all versions ``                                           |
| [`7893a8f7`](https://github.com/NixOS/nixpkgs/commit/7893a8f78fbea7dbca89268c4af14eb8a99d74d4) | `` chromiumBeta: 110.0.5481.77 -> 111.0.5563.19 ``                     |
| [`5cbeee05`](https://github.com/NixOS/nixpkgs/commit/5cbeee05f3c05c6049ab24b8ab083c328d91a94b) | `` python310Packages.types-protobuf: 4.21.0.2 -> 4.21.0.5 ``           |
| [`08e6d08a`](https://github.com/NixOS/nixpkgs/commit/08e6d08acea8ac91619c5be4223d44e49f6476a7) | `` qemu: Remove --cpu= flag ``                                         |
| [`f70071e4`](https://github.com/NixOS/nixpkgs/commit/f70071e41da960a1d68d3cef0cb1e2e4d0d93fbf) | `` qemu: fix cross compilation, again ``                               |
| [`61d2d6ed`](https://github.com/NixOS/nixpkgs/commit/61d2d6ed26434f9a1572165673776b09832ab40a) | `` python311Packages.cot: skip failing tests ``                        |
| [`266eafad`](https://github.com/NixOS/nixpkgs/commit/266eafadc01d98b4c2046b136a4edeb78a68c647) | `` git-credential-keepassxc: 0.11.0 -> 0.12.0 ``                       |
| [`1f884807`](https://github.com/NixOS/nixpkgs/commit/1f88480755058f929995b167d318cdbf5da89d86) | `` python310Packages.chart-studio: 5.11.0 -> 5.13.0 ``                 |
| [`187e4348`](https://github.com/NixOS/nixpkgs/commit/187e43489b5f4cbe319305cae9ca1acda01216f1) | `` python310Packages.inquirer: add changelog to meta ``                |
| [`112a1cff`](https://github.com/NixOS/nixpkgs/commit/112a1cffabce7afb9fed5da89a87a80f50854c24) | `` python310Packages.inquirer: 3.1.1 -> 3.1.2 ``                       |
| [`dce177b0`](https://github.com/NixOS/nixpkgs/commit/dce177b067b0a98245421b698cc176ab5f790db6) | `` python310Packages.coconut: 2.1.1 -> 2.2.0 ``                        |
| [`0675daec`](https://github.com/NixOS/nixpkgs/commit/0675daec05c627b78aeca610f345738a11a77f07) | `` ikiwiki: add ikiwiki-full ``                                        |
| [`cbed6a64`](https://github.com/NixOS/nixpkgs/commit/cbed6a640f9d1aeb7621a8048e6245cafaca2568) | `` ikiwiki: fix broken test for gitSupport ``                          |
| [`26dbf446`](https://github.com/NixOS/nixpkgs/commit/26dbf446cf3bd2da334d7384512a9b97839545cb) | `` Change clickhouse's module conf directory to permit overrides ``    |