### PR TITLE
chore(flake/nixpkgs): `50a18318` -> `7084250d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684662198,
-        "narHash": "sha256-lmGDGuFONWSoGBKDDhU/6fOhhmFoZQ8rPf+kS7/e/Gs=",
+        "lastModified": 1684754342,
+        "narHash": "sha256-plGnjnbnPLoZCTdQX21oT7xliQhFtgcWlkuDHgtEb1o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "50a183182d7ae39133555414d48d5d609a28a57d",
+        "rev": "7084250df3d7f9735087d3234407f3c1fc2400e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`49a5cd8b`](https://github.com/NixOS/nixpkgs/commit/49a5cd8be665a5152b941890db54c8a92a69ce5a) | `` darwin.sigtool: add meta ``                                                     |
| [`d79d7bdb`](https://github.com/NixOS/nixpkgs/commit/d79d7bdbf43df9aa19f3c3234c0729c54cee6105) | `` lens: Change lens' listed license from MIT to their own proprietary license. `` |
| [`a4b25ea8`](https://github.com/NixOS/nixpkgs/commit/a4b25ea80898ea87ec2427719f2ec2dee427019a) | `` python310Packages.bx-py-utils: 78 -> 80 ``                                      |
| [`9be9b726`](https://github.com/NixOS/nixpkgs/commit/9be9b726f4b57814f67b58e860aec7cae2c18675) | `` linux_testing: 6.4-rc2 -> 6.4-rc3 ``                                            |
| [`02df3006`](https://github.com/NixOS/nixpkgs/commit/02df300699f8e4c24b39eeb7e034403880715dc5) | `` cargo-leptos: init at 0.1.8 ``                                                  |
| [`d42b8bcd`](https://github.com/NixOS/nixpkgs/commit/d42b8bcdf981569e39e95ee2a39598bc59d1a9d3) | `` maintainers: add benwis ``                                                      |
| [`0b3a80b2`](https://github.com/NixOS/nixpkgs/commit/0b3a80b2d750b927be92bffb2543f69cbc33373b) | `` wget: 1.21.3 -> 1.21.4 ``                                                       |
| [`6d71b5d6`](https://github.com/NixOS/nixpkgs/commit/6d71b5d6de16abfa008340f3bf5ad51e6eb7f677) | `` iqtree: set platforms ``                                                        |
| [`a507668d`](https://github.com/NixOS/nixpkgs/commit/a507668d8de9c0ca17a012191cbb82ef94388d59) | `` libcpr: use version variable as Git rev ``                                      |
| [`eeefa71d`](https://github.com/NixOS/nixpkgs/commit/eeefa71db439b9d2d41544fd564207259ed58a88) | `` ronin: init at 2.0.1 ``                                                         |
| [`1493a57c`](https://github.com/NixOS/nixpkgs/commit/1493a57cb6c7f0bc0a51d64c27da07055b357af3) | `` privacyidea: fix build ``                                                       |
| [`c92f2244`](https://github.com/NixOS/nixpkgs/commit/c92f2244d1a31ed5ac66d3c625c332e817a1e92a) | `` wordpress6_2: 6.2.1 -> 6.2.2 ``                                                 |
| [`1d0432ec`](https://github.com/NixOS/nixpkgs/commit/1d0432ec589c12815b84e2c944c38b800e541145) | `` neomutt: 20230512 -> 20230517 ``                                                |
| [`c009c2bc`](https://github.com/NixOS/nixpkgs/commit/c009c2bc1da372716785b3afac0ff23a5660bf0d) | `` helix: add maintainer ``                                                        |
| [`aee4db0f`](https://github.com/NixOS/nixpkgs/commit/aee4db0fdab8e46d8bb5a914277bd6fbca77cc55) | `` steam: fix lib32 dependencies ``                                                |
| [`bbac6aa5`](https://github.com/NixOS/nixpkgs/commit/bbac6aa50614392a813c8b7ca512cae139f6e568) | `` python310Packages.manifest-ml: 0.1.5 -> 0.1.7 ``                                |
| [`0a560af5`](https://github.com/NixOS/nixpkgs/commit/0a560af56c4e58bf7e9265df99ad056d7715409c) | `` crow-translate: 2.10.4 -> 2.10.5 ``                                             |
| [`fd4c32ce`](https://github.com/NixOS/nixpkgs/commit/fd4c32ce8314cc60e4735049a61e14389de35b8a) | `` refinery-cli: 0.8.9 -> 0.8.10 ``                                                |
| [`b72f90dc`](https://github.com/NixOS/nixpkgs/commit/b72f90dc4b04e17f00fb35f98e99b01b4cd556fd) | `` python310Packages.pysimplegui: 4.60.4 -> 4.60.5 ``                              |
| [`cf87e1bc`](https://github.com/NixOS/nixpkgs/commit/cf87e1bc8681574b8b192d768db34edf6768fa80) | `` terraform-providers.alicloud: 1.204.1 -> 1.205.0 ``                             |
| [`2f9d8929`](https://github.com/NixOS/nixpkgs/commit/2f9d89291a977ba7f84934d4d7d7df506ca8a7df) | `` python310Packages.trimesh: 3.21.6 -> 3.21.7 ``                                  |
| [`aa945561`](https://github.com/NixOS/nixpkgs/commit/aa9455616dc6c008ddcc2749da24f28a34c81dea) | `` python310Packages.atlassian-python-api: 3.36.0 -> 3.37.0 ``                     |
| [`b36979ec`](https://github.com/NixOS/nixpkgs/commit/b36979ec74488ce153d936eb630e71010c251193) | `` iqtree: 2.2.0.4 -> 2.2.2.4 ``                                                   |
| [`47c722bd`](https://github.com/NixOS/nixpkgs/commit/47c722bd77738ac42c71ac5ce883f2653c4d85a4) | `` coqPackages_8_17.dpdgraph: init at 1.0+8.17 ``                                  |
| [`2a7863eb`](https://github.com/NixOS/nixpkgs/commit/2a7863eb2f1adfddf98136bbff1a1f670e5fb4ff) | `` iwd: 2.3 -> 2.4 ``                                                              |
| [`11200746`](https://github.com/NixOS/nixpkgs/commit/11200746852ab36c23e850234ef66c90d1c9a9ac) | `` gtk4: Backport fixes to fix regression in nautilus, mutter ``                   |
| [`3bfd604d`](https://github.com/NixOS/nixpkgs/commit/3bfd604d163b5017cdc8b9af1fc5d0c1863b463f) | `` python3Packages.scikit-fmm: 2022.8.15 -> 2023.4.2 ``                            |
| [`f6e677ac`](https://github.com/NixOS/nixpkgs/commit/f6e677ac8bcb03624182e2acc42648344ddd3efd) | `` intel-compute-runtime: 23.05.25593.11 -> 23.13.26032.30 ``                      |
| [`3ee719e7`](https://github.com/NixOS/nixpkgs/commit/3ee719e763011313277daec010e05e569cb6277c) | `` kde-cli-tools: 5.27.5 -> 5.27.5.1 ``                                            |
| [`1d6faf84`](https://github.com/NixOS/nixpkgs/commit/1d6faf84a9098f5121e1c25dc24beee5130cdab3) | `` python3Packages.word2vec: remove ``                                             |
| [`b4260c35`](https://github.com/NixOS/nixpkgs/commit/b4260c35b8eedd05745b3eaa37d1cf6e8203c0c8) | `` python3Packages.wordcloud: unstable-2023-01-04 -> 1.9.1.1 ``                    |
| [`d55fa729`](https://github.com/NixOS/nixpkgs/commit/d55fa72969dde83659845d042154350e52fcda1a) | `` esphome: 2023.5.1 -> 2023.5.2 ``                                                |
| [`56bc1c4e`](https://github.com/NixOS/nixpkgs/commit/56bc1c4ec838238a340316cbe5e5dc9d0fa1ecf8) | `` maintainers: update email for emilytrau ``                                      |
| [`8586478e`](https://github.com/NixOS/nixpkgs/commit/8586478e174493b4eff3ef4904e814a0480aecf4) | `` minimal-bootstrap.gnugrep: init at 2.4 ``                                       |
| [`40bb45b8`](https://github.com/NixOS/nixpkgs/commit/40bb45b83f32232c0a4977855c061d10dc02f3e6) | `` ftxui: 3.0.0 -> 4.1.0 ``                                                        |
| [`752cf0f4`](https://github.com/NixOS/nixpkgs/commit/752cf0f485774753d3b104bb7bab4f6b58cc1d41) | `` orogene: 0.3.26 -> 0.3.27 ``                                                    |
| [`1a13b4c0`](https://github.com/NixOS/nixpkgs/commit/1a13b4c0f965f72be51637330aaddfac67a1f118) | `` powerdns-admin: 0.3.0 -> 0.4.1 ``                                               |
| [`1619fe40`](https://github.com/NixOS/nixpkgs/commit/1619fe4067ba02c16eb3523916d52237e2dac286) | `` werf: 1.2.233 -> 1.2.235 ``                                                     |
| [`714c4d35`](https://github.com/NixOS/nixpkgs/commit/714c4d35fa509d168f2df634fe1d4711f51b2e62) | `` elmPackages: nodejs_14 -> nodejs_18. ``                                         |
| [`335976b8`](https://github.com/NixOS/nixpkgs/commit/335976b8555a98b35135a73867febe13d0db849d) | `` paperwm: unstable-2023-04-20 -> 44.0.0-beta.1 ``                                |
| [`92bca334`](https://github.com/NixOS/nixpkgs/commit/92bca3345b544fc7f956eabbb841422f8419ec9e) | `` pulldown-cmark: 0.9.2 -> 0.9.3 ``                                               |
| [`789d16f5`](https://github.com/NixOS/nixpkgs/commit/789d16f52d03d3747cb0465b636a00ffed6a2947) | `` basu: init at 0.2.1 ``                                                          |
| [`a8c39f77`](https://github.com/NixOS/nixpkgs/commit/a8c39f772b58a608a40e9060f85c97816cff9788) | `` botamusique: move to fetchNpmDeps ``                                            |
| [`9117f012`](https://github.com/NixOS/nixpkgs/commit/9117f0127222bd53c56ca821d3ba369ba7f2f09c) | `` npmHooks.npmConfigHook: add npmRoot option ``                                   |
| [`32d1d6e7`](https://github.com/NixOS/nixpkgs/commit/32d1d6e7bf2a44c420008f769605d9a9dbf2f358) | `` httpref: init at 1.6.1 ``                                                       |
| [`796d3f65`](https://github.com/NixOS/nixpkgs/commit/796d3f65340b2f18b5cc9d7b095f0538d30baf3c) | `` iosevka: 22.1.0 -> 23.0.0 ``                                                    |
| [`12841b63`](https://github.com/NixOS/nixpkgs/commit/12841b63a13e3b9bb512e12c2dd2fc3fa3fed362) | `` python311Packages.xiaomi-ble: 0.17.0 -> 0.17.1 ``                               |
| [`b7aab995`](https://github.com/NixOS/nixpkgs/commit/b7aab9951ce7b2bed13bacc49723664d59a449e6) | `` python311Packages.scancode-toolkit: add changelog to meta ``                    |
| [`d2315648`](https://github.com/NixOS/nixpkgs/commit/d2315648eccb90edaa137446bf78cca1a8efa0f6) | `` protobuf3_17: drop ``                                                           |
| [`c7edaa49`](https://github.com/NixOS/nixpkgs/commit/c7edaa494341026a3134579c47881a54c9f212d3) | `` python311Packages.scancode-toolkit: 31.2.4 -> 31.2.6 ``                         |
| [`540253e9`](https://github.com/NixOS/nixpkgs/commit/540253e916b1d37cb72c1b44f9523c707255b734) | `` python310Packages.pytelegrambotapi: 4.11.0 -> 4.12.0 ``                         |
| [`d0604c77`](https://github.com/NixOS/nixpkgs/commit/d0604c778672b3adffef486cfcf81cd926fa23dc) | `` cargo-flamegraph: 0.6.2 -> 0.6.3 ``                                             |
| [`197ef325`](https://github.com/NixOS/nixpkgs/commit/197ef32594629926abce61aedce845d7c35b9aef) | `` python310Packages.pwntools: clean-up postPatch section ``                       |
| [`00342bef`](https://github.com/NixOS/nixpkgs/commit/00342befa0f2635feb1a000134fa9c12f12f50ec) | `` python310Packages.pwntools: 4.9.0 -> 4.10.0 ``                                  |
| [`2c3469de`](https://github.com/NixOS/nixpkgs/commit/2c3469de9638a762c48ca1e240571858c4d70060) | `` python310Packages.google-cloud-bigtable: 2.17.0 -> 2.18.1 ``                    |
| [`e45c5042`](https://github.com/NixOS/nixpkgs/commit/e45c504209eca775e247139a9ec059642f9b45bc) | `` python310Packages.energyzero: 0.4.1 -> 0.4.2 ``                                 |
| [`2a9e8298`](https://github.com/NixOS/nixpkgs/commit/2a9e82985c4becd628ecf349f3a410ebc02ae929) | `` python310Packages.archspec: 0.2.0 -> 0.2.1 ``                                   |
| [`a88ea63a`](https://github.com/NixOS/nixpkgs/commit/a88ea63aa18c2ea26195fda16388821e8fd3267e) | `` httpie: 3.2.1 -> 3.2.2 ``                                                       |
| [`2aade383`](https://github.com/NixOS/nixpkgs/commit/2aade383c926a47fb090493ef92fa6bba091723d) | `` step-ca: add changelog to meta ``                                               |
| [`30ff366f`](https://github.com/NixOS/nixpkgs/commit/30ff366f77c835d9ab8755d1f95bf522843ccd16) | `` ghidra: mark broken on darwin ``                                                |
| [`92275616`](https://github.com/NixOS/nixpkgs/commit/9227561605a792580f4dfb330c6207b38648256b) | `` step-ca: 0.23.2 -> 0.24.2 ``                                                    |
| [`4443e737`](https://github.com/NixOS/nixpkgs/commit/4443e737e1ae2194f1261036c2b7388a7b637a2a) | `` python310Packages.python-mystrom: 2.1.0 -> 2.2.0 ``                             |
| [`300f31f8`](https://github.com/NixOS/nixpkgs/commit/300f31f8a5f74242b05add977cf2475a041f9b49) | `` jpegoptim: 1.5.3 -> 1.5.4 ``                                                    |
| [`73cd2b02`](https://github.com/NixOS/nixpkgs/commit/73cd2b02866e8b6128d0c068f950af843af85cda) | `` osv-scanner: 1.3.2 -> 1.3.3 ``                                                  |
| [`25c19303`](https://github.com/NixOS/nixpkgs/commit/25c193034f4628ddba645fc3794ba72f5f91da5d) | `` automatic-timezoned: 1.0.87 -> 1.0.91 ``                                        |
| [`db9ec6a0`](https://github.com/NixOS/nixpkgs/commit/db9ec6a006218b14e4c5d0ed47a6ec46d7e7dd77) | `` viceroy: 0.5.0 -> 0.5.1 ``                                                      |
| [`6ca0ca7f`](https://github.com/NixOS/nixpkgs/commit/6ca0ca7f0769d3df9591956486ca8e0102c8a24d) | `` charls: 2.4.1 -> 2.4.2 ``                                                       |
| [`88114e92`](https://github.com/NixOS/nixpkgs/commit/88114e926ba197f1584ed8e3eddee15a93389881) | `` civo: 1.0.53 -> 1.0.54 ``                                                       |
| [`8ab26b2d`](https://github.com/NixOS/nixpkgs/commit/8ab26b2dcc29c0a68c7b491d5f104e267f9ef8f6) | `` broot: 1.21.3 -> 1.22.0 ``                                                      |
| [`4143506b`](https://github.com/NixOS/nixpkgs/commit/4143506bbbff5df338f973488d696a8f7fffc42b) | `` ghidra-bin: 10.2.2 -> 10.3 ``                                                   |
| [`206692b3`](https://github.com/NixOS/nixpkgs/commit/206692b33f4bb52220090e6760680313387f0b4d) | `` ghidra: 10.2.3 -> 10.3 ``                                                       |
| [`601b8658`](https://github.com/NixOS/nixpkgs/commit/601b8658d53c5e25ac3b5203e4a163122a77a84b) | `` souffle: 2.3 -> 2.4 ``                                                          |
| [`afbbd3fc`](https://github.com/NixOS/nixpkgs/commit/afbbd3fcf67a7c03a7586e1486ab21c013fd0ec5) | `` clipboard-jh: fixed broken system clipboard integration ``                      |
| [`f28bc280`](https://github.com/NixOS/nixpkgs/commit/f28bc28062c85b8d5a8a8c20f7a982354e4414cc) | `` espanso: support for darwin ``                                                  |
| [`150be958`](https://github.com/NixOS/nixpkgs/commit/150be958553edaf4cf23c7c6c1f12bdd8be6ea34) | `` espanso: add version test ``                                                    |
| [`5762a20a`](https://github.com/NixOS/nixpkgs/commit/5762a20a253e88a8dd9b2e49a6719fda00cb54ca) | `` espanso: 0.7.3 -> 2.1.8 ``                                                      |
| [`5eb2c2b2`](https://github.com/NixOS/nixpkgs/commit/5eb2c2b23dcfa65eac83e0e92851e24333a6c34d) | `` pipe-rename: 1.6.2 -> 1.6.3 ``                                                  |
| [`1ff22488`](https://github.com/NixOS/nixpkgs/commit/1ff2248885837a712a931dc00f6380ccef832ae0) | `` fusesoc: init at 2.2.1 ``                                                       |
| [`286e27c1`](https://github.com/NixOS/nixpkgs/commit/286e27c139acae6d3d6bd723fa17203fad50cf3b) | `` python3Packages.simplesat: init at 0.8.2 ``                                     |
| [`601006e6`](https://github.com/NixOS/nixpkgs/commit/601006e6ba3f985cd15cafa471d676f9831e13f0) | `` python3Pacakges.okonomiyaki: init at 1.3.2 ``                                   |
| [`82a7b271`](https://github.com/NixOS/nixpkgs/commit/82a7b2717ffa362d6f84921e4f146e368f2fb402) | `` python3Packages.zipfile2: init at 0.0.12 ``                                     |
| [`a83a3597`](https://github.com/NixOS/nixpkgs/commit/a83a3597cd17386067a99331a86e38151d52e1ff) | `` python3Packages.ipyxact: init at 0.3.2 ``                                       |
| [`dc1813ff`](https://github.com/NixOS/nixpkgs/commit/dc1813ff77c467d6e04d0023f93b748ebca0eefa) | `` nordic: unstable-2022-06-21 -> unstable-2023-05-12 ``                           |
| [`9cea0bc2`](https://github.com/NixOS/nixpkgs/commit/9cea0bc2fdb8601a837e9b4c9e5ec7eb8c43c2c0) | `` cxxopts: 3.0.0 -> 3.1.1 ``                                                      |
| [`3039b593`](https://github.com/NixOS/nixpkgs/commit/3039b593ab0b99b4943a3542479df05d65c76ba3) | `` metasploit: 6.3.16 -> 6.3.17 ``                                                 |
| [`961af3e1`](https://github.com/NixOS/nixpkgs/commit/961af3e15f7e3070321df461511946458ca8fddb) | `` cloudcompare: disable qRANSAC_SD plugin to fix build ``                         |
| [`40039cff`](https://github.com/NixOS/nixpkgs/commit/40039cffc04bf8ea86e06ebcbb9eaba33a0fb325) | `` python311Packages.boiboite-opener-framework: init at 1.2.1 ``                   |
| [`999652eb`](https://github.com/NixOS/nixpkgs/commit/999652eb33fc84ac62fe85745ca240a84677b785) | `` doc/python: remove usages of `fetchPypi` aliases ``                             |
| [`d56e6140`](https://github.com/NixOS/nixpkgs/commit/d56e6140dfac2766666f457170c43a59fa056bca) | `` dnscontrol: 4.0.0 -> 4.0.1 ``                                                   |
| [`cb1bce2e`](https://github.com/NixOS/nixpkgs/commit/cb1bce2e1c2eb52708ad815a02e42802dd38ace9) | `` gitlab: patch for openssl 3.x support (#233235) ``                              |
| [`810268b8`](https://github.com/NixOS/nixpkgs/commit/810268b85317d5ce6b79309ca27f3f561c2186a5) | `` nixosTests.prometheus-exporters.statsd fix test ``                              |
| [`9695889e`](https://github.com/NixOS/nixpkgs/commit/9695889e9035cc4ba177e732d37e6b011ce04c6a) | `` n8n: regenerate with nodejs 18 ``                                               |
| [`4d26725a`](https://github.com/NixOS/nixpkgs/commit/4d26725ab9c7b21bb12b446d7fb3e78205257c01) | `` girsh: init at 0.41 ``                                                          |
| [`998819a0`](https://github.com/NixOS/nixpkgs/commit/998819a01a7a19a8e1c13226346c2356ad658400) | `` nixosTests.prometheus-exporters.domain fix test ``                              |
| [`6a18e4b8`](https://github.com/NixOS/nixpkgs/commit/6a18e4b8a4ecaeea106e4b50e76f767dfab94998) | `` wezterm: fix darwin build ``                                                    |
| [`c921e7c2`](https://github.com/NixOS/nixpkgs/commit/c921e7c28b9587e5cc08861b7f8fb621eb643b10) | `` heroic: small cleanup ``                                                        |