### PR TITLE
chore(flake/nixpkgs): `7f5639fa` -> `68196a61`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -198,11 +198,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677407201,
-        "narHash": "sha256-3blwdI9o1BAprkvlByHvtEm5HAIRn/XPjtcfiunpY7s=",
+        "lastModified": 1677587185,
+        "narHash": "sha256-zYT66MAYwctAQqI5VBw3LbBXiSKdB8vuMAqCGG8onbE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7f5639fa3b68054ca0b062866dc62b22c3f11505",
+        "rev": "68196a61c26748d3e53a6803de3d2f8c69f27831",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                 |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
| [`4819abf7`](https://github.com/NixOS/nixpkgs/commit/4819abf7f4baa7e8ca7e9e375c28b8c51b0f1ce9) | `` maintainers: fix @MrFreezeex githubid ``                                                                             |
| [`2caa0a81`](https://github.com/NixOS/nixpkgs/commit/2caa0a8188e8181b2943df624b5ea4bd2870b816) | `` manaplus: fix build ``                                                                                               |
| [`db0dc689`](https://github.com/NixOS/nixpkgs/commit/db0dc689754280e1fc31bf742ee18fb01f892c59) | `` mkCoqDerivation: findlib is an optional input ``                                                                     |
| [`0cad0fd1`](https://github.com/NixOS/nixpkgs/commit/0cad0fd11994d7aa9a2e856e380e661550660251) | `` coqPackages.coq-elpi: propagate findlib ``                                                                           |
| [`a18a7e5f`](https://github.com/NixOS/nixpkgs/commit/a18a7e5ff832525acd4803a55d805e20e2e6c939) | `` coqPackages.coqhammer: fix src URL ``                                                                                |
| [`71210f04`](https://github.com/NixOS/nixpkgs/commit/71210f04101a86edb519085e53002f6d8b4d7ba9) | `` neovimUtils.makeNeovimConfig: expose packpathsDir ``                                                                 |
| [`74422033`](https://github.com/NixOS/nixpkgs/commit/74422033aa269c101b3c4d2f27acd335ffe97c32) | `` mmex: 1.6.1 -> 1.6.3 ``                                                                                              |
| [`cad64885`](https://github.com/NixOS/nixpkgs/commit/cad648850915c9a5f8219e5635766c69d858c146) | `` nixos/multipass: typo s/SyslogIdentifer/SyslogIdentifier/ ``                                                         |
| [`bcaa9892`](https://github.com/NixOS/nixpkgs/commit/bcaa98928564bdf0dcf289b3c17eea703babf8b3) | `` maestral-gui: 1.7.0 -> 1.7.1 ``                                                                                      |
| [`edc35cbe`](https://github.com/NixOS/nixpkgs/commit/edc35cbefcf3fc0fae0a2a1e59daa1f2a2dc3d91) | `` python3Packages.maestral: 1.7.0 -> 1.7.1 ``                                                                          |
| [`605ba646`](https://github.com/NixOS/nixpkgs/commit/605ba64680fa8ba9af62d927cd1d1ad5c74f5de6) | `` maestral-gui: 1.6.5 -> 1.7.0 ``                                                                                      |
| [`86231302`](https://github.com/NixOS/nixpkgs/commit/86231302a593e7c0829a151d731c823976f649b0) | `` python3Packages.maestral: 1.6.5 -> 1.7.0 ``                                                                          |
| [`42748f7e`](https://github.com/NixOS/nixpkgs/commit/42748f7eea63167a41b4b60a2a162500379f6847) | `` rathole: disable tests, as they loop forever ``                                                                      |
| [`d0c6fa6d`](https://github.com/NixOS/nixpkgs/commit/d0c6fa6d4e09fa8a946ef81a836635ded8abded3) | `` qbittorrent: 4.5.1 -> 4.5.2 ``                                                                                       |
| [`bcf8849a`](https://github.com/NixOS/nixpkgs/commit/bcf8849a8144cd2dde13784e3de04d9b1e27cfb6) | `` gnome-decoder: fixup build after pipewire updates ``                                                                 |
| [`dbfe0825`](https://github.com/NixOS/nixpkgs/commit/dbfe0825c7d0659a6124f38e59eb2b321ffb361c) | `` rocm-cmake: 5.4.2 -> 5.4.3 ``                                                                                        |
| [`7b6e9e2c`](https://github.com/NixOS/nixpkgs/commit/7b6e9e2cac171e7e7162f449dc86c61a0c184f91) | `` kakoune: use gcc12Stdenv on aarch64-linux ``                                                                         |
| [`251f64f1`](https://github.com/NixOS/nixpkgs/commit/251f64f1d0aa2d912369736a9d639f2ea579058d) | `` google-cloud-sdk: add autoPatchElf to components ``                                                                  |
| [`9fd1c278`](https://github.com/NixOS/nixpkgs/commit/9fd1c2781591a3d7e58093b01a61cecc4cf501f1) | `` dolphin-emu: use gcc12Stdenv on aarch64-linux ``                                                                     |
| [`206a7d61`](https://github.com/NixOS/nixpkgs/commit/206a7d61dc253fd028eba8bb0ce2bbbf931d03ee) | `` root: use gcc12Stdenv on aarch64-linux ``                                                                            |
| [`ed4566be`](https://github.com/NixOS/nixpkgs/commit/ed4566be65272b8683bc67fc7ed1e9ea07e2e7ab) | `` mtxclient: use gcc12Stdenv on aarch64-linux ``                                                                       |
| [`16b10bf1`](https://github.com/NixOS/nixpkgs/commit/16b10bf1127ee7522c066ba6820dc1c0b78da267) | `` nheko: use gcc12Stdenv on aarch64-linux ``                                                                           |
| [`719a3afa`](https://github.com/NixOS/nixpkgs/commit/719a3afafcc9e2f7e94a635ca78a5ff6c5ab774b) | `` rpm-ostree: use gcc12Stdenv on aarch64-linux ``                                                                      |
| [`42cba719`](https://github.com/NixOS/nixpkgs/commit/42cba719c818f1303af398d93985ff3794f2ae7e) | `` bobcat: use gcc12Stdenv on aarch64-linux ``                                                                          |
| [`43760d9c`](https://github.com/NixOS/nixpkgs/commit/43760d9cc454ade3f7f00de14c27adb40889400b) | `` build(deps): bump korthout/backport-action from 1.1.0 to 1.2.0 ``                                                    |
| [`2ab049a5`](https://github.com/NixOS/nixpkgs/commit/2ab049a5c7c24dab62a7c3aa53b617fb16e98092) | `` nixos/tests/podman: add zfs to rootful test ``                                                                       |
| [`48642c63`](https://github.com/NixOS/nixpkgs/commit/48642c634e51b949d3ea01f09c28c83f9aa824d9) | `` podman: remove wrapper ``                                                                                            |
| [`ca6c9318`](https://github.com/NixOS/nixpkgs/commit/ca6c93187db55a7964e0032ab981729acf8df7f7) | `` invidious: unstable-2023-02-13 -> unstable-2023-02-22 ``                                                             |
| [`c884849a`](https://github.com/NixOS/nixpkgs/commit/c884849a3c6407bfff3383c54499595781fea73a) | `` openmm: use gcc11Stdenv everywhere ``                                                                                |
| [`6c4c6f73`](https://github.com/NixOS/nixpkgs/commit/6c4c6f731252e4530d1c0ca900bb445251b8dc3b) | `` jira_cli: mark as broken ``                                                                                          |
| [`d531f0a0`](https://github.com/NixOS/nixpkgs/commit/d531f0a0d632de6d43bbd6c5edc97e5464e52923) | `` vscode-extensions.streetsidesoftware.code-spell-checker: 2.17.1 -> 2.18.0 ``                                         |
| [`b41bc9a0`](https://github.com/NixOS/nixpkgs/commit/b41bc9a0e0b564ebc095d9819afa523d0b241262) | `` python310Packages.adblock: fix build ``                                                                              |
| [`36405d17`](https://github.com/NixOS/nixpkgs/commit/36405d170ac00549cf0f5139a3f5adbc1c5cffa0) | `` freefilesync: 12.0 -> 12.1 ``                                                                                        |
| [`9e56d6ec`](https://github.com/NixOS/nixpkgs/commit/9e56d6ec92c8fb4192f1392aa5c4101ad77f2070) | `` moodle-dl: 2.1.2.5 -> 2.2.2.4 ``                                                                                     |
| [`d7189365`](https://github.com/NixOS/nixpkgs/commit/d71893657dea77da27e2885c0542f018fe98b475) | `` python310Packages.aioxmpp: init at 0.13.3 ``                                                                         |
| [`6025563b`](https://github.com/NixOS/nixpkgs/commit/6025563be6c1cf39bd3124649dc0c9f7302d2762) | `` python310Packages.aiosasl: init at 0.5.0 ``                                                                          |
| [`eafa5eba`](https://github.com/NixOS/nixpkgs/commit/eafa5eba29feec42459b2e6fc7e00d3ca0a6ffb4) | `` python310Packages.aioopenssl: init at 0.6.0 ``                                                                       |
| [`6d945d28`](https://github.com/NixOS/nixpkgs/commit/6d945d280326d15b1850c0df3219d8d40d1735f9) | `` python310Packages.svg2tikz: unstable-2021-01-12 -> 1.2.0 ``                                                          |
| [`5d12e405`](https://github.com/NixOS/nixpkgs/commit/5d12e405f6ed8f061673f5ce609b5e74fb135f34) | `` python310Packages.inkex: build independently ``                                                                      |
| [`5261692e`](https://github.com/NixOS/nixpkgs/commit/5261692e980d4d39d743b6be5bf2ccbbe919c209) | `` python310Packages.bx-py-utils: 75 -> 76 ``                                                                           |
| [`375f5b6f`](https://github.com/NixOS/nixpkgs/commit/375f5b6f80d6f824f4dcbdee55df413174ff6ed9) | `` openvpn3: 18_beta -> 19_beta ``                                                                                      |
| [`3a2f536e`](https://github.com/NixOS/nixpkgs/commit/3a2f536e742e51f9b49055e3f82a5ac665a2eded) | `` python311Packages.sip_4: disable ``                                                                                  |
| [`0e1d56a3`](https://github.com/NixOS/nixpkgs/commit/0e1d56a397cc47fc2bcfa8a2fcee83b4a6d4f678) | `` reaper: add curl and libxml2 ld_library_path deps ``                                                                 |
| [`44ac1cbe`](https://github.com/NixOS/nixpkgs/commit/44ac1cbea8621d6e18a2b0cbfa3d773ba04f3268) | `` terraform-providers.tencentcloud: 1.79.11 → 1.79.12 ``                                                               |
| [`37eea1f9`](https://github.com/NixOS/nixpkgs/commit/37eea1f95048ffd9e2c2f14dc18fa3fe5e279075) | `` terraform-providers.ucloud: 1.34.0 → 1.34.1 ``                                                                       |
| [`872ba191`](https://github.com/NixOS/nixpkgs/commit/872ba19121a7a56a4c8b82d1cb2a0e92e02a8a05) | `` terraform-providers.spotinst: 1.100.0 → 1.101.0 ``                                                                   |
| [`ea7312d1`](https://github.com/NixOS/nixpkgs/commit/ea7312d1efcbb7d852637d79bf7e7efe425b4e30) | `` terraform-providers.sumologic: 2.20.0 → 2.21.0 ``                                                                    |
| [`c97c4ccd`](https://github.com/NixOS/nixpkgs/commit/c97c4ccd378a9c7bdcec749d2b46da0ec99f2ebc) | `` terraform-providers.newrelic: 3.14.0 → 3.15.0 ``                                                                     |
| [`72541551`](https://github.com/NixOS/nixpkgs/commit/725415519f4c20426659e1591536a2cd9af7de12) | `` terraform-providers.minio: 1.11.0 → 1.12.0 ``                                                                        |
| [`5c48a036`](https://github.com/NixOS/nixpkgs/commit/5c48a036021ae46de26ec8cc0949fbd5b664a351) | `` terraform-providers.launchdarkly: 2.9.5 → 2.10.0 ``                                                                  |
| [`568bece2`](https://github.com/NixOS/nixpkgs/commit/568bece2c567fd2c36c4f1946ebb7c7a29e79d76) | `` terraform-providers.google-beta: 4.54.0 → 4.55.0 ``                                                                  |
| [`4659cef5`](https://github.com/NixOS/nixpkgs/commit/4659cef5b9aadbe0c77d43925d6dfd60527bd217) | `` terraform-providers.google: 4.54.0 → 4.55.0 ``                                                                       |
| [`79414696`](https://github.com/NixOS/nixpkgs/commit/79414696e027f4448dd74654ec37c4a1ff5d964c) | `` pantheon.granite7: 7.1.0 -> 7.2.0 ``                                                                                 |
| [`358fa30b`](https://github.com/NixOS/nixpkgs/commit/358fa30bafddf8ba394fb68b76d196ecc4f9ae42) | `` oguri: reduce supported platforms ``                                                                                 |
| [`660e32a9`](https://github.com/NixOS/nixpkgs/commit/660e32a9ffb0cc797b9dd2dd6e26b9bd43deb3d7) | `` kdiff3: 1.9.6 -> 1.10.0 ``                                                                                           |
| [`02fa99fd`](https://github.com/NixOS/nixpkgs/commit/02fa99fd08645c921d970d397502c6338eae9dbc) | `` lua_5_3_compat, lua_5_4_compat: set LUA_COMPAT_5_x as LUA_COMPAT_ALL was removed ``                                  |
| [`61295f7a`](https://github.com/NixOS/nixpkgs/commit/61295f7a0e394af834e5fcb785b4eb0ea3b09919) | `` poetry2nix: fix override bootstrapped-pip ``                                                                         |
| [`359a46e7`](https://github.com/NixOS/nixpkgs/commit/359a46e751124454a1a03ad1cdcb1efef745abd8) | `` llvm*: Remove `outputSpecified` workaround where possible ``                                                         |
| [`ce07d44c`](https://github.com/NixOS/nixpkgs/commit/ce07d44ca9d6824125f4a30a96a42555b61de205) | `` Revert "nixos/release: disable nfs3.simple" ``                                                                       |
| [`ae671e1b`](https://github.com/NixOS/nixpkgs/commit/ae671e1b918e8ce7e7cf1372f5a91bcbd3d44d58) | `` Revert "nixos/release: disable nfs3.simple" ``                                                                       |
| [`fd802ced`](https://github.com/NixOS/nixpkgs/commit/fd802ced97642e511dd2fc5805703cbb38ebc8a9) | `` python310Packages.notifications-python-client: 7.0.0 -> 8.0.0 ``                                                     |
| [`d654c44d`](https://github.com/NixOS/nixpkgs/commit/d654c44d2f967247c219950158e7fc3cc36658e0) | `` drawio-headless: add --auto-display to prevent races ``                                                              |
| [`254fbb6a`](https://github.com/NixOS/nixpkgs/commit/254fbb6a378b6dd3b0d7a7b8a0d9dd070c3a6f60) | `` python310Packages.msoffcrypto-tool: add changelog to meta ``                                                         |
| [`a6bc7c0b`](https://github.com/NixOS/nixpkgs/commit/a6bc7c0bbaf4f0168c33dc74bb5ad0fe02b19496) | `` python310Packages.msoffcrypto-tool: 5.0.0 -> 5.0.1 ``                                                                |
| [`b9b555ff`](https://github.com/NixOS/nixpkgs/commit/b9b555ff62797b1b73be449d8ceb716e7a468209) | `` spicedb-zed: 0.9.1 -> 0.10.0 ``                                                                                      |
| [`ce83a0c1`](https://github.com/NixOS/nixpkgs/commit/ce83a0c11c149cacaf708cd44e69487293ccf671) | `` medfile: build with hdf5 1.14 ``                                                                                     |
| [`d15787c4`](https://github.com/NixOS/nixpkgs/commit/d15787c4dcbd3845270231b3e324dcf6be46d5f7) | `` python310Packages.roonapi: 0.1.3 -> 0.1.4 ``                                                                         |
| [`77bbdaa9`](https://github.com/NixOS/nixpkgs/commit/77bbdaa9be377676cadd55febcb2cafe76f7b853) | `` cudatext-qt: 1.185.0 -> 1.186.0 ``                                                                                   |
| [`70335751`](https://github.com/NixOS/nixpkgs/commit/70335751e46c5201d4b613099aeb8456a33c087b) | `` vte: restrict condition for using clangStdenv ``                                                                     |
| [`5e98938f`](https://github.com/NixOS/nixpkgs/commit/5e98938f2bf3642d0fe6ef2245c9614993374087) | `` python310Packages.tld: 0.12.7 -> 0.13 ``                                                                             |
| [`8f32beea`](https://github.com/NixOS/nixpkgs/commit/8f32beea227a1cfb2908e3a5d04f265cfe6a43ac) | `` uxplay: 1.63 -> 1.63.2 ``                                                                                            |
| [`36fccf2f`](https://github.com/NixOS/nixpkgs/commit/36fccf2fdb240c8fe71c7ec0752572e227c85140) | `` mir: 2.12.0 -> 2.12.1 ``                                                                                             |
| [`a46074d1`](https://github.com/NixOS/nixpkgs/commit/a46074d1acc319fc8ad0f269af0db751a1bd56ad) | `` trufflehog: 3.28.1 -> 3.28.2 ``                                                                                      |
| [`2c106c1e`](https://github.com/NixOS/nixpkgs/commit/2c106c1e7c0794927c3b889de51e3c2cdd9130ba) | `` google-chrome: Support GTK 4 (#218572) ``                                                                            |
| [`000960c3`](https://github.com/NixOS/nixpkgs/commit/000960c351145a43cbcbe2ef792fe3a115046059) | `` cosign: add developer-guy to the maintainers ``                                                                      |
| [`f2a1f0cf`](https://github.com/NixOS/nixpkgs/commit/f2a1f0cf82b515f5da2583334288aea59b2d4ff8) | `` maintainers: add developer-guy ``                                                                                    |
| [`ae6dc252`](https://github.com/NixOS/nixpkgs/commit/ae6dc2525ddcb25706f17fe7db1cc089c04b8267) | `` konstraint: 0.25.0 -> 0.25.1 ``                                                                                      |
| [`a3a34145`](https://github.com/NixOS/nixpkgs/commit/a3a34145d3183aa9ed55e1b35f5a6ba604ce221a) | `` otel-cli: 0.1.0 -> 0.2.0 ``                                                                                          |
| [`7f17cacb`](https://github.com/NixOS/nixpkgs/commit/7f17cacb6ade23cee05f055b4dea5276c8b86da0) | `` wolf-shaper: 1.0.0 -> 1.0.1 ``                                                                                       |
| [`e825a158`](https://github.com/NixOS/nixpkgs/commit/e825a158dc79ce22987688ef714a674eff48f27b) | `` orc: fix build with gcc12 on aarch64-linux ``                                                                        |
| [`fe4e3211`](https://github.com/NixOS/nixpkgs/commit/fe4e3211889a553f9d4ee4f93b8e481626913302) | `` protonup-qt: 2.7.4 -> 2.7.7 ``                                                                                       |
| [`3a6f8a58`](https://github.com/NixOS/nixpkgs/commit/3a6f8a5871df0972fbd1566b2226d531acb9dbaf) | `` linuxPackages.nvidia_x11_vulkan_beta: 515.47.06 -> 525.47.11 ``                                                      |
| [`8f7e647c`](https://github.com/NixOS/nixpkgs/commit/8f7e647c3032cf7536c2df117655b08b035f6bfe) | `` linux: enable VIRTIO_MMIO_CMDLINE_DEVICES ``                                                                         |
| [`dc17f0ae`](https://github.com/NixOS/nixpkgs/commit/dc17f0ae4eaab11f4f7d07d4578a15de3159743b) | `` ttfb: cleanup ``                                                                                                     |
| [`137ed8a0`](https://github.com/NixOS/nixpkgs/commit/137ed8a032ca50e1b3b3b29b21026cc872ff9d5d) | `` ansi: cleanup ``                                                                                                     |
| [`2af041ab`](https://github.com/NixOS/nixpkgs/commit/2af041ab44ce4b8c10b015ff3674c0852d193a75) | `` nixos/gitlab-runner: do not pull in Docker if gitlab-runner-clear-docker-cache is disabled ``                        |
| [`1119b007`](https://github.com/NixOS/nixpkgs/commit/1119b007101afa65b2e7a6f3eae28d357388e830) | `` python310Packages.wasmer*: Fix build with maturin 0.14 ``                                                            |
| [`509f32d9`](https://github.com/NixOS/nixpkgs/commit/509f32d9c9262cb76f06d21a811b1bb2f3399ef6) | `` python3Packages.dnspython: fix tests (again) (#218662) ``                                                            |
| [`de8e79c9`](https://github.com/NixOS/nixpkgs/commit/de8e79c9ba13bc023278cf0d35990738108b9b8a) | `` Revert "netcdfcxx4: disable tests" ``                                                                                |
| [`6123056e`](https://github.com/NixOS/nixpkgs/commit/6123056e1840d9d56d7d8723ecd30eeb3df11675) | `` netcdf-cxx4: during tests, use netcdf's installed plugins ``                                                         |
| [`981839f2`](https://github.com/NixOS/nixpkgs/commit/981839f265b5b73dcd12fa9f5fdf78269d27e971) | `` netcdf: install plugins into lib/hdf5-plugins ``                                                                     |
| [`8dbf4797`](https://github.com/NixOS/nixpkgs/commit/8dbf47975942793c7fd9646a038c684dbb05ddce) | `` netcdf: enable parallel building ``                                                                                  |
| [`3e439e7c`](https://github.com/NixOS/nixpkgs/commit/3e439e7cc4bd14893db755d37404305d323d8a0a) | `` netcdf: add bzip2/libzip/zstd dependencies (and allow for szip support; disabled by default because it's nonfree) `` |
| [`28f16257`](https://github.com/NixOS/nixpkgs/commit/28f162579b0a002ed9faa9329e9b68853424b7da) | `` rocclr: 5.4.2 -> 5.4.3 ``                                                                                            |
| [`702dd8ea`](https://github.com/NixOS/nixpkgs/commit/702dd8ea613cf9b11882962c92ef3e3298eb1f0e) | `` nodenv: support more platforms ``                                                                                    |
| [`cb1ee0a7`](https://github.com/NixOS/nixpkgs/commit/cb1ee0a78a2f7e7247809fa3b7aa9e8ba6a8049a) | `` rng-tools: don't use librtlsdr alias ``                                                                              |
| [`cf3243a2`](https://github.com/NixOS/nixpkgs/commit/cf3243a24380e1ba6c6b03b20b864e3046669922) | `` sdrpp: don't use librtlsdr alias ``                                                                                  |
| [`e59f35e7`](https://github.com/NixOS/nixpkgs/commit/e59f35e7f67bf7cb75b9e1c8a9d0bdebd1306d50) | `` guglielmo: don't use librtlsdr alias ``                                                                              |
| [`d729a80b`](https://github.com/NixOS/nixpkgs/commit/d729a80b14e4a5e2d9e3a85c43f7dac1eb7abcbf) | `` cargo-dist: 0.0.2 -> 0.0.3 ``                                                                                        |
| [`2d0a4d55`](https://github.com/NixOS/nixpkgs/commit/2d0a4d55c7c582992dceff56b069577de006ee8f) | `` onlyoffice-bin: add gcc lib to runtimeInputs ``                                                                      |
| [`36ea8625`](https://github.com/NixOS/nixpkgs/commit/36ea86257bfbbc1d7f52f5676082e2f4c33e9b19) | `` nixVersions.nix_2_12: 2.12.0 -> 2.12.1 ``                                                                            |
| [`056b679c`](https://github.com/NixOS/nixpkgs/commit/056b679c35b66515f3305921500a989b3951f1ff) | `` nix-fallback-paths.nix: Update to 2.13.3 ``                                                                          |
| [`aaecc6a7`](https://github.com/NixOS/nixpkgs/commit/aaecc6a7c7a879201d58cb39b333314dce4a17d2) | `` nixVersions.nix_2_13: 2.13.2 -> 2.13.3 ``                                                                            |
| [`a12ccf90`](https://github.com/NixOS/nixpkgs/commit/a12ccf900be540e6c2216f50628b377cd074e9b8) | `` python3.pkgs.wordcloud: 1.8.1 -> unstable-2023-01-04 ``                                                              |
| [`61770c9a`](https://github.com/NixOS/nixpkgs/commit/61770c9a168a5532b9973d28ceb917d296c22498) | `` python310Packages.azure-storage-blob: 12.14.1 -> 12.15.0 ``                                                          |
| [`7b7e2a21`](https://github.com/NixOS/nixpkgs/commit/7b7e2a217eba414f04ba3fde67e651908e4164e6) | `` python310Packages.hg-evolve: 10.5.3 -> 11.0.0 ``                                                                     |
| [`cc7b8d0e`](https://github.com/NixOS/nixpkgs/commit/cc7b8d0e92fae1df8ac03e89ebce0fda01f5e93e) | `` gogs: 0.12.10 -> 0.13.0 ``                                                                                           |
| [`7b6e7dd7`](https://github.com/NixOS/nixpkgs/commit/7b6e7dd796f8fe17f673b7434e9366f2f7dbd67e) | `` electron-bin: move print-hashes.sh script ``                                                                         |
| [`43e79015`](https://github.com/NixOS/nixpkgs/commit/43e79015bf52e90bfe2983e0f1c54e781557d79f) | `` nixos/tests/haproxy: stop using nixos/profiles/minimal ``                                                            |
| [`50800cbe`](https://github.com/NixOS/nixpkgs/commit/50800cbe94a065e3f152e7901d294d66f64985ff) | `` blightmud: 5.0.0 -> 5.1.0 ``                                                                                         |
| [`592fe49f`](https://github.com/NixOS/nixpkgs/commit/592fe49fc7fc4b92e26a0bb85def2d3a2e7d8ccf) | `` haproxy: 2.7.2 -> 2.7.3 ``                                                                                           |
| [`2cbded08`](https://github.com/NixOS/nixpkgs/commit/2cbded08a287aab6721479772604fd2146606290) | `` wezterm: add vulkan-loader to library path (#218410) ``                                                              |
| [`03924558`](https://github.com/NixOS/nixpkgs/commit/039245588c2871c3d62783010dbdd252ae430284) | `` zoom-us: 5.13.7.683 -> 5.13.10.1208 ``                                                                               |
| [`b4c4419b`](https://github.com/NixOS/nixpkgs/commit/b4c4419b05700f5a0af8a9d603f293404d75854e) | `` libwacom-surface: init at 2.4.0 ``                                                                                   |
| [`55f6bccb`](https://github.com/NixOS/nixpkgs/commit/55f6bccb51cfc625c2498c18b64be742ea07f294) | `` apfs-fuse: 2020-09-28 -> 2023-01-04 ``                                                                               |
| [`922fbae5`](https://github.com/NixOS/nixpkgs/commit/922fbae50c3d738d33a963ab0b07afeb9e03a294) | `` python serialio: connunication -> communication ``                                                                   |
| [`ff7dfcba`](https://github.com/NixOS/nixpkgs/commit/ff7dfcba57fd60c53c333285012f78fd48da6920) | `` nixos/opensearch: fix opensearch startup ``                                                                          |
| [`2378d1a2`](https://github.com/NixOS/nixpkgs/commit/2378d1a21466f58e85a0394fef54bfa5a93e7711) | `` nixos/klipper: fix assert message to match actual assertion ``                                                       |
| [`d0f30dbf`](https://github.com/NixOS/nixpkgs/commit/d0f30dbfc8ea09645ac6f008776b8501f9af3d81) | `` zine: 0.11.0 -> 0.11.1 ``                                                                                            |