### PR TITLE
chore(flake/nixpkgs): `da45bf6e` -> `1a411f23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -217,11 +217,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682879489,
-        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
+        "lastModified": 1683014792,
+        "narHash": "sha256-6Va9iVtmmsw4raBc3QKvQT2KT/NGRWlvUlJj46zN8B8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
+        "rev": "1a411f23ba299db155a5b45d5e145b85a7aafc42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`b4135f4f`](https://github.com/NixOS/nixpkgs/commit/b4135f4f3934198366851f8f694bd1b1972ae89a) | `` networkmanager-fortisslvpn: patch to build with ppp-2.5.0 ``                       |
| [`c9c5068a`](https://github.com/NixOS/nixpkgs/commit/c9c5068a274c045efdbd2a67de7270ab583967f4) | `` grandorgue: 3.10.1-1 -> 3.11.0 ``                                                  |
| [`ad92e6c8`](https://github.com/NixOS/nixpkgs/commit/ad92e6c8be79dcd601aed529dd4f1c927af19db7) | `` cargo-udeps: 0.1.35 -> 0.1.36 ``                                                   |
| [`da527daa`](https://github.com/NixOS/nixpkgs/commit/da527daa8dda1d87e40abcf2cf49415feddaad64) | `` panoply: 5.2.5 -> 5.2.6 ``                                                         |
| [`73e5eb89`](https://github.com/NixOS/nixpkgs/commit/73e5eb89496cfe0ea568e87af832d1ca4c2cc074) | `` netatalk: 3.1.13 -> 3.1.15 ``                                                      |
| [`84a94cf5`](https://github.com/NixOS/nixpkgs/commit/84a94cf56dc836293fb418ed9eeea862bce74fb8) | `` mopidy-ytmusic: use ytmusicapi 0.25.1 ``                                           |
| [`f7251fd6`](https://github.com/NixOS/nixpkgs/commit/f7251fd62a591ee9138d9c7c3943711206f37ca4) | `` terraform-providers.rancher2: 2.0.0 -> 3.0.0 ``                                    |
| [`0105a684`](https://github.com/NixOS/nixpkgs/commit/0105a68468a628af5b2d6c711b510498e3d3faf9) | `` terraform-providers.github: 5.23.0 -> 5.24.0 ``                                    |
| [`99cf3770`](https://github.com/NixOS/nixpkgs/commit/99cf3770735bbf9a4800f65e5067b14f4e185824) | `` beanstalkd: 1.12 -> 1.13 ``                                                        |
| [`e6a50698`](https://github.com/NixOS/nixpkgs/commit/e6a506988a0738fe776cf828df3b4fe68cbdee60) | `` flavours: add myself as maintainer ``                                              |
| [`d6fe5898`](https://github.com/NixOS/nixpkgs/commit/d6fe5898196a4402c63e09f105ae5971a1ec1c14) | `` flavours: 0.6.1 -> 0.7.0 ``                                                        |
| [`02d16c1d`](https://github.com/NixOS/nixpkgs/commit/02d16c1d6f051e73acfec21850aa95649d8946a6) | `` nerdfix: 0.2.1 -> 0.2.2 ``                                                         |
| [`cba07817`](https://github.com/NixOS/nixpkgs/commit/cba07817fd7678c4923c6a103b7a804c9e05487c) | `` nodePackages: update to latest ``                                                  |
| [`5104455e`](https://github.com/NixOS/nixpkgs/commit/5104455e902198d6404e9354525bd7a6db921d98) | `` ruff: 0.0.262 -> 0.0.263 ``                                                        |
| [`91c65c93`](https://github.com/NixOS/nixpkgs/commit/91c65c938b91c943e92835b0c06a941fc5a46a32) | `` tl-expected: 2023-02-15 -> 1.1.0 ``                                                |
| [`45828de5`](https://github.com/NixOS/nixpkgs/commit/45828de59578888e1cd08d9e06343b840e486cd8) | `` skribilo: 0.9.5 -> 0.10.0 ``                                                       |
| [`70ae8a5d`](https://github.com/NixOS/nixpkgs/commit/70ae8a5df99d4ade4c2b43980912059a0e680318) | `` arianna: 1.0.0 -> 1.0.1 ``                                                         |
| [`052341df`](https://github.com/NixOS/nixpkgs/commit/052341df029a36590dcb3d208d8b2073bf9f9ba5) | `` python310Packages.sipyco: init at version 1.4 (#227876) ``                         |
| [`dfb0349a`](https://github.com/NixOS/nixpkgs/commit/dfb0349a78fc60be082db19aa885167d8f8e234b) | `` python310Packages.strawberry-graphql: 0.159.0 -> 0.176.0 ``                        |
| [`b7956895`](https://github.com/NixOS/nixpkgs/commit/b7956895ee73310cb88dc059a72d52ccde386854) | `` python310Packages.pytest-emoji: init at 0.2.0 ``                                   |
| [`0b9dd4a1`](https://github.com/NixOS/nixpkgs/commit/0b9dd4a1b646fa9906885dd39da12ecf4c358768) | `` python310Packages.chalice: 1.27.3 -> 1.28.0 ``                                     |
| [`db3e78b8`](https://github.com/NixOS/nixpkgs/commit/db3e78b8d3c0c6c8d5da77250c0675d95f4a9a1a) | `` rust-script: 0.26.0 -> 0.27.0 ``                                                   |
| [`0fd3f232`](https://github.com/NixOS/nixpkgs/commit/0fd3f2326368b2f5e40ad1203bf929db011c59ee) | `` python310Packages.ipyniivue: init at 1.0.2 ``                                      |
| [`57cc5abf`](https://github.com/NixOS/nixpkgs/commit/57cc5abf4afb093055e06089b89e0e8b14107963) | `` python310Packages.jupyter-ui-poll: init at 0.2.2 ``                                |
| [`9e4b3ac3`](https://github.com/NixOS/nixpkgs/commit/9e4b3ac34d6d41026ce703b05e5955e730f37938) | `` python3Packages.desktop-notifier: 3.4.3 -> 3.5.1 ``                                |
| [`b3d0ead7`](https://github.com/NixOS/nixpkgs/commit/b3d0ead70e5e4531e668d69b443e43454dd10466) | `` python310Packages.kornia: add changelog to meta ``                                 |
| [`965ca258`](https://github.com/NixOS/nixpkgs/commit/965ca25828ff1e88370ecf99fb8a4814e753d88a) | `` python310Packages.kornia: 0.6.11 -> 0.6.12 ``                                      |
| [`6592c272`](https://github.com/NixOS/nixpkgs/commit/6592c2723fa9e12cb9e71268320cf1294ebe9888) | `` python310Packages.inquirer: 3.1.2 -> 3.1.3 ``                                      |
| [`92fa862d`](https://github.com/NixOS/nixpkgs/commit/92fa862d74e8991b0c43a719c7508c991f188f33) | `` python310Packages.inform: add changelog to meta ``                                 |
| [`e07db3e3`](https://github.com/NixOS/nixpkgs/commit/e07db3e3795205a024905685450630a27315c08d) | `` python310Packages.inform: 1.27 -> 1.28 ``                                          |
| [`c87e3dc9`](https://github.com/NixOS/nixpkgs/commit/c87e3dc91580e28224111d9275f0d7040181876e) | `` python310Packages.invocations: add changelog to meta ``                            |
| [`01d15621`](https://github.com/NixOS/nixpkgs/commit/01d15621fe60f6dcb66145011871847fccae43c2) | `` python311Packages.datafusion: add changelog to meta ``                             |
| [`611d0883`](https://github.com/NixOS/nixpkgs/commit/611d0883038957b66a26bf4f8d96666f5db9d346) | `` python310Packages.intake: 0.6.6 -> 0.6.8 ``                                        |
| [`75fea21c`](https://github.com/NixOS/nixpkgs/commit/75fea21c44ed23ad363abc92004ef3ada16332f9) | `` python311Packages.datafusion: 22.0.0 -> 23.0.0 ``                                  |
| [`216ce975`](https://github.com/NixOS/nixpkgs/commit/216ce975ba58d4eab2e879280c78e8ee16d180fc) | `` python310Packages.glean-sdk: 52.2.0 -> 52.6.0 ``                                   |
| [`6f44a063`](https://github.com/NixOS/nixpkgs/commit/6f44a0632a991775ee098e9a54d95b13cbd2115c) | `` python310Packages.invocations: 3.0.1 -> 3.0.2 ``                                   |
| [`4ee45a31`](https://github.com/NixOS/nixpkgs/commit/4ee45a31931f91587c0d955c392e8ca4f73318e6) | `` python310Packages.datasette: 0.64.2 -> 0.64.3 ``                                   |
| [`7b3d0a5e`](https://github.com/NixOS/nixpkgs/commit/7b3d0a5e74c4da8fa6f5765f6c95787081e78181) | `` python311Packages.datasets: 2.11.0 -> 2.12.0 ``                                    |
| [`1c3c2c82`](https://github.com/NixOS/nixpkgs/commit/1c3c2c820321a411a3a71006de8c17a7255442d6) | `` nixos/navidrome: add package option ``                                             |
| [`856a549b`](https://github.com/NixOS/nixpkgs/commit/856a549bae7ffc959070028672b12fd4df6f1f69) | `` checkov: 2.3.209 -> 2.3.212 ``                                                     |
| [`ed64acf4`](https://github.com/NixOS/nixpkgs/commit/ed64acf42d2e4fa4257a92cd792828bac9c80276) | `` networkmanager-sstp: 1.3.1 -> unstable-2023-03-09 ``                               |
| [`fe2bd7e2`](https://github.com/NixOS/nixpkgs/commit/fe2bd7e2a2c6526f912c054c549ff1fb000623f0) | `` networkmanager-l2tp: 1.20.4 -> 1.20.10 (#229312) ``                                |
| [`5564cf7e`](https://github.com/NixOS/nixpkgs/commit/5564cf7e32d4f617d8e5533f9adab6294e694b2b) | `` wpsoffice: 11.1.0.11691 -> 11.1.0.11698 ``                                         |
| [`7931cb36`](https://github.com/NixOS/nixpkgs/commit/7931cb3647b42c04aeef1dd4b91217a311936d7f) | `` python310Packages.channels-redis: add changelog to meta ``                         |
| [`fe3c7bc1`](https://github.com/NixOS/nixpkgs/commit/fe3c7bc17e95a5ab86fe2a2c126335aebfe3e11f) | `` python310Packages.channels-redis: 4.0.0 -> 4.1.0 ``                                |
| [`cbcafdc1`](https://github.com/NixOS/nixpkgs/commit/cbcafdc13b3ae14847b305b8af64f25b65f9ca19) | `` grafana-agent: add version test ``                                                 |
| [`ec38c9c7`](https://github.com/NixOS/nixpkgs/commit/ec38c9c76bbeda6fd6cf718f310fb12869c78108) | `` grafana-agent: 0.33.0 -> 0.33.1 ``                                                 |
| [`c5eb25a2`](https://github.com/NixOS/nixpkgs/commit/c5eb25a2bbc76136881d34c9df4d92c7af384c92) | `` rbdoom-3-bfg: 1.4.0 -> 1.5.0 ``                                                    |
| [`a02f9c10`](https://github.com/NixOS/nixpkgs/commit/a02f9c10ea0b42560c7ff8cd017ff19ad946f8c0) | `` trayscale: init at 0.9.6 ``                                                        |
| [`2b6b08f9`](https://github.com/NixOS/nixpkgs/commit/2b6b08f921a7024b82c644416df0d5dd6d156e70) | `` python310Packages.fuzzytm: init at 2.0.5 ``                                        |
| [`2ad68a7d`](https://github.com/NixOS/nixpkgs/commit/2ad68a7d90ba08dbdd426cf0d8e4dd1f53d1af1f) | `` stdenv: factor out `meta` attr augmentation for reusability ``                     |
| [`616ba4ae`](https://github.com/NixOS/nixpkgs/commit/616ba4ae5cad56b00154da4889925eb767b51ce8) | `` nixos/maddy: Add tls option ``                                                     |
| [`7ca0c7b4`](https://github.com/NixOS/nixpkgs/commit/7ca0c7b4f7ec40f20486c9b068546602f49b087e) | `` python310Packages.gensim: 4.3.0 -> 4.3.1 ``                                        |
| [`20c9f17a`](https://github.com/NixOS/nixpkgs/commit/20c9f17a64affcb85a9a2d5e98c2e869b03b3952) | `` youtube-tui: 0.7.0 -> 0.7.1 ``                                                     |
| [`8ae7eef5`](https://github.com/NixOS/nixpkgs/commit/8ae7eef571459df734088cba11958adf6055d49b) | `` python310Packages.pyfume: init at 0.2.25 ``                                        |
| [`677357e5`](https://github.com/NixOS/nixpkgs/commit/677357e5d048457319fedc18fb897ad27de808de) | `` evcc: 0.116.6 -> 0.116.7 ``                                                        |
| [`8ec8cee9`](https://github.com/NixOS/nixpkgs/commit/8ec8cee994590594adea5f300b9e513990be2a87) | `` lightning-loop: 0.20.0 -> 0.23.0 ``                                                |
| [`64ac2802`](https://github.com/NixOS/nixpkgs/commit/64ac28023200d721f178659aac53e267202fba1e) | `` orchis-theme: fix version number ``                                                |
| [`fddf531c`](https://github.com/NixOS/nixpkgs/commit/fddf531c6fa3c769f70a4a0dfc4d886216f0107e) | `` nixos/nextcloud: refactor database.createLocally ``                                |
| [`33d2eac2`](https://github.com/NixOS/nixpkgs/commit/33d2eac2e94297fa8b97a45db64cea350ace2b74) | `` clickhouse: set default logging level to warning ``                                |
| [`69deb715`](https://github.com/NixOS/nixpkgs/commit/69deb715bbaa056c090812ef78786f4030627d80) | `` kopia: 0.12.1 -> 0.13.0 ``                                                         |
| [`7fe4909b`](https://github.com/NixOS/nixpkgs/commit/7fe4909bee9864df3d4bc196cb337aebaae32153) | `` services.datadog: remove python2 from systemd service (#228312) ``                 |
| [`d28ce724`](https://github.com/NixOS/nixpkgs/commit/d28ce724a6803a4709ca9578a8d1fbab42ba68b1) | `` espeak-ng: fix cross ``                                                            |
| [`b06519dd`](https://github.com/NixOS/nixpkgs/commit/b06519dda9991f78ffb3f5ca1c0bfc04bc273e7f) | `` nrfconnect: 3.11.1 -> 4.0.1 ``                                                     |
| [`6027cc8c`](https://github.com/NixOS/nixpkgs/commit/6027cc8c1c4567d8e6d02c5ac1e4b8ff1193c08d) | `` shell_gpt: 0.8.8 -> 0.9.0 ``                                                       |
| [`14475881`](https://github.com/NixOS/nixpkgs/commit/1447588102afb8c20885f0bbbe768bc1933a863e) | `` pythonPackages.maestral: 1.7.1 -> 1.7.2 ``                                         |
| [`1de8d2f1`](https://github.com/NixOS/nixpkgs/commit/1de8d2f180afe1f1eac7548080cbcf8082f4d4fe) | `` chromium: use python3 for build to work towards working cross ``                   |
| [`a7512939`](https://github.com/NixOS/nixpkgs/commit/a7512939c45238b167a18a8a65ab4dea1c65c39f) | `` python311Packages.django-model-utils: add changelog to meta ``                     |
| [`9fb69343`](https://github.com/NixOS/nixpkgs/commit/9fb69343d1f53fe9cee86ba139eea072dd1f1a3f) | `` python311Packages.django-model-utils: 4.2.0 -> 4.3.1 ``                            |
| [`b54d45dc`](https://github.com/NixOS/nixpkgs/commit/b54d45dca0b09512997d29a84051f9cdb4027d60) | `` python311Packages.dipy: add changelog to meta ``                                   |
| [`040cf878`](https://github.com/NixOS/nixpkgs/commit/040cf878bf099bb7790f600c269bde1566b50d5a) | `` python310Packages.django-import-export: 3.1.0 -> 3.2.0 ``                          |
| [`a7d9cfdc`](https://github.com/NixOS/nixpkgs/commit/a7d9cfdc03810645c2480ed63486a28a03c195ac) | `` vulkan-validation-layers: 1.3.243 -> 1.3.249 ``                                    |
| [`07fd3ec5`](https://github.com/NixOS/nixpkgs/commit/07fd3ec5dfc0c34d4c0c63ee0b20f688250bb698) | `` vulkan-extension-layer: 1.3.243 -> 1.3.248, remove vulkan-headers version check `` |
| [`064bcc58`](https://github.com/NixOS/nixpkgs/commit/064bcc58cd4013825212f558d1e64abfdab9154d) | `` vulkan-tools: 1.3.243 -> 1.3.249, remove vulkan-headers version check ``           |
| [`19ca45e3`](https://github.com/NixOS/nixpkgs/commit/19ca45e39f1dd7ec9f35cf836c7e7a3ff7f18304) | `` vulkan/update-script: always update to latest upstream tags ``                     |
| [`4faf10e9`](https://github.com/NixOS/nixpkgs/commit/4faf10e97859351984739953fbf52ff498ff384f) | `` python311Packages.dipy: 1.5.0 -> 1.7.0 ``                                          |
| [`2d8e0c3c`](https://github.com/NixOS/nixpkgs/commit/2d8e0c3c986d9c7339dfde2d98f58d03949c2fb9) | `` git-cola: 4.1.0 -> 4.2.1 ``                                                        |
| [`5130c4f4`](https://github.com/NixOS/nixpkgs/commit/5130c4f4ef66b1cf34d63220bdd1cc8f20de6515) | `` freshBootstrapTools: enable musl on RISC-V ``                                      |
| [`2af4b551`](https://github.com/NixOS/nixpkgs/commit/2af4b551c1ddd0fdcf0d43d46c9638fd8db31886) | `` musl: tighten platforms ``                                                         |
| [`d5bc0875`](https://github.com/NixOS/nixpkgs/commit/d5bc08754b7a52f84ccd32aa523d3387f57f5b31) | `` arianna: init at 1.0.0 ``                                                          |
| [`9864b154`](https://github.com/NixOS/nixpkgs/commit/9864b15480f8c95728be14260409d1e6aeca51bf) | `` kirigami-addons: 0.7.2 -> 0.8.0 ``                                                 |
| [`b4403bcc`](https://github.com/NixOS/nixpkgs/commit/b4403bcc85d894446c11755d9b12a91a630cfc12) | `` taskjuggler: add webrick for tj3webd ``                                            |
| [`12e08bd3`](https://github.com/NixOS/nixpkgs/commit/12e08bd339ef5dbaabb4c892d0c7637c96bafe18) | `` lib.kernel.unset: init ``                                                          |
| [`965bdf48`](https://github.com/NixOS/nixpkgs/commit/965bdf48b1748a056a8ccb52ff3903437ad7369f) | `` seaweedfs: 3.47 -> 3.48 ``                                                         |
| [`a4202cfe`](https://github.com/NixOS/nixpkgs/commit/a4202cfee50473b8d3534aea06ccb8903303f4c5) | `` python310Packages.plantuml-markdown: add changelog to meta ``                      |
| [`5915f52e`](https://github.com/NixOS/nixpkgs/commit/5915f52e04878403b7b8604740ebf4aba2325e8f) | `` python310Packages.python-keycloak: fix typo ``                                     |
| [`790628ae`](https://github.com/NixOS/nixpkgs/commit/790628ae9f6bc4a8f5f7a2c6945b68f8e3139345) | `` chromium: (cross) move bison and gperf to nativeBuildInputs ``                     |
| [`fd70aa16`](https://github.com/NixOS/nixpkgs/commit/fd70aa16b13195ec8e2cb3117e4afcd192befcc4) | `` exportarr: 1.3.1 -> 1.3.2 ``                                                       |
| [`d74180d0`](https://github.com/NixOS/nixpkgs/commit/d74180d07b7720f7f34d06a3a44782c440973f87) | `` mu: don't use (very) old version of texinfo ``                                     |
| [`f050b8d3`](https://github.com/NixOS/nixpkgs/commit/f050b8d31283595ebc4041c42afb88a9323334ec) | `` mu: 1.18.14 -> 1.10.3 ``                                                           |
| [`be3a8679`](https://github.com/NixOS/nixpkgs/commit/be3a867936d6f4b9872e1bb8902e8d237173270f) | `` vcmi: 1.1.1 -> 1.2.1 ``                                                            |
| [`6aed0cf7`](https://github.com/NixOS/nixpkgs/commit/6aed0cf741f8fdafbbeac98e8b15a447133d595c) | `` fuzzylite: init at 6.0 ``                                                          |
| [`576d7d34`](https://github.com/NixOS/nixpkgs/commit/576d7d34c46dc2c40a86d2f8cdb7da28b7d54edf) | `` asusctl: 4.5.8 -> 4.6.2 ``                                                         |
| [`a0366812`](https://github.com/NixOS/nixpkgs/commit/a03668123394151dd8e2df6068ef74aaff48b523) | `` python310Packages.nats-py: disable failing test ``                                 |
| [`c3a2a238`](https://github.com/NixOS/nixpkgs/commit/c3a2a238f77763c952d5301f3aabe625f71a32aa) | `` defaultGemConfig.grpc: update config ``                                            |
| [`511a1dbe`](https://github.com/NixOS/nixpkgs/commit/511a1dbe6380f89fc583f12536d1f5b885d0812d) | `` python310Packages.bucketstore: fix version specifier ``                            |
| [`d163a2e8`](https://github.com/NixOS/nixpkgs/commit/d163a2e8ffb103cf081d8ce5eaa78fd8643043aa) | `` i3status-rust: 0.31.0 -> 0.31.1 ``                                                 |
| [`ab9c7572`](https://github.com/NixOS/nixpkgs/commit/ab9c7572290cda3db7e05e3f4bbe5559eb98235c) | `` python310Packages.plantuml-markdown: 3.8.1 -> 3.9.1 ``                             |
| [`292f3ae2`](https://github.com/NixOS/nixpkgs/commit/292f3ae2b0765a0bf0fe9fb63fe0325b77233f07) | `` python3Packages.dbus-python-client-gen: 0.8.2 -> 0.8.3 ``                          |
| [`82cea119`](https://github.com/NixOS/nixpkgs/commit/82cea11923906492263ea968ccd986a01238b5d9) | `` gnome.geary: Fix build with Vala 0.56.7 & 0.57+ ``                                 |
| [`732d2353`](https://github.com/NixOS/nixpkgs/commit/732d2353098d5233dda2a293f2d2ccc7e47a00a6) | `` restic-rest-server: 0.11.0 -> 0.12.0 (#228395) ``                                  |
| [`4c598381`](https://github.com/NixOS/nixpkgs/commit/4c598381e0b742608d481ae4bf88ac31f69df978) | `` Update default.nix ``                                                              |
| [`ab12ff29`](https://github.com/NixOS/nixpkgs/commit/ab12ff29abc17412807587fe7a7fb34102f5ebde) | `` commonsCompress: 1.22 -> 1.23.0 ``                                                 |
| [`69443ec2`](https://github.com/NixOS/nixpkgs/commit/69443ec28a7027d3c73ac471c32bf5875067fca6) | `` pipecontrol: 0.2.8 -> 0.2.10 ``                                                    |
| [`97a2834c`](https://github.com/NixOS/nixpkgs/commit/97a2834cf313e5121fd9159d99f66c9767c7b109) | `` vmware-horizon-client: 2206 -> 2303 ``                                             |
| [`47e35d0f`](https://github.com/NixOS/nixpkgs/commit/47e35d0f361625fefeec24ad6e94bb78bf023af8) | `` unpackerr: 0.11.1 -> 0.11.2 ``                                                     |
| [`e689a64f`](https://github.com/NixOS/nixpkgs/commit/e689a64f24490753c79cf9e2139117607a21938d) | `` ocamlPackages.postgresql: `postgresql` is a buildInput ``                          |
| [`b339c58d`](https://github.com/NixOS/nixpkgs/commit/b339c58df18a0c3b2fb951e1de1055d084c2b2c8) | `` rsyslog: 8.2302.0 -> 8.2304.0 ``                                                   |
| [`948cf105`](https://github.com/NixOS/nixpkgs/commit/948cf105b99a4e1db6b786722a33ef1a1d376bd1) | `` anki-bin: 2.1.61 -> 2.1.62 ``                                                      |
| [`cdefca3d`](https://github.com/NixOS/nixpkgs/commit/cdefca3d7a883d56975d2d3d859f9540fdc9cec1) | `` nixos/release-notes: fix typo ``                                                   |
| [`adea3473`](https://github.com/NixOS/nixpkgs/commit/adea347368d8dfceffca0d6b7f21d3054e92e397) | `` gnome-builder: 44.1 → 44.2 ``                                                      |
| [`dd36ed45`](https://github.com/NixOS/nixpkgs/commit/dd36ed450cd59fc492f1f4ad358f9d227c6c3384) | `` xfce.xfce4-netload-plugin: 1.4.0 -> 1.4.1 ``                                       |