### PR TITLE
chore(flake/pre-commit-hooks): `32b1dbed` -> `29dbe1ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1678976941,
-        "narHash": "sha256-skNr08frCwN9NO+7I77MjOHHAw+L410/37JknNld+W4=",
+        "lastModified": 1680170909,
+        "narHash": "sha256-FtKU/edv1jFRr/KwUxWTYWXEyj9g8GBrHntC2o8oFI8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "32b1dbedfd77892a6e375737ef04d8efba634e9e",
+        "rev": "29dbe1efaa91c3a415d8b45d62d48325a4748816",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                  |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
| [`30d1c34b`](https://github.com/cachix/pre-commit-hooks.nix/commit/30d1c34bdbfe3dd0b8fbdde3962180c56cf16f12) | `` add treefmt ``                        |
| [`eced2275`](https://github.com/cachix/pre-commit-hooks.nix/commit/eced227562737ab18435e72a10aac8dfe092d4b3) | `` nil: fix issue with multiple files `` |