### PR TITLE
chore(flake/nixos-hardware): `648021dc` -> `f38f9a4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1679598117,
-        "narHash": "sha256-Vs1f/7imI77OkMOQhO3xgx4jalN2Gx3D3C2wmnlpWJM=",
+        "lastModified": 1679765008,
+        "narHash": "sha256-VCkg/wC2e882suYDS5PDAemaMLYSOdFm4fsx2gowMR0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "648021dcb2b65498eed3ea3a7339cdfc3bea4d82",
+        "rev": "f38f9a4c9b2b6f89a5778465e0afd166a8300680",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                               |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`a0eda74e`](https://github.com/NixOS/nixos-hardware/commit/a0eda74ee0aec5c161c602eb32ae0365127af935) | `` lenovo legion 7 slim 15ach6: add hidpi settings `` |
| [`449ab4e6`](https://github.com/NixOS/nixos-hardware/commit/449ab4e6252cfdec69a98daa7677ad2a51ddfbc8) | `` thinkpad-z: move to hidpi module ``                |
| [`7daa0f58`](https://github.com/NixOS/nixos-hardware/commit/7daa0f589d66d272fc4f0c73ba2e67cf7ff30e66) | `` drop hidpi comment ``                              |