### PR TITLE
chore(flake/home-manager): `de8ba413` -> `78ceec68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683492229,
-        "narHash": "sha256-vJgBn/oSW11ujPg+ai92a8DWMssXBpl+/ZeLMS3bDJQ=",
+        "lastModified": 1683496796,
+        "narHash": "sha256-MgC6q2tEFM0uPB/kt+MYQSrnuLnTTvIFziZSDJCloQ4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "de8ba413c578b68ef602c4f4c5909d9636a5bf92",
+        "rev": "78ceec68f29ed56d6118617e9f0f588bf164067f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`78ceec68`](https://github.com/nix-community/home-manager/commit/78ceec68f29ed56d6118617e9f0f588bf164067f) | `` xsession: cleanup systemd variables (#3636) ``        |
| [`e34fbe18`](https://github.com/nix-community/home-manager/commit/e34fbe18011483d1aac6f44cd2f03c0c89196812) | `` pass-secret-service: Add dbus file, assert (#3953) `` |
| [`d12ca778`](https://github.com/nix-community/home-manager/commit/d12ca77844a08b8b44edae0d66be0922544c2172) | `` atuin: Replace dead link in documentation (#3962) ``  |