### PR TITLE
chore(flake/home-manager): `68ba5957` -> `e314f6cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678006026,
-        "narHash": "sha256-cGOfrU7JsKHAWXbPVDTOu2yyMb7GeWdUtJQNQSqht+w=",
+        "lastModified": 1678019241,
+        "narHash": "sha256-ntj0u3guaIu9dT8aZ3HtnEVhIsibtM7EaG/2VteKaTw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "68ba59578352815ac372b17fb3df9db39afb1407",
+        "rev": "e314f6cf211e480ab8fa101a017e593a9bb9f21b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                             |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`e314f6cf`](https://github.com/nix-community/home-manager/commit/e314f6cf211e480ab8fa101a017e593a9bb9f21b) | `` broot: remove unnecessary IFD `` |