### PR TITLE
chore(flake/home-manager): `5eec450c` -> `2bd74d92`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678881170,
-        "narHash": "sha256-S22WL1ZVBn8CRTLCpJsF7m7+6tRfgRFez2jfqUbWVtI=",
+        "lastModified": 1678886248,
+        "narHash": "sha256-ff81NJtc+AgQhUlTCkx8t8hda0o72vSxDeHVGrfxH70=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5eec450c75ee10307b3068467ccfb03e41ea76e2",
+        "rev": "2bd74d92bc7345f323ebcbfeb631d5cf4067ed8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`2bd74d92`](https://github.com/nix-community/home-manager/commit/2bd74d92bc7345f323ebcbfeb631d5cf4067ed8e) | `` ci: bump DeterminateSystems/update-flake-lock from 16 to 17 `` |
| [`85196310`](https://github.com/nix-community/home-manager/commit/85196310e1aceb1d91ff4fb5ac5cd6e1f630a66a) | `` Translate using Weblate (Spanish) ``                           |
| [`5b798e2b`](https://github.com/nix-community/home-manager/commit/5b798e2b99c64b5f9f533ef75663b7a3e3725d96) | `` Translate using Weblate (Swedish) ``                           |