### PR TITLE
chore(flake/pre-commit-hooks): `48c59cec` -> `96eabec5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -370,11 +370,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1684176146,
-        "narHash": "sha256-jZcgFyyBvlP0MHoBI1X8A0liVMb/trS2fIDG00FmQNQ=",
+        "lastModified": 1684195081,
+        "narHash": "sha256-IKnQUSBhQTChFERxW2AzuauVpY1HRgeVzAjNMAA4B6I=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "48c59cec0b8ca341cca96f759cb066333309c1fe",
+        "rev": "96eabec58248ed8f4b0ad59e7ce9398018684fdc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message               |
| ------------------------------------------------------------------------------------------------------------ | --------------------- |
| [`00d88811`](https://github.com/cachix/pre-commit-hooks.nix/commit/00d88811c82fe44533363d1ac3d94c8ee2b2a479) | `` Fixup hook docs `` |