### PR TITLE
chore(flake/nixos-hardware): `525177a7` -> `26c9dbdc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -183,11 +183,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1676775543,
-        "narHash": "sha256-VI0e60l94RY9Sc90OwDZpOf/nyLy41n2ULK6I6YkoP8=",
+        "lastModified": 1676886000,
+        "narHash": "sha256-t7nxEvJb4ISR7u54YADZiZi9EaKHJKbXQjyyf00Q8TA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "525177a78023e1363bee482f520d4f2471ada03a",
+        "rev": "26c9dbdc92abc370510be78889942f38a272d705",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message               |
| ----------------------------------------------------------------------------------------------------- | --------------------- |
| [`1c319687`](https://github.com/NixOS/nixos-hardware/commit/1c319687c124f180f10c306719555d183d75246a) | `` gpd/win-2: init `` |