### PR TITLE
chore(flake/home-manager): `4e79c6a4` -> `6e57fc47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681162249,
-        "narHash": "sha256-jh5fLaTxR5XowXA0CN/1Gs2qbvVdmdPCSeO424XWZLI=",
+        "lastModified": 1681245941,
+        "narHash": "sha256-RgFsg7+GRPzarip2zdhXUvc5T950BgCoqGYTFTHC/30=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4e79c6a414ce59fd1a53ab77899c77ab87774e6b",
+        "rev": "6e57fc470508ae65caf59b8de391cdaafc88b1de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`6e57fc47`](https://github.com/nix-community/home-manager/commit/6e57fc470508ae65caf59b8de391cdaafc88b1de) | `` home-manager: add some i18n context ``                   |
| [`013948dd`](https://github.com/nix-community/home-manager/commit/013948ddf6576bbc02629e9b78e87b1364cd3dcf) | `` home-cursor: follow xdg spec for icons folder (#3851) `` |