### PR TITLE
chore(flake/home-manager): `a834ddf8` -> `990b82ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683451573,
-        "narHash": "sha256-4PPXy8wn9Zd4xsxPasTjI8VUr3F0U6pLzGcvQ7eiJ/8=",
+        "lastModified": 1683456233,
+        "narHash": "sha256-BUclM2YmS0rpkSlHSvJ+5aWTu+OcjFiI4iIMRt9qCuI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a834ddf88cb2eb4f77b7c0a2d6e2e8e0fb37c4e3",
+        "rev": "990b82ecd31f6372bc4c3f39a9171961bc370a22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`0b4ec666`](https://github.com/nix-community/home-manager/commit/0b4ec66640ad5a1aa912a2ae7643f9756e71b4a7) | `` dconf: Warn about strict typing of options ``                    |
| [`ea29b1a8`](https://github.com/nix-community/home-manager/commit/ea29b1a8d1e2717581f4db852ad6647fc03bd00d) | `` docs: Add GVariant cross-references ``                           |
| [`13d666dd`](https://github.com/nix-community/home-manager/commit/13d666dd68d18dd20760662b78e885559f90991d) | `` docs: Mention GVariant format strings ``                         |
| [`a0ddb8af`](https://github.com/nix-community/home-manager/commit/a0ddb8af40bee08737170b167e04ab608215d8de) | `` docs: Mention GVariant auto-coercion at the top ``               |
| [`cfa5c286`](https://github.com/nix-community/home-manager/commit/cfa5c2869b535e5e83dac6b04745f673c591e0d2) | `` docs: GVariant dictionaries are already supported ``             |
| [`81d5b220`](https://github.com/nix-community/home-manager/commit/81d5b220cde5860b529e87fdc3aae55718c24030) | `` docs: Fix broken GVariant docs link ``                           |
| [`3e906060`](https://github.com/nix-community/home-manager/commit/3e906060a88a6929c40b7170e73e7adf9e84a8a8) | `` docs: Add inline anchors for direct linking to GVariant types `` |
| [`c7529068`](https://github.com/nix-community/home-manager/commit/c7529068002983f4a0489ec625fe51dd1d4ec0c5) | `` flake.lock: Update ``                                            |