### PR TITLE
chore(flake/nixpkgs): `d9f759f2` -> `fd531dee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -220,11 +220,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680945546,
-        "narHash": "sha256-8FuaH5t/aVi/pR1XxnF0qi4WwMYC+YxlfdsA0V+TEuQ=",
+        "lastModified": 1681036984,
+        "narHash": "sha256-AbScJXshYzbeUKHh+Y3OICc3iAtr+NqJ3Xb81GW+ptU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d9f759f2ea8d265d974a6e1259bd510ac5844c5d",
+        "rev": "fd531dee22c9a3d4336cc2da39e8dd905e8f3de4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
| [`f9adb566`](https://github.com/NixOS/nixpkgs/commit/f9adb566707a492bd3d17fee1e223695d939b52a) | `` ocamlPackages.hpack: 0.9.0 → 0.10.0 (#225270) ``                                                    |
| [`7f8f94d0`](https://github.com/NixOS/nixpkgs/commit/7f8f94d0a7b75257828bef4a385b4e5e078ef767) | `` smartgithg: 22.1.4 -> 22.1.5 ``                                                                     |
| [`bfb7a581`](https://github.com/NixOS/nixpkgs/commit/bfb7a581c85a74bffca2f459e698a07fa8a3c987) | `` xray: fix GUI compatibility ``                                                                      |
| [`08078f6a`](https://github.com/NixOS/nixpkgs/commit/08078f6ab7b2136ad81bf2df54b3b9139f5cad0f) | `` irrlichtmt: 1.9.0mt8 -> 1.9.0mt10 ``                                                                |
| [`a2d13a68`](https://github.com/NixOS/nixpkgs/commit/a2d13a6801ecf2c0ee783717f247f7e8a0ec7a55) | `` fwupd: 1.8.13 -> 1.8.14 ``                                                                          |
| [`569784d5`](https://github.com/NixOS/nixpkgs/commit/569784d50be3560d211e3af2720b81ac2cc66df0) | `` minetest: 5.6.1 -> 5.7.0 ``                                                                         |
| [`d7c5b735`](https://github.com/NixOS/nixpkgs/commit/d7c5b735a09fabc7a93a669ed19d26760b3f977a) | `` maintainers: remove drzoidberg ``                                                                   |
| [`9dc15740`](https://github.com/NixOS/nixpkgs/commit/9dc1574013cf5d8529e7909d3c78fb412197e3ad) | `` nux: refactor ``                                                                                    |
| [`22940300`](https://github.com/NixOS/nixpkgs/commit/22940300fec1b4be169404422a60d3777a0c1491) | `` dwt1-shell-color-scripts: init at unstable-2023-03-27 ``                                            |
| [`f4f836e4`](https://github.com/NixOS/nixpkgs/commit/f4f836e4dee5e25cd7698045e4b37f3e747d9d4a) | `` dt-shell-color-scripts: remove ``                                                                   |
| [`8650711f`](https://github.com/NixOS/nixpkgs/commit/8650711fd81c6131ca77ec43f35e8b88d03b216a) | `` bqn386: split woff2 fonts into a separate output ``                                                 |
| [`d1d1b9d6`](https://github.com/NixOS/nixpkgs/commit/d1d1b9d6b7e3e21cd7386f1ee382b2bc530d6566) | `` apl386: init at unstable-2022-03-07 ``                                                              |
| [`dc73bd64`](https://github.com/NixOS/nixpkgs/commit/dc73bd6430dc594655488337944b64a9841bf8d8) | `` buildGo{Module,Package}: minor cleanup ``                                                           |
| [`5b49c4e3`](https://github.com/NixOS/nixpkgs/commit/5b49c4e3a2e432a87c93e360d0a1e5a45fe90517) | `` onefetch: 2.16.0 -> 2.17.0 ``                                                                       |
| [`00ae7d13`](https://github.com/NixOS/nixpkgs/commit/00ae7d13b82ae7a6827eeab42b29589e556181fc) | `` python310Packages.niaclass: init at 0.1.3 (#214734) ``                                              |
| [`4bdd70bb`](https://github.com/NixOS/nixpkgs/commit/4bdd70bbdb21ab97e376f06193b1ad0474628df4) | `` gdu: 5.22.0 -> 5.23.0 ``                                                                            |
| [`e4e00d22`](https://github.com/NixOS/nixpkgs/commit/e4e00d22bfb585a5d8abd0729c1f7ceeb2d85786) | `` nixos/hardware/ipu6: init ``                                                                        |
| [`dd33a7a9`](https://github.com/NixOS/nixpkgs/commit/dd33a7a9b9a926eca452e1f19e2945f6a59ecbc8) | `` nixos/v4l2-relayd: init ``                                                                          |
| [`608f3a18`](https://github.com/NixOS/nixpkgs/commit/608f3a1885dfb10561b4eb049d599523ffe12282) | `` cpuid: 20230228 -> 20230406 ``                                                                      |
| [`2669f6d3`](https://github.com/NixOS/nixpkgs/commit/2669f6d35402ccf898b4e5772a26ddd128203621) | `` nats-top: add changelog to meta ``                                                                  |
| [`5da97c87`](https://github.com/NixOS/nixpkgs/commit/5da97c87a82248b4cabf2e53638b63508c94de36) | `` nats-top: 0.5.3 -> 0.6.0 ``                                                                         |
| [`cb9c4a59`](https://github.com/NixOS/nixpkgs/commit/cb9c4a59f9ab153a57c8a9d1c53936020d26d7f9) | `` exploitdb: 2023-04-07 -> 2023-04-08 ``                                                              |
| [`615c0d9b`](https://github.com/NixOS/nixpkgs/commit/615c0d9b220326405fe4fccd827f0c2495041c7c) | `` v4l2-relayd: remove dependency to icamerasrc ``                                                     |
| [`4c96ce20`](https://github.com/NixOS/nixpkgs/commit/4c96ce207a1894a2f2fe65d55717e4092ac45657) | `` orchis-theme: 2023-03-18 -> 2024-04-08 ``                                                           |
| [`47cf3753`](https://github.com/NixOS/nixpkgs/commit/47cf37532515868f73eb73b8fbfdd67c7a48a1f3) | `` kiconthemes: drop merged patch ``                                                                   |
| [`6685004c`](https://github.com/NixOS/nixpkgs/commit/6685004cd5d872185df2ccb758c15809f1ca05ef) | `` libiio: fix cross compilation ``                                                                    |
| [`0981043d`](https://github.com/NixOS/nixpkgs/commit/0981043da85f5efdf5057ce52b0f30f5811987a6) | `` lyx: fix cross ``                                                                                   |
| [`584278ef`](https://github.com/NixOS/nixpkgs/commit/584278eface16359dec7839e001b80a7db7347d9) | `` noice-nvim: Remove nvim-notify from noice-nvim dependencies ``                                      |
| [`a599a94d`](https://github.com/NixOS/nixpkgs/commit/a599a94d2162217abbf8379941d5e02e3cd1ebbc) | `` kde/frameworks: 5.104 -> 5.105 ``                                                                   |
| [`398f1d6b`](https://github.com/NixOS/nixpkgs/commit/398f1d6b14f19f6e37a5b98f252cfd2566c9b7c3) | `` mozphab: 1.1.0 -> 1.4.3 ``                                                                          |
| [`993f9def`](https://github.com/NixOS/nixpkgs/commit/993f9defe1246cefae13dccf285979f5adbe8943) | `` python310Packages.immutabledict: 2.2.3 -> 2.2.4 ``                                                  |
| [`54731a8c`](https://github.com/NixOS/nixpkgs/commit/54731a8cea6d8b9d4fcb9ca7cbfc75ae1e07a171) | `` nixos/installer: update getty help message ``                                                       |
| [`bc3272f5`](https://github.com/NixOS/nixpkgs/commit/bc3272f51e3cf4433f6ffe62c8307e92c35fb997) | `` nixos/installation-device.nix: improve comment about ssh login ``                                   |
| [`aeb3a380`](https://github.com/NixOS/nixpkgs/commit/aeb3a380ccef9e3b38738fa2bade8b98a362a7b1) | `` tree-sitter: 0.20.7 -> 0.20.8 ``                                                                    |
| [`5c04ea5c`](https://github.com/NixOS/nixpkgs/commit/5c04ea5ccd3afd94125c51eddb01566a592b47fc) | `` pip-audit: 2.4.12 -> 2.5.4 (#224590) ``                                                             |
| [`ae48654b`](https://github.com/NixOS/nixpkgs/commit/ae48654bb10c274be1676c77b4c7038fdee2898e) | `` teleport_11: 11.3.5 -> 11.3.10 ``                                                                   |
| [`b87655eb`](https://github.com/NixOS/nixpkgs/commit/b87655eb5f00e55a59aa3869f913153a764d977f) | `` python310Packages.deepdiff: Add python-dateutil to checkInputs ``                                   |
| [`c81c3d2f`](https://github.com/NixOS/nixpkgs/commit/c81c3d2fcfc0f8e69c50eb66ea8682a155643de5) | `` mpd-touch-screen-gui: init at unstable-2022-12-30 ``                                                |
| [`6d79af42`](https://github.com/NixOS/nixpkgs/commit/6d79af426396a857266bf72a8694963c9c9164d1) | `` libwtk-sdl2: init at unstable-2023-02-28 ``                                                         |
| [`5b865460`](https://github.com/NixOS/nixpkgs/commit/5b86546070673909913858240f4dfda1eed2af2e) | `` python310Packages.clevercsv: Expose optional dependencies ``                                        |
| [`81c1c63b`](https://github.com/NixOS/nixpkgs/commit/81c1c63b70afeb19b32e853005636096482af56f) | `` python310Packages.clevercsv: 0.7.6 -> 0.8.0 ``                                                      |
| [`b345e08f`](https://github.com/NixOS/nixpkgs/commit/b345e08f5d02ec31687d090c1e61820476925c60) | `` python310Packages.bottle: disable timing sensitive test ``                                          |
| [`cbff37bc`](https://github.com/NixOS/nixpkgs/commit/cbff37bcbc5e006758b5db46b2a03cc3928e9f96) | `` pulumi-bin: 3.60.0 -> 3.62.0 ``                                                                     |
| [`7344ae11`](https://github.com/NixOS/nixpkgs/commit/7344ae11ab37423865c34533d317ebeb2c2feb4d) | `` fnott: add zlib license to list ``                                                                  |
| [`100d12b4`](https://github.com/NixOS/nixpkgs/commit/100d12b4867272ed1a0c7c9e0ec0c3fe128e1abc) | `` cloud-hypervisor: 30.0 -> 31.0 ``                                                                   |
| [`38da9961`](https://github.com/NixOS/nixpkgs/commit/38da99614344a1e3964aaee85ea3aad7f68d6109) | `` hyprwm: update packages ``                                                                          |
| [`a360e21d`](https://github.com/NixOS/nixpkgs/commit/a360e21d11d5f96099a412605b4b8282f1fe5c91) | `` conceal: init at 0.3.2 ``                                                                           |
| [`3472b48f`](https://github.com/NixOS/nixpkgs/commit/3472b48fe67e1c51f508dfcad560f395ab39a3a2) | `` chromiumDev: 113.0.5672.24 -> 114.0.5696.0 ``                                                       |
| [`55fbe3d7`](https://github.com/NixOS/nixpkgs/commit/55fbe3d799155a45663b8cc616f3e610d3a6fc32) | `` chromiumBeta: 112.0.5615.49 -> 113.0.5672.24 ``                                                     |
| [`2741fe2a`](https://github.com/NixOS/nixpkgs/commit/2741fe2ac110e33b9fd1b7713998a4dfe5dbae22) | `` fluffychat: fix version number on package search ``                                                 |
| [`984e27cd`](https://github.com/NixOS/nixpkgs/commit/984e27cd84672b1c9cbdabc3c88bea1e08acfbcf) | `` fluffychat: fix encryption ``                                                                       |
| [`4f255d1d`](https://github.com/NixOS/nixpkgs/commit/4f255d1d045b20267f9e391a3b733d043c4d637f) | `` goawk: 1.21.0 -> 1.22.0 ``                                                                          |
| [`5b6baa6c`](https://github.com/NixOS/nixpkgs/commit/5b6baa6c8c763735a630854e3a0a360712ab6216) | `` trino-cli: 410 -> 412 ``                                                                            |
| [`09462c7f`](https://github.com/NixOS/nixpkgs/commit/09462c7f66f51d172955e6cee70a58f697979f41) | `` rustdesk: fix build ``                                                                              |
| [`9db789fd`](https://github.com/NixOS/nixpkgs/commit/9db789fd83bd06cf3d98e025952e5e428934d306) | `` v2ray-domain-list-community: 20230320093818 -> 20230407083123 ``                                    |
| [`e52b753d`](https://github.com/NixOS/nixpkgs/commit/e52b753d2c2539cbbc4bbad5fc43d796b5e9d63c) | `` v2ray-geoip: 202303272340 -> 202304060040 ``                                                        |
| [`b8858b7f`](https://github.com/NixOS/nixpkgs/commit/b8858b7f78077f9c2c44264341f876ebf7c5380a) | `` dotnet-sdk_8: 8.0.100-preview.1.23115.2 -> 8.0.100-preview.2.23157.25 ``                            |
| [`d0242fd7`](https://github.com/NixOS/nixpkgs/commit/d0242fd7fe1a26a9909d951c2d5d79533c5f215d) | `` discordo: init at unstable-2023-03-07 ``                                                            |
| [`cc46277b`](https://github.com/NixOS/nixpkgs/commit/cc46277bf587e589d345a849d48f02b55ae8de6c) | `` nixos/minipro: init ``                                                                              |
| [`abebf789`](https://github.com/NixOS/nixpkgs/commit/abebf789a3131d9527a497b326f09e0f12cf827d) | `` rapidfuzz-cpp: inherit default `doCheck` instead of setting it explicitly ``                        |
| [`9071d06d`](https://github.com/NixOS/nixpkgs/commit/9071d06d01ed34c80c97d44de879da93e98512fb) | `` abcl: follow up fixes for #223317 ``                                                                |
| [`1c366b6a`](https://github.com/NixOS/nixpkgs/commit/1c366b6a3f1d4927d76ca794fedf709e224363a2) | `` python310Packages.inflect: 6.0.2 -> 6.0.4 ``                                                        |
| [`632cff6f`](https://github.com/NixOS/nixpkgs/commit/632cff6fcef0895202515d875dc89cc41fc14a8c) | `` python3Packages.openai-triton: justify the use of pkgsTargetTarget ``                               |
| [`24d20fef`](https://github.com/NixOS/nixpkgs/commit/24d20fefbf967ce83126098a1c788ca9866c4570) | `` python3Packages.openai-triton: inline bash comments ``                                             |
| [`91f24957`](https://github.com/NixOS/nixpkgs/commit/91f24957262e76a6cff959ce49867703349d839d) | `` ocamlPackages.torch: patch for pytorch 2.0.0 compatibility ``                                       |
| [`9b5fb183`](https://github.com/NixOS/nixpkgs/commit/9b5fb1838d85f74a4c7f5b2362cec1570ba682e3) | `` python3Packages.torchinfo: fix pythonImportsCheck ``                                                |
| [`455d23b9`](https://github.com/NixOS/nixpkgs/commit/455d23b95d67f1774a59eabdbaafa9650ca2f61f) | `` python3Packages.torchinfo: 1.64 -> 1.7.2 ``                                                         |
| [`5e8008a5`](https://github.com/NixOS/nixpkgs/commit/5e8008a536aeb17f3b90a9926e59d217591697e7) | `` python3Packages.torchWithCuda: avoid "unknown-warning" when building with cuda-compatible stdenv `` |
| [`378c0c69`](https://github.com/NixOS/nixpkgs/commit/378c0c69832c350f672a21128b5d2782a29c2d6e) | `` python3Packages.openai-triton: init at 2.0.0 ``                                                     |
| [`0f76efb4`](https://github.com/NixOS/nixpkgs/commit/0f76efb48143e4f38f7714588e3cb38d055404b2) | `` python3Packages.torchWithRocm: ignore config.cudaSupport ``                                         |
| [`a9faf1b9`](https://github.com/NixOS/nixpkgs/commit/a9faf1b9efee58458e0174e696471a7db3ff97ed) | `` python3Packages.torch: add missing install_requires ``                                              |
| [`09d5d6b1`](https://github.com/NixOS/nixpkgs/commit/09d5d6b198a6af9bdab0ee5c211a459070f71b88) | `` python3Packages.torch: 1.13.1 -> 2.0.0 ``                                                           |
| [`3fdb0346`](https://github.com/NixOS/nixpkgs/commit/3fdb0346d778334c44a36e7d371df5dcec832c61) | `` phpactor: init at 2023.01.21 ``                                                                     |
| [`c8131513`](https://github.com/NixOS/nixpkgs/commit/c8131513026841e21253f65d24a74e699afeef5f) | `` fnott: 1.3.0 -> 1.4.0 ``                                                                            |
| [`da787e09`](https://github.com/NixOS/nixpkgs/commit/da787e098958ba15700fa96c24d2ab84f753f00f) | `` oracle-instantclient: 19.3.0.0.0 -> 19.8.0.0.0 (x86_64-darwin) ``                                   |
| [`fcc5bc2a`](https://github.com/NixOS/nixpkgs/commit/fcc5bc2af4cb45e47ab7fc05d65016754707f4e0) | `` oracle-instantclient: 19.16.0.0.0 -> 21.9.0.0.0 (x86_64-linux) ``                                   |
| [`4fc3e2c4`](https://github.com/NixOS/nixpkgs/commit/4fc3e2c4aa4a703e61e2f32d17616c071b8b5348) | `` python310Packages.yasi: don't mix python versions ``                                                |
| [`383737d5`](https://github.com/NixOS/nixpkgs/commit/383737d5456a9423042833a317f4a09f41946120) | `` python310Packages.calysto: don't mix python versions ``                                             |
| [`49dfd62e`](https://github.com/NixOS/nixpkgs/commit/49dfd62eb6e2fca97160dd81334d8bec125525a3) | `` python310Packages.calysto-scheme: don't mix python versions ``                                      |
| [`0e8dc8b1`](https://github.com/NixOS/nixpkgs/commit/0e8dc8b10b501a625d22e355b7ec455bedd257f8) | `` sqlfluff: 2.0.2 -> 2.0.3 ``                                                                         |
| [`bddff587`](https://github.com/NixOS/nixpkgs/commit/bddff58799c11c7f52684022c4c012eeb5ddc355) | `` python3.pkgs.django-payments: init at 2.0.0 ``                                                      |
| [`ea0fe11a`](https://github.com/NixOS/nixpkgs/commit/ea0fe11aea5b14dce8838f58c8381e0dc4c8d75d) | `` python3.pkgs.mercadopago: init at 2.2.0 ``                                                          |
| [`373e52bc`](https://github.com/NixOS/nixpkgs/commit/373e52bcfe59d8d1aef4ec72c184930a81605e45) | `` python310Packages.django-phonenumber-field: add optional-dependencies, move babel to tests ``       |
| [`4bc8335b`](https://github.com/NixOS/nixpkgs/commit/4bc8335bb4e33456284682459fe15c4dbdd5bcaf) | `` maintainers: add derdennisop ``                                                                     |
| [`cf6c8c55`](https://github.com/NixOS/nixpkgs/commit/cf6c8c5501feed7c446a0ccabab5565988491810) | `` python3Packages.xmldiff: 2.5 -> 2.6.1 ``                                                            |
| [`8ddb5204`](https://github.com/NixOS/nixpkgs/commit/8ddb5204bc8c3b2eedd5268e392ae2970e0f6498) | `` dfilemanager: unstable-2020-09-04 -> unstable-2021-02-20 ``                                         |
| [`00afa18a`](https://github.com/NixOS/nixpkgs/commit/00afa18aff64de113ade8c70bb4e85def296b387) | `` partition-manager: add indication for the nix option ``                                             |
| [`136e3dbd`](https://github.com/NixOS/nixpkgs/commit/136e3dbdae827ca91aa5559f9edbce5191ded602) | `` docker: add pointer to related nix option ``                                                        |
| [`ee61271b`](https://github.com/NixOS/nixpkgs/commit/ee61271b2f249e1b434f4691cf44a528e7e6ce52) | `` gcsfuse: 0.41.12 -> 0.42.3 ``                                                                       |
| [`b4ef4bca`](https://github.com/NixOS/nixpkgs/commit/b4ef4bca0e2ce77f663ac6616c6e450dd1e26ffd) | `` python310Packages.vallox-websocket-api: 3.1.0 -> 3.2.1 ``                                           |
| [`9c82fd29`](https://github.com/NixOS/nixpkgs/commit/9c82fd294f2488c59388bd40e95c974723bc6e41) | `` brave: 1.49.128 -> 1.50.114 ``                                                                      |
| [`816045aa`](https://github.com/NixOS/nixpkgs/commit/816045aabcc7f60b25970008b34cb1c966febf9d) | `` millet: 0.8.7 -> 0.8.8 ``                                                                           |
| [`9fc1b4db`](https://github.com/NixOS/nixpkgs/commit/9fc1b4dbfbc4c4627a974d6aaa47f52317cac3f4) | `` udpreplay: 1.0.0 -> 1.1.0 ``                                                                        |
| [`837b784d`](https://github.com/NixOS/nixpkgs/commit/837b784d15c6d415cf84955b2fc4aaba55d56352) | `` binocle: 0.3.0 -> 0.3.1 ``                                                                          |
| [`3d5b7936`](https://github.com/NixOS/nixpkgs/commit/3d5b79368ae6fd5a787945f855a691c0acd952cd) | `` goeland: 0.13.0 -> 0.14.0 ``                                                                        |
| [`63c7ecba`](https://github.com/NixOS/nixpkgs/commit/63c7ecbafb6b0679fd5fbdb136f9d9f4d0d976a7) | `` traefik: 2.9.9 -> 2.9.10 ``                                                                         |
| [`68b4014b`](https://github.com/NixOS/nixpkgs/commit/68b4014b6508c4b1555eae7191509fea1218e7e6) | `` tauon: 7.6.2 -> 7.6.3 ``                                                                            |
| [`bcd2d49d`](https://github.com/NixOS/nixpkgs/commit/bcd2d49d8512a8530def8fe999d6183e0fff3f09) | `` nixos: Make services.resolved discoverable via "systemd-resolved" search ``                         |
| [`579b812b`](https://github.com/NixOS/nixpkgs/commit/579b812b0e0395d10aa55507e2f6c2e0763fb565) | `` https://github.com/NixOS/nixpkgs/pull/224893#pullrequestreview-1375521876 ``                        |
| [`482b61e1`](https://github.com/NixOS/nixpkgs/commit/482b61e1423f264279bb321b8d8c93fb766d4927) | `` default-crate-overrides.nix: prevent `git fetch` ``                                                 |
| [`0d7295ad`](https://github.com/NixOS/nixpkgs/commit/0d7295ade22f125bfd5e40687e665bb664a7cfb9) | `` vscode-extensions.devsense.profiler-php-vscode: init at 1.33.12924 ``                               |
| [`ec5d68c9`](https://github.com/NixOS/nixpkgs/commit/ec5d68c93a83bb26b60dd396dd22a66707b1cba5) | `` vscode-extensions.devsense.phptools-vscode: init at 1.33.12924 ``                                   |
| [`0150df8d`](https://github.com/NixOS/nixpkgs/commit/0150df8d513f97cc85cdff47d025339d580ded20) | `` vscode-extensions.devsense.composer-php-code: init at 1.33.12924 ``                                 |
| [`7d574da9`](https://github.com/NixOS/nixpkgs/commit/7d574da9c96af0c08e6b70d004b9c9d87818939b) | `` rbspy: 0.16.0 -> 0.17.0 ``                                                                          |
| [`c37fcd89`](https://github.com/NixOS/nixpkgs/commit/c37fcd89275ae42917f5f5dac0a667d094104955) | `` ungoogled-chromium: 111.0.5563.147 -> 112.0.5615.50 ``                                              |
| [`9ee68d48`](https://github.com/NixOS/nixpkgs/commit/9ee68d484a442c6f79d5f0e077fc3b644008b06f) | `` deepin.dde-daemon: init at 5.14.122 ``                                                              |
| [`cd15ccf8`](https://github.com/NixOS/nixpkgs/commit/cd15ccf8d0b9e569ea79ce157f4c2d1ede58bf3e) | `` deepin.dde-network-core: init at 1.1.8 ``                                                           |
| [`0c8b3d42`](https://github.com/NixOS/nixpkgs/commit/0c8b3d428520c7bf7ecaf1d374f5e47f56266c0f) | `` deepin.dde-session-ui: init at 5.6.2 ``                                                             |
| [`6ee20da0`](https://github.com/NixOS/nixpkgs/commit/6ee20da0650c7343a576ac7caac4fc34b9246a28) | `` deepin.dde-session-shell: init at 5.6.4 ``                                                          |
| [`b48842d5`](https://github.com/NixOS/nixpkgs/commit/b48842d5071e93fa3e16302baaa3d7cbffa14b18) | `` deepin.dde-app-services: init at 0.0.20 ``                                                          |
| [`920be30f`](https://github.com/NixOS/nixpkgs/commit/920be30f437f5687bbe7d34f201185f90c0721e9) | `` principia: init at unstable-2023-03-21 ``                                                           |
| [`43fa3347`](https://github.com/NixOS/nixpkgs/commit/43fa3347164a954ea933b81bb722384eda94a415) | `` deepin.dde-clipboard: init at 5.4.25 ``                                                             |
| [`ec1ecba2`](https://github.com/NixOS/nixpkgs/commit/ec1ecba26a6b8065fe5d931e51df40914d801995) | `` deepin.dde-launcher: init at 5.6.1 ``                                                               |
| [`082ee207`](https://github.com/NixOS/nixpkgs/commit/082ee207f13c27b3b9e6a35fa3d1631e127580c5) | `` deepin.dde-dock: init at 5.5.81 ``                                                                  |
| [`f4d36c53`](https://github.com/NixOS/nixpkgs/commit/f4d36c53a711a5e0096b567928366a9b8b33bfe6) | `` interactsh: 1.1.0 -> 1.1.2 ``                                                                       |
| [`9f1a1b93`](https://github.com/NixOS/nixpkgs/commit/9f1a1b9373cb1fe754bbcd318a1789ec1f691398) | `` forgejo: 1.19.0-2 -> 1.19.0-3 ``                                                                    |
| [`0dd0b210`](https://github.com/NixOS/nixpkgs/commit/0dd0b2103a25d2068462895faa852d535666a977) | `` forgejo: use "predictable URLs" as src ``                                                           |
| [`64953434`](https://github.com/NixOS/nixpkgs/commit/64953434f2a34fa81f71989a1187e63a4ea0dbae) | `` matcha-gtk-theme: 2022-11-15 -> 2023-04-03 ``                                                       |
| [`8be794b1`](https://github.com/NixOS/nixpkgs/commit/8be794b197fd5e9146aeb2903044121f362b70fe) | `` nginx: sha256 -> hash ``                                                                            |
| [`b7cb7432`](https://github.com/NixOS/nixpkgs/commit/b7cb74322c663479e5b2382bd88978a5e61b59a1) | `` fetchhg: allow specifying (sri) hash ``                                                             |
| [`9554582b`](https://github.com/NixOS/nixpkgs/commit/9554582b341104529ffc8baaaa8955635636420e) | `` nginxMainline: 1.23.3 -> 1.23.4 ``                                                                  |
| [`7ec7922b`](https://github.com/NixOS/nixpkgs/commit/7ec7922b04f6775b2fb3416fd85cea26e7480f81) | `` nixos/tests/nginx: update test script ``                                                            |
| [`31cb9b08`](https://github.com/NixOS/nixpkgs/commit/31cb9b08409ea3d4c0fc0eaaaa2af600bc8eb9fa) | `` ntopng: 5.2.1 -> 5.6 ``                                                                             |
| [`0d88b0da`](https://github.com/NixOS/nixpkgs/commit/0d88b0dac68abc0e9ebc4fb36a6fecbe818d3c5f) | `` ntopng: add changelog to meta ``                                                                    |
| [`a9c29a7a`](https://github.com/NixOS/nixpkgs/commit/a9c29a7af72e8f7ea1f193a52d60431a9a1aed09) | `` ndpi: 4.2 -> 4.6 ``                                                                                 |
| [`26773687`](https://github.com/NixOS/nixpkgs/commit/26773687e155a68ecafb8a333a660f7e339347ce) | `` ndpi: add changelog to meta ``                                                                      |
| [`0f57b4bd`](https://github.com/NixOS/nixpkgs/commit/0f57b4bd736cbb3237e2b221d4fcbb742d24b527) | `` fetchMavenArtifact: deprecate phases & use pname+version ``                                         |
| [`9435abca`](https://github.com/NixOS/nixpkgs/commit/9435abcaee6e68ba746deef96bde5846e0abe46e) | `` Expose the buildTensorRTPackage function. ``                                                        |
| [`80d3f484`](https://github.com/NixOS/nixpkgs/commit/80d3f4849cb34004b8eb6536b561552092e1304e) | `` maintainers: add arian-d ``                                                                         |
| [`b639a8c6`](https://github.com/NixOS/nixpkgs/commit/b639a8c6a6d02c2694318c1e8841f83388ebc6c5) | `` qt6.qtdeclarative: build qmlls ``                                                                   |