### PR TITLE
chore(flake/nixos-hardware): `f6610997` -> `6e303a50`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -183,11 +183,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1678095239,
-        "narHash": "sha256-4F6jovFJcwh6OkMsY94ZrHdrvVqZi1FX5pYv6V9LIQw=",
+        "lastModified": 1678350133,
+        "narHash": "sha256-sUxDtERkqq0oGU5eGtlem5zE5ga801yXfpc3XlPfC4k=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f6610997b0fc5ea5f9e142c348fca27497efe1c7",
+        "rev": "6e303a505ad31a8e68a7f0d43e2170e81c16919b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`e72756d0`](https://github.com/NixOS/nixos-hardware/commit/e72756d0b46832bfeabeef4635bfebe863114613) | `` Enable NVIDIA power management for Dell XPS 7590 `` |
| [`826a2714`](https://github.com/NixOS/nixos-hardware/commit/826a2714d788187b27ee519abc5284de54d12464) | `` nxp: imx8: Fix wrong paths to imx-uboot.nix file `` |