### PR TITLE
chore(flake/nixos-hardware): `26c9dbdc` -> `0f900cfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -183,11 +183,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1676886000,
-        "narHash": "sha256-t7nxEvJb4ISR7u54YADZiZi9EaKHJKbXQjyyf00Q8TA=",
+        "lastModified": 1676908411,
+        "narHash": "sha256-WGXUAN3Q7/vsmxqApzct5/3LZvxHIcIJnPY6VXpysbQ=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "26c9dbdc92abc370510be78889942f38a272d705",
+        "rev": "0f900cfae013b11d5387624496239825ffaf9665",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                       |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`576be211`](https://github.com/NixOS/nixos-hardware/commit/576be211f095c3305110a83c579f006ee42799cc) | `` lenovo/legion/16ach6h: disable thermald `` |