### PR TITLE
chore(flake/nixpkgs): `e78d25df` -> `884ac294`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -217,11 +217,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682268651,
-        "narHash": "sha256-2eZriMhnD24Pmb8ideZWZDiXaAVe6LzJrHQiNPck+Lk=",
+        "lastModified": 1682362401,
+        "narHash": "sha256-/UMUHtF2CyYNl4b60Z2y4wwTTdIWGKhj9H301EDcT9M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e78d25df6f1036b3fa76750ed4603dd9d5fe90fc",
+        "rev": "884ac294018409e0d1adc0cae185439a44bd6b0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`74a7d447`](https://github.com/NixOS/nixpkgs/commit/74a7d447b2164cfd273014cc374a8877fdc29045) | `` iptsd: 1.1.1 -> 1.2.0 ``                                                          |
| [`7509871f`](https://github.com/NixOS/nixpkgs/commit/7509871fea118c38e7342551254015f42868b544) | `` looseversion: init at 1.0.3 ``                                                    |
| [`f515d4ad`](https://github.com/NixOS/nixpkgs/commit/f515d4ad45432e58d2ab3708e64d47381eb664b1) | `` maintainers: add pelme ``                                                         |
| [`3fd093ef`](https://github.com/NixOS/nixpkgs/commit/3fd093ef5b1ecac98c38b69b8819070b53c218bf) | `` terminator: 2.1.2 -> 2.1.3 ``                                                     |
| [`1c74fa18`](https://github.com/NixOS/nixpkgs/commit/1c74fa18ce7fd8b644841bf661742ec6fad2562c) | `` xplr: 0.20.2 -> 0.21.1 ``                                                         |
| [`4a2cbfd0`](https://github.com/NixOS/nixpkgs/commit/4a2cbfd0e52059b79ff128ddad0fdc741aa0d030) | `` owl-compositor: fix pname conflict with owl ``                                    |
| [`719666c4`](https://github.com/NixOS/nixpkgs/commit/719666c4792d84099d2e62b16bbd91b94e35b692) | `` spotify: 1.1.99.878.g1e4ccc6e -> 1.2.9.743.g85d9593d ``                           |
| [`4a5817c4`](https://github.com/NixOS/nixpkgs/commit/4a5817c44a62c415ce3ec24ff832d12108805012) | `` toot: 0.34.1 -> 0.36.0 (#227688) ``                                               |
| [`f0dcebd4`](https://github.com/NixOS/nixpkgs/commit/f0dcebd4f6157403008e7253541a5faea0b2872c) | `` patchelfUnstable: unstable-2023-03-27 -> unstable-2023-04-23 ``                   |
| [`cc782a95`](https://github.com/NixOS/nixpkgs/commit/cc782a953dc252dca4774364fd4f1be2dfafb03a) | `` graph-easy: change pname to graph-easy ``                                         |
| [`51e0e48f`](https://github.com/NixOS/nixpkgs/commit/51e0e48f35edc0c36b57fea9acbb3fa8a0b2046a) | `` CONTRIBUTING.md: Clarify guidelines for `meta.description` ``                     |
| [`6c2712db`](https://github.com/NixOS/nixpkgs/commit/6c2712dbf09d21f5e76e15170235fd62bf9e1cf4) | `` fix(banana-accounting): multiple issues (#221820) ``                              |
| [`2493aa0d`](https://github.com/NixOS/nixpkgs/commit/2493aa0d131a792606c0135d67933aae8df94636) | `` python310Packages.beautifulsoup4: workaround splicing issue with python hooks ``  |
| [`ecd33b6f`](https://github.com/NixOS/nixpkgs/commit/ecd33b6f92472081efb7c4d16f99c0b955517b2d) | `` lightgbm: init at 2023-02-18 (#216971) ``                                         |
| [`b8e9168c`](https://github.com/NixOS/nixpkgs/commit/b8e9168ca74d9974d6a8728ad13583b9e7ad40a5) | `` owncloud-client: 2.11.0.8354 -> 3.2.1 ``                                          |
| [`1c757960`](https://github.com/NixOS/nixpkgs/commit/1c7579605bc7730e7d88539704aa1b467952c9bd) | `` uboot: 2022.10 -> 2023.01 ``                                                      |
| [`ed66b775`](https://github.com/NixOS/nixpkgs/commit/ed66b7751ca38b1f4dbe29f2df44861d23b38ebf) | `` maintainers: add hellwolf ``                                                      |
| [`9ed444d2`](https://github.com/NixOS/nixpkgs/commit/9ed444d2124706d58b8ab546ad4252e51ab47674) | `` python3.pkgs.pyblake2: remove ``                                                  |
| [`414e1038`](https://github.com/NixOS/nixpkgs/commit/414e10385a7682218eb123066199dacfc1ed082d) | `` muon: update wrapfiles ``                                                         |
| [`1db78654`](https://github.com/NixOS/nixpkgs/commit/1db78654420620c8b2d65c299fcde6ea63f07349) | `` muon: 0.1.0 -> 0.2.0 ``                                                           |
| [`98eea76f`](https://github.com/NixOS/nixpkgs/commit/98eea76fc676b3ca29bd795b3304b98f4d628916) | `` python310Packages.niko-home-control: 0.2.2 -> 0.3.0 ``                            |
| [`4e2d1aee`](https://github.com/NixOS/nixpkgs/commit/4e2d1aeed841dcacdc3178c072ad72e2c9124216) | `` python310Packages.fakeredis: 2.10.3 -> 2.11.0 ``                                  |
| [`15fdac88`](https://github.com/NixOS/nixpkgs/commit/15fdac8845e9a1f43a028056f1a81eb2e76a9574) | `` linux_6_3: init ``                                                                |
| [`372e0f8e`](https://github.com/NixOS/nixpkgs/commit/372e0f8efc5ee4d73ab7197c0312e7ee9d13d997) | `` doc/stdenv/meta.chapter.md: document meta.badPlatforms (#225276) ``               |
| [`466bfb64`](https://github.com/NixOS/nixpkgs/commit/466bfb64dc048e19442001e18e1000e2d914f5a4) | `` Add geri1701 to maintainer-list.nix ``                                            |
| [`f30c5b8c`](https://github.com/NixOS/nixpkgs/commit/f30c5b8c64d8390111456f4792f2764cea84662a) | `` typst-fmt: init at unstable-2023-04-16 ``                                         |
| [`75bbbbd3`](https://github.com/NixOS/nixpkgs/commit/75bbbbd39b15341bb54197db321ea37fc6e25b4b) | `` remove trailing whitespace ``                                                     |
| [`40143031`](https://github.com/NixOS/nixpkgs/commit/401430319c2a5ceb488cfad9a3e4a6207aa5cad7) | `` Update doc/stdenv/meta.chapter.md ``                                              |
| [`467ee31e`](https://github.com/NixOS/nixpkgs/commit/467ee31e58ccb79476d815f4131cb283cecd9560) | `` Update doc/stdenv/meta.chapter.md ``                                              |
| [`26ecc0c3`](https://github.com/NixOS/nixpkgs/commit/26ecc0c359f627cdf7b3a0e8b13f4b2b5902c53a) | `` nmh: add -Wno-stringop-truncation ``                                              |
| [`bece4931`](https://github.com/NixOS/nixpkgs/commit/bece4931b53c901bbe6aa34b5c84a4782de5fabd) | `` Update pkgs/tools/networking/nmh/default.nix ``                                   |
| [`0227195b`](https://github.com/NixOS/nixpkgs/commit/0227195b627529e40a5f14fcc25f19f39c60ab5b) | `` nmh: init at 1.7.1 ``                                                             |
| [`abab00a8`](https://github.com/NixOS/nixpkgs/commit/abab00a89c60a866bfcaecdcdd451d5814881624) | `` zathura: fix cross by disabling tests, adding `check` ``                          |
| [`4616038a`](https://github.com/NixOS/nixpkgs/commit/4616038ad3bcbf7b1cea8b42e7c13b7143782b7c) | `` rnote: 0.5.18 -> 0.6.0 ``                                                         |
| [`a3bc6d87`](https://github.com/NixOS/nixpkgs/commit/a3bc6d87d5eb4ab83d642a46423201b41bf0912a) | `` python310Packages.bx-py-utils: 76 -> 78 ``                                        |
| [`b75b059c`](https://github.com/NixOS/nixpkgs/commit/b75b059c747da4e2cd213c23895f49db94b57290) | `` python310Packages.jaraco-abode: 4.1.0 -> 5.0.1 ``                                 |
| [`be4c8aaa`](https://github.com/NixOS/nixpkgs/commit/be4c8aaaa5179216dcd2424c0a3c397ac8b54c22) | `` python310Packages.trove-classifiers: 2023.4.18 -> 2023.4.22 ``                    |
| [`359c7a11`](https://github.com/NixOS/nixpkgs/commit/359c7a11bcd58c313701257c0a0a08c33d801a88) | `` python310Packages.fints: 3.1.0 -> 4.0.0 ``                                        |
| [`af10ec1c`](https://github.com/NixOS/nixpkgs/commit/af10ec1c5b7af7106a5b5ea2b633275d549d7e8c) | `` gdal: 3.6.3 -> 3.6.4 ``                                                           |
| [`07751535`](https://github.com/NixOS/nixpkgs/commit/077515351e90b5eb8ea7c2268e96494a7ff3b826) | `` python310Packages.homeassistant-stubs: 2023.4.5 -> 2023.4.6 ``                    |
| [`646c8985`](https://github.com/NixOS/nixpkgs/commit/646c89856932aae45a3c6476d975bcb411c6cf71) | `` home-assistant: 2023.4.5 -> 2023.4.6 ``                                           |
| [`2544a7f2`](https://github.com/NixOS/nixpkgs/commit/2544a7f2438f0fd6c8147b66cba44e2755603491) | `` python310Packages.pylitterbot: 2023.1.2 -> 2023.4.0 ``                            |
| [`e2b6b51e`](https://github.com/NixOS/nixpkgs/commit/e2b6b51e7596c2176d7d90258fb28871243b143e) | `` python310Packages.pyinsteon: 1.4.1 -> 1.4.2 ``                                    |
| [`b2d51541`](https://github.com/NixOS/nixpkgs/commit/b2d51541a37678ad4e870f75326b6e68daf3b3c7) | `` libsForQt5.mauiPackages: 2.2.1 -> 2.2.2 ``                                        |
| [`9523cce8`](https://github.com/NixOS/nixpkgs/commit/9523cce8a084194dab37236fe403687fb675388c) | `` jql: 5.2.0 -> 6.0.5, add figsoda as a maintainer ``                               |
| [`670862bf`](https://github.com/NixOS/nixpkgs/commit/670862bf405993fcae1e6de66d262f462de58dc1) | `` python310Packages.ttp: 0.9.2 -> 0.9.4 ``                                          |
| [`0df5257b`](https://github.com/NixOS/nixpkgs/commit/0df5257b8217dcbd43b195cc25e9fbc309017487) | `` nixos/qemu-vm: introduce `virtualisation.mountHostNixStore` option ``             |
| [`ada2efde`](https://github.com/NixOS/nixpkgs/commit/ada2efde07053ec6a6adb892193f0fdc8d31e31e) | `` sic-image-cli: 0.22.0 -> 0.22.1 ``                                                |
| [`5afaa90a`](https://github.com/NixOS/nixpkgs/commit/5afaa90a001b9da66894c5d26a8961e580022706) | `` khal: 0.10.5 -> 0.11.1 ``                                                         |
| [`5a7bcb52`](https://github.com/NixOS/nixpkgs/commit/5a7bcb521c60fa8729a5be612a091a49f5c69a55) | `` felix-fm: 2.2.5 -> 2.2.6 ``                                                       |
| [`66504778`](https://github.com/NixOS/nixpkgs/commit/66504778ce157db536f70274d1dadc7f8a576a11) | `` rye: init at unstable-2023-04-23 ``                                               |
| [`ff22bd3a`](https://github.com/NixOS/nixpkgs/commit/ff22bd3ada89e3404b865b5b6142da2cd2095ea0) | `` plex: 1.32.0.6950-8521b7d99 -> 1.32.0.6973-a787c5a8e ``                           |
| [`94add426`](https://github.com/NixOS/nixpkgs/commit/94add426514aab7e9c9dd39e5631f5a49a8c8722) | `` octopus: 12.1 -> 12.2 ``                                                          |
| [`6cc2ab02`](https://github.com/NixOS/nixpkgs/commit/6cc2ab022a2df93d898ef6434ca02cd78f1d5bf5) | `` gromacs: 2023 -> 2023.1 ``                                                        |
| [`6301ccc2`](https://github.com/NixOS/nixpkgs/commit/6301ccc20e5cdb1b5f3c792f0989c1301cf2af64) | `` nextcloudPackages: update ``                                                      |
| [`3348bc45`](https://github.com/NixOS/nixpkgs/commit/3348bc45086f65404ecb71adc7d85f7d68246332) | `` mopidy-jellyfin: 1.0.2 -> 1.0.4 ``                                                |
| [`815fed2e`](https://github.com/NixOS/nixpkgs/commit/815fed2e05a17838b7c3f6be448428fa5fccd1e4) | `` cargo-pgx: 0.6.1 -> 0.7.4, keep 0.6.1, add 0.7.1 ``                               |
| [`9d5dba71`](https://github.com/NixOS/nixpkgs/commit/9d5dba717041400aececbb86b46896cd18d8b84d) | `` nixos/roundcube: read only first line of password file ``                         |
| [`2d248b09`](https://github.com/NixOS/nixpkgs/commit/2d248b097854b17a553ca3e131b5efa5b68cf17f) | `` boxxy: 0.6.3 -> 0.6.4 ``                                                          |
| [`072de16b`](https://github.com/NixOS/nixpkgs/commit/072de16b78efebb5362277a341e9a5f4a6830754) | `` emacsPackages.lsp-bridge: 20230311.1648 -> 20230424.1642 ``                       |
| [`646872b2`](https://github.com/NixOS/nixpkgs/commit/646872b228ac8ef00b3923d90993b381a4bf18b7) | `` texlab: 5.4.2 -> 5.5.0 ``                                                         |
| [`83d4fa46`](https://github.com/NixOS/nixpkgs/commit/83d4fa464aa8e6de17119694faa5578590bc5e70) | `` texlab: 5.4.1 -> 5.4.2 ``                                                         |
| [`e9b41616`](https://github.com/NixOS/nixpkgs/commit/e9b416168a8dc4ce8d9ebdd571e83b5162d18df5) | `` lib.generators.toLua: allow disabling multiline ``                                |
| [`a48fd10c`](https://github.com/NixOS/nixpkgs/commit/a48fd10c8699c4ae3cd6b4565cf1ebf1d9b38333) | `` lib.generators.toLua: tune comment for noogle use ``                              |
| [`cf24129e`](https://github.com/NixOS/nixpkgs/commit/cf24129e93b81c1916ba3c597618abb9349c3cb4) | `` krane: 3.0.1 -> 3.1.0 ``                                                          |
| [`b77d3fea`](https://github.com/NixOS/nixpkgs/commit/b77d3fea43b94be94dc2a5d0dd4da45a55f4e199) | `` cargo-semver-checks: 0.19.0 -> 0.20.0 ``                                          |
| [`26f3c3b0`](https://github.com/NixOS/nixpkgs/commit/26f3c3b0848ab83f50bf84aa9f90c80235e181ff) | `` got: 0.86 -> 0.87 ``                                                              |
| [`d5355161`](https://github.com/NixOS/nixpkgs/commit/d5355161f566b1fecfb3c79bb134ec78ac42d999) | `` mangohud: enable tests ``                                                         |
| [`a1363863`](https://github.com/NixOS/nixpkgs/commit/a1363863899cf7eee38bc6b1d4d38abe81b112fa) | `` aaaaxy: 1.3.421 -> 1.3.457 ``                                                     |
| [`862488f4`](https://github.com/NixOS/nixpkgs/commit/862488f4591286e6287bd0059bb8278c7a370590) | `` nfs-ganesha: 4.4 -> 5.0 ``                                                        |
| [`c5d83918`](https://github.com/NixOS/nixpkgs/commit/c5d839180a5c70c72f08ab44f22bef4ce6cad3f6) | `` ntirpc: 4.3 -> 5.0 ``                                                             |
| [`60c3435a`](https://github.com/NixOS/nixpkgs/commit/60c3435ab9241dad3124a80ba8c8888ec8712b93) | `` angelfish: fix build ``                                                           |
| [`e4497988`](https://github.com/NixOS/nixpkgs/commit/e4497988b467b44821ce3068557663ad224896b7) | `` bird: 2.0.12 -> 2.13 ``                                                           |
| [`8678ac74`](https://github.com/NixOS/nixpkgs/commit/8678ac74d7fed27d558df0128f5a33143f0bd091) | `` babashka: 1.3.176 -> 1.3.178 ``                                                   |
| [`c58c844b`](https://github.com/NixOS/nixpkgs/commit/c58c844b364a776b3251c1725afa597c1e199a96) | `` nix-init: 0.2.1 -> 0.2.2 ``                                                       |
| [`f2de0166`](https://github.com/NixOS/nixpkgs/commit/f2de0166bc2cace212d0a42ad2f6986a029db336) | `` soft-serve: 0.4.6 -> 0.4.7 ``                                                     |
| [`45bc53cb`](https://github.com/NixOS/nixpkgs/commit/45bc53cb5214f83767065865ac56700cddc4ba91) | `` lux: 0.17.2 -> 0.18.0 ``                                                          |
| [`44a4afba`](https://github.com/NixOS/nixpkgs/commit/44a4afba11fba6f636a1566e022de2d92ba0ae3d) | `` asterisk: drop pjsip 2.12 and patches, no longer used ``                          |
| [`0a8004f4`](https://github.com/NixOS/nixpkgs/commit/0a8004f496612a3ec179695ff2304855124bddb9) | `` asterisk: drop 16 and 19 ``                                                       |
| [`f51c667a`](https://github.com/NixOS/nixpkgs/commit/f51c667a290311d9abdbb6be1e775ba9917971ec) | `` asterisk: 18.16.0 -> 18.17.1, 20.1.0 -> 20.2.1 ``                                 |
| [`ab513057`](https://github.com/NixOS/nixpkgs/commit/ab51305750a12d678b841f939a0ac26d2ada57b9) | `` snapmaker-luban: 4.7.2 -> 4.7.3 ``                                                |
| [`37142a97`](https://github.com/NixOS/nixpkgs/commit/37142a9703bb1b65b49764d0c21bded2fdb6bfcf) | `` python310Packages.simple-salesforce: add pyjwt as input ``                        |
| [`78fb35ce`](https://github.com/NixOS/nixpkgs/commit/78fb35ce39b9f4db45999457c170f65ed153f3eb) | `` nixos/roundcube: extend documentation for passwordFile ``                         |
| [`279eeae1`](https://github.com/NixOS/nixpkgs/commit/279eeae178543bfd0a8b5f04793f586699f64555) | `` nixos/roundcube: fix roundcube-setup start ``                                     |
| [`2af4a9bc`](https://github.com/NixOS/nixpkgs/commit/2af4a9bc09bccb74cda5eefb98193b4bbbb0eba5) | `` nixos/roundcube: fix PostgreSQL password ``                                       |
| [`58f2928e`](https://github.com/NixOS/nixpkgs/commit/58f2928ed51bd2a0de5fc19c188fdd5b1ef57b0a) | `` python310Packages.qualysclient: fix invalid specifier ``                          |
| [`ba5d35ba`](https://github.com/NixOS/nixpkgs/commit/ba5d35ba668ce07823c4d0ed4c48b3940787233f) | `` python310Packages.pydsdl: 1.12.1 -> 1.18.0 ``                                     |
| [`b32e668a`](https://github.com/NixOS/nixpkgs/commit/b32e668a9cc0095a8bc4640ef935f0f550a3b154) | `` python311Packages.python-ipmi: fix invalid specifier ``                           |
| [`877095c0`](https://github.com/NixOS/nixpkgs/commit/877095c0f2ec8720f31ead0f4218651759a18f18) | `` python310Packages.gemfileparser2: fix invalid specifier ``                        |
| [`2a0e437c`](https://github.com/NixOS/nixpkgs/commit/2a0e437c8d70dda8369a08ddb63ebca3fc2fd726) | `` nwg-bar: 0.1.1 -> 0.1.3 ``                                                        |
| [`3c3b6a4e`](https://github.com/NixOS/nixpkgs/commit/3c3b6a4ebc2179fc141e8c5c04b13816b88c1964) | `` lidarr: 1.0.2.2592 -> 1.1.4.3027 ``                                               |
| [`c552ebbc`](https://github.com/NixOS/nixpkgs/commit/c552ebbca826b00f2b7286bf09efa8be3ab5d1db) | `` amdvlk: 2023.Q1.3 -> 2023.Q2.1 ``                                                 |
| [`ff553c35`](https://github.com/NixOS/nixpkgs/commit/ff553c356c73d0b03c560530f02a7210ca1ca0bf) | `` okteto: 2.14.2 -> 2.14.3 ``                                                       |
| [`4ec4c6fd`](https://github.com/NixOS/nixpkgs/commit/4ec4c6fda90cec38b0878bf6e601f5df82ae5a8f) | `` lib/generators: add toLua/mkLuaInline ``                                          |
| [`e7a7316c`](https://github.com/NixOS/nixpkgs/commit/e7a7316c5315efa87965f79c5cfcfca90e3d275f) | `` imagemagick: 7.1.1-7 -> 7.1.1-8 ``                                                |
| [`7265c2b8`](https://github.com/NixOS/nixpkgs/commit/7265c2b8a009c335f367ff9d4bde4011fa8633c5) | `` linuxwave: init at 0.1.3 ``                                                       |
| [`f8005e14`](https://github.com/NixOS/nixpkgs/commit/f8005e1487c7e7ec23ab065a6eb73e4a6416200d) | `` soapysdr: fix cross ``                                                            |
| [`3f298745`](https://github.com/NixOS/nixpkgs/commit/3f298745ad230ee22df51105fe07f0fc958e387a) | `` lua54Packages.bit32: mark as broken ``                                            |
| [`dcf7b468`](https://github.com/NixOS/nixpkgs/commit/dcf7b468ce3b44c9c52e132a99bde1ffc6e1f366) | `` lua54Packages.lua-subprocess: mark as broken ``                                   |
| [`30a70671`](https://github.com/NixOS/nixpkgs/commit/30a70671f49dbb61abb66a5755398919f81d2d25) | `` buildLuaPackage: enable __structuredAttrs rocks ``                                |
| [`92d81d03`](https://github.com/NixOS/nixpkgs/commit/92d81d03bd4a270a61f61352c9ebacacbd2f4c65) | `` python310Packages.google-cloud-kms: 2.15.0 -> 2.16.1 ``                           |
| [`fc952043`](https://github.com/NixOS/nixpkgs/commit/fc952043685f3de8ca1f5c19348de404c31e38df) | `` lua54Packages.vstruct: mark broken ``                                             |
| [`17ceaffa`](https://github.com/NixOS/nixpkgs/commit/17ceaffab1a67a0e76c11ae88e68711cd9c06104) | `` dante: disable getaddrinfo() checks if cross ``                                   |
| [`5e89f704`](https://github.com/NixOS/nixpkgs/commit/5e89f7044484b0e86fe06637fe5d187ea32e169f) | `` telegram-desktop: 4.7.1 -> 4.8.0 ``                                               |
| [`b8b706b0`](https://github.com/NixOS/nixpkgs/commit/b8b706b0708e7c61b7dd715f0fab9bd7b9e627c7) | `` python3Packages.uamqp: use github source, unpin openssl_1_1, enable tests ``      |
| [`61939b04`](https://github.com/NixOS/nixpkgs/commit/61939b04276d218935da2640e734f27cc44435b1) | `` millet: 0.9.3 -> 0.9.4 ``                                                         |
| [`6c798c9c`](https://github.com/NixOS/nixpkgs/commit/6c798c9c0e1f778d449a74d1a74c0463cb3f7018) | `` docker-compose: 2.17.2 -> 2.17.3 ``                                               |
| [`9536dd12`](https://github.com/NixOS/nixpkgs/commit/9536dd12465613013c15dbd2496438b6c046a693) | `` signalbackup-tools: 20230414 -> 20230421-1 ``                                     |
| [`39dc9a9f`](https://github.com/NixOS/nixpkgs/commit/39dc9a9f2cdd9473181f2bf000a8f3a033a8cd28) | `` pgadmin4: 6.21 -> 7.0 ``                                                          |
| [`35b5ea83`](https://github.com/NixOS/nixpkgs/commit/35b5ea83e3005cfc58ae9b3e545195608ea276c8) | `` python3Packages:azure-mgmt-resource: 22.0.0 -> 23.0.0 ``                          |
| [`a8cc62f9`](https://github.com/NixOS/nixpkgs/commit/a8cc62f9ce351f4eaaa6b2c61219f7b5fa4ac2be) | `` python3Packages.flask-socketio: 5.1.1 -> 5.3.3 ``                                 |
| [`40a5c0a0`](https://github.com/NixOS/nixpkgs/commit/40a5c0a05841641225c8e77bb5eae0ca23d67898) | `` linux_xanmod: 6.1.24 -> 6.1.25 ``                                                 |
| [`a9f4dfc8`](https://github.com/NixOS/nixpkgs/commit/a9f4dfc8950b7e98a395c34cb9a9562664740ffc) | `` linux_xanmod_latest: 6.2.11 -> 6.2.12 ``                                          |
| [`52cb2d2c`](https://github.com/NixOS/nixpkgs/commit/52cb2d2cdd436834d0bb5b62d2c73038ad1b1650) | `` cemu: 2.0-32 -> 2.0-36 ``                                                         |
| [`96ef4901`](https://github.com/NixOS/nixpkgs/commit/96ef490147083133d64118f5cb4967cd93546789) | `` Update pkgs/development/compilers/flix/default.nix ``                             |
| [`60eb9a47`](https://github.com/NixOS/nixpkgs/commit/60eb9a470f5d1a2015e02496f01c1e56e315698f) | `` Update pkgs/development/compilers/flix/default.nix ``                             |
| [`254180d5`](https://github.com/NixOS/nixpkgs/commit/254180d5089523bfe9011b510df13981b263296e) | `` nixosTests.gitea: fix sshd race condition ``                                      |
| [`e6a04bc9`](https://github.com/NixOS/nixpkgs/commit/e6a04bc9eff50e196a94f527d5869369bb3400b5) | `` forgejo: build from source ``                                                     |
| [`6ad64af7`](https://github.com/NixOS/nixpkgs/commit/6ad64af778b6f44a0e8a7ca0e74f21d3c4089054) | `` nixos/consul: use `lib.getExe` where possible ``                                  |
| [`9c1f2921`](https://github.com/NixOS/nixpkgs/commit/9c1f292155efcefc147186d76921874a16caee01) | `` nixos/consul: fix package reference in service `$PATH` ``                         |
| [`75d51afa`](https://github.com/NixOS/nixpkgs/commit/75d51afa426c2e8b50759367f4529499f7d84a49) | `` webcord-vencord: init at 4.1.1 ``                                                 |
| [`abd2c440`](https://github.com/NixOS/nixpkgs/commit/abd2c440971083bb3b7b2db56d0e96897a2bfe55) | `` zfs: 2.1.9 → 2.1.11 ``                                                            |
| [`762f8328`](https://github.com/NixOS/nixpkgs/commit/762f8328f9256be3bb04582db680ee7616fce082) | `` tor-browser-bundle-bin: 12.0.4 -> 12.0.5 ``                                       |
| [`1425758d`](https://github.com/NixOS/nixpkgs/commit/1425758d4c36ae6265fbe0ed8ce7a8bb1572cdee) | `` warzone2100: 4.3.4 -> 4.3.5 ``                                                    |
| [`2890af5e`](https://github.com/NixOS/nixpkgs/commit/2890af5e4bf5badd939e30651e2328ddb4e7647c) | `` nixos/acme: fix options type ``                                                   |
| [`23205d28`](https://github.com/NixOS/nixpkgs/commit/23205d28d2c0d134508ae0b6d79ba0f9a53835ab) | `` kent: add missing information to the meta ``                                      |
| [`5b621525`](https://github.com/NixOS/nixpkgs/commit/5b62152599b15c85a8b7420c9fed2eeff6838aa3) | `` kent: add runHooks ``                                                             |
| [`1e68ff3e`](https://github.com/NixOS/nixpkgs/commit/1e68ff3ee9d30565b684d9d93a89cc6f87485723) | `` kent: 404 -> 446 ``                                                               |
| [`b6a6c4a9`](https://github.com/NixOS/nixpkgs/commit/b6a6c4a96f47e611850c37492bd7a8ba4694341b) | `` swww: 0.7.2 -> 0.7.3 ``                                                           |
| [`7425cd06`](https://github.com/NixOS/nixpkgs/commit/7425cd06fca780f559d4a5e9782c25232e59c83f) | `` flix: init at 0.35.0 ``                                                           |
| [`a2726066`](https://github.com/NixOS/nixpkgs/commit/a272606614d7c22aa8f2091f996c1a8155e3c4a2) | `` hh-suite: init at 3.3.0 ``                                                        |
| [`d07b2110`](https://github.com/NixOS/nixpkgs/commit/d07b21106c74b4dfceef18ce3b17a47e7993eb14) | `` snipe-it: 6.0.14 -> 6.1.0 ``                                                      |
| [`babf0983`](https://github.com/NixOS/nixpkgs/commit/babf09839cfd263f2d4631b8eb207e85d4452921) | `` libsForQt5.libqglviewer: 2.8.0 -> 2.9.1 ``                                        |
| [`e0caa914`](https://github.com/NixOS/nixpkgs/commit/e0caa91427d6d06e86f6a812accdf073f77b3a1a) | `` at-spi2-core: use availableOn ``                                                  |
| [`1a41d761`](https://github.com/NixOS/nixpkgs/commit/1a41d76159d8cd81bc7dbdee35a93d15fa2b5f50) | `` maintainers: Add FlafyDev and NotAShelf ``                                        |
| [`a8370201`](https://github.com/NixOS/nixpkgs/commit/a837020120f58d3ef446a84014a34a7611274e33) | `` apfsprogs: unstable-2022-10-15 -> unstable-2023-03-21 ``                          |
| [`ad7996ab`](https://github.com/NixOS/nixpkgs/commit/ad7996abce1894cd3c6cd46eb0b5bf3036753e43) | `` apfsprogs: link to apfs NixOS test ``                                             |
| [`01353a1e`](https://github.com/NixOS/nixpkgs/commit/01353a1ee12f0f98f1bd4f5a8dd6eafc84a57dd6) | `` python3Packages.sphinxext-opengraph: 0.8.1 -> 0.8.2 ``                            |
| [`cffe87b9`](https://github.com/NixOS/nixpkgs/commit/cffe87b9f509e0dfe7aeedff950dcc74ceca785a) | `` gpxsee: 12.2 → 12.4 ``                                                            |
| [`83907067`](https://github.com/NixOS/nixpkgs/commit/839070670e7a32d2785ca590a4a4bd28ec183918) | `` cen64: unstable-2021-03-12 -> unstable-2022-10-02 ``                              |
| [`4be94ba4`](https://github.com/NixOS/nixpkgs/commit/4be94ba44b43a661a55d19e8a9e77030d3424ee6) | `` galene: 0.6.1 -> 0.7.0 ``                                                         |
| [`bd80d99a`](https://github.com/NixOS/nixpkgs/commit/bd80d99a616f37bbf4928b574e5c106a70047932) | `` galene: add erdnaxe as maintainer ``                                              |
| [`e396a4ec`](https://github.com/NixOS/nixpkgs/commit/e396a4ec1f9a484e95eb685e0d877869b5edb753) | `` rocdbgapi: fix build ``                                                           |
| [`dd456244`](https://github.com/NixOS/nixpkgs/commit/dd4562447dabdd9b94e8c0a0a7a2e65bbdbd65ca) | `` ArchiSteamFarm: 5.4.3.2 -> 5.4.4.5 ``                                             |
| [`19d48a92`](https://github.com/NixOS/nixpkgs/commit/19d48a925778a524a970ca06cabc45ade3f82474) | `` doc/stdenv/meta.chapter.md: explain difference between broken and badPlatforms `` |
| [`4d41c937`](https://github.com/NixOS/nixpkgs/commit/4d41c9374502b1f666ad7b0db3ec97a7c1492d46) | `` osl: 1.11.17.0 -> 1.12.11.0 ``                                                    |
| [`e22e3f4c`](https://github.com/NixOS/nixpkgs/commit/e22e3f4c62340456ab84d285422ff87f10591524) | `` bitwarden: 2023.2.0 -> 2023.3.2 ``                                                |
| [`491667f8`](https://github.com/NixOS/nixpkgs/commit/491667f8a95d89d3401bd9cfa99021cf7a7eb7b5) | `` dante: autoreconfHook unconditionally ``                                          |
| [`15399cff`](https://github.com/NixOS/nixpkgs/commit/15399cff6d678b035e1b2b97542203f641bb8f42) | `` gsocket: 1.4.39 -> 1.4.40 ``                                                      |
| [`138983c6`](https://github.com/NixOS/nixpkgs/commit/138983c60019183a6f0cb96623f44032f8b51b37) | `` xp-pen-deco-01-v2-driver: 3.2.3 -> 3.3.9 ``                                       |
| [`6ed55eaa`](https://github.com/NixOS/nixpkgs/commit/6ed55eaa191146ffda72cda307ef86a2aef2cd06) | `` framesh: 0.5.0 -> 0.6.2 ``                                                        |
| [`8fbe036f`](https://github.com/NixOS/nixpkgs/commit/8fbe036fb2bf56ac5f1195a1c68d7a1641931ddf) | `` mercury: use jdk_headless to allow non-gui builds ``                              |