### PR TITLE
chore(flake/nixpkgs): `c707238d` -> `c90c4025`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -198,11 +198,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678201391,
-        "narHash": "sha256-dX4z2oSJ5UKzY5wb5HX2VaPP08DPWZ6B7EHzOJfP7GM=",
+        "lastModified": 1678293141,
+        "narHash": "sha256-lLlQHaR0y+q6nd6kfpydPTGHhl1rS9nU9OQmztzKOYs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c707238dc262923da5a53a5a11914117caac07a2",
+        "rev": "c90c4025bb6e0c4eaf438128a3b2640314b1c58d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`4d40a028`](https://github.com/NixOS/nixpkgs/commit/4d40a028a1f3795e0b8257cab781c8827123abf5) | `` rtorrent: set meta.mainProgram ``                                                |
| [`d8d8b55e`](https://github.com/NixOS/nixpkgs/commit/d8d8b55e7dccfe10e99d2f4ed968fa8acaef9b78) | `` nixos/murmur: expose dbus ``                                                     |
| [`ff28bb10`](https://github.com/NixOS/nixpkgs/commit/ff28bb10554a2e967cde4b5183e0fe02b8c5f8a7) | `` asusctl: 4.5.6 -> 4.5.8 ``                                                       |
| [`76657296`](https://github.com/NixOS/nixpkgs/commit/76657296600b57277016389a8daa96342e77df06) | `` flyctl: 0.0.477 -> 0.0.478 ``                                                    |
| [`be521607`](https://github.com/NixOS/nixpkgs/commit/be5216077e2ed22cde9af456f90cf0cfdf0358fe) | `` offpunk: install the project's man page ``                                       |
| [`29da1234`](https://github.com/NixOS/nixpkgs/commit/29da123428dd71f553f8effe28d284d8d57b080b) | `` offpunk: 1.8->1.9 ``                                                             |
| [`270c722c`](https://github.com/NixOS/nixpkgs/commit/270c722c89b37b383b144d3d3f4429fbe094fa86) | `` aws-vault: 6.6.2 -> 7.0.0 (#220033) ``                                           |
| [`c10d18c7`](https://github.com/NixOS/nixpkgs/commit/c10d18c7e74aee0928322ca45087a27ce9183d5d) | `` cpp-utilities: 5.20.0 -> 5.21.0 ``                                               |
| [`a5613d24`](https://github.com/NixOS/nixpkgs/commit/a5613d24efe0d082a23bbb7b828564d843490101) | `` libsForQt5.qtutilities: 6.10.0 -> 6.11.0 ``                                      |
| [`5b9ed59e`](https://github.com/NixOS/nixpkgs/commit/5b9ed59e80adbf700a76f070556cf3a56e8f1dba) | `` syncthingtray: 1.3.2 -> 1.3.3 ``                                                 |
| [`fd400f54`](https://github.com/NixOS/nixpkgs/commit/fd400f5425f36c49b5592c45866094baeaf88a7f) | `` terracognita: 0.8.1 -> 0.8.2 ``                                                  |
| [`b23a5794`](https://github.com/NixOS/nixpkgs/commit/b23a5794db78b057cf65cfcd4934a9c2a77aff8d) | `` linux_xanmod: remove LRU option ``                                               |
| [`008aeed9`](https://github.com/NixOS/nixpkgs/commit/008aeed915240b6c0a140696b9b440641892bd79) | `` krabby: init at 0.1.6 ``                                                         |
| [`da95db0a`](https://github.com/NixOS/nixpkgs/commit/da95db0a3a06fda8bd13ff00c3a0a11a6409b3e3) | `` taskwarrior: fix nvim/site installation path ``                                  |
| [`4de2b19f`](https://github.com/NixOS/nixpkgs/commit/4de2b19fa184d9c3d5aa158d0923931976441442) | `` boogie: install vim-plugin to nvim/site ``                                       |
| [`78fee034`](https://github.com/NixOS/nixpkgs/commit/78fee034672c1ffe3a570bc8958769a3a784d577) | `` txr: install vim-plugin to nvim/site ``                                          |
| [`79c65780`](https://github.com/NixOS/nixpkgs/commit/79c6578005f4eb8cd287a212ff72e0b262ffcf69) | `` fzf: install vim-plugin to nvim/site ``                                          |
| [`ba4d56e2`](https://github.com/NixOS/nixpkgs/commit/ba4d56e20e434d0ac2f3006d60a549d994b28259) | `` tamarin-prover: install vim-plugin to nvim/site ``                               |
| [`ff894f5e`](https://github.com/NixOS/nixpkgs/commit/ff894f5efa5636117d30cf837e29b83f4d8a12bd) | `` typos: 1.13.16 -> 1.13.18 ``                                                     |
| [`32af296b`](https://github.com/NixOS/nixpkgs/commit/32af296bbed999d10a5e0f54c1a1ad062b4030dc) | `` linux_xanmod_latest: 6.1.14 -> 6.2.2 ``                                          |
| [`c70c23e0`](https://github.com/NixOS/nixpkgs/commit/c70c23e08809f0266076427567d25a8f8bc28764) | `` linux_xanmod: 5.15.89 -> 6.1.15 ``                                               |
| [`9796cbfe`](https://github.com/NixOS/nixpkgs/commit/9796cbfe140d00504d7f8ee42a2b19132967608c) | `` linux_xanmod_latest: 6.1.13 -> 6.1.14 ``                                         |
| [`d1323857`](https://github.com/NixOS/nixpkgs/commit/d1323857f853e14b4f45a6f18ae9907065653aff) | `` tilemaker: 2.2.0 → 2.3.0 ``                                                      |
| [`ffcf148a`](https://github.com/NixOS/nixpkgs/commit/ffcf148a8dd6e8d1e240137e3f8071af5fa92a28) | `` nixos/waybar: allow change waybar package to use ``                              |
| [`60709908`](https://github.com/NixOS/nixpkgs/commit/60709908a27fa813022c10838908c979b291ca4c) | `` ocaml: remove obsolete aliases for old versions ``                               |
| [`d6e7f3fc`](https://github.com/NixOS/nixpkgs/commit/d6e7f3fc7b72a1e9a7616fcd378f4dcfb35cfb9e) | `` rmw: init at 0.9.0 ``                                                            |
| [`2a508fbf`](https://github.com/NixOS/nixpkgs/commit/2a508fbf2c3bfd4130d7390b6ff9b1b29ccbbc44) | `` python310Packages.sphinxext-opengraph: disable on unsupported Python releases `` |
| [`c1d9d8c7`](https://github.com/NixOS/nixpkgs/commit/c1d9d8c7f3e99af8f475730c79cb2ad25b52558e) | `` exploitdb: 2023-03-01 -> 2023-03-06 ``                                           |
| [`a35b09be`](https://github.com/NixOS/nixpkgs/commit/a35b09be82e3ecd237791f32a93e9b681ffd553e) | `` audacious: 4.2 -> 4.3 ``                                                         |
| [`41ec7e2f`](https://github.com/NixOS/nixpkgs/commit/41ec7e2fefb0c3b8942cbfc47e579a052bdc5c49) | `` python3Packages.sphinxext-opengraph: add changelog to meta ``                    |
| [`f7f6256d`](https://github.com/NixOS/nixpkgs/commit/f7f6256de8c51bb4aaec38792ef5d93853703ab4) | `` ytt: 0.44.1 -> 0.45.0 ``                                                         |
| [`b6b23791`](https://github.com/NixOS/nixpkgs/commit/b6b23791f51d1df6416d9ae713af57ccc8ff271b) | `` pachyderm: 2.5.0 -> 2.5.1 ``                                                     |
| [`fb825182`](https://github.com/NixOS/nixpkgs/commit/fb8251822c6236d95629cfc4800f5eea9ee9932b) | `` libadwaita: 1.2.2 -> 1.2.3 ``                                                    |
| [`76c0e3ef`](https://github.com/NixOS/nixpkgs/commit/76c0e3ef55c937f83bbe6ba6543d430d7e6412a9) | `` python310Packages.klein: don't test on multiple cores ``                         |
| [`1599fe76`](https://github.com/NixOS/nixpkgs/commit/1599fe767a9636c79b431420a20e0bf44f7e6787) | `` terraform-providers.yandex: 0.85.0 → 0.86.0 ``                                   |
| [`2369bf3d`](https://github.com/NixOS/nixpkgs/commit/2369bf3d444bfd84a8b31e28ca867618e81d0077) | `` terraform-providers.scaleway: 2.12.0 → 2.12.1 ``                                 |
| [`75725216`](https://github.com/NixOS/nixpkgs/commit/75725216fd4480420f45ff0437ca408965e7ea93) | `` terraform-providers.mongodbatlas: 1.8.0 → 1.8.1 ``                               |
| [`59d19cf0`](https://github.com/NixOS/nixpkgs/commit/59d19cf0a1e47595f4f38db20c00df5c7ef1db80) | `` terraform-providers.okta: 3.42.0 → 3.43.0 ``                                     |
| [`54c038d6`](https://github.com/NixOS/nixpkgs/commit/54c038d693d78fec48eb45ad34c6df14e5907f9c) | `` terraform-providers.datadog: 3.21.0 → 3.22.0 ``                                  |
| [`c242f5c8`](https://github.com/NixOS/nixpkgs/commit/c242f5c89d42cef004ea0f8d155121b848b5b764) | `` terraform-providers.cloudamqp: 1.23.0 → 1.24.0 ``                                |
| [`5f93b977`](https://github.com/NixOS/nixpkgs/commit/5f93b9774eb22fc13275d89a081a0acc14a82ca9) | `` terraform-providers.cloudfoundry: 0.50.4 → 0.50.5 ``                             |
| [`35ebb2dc`](https://github.com/NixOS/nixpkgs/commit/35ebb2dc8341d34b01e5cf5092c29af180925391) | `` terraform-providers.aiven: 4.0.0 → 4.1.0 ``                                      |
| [`392c79de`](https://github.com/NixOS/nixpkgs/commit/392c79dece5491dd62471da85df6adec1edcd29c) | `` terraform-providers.aviatrix: 3.0.1 → 3.0.2 ``                                   |
| [`d1ffbed1`](https://github.com/NixOS/nixpkgs/commit/d1ffbed1759054328af3c06a6f49c4e6996bfb7d) | `` qcad: 3.27.9.2 -> 3.27.9.3 ``                                                    |
| [`5e651fe3`](https://github.com/NixOS/nixpkgs/commit/5e651fe37e98c69121609146ad5240663d0387df) | `` nixos/nexttrace: init ``                                                         |
| [`194a3801`](https://github.com/NixOS/nixpkgs/commit/194a380161f12b7b720d25527b06292b715ddaf2) | `` nexttrace: init at 1.1.3 ``                                                      |
| [`61852b7f`](https://github.com/NixOS/nixpkgs/commit/61852b7faa8b47aad422adca0fea90fe007e9ead) | `` lib: remove deprecated functions ``                                              |
| [`3d647935`](https://github.com/NixOS/nixpkgs/commit/3d647935eb8341ff5d70ce0ef53e00891430fc39) | `` ov: 0.14.2 -> 0.15.0 ``                                                          |
| [`8648885a`](https://github.com/NixOS/nixpkgs/commit/8648885a80194aea9fa20a699c260af357428a76) | `` xc: 0.0.159 -> 0.0.175 ``                                                        |
| [`a8a12fdf`](https://github.com/NixOS/nixpkgs/commit/a8a12fdf8538e363846af8634b2a663595a8e686) | `` erdtree: 1.2.0 -> 1.3.0 ``                                                       |
| [`22c6c560`](https://github.com/NixOS/nixpkgs/commit/22c6c5609143c5714cf7f3028f0f9744b8d27040) | `` opa: migrate to OCaml 4.14 ``                                                    |
| [`cbb6abb8`](https://github.com/NixOS/nixpkgs/commit/cbb6abb8025f2d9503700667810a1289d36f5bf2) | `` python311Packages.fire: fix tests ``                                             |
| [`938d9f5b`](https://github.com/NixOS/nixpkgs/commit/938d9f5b39bf17b15bc1c52112c135ffc503b4a0) | `` python310Packages.herepy: 3.5.8 -> 3.6.0 ``                                      |
| [`c051db62`](https://github.com/NixOS/nixpkgs/commit/c051db62ce639d91f4e039dbc5fc1b090b0a35e8) | `` linvstmanager: init at 1.1.1 ``                                                  |
| [`34f4be4a`](https://github.com/NixOS/nixpkgs/commit/34f4be4ad2e7d153f370570ccec8467bec1b23d4) | `` python310Packages.apispec: 6.1.0 -> 6.2.0 ``                                     |
| [`45a706c5`](https://github.com/NixOS/nixpkgs/commit/45a706c5991d6c305ed7942c7b3ec9e23242342e) | `` python310Packages.prance: 0.21.8.0 -> 0.22.02.22.0 ``                            |
| [`4ffa19a0`](https://github.com/NixOS/nixpkgs/commit/4ffa19a0e91bd24c0e93839c4062987f4ddaa633) | `` kubescape: 2.2.3 -> 2.2.4 ``                                                     |
| [`8bde91a3`](https://github.com/NixOS/nixpkgs/commit/8bde91a3ab6451c60c426a5f4d840c65d77c9efd) | `` kbibtex: 0.9.3.1 -> 0.9.3.2 ``                                                   |
| [`2d7bb420`](https://github.com/NixOS/nixpkgs/commit/2d7bb420c8d4bd47bfb8f9b345da7a38ebea78a6) | `` arkade: 0.9.3 -> 0.9.4 ``                                                        |
| [`43a3285b`](https://github.com/NixOS/nixpkgs/commit/43a3285b1ee7058cf90db774f169f4d5f48bfe97) | `` kubescape: 2.0.161 -> 2.2.3 ``                                                   |
| [`43dcf6a2`](https://github.com/NixOS/nixpkgs/commit/43dcf6a240cce10e04ebfde7da6b6f5c4f17ad3f) | `` python310Packages.app-model: 0.1.1 -> 0.1.2 ``                                   |
| [`992b7224`](https://github.com/NixOS/nixpkgs/commit/992b72241df579171f3d3a34c0338fda89c315aa) | `` katawa-shoujo: Add desktop file ``                                               |
| [`22aa2d8c`](https://github.com/NixOS/nixpkgs/commit/22aa2d8cffa2299956fbb624cceb16789005d70d) | `` home-assistant: add eufylife-ble-client to component-packages ``                 |
| [`cad0a950`](https://github.com/NixOS/nixpkgs/commit/cad0a950fb2ec6e44565fb77c17674757cfddf8e) | `` python310Packages.eufylife-ble-client: init at 0.1.7 ``                          |
| [`1e36120c`](https://github.com/NixOS/nixpkgs/commit/1e36120c94ad86c19c080e919a84f1ce3d1204e5) | `` signalbackup-tools: 20230305 -> 20230307-1 ``                                    |
| [`68114301`](https://github.com/NixOS/nixpkgs/commit/681143012d4444c4c6a10a4bbb7869fb894d35be) | `` beamPackages.hex: 1.0.1 -> 2.0.6 ``                                              |
| [`4b9d8758`](https://github.com/NixOS/nixpkgs/commit/4b9d8758520ea7bb7a8f728bbda6144e622dbbd7) | `` home-assistant: add energyzero to component-packages ``                          |
| [`779db789`](https://github.com/NixOS/nixpkgs/commit/779db7898ca58416f6d1e5bc3c4ed4dafd32879c) | `` go_1_20: 1.20.1 -> 1.20.2 ``                                                     |
| [`044670c7`](https://github.com/NixOS/nixpkgs/commit/044670c79be20d52d5f6ac54824c52fff4fedcc4) | `` python310Packages.energyzero: init at 0.4.0 ``                                   |
| [`2011b1f0`](https://github.com/NixOS/nixpkgs/commit/2011b1f0030f2f51537a22c5a24beb25ce9326d1) | `` python310Packages.cemm: init at 0.5.1 ``                                         |
| [`bfe60278`](https://github.com/NixOS/nixpkgs/commit/bfe60278b96cdefda06fe6ce4ed7a8370e4a4f5b) | `` re-flex: init at 3.3.1 ``                                                        |
| [`ec822d4c`](https://github.com/NixOS/nixpkgs/commit/ec822d4c4563a9171d2540bf051188c5a116d265) | `` home-assistant: add easyenergy to component-packages ``                          |
| [`b6214c95`](https://github.com/NixOS/nixpkgs/commit/b6214c95918d749802256ae7bd1c0a17b44e3774) | `` maintainers: add prrlvr ``                                                       |
| [`ef9f273e`](https://github.com/NixOS/nixpkgs/commit/ef9f273e3090f3531fa2b445fa1177db975ae11f) | `` python310Packages.easyenergy: init at 0.2.0 ``                                   |
| [`b4c26395`](https://github.com/NixOS/nixpkgs/commit/b4c263953e0ef0d038002a250aa2b6bcf51bb0e0) | `` python310Packages.python-otbr-api: 1.0.5 -> 1.0.7 ``                             |
| [`6a6ce419`](https://github.com/NixOS/nixpkgs/commit/6a6ce4198dee9a22fe7dfd3ed5553a00df1bb336) | `` chromiumBeta: 111.0.5563.50 -> 111.0.5563.64 ``                                  |
| [`524885c1`](https://github.com/NixOS/nixpkgs/commit/524885c108a3386d07fd710275363f29cf545a39) | `` syft: 0.73.0 -> 0.74.0 ``                                                        |
| [`01e6f31e`](https://github.com/NixOS/nixpkgs/commit/01e6f31e561bdf6107dd9f1dbae30e4017d7f9ce) | `` python310Packages.angr: 9.2.40 -> 9.2.41 ``                                      |
| [`7e96ced3`](https://github.com/NixOS/nixpkgs/commit/7e96ced3ea0539cf338136c07b1ccc3da66a0942) | `` python310Packages.cle: 9.2.40 -> 9.2.41 ``                                       |
| [`dd974c57`](https://github.com/NixOS/nixpkgs/commit/dd974c57ac8a0053b1924fa8e2dda87045b301a5) | `` python310Packages.claripy: 9.2.40 -> 9.2.41 ``                                   |
| [`8318c658`](https://github.com/NixOS/nixpkgs/commit/8318c658b973ddad416400fa435df09e9a42202f) | `` python310Packages.pyvex: 9.2.40 -> 9.2.41 ``                                     |
| [`263f871a`](https://github.com/NixOS/nixpkgs/commit/263f871a627224db5af69ea1e93ef8e76cf577e7) | `` python310Packages.ailment: 9.2.40 -> 9.2.41 ``                                   |
| [`c0fb30a6`](https://github.com/NixOS/nixpkgs/commit/c0fb30a60e8d2a4de18c0ce53ea6cc8d05f796c9) | `` python310Packages.archinfo: 9.2.40 -> 9.2.41 ``                                  |
| [`94ab7a23`](https://github.com/NixOS/nixpkgs/commit/94ab7a2363f730e8fcd92387154ccebcb21b1410) | `` python310Packages.hvac: disable on unsupported Python releases ``                |
| [`337384d8`](https://github.com/NixOS/nixpkgs/commit/337384d81cc6e47326062cd619445325c756f69b) | `` python310Packages.hvac: add changelog to meta ``                                 |
| [`9f031004`](https://github.com/NixOS/nixpkgs/commit/9f031004e71fe8cfa4ae1095a50a3afd8cdfe3d5) | `` libdisplay-info: 0.1.0 -> 0.1.1 ``                                               |
| [`8312cc0a`](https://github.com/NixOS/nixpkgs/commit/8312cc0a1f951b8c656b5e8f93578c57e6932045) | `` python310Packages.pyobihai: 1.3.2 -> 1.4.0 ``                                    |
| [`93711c6f`](https://github.com/NixOS/nixpkgs/commit/93711c6fdfb0dd37151f005df90bac103b9094e7) | `` tsung: add changelog to meta ``                                                  |
| [`5e6ebb3e`](https://github.com/NixOS/nixpkgs/commit/5e6ebb3e898d5dfee032464e54995f2fcb60bdbb) | `` python310Packages.aiolivisi: 0.0.16 -> 0.0.18 ``                                 |
| [`3d206db3`](https://github.com/NixOS/nixpkgs/commit/3d206db3c4ad64239968b7095cc12b85ae156354) | `` tsung: 1.7.0 -> 1.8.0 ``                                                         |
| [`ecfff018`](https://github.com/NixOS/nixpkgs/commit/ecfff018eb859fe3d77f3c27a61c7cc11fe54d52) | `` masscan: add patch to fix resume functionality (#219905) ``                      |
| [`72d7d2e9`](https://github.com/NixOS/nixpkgs/commit/72d7d2e9cc08bd38fec8cd96fe1bb0b743e87f2d) | `` awsebcli: add kirillrdy as maintainer ``                                         |
| [`985e04ac`](https://github.com/NixOS/nixpkgs/commit/985e04ac1b00e59cc927e42812576845c10c2e78) | `` maintainers: add kirillrdy ``                                                    |
| [`0a11517a`](https://github.com/NixOS/nixpkgs/commit/0a11517a84f5eab2e7d4ef5219325f20cc52653f) | `` act: 0.2.42 -> 0.2.43 ``                                                         |
| [`8460c8b1`](https://github.com/NixOS/nixpkgs/commit/8460c8b124a00c603ccf1786e1a7d19d58874790) | `` tlaps: migrate to OCaml 4.14 ``                                                  |
| [`937e716d`](https://github.com/NixOS/nixpkgs/commit/937e716d4ea11874fdd6381ced8a93f42f4d7273) | `` python3Packages.sphinxext-opengraph: 0.7.5 -> 0.8.1 ``                           |
| [`0c370aab`](https://github.com/NixOS/nixpkgs/commit/0c370aab6450244197fcd08814a42cdf560ea973) | `` aws-sso-cli: 1.9.9 -> 1.9.10 ``                                                  |
| [`7e1bcf5f`](https://github.com/NixOS/nixpkgs/commit/7e1bcf5f38a361828604e68efc98825ee0e060c2) | `` glooctl: 1.13.8 -> 1.13.9 ``                                                     |
| [`25939765`](https://github.com/NixOS/nixpkgs/commit/25939765180ed716662ed2c441ebe2506202cd8b) | `` csdr: 0.18.0 -> 0.18.1 ``                                                        |
| [`a76b5ced`](https://github.com/NixOS/nixpkgs/commit/a76b5ced8b75f6b3767d6a0349abc5a8b5efb777) | `` goreleaser: add developer-guy to maintainers list ``                             |
| [`acf1389e`](https://github.com/NixOS/nixpkgs/commit/acf1389e2fbc757cbcd731bf1c26a1ef940b2e0f) | `` goreleaser: add caarlos0 to maintainers list ``                                  |
| [`27684f88`](https://github.com/NixOS/nixpkgs/commit/27684f8832048988eecdced28f3879db396a9b7e) | `` mindustry: 141.2 -> 142 ``                                                       |
| [`02cd0a5d`](https://github.com/NixOS/nixpkgs/commit/02cd0a5dfcb99b162791bade2d2888c8187a6a92) | `` sherpa: 2.2.13 -> 2.2.14 (#220016) ``                                            |
| [`de1f8d6b`](https://github.com/NixOS/nixpkgs/commit/de1f8d6bd89b43d0cd09ee13c94e5c60736b8333) | `` maestro: 1.23.0 -> 1.24.0 ``                                                     |
| [`2f430da1`](https://github.com/NixOS/nixpkgs/commit/2f430da1c6aaeb4306427b77f139f53dcd729e08) | `` Replacing MRAN mirror with posit ``                                              |
| [`d8831d92`](https://github.com/NixOS/nixpkgs/commit/d8831d9224687aeb8e5b49ec7d626c94fa61d2e3) | `` somebar: 1.0.0 -> 1.0.3 ``                                                       |
| [`518ee5c9`](https://github.com/NixOS/nixpkgs/commit/518ee5c99bb9980deeaf2db102bf7abca901ad8b) | `` zine: 0.11.1 -> 0.12.0 ``                                                        |
| [`3e38add9`](https://github.com/NixOS/nixpkgs/commit/3e38add9b06f92e0508acd7013bd4e15c388bd8a) | `` maintainers: add connorbaker ``                                                  |
| [`5eb5d881`](https://github.com/NixOS/nixpkgs/commit/5eb5d881a49ce1eeecf24dc501efead1f70fc620) | `` nixos/nginx: add defaultMimeTypes option ``                                      |
| [`9bfeb0d7`](https://github.com/NixOS/nixpkgs/commit/9bfeb0d751e7bbffb3d078f6a87804dd26ceae19) | `` checkip: 0.44.2 -> 0.45.1 ``                                                     |
| [`47ace7b0`](https://github.com/NixOS/nixpkgs/commit/47ace7b0af442b2e6bdb8728330622c7dbc81499) | `` pkgs/tools/nix: enable strictDeps ``                                             |
| [`94ce5a87`](https://github.com/NixOS/nixpkgs/commit/94ce5a875a001d285537a8757fd6e63d6b3f93f3) | `` pkgs/tools/wayland: enable strictDeps ``                                         |
| [`27688662`](https://github.com/NixOS/nixpkgs/commit/2768866261ee21659edc6427f66d5b5b0f613752) | `` nixosTests.pantheon: ensure the password box is focused when login ``            |
| [`73f2f4c6`](https://github.com/NixOS/nixpkgs/commit/73f2f4c6a8d503c5f179a84162a2eda151a93874) | `` freac: 1.1.6 -> 1.1.7 ``                                                         |
| [`1f2cf28a`](https://github.com/NixOS/nixpkgs/commit/1f2cf28aa96e39f23abd7fa367273f9800f87521) | `` algolia-cli: 1.3.0 -> 1.3.1 ``                                                   |
| [`701a8387`](https://github.com/NixOS/nixpkgs/commit/701a838718504aa719de3913be0530c35b83da36) | `` teleport: add arianvp to maintainers ``                                          |
| [`5b9628a9`](https://github.com/NixOS/nixpkgs/commit/5b9628a9ed381e34171c88cd8f17f1b6b7614dcc) | `` teleport: add justinas to maintainers ``                                         |
| [`42cda97c`](https://github.com/NixOS/nixpkgs/commit/42cda97c500b54ad2e8617d515cc198a027dceaa) | `` gqlgenc: init at 0.11.3 ``                                                       |
| [`04a5d95d`](https://github.com/NixOS/nixpkgs/commit/04a5d95dbf13ed3776edc7c24927cf76975f37aa) | `` maintainers: add milran ``                                                       |
| [`0ba1c25b`](https://github.com/NixOS/nixpkgs/commit/0ba1c25b620047a8c05cccce308fcb76c25c1780) | `` python310Packages.hvac: 1.0.2 -> 1.1.0 ``                                        |
| [`6d8041b0`](https://github.com/NixOS/nixpkgs/commit/6d8041b0532c8b51a93f68c9737feecbb195d32a) | `` writeShellApplication: Prefer lib.getExe over unwrapped ShellChecked ``          |
| [`35ca4727`](https://github.com/NixOS/nixpkgs/commit/35ca4727fbf3cedef60681f23f5384aa8e758998) | `` python310Packages.slack-sdk: 3.20.0 -> 3.20.1 ``                                 |
| [`2ca73535`](https://github.com/NixOS/nixpkgs/commit/2ca73535423e4252803b41d843ef59309658af49) | `` linuxPackages.tuxedo-keyboard: 3.1.1 -> 3.1.4 ``                                 |
| [`f78d3c7d`](https://github.com/NixOS/nixpkgs/commit/f78d3c7d5f671fb2917e5212a20daab099cdbb05) | `` jql: 5.1.6 -> 5.1.7 ``                                                           |
| [`23e0077d`](https://github.com/NixOS/nixpkgs/commit/23e0077d3653757c405a848d07ddbd37507a7ece) | `` fizz: 2023.02.27.00 -> 2023.03.06.00 ``                                          |
| [`9cb0772d`](https://github.com/NixOS/nixpkgs/commit/9cb0772d436dd64f319643d1f0b78076237ed82a) | `` calcure: init at 2.8.2 ``                                                        |
| [`2acbdc41`](https://github.com/NixOS/nixpkgs/commit/2acbdc41e9c7ba55d2d876ab15039ce49e13bf8d) | `` ffado: 2.4.3 -> 2.4.7 ``                                                         |