### PR TITLE
chore(flake/home-manager): `eec22729` -> `93849977`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683929392,
-        "narHash": "sha256-qJddrb/bgS58AXAv25iv5xJ+69G5g7FAYCWec1lLnW0=",
+        "lastModified": 1683960530,
+        "narHash": "sha256-hasZQSnM0nZkt8wlc0qKZIJ0Vn2EuJo8cOhxhLPkQH4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "eec22729990ddf53d1e45e74624ddf667cdbe11b",
+        "rev": "938499771727f2a53a19eb178f16fc42ff53a9f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`93849977`](https://github.com/nix-community/home-manager/commit/938499771727f2a53a19eb178f16fc42ff53a9f8) | `` Translate using Weblate (Japanese) `` |
| [`130abb8d`](https://github.com/nix-community/home-manager/commit/130abb8dbdf441be2dbd3c2d42398faeff5d89b1) | `` Translate using Weblate (German) ``   |