### PR TITLE
chore(flake/lanzaboote): `3a5e15f4` -> `7ed294c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1684430190,
-        "narHash": "sha256-v5Uc5wP3HKHkp+26QtZLL1IIFnSLx33QCfPkgZt1Ei4=",
+        "lastModified": 1684449391,
+        "narHash": "sha256-VV8YqRvIdEAheLUd36R7pXl0tAmk+4bECGYosLTGw6U=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "3a5e15f4ac0a2ae9d0bf51080690ab677a4fc9e4",
+        "rev": "7ed294c84da4bedd144a7525394ed7dbf01853da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                         |
| --------------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`ad28b4cd`](https://github.com/nix-community/lanzaboote/commit/ad28b4cd017b5eb2bc4cd3c4240dc5cc1bf3908f) | `` stub: bump crate to 0.3.0 `` |
| [`39cda9e4`](https://github.com/nix-community/lanzaboote/commit/39cda9e457841a7ab70fc1d98536dc9e40a2eaaf) | `` tool: bump crate to 0.3.0 `` |
| [`cc428efc`](https://github.com/nix-community/lanzaboote/commit/cc428efc862d9169f5c826f342ed9938c89ba70c) | `` flake: add cargo-release ``  |