### PR TITLE
chore(flake/lanzaboote): `d93eebb9` -> `354ec6f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -275,11 +275,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1684327479,
-        "narHash": "sha256-MqFzPr5DwHlK4lcobLfniRtwMdEatPclNtjGOhuVnzE=",
+        "lastModified": 1684428412,
+        "narHash": "sha256-KUaSvryMxoRGjcMRNlz96AnteyTEv5cYrgLXnmCSpt0=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "d93eebb9c6b377870684c00e012373e84a100d77",
+        "rev": "354ec6f451edcb8030da4768aa93d671d14f6271",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                         |
| --------------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`c17650da`](https://github.com/nix-community/lanzaboote/commit/c17650dafc065c607d199a3125d33402603c5076) | `` flake: add rustfmt checks `` |
| [`65dbe449`](https://github.com/nix-community/lanzaboote/commit/65dbe449996c6937cfa9d55e5d97c525d98a5412) | `` stub: format with rustfmt `` |
| [`e37bf51e`](https://github.com/nix-community/lanzaboote/commit/e37bf51ed3c600e9fa851c491f0a3de0ff4eae1f) | `` stub: format with rustfmt `` |