### PR TITLE
chore(flake/impermanence): `df1692e2` -> `ec1a8e70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -244,11 +244,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1682268411,
-        "narHash": "sha256-ICDKQ7tournRVtfM8C2II0qHiOZOH1b3dXVOCsgr11o=",
+        "lastModified": 1684144492,
+        "narHash": "sha256-5TBG9kZGdKrZGHdyjLA04ODSzhx1Bx/vwMxfRgWF+JU=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "df1692e2d9f1efc4300b1ea9201831730e0b817d",
+        "rev": "ec1a8e70d61261f9ada30f4e450ea7230d9efb62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`5a39142b`](https://github.com/nix-community/impermanence/commit/5a39142bbbb87e928a195b996dc134e7bfe2471a) | `` feat(nixos): allow persistant locations to be disabled `` |