### PR TITLE
chore(flake/nixpkgs): `a08d6979` -> `3c5319ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -198,11 +198,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677676435,
-        "narHash": "sha256-6FxdcmQr5JeZqsQvfinIMr0XcTyTuR7EXX0H3ANShpQ=",
+        "lastModified": 1677932085,
+        "narHash": "sha256-+AB4dYllWig8iO6vAiGGYl0NEgmMgGHpy9gzWJ3322g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a08d6979dd7c82c4cef0dcc6ac45ab16051c1169",
+        "rev": "3c5319ad3aa51551182ac82ea17ab1c6b0f0df89",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`3f7908a1`](https://github.com/NixOS/nixpkgs/commit/3f7908a1ecd1344d43654e9dc72cc6c671d5857c) | `` python310Packages.pykeyatome: 2.1.1 -> 2.1.2 ``                                  |
| [`e8fbf83f`](https://github.com/NixOS/nixpkgs/commit/e8fbf83f5e697a3d1fe1ca2fb8b74ba75dabc040) | `` nixos/virtualbox-image: remove the raw image trick ``                            |
| [`9692e965`](https://github.com/NixOS/nixpkgs/commit/9692e965c64ab57aabb90285028e3e2e73430f9f) | `` virtualbox: 6.1.40 -> 7.0.6 ``                                                   |
| [`5a676e73`](https://github.com/NixOS/nixpkgs/commit/5a676e73bffe76a16f56a8aed6a7141e8484ca61) | `` python310Packages.angrop: 9.2.7 -> 9.2.8 ``                                      |
| [`004d858d`](https://github.com/NixOS/nixpkgs/commit/004d858df899a7096f508dc7d76649f96b01577e) | `` rekor: add developer-guy to maintainers list ``                                  |
| [`3330d1de`](https://github.com/NixOS/nixpkgs/commit/3330d1de1d6fd0a72058dbf8b2da007b83cb747e) | `` prometheus-redis-exporter: 1.47.0 -> 1.48.0 ``                                   |
| [`58347c6d`](https://github.com/NixOS/nixpkgs/commit/58347c6d96a12ea7d4691f9ace76ce2d1be2c80a) | `` waf-tester: add changelog to meta ``                                             |
| [`1d6febd8`](https://github.com/NixOS/nixpkgs/commit/1d6febd896ea08065fc0a70893d4ff3db11194af) | `` automatic-timezoned: 1.0.62 -> 1.0.68 ``                                         |
| [`c0161445`](https://github.com/NixOS/nixpkgs/commit/c016144591b351e6ade3a5e54e619baa0acfe135) | `` grafana: 9.4.2 -> 9.4.3 ``                                                       |
| [`1bca4bbc`](https://github.com/NixOS/nixpkgs/commit/1bca4bbc8aea29fce9ab85bc796a8cfae9e8f1b4) | `` waf-tester: 0.6.12 -> 0.6.13 ``                                                  |
| [`546a42df`](https://github.com/NixOS/nixpkgs/commit/546a42df3cdc3bdf85bd5c8fd7b4faf89d996af3) | `` mwic: 0.7.9 -> 0.7.10 ``                                                         |
| [`52006da6`](https://github.com/NixOS/nixpkgs/commit/52006da65b2d65d8d576975b2ee8e52c46f68a09) | `` nixos/release-*: finish dropping the conntrack tests ``                          |
| [`32bc50dc`](https://github.com/NixOS/nixpkgs/commit/32bc50dc369e3c0ee6e7516b6766c4a3cfe2a498) | `` lkl: add raitobezarius to maintainers ``                                         |
| [`dc01a822`](https://github.com/NixOS/nixpkgs/commit/dc01a822821a033f188987a4a861cfe4381914ba) | `` lkl: add note for future update attempts ``                                      |
| [`84f3520c`](https://github.com/NixOS/nixpkgs/commit/84f3520c8ff96b0eb10b9d511e630c5bace07c29) | `` nixos/tests/nat: remove conntrack helpers test ``                                |
| [`18f85de7`](https://github.com/NixOS/nixpkgs/commit/18f85de76dac7d3a86767be3aea313a1add5ec67) | `` nixos/firewall: assert that the kernel supports conntrack helper auto-loading `` |
| [`0bba5cdd`](https://github.com/NixOS/nixpkgs/commit/0bba5cdd8ce70f07500910703721b4e9e52a0889) | `` python310Packages.peaqevcore: 12.2.1 -> 12.2.6 ``                                |
| [`f0ea95c2`](https://github.com/NixOS/nixpkgs/commit/f0ea95c2c7d52a5a6dcef105c97343d46749382a) | `` osu-lazer: 2023.207.0 -> 2023.301.0 ``                                           |
| [`7f76ed40`](https://github.com/NixOS/nixpkgs/commit/7f76ed40100aeb413ef019b5c0f116038d83e546) | `` osu-lazer-bin: 2023.207.0 -> 2023.301.0 ``                                       |
| [`f6f9829f`](https://github.com/NixOS/nixpkgs/commit/f6f9829f50dc13807565b2b7d41fbbc0f41b9ba7) | `` atuin: fix build on darwin ``                                                    |
| [`ce2f08f1`](https://github.com/NixOS/nixpkgs/commit/ce2f08f142ab289720f317f2f8d313e6347e67db) | `` terraform-providers.tencentcloud: 1.79.12 → 1.79.13 ``                           |
| [`140fadb4`](https://github.com/NixOS/nixpkgs/commit/140fadb426b7c2fa0a4c11af6aeb785ee34a99a9) | `` terraform-providers.snowflake: 0.57.0 → 0.58.0 ``                                |
| [`f0d64d84`](https://github.com/NixOS/nixpkgs/commit/f0d64d844b5b540353ff32282370dc2cfe148576) | `` terraform-providers.ns1: 1.13.4 → 2.0.0 ``                                       |
| [`828ffa71`](https://github.com/NixOS/nixpkgs/commit/828ffa7112b90d7fefa4c2709d37087c5a56e271) | `` terraform-providers.ksyun: 1.3.64 → 1.3.66 ``                                    |
| [`13f6bc07`](https://github.com/NixOS/nixpkgs/commit/13f6bc07111fc875402734e37f2941b1267209d8) | `` terraform-providers.ibm: 1.50.0 → 1.51.0 ``                                      |
| [`9d4587ae`](https://github.com/NixOS/nixpkgs/commit/9d4587aec8bfdbac21acceb109e6fc83ab7ea931) | `` terraform-providers.aws: 4.56.0 → 4.57.0 ``                                      |
| [`58cbbfbc`](https://github.com/NixOS/nixpkgs/commit/58cbbfbc78638f86ff761340239384a5fbd1e78e) | `` terraform-providers.huaweicloud: 1.44.2 → 1.45.0 ``                              |
| [`ad344d3e`](https://github.com/NixOS/nixpkgs/commit/ad344d3e2ed66ab5cff5497c38f8099a0216b815) | `` terraform-providers.flexibleengine: 1.36.0 → 1.36.1 ``                           |
| [`c8164056`](https://github.com/NixOS/nixpkgs/commit/c816405620ec1e1f10f2a4d44c1ab208c2542d86) | `` terraform-providers.equinix: 1.12.0 → 1.13.0 ``                                  |
| [`70126da3`](https://github.com/NixOS/nixpkgs/commit/70126da303672d743b03fdfcf25e5e50dca5dce8) | `` terraform-providers.azuread: 2.35.0 → 2.36.0 ``                                  |
| [`7fe2256c`](https://github.com/NixOS/nixpkgs/commit/7fe2256c99842bfeb1b3cc0af762d50614efe3b4) | `` terraform-providers.alicloud: 1.199.0 → 1.200.0 ``                               |
| [`3696038c`](https://github.com/NixOS/nixpkgs/commit/3696038c3dce4a2f2316ea3f640bbc9a878feca0) | `` terraform-providers.auth0: 0.44.0 → 0.44.1 ``                                    |
| [`b6736904`](https://github.com/NixOS/nixpkgs/commit/b67369049f8297747e5ed721e4cbf4406da24417) | `` mpdecimal: split C++ library into separate output ``                             |
| [`7ffb4278`](https://github.com/NixOS/nixpkgs/commit/7ffb427895cb5e2da3d351e8b5cc8cb56f9e788e) | `` linuxKernel.kernels.linux_zen: 6.2-zen1 -> 6.2.2-zen1 ``                         |
| [`593e4a3c`](https://github.com/NixOS/nixpkgs/commit/593e4a3c6e334e7b3c95572210efc7b6aeffeb06) | `` linuxKernel.kernels.linux_lqx: 6.1.13-lqx2 -> 6.1.14-lqx1 ``                     |
| [`a2d85f5b`](https://github.com/NixOS/nixpkgs/commit/a2d85f5bad9d3e93ab6a728b87ffac29949fa2a0) | `` python310Packages.openapi-core: 0.16.5 -> 0.16.6 ``                              |
| [`0385ba71`](https://github.com/NixOS/nixpkgs/commit/0385ba7150bb07c8d2efadcf8aeedb50e91aa912) | `` python310Packages.ulid-transform: init at 0.4.0 ``                               |
| [`a84a25c3`](https://github.com/NixOS/nixpkgs/commit/a84a25c3ae077754d5571623cb3f34b60fa29d4e) | `` lkl: downgrade to 5.15 ``                                                        |
| [`484099cd`](https://github.com/NixOS/nixpkgs/commit/484099cd447899bd84c8babfdbcb37fbf345ebb0) | `` python310Packages.mypy-boto3-builder: 7.12.4 -> 7.12.5 ``                        |
| [`e3d8ef89`](https://github.com/NixOS/nixpkgs/commit/e3d8ef89aa9038481890a947a482908aa108d242) | `` jmusicbot: 0.3.8 -> 0.3.9 ``                                                     |
| [`4b853137`](https://github.com/NixOS/nixpkgs/commit/4b853137a6341956d56280e08c559e0a35454e15) | `` cargo-tarpaulin: add aarch64 support ``                                          |
| [`c075b6b1`](https://github.com/NixOS/nixpkgs/commit/c075b6b1d658a1810f10c0afd8a153034f9b5456) | `` python310Packages.youless-api: 1.0 -> 1.0.1 ``                                   |
| [`a1979b77`](https://github.com/NixOS/nixpkgs/commit/a1979b77913b5d067d2e9e57053356372c9bbdaf) | `` stellar-core: add aarch64-linux support ``                                       |
| [`d8cc4e21`](https://github.com/NixOS/nixpkgs/commit/d8cc4e215dfb8c62206b5c53bbac0d99e8ac9b20) | `` coqPackages.mathcomp-analysis: 0.6.0 → 0.6.1 ``                                  |
| [`c81f6065`](https://github.com/NixOS/nixpkgs/commit/c81f6065c55f0749d2697b46fe3d64f1ca4d710d) | `` coqPackages.mathcomp-analysis: 0.5.3 → 0.6.0 ``                                  |
| [`744f88a9`](https://github.com/NixOS/nixpkgs/commit/744f88a98f41ede419d7527e1af856f517f891ce) | `` trufflehog: 3.28.6 -> 3.28.7 ``                                                  |
| [`d168fec9`](https://github.com/NixOS/nixpkgs/commit/d168fec9cf5b1f5ff6312d2ed8f9a89993ec5263) | `` pods: 1.0.5 -> 1.0.6 ``                                                          |
| [`3b02da3f`](https://github.com/NixOS/nixpkgs/commit/3b02da3fddeb9f7df648a420dbf4fc107142578f) | `` nixos/tests/gitea: keep calling the file itself evaluatable ``                   |
| [`31d0522d`](https://github.com/NixOS/nixpkgs/commit/31d0522d6032a57e80a67af7e8d7e3bef663756e) | `` python310Packages.pyfibaro: 0.6.8 -> 0.6.9 ``                                    |
| [`e62c9138`](https://github.com/NixOS/nixpkgs/commit/e62c913822079b3858cc8356c803cd92dcc42c65) | `` treewide: remove ma27 from a bunch of packages (again) ``                        |
| [`f43792f7`](https://github.com/NixOS/nixpkgs/commit/f43792f70c6ee228010236aaa519dcf7b695c34f) | `` maintainers/ma27: add pgp fingerprint ``                                         |
| [`398602b4`](https://github.com/NixOS/nixpkgs/commit/398602b401157b7efbe3810e330e13ffc459f981) | `` flyctl: 0.0.474 -> 0.0.475 ``                                                    |
| [`7089294f`](https://github.com/NixOS/nixpkgs/commit/7089294f10068dbeeed6e2e4d7a24300bf4bacb6) | `` strings: add escapeQuery for url encoding ``                                     |
| [`3d850578`](https://github.com/NixOS/nixpkgs/commit/3d8505781153d8328c1dc771f1f1890acc6e25f8) | `` roon-server: 2.0-1202 -> 2.0-1223 ``                                             |
| [`18a6d5d1`](https://github.com/NixOS/nixpkgs/commit/18a6d5d13233d2cabf616d4bb29177822258bbf8) | `` openjfx19: add gtk2 ``                                                           |
| [`b434398a`](https://github.com/NixOS/nixpkgs/commit/b434398a500d8c2ec94f4337f4dc65b8bfa8a882) | `` openjfx17: add gtk2 ``                                                           |
| [`4eaa0c57`](https://github.com/NixOS/nixpkgs/commit/4eaa0c57d91c8db589312d244f5a43d08f52ee8b) | `` openjfx11: add gtk2 ``                                                           |
| [`fa71352f`](https://github.com/NixOS/nixpkgs/commit/fa71352fb08d8abb5fece98c20f88e2389eeee86) | `` cargo-dist: 0.0.3 -> 0.0.4 ``                                                    |
| [`8f386acc`](https://github.com/NixOS/nixpkgs/commit/8f386acc47fa8318e29bbbfe22b2c2ff20aab6e9) | `` viber: fix build with openssl ``                                                 |
| [`9bedd92d`](https://github.com/NixOS/nixpkgs/commit/9bedd92dd9022a395f89aff29286bebc9fd94900) | `` python310Packages.py_stringmatching: normalize pname ``                          |
| [`1fe9600d`](https://github.com/NixOS/nixpkgs/commit/1fe9600d6fd22031ed5c576640ef0c257918eb93) | `` python310Packages.py_stringmatching: add pythonImportsCheck ``                   |
| [`df305355`](https://github.com/NixOS/nixpkgs/commit/df3053556ab8a1b3b4fa92351ccb2974d1ae2147) | `` python310Packages.py_stringmatching: disable on older Python releases ``         |
| [`fede9624`](https://github.com/NixOS/nixpkgs/commit/fede9624c8968f0daa7eb1de31f40478a4ffaff3) | `` viber: fix no internet error ``                                                  |
| [`88bd54d6`](https://github.com/NixOS/nixpkgs/commit/88bd54d6a8101006cdedfd8837a9ac9a1cd4d6a6) | `` difftastic: 0.43.1 -> 0.45.0 ``                                                  |
| [`fef55533`](https://github.com/NixOS/nixpkgs/commit/fef55533f19da5e288e54d8de151d73bc6d11a9c) | `` cudatext: 1.186.0 -> 1.186.2 ``                                                  |
| [`a01aa125`](https://github.com/NixOS/nixpkgs/commit/a01aa125cce4b314836ac6af1e213574b4003eb5) | `` python310Packages.py_stringmatching: update meta ``                              |
| [`30905848`](https://github.com/NixOS/nixpkgs/commit/3090584869c2dba3edcc92cfcca413181a100e7f) | `` gleam: 0.26.2 -> 0.27.0 ``                                                       |
| [`cf74adcf`](https://github.com/NixOS/nixpkgs/commit/cf74adcf26300d07c883e83a3567e633adb69dea) | `` python310Packages.google-cloud-container: 2.17.3 -> 2.17.4 ``                    |
| [`a0691fc8`](https://github.com/NixOS/nixpkgs/commit/a0691fc8102eb772cd86daaf56db8762499ba32e) | `` sgx/sdk/ipp-crypto: pin stdenv to gcc11 ``                                       |
| [`e7b2ea28`](https://github.com/NixOS/nixpkgs/commit/e7b2ea28443eb7907141a551ba48771cde781985) | `` python310Packages.yaramod: 3.12.2 -> 3.19.0 ``                                   |
| [`4389e5f7`](https://github.com/NixOS/nixpkgs/commit/4389e5f7237dc9772a38496c6ef1d4474b30d6d9) | `` git-stack: init at 0.10.12 ``                                                    |
| [`da678d4e`](https://github.com/NixOS/nixpkgs/commit/da678d4e7404500ed3adf929e0eb52b8dc526e03) | `` python310Packages.pybigwig: 0.3.18 -> 0.3.20 ``                                  |
| [`151ff48b`](https://github.com/NixOS/nixpkgs/commit/151ff48bb4bf977311746c9a4e5f21b836c6e413) | `` python310Packages.pybigwWig: normalize pname ``                                  |
| [`84c5341c`](https://github.com/NixOS/nixpkgs/commit/84c5341c9622c9fd1a846f317a9ef16fe308c68b) | `` python310Packages.pybigwig: add changelog to meta ``                             |
| [`8da62bda`](https://github.com/NixOS/nixpkgs/commit/8da62bda3eaa5a2bcf43a3ec4ed9a825a9cad322) | `` python310Packages.py_stringmatching: 0.4.2 -> 0.4.3 ``                           |
| [`16f17597`](https://github.com/NixOS/nixpkgs/commit/16f1759737d9c26b814c15e3f50cb6f3607d1eba) | `` google-cloud-sdk: only use autoPatchelf on Linux ``                              |
| [`5ce9b192`](https://github.com/NixOS/nixpkgs/commit/5ce9b192ff9564f3b0d16b831c724866bfd8bfc4) | `` python310Packages.pybravia: 0.3.1 -> 0.3.2 ``                                    |
| [`a618e659`](https://github.com/NixOS/nixpkgs/commit/a618e6594f5d6e16b845e5c764749893eb9bc668) | `` python310Packages.pontos: 23.3.1 -> 23.3.3 ``                                    |
| [`7ff0d025`](https://github.com/NixOS/nixpkgs/commit/7ff0d025cc1a205a27b5c73953c3d3f412f21fee) | `` Revert "shadowsocks-v2ray-plugin: 1.3.1 -> 1.3.2" ``                             |
| [`3cfda407`](https://github.com/NixOS/nixpkgs/commit/3cfda4078482e7e7177e86f841c483772662c9e1) | `` linux-rt_5_15: 5.15.95-rt60 -> 5.15.96-rt61 ``                                   |
| [`5b355085`](https://github.com/NixOS/nixpkgs/commit/5b3550852a0fa83ab9ef954f85f3586163be49fd) | `` linux: 6.2.1 -> 6.2.2 ``                                                         |
| [`579cf127`](https://github.com/NixOS/nixpkgs/commit/579cf1274967a87abeda494fa700750753d544ca) | `` linux: 6.1.14 -> 6.1.15 ``                                                       |
| [`4d878aaf`](https://github.com/NixOS/nixpkgs/commit/4d878aaf53d9a571aea7ce37f40541e42f773bba) | `` linux: 5.4.233 -> 5.4.234 ``                                                     |
| [`aee193be`](https://github.com/NixOS/nixpkgs/commit/aee193bed863d1cc2b9447815cc6c5d415d81e46) | `` linux: 5.15.96 -> 5.15.97 ``                                                     |
| [`248de5d6`](https://github.com/NixOS/nixpkgs/commit/248de5d61e84a85405a635f9af0f13b7727701b9) | `` linux: 5.10.170 -> 5.10.172 ``                                                   |
| [`e8cf0bfc`](https://github.com/NixOS/nixpkgs/commit/e8cf0bfcdf9deea8bd65d2475325d9068e5bdf52) | `` linux: 4.19.274 -> 4.19.275 ``                                                   |
| [`d2b52437`](https://github.com/NixOS/nixpkgs/commit/d2b5243765dc4f6393b52cb5fe26af3e8c74edef) | `` python310Packages.flask-security-too: 5.1.0 -> 5.1.1 ``                          |
| [`0c0ff98e`](https://github.com/NixOS/nixpkgs/commit/0c0ff98ef2a4a4bbb1a88e864cc9878a2819333c) | `` openblas: tighten platforms ``                                                   |
| [`a210bb21`](https://github.com/NixOS/nixpkgs/commit/a210bb2111aa393cec9d4e6e62839129f8204033) | `` phosh: add tomfitzhenry@ as maintainer ``                                        |
| [`343fec93`](https://github.com/NixOS/nixpkgs/commit/343fec936374f0d481adb1b78444b1a96774db64) | `` squeekboard: 1.20.0 -> 1.21.0 ``                                                 |
| [`1e69e5c4`](https://github.com/NixOS/nixpkgs/commit/1e69e5c4280208e7d99fe4b1fb23b3836a532b4b) | `` shell-genie: unstable-2023-01-27 -> 0.2.6 ``                                     |
| [`b5e87c2c`](https://github.com/NixOS/nixpkgs/commit/b5e87c2c76fee2a1b77fb823dff557f5af89fd77) | `` gojq: add changelog to meta ``                                                   |
| [`a9ea617e`](https://github.com/NixOS/nixpkgs/commit/a9ea617e3a28a196696fba0999649ee47e627cec) | `` godns: modernize ``                                                              |
| [`76ba8f5d`](https://github.com/NixOS/nixpkgs/commit/76ba8f5d3cc254f6239bfde773180348bfa411cb) | `` godns: add changelog to meta ``                                                  |