### PR TITLE
chore(flake/nixpkgs): `5a3b04e5` -> `28319deb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676391076,
-        "narHash": "sha256-t2Awu5Aucb5kVan9BniyIHn2gqDy1muzQTox9MQl09A=",
+        "lastModified": 1676481215,
+        "narHash": "sha256-afma/1RU0EePRyrBPcjBdOt+dV8z1bJH9dtpTN/WXmY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a3b04e58b86d885bb441ee52ed2d23128fc9156",
+        "rev": "28319deb5ab05458d9cd5c7d99e1a24ec2e8fc4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`9e9007e4`](https://github.com/NixOS/nixpkgs/commit/9e9007e45fec743f41f47aa92c47ba36bc8e76b5) | `` nixos/opensearch: Use DynamicUser and StateDirectory by default ``             |
| [`fa903598`](https://github.com/NixOS/nixpkgs/commit/fa90359876285998d9e1877c671dc6cadaf9cb2c) | `` linux/hardened/patches/6.1: 6.1.10-hardened1 -> 6.1.11-hardened1 ``            |
| [`5aec2a79`](https://github.com/NixOS/nixpkgs/commit/5aec2a7956678bca924b3324f773eb0cd1665dca) | `` linux/hardened/patches/5.15: 5.15.92-hardened1 -> 5.15.93-hardened1 ``         |
| [`30a72be3`](https://github.com/NixOS/nixpkgs/commit/30a72be3384bc56f4102e42cd20001cfa847b99f) | `` linux-rt_5_15: 5.15.92-rt57 -> 5.15.93-rt58 ``                                 |
| [`6ee2f048`](https://github.com/NixOS/nixpkgs/commit/6ee2f048f2e18d77afcc1e3f4c830573c21e29fd) | `` linux: 6.1.11 -> 6.1.12 ``                                                     |
| [`30e36d2e`](https://github.com/NixOS/nixpkgs/commit/30e36d2e82c33cab87f1f50f4e66e1930942690f) | `` linux: 5.15.93 -> 5.15.94 ``                                                   |
| [`c5a0a5ac`](https://github.com/NixOS/nixpkgs/commit/c5a0a5ac5e205458224755ae194f768f2a8e6d8f) | `` curl: add pkg-config metadata for libcurl.pc ``                                |
| [`bc12cf59`](https://github.com/NixOS/nixpkgs/commit/bc12cf5976f682bfada4a780d4209202fa514512) | `` linuxKernel.kernels.linux_zen: 6.1.10-zen1 -> 6.1.12-zen1 ``                   |
| [`d7e04271`](https://github.com/NixOS/nixpkgs/commit/d7e04271d5fcc702f5f8b0d6f0ca0d8a9babae5d) | `` linuxKernel.kernels.linux_lqx: 6.1.10-lqx1 -> 6.1.12-lqx1 ``                   |
| [`5ef2ffc6`](https://github.com/NixOS/nixpkgs/commit/5ef2ffc6c9ff40f9a18fee2d17cc7c1f2f1b4f55) | `` esphome: 2022.12.8 -> 2023.2.0 ``                                              |
| [`016bfaf3`](https://github.com/NixOS/nixpkgs/commit/016bfaf3026ecc096360c78f93ae9d046839e1d7) | `` numix-icon-theme-circle: 23.02.05 -> 23.02.12 ``                               |
| [`2b54954f`](https://github.com/NixOS/nixpkgs/commit/2b54954fdb4a25c6f9cf80cfd36c43e4c4577c0b) | `` python3Packages.aiohttp-jinja2: remove maintainer ``                           |
| [`88128a0d`](https://github.com/NixOS/nixpkgs/commit/88128a0d86d74be43afe2740307e0d45af2b9539) | `` python310Packages.google-cloud-pubsub: 2.14.0 -> 2.14.1 ``                     |
| [`e6257034`](https://github.com/NixOS/nixpkgs/commit/e6257034e85e9bf96e165fc243b67a32712ede88) | `` eccodes: remove no longer needed replacement ``                                |
| [`a9b83cbf`](https://github.com/NixOS/nixpkgs/commit/a9b83cbff472c52ef468dd42452c3d6587e812fb) | `` eccodes: 2.24.2 -> 2.28.0 ``                                                   |
| [`c5edb111`](https://github.com/NixOS/nixpkgs/commit/c5edb111ae86d707134138f16587da19d9c55fd8) | `` tbls: 1.61.0 -> 1.62.0 ``                                                      |
| [`0b6ee488`](https://github.com/NixOS/nixpkgs/commit/0b6ee48830e8089e8a8decf76aa17daf0929729d) | `` zine: 0.10.0 -> 0.10.1 ``                                                      |
| [`bb3879e8`](https://github.com/NixOS/nixpkgs/commit/bb3879e8774124e43ee8d52ea67d06a03071fa6a) | `` terraform-providers.spotinst: 1.97.0 → 1.99.0 ``                               |
| [`94c35e37`](https://github.com/NixOS/nixpkgs/commit/94c35e37558662f72b8fb5b21209dcbafeee114c) | `` terraform-providers.helm: 2.8.0 → 2.9.0 ``                                     |
| [`62db9eec`](https://github.com/NixOS/nixpkgs/commit/62db9eec723f6df3618bb6d9a1ef23d548d329bf) | `` terraform-providers.google-beta: 4.53.0 → 4.53.1 ``                            |
| [`f29d37e5`](https://github.com/NixOS/nixpkgs/commit/f29d37e5002bd4b924ca3d0eda1aeb1914588f3d) | `` terraform-providers.google: 4.53.0 → 4.53.1 ``                                 |
| [`48a0a6cc`](https://github.com/NixOS/nixpkgs/commit/48a0a6ccee48b908c7a86d91396c270b48e79c0c) | `` terraform-providers.brightbox: 3.2.0 → 3.2.1 ``                                |
| [`bd067f1a`](https://github.com/NixOS/nixpkgs/commit/bd067f1a8c8cfce562006b2b527badf187ca62c3) | `` amber-secret: 0.1.3 -> 0.1.5 ``                                                |
| [`0c9bacba`](https://github.com/NixOS/nixpkgs/commit/0c9bacbad83474be5e664bf470b94178bb54b852) | `` gotrue-supabase: 2.47.0 -> 2.47.1 ``                                           |
| [`3fb06366`](https://github.com/NixOS/nixpkgs/commit/3fb063661032667cec8a853aa94364e428fdf888) | `` mdbook-open-on-gh: 2.3.2 -> 2.3.3 ``                                           |
| [`9aac52f6`](https://github.com/NixOS/nixpkgs/commit/9aac52f6364bfe727df08c115993c3ced202fb8d) | `` syft: 0.70.0 -> 0.71.0 ``                                                      |
| [`a1fed0d5`](https://github.com/NixOS/nixpkgs/commit/a1fed0d5c493a097bb2f43579be8745d4b0bb1f6) | `` mdbook-open-on-gh: 2.3.1 -> 2.3.2 ``                                           |
| [`cfd6d439`](https://github.com/NixOS/nixpkgs/commit/cfd6d439f2fab36535c251df6de3bfd3259a9396) | `` static-web-server: 2.14.1 -> 2.14.2 ``                                         |
| [`dbed3a07`](https://github.com/NixOS/nixpkgs/commit/dbed3a071fe86ae546f4da7df96614e2000da75f) | `` slop: fix build ``                                                             |
| [`f5f6f058`](https://github.com/NixOS/nixpkgs/commit/f5f6f0582b56f7c0d0c6e3ba92832a5dcfb13f5b) | `` calibre: add speechd as python dependencies ``                                 |
| [`36c3acef`](https://github.com/NixOS/nixpkgs/commit/36c3acef215191c09d5be2cac30096e6d127ce38) | `` microcodeIntel: 20221108 -> 20230214 ``                                        |
| [`413e3eb3`](https://github.com/NixOS/nixpkgs/commit/413e3eb3c0746db175b747e7aa6996667b47beca) | `` gpg-tui: 0.9.3 -> 0.9.4 ``                                                     |
| [`613fac9d`](https://github.com/NixOS/nixpkgs/commit/613fac9d41baa970361e47e5c03ba6bcd6d3a490) | `` pulumi: 3.54.0 -> 3.55.0 ``                                                    |
| [`56a285e2`](https://github.com/NixOS/nixpkgs/commit/56a285e2b78b3e5a36ac8f3752723bd9965eb190) | `` gtksourceview: remove with lib over entire file ``                             |
| [`747decaf`](https://github.com/NixOS/nixpkgs/commit/747decaf2e5afb22185e71943de5ebc48daaf41a) | `` caddy: 2.6.3 -> 2.6.4 ``                                                       |
| [`d6ba2dd3`](https://github.com/NixOS/nixpkgs/commit/d6ba2dd35403db427e53568653cfb03d1b2fd7be) | `` android-studio: 2022.1.1.19 -> 2022.1.1.20 ``                                  |
| [`0dfdc09d`](https://github.com/NixOS/nixpkgs/commit/0dfdc09dba3ea6e873c5dbc81dc88577cab97979) | `` libadwaita: 1.2.1 -> 1.2.2 ``                                                  |
| [`07be193b`](https://github.com/NixOS/nixpkgs/commit/07be193b44a688b092aaa17e32aefaf7977a22bf) | `` python310Packages.approvaltests: 8.1.0 -> 8.2.0 ``                             |
| [`0afb28ea`](https://github.com/NixOS/nixpkgs/commit/0afb28ea1f6eb8450c982316f5a4b4e8340e8339) | `` python310Packages.twitchapi: 3.7.0 -> 3.8.0 ``                                 |
| [`0f923da3`](https://github.com/NixOS/nixpkgs/commit/0f923da38be266e8d2862c3b8ebbf6d5b561dc1e) | `` nixos/tests/predictable-interface-names: fix eval ``                           |
| [`8b84a720`](https://github.com/NixOS/nixpkgs/commit/8b84a720e87fe30f992fcee9ba9ae4b5f5588b91) | `` nixos/doc: add release note for opensearch ``                                  |
| [`4561785d`](https://github.com/NixOS/nixpkgs/commit/4561785dfc6f454ce4df116a212f9282be76a164) | `` nixos/tests/opensearch: init ``                                                |
| [`d7eb44a4`](https://github.com/NixOS/nixpkgs/commit/d7eb44a4210e86e93002a5de90dd425ddef8e5d4) | `` nixos/opensearch: init module ``                                               |
| [`14a11460`](https://github.com/NixOS/nixpkgs/commit/14a114606a660e99feec27de917eec7e061201d4) | `` opensearch: init at 2.5.0 ``                                                   |
| [`7cccc07a`](https://github.com/NixOS/nixpkgs/commit/7cccc07ab2acf7e3935c3673d2a8df54762ba7b5) | `` admin-fe: 2022-09-10 -> 2023-02-11 ``                                          |
| [`507c66f5`](https://github.com/NixOS/nixpkgs/commit/507c66f5b1829b44e660f33ea2d124b07c395bc4) | `` pleroma-fe: Rename to akkoma-fe ``                                             |
| [`7ea52d1d`](https://github.com/NixOS/nixpkgs/commit/7ea52d1d387fe47fdf29e95bd10de8fabda99e53) | `` pleroma-fe: 2022-12-10 -> 2023-02-11 ``                                        |
| [`7ccf83c6`](https://github.com/NixOS/nixpkgs/commit/7ccf83c6472bc0f1ac8c6d84acc1e7c928b3d6c6) | `` akkoma: 3.5.0 -> 3.6.0 ``                                                      |
| [`cce466a5`](https://github.com/NixOS/nixpkgs/commit/cce466a5827333c67a5a9ae4c2929e7ce1c0050b) | `` graalvm*-ce: allow all parameters to be overriden ``                           |
| [`2b4f446e`](https://github.com/NixOS/nixpkgs/commit/2b4f446ee82c2962fe5a86c26675c6205f40754e) | `` spidermonkey_91: 91.12.0 -> 91.13.0 ``                                         |
| [`f7eba371`](https://github.com/NixOS/nixpkgs/commit/f7eba3716c09b53359c4d206f46e10ee9b2c78d7) | `` spidermonkey_102: 102.1.0 -> 102.8.0 ``                                        |
| [`10d31fb8`](https://github.com/NixOS/nixpkgs/commit/10d31fb80611a59a342c6cf51ca81584338a6326) | `` cargo-dist: init at 0.0.2 ``                                                   |
| [`47ccc24b`](https://github.com/NixOS/nixpkgs/commit/47ccc24b0afa63f555279feb3e57d3e6538301c1) | `` netdata: 1.37.1 -> 1.38.1 ``                                                   |
| [`bc3d5934`](https://github.com/NixOS/nixpkgs/commit/bc3d5934d7f276a21537b40159491257ee163d94) | `` treewide: use lib.optionals ``                                                 |
| [`9016c8a0`](https://github.com/NixOS/nixpkgs/commit/9016c8a006d6e339650739be659473103cba1d21) | `` firefox-esr-unwrapped: 102.7.0esr -> 102.8.0esr ``                             |
| [`496b1fb4`](https://github.com/NixOS/nixpkgs/commit/496b1fb4978550f8ef18840cd545d627e3e948d4) | `` firefox-bin-unwrapped: 109.0.1 -> 110.0 ``                                     |
| [`f6670807`](https://github.com/NixOS/nixpkgs/commit/f6670807d84299244c2952910b72603b911d9eaa) | `` firefox-unwrapped: 109.0.1 -> 110.0 ``                                         |
| [`b3c41de5`](https://github.com/NixOS/nixpkgs/commit/b3c41de572f8601dcd3a89eccf2ee1eafe36ee36) | `` nfd: 0.7.1 -> 22.12 ``                                                         |
| [`8e2c342d`](https://github.com/NixOS/nixpkgs/commit/8e2c342d1b1c61639a095ac7a752adc7acffd1ed) | `` goreleaser: 1.15.1 -> 1.15.2 ``                                                |
| [`3926d8c4`](https://github.com/NixOS/nixpkgs/commit/3926d8c482fcb577f22e2c68ed36d537fb6a927c) | `` graalvmCEPackages.ruby-installable-svm: disable broken test in darwin ``       |
| [`c09076d5`](https://github.com/NixOS/nixpkgs/commit/c09076d5d94a84af5866f10a6ef4ae23f9de6fcb) | `` listenbrainz-mpd: init at 2.0.2 ``                                             |
| [`6e6610ed`](https://github.com/NixOS/nixpkgs/commit/6e6610edd48f706b0eb8d8a846ea5b453d1ff28a) | `` python3Packages.patool: local backport of `file` regression fix ``             |
| [`19e4e0a5`](https://github.com/NixOS/nixpkgs/commit/19e4e0a5e9465de8a60e7b62a37fa97d2dc06087) | `` graalvmCEPackages.graaljs: init at 22.3.1 ``                                   |
| [`248449fb`](https://github.com/NixOS/nixpkgs/commit/248449fbdf50e60cc38a52c243e3d68bb3efcb66) | `` graalvmCEPackages: formatting ``                                               |
| [`820eb1cc`](https://github.com/NixOS/nixpkgs/commit/820eb1cc8dfed101fd25c81f8aef9bf68210da79) | `` graalvmCEPackages.buildGraalvm: disable test in Darwin ``                      |
| [`8422db6f`](https://github.com/NixOS/nixpkgs/commit/8422db6f0da1b2e7920f1d0c3be4c2e583a497a1) | `` eccodes: build with gcc on darwin ``                                           |
| [`eaa3e39c`](https://github.com/NixOS/nixpkgs/commit/eaa3e39cc0e870e38d9d2ac6d105458b4df45830) | `` graalvmCEPackages.ruby-installable-svm: run patchelf only in Linux ``          |
| [`a065de41`](https://github.com/NixOS/nixpkgs/commit/a065de41acc840cbb2931a68f1177d8b6eddc2f0) | `` graalvmCEPackages.ruby-installable-svm: update comment about locale ``         |
| [`3e5d655f`](https://github.com/NixOS/nixpkgs/commit/3e5d655f0f3305dfac6d397734fcfd74e5482573) | `` graalvmCEPackages.graalvm11-ce-full: fix llvm-installable-svm version ``       |
| [`c9d481f3`](https://github.com/NixOS/nixpkgs/commit/c9d481f3caa646e1131e254dd8ad8919c17b7611) | `` graalvm*-ce-full: improve comment about it ``                                  |
| [`a51f9c5c`](https://github.com/NixOS/nixpkgs/commit/a51f9c5c1ca965c2dd3780d86692ce7766cc0930) | `` spotify, renpy: fix wrong ffmpeg references ``                                 |
| [`acf85793`](https://github.com/NixOS/nixpkgs/commit/acf85793075f03d54d6639abc3dd02503f7c8499) | `` graalvmCEPackages.buildGraalvmProduct: add passthru.graalvmPhases ``           |
| [`140046c4`](https://github.com/NixOS/nixpkgs/commit/140046c4225a8bc349a1e9241f3666b739d5b5b7) | `` graalvmCEPackages.ruby-installable-svm: init at 22.3.1 ``                      |
| [`365ff224`](https://github.com/NixOS/nixpkgs/commit/365ff22467cf1a43ed36f9c5aac6851840b6e84b) | `` graalvmCEPackages.llvm-installable-svm: init at 22.3.1 ``                      |
| [`4f150675`](https://github.com/NixOS/nixpkgs/commit/4f150675badaeaaf2aa9e2c49ff37a69e52b9c72) | `` graalvm*-ce: make update.sh script re-use cache ``                             |
| [`f164ce43`](https://github.com/NixOS/nixpkgs/commit/f164ce437306c2e7fe41c758226ead343091bcb9) | `` vhs: add chromium to wrapper ``                                                |
| [`e9748e4b`](https://github.com/NixOS/nixpkgs/commit/e9748e4b9bc39bd5efca90f5eb5f098741276dd4) | `` vhs: remove unneeded buildInputs ``                                            |
| [`b4c6ce42`](https://github.com/NixOS/nixpkgs/commit/b4c6ce423b98d65d4e1d4618cae2d010c5024af6) | `` libdisplay-info: init at 0.1.0 ``                                              |
| [`e918da4d`](https://github.com/NixOS/nixpkgs/commit/e918da4d48ca1e5721cb11ade963e6c4ec3c91d0) | `` openssh: 9.1p1 -> 9.2p1 ``                                                     |
| [`9286a755`](https://github.com/NixOS/nixpkgs/commit/9286a75505ce335cee5e817192aefd6fbbc9e1d4) | `` jmol: 14.32.83 -> 16.1.3 ``                                                    |
| [`a217df51`](https://github.com/NixOS/nixpkgs/commit/a217df51cf3d4a6dba245eba903f1b5604ca30a1) | `` maliit-framework: backport GCC 12 build fix ``                                 |
| [`da6293b9`](https://github.com/NixOS/nixpkgs/commit/da6293b9b534518be800eede49cad6765ad6be8f) | `` nixos/doc: add release note for Plasma 5.27 ``                                 |
| [`c3f2eb7d`](https://github.com/NixOS/nixpkgs/commit/c3f2eb7dba0ba89c4cd33ae4d8b2d92ea5baa109) | `` applet-window-buttons: backport build fixes for Plasma 5.27 ``                 |
| [`ebd78ed6`](https://github.com/NixOS/nixpkgs/commit/ebd78ed69f7a526cfc9ddea22acff5d0d7326795) | `` lxqt-config: backport build fixes for Plasma 5.27 ``                           |
| [`06ca9b6b`](https://github.com/NixOS/nixpkgs/commit/06ca9b6bd82924d28bbe2489d3d72f56a6d5a427) | `` kwin: force gcc12Stdenv on aarch64 ``                                          |
| [`0a1a4be7`](https://github.com/NixOS/nixpkgs/commit/0a1a4be75e81601b7941301673958e55c77125b2) | `` plasma5: allow overriding stdenv in wrapper ``                                 |
| [`d5210b67`](https://github.com/NixOS/nixpkgs/commit/d5210b672557dce7fb4b05018ef6f00dd69f536d) | `` kwin: stop reverting c++20 things ``                                           |
| [`0091bd63`](https://github.com/NixOS/nixpkgs/commit/0091bd63464bf61a75ec98808cb3b9d7fa7fb02b) | `` kinfocenter: symlink correct executable ``                                     |
| [`803c28d8`](https://github.com/NixOS/nixpkgs/commit/803c28d81e9d9b4a682b2f02e95d462e0d5f3984) | `` plasma-remotecontrollers: add new dependency ``                                |
| [`4d28accf`](https://github.com/NixOS/nixpkgs/commit/4d28accf12230fea2b8fe220ce4a49de08bf3c25) | `` kwin: fixup patch ``                                                           |
| [`2469eab4`](https://github.com/NixOS/nixpkgs/commit/2469eab45efef92d0b2a084064cf5cbc444cc08b) | `` kscreenlocker: and libkscreen dependency ``                                    |
| [`b7409ad3`](https://github.com/NixOS/nixpkgs/commit/b7409ad3bff4f89f12676a30f54fcedd5e2934f4) | `` libkscreen: refresh patch ``                                                   |
| [`84747163`](https://github.com/NixOS/nixpkgs/commit/8474716356e4f542faea463647b686fecb045d07) | `` nixos/plasma5: install flatpak-kcm if needed ``                                |
| [`f0b101fd`](https://github.com/NixOS/nixpkgs/commit/f0b101fd06a0b186226fb6a163c0ff0b7b48a18e) | `` plasma-welcome: init at 5.27.0 ``                                              |
| [`131c8fa5`](https://github.com/NixOS/nixpkgs/commit/131c8fa5327227bfeb77977fc05bf6d84dbbfe7d) | `` kuserfeedback: init at 1.2.0 ``                                                |
| [`984315e6`](https://github.com/NixOS/nixpkgs/commit/984315e6e1a55015b79c412a52941e4219f2ff1f) | `` flatpak-kcm: init at 5.27.0 ``                                                 |
| [`9bd88aa6`](https://github.com/NixOS/nixpkgs/commit/9bd88aa6ec3fa00b8745b4e528ca09ea51aabd09) | `` plasma5: 5.26.5 -> 5.27.0 ``                                                   |
| [`a80aad7a`](https://github.com/NixOS/nixpkgs/commit/a80aad7a10c352d77f571bbcc557d50f92fa33fe) | `` c64-debugger: init at 0.64.58.6 ``                                             |
| [`2776e629`](https://github.com/NixOS/nixpkgs/commit/2776e6295585a3927c8674669c0c73e43e998367) | `` oh-my-posh: 14.2.5 -> 14.2.7 ``                                                |
| [`1645ebc8`](https://github.com/NixOS/nixpkgs/commit/1645ebc882f17e0913aefafcedcafc7cbdb62fa2) | `` soco-cli: 0.4.21 -> 0.4.55 ``                                                  |
| [`7284a97d`](https://github.com/NixOS/nixpkgs/commit/7284a97dff30497e9f2e071dc5b39d7df4560fad) | `` python310Packages.dbus-fast: 1.84.0 -> 1.84.1 ``                               |
| [`171730f0`](https://github.com/NixOS/nixpkgs/commit/171730f0f744675b14fdc3109f0bb2dd92b59dde) | `` graalvmCEProducts.buildGraalvmProduct: make it overridable ``                  |
| [`751f8617`](https://github.com/NixOS/nixpkgs/commit/751f8617b38e915500142a2ac001b4586722b4ed) | `` nix-your-shell: 1.0.1 -> 1.0.2 ``                                              |
| [`6f966cdd`](https://github.com/NixOS/nixpkgs/commit/6f966cdd2adc51761d686cd0d7a5393bca595acd) | `` python310Packages.astropy-healpix: skip test_interpolate_bilinear_skycoord ``  |
| [`e17f76f9`](https://github.com/NixOS/nixpkgs/commit/e17f76f94f2fd9460bbf33eb072a0e0e7d807f4c) | `` graalvmCEPackages.wasm-installable-svm: init at 22.3.1 ``                      |
| [`c37428c7`](https://github.com/NixOS/nixpkgs/commit/c37428c7f35289e7b52092635777020ec6def81c) | `` graalvmCEPackages.python-installable-svm: init at 22.3.1 ``                    |
| [`ccbff74b`](https://github.com/NixOS/nixpkgs/commit/ccbff74b884ea0e16c1a970017b9f4ad0c083ff9) | `` graalvmCEPackages.buildGraalvmProduct: inherit default meta from graalvm-ce `` |
| [`cdb39a86`](https://github.com/NixOS/nixpkgs/commit/cdb39a86e0dd7cda3a057f4f4795485a5c9b9be5) | `` treewide: use optionalString ``                                                |
| [`e2357870`](https://github.com/NixOS/nixpkgs/commit/e23578703ad5d57bfa1c48db341348e5cdd25b1b) | `` rubyPackages: update ``                                                        |
| [`6965ac6c`](https://github.com/NixOS/nixpkgs/commit/6965ac6ccecb23e1120aad8fdb67fdcd89a0bc9f) | `` rubyPackages.mail: init at 2.8.1 ``                                            |
| [`78aa32e7`](https://github.com/NixOS/nixpkgs/commit/78aa32e76e2e7e1c15a2353d9df0f62360a33781) | `` Revert "dosbox-staging: add meta.changelog" ``                                 |
| [`a9237c3a`](https://github.com/NixOS/nixpkgs/commit/a9237c3a605ff641fe7986d1c00b5faf87324f7d) | `` Revert "irr1: add meta.changelog" ``                                           |
| [`b75c6c70`](https://github.com/NixOS/nixpkgs/commit/b75c6c70bdca991cd0c4f4a700899bd9b2480bc7) | `` gnome.gnome-software: 43.3 → 43.4 ``                                           |
| [`1543d46a`](https://github.com/NixOS/nixpkgs/commit/1543d46a89571e41d377f35c1bd74288a0581d81) | `` evolution-ews: 3.46.3 → 3.46.4 ``                                              |
| [`549d7f90`](https://github.com/NixOS/nixpkgs/commit/549d7f905ecda05d3dbb6765e77f490c83be140a) | `` evolution-data-server: 3.46.3 → 3.46.4 ``                                      |
| [`af9ab543`](https://github.com/NixOS/nixpkgs/commit/af9ab54357371cde8ce7afd458738dfb4e401731) | `` evolution: 3.46.3 → 3.46.4 ``                                                  |
| [`b0f5cb08`](https://github.com/NixOS/nixpkgs/commit/b0f5cb08bf1f2f7d5a4c659bdd451b904cf7250e) | `` pyside2: Disable on Python 3.11 or later ``                                    |
| [`53cd64ce`](https://github.com/NixOS/nixpkgs/commit/53cd64ce18c415dbf47e16c69f8e412e40f731f1) | `` pyside2: Add qt3d to buildInputs ``                                            |
| [`4ed059d0`](https://github.com/NixOS/nixpkgs/commit/4ed059d041c25cc2d933620d3a27d74dfa7ccb97) | `` vmTools: update debian versions ``                                             |
| [`bae9dc42`](https://github.com/NixOS/nixpkgs/commit/bae9dc42dcdfcc6fedae1a6c8a4dc423b6fadfed) | `` river: 0.2.3 -> 0.2.4 ``                                                       |
| [`14edf27b`](https://github.com/NixOS/nixpkgs/commit/14edf27b25d929459c371b2a7fc5167ab5fa497d) | `` python310Packages.grad-cam: init at 1.4.6 ``                                   |
| [`35b5c598`](https://github.com/NixOS/nixpkgs/commit/35b5c598f10c88b9a2ac571c477586bd2fd0feba) | `` deepin-reader: init at 5.10.28 ``                                              |
| [`79a30130`](https://github.com/NixOS/nixpkgs/commit/79a301305be732d1bc294dcc18126f14f7ef5581) | `` nginx: remove with lib over entire file ``                                     |
| [`1de7179b`](https://github.com/NixOS/nixpkgs/commit/1de7179b424a328a534f09184a7f65f2e3882b90) | `` imaginary: fix tests on Darwin ``                                              |
| [`b872c2ad`](https://github.com/NixOS/nixpkgs/commit/b872c2ad6ada8a23e4814fc26fab9f2de3243bfd) | `` vips: don't build gtk_doc on Darwin ``                                         |
| [`152204b0`](https://github.com/NixOS/nixpkgs/commit/152204b08cf68bc4f84152e12dddf5b061fea7d4) | `` vips: 8.13.3 -> 8.14.1 ``                                                      |
| [`3fb9672b`](https://github.com/NixOS/nixpkgs/commit/3fb9672b71c61854fbdddfc8be9c7159d1c1ea55) | `` vips: Switch to Meson ``                                                       |
| [`c1ab1549`](https://github.com/NixOS/nixpkgs/commit/c1ab15495e72643b205887db388746f5994901aa) | `` ndn-tools: 0.7.0 -> 22.12 ``                                                   |
| [`86e33692`](https://github.com/NixOS/nixpkgs/commit/86e33692cc9f308ab672cd05845a3c91e78540a4) | `` ndn-cxx: 0.7.1 -> 0.8.1 ``                                                     |
| [`3e1fdaf2`](https://github.com/NixOS/nixpkgs/commit/3e1fdaf2e5d9f13fa0d5b08e866201173ef70b98) | `` nixos/nextcloud: fix typo in option description ``                             |
| [`fd06c8fc`](https://github.com/NixOS/nixpkgs/commit/fd06c8fc9f497975bac50a8f3188fcb9a3a40477) | `` nixos/systemd-initrd: allow symlink into when checking for `/prepare-root` ``  |
| [`030b1aae`](https://github.com/NixOS/nixpkgs/commit/030b1aae17a7c520ae648fa9e8c3621889d04014) | `` scorecard: 4.8.0 -> 4.10.2 ``                                                  |
| [`c5923af9`](https://github.com/NixOS/nixpkgs/commit/c5923af98669282886140478c6d83ddcdcf77a42) | `` lib/systems/architectures: expand inferiors ``                                 |
| [`38508169`](https://github.com/NixOS/nixpkgs/commit/385081693ecd71bed8d4352cd45457819abbcad9) | `` nixos/moonraker: Don't allow Moonraker to validate its systemd service ``      |
| [`9411ea92`](https://github.com/NixOS/nixpkgs/commit/9411ea9214a23fda8ad17fbe2386dbdec4545457) | `` nixos/moonraker: Remove database_path ``                                       |
| [`7856ac79`](https://github.com/NixOS/nixpkgs/commit/7856ac79ac9edc10078986aba25e2271076f3645) | `` nixos/moonraker: Deprecate configDir ``                                        |
| [`76583721`](https://github.com/NixOS/nixpkgs/commit/76583721855538f906f451d5711fa65729975299) | `` nixos/moonraker: Pass -d (data-path) to moonraker ``                           |
| [`ce86df4a`](https://github.com/NixOS/nixpkgs/commit/ce86df4a2164c568e73f866eca0174f4ac121d0e) | `` nixos/moonraker: Add zhaofengli as maintainer ``                               |
| [`7b664c15`](https://github.com/NixOS/nixpkgs/commit/7b664c15c1f750f41e13ff93e8f0319b88ab79bf) | `` moonraker: unstable-2022-04-23 -> unstable-2022-11-18 ``                       |