### PR TITLE
chore(flake/home-manager): `d80bf24d` -> `cf662b6c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679758258,
-        "narHash": "sha256-/fsleSIKfnCCzrn4MIAEDTCKeCe+ZxXEPrKykAI5q08=",
+        "lastModified": 1679786039,
+        "narHash": "sha256-VNjswu0Q4bZOkWNuc0+dHvRdjUCj+MnDlRfw/Q0R3vI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d80bf24dab1c1abb3c36e6e28cd30d27599a9620",
+        "rev": "cf662b6c98a0da81e06066fff0ecf9cbd4627727",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`da325265`](https://github.com/nix-community/home-manager/commit/da325265b72b338647720b33df23d775aa73825d) | `` launchd: sync option definition with nix-darwin ``       |
| [`2acea865`](https://github.com/nix-community/home-manager/commit/2acea86583ba10b67b36db135c94d6df1ae41d55) | `` launchd: make Launch Agents config a freeform setting `` |