### PR TITLE
chore(flake/nixpkgs): `f294325a` -> `f00994e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -217,11 +217,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681648924,
-        "narHash": "sha256-pzi3HISK8+7mpEtv08Yr80wswyHKsz+RP1CROG1Qf6s=",
+        "lastModified": 1681737997,
+        "narHash": "sha256-pHhjgsIkRMu80LmVe8QoKIZB6VZGRRxFmIvsC5S89k4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f294325aed382b66c7a188482101b0f336d1d7db",
+        "rev": "f00994e78cd39e6fc966f0c4103f908e63284780",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`1ee86f28`](https://github.com/NixOS/nixpkgs/commit/1ee86f28c7e3499c8e83ef8ab280ab05486b1ee8) | `` nixos-shell: add jq dependency ``                                                  |
| [`757b6381`](https://github.com/NixOS/nixpkgs/commit/757b6381ec238148d9a8a6c1aeec3240981b513c) | `` yaru-theme: 22.10.3 -> 23.04.4 ``                                                  |
| [`fed6621d`](https://github.com/NixOS/nixpkgs/commit/fed6621deb2c70ec3d69c337157edef4e626d163) | `` yandex-browser: 22.9.1.1110-1 -> 23.3.1.906-1 ``                                   |
| [`9678498e`](https://github.com/NixOS/nixpkgs/commit/9678498e45d84cd79d09055f25a4882a35fc80a0) | `` maintainers: add ionutnechita ``                                                   |
| [`15e8ee51`](https://github.com/NixOS/nixpkgs/commit/15e8ee51d47ff4a57ee7ceb92d7b7924e7f550b3) | `` zerotierone: 1.10.3 -> 1.10.6 (#224992) ``                                         |
| [`d1f57357`](https://github.com/NixOS/nixpkgs/commit/d1f57357449c312491b6a957558b7a34655f80a0) | `` linux_testing: 6.3-rc6 -> 6.3-rc7 ``                                               |
| [`7081da42`](https://github.com/NixOS/nixpkgs/commit/7081da42c68f57bc605a723e1720c2e5d157b04a) | `` atuin: 14.0.0 -> 14.0.1 (#226495) ``                                               |
| [`376fc84b`](https://github.com/NixOS/nixpkgs/commit/376fc84bbc14306712b4fa0ded62ab5ec56dd43c) | `` clickhouse: 22.8.11.15 -> 22.8.16.32 (#226603) ``                                  |
| [`e2a237d6`](https://github.com/NixOS/nixpkgs/commit/e2a237d6f9c903be392be159e617027874e05490) | `` fastnetmon-advanced: 2.0.335 -> 2.0.336 (#226602) ``                               |
| [`6036c991`](https://github.com/NixOS/nixpkgs/commit/6036c9910617bf470ff280779681285678bc0208) | `` signal-desktop-beta: v6.11.0-beta.2 -> v6.15.0-beta.1 ``                           |
| [`71104175`](https://github.com/NixOS/nixpkgs/commit/711041757168b239548041e4ecab29f392cec5bd) | `` signal-desktop: v6.10.1 -> v6.14.0 ``                                              |
| [`37e60911`](https://github.com/NixOS/nixpkgs/commit/37e609113cf03bb61cf984fc457e94aa456acc57) | `` deepin.deepin-terminal: 5.9.40 -> 6.0.5 ``                                         |
| [`41d524d5`](https://github.com/NixOS/nixpkgs/commit/41d524d5be2b14bd4cc40a4914a7dfb864aa1c6c) | `` v2ray-geoip: 202304060040 -> 202304130041 ``                                       |
| [`be06a2b9`](https://github.com/NixOS/nixpkgs/commit/be06a2b91ce327c50757b4d4b08129ffc168a80b) | `` mesa-demos: fix cross compilation ``                                               |
| [`1cc5062c`](https://github.com/NixOS/nixpkgs/commit/1cc5062cb50d4098375be7a9cbee0e67015aa0fd) | `` deepin.dde-file-manager: 6.0.13 -> 6.0.14 ``                                       |
| [`80d27a63`](https://github.com/NixOS/nixpkgs/commit/80d27a6317347302672ae6c7d5cf19ee379d3ce5) | `` deepin.util-dfm: 1.2.7 -> 1.2.8 ``                                                 |
| [`0c88ed25`](https://github.com/NixOS/nixpkgs/commit/0c88ed25e0eab5b272af73ed2d2127056d4d94dd) | `` deepin.dde-calendar: disable unit testing ``                                       |
| [`e7a73d03`](https://github.com/NixOS/nixpkgs/commit/e7a73d03f5adc6c7c259978035d8158b2c473329) | `` sigma-cli: 0.5.3 -> 0.7.2 ``                                                       |
| [`a8a94887`](https://github.com/NixOS/nixpkgs/commit/a8a948870445f0be77983b5ced7738c5df793a1c) | `` ots: init at 0.2.0 ``                                                              |
| [`5586e0dd`](https://github.com/NixOS/nixpkgs/commit/5586e0dd1433e8712fcc5f04f422bf540f686827) | `` python310Packages.pysigma: 0.9.5 -> 0.9.6 ``                                       |
| [`2f852c48`](https://github.com/NixOS/nixpkgs/commit/2f852c48ca80e65abc4484d577d2ad22d34c4a99) | `` python310Packages.pysigma-backend-opensearch: 0.1.6 -> 0.1.6 ``                    |
| [`b9157c11`](https://github.com/NixOS/nixpkgs/commit/b9157c11a51dc8bf2a9fce81542c4ab84953d24a) | `` python310Packages.pysigma-backend-elasticsearch: 0.2.0 -> 1.0.1 ``                 |
| [`61662955`](https://github.com/NixOS/nixpkgs/commit/616629559c104d2c02c1648ad946d20465a19cc2) | `` seaweedfs: 3.45 -> 3.46 ``                                                         |
| [`bf8dc7ed`](https://github.com/NixOS/nixpkgs/commit/bf8dc7ed769798c06d585ba22bf8014d24ebefef) | `` jasmin-compiler: 2022.09.0 → 2022.09.2 ``                                          |
| [`0939a960`](https://github.com/NixOS/nixpkgs/commit/0939a9604db7f77186505833ddf327649a944ba8) | `` ocamlPackages.ocaml-migrate-parsetree: use Dune 3 ``                               |
| [`244c5561`](https://github.com/NixOS/nixpkgs/commit/244c5561fb36ee1b10285aec4fbf14917646df06) | `` ocamlPackages.hack_parallel: use Dune 3 ``                                         |
| [`c8c09014`](https://github.com/NixOS/nixpkgs/commit/c8c0901412f7030f999ba32f5bfa6e70fc53934c) | `` ocamlPackages.ppx_tools_versioned: use Dune 3 ``                                   |
| [`4a831cda`](https://github.com/NixOS/nixpkgs/commit/4a831cda4a208a54bdb49d6814a0f8fa53c18c68) | `` sketchybar: 2.14.1 -> 2.14.4 ``                                                    |
| [`df496ea6`](https://github.com/NixOS/nixpkgs/commit/df496ea67e2a9e3e09b4c3c5394a38ef946b6923) | `` sketchybar: fix build ``                                                           |
| [`3c498a22`](https://github.com/NixOS/nixpkgs/commit/3c498a2216fe5992cd3a5e65330e5f06b1ebc2fd) | `` ustreamer: 5.36 -> 5.37 ``                                                         |
| [`beb3583b`](https://github.com/NixOS/nixpkgs/commit/beb3583b7716a453b54310a703367b114e3ab05e) | `` chirp: use wrapGAppsHook to fix file manager crash ``                              |
| [`952e23ab`](https://github.com/NixOS/nixpkgs/commit/952e23abcf188b59aa326ea9990bd0dd65682e79) | `` libmodsecurity: 3.0.8 -> 3.0.9 ``                                                  |
| [`0d0e8a1d`](https://github.com/NixOS/nixpkgs/commit/0d0e8a1df72177019960750cc2d7f3d68e8e56a3) | `` circt: 1.34.0 -> 1.37.0 ``                                                         |
| [`185a0cd7`](https://github.com/NixOS/nixpkgs/commit/185a0cd73d4bf2effaccfbaa1d064a4e7f1e292c) | `` nomad-driver-podman: 0.4.1 -> 0.4.2 (#224960) ``                                   |
| [`4236b224`](https://github.com/NixOS/nixpkgs/commit/4236b2245dbe76dbe9e5e9924e0ff9840878e3ae) | `` supabase-cli: 1.29.3 -> 1.48.1 (#224941) ``                                        |
| [`9aa3e69c`](https://github.com/NixOS/nixpkgs/commit/9aa3e69c99a99bad659e51ab18a179ca3eefa778) | `` yosys/plugins/ghdl.nix: fix build ``                                               |
| [`ec1631a0`](https://github.com/NixOS/nixpkgs/commit/ec1631a06f864c5303c86f63862e5bc3c4ee3e67) | `` uhd: fix cross ``                                                                  |
| [`cc768325`](https://github.com/NixOS/nixpkgs/commit/cc7683256548beb06bb5546660180d9a74646241) | `` exploitdb: 2023-04-13 -> 2023-04-15 ``                                             |
| [`9c9ce732`](https://github.com/NixOS/nixpkgs/commit/9c9ce732bc291bb50c033f852e9c7a54f75c6b76) | `` lefthook: 1.3.9 -> 1.3.10 ``                                                       |
| [`8050381a`](https://github.com/NixOS/nixpkgs/commit/8050381a438cf3a35ff0260c08e6c137dbfafaa8) | `` elasticsearch: bump version, adjust sha256, drop esversion 6.8.21 support ``       |
| [`6c15c20d`](https://github.com/NixOS/nixpkgs/commit/6c15c20d94bbd454bdc7c8e7e8b58779409fe9ff) | `` teams-for-linux: add hack fix for wayland screen-sharing ``                        |
| [`86f8f8ca`](https://github.com/NixOS/nixpkgs/commit/86f8f8caf5d7391e50eb52704caf9912449d15e7) | `` postgresqlPackages.pg_partman: add changelog to meta ``                            |
| [`3a032115`](https://github.com/NixOS/nixpkgs/commit/3a032115802a30cf69d728589a406b269218aa0d) | `` postgresql11JitPackages.pg_partman: 4.7.1 -> 4.7.3 ``                              |
| [`481dd8e7`](https://github.com/NixOS/nixpkgs/commit/481dd8e7f92825546751d89554ef91417186f30e) | `` iosevka-bin: 22.0.1 -> 22.0.2 ``                                                   |
| [`eea5ebb1`](https://github.com/NixOS/nixpkgs/commit/eea5ebb173ec55f9761534b5be8e6ebd58ee64d4) | `` webcord: 4.1.1 -> 4.2.0 ``                                                         |
| [`c26ff1d9`](https://github.com/NixOS/nixpkgs/commit/c26ff1d91894c9edd9285973af40aef1eed7a353) | `` opengrok: 1.9.2 -> 1.11.5 ``                                                       |
| [`ec5ee07b`](https://github.com/NixOS/nixpkgs/commit/ec5ee07b1b29070475284ada1eee05ec5b7ad821) | `` teams-for-linux: 1.0.59 -> 1.0.65 ``                                               |
| [`05a26cee`](https://github.com/NixOS/nixpkgs/commit/05a26cee27ab211691ef359f406bd71d53be59f1) | `` sapling: 0.2.20230228-144002-h9440b05e -> 0.2.20230330-193452-h69692651 ``         |
| [`b9e9372e`](https://github.com/NixOS/nixpkgs/commit/b9e9372e6be61a91f0b13fd5eb88b34ccd6d16ff) | `` gpsd: 3.24 -> 3.25 ``                                                              |
| [`0854f387`](https://github.com/NixOS/nixpkgs/commit/0854f3873d2a328bae0cd97b7148d850c2cc7602) | `` nix-direnv: 2.2.1 -> 2.3.0 ``                                                      |
| [`84e27921`](https://github.com/NixOS/nixpkgs/commit/84e27921aae555d309eebbdf00e309b016bb8991) | `` haunt: 0.2.4 -> 0.2.6 ``                                                           |
| [`ec9f9bc6`](https://github.com/NixOS/nixpkgs/commit/ec9f9bc670d71ebd15e2035fcb4259cebdaf3508) | `` dosbox-staging: pull upstream fixes for SDL2_net and SDL2_image headers ``         |
| [`7a40725f`](https://github.com/NixOS/nixpkgs/commit/7a40725f9eb291bb11a46122d93faeb661e536d6) | `` mautrix-whatsapp: 0.8.3 -> 0.8.4 ``                                                |
| [`91de60e1`](https://github.com/NixOS/nixpkgs/commit/91de60e122e657f978bc3fc047fd59ed7433c4cc) | `` batman-adv: 2022.3 -> 2023.0 ``                                                    |
| [`83a39a0a`](https://github.com/NixOS/nixpkgs/commit/83a39a0abe0d4ebb17958027ef1a595796d3c021) | `` python3Packages.rdkit: 2022.09.1 -> 2022.09.5 (#224600) ``                         |
| [`3a6205d9`](https://github.com/NixOS/nixpkgs/commit/3a6205d9f79fe526be03d8c465403b118ca4cf37) | `` ventoy: 1.0.90 -> 1.0.91 ``                                                        |
| [`c0ba68e8`](https://github.com/NixOS/nixpkgs/commit/c0ba68e87488480a1d30363f9515d4d185868574) | `` aliases.nix: add ventoy-bin and ventoy-bin-full as throws ``                       |
| [`630e1fbb`](https://github.com/NixOS/nixpkgs/commit/630e1fbb519211111401114e8d64b96ecbf76b69) | `` ventoy-bin: rename to ventoy ``                                                    |
| [`15c760d6`](https://github.com/NixOS/nixpkgs/commit/15c760d6b8fd425c4f10cda6f82959dd98ea191c) | `` nixos/make-disk-image: fix contents dir paths ``                                   |
| [`a711e445`](https://github.com/NixOS/nixpkgs/commit/a711e445cc057ac06160816b848f5752a6b4b753) | `` nixos/tests/ec2: Fix test tooling ``                                               |
| [`b605a205`](https://github.com/NixOS/nixpkgs/commit/b605a205390e53e18c03329ab3dba489970c1e0a) | `` gleam: 0.27.0 -> 0.28.2 ``                                                         |
| [`d8f05d46`](https://github.com/NixOS/nixpkgs/commit/d8f05d468eb7b0a97cef73b9b6631613cfac13a7) | `` f2fs-tools: 1.15.0 -> 1.16.0 ``                                                    |
| [`a373f763`](https://github.com/NixOS/nixpkgs/commit/a373f76301cb87598ffe9bdbd5323a0d82edb572) | `` cloudflare-warp: fix build ``                                                      |
| [`866378da`](https://github.com/NixOS/nixpkgs/commit/866378da6ed3203ad01fe17b0818227c073319a5) | `` findomain: 8.2.2 -> 9.0.0, add figsoda as a maintainer ``                          |
| [`f30febf8`](https://github.com/NixOS/nixpkgs/commit/f30febf83039aaa4a4399d46d068900a2b449de6) | `` form: 4.3.0 -> 4.3.1 ``                                                            |
| [`46792be4`](https://github.com/NixOS/nixpkgs/commit/46792be4d0e899b12bdb1ecb49c7ce5474fae1ae) | `` typst-lsp: 0.3.0 -> 0.4.0, add figsoda as a maintainer ``                          |
| [`c62a52ff`](https://github.com/NixOS/nixpkgs/commit/c62a52ff59d409478d4d8269a591222b4e15c029) | `` python310Packages.tplink-omada-client: 1.1.5 -> 1.2.3 ``                           |
| [`8792ed32`](https://github.com/NixOS/nixpkgs/commit/8792ed32bb8f8c88449713cb6720ff6e59ddcbe2) | `` python310Packages.peaqevcore: 15.2.8 -> 15.3.1 ``                                  |
| [`d1831b37`](https://github.com/NixOS/nixpkgs/commit/d1831b373a55345489ac64f819d3d0d347abc647) | `` python310Packages.publicsuffixlist: 0.9.3 -> 0.9.4 ``                              |
| [`8b0d32ba`](https://github.com/NixOS/nixpkgs/commit/8b0d32ba68c39fa8739fff6415af868574d8d17a) | `` python310Packages.hahomematic: 2023.3.1 -> 2023.4.0 ``                             |
| [`3cc8b447`](https://github.com/NixOS/nixpkgs/commit/3cc8b4477e175bb700022c147a59bd40e0de8161) | `` python3.pkgs.ihatemoney: remove ``                                                 |
| [`9da70d13`](https://github.com/NixOS/nixpkgs/commit/9da70d133f182fd6afaf437ca4f03694922a5d31) | `` syncthingtray: Add Darwin support ``                                               |
| [`e0eec9ae`](https://github.com/NixOS/nixpkgs/commit/e0eec9aed436763c822664bd791cfeeb717314f1) | `` qtforkawesome: Add Darwin to supported platforms ``                                |
| [`1dffb0f9`](https://github.com/NixOS/nixpkgs/commit/1dffb0f917025ef0447511eadcc0f2205ef799e1) | `` qtutilities: Add Darwin to supported platforms ``                                  |
| [`8e3b7417`](https://github.com/NixOS/nixpkgs/commit/8e3b74171da04dec217866ce89e6c6c453ca23e0) | `` cpp-utilities: Add Darwin support ``                                               |
| [`0e72f5fa`](https://github.com/NixOS/nixpkgs/commit/0e72f5fab96275c23e91e571cc3fc8fb903b8ef5) | `` python3Packages.trino-python-client: init at 0.322.0 ``                            |
| [`cb5a83c6`](https://github.com/NixOS/nixpkgs/commit/cb5a83c60c8ca03a5704faf7b2b4c755fa92c597) | `` signal-cli: 0.11.7 -> 0.11.8 ``                                                    |
| [`adfa13ca`](https://github.com/NixOS/nixpkgs/commit/adfa13cadfbad7d91d73375c1d35824999888e9b) | `` python3Packages.pydata-google-auth: init at 1.7.0 ``                               |
| [`f05bd43e`](https://github.com/NixOS/nixpkgs/commit/f05bd43e9239ef98697cadc66294a05ece28d233) | `` ksnip: fix typo in description ``                                                  |
| [`dc15146c`](https://github.com/NixOS/nixpkgs/commit/dc15146cbec976f735a186fece7dad084de8c3f5) | `` python3Packages.sqlalchemy-views: init at 0.3.2 ``                                 |
| [`bebf5b1a`](https://github.com/NixOS/nixpkgs/commit/bebf5b1a38c39221041c0191f240c20d5a0ab1c0) | `` python3Packages.sphinx-copybutton: 0.5.1 -> 0.5.2 ``                               |
| [`68bd8123`](https://github.com/NixOS/nixpkgs/commit/68bd81231ad40850af59bbd2865f99d2bd8fdeb3) | `` python310Packages.django-hierarkey: init at 1.1.0 ``                               |
| [`db5206b9`](https://github.com/NixOS/nixpkgs/commit/db5206b982434c26419e21922c65d1563756ab48) | `` python310Packages.django-countries: init at 7.5.1 ``                               |
| [`ed28d79f`](https://github.com/NixOS/nixpkgs/commit/ed28d79fd468d1da51d7341395c2846f11fd1bf0) | `` python310Packages.django-markup: init at 1.6 ``                                    |
| [`9628dfdc`](https://github.com/NixOS/nixpkgs/commit/9628dfdca89be7999e09ab762c766af4f757648a) | `` python310Packages.python-creole: init at 1.4.10 ``                                 |
| [`8cc14b77`](https://github.com/NixOS/nixpkgs/commit/8cc14b775d182e7e05ed4990307f223f2716726a) | `` python310Packages.django-formset-js-improved: init at 0.5.0.3 ``                   |
| [`a2819ed8`](https://github.com/NixOS/nixpkgs/commit/a2819ed80d8d08f6c7da125d4fb67c39837e10c0) | `` python310Packages.django-jquery-js: init at 3.1.1 ``                               |
| [`84f0e42d`](https://github.com/NixOS/nixpkgs/commit/84f0e42d595274b6630fa9a7a35b5cb8c92c58b2) | `` python310Packages.django-bootstrap3: init at 23.1 ``                               |
| [`4825f97f`](https://github.com/NixOS/nixpkgs/commit/4825f97fce5d1755da136724a0c5eed57c7bd64d) | `` nvc: 1.9.0 -> 1.9.1 ``                                                             |
| [`12875aed`](https://github.com/NixOS/nixpkgs/commit/12875aede6e6ae67b645e91b499728b609855d82) | `` openlens: 6.4.5 -> 6.4.15 ``                                                       |
| [`424e5ca7`](https://github.com/NixOS/nixpkgs/commit/424e5ca7c99f5a4c08f8480bc3be395181ec827a) | `` xcbuild: add ProductBuildVersion ``                                                |
| [`2486e007`](https://github.com/NixOS/nixpkgs/commit/2486e00723d532ee2a2b5c9c3ae164f6f2b5dbc7) | `` tidb: 6.6.0 -> 7.0.0 ``                                                            |
| [`49313171`](https://github.com/NixOS/nixpkgs/commit/49313171fab800e24357b68ebc3e4171d4964bb4) | `` qovery-cli: 0.57.1 -> 0.58.1 ``                                                    |
| [`60eeffdd`](https://github.com/NixOS/nixpkgs/commit/60eeffddb3c2e32910658285cc90fc388674801a) | `` python310Packages.ocifs: 1.1.4 -> 1.2.1 ``                                         |
| [`14defab3`](https://github.com/NixOS/nixpkgs/commit/14defab355e97cd6289dad730f14c2e124b5fc19) | `` nnn: 4.7 → 4.8 ``                                                                  |
| [`f9910b39`](https://github.com/NixOS/nixpkgs/commit/f9910b39bd3115a72630b1dd102f536faac324fc) | `` anki: allow using wayland on linux ``                                              |
| [`51b7374e`](https://github.com/NixOS/nixpkgs/commit/51b7374ec9fba88c713a704d8515edaa5cbc8b65) | `` ncmpc: 0.47 -> 0.48 ``                                                             |
| [`31b0ff34`](https://github.com/NixOS/nixpkgs/commit/31b0ff34acdc2c2d7bdc9a44451c5121c4f039e3) | `` hut: 0.2.0 -> 0.3.0 ``                                                             |
| [`faed40ae`](https://github.com/NixOS/nixpkgs/commit/faed40ae61e3511610be2d5f76148c4740f34545) | `` gnomeExtensions.volume-mixer: remove patch ``                                      |
| [`4b53c01e`](https://github.com/NixOS/nixpkgs/commit/4b53c01e5620be6156139d4e38d7b0c00634de75) | `` gnomeExtensions.screen-autorotate: remove patch ``                                 |
| [`c9e56bda`](https://github.com/NixOS/nixpkgs/commit/c9e56bdab7058e5b6342a7303889cd321b1dc4a2) | `` gnomeExtensions: Update for GNOME 44 ``                                            |
| [`a602da1b`](https://github.com/NixOS/nixpkgs/commit/a602da1b892282fa636bed6c43b883225e692e9a) | `` python310Packages.django-two-factor-auth: add optional-dependencies ``             |
| [`d8818256`](https://github.com/NixOS/nixpkgs/commit/d88182569de61464d2b663ad1957aae63acf005f) | `` iamb: init at 0.0.7 ``                                                             |
| [`61bde15d`](https://github.com/NixOS/nixpkgs/commit/61bde15dd727493ffa57a3dc5e05f3bcf22832e4) | `` cotton: unstable-2022-10-04 -> unstable-2023-04-13, add figsoda as a maintainer `` |
| [`be7c854c`](https://github.com/NixOS/nixpkgs/commit/be7c854cb42f5bebaa8c580d2159e9809707d207) | `` python310Packages.palettable: add changelog to meta ``                             |
| [`6b4d7301`](https://github.com/NixOS/nixpkgs/commit/6b4d7301fe456002729dfbade9609c787b29684a) | `` arkade: 0.9.11 -> 0.9.12 ``                                                        |
| [`399081df`](https://github.com/NixOS/nixpkgs/commit/399081df3e9c77ec6fc06243b1a9aba05e23f1be) | `` bob: 0.8.0 -> 0.8.1 ``                                                             |
| [`8b8c09ac`](https://github.com/NixOS/nixpkgs/commit/8b8c09ac7633f3cc4cd130e33a3bc9e6d667c305) | `` python310Packages.palettable: use pytestCheckHook ``                               |
| [`be005b59`](https://github.com/NixOS/nixpkgs/commit/be005b5940fc4e82be117391d02029dd61b51fa2) | `` python310Packages.palettable: 3.3.1 -> 3.3.2 ``                                    |
| [`31d68027`](https://github.com/NixOS/nixpkgs/commit/31d680277326600fd73ad5681993447f8e30ac65) | `` gnatboot: rename to gnat-bootstrap ``                                              |
| [`cd27779d`](https://github.com/NixOS/nixpkgs/commit/cd27779dbcf3f27ab7b438c86757f899d3080efb) | `` nurl: 0.3.10 -> 0.3.11 ``                                                          |
| [`72459934`](https://github.com/NixOS/nixpkgs/commit/7245993436c99e7568ee8a0fb44776f498245a99) | `` python3Packages.duckdb-engine: 0.6.9 -> 0.7.0 ``                                   |
| [`8b22596a`](https://github.com/NixOS/nixpkgs/commit/8b22596a5ef6c47d8f7597b1b9e147fe0ea5ca67) | `` duckdb: ignore now-failing timezone/icu tests ``                                   |
| [`ed44e8ba`](https://github.com/NixOS/nixpkgs/commit/ed44e8baa48ba76f3002f5d87f1512445edf0c84) | `` vale: 2.24.0 -> 2.24.2 ``                                                          |
| [`33c6ef15`](https://github.com/NixOS/nixpkgs/commit/33c6ef1560100b51179d4e1deee4b406e8a234c6) | `` dot-language-server: init at 1.1.26 ``                                             |
| [`5f445d9d`](https://github.com/NixOS/nixpkgs/commit/5f445d9dbddf41be2f75297d292c25782faa1af1) | `` python310Packages.bitsandbytes: init at 0.38.0 ``                                  |
| [`758f1e9b`](https://github.com/NixOS/nixpkgs/commit/758f1e9b833426c3aaebc482fd21b549e0506fee) | `` python310Packages.lion-pytorch: init at 0.0.7 ``                                   |
| [`ae994654`](https://github.com/NixOS/nixpkgs/commit/ae9946549c0931e53b4e16518a24c9e857b842ea) | `` rdc: fix build ``                                                                  |
| [`2fe6f096`](https://github.com/NixOS/nixpkgs/commit/2fe6f096c93aa78624bf45d5e7239b7591bf3fd6) | `` python3.pkgs.django-two-factor-auth: init at 1.15.1 ``                             |
| [`fdbd0834`](https://github.com/NixOS/nixpkgs/commit/fdbd0834b2cd974c16718297474a7f60e8d92ba7) | `` nixos/smokeping: use ln with -f ``                                                 |
| [`197ed8e7`](https://github.com/NixOS/nixpkgs/commit/197ed8e75df56e5bb9776cda3c04c72a8c939a66) | `` mediamtx: Remove doronbehar from maintenance. ``                                   |
| [`504849a7`](https://github.com/NixOS/nixpkgs/commit/504849a7bb581207756d5767d55213ee422281ce) | `` rtsp-simple-server: rebrand as mediamtx ``                                         |
| [`13a46443`](https://github.com/NixOS/nixpkgs/commit/13a464432548c18924e8a1183209e61050d9f10d) | `` playwright: 1.30.0 -> 1.31.1 ``                                                    |
| [`dd16761a`](https://github.com/NixOS/nixpkgs/commit/dd16761a2b8c15321bf22f89884c9def72a8e584) | `` playwright: remove firefox support ``                                              |
| [`20559ae2`](https://github.com/NixOS/nixpkgs/commit/20559ae2863ba0554df5a7cfcea21955ed406dee) | `` playwright: 1.27.1 -> 1.30.0 ``                                                    |
| [`121dfc18`](https://github.com/NixOS/nixpkgs/commit/121dfc185a23113173e653cd538f80ff9171f3c3) | `` rtsp-simple-server: 0.21.6 -> 0.22.0 ``                                            |
| [`c647fb0d`](https://github.com/NixOS/nixpkgs/commit/c647fb0d79f2d1e3e191aa198060976eb27bd7c6) | `` bob: 0.7.2 -> 0.8.0 ``                                                             |
| [`755f2ec7`](https://github.com/NixOS/nixpkgs/commit/755f2ec7c2e9715cbb57b4a4a8d76ec2e3f0a490) | `` arkade: 0.9.6 -> 0.9.11 ``                                                         |
| [`053afa80`](https://github.com/NixOS/nixpkgs/commit/053afa8036b68ee9f7a485e6f9d942af49b32c59) | `` astc-encoder: 4.3.1 -> 4.4.0 ``                                                    |
| [`1fefeb75`](https://github.com/NixOS/nixpkgs/commit/1fefeb759ee29c4547a8b3d2078da19d9b3a40db) | `` influxdb2-cli: 2.5.0 -> 2.7.1 ``                                                   |
| [`46e32697`](https://github.com/NixOS/nixpkgs/commit/46e326973d603fe90975b62549385401213e608a) | `` python310Packages.asf-search: 6.2.0 -> 6.3.1 ``                                    |
| [`8d91dcbf`](https://github.com/NixOS/nixpkgs/commit/8d91dcbfe000a08d3c3a229781482ad5f0dfda88) | `` pdm: 2.4.6 -> 2.5.1 ``                                                             |
| [`57f54cea`](https://github.com/NixOS/nixpkgs/commit/57f54cea65dc6725d48e75204ecbd91e46077ef0) | `` libcpuid: 0.6.2 -> 0.6.3 ``                                                        |
| [`bf893d1b`](https://github.com/NixOS/nixpkgs/commit/bf893d1b9e656f32024dd96e229f0b4a62642af2) | `` python3Packages.unearth: 0.7.2 -> 0.9.0 ``                                         |
| [`9810382a`](https://github.com/NixOS/nixpkgs/commit/9810382a6c474ba358e9db2761cee794ca7fc92c) | `` geckodriver: 0.32.2 -> 0.33.0 ``                                                   |
| [`e7997ece`](https://github.com/NixOS/nixpkgs/commit/e7997ece6ec632512e534ef8a79b9988e06a1160) | `` kstars: 3.6.3 -> 3.6.4 ``                                                          |
| [`c30de189`](https://github.com/NixOS/nixpkgs/commit/c30de18915f3686f38741be9f5f67bd5ec06d32b) | `` python310Packages.palettable: 3.3.0 -> 3.3.1 ``                                    |
| [`266bbb12`](https://github.com/NixOS/nixpkgs/commit/266bbb12b427e7ed600a8beb71b179c126537af3) | `` yubikey-manager-qt: set meta.mainProgram ``                                        |
| [`052463fa`](https://github.com/NixOS/nixpkgs/commit/052463fa20757074f8e7ac6e41d91a4ac5caceca) | `` python310Packages.google-api-python-client: 2.83.0 -> 2.84.0 ``                    |
| [`42748a7d`](https://github.com/NixOS/nixpkgs/commit/42748a7d6d42a8c8122687afe83df7b97aced730) | `` libheif: 1.15.1 -> 1.15.2 ``                                                       |
| [`12bc0de0`](https://github.com/NixOS/nixpkgs/commit/12bc0de0c03a7c4511cc6f0645ebeeb0dd572557) | `` python310Packages.kornia: init at 0.6.11 ``                                        |
| [`98e736d0`](https://github.com/NixOS/nixpkgs/commit/98e736d09e166f11464a5925741d64e6637f645f) | `` metabase: 0.45.2.1 -> 0.46.1 ``                                                    |
| [`86d052f7`](https://github.com/NixOS/nixpkgs/commit/86d052f7d44af5a193d99ac84f1bc3828fcfbd43) | `` kind: 0.17.0 -> 0.18.0 ``                                                          |
| [`32f10b45`](https://github.com/NixOS/nixpkgs/commit/32f10b45f8458a495a5d96a7c3f06fc3a02d1fa7) | `` fishPlugins.wakatime-fish: init at 0.0.3 ``                                        |
| [`2638fb72`](https://github.com/NixOS/nixpkgs/commit/2638fb722ec78b51695b6be2aa5affef97263c4c) | `` systemd-boot-builder only ignores OSError "invalid argument" ``                    |
| [`1fd08a86`](https://github.com/NixOS/nixpkgs/commit/1fd08a866e6c83decd019008b1e35f8c97c916a4) | `` sherlock:  0.14.0 -> 0.14.3 ``                                                     |
| [`d5b9f6cc`](https://github.com/NixOS/nixpkgs/commit/d5b9f6cc5a356201a65e05b5050480aef6d651b2) | `` python310Packages.pysigma: 0.9.4 -> 0.9.5 ``                                       |
| [`5e30b82d`](https://github.com/NixOS/nixpkgs/commit/5e30b82dabf0bf6a8212c7e44f13336589f09a34) | `` micropad: 4.2.0 -> 4.2.1 ``                                                        |