### PR TITLE
chore(flake/flake-utils): `946da791` -> `033b9f25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -107,12 +107,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1680946745,
-        "narHash": "sha256-KqGlwg9UTDsFBZZB8wzXgMnc8XQm95LtSbFvBsnqkPI=",
+        "lastModified": 1681037374,
+        "narHash": "sha256-XL6X3VGbEFJZDUouv2xpKg2Aljzu/etPLv5e1FPt1q0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "946da791763db1c306b86a8bd3828bf5814a1247",
+        "rev": "033b9f258ca96a10e543d4442071f614dc3f8412",
         "type": "github"
       },
       "original": {
@@ -369,6 +372,21 @@
       "original": {
         "owner": "danth",
         "repo": "stylix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     },


### PR DESCRIPTION
| Commit                                                                                               | Message                                                    |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`033b9f25`](https://github.com/numtide/flake-utils/commit/033b9f258ca96a10e543d4442071f614dc3f8412) | `` clean flake check warnings ``                           |
| [`2f02e38d`](https://github.com/numtide/flake-utils/commit/2f02e38dfa6cf8afb4d830aad171d8d7cf100c06) | `` update allSystems.nix ``                                |
| [`575419ad`](https://github.com/numtide/flake-utils/commit/575419ad23de2f2886a3905163a29b854793338d) | `` split out allSystems.nix ``                             |
| [`471aed54`](https://github.com/numtide/flake-utils/commit/471aed544aef9c610ea465cddf4a39c358ac5aa8) | `` fixup! introduce externally extensible systems (#93) `` |
| [`1c226cc8`](https://github.com/numtide/flake-utils/commit/1c226cc8c6562379ffd0ac36ca095396250d94d7) | `` introduce externally extensible systems (#93) ``        |
| [`13faa43c`](https://github.com/numtide/flake-utils/commit/13faa43c34c0c943585532dacbb457007416d50b) | `` Use less confusing syntax (#85) ``                      |