### PR TITLE
chore(flake/nixos-hardware): `a6aa8174` -> `148fee31`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -202,11 +202,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1680070330,
-        "narHash": "sha256-aoT2YZCd9LEtiEULFLIF0ykKydgE72X8gw/k9/pRS5I=",
+        "lastModified": 1680780295,
+        "narHash": "sha256-lpPh5EXqnAFyioHfiDxnyIH/gETjjp29p/YJ17MHNUE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a6aa8174fa61e55bd7e62d35464d3092aefe0421",
+        "rev": "148fee317058fad8159619e9d6ccc8c0aa6d0fce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`d2f0dce9`](https://github.com/NixOS/nixos-hardware/commit/d2f0dce97bbcda8c9600027b24a5d3c3a7405eaf) | `` Lenovo legion 7i 16ithg6: add hidpi settings `` |