### PR TITLE
chore(flake/stylix): `acd0c343` -> `4205a141`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -359,11 +359,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680346413,
-        "narHash": "sha256-204B2fXRnIwy85zimjPVQOMfuK0dddrm896PGygYA2Y=",
+        "lastModified": 1680432579,
+        "narHash": "sha256-sIcl3DvrDdQZM5kBWY25ocxJsIQFPV4gm54l79ZysB0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "acd0c34393b218588c2bbe232fd8fbf0e5069b46",
+        "rev": "4205a141bfcc0b9d1c04932ec7fdf0f86f99aaf6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                   |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`4205a141`](https://github.com/danth/stylix/commit/4205a141bfcc0b9d1c04932ec7fdf0f86f99aaf6) | `` Fix usage of hm module when system config does not use stylix (#79) `` |