### PR TITLE
chore(flake/lanzaboote): `7ed294c8` -> `3fb74cfb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1684449391,
-        "narHash": "sha256-VV8YqRvIdEAheLUd36R7pXl0tAmk+4bECGYosLTGw6U=",
+        "lastModified": 1684612915,
+        "narHash": "sha256-+hiMql6ur3c1a78JClsuyeE1T1YMst9sr7v9xQB0PCU=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "7ed294c84da4bedd144a7525394ed7dbf01853da",
+        "rev": "3fb74cfb5345431175338019b48d3805fc21b1a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                       |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`77f12794`](https://github.com/nix-community/lanzaboote/commit/77f1279406db09e572954e970163312a7fb1cfe0) | `` tool(bootspec): remove boilerplate with newest bootspec `` |