### PR TITLE
chore(flake/nixpkgs): `0c4800d5` -> `1e3bac17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678470307,
-        "narHash": "sha256-OEeMUr3ueLIXyW/OaFUX5jUdimyQwMg/7e+/Q0gC/QE=",
+        "lastModified": 1678563391,
+        "narHash": "sha256-fGSVN8pdE8ACraNsbsx1UVL7Jl7Huhz4N+0udFT35XU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c4800d579af4ed98ecc47d464a5e7b0870c4b1f",
+        "rev": "1e3bac17a6c67dcbef9908bc2977e9449ef499a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`54f14e8c`](https://github.com/NixOS/nixpkgs/commit/54f14e8ca655e34a03323ba2a4e3a538f9e59261) | `` pufferpanel: 2.2.0 -> 2.6.6 (#220506) ``                                    |
| [`aaed4bc5`](https://github.com/NixOS/nixpkgs/commit/aaed4bc5e05a30829373a96519b08ae2f932b10e) | `` linuxKernel.kernels.linux_lqx: 6.1.16-lqx1 -> 6.1.18-lqx1 ``                |
| [`1c52bfa2`](https://github.com/NixOS/nixpkgs/commit/1c52bfa28b82881b61dbbb0ed5e9a4053b7fd1f9) | `` xc: 0.0.175 -> 0.1.181 ``                                                   |
| [`7097fbe6`](https://github.com/NixOS/nixpkgs/commit/7097fbe6a6c22f909441f184ce1aa04a590285a8) | `` tree-wide: add git revisions to alpine git urls ``                          |
| [`2378677b`](https://github.com/NixOS/nixpkgs/commit/2378677bc4852227badeb8274ed42e7ebf5beac5) | `` cudatext-qt: 1.186.2 -> 1.187.0 ``                                          |
| [`b19c2ff4`](https://github.com/NixOS/nixpkgs/commit/b19c2ff48ad354f1e1657a35662f1e3a92396624) | `` kluctl: 2.19.2 -> 2.19.3 ``                                                 |
| [`a3274336`](https://github.com/NixOS/nixpkgs/commit/a3274336f90089e49fdb803669d4742fdaa2e852) | `` linuxKernel.kernels.linux_zen: 6.2.2-zen2 -> 6.2.5-zen1 ``                  |
| [`92a95461`](https://github.com/NixOS/nixpkgs/commit/92a95461e93986a820cfab01a7c98a9deb9dd61a) | `` nil: 2023-03-01 -> 2023-03-11 ``                                            |
| [`578aff14`](https://github.com/NixOS/nixpkgs/commit/578aff14dc9de7610bab3cfd17bf478e21348c71) | `` flyctl: 0.0.483 -> 0.0.484 ``                                               |
| [`72c697f9`](https://github.com/NixOS/nixpkgs/commit/72c697f9f17f033adb570cc49f6abc8ad4641d09) | `` dnsperf: 2.11.0 -> 2.11.1 ``                                                |
| [`a0ddd1a5`](https://github.com/NixOS/nixpkgs/commit/a0ddd1a5895e710eee2dab7a908832d0ddec8986) | `` strawberry: 1.0.14 -> 1.0.15 ``                                             |
| [`53fcb2e5`](https://github.com/NixOS/nixpkgs/commit/53fcb2e5859bfe7b8e88a405c242599efdfa215d) | `` liblouis: 3.24.0 → 3.25.0 ``                                                |
| [`4b0bc9ea`](https://github.com/NixOS/nixpkgs/commit/4b0bc9ea727d682e9c1c19bba850e81cfb623d9d) | `` nixos/plasma5: add ark as an optional package instead ``                    |
| [`9e8f51fc`](https://github.com/NixOS/nixpkgs/commit/9e8f51fc6c934e671bc3a5ae7cb900df0a4cd0b4) | `` Adding Ark as a file archiver ``                                            |
| [`78aceb01`](https://github.com/NixOS/nixpkgs/commit/78aceb012c0c20ffa10ce8b1bfc47d5b9515eb9d) | `` gitlint: 0.19.0 -> 0.19.1 ``                                                |
| [`0c3e6815`](https://github.com/NixOS/nixpkgs/commit/0c3e681540cebfd0bf37863043830e2224b41f56) | `` linuxKernel.kernels.linux_lqx: 6.1.15-lqx2 -> 6.1.16-lqx1 ``                |
| [`68c7d4da`](https://github.com/NixOS/nixpkgs/commit/68c7d4da1d1fb167535f218d97f64d22872965c1) | `` turbo: add version test ``                                                  |
| [`897a46dd`](https://github.com/NixOS/nixpkgs/commit/897a46dd297b727911c8e0acc8f297de6ae20a3f) | `` opensnitch: basic version test ``                                           |
| [`f30e1c22`](https://github.com/NixOS/nixpkgs/commit/f30e1c22030b48ca7331f5ac711b48620ca6606a) | `` terraform-providers.scaleway: 2.13.0 → 2.13.1 ``                            |
| [`e6ea8c59`](https://github.com/NixOS/nixpkgs/commit/e6ea8c5992ec4a73a43dd5cfc7e15ca55528a071) | `` terraform-providers.azurerm: 3.46.0 → 3.47.0 ``                             |
| [`830c7ef0`](https://github.com/NixOS/nixpkgs/commit/830c7ef0a11ff9df762635c1069eebdeaf54759f) | `` terraform-providers.pagerduty: 2.11.1 → 2.11.2 ``                           |
| [`3e87076f`](https://github.com/NixOS/nixpkgs/commit/3e87076f2c085d592d9eb0985e69832927c6b650) | `` terraform-providers.okta: 3.43.0 → 3.44.0 ``                                |
| [`efdc95ce`](https://github.com/NixOS/nixpkgs/commit/efdc95cea9da16d43534ccaa055ac986f905a468) | `` terraform-providers.launchdarkly: 2.11.0 → 2.12.0 ``                        |
| [`d0e8e10b`](https://github.com/NixOS/nixpkgs/commit/d0e8e10b132bc888a0b7060838e39aaf478957d1) | `` terraform-providers.huaweicloud: 1.45.0 → 1.45.1 ``                         |
| [`17282218`](https://github.com/NixOS/nixpkgs/commit/17282218f0e2fa78c0cac8df558953facd9b36e2) | `` terraform-providers.grafana: 1.36.0 → 1.36.1 ``                             |
| [`baa1a544`](https://github.com/NixOS/nixpkgs/commit/baa1a54405e7f8ffe0590674215e61ba763ab4d9) | `` step-cli: 0.23.3 -> 0.23.4 ``                                               |
| [`45aae5c2`](https://github.com/NixOS/nixpkgs/commit/45aae5c2fec488f0dac3051b840650f7cd274fbb) | `` haskell.compiler.ghc9*: work around output cycles on aarch64-darwin ``      |
| [`41c538f8`](https://github.com/NixOS/nixpkgs/commit/41c538f80f3a98d6e40e7ea5e79f33429850a43e) | `` haskellPackages.regex-rure: mark broken on aarch64-darwin ``                |
| [`c61157bb`](https://github.com/NixOS/nixpkgs/commit/c61157bbe3f29b7cffe8f8f5505ed9d9a50b5f8f) | `` haskell.compiler.ghc{8107,902}: give cabal-paths.patch a better name ``     |
| [`d6368e36`](https://github.com/NixOS/nixpkgs/commit/d6368e3654255ab47fe1bac30fcc1a27d25495ef) | `` python310Packages.pydeconz: 108 -> 110 ``                                   |
| [`9260d9f5`](https://github.com/NixOS/nixpkgs/commit/9260d9f53bb6ca6d84804713ec6d383fb8b832f1) | `` python310Packages.peaqevcore: 13.0.0 -> 13.0.1 ``                           |
| [`d16ecddf`](https://github.com/NixOS/nixpkgs/commit/d16ecddfe0e6d3d84d48b0adfe48121fad5ba7ff) | `` kubebuilder: 3.9.0 -> 3.9.1 ``                                              |
| [`21bf80e4`](https://github.com/NixOS/nixpkgs/commit/21bf80e472eed6ac6aacd29085f87c5cfbf00cfc) | `` trufflehog: 3.29.0 -> 3.29.1 ``                                             |
| [`0fa6ab1d`](https://github.com/NixOS/nixpkgs/commit/0fa6ab1de5061433a28455f2ecc349e3d77b3128) | `` colima: 0.5.3 -> 0.5.4 ``                                                   |
| [`df45c526`](https://github.com/NixOS/nixpkgs/commit/df45c5266de4a2e4445474d1b59d50ba044ae5d7) | `` adguardhome: 0.107.25 -> 0.107.26 ``                                        |
| [`4c747a81`](https://github.com/NixOS/nixpkgs/commit/4c747a810d90ef9aa87fa245a29e0ef5050b43a7) | `` turbo: 1.7.0 -> 1.8.3 ``                                                    |
| [`15ea67e7`](https://github.com/NixOS/nixpkgs/commit/15ea67e7fae6c026957bd78a12b652eca5a00887) | `` geekbench_5: add meta.mainProgram ``                                        |
| [`29277717`](https://github.com/NixOS/nixpkgs/commit/29277717d7c4c6629cb832650bcdaf34656213a6) | `` geekbench_4: add meta.mainProgram ``                                        |
| [`00f7fa94`](https://github.com/NixOS/nixpkgs/commit/00f7fa948d5e63d29cee0969d10e5e61491fe7c5) | `` geekbench6: init at 6.0.1 ``                                                |
| [`62d60963`](https://github.com/NixOS/nixpkgs/commit/62d60963c7e91f9255e8b0255656170fedbb0bf0) | `` geekbench5: use autoPatchelfHook and do not hardcode CUDA lib ``            |
| [`b4bb4a43`](https://github.com/NixOS/nixpkgs/commit/b4bb4a434c13c9225d43021d9fd7dbcf1eff0f88) | `` geekbench5: 5.4.6 -> 5.5.1 ``                                               |
| [`04cdb56e`](https://github.com/NixOS/nixpkgs/commit/04cdb56ec932c2e6b500fec40d0e5c6c91c19e40) | `` geekbench4: use autoPatchelfHook and do not hardcode CUDA lib ``            |
| [`44642937`](https://github.com/NixOS/nixpkgs/commit/446429370e2bed87de9bc41f182842ed6079498f) | `` gpxsee: 11.12 → 12.2 ``                                                     |
| [`12921eed`](https://github.com/NixOS/nixpkgs/commit/12921eed861acb61120ca1c6a29a43ce8d1ecfb0) | `` python310Packages.rangehttpserver: 1.2.0 -> 1.3.3 ``                        |
| [`5edff6fe`](https://github.com/NixOS/nixpkgs/commit/5edff6feabdbd9c6b6c940eb2b30f731d5f34a43) | `` trufflehog: 3.29.0 -> 3.29.1 ``                                             |
| [`bb416ad5`](https://github.com/NixOS/nixpkgs/commit/bb416ad53eeacc8c4298f5ee657a262ee43a941a) | `` migraphx: 5.4.2 -> 5.4.3 ``                                                 |
| [`45fe5a16`](https://github.com/NixOS/nixpkgs/commit/45fe5a16d6fa256d4b261c4364547d115d9d86bf) | `` glab: 1.25.3 -> 1.26.0 ``                                                   |
| [`68cd4eed`](https://github.com/NixOS/nixpkgs/commit/68cd4eededa6f6fcfe926c736ffd0e4e64c5726a) | `` cups-filters: fix build with qpdf >= 11.3.0 ``                              |
| [`1f24c435`](https://github.com/NixOS/nixpkgs/commit/1f24c435a7528d6a1ba6a1e0cb8cadf65501005c) | `` vale: 2.23.3 -> 2.24.0 ``                                                   |
| [`45e610e6`](https://github.com/NixOS/nixpkgs/commit/45e610e668e77b61b16939dd55b665c5b92e14d0) | `` eksctl: 0.132.0 -> 0.133.0 ``                                               |
| [`e9775607`](https://github.com/NixOS/nixpkgs/commit/e97756073d4540491d37a545661154e7aab9ca4d) | `` cargo-update: 11.1.1 -> 11.1.2 ``                                           |
| [`df3f33c7`](https://github.com/NixOS/nixpkgs/commit/df3f33c71dc4909f903616dd3af9c39c4ca9eaa7) | `` netbird: 0.14.2 -> 0.14.4 ``                                                |
| [`a2a612b9`](https://github.com/NixOS/nixpkgs/commit/a2a612b9d9941da2c358b27cc72721d0195a9e24) | `` karlender: 0.9.0 -> 0.9.1; unbreak ``                                       |
| [`ac3b333f`](https://github.com/NixOS/nixpkgs/commit/ac3b333f7298af0a7db53e03e4318d7d038ce7ef) | `` protoc-gen-go-grpc: 1.2.0 -> 1.3.0 ``                                       |
| [`dabb4a53`](https://github.com/NixOS/nixpkgs/commit/dabb4a536919f9bee64f10533d30e510918eb30e) | `` v2ray-geoip: 202303020053 -> 202303090050 ``                                |
| [`a48e7da5`](https://github.com/NixOS/nixpkgs/commit/a48e7da55a2f5b1e1969250e12926f4994e0e2ca) | `` ocamlPackages.ffmpeg-avdevice: add missing AVFoundation library on macOS `` |
| [`77a35de8`](https://github.com/NixOS/nixpkgs/commit/77a35de8ae1d400bf661b810926d1fe58cc9e757) | `` waffle: 1.7.0 -> 1.7.2 ``                                                   |
| [`fe5c4339`](https://github.com/NixOS/nixpkgs/commit/fe5c43391ecc031770f0bdda2fcbaf0c52cb741f) | `` scarab: 1.20.0.0 -> 1.31.0.0 ``                                             |
| [`c8bf4141`](https://github.com/NixOS/nixpkgs/commit/c8bf4141c9b25d40742edc4ee667604e55bb0463) | `` oh-my-posh: 14.9.2 -> 14.12.0 ``                                            |
| [`160b8923`](https://github.com/NixOS/nixpkgs/commit/160b8923daa94c79b2f350353c741bb41435541f) | `` shellhub-agent: 0.10.8 -> 0.11.6 ``                                         |
| [`89b6f411`](https://github.com/NixOS/nixpkgs/commit/89b6f4114a173669da564e9d0a670cd450f1da9e) | `` pe-bear: 0.6.5 -> 0.6.5.2 ``                                                |
| [`4a3c40a6`](https://github.com/NixOS/nixpkgs/commit/4a3c40a6a827971a2ec961798efd1300a3eac0ce) | `` hclfmt: 2.16.1 -> 2.16.2 ``                                                 |
| [`000b5484`](https://github.com/NixOS/nixpkgs/commit/000b5484bd6b812cad5a904fe6d1ff86db313f98) | `` nextcloud-client: 3.7.3 -> 3.7.4 ``                                         |
| [`986fafcc`](https://github.com/NixOS/nixpkgs/commit/986fafcc3c593be23539aea512566876da18617e) | `` vals: 0.22.0 -> 0.23.0 ``                                                   |
| [`05d40d8c`](https://github.com/NixOS/nixpkgs/commit/05d40d8c8785f3f70fbdca901b466344c17dbb11) | `` lux: 0.16.0 -> 0.17.0 ``                                                    |
| [`476caaac`](https://github.com/NixOS/nixpkgs/commit/476caaac8a878e7710e75c77cf5e1aaa41ccd4f1) | `` prometheus-statsd-exporter: 0.23.0 -> 0.23.1 ``                             |
| [`815d85d4`](https://github.com/NixOS/nixpkgs/commit/815d85d400d91c8f097be7bf21be914c42150929) | `` podman: remove unused code ``                                               |
| [`264bbeea`](https://github.com/NixOS/nixpkgs/commit/264bbeea5460c13cdaefac434f361b13ae12a05c) | `` spicedb: 1.16.2 -> 1.17.0 ``                                                |
| [`930cbecf`](https://github.com/NixOS/nixpkgs/commit/930cbecf20e0837391915ba5f64d0f582a2ea918) | `` minizip-ng: 3.0.7 -> 3.0.8 ``                                               |
| [`b7340313`](https://github.com/NixOS/nixpkgs/commit/b73403135630d5e1ef3bc1d0cb4922961ecbd17d) | `` cliphist: 0.3.1 -> 0.4.0 ``                                                 |
| [`0a1a3e9d`](https://github.com/NixOS/nixpkgs/commit/0a1a3e9d95ee606eeb52ff5815770d4b12c9b01d) | `` maxima-ecl: fix build by removing upstreamed patch ``                       |
| [`fed7a0ce`](https://github.com/NixOS/nixpkgs/commit/fed7a0cea317a1104b9f0a6c5e46d58fe48f5670) | `` cmake-language-server: unstable-2023-01-08 → 0.1.7 ``                       |
| [`6e6d31f4`](https://github.com/NixOS/nixpkgs/commit/6e6d31f4bc13e12af7164cd6850a7d4d83b7a2cb) | `` nixos/fwupd: add settings option for uefi_capsule.conf ``                   |
| [`7355953d`](https://github.com/NixOS/nixpkgs/commit/7355953d4912a77670891d3eb82ab77ed998d03f) | `` smartdns: 40 -> 41 ``                                                       |
| [`4ef9f57e`](https://github.com/NixOS/nixpkgs/commit/4ef9f57ea75d46ab55a37b59d94ecd2eb90efdf4) | `` flyctl: 0.0.478 -> 0.0.483 ``                                               |
| [`56c43167`](https://github.com/NixOS/nixpkgs/commit/56c4316772da8c93f16c0ce69bc6b6c7ae4e682f) | `` gfold: 4.3.1 -> 4.3.2 ``                                                    |
| [`e4c76d2e`](https://github.com/NixOS/nixpkgs/commit/e4c76d2edd4bcd2649051e6acb8cb4413fd3bb8a) | `` usql: 0.13.9 -> 0.13.10 ``                                                  |
| [`3f8dc17c`](https://github.com/NixOS/nixpkgs/commit/3f8dc17c26b4de690c1c90657a0391837ca4930f) | `` vkbasalt: 0.3.2.8 -> 0.3.2.9 ``                                             |
| [`dd3185a9`](https://github.com/NixOS/nixpkgs/commit/dd3185a90e49b3939839ef1a23c28072382e6108) | `` python38Packages.pydantic: fix build with libxcrypt ``                      |
| [`88b9be94`](https://github.com/NixOS/nixpkgs/commit/88b9be949d3cd53abf51033a31b0ae9108c0a732) | `` unciv: 4.5.2 -> 4.5.5 ``                                                    |
| [`f99ef190`](https://github.com/NixOS/nixpkgs/commit/f99ef190e0ab5c4964470dccf7d93aff53c87e01) | `` fluxcd: 0.41.0 -> 0.41.1 ``                                                 |
| [`220df01f`](https://github.com/NixOS/nixpkgs/commit/220df01fbdd7390d65fc4ec318abd1539067acbc) | `` tageditor: 3.7.7 -> 3.7.8 ``                                                |
| [`f63f93c0`](https://github.com/NixOS/nixpkgs/commit/f63f93c0191f15b414a55b82cf200cb471771078) | `` home-assistant: Unify linter choice for parse-requirements ``               |
| [`66c14798`](https://github.com/NixOS/nixpkgs/commit/66c14798e27a27cf03caa84c8ee30d4d08c65b58) | `` aws-vault: 7.0.0 -> 7.0.2 ``                                                |
| [`1a0cf212`](https://github.com/NixOS/nixpkgs/commit/1a0cf212db3dc6ad2f6df5de2695e01077c27ee1) | `` home-assistant: 2023.3.2 -> 2023.3.3 ``                                     |
| [`b657f03b`](https://github.com/NixOS/nixpkgs/commit/b657f03bab11d75028e02a71eae4e435a74a20dc) | `` python310Packages.roombapy: 1.6.5 -> 1.6.6 (#220403) ``                     |
| [`6c8e6ce0`](https://github.com/NixOS/nixpkgs/commit/6c8e6ce0d92760b162791deda6734f003b35b5c7) | `` home-assistant: Introduce new updater ``                                    |
| [`6cd20f03`](https://github.com/NixOS/nixpkgs/commit/6cd20f03dc69102085a73a731e67b02dbbef85d3) | `` automatic-timezoned: 1.0.69 -> 1.0.72 ``                                    |
| [`805e23ad`](https://github.com/NixOS/nixpkgs/commit/805e23adf2d8352fc47ed92ce6212427cbe1c7ed) | `` purescript: 0.15.7 -> 0.15.8 ``                                             |
| [`981628e5`](https://github.com/NixOS/nixpkgs/commit/981628e5fd5cce16541059f2a178d8cb886ef355) | `` pocketbase: 0.12.3 -> 0.13.2 ``                                             |
| [`531ff4b6`](https://github.com/NixOS/nixpkgs/commit/531ff4b6ca90bf247c3dde0f0217542effe2503b) | `` muparserx: 4.0.11 -> 4.0.12 ``                                              |
| [`0daab19d`](https://github.com/NixOS/nixpkgs/commit/0daab19dfce391ecf220cb81fc11653b881a288e) | `` mdbook-pagetoc: 0.1.5 -> 0.1.6 ``                                           |
| [`4199dcee`](https://github.com/NixOS/nixpkgs/commit/4199dcee711a52c57f7166e9b3254e8eeeda52dc) | `` frp: 0.47.0 -> 0.48.0 ``                                                    |
| [`a2d8fbf6`](https://github.com/NixOS/nixpkgs/commit/a2d8fbf6790783da7e9bdd4e451125031c87cc8d) | `` mdbook-katex: 0.3.9 -> 0.3.10 ``                                            |
| [`2821b95a`](https://github.com/NixOS/nixpkgs/commit/2821b95a7a92a3d304d974746a9fe66ae59115ab) | `` zine: 0.12.0 -> 0.12.1 ``                                                   |
| [`aa745c9b`](https://github.com/NixOS/nixpkgs/commit/aa745c9b730de5b20794e3007f8abad985bd7743) | `` zellij: 0.35.1 -> 0.35.2 ``                                                 |
| [`d1dccc71`](https://github.com/NixOS/nixpkgs/commit/d1dccc71564921a7bd466083529f15637c82b7e8) | `` python310Packages.garminconnect: 0.1.53 -> 0.1.54 ``                        |
| [`b876f129`](https://github.com/NixOS/nixpkgs/commit/b876f129b4a57612856195ad252c68c7a2d2a5f4) | `` exploitdb: 2023-03-09 -> 2023-03-10 ``                                      |
| [`b820cb18`](https://github.com/NixOS/nixpkgs/commit/b820cb182aa4919f6451e3429cefa334699ff92e) | `` ryujinx: 1.1.650 -> 1.1.651 ``                                              |
| [`38e03308`](https://github.com/NixOS/nixpkgs/commit/38e0330878d41fe6aa1ed69e358cbcf1bec804c1) | `` github-runner: 2.302.1 -> 2.303.0 ``                                        |
| [`06bac90e`](https://github.com/NixOS/nixpkgs/commit/06bac90e276f5b0b1ef27a831f81ef9dbf19b5a9) | `` grype: 0.59.0 -> 0.59.1 ``                                                  |
| [`e857b1ec`](https://github.com/NixOS/nixpkgs/commit/e857b1ecad8fcf3c98d3a88d9432a8d0b1327fdc) | `` wireplumber: 0.4.13 -> 0.4.14 ``                                            |
| [`03a1ed12`](https://github.com/NixOS/nixpkgs/commit/03a1ed12945851c76e373eb66fe677a9121d4415) | `` python3Packages.bandit: 1.7.4 -> 1.7.5 ``                                   |
| [`a7958735`](https://github.com/NixOS/nixpkgs/commit/a7958735475e2a279eda398ab11dd643c964b2a8) | `` ncspot: 0.12.0 -> 0.13.0 ``                                                 |
| [`b3a858b5`](https://github.com/NixOS/nixpkgs/commit/b3a858b5420390a627b1ee12ad8624c3d45ad8ac) | `` python310Packages.unidiff: 0.7.4 -> 0.7.5 ``                                |
| [`839130b9`](https://github.com/NixOS/nixpkgs/commit/839130b9f7e6c28b024bb9a0420914f2ea021cf5) | `` prometheus-influxdb-exporter: 0.11.2 -> 0.11.3 ``                           |
| [`08cdfbf9`](https://github.com/NixOS/nixpkgs/commit/08cdfbf94f92b1b92c79b0cb03b8a83fce2b0f44) | `` komga: 0.162.0 -> 0.163.0 ``                                                |
| [`da66cb10`](https://github.com/NixOS/nixpkgs/commit/da66cb10cec632789e5e3463dcbd3f31feef58cc) | `` python310Packages.ipwhois: init at 1.2.0 ``                                 |
| [`0549af80`](https://github.com/NixOS/nixpkgs/commit/0549af80ecf15c2d75e4163307c9a2de92c4bc83) | `` torchvision: no need to specify CUDAHOSTCXX ``                              |
| [`ef50d327`](https://github.com/NixOS/nixpkgs/commit/ef50d327693590803c56cf9d8ee10adc547796cc) | `` unnethack: disable build parallelism ``                                     |
| [`71824bbf`](https://github.com/NixOS/nixpkgs/commit/71824bbf9d46cec3d295b812af50255ef15142b7) | `` jenkins-job-builder: 4.1.0 -> 4.3.0 ``                                      |
| [`f7b15931`](https://github.com/NixOS/nixpkgs/commit/f7b1593179eba14d58b46c0e2441f06bc8270578) | `` tagparser: 11.5.1 -> 11.6.0 ``                                              |
| [`bab298bf`](https://github.com/NixOS/nixpkgs/commit/bab298bf031eb322c1ec95922e87c552a9c90f90) | `` texlive: fix kpathsea path expansion. ``                                    |