### PR TITLE
chore(flake/flake-utils): `3db36a8b` -> `93a2b84f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -87,11 +87,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                            |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`93a2b84f`](https://github.com/numtide/flake-utils/commit/93a2b84fc4b70d9e089d029deacc3583435c2ed6) | `` Update README to reflect example for eachDefaultSystem (#90) `` |