### PR TITLE
chore(flake/nixos-hardware): `e810467b` -> `3006d286`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -202,11 +202,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1680875433,
-        "narHash": "sha256-nDeicTLgNCCFbKiYJosgvNSfiU/bBAQWx5XRxIF9oeQ=",
+        "lastModified": 1680876084,
+        "narHash": "sha256-eP9yxP0wc7XuVaODugh+ajgbFGaile2O1ihxiLxOuvU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e810467b0f6cab50d764f016f0e18881370cc2ae",
+        "rev": "3006d2860a6ed5e01b0c3e7ffb730e9b293116e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                              |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`9dbe8dea`](https://github.com/NixOS/nixos-hardware/commit/9dbe8dea5fee7180991f4a65d1a5876422f33681) | `` Add condition for kernel version 6.2 and above `` |
| [`5fc0f235`](https://github.com/NixOS/nixos-hardware/commit/5fc0f2352069cadea929afe201532b8673488ab3) | `` Add module import to flake ``                     |
| [`5d475533`](https://github.com/NixOS/nixos-hardware/commit/5d4755338109a5c6600650a7246b267bf7e2ea11) | `` Remove unnecessary mkMerge ``                     |
| [`70a8ff0a`](https://github.com/NixOS/nixos-hardware/commit/70a8ff0a2511c300a7ab4dc8a9ab03328d52da5a) | `` Add settings for AMD Raphael iGPU ``              |