### PR TITLE
chore(flake/darwin): `0dbf1c2f` -> `dfbdabbb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684148371,
-        "narHash": "sha256-CEVaArsziqantqU418XXruNDjPZN/HC3x1rqr2D4g+o=",
+        "lastModified": 1684343812,
+        "narHash": "sha256-ZTEjiC8PDKeP8JRchuwcFXUNlMcyQ4U+DpyVZ3pB6Q4=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "0dbf1c2fb1a5a0372a324eff1ba44f9da66febd2",
+        "rev": "dfbdabbb3e797334172094d4f6c0ffca8c791281",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                      |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
| [`6236fd19`](https://github.com/LnL7/nix-darwin/commit/6236fd19231394d74520274c457fd72cab569ab3) | `` buildkite-agent: allow 'types.path' in runtimePackages `` |
| [`f1a562ee`](https://github.com/LnL7/nix-darwin/commit/f1a562eef19a042a1b2693e412a1f95aad11eab6) | `` refactor: rename clock option menuExtraClock ``           |
| [`f6b7489d`](https://github.com/LnL7/nix-darwin/commit/f6b7489ddb316eb2b331e2f3a5ef43e11d8eff34) | `` feat: defaults write com.apple.menuextra.clock ``         |