### PR TITLE
chore(flake/home-manager): `8631c044` -> `17198cf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -149,17 +149,14 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "utils": [
-          "flake-utils"
         ]
       },
       "locked": {
-        "lastModified": 1681457346,
-        "narHash": "sha256-9cDHr8CRhcH7zdDpcHL5f/Cks7ecezlbGxqhHuhZTvs=",
+        "lastModified": 1681468923,
+        "narHash": "sha256-+X2oO4juRVhQRs002mn8km6PODccIRiz09c2K1xtSpY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8631c0441614587a10c9e10372f85561211a4bb8",
+        "rev": "17198cf5ae27af5b647c7dac58d935a7d0dbd189",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`17198cf5`](https://github.com/nix-community/home-manager/commit/17198cf5ae27af5b647c7dac58d935a7d0dbd189) | `` flake.nix: get rid of flake-utils ``        |
| [`5cdaa298`](https://github.com/nix-community/home-manager/commit/5cdaa2982c0e36332ec1d2bbc5908c114a7a3736) | `` Translate using Weblate (Ukrainian) ``      |
| [`48aa5429`](https://github.com/nix-community/home-manager/commit/48aa5429cc41dfb36fdfb2e49c1cff63aefe58a1) | `` Update translation files ``                 |
| [`d53b9b39`](https://github.com/nix-community/home-manager/commit/d53b9b39b222b538b3f7953f3116e3715c64554d) | `` Translate using Weblate (Japanese) ``       |
| [`61f5c219`](https://github.com/nix-community/home-manager/commit/61f5c2196fa61868d905b2533aef5d91c2a55612) | `` Translate using Weblate (Spanish) ``        |
| [`49a3eff1`](https://github.com/nix-community/home-manager/commit/49a3eff14683a4a6f2f5cd1297a7bc37e8f579f0) | `` Translate using Weblate (Italian) ``        |
| [`9481677f`](https://github.com/nix-community/home-manager/commit/9481677f34a4695d175d0afa58cf6b3020cd0d49) | `` Update translation files ``                 |
| [`b10e3ee4`](https://github.com/nix-community/home-manager/commit/b10e3ee4ad905f0dd7c3cfbd851ffac7ef74ad21) | `` Translate using Weblate (Dutch) ``          |
| [`916b7a54`](https://github.com/nix-community/home-manager/commit/916b7a545d9e9f9270a821c6c5602082769d7e62) | `` Add translation using Weblate (Romanian) `` |
| [`af8a80c4`](https://github.com/nix-community/home-manager/commit/af8a80c4ce46dceff40491899d6587c0534e8501) | `` Add translation using Weblate (Romanian) `` |