### PR TITLE
chore(flake/lanzaboote): `adc01887` -> `ae49611b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -253,11 +253,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1682977736,
-        "narHash": "sha256-dYRnLAVKmzm822fq503foGiTS3xmOZwdmNTs7eLTw3Y=",
+        "lastModified": 1683315170,
+        "narHash": "sha256-v4neNXXjOGingMw76fnXbYbxOK4pZfGA2r/O+cn5btY=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "adc01887d9db2c3e354bbe86d7f46c4661357c27",
+        "rev": "ae49611bd6d1cbfc4f5aaa6352c25324b336542a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                        |
| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`a5372db9`](https://github.com/nix-community/lanzaboote/commit/a5372db91fb13d98b2d32bc15d2ad303f58885a6) | `` hotfix(stub): rust_version -> rust-version in Cargo.toml `` |
| [`9dd9116b`](https://github.com/nix-community/lanzaboote/commit/9dd9116b1ec88f834483de6b95f499dee25f0fea) | `` stub: export boot loader interface efivars ``               |