### PR TITLE
chore(flake/nixpkgs): `b69883fa` -> `d0d55259`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -198,11 +198,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676885936,
-        "narHash": "sha256-ZRKb6zBfTvdCOXI7nGC1L9UWSU5ay2ltxg+f5UIzBOU=",
+        "lastModified": 1676973346,
+        "narHash": "sha256-rft8oGMocTAhUVqG3LW6I8K/Fo9ICGmNjRqaWTJwav0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b69883faca9542d135fa6bab7928ff1b233c167f",
+        "rev": "d0d55259081f0b97c828f38559cad899d351cad1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`4c164bc4`](https://github.com/NixOS/nixpkgs/commit/4c164bc42d56b3932a2a6982c0e92921485fdc16) | `` keepassxc: fix test timeout ``                                                            |
| [`beddcca9`](https://github.com/NixOS/nixpkgs/commit/beddcca93f45929dfafb5891148937a7dbf1926d) | `` keepassxc: fix build on darwin ``                                                         |
| [`6f6d61df`](https://github.com/NixOS/nixpkgs/commit/6f6d61df2bb2a6667f8ec9c703f34bb3441a9b1a) | `` rabbitmq-server: 3.11.8 -> 3.11.9 ``                                                      |
| [`8ee504eb`](https://github.com/NixOS/nixpkgs/commit/8ee504eb7f7f2fcb08a4c8d8448a227911e9ad2f) | `` pythonPackages.lektor: add changelog to meta ``                                           |
| [`ec058932`](https://github.com/NixOS/nixpkgs/commit/ec0589328603824881ff25181ac749c35709d9b0) | `` python310Packages.azure-mgmt-containerregistry: adjust inputs ``                          |
| [`25aa98a6`](https://github.com/NixOS/nixpkgs/commit/25aa98a67a2a2c8d2cb13c50b62825dd0e2738bd) | `` python310Packages.azure-mgmt-containerregistry: disable on unsupported Python releases `` |
| [`c322b3ea`](https://github.com/NixOS/nixpkgs/commit/c322b3ea376d0c46014b87b20716134bc3845bc2) | `` python310Packages.insteon-frontend-home-assistant: 0.3.1 -> 0.3.2 ``                      |
| [`ad9c008f`](https://github.com/NixOS/nixpkgs/commit/ad9c008fd0d32d68b9fb7be05d2e566ccdf27b22) | `` ocamlPackages.sha: 1.15.2 → 1.15.4 ``                                                     |
| [`e0b99fe0`](https://github.com/NixOS/nixpkgs/commit/e0b99fe0fe8862bfbbcbe4c9dc013e46cdfecb38) | `` grails: 5.3.0 -> 5.3.2 ``                                                                 |
| [`765a1ab2`](https://github.com/NixOS/nixpkgs/commit/765a1ab24b170cbfa59330ae24a95dc1cf5b5871) | `` python310Packages.azure-mgmt-containerregistry: 10.0.0 -> 10.1.0 ``                       |
| [`7cd1e93a`](https://github.com/NixOS/nixpkgs/commit/7cd1e93a0b7579d3738b63d39813aa2f2279d1a9) | `` packwiz: unstable-2022-10-29 -> unstable-2023-02-13 ``                                    |
| [`e685e617`](https://github.com/NixOS/nixpkgs/commit/e685e617900306f5708b0e7ba901ea3ffc2dcaf5) | `` esbuild: 0.17.9 -> 0.17.10 ``                                                             |
| [`8e27bd25`](https://github.com/NixOS/nixpkgs/commit/8e27bd2543657905e33c36374a13e0657dd1e171) | `` esbuild: 0.17.8 -> 0.17.9 ``                                                              |
| [`2a54120d`](https://github.com/NixOS/nixpkgs/commit/2a54120d5a64afff854baeeb1db03e2200054c80) | `` go-camo: 2.4.2 -> 2.4.3 ``                                                                |
| [`6b9b4ff8`](https://github.com/NixOS/nixpkgs/commit/6b9b4ff80e75f2732fb959b00d9aed4cea6c8d16) | `` terraform-providers.stackpath: 1.4.0 → 1.5.0 ``                                           |
| [`05800f53`](https://github.com/NixOS/nixpkgs/commit/05800f53b6c6f86e0f78c50b411d73f7276bb86c) | `` terraform-providers.heroku: 5.1.10 → 5.1.11 ``                                            |
| [`871a81ce`](https://github.com/NixOS/nixpkgs/commit/871a81ce40a2f9923ec7baed4ba420eeabb6ef3e) | `` terraform-providers.cloudflare: 3.33.1 → 4.0.0 ``                                         |
| [`5045ec5e`](https://github.com/NixOS/nixpkgs/commit/5045ec5e82e6966b523fae69218e189f07a6bc8e) | `` ashuffle: 3.13.4 -> 3.13.6 ``                                                             |
| [`89c3b764`](https://github.com/NixOS/nixpkgs/commit/89c3b7644c02922821b100df6abf069b1851087f) | `` cozette: 1.19.0 -> 1.19.1 ``                                                              |
| [`5635c362`](https://github.com/NixOS/nixpkgs/commit/5635c362084ae0ace9687cb77585f6b419d06962) | `` pythonPackages.lektor: 3.4.0b2 -> 3.4.0b4 ``                                              |
| [`88edc0c8`](https://github.com/NixOS/nixpkgs/commit/88edc0c8601a132941e059af62d09dfc20b6fc10) | `` python310Packages.google-cloud-language: 2.8.1 -> 2.9.0 ``                                |
| [`a7f7de85`](https://github.com/NixOS/nixpkgs/commit/a7f7de856a96e8e6d99e83583a31753d721453d3) | `` pueue: 3.1.0 -> 3.1.1 ``                                                                  |
| [`7ccc6dd4`](https://github.com/NixOS/nixpkgs/commit/7ccc6dd47e68e628a12186f80679e20c5fbc217a) | `` cudatext-qt: 1.184.0 -> 1.185.0 ``                                                        |
| [`a4a9d07c`](https://github.com/NixOS/nixpkgs/commit/a4a9d07c547fb6a74ad5ea7abf1bf81933672884) | `` python310Packages.nose_progressive: Drop ``                                               |
| [`43c19a33`](https://github.com/NixOS/nixpkgs/commit/43c19a33e1db4eb47a001fa60009e0a0d7617fb5) | `` cve: 1.2.0 -> 1.2.1 ``                                                                    |
| [`e23e30c9`](https://github.com/NixOS/nixpkgs/commit/e23e30c9305b13a8f6389fc1dc6444e8a3503826) | `` python310Packages.boltons: 21.0.0 -> 23.0.0 ``                                            |
| [`adcb364c`](https://github.com/NixOS/nixpkgs/commit/adcb364cc59928a7640d7132eead185fa03de66f) | `` python310Packages.pyswitchbot: 0.37.1 -> 0.37.3 ``                                        |
| [`5e098670`](https://github.com/NixOS/nixpkgs/commit/5e0986701815779b1f81fdbdb12ebecd4ef6f017) | `` vimPlugins.vim-vue-plugin: init at 2023-02-02 ``                                          |
| [`fbfda26f`](https://github.com/NixOS/nixpkgs/commit/fbfda26f7fa8bf621e797003c03944cd7fbd14f6) | `` python310Packages.yalexs-ble: 2.0.1 -> 2.0.2 ``                                           |
| [`542393cc`](https://github.com/NixOS/nixpkgs/commit/542393ccd8f0d9dc592a47cd5c619fd503f0d6ba) | `` sagoin: 0.2.0 -> 0.2.1 ``                                                                 |
| [`18960858`](https://github.com/NixOS/nixpkgs/commit/18960858789d004b579d8eee7ba9feec0d76feb9) | `` python310Packages.sanic: unbreak on Darwin ``                                             |
| [`18080bbf`](https://github.com/NixOS/nixpkgs/commit/18080bbfd0de49796382fd1ce9a2e2c782314567) | `` python310Packages.aiocurrencylayer: 1.0.4 -> 1.0.5 ``                                     |
| [`4e0aa987`](https://github.com/NixOS/nixpkgs/commit/4e0aa987626cff278ce995363b6385bfef9c7678) | `` python310Packages.aiocurrencylayer: add changelog to meta ``                              |
| [`ea6d656d`](https://github.com/NixOS/nixpkgs/commit/ea6d656dd9db3eb6b0408dd23f43c4f7c8a49641) | `` github-runner: 2.302.0 -> 2.302.1 (#217350) ``                                            |
| [`4375ddbf`](https://github.com/NixOS/nixpkgs/commit/4375ddbf1fda94712fc6075769aaec66719547ae) | `` cppcheck: 2.9.3 -> 2.10 ``                                                                |
| [`bfb63ef4`](https://github.com/NixOS/nixpkgs/commit/bfb63ef47f5a55939cf42d4e34e857f42ee9451a) | `` vimPlugins.go-nvim: init at 2023-02-19 ``                                                 |
| [`dbd1ee56`](https://github.com/NixOS/nixpkgs/commit/dbd1ee56b1ad4219d9c2f5568bbac2e57b25f109) | `` broot: 1.20.1 -> 1.20.2 ``                                                                |
| [`4ca106a6`](https://github.com/NixOS/nixpkgs/commit/4ca106a6a033ad7acb13c27bf53b5476e8a443fe) | `` tor-browser-bundle-bin: 11.5.8 -> 12.0.3 ``                                               |
| [`7a76e0a1`](https://github.com/NixOS/nixpkgs/commit/7a76e0a1a83da876114841189f22fd29a72dec41) | `` datree: 1.8.21 -> 1.8.24 ``                                                               |
| [`b5c3d554`](https://github.com/NixOS/nixpkgs/commit/b5c3d554f58bb07964870e414b5eee6c9eae7d1a) | `` python310Packages.yalexs: remove asynctest ``                                             |
| [`a7d95c38`](https://github.com/NixOS/nixpkgs/commit/a7d95c3874d3dd7dc773cdac9a61d2ff1106e250) | `` python310Packages.yalexs: update disabled ``                                              |
| [`c8d94feb`](https://github.com/NixOS/nixpkgs/commit/c8d94febd7f6869eae615afe4fea077d2fbf206c) | `` python310Packages.yalexs: add changelog to meta ``                                        |
| [`82b31b53`](https://github.com/NixOS/nixpkgs/commit/82b31b530d24995c823338a8799edadbccf7bc8c) | `` foxitreader: drop ``                                                                      |
| [`d83759c1`](https://github.com/NixOS/nixpkgs/commit/d83759c1af2448a927b45660f02f23452597adf3) | `` python3Packages.screed: 1.1.1 -> 1.1.2 ``                                                 |
| [`a3c9f191`](https://github.com/NixOS/nixpkgs/commit/a3c9f191bf4e951f65d3dddfa5c353eb5efb8dce) | `` python310Packages.yalexs: 1.2.6 -> 1.2.8 ``                                               |
| [`143f3098`](https://github.com/NixOS/nixpkgs/commit/143f30987c07bedd593fa2de846b1ebb5d98980c) | `` polypane: 10.0.1 -> 13.0.2 ``                                                             |
| [`f98462a2`](https://github.com/NixOS/nixpkgs/commit/f98462a27d097f1b8397ed07ca545b26009bf6c9) | `` nixos/tests/home-assistant: Resolve deprecation warning ``                                |
| [`9bf8744a`](https://github.com/NixOS/nixpkgs/commit/9bf8744a732fad91482a66c28c5462a683be727c) | `` nixos/tests/home-assistant: Check dependencies arrive in the PYTHONPATH ``                |
| [`e01ccd62`](https://github.com/NixOS/nixpkgs/commit/e01ccd6245fe1fe34aa49aa48fe3d53e3b013c20) | `` home-assistant: Inject extra dependencies through PYTHONPATH ``                           |
| [`3fa7dc20`](https://github.com/NixOS/nixpkgs/commit/3fa7dc206a54265f04fc2ea2afd1cf1cdb650c83) | `` home-assistant: Stop exposing component & package files ``                                |
| [`ba3f159c`](https://github.com/NixOS/nixpkgs/commit/ba3f159cc8261160511b0c7f42446b7d3a66de1b) | `` nixos/tests/home-assistant: Overhaul and refactor ``                                      |
| [`e69c0d69`](https://github.com/NixOS/nixpkgs/commit/e69c0d6910fb3299095914f54843a1083f61c0bf) | ``  cloudlog: 2.3.3. -> 2.4 ``                                                               |
| [`eaf54489`](https://github.com/NixOS/nixpkgs/commit/eaf54489440729d4a84ee684898bbf059e9a7f1c) | ``  cloudlog: add passthru update script ``                                                  |
| [`20c135b1`](https://github.com/NixOS/nixpkgs/commit/20c135b191fd84f556cc5eb37b8d9d683a580b1e) | `` docs: borg expects --rsh, not -rsh ``                                                     |
| [`5455a9de`](https://github.com/NixOS/nixpkgs/commit/5455a9deb2d650f6d1d25c6095c30e74c06fdaa8) | `` golangci-lint: 1.51.1 -> 1.51.2 ``                                                        |
| [`075bf797`](https://github.com/NixOS/nixpkgs/commit/075bf7974485c26d66406c2a790cc4f97a79b4bb) | `` zine: 0.10.1 -> 0.11.0 ``                                                                 |
| [`859212e3`](https://github.com/NixOS/nixpkgs/commit/859212e303874ebbf0fafae1087c57c775daed9a) | `` czkawka: add meta.changelog, use hash ``                                                  |
| [`2167e43a`](https://github.com/NixOS/nixpkgs/commit/2167e43ab85037c587ddfa9b1a0823a8e849af80) | `` czkawka: 5.0.2 -> 5.1.0 ``                                                                |
| [`433e205e`](https://github.com/NixOS/nixpkgs/commit/433e205e25ae5d8e9e2dfa4f05c31faac67c3847) | `` firefox-devedition-bin-unwrapped: 110.0b9 -> 111.0b3 ``                                   |
| [`cb04c509`](https://github.com/NixOS/nixpkgs/commit/cb04c509120050091f85e0d8cd0179f1bd7f42db) | `` gitea: 1.18.3 -> 1.18.4 ``                                                                |
| [`a43dc018`](https://github.com/NixOS/nixpkgs/commit/a43dc01871b7e90d12113ec79a7b55d9f3b259ce) | `` clash-meta: init at 1.14.2 ``                                                             |
| [`e83babd4`](https://github.com/NixOS/nixpkgs/commit/e83babd4939e26279da58cb9e448848bec5de8f7) | `` nixos/tests/systemd-credentials-tpm2: Add tests for systemd credentials ``                |
| [`1fa1b58c`](https://github.com/NixOS/nixpkgs/commit/1fa1b58c2521cc8aa2e4eca41e1422df4724e199) | `` nixos/console,nixos/systemd-initrd: remove now-unnecessary wrapped bin inclusions ``      |
| [`d01bc6f9`](https://github.com/NixOS/nixpkgs/commit/d01bc6f9cb7b0b1851fdd80ab45eaccc07e9730d) | `` make-initrd-ng: document wrapped file behavior ``                                         |
| [`4df8f9a2`](https://github.com/NixOS/nixpkgs/commit/4df8f9a2f82c85a8c2ef64362cef5a3cec695dbb) | `` make-initrd-ng: support wrapped executables ``                                            |
| [`c80bfb40`](https://github.com/NixOS/nixpkgs/commit/c80bfb405221c7658a598744e617c762c7ab1972) | `` python310Packages.aiohomekit: 2.5.0 -> 2.6.1 ``                                           |
| [`5c458b42`](https://github.com/NixOS/nixpkgs/commit/5c458b422bfd4782cbead4470abcd2473414bd09) | `` python310Packages.pyunifiprotect: 4.6.2 -> 4.7.0 ``                                       |
| [`17a476a3`](https://github.com/NixOS/nixpkgs/commit/17a476a3a64acf23565af7af2f08bac56df2ab1e) | `` python310Packages.yfinance: 0.2.11 -> 0.2.12 ``                                           |
| [`3092bd8a`](https://github.com/NixOS/nixpkgs/commit/3092bd8a790e4b3950f70594d81dd93903a328e6) | `` python310Packages.lupupy: 0.2.8 -> 0.3.0 ``                                               |
| [`8fab0b16`](https://github.com/NixOS/nixpkgs/commit/8fab0b16e2b2e37811188fa5d558b88128723849) | `` domoticz: Add changelog ``                                                                |
| [`522512e7`](https://github.com/NixOS/nixpkgs/commit/522512e7b46054645bba9deefb90547d47dbd149) | `` linux: init 6.2 ``                                                                        |
| [`e4b42071`](https://github.com/NixOS/nixpkgs/commit/e4b420716f8fd98dd54867662fb30872a002106b) | `` python310Packages.quantities: add nativeBuildInputs ``                                    |
| [`2e75e17a`](https://github.com/NixOS/nixpkgs/commit/2e75e17a54dfcad2c23a0e01c0aa06f55fdf5bb0) | `` python311Packages.neo: 0.11.1 -> 0.12.0 ``                                                |
| [`bd189f47`](https://github.com/NixOS/nixpkgs/commit/bd189f478f4fa419611c90f88d494f0a85e37f25) | `` python310Packages.neo: add changelog to meta ``                                           |
| [`dec690df`](https://github.com/NixOS/nixpkgs/commit/dec690df7fa58c88e3bd28d10b51c1aee4795c32) | `` python310Packages.quantities: disable on unsupported Python releases ``                   |
| [`38f63762`](https://github.com/NixOS/nixpkgs/commit/38f637624366ac5ed856eb36eb9c524aa615f03a) | `` python310Packages.quantities: add changelog to meta ``                                    |
| [`72a48aaa`](https://github.com/NixOS/nixpkgs/commit/72a48aaacd4523fd7d5829cc549f6add32ec6cf6) | `` v2ray-geoip: 202302160443 -> 202302200325 ``                                              |
| [`65a2ffba`](https://github.com/NixOS/nixpkgs/commit/65a2ffba207a43c13ab8eff94986199bb90048f4) | `` ligo: 0.59.0 -> 0.60.0 ``                                                                 |
| [`430385ca`](https://github.com/NixOS/nixpkgs/commit/430385cad56869d1163bd4020dc5a59a4f633aec) | `` ocamlPackages.simple-diff: init at 0.3 ``                                                 |
| [`201a78e5`](https://github.com/NixOS/nixpkgs/commit/201a78e51cc1242343cb9dba05b4481fff60fb42) | `` python310Packages.entrance: 1.1.17 -> 1.1.20 ``                                           |
| [`46d790b4`](https://github.com/NixOS/nixpkgs/commit/46d790b44bb41ce7379e49d19aec94f43222d024) | `` python310Packages.quantities: 0.13.0 -> 0.14.1 ``                                         |
| [`5e6a7aab`](https://github.com/NixOS/nixpkgs/commit/5e6a7aab54dc26cfc8f2c14867f04972eb3b6fe5) | `` .editorconfig: exempt test OVA files packaged with ovftool ``                             |
| [`b11de88b`](https://github.com/NixOS/nixpkgs/commit/b11de88b221ed5fce626b0ff0562635273894fec) | `` ovftool: 4.4.1-16812187 -> 4.5.0-20459872 ``                                              |
| [`51094d7c`](https://github.com/NixOS/nixpkgs/commit/51094d7cf348e96852cd0c88c1a68918f8f9d261) | `` nvc: 1.8.1 -> 1.8.2 ``                                                                    |
| [`93218068`](https://github.com/NixOS/nixpkgs/commit/93218068b2620cee8afcdb28bdf05dfa5a03c1cd) | `` wiki-js: 2.5.296 -> 2.5.297 ``                                                            |
| [`a3a92e39`](https://github.com/NixOS/nixpkgs/commit/a3a92e390132607721ecb77250488bbc16ad1b49) | `` python310Packages.ipydatawidgets: 4.3.2 -> 4.3.3 ``                                       |
| [`68787dcc`](https://github.com/NixOS/nixpkgs/commit/68787dccb0e068e617a063cb939edda060391d58) | `` python310Packages.python-cinderclient: 9.2.0 -> 9.3.0 ``                                  |
| [`1fe9b33a`](https://github.com/NixOS/nixpkgs/commit/1fe9b33a8fefca1b222281c85393ea05d8eb48e8) | `` python310Packages.flake8-bugbear: 23.1.20 -> 23.2.13 ``                                   |
| [`f70068f8`](https://github.com/NixOS/nixpkgs/commit/f70068f86dfb78408ceeff3d2595dbfcddba2643) | `` python310Packages.python-novaclient: 18.2.0 -> 18.3.0 ``                                  |
| [`50bfecb5`](https://github.com/NixOS/nixpkgs/commit/50bfecb5bc311222c2e7acdbeb94a85710755d1a) | `` streamlink: 5.2.1 -> 5.3.0 ``                                                             |
| [`10e3e7cc`](https://github.com/NixOS/nixpkgs/commit/10e3e7ccb93de15a9f5ea9851a04b45d5091b82c) | `` python310Packages.azure-mgmt-kusto: 3.0.0 -> 3.1.0 ``                                     |
| [`2cf29e46`](https://github.com/NixOS/nixpkgs/commit/2cf29e463524e46d0aa34f3aac26bd628ef1166f) | `` mfoc-hardnested: init at unstable-2021-08-14 ``                                           |
| [`17d9434c`](https://github.com/NixOS/nixpkgs/commit/17d9434c6f7a631b0a707e75af43199068c2d1d8) | `` python310Packages.restview: add changelog to meta ``                                      |
| [`bfac2d00`](https://github.com/NixOS/nixpkgs/commit/bfac2d0034f395a8dbcd7eabe633e68757c3f1c9) | `` treewide:replace http by https when https is a permanent redirection ``                   |
| [`d6dd12a2`](https://github.com/NixOS/nixpkgs/commit/d6dd12a2c95d2865e78e34ec447400b55abc9407) | `` python311Packages.gradient_statsd: add missing inputs ``                                  |
| [`cfd6efaf`](https://github.com/NixOS/nixpkgs/commit/cfd6efafc8de39f37cee550f086bc99af76d0bb8) | `` python310Packages.pyomo: 6.4.4 -> 6.5.0 ``                                                |
| [`d4f730ee`](https://github.com/NixOS/nixpkgs/commit/d4f730eea658d6aae88e6451d380bbd910b36ee3) | `` python311Packages.eliot: switch to pytestCheckHook ``                                     |
| [`fdfb7f36`](https://github.com/NixOS/nixpkgs/commit/fdfb7f360706f652e1c48433acb1ddfc12ddbaf2) | `` python310Packages.dinghy: add changelog to meta ``                                        |
| [`f1e1feed`](https://github.com/NixOS/nixpkgs/commit/f1e1feedac3673a27a3893693bf76f2d613931ea) | `` python311Packages.glom: disable failing tests on Python 3.11 ``                           |
| [`13b94f18`](https://github.com/NixOS/nixpkgs/commit/13b94f186cbe94b43793a14b7c0d681f928a0efe) | `` keynav: update ``                                                                         |
| [`d7bf4cb9`](https://github.com/NixOS/nixpkgs/commit/d7bf4cb9020d0c369fc67f559b5a31bae0619172) | `` python311Packages.glom: add changelog to meta ``                                          |
| [`145d1f37`](https://github.com/NixOS/nixpkgs/commit/145d1f379db37559a09870fc1d28537dc0651062) | `` python311Packages.datadog: disable failing tests on Python 3.11 ``                        |
| [`3a574538`](https://github.com/NixOS/nixpkgs/commit/3a574538ee8e600f2bd3498af6cfa883af304894) | `` caddy: add shell completions for fish ``                                                  |
| [`0f701851`](https://github.com/NixOS/nixpkgs/commit/0f701851358739d8703ba4dcc29b6ef339f24203) | `` caddy: install man pages ``                                                               |
| [`734f3226`](https://github.com/NixOS/nixpkgs/commit/734f322686694ee0a43ece28954394c3b355ed98) | `` python311Packages.datadog: disable on unsupported Python releases ``                      |
| [`d575718c`](https://github.com/NixOS/nixpkgs/commit/d575718cc35456aab00fd6ea25c5f6a1038f9c2f) | `` python311Packages.datadog: add changelog to meta ``                                       |
| [`fff94b11`](https://github.com/NixOS/nixpkgs/commit/fff94b111d928c0f03f6c4a5da0a6ebeada37e05) | `` python311Packages.boltons: disable failing test on Python 3.11 ``                         |
| [`0e92f9eb`](https://github.com/NixOS/nixpkgs/commit/0e92f9ebceddcea2f9243cd17abc46ac99745c57) | `` python311Packages.boltons: add changelog to meta ``                                       |
| [`d076d05d`](https://github.com/NixOS/nixpkgs/commit/d076d05deb328757db814b421ce294b405577cf5) | `` icinga2: 2.13.6 -> 2.13.7 ``                                                              |
| [`7ea75aa6`](https://github.com/NixOS/nixpkgs/commit/7ea75aa672527ba9f4623955a0d1d4fccf759de3) | `` diswall: 0.3.0 -> 0.3.1 ``                                                                |
| [`8239d1fd`](https://github.com/NixOS/nixpkgs/commit/8239d1fde5407c7530d95c22c8206f5b552248d1) | `` domoticz: 2022.2 -> 2023.1 ``                                                             |
| [`e9f759c8`](https://github.com/NixOS/nixpkgs/commit/e9f759c8257680e2430481cb2cce83b5a6d5f315) | `` element-{web,desktop}: 1.11.22 -> 1.11.23 ``                                              |
| [`1e75de33`](https://github.com/NixOS/nixpkgs/commit/1e75de336c3eca39b23d55ca696528c0c0a16a37) | `` nixos/mbpfan: add aggressive option ``                                                    |
| [`e8f21cba`](https://github.com/NixOS/nixpkgs/commit/e8f21cbac9ac2ab0020c7a51564f0f5b556f73d3) | `` cinnamon.warpinator: 1.4.4 -> 1.4.5 ``                                                    |
| [`4813c90d`](https://github.com/NixOS/nixpkgs/commit/4813c90dcf8398fcb38ba40e8ee640205b3ec928) | `` nchat: init at 3.17 ``                                                                    |
| [`0de3431e`](https://github.com/NixOS/nixpkgs/commit/0de3431e303e372e509f37479e856c23de6ecc18) | `` tests/miriway: Explicitly enable X11 for XWayland testing ``                              |
| [`b2a74bc0`](https://github.com/NixOS/nixpkgs/commit/b2a74bc0ab17f32532318e80b32e0759583a287a) | `` tests/miriway: Refer to upstream issue about keyboard problem ``                          |
| [`4f3353c7`](https://github.com/NixOS/nixpkgs/commit/4f3353c775c40dd7fbfb6718ef0175c13d731227) | `` miriway: unstable-2022-12-18 -> unstable-2023-02-18 ``                                    |
| [`482dfddc`](https://github.com/NixOS/nixpkgs/commit/482dfddc233f5aecefbdb8f5d50cfc3f5fbdae36) | `` thrift: 0.17.0 -> 0.18.0 ``                                                               |
| [`7df36e5a`](https://github.com/NixOS/nixpkgs/commit/7df36e5addf6b20df1ba4fc0fa778457576f4c27) | `` openssh_hpn: 9.1p1 -> 9.2p1 ``                                                            |
| [`64076a98`](https://github.com/NixOS/nixpkgs/commit/64076a9875f7802cff49083e2f5e5779268ad5e0) | `` directx-shader-compiler: build with gcc11 for i686 ``                                     |
| [`5e0646d8`](https://github.com/NixOS/nixpkgs/commit/5e0646d8dbf265677b221715d40152d39e889246) | `` squawk: 0.20.0 -> 0.21.0 ``                                                               |
| [`5a2d66c8`](https://github.com/NixOS/nixpkgs/commit/5a2d66c88322d07e592751172b798267e4e266e6) | `` deepin-wallpapers: init at 1.7.10 ``                                                      |
| [`9f79456f`](https://github.com/NixOS/nixpkgs/commit/9f79456f9078a0c6401404888efa972e15408de7) | `` vscode-extensions.matthewpi.caddyfile-support: init at 0.2.4 ``                           |
| [`d37bd519`](https://github.com/NixOS/nixpkgs/commit/d37bd519ba0dffd075dfd4b67b5caec0d020ef0f) | `` gavin-bc: enable extra options ``                                                         |
| [`98157f13`](https://github.com/NixOS/nixpkgs/commit/98157f131dac8d56997673abd69d9f154d35e00e) | `` gavin-bc: mark as broken on Darwin ``                                                     |
| [`024cab59`](https://github.com/NixOS/nixpkgs/commit/024cab5905e49bb16bbdeae315580e920e726c30) | `` gavin-bc: init at 6.2.4 ``                                                                |
| [`f445f928`](https://github.com/NixOS/nixpkgs/commit/f445f928f4edd24ceffab951ba013b66e7d7ad23) | `` 2048-cli: 0.9.1 -> unstable-2019-12-10 ``                                                 |
| [`93aba2c9`](https://github.com/NixOS/nixpkgs/commit/93aba2c96d34e84e543ed608b3e1b7322a4bc783) | `` 2048-cli: init at 0.9.1 ``                                                                |
| [`9fc6149d`](https://github.com/NixOS/nixpkgs/commit/9fc6149defc78ed3b459194b9acb7d53ace95aa3) | `` python310Packages.django_4: 4.1.6 -> 4.1.7 ``                                             |
| [`c8d7452c`](https://github.com/NixOS/nixpkgs/commit/c8d7452cedaca6f50e2dd846ac6d41ac8ad268f8) | `` python310Packages.pytest-forked: 1.4.0 -> 1.6.0 ``                                        |
| [`48c2d328`](https://github.com/NixOS/nixpkgs/commit/48c2d3284a166b3b852a4398a177fe3075cb3902) | `` mailman: 3.3.5 -> 3.3.8 supports latest sqlalchemy ``                                     |
| [`0d41f3a1`](https://github.com/NixOS/nixpkgs/commit/0d41f3a17430627960ce0b65ad937cd5eb00b55e) | `` joplin-desktop: 2.9.17 -> 2.10.4 ``                                                       |
| [`ca6aa073`](https://github.com/NixOS/nixpkgs/commit/ca6aa0730465ad871a2abc3bf696a01893fc62fc) | `` discourse: Document how to update ``                                                      |
| [`5757259e`](https://github.com/NixOS/nixpkgs/commit/5757259eeeee5b767081bfbad66ad627cb261ef8) | `` discourse.tests: nodes.discourse.config -> nodes.discourse ``                             |
| [`0dcc8c9a`](https://github.com/NixOS/nixpkgs/commit/0dcc8c9adb13d4a73e90be4d9ee16b6e0dd308ca) | `` discourse: Update plugins ``                                                              |
| [`8fb5bab7`](https://github.com/NixOS/nixpkgs/commit/8fb5bab784b274d37a11668b6b85c756ab044ef1) | `` discourse: 2.9.0.beta14 -> 3.1.0.beta2 ``                                                 |
| [`aef5ef01`](https://github.com/NixOS/nixpkgs/commit/aef5ef01089eb39c4abea5d1cf05866a57cc444a) | `` discourse: Reformat function arguments ``                                                 |
| [`9b31147b`](https://github.com/NixOS/nixpkgs/commit/9b31147be92551e14c3b906f45096d6c7961e6ff) | `` nixos/tests/systemd-initrd-vconsole: init new test for console.earlySetup ``              |
| [`3cb38595`](https://github.com/NixOS/nixpkgs/commit/3cb385953bcdd0dc8676efd5dd28c520457ca549) | `` mimir: add package override ``                                                            |
| [`2f6d2e99`](https://github.com/NixOS/nixpkgs/commit/2f6d2e99866cb816f2b401596996021d20048bf9) | `` musikcube: order dependencies A-Z ``                                                      |
| [`4dbac40f`](https://github.com/NixOS/nixpkgs/commit/4dbac40f65f70f67bbe37346febfcb430e652098) | `` musikcube: activate portaudio, pipewire, sndio, core audio plugins ``                     |