### PR TITLE
chore(flake/nixpkgs): `ac1f5b72` -> `958dbd6c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676569297,
-        "narHash": "sha256-2n4C4H3/U+3YbDrQB6xIw7AaLdFISCCFwOkcETAigqU=",
+        "lastModified": 1676659111,
+        "narHash": "sha256-nj3GONWv33Zr/ahm6ATep2qhtuu1mH5e4I4fuKdSVzU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ac1f5b72a9e95873d1de0233fddcb56f99884b37",
+        "rev": "958dbd6c08c7e276451704409ebc7cb0d8bc94c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`427d0b71`](https://github.com/NixOS/nixpkgs/commit/427d0b71b6f788769320391cb779f6387d1ecd9c) | `` protonup-qt: Fix CI ``                                                       |
| [`807b7f43`](https://github.com/NixOS/nixpkgs/commit/807b7f4363e5ccb10c60d088c79da6861269534e) | `` python310Packages.python-ironicclient: 5.0.1 -> 5.1.0 ``                     |
| [`f14e3fef`](https://github.com/NixOS/nixpkgs/commit/f14e3fef033f1b6048a951f7395db841c18cdd64) | `` python310Packages.simpleeval: add changelog to meta ``                       |
| [`6ebfe7e1`](https://github.com/NixOS/nixpkgs/commit/6ebfe7e1c28b7b702a90ebaa2ca97fa2f4a9e037) | `` webkitgtk: 2.38.4 → 2.38.5 ``                                                |
| [`61f8e051`](https://github.com/NixOS/nixpkgs/commit/61f8e0511f279599f340eec22a8f967e2bfc376a) | `` python310Packages.simpleeval: 0.9.12 -> 0.9.13 ``                            |
| [`0c4ece05`](https://github.com/NixOS/nixpkgs/commit/0c4ece0585d4c22666531729b7e6afe35ac4c307) | `` python310Packages.arcam-fmj: 1.2.0 -> 1.2.1 ``                               |
| [`f2544dc8`](https://github.com/NixOS/nixpkgs/commit/f2544dc85f4532fe8fabde0dce3a061b3dd336c7) | `` mdcat: add mdless symlink and install completions ``                         |
| [`b8997651`](https://github.com/NixOS/nixpkgs/commit/b89976519b35b08c0ddd529c22f47a550ebb7dfd) | `` rqlite: init at 7.6.1 (#187962) ``                                           |
| [`2b71a590`](https://github.com/NixOS/nixpkgs/commit/2b71a590f45f6737d42fcf057914360f1d333473) | `` yt-dlp: 2023.1.6 -> 2023.2.17 ``                                             |
| [`bc485d9e`](https://github.com/NixOS/nixpkgs/commit/bc485d9e26201f28132af6573ae34a00be3d53e9) | `` fnc: fix clang build ``                                                      |
| [`609af8df`](https://github.com/NixOS/nixpkgs/commit/609af8dfbc324dee20447b89a49f4b906f4d8299) | `` python310Packages.ansible-doctor: 2.0.0 -> 2.0.1 ``                          |
| [`16edc68c`](https://github.com/NixOS/nixpkgs/commit/16edc68ccba48392c489b187a36d8f677d5cc8e1) | `` maintaniers: remove dizfer ``                                                |
| [`2c668329`](https://github.com/NixOS/nixpkgs/commit/2c6683291e6b9f789554bf0d62bb89b3fd9202d9) | `` cargo-valgrind: 2.1.0 -> 2.1.1 ``                                            |
| [`3e081095`](https://github.com/NixOS/nixpkgs/commit/3e081095a4471f126dfb1346cb51ddec36784c23) | `` Revert "podman: remove wrapper" ``                                           |
| [`59d53939`](https://github.com/NixOS/nixpkgs/commit/59d5393967c4636de90b1b1068433a10d363a485) | `` posteid-seed-extractor: init at unstable-23-02-2022 ``                       |
| [`1393d226`](https://github.com/NixOS/nixpkgs/commit/1393d2262bfb01ba47c7f78a23322de8de17e7d7) | `` redpanda: 22.3.11 -> 22.3.13 ``                                              |
| [`da293b7a`](https://github.com/NixOS/nixpkgs/commit/da293b7a0f1683044ff8fd3eabba3bc5c0b1ae1c) | `` clamav: 1.0.0 -> 1.0.1 ``                                                    |
| [`05fa52ab`](https://github.com/NixOS/nixpkgs/commit/05fa52aba636544d2a99945d916e1398e0f1e561) | `` mutagen-compose: 0.16.4 -> 0.16.5 ``                                         |
| [`830ddba0`](https://github.com/NixOS/nixpkgs/commit/830ddba077a93bd4177d7aafc394429d7d86d462) | `` pianotrans: 1.0 -> 1.0.1 ``                                                  |
| [`1668ab99`](https://github.com/NixOS/nixpkgs/commit/1668ab99ae518b071762f6ca2444a378028a7450) | `` python3Packages.gdtoolkit: Move to pkgs/development/tools ``                 |
| [`142a8951`](https://github.com/NixOS/nixpkgs/commit/142a89518ee69856393e2f80190583e5d1c45a7d) | `` python3Packages.gdtoolkit: Add maintainer tmarkus ``                         |
| [`be8ad9be`](https://github.com/NixOS/nixpkgs/commit/be8ad9be4dd15764e19a31663904782a5622c9dc) | `` python3Packages.gdtoolkit: Enable tests ``                                   |
| [`c0896274`](https://github.com/NixOS/nixpkgs/commit/c0896274ddcbbe5d2e934071f6ba93242fe5e068) | `` eartag: 0.3.1 -> 0.3.2 ``                                                    |
| [`e326e8ca`](https://github.com/NixOS/nixpkgs/commit/e326e8ca30d18a5364b2b88c6f5aa1ba719f6356) | `` numix-icon-theme-square: 23.02.05 -> 23.02.16 ``                             |
| [`ee2ae036`](https://github.com/NixOS/nixpkgs/commit/ee2ae036a1967332e22dcad2ca4ee5ebccf80732) | `` kubernetes-helmPlugins.helm-secrets: 3.8.3 -> 4.2.2 ``                       |
| [`815a21e9`](https://github.com/NixOS/nixpkgs/commit/815a21e9f16ed11a2dd8051d29ac2385625b539a) | `` openocd: 0.11.0 -> 0.12.0 ``                                                 |
| [`75a5ebbf`](https://github.com/NixOS/nixpkgs/commit/75a5ebbfba6adc61627b1667d12ebda21375a2d1) | `` terraform-providers.aws: 4.54.0 → 4.55.0 ``                                  |
| [`e653c5b4`](https://github.com/NixOS/nixpkgs/commit/e653c5b46215446b9313102bded9cae9e266914d) | `` terraform-providers.snowflake: 0.56.3 → 0.56.4 ``                            |
| [`3ebc795b`](https://github.com/NixOS/nixpkgs/commit/3ebc795b5759fbc7cd0b1027b3188644b1079641) | `` terraform-providers.azurerm: 3.43.0 → 3.44.0 ``                              |
| [`18a64c86`](https://github.com/NixOS/nixpkgs/commit/18a64c863d90066cefe230402957abe27d7d32ea) | `` terraform-providers.azuread: 2.33.0 → 2.34.0 ``                              |
| [`214add38`](https://github.com/NixOS/nixpkgs/commit/214add38535093a72200acb7587eab797178622d) | `` flexget: 3.5.23 -> 3.5.24 ``                                                 |
| [`d42631d6`](https://github.com/NixOS/nixpkgs/commit/d42631d6c59fabbb3b4a6109cce8f22e75761b2f) | `` nodejs-19_x: 19.6.0 -> 19.6.1 ``                                             |
| [`cfdcb8d7`](https://github.com/NixOS/nixpkgs/commit/cfdcb8d7fa7ae40616ec304eac07048d5a9e28ea) | `` nodejs-18_x: 18.14.0 -> 18.14.1 ``                                           |
| [`4313c636`](https://github.com/NixOS/nixpkgs/commit/4313c6360fba1111d5f25994d4c90a7aa68253a3) | `` nodejs-16_x: 16.19.0 -> 16.19.1 ``                                           |
| [`00371102`](https://github.com/NixOS/nixpkgs/commit/00371102782b231060044411be21d23da116f381) | `` nodejs-14_x: 14.21.2 -> 14.21.3 ``                                           |
| [`dcd759fe`](https://github.com/NixOS/nixpkgs/commit/dcd759fe65b0c85dc60a0c9d3cb7d071d44a973f) | `` rPackages.quarto: add quarto dependency ``                                   |
| [`ac44b254`](https://github.com/NixOS/nixpkgs/commit/ac44b254b42f997d7628b4ef0ab2cae74b615610) | `` zig_0_9: build with baseline CPU target ``                                   |
| [`4f9a955c`](https://github.com/NixOS/nixpkgs/commit/4f9a955c5adbe39aa265d1e2a7e31539a9e8024a) | `` cemu: 2.0-22 -> 2.0-26 ``                                                    |
| [`83aa89fa`](https://github.com/NixOS/nixpkgs/commit/83aa89faa9e31442c26e106b7bcb1cb2d866441b) | `` obs-vkcapture: fix xcursor not rendering ``                                  |
| [`8f5bd5c6`](https://github.com/NixOS/nixpkgs/commit/8f5bd5c6354fa1f97b2b99dabd471dac30aba726) | `` python310Packages.pynvml: 11.4.1 -> 11.5.0 ``                                |
| [`0372c798`](https://github.com/NixOS/nixpkgs/commit/0372c798146ecbc3e8b166829fbc0ff18179c3cc) | `` python310Packages.elastic-apm: 6.14.0 -> 6.15.0 ``                           |
| [`03eaff22`](https://github.com/NixOS/nixpkgs/commit/03eaff2242ac38fc5fe09f994ea78faf19ceabdd) | `` faas-cli: 0.15.4 -> 0.15.9 ``                                                |
| [`5fc03b04`](https://github.com/NixOS/nixpkgs/commit/5fc03b04a15b5743f0bb9fcc1a5194a5db376ad4) | `` wiki-tui: 0.6.1 -> 0.6.3 ``                                                  |
| [`705658bf`](https://github.com/NixOS/nixpkgs/commit/705658bf99204f650978e2c14f16d1aa863c2dd8) | `` python310Packages.pynobo: add changelog to meta ``                           |
| [`c857a1c3`](https://github.com/NixOS/nixpkgs/commit/c857a1c3234827ff691d8b1bc62a76d0db0c2805) | `` python310Packages.pynobo: 1.6.0 -> 1.6.1 ``                                  |
| [`831f4809`](https://github.com/NixOS/nixpkgs/commit/831f48091df9b8dcf33f9c024035143436f86a2a) | `` python310Packages.requests-pkcs12: 1.14 -> 1.15 ``                           |
| [`084e4314`](https://github.com/NixOS/nixpkgs/commit/084e4314af36132448eb0fcf06c37f9b9bc3effe) | `` python310Packages.types-python-dateutil: 2.8.19.6 -> 2.8.19.7 ``             |
| [`c5e9df48`](https://github.com/NixOS/nixpkgs/commit/c5e9df4832d4aed24bdb12dd0b9bd79789fb9b99) | `` python310Packages.types-requests: 2.28.11.12 -> 2.28.11.13 ``                |
| [`ef6fde65`](https://github.com/NixOS/nixpkgs/commit/ef6fde65d1455da7ce0aa12adafd694453fbf893) | `` python310Packages.canonicaljson: add changelog to meta ``                    |
| [`0a2c1a24`](https://github.com/NixOS/nixpkgs/commit/0a2c1a24a6097f17742f38f1303c4243ea267a38) | `` python310Packages.canonicaljson: 1.6.4 -> 1.6.5 ``                           |
| [`62853560`](https://github.com/NixOS/nixpkgs/commit/6285356012d0490c4073753ea764c7e9a50346d8) | `` skopeo: 1.11.0 -> 1.11.1 ``                                                  |
| [`fa644ef3`](https://github.com/NixOS/nixpkgs/commit/fa644ef3432452feaa753bf569acbdbbb905df99) | `` vaultwarden.updateScript: make compatible with webvault built from source `` |
| [`6cf19065`](https://github.com/NixOS/nixpkgs/commit/6cf19065ad9e5e8663ef11450d44079c8bbf34bc) | `` theforceengine: init at 1.09.100 ``                                          |
| [`b383c768`](https://github.com/NixOS/nixpkgs/commit/b383c76895799aa99bf1a74ba147656a6eac9b21) | `` python310Packages.leb128: 1.0.4 -> 1.0.5 ``                                  |
| [`fc24a540`](https://github.com/NixOS/nixpkgs/commit/fc24a5407490fde4f044fe59cfecf435f59c087a) | `` python310Packages.pyhocon: 0.3.59 -> 0.3.60 ``                               |
| [`a89eef2c`](https://github.com/NixOS/nixpkgs/commit/a89eef2c5e13f27009cdb8da139aac42bea5377f) | `` cwltool: 3.1.20230209161050 -> 3.1.20230213100550 ``                         |
| [`dbe3030d`](https://github.com/NixOS/nixpkgs/commit/dbe3030d4ed962f61459c5b14b2b222125893286) | `` youtrack: 2021.4.35970 -> 2022.3.65371 (#216643) ``                          |
| [`4183f105`](https://github.com/NixOS/nixpkgs/commit/4183f105245a18d2cc45c756f5329b5248767622) | `` gitlab: 15.8.1 -> 15.8.3 (#216372) ``                                        |
| [`b32db566`](https://github.com/NixOS/nixpkgs/commit/b32db566fe04a1473b51dffd8d907a888c8c07af) | `` nix-your-shell: 1.0.2 -> 1.1.0 ``                                            |
| [`0419385c`](https://github.com/NixOS/nixpkgs/commit/0419385c7fe35823581ee5b2505afeb2c6c09b6a) | `` chromium: 110.0.5481.77 -> 110.0.5481.100 ``                                 |
| [`43985b4f`](https://github.com/NixOS/nixpkgs/commit/43985b4fc45610ee236aac654c4d79a66ab8f2a2) | `` python310Packages.jupyter_console: 6.5.0 -> 6.5.1 ``                         |
| [`488184ca`](https://github.com/NixOS/nixpkgs/commit/488184caef263d6e3d17ed51201abd4e2b2787cd) | `` ungoogled-chromium: 110.0.5481.78 -> 110.0.5481.100 ``                       |
| [`5a562697`](https://github.com/NixOS/nixpkgs/commit/5a562697963ba49a752580215122d3212058e633) | `` python310Packages.fake-useragent: 1.1.1 -> 1.1.2 ``                          |
| [`c6e2fbf1`](https://github.com/NixOS/nixpkgs/commit/c6e2fbf1a2193d89675252314fa4d27b5ac6fff5) | `` vaultwarden.webvault: build from source ``                                   |
| [`232006fb`](https://github.com/NixOS/nixpkgs/commit/232006fbe6bbe866e91de8747d47446383a83d43) | `` gnss-share: init at 0.6 ``                                                   |
| [`30daac9f`](https://github.com/NixOS/nixpkgs/commit/30daac9f3a498415646f186e268a9aa84fe0586e) | `` usql: 0.13.8 -> 0.13.9 ``                                                    |
| [`ba1078be`](https://github.com/NixOS/nixpkgs/commit/ba1078beb5c5957158b786c2c6c5c2b19b4f7408) | `` flycast: 2.0 -> 2.1 ``                                                       |
| [`820c86da`](https://github.com/NixOS/nixpkgs/commit/820c86da446b74850c53e123346892a75b3bc5a0) | `` searxng: replace maintainer Kranzes with me ``                               |
| [`4ce10e41`](https://github.com/NixOS/nixpkgs/commit/4ce10e413f7d465ef64be53ac7144475f1e5fc06) | `` searxng: unstable-2022-09-01 -> unstable-2023-03-13 ``                       |
| [`cb1546de`](https://github.com/NixOS/nixpkgs/commit/cb1546dedb16b402f994e5e167753424824296c5) | `` python310Packages.fasttext-predict: init at 0.9.2.1 ``                       |
| [`19de50fd`](https://github.com/NixOS/nixpkgs/commit/19de50fd8f49a3300cf30755e5775d9a45f65834) | `` kotatogram-desktop: fix tg_owt ``                                            |
| [`4b974b54`](https://github.com/NixOS/nixpkgs/commit/4b974b5420e4eb58e49307c712cfad4833200817) | `` mpc-qt: 22.02 -> 23.02 ``                                                    |
| [`121fbb3c`](https://github.com/NixOS/nixpkgs/commit/121fbb3cf7d339db9c998dadfa5b485775f2c94b) | `` docs: Building a stdenv package in nix-shell (#216650) ``                    |
| [`c3dc516f`](https://github.com/NixOS/nixpkgs/commit/c3dc516fe20b24540ca5307c063f26cf458d00b2) | `` boxxy: 0.2.7 -> 0.3.4, add figsoda as a maintainer ``                        |
| [`bad58b9e`](https://github.com/NixOS/nixpkgs/commit/bad58b9eb6aa6b2c6c3309c92f84f3b02cd2fdde) | `` python3Packages.datasets: 2.6.1 -> 2.9.0 ``                                  |
| [`72f17738`](https://github.com/NixOS/nixpkgs/commit/72f1773807dfc9d9d9ac48d4bdc47275fd120bc1) | `` teleport: 11.2.3 -> 11.3.4 ``                                                |
| [`3ac55d31`](https://github.com/NixOS/nixpkgs/commit/3ac55d312df6f771b32047153175f1a01dc9e3cb) | `` Revert "rubyPackages: update" ``                                             |
| [`9d8f05ee`](https://github.com/NixOS/nixpkgs/commit/9d8f05ee8bfce08526bffb14f2a0e49a17a07403) | `` python310Packages.fakeredis: 2.8.0 -> 2.9.0 ``                               |
| [`2a4825f1`](https://github.com/NixOS/nixpkgs/commit/2a4825f1586e1ecb878e15d1758439c4a716f9d1) | `` ledger-live-desktop: 2.51.0 -> 2.53.2 ``                                     |
| [`e48314c8`](https://github.com/NixOS/nixpkgs/commit/e48314c8175e29cfddc5bd41227d5b6fb359af0d) | `` python311Packages.aioguardian: drop asynctest ``                             |
| [`fa786e1e`](https://github.com/NixOS/nixpkgs/commit/fa786e1ea71dce25a5310dedc124d7f788dee8ec) | `` python311Packages.aioambient: drop asynctest ``                              |
| [`08fc9157`](https://github.com/NixOS/nixpkgs/commit/08fc91571f2728807a36247121ef70b55211b2df) | `` python310Packages.pandas-stubs: 1.5.0.221003 -> 1.5.3.230214 ``              |
| [`d484961b`](https://github.com/NixOS/nixpkgs/commit/d484961ba8a364de64aa7f05bc22c5e2db182d20) | `` syncthing: fix cross ``                                                      |
| [`fe89d894`](https://github.com/NixOS/nixpkgs/commit/fe89d894ed2ab94e9d1d907bc9c0dd423aa92363) | `` invidious: unstable-2023-02-02 -> unstable-2023-02-13 ``                     |
| [`ce74158b`](https://github.com/NixOS/nixpkgs/commit/ce74158b70fc4d529ea1542d962a6cb8995880d9) | `` gnome.gnome-control-center: 43.2 → 43.4.1 ``                                 |
| [`29a1311a`](https://github.com/NixOS/nixpkgs/commit/29a1311a65314f528bf29ca4733765aa0691208d) | `` gnome.rygel: 0.42.0 → 0.42.1 ``                                              |
| [`b424c052`](https://github.com/NixOS/nixpkgs/commit/b424c05225be95dac7534c3110db8ac86ba243c0) | `` vte: 0.70.2 → 0.70.3 ``                                                      |
| [`d76127f9`](https://github.com/NixOS/nixpkgs/commit/d76127f9fef3a9ac265acfc369324c0332890d8f) | `` turbo: init at 1.7.0 ``                                                      |
| [`e1d4a40c`](https://github.com/NixOS/nixpkgs/commit/e1d4a40c44069d9cdc06fa9c66f9b3b652fb774a) | `` traefik: 2.9.6 -> 2.9.8 ``                                                   |
| [`8f4a9f86`](https://github.com/NixOS/nixpkgs/commit/8f4a9f866e874cd5cc8897311a1724dc4fef1ce9) | `` tl-expected: 2019-11-11 -> 2023-02-15 ``                                     |
| [`2bcea975`](https://github.com/NixOS/nixpkgs/commit/2bcea97534f1ba061fe7a80fb956b846254778d5) | `` python310Packages.locationsharinglib: add changelog to meta ``               |
| [`c2ccc12c`](https://github.com/NixOS/nixpkgs/commit/c2ccc12c3f16a32dcd1fbe993328564c61abaea4) | `` python311Packages.ncclient: add missing input ``                             |
| [`3cbf66ca`](https://github.com/NixOS/nixpkgs/commit/3cbf66ca1d5243e7bff7ca42a8610cb040abc750) | `` plex: 1.30.2.6563-3d4dc0cce -> 1.31.0.6654-02189b09f ``                      |
| [`d382e6d1`](https://github.com/NixOS/nixpkgs/commit/d382e6d1bdd91581a766f05f393b5d8c2e1fb05d) | `` migraphx: remove cppcheck linter ``                                          |
| [`2f97cda1`](https://github.com/NixOS/nixpkgs/commit/2f97cda1f8108ed2d7a5b43ca47c758831fc800e) | `` freeorion: use boost that builds with python3, remove cppcheck linter ``     |
| [`e4c2a7ce`](https://github.com/NixOS/nixpkgs/commit/e4c2a7ceb39d2adf3892dd06a62cf0b10079ebde) | `` sqlitecpp: don't run cppcheck linter ``                                      |
| [`02124bbb`](https://github.com/NixOS/nixpkgs/commit/02124bbb7ea70ecec0add1a0036abf0c6127298c) | `` rsstail: don't run cppcheck linter, little cleanup ``                        |
| [`7cf9c5dd`](https://github.com/NixOS/nixpkgs/commit/7cf9c5dde5835a408e33695a35c7de1e9decc352) | `` mpy-utils: init at 0.1.13 ``                                                 |
| [`ad09ab16`](https://github.com/NixOS/nixpkgs/commit/ad09ab166b28790b134be2cb2df4754f0bc0fc2e) | `` ntfy-sh: 1.30.1 -> 1.31.0 ``                                                 |
| [`4ca42ad0`](https://github.com/NixOS/nixpkgs/commit/4ca42ad0a78017199ae6bf91b8ce90a9e35c5641) | `` invoice2data: 0.3.6 -> 0.4.2 ``                                              |
| [`b1ff1e16`](https://github.com/NixOS/nixpkgs/commit/b1ff1e165821a6842f05cd358a8379ea60bd867b) | `` nixos/systemd-repart: enable running after initrd ``                         |
| [`6c07e1b7`](https://github.com/NixOS/nixpkgs/commit/6c07e1b78c5a85fefa702e5bd0244adfc40339b9) | `` subtitleedit: init at 3.6.11 ``                                              |
| [`7ca8fddf`](https://github.com/NixOS/nixpkgs/commit/7ca8fddf5761afa278bc7dfed041cf3fc01e57e0) | `` maintainers: add paveloom ``                                                 |
| [`a61f3328`](https://github.com/NixOS/nixpkgs/commit/a61f33281581ccd06b7a37ca1a5abde7b916e7c1) | `` python311Packages.asyncio-dgram: disable failing test ``                     |
| [`105c76e7`](https://github.com/NixOS/nixpkgs/commit/105c76e711cbdbf5f615ce37f702cb37228f3bc1) | `` maintainers: add luizirber ``                                                |
| [`3953ad2e`](https://github.com/NixOS/nixpkgs/commit/3953ad2e6b668b25c2f56ba739c5fb9e314e993a) | `` python3Packages.screed: init at 1.1.1 ``                                     |
| [`fe5d8a3f`](https://github.com/NixOS/nixpkgs/commit/fe5d8a3fb7fa154f85a6a5b593741da1a6d3c44b) | `` structorizer: init at 3.32-11 ``                                             |
| [`771e7050`](https://github.com/NixOS/nixpkgs/commit/771e70507bb0df402049fc39955da0985e7e8c49) | `` prowlarr: 1.1.3.2521 -> 1.2.0.2583 ``                                        |
| [`bfc6975c`](https://github.com/NixOS/nixpkgs/commit/bfc6975cbc399cac0719b9305a8ac0fedb957aca) | `` nixos/manual: remove holdovers from docbook times ``                         |
| [`1229e735`](https://github.com/NixOS/nixpkgs/commit/1229e735ac51dbe79724f7648655a2089c9c67b9) | `` nixos-render-docs: add structural includes, use for manual ``                |
| [`8b7f0e55`](https://github.com/NixOS/nixpkgs/commit/8b7f0e559ad9419815d0a4c8d231e2bf464c0ad2) | `` nixos/manual: clean up default.nix a bit ``                                  |
| [`ef413e3e`](https://github.com/NixOS/nixpkgs/commit/ef413e3eac947507ae1dc62dc365d225c30f4bbf) | `` nixos/manual: split manpages-combined from manual-combined ``                |
| [`9977f997`](https://github.com/NixOS/nixpkgs/commit/9977f997400309871a82fcb4b6255b3bdd8dbc41) | `` nixos/manual: inline man-configuration.xml ``                                |
| [`d30da4d9`](https://github.com/NixOS/nixpkgs/commit/d30da4d9cd20f18b08d51fc28b20b4bbd2aa2a64) | `` nixos-render-docs: add support for <part> ``                                 |
| [`ad2b150a`](https://github.com/NixOS/nixpkgs/commit/ad2b150af78f260f9b1caee0f4d3d877af78c121) | `` nixos-render-docs: use Mapping for options converter ``                      |
| [`d0041050`](https://github.com/NixOS/nixpkgs/commit/d004105003d6336b0b0afcecf2210e866c029245) | `` nixos-render-docs: print exception trees by __cause__ ``                     |
| [`2dd58d64`](https://github.com/NixOS/nixpkgs/commit/2dd58d648775b7efb1b5d09ca47fa61a1250a92c) | `` flatpak: 1.14.1 → 1.14.2 ``                                                  |
| [`c976bd78`](https://github.com/NixOS/nixpkgs/commit/c976bd78844756f1fec76e5573319077c6bcf70a) | `` python310Packages.oslo-serialization: 5.0.0 -> 5.1.0 ``                      |
| [`95b08561`](https://github.com/NixOS/nixpkgs/commit/95b0856179ba4ac8ef21a5d82b34f6b97c17dd43) | `` python310Packages.playwright: set meta.platforms ``                          |
| [`2d30754d`](https://github.com/NixOS/nixpkgs/commit/2d30754df3e98a72f1080fa0e5a2f590fa28cd9a) | `` kubernetes-helmPlugins.helm-diff: 3.5.0 -> 3.6.0 ``                          |
| [`e6e02bc9`](https://github.com/NixOS/nixpkgs/commit/e6e02bc9c21aeedb9c70893e5d0b9f68a7b05997) | `` dde-api: init at 5.5.32 ``                                                   |
| [`5a1ba628`](https://github.com/NixOS/nixpkgs/commit/5a1ba628417ce5f6151bea3f37351d8e68383252) | `` onlyoffice: allow ExecStartPre additions ``                                  |
| [`36acad3d`](https://github.com/NixOS/nixpkgs/commit/36acad3daf6fa6cc32fed4641eaf7e36984f055b) | `` python310Packages.bambi: enable more tests ``                                |
| [`20f49fa1`](https://github.com/NixOS/nixpkgs/commit/20f49fa10b8d28c581a1cf125de12e5bbf47840a) | `` python310Packages.blackjax: init at 0.9.6 ``                                 |
| [`2f14f5d5`](https://github.com/NixOS/nixpkgs/commit/2f14f5d561cb1cb5f8f95902a37568c9c350c1b1) | `` python310Packages.jaxopt: init at 0.5.5 ``                                   |
| [`62928668`](https://github.com/NixOS/nixpkgs/commit/62928668a8562dfc910ce5d5b21cdaff8366ad06) | `` nixos/no-x-libs: add vim-full ``                                             |
| [`e608e04f`](https://github.com/NixOS/nixpkgs/commit/e608e04f3c5d1db8f583eb053ad7d6b6aca80ae4) | `` puddletag: fix wrapping ``                                                   |
| [`68e2afd4`](https://github.com/NixOS/nixpkgs/commit/68e2afd480150e2b10eeac2eab6f420ea4e7ca33) | `` python310Packages.selenium: 4.7.0 -> 4.8.0 ``                                |
| [`5bf53688`](https://github.com/NixOS/nixpkgs/commit/5bf53688d62ab6e8d080f6c395077b01a0804425) | `` webex: 42.10.0.24000 → 42.12.0.24485 ``                                      |
| [`18d6f135`](https://github.com/NixOS/nixpkgs/commit/18d6f13520878b2b7f2fdc9b57b21b2ad925c38a) | `` python3Packages.brian2: init at 2.5.1 ``                                     |
| [`fc2812a1`](https://github.com/NixOS/nixpkgs/commit/fc2812a1f8a2b74ce0ab9a36912e9298b2027bfe) | `` nest: init at 3.3 ``                                                         |
| [`4add2dd5`](https://github.com/NixOS/nixpkgs/commit/4add2dd5c64f1c65284b3aa1c57f9508a6d85f0e) | `` hunspell-dict-tok: init at 20220829 ``                                       |
| [`75fae935`](https://github.com/NixOS/nixpkgs/commit/75fae935dc081f86bd0fff64d2b54fc7138117bb) | `` protonup-qt: init at 2.7.4 ``                                                |
| [`c5ec1baa`](https://github.com/NixOS/nixpkgs/commit/c5ec1baa8f23c91640c1e2c40170e66ef5597ee2) | `` nasin-nanpa: init at 2.5.1 ``                                                |