### PR TITLE
chore(flake/nix-index-database): `375ed1ce` -> `68ec961c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681460490,
-        "narHash": "sha256-uA5IvXUPV3LboIyjGrPYvNuaShxWR7hDjZC6aXY5z4o=",
+        "lastModified": 1681591833,
+        "narHash": "sha256-lW+xOELafAs29yw56FG4MzNOFkh8VHC/X/tRs1wsGn8=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "375ed1ce48ee67f528fda03acdf99fd542df41c6",
+        "rev": "68ec961c51f48768f72d2bbdb396ce65a316677e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                               |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`68ec961c`](https://github.com/Mic92/nix-index-database/commit/68ec961c51f48768f72d2bbdb396ce65a316677e) | `` fix eval ``                        |
| [`d380d39b`](https://github.com/Mic92/nix-index-database/commit/d380d39bcead965a0326cb84a8a6e68711e3f865) | `` nixos-module: use lib.mkDefault `` |