### PR TITLE
chore(flake/darwin): `a1ee4d33` -> `379d42fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682009832,
-        "narHash": "sha256-QdNOeFE7sI+0ddqVfn9vQDCUs7OdxhJ7evo9sdyP82Y=",
+        "lastModified": 1682773107,
+        "narHash": "sha256-+h94XeJnG3uk5imJlBi/1lVmcfCbxHpwZp5u7n3Krwg=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "a1ee4d333b092bc055655fb06229eb3013755812",
+        "rev": "379d42fad6bc5c28f79d5f7ff2fa5f1c90cb7bf8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                    |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
| [`597c723f`](https://github.com/LnL7/nix-darwin/commit/597c723f1c2b70697f1de84802c25daaf22a166c) | `` test: added a test to run build with git+file schema `` |
| [`d0e36622`](https://github.com/LnL7/nix-darwin/commit/d0e36622c12f7a7fec2d46d60987f565f4cb3247) | `` fix: in URI use proper groups ``                        |
| [`fad0282b`](https://github.com/LnL7/nix-darwin/commit/fad0282b5fc9c05c2751be5df79ddb8c3f1c3452) | `` add '://' to built flake uri ``                         |