### PR TITLE
chore(flake/nixpkgs): `b573a7f6` -> `1603d115`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -196,11 +196,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679081381,
-        "narHash": "sha256-n4+SbrVohxbgbmOTkodfxc3d8W38OfKowD6YNA8j27o=",
+        "lastModified": 1679172431,
+        "narHash": "sha256-XEh5gIt5otaUbEAPUY5DILUTyWe1goAyeqQtmwaFPyI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b573a7f69484a7d213680abb70b4f95bdc28eee5",
+        "rev": "1603d11595a232205f03d46e635d919d1e1ec5b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                             |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [`c60afb9c`](https://github.com/NixOS/nixpkgs/commit/c60afb9cbe3390e7b57f1dd553774e79864cea4d) | `` sapling: fix build ``                                                                            |
| [`4054db2f`](https://github.com/NixOS/nixpkgs/commit/4054db2f358c69b7051568e48076c78453d3f248) | `` zrythm: 1.0.0-beta.4.5.62 -> 1.0.0-beta.4.6.3 (#221681) ``                                       |
| [`ffd48ee0`](https://github.com/NixOS/nixpkgs/commit/ffd48ee04d11a87b36bae3ac7cf4806c8a0639f2) | `` matrix-conduit: use importCargoLock instead of hacky patch ``                                    |
| [`4ba9fc50`](https://github.com/NixOS/nixpkgs/commit/4ba9fc5008b06c59d3fff795db897df4b2d0e382) | `` ruff: 0.0.244 -> 0.0.248 ``                                                                      |
| [`5686f006`](https://github.com/NixOS/nixpkgs/commit/5686f0064d5f36e7f39984ea9232b42c1104bf1e) | `` rustPlatform.importCargoLock: add support for git dependencies that use workspace inheritance `` |
| [`d0661c94`](https://github.com/NixOS/nixpkgs/commit/d0661c9406eed2766eb8b28b74ce97bdd4d53756) | `` vimPlugins.sniprun: 1.2.8 -> 1.2.13 ``                                                           |
| [`e5005453`](https://github.com/NixOS/nixpkgs/commit/e5005453d3315aa58a04b901cbecbef5e241f7b1) | `` vscode-extensions: refactor of extensions (#221878) ``                                           |
| [`c03e56b8`](https://github.com/NixOS/nixpkgs/commit/c03e56b8e6e2ecf6047445c8f3c737143c8a315f) | `` python3Packages.pywlroots: add qtile to passthru.tests ``                                        |
| [`69b0f3dc`](https://github.com/NixOS/nixpkgs/commit/69b0f3dc3e05879a627ac787cc55366abc4ba374) | `` python310Packages.python-lsp-server: Add meta.mainProgram (#221728) ``                           |
| [`0ddc01c5`](https://github.com/NixOS/nixpkgs/commit/0ddc01c5694ee1f80944f2a1f1fa1204638782c1) | `` glucose: refactor ``                                                                             |
| [`bb374eb1`](https://github.com/NixOS/nixpkgs/commit/bb374eb189197d7eea01b7e2f2026d7f7ae0bed0) | `` python3Packages.scooby: unbreak ``                                                               |
| [`7f5a3739`](https://github.com/NixOS/nixpkgs/commit/7f5a37392dc4d7645f412e8ce256b7aadf4a173e) | `` cl, wings: unbreak on aarch64-linux ``                                                           |
| [`5ab6260d`](https://github.com/NixOS/nixpkgs/commit/5ab6260d62ebcbf72e96484584a26e8226167fc8) | `` metamorphose2: migrate to wxPython_4_2 ``                                                        |
| [`b3a8004b`](https://github.com/NixOS/nixpkgs/commit/b3a8004bd2b8f8bb0fb5a2cc2b33925a74809204) | `` rapidsvn: 0.12.1 -> unstable-2021-08-02 ``                                                       |
| [`184dd6c6`](https://github.com/NixOS/nixpkgs/commit/184dd6c69877503ff08ac584967fc66fb922c821) | `` maintainers: add markbeep ``                                                                     |
| [`00b01da5`](https://github.com/NixOS/nixpkgs/commit/00b01da53bd96a19fc01266fe1a7f3600a087d60) | `` ramfetch: init at 1.1.0 ``                                                                       |
| [`faee400b`](https://github.com/NixOS/nixpkgs/commit/faee400b3f2adde84d9f6dcd3e5eb92af06585c2) | `` golangci-lint: 1.51.2 -> 1.52.0 ``                                                               |
| [`f6bbab19`](https://github.com/NixOS/nixpkgs/commit/f6bbab1940f15d80cc6593552ece764fa1677b7c) | `` CODEOWNERS: Add OCaml maintainers ``                                                             |
| [`eacf840b`](https://github.com/NixOS/nixpkgs/commit/eacf840bcaa35ee0ba0ae05ae094fc7f2469c8a2) | `` ocamlPackages.pgocaml: 4.2.2-dev-20210111 → 4.3.0 ``                                             |
| [`3f96a3fb`](https://github.com/NixOS/nixpkgs/commit/3f96a3fbe1400aea19e8f0729714c9fc9cd4bce8) | `` balena-cli: init at 15.1.1 ``                                                                    |
| [`c1bfba96`](https://github.com/NixOS/nixpkgs/commit/c1bfba963d794bce5715e6cf2c61e323e67272f7) | `` pomerium: 0.20.0 -> 0.21.2 ``                                                                    |
| [`05655e8a`](https://github.com/NixOS/nixpkgs/commit/05655e8ad3ef0aa1150ac5508d784829fd9f429b) | `` pomerium: add test for UI ``                                                                     |
| [`d76601d5`](https://github.com/NixOS/nixpkgs/commit/d76601d5595b7267e01197d1eb3733c7df88b6ba) | `` pomerium: add update script ``                                                                   |
| [`e6bbcf84`](https://github.com/NixOS/nixpkgs/commit/e6bbcf847d6affe5807bde1d6c521f608cac14d8) | `` vault-bin: 1.12.2 -> 1.13.0 ``                                                                   |
| [`a1238be2`](https://github.com/NixOS/nixpkgs/commit/a1238be2615289f9f505282462b440c3c207f996) | `` nomad_1_4: 1.4.4 -> 1.4.6 ``                                                                     |
| [`2e29c38e`](https://github.com/NixOS/nixpkgs/commit/2e29c38ec41236bef9a4ae8001beb47bc215d99c) | `` emacs.pkgs.project: Use project from elpa ``                                                     |
| [`1b99cfd1`](https://github.com/NixOS/nixpkgs/commit/1b99cfd174289cbab3c72fa2c6b2cad53c6d255f) | `` python310Packages.pypdf: 3.5.1 -> 3.5.2 ``                                                       |
| [`6831c05b`](https://github.com/NixOS/nixpkgs/commit/6831c05b634ec8a1e84131dcd674d56de2a6d11e) | `` python310Packages.pdm-backend: 2.0.2 -> 2.0.5 ``                                                 |
| [`96585d33`](https://github.com/NixOS/nixpkgs/commit/96585d333242f0cfe403fb274e2276978b575e1e) | `` python310Packages.lightning-utilities: 0.7.1 -> 0.8.0 ``                                         |
| [`952327b3`](https://github.com/NixOS/nixpkgs/commit/952327b3b09268aedeee13ea40bc61b5db8b6d2b) | `` codeql: jdk11 -> jdk17 ``                                                                        |
| [`b3cf0538`](https://github.com/NixOS/nixpkgs/commit/b3cf05383eb1b717011df8d752709a9ddcd7dffa) | `` jpegoptim: apply patch for CVE-2023-27781 ``                                                     |
| [`fb16963f`](https://github.com/NixOS/nixpkgs/commit/fb16963fded3c3be137823e70252aab1587b273e) | `` pypy3Packages.six: Disable test that loads native library ``                                     |
| [`109f8ccd`](https://github.com/NixOS/nixpkgs/commit/109f8ccdfe9c805b9963718dd18add195f31d53c) | `` nest: specify license ``                                                                         |
| [`63a3c7c6`](https://github.com/NixOS/nixpkgs/commit/63a3c7c636697fd5dbe4bc9acb74555a69d915fd) | `` pypy3Packages.greenlet: Set null for pypi ``                                                     |
| [`c7ec2912`](https://github.com/NixOS/nixpkgs/commit/c7ec29123516c51f5f4795dbfbc07a36fbf76f01) | `` nest: add changelog to meta ``                                                                   |
| [`b7b0c8ff`](https://github.com/NixOS/nixpkgs/commit/b7b0c8ff41d13a7ce1ab9b0d38c707aed31d4201) | `` python310Packages.peaqevcore: 13.2.0 -> 13.2.2 ``                                                |
| [`ea847dd1`](https://github.com/NixOS/nixpkgs/commit/ea847dd1a0ffc0b33f301d91bc2bf36e7fa1d9d8) | `` nest: 3.3 -> 3.4 ``                                                                              |
| [`d7acfb18`](https://github.com/NixOS/nixpkgs/commit/d7acfb1889e0d2435b92944431758a62679fd3ed) | `` python310Packages.pyobihai: 1.4.0 -> 1.4.1 ``                                                    |
| [`2865dd5a`](https://github.com/NixOS/nixpkgs/commit/2865dd5aaf7e92b95f4d8f06b867396a8445cf60) | `` orchis-theme: 2023-02-26 -> 2023-03-18 ``                                                        |
| [`bdb75d06`](https://github.com/NixOS/nixpkgs/commit/bdb75d06dc398e85892e64b71af096a5d08c3a01) | `` perlPackages.CpanelJSONXS: 4.31 -> 4.36 ``                                                       |
| [`8b7c79c8`](https://github.com/NixOS/nixpkgs/commit/8b7c79c8ba4b5e77a8ffadb4e065e26870eb8b23) | `` python3Packages.pywlroots: revert to pywlroots 0.15.24 ``                                        |
| [`76827e5e`](https://github.com/NixOS/nixpkgs/commit/76827e5ec81c1ba78acc8c2d45a40528c248ff90) | `` hyperledger-fabric: 2.4.6 -> 2.4.9 ``                                                            |
| [`decdea95`](https://github.com/NixOS/nixpkgs/commit/decdea95b6aa125b79f2b92305f3aaafc11048bc) | `` go-cqhttp: 1.0.0-rc4 -> 1.0.0-rc5 ``                                                             |
| [`8403c0d5`](https://github.com/NixOS/nixpkgs/commit/8403c0d5e2c41d8b25eac7bec689159c09255302) | `` python3Packages.debugpy: fix test failures ``                                                    |
| [`c1329a14`](https://github.com/NixOS/nixpkgs/commit/c1329a147a5fc2bb49367f6c2cd84bdfeccade43) | `` terraform-providers.tencentcloud: 1.79.16 → 1.79.17 ``                                           |
| [`b2afe552`](https://github.com/NixOS/nixpkgs/commit/b2afe552f570d2373a77772fd38c5332d05a0eb1) | `` terraform-providers.newrelic: 3.17.0 → 3.17.1 ``                                                 |
| [`2b9351c1`](https://github.com/NixOS/nixpkgs/commit/2b9351c15dd629e879a747676d64a09a80496ef4) | `` terraform-providers.minio: 1.12.0 → 1.13.0 ``                                                    |
| [`4e2546af`](https://github.com/NixOS/nixpkgs/commit/4e2546af0a78087b570319fb3c5f0e29706382b9) | `` terraform-providers.huaweicloud: 1.45.1 → 1.46.0 ``                                              |
| [`a754c8ae`](https://github.com/NixOS/nixpkgs/commit/a754c8ae2cac3660d6f0fa90471cb83df664a0f3) | `` terraform-providers.alicloud: 1.201.1 → 1.201.2 ``                                               |
| [`8ae4bb5a`](https://github.com/NixOS/nixpkgs/commit/8ae4bb5a63c542c25e71f17790b6bcf7a6605bca) | `` terraform-providers.docker: 3.0.1 → 3.0.2 ``                                                     |
| [`88033436`](https://github.com/NixOS/nixpkgs/commit/88033436bb822a6c04da9907437f7998a03f3275) | `` terraform-providers.auth0: 0.44.1 → 0.45.0 ``                                                    |
| [`53262cef`](https://github.com/NixOS/nixpkgs/commit/53262cefb708a74efa8bdf0c72ee60d099b69ccc) | `` netdata-go-plugins: update meta ``                                                               |
| [`a0753a8b`](https://github.com/NixOS/nixpkgs/commit/a0753a8b4b947179749f9f0550590835a0d7b51f) | `` netdata-go-plugins: add netdata test to passthru ``                                              |
| [`bd2b3ec6`](https://github.com/NixOS/nixpkgs/commit/bd2b3ec62b18c45293878bdff863f8c8ca663698) | `` netdata-go-plugins: 0.51.3 -> 0.51.4 ``                                                          |
| [`8815ddf3`](https://github.com/NixOS/nixpkgs/commit/8815ddf3ebace99bfd294468120a46a431f95714) | `` tbls: 1.62.1 -> 1.63.0 ``                                                                        |
| [`1a657f18`](https://github.com/NixOS/nixpkgs/commit/1a657f18f75cadad19c5374fcd05c7f7e096fcd6) | `` trivial-builders/test/references.nix: fix eval ``                                                |
| [`a6a085c6`](https://github.com/NixOS/nixpkgs/commit/a6a085c6dc581b8a351295ffe42e99e770f2f6a7) | `` netdata-go-plugins: 0.51.2 -> 0.51.3 ``                                                          |
| [`07c9ae7a`](https://github.com/NixOS/nixpkgs/commit/07c9ae7a658766e5eea496d986cf1b43036d5caa) | `` test-defaultPkgConfigPackages.nix: filter out recurseForDerivations ``                           |
| [`11e800d5`](https://github.com/NixOS/nixpkgs/commit/11e800d521145ed51e36f0d2513866e4bdbb3615) | `` uncover: 1.0.2 -> 1.0.3 ``                                                                       |
| [`720340dd`](https://github.com/NixOS/nixpkgs/commit/720340dd81781657ea8b0865903e1e2405de1fe1) | `` bacon: 2.6.3 -> 2.7.0 ``                                                                         |
| [`6214de91`](https://github.com/NixOS/nixpkgs/commit/6214de91379c855f6ac929941e6e8aa8910589e8) | `` aws-vault: 7.0.2 -> 7.1.1 ``                                                                     |
| [`0e8870cc`](https://github.com/NixOS/nixpkgs/commit/0e8870ccbd67757a0c6e991b0aedf6bdb16f9ac0) | `` devbox: 0.4.2 -> 0.4.4 ``                                                                        |
| [`f703a121`](https://github.com/NixOS/nixpkgs/commit/f703a121c0fc3be1b2fcbbefa670c14b988fd424) | `` step-kms-plugin: 0.7.0 -> 0.8.0 ``                                                               |
| [`a09aae0d`](https://github.com/NixOS/nixpkgs/commit/a09aae0d759a7147cb226c177f76fff2431f0213) | `` rakudo: 2022.07 -> 2023.02 ``                                                                    |
| [`307db406`](https://github.com/NixOS/nixpkgs/commit/307db4066c2ccd3ede34f44067110a6c23566642) | `` nqp: 2022.07 -> 2023.02 ``                                                                       |
| [`ac5ad78a`](https://github.com/NixOS/nixpkgs/commit/ac5ad78aba3c1217b389ac6f748e7cde765c94e6) | `` moarvm: 2022.07 -> 2023.02 ``                                                                    |
| [`15fa0306`](https://github.com/NixOS/nixpkgs/commit/15fa0306e56a3316a8982de9a4b9f9e3b305139f) | `` tfplugindocs: 0.14.0 -> 0.14.1 ``                                                                |
| [`d18427d8`](https://github.com/NixOS/nixpkgs/commit/d18427d816394c56336c4510158eb6f657570e4f) | `` maintainers: add kalebpace as maintainer ``                                                      |
| [`7d718ba1`](https://github.com/NixOS/nixpkgs/commit/7d718ba1662ad881c63d05bc37884693b0c76860) | `` vscode-extensions.kalebpace.balena-vscode: init at 0.1.3 ``                                      |
| [`bcc5d6cc`](https://github.com/NixOS/nixpkgs/commit/bcc5d6cc2049243b0a00852bdd86e0ef058498cd) | `` CODEOWNERS: add superherointj to vscode (2th path) ``                                            |
| [`b7a30876`](https://github.com/NixOS/nixpkgs/commit/b7a3087658927fa6d2389c4045b2fe7597970027) | `` komikku: init at 1.15.0 ``                                                                       |
| [`cce4df23`](https://github.com/NixOS/nixpkgs/commit/cce4df2373afdff8f9c53bd78841bc01cea474c3) | `` avizo: fix dependencies of helper scripts ``                                                     |
| [`ffba854a`](https://github.com/NixOS/nixpkgs/commit/ffba854a07413ef90ce77b0561a69c7a926eec45) | `` vscode-extensions.eamodio.gitlens: 13.3.2 -> 13.4.0 ``                                           |
| [`a5a292c7`](https://github.com/NixOS/nixpkgs/commit/a5a292c7a82c694129c1045a4ee8a5078db37d71) | `` treewide: clear out remaining qt5 conditionals ``                                                |
| [`0a766760`](https://github.com/NixOS/nixpkgs/commit/0a7667609f302632c9b5cd605659f75b4f938260) | `` samba: unbreak on darwin ``                                                                      |
| [`776f5e41`](https://github.com/NixOS/nixpkgs/commit/776f5e4124333059622d101df194f2cfe442f6c7) | `` python310Packages.homeassistant-stubs: 2023.3.4 -> 2023.3.5 ``                                   |
| [`30d14133`](https://github.com/NixOS/nixpkgs/commit/30d14133d272be109159b22a86442b168b40c37b) | `` home-assistant: 2023.3.4 -> 2023.3.5 ``                                                          |
| [`c9ed3e99`](https://github.com/NixOS/nixpkgs/commit/c9ed3e993f22f38a5ee6841caf08a2f1a57a51a3) | `` python310Packages.nibe: 2.0.0 -> 2.1.4 (#219597) ``                                              |
| [`3f2cd046`](https://github.com/NixOS/nixpkgs/commit/3f2cd046d5e27ac1de4a4ad627c9b9d4161e7a4a) | `` halp: 0.1.3 -> 0.1.4 ``                                                                          |
| [`38d9db29`](https://github.com/NixOS/nixpkgs/commit/38d9db299e5787e7a8d0c3376216f4ec6c442bf2) | `` nixos/plasma5: remove supportDDC option ``                                                       |
| [`00cd62b7`](https://github.com/NixOS/nixpkgs/commit/00cd62b7fc851ad1df607a95883381a085a1471e) | `` python3Packages.aiocontextvars: Remove sqlalchemy dependency ``                                  |
| [`bbf45c96`](https://github.com/NixOS/nixpkgs/commit/bbf45c9665bf997761499b83919464b2287a4f6f) | `` tts: 0.11.1 -> 0.12.0 ``                                                                         |
| [`11cd8fcb`](https://github.com/NixOS/nixpkgs/commit/11cd8fcb704922b1e0c234b44e5cd162f203ac91) | `` python310Packages.trainer: 0.0.22 -> 0.0.24 ``                                                   |
| [`f4131658`](https://github.com/NixOS/nixpkgs/commit/f41316581d8b2168dabb1c1430e7dec79942a641) | `` gnomeExtension.dash-to-dock: v75 => v79 ``                                                       |
| [`49937bab`](https://github.com/NixOS/nixpkgs/commit/49937bab48736a85b702e970a614d25d5c5b0395) | `` otpclient: restrict platforms ``                                                                 |
| [`b8ef1b27`](https://github.com/NixOS/nixpkgs/commit/b8ef1b276fbd40a93cd7c5731c43262bb3b6d22c) | `` teams: 1.5.00.22362 -> 1.6.00.4464 (darwin) ``                                                   |
| [`ac16f025`](https://github.com/NixOS/nixpkgs/commit/ac16f025eec69f1ab0d79bba677eea47e89f3a9a) | `` rapid-photo-downloader: fix build ``                                                             |
| [`798e414d`](https://github.com/NixOS/nixpkgs/commit/798e414d3e11079b49f639dc6dd7de7515a56d60) | `` python310Packages.nbdev: unbreak ``                                                              |
| [`e369dab2`](https://github.com/NixOS/nixpkgs/commit/e369dab24e822a882031b654356f208f9f04e61c) | `` heroic: Add GStreamer dependencies to FHS environment ``                                         |
| [`7fb4aae8`](https://github.com/NixOS/nixpkgs/commit/7fb4aae81f3afc1336a88b0b3f1fa8518f64968e) | `` nixos/peroxide: add module for peroxide service ``                                               |
| [`22850f79`](https://github.com/NixOS/nixpkgs/commit/22850f79040033b22712d27ad8d95a13e35b0831) | `` peroxide: init at 0.5.0 ``                                                                       |
| [`66bdaf7f`](https://github.com/NixOS/nixpkgs/commit/66bdaf7f873c967948fe086ec7709daad97004e3) | `` ferdium: 6.2.0 -> 6.2.4 ``                                                                       |
| [`e3f324ba`](https://github.com/NixOS/nixpkgs/commit/e3f324babf0dd64f59985922a1bb3d0ef1c100cd) | `` rnote: 0.5.17 -> 0.5.18 ``                                                                       |
| [`42ef5ded`](https://github.com/NixOS/nixpkgs/commit/42ef5ded06774d4b269a7c95e29e12ab64fc553a) | `` build-fhs-userenv-bubblewrap: Use more descriptive names ``                                      |
| [`58d73d23`](https://github.com/NixOS/nixpkgs/commit/58d73d2397f5ccd251d7e3833ee36b2f117ec06d) | `` build-fhs-userenv-bubblewrap: Preserve symlinks in /etc ``                                       |
| [`9a0666a7`](https://github.com/NixOS/nixpkgs/commit/9a0666a7d024e5ecc0db98493c9027c51e081a31) | `` zfs: add raitobezarius as a maintainer ``                                                        |
| [`6da5fdde`](https://github.com/NixOS/nixpkgs/commit/6da5fddeb5dff5c513e03be6e65cb5b0c4a0ab00) | `` netdata: add raitobezarius as a maintainer ``                                                    |
| [`a2f9942d`](https://github.com/NixOS/nixpkgs/commit/a2f9942dd8f0304a00aab859b3cc911062f7ede9) | `` usbguard-notifier: init at 0.1.0 ``                                                              |
| [`01285fcc`](https://github.com/NixOS/nixpkgs/commit/01285fcc4994d7bf1a3e06db62613f7d7be87bce) | `` deepin.qt5platform-plugins: 5.6.3 -> 5.6.5 ``                                                    |
| [`7a2128a8`](https://github.com/NixOS/nixpkgs/commit/7a2128a83638c7bbe20b845f108f03874969d0c4) | `` woodpecker-server: 0.15.6 -> 0.15.7 ``                                                           |
| [`cb6c2399`](https://github.com/NixOS/nixpkgs/commit/cb6c23996f58a500dbbb16743c28f0fa198706cd) | `` itchiodl: 2.2.0 -> 2.3.0 ``                                                                      |
| [`a1ac7307`](https://github.com/NixOS/nixpkgs/commit/a1ac7307f632cb2f8eea9d942a06f8e15d193377) | `` cargo-diet: 1.2.4 -> 1.2.5 ``                                                                    |
| [`756cdf80`](https://github.com/NixOS/nixpkgs/commit/756cdf80899120217ad5c702b42ac1de67618fb1) | `` pantheon.elementary-mail: Backport crash fix for empty mime ``                                   |
| [`d88ec152`](https://github.com/NixOS/nixpkgs/commit/d88ec152cfd6f2a3c6ca74fbef6f5c18a4484f17) | `` pantheon.elementary-gtk-theme: Backport fixes for epiphany 44 ``                                 |
| [`cfa79e45`](https://github.com/NixOS/nixpkgs/commit/cfa79e458d8aad444ca306097e4425c33b82d312) | `` python310Packages.social-auth-app-django: 5.0.0 -> 5.1.0 ``                                      |
| [`7d32101a`](https://github.com/NixOS/nixpkgs/commit/7d32101a66f68f13be396677830cf2ffc514dd66) | `` cista: init at 0.13 ``                                                                           |
| [`5d17348a`](https://github.com/NixOS/nixpkgs/commit/5d17348a5f583f946da1738ca721a04181f3c9b1) | `` ryujinx: 1.1.651 -> 1.1.665 ``                                                                   |
| [`d81364ce`](https://github.com/NixOS/nixpkgs/commit/d81364ce749040bc9660fb8e322efb54eaeed26f) | `` mautrix-whatsapp: 0.8.2 -> 0.8.3 ``                                                              |
| [`30a52ec2`](https://github.com/NixOS/nixpkgs/commit/30a52ec2c261f86c7374ebc7668025c17202d8c9) | `` sing-box: set ldflags to embed version info ``                                                   |
| [`8c956117`](https://github.com/NixOS/nixpkgs/commit/8c9561175aa9ae1159c080f80fdc0d15e456c3ad) | `` sing-box: 1.1.6 -> 1.1.7 ``                                                                      |
| [`f749c3ec`](https://github.com/NixOS/nixpkgs/commit/f749c3ec34f129c69d46abb6f943688dc708095e) | `` xorg.fontalias: 1.0.4 -> 1.0.5 ``                                                                |
| [`cb2e486f`](https://github.com/NixOS/nixpkgs/commit/cb2e486f00ca50deb59a8a4725b30c16ec82eb76) | `` python310Packages.types-protobuf: 4.21.0.7 -> 4.22.0.0 ``                                        |
| [`8e932ee2`](https://github.com/NixOS/nixpkgs/commit/8e932ee299f1243e8271f898af3f6a50846b547f) | `` esbuild: 0.17.11 -> 0.17.12 ``                                                                   |
| [`a7a67b17`](https://github.com/NixOS/nixpkgs/commit/a7a67b17aef2cd77ff292cda540b896224d0be02) | `` maintainers: update my information ``                                                            |
| [`5c4be377`](https://github.com/NixOS/nixpkgs/commit/5c4be3771b25fc5bf719c66d0b1eff47abaa2435) | `` typeshare: 1.1.0 -> 1.2.0 ``                                                                     |
| [`0ded5535`](https://github.com/NixOS/nixpkgs/commit/0ded55350707ea77f4a75cebd7ee69b59cfb1513) | `` otpclient: 3.1.4 -> 3.1.5 ``                                                                     |
| [`7b400e8d`](https://github.com/NixOS/nixpkgs/commit/7b400e8d380dcc07d861a5d815d736ec46697d83) | `` portfolio: 0.61.3 -> 0.61.4 ``                                                                   |
| [`951b5edd`](https://github.com/NixOS/nixpkgs/commit/951b5edd726ec21b1419e525c3efa2473c6f33bb) | `` webcord: name -> pname, suffix xdg-utils to PATH ``                                              |
| [`102e3d51`](https://github.com/NixOS/nixpkgs/commit/102e3d5102774b1e97921e674c1a0605346cd73d) | `` chatterino2: 2.4.0 -> 2.4.2 ``                                                                   |
| [`5698eccb`](https://github.com/NixOS/nixpkgs/commit/5698eccb734ed6f679ab641362e341f72d32b709) | `` rust-analyzer-unwrapped: 2023-03-06 -> 2023-03-13 ``                                             |
| [`c24a8ccc`](https://github.com/NixOS/nixpkgs/commit/c24a8ccc98ee98e23b24f7575049bad05608224d) | `` solr: drop ``                                                                                    |
| [`c45c560f`](https://github.com/NixOS/nixpkgs/commit/c45c560fa0437f4931b46ce5de3ed24e5cd29e9f) | `` qt6: 6.4.2 -> 6.4.3 ``                                                                           |
| [`3c86f2eb`](https://github.com/NixOS/nixpkgs/commit/3c86f2eb23a1ee20bf73fd846105e6aad1118142) | `` maintainers/scripts/fetch-kde-qt.sh: fix handling of fallback file urls ``                       |
| [`e396c6e6`](https://github.com/NixOS/nixpkgs/commit/e396c6e6a97f80f6ba71010bf9914006d99ffead) | `` slack: fix feature flags ``                                                                      |
| [`fadb7ecf`](https://github.com/NixOS/nixpkgs/commit/fadb7ecfc201119940db87651734ab6184615ae0) | `` teams-for-linux: fix notification sounds ``                                                      |
| [`249425ec`](https://github.com/NixOS/nixpkgs/commit/249425ecb72677b415056bb872801f686b3a1e25) | `` teams-for-linux: 1.0.45 -> 1.0.53 ``                                                             |
| [`49ca01bf`](https://github.com/NixOS/nixpkgs/commit/49ca01bf9d93907ef7255289ced1b99797eea79c) | `` nixosTests.xfce: silence a deprecation warning ``                                                |
| [`e5fdb2fc`](https://github.com/NixOS/nixpkgs/commit/e5fdb2fce869bc2e337d2d8018ed96a9f451a195) | `` xfce.xfce4-settings: 4.18.1 -> 4.18.2 ``                                                         |
| [`4acaba28`](https://github.com/NixOS/nixpkgs/commit/4acaba28d3625ad6018cd13d74788eca586c4b15) | `` xfce.xfce4-session: 4.18.0 -> 4.18.1 ``                                                          |
| [`f1a9f530`](https://github.com/NixOS/nixpkgs/commit/f1a9f5302bc7f8e68849b6deb42f6a0c67829451) | `` xfce.xfce4-power-manager: 4.18.0 -> 4.18.1 ``                                                    |
| [`291f20b5`](https://github.com/NixOS/nixpkgs/commit/291f20b5cb436f5ed9222637b2bbbca6246ca4cd) | `` xfce.xfce4-panel: 4.18.1 -> 4.18.2 ``                                                            |
| [`351f24b3`](https://github.com/NixOS/nixpkgs/commit/351f24b3e0ec16432cb569b60379c08fe8ac961d) | `` xfce.xfce4-notifyd: 0.6.5 -> 0.8.2 ``                                                            |
| [`28de836c`](https://github.com/NixOS/nixpkgs/commit/28de836c95c7292b703bb20c8300946371a2a9d2) | `` xfce.xfburn: 0.6.2 -> 0.7.0 ``                                                                   |
| [`406e7ad9`](https://github.com/NixOS/nixpkgs/commit/406e7ad9fb57872667616f5d463c476af73b4482) | `` xfce.thunar: 4.18.3 -> 4.18.4 ``                                                                 |
| [`2a3a0d46`](https://github.com/NixOS/nixpkgs/commit/2a3a0d46d4c6cdc60b1be956963325662b80d660) | `` xfce.ristretto: 0.12.4 -> 0.13.0 ``                                                              |
| [`188962a0`](https://github.com/NixOS/nixpkgs/commit/188962a0d0e8fe9a370b2d8c3aa91ada5b3cd271) | `` xfce.parole: 4.16.0 -> 4.18.0 ``                                                                 |
| [`45e991cf`](https://github.com/NixOS/nixpkgs/commit/45e991cfb55e2293618ed92c664016e998ede7bf) | `` xfce.orage: 4.16.0 -> 4.18.0 ``                                                                  |
| [`bfde45b1`](https://github.com/NixOS/nixpkgs/commit/bfde45b1df70fc5fff69ad2103d69b4e428b8414) | `` xfce.mousepad: 0.5.10 -> 0.6.0 ``                                                                |
| [`de633809`](https://github.com/NixOS/nixpkgs/commit/de6338094bd078019a0da89f74581c9fed198404) | `` xfce.libxfce4ui: 4.18.1 -> 4.18.2 ``                                                             |
| [`291a1ae4`](https://github.com/NixOS/nixpkgs/commit/291a1ae485564d64f6c09ad7f648a153c255087d) | `` codeql: 2.12.3 -> 2.12.4 ``                                                                      |
| [`c9bef769`](https://github.com/NixOS/nixpkgs/commit/c9bef7694e8473f3678272a25a8732ae4c8d0a7b) | `` rbdoom-3-bfg: init at 1.4.0 ``                                                                   |
| [`50c361e0`](https://github.com/NixOS/nixpkgs/commit/50c361e06484016fb71e28e3612aded7adcf53f5) | `` geogram: init at 1.8.3 ``                                                                        |
| [`e9bb5bdb`](https://github.com/NixOS/nixpkgs/commit/e9bb5bdbfda19d0c6847dcbe99ae3998ae864ac0) | `` klipper-firmware: migrate to wxGTK32 ``                                                          |
| [`ca33e8f4`](https://github.com/NixOS/nixpkgs/commit/ca33e8f4e0af210117026d8904547677e891262a) | `` bossa: migrate to wxGTK32 ``                                                                     |
| [`62327ff6`](https://github.com/NixOS/nixpkgs/commit/62327ff6a9cc828309c135ef370cdc13ebf9913c) | `` fetchCrate: add unpack option to use fetchurl instead of fetchzip ``                             |
| [`38f8824e`](https://github.com/NixOS/nixpkgs/commit/38f8824e06e3110f8c6b5eb5513196ca78063308) | `` dagger: 0.3.13 -> 0.4.0 ``                                                                       |
| [`1956f53c`](https://github.com/NixOS/nixpkgs/commit/1956f53cb6fefac5ea97544e98bf98d90b1735a9) | `` heimer: 3.7.0 -> 4.0.0 ``                                                                        |
| [`ab570e4a`](https://github.com/NixOS/nixpkgs/commit/ab570e4a4262468034928efec5c8bd340d81191a) | `` sdrangel: fix darwin build ``                                                                    |