### PR TITLE
chore(flake/home-manager): `48ad7ade` -> `e21ec3db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682254187,
-        "narHash": "sha256-KQHLs6QLBLA3TQm61oKdAJIwErAt+aC4xnstdmy39Q0=",
+        "lastModified": 1682272948,
+        "narHash": "sha256-74UXjwtwHKU5fimrniKAfNRia/DCQBrcIpTMJGSlI24=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "48ad7ade11795dd10a095c68f6a4a4dcb339307b",
+        "rev": "e21ec3db17c4b474f6bd9d8b967a3415fbc6b51d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                             |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`e21ec3db`](https://github.com/nix-community/home-manager/commit/e21ec3db17c4b474f6bd9d8b967a3415fbc6b51d) | `` git: add delta.package option `` |
| [`5904f12d`](https://github.com/nix-community/home-manager/commit/5904f12d7d343929c8a09a9bbcbf3eb88c2e0a26) | `` flake.lock: Update ``            |