### PR TITLE
chore(flake/nixpkgs): `5ae23a80` -> `3005f20c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684528365,
-        "narHash": "sha256-2b5IfkV6WPZ3S9SgIajbftinfGlBnwUwOcmLiyCck+w=",
+        "lastModified": 1684570954,
+        "narHash": "sha256-FX5y4Sm87RWwfu9PI71XFvuRpZLowh00FQpIJ1WfXqE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5ae23a806c7cb16e2ade63400d0c6e5aa8e54797",
+        "rev": "3005f20ce0aaa58169cdee57c8aa12e5f1b6e1b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`68c1807f`](https://github.com/NixOS/nixpkgs/commit/68c1807f3c523788b5ce58879ec67ed9c43022d6) | `` eudev: 3.2.11 -> 3.2.12 ``                                                |
| [`aff52a74`](https://github.com/NixOS/nixpkgs/commit/aff52a7444ae59535c44ed4dd33a038fbea9af80) | `` komikku: 1.19.0 -> 1.20.0 ``                                              |
| [`7a288f77`](https://github.com/NixOS/nixpkgs/commit/7a288f777a58a0a962bdf5e03b7308f7f02fa149) | `` terraform-providers.azurerm: 3.56.0 -> 3.57.0 ``                          |
| [`a2b91c07`](https://github.com/NixOS/nixpkgs/commit/a2b91c07c30eb583b58077e6f9bcf69168745ae7) | `` bpftrace: 0.17.1 -> 0.18.0 ``                                             |
| [`fd6e60a6`](https://github.com/NixOS/nixpkgs/commit/fd6e60a677ce96210a4c826a8313126f332255ca) | `` qt6Packages.qtpbfimageplugin: 2.3 -> 2.4 ``                               |
| [`4b939b45`](https://github.com/NixOS/nixpkgs/commit/4b939b45c6911216c441761b714e8a0d49af54e7) | `` shairport-sync: switch to openssl 3 ``                                    |
| [`ee683572`](https://github.com/NixOS/nixpkgs/commit/ee683572054e8caea194693419c46c8d17422999) | `` nixos/tests/home-assistant: Don't test matter ``                          |
| [`7c5d339b`](https://github.com/NixOS/nixpkgs/commit/7c5d339b09a02c25af5333cb9de071faaa946b26) | `` python3Packages.wasm: remove ``                                           |
| [`8a89abcb`](https://github.com/NixOS/nixpkgs/commit/8a89abcb7897d989e0d6067c57e42b8d1d82c8ba) | `` python3Packages.manticore: remove ``                                      |
| [`ee0de1a8`](https://github.com/NixOS/nixpkgs/commit/ee0de1a8cc08b9ae6a0296d272dc2824417d8ba0) | `` linuxPackages_latest.prl-tools: 18.2.0-53488 -> 18.3.0-53606 ``           |
| [`9df8adbd`](https://github.com/NixOS/nixpkgs/commit/9df8adbdb3a8ccdd1d626ccfc33023e8b8211dd0) | `` python310Packages.cloudflare: add changelog to meta ``                    |
| [`8ee5a6fc`](https://github.com/NixOS/nixpkgs/commit/8ee5a6fcbf8d98936fe1a336ac21ef1f31d28310) | `` linuxManualConfig: don't ignore cross config errors ``                    |
| [`bb237b55`](https://github.com/NixOS/nixpkgs/commit/bb237b5522b0ae6f3618231d037682f38074ac12) | `` python310Packages.cloudflare: 2.11.1 -> 2.11.2 ``                         |
| [`431cae5b`](https://github.com/NixOS/nixpkgs/commit/431cae5b51fc9f7aa91bba881d02031671db514b) | `` oh-my-posh: 16.4.2 -> 16.7.0 ``                                           |
| [`99a570d2`](https://github.com/NixOS/nixpkgs/commit/99a570d2727b1c9d90d19fdea08d815ea14ce5cd) | `` exploitdb: 2023-05-17 -> 2023-05-19 ``                                    |
| [`0812dc17`](https://github.com/NixOS/nixpkgs/commit/0812dc17079a94af4497c1ef780769cc276f0de2) | `` python311Packages.rns: 0.5.2 -> 0.5.3 ``                                  |
| [`a1755d23`](https://github.com/NixOS/nixpkgs/commit/a1755d23a7faf1ce6484ad54f646eca5c9ae6c12) | `` hvm: 1.0.8 -> 1.0.9 ``                                                    |
| [`62823d7e`](https://github.com/NixOS/nixpkgs/commit/62823d7e0b270c63a461559bb5ef703d620de51d) | `` python311Packages.pyvesync: 2.1.6 -> 2.1.7 ``                             |
| [`74c65ff0`](https://github.com/NixOS/nixpkgs/commit/74c65ff0f7803c418851bad022f02e616b9d5776) | `` python311Packages.pyoverkiz: 1.7.8 -> 1.7.9 ``                            |
| [`6d8b918d`](https://github.com/NixOS/nixpkgs/commit/6d8b918da033604395a986182be4ec31a3935d55) | `` python311Packages.plugwise: 0.31.3 -> 0.31.4 ``                           |
| [`5e7b8176`](https://github.com/NixOS/nixpkgs/commit/5e7b81762278bedf8f0a5d59816c55d3f364b20b) | `` python310Packages.metar: 1.9.0 -> 1.10.0 ``                               |
| [`7c428691`](https://github.com/NixOS/nixpkgs/commit/7c428691d28b345cc4c7c3ad80a876ccad72f7bd) | `` spotify: use ffmpeg_4 ``                                                  |
| [`9b942da0`](https://github.com/NixOS/nixpkgs/commit/9b942da0bd0e41fe44b16793705d5cf141a0632a) | `` ungoogled-chromium: 113.0.5672.93 -> 113.0.5672.126 ``                    |
| [`690a8f61`](https://github.com/NixOS/nixpkgs/commit/690a8f613d98455da45d926108f28c071128443c) | `` ungoogled-chromium: add networkexception as maintainer ``                 |
| [`b3460634`](https://github.com/NixOS/nixpkgs/commit/b3460634eab7dc93a20d85a246fa95c5c82752b6) | `` maintainers: add networkexception ``                                      |
| [`6e042512`](https://github.com/NixOS/nixpkgs/commit/6e042512720232d8cab1f97cdd62b69df79ccc02) | `` orogene: 0.3.25 -> 0.3.26 ``                                              |
| [`f4e18158`](https://github.com/NixOS/nixpkgs/commit/f4e18158002adaa094b3e22268662df9ecc0b769) | `` threatest: install shell completions ``                                   |
| [`5b14e87e`](https://github.com/NixOS/nixpkgs/commit/5b14e87eca460f123e9f371e2243409b299d4c38) | `` threatest: fix build on darwin ``                                         |
| [`f7c59ea0`](https://github.com/NixOS/nixpkgs/commit/f7c59ea08cbda5bad1c3222db7c1662f2596cf6f) | `` arrayfire: fix build on darwin ``                                         |
| [`99079728`](https://github.com/NixOS/nixpkgs/commit/99079728ab0a3f398d05177c188faad21cfc4237) | `` ast-grep: fix build on x86_64-darwin ``                                   |
| [`6b296fbc`](https://github.com/NixOS/nixpkgs/commit/6b296fbcf2fed22c85aaf555e81a21c3399f75f4) | `` ast-grep: fix build on aarch64-linux ``                                   |
| [`6dcc0ab9`](https://github.com/NixOS/nixpkgs/commit/6dcc0ab9b50e8a152407b409285a311cc13e3085) | `` maintainers/haskell/merge-and-open-pr: only push haskell-updates ``       |
| [`682790ae`](https://github.com/NixOS/nixpkgs/commit/682790aee0f2de043134d3f5a40a66f483ae374c) | `` haskellPackages: mark builds failing on hydra as broken ``                |
| [`8ef16d70`](https://github.com/NixOS/nixpkgs/commit/8ef16d70af4b813a6dbeca47435fae18443af650) | `` muffet: 2.8.0 -> 2.8.1 ``                                                 |
| [`2b369846`](https://github.com/NixOS/nixpkgs/commit/2b36984627d8396aa559a61a611c7a8333b463cc) | `` example-robot-data: 4.0.6 -> 4.0.7 ``                                     |
| [`a43c3a78`](https://github.com/NixOS/nixpkgs/commit/a43c3a7874d8ccb99276c88e31f21e9e16848bd7) | `` typos: 1.14.9 -> 1.14.10, add figsoda as a maintainer ``                  |
| [`46761468`](https://github.com/NixOS/nixpkgs/commit/4676146840140489e20aad7525ff1f0e31ad4a46) | `` numix-icon-theme: 22.11.17 -> 23.04.26 ``                                 |
| [`7258cac6`](https://github.com/NixOS/nixpkgs/commit/7258cac6d58d239c22759055fb41deaf198cb7b7) | `` python310Packages.pims: ignore also PendingDeprecationWarning ``          |
| [`df8b05e0`](https://github.com/NixOS/nixpkgs/commit/df8b05e0bacc783c37f3b7c50de81254bb522762) | `` callaudiod: 0.1.7 -> 0.1.9 ``                                             |
| [`3750e418`](https://github.com/NixOS/nixpkgs/commit/3750e418e38b16532738c9d970811845182af344) | `` python310Packages.persim: disable failing test ``                         |
| [`bee52d7d`](https://github.com/NixOS/nixpkgs/commit/bee52d7d8e791ec07fc14976d5f15dc5fd6d6e47) | `` grafana-image-renderer: 3.7.0 -> 3.7.1 ``                                 |
| [`f5f2c185`](https://github.com/NixOS/nixpkgs/commit/f5f2c185df3f22252cd4028c7334ab20dbc975fc) | `` emacsPackages.prolog-mode: use trivialBuild ``                            |
| [`a357a3e0`](https://github.com/NixOS/nixpkgs/commit/a357a3e0919ef81b24ae6efee8e37d98d9a7e4b8) | `` libarchive-qt: 2.0.7 -> 2.0.8 ``                                          |
| [`6d93fcda`](https://github.com/NixOS/nixpkgs/commit/6d93fcda5b5ebd53ae0ffb05a97ce167f3f13a9b) | `` python310Packages.polyline: modernize ``                                  |
| [`037e2285`](https://github.com/NixOS/nixpkgs/commit/037e2285227e4b48c318d3711964e0648eaf4955) | `` isl_0_24: pull CC_FOR_BUILD ``                                            |
| [`db31fcec`](https://github.com/NixOS/nixpkgs/commit/db31fcec3ff370ddc6195e9d933deac9351a529c) | `` cassandra-cpp-driver: fix libuv include path ``                           |
| [`ebbd3bdf`](https://github.com/NixOS/nixpkgs/commit/ebbd3bdfa871f30fd943aa58f0d54b69f6a8112b) | `` maintainers.ShamrockLee: renew information ``                             |
| [`38ed4d99`](https://github.com/NixOS/nixpkgs/commit/38ed4d99adb22bb5b20d44cdea4b687240223dd3) | `` alpine: pull CC_FOR_BUILD ``                                              |
| [`1be8707a`](https://github.com/NixOS/nixpkgs/commit/1be8707a2c1319b33a957435113eb3523b81f476) | `` dataexplorer: 3.7.6 -> 3.7.7 ``                                           |
| [`a728604a`](https://github.com/NixOS/nixpkgs/commit/a728604a9ff1d39a8ce94d213b6cdbc79264644e) | `` ombi: 4.35.10 -> 4.39.1 ``                                                |
| [`be0dec61`](https://github.com/NixOS/nixpkgs/commit/be0dec613ed2c165f5acb811a643925ec7ae4c34) | `` karlender: 0.9.1 -> 0.9.2 ``                                              |
| [`4600be9f`](https://github.com/NixOS/nixpkgs/commit/4600be9f2dffe46ddc9ddbaa4382c6f99ea85d71) | `` python310Packages.chat-downloader: 0.2.5 -> 0.2.6 ``                      |
| [`0eb61aaf`](https://github.com/NixOS/nixpkgs/commit/0eb61aafd793580d44e1ca7ea12bfa2511e3c0f7) | `` python310Packages.google-auth: move urllib3 to propagatedBuildInputs ``   |
| [`fe4ac7ec`](https://github.com/NixOS/nixpkgs/commit/fe4ac7ec965ffb7c546159a2194aa0b851de207a) | `` morgen: 2.6.7 -> 2.7.0 ``                                                 |
| [`985286d4`](https://github.com/NixOS/nixpkgs/commit/985286d4a763cdecf02967382fb4a303728bbdc8) | `` python311Packages.gmpy: disable ``                                        |
| [`8328c914`](https://github.com/NixOS/nixpkgs/commit/8328c914e9c628d5ab823e0d891aa436dae7fd64) | `` python311Packages.contextlib2: disable ``                                 |
| [`56c21f04`](https://github.com/NixOS/nixpkgs/commit/56c21f04d1ef198f6e91626d01d70cff6c0bcb3c) | `` python310Packages.pyshark: skip flaky test ``                             |
| [`bfe471df`](https://github.com/NixOS/nixpkgs/commit/bfe471df4d34375c69ffcd06a841ea846388880a) | `` easyeffects: 7.0.3 -> 7.0.4 ``                                            |
| [`8bd588bb`](https://github.com/NixOS/nixpkgs/commit/8bd588bb31d5f1417c9fef03a34ca6d4ae96ca79) | `` exodus: 23.4.10 -> 23.5.8 ``                                              |
| [`809eaafd`](https://github.com/NixOS/nixpkgs/commit/809eaafd8b19027b57215596179d0d2cca0c4cb6) | `` _1password-gui-beta: 8.10.6-20.BETA -> 8.10.7-11.BETA ``                  |
| [`8d7bc365`](https://github.com/NixOS/nixpkgs/commit/8d7bc3658f813db5256c16e50369d092ebe027f8) | `` _1password-gui: 8.10.4 -> 8.10.6 ``                                       |
| [`31aa936b`](https://github.com/NixOS/nixpkgs/commit/31aa936b15dfb39f536e87b63bf161c2c7fd0ff5) | `` python310Packages.django-hijack: 3.2.6 -> 3.3.0 ``                        |
| [`1149329a`](https://github.com/NixOS/nixpkgs/commit/1149329a284b8e0c239087622e066df194a05d28) | `` python310Packages.django-hijack-admin: rename from django_hijack_admin `` |
| [`ded217e5`](https://github.com/NixOS/nixpkgs/commit/ded217e525f2180d7fb1dfb1647efa41062bd63b) | `` python310Packages.django-hijack: rename from django_hijack ``             |
| [`cb3180c0`](https://github.com/NixOS/nixpkgs/commit/cb3180c0fef15858e0d1405d42db8dccc6b68173) | `` daemon: 0.8 -> 0.8.2 ``                                                   |
| [`f1ee4207`](https://github.com/NixOS/nixpkgs/commit/f1ee4207ebff31d1f52b142423ed58506142d8a2) | `` tts: 0.13.3 -> 0.14.0 ``                                                  |
| [`abc7af78`](https://github.com/NixOS/nixpkgs/commit/abc7af781e36a8c0532c1d4e25087b2b4a8bea69) | `` python310Packages.k-diffusion: ini at 0.0.14 ``                           |
| [`cb493f5d`](https://github.com/NixOS/nixpkgs/commit/cb493f5d128407f6d3d655e532ffdcc21e3c52c7) | `` python310Packages.torchsde: init at 0.2.4 ``                              |
| [`b1b84b72`](https://github.com/NixOS/nixpkgs/commit/b1b84b722ca8046bfcfde118dae5eacaed0b3834) | `` python310Packages.trampoline: init at 0.1.2 ``                            |
| [`3ba5ff84`](https://github.com/NixOS/nixpkgs/commit/3ba5ff8416d85fb934b12fd8bac3668866ea6613) | `` python310Packages.torchdiffeq: init at 0.2.3 ``                           |
| [`2901b67d`](https://github.com/NixOS/nixpkgs/commit/2901b67d764eb4e874e5274493289cd4d4d4d3a3) | `` python310Packages.resize-right: init at 0.0.2 ``                          |
| [`1b28a9b9`](https://github.com/NixOS/nixpkgs/commit/1b28a9b9b886f008cae25783bf5fb6f005e6d99c) | `` python310Packages.clip-anytorch: init at 2.5.2 ``                         |
| [`a1a072ee`](https://github.com/NixOS/nixpkgs/commit/a1a072ee66f82eba4949688d5afd41b9c64f4ba4) | `` python310Packages.clean-fid: init at 0.1.35 ``                            |
| [`259d93b0`](https://github.com/NixOS/nixpkgs/commit/259d93b07faf7d33a96725bca0766d7c68fea1dd) | `` haskell.packages.ghc945.ghc-lib{,-parser}: use 9.4.5 versions ``          |
| [`6d84a707`](https://github.com/NixOS/nixpkgs/commit/6d84a7071d24eacc8ce7144f491f76b8ed0c8ae7) | `` haskellPackages.hedgehog-extras: allow building against aeson 2.0.* ``    |
| [`02def6b1`](https://github.com/NixOS/nixpkgs/commit/02def6b1a0d673c55babf1debbe69e4445a5f384) | `` haskellPackages.tasty-sugar: allow tasty-hedgehog 1.3.* ``                |
| [`a5387f5b`](https://github.com/NixOS/nixpkgs/commit/a5387f5bec722514a2d9750d4850e3d4dfe5a47f) | `` haskellPackages.srtree: remove broken flag ``                             |
| [`964d55b1`](https://github.com/NixOS/nixpkgs/commit/964d55b1e02051f94f3d0bb9dab800e2f72b8a3f) | `` vimPlugins.monokai-pro-nvim: init at 2023-05-13 ``                        |
| [`333d2850`](https://github.com/NixOS/nixpkgs/commit/333d285072d7e026f50003e69b1758130bf7a22e) | `` deepin.deepin-screensaver: init at 5.0.16 ``                              |
| [`71d6ed69`](https://github.com/NixOS/nixpkgs/commit/71d6ed698f6a6228fe97f69ea761614dd602a8bd) | `` nixos/gnupg: default to qt pinentry program in deepin ``                  |
| [`bacda588`](https://github.com/NixOS/nixpkgs/commit/bacda5885c67735b7d72692827b89fd10e3fbe7d) | `` haskellPackages.utility-ht: drop obsolete override ``                     |
| [`5bedf1dd`](https://github.com/NixOS/nixpkgs/commit/5bedf1ddff49973a6be0f08e44878078064d6c05) | `` haskellPackages: regenerate package set based on current config ``        |
| [`27fc9be1`](https://github.com/NixOS/nixpkgs/commit/27fc9be18d59b977c2e5dccb97c88712e703f2f9) | `` haskellPackages: stackage LTS 20.19 -> LTS 20.20 ``                       |
| [`3cc08f8a`](https://github.com/NixOS/nixpkgs/commit/3cc08f8a51ee4c7f03ddaf1074bfd25d3b8e5a83) | `` all-cabal-hashes: 2023-04-29T17:51:14Z -> 2023-05-10T18:33:26Z ``         |