### PR TITLE
chore(flake/nixpkgs): `28319deb` -> `ac1f5b72`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676481215,
-        "narHash": "sha256-afma/1RU0EePRyrBPcjBdOt+dV8z1bJH9dtpTN/WXmY=",
+        "lastModified": 1676569297,
+        "narHash": "sha256-2n4C4H3/U+3YbDrQB6xIw7AaLdFISCCFwOkcETAigqU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "28319deb5ab05458d9cd5c7d99e1a24ec2e8fc4b",
+        "rev": "ac1f5b72a9e95873d1de0233fddcb56f99884b37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`122a7435`](https://github.com/NixOS/nixpkgs/commit/122a7435fb67bedfd54d700b04ccb826298c6e05) | `` Revert "nixos/jellyseerr: init" ``                                       |
| [`453840da`](https://github.com/NixOS/nixpkgs/commit/453840daf19a9003adfac25ba583919039a6961f) | `` nushell: use newer libproc.h ``                                          |
| [`2ca375ab`](https://github.com/NixOS/nixpkgs/commit/2ca375abdc77780b785cb297f4a52f1115801eaa) | `` nixos/jellyseerr: init ``                                                |
| [`f7c97e89`](https://github.com/NixOS/nixpkgs/commit/f7c97e8938718456ca481c858df1519614d6b2f8) | `` python310Packages.types-dateutil: 2.8.19.6 -> 2.8.19.7 ``                |
| [`ca931c42`](https://github.com/NixOS/nixpkgs/commit/ca931c42f2b929b499b60715578fdc3885b9318c) | `` pueue: 2.1.0 -> 3.1.0 ``                                                 |
| [`6657a4d5`](https://github.com/NixOS/nixpkgs/commit/6657a4d538a0474046ef8141cb961fd715f33a59) | `` tuckr: init at 0.7.0 ``                                                  |
| [`2421182a`](https://github.com/NixOS/nixpkgs/commit/2421182a709bed6e5746ea8a8613cad5dd326227) | `` python310Packages.bitarray: 2.7.0 -> 2.7.2 ``                            |
| [`f7dcc5ff`](https://github.com/NixOS/nixpkgs/commit/f7dcc5ff1cde75122e1e057c28daf9d6d84f4a72) | `` hyrule: 0.2.1 -> 0.3.0 ``                                                |
| [`28b6f0fb`](https://github.com/NixOS/nixpkgs/commit/28b6f0fb2a5956f0746b5bf0e7465f806166973c) | `` hy: 0.25.0 -> 0.26.0 ``                                                  |
| [`0ad22750`](https://github.com/NixOS/nixpkgs/commit/0ad2275000493269991fe18677e46d2b2a057104) | `` mautrix-whatsapp: 0.8.1 -> 0.8.2 ``                                      |
| [`05b3fb64`](https://github.com/NixOS/nixpkgs/commit/05b3fb643f272ea4acff5251cf8ecfa0ef288f92) | `` senpai: unstable-2023-01-03 → unstable-2023-02-13 ``                     |
| [`765d9282`](https://github.com/NixOS/nixpkgs/commit/765d9282965382163b4f63cf1124de73404bc099) | `` kicad-unstable: 2022-12-19 -> 2023-02-14 ``                              |
| [`08c96035`](https://github.com/NixOS/nixpkgs/commit/08c96035b988ed54b4b7526054a7737cbb82dfd0) | `` kicad: add patches to accept wxwidgets 3.2.2.1 ``                        |
| [`c8d22b3c`](https://github.com/NixOS/nixpkgs/commit/c8d22b3c2a8aa87a717b2ac81ec9d04452e0b57f) | `` kicad: 6.0.11 -> 7.0.0 ``                                                |
| [`68329697`](https://github.com/NixOS/nixpkgs/commit/68329697a676cce731ba9cd568dea73fb2facbf2) | `` oh-my-zsh: 2023-02-05 -> 2023-02-16 ``                                   |
| [`8530c5e3`](https://github.com/NixOS/nixpkgs/commit/8530c5e38a3c53ff644e5dd6ad608f0d9c0cb4cf) | `` sonixd: package icon and desktop file ``                                 |
| [`41817843`](https://github.com/NixOS/nixpkgs/commit/418178435e83d9e04f92ba049cd18412c4e7161f) | `` saga: 8.5.0 -> 8.5.1 ``                                                  |
| [`f8154fc3`](https://github.com/NixOS/nixpkgs/commit/f8154fc3e3c4ac72a55d192decbaf41d1d1e09f2) | `` libayatana-appindicator: 0.5.91 -> 0.5.92 ``                             |
| [`047bd73c`](https://github.com/NixOS/nixpkgs/commit/047bd73c5e05e8f60abb0ea2a3b22c845404f9cd) | `` nixos/wireguard: make publicKeys singleLineStrs ``                       |
| [`0644dc47`](https://github.com/NixOS/nixpkgs/commit/0644dc47401572c0cc7790a4d4ce28d6ad1e0800) | `` flashrom: 1.2.1 -> 1.3.0 ``                                              |
| [`09747990`](https://github.com/NixOS/nixpkgs/commit/09747990b2e09c484167423ee1b77f610056ecd3) | `` python310Packages.isbnlib: 3.10.12 -> 3.10.13 ``                         |
| [`ae483501`](https://github.com/NixOS/nixpkgs/commit/ae48350154bc245aed8c2ee8c9ec0daf7ccc067e) | `` python311Packages.regenmaschine: drop asynctest ``                       |
| [`64bf02e1`](https://github.com/NixOS/nixpkgs/commit/64bf02e1cf2bcf8c772962cd4da27d6aa8bc7beb) | `` python310Packages.simplisafe-python: drop asynctest ``                   |
| [`5262f0fd`](https://github.com/NixOS/nixpkgs/commit/5262f0fd99f6231880819de367d2a5576782b25d) | `` geckodriver: 0.32.1 -> 0.32.2 ``                                         |
| [`833a716f`](https://github.com/NixOS/nixpkgs/commit/833a716f8cb20b9657fd1bf5de7a484be45142d3) | `` okteto: 2.12.0 -> 2.12.1 ``                                              |
| [`4bf9b060`](https://github.com/NixOS/nixpkgs/commit/4bf9b060c1514974573cd7fff74ea416f83a8fee) | `` instaloader: 4.9.5 -> 4.9.6 ``                                           |
| [`ebbfc97c`](https://github.com/NixOS/nixpkgs/commit/ebbfc97cb614399a76817f434394b04ade4d8707) | `` python310Packages.pyathena: 2.21.0 -> 2.23.0 ``                          |
| [`5c78cb7f`](https://github.com/NixOS/nixpkgs/commit/5c78cb7fe7301ecddd68fa3141b8a27a7e41a16a) | `` roxctl: 3.73.1 -> 3.73.2 ``                                              |
| [`4987c7aa`](https://github.com/NixOS/nixpkgs/commit/4987c7aacdeeed0b08fcd12ab1c5813b683be7d6) | `` libretro.picodrive: unstable-2022-12-20 -> unstable-2023-02-15 ``        |
| [`c1f110ee`](https://github.com/NixOS/nixpkgs/commit/c1f110eef4c301ebe00cd6b0d8df5ea06f361a75) | `` ocamlPackages.npy: use Dune 3 ``                                         |
| [`12fdba08`](https://github.com/NixOS/nixpkgs/commit/12fdba08f0596c74f883470e842aa69dc91d0756) | `` ocamlPackages.torch: 0.15 → 0.17 ``                                      |
| [`55f76acc`](https://github.com/NixOS/nixpkgs/commit/55f76accb31ffc52ec58241961c92fe62dc1ccd3) | `` ocamlPackages.owl: use Dune 3 ``                                         |
| [`6dc7c7a7`](https://github.com/NixOS/nixpkgs/commit/6dc7c7a776fe9c34005a2bcf7612046c1cb292a7) | `` maestro: 1.22.1 -> 1.23.0 ``                                             |
| [`4e3fef78`](https://github.com/NixOS/nixpkgs/commit/4e3fef78deb697bd01e56e3c68f393c3c214b584) | `` uair: 0.4.0 -> 0.5.1 ``                                                  |
| [`81b58ec5`](https://github.com/NixOS/nixpkgs/commit/81b58ec58c2f6155845790c84c4085577b560a38) | `` python310Packages.plaid-python: 11.4.0 -> 11.5.0 ``                      |
| [`c54e18dc`](https://github.com/NixOS/nixpkgs/commit/c54e18dc013199b1c87d4dc730a95384ec8b6491) | `` python310Packages.ansible-lint: 6.12.2 -> 6.13.0 ``                      |
| [`80929738`](https://github.com/NixOS/nixpkgs/commit/80929738f59c0f0ec760c38987a4cf30e7ee945e) | `` python310Packages.types-pyyaml: 6.0.12.4 -> 6.0.12.6 ``                  |
| [`f7d3b72f`](https://github.com/NixOS/nixpkgs/commit/f7d3b72f4945158c41edbc5fab7890175d78d4c2) | `` mmc-utils: unstable-2022-11-09 -> unstable-2023-02-09 ``                 |
| [`07ce7b2f`](https://github.com/NixOS/nixpkgs/commit/07ce7b2f5b110c28b48c9690c5be130f5b19e6e6) | `` volantes-cursors: init at 2022-08-27 ``                                  |
| [`0e13156a`](https://github.com/NixOS/nixpkgs/commit/0e13156ae35702f1720b28b75b68449263ddc4ef) | `` multipass: 1.11.0 -> 1.11.1 ``                                           |
| [`40ea49cc`](https://github.com/NixOS/nixpkgs/commit/40ea49cc96ed9f5b2dc0f1c91d697ead8538e034) | `` dht: 0.25 -> 0.27 ``                                                     |
| [`d4bdf1a0`](https://github.com/NixOS/nixpkgs/commit/d4bdf1a05da143ac57e8a78082f33b2b390e6718) | `` function-runner: init at 3.2.2 ``                                        |
| [`c049b21f`](https://github.com/NixOS/nixpkgs/commit/c049b21fd36d306668805651fe302007b4b6d041) | `` pdfsam-basic: 5.0.2 -> 5.0.3 ``                                          |
| [`3fa70162`](https://github.com/NixOS/nixpkgs/commit/3fa7016274af7b26782c735e7cbe518a02ea9dcf) | `` maintainers: add nintron ``                                              |
| [`a5ec32ce`](https://github.com/NixOS/nixpkgs/commit/a5ec32cef141b6ff548951a3d12708ed4549e286) | `` vimPlugins.tint-nvim: init at 2022-09-27 ``                              |
| [`063272c0`](https://github.com/NixOS/nixpkgs/commit/063272c0d839f614d574af5d97338f185a430876) | `` terraform-providers.tencentcloud: 1.79.9 → 1.79.10 ``                    |
| [`4bd3d595`](https://github.com/NixOS/nixpkgs/commit/4bd3d595c44d6dd06a1c58481f115456112fa2e6) | `` terraform-providers.oci: 4.107.0 → 4.108.0 ``                            |
| [`c6eb60c6`](https://github.com/NixOS/nixpkgs/commit/c6eb60c6d7cc921251c8eec56fd44dd549df7a30) | `` terraform-providers.spotinst: 1.99.0 → 1.100.0 ``                        |
| [`e7c4c418`](https://github.com/NixOS/nixpkgs/commit/e7c4c418c44303794b7146757fb53ced3dc8e0fc) | `` terraform-providers.pagerduty: 2.10.2 → 2.11.0 ``                        |
| [`c9a944bb`](https://github.com/NixOS/nixpkgs/commit/c9a944bb1d88e751953e81c023d59a115353387f) | `` terraform-providers.kubernetes: 2.17.0 → 2.18.0 ``                       |
| [`d7b70b0f`](https://github.com/NixOS/nixpkgs/commit/d7b70b0f99f3db9ee3b05949634ae122947b4109) | `` terraform-providers.launchdarkly: 2.9.4 → 2.9.5 ``                       |
| [`a302f554`](https://github.com/NixOS/nixpkgs/commit/a302f554bff85581ba4b31793bc2bdb2272aad1b) | `` vimPlugins.nvim-ufo: init at 2023-02-03 ``                               |
| [`da1ff3f9`](https://github.com/NixOS/nixpkgs/commit/da1ff3f93c24fe5d91b48c3ebacb30d7fa465f45) | `` vimPlugins.promise-async: init at 2023-02-01 ``                          |
| [`52972d8c`](https://github.com/NixOS/nixpkgs/commit/52972d8c810984f2e1373d755e6baf6a150af607) | `` deepin-voice-note: init at 5.10.22 ``                                    |
| [`0e36d954`](https://github.com/NixOS/nixpkgs/commit/0e36d95426fd65efc5fff1e7ecbc79f2df355f11) | `` tokyo-night-gtk: init at 2023.01.17 ``                                   |
| [`b77dc354`](https://github.com/NixOS/nixpkgs/commit/b77dc354d7af4b320c92e4ec2d6a4d9b991b1656) | `` osu-lazer{,-bin}: 2022.1228.0 -> 2023.207.0 ``                           |
| [`c5ef1aa9`](https://github.com/NixOS/nixpkgs/commit/c5ef1aa913c0313dc62874922d6ac309373cbf63) | `` vimPlugins.vim-clap: fix cargoSha256 ``                                  |
| [`66dccd88`](https://github.com/NixOS/nixpkgs/commit/66dccd88b83838c821774e6c8de81c58caf37f65) | `` build-support/rust/lib: Add `toTargetVendor` ``                          |
| [`61dedac5`](https://github.com/NixOS/nixpkgs/commit/61dedac57d572a61aa6c8f87870f0b680d747136) | `` srvc: 0.13.0 -> 0.14.0 ``                                                |
| [`edd4aa24`](https://github.com/NixOS/nixpkgs/commit/edd4aa2490e71fff0365322d0ad218cff36d660d) | `` mmtc: 0.3.1 -> 0.3.2 ``                                                  |
| [`5f60ed68`](https://github.com/NixOS/nixpkgs/commit/5f60ed68612391f2695332934e043ef95701cad9) | `` vimPlugins.nvim-treesitter: update grammars ``                           |
| [`0aeca9fa`](https://github.com/NixOS/nixpkgs/commit/0aeca9fa9b4797e5872282b0f46d361480c0c903) | `` vimPlugins.no-neck-pain-nvim: init at 2023-02-15 ``                      |
| [`21443c03`](https://github.com/NixOS/nixpkgs/commit/21443c03856213790cda875e78cdbb6ad022c4fd) | `` vimPlugins: update ``                                                    |
| [`0ad9c727`](https://github.com/NixOS/nixpkgs/commit/0ad9c7275df2f2f239ef53437735104b3c7f88ae) | `` talosctl: 1.3.3 -> 1.3.4 ``                                              |
| [`da49c6e7`](https://github.com/NixOS/nixpkgs/commit/da49c6e74802fc38100add68e2b7fca5d7ce5da2) | `` fdk-aac-encoder: 1.0.3 → 1.0.5 ``                                        |
| [`93d9b18a`](https://github.com/NixOS/nixpkgs/commit/93d9b18aee4e7b8c6f2bc810d42428f91b8d7fa4) | `` snappymail: 2.25.5 -> 2.26.0 ``                                          |
| [`51babccd`](https://github.com/NixOS/nixpkgs/commit/51babccd092b4ce8ada6bd3065b2f243ab3d115f) | `` go-mockery: 2.18.0 -> 2.20.0 ``                                          |
| [`964dc8e4`](https://github.com/NixOS/nixpkgs/commit/964dc8e4082226744aa4f81e93c189c28a5a8ce6) | `` terraform: 1.3.8 -> 1.3.9 ``                                             |
| [`e06c5e01`](https://github.com/NixOS/nixpkgs/commit/e06c5e01088672bc460b2bc6b61d88e95190a492) | `` go: add meta.changelog ``                                                |
| [`812f10ce`](https://github.com/NixOS/nixpkgs/commit/812f10ce55526a2bce463f85cebb3c6775682c4a) | `` containerd: 1.6.17 -> 1.6.18 ``                                          |
| [`e2d4cf84`](https://github.com/NixOS/nixpkgs/commit/e2d4cf849dd83be06c2347a0b7e10d0f2f3ab244) | `` undocker: 1.0.3 -> 1.0.4 ``                                              |
| [`4b1018ba`](https://github.com/NixOS/nixpkgs/commit/4b1018ba0a50fcebdd98f4103cf1a489302cd3ba) | `` pkgsMusl.wxwidgets: fix build ``                                         |
| [`cbf8197c`](https://github.com/NixOS/nixpkgs/commit/cbf8197c12048cc841d417ccb8377a737713e84f) | `` python310Packages.aiosomecomfort: 0.0.7 -> 0.0.8 ``                      |
| [`c0fe9965`](https://github.com/NixOS/nixpkgs/commit/c0fe996500b4e99742bb2ffd72a3bedd40e4dc7a) | `` s3fs: fix build on darwin ``                                             |
| [`4c6d0673`](https://github.com/NixOS/nixpkgs/commit/4c6d0673222348d912d5cfd2ffa0d099f40ce284) | `` gnomeExtensions: auto-update ``                                          |
| [`06334618`](https://github.com/NixOS/nixpkgs/commit/0633461889a4916bad1f4665699812dbffaad7e5) | `` python310Packages.pyopenuv: add patch to remove asynctest ``             |
| [`cc7ec82f`](https://github.com/NixOS/nixpkgs/commit/cc7ec82f3cd89afdf4fb55dad0603cf00ae4bd0c) | `` graalvmCEPackages.nodejs-installable-svm: init at 22.3.1 ``              |
| [`3a53307d`](https://github.com/NixOS/nixpkgs/commit/3a53307dd9f12e781acb5306bed69d364c2ad812) | `` graalvmCEPackages.buildGraalvmProduct: link languages .so to $out/lib `` |
| [`bc005b22`](https://github.com/NixOS/nixpkgs/commit/bc005b22271923e25998ba00c0a72a90d45e8f4a) | `` python310Packages.pyopenuv: add changelog to meta ``                     |
| [`34dcadee`](https://github.com/NixOS/nixpkgs/commit/34dcadee7c74d12ddece2bd8a947509a384c415b) | `` waylock: 0.6.0 -> 0.6.2 ``                                               |
| [`a2367655`](https://github.com/NixOS/nixpkgs/commit/a23676554e07d51715333cdd344602e9749fd7fd) | `` chia-dev-tools: fix build ``                                             |
| [`334b915c`](https://github.com/NixOS/nixpkgs/commit/334b915c8b5a666ed74d4027c8fc94dcf2c42d2b) | `` python310Packages.pontos: 23.2.8 -> 23.2.9 ``                            |
| [`5cbf79a9`](https://github.com/NixOS/nixpkgs/commit/5cbf79a9382a0e267cef07d639d02aebecfcbe41) | `` mitmproxy2swagger: 0.7.2 -> 0.8.0 ``                                     |
| [`1bddde31`](https://github.com/NixOS/nixpkgs/commit/1bddde315297c092712b0ef03d9def7a474b28ae) | `` fzf: 0.37.0 -> 0.38.0 ``                                                 |
| [`4ffd5a86`](https://github.com/NixOS/nixpkgs/commit/4ffd5a8684e9ab7e519904c1fcda051917b278b4) | `` go_1_20: 1.20 -> 1.20.1 ``                                               |
| [`8af77c76`](https://github.com/NixOS/nixpkgs/commit/8af77c7601c3f39f095fec2af3a60484623e2bf2) | `` chia: 1.6.2 -> 1.7.0 ``                                                  |
| [`a930fdc6`](https://github.com/NixOS/nixpkgs/commit/a930fdc6bcee0915b76743862d29e82ec3f14851) | `` python3Packages.clvm-tools-rs: 0.1.25 -> 0.1.30 ``                       |
| [`08799632`](https://github.com/NixOS/nixpkgs/commit/08799632dc01aba3b0bf04892781d2cc1e66dad5) | `` python3Packages.chia-rs: 0.1.16 -> 0.2.0 ``                              |
| [`8c3cb111`](https://github.com/NixOS/nixpkgs/commit/8c3cb11157620856b9eeec5874c6cce42bcbafa8) | `` python310Packages.asyauth: 0.0.12 -> 0.0.13 ``                           |
| [`a1ee2e61`](https://github.com/NixOS/nixpkgs/commit/a1ee2e61f7c2472afb8d9a25f5fa060a7dc344bd) | `` python310Packages.minikerberos: 0.3.5 -> 0.4.0 ``                        |
| [`4807642e`](https://github.com/NixOS/nixpkgs/commit/4807642e23c40cf9e8931f3869d9b474e9b2e2a1) | `` python310Packages.asyncmy: 0.2.6 -> 0.2.7 ``                             |
| [`6a827032`](https://github.com/NixOS/nixpkgs/commit/6a8270323e23f1084b319b9ec2aa84313f65aea1) | `` python310Packages.unicrypto: 0.0.9 -> 0.0.10 ``                          |
| [`1e39bda3`](https://github.com/NixOS/nixpkgs/commit/1e39bda357bedf5b22fa31baab1f6c16d07f65b8) | `` graalvm*-ce: improve update.sh script ``                                 |
| [`853650b7`](https://github.com/NixOS/nixpkgs/commit/853650b77eb8d0de389da792f0bea7d760c6da94) | `` php80: 8.0.27 -> 8.0.28 ``                                               |
| [`10e361a9`](https://github.com/NixOS/nixpkgs/commit/10e361a93e8139693f33272e2beb3f44baf50edb) | `` php81: 8.1.15 -> 8.1.16 ``                                               |
| [`5d61c37a`](https://github.com/NixOS/nixpkgs/commit/5d61c37a902a4df6807acdf4b45dbd427be474f7) | `` php82: 8.2.2 -> 8.2.3 ``                                                 |
| [`76e8420c`](https://github.com/NixOS/nixpkgs/commit/76e8420cf80b1214450d43ec1b5aac91975f356a) | `` graalvmCEPackages: remove unnecessary inputs ``                          |
| [`a89a024e`](https://github.com/NixOS/nixpkgs/commit/a89a024ed4a21f0d3e1baa246b0300791953afe4) | `` python310Packages.angr: 9.2.37 -> 9.2.38 ``                              |
| [`b54820c9`](https://github.com/NixOS/nixpkgs/commit/b54820c90054a69d98efcbac6c12115e4b587a10) | `` python310Packages.cle: 9.2.37 -> 9.2.38 ``                               |
| [`061f0074`](https://github.com/NixOS/nixpkgs/commit/061f0074da186aa7c91c81f119bc361c49ad32fe) | `` python310Packages.claripy: 9.2.37 -> 9.2.38 ``                           |
| [`d63b815e`](https://github.com/NixOS/nixpkgs/commit/d63b815ed66e890d7bd8e4149bec9f32deee8e7e) | `` python310Packages.pyvex: 9.2.37 -> 9.2.38 ``                             |
| [`3324200a`](https://github.com/NixOS/nixpkgs/commit/3324200a2ce7d3ab4efafb58c2faf82f1f992e21) | `` python310Packages.ailment: 9.2.37 -> 9.2.38 ``                           |
| [`f5be8464`](https://github.com/NixOS/nixpkgs/commit/f5be8464dbe91fbe9a4669e7be8534b0f3ead587) | `` python310Packages.archinfo: 9.2.37 -> 9.2.38 ``                          |
| [`c5ff9f89`](https://github.com/NixOS/nixpkgs/commit/c5ff9f89c6cf50ccf4f08113585709a522b14eea) | `` khoj: 0.2.5 -> 0.2.6 ``                                                  |
| [`f998fc2a`](https://github.com/NixOS/nixpkgs/commit/f998fc2a691cba2828882edaf6b2303a46239686) | `` home-assistant: 2023.2.4 -> 2023.2.5 ``                                  |
| [`ef4209a7`](https://github.com/NixOS/nixpkgs/commit/ef4209a7abe68e1b008b8f9add866281a6a80fc1) | `` python310Packages.reolink-aio: 0.4.0 -> 0.4.2 ``                         |
| [`88b16f26`](https://github.com/NixOS/nixpkgs/commit/88b16f26057e3d837d9c37a92d8f44a35efa66fa) | `` python310Packages.python-matter-server: 2.0.2 -> 2.1.0 ``                |
| [`058d733e`](https://github.com/NixOS/nixpkgs/commit/058d733e757b584481a7c2ec0563c2aaf4a24054) | `` python310Packages.pyopenuv: 2023.01.0 -> 2023.02.0 ``                    |
| [`e8ac0b5e`](https://github.com/NixOS/nixpkgs/commit/e8ac0b5e12e280a13b370b8e830e8257e1baa0de) | `` python310Packages.aioaladdinconnect: 0.1.55 -> 0.1.56 ``                 |
| [`c578f3f8`](https://github.com/NixOS/nixpkgs/commit/c578f3f84432df11a67f76b3011a6e6ead90f54c) | `` praat: 6.3.07 -> 6.3.08 ``                                               |
| [`e5bde651`](https://github.com/NixOS/nixpkgs/commit/e5bde651a57cb4e136797d794acf33fce4110eea) | `` Revert "cppcheck: 2.9.3 -> 2.10" ``                                      |
| [`e91a36b8`](https://github.com/NixOS/nixpkgs/commit/e91a36b823657f00b57c375cb48accabb233f364) | `` gitmux: 0.7.10 -> 0.7.12 ``                                              |
| [`858e6cb6`](https://github.com/NixOS/nixpkgs/commit/858e6cb6ed3d094cbac5a9a75155e430dca4bded) | `` adguardhome: 0.107.23 -> 0.107.24 ``                                     |
| [`e69c7f78`](https://github.com/NixOS/nixpkgs/commit/e69c7f78148b97b20992ee5ab7d58c5914dc10a7) | `` auto-multiple-choice: Use default value for $MODSDIR ``                  |
| [`bb584ee6`](https://github.com/NixOS/nixpkgs/commit/bb584ee6cd8b0d543b559ef715d161deb318ff3b) | `` cf-terraforming: 0.9.0 -> 0.10.0 (#216462) ``                            |
| [`9483a3cb`](https://github.com/NixOS/nixpkgs/commit/9483a3cb0e413f55b8e6fe5c3fb683f080b55f77) | `` github-runner: 2.301.1 -> 2.302.0 ``                                     |
| [`d5c4fdaa`](https://github.com/NixOS/nixpkgs/commit/d5c4fdaa0085ced92826ceefacbddebc1c1ccccc) | `` python310Packages.types-urllib3: 1.26.25.5 -> 1.26.25.6 ``               |
| [`a2cc3e37`](https://github.com/NixOS/nixpkgs/commit/a2cc3e37ec1ef63c5689513a7092007da0ab79d4) | `` librewolf: 109.0.1-2 -> 110.0-1 ``                                       |
| [`d4c94048`](https://github.com/NixOS/nixpkgs/commit/d4c9404846a082b435e4f97c6541516dff8e9c57) | `` ov: 0.14.1 -> 0.14.2 ``                                                  |
| [`2d03b168`](https://github.com/NixOS/nixpkgs/commit/2d03b16868e6ba8555119868a2d574ffe4d7dfcc) | `` asnmap: 0.0.1 -> 1.0.0 ``                                                |
| [`e7d91197`](https://github.com/NixOS/nixpkgs/commit/e7d911977671471a206d3484a04e6f2cdb789c40) | `` python311Packages.pyregion: skip 2 failing tests ``                      |
| [`5ccbeb3a`](https://github.com/NixOS/nixpkgs/commit/5ccbeb3a3daaac9343921c31cec1b18440ebbc76) | `` coredns: 1.10.0 -> 1.10.1 ``                                             |
| [`f28e84d8`](https://github.com/NixOS/nixpkgs/commit/f28e84d855a287d20fd995f203ce4fdfc23cbef8) | `` python3Packages.pyls-mypy: remove ``                                     |
| [`a78eae7c`](https://github.com/NixOS/nixpkgs/commit/a78eae7c0a70f354b44945f53e12626334ec2503) | `` sofia_sip: 1.13.12 -> 1.13.13 ``                                         |
| [`418cc13d`](https://github.com/NixOS/nixpkgs/commit/418cc13dd1c2e7550c1c59fe4f1046d4e0c7ea94) | `` docker-compose: 2.15.1 -> 2.16.0 ``                                      |
| [`0bbb1901`](https://github.com/NixOS/nixpkgs/commit/0bbb1901004c3de330276638de51396091eb9f85) | `` dnsperf: 2.10.0 -> 2.11.0 ``                                             |
| [`7b9eefac`](https://github.com/NixOS/nixpkgs/commit/7b9eefac651cc29e1f35f2201270f9961a583e8a) | `` ihp-new: 1.0.0 -> 1.0.1 ``                                               |
| [`8642e02a`](https://github.com/NixOS/nixpkgs/commit/8642e02a5639bb46b2db43d379c5b7a4f54059d9) | `` treesheets: unstable-2023-01-31 -> unstable-2023-02-14 ``                |
| [`a2585e0f`](https://github.com/NixOS/nixpkgs/commit/a2585e0f5fcb2d130f69366fb5d103ae0e50c6ed) | `` python310Packages.yfinance: 0.2.10 -> 0.2.11 ``                          |
| [`a46227a6`](https://github.com/NixOS/nixpkgs/commit/a46227a6c961a99e3a18280363b9878d236b0dfe) | `` libcouchbase: 3.3.3 -> 3.3.4 ``                                          |
| [`551245d6`](https://github.com/NixOS/nixpkgs/commit/551245d6c4636862f91ba4a0e94b8120b7e8d4d4) | `` plasma-mobile/qmlkonsole: init at 23.01.0 ``                             |
| [`43a52039`](https://github.com/NixOS/nixpkgs/commit/43a52039353acfdc554a8a64efcf5aa37993f67c) | `` httplib: 0.11.4 -> 0.12.0 ``                                             |
| [`40ac9dfd`](https://github.com/NixOS/nixpkgs/commit/40ac9dfd1eb3b0d207c585617b133c42bee6f354) | `` python310Packages.bids-validator: 1.9.9 -> 1.10.0 ``                     |
| [`ab0d758a`](https://github.com/NixOS/nixpkgs/commit/ab0d758a05d6af88708ff955764f4a800db2df78) | `` python310Packages.azure-appconfiguration: 1.3.0 -> 1.4.0 ``              |
| [`b30f0bcf`](https://github.com/NixOS/nixpkgs/commit/b30f0bcf1277f1bad9873393ee67972cff1f7a3d) | `` holochain-launcher: 0.6.0 -> 0.9.0 ``                                    |
| [`b524b5a9`](https://github.com/NixOS/nixpkgs/commit/b524b5a9c0d6fdbe70bce673b141bcab89a2a027) | `` simdjson: 3.1.0 -> 3.1.1 ``                                              |
| [`931af232`](https://github.com/NixOS/nixpkgs/commit/931af232bc10031853396f0a73fc306d17642df6) | `` grafana-image-renderer: 3.6.3 -> 3.6.4 ``                                |
| [`facf14a7`](https://github.com/NixOS/nixpkgs/commit/facf14a7da4b8533ff1dff6e430fec2375bdbb06) | `` infracost: 0.10.16 -> 0.10.17 ``                                         |
| [`e13502bb`](https://github.com/NixOS/nixpkgs/commit/e13502bb7857a69eb372321bcfd99c08f572def1) | `` python310Packages.pyrogram: 2.0.98 -> 2.0.99 ``                          |
| [`10cbd859`](https://github.com/NixOS/nixpkgs/commit/10cbd85948034fd68c44233810cec73b80716ebd) | `` python310Packages.djangorestframework-camel-case: 1.4.0 -> 1.4.2 ``      |
| [`9e3e928a`](https://github.com/NixOS/nixpkgs/commit/9e3e928ad45fa9df11280be4ff581c4c11992e21) | `` nixos/no-x-libs: fix infinite recursion with ffmpeg ``                   |