### PR TITLE
chore(flake/nixpkgs): `1e259067` -> `0c4800d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678380223,
-        "narHash": "sha256-HUxnK38iqrX84QdQxbFcosRKV3/koj1Zzp5b5aP4lIo=",
+        "lastModified": 1678470307,
+        "narHash": "sha256-OEeMUr3ueLIXyW/OaFUX5jUdimyQwMg/7e+/Q0gC/QE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1e2590679d0ed2cee2736e8b80373178d085d263",
+        "rev": "0c4800d579af4ed98ecc47d464a5e7b0870c4b1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`cab32f0f`](https://github.com/NixOS/nixpkgs/commit/cab32f0f86e519a90249c612b3fee06fab9d1db3) | `` nixos/jellyseerr: init ``                                                                |
| [`c69fbc12`](https://github.com/NixOS/nixpkgs/commit/c69fbc12abc41cc76508c6ca6abf4351f285b591) | `` ArchiSteamFarm: 5.4.2.13 -> 5.4.3.2 ``                                                   |
| [`f69a8fab`](https://github.com/NixOS/nixpkgs/commit/f69a8fabf17ed54198cd15479f9836e97087ca45) | `` treewide: withIntrospection (host == build) -> (host.emulatorAvailable buildPackages) `` |
| [`262539b3`](https://github.com/NixOS/nixpkgs/commit/262539b3dd5f3e3207ab31cfb5df9ab4490f776a) | `` photoflow: drop ``                                                                       |
| [`f8fcd228`](https://github.com/NixOS/nixpkgs/commit/f8fcd228dff4b3804762f5f401c6595dab297637) | `` jellyseerr: init at 1.4.1 ``                                                             |
| [`711dbcd4`](https://github.com/NixOS/nixpkgs/commit/711dbcd43bf7f155c59428b04325713a161913c8) | `` invidious: unstable-2023-02-22 -> unstable-2023-03-07 ``                                 |
| [`7c98145f`](https://github.com/NixOS/nixpkgs/commit/7c98145f36b0c023185e71e0a52701a4f6ba419a) | `` openocd: rework configuration flags ``                                                   |
| [`1dea6175`](https://github.com/NixOS/nixpkgs/commit/1dea6175784e082ef77bcbf960fe6c43238592e3) | `` python3.pkgs.hepmc3: use pythonImportsCheck ``                                           |
| [`cf91b242`](https://github.com/NixOS/nixpkgs/commit/cf91b242d2b806c5d3592d415cbbb84e46df4485) | `` python3.pkgs.sip_4: use pythonImportsCheck ``                                            |
| [`809c0ce0`](https://github.com/NixOS/nixpkgs/commit/809c0ce0cdfa4b386325acbb42adf3809958ac29) | `` python3.pkgs.mpv: use pythonImportsCheck ``                                              |
| [`56c60393`](https://github.com/NixOS/nixpkgs/commit/56c60393564fc4636961bc6ea5828cbbb1aab3e0) | `` gvproxy: 0.5.0 -> 0.6.0 ``                                                               |
| [`fd9da353`](https://github.com/NixOS/nixpkgs/commit/fd9da3532ffd5a4c8f5b84537c8abb500d9bf0cf) | `` linux/hardened/patches/6.1: 6.1.14-hardened1 -> 6.1.15-hardened1 ``                      |
| [`4ca1df07`](https://github.com/NixOS/nixpkgs/commit/4ca1df077ba81e823d4c2999d99754dd163a0739) | `` linux/hardened/patches/5.4: 5.4.233-hardened1 -> 5.4.234-hardened1 ``                    |
| [`9807c723`](https://github.com/NixOS/nixpkgs/commit/9807c72306bc0d874bd357b7484f55baea0815b9) | `` linux/hardened/patches/5.15: 5.15.96-hardened1 -> 5.15.98-hardened1 ``                   |
| [`1f0d5bff`](https://github.com/NixOS/nixpkgs/commit/1f0d5bff11dadfaa8bb8950c92cf58445654653b) | `` linux/hardened/patches/5.10: 5.10.170-hardened1 -> 5.10.172-hardened1 ``                 |
| [`c4945107`](https://github.com/NixOS/nixpkgs/commit/c49451078dba6127640d9bfb39f2c7a16cf44dde) | `` linux/hardened/patches/4.19: 4.19.274-hardened1 -> 4.19.275-hardened1 ``                 |
| [`0babddbc`](https://github.com/NixOS/nixpkgs/commit/0babddbcb546ae090eb34f17c47e65035762c614) | `` linux: 6.2.2 -> 6.2.3 ``                                                                 |
| [`49009b03`](https://github.com/NixOS/nixpkgs/commit/49009b03b84472cb4bd573a4b742f6fba1645a8f) | `` linux: 6.1.15 -> 6.1.16 ``                                                               |
| [`67ca0e54`](https://github.com/NixOS/nixpkgs/commit/67ca0e5422382ab47421290283b8e21e9ae64ed9) | `` linux: 5.15.97 -> 5.15.99 ``                                                             |
| [`f6c7c982`](https://github.com/NixOS/nixpkgs/commit/f6c7c9820951cf5ac41ff278269fa2b1b8493928) | `` lagrange: 1.15.3 -> 1.15.4 ``                                                            |
| [`50389247`](https://github.com/NixOS/nixpkgs/commit/5038924756ca156303d7fb1b265091bb133c7f74) | `` dia: fix darwin build ``                                                                 |
| [`5d59944c`](https://github.com/NixOS/nixpkgs/commit/5d59944c16cb301dad1116989f5ff565c32a2af9) | `` python310Packages.r2pipe: 1.7.4 -> 1.8.0 ``                                              |
| [`d60c3be2`](https://github.com/NixOS/nixpkgs/commit/d60c3be234c940986f85d86e7c78900c4c4f8986) | `` glmark2: enable more flavors ``                                                          |
| [`44e32d9d`](https://github.com/NixOS/nixpkgs/commit/44e32d9dc01168a9fc00d7504a27499c4de9b26b) | `` glmark2: remove unused xorg.libxcb input ``                                              |
| [`b80dd48f`](https://github.com/NixOS/nixpkgs/commit/b80dd48f26ac240a60c3151f6bbc452a099833a1) | `` glmark2: fix cross ``                                                                    |
| [`48532d59`](https://github.com/NixOS/nixpkgs/commit/48532d5957853537a7805fcd99602b91059e9e8f) | `` glmark2: switch to meson ``                                                              |
| [`52f23c96`](https://github.com/NixOS/nixpkgs/commit/52f23c96b3941bf189e97c3676504772b371e08e) | `` libtiger: fix cross ``                                                                   |
| [`15d17270`](https://github.com/NixOS/nixpkgs/commit/15d172707718193781fa7301b813a088c80c19a8) | `` fac-build: fix tests calling out to git ``                                               |
| [`b6d9b11b`](https://github.com/NixOS/nixpkgs/commit/b6d9b11bf0ca422eb699ed85a74936f0654eae25) | `` python3.pkgs.tensorflow: fix evaluation when generating nix dependency graph ``          |
| [`fd613a85`](https://github.com/NixOS/nixpkgs/commit/fd613a859742173af8a524e9203e55a8a349bde2) | `` python3.pkgs.ray: fix evaluation when generating nix dependency graph ``                 |
| [`6cf53666`](https://github.com/NixOS/nixpkgs/commit/6cf53666ccf8dbd2df3b4ddafd7abfde4a3d3e13) | `` blackfire: 2.13.2 -> 2.14.0 ``                                                           |
| [`621e0326`](https://github.com/NixOS/nixpkgs/commit/621e03261bee46cc5cfe0de8ad8523c088fa4eb9) | `` cargo-public-api: add changelog to meta ``                                               |
| [`2dac2163`](https://github.com/NixOS/nixpkgs/commit/2dac2163199113a5e7aed7201faaab4240fd1450) | `` python310Packages.pymumble: disable on unsupported Python releases ``                    |
| [`e26618d5`](https://github.com/NixOS/nixpkgs/commit/e26618d5f160a4e768126ab9ebbe5518a077c2fa) | `` python310Packages.pymumble: fix description and add changelog ``                         |
| [`db8204b8`](https://github.com/NixOS/nixpkgs/commit/db8204b8c117096628eff0644d08ac4709c1d7fb) | `` libreddit: 0.29.4 -> 0.30.0 ``                                                           |
| [`dacdad83`](https://github.com/NixOS/nixpkgs/commit/dacdad8313b13b600686cca4d728bea9cf0ec6f8) | `` python310Packages.gcovr: add changelog to meta ``                                        |
| [`aae53ab9`](https://github.com/NixOS/nixpkgs/commit/aae53ab9d7a0c51348a6d906622b920d55d68572) | `` python310Packages.adafruit-platformdetect: 3.40.3 -> 3.41.0 ``                           |
| [`541165f6`](https://github.com/NixOS/nixpkgs/commit/541165f6f804438c749a0745ae1098a5a07d3344) | `` python310Packages.gcovr: 5.2 -> 6.0 ``                                                   |
| [`99644ea9`](https://github.com/NixOS/nixpkgs/commit/99644ea939a3c621eb5da32ca3edc0e0ac11b648) | `` cargo-public-api: 0.27.2 -> 0.27.3 ``                                                    |
| [`88bdb6d7`](https://github.com/NixOS/nixpkgs/commit/88bdb6d79b0bdf03d3338f6f3d1416a55ec199ab) | `` terraform-providers.aws: 4.57.1 → 4.58.0 ``                                              |
| [`822303df`](https://github.com/NixOS/nixpkgs/commit/822303df353a3e56d12b62fde718ed8433943d40) | `` terraform-providers.spotinst: 1.104.0 → 1.105.0 ``                                       |
| [`5842c95c`](https://github.com/NixOS/nixpkgs/commit/5842c95c5a2d30c07876116d7d0a816386eb335f) | `` terraform-providers.pagerduty: 2.11.0 → 2.11.1 ``                                        |
| [`f3cebecb`](https://github.com/NixOS/nixpkgs/commit/f3cebecb6e6c5da48aed554722c3bb1c9e3e5eb1) | `` terraform-providers.opentelekomcloud: 1.33.1 → 1.33.2 ``                                 |
| [`d970c3c4`](https://github.com/NixOS/nixpkgs/commit/d970c3c412c97770ff720c168a84d0b3423f1288) | `` terraform-providers.newrelic: 3.15.0 → 3.16.0 ``                                         |
| [`a7fff547`](https://github.com/NixOS/nixpkgs/commit/a7fff5473b83eb6d2419386d37e8a75d9106d145) | `` terraform-providers.grafana: 1.35.0 → 1.36.0 ``                                          |
| [`202eb1af`](https://github.com/NixOS/nixpkgs/commit/202eb1afb5b6654b19c3967aae391af0965739f1) | `` terraform-providers.fastly: 3.2.0 → 4.0.0 ``                                             |
| [`1c4e1ea5`](https://github.com/NixOS/nixpkgs/commit/1c4e1ea502d792f47b0b3995b9bf3e57dfb821db) | `` boomerang: remove obsolete comment ``                                                    |
| [`564e20e6`](https://github.com/NixOS/nixpkgs/commit/564e20e62dc9fcf1af8a8eb7ddbcb62592e5a4f4) | `` Revert "root: remove the already-default CMAKE_INSTALL_*DIR flags" (#220437) ``          |
| [`773dfa22`](https://github.com/NixOS/nixpkgs/commit/773dfa2228130743d4a59f6523807f7d48b14a14) | `` qt5/qtbase.nix: add mysqlSupport ``                                                      |
| [`e99d07eb`](https://github.com/NixOS/nixpkgs/commit/e99d07ebddc6422f688a9d8a3acc3c88913e65cb) | `` python310Packages.pymumble: 1.6.1 -> 1.7 ``                                              |
| [`31d5f226`](https://github.com/NixOS/nixpkgs/commit/31d5f226eed13018196f94e63fa0b57ffd09b5a8) | `` embree,embree2: disable aarch64-linux ``                                                 |
| [`9ebf2623`](https://github.com/NixOS/nixpkgs/commit/9ebf26234783dbdac54c470b466e02c99f39bdc0) | `` cryptomator: mark as working on intel only ``                                            |
| [`dc23d0ab`](https://github.com/NixOS/nixpkgs/commit/dc23d0abfef0527b71a89ceeb51bce4362ce98db) | `` httm: 0.23.2 -> 0.23.3 ``                                                                |
| [`71566884`](https://github.com/NixOS/nixpkgs/commit/71566884c7980394e63a57f2471f89477cf3f827) | `` oven-media-engine: 0.15.1 -> 0.15.3 ``                                                   |
| [`b7a9c677`](https://github.com/NixOS/nixpkgs/commit/b7a9c67760faadccb19020aa19509af89cc4714a) | `` lua-language-server: 3.6.13 -> 3.6.17 ``                                                 |
| [`432d2776`](https://github.com/NixOS/nixpkgs/commit/432d2776b9dc296cf6f39d37f3a3bc85a4ded93e) | `` keyscope: 1.2.3 -> 1.3.0 ``                                                              |
| [`813991f1`](https://github.com/NixOS/nixpkgs/commit/813991f103de820455b49b0a24af297f74b21c56) | `` bc-decaf: Update to latest commit ``                                                     |
| [`63118380`](https://github.com/NixOS/nixpkgs/commit/631183807e8998d430c331ccd70e98b91d018c2e) | `` comma: 1.4.1 -> 1.5.0 ``                                                                 |
| [`2cae38a7`](https://github.com/NixOS/nixpkgs/commit/2cae38a78fa89908c3f2fe34570d0470369f6eda) | `` secp256k1: 0.2.0 -> 0.3.0 ``                                                             |
| [`f71a3fa4`](https://github.com/NixOS/nixpkgs/commit/f71a3fa40adfff2858dccff14751c9ca1e8d2f5c) | `` infracost: 0.10.17 -> 0.10.18 ``                                                         |
| [`20089ada`](https://github.com/NixOS/nixpkgs/commit/20089adad9a06c81aa204b1ee14cd103117297de) | `` moq: 0.3.0 -> 0.3.1 ``                                                                   |
| [`c42b85cf`](https://github.com/NixOS/nixpkgs/commit/c42b85cfd2633d6f07de5542f6f9dd8897fd61d2) | `` ventoy-bin-full: 1.0.88 -> 1.0.89 ``                                                     |
| [`4e283a00`](https://github.com/NixOS/nixpkgs/commit/4e283a00750d3f9052c94fea26bd511b33e6b8c4) | `` dnscontrol: 3.27.1 -> 3.27.2 ``                                                          |
| [`5b4645a2`](https://github.com/NixOS/nixpkgs/commit/5b4645a2ea79b26b770e0fd86853f6a8e66a1e2a) | `` python310Packages.trove-classifiers: 2023.2.20 -> 2023.3.9 ``                            |
| [`7f2b7d56`](https://github.com/NixOS/nixpkgs/commit/7f2b7d56d816eba7058447ddd07674c4b10a5337) | `` nodePackages: update all ``                                                              |
| [`9f98bcb9`](https://github.com/NixOS/nixpkgs/commit/9f98bcb917b646ce038bd2e6960ba618e569ed66) | `` vscode-extensions.rust-lang.rust-analyzer: 0.3.1059 -> 0.3.1426 ``                       |
| [`edcd3849`](https://github.com/NixOS/nixpkgs/commit/edcd3849a6f4c11ac7c5fc8092a6deb0c2f7bf8f) | `` blender: Fix build after changes in Alembic package ``                                   |
| [`54e1189f`](https://github.com/NixOS/nixpkgs/commit/54e1189fbc2d0b89c16abb1ddf42ec8ad2cb55e0) | `` alembic: Add maintainer tmarkus ``                                                       |
| [`79aebb62`](https://github.com/NixOS/nixpkgs/commit/79aebb620410688000749775c4c52171fdb8c748) | `` alembic: Fix install destinations ``                                                     |
| [`dbcfd1f9`](https://github.com/NixOS/nixpkgs/commit/dbcfd1f947999ebefbe02e12a6a12f25aace9ba0) | `` skim: 0.10.3 -> 0.10.4 ``                                                                |
| [`633dd775`](https://github.com/NixOS/nixpkgs/commit/633dd775ee3a8d311899483a4b20fe8112506810) | `` toast: 0.46.1 -> 0.46.2 ``                                                               |
| [`90bca354`](https://github.com/NixOS/nixpkgs/commit/90bca3541d87edf83cb7d7693da9e5bdf7e1b107) | `` gh: 2.24.1 -> 2.24.3 ``                                                                  |
| [`56ddb037`](https://github.com/NixOS/nixpkgs/commit/56ddb0373d74e6fa05f72d2a261c98fd04624517) | `` stduuid: 1.2.2 -> 1.2.3 ``                                                               |
| [`0061cd98`](https://github.com/NixOS/nixpkgs/commit/0061cd98801ada930e04bec8c9d9df45691bc40d) | `` vimPlugins.smartyank-nvim: init at 2023-02-25 ``                                         |
| [`ed00c38e`](https://github.com/NixOS/nixpkgs/commit/ed00c38e0a4885aae0ba183402e8a36bee34265a) | `` torchvision: fix C/C++ compilers when using CUDA; migrate to cudaPackages ``             |
| [`175a86d3`](https://github.com/NixOS/nixpkgs/commit/175a86d3b654afcfb6d98598c3abca5f436f35fb) | `` ungoogled-chromium: 110.0.5481.177 -> 111.0.5563.65 ``                                   |
| [`afd3b4cf`](https://github.com/NixOS/nixpkgs/commit/afd3b4cfe254a131f95402fbb29af7be79c9b864) | `` chromiumDev: 112.0.5615.20 -> 113.0.5638.0 ``                                            |
| [`036f75ff`](https://github.com/NixOS/nixpkgs/commit/036f75ff5c9a8f49c09a656fc88e20ace2b34513) | `` chromiumBeta: 111.0.5563.64 -> 112.0.5615.20 ``                                          |
| [`a16f7f0b`](https://github.com/NixOS/nixpkgs/commit/a16f7f0b658f8182ac29ebdd2f7c8a39d8a8eaeb) | `` brave: 1.48.171 -> 1.49.120 ``                                                           |
| [`737e372a`](https://github.com/NixOS/nixpkgs/commit/737e372a78fbbc4f9dd8bdb9c7eeefe4d1e233f8) | `` fastly: use viceroy from nix ``                                                          |
| [`bc7d355d`](https://github.com/NixOS/nixpkgs/commit/bc7d355dc07ad0c789e45877cd8d7896253923ad) | `` lib.systems: don't try to emulate s390-linux ``                                          |
| [`56be2087`](https://github.com/NixOS/nixpkgs/commit/56be2087c5c3080052a2b70376cb70f810b34d14) | `` ebook_tools: fix cross ``                                                                |
| [`2cbbef00`](https://github.com/NixOS/nixpkgs/commit/2cbbef006b5b48dc9428d3caa99f853fedc6bfe7) | `` qt5: use makeScopeWithSplicing ``                                                        |
| [`7d8b42a5`](https://github.com/NixOS/nixpkgs/commit/7d8b42a553f3fa2f76e1b754b424d1c3c23bd7d0) | `` qt5: inherit from __splicedPackages to fix cross ``                                      |
| [`b5eda881`](https://github.com/NixOS/nixpkgs/commit/b5eda8810115633af15ad39228384e25c123bf51) | `` syncthing: 1.23.1 -> 1.23.2 ``                                                           |
| [`571144ff`](https://github.com/NixOS/nixpkgs/commit/571144ff898f49451dbe6334876f7d5bca069dff) | `` AusweisApp2: 1.26.2 -> 1.26.3 ``                                                         |
| [`da836086`](https://github.com/NixOS/nixpkgs/commit/da8360869d6d10895e8b7a6f1578149aac6e0a29) | `` ocamlPackages.letsencrypt-mirage: init at 0.5.0 ``                                       |
| [`b9e07a88`](https://github.com/NixOS/nixpkgs/commit/b9e07a88a2932fd6314c285e9314612f77376b13) | `` ocamlPackages.mirage-crypto: use Dune 3 ``                                               |
| [`28716c57`](https://github.com/NixOS/nixpkgs/commit/28716c579465ab66c1408ad8dd303aa232ab01f1) | `` ocamlPackages.chacha: use Dune 3 ``                                                      |
| [`92cebed2`](https://github.com/NixOS/nixpkgs/commit/92cebed2f9f5342604f4e594f3d1e8acd305dd29) | `` ocamlPackages.http-mirage-client: init at 0.0.2 ``                                       |
| [`28408bf0`](https://github.com/NixOS/nixpkgs/commit/28408bf0764b3e49797c4169cc9d708d212be120) | `` fluxcd: 0.40.2 -> 0.41.0 ``                                                              |
| [`78c95c14`](https://github.com/NixOS/nixpkgs/commit/78c95c14b6b74812dfd76ddc44344826f723cc7c) | `` awscli2: 2.11.0 -> 2.11.1 ``                                                             |
| [`1a032cd8`](https://github.com/NixOS/nixpkgs/commit/1a032cd8e706635ecd904475020cf6ae41a569db) | `` pdfmixtool: 1.1 -> 1.1.1 ``                                                              |
| [`b475625a`](https://github.com/NixOS/nixpkgs/commit/b475625a9e248f6ff3d9982c6546489306be867f) | `` mkgmap: 4906 -> 4907 ``                                                                  |
| [`adfc3fec`](https://github.com/NixOS/nixpkgs/commit/adfc3fec360260358a48e1bad5f7ab507407230b) | `` julia_19: 1.9.0-beta4 -> 1.9.0-rc1 ``                                                    |
| [`6cdbfcb0`](https://github.com/NixOS/nixpkgs/commit/6cdbfcb08621d161f33395fc11470f9cd650ebd2) | `` imagemagick: 7.1.0-62 -> 7.1.1-0 ``                                                      |
| [`4a3ca0b4`](https://github.com/NixOS/nixpkgs/commit/4a3ca0b41bffdcf413e8d2b12037fdf7fcb1d098) | `` python310Packages.pybalboa: 1.0.0 -> 1.0.1 ``                                            |
| [`5b6722f2`](https://github.com/NixOS/nixpkgs/commit/5b6722f20ecb9e1c7ed76018c9736a6d114ba035) | `` plexRaw: 1.31.1.6733-bc0674160 -> 1.31.1.6782-77dfff442 ``                               |
| [`d7867e8b`](https://github.com/NixOS/nixpkgs/commit/d7867e8b8cc47c40998c6a26871fde1c4226a248) | `` ffmpeg: fix configure errors on native armv7l-linux ``                                   |
| [`9202661d`](https://github.com/NixOS/nixpkgs/commit/9202661d5b0dc3f8c42080b12f046314e1af808f) | `` minimacy: 0.6.2 -> 0.6.4 ``                                                              |
| [`83ebe5b1`](https://github.com/NixOS/nixpkgs/commit/83ebe5b11174dc6ce177a52827132111c184a55b) | `` vala-language-server: aarch64-darwin build ``                                            |
| [`fe12faba`](https://github.com/NixOS/nixpkgs/commit/fe12faba4d9e8d57aea0d2940d756bbd44c7370f) | `` Revert "Merge pull request #217317 from atorres1985-contrib/remove-bqn-mode" ``          |
| [`e2b1f289`](https://github.com/NixOS/nixpkgs/commit/e2b1f289a30addca193722c525e1a8cfd7b421ce) | `` python310Packages.timeago: 1.0.15 -> 1.0.16 ``                                           |
| [`2aa99214`](https://github.com/NixOS/nixpkgs/commit/2aa9921403ddc795344a3af7f891ddde7f48bc83) | `` datree: 1.8.33 -> 1.8.36 ``                                                              |
| [`d6e52d26`](https://github.com/NixOS/nixpkgs/commit/d6e52d26b092036423beb029e67283e6fa9c4768) | `` shell-genie: specify license ``                                                          |
| [`7c88c18a`](https://github.com/NixOS/nixpkgs/commit/7c88c18a082c20a2ab556488615626c01fac534f) | `` qdrant: 1.0.2 -> 1.0.3 ``                                                                |
| [`de470781`](https://github.com/NixOS/nixpkgs/commit/de4707810d0eb970b073ce584906b9752b2d1971) | `` python310Packages.screenlogicpy: 0.8.0 -> 0.8.1 ``                                       |
| [`3da4f828`](https://github.com/NixOS/nixpkgs/commit/3da4f828a0533cfcdc75a449963d7d552f84303e) | `` python310Packages.scmrepo: 0.1.13 -> 0.1.15 ``                                           |
| [`2e61c703`](https://github.com/NixOS/nixpkgs/commit/2e61c703f29259d23fb796813ed04867d3caadaf) | `` python310Packages.rns: 0.4.9 -> 0.5.0 ``                                                 |
| [`9fd32c52`](https://github.com/NixOS/nixpkgs/commit/9fd32c52cc4c26009da39236831819ea16a084ed) | `` python310Packages.identify: 2.5.18 -> 2.5.19 ``                                          |
| [`6cbc7d98`](https://github.com/NixOS/nixpkgs/commit/6cbc7d9832e977099270619396270f19fef07ea2) | `` python310Packages.pymazda: 0.3.7 -> 0.3.8 ``                                             |
| [`88e9562f`](https://github.com/NixOS/nixpkgs/commit/88e9562f2c4027dd961e55b084877be2c1750fe0) | `` python310Packages.peaqevcore: 12.2.7 -> 13.0.0 ``                                        |
| [`9984b263`](https://github.com/NixOS/nixpkgs/commit/9984b263bf82339258d405d4e7754df669384eab) | `` exploitdb: 2023-03-08 -> 2023-03-09 ``                                                   |
| [`48dad033`](https://github.com/NixOS/nixpkgs/commit/48dad033bbbd540fa0e397efd0175ab1ce522dd6) | `` python310Packages.aioairzone: 0.5.2 -> 0.5.3 ``                                          |
| [`ae09bc0f`](https://github.com/NixOS/nixpkgs/commit/ae09bc0fd305623089d9086ff7802b9a8f4b3d7b) | `` airgeddon: add changelog to meta ``                                                      |
| [`bcddd70e`](https://github.com/NixOS/nixpkgs/commit/bcddd70e030d36663ab45a332869f93bc7a1ab17) | `` metal-cli: 0.13.0 -> 0.14.1 ``                                                           |
| [`e7fe48e8`](https://github.com/NixOS/nixpkgs/commit/e7fe48e8020eab609f59da6b94b26e3a8205a154) | `` airgeddon: 11.10 -> 11.11 ``                                                             |
| [`6e825d6f`](https://github.com/NixOS/nixpkgs/commit/6e825d6f548078e07f585d0002559361b2ebc969) | `` sentry-cli: 2.14.3 -> 2.14.4 ``                                                          |
| [`637092b8`](https://github.com/NixOS/nixpkgs/commit/637092b8e755f1ee0368016a41f284d22c43f519) | `` intel-compute-runtime: 22.49.25018.24 -> 23.05.25593.11 ``                               |
| [`0701506b`](https://github.com/NixOS/nixpkgs/commit/0701506bf12ecdbec8852f541c4cf47f7b9c015c) | `` codespell: 2.2.2 -> 2.2.4 ``                                                             |
| [`cbbc0750`](https://github.com/NixOS/nixpkgs/commit/cbbc0750671cf816cbaf1cde38c7eef075f5c45b) | `` chromiumDev: 112.0.5615.12 -> 112.0.5615.20 ``                                           |
| [`96e08120`](https://github.com/NixOS/nixpkgs/commit/96e0812048ea638686a700dbfd92989456160c27) | `` scaleway-cli: 2.11.1 -> 2.12.0 ``                                                        |
| [`f7882319`](https://github.com/NixOS/nixpkgs/commit/f7882319e35a97aa6e5baf618b7b1ed6257876f9) | `` process-viewer: 0.5.6 -> 0.5.8 ``                                                        |
| [`2a7bd670`](https://github.com/NixOS/nixpkgs/commit/2a7bd670fca94169b09c3b966f05ab497e4accfe) | `` cargo-all-features: 1.6.0 -> 1.7.0 ``                                                    |
| [`64eb9216`](https://github.com/NixOS/nixpkgs/commit/64eb9216d9be5c4239121619d8828b5249b7947f) | `` sarasa-gothic: 0.40.1 -> 0.40.2 ``                                                       |
| [`3374f379`](https://github.com/NixOS/nixpkgs/commit/3374f379ce3021e2add5ead7fed27a3a55f1e09c) | `` media-downloader: 2.8.0 -> 2.9.0 ``                                                      |
| [`8d42f2aa`](https://github.com/NixOS/nixpkgs/commit/8d42f2aa9d5e8d46b968db1a2b5efd7a5531c62e) | `` opam_1_2: drop ``                                                                        |
| [`5e0eeea8`](https://github.com/NixOS/nixpkgs/commit/5e0eeea8391658f3b138e844e2948423f532c181) | `` pony-corral: 0.6.1 -> unstable-2023-02-11 ``                                             |
| [`47276cf4`](https://github.com/NixOS/nixpkgs/commit/47276cf43bcc59e220cf5f95523b3b62d2eac395) | `` ponyc: 0.50.0 -> 0.54.0 ``                                                               |
| [`60446dda`](https://github.com/NixOS/nixpkgs/commit/60446dda1fca1f80876ba16e26b61ec486b377aa) | `` nixos/hydra: wait for network-online before evaluator start ``                           |
| [`49878856`](https://github.com/NixOS/nixpkgs/commit/49878856e6cde3ae674f470da407e3bde2f55c9d) | `` https://github.com/NixOS/nixpkgs/pull/188334#issuecomment-1445425412 ``                  |
| [`70073985`](https://github.com/NixOS/nixpkgs/commit/70073985ae856f777639a4742943f48b317d7799) | `` nixos/gemstash: init module ``                                                           |
| [`fc9ceeba`](https://github.com/NixOS/nixpkgs/commit/fc9ceeba82d0f5c0b4be97ee333e58c41b7ab67d) | `` brakeman: 5.4.0 -> 5.4.1 ``                                                              |
| [`f6546a76`](https://github.com/NixOS/nixpkgs/commit/f6546a76559371bd690c30e4c4db8f898704ac31) | `` python310Packages.jupyter-book: 0.14.0 -> 0.15.0 ``                                      |
| [`ea593627`](https://github.com/NixOS/nixpkgs/commit/ea593627b9df5925f6a9c78698daedbaf2536753) | `` python310Packages.pydata-sphinx-theme: 0.13.0 -> 0.13.1 ``                               |
| [`7e29e1b2`](https://github.com/NixOS/nixpkgs/commit/7e29e1b2c2cb2adb79783f2393553fbfd52175c5) | `` postgresqlPackages.timescaledb: 2.10.0 -> 2.10.1 ``                                      |
| [`3966519d`](https://github.com/NixOS/nixpkgs/commit/3966519d12be2fb3fded3420f1cc82d681b17b5d) | `` libreoffice: wrapper.nix rewrite ``                                                      |
| [`ad920652`](https://github.com/NixOS/nixpkgs/commit/ad9206529272709d983822f7661bcc8b2ab343c8) | `` element-{web,desktop}: hack to make ofborg maintainer pings work again ``                |
| [`823e822a`](https://github.com/NixOS/nixpkgs/commit/823e822aeec15abad61d2b56ee2bf8130a9e34d4) | `` mdbook: 0.4.26 -> 0.4.28 ``                                                              |
| [`32907346`](https://github.com/NixOS/nixpkgs/commit/3290734615c91f490550d8336e4cf14d897b2027) | `` pkgsStatic.iproute2: fix build (disable shared libraries) ``                             |
| [`7e13b629`](https://github.com/NixOS/nixpkgs/commit/7e13b629c733ed7510c8d5fe3c77dce1316c1460) | `` ndn-tools: unpin openssl_1_1 ``                                                          |
| [`fa06318a`](https://github.com/NixOS/nixpkgs/commit/fa06318a46c6110eb5395ffcb0270fca38da09f1) | `` ndn-cxx: unpin openssl_1_1 ``                                                            |
| [`a10d6761`](https://github.com/NixOS/nixpkgs/commit/a10d67619900daa500e010a3c68c1e7799c32eb8) | `` llvm: tighten platforms ``                                                               |
| [`ca44f048`](https://github.com/NixOS/nixpkgs/commit/ca44f0485c6135d1a1be5f9a3ac7ab1b18c24752) | `` python310Packages.questionary: increase open files for testing ``                        |
| [`4d547243`](https://github.com/NixOS/nixpkgs/commit/4d547243a283353e7cb1c39fe76efa66f18ecf3c) | `` signal-desktop: 6.5.1 -> 6.7.0, signal-desktop-beta: 6.6.0-beta.1 -> 6.8.0-beta.1 ``     |