### PR TITLE
chore(flake/nixpkgs): `5b1bc788` -> `5ae23a80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684481515,
-        "narHash": "sha256-sDMEZ4HLP6sVNiBcgla3KWihdDjh67DP5ZWkGKWFgY0=",
+        "lastModified": 1684528365,
+        "narHash": "sha256-2b5IfkV6WPZ3S9SgIajbftinfGlBnwUwOcmLiyCck+w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5b1bc788f578cd83d54b48bb057d6f6703ae7725",
+        "rev": "5ae23a806c7cb16e2ade63400d0c6e5aa8e54797",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`ef85c3fe`](https://github.com/NixOS/nixpkgs/commit/ef85c3fe518186ae1effb0441a92c33468c475e2) | `` nixos: use passAsFile to avoid "Argument list too long" error ``                  |
| [`7a7b0862`](https://github.com/NixOS/nixpkgs/commit/7a7b0862dbe772582eb3e41c85430faf206fb606) | `` erlang_26: init ``                                                                |
| [`26f38459`](https://github.com/NixOS/nixpkgs/commit/26f38459ada3689899de2d2fea44f338e2dba2fd) | `` maintainers: mention sort script ``                                               |
| [`aca056ff`](https://github.com/NixOS/nixpkgs/commit/aca056ff37550920ed737b67f01170726bc5caca) | `` omrdatasettools,muscima: rename scikit-image ``                                   |
| [`7ae9a372`](https://github.com/NixOS/nixpkgs/commit/7ae9a372d9b79e0fa5b299fedd5bf324ced051a6) | `` mung: fix scikit-image name ``                                                    |
| [`0b0df14f`](https://github.com/NixOS/nixpkgs/commit/0b0df14f76c07e2852f1d8f831203e9671691fb2) | `` mqttui: add changelog to meta ``                                                  |
| [`b23eb059`](https://github.com/NixOS/nixpkgs/commit/b23eb059cca34e280382bb224e072727c5d6143a) | `` doomretro: fix build on darwin ``                                                 |
| [`edaf6d04`](https://github.com/NixOS/nixpkgs/commit/edaf6d04135616543dc86cc949d1158c34801f06) | `` rabtap: init at 1.38.2 (#230385) ``                                               |
| [`a41a78ef`](https://github.com/NixOS/nixpkgs/commit/a41a78efc135a4924a6dee542a9edcf3e606e45b) | `` burpsuite: 2023.4.3 -> 2023.4.4 ``                                                |
| [`38c05249`](https://github.com/NixOS/nixpkgs/commit/38c0524988250a43c16846e579ce92d06f7be0e0) | `` vimPlugins.nvchad: init at unstable-2023-05-18 ``                                 |
| [`bff94277`](https://github.com/NixOS/nixpkgs/commit/bff94277d34a30be1488ef5407cac3252e52a53d) | `` vimPlugins.nvchad-ui: init at unstable-2023-05-18 ``                              |
| [`04a6d9fc`](https://github.com/NixOS/nixpkgs/commit/04a6d9fc61391fe229a3bfe5aa7ccce6c8c77b3c) | `` vimPlugins.nvchad-extensions: init at unstable-2023-05-14 ``                      |
| [`9a6c4bc6`](https://github.com/NixOS/nixpkgs/commit/9a6c4bc66fdc2935ec3635c43f59ac2777df339c) | `` vimPlugins.nvterm: init at unstable-2023-05-05 ``                                 |
| [`a8c242fc`](https://github.com/NixOS/nixpkgs/commit/a8c242fce0f2c623e9f4e89c9a1d06c18cee2761) | `` vimPlugins.base46: init at unstable-2023-05-06 ``                                 |
| [`2dfec9ca`](https://github.com/NixOS/nixpkgs/commit/2dfec9ca750d68af9a7237fe12d151d70b48055f) | `` bitcoin: 24.0.1 -> 24.1 ``                                                        |
| [`19916860`](https://github.com/NixOS/nixpkgs/commit/19916860db67aa58750fa270ab37e42c9aaf2890) | `` xpdf: add recent CVE IDs to the knownVulnerabilities ``                           |
| [`cca08be9`](https://github.com/NixOS/nixpkgs/commit/cca08be917d33f82e45719b13132a43f89b1db3d) | `` cz-cli: 4.2.4 -> 4.3.0 ``                                                         |
| [`76836dee`](https://github.com/NixOS/nixpkgs/commit/76836deefd06ee4e9427617fa7a1de0ad895aa87) | `` wasmtime: run tests depending on the platform features ``                         |
| [`561f03ae`](https://github.com/NixOS/nixpkgs/commit/561f03ae3ade9531a773f98310aafbd1041b06d0) | `` terraform-providers.yandex: 0.90.0 -> 0.91.0 ``                                   |
| [`0f201b12`](https://github.com/NixOS/nixpkgs/commit/0f201b12a78d1d234da553d990ba1ef355b31cd7) | `` terraform-providers.opentelekomcloud: 1.34.3 -> 1.34.4 ``                         |
| [`d7a44053`](https://github.com/NixOS/nixpkgs/commit/d7a44053b024b02892b9bcf1a649123a1ca05ea2) | `` terraform-providers.github: 5.25.0 -> 5.25.1 ``                                   |
| [`72b6e456`](https://github.com/NixOS/nixpkgs/commit/72b6e456322ca04aa2065d5c258136ddb22e42b3) | `` terraform-providers.auth0: 0.46.0 -> 0.47.0 ``                                    |
| [`ee72818e`](https://github.com/NixOS/nixpkgs/commit/ee72818e84ff173831fbbdddd23d20adfad3d6c5) | `` vimPlugins.sniprun: 1.3.1 -> 1.3.3 ``                                             |
| [`1e636c44`](https://github.com/NixOS/nixpkgs/commit/1e636c4437d1d75f41b7989eaad4105e58e89f83) | `` credhub-cli: 2.9.14 -> 2.9.15 ``                                                  |
| [`0e5c0c5e`](https://github.com/NixOS/nixpkgs/commit/0e5c0c5e6482f566f8fc5ca47f0a4320151ed0f0) | `` mlterm: disable fb gui due to mlconfig tool issue ``                              |
| [`bed8c426`](https://github.com/NixOS/nixpkgs/commit/bed8c426e979eaafb3daf812d0345071ee95b123) | `` numix-icon-theme-square: 23.04.28 -> 23.05.15 ``                                  |
| [`e5c8528b`](https://github.com/NixOS/nixpkgs/commit/e5c8528b1cd03fb8a7b97143ed0a30c6cbe196f7) | `` nushellPlugins.query: 0.79.0 -> 0.80.0 ``                                         |
| [`d4ccb9d6`](https://github.com/NixOS/nixpkgs/commit/d4ccb9d673afc964d324cc422e271a451a508b62) | `` cemu: 2.0-36 -> 2.0-39 ``                                                         |
| [`b2c35b8b`](https://github.com/NixOS/nixpkgs/commit/b2c35b8b0e1274bf9fbaaffd3a0a64a28dac46e2) | `` wordpressPackages.plugins: update, wPackages.plugins.wp-swiper: init at 1.0.32 `` |
| [`87a64c39`](https://github.com/NixOS/nixpkgs/commit/87a64c39798ca8d65a37524a121ddc5e0ce33c47) | `` ueberzugpp: 2.8.1 -> 2.8.3 ``                                                     |
| [`0d813865`](https://github.com/NixOS/nixpkgs/commit/0d81386539fc2d0537483a83a996af9774747d3e) | `` xemu: 0.7.88 -> 0.7.90 ``                                                         |
| [`b83961d3`](https://github.com/NixOS/nixpkgs/commit/b83961d3f0fadcd6d06b0130240c73ba8292d1d3) | `` dunst: wrap dunstctl command with its runtime dependencies ``                     |
| [`8e596496`](https://github.com/NixOS/nixpkgs/commit/8e5964963fd6fce214ff6339c2f040b043ad49a9) | `` python3Packages.pyvcf: remove ``                                                  |
| [`10d6d567`](https://github.com/NixOS/nixpkgs/commit/10d6d56743c73ae8c7ebb26b209348482829a620) | `` release-cross.nix: test cross compilation to x86_64-freebsd ``                    |
| [`788b15bb`](https://github.com/NixOS/nixpkgs/commit/788b15bb7a2024fca357abfa37e65bd509faf2b7) | `` kyverno: 1.9.2 -> 1.9.3 ``                                                        |
| [`caa27271`](https://github.com/NixOS/nixpkgs/commit/caa272713e66ebc395d6c367d9a7f49563b7240d) | `` cloud-hypervisor: 31.1 -> 32.0 ``                                                 |
| [`5e97a107`](https://github.com/NixOS/nixpkgs/commit/5e97a1075620dfd2445d8cf037ec216cb86812ee) | `` python3Packages.acebinf: remove ``                                                |
| [`ac62b288`](https://github.com/NixOS/nixpkgs/commit/ac62b2882a9ff8b406234cde2cced8c2192aed58) | `` stratisd: 3.5.4 -> 3.5.5 ``                                                       |
| [`67d181f1`](https://github.com/NixOS/nixpkgs/commit/67d181f13c4c2491ddd487c0be962b29c9282a80) | `` microsoft_gsl: 3.1.0 -> 4.0.0 ``                                                  |
| [`2fbd46c4`](https://github.com/NixOS/nixpkgs/commit/2fbd46c4db38f90618a266ff2b2fac098eaf35b7) | `` stratis-cli: 3.5.1 -> 3.5.2 ``                                                    |
| [`b0cc16f9`](https://github.com/NixOS/nixpkgs/commit/b0cc16f9e2dad4e2962ef36e7a92fe4b2cd91c9f) | `` clickhouse: build rust parts ``                                                   |
| [`17db7c08`](https://github.com/NixOS/nixpkgs/commit/17db7c08d86625fd0aea1453a4b59a131b7f1975) | `` pomerium: 0.21.3 -> 0.22.1 ``                                                     |
| [`7ce0a29d`](https://github.com/NixOS/nixpkgs/commit/7ce0a29dfe0b8fc64c8b9c763136ab994aabbc1b) | `` datree: 1.9.0 -> 1.9.2 ``                                                         |
| [`da35f6a5`](https://github.com/NixOS/nixpkgs/commit/da35f6a56f87d8a20178f9118935f0615efca7de) | `` kustomize: 5.0.2 -> 5.0.3 ``                                                      |
| [`aedc462e`](https://github.com/NixOS/nixpkgs/commit/aedc462e8b9dfd55f5c075125206d4329b16b68d) | `` nixosTests.mailman: init ``                                                       |
| [`7ddca494`](https://github.com/NixOS/nixpkgs/commit/7ddca49451f841637491a6d2bbfc2048c78e5777) | `` nixos/mailman: set RemainAfterExit for settings ``                                |
| [`43465c94`](https://github.com/NixOS/nixpkgs/commit/43465c94d4d30c5c977b78ae12f4e1a47a3760ea) | `` nixos/mailman: randomly generate REST API token ``                                |
| [`9943a267`](https://github.com/NixOS/nixpkgs/commit/9943a26764952cc2fe2704d49be91034de3f4370) | `` roxctl: 4.0.0 -> 4.0.1 ``                                                         |
| [`8c4ec55a`](https://github.com/NixOS/nixpkgs/commit/8c4ec55af844a03e0d96f29ce7f296ca964c4c43) | `` flyctl: 0.1.7 -> 0.1.8 ``                                                         |
| [`3e3b0916`](https://github.com/NixOS/nixpkgs/commit/3e3b09165625e3d9aa7bf9386660dde5f43d2fea) | `` flyctl: 0.1.2 -> 0.1.7 ``                                                         |
| [`be06ff96`](https://github.com/NixOS/nixpkgs/commit/be06ff96a996bcb0d2a1101f15ed66b8ce6ae53f) | `` bazelisk: 1.16.0 -> 1.17.0 ``                                                     |
| [`7493289d`](https://github.com/NixOS/nixpkgs/commit/7493289d0387e9b195b58f322262ea04b9ec743b) | `` vimPlugins.coq_nvim: add python dependencies ``                                   |
| [`6d5d0453`](https://github.com/NixOS/nixpkgs/commit/6d5d0453f944b9fcfabef2dc75348feba4b91950) | `` ani-cli: 4.2 -> 4.3 ``                                                            |
| [`d716e174`](https://github.com/NixOS/nixpkgs/commit/d716e174618c55ed01a6a9a93e117fd4a79d1ee6) | `` maintainers: Update chkno email ``                                                |
| [`dedcfd39`](https://github.com/NixOS/nixpkgs/commit/dedcfd398fc063a782db0a386a7f63eef4586923) | `` treesheets: unstable-2023-05-17 -> unstable-2023-05-18 ``                         |
| [`66b5556d`](https://github.com/NixOS/nixpkgs/commit/66b5556d908c515cb01f66a49cd5da3fc718993c) | `` stripe-cli: 1.14.1 -> 1.14.6 ``                                                   |
| [`59ddf03f`](https://github.com/NixOS/nixpkgs/commit/59ddf03f7b47c91ae72f4a24f668de2666b4dc37) | `` simdjson: 3.1.7 -> 3.1.8 ``                                                       |
| [`8f4ccdf5`](https://github.com/NixOS/nixpkgs/commit/8f4ccdf5b3a2f183a80cdecfb62ec5aa4ea74720) | `` qtads: 3.3.0 -> 3.4.0 ``                                                          |
| [`2fc5317d`](https://github.com/NixOS/nixpkgs/commit/2fc5317d90680437f5563830f1e4ea5903e9858d) | `` fastly: 9.0.3 -> 10.0.1 ``                                                        |
| [`cd582d8d`](https://github.com/NixOS/nixpkgs/commit/cd582d8d370f6d158b718697fce20f53102f4feb) | `` python311Packages.kajiki: add input linetable ``                                  |
| [`067098c3`](https://github.com/NixOS/nixpkgs/commit/067098c3ac21ca990d1c98b136a08c8c776940c9) | `` devbox: 0.5.1 -> 0.5.2 ``                                                         |
| [`06c0791e`](https://github.com/NixOS/nixpkgs/commit/06c0791e969d29bc00dbccab18a2b6dc5e05e36c) | `` devbox: 0.4.9 -> 0.5.1 ``                                                         |
| [`df473425`](https://github.com/NixOS/nixpkgs/commit/df473425cacc7ba47c84d9a9fdb99faf0036637d) | `` python310Packages.linetable: init at 0.0.3 ``                                     |
| [`a4e81589`](https://github.com/NixOS/nixpkgs/commit/a4e8158923758b5a0670507ef264717bbdccf520) | `` libcpuid: Fix NetBSD cross build ``                                               |
| [`55015c79`](https://github.com/NixOS/nixpkgs/commit/55015c79d2d3ba4a89fd9ddc10f2c9c53faecc82) | `` libpg_query: 15-4.2.0 -> 15-4.2.1 ``                                              |
| [`aa7f55ce`](https://github.com/NixOS/nixpkgs/commit/aa7f55ce85f96771a1e45942465955febcd30086) | `` resvg: install libresvg ``                                                        |
| [`1780fa9c`](https://github.com/NixOS/nixpkgs/commit/1780fa9ca3bee9bb862981c70fb92c3440566d0f) | `` resvg: 0.32.0 -> 0.33.0 ``                                                        |
| [`8cd9cecc`](https://github.com/NixOS/nixpkgs/commit/8cd9cecc5b2aeec23c4464b9d4e7da1e41f58d19) | `` python3Packages.edk2-pytool-library: add changelog to meta ``                     |
| [`4f7eab5c`](https://github.com/NixOS/nixpkgs/commit/4f7eab5c821195b0f81b03a1e5a863c463b8ada3) | `` python3Packages.edk2-pytool-library: 0.14.1 -> 0.15.0 ``                          |
| [`78bb6ceb`](https://github.com/NixOS/nixpkgs/commit/78bb6ceb7cda009ea60755d24b4e906067e0149c) | `` python310Packages.aliyun-python-sdk-cdn: 3.8.7 -> 3.8.8 ``                        |
| [`3861670f`](https://github.com/NixOS/nixpkgs/commit/3861670fad7e610cfc492420a4a303d9b94d5046) | `` python310Packages.pontos: 23.5.1 -> 23.5.3 ``                                     |
| [`76cc5d83`](https://github.com/NixOS/nixpkgs/commit/76cc5d83dcda9d4226292be8bae71646555356b5) | `` worldengine-cli: fix build ``                                                     |
| [`6db453b3`](https://github.com/NixOS/nixpkgs/commit/6db453b3c678bbcd939c994cc31d326bd443c400) | `` python310Packages.purepng: fix build ``                                           |
| [`880ef65c`](https://github.com/NixOS/nixpkgs/commit/880ef65c441e86ab23a0e266887cfb732da56990) | `` python310Packages.pysam: 0.20.0 -> 0.21.0 ``                                      |
| [`efb119ab`](https://github.com/NixOS/nixpkgs/commit/efb119ab7798047b7d409c976d54d2fcb6352f80) | `` python311Packages.pytest-ansible: 3.0.0 -> 3.1.5 ``                               |
| [`620e0bf4`](https://github.com/NixOS/nixpkgs/commit/620e0bf44fd85de3fa77bd89e3a3a35e3cb716f4) | `` python311Packages.pysml: disable on unsupported Python releases ``                |
| [`64bdaffb`](https://github.com/NixOS/nixpkgs/commit/64bdaffb0549721af50d212365847b8ff6a7385f) | `` python311Packages.pysml: 0.0.11 -> 0.0.12 ``                                      |
| [`47e1eefc`](https://github.com/NixOS/nixpkgs/commit/47e1eefcc3acbd639503938236318f68be39c10e) | `` quisk: Migrate to python 3.10 ``                                                  |
| [`5f1adf87`](https://github.com/NixOS/nixpkgs/commit/5f1adf8775ea36bf69fb72da6fdba59969e23455) | `` python311Packages.plugincode: add changelog to meta ``                            |
| [`9b8d1f45`](https://github.com/NixOS/nixpkgs/commit/9b8d1f45f7d346c3d596e0d4d92ad958bba1b11e) | `` python311Packages.plugincode: 31.0.0 -> 32.0.0 ``                                 |
| [`05679bf6`](https://github.com/NixOS/nixpkgs/commit/05679bf6b5d8a3741ba4e7d2c39685284498f76d) | `` python311Packages.gremlinpython: 3.6.3 -> 3.6.4 ``                                |
| [`f32672f9`](https://github.com/NixOS/nixpkgs/commit/f32672f968f35166fd3f704915ab9929bdc395a8) | `` python311Packages.cloup: add changelog to meta ``                                 |
| [`37c2ebcd`](https://github.com/NixOS/nixpkgs/commit/37c2ebcda6ec2e19c833b23df531be2ea21af46b) | `` python311Packages.cloup: 2.0.0.post1 -> 2.1.0 ``                                  |
| [`e19cfdde`](https://github.com/NixOS/nixpkgs/commit/e19cfdde967f05eeb23294f6e8f419907d6c75e9) | `` flare-floss: add mainProgram ``                                                   |
| [`7a62e75e`](https://github.com/NixOS/nixpkgs/commit/7a62e75e6caf9c8d6b0922140385613f370bace8) | `` flare-floss: 2.0.0 -> 2.2.0 ``                                                    |
| [`48b821d2`](https://github.com/NixOS/nixpkgs/commit/48b821d2f176533ae5aee36b2523129230f92adb) | `` grub2: remove the beta mention from the meta.description ``                       |
| [`6e5c09c8`](https://github.com/NixOS/nixpkgs/commit/6e5c09c8c46b2cb7e89ef649943b0512b704be3a) | `` volatility: mark as broken ``                                                     |
| [`ebabf63f`](https://github.com/NixOS/nixpkgs/commit/ebabf63fd1514176f5a9b3c82e769f0c1550849b) | `` maestro: 1.27.0 -> 1.28.0 ``                                                      |
| [`db50fb67`](https://github.com/NixOS/nixpkgs/commit/db50fb6714a3eb7e536a2613dadb8155b22d48c0) | `` cargo-zigbuild: 0.16.8 -> 0.16.9 ``                                               |
| [`543ab376`](https://github.com/NixOS/nixpkgs/commit/543ab3761b3ee9bdb572d7e9b71b07eb6a3bc2a2) | `` swayosd: add gtk wrapper ``                                                       |
| [`1412b439`](https://github.com/NixOS/nixpkgs/commit/1412b439704bba22e9f6c2e54501472875f58613) | `` minimal-bootstrap.bash_2_05: init at 2.05b ``                                     |
| [`4401af69`](https://github.com/NixOS/nixpkgs/commit/4401af698c53d494142f6e537cf6ba393ff69056) | `` mqttui: 0.18.0 -> 0.19.0 ``                                                       |
| [`ff3ac925`](https://github.com/NixOS/nixpkgs/commit/ff3ac9258a64c52b2f80c8d4da01208b85ec142e) | `` signal-cli: 0.11.9.1 -> 0.11.10 ``                                                |
| [`6f045a37`](https://github.com/NixOS/nixpkgs/commit/6f045a3767b837465b3169dcc6f0485149c8ea27) | `` python310Packages.nipype: 1.8.5 -> 1.8.6 ``                                       |
| [`37caeedd`](https://github.com/NixOS/nixpkgs/commit/37caeedd86fbe1900ea4cacd67fd7cc271b4cc56) | `` plantuml-server: 1.2023.6 -> 1.2023.7 ``                                          |
| [`e872de9a`](https://github.com/NixOS/nixpkgs/commit/e872de9a9e1fffd865a8e8ff72b6d420abd1f3e0) | `` openssl_1_1: mark end-of-life ``                                                  |
| [`40964357`](https://github.com/NixOS/nixpkgs/commit/40964357ee35862626dd8cf43caf2d0b159dfc6b) | `` alkalami: 2.000 -> 3.000 ``                                                       |
| [`2df23a6b`](https://github.com/NixOS/nixpkgs/commit/2df23a6b37c96854065ae96af51dddab806ef300) | `` wapp: init at unstable-2023-05-05 ``                                              |
| [`90ffae10`](https://github.com/NixOS/nixpkgs/commit/90ffae10d734dd4938d168a47c1ab366a86cf772) | `` vscode-extensions.james-yu.latex-workshop: 9.8.1 -> 9.10.0 ``                     |
| [`c26ad1f6`](https://github.com/NixOS/nixpkgs/commit/c26ad1f611b227fe28d364a8b12900b6c6e9f784) | `` vscode-extensions.github.vscode-pull-request-github: 0.60.0 -> 0.64.0 ``          |
| [`4373b5a0`](https://github.com/NixOS/nixpkgs/commit/4373b5a085a51e7e926c3d7fad685b43de961023) | `` vscode-extensions.github.copilot: 1.78.9758 -> 1.86.82 ``                         |
| [`703467dd`](https://github.com/NixOS/nixpkgs/commit/703467dda6e88e6b50416265710966cd885eebd7) | `` vscode-extensions.github.codespaces: 1.14.1 -> 1.14.7 ``                          |
| [`30b8a736`](https://github.com/NixOS/nixpkgs/commit/30b8a73610b024f242d02c5c962f1106a9eefd26) | `` vscode-extensions.genieai.chatgpt-vscode: 0.0.7 -> 0.0.8 ``                       |
| [`ac6854d5`](https://github.com/NixOS/nixpkgs/commit/ac6854d5a94da0d2e3339eda88235d0e0394018f) | `` vscode-extensions.chris-hayes.chatgpt-reborn: 3.16.1 -> 3.16.3 ``                 |
| [`bf6f3970`](https://github.com/NixOS/nixpkgs/commit/bf6f3970c04e58bcf32304ca785295220e1b7e23) | `` ocamlPackages.cmarkit: 0.1.0 -> 0.2.0 ``                                          |
| [`bbe2c27a`](https://github.com/NixOS/nixpkgs/commit/bbe2c27ace6d862aa49696f58b6dfabb71bd0cf1) | `` bfscripts: init at unstable-2023-05-15 ``                                         |
| [`e217274f`](https://github.com/NixOS/nixpkgs/commit/e217274f2eac8ad1c043503c0c440cf99b056c2f) | `` mautrix-whatsapp: 0.8.4 -> 0.8.5 ``                                               |
| [`15fe512d`](https://github.com/NixOS/nixpkgs/commit/15fe512d7774840f6079c359adcb72b06690bf3c) | `` wolf-shaper: update links, clarify license ``                                     |
| [`763dbd1d`](https://github.com/NixOS/nixpkgs/commit/763dbd1d4676ae832d819db409fcc22b87fb1e1f) | `` sfwbar: init at 1.0_beta11 ``                                                     |
| [`043c0b67`](https://github.com/NixOS/nixpkgs/commit/043c0b67cfb94907fdbf3fe35db71dc6343e6596) | `` python311Packages.aionotion: 2023.05.1 -> 2023.05.4 ``                            |
| [`bc87805d`](https://github.com/NixOS/nixpkgs/commit/bc87805d558718feca01013063a73d19998b9e3d) | `` python3Packages.omrdatasettools: init at 1.3.1 ``                                 |
| [`ed68fa60`](https://github.com/NixOS/nixpkgs/commit/ed68fa60fba4c00c701c0d38f13d9aed0316d26b) | `` python3Packages.mung: init at unstable-2022-07-10 ``                              |
| [`f9713de0`](https://github.com/NixOS/nixpkgs/commit/f9713de024f457b49fa44908f3db235d8f989fe3) | `` python3Packages.muscima: init at unstable-2023-04-26 ``                           |
| [`05129aab`](https://github.com/NixOS/nixpkgs/commit/05129aab01a352e6f46487633820d9d75681538d) | `` nixos/lib: save triggers of systemd into nix store ``                             |
| [`f68ae132`](https://github.com/NixOS/nixpkgs/commit/f68ae132f843f17e4a3fb881e49b032026450d48) | `` nodejs_16: also mark EOL ``                                                       |
| [`cc41b47c`](https://github.com/NixOS/nixpkgs/commit/cc41b47c6f4fbc841dd4bdb89e11d7c00e42e76a) | `` nixos/lib: hash triggers after converting them to string in systemd-lib ``        |
| [`d34f3e8f`](https://github.com/NixOS/nixpkgs/commit/d34f3e8f31730a7078f00c58bbc0691363824e65) | `` wavm: init at 2022-05-14 ``                                                       |
| [`f75ad820`](https://github.com/NixOS/nixpkgs/commit/f75ad820a1370a20f80b6943836002c09d39f91f) | `` nodejs_14: is EOL on 2023-04-30 ``                                                |
| [`90d55a09`](https://github.com/NixOS/nixpkgs/commit/90d55a091ff3fd20077e997ea9e5832e2994c2e9) | `` livecaptions: init at 0.4.0 ``                                                    |