### PR TITLE
chore(flake/nixpkgs): `0d8145a5` -> `3e313808`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -303,11 +303,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1683194677,
-        "narHash": "sha256-Am7aCGNy/h6RMnvg7Pn4PHQXZZq9FyIUA9klYxBwyDI=",
+        "lastModified": 1683286087,
+        "narHash": "sha256-xseOd7W7xwF5GOF2RW8qhjmVGrKoBz+caBlreaNzoeI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0d8145a5d81ebf6698077b21042380a3a66a11c7",
+        "rev": "3e313808bd2e0a0669430787fb22e43b2f4bf8bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`e5fa77e7`](https://github.com/NixOS/nixpkgs/commit/e5fa77e771e3f80914de72d05ee9c3263b8b5ab4) | `` xplorer: init at unstable-2023-03-19 ``                                                   |
| [`62c557d5`](https://github.com/NixOS/nixpkgs/commit/62c557d55438f460251b065c8ab21bffd3022d8d) | `` python3Packages.langchain: init at 0.0.158 ``                                             |
| [`4503d47a`](https://github.com/NixOS/nixpkgs/commit/4503d47a56950a21aeae9a3e648d6862682756ae) | `` python3Packages.openapi-schema-pydantic: init at 1.2.4 ``                                 |
| [`05064947`](https://github.com/NixOS/nixpkgs/commit/050649477df7f25862fc7d4d2345f66b1a3d79c7) | `` mimir: 2.7.1 -> 2.8.0 ``                                                                  |
| [`d6a684d2`](https://github.com/NixOS/nixpkgs/commit/d6a684d22358e6f175191cb56e659720344d2d43) | `` ppsspp-sdl: 1.14.4 -> 1.15.2 ``                                                           |
| [`0fc052a4`](https://github.com/NixOS/nixpkgs/commit/0fc052a4f42112552ab10e27edcfa0439687beda) | `` owncloud-client: improve nix expressions ``                                               |
| [`a1c2e260`](https://github.com/NixOS/nixpkgs/commit/a1c2e2606c37fcddee03ab52f6256ceb1cafa320) | `` aws-lambda-rie: 1.10 -> 1.11 ``                                                           |
| [`18f2c5f5`](https://github.com/NixOS/nixpkgs/commit/18f2c5f5b860733ecbd499ebd74a72c685f8917d) | `` ocamlPackages.lsp: fix propagatedInputs ``                                                |
| [`3576a3e2`](https://github.com/NixOS/nixpkgs/commit/3576a3e25633039e9fd4755a2ac6a8c02eda0e3f) | `` ocamlPackages.linol: fix minimalOCamlVersion ``                                           |
| [`2a5ea263`](https://github.com/NixOS/nixpkgs/commit/2a5ea263899c3ec5bc5832ee268e8e98da2ffcb3) | `` python311Packages.dvc-studio-client: 0.8.0 -> 0.9.0 ``                                    |
| [`8de789ec`](https://github.com/NixOS/nixpkgs/commit/8de789ece508598a2132bcdab7be033bbc0e4bbb) | `` python311Packages.dvc-azure: 2.21.0 -> 2.21.1 ``                                          |
| [`23cac0d4`](https://github.com/NixOS/nixpkgs/commit/23cac0d4d692a15da70aa63abd64ec229aae8787) | `` python311Packages.dvc-s3: 2.21.0 -> 2.22.0 ``                                             |
| [`f3a4d5b3`](https://github.com/NixOS/nixpkgs/commit/f3a4d5b323bc1730416e238978aaad5cea7793a6) | `` python311Packages.dvc-gs: 2.21.0 -> 2.22.0 ``                                             |
| [`f0520ce5`](https://github.com/NixOS/nixpkgs/commit/f0520ce51dd8bd06a243c46eb93cb2eed67e19e3) | `` python311Packages.dvc-ssh: 2.21.0 -> 2.22.1 ``                                            |
| [`51805d5c`](https://github.com/NixOS/nixpkgs/commit/51805d5c2f7778770021cb0379569e41b6b4dd16) | `` promexplorer: 0.0.4 -> 0.0.5 ``                                                           |
| [`ef1d1d7a`](https://github.com/NixOS/nixpkgs/commit/ef1d1d7a4e00e558f833d7f203ffe0eff22aa46f) | `` python311Packages.holidays: 0.21.13 -> 0.24 ``                                            |
| [`43d8b31d`](https://github.com/NixOS/nixpkgs/commit/43d8b31dd20beb4a1779d64c5169ac20b0f53762) | `` oh-my-posh: 15.4.0 -> 15.4.2 ``                                                           |
| [`733b43ba`](https://github.com/NixOS/nixpkgs/commit/733b43ba8940e38b9616c5cbdf398dc138c05202) | `` python311Packages.elkm1-lib: 2.2.1 -> 2.2.2 ``                                            |
| [`70ca1fab`](https://github.com/NixOS/nixpkgs/commit/70ca1fab1b890b5f19bc1d4d44e1de632a9eea04) | `` gocryptfs: 2.3.1 -> 2.3.2 ``                                                              |
| [`12a715b8`](https://github.com/NixOS/nixpkgs/commit/12a715b89570eecf3100a543e839a9b020e185c0) | `` ginkgo: 2.9.2 -> 2.9.4 ``                                                                 |
| [`661117e1`](https://github.com/NixOS/nixpkgs/commit/661117e16fef233387866691c749f2427d349c1f) | `` gh: fix cross ``                                                                          |
| [`014cc7a7`](https://github.com/NixOS/nixpkgs/commit/014cc7a7ac43af4bbc26d823e4597bfcf798e8b6) | `` libcotp: 2.0.0 -> 2.0.1 ``                                                                |
| [`7e882fb1`](https://github.com/NixOS/nixpkgs/commit/7e882fb1fb1cf4d892c9bcca67e21a4a8c561075) | `` pocketbase: 0.15.2 -> 0.15.3 ``                                                           |
| [`799e37bd`](https://github.com/NixOS/nixpkgs/commit/799e37bd1674297a030b02b36e32b7e67e258f33) | `` wishlist: 0.10.0 -> 0.11.0 ``                                                             |
| [`fb66a26b`](https://github.com/NixOS/nixpkgs/commit/fb66a26b75ceb76826e9c186ea1ae62edefb2f58) | `` ddcci-driver: 0.4.2 -> 0.4.3 ``                                                           |
| [`80e81b98`](https://github.com/NixOS/nixpkgs/commit/80e81b989be55a91fb916c5822e910d561f2cab3) | `` terraform-providers.aws: 4.65.0 -> 4.66.0 ``                                              |
| [`014897d1`](https://github.com/NixOS/nixpkgs/commit/014897d1da2e7d7dd3824bfc5cbef729ca06ed1d) | `` terraform-providers.yandex: 0.89.0 -> 0.90.0 ``                                           |
| [`31cd152c`](https://github.com/NixOS/nixpkgs/commit/31cd152ce72e195d087e8c8323a963e9d055f5b3) | `` terraform-providers.vultr: 2.14.1 -> 2.15.0 ``                                            |
| [`e5c8a4ea`](https://github.com/NixOS/nixpkgs/commit/e5c8a4ea58bdd6f4048ebd419e687d8ad4c19456) | `` terraform-providers.vault: 3.15.1 -> 3.15.2 ``                                            |
| [`deb7ec86`](https://github.com/NixOS/nixpkgs/commit/deb7ec86cc32f0ab87ff8f8e5c07f6ddfecf3818) | `` terraform-providers.opentelekomcloud: 1.34.2 -> 1.34.3 ``                                 |
| [`4de7c276`](https://github.com/NixOS/nixpkgs/commit/4de7c2761f6fe9cef3f7a6bd583c005a734fb597) | `` terraform-providers.okta: 3.46.0 -> 4.0.0 ``                                              |
| [`74e89bd3`](https://github.com/NixOS/nixpkgs/commit/74e89bd33f5bc0599cc2e5f45cb8aab9f9cc0082) | `` terraform-providers.ibm: 1.52.1 -> 1.53.0 ``                                              |
| [`b5c3f904`](https://github.com/NixOS/nixpkgs/commit/b5c3f904fb18225c6e11ce83ef1f928b44efa5fb) | `` zim-tools: 3.1.1 -> 3.1.3 ``                                                              |
| [`50b86d1a`](https://github.com/NixOS/nixpkgs/commit/50b86d1a3e5121600c65edc2e4395ef855e3b907) | `` zsh-forgit: 23.04.0 -> 23.05.0 ``                                                         |
| [`810b5bf8`](https://github.com/NixOS/nixpkgs/commit/810b5bf86febacbade842cada85ad9ee4df1f12b) | `` netbird-ui: 0.17.0 -> 0.19.0 ``                                                           |
| [`c6d51780`](https://github.com/NixOS/nixpkgs/commit/c6d51780cdc7de89f052b4c171d8ce3ef4062eaa) | `` typos: 1.14.8 -> 1.14.9 ``                                                                |
| [`a99f5f24`](https://github.com/NixOS/nixpkgs/commit/a99f5f247aac71e9759ccbfc4895818d67b90c90) | `` okteto: 2.15.1 -> 2.15.2 ``                                                               |
| [`30f26d07`](https://github.com/NixOS/nixpkgs/commit/30f26d070db7778ee085c1a3eea7153e7c84767e) | `` chef-cli, inspec, serverspec: Fix Gemfile deprecation warnings ``                         |
| [`54280813`](https://github.com/NixOS/nixpkgs/commit/5428081305e8f3146a4a65d454b47a24cbea80ad) | `` ukmm: 0.8.0 -> 0.8.1 ``                                                                   |
| [`de570038`](https://github.com/NixOS/nixpkgs/commit/de5700389969692238fb9d1386b0c8d05422c0d3) | `` cargo-dist: 0.0.5 -> 0.0.6 ``                                                             |
| [`48bd94f1`](https://github.com/NixOS/nixpkgs/commit/48bd94f10aa61a6040d94935b9e0991ba7961fd2) | `` python3.pkgs.interface-meta: fix typo ``                                                  |
| [`249950f7`](https://github.com/NixOS/nixpkgs/commit/249950f75d2c0e92207f71314c02a70ceac2b16c) | `` home-assistant: 2023.5.0 -> 2023.5.1 ``                                                   |
| [`4e2bb2c2`](https://github.com/NixOS/nixpkgs/commit/4e2bb2c2be03e5efe8a413096c0bd7217daca9c1) | `` thunderbird-bin: Set explicit binaryName after betterbird changes ``                      |
| [`55dc96a5`](https://github.com/NixOS/nixpkgs/commit/55dc96a50b3f82d8224f21c3fdd14c736f7f062e) | `` python311Packages.pex: 2.1.134 -> 2.1.135 ``                                              |
| [`646c4dcc`](https://github.com/NixOS/nixpkgs/commit/646c4dcca3cc18d0f17b436a7bb31bdf903f851d) | `` python311Packages.json-schema-for-humans: 0.44.4 -> 0.44.5 ``                             |
| [`0b5e6272`](https://github.com/NixOS/nixpkgs/commit/0b5e6272d2f99fd6f210aef5641a23cd4ef8ca3f) | `` python311Packages.hijri-converter: add changelog to meta ``                               |
| [`88c28061`](https://github.com/NixOS/nixpkgs/commit/88c280611ac81b9257121f4d474b2d25c249909e) | `` python311Packages.hijri-converter: 2.2.4 -> 2.3.1 ``                                      |
| [`6fe32e6d`](https://github.com/NixOS/nixpkgs/commit/6fe32e6da5d40508c666a2933b84c57586c9c597) | `` python311Packages.discordpy: 2.2.2 -> 2.2.3 ``                                            |
| [`65de422b`](https://github.com/NixOS/nixpkgs/commit/65de422b3f6c13da2d68b4d6073e7d2e5a734b23) | `` python311Packages.css-parser: 1.0.8 -> 1.0.9 ``                                           |
| [`baa121ed`](https://github.com/NixOS/nixpkgs/commit/baa121ed6340aba705824e6893b8e06007010ee9) | `` python311Packages.cloudscraper: 1.2.69 -> 1.2.71 ``                                       |
| [`e21e086b`](https://github.com/NixOS/nixpkgs/commit/e21e086b31566d0427d9bd61a1662dd05a08f6d6) | `` python311Packages.auth0-python: 4.1.1 -> 4.2.0 ``                                         |
| [`f69f9295`](https://github.com/NixOS/nixpkgs/commit/f69f92952580bba312a319f9e5d0a847b6d03dd3) | `` python311Packages.aioesphomeapi: 13.7.2 -> 13.7.3 ``                                      |
| [`d9b3bcf5`](https://github.com/NixOS/nixpkgs/commit/d9b3bcf504fe6551e337e7be1050d627f664aabe) | `` urlwatch: 2.26 -> 2.28 ``                                                                 |
| [`c8b4ed1d`](https://github.com/NixOS/nixpkgs/commit/c8b4ed1db50c73e1e2dbaefc4cf1b253fca8667a) | `` cargo-llvm-lines: 0.4.28 -> 0.4.29 ``                                                     |
| [`f06d24a5`](https://github.com/NixOS/nixpkgs/commit/f06d24a512ca4a470877938a746cd9af410c5c3f) | `` kubernetes: 1.27.0 -> 1.27.1 ``                                                           |
| [`77560c8c`](https://github.com/NixOS/nixpkgs/commit/77560c8c718fac665f8590a2813f12eb8a601f4a) | `` subfinder: 2.5.7 -> 2.5.8 ``                                                              |
| [`aa2cbfd0`](https://github.com/NixOS/nixpkgs/commit/aa2cbfd02dabc15d8c1f0e8a908e07e159901972) | `` newsflash: 2.2.4 -> 2.3.0 ``                                                              |
| [`d0bfc907`](https://github.com/NixOS/nixpkgs/commit/d0bfc9077d56ec18472d8899ef3cb5b536228143) | `` ungoogled-chromium: 112.0.5615.165 -> 113.0.5672.64 ``                                    |
| [`017293da`](https://github.com/NixOS/nixpkgs/commit/017293daa821d9a6ac7c23a17714f1d28f02d7e4) | `` python311Packages.sqlmap: 1.7.4 -> 1.7.5 ``                                               |
| [`2819752a`](https://github.com/NixOS/nixpkgs/commit/2819752ac3aa1f3fe1afb24fb529677dab45c068) | `` spek: 0.8.4 -> 0.8.5 ``                                                                   |
| [`a9388b8a`](https://github.com/NixOS/nixpkgs/commit/a9388b8af4ba1e49b05e2df9ce68b996baf45bd9) | `` python311Packages.webauthn: 1.7.2 -> 1.8.1 ``                                             |
| [`22314cf0`](https://github.com/NixOS/nixpkgs/commit/22314cf04bd57dfda59203ef6f09c240b9395f9c) | `` openfortivpn: 1.20.1 -> 1.20.2 ``                                                         |
| [`922a202f`](https://github.com/NixOS/nixpkgs/commit/922a202fb6e0cb49caef34d1304d47cde1b77a5a) | `` osv-scanner: 1.3.1 -> 1.3.2 ``                                                            |
| [`0d108189`](https://github.com/NixOS/nixpkgs/commit/0d108189c7824efaddb5f7c4399424b269dcf30f) | `` vscode/generic: restore hack conditional on version ``                                    |
| [`e0d99308`](https://github.com/NixOS/nixpkgs/commit/e0d993080395ce784dff6072d3652cbee4461e65) | `` vscode: 1.77.3 -> 1.78.0 ``                                                               |
| [`c35f64ef`](https://github.com/NixOS/nixpkgs/commit/c35f64efbe62f33058691e4d2cfb31079f9b068e) | `` checkov: 2.3.216 -> 2.3.223 ``                                                            |
| [`6cf957a1`](https://github.com/NixOS/nixpkgs/commit/6cf957a10c7b2308ea5484cb8af42d611a64bff3) | `` python311Packages.pytrafikverket: 0.2.3 -> 0.3.1 ``                                       |
| [`70555500`](https://github.com/NixOS/nixpkgs/commit/705555006e2e1608024e7b4603c6b01c3df27402) | `` python311Packages.python-roborock: 0.10.0 -> 0.11.0 ``                                    |
| [`db77b19d`](https://github.com/NixOS/nixpkgs/commit/db77b19d762f318c7e9e08e172970f3426ba0583) | `` python311Packages.onvif-zeep-async: 1.3.1 -> 2.1.0 ``                                     |
| [`3ba33c98`](https://github.com/NixOS/nixpkgs/commit/3ba33c98f5dea269a0425e7223aade1bcf2a79f2) | `` python311Packages.nibe: 2.1.4 -> 2.2.0 ``                                                 |
| [`0139df51`](https://github.com/NixOS/nixpkgs/commit/0139df51a129126adbb3d77630390f1b065c376b) | `` python311Packages.msgspec: 0.14.0 -> 0.14.2 ``                                            |
| [`f587113e`](https://github.com/NixOS/nixpkgs/commit/f587113e89243099428cde1873ba9d2eee735b3a) | `` python311Packages.bthome-ble: 2.10.1 -> 2.11.0 ``                                         |
| [`2a6ff46c`](https://github.com/NixOS/nixpkgs/commit/2a6ff46ca2a227bf7e757b5e122810cc048b5061) | `` nuclei: 2.9.2 -> 2.9.3 ``                                                                 |
| [`62b0017f`](https://github.com/NixOS/nixpkgs/commit/62b0017f8675d2407979260f78a27595572bbce9) | `` envoy: mark with `knownVulnerabilities` ``                                                |
| [`c9720580`](https://github.com/NixOS/nixpkgs/commit/c97205806d6191b0ab4d27a63232f9a39d9d1b34) | `` grafx2: 2.4.2035 -> 2.8.3091 ``                                                           |
| [`578d5e94`](https://github.com/NixOS/nixpkgs/commit/578d5e941d5311ca50c99edbb52162840bf96cfb) | `` tclx: 8.4.1 -> 8.6.1 ``                                                                   |
| [`96c1b380`](https://github.com/NixOS/nixpkgs/commit/96c1b380e28d7377d8b99f898ebf4ec43744892d) | `` tclx: add fgaz to maintainers ``                                                          |
| [`8dc6ea5d`](https://github.com/NixOS/nixpkgs/commit/8dc6ea5d4298c0753aaf78483e3f83907f9dbc87) | `` python311Packages.aionotion: 2023.04.2 -> 2023.05.0 ``                                    |
| [`f4ca1bde`](https://github.com/NixOS/nixpkgs/commit/f4ca1bde6e596f01bc63e5178f6a4349bfad9be8) | `` python311Packages.bluetooth-auto-recovery: 1.1.1 -> 1.1.2 ``                              |
| [`b12e7df7`](https://github.com/NixOS/nixpkgs/commit/b12e7df751e845ca082576db2037180e1a97ee2c) | `` jumpy: 0.6.1 -> 0.7.0 ``                                                                  |
| [`774fc98e`](https://github.com/NixOS/nixpkgs/commit/774fc98ec6aa2ceb59cac1a4c19d152f459e3306) | `` python311Packages.pyrevolve:  add changelog to meta ``                                    |
| [`9680729a`](https://github.com/NixOS/nixpkgs/commit/9680729a53114fb3e3ea665edc9f97972dd08f94) | `` vimPlugins.vim-clap: 0.42 -> 0.43 ``                                                      |
| [`24852fbb`](https://github.com/NixOS/nixpkgs/commit/24852fbbb44199739eef95de43816fdbee4089dd) | `` typeshare: 1.5.0 -> 1.5.1 ``                                                              |
| [`bfe287be`](https://github.com/NixOS/nixpkgs/commit/bfe287be95f816723baf9d5c883782fa3b38fe05) | `` python311Packages.pyrevolve: 2.2 -> 2.2.2 ``                                              |
| [`fc3de20c`](https://github.com/NixOS/nixpkgs/commit/fc3de20c748defdeef471209cf303ecf414a1e81) | `` cargo-nextest: 0.9.51 -> 0.9.52 ``                                                        |
| [`0e3cb3fc`](https://github.com/NixOS/nixpkgs/commit/0e3cb3fcea101aa193847048a0e337ccc91161b9) | `` shellhub-agent: 0.11.8 -> 0.12.0 ``                                                       |
| [`c7d8c3a0`](https://github.com/NixOS/nixpkgs/commit/c7d8c3a02b623f8cdde01a2568f80eff83647b6d) | `` github-runner: drop leaveDotGit to not break checksums ``                                 |
| [`39afca1d`](https://github.com/NixOS/nixpkgs/commit/39afca1d80f3291fecb28f382de7a24d33b0f44b) | `` esphome: 2023.4.3 -> 2023.4.4 ``                                                          |
| [`fb36a1da`](https://github.com/NixOS/nixpkgs/commit/fb36a1da5609fde4ff07f94fa75619a723089922) | `` zsh-powerlevel10k: 1.17.0 -> 1.18.0 ``                                                    |
| [`3d118da4`](https://github.com/NixOS/nixpkgs/commit/3d118da4417891c8ac64d8e6dcbc9da3ade8eb80) | `` git-stack: 0.10.15 -> 0.10.16 ``                                                          |
| [`9db09bd7`](https://github.com/NixOS/nixpkgs/commit/9db09bd760312ac76e24d7ee485b77684b842b6d) | `` gh-dash: 3.7.7 -> 3.7.8 ``                                                                |
| [`9307a0f3`](https://github.com/NixOS/nixpkgs/commit/9307a0f393f8299021095eebe48e19a4ecacaea4) | `` uncover: 1.0.3 -> 1.0.4 ``                                                                |
| [`76abab80`](https://github.com/NixOS/nixpkgs/commit/76abab80cd63696e2de495d5cb6b3be3ac71f2d9) | `` dagger: 0.4.2 -> 0.5.1 ``                                                                 |
| [`e4474334`](https://github.com/NixOS/nixpkgs/commit/e4474334415ac41efb5fda33d4cc8f312397ef05) | `` rivalcfg: generate udev dynamically ``                                                    |
| [`a7676539`](https://github.com/NixOS/nixpkgs/commit/a7676539f5443ba8ee49cc6907f0000bec303523) | `` rivalcfg: init at 4.8.0 ``                                                                |
| [`c5bf4b91`](https://github.com/NixOS/nixpkgs/commit/c5bf4b91e8ed2772533fe3c704e5936cfbfad645) | `` davinci-resolve: override appimage-run to use buildFHSEnvChroot ``                        |
| [`c13aaba5`](https://github.com/NixOS/nixpkgs/commit/c13aaba583fa5253d343468c50a4734c712362f7) | `` ldtk: 1.3.0 -> 1.3.2 ``                                                                   |
| [`949373ca`](https://github.com/NixOS/nixpkgs/commit/949373caa270d7ae787fb8595959348730e5b436) | `` google-guest-oslogin: 20230406.02 -> 20230502.00 ``                                       |
| [`5eccb878`](https://github.com/NixOS/nixpkgs/commit/5eccb8782dbcf1f3cd36caa52e27c8592b6da29a) | `` grpc_cli: 1.54.0 -> 1.54.1 ``                                                             |
| [`2c55bef5`](https://github.com/NixOS/nixpkgs/commit/2c55bef565acef427a299bb4beadc7574f4de1e6) | `` sublime4-dev: 4147 → 4149 ``                                                              |
| [`f66901ff`](https://github.com/NixOS/nixpkgs/commit/f66901ff23f23d45b240bae2395627ded4e20f42) | `` faiss.tests.pytest: disable a failing float-vs-double test ``                             |
| [`eaf8bba9`](https://github.com/NixOS/nixpkgs/commit/eaf8bba9f8e21cc39aab628abb0f3dcc65f98c7e) | `` cglm: 0.8.9 -> 0.9.0 ``                                                                   |
| [`7dc54136`](https://github.com/NixOS/nixpkgs/commit/7dc5413649be700c1ce08781df5106abc0b2f18d) | `` python310Packages.safe-pysha3: 1.0.3 -> 1.0.4 ``                                          |
| [`d1464797`](https://github.com/NixOS/nixpkgs/commit/d14647974ef3855952ca2a30206cab765cabc8cb) | `` coreth: 0.12.0 -> 0.12.1 ``                                                               |
| [`f7011145`](https://github.com/NixOS/nixpkgs/commit/f701114548ba22bdf03f465dcc25649d8bd0f5c4) | `` hexdiff: init at unstable-2018-01-24 ``                                                   |
| [`b6b2079f`](https://github.com/NixOS/nixpkgs/commit/b6b2079faa9480711c58059169919227d328fad3) | `` exoscale-cli: 1.67.0 -> 1.68.0 ``                                                         |
| [`25627185`](https://github.com/NixOS/nixpkgs/commit/2562718511cd8fa309f020529f34081cfa334385) | `` python3Packages.pyowm: fix build ``                                                       |
| [`0f4252aa`](https://github.com/NixOS/nixpkgs/commit/0f4252aa0aedd008ebb0845280eaf07e913f85e7) | `` tone: fix build, update description, restrict the platform to "x86_64-linux" (#229434) `` |
| [`286e0ac8`](https://github.com/NixOS/nixpkgs/commit/286e0ac8dfe4e135cc71420a1b30b9ff2b5e6e74) | `` lobster: 2023.4 -> 2023.5 ``                                                              |
| [`af599f5b`](https://github.com/NixOS/nixpkgs/commit/af599f5b8ef0a091f26e4f54130d1b703dee3df2) | `` paperless-ngx: 1.14.2 -> 1.14.4 ``                                                        |
| [`5a6fca4e`](https://github.com/NixOS/nixpkgs/commit/5a6fca4ed48abf04b976f1f2c2354f7359effcc3) | `` teams-for-linux: 1.0.65 -> 1.0.83 ``                                                      |
| [`fcbb2f74`](https://github.com/NixOS/nixpkgs/commit/fcbb2f74fe1c892ca3d8cd8d7f55b1e9d5493fb5) | `` maintainers: add philclifford ``                                                          |
| [`96726133`](https://github.com/NixOS/nixpkgs/commit/96726133820f5975e5c8c0bb4727e8a1527c2aca) | `` cargo-ui: 0.3.2 -> 0.3.3 ``                                                               |
| [`2b615ebf`](https://github.com/NixOS/nixpkgs/commit/2b615ebf84def4b295484bc64dc225226c28279c) | `` maintainers: update tilpner ``                                                            |
| [`ad29cf7d`](https://github.com/NixOS/nixpkgs/commit/ad29cf7d850ce80b99dcdec76a3d7a9adbe449ee) | `` python311Packages.pynisher: update homepage ``                                            |
| [`a70c7aba`](https://github.com/NixOS/nixpkgs/commit/a70c7aba366aea14866c4114af7d29fd8eaa8b1e) | `` nixos/networkd: Fix typo in usage sectionBridgeVLAN ``                                    |