### PR TITLE
chore(flake/nixpkgs): `f00994e7` -> `555daa9d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -217,11 +217,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681737997,
-        "narHash": "sha256-pHhjgsIkRMu80LmVe8QoKIZB6VZGRRxFmIvsC5S89k4=",
+        "lastModified": 1681828457,
+        "narHash": "sha256-o4Zvs309HOhrNeVloPKqangcKHobsggVt6GFbnEPZlQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f00994e78cd39e6fc966f0c4103f908e63284780",
+        "rev": "555daa9d339b3df75e58ee558a4fec98ea92521e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`9b419c67`](https://github.com/NixOS/nixpkgs/commit/9b419c67cfeb210d333fc0c34ae6e8c7a987d443) | `` ocaml-ng.ocamlPackages_4_02.bdd: fix build ``                                               |
| [`114ea420`](https://github.com/NixOS/nixpkgs/commit/114ea420db12a3a6fa19b6aadce52b25819c3481) | `` ocamlPackages.slug: init at 1.0.1 ``                                                        |
| [`d2f4583e`](https://github.com/NixOS/nixpkgs/commit/d2f4583edc1190820a0e3da837f9c6195a587f30) | `` virglrenderer: enable debug info ``                                                         |
| [`b3927c2a`](https://github.com/NixOS/nixpkgs/commit/b3927c2a0f89e0cab46b41e029ba9a2271896383) | `` mercurial: 6.4.1 -> 6.4.2 ``                                                                |
| [`e956ce0a`](https://github.com/NixOS/nixpkgs/commit/e956ce0a46ec1fa958ceff40e75531894e52ff70) | `` gavin-bc: 6.2.4 -> 6.5.0 ``                                                                 |
| [`47651eba`](https://github.com/NixOS/nixpkgs/commit/47651eba67d099d863f54b5a7e11515d7c2cd137) | `` gavin-bc: add meta.changelog ``                                                             |
| [`282d879c`](https://github.com/NixOS/nixpkgs/commit/282d879c0341129e7bf30e29b516cff542004c03) | `` gavin-bc: fix configureFlags ``                                                             |
| [`34eac236`](https://github.com/NixOS/nixpkgs/commit/34eac2362be4364de5b7265e7ac42ebd6538a6b9) | `` python310Packages.ibis-framework: 4.1.0 -> 5.1.0 ``                                         |
| [`60b08961`](https://github.com/NixOS/nixpkgs/commit/60b08961e05d999b74eb96ad77b1fac7b8f08d96) | `` python311Packages.pyorthanc: add changelog to meta ``                                       |
| [`1b2eded7`](https://github.com/NixOS/nixpkgs/commit/1b2eded7104def5896a15144c9a23a56a892f3da) | `` python311Packages.pyorthanc: 1.11.4 -> 1.11.5 ``                                            |
| [`84a92710`](https://github.com/NixOS/nixpkgs/commit/84a927100031b8e87372510d5e2bb211c3fbf1f8) | `` d2: 0.4.0 -> 0.4.1 ``                                                                       |
| [`d9f622af`](https://github.com/NixOS/nixpkgs/commit/d9f622af3386887b917e44d30cbd1096c6ece87b) | `` cloudfox: 1.10.2 -> 1.10.3 ``                                                               |
| [`54a682e1`](https://github.com/NixOS/nixpkgs/commit/54a682e11929364163447d611954d0f57ec17d40) | `` delve: 1.20.1 -> 1.20.2 ``                                                                  |
| [`d3648861`](https://github.com/NixOS/nixpkgs/commit/d3648861353cf50fa8e315c4b2998ac1dbb92858) | `` python310Packages.meraki: add changelog to meta ``                                          |
| [`e9dadae2`](https://github.com/NixOS/nixpkgs/commit/e9dadae2c6487e02cf791348dad522cd65df0b33) | `` python310Packages.mcstatus: 10.0.2 -> 10.0.3 ``                                             |
| [`bc35d8dc`](https://github.com/NixOS/nixpkgs/commit/bc35d8dce2d9bef43938a1f3c00a75ca3f25b49a) | `` python310Packages.aqualogic: 3.3 -> 3.4 ``                                                  |
| [`5bbb301b`](https://github.com/NixOS/nixpkgs/commit/5bbb301be2b91eee486949389abe254bc6643bbb) | `` ocamlPackages.bdd: init at unstable-2022-07-14 ``                                           |
| [`50ce88d4`](https://github.com/NixOS/nixpkgs/commit/50ce88d4ae0920ae4e0ac219774051c211a866a7) | `` ocamlPackages.mdx: 2.2.1 → 2.3.0 ``                                                         |
| [`f20115d2`](https://github.com/NixOS/nixpkgs/commit/f20115d27df7e71183fd54f896ee08a4319414e1) | `` gnomeExtensions.arcmenu: 43 -> 44 ``                                                        |
| [`49c494be`](https://github.com/NixOS/nixpkgs/commit/49c494be20e172979d16245bb77bca41e4858dc6) | `` ddosify: 0.15.4 -> 0.16.2 ``                                                                |
| [`e2584d57`](https://github.com/NixOS/nixpkgs/commit/e2584d57d6a54532b7027123756649997d6f78e1) | `` exportarr: 1.2.6 -> 1.3.1 ``                                                                |
| [`53b6e1a3`](https://github.com/NixOS/nixpkgs/commit/53b6e1a3c5ad2d42bd97f8a108bdb275954bf38b) | `` rustc: fix >=1.68 host!=build ``                                                            |
| [`1e2c3e2e`](https://github.com/NixOS/nixpkgs/commit/1e2c3e2e130e3c70187f0f49d86cd9ee0b1cffc0) | `` terraform-providers.vault: 3.14.0 -> 3.15.0 ``                                              |
| [`767714eb`](https://github.com/NixOS/nixpkgs/commit/767714eb50c9d08f33f7907b60661dd3c96f73b4) | `` terraform-providers.ucloud: 1.35.1 -> 1.36.0 ``                                             |
| [`22eace22`](https://github.com/NixOS/nixpkgs/commit/22eace2276747c34272fd73d956eae8bce5c4237) | `` terraform-providers.pagerduty: 2.14.1 -> 2.14.2 ``                                          |
| [`a55f1a9e`](https://github.com/NixOS/nixpkgs/commit/a55f1a9e97a634ba97029de2ba1ab2bc55555d6c) | `` terraform-providers.okta: 3.45.0 -> 3.46.0 ``                                               |
| [`6c1b3d79`](https://github.com/NixOS/nixpkgs/commit/6c1b3d79173d84a1ee34da69527bbbd71e7cc4dc) | `` terraform-providers.grafana: 1.37.1 -> 1.37.2 ``                                            |
| [`48b8f87d`](https://github.com/NixOS/nixpkgs/commit/48b8f87d8cc9b58b2c29395f26f8b0a70be6a1cf) | `` terraform-providers.google-beta: 4.61.0 -> 4.62.0 ``                                        |
| [`c335883b`](https://github.com/NixOS/nixpkgs/commit/c335883b49db3b62b0658fdd9b0278cd1527723d) | `` terraform-providers.google: 4.61.0 -> 4.62.0 ``                                             |
| [`70ddbe7a`](https://github.com/NixOS/nixpkgs/commit/70ddbe7ace9efaa5511d6d3a485f7ba69697f078) | `` terraform-providers.azuread: 2.37.0 -> 2.37.1 ``                                            |
| [`f88eb92f`](https://github.com/NixOS/nixpkgs/commit/f88eb92ff9cee37efada430c33311673814c8360) | `` platformio: Don't link udev rules into a subdirectory ``                                    |
| [`9d228c10`](https://github.com/NixOS/nixpkgs/commit/9d228c10ba1d25c37abfa82a497f34d188fd7359) | `` fulcrum: 1.9.0 -> 1.9.1 ``                                                                  |
| [`df24febd`](https://github.com/NixOS/nixpkgs/commit/df24febd83fa458533748d61fc51c857ff29dbaa) | `` vscodium: 1.77.1.23095 -> 1.77.3.23102 ``                                                   |
| [`10d06c61`](https://github.com/NixOS/nixpkgs/commit/10d06c610fb80e724a53599b87a831f63b927866) | `` abiword: set strictDeps=true ``                                                             |
| [`715bc56b`](https://github.com/NixOS/nixpkgs/commit/715bc56b080974f2be2bd985a0b96c95cefb3c05) | `` abiword: fix cross ``                                                                       |
| [`1df6c2d1`](https://github.com/NixOS/nixpkgs/commit/1df6c2d1488517d3b893d2c7e38513df96f1303b) | `` havoc: 0.4.0 -> 0.5.0 ``                                                                    |
| [`788fa2fe`](https://github.com/NixOS/nixpkgs/commit/788fa2feda53a5e715aa4df124cb36d90e56e701) | `` pipes-rs: update license ``                                                                 |
| [`f03dba5d`](https://github.com/NixOS/nixpkgs/commit/f03dba5d676b2dbd0ff46147c982b49884f389cf) | `` python3Packages.meraki: 1.30.0 -> 1.32.1 ``                                                 |
| [`338611e7`](https://github.com/NixOS/nixpkgs/commit/338611e7663c010494780f84e08e2420bb895560) | `` stratisd: 3.5.2 -> 3.5.3 ``                                                                 |
| [`1fbdaa0e`](https://github.com/NixOS/nixpkgs/commit/1fbdaa0e43620289495d136a73745a8a461e77a1) | `` go-jsonnet: 0.19.1 -> 0.20.0 ``                                                             |
| [`bb674c65`](https://github.com/NixOS/nixpkgs/commit/bb674c654f3e1e7ec0b58f6bbcb78ac98a80024c) | `` algolia-cli: 1.3.2 -> 1.3.4 ``                                                              |
| [`406ff6a7`](https://github.com/NixOS/nixpkgs/commit/406ff6a75dc020e3634235fdd113fc7f65246a70) | `` faas-cli: 0.15.9 -> 0.16.3 ``                                                               |
| [`df24f905`](https://github.com/NixOS/nixpkgs/commit/df24f90584734a76ae47f527c17de708cc03025c) | `` ghorg: 1.9.1 -> 1.9.4 ``                                                                    |
| [`77aa927a`](https://github.com/NixOS/nixpkgs/commit/77aa927abcc77c0e124b6ddee69356f8012c2d36) | `` air: 1.42.0 -> 1.43.0 ``                                                                    |
| [`2f81686e`](https://github.com/NixOS/nixpkgs/commit/2f81686ec826ec91bc19200af30b5494030646c7) | `` router: init at 1.15.0 ``                                                                   |
| [`86b0fd9f`](https://github.com/NixOS/nixpkgs/commit/86b0fd9fd726b851a3afb35af3925df10f2e388d) | `` coreth: 0.11.9 -> 0.12.0 ``                                                                 |
| [`f21e8bbf`](https://github.com/NixOS/nixpkgs/commit/f21e8bbfcaecf54594ca2b2915adde2c112ea1a1) | `` chezmoi: 2.33.0 -> 2.33.1 ``                                                                |
| [`feede794`](https://github.com/NixOS/nixpkgs/commit/feede7944493802f82aadbad045654c92e7fac1e) | `` gopass: 1.15.4 -> 1.15.5 ``                                                                 |
| [`229fb0c0`](https://github.com/NixOS/nixpkgs/commit/229fb0c066610346150a754325f65e61018ea61f) | `` envsubst: 1.2.0 -> 1.4.2 ``                                                                 |
| [`e1f004d9`](https://github.com/NixOS/nixpkgs/commit/e1f004d9c5306607f3e6a0451ac4f2416464e24a) | `` systeroid: 0.3.1 -> 0.3.2 ``                                                                |
| [`4df48038`](https://github.com/NixOS/nixpkgs/commit/4df48038a44e9f3a3da8e9b42ca182726b743de4) | `` ucg: mark as broken on Darwin ``                                                            |
| [`a5df3bfe`](https://github.com/NixOS/nixpkgs/commit/a5df3bfe1fe071a434d1a6c19396b934eb4286c7) | `` ucg: 2019-02-25 -> 2022-09-03 ``                                                            |
| [`96cbb174`](https://github.com/NixOS/nixpkgs/commit/96cbb1743f22de91d39a4839512586eb7917dd3b) | `` ucg: cosmetical rewrite ``                                                                  |
| [`ce8e0c72`](https://github.com/NixOS/nixpkgs/commit/ce8e0c72d5f879ea5977e52fb1c8e25185f3953d) | `` libmad: add some key reverse dependencies to passthru.tests ``                              |
| [`34dbbdd6`](https://github.com/NixOS/nixpkgs/commit/34dbbdd6ebd9d029166dd5a31a7412132f134633) | `` haskellPackages: Add myself as maintainer for some packages ``                              |
| [`2c544dbb`](https://github.com/NixOS/nixpkgs/commit/2c544dbb850d2c2843c6d80f6b072d773d79e212) | `` haskellPackages.ghc-debug-brick: Fix build ``                                               |
| [`7f0e7444`](https://github.com/NixOS/nixpkgs/commit/7f0e744480f2aec5ea22faebcf6ad142fc1bead1) | `` python310Packages.pylacrosse: patch version ``                                              |
| [`9b233b8f`](https://github.com/NixOS/nixpkgs/commit/9b233b8fd3a870042beb8f1493ea84bf0fc96d04) | `` rofi-emoji: 3.1.0 -> 3.2.0 ``                                                               |
| [`cb2d5a2f`](https://github.com/NixOS/nixpkgs/commit/cb2d5a2fa9f2fa6dd2a619fc3be3e2de21a6a2f4) | `` gdbHostCpuOnly: init (#226134) ``                                                           |
| [`50bf9252`](https://github.com/NixOS/nixpkgs/commit/50bf9252cc6d70f7532cc3a7be75311e2d913772) | `` gnomeExtensions.dash-to-dock v79 -> v80 ``                                                  |
| [`aac197ee`](https://github.com/NixOS/nixpkgs/commit/aac197ee00feae0f9e46310c394553c0279fd5a2) | `` redis: 7.0.10 -> 7.0.11 ``                                                                  |
| [`0f2e3635`](https://github.com/NixOS/nixpkgs/commit/0f2e3635c5c8d82fda0319f23ed6b3b3d939f874) | `` haskellPackages: mark builds failing on hydra as broken ``                                  |
| [`d8ac0784`](https://github.com/NixOS/nixpkgs/commit/d8ac078493a6e443786e1204b1edf329d8c3e751) | `` octavePackages.ltfat: remove old syntax-error.patch ``                                      |
| [`cd439c64`](https://github.com/NixOS/nixpkgs/commit/cd439c64b0abe18e7fe8982b9387c67e31354e74) | `` octavePackages.stk: update source URL ``                                                    |
| [`a5c08404`](https://github.com/NixOS/nixpkgs/commit/a5c08404835b908ad98b6a20756b614f5910ce1c) | `` python310Packages.reolink-aio: 0.5.12 -> 0.5.13 ``                                          |
| [`4463a6c2`](https://github.com/NixOS/nixpkgs/commit/4463a6c2c42821ef1f7965f1a500c98861303cf4) | `` octavePackages.ltfat: update source URL ``                                                  |
| [`9941f145`](https://github.com/NixOS/nixpkgs/commit/9941f1457d010a2e3c4cfd88fd298b8374bf1953) | `` python310Packages.env-canada: 0.5.32 -> 0.5.33 ``                                           |
| [`175c646b`](https://github.com/NixOS/nixpkgs/commit/175c646b8a734107f6ae034a528d59711f5601eb) | `` texlive.bin.xindy: add perl to buildInputs to fix shebang (#226530) ``                      |
| [`98182aec`](https://github.com/NixOS/nixpkgs/commit/98182aec04aa1d429db5b4fe1c16a057e13306d3) | `` llvmPackages_git: unstable-2022-26-07 → 15.0.7 ``                                           |
| [`a77eef2b`](https://github.com/NixOS/nixpkgs/commit/a77eef2bb9970e9fd911c834cba6d22e1261d07b) | `` llvmPackages_git: expose the release information and monorepo source as overridable args `` |
| [`4917dc75`](https://github.com/NixOS/nixpkgs/commit/4917dc751ccc14daf238294dfc0ac862a28ceea1) | `` llvmPackages_git.llvm: add checks for the LLVM version ``                                   |
| [`ad0c509f`](https://github.com/NixOS/nixpkgs/commit/ad0c509f731c0f51f58f25a3d9d099cb1c634b93) | `` pipes-rs: 1.6.0 -> 1.6.1 ``                                                                 |
| [`37a45abb`](https://github.com/NixOS/nixpkgs/commit/37a45abb280e266b161a1b1f37d72ebd4c48ca48) | `` circup: 1.1.4 -> 1.2.1 ``                                                                   |
| [`fb13118f`](https://github.com/NixOS/nixpkgs/commit/fb13118f4bdf15850909aab93b63612e0b4f7902) | `` kapp: 0.54.1 -> 0.55.0 ``                                                                   |
| [`2f35bf5d`](https://github.com/NixOS/nixpkgs/commit/2f35bf5d34e6bb40b21ce8009c54a0af0b984f36) | `` octaveFull: 8.1.0 -> 8.2.0 ``                                                               |
| [`962d920b`](https://github.com/NixOS/nixpkgs/commit/962d920b8dff4607dd27d33c36c88e4882f62a96) | `` honggfuzz: enable on aarch64-linux ``                                                       |
| [`d8cd4e60`](https://github.com/NixOS/nixpkgs/commit/d8cd4e60d1f8bbdd5cb2be79901474e15c11b6b4) | `` honggfuzz: install libraries, too ``                                                        |
| [`6da3d3a4`](https://github.com/NixOS/nixpkgs/commit/6da3d3a400a0e0bbccc4dcc20862e0211cd3a6e3) | `` lxqt.xdg-desktop-portal-lxqt: 0.3.0 -> 0.4.0 ``                                             |
| [`73c9e3a6`](https://github.com/NixOS/nixpkgs/commit/73c9e3a66e9be4ddcda974cecf1c524bc109cfbb) | `` lxqt.screengrab: 2.5.0 -> 2.6.0 ``                                                          |
| [`a4295d62`](https://github.com/NixOS/nixpkgs/commit/a4295d62cfb678a1eb1010d188a57d3b7bdf9720) | `` lxqt.qtxdg-tools: 3.10.0 -> 3.11.0 ``                                                       |
| [`b38a3f20`](https://github.com/NixOS/nixpkgs/commit/b38a3f2037bd07af9efb05260cbca468ab41f265) | `` lxqt.qtermwidget: 1.2.0 -> 1.3.0 ``                                                         |
| [`8e787d04`](https://github.com/NixOS/nixpkgs/commit/8e787d0460684d8bfce42cfbf7b2da0b3471e73e) | `` lxqt.qterminal: 1.2.0 -> 1.3.0 ``                                                           |
| [`9fbb59ef`](https://github.com/NixOS/nixpkgs/commit/9fbb59ef0fa0a98c0bbe068c2884eb4a6e37c8ed) | `` lxqt.qps: 2.6.0 -> 2.7.0 ``                                                                 |
| [`b2b767fc`](https://github.com/NixOS/nixpkgs/commit/b2b767fcffd44ec8da2f2a0041de447c5f5edc70) | `` lxqt.pcmanfm-qt: 1.2.1 -> 1.3.0 ``                                                          |
| [`0a4206a5`](https://github.com/NixOS/nixpkgs/commit/0a4206a51b386e5cda731e8ac78d76ad924c7125) | `` ocamlPackages.uring: init at 0.5 ``                                                         |
| [`26bf7bbe`](https://github.com/NixOS/nixpkgs/commit/26bf7bbe84d0a3418d15d5a27d22400db4b27aea) | `` lxqt.pavucontrol-qt: 1.2.0 -> 1.3.0 ``                                                      |
| [`620425ed`](https://github.com/NixOS/nixpkgs/commit/620425edad0608f422bfc66b90a5d174b0a62f0b) | `` lxqt.lxqt-themes: 1.2.0 -> 1.3.0 ``                                                         |
| [`0a0781d4`](https://github.com/NixOS/nixpkgs/commit/0a0781d4e17909d6868ef70f8d3be71aeefb94b4) | `` lxqt.lxqt-sudo: 1.2.0 -> 1.3.0 ``                                                           |
| [`db0c6cf3`](https://github.com/NixOS/nixpkgs/commit/db0c6cf3b5d6974170950bcbd807c8ffcf13ff04) | `` lxqt.lxqt-session: 1.2.0 -> 1.3.0 ``                                                        |
| [`90512d55`](https://github.com/NixOS/nixpkgs/commit/90512d552e4f09addb0a74069c7eea0b74493a55) | `` lxqt.lxqt-runner: 1.2.0 -> 1.3.0 ``                                                         |
| [`b17234ba`](https://github.com/NixOS/nixpkgs/commit/b17234baba6bc3f740b53623f2f621b1d96ac827) | `` lxqt.lxqt-qtplugin: 1.2.0 -> 1.3.0 ``                                                       |
| [`b2be78e4`](https://github.com/NixOS/nixpkgs/commit/b2be78e4de23c35ad87f48e0b9468805566cf4a0) | `` lxqt.lxqt-powermanagement: 1.2.0 -> 1.3.0 ``                                                |
| [`b353525e`](https://github.com/NixOS/nixpkgs/commit/b353525e5e2c1ac787bba2937f4e2f9742d17697) | `` lxqt.lxqt-policykit: 1.2.0 -> 1.3.0 ``                                                      |
| [`7ad834fb`](https://github.com/NixOS/nixpkgs/commit/7ad834fb3e2476c3e58c65f2e8d29439092b2061) | `` lxqt.lxqt-panel: 1.2.1 -> 1.3.0 ``                                                          |
| [`47e18213`](https://github.com/NixOS/nixpkgs/commit/47e182132aa25d5373bb92f1dbb510cdd18d1810) | `` lxqt.lxqt-openssh-askpass: 1.2.0 -> 1.3.0 ``                                                |
| [`ef0c5333`](https://github.com/NixOS/nixpkgs/commit/ef0c5333abc3ee148c9ca111f692d4f67b636749) | `` lxqt.lxqt-notificationd: 1.2.0 -> 1.3.0 ``                                                  |
| [`83762543`](https://github.com/NixOS/nixpkgs/commit/83762543e5eb0f944ec6525c438fcc1645e9e968) | `` lxqt.lxqt-globalkeys: 1.2.0 -> 1.3.0 ``                                                     |
| [`9c86a46a`](https://github.com/NixOS/nixpkgs/commit/9c86a46a8689f8d3ad807c1fa6292c5ed8b6c0ee) | `` lxqt.lxqt-config: 1.2.0 -> 1.3.0 ``                                                         |
| [`bda7e117`](https://github.com/NixOS/nixpkgs/commit/bda7e117c52d628d91e604482633a193993c41e1) | `` lxqt.lxqt-build-tools: 0.12.0 -> 0.13.0 ``                                                  |
| [`2ef748c8`](https://github.com/NixOS/nixpkgs/commit/2ef748c8de50bdcaf0f244f312ad99e582ed5dbc) | `` waynergy: 0.0.15 -> 0.0.16 ``                                                               |
| [`c34918a1`](https://github.com/NixOS/nixpkgs/commit/c34918a1c2f0ee56d2a1f84a65e407696cbccab2) | `` freeswitch: remove misuzu as maintainer ``                                                  |
| [`dfbcd782`](https://github.com/NixOS/nixpkgs/commit/dfbcd782b3ad78ab1fd38b6a6194834014080834) | `` ocamlPackages.ppx_monad: init at 0.2.0 ``                                                   |
| [`de9b7f2e`](https://github.com/NixOS/nixpkgs/commit/de9b7f2e5d236907afeff351c9e4e3d9b916bf76) | `` ocamlPackages.dates_calc: init at 0.0.4 ``                                                  |
| [`bc07f0ac`](https://github.com/NixOS/nixpkgs/commit/bc07f0ac318f53753aca2efc8e568d0b8ec77d22) | `` borgmatic: fix timer wantedBy ``                                                            |
| [`79d5a539`](https://github.com/NixOS/nixpkgs/commit/79d5a53953b33598f9b29fef6ca296f5f8597b09) | `` realvnc-vnc-viewer: 6.22.515 -> 7.1.0 ``                                                    |
| [`56315519`](https://github.com/NixOS/nixpkgs/commit/56315519c95b5f598f933127d1e087be08bb48d1) | `` maintainers: add onedragon ``                                                               |
| [`834c6bf7`](https://github.com/NixOS/nixpkgs/commit/834c6bf77768a038b430ae4ea354994da584d354) | `` libqalculate, qalculate-gtk, qalculate-qt: 4.6.0 -> 4.6.1 ``                                |
| [`642deff3`](https://github.com/NixOS/nixpkgs/commit/642deff3214b8515758d1310616b61434ab747fa) | `` python310Packages.google-cloud-bigquery: 3.7.0 -> 3.9.0 ``                                  |
| [`ec826f33`](https://github.com/NixOS/nixpkgs/commit/ec826f33852f2226b907291fe5a60d5a5e0b86c2) | `` vscode-extensions.kahole.magit: 0.6.39 → 0.6.40 ``                                          |
| [`5bf1f8fd`](https://github.com/NixOS/nixpkgs/commit/5bf1f8fd50d57e285c6b495e9c63ff03d5f52a6f) | `` emacs.pkgs.sqlite3: build .so file ``                                                       |
| [`45c1aabe`](https://github.com/NixOS/nixpkgs/commit/45c1aabe9472a2570b07496bdc82868ec958785c) | `` yed: 3.22 -> 3.23.1 ``                                                                      |
| [`dd8daa40`](https://github.com/NixOS/nixpkgs/commit/dd8daa40094d77da09053888f8ae1b98a5a50387) | `` python310Packages.pydrive2: 1.15.1 -> 1.15.3 ``                                             |
| [`b1fde22c`](https://github.com/NixOS/nixpkgs/commit/b1fde22c3b315ba78eb3101d14f9d501ddd86674) | `` python310Packages.pytelegrambotapi: 4.10.0 -> 4.11.0 ``                                     |
| [`7607b322`](https://github.com/NixOS/nixpkgs/commit/7607b322f7558e3d5a9fe3d30864c12f6ed37db2) | `` python3.pkgs.pytomlpp: 1.0.6 -> 1.0.13 ``                                                   |
| [`e21be863`](https://github.com/NixOS/nixpkgs/commit/e21be86383a4019d3840fc0011956ed44d4e110d) | `` python310Packages.pyunifiprotect: 4.7.0 -> 4.8.1 ``                                         |
| [`7616253b`](https://github.com/NixOS/nixpkgs/commit/7616253bac1cf55b5b8845e66bad87edbbdf25e4) | `` sqlfluff: 2.0.4 -> 2.0.5 ``                                                                 |
| [`f8700b4f`](https://github.com/NixOS/nixpkgs/commit/f8700b4f1674288c61c0053da50159add405eb34) | `` python310Packages.onvif-zeep-async: 1.2.5 -> 1.2.11 ``                                      |
| [`b72b8eff`](https://github.com/NixOS/nixpkgs/commit/b72b8eff54718a3c638bedb216ba77e4099e4e82) | `` firefox-beta-unwrapped: 113.0b3 -> 113.0b4 ``                                               |
| [`bb724fcf`](https://github.com/NixOS/nixpkgs/commit/bb724fcfb1610a1bc78a0f15b5431ec55f218638) | `` dnscontrol: 3.30.0 -> 3.31.0 ``                                                             |
| [`9c876916`](https://github.com/NixOS/nixpkgs/commit/9c876916b1a7e7f2dfeec5f6a64302e7d05f0a14) | `` firefox-devedition-unwrapped: 113.0b3 -> 113.0b4 ``                                         |
| [`4cee616f`](https://github.com/NixOS/nixpkgs/commit/4cee616fa8e6606625608202de89a9c49172ff2c) | `` firefox-devedition-bin-unwrapped: 113.0b3 -> 113.0b4 ``                                     |
| [`71266bac`](https://github.com/NixOS/nixpkgs/commit/71266bac032cb80172b201ffd2b15c127c2e2872) | `` firefox-beta-bin-unwrapped: 113.0b3 -> 113.0b4 ``                                           |
| [`02bb7124`](https://github.com/NixOS/nixpkgs/commit/02bb71243f0dcfdc79c2bb50b4a3606e1ab1cb42) | `` python310Packages.mautrix: 0.19.9 -> 0.19.11 ``                                             |
| [`b3846242`](https://github.com/NixOS/nixpkgs/commit/b384624244ce0dd49b9c67baf6dd2d5458f82d64) | `` php82: 8.2.4 -> 8.2.5 ``                                                                    |
| [`9b5533a3`](https://github.com/NixOS/nixpkgs/commit/9b5533a3be9057f6d1c0336c5ddb9e0be89c1f3d) | `` php81: 8.1.17 -> 8.1.18 ``                                                                  |
| [`6d277318`](https://github.com/NixOS/nixpkgs/commit/6d2773189f7db4ba87869e0a249ae0e7220adda6) | `` python310Packages.pylaunches: 1.3.0 -> 1.4.0 ``                                             |
| [`29e1d4e7`](https://github.com/NixOS/nixpkgs/commit/29e1d4e77c8f1d37d0d224060520b4e42076c7ca) | `` python310Packages.pyfibaro: 0.6.9 -> 0.7.0 ``                                               |
| [`55c89ba0`](https://github.com/NixOS/nixpkgs/commit/55c89ba02b2ae39434d6514145b240a75f1b4b83) | `` python310Packages.azure-eventgrid: 4.9.1 -> 4.10.0 ``                                       |
| [`06b09a50`](https://github.com/NixOS/nixpkgs/commit/06b09a500e5450423b0bab6f914e62f56f37bbaf) | `` python311Packages.devito: 4.8.0 -> 4.8.1 ``                                                 |
| [`78154339`](https://github.com/NixOS/nixpkgs/commit/781543392bb172f9265537335758078e15b21e22) | `` wthrr: init at 1.0.1 ``                                                                     |
| [`e7dac23c`](https://github.com/NixOS/nixpkgs/commit/e7dac23ca45cd1a1c6834a3525f87c6a5489f1a8) | `` checkSSLCert: 2.62.0 -> 2.64.0 ``                                                           |
| [`2dac5440`](https://github.com/NixOS/nixpkgs/commit/2dac5440f1592700ecc1628bbdd97ec4c3321529) | `` emblem: 1.1.0 -> 1.2.0, increase platform support, add figsoda as a maintainer ``           |
| [`670a6325`](https://github.com/NixOS/nixpkgs/commit/670a6325291962dd852679273f60501fe81490a0) | `` powertop: change substitute for xset ``                                                     |
| [`49df77a3`](https://github.com/NixOS/nixpkgs/commit/49df77a302dc9aab38d78d60a3d769365fce6c9d) | `` lxqt.lxqt-archiver: 0.7.0 -> 0.8.0 ``                                                       |
| [`6182cbb4`](https://github.com/NixOS/nixpkgs/commit/6182cbb4b3be85e8d8a74aacf6b415ffd7aa38f9) | `` lxqt.lxqt-admin: 1.2.0 -> 1.3.0 ``                                                          |
| [`96412f3b`](https://github.com/NixOS/nixpkgs/commit/96412f3bb89f442d8667762297ca15f2446a3d14) | `` lxqt.lxqt-about: 1.2.0 -> 1.3.0 ``                                                          |
| [`bf17d531`](https://github.com/NixOS/nixpkgs/commit/bf17d531b91f728b9720e9e4e0c9d2a5e3536e5b) | `` lxqt.lximage-qt: 1.2.0 -> 1.3.0 ``                                                          |
| [`2e4a8e63`](https://github.com/NixOS/nixpkgs/commit/2e4a8e6376f0ad45ec226da2294b17a73c379035) | `` lxqt.libfm-qt: 1.2.1 -> 1.3.0 ``                                                            |
| [`97271f59`](https://github.com/NixOS/nixpkgs/commit/97271f5991e0c785044d8ec9405607cc73300380) | `` lxqt.libqtxdg: 3.10.0 -> 3.11.0 ``                                                          |
| [`af0ce076`](https://github.com/NixOS/nixpkgs/commit/af0ce076612bd4b2c3ff4fa3279dafdaa5c5b44a) | `` lxqt.liblxqt: 1.2.0 -> 1.3.0 ``                                                             |
| [`f7eee945`](https://github.com/NixOS/nixpkgs/commit/f7eee9453835e5effc4fb02a31a2b89b677198e3) | `` haskellPackages: Remove trailing whitespace ``                                              |
| [`349cdce3`](https://github.com/NixOS/nixpkgs/commit/349cdce31e42b0388e139758e9542037c9ae7d6e) | `` haskellPackages.jsaddle-webkit2gtk: Apply patch for webkit 2.40 compat ``                   |
| [`19f2603c`](https://github.com/NixOS/nixpkgs/commit/19f2603c1c1780abf02af433adaa146bae2a3fdd) | `` mediaelch: add patch to fix build with qt 6.5 ``                                            |
| [`d0565d40`](https://github.com/NixOS/nixpkgs/commit/d0565d403eae66e22a993cfa0d09494a8239253e) | `` texworks: add patch to fix build with qt 6.5 ``                                             |
| [`b4026106`](https://github.com/NixOS/nixpkgs/commit/b4026106f793c500313cd29595b86d949c94f2ad) | `` jami: add patch to fix annotations in bin/dbus/cx.ring.Ring.CallManager.xml ``              |
| [`fca522b5`](https://github.com/NixOS/nixpkgs/commit/fca522b53865fb9d890e0b5958a3120fff67e566) | `` qt6.qtbase: set strictDeps, remove python3 from buildInputs to reduce closure size ``       |