### PR TITLE
chore(flake/home-manager): `47d6c3f6` -> `38954690`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682072616,
-        "narHash": "sha256-sR5RL3LACGuq5oePcAoJ/e1S3vitKQQSNACMYmqIE1E=",
+        "lastModified": 1682174966,
+        "narHash": "sha256-DA2lV1G7RMoX8LDN80AC7c2tdguC9522YqKc7JdtHOU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "47d6c3f65234230d37f1cf7d3d6b5575ec80fe0c",
+        "rev": "3895469036e4f42ab4bb0482e18c3677e3fb12b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                      |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`38954690`](https://github.com/nix-community/home-manager/commit/3895469036e4f42ab4bb0482e18c3677e3fb12b1) | `` fnott: add D-Bus service file ``          |
| [`64d1f75a`](https://github.com/nix-community/home-manager/commit/64d1f75a1eda1e329f9f795578de10fad0fb82df) | `` herbstluftwm: fix default tag renaming `` |
| [`218503b6`](https://github.com/nix-community/home-manager/commit/218503b691d25d7df00644e775f4aab1e464d516) | `` zellij: use xdg.configHome on darwin ``   |