### PR TITLE
chore(flake/home-manager): `ba006d7c` -> `d9995d94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -209,11 +209,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1684741999,
-        "narHash": "sha256-KZLKsFZ6cLjCdCNKZoT8bc1y+rYBuFgKatmIB38zqy4=",
+        "lastModified": 1684788503,
+        "narHash": "sha256-ewr/8U0/iCs8K+MP5Fw9Q1IQ1Pt57ZgC2k/dg1c+CMk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ba006d7cca2cb871c6a31bdbc130c05cde5ca8e8",
+        "rev": "d9995d94f194955d1f1af0e1ad5866a904196c20",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`d9995d94`](https://github.com/nix-community/home-manager/commit/d9995d94f194955d1f1af0e1ad5866a904196c20) | `` lib/file-type: fix xrefs (#4007) `` |