### PR TITLE
chore(flake/home-manager): `0e4c33d7` -> `514c0a71`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682977601,
-        "narHash": "sha256-F1Va/Uiw2tVNn27FLqWyBkiqDyIm/eCamw9wA/GK8Fw=",
+        "lastModified": 1683153724,
+        "narHash": "sha256-wiQ8pBYbbPklLngAz5w3VvwmpLqTNroKc7um56iCLHo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0e4c33d76006c9080d2f228ba1c2308e3e4d7be6",
+        "rev": "514c0a71f47cb80282742d7e4b6913c2c0582c2d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`514c0a71`](https://github.com/nix-community/home-manager/commit/514c0a71f47cb80282742d7e4b6913c2c0582c2d) | `` helix: provide more detailed settings description (#3932) `` |
| [`788777b5`](https://github.com/nix-community/home-manager/commit/788777b536df6e4c48fa158a9245c6f8a82beb43) | `` nushell: add envVars attribute (#3930) ``                    |