### PR TITLE
chore(flake/nixpkgs): `1a411f23` -> `0d8145a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -303,11 +303,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1683014792,
-        "narHash": "sha256-6Va9iVtmmsw4raBc3QKvQT2KT/NGRWlvUlJj46zN8B8=",
+        "lastModified": 1683194677,
+        "narHash": "sha256-Am7aCGNy/h6RMnvg7Pn4PHQXZZq9FyIUA9klYxBwyDI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1a411f23ba299db155a5b45d5e145b85a7aafc42",
+        "rev": "0d8145a5d81ebf6698077b21042380a3a66a11c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`fd155c2a`](https://github.com/NixOS/nixpkgs/commit/fd155c2a9494bd706bea5dc3916869bb3ffa739a) | `` llvmPackages_16.llvm: avoid calling roundevenf on darwin ``              |
| [`3c7fba2b`](https://github.com/NixOS/nixpkgs/commit/3c7fba2b0f70f0d6860f0be3780fa0176f6339a8) | `` llvmPackages_16.llvm: fix postPatch on darwin ``                         |
| [`cae55ac3`](https://github.com/NixOS/nixpkgs/commit/cae55ac31d4d904d5281c8c382e4eb68f36bb6d0) | `` gomplate: use go 1.20 ``                                                 |
| [`8a00768f`](https://github.com/NixOS/nixpkgs/commit/8a00768ffb9b27f8885ed5b766ff8080280f11bb) | `` qc: init at 0.0.4 ``                                                     |
| [`1348f199`](https://github.com/NixOS/nixpkgs/commit/1348f199a5d9b836a6672fcc8588fd1b90578ffd) | `` lib/systems: move loongarch64-linux out of mips block ``                 |
| [`e2adc3a3`](https://github.com/NixOS/nixpkgs/commit/e2adc3a3a23d8735937e23105741763b05140812) | `` bootstrap-tools-cross: add loongarch64-linux ``                          |
| [`fa96c4dc`](https://github.com/NixOS/nixpkgs/commit/fa96c4dc96b51831a6161b0df8c513613c00eebc) | `` python310Packages.pyvista: 0.38.5 -> 0.38.6 ``                           |
| [`cc09d6a1`](https://github.com/NixOS/nixpkgs/commit/cc09d6a1d08538173df65d217e31b12a6cd29189) | `` unciv: 4.6.7 -> 4.6.8 ``                                                 |
| [`fb91facd`](https://github.com/NixOS/nixpkgs/commit/fb91facda232392df1c2fe3a10e5a28232be54d5) | `` nixos/tests/installer.nix: add missing kbd.dev ``                        |
| [`c65c2f09`](https://github.com/NixOS/nixpkgs/commit/c65c2f09e5bb54cbbbc4aa72030d62e138d8f0cf) | `` lnd: 0.16.1 -> 0.16.2 ``                                                 |
| [`8c32a5b2`](https://github.com/NixOS/nixpkgs/commit/8c32a5b2ce0e2b29c5d21424109539c953bca04e) | `` blender 3.4.1 -> 3.5.1 (#229570) ``                                      |
| [`d4c2564b`](https://github.com/NixOS/nixpkgs/commit/d4c2564bb6d3a3a62acac3c8bf0214c276141ee0) | `` llvmPackages_16.llvm: fix build on armv7l-linux ``                       |
| [`ff7edb3c`](https://github.com/NixOS/nixpkgs/commit/ff7edb3c7f07db8d348450e78127a23884970e2a) | `` terraform-providers.vault: 3.15.0 -> 3.15.1 ``                           |
| [`679cace1`](https://github.com/NixOS/nixpkgs/commit/679cace1c747130c4e8024240d816ed9f52617d6) | `` terraform-providers.oci: 4.118.0 -> 4.119.0 ``                           |
| [`c78c89f7`](https://github.com/NixOS/nixpkgs/commit/c78c89f7d2d6e937bd1b699c16cacced48dd98d5) | `` terraform-providers.ovh: 0.29.0 -> 0.30.0 ``                             |
| [`e25ab1bd`](https://github.com/NixOS/nixpkgs/commit/e25ab1bd0f7f642b2d5c7c0617d182e00742b85f) | `` terraform-providers.datadog: 3.24.0 -> 3.24.1 ``                         |
| [`7f892230`](https://github.com/NixOS/nixpkgs/commit/7f892230ba3891ddae65be4be18f5c336489170a) | `` terraform-providers.cloudamqp: 1.25.0 -> 1.26.0 ``                       |
| [`9237be6b`](https://github.com/NixOS/nixpkgs/commit/9237be6b9d9fdf8bda7a9a3904932e8a4d262749) | `` python310Packages.plaid-python: 12.0.0 -> 13.0.0 ``                      |
| [`b2504311`](https://github.com/NixOS/nixpkgs/commit/b25043119fce3ecfa4c1381d510dd5041bf995aa) | `` trayscale: 0.9.6 -> 0.9.7 ``                                             |
| [`91011996`](https://github.com/NixOS/nixpkgs/commit/91011996040e71228e58f4f0fc44b8582ddb6450) | `` python3.pkgs.mlflow: fix build ``                                        |
| [`de9e53d9`](https://github.com/NixOS/nixpkgs/commit/de9e53d994e637d217927fa65c3bee319464f32c) | `` amdgpu_top: fix GUI mode missing x11 and wayland libs ``                 |
| [`48a1e1f7`](https://github.com/NixOS/nixpkgs/commit/48a1e1f75363a3aaa5055d54d4d2fa6e9763892b) | `` trivy: 0.40.0 -> 0.41.0 ``                                               |
| [`dd3c0085`](https://github.com/NixOS/nixpkgs/commit/dd3c008537970513873aa7bfcf05de8bf05ed5e1) | `` gnucash: 4.12 -> 5.1 ``                                                  |
| [`eefc3b65`](https://github.com/NixOS/nixpkgs/commit/eefc3b651514cbcc5c22cbf01e7a2035426df352) | `` protoc-gen-entgrpc: 0.4.3 -> 0.4.5 ``                                    |
| [`16100e18`](https://github.com/NixOS/nixpkgs/commit/16100e187b666e37b3fc7d53b80d3b97b8f241f4) | `` go-musicfox: 4.0.5 -> 4.0.6 ``                                           |
| [`914b27a7`](https://github.com/NixOS/nixpkgs/commit/914b27a77966f599389083a39905bd6f352e88d9) | `` prometheus-artifactory-exporter: 1.13.0 -> 1.13.1 ``                     |
| [`974ad83f`](https://github.com/NixOS/nixpkgs/commit/974ad83f91e3d1c0ebb6644f62aea82d11987261) | `` erlang_24: 24.3.4.10 -> 24.3.4.11 ``                                     |
| [`5471a96f`](https://github.com/NixOS/nixpkgs/commit/5471a96ff4a3395676707d3fc3c4d0189ff9595f) | `` openasar: unstable-2023-04-01 -> unstable-2023-05-01 ``                  |
| [`be06db87`](https://github.com/NixOS/nixpkgs/commit/be06db870f8e9b2c7ebbf883b731e2867b6d476d) | `` linuxKernel.kernels.linux_zen: 6.2.12-zen1 -> 6.3.1-zen1 ``              |
| [`2deb6be6`](https://github.com/NixOS/nixpkgs/commit/2deb6be6f6fee4745612ab66982cebdc1b4528f5) | `` linuxKernel.kernels.linux_lqx: 6.2.12-lqx1 -> 6.2.14-lqx1 ``             |
| [`ec828808`](https://github.com/NixOS/nixpkgs/commit/ec828808431c577245db4fc0ad2e0e2a813c5968) | `` opentelemetry-collector: 0.75.0 -> 0.76.1 ``                             |
| [`d2be6664`](https://github.com/NixOS/nixpkgs/commit/d2be66648c4099f086e47caaafdc4fbeb3fbc618) | `` crowdin-cli: 3.10.1 -> 3.11.0 ``                                         |
| [`46d395e1`](https://github.com/NixOS/nixpkgs/commit/46d395e1df1a08ebb1ece5b1f1722492aceb5cd8) | `` clang_16: Reference the correct LLVM packages version (16 vs. 15) ``     |
| [`5f05c243`](https://github.com/NixOS/nixpkgs/commit/5f05c243c49f7b033e4f3132a0c603c400c7ea5c) | `` go_1_19: 1.19.8 -> 1.19.9 ``                                             |
| [`57de621a`](https://github.com/NixOS/nixpkgs/commit/57de621aaef7fe6118cca9dcc15ac8a595dc3db8) | `` qownnotes: build with Qt6 ``                                             |
| [`4dc86524`](https://github.com/NixOS/nixpkgs/commit/4dc865249ae75361f05c8056af355235dd100a33) | `` libva-utils: 2.18.0 -> 2.18.1 ``                                         |
| [`3d05e857`](https://github.com/NixOS/nixpkgs/commit/3d05e857456aab302aa10f1ae279731524718127) | `` open-policy-agent: 0.51.0 -> 0.52.0 ``                                   |
| [`bfa29e52`](https://github.com/NixOS/nixpkgs/commit/bfa29e52453428b5a9634362009f520f388db98d) | `` vulkan-tools-lunarg: 1.3.243.0 -> 1.3.249 ``                             |
| [`0cb697b2`](https://github.com/NixOS/nixpkgs/commit/0cb697b2df391b5cf48c7ce757033b8a3e2f0414) | `` vulkan-validation-layers: fix hash, update spirv-headers to fix build `` |
| [`6d693533`](https://github.com/NixOS/nixpkgs/commit/6d6935337c1d4f22c75ef197fb841d4d066c3f25) | `` fingerprintx: 1.1.8 -> 1.1.9 ``                                          |
| [`f450ee14`](https://github.com/NixOS/nixpkgs/commit/f450ee1472cc5e7b001f8020484d8a8da2002cb6) | `` lunatic: 0.12.0 -> 0.13.2 ``                                             |
| [`37169713`](https://github.com/NixOS/nixpkgs/commit/371697135ed548544503b5b64c5d71982985adf1) | `` jsonnet: 0.19.1 -> 0.20.0 ``                                             |
| [`fcaa69e5`](https://github.com/NixOS/nixpkgs/commit/fcaa69e52cf2386f7a88d62aba751037112abc1d) | `` gurk-rs: 0.3.0 -> 0.4.0 ``                                               |
| [`d1ab33d2`](https://github.com/NixOS/nixpkgs/commit/d1ab33d23078dec433c64953da81cb37b8ea7046) | `` guglielmo: 0.4 -> 0.5 ``                                                 |
| [`5d508929`](https://github.com/NixOS/nixpkgs/commit/5d5089297eadba0609854e374c5ed6627929036f) | `` ocamlPackages.result: pin Dune to version 1 for OCaml < 4.08 ``          |
| [`23eecca4`](https://github.com/NixOS/nixpkgs/commit/23eecca49565b351adee586eac37487bbf27ac2f) | `` ocamlPackages.octavius: pin Dune to version 1 for OCaml < 4.08 ``        |
| [`400e6f08`](https://github.com/NixOS/nixpkgs/commit/400e6f08b6b034aa9e26e0f474b029d2e40f3cb9) | `` ocamlPackages.re: pin Dune to version 1 for OCaml < 4.08 ``              |
| [`8373826e`](https://github.com/NixOS/nixpkgs/commit/8373826ef25c3addfd1e4627ec9d14d5cd5661da) | `` ocamlPackages.stdlib-shims: pin Dune to version 1 for OCaml < 4.08 ``    |
| [`6dace220`](https://github.com/NixOS/nixpkgs/commit/6dace2206e7134615d9a287c54e3d8062297551d) | `` ocamlPackages.ppx_derivers: pin Dune to version 1 for OCaml < 4.08 ``    |
| [`6eab4caa`](https://github.com/NixOS/nixpkgs/commit/6eab4caac79d9f5d4b9cfdafb98bc74109770294) | `` boatswain: add Darwin as broken ``                                       |
| [`d7a82425`](https://github.com/NixOS/nixpkgs/commit/d7a8242535ac2b8a25ca2ebe5362c1ea9a91d6fa) | `` boatswain: init at 0.3.0 ``                                              |
| [`6ab8f2ae`](https://github.com/NixOS/nixpkgs/commit/6ab8f2aea546012da7d72fdf55aa7ce650a3cb21) | `` xpdf: fix build failure on darwin ``                                     |
| [`136ba126`](https://github.com/NixOS/nixpkgs/commit/136ba12619a6f93d665113dabc641c25ed88ea6b) | `` libsForQt5.phonon: unbreak on darwin ``                                  |
| [`d15a24c7`](https://github.com/NixOS/nixpkgs/commit/d15a24c766a422b1460b139363dacc6568aaf7d2) | `` mdbook-katex: 0.3.15 -> 0.4.1 ``                                         |
| [`57a7c9d5`](https://github.com/NixOS/nixpkgs/commit/57a7c9d51f81103cf8b2251136f328d2ece401f7) | `` cmdstan: 2.32.0 -> 2.32.1 ``                                             |
| [`1519ef71`](https://github.com/NixOS/nixpkgs/commit/1519ef71b42d0a226bd2ed31d869f4ac3b19f37d) | `` stanc: 2.32.0 -> 2.32.1 ``                                               |
| [`38412e10`](https://github.com/NixOS/nixpkgs/commit/38412e10294bd9e4d7b4dc70912cdce955e31589) | `` libamqpcpp: 4.3.23 -> 4.3.24 ``                                          |
| [`b8466582`](https://github.com/NixOS/nixpkgs/commit/b8466582d64ebc601ffd32a21f2bb4682480b873) | `` trippy: init at 0.7.0 ``                                                 |
| [`f18b8a77`](https://github.com/NixOS/nixpkgs/commit/f18b8a775432727d0f02f4c90ee686f2f00f24eb) | `` chezmoi: 2.33.3 -> 2.33.4 ``                                             |
| [`531d494b`](https://github.com/NixOS/nixpkgs/commit/531d494be2dd120a2611d6206a51ea1bf9fd4b3e) | `` python310Packages.identify: 2.5.23 -> 2.5.24 ``                          |
| [`143f7b5a`](https://github.com/NixOS/nixpkgs/commit/143f7b5afdddceb3a00102906f51101989bbc377) | `` python310Packages.zha-quirks: 0.0.98 -> 0.0.99 ``                        |
| [`7f4280c5`](https://github.com/NixOS/nixpkgs/commit/7f4280c53866a3febad623d669db7eb2adea876d) | `` pkgsStatic.gcc: fix build ``                                             |
| [`07a81318`](https://github.com/NixOS/nixpkgs/commit/07a813187c3ef64b48ed12983cf1f09e10b0ba82) | `` balena-cli: 15.1.1 -> 15.2.2 ``                                          |
| [`9ae92527`](https://github.com/NixOS/nixpkgs/commit/9ae9252729f5f7533483a7263be0a154548487ad) | `` python310Packages.rl-coach: remove ``                                    |
| [`aad25290`](https://github.com/NixOS/nixpkgs/commit/aad25290ee4655200f63206c2a507611a8e6338d) | `` nixos/emacs: restore example markup ``                                   |
| [`407f6196`](https://github.com/NixOS/nixpkgs/commit/407f6196a23f8b0b42c74c66f2717645aa277bbd) | `` nixos-render-docs: add examples support ``                               |
| [`107507c0`](https://github.com/NixOS/nixpkgs/commit/107507c091730e8c9b2411098420f9bb4a45dbf5) | `` glooctl: 1.14.1 -> 1.14.2 ``                                             |
| [`ed67203e`](https://github.com/NixOS/nixpkgs/commit/ed67203e6d462b22067dc8c2deabb245d3c63ff0) | `` lndhub-go: 0.13.0 -> 0.14.0 ``                                           |
| [`d2ba8588`](https://github.com/NixOS/nixpkgs/commit/d2ba8588f5661271d5e87e3e4979b64182a5c46b) | `` standardnotes: 3.151.3 -> 3.154.1 ``                                     |
| [`0b360b1c`](https://github.com/NixOS/nixpkgs/commit/0b360b1c34a4508183fa66cccb581cd62708a946) | `` numix-icon-theme-square: 23.04.20 -> 23.04.28 ``                         |
| [`241a51f7`](https://github.com/NixOS/nixpkgs/commit/241a51f73f3ba92c0ab334a0dd238d0737c6c60f) | `` radsecproxy: 1.9.2 -> 1.9.3 ``                                           |
| [`e184d4d1`](https://github.com/NixOS/nixpkgs/commit/e184d4d14de27797a004ca84731170e21a38a4e8) | `` python310Packages.hahomematic: 2023.4.5 -> 2023.5.0 ``                   |
| [`4f506d38`](https://github.com/NixOS/nixpkgs/commit/4f506d389bb9b0b53aa51275837c16fe7b8a777e) | `` python310Packages.aiomisc: 17.1.4 -> 17.2.2 ``                           |
| [`49c41315`](https://github.com/NixOS/nixpkgs/commit/49c41315008096979014b15a189c15f2d91b40a9) | `` yoda: 1.9.7 -> 1.9.8 (#229376) ``                                        |
| [`b3f44e39`](https://github.com/NixOS/nixpkgs/commit/b3f44e392e1a0fbab6ae8e3b3a16123e416d1339) | `` nfs-ganesha: 5.0 -> 5.1 ``                                               |
| [`279c6c61`](https://github.com/NixOS/nixpkgs/commit/279c6c6109da49b9b00233e8e29a6ed7454afc35) | `` ukmm: 0.7.1 -> 0.8.0 ``                                                  |
| [`68dabf2a`](https://github.com/NixOS/nixpkgs/commit/68dabf2a1338a8f515f01a811efc03461155738c) | `` paper-note: remove ``                                                    |
| [`b6a52438`](https://github.com/NixOS/nixpkgs/commit/b6a5243860b2bfad067287495d0e4b376dd65a28) | `` mate.mate-panel: 1.26.2 -> 1.26.3 ``                                     |
| [`ce8d0a23`](https://github.com/NixOS/nixpkgs/commit/ce8d0a2348ef30f7355c590221d5c0d8d990c6ce) | `` pianoteq: add aarch64-linux support ``                                   |
| [`d6b6b5f9`](https://github.com/NixOS/nixpkgs/commit/d6b6b5f94f4dfe2e24583bdc2235b493afdc0095) | `` lowdown: add nix to passthru.tests ``                                    |
| [`90b4a9b7`](https://github.com/NixOS/nixpkgs/commit/90b4a9b7d3532745f0672f7693a0b7500018e005) | `` lowdown: run tests when cross-compiling if possible ``                   |
| [`90ff53d7`](https://github.com/NixOS/nixpkgs/commit/90ff53d72cb6455c68705c26c4dd91b8eb9a720a) | `` lowdown: 1.0.0 -> 1.0.1 ``                                               |
| [`fd3298ba`](https://github.com/NixOS/nixpkgs/commit/fd3298bac4d41371f9eb036d158b80473a52d368) | `` wordpress: update languages and plugins ``                               |
| [`b8d9c8a7`](https://github.com/NixOS/nixpkgs/commit/b8d9c8a7efab3186bd55b95d44781b67f9714ac4) | `` oculante: remove duplicate build input ``                                |
| [`db8e2ab5`](https://github.com/NixOS/nixpkgs/commit/db8e2ab5e6be9cb7c57110c221c326b22d6d2537) | `` muffet: 2.7.0 -> 2.8.0 ``                                                |
| [`fbd45c0b`](https://github.com/NixOS/nixpkgs/commit/fbd45c0bfd530960ba9a2f71d0f928bfc7124805) | `` wp4nix: build on darwin ``                                               |
| [`1a7ab2f7`](https://github.com/NixOS/nixpkgs/commit/1a7ab2f7b26a12f33e02dbb9fbd8538980fdca66) | `` nerdfix: 0.2.2 -> 0.2.3 ``                                               |
| [`96b17026`](https://github.com/NixOS/nixpkgs/commit/96b170269a37e661be29a51e961f78757a92b46d) | `` python310Packages.graphene-django: 3.0.1 -> 3.0.2 ``                     |
| [`01986b07`](https://github.com/NixOS/nixpkgs/commit/01986b07f43a12bd0396bd81876f5a8a664ebcc5) | `` python310Packages.scooby: 0.7.1 -> 0.7.2 ``                              |
| [`c0678197`](https://github.com/NixOS/nixpkgs/commit/c067819735ccf863a3efe6f2d0fdb09c773cd5d9) | `` pdfpc: import upstream patch to fix build ``                             |
| [`41a5d657`](https://github.com/NixOS/nixpkgs/commit/41a5d6578054e3244de88080f09869791edd0f92) | `` tomlplusplus: apply fix for detect_voidp_size when ``                    |
| [`493100a8`](https://github.com/NixOS/nixpkgs/commit/493100a898600d70852336f321a3c2c728bf2f4e) | `` gomplate: add reminder to switch to go 1.20 ``                           |
| [`f1d17a79`](https://github.com/NixOS/nixpkgs/commit/f1d17a7955fc7813eca25b0916f9222b0ec690d9) | `` kubo: add Luflosi as maintainer ``                                       |
| [`da108ddd`](https://github.com/NixOS/nixpkgs/commit/da108ddd6c73d00dae675f8b22b85dfc9dd9a374) | `` grafana-loki,promtail: 2.8.1 -> 2.8.2 ``                                 |
| [`ed1fb37e`](https://github.com/NixOS/nixpkgs/commit/ed1fb37eba4accf1654cc7fbfd07e340b0110af8) | `` freedv: 1.8.8.1 -> 1.8.9 ``                                              |
| [`1c9a8dd0`](https://github.com/NixOS/nixpkgs/commit/1c9a8dd083da5395c5d4ee2f33c494a40a418853) | `` python310Packages.python-swiftclient: 4.2.0 -> 4.3.0 ``                  |
| [`46a6f11d`](https://github.com/NixOS/nixpkgs/commit/46a6f11d8f06c20ffe5b85c7ee39a68a14f1b493) | `` kubo: 0.19.1 -> 0.19.2 ``                                                |
| [`b7470870`](https://github.com/NixOS/nixpkgs/commit/b74708700e2d068de5da3acb86be7acdc95272d6) | `` verilator: 5.008 -> 5.010 ``                                             |
| [`1c858235`](https://github.com/NixOS/nixpkgs/commit/1c858235550aabed9fbcba959be7afce7adf259b) | `` python310Packages.tempest: 33.0.0 -> 34.1.0 ``                           |
| [`b53e7502`](https://github.com/NixOS/nixpkgs/commit/b53e7502f39e9214013a51ac373029f044bfcfef) | `` nb: 7.4.1 -> 7.5.1 ``                                                    |
| [`34005cd9`](https://github.com/NixOS/nixpkgs/commit/34005cd963ad7a5829ffc03244621bf973f6e0be) | `` audacious: 4.3 -> 4.3.1 ``                                               |
| [`96795826`](https://github.com/NixOS/nixpkgs/commit/9679582652277b2f556eeda13e9207ffd2023964) | `` wordpress: 6.1.1 -> 6.2; wordpress6_2: init ``                           |
| [`d14d78ac`](https://github.com/NixOS/nixpkgs/commit/d14d78ac310d3028fd0776ba0f3e399c06795655) | `` squeezelite: 1.9.9.1428 -> 1.9.9.1430 ``                                 |
| [`7f2f9955`](https://github.com/NixOS/nixpkgs/commit/7f2f9955ce8c7ba4b54ae913e96ba5781f690e63) | `` qjackctl: 0.9.9 -> 0.9.10 ``                                             |
| [`1a2145e4`](https://github.com/NixOS/nixpkgs/commit/1a2145e48d9ec8113d3fa5a689ae953cf0e0b7a5) | `` hackgen-nf-font: 2.8.0 -> 2.9.0 ``                                       |
| [`28055e80`](https://github.com/NixOS/nixpkgs/commit/28055e80b8c108c11b79b4e33082e875c59c2015) | `` hackgen-font: 2.8.0 -> 2.9.0 ``                                          |
| [`8c873d84`](https://github.com/NixOS/nixpkgs/commit/8c873d84bb895054daf0b576edced424ca3b16ad) | `` python310Packages.niaaml: 1.1.11 -> 1.1.12 ``                            |
| [`5696e84e`](https://github.com/NixOS/nixpkgs/commit/5696e84ee7be09cebdd88950fd13a132895e8bf9) | `` python310Packages.browser-cookie3: 0.17.0 -> 0.18.0 ``                   |
| [`7662238e`](https://github.com/NixOS/nixpkgs/commit/7662238eb53739e0026a07ef7b497f2ea7ebd2ba) | `` python310Packages.json-stream: 2.2.1 -> 2.3.0 ``                         |
| [`66d4106a`](https://github.com/NixOS/nixpkgs/commit/66d4106a41b82bbe32b2fce3d5883af1e9d0fd7a) | `` python310Packages.psycopg: Test against a live postgresql instance ``    |
| [`d15f5daf`](https://github.com/NixOS/nixpkgs/commit/d15f5daf89123628704cfe98f29195ee8614cdb8) | `` python310Packages.distributed: 2023.2.1 -> 2023.4.1 ``                   |
| [`0d41b621`](https://github.com/NixOS/nixpkgs/commit/0d41b621531fc46d2343f9748fd269cc009277ee) | `` bonnie: 1.98 -> 2.00a ``                                                 |
| [`ff7d11c9`](https://github.com/NixOS/nixpkgs/commit/ff7d11c915e64a1234b8b0096702316fe4a37ec9) | `` python310Packages.nocasedict: 2.0.0 -> 2.0.1 ``                          |
| [`8f9037de`](https://github.com/NixOS/nixpkgs/commit/8f9037de891fe28867f4799e517f1d01d6e36a7c) | `` a2ps: 4.15.1 -> 4.15.4 ``                                                |