### PR TITLE
chore(flake/home-manager): `305daba4` -> `ef7d3165`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677533532,
-        "narHash": "sha256-2Ie47MONhIFOxvbLmwhmCCe/IoVDVd7YnoK61vu5Xy8=",
+        "lastModified": 1677621055,
+        "narHash": "sha256-n3D/pZX0cYEpWKcLJSFImo5Dpk3D1RrxKVDmI6lnaIg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "305daba44a9df57738cffc67c08129005a25579a",
+        "rev": "ef7d316578367ed7732a21eede6c79546a36124f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                               |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`ef7d3165`](https://github.com/nix-community/home-manager/commit/ef7d316578367ed7732a21eede6c79546a36124f) | `` exa: always configure `exa` alias (#3721) ``                       |
| [`ddcbf676`](https://github.com/nix-community/home-manager/commit/ddcbf676ba422ae3dc0c386bc5001acbebbf0b0d) | `` specialization: fix `name` conflict inside NixOS module (#3718) `` |
| [`9438e56a`](https://github.com/nix-community/home-manager/commit/9438e56a7b7df5e02091027dccdd8d86768f1a2d) | `` .github: pin nix 2.13 in workflows (#3720) ``                      |
| [`4bac3418`](https://github.com/nix-community/home-manager/commit/4bac34186886f8d484791702f32ec371f8c7a81e) | `` `exa`: add more options (#3505) ``                                 |