### PR TITLE
chore(flake/home-manager): `db37c537` -> `2f8d24b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679684476,
-        "narHash": "sha256-WTYZFt9cJmOSp1n3hxAS+BQnu7smcBsC98RSgdp2qsE=",
+        "lastModified": 1679741227,
+        "narHash": "sha256-9k9oBF5/yU9MfX1VJ1sRali172V4uTylGdNkzqTEouA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "db37c537603d1d45d022cc0666ad45197455b364",
+        "rev": "2f8d24b7f57fdd404defe84626b08f3318612f8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`2f8d24b7`](https://github.com/nix-community/home-manager/commit/2f8d24b7f57fdd404defe84626b08f3318612f8c) | `` zoxide: enable nushell integration `` |
| [`a34aaad2`](https://github.com/nix-community/home-manager/commit/a34aaad2ae159b66306ced0cbfa1eefac8c4343e) | `` gpg: fix URL of key in test case ``   |