### PR TITLE
chore(flake/nixpkgs): `5f9d1bb5` -> `4361baa7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -196,11 +196,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679797994,
-        "narHash": "sha256-Kr/O/UlfqAtoFmkZeAaphsxogeaN8a/IugBApFzPfpk=",
+        "lastModified": 1679865578,
+        "narHash": "sha256-sYQmxxqIYL3QFsRYjW0AufhGur8qWfwoOGPGHRJZlGc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5f9d1bb572e08ec432ae46c78581919d837a90f6",
+        "rev": "4361baa782dc3d3b35fd455a1adc370681d9187c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                     |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| [`4361baa7`](https://github.com/NixOS/nixpkgs/commit/4361baa782dc3d3b35fd455a1adc370681d9187c) | `` trash-cli: 0.22.10.20 -> 0.23.2.13.2 ``                                                                  |
| [`b0fd7a31`](https://github.com/NixOS/nixpkgs/commit/b0fd7a3179772d1a640dfc9f00b3df8cc50873ec) | `` nixos/nftables: add release notes for checkRuleset option (#223283) ``                                   |
| [`972b0fa8`](https://github.com/NixOS/nixpkgs/commit/972b0fa87ffc622a690461a43c1608bef5b776ee) | `` xdp-tools: fix hash of the patch ``                                                                      |
| [`238eb47d`](https://github.com/NixOS/nixpkgs/commit/238eb47d6b4e6d031328eed425aa8f83c1b168e2) | `` miniupnpd: 2.3.1 -> 2.3.3 ``                                                                             |
| [`f3f0a132`](https://github.com/NixOS/nixpkgs/commit/f3f0a132fb82d2daa2a0133e8e679f689f92693e) | `` kmail: enable user feedback support ``                                                                   |
| [`b4c45042`](https://github.com/NixOS/nixpkgs/commit/b4c450422e8fbe35a2147ea6e9e774233d48969f) | `` pim-data-exporter: enable user feedback support ``                                                       |
| [`f7d6afe0`](https://github.com/NixOS/nixpkgs/commit/f7d6afe0db3a87175019f6bbeed7343cea86dc24) | `` mfc5890cncupswrapper: Fix illegal meta key ``                                                            |
| [`037cc92a`](https://github.com/NixOS/nixpkgs/commit/037cc92ae90957c3e4ab856093de2b369efc0e7e) | `` discover: build with user feedback support ``                                                            |
| [`c247a4f1`](https://github.com/NixOS/nixpkgs/commit/c247a4f1eb13ba9e9cd09db599de9a94b79540ee) | `` pim-sieve-editor: build with user feedback support ``                                                    |
| [`8c4c762d`](https://github.com/NixOS/nixpkgs/commit/8c4c762da229b5f7c83e3946eab8875df9dd88c6) | `` lighttpd: Disable tests for DES and MD5 ``                                                               |
| [`277320f4`](https://github.com/NixOS/nixpkgs/commit/277320f49efe9402bcb1fa3e371e4f4391104d48) | `` korganizer: build with user feedback support ``                                                          |
| [`1872ad4b`](https://github.com/NixOS/nixpkgs/commit/1872ad4bf8ce3df137197bcf042b035902eecb64) | `` kaddressbook: build with user feedback support ``                                                        |
| [`b8b8cfea`](https://github.com/NixOS/nixpkgs/commit/b8b8cfeab4c5006b0b049e60aee401f3c4645b52) | `` akregator: build with user feedback support ``                                                           |
| [`d26b2394`](https://github.com/NixOS/nixpkgs/commit/d26b239493dffa04cd9524b395c5d1143e5f0b70) | `` libreoffice/wrapper: Don't --chdir ``                                                                    |
| [`ca4a734f`](https://github.com/NixOS/nixpkgs/commit/ca4a734f86c0c64d11d8910c910c31433219c878) | `` maintainers: add Ben Kuhn (PR #223178) ``                                                                |
| [`4413ef0e`](https://github.com/NixOS/nixpkgs/commit/4413ef0e0cc0ca677f28f1ec99e1e6262cb94d9a) | `` radicale2: Disable weak crypt htpasswd test ``                                                           |
| [`38ac9d07`](https://github.com/NixOS/nixpkgs/commit/38ac9d077aabe8967c7119a6844abd3f24524f2a) | `` mfc5890cncupswrapper: init at 1.1.2-2 ``                                                                 |
| [`ab35899c`](https://github.com/NixOS/nixpkgs/commit/ab35899c9a3a8140fa9b64d3c50e15d58cb0dbfe) | `` werf: 1.2.214 -> 1.2.217 ``                                                                              |
| [`db461ccf`](https://github.com/NixOS/nixpkgs/commit/db461ccf9dcb91ec0ef6d71d956540541e6a27d9) | `` plasma-workspace: build with user feedback support ``                                                    |
| [`19582cb3`](https://github.com/NixOS/nixpkgs/commit/19582cb3329d9f461ade07214396456fdb3ed3df) | `` kate: build with user feedback support ``                                                                |
| [`fc6ff693`](https://github.com/NixOS/nixpkgs/commit/fc6ff6930257a261081436f47607c52fd34329ef) | `` dolphin: build with user feedback support ``                                                             |
| [`1d19eeef`](https://github.com/NixOS/nixpkgs/commit/1d19eeefeea4cb51d96592712acc4443c42efd0b) | `` nixos/opengl: fix wrong function application ``                                                          |
| [`38655026`](https://github.com/NixOS/nixpkgs/commit/386550260996d834b544b61cb7ec12ad82429245) | `` drawing: add changelog to meta ``                                                                        |
| [`adbd2bd4`](https://github.com/NixOS/nixpkgs/commit/adbd2bd4268c8d20aeaa0fdd5cdd687a25b783d3) | `` gnomeExtensions.EasyScreenCast: fix build ``                                                             |
| [`c87fb8fd`](https://github.com/NixOS/nixpkgs/commit/c87fb8fdca1531fe55cba3db076cc71dd9d9b2de) | `` drumstick: 2.7.0 -> 2.7.2 (#223196) ``                                                                   |
| [`b50e5e8f`](https://github.com/NixOS/nixpkgs/commit/b50e5e8f1d6682affc56d84deca7044414874862) | `` opentyrian: 2.1.20220318 -> 2.1.20221123 ``                                                              |
| [`6f4400f8`](https://github.com/NixOS/nixpkgs/commit/6f4400f8fd79756f2a90952e1bc7520056fa1d44) | `` darwin.Csu: disable parallel installing ``                                                               |
| [`dfcb6f56`](https://github.com/NixOS/nixpkgs/commit/dfcb6f5667114a0bb22c399a5a7d039ccf75bfcd) | `` ebumeter: 0.4.2 -> 0.5.1 (#223191) ``                                                                    |
| [`0098179e`](https://github.com/NixOS/nixpkgs/commit/0098179e4a24aea294af012d9b74688a44946cd4) | `` sentry-cli: 2.15.2 -> 2.16.0 ``                                                                          |
| [`3cf37217`](https://github.com/NixOS/nixpkgs/commit/3cf37217ef901dd83ccaa0cefd62e523e55076b0) | `` bdf2psf: 1.217 -> 1.218 ``                                                                               |
| [`2fb36b81`](https://github.com/NixOS/nixpkgs/commit/2fb36b81eaf9a3051aaf2501f83a7ca02065e53b) | `` wmic-bin: fix by switching to libxcrypt-legacy ``                                                        |
| [`6ca69ac3`](https://github.com/NixOS/nixpkgs/commit/6ca69ac3eed2b70a2d4d59d7b2878cc4dab99a9d) | `` drawing: 1.0.1 -> 1.0.2 ``                                                                               |
| [`5b1f5c1f`](https://github.com/NixOS/nixpkgs/commit/5b1f5c1f55b24604aba106d00dcbe10262866ebb) | `` snes9x: 1.62 -> 1.62.1 ``                                                                                |
| [`d89c7858`](https://github.com/NixOS/nixpkgs/commit/d89c7858b21687ce8e946c9404b09adb5cb3ad18) | `` opengrok: 1.8.4 -> 1.9.2 ``                                                                              |
| [`757d8c8e`](https://github.com/NixOS/nixpkgs/commit/757d8c8e3a6edf914730db530691f06056aaca74) | `` trdl-client: 0.6.3 -> 0.6.5 ``                                                                           |
| [`68d6ec11`](https://github.com/NixOS/nixpkgs/commit/68d6ec1157fbd06a325c068ca394a05d30945054) | `` python310Packages.asana: 3.1.1 -> 3.2.0 ``                                                               |
| [`88344cc7`](https://github.com/NixOS/nixpkgs/commit/88344cc7853b8dfead4c974ef194e588e4ad18fd) | `` karma: 0.113 -> 0.114 ``                                                                                 |
| [`e3eeeeca`](https://github.com/NixOS/nixpkgs/commit/e3eeeecadd5e6ef055a83c5eaed8a660b5b464dd) | `` terraform-providers.aviatrix: 3.0.2 → 3.0.3 ``                                                           |
| [`fa7e3d19`](https://github.com/NixOS/nixpkgs/commit/fa7e3d197327a46f21040f053d9dd13695b5698a) | `` castxml: 0.5.1 -> 0.6.1 ``                                                                               |
| [`a0b7d434`](https://github.com/NixOS/nixpkgs/commit/a0b7d434aefd10f2b693915ad6575531068fc5c6) | `` python310Packages.eternalegypt: 0.0.13 -> 0.0.15 ``                                                      |
| [`15b859ce`](https://github.com/NixOS/nixpkgs/commit/15b859cefec4886310d93f6d2c80edd9d9bafd3e) | `` nixos/nextcloud: set X-Robots-Tag to "noindex, nofollow" ``                                              |
| [`44020f0c`](https://github.com/NixOS/nixpkgs/commit/44020f0c7776e869b46ba8791ae8e9553fd7db4c) | `` cargo-release: 0.24.6 -> 0.24.8 ``                                                                       |
| [`33b7b0bf`](https://github.com/NixOS/nixpkgs/commit/33b7b0bf88d7d5ee13a7072b5b582b640babac61) | `` perlPackages.CatalystAuthenticationStoreHtpasswd: add patch to avoid DES encrypted passwords in tests `` |
| [`f8af7d5b`](https://github.com/NixOS/nixpkgs/commit/f8af7d5b1cdd83c13e77142750fe90434176f22f) | `` perlPackages.AuthenHtpasswd: removed failing DES crypt() tests ``                                        |
| [`9b1c6cc9`](https://github.com/NixOS/nixpkgs/commit/9b1c6cc98db397f09ea83be316471ba68c83f16f) | `` odoo: 20220506 -> 20230317 ``                                                                            |
| [`f32cc8d4`](https://github.com/NixOS/nixpkgs/commit/f32cc8d48c2a3e8673935628c44cb053721395d7) | `` matrix-synapse: remove old comment ``                                                                    |
| [`a7ff1f17`](https://github.com/NixOS/nixpkgs/commit/a7ff1f17509f962e46cd2bf5515be139305735e0) | `` python310Packages.fake-useragent: add changelog to meta ``                                               |
| [`e6d62e3b`](https://github.com/NixOS/nixpkgs/commit/e6d62e3b9667b98ebfc79b8c2e65adaf2cd732d2) | `` python310Packages.fake-useragent: 1.1.2 -> 1.1.3 ``                                                      |
| [`015f6410`](https://github.com/NixOS/nixpkgs/commit/015f6410b0583fad3d4fd9d3d3f879d6443ae178) | `` python310Packages.denonavr: 0.11.1 -> 0.11.2 ``                                                          |
| [`d6074f19`](https://github.com/NixOS/nixpkgs/commit/d6074f1999d24fbc765175a67a10f2e4802a4a3c) | `` mapcidr: add changelog to meta ``                                                                        |
| [`301d70da`](https://github.com/NixOS/nixpkgs/commit/301d70dae8283d24283cb31bff937b91ec5c8630) | `` perlPackages.Plack: add patch to avoid DES encrypted passwords in tests ``                               |
| [`c1baed08`](https://github.com/NixOS/nixpkgs/commit/c1baed0895c2c9e3738ef61614d3de9f999aa856) | `` mapcidr: 1.1.0 -> 1.1.1 ``                                                                               |
| [`fac1858b`](https://github.com/NixOS/nixpkgs/commit/fac1858b39d01c4c0ab721caab872c526c5ed43c) | `` synapse-admin: 0.8.5 -> 0.8.7 ``                                                                         |
| [`3f32b063`](https://github.com/NixOS/nixpkgs/commit/3f32b063ae2df9d21643907266e1905b5232e6ad) | `` bombono: migrate to scons_latest ``                                                                      |
| [`2cc69e24`](https://github.com/NixOS/nixpkgs/commit/2cc69e245ab211bb2eb27eca9f749038f1b76750) | `` libcef: 110.0.27 -> 111.2.6 ``                                                                           |
| [`d8f58908`](https://github.com/NixOS/nixpkgs/commit/d8f58908ce0f1a7bce0a8675a09b2e6d5f190d5c) | `` nixos/opengl: mesa_22 -> mesa_23 ``                                                                      |
| [`33a700b4`](https://github.com/NixOS/nixpkgs/commit/33a700b406d0d5056079cc5a9ce7c78aae28e5d5) | `` mesa: provide patch versions ``                                                                          |
| [`bf1785d0`](https://github.com/NixOS/nixpkgs/commit/bf1785d0a91d5d3bb0ef3c2afe031554f17a87e4) | `` nixos/opengl: add mesaPackage option ``                                                                  |
| [`75cf58e3`](https://github.com/NixOS/nixpkgs/commit/75cf58e348d9c15d555c6c7f155cd7092f2d4838) | `` fish: disable flaky pexpect test on darwin ``                                                            |
| [`20fe9757`](https://github.com/NixOS/nixpkgs/commit/20fe97573f79a073b05d1facd97fc437bfd2b71c) | `` python310Packages.onvif-zeep-async: 1.2.1 -> 1.2.2 ``                                                    |
| [`9c2912c4`](https://github.com/NixOS/nixpkgs/commit/9c2912c42f0e87f66c3c8c527606c61e8dca69ce) | `` maintainer-list.nix: remove weihua ``                                                                    |
| [`777a3a52`](https://github.com/NixOS/nixpkgs/commit/777a3a522f0e5f71661897da97a0c9d249cf0fbf) | `` dxx-rebirth: unstable-2022-09-17 -> unstable-2023-03-23 ``                                               |
| [`b27114d1`](https://github.com/NixOS/nixpkgs/commit/b27114d16bb4fb0f05ceb1679c163abeff93455e) | `` fish: 3.6.0 -> 3.6.1 ``                                                                                  |
| [`7a2277b9`](https://github.com/NixOS/nixpkgs/commit/7a2277b9e4a158aaebb40bb69ce6e9c41b194780) | `` woob: 3.3.1->3.4 ``                                                                                      |
| [`a2dd6267`](https://github.com/NixOS/nixpkgs/commit/a2dd6267996c83d7eac71d55aaeba75b9180cd3b) | `` vmpk: 0.8.7 -> 0.8.8 ``                                                                                  |
| [`ed3120b8`](https://github.com/NixOS/nixpkgs/commit/ed3120b8b37d972aa513cecc433a4e3f2055baa1) | `` flyway: 9.15.1 -> 9.16.1 ``                                                                              |
| [`309e5947`](https://github.com/NixOS/nixpkgs/commit/309e59471f500939942ebd7041f67b73b8514dc3) | `` oha: 0.5.7 -> 0.5.8 ``                                                                                   |
| [`95381a8a`](https://github.com/NixOS/nixpkgs/commit/95381a8ab52158adadd07a29425e48ee13489995) | `` moodle: 4.1.1 -> 4.1.2 ``                                                                                |
| [`c4752a16`](https://github.com/NixOS/nixpkgs/commit/c4752a1631e46bde11bf8038f30e067c39b97cd4) | `` mesa_23: init at 23.0.1 ``                                                                               |
| [`c2ebb395`](https://github.com/NixOS/nixpkgs/commit/c2ebb395cadfd081c015f7da5034b12c145bf6bc) | `` mesa: refactor for multi-version setup ``                                                                |
| [`ddd3de70`](https://github.com/NixOS/nixpkgs/commit/ddd3de70aaa9c55d970d4eeda2d53dc213853758) | `` jpegoptim: 1.5.2 -> 1.5.3 ``                                                                             |
| [`c74c9adc`](https://github.com/NixOS/nixpkgs/commit/c74c9adc10d28f90282ee74dc0f329050dc96126) | `` ngtcp2: 0.13.1 -> 0.14.0 ``                                                                              |
| [`6e8960b5`](https://github.com/NixOS/nixpkgs/commit/6e8960b57247a4a4a154d6ed30f35d2fe214bb5a) | `` nghttp3: 0.9.0 -> 0.10.0 ``                                                                              |
| [`cdfccb0b`](https://github.com/NixOS/nixpkgs/commit/cdfccb0b0e6b352b93bfb779be7c5780642d84f2) | `` python310Packages.python-benedict: 0.29.1 -> 0.30.0 ``                                                   |
| [`2646204f`](https://github.com/NixOS/nixpkgs/commit/2646204f1cd22b12cfe501b947021d7491179bf4) | `` pgo-client: 4.7.7 -> 4.7.10 ``                                                                           |
| [`34ec699e`](https://github.com/NixOS/nixpkgs/commit/34ec699ea0f55c36247a426cd102942f232ca8c5) | `` graalvmCEPackages.python-installable-svm-java*: fix by libxcrypt-legacy ``                               |
| [`9b766dd4`](https://github.com/NixOS/nixpkgs/commit/9b766dd41b9b49cb0c1b1f3317fc2273f1f8f3a0) | `` libxcrypt: add -legacy variant ``                                                                        |
| [`3fbc1838`](https://github.com/NixOS/nixpkgs/commit/3fbc1838ebd6ac0bfed0cb03c3781aa2a6daab43) | `` hplip: disable parallel installing ``                                                                    |
| [`ea91658f`](https://github.com/NixOS/nixpkgs/commit/ea91658f851be21dace58a208b6557a83bb4530b) | `` multipath-tools: fixup build (missing #include) ``                                                       |
| [`f4933e22`](https://github.com/NixOS/nixpkgs/commit/f4933e2243b75daa16ff062f73cb6c5e750536a4) | `` ndn-tools: fix build after libpcap update ``                                                             |
| [`eb157e65`](https://github.com/NixOS/nixpkgs/commit/eb157e657a60d84ad528f01a31931a6d009758fb) | `` ntirpc: fixup build (missing #include) ``                                                                |
| [`3b6c5abc`](https://github.com/NixOS/nixpkgs/commit/3b6c5abc735c868209300e8e6c330d3245e84faa) | `` python310Packages.param: update homepage ``                                                              |
| [`aefa51a1`](https://github.com/NixOS/nixpkgs/commit/aefa51a1e84cf82d1c6c76b484d4935bbcfba520) | `` python310Packages.param: 1.12.3 -> 1.13.0 ``                                                             |
| [`abdd2b09`](https://github.com/NixOS/nixpkgs/commit/abdd2b09d1f2fb954ada246a7acb13fcbf2497a7) | `` terminal-stocks: 1.0.14 -> 1.0.15 ``                                                                     |
| [`afd5df90`](https://github.com/NixOS/nixpkgs/commit/afd5df90c4229e16a8ec91195fbd20f511530421) | `` roxctl: 3.73.3 -> 3.74.1 ``                                                                              |
| [`d52eb8b3`](https://github.com/NixOS/nixpkgs/commit/d52eb8b36c61873bf346e8f54f095e36ac027a1d) | `` python310Packages.readchar: 4.0.3 -> 4.0.5 ``                                                            |
| [`42574a80`](https://github.com/NixOS/nixpkgs/commit/42574a8027a021708355718e24a6ff96b87d7b68) | `` buildpack: 0.28.0 -> 0.29.0 ``                                                                           |
| [`4153e75d`](https://github.com/NixOS/nixpkgs/commit/4153e75de4e17fb943c2357de08594eb5bee94d9) | `` luau: 0.568 -> 0.569 ``                                                                                  |
| [`5152baeb`](https://github.com/NixOS/nixpkgs/commit/5152baeb160be4b7b9737c7a9f33d7211546d275) | `` gallery-dl: 1.25.0 -> 1.25.1 ``                                                                          |
| [`ff89da0e`](https://github.com/NixOS/nixpkgs/commit/ff89da0ee6a89d60865c601b3eb27489f4fd79ef) | `` python310Packages.jupyter-cache: fix build ``                                                            |
| [`0e3d87be`](https://github.com/NixOS/nixpkgs/commit/0e3d87beb5fad1de82ceed43fb333483fb27c391) | `` scaleway-cli: 2.12.0 -> 2.13.0 ``                                                                        |
| [`d93774ba`](https://github.com/NixOS/nixpkgs/commit/d93774ba644bdf320a2b8f400b280b2aa4c147bc) | `` saml2aws: 2.36.4 -> 2.36.5 ``                                                                            |
| [`2baef576`](https://github.com/NixOS/nixpkgs/commit/2baef5767270799b7e88c3e76ba40339013b321a) | `` protobuf3_8: remove ``                                                                                   |
| [`9a646316`](https://github.com/NixOS/nixpkgs/commit/9a646316b1908c8611af534ebd0a79190dd44850) | `` qt6.qtwebengine: pin to ffmpeg_4 ``                                                                      |
| [`b7f88dd5`](https://github.com/NixOS/nixpkgs/commit/b7f88dd5ca21cdee4ba6811b07a2279f9b6a5b12) | `` python310Packages.ansible-lint: 6.14.2 -> 6.14.3 ``                                                      |
| [`399f4f02`](https://github.com/NixOS/nixpkgs/commit/399f4f024b593724ca0842d515c40018c80b2b3f) | `` goa: 3.11.2 -> 3.11.3 ``                                                                                 |
| [`5d41b7a6`](https://github.com/NixOS/nixpkgs/commit/5d41b7a6bdcdef0ea984a1cebf20d0248b526028) | `` bun: 0.5.7 -> 0.5.8 ``                                                                                   |
| [`b06cac09`](https://github.com/NixOS/nixpkgs/commit/b06cac0904fd05dd0c8bb1e59c360c81e2d86572) | `` kubeseal: 0.20.1 -> 0.20.2 ``                                                                            |
| [`260a0f45`](https://github.com/NixOS/nixpkgs/commit/260a0f4583eac7e1a172fe58edce3cfe75d60ca4) | `` go-swag: 1.8.10 -> 1.8.11 ``                                                                             |
| [`b6b4543b`](https://github.com/NixOS/nixpkgs/commit/b6b4543bc444bf588bf03673f6cc33b36f9deba5) | `` minidsp: add mrene as maintainer ``                                                                      |
| [`44caa110`](https://github.com/NixOS/nixpkgs/commit/44caa1102a26d4297faf286ec88c91edb300075b) | `` maintainers: add mrene ``                                                                                |
| [`f202a861`](https://github.com/NixOS/nixpkgs/commit/f202a861d9e24be5b60a59fc0237d4ea6e32947b) | `` python310Packages.types-requests: 2.28.11.15 -> 2.28.11.16 ``                                            |
| [`ae273bf3`](https://github.com/NixOS/nixpkgs/commit/ae273bf340f2c44239e3a870ffcbc4693a664aca) | `` lagrange: 1.15.5 → 1.15.6 ``                                                                             |
| [`2292347f`](https://github.com/NixOS/nixpkgs/commit/2292347fc7b416b793d4c170cb75af8cd65ba18c) | `` boxxy: 0.4.0 -> 0.5.1 ``                                                                                 |
| [`04708846`](https://github.com/NixOS/nixpkgs/commit/0470884699b4d45570985ee97735efb7562e2656) | `` cargo-vet: 0.5.1 -> 0.5.2 ``                                                                             |
| [`89c01366`](https://github.com/NixOS/nixpkgs/commit/89c01366f924b066e284b287eb07168f94716d19) | `` bustle: Fix build with libpcap 1.10.2 ``                                                                 |
| [`2a21328f`](https://github.com/NixOS/nixpkgs/commit/2a21328f7e0b751c6ec1f2539cb07dc8e85c8e43) | `` snappy: fix x86_64-darwin build ``                                                                       |
| [`aa5e1912`](https://github.com/NixOS/nixpkgs/commit/aa5e191213cec43d03f72e87b6dae450c782400c) | `` golangci-lint: 1.52.0 -> 1.52.1 ``                                                                       |
| [`cd585031`](https://github.com/NixOS/nixpkgs/commit/cd585031d3159ce83604050e984af6e56bfeb499) | `` ettercap: patch to accept curl 8 ``                                                                      |
| [`298c17f2`](https://github.com/NixOS/nixpkgs/commit/298c17f273ab09c907ba5296617d2e94a5ebe6d6) | `` gotools: 0.1.10 -> 0.7.0, adopt, cleanup ``                                                              |
| [`6378c290`](https://github.com/NixOS/nixpkgs/commit/6378c2909e89567e06afa99c0254c55b1fce8aff) | `` zoom-us: 5.13.11.1288 -> 5.14.0.1720 ``                                                                  |
| [`cb10bd6c`](https://github.com/NixOS/nixpkgs/commit/cb10bd6cb34e5cf093340b14852844dd82de0813) | `` lapack: force a rebuild on x86_64-darwin ``                                                              |
| [`a4870bb4`](https://github.com/NixOS/nixpkgs/commit/a4870bb43cbe3d980d4e6a4879e69bd4712a3ecc) | `` swayws: unstable-2022-03-10 -> 1.2.0 ``                                                                  |
| [`ac6b47a9`](https://github.com/NixOS/nixpkgs/commit/ac6b47a91f517ee230952d253e8c0c21d152ae7b) | `` tempo: 2.0.0 -> 2.0.1 ``                                                                                 |
| [`e0bbf6be`](https://github.com/NixOS/nixpkgs/commit/e0bbf6beb27371bf0891d007ee4c944690273f93) | `` portfolio-filemanager: add chuangzhu as a maintainer ``                                                  |
| [`e32fabac`](https://github.com/NixOS/nixpkgs/commit/e32fabacb7db7d9da6b889aeeb579e0b37feded6) | `` portfolio-filemanager: 0.9.14 -> 0.9.15 ``                                                               |
| [`2b01458e`](https://github.com/NixOS/nixpkgs/commit/2b01458e66af186e75a9d96e0d55f9bdffb69e13) | `` tuba: init at 0.1.0 ``                                                                                   |
| [`0fd8c4fc`](https://github.com/NixOS/nixpkgs/commit/0fd8c4fc72b6910092e3fc123d985d755cccbfe9) | `` gopass-jsonapi: Use the same gopass' wrapper dependencies ``                                             |
| [`a80835a2`](https://github.com/NixOS/nixpkgs/commit/a80835a2b0618a635e10712f7036ef0223a16fd7) | `` gopass-jsonapi: Don't wrap with gopass ``                                                                |
| [`fa117537`](https://github.com/NixOS/nixpkgs/commit/fa1175372bd14201a507771ab53cb0478df56f4d) | `` maintainers/team-list: add 3 new members to LLVM ``                                                      |
| [`14d9206f`](https://github.com/NixOS/nixpkgs/commit/14d9206fae6bbc2607ca28089b3ebb22b6b28507) | `` maintainers/team-list: sort llvm members ``                                                              |
| [`e5592313`](https://github.com/NixOS/nixpkgs/commit/e559231384ac6a2d2aefdb3d747d48d5fe530e2b) | `` perlPackages.AuthenSimplePasswd: don't test the "crypt" algo ``                                          |
| [`a9733393`](https://github.com/NixOS/nixpkgs/commit/a9733393244300f603aa2d2f270ac1ec03424abe) | `` perlPackages.AuthenSimple: don't test the "crypt" algo ``                                                |
| [`68489594`](https://github.com/NixOS/nixpkgs/commit/6848959460260b8c6e4e6411b6f00af2ee09e332) | `` sdrangel: add myself as mantainer ``                                                                     |
| [`ade83d31`](https://github.com/NixOS/nixpkgs/commit/ade83d316b9032c565bdcf33a872ac6072433e98) | `` nixos/doc/rl-2305: remove stray conflict marker ``                                                       |
| [`bfbc0f56`](https://github.com/NixOS/nixpkgs/commit/bfbc0f56e55b1351423ebc4845cfd4f8e432a667) | `` override test for curl version ``                                                                        |
| [`7a5c02ce`](https://github.com/NixOS/nixpkgs/commit/7a5c02ce0b9d092fff778b60c2b59fd8828f886c) | `` sdrangel: unpin boost ``                                                                                 |