### PR TITLE
chore(flake/nixpkgs): `3fb8eedc` -> `fe2ecaf7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -220,11 +220,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681217261,
-        "narHash": "sha256-RbxCHWN3Vhyv/WEsXcJlDwF7bpvZ9NxDjfSouQxXEKo=",
+        "lastModified": 1681303793,
+        "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3fb8eedc450286d5092e4953118212fa21091b3b",
+        "rev": "fe2ecaf706a5907b5e54d979fbde4924d84b65fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`fe2ecaf7`](https://github.com/NixOS/nixpkgs/commit/fe2ecaf706a5907b5e54d979fbde4924d84b65fc) | `` rocm-thunk: evaluate even on unsupported platforms again ``              |
| [`7486a74d`](https://github.com/NixOS/nixpkgs/commit/7486a74d9f5c3581c2db0e186d4763ff3a4ae782) | `` lisp-modules: avoid the replaced pkgs.webkitgtk_5_0 ``                   |
| [`d0bb9ed6`](https://github.com/NixOS/nixpkgs/commit/d0bb9ed674a258ef8bd6a787d8d1ad0f2164cfdd) | `` rocm-thunk: hack-fix failing to find libgcc_s.so ``                      |
| [`6b7f0fbe`](https://github.com/NixOS/nixpkgs/commit/6b7f0fbe8a3f670a046d411a335ed924bb8026db) | `` chickenPackages_5.chickenEggs.opencl: unbreak on darwin ``               |
| [`a40dfa4f`](https://github.com/NixOS/nixpkgs/commit/a40dfa4f6483a067003ca0d50324670601cb08e8) | `` chickenPackages_5.chickenEggs.allegro: Add missing deps ``               |
| [`d51f7d4e`](https://github.com/NixOS/nixpkgs/commit/d51f7d4ef773ef57cb064c192eba1433c673ba19) | `` chickenPackages_5.chickenEggs.taglib: unbreak on darwin ``               |
| [`edfb1b1d`](https://github.com/NixOS/nixpkgs/commit/edfb1b1d4f2fd0f778357b182a3496fe6053be45) | `` chicken: pass CXX_COMPILER ``                                            |
| [`72767191`](https://github.com/NixOS/nixpkgs/commit/72767191ddac3de79e458d740ac0bbfc44287724) | `` chickenPackages: pass pkg-config to more packages ``                     |
| [`cdefbd2e`](https://github.com/NixOS/nixpkgs/commit/cdefbd2eb03c0ad875f43d2a003678ff73395a82) | `` grafana: skip a test that started failing ``                             |
| [`9317e607`](https://github.com/NixOS/nixpkgs/commit/9317e60776aaf67828a5e85859344673d96858b5) | `` terraform-providers.heroku: 5.2.0 -> 5.2.1 ``                            |
| [`0cb9d80a`](https://github.com/NixOS/nixpkgs/commit/0cb9d80a54dac38d50d627ca9e1d64034b8093e6) | `` terraform-providers.random: 3.4.3 -> 3.5.0 ``                            |
| [`9161d107`](https://github.com/NixOS/nixpkgs/commit/9161d1074ce8e602293e6a7f6163282ddaec1c24) | `` terraform-providers.pagerduty: 2.12.1 -> 2.12.2 ``                       |
| [`5b5cc67e`](https://github.com/NixOS/nixpkgs/commit/5b5cc67eff9a2452670160aa3c73d363ffcddf4a) | `` terraform-providers.github: 5.21.1 -> 5.22.0 ``                          |
| [`9bf18e06`](https://github.com/NixOS/nixpkgs/commit/9bf18e069e9c5455b7759f9b6e2ee8ebedff2279) | `` llvmPackages_13.compiler-rt-libc: also apply tmp hack ``                 |
| [`42699d05`](https://github.com/NixOS/nixpkgs/commit/42699d0538617d582b39f1a522094ab5e1a8a17e) | `` python310Packages.peewee-migrate: 1.6.6 -> 1.7.1 ``                      |
| [`0dc61806`](https://github.com/NixOS/nixpkgs/commit/0dc61806f6bb84977e488cbafa6f57f29fcd75e3) | `` ocamlPackages.headache: init at 1.06 ``                                  |
| [`6deaf0e0`](https://github.com/NixOS/nixpkgs/commit/6deaf0e061be9756dededdd71128f249ef0b698d) | `` maintainers: add niols ``                                                |
| [`3ecc7b14`](https://github.com/NixOS/nixpkgs/commit/3ecc7b14844c5edb21b011af2b477c9d244b99e8) | `` nixos/gpsd: add multiple-device support for gpsd ``                      |
| [`9e37d6c9`](https://github.com/NixOS/nixpkgs/commit/9e37d6c90b49df3b65bddef1f055e274afb7f5fa) | `` thunderbird-unwrapped: 102.9.1 -> 102.10.0 ``                            |
| [`f5eed9b9`](https://github.com/NixOS/nixpkgs/commit/f5eed9b97ca6ced9683103e8af3200a4a67d6567) | `` thunderbird-bin-unwrapped: 102.8.0 -> 102.10.0 ``                        |
| [`c7075836`](https://github.com/NixOS/nixpkgs/commit/c707583645406a98df72440f5bd28f6c707db894) | `` runc: 1.1.5 -> 1.1.6 ``                                                  |
| [`ac3acd95`](https://github.com/NixOS/nixpkgs/commit/ac3acd956f730fa9870d4488c91699c8e2892a39) | `` cc-wrapper: add optional temporary hack for -B ``                        |
| [`debaa5d9`](https://github.com/NixOS/nixpkgs/commit/debaa5d9a80c95ecc4a21324ccf92d8e248bdb74) | `` trufflehog: 3.31.4 -> 3.31.5 ``                                          |
| [`a758953c`](https://github.com/NixOS/nixpkgs/commit/a758953c19b384e03a2ca724167b94c4090a97af) | `` platformio: add ncurses ``                                               |
| [`8a344794`](https://github.com/NixOS/nixpkgs/commit/8a344794fcee8b31584a060c4577a646d0eb430c) | `` python311Packages.duckduckgo-search: init 2.8.5 ``                       |
| [`03ec4a63`](https://github.com/NixOS/nixpkgs/commit/03ec4a637aaa89266c1c4139e007cfdd97bb5318) | `` deepin.dde-api: dont set PATH ``                                         |
| [`136e1d9a`](https://github.com/NixOS/nixpkgs/commit/136e1d9aa368f72bf8390eef3384fbdaf37dea04) | `` deepin(go-package): don't use replaceAll ``                              |
| [`cc37d2b9`](https://github.com/NixOS/nixpkgs/commit/cc37d2b931e9fafabb0e86bf407aa46f00e9aa64) | `` dotnet-sdk_8: 8.0.100-preview.2.23157.25 -> 8.0.100-preview.3.23178.7 `` |
| [`6dbaba45`](https://github.com/NixOS/nixpkgs/commit/6dbaba45aca77d8d8c0cd6b3d91a1f177a7696b1) | `` dotnet-sdk_7.0: 7.0.202 -> 7.0.203 ``                                    |
| [`031c6621`](https://github.com/NixOS/nixpkgs/commit/031c6621fb9004a792e4af1b5fa26d2d2f964e58) | `` dotnet-sdk_6.0 6.0.407 -> 6.0.408 ``                                     |
| [`ef5caa67`](https://github.com/NixOS/nixpkgs/commit/ef5caa6748fad30a87c68dd87c28667c71b317b9) | `` deepin(go-package): use addToSearchPath to set GOPATH ``                 |
| [`5959e9a1`](https://github.com/NixOS/nixpkgs/commit/5959e9a15defc54541707d1a01189b10a0ba4d86) | `` deepin: use file name as fetchpatch's name ``                            |
| [`d17e087d`](https://github.com/NixOS/nixpkgs/commit/d17e087daaf6dae3a72c4073b5be88580f533cfa) | `` python310Packages.webssh: 1.6.1 -> 1.6.2 ``                              |
| [`49712bf3`](https://github.com/NixOS/nixpkgs/commit/49712bf3bf003831c82b8d787092c0351be2bcf3) | `` librewolf: 111.0.1-1 -> 112.0-1 ``                                       |
| [`6d6c4016`](https://github.com/NixOS/nixpkgs/commit/6d6c4016f224ae9032d690b8639ca81d3dbd7453) | `` palemoon-bin: Add version test ``                                        |
| [`71a153a6`](https://github.com/NixOS/nixpkgs/commit/71a153a69fde58afebe39ce0d287030570ee471e) | `` palemoon-bin: 32.0.1 -> 32.1.0 ``                                        |
| [`718abd31`](https://github.com/NixOS/nixpkgs/commit/718abd311cf3eeb52603a63e12445306d791fd9a) | `` sequoia: 0.27.0 -> 0.28.0 ``                                             |
| [`c581a52a`](https://github.com/NixOS/nixpkgs/commit/c581a52a41b028bf9c994f2e1ad719c643ce8965) | `` go-musicfox: 4.0.0 -> 4.0.1 ``                                           |
| [`5f711122`](https://github.com/NixOS/nixpkgs/commit/5f711122351dbbf27ddfc0676517870968e81ab7) | `` firecracker: 1.1.3 -> 1.3.1 ``                                           |
| [`36fbc69d`](https://github.com/NixOS/nixpkgs/commit/36fbc69d4143c31cde686ed15c5002a8e2353dc0) | `` hub: unstable-2022-04-04 -> unstable-2022-12-01 ``                       |
| [`ed0a9877`](https://github.com/NixOS/nixpkgs/commit/ed0a9877559a5ff1949067b0ae5f9a7a70d80f9e) | `` hd-idle: 1.17 -> 1.20 ``                                                 |
| [`e3702c07`](https://github.com/NixOS/nixpkgs/commit/e3702c078896999b5d763452d3738baca569234b) | `` nixos/dhcpd: warn of pending removal ``                                  |
| [`8fb5d438`](https://github.com/NixOS/nixpkgs/commit/8fb5d438e2eb97f2d985e889fab07fb95ee5a427) | `` cc2538-bsl: init at unstable-2022-08-03 (#221394) ``                     |
| [`445ef29d`](https://github.com/NixOS/nixpkgs/commit/445ef29db8212912ef8f4e83258171e357d234e5) | `` typst: 0.1.0 -> 0.2.0 ``                                                 |
| [`6c108c5a`](https://github.com/NixOS/nixpkgs/commit/6c108c5a7208cf26c5b1048ce6f7b82f1a10b22c) | `` ferretdb: 0.9.4 -> 1.0.0 (#225792) ``                                    |
| [`d02debc0`](https://github.com/NixOS/nixpkgs/commit/d02debc0fab3d870b34d987260850d59e485c856) | `` python310Packages.pythonegardia: 1.0.51 -> 1.0.52 ``                     |
| [`e7c6a07d`](https://github.com/NixOS/nixpkgs/commit/e7c6a07d2558c31cdf167103997ac3c8ba5bbcbc) | `` gnomecast: 1.9.11 -> unstable-2022-04-23 (#180342) ``                    |
| [`c347bd62`](https://github.com/NixOS/nixpkgs/commit/c347bd62a16ba88322be96cf733f7c49d7988afc) | `` noto-fonts: switch to variable fonts and remove noto-font-extra ``       |
| [`56efef44`](https://github.com/NixOS/nixpkgs/commit/56efef44662c3ab3e81dc6ee0dfb4f29f09156e7) | `` python310Packages.shtab: 1.6.0 -> 1.6.1 ``                               |
| [`7499ef8c`](https://github.com/NixOS/nixpkgs/commit/7499ef8c672553f507e5ae95b47851a378c776fb) | `` metasploit: 6.3.9 -> 6.3.11 ``                                           |
| [`7972af8e`](https://github.com/NixOS/nixpkgs/commit/7972af8ea07813a472713b8e7f003b2bed7aef69) | `` python310Packages.angr: 9.2.45 -> 9.2.46 ``                              |
| [`74a4dd20`](https://github.com/NixOS/nixpkgs/commit/74a4dd20ec51f2b14a8c81998db9a6524204fb46) | `` python310Packages.cle: 9.2.45 -> 9.2.46 ``                               |
| [`311b1041`](https://github.com/NixOS/nixpkgs/commit/311b10412bf480f3fc35819575b0c26f4b1e5a1b) | `` python310Packages.claripy: 9.2.45 -> 9.2.46 ``                           |
| [`fcee22c7`](https://github.com/NixOS/nixpkgs/commit/fcee22c7e005d3a4b491b2d97b6676d1c758831b) | `` python310Packages.pyvex: 9.2.45 -> 9.2.46 ``                             |
| [`da26a3b6`](https://github.com/NixOS/nixpkgs/commit/da26a3b6cb20ed76f001c749cafba88e2bd7e449) | `` python310Packages.ailment: 9.2.45 -> 9.2.46 ``                           |
| [`b0f06399`](https://github.com/NixOS/nixpkgs/commit/b0f06399bd16c1106c687a60f75611cda637402e) | `` python310Packages.archinfo: 9.2.45 -> 9.2.46 ``                          |
| [`b2a38e68`](https://github.com/NixOS/nixpkgs/commit/b2a38e68e1746038cac34cdedbc5c6860d137132) | `` standardnotes: 3.150.7 -> 3.150.45 ``                                    |
| [`8cbf65ec`](https://github.com/NixOS/nixpkgs/commit/8cbf65ece948ad3f98118b4fd10d8657d61450b8) | `` Fix typo in coding-conventions.chapter.md ``                             |
| [`870c0f95`](https://github.com/NixOS/nixpkgs/commit/870c0f95fb4e122b97f3f0de904f1c5e8cf5874a) | `` gitsign: add passthru.tests.version ``                                   |
| [`feb19d86`](https://github.com/NixOS/nixpkgs/commit/feb19d8697fffee8bd7b6d807dd0d5d46d1326de) | `` gitsign: 0.4.1 -> 0.6.0 ``                                               |
| [`9adf8373`](https://github.com/NixOS/nixpkgs/commit/9adf83737fe850f99c1b1a50cfe477248926c504) | `` stdenvAdapters: fix preservation of env ``                               |
| [`3c59da4b`](https://github.com/NixOS/nixpkgs/commit/3c59da4b6dea9db1b6da0202970ad8ff76291a60) | `` vimPlugins.sniprun: fix missing documentation ``                         |
| [`2ed32c48`](https://github.com/NixOS/nixpkgs/commit/2ed32c48a55086934bc3b1f0427a9d1dc5bbe3b2) | `` primecount: 7.7 -> 7.8 ``                                                |
| [`4d241881`](https://github.com/NixOS/nixpkgs/commit/4d24188185ea32b915235189ef0ac724739a597d) | `` vimPlugins.sniprun: 1.2.13 -> 1.3.0 ``                                   |
| [`832587fd`](https://github.com/NixOS/nixpkgs/commit/832587fd0e5c22b974768da9ba435613e58507d5) | `` jwasm: 2.16 -> 2.17 ``                                                   |
| [`17014b08`](https://github.com/NixOS/nixpkgs/commit/17014b0886a2eb420c74f62fb6bb7fcc75f188f3) | `` doublecmd: 1.0.10 -> 1.0.11 ``                                           |
| [`65a1084e`](https://github.com/NixOS/nixpkgs/commit/65a1084e4119badb1c4c1f2f24dca1b6d952fda8) | `` openttd-jgrpp: 0.50.2 -> 0.52.1 ``                                       |
| [`7f5eaf18`](https://github.com/NixOS/nixpkgs/commit/7f5eaf18d48a0189ae549073d623fb525d583eac) | `` timer: unstable-2023-02-01 -> v1.3.0 ``                                  |
| [`d37ee822`](https://github.com/NixOS/nixpkgs/commit/d37ee8222bbc5a0cf90d8e460a8e1474e819e86e) | `` nixos/borgbackup: run compact after prune ``                             |
| [`2f06bf09`](https://github.com/NixOS/nixpkgs/commit/2f06bf09b3fa6a31422204f6adcb400fc0380504) | `` hck: 0.9.1 -> 0.9.2 ``                                                   |
| [`309b8ce8`](https://github.com/NixOS/nixpkgs/commit/309b8ce82deac47a92fb69fc334a28434b0427b2) | `` gitlab: 15.10.1 -> 15.10.2 (#225716) ``                                  |
| [`6a90a7e1`](https://github.com/NixOS/nixpkgs/commit/6a90a7e12ca5593539f49877669416c2cc5c382a) | `` slurm: 23.02.0.1 -> 23.02.1.1 ``                                         |
| [`11c5a620`](https://github.com/NixOS/nixpkgs/commit/11c5a620ef742d00d5c4eeb601797059ef391f0a) | `` chickenPackages: mark more as broken ``                                  |
| [`d017614a`](https://github.com/NixOS/nixpkgs/commit/d017614a2649d720704721eca2ed958352160361) | `` erdtree: 1.7.1 -> 1.8.1 ``                                               |
| [`2b292f9d`](https://github.com/NixOS/nixpkgs/commit/2b292f9d1f4b0c95361a8da9854592f55df580cd) | `` nerdfix: 0.2.0 -> 0.2.1 ``                                               |
| [`e9cb831e`](https://github.com/NixOS/nixpkgs/commit/e9cb831ee1bd1cb76281cff739da265b7c597ab6) | `` fuse-7z-ng: link to <https://github.com/kedazo/fuse-7z-ng/pull/8> ``     |
| [`d9f35038`](https://github.com/NixOS/nixpkgs/commit/d9f35038102e24d3baebb71ac3c1e508fcd87276) | `` vimPlugins.vim-clap: revert update ``                                    |
| [`07c4c839`](https://github.com/NixOS/nixpkgs/commit/07c4c8394957fc3fe37294320c3cf2a4f75737b5) | `` firefox-esr-102-unwrapped: 102.9.0esr -> 102.10.0esr ``                  |
| [`170d143f`](https://github.com/NixOS/nixpkgs/commit/170d143fc7b7c3841cb813991048a22dab1bdc2b) | `` vimPlugins.nvim-treesitter: update grammars ``                           |
| [`3a0d22f1`](https://github.com/NixOS/nixpkgs/commit/3a0d22f1303368b8d7c5273813eb22b06b44d0ed) | `` vimPlugins.whitespace-nvim: init at 2023-02-13 ``                        |
| [`0a961e6b`](https://github.com/NixOS/nixpkgs/commit/0a961e6b2af09bd9404e252c276e502a1c2e6751) | `` vimPlugins.ltex_extra-nvim: init at 2023-01-29 ``                        |
| [`828c205e`](https://github.com/NixOS/nixpkgs/commit/828c205e72c05f29e02053806f15deedef25ffe4) | `` vimPlugins.tmux-nvim: init at 2023-03-11 ``                              |
| [`f9e3da25`](https://github.com/NixOS/nixpkgs/commit/f9e3da25591135c1b6166a13aa9941c7b58865dc) | `` vimPlugins: update ``                                                    |
| [`258038d4`](https://github.com/NixOS/nixpkgs/commit/258038d472140ce701915de3726567ba376d4806) | `` firefox-bin-unwrapped: 111.0.1 -> 112.0 ``                               |
| [`24ccda16`](https://github.com/NixOS/nixpkgs/commit/24ccda1678d5bfddfda6b7c21bff3b418c9073e7) | `` firefox-unwrapped: 111.0.1 -> 112.0 ``                                   |
| [`74269d8f`](https://github.com/NixOS/nixpkgs/commit/74269d8fa8222a4ce546161840e6cbcbb817ff91) | `` pkgsStatic.cachix: make it build ``                                      |
| [`b24aacfd`](https://github.com/NixOS/nixpkgs/commit/b24aacfd01a51cd7eb7fba0f91979e5f6484b99f) | `` playwright: fix darwin tests ``                                          |
| [`c6f6191d`](https://github.com/NixOS/nixpkgs/commit/c6f6191dbb597ddb1445b34e23f4b2c465257fa3) | `` exploitdb: 2023-04-09 -> 2023-04-11 ``                                   |
| [`f7e5db28`](https://github.com/NixOS/nixpkgs/commit/f7e5db282bf9579bdc9fcb1944e93665c88a32f1) | `` pipewire: add native modemmanager ``                                     |
| [`3c7f8069`](https://github.com/NixOS/nixpkgs/commit/3c7f806954c66a6e2f047255c6bd64201037c738) | `` pipewire: backport fix as recommended upstream ``                        |
| [`ffbea7a3`](https://github.com/NixOS/nixpkgs/commit/ffbea7a3d96351e7af4f3fa6e0896659b3de5c46) | `` logseq: add NIXOS_OZONE_WL check ``                                      |
| [`c6a04a00`](https://github.com/NixOS/nixpkgs/commit/c6a04a00a6690d87b4df3aa32b38420a68ecd1be) | `` Add ‘proxyVendor=true’ ``                                                |
| [`9c07acac`](https://github.com/NixOS/nixpkgs/commit/9c07acac91d5592b6d049555908b3210502f78b9) | `` faircamp: unstable-2022-12-28 -> unstable-2023-04-10 ``                  |
| [`c3a88e46`](https://github.com/NixOS/nixpkgs/commit/c3a88e466ee2fb350d3aaf7ad1c0d7ea3e39298d) | `` libvirt: fix build on darwin ``                                          |
| [`317909bd`](https://github.com/NixOS/nixpkgs/commit/317909bd6dbf5faeaab390682ef2abe920785e57) | `` checkmake: 0.2.1 -> 0.2.2 ``                                             |
| [`68e9d5df`](https://github.com/NixOS/nixpkgs/commit/68e9d5dff81d584eb6210a142434c3c1eb51ea71) | `` tracee: 0.13.0 -> 0.13.1 ``                                              |
| [`83c344fe`](https://github.com/NixOS/nixpkgs/commit/83c344fedb862ca8ef1d24679eac732dc4120e53) | `` nixos/tests/yggdrasil: fix local peering test ``                         |
| [`b6df389e`](https://github.com/NixOS/nixpkgs/commit/b6df389ebb9feb53f3cb76b553be298272f4589a) | `` rich-cli: update override ``                                             |
| [`0fb16f3f`](https://github.com/NixOS/nixpkgs/commit/0fb16f3f42ca6d824c33599bc62e80417a588491) | `` rambox: 2.1.0 -> 2.1.2 ``                                                |
| [`7a1de489`](https://github.com/NixOS/nixpkgs/commit/7a1de48994dadc3ce94f06f9a3a0f41775751f81) | `` anki-bin: use pname + version instead of hacky override ``               |
| [`4f4bae4d`](https://github.com/NixOS/nixpkgs/commit/4f4bae4dd0935f68b0b45663f517329ff56a9f9d) | `` python310Packages.django-configurations: 2.4 -> 2.4.1 ``                 |
| [`279a7f71`](https://github.com/NixOS/nixpkgs/commit/279a7f71230f58ff8bcba958202c9c5b88a73b59) | `` skypeforlinux: 8.87.0.406 -> 8.96.0.207 ``                               |
| [`90b75045`](https://github.com/NixOS/nixpkgs/commit/90b750456ea62408dc4c0bbe68adabdd96e381a7) | `` buildbot: move out of python3.pkgs ``                                    |
| [`3c1b2cf9`](https://github.com/NixOS/nixpkgs/commit/3c1b2cf96165aa18ca223670e8e3e0b4611077db) | `` timewarrior: 1.4.3 -> 1.5.0 ``                                           |
| [`fe265570`](https://github.com/NixOS/nixpkgs/commit/fe26557008b7b75dfd82ed7c4c40804003a8de59) | `` carapace: 0.23.0 -> 0.24.1 ``                                            |
| [`ba1e506c`](https://github.com/NixOS/nixpkgs/commit/ba1e506c2506632da0ca9b59819920c7ad533bd0) | `` python310Packages.frigidaire: fix version identifiers ``                 |
| [`19fe29df`](https://github.com/NixOS/nixpkgs/commit/19fe29df6804efadc7e90f25261a681b086381d9) | `` python310Packages.frigidaire: add changelog to meta ``                   |
| [`ffa1bc28`](https://github.com/NixOS/nixpkgs/commit/ffa1bc28337aa5032584aa4c3bdc3a30446d9c41) | `` python310Packages.httpx-ntlm: fix version specifiers ``                  |
| [`4b29e9bd`](https://github.com/NixOS/nixpkgs/commit/4b29e9bd33ddba4036148922d9c0e91c8c249f57) | `` monero-{cli,gui}: 0.18.2.0 -> 0.18.2.2 ``                                |
| [`3387728d`](https://github.com/NixOS/nixpkgs/commit/3387728db866fa0eff8c910711d009a2f7ed0929) | `` python310Packages.pip-tools: 6.12.2 -> 6.13.0 ``                         |
| [`580b00a3`](https://github.com/NixOS/nixpkgs/commit/580b00a32f1ddca7fab21ae03480c7681c44d9d1) | `` python310Packages.sqlalchemy-mixins: add changelog to meta ``            |
| [`4beb1b35`](https://github.com/NixOS/nixpkgs/commit/4beb1b350f19099136e94016bc53a20a1ea8d575) | `` soundux: fixup build (deprecation warning) ``                            |
| [`398b54bc`](https://github.com/NixOS/nixpkgs/commit/398b54bcffb00c34fed6458132651ab8a14c37eb) | `` python310Packages.kaldi-active-grammar: fixup build ``                   |
| [`ab1cc58b`](https://github.com/NixOS/nixpkgs/commit/ab1cc58b5cf895065d7e487e90a371a94e7f7870) | `` pulumi-bin: fixup build (missing libgcc_s.so) ``                         |
| [`51d99c19`](https://github.com/NixOS/nixpkgs/commit/51d99c194f916a7b07aff73bba1bc9a8a39a3a3f) | `` tockloader: 1.6.0 -> 1.9.0 ``                                            |
| [`1d391acf`](https://github.com/NixOS/nixpkgs/commit/1d391acf5f496f3e8e0b5f693445f53101bfc2be) | `` tockloader: add changelog to meta ``                                     |
| [`b63db437`](https://github.com/NixOS/nixpkgs/commit/b63db43781eb744c8fa87ccbfbbb9fe7b8bc20f4) | `` python310Packages.galois: update meta ``                                 |
| [`1ce963ac`](https://github.com/NixOS/nixpkgs/commit/1ce963acecc3c0d6d761f1a1d545943bc670fd68) | `` peco: 0.5.10 -> 0.5.11 ``                                                |
| [`82a8834f`](https://github.com/NixOS/nixpkgs/commit/82a8834ffe1e88f7df9eaa1a658b4881d17d8ab8) | `` alsa-scarlett-gui: fixup build after gtk4 update ``                      |
| [`6e2f8f5b`](https://github.com/NixOS/nixpkgs/commit/6e2f8f5b89ddf86d701fde1709f0ea2f3e7a7f78) | `` kustomize-sops: 4.1.0 -> 4.1.1 ``                                        |
| [`4a337f0c`](https://github.com/NixOS/nixpkgs/commit/4a337f0c304e2b8356f7ea9c75c0e222747c8524) | `` asn: 0.73.1 -> 0.73.2 ``                                                 |
| [`234b1938`](https://github.com/NixOS/nixpkgs/commit/234b193821368fd1a6e8c1d6b19fc7eee843740f) | `` ocamlPackages.alcotest: 1.6.0 → 1.7.0 ``                                 |
| [`8a288f2c`](https://github.com/NixOS/nixpkgs/commit/8a288f2c760948466d357a7fe1b02c685d5663cb) | `` ocamlPackages.pecu: use Dune 3 ``                                        |
| [`cb9fc605`](https://github.com/NixOS/nixpkgs/commit/cb9fc605bb17bf16c2dff33abf35f5806f47f098) | `` ocamlPackages.terminal: use Dune 3 ``                                    |
| [`23100ea3`](https://github.com/NixOS/nixpkgs/commit/23100ea3c8cbae76dd672d4c5ed67e668ac2061d) | `` ocamlPackages.ff: use Dune 3 ``                                          |
| [`7464ae25`](https://github.com/NixOS/nixpkgs/commit/7464ae25e79290fa9798bef17cf4e23d7fca0dd9) | `` ocamlPackages.dispatch: use Dune 3 ``                                    |
| [`ca7d2614`](https://github.com/NixOS/nixpkgs/commit/ca7d2614d71265121bb7cedd7f41ed53f240c944) | `` ocamlPackages.gmap: use Dune 3 ``                                        |
| [`bed82a9b`](https://github.com/NixOS/nixpkgs/commit/bed82a9b5029883473d2c6e6b97f23b1c907790b) | `` ocamlPackages.junit: use Dune 3 ``                                       |
| [`6ab83d22`](https://github.com/NixOS/nixpkgs/commit/6ab83d22558860198aaa79fb544b92b58ff913d0) | `` ocamlPackages.ppx_deriving_cmdliner: use Dune 3 ``                       |
| [`c1db7e08`](https://github.com/NixOS/nixpkgs/commit/c1db7e08ebf6be654d26c945140371f03b28656e) | `` ocamlPackages.ppx_blob: use Dune 3 ``                                    |
| [`f94acff2`](https://github.com/NixOS/nixpkgs/commit/f94acff2393fc940b1cf9cfcd60ccfe89e97e6ad) | `` ocamlPackages.yuscii: use Dune 3 ``                                      |
| [`b9821fbd`](https://github.com/NixOS/nixpkgs/commit/b9821fbd4d5dcedb0412e9bf1ca35d4bdc32bb14) | `` ocamlPackages.bigstringaf: use Dune 3 ``                                 |
| [`7bbbb27a`](https://github.com/NixOS/nixpkgs/commit/7bbbb27a83ec26d1cf1c05ad2497a130f5df1e04) | `` ocamlPackages.duff: use Dune 3 ``                                        |
| [`704a0dd9`](https://github.com/NixOS/nixpkgs/commit/704a0dd9544a96d85cfca0ceb40df8228852f7cd) | `` ocamlPackages.ke: use Dune 3 ``                                          |