### PR TITLE
chore(flake/nixos-hardware): `82ecc5b8` -> `a6aa8174`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -202,11 +202,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1679944521,
-        "narHash": "sha256-SipdMlnCv/pDvo/j7ctEGqKvQSmn2gcoHSJgIVysXbk=",
+        "lastModified": 1680070330,
+        "narHash": "sha256-aoT2YZCd9LEtiEULFLIF0ykKydgE72X8gw/k9/pRS5I=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "82ecc5b88ffed8c0317c064dfd8f82f4b9882100",
+        "rev": "a6aa8174fa61e55bd7e62d35464d3092aefe0421",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`523e6f9f`](https://github.com/NixOS/nixos-hardware/commit/523e6f9faf4599d4144d9a4ac71a74be587bb0fd) | `` fix: remove rpi_backlight driver from rpi4 config ``           |
| [`b7c184da`](https://github.com/NixOS/nixos-hardware/commit/b7c184da76c87dde8ae25446e0ccb252b6ff7a02) | `` fix: add missing touch-ft5406 export to raspberry-pi config `` |
| [`39fb4bb2`](https://github.com/NixOS/nixos-hardware/commit/39fb4bb20e3d429ba541927d265e35a87b886534) | `` microsoft-surface: upgrade kernel 6.1.6 to 6.1.18 ``           |