### PR TITLE
chore(flake/nixpkgs): `5a1dc8ac` -> `7067edc6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -196,11 +196,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678654296,
-        "narHash": "sha256-aVfw3ThpY7vkUeF1rFy10NAkpKDS2imj3IakrzT0Occ=",
+        "lastModified": 1678819893,
+        "narHash": "sha256-lfA6WGdxPsPkBK5Y19ltr5Sn7v7MlT+jpZ4nUgco0Xs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a1dc8acd977ff3dccd1328b7c4a6995429a656b",
+        "rev": "7067edc68c035e21780259ed2d26e1f164addaa2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                         |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
| [`86dbc928`](https://github.com/NixOS/nixpkgs/commit/86dbc928fbc8f5f577b628100e55bf852652549e) | `` writers: make codesign_allocate available in PATH on aarch64-darwin ``                                       |
| [`88895129`](https://github.com/NixOS/nixpkgs/commit/8889512934037f08a9d09104d604b231095f8d02) | `` babl: 0.1.100 -> 0.1.102 ``                                                                                  |
| [`77e09950`](https://github.com/NixOS/nixpkgs/commit/77e09950a6095ca89aad69778ee65d9d5b4db3f2) | `` plasma: 5.27.2 -> 5.27.3 ``                                                                                  |
| [`78f395e4`](https://github.com/NixOS/nixpkgs/commit/78f395e4865e8586fbbec1dee74eabe2ed28304c) | `` firefox-esr-unwrapped: 102.8.0esr -> 102.9.0esr ``                                                           |
| [`5cd9737d`](https://github.com/NixOS/nixpkgs/commit/5cd9737ddb9ed92923be051e2bdd976c6e56b7e8) | `` firefox-bin-unwrapped: 110.0.1 -> 111.0 ``                                                                   |
| [`ec8a9cdd`](https://github.com/NixOS/nixpkgs/commit/ec8a9cddc814ea3ee60ae3984ccd17d70bf26d0a) | `` firefox-unwrapped: 110.0.1 -> 111.0 ``                                                                       |
| [`b514253c`](https://github.com/NixOS/nixpkgs/commit/b514253c07ad60d9960a1cf8d85c6742bc012b14) | `` python310Packages.homeassistant-stubs: 2023.3.2 -> 2023.3.4 ``                                               |
| [`3f0518f3`](https://github.com/NixOS/nixpkgs/commit/3f0518f306cc3a5644a9cebc06532ca140d996b0) | `` webrtc-audio-processing: add arm to supported platforms ``                                                   |
| [`6bade5f7`](https://github.com/NixOS/nixpkgs/commit/6bade5f7df44ce455f568e5d06b4177a614e3b35) | `` tamarin-prover: only use glibcLocales on linux ``                                                            |
| [`3b3e37f9`](https://github.com/NixOS/nixpkgs/commit/3b3e37f996a1265c6bfb7b4415241e3519c286c0) | `` [OCaml] tell dune where to install man ``                                                                    |
| [`628686ab`](https://github.com/NixOS/nixpkgs/commit/628686ab4539af55de0503405518f3bb2e97a156) | `` amass: 3.22.0 -> 3.22.1 ``                                                                                   |
| [`fbb554fa`](https://github.com/NixOS/nixpkgs/commit/fbb554fa58b6efd14525cf2b542ca67b1e7d1170) | `` nixos/kubernetes: update coredns 1.7.1 -> 1.10.1 ``                                                          |
| [`f39cdb78`](https://github.com/NixOS/nixpkgs/commit/f39cdb7806f1cd5af8269aae13b0d2e3e8637e62) | `` python310Packages.myst-parser: fix test dependencies ``                                                      |
| [`5549def3`](https://github.com/NixOS/nixpkgs/commit/5549def360284e5c1ee7b92c351d3a6a902715ff) | `` python310Packages.markdown-it-py: properly separate optional dependencies, drop python 3.7-3.8 support ``    |
| [`1df9510f`](https://github.com/NixOS/nixpkgs/commit/1df9510fdba443f7cc24a7f291cf173f49dd9504) | `` python310Packages.databricks-sql-connector: 2.3.0 -> 2.4.0 ``                                                |
| [`d51b1600`](https://github.com/NixOS/nixpkgs/commit/d51b160067442c8b232366cc0e91e6760104c459) | `` databricks-sql-cli: use python3.pkgs ``                                                                      |
| [`144e7d88`](https://github.com/NixOS/nixpkgs/commit/144e7d8859761538d062aa262941baeefb0c5d63) | `` databricks-sql-cli: add changelog to meta ``                                                                 |
| [`30b287fb`](https://github.com/NixOS/nixpkgs/commit/30b287fbad05a5a3a0cb25e11d08a5644aa2ced4) | `` fwupd: add passthru.fwupd-efi ``                                                                             |
| [`490b3385`](https://github.com/NixOS/nixpkgs/commit/490b338580db6a18cb4a8cfef60d64e51ba9145c) | `` protoc-gen-go: 1.29.0 -> 1.29.1 ``                                                                           |
| [`d433beb6`](https://github.com/NixOS/nixpkgs/commit/d433beb6c44d8463daca0c81911d97aa6a2fe68f) | `` python310Packages.asyncssh: add optional-dependencies ``                                                     |
| [`12ebd64d`](https://github.com/NixOS/nixpkgs/commit/12ebd64d985e674ec55e3d7312c5ecea2c692db2) | `` garage: 0.8.1 -> 0.8.2 ``                                                                                    |
| [`3f795bc5`](https://github.com/NixOS/nixpkgs/commit/3f795bc5785106f4b3a83ab3d6240dcafc314784) | `` acpica-tools: fix darwin build ``                                                                            |
| [`ae8fa234`](https://github.com/NixOS/nixpkgs/commit/ae8fa2344871a012b4ae173d5fd531bf7d27b269) | `` geographiclib: 2.1.2 -> 2.2 ``                                                                               |
| [`18055cef`](https://github.com/NixOS/nixpkgs/commit/18055cefb1a503498279f5e9022eb626b4211815) | `` fheroes2: 1.0.1 -> 1.0.2 ``                                                                                  |
| [`d116f707`](https://github.com/NixOS/nixpkgs/commit/d116f70722da14dd3a61e27db6bc680682071a8e) | `` a2ps: 4.14 -> 4.15.1 ``                                                                                      |
| [`2d851c7d`](https://github.com/NixOS/nixpkgs/commit/2d851c7d97860c3ebce0fda7bc4b5678bd385c94) | `` jql: add changelog to meta ``                                                                                |
| [`e1c8e49e`](https://github.com/NixOS/nixpkgs/commit/e1c8e49e43de3b451a8ef3c3b96e60c7e7556945) | `` k3s: 1.26.1+k3s1 -> 1.26.2+k3s1 ``                                                                           |
| [`5c50f54d`](https://github.com/NixOS/nixpkgs/commit/5c50f54db8f94b766d18c2e10c7a19df56d618d1) | `` python310Packages.rflink: 0.0.63 -> 0.0.65 ``                                                                |
| [`f6005898`](https://github.com/NixOS/nixpkgs/commit/f6005898a12f66a96674063cd7d5bae101284c55) | `` buildkit: add developer-guy to maintainers list ``                                                           |
| [`234304f5`](https://github.com/NixOS/nixpkgs/commit/234304f50d9f5d65a4d38a0ffea2028c2e2fa7f1) | `` python310Packages.ulid-transform: 0.4.0 -> 0.4.2 ``                                                          |
| [`533bd10e`](https://github.com/NixOS/nixpkgs/commit/533bd10ef6bf30d2e3296cc667ac7abb50d1895c) | `` python310Packages.easyenergy: 0.2.0 -> 0.2.1 ``                                                              |
| [`d9925fde`](https://github.com/NixOS/nixpkgs/commit/d9925fdefa3ff6324109cc82464c1c0659490ef5) | `` python310Packages.argcomplete: disable on unsupported Python releases ``                                     |
| [`c921484a`](https://github.com/NixOS/nixpkgs/commit/c921484a9814523da13327b359fd31ca321d0797) | `` python310Packages.argcomplete: add changelog to meta ``                                                      |
| [`8a48222c`](https://github.com/NixOS/nixpkgs/commit/8a48222ce98ba3d3d69bdabf1f516764ef290058) | `` python310Packages.argcomplete: update ordering and style ``                                                  |
| [`dbda7cc5`](https://github.com/NixOS/nixpkgs/commit/dbda7cc58cc140fc70c973dc3d7068de94e79233) | `` home-assistant: 2023.3.3 -> 2023.3.4 ``                                                                      |
| [`8ee55708`](https://github.com/NixOS/nixpkgs/commit/8ee557085bd8c74f14c82b29e74c5dfa84680f14) | `` python310Packages.bellows: 0.34.9 -> 0.34.10 ``                                                              |
| [`4abd7c8e`](https://github.com/NixOS/nixpkgs/commit/4abd7c8e58ece3b6debe8a903376cb660d58767b) | `` python310Packages.zha-quirks: 0.0.93 -> 0.0.94 ``                                                            |
| [`ba9146d6`](https://github.com/NixOS/nixpkgs/commit/ba9146d6d882f0341cc5fa0155e40e35566ee8fe) | `` python310Packages.nextcord: 2.4.0 -> 2.4.1 ``                                                                |
| [`c18302e3`](https://github.com/NixOS/nixpkgs/commit/c18302e31a698a3cbb789b105d4441184d690d69) | `` python310Packages.mkdocs-minify: 0.6.2 -> 0.6.3 ``                                                           |
| [`1b803334`](https://github.com/NixOS/nixpkgs/commit/1b803334ee027cf4e5bf26a8b9818f0d2fa99523) | `` jql: 5.1.7 -> 5.2.0 ``                                                                                       |
| [`cbcb0330`](https://github.com/NixOS/nixpkgs/commit/cbcb0330c7eb1efec8fc27a095affe75ecdbd94d) | `` python310Packages.eve: 2.0.4 -> 2.1.0 ``                                                                     |
| [`7c9b69b1`](https://github.com/NixOS/nixpkgs/commit/7c9b69b1aa79fb3f92623234ef74643c220d8c18) | `` twilio-cli: 5.4.1 -> 5.4.2 ``                                                                                |
| [`ba6524a7`](https://github.com/NixOS/nixpkgs/commit/ba6524a7063b7344900b2d70985011d57b7f6bfb) | `` terraform-providers.google-beta: 4.56.0 → 4.57.0 ``                                                          |
| [`c2d6a003`](https://github.com/NixOS/nixpkgs/commit/c2d6a003a44b43882784841c961142867d61135f) | `` terraform-providers.google: 4.56.0 → 4.57.0 ``                                                               |
| [`20426d62`](https://github.com/NixOS/nixpkgs/commit/20426d62eb74ef0e746e1c555197ef0a0a1b4fc3) | `` codevis: 0.8.0 -> 0.8.1 ``                                                                                   |
| [`57bb04e3`](https://github.com/NixOS/nixpkgs/commit/57bb04e38e2ffa1972d7d430667dd6d8ed323237) | `` goreleaser: 1.16.0 -> 1.16.1 ``                                                                              |
| [`8df2011f`](https://github.com/NixOS/nixpkgs/commit/8df2011f57dd74a4e94feb0c1394c4076705c412) | `` hypr: unstable-2022-05-25 -> unstable-2023-01-26 ``                                                          |
| [`0d0949b3`](https://github.com/NixOS/nixpkgs/commit/0d0949b3a383e4c54dec7208903fdd91d84cbd10) | `` sq: 0.24.0 -> 0.24.1 ``                                                                                      |
| [`d3e75339`](https://github.com/NixOS/nixpkgs/commit/d3e75339e5d54a5d7bf004f769757a31513ea378) | `` vscode: 1.76.0 -> 1.76.1 ``                                                                                  |
| [`c373fc96`](https://github.com/NixOS/nixpkgs/commit/c373fc96267c1a09e84fbc0c3b1bfbf4f798ac7a) | `` paging-calculator: 0.1.2 -> 0.2.0 (#219752) ``                                                               |
| [`98fe000b`](https://github.com/NixOS/nixpkgs/commit/98fe000b3db44821eee3e92173a7906cbffda828) | `` python310Packages.dvc-http: 0.0.1 -> 2.30.2 ``                                                               |
| [`aa112217`](https://github.com/NixOS/nixpkgs/commit/aa11221764e42cf9a5a18f4291c2a2858cbb57d8) | `` vokoscreen-ng: 3.0.8 -> 3.5.0 (#219070) ``                                                                   |
| [`ddd7321d`](https://github.com/NixOS/nixpkgs/commit/ddd7321df044a4eee465baf792d64d5f6427e242) | `` prometheus: enable OVHCloud plugin ``                                                                        |
| [`585903e2`](https://github.com/NixOS/nixpkgs/commit/585903e26e5fc2eddd9ac9ab98a28f7f6100fac6) | `` nurl: 0.3.7 -> 0.3.9 ``                                                                                      |
| [`2761bf7e`](https://github.com/NixOS/nixpkgs/commit/2761bf7ec0fbdb784ebcbf4e90e1a9e727c83657) | `` enumerepo: init at 1.0.0 ``                                                                                  |
| [`1b1910bf`](https://github.com/NixOS/nixpkgs/commit/1b1910bf7c8ad4af7c6e2f858cd90a10a8be903b) | `` checkov: 2.1.20 -> 2.3.85 ``                                                                                 |
| [`2f0dc858`](https://github.com/NixOS/nixpkgs/commit/2f0dc858194c0f2f27e136eb3d4ea1dbb33a2c3a) | `` python310Packages.mdit-py-plugins: remove unused disableTests option ``                                      |
| [`6700d67d`](https://github.com/NixOS/nixpkgs/commit/6700d67d8cc9d12271881311b04234211af340d8) | `` python310Packages.markdown-it-py: remove unused disableTests option, cleanup and reduce test dependencies `` |
| [`d1a388ae`](https://github.com/NixOS/nixpkgs/commit/d1a388ae8eb203269a29b3c9b9829869c0a14385) | `` nixos-render-docs: use packageOverrides to construct python packages ``                                      |
| [`778f26d3`](https://github.com/NixOS/nixpkgs/commit/778f26d3ec07a6713c9b5c19fa6964e68eb281cc) | `` codevis: 0.7.1 -> 0.8.0 ``                                                                                   |
| [`b638c868`](https://github.com/NixOS/nixpkgs/commit/b638c8689b22ae30f49d01e9e55b5a2de684ebfb) | `` maddy: 0.6.2 -> 0.6.3 ``                                                                                     |
| [`9cf4b8b3`](https://github.com/NixOS/nixpkgs/commit/9cf4b8b3ebe77c729c9f7599deb725fbdf62aa40) | `` gitlab: 15.8.4 -> 15.9.3 (#220482) ``                                                                        |
| [`127f7023`](https://github.com/NixOS/nixpkgs/commit/127f7023436df812eee4dcf6e87876afe3d5f67f) | `` halp: 0.1.0 -> 0.1.1 ``                                                                                      |
| [`83f6c0e0`](https://github.com/NixOS/nixpkgs/commit/83f6c0e01b80a718996fb991eedb8dfbf1d1fa4c) | `` python310Packages.bc-jsonpath-ng: init at 1.5.9 ``                                                           |
| [`e0c6fb80`](https://github.com/NixOS/nixpkgs/commit/e0c6fb80a36f66a2254188b662f21c80011ba28f) | `` python310Packages.bc-detect-secrets: init at 1.4.14 ``                                                       |
| [`ceea8b45`](https://github.com/NixOS/nixpkgs/commit/ceea8b450795845bef61af24993b1f67fbc3f564) | `` payload-dumper-go: init at 1.2.2 ``                                                                          |
| [`8d32fec9`](https://github.com/NixOS/nixpkgs/commit/8d32fec9ccac96013dcd58d3bed08eb6fa98fe74) | `` speedtest-go: init at 1.5.2 ``                                                                               |
| [`3c2b9b3c`](https://github.com/NixOS/nixpkgs/commit/3c2b9b3cbb7f7a34373871c8d659f2ffc25698a4) | `` vimPlugins.searchbox-nvim: init at 2022-11-01 ``                                                             |
| [`c1b5b438`](https://github.com/NixOS/nixpkgs/commit/c1b5b438f1dd9ff907d6a0c979537f404ea3f174) | `` shell-genie: 0.2.6 -> 0.2.8 ``                                                                               |
| [`58479570`](https://github.com/NixOS/nixpkgs/commit/58479570e6f000707e83fba26b36579529b3aa33) | `` python310Packages.rstcheck: 6.1.1 -> 6.1.2 ``                                                                |
| [`1c9509f4`](https://github.com/NixOS/nixpkgs/commit/1c9509f4e83f9f3c7c35713af2a97e3de3a3785b) | `` python310Packages.reolink-aio: 0.5.4 -> 0.5.5 ``                                                             |
| [`00398e92`](https://github.com/NixOS/nixpkgs/commit/00398e923cefbb038b488019d1d6169c14693d88) | `` gamescope: 3.11.49 -> 3.11.52-beta6 ``                                                                       |
| [`dc9f7e5a`](https://github.com/NixOS/nixpkgs/commit/dc9f7e5adab4a1618514c0a69ac417d398e88762) | `` libliftoff: 0.3.0 -> 0.4.1 ``                                                                                |
| [`1b88a5bc`](https://github.com/NixOS/nixpkgs/commit/1b88a5bc22dc96281226580fa87170fa3f485aa5) | `` openvr: init at 1.23.8 ``                                                                                    |
| [`38540757`](https://github.com/NixOS/nixpkgs/commit/38540757f473be3652e2ad525c37b16cd2ca001b) | `` python310Packages.google-nest-sdm: remove asynctest ``                                                       |
| [`ec40c453`](https://github.com/NixOS/nixpkgs/commit/ec40c45390e9bfb0a1fb04e25a9dd7d0d8abe7ce) | `` python310Packages.ismartgate: remove asynctest ``                                                            |
| [`a62bd76f`](https://github.com/NixOS/nixpkgs/commit/a62bd76f7f59f76f5e61d47a5608d9764aee651c) | `` python310Packages.ismartgate: add changelog to meta ``                                                       |
| [`a8cfd275`](https://github.com/NixOS/nixpkgs/commit/a8cfd275226ecc37b09dccd3e303884c48118e0b) | `` scrcpy: 1.25 -> 2.0 (#220783) ``                                                                             |
| [`ab94f417`](https://github.com/NixOS/nixpkgs/commit/ab94f4171637980e5c6b06daabf3eb4b1d4e1a3b) | `` metasploit: 6.3.5 -> 6.3.7 ``                                                                                |
| [`f60b11ce`](https://github.com/NixOS/nixpkgs/commit/f60b11ce4d33bdb681aeb9efdb788e3ab3731451) | `` kubescape: 2.2.4 -> 2.2.5 ``                                                                                 |
| [`44499407`](https://github.com/NixOS/nixpkgs/commit/44499407c25d1f05e0dc076914dbe680c2873895) | `` python310Packages.python-otbr-api: 1.0.7 -> 1.0.9 ``                                                         |
| [`0ff69296`](https://github.com/NixOS/nixpkgs/commit/0ff6929661f2a913cbe9391bd6e8c2fd3b00d397) | `` mitmproxy2swagger: 0.8.1 -> 0.8.2 ``                                                                         |
| [`440ccc0e`](https://github.com/NixOS/nixpkgs/commit/440ccc0eb823f15132d169dae7f660e04c16e47b) | `` deckmaster: add changelog to meta ``                                                                         |
| [`190082d2`](https://github.com/NixOS/nixpkgs/commit/190082d2fd184bc078127135fd358160ab4c4e5d) | `` py-spy: add homepage and changelog ``                                                                        |
| [`c6678ba4`](https://github.com/NixOS/nixpkgs/commit/c6678ba42d64aa41d7da738b274138b86dd75a9b) | `` python310Packages.ray: 2.0.0 -> 2.3.0 ``                                                                     |
| [`034265f6`](https://github.com/NixOS/nixpkgs/commit/034265f603383a688f07ba0fed3e36de22515c4b) | `` python310Packages.ray: add changelog to meta ``                                                              |
| [`a320d6a5`](https://github.com/NixOS/nixpkgs/commit/a320d6a511ca947961b6605c859708e078ad1139) | `` py-spy: disable failing test ``                                                                              |
| [`d742e50b`](https://github.com/NixOS/nixpkgs/commit/d742e50b2f36832c88699bb71bb6362f8baf5582) | `` osslsigncode: per review feedback, pull patches from github rather than vendoring into the tree ``           |
| [`08a747a4`](https://github.com/NixOS/nixpkgs/commit/08a747a4ca8d5ef128f3ad0953a5abe1326afceb) | `` deckmaster: 0.8.0 -> 0.9.0 ``                                                                                |
| [`64f561b4`](https://github.com/NixOS/nixpkgs/commit/64f561b4f5bae9ccc725b839fc4b02215fec6e73) | `` py-spy: equalize ``                                                                                          |
| [`45c3600b`](https://github.com/NixOS/nixpkgs/commit/45c3600bb13554ab0c68a6a3d2d3d5fe0af39ef3) | `` buildDunePackage: fix doc installation ``                                                                    |
| [`4777ea72`](https://github.com/NixOS/nixpkgs/commit/4777ea72cabacbbbe28052bacb6272ff6d45adf0) | `` clash-geoip: 20230212 -> 20230312 ``                                                                         |
| [`8441efbc`](https://github.com/NixOS/nixpkgs/commit/8441efbcab1fe45005e360a699413bd2d544ddd2) | `` p4c: 1.2.3.6 -> 1.2.3.7 ``                                                                                   |
| [`a5e08c8e`](https://github.com/NixOS/nixpkgs/commit/a5e08c8e58fa30c975723697a32aa38a6c9ce2f8) | `` cargo-nextest: 0.9.49 -> 0.9.50 ``                                                                           |
| [`1d65c727`](https://github.com/NixOS/nixpkgs/commit/1d65c7279ce469ef89a60653ac966b9e388f02ab) | `` nixos-generate-config: update microcode only on bare metal ``                                                |
| [`a9ad7261`](https://github.com/NixOS/nixpkgs/commit/a9ad7261b1e069a71e0103a640fd717e5e6fa1d2) | `` qovery-cli: 0.50.3 -> 0.51.1 ``                                                                              |
| [`70723fce`](https://github.com/NixOS/nixpkgs/commit/70723fce93cb3db3961fa7ccba08325aeacb38d3) | `` calc: 2.14.1.3 -> 2.14.1.5 ``                                                                                |
| [`ee5c0714`](https://github.com/NixOS/nixpkgs/commit/ee5c0714a747f5645c14aca3f1515aeec8fcac1f) | `` cargo-release: 0.24.5 -> 0.24.6 ``                                                                           |
| [`4c937efb`](https://github.com/NixOS/nixpkgs/commit/4c937efbfada701b59cd51c518768e132f802d50) | `` circumflex: 2.8.1 -> 2.8.2 ``                                                                                |
| [`cb24745b`](https://github.com/NixOS/nixpkgs/commit/cb24745b7f028148131e3c1f8cd14f509efe70b9) | `` confy: init at 0.6.4 ``                                                                                      |
| [`284126e8`](https://github.com/NixOS/nixpkgs/commit/284126e8bcdefad371eefde8ccec8d9113f591cc) | `` vivaldi: 5.7.2921.53 -> 5.7.2921.63 ``                                                                       |
| [`9513f526`](https://github.com/NixOS/nixpkgs/commit/9513f526c38b28ff4674314cea44fa87ab7342de) | `` datree: 1.8.37 -> 1.8.39 ``                                                                                  |
| [`77f3fa8c`](https://github.com/NixOS/nixpkgs/commit/77f3fa8c58fda2038c94322f28629c4f22c0b827) | `` osslsigncode: 2.3 -> 2.5 ``                                                                                  |
| [`d3b0f1d1`](https://github.com/NixOS/nixpkgs/commit/d3b0f1d1d6aa5472590b298b08c6d74375757b39) | `` python310Packages.myjwt: 1.6.0 -> 1.6.1 ``                                                                   |
| [`0c70e0f0`](https://github.com/NixOS/nixpkgs/commit/0c70e0f0229dd8e319fb2b91eb281807ae4b11d9) | `` python310Packages.exrex: unstable-2021-04-22 -> 0.11.0 ``                                                    |
| [`e83e79a0`](https://github.com/NixOS/nixpkgs/commit/e83e79a0ef8807b106599e6ddd0d90502c9b71f5) | `` linuxKernel.kernels.linux_zen: 6.2.5-zen2 -> 6.2.6-zen1 ``                                                   |
| [`fe8ec75a`](https://github.com/NixOS/nixpkgs/commit/fe8ec75ad82c05ebb33907085442bf891722f316) | `` python310Packages.idasen: 0.9.4 -> 0.9.5 ``                                                                  |
| [`cd1d2565`](https://github.com/NixOS/nixpkgs/commit/cd1d2565a2c71340b87f4b4d4bff4d3d31be95a2) | `` linuxKernel.kernels.linux_lqx: 6.2.5-lqx3 -> 6.2.6-lqx1 ``                                                   |
| [`c79b98dd`](https://github.com/NixOS/nixpkgs/commit/c79b98dd409766c342cb4917ed23f2c56b80f38d) | `` coldsnap: 0.4.3 -> 0.5.0 ``                                                                                  |
| [`eeb6008c`](https://github.com/NixOS/nixpkgs/commit/eeb6008cdc7d73a9685bc27fcbaceb6e8d78ceb8) | `` vivaldi: add updateScript ``                                                                                 |
| [`a47d2b3d`](https://github.com/NixOS/nixpkgs/commit/a47d2b3dde1133e0917b5154ce6ee2bdfc0fc4f4) | `` phpExtensions.msgpack: init at 2.2.0RC2 ``                                                                   |
| [`7953ef01`](https://github.com/NixOS/nixpkgs/commit/7953ef015a02644b5be6cfb4c60cf413a77c7cd4) | `` phpExtensions.ssh2: init at 1.3.1 ``                                                                         |