### PR TITLE
chore(flake/home-manager): `36999b8d` -> `7224d7c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678271387,
-        "narHash": "sha256-H2dv/i1LRlunRtrESirELzfPWdlG/6ElDB1ksO529H4=",
+        "lastModified": 1678464939,
+        "narHash": "sha256-pRMlwOUkO1OwSi7qF6XR/zcocWy/ZYxXgbYWvnZQO9k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "36999b8d19eb6eebb41983ef017d7e0095316af2",
+        "rev": "7224d7c54c5fc74cdf60b208af6148ed3295aa32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`7224d7c5`](https://github.com/nix-community/home-manager/commit/7224d7c54c5fc74cdf60b208af6148ed3295aa32) | `` zellij: fix typo ``                                       |
| [`c03d1e75`](https://github.com/nix-community/home-manager/commit/c03d1e75a1e5e10384e2836cdd6537a4e94be89a) | `` zellij: switch config lang from yaml to kdl for 0.32.0 `` |
| [`fce9dbfe`](https://github.com/nix-community/home-manager/commit/fce9dbfeb4fa0b0878cf4ebd375d4f2b5acc87b0) | `` lib: add generator for KDL ``                             |