### PR TITLE
chore(flake/darwin): `9520a6e4` -> `252541bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683719734,
-        "narHash": "sha256-+PVRapPi3KK4dL93zHr+BZaWES/GseroTetW2Ua1Bls=",
+        "lastModified": 1683754942,
+        "narHash": "sha256-L+Bj8EL4XLmODRIuOkk9sI6FDECVzK+C8jeZFv7q6eY=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "9520a6e48393d4bfefe1cd47b726b7c10a3b9b6c",
+        "rev": "252541bd05a7f55f3704a3d014ad1badc1e3360d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                        |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
| [`fa97d795`](https://github.com/LnL7/nix-darwin/commit/fa97d795677432ceea46df9a6f609efbe3dbe90c) | `` nix: Fix registry extra attrs not being applied ``                          |
| [`2303eed5`](https://github.com/LnL7/nix-darwin/commit/2303eed571946c367d134dd39d017e3bb3517241) | `` feat(screensaver): add support of askForPassword and askForPasswordDelay `` |
| [`ca62d93c`](https://github.com/LnL7/nix-darwin/commit/ca62d93c6c6bf89891aa24071ad312fe923801f1) | `` Only use `--force` for patches applied in reverse ``                        |
| [`42e0e4f3`](https://github.com/LnL7/nix-darwin/commit/42e0e4f3b4aadcae627f65a395600ea17fd6f9f0) | `` Add `--force` to all patch invocations ``                                   |
| [`e62b83a9`](https://github.com/LnL7/nix-darwin/commit/e62b83a934ea44d6da145cfe02b2d401d95d174f) | `` Fix system.patches ``                                                       |