### PR TITLE
chore(flake/pre-commit-hooks): `a0e9703a` -> `c77e64a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -265,11 +265,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1681206676,
-        "narHash": "sha256-6hQR0fSJ22BSV1XpjyxYur/MPab6gn3aI/l8qEpwNHk=",
+        "lastModified": 1681227715,
+        "narHash": "sha256-kQZOoTa177VF5uk1JK7bA9ZTU5g6d5IuDp/6YdxUWao=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "a0e9703a95342d1dba4ba0d989b2e0b429d42516",
+        "rev": "c77e64a5adab96866ea97449a5a7a327d4629828",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                 |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------- |
| [`b7a69f02`](https://github.com/cachix/pre-commit-hooks.nix/commit/b7a69f026e654cf184ae21a50337fd4b3f073638) | `` Allow Topiary's tool to be `null` `` |
| [`f8f86427`](https://github.com/cachix/pre-commit-hooks.nix/commit/f8f864276ab3a9dc9d23c3c875ec10a77a3a1700) | `` Add a hook that uses Topiary ``      |