### PR TITLE
chore(flake/nixpkgs): `0470f36b` -> `17a68959`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -325,11 +325,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684049129,
-        "narHash": "sha256-7WB9LpnPNAS8oI7hMoHeKLNhRX7k3CI9uWBRSfmOCCE=",
+        "lastModified": 1684139381,
+        "narHash": "sha256-YPLMeYE+UzxxP0qbkBzv3RBDvyGR5I4d7v2n8dI3+fY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0470f36b02ef01d4f43c641bbf07020bcab71bf1",
+        "rev": "17a689596b72d1906883484838eb1aaf51ab8001",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`70c1240b`](https://github.com/NixOS/nixpkgs/commit/70c1240b6fb88a51f06942b00dc5092bc13fd35c) | `` python3Packages.cocotb: fix failing build (#231184) ``                         |
| [`25f3323d`](https://github.com/NixOS/nixpkgs/commit/25f3323d60271ac9b668757322c47f96aa7ca726) | `` nixos/etcd: Fix mapping of clientCertAuth option ``                            |
| [`cedcd620`](https://github.com/NixOS/nixpkgs/commit/cedcd620c50b0cca699373cb4d9186670e8b4455) | `` python311Packages.azure-mgmt-iothub: disable on unsupported Python releases `` |
| [`6d48cf61`](https://github.com/NixOS/nixpkgs/commit/6d48cf61f8a7ebcd26ddeb63ff63269b4b04a29a) | `` phpunit: 10.1.2 -> 10.1.3 ``                                                   |
| [`4461bbcc`](https://github.com/NixOS/nixpkgs/commit/4461bbccec34e661daf3c6e08418f041664a599d) | `` python311Packages.azure-mgmt-iothub: 2.3.0 -> 2.4.0 ``                         |
| [`8abdc92c`](https://github.com/NixOS/nixpkgs/commit/8abdc92c8c0b44e1ea4a4e58cd15448473fe9dd5) | `` colmena: 0.3.2 -> 0.4.0 ``                                                     |
| [`b05ef018`](https://github.com/NixOS/nixpkgs/commit/b05ef018ff27c71304cdf1d19b9e7a1103f3a233) | `` craftos-pc: fix broken hashes ``                                               |
| [`eae5f836`](https://github.com/NixOS/nixpkgs/commit/eae5f83649645c1db5fd0474b95ab709aabed5fd) | `` chipsec: mark broken on hardened kernels older than 5.4 ``                     |
| [`fd64f69c`](https://github.com/NixOS/nixpkgs/commit/fd64f69c731e77d8b645afc4e8dbec74ba207bf9) | `` mympd: 10.3.1 -> 10.3.2 ``                                                     |
| [`8f62edb0`](https://github.com/NixOS/nixpkgs/commit/8f62edb01f32b9410451271d2492e1c6f9b2088a) | `` step-cli: 0.24.3 -> 0.24.4 ``                                                  |
| [`32e78a7a`](https://github.com/NixOS/nixpkgs/commit/32e78a7a827575639273b757dce10b0ecfd27a2d) | `` Update pkgs/applications/misc/koreader/default.nix ``                          |
| [`b4c19e85`](https://github.com/NixOS/nixpkgs/commit/b4c19e85483dea24e59c0f05f57b15fa59ee70ad) | `` python310Packages.skrl: 0.10.1 -> 0.10.2; unbreak ``                           |
| [`8df7cada`](https://github.com/NixOS/nixpkgs/commit/8df7cadadc5716a95f39ad5199eec476b80a81a2) | `` git-mit: init at 5.12.146 ``                                                   |
| [`7edb72db`](https://github.com/NixOS/nixpkgs/commit/7edb72db10be8a47a818c3a808fe2926a767ed29) | `` truvari: add patches to fix `truvari anno` ``                                  |
| [`40136a1f`](https://github.com/NixOS/nixpkgs/commit/40136a1f7f3c6f2484b5455f911c7c35743b7df2) | `` nixos/birdwatcher: init ``                                                     |
| [`55bd75e9`](https://github.com/NixOS/nixpkgs/commit/55bd75e98fdb899eb9a9e5929efb2c9097c20d7b) | `` birdwatcher: init at 2.2.4 ``                                                  |
| [`8ed86700`](https://github.com/NixOS/nixpkgs/commit/8ed86700a2d33243b390b8ed14b8d3c8457c0308) | `` nixos/alice-lg: init ``                                                        |
| [`5435eaaa`](https://github.com/NixOS/nixpkgs/commit/5435eaaa4d34d941c9493da7a3918d4925162469) | `` nixos/rshim: init ``                                                           |
| [`f0284ab4`](https://github.com/NixOS/nixpkgs/commit/f0284ab4d84681db8cbc92445a2b69626713e06e) | `` topydo: clean up ``                                                            |
| [`3d95de61`](https://github.com/NixOS/nixpkgs/commit/3d95de61994d2cc814feee8a7a88652194afd985) | `` python3Packages.retworkx: remove ``                                            |
| [`4e24a1c1`](https://github.com/NixOS/nixpkgs/commit/4e24a1c1d01d254bd1414b6f3b73e18da3e1cc0b) | `` python3Packages.pyp: repair ``                                                 |
| [`350603ae`](https://github.com/NixOS/nixpkgs/commit/350603ae67615d45d8b59a827db34038e412e8f1) | `` coercer: fix build on darwin ``                                                |
| [`eaa4b4c1`](https://github.com/NixOS/nixpkgs/commit/eaa4b4c1540bc87b5d3a02b9605e3875842b7620) | `` python310Packages.python-roborock: 0.17.3 -> 0.17.6 ``                         |
| [`345e8896`](https://github.com/NixOS/nixpkgs/commit/345e8896adb22a44af8d7aefe2b4ed960e33ff22) | `` python310Packages.rns: 0.5.1 -> 0.5.2 ``                                       |
| [`0e60ea38`](https://github.com/NixOS/nixpkgs/commit/0e60ea38d85731058768cac1831dde160339a072) | `` python310Packages.sensor-state-data: 2.14.0 -> 2.15.1 ``                       |
| [`5544f243`](https://github.com/NixOS/nixpkgs/commit/5544f2430f2345e73d200ece069f5bd8bc4dbc30) | `` exploitdb: 2023-05-12 -> 2023-05-14 ``                                         |
| [`9bb523f5`](https://github.com/NixOS/nixpkgs/commit/9bb523f5c93538d45d26d768eaf2377c6388d3f4) | `` python310Packages.pyaussiebb: 0.0.16 -> 0.0.18 ``                              |
| [`94e69e30`](https://github.com/NixOS/nixpkgs/commit/94e69e30f2352bd14a9d2c68f9108d91c7a81e8c) | `` python310Packages.pydeps: 1.12.3 -> 1.12.4 ``                                  |
| [`e2f552cc`](https://github.com/NixOS/nixpkgs/commit/e2f552cccae71b964f745421815c9b46a7e0eb47) | `` python310Packages.pysml: 0.0.10 -> 0.0.11 ``                                   |
| [`7c38f9ce`](https://github.com/NixOS/nixpkgs/commit/7c38f9ce7c4ee07b7797699488d10dd6fca6b6d0) | `` python310Packages.dvc-data: 0.49.1 -> 0.50.0 ``                                |
| [`650d4029`](https://github.com/NixOS/nixpkgs/commit/650d40293d9987a58feadedabc70704d01df83d0) | `` python310Packages.atenpdu: 0.6.0 -> 0.6.1 ``                                   |
| [`9dcb2160`](https://github.com/NixOS/nixpkgs/commit/9dcb216045ea84bda1f3bc941b1687f4fee35c97) | `` python310Packages.cwl-upgrader: 1.2.6 -> 1.2.7 ``                              |
| [`37ea427c`](https://github.com/NixOS/nixpkgs/commit/37ea427cd829f51f95b7c2539eedc057204a5820) | `` python310Packages.findimports: 2.2.0 -> 2.3.0 ``                               |
| [`6a4caae7`](https://github.com/NixOS/nixpkgs/commit/6a4caae7ebe8841e4322fd735af31da804f53f85) | `` termbook: install shell completions ``                                         |
| [`9d8d1301`](https://github.com/NixOS/nixpkgs/commit/9d8d1301bac99a005770c0acc56c1a4e955559a3) | `` termbook: fix build ``                                                         |
| [`5cabe53d`](https://github.com/NixOS/nixpkgs/commit/5cabe53dfc8c89624b64f0f66c7c87efa9859e0b) | `` python310Packages.onvif-zeep-async: 3.1.3 -> 3.1.7 ``                          |
| [`1064eb90`](https://github.com/NixOS/nixpkgs/commit/1064eb90c603a96ceaa8ee71b20042e305aaae4d) | `` python310Packages.logging-journald: 0.6.4 -> 0.6.5 ``                          |
| [`1e84e403`](https://github.com/NixOS/nixpkgs/commit/1e84e403c7ca58489369ab5f0a56213f682c3c84) | `` python310Packages.guppy3: 3.1.2 -> 3.1.3 ``                                    |
| [`2b394ff6`](https://github.com/NixOS/nixpkgs/commit/2b394ff638b770eb15e9c0d0d28abed64ea144d6) | `` tickrs: fix build on darwin ``                                                 |
| [`b53cb861`](https://github.com/NixOS/nixpkgs/commit/b53cb8614489d51018339e55d09558eafad8d8bd) | `` python310Packages.yfinance: add missing input html5lib ``                      |
| [`5fc7480c`](https://github.com/NixOS/nixpkgs/commit/5fc7480c9424362651eb089b0a8ebddbe122364e) | `` topydo: apply patch to fix test ``                                             |
| [`74c5abae`](https://github.com/NixOS/nixpkgs/commit/74c5abae16e6d087fc205dddb041850381786373) | `` mpvScripts.{autocrop,autodeint}: add to all-packages.nix ``                    |
| [`47e8beba`](https://github.com/NixOS/nixpkgs/commit/47e8bebacd676c7c0fdd577b6a933b36db078e8b) | `` koreader: add support for aarch64-linux ``                                     |
| [`7320cd6f`](https://github.com/NixOS/nixpkgs/commit/7320cd6f0f2f453553ba8b98471bd2e4a745d325) | `` trashy: limit platforms to linux ``                                            |
| [`179ba02c`](https://github.com/NixOS/nixpkgs/commit/179ba02c2b93e6b9dc04c52234d0e428da4a3078) | `` nerdfix: 0.3.0 -> 0.3.1 ``                                                     |
| [`9c63dd37`](https://github.com/NixOS/nixpkgs/commit/9c63dd372dcf22705f1777c71f7f325afd6b4000) | `` cloud-init module: fix default settings (#231867) ``                           |
| [`f7a07504`](https://github.com/NixOS/nixpkgs/commit/f7a07504535cf5d9f24a3885649ef1a374dcad57) | `` heroic: remove leftover files ``                                               |
| [`e7300695`](https://github.com/NixOS/nixpkgs/commit/e730069542cbafd78758a4f44998bef4f610a1cf) | `` strace-analyzer: fix build on aarch64-linux ``                                 |
| [`f4922269`](https://github.com/NixOS/nixpkgs/commit/f4922269c557fdaa42367ef5acc213ac686e71b7) | `` docker-slim: update hash ``                                                    |
| [`e3d1294a`](https://github.com/NixOS/nixpkgs/commit/e3d1294a9fa1962ba511e86b33e7d1c9bffbc41a) | `` chipsec: add erdnaxe to maintainers ``                                         |
| [`1dd536c5`](https://github.com/NixOS/nixpkgs/commit/1dd536c54c896105b1e0c1d0661c91dd61fee63f) | `` chipsec: 1.8.1 -> 1.10.6 ``                                                    |
| [`86e11e59`](https://github.com/NixOS/nixpkgs/commit/86e11e5924c2f9ac7ed4e00b0bdfea6421836269) | `` kvdo: no longer broken on kernel 5.17+ ``                                      |
| [`343834d6`](https://github.com/NixOS/nixpkgs/commit/343834d6fd55eb470d9ce6c1dff3d5dbdf5bfc29) | `` kvdo: 8.2.0.2 -> 8.2.1.6 ``                                                    |
| [`c23d2709`](https://github.com/NixOS/nixpkgs/commit/c23d2709c1b16cce9e8bb7c3b47f5a35d4a232af) | `` python310Packages.intensity-normalization: unbreak ``                          |
| [`8e0b6612`](https://github.com/NixOS/nixpkgs/commit/8e0b66120d7fd29ebb707bf8d84c7a73d6a2932e) | `` kvdo: add missing kernel.moduleBuildDependencies ``                            |
| [`207731e3`](https://github.com/NixOS/nixpkgs/commit/207731e3e35bc0f62b3d1a270acc023566c612e1) | `` clisp: enable ffcall on Darwin ``                                              |
| [`9a48c439`](https://github.com/NixOS/nixpkgs/commit/9a48c43909ec15019d2f37609e44266d6e7383c6) | `` wabt: 1.0.32 -> 1.0.33 ``                                                      |
| [`fe940917`](https://github.com/NixOS/nixpkgs/commit/fe9409176b070bb177465993bbb5f2c21b2b392b) | `` joystickwake: 0.4 -> 0.4.1 ``                                                  |
| [`0849fd59`](https://github.com/NixOS/nixpkgs/commit/0849fd5947752858ad351d4a3cd0cb37068d4202) | `` motrix: 1.8.14 -> 1.8.19 ``                                                    |
| [`9d4e72cd`](https://github.com/NixOS/nixpkgs/commit/9d4e72cd73ee83c1a63beb71fecb5787d4450d3b) | `` clisp-tip: mark Darwin as broken instead of restricting platforms ``           |
| [`afd2bbf2`](https://github.com/NixOS/nixpkgs/commit/afd2bbf22c36da54feaef33331eb3073ef69d150) | `` clisp: remove broken status on Darwin ``                                       |
| [`7f64e404`](https://github.com/NixOS/nixpkgs/commit/7f64e404149c9af823f608cecfbd07c25ded0651) | `` python310Packages.scikit-fuzzy: unbreak by disabling erroring test ``          |
| [`eb34a225`](https://github.com/NixOS/nixpkgs/commit/eb34a2251138b07e897e836fd5cc441f846817be) | `` meilisearch: 1.1.0 -> 1.1.1 ``                                                 |
| [`f0db601c`](https://github.com/NixOS/nixpkgs/commit/f0db601c9165eec7f3021c1c34b45a98c2b69bad) | `` google-guest-agent: 20230221.00 -> 20230510.00 ``                              |
| [`0d0f783d`](https://github.com/NixOS/nixpkgs/commit/0d0f783de21f945708b74d8b998eb0393f3619aa) | `` elixir-ls: 0.14.5 -> 0.14.6 ``                                                 |
| [`13c12ae5`](https://github.com/NixOS/nixpkgs/commit/13c12ae53f565ba343b2bdb4f28bc825741aba29) | `` do-agent: 3.16.2 -> 3.16.4 ``                                                  |
| [`ee50fcd6`](https://github.com/NixOS/nixpkgs/commit/ee50fcd6ac7c54b95a36a81d5b666f8e44d03eab) | `` open-stage-control: 1.24.2 -> 1.25.0 ``                                        |
| [`a74d45c3`](https://github.com/NixOS/nixpkgs/commit/a74d45c3a560423884f37971eaca86e2dc535401) | `` btcpayserver: 1.9.2 -> 1.9.3 ``                                                |
| [`570fff5e`](https://github.com/NixOS/nixpkgs/commit/570fff5e92d55dd4d071535d35a858d57b69150d) | `` nixos/klipper: add logFile option ``                                           |
| [`7a5f684f`](https://github.com/NixOS/nixpkgs/commit/7a5f684ffdf0ba0c5448347ed5615c1a7ce338ad) | `` nixos/klipper: use klippy from $out/bin ``                                     |
| [`a30d3677`](https://github.com/NixOS/nixpkgs/commit/a30d3677d0db9fbc5c4afc18bd69c379d45b4393) | `` fblog: 4.3.0 -> 4.4.0 ``                                                       |
| [`3d5ca1b4`](https://github.com/NixOS/nixpkgs/commit/3d5ca1b48f5829eed4e0468968e24889362796ef) | `` asn: 0.73.3 -> 0.74 ``                                                         |
| [`ea472339`](https://github.com/NixOS/nixpkgs/commit/ea47233988549592f1197de747c4953516fa99a4) | `` klipper: install klippy to $out/bin ``                                         |
| [`13468fe9`](https://github.com/NixOS/nixpkgs/commit/13468fe908b334d093017bc380b0010c1a1b3fba) | `` gotify-cli: 2.2.2 -> 2.2.3 ``                                                  |
| [`5efe4a6e`](https://github.com/NixOS/nixpkgs/commit/5efe4a6ec0fb0fa9de181f01d7db01eef39cb939) | `` catppuccin-papirus-folders:  20221204 -> 20230802 ``                           |
| [`b3915bd5`](https://github.com/NixOS/nixpkgs/commit/b3915bd5e2f03eb3a7f96f77a53f0bb5bfb81bd6) | `` nixosTests.prometheus-exporters.wireguard: fix test script ``                  |
| [`893c5215`](https://github.com/NixOS/nixpkgs/commit/893c521565957bdf54962d542b77cadace030b07) | `` factorio: fix eval ``                                                          |
| [`cfe4464d`](https://github.com/NixOS/nixpkgs/commit/cfe4464d7e8cf2f67fd6c8d3c3b534de75d676c1) | `` python3Packages.python-mapnik: fix tests on darwin ``                          |
| [`2386b444`](https://github.com/NixOS/nixpkgs/commit/2386b444c74738f141920eb4350a28114cb6e6eb) | `` fluffychat: add zenity (fix #229879) ``                                        |
| [`8991fac3`](https://github.com/NixOS/nixpkgs/commit/8991fac3051ce05feb9137af684430470fa4f634) | `` flutter: build-support: allow customizing wrapProgram args ``                  |
| [`f9f76529`](https://github.com/NixOS/nixpkgs/commit/f9f76529cd9682bee8a3a805cb4c8f7e0f8e7af4) | `` nixos/nextcloud: default createLocally to false ``                             |
| [`dd69797e`](https://github.com/NixOS/nixpkgs/commit/dd69797eae9e15ac27cbc9d3fe8d6b887ae85d70) | `` fluffychat: 1.11.0 -> 1.11.2 ``                                                |
| [`d3b28b7f`](https://github.com/NixOS/nixpkgs/commit/d3b28b7fd99e435f5401cbb291b2b6aa2711ad6f) | `` texlive.combine: move repstopdf test to tests.texlive (#231742) ``             |
| [`8af23590`](https://github.com/NixOS/nixpkgs/commit/8af23590d3b1e9f29cee0f7a3503c382e663e388) | `` nixos/borgbackup: fix extraCompactArgs ``                                      |
| [`7ecb6dff`](https://github.com/NixOS/nixpkgs/commit/7ecb6dffd2895009bbf4556455c31c4d4f30db10) | `` gphotos-sync: 3.04 -> 3.1.2 ``                                                 |
| [`7f0646b7`](https://github.com/NixOS/nixpkgs/commit/7f0646b7b6b7e1fc8da65e20c940ed785262d074) | `` cloudlog: shorten description ``                                               |
| [`3c0e7c5c`](https://github.com/NixOS/nixpkgs/commit/3c0e7c5cb27a92d6dc736c0c86db514a876c058d) | `` cargo-semver-checks: 0.20.0 -> 0.20.1 ``                                       |
| [`764201a4`](https://github.com/NixOS/nixpkgs/commit/764201a478c43ffdb41e53fae8698b4c293b4060) | `` github/CODEOWNERS: drop nbp ``                                                 |
| [`15c18b63`](https://github.com/NixOS/nixpkgs/commit/15c18b6319bf65b73a093f9630e7a1b65fa816d5) | `` pokete: fix version test ``                                                    |
| [`f4b86504`](https://github.com/NixOS/nixpkgs/commit/f4b86504ea6be349598c73db15580837cf711e9a) | `` dae: 0.1.7 -> 0.1.8 ``                                                         |
| [`2403d25b`](https://github.com/NixOS/nixpkgs/commit/2403d25b6f6475ef0a2125f3f4b133902d2fba72) | `` star-history: 1.0.11 -> 1.0.12 ``                                              |
| [`ff3341d8`](https://github.com/NixOS/nixpkgs/commit/ff3341d834bc98646d16af0662f9e7705d3cb5bf) | `` cargo-expand: 1.0.48 -> 1.0.49 ``                                              |
| [`8b94c04d`](https://github.com/NixOS/nixpkgs/commit/8b94c04d157bc83682f4cbc6800c1e1b59428655) | `` bottom: 0.9.0 -> 0.9.1 ``                                                      |
| [`bb95e773`](https://github.com/NixOS/nixpkgs/commit/bb95e773ebba4cd0a81b972c455c4360200f6cb1) | `` open-in-mpv: init at 2.1.0 ``                                                  |
| [`6c680af3`](https://github.com/NixOS/nixpkgs/commit/6c680af3ae851731d6cf056fb549342ab382c805) | `` i3status-rust: 0.31.2 -> 0.31.4 ``                                             |
| [`a4aa2c04`](https://github.com/NixOS/nixpkgs/commit/a4aa2c04761f5d6ec312c28f07474b5c9fd826c9) | `` linux: enable DRM_AMD_DC_FP on 6.4 ``                                          |
| [`a14e2b4b`](https://github.com/NixOS/nixpkgs/commit/a14e2b4b1631efa899f0487231b0706937b02ad7) | `` plausible: unbreak with latest nodejs ``                                       |
| [`a8a036a1`](https://github.com/NixOS/nixpkgs/commit/a8a036a1ba1d51bc80493a018c357f9f57c1adc5) | `` python3Packages.langchain: 0.0.166 -> 0.0.168 ``                               |
| [`4d5505e9`](https://github.com/NixOS/nixpkgs/commit/4d5505e97b8378887e5f80b533477b5db55ee370) | `` python3Packages.steamship: init at 2.16.9 ``                                   |
| [`1fed084b`](https://github.com/NixOS/nixpkgs/commit/1fed084b65935d70a64b6cb0eddac92a2b0d5984) | `` crosvm: 112.0 -> 113.0 ``                                                      |
| [`d5d16930`](https://github.com/NixOS/nixpkgs/commit/d5d16930f3010c1ceeb85270c62cd3ccb00542b8) | `` cni-plugins: 1.2.0 -> 1.3.0 ``                                                 |
| [`577ffe76`](https://github.com/NixOS/nixpkgs/commit/577ffe768cd18ddfd61c5b36853532b02e613278) | `` wiki-js: use nodejs18 ``                                                       |
| [`b53d5fd0`](https://github.com/NixOS/nixpkgs/commit/b53d5fd054644e46329e43567dcb8b0468814688) | `` wbg: 1.0.2 -> 1.1.0 ``                                                         |
| [`480f5428`](https://github.com/NixOS/nixpkgs/commit/480f54285885eb06a7c2c5554bbc5a0efd369ef0) | `` bitcoin: fix copmilation on x86_64-darwin ``                                   |
| [`03b6a32a`](https://github.com/NixOS/nixpkgs/commit/03b6a32a67df3b19de0ed9c2de51c79c514a43d3) | `` function-runner: 3.3.1 -> 3.4.0 ``                                             |
| [`271735a0`](https://github.com/NixOS/nixpkgs/commit/271735a0b9ad2c62848281bc381fd3cb51913c86) | `` xorg.xorgserver: substitute outside of patches ``                              |
| [`baa7ca47`](https://github.com/NixOS/nixpkgs/commit/baa7ca476f377871597eaaba7b6787cfc60852f5) | `` pokete: 0.9.0 -> 0.9.1 ``                                                      |
| [`d15132bd`](https://github.com/NixOS/nixpkgs/commit/d15132bdeaffb6b2c9b0606f8c363a0ec87c6e18) | `` treesheets: unstable-2023-05-04 -> unstable-2023-05-13 ``                      |
| [`3830fa6e`](https://github.com/NixOS/nixpkgs/commit/3830fa6e2816e217be8477e8c12300383476f9bc) | `` mods: init at 0.1.1 ``                                                         |
| [`d4f2e34e`](https://github.com/NixOS/nixpkgs/commit/d4f2e34e34cd1eb956877926aaaa37d48cbee3a7) | `` poetry: make sure we don't load stuff from ambient PYTHONPATH ``               |
| [`6bd61974`](https://github.com/NixOS/nixpkgs/commit/6bd61974b856a4e839e1f2e3270d7da8d3f4a6dd) | `` vault-bin: 1.13.1 -> 1.13.2 ``                                                 |
| [`1ddde938`](https://github.com/NixOS/nixpkgs/commit/1ddde9385a757686354e049ae02d4506ca49b076) | `` fheroes2: 1.0.3 -> 1.0.4 ``                                                    |
| [`d8b65b71`](https://github.com/NixOS/nixpkgs/commit/d8b65b7123fe35e77daeccc8dd0417d2eb4749ab) | `` clightning: 23.02.2 -> 23.05 ``                                                |
| [`9362bc68`](https://github.com/NixOS/nixpkgs/commit/9362bc682ac64402dc2d3deb1fce9b5eb35e7531) | `` cudatext-qt: 1.193.3 -> 1.194.0 ``                                             |
| [`d080004d`](https://github.com/NixOS/nixpkgs/commit/d080004dfa05265c4a85a3db9f8c2142b0b88707) | `` viceroy: 0.4.5 -> 0.5.0 ``                                                     |
| [`60eb400a`](https://github.com/NixOS/nixpkgs/commit/60eb400a1b3a56da00620efcaec32a6bddea0a59) | `` salt: 3006.0 -> 3006.1 ``                                                      |
| [`bb3fc098`](https://github.com/NixOS/nixpkgs/commit/bb3fc098531b16312a52467fc5b11191e91a0580) | `` frugal: 3.16.18 -> 3.16.19 ``                                                  |