### PR TITLE
chore(flake/nix-index-database): `b61432cc` -> `fb4949a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678780868,
-        "narHash": "sha256-r6EfMQCAGX5JE6lW4YgZdH7bOSi1pul1TCbAJ7bVfSw=",
+        "lastModified": 1678900860,
+        "narHash": "sha256-whR4CNeKaXFi2o+oZBj7o4bV+sw8fAHW9s1Dk+JPZU0=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "b61432cc89bb6d16aa30cf546e8dca3d4fea006b",
+        "rev": "fb4949a2ddf4dcfb53c0eaf01334522309045471",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                       |
| --------------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`0b8bcdb0`](https://github.com/Mic92/nix-index-database/commit/0b8bcdb02a08366b91f80b37d624fa0347d7b17a) | `` feat: add darwinModules `` |