### PR TITLE
chore(flake/stylix): `dd338366` -> `e626c4e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -382,11 +382,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680015786,
-        "narHash": "sha256-4GRkgXqjD+UL6uhjl4fnPBEd6bJ5HdMIgsV2eukp/CQ=",
+        "lastModified": 1680023459,
+        "narHash": "sha256-9INeu9GEIzqhNMd+/CD2rmX3bNtu+sWuPcEeEh4BjkI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "dd33836655c87ca011d9c29cf8b794b789728950",
+        "rev": "e626c4e54e7ecc903781c6f0fab89f889a7ba1f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                   |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`e626c4e5`](https://github.com/danth/stylix/commit/e626c4e54e7ecc903781c6f0fab89f889a7ba1f4) | `` Enable CI for Darwin packages :construction_worker: `` |