### PR TITLE
chore(flake/deploy-rs): `8c9ea960` -> `c2ea4e64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674127017,
-        "narHash": "sha256-QO1xF7stu5ZMDLbHN30LFolMAwY6TVlzYvQoUs1RD68=",
+        "lastModified": 1682063650,
+        "narHash": "sha256-VaDHh2z6xlnTHaONlNVHP7qEMcK5rZ8Js3sT6mKb2XY=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "8c9ea9605eed20528bf60fae35a2b613b901fd77",
+        "rev": "c2ea4e642dc50fd44b537e9860ec95867af30d39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`55aac55c`](https://github.com/serokell/deploy-rs/commit/55aac55cfafec93938e19a6b475142d81110b3d4) | `` [#197] Fix hostname overriding for remote builds `` |