### PR TITLE
chore(flake/stylix): `1c953ad0` -> `cd9e19da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -421,11 +421,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684436450,
-        "narHash": "sha256-P0QN0cJl2+dxymCAnXR2Q89aIXHn0xf8hB+IkYhQ/38=",
+        "lastModified": 1684579323,
+        "narHash": "sha256-9YL2581CnrIOMMCRFXjfZeUPOvZN7+7Q4BhgXq5Imwo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "1c953ad0dc9d7f0a8e0dd52b286d2d25dd43f0b5",
+        "rev": "cd9e19daa104c7f49fdc571b9cf8c9d76dd1b3ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                      |
| --------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`cd9e19da`](https://github.com/danth/stylix/commit/cd9e19daa104c7f49fdc571b9cf8c9d76dd1b3ba) | `` Add options availability checks (#100) `` |