### PR TITLE
chore(flake/nixpkgs): `48a0fb7a` -> `5b1bc788`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684385584,
-        "narHash": "sha256-O7y0gK8OLIDqz+LaHJJyeu09IGiXlZIS3+JgEzGmmJA=",
+        "lastModified": 1684481515,
+        "narHash": "sha256-sDMEZ4HLP6sVNiBcgla3KWihdDjh67DP5ZWkGKWFgY0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48a0fb7aab511df92a17cf239c37f2bd2ec9ae3a",
+        "rev": "5b1bc788f578cd83d54b48bb057d6f6703ae7725",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`ad86cb32`](https://github.com/NixOS/nixpkgs/commit/ad86cb327212828c44236aff5fe0d3ba452a8f56) | `` pasystray: 0.7.1 -> 0.8.2 ``                                           |
| [`3041059a`](https://github.com/NixOS/nixpkgs/commit/3041059a288d155dd72fdca4812ec383e08e4489) | `` polypane: 13.0.3 -> 13.1.2 ``                                          |
| [`44d0de34`](https://github.com/NixOS/nixpkgs/commit/44d0de3499c11f5c9817a00fec76386ae16ff606) | `` trufflehog: 3.34.0 -> 3.36.0 ``                                        |
| [`278dc7dd`](https://github.com/NixOS/nixpkgs/commit/278dc7dda3694f10c437a4df588cba51ce45c1a9) | `` cargo-ndk: 3.0.1 -> 3.1.2 ``                                           |
| [`597b9c06`](https://github.com/NixOS/nixpkgs/commit/597b9c0682293e936b4300d39161981d8e328bf3) | `` shell-genie: 0.2.8 -> 0.2.10 ``                                        |
| [`395144ca`](https://github.com/NixOS/nixpkgs/commit/395144ca7ab7721c05e2c522a42a407fe473bddd) | `` python311Packages.rapt-ble: 0.1.0 -> 0.1.1 ``                          |
| [`3e5cb8a4`](https://github.com/NixOS/nixpkgs/commit/3e5cb8a4f89e108062be142ddb31ff14d62e52ab) | `` brook: 20230404.5.1 -> 20230601 ``                                     |
| [`b6d1cbfc`](https://github.com/NixOS/nixpkgs/commit/b6d1cbfcf1de01416634a23b8d9d1c525a242cf0) | `` python311Packages.numpy-stl: 3.0.0 -> 3.0.1 ``                         |
| [`5c7f6156`](https://github.com/NixOS/nixpkgs/commit/5c7f615664a8275b2f291b34bfb088eb4843913c) | `` dnscontrol: 3.31.4 -> 4.0.0 ``                                         |
| [`54959604`](https://github.com/NixOS/nixpkgs/commit/54959604428b91087751d011b1ea18dbd65a05cf) | `` cargo-shuttle: fix pname ``                                            |
| [`3c6423d3`](https://github.com/NixOS/nixpkgs/commit/3c6423d3211c8d1354a23bd230a73d4452ab1cc4) | `` crossfire-server: Use python39 instead of python3 (#232282) ``         |
| [`2a49ffd1`](https://github.com/NixOS/nixpkgs/commit/2a49ffd1580c5dc5042a71ffb8c6f7365a424a8a) | `` live555: 2023.03.30 -> 2023.05.10 ``                                   |
| [`745a1425`](https://github.com/NixOS/nixpkgs/commit/745a1425f6721e1aa5d4ecc102c1fc4939672f76) | `` nls: init at 1.0.0 ``                                                  |
| [`f6e33f6a`](https://github.com/NixOS/nixpkgs/commit/f6e33f6aa36de8b6fb12b9ed140b6457b813a058) | `` nickel: 0.3.1 -> 1.0.0 ``                                              |
| [`58cbf088`](https://github.com/NixOS/nixpkgs/commit/58cbf088e4e322bb2b4b115c8e395e7d33371f04) | `` nickel: add passthru.updateScript ``                                   |
| [`b2bcabde`](https://github.com/NixOS/nixpkgs/commit/b2bcabde73bb9d4a410895e092ba2e4d74ac46fd) | `` nickel: add felschr as maintainer ``                                   |
| [`faf9b69f`](https://github.com/NixOS/nixpkgs/commit/faf9b69f8dd4e8c8b250a1346ed587a937ff8978) | `` reindeer: init at unstable-2023-05-18 ``                               |
| [`97c88173`](https://github.com/NixOS/nixpkgs/commit/97c8817371d1251a3353651c4c1152d683f4d6d9) | `` nixos/clickhouse: Notify systemd about successful startup (#232443) `` |
| [`cf63649b`](https://github.com/NixOS/nixpkgs/commit/cf63649b51b4cd9160493a45e148e999d4075205) | `` anomalocaris: add to maintainers ``                                    |
| [`9f5d86c4`](https://github.com/NixOS/nixpkgs/commit/9f5d86c40703712b9824da89a1a6b5d52283714b) | `` handlr-regex: init at 0.8.5 ``                                         |
| [`bec29a03`](https://github.com/NixOS/nixpkgs/commit/bec29a0327d357db8ca6f46020c391622d5b98d8) | `` helm-dashboard: init at 1.3.1 (#231299) ``                             |
| [`f744a2df`](https://github.com/NixOS/nixpkgs/commit/f744a2df21084a359bfcc60a320ac1a94913e69c) | `` clickhouse: 22.8.5.29 -> 23.3.1.2823 ``                                |
| [`2812ca55`](https://github.com/NixOS/nixpkgs/commit/2812ca551a18a835c5b059198077ec0295b02a9e) | `` i3status-rust: 0.31.4 -> 0.31.5 ``                                     |
| [`a4449ccc`](https://github.com/NixOS/nixpkgs/commit/a4449ccc38bbbdeb307891e3f21491f1cbda282d) | `` cider 1.6.0 -> 1.6.1  ``                                               |
| [`ff51a8d4`](https://github.com/NixOS/nixpkgs/commit/ff51a8d441635c8da580731cea40b068737802c2) | `` felix-fm: 2.2.7 -> 2.2.8 ``                                            |
| [`38f9b3d9`](https://github.com/NixOS/nixpkgs/commit/38f9b3d9dc9ec699f77bc451b3fff17fa9cd4313) | `` ruff: 0.0.267 -> 0.0.269 ``                                            |
| [`f09d9019`](https://github.com/NixOS/nixpkgs/commit/f09d9019f97b91dee12b8a8cd0e9bef73ec6336c) | `` maintainers: add nickgerace ``                                         |
| [`1ca636d1`](https://github.com/NixOS/nixpkgs/commit/1ca636d15e73fca28445ebaf23b26672460568d7) | `` python311Packages.plum-py: add changelog to meta ``                    |
| [`916f3fdd`](https://github.com/NixOS/nixpkgs/commit/916f3fdd4d005048825f4eb60f754cf3047d1478) | `` python311Packages.plum-py: 0.8.5 -> 0.8.6 ``                           |
| [`9989f9d2`](https://github.com/NixOS/nixpkgs/commit/9989f9d20cd79a604f15dcac24f4f228cc7038b7) | `` pattypan: build with JDK that includes JavaFX ``                       |
| [`384fb522`](https://github.com/NixOS/nixpkgs/commit/384fb52227aa270e76936c61bec40f993f71057e) | `` pre-commit: 3.3.1 -> 3.3.2 ``                                          |
| [`66f37ec3`](https://github.com/NixOS/nixpkgs/commit/66f37ec350d2bdd18ca684f4986c834ddad2d197) | `` nurl: 0.3.11 -> 0.3.12 ``                                              |
| [`192910cd`](https://github.com/NixOS/nixpkgs/commit/192910cd70c05306242438ab6a68a85be97d6f76) | `` python311Packages.flax: mark as broken ``                              |
| [`c35f96ef`](https://github.com/NixOS/nixpkgs/commit/c35f96ef725aad9b95056840e2752412988214d5) | `` python311Packages.flax: add changelog to meta ``                       |
| [`e56682c1`](https://github.com/NixOS/nixpkgs/commit/e56682c122da193bbf6b941524e9ebb62727d4d9) | `` python311Packages.pex: 2.1.135 -> 2.1.137 ``                           |
| [`d0e79956`](https://github.com/NixOS/nixpkgs/commit/d0e7995686b30253cbab5e1a37c4d19fbaac0704) | `` python311Packages.invocations: 3.1.0 -> 3.3.0 ``                       |
| [`5f55e6a3`](https://github.com/NixOS/nixpkgs/commit/5f55e6a3d231a44fe8d487cd1b8312d494d12e02) | `` python311Packages.holidays: 0.24 -> 0.25 ``                            |
| [`ed01285e`](https://github.com/NixOS/nixpkgs/commit/ed01285e71d860aa0214c935a68e41cfe988b7ab) | `` python311Packages.exif: aadd changelog to meta ``                      |
| [`8c3476df`](https://github.com/NixOS/nixpkgs/commit/8c3476dfdfac6ba97221413c7fd95f18377b00f1) | `` python311Packages.exif: 1.3.5 -> 1.6.0 ``                              |
| [`a80f972c`](https://github.com/NixOS/nixpkgs/commit/a80f972c15404effaf7b62b72705430aba6aa2dd) | `` firmware-manager: unstable-2022-12-09 -> 0.1.5 ``                      |
| [`3733d828`](https://github.com/NixOS/nixpkgs/commit/3733d828401092b50b68c11a5d8bd2a2733663b4) | `` python311Packages.cypherpunkpay: switch to pythonRelaxDepsHook ``      |
| [`c46eda3c`](https://github.com/NixOS/nixpkgs/commit/c46eda3c6cecad079b343160ff780c0ae1c706c3) | `` cargo-ndk: support Darwin builds ``                                    |
| [`c0649856`](https://github.com/NixOS/nixpkgs/commit/c064985640cf4544dd4f7a9bce249d5c77e5003c) | `` python311Packages.colout: specify license ``                           |
| [`0ddb3429`](https://github.com/NixOS/nixpkgs/commit/0ddb34290f4028d782b3f0c0258147fc50b619b6) | `` python311Packages.colout: 0.12.0 -> 1.1 ``                             |
| [`177aecab`](https://github.com/NixOS/nixpkgs/commit/177aecab4a78e606d026a8679b1772fd77e94d97) | `` python311Packages.bimmer-connected: 0.13.3 -> 0.13.5 ``                |
| [`df4d327e`](https://github.com/NixOS/nixpkgs/commit/df4d327e5973a8595f47800069cbf5928f8e7f68) | `` python311Packages.bitstring: 4.0.1 -> 4.0.2 ``                         |
| [`9fcc3d3f`](https://github.com/NixOS/nixpkgs/commit/9fcc3d3f9d6c19836ed0ca5488cb9b2fa89012d6) | `` python311Packages.azure-storage-blob: 12.15.0 -> 12.16.0 ``            |
| [`e579bf5e`](https://github.com/NixOS/nixpkgs/commit/e579bf5e93de693ddee3a1de26b38307fda42005) | `` python311Packages.azure-multiapi-storage: 1.0.0 -> 1.1.0 ``            |
| [`43fd00ff`](https://github.com/NixOS/nixpkgs/commit/43fd00ff4a18bdcbef53993249f954ebd014c7d2) | `` python311Packages.azure-mgmt-resource: 23.0.0 -> 23.0.1 ``             |
| [`c280495f`](https://github.com/NixOS/nixpkgs/commit/c280495fad0b16b7d14f5c311fe6ea5ec3f59445) | `` python311Packages.azure-mgmt-recoveryservicesbackup: 5.1.0 -> 6.0.0 `` |
| [`4a471873`](https://github.com/NixOS/nixpkgs/commit/4a471873e3ea7d5b57d4abf2b637133f8fc39033) | `` python311Packages.azure-datalake-store: 0.0.52 -> 0.0.53 ``            |
| [`c10c8b65`](https://github.com/NixOS/nixpkgs/commit/c10c8b65bff6763cc836fd25d92cb8cd7ca62980) | `` python311Packages.azure-mgmt-containerservice: 22.1.0 -> 23.0.0 ``     |
| [`41347c5b`](https://github.com/NixOS/nixpkgs/commit/41347c5b9c6d69b2b58b516a0c2f801907fe6b54) | `` pulumi-bin: 3.65.1 -> 3.67.1 ``                                        |
| [`0940a244`](https://github.com/NixOS/nixpkgs/commit/0940a244e5b4bd88c10be12e818a4a17996c8642) | `` python311Packages.azure-synapse-artifacts: 0.15.0 -> 0.16.0 ``         |
| [`a10ecb37`](https://github.com/NixOS/nixpkgs/commit/a10ecb37078e152a40f51bb31448b719f0a369d3) | `` python311Packages.funcparserlib: 1.0.0 -> 1.0.1 ``                     |
| [`2a9dbb44`](https://github.com/NixOS/nixpkgs/commit/2a9dbb449cbd292866b593f77d5b82c74b6c8a28) | `` python311Packages.google-auth: 2.17.3 -> 2.18.1 ``                     |
| [`dde15f06`](https://github.com/NixOS/nixpkgs/commit/dde15f06875fd89c0f3139ee40d4c90a4566e91d) | `` python311Packages.google-cloud-resource-manager: 1.10.0 -> 1.10.1 ``   |
| [`55192848`](https://github.com/NixOS/nixpkgs/commit/55192848d503f1d1695ac3af1204452427530e13) | `` smartdns: 41 -> 42 ``                                                  |
| [`48143308`](https://github.com/NixOS/nixpkgs/commit/4814330817266eed4260867dd9a70ff9f1f4afff) | `` python311Packages.google-cloud-kms: 2.16.1 -> 2.17.0 ``                |
| [`d954d016`](https://github.com/NixOS/nixpkgs/commit/d954d016f1f02813367ba04eaba17cc34b4b868c) | `` python311Packages.google-cloud-spanner: 3.33.0 -> 3.34.0 ``            |
| [`f3afb133`](https://github.com/NixOS/nixpkgs/commit/f3afb133fe20785061ff5a20aa8b87d11276b441) | `` nextpnr: 0.5 -> 0.6 ``                                                 |
| [`dfcff674`](https://github.com/NixOS/nixpkgs/commit/dfcff674e089dd4ecc0ba5db1aa094f1f50a0387) | `` win-spice: fix build ``                                                |
| [`a771af89`](https://github.com/NixOS/nixpkgs/commit/a771af8900ebcbb50a6f80933e6077208c23c3a4) | `` ashpd-demo: 0.2.2 → 0.3.0 ``                                           |
| [`8bf19679`](https://github.com/NixOS/nixpkgs/commit/8bf196796456cc9e7b6685d74741bf2cf305234c) | `` doc/stdenv/Dependencies: fix inference rule var name ``                |
| [`edf56596`](https://github.com/NixOS/nixpkgs/commit/edf56596888b1028584adc0cda9c992b098d3fe8) | `` systemd.units.<name>.wantedBy: fix documentation rendering ``          |
| [`e84ca1b8`](https://github.com/NixOS/nixpkgs/commit/e84ca1b8397214627f63344564194e6959825d8f) | `` calibre-web: fix `requests` dependency error ``                        |
| [`fb6410b1`](https://github.com/NixOS/nixpkgs/commit/fb6410b1c998f3f37a1cf433b6d8beb9bf6e99fc) | `` nushell: 0.79.0 -> 0.80.0 ``                                           |
| [`63c4d432`](https://github.com/NixOS/nixpkgs/commit/63c4d4328d384a601822db87b539dcd5d34d8637) | `` dra-cla: init at 2023-03-10 ``                                         |
| [`ad0fa6ee`](https://github.com/NixOS/nixpkgs/commit/ad0fa6ee29c2413265831e243c3fa1631bf6f68e) | `` python311Packages.exchangelib: 5.0.2 -> 5.0.3 ``                       |
| [`e9badc5e`](https://github.com/NixOS/nixpkgs/commit/e9badc5e603ccc6e8f617ea4b193a0e7b82d4f26) | `` python310Packages.pypck: 0.7.16 -> 0.7.17 ``                           |
| [`860fbcee`](https://github.com/NixOS/nixpkgs/commit/860fbcee793a42e867ac925d69e9a2e88616ca2b) | `` python311Packages.aggdraw: 1.3.15 -> 1.3.16 ``                         |
| [`f7a6fb04`](https://github.com/NixOS/nixpkgs/commit/f7a6fb0402a6a208a9828f265e603fdcc6bb057b) | `` python311Packages.accuweather: 0.5.1 -> 0.5.2 ``                       |
| [`f550c12a`](https://github.com/NixOS/nixpkgs/commit/f550c12a25e210d65d195355ff827eaf52b866a0) | `` log4cxx: 0.10.0 -> 1.1.0 ``                                            |
| [`26db9b95`](https://github.com/NixOS/nixpkgs/commit/26db9b9527c29f0945af0e613845680c140e9ee1) | `` linux/common-config: fix i686 ``                                       |
| [`df4bb510`](https://github.com/NixOS/nixpkgs/commit/df4bb510a6b7e6675e93fa6ffe64b75a2b2b0785) | `` netlify-cli: Upgrade to nodejs_18 ``                                   |
| [`23b86ffd`](https://github.com/NixOS/nixpkgs/commit/23b86ffd81342d0da5e6c35b03d9e487fd070b30) | `` base16384: 2.2.2 -> 2.2.3 ``                                           |
| [`27e3c0da`](https://github.com/NixOS/nixpkgs/commit/27e3c0da4437131f3c01d2b82ecb98d9046b0997) | `` qemu: add capstone support ``                                          |
| [`26a72b29`](https://github.com/NixOS/nixpkgs/commit/26a72b293738b24a3d49319aff1f12719797182c) | `` sniffnet: 1.1.4 -> 1.2.0 ``                                            |
| [`731b0007`](https://github.com/NixOS/nixpkgs/commit/731b00074fc6dac1dbc69e6cb50f3a4b1476c920) | `` checkov: 2.3.237 -> 2.3.246 ``                                         |
| [`4650c435`](https://github.com/NixOS/nixpkgs/commit/4650c4350a520642b03ce7e6642698b7c217deba) | `` dvc: 2.56.0 -> 2.57.2 ``                                               |
| [`c8ae2377`](https://github.com/NixOS/nixpkgs/commit/c8ae2377b77e7618155585a53d205d16185fe831) | `` python311Packages.dvc-studio-client: 0.9.0 -> 0.9.2 ``                 |
| [`a33b24f0`](https://github.com/NixOS/nixpkgs/commit/a33b24f0384be586ad45c7af9ff085a9e0314a62) | `` libdeltachat: 1.114.0 -> 1.115.0 ``                                    |
| [`b74b868c`](https://github.com/NixOS/nixpkgs/commit/b74b868ce02413d778f2f4eb6e1eced6b60598ee) | `` iptsd: 1.2.0 -> 1.2.1 ``                                               |
| [`db8103f9`](https://github.com/NixOS/nixpkgs/commit/db8103f909784ad7ccb000f1c499f73f63d06720) | `` python311Packages.bc-detect-secrets: 1.4.27 -> 1.4.28 ``               |
| [`bc359cb0`](https://github.com/NixOS/nixpkgs/commit/bc359cb075994ca3a864ab7a182ac8fa672a852b) | `` evcc: 0.117.2 -> 0.117.4 ``                                            |
| [`d8b26a4e`](https://github.com/NixOS/nixpkgs/commit/d8b26a4ec11e6ec1af9ca36d9e93aafb5f1f3b90) | `` moar: 1.14.0 -> 1.15.0 ``                                              |
| [`d8cc0474`](https://github.com/NixOS/nixpkgs/commit/d8cc04741f936a508f7ba3bc42caab3ccb0b951b) | `` python310Packages.django-bootstrap4: 3.0.1 -> 23.1 ``                  |
| [`9f3b5383`](https://github.com/NixOS/nixpkgs/commit/9f3b538371f72a41ffaf3ac3f71bd0512b85123b) | `` palemoon: Drop ``                                                      |
| [`858533dd`](https://github.com/NixOS/nixpkgs/commit/858533dd4ce98b64fb63a641660e202a8224123d) | `` sic-image-cli: 0.22.2 -> 0.22.3 ``                                     |
| [`52038c0d`](https://github.com/NixOS/nixpkgs/commit/52038c0d019c66e515460f48599843053209bc96) | `` terraria-server: add dependency ``                                     |
| [`9f356b9f`](https://github.com/NixOS/nixpkgs/commit/9f356b9f118948ea84e77c837d726dbffe665b70) | `` jql: 6.0.7 -> 6.0.8 ``                                                 |
| [`e7820571`](https://github.com/NixOS/nixpkgs/commit/e7820571fc84689b3a6ae42815ae975aa35c9d72) | `` mu: generate mu4e-autoloads.el ``                                      |
| [`2f962779`](https://github.com/NixOS/nixpkgs/commit/2f9627794dde850e401038b8528c7952516b1424) | `` shopware-cli: 0.1.70 -> 0.1.71 ``                                      |
| [`c64d445d`](https://github.com/NixOS/nixpkgs/commit/c64d445d6c323f95d653a6964d3786d68751c650) | `` esphome: 2023.5.0. -> 2023.5.1 ``                                      |
| [`b451cc76`](https://github.com/NixOS/nixpkgs/commit/b451cc766836b00956c65e262b06b126e88640ab) | `` nixos/libinput: only enable when X11 is enabled ``                     |
| [`0bfa6b2f`](https://github.com/NixOS/nixpkgs/commit/0bfa6b2fbec7e9f782b4b510c4dd5691fb36a60b) | `` python311Packages.aioswitcher: 3.3.0 -> 3.4.0 ``                       |
| [`4520b86f`](https://github.com/NixOS/nixpkgs/commit/4520b86fd1c43ca91c45757046cefb6b5706a40a) | `` python311Packages.simplisafe-python: 2023.04.0 -> 2023.05.0 ``         |
| [`4515ff7c`](https://github.com/NixOS/nixpkgs/commit/4515ff7c40614d43e0ee1abeb77b4dc0b68ff482) | `` ospd-openvas: 22.5.0 -> 22.5.1 ``                                      |
| [`64e2f5db`](https://github.com/NixOS/nixpkgs/commit/64e2f5dbf76497fb5ca8cf3d640fea2ee44295e6) | `` python310Packages.pydeps: 1.12.3 -> 1.12.4 ``                          |
| [`75457ff7`](https://github.com/NixOS/nixpkgs/commit/75457ff77edd989dcc1b31b52bb919048daa116a) | `` rdap: 2019-10-17 -> 0.9.1 ``                                           |
| [`cc7bae41`](https://github.com/NixOS/nixpkgs/commit/cc7bae417c2e33ff7c4fb04d14151289c43409c6) | `` mmv: 2.3 -> 2.4 ``                                                     |
| [`84a1117d`](https://github.com/NixOS/nixpkgs/commit/84a1117d5b677157650158713a0c0f29e4fc953b) | `` xcaddy: 0.3.3 -> 0.3.4 ``                                              |
| [`47629326`](https://github.com/NixOS/nixpkgs/commit/4762932601160798aaf20c39ecfc2c202aa6a9e7) | `` nixos/syncthing: fix disabled folders ``                               |
| [`4d4d5e4c`](https://github.com/NixOS/nixpkgs/commit/4d4d5e4c671875dc878c7ab0bd75e146f4308dbb) | `` bemenu: 0.6.14 -> 0.6.15 ``                                            |
| [`8f616ec0`](https://github.com/NixOS/nixpkgs/commit/8f616ec0ac621f08c54f8ae8621ed80f2acc2fa0) | `` minimal-bootstrap.coreutils: init at 5.0 ``                            |
| [`cca2a7ac`](https://github.com/NixOS/nixpkgs/commit/cca2a7acb592a68c0ad6805e135ecb3b3baa6560) | `` virtiofsd: 1.6.0 -> 1.6.1 ``                                           |
| [`3caff704`](https://github.com/NixOS/nixpkgs/commit/3caff70464e9c6900620f4a8c0f6dbeb019f8ce3) | `` nextcloud-notify_push: 0.6.2 -> 0.6.3 ``                               |
| [`cac01149`](https://github.com/NixOS/nixpkgs/commit/cac01149e7756870b5408acc117017c03cba7755) | `` nextcloudPackages: update ``                                           |
| [`ce06f20e`](https://github.com/NixOS/nixpkgs/commit/ce06f20e84080ed0d09fa9d722460b8c03df4270) | `` amdgpu_top: 0.1.7-stable -> 0.1.8 ``                                   |
| [`23739d2d`](https://github.com/NixOS/nixpkgs/commit/23739d2d114c89d74db0ed8aab91c6323dd71bdb) | `` citra: nightly 1873 -> 1907, canary 2440 -> 2484 ``                    |
| [`8fef3f40`](https://github.com/NixOS/nixpkgs/commit/8fef3f40514fe2b51308428df719e1e745fe50e3) | `` terraform-providers.tencentcloud: 1.81.0 -> 1.81.1 ``                  |
| [`2ac44558`](https://github.com/NixOS/nixpkgs/commit/2ac44558135642acf315c031c85217dd5875c6ef) | `` terraform-providers.oci: 4.120.0 -> 4.121.0 ``                         |
| [`16362c93`](https://github.com/NixOS/nixpkgs/commit/16362c93367eaea312ce95ad1154c69b02535d02) | `` terraform-providers.newrelic: 3.22.0 -> 3.23.0 ``                      |
| [`1cf15073`](https://github.com/NixOS/nixpkgs/commit/1cf15073eff65c86bc56d1e7b0a22d1e01da0112) | `` terraform-providers.dnsimple: 1.1.1 -> 1.1.2 ``                        |
| [`c772c846`](https://github.com/NixOS/nixpkgs/commit/c772c846db4375af6c09394761c1528c9d0fff42) | `` stanc: 2.32.1 -> 2.32.2 ``                                             |
| [`6d9bf329`](https://github.com/NixOS/nixpkgs/commit/6d9bf329cbc9d5aa338c7e7ea5b201a096f53794) | `` vdo: use upstream platforms ``                                         |