### PR TITLE
chore(flake/home-manager): `cd690d20` -> `6db559da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681759968,
-        "narHash": "sha256-hW5MdNfnZa8ayAor4vLvlZobvsyT1WEJ6tirN/cBsVY=",
+        "lastModified": 1681764152,
+        "narHash": "sha256-GocJ/OoYihIHMGlHaoVD+WmetmgRwuCGLp53kQV8iwk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cd690d202176c251f2a5ed31b621937f8a95268d",
+        "rev": "6db559daa952833fb16bd52c5ae24e1c4fffd488",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`6db559da`](https://github.com/nix-community/home-manager/commit/6db559daa952833fb16bd52c5ae24e1c4fffd488) | `` thunderbird: add extraConfig option ``  |
| [`e17e5e4f`](https://github.com/nix-community/home-manager/commit/e17e5e4f48116763e7c544147cd5d27f94a63623) | `` bottom: use xdg.configHome on Darwin `` |