### PR TITLE
chore(flake/nixpkgs): `68196a61` -> `a08d6979`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -198,11 +198,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677587185,
-        "narHash": "sha256-zYT66MAYwctAQqI5VBw3LbBXiSKdB8vuMAqCGG8onbE=",
+        "lastModified": 1677676435,
+        "narHash": "sha256-6FxdcmQr5JeZqsQvfinIMr0XcTyTuR7EXX0H3ANShpQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68196a61c26748d3e53a6803de3d2f8c69f27831",
+        "rev": "a08d6979dd7c82c4cef0dcc6ac45ab16051c1169",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`fea42519`](https://github.com/NixOS/nixpkgs/commit/fea42519a41102668eb215a6cb4a883a88b4b236) | `` ocaml: 4.14.0 -> 4.14.1 ``                                             |
| [`08b9cec3`](https://github.com/NixOS/nixpkgs/commit/08b9cec3b5fc7b6bb17efe0dd3f5995ad4846ff1) | `` gnome-icon-theme: ensure empty runtime closure ``                      |
| [`1b0c89ab`](https://github.com/NixOS/nixpkgs/commit/1b0c89ab599ea2088e390acbd39be12260487938) | `` gnome-icon-theme: fix cross ``                                         |
| [`b7cfef7e`](https://github.com/NixOS/nixpkgs/commit/b7cfef7e043884ab955612d85e54d182303607c5) | `` flyctl: 0.470 -> 0.473 ``                                              |
| [`54b1d155`](https://github.com/NixOS/nixpkgs/commit/54b1d155046952c41c79bb0a7da834f52effe3b4) | `` xmind: add meta.mainProgram ``                                         |
| [`eaace184`](https://github.com/NixOS/nixpkgs/commit/eaace18465ca477645cfffa391d21ab55c2db725) | `` matrix-synapse: 1.77.0 -> 1.78.0 ``                                    |
| [`81218d82`](https://github.com/NixOS/nixpkgs/commit/81218d829ba617e3494c5d949562055e22ba1abd) | `` babl: 0.1.98 → 0.1.100 ``                                              |
| [`20bd2738`](https://github.com/NixOS/nixpkgs/commit/20bd2738a40d13d006bde8ee2cf42c605af05bf5) | `` gnome-photos: support babel 0.1.100 ``                                 |
| [`c1a55b82`](https://github.com/NixOS/nixpkgs/commit/c1a55b8249eeb7a5b394e50f3ed6287ef2c303d2) | `` gimp: 2.10.32 → 2.10.34 ``                                             |
| [`d6aa0204`](https://github.com/NixOS/nixpkgs/commit/d6aa02046bfaf4f44bf28b51f622787973946ad6) | `` gegl: 0.4.40 → 0.4.42 ``                                               |
| [`1662bbb5`](https://github.com/NixOS/nixpkgs/commit/1662bbb5fb786d57473d9c6b5cdef5376fea936e) | `` coqPackages.smtcoq.cvc4: fix build with bash 5.2 ``                    |
| [`82d2212d`](https://github.com/NixOS/nixpkgs/commit/82d2212d29ca5e7536451d735750ce669087f322) | `` compcert: 3.11 → 3.12 ``                                               |
| [`48e43dd6`](https://github.com/NixOS/nixpkgs/commit/48e43dd6617f3a8b2656bcd6a10d5a02ba5145b7) | `` logseq: 0.8.17 -> 0.8.18 ``                                            |
| [`4b577494`](https://github.com/NixOS/nixpkgs/commit/4b577494fd9c74a3fdca082bdd2f9445fb04a49c) | `` libgee: clean up ``                                                    |
| [`4a40c0ab`](https://github.com/NixOS/nixpkgs/commit/4a40c0ab8a0ba7b969f4e9a11923dad79df30b5f) | `` conmon: 2.1.6 -> 2.1.7 ``                                              |
| [`e8884540`](https://github.com/NixOS/nixpkgs/commit/e8884540b5b5ffaa0bd18b10ae276f9cc76d9ef3) | `` cargo-llvm-cov: 0.5.10 -> 0.5.11 ``                                    |
| [`9dd52da7`](https://github.com/NixOS/nixpkgs/commit/9dd52da7cdb4b3a13230f147fc9dbe67d17bda2b) | `` python311Packages.junos-eznc: patch inspect.getargspec ``              |
| [`5f39a337`](https://github.com/NixOS/nixpkgs/commit/5f39a3378beedc33ba17f2e9aae93c67f918db99) | `` python310Packages.junos-eznc: add changelog to meta ``                 |
| [`ee7e4139`](https://github.com/NixOS/nixpkgs/commit/ee7e41392f5ab9438df22e5d2b69f15565125a7b) | `` deepin.deepin-camera: move NIX_CFLAGS_COMPILE to the env attrset ``    |
| [`c457b8f2`](https://github.com/NixOS/nixpkgs/commit/c457b8f256043aba5dacc4aa844fc03c3fc581a5) | `` python310Packages.asyncwhois: 1.0.2 -> 1.0.3 ``                        |
| [`5d9c3e7e`](https://github.com/NixOS/nixpkgs/commit/5d9c3e7ec20f2af335b6809cec5060a65905b792) | `` python310Packages.pydata-sphinx-theme: 0.13.0rc6 -> 0.13.0 ``          |
| [`a681323b`](https://github.com/NixOS/nixpkgs/commit/a681323bcc76d40ebb18f406dff3bf845f2fd149) | `` python310Packages.sunweg: 0.0.11 -> 1.0.0 ``                           |
| [`92ad4b79`](https://github.com/NixOS/nixpkgs/commit/92ad4b792cae0bfa9c29d6fb030850c8c24dd01f) | `` python310Packages.reolink-aio: 0.5.1 -> 0.5.2 ``                       |
| [`784a88b8`](https://github.com/NixOS/nixpkgs/commit/784a88b8eff853de378c40712442582910d2f1e1) | `` trufflehog: 3.28.3 -> 3.28.4 ``                                        |
| [`85246c3f`](https://github.com/NixOS/nixpkgs/commit/85246c3f388dfc54ac0c83422ebda0b387e0479f) | `` python310Packages.pontos: 23.2.10 -> 23.2.12 ``                        |
| [`7b4ce6bb`](https://github.com/NixOS/nixpkgs/commit/7b4ce6bbc8187fd190f56765cd96fe8213f9ecec) | `` trufflehog: 3.28.2 -> 3.28.3 ``                                        |
| [`caac1223`](https://github.com/NixOS/nixpkgs/commit/caac122399aca717ec5ee76cefa19560f8ca0faa) | `` worker-build: 0.0.12 -> 0.0.13 ``                                      |
| [`d07f292e`](https://github.com/NixOS/nixpkgs/commit/d07f292e550c7ab1c108e7e98e0d90fe5756380a) | `` python310Packages.junos-eznc: 2.6.6 -> 2.6.7 ``                        |
| [`9df748f5`](https://github.com/NixOS/nixpkgs/commit/9df748f599da933a7ca8d8fb49cd4dea0d013793) | `` Revert "workflows: pin install-nix-action to use nix 2.13.3" ``        |
| [`6a174c65`](https://github.com/NixOS/nixpkgs/commit/6a174c65c28d9594d0bc855869c0c0d833873e71) | `` .github/workflows: update cachix/install-nix-action to v20 ``          |
| [`a4d5b853`](https://github.com/NixOS/nixpkgs/commit/a4d5b8533a63efe74ac484b2d00f351f4da5a9c8) | `` ugrep: 3.9.7 -> 3.10.0 ``                                              |
| [`3b9518f1`](https://github.com/NixOS/nixpkgs/commit/3b9518f1aeb69e3edb80483ea90f1dd598e7f60e) | `` python310Packages.toposort: 1.9 -> 1.10 ``                             |
| [`d680957e`](https://github.com/NixOS/nixpkgs/commit/d680957e110a76f30f1986be839f7b3498b58f26) | `` containerd: 1.6.18 -> 1.6.19 ``                                        |
| [`8aa433fd`](https://github.com/NixOS/nixpkgs/commit/8aa433fd6460f9aa5e119b82b4cebd7aff91ebd6) | `` treewide: pin packages with failures to go 1.19 ``                     |
| [`06c5a4d8`](https://github.com/NixOS/nixpkgs/commit/06c5a4d8c9e927cc9a257414bd3914130bd23566) | `` terraform-providers.snowflake: 0.56.5 → 0.57.0 ``                      |
| [`f2995531`](https://github.com/NixOS/nixpkgs/commit/f2995531d041edaf830dfa0cf6f404357cc8c3e4) | `` terraform-providers.scaleway: 2.11.1 → 2.12.0 ``                       |
| [`0c21ea6a`](https://github.com/NixOS/nixpkgs/commit/0c21ea6a855f7a1ed74d5b7a27b3a1aeaf4723c8) | `` terraform-providers.launchdarkly: 2.10.0 → 2.11.0 ``                   |
| [`1c2d6305`](https://github.com/NixOS/nixpkgs/commit/1c2d630513ac5bdedfc5ffb696e32423db99a69a) | `` terraform-providers.dnsimple: 0.15.0 → 0.16.0 ``                       |
| [`1251ac58`](https://github.com/NixOS/nixpkgs/commit/1251ac584c210cb635aa14e859446889b89fe195) | `` python310Packages.srsly: 2.4.5 -> 2.4.6 ``                             |
| [`5c72d17b`](https://github.com/NixOS/nixpkgs/commit/5c72d17b21221b21df7fab1128b8f738fa3c0da5) | `` python310Packages.twitchapi: 3.8.0 -> 3.9.0 ``                         |
| [`8f7660bd`](https://github.com/NixOS/nixpkgs/commit/8f7660bddfe384be08a658305c1f5e5f4665e108) | `` python310Packages.pyrogram: 2.0.99 -> 2.0.100 ``                       |
| [`45b33173`](https://github.com/NixOS/nixpkgs/commit/45b33173d6f9f4fdbf1e3ebab76685d4a36ffe9a) | `` ipxe: unstable-2023-02-20 -> unstable-2023-02-28 ``                    |
| [`d5dfcf22`](https://github.com/NixOS/nixpkgs/commit/d5dfcf220a590a1a539b98d80ab1b786233e2276) | `` clusterctl: 1.3.3 -> 1.3.4 ``                                          |
| [`9eae4723`](https://github.com/NixOS/nixpkgs/commit/9eae4723b3c19eceb318ef08faa9724d672f65cb) | `` d2: 0.2.1 -> 0.2.2 ``                                                  |
| [`074245ae`](https://github.com/NixOS/nixpkgs/commit/074245aea0e9613241f26669e51ac8f72a27531f) | `` lefthook: 1.3.2 -> 1.3.3 ``                                            |
| [`7773d61a`](https://github.com/NixOS/nixpkgs/commit/7773d61a07d1da96a8fadc8cbe1be9366b028738) | `` miniserve: 0.22.0 -> 0.23.0 ``                                         |
| [`6340fcc6`](https://github.com/NixOS/nixpkgs/commit/6340fcc6a9ebb78d16b674d462508ee467884e96) | `` proj: fix test suite (#218719) ``                                      |
| [`ecd57170`](https://github.com/NixOS/nixpkgs/commit/ecd57170875170b8e487b4ab2aad0d460700dc76) | `` wangle: 2023.02.20.00 -> 2023.02.27.00 ``                              |
| [`6e3507b1`](https://github.com/NixOS/nixpkgs/commit/6e3507b17499fbef955541cfde00cca2c86a5852) | `` lefthook: 1.2.9 -> 1.3.2 ``                                            |
| [`220e3491`](https://github.com/NixOS/nixpkgs/commit/220e3491c57bbf5557e7a56378c1c218cd535f3e) | `` air: 1.41.0 -> 1.42.0 ``                                               |
| [`7a6bbe39`](https://github.com/NixOS/nixpkgs/commit/7a6bbe39701e26ff2ccdc320169b0c3fb6da8012) | `` d2: 0.2.0 -> 0.2.1 ``                                                  |
| [`2010b76f`](https://github.com/NixOS/nixpkgs/commit/2010b76f58fbbd18aefee401c6606c2f268ac287) | `` yubikey-touch-detector: 1.10.0 -> 1.10.1 ``                            |
| [`d0e6ae38`](https://github.com/NixOS/nixpkgs/commit/d0e6ae382a68a2c1151567d509e829e8585530ad) | `` yubikey-manager4: cleanup ``                                           |
| [`4abfe25f`](https://github.com/NixOS/nixpkgs/commit/4abfe25fafccd0beb911e13ad4ae58a5b99e720c) | `` yubikey-manager4: fix build ``                                         |
| [`1b564ea8`](https://github.com/NixOS/nixpkgs/commit/1b564ea8485e39827295a247cc3a778100fc8e88) | `` python310Packages.psrpcore: 0.2.1 -> 0.2.2 ``                          |
| [`41f45c32`](https://github.com/NixOS/nixpkgs/commit/41f45c329f8e6641c4e79463fcfd2cffaa1b39e6) | `` ocamlPackages.shine: 0.2.2 -> 0.2.3 ``                                 |
| [`1b66e8cf`](https://github.com/NixOS/nixpkgs/commit/1b66e8cffc44c0dc82d4f68cd2d6f5fcce0a5bcc) | `` ocamlPackages.ffmpeg: 1.1.6 -> 1.1.7 ``                                |
| [`4cdf5cd0`](https://github.com/NixOS/nixpkgs/commit/4cdf5cd02481d56685cf675b12d4dc261db96026) | `` ocamlPackages.mm: 0.8.1 -> 0.8.2 ``                                    |
| [`3603891b`](https://github.com/NixOS/nixpkgs/commit/3603891b63e0ad837b75c335ccf8ac6acec66a50) | `` vscode-extensions.eamodio.gitlens: 2023.2.1404 -> 2023.2.2804 ``       |
| [`5280ef56`](https://github.com/NixOS/nixpkgs/commit/5280ef56982254d1b713ca290d7ea7c2c21d3cd9) | `` python310Packages.auroranoaa: 0.0.2 -> 0.0.3 ``                        |
| [`4130d1b8`](https://github.com/NixOS/nixpkgs/commit/4130d1b884ecda501f31f2a0ffabdf9cd9e1bf73) | `` exploitdb: 2023-02-03 -> 2023-02-28 ``                                 |
| [`ed9386a0`](https://github.com/NixOS/nixpkgs/commit/ed9386a0509e81f92822dee0c07e43aebf079d06) | `` cpuid: 20230120 -> 20230228 ``                                         |
| [`8695787b`](https://github.com/NixOS/nixpkgs/commit/8695787be7b0aaec71f367bb753f17c322db2bff) | `` python310Packages.weconnect-mqtt: 0.42.1 -> 0.42.2 ``                  |
| [`b36f3974`](https://github.com/NixOS/nixpkgs/commit/b36f3974b8d60eddf6f3eae1c9dc61e4f091d602) | `` python310Packages.weconnect: relax ascii_magic constraint ``           |
| [`036d2a37`](https://github.com/NixOS/nixpkgs/commit/036d2a376efd8cf260ea0492c1eebeb7dbe07053) | `` python310Packages.ascii-magic: 2.1.1 -> 2.3.0 ``                       |
| [`74cbd2b7`](https://github.com/NixOS/nixpkgs/commit/74cbd2b79c6c42face4302ce5fcc113e64eacea1) | `` python310Packages.haversine: 2.7.0 -> 2.8.0 ``                         |
| [`8cba148e`](https://github.com/NixOS/nixpkgs/commit/8cba148eaca12d43e60a09f2d3a593e85a5c6bee) | `` rocsparse: 5.4.2 -> 5.4.3 ``                                           |
| [`62dcd158`](https://github.com/NixOS/nixpkgs/commit/62dcd158d3e6b49fce660aa53da17145cb66ac89) | `` eventstat: 0.05.00 -> 0.05.01 ``                                       |
| [`204e4756`](https://github.com/NixOS/nixpkgs/commit/204e4756029cd23c8696b5ae164cb965994ac1cf) | `` mailutils: disable tests on darwin ``                                  |
| [`5c6e41f6`](https://github.com/NixOS/nixpkgs/commit/5c6e41f6cee4ab889caf71fb400688c3a699624b) | `` python310Packages.angr: 9.2.39 -> 9.2.40 ``                            |
| [`40c4e9dc`](https://github.com/NixOS/nixpkgs/commit/40c4e9dca58911cea2245163ed118efab01d6fd4) | `` python310Packages.cle: 9.2.39 -> 9.2.40 ``                             |
| [`8a980cd2`](https://github.com/NixOS/nixpkgs/commit/8a980cd28e9ff6de682c56c2c61610e159f06870) | `` python310Packages.claripy: 9.2.39 -> 9.2.40 ``                         |
| [`7d1f96b0`](https://github.com/NixOS/nixpkgs/commit/7d1f96b0bf9505aec000478249b63e982b5ea060) | `` python310Packages.pyvex: 9.2.39 -> 9.2.40 ``                           |
| [`d663a19f`](https://github.com/NixOS/nixpkgs/commit/d663a19fe84617bb938a7153b79bfc8133640642) | `` python310Packages.ailment: 9.2.39 -> 9.2.40 ``                         |
| [`5573b8dc`](https://github.com/NixOS/nixpkgs/commit/5573b8dc566f0e9269af299ff3f32fded7c0b759) | `` python310Packages.archinfo: 9.2.39 -> 9.2.40 ``                        |
| [`bdfb775f`](https://github.com/NixOS/nixpkgs/commit/bdfb775fbe0df86e7fe4ba7c46a42e86e81116cd) | `` frogatto: unstable-2020-12-04 -> unstable-2023-02-27 ``                |
| [`2b554db6`](https://github.com/NixOS/nixpkgs/commit/2b554db6c0cc0b8f26db0d316dd925e8b94fc28b) | `` gleam: 0.25.3 -> 0.26.2 ``                                             |
| [`2aea26ed`](https://github.com/NixOS/nixpkgs/commit/2aea26edc2fe01cbd7a50328288b9d8a73933b28) | `` nodePackages: update them all (#218736) ``                             |
| [`d34eea8f`](https://github.com/NixOS/nixpkgs/commit/d34eea8f499ec37cc58d506d0c42a243c763a8e3) | `` libreddit: 0.29.3 -> 0.29.4 ``                                         |
| [`3563c178`](https://github.com/NixOS/nixpkgs/commit/3563c178ca7d45d028c095b2a3ba35ee28294eea) | `` workflows: pin install-nix-action to use nix 2.13.3 ``                 |
| [`210852bd`](https://github.com/NixOS/nixpkgs/commit/210852bd518f8a79d78b26419c5e4e169dd13fbe) | `` pdfstudio: gcc -> stdenv.cc.cc ``                                      |
| [`bb7879af`](https://github.com/NixOS/nixpkgs/commit/bb7879af9299476d4b10564ef8d781a691f65f00) | `` scraper: 0.14.0 -> 0.15.0 ``                                           |
| [`19a122e0`](https://github.com/NixOS/nixpkgs/commit/19a122e092517d5530154c7f85117a9840b9125d) | `` ci: editorconfig: use nix-shell instead of nix-env ``                  |
| [`f4e48a37`](https://github.com/NixOS/nixpkgs/commit/f4e48a372d747669025ab305e75c07a639e6c101) | `` webex: 42.12.0.24485 -> 43.2.0.25211 ``                                |
| [`1aab1595`](https://github.com/NixOS/nixpkgs/commit/1aab159514d58256b0e5235fdd795b48d886e793) | `` werf: 1.2.199 -> 1.2.202 ``                                            |
| [`64ff965c`](https://github.com/NixOS/nixpkgs/commit/64ff965cf84ccbbc9ea8aa9b32ccf39e52cd5dfc) | `` pulumi-bin: 3.54.0 -> 3.55.0 ``                                        |
| [`b71b395f`](https://github.com/NixOS/nixpkgs/commit/b71b395f62abad9e11bb12a1c079d6e6969eedc1) | `` jira_cli: remove ``                                                    |
| [`c72a3095`](https://github.com/NixOS/nixpkgs/commit/c72a30954f1aaa1d82406283e92413f71e0b90b1) | `` plasma: 5.27.1 -> 5.27.2 ``                                            |
| [`2ce6d739`](https://github.com/NixOS/nixpkgs/commit/2ce6d7392a8bb235fce03c0b9ef3157f86217b45) | `` rtl88x2bu: 2022-12-17 -> 2023-02-24 ``                                 |
| [`45ee5cbf`](https://github.com/NixOS/nixpkgs/commit/45ee5cbf63b01a7edd3f742e09c7b84b1bdeb045) | `` cargo-hack: 0.5.27 -> 0.5.28 ``                                        |
| [`36e65418`](https://github.com/NixOS/nixpkgs/commit/36e654185065cc26117ffac4ec3031a43c7533c7) | `` python310Packages.suseapi: remove ``                                   |
| [`31f780bf`](https://github.com/NixOS/nixpkgs/commit/31f780bf67407348c2362219997305a50a9402b9) | `` python310Packages.weconnect: 0.54.0 -> 0.54.1 ``                       |
| [`cfc46fb3`](https://github.com/NixOS/nixpkgs/commit/cfc46fb39a33e59942b62f7538298cc937d4215f) | `` python310Packages.types-dateutil: 2.8.19.8 -> 2.8.19.9 ``              |
| [`ab42f6fd`](https://github.com/NixOS/nixpkgs/commit/ab42f6fdb48096ebd9823df9029c51d0818b4ab2) | `` firefox-beta-bin-unwrapped: 111.0b5 -> 111.0b6 ``                      |
| [`c3bc7b1b`](https://github.com/NixOS/nixpkgs/commit/c3bc7b1bcb7a6da680507c01d058a6d506bed69f) | `` fluxcd: 0.40.1 -> 0.40.2 ``                                            |
| [`6f1d2013`](https://github.com/NixOS/nixpkgs/commit/6f1d2013c0f6df93cd0164b3cdcc24eaed5d46f8) | `` git-cola: run tests ``                                                 |
| [`78e3d43b`](https://github.com/NixOS/nixpkgs/commit/78e3d43ba45e0fd1681ac06d81fb66b26d259dd9) | `` unciv: 4.4.19 -> 4.5.1 ``                                              |
| [`95e89adf`](https://github.com/NixOS/nixpkgs/commit/95e89adfb7769ca0129576477795711d6863e711) | `` regctl: 0.4.5 -> 0.4.7 ``                                              |
| [`b850f713`](https://github.com/NixOS/nixpkgs/commit/b850f713c41552e8c3e9bb96ab27f3b9bde13c8c) | `` oh-my-posh: 14.2.7 -> 14.9.1 ``                                        |
| [`2e07ef87`](https://github.com/NixOS/nixpkgs/commit/2e07ef872d5efc15cda8e0f5d9679903c855e65f) | `` checkstyle: 10.7.0 -> 10.8.0 ``                                        |
| [`39caebab`](https://github.com/NixOS/nixpkgs/commit/39caebaba5927b791d6916052a0b31ffc64c7139) | `` rl-2305: Mention Pantheon 7 & Mutter 42 update ``                      |
| [`f685834e`](https://github.com/NixOS/nixpkgs/commit/f685834edf44b1401f788dd08cc369dde6f825d3) | `` pantheon.wingpanel-applications-menu: 2.11.0 -> 2.11.1 ``              |
| [`f9ea95f0`](https://github.com/NixOS/nixpkgs/commit/f9ea95f0df1a8a8e52f2498d8e5d75fc8f07480c) | `` pantheon.elementary-default-settings: 6.0.2 -> 7.0.1 ``                |
| [`3da565c1`](https://github.com/NixOS/nixpkgs/commit/3da565c170edd16efa5503f958005d8184dc9c5c) | `` pantheon.elementary-shortcut-overlay: 1.2.1 -> 2.0.1 ``                |
| [`5d5e8537`](https://github.com/NixOS/nixpkgs/commit/5d5e8537018986a131e76a0e8f0b83ddf38aedc0) | `` pantheon.switchboard-plug-keyboard: Adjust GSD & Gala schema change `` |
| [`7f1e7923`](https://github.com/NixOS/nixpkgs/commit/7f1e79239be0d65634dadede08e6f3c658728a38) | `` pantheon.switchboard-plug-mouse-touchpad: 6.1.0 -> 7.0.0 ``            |
| [`93a524db`](https://github.com/NixOS/nixpkgs/commit/93a524dba0299e2096643635bcf87dc5c23a97aa) | `` git-cola: update dependencies and make it work in darwin ``            |
| [`6eec5051`](https://github.com/NixOS/nixpkgs/commit/6eec505196c94945703a197b6aee07aabf85d9fe) | `` pantheon.gala: 6.3.1 -> 7.0.1 ``                                       |
| [`3a97d63d`](https://github.com/NixOS/nixpkgs/commit/3a97d63d5c4f06c3909fc7a78f6c6e65ead4478d) | `` pantheon.gnome-settings-daemon: 3.38.2 -> 42.2 ``                      |
| [`cae5a65c`](https://github.com/NixOS/nixpkgs/commit/cae5a65c90871aaeeb346e0d986b9de1310a66af) | `` pantheon.mutter: 3.38.6 -> 42.7 ``                                     |
| [`7fcb2ae4`](https://github.com/NixOS/nixpkgs/commit/7fcb2ae4b53b8402ff30fa808e6e5aeb8666fbca) | `` dotnet-sdk_8: init at 8.0.100-preview.1.23115.2 ``                     |
| [`a4bb6c3c`](https://github.com/NixOS/nixpkgs/commit/a4bb6c3c49e2c78290832d34254fda7fb16bbf4a) | `` devspace: 6.2.5 -> 6.3.0 ``                                            |
| [`87cb67b8`](https://github.com/NixOS/nixpkgs/commit/87cb67b8c6ef4c708667909d7c65c04e09403f16) | `` lzwolf: pin SDL2_mixer to 2.0.x ``                                     |
| [`6ef8111c`](https://github.com/NixOS/nixpkgs/commit/6ef8111cc762e85ccc2a5fb57529fab1837f88bf) | `` vt-cli: add mainProgram ``                                             |
| [`0536b97f`](https://github.com/NixOS/nixpkgs/commit/0536b97fb49f7c42ef84621ef87f6bb0ff64d66a) | `` vt-cli: add changelog to meta ``                                       |
| [`e07edafb`](https://github.com/NixOS/nixpkgs/commit/e07edafb95211338ebeba5282f07639702582857) | `` python311Packages.pygame: marked broken for python >3.11 ``            |
| [`71aac402`](https://github.com/NixOS/nixpkgs/commit/71aac402cce3f2e895875624871e98c35d408fa2) | `` SDL2_mixer_2_0: init at 2.0.4 ``                                       |
| [`008a86b2`](https://github.com/NixOS/nixpkgs/commit/008a86b223df66253c5d7c22edbc42a64ab1a14e) | `` strace: 6.1 -> 6.2 ``                                                  |
| [`f3a39f21`](https://github.com/NixOS/nixpkgs/commit/f3a39f218ae33cbebb6f26601bc083f8e1e22ee4) | `` python311Packages.psrpcore: disable failing tests on Python 3.11 ``    |
| [`aa5fe70f`](https://github.com/NixOS/nixpkgs/commit/aa5fe70f46f41e2dc11b11d94b719d5366422cd0) | `` python2.pkgs.pysparse: drop ``                                         |
| [`9900c9ea`](https://github.com/NixOS/nixpkgs/commit/9900c9eaad0662e6beffe6942b30fb362dbce1a1) | `` mautrix-telegram: unstable-2023-02-16 -> 0.13.0 ``                     |
| [`96765056`](https://github.com/NixOS/nixpkgs/commit/9676505649de376abec72bc104c5f37458375bd0) | `` flyway: 9.15.0 -> 9.15.1 ``                                            |
| [`d6effdc6`](https://github.com/NixOS/nixpkgs/commit/d6effdc692304be756e5b84dbace75e90c37aa2d) | `` rubyPackages.fiddle: add libffi to dependencies ``                     |
| [`95df4033`](https://github.com/NixOS/nixpkgs/commit/95df4033fc9febdcb57b5d6706c6db7cdb5bba71) | `` python310Packages.pypsrp: disable failing tests ``                     |
| [`b6b62949`](https://github.com/NixOS/nixpkgs/commit/b6b62949e7365c606a7a1577b642de0ffea956e3) | `` python310Packages.pypsrp: add changelog to meta ``                     |
| [`b17c7d1b`](https://github.com/NixOS/nixpkgs/commit/b17c7d1ba4ec14a690ce8b6a0177beb3181e11bb) | `` gitleaks: 8.15.4 -> 8.16.0 ``                                          |
| [`cb361de4`](https://github.com/NixOS/nixpkgs/commit/cb361de4e7a1222b253b6f2d4c4de090e529b576) | `` evans: 0.10.10 -> 0.10.11 ``                                           |