### PR TITLE
chore(flake/home-manager): `c10403a5` -> `b9a52ad2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -209,11 +209,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684442239,
-        "narHash": "sha256-8wD+fQpNULCF9a88E1Knw3MtXWqvyhn8u/859QSSoE4=",
+        "lastModified": 1684484967,
+        "narHash": "sha256-P3ftCqeJmDYS9LSr2gGC4XGGcp5vv8TOasJX6fVHWsw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c10403a5739d6275334710903fe709bc8d587980",
+        "rev": "b9a52ad20e58ebd003444915e35e3dd2c18fc715",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`b9a52ad2`](https://github.com/nix-community/home-manager/commit/b9a52ad20e58ebd003444915e35e3dd2c18fc715) | `` script-directory: add module (#3995) `` |