### PR TITLE
chore(flake/lanzaboote): `354ec6f4` -> `3a5e15f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -275,11 +275,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1684428412,
-        "narHash": "sha256-KUaSvryMxoRGjcMRNlz96AnteyTEv5cYrgLXnmCSpt0=",
+        "lastModified": 1684430190,
+        "narHash": "sha256-v5Uc5wP3HKHkp+26QtZLL1IIFnSLx33QCfPkgZt1Ei4=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "354ec6f451edcb8030da4768aa93d671d14f6271",
+        "rev": "3a5e15f4ac0a2ae9d0bf51080690ab677a4fc9e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                                |
| --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`f603e0c1`](https://github.com/nix-community/lanzaboote/commit/f603e0c134e606f6a7a845a6f2bd2d35354f3015) | `` tests: support TPM2 + SecureBoot tests ``                           |
| [`606b9e8b`](https://github.com/nix-community/lanzaboote/commit/606b9e8bab0c21c25e9e84056887bb291ab4e70a) | `` stub(tpm): Measure "UKI" (i.e. all unified sections in our stub) `` |