### PR TITLE
chore(flake/home-manager): `c0deab0e` -> `b7d814c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684157850,
-        "narHash": "sha256-xGHTCgvAxO5CgAL6IAgE/VGRX2wob2Y+DPyqpXJ32oQ=",
+        "lastModified": 1684189380,
+        "narHash": "sha256-GUp9OkZynocyppLur1VX8oAjtXGue0oKRHbsksOMUm0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c0deab0effd576e70343cb5df0c64428e0e0d010",
+        "rev": "b7d814c5744dca7e70b3dc2638f06568dce96ca6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`b7d814c5`](https://github.com/nix-community/home-manager/commit/b7d814c5744dca7e70b3dc2638f06568dce96ca6) | `` tests: bump nmt to latest `` |