### PR TITLE
chore(flake/home-manager): `fa720861` -> `2f6a917a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683796878,
-        "narHash": "sha256-8y2RossxrzY/RthUj8vikfwQDp25XkWNi0lw2oEYVbc=",
+        "lastModified": 1683806669,
+        "narHash": "sha256-FVHgKAZqiUI579DCBJ4pigkUKBmft/1KuEm6/4rx5zI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fa720861b5b68536434360aa0ccf0a5fb9060a73",
+        "rev": "2f6a917ade976325093dc60abe17cc72bdf3b76e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                           |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`2f6a917a`](https://github.com/nix-community/home-manager/commit/2f6a917ade976325093dc60abe17cc72bdf3b76e) | `` i3-sway: fix indentation of `bar` blocks (#3978) ``                            |
| [`d9917765`](https://github.com/nix-community/home-manager/commit/d991776527b641b029a5916597a1261e2f3b4235) | `` taskwarrior: add package option (#3768) ``                                     |
| [`622fa737`](https://github.com/nix-community/home-manager/commit/622fa73725caa1f11ae184e70b406b207875ef9d) | `` beets: add mpdIntegration (#3755) ``                                           |
| [`f714b170`](https://github.com/nix-community/home-manager/commit/f714b170315770f5cb34107b17f2925f0aed7dd4) | `` emacs: extend startWithUserSession to start after graphical session (#3010) `` |