### PR TITLE
chore(flake/stylix): `936d97a0` -> `a1c5d01a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681893229,
-        "narHash": "sha256-fHMQgd1wcdI/2Oic67n1GZFY1ybgkzyTiF27vRbL/s0=",
+        "lastModified": 1682014490,
+        "narHash": "sha256-mrTFkf7AYlcwHWWj82W1fV87Y36k4UgFRlYdEBEpt+M=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "936d97a0578f7e1a6e8ba6273654f5147b6a5886",
+        "rev": "a1c5d01a40ca65335925974741020fe8b217b7bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                |
| --------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`a1c5d01a`](https://github.com/danth/stylix/commit/a1c5d01a40ca65335925974741020fe8b217b7bd) | `` Add example configuration :memo: `` |