### PR TITLE
chore(flake/nixpkgs): `4361baa7` -> `4bb072f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -196,11 +196,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679865578,
-        "narHash": "sha256-sYQmxxqIYL3QFsRYjW0AufhGur8qWfwoOGPGHRJZlGc=",
+        "lastModified": 1679944645,
+        "narHash": "sha256-e5Qyoe11UZjVfgRfwNoSU57ZeKuEmjYb77B9IVW7L/M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4361baa782dc3d3b35fd455a1adc370681d9187c",
+        "rev": "4bb072f0a8b267613c127684e099a70e1f6ff106",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                     |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| [`87d4e177`](https://github.com/NixOS/nixpkgs/commit/87d4e177760993d588d7a89aa9935c723945138c) | `` maintainers/team-list: add asymmetric to docs ``                                                         |
| [`c29ca670`](https://github.com/NixOS/nixpkgs/commit/c29ca6704dfd562e22bc60ad3d650d753f4bb22f) | `` mattermost: add environmentFile option to allow declarative secrets ``                                   |
| [`7159363f`](https://github.com/NixOS/nixpkgs/commit/7159363f5172a53286678ea84693570d3b35a9db) | `` linuxPackages.nvidia_x11_legacy340: Fix build on 6.1 ``                                                  |
| [`56fa7ab0`](https://github.com/NixOS/nixpkgs/commit/56fa7ab066165a2eb6274a0ab423b518e3e115b4) | `` nixos/tests/zfs: add zfsUnstable test for systemd-stage 1 ``                                             |
| [`64a4de85`](https://github.com/NixOS/nixpkgs/commit/64a4de856877a32e4f8f4863101e2cbbfdc6b62b) | `` zfsUnstable: make it compatible again with 6.2.8 and potentially 6.3 ``                                  |
| [`a3983c88`](https://github.com/NixOS/nixpkgs/commit/a3983c8856895190bcfc5f6b59f2f279059de1a3) | `` gitlab: 15.9.3 -> 15.10.0 (#223367) ``                                                                   |
| [`44780192`](https://github.com/NixOS/nixpkgs/commit/4478019214283d60518162c70ecf8e337520e18b) | `` urbit: 1.22 -> 2.0 ``                                                                                    |
| [`93baaff4`](https://github.com/NixOS/nixpkgs/commit/93baaff43466512c424911fcad7a49ee695c560a) | `` nfpm: add caarlos0 to maintainers list ``                                                                |
| [`bc805499`](https://github.com/NixOS/nixpkgs/commit/bc805499d9aef332715154581f94ef24fa35f81c) | `` timer: add caarlos0 to maintainers list ``                                                               |
| [`403affda`](https://github.com/NixOS/nixpkgs/commit/403affdafec92e24078b4b8ce9e13f8b66f31022) | `` domain-exporter: add caarlos0 to maintainer list ``                                                      |
| [`6cbbc163`](https://github.com/NixOS/nixpkgs/commit/6cbbc163798888916ec28e6a3ef75d58373739cb) | `` tasktimer: add caarlos0 to maintainers list ``                                                           |
| [`bc319601`](https://github.com/NixOS/nixpkgs/commit/bc3196013a3ffa4daa9b172063d0293a39bde295) | `` sccache: 0.4.0 -> 0.4.1 ``                                                                               |
| [`8a2c93e5`](https://github.com/NixOS/nixpkgs/commit/8a2c93e5b80ae8e93115628dff4a423a2ca395b7) | `` xfsprogs: 6.1.1 -> 6.2.0 ``                                                                              |
| [`147e04f2`](https://github.com/NixOS/nixpkgs/commit/147e04f2c892ba12f90ee5ece40832229f98cce9) | `` wezterm: 20230320-124340-559cb7b0 -> 20230326-111934-3666303c ``                                         |
| [`a188ce34`](https://github.com/NixOS/nixpkgs/commit/a188ce34366863de551a5721525a52a0aa38612a) | `` python310Packages.pyzerproc: remove asynctest ``                                                         |
| [`1b691903`](https://github.com/NixOS/nixpkgs/commit/1b6919037c1e5c7449901657a22a84fb9726b94e) | `` python310Packages.hahomematic: 2023.2.11 -> 2023.3.0 ``                                                  |
| [`7d7f8be0`](https://github.com/NixOS/nixpkgs/commit/7d7f8be0b776dd3f55fb16c2fa939fa2e1e25a68) | `` python310Packages.niapy: 2.0.4 -> 2.0.5 ``                                                               |
| [`bc80e23d`](https://github.com/NixOS/nixpkgs/commit/bc80e23d048ec46e224352e530b6a86ecd03d547) | `` python310Packages.pydeconz: 110 -> 111 ``                                                                |
| [`bb82199e`](https://github.com/NixOS/nixpkgs/commit/bb82199ebebf26c262712daaa90f2a3f53777d41) | `` python310Packages.yalexs-ble: 2.1.6 -> 2.1.10 ``                                                         |
| [`111ff168`](https://github.com/NixOS/nixpkgs/commit/111ff168c9b0dbdd8624a85f5d11632fc2da8848) | `` amass: 3.22.1 -> 3.22.2 ``                                                                               |
| [`f70568dd`](https://github.com/NixOS/nixpkgs/commit/f70568dd6d3babc3749796acc9ec58c7fcabf71c) | `` qovery-cli: 0.54.0 -> 0.55.0 ``                                                                          |
| [`3b865634`](https://github.com/NixOS/nixpkgs/commit/3b8656349258ff70c03e1bde168a962059ef6297) | `` mpd-mpris: 0.3.1 -> 0.4.0 ``                                                                             |
| [`9c7e5c7c`](https://github.com/NixOS/nixpkgs/commit/9c7e5c7c532d88f194a96d7711c580b363e556b4) | `` python3Packages.pymoo: 0.6.0 -> 0.6.0.1 (#223332) ``                                                     |
| [`822ae3e8`](https://github.com/NixOS/nixpkgs/commit/822ae3e89125fb2f709a237435713b020b00ab37) | `` nvidia-vaapi-driver: add `-Wno-error` ``                                                                 |
| [`ae3ac99d`](https://github.com/NixOS/nixpkgs/commit/ae3ac99d579b4d881813e7c94542123efec95d7e) | `` exhaustive: init at 0.10.0 ``                                                                            |
| [`59cf5102`](https://github.com/NixOS/nixpkgs/commit/59cf5102f01f0f6aa368a9ba82202edca86a1845) | `` onlyoffice-bin: fix icon location ``                                                                     |
| [`15292223`](https://github.com/NixOS/nixpkgs/commit/152922233a6aed02705998bdc3cd00515d30a611) | `` microsoft-edge: Rewrite update script to use latest version (#219395) ``                                 |
| [`0ad13637`](https://github.com/NixOS/nixpkgs/commit/0ad13637b7b4d2bd46b76161a666d36e15e2042a) | `` zcash: 5.3.0 -> 5.4.2 (#216422) ``                                                                       |
| [`83ae03de`](https://github.com/NixOS/nixpkgs/commit/83ae03de66e3b69ec9e34effd739d43c7971b496) | `` vimPlugins.nvim-treesitter: prefix version with 0.0.0+rev= ``                                            |
| [`ba9c441e`](https://github.com/NixOS/nixpkgs/commit/ba9c441efc98efa07ea52a1f017c943bb905f4f0) | `` vscode-extensions: nixpkgs-fmt format ``                                                                 |
| [`40c8ceba`](https://github.com/NixOS/nixpkgs/commit/40c8cebade44d2874453ed992a7ec2d50123a34d) | `` nixos/synapse: Fix incorrect module path after it was moved ``                                           |
| [`3be70b09`](https://github.com/NixOS/nixpkgs/commit/3be70b091b5af3a3c782bae4af8837267db65bc3) | `` vscode-extensions: upgrade in batch (#223308) ``                                                         |
| [`056be64f`](https://github.com/NixOS/nixpkgs/commit/056be64f11fe2ee33373f07abda4d8cf6fabf572) | `` nixos/podman: add example to enable network dns ``                                                       |
| [`0297a2db`](https://github.com/NixOS/nixpkgs/commit/0297a2db9a47c57128e30eaa9104a0a72a1cc268) | `` wezterm: 20221119-145034-49b9839f -> 20230320-124340-559cb7b0 ``                                         |
| [`744cfdaf`](https://github.com/NixOS/nixpkgs/commit/744cfdaf11096ae724e920107229d2ca59dafea8) | `` yq-go: 4.32.2 -> 4.33.1 ``                                                                               |
| [`82427c93`](https://github.com/NixOS/nixpkgs/commit/82427c93fe40596a482a279d32529a5e2a8711c9) | `` hip: 5.4.3 -> 5.4.4 ``                                                                                   |
| [`3bdb805c`](https://github.com/NixOS/nixpkgs/commit/3bdb805c5fb70bf30d0db3eb5655fe040e05b335) | `` xrootd: 5.5.3 -> 5.5.4 ``                                                                                |
| [`eb123f6e`](https://github.com/NixOS/nixpkgs/commit/eb123f6e7c8860a30e9ef8ad88f4f3df264890ad) | `` typst: 22-03-21-2 -> 23-03-21-2 ``                                                                       |
| [`5c7757b1`](https://github.com/NixOS/nixpkgs/commit/5c7757b10b1347c23d141a5a0c5672a81f48fda7) | `` microbin: 1.1.0 -> 1.2.1, add figsoda as a maintainer ``                                                 |
| [`781f0f10`](https://github.com/NixOS/nixpkgs/commit/781f0f106aa39ad5491c62a8aae7e38e7ff8e363) | `` tauon: 7.6.0 -> 7.6.2 ``                                                                                 |
| [`c239772e`](https://github.com/NixOS/nixpkgs/commit/c239772ef27312876e585f8610de52883886e2e2) | `` nerdfix: init at 0.1.0 ``                                                                                |
| [`e6145346`](https://github.com/NixOS/nixpkgs/commit/e6145346d3a745536a1b79bc983c7fda43e8fdcc) | `` imagemagick: 7.1.1-4 -> 7.1.1-5 ``                                                                       |
| [`83979742`](https://github.com/NixOS/nixpkgs/commit/83979742992859f01a78adc19ff47a4f1c4c6567) | `` hugin: add wrapGAppsHook ``                                                                              |
| [`761552c4`](https://github.com/NixOS/nixpkgs/commit/761552c4c30d714cec66422eaf032df025ddc6f9) | `` prometheus-postgres-exporter: 0.11.1 -> 0.12.0 ``                                                        |
| [`ea5208f0`](https://github.com/NixOS/nixpkgs/commit/ea5208f0e5fdf1b0343a207847e27fb37b62af92) | `` python310Packages.zha-quirks: remove asynctest ``                                                        |
| [`169ea380`](https://github.com/NixOS/nixpkgs/commit/169ea3800c8eb086439d95150aa50c2b43663e78) | `` python310Packages.zwave-me-ws: 0.3.1 -> 0.3.6 ``                                                         |
| [`4bd4a8d4`](https://github.com/NixOS/nixpkgs/commit/4bd4a8d462132e38417d2aaf9a1f98c2d1babd51) | `` python310Packages.lightwave2: 0.8.21 -> 0.8.22 ``                                                        |
| [`ef989867`](https://github.com/NixOS/nixpkgs/commit/ef989867aeb6acd08dcd40c132d33f80ce088a3d) | `` exploitdb: 2023-03-25 -> 2023-03-26 ``                                                                   |
| [`877f8b10`](https://github.com/NixOS/nixpkgs/commit/877f8b10c20350ab88a3256ef519a2a708bc5e78) | `` burpsuite: 2023.1.2 -> 2023.2.4 https://portswigger.net/burp/releases/professional-community-2023-2-4 `` |
| [`a2cb09e3`](https://github.com/NixOS/nixpkgs/commit/a2cb09e3047759070fc29c1abd70d3b8cc35ef91) | `` katana: add changelog to meta ``                                                                         |
| [`81fdb1ae`](https://github.com/NixOS/nixpkgs/commit/81fdb1ae5ccec2c139b232f3d409d72a8480d7b6) | `` abcl: 1.9.0 -> 1.9.1 ``                                                                                  |
| [`501da627`](https://github.com/NixOS/nixpkgs/commit/501da627577660f187caab5c1025a9938aa17a51) | `` sonixd: 0.15.4 -> 0.15.5 ``                                                                              |
| [`70a99e3b`](https://github.com/NixOS/nixpkgs/commit/70a99e3b793c4908e95143e0913f8ef4fad830e4) | `` fcitx5-gtk: 5.0.22 -> 5.0.23 ``                                                                          |
| [`6198b309`](https://github.com/NixOS/nixpkgs/commit/6198b30952bb68899ba0f5ada3d2cbe3990177b0) | `` srain: 1.5.0 -> 1.5.1 ``                                                                                 |
| [`9022b97e`](https://github.com/NixOS/nixpkgs/commit/9022b97ed5c935db7dbba4a8a7c30d750f69f5d3) | `` python310Packages.yalexs-ble: 2.1.4 -> 2.1.6 ``                                                          |
| [`53afe093`](https://github.com/NixOS/nixpkgs/commit/53afe093767f53784c3da35cc3711778851b4835) | `` python310Packages.teslajsonpy: 3.7.5 -> 3.8.0 ``                                                         |
| [`8f1b3705`](https://github.com/NixOS/nixpkgs/commit/8f1b37050f0c0bbbb73b96f9b5dcfc07c8dd060c) | `` qovery-cli: 0.53.1 -> 0.54.0 ``                                                                          |
| [`e664468e`](https://github.com/NixOS/nixpkgs/commit/e664468e773316a10eaa36a1b9fd8c89cae014ef) | `` prosody: 0.12.1 → 0.12.3 ``                                                                              |
| [`155af545`](https://github.com/NixOS/nixpkgs/commit/155af54567c48d09843b7816696fd496a3ddd6b0) | `` gitmux: 0.9.1 -> 0.10.1 ``                                                                               |
| [`1c415839`](https://github.com/NixOS/nixpkgs/commit/1c41583945c03f0d5d2bf0919dc802c628754274) | `` vala-language-server: 0.48.5 -> 0.48.7 ``                                                                |
| [`c3966c2d`](https://github.com/NixOS/nixpkgs/commit/c3966c2d35b14e4ed90723724f986183ba9c68ee) | `` freedv: 1.8.7 -> 1.8.8 ``                                                                                |
| [`0ca43a61`](https://github.com/NixOS/nixpkgs/commit/0ca43a611317b73f54e6436b27dd6930f85af5ca) | `` rbw: 1.6.0 -> 1.7.0 ``                                                                                   |
| [`11b3e643`](https://github.com/NixOS/nixpkgs/commit/11b3e643de14be40a6a8cf07281e77424acc734b) | `` xfce.xfce4-clipman-plugin: 1.6.2 -> 1.6.3 ``                                                             |
| [`c62b815b`](https://github.com/NixOS/nixpkgs/commit/c62b815bc4ae6937e13bfee4399e3af6aacd4b6d) | `` adw-gtk3: support all unix platforms ``                                                                  |
| [`c6de147d`](https://github.com/NixOS/nixpkgs/commit/c6de147d1325d55ba2ed39ad557b85f4afd51d0a) | `` fizz: add changelog to meta ``                                                                           |
| [`ddfbf234`](https://github.com/NixOS/nixpkgs/commit/ddfbf234cede27e482894c7b202fd0d95393081f) | `` fizz: 2023.03.06.00 -> 2023.03.20.00 ``                                                                  |
| [`aeba1e07`](https://github.com/NixOS/nixpkgs/commit/aeba1e075eb7887182c024ae5bd558890119cf2f) | `` stress-ng: 0.15.05 -> 0.15.06 ``                                                                         |
| [`d752b1a8`](https://github.com/NixOS/nixpkgs/commit/d752b1a8c5bc0e3e5ef8926d4765c9f22a5c067c) | `` alacritty: 0.11.0 -> 0.12.0 ``                                                                           |
| [`dd557d36`](https://github.com/NixOS/nixpkgs/commit/dd557d36371e7b1d719f72ad25c825a517a4f484) | `` ack: 3.6.0 -> 3.7.0 ``                                                                                   |
| [`ee055b14`](https://github.com/NixOS/nixpkgs/commit/ee055b1457068ce23986f06e48716933a168271a) | `` dnscontrol: 3.28.0 -> 3.29.0 ``                                                                          |
| [`1c313584`](https://github.com/NixOS/nixpkgs/commit/1c313584cc51607840d5e54d4a51bd0a266049f1) | `` katana: 0.0.3 -> 1.0.0 ``                                                                                |
| [`d4f55d10`](https://github.com/NixOS/nixpkgs/commit/d4f55d1005d782a8c174da2f2c084e55266f59d0) | `` twilio-cli: changelog url ``                                                                             |
| [`4d164b7d`](https://github.com/NixOS/nixpkgs/commit/4d164b7d1c7a3490cc9e7d574572fb2bf5107f81) | `` python310Packages.myst-nb: fix build ``                                                                  |
| [`231ecef5`](https://github.com/NixOS/nixpkgs/commit/231ecef5a919284dacdaf1b57dfbe3ce8e4a045b) | `` twilio-cli: fix tests.version ``                                                                         |
| [`6e65c36d`](https://github.com/NixOS/nixpkgs/commit/6e65c36d1bff6eca3005f123a34780267107783a) | `` python310Packages.azure-mgmt-monitor: 5.0.1 -> 6.0.0 ``                                                  |
| [`bb270775`](https://github.com/NixOS/nixpkgs/commit/bb270775f2dc80e6fba3984d641415adbe58393b) | `` cvc5: 1.0.4 -> 1.0.5 ``                                                                                  |
| [`dafa42af`](https://github.com/NixOS/nixpkgs/commit/dafa42afffbcb209acd6f8e3075490fc1c68d5b7) | `` docker-compose: 2.16.0 -> 2.17.0 ``                                                                      |
| [`d60cc037`](https://github.com/NixOS/nixpkgs/commit/d60cc03705f4aeb956285b79fe088b153bdd3875) | `` twilio-cli: 5.4.2 -> 5.5.0 ``                                                                            |
| [`07b7e795`](https://github.com/NixOS/nixpkgs/commit/07b7e7950206791b4fc5c74a804fccbb07b5e959) | `` viceroy: 0.4.0 -> 0.4.1 ``                                                                               |
| [`0f3c8f0e`](https://github.com/NixOS/nixpkgs/commit/0f3c8f0e3cd04224f0c21a05705b693657b32296) | `` python3Packages.cairosvg: 2.6.0 -> 2.7.0 ``                                                              |
| [`cb619a09`](https://github.com/NixOS/nixpkgs/commit/cb619a09e024e7d16523422091d7027826f9678b) | `` pythonPackages.pyrr: 0.10.3 -> unstable-2022-07-22 ``                                                    |
| [`d443805f`](https://github.com/NixOS/nixpkgs/commit/d443805fe39d40e2c4bd31e3e54193f42735757b) | `` megam: add leixb as maintainer ``                                                                        |
| [`d85fae35`](https://github.com/NixOS/nixpkgs/commit/d85fae35d94dd270b5904c7d9cd516a2cd45f4bc) | `` megam: add megam.opt binary ``                                                                           |
| [`d8d5d73b`](https://github.com/NixOS/nixpkgs/commit/d8d5d73bac777eab35e05e1347818b91f314a9f0) | `` rPackages.Rhdf5lib: enable cxx bindings ``                                                               |
| [`5ea1b9d7`](https://github.com/NixOS/nixpkgs/commit/5ea1b9d7cdb6356083674a6bb5bbdb95909d5cdb) | `` python310Packages.quart-cors: init at 0.6.0 ``                                                           |
| [`14c9c309`](https://github.com/NixOS/nixpkgs/commit/14c9c309823b248aa352d92ed519823c01a1d4de) | `` python310Packages.quart: init at 0.18.3 ``                                                               |
| [`445df9ef`](https://github.com/NixOS/nixpkgs/commit/445df9ef48296ff93aefdbdee3fac3e68036c221) | `` rPackages.Rhdflib: patch linking flags ``                                                                |
| [`2235dd46`](https://github.com/NixOS/nixpkgs/commit/2235dd4616b3e228e9811ebc6892c08b6a97f500) | `` kubo: 0.18.1 -> 0.19.0 ``                                                                                |
| [`ef9c99a0`](https://github.com/NixOS/nixpkgs/commit/ef9c99a035aea4b828324abe686210460a8cfd9e) | `` nixos/kubo: add QUICv1 and WebTransport to Addresses.Swarm list ``                                       |
| [`c229a646`](https://github.com/NixOS/nixpkgs/commit/c229a6463eae1b8736f9d4fae92a1d5e52be2121) | `` nixos/tests/consul: stop consul cleanly ``                                                               |
| [`11b400bf`](https://github.com/NixOS/nixpkgs/commit/11b400bf58d6c8fe0abc1ba8c7ca72254350d10d) | `` signalbackup-tools: 20230316 -> 20230322 ``                                                              |
| [`14db22f8`](https://github.com/NixOS/nixpkgs/commit/14db22f86827277db0c973d665e0272c627b77c7) | `` rPackages.rhdf5: fix build ``                                                                            |
| [`442e1b87`](https://github.com/NixOS/nixpkgs/commit/442e1b87d1bf0134f0fdea1ca7697e08e0b04627) | `` rPackages.rhdf5filters: fix build ``                                                                     |
| [`ccfbc196`](https://github.com/NixOS/nixpkgs/commit/ccfbc19630465aaa666588417d38b56a557a1bff) | `` rPackages.Rhdf5lib: fix build ``                                                                         |
| [`1907fe8d`](https://github.com/NixOS/nixpkgs/commit/1907fe8d2558649df796ab40553b23aad2a7f911) | `` tor-browser-bundle-bin: 12.0.3 -> 12.0.4 ``                                                              |
| [`1addf91b`](https://github.com/NixOS/nixpkgs/commit/1addf91b0b24b8c8556bf5c484a7382f6fd4a6e8) | `` qtile: add more options and expose unwrapped package ``                                                  |
| [`edc62383`](https://github.com/NixOS/nixpkgs/commit/edc62383e460f56f1050d65d20d578b8dca631b2) | `` qtile: add myself as maintainer ``                                                                       |
| [`fae83110`](https://github.com/NixOS/nixpkgs/commit/fae831109185e5a2d0d78f1c7c62b36185b0657e) | `` qtile: fix pulsevolume widget ``                                                                         |
| [`a10887cb`](https://github.com/NixOS/nixpkgs/commit/a10887cb3fd7087c006b91197b6eb2b8730eebeb) | `` rPackages.purrr: patch configure shebang ``                                                              |
| [`0c0c6908`](https://github.com/NixOS/nixpkgs/commit/0c0c6908b9ccc81350f86640dc07ad78981431a1) | `` rPackages: CRAN and BioC update ``                                                                       |
| [`5eff9f19`](https://github.com/NixOS/nixpkgs/commit/5eff9f19408717e3d330fd0f97961cddf8ac23b6) | `` R: 4.2.2 -> 4.2.3 ``                                                                                     |
| [`81d23b8d`](https://github.com/NixOS/nixpkgs/commit/81d23b8d3a022b5a74c9944a96e916c7f156382d) | `` buildFHSUserEnv: rewrite not isNull check ``                                                             |
| [`23ee7693`](https://github.com/NixOS/nixpkgs/commit/23ee7693587b2aac2b633012290f2bc400fdc8b3) | `` buildFHSUserEnv: add version arg ``                                                                      |
| [`7a7ff877`](https://github.com/NixOS/nixpkgs/commit/7a7ff877b78e4f602a3aa8d3704bfd68caefb5de) | `` nixos/podman: remove unused mkMerge ``                                                                   |