### PR TITLE
chore(flake/home-manager): `f8077880` -> `68ba5957`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677704978,
-        "narHash": "sha256-3ijjQ5Vb51NdHvslbCpG8/UZ61ECcogxguRqgknlejc=",
+        "lastModified": 1678006026,
+        "narHash": "sha256-cGOfrU7JsKHAWXbPVDTOu2yyMb7GeWdUtJQNQSqht+w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f8077880359b72bbd290ee216b105f200a6f7cc7",
+        "rev": "68ba59578352815ac372b17fb3df9db39afb1407",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`68ba5957`](https://github.com/nix-community/home-manager/commit/68ba59578352815ac372b17fb3df9db39afb1407) | `` xfconf: fix dbus may not be started in the startup of NixOS. (#3707) ``   |
| [`3c18113b`](https://github.com/nix-community/home-manager/commit/3c18113bd768ae925b383867d1821563391ecab6) | `` mpd: add `extraArgs` (#3735) ``                                           |
| [`b9e3a298`](https://github.com/nix-community/home-manager/commit/b9e3a29864798d55ec1d6579ab97876bb1ee9664) | `` recoll: fix generation of string lists ``                                 |
| [`547a3bc8`](https://github.com/nix-community/home-manager/commit/547a3bc8d464cb2a22e4cf0dbbb746f8c654151a) | `` git: allow tags to be unsigned when signing.signByDefault=true (#3479) `` |
| [`db1c2262`](https://github.com/nix-community/home-manager/commit/db1c22626ad1058834f043eae7d80bbf2a8e1532) | `` mako: programs.mako -> services.mako (#3265) ``                           |