### PR TITLE
chore(flake/nixpkgs): `3005f20c` -> `50a18318`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684570954,
-        "narHash": "sha256-FX5y4Sm87RWwfu9PI71XFvuRpZLowh00FQpIJ1WfXqE=",
+        "lastModified": 1684662198,
+        "narHash": "sha256-lmGDGuFONWSoGBKDDhU/6fOhhmFoZQ8rPf+kS7/e/Gs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3005f20ce0aaa58169cdee57c8aa12e5f1b6e1b3",
+        "rev": "50a183182d7ae39133555414d48d5d609a28a57d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                               |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`9e291a27`](https://github.com/NixOS/nixpkgs/commit/9e291a2755fbfb7af294508424b381ebc8839d80) | `` terragrunt: 0.45.11 -> 0.45.13 ``                                  |
| [`ec9e4dd1`](https://github.com/NixOS/nixpkgs/commit/ec9e4dd188bd81da41c5800bb63445be525e1d69) | `` jfrog-cli: add changelog to meta ``                                |
| [`10ecb4b8`](https://github.com/NixOS/nixpkgs/commit/10ecb4b84e19960701ee48bae0f521f9fcf92268) | `` nebula: 1.7.0 -> 1.7.1 ``                                          |
| [`afd3f57b`](https://github.com/NixOS/nixpkgs/commit/afd3f57b9a1d854f663dd33f502296205fc7a864) | `` jfrog-cli: 2.37.1 -> 2.37.3 ``                                     |
| [`f2d8008a`](https://github.com/NixOS/nixpkgs/commit/f2d8008acbd052d99ca18b65a2045e4a8f97cd99) | `` python310Packages.nodeenv: add changelog to meta ``                |
| [`9914d8b3`](https://github.com/NixOS/nixpkgs/commit/9914d8b3a32289c4275b940670dba15d29bec33c) | `` taxi-cli: 6.1.1 -> 6.2.0 ``                                        |
| [`0f6712d4`](https://github.com/NixOS/nixpkgs/commit/0f6712d45a7aef65a92780c3f367da953768d87e) | `` nix-prefetch-git: redirect git lfs to stderr ``                    |
| [`7c15e20e`](https://github.com/NixOS/nixpkgs/commit/7c15e20ed71b4474af6932207d3d2116b50bf3a2) | `` netbird-ui: 0.20.1 -> 0.20.3 ``                                    |
| [`43990017`](https://github.com/NixOS/nixpkgs/commit/43990017251b6cf09e44e10850ce78926a2caad0) | `` python311Packages.databricks-cli: 0.17.6 -> 0.17.7 ``              |
| [`308ccc25`](https://github.com/NixOS/nixpkgs/commit/308ccc25f198ba498fbd5b02890ea5de4e4f0ed6) | `` python310Packages.types-redis: 4.5.4.1 -> 4.5.5.2 ``               |
| [`6ddfdf16`](https://github.com/NixOS/nixpkgs/commit/6ddfdf16adbf3bde8306efbacae116f12577c54f) | `` python310Packages.nodeenv: 1.7.0 -> 1.8.0 ``                       |
| [`ea04a14f`](https://github.com/NixOS/nixpkgs/commit/ea04a14fe20350a09e46767986c3a79482183729) | `` nmap-formatter: 2.0.4 -> 2.1.0 ``                                  |
| [`0d324083`](https://github.com/NixOS/nixpkgs/commit/0d324083df5fbf7399c6c2b953781dc4346d0486) | `` sdbus-cpp: remove `with lib` ``                                    |
| [`955d34eb`](https://github.com/NixOS/nixpkgs/commit/955d34ebe8ec138c45017d4b847d65cbce5d9cf9) | `` sdbus-cpp: reorder inputs ``                                       |
| [`a3f3faa8`](https://github.com/NixOS/nixpkgs/commit/a3f3faa8af58e99963f91ce0aca9e5179e6b3280) | `` sdbus-cpp: change src.sha256 to src.hash ``                        |
| [`b51bc99b`](https://github.com/NixOS/nixpkgs/commit/b51bc99bd551cc0bbd1de68ec990d17ab63fe117) | `` sdbus-cpp: reformat meta.longDescription ``                        |
| [`c922c8b8`](https://github.com/NixOS/nixpkgs/commit/c922c8b83ebaa7f6ee8630072b7b2e1bf40cfe44) | `` jackett: 0.20.4145 -> 0.20.4199 ``                                 |
| [`0bda285f`](https://github.com/NixOS/nixpkgs/commit/0bda285f063f3d67c1ddc0475d307aa87e706267) | `` nwg-dock: 0.3.3 -> 0.3.4 ``                                        |
| [`5f3b60ef`](https://github.com/NixOS/nixpkgs/commit/5f3b60efbf8d8e95ac73ebf8bec50898731b232a) | `` pluto: 5.16.1 -> 5.16.3 ``                                         |
| [`117bcd83`](https://github.com/NixOS/nixpkgs/commit/117bcd834d17583e44d568efdc7e9bad8aaeacae) | `` checkpwn: init at 0.5.6 ``                                         |
| [`a38539cd`](https://github.com/NixOS/nixpkgs/commit/a38539cd3c1ad23dac337283f639fe77f298da53) | `` pulumi-bin: 3.67.1 -> 3.68.0 ``                                    |
| [`d0283b79`](https://github.com/NixOS/nixpkgs/commit/d0283b791296585946fb5672db6774d6d05d109e) | `` goawk: 1.23.0 -> 1.23.1 ``                                         |
| [`7e54c1a6`](https://github.com/NixOS/nixpkgs/commit/7e54c1a6ac530d68d3643b4a033d801418d1807f) | `` cudatext-gtk: 1.194.0 -> 1.194.4 ``                                |
| [`5ab4f6b4`](https://github.com/NixOS/nixpkgs/commit/5ab4f6b4385a92aa9a24d98291a7f295b41a789a) | `` doctl: 1.94.0 -> 1.95.0 ``                                         |
| [`0305e8da`](https://github.com/NixOS/nixpkgs/commit/0305e8da5b42fde53f94277fa76b39771a434968) | `` darklua: init at 0.9.0 ``                                          |
| [`6eee961e`](https://github.com/NixOS/nixpkgs/commit/6eee961e5e0244cbc2e33992a88b18ba204101ef) | `` glooctl: 1.14.2 -> 1.14.4 ``                                       |
| [`f2a43c25`](https://github.com/NixOS/nixpkgs/commit/f2a43c25554c5e5fa6b61c09d3f0e08398c03b3a) | `` process-compose: 0.43.1 -> 0.45.0 ``                               |
| [`51c2a672`](https://github.com/NixOS/nixpkgs/commit/51c2a67289de6d2eb8fde306350f2a83ecbd0051) | `` fluxcd: 2.0.0-rc.2 -> 2.0.0-rc.3 ``                                |
| [`2cbd3082`](https://github.com/NixOS/nixpkgs/commit/2cbd3082b23be1ee414cce5f2a44f16025e4a59e) | `` ooniprobe-cli: 3.17.1 -> 3.17.2 ``                                 |
| [`00660c30`](https://github.com/NixOS/nixpkgs/commit/00660c303189c675a33e681f25b96fbaf534229a) | `` python310Packages.cupy: 11.5.0 -> 12.0.0 ``                        |
| [`9ae541a3`](https://github.com/NixOS/nixpkgs/commit/9ae541a3c20dbc88e55effd0d26526e9be1f1a2f) | `` mpv: fix umpv.desktop ``                                           |
| [`13f01e8f`](https://github.com/NixOS/nixpkgs/commit/13f01e8f5da04c7d2fd72fb4a095bc177b700048) | `` vhs: 0.4.0 -> 0.5.0 ``                                             |
| [`473ef198`](https://github.com/NixOS/nixpkgs/commit/473ef198a96044577de0db3ccda3d59e86921327) | `` terraform-providers: use nurl in update-provider script ``         |
| [`00b83ae6`](https://github.com/NixOS/nixpkgs/commit/00b83ae6ed872bf41fe73aa150f36a16d8d3e027) | `` chamber: 2.12.0 -> 2.13.0 ``                                       |
| [`d8f440ad`](https://github.com/NixOS/nixpkgs/commit/d8f440adbb171a2c9bd59749fe7962d03d64f448) | `` checkip: add changelog to meta ``                                  |
| [`0d531f16`](https://github.com/NixOS/nixpkgs/commit/0d531f162ed0e8e5052114f88124eaf8d21f98db) | `` python310Packages.xdis: disable on Python 3.11 ``                  |
| [`30faa31d`](https://github.com/NixOS/nixpkgs/commit/30faa31dd1b9f26c78c0caf5c70bfcc610bf7c9d) | `` tagref: 1.7.0 -> 1.8.1 ``                                          |
| [`6add9f88`](https://github.com/NixOS/nixpkgs/commit/6add9f882954b20287d54009b9c61c4ff6cadd79) | `` python310Packages.timm: 0.6.12 -> 0.9.2 ``                         |
| [`1d4afe48`](https://github.com/NixOS/nixpkgs/commit/1d4afe48fd2ca0a64b2744129b58f1dd440bcfe0) | `` checkip: 0.45.1 -> 0.46.1 ``                                       |
| [`767111bc`](https://github.com/NixOS/nixpkgs/commit/767111bc41e3658c3011ef66f467c42d08922cbe) | `` v2ray-geoip: 202305110042 -> 202305180042 ``                       |
| [`716fb680`](https://github.com/NixOS/nixpkgs/commit/716fb6808b82ac84da81c1b1dac5f2967a0b1daf) | `` typst-lsp: 0.4.1 -> 0.5.1 ``                                       |
| [`b0f92293`](https://github.com/NixOS/nixpkgs/commit/b0f92293e9772839a06f6eaf92c0d5704420b84d) | `` rubyPackages.ruby-terminfo: fix ruby 3 build ``                    |
| [`76e765c5`](https://github.com/NixOS/nixpkgs/commit/76e765c5f88cd90d6895d251b6549240633fff9f) | `` kubeclarity: rename from kubei ``                                  |
| [`03b689e3`](https://github.com/NixOS/nixpkgs/commit/03b689e3baa2803d4cc7a9c60fc99e881f22a0f0) | `` perlPackages.FinanceQuote: 1.49 -> 1.55 ``                         |
| [`6827ad0a`](https://github.com/NixOS/nixpkgs/commit/6827ad0aa5cf53d19f19e74391edca31e444fd17) | `` perlPackages.WebScraper: init at 0.38 ``                           |
| [`de941a42`](https://github.com/NixOS/nixpkgs/commit/de941a42753b777c5b6f4508d32686c2c4fdcbf3) | `` perlPackages.SpreadsheetXLSX: init at 0.17 ``                      |
| [`5345c491`](https://github.com/NixOS/nixpkgs/commit/5345c491e482d53deec5f2f356637d563e137002) | `` perlPackages.libwwwperl: init at 6.70 ``                           |
| [`9060f35c`](https://github.com/NixOS/nixpkgs/commit/9060f35cdaed65cf742dc8d6f8e5a12f3aca70ef) | `` perlPackages.DateRange: init at 1.41 ``                            |
| [`65c52695`](https://github.com/NixOS/nixpkgs/commit/65c526958983f4bd2620d2c69fda5fe1950ada8b) | `` gnucash: fix finance-quote-wrapper exec ``                         |
| [`a4f49985`](https://github.com/NixOS/nixpkgs/commit/a4f499852ba38ff6ff0aef7ea577c354db4d42af) | `` go365: 1.4 -> 2.0 ``                                               |
| [`b3f5ab37`](https://github.com/NixOS/nixpkgs/commit/b3f5ab3796733608794a2727e64a5efb5e7b93db) | `` typst: 0.3.0 -> 0.4.0 ``                                           |
| [`b906d8a3`](https://github.com/NixOS/nixpkgs/commit/b906d8a3a7002c79045b35ce46c95040286272f3) | `` pgmodeler: 1.0.3 -> 1.0.4 ``                                       |
| [`3e7e852f`](https://github.com/NixOS/nixpkgs/commit/3e7e852f453e53312efe70efa8d0a57b3c20429f) | `` opendylan: mark broken ``                                          |
| [`fb55842f`](https://github.com/NixOS/nixpkgs/commit/fb55842f43dd14e5c0a0b91d42d5f766a43c8285) | `` python3Packages.vmprof: fix build ``                               |
| [`142c2471`](https://github.com/NixOS/nixpkgs/commit/142c24711e90e29ded210331db5c41cfb10a1fe3) | `` doc: fix typo ``                                                   |
| [`9287bf86`](https://github.com/NixOS/nixpkgs/commit/9287bf867622f1205e48a240ef342b39348e6f3f) | `` vimPlugins.denops-vim: init at 2023-01-20 ``                       |
| [`8bf3e834`](https://github.com/NixOS/nixpkgs/commit/8bf3e834daedadc6d0f4172616b2bdede1109c48) | `` icewm: 3.3.4 -> 3.3.5 ``                                           |
| [`b182c03d`](https://github.com/NixOS/nixpkgs/commit/b182c03d1c65199ea223cc4b0a81e4ea8643b1f8) | `` python311Packages.virtualenv-clone: fix tests ``                   |
| [`f84d41f5`](https://github.com/NixOS/nixpkgs/commit/f84d41f5ad5ecad42e62d59dd62826ee28905f78) | `` python310Packages.motionblinds: 0.6.17 -> 0.6.18 ``                |
| [`4a6077e7`](https://github.com/NixOS/nixpkgs/commit/4a6077e77f54582de7ee1d938061ddc1903ece61) | `` go-exploitdb: init at 0.4.5 ``                                     |
| [`c1c562cf`](https://github.com/NixOS/nixpkgs/commit/c1c562cf1ec3d42a8c808b7a8f0a614be5027599) | `` mullvad-browser: fix file picker crashing ``                       |
| [`c20f48fd`](https://github.com/NixOS/nixpkgs/commit/c20f48fdb293988b5778e6d6e3ef2e99539c2327) | `` python3Packages.timelib: 0.2.5 -> 0.3.0 ``                         |
| [`2fa279fb`](https://github.com/NixOS/nixpkgs/commit/2fa279fbf31d4f9b7492b4a49a887666412473c2) | `` gajim: 1.6.1 -> 1.7.3 ``                                           |
| [`93b61e55`](https://github.com/NixOS/nixpkgs/commit/93b61e55f3fa530f7a3cd9c77e2186ad3bb3ebbf) | `` python311Packages.fn: disable ``                                   |
| [`dc07e260`](https://github.com/NixOS/nixpkgs/commit/dc07e260c989e820f534224130c2ecb4b56a17df) | `` slskd: 0.17.5 -> 0.17.8 ``                                         |
| [`b8733cfa`](https://github.com/NixOS/nixpkgs/commit/b8733cfa6cbb959b1a590f4d80db082474e07548) | `` buf: 1.18.0 -> 1.19.0 ``                                           |
| [`58228cf8`](https://github.com/NixOS/nixpkgs/commit/58228cf8b22560282a7f4f3d8e5a9f68a4326798) | `` nbxmpp: 4.0.1 -> 4.2.2 ``                                          |
| [`95c7a595`](https://github.com/NixOS/nixpkgs/commit/95c7a595cef4ffb097bf3718a29982d8d66902b7) | `` helix: 23.03 -> 23.05 ``                                           |
| [`384aff71`](https://github.com/NixOS/nixpkgs/commit/384aff71f2d2bdd044e3c7072b4bdfc431eeac62) | `` python3Packages.scancode-toolkit: fix build ``                     |
| [`2d9c3066`](https://github.com/NixOS/nixpkgs/commit/2d9c30663078e97411c199275193c384075e7744) | `` doppler: 3.58.0 -> 3.60.1 ``                                       |
| [`6d95ed08`](https://github.com/NixOS/nixpkgs/commit/6d95ed08b4821978a6c97eed860dcc2646a018e0) | `` python310Packages.bimmer-connected: 0.13.5 -> 0.13.6 ``            |
| [`f07f108c`](https://github.com/NixOS/nixpkgs/commit/f07f108c7c0ff8969a2d708cc199183f9a198516) | `` python311Packages.pympler: fix tests ``                            |
| [`458d44a5`](https://github.com/NixOS/nixpkgs/commit/458d44a550c177c6e8c5d464765febea4052e2ee) | `` python311Packages.gtts: 2.3.1 -> 2.3.2 ``                          |
| [`23cf0d4b`](https://github.com/NixOS/nixpkgs/commit/23cf0d4b69defae9bd6e80b3d4a96a069f14c27b) | `` texlive.bin.core-big: fix CVE-2023-32700 ``                        |
| [`91d415a1`](https://github.com/NixOS/nixpkgs/commit/91d415a123b119aef9a4d3f5d818bcdbefb27dcc) | `` nanomq: 0.16.3 -> 0.18.2 ``                                        |
| [`82824402`](https://github.com/NixOS/nixpkgs/commit/828244022d5c8ea56facb3bb482faac68b200ca8) | `` komikku: 1.20.0 -> 1.21.1 ``                                       |
| [`6dbe5d69`](https://github.com/NixOS/nixpkgs/commit/6dbe5d6930d02ad546ff41dac7fe5c8b50192796) | `` wails: 2.4.1 -> 2.5.1 ``                                           |
| [`67b35dd7`](https://github.com/NixOS/nixpkgs/commit/67b35dd7ee6dc85dbd3fa290252b5f62a3779d91) | `` python311Packages.python-ctags3: fix build ``                      |
| [`7a75e0b0`](https://github.com/NixOS/nixpkgs/commit/7a75e0b0af9f048fbcb02384e5d6c0b5228e3129) | `` werf: 1.2.231 -> 1.2.233 ``                                        |
| [`fd53d1fc`](https://github.com/NixOS/nixpkgs/commit/fd53d1fc0ca181d0ae8a811994669eacb8018e2f) | `` argocd: 2.7.1 -> 2.7.2 ``                                          |
| [`7cf6ca10`](https://github.com/NixOS/nixpkgs/commit/7cf6ca10a59a728ce5c98a7a54411d19b3319fcb) | `` fractal-next: 5-alpha1 -> 5.beta1 (#232918) ``                     |
| [`7abd408b`](https://github.com/NixOS/nixpkgs/commit/7abd408b7f10648bc886b868dfa490e49c3c85e6) | `` nixos/pam_mount: fix cryptmount options (#232873) ``               |
| [`df8cabc8`](https://github.com/NixOS/nixpkgs/commit/df8cabc8f7a89741047168fd58e15b972d3aa567) | `` hedgedoc: unpin nodejs_16 (#232919) ``                             |
| [`64361e26`](https://github.com/NixOS/nixpkgs/commit/64361e26b22f6f78a1494affc0b482ac668e878f) | `` nixos/libvirtd: enable polkit ``                                   |
| [`d856c35f`](https://github.com/NixOS/nixpkgs/commit/d856c35fdfbb99adc16eb9f589d993d62e892601) | `` ossutil: 1.7.6 -> 1.7.16 ``                                        |
| [`e32dd645`](https://github.com/NixOS/nixpkgs/commit/e32dd64558621ed1291038d81cc1cf6e28af6a02) | `` python311Packages.pygpgme: disable ``                              |
| [`48cfede2`](https://github.com/NixOS/nixpkgs/commit/48cfede24f643b99de61ac1ad1958a71df5e1de9) | `` python311Packages.pydbus: disable ``                               |
| [`ac6f1ccc`](https://github.com/NixOS/nixpkgs/commit/ac6f1ccc0737c775e83a68e50c980c12ccc65f1c) | `` oven-media-engine: relax platforms ``                              |
| [`a2f49342`](https://github.com/NixOS/nixpkgs/commit/a2f49342d860f6d0875598c3ff279881c9e283b6) | `` treewide: Reduce jtojnar maintainership ``                         |
| [`fe9166fd`](https://github.com/NixOS/nixpkgs/commit/fe9166fd675bb574dd7fd1602c15a0cddb1175d4) | `` lutris: 0.5.12 -> 0.5.13 ``                                        |
| [`5344bd53`](https://github.com/NixOS/nixpkgs/commit/5344bd532d7e1f4b994c0e471cb34806e7eb23d4) | `` python3Packages.moddb: init at 0.8.1 ``                            |
| [`d1c01ddc`](https://github.com/NixOS/nixpkgs/commit/d1c01ddce4d91bebffd8c6aebdac69605d7cfe63) | `` python3Packages.pyrate-limiter: init at 2.10.0 ``                  |
| [`f6976e11`](https://github.com/NixOS/nixpkgs/commit/f6976e11e0999aa4c7df1ceca467ed2d5c4a5858) | `` exiv2: 0.27.6 -> 0.27.7 ``                                         |
| [`f3c37c91`](https://github.com/NixOS/nixpkgs/commit/f3c37c91bbcfe6959411390973d0ee0ea94863de) | `` exoscale-cli: 1.68.0 -> 1.69.0 ``                                  |
| [`c8f87935`](https://github.com/NixOS/nixpkgs/commit/c8f87935e58302e7e515875e2da37dc1c38e0842) | `` revive: 1.3.1 -> 1.3.2 ``                                          |
| [`d81de9fc`](https://github.com/NixOS/nixpkgs/commit/d81de9fc07060ba680fae01da33aa6390d2a2666) | `` nodePackages: update ``                                            |
| [`13f2a12d`](https://github.com/NixOS/nixpkgs/commit/13f2a12d8389f59d5c47fa48b14bc634cd6a77f7) | `` kube-bench: 0.6.13 -> 0.6.14 ``                                    |
| [`fc9c2a15`](https://github.com/NixOS/nixpkgs/commit/fc9c2a15a19f233f0ae07d8a240c4d76bdeace08) | `` python3Packages.bayesian-optimization: unbreak on darwin ``        |
| [`64b01126`](https://github.com/NixOS/nixpkgs/commit/64b0112629b4a2ba23931515ccea81cca7548b7c) | `` python3Packages.bayesian-optimization: format ``                   |
| [`2a8c40ef`](https://github.com/NixOS/nixpkgs/commit/2a8c40ef77d6178bdf746661d407cf9e038aca36) | `` python3Packages.bayesian-optimization: 1.2.0 -> 1.4.3 ``           |
| [`149fa3e6`](https://github.com/NixOS/nixpkgs/commit/149fa3e66dc4e542cf21e02b4328cd78d4bb31c8) | `` wordpress6_1: 6.1.1 -> 6.1.2 ``                                    |
| [`ca7f83f6`](https://github.com/NixOS/nixpkgs/commit/ca7f83f6df6c76f3354d6edc310a47d3c8434198) | `` tomcat*: add sourceProvenance binaryBytecode ``                    |
| [`65bcc91b`](https://github.com/NixOS/nixpkgs/commit/65bcc91beac09f8d675862e85f4ea436ed469b5b) | `` freeze: 1.1 -> 1.3 ``                                              |
| [`a1200481`](https://github.com/NixOS/nixpkgs/commit/a1200481f28b4637f9a8738e1bfd9ebbba3d5bdb) | `` rubyPackages.ovirt-engine-sdk: fix build on ruby 3.1 and higher `` |
| [`07f20d65`](https://github.com/NixOS/nixpkgs/commit/07f20d6508726b8ec03ba8f8f98873316baa0db9) | `` pythonPackages.pysha3: replace with safe-pysha3 ``                 |
| [`2d9d3757`](https://github.com/NixOS/nixpkgs/commit/2d9d3757e1903a5bdc6f5d855f689fa09348794f) | `` headscale: 0.22.1 -> 0.22.3 ``                                     |
| [`e1fd8cad`](https://github.com/NixOS/nixpkgs/commit/e1fd8cad1fc7f8fc6b3e3a230725959db233c892) | `` python3Packages.hg-git: 1.0.1 -> 1.0.2 ``                          |
| [`0749e39f`](https://github.com/NixOS/nixpkgs/commit/0749e39f647888d290eef3efcfedf16ddd1df1b3) | `` tomcat9: 9.0.68 -> 9.0.75 ``                                       |