### PR TITLE
chore(flake/nixpkgs): `85b08152` -> `f294325a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -217,11 +217,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681557730,
-        "narHash": "sha256-j2E3639kS3Qop2jQPyqWCdenZNaqIdxfoTvAHnGuAGI=",
+        "lastModified": 1681648924,
+        "narHash": "sha256-pzi3HISK8+7mpEtv08Yr80wswyHKsz+RP1CROG1Qf6s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "85b081528b937df4bfcaee80c3541b58f397df8b",
+        "rev": "f294325aed382b66c7a188482101b0f336d1d7db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`fb20a53c`](https://github.com/NixOS/nixpkgs/commit/fb20a53c1db0e0244afd3660d0bbbab23378f018) | `` python3Packages.datafusion: fix darwin build ``                                      |
| [`98e434a8`](https://github.com/NixOS/nixpkgs/commit/98e434a890eab128fef4e2595b8d11bbebd3444d) | `` duckstation: unstable-2023-01-01 -> unstable-2023-04-14 ``                           |
| [`d978b588`](https://github.com/NixOS/nixpkgs/commit/d978b588655200a5510642760e9dfbbd83242119) | `` buildFHSEnvChroot: deprecate ``                                                      |
| [`24a513a8`](https://github.com/NixOS/nixpkgs/commit/24a513a87c39bd117b37aa3898b264a8059e11a9) | `` tree-wide: do not depend on buildFHSEnvBubblewrap ``                                 |
| [`2a641efe`](https://github.com/NixOS/nixpkgs/commit/2a641efe76ab00865991f942b4477e47e5a7bb5a) | `` zulip: use bubblewrap again ``                                                       |
| [`cae417d3`](https://github.com/NixOS/nixpkgs/commit/cae417d315dd27d820e967dbcf5002d8d4529ac2) | `` quartus-prime: use buildFHSEnvChroot ``                                              |
| [`7e689a7d`](https://github.com/NixOS/nixpkgs/commit/7e689a7dd80975205bfb7290396daae0eaf4824c) | `` quartus-prime: use libxcrypt-legacy ``                                               |
| [`756c5ea5`](https://github.com/NixOS/nixpkgs/commit/756c5ea52573f6ce302daf23f4428e92e539a702) | `` pdfstudio2022, pdfstudioviewer: mark broken ``                                       |
| [`f63a12f2`](https://github.com/NixOS/nixpkgs/commit/f63a12f296b806a1b838d6fd8eef99fa65929649) | `` tree-wide: buildFHSUserEnv -> buildFHSEnv ``                                         |
| [`1baab4e1`](https://github.com/NixOS/nixpkgs/commit/1baab4e14a6c9d5fd0f3e6af144aeeb61e911110) | `` buildFHSUserEnv: use bubblewrap by default ``                                        |
| [`2e0f01cc`](https://github.com/NixOS/nixpkgs/commit/2e0f01cc438125860827647b7d5c7788b860eb0e) | `` warp: 0.4 -> 0.5.2 ``                                                                |
| [`4b0824ed`](https://github.com/NixOS/nixpkgs/commit/4b0824ed01bade941305f43f8372f1f1b30df90e) | `` brlcad: 7.34.0 -> 7.34.2 ``                                                          |
| [`d479ac2b`](https://github.com/NixOS/nixpkgs/commit/d479ac2b8ed41afb5c2f0e1fbd1d2764a250de25) | `` python310Packages.html5-parser: run tests ``                                         |
| [`84987d3d`](https://github.com/NixOS/nixpkgs/commit/84987d3dfd13f9c95c2a55fcd3ef23a61e6e1379) | `` verible: 0.0.2821 -> 0.0.3179 ``                                                     |
| [`20761c31`](https://github.com/NixOS/nixpkgs/commit/20761c31d02d1d571772045bf403910b2098fc6a) | `` jool-cli: fix build ``                                                               |
| [`855d27a2`](https://github.com/NixOS/nixpkgs/commit/855d27a28b4da3b03b7570b38d4e012618f71325) | `` ladybird: fix build on x86_64-darwin ``                                              |
| [`7f8c3574`](https://github.com/NixOS/nixpkgs/commit/7f8c35748e46698f0845c195f0b32062e3addefb) | `` qt6.qtwebengine: add frameworks for darwin ``                                        |
| [`fad703cb`](https://github.com/NixOS/nixpkgs/commit/fad703cb4a3dc5d21f79f1dfa632411daa705608) | `` ladybird: fix runtime error on darwin ``                                             |
| [`9ca82599`](https://github.com/NixOS/nixpkgs/commit/9ca82599050a9da1913f3101040db1989e7ab1a5) | `` datafusion-cli: 15.0.0 -> 22.0.0 ``                                                  |
| [`d5946bd4`](https://github.com/NixOS/nixpkgs/commit/d5946bd41694e5c401eef408ded53ecd190c82a6) | `` python3Packages.datafusion: 0.7.0 -> 22.0.0 ``                                       |
| [`634ddbd6`](https://github.com/NixOS/nixpkgs/commit/634ddbd6a1deb47c61a6fc426095fa1fefc3f1da) | `` tautulli: 2.12.2 -> 2.12.3 ``                                                        |
| [`a16b9991`](https://github.com/NixOS/nixpkgs/commit/a16b9991da41df76f484f583c0756378f96a4e10) | `` adguardhome: 0.107.27 -> 0.107.28 ``                                                 |
| [`d9be7e51`](https://github.com/NixOS/nixpkgs/commit/d9be7e51efe196cd488897ec1c4c3519d0962c99) | `` cargo-guppy: unstable-2023-01-19 -> unstable-2023-04-15 ``                           |
| [`24d12cf2`](https://github.com/NixOS/nixpkgs/commit/24d12cf2f51ccfbbfb908913fab55c745df18464) | `` cargo-hakari: 0.9.23 -> 0.9.24 ``                                                    |
| [`726da3a8`](https://github.com/NixOS/nixpkgs/commit/726da3a8b5517decb46df759142d5aa3cb04169e) | `` stargazer: init at 1.0.5 ``                                                          |
| [`7e408477`](https://github.com/NixOS/nixpkgs/commit/7e4084777e3a7f4d5cd8906bf24c434ff98f5e0c) | `` maintainers: add gaykitty ``                                                         |
| [`71e913c3`](https://github.com/NixOS/nixpkgs/commit/71e913c3535f241f0479a5e18cde8c30ce1cfecb) | `` maintainers: add jasonodoom ``                                                       |
| [`35224a6b`](https://github.com/NixOS/nixpkgs/commit/35224a6bb63ccf52b00b81d7d04261511b16428a) | `` shavee: init at 0.5.1 ``                                                             |
| [`78f207a6`](https://github.com/NixOS/nixpkgs/commit/78f207a67aa04b7b69797e92f2337c784c04859c) | `` podman-compose: 1.0.3 -> 1.0.6 ``                                                    |
| [`79c4e8aa`](https://github.com/NixOS/nixpkgs/commit/79c4e8aaa88f007760c64ec669cdaf533c746ab5) | `` nasc: fix compile failure ``                                                         |
| [`64040348`](https://github.com/NixOS/nixpkgs/commit/64040348b93a82f09c46886ffce3e325a6a1d006) | `` mdcat: 1.1.1 -> 2.0.0 ``                                                             |
| [`92ca3bdb`](https://github.com/NixOS/nixpkgs/commit/92ca3bdbae2c2492e2af530bcf7bbfb72487fdeb) | `` prowlarr: 1.2.2.2699 -> 1.3.2.3006 ``                                                |
| [`c0020302`](https://github.com/NixOS/nixpkgs/commit/c00203020626360baec5b9c2e0c5225664602623) | `` litecli: 1.8.0 -> 1.9.0 ``                                                           |
| [`c5928f3d`](https://github.com/NixOS/nixpkgs/commit/c5928f3df410e1a47dade13c64c31a31625b9f93) | `` chatgpt-retrieval-plugin: loosen redis requirement ``                                |
| [`58425e46`](https://github.com/NixOS/nixpkgs/commit/58425e46261d6f12c8ca83b21457b0bcb31ffb40) | `` python3Packages.pymilvus: 2.2.4 -> 2.2.6 ``                                          |
| [`f9541622`](https://github.com/NixOS/nixpkgs/commit/f95416222aaf3ad7bbdb40cf6705fbb175ed2fe5) | `` step-cli: 0.23.4 -> 0.24.3 ``                                                        |
| [`0a02190f`](https://github.com/NixOS/nixpkgs/commit/0a02190f4bc8f8bfa27d20971e9f51b627dc5678) | `` promexplorer: init at 0.0.3 ``                                                       |
| [`0079822b`](https://github.com/NixOS/nixpkgs/commit/0079822b382efe87b6d3e42bf686c0b05021a72b) | `` illwillwidgets: init at 0.1.11 ``                                                    |
| [`43b09bc0`](https://github.com/NixOS/nixpkgs/commit/43b09bc0721c19680cec57c6858623b0352f088d) | `` volatility3: 2.4.0 -> 2.4.1 ``                                                       |
| [`c0014f0f`](https://github.com/NixOS/nixpkgs/commit/c0014f0fca930d5fd5a818aa383ce6698bf4758c) | `` python3Packages.twisted: fix cross ``                                                |
| [`9a358eeb`](https://github.com/NixOS/nixpkgs/commit/9a358eeb72d3d38e76316d805e63b368fdcf01f8) | `` trufflehog: 3.31.5 -> 3.31.6 ``                                                      |
| [`04e5d9fc`](https://github.com/NixOS/nixpkgs/commit/04e5d9fc7fafe4fa7a85ba86d4b86e853c2fd070) | `` ssldump: 1.6 -> 1.7 ``                                                               |
| [`160c8e0a`](https://github.com/NixOS/nixpkgs/commit/160c8e0a45568fea053871bf2b10e3a2a6197cd1) | `` sslscan: 2.0.15 -> 2.0.16 ``                                                         |
| [`fbd6730a`](https://github.com/NixOS/nixpkgs/commit/fbd6730a98419d7feb18c9632204e408fc8b62e3) | `` python310Packages.deepdiff: 6.2.3 -> 6.3.0 ``                                        |
| [`aa60644d`](https://github.com/NixOS/nixpkgs/commit/aa60644dbb41987ffa0e25ea24081a8f8cab3952) | `` python310Packages.deezer-python: 5.8.1 -> 5.9.0 ``                                   |
| [`092236f1`](https://github.com/NixOS/nixpkgs/commit/092236f148ac5cf8d57a38b553d1fded133b1532) | `` python310Packages.ansible-later: 3.2.1 -> 3.2.2 ``                                   |
| [`0cdd7812`](https://github.com/NixOS/nixpkgs/commit/0cdd78126c07dbedca3eb3ba060379656eb0901e) | `` qdrant: module increase limitnofile ``                                               |
| [`8ac0dd93`](https://github.com/NixOS/nixpkgs/commit/8ac0dd93c1fd4926d3618132ced44e6d7e938cdd) | `` python310Packages.hahomematic: 2023.3.0 -> 2023.3.1 ``                               |
| [`f57342d6`](https://github.com/NixOS/nixpkgs/commit/f57342d6adeec9378399fa959e2ebd6b5ea598b0) | `` symengine: fix build on aarch64-darwin ``                                            |
| [`63c74838`](https://github.com/NixOS/nixpkgs/commit/63c7483850d4db8296b2644b2d56f8dc338b4d2a) | `` hilbish: 2.1.0 -> 2.1.2 ``                                                           |
| [`4a2d06b2`](https://github.com/NixOS/nixpkgs/commit/4a2d06b255f13ad9183c5c4916570c787851da46) | `` ungoogled-chromium: 112.0.5615.87 -> 112.0.5615.121 ``                               |
| [`5c672902`](https://github.com/NixOS/nixpkgs/commit/5c67290228687191a4b0c0e5b9dbb366f302b8ba) | `` ungoogled-chromium: 112.0.5615.50 -> 112.0.5615.87 ``                                |
| [`3bc0224b`](https://github.com/NixOS/nixpkgs/commit/3bc0224b22155f15e506c023380df1228fa33aa6) | `` chromiumBeta: 113.0.5672.24 -> 113.0.5672.37 ``                                      |
| [`e1d12d94`](https://github.com/NixOS/nixpkgs/commit/e1d12d9468a004b4e3d831d5622fc9ed1ddd2e39) | `` chromium: 112.0.5615.49 -> 112.0.5615.121 ``                                         |
| [`f0630d69`](https://github.com/NixOS/nixpkgs/commit/f0630d69acad11de3da82f2f7c8a73ef5b934742) | `` rustic-rs: re-enable zsh shell completions ``                                        |
| [`ceb4451b`](https://github.com/NixOS/nixpkgs/commit/ceb4451bcc678673123d1ea5fbd5789f3e26822b) | `` gst_all_1.vaapi: move `python3` to `nativeBuildInputs` to fix cross compilation ``   |
| [`5b82c9d5`](https://github.com/NixOS/nixpkgs/commit/5b82c9d52cc1571da04057784c2cba941d0a7438) | `` gst_all_1.gst_editing_service: fix cross compilation ``                              |
| [`3b70ab02`](https://github.com/NixOS/nixpkgs/commit/3b70ab02668f6bde6b2d033847c1acae207bd345) | `` electron_22-bin: 22.1.0 -> 22.3.6 ``                                                 |
| [`c2114add`](https://github.com/NixOS/nixpkgs/commit/c2114add0251c0691ba05b3d6d28a83a084b1ba2) | `` electron_23-bin: 23.1.1 -> 23.2.4 ``                                                 |
| [`069a804d`](https://github.com/NixOS/nixpkgs/commit/069a804d326400f6601702824016f62e6bbe05f5) | `` electron-bin: fix generated name in print-hashes script ``                           |
| [`6da5bbbe`](https://github.com/NixOS/nixpkgs/commit/6da5bbbe52d9b3ad2f5819fa2973d47a3d1dad30) | `` electron_21: mark EOL ``                                                             |
| [`e6d382d3`](https://github.com/NixOS/nixpkgs/commit/e6d382d3887e930ffe8733192ecb33ed63fe0925) | `` electron_24-bin: init at 24.1.2 ``                                                   |
| [`7baae9cf`](https://github.com/NixOS/nixpkgs/commit/7baae9cf2f46ac91a58362a1211de557ad6b607e) | `` kubernetes-helmPlugins.helm-secrets: 4.2.2 -> 4.4.2 ``                               |
| [`0a2a7f54`](https://github.com/NixOS/nixpkgs/commit/0a2a7f5400e29bf75f09d41ed3ccaffc41d66afc) | `` deltachat-desktop: 1.36.1 -> 1.36.2 ``                                               |
| [`b2d23abb`](https://github.com/NixOS/nixpkgs/commit/b2d23abb0bd884a3f6ebf24e3a64d52c2b656e38) | `` ec2instanceconnectcli: 1.0.2 -> 1.0.3 ``                                             |
| [`765aa461`](https://github.com/NixOS/nixpkgs/commit/765aa4610bf11a96f4ca9ccc232492703103065f) | `` cargo-zigbuild: 0.16.6 -> 0.16.7 ``                                                  |
| [`5d20d9ff`](https://github.com/NixOS/nixpkgs/commit/5d20d9ff9fae0aebb43cace7615ce5908b08380c) | `` doc/stdenv: don't use name in examples, highlight preferring pname ``                |
| [`f5adc891`](https://github.com/NixOS/nixpkgs/commit/f5adc89186e5a22ea6a8be55b48409b72aed05d2) | `` trino-cli: 412 -> 413 ``                                                             |
| [`48921b61`](https://github.com/NixOS/nixpkgs/commit/48921b61000188ce6843845355f6dbde1db62880) | `` ibus-engines.typing-booster: 2.20.0 -> 2.22.3 ``                                     |
| [`f2be3ae3`](https://github.com/NixOS/nixpkgs/commit/f2be3ae30d960b2f7f1c816d9cab43000556fd0a) | `` nixos/kubo: restrict access to the API to users in a group by default ``             |
| [`7ceebbb3`](https://github.com/NixOS/nixpkgs/commit/7ceebbb35bfebd887f41418588d1ccc32d3a977a) | `` nixos/kubo: allow multiple API and Gateway addresses ``                              |
| [`929a00bd`](https://github.com/NixOS/nixpkgs/commit/929a00bd84acbf35447d3df1066b1c8afd7ac82d) | `` nixos/kubo: give normal users access to the daemon by default ``                     |
| [`409df93c`](https://github.com/NixOS/nixpkgs/commit/409df93c01854b70606720a50da9bca283e8164e) | `` nixos/tests/kubo: use subtests instead of comments ``                                |
| [`bf97703f`](https://github.com/NixOS/nixpkgs/commit/bf97703f0e160307cc9318029b05a028e95f6ce3) | `` nixos/tests/kubo: clean up code ``                                                   |
| [`62bff9ab`](https://github.com/NixOS/nixpkgs/commit/62bff9ab15f7c23f7db90664c53d13b080bf34b1) | `` nixos/tests/kubo: add Luflosi as maintainer ``                                       |
| [`8a9190be`](https://github.com/NixOS/nixpkgs/commit/8a9190bee780284aae83171422fbe8a2d0a49f60) | `` nixos/doc/rl-2305: clean up Kubo notes ``                                            |
| [`2e07e19d`](https://github.com/NixOS/nixpkgs/commit/2e07e19dbd8c1414803790894e3c5c80560e47b1) | `` openjdk: explicitly specify build platform to avoid WSL autodetection shenanigans `` |
| [`dc09b905`](https://github.com/NixOS/nixpkgs/commit/dc09b9057694cfc64053d1578256e525f95f6767) | `` firefox-devedition-unwrapped: 113.0b2 -> 113.0b3 ``                                  |
| [`6efbebe3`](https://github.com/NixOS/nixpkgs/commit/6efbebe38d1131594a24a55a375a449a66cb1333) | `` firefox-beta-unwrapped: 113.0b2 -> 113.0b3 ``                                        |
| [`4eff7a83`](https://github.com/NixOS/nixpkgs/commit/4eff7a83b44fe28c994c95b65b7873e256400061) | `` firefox-devedition-bin-unwrapped: 113.0b2 -> 113.0b3 ``                              |
| [`f386ef17`](https://github.com/NixOS/nixpkgs/commit/f386ef17ae6a299376a373b5d8e7e3a6114057e9) | `` firefox-beta-bin-unwrapped: 113.0b2 -> 113.0b3 ``                                    |
| [`f91edb5e`](https://github.com/NixOS/nixpkgs/commit/f91edb5e283796bd3d9bbe344418469cc71af80f) | `` fluffychat: use pname + version, fix missing ``                                      |
| [`fbe34c11`](https://github.com/NixOS/nixpkgs/commit/fbe34c113c12b180d318711588c7ddf988c43f79) | `` Revert "fluffychat: fix version number on package search" ``                         |
| [`16a953c9`](https://github.com/NixOS/nixpkgs/commit/16a953c9377d446b78b0cc12e7b1bb04ab7b3057) | `` yamlpath: 3.7.0 -> 3.8.0 ``                                                          |
| [`4566cd69`](https://github.com/NixOS/nixpkgs/commit/4566cd69016a275d8aba3fdb6f6e6aec2d8f97f2) | `` qt6.qtbase: add frameworks on x86_64-darwin ``                                       |
| [`38b22286`](https://github.com/NixOS/nixpkgs/commit/38b22286ca92b51d57e810bc43d31f9f2498c8df) | `` isoimagewriter: 0.9.1 -> 0.9.2 ``                                                    |
| [`a3b64641`](https://github.com/NixOS/nixpkgs/commit/a3b646410a0f53663f2d36cafb45beff7f1c1232) | `` prometheus-redis-exporter: 1.48.0 -> 1.50.0 ``                                       |
| [`310a715b`](https://github.com/NixOS/nixpkgs/commit/310a715b992d50f7a2c2eb55ce95be9709179862) | `` python3Packages.pooch: add optional-dependencies ``                                  |
| [`1b4db297`](https://github.com/NixOS/nixpkgs/commit/1b4db297a52b66316fae042d7b74b9df35008ada) | `` meshcentral: 1.1.4 -> 1.1.5 ``                                                       |
| [`8c0bb773`](https://github.com/NixOS/nixpkgs/commit/8c0bb7730ea7b544091ce8f93712c153ca70f5ec) | `` hex-a-hop: init at 1.1.0 ``                                                          |
| [`118de162`](https://github.com/NixOS/nixpkgs/commit/118de162d50b69a08048c8c4d6579e603a4964e3) | `` maintainers: add rampoina ``                                                         |
| [`4c93f32a`](https://github.com/NixOS/nixpkgs/commit/4c93f32ad63578ee36483cbf6eb78e77443ea09a) | `` metasploit: 6.3.11 -> 6.3.12 ``                                                      |
| [`a5850e49`](https://github.com/NixOS/nixpkgs/commit/a5850e496d3b44aa95c1c694f1d471d031f1c099) | `` cargo-llvm-cov: 0.5.13 -> 0.5.15 ``                                                  |
| [`da27ace7`](https://github.com/NixOS/nixpkgs/commit/da27ace74efef3dba65acbde9fe13b6cb96aa8fc) | `` gnome.pomodoro: 0.22.0 → 0.23.1 ``                                                   |
| [`2d219d5c`](https://github.com/NixOS/nixpkgs/commit/2d219d5cfcd4844913e587162fa96653c53267b5) | `` gnome.gucharmap: 15.0.2 → 15.0.3 ``                                                  |
| [`6492ae6d`](https://github.com/NixOS/nixpkgs/commit/6492ae6d1474921f1d749bfd3145df1972cacc16) | `` gnome.aisleriot: 3.22.27 → 3.22.28 ``                                                |
| [`7d67d51c`](https://github.com/NixOS/nixpkgs/commit/7d67d51c6dd450c62a09dc7f60bdb74661da705a) | `` evolution-ews: 3.46.4 → 3.48.0 ``                                                    |
| [`0b23bcb8`](https://github.com/NixOS/nixpkgs/commit/0b23bcb80700be664de766332c29bbf105e69d46) | ``  go-cqhttp: 1.0.0-rc5 -> 1.0.1 ``                                                    |
| [`2944ade4`](https://github.com/NixOS/nixpkgs/commit/2944ade41117059cdfb76610882ae3fe115a71dc) | `` pet: split ldflags into parts ``                                                     |
| [`9cc6d166`](https://github.com/NixOS/nixpkgs/commit/9cc6d166ad33f3b862ac420eddf001ecd48b59c3) | `` python310Packages.peaqevcore: 15.2.4 -> 15.2.8 ``                                    |
| [`ee529343`](https://github.com/NixOS/nixpkgs/commit/ee529343bb3122cf861ce76988e85f851cf83598) | `` clash: 1.14.0 -> 1.15.0 ``                                                           |
| [`cdbedf38`](https://github.com/NixOS/nixpkgs/commit/cdbedf3854acc320fb48ed3c67ece7da3ee90742) | `` python310Packages.pontos: 23.4.2 -> 23.4.3 ``                                        |
| [`11eaedf5`](https://github.com/NixOS/nixpkgs/commit/11eaedf5b3fdddcc406f8206450200f8804c283c) | `` python310Packages.yalexs: 1.2.8 -> 1.3.0 ``                                          |
| [`d326917a`](https://github.com/NixOS/nixpkgs/commit/d326917a641bd088537a5c506782ff03e3397108) | `` python310Packages.onvif-zeep-async: 1.2.3 -> 1.2.5 ``                                |
| [`e9583cc8`](https://github.com/NixOS/nixpkgs/commit/e9583cc89d33d8f7e36035f9ac2a6f4704d0590e) | `` python310Packages.html5-parser: 0.4.10 -> 0.4.11 ``                                  |
| [`fc3cb382`](https://github.com/NixOS/nixpkgs/commit/fc3cb382230a64c500d9a10f3034be76060dded2) | `` millet: 0.8.8 -> 0.9.0 ``                                                            |
| [`17df108c`](https://github.com/NixOS/nixpkgs/commit/17df108ce26aa752d152f4d8661dee2eead08954) | `` luau: 0.571 -> 0.572 ``                                                              |
| [`88d12610`](https://github.com/NixOS/nixpkgs/commit/88d12610da50d8252715e3837b4b7337f0fe225f) | `` bundletool: 1.14.0 -> 1.14.1 ``                                                      |
| [`37656de3`](https://github.com/NixOS/nixpkgs/commit/37656de350532ff41f72b81c5e532ff8e22ff44d) | `` gallery-dl: 1.25.1 -> 1.25.2 ``                                                      |
| [`5833fa85`](https://github.com/NixOS/nixpkgs/commit/5833fa85e5ba0b313dc2d41abc12100e1d328267) | `` flexget: 3.6.0 -> 3.6.3 ``                                                           |
| [`0b5a7ef4`](https://github.com/NixOS/nixpkgs/commit/0b5a7ef4b7d245476fd7a67b930d2746c5aa763c) | `` lxd: 5.12 -> 5.13 ``                                                                 |
| [`97515a54`](https://github.com/NixOS/nixpkgs/commit/97515a547661f984bd34cd8255c8d6df83b7c622) | `` svgbob: add changelog to meta ``                                                     |
| [`207b31a9`](https://github.com/NixOS/nixpkgs/commit/207b31a931c985c716b7a48939008aee9b5e7530) | `` squawk: 0.23.0 -> 0.24.0 ``                                                          |
| [`440583bc`](https://github.com/NixOS/nixpkgs/commit/440583bc8102c31ce5c6e1c762f6f960c10c34f8) | `` svgbob: 0.6.6 -> 0.7.0 ``                                                            |
| [`2ee52df6`](https://github.com/NixOS/nixpkgs/commit/2ee52df62c37e5fffa8ce298f6d2806071179a59) | `` cargo-release: 0.24.8 -> 0.24.9 ``                                                   |
| [`4d73c5e5`](https://github.com/NixOS/nixpkgs/commit/4d73c5e501290ff849e71abc9a7469d306278464) | `` radicle-cli: fix build by setting `auditable = false` ``                             |
| [`ec5a76b2`](https://github.com/NixOS/nixpkgs/commit/ec5a76b2031cf31caea7a97341ebb0572948dc39) | `` podman: 4.4.4 -> 4.5.0 ``                                                            |
| [`0aa3f7aa`](https://github.com/NixOS/nixpkgs/commit/0aa3f7aad35061d33dd5b557051723679be1bafc) | `` forgejo: 1.19.0-3 -> 1.19.1-0 ``                                                     |
| [`2a59caf5`](https://github.com/NixOS/nixpkgs/commit/2a59caf5dece7267db9cbba790ea76994e0e7b4f) | `` pachyderm: 2.5.2 -> 2.5.4 ``                                                         |
| [`a3b117a7`](https://github.com/NixOS/nixpkgs/commit/a3b117a70aeae149eca3a69b7767b8163ef63f0b) | `` ocamlPackages.bisect_ppx: 2.8.1 → 2.8.2 ``                                           |
| [`0712b966`](https://github.com/NixOS/nixpkgs/commit/0712b966d12f00e907aec196c955693fa9ad3409) | `` liferea: 1.14.4 -> 1.14.5 ``                                                         |
| [`c16c3f82`](https://github.com/NixOS/nixpkgs/commit/c16c3f82b2fc869c134164f041ac7a3c1948ecde) | `` uwimap: fix cross and remove unnecessary conditional ``                              |
| [`4201015d`](https://github.com/NixOS/nixpkgs/commit/4201015d754843a53d44b3a5aaf39ae601e010d7) | `` linux_xanmod: 6.1.23 -> 6.1.24 ``                                                    |
| [`bf975dc5`](https://github.com/NixOS/nixpkgs/commit/bf975dc5b3cf7ae89aa488957010e2184a989c70) | `` linux_xanmod_latest: 6.2.10 -> 6.2.11 ``                                             |
| [`332d775c`](https://github.com/NixOS/nixpkgs/commit/332d775c5337005b669327f7fe90438f2d9b4af2) | `` mangohud: 0.6.8 -> 0.6.9 ``                                                          |
| [`a98e3ade`](https://github.com/NixOS/nixpkgs/commit/a98e3adeeb186033883d5d737b07af34ebafd622) | `` mangohud: add update script ``                                                       |
| [`69ac4b60`](https://github.com/NixOS/nixpkgs/commit/69ac4b600b63f72c01244ee8e9635673d63f04de) | `` mangohud: support 32bit mango app vulkan layer ``                                    |
| [`62bad427`](https://github.com/NixOS/nixpkgs/commit/62bad427ffb0104cf5c577ca45557f7d3bce7faf) | `` mangohud: suport nvidia cards when directly using vulkan layer ``                    |
| [`d9cb1091`](https://github.com/NixOS/nixpkgs/commit/d9cb109138cb32c7441794072e6fc122e8b08473) | `` mangohud: move loader header deps to nativeBuildInputs ``                            |
| [`eefb3eb9`](https://github.com/NixOS/nixpkgs/commit/eefb3eb9a4cb639d8598535fc2fb44c392dd60a0) | `` mangohud: switch back to using system spdlog ``                                      |
| [`83c65fd6`](https://github.com/NixOS/nixpkgs/commit/83c65fd633ae13ac74a0d2a95e567ca369ee42ae) | `` mangohud: prefer finalAttrs over rec ``                                              |
| [`2a6b15d3`](https://github.com/NixOS/nixpkgs/commit/2a6b15d371f31796c8bcd6521328b109a04608ef) | `` linuxPackages.nvidia_x11: aarch64-linux support ``                                   |
| [`19ee9ae5`](https://github.com/NixOS/nixpkgs/commit/19ee9ae59ddff977f4ee541013b282ebb3c1a432) | `` deno: 1.32.3 -> 1.32.4 ``                                                            |
| [`d5334e8d`](https://github.com/NixOS/nixpkgs/commit/d5334e8dd6192584c0e5b280cfa9a866c8d504be) | `` fblog: 4.2.0 -> 4.3.0 ``                                                             |
| [`af1dd138`](https://github.com/NixOS/nixpkgs/commit/af1dd1387cac80ee46989e886d8214f0aac44738) | `` pet: add ldflags to set version of application ``                                    |
| [`4aa036f1`](https://github.com/NixOS/nixpkgs/commit/4aa036f15aa55e788eda633805d8397274d6c052) | `` rav1e: fix cross ``                                                                  |
| [`e11ba0e7`](https://github.com/NixOS/nixpkgs/commit/e11ba0e7e1dcd78c0fbccf4818a97d4899002f01) | `` coq: default to version 8.17 ``                                                      |