### PR TITLE
chore(flake/pre-commit-hooks): `1a20b970` -> `32b1dbed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -212,11 +212,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1673800717,
-        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
+        "lastModified": 1678872516,
+        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
+        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
         "type": "github"
       },
       "original": {
@@ -241,11 +241,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1678376203,
-        "narHash": "sha256-3tyYGyC8h7fBwncLZy5nCUjTJPrHbmNwp47LlNLOHSM=",
+        "lastModified": 1678976941,
+        "narHash": "sha256-skNr08frCwN9NO+7I77MjOHHAw+L410/37JknNld+W4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "1a20b9708962096ec2481eeb2ddca29ed747770a",
+        "rev": "32b1dbedfd77892a6e375737ef04d8efba634e9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                        |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------ |
| [`1045ae05`](https://github.com/cachix/pre-commit-hooks.nix/commit/1045ae059bc179b8f0997ec932a01c9441c3239a) | `` [bump] bump dependencies `` |
| [`ad0d326b`](https://github.com/cachix/pre-commit-hooks.nix/commit/ad0d326b2a1a1a0876a8312d4a2c6232c49ca3b1) | `` Add tagref to README.md ``  |
| [`fb032377`](https://github.com/cachix/pre-commit-hooks.nix/commit/fb032377d74c904904743f41dbbd63856fefdc4b) | `` Add nil hook ``             |