### PR TITLE
chore(flake/stylix): `c80d054f` -> `7e70eedc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681481742,
-        "narHash": "sha256-VIc2fV6P3o4b+C+qFji7YfUZVZE/LtBDOR+TJujBr/4=",
+        "lastModified": 1681890933,
+        "narHash": "sha256-fhtIKKtzt11Rq1xkk6GrP1x33mB240DRplpMmaz1xzM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "c80d054fd4b62a4e8e1accf9c22b2e622737aadd",
+        "rev": "7e70eedc49d058f6d97bb6c37a39776b4d2ef6e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                        |
| --------------------------------------------------------------------------------------------- | ------------------------------ |
| [`7e70eedc`](https://github.com/danth/stylix/commit/7e70eedc49d058f6d97bb6c37a39776b4d2ef6e8) | `` Add fzf module (#84) ``     |
| [`5925e3da`](https://github.com/danth/stylix/commit/5925e3da17bcf49f91b5c78fa498b222cea8f3f7) | `` Add kmscon support (#86) `` |