### PR TITLE
chore(flake/home-manager): `885a504f` -> `225d1fb7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679746195,
-        "narHash": "sha256-L4RT64g2QqsK/gwLkuZwlYPLOR63G8+oX34xCcgHrKM=",
+        "lastModified": 1679756596,
+        "narHash": "sha256-wQp7CoYqREPGssf1F0JKx2A4tScbu3iNgI1kS74ib/8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "885a504f80227b98d137a84a888bf7faa36d00dc",
+        "rev": "225d1fb77e6c9f9be1ffd65c8e5eb9cf583aa698",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                               |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`225d1fb7`](https://github.com/nix-community/home-manager/commit/225d1fb77e6c9f9be1ffd65c8e5eb9cf583aa698) | `` hstr: fix sorting in CODEOWNERS ``                                 |
| [`99680311`](https://github.com/nix-community/home-manager/commit/99680311f1d94632e75da1b8f78091220684b4bf) | `` hstr: add module ``                                                |
| [`3ace6a31`](https://github.com/nix-community/home-manager/commit/3ace6a31dd859710e7b7666a9d456b611f9376dc) | `` im/fcitx: drop as fcitx 4 has been removed from nixpkgs (#3804) `` |