### PR TITLE
chore(flake/nix-index-database): `2f5e6e91` -> `c93f2e0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679224439,
-        "narHash": "sha256-QkvcuC4b67FUkkxlMsLTMPbwoD7yZr0UvJpu6jkFuLo=",
+        "lastModified": 1681392449,
+        "narHash": "sha256-Ld8n4QiqfDegqnRBq5LZ+kryENyEGNif/LBjwhqXopc=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "2f5e6e915d70c04d673a8930f94591595c73eb84",
+        "rev": "c93f2e0bfe779601be514e1bca3b02443d4ce46b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`c93f2e0b`](https://github.com/Mic92/nix-index-database/commit/c93f2e0bfe779601be514e1bca3b02443d4ce46b) | `` update packages.nix to release 2023-04-13-132626 `` |