### PR TITLE
chore(flake/nixpkgs): `1e3bac17` -> `5a1dc8ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678563391,
-        "narHash": "sha256-fGSVN8pdE8ACraNsbsx1UVL7Jl7Huhz4N+0udFT35XU=",
+        "lastModified": 1678654296,
+        "narHash": "sha256-aVfw3ThpY7vkUeF1rFy10NAkpKDS2imj3IakrzT0Occ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1e3bac17a6c67dcbef9908bc2977e9449ef499a5",
+        "rev": "5a1dc8acd977ff3dccd1328b7c4a6995429a656b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                             |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`a8789453`](https://github.com/NixOS/nixpkgs/commit/a8789453360d3821320eca966f11fec20963cd23) | `` alttab: Remove sgraf as maintainer ``                            |
| [`3e29ae41`](https://github.com/NixOS/nixpkgs/commit/3e29ae4159bddf6ea90c2c85e802af220b3987fe) | `` kitty-themes: 2023-01-08 -> 2023-03-08 ``                        |
| [`0871493a`](https://github.com/NixOS/nixpkgs/commit/0871493aa51c575f00c3418729fde24db77d9d13) | `` kitty-themes: move to kitty directory ``                         |
| [`b09533e7`](https://github.com/NixOS/nixpkgs/commit/b09533e71e10e728020e17765b413cea83a09d6f) | `` dxvk: fix all shellcheck warnings ``                             |
| [`f67a9f0e`](https://github.com/NixOS/nixpkgs/commit/f67a9f0e27948fd2f16e5027c401fee80b1fef64) | `` dxvk: fix unbound variable warning in setup_dxvk.sh ``           |
| [`7931e2d6`](https://github.com/NixOS/nixpkgs/commit/7931e2d6de5f2069571eaf6098cd4285ca3b28f6) | `` linuxKernel.kernels.linux_lqx: 6.1.18-lqx1 -> 6.2.5-lqx3 ``      |
| [`d63da959`](https://github.com/NixOS/nixpkgs/commit/d63da959fd7422e523c24ce469ffc8a5099ac56d) | `` zine: 0.12.1 -> 0.13.0 ``                                        |
| [`57cc17cd`](https://github.com/NixOS/nixpkgs/commit/57cc17cd46fef2ded8a02c85d7193bb75affdef9) | `` the-way: 0.19.1 -> 0.19.2 ``                                     |
| [`c22bd45b`](https://github.com/NixOS/nixpkgs/commit/c22bd45b2a2de7e37768fcc6697c22c6496ed648) | `` highlight-assertions: 0.1.6 -> 0.1.7 ``                          |
| [`0fd546c7`](https://github.com/NixOS/nixpkgs/commit/0fd546c7602f8813c89e627b7590e7b57489e224) | `` alttab: 1.6.1 -> 1.7.0 ``                                        |
| [`5ffd1b17`](https://github.com/NixOS/nixpkgs/commit/5ffd1b17f84f5cc3c6bb33fde515a883e850dc09) | `` maintainers: update felipeqq2's gpg key ``                       |
| [`7d15a397`](https://github.com/NixOS/nixpkgs/commit/7d15a3978150e4cdc9b749c1b2efdcf7fd7faae0) | `` libreoffice: Fix invalid desktop files ``                        |
| [`cd31f1e8`](https://github.com/NixOS/nixpkgs/commit/cd31f1e8a186d50bc9399434d06b5494f82b5ec3) | `` terragrunt: 0.44.4 -> 0.44.5 ``                                  |
| [`08916245`](https://github.com/NixOS/nixpkgs/commit/08916245bd25d03fa6f837d3c23ebac8b6ada016) | `` emacsPackages.acm-terminal: init at 20230215.414 ``              |
| [`86115641`](https://github.com/NixOS/nixpkgs/commit/861156414d40bf6b3f1b0aabd4b422f1d424e129) | `` emacsPackages.lsp-bridge: init at 20230309.554 ``                |
| [`21555599`](https://github.com/NixOS/nixpkgs/commit/2155559979388577678b793db3ee0fa81e670a4c) | `` maintainers: add fxttr ``                                        |
| [`28065039`](https://github.com/NixOS/nixpkgs/commit/28065039e66e874c9380821c85ee01ceb5f2469f) | `` linux_testing: 6.2-rc6 -> 6.3-rc1 ``                             |
| [`cf3fb3c7`](https://github.com/NixOS/nixpkgs/commit/cf3fb3c782a2063bb72406cb18c66d949385ffa1) | `` linux: 5.15.100 -> 5.15.101 ``                                   |
| [`61c8a0f6`](https://github.com/NixOS/nixpkgs/commit/61c8a0f6bc86788e4d1ccbbcc82a245f4c78d307) | `` photoqt: 1.7.1 -> 3.1 ``                                         |
| [`b0cdb866`](https://github.com/NixOS/nixpkgs/commit/b0cdb866af6f9189fd26946aa188fa6cefe93426) | `` zombietrackergps: mark broken ``                                 |
| [`5df4acff`](https://github.com/NixOS/nixpkgs/commit/5df4acffc43336260aa879ca389a12433692e255) | `` lighthouse: 3.5.0 -> 3.5.1 ``                                    |
| [`17ccdf0e`](https://github.com/NixOS/nixpkgs/commit/17ccdf0ebfce957bba9a3667b2943e79dc21aae0) | `` vikunja-api: 0.20.3 -> 0.20.4 ``                                 |
| [`eb3e8ca5`](https://github.com/NixOS/nixpkgs/commit/eb3e8ca5c1e9f4907c3533c507d4719f2ca3f3c6) | `` vikunja-frontend: 0.20.4 -> 0.20.5 ``                            |
| [`2fc61b77`](https://github.com/NixOS/nixpkgs/commit/2fc61b77cfacf8651112a5b2320e598f7946b1ca) | `` dxvk: fix DLL override setup ``                                  |
| [`22114158`](https://github.com/NixOS/nixpkgs/commit/22114158169e50d51950c3ec1d108fc1fdedf1ed) | `` hugo: 0.111.2 -> 0.111.3 ``                                      |
| [`d58f6710`](https://github.com/NixOS/nixpkgs/commit/d58f6710982f0f4c4911284aff497ff4ed2c668a) | `` beancount-black: 0.1.14 -> 0.2.0 ``                              |
| [`463f5558`](https://github.com/NixOS/nixpkgs/commit/463f5558994491f1bc70e03a2a057f15bd56518b) | `` all-packages.nix: change `{}` to `{ }` ``                        |
| [`fda29b84`](https://github.com/NixOS/nixpkgs/commit/fda29b8467e261032ed088fa332ffa386192ac46) | `` kubesec: 2.12.0 -> 2.13.0 ``                                     |
| [`39552719`](https://github.com/NixOS/nixpkgs/commit/39552719a6c3aa618c1c85ce6c87042a6a75fdda) | `` deepin.deepin-compressor: 5.12.9 -> 5.12.14 ``                   |
| [`68de044c`](https://github.com/NixOS/nixpkgs/commit/68de044c360f94f7a0f4caff4a0fe4b5f615f999) | `` cpm-cmake: remove myself as maintainer ``                        |
| [`b533639b`](https://github.com/NixOS/nixpkgs/commit/b533639bd33007128504dd3b985eaefca3590b8a) | `` stress-ng: 0.15.03 -> 0.15.05 ``                                 |
| [`b0214592`](https://github.com/NixOS/nixpkgs/commit/b021459220fd6b823cc71ad5d012a54e24a92c60) | `` deepin.deepin-draw: 5.11.4 -> 5.11.7 ``                          |
| [`98fb99a7`](https://github.com/NixOS/nixpkgs/commit/98fb99a778fe3c77cc2092ef0f4da438eed73ec8) | `` meshcentral: 1.1.2 -> 1.1.4 ``                                   |
| [`50d7f46a`](https://github.com/NixOS/nixpkgs/commit/50d7f46a2087e7447cf416e7b38e71bd9e86d6d1) | `` openai: 0.27.0 -> 0.27.1 ``                                      |
| [`141317df`](https://github.com/NixOS/nixpkgs/commit/141317dff92656e67ffb726c727766ceffcba52b) | `` linux: fix `brcmfmac` driver ``                                  |
| [`db2b267a`](https://github.com/NixOS/nixpkgs/commit/db2b267a59fc3ed8c2850873acc1d5272c63198b) | `` bacon: 2.6.2 -> 2.6.3 ``                                         |
| [`81643d25`](https://github.com/NixOS/nixpkgs/commit/81643d25ab6efe473542a0e79a43bc639c594bd2) | `` mubeng: 0.13.2 -> 0.14.0 ``                                      |
| [`6a988452`](https://github.com/NixOS/nixpkgs/commit/6a988452ed9d87acff0844e515c7935b5d529b8e) | `` kde/frameworks: 5.103 -> 5.104 ``                                |
| [`b254a561`](https://github.com/NixOS/nixpkgs/commit/b254a56147c23d404a8a6e8194e3867d07c2303c) | `` pythonPackages.mdutils: 1.4.0 -> 1.5.1 ``                        |
| [`888878ac`](https://github.com/NixOS/nixpkgs/commit/888878aca21d3c212f3f9520027045900ca4682c) | `` polkadot: 0.9.39 -> 0.9.39-1 ``                                  |
| [`23091da2`](https://github.com/NixOS/nixpkgs/commit/23091da20c6491ccce78acbc71bfa98d8c64af28) | `` coder: resolve hash mismatch in fixed-output derivation ``       |
| [`8dcc17b6`](https://github.com/NixOS/nixpkgs/commit/8dcc17b6c1dec2f9d7a7ee35941a01ae2f64fed3) | `` openmoji: fixup! patch for newer glob ``                         |
| [`140b403b`](https://github.com/NixOS/nixpkgs/commit/140b403b2b20f5632ea7cb893b6b40519e4959d3) | `` hipfft: 5.4.2 -> 5.4.3 ``                                        |
| [`9a9fe39a`](https://github.com/NixOS/nixpkgs/commit/9a9fe39ab64adad52ff51525501c2097aa845ecb) | `` discord: add taskbar notification badge ``                       |
| [`5718645f`](https://github.com/NixOS/nixpkgs/commit/5718645f57e6361d05bc8784afd308113c2eca56) | `` function-runner: 3.2.2 -> 3.2.3 ``                               |
| [`d722c43d`](https://github.com/NixOS/nixpkgs/commit/d722c43d9ae4637ef40681198bb6e72bf9a62b96) | `` go-protobuf: 1.5.2 -> 1.5.3 ``                                   |
| [`b845cae3`](https://github.com/NixOS/nixpkgs/commit/b845cae3647b0930c5d06a800493f7911183bbe5) | `` circleci-cli: 0.1.23816 -> 0.1.23845 ``                          |
| [`0f63c5dc`](https://github.com/NixOS/nixpkgs/commit/0f63c5dcaf45bc905150be274d9c559ffe81ca22) | `` checkSSLCert: 2.60.0 -> 2.61.0 ``                                |
| [`37d541aa`](https://github.com/NixOS/nixpkgs/commit/37d541aa462f724b90275aed26e092e194858c33) | `` datree: 1.8.36 -> 1.8.37 ``                                      |
| [`3e6a6f6f`](https://github.com/NixOS/nixpkgs/commit/3e6a6f6fcb51af497501a3cf5b3883329a03907d) | `` imgproxy: 3.13.2 -> 3.14.0 ``                                    |
| [`19a3a187`](https://github.com/NixOS/nixpkgs/commit/19a3a187272fa317cf9ef69501101bf86ee06ee2) | `` cargo-zigbuild: 0.16.2 -> 0.16.3 ``                              |
| [`61dbff71`](https://github.com/NixOS/nixpkgs/commit/61dbff71ba042fd14325c53b49b2dc17f1f8c378) | `` sensu-go-backend: 6.9.1 -> 6.9.2 ``                              |
| [`044e07e2`](https://github.com/NixOS/nixpkgs/commit/044e07e2f8c13a109597bd25292c211ea87a2a3b) | `` boxxy: 0.3.5 -> 0.3.6 ``                                         |
| [`62d69c8e`](https://github.com/NixOS/nixpkgs/commit/62d69c8ef2b743c24ca1c2e00d50a1f36d2b9be3) | `` python310Packages.pyrogram: 2.0.100 -> 2.0.101 ``                |
| [`08bcde01`](https://github.com/NixOS/nixpkgs/commit/08bcde01e6ab1d48d6143eb365afb568ba645bac) | `` v2ray-domain-list-community: 20230227064844 -> 20230311145412 `` |
| [`63165e6a`](https://github.com/NixOS/nixpkgs/commit/63165e6af7089b01fee7952d0472aa932c5c9a2b) | `` go-musicfox: 3.7.2 -> 3.7.3 ``                                   |
| [`43df84b3`](https://github.com/NixOS/nixpkgs/commit/43df84b36bae1b276beb504b76ed52fb5ae052f6) | `` lmdb: 0.9.29 -> 0.9.30 ``                                        |
| [`b321bf86`](https://github.com/NixOS/nixpkgs/commit/b321bf861caacfe247c77a4b0335616f5cb4403b) | `` ipcalc: 1.0.1 -> 1.0.2 ``                                        |
| [`bede8834`](https://github.com/NixOS/nixpkgs/commit/bede883466abe6691955c0340c2b4f0a24b0f406) | `` brev-cli: 0.6.208 -> 0.6.211 ``                                  |
| [`38d554a7`](https://github.com/NixOS/nixpkgs/commit/38d554a70c09624409db54f9b6cb686da90e37a0) | `` python310Packages.commonmark: normalise pname ``                 |
| [`e636a55c`](https://github.com/NixOS/nixpkgs/commit/e636a55c15e09f4582a21cc8e32dafe653e64312) | `` doc: document fetchpatch's decode argument ``                    |
| [`23e999fd`](https://github.com/NixOS/nixpkgs/commit/23e999fd9b98ba85a931bc8fe7f113fd235fb958) | `` fetchpatch: add decode test ``                                   |
| [`dd6e94f2`](https://github.com/NixOS/nixpkgs/commit/dd6e94f2c1ae61633c69c6416c9da9d9853015ca) | `` fetchpatch: add "decode" argument for gerrit ``                  |
| [`8bc170b1`](https://github.com/NixOS/nixpkgs/commit/8bc170b1b4a2469f2a2eb8565389ab037b23d89e) | `` pahole: 1.24-unstable-2022-11-24 -> 1.24-unstable-2023-03-02 ``  |
| [`487b6a38`](https://github.com/NixOS/nixpkgs/commit/487b6a38f3af412550a0bdcdbb384f8635136752) | `` nixos/tests/knot: Use more appropriate terminology ``            |
| [`1fc6f2c4`](https://github.com/NixOS/nixpkgs/commit/1fc6f2c41209b51f7c9b4ea87f7ab8e3d53cc275) | `` nixos/tests/knot: Use automatic-acl and drop explicit acls ``    |
| [`66579946`](https://github.com/NixOS/nixpkgs/commit/66579946d38ee882304f0e96235423290c65dec9) | `` knot-dns: Test interaction with kea dhcp-ddns ``                 |
| [`2dc78b7a`](https://github.com/NixOS/nixpkgs/commit/2dc78b7a6d2071b9fa706e616120388bc5064987) | `` nixos/tests/kea: Test dhcp-ddns against knot ``                  |
| [`69326363`](https://github.com/NixOS/nixpkgs/commit/69326363f710ba45d722fa4e1e57d78b01a1513c) | `` python310Packages.python-rapidjson: specify patch name ``        |
| [`150526a2`](https://github.com/NixOS/nixpkgs/commit/150526a2da1827f17edc91d63e5d6ad00ca8765c) | `` rapidjson: specify patch name ``                                 |
| [`be48e630`](https://github.com/NixOS/nixpkgs/commit/be48e630aa07a4efb29f21b6ab4e1117726604d4) | `` presage: specify patch name ``                                   |
| [`a7af0ac6`](https://github.com/NixOS/nixpkgs/commit/a7af0ac6a69e93d52a388c9bb1b8d736896a8a38) | `` python310Packages.swift: 2.31.0 -> 2.31.1 ``                     |
| [`d13fc847`](https://github.com/NixOS/nixpkgs/commit/d13fc847f130bb8dcdbad7dafb8f5350ea34736d) | `` linux_latest-libre: 19049 -> 19102 ``                            |
| [`a693dc5c`](https://github.com/NixOS/nixpkgs/commit/a693dc5ccf4274faedf94d959c9271ab08c8d869) | `` linux: 6.2.3 -> 6.2.5 ``                                         |
| [`543d1cb0`](https://github.com/NixOS/nixpkgs/commit/543d1cb0ab572de71d9b6fbb7ab61da8c4089f78) | `` linux: 6.1.16 -> 6.1.18 ``                                       |
| [`268d3c83`](https://github.com/NixOS/nixpkgs/commit/268d3c83e9bb8606cba66d81d7ae6634733438a4) | `` linux: 5.4.234 -> 5.4.235 ``                                     |
| [`b8f7014c`](https://github.com/NixOS/nixpkgs/commit/b8f7014cd37c114eabf0fe1f47c500dc4102578a) | `` linux: 5.15.99 -> 5.15.100 ``                                    |
| [`fb6c3990`](https://github.com/NixOS/nixpkgs/commit/fb6c399020bd844589279bca49bd8fb1003566a7) | `` linux: 5.10.172 -> 5.10.173 ``                                   |
| [`26c18b8d`](https://github.com/NixOS/nixpkgs/commit/26c18b8d2779965fa3cea8d21fece2fd4d3ae5d6) | `` linux: 4.19.275 -> 4.19.276 ``                                   |
| [`9e15b244`](https://github.com/NixOS/nixpkgs/commit/9e15b24443bdbe400b2335c2b01710450e635a4c) | `` linux: 4.14.307 -> 4.14.308 ``                                   |
| [`63156f7a`](https://github.com/NixOS/nixpkgs/commit/63156f7a0ef22a116f8774ac5fa2a5d5b6084712) | `` ogre: 13.6.2 -> 13.6.3 ``                                        |
| [`4dab9b6c`](https://github.com/NixOS/nixpkgs/commit/4dab9b6c97bd5f40c9d8340308f37a872e92bdbe) | `` qmmp: add missing plugins ``                                     |
| [`e5f6d1f1`](https://github.com/NixOS/nixpkgs/commit/e5f6d1f121091c792f1be9e02ec1aa8272962d68) | `` chaos: 0.4.0 -> 0.5.0 ``                                         |
| [`d4a0e2f8`](https://github.com/NixOS/nixpkgs/commit/d4a0e2f8dcfd40bb8c88305c3514dda36820e257) | `` github-runner: fix hash ``                                       |
| [`be31f4a4`](https://github.com/NixOS/nixpkgs/commit/be31f4a47e90ffe395d20f4e060a5c0651f13246) | `` gbinder-python: fix cross-compilation ``                         |
| [`19c3fb47`](https://github.com/NixOS/nixpkgs/commit/19c3fb47f1fb4203b4c59d85f18964619fd8709b) | `` libgbinder: fix cross-compilation ``                             |
| [`ec588179`](https://github.com/NixOS/nixpkgs/commit/ec58817987e72af0b71d709497790bdf1c4815cc) | `` libglibutil: fix cross-compilation ``                            |
| [`347cb9c9`](https://github.com/NixOS/nixpkgs/commit/347cb9c9ee0fee9ead947a209768ac6572d1884d) | `` vimPlugins.flatten-nvim: init at 2023-03-11 ``                   |
| [`dd8a9036`](https://github.com/NixOS/nixpkgs/commit/dd8a903634f50e688157b075d64190711df09b93) | `` nixpacks: 1.4.1 -> 1.5.0 ``                                      |
| [`9458b9a0`](https://github.com/NixOS/nixpkgs/commit/9458b9a091121069060a97f6fcdfddeb817b2786) | `` g2o: remove CXXFLAGS ``                                          |
| [`77c83ddb`](https://github.com/NixOS/nixpkgs/commit/77c83ddbc9dea7d0043349c383e9f65fb7935293) | `` diamond: 2.1.4 -> 2.1.5 ``                                       |
| [`6b655779`](https://github.com/NixOS/nixpkgs/commit/6b655779b6edc2262af62ca83e7318d56a33b37e) | `` weston: add option to build demo-clients ``                      |
| [`9d195547`](https://github.com/NixOS/nixpkgs/commit/9d195547170184de54b793978b8308c68b4323a3) | `` stylua: 0.16.1 -> 0.17.0 ``                                      |
| [`4e34e4da`](https://github.com/NixOS/nixpkgs/commit/4e34e4daacacf10f79c3a93bf16cf3d221cbfe1f) | `` bvi: 1.4.1 -> 1.4.2 ``                                           |
| [`6e39f161`](https://github.com/NixOS/nixpkgs/commit/6e39f161dc2829c40082e5dc9565f5b5e7aef858) | `` smooth: 0.9.9 -> 0.9.10 ``                                       |
| [`610449c9`](https://github.com/NixOS/nixpkgs/commit/610449c9b6404dc2a819f05b84eb9e4951714153) | `` karma: 0.112 -> 0.113 ``                                         |
| [`2a243b0f`](https://github.com/NixOS/nixpkgs/commit/2a243b0f59a8aca1a825f7fd353ca201d6ca2694) | `` mympd: 10.2.4 -> 10.2.5 ``                                       |
| [`6c573aa3`](https://github.com/NixOS/nixpkgs/commit/6c573aa3aae71e080c252c079d341fe762282184) | `` ansible-lint: 6.14.0 -> 6.14.2 ``                                |
| [`06a1851d`](https://github.com/NixOS/nixpkgs/commit/06a1851ded9414e2839832b8bba5333c2a1a3049) | `` box64: 0.2.0 -> 0.2.2 ``                                         |
| [`b69554a0`](https://github.com/NixOS/nixpkgs/commit/b69554a0d288345d889161c0e630395fba6d3441) | `` xivlauncher: include GStreamer in closure ``                     |
| [`ad1a5da4`](https://github.com/NixOS/nixpkgs/commit/ad1a5da461333a247e46abdbd94285a899a574e6) | `` gitlab-runner: 15.9.0 -> 15.9.1 ``                               |
| [`89786dfa`](https://github.com/NixOS/nixpkgs/commit/89786dfaf32769900017849f319e3deca20edeb6) | `` python3Packages.pygls: 1.0.0 → 1.0.1 ``                          |
| [`d155c6b9`](https://github.com/NixOS/nixpkgs/commit/d155c6b92d1bf1a3d7761baee38b47533ffe0506) | `` fragments: 2.0.2 -> 2.1; unbreak ``                              |
| [`29d1503d`](https://github.com/NixOS/nixpkgs/commit/29d1503d99852399d93f80c4bfe832f0db88b92a) | `` trivy: 0.38.1 -> 0.38.2 ``                                       |
| [`ba02b526`](https://github.com/NixOS/nixpkgs/commit/ba02b526605cd9c5f62fa003c8d775b59763ebc3) | `` python310Packages.sqlmap: 1.7.2 -> 1.7.3 ``                      |
| [`00e4dc8b`](https://github.com/NixOS/nixpkgs/commit/00e4dc8b1b330e29d60cca2a1d227feb344f42b2) | `` python310Packages.flipr-api: add changelog to meta ``            |
| [`1ff0d17a`](https://github.com/NixOS/nixpkgs/commit/1ff0d17a2a4c63af380307f3b623f71ea9e8c9b7) | `` python310Packages.flipr-api: 1.4.4 -> 1.5.0 ``                   |
| [`60a3383e`](https://github.com/NixOS/nixpkgs/commit/60a3383eed3d1d025954da546f130de054be42eb) | `` buf: 1.15.0 -> 1.15.1 ``                                         |
| [`d0f40593`](https://github.com/NixOS/nixpkgs/commit/d0f405936b4cbecf131344bc573850737dc9beb0) | `` pulumi: 3.56.0 -> 3.57.1 ``                                      |
| [`a2fe9a01`](https://github.com/NixOS/nixpkgs/commit/a2fe9a01e55e474dfb0e981b9210d9faccbe4438) | `` redis: fix flaky test tests/unit/memefficiency.tcl ``            |
| [`e58ca987`](https://github.com/NixOS/nixpkgs/commit/e58ca987e5c3256b8d8671b11160218495aba1da) | `` httplib: 0.12.0 -> 0.12.1 ``                                     |
| [`86de7888`](https://github.com/NixOS/nixpkgs/commit/86de78883a7b7f5f12fca07df21026f76cc79f4a) | `` karmor: 0.11.7 -> 0.12.4 ``                                      |
| [`90e6adff`](https://github.com/NixOS/nixpkgs/commit/90e6adffd4c6b3955fae3c4196ddc07697661d9f) | `` simdjson: 3.1.3 -> 3.1.5 ``                                      |
| [`30e9f0b9`](https://github.com/NixOS/nixpkgs/commit/30e9f0b97b2147e5478b33787457ee5c22b175da) | `` gradle: 7.6 -> 7.6.1 ``                                          |
| [`1c13c5da`](https://github.com/NixOS/nixpkgs/commit/1c13c5daf45e23f590e60439268de827ab616c7b) | `` checkstyle: 10.8.0 -> 10.8.1 ``                                  |
| [`80cd61dd`](https://github.com/NixOS/nixpkgs/commit/80cd61dd415c30e42f881b9eb35ba9b875f89daa) | `` hotspot: Fix Rust demangling support ``                          |
| [`3c3a8739`](https://github.com/NixOS/nixpkgs/commit/3c3a8739a595f6309f6c8661a5b36ad8aaa5708c) | `` jami: 20230206.0 -> 20230306.0 ``                                |
| [`4e96143c`](https://github.com/NixOS/nixpkgs/commit/4e96143c7df4bb100d5dbd33a59228c4f21cdcab) | `` sm64ex-coop: 0.pre+date=2022-08-05 -> unstable-2023-02-22 ``     |
| [`7be3956a`](https://github.com/NixOS/nixpkgs/commit/7be3956a4661e9a8a5b02e7d5abec4c17adbca53) | `` sm64ex: 0.pre+date=2021-11-30 -> unstable-2022-12-19 ``          |
| [`a3b0a020`](https://github.com/NixOS/nixpkgs/commit/a3b0a020206bf4a7cfc19a6fd9eaf052c371d150) | `` velero: 1.10.1 -> 1.10.2 ``                                      |
| [`28e9c450`](https://github.com/NixOS/nixpkgs/commit/28e9c450fff7be43ee041d042b6fe7ec00609080) | `` awscli2: 2.11.1 -> 2.11.2 ``                                     |
| [`c8f9ad68`](https://github.com/NixOS/nixpkgs/commit/c8f9ad682d7557abdefb760f319f637fd6084dcd) | `` dkimpy: 1.1.0 -> 1.1.1 ``                                        |
| [`27b57d39`](https://github.com/NixOS/nixpkgs/commit/27b57d395ec0074bb955982c14fe1a51b766e4e2) | `` micronaut: 3.8.6 -> 3.8.7 ``                                     |
| [`d03d7d10`](https://github.com/NixOS/nixpkgs/commit/d03d7d1028d3866e9b8b6cd20b978ee6682b3234) | `` gallery-dl: 1.24.5 -> 1.25.0 ``                                  |
| [`92f6c2c8`](https://github.com/NixOS/nixpkgs/commit/92f6c2c8e78da0799248105be27f3be9008af9f8) | `` ipopt: 3.14.10 -> 3.14.11 ``                                     |
| [`ec5f1c11`](https://github.com/NixOS/nixpkgs/commit/ec5f1c111b7d26d3843f3b2697d3b0b74cccfb2b) | `` dunst: 1.9.0 -> 1.9.1 ``                                         |