### PR TITLE
chore(flake/home-manager): `24c1a633` -> `cae54dc4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678729503,
-        "narHash": "sha256-j+h4Bdqbe+qjzhxdhkRmVgSx2lxJ8HnKeYcAhhnd1zM=",
+        "lastModified": 1678831854,
+        "narHash": "sha256-7HBmLFNVD2KjovSzypIN9NfyzpWelMe8sNbUVZIRsS0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "24c1a6335e3da6a3ecf82f33ac50c2ad66aee346",
+        "rev": "cae54dc45c0d61c99c1dc8b04bc42f36c76f9771",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`cae54dc4`](https://github.com/nix-community/home-manager/commit/cae54dc45c0d61c99c1dc8b04bc42f36c76f9771) | `` home-manager: change default configuration home ``     |
| [`da15dd1f`](https://github.com/nix-community/home-manager/commit/da15dd1f274d5de616f1dfd77a262d833b0726c9) | `` docs: minor typographic improvement in release note `` |
| [`8d2b8985`](https://github.com/nix-community/home-manager/commit/8d2b898532849ba0726b546a2ba52e0d2e5c2501) | `` docs: update description of uninstall command ``       |