### PR TITLE
chore(flake/nixos-hardware): `e4a21ddc` -> `7dc46304`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -202,11 +202,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1682836095,
-        "narHash": "sha256-PdzpJhuXBz71AgWNWMMYLbB8GMMce6QguhQY/6HOOcc=",
+        "lastModified": 1683009613,
+        "narHash": "sha256-jJh8JaoHOLlk7iFLgZk1PlxCCNA2KTKfOLMLCa9mduA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e4a21ddcb45ee5f5c85a5d9e9698debf77fb98c3",
+        "rev": "7dc46304675f4ff2d6be921ef60883efd31363c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`23ac1ecb`](https://github.com/NixOS/nixos-hardware/commit/23ac1ecb8fdccbf880c0d051b5df69745543db3e) | `` Update README.md ``                      |
| [`8792ddc5`](https://github.com/NixOS/nixos-hardware/commit/8792ddc50c954685c5588e53dccf49847e5a1e54) | `` Add Dell XPS 9520 to flake and README `` |
| [`03548bee`](https://github.com/NixOS/nixos-hardware/commit/03548beefd2a015e8db3e5f6171bbdd5435f2fc1) | `` add dell precision 3541 to flake.nix ``  |
| [`57690390`](https://github.com/NixOS/nixos-hardware/commit/576903907ae821792bdf82cdbb09e81e5d8972b1) | `` add dell precision 3541 ``               |
| [`b13c895f`](https://github.com/NixOS/nixos-hardware/commit/b13c895f11f41e7f64d150074845252a927c56c5) | `` Add config for Dell XPS 15 9520 ``       |