### PR TITLE
chore(flake/pre-commit-hooks): `2144d9dd` -> `a0e9703a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -265,11 +265,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1680981441,
-        "narHash": "sha256-Tqr2mCVssUVp1ZXXMpgYs9+ZonaWrZGPGltJz94FYi4=",
+        "lastModified": 1681206676,
+        "narHash": "sha256-6hQR0fSJ22BSV1XpjyxYur/MPab6gn3aI/l8qEpwNHk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "2144d9ddcb550d6dce64a2b44facdc8c5ea2e28a",
+        "rev": "a0e9703a95342d1dba4ba0d989b2e0b429d42516",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                             |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
| [`376c8123`](https://github.com/cachix/pre-commit-hooks.nix/commit/376c81237fbcadfda5cf40866d168ed4feb6fed6) | `` Undo back to original migration command ``                       |
| [`aa06ccf4`](https://github.com/cachix/pre-commit-hooks.nix/commit/aa06ccf4ed022ddbd143eaa98a7762083ecd1307) | `` Use --show-toplevel for reliable detection of git working dir `` |
| [`d2d0baca`](https://github.com/cachix/pre-commit-hooks.nix/commit/d2d0bacafdcd22543162b7e09be5e28bc9cbce06) | `` Force creation of symlink ``                                     |
| [`76582768`](https://github.com/cachix/pre-commit-hooks.nix/commit/76582768d899793f44527cb5efea90e694e9bc1e) | `` Generate .pre-commit-config.yaml always at git root ``           |