### PR TITLE
chore(flake/stylix): `f7ab221e` -> `a9367cea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683056332,
-        "narHash": "sha256-exzcFBSohyYyNm8/FP3jR+7OcdZXQaH8SyAqk+r3H5s=",
+        "lastModified": 1683100629,
+        "narHash": "sha256-c+cHSnwkWYJNydJJYo0vS1uy/NoLW4OAkQZsxRl4WCY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f7ab221e56678b04adc8f889945988afa6be8a2e",
+        "rev": "a9367cea1bdc0ad35b3b0b2afc4aa9cf94cdecdb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                  |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`a9367cea`](https://github.com/danth/stylix/commit/a9367cea1bdc0ad35b3b0b2afc4aa9cf94cdecdb) | `` Fix screenshots not loading on GitHub Pages :memo: `` |