### PR TITLE
chore(flake/nixpkgs): `937a9d1e` -> `08e4dc3a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -217,11 +217,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682692304,
-        "narHash": "sha256-9/lyXN2BpHw+1xE+D2ySBSLMCHWqiWu5tPHBMRDib8M=",
+        "lastModified": 1682786779,
+        "narHash": "sha256-m7QFzPS/CE8hbkbIVK4UStihAQMtczr0vSpOgETOM1g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "937a9d1ee7b1351d8c55fff6611a8edf6e7c1c37",
+        "rev": "08e4dc3a907a6dfec8bb3bbf1540d8abbffea22b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`67a6315b`](https://github.com/NixOS/nixpkgs/commit/67a6315ba873f60d93d26631256df497c39cf8a9) | `` vkd3d-proton: init at unstable-2023-04-21 ``                               |
| [`7d7d95d8`](https://github.com/NixOS/nixpkgs/commit/7d7d95d871f35d3d8e54ce705d9ae665227daa9e) | `` vkd3d: init at 1.7 ``                                                      |
| [`99fa5c68`](https://github.com/NixOS/nixpkgs/commit/99fa5c68cab8434d6eabe500d588f00898587ddb) | `` txr: cosmetic patch ``                                                     |
| [`c307bf0d`](https://github.com/NixOS/nixpkgs/commit/c307bf0d0ac259eed5e1391df11423cd49a72d07) | `` txr: 284 -> 285 ``                                                         |
| [`c5b46371`](https://github.com/NixOS/nixpkgs/commit/c5b46371a7ecd7f34f6fe4fed162f865d74af714) | `` didder: init at 1.2.0 ``                                                   |
| [`7d2d1a28`](https://github.com/NixOS/nixpkgs/commit/7d2d1a28950035aa571141c4e005aed86c1aacc8) | `` eksctl: 0.138.0 -> 0.139.0 ``                                              |
| [`921d785c`](https://github.com/NixOS/nixpkgs/commit/921d785c1346f2d9146c63fd0b5098f932ba51ca) | `` qmmp: 2.1.2 -> 2.1.3 ``                                                    |
| [`7ff76721`](https://github.com/NixOS/nixpkgs/commit/7ff767213e14e3940086467b68ad09b51fad363b) | `` protoc-gen-entgrpc: 0.3.0 -> 0.4.3 ``                                      |
| [`599dbaac`](https://github.com/NixOS/nixpkgs/commit/599dbaacc0a562614d4df355e9b64b9e61426f86) | `` git-cinnabar: 0.6.0 -> 0.6.1 ``                                            |
| [`63fcbb8b`](https://github.com/NixOS/nixpkgs/commit/63fcbb8bf7f3639627915ae74758552649d92fcf) | `` libgweather: disable introspection for cross ``                            |
| [`a49eb172`](https://github.com/NixOS/nixpkgs/commit/a49eb1726cdaa0bec129a934e97f4a1c9481bd33) | `` solana-cli: 1.10.9 -> 1.14.17 ``                                           |
| [`d9b04ae5`](https://github.com/NixOS/nixpkgs/commit/d9b04ae5de5e6bd9021fc353ba58454b9333ec01) | `` maintainers: add netfox ``                                                 |
| [`d080500e`](https://github.com/NixOS/nixpkgs/commit/d080500ec9440cbb239eae73562917aa614a6399) | `` python310Packages.pyparted: patch against newer parted ``                  |
| [`97ece073`](https://github.com/NixOS/nixpkgs/commit/97ece073655103cf45b7e11b2f34cd2682cf0f14) | `` ton: 2023.01 -> 2023.04 ``                                                 |
| [`0dc014bc`](https://github.com/NixOS/nixpkgs/commit/0dc014bc54e700f0beaa6297c69a0f537ba9de5f) | `` prometheus-nats-exporter: 0.10.1 -> 0.11.0 ``                              |
| [`f7a917cb`](https://github.com/NixOS/nixpkgs/commit/f7a917cbc5b456fbe3118f4056cd50ee0fc086b8) | `` moonlight-qt: fix build ``                                                 |
| [`b77e85b2`](https://github.com/NixOS/nixpkgs/commit/b77e85b230b08e7799693406c971996bffaea272) | `` python310Packages.env-canada: 0.5.33 -> 0.5.34 ``                          |
| [`51d930f5`](https://github.com/NixOS/nixpkgs/commit/51d930f53e48a5fbe68e90817ccd5c6dd8cd5ab7) | `` chez: 9.5.8 -> 9.5.8a ``                                                   |
| [`4e00bd09`](https://github.com/NixOS/nixpkgs/commit/4e00bd09bec26ffc68fa3bda5e9e78a8309cb7d6) | `` nali: install completions ``                                               |
| [`b4637b22`](https://github.com/NixOS/nixpkgs/commit/b4637b2283dd89348a87af811c61901634dd3e08) | `` nali: 0.7.1 -> 0.7.2 ``                                                    |
| [`c4977714`](https://github.com/NixOS/nixpkgs/commit/c49777144b4e97cfb9a7606861b8a2dbb8173fd7) | `` mmv-go: 0.1.5 -> 0.1.6 ``                                                  |
| [`f24b9558`](https://github.com/NixOS/nixpkgs/commit/f24b955814afda33ae9df903a2a5a804e4cdb638) | `` nncp: 8.8.2 -> 8.8.3 ``                                                    |
| [`7bd27618`](https://github.com/NixOS/nixpkgs/commit/7bd27618b369b2a783127a84173a697d6e2d5b13) | `` rpm-ostree: 2023.2 -> 2023.3 ``                                            |
| [`ba971c42`](https://github.com/NixOS/nixpkgs/commit/ba971c4284459ae398180adb5b0f1854620de9eb) | `` algolia-cli: 1.3.5 -> 1.3.6 ``                                             |
| [`5a1e93e6`](https://github.com/NixOS/nixpkgs/commit/5a1e93e67ff04bf71d1c215295c8383c93f607c1) | `` clipman: 1.6.1 -> 1.6.2, re-add myself as maintainer, install man-pages `` |
| [`e4cb5734`](https://github.com/NixOS/nixpkgs/commit/e4cb5734053a737efae5f5edef9fac4a8e8c0848) | `` httpx: do not build testing packages ``                                    |
| [`7b04ee0f`](https://github.com/NixOS/nixpkgs/commit/7b04ee0f8a7c789f14897fcda3f5c2477350bf39) | `` httpx: 1.2.9 -> 1.3.0 ``                                                   |
| [`1314174d`](https://github.com/NixOS/nixpkgs/commit/1314174d3a1d5c7787acdf9259873f275bcfec5b) | `` solo5: 0.7.5 -> 0.8.0 ``                                                   |
| [`871c8e66`](https://github.com/NixOS/nixpkgs/commit/871c8e661c615fbd6fbb3d81405c4002bf652f56) | `` vimPlugins.feline-nvim: update repo owner ``                               |
| [`dc727dbb`](https://github.com/NixOS/nixpkgs/commit/dc727dbbfa2d3a20226715cf1a60f288b9b9474d) | `` nodePackages: @shopify/cli init at 3.45.1 ``                               |
| [`0c97d307`](https://github.com/NixOS/nixpkgs/commit/0c97d307e68209414977ae270db9d9afafde21b6) | `` netbox: 3.4.10 -> 3.5.0 ``                                                 |
| [`aa4d05bd`](https://github.com/NixOS/nixpkgs/commit/aa4d05bdc2fc2c3c8a32f3ac95ab8d633efab972) | `` netbox: 3.4.9 -> 3.4.10 ``                                                 |
| [`f71efbb6`](https://github.com/NixOS/nixpkgs/commit/f71efbb6e618b08c21d5d2073f5ec2501c86b7e2) | `` netbox: 3.4.7 -> 3.4.9 ``                                                  |
| [`0f8c0221`](https://github.com/NixOS/nixpkgs/commit/0f8c0221c4a5ff5dccca41a4f2f79fb89b7a6264) | `` bindfs: Use fuse3 on linux ``                                              |
| [`485b4574`](https://github.com/NixOS/nixpkgs/commit/485b45741126a5abe259ddcd34e036cf96083a35) | `` tauon: 7.6.3 -> 7.6.4 ``                                                   |
| [`75ed5ecf`](https://github.com/NixOS/nixpkgs/commit/75ed5ecfd6558f4eb8fd097defbf4e1b623270e9) | `` rofi-rbw: add previously implicit dependency to rbw ``                     |
| [`a476b39f`](https://github.com/NixOS/nixpkgs/commit/a476b39fec571dbf29b33f4ebc5d20205698b99f) | `` exploitdb: 2023-04-28 -> 2023-04-29 ``                                     |
| [`6628efd8`](https://github.com/NixOS/nixpkgs/commit/6628efd894d956c162688a4c481feb227783e94f) | `` python310Packages.pytenable: 1.4.12 -> 1.4.13 ``                           |
| [`10826743`](https://github.com/NixOS/nixpkgs/commit/1082674307ba9dd6d386f5c9bc1ea79ccb3cc162) | `` linkerd: 2.13.1 -> 2.13.2 ``                                               |
| [`2c8db12a`](https://github.com/NixOS/nixpkgs/commit/2c8db12ac29cd51d668ad7c094acbad1e0a8e713) | `` cilium-cli: 0.13.2 -> 0.14.0 ``                                            |
| [`b27c7ee2`](https://github.com/NixOS/nixpkgs/commit/b27c7ee29ef0c916c73287955c14071989e26d16) | `` httplib: build with cmake + openssl ``                                     |
| [`2c375c96`](https://github.com/NixOS/nixpkgs/commit/2c375c96f7b53e7a95c021c55ee8095fa338babc) | `` cpp-jwt: fix reported version in cmake files ``                            |
| [`71ef2855`](https://github.com/NixOS/nixpkgs/commit/71ef2855a806af91996ff53794c946af1fde70a5) | `` mongodb-compass: 1.36.3 -> 1.36.4 ``                                       |
| [`cf55738d`](https://github.com/NixOS/nixpkgs/commit/cf55738d99b06fb41b995d6f721c203b50baedc8) | `` postgresql11JitPackages.pg_cron: 1.5.1 -> 1.5.2 ``                         |
| [`4df84a7b`](https://github.com/NixOS/nixpkgs/commit/4df84a7b08f64046a5fd7e7a12616279794bafd3) | `` flow: 0.204.1 -> 0.205.0 ``                                                |
| [`d6102a34`](https://github.com/NixOS/nixpkgs/commit/d6102a348fed7e34b7206202c85731dec34aeb3e) | `` flow: 0.204.0 -> 0.204.1 ``                                                |
| [`e7731568`](https://github.com/NixOS/nixpkgs/commit/e773156881c4cfa13de5a78eb9aaed06b10b85ea) | `` python310Packages.avro3k: fix build ``                                     |
| [`f4da3771`](https://github.com/NixOS/nixpkgs/commit/f4da377155951f5af53766b9089091bbd481f095) | `` ibus-engines.typing-booster-unwrapped: 2.22.3 -> 2.22.4 ``                 |
| [`6a528aaf`](https://github.com/NixOS/nixpkgs/commit/6a528aaffa896690d7dc4017d874d93d71aa16c0) | `` wesnoth: 1.16.8 -> 1.16.9 ``                                               |
| [`409b519c`](https://github.com/NixOS/nixpkgs/commit/409b519ce909dedbbd231e46c302963c082dfce5) | `` nmrpflash: 0.9.19 -> 0.9.20 ``                                             |
| [`988b93dd`](https://github.com/NixOS/nixpkgs/commit/988b93ddb84c5cd419ed58f188c3ebb17ae2cabe) | `` rnote: build cli ``                                                        |
| [`9c83f0df`](https://github.com/NixOS/nixpkgs/commit/9c83f0df004a650f5727402fc54cf734a056fd7c) | `` gcsfuse: 0.42.3 -> 0.42.4 ``                                               |
| [`16f50b26`](https://github.com/NixOS/nixpkgs/commit/16f50b260bb02e9a1ce0447b52580af1cc2a3f30) | `` jetbrains-toolbox: 1.27.3.14493 -> 1.28.0.15158 ``                         |
| [`320b165c`](https://github.com/NixOS/nixpkgs/commit/320b165c863a3061074fce1fd56fec8b27965d8e) | `` unciv: 4.6.5 -> 4.6.7 ``                                                   |
| [`6c81a3b0`](https://github.com/NixOS/nixpkgs/commit/6c81a3b0f6d59dab0f31c049c5ed6aa359cb82cc) | `` haproxy: 2.7.6 -> 2.7.7 ``                                                 |
| [`b34c00d4`](https://github.com/NixOS/nixpkgs/commit/b34c00d43d557cbaf589914c7f858cef10289400) | `` php80Packages.psysh: 0.11.10 -> 0.11.16 ``                                 |
| [`373e9eb4`](https://github.com/NixOS/nixpkgs/commit/373e9eb4c42b2fc0611d794de5ea715a35d72393) | `` terraform-providers.vultr: 2.14.0 -> 2.14.1 ``                             |
| [`c909f76c`](https://github.com/NixOS/nixpkgs/commit/c909f76ca739d8d4fac17041bdc96e17f52e29b3) | `` terraform-providers.newrelic: 3.20.2 -> 3.21.3 ``                          |
| [`268c4d36`](https://github.com/NixOS/nixpkgs/commit/268c4d36b48b0cad78860f79057ff85b2a5232ef) | `` terraform-providers.mongodbatlas: 1.8.2 -> 1.9.0 ``                        |
| [`77e159b6`](https://github.com/NixOS/nixpkgs/commit/77e159b6cc98dd3fd856e90d464817cf55e12a23) | `` terraform-providers.huaweicloud: 1.47.1 -> 1.48.0 ``                       |
| [`c7223953`](https://github.com/NixOS/nixpkgs/commit/c7223953796c1a034b8c6bd8461ca036ad493736) | `` terraform-providers.azurerm: 3.53.0 -> 3.54.0 ``                           |
| [`9026f3c4`](https://github.com/NixOS/nixpkgs/commit/9026f3c4f770391569a0af8da99651a715e816e1) | `` terraform-providers.brightbox: 3.3.0 -> 3.4.1 ``                           |
| [`ce8e7a83`](https://github.com/NixOS/nixpkgs/commit/ce8e7a8353505e14697b96ec09f65ce030da0099) | `` terraform-providers.bitbucket: 2.31.0 -> 2.32.0 ``                         |
| [`e4932331`](https://github.com/NixOS/nixpkgs/commit/e49323315eb752eb043c5e81715f26966409c629) | `` terraform-providers.alicloud: 1.203.0 -> 1.204.0 ``                        |
| [`32d211fb`](https://github.com/NixOS/nixpkgs/commit/32d211fbb0c6bae51829630181a2cb2ea4602622) | `` fb303: 2023.02.20.00 -> 2023.04.24.00 ``                                   |
| [`673b3b9c`](https://github.com/NixOS/nixpkgs/commit/673b3b9c22b5bf699b3ed4a5c5630218ae06689c) | `` calamares: 3.2.61 -> 3.2.62 ``                                             |
| [`395db289`](https://github.com/NixOS/nixpkgs/commit/395db2896e5628d0492c3481ec958da55b6af63d) | `` bedtools: 2.30.0 -> 2.31.0 ``                                              |
| [`9b2ebc56`](https://github.com/NixOS/nixpkgs/commit/9b2ebc5666ad48ed3debde4c1bd5434e99f2dabc) | `` flowtime: 3.0 -> 3.1 ``                                                    |
| [`d09e5fd7`](https://github.com/NixOS/nixpkgs/commit/d09e5fd72e8ad6b559c050a77b1cef5d1fae8bb4) | `` grcov: 0.8.13 -> 0.8.18 ``                                                 |
| [`4c71680a`](https://github.com/NixOS/nixpkgs/commit/4c71680ac86798b8c3a3d7992eebf027aad9b000) | `` yutto: 2.0.0b21 -> 2.0.0b24 ``                                             |
| [`07e3b618`](https://github.com/NixOS/nixpkgs/commit/07e3b618855d6b8493369634684aee5b4c5a1565) | `` kn: 1.7.0 -> 1.10.0 ``                                                     |
| [`52f14510`](https://github.com/NixOS/nixpkgs/commit/52f14510d381655da2b75c82b906d4cb4dcf6769) | `` bootspec: unstable-2022-12-05 -> 0.1.0 ``                                  |
| [`bc502d0a`](https://github.com/NixOS/nixpkgs/commit/bc502d0a14964d09be334faae25373c9d8d491bd) | `` nixos/bootspec: adopt the merged RFC-0125 ``                               |
| [`9a6696c4`](https://github.com/NixOS/nixpkgs/commit/9a6696c42e44da58df7014cd04555752ee927171) | `` jellyfin-media-player: 1.9.0 -> 1.9.1 ``                                   |
| [`cea12290`](https://github.com/NixOS/nixpkgs/commit/cea12290ce32aedc0906d03475d3186df7b43cfc) | `` python310Packages.spsdk: 1.9.0 -> 1.10.0 ``                                |
| [`9a32bdc2`](https://github.com/NixOS/nixpkgs/commit/9a32bdc2b37d21a55b6cae7779f946640cbe7259) | `` go-musicfox: removing clang dependency ``                                  |
| [`8a59d449`](https://github.com/NixOS/nixpkgs/commit/8a59d44958e87621f5ffefb5b1a59910c6c51219) | `` forgejo: 1.19.1-0 -> 1.19.2-0 ``                                           |
| [`802365a1`](https://github.com/NixOS/nixpkgs/commit/802365a116a008e743d2662fca3e9153a24e3779) | `` ghauri: fix typo in rev ``                                                 |
| [`23b63e1f`](https://github.com/NixOS/nixpkgs/commit/23b63e1fef9495a8c7cc0ba77593573911af17d3) | `` febio: fix build ``                                                        |
| [`0b863fe2`](https://github.com/NixOS/nixpkgs/commit/0b863fe2dfb277b3995e53822e471fe54318329c) | `` mkl: linux: 2023.0.0 -> 2023.1.0 ``                                        |
| [`d5e8851f`](https://github.com/NixOS/nixpkgs/commit/d5e8851f6f931d733a4c397b11e69a43dd49af9e) | `` mkl: darwin: 2019.3 -> 2023.1.0 ``                                         |
| [`2909d9b1`](https://github.com/NixOS/nixpkgs/commit/2909d9b11778ee01908656f63398aa5b9831bc27) | `` vector: 0.28.1 -> 0.29.1 ``                                                |
| [`6af56a90`](https://github.com/NixOS/nixpkgs/commit/6af56a90ad5ac336eeeb67240b3f4974dec9ed54) | `` python310Packages.pymilvus: 2.2.6 -> 2.2.8 ``                              |
| [`33175436`](https://github.com/NixOS/nixpkgs/commit/3317543699a82f442800fbaca45bf68d43f0aa04) | `` python310Packages.grpcio-testing: init at 1.54.0 ``                        |
| [`c3f48fc8`](https://github.com/NixOS/nixpkgs/commit/c3f48fc86fe7f422ac56c37e3695f3e778016df7) | `` python310Packages.pymilvus: add changelog to meta ``                       |
| [`7af2b867`](https://github.com/NixOS/nixpkgs/commit/7af2b867481052cbc694d030add96981c18ee1f7) | `` python310Packages.ds-store: 1.3.0 -> 1.3.1 ``                              |
| [`6fcae952`](https://github.com/NixOS/nixpkgs/commit/6fcae952c1cceea0f28088d04e22e687f6be82a7) | `` python310Packages.ds-store: normalize pname ``                             |
| [`4d0df029`](https://github.com/NixOS/nixpkgs/commit/4d0df0291189ac2b11eba93d2102c537d1bd1c1a) | `` vimPlugins.wgsl-vim: init at 2023-04-12 ``                                 |
| [`24ea5fdb`](https://github.com/NixOS/nixpkgs/commit/24ea5fdb3b2c20efd545e17322f409a2125e9abf) | `` ubootQemuRiscv64Smode: Remove upstreamed patch ``                          |
| [`716ed92c`](https://github.com/NixOS/nixpkgs/commit/716ed92c8e2d1c67ec5fffdd7397f5d6aabdd653) | `` systemd: assert withUkify -> withEfi ``                                    |
| [`d41fd13b`](https://github.com/NixOS/nixpkgs/commit/d41fd13b9828fcfb6254a2c4f803ed74fcd4fbc0) | `` element-{web,desktop}: 1.11.29 -> 1.11.30 ``                               |
| [`3c2a276f`](https://github.com/NixOS/nixpkgs/commit/3c2a276f555bd592f92ade31412e1970481faa44) | `` mysql-workbench: 8.0.32 -> 8.0.33 ``                                       |
| [`fb14b784`](https://github.com/NixOS/nixpkgs/commit/fb14b7846c279a97632fc03d944db75c626f1bc9) | `` cvise: 2.7.0 -> 2.8.0 ``                                                   |
| [`77b2cd73`](https://github.com/NixOS/nixpkgs/commit/77b2cd73cfd763c21acd8988a0941b44bc7930e0) | `` python310Packages.bthome-ble: 2.9.0 -> 2.10.1 ``                           |
| [`f480da3b`](https://github.com/NixOS/nixpkgs/commit/f480da3ba063e5e6d9eb4b4395e73bd8010f265f) | `` checkov: 2.3.202 -> 2.3.205 ``                                             |
| [`2fcc8051`](https://github.com/NixOS/nixpkgs/commit/2fcc80515b21638fc81fac3be164265b2940847e) | `` python310Packages.hahomematic: 2023.4.4 -> 2023.4.5 ``                     |
| [`ea065ff3`](https://github.com/NixOS/nixpkgs/commit/ea065ff372694f844e789d219ca7d58eed13ca90) | `` python310Packages.dtschema: 2022.12 -> 2023.04 ``                          |
| [`de2da79e`](https://github.com/NixOS/nixpkgs/commit/de2da79e222c59635c1c2e48e5ead325d9ee3acb) | `` python310Packages.sonos-websocket: init at 0.1.0 ``                        |
| [`71d1118b`](https://github.com/NixOS/nixpkgs/commit/71d1118bd4383cbb072103af324b2b23873dafee) | `` onefetch: 2.17.0 -> 2.17.1 ``                                              |
| [`2737d0fe`](https://github.com/NixOS/nixpkgs/commit/2737d0fe1637b04b371e853fe780df048e0fc7cf) | `` python310Packages.py-synologydsm-api: 2.2.0 -> 2.3.0 ``                    |
| [`968a459d`](https://github.com/NixOS/nixpkgs/commit/968a459d07a201d816b39d8ba95a5d723a655049) | `` gitoxide: 0.22.1 -> 0.23.0 ``                                              |
| [`670fc549`](https://github.com/NixOS/nixpkgs/commit/670fc54922d520f6a7f9dbd0f7f7d595aba1713a) | `` apfs-fuse: add darwin support ``                                           |
| [`dc97d2c2`](https://github.com/NixOS/nixpkgs/commit/dc97d2c2641b5491da4f34dd55683787ec8e0152) | `` googleearth-pro: Avoid dragging in stdenv ``                               |
| [`23caee0f`](https://github.com/NixOS/nixpkgs/commit/23caee0f0a039df46f88c869d6f2b3bd12b00b02) | `` chromium: fix gtk4 schema paths ``                                         |
| [`9ebb4696`](https://github.com/NixOS/nixpkgs/commit/9ebb469697abcbae1b8b91275e62a6ddc7932682) | `` nixosTests.home-assistant: Test more components ``                         |
| [`d5edd07a`](https://github.com/NixOS/nixpkgs/commit/d5edd07a01397450e9faebf6a68adb01330364fa) | `` python310Packages.aioesphomeapi: Propagate protobuf dev output ``          |
| [`e827e6e7`](https://github.com/NixOS/nixpkgs/commit/e827e6e7b4d4b872cd628eca972940ac5b7c8160) | `` jprofiler: 13.0.2 -> 13.0.6 ``                                             |
| [`ab4d4f6f`](https://github.com/NixOS/nixpkgs/commit/ab4d4f6fd55a2d17f3bd125ed08de2564525ea2d) | `` jprofiler: darwin: 11.1.4 -> 13.0.2 ``                                     |
| [`046cbe3c`](https://github.com/NixOS/nixpkgs/commit/046cbe3c60dc0c1c429e382c6289d09955e073a7) | `` python3Packages.sphinx-inline-tabs: 2022.01.02.beta11 -> 2023.04.21 ``     |
| [`741eb276`](https://github.com/NixOS/nixpkgs/commit/741eb276a87d3d5681e2a3cba22443a82043dbba) | `` php80Extensions.swoole: 5.0.1 -> 5.0.3 ``                                  |
| [`e5e928d2`](https://github.com/NixOS/nixpkgs/commit/e5e928d2bee0c93d6925ed97940db40914210b46) | `` oh-my-posh: 14.27.0 -> 15.4.0 ``                                           |
| [`a38198b2`](https://github.com/NixOS/nixpkgs/commit/a38198b2997322121ad5890ac6734a14671359de) | `` tempo: 2.1.0 -> 2.1.1 ``                                                   |
| [`f73c3cca`](https://github.com/NixOS/nixpkgs/commit/f73c3cca56799eb639454785da92dba3378ebbd8) | `` infracost: 0.10.20 -> 0.10.21 ``                                           |
| [`36504141`](https://github.com/NixOS/nixpkgs/commit/365041415b7c2b9a16cc753096da4d9e46f85d8d) | `` buildMozillaMach: Apply musl compat patch up to 114.0 ``                   |
| [`4cc306b6`](https://github.com/NixOS/nixpkgs/commit/4cc306b6e39ae03ca606b08ea6ef456012991335) | `` rke: 1.4.4 -> 1.4.5 ``                                                     |
| [`e24518ef`](https://github.com/NixOS/nixpkgs/commit/e24518ef5910fe0bea06c13ffa8507bbd71dba89) | `` jetbrains: 2023.1 -> 2023.1.2 ``                                           |
| [`82ef0bb1`](https://github.com/NixOS/nixpkgs/commit/82ef0bb184e99f13bce7cca60e677cd108491b16) | `` taskjuggler: 3.6.0 -> 3.7.2 ``                                             |
| [`c36f0fea`](https://github.com/NixOS/nixpkgs/commit/c36f0feabccaa096a2a59f187019d7907491c2e0) | `` python311Packages.skl2onnx: 1.13 -> 1.14.0 ``                              |
| [`0fc5fdce`](https://github.com/NixOS/nixpkgs/commit/0fc5fdce8417e1b530b81cdf8fcdf91ad53a3f0b) | `` raycast: 1.49.3 -> 1.50.0 ``                                               |
| [`eaf8bd44`](https://github.com/NixOS/nixpkgs/commit/eaf8bd44d039d8a3f74192887a111635d01e99bf) | `` cargo-llvm-cov: 0.5.18 -> 0.5.19 ``                                        |
| [`fa2d0aed`](https://github.com/NixOS/nixpkgs/commit/fa2d0aed979644ef1b2bb0c273b4b524a12995bf) | `` cargo-llvm-cov: 0.5.17 -> 0.5.18 ``                                        |
| [`7e6b3354`](https://github.com/NixOS/nixpkgs/commit/7e6b335400dbd7f57bc76ee653b84a4125df959f) | `` path-of-building: 2.28.0 -> 2.29.0 ``                                      |
| [`43a0f480`](https://github.com/NixOS/nixpkgs/commit/43a0f4801ebed9173798cb92d41446c5d1c0a885) | `` can-utils: 20170830 -> 2023.03 ``                                          |
| [`cdc53e9a`](https://github.com/NixOS/nixpkgs/commit/cdc53e9ab6a1756eb528a9d678f35cec2bdd0b74) | `` can-utils: add Luflosi as maintainer ``                                    |