### PR TITLE
chore(flake/home-manager): `21ca88f3` -> `68eaf4b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681617561,
-        "narHash": "sha256-Fyf2sBz3CK9SuptsN4+Brf62jMfd99BlyijJD5HAtcg=",
+        "lastModified": 1681688069,
+        "narHash": "sha256-1w6zBfwxwMbyewUyqzSnZs8nwNqj6ZBVcP0rkCueyIo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "21ca88f3a98f15e4791c82697745e3698ad883d8",
+        "rev": "68eaf4b577cfa8024fb910a1ce7d60385044f798",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                               |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`68eaf4b5`](https://github.com/nix-community/home-manager/commit/68eaf4b577cfa8024fb910a1ce7d60385044f798) | `` i3-sway: add option trayPadding (tray_padding) for bars (#3829) `` |
| [`d1d0ee37`](https://github.com/nix-community/home-manager/commit/d1d0ee37c315537cdcadbcf0f773694e9da0605d) | `` home-manager: ignore errors from notify-send ``                    |