### PR TITLE
chore(flake/nixos-hardware): `6e303a50` -> `22ef358f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -161,11 +161,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1678350133,
-        "narHash": "sha256-sUxDtERkqq0oGU5eGtlem5zE5ga801yXfpc3XlPfC4k=",
+        "lastModified": 1678389441,
+        "narHash": "sha256-k7DgWCNPfeNK1CmDHmL0t/qV7Bl47OU/eE04ZHhbfzI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "6e303a505ad31a8e68a7f0d43e2170e81c16919b",
+        "rev": "22ef358f5fc72445bb920ae1395f5258e9838df7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`8732ed0a`](https://github.com/NixOS/nixos-hardware/commit/8732ed0a3629705be34295982ffd4bfb6bd07750) | `` 16ach6h: add amd cpu pstate `` |