### PR TITLE
chore(flake/nixos-hardware): `22ef358f` -> `556101ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -161,11 +161,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1678389441,
-        "narHash": "sha256-k7DgWCNPfeNK1CmDHmL0t/qV7Bl47OU/eE04ZHhbfzI=",
+        "lastModified": 1678397099,
+        "narHash": "sha256-5xq8YJe+h19TlD+EI4AE/3H3jcCcQ2AWU6CWBVc5tRc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "22ef358f5fc72445bb920ae1395f5258e9838df7",
+        "rev": "556101ff85bd6e20900ec73ee525b935154bc8ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`0d8c8525`](https://github.com/NixOS/nixos-hardware/commit/0d8c852503581906dada5e8a22ca5d9248f87427) | `` zephyrus ga401: Enable nvidia powerManagement & modesetting (nvidia-drm) `` |
| [`5c55f242`](https://github.com/NixOS/nixos-hardware/commit/5c55f2428f571fe06e382c800454176b4f8b67f5) | `` zephyrus ga401: Enable asusd  services ``                                   |
| [`b5416e91`](https://github.com/NixOS/nixos-hardware/commit/b5416e9171d95e7ed94abad325218f78a8fab5f8) | `` zephyrus ga401: change pc/ssd to pc/laptop/ssd ``                           |
| [`0b49fc77`](https://github.com/NixOS/nixos-hardware/commit/0b49fc7783e7125c8ec48abd2bb6bb902421f5f6) | `` zephyrus ga401: add amd cpu pstate ``                                       |
| [`56ad5526`](https://github.com/NixOS/nixos-hardware/commit/56ad55261c313f3736193fb6a10d71713de161c8) | `` zephyrus ga401: add amdgpu driver ``                                        |