### PR TITLE
chore(flake/agenix): `2994d002` -> `92197270`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,16 +5,17 @@
         "darwin": [
           "darwin"
         ],
+        "home-manager": "home-manager",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1682101079,
-        "narHash": "sha256-MdAhtjrLKnk2uiqun1FWABbKpLH090oeqCSiWemtuck=",
+        "lastModified": 1683866323,
+        "narHash": "sha256-M2bEuh2jr0Ec13GnP5f8unD8q0AcPt2fHSUynOZJ8No=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "2994d002dcff5353ca1ac48ec584c7f6589fe447",
+        "rev": "92197270a1eedd142a4aff853e4cc6d1e838c22f",
         "type": "github"
       },
       "original": {
@@ -203,6 +204,27 @@
     "home-manager": {
       "inputs": {
         "nixpkgs": [
+          "agenix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1682203081,
+        "narHash": "sha256-kRL4ejWDhi0zph/FpebFYhzqlOBrk0Pl3dzGEKSAlEw=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "32d3e39c491e2f91152c84f8ad8b003420eab0a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_2": {
+      "inputs": {
+        "nixpkgs": [
           "nixpkgs"
         ]
       },
@@ -369,7 +391,7 @@
         "deploy-rs": "deploy-rs",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "home-manager": "home-manager",
+        "home-manager": "home-manager_2",
         "impermanence": "impermanence",
         "lanzaboote": "lanzaboote",
         "nix-index-database": "nix-index-database",


### PR DESCRIPTION
| Commit                                                                                         | Message                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`6b4ff3d1`](https://github.com/ryantm/agenix/commit/6b4ff3d19165b2bbf8f3447ceaa431fb22311037) | `` Check darwin home-manager test in CI ``     |
| [`50743bd1`](https://github.com/ryantm/agenix/commit/50743bd1178c1afc426ee914686d1437eec8c9d2) | `` Add darwin tests for home-manager module `` |
| [`19bf5a20`](https://github.com/ryantm/agenix/commit/19bf5a20d835145e5f3fc8d61672eefee4c33450) | `` Clean-up Darwin integration test ``         |
| [`3fbc22fe`](https://github.com/ryantm/agenix/commit/3fbc22fe43673401c37f862057d045ec90ad5670) | `` Install user keys in Darwin tests ``        |
| [`0155c571`](https://github.com/ryantm/agenix/commit/0155c5710e8527f19ec61dbbd076495f3f920868) | `` Test home-manager module ``                 |
| [`1f43d94d`](https://github.com/ryantm/agenix/commit/1f43d94d52a750270202f22d50598e6234aecf86) | `` Add home-manager input ``                   |
| [`9274b828`](https://github.com/ryantm/agenix/commit/9274b82816ae4450ff13f634113e99a83d1bd4b1) | `` Add home-manager module ``                  |