### PR TITLE
chore(flake/darwin): `dfbdabbb` -> `b8c286c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -87,11 +87,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684343812,
-        "narHash": "sha256-ZTEjiC8PDKeP8JRchuwcFXUNlMcyQ4U+DpyVZ3pB6Q4=",
+        "lastModified": 1684774948,
+        "narHash": "sha256-hJTaw4dYzcB+lsasKejnafq0CxPsVetn9RLXrcL+4jE=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "dfbdabbb3e797334172094d4f6c0ffca8c791281",
+        "rev": "b8c286c82c6b47826a6c0377e7017052ad91353c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                      |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
| [`ebdd18cd`](https://github.com/LnL7/nix-darwin/commit/ebdd18cdc169f680a1385c0d26dfe92dc5062ade) | `` ci: refactor to several jobs to enable optional checks `` |
| [`d2222000`](https://github.com/LnL7/nix-darwin/commit/d222200091f2d739bf811b98056fbd0062ea0789) | `` ci: use latest stable channel 22.05 -> 22.11 ``           |
| [`a379f9af`](https://github.com/LnL7/nix-darwin/commit/a379f9afe7f80b137d66fbbeeb81da9b29b519da) | `` docs: update flake snippet to 22.11 ``                    |
| [`8c9337e2`](https://github.com/LnL7/nix-darwin/commit/8c9337e28685448882142302b45daef38a127df4) | `` ci: bump actions to most recent version ``                |
| [`9f93b195`](https://github.com/LnL7/nix-darwin/commit/9f93b195853a275668e013d330d7bdd59e6c4b49) | `` feat: support writing arrays to system defaults ``        |