### PR TITLE
chore(flake/nixos-hardware): `0f900cfa` -> `157e1e4b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -183,11 +183,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1676908411,
-        "narHash": "sha256-WGXUAN3Q7/vsmxqApzct5/3LZvxHIcIJnPY6VXpysbQ=",
+        "lastModified": 1676908974,
+        "narHash": "sha256-o7sJTBeumorVIM/b1b/Q4q+WJn8Rou5kx8DEBbKOZJI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0f900cfae013b11d5387624496239825ffaf9665",
+        "rev": "157e1e4b127b5cb37822be247e8ec37a7f475270",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`75b6ec47`](https://github.com/NixOS/nixos-hardware/commit/75b6ec4775ddfe657f19d02bee7f063bd7229620) | `` Add NXP i.MX8 SOC family support. `` |