### PR TITLE
chore(flake/nixpkgs): `645bc49f` -> `6c43a349`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -217,11 +217,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681920287,
-        "narHash": "sha256-+/d6XQQfhhXVfqfLROJoqj3TuG38CAeoT6jO1g9r1k0=",
+        "lastModified": 1682181988,
+        "narHash": "sha256-CYWhlNi16cjGzMby9h57gpYE59quBcsHPXiFgX4Sw5k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "645bc49f34fa8eff95479f0345ff57e55b53437e",
+        "rev": "6c43a3495a11e261e5f41e5d7eda2d71dae1b2fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`6c43a349`](https://github.com/NixOS/nixpkgs/commit/6c43a3495a11e261e5f41e5d7eda2d71dae1b2fe) | `` linux_6_1: fixup evaluation without aliases ``                                 |
| [`ada2485f`](https://github.com/NixOS/nixpkgs/commit/ada2485ff397bc4adcae778bdfa0b242e8dcc4d4) | `` atari++: refactor ``                                                           |
| [`9fec09d9`](https://github.com/NixOS/nixpkgs/commit/9fec09d93cb2cf0410f050a93b2897805e7b452f) | `` ataripp: 1.83 -> 1.85 ``                                                       |
| [`2fe11e6f`](https://github.com/NixOS/nixpkgs/commit/2fe11e6fee6d723f738cd1ec27baaea8a678dcea) | `` haskell.compiler.ghc94: 9.4.4 -> 9.4.5 ``                                      |
| [`fa8367c2`](https://github.com/NixOS/nixpkgs/commit/fa8367c2d50781f3e49ed424ea61af0c77615069) | `` linux_6_1: rebuild on x86_64-linux ``                                          |
| [`00cc237f`](https://github.com/NixOS/nixpkgs/commit/00cc237f08acfc4096ef5de8cf8782d3dcff7d19) | `` malpa-packages: shadow ligo-mode ``                                            |
| [`fa9e9b0a`](https://github.com/NixOS/nixpkgs/commit/fa9e9b0a65475fafbcd1eb5243085a24a28545dc) | `` emacsPackages.ligo-mode: init at 20230302.1616 ``                              |
| [`3b23c189`](https://github.com/NixOS/nixpkgs/commit/3b23c18951210bd958f222fbd06d379ec94c32cf) | `` elisp-packages: break ligo-mode ``                                             |
| [`255786c0`](https://github.com/NixOS/nixpkgs/commit/255786c08a8d5a15291731976264287051dc12f0) | `` elisp-packages: remove bqn-mode ``                                             |
| [`1af03fae`](https://github.com/NixOS/nixpkgs/commit/1af03fae83f4dd294c889014ff4b874d315abfb1) | `` nongnu-packages: updated 2023-04-21 (from overlay) ``                          |
| [`342214aa`](https://github.com/NixOS/nixpkgs/commit/342214aa58af9298c9b2dd695cec733d4cfcaef4) | `` melpa-packages: updated 2023-04-21 (from overlay) ``                           |
| [`e4024ca8`](https://github.com/NixOS/nixpkgs/commit/e4024ca8532b79f1e17c543aa3f36ccbd398527e) | `` elpa-packages: updated 2023-04-21 (from overlay) ``                            |
| [`088941cc`](https://github.com/NixOS/nixpkgs/commit/088941cc9d28f96e86f9afb164a17b1346634f32) | `` tcsh: 6.24.07 -> 6.24.10 ``                                                    |
| [`e56084d2`](https://github.com/NixOS/nixpkgs/commit/e56084d2a0ab8f6c2e7b68550842101b8c1fc546) | `` systemd-stage-1: Revert assertions about initrd commands ``                    |
| [`c9873fde`](https://github.com/NixOS/nixpkgs/commit/c9873fdef0413155137da5bbfde78b6e61d65097) | `` lua/updater: fix a few issues ``                                               |
| [`6062acb7`](https://github.com/NixOS/nixpkgs/commit/6062acb728bf967ea5f3ab9cc55e7ca7317aa39d) | `` havoc: enable parallel building ``                                             |
| [`6d70a411`](https://github.com/NixOS/nixpkgs/commit/6d70a4116d918646c579ae7d2d4613b613f4c868) | `` havoc: fix cross ``                                                            |
| [`4955f1c7`](https://github.com/NixOS/nixpkgs/commit/4955f1c73f73067d59ff5441c0f2261068c5dbb2) | `` calibre: use overlay-style attributes ``                                       |
| [`36351ac9`](https://github.com/NixOS/nixpkgs/commit/36351ac94e9c6608bb95f6946f2ec01dee45f65b) | `` calibre: add meta.changelog ``                                                 |
| [`af697489`](https://github.com/NixOS/nixpkgs/commit/af697489613404b879f6e6fa4213c499a5d28df9) | `` calibre: remove self-references to pname ``                                    |
| [`6d001ab3`](https://github.com/NixOS/nixpkgs/commit/6d001ab31a7fc1b2bd9d8d155d253928dada0b59) | `` gnome.nautilus: Backport crash fix for search after copy/cut ``                |
| [`7b3dedb5`](https://github.com/NixOS/nixpkgs/commit/7b3dedb54f81b192d60f159a67f7e8c0bf0add54) | `` vimPlugins.vim-be-good: init at 2022-11-08 ``                                  |
| [`99f579e7`](https://github.com/NixOS/nixpkgs/commit/99f579e75020cf6d278fc3edeb2df2ee4b526721) | `` hcloud: 1.33.0 -> 1.33.1 ``                                                    |
| [`8afca67a`](https://github.com/NixOS/nixpkgs/commit/8afca67ad57691b3bb1382f768dc50711f2d6fc9) | `` xdg-desktop-portal-gnome: 44.0 → 44.1 ``                                       |
| [`467e01d3`](https://github.com/NixOS/nixpkgs/commit/467e01d3027ed29df11e57c79e0e0cd20273947b) | `` gnome.gnome-software: 44.0 → 44.1 ``                                           |
| [`6d98c26d`](https://github.com/NixOS/nixpkgs/commit/6d98c26d17d80033ea38d97530b64ba5e58df74e) | `` gnome.gnome-settings-daemon: 44.0 → 44.1 ``                                    |
| [`894123d8`](https://github.com/NixOS/nixpkgs/commit/894123d8e2fdf929c85a2c8ac0d83405ae8aebe8) | `` gnome.gnome-maps: 44.0 → 44.1 ``                                               |
| [`611e5803`](https://github.com/NixOS/nixpkgs/commit/611e58030ce5c93cd54cfadf03ab917ced2c72af) | `` gnome.gnome-control-center: Re-apply fix for hardcode usermod ``               |
| [`4c8bc016`](https://github.com/NixOS/nixpkgs/commit/4c8bc016d3c6b17583e90ff7f518d3e774e07098) | `` cloudflared: 2023.4.0 -> 2023.4.1 ``                                           |
| [`eae7d49b`](https://github.com/NixOS/nixpkgs/commit/eae7d49b1b38d458e7e231a5f5eb6c85d42472be) | `` v2ray-geoip: 202304130041 -> 202304200041 ``                                   |
| [`c10d37f6`](https://github.com/NixOS/nixpkgs/commit/c10d37f6d4b9059860229e7948b89bffb17f696b) | `` spleen: 1.9.2 -> 1.9.3 ``                                                      |
| [`ed57dc06`](https://github.com/NixOS/nixpkgs/commit/ed57dc06a1142c67c33460f40c8c5a7b5b456336) | `` feroxbuster: 2.9.3 -> 2.9.4 ``                                                 |
| [`06e514b9`](https://github.com/NixOS/nixpkgs/commit/06e514b9159d3a9154016a1da6b4880cae9e1b37) | `` trufflehog: 3.32.0 -> 3.32.1 ``                                                |
| [`07a10ffb`](https://github.com/NixOS/nixpkgs/commit/07a10ffb35a6ce703a6aeb679be0e0ab47da1ee4) | `` python310Packages.pysml: 0.0.9 -> 0.0.10 ``                                    |
| [`8fe17a03`](https://github.com/NixOS/nixpkgs/commit/8fe17a03a880acfdfab27be77365089033fb66ba) | `` crowdsec: 1.4.4 -> 1.4.6 ``                                                    |
| [`36a76579`](https://github.com/NixOS/nixpkgs/commit/36a76579174389122338f191ce3a774e89626e09) | `` grype: 0.61.0 -> 0.61.1 ``                                                     |
| [`db4fcb28`](https://github.com/NixOS/nixpkgs/commit/db4fcb28663e8b6b4da945426c79e7403fffb656) | `` exploitdb: 2023-04-18 -> 2023-04-21 ``                                         |
| [`c9e08279`](https://github.com/NixOS/nixpkgs/commit/c9e0827951dd8cd64d2783f88691db46c1efa961) | `` python310Packages.arc4: 0.3.0 -> 0.4.0 ``                                      |
| [`b7fe0de9`](https://github.com/NixOS/nixpkgs/commit/b7fe0de9740cb253c0f1b48c8943a392489a8914) | `` python310Packages.atenpdu: 0.5.0 -> 0.6.0 ``                                   |
| [`e18e292a`](https://github.com/NixOS/nixpkgs/commit/e18e292a4f050df854e4449bda8ad22dc807f7f3) | `` nuclei: 2.9.1 -> 2.9.2 ``                                                      |
| [`3856e84b`](https://github.com/NixOS/nixpkgs/commit/3856e84b79e86b1c9c269a207b1c3e8a07e5f4d3) | `` nixos/gitea: remove extra `"` in prestart ``                                   |
| [`4302b175`](https://github.com/NixOS/nixpkgs/commit/4302b1756b52d3c9dd2b715e3a4cb88aa39fd7ca) | `` mackerel-agent: 0.75.1 -> 0.75.2 ``                                            |
| [`545078d5`](https://github.com/NixOS/nixpkgs/commit/545078d5d240ab2d6883ac545f5545a38c2e5ddb) | `` terraform-providers.tencentcloud: 1.80.4 -> 1.80.5 ``                          |
| [`ee9dee37`](https://github.com/NixOS/nixpkgs/commit/ee9dee37fc5138196c156f507577a984c7076da9) | `` terraform-providers.tfe: 0.44.0 -> 0.44.1 ``                                   |
| [`87e3c579`](https://github.com/NixOS/nixpkgs/commit/87e3c579dd138eee303c523a420092d4c8bee287) | `` terraform-providers.spotinst: 1.112.0 -> 1.113.0 ``                            |
| [`e30cd9c7`](https://github.com/NixOS/nixpkgs/commit/e30cd9c7bdf14c8ff9fc8ff522a4c92046d054d1) | `` terraform-providers.jetstream: 0.0.34 -> 0.0.35 ``                             |
| [`b51b5639`](https://github.com/NixOS/nixpkgs/commit/b51b5639f9bf5566c6aeb0af80633c9a1c005d30) | `` terraform-providers.dnsimple: 1.0.0 -> 1.1.0 ``                                |
| [`7d6a118d`](https://github.com/NixOS/nixpkgs/commit/7d6a118d697a1e3547a962788c592d97a0d3c59b) | `` terraform-providers.argocd: 5.1.0 -> 5.2.0 ``                                  |
| [`72ca2457`](https://github.com/NixOS/nixpkgs/commit/72ca2457b8cd9da135c4dc2c86881b50068d30b3) | `` terraform-providers.digitalocean: 2.27.1 -> 2.28.0 ``                          |
| [`a150ff22`](https://github.com/NixOS/nixpkgs/commit/a150ff22aac81d6dbc519acee28e3345a11628fc) | `` terraform-providers.buildkite: 0.15.0 -> 0.16.0 ``                             |
| [`10057a3e`](https://github.com/NixOS/nixpkgs/commit/10057a3ecb5ac22cd6ae9a10b878626ab6fda8a2) | `` musikcube: 0.99.7 -> 3.0.0 ``                                                  |
| [`ca37359b`](https://github.com/NixOS/nixpkgs/commit/ca37359bf1449332d0105aa3a080581324a470f5) | `` rvvm: unstable-2023-01-25 -> 0.5 ``                                            |
| [`96864488`](https://github.com/NixOS/nixpkgs/commit/96864488ce6d0d667c6c4a42f01e50d1578f4b20) | `` python310Packages.myst-nb: 0.17.1 -> 0.17.2 ``                                 |
| [`fe385dd4`](https://github.com/NixOS/nixpkgs/commit/fe385dd423344c761da87bfefb1041ed9bfe0c98) | `` python310Packages.mautrix: 0.19.11 -> 0.19.12 ``                               |
| [`10e01bc7`](https://github.com/NixOS/nixpkgs/commit/10e01bc7aad130d41cc90f87a97ea43c22107e68) | `` blackfire: 2.14.2 -> 2.15.0 ``                                                 |
| [`077052e0`](https://github.com/NixOS/nixpkgs/commit/077052e040ce39ac1af8ae7f80d5d8c104b04d5d) | `` gnome.gnome-control-center: 44.0 → 44.1 ``                                     |
| [`88871788`](https://github.com/NixOS/nixpkgs/commit/888717888db832c9193e75462656a1d7a5051c05) | `` zsh-fzf-tab: unstable-2022-12-08 -> unstable-2023-05-19 ``                     |
| [`80e7069f`](https://github.com/NixOS/nixpkgs/commit/80e7069fb04253c4dded4580460783124b9e946f) | `` wingpanel-indicator-ayatana: unstable-2021-12-18 -> unstable-2023-04-18 ``     |
| [`f3834e6f`](https://github.com/NixOS/nixpkgs/commit/f3834e6fde576ff36334212a16b0744af25fc4d8) | `` stratisd: 3.5.3 -> 3.5.4 ``                                                    |
| [`2c1be1a7`](https://github.com/NixOS/nixpkgs/commit/2c1be1a764fcdeb8ff0f2ef2ac45f4e36b9c58a1) | `` sing-box: 1.2.2 -> 1.2.6 ``                                                    |
| [`15983385`](https://github.com/NixOS/nixpkgs/commit/1598338521d64bec008fb727ad0dfd9f82dcb245) | `` systemd-stage-1: Make networkd options shallow ``                              |
| [`07980a82`](https://github.com/NixOS/nixpkgs/commit/07980a829def02b90dbbbdba733af533baf9dd32) | `` python310Packages.beartype: 0.12.0 -> 0.13.1 ``                                |
| [`a82c8611`](https://github.com/NixOS/nixpkgs/commit/a82c8611ce47491bd3f80e2219bfaab06d47ec2f) | `` buildGoModule: don't inherit build hooks when building go-modules (#225349) `` |
| [`ffac060d`](https://github.com/NixOS/nixpkgs/commit/ffac060d027a8c2ac2b9253c0181f8d154f78975) | `` unciv: 4.5.15 -> 4.6.4-patch2 ``                                               |
| [`5766d37d`](https://github.com/NixOS/nixpkgs/commit/5766d37d0703b9f7aed28c78797b1503e842b031) | `` mdbook-katex: 0.3.11 -> 0.3.15 ``                                              |
| [`0d267981`](https://github.com/NixOS/nixpkgs/commit/0d2679819cc30b3000d9fe3404e3c53be5c6aeab) | `` level-zero: 1.9.9 -> 1.10.0 ``                                                 |
| [`4a44bcb3`](https://github.com/NixOS/nixpkgs/commit/4a44bcb328ad0befb41c35e80013209b9d239587) | `` web-eid-app: 2.2.0 -> 2.3.0 ``                                                 |
| [`ed2bcda5`](https://github.com/NixOS/nixpkgs/commit/ed2bcda52b4eb863fcc5dc250a78033d588e805f) | `` pscale: 0.134.0 -> 0.138.0 ``                                                  |
| [`52bb6070`](https://github.com/NixOS/nixpkgs/commit/52bb607095e456c9aaad796a1553e7a97001b578) | `` xmrig-mo: 6.19.1-mo1 -> 6.19.2-mo1 ``                                          |
| [`a83fd3a9`](https://github.com/NixOS/nixpkgs/commit/a83fd3a99bdafcda4d4bfa74543accfb967a2be5) | `` caf: 0.18.7 -> 0.19.0 ``                                                       |
| [`40b646c5`](https://github.com/NixOS/nixpkgs/commit/40b646c5b029ee592b4aa2da8efa2b877f4f4f75) | `` pathvector: 6.1.0 -> 6.2.1 ``                                                  |
| [`06e8d82e`](https://github.com/NixOS/nixpkgs/commit/06e8d82e9c74205ffa2fe4dda06c7430064243d2) | `` lib/systems: disable docs in qemu-user ``                                      |
| [`c407873d`](https://github.com/NixOS/nixpkgs/commit/c407873d50f7ec6aa643f3052475160068696b01) | `` qemu: allow to disable generation of documentation ``                          |
| [`d2a6b811`](https://github.com/NixOS/nixpkgs/commit/d2a6b811d852c68789e1f64d2586c48053aa9045) | `` python310Packages.yara-python: 4.3.0 -> 4.3.1 ``                               |
| [`777d4101`](https://github.com/NixOS/nixpkgs/commit/777d4101c5baca0d7ad50b2dadddcce276a930e9) | `` sqlfluff: 2.0.5 -> 2.0.7 ``                                                    |
| [`67bf779b`](https://github.com/NixOS/nixpkgs/commit/67bf779b684257306fab2fd09ca646e43c2adcbf) | `` sdcc: enableParallelBuilding = true ``                                         |
| [`2362848a`](https://github.com/NixOS/nixpkgs/commit/2362848adf8def2866fabbffc50462e929d7fffb) | `` truvari: add natsukium to maintainers ``                                       |
| [`ea468d96`](https://github.com/NixOS/nixpkgs/commit/ea468d9691c1db8d9e288a1fc453fdfaf3e4f9a4) | `` truvari: 2.1.1 -> 4.0.0 ``                                                     |
| [`41794ae4`](https://github.com/NixOS/nixpkgs/commit/41794ae4b30d8c27d67f3f18e74a4405560b8a0d) | `` nix: use [ ] instead null to empty requiredSystemFeatures ``                   |
| [`9ec0e984`](https://github.com/NixOS/nixpkgs/commit/9ec0e984fbd8c0ec6a9f2a750c936083a6b6f4ea) | `` python310Packages.trove-classifiers: 2023.3.9 -> 2023.4.18 ``                  |
| [`ca77e255`](https://github.com/NixOS/nixpkgs/commit/ca77e25522db149090f87fd5909b6a276c5f654d) | `` python310Packages.arcam-fmj: 1.2.1 -> 1.3.0 ``                                 |
| [`fef52d1d`](https://github.com/NixOS/nixpkgs/commit/fef52d1d7cf6d0248b8f92cb8c6af31dc6be18d3) | `` libdeltachat: 1.112.7 -> 1.113.0 ``                                            |
| [`e03d2324`](https://github.com/NixOS/nixpkgs/commit/e03d23246e1a13ef0dc75eea7b953c428fb014e1) | `` setzer: 0.4.8 -> 55 ``                                                         |
| [`703fd26f`](https://github.com/NixOS/nixpkgs/commit/703fd26f1f0fdd26a37157c316147b3bfd0a9071) | `` rivet: fix rivet-mkhtml (#227331) ``                                           |
| [`d0e1f5eb`](https://github.com/NixOS/nixpkgs/commit/d0e1f5ebce855fa0d8dec005153e0996cd0844ce) | `` yara: 4.3.0 -> 4.3.1 ``                                                        |
| [`d15ce1cf`](https://github.com/NixOS/nixpkgs/commit/d15ce1cf2a40d70684e8b0225bbb83f90d4b717b) | `` chromiumDev: 114.0.5696.0 -> 114.0.5720.4 ``                                   |
| [`a4ab065c`](https://github.com/NixOS/nixpkgs/commit/a4ab065cbe0eb0097370a0830cd1b62c40c255ee) | `` chromiumBeta: 113.0.5672.37 -> 113.0.5672.53 ``                                |
| [`e74172b1`](https://github.com/NixOS/nixpkgs/commit/e74172b19d524e9a3327192d5011ddfdc43b5ede) | `` chromium: 112.0.5615.121 -> 112.0.5615.165 ``                                  |
| [`a673f6bc`](https://github.com/NixOS/nixpkgs/commit/a673f6bcb681edf38b8bdab7051c292327941b6a) | `` trufflehog: 3.31.6 -> 3.32.0 ``                                                |
| [`eac9772c`](https://github.com/NixOS/nixpkgs/commit/eac9772c0a9e5fc10d7561cc4b65bab6ac60405b) | `` python310Packages.pysigma-backend-opensearch: 0.1.6 -> 1.0.0 ``                |
| [`f5309f4c`](https://github.com/NixOS/nixpkgs/commit/f5309f4caaadc964cb70486f5c8200055c043ab2) | `` python310Packages.pysigma-backend-elasticsearch: 1.0.1 -> 1.0.3 ``             |
| [`95e441b0`](https://github.com/NixOS/nixpkgs/commit/95e441b0022eb4192e211f7e339c10802ae62808) | `` authenticator: unbreak on aarch64-linux ``                                     |
| [`9b6be551`](https://github.com/NixOS/nixpkgs/commit/9b6be5519d90e4217d581384e624a29730a88019) | `` hipsolver: 5.4.2 -> 5.4.4 ``                                                   |
| [`eec1ba45`](https://github.com/NixOS/nixpkgs/commit/eec1ba45f1dd1ff38a48cdee5b8f9e32af5142c8) | `` vimPlugins: update ``                                                          |
| [`cfe74e51`](https://github.com/NixOS/nixpkgs/commit/cfe74e5102c2b2af4ee012c7541715870aa11302) | `` scaleway-cli: 2.13.0 -> 2.14.0 ``                                              |
| [`051e21b2`](https://github.com/NixOS/nixpkgs/commit/051e21b25ae1ec31d506f24a465fddaecc270956) | `` tagref: 1.6.0 -> 1.7.0 ``                                                      |
| [`4d645123`](https://github.com/NixOS/nixpkgs/commit/4d6451237e65c413b1bdbb001161bfb9f131af71) | `` ktextaddons: 1.1.0 -> 1.2.0 ``                                                 |
| [`f8556eea`](https://github.com/NixOS/nixpkgs/commit/f8556eeab2547234b8afed436f0c3dd948ba9b4e) | `` python310Packages.crate: 0.31.0 -> 0.31.1 ``                                   |
| [`c7819905`](https://github.com/NixOS/nixpkgs/commit/c7819905fb2c54724c61ea387da59b5377817fbb) | `` srvc: 0.17.0 -> 0.17.1 ``                                                      |
| [`d76fb26a`](https://github.com/NixOS/nixpkgs/commit/d76fb26a8ea76d584a692255e8099880cf1e31d8) | `` python310Packages.levenshtein: fix hash ``                                     |
| [`a7e41cdd`](https://github.com/NixOS/nixpkgs/commit/a7e41cdde3d7b9b5147393cec7953e5ed666a830) | `` vscode-extensions.esbenp.prettier-vscode: 9.10.4 -> 9.12.0 ``                  |
| [`e7ee2f52`](https://github.com/NixOS/nixpkgs/commit/e7ee2f526f99ed94e240933cabc5b75856571b67) | `` nodePackages: update all ``                                                    |
| [`c9dea119`](https://github.com/NixOS/nixpkgs/commit/c9dea1196e54e0f2c8eaf93d12a5737b7715663f) | `` discord-canary: 0.0.150 -> 0.0.151 ``                                          |
| [`5c46e6f4`](https://github.com/NixOS/nixpkgs/commit/5c46e6f4e3b517418c64f32c9a0e0c874e81ee8b) | `` systemd-stage-1: Add assertions for unsupported options. ``                    |
| [`8f9416e9`](https://github.com/NixOS/nixpkgs/commit/8f9416e9e3526cddc5faeadd5959b29353caf354) | `` systemd-stage-1: Unhide documentation ``                                       |
| [`5ae746ff`](https://github.com/NixOS/nixpkgs/commit/5ae746ffbde9b79335a9f796f6a41bf82023b9bf) | `` python310Packages.sentry-sdk: 1.18.0 -> 1.20.0 ``                              |
| [`93a48d2b`](https://github.com/NixOS/nixpkgs/commit/93a48d2bf96757bd52c56019f5d2e9692c776030) | `` python311Packages.unittest-xml-reporting: Disable failing tests ``             |
| [`18bf35d6`](https://github.com/NixOS/nixpkgs/commit/18bf35d603d20f31f878b94e236c16022ec6f5c9) | `` python311Packages.django-redis: Fix tests ``                                   |
| [`1f293528`](https://github.com/NixOS/nixpkgs/commit/1f293528ccc578ecdc7a7b34ebafdb65694ab467) | `` python310Packages.opencontainers: init at 0.0.14 ``                            |
| [`1859a209`](https://github.com/NixOS/nixpkgs/commit/1859a209527f1b05ee6df9b496bf3757bb657f35) | `` clojure-lsp: 2023.02.27-13.12.12 -> 2023.04.19-12.43.29 ``                     |
| [`fd39851c`](https://github.com/NixOS/nixpkgs/commit/fd39851cc69ac678163f46cdfaee9e5232660702) | `` vimPlugins.sniprun: 1.3.0 -> 1.3.1 ``                                          |
| [`51d0f9f8`](https://github.com/NixOS/nixpkgs/commit/51d0f9f821c0f9c056981e265ddf19a619793e19) | `` calibre: 6.15.1 -> 6.16.0 ``                                                   |
| [`419d6458`](https://github.com/NixOS/nixpkgs/commit/419d64586e5fec185b3acc99ed018666c691eedb) | `` xfce.xfce4-mailwatch-plugin: 1.3.0 -> 1.3.1 ``                                 |
| [`e25dc4a9`](https://github.com/NixOS/nixpkgs/commit/e25dc4a95ed69f37ce443b8fcad00fb9337e6eed) | `` nixos/nginx: Fix listen string generation ``                                   |
| [`b5c4fe27`](https://github.com/NixOS/nixpkgs/commit/b5c4fe279abda720af644f2c330b03f132421ce9) | `` xfce.xfce4-fsguard-plugin: 1.1.2 -> 1.1.3 ``                                   |
| [`92a47311`](https://github.com/NixOS/nixpkgs/commit/92a47311bede8848bfcc961d0bf1d6c826cd67c2) | `` vimPlugins.elixir-tools-nvim: init at 2023-04-20 ``                            |
| [`dd42f866`](https://github.com/NixOS/nixpkgs/commit/dd42f866dcf3a86fd33f381c75f2cdfbc588a349) | `` xfce.xfce4-battery-plugin: 1.1.4 -> 1.1.5 ``                                   |
| [`45dd4709`](https://github.com/NixOS/nixpkgs/commit/45dd47094008c42d9b7377c5163ee332da8709bb) | `` python310Packages.google-cloud-bigquery: 3.9.0 -> 3.10.0 ``                    |
| [`d3b42598`](https://github.com/NixOS/nixpkgs/commit/d3b42598eb10e586126bf8520f025ef2bc052d9a) | `` elastic: init at 0.1.3 (#226428) ``                                            |
| [`aec122af`](https://github.com/NixOS/nixpkgs/commit/aec122af561a5ed998a47e7d1f5194338eff44de) | `` dtrx: 8.4.0 -> 8.5.0 (#225953) ``                                              |
| [`dcb92f0a`](https://github.com/NixOS/nixpkgs/commit/dcb92f0aee79119b45d320f6c55bffda83d739fb) | `` python310Packages.aioshelly: 5.3.1 -> 5.3.2 ``                                 |
| [`7f17c918`](https://github.com/NixOS/nixpkgs/commit/7f17c918d63bdb59e2c67a084d11c395ccac845a) | `` evolution: 3.48.0 → 3.48.1 ``                                                  |
| [`5779d314`](https://github.com/NixOS/nixpkgs/commit/5779d314d901c71c5898d99106024c8ae4b62660) | `` evolution-ews: 3.48.0 → 3.48.1 ``                                              |