### PR TITLE
chore(flake/darwin): `252541bd` -> `0dbf1c2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683754942,
-        "narHash": "sha256-L+Bj8EL4XLmODRIuOkk9sI6FDECVzK+C8jeZFv7q6eY=",
+        "lastModified": 1684148371,
+        "narHash": "sha256-CEVaArsziqantqU418XXruNDjPZN/HC3x1rqr2D4g+o=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "252541bd05a7f55f3704a3d014ad1badc1e3360d",
+        "rev": "0dbf1c2fb1a5a0372a324eff1ba44f9da66febd2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                 |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`3d22883c`](https://github.com/LnL7/nix-darwin/commit/3d22883cdb4226306be7583f5513b3ca23a72e24) | `` add tests ``                                         |
| [`f781cb0a`](https://github.com/LnL7/nix-darwin/commit/f781cb0ac5ea2daa5183b8df8f4de4ef0747f440) | `` give credits ``                                      |
| [`4094dbcc`](https://github.com/LnL7/nix-darwin/commit/4094dbccde0d00fd062d365b8c79526711a6bc95) | `` newline eof for authorized-keys conf ``              |
| [`ab2e1615`](https://github.com/LnL7/nix-darwin/commit/ab2e16159f5a04fd962f3d7de8dc4901d048db17) | `` authkeys path in sshd_config ``                      |
| [`ccaa9428`](https://github.com/LnL7/nix-darwin/commit/ccaa942888f53404b56d979cb3a0a5c9f18a1faa) | `` don't check knownSha256 for authorized_keys files `` |
| [`ecb5840f`](https://github.com/LnL7/nix-darwin/commit/ecb5840f6bc2cdb453bbc0dbbd8f63ec441808d6) | `` enable copy ``                                       |
| [`64a15676`](https://github.com/LnL7/nix-darwin/commit/64a15676ac5b7cb8990d683f19ad78ac9a6bc4ef) | `` support authorized_keys for users ``                 |