### PR TITLE
chore(flake/nixpkgs): `958dbd6c` -> `5f4e07de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676659111,
-        "narHash": "sha256-nj3GONWv33Zr/ahm6ATep2qhtuu1mH5e4I4fuKdSVzU=",
+        "lastModified": 1676721149,
+        "narHash": "sha256-mN2EpTGxxVNnFZLoLWRwh6f7UWhXy4qE+wO2CZyrXps=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "958dbd6c08c7e276451704409ebc7cb0d8bc94c7",
+        "rev": "5f4e07deb7c44f27d498f8df9c5f34750acf52d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`5f4e07de`](https://github.com/NixOS/nixpkgs/commit/5f4e07deb7c44f27d498f8df9c5f34750acf52d2) | `` terraform-providers.vault: 3.12.0 → 3.13.0 ``                                             |
| [`28f6883d`](https://github.com/NixOS/nixpkgs/commit/28f6883dd5a1ba48c54224d6c23947927e9b8f35) | `` terraform-providers.azurerm: 3.44.0 → 3.44.1 ``                                           |
| [`29b571a5`](https://github.com/NixOS/nixpkgs/commit/29b571a5053025e884c2fb6b2803d6d09bf07159) | `` terraform-providers.huaweicloud: 1.44.1 → 1.44.2 ``                                       |
| [`e26cbd73`](https://github.com/NixOS/nixpkgs/commit/e26cbd73d3a57e6751603168e6839dedef97ceac) | `` terraform-providers.github: 5.17.0 → 5.18.0 ``                                            |
| [`6d3b26f1`](https://github.com/NixOS/nixpkgs/commit/6d3b26f1542d214017783a4cfbcb369eaa0cd6b4) | `` terraform-providers.azuread: 2.34.0 → 2.34.1 ``                                           |
| [`e1f1c7eb`](https://github.com/NixOS/nixpkgs/commit/e1f1c7eb79fefa5e640bfbc9e023619ef095935a) | `` Revert "setup-hooks/reproducible-builds.sh: NIX_OUTPATH_USED_AS_RANDOM_SEED" (#216935) `` |
| [`ef56f34e`](https://github.com/NixOS/nixpkgs/commit/ef56f34e07c157e5b9b694c0be2c8d2125239cb3) | `` opensnitch: Fix build by sticking with Go 1.18 ``                                         |
| [`0fcc1b8e`](https://github.com/NixOS/nixpkgs/commit/0fcc1b8ef83241283cccb2be0882b661860bd081) | `` kubeshark: init at 38.5 ``                                                                |
| [`aae8cfd9`](https://github.com/NixOS/nixpkgs/commit/aae8cfd998b52cba9977e54d11e30881038a8c93) | `` tvnamer: add setuptools dependency to requests-cache 0.5.2 ``                             |
| [`06841a64`](https://github.com/NixOS/nixpkgs/commit/06841a64aaf15fa81b3f9ded0f4842aa2f49e336) | `` tvdb_api: unblock by using the latest version ``                                          |
| [`14563095`](https://github.com/NixOS/nixpkgs/commit/145630955db0e5cb91cb3806b2a2a191edafa213) | `` flexget: 3.5.24 -> 3.5.25 ``                                                              |
| [`c79e326a`](https://github.com/NixOS/nixpkgs/commit/c79e326a5919075eb6386e7485b691324595e71c) | `` erlang: 25.2.2 -> 25.2.3 ``                                                               |
| [`0980625b`](https://github.com/NixOS/nixpkgs/commit/0980625b3c4c99c23dadf3a6df515945ea60de08) | `` python310Packages.pipdeptree: 2.3.3 -> 2.4.0 ``                                           |
| [`9e9a2124`](https://github.com/NixOS/nixpkgs/commit/9e9a2124cff6edf577711df8a673df293ac974cd) | `` cargo-tally: 1.0.22 -> 1.0.23 ``                                                          |
| [`a7deb859`](https://github.com/NixOS/nixpkgs/commit/a7deb859a892e7fbb91307f6c256ee6e30f1980b) | `` python310Packages.tensorflow: remove ? null from inputs ``                                |
| [`a4f7cd5f`](https://github.com/NixOS/nixpkgs/commit/a4f7cd5fe3bc3d961ce0668890295ec542ad00fc) | `` julia_19: add joshniemela to maintainers ``                                               |
| [`ebb1b60b`](https://github.com/NixOS/nixpkgs/commit/ebb1b60be1567e2661d8e7c7a73fabbbf68c7e1e) | `` maintainers: add joshniemela ``                                                           |
| [`be1f8ec4`](https://github.com/NixOS/nixpkgs/commit/be1f8ec4f599a5325216850bcae6e18a8d96cdec) | `` fetchHex produces outputs that mix will accept ``                                         |
| [`af1a1062`](https://github.com/NixOS/nixpkgs/commit/af1a1062417456fb9188283daa502631c9a469f4) | `` python310Packages.jaconv: 0.3.1 -> 0.3.4 ``                                               |
| [`cce3f920`](https://github.com/NixOS/nixpkgs/commit/cce3f9204cca6d9a1573eafe6f31a4d64172a061) | `` python310Packages.jaconv: update rev ``                                                   |
| [`5759ce6c`](https://github.com/NixOS/nixpkgs/commit/5759ce6ce0709cb218faa79bc6091535c3af7d42) | `` python310Packages.ha-philipsjs: 3.0.0 -> 3.0.1 ``                                         |
| [`66e36156`](https://github.com/NixOS/nixpkgs/commit/66e3615642b27e39f83c0558f2e2c9a8b153acb4) | `` python310Packages.fortiosapi: add missing input ``                                        |
| [`9c29ccb3`](https://github.com/NixOS/nixpkgs/commit/9c29ccb37694129f14bcf9a139593bd7594b711b) | `` pgmodeler: 1.0.0 -> 1.0.1 ``                                                              |
| [`270de46d`](https://github.com/NixOS/nixpkgs/commit/270de46da665638e4b3769e67eef0f0e9ecfa398) | `` nomad_1_4: 1.4.3 -> 1.4.4 ``                                                              |
| [`5618484d`](https://github.com/NixOS/nixpkgs/commit/5618484d80adaa550b7a6853d3d66e5e2474bbfd) | `` nomad_1_3: 1.3.8 -> 1.3.9 ``                                                              |
| [`fe4364f5`](https://github.com/NixOS/nixpkgs/commit/fe4364f503f6072c5ffb8a4b1670064b5227932e) | `` nomad_1_2: 1.2.15 -> 1.2.16 ``                                                            |
| [`2ea8b001`](https://github.com/NixOS/nixpkgs/commit/2ea8b001f6ba09cc6eb9a30f4e117cbc3ec5afe2) | `` beam/fetch-mix-deps: replace mixEnv with MIX_ENV ``                                       |
| [`13ff144c`](https://github.com/NixOS/nixpkgs/commit/13ff144c70351811141067d6e77b599e146e44b2) | `` nixos/maddy: Add option ensureAccounts ``                                                 |
| [`3dbc3b9c`](https://github.com/NixOS/nixpkgs/commit/3dbc3b9c6502c48c71c3e9598a7f47d4d7bdcd6e) | `` mongoc: add patch documentation ``                                                        |
| [`0614908d`](https://github.com/NixOS/nixpkgs/commit/0614908d626863e8547d5346cfff416c866938f5) | `` paperview: init at unstable-2020-09-22 ``                                                 |
| [`405919c6`](https://github.com/NixOS/nixpkgs/commit/405919c6c9eafd5efab75910acddb4f757d9d51c) | `` nixos/kanata: misc improvements ``                                                        |
| [`46122183`](https://github.com/NixOS/nixpkgs/commit/46122183b5bcda762d3df29523a9e941a72c7d5a) | `` nixos/kanata: remove a limit that number of devices cannot be 0 ``                        |
| [`f34917b1`](https://github.com/NixOS/nixpkgs/commit/f34917b128d005fff727867969003ad7e7aace00) | `` nixos/kanata: do not use path activation ``                                               |
| [`bb641291`](https://github.com/NixOS/nixpkgs/commit/bb641291755ca289e703b638a88ed2c2ea65f37d) | `` ansi: fix typo ``                                                                         |
| [`ef9eccad`](https://github.com/NixOS/nixpkgs/commit/ef9eccad572028b167c047e97b0304ab15b9a262) | `` Revert "python3Packages.catboost: 1.0.5 -> 1.1.1" ``                                      |
| [`069a7247`](https://github.com/NixOS/nixpkgs/commit/069a72478dfe9a1d76038aeedf73687b50eb64a6) | `` python3Packages.types-pillow: init at 9.4.0.12 ``                                         |
| [`bc18c81d`](https://github.com/NixOS/nixpkgs/commit/bc18c81dbef45ca279c237a8c43dc499eaa4c4c2) | `` python310Packages.xiaomi-ble: 0.16.3 -> 0.16.4 ``                                         |
| [`ffc11107`](https://github.com/NixOS/nixpkgs/commit/ffc11107d9c77fc37d8324806c9ebbc4b706f411) | `` grype: 0.56.0 -> 0.57.1 ``                                                                |
| [`a48a5d63`](https://github.com/NixOS/nixpkgs/commit/a48a5d6359625ab89e4a62b6c578ffcd83622cea) | `` gh-dash: add version test ``                                                              |
| [`abda1b2b`](https://github.com/NixOS/nixpkgs/commit/abda1b2b4482fc2659c943e1f1f29eafabbbb031) | `` yt-dlp: add updateScript ``                                                               |
| [`364fd188`](https://github.com/NixOS/nixpkgs/commit/364fd1883b76eea2b61ed9bdecd8c0dca1b09e10) | `` gh-dash: 3.6.0 -> 3.7.6 ``                                                                |
| [`db6118df`](https://github.com/NixOS/nixpkgs/commit/db6118df654ee75e60b12e23da6c31ca0ffebefc) | `` libdisplay-info: adequate patch phase ``                                                  |
| [`5123929a`](https://github.com/NixOS/nixpkgs/commit/5123929a70e353f13b99d78a2491d8395917eae1) | `` kodelife: add updateScript ``                                                             |
| [`f3d2bbea`](https://github.com/NixOS/nixpkgs/commit/f3d2bbea40260c27bfbe6ca45ce5dfcd5dc991ff) | `` crossguid: add updateScript ``                                                            |
| [`5f5bdf86`](https://github.com/NixOS/nixpkgs/commit/5f5bdf86d7939a24469c678a4fe8cba8fcef3870) | `` gl3w: add updateScript ``                                                                 |
| [`2515951e`](https://github.com/NixOS/nixpkgs/commit/2515951ed8846300d381da7f5019433da4a22bc3) | `` platform-folders: add updateScript ``                                                     |
| [`b933aac0`](https://github.com/NixOS/nixpkgs/commit/b933aac06ee1e72c2c72bf90a6bfd9971fef5181) | `` tauon: 7.4.7 -> 7.5.0 ``                                                                  |
| [`e7d380ac`](https://github.com/NixOS/nixpkgs/commit/e7d380acc074547332ae15b0ce5f6e47cb86b87d) | `` python310Packages.weconnect-mqtt: 0.41.1 -> 0.42.0 ``                                     |
| [`668e973b`](https://github.com/NixOS/nixpkgs/commit/668e973bd2d4d811d637f3c56caadac6f10099d2) | `` python310Packages.weconnect: 0.50.1 -> 0.52.0 ``                                          |
| [`3d139e11`](https://github.com/NixOS/nixpkgs/commit/3d139e1130813f94ecc3a19856b12a3f029254b2) | `` protonup-qt: add michaelBelsanti as maintainer ``                                         |
| [`4c498fa0`](https://github.com/NixOS/nixpkgs/commit/4c498fa0c15ceae8a2d828e60edc736d16f4e256) | `` python310Packages.pydeconz: add changelog to meta ``                                      |
| [`f5b13396`](https://github.com/NixOS/nixpkgs/commit/f5b1339601f9ae83f312f07219ef80cddcc968a5) | `` python310Packages.griffe: 0.25.4 -> 0.25.5 ``                                             |
| [`7c3506e4`](https://github.com/NixOS/nixpkgs/commit/7c3506e42bf3a58dacafa9a028bb425111e6c15e) | `` python310Packages.python-ipmi: 0.5.3 -> 0.5.4 ``                                          |
| [`95cacec5`](https://github.com/NixOS/nixpkgs/commit/95cacec56613fb9eabdc7b934b5ff83b313ac8e6) | `` python310Packages.pyfido: 2.1.1 -> 2.1.2 ``                                               |
| [`9c6e67c9`](https://github.com/NixOS/nixpkgs/commit/9c6e67c969c8eefb634e0662a0b537ca955e2b43) | `` python310Packages.pydeconz: 106 -> 107 ``                                                 |
| [`4817f6a7`](https://github.com/NixOS/nixpkgs/commit/4817f6a7791e05684516ee494aac9bbb3311b77d) | `` python310Packages.slack-sdk: 3.19.5 -> 3.20.0 ``                                          |
| [`99648914`](https://github.com/NixOS/nixpkgs/commit/99648914400685392377abc98f29a0a90a9b48c2) | `` nixos/doc: Add Developing the Test Driver ``                                              |
| [`c1422cea`](https://github.com/NixOS/nixpkgs/commit/c1422cea7af76253968a14847c700ca72325c827) | `` python310Packages.cwl-utils: 0.22 -> 0.23 ``                                              |
| [`13be52be`](https://github.com/NixOS/nixpkgs/commit/13be52bef65b2b6e2ef8a7161a0cf0e20b10f21a) | `` pgsync: 0.7.2 → 0.7.3 ``                                                                  |
| [`379bb7c2`](https://github.com/NixOS/nixpkgs/commit/379bb7c2afe275ccef2c64b1ec471b73a0bace9d) | `` xemu: init at 0.7.84 ``                                                                   |
| [`dd65018d`](https://github.com/NixOS/nixpkgs/commit/dd65018d4ebbcad268e1e72b94ad5184189dcde9) | `` Via 2.0.5 -> 2.1.0 ``                                                                     |
| [`e34febdd`](https://github.com/NixOS/nixpkgs/commit/e34febdd88aab94c4167a37bebae4d2b890347ac) | `` kitty-themes: 2022-08-11 -> 2023-01-08 ``                                                 |
| [`e37ca9c3`](https://github.com/NixOS/nixpkgs/commit/e37ca9c317ba0eaba8573ccf1427573c8a35b2aa) | `` julia_19: 1.9.0-beta2 -> 1.9.0-beta4 ``                                                   |
| [`dd30696b`](https://github.com/NixOS/nixpkgs/commit/dd30696b67ed9908ee77ab587480bada82e8c804) | `` btcpayserver: 1.7.7 -> 1.7.12 ``                                                          |
| [`f34f3243`](https://github.com/NixOS/nixpkgs/commit/f34f324382c00d20899d5d7698d1da93144f8990) | `` nbxplorer: 2.3.60 -> 2.3.62 ``                                                            |
| [`62ad474f`](https://github.com/NixOS/nixpkgs/commit/62ad474f0ff81f22f6db31e44b289b973e69b522) | `` postgresqlPackages.pg_ivm: 1.4 -> 1.5 ``                                                  |
| [`0d193e46`](https://github.com/NixOS/nixpkgs/commit/0d193e46160ef485b3692e9008a210c8957605c6) | `` python310Packages.wandb: unbreak ``                                                       |
| [`8ef4c086`](https://github.com/NixOS/nixpkgs/commit/8ef4c0860c7259ccdebed57f98fe2aa8b056311a) | `` mongoc: mark darwin x86_64 as broken ``                                                   |
| [`9aa9c5e7`](https://github.com/NixOS/nixpkgs/commit/9aa9c5e79279b025892dcf347c329938b22bf17f) | `` trilium-{desktop,server}: 0.58.7 -> 0.58.8 ``                                             |
| [`8526c101`](https://github.com/NixOS/nixpkgs/commit/8526c101275591e47b43ea5f8d4bac45af659197) | `` vimPlugins.nvim-treesitter: update grammars ``                                            |
| [`b5f27982`](https://github.com/NixOS/nixpkgs/commit/b5f27982a9a481e93633c0f3492507421569fc71) | `` vimPlugins.pest-vim: init at 2020-04-20 ``                                                |
| [`d20cbeb1`](https://github.com/NixOS/nixpkgs/commit/d20cbeb18fde359c5d57e8e34366c2f2d226b650) | `` vimPlugins: update ``                                                                     |
| [`c66aae62`](https://github.com/NixOS/nixpkgs/commit/c66aae629e3a0a4a55aba157ce10bddc560f2fcf) | `` awscli2: 2.9.21 -> 2.10.0 ``                                                              |
| [`254426ec`](https://github.com/NixOS/nixpkgs/commit/254426ec4bce7d289c80d7e84feb616d756efdd7) | `` nixos/lib/testing: set default timeout for VM tests ``                                    |
| [`84434922`](https://github.com/NixOS/nixpkgs/commit/84434922bcb77dda8bdde7818276dc730cfc0af0) | `` nixos/tests/quake3: fix eval ``                                                           |
| [`a456da34`](https://github.com/NixOS/nixpkgs/commit/a456da3490fc245c908654d6efed64a78b67763e) | `` nixos/tests/pass-secret-service: fix eval ``                                              |
| [`e5ef7ae7`](https://github.com/NixOS/nixpkgs/commit/e5ef7ae79e756cee3cf492e9c17b0f6c4f23d1ec) | `` tdesktop: 4.6.2 -> 4.6.3 ``                                                               |
| [`a9953119`](https://github.com/NixOS/nixpkgs/commit/a99531196862423e464b5f15f1dacb98c07534f9) | `` pantheon.elementary-greeter: Use mesa instead of clutter-gtk ``                           |
| [`e4105481`](https://github.com/NixOS/nixpkgs/commit/e410548128820439974ecfa611db8706de9ef5e6) | `` pantheon.gala: Use mesa instead of clutter ``                                             |
| [`483aff0b`](https://github.com/NixOS/nixpkgs/commit/483aff0b1ff3130a0120f07c7cfb6edd21efc71c) | `` python3Packages.z3c-checkversions: 1.2 -> 2.0 ``                                          |
| [`b8eadbe1`](https://github.com/NixOS/nixpkgs/commit/b8eadbe19ff82b4c13d6ac53569f8f5306f51447) | `` mongoc: formatting ``                                                                     |
| [`b68077df`](https://github.com/NixOS/nixpkgs/commit/b68077df875d866a239a0ba5938159c652a57422) | `` mongoc: add Security Framework Darwin build dep ``                                        |
| [`11b095e8`](https://github.com/NixOS/nixpkgs/commit/11b095e8805aa123a4d77a5e706bebaf86622879) | `` libvisual: disable building examples when cross compiling ``                              |
| [`463ab8de`](https://github.com/NixOS/nixpkgs/commit/463ab8deaa17d333be2ff7c61bea4e8e664e71cb) | `` Revert "libvisual: fix null malloc check on cross" ``                                     |
| [`08b9cb9e`](https://github.com/NixOS/nixpkgs/commit/08b9cb9e7033e6f3aef2b4e46e0e927800b50a0e) | `` mongoc: 1.23.1 -> 1.23.2 ``                                                               |
| [`c73f3cf9`](https://github.com/NixOS/nixpkgs/commit/c73f3cf9276f742f4cd65aee51953553b4732838) | `` xwayland: enable libunwind ``                                                             |
| [`67a00c20`](https://github.com/NixOS/nixpkgs/commit/67a00c202463acfef373b9a22d4e65a7174290ab) | `` python310Packages.check-manifest: 0.48 -> 0.49 ``                                         |
| [`49a06c00`](https://github.com/NixOS/nixpkgs/commit/49a06c00057ca9db11f0f5ab524db88f836481bf) | `` python310Packages.check-manifest: add changelog to meta ``                                |
| [`07942cdb`](https://github.com/NixOS/nixpkgs/commit/07942cdbdf40df390eb29ddf3f8f0264deb9623e) | `` setup-hooks/reproducible-builds.sh: NIX_OUTPATH_USED_AS_RANDOM_SEED ``                    |
| [`2db8ff4f`](https://github.com/NixOS/nixpkgs/commit/2db8ff4f424abf54ecf6f74896a59736c414adb9) | `` python310Packages.ciscoconfparse: 1.6.50 -> 1.7.15 ``                                     |
| [`9a1e9d42`](https://github.com/NixOS/nixpkgs/commit/9a1e9d423afea66e56f6c0d011ea07e8b33c3a7f) | `` python310Packages.deprecat: init at 2.1.1 ``                                              |
| [`f9c43e87`](https://github.com/NixOS/nixpkgs/commit/f9c43e87acb3f2c724ceab1dffbcbb04e47b6f80) | `` python310Packages.ciscoconfparse: add changelog to meta ``                                |
| [`a88d103b`](https://github.com/NixOS/nixpkgs/commit/a88d103bfcf52561b74ee8d23647ef6886664df1) | `` python3Packages.isort: 5.11.4 → 5.12.0 ``                                                 |
| [`ac2d27b1`](https://github.com/NixOS/nixpkgs/commit/ac2d27b1c27eeed834652bed2b0cd30fbfe2e84e) | `` openrgb-plugin-effects: init at 0.8 ``                                                    |
| [`9e01b532`](https://github.com/NixOS/nixpkgs/commit/9e01b53234f2a242a51c7fb7f598121f1092cdcf) | `` openrgb-with-all-plugins: init ``                                                         |
| [`9aac1343`](https://github.com/NixOS/nixpkgs/commit/9aac134336f7596d8d2f7bb1a6f141673776a5db) | `` openrgb: add withPlugins ``                                                               |
| [`2e03c5e8`](https://github.com/NixOS/nixpkgs/commit/2e03c5e81dd265271234695a4b09cc9ed12e8bff) | `` openrgb-plugin-hardwaresync: init at 0.8 ``                                               |
| [`3278ce10`](https://github.com/NixOS/nixpkgs/commit/3278ce100b61226f475fb222efcd11cbda81bf1c) | `` sslscan: enable TLS compression check ``                                                  |
| [`12755ecd`](https://github.com/NixOS/nixpkgs/commit/12755ecdd522b502048c5b915cae1241778feabf) | `` nixos/docker: load more required kernel modules ``                                        |