### PR TITLE
chore(flake/home-manager): `93849977` -> `e0026e16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683960530,
-        "narHash": "sha256-hasZQSnM0nZkt8wlc0qKZIJ0Vn2EuJo8cOhxhLPkQH4=",
+        "lastModified": 1683986074,
+        "narHash": "sha256-+sU3057hb7sy3NHrOX2uLrBY6wVz8TcNWyciGwKcqe0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "938499771727f2a53a19eb178f16fc42ff53a9f8",
+        "rev": "e0026e16a5beff80f641e4edca318e654baa5a9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`e0026e16`](https://github.com/nix-community/home-manager/commit/e0026e16a5beff80f641e4edca318e654baa5a9b) | `` fuzzel: add module `` |