### PR TITLE
chore(flake/nixpkgs): `17a68959` -> `963006aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -325,11 +325,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684139381,
-        "narHash": "sha256-YPLMeYE+UzxxP0qbkBzv3RBDvyGR5I4d7v2n8dI3+fY=",
+        "lastModified": 1684215771,
+        "narHash": "sha256-fsum28z+g18yreNa1Y7MPo9dtps5h1VkHfZbYQ+YPbk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "17a689596b72d1906883484838eb1aaf51ab8001",
+        "rev": "963006aab35e3e8ebbf6052b6bf4ea712fdd3c28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`e2bde0d4`](https://github.com/NixOS/nixpkgs/commit/e2bde0d450ba2bbd80785f69706ba9844ff4faec) | `` terraform-providers.sumologic: 2.22.0 -> 2.22.1 ``                      |
| [`e82d36f9`](https://github.com/NixOS/nixpkgs/commit/e82d36f97f71784333278b7473d553ec548bb9af) | `` terraform-providers.scaleway: 2.18.0 -> 2.19.0 ``                       |
| [`17c278a8`](https://github.com/NixOS/nixpkgs/commit/17c278a8758e67559dd9b40900970bf37350dcc6) | `` terraform-providers.pagerduty: 2.14.4 -> 2.14.5 ``                      |
| [`32865f79`](https://github.com/NixOS/nixpkgs/commit/32865f79c80e3165a791c5312e17216fe74ba54c) | `` terraform-providers.linode: 2.1.1 -> 2.2.0 ``                           |
| [`92fd2547`](https://github.com/NixOS/nixpkgs/commit/92fd2547257ee266847944979e48f701f700be8d) | `` terraform-providers.hcloud: 1.38.2 -> 1.39.0 ``                         |
| [`4b0bd280`](https://github.com/NixOS/nixpkgs/commit/4b0bd2802fc6dd02df35b29ca21a273ac43d571a) | `` terraform-providers.google-beta: 4.64.0 -> 4.65.0 ``                    |
| [`139ea5d1`](https://github.com/NixOS/nixpkgs/commit/139ea5d15185c4c63d5629b44bedff5a1d7a393e) | `` terraform-providers.google: 4.64.0 -> 4.65.0 ``                         |
| [`c05de23e`](https://github.com/NixOS/nixpkgs/commit/c05de23e9b0e4502599cb7913bb6e9316552b5bc) | `` power-profiles-daemon: 0.12 -> 0.13 ``                                  |
| [`e4e24721`](https://github.com/NixOS/nixpkgs/commit/e4e24721a1b135095d135a694ddb2d42f8fa2083) | `` toast: 0.47.1 -> 0.47.2 ``                                              |
| [`67ea6086`](https://github.com/NixOS/nixpkgs/commit/67ea608667422190c4069823cd194bffb2956de0) | `` usql: 0.14.5 -> 0.14.6 ``                                               |
| [`7f7dc0eb`](https://github.com/NixOS/nixpkgs/commit/7f7dc0eb8c6f5ebe7c0aa3fe0323c36c8fa26afd) | `` checkSSLCert: 2.68.0 -> 2.69.0 ``                                       |
| [`21a9f9c3`](https://github.com/NixOS/nixpkgs/commit/21a9f9c385b4f07583df58562dd605e4945a38f5) | `` mermerd: 0.7.0 -> 0.7.1 ``                                              |
| [`1e635a5a`](https://github.com/NixOS/nixpkgs/commit/1e635a5a18b51a0a6a1953cb164e4ad27ae38d0f) | `` ddosify: 0.16.7 -> 1.0.1 ``                                             |
| [`9b0ca3e4`](https://github.com/NixOS/nixpkgs/commit/9b0ca3e49220c1e6c128d6336e5a1ca6297f3192) | `` python310Packages.bx-py-utils: disable failing tests ``                 |
| [`62d4e490`](https://github.com/NixOS/nixpkgs/commit/62d4e490d4c2d28c2c63442857afe6465fba54bf) | `` networkd-notify: init at unstable-2022-11-29 ``                         |
| [`024dcb39`](https://github.com/NixOS/nixpkgs/commit/024dcb39380872fb391e23265623f850a06f3917) | `` gitoxide: 0.23.0 -> 0.25.0 ``                                           |
| [`830a98d3`](https://github.com/NixOS/nixpkgs/commit/830a98d3466eb989477a40e67f5847478d73e211) | `` Revert "clisp: remove broken status on Darwin" ``                       |
| [`3f1f58e4`](https://github.com/NixOS/nixpkgs/commit/3f1f58e44afbe7823d2d204505a2bbbe2c2988f5) | `` python310Packages.django-rq: 2.8.0 -> 2.8.1 ``                          |
| [`dfb1745a`](https://github.com/NixOS/nixpkgs/commit/dfb1745a65d88370dcc09041b1e3fe25e3f25be6) | `` python310Packages.homeassistant-stubs: 2023.5.2 -> 2023.5.3 ``          |
| [`5c6f7afd`](https://github.com/NixOS/nixpkgs/commit/5c6f7afda1433d0df6f564f9f89f9aab76aac1fc) | `` lldap: use upstream wasm-pack ``                                        |
| [`d6d676b7`](https://github.com/NixOS/nixpkgs/commit/d6d676b70969cc4b9dd6cb3d3d5ca6fc733256b8) | `` cobalt: 0.18.3 -> 0.18.4 ``                                             |
| [`fa2aea6c`](https://github.com/NixOS/nixpkgs/commit/fa2aea6c5a76ad8f45c1b78924812224cc5ac471) | `` wasm-pack: 0.11.0 -> 0.11.1 ``                                          |
| [`7d17e260`](https://github.com/NixOS/nixpkgs/commit/7d17e2609941565435204a27b2b26c7195504d59) | `` git-machete: 3.17.3 -> 3.17.4 ``                                        |
| [`bab30c06`](https://github.com/NixOS/nixpkgs/commit/bab30c06f176eef80cb5e110102583c13d883fbb) | `` dumptorrent: support cross compilation ``                               |
| [`0ad5a247`](https://github.com/NixOS/nixpkgs/commit/0ad5a24738e0f456a1f2c43e2381fe51f75fa0b8) | `` pngcheck: support cross compilation and install man page ``             |
| [`591e14d6`](https://github.com/NixOS/nixpkgs/commit/591e14d6caf9c2cd4382d3a2375f2c8e0d851c20) | `` python310Packages.dvclive: 2.8.1 -> 2.9.0 ``                            |
| [`437220cd`](https://github.com/NixOS/nixpkgs/commit/437220cd683bb6038dfeac075285269e79c61b9f) | `` python311Packages.dvc-render: 0.4.0 -> 0.5.0 ``                         |
| [`77668613`](https://github.com/NixOS/nixpkgs/commit/776686132f33ea8e0c9549c2e8cffc2bb503ccf7) | `` python311Packages.losant-rest: 1.17.3 -> 1.17.4 ``                      |
| [`1794d78d`](https://github.com/NixOS/nixpkgs/commit/1794d78df4cc08453a6c482bec8acdec517c26e5) | `` python311Packages.hahomematic: 2023.5.1 -> 2023.5.2 ``                  |
| [`c2eefa77`](https://github.com/NixOS/nixpkgs/commit/c2eefa7785cd271abba157c0f29e37668565f0b4) | `` python311Packages.aioesphomeapi: 13.7.4 -> 13.7.5 ``                    |
| [`f1ad4e25`](https://github.com/NixOS/nixpkgs/commit/f1ad4e2582b9ae5477df819b641c1f1c72738899) | `` dog: support cross-compilation ``                                       |
| [`8a4f0162`](https://github.com/NixOS/nixpkgs/commit/8a4f016281d5d1458013aef414e17574f883d338) | `` nixos/maddy: tls.loader add acme support, add secrets option ``         |
| [`81bc5f3d`](https://github.com/NixOS/nixpkgs/commit/81bc5f3db8f9ba812836036d5d3e54e933ca2cd6) | `` pkgs/linux: Vendor maple tree patch ``                                  |
| [`1784646f`](https://github.com/NixOS/nixpkgs/commit/1784646fc10266683fa63a32beaa2a37804f6df5) | `` fritzing: added meta.mainProgram (#232059) ``                           |
| [`10092e14`](https://github.com/NixOS/nixpkgs/commit/10092e14180fdff037aea3a14ad3faeaf6950ac1) | `` licenses: add CC-BY-NC-ND-4.0 ``                                        |
| [`d925734d`](https://github.com/NixOS/nixpkgs/commit/d925734d3bb7f12924e6016cd33222684b5435f5) | `` Nim: add meta.mainProgram ``                                            |
| [`532b383f`](https://github.com/NixOS/nixpkgs/commit/532b383f4387304cc0109226475c73e48396d3df) | `` kemai: init at 0.9.2 ``                                                 |
| [`97fab1a3`](https://github.com/NixOS/nixpkgs/commit/97fab1a38c9e973b424a7750eafec2b88c1fa8cf) | `` chenglou92.rescript-vscode: 1.8.1 -> 1.16.0 (#231648) ``                |
| [`391b059c`](https://github.com/NixOS/nixpkgs/commit/391b059c1d93889e597797841fa20148f7e6dd4c) | `` nixosTests.pgadmin4: increase test coverage (#229632) ``                |
| [`190bf8b2`](https://github.com/NixOS/nixpkgs/commit/190bf8b28146dee803060e71ba10710778453f60) | `` mlxbf-bootctl: init at 1.1-6 ``                                         |
| [`696596a8`](https://github.com/NixOS/nixpkgs/commit/696596a8a0c9b0c00764051c399569a1583765df) | `` owncloud: 3.2.1 -> 4.0.0 ``                                             |
| [`3c0f0d84`](https://github.com/NixOS/nixpkgs/commit/3c0f0d84a8813412156d8008de96da39287a2cc5) | `` nixosTests.mjolnir: unbreak ``                                          |
| [`725bb2a7`](https://github.com/NixOS/nixpkgs/commit/725bb2a78be8696e21b16b1abb714a6c9f427304) | `` ast-grep: init at 0.5.2 ``                                              |
| [`25f85bdc`](https://github.com/NixOS/nixpkgs/commit/25f85bdcc2c6e73456568f7fc8107e6cb76febef) | `` schildichat: 1.11.22-sc.1 -> 1.11.30-sc.2 (#231938) ``                  |
| [`00ca6e1c`](https://github.com/NixOS/nixpkgs/commit/00ca6e1c97160b8d0528494ef2aa92a1f9c5c757) | `` shopware-cli: 0.1.62 -> 0.1.70 ``                                       |
| [`0066142d`](https://github.com/NixOS/nixpkgs/commit/0066142d564c46212dfca02bfb9d145514a0b4f7) | `` coreboot-toolchain: 4.19 -> 4.20 ``                                     |
| [`2ee66a30`](https://github.com/NixOS/nixpkgs/commit/2ee66a3000fd65bc76e83a62e57337a9dccdb7c2) | `` keyd: run systemd service as root user ``                               |
| [`55061dd7`](https://github.com/NixOS/nixpkgs/commit/55061dd7220ed4854f878c152143ff51238a7d85) | `` dbus_cplusplus: update broken patch URLs ``                             |
| [`f6e4dcb0`](https://github.com/NixOS/nixpkgs/commit/f6e4dcb061fb2148dc086ecc27333f13cdf09e97) | `` deno: 1.33.2 -> 1.33.3 ``                                               |
| [`95e1099d`](https://github.com/NixOS/nixpkgs/commit/95e1099d2a042ed6d4c23ae3bd46317e0d28c5c5) | `` restic: add persistent default for timer unit ``                        |
| [`292ac0da`](https://github.com/NixOS/nixpkgs/commit/292ac0da99fc47a38f4ed27f50d2364aea023ff1) | `` libosmoabis, libosmo-{netif,sccp}: add markuskowa to maintainers ``     |
| [`26e68112`](https://github.com/NixOS/nixpkgs/commit/26e68112909a3bb6fca067122e81b3c4fe1c167c) | `` Revert "Merge pull request #229369 from markuskowa/add-libsomo-s" ``    |
| [`77ef06b4`](https://github.com/NixOS/nixpkgs/commit/77ef06b4a2cbacd43053a7f19f03e654541f3ec2) | `` kubescape: 2.3.1 -> 2.3.2 ``                                            |
| [`969c48ea`](https://github.com/NixOS/nixpkgs/commit/969c48ead61b86c445baf14f608522eeadac55f1) | `` ov: 0.15.0 -> 0.22.0 ``                                                 |
| [`f197c8db`](https://github.com/NixOS/nixpkgs/commit/f197c8db8f17d99bbc13d406f71e95f3b3be6c5a) | `` python310Packages.python-gvm: 23.4.2 -> 23.5.0 ``                       |
| [`aa24b33e`](https://github.com/NixOS/nixpkgs/commit/aa24b33e2420f5bd98d17595bd041c593d1283b6) | `` python310Packages.pyvicare: 2.27.2 -> 2.28.1 ``                         |
| [`75951ec5`](https://github.com/NixOS/nixpkgs/commit/75951ec554c37f56bf1c1aebd15582baf8005eb0) | `` python311Packages.aioecowitt: 2023.01.0 -> 2023.5.0 ``                  |
| [`46dfed60`](https://github.com/NixOS/nixpkgs/commit/46dfed6010a624a7aec49bbc63752847ae3ff15a) | `` nixos/tests/rshim: init ``                                              |
| [`6852dc23`](https://github.com/NixOS/nixpkgs/commit/6852dc2359784c34941270d3f9532b0d7cfcd225) | `` nixos/rshim: fix shell escape ``                                        |
| [`f3587b78`](https://github.com/NixOS/nixpkgs/commit/f3587b78c38ba82d8818bb9ed3e3e7bab1502c40) | `` muso: don't mark as broken on aarch64-linux ``                          |
| [`5ce9c57e`](https://github.com/NixOS/nixpkgs/commit/5ce9c57e1a23ae50aed8f33265a9c09b3ffc2a81) | `` muso: avoid build failure using an updated lockfile ``                  |
| [`d8f99d83`](https://github.com/NixOS/nixpkgs/commit/d8f99d83e77fcc6ff1d274d9aa37ed2d555c7d77) | `` python310Packages.css-inline: init at 0.8.7 ``                          |
| [`3c63d740`](https://github.com/NixOS/nixpkgs/commit/3c63d74009b1ba84b9f3633bb48d7373a8a0cb4c) | `` ruff: add ruff-lsp to passthru.tests ``                                 |
| [`bf65f7c2`](https://github.com/NixOS/nixpkgs/commit/bf65f7c29192d629e772afce7b3ff7eb90c72c69) | `` python310Packages.pymc: 5.0.2 -> 5.3.1 ``                               |
| [`4e8b848f`](https://github.com/NixOS/nixpkgs/commit/4e8b848f13657af4ebd44a0a0fb525c39d195f12) | `` bdf2psf: 1.218 -> 1.220 ``                                              |
| [`49eee7c7`](https://github.com/NixOS/nixpkgs/commit/49eee7c7aa6bafa76d3dd822b9a07981c6175bb5) | `` privacyidea: build on linux only ``                                     |
| [`847b66d0`](https://github.com/NixOS/nixpkgs/commit/847b66d0551456737741733fbd2bdec64c1b4326) | `` privacyidea: fix build ``                                               |
| [`bc053c32`](https://github.com/NixOS/nixpkgs/commit/bc053c32fcee4aeda68b9168085b79fc57c126e3) | `` abaddon: init at 0.1.10 ``                                              |
| [`80c0a5de`](https://github.com/NixOS/nixpkgs/commit/80c0a5deb91480495f839ba1845931f38a01c417) | `` python3Packages.ruff-lsp: 0.0.24 -> 0.0.27 ``                           |
| [`5a8a8e0d`](https://github.com/NixOS/nixpkgs/commit/5a8a8e0d9f0731cc4cf6a561d72b017c38eb2ae3) | `` labwc: 0.6.2 -> 0.6.3 ``                                                |
| [`a9a1928b`](https://github.com/NixOS/nixpkgs/commit/a9a1928bd28de5b40780568e83c820b9d33d0043) | `` ocamlPackages.cmarkit: init at 0.1.0 ``                                 |
| [`18fa9fc6`](https://github.com/NixOS/nixpkgs/commit/18fa9fc63fa79e98e7d0875ccf5b93ee1a06c356) | `` slweb: 0.5.4 -> 0.5.5 ``                                                |
| [`c256ecf7`](https://github.com/NixOS/nixpkgs/commit/c256ecf7a3f5f5b8ac63c70a1ad216cf1f8312fc) | `` nixos/mjolnir: explicitly set --mjolnir-config ``                       |
| [`adede1eb`](https://github.com/NixOS/nixpkgs/commit/adede1eb03c4cbacf1836288cc55f87f45b3217a) | `` mjolnir: 1.5.0 -> 1.6.4, build with mkYarnPackage ``                    |
| [`e232bbd9`](https://github.com/NixOS/nixpkgs/commit/e232bbd926aa692cbbc1ddfeb4635714a0a7549d) | `` python311Packages.extractcode: add missing input six ``                 |
| [`da95e6a2`](https://github.com/NixOS/nixpkgs/commit/da95e6a2e6f1f4d104715bb3a231a9e4a65c1f1c) | `` psst: add update script ``                                              |
| [`6250f860`](https://github.com/NixOS/nixpkgs/commit/6250f8607c0f8550571fb6fe79c5da76cbeb91f7) | `` psst: 2022-10-13 -> 2023-05-13 ``                                       |
| [`3f446bfb`](https://github.com/NixOS/nixpkgs/commit/3f446bfbd356a58ce673d88b6e78f368f707c9f1) | `` nixos/pam: fix ZFS support assertion ``                                 |
| [`6b2ac1c4`](https://github.com/NixOS/nixpkgs/commit/6b2ac1c44caa398f33c09a7f354e5cf1fb8357d6) | `` monotoneViz: update broken patch URLs ``                                |
| [`8b72abdb`](https://github.com/NixOS/nixpkgs/commit/8b72abdbe8a57191b36f9901f36d1a7eecd59ec0) | `` libudev-zero: fix cross compilation ``                                  |
| [`a0ca4311`](https://github.com/NixOS/nixpkgs/commit/a0ca431141b4ff32509f791a91a0c01e07fbd37e) | `` Add coqPackages.mathcomp 2.0.0 ``                                       |
| [`c984f441`](https://github.com/NixOS/nixpkgs/commit/c984f4414cb3673b2b04834e89fdc4df4865607a) | `` python311Packages.ciscoconfparse: 1.7.18 -> 1.7.24 ``                   |
| [`a951a512`](https://github.com/NixOS/nixpkgs/commit/a951a512236c7122f8822441ed16d4eb08823763) | `` python310Packages.cheetah3: 3.2.6.post2 -> 3.3.1 ``                     |
| [`46f2510f`](https://github.com/NixOS/nixpkgs/commit/46f2510f2bf5721673f885023af223180765ad24) | `` python310Packages.atlassian-python-api: add changelog to meta ``        |
| [`c81792a4`](https://github.com/NixOS/nixpkgs/commit/c81792a4571d5a6ba7a7f3d84cbc0e5dc5f16335) | `` ocamlPackages.ounit2: disable for OCaml < 4.08 ``                       |
| [`bc9afd16`](https://github.com/NixOS/nixpkgs/commit/bc9afd16865cddb0f2f2be9f65741626779687f1) | `` ocamlPackages.tcslib: remove unused input ``                            |
| [`77f98373`](https://github.com/NixOS/nixpkgs/commit/77f983732c0fcdd2df55e141209ba7c776416f1d) | `` ocamlPackages.ocaml_expat: remove at 0.9.1 (for OCaml < 4.02) ``        |
| [`f3f6bacd`](https://github.com/NixOS/nixpkgs/commit/f3f6bacd0b47d66fabbc48136d6d43c73ba17a4d) | `` python311Packages.types-python-dateutil: 2.8.19.12 -> 2.8.19.13 ``      |
| [`b2cc7fb2`](https://github.com/NixOS/nixpkgs/commit/b2cc7fb23db7a104f223649932fdb128278159eb) | `` python311Packages.py-zabbix: add patch to remove getargspec ``          |
| [`1bb61875`](https://github.com/NixOS/nixpkgs/commit/1bb618759ed431be9d140a3247c92f11be94e671) | `` python310Packages.atlassian-python-api: 3.34.0 -> 3.36.0 ``             |
| [`56e894b0`](https://github.com/NixOS/nixpkgs/commit/56e894b0b137b223d297896b13c84a12345b58d5) | `` nixos/pam: add test for ZFS home dataset unlocking ``                   |
| [`87cbaf7c`](https://github.com/NixOS/nixpkgs/commit/87cbaf7ce339136ccbd639b7b5a1cf988d0fa440) | `` nixos/pam: assert ZFS support for PAM module ``                         |
| [`5466f767`](https://github.com/NixOS/nixpkgs/commit/5466f767556b12a6db4bcaa6e9ab9970d28b0d29) | `` nixos/pam: improve documentation of ZFS module ``                       |
| [`09f4bf7f`](https://github.com/NixOS/nixpkgs/commit/09f4bf7f166d4bf2e09b1923ae5744e6193caf44) | `` nixos/pam: enable unlocking ZFS home dataset ``                         |
| [`47d41eda`](https://github.com/NixOS/nixpkgs/commit/47d41eda7cebd6679ad17de1be97747bfb53fc3f) | `` xfce.xfce4-i3-workspaces-plugin: 1.4.0 -> 1.4.1 ``                      |
| [`83df8d51`](https://github.com/NixOS/nixpkgs/commit/83df8d51b6911eb97a7f96c989e337ff2e3d32c9) | `` xfce.xfce4-screenshooter: 1.10.3 -> 1.10.4 ``                           |
| [`587fa62e`](https://github.com/NixOS/nixpkgs/commit/587fa62e815927939f2872c96e95396cb985445d) | `` xfce.ristretto: 0.13.0 -> 0.13.1 ``                                     |
| [`3be4449a`](https://github.com/NixOS/nixpkgs/commit/3be4449adcf8a14a30e459549904b0c4615da7cd) | `` bodyclose: init at 2023-04-21 ``                                        |
| [`c240ad39`](https://github.com/NixOS/nixpkgs/commit/c240ad39d3a963be04d128111c3def7b15617103) | `` xfce.mousepad: 0.6.0 -> 0.6.1 ``                                        |
| [`6692d1dc`](https://github.com/NixOS/nixpkgs/commit/6692d1dcc1d70b97bba4b7f7f8e07a324f4716c6) | `` flightgear: 2020.3.17 -> 2020.3.18 ``                                   |
| [`3d6d1d4d`](https://github.com/NixOS/nixpkgs/commit/3d6d1d4d6b510c180eeeff0f1966330418abdce5) | `` nerd-font-patcher: 2.2.2 -> 3.0.1 ``                                    |
| [`bac8c263`](https://github.com/NixOS/nixpkgs/commit/bac8c263a7a7a8d637aed93238cb3da2bc127a6d) | `` rofi-power-menu: 3.0.2 -> 3.1.0 ``                                      |
| [`60c69da2`](https://github.com/NixOS/nixpkgs/commit/60c69da248a9e0c2b4aadf0e1c6da5916b808d4d) | `` fastp: 0.23.2 -> 0.23.3 ``                                              |
| [`ebdfb209`](https://github.com/NixOS/nixpkgs/commit/ebdfb20941c66e7ace30b57706e9012dfbf202dd) | `` step-kms-plugin: 0.8.2 -> 0.8.3 ``                                      |
| [`ec83b05f`](https://github.com/NixOS/nixpkgs/commit/ec83b05fef2b49282e7213776b053da246e3965a) | `` tanka: 0.24.0 -> 0.25.0 ``                                              |
| [`17d26e4c`](https://github.com/NixOS/nixpkgs/commit/17d26e4c7fc1ab8697d63523daf2d2742f432d2a) | `` linux: patch to fix MAP_32BIT crashes, e.g. Haskell ``                  |
| [`76d34bfa`](https://github.com/NixOS/nixpkgs/commit/76d34bfa54727e423662aabad4e491ca32a9effa) | `` argo-rollouts: 1.4.1 -> 1.5.0 ``                                        |
| [`063c724e`](https://github.com/NixOS/nixpkgs/commit/063c724efee38e5f6eab1f5228f6ea5d0d0a4e16) | `` cirrus-cli: 0.97.0 -> 0.98.0 ``                                         |
| [`e20c707a`](https://github.com/NixOS/nixpkgs/commit/e20c707a1b9ea3f0bd8b7c267406888cea755743) | `` eksctl: 0.140.0 -> 0.141.0 ``                                           |
| [`211f15a2`](https://github.com/NixOS/nixpkgs/commit/211f15a271fe2e300aef7daa688d5060ac41ea46) | `` phantomsocks: fix build tag ``                                          |
| [`b0aff56c`](https://github.com/NixOS/nixpkgs/commit/b0aff56c9c77a37d0bef82bc1083b7848a9f563f) | `` blueman: specify changelog ``                                           |
| [`b89decb1`](https://github.com/NixOS/nixpkgs/commit/b89decb10715783bd6daacc18518d4be25e3ce15) | `` blueman: 2.3.4 -> 2.3.5 ``                                              |
| [`ac3d1b53`](https://github.com/NixOS/nixpkgs/commit/ac3d1b53371a928e2123d2689e4163a4192f8df1) | `` restic-integrity: init at 1.2.1 ``                                      |
| [`33b15fdc`](https://github.com/NixOS/nixpkgs/commit/33b15fdce01f528cba388d1e023f04491c0879b3) | `` security/acme: Fix listenHTTP bug with IPv6 addresses ``                |
| [`dde08220`](https://github.com/NixOS/nixpkgs/commit/dde0822009c8b04e673854d50a8c93f31af67421) | `` python310Packages.dj-static: init at 0.0.6 ``                           |
| [`e639bfd1`](https://github.com/NixOS/nixpkgs/commit/e639bfd14d095566a363343aebaac51572d64185) | `` python310Packages.h5netcdf: fix versioning ``                           |
| [`6d2ffb19`](https://github.com/NixOS/nixpkgs/commit/6d2ffb194e421ebaca1990eed926eda690b4085a) | `` python310Packages.arviz: 0.15.0 -> 0.15.1 ``                            |
| [`275ce8c4`](https://github.com/NixOS/nixpkgs/commit/275ce8c4e414fdd65abc4975f64c314038665d31) | `` python310Packages.django-localflavor: init at 4.0 ``                    |
| [`4414a2d9`](https://github.com/NixOS/nixpkgs/commit/4414a2d94878818f7645b080fdf8f11ea9a1b92a) | `` nix-output-monitor: 2.0.0.5 -> 2.0.0.6 ``                               |
| [`72b02105`](https://github.com/NixOS/nixpkgs/commit/72b021051f4d16f029dfe0073bd37e107f57991b) | `` nix-output-monitor: comment and cleanup ``                              |
| [`8b16fe92`](https://github.com/NixOS/nixpkgs/commit/8b16fe92d62a4913618c8673bd1cab4332fa2670) | `` python310Packages.cvxpy: 1.3.0 -> 1.3.1 ``                              |
| [`671ac5d2`](https://github.com/NixOS/nixpkgs/commit/671ac5d2a5681e33bc8d75eb03155b2401d91b90) | `` libphonenumber: patch code generation tool for build reproducibility `` |
| [`247fce9f`](https://github.com/NixOS/nixpkgs/commit/247fce9fe8c489b6e97fd3cb4210cc8e41288804) | `` SDL_classic: update broken patch URL ``                                 |
| [`7b17416a`](https://github.com/NixOS/nixpkgs/commit/7b17416a3cbef61847841d96b6b4b66f2b875df6) | `` openslp: update broken patch URLs ``                                    |
| [`4cbe7d35`](https://github.com/NixOS/nixpkgs/commit/4cbe7d35504dc1a45cc4335e9b090b25c9de714f) | `` home-assistant: 2023.5.2 -> 2023.5.3 ``                                 |
| [`09512358`](https://github.com/NixOS/nixpkgs/commit/09512358faf83630fc6db5e876cd57c363fc32d6) | `` python310Packages.bellows: 0.35.2 -> 0.35.5 ``                          |
| [`e3c06521`](https://github.com/NixOS/nixpkgs/commit/e3c0652181ea9ee1a8a87ea494e234422ffd848e) | `` python310Packages.aionotion: 2023.05.1 -> 2023.05.4 ``                  |
| [`7eacc7f5`](https://github.com/NixOS/nixpkgs/commit/7eacc7f5492f39286696e57fa99bb2becf711bd5) | `` mangohud: make lower bitness support configurable ``                    |
| [`272154f2`](https://github.com/NixOS/nixpkgs/commit/272154f2602ac55700c15cf38f84c44a67fb11b0) | `` mangohud: add bitness suffix to layer name ``                           |
| [`58511b12`](https://github.com/NixOS/nixpkgs/commit/58511b124ef34f1a0c89aa58a7e87a8861bc5700) | `` python3.pkgs.xdg-base-dirs: init at 6.0.0 ``                            |
| [`ef5407df`](https://github.com/NixOS/nixpkgs/commit/ef5407df8d8f815a2f72c84b7d0b0a3ba453ca2a) | `` python3.pkgs.textual: 0.23.0 -> 0.24.1 ``                               |
| [`33465c23`](https://github.com/NixOS/nixpkgs/commit/33465c23ea6464cf353083c45beb8f4eadbba75e) | `` python310Packages.ecos: 2.0.10 -> 2.0.11 ``                             |
| [`3aa6580f`](https://github.com/NixOS/nixpkgs/commit/3aa6580f465ad97bf69a04213899e59350e70ef4) | `` nixos/trippy: init ``                                                   |
| [`1623309e`](https://github.com/NixOS/nixpkgs/commit/1623309ee2df85e952f79ea7ed7c75137b48f48b) | `` texlive: execute postaction scripts ``                                  |
| [`17d4034e`](https://github.com/NixOS/nixpkgs/commit/17d4034e89f418108837af481e043586a0e44568) | `` texlive: unpack and expose useful tlpkg/ content ``                     |
| [`d9f9708a`](https://github.com/NixOS/nixpkgs/commit/d9f9708a99765239405543f45cf979400a978ae2) | `` meshcentral: nodejs_16 -> nodejs_18 ``                                  |
| [`cddb66d6`](https://github.com/NixOS/nixpkgs/commit/cddb66d6552f3fb9912081601303d890dd693cc0) | `` python310Packages.scikit-image: rename from scikitimage ``              |
| [`7452a2d1`](https://github.com/NixOS/nixpkgs/commit/7452a2d176f539244a16c7818d1ba5d7e6cd82de) | `` python310Packages.numpyro: add missing input for tests ``               |
| [`c3b69fdb`](https://github.com/NixOS/nixpkgs/commit/c3b69fdb05e86fcd5d6e621ec036706afbc0fde9) | `` python311Packages.mizani: 0.8.1 -> 0.9.0 ``                             |
| [`11b96796`](https://github.com/NixOS/nixpkgs/commit/11b967964222e17ea69e33bab13d1bba7156d7bc) | `` insync: 3.3.5.40925 -> 3.8.5.50499 ``                                   |
| [`7a6a78c9`](https://github.com/NixOS/nixpkgs/commit/7a6a78c9700cf0205975ae07e0b04c2e3442fc8c) | `` insync-v3: remove ``                                                    |
| [`9b9eaf02`](https://github.com/NixOS/nixpkgs/commit/9b9eaf0208516f4f72ad64b2c6d8e672ccf480d1) | `` insync: superceded by insync-v3 ``                                      |
| [`4b176f4e`](https://github.com/NixOS/nixpkgs/commit/4b176f4ec4843ceadaa444c5e879eb74edb2f229) | `` vimPlugins.openscad-nvim: fix patch ``                                  |