### PR TITLE
chore(flake/nixpkgs): `884ac294` -> `c8018361`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -217,11 +217,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682362401,
-        "narHash": "sha256-/UMUHtF2CyYNl4b60Z2y4wwTTdIWGKhj9H301EDcT9M=",
+        "lastModified": 1682453498,
+        "narHash": "sha256-WoWiAd7KZt5Eh6n+qojcivaVpnXKqBsVgpixpV2L9CE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "884ac294018409e0d1adc0cae185439a44bd6b0b",
+        "rev": "c8018361fa1d1650ee8d4b96294783cf564e8a7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`f1f0ef95`](https://github.com/NixOS/nixpkgs/commit/f1f0ef95cc4b5eb6a30bda28bce1838819bb2a81) | `` tauri-mobile: init at unstable-2023-04-25 (#228178) ``                    |
| [`a7b0ff0a`](https://github.com/NixOS/nixpkgs/commit/a7b0ff0a0de9d5576fe15fa9083c933cfd430902) | `` bugdom,nanosaur,nanosaur2,otto-matic: add desktop files (#215525) ``      |
| [`c634094e`](https://github.com/NixOS/nixpkgs/commit/c634094e7b103b68935b8aae2e040819e9815f63) | `` diffr: 0.1.4 -> 0.1.5 ``                                                  |
| [`e5e680a9`](https://github.com/NixOS/nixpkgs/commit/e5e680a99abc3cd0a7b808441d2555893546613f) | `` qovery-cli: 0.58.3 -> 0.58.6 ``                                           |
| [`c3a60a4e`](https://github.com/NixOS/nixpkgs/commit/c3a60a4ece65217f54b52f3a507dee80a2fa2ebf) | `` corerad: 1.2.1 -> 1.2.2 ``                                                |
| [`b6c5e7e2`](https://github.com/NixOS/nixpkgs/commit/b6c5e7e2308d6f96995ccfa07a492fd0543e7c21) | `` mdbook-kroki-preprocessor: 0.1.2 -> 0.2.0 ``                              |
| [`e64a3fde`](https://github.com/NixOS/nixpkgs/commit/e64a3fdef2a2093e0a360efbe01d7e701c5facb6) | `` godns: 2.9.4 -> 2.9.6 ``                                                  |
| [`7fb8a68e`](https://github.com/NixOS/nixpkgs/commit/7fb8a68efa06d078d9e25e673e4072d05f46ebb6) | `` flutter: Fix linux-x64-profile/linux-x64-flutter-gtk artifact hash ``     |
| [`e76ecd24`](https://github.com/NixOS/nixpkgs/commit/e76ecd244a70805302ab7e628b239733845fceb5) | `` algolia-cli: 1.3.4 -> 1.3.5 ``                                            |
| [`dd8fb54c`](https://github.com/NixOS/nixpkgs/commit/dd8fb54c4db75cce40b4c12e04dfbae13388050d) | `` jot: 0.1.1 -> 0.1.2 ``                                                    |
| [`05a8a32f`](https://github.com/NixOS/nixpkgs/commit/05a8a32f6093d278975e27c0075530fc377a09e8) | `` burpsuite: 2023.2.4 -> 2023.3.5 ``                                        |
| [`7f57b38c`](https://github.com/NixOS/nixpkgs/commit/7f57b38cc89dfdd10bdc99f0525b84b981777c9f) | `` static-web-server: 2.15.0 -> 2.16.0 (#228048) ``                          |
| [`10b8dd69`](https://github.com/NixOS/nixpkgs/commit/10b8dd6997023142fc980a265f55b3fb0edb2a9a) | `` seaweedfs: 3.46 -> 3.47 (#228043) ``                                      |
| [`dcb1d8d5`](https://github.com/NixOS/nixpkgs/commit/dcb1d8d5e88dd74289a62418408e06bcafabc088) | `` cudatext: 1.191.0 -> 1.191.5 ``                                           |
| [`402182b6`](https://github.com/NixOS/nixpkgs/commit/402182b66d3864d80f613427edbaaa2feb178bb8) | `` libdeltachat: 1.113.0 -> 1.114.0 (#228081) ``                             |
| [`30155955`](https://github.com/NixOS/nixpkgs/commit/301559558f03fb961e333442eeb485d80b5f9544) | `` restique: unstable-2021-05-03 -> unstable-2022-11-29 ``                   |
| [`0d1a36bf`](https://github.com/NixOS/nixpkgs/commit/0d1a36bfb4eaf63ea0bdae28ba7431ee90eefc72) | `` restic: 0.15.1 -> 0.15.2 ``                                               |
| [`72c1d14d`](https://github.com/NixOS/nixpkgs/commit/72c1d14d767dabc402f50bb38f283ee14bc5f449) | `` gitlab-runner: 15.10.0 -> 15.11.0 (#228102) ``                            |
| [`ed312cb4`](https://github.com/NixOS/nixpkgs/commit/ed312cb4f78d3d79c11769cb07880fcfaf582377) | `` doc/default.nix: make the manual build on more than one core (#225921) `` |
| [`37057275`](https://github.com/NixOS/nixpkgs/commit/37057275a0fcced68a447a97a154269df93fcf93) | `` supabase-cli: 1.48.1 -> 1.50.13 ``                                        |
| [`7e047604`](https://github.com/NixOS/nixpkgs/commit/7e0476043014bfe97937084cde8c3f3c4c0554a5) | `` bacon: 2.7.0 -> 2.8.1 ``                                                  |
| [`25671114`](https://github.com/NixOS/nixpkgs/commit/25671114cd9266e27b2609d94babdc66f52357a6) | `` cloud-init: add udhcpc support (#226216) ``                               |
| [`8c051713`](https://github.com/NixOS/nixpkgs/commit/8c051713653593e4c8c58795b648130bf450bf62) | `` duckscript: 0.8.17 -> 0.8.18 ``                                           |
| [`f96b6538`](https://github.com/NixOS/nixpkgs/commit/f96b6538dff698905f95cbefd8dbf74a67ed7733) | `` git-subrepo: 0.4.5 -> 0.4.6 ``                                            |
| [`e1b387b9`](https://github.com/NixOS/nixpkgs/commit/e1b387b9214e908421709af7d0f477efba565e33) | `` Update github owner and URL for mdcat (#228116) ``                        |
| [`d4ade747`](https://github.com/NixOS/nixpkgs/commit/d4ade747dc84df574d7f45e7a67e6b635f39fca3) | `` bird-lg: Pass version and meta ``                                         |
| [`3dc05fbe`](https://github.com/NixOS/nixpkgs/commit/3dc05fbe40e192001a5057dd0f514e0c3bf6cbc7) | `` nixos/bird-lg: Add support for traceroute-flags ``                        |
| [`6a38c71d`](https://github.com/NixOS/nixpkgs/commit/6a38c71d3ca2bcafbca9cdb49ff44d05cc6482bb) | `` bird-lg: unstable-2022-05-08 -> 1.2.0 ``                                  |
| [`f3f15fa7`](https://github.com/NixOS/nixpkgs/commit/f3f15fa73ddf15fa66cc4f80cda4c5afb356306b) | `` networkmanager: 1.42.2 -> 1.42.6 (#227809) ``                             |
| [`83c3fb2e`](https://github.com/NixOS/nixpkgs/commit/83c3fb2e8d9506c936cc00f5f080e2ee4f48c455) | `` trufflehog: 3.32.1 -> 3.32.2 ``                                           |
| [`a33e936a`](https://github.com/NixOS/nixpkgs/commit/a33e936aa62839761716c40d7a533af12d80a713) | `` exploitdb: 2023-04-24 -> 2023-04-25 ``                                    |
| [`9dc7d17e`](https://github.com/NixOS/nixpkgs/commit/9dc7d17ed8744b1d3b8acc0d7150bfc825eadfcd) | `` node2nix: use new name package name for nodejs ``                         |
| [`aad577bd`](https://github.com/NixOS/nixpkgs/commit/aad577bd30b0ab16a7859973c88edd6d0d5becde) | `` nodejs*: normalise names to better fit other packages ``                  |
| [`71d1beb9`](https://github.com/NixOS/nixpkgs/commit/71d1beb95a360e4d083eed6b4c45b13eb757220a) | `` libadwaita: Document why tests are disabled on darwin right now ``        |
| [`19964a24`](https://github.com/NixOS/nixpkgs/commit/19964a24dc4d62daa565794cebf8771a65860bab) | `` telegram-desktop: 4.8.0 -> 4.8.1 (#228060) ``                             |
| [`fe492a88`](https://github.com/NixOS/nixpkgs/commit/fe492a885c1e043f8f4f1821b6930dfee1406c9e) | `` amberol: unstable-2023-01-12 -> 0.10.0 ``                                 |
| [`a2e2972f`](https://github.com/NixOS/nixpkgs/commit/a2e2972ff3b1df8aa342300d6690b3615cc8cc70) | `` nixos/bird-lg: Add maintainers ``                                         |
| [`b63e0d77`](https://github.com/NixOS/nixpkgs/commit/b63e0d77b8eaf7ccc529eaa0640b348690e538a7) | `` nixos/bird-lg: Rework command attribute generation ``                     |
| [`dc07c158`](https://github.com/NixOS/nixpkgs/commit/dc07c15817c650d0114f044c040e73459037ad2e) | `` wireshark: 4.0.4 -> 4.0.5 (#227852) ``                                    |
| [`57e73d23`](https://github.com/NixOS/nixpkgs/commit/57e73d23bb6cc89a25293e5cfb26787438b4efba) | `` rustc,rustPlatform.buildRustPackage: broaden platforms ``                 |
| [`2b920e5a`](https://github.com/NixOS/nixpkgs/commit/2b920e5a082fc168db055dc4724b21c0cbf6fb08) | `` flashrom-stable: init at v1.1 ``                                          |
| [`3a10faf6`](https://github.com/NixOS/nixpkgs/commit/3a10faf6a16580c8166fac6c16a79348dc138429) | `` python3Packages.tensorflow: update darwin aarch64 deps hash ``            |
| [`4515e5ba`](https://github.com/NixOS/nixpkgs/commit/4515e5ba123c523d69867ade391ef23a354ef80c) | `` dasel: 2.1.2 -> 2.2.0 ``                                                  |
| [`e73da62a`](https://github.com/NixOS/nixpkgs/commit/e73da62a1d41959ccfa5a5eb5a0464f45b66c32c) | `` boost182: init at 1.82.0 ``                                               |
| [`07d9193e`](https://github.com/NixOS/nixpkgs/commit/07d9193e644558ab2a0f848e505071ea1439aaec) | `` stanc, cmdstan: 2.31.0 -> 2.32.0 ``                                       |
| [`4536fdd9`](https://github.com/NixOS/nixpkgs/commit/4536fdd9b17c930364d53839add23899416163d4) | `` python310Packages.google-cloud-firestore: 2.10.1 -> 2.11.0 ``             |
| [`e205b43f`](https://github.com/NixOS/nixpkgs/commit/e205b43f47a435ddff30a97d46cd6a1c0b098f9b) | `` linuxPackages_latest.perf: fix python shebangs on 6.3+ ``                 |
| [`b78be66a`](https://github.com/NixOS/nixpkgs/commit/b78be66ad12f2b7b74497e14b977b2347f1e7e10) | `` qelectrotech: mark as broken on darwin ``                                 |
| [`d5b1550f`](https://github.com/NixOS/nixpkgs/commit/d5b1550fc8328ea68e94d9604e8d5d3c1ba08abd) | `` pythonPackages.devito: fix source hash ``                                 |
| [`e452880e`](https://github.com/NixOS/nixpkgs/commit/e452880efe71c8989afb386020784b4fc7983003) | `` cfssl: 1.6.3 -> 1.6.4 ``                                                  |
| [`0cc1844b`](https://github.com/NixOS/nixpkgs/commit/0cc1844bb4d0ce28fd187531afa818b152c3d1b8) | `` deltachat-desktop: fix build of libdeltachat ``                           |
| [`aa7e3f35`](https://github.com/NixOS/nixpkgs/commit/aa7e3f35c5ea931f382fd8f452264c68e7036ba3) | `` orbiton: 2.60.6 -> 2.61.0 ``                                              |
| [`f7af9373`](https://github.com/NixOS/nixpkgs/commit/f7af9373ed3a615471669802134cf02f7a46f985) | `` flutter: Generate target PKG_CONFIG_PATH at build time ``                 |
| [`39d2fafe`](https://github.com/NixOS/nixpkgs/commit/39d2fafebc12010318f74b2f5ecdfff124560628) | `` yq-go: 4.33.2 -> 4.33.3 ``                                                |
| [`50dc8c78`](https://github.com/NixOS/nixpkgs/commit/50dc8c78599e2b15ab6f34be40ac4548bdd8cecd) | `` terraform-providers.talos: 0.1.2 -> 0.2.0 ``                              |
| [`0c51ac72`](https://github.com/NixOS/nixpkgs/commit/0c51ac724ad30d26feb46cd45b1f4f23dddd5555) | `` terraform-providers.google-beta: 4.62.1 -> 4.63.0 ``                      |
| [`7edcaa48`](https://github.com/NixOS/nixpkgs/commit/7edcaa486f5bd34053e706ab64e104e7dcccacea) | `` terraform-providers.google: 4.62.1 -> 4.63.0 ``                           |
| [`0c8e19ac`](https://github.com/NixOS/nixpkgs/commit/0c8e19ac9a71f8c26784dccef8aa72f338fbd2e8) | `` terraform-providers.dns: 3.3.1 -> 3.3.2 ``                                |
| [`7c71129d`](https://github.com/NixOS/nixpkgs/commit/7c71129d9d8691f5068bd84d520502b507f8df77) | `` terraform-providers.exoscale: 0.46.0 -> 0.47.0 ``                         |
| [`fe0e07a2`](https://github.com/NixOS/nixpkgs/commit/fe0e07a2d49b26a14a382883e15861be1ce8c1f7) | `` gocryptfs: 2.3 -> 2.3.1 ``                                                |
| [`ead4dd05`](https://github.com/NixOS/nixpkgs/commit/ead4dd05d38c08f5c1412bc69e2b5a442419209f) | `` sarasa-gothic: 0.40.5 -> 0.40.6 ``                                        |
| [`8a3121c4`](https://github.com/NixOS/nixpkgs/commit/8a3121c4e24591bf7d242e1ee58dc0aec1ad2fd0) | `` qtcreator-qt6: 9.0.2 -> 10.0.0 ``                                         |
| [`3a39edac`](https://github.com/NixOS/nixpkgs/commit/3a39edac802280e5e536419708d89b356434e238) | `` elmerfem: 9.0 -> unstable-2023-02-03 ``                                   |
| [`33400e3f`](https://github.com/NixOS/nixpkgs/commit/33400e3fea591d51e320cc302e12890ec6f73058) | `` gtk-frdp: unstable-2023-03-03 → unstable-2023-04-14 ``                    |
| [`177bac3f`](https://github.com/NixOS/nixpkgs/commit/177bac3fb17c3c23f2490f7c46d2f3bd64c99aa4) | `` gnome-connections: 44.0 → 44.1 ``                                         |
| [`84b3d638`](https://github.com/NixOS/nixpkgs/commit/84b3d63860982d4b30488d1f93091fb529dc1f55) | `` networkmanagerapplet: 1.30.0 → 1.32.0 ``                                  |
| [`4c36ee77`](https://github.com/NixOS/nixpkgs/commit/4c36ee7712a5cf3bc2e29602fa124f4f86b110d7) | `` gnome-user-docs: 44.0 → 44.1 ``                                           |
| [`1065acd6`](https://github.com/NixOS/nixpkgs/commit/1065acd63332ccf377db717729f3bd59ee838319) | `` epiphany: 44.1 → 44.2 ``                                                  |
| [`e37823b7`](https://github.com/NixOS/nixpkgs/commit/e37823b7f2f875dd1b70a0f2136e17099df194cc) | `` markdown-it-py: disable checks on i686 ``                                 |
| [`75258c90`](https://github.com/NixOS/nixpkgs/commit/75258c90ea9cf9dc06f30b48d598bc2a8c3c357e) | `` gh-dash: 3.7.6 -> 3.7.7 ``                                                |
| [`6b9626a8`](https://github.com/NixOS/nixpkgs/commit/6b9626a8c06eb16b4e209b700a593ed5de30db61) | `` ttdl: 3.7.1 -> 3.8.0 ``                                                   |
| [`c251c021`](https://github.com/NixOS/nixpkgs/commit/c251c021fe168479f811d1496d5c4571592d8dfa) | `` nixos/stargazer: init ``                                                  |
| [`a541b371`](https://github.com/NixOS/nixpkgs/commit/a541b37190bdb1a5b4c9bc1bd091cd9448109462) | `` maintainers: Add `cyntheticfox` key fingerprint ``                        |
| [`56268b0c`](https://github.com/NixOS/nixpkgs/commit/56268b0c6b8c920b20fec694a977ad8357d509a8) | `` maintainers: Update `cyntheticfox` email ``                               |
| [`9d1fa577`](https://github.com/NixOS/nixpkgs/commit/9d1fa577a1747846574388f4e7b006d1d1237b34) | `` python311Packages.syncedlyrics: 0.4.0 -> 0.5.0 ``                         |
| [`1e4e8a17`](https://github.com/NixOS/nixpkgs/commit/1e4e8a1775f813b6145e872e33997e6f9280573c) | `` gmic-qt: add meta.mainProgram ``                                          |
| [`11d5f170`](https://github.com/NixOS/nixpkgs/commit/11d5f170ad714021b82c62e64666d3eb47d679af) | `` python311Packages.ttp-templates: 0.3.4 -> 0.3.5 ``                        |
| [`df0aedb1`](https://github.com/NixOS/nixpkgs/commit/df0aedb1e9b211ceb8f19f4265bb22542754a338) | `` python311Packages.yalexs: 1.3.0 -> 1.3.2 ``                               |
| [`663d19f9`](https://github.com/NixOS/nixpkgs/commit/663d19f9196d91cc185789dc1ed87a9da666c907) | `` python311Packages.gehomesdk: 0.5.8 -> 0.5.9 ``                            |
| [`116edd5e`](https://github.com/NixOS/nixpkgs/commit/116edd5e23413bee532a921c518deef352c7a019) | `` python311Packages.elmax-api: 0.0.3 -> 0.0.4 ``                            |
| [`de6e3b24`](https://github.com/NixOS/nixpkgs/commit/de6e3b24ed23f738fbc7bd4003b2e106f1ee6e57) | `` python311Packages.hahomematic: 2023.4.0 -> 2023.4.2 ``                    |
| [`1fcf617f`](https://github.com/NixOS/nixpkgs/commit/1fcf617fdc391f20c764b625b30e53b2a1ebf9a7) | `` exploitdb: 2023-04-22 -> 2023-04-24 ``                                    |
| [`244a2f39`](https://github.com/NixOS/nixpkgs/commit/244a2f399fa62bea8580b6c8518e9a0d0603a383) | `` metasploit: 6.3.12 -> 6.3.13 ``                                           |
| [`b9ba5d3e`](https://github.com/NixOS/nixpkgs/commit/b9ba5d3e7e0933ac709b249e45d0e6791372dd27) | `` tauon: Add Darwin support ``                                              |
| [`70a89b05`](https://github.com/NixOS/nixpkgs/commit/70a89b0500553cb864f6021be3033bf007baccae) | `` awsebcli: 3.20.5 -> 3.20.6 ``                                             |
| [`793b1a70`](https://github.com/NixOS/nixpkgs/commit/793b1a707f8165bc185f82eb7f781dbd730790f8) | `` epoll-shim: unstable-2023-02-05 -> 0.0.20230411 ``                        |
| [`7eb272bb`](https://github.com/NixOS/nixpkgs/commit/7eb272bbe8258738cfbae7ae8223901306987c7b) | `` checkov: 2.3.192 -> 2.3.199 ``                                            |
| [`5d391228`](https://github.com/NixOS/nixpkgs/commit/5d391228f62ece322441ac73b15e20185fbd9672) | `` electrum: 4.3.4 -> 4.4.0 ``                                               |
| [`19820516`](https://github.com/NixOS/nixpkgs/commit/198205160db3e3984a2257c7af5ff1ed12b5a46c) | `` qmake2cmake: 1.0.3 -> 1.0.5 ``                                            |
| [`98a1542d`](https://github.com/NixOS/nixpkgs/commit/98a1542d62b308449e134275be41733e2934c9dd) | `` rustic-rs: 0.5.1 -> 0.5.2 ``                                              |
| [`9f74a9f9`](https://github.com/NixOS/nixpkgs/commit/9f74a9f9ccd9ed327eba0dd4568187662c9df718) | `` drawpile: mark as broken on darwin ``                                     |
| [`50058841`](https://github.com/NixOS/nixpkgs/commit/50058841dbdca5eed17cb378857214b0b7f32f64) | `` libsForQt5.maui-core: restrict platforms ``                               |
| [`ae0a6be2`](https://github.com/NixOS/nixpkgs/commit/ae0a6be287d7550a4940cd32716f1ea937acd141) | `` plasma5Packages.kinit: refactor ``                                        |
| [`bb8a261e`](https://github.com/NixOS/nixpkgs/commit/bb8a261ecb89802db85383f2833404de1ca2b30e) | `` plasma5Packages.kdesu: restrict platforms ``                              |
| [`2ddd52c9`](https://github.com/NixOS/nixpkgs/commit/2ddd52c93f73282070317e569b09518f252ffeb6) | `` plasma5Packages.kded: restrict platforms ``                               |
| [`b1053255`](https://github.com/NixOS/nixpkgs/commit/b10532554663735e463b506a573bbe35941dd32e) | `` plasma5Packages.baloo: restrict platforms ``                              |
| [`5b36fa16`](https://github.com/NixOS/nixpkgs/commit/5b36fa169886225e06aa3c1412f3fbf07ab74096) | `` plasma5Packages.kfilemetadata: refactor ``                                |
| [`c49f5e48`](https://github.com/NixOS/nixpkgs/commit/c49f5e48bd2f14f25fef897f997d2980ee50bb22) | `` plasma5Packages.kactivities-stats: restrict platforms ``                  |
| [`b82dbe2f`](https://github.com/NixOS/nixpkgs/commit/b82dbe2fdc61a78f9eb931170bfea09fa824888d) | `` python3Packages.torchvision: 0.14.1 -> 0.15.1 ``                          |
| [`c155ee2b`](https://github.com/NixOS/nixpkgs/commit/c155ee2b7f68c044822968e901082c266ba2de5e) | `` plasma5Packages.kactivities: refactor ``                                  |
| [`4a2fb58f`](https://github.com/NixOS/nixpkgs/commit/4a2fb58f1a0001f2076a4252350b944d7a73c776) | `` plasma5Packages.solid: refactor ``                                        |
| [`1133eae7`](https://github.com/NixOS/nixpkgs/commit/1133eae76c1784a8a2f9292a41c627b96d1b00b7) | `` plasma5Packages.networkmanager-qt: restrict platforms ``                  |
| [`8c0dde12`](https://github.com/NixOS/nixpkgs/commit/8c0dde1254622a05a682cc06f0335e6b11167536) | `` plasma5Packages.modemmanager-qt: restrict platforms ``                    |
| [`f99a52e7`](https://github.com/NixOS/nixpkgs/commit/f99a52e735c9b8b22fe149e34ec59cdaa8cb2892) | `` plasma5Packages.kwayland: restrict platforms ``                           |
| [`c033b967`](https://github.com/NixOS/nixpkgs/commit/c033b967182439e7f348eb70e315c1127cbec2cb) | `` signalbackup-tools: 20230421-1 -> 20230424-1 ``                           |
| [`e51b538b`](https://github.com/NixOS/nixpkgs/commit/e51b538b35553dace80c6db9574aeae6a993cba7) | `` plasma5Packages.bluez-qt: restrict platforms ``                           |
| [`53655d96`](https://github.com/NixOS/nixpkgs/commit/53655d967acd13807a32988637d3f394ad910189) | `` cosign: 2.0.1 -> 2.0.2 ``                                                 |
| [`90a8b9e3`](https://github.com/NixOS/nixpkgs/commit/90a8b9e3febfc1e615ff8308ed2418d48ba4eb6a) | `` rustPlatform.buildRustPackage: fix cross ``                               |
| [`9da5430a`](https://github.com/NixOS/nixpkgs/commit/9da5430a791fad5bb7da395c6320b8166f6ca69b) | `` bear: 3.1.1 -> 3.1.2 ``                                                   |
| [`58ebe2d6`](https://github.com/NixOS/nixpkgs/commit/58ebe2d68019602e8bc45307b39cb9fe4f5b02bc) | `` firefox-bin-unwrapped: 112.0.1 -> 112.0.2 ``                              |
| [`a13e5eea`](https://github.com/NixOS/nixpkgs/commit/a13e5eea982b5b1c2dc33ce295c4166aba06c202) | `` firefox-unwrapped: 112.0.1 -> 112.0.2 ``                                  |
| [`248a283b`](https://github.com/NixOS/nixpkgs/commit/248a283b4894405260c90a89d9a9212cf84618ad) | `` kubeshark: 39.5 -> 40.0 ``                                                |
| [`1551a82b`](https://github.com/NixOS/nixpkgs/commit/1551a82b814c3ac764b4b47855d039162f884455) | `` python310Packages.docformatter: 1.6.2 -> 1.6.3 ``                         |
| [`4e0f98c3`](https://github.com/NixOS/nixpkgs/commit/4e0f98c33bb736cd6bf2ebb7abe4fa06fcb4a671) | `` vale: 2.24.3 -> 2.24.4 ``                                                 |
| [`78dad85b`](https://github.com/NixOS/nixpkgs/commit/78dad85b64a1ca5290f751edddc237dab87ebee7) | `` Revert "python3Packages.catboost: 1.0.5 -> 1.1.1" ``                      |
| [`96d7f371`](https://github.com/NixOS/nixpkgs/commit/96d7f37161691155cd98d71e9d38a6006b8aa71f) | `` iosevka-bin: 22.0.2 -> 22.1.0 ``                                          |
| [`51b96d8e`](https://github.com/NixOS/nixpkgs/commit/51b96d8e85a27800a6c710cc63189ca8dd6651b8) | `` electrum: fix ledger devices support ``                                   |
| [`12f58ef5`](https://github.com/NixOS/nixpkgs/commit/12f58ef507c3be66139984adc4b0c3ea63606344) | `` standardnotes: 3.150.45 -> 3.151.3 ``                                     |
| [`38b8adcc`](https://github.com/NixOS/nixpkgs/commit/38b8adcca55561ba9a8a10aef81679ada97a9c80) | `` pgmodeler: 1.0.2 -> 1.0.3 ``                                              |
| [`15233643`](https://github.com/NixOS/nixpkgs/commit/1523364317d5bccd5a29e734e774f94b90acf7de) | `` goda: 0.5.6 -> 0.5.7 ``                                                   |
| [`775e5cf5`](https://github.com/NixOS/nixpkgs/commit/775e5cf5f4f6cb8a95c05ded80bdae047aa81a23) | `` localsend: 1.8.0 -> 1.9.0 ``                                              |
| [`bf5333b0`](https://github.com/NixOS/nixpkgs/commit/bf5333b014bd691b5ccf5b996eb89140b17f3027) | `` jql: 6.0.5 -> 6.0.6 ``                                                    |
| [`085203d8`](https://github.com/NixOS/nixpkgs/commit/085203d84c0b1713947d0710eab1ca6e2f47cea0) | `` simple-http-server: 0.6.6 -> 0.6.7 ``                                     |
| [`aac51377`](https://github.com/NixOS/nixpkgs/commit/aac51377f0eecb49e86288f0616123590511a941) | `` sketchybar: 2.14.4 -> 2.15.1 ``                                           |
| [`2c5843f7`](https://github.com/NixOS/nixpkgs/commit/2c5843f731e19846497cfee4d6e21ac6bab6d2f4) | `` sccache: 0.4.1 -> 0.4.2 ``                                                |
| [`48c4390e`](https://github.com/NixOS/nixpkgs/commit/48c4390ebfaa3ce53eae58650d0419dd4a2086f3) | `` cargo-careful: 0.3.2 -> 0.3.3 ``                                          |
| [`9deea846`](https://github.com/NixOS/nixpkgs/commit/9deea846bd627f4ebabbc01e8062028b0d6ecf49) | `` boxxy: 0.6.4 -> 0.7.0 ``                                                  |
| [`7fce3da6`](https://github.com/NixOS/nixpkgs/commit/7fce3da6da337372f2d2ec5e23810b4d8c0246fb) | `` avian: cleanup alias ``                                                   |
| [`41a52f6d`](https://github.com/NixOS/nixpkgs/commit/41a52f6d2355b2c087f0bdae982a8f0bb85526e0) | `` riot-{desktop,web}: cleanup alias ``                                      |
| [`a8377dd1`](https://github.com/NixOS/nixpkgs/commit/a8377dd16d83f57eec55dd52529640202ed71c21) | `` oracle{jdk,jre}8psu{,_distro}: cleanup alias ``                           |
| [`e339d7b7`](https://github.com/NixOS/nixpkgs/commit/e339d7b79aa5e4ba58d71218c9da7c3ae9aa75fe) | `` libayatana-appindicator-gtk2: add missing throw in alias ``               |
| [`6196f9de`](https://github.com/NixOS/nixpkgs/commit/6196f9de5e504f3f55adb4d82241f7e78eb2bde8) | `` alibayatana-indicator-gtk2: add missing throw in alias ``                 |
| [`a6b9a1e5`](https://github.com/NixOS/nixpkgs/commit/a6b9a1e5c75b6e47695ab85ffab371ca275adec9) | `` kexpand: add missing throw in alias ``                                    |
| [`c0649e3c`](https://github.com/NixOS/nixpkgs/commit/c0649e3c5ac98340060467953c82b25b4b7b523c) | `` transmission-remote-cli: add missing throw in alias ``                    |
| [`d45ee7f0`](https://github.com/NixOS/nixpkgs/commit/d45ee7f0c9b9d41e39bdcaf3bd9aa94eb636fb27) | `` okteto: 2.14.3 -> 2.15.0 ``                                               |
| [`a544b582`](https://github.com/NixOS/nixpkgs/commit/a544b5828fecf0e6a984a4a43bf52542574864b2) | `` python310Packages.pyunifiprotect: 4.8.1 -> 4.8.2 ``                       |
| [`e46a7cd1`](https://github.com/NixOS/nixpkgs/commit/e46a7cd12a5fc44ad468be8cc8beb1380e2f5569) | `` _1password: 2.16.1 -> 2.17.0 ``                                           |
| [`1ad9fb62`](https://github.com/NixOS/nixpkgs/commit/1ad9fb62a99384c3cf120f0d258061515de4fe1d) | `` wasmtime: 7.0.0 -> 8.0.0 ``                                               |
| [`106fdb05`](https://github.com/NixOS/nixpkgs/commit/106fdb05d9d95370b4b8227eaac18c3816c67503) | `` gp-saml-gui: init at version 0.1 ``                                       |
| [`e4042ded`](https://github.com/NixOS/nixpkgs/commit/e4042dedfb966c7f88e032f0c74e26eab30b8043) | `` maintainers: add pallix ``                                                |
| [`9605ca48`](https://github.com/NixOS/nixpkgs/commit/9605ca4834edd44efe423ec81ec1c0f89829cd2f) | `` ledger-live-desktop: 2.55.0->2.57.0 ``                                    |
| [`4a0f7c97`](https://github.com/NixOS/nixpkgs/commit/4a0f7c97d986f7de6450d1813fc4668f6cd27e60) | `` python310Packages.forecast-solar: 2.3.0 -> 3.0.0 ``                       |
| [`bfc30718`](https://github.com/NixOS/nixpkgs/commit/bfc307189f15407b78f0034251c74cb109804eb3) | `` wike: 1.7.1 -> 2.0.1 ``                                                   |
| [`12c4aafc`](https://github.com/NixOS/nixpkgs/commit/12c4aafccb1a310a0b3855eaebcdf7ac37862ce4) | `` python310Packages.eigenpy: 2.9.2 -> 3.0.0 ``                              |
| [`16865b95`](https://github.com/NixOS/nixpkgs/commit/16865b959fbcea2769c02ea864c51414fa4f50b8) | `` gtk4: 4.10.1 → 4.10.3 ``                                                  |
| [`0e191c7e`](https://github.com/NixOS/nixpkgs/commit/0e191c7ec12e5af4041c2c5cba1a3ab52f3a17ae) | `` promscale_extension: fixed cargoPatch ``                                  |
| [`552e3fe4`](https://github.com/NixOS/nixpkgs/commit/552e3fe49817599c2127a8ab32b72b8e6bf9f724) | `` flutter: Don't use IFD to read the engine version ``                      |
| [`ae0aff84`](https://github.com/NixOS/nixpkgs/commit/ae0aff848fce2a672919bedffbe04f85bfed13b6) | `` flutter: Throw a useful message when there are missing artifact hashes `` |
| [`7e535988`](https://github.com/NixOS/nixpkgs/commit/7e53598823416e2feb0c4fdc645e7692b8453b5d) | `` flutter: 3.7.11 -> 3.7.12 ``                                              |