### PR TITLE
chore(flake/home-manager): `ccf650bb` -> `24f60622`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680549487,
-        "narHash": "sha256-9Sbk3OJF9Y3EICGetwcO2vaOdovJrOywHinn4GBWAsw=",
+        "lastModified": 1680556031,
+        "narHash": "sha256-6akX0QxwIvPoL3trbrngsocwrZkwyoteXcYOex/FaDQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ccf650bb5badcf48054cf77f74ac85ea87c6f84c",
+        "rev": "24f60622a7ca9e424ff4be41c4ac49f1a9385570",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`24f60622`](https://github.com/nix-community/home-manager/commit/24f60622a7ca9e424ff4be41c4ac49f1a9385570) | `` flake.lock: Update ``                 |
| [`a5fe7bf7`](https://github.com/nix-community/home-manager/commit/a5fe7bf73ce0c2cc5d7497ec9bef63e94912232f) | `` Translate using Weblate (Japanese) `` |