### PR TITLE
chore(flake/home-manager): `765e4007` -> `0e065e1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680000368,
-        "narHash": "sha256-TlgC4IJ7aotynUdkGRtaAVxquaiddO38Ws89nB7VGY8=",
+        "lastModified": 1680114304,
+        "narHash": "sha256-XymtLu8G2nzenjDUWI7XV2MMHztvPkEZUFpwmZFcxVM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "765e4007b6f9f111469a25d1df6540e8e0ca73a6",
+        "rev": "0e065e1b6f0776ebbacea9dcbc977af7bc9eddc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                            |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`0e065e1b`](https://github.com/nix-community/home-manager/commit/0e065e1b6f0776ebbacea9dcbc977af7bc9eddc0) | `` Revert "programs.neovim: link packpath dir in XDG_DATA_HOME (#3717)" (#3817) `` |