### PR TITLE
chore(flake/home-manager): `669669fc` -> `a834ddf8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683276747,
-        "narHash": "sha256-T3st1VBg3wmhHyBQb0z12sTSGsQgiu3mxkS61nLO8Xs=",
+        "lastModified": 1683451573,
+        "narHash": "sha256-4PPXy8wn9Zd4xsxPasTjI8VUr3F0U6pLzGcvQ7eiJ/8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "669669fcb403e3137dfe599bbcc26e60502c3543",
+        "rev": "a834ddf88cb2eb4f77b7c0a2d6e2e8e0fb37c4e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`a834ddf8`](https://github.com/nix-community/home-manager/commit/a834ddf88cb2eb4f77b7c0a2d6e2e8e0fb37c4e3) | `` flake: set source path in home-manager tool `` |