### PR TITLE
chore(flake/nixos-hardware): `fb131794` -> `81cd8867`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1683836901,
-        "narHash": "sha256-ecv+VfhGmeQOBS6j9SptM0aKS25sMIEh+QbaYI4pyI0=",
+        "lastModified": 1683965003,
+        "narHash": "sha256-DrzSdOnLv/yFBvS2FqmwBA2xIbN/Lny/WlxHyoLR9zE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "fb1317948339713afa82a775a8274a91334f6182",
+        "rev": "81cd886719e10d4822b2a6caa96e95d56cc915ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                       |
| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`e39036d5`](https://github.com/NixOS/nixos-hardware/commit/e39036d599ad51d6a3f77f7e96bfa630f4991410) | `` feat: Add focus m2 gen1 `` |