### PR TITLE
chore(flake/home-manager): `defd16c5` -> `f6981648`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678185531,
-        "narHash": "sha256-S9UgBQJcbf7rfy4I5FxvAmGjHeYq82dc3SBTPktbrt8=",
+        "lastModified": 1678229586,
+        "narHash": "sha256-6Kg9nTzHdfW4JUaGfwT9XA5x4F+nVJWORw9aD4lOXo4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "defd16c5d5b271ff6cd7f72a108f711ebf31c936",
+        "rev": "f69816489d5bcd1329c50fb4a7035a9a9dc19a3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`f6981648`](https://github.com/nix-community/home-manager/commit/f69816489d5bcd1329c50fb4a7035a9a9dc19a3b) | `` home-manager: handle missing per-user profiles directory `` |
| [`0f3dfc16`](https://github.com/nix-community/home-manager/commit/0f3dfc16d0e62f568bf08056de1a37832e900c32) | `` home-manager: fix nix-env uninstall command ``              |