### PR TITLE
chore(flake/nixpkgs): `db24d86d` -> `3fb8eedc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -220,11 +220,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681126633,
-        "narHash": "sha256-evQ3Ct/yJDSHej16Hiq+JfxRjgm9FXu/2LBxsyorGdE=",
+        "lastModified": 1681217261,
+        "narHash": "sha256-RbxCHWN3Vhyv/WEsXcJlDwF7bpvZ9NxDjfSouQxXEKo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "db24d86dd8a4769c50d6b7295e81aa280cd93f35",
+        "rev": "3fb8eedc450286d5092e4953118212fa21091b3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                  |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`853a90c2`](https://github.com/NixOS/nixpkgs/commit/853a90c2d7fd88fe3d1c740df87f7397cef96cfb) | `` fabs: Don't use alias for python-dateutil ``                          |
| [`fdb17390`](https://github.com/NixOS/nixpkgs/commit/fdb1739028a504698afe268e06b755deb55e0f7b) | `` python310Packages.aioesphomeapi: 13.6.1 -> 13.7.0 ``                  |
| [`4ace88d6`](https://github.com/NixOS/nixpkgs/commit/4ace88d63b14ef62f24d26c984775edc2ab1737c) | `` python38Packages.meson: fix build with libxcrypt ``                   |
| [`9f0e1b60`](https://github.com/NixOS/nixpkgs/commit/9f0e1b6047166ff331bea1d7f498794a15833c6d) | `` modules.openafsServer: Add FABS backup server ``                      |
| [`e86e7eb4`](https://github.com/NixOS/nixpkgs/commit/e86e7eb495bae5c482d204e2a15a09da94075e22) | `` kstart: init at 4.3 ``                                                |
| [`38b97e37`](https://github.com/NixOS/nixpkgs/commit/38b97e374d7f108b059b5662bfb5cc5cac407871) | `` fabs: init at 1.1 ``                                                  |
| [`2e0b3b91`](https://github.com/NixOS/nixpkgs/commit/2e0b3b9162630f4b1d9ef62858d6623beb85a527) | `` woob: 3.4->3.5 ``                                                     |
| [`3f20a4e9`](https://github.com/NixOS/nixpkgs/commit/3f20a4e9b1f4caded6e3e32b7749569ff7adfbaa) | `` akkoma-fe: 2023-02-11 -> 2023-03-11 ``                                |
| [`a70485b3`](https://github.com/NixOS/nixpkgs/commit/a70485b3bcc7c4b937fed3d36d850312b37b854d) | `` akkoma: 3.6.0 -> 3.7.1 ``                                             |
| [`3ca5d676`](https://github.com/NixOS/nixpkgs/commit/3ca5d676aa7d2d3325f252636549542e21733eb1) | `` sweet-nova: init at unstable-2023-04-02 ``                            |
| [`c0a4950b`](https://github.com/NixOS/nixpkgs/commit/c0a4950b5251d6add330f2481c10d316e5fd7f8f) | `` maintainers: add dr460nf1r3 ``                                        |
| [`209ba54b`](https://github.com/NixOS/nixpkgs/commit/209ba54b575578a5ddb82d3bddfcc187fe299691) | `` hase: init at unstable-2020-10-06 ``                                  |
| [`5325503f`](https://github.com/NixOS/nixpkgs/commit/5325503f653f8cf473a23fb970cc1af2fef56fd3) | `` sparrow3d: init at unstable-2020-10-06 ``                             |
| [`a20bec57`](https://github.com/NixOS/nixpkgs/commit/a20bec5731cb2f6e30c82e1d3954cd5aaac3d5c0) | `` senpai: homepage update ``                                            |
| [`b06412a0`](https://github.com/NixOS/nixpkgs/commit/b06412a09bb24086265ecae555cbdc3e0f573b3d) | `` senpai: unstable-2023-02-13 → 0.2.0 ``                                |
| [`065b3501`](https://github.com/NixOS/nixpkgs/commit/065b3501289fefb3a0ce924cabe17120b4070a9c) | `` lefthook: 1.3.8 -> 1.3.9 ``                                           |
| [`68652847`](https://github.com/NixOS/nixpkgs/commit/68652847ede92d63c9cf999be600e8f42d2017c7) | `` starship: 1.14.0 -> 1.14.1 ``                                         |
| [`8e1a0d0d`](https://github.com/NixOS/nixpkgs/commit/8e1a0d0d56a7652101e8e6c60a9c96e78c567435) | `` python310Packages.tables: add changelog to meta ``                    |
| [`29471a7f`](https://github.com/NixOS/nixpkgs/commit/29471a7f5de41d45db493e8bcadc5e1c20b2296e) | `` python310Packages.tables: update disabled ``                          |
| [`e4ae7515`](https://github.com/NixOS/nixpkgs/commit/e4ae75154e955ec1e7a85226ec2e376bcdbdd050) | `` tmux-weather: init at unstable-2020-02-08 ``                          |
| [`1418fa5a`](https://github.com/NixOS/nixpkgs/commit/1418fa5ae5ff9c90b4d7651b42697af12a8a94a5) | `` python310Packages.marshmallow-sqlalchemy: 0.28.2 -> 0.29.0 ``         |
| [`97c29cb8`](https://github.com/NixOS/nixpkgs/commit/97c29cb888f4eea442b7939378bd170857767bdc) | `` python3.pkgs.tables: fix build ``                                     |
| [`d64fda58`](https://github.com/NixOS/nixpkgs/commit/d64fda586217603d84853ded02255a2e484179db) | `` python310Packages.pex: 2.1.123 -> 2.1.131 ``                          |
| [`b7fba138`](https://github.com/NixOS/nixpkgs/commit/b7fba1385cac611c421563dda5044aef21eb9270) | `` python310Packages.oracledb: 1.2.2 -> 1.3.0 ``                         |
| [`520060c6`](https://github.com/NixOS/nixpkgs/commit/520060c64b76ca84ae1847fa458fcb125ab0d9ce) | `` python310Packages.libtmux: 0.21.0 -> 0.21.1 ``                        |
| [`e6027d63`](https://github.com/NixOS/nixpkgs/commit/e6027d63a1df668dbdb413027f10a34a4e5ea60f) | `` python310Packages.pytile: 2022.10.0 -> 2023.04.0 ``                   |
| [`187f6de0`](https://github.com/NixOS/nixpkgs/commit/187f6de08d267b3fce4d01d23d7007c0016f84ac) | `` elm-spa: init at 6.0.4 ``                                             |
| [`df8fa3cc`](https://github.com/NixOS/nixpkgs/commit/df8fa3cc47696c03ee0d8cf54f32e221acfc63d1) | `` chickenPackages: dontRecurseIntoAttrs ``                              |
| [`1da2695f`](https://github.com/NixOS/nixpkgs/commit/1da2695f66b5446b608be328923c46d1103d5ceb) | `` python310Packages.intreehooks: remove ``                              |
| [`1bcb788a`](https://github.com/NixOS/nixpkgs/commit/1bcb788a92890918da4fa8b05e558d0f372499f0) | `` starship: 1.13.1 -> 1.14.0 ``                                         |
| [`ac70fb75`](https://github.com/NixOS/nixpkgs/commit/ac70fb750c8ede5679d8ce2e73525309fd5a8cb1) | `` terraform-providers.tencentcloud: 1.80.1 -> 1.80.2 ``                 |
| [`cae1432c`](https://github.com/NixOS/nixpkgs/commit/cae1432c28e01b78903706f487f8773918cf039d) | `` terraform-providers.rancher2: 1.25.0 -> 2.0.0 ``                      |
| [`89c913e5`](https://github.com/NixOS/nixpkgs/commit/89c913e58c7c0584ee9d8aa6fd1c88122f0e94bb) | `` terraform-providers.ibm: 1.52.0 -> 1.52.1 ``                          |
| [`71e677d3`](https://github.com/NixOS/nixpkgs/commit/71e677d32bfa747a2492384935a02f08a0af4cd8) | `` terraform-providers.google-beta: 4.60.2 -> 4.61.0 ``                  |
| [`60b5bcbb`](https://github.com/NixOS/nixpkgs/commit/60b5bcbbc920970f74ddd0a4d1f63681fff52e1f) | `` terraform-providers.google: 4.60.2 -> 4.61.0 ``                       |
| [`657344c1`](https://github.com/NixOS/nixpkgs/commit/657344c12e70adea2e9ccb0159b7330d7ea3472e) | `` flyctl: 0.0.500 -> 0.0.509 ``                                         |
| [`f017b32e`](https://github.com/NixOS/nixpkgs/commit/f017b32eefefc38a1a76aa0a7eabe48e2b49e9e8) | `` jbang: fix meta.homepage ``                                           |
| [`85f94a09`](https://github.com/NixOS/nixpkgs/commit/85f94a09a8fbb77ae348c5a47b8b8e5df1f86eac) | `` adv_cmds: fix build on aarch64-darwin ``                              |
| [`372b4143`](https://github.com/NixOS/nixpkgs/commit/372b41433c859c901d5d9cce30f9a1cd9f2ea737) | `` python310Packages.spotipy: 2.22.1 -> 2.23.0 ``                        |
| [`4edb1697`](https://github.com/NixOS/nixpkgs/commit/4edb169739a5ac2c7673052aac1115802ff423e4) | `` circleci-cli: 0.1.25638 -> 0.1.25725 ``                               |
| [`f828f3e0`](https://github.com/NixOS/nixpkgs/commit/f828f3e06d332cb0fda9d84432ede9b81d412d4d) | `` cmark-gfm: add changelog to meta ``                                   |
| [`1256c867`](https://github.com/NixOS/nixpkgs/commit/1256c8670da0ca740224d77f5570c767ea84e26a) | `` cmark-gfm: remove outdated substituteInPlace ``                       |
| [`56339cb1`](https://github.com/NixOS/nixpkgs/commit/56339cb19c03b4560b59fada884452efae967080) | `` cmark-gfm: 0.29.0.gfm.10 -> 0.29.0.gfm.11 ``                          |
| [`539a0c70`](https://github.com/NixOS/nixpkgs/commit/539a0c7015520cd40bdb7fbe7166323b27ccfa14) | `` python310Packages.versioneer: Expose toml extra, update homepage ``   |
| [`81b7dcdf`](https://github.com/NixOS/nixpkgs/commit/81b7dcdf60981d5a986e6434e1f73fa1528ed7dd) | `` toast: 0.46.2 -> 0.47.1 ``                                            |
| [`81c751e6`](https://github.com/NixOS/nixpkgs/commit/81c751e68076ede65f1fe66a8bff5e437d964650) | `` deltachat-desktop: 1.34.5 -> 1.36.1 ``                                |
| [`4b9c4c7f`](https://github.com/NixOS/nixpkgs/commit/4b9c4c7f805d9394564664e58e25101e6c2bc22e) | `` nfpm: 2.27.1 -> 2.28.0 ``                                             |
| [`1ced7aeb`](https://github.com/NixOS/nixpkgs/commit/1ced7aeb8d72b86b45265c28b76c79643565d3af) | `` nerdctl: 1.2.0 -> 1.3.0 ``                                            |
| [`9bdc5800`](https://github.com/NixOS/nixpkgs/commit/9bdc58003708d7af43a52fbe1763c068966d3b55) | `` pulldown-cmark: init at 0.9.2 ``                                      |
| [`4f06c355`](https://github.com/NixOS/nixpkgs/commit/4f06c35547e96e7466bc56abc8b6178d7dfc9de5) | `` kubeshark: 39.4 -> 39.5 ``                                            |
| [`9ecc36c8`](https://github.com/NixOS/nixpkgs/commit/9ecc36c8895283d8f33211d32df5f7dfb5093d07) | `` jbang: 0.105.1 -> 0.106.1 ``                                          |
| [`e76c7c7a`](https://github.com/NixOS/nixpkgs/commit/e76c7c7a8ba65bca19cac0d088f7a05088364259) | `` boundary: fix build on x86_64-darwin ``                               |
| [`2f82ca18`](https://github.com/NixOS/nixpkgs/commit/2f82ca18cf6376f640b5b258dd2bb8364824a04f) | `` gitmux: 0.10.1 -> 0.10.2 ``                                           |
| [`d2fd0049`](https://github.com/NixOS/nixpkgs/commit/d2fd0049b1e2edcf5947088b2f17f9784bdd430d) | `` rust-script: 0.24.0 -> 0.25.0 ``                                      |
| [`265bcf65`](https://github.com/NixOS/nixpkgs/commit/265bcf653cc57c1e1b34262a534ec66e60e17b07) | `` buildah: 1.29.1 -> 1.30.0 ``                                          |
| [`1130a035`](https://github.com/NixOS/nixpkgs/commit/1130a0358372dc019ad6bf3c4a71b03847c448fc) | `` gfold: 4.3.2 -> 4.3.3 ``                                              |
| [`5e73ac2b`](https://github.com/NixOS/nixpkgs/commit/5e73ac2b7df267b9d9cd08b2972768f8e9af820d) | `` build(deps): bump peter-evans/create-or-update-comment from 2 to 3 `` |
| [`7a9db6ef`](https://github.com/NixOS/nixpkgs/commit/7a9db6efd792932af40fe0c4603d2e98ef66cd27) | `` build(deps): bump peter-evans/create-pull-request from 4 to 5 ``      |
| [`eb374d7b`](https://github.com/NixOS/nixpkgs/commit/eb374d7bae42d185422d7f4bbcd4ed0a5f048e10) | `` clipboard-jh: 0.3.2 -> 0.6.0 ``                                       |
| [`0f695a44`](https://github.com/NixOS/nixpkgs/commit/0f695a44a5f9512f82192f12a875a3213dbb7030) | `` mermerd: init at 0.6.1 ``                                             |
| [`1eb8bc6a`](https://github.com/NixOS/nixpkgs/commit/1eb8bc6a06631a4770d6c92315909b87d40a5152) | `` maintainers: add austin-artificial ``                                 |
| [`866fa68c`](https://github.com/NixOS/nixpkgs/commit/866fa68c4044c78ae033b2dc1227ef06b2a6cfa1) | `` kvmtool: unstable-2022-06-09 -> unstable-2023-04-06 ``                |
| [`d022acdf`](https://github.com/NixOS/nixpkgs/commit/d022acdf6e07be63529e0de2367ba4320c08815c) | `` python310Packages.sshfs: 2023.1.0 -> 2023.4.1 ``                      |
| [`c7d390ea`](https://github.com/NixOS/nixpkgs/commit/c7d390eaed41864fa7051e87b5a384207a9fe11e) | `` goreleaser: 1.16.2 -> 1.17.0 ``                                       |
| [`cd4ba717`](https://github.com/NixOS/nixpkgs/commit/cd4ba7172bcc3a458c0410e1006fb10f8bac533e) | `` mujs: fix build on darwin ``                                          |
| [`c84d9db2`](https://github.com/NixOS/nixpkgs/commit/c84d9db2894ce06ece192bfb8e69495e41cb74fb) | `` python310Packages.twitchapi: 3.9.0 -> 3.10.0 ``                       |
| [`7bb45048`](https://github.com/NixOS/nixpkgs/commit/7bb4504847e0658c02d4afacf9d264950fb2e445) | `` python310Packages.sqltrie: 0.1.0 -> 0.3.1 ``                          |
| [`7cfba70b`](https://github.com/NixOS/nixpkgs/commit/7cfba70bc4acb74037383880741e7b1c050a59d9) | `` python310Packages.reolink-aio: 0.5.11 -> 0.5.12 ``                    |
| [`246d8f37`](https://github.com/NixOS/nixpkgs/commit/246d8f37ae3cd98e6c12a11531e26c30a0353497) | `` python310Packages.peaqevcore: 15.1.1 -> 15.2.1 ``                     |
| [`d3e738d3`](https://github.com/NixOS/nixpkgs/commit/d3e738d3ddb9736cc231afea37359376748007eb) | `` python310Packages.phonenumbers: 8.13.7 -> 8.13.8 ``                   |
| [`2427b4ea`](https://github.com/NixOS/nixpkgs/commit/2427b4ea84ebad032c44be71e8d5759d47a9a6cd) | `` python310Packages.google-cloud-language: 2.9.0 -> 2.9.1 ``            |
| [`ff4a5234`](https://github.com/NixOS/nixpkgs/commit/ff4a5234da242d80a6c95bb7ce2668b299810983) | `` nixos/minipro: add to module list ``                                  |
| [`b41dbf17`](https://github.com/NixOS/nixpkgs/commit/b41dbf177a12c7846f9c1c61399d6d49b5f35a05) | `` vaultwarden: Drop rust nightly workaround ``                          |
| [`953b44aa`](https://github.com/NixOS/nixpkgs/commit/953b44aaeabf59aaa113db862f82db346f540c02) | `` mullvad: 2023.2 -> 2023.3 ``                                          |
| [`e5ce1f01`](https://github.com/NixOS/nixpkgs/commit/e5ce1f015b6c82560f5e9f4a4e034bd72b848910) | `` bun: 0.5.8 -> 0.5.9 ``                                                |
| [`256b5d26`](https://github.com/NixOS/nixpkgs/commit/256b5d26b548519d50fa055a5613b1d5c0155e96) | `` chickenPackages: fixes and mark broken ``                             |
| [`12239f61`](https://github.com/NixOS/nixpkgs/commit/12239f61f57e410a5dc2dc4c021593509ed7e368) | `` python310Packages.google-cloud-videointelligence: 2.11.0 -> 2.11.1 `` |
| [`2a559c3d`](https://github.com/NixOS/nixpkgs/commit/2a559c3d63655b541e7286d8a2fd96e25885572a) | `` python310Packages.google-cloud-container: 2.17.4 -> 2.19.0 ``         |
| [`327e5b53`](https://github.com/NixOS/nixpkgs/commit/327e5b539ae74c56a455d36a253497575ec6dd20) | `` python310Packages.google-cloud-automl: 2.11.0 -> 2.11.1 ``            |
| [`7cb9558e`](https://github.com/NixOS/nixpkgs/commit/7cb9558e7af640481bd1935d900afad380916c7c) | `` python310Packages.google-cloud-asset: 3.18.0 -> 3.19.0 ``             |
| [`3d771188`](https://github.com/NixOS/nixpkgs/commit/3d771188ce0423be0cdada83826a8eb27cf5b4e3) | `` python310Packages.google-cloud-compute: 1.10.1 -> 1.11.0 ``           |
| [`860851df`](https://github.com/NixOS/nixpkgs/commit/860851df85778efd099afc7f4e9eb845258346fa) | `` python310Packages.google-cloud-iot: 2.9.0 -> 2.9.1 ``                 |
| [`6044fb29`](https://github.com/NixOS/nixpkgs/commit/6044fb2966b0b3cc2004952b342f4029c4276349) | `` python310Packages.transmission-rpc: add changelog to meta ``          |
| [`8b604cdc`](https://github.com/NixOS/nixpkgs/commit/8b604cdc3c055225cfc93ac56d198c87bdc1cda2) | `` python310Packages.transmission-rpc: 4.1.4 -> 4.2.0 ``                 |
| [`7c24233a`](https://github.com/NixOS/nixpkgs/commit/7c24233a0c0fcee949a2298a75ca1d40eea032d4) | `` python310Packages.advantage-air: 0.4.2 -> 0.4.4 ``                    |
| [`2c29a384`](https://github.com/NixOS/nixpkgs/commit/2c29a384ee2521abf5a122b8c4991e4a30db4a28) | `` gut: init at 0.2.7 ``                                                 |
| [`19fa5ab1`](https://github.com/NixOS/nixpkgs/commit/19fa5ab1e65d11d1a53fa9b66a8508d5be9b1edc) | `` nixos/hardware/ipu6: Improve the enable description ``                |
| [`4db61062`](https://github.com/NixOS/nixpkgs/commit/4db61062ac9bea3def29b7804781d4f8877197bc) | `` prometheus-mysqld-exporter: cleanup rev variable (#225364) ``         |
| [`49581078`](https://github.com/NixOS/nixpkgs/commit/495810788b853b67146c747826493f0d76b1b6f3) | `` vimPlugins.vim-clap: 2023-04-06 -> 2023-04-02 ``                      |
| [`070cdd99`](https://github.com/NixOS/nixpkgs/commit/070cdd995124496e4fd5ca1f2607543bcdfca314) | `` google-guest-oslogin: 20230217.00 -> 20230406.02 ``                   |
| [`6f1991d8`](https://github.com/NixOS/nixpkgs/commit/6f1991d86b6967939bff8085affeb44f687ac182) | `` plasma-5: run deadnix on all files ``                                 |
| [`ad3bc85d`](https://github.com/NixOS/nixpkgs/commit/ad3bc85ddb7b228670f79934e59bc6d654eabaa7) | `` maintainers: add amz-x ``                                             |
| [`939b4f2b`](https://github.com/NixOS/nixpkgs/commit/939b4f2be9a4739083d994bd1fb781e81c9e2562) | `` vscode-extensions.nonylene.dark-molokai-theme: init at 1.0.5 ``       |
| [`dd592214`](https://github.com/NixOS/nixpkgs/commit/dd5922144e90f774253e21964f2f68d1ec548d65) | `` surge-XT: 1.0.1 -> 1.2.0 ``                                           |
| [`0a84e544`](https://github.com/NixOS/nixpkgs/commit/0a84e544f370477d9ae66dedfdcf3d386cdf2e53) | `` openai-whisper: add MayNiklas to maintainers ``                       |
| [`541a8701`](https://github.com/NixOS/nixpkgs/commit/541a8701395eef4084f76b374181b6ca85d2f2c6) | `` python310Packages.plugwise: 0.27.9 -> 0.27.10 ``                      |
| [`6bc79d41`](https://github.com/NixOS/nixpkgs/commit/6bc79d4186817d33873af8a715057ad9024c0fee) | `` python3Packages.owslib: disable two failing tests on darwin ``        |
| [`0d00fe58`](https://github.com/NixOS/nixpkgs/commit/0d00fe581796b3a9ae28393f134e272e42a22404) | `` infracost: 0.10.18 -> 0.10.19 ``                                      |
| [`79d0a181`](https://github.com/NixOS/nixpkgs/commit/79d0a1812a9ba1b57ea24714af2d3682a586b9bd) | `` openai-whisper: 20230124 -> 20230314 ``                               |
| [`5efbe970`](https://github.com/NixOS/nixpkgs/commit/5efbe9703d45fd5fa32841b7d18c46e161d011df) | `` nextcloudPackages: update ``                                          |
| [`cae9fedd`](https://github.com/NixOS/nixpkgs/commit/cae9feddd289f95daaf6baeb0b72d8d9f7740892) | `` python310Packages.duo-client: 4.7.0 -> 4.7.1 ``                       |
| [`571f2c73`](https://github.com/NixOS/nixpkgs/commit/571f2c7337ea0b31c643a541ce05f759dbd6923a) | `` python310Packages.pgspecial: 2.0.1 -> 2.1.0 ``                        |