### PR TITLE
chore(flake/nixpkgs): `c90c4025` -> `1e259067`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678293141,
-        "narHash": "sha256-lLlQHaR0y+q6nd6kfpydPTGHhl1rS9nU9OQmztzKOYs=",
+        "lastModified": 1678380223,
+        "narHash": "sha256-HUxnK38iqrX84QdQxbFcosRKV3/koj1Zzp5b5aP4lIo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c90c4025bb6e0c4eaf438128a3b2640314b1c58d",
+        "rev": "1e2590679d0ed2cee2736e8b80373178d085d263",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                  |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
| [`130fa0ba`](https://github.com/NixOS/nixpkgs/commit/130fa0baaa2b93ec45523fdcde942f6844ee9f6e) | `` mullvad: add shell completion ``                                                                      |
| [`b094f644`](https://github.com/NixOS/nixpkgs/commit/b094f644af3baabbe5d0086ef7faf2e5a33d3581) | `` biscuit-cli: init at 0.2.0-next-pre20230103 ``                                                        |
| [`92d29501`](https://github.com/NixOS/nixpkgs/commit/92d2950194214e975ae7bd2655036689fccac155) | `` ocamlPackages.mirage-crypto: 0.10.7 -> 0.11.0 ``                                                      |
| [`551cec9f`](https://github.com/NixOS/nixpkgs/commit/551cec9f1500b1697d8cb519cae6aabb9b54ffd4) | `` cachix: 1.3 -> 1.3.1 ``                                                                               |
| [`031600bf`](https://github.com/NixOS/nixpkgs/commit/031600bf1509cc9b8c87d3f204f4b7f78183c5be) | `` erlangR25: 25.2.3 -> 25.3 ``                                                                          |
| [`29590623`](https://github.com/NixOS/nixpkgs/commit/2959062362b8521165a7582660053722b16f3323) | `` coqPackages: various 8.16 -> 8.17 ``                                                                  |
| [`8bc659c5`](https://github.com/NixOS/nixpkgs/commit/8bc659c5b73d3f160987ddee5f0db79d6238f354) | `` zen-kernels: remove myself as maintainer ``                                                           |
| [`13bfde1a`](https://github.com/NixOS/nixpkgs/commit/13bfde1a80811ace038631fb95603733c57a7ad6) | `` redmine: 4.2.9 -> 4.2.10 ``                                                                           |
| [`d315cae1`](https://github.com/NixOS/nixpkgs/commit/d315cae1d9906bce34012162548d6a8d7d6f401b) | `` lightning: 2.2.0 -> 2.2.1 ``                                                                          |
| [`1bf1f7a7`](https://github.com/NixOS/nixpkgs/commit/1bf1f7a75fc139db5c500550efd51568a32cf9be) | `` yabasic: 2.90.2 -> 2.90.3 ``                                                                          |
| [`d5a716d4`](https://github.com/NixOS/nixpkgs/commit/d5a716d4d68211f5c8f52b1d3d4b3eab8399d1cc) | `` acr: 2.0.0 -> 2.1.1 ``                                                                                |
| [`9670b19c`](https://github.com/NixOS/nixpkgs/commit/9670b19ce8f7c23c975a34206bb40e2ace152d09) | `` go-mockery: add package test ``                                                                       |
| [`16bddcfb`](https://github.com/NixOS/nixpkgs/commit/16bddcfbaf8f1942168a553be64a574c635b4622) | `` cri-o: 1.26.1 -> 1.26.2 ``                                                                            |
| [`a58940b3`](https://github.com/NixOS/nixpkgs/commit/a58940b35c31325588802fa70901dc9b290e864b) | `` python310Packages.homeassistant-stubs: 2023.3.1 -> 2023.3.2 ``                                        |
| [`cac6d5d8`](https://github.com/NixOS/nixpkgs/commit/cac6d5d8624a190b558eab1fe6029fd216cd289f) | `` wakatime: 1.68.1 -> 1.68.3 ``                                                                         |
| [`6bbf9ab1`](https://github.com/NixOS/nixpkgs/commit/6bbf9ab16673f8cd656dcca7adef16f06a980125) | `` syncstorage-rs: 0.13.5 -> 0.13.6 ``                                                                   |
| [`099dccdd`](https://github.com/NixOS/nixpkgs/commit/099dccddc9b02f23a8434e75f7c6480a9e554217) | `` ocamlPackages.mirage-kv: 3.0.1 → 4.0.1 ``                                                             |
| [`4fb55b05`](https://github.com/NixOS/nixpkgs/commit/4fb55b055dd0d2ca3500b200de2446d842c7d128) | `` ocamlPackages.mirage-fs: use Dune 3 ``                                                                |
| [`47d453b7`](https://github.com/NixOS/nixpkgs/commit/47d453b770cd91efc11ee95eca59577e502900d8) | `` waybox: unstable-2021-04-07 -> 0.2.0 ``                                                               |
| [`b6124a62`](https://github.com/NixOS/nixpkgs/commit/b6124a6283041411fc8454d5800af499ad82fe94) | `` xemu: 0.7.84 -> 0.7.85 ``                                                                             |
| [`a71e4596`](https://github.com/NixOS/nixpkgs/commit/a71e45961e88c8a6dde6287fa1e061f30f8c2fb7) | `` terraform-providers.tencentcloud: 1.79.13 → 1.79.14 ``                                                |
| [`9d48f500`](https://github.com/NixOS/nixpkgs/commit/9d48f5009d59612000c198801d1f03e960a656c1) | `` terraform-providers.oci: 4.110.0 → 4.111.0 ``                                                         |
| [`b6f45b0f`](https://github.com/NixOS/nixpkgs/commit/b6f45b0f3198b2ed8ea7d694d1a2e736e0907963) | `` terraform-providers.spotinst: 1.103.0 → 1.104.0 ``                                                    |
| [`5a79b956`](https://github.com/NixOS/nixpkgs/commit/5a79b9562ff77f1faf04e4a62c0641dbd71eee42) | `` terraform-providers.scaleway: 2.12.1 → 2.13.0 ``                                                      |
| [`991dd6bf`](https://github.com/NixOS/nixpkgs/commit/991dd6bf2a992bd416b9fae69bdbea38c5e4c043) | `` terraform-providers.local: 2.3.0 → 2.4.0 ``                                                           |
| [`0c0fe2e9`](https://github.com/NixOS/nixpkgs/commit/0c0fe2e9f14387595f8297cfe6352bccf842b5ad) | `` terraform-providers.cloudflare: 4.0.0 → 4.1.0 ``                                                      |
| [`95712a73`](https://github.com/NixOS/nixpkgs/commit/95712a7325653631ecf97ab1f18c8101162815ff) | `` cargo-deb: 1.42.1 -> 1.42.2 ``                                                                        |
| [`a6561d82`](https://github.com/NixOS/nixpkgs/commit/a6561d8237921e552b2cea4c05b74bb0b8a98ddf) | `` cppcheck: 2.10.1 -> 2.10.2 ``                                                                         |
| [`9e6a70d0`](https://github.com/NixOS/nixpkgs/commit/9e6a70d060a2bd7ea328cb7aa29bad10456a3d2d) | `` zoom-us: 5.13.10.1208 -> 5.13.11.1288 ``                                                              |
| [`78ac44af`](https://github.com/NixOS/nixpkgs/commit/78ac44af766f967a2c9dfb88d13688729fba4595) | `` parallel: 20221222 -> 20230222 ``                                                                     |
| [`e9da3a88`](https://github.com/NixOS/nixpkgs/commit/e9da3a88e81c2272f23290dbbb73f953e30c6c15) | `` firefox-devedition-bin-unwrapped: 111.0b7 -> 111.0b8 ``                                               |
| [`e3a07ea7`](https://github.com/NixOS/nixpkgs/commit/e3a07ea75239a62a26c14ad2672737949af8a50c) | `` gh: 2.24.0 -> 2.24.1 ``                                                                               |
| [`b3189634`](https://github.com/NixOS/nixpkgs/commit/b3189634581d204b3c927f1033771cb964fc612f) | `` ssh-to-age: 1.1.1 -> 1.1.2 ``                                                                         |
| [`fe5b3c3e`](https://github.com/NixOS/nixpkgs/commit/fe5b3c3e2d0216796caa875dd85eb52b32aaae00) | `` avalanchego: 1.9.10 -> 1.9.11 ``                                                                      |
| [`0e3e5f3c`](https://github.com/NixOS/nixpkgs/commit/0e3e5f3c7c97054df06969cc95b352dbcd199d7b) | `` automatic-timezoned: 1.0.68 -> 1.0.69 ``                                                              |
| [`ca29761e`](https://github.com/NixOS/nixpkgs/commit/ca29761ef5bc38947d9048b6dc8f3e8c795b6a34) | `` gitlint: 0.18.0 -> 0.19.0 ``                                                                          |
| [`55544a3f`](https://github.com/NixOS/nixpkgs/commit/55544a3fd9ec7b018281b20ec0b0c8f29a1b46c3) | `` gh: 2.23.0 -> 2.24.0 ``                                                                               |
| [`bb9b8682`](https://github.com/NixOS/nixpkgs/commit/bb9b8682d526e193e254db8d3b35832c91d6219e) | `` python310Packages.vsure: 2.6.0 -> 2.6.1 ``                                                            |
| [`374fc068`](https://github.com/NixOS/nixpkgs/commit/374fc068ec1fe11c9f638f5fbf1d5cadb855f938) | `` nixos/systemd-oomd: disable systemd-oomd when enableUnifiedCgroupHierarchy is false ``                |
| [`ea0070a5`](https://github.com/NixOS/nixpkgs/commit/ea0070a5189adcd3e16bd15f0609d34b5abbbcfe) | `` celeste: init at 0.4.6 ``                                                                             |
| [`6d9f07d8`](https://github.com/NixOS/nixpkgs/commit/6d9f07d8fe1b965e9dffdda2ac9638347e8b9bd9) | `` librclone: init at 1.61.1 ``                                                                          |
| [`8fbdc129`](https://github.com/NixOS/nixpkgs/commit/8fbdc12942691a7aa5b5b195b1c0c1924ca49c36) | `` terraform: 1.3.9 -> 1.4.0 ``                                                                          |
| [`9ce2e1a4`](https://github.com/NixOS/nixpkgs/commit/9ce2e1a4153746a5b92d5e10858d306e896594af) | `` python310Packages.homeassistant-stubs: Relax home-assistant version ``                                |
| [`a6f6ec73`](https://github.com/NixOS/nixpkgs/commit/a6f6ec738bd03e99cf4efe8553dbe71f25e3cc5f) | `` tabnine: 4.4.245 -> 4.4.265 ``                                                                        |
| [`36e5e6be`](https://github.com/NixOS/nixpkgs/commit/36e5e6be647356dcd6b9aa0dd31187135af40d17) | `` redpanda: 22.3.13 -> 23.1.1 ``                                                                        |
| [`64a0faa7`](https://github.com/NixOS/nixpkgs/commit/64a0faa70032bf4401e80dba27a9c76d681c8934) | `` erigon: 2.39.0 -> 2.40.1 ``                                                                           |
| [`b1455c8c`](https://github.com/NixOS/nixpkgs/commit/b1455c8cf4326efc4d0ff59d4c1f287718fc3938) | `` python10Packages.ldapdomaindump: add toPythonApplication ``                                           |
| [`c4d1f2b7`](https://github.com/NixOS/nixpkgs/commit/c4d1f2b78ca6fc3d23d66be591e4c2d02f31faed) | `` python310Packages.lcgit: init at 0.2.0 ``                                                             |
| [`b3208451`](https://github.com/NixOS/nixpkgs/commit/b3208451ef21d45ec80eea7fb456fc1d00c64e56) | `` open-pdf-sign: 0.1.3 -> 0.1.4 ``                                                                      |
| [`b4990c98`](https://github.com/NixOS/nixpkgs/commit/b4990c9891e53aabb22504504d890e41f745540d) | `` wasmtime: 6.0.0 -> 6.0.1 ``                                                                           |
| [`856936ab`](https://github.com/NixOS/nixpkgs/commit/856936abc863e1f9b95368c4ac300b0ac82c4e03) | `` buildRustCrate: add libiconv to nativeBuildInputs on darwin ``                                        |
| [`29c84e0d`](https://github.com/NixOS/nixpkgs/commit/29c84e0d6a21fa22c1da464d2575378af3a6daa7) | `` trufflehog: 3.28.7 -> 3.29.0 ``                                                                       |
| [`95b53814`](https://github.com/NixOS/nixpkgs/commit/95b53814cdd8998d504887c445e689089a77d7ad) | `` exploitdb: 2023-03-06 -> 2023-03-08 ``                                                                |
| [`8853df99`](https://github.com/NixOS/nixpkgs/commit/8853df99bce7498a4bbad5c682097371c60d4bc0) | `` fq: 0.3.0 -> 0.4.0 ``                                                                                 |
| [`2f4ea5fa`](https://github.com/NixOS/nixpkgs/commit/2f4ea5fab6dda0199cb5e65d85b5af2eed4de14d) | `` privoxy: 3.0.33 -> 3.0.34 ``                                                                          |
| [`4bc7e7bd`](https://github.com/NixOS/nixpkgs/commit/4bc7e7bd5d92a9ff3776c7ab2d31c4ef9bec21ec) | `` pulumi-bin: 3.55.0 -> 3.56.0 ``                                                                       |
| [`70fa4c65`](https://github.com/NixOS/nixpkgs/commit/70fa4c65696495be22bce506accfca52310f476b) | `` haste-server: ccc5049b07e9f90ec19fc2a88e5056367c53e202 -> b52b394bad909ddf151073987671e843540d91d6 `` |
| [`ad075bd9`](https://github.com/NixOS/nixpkgs/commit/ad075bd91580666d97ad5125d78c7c5cd32403c4) | `` viceroy: init at 0.3.5 ``                                                                             |
| [`4e04af68`](https://github.com/NixOS/nixpkgs/commit/4e04af68ea0029237ba55437a869f4de5a03cdf0) | `` home-assistant: 2023.3.1 -> 2023.3.2 ``                                                               |
| [`cc53194f`](https://github.com/NixOS/nixpkgs/commit/cc53194fbd775345ae3afee98a827630c2310dc9) | `` python310Packages.pyinsteon: 1.3.3 -> 1.3.4 ``                                                        |
| [`53d3317f`](https://github.com/NixOS/nixpkgs/commit/53d3317f6d43e3759f4eef365c6a8dfe099570ff) | `` vscode-extensions.ionide.ionide-fsharp: 6.0.5 -> 7.5.1 ``                                             |
| [`30c16853`](https://github.com/NixOS/nixpkgs/commit/30c168537c08c60454ada54db259bdf7cd300b6c) | `` numix-icon-theme-circle: 23.02.28 -> 23.03.04 ``                                                      |
| [`afeb316d`](https://github.com/NixOS/nixpkgs/commit/afeb316dc36c7f104ea43045d77745ab0705c873) | `` wakapi: 2.6.1 -> 2.6.2 ``                                                                             |
| [`3d8632ab`](https://github.com/NixOS/nixpkgs/commit/3d8632ab47db91f79703f10c0dfb98bd8273013f) | `` phpunit: 10.0.11 -> 10.0.14 ``                                                                        |
| [`978b7cfd`](https://github.com/NixOS/nixpkgs/commit/978b7cfd6046a8611aeb429ca27cfc886eb91a17) | `` go-licenses: init at 1.6.0 ``                                                                         |
| [`ff37d983`](https://github.com/NixOS/nixpkgs/commit/ff37d983b0e343dab0a69ae0602433cdafb13958) | `` linuxKernel.kernels.linux_lqx: 6.1.14-lqx1 -> 6.1.15-lqx2 ``                                          |
| [`41745015`](https://github.com/NixOS/nixpkgs/commit/41745015f68c11694cf7b474db9ccb5de0be6ffa) | `` reaper: 6.75 -> 6.77 ``                                                                               |
| [`ff048a29`](https://github.com/NixOS/nixpkgs/commit/ff048a29f0565668fd7e9c746f8a57a4b173d9e4) | `` linuxKernel.kernels.linux_zen: 6.2.2-zen1 -> 6.2.2-zen2 ``                                            |
| [`668f36db`](https://github.com/NixOS/nixpkgs/commit/668f36dbd53aa72348e0187b6d174312ea627b33) | `` ryujinx: 1.1.489 -> 1.1.650 ``                                                                        |
| [`eb127968`](https://github.com/NixOS/nixpkgs/commit/eb12796851c12259d3a628eda8f8c0a07c455fa9) | `` shadowsocks-v2ray-plugin: 1.3.1 -> 1.3.2 ``                                                           |
| [`bd7439ef`](https://github.com/NixOS/nixpkgs/commit/bd7439ef8c332465035bba3f564540bf5692513f) | `` xcp: 0.9.3 -> 0.9.4 ``                                                                                |
| [`22fd05ad`](https://github.com/NixOS/nixpkgs/commit/22fd05adeeae38dd23be4b4c0ffb18f3f1fd264c) | `` networkd-dispatcher: Add patch support store files ``                                                 |
| [`26e14e57`](https://github.com/NixOS/nixpkgs/commit/26e14e57af344f61d8adc37ce4f6f1fe554861bc) | `` nixos/networkd-dispatcher: add rules option ``                                                        |
| [`410dfd65`](https://github.com/NixOS/nixpkgs/commit/410dfd651a828131ee0cd6f9a043310b07539db5) | `` python310Packages.aioslimproto: add changelog to meta ``                                              |
| [`3d37d1bc`](https://github.com/NixOS/nixpkgs/commit/3d37d1bcc22837edfe18874a3fe83db6b981bb5c) | `` python310Packages.aioslimproto: 2.1.1 -> 2.2.0 ``                                                     |
| [`3a38710c`](https://github.com/NixOS/nixpkgs/commit/3a38710c9211940fb7cebb88c1805d1973b6a918) | `` python3Packages.squarify: init at 0.4.3 ``                                                            |
| [`d7a0fc6e`](https://github.com/NixOS/nixpkgs/commit/d7a0fc6e764f1a8cca6532a97b3d228c1f6bec90) | `` amass: 3.21.2 -> 3.22.0 ``                                                                            |
| [`bfb509e4`](https://github.com/NixOS/nixpkgs/commit/bfb509e45c09585a5fb4c36032b5cfcab65ee9f4) | `` python310Packages.insteon-frontend-home-assistant: 0.3.2 -> 0.3.3 ``                                  |
| [`2cd53e12`](https://github.com/NixOS/nixpkgs/commit/2cd53e12829b1d80ca79e520cd720ec9bcb51ee0) | `` python310Packages.caldav: 1.2.0 -> 1.2.1 ``                                                           |
| [`c3dcd58d`](https://github.com/NixOS/nixpkgs/commit/c3dcd58d7ef46075fa5f3aa2a106b98dd636223c) | `` netbird: 0.14.1 -> 0.14.2 ``                                                                          |
| [`7018cf78`](https://github.com/NixOS/nixpkgs/commit/7018cf78c618e0a8ec4369c587319f51cb7b19b0) | `` magma: fix for cuda_profiler_api.h for CUDA 11.8+ ``                                                  |
| [`de134a16`](https://github.com/NixOS/nixpkgs/commit/de134a16be5e6393b8852b4c4aa61bc623c13eb8) | `` chromium: 110.0.5481.177 -> 111.0.5563.64 ``                                                          |
| [`0835e5a1`](https://github.com/NixOS/nixpkgs/commit/0835e5a189bf0ae676ccfd91afaf0e6c39c65b28) | `` nodePackages: regen only node-env ``                                                                  |
| [`b85c1e31`](https://github.com/NixOS/nixpkgs/commit/b85c1e319e28161044e0ca1a33cdb69310d1e93f) | `` node2nix: pull in patch to fix bin scripts with crlf line-endings ``                                  |
| [`19f0a78c`](https://github.com/NixOS/nixpkgs/commit/19f0a78c195223e7021ff4d16bad71c6f4cb981d) | `` mpvScripts.uosc: init at 4.6.0 ``                                                                     |
| [`f59d3afc`](https://github.com/NixOS/nixpkgs/commit/f59d3afcd5e0d0e7e763155254b89ef115ecb654) | `` organicmaps: add updateScript ``                                                                      |
| [`546adc67`](https://github.com/NixOS/nixpkgs/commit/546adc67e70ce0b1aa6a34ad2ccc0238548320ed) | `` organicmaps: 2023.01.25-3 -> 2023.03.05-5 ``                                                          |
| [`481f02f7`](https://github.com/NixOS/nixpkgs/commit/481f02f7dd1b21ddfc363ec30b99fcfac04deaec) | `` mpv: allow scripts to add wrapper args ``                                                             |
| [`16818343`](https://github.com/NixOS/nixpkgs/commit/16818343f11972ed7f591080992ba146790cc2f1) | `` maintainers: add apfelkuchen6 ``                                                                      |
| [`33c3687d`](https://github.com/NixOS/nixpkgs/commit/33c3687d221b4be03e9a891636d8c25401c3317b) | `` vscodium: 1.75.0.23033 -> 1.76.0.23062 ``                                                             |
| [`abedfdd3`](https://github.com/NixOS/nixpkgs/commit/abedfdd3da6c1a301f23556f06936490e69c070a) | `` maintainers: remove nichtsfrei ``                                                                     |
| [`6428223c`](https://github.com/NixOS/nixpkgs/commit/6428223c0ec203dc80716f100f89985bc4caafb2) | `` cgreen: take maintenance ``                                                                           |
| [`2c02d0ba`](https://github.com/NixOS/nixpkgs/commit/2c02d0ba11687d5ecca95ac33b1e9227f920ac3c) | `` mongosh: 1.6.2 -> 1.8.0, use buildNpmPackage ``                                                       |
| [`35081a77`](https://github.com/NixOS/nixpkgs/commit/35081a77d56c84bea79bc810a825179357d68658) | `` cargo-llvm-cov: don't recommend nixpkgs-mozilla ``                                                    |
| [`fcc10ee9`](https://github.com/NixOS/nixpkgs/commit/fcc10ee9a4891ea20194fa8178d55786439fd73a) | `` cargo-binutils: don't recommend nixpkgs-mozilla ``                                                    |
| [`b373d299`](https://github.com/NixOS/nixpkgs/commit/b373d299bae89922f2bde5f351b90495b182daf2) | `` docs/rust: improve docs for nightly usage ``                                                          |
| [`fa8ecdce`](https://github.com/NixOS/nixpkgs/commit/fa8ecdced8888122a4ec14c8e652d350b2c97fd1) | `` monocraft: 1.4 -> 2.4 ``                                                                              |
| [`2100c492`](https://github.com/NixOS/nixpkgs/commit/2100c4926200b1ebbee032ad22113597195932f2) | `` endless-sky:0.9.14 -> 0.9.16.1 ``                                                                     |
| [`a48211c3`](https://github.com/NixOS/nixpkgs/commit/a48211c319dc9520dbabfd20bd2001f991fd898e) | `` microsoft-edge: fix file picker and `subsituteInPlace` ``                                             |
| [`118bdf25`](https://github.com/NixOS/nixpkgs/commit/118bdf25a6c572dd2fd29d10b1ae2e4d9a95b907) | `` lib/modules: Allow an "anonymous" module with key in disabledModules ``                               |
| [`eddb6a1b`](https://github.com/NixOS/nixpkgs/commit/eddb6a1b6241303c0310993294662e9347a2435d) | `` hunspell: fix spanish-language dictionaries ``                                                        |
| [`1e2257a4`](https://github.com/NixOS/nixpkgs/commit/1e2257a4584ee372ab772741e5546bed6244d591) | `` maintainers: update lunik1's gpg key ``                                                               |
| [`2c7af955`](https://github.com/NixOS/nixpkgs/commit/2c7af95567179d59340bf54800642b851133dd3c) | `` pre-commit: 2.20.0 -> 3.1.0 ``                                                                        |
| [`e78dc938`](https://github.com/NixOS/nixpkgs/commit/e78dc938d81cc175f4af9da0d94771c39aa43cd5) | `` nixos/qemu-vm: fix minor typo ``                                                                      |
| [`f83f0f8d`](https://github.com/NixOS/nixpkgs/commit/f83f0f8dfaf0f7ec853597fa236340bc1873d315) | `` python3Packages.mixins: init at 0.1.4 ``                                                              |
| [`51417891`](https://github.com/NixOS/nixpkgs/commit/514178918f7f97a066911c0ce3fc2d41f550a934) | `` 0.7.0 -> 0.7.2 ``                                                                                     |
| [`ee89f8e1`](https://github.com/NixOS/nixpkgs/commit/ee89f8e1e558c2021a7bea8a7dd50b9521afb772) | `` navidrome: 0.49.1 -> 0.49.3 ``                                                                        |
| [`84e04ccf`](https://github.com/NixOS/nixpkgs/commit/84e04ccf8570e9f8072486f7d750d326225c7117) | `` dockerTools: Preprocess layers list before unpack to handle repeated layers ``                        |
| [`298c543e`](https://github.com/NixOS/nixpkgs/commit/298c543e55284a3be8e8785302883fb873e005af) | `` dockerTools: Specify 'latest' tag for repeated layer test image ``                                    |
| [`c66cabe3`](https://github.com/NixOS/nixpkgs/commit/c66cabe33ea1f969ef9562feeef0a015b83a60b1) | `` dockerTools: use more familiar terminology to describe test image ``                                  |
| [`eb38ad04`](https://github.com/NixOS/nixpkgs/commit/eb38ad04efae0ebcd7217c4ccace3da0102d85af) | `` dockerTools: ensure runAsRoot script not optimized away in test ``                                    |
| [`56ecab70`](https://github.com/NixOS/nixpkgs/commit/56ecab709a5a6e49049c0892a7cc59cfa22bdd98) | `` nixos/coder: init module ``                                                                           |
| [`0566d27d`](https://github.com/NixOS/nixpkgs/commit/0566d27d03a7b9c285045f57004a6ba2c2613454) | `` coder: fix web frontend building ``                                                                   |
| [`7c201f6b`](https://github.com/NixOS/nixpkgs/commit/7c201f6b53bf4acc77184d110cd2cfd72d065bae) | `` Add whitespaces for readability. ``                                                                   |
| [`68f5e955`](https://github.com/NixOS/nixpkgs/commit/68f5e9554ffa3cfee31786f9a3013ebd8a7d8308) | `` Add maintainers ``                                                                                    |
| [`2bf1fca5`](https://github.com/NixOS/nixpkgs/commit/2bf1fca5ac68b085bbc42f445731791cf5aa3b1b) | `` Update pkgs/tools/wayland/swww/default.nix ``                                                         |
| [`2a5bf1fc`](https://github.com/NixOS/nixpkgs/commit/2a5bf1fcdfc8658678bc9305677dfa0fda907367) | `` Update pkgs/tools/wayland/swww/default.nix ``                                                         |
| [`a124a517`](https://github.com/NixOS/nixpkgs/commit/a124a517b2e66078143beaae058e394aa5c1acc0) | `` Update pkgs/tools/wayland/swww/default.nix ``                                                         |
| [`9377f94a`](https://github.com/NixOS/nixpkgs/commit/9377f94ac5c69eaeca0a2a9d13a41ea7f41c0b7d) | `` swww: v0.5.0 -> v0.7.0 ``                                                                             |
| [`f4e4cac0`](https://github.com/NixOS/nixpkgs/commit/f4e4cac0c86f0e16aac773083aebbfc0e7daea43) | `` dockerTools: Correctly unpack duplicate rootfs diffs ``                                               |
| [`6f63865c`](https://github.com/NixOS/nixpkgs/commit/6f63865cf470ce99b36bceacbefbb6886d05be51) | `` dockerTools: Add minimal test case for #214434 ``                                                     |
| [`a7ea3911`](https://github.com/NixOS/nixpkgs/commit/a7ea3911798120047beb25be107138a0c547dce2) | `` swww: init at 0.5.0 ``                                                                                |