### PR TITLE
chore(flake/nixpkgs): `19cf008b` -> `a64e169e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -196,11 +196,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679437018,
-        "narHash": "sha256-vOuiDPLHSEo/7NkiWtxpHpHgoXoNmrm+wkXZ6a072Fc=",
+        "lastModified": 1679616449,
+        "narHash": "sha256-E6Fvb13mDFa1ZY4lDbTpKbjvUOA4gbh23GWRf3ZzOOw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "19cf008bb18e47b6e3b4e16e32a9a4bdd4b45f7e",
+        "rev": "a64e169e396460d6b5763a1de1dd197df8421688",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                     |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| [`09a4d16b`](https://github.com/NixOS/nixpkgs/commit/09a4d16b85344e03e6526b4f70d1f4609ef5e6f8) | `` dino: 0.4.1 -> 0.4.2 ``                                                                                  |
| [`24f9df3b`](https://github.com/NixOS/nixpkgs/commit/24f9df3b9fe7411250b91120c3a6d2eb08392dd4) | `` komikku: 1.15.0 -> 1.16.0 ``                                                                             |
| [`b150ab24`](https://github.com/NixOS/nixpkgs/commit/b150ab2435b04635b9624f5d966439b090ab2cf4) | `` python310Packages.mautrix: 0.19.6 -> 0.19.7 ``                                                           |
| [`c6b64a9b`](https://github.com/NixOS/nixpkgs/commit/c6b64a9bfe371759fb52af271b09e1b3c1eb549c) | `` shellhub-agent: 0.11.6 -> 0.11.7 ``                                                                      |
| [`b46c97e1`](https://github.com/NixOS/nixpkgs/commit/b46c97e1dc27f78bcc1c72e9999e07c9b49ace6e) | `` stdenv: generalise showPlatforms ``                                                                      |
| [`3c2ac03b`](https://github.com/NixOS/nixpkgs/commit/3c2ac03bdc3166091072ca2027a27ef00e12a4b6) | `` vimPlugins.nvim-treesitter: update grammars ``                                                           |
| [`cc14c50c`](https://github.com/NixOS/nixpkgs/commit/cc14c50c6d0f16deee7617052c68d7b7a3b82e55) | `` vimPlugins.inc-rename-nvim: init at 2023-01-29 ``                                                        |
| [`0da7dcb9`](https://github.com/NixOS/nixpkgs/commit/0da7dcb9eab2a3ffaeaaf64fc16c48486e209d4b) | `` vimPlugins: update ``                                                                                    |
| [`d1833117`](https://github.com/NixOS/nixpkgs/commit/d1833117a89aca751b0a12220c933c33e9e74a03) | `` ocamlPackages.spacetime_lib: patch for compat with owee 0.6 ``                                           |
| [`1d9610bb`](https://github.com/NixOS/nixpkgs/commit/1d9610bb9330f12b615d697a5ff063314859fa3b) | `` ocamlPackages.magic-trace: init at 1.1.0 ``                                                              |
| [`089467fe`](https://github.com/NixOS/nixpkgs/commit/089467fefb3d6c0a568a379af110de4447c6dc2f) | `` ocamlPackages.owee: 0.4 -> 0.6 ``                                                                        |
| [`e0591b2e`](https://github.com/NixOS/nixpkgs/commit/e0591b2e56b0010869307b7b836ae7d14e03fa97) | `` ocamlPackages.cohttp_static_handler: init at 0.15.0 ``                                                   |
| [`022436c4`](https://github.com/NixOS/nixpkgs/commit/022436c47b71f260bbebc3b2e6eccf427a675cce) | `` nixos/logrotate: fix typo ``                                                                             |
| [`6efc090d`](https://github.com/NixOS/nixpkgs/commit/6efc090d5c15048c23bcceaab000ef3eef1bd932) | `` fetch-scm: init at 0.1.5 ``                                                                              |
| [`19ce5c74`](https://github.com/NixOS/nixpkgs/commit/19ce5c743ce0f3ccca24d3079ba83b16004b8d89) | `` sope: make build less illegal ``                                                                         |
| [`bc17a967`](https://github.com/NixOS/nixpkgs/commit/bc17a9670efed9c27b1981f52021bf92f53e84f8) | `` bootil: fix eval ``                                                                                      |
| [`65041d46`](https://github.com/NixOS/nixpkgs/commit/65041d46953f32f92c08fd07f859b27b22bb9b23) | `` vscode-extensions.vscjava.vscode-gradle: init at 3.12.2023032100 ``                                      |
| [`c9a74cf4`](https://github.com/NixOS/nixpkgs/commit/c9a74cf40f72c5fbcfc5be04c50fd96e9154a5b3) | `` nixos/fontconfig: time capsule ``                                                                        |
| [`3eba6e01`](https://github.com/NixOS/nixpkgs/commit/3eba6e019d56bdc453611bf54926a43b95b0a1d4) | `` pick-colour-picker: drop preDistPhases ``                                                                |
| [`81357395`](https://github.com/NixOS/nixpkgs/commit/8135739538b1a6cc33926b6a39b238156bacdea0) | `` chromiumBeta: 112.0.5615.29 -> 112.0.5615.39 ``                                                          |
| [`4b77b5e3`](https://github.com/NixOS/nixpkgs/commit/4b77b5e37525ebaf11526583c8a16aaf783db523) | `` ungoogled-chromium: 111.0.5563.65 -> 111.0.5563.111 ``                                                   |
| [`8454084f`](https://github.com/NixOS/nixpkgs/commit/8454084ffca01cfbd190caf94c0adc5626bbbc27) | `` nixos/hidpi: remove harder ``                                                                            |
| [`8ae67494`](https://github.com/NixOS/nixpkgs/commit/8ae67494ca10e5e3e3d099c5a30e4bf537d8754e) | `` grafanaPlugins.redis-explorer-app: init at 2.1.1 ``                                                      |
| [`6c4f7960`](https://github.com/NixOS/nixpkgs/commit/6c4f7960cda8f54663bdaf4f6bd37c4696f2b861) | `` grafanaPlugins.redis-app: init at 2.2.1 ``                                                               |
| [`7c48c824`](https://github.com/NixOS/nixpkgs/commit/7c48c824bd594dcc90bcb22e4246a09ba7bf8117) | `` grafanaPlugins.redis-datasource: init at 2.1.1 ``                                                        |
| [`92be6976`](https://github.com/NixOS/nixpkgs/commit/92be697638ebc7300fa093a0a00daac314bc056d) | `` xwayland: Add support for the X Security extension ``                                                    |
| [`79afcc7c`](https://github.com/NixOS/nixpkgs/commit/79afcc7ccebb108713a94ef67f07d1bea798f7cd) | `` abcmidi: 2023.02.08 -> 2023.03.15 ``                                                                     |
| [`6ae1c164`](https://github.com/NixOS/nixpkgs/commit/6ae1c1641d1d5922262f949235c5da3c70c09f36) | `` python310Packages.ocrmypdf: 14.0.3 -> 14.0.4 ``                                                          |
| [`4bb70cfa`](https://github.com/NixOS/nixpkgs/commit/4bb70cfa285a65042cd19ed3640355581ec852ba) | `` python310Packages.clevercsv: 0.7.5 -> 0.7.6 ``                                                           |
| [`19217369`](https://github.com/NixOS/nixpkgs/commit/19217369841af150089f1b554a771dfba5621b0a) | `` corrosion: 0.3.4 -> 0.3.5 ``                                                                             |
| [`ee4ed757`](https://github.com/NixOS/nixpkgs/commit/ee4ed757274fe821392eb66ad5f2d2022ffa966c) | `` groff: Fix ghostscript and html output, add X11 support ``                                               |
| [`669846d0`](https://github.com/NixOS/nixpkgs/commit/669846d0f16dda31a93cfdf7358e1c08b3453e58) | `` freefilesync: add wrapGAppsHook ``                                                                       |
| [`76786cd4`](https://github.com/NixOS/nixpkgs/commit/76786cd4fc7b52d842d2d3813163167867eca0f0) | `` gitlab-runner: 15.9.1 -> 15.10.0 (#222532) ``                                                            |
| [`fa448b51`](https://github.com/NixOS/nixpkgs/commit/fa448b51e0034926d70ea13dd7fcb9c25b3a1aab) | `` ocamlPackages.mirage-profile: use Dune 3 ``                                                              |
| [`580bb886`](https://github.com/NixOS/nixpkgs/commit/580bb886228f454ffaec89025cba75d284445649) | `` ocamlPackages.mirage-logs: 1.2.0 → 1.3.0 ``                                                              |
| [`fc8420f3`](https://github.com/NixOS/nixpkgs/commit/fc8420f3793e9b43f0906a35d7aea87e33f23653) | `` ocamlPackages.shared-memory-ring: use Dune 3 ``                                                          |
| [`cc766b2e`](https://github.com/NixOS/nixpkgs/commit/cc766b2e44f90e1fb6338d82832e6de80a04ae50) | `` ocamlPackages.hex: 1.4.0 → 1.5.0 ``                                                                      |
| [`a29c4b0b`](https://github.com/NixOS/nixpkgs/commit/a29c4b0bf543f64a87688732c66c24f49412ed8c) | `` ocamlPackages.bls12-381: use Dune 3 ``                                                                   |
| [`1352481e`](https://github.com/NixOS/nixpkgs/commit/1352481e8eba83675cec9287b08c3c8d422b88e6) | `` wayland: use epoll-shim on unix platforms ``                                                             |
| [`8926c5a2`](https://github.com/NixOS/nixpkgs/commit/8926c5a2feb813d816567613f183a2f63abfa01b) | `` libsegfault: init unstable-2022-11-13 ``                                                                 |
| [`2a7e1e02`](https://github.com/NixOS/nixpkgs/commit/2a7e1e022894a320c433047e8424fe0f1a05a9a1) | `` stdenv: fix error with patterned platforms ``                                                            |
| [`db4683a0`](https://github.com/NixOS/nixpkgs/commit/db4683a0d2438eac0bc1301e05e21619b3416977) | `` mimir: 2.6.0 -> 2.7.1 ``                                                                                 |
| [`c685b5a9`](https://github.com/NixOS/nixpkgs/commit/c685b5a98915360742c9c1398affd9538455eace) | `` dvc: mark broken due to none existing dependency ``                                                      |
| [`20842ac0`](https://github.com/NixOS/nixpkgs/commit/20842ac039563e221d5ad05461ce1858ca50cb16) | `` nixos/gitea: disable updater by default ``                                                               |
| [`5907b939`](https://github.com/NixOS/nixpkgs/commit/5907b939fb25847873f2530eee15124ae45c692b) | `` python311Packages.debugpy: disable 3.11 build until supported ``                                         |
| [`b1fe611f`](https://github.com/NixOS/nixpkgs/commit/b1fe611fa9c69a54717de94b41e1a563b264aecb) | `` coursier: remove zsh completion which was removed upstream, remove nixfmt formatting in update script `` |
| [`6176066e`](https://github.com/NixOS/nixpkgs/commit/6176066e29ee936eed44d7e6d041cc916116a01b) | `` python310Packages.debugpy: fix src hash ``                                                               |
| [`614ad50d`](https://github.com/NixOS/nixpkgs/commit/614ad50d03739214a64e36c26eff6f49007c94c0) | `` dvc: fix src hash ``                                                                                     |
| [`90040062`](https://github.com/NixOS/nixpkgs/commit/90040062f206fb5259a8577d2fdf2fc5cf89fed1) | `` python310Packages.annexremote: fix src hash ``                                                           |
| [`1b0e9035`](https://github.com/NixOS/nixpkgs/commit/1b0e903593e95e86d084451bfa99d27245b2e3c1) | `` datalad: fix src hash ``                                                                                 |
| [`01124da5`](https://github.com/NixOS/nixpkgs/commit/01124da5439d6ae5b38846113c75c10502b58e94) | `` nixpacks: 1.5.0 -> 1.5.1 ``                                                                              |
| [`89589f1f`](https://github.com/NixOS/nixpkgs/commit/89589f1ffdacaa91c93cc70c4ec5e9eea3840e6b) | `` exploitdb: 2023-03-22 -> 2023-03-23 ``                                                                   |
| [`612ce721`](https://github.com/NixOS/nixpkgs/commit/612ce7218d092b32d5134498ff50a17b84b1227b) | `` minizip-ng: 3.0.8 -> 3.0.9 ``                                                                            |
| [`98f89cf4`](https://github.com/NixOS/nixpkgs/commit/98f89cf43cdb83576b60007c0fbdfe90d17bc401) | `` polarizationsolver: set a pep compliant version string ``                                                |
| [`9bc28cfe`](https://github.com/NixOS/nixpkgs/commit/9bc28cfe7357eec6474558700310545664d24704) | `` oh-my-posh: 14.14.1 -> 14.14.3 ``                                                                        |
| [`1ea1361a`](https://github.com/NixOS/nixpkgs/commit/1ea1361aed8c3794c0fb3c5d132048f669779f5a) | `` rocminfo: 5.4.3 -> 5.4.4 ``                                                                              |
| [`43c964b1`](https://github.com/NixOS/nixpkgs/commit/43c964b1bec4ece6a6611bd4dd2b282b5c013da0) | `` elixir-ls: fix build ``                                                                                  |
| [`ae0f402b`](https://github.com/NixOS/nixpkgs/commit/ae0f402b4c60af3f0130d80ff70d400e02f761a2) | `` aerospike: mark as insecure ``                                                                           |
| [`26f55176`](https://github.com/NixOS/nixpkgs/commit/26f55176e77696556658c04f2167db02f401d6b5) | `` Revert #222072: "directx-shader-compiler: remove workaround" ``                                          |
| [`40f52d90`](https://github.com/NixOS/nixpkgs/commit/40f52d9003c5cb4929a346529d2ff1357bd89d6c) | `` ogre1_9: cleanup ``                                                                                      |
| [`8ee5702c`](https://github.com/NixOS/nixpkgs/commit/8ee5702c66c7444fb56a48d505ac4f429f5a8793) | `` linux/hardened/patches/6.1: 6.1.19-hardened1 -> 6.1.20-hardened1 ``                                      |
| [`9791cc43`](https://github.com/NixOS/nixpkgs/commit/9791cc4323f4660ebe0befcb35676b0a3a7ba58c) | `` linux/hardened/patches/5.4: 5.4.236-hardened1 -> 5.4.237-hardened1 ``                                    |
| [`4634bbc4`](https://github.com/NixOS/nixpkgs/commit/4634bbc4c5bd1b037b25a8e817dffe0a6a70a2a8) | `` linux/hardened/patches/5.15: 5.15.102-hardened1 -> 5.15.103-hardened1 ``                                 |
| [`c818f30d`](https://github.com/NixOS/nixpkgs/commit/c818f30da7e101eb9f22f71802984482b2b32f2a) | `` linux/hardened/patches/5.10: 5.10.174-hardened1 -> 5.10.175-hardened1 ``                                 |
| [`0272420a`](https://github.com/NixOS/nixpkgs/commit/0272420a3c4557e61dcea80e6640d19045d27d64) | `` linux/hardened/patches/4.19: 4.19.277-hardened1 -> 4.19.278-hardened1 ``                                 |
| [`79148a9f`](https://github.com/NixOS/nixpkgs/commit/79148a9f3b89f06c0003f3a6bf3057ef50278957) | `` linux/hardened/patches/4.14: 4.14.309-hardened1 -> 4.14.310-hardened1 ``                                 |
| [`c4e51ce8`](https://github.com/NixOS/nixpkgs/commit/c4e51ce8678c3ca3aef498667eb8d8d5b3f431d5) | `` linux_latest-libre: 19109 -> 19160 ``                                                                    |
| [`29b3bf6f`](https://github.com/NixOS/nixpkgs/commit/29b3bf6fb05529e3f5783578a00f80ae2ee504e3) | `` linux-rt_5_10: 5.10.168-rt83 -> 5.10.175-rt84 ``                                                         |
| [`51b22f7f`](https://github.com/NixOS/nixpkgs/commit/51b22f7f5baf57fd5565117c07931e3a20b11c9f) | `` linux: 6.2.7 -> 6.2.8 ``                                                                                 |
| [`25ee2ea0`](https://github.com/NixOS/nixpkgs/commit/25ee2ea037dccf8d0a8af880c12e894852597978) | `` linux: 6.1.20 -> 6.1.21 ``                                                                               |
| [`8d7db242`](https://github.com/NixOS/nixpkgs/commit/8d7db2427d33a79778c5514ea9a0bec2eb76302c) | `` linux: 5.4.237 -> 5.4.238 ``                                                                             |
| [`609bd9bc`](https://github.com/NixOS/nixpkgs/commit/609bd9bceec1d98bc3fa626a6feb388ba76ea233) | `` linux: 5.15.103 -> 5.15.104 ``                                                                           |
| [`db9b3233`](https://github.com/NixOS/nixpkgs/commit/db9b3233fc3236b7b433b1e96db32cd507759f38) | `` linux: 5.10.175 -> 5.10.176 ``                                                                           |
| [`72cd47a8`](https://github.com/NixOS/nixpkgs/commit/72cd47a8c1ab6171b2532aa48f9b7b9121a7565b) | `` linux: 4.19.278 -> 4.19.279 ``                                                                           |
| [`2dff193f`](https://github.com/NixOS/nixpkgs/commit/2dff193f3d86c94d46e285738527c5f736ba0543) | `` linux: 4.14.310 -> 4.14.311 ``                                                                           |
| [`9dda81ca`](https://github.com/NixOS/nixpkgs/commit/9dda81ca70352da84bf4122eb3173cf79ff89ad2) | `` railway: 3.0.12 -> 3.0.13 ``                                                                             |
| [`d25311fa`](https://github.com/NixOS/nixpkgs/commit/d25311fad4b5bea9b63f34eb1e96f76e41276c19) | `` terraform-providers.oci: 4.112.0 → 4.113.0 ``                                                            |
| [`1aad1127`](https://github.com/NixOS/nixpkgs/commit/1aad1127547d60cbc7723584aff281bcaefa0025) | `` terraform-providers.statuscake: 2.0.6 → 2.1.0 ``                                                         |
| [`3a3b5207`](https://github.com/NixOS/nixpkgs/commit/3a3b5207b94455cb84e7b22994fb14e586aaf86b) | `` terraform-providers.spotinst: 1.106.1 → 1.108.0 ``                                                       |
| [`a50421ad`](https://github.com/NixOS/nixpkgs/commit/a50421ada987ebd6ab66d209dac94f34b91130df) | `` terraform-providers.newrelic: 3.17.1 → 3.18.0 ``                                                         |
| [`489c8b2c`](https://github.com/NixOS/nixpkgs/commit/489c8b2caedc16417babc523cdafcbbcc57234d7) | `` terraform-providers.gridscale: 1.18.0 → 1.18.1 ``                                                        |
| [`4e5a976b`](https://github.com/NixOS/nixpkgs/commit/4e5a976b3825c7754d4e07b94b360a20288b0953) | `` terraform-providers.gitlab: 15.9.0 → 15.10.0 ``                                                          |
| [`968fffa6`](https://github.com/NixOS/nixpkgs/commit/968fffa67fcaa04fceefa41a006bf85308be8aac) | `` terraform-providers.digitalocean: 2.26.0 → 2.27.1 ``                                                     |
| [`81c1d0ee`](https://github.com/NixOS/nixpkgs/commit/81c1d0eef5899a628b3461cdbe71a03d5a77ab69) | `` terraform-providers.aiven: 4.1.2 → 4.1.3 ``                                                              |
| [`4b8b50fe`](https://github.com/NixOS/nixpkgs/commit/4b8b50fed723044476137b18c162905dca07aaa6) | `` tuxedo-keyboard: fix building of tuxedo-keyboard kernel module ``                                        |
| [`283218b5`](https://github.com/NixOS/nixpkgs/commit/283218b5cb20f1375fdb8c0dd061937139f30806) | `` glooctl: 1.13.10 -> 1.13.11 ``                                                                           |
| [`b174387b`](https://github.com/NixOS/nixpkgs/commit/b174387ba919dddd50e347f18012343dcb6ba4fa) | `` ocamlPackages.macaddr: 5.3.0 → 5.4.0 ``                                                                  |
| [`33cffcde`](https://github.com/NixOS/nixpkgs/commit/33cffcde611ae2c6b62456f016ca0916e42d5401) | `` ocamlPackages.tuntap: use Dune 3 ``                                                                      |
| [`f2aa79b5`](https://github.com/NixOS/nixpkgs/commit/f2aa79b5e11d3c87d090089f87e7071bdbebfa16) | `` ocamlPackages.mirage-runtime: use Dune 3 ``                                                              |
| [`c9d19def`](https://github.com/NixOS/nixpkgs/commit/c9d19defb1cc575c083bcfa92a8d5242a016243e) | `` ocamlPackages.mirage-net: use Dune 3 ``                                                                  |
| [`d35aead4`](https://github.com/NixOS/nixpkgs/commit/d35aead486d7885d192bbe912fd1eb70131dd98a) | `` sarasa-gothic: 0.40.3 -> 0.40.4 ``                                                                       |
| [`5c305b5a`](https://github.com/NixOS/nixpkgs/commit/5c305b5a8fe74fd3558aab0aee28916039e11f50) | `` checkpolicy: 3.3 -> 3.5 ``                                                                               |
| [`32759a00`](https://github.com/NixOS/nixpkgs/commit/32759a00da1fdaaba82611b96601e16851879849) | `` python310Packages.upcloud-api: 2.0.0 -> 2.0.1 ``                                                         |
| [`f3d22c3f`](https://github.com/NixOS/nixpkgs/commit/f3d22c3f3cf262eaf29b3895a15c3089867b55a8) | `` automatic-timezoned: 1.0.72 -> 1.0.75 ``                                                                 |
| [`aa410839`](https://github.com/NixOS/nixpkgs/commit/aa410839cdbdeecf016dcc21fbf544eb0f1ad2a1) | `` emacsPackages.mind-wave packaging ``                                                                     |
| [`6f52aa86`](https://github.com/NixOS/nixpkgs/commit/6f52aa868cc6d42ded66c14b60bcd70169856a0f) | `` lxgw-neoxihei: 1.007 -> 1.009 ``                                                                         |
| [`1860169d`](https://github.com/NixOS/nixpkgs/commit/1860169db725f3434818da33001098f910e53fa6) | `` goreman: 0.3.14 -> 0.3.15 ``                                                                             |
| [`8883bb63`](https://github.com/NixOS/nixpkgs/commit/8883bb63d2b5f24ed4ba132cbaf63fa13f37a3c4) | `` drush: 8.4.11 -> 8.4.12 ``                                                                               |
| [`6416b891`](https://github.com/NixOS/nixpkgs/commit/6416b89123b32c1e4c83d147a723db549e6970b4) | `` topgrade: 10.3.2 -> 10.3.3 ``                                                                            |
| [`a6e16caa`](https://github.com/NixOS/nixpkgs/commit/a6e16caa14a86b3185044fa2e6c8a6b5f564c759) | `` firefox-devedition-bin-unwrapped: 112.0b3 -> 112.0b5 ``                                                  |
| [`c5ab8fd9`](https://github.com/NixOS/nixpkgs/commit/c5ab8fd93f9315988a17a9dfbd7127760466c6bb) | `` ciel: init at 3.1.4 ``                                                                                   |
| [`a53ae00e`](https://github.com/NixOS/nixpkgs/commit/a53ae00ec5c6dc07c9f9c2125c043716359e55cb) | `` focus-stack: init at 1.4 ``                                                                              |
| [`3c7f1cea`](https://github.com/NixOS/nixpkgs/commit/3c7f1ceab26a27dbfeb5ecb3cf461aa091dbd82c) | `` wavedrom-cli: add missing giflib dep ``                                                                  |
| [`53c2bb7b`](https://github.com/NixOS/nixpkgs/commit/53c2bb7b496c6ba2966f43c30fe172790b1811d5) | `` watchexec: 1.21.1 -> 1.22.0 ``                                                                           |
| [`c33cce28`](https://github.com/NixOS/nixpkgs/commit/c33cce281f060b98643f0aa3fec0edcfb6be74bf) | `` checkSSLCert: 2.61.0 -> 2.62.0 ``                                                                        |
| [`4596763e`](https://github.com/NixOS/nixpkgs/commit/4596763e33cfae1135276135c76ce3a1e4e1d2cf) | `` ddosify: 0.15.1 -> 0.15.3 ``                                                                             |
| [`b7803446`](https://github.com/NixOS/nixpkgs/commit/b780344698497b99f44dd46d6c14ddccc0f50ed0) | `` nushell: 0.77.0 -> 0.77.1 ``                                                                             |
| [`4e637df7`](https://github.com/NixOS/nixpkgs/commit/4e637df751af873db0a4ea05599a03f186bb6efc) | `` libgourou: init at 0.8.1 ``                                                                              |
| [`958836a0`](https://github.com/NixOS/nixpkgs/commit/958836a059a136118769bc1f0b411548f5e062f0) | `` updfparser: init at unstable-2023-01-10 ``                                                               |
| [`84141774`](https://github.com/NixOS/nixpkgs/commit/841417745c50099ae55a26042ecd40c82ca715be) | `` grafana: 9.4.3 -> 9.4.7 ``                                                                               |
| [`f1f4cc5d`](https://github.com/NixOS/nixpkgs/commit/f1f4cc5dd62e33fc874bd61dc7b282b1b68866ff) | `` aws-vault: 7.1.1 -> 7.1.2 ``                                                                             |
| [`a5e81d73`](https://github.com/NixOS/nixpkgs/commit/a5e81d739ef6e7bfdfa29e31c84c1de3d2b6ab6c) | `` chromium: 111.0.5563.64 -> 111.0.5563.110 ``                                                             |
| [`c9c9abc6`](https://github.com/NixOS/nixpkgs/commit/c9c9abc60872e7f7facfe17489cfb5f8802aedd3) | `` openssh: fix 'undefined variable' error ``                                                               |
| [`42c78ccc`](https://github.com/NixOS/nixpkgs/commit/42c78ccc6b27249d89fd6dec7affc2a97fa76d62) | `` nixos/nextcloud: release notes ``                                                                        |
| [`cbc539c1`](https://github.com/NixOS/nixpkgs/commit/cbc539c19fb9f95bb513eb724757bded539a8ae9) | `` nixos/nextcloud: minor fixups ``                                                                         |
| [`6a0b0a5d`](https://github.com/NixOS/nixpkgs/commit/6a0b0a5de9b563254ae886d9e1709acd43e612b5) | `` nextcloud: remove compat references to v23 ``                                                            |