### PR TITLE
chore(flake/nixpkgs): `6c43a349` -> `e78d25df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -217,11 +217,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682181988,
-        "narHash": "sha256-CYWhlNi16cjGzMby9h57gpYE59quBcsHPXiFgX4Sw5k=",
+        "lastModified": 1682268651,
+        "narHash": "sha256-2eZriMhnD24Pmb8ideZWZDiXaAVe6LzJrHQiNPck+Lk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c43a3495a11e261e5f41e5d7eda2d71dae1b2fe",
+        "rev": "e78d25df6f1036b3fa76750ed4603dd9d5fe90fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`75e62acf`](https://github.com/NixOS/nixpkgs/commit/75e62acf2e6f7e998ea913ac646d4596e9ca95d5) | `` jfrog-cli: 2.36.0 -> 2.36.1 ``                                         |
| [`5d91a896`](https://github.com/NixOS/nixpkgs/commit/5d91a896449650d13fbba8c8abc65d1615c2b654) | `` kalendar: Remove unused fetchFromGitLab ``                             |
| [`a5cbcee7`](https://github.com/NixOS/nixpkgs/commit/a5cbcee70b0a1e3711f41ffcb6b6ab64a22e080a) | `` jellyfin: 10.8.9 -> 10.8.10 ``                                         |
| [`36034fbc`](https://github.com/NixOS/nixpkgs/commit/36034fbc517692ee203cac218b1dc0658ebfd7cc) | `` jellyfin-web: 10.8.9 -> 10.8.10 ``                                     |
| [`a5340ba9`](https://github.com/NixOS/nixpkgs/commit/a5340ba9ff3484008c7b7633f9c4cb231ebcce42) | `` tree-sitter-grammars: add nu ``                                        |
| [`a683a04e`](https://github.com/NixOS/nixpkgs/commit/a683a04ebe4c3123eb8530aaee9eda28350c4e26) | `` kubexit: Init at 0.3.2 ``                                              |
| [`b4dea3ca`](https://github.com/NixOS/nixpkgs/commit/b4dea3ca4c58f276b834f4c42c8a8203bd2ef1f0) | `` numix-icon-theme-circle: 23.04.05 -> 23.04.20 ``                       |
| [`24d6aa1a`](https://github.com/NixOS/nixpkgs/commit/24d6aa1a9003225dfdbed496704f6d363e272a09) | `` python310Packages.qdrant-client: adjust inputs ``                      |
| [`394bf4e5`](https://github.com/NixOS/nixpkgs/commit/394bf4e5be27cbbd4c425cd8881cc775efaeb0e0) | `` python311Packages.tablib: 3.3.0 -> 3.4.0 ``                            |
| [`c8f2f13f`](https://github.com/NixOS/nixpkgs/commit/c8f2f13fdaef8021db6ca1c834caba6ef141fc0f) | `` cargo-geiger: 0.11.5 -> 0.11.6 ``                                      |
| [`de4e75a7`](https://github.com/NixOS/nixpkgs/commit/de4e75a79b0ba8fb0a4365ff4831da093cd91320) | `` cri-o: 1.26.3 -> 1.27.0 ``                                             |
| [`84be28f3`](https://github.com/NixOS/nixpkgs/commit/84be28f36ac4ce0632df8ff2cd91822b234360db) | `` headscale: change 'sha256'-style attributes 'hash'-style attributes `` |
| [`a5165e99`](https://github.com/NixOS/nixpkgs/commit/a5165e99c8000bb088be07971f3ac4723ab145c4) | `` phantomsocks: init at unstable-2023-04-05 ``                           |
| [`9e16658e`](https://github.com/NixOS/nixpkgs/commit/9e16658e3039efed7373bbdcd95dc5c3e1598977) | `` python310Packages.ssdp: update build requirements ``                   |
| [`513975ec`](https://github.com/NixOS/nixpkgs/commit/513975ec4b1fc2293ffd48c984f0913817d78626) | `` systemd: disable libbpf if compiler-rt unsupported ``                  |
| [`4388afbd`](https://github.com/NixOS/nixpkgs/commit/4388afbd9bef812fc22419154139409ffea4a8b1) | `` usql: 0.14.0 -> 0.14.4 ``                                              |
| [`f563bd3b`](https://github.com/NixOS/nixpkgs/commit/f563bd3ba46f90006b25707b0b60e7747a76fd37) | `` jd-diff-patch: 1.6.1 -> 1.7.1 ``                                       |
| [`230c99e5`](https://github.com/NixOS/nixpkgs/commit/230c99e505f207bcb8a312c29e87ccd6373d4b2d) | `` clair: fix src hash ``                                                 |
| [`b65f68fd`](https://github.com/NixOS/nixpkgs/commit/b65f68fdcdd3194191bdc922ce23c382fe4fb361) | `` lima: 0.15.0 -> 0.15.1 ``                                              |
| [`73af3651`](https://github.com/NixOS/nixpkgs/commit/73af36514aa95a2cc57dfec5ba23f9dfbda65404) | `` schemes: init at 0.2.0 ``                                              |
| [`4f3a8eab`](https://github.com/NixOS/nixpkgs/commit/4f3a8eabd79fbc64625ed0140371359205b94e4b) | `` python311Packages.stripe: 5.2.0 -> 5.4.0 ``                            |
| [`6e7bb759`](https://github.com/NixOS/nixpkgs/commit/6e7bb7594d4c6393e80f1d0e95d0e2ef9290dbc3) | `` python311Packages.titlecase: 2.3 -> 2.4 ``                             |
| [`31fc7838`](https://github.com/NixOS/nixpkgs/commit/31fc7838182b415b2ea37550167fcb1293e2ce21) | `` terrascan: 1.18.0 -> 1.18.1 ``                                         |
| [`5ea90577`](https://github.com/NixOS/nixpkgs/commit/5ea90577ffedaa09a52b4979565f3850592ebe91) | `` python310Packages.docformatter: update disabled ``                     |
| [`a009dbc3`](https://github.com/NixOS/nixpkgs/commit/a009dbc329a48050a11cedab19ec326e6e33a099) | `` kubecfg: 0.29.1 -> 0.29.2 ``                                           |
| [`44548422`](https://github.com/NixOS/nixpkgs/commit/44548422375dd0cd990af3e8191f232ed20cf250) | `` tun2socks: 2.4.1 -> 2.5.0 ``                                           |
| [`869a6db0`](https://github.com/NixOS/nixpkgs/commit/869a6db08db06e70198ab353e059763f4d135494) | `` terraform-providers.gitlab: 15.10.0 -> 15.11.0 ``                      |
| [`d2797ded`](https://github.com/NixOS/nixpkgs/commit/d2797ded5f1d25ed6fcb230c5b3ed43a606bd34b) | `` codeql: 2.12.6 -> 2.13.0 ``                                            |
| [`910fc742`](https://github.com/NixOS/nixpkgs/commit/910fc742dbdc4264e7c426f2aeed6532e772e88d) | `` fluent-bit: 2.0.11 -> 2.1.1 ``                                         |
| [`24dd72f6`](https://github.com/NixOS/nixpkgs/commit/24dd72f6eceb7353e8d058ed8152665198028db3) | `` vhs: 0.3.0 -> 0.4.0 ``                                                 |
| [`25e3d8fc`](https://github.com/NixOS/nixpkgs/commit/25e3d8fc97cd3f7f711a5134b5acdd515bd9f4f7) | `` python310Packages.docformatter: 1.6.0 -> 1.6.2 ``                      |
| [`e90dd763`](https://github.com/NixOS/nixpkgs/commit/e90dd763e10a56debe6c377c066210f4cea61646) | `` deepin-system-monitor: 5.9.32 -> 5.9.33 ``                             |
| [`cc3a1825`](https://github.com/NixOS/nixpkgs/commit/cc3a18251f7fcf789f1cc457c7b2074ca79f5b6a) | `` python310Packages.sense-energy: 0.11.1 -> 0.11.2 ``                    |
| [`e9b044f2`](https://github.com/NixOS/nixpkgs/commit/e9b044f247d64a62013acee8fb4460e172139f60) | `` xfce.xfce4-weather-plugin: 0.11.0 -> 0.11.1 ``                         |
| [`0bbec286`](https://github.com/NixOS/nixpkgs/commit/0bbec286d7935a79f51c2b66869935b64689c241) | `` xfce.xfce4-time-out-plugin: 1.1.2 -> 1.1.3 ``                          |
| [`6537121e`](https://github.com/NixOS/nixpkgs/commit/6537121e53c76c73f8e1aaa65954e998731f2b86) | `` xfce.xfce4-dict: 0.8.4 -> 0.8.5 ``                                     |
| [`3da86411`](https://github.com/NixOS/nixpkgs/commit/3da8641170ae8ec6afc5dd54ceba1eb40636518f) | `` terragrunt: 0.45.2 -> 0.45.4 ``                                        |
| [`62bd9614`](https://github.com/NixOS/nixpkgs/commit/62bd9614404d55cf752b2bfbbc52b47de659b215) | `` xscreensaver: 6.04 -> 6.06 ``                                          |
| [`642f20ca`](https://github.com/NixOS/nixpkgs/commit/642f20cae1ebf9e9495d0154adc6922ea30ada7d) | `` deepin.dde-launcher: fix build with new dtk ``                         |
| [`6d6d1770`](https://github.com/NixOS/nixpkgs/commit/6d6d177020b6d05aaf1f603215c5a1561311bbfd) | `` deepin.qt5platform-plugins: 5.6.5 -> 5.6.9 ``                          |
| [`9431b2a0`](https://github.com/NixOS/nixpkgs/commit/9431b2a0f064e6219ae9302160a11e5fe599b272) | `` deepin.qt5integration: 5.6.4 -> 5.6.6 ``                               |
| [`b62a9507`](https://github.com/NixOS/nixpkgs/commit/b62a9507791712c6a7ca47b1294db8e3d6644b49) | `` deepin.dtkwidget: 5.6.3 -> 5.6.10 ``                                   |
| [`8f7d0e6a`](https://github.com/NixOS/nixpkgs/commit/8f7d0e6ab29fb4acd2474ab5eaf3017952b0e3ea) | `` deepin.dtkgui: 5.6.3 -> 5.6.10 ``                                      |
| [`6bbb08f7`](https://github.com/NixOS/nixpkgs/commit/6bbb08f744862d21f29dadd2807afff8047e70a6) | `` deepin.dtkcore: 5.6.3 -> 5.6.10 ``                                     |
| [`100e4784`](https://github.com/NixOS/nixpkgs/commit/100e4784659cdb6ea81f872c19d4cc4031578abd) | `` deepin.dtkcommon: 5.6.3 -> 5.6.9 ``                                    |
| [`de85369e`](https://github.com/NixOS/nixpkgs/commit/de85369ecdeff51f2213c6203ee7bd67ccf62108) | `` elixir-ls: 0.13.0 -> 0.14.5 ``                                         |
| [`f6f7b673`](https://github.com/NixOS/nixpkgs/commit/f6f7b673d451c4f320a5dd52dc1da67f3b587833) | `` nix-update: 0.17.0 -> 0.17.1 ``                                        |
| [`2ddb47d1`](https://github.com/NixOS/nixpkgs/commit/2ddb47d131d5aafbc30e4a0190ea569db9b661e6) | `` shotwell: 0.31.7 → 0.32.0 ``                                           |
| [`a45bbf6c`](https://github.com/NixOS/nixpkgs/commit/a45bbf6c9b079d454781576a7e066a07586fcb61) | `` gnome.rygel: 0.42.2 → 0.42.3 ``                                        |
| [`6c2f58bd`](https://github.com/NixOS/nixpkgs/commit/6c2f58bd6b509939e02967a2598d28400b932faa) | `` go-musicfox: 4.0.4 -> 4.0.5 ``                                         |
| [`ce228ef8`](https://github.com/NixOS/nixpkgs/commit/ce228ef8008a70ff5e530266cc4f29c79bbb9d11) | `` whatip: 1.1 -> 1.2 ``                                                  |
| [`f057d60a`](https://github.com/NixOS/nixpkgs/commit/f057d60a1d6b0638c15cbe5ed281d294d784469d) | `` gnome.gnome-remote-desktop: 44.0 → 44.1 ``                             |
| [`fd00edb3`](https://github.com/NixOS/nixpkgs/commit/fd00edb3997226ec56c4de475847f1072c4b9b61) | `` gnome.gnome-calendar: 44.0 → 44.1 ``                                   |
| [`9ac500b2`](https://github.com/NixOS/nixpkgs/commit/9ac500b2b34d34c2258a3dca3f5ecf5037168477) | `` gnome.eog: 44.0 → 44.1 ``                                              |
| [`05a5046b`](https://github.com/NixOS/nixpkgs/commit/05a5046b445e19afa54a0b920f535dfad31eff9e) | `` factorio-experimental: 1.1.80 -> 1.1.81 ``                             |
| [`63a9bf89`](https://github.com/NixOS/nixpkgs/commit/63a9bf896fbdf458aa8824df64c59fc54fd2d0b1) | `` factorio-stable: 1.1.76 -> 1.1.80 ``                                   |
| [`053dcdfb`](https://github.com/NixOS/nixpkgs/commit/053dcdfbdb64e7bebfa4917817840495acab1d35) | `` python310Packages.pyproj: add pythonImportsCheck ``                    |
| [`15a21848`](https://github.com/NixOS/nixpkgs/commit/15a218484b9c9e3a1fda1a808d6c6a61f205094d) | `` python310Packages.pyproj: 3.4.1 -> 3.5.0 ``                            |
| [`97f06d6c`](https://github.com/NixOS/nixpkgs/commit/97f06d6cb75398dfeb986c06c5c7cb20bbdafaf1) | `` papeer: init at 0.7.0 ``                                               |
| [`1ead2ab0`](https://github.com/NixOS/nixpkgs/commit/1ead2ab094f37cba585d75dfd65c0247e1b2c786) | `` google-cloud-sdk: add passthru.updateScript (#222631) ``               |
| [`9e7811d7`](https://github.com/NixOS/nixpkgs/commit/9e7811d7acaa61d76a105429847ac51e4a8fb0f9) | `` kubeseal: 0.20.2 -> 0.20.5 ``                                          |
| [`c42d6a37`](https://github.com/NixOS/nixpkgs/commit/c42d6a371bc87e28faebb86bec4953b4caf4736c) | `` ouch: remove unused input ``                                           |
| [`8ef171d4`](https://github.com/NixOS/nixpkgs/commit/8ef171d482ae13f36aee5e28269edceb27600e2c) | `` svtplay-dl: 4.19 -> 4.20 ``                                            |
| [`013b60d0`](https://github.com/NixOS/nixpkgs/commit/013b60d032b117698623f7abe3e03a2b7b8de137) | `` urlwatch: 2.25 -> 2.26 ``                                              |
| [`00ee240c`](https://github.com/NixOS/nixpkgs/commit/00ee240c5e950cbb981806d9621beaae6e8bc27b) | `` udpx: init at 1.0.7 ``                                                 |
| [`547cd3cf`](https://github.com/NixOS/nixpkgs/commit/547cd3cfd122c8ac59f50b2d4e7704087fce2232) | `` python310Packages.pyroute2: 0.7.5 -> 0.7.7 ``                          |
| [`2f54a3bc`](https://github.com/NixOS/nixpkgs/commit/2f54a3bcef6c3a7be14f5984940f7d4546f01f0f) | `` phpunit: enable for all platforms ``                                   |
| [`5539c7fd`](https://github.com/NixOS/nixpkgs/commit/5539c7fd823328e180b35bd66ed295563bd4afad) | `` python310Packages.bc-detect-secrets: 1.4.20 -> 1.4.21 ``               |
| [`7d9fe0a8`](https://github.com/NixOS/nixpkgs/commit/7d9fe0a83587bfb7ac0932a1ab662fac496f83c3) | `` python310Packages.pegen: init at 0.2.0 ``                              |
| [`5171e6a3`](https://github.com/NixOS/nixpkgs/commit/5171e6a356467585a40d8e1b09ae983ab9bb001d) | `` python310Packages.enaml: disable on unsupported Python releases ``     |
| [`e34a17ca`](https://github.com/NixOS/nixpkgs/commit/e34a17ca0a5295b5448882c6ec28130c7c24a544) | `` python310Packages.enaml: add pegen ``                                  |
| [`97bc2824`](https://github.com/NixOS/nixpkgs/commit/97bc2824dce24e31df459b20921688faf79f6e79) | `` python310Packages.enaml: add changelog to meta ``                      |
| [`41f44bc0`](https://github.com/NixOS/nixpkgs/commit/41f44bc0a7bdfce9135512a087fbad3af3f94b48) | `` deltachat-desktop: 1.36.3 -> 1.36.4 ``                                 |
| [`6a67d184`](https://github.com/NixOS/nixpkgs/commit/6a67d1842795d3eff3f428d9f6c94405dbd59b59) | `` python310Packages.siobrultech-protocols: 0.7.0 -> 0.9.0 ``             |
| [`0ac955ad`](https://github.com/NixOS/nixpkgs/commit/0ac955ad63e2f94c64de584551493ceb33b00b45) | `` rust/cargo.nix: set HOST_PKG_CONFIG_PATH for cross builds ``           |
| [`80d42840`](https://github.com/NixOS/nixpkgs/commit/80d42840e8195dd3622833513b44261c9bc01392) | `` helm-ls: fix completion cmd ``                                         |
| [`89c4041e`](https://github.com/NixOS/nixpkgs/commit/89c4041ea54d4d0478ab9b2b2eb03c8f29dcbbd1) | `` python310Packages.mypy-boto3-s3: 1.26.104 -> 1.26.116 ``               |
| [`9248879f`](https://github.com/NixOS/nixpkgs/commit/9248879fab09beba6c6a2e968515f4b480e9d6d3) | `` exploitdb: 2023-04-21 -> 2023-04-22 ``                                 |
| [`d7a00225`](https://github.com/NixOS/nixpkgs/commit/d7a002252668cb007fedeada7186bd4715f5641a) | `` python310Packages.marshmallow-dataclass: 8.5.12 -> 8.5.13 ``           |
| [`db9eda09`](https://github.com/NixOS/nixpkgs/commit/db9eda0945fef849a48491c9c5fea76a6d9065c8) | `` steam: fix error message on unsupported arch ``                        |
| [`081a33eb`](https://github.com/NixOS/nixpkgs/commit/081a33eb3d952aec0a913fe9dcaa1db5f2ba259d) | `` python3Packages.pyssim: 0.4 -> 0.6 ``                                  |
| [`32b313f7`](https://github.com/NixOS/nixpkgs/commit/32b313f704c70c8fb2b85d16817b302e22b87f86) | `` snobol4: init at 2.3.1 (#225028) ``                                    |
| [`ad3a5326`](https://github.com/NixOS/nixpkgs/commit/ad3a53265807daf53c1e64482ad710a93fe8f1ce) | `` rust/cargo.nix: disable audit if audit.meta.broken ``                  |
| [`758ae7d4`](https://github.com/NixOS/nixpkgs/commit/758ae7d4f44e7d0544f4b57debdbd1d385c9ea3e) | `` cargo-auditable: mark broken if cross ``                               |
| [`423204a9`](https://github.com/NixOS/nixpkgs/commit/423204a9821710b7f85af25aefea83aaef1ed0f3) | `` emacsPackages.ligo-mode: fixup meta ``                                 |
| [`a4d304a6`](https://github.com/NixOS/nixpkgs/commit/a4d304a664ededf9ca2873fe5d38147b09ead8da) | `` intel-media-sdk: 23.1.2 -> 23.2.0 ``                                   |
| [`ab0f243a`](https://github.com/NixOS/nixpkgs/commit/ab0f243aeef0a840988346bdd0814d7ad426ec37) | `` mdcat: 2.0.1 -> 2.0.2 ``                                               |
| [`1c64f726`](https://github.com/NixOS/nixpkgs/commit/1c64f726d9a8649c4e011e8050998e3923fee703) | `` checkov: 2.3.150 -> 2.3.192 ``                                         |
| [`fcafb393`](https://github.com/NixOS/nixpkgs/commit/fcafb3938f1960fc2440614c43dd1bf9fd4fcda2) | `` cargo-careful: 0.2.4 -> 0.3.2 ``                                       |
| [`0d3eb74e`](https://github.com/NixOS/nixpkgs/commit/0d3eb74e18b0db9ae01cc208adb15d6a1e983e79) | `` sic-image-cli: 0.21.1 -> 0.22.0 ``                                     |
| [`459b4494`](https://github.com/NixOS/nixpkgs/commit/459b4494c86812e7d23b406d36449141c55e6659) | `` python310Packages.django-taggit: Fix django 4.2 support ``             |
| [`18024a42`](https://github.com/NixOS/nixpkgs/commit/18024a4201fef4ad4f7062a88fae352bcb04444e) | `` swayimg: fix cross ``                                                  |
| [`2029c3fa`](https://github.com/NixOS/nixpkgs/commit/2029c3fa2a92670a7dec9161dafcb293dee14ec9) | `` linuxKernel.kernels.linux_lqx: 6.2.11-lqx1 -> 6.2.12-lqx1 ``           |
| [`1aab61ec`](https://github.com/NixOS/nixpkgs/commit/1aab61ecfe8b0118d3136af2dfb6fd9d9e8f532c) | `` linuxKernel.kernels.linux_zen: 6.2.11-zen1 -> 6.2.12-zen1 ``           |
| [`42b04489`](https://github.com/NixOS/nixpkgs/commit/42b044893ee8a7a6a748b11f67daaad1623b6afc) | `` vulkan-cts: 1.3.5.1 -> 1.3.5.2 ``                                      |
| [`38907ef2`](https://github.com/NixOS/nixpkgs/commit/38907ef24ed61f3fe90098c0a0aad538cc60ddb1) | `` python310Packages.types-redis: 4.5.1.4 -> 4.5.4.1 ``                   |
| [`b893544c`](https://github.com/NixOS/nixpkgs/commit/b893544c70c393c2db30a220d131f432b33c2025) | `` nix-build-uncached: 1.1.1 -> 1.1.2 ``                                  |
| [`aed26c95`](https://github.com/NixOS/nixpkgs/commit/aed26c958098866eed42519e686b704299ab5226) | `` lavalauncher: fix cross ``                                             |
| [`13c3024d`](https://github.com/NixOS/nixpkgs/commit/13c3024d17a340b841b4e5934d205acb5f43922e) | `` python310Packages.sepaxml: 2.5.0 -> 2.6.1 ``                           |
| [`bfda831f`](https://github.com/NixOS/nixpkgs/commit/bfda831f76a44fec297525ceed4ac12b65dcc566) | `` mako: fix cross ``                                                     |
| [`3687bee8`](https://github.com/NixOS/nixpkgs/commit/3687bee81c0c06f06c3aa0b112232a6e1dac4623) | `` requireFile: allow using `hash` instead of `sha256`/`sha1` ``          |
| [`e721a171`](https://github.com/NixOS/nixpkgs/commit/e721a171cd3f8dc176a20b0d6f6725f33347d7e0) | `` python310Packages.peewee: 3.15.4 -> 3.16.2 ``                          |
| [`1d3420bb`](https://github.com/NixOS/nixpkgs/commit/1d3420bb96bc39d97ebf877b9641800a6ac18446) | `` python310Packages.ibm-cloud-sdk-core: 3.16.2 -> 3.16.5 ``              |
| [`eda27c3e`](https://github.com/NixOS/nixpkgs/commit/eda27c3e8b0ee323a0d0bae6a57c4092db0124ab) | `` python310Packages.google-cloud-error-reporting: 1.9.0 -> 1.9.1 ``      |
| [`3f1db579`](https://github.com/NixOS/nixpkgs/commit/3f1db5792f03d5f9f40b06941c8e1fda1650c8d4) | `` python310Packages.google-cloud-container: 2.20.0 -> 2.21.0 ``          |
| [`fbc9875f`](https://github.com/NixOS/nixpkgs/commit/fbc9875f76fccc425b0f80e752baac941a8a36d0) | `` python310Packages.google-cloud-resource-manager: 1.9.1 -> 1.10.0 ``    |
| [`e607847d`](https://github.com/NixOS/nixpkgs/commit/e607847d45b6a57ac5633ab3de07031f843ad2e1) | `` python310Packages.google-cloud-spanner: 3.30.0 -> 3.31.0 ``            |
| [`56dcf824`](https://github.com/NixOS/nixpkgs/commit/56dcf8245439017138259d381322872c367d2e05) | `` python310Packages.google-cloud-translate: 3.11.0 -> 3.11.1 ``          |
| [`fb9c3d10`](https://github.com/NixOS/nixpkgs/commit/fb9c3d10330e7290fde7a5f190ddb50f4745d5f5) | `` python310Packages.potentials: 0.3.5 -> 0.3.6 ``                        |
| [`1f05afcd`](https://github.com/NixOS/nixpkgs/commit/1f05afcdd8807541856a94af69a2ea4aa738cd05) | `` python311Packages.yabadaba: 0.1.3 -> 0.2.0 ``                          |
| [`c4b144f3`](https://github.com/NixOS/nixpkgs/commit/c4b144f33847b168521c8570219e34c6328e423e) | `` python311Packages.cdcs: 0.1.9 -> 0.2.1 ``                              |
| [`3c6e26b2`](https://github.com/NixOS/nixpkgs/commit/3c6e26b2ee808e3a895a83713904b63ba5dbc3bf) | `` buildFHSEnv: restrict pkgsi686Linux to x86_64-linux ``                 |
| [`407508a0`](https://github.com/NixOS/nixpkgs/commit/407508a06d53c5c945ed009a22b6f5ad5be87f5d) | `` fnott: fix cross ``                                                    |
| [`80cf91af`](https://github.com/NixOS/nixpkgs/commit/80cf91af2080d0db5e157187a53e500ac8e7da88) | `` php81Extensions.pdlib: 1.0.2 -> 1.1.0 ``                               |
| [`bbf0ab93`](https://github.com/NixOS/nixpkgs/commit/bbf0ab935df8ffd4162f73cf2c53f62e5f2aa831) | `` wlclock: fix cross ``                                                  |
| [`a27b9b91`](https://github.com/NixOS/nixpkgs/commit/a27b9b91cd422d603852eb6aab59ed509a7f502a) | `` lswt: fix cross ``                                                     |
| [`5a14c302`](https://github.com/NixOS/nixpkgs/commit/5a14c302563774cb9ff8bd24080841115328ec9f) | `` somebar: fix cross ``                                                  |
| [`fd42fb3b`](https://github.com/NixOS/nixpkgs/commit/fd42fb3bdb5dc4ed295fee9c3b7882f79df04871) | `` cargo-llvm-cov: use fetchCrate ``                                      |
| [`97666f3a`](https://github.com/NixOS/nixpkgs/commit/97666f3ae0584b7c2dddc70fe7f962b5f4d995d8) | `` mapserver: 8.0.0 -> 8.0.1 ``                                           |
| [`f1694fde`](https://github.com/NixOS/nixpkgs/commit/f1694fdedce60560c0fda44e3fad8518942312f9) | `` androidStudioPackages.beta: 2022.3.1.11 -> 2022.3.1.12 ``              |
| [`a942be70`](https://github.com/NixOS/nixpkgs/commit/a942be70156a3cee996bbcff0bfdac31ea5395e5) | `` drawio: 21.1.2 -> 21.2.1 ``                                            |
| [`2858603a`](https://github.com/NixOS/nixpkgs/commit/2858603a319f57bfd6aa52f499ba1ea1975f928f) | `` telegraf: 1.26.0 -> 1.26.1 ``                                          |
| [`b2d9d992`](https://github.com/NixOS/nixpkgs/commit/b2d9d9928f75bfa2b3135b699e0433e34529397d) | `` cargo-llvm-cov: 0.5.16 -> 0.5.17 ``                                    |
| [`7432b752`](https://github.com/NixOS/nixpkgs/commit/7432b75233b05597124dc5d04e5d787bdd1711f9) | `` pyrosimple: init at 2.7.0 ``                                           |
| [`501deb05`](https://github.com/NixOS/nixpkgs/commit/501deb05fa0b5b7cd01571d272d8f47deb2bd8d6) | `` dot-language-server: 1.1.26 -> 1.1.27 ``                               |
| [`a3a582ab`](https://github.com/NixOS/nixpkgs/commit/a3a582ab8cdf700a2f9ae6b558a9cd6fc5a84d0b) | `` tflint: 0.46.0 -> 0.46.1 ``                                            |
| [`5ae47dfe`](https://github.com/NixOS/nixpkgs/commit/5ae47dfec6679ffacafa5e97975aa2127d7b33d8) | `` esbuild: 0.17.17 -> 0.17.18 ``                                         |
| [`505b1e5b`](https://github.com/NixOS/nixpkgs/commit/505b1e5bf5e0c1211bcbe5056db27dd03110f257) | `` python310Packages.jupyter-cache: 0.5.0 -> 0.6.1 ``                     |
| [`135bf564`](https://github.com/NixOS/nixpkgs/commit/135bf5646b6dbc9aaec388a5b83d743971566c1b) | `` python310Packages.itemloaders: 1.0.6 -> 1.1.0 ``                       |
| [`f20bb8d2`](https://github.com/NixOS/nixpkgs/commit/f20bb8d21acf6480f662ef1a5dfd87fb2d97ec4e) | `` python310Packages.types-python-dateutil: 2.8.19.10 -> 2.8.19.12 ``     |
| [`b153b30d`](https://github.com/NixOS/nixpkgs/commit/b153b30d63820898a33818f09b45f32327476707) | `` plasma5Packages: update tiers ``                                       |
| [`61f2c50d`](https://github.com/NixOS/nixpkgs/commit/61f2c50d97de1b014fed76e6c44abd77e7f94e6b) | `` python310Packages.py3status: 3.49 -> 3.50 ``                           |
| [`852ae6f0`](https://github.com/NixOS/nixpkgs/commit/852ae6f068dec80a4d63b664fc6274cddd909d56) | `` zed: 1.6.0 -> 1.7.0 ``                                                 |
| [`cf25c427`](https://github.com/NixOS/nixpkgs/commit/cf25c427f3030b16a5d8e249fcd12179200f8c32) | `` xfce.xfce4-dockbarx-plugin: 0.6 -> 0.7.2 ``                            |
| [`5d8ba448`](https://github.com/NixOS/nixpkgs/commit/5d8ba448c27a7ac5e06cdc278240d6eddaad816d) | `` dockbarx: 1.0-beta -> 1.0-beta2 ``                                     |
| [`ad4b2c27`](https://github.com/NixOS/nixpkgs/commit/ad4b2c272cbef0972479006b5d8f1cad6f98e7b5) | `` mongodb-tools: 100.6.0 -> 100.7.0 ``                                   |
| [`dc15346f`](https://github.com/NixOS/nixpkgs/commit/dc15346f072f05974c55b37ca4d651dc53948bfe) | `` mdbook-d2: init at unstable-2023-03-30 ``                              |
| [`d0070ed0`](https://github.com/NixOS/nixpkgs/commit/d0070ed03dd423dd9e2b4d0fdf48a3e3913fa221) | `` apacheHttpdPackages.mod_auth_mellon: 0.18.0 -> 0.18.1 ``               |
| [`d85ad87d`](https://github.com/NixOS/nixpkgs/commit/d85ad87d119d296883679682ad527596f8b9ac6d) | `` python310Packages.bc-detect-secrets: 1.4.19 -> 1.4.20 ``               |
| [`a8a97691`](https://github.com/NixOS/nixpkgs/commit/a8a976914697252e188ceea1753635829a300724) | `` codemov: init at unstable-2022-10-24 ``                                |
| [`9c99a7da`](https://github.com/NixOS/nixpkgs/commit/9c99a7dadc94f41f63c50e41c95319c0b8f4eeaa) | `` androidStudioPackages.stable: 2022.1.1.20 -> 2022.2.1.18 ``            |
| [`880d99b2`](https://github.com/NixOS/nixpkgs/commit/880d99b259b502f936d98a2f884ab85fa889a1b8) | `` jetbrains: 2022.3.2 -> 2023.1.1 ``                                     |
| [`88f4f0f3`](https://github.com/NixOS/nixpkgs/commit/88f4f0f3759120538ec0c6e4ff0e2b8ec2073f65) | `` zookeeper: 3.6.3 -> 3.7.1 ``                                           |
| [`a56b0af5`](https://github.com/NixOS/nixpkgs/commit/a56b0af5ff980f795b223bac9a03dcf8460ca5aa) | `` maintainers: add ne9z ``                                               |
| [`664d9fd9`](https://github.com/NixOS/nixpkgs/commit/664d9fd9a252569075f21f2b7d13463466d9ae8c) | `` alice-tools-qt6: Fix Qt tool detection on Darwin ``                    |
| [`82c8852b`](https://github.com/NixOS/nixpkgs/commit/82c8852b6f60e838d50dcd1b1add6d6aa61e8a6e) | `` alice-tools,alice-tools-qt5,alice-tools-qt6: Add version test ``       |
| [`d9263322`](https://github.com/NixOS/nixpkgs/commit/d92633226f5c4aa8f5c8e875e664cef54b2849f9) | `` alice-tools,alice-tools-qt5,alice-tools-qt6: 0.12.1 -> 0.13.0 ``       |
| [`02c1d132`](https://github.com/NixOS/nixpkgs/commit/02c1d132478b5e479d5e5d13b26f5ef77fee72d5) | `` factorio: 1.1.77 -> 1.1.80 ``                                          |
| [`ec6f63da`](https://github.com/NixOS/nixpkgs/commit/ec6f63dae7982f3d83b792afa0d8a88ac754a0ac) | `` libsForQt5.qtpositioning: init at 5.15.2 ``                            |