### PR TITLE
chore(flake/nixpkgs): `e6e38991` -> `48a0fb7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -325,11 +325,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684305980,
-        "narHash": "sha256-vd4SKXX1KZfSX6n3eoguJw/vQ+sBL8XGdgfxjEgLpKc=",
+        "lastModified": 1684385584,
+        "narHash": "sha256-O7y0gK8OLIDqz+LaHJJyeu09IGiXlZIS3+JgEzGmmJA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e6e389917a8c778be636e67a67ec958f511cc55d",
+        "rev": "48a0fb7aab511df92a17cf239c37f2bd2ec9ae3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`099081ff`](https://github.com/NixOS/nixpkgs/commit/099081ff402d0b649becb48d986331132dfbe95a) | `` skaffold: 2.4.0 -> 2.4.1 ``                                                  |
| [`1af30523`](https://github.com/NixOS/nixpkgs/commit/1af3052329c3de4a95b2efd98f71839e6bbb5191) | `` pulumictl: 0.0.42 -> 0.0.43 ``                                               |
| [`5cc6776f`](https://github.com/NixOS/nixpkgs/commit/5cc6776fe11dcce86105e4992b76f7000289ee62) | `` godns: 2.9.7 -> 2.9.8 ``                                                     |
| [`963f689a`](https://github.com/NixOS/nixpkgs/commit/963f689aa17487ec30cc9f1599672866bbf162ca) | `` android-tools: 34.0.0 -> 34.0.1 ``                                           |
| [`72590183`](https://github.com/NixOS/nixpkgs/commit/72590183f0a1301dafb44b8f0a57871e71d32d00) | `` mods: add updateScript and tests.version ``                                  |
| [`1d77f3b7`](https://github.com/NixOS/nixpkgs/commit/1d77f3b72756ca36f16440c59e6b89a957908647) | `` goose: init at 3.11.2 (#232485) ``                                           |
| [`5c45d6cf`](https://github.com/NixOS/nixpkgs/commit/5c45d6cfbb5f6470e9e2082b84bbcee55fbd5a09) | `` python311Packages.ecs-logging: 2.0.0 -> 2.0.2 ``                             |
| [`ab83f80d`](https://github.com/NixOS/nixpkgs/commit/ab83f80d5d4de65cda504a344572fac498cd0cdd) | `` python311Packages.neo4j: 5.8.0 -> 5.8.1 ``                                   |
| [`6eb2e9f7`](https://github.com/NixOS/nixpkgs/commit/6eb2e9f78d6b35db641cba637032001e4bd5bbf6) | `` python311Packages.python-roborock: 0.18.3 -> 0.18.5 ``                       |
| [`0c2d910d`](https://github.com/NixOS/nixpkgs/commit/0c2d910d85796314ac196c0454bcd07c749e1588) | `` python311Packages.types-urllib3: 1.26.25.12 -> 1.26.25.13 ``                 |
| [`dff17426`](https://github.com/NixOS/nixpkgs/commit/dff1742675b6fb29d886a5cc9ec75f1a56131f60) | `` python311Packages.yalexs-ble: 2.1.16 -> 2.1.17 ``                            |
| [`01098eb6`](https://github.com/NixOS/nixpkgs/commit/01098eb609f1f966b4f4e1af90056e6342b39a79) | `` exploitdb: 2023-05-14 -> 2023-05-17 ``                                       |
| [`50c75a58`](https://github.com/NixOS/nixpkgs/commit/50c75a58260a10439f2d808260d6bbbd1255a664) | `` python310Packages.uproot: 5.0.3 -> 5.0.7 ``                                  |
| [`d98541f6`](https://github.com/NixOS/nixpkgs/commit/d98541f668e89691009311997fa711655884cab1) | `` python311Packages.pyvista: 0.39.0 -> 0.39.1 ``                               |
| [`73424fa2`](https://github.com/NixOS/nixpkgs/commit/73424fa2eb27fe8cabb246fc00d4db8d89e1719b) | `` vtk: fix egg-info ``                                                         |
| [`5439fa8e`](https://github.com/NixOS/nixpkgs/commit/5439fa8e440044788219bfbd904c571812680a9b) | `` okta-aws-cli: init at version 1.0.1 ``                                       |
| [`6d740511`](https://github.com/NixOS/nixpkgs/commit/6d74051119387348fc7a2c600ef24ae5e1710d0b) | `` maintainers: add daniyalsuri ``                                              |
| [`f3562ea2`](https://github.com/NixOS/nixpkgs/commit/f3562ea26a4121163a56606e12fe2eef38acf4df) | `` python311Packages.google-cloud-pubsub: 2.16.1 -> 2.17.0 ``                   |
| [`55e5de41`](https://github.com/NixOS/nixpkgs/commit/55e5de416f19973a821606e92818ab4981eefc50) | `` isabelle-components.isabelle-linter: add platforms ``                        |
| [`b2b89dc3`](https://github.com/NixOS/nixpkgs/commit/b2b89dc3680d00f7b748a118ed191002d0fa3c54) | `` iosevka-bin: 22.1.1 -> 22.1.2 ``                                             |
| [`1d2e6b87`](https://github.com/NixOS/nixpkgs/commit/1d2e6b872cfa778e37466ada0c1b835d6253a102) | `` python310Packages.conda: disable on python 3.10+ ``                          |
| [`84d5e9b1`](https://github.com/NixOS/nixpkgs/commit/84d5e9b1236959b053ac7525016e9ebcc6ab44cd) | `` release-notes: Mention services.syncthing changes due to RFC 42 ``           |
| [`d116e5e2`](https://github.com/NixOS/nixpkgs/commit/d116e5e269a7e04aab5c6f96994fd86e207c13bc) | `` python311Packages.snapcast: 2.3.2 -> 2.3.3 ``                                |
| [`776fbde6`](https://github.com/NixOS/nixpkgs/commit/776fbde672a2158a5407f12d41435292a9d6e2e0) | `` goflow2: init at 1.3.3 (#232430) ``                                          |
| [`9775ce1b`](https://github.com/NixOS/nixpkgs/commit/9775ce1bd39d7fc8b4d6a9ecb67ba8b67ce45988) | `` python310Packages.torchWithCuda: add platform check ``                       |
| [`2ae406b5`](https://github.com/NixOS/nixpkgs/commit/2ae406b5200e19d1e51421c340e00e70bb3e79cb) | `` python310Packages.repoze_who: skip failing test ``                           |
| [`a7dc576a`](https://github.com/NixOS/nixpkgs/commit/a7dc576a248d2e59780e9d299ece2d01403bd359) | `` python310Packages.pyshark: fix build on darwin ``                            |
| [`30af8270`](https://github.com/NixOS/nixpkgs/commit/30af8270c8ac24a3ee4adfd1727270efdbdc3695) | `` python310Packages.k5test: fix build ``                                       |
| [`e61d73c2`](https://github.com/NixOS/nixpkgs/commit/e61d73c29febbc2557a1996f364a2421ed4aaea7) | `` python310Packages.finalfusion: fix build ``                                  |
| [`2b47cede`](https://github.com/NixOS/nixpkgs/commit/2b47cedec6e807e0906f60cf685840f066fb94cd) | `` python310Packages.cx_Freeze: fix build ``                                    |
| [`c089534d`](https://github.com/NixOS/nixpkgs/commit/c089534da5c928ea6f376672b0c828eb340d5cfa) | `` imagemagick: 7.1.1-8 -> 7.1.1-9 ``                                           |
| [`954fb6b7`](https://github.com/NixOS/nixpkgs/commit/954fb6b75b785cbd209092dce5d3bdfc534a0536) | `` git-mit: fix build on darwin, adopt ``                                       |
| [`2515b0e0`](https://github.com/NixOS/nixpkgs/commit/2515b0e0dc65496ac52a6a15c6de58008f16a439) | `` python310Packages.rivet: 3.1.7 -> 3.1.8 ``                                   |
| [`0e29625b`](https://github.com/NixOS/nixpkgs/commit/0e29625b7636ad447395e5d337065e0c562e13c8) | `` schildichat-desktop: use electron 24.x (#232441) ``                          |
| [`af4a1982`](https://github.com/NixOS/nixpkgs/commit/af4a1982edb5bf8792b9e64fcc642106403a56fa) | `` joplin: fix build on darwin ``                                               |
| [`5907564d`](https://github.com/NixOS/nixpkgs/commit/5907564df065fd0e63cd0b6070a48fa9829ed0b3) | `` purescript: Add aarch64-darwin target ``                                     |
| [`a8a453ca`](https://github.com/NixOS/nixpkgs/commit/a8a453caf8f93c6d72383f6844d3519d5a39ab5c) | `` python310Packages.torch: restrict platforms ``                               |
| [`1071529f`](https://github.com/NixOS/nixpkgs/commit/1071529f67f12823924bc37cefaaa0eabd6c75d1) | `` linuxKernel.kernels: remove CVE-2023-32233 patch from up-to-date kernels ``  |
| [`092f89bc`](https://github.com/NixOS/nixpkgs/commit/092f89bc39fb2d704facbfbc82e31529ce0a0c17) | `` wordpress: update languages and plugins ``                                   |
| [`44110aeb`](https://github.com/NixOS/nixpkgs/commit/44110aeb1198882555abc0084c9bb743d48574fa) | `` isabelle-linter: unstable-2022-09-05 -> 1.2.1 ``                             |
| [`2144f16c`](https://github.com/NixOS/nixpkgs/commit/2144f16ca5a4cf7b562f2089b4874ddc56a30f92) | `` n8n: 0.225.2 -> 0.227.1 ``                                                   |
| [`40a2df0f`](https://github.com/NixOS/nixpkgs/commit/40a2df0fb0e2c194ded70b7d95a064b1bbf676e7) | `` nixos/syncthing: fixup #226088 ``                                            |
| [`3a0ab523`](https://github.com/NixOS/nixpkgs/commit/3a0ab52313f2c00b211c0d5a34d10e7e82fe3f92) | `` wordpress: fix generate.sh ``                                                |
| [`06c774fb`](https://github.com/NixOS/nixpkgs/commit/06c774fb8e6dc1e9a867df811c93a3a37dc82706) | `` zammad: allow on aarch64-linux ``                                            |
| [`8c5087c1`](https://github.com/NixOS/nixpkgs/commit/8c5087c1f669fea2943259f11867a761c441e2d2) | `` zammad: link test in passthru.tests ``                                       |
| [`a8b64944`](https://github.com/NixOS/nixpkgs/commit/a8b64944b0ebe709c44794ba26fcdbff099c59cb) | `` linux/hardened/patches/6.1: 6.1.27-hardened1 -> 6.1.28-hardened1 ``          |
| [`a8097be9`](https://github.com/NixOS/nixpkgs/commit/a8097be96126d9e0d21831e415faef45c3862cda) | `` linux/hardened/patches/5.15: 5.15.110-hardened1 -> 5.15.111-hardened1 ``     |
| [`5c05de9f`](https://github.com/NixOS/nixpkgs/commit/5c05de9fb65e75d3dcfecf3d1daa15d2e3e9115d) | `` linux-rt_6_1: 6.1.26-rt8 -> 6.1.28-rt10 ``                                   |
| [`d25c1c5b`](https://github.com/NixOS/nixpkgs/commit/d25c1c5b25924da9d67df51b42c697a417710c1a) | `` linux: 6.3.2 -> 6.3.3 ``                                                     |
| [`f0070d3c`](https://github.com/NixOS/nixpkgs/commit/f0070d3c9099e2867aaba8f48009348088998be8) | `` linux: 6.2.15 -> 6.2.16 ``                                                   |
| [`bad1b07d`](https://github.com/NixOS/nixpkgs/commit/bad1b07d9df6a537b6f91d77b485658b6d6a0fdd) | `` linux: 6.1.28 -> 6.1.29 ``                                                   |
| [`c9334583`](https://github.com/NixOS/nixpkgs/commit/c9334583006911e8c65de9b22fb7d5f2a0615e96) | `` linux: 5.4.242 -> 5.4.243 ``                                                 |
| [`e91187fd`](https://github.com/NixOS/nixpkgs/commit/e91187fdda7a2c776d42bb682c4447616f580bf8) | `` linux: 5.15.111 -> 5.15.112 ``                                               |
| [`bc431790`](https://github.com/NixOS/nixpkgs/commit/bc431790c277cbf610be4158c73d542e6b057201) | `` linux: 5.10.179 -> 5.10.180 ``                                               |
| [`9feb862c`](https://github.com/NixOS/nixpkgs/commit/9feb862c4ed20a256955af7b39f2a712f5d95044) | `` linux: 4.19.282 -> 4.19.283 ``                                               |
| [`33000729`](https://github.com/NixOS/nixpkgs/commit/330007294cebc5a7af6503da0737b29b47c5daba) | `` linux: 4.14.314 -> 4.14.315 ``                                               |
| [`149cdf41`](https://github.com/NixOS/nixpkgs/commit/149cdf413ca82e26e8ea14a62edd926ca85a977e) | `` mullvad-browser: 12.0.5 -> 12.0.6 (#232367) ``                               |
| [`96252379`](https://github.com/NixOS/nixpkgs/commit/962523799e7d3a82a14f1e7b06578a0b5d9c5727) | `` partition-manager: 22.12.1 -> 23.04.1 ``                                     |
| [`dcc7d64c`](https://github.com/NixOS/nixpkgs/commit/dcc7d64c43cce7e5ac9454f2ab9c8296e9a768f0) | `` oh-my-posh: 15.4.2 -> 16.4.2 ``                                              |
| [`6c9fe0be`](https://github.com/NixOS/nixpkgs/commit/6c9fe0bea0b7347ff5e8f46558a29ee40bf03f7f) | `` python3Packages.torchvision: 0.15.1 -> 0.15.2 ``                             |
| [`ce1398ca`](https://github.com/NixOS/nixpkgs/commit/ce1398cad8b5813117b36f085a2bea371d57d35a) | `` python3Packages.torchaudio: 2.0.1 -> 2.0.2 ``                                |
| [`41f73b7f`](https://github.com/NixOS/nixpkgs/commit/41f73b7fc70cbd421ce213c03df6b6570eba275c) | `` python3Packages.torch: 2.0.0 -> 2.0.1 ``                                     |
| [`dcce6ead`](https://github.com/NixOS/nixpkgs/commit/dcce6eadebaa47216473af5b083e7a066bb502ea) | `` jf: init at 0.2.2 ``                                                         |
| [`2c3a5a0f`](https://github.com/NixOS/nixpkgs/commit/2c3a5a0f2b6bcdd9f2e7c4bdc77da137f0cb3fcd) | `` libcpr: make curl a propagated build input ``                                |
| [`1b2e8915`](https://github.com/NixOS/nixpkgs/commit/1b2e8915e2e389f64771c08e6035437b8328d08e) | `` esphome: 2023.4.4 -> 2023.5.0 ``                                             |
| [`feb404e7`](https://github.com/NixOS/nixpkgs/commit/feb404e7c02f9e8f5108603ce87ad7555c25dcb5) | `` python3Packages.torchvision-bin: 0.15.1 -> 0.15.2 ``                         |
| [`85598f4c`](https://github.com/NixOS/nixpkgs/commit/85598f4cd3d69971a078381280e32d12f34cf249) | `` python3Packages.torchaudio-bin: 2.0.1 -> 2.0.2 ``                            |
| [`82c71e67`](https://github.com/NixOS/nixpkgs/commit/82c71e671ea49c521c3f863bf13c47230c1ca056) | `` python3Packages.torch-bin: 2.0.0 -> 2.0.1 ``                                 |
| [`951deaab`](https://github.com/NixOS/nixpkgs/commit/951deaab3dbe8780d91a5768486ab296e1a60a33) | `` wallutils: 5.12.5 -> 5.12.7 ``                                               |
| [`6119afdc`](https://github.com/NixOS/nixpkgs/commit/6119afdc428b1c9a2e0a6d6076fe6ea1f1e989ca) | `` python310Packages.django-context-decorator: 1.5.0 -> 1.6.0 ``                |
| [`2e485f25`](https://github.com/NixOS/nixpkgs/commit/2e485f2581810ad51636cd6950bbc62eb4aaa16b) | `` lib.types.submoduleWith: Interoperate with older version of submoduleWith `` |
| [`fe167c44`](https://github.com/NixOS/nixpkgs/commit/fe167c44f9b28046c4e824bb22dbdbe317b55746) | `` python310Packages.anthropic: 0.2.7 -> 0.2.9 ``                               |
| [`a94631c6`](https://github.com/NixOS/nixpkgs/commit/a94631c6a80bc389f7b1e314a9d23461e32d7b37) | `` python310Packages.wn: 0.9.3 -> 0.9.4 ``                                      |
| [`cc09f943`](https://github.com/NixOS/nixpkgs/commit/cc09f9434749310aca0dbae39dd840c344905b44) | `` python3Packages.langchain: 0.0.168 -> 0.0.170 ``                             |
| [`86c366b4`](https://github.com/NixOS/nixpkgs/commit/86c366b4405a02f597edb066ffb9041e07ca28de) | `` nixos/grafana-agent: remove deprecated option (#232375) ``                   |
| [`87a34eee`](https://github.com/NixOS/nixpkgs/commit/87a34eee3864037e8c8f680cef179a4c617b8d58) | `` fwupd: 1.8.14 -> 1.8.15 ``                                                   |
| [`cc5e50c7`](https://github.com/NixOS/nixpkgs/commit/cc5e50c720366c659c9f8f493ca18075ec6e7815) | `` python3Packages.edk2-pytool-library: init at 0.14.1 ``                       |
| [`112849bd`](https://github.com/NixOS/nixpkgs/commit/112849bd19c460757d15d6021e4be0033314dfc3) | `` wordpress6_2: 6.2 -> 6.2.1 ``                                                |
| [`2b046918`](https://github.com/NixOS/nixpkgs/commit/2b046918906f63555ec5e400e7d09f59163d2ba6) | `` libcpr: 1.10.2 -> 1.10.3 ``                                                  |
| [`d1b93f70`](https://github.com/NixOS/nixpkgs/commit/d1b93f70f00660d86d1a69c0890aad2514612d4c) | `` python311Packages.plugwise: 0.31.2 -> 0.31.3 ``                              |
| [`c039951f`](https://github.com/NixOS/nixpkgs/commit/c039951fea36c7b5ed0bfb32ff7950efb7deea4b) | `` androidStudioPackages.stable: 2022.2.1.18 -> 2022.2.1.19 ``                  |
| [`f6e7db0d`](https://github.com/NixOS/nixpkgs/commit/f6e7db0da0aa09dc87eb9afe8d536d5d25b6b492) | `` python310Packages.angr: 9.2.50 -> 9.2.51 ``                                  |
| [`052a35fd`](https://github.com/NixOS/nixpkgs/commit/052a35fd4ce5ef84ae977fe0c99bbe3b9342615e) | `` python310Packages.cle: 9.2.50 -> 9.2.51 ``                                   |
| [`d3f050c9`](https://github.com/NixOS/nixpkgs/commit/d3f050c9d80b7870bb3d412be876cb985f5413b2) | `` python310Packages.claripy: 9.2.50 -> 9.2.51 ``                               |
| [`f8658a8a`](https://github.com/NixOS/nixpkgs/commit/f8658a8ae5c9d1e979765a07016642ced917ff1e) | `` python310Packages.pyvex: 9.2.50 -> 9.2.51 ``                                 |
| [`a6b6b92a`](https://github.com/NixOS/nixpkgs/commit/a6b6b92aeeecb0fe5e979bc4392613842c452904) | `` python310Packages.ailment: 9.2.50 -> 9.2.51 ``                               |
| [`b3132434`](https://github.com/NixOS/nixpkgs/commit/b31324342d089aaf8da03ebfb3533b336ba9d31b) | `` python310Packages.archinfo: 9.2.50 -> 9.2.51 ``                              |
| [`af7f8a2a`](https://github.com/NixOS/nixpkgs/commit/af7f8a2a1275e243b4e5133f2c6811805e040789) | `` python310Packages.shodan: add changelog to meta ``                           |
| [`31e12507`](https://github.com/NixOS/nixpkgs/commit/31e1250786c2ef785f368d66b7f09d2081838c05) | `` ibus-engines.typing-booster-unwrapped: 2.22.4 -> 2.22.5 ``                   |
| [`d52c763b`](https://github.com/NixOS/nixpkgs/commit/d52c763b99ca324c10c91d245b9b57a81d6d342b) | ``  python310Packages.pyjnius: disable on unsupported Python releases ``        |
| [`a98b9e25`](https://github.com/NixOS/nixpkgs/commit/a98b9e251bf191c4de9a12b0490472779a3dd334) | `` python310Packages.pyjnius: add changelog to meta ``                          |
| [`601dfdb8`](https://github.com/NixOS/nixpkgs/commit/601dfdb82e15f2265bf8c31ddb7ac13b1699ca15) | `` python311Packages.google-cloud-datastore: 2.15.1 -> 2.15.2 ``                |
| [`e0f5b877`](https://github.com/NixOS/nixpkgs/commit/e0f5b877be04ad5e14907888d7c61987af94148e) | `` mutagen-compose: 0.16.5 -> 0.17.1 ``                                         |
| [`edbe9b5a`](https://github.com/NixOS/nixpkgs/commit/edbe9b5ad68af9a73f1f8402aed758a58de803bc) | `` mutagen: 0.17.0 -> 0.17.1 ``                                                 |
| [`b558b26e`](https://github.com/NixOS/nixpkgs/commit/b558b26eed1d3cd59886559cd98617bf721dd745) | `` python310Packages.shodan: 1.28.0 -> 1.29.0 ``                                |
| [`4e70a8f3`](https://github.com/NixOS/nixpkgs/commit/4e70a8f3933202a8521ecd002400f36da742b98a) | `` python310Packages.roombapy: 1.6.8 -> 1.6.9 ``                                |
| [`b7a367f8`](https://github.com/NixOS/nixpkgs/commit/b7a367f8766198d25b556a68de9dc37965fe38da) | `` phockup: 1.9.2 -> 1.10.1 ``                                                  |
| [`ae2918bc`](https://github.com/NixOS/nixpkgs/commit/ae2918bcf11284c1d1b30d60c6bed9082af57dcd) | `` cutter: 2.2.0 -> 2.2.1 ``                                                    |
| [`a877b781`](https://github.com/NixOS/nixpkgs/commit/a877b781e50b1be78e8826c850aed6081624bf94) | `` python310Packages.pdm-backend: 2.0.6 -> 2.0.7 ``                             |
| [`d4bf8d17`](https://github.com/NixOS/nixpkgs/commit/d4bf8d17c635494884935a8847582d0c1c5eca44) | `` glab: 1.28.0 -> 1.29.4 ``                                                    |
| [`ed3e3d8a`](https://github.com/NixOS/nixpkgs/commit/ed3e3d8aa36fb381566a018dfee193e696924903) | `` python310Packages.pyjnius: 1.4.2 -> 1.5.0 ``                                 |
| [`e73aa7f5`](https://github.com/NixOS/nixpkgs/commit/e73aa7f5c5ca71b5dacbfecdb86bd64e77c4069e) | `` python3Packages.mautrix: 0.19.13 -> 0.19.14 ``                               |
| [`a5b1638a`](https://github.com/NixOS/nixpkgs/commit/a5b1638a9b275fdbcfdf435f5e75e10a056e0475) | `` v2ray-domain-list-community: 20230407083123 -> 20230517022917 ``             |
| [`5f2061d0`](https://github.com/NixOS/nixpkgs/commit/5f2061d0d54d8ab34908f982464118c521b17088) | `` v2ray-geoip: 202305040042 -> 202305110042 ``                                 |
| [`07f48de4`](https://github.com/NixOS/nixpkgs/commit/07f48de4b7fb85432d2c80ad85d7dcdaf2fdf3de) | `` python310Packages.unearth: 0.9.0 -> 0.9.1 ``                                 |
| [`0b04d4d4`](https://github.com/NixOS/nixpkgs/commit/0b04d4d495de10e7fa633a3dab2f5a619966b8d7) | `` python310Packages.nbdev: 2.3.11 -> 2.3.12 ``                                 |
| [`1419b8ec`](https://github.com/NixOS/nixpkgs/commit/1419b8ecb6395faf8df68330706408e5d29f1eec) | `` mdbook-katex: 0.4.1 -> 0.4.2 ``                                              |
| [`b1c0f3be`](https://github.com/NixOS/nixpkgs/commit/b1c0f3bec2698cdce9f8be93072f7bf39c8e854e) | `` nodejs_19: drop ``                                                           |
| [`f48919f8`](https://github.com/NixOS/nixpkgs/commit/f48919f89f3fb14a3d0953059477db4bb311d55a) | `` _1password: 2.17.0 -> 2.18.0 ``                                              |
| [`793d3463`](https://github.com/NixOS/nixpkgs/commit/793d3463045d1167fa72bff627d1f7655dd243c8) | `` nodejs_20: 20.1.0 -> 20.2.0 ``                                               |
| [`0b84f6b9`](https://github.com/NixOS/nixpkgs/commit/0b84f6b9a93452c4d5b012694665ed43d976acf0) | `` threatest: 1.1.1 -> 1.2.0 ``                                                 |
| [`1ca1add5`](https://github.com/NixOS/nixpkgs/commit/1ca1add59b9ab65cb293f78717b99b9f66bb40df) | `` mage: 1.14.0 -> 1.15.0 ``                                                    |
| [`88074794`](https://github.com/NixOS/nixpkgs/commit/880747942a2ad86b0ce6b3758e91cb8f639098bf) | `` brev-cli: 0.6.224 -> 0.6.227 ``                                              |
| [`783a8712`](https://github.com/NixOS/nixpkgs/commit/783a8712f2e18a06b13a2663005a349625264c40) | `` tektoncd-cli: 0.30.1 -> 0.31.0 ``                                            |
| [`f36370a8`](https://github.com/NixOS/nixpkgs/commit/f36370a8787ce691330c6d5c3a9ed4e08c5e93bc) | `` python310Packages.pipdeptree: 2.7.0 -> 2.7.1 ``                              |
| [`d457cf26`](https://github.com/NixOS/nixpkgs/commit/d457cf2601d73dbfb047e874221d76cbb74f43ab) | `` flyway: 9.17.0 -> 9.18.0 ``                                                  |
| [`1b5f071f`](https://github.com/NixOS/nixpkgs/commit/1b5f071fbd146741fb9fdd36a47386b06ca9d660) | `` python310Packages.poetry-dynamic-versioning: 0.21.4 -> 0.21.5 ``             |
| [`61ec73f2`](https://github.com/NixOS/nixpkgs/commit/61ec73f2c698eb65a1490dab106e2aff184fb089) | `` timeular: 5.7.8 -> 5.8.7 ``                                                  |
| [`b4845456`](https://github.com/NixOS/nixpkgs/commit/b48454560360219e9b2e9989d05fb709d92e0335) | `` cilium-cli: 0.14.1 -> 0.14.2 ``                                              |
| [`45d7f9fc`](https://github.com/NixOS/nixpkgs/commit/45d7f9fcc39c820d11c72bf4c2f1f667b5c8d01e) | `` yubioath-flutter: fix build by relaxing helper deps ``                       |
| [`8823553e`](https://github.com/NixOS/nixpkgs/commit/8823553e51ff57c6260f53c37a0cdae0833fd63d) | `` temporal: 1.20.2 -> 1.20.3 ``                                                |
| [`95d6d9c3`](https://github.com/NixOS/nixpkgs/commit/95d6d9c3f9ee389fffa337e9d73e88d6fa8e0bf9) | `` mumble: Fix 32-bit build ``                                                  |
| [`b166262b`](https://github.com/NixOS/nixpkgs/commit/b166262b1bd1770dd72e23295b8dfc4f08fa5cc0) | `` router: 1.18.0 -> 1.18.1 ``                                                  |
| [`2d128fec`](https://github.com/NixOS/nixpkgs/commit/2d128fec51f38ffb8cd1828e84a76bc4957bc977) | `` firefox-bin-unwrapped: 113.0 -> 113.0.1 ``                                   |
| [`120cb637`](https://github.com/NixOS/nixpkgs/commit/120cb637bbf69885c2615941c5c5fc71143a222f) | `` firefox-unwrapped: 113.0 -> 113.0.1 ``                                       |
| [`f38f6299`](https://github.com/NixOS/nixpkgs/commit/f38f6299e6b7f32671dbbde11ffa8b940d6a0c56) | `` palemoon-bin: 32.1.1 -> 32.2.0 ``                                            |
| [`504befb5`](https://github.com/NixOS/nixpkgs/commit/504befb5d60aae497ff5bc1ab1b56c2b46fee574) | `` Verible: 0.0.3179 -> 0.0.3253 ``                                             |
| [`6387628c`](https://github.com/NixOS/nixpkgs/commit/6387628ca35b82b0c7987fedb83b979416d0797c) | `` palemoon: 32.1.1 -> 32.2.0 ``                                                |
| [`83718633`](https://github.com/NixOS/nixpkgs/commit/837186331fe0705ebb7d3c2599f72c2be6109433) | `` python3Packages.geoip2: 4.6.0 -> 4.7.0 ``                                    |
| [`9e05db2b`](https://github.com/NixOS/nixpkgs/commit/9e05db2bc7e6ea291c7ee66835fb1a735fb457ff) | `` python3Packages.maxminddb: 2.2.0 -> 2.3.0 ``                                 |
| [`87f208b5`](https://github.com/NixOS/nixpkgs/commit/87f208b505f6aeb8aaa78aa31c5a2b560c1c4dab) | `` python310Packages.trackpy: add missing input looseversion ``                 |
| [`174a4a77`](https://github.com/NixOS/nixpkgs/commit/174a4a77aee758577da46cbea14c456306a36c77) | `` python310Packages.reportlab: 3.6.12 -> 3.6.13 ``                             |
| [`eefbea95`](https://github.com/NixOS/nixpkgs/commit/eefbea9557f23bbe16027d7b0fe5f82d62e6ef29) | `` python310Packages.qrcode: propagate setuptools ``                            |
| [`b7ac3019`](https://github.com/NixOS/nixpkgs/commit/b7ac30197b87876f6ec81917fae19f307e187499) | `` linux: enable zram writeback ``                                              |
| [`d6db3031`](https://github.com/NixOS/nixpkgs/commit/d6db303160000efbd402e2910accedef648872e6) | `` linux: enable RCU_LAZY where supported ``                                    |
| [`748d0ba7`](https://github.com/NixOS/nixpkgs/commit/748d0ba77f898a3db27edddf25be8083d7fd3e8d) | `` python3Packages.lazy_import: drop marenz as maintainer ``                    |