### PR TITLE
chore(flake/home-manager): `28698126` -> `8631c044`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681250798,
-        "narHash": "sha256-fQMROyKzPFBPqJy9J4ffywm02ZuqAI0GW1O1QibVpdQ=",
+        "lastModified": 1681457346,
+        "narHash": "sha256-9cDHr8CRhcH7zdDpcHL5f/Cks7ecezlbGxqhHuhZTvs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "28698126bd825aff21cae9ffd15cf83e169051b0",
+        "rev": "8631c0441614587a10c9e10372f85561211a4bb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`8631c044`](https://github.com/nix-community/home-manager/commit/8631c0441614587a10c9e10372f85561211a4bb8) | `` home-manager: ignore errors when creating the profiles path `` |
| [`fe1e2dee`](https://github.com/nix-community/home-manager/commit/fe1e2dee1955f130830536403c7564f4afc6edc0) | `` home-manager: make sure Nix profiles path exists ``            |