### PR TITLE
chore(flake/home-manager): `6c76fb5b` -> `ccf650bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680546509,
-        "narHash": "sha256-Nh6TFRrCkd3+nNrX3M8aA/TMpQS46Cf6jMwp352PNn8=",
+        "lastModified": 1680549487,
+        "narHash": "sha256-9Sbk3OJF9Y3EICGetwcO2vaOdovJrOywHinn4GBWAsw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6c76fb5b125232048458c50dfe600dc7380177c3",
+        "rev": "ccf650bb5badcf48054cf77f74ac85ea87c6f84c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                          |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`ccf650bb`](https://github.com/nix-community/home-manager/commit/ccf650bb5badcf48054cf77f74ac85ea87c6f84c) | `` man: use cfg when possible `` |