### PR TITLE
chore(flake/home-manager): `04d6cad6` -> `defd16c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678109311,
-        "narHash": "sha256-Q64FoCH5rp3XHoC8u1+KyjLEFGTY7kX9YaIaYfugvfY=",
+        "lastModified": 1678185531,
+        "narHash": "sha256-S9UgBQJcbf7rfy4I5FxvAmGjHeYq82dc3SBTPktbrt8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "04d6cad67557512452decbfe888c68fa11338a96",
+        "rev": "defd16c5d5b271ff6cd7f72a108f711ebf31c936",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`defd16c5`](https://github.com/nix-community/home-manager/commit/defd16c5d5b271ff6cd7f72a108f711ebf31c936) | `` Translate using Weblate (Japanese) `` |