### PR TITLE
chore(flake/home-manager): `7fe539df` -> `24c1a633`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678714646,
-        "narHash": "sha256-L7u4ua/p3cTptqlTVwT1OaQMGkexULjQhKmUxRUYmMQ=",
+        "lastModified": 1678729503,
+        "narHash": "sha256-j+h4Bdqbe+qjzhxdhkRmVgSx2lxJ8HnKeYcAhhnd1zM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7fe539dfbba8a158a455b54697d1bd7e97b37c60",
+        "rev": "24c1a6335e3da6a3ecf82f33ac50c2ad66aee346",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`24c1a633`](https://github.com/nix-community/home-manager/commit/24c1a6335e3da6a3ecf82f33ac50c2ad66aee346) | `` vscode: add options for global and user snippets (#3765) `` |