### PR TITLE
chore(flake/nixpkgs): `5f4e07de` -> `b69883fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -198,11 +198,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676721149,
-        "narHash": "sha256-mN2EpTGxxVNnFZLoLWRwh6f7UWhXy4qE+wO2CZyrXps=",
+        "lastModified": 1676885936,
+        "narHash": "sha256-ZRKb6zBfTvdCOXI7nGC1L9UWSU5ay2ltxg+f5UIzBOU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5f4e07deb7c44f27d498f8df9c5f34750acf52d2",
+        "rev": "b69883faca9542d135fa6bab7928ff1b233c167f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`ab28fd01`](https://github.com/NixOS/nixpkgs/commit/ab28fd0173ba84e355118e4761c1acb900654369) | `` clucene_core_2: fix build with musl and gcc>=11 (#217146) ``                   |
| [`91cfaa25`](https://github.com/NixOS/nixpkgs/commit/91cfaa255c6ee4df0234294035346abffbb4cdd3) | `` ppp: add ppp_defs.h shim for musl ``                                           |
| [`37cc718b`](https://github.com/NixOS/nixpkgs/commit/37cc718bf9a3dc1c2251906650e04a2d3564ca57) | `` liburing: backport portability fixes (#216975) ``                              |
| [`ced929a2`](https://github.com/NixOS/nixpkgs/commit/ced929a2d02672e23f5c528829b9b99988476c16) | `` nixos/tests: add test for luksroot and initrd keymaps (#189725) ``             |
| [`10803b96`](https://github.com/NixOS/nixpkgs/commit/10803b968b2be9cfbf3137904908c80057fcc728) | `` unison: 2.52.1 -> 2.53.0 ``                                                    |
| [`20539ac2`](https://github.com/NixOS/nixpkgs/commit/20539ac23d38ef257b5db8d199ad1eb17f25b2f1) | `` prefetch-npm-deps: add nix to PATH ``                                          |
| [`f08437ed`](https://github.com/NixOS/nixpkgs/commit/f08437edcb9249eb7bd9f9ebe11982ac5dbf655c) | `` clippy: add rust team to maintainers ``                                        |
| [`fd5fa383`](https://github.com/NixOS/nixpkgs/commit/fd5fa383fe79a0582100a26fa223a9099d5bac7e) | `` clippy: drop rustc from buildInputs ``                                         |
| [`759bd7b2`](https://github.com/NixOS/nixpkgs/commit/759bd7b26f363f4701cb9a44da578fcf4676f103) | `` clippy: fix on darwin ``                                                       |
| [`8be63c2f`](https://github.com/NixOS/nixpkgs/commit/8be63c2f948c7329faba3becb39f7bf31f5082bb) | `` wezterm: cleanup meta, format ``                                               |
| [`c90dcc73`](https://github.com/NixOS/nixpkgs/commit/c90dcc73273387b152e7d3cf1a50abec00c3204b) | `` rustc: add ripgrep and wezterm to passthru.tests ``                            |
| [`af260c1e`](https://github.com/NixOS/nixpkgs/commit/af260c1e5a5d9dc0fa046343f2151e0fe743495c) | `` wezterm: fix build against rust 1.67, remove outdated checkFlags ``            |
| [`434bb4d0`](https://github.com/NixOS/nixpkgs/commit/434bb4d090db77c495c1bb2bcf9bb97447b42b0a) | `` librtlsdr: remove ``                                                           |
| [`654cc11a`](https://github.com/NixOS/nixpkgs/commit/654cc11a5f4c19bc9f0a719b02f8e08e5b4efc60) | `` git-machete: 3.15.0 -> 3.15.2 ``                                               |
| [`9c87dcbf`](https://github.com/NixOS/nixpkgs/commit/9c87dcbf85069c5a94325c0eec52623f77689353) | `` maintainers: fix incorrect Matrix for toastal ``                               |
| [`7addad2d`](https://github.com/NixOS/nixpkgs/commit/7addad2d7c3b302beca4474a2902fb6b0ee2934e) | `` shadowsocks-rust: fixup after https://github.com/NixOS/nixpkgs/pull/214126 ``  |
| [`e3926b70`](https://github.com/NixOS/nixpkgs/commit/e3926b7046e45ac29f20802637e9a51273cb0771) | `` python310Packages.ansible-lint: 6.13.0 -> 6.13.1 ``                            |
| [`d3b783f2`](https://github.com/NixOS/nixpkgs/commit/d3b783f29b7666dff6a4b33eb134c01d0e93b90d) | `` commix: 3.6 -> 3.7 ``                                                          |
| [`864ce60e`](https://github.com/NixOS/nixpkgs/commit/864ce60ec130998600566d7104353854640026cb) | `` todoman: skip flaky test ``                                                    |
| [`3f8ad50f`](https://github.com/NixOS/nixpkgs/commit/3f8ad50f9afc077784c260f0e3c948c926f0d402) | `` build-support/vm/deb/deb-closure: quote generated urls ``                      |
| [`b457ff6d`](https://github.com/NixOS/nixpkgs/commit/b457ff6d04fd0fee61d696fa466f5082a2d48b6c) | `` traceroute: 2.1.1 -> 2.1.2 ``                                                  |
| [`fc9e3696`](https://github.com/NixOS/nixpkgs/commit/fc9e3696e009566163c7d4b6b217dc6b7f205ed5) | `` rtw89-firmware: drop ``                                                        |
| [`8aed016f`](https://github.com/NixOS/nixpkgs/commit/8aed016f9cedce3ca4d0a6539a236c70fdc676ed) | `` python310Packages.duo-client: 4.5.0 -> 4.6.1 (#217194) ``                      |
| [`82e9b7c5`](https://github.com/NixOS/nixpkgs/commit/82e9b7c529e39b244b17e40b0402ace2018f3041) | `` python310Packages.python-glanceclient: 4.2.0 -> 4.3.0 ``                       |
| [`c03b73f2`](https://github.com/NixOS/nixpkgs/commit/c03b73f2ec89f35c0f3f017b1e0f8adbe5583250) | `` mozwire: 0.8.0 -> 0.8.1 ``                                                     |
| [`2590b996`](https://github.com/NixOS/nixpkgs/commit/2590b99640bda4c1e84da440b56031a9f48d8578) | `` etcd_3_4: 3.4.23 -> 3.4.24 ``                                                  |
| [`112924de`](https://github.com/NixOS/nixpkgs/commit/112924de490c593fc6fa031935ab3632c68d5831) | `` snowsql: 1.2.21 -> 1.2.23 ``                                                   |
| [`1c60c2a8`](https://github.com/NixOS/nixpkgs/commit/1c60c2a81301a3b4d07ebfc3cbf7dcee7344d67c) | `` zerotierone: 1.10.2 -> 1.10.3 (#216895) ``                                     |
| [`1d7e7869`](https://github.com/NixOS/nixpkgs/commit/1d7e7869b917bf8561b45b78d80b24f8c538db74) | `` quickgui: init at 1.2.8 ``                                                     |
| [`e029dad9`](https://github.com/NixOS/nixpkgs/commit/e029dad941ecc1012851615bae3c63455b3705f0) | `` iucode-tool: add argp-standalone buildInput on musl (#217202) ``               |
| [`85f7fc14`](https://github.com/NixOS/nixpkgs/commit/85f7fc149cb5099be71254ca9cf4b88835b4bea5) | `` python310Packages.sybil: 4.0.0 -> 4.0.1 ``                                     |
| [`c683aaaa`](https://github.com/NixOS/nixpkgs/commit/c683aaaa1dda5fc9b3a023ba28000fdf4e9ea078) | `` nixos/nixos-containers: add specialArgs option (#216677) ``                    |
| [`d6e4740b`](https://github.com/NixOS/nixpkgs/commit/d6e4740b02b39c0d58a981b35e75e891bfbabd6f) | `` python310Packages.types-pillow: 9.4.0.12 -> 9.4.0.13 ``                        |
| [`743bd1f2`](https://github.com/NixOS/nixpkgs/commit/743bd1f29fb0c2aeeb8e756f23f44a51e4de3596) | `` linux: fix-build on i686 ``                                                    |
| [`aebdd631`](https://github.com/NixOS/nixpkgs/commit/aebdd631d1395bb43e0f989be26ae397f9d98186) | `` python310Packages.mypy-boto3-builder: 7.12.3 -> 7.12.4 ``                      |
| [`0b253899`](https://github.com/NixOS/nixpkgs/commit/0b25389993c9ae1f890422e78830b432ccdeadf6) | `` python310Packages.pytibber: 0.27.0 -> 0.27.1 ``                                |
| [`a8302dab`](https://github.com/NixOS/nixpkgs/commit/a8302dabae9989de3da9dbd318128166cb913843) | `` python310Packages.motionblinds: 0.6.16 -> 0.6.17 ``                            |
| [`22d9547c`](https://github.com/NixOS/nixpkgs/commit/22d9547ce3f6bdd3f33eb20b03b59614844a5660) | `` envoy: 1.23.3 -> 1.25.1 ``                                                     |
| [`1a0b4d0c`](https://github.com/NixOS/nixpkgs/commit/1a0b4d0c3f4f9241aaf62ab2ee49b17a62936896) | `` python310Packages.azure-mgmt-cosmosdb: 8.0.0 -> 9.0.0 ``                       |
| [`457c04dc`](https://github.com/NixOS/nixpkgs/commit/457c04dc25b9b5b77575e22d9f69329c9479afae) | `` cargo-llvm-lines: 0.4.23 -> 0.4.24 ``                                          |
| [`fd90e459`](https://github.com/NixOS/nixpkgs/commit/fd90e459bbb3c77d545a96e04275045a69da25b5) | `` linux-firmware: 20221214 -> 20230210 ``                                        |
| [`81ff8e64`](https://github.com/NixOS/nixpkgs/commit/81ff8e645659ef512b1b66fa3b0fbfc83e814ee4) | `` glitter: 1.6.3 -> 1.6.5 ``                                                     |
| [`c3bf65df`](https://github.com/NixOS/nixpkgs/commit/c3bf65df673ad1bd7141b87af6d528bf5d027266) | ``  ocaml: remove spaceTimeSupport after 4.12 ``                                  |
| [`3ba21fc8`](https://github.com/NixOS/nixpkgs/commit/3ba21fc8f82db02887963450b71262528e72be2a) | `` erdtree: set meta.mainProgram ``                                               |
| [`318498c4`](https://github.com/NixOS/nixpkgs/commit/318498c4edf30649f77eff149d44847bb5fba712) | `` nanum: 20170925 -> 20200506 ``                                                 |
| [`b681d064`](https://github.com/NixOS/nixpkgs/commit/b681d0642d32c6a9d5790b2cd60bf656f0d4934e) | `` nanomq: 0.15.1 → 0.15.5 ``                                                     |
| [`af6dd1ae`](https://github.com/NixOS/nixpkgs/commit/af6dd1ae5e4de709db69bfa2331a98c329b6e727) | `` q: 0.8.4 -> 0.9.0 ``                                                           |
| [`c94f4441`](https://github.com/NixOS/nixpkgs/commit/c94f4441cc2acc583f2f88d1db56a0915576f0da) | `` erdtree: 1.0.0 -> 1.1.0 ``                                                     |
| [`9f675690`](https://github.com/NixOS/nixpkgs/commit/9f67569096d7dde25878397532567e4d4a399546) | `` python310Packages.rokuecp: add changelog to meta ``                            |
| [`2aa26f0f`](https://github.com/NixOS/nixpkgs/commit/2aa26f0fccf284ad3324e8da7d2962ac4b781aad) | `` inferno: 0.11.14 -> 0.11.15 ``                                                 |
| [`48a6859d`](https://github.com/NixOS/nixpkgs/commit/48a6859db6c95d082b139770b83119ce57725141) | `` wander: 0.8.2 -> 0.9.0 ``                                                      |
| [`2fe7e66c`](https://github.com/NixOS/nixpkgs/commit/2fe7e66ca091f5d3e7cef55ac4d8354ac13c5062) | `` lattice-diamond: Replace direct use of /usr/bin/id with Nix-compatible path `` |
| [`4df32ef3`](https://github.com/NixOS/nixpkgs/commit/4df32ef3b7a724566e31de8462f9c40696d62c99) | `` lattice-diamond: Make ELF binaries in synpbase usable ``                       |
| [`9b5469bd`](https://github.com/NixOS/nixpkgs/commit/9b5469bd507f9882db9fcc0302bd22d402a909e3) | `` lattice-diamond: Add Diamond's library directories into RPATH ``               |
| [`3cb4d033`](https://github.com/NixOS/nixpkgs/commit/3cb4d0338d444c77a10c4ae15849ffc0f2867d1c) | `` lattice-diamond: Expose pnmainc and ddtcmd commands ``                         |
| [`c18331a5`](https://github.com/NixOS/nixpkgs/commit/c18331a521c7588c70bd119a374361edf57037b7) | `` gitmux: 0.7.12 -> 0.9.0 ``                                                     |
| [`0c203a73`](https://github.com/NixOS/nixpkgs/commit/0c203a7386ab973585ded55cdc92d3b71a5d84c1) | `` spdx-license-list-data: 3.19 -> 3.20 ``                                        |
| [`b11b182a`](https://github.com/NixOS/nixpkgs/commit/b11b182abaffae427cbaae9670efc40307972dfa) | `` python310Packages.aioruuvigateway: remove blank lines ``                       |
| [`8ab4f02a`](https://github.com/NixOS/nixpkgs/commit/8ab4f02ae39fdb66d6748065fe8b8c668b28c822) | `` python310Packages.aioruuvigateway: add pythonImportsCheck ``                   |
| [`142c6348`](https://github.com/NixOS/nixpkgs/commit/142c634891beb680cca285e48e45804a378697fd) | `` hdhomerun-config-gui: 20221031 -> 20221205 ``                                  |
| [`8f632a13`](https://github.com/NixOS/nixpkgs/commit/8f632a13a9219374e1c124268bf71614fa7aff2c) | `` vivaldi: 5.6.2867.62 -> 5.7.2921.53 ``                                         |
| [`82224be8`](https://github.com/NixOS/nixpkgs/commit/82224be8a2046ad8cc744e63496ae83f5fa86c48) | `` python310Packages.txtorcon: add changelog to meta ``                           |
| [`24ffb538`](https://github.com/NixOS/nixpkgs/commit/24ffb538e57dd2e78d284d8f2c0bbf5ca5b9e997) | `` qownnotes: 23.2.0 -> 23.2.4 ``                                                 |
| [`74385d98`](https://github.com/NixOS/nixpkgs/commit/74385d988c4fd7f7169a6dbd9e9d30d862166b0e) | `` openpgp-card-tools: 0.9.0 -> 0.9.1 ``                                          |
| [`fce337b3`](https://github.com/NixOS/nixpkgs/commit/fce337b37cb101e929e8347fcfa4becc46355e20) | `` python310Packages.pymicrobot: add changelog to meta ``                         |
| [`d59a93de`](https://github.com/NixOS/nixpkgs/commit/d59a93de92a5dd1e261cd3aaa7d26d5bf7750685) | `` python310Packages.pymicrobot: 0.0.8 -> 0.0.9 ``                                |
| [`2e97ef89`](https://github.com/NixOS/nixpkgs/commit/2e97ef89424435f8a48991f389daa869c441fad9) | `` sentry-cli: 2.12.0 -> 2.13.0 ``                                                |
| [`c5a66db7`](https://github.com/NixOS/nixpkgs/commit/c5a66db7483c4d66e0e2ce2c833c141b3274e430) | `` bingo: 0.7.0 -> 0.8.0 ``                                                       |
| [`03ee925c`](https://github.com/NixOS/nixpkgs/commit/03ee925c058b7c0ad3786897883acae8adfd862a) | `` firejail: Fix double-dash usage on non-POSIX shells ``                         |
| [`a40ddd91`](https://github.com/NixOS/nixpkgs/commit/a40ddd91927b041515099291e54da5ef0227e53f) | `` pinocchio: 2.6.16 -> 2.6.17 ``                                                 |
| [`e8de6a73`](https://github.com/NixOS/nixpkgs/commit/e8de6a730c1554c8d34d0fe5719067f566d819b1) | `` tdesktop.tg_owt: additional fix for GCC 12 + musl ``                           |
| [`04b1a12a`](https://github.com/NixOS/nixpkgs/commit/04b1a12a6ec7b019866a0dce26a49da1e3df8f4c) | `` chromium: Support GTK 4 ``                                                     |
| [`d71d4270`](https://github.com/NixOS/nixpkgs/commit/d71d42707ed7d00201f99f6935044549f96869bb) | `` ell: disable tests on musl (#217073) ``                                        |
| [`e91a9082`](https://github.com/NixOS/nixpkgs/commit/e91a908215c067acf319a5fc1aaadf057b2588cf) | `` wangle: 2023.01.30.00 -> 2023.02.13.00 ``                                      |
| [`7e52a2bc`](https://github.com/NixOS/nixpkgs/commit/7e52a2bc76c05f83d9b5ec61eff86d50110440c7) | `` librsync: 2.3.3 -> 2.3.4 ``                                                    |
| [`143c3a78`](https://github.com/NixOS/nixpkgs/commit/143c3a786959943d1c4405b45aaab5e388662a5f) | `` librsync: 2.3.2 -> 2.3.3 ``                                                    |
| [`4902c3e0`](https://github.com/NixOS/nixpkgs/commit/4902c3e0742b0c78996dbb5304878d22906ec71c) | `` nixpacks: 1.3.1 -> 1.4.0 ``                                                    |
| [`b6bac132`](https://github.com/NixOS/nixpkgs/commit/b6bac132030368d56de71679e3908e9eddb477b6) | `` mackerel-agent: 0.75.0 -> 0.75.1 ``                                            |
| [`582795ab`](https://github.com/NixOS/nixpkgs/commit/582795ab5a273716e9e3843e0de6967eb59d88ef) | `` matrix-hookshot: init at 2.7.0 ``                                              |
| [`9a0c8c5c`](https://github.com/NixOS/nixpkgs/commit/9a0c8c5c4445533bb143d31dc1405b806042b3e8) | `` clash-geoip: 20230112 -> 20230212 ``                                           |
| [`5442ecbb`](https://github.com/NixOS/nixpkgs/commit/5442ecbb129c715912c94d53a0c12901825de210) | `` apksigcopier: 1.1.0 -> 1.1.1 ``                                                |
| [`6ba1fdef`](https://github.com/NixOS/nixpkgs/commit/6ba1fdef07320078dd4eb9289f7d67815e381ae4) | `` numix-icon-theme-circle: 23.02.12 -> 23.02.16 ``                               |
| [`711b317c`](https://github.com/NixOS/nixpkgs/commit/711b317cf7cf72d19e34be540ff1e2c982f5c291) | `` python310Packages.types-docutils: 0.19.1.3 -> 0.19.1.4 ``                      |
| [`0bc3315a`](https://github.com/NixOS/nixpkgs/commit/0bc3315a9877defcbde8518e6b64cbfea320e69a) | `` python310Packages.itanium-demangler: remove whitespaces ``                     |
| [`3c603d0e`](https://github.com/NixOS/nixpkgs/commit/3c603d0e0b5b28f0d9c75d1ad011a302530351b2) | `` python310Packages.gdown: 4.6.2 -> 4.6.3 ``                                     |
| [`3c46639d`](https://github.com/NixOS/nixpkgs/commit/3c46639d257efdda8a5f13e2b1257e94be2a60f7) | `` sdlpop: Add changelog ``                                                       |
| [`553c376a`](https://github.com/NixOS/nixpkgs/commit/553c376a49c778b8fde42256cfd399d276c21295) | `` nixos/networkd-dispatcher: init ``                                             |
| [`ddb0eb52`](https://github.com/NixOS/nixpkgs/commit/ddb0eb521dc8ad4313af91a1a28c87a728e0a447) | `` networkd-dispatcher: init at 2.2.4 ``                                          |
| [`dbd2e23b`](https://github.com/NixOS/nixpkgs/commit/dbd2e23b4f0abdeb8f4824aed5ac7452ad6db265) | `` python310Packages.webauthn: 1.7.0 -> 1.7.2 ``                                  |
| [`e28ebd67`](https://github.com/NixOS/nixpkgs/commit/e28ebd6780f5f2b8b38aa8ef92c946b06a501e38) | `` gwc: Add changelog ``                                                          |
| [`d6865fa8`](https://github.com/NixOS/nixpkgs/commit/d6865fa8f5f4989b325a0d27e61df0d4f9f290b4) | `` python310Packages.rokuecp: 0.17.0 -> 0.17.1 ``                                 |
| [`41d114b2`](https://github.com/NixOS/nixpkgs/commit/41d114b234490b8c529d4895475eea53c8c4b726) | `` fulcio: 1.0.0 -> 1.1.0 ``                                                      |
| [`c7ba69b1`](https://github.com/NixOS/nixpkgs/commit/c7ba69b1f80dc0e8da82ba40eea95c78aa48d082) | `` xrootd: 5.5.2 -> 5.5.3 ``                                                      |
| [`4513fc69`](https://github.com/NixOS/nixpkgs/commit/4513fc6975776a0bbb40ba5b37831923bc140afa) | `` evscript: unstable-2021-06-16 -> unstable-2022-11-20 ``                        |
| [`6e9902c7`](https://github.com/NixOS/nixpkgs/commit/6e9902c7f6ef9af4434f01db2c05a6a3f488ce97) | `` apptainer: always specify either --with-suid or --without-suid build flag ``   |
| [`3a713975`](https://github.com/NixOS/nixpkgs/commit/3a71397570fb20f16c0263248d0eb2b1f9b308c5) | `` git-chglog: 0.15.2 -> 0.15.4 ``                                                |
| [`883a0d45`](https://github.com/NixOS/nixpkgs/commit/883a0d45a72fede827962ddfcb8c4d3b515d1db2) | `` syft: 0.71.0 -> 0.72.0 ``                                                      |
| [`eef34e34`](https://github.com/NixOS/nixpkgs/commit/eef34e3476311dffc13b79ed0d9b7867db222119) | `` temporal: 1.19.1 -> 1.20.0 ``                                                  |
| [`d8d60a3a`](https://github.com/NixOS/nixpkgs/commit/d8d60a3af15ae1a6eea129989daa2ecb8fe8d7ac) | `` vtm: 0.9.8t -> 0.9.8v ``                                                       |
| [`bab6f9f3`](https://github.com/NixOS/nixpkgs/commit/bab6f9f3a5e2efbb1783d7f415fdb168f505a4ee) | `` murex: 3.0.9310 -> 3.1.3100 ``                                                 |
| [`0d8f0e53`](https://github.com/NixOS/nixpkgs/commit/0d8f0e53877cf0eeacab6fc471f5339f8e44e593) | `` nip2: 8.7.1 -> 8.9.1 ``                                                        |
| [`17ce1cc3`](https://github.com/NixOS/nixpkgs/commit/17ce1cc30c87610472947859e769d11aa6b27188) | `` go-camo: 2.4.1 -> 2.4.2 ``                                                     |
| [`c1541800`](https://github.com/NixOS/nixpkgs/commit/c154180073790ce7ebadd4c1204b14d938ef43ef) | `` k3s: add ipset runtime dependency ``                                           |
| [`96e43af6`](https://github.com/NixOS/nixpkgs/commit/96e43af61a1d14c7ccaea49470bdfde1c64f4466) | `` example-robot-data: 4.0.4 -> 4.0.5 ``                                          |
| [`6bdbb479`](https://github.com/NixOS/nixpkgs/commit/6bdbb4797ee3fa4b46603afb95c8b92b26a24b9a) | `` tea: 0.9.0 -> 0.9.2 ``                                                         |
| [`03057aa1`](https://github.com/NixOS/nixpkgs/commit/03057aa1fd4762137877036e954e62b13c9fae76) | `` python310Packages.seaborn: fix sandboxless build (#216254) ``                  |
| [`3824ca44`](https://github.com/NixOS/nixpkgs/commit/3824ca44a6416817c7e72ea8672a42c971eb98be) | `` s2n-tls: 1.3.36 -> 1.3.37 ``                                                   |
| [`8a784555`](https://github.com/NixOS/nixpkgs/commit/8a78455528fcdd0e024175e60452222acb4cb4e8) | `` sarasa-gothic: 0.40.0 -> 0.40.1 ``                                             |
| [`1ed5cc0d`](https://github.com/NixOS/nixpkgs/commit/1ed5cc0d4856c192b29a4622fc53b1d225fc7414) | `` nanotts: fix dependency on alsa-plugins ``                                     |
| [`406e78e5`](https://github.com/NixOS/nixpkgs/commit/406e78e5ae3485245b437a41fd7c2923c17e8976) | `` terraform-providers.acme: 2.12.0 → 2.13.0 ``                                   |
| [`d976cb34`](https://github.com/NixOS/nixpkgs/commit/d976cb34a11e3111ecfbd36d768f22f4218f1323) | `` terraform-providers.bitbucket: 2.30.0 → 2.30.1 ``                              |
| [`ff1b6290`](https://github.com/NixOS/nixpkgs/commit/ff1b6290ab8db7e1941bdb782b7d4a492c3b81ca) | `` hyfetch: 1.4.6 -> 1.4.7 ``                                                     |
| [`b4716ea1`](https://github.com/NixOS/nixpkgs/commit/b4716ea17953b3e32ca431e79f752f9f02f08901) | `` gptcommit: init at 0.1.15 ``                                                   |
| [`d9c83706`](https://github.com/NixOS/nixpkgs/commit/d9c837063a0a5acf72aca17324067dd2a0cd04bb) | `` python310Packages.simber: 0.2.5 -> 0.2.6 ``                                    |