### PR TITLE
chore(flake/home-manager): `2bd74d92` -> `95201931`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678886248,
-        "narHash": "sha256-ff81NJtc+AgQhUlTCkx8t8hda0o72vSxDeHVGrfxH70=",
+        "lastModified": 1678904532,
+        "narHash": "sha256-ziszYqNQtYxS1iPAPy6K8G94P/LghqM3niXrnKbp8pI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2bd74d92bc7345f323ebcbfeb631d5cf4067ed8e",
+        "rev": "95201931f2e733705296d1d779e70793deaeb909",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`95201931`](https://github.com/nix-community/home-manager/commit/95201931f2e733705296d1d779e70793deaeb909) | `` qutebrowser: allow for specifying multiple commands in bindings (#3322) `` |