### PR TITLE
chore(flake/nix-index-database): `7b9e09d4` -> `54049e3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -274,11 +274,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683440419,
-        "narHash": "sha256-hhKqikDwHzrl8pdB482Jy9Ld+I+CpiYwIncEItxZVGA=",
+        "lastModified": 1683560204,
+        "narHash": "sha256-YidI1lVXVtz4fYCsQkapUx/76WKs682rZybztLOt9S0=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "7b9e09d4a10d03f703ffa2e25806f0c81b4a7a23",
+        "rev": "54049e3d602b4525dabca5d61865adf529377774",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                         |
| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`0b380642`](https://github.com/Mic92/nix-index-database/commit/0b3806422d55fc9fdd20b1c19e6065c717dbdec9) | `` fix the comma package in nixos-module.nix `` |