### PR TITLE
chore(flake/pre-commit-hooks): `df448ffc` -> `61e567d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1684763926,
-        "narHash": "sha256-1pSTzogoCmZc7JB3VrFFgFoj5lNXIIWwkVReFVMHDT8=",
+        "lastModified": 1684842236,
+        "narHash": "sha256-rYWsIXHvNhVQ15RQlBUv67W3YnM+Pd+DuXGMvCBq2IE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "df448ffc5d244f52261d05894c5a96af7f3758a1",
+        "rev": "61e567d6497bc9556f391faebe5e410e6623217f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                        |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
| [`560e21c2`](https://github.com/cachix/pre-commit-hooks.nix/commit/560e21c20d3e5b18ada14fc09d5af718fba639ee) | `` deadnix: Use mkCmdArgs, expose more args `` |
| [`401a0ea6`](https://github.com/cachix/pre-commit-hooks.nix/commit/401a0ea664b1639556518583d68ef3873bef2d6d) | `` Add optional `hintFile` setting to hlint `` |
| [`b9c72a40`](https://github.com/cachix/pre-commit-hooks.nix/commit/b9c72a405d7b8aba0133b63720fcbc285563f2c0) | `` Wrap `dune fmt` in a clean written tool ``  |
| [`605664fb`](https://github.com/cachix/pre-commit-hooks.nix/commit/605664fb2a2c918b7dbda0b540afe99a57e7f322) | `` add cspell ``                               |
| [`18c6fd38`](https://github.com/cachix/pre-commit-hooks.nix/commit/18c6fd38ab8fe6e1894727823c373f87e5873b46) | `` Add support for pyright ``                  |