### PR TITLE
chore(flake/nixpkgs): `b1f87ca1` -> `7f5639fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -198,11 +198,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677342105,
-        "narHash": "sha256-kv1fpkfCJGb0M+LZaCHFUuIS9kRIwyVgupHu86Y28nc=",
+        "lastModified": 1677407201,
+        "narHash": "sha256-3blwdI9o1BAprkvlByHvtEm5HAIRn/XPjtcfiunpY7s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b1f87ca164a9684404c8829b851c3586c4d9f089",
+        "rev": "7f5639fa3b68054ca0b062866dc62b22c3f11505",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`7f5639fa`](https://github.com/NixOS/nixpkgs/commit/7f5639fa3b68054ca0b062866dc62b22c3f11505) | `` shell-genie: init at unstable-2023-01-27 ``                                                 |
| [`1af0d67e`](https://github.com/NixOS/nixpkgs/commit/1af0d67ebe17baaa14029379e430f21a3507a53b) | `` haskellPackages.haskell-gi: 0.26.2 -> 0.26.3 (hacky) ``                                     |
| [`f49ebf25`](https://github.com/NixOS/nixpkgs/commit/f49ebf25d053f1adfb500e745aded05d1e1ed7dc) | `` python3.pkgs.moku: Remove ``                                                                |
| [`9d9ea518`](https://github.com/NixOS/nixpkgs/commit/9d9ea5188bc8de19488c8173801894acadb7f654) | `` glasgow: move out of python3Packages ``                                                     |
| [`c27a1a10`](https://github.com/NixOS/nixpkgs/commit/c27a1a105e785a208b797fd4befe7d8a5291fd57) | `` pika-backup: 0.4.2 -> 0.5.2 ``                                                              |
| [`271bca87`](https://github.com/NixOS/nixpkgs/commit/271bca8765c3c0b4d5f52ab434691fd025b05193) | `` numberstation: 1.2.0 -> 1.3.0 ``                                                            |
| [`8872f527`](https://github.com/NixOS/nixpkgs/commit/8872f527328e4e347ac031721752a361acc9c92a) | `` qdrant: service module init ``                                                              |
| [`3d0de0e8`](https://github.com/NixOS/nixpkgs/commit/3d0de0e8c81d097c7bed0e482f47e24089df8ff9) | `` gcc12: fix building foreign toolchain on aarch64-darwin ``                                  |
| [`6fcd1dcb`](https://github.com/NixOS/nixpkgs/commit/6fcd1dcb0bdd12676fae025f5f2a5f56cf363968) | `` rustPlatform.importCargoLock: passthru lockFile ``                                          |
| [`115e3413`](https://github.com/NixOS/nixpkgs/commit/115e3413e1ffb822d490ed11fa0d36d5f01cc268) | `` rustPlatform.importCargoLock: add support for v1 lock files ``                              |
| [`9952d6bc`](https://github.com/NixOS/nixpkgs/commit/9952d6bc395f5841262b006fbace8dd7e143b634) | `` terraform-providers.bitbucket: 2.30.1 → 2.30.2 ``                                           |
| [`e8f54cbb`](https://github.com/NixOS/nixpkgs/commit/e8f54cbb3df54c19def0204063b197e3311e80b5) | `` rocfft: 5.4.2 -> 5.4.3 ``                                                                   |
| [`e3f99213`](https://github.com/NixOS/nixpkgs/commit/e3f9921357f83dbf45934d1e72e89b928544a4be) | `` tdesktop: 4.6.3 -> 4.6.5 ``                                                                 |
| [`9769e902`](https://github.com/NixOS/nixpkgs/commit/9769e9023340c673d9c15f91efa89f0787b9a564) | `` lib/options: Add more options to mkPackageOption ``                                         |
| [`7118df46`](https://github.com/NixOS/nixpkgs/commit/7118df46c4a1300537398f52422687d121e58a24) | `` aws-sso-creds: 1.4.0 -> 1.4.1 ``                                                            |
| [`8e822add`](https://github.com/NixOS/nixpkgs/commit/8e822add5bb87567686bf77e61f3c025681accfa) | `` libdeltachat: 1.109.0 -> 1.110.0 ``                                                         |
| [`7ed285ec`](https://github.com/NixOS/nixpkgs/commit/7ed285ecc1fc4a5dc3e57090f2bfe961d8155401) | `` eidolon: replace patch with Cargo.lock ``                                                   |
| [`daec1281`](https://github.com/NixOS/nixpkgs/commit/daec12817710f8b5e45ad0832586d46c3379df17) | `` libgpiod: 1.6.3 -> 1.6.4 ``                                                                 |
| [`c2ecfe9f`](https://github.com/NixOS/nixpkgs/commit/c2ecfe9f913212d28a66fc279319547c5d81c153) | `` libjcat: 0.1.12 -> 0.1.13 ``                                                                |
| [`36a264c8`](https://github.com/NixOS/nixpkgs/commit/36a264c83ac6b90fe4c9eff317dc3001d0de7e5f) | `` polypane: 13.0.2 -> 13.0.3 ``                                                               |
| [`dba8d711`](https://github.com/NixOS/nixpkgs/commit/dba8d7112806dc1c875fa1aa17c583e3bd707845) | `` codevis: 0.5.1 -> 0.6.1 ``                                                                  |
| [`54192039`](https://github.com/NixOS/nixpkgs/commit/54192039a9431b5fd5c309f460f7b2125c116e6c) | `` rocprim: 5.4.2 -> 5.4.3 ``                                                                  |
| [`82d225e0`](https://github.com/NixOS/nixpkgs/commit/82d225e0d4cb2aba05f2f8e9ccd29772d72ececa) | `` lib.maintainers.qyliss.matrix: add ``                                                       |
| [`8eae3dd5`](https://github.com/NixOS/nixpkgs/commit/8eae3dd52f05239feb6d2cf7cf1b0db2ec3ead2b) | `` gitleaks: 8.15.3 -> 8.15.4 ``                                                               |
| [`b8e7ec9c`](https://github.com/NixOS/nixpkgs/commit/b8e7ec9cbaa1f428f9beea25e7256bfa348ab01f) | `` iptsd: 1.1.0 -> 1.1.1 ``                                                                    |
| [`af3e0638`](https://github.com/NixOS/nixpkgs/commit/af3e06387fe62960fec7902b2946fb0d9169ca42) | `` cpm-cmake: 0.37.0 -> 0.38.0 ``                                                              |
| [`cea40991`](https://github.com/NixOS/nixpkgs/commit/cea4099164c7141f1fad1543b124d9e8f14e9de5) | `` numix-icon-theme-circle: 23.02.16 -> 23.02.25 ``                                            |
| [`e9f5466e`](https://github.com/NixOS/nixpkgs/commit/e9f5466e3203b030b1bab1316ca1935ce6bedbad) | `` python310Packages.total-connect-client: 2023.1 -> 2023.2 ``                                 |
| [`2d142a6c`](https://github.com/NixOS/nixpkgs/commit/2d142a6cef260566afaec78adfcc658237f13344) | `` python310Packages.aiosomecomfort: 0.0.8 -> 0.0.10 ``                                        |
| [`01ab6415`](https://github.com/NixOS/nixpkgs/commit/01ab64154e5a1be01bdd0206d0d8de15d71cb12b) | `` prometheus-redis-exporter: 1.46.0 -> 1.47.0 ``                                              |
| [`79768df6`](https://github.com/NixOS/nixpkgs/commit/79768df602978e03a77a13a52bd122f37d33f484) | `` linux-doc: remove Python overrides ``                                                       |
| [`92014caf`](https://github.com/NixOS/nixpkgs/commit/92014cafa7e6031e6517555d20b6f4381840e4ce) | `` python310Packages.evtx: add changelog to meta ``                                            |
| [`1b26b4fa`](https://github.com/NixOS/nixpkgs/commit/1b26b4fab5896db76ac6c62ac10d2dd8cb56774d) | `` python310Packages.evtx: 0.8.1 -> 0.8.2 ``                                                   |
| [`4a92f37a`](https://github.com/NixOS/nixpkgs/commit/4a92f37a14a040a150c25e874384645c9ea67f13) | `` checkSSLCert: 2.58.0 -> 2.60.0 ``                                                           |
| [`f69f7b85`](https://github.com/NixOS/nixpkgs/commit/f69f7b85b085980f8c6b54b6937158dd3e1ae7f2) | `` watchmate: 0.4.1 -> 0.4.2 ``                                                                |
| [`f80a7ac5`](https://github.com/NixOS/nixpkgs/commit/f80a7ac5d079a7c2be57945abca42fbafe4ee71a) | `` slstatus: update to unstable-2022-12-19 ``                                                  |
| [`1e4766bd`](https://github.com/NixOS/nixpkgs/commit/1e4766bd025d31ced910c306147cbbc8fcc529c4) | `` python310Packages.pytest-cases: add changelog to meta ``                                    |
| [`5cc75dc2`](https://github.com/NixOS/nixpkgs/commit/5cc75dc281e28194021c6a115a66f78236f61579) | `` python310Packages.pytest-cases: 3.6.13 -> 3.6.14 ``                                         |
| [`ad22b9a1`](https://github.com/NixOS/nixpkgs/commit/ad22b9a1d357e69ad4cf5415d8b1630fb7fbfb2d) | `` gobuster: 3.4.0 -> 3.5.0 ``                                                                 |
| [`880c0b2c`](https://github.com/NixOS/nixpkgs/commit/880c0b2c8b2bf54229d5eb13d61b5b4a1cffc72c) | `` python310Packages.bthome-ble: 2.6.0 -> 2.7.0 ``                                             |
| [`0663b80b`](https://github.com/NixOS/nixpkgs/commit/0663b80b7c457c3cba1ebc1e9f2cfdf3745ccee5) | `` python310Packages.aliyun-python-sdk-cdn: 3.8.2 -> 3.8.3 ``                                  |
| [`dc6ad930`](https://github.com/NixOS/nixpkgs/commit/dc6ad93098a5acc9d035283ccfdce7269966201f) | `` chezmoi: 2.30.0 -> 2.31.0 ``                                                                |
| [`c56e5ef8`](https://github.com/NixOS/nixpkgs/commit/c56e5ef8016ff6683c822117ecc8a285c7add5fb) | `` nixos/users-groups: update option description to clarify initial* option precedence ``      |
| [`5508000d`](https://github.com/NixOS/nixpkgs/commit/5508000ddfc5b6b0db7f25272ef09588637e375f) | `` nixos/tests/shadow: ensure hashedPassword takes precedence over initialHashedPassword ``    |
| [`bfa0bff6`](https://github.com/NixOS/nixpkgs/commit/bfa0bff64474a528eb06a7f9e0a9f53f1b41af45) | `` nixos/update-users-groups: let hashedPassword take precedence over initialHashedPassword `` |
| [`4a374528`](https://github.com/NixOS/nixpkgs/commit/4a3745285661c63e908d4b90671f5c76cf6b4903) | `` python310Packages.wandb: disable more tests ``                                              |
| [`c226362e`](https://github.com/NixOS/nixpkgs/commit/c226362e96609bfa51fc47bb0d71efd694ca16ad) | `` cdogs-sdl: update pname ``                                                                  |
| [`f096f0df`](https://github.com/NixOS/nixpkgs/commit/f096f0df37921878d922932fbfa9758859ae6d72) | `` lychee: 0.10.3 -> 0.11.1 ``                                                                 |
| [`6fb4184c`](https://github.com/NixOS/nixpkgs/commit/6fb4184cc3397a5dbb3e8eaaf5cf9a366cc6526d) | `` pkgsMusl.directfb: mark broken for Musl ``                                                  |
| [`f2a84bdb`](https://github.com/NixOS/nixpkgs/commit/f2a84bdb398fd723b9271443239d7ae22e200ac1) | `` unifi7: 7.3.76 -> 7.3.83 ``                                                                 |
| [`5dce130d`](https://github.com/NixOS/nixpkgs/commit/5dce130d1cf9a2a5cac08e66363de3de01970bfe) | `` nixos/tests/unifi: inherit allowUnfree into test node ``                                    |
| [`f92db6b0`](https://github.com/NixOS/nixpkgs/commit/f92db6b0e406cd38c6de232ea4a1e6d50a98d70e) | `` conftest: 0.39.0 -> 0.39.1 ``                                                               |
| [`68de1281`](https://github.com/NixOS/nixpkgs/commit/68de1281efd16c440416a5ef5a4bd63502c19310) | `` ddosify: 0.13.2 -> 0.14.1 ``                                                                |
| [`d3a53947`](https://github.com/NixOS/nixpkgs/commit/d3a5394744cb30d8e8e1903a89ab7d91f7cf8b24) | `` sniffnet: 1.1.0 -> 1.1.1 ``                                                                 |
| [`6bde4e9a`](https://github.com/NixOS/nixpkgs/commit/6bde4e9adea3f4d2e51fede682ca04c373875463) | `` kubelogin: 0.0.26 -> 0.0.27 ``                                                              |
| [`546f356d`](https://github.com/NixOS/nixpkgs/commit/546f356db67baac2c34fcb1245c6267de1100260) | `` remove myself as maintainer for now as I switched to another distro ``                      |
| [`2f403969`](https://github.com/NixOS/nixpkgs/commit/2f403969dac319845bc4ce6c16d4c76b2c1c6e0a) | `` vimPlugins.harpoon: add plenary-nvim dependency ``                                          |
| [`9ca03702`](https://github.com/NixOS/nixpkgs/commit/9ca037029afb201d898837b4145718fb90102fd1) | `` starship: 1.12.0 -> 1.13.0 ``                                                               |
| [`2c1ff162`](https://github.com/NixOS/nixpkgs/commit/2c1ff16299f37edd358b7ff794a112abb22a5820) | `` ffmpeg-5: fix Vulkan builds ``                                                              |
| [`c83bee75`](https://github.com/NixOS/nixpkgs/commit/c83bee753c92c14908a57f267135b0f4d61bebbb) | `` vhs: 0.2.0 -> 0.3.0 ``                                                                      |
| [`30334423`](https://github.com/NixOS/nixpkgs/commit/30334423e6504e9bd8fc4adfb40a7ee0c0de4001) | `` oha: 0.5.6 -> 0.5.7 ``                                                                      |
| [`32cc44d2`](https://github.com/NixOS/nixpkgs/commit/32cc44d24e82892aa2c5e1f832b967aa25af011a) | `` cargo-generate: 0.18.0 -> 0.18.1 ``                                                         |
| [`5ce4a026`](https://github.com/NixOS/nixpkgs/commit/5ce4a02687e8ac4bac199b04c2718c26b907373e) | `` nest: fix Python & Darwin ``                                                                |
| [`cb28b010`](https://github.com/NixOS/nixpkgs/commit/cb28b010b1a3c6a5d969abfbba06ddc95084d721) | `` python3Packages.returns: init at 0.19.0 ``                                                  |
| [`f3942656`](https://github.com/NixOS/nixpkgs/commit/f39426567e78fd19e3e77a43b68cf7f959eb816d) | `` python310Packages.onnx: 1.13.0 -> 1.13.1 ``                                                 |
| [`79396a2a`](https://github.com/NixOS/nixpkgs/commit/79396a2aa89ccc5ef5b655de807f79df84875dbd) | `` cosign: allow darwin networking for tests ``                                                |
| [`a15c903b`](https://github.com/NixOS/nixpkgs/commit/a15c903b4b5244676bef37b391f2dba360eddd4d) | `` hobbits: 0.53.2 -> 0.54.0 ``                                                                |
| [`0e488564`](https://github.com/NixOS/nixpkgs/commit/0e4885645a1ba6384ec05ee42c9244d44c963273) | `` sigslot: 1.2.1 -> 1.2.2 ``                                                                  |
| [`4f820e9c`](https://github.com/NixOS/nixpkgs/commit/4f820e9c4c250e2233cb1561af2879874aadb5dc) | `` obsidian: fix missed hash change for darwin ``                                              |
| [`39ff9ec4`](https://github.com/NixOS/nixpkgs/commit/39ff9ec4c886512072e33b298551787def38b9ab) | `` pypi-mirror: 5.0.1 -> 5.0.2 ``                                                              |
| [`c7fd310a`](https://github.com/NixOS/nixpkgs/commit/c7fd310aa0df8e5edbffc348e149dada0e1a007f) | `` osv-scanner: 1.1.0 -> 1.2.0 ``                                                              |
| [`a69d8e46`](https://github.com/NixOS/nixpkgs/commit/a69d8e4658b325d55b9b959af262556c0a3ad8be) | `` seahub: 9.0.6 -> 9.0.10 ``                                                                  |
| [`55d8a78f`](https://github.com/NixOS/nixpkgs/commit/55d8a78f7395cacae99d62606e3cbca4707af0e7) | `` imapfilter: 2.7.6 -> 2.8.1 ``                                                               |
| [`83d62a00`](https://github.com/NixOS/nixpkgs/commit/83d62a00ea967e67b4a418909b222eaaa8b56b26) | `` prl-tools: 18.1.1-53328 -> 18.2.0-53488 ``                                                  |
| [`ee6bc5a5`](https://github.com/NixOS/nixpkgs/commit/ee6bc5a597f595cc0e4edb6c3b64a6e39cffd2ad) | `` krill: 0.12.1 -> 0.12.2 ``                                                                  |
| [`a82015b5`](https://github.com/NixOS/nixpkgs/commit/a82015b5aad9984f72b7e2597d6e186621c490a0) | `` pocketbase: 0.12.2 -> 0.12.3 ``                                                             |
| [`50b8115f`](https://github.com/NixOS/nixpkgs/commit/50b8115f67b2925c151eb88767d1cdddd18c3b81) | `` spotdl: 4.0.6 -> 4.0.7 ``                                                                   |
| [`49c528f3`](https://github.com/NixOS/nixpkgs/commit/49c528f328c54e20c3be5dce3c46adb58e9a327d) | `` spotdl: add changelog to meta ``                                                            |
| [`94e12755`](https://github.com/NixOS/nixpkgs/commit/94e12755b1d375d85b92b631b5cc6184916142b9) | `` python310Packages.ipyvue: 1.8.0 -> 1.9.0 ``                                                 |
| [`560c3389`](https://github.com/NixOS/nixpkgs/commit/560c3389f4fe0b38294eb1da4853dd2128679a6b) | `` sing-geoip: init at 20230112 ``                                                             |
| [`ed6c7c81`](https://github.com/NixOS/nixpkgs/commit/ed6c7c8161c818d34cb1de1bc2e82de290b7516d) | `` readstat: 1.1.8 -> 1.1.9 ``                                                                 |
| [`c27ce218`](https://github.com/NixOS/nixpkgs/commit/c27ce2188094c79be74f7b64ef5554260faa6d3a) | `` nwg-bar: 0.1.0 -> 0.1.1 ``                                                                  |
| [`1b46f857`](https://github.com/NixOS/nixpkgs/commit/1b46f8574d69baa116a58e31e8bedff44f09153a) | `` signalbackup-tools: 20230211 -> 20230223-1 ``                                               |
| [`159ca81a`](https://github.com/NixOS/nixpkgs/commit/159ca81a66184abb27b2e4fb82c919a1f1c243d9) | `` cargo-zigbuild: 0.16.0 -> 0.16.1 ``                                                         |
| [`93cabac3`](https://github.com/NixOS/nixpkgs/commit/93cabac35e4ace47c816f8f91c3677a4b80e81c3) | `` neo4j-desktop: 1.5.6 -> 1.5.7 ``                                                            |
| [`c9ff9afb`](https://github.com/NixOS/nixpkgs/commit/c9ff9afbad1036a75e7c9402dc0b704ff5281846) | `` asymptote: 2.83 -> 2.85 ``                                                                  |
| [`d3d5cdeb`](https://github.com/NixOS/nixpkgs/commit/d3d5cdebb63ac6a48ca62ff1ff563213a9694b64) | `` rtsp-simple-server: 0.21.4 -> 0.21.5 ``                                                     |
| [`febcedca`](https://github.com/NixOS/nixpkgs/commit/febcedca14e7e7528064ed1076279da4c253ffbc) | `` cdogs-sdl: 1.4.0 -> 1.4.1 ``                                                                |
| [`fde292c8`](https://github.com/NixOS/nixpkgs/commit/fde292c8ff7009b893c041a0ccc6def066d82229) | `` cli53: 0.8.18 -> 0.8.21 ``                                                                  |
| [`26c256b6`](https://github.com/NixOS/nixpkgs/commit/26c256b671a446fdcea96e931fc8b514fe2cc795) | `` phlare: 0.3.0 -> 0.5.1 ``                                                                   |
| [`1c8bde1d`](https://github.com/NixOS/nixpkgs/commit/1c8bde1d29d8491a04de4ddfe58b34a5b510d714) | `` libsemanage: 3.4 -> 3.5 ``                                                                  |
| [`78203038`](https://github.com/NixOS/nixpkgs/commit/78203038bd2be6e9ebaafeab03b164d76cc95112) | `` go-minimock: 3.0.10 -> 3.1.1 ``                                                             |
| [`668a7729`](https://github.com/NixOS/nixpkgs/commit/668a7729da7566742d1c0b9f16065f9010c2e96e) | `` python310Packages.oslo-context: 5.1.0 -> 5.1.1 ``                                           |
| [`2b1a168d`](https://github.com/NixOS/nixpkgs/commit/2b1a168d2d528a99e075c0d5b13643f26d8976f4) | `` python310Packages.torchmetrics: 0.11.0 -> 0.11.2 ``                                         |
| [`92863b70`](https://github.com/NixOS/nixpkgs/commit/92863b70b9cbf2ba2a48ac3180f403c1b51c66b3) | `` python311Packages.in-n-out: disable failing tests on Python 3.11 ``                         |
| [`24d0a228`](https://github.com/NixOS/nixpkgs/commit/24d0a228a0c803ea74e2bdd48f982407a7235a0b) | `` python310Packages.app-model: init at 0.1.1 ``                                               |
| [`9523ec0c`](https://github.com/NixOS/nixpkgs/commit/9523ec0c78126897dd44ad2a657390d4d169e63c) | `` python310Packages.napari: add missing inputs ``                                             |
| [`5181d169`](https://github.com/NixOS/nixpkgs/commit/5181d1693d487e299e44b5d1938117d83c8912ff) | `` python310Packages.napari-console: 0.0.4 -> 0.0.7 ``                                         |
| [`56700a8d`](https://github.com/NixOS/nixpkgs/commit/56700a8d450e5d6ec5596f21f65b69a44b547406) | `` python310Packages.in-n-out: init at 0.1.6 ``                                                |
| [`18750d34`](https://github.com/NixOS/nixpkgs/commit/18750d345514f2c26c04f0da8f68906a5f379284) | `` rpcs3: 0.0.26-14702-cfb788941 -> 0.0.26-14757-3388c8ed0 ``                                  |
| [`722c5c13`](https://github.com/NixOS/nixpkgs/commit/722c5c1322d1599388e422bac8cc470f5a6a1432) | `` python310Packages.makefun: 1.15.0 -> 1.15.1 ``                                              |
| [`f6e9dc1a`](https://github.com/NixOS/nixpkgs/commit/f6e9dc1ae3d7dd392cde5220e4f95e1e636169c2) | `` python310Packages.napari-plugin-engine: add pythonImportsCheck ``                           |
| [`36a981d9`](https://github.com/NixOS/nixpkgs/commit/36a981d9baa025c7f3df391aefe764f87457580f) | `` python310Packages.napari-plugin-engine: disable on unsupported Python releases ``           |
| [`266618d2`](https://github.com/NixOS/nixpkgs/commit/266618d20b5177f47f565bc4b27a3fa78c8e900b) | `` python310Packages.napari-plugin-engine: equalize ``                                         |
| [`2652ef1e`](https://github.com/NixOS/nixpkgs/commit/2652ef1e69360ddfe54ff4c16f47e03d21b05367) | `` python310Packages.napari-console: add pythonImportsCheck ``                                 |
| [`7a504fd9`](https://github.com/NixOS/nixpkgs/commit/7a504fd9746775e2497663c8a223cf4e2589d569) | `` python310Packages.sounddevice: 0.4.5 -> 0.4.6 ``                                            |
| [`b8907ac5`](https://github.com/NixOS/nixpkgs/commit/b8907ac527aeb2f8abb5d4ff25c642489f594cc9) | `` python310Packages.napari-console: disable on unsupported Python releases ``                 |
| [`9ede7bf5`](https://github.com/NixOS/nixpkgs/commit/9ede7bf57b1975b9d18d5edb3fb49d1c01a5214f) | `` python310Packages.napari-console: add pythonImportsCheck ``                                 |
| [`81a543c5`](https://github.com/NixOS/nixpkgs/commit/81a543c59af2743fd02e66b727606fc1e87d0070) | `` python310Packages.napari-console: equalize ``                                               |
| [`5fcd9b14`](https://github.com/NixOS/nixpkgs/commit/5fcd9b14439719006af9a15cf32eddd8866c48de) | `` python310Packages.napari-svg: 0.1.5 -> 0.1.6 ``                                             |
| [`9acadbcd`](https://github.com/NixOS/nixpkgs/commit/9acadbcd3af777a9daa2ad982557b46ed3877df6) | `` python310Packages.napari: add changelog to meta ``                                          |
| [`c511b753`](https://github.com/NixOS/nixpkgs/commit/c511b7532a97d5aefa73ddb5a5102a5ba56dea9b) | `` python310Packages.napari-svg: disable on unsupported Python releases ``                     |
| [`f4cdbedf`](https://github.com/NixOS/nixpkgs/commit/f4cdbedf907d33d27534df14ac714dec0e4eea6e) | `` python310Packages.napari-svg: equalize ``                                                   |
| [`bede2d61`](https://github.com/NixOS/nixpkgs/commit/bede2d6132662cd4b53f1af4a878c4d0055e0c87) | `` maintainers: add jessemoore ``                                                              |
| [`4497ad81`](https://github.com/NixOS/nixpkgs/commit/4497ad811391f60f9bdbf6dcc43f8164b4fc654f) | `` python310Packages.poetry-dynamic-versioning: 0.21.3 -> 0.21.4 ``                            |
| [`308657da`](https://github.com/NixOS/nixpkgs/commit/308657daec2c8d3508b34f171305e9b10d297267) | `` nixos/tests/systemd-shutdown: ensure systemd-initrd variant actually enables it ``          |
| [`480786a0`](https://github.com/NixOS/nixpkgs/commit/480786a0b94e0a350f9797c7653805c4b8842698) | `` dprint: 0.34.4 -> 0.34.5 ``                                                                 |
| [`4ba42ffd`](https://github.com/NixOS/nixpkgs/commit/4ba42ffd815c0d931fa73f32cfb5ba9d376b8d96) | `` python310Packages.moku: 2.6.0 -> 2.6.2 ``                                                   |
| [`f5483464`](https://github.com/NixOS/nixpkgs/commit/f5483464d5726d05b6169017e6b0f64ebccc2f53) | `` nixos/systemd-coredump: guard static gid for systemd-coredump behind state version ``       |
| [`2265160f`](https://github.com/NixOS/nixpkgs/commit/2265160fc0b4cc9a38b392ec3b3a3fe18c2e5413) | `` nixos/polkit: guard static gid for polkituser behind state version ``                       |
| [`cb753dd2`](https://github.com/NixOS/nixpkgs/commit/cb753dd281835ccc42dd17446453a5dca32bdaee) | `` python310Packages.pastedeploy: 2.1.1 -> 3.0.1 ``                                            |
| [`a6ae7f73`](https://github.com/NixOS/nixpkgs/commit/a6ae7f73875a3c669d1d83154edfda47191d8742) | `` python310Packages.pastedeploy: add changelog to meta ``                                     |
| [`373932e8`](https://github.com/NixOS/nixpkgs/commit/373932e83b3b587e7d00ca5fe2992ef351ff3dc4) | `` cmocka: fixup on aarch64-darwin by updating to 1.1.6 ``                                     |
| [`9eeb000b`](https://github.com/NixOS/nixpkgs/commit/9eeb000bfea34e87ade554604d5fc9bab3642571) | `` ceph: add xz dependency ``                                                                  |
| [`4bd8b542`](https://github.com/NixOS/nixpkgs/commit/4bd8b542eb3d2631a62ba55c3892bc6287c6fe94) | `` hdf5: add h5py to passthru.tests ``                                                         |
| [`19f87bba`](https://github.com/NixOS/nixpkgs/commit/19f87bba7e0b48fe3fa5110a34486d7cbb7a4888) | `` python310Packages.h5py: 3.7.0 -> 3.8.0 ``                                                   |
| [`70882beb`](https://github.com/NixOS/nixpkgs/commit/70882beb2a9e903f0548cbdcaffe7d88997373e2) | `` talloc: 2.3.4 -> 2.4.0 ``                                                                   |
| [`c2de8016`](https://github.com/NixOS/nixpkgs/commit/c2de80161e28a606380ccc2857bbca18379e1907) | `` python311Packages.paste: add changelog to meta ``                                           |
| [`3d9cd7c1`](https://github.com/NixOS/nixpkgs/commit/3d9cd7c149b38d3d9bf077c212c62770503cbe6e) | `` python310Packages.paste: disable failing test on Python 3.11 ``                             |
| [`2c6cbd0d`](https://github.com/NixOS/nixpkgs/commit/2c6cbd0d72b0aad99672d36c30bdfe8d127c8f4a) | `` python310Packages.paste: 3.5.0 -> 3.5.2 ``                                                  |
| [`cb3a2794`](https://github.com/NixOS/nixpkgs/commit/cb3a27940cf1dad2ff1396b4701d70cecc8cce88) | `` python310Packages.pglast: 4.1 -> 5.0 ``                                                     |