### PR TITLE
chore(flake/pre-commit-hooks): `382bee73` -> `1a20b970`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -243,11 +243,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1677832802,
-        "narHash": "sha256-XQf+k6mBYTiQUjWRf/0fozy5InAs03O1b30adCpWeXs=",
+        "lastModified": 1678376203,
+        "narHash": "sha256-3tyYGyC8h7fBwncLZy5nCUjTJPrHbmNwp47LlNLOHSM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "382bee738397ca005206eefa36922cc10df8a21c",
+        "rev": "1a20b9708962096ec2481eeb2ddca29ed747770a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message           |
| ------------------------------------------------------------------------------------------------------------ | ----------------- |
| [`fd2babcd`](https://github.com/cachix/pre-commit-hooks.nix/commit/fd2babcdb4906ed8a46259b452bbf2cf78dd6176) | `` tagref hook `` |