### PR TITLE
chore(flake/agenix): `92197270` -> `db5637d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -11,11 +11,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683866323,
-        "narHash": "sha256-M2bEuh2jr0Ec13GnP5f8unD8q0AcPt2fHSUynOZJ8No=",
+        "lastModified": 1684153753,
+        "narHash": "sha256-PVbWt3qrjYAK+T5KplFcO+h7aZWfEj1UtyoKlvcDxh0=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "92197270a1eedd142a4aff853e4cc6d1e838c22f",
+        "rev": "db5637d10f797bb251b94ef9040b237f4702cde3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                      |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`72205a86`](https://github.com/ryantm/agenix/commit/72205a86cafc06df6a11e1ae9dcef71374cd2cf5) | `` Add test for custom secret paths for HM ``                |
| [`758cdc98`](https://github.com/ryantm/agenix/commit/758cdc98f49ba72f4e941933575db8a70f24cfe3) | `` Disable shellcheck warning about impossible comparison `` |