### PR TITLE
chore(flake/nix-index-database): `e689206f` -> `2f5e6e91`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679223134,
-        "narHash": "sha256-WFDXtjOETUwKm1uIS6aHlxU79GzVNxrbjVrECJG/6zk=",
+        "lastModified": 1679224439,
+        "narHash": "sha256-QkvcuC4b67FUkkxlMsLTMPbwoD7yZr0UvJpu6jkFuLo=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "e689206f0e0707c8e27070b0e88d3f6f031584a4",
+        "rev": "2f5e6e915d70c04d673a8930f94591595c73eb84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`2f5e6e91`](https://github.com/Mic92/nix-index-database/commit/2f5e6e915d70c04d673a8930f94591595c73eb84) | `` update packages.nix to release 2023-03-19-111256 `` |