### PR TITLE
chore(flake/nixos-hardware): `7dc46304` -> `51559e69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -288,11 +288,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1683009613,
-        "narHash": "sha256-jJh8JaoHOLlk7iFLgZk1PlxCCNA2KTKfOLMLCa9mduA=",
+        "lastModified": 1683269598,
+        "narHash": "sha256-KNsb+nBbB1Fmxd07dt4E0KXMT4YeKJB7gQaA6Xfk+mo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "7dc46304675f4ff2d6be921ef60883efd31363c4",
+        "rev": "51559e691f1493a26f94f1df1aaf516bb507e78b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`db08b1f1`](https://github.com/NixOS/nixos-hardware/commit/db08b1f13fe125d3dfeac89745ea3f362442eede) | `` tests: fix conflicts with profiles using grub ``        |
| [`d626c3f8`](https://github.com/NixOS/nixos-hardware/commit/d626c3f873e20e56f59bea88430f83328a355933) | `` add missing nxp boards ``                               |
| [`31f8d1c3`](https://github.com/NixOS/nixos-hardware/commit/31f8d1c36431153b98606e0b0c4427140ab8dc69) | `` Added Lenovo Thinkpad x390 ``                           |
| [`adab6fd8`](https://github.com/NixOS/nixos-hardware/commit/adab6fd8e96ee67f8b7afbf91a7e990694d76e52) | `` hardkernel/odroid-hc4: fix fancontrol on 5.15 kernel `` |