### PR TITLE
chore(flake/home-manager): `693d76ee` -> `bf76afbb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677400245,
-        "narHash": "sha256-+/oDZltWUhYFYcIRjH0F5lSNWcBj+4o5kzmDSheiLRw=",
+        "lastModified": 1677437727,
+        "narHash": "sha256-1BoofKqPT08sLCtm2hzABocYrSwkc8GtmeDuvrIXdjc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "693d76eeb84124cc3110793ff127aeab3832f95c",
+        "rev": "bf76afbb06b77237507b5279d0d555e05b5cc7f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`bf76afbb`](https://github.com/nix-community/home-manager/commit/bf76afbb06b77237507b5279d0d555e05b5cc7f7) | `` Set the SHELL environment variable for keychain in .xsession (#3695) `` |
| [`fc3432ba`](https://github.com/nix-community/home-manager/commit/fc3432bac27d0dd3ffd8625d2724c41f86b8ad10) | `` home-manager: make `--version` report 23.05-pre ``                      |
| [`d68cd7f7`](https://github.com/nix-community/home-manager/commit/d68cd7f7df34331b46ac8a9bca79aa13117b4bfb) | `` flake: avoid recursive set ``                                           |
| [`7b6e5071`](https://github.com/nix-community/home-manager/commit/7b6e5071518c726b9e9371bbfc8bb9beb81f50b9) | `` docs: slight improvement of Flake documentation ``                      |