### PR TITLE
chore(flake/pre-commit-hooks): `c9495f01` -> `2bd861ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -243,11 +243,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1676879534,
-        "narHash": "sha256-HU4RXcwsAX1u7AUbGOBDxkYQkeODcn+HZjXqKa1y/hk=",
+        "lastModified": 1677160285,
+        "narHash": "sha256-tBzpCjMP+P3Y3nKLYvdBkXBg3KvTMo3gvi8tLQaqXVY=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "c9495f017f67a11e9c9909b032dc7762dfc853cf",
+        "rev": "2bd861ab81469428d9c823ef72c4bb08372dd2c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                  |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
| [`f15232b7`](https://github.com/cachix/pre-commit-hooks.nix/commit/f15232b739b4f9c684991f1a50aef10e5d93fa3b) | `` options: add fail_fast and require_serial ``                          |
| [`ca42ec27`](https://github.com/cachix/pre-commit-hooks.nix/commit/ca42ec27cd5085063e712fc087730d35e60b1d5a) | `` [fix] do not try to access the internet when running cargo clippy ``  |
| [`d71e3d75`](https://github.com/cachix/pre-commit-hooks.nix/commit/d71e3d75ec0cc37d180238bfddd79b79ef02f177) | `` [feat] change usage of direnv to using nix-direnv instead of lorri `` |