### PR TITLE
chore(flake/nixos-hardware): `00d1c8da` -> `9bbcc37b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -159,11 +159,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1676699427,
-        "narHash": "sha256-Z4d4Gwk4PlYaM4PGU3SSGzjWvm8hhuW91Kh5nvfxPyc=",
+        "lastModified": 1676699914,
+        "narHash": "sha256-cM2Hd+odgCYWSUiYPZGW/4B+OI64S0lrdf9YR9ts9I4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "00d1c8da9a24f8b04f3a6ee3a05169e514628d1c",
+        "rev": "9bbcc37b011b0d925f3115888ea77f58487619b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`85fb2c41`](https://github.com/NixOS/nixos-hardware/commit/85fb2c41b60b53742e124cbaae52f95da51f18ba) | `` Bump cachix/install-nix-action from 18 to 19 `` |