### PR TITLE
chore(flake/flake-utils): `033b9f25` -> `cfacdce0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -111,11 +111,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681037374,
-        "narHash": "sha256-XL6X3VGbEFJZDUouv2xpKg2Aljzu/etPLv5e1FPt1q0=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "033b9f258ca96a10e543d4442071f614dc3f8412",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                               |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`cfacdce0`](https://github.com/numtide/flake-utils/commit/cfacdce06f30d2b68473a46042957675eebb3401) | `` REAMDE: document the systems pattern a bit more `` |