### PR TITLE
chore(flake/home-manager): `5e889b38` -> `564b82b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1676933022,
-        "narHash": "sha256-gLghsEHOy2W2ZmSwqNOyj2mSHe9SMpdcbqnoySlZnmY=",
+        "lastModified": 1677013990,
+        "narHash": "sha256-HwAnE5MHsyLiRJp50KfDFPiiOZXI0Ts8hXpIh6yBilE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5e889b385c43a8a72ada5ebc4888bbebb129b438",
+        "rev": "564b82b3542026e7fb5d0da16c56ae3e40e5c9dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`564b82b3`](https://github.com/nix-community/home-manager/commit/564b82b3542026e7fb5d0da16c56ae3e40e5c9dd) | `` firefox: fix search options without a default engine `` |
| [`c7c69ec4`](https://github.com/nix-community/home-manager/commit/c7c69ec40543d5c088abf0af816aff7b738ccaa2) | `` launchd: fix example of StartCalendarInterval ``        |