### PR TITLE
chore(flake/home-manager): `e386ec64` -> `486ba3de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679394816,
-        "narHash": "sha256-1V1esJt2YAxsKmRuGuB62RF5vhDAVFDvJXVNhtEO22A=",
+        "lastModified": 1679470414,
+        "narHash": "sha256-SVJ7xHCv35Vv50IBd3GnPxunoySOqnQXnntjXOgls7Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e386ec640e16dc91120977285cb8c72c77078164",
+        "rev": "486ba3de4ecca3ef8371c20b0c53866d61e97dbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                            |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`486ba3de`](https://github.com/nix-community/home-manager/commit/486ba3de4ecca3ef8371c20b0c53866d61e97dbd) | `` copyq: add module ``            |
| [`e60080dd`](https://github.com/nix-community/home-manager/commit/e60080ddfb45f6e667d8cac3ca20922ddbaf4e5b) | `` listenbrainz-mpd: add module `` |