### PR TITLE
chore(flake/stylix): `095ab80a` -> `f7ab221e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683039066,
-        "narHash": "sha256-xeJHdFxILyx75mjSk3sqJ3bEUN4HmBnsUfbZNJkQAt8=",
+        "lastModified": 1683056332,
+        "narHash": "sha256-exzcFBSohyYyNm8/FP3jR+7OcdZXQaH8SyAqk+r3H5s=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "095ab80afc90b264886fbeab91ee82c4d0cc88a1",
+        "rev": "f7ab221e56678b04adc8f889945988afa6be8a2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                             |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`f7ab221e`](https://github.com/danth/stylix/commit/f7ab221e56678b04adc8f889945988afa6be8a2e) | `` Add example by SomeGuyNamedMy (#96) ``           |
| [`d3153db5`](https://github.com/danth/stylix/commit/d3153db5e367478368be275b1aa57d6c1a4bf7aa) | `` Improve README and link to Matrix room :memo: `` |