### PR TITLE
chore(flake/lanzaboote): `36adaf5a` -> `1f542a1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1684743071,
-        "narHash": "sha256-MPQGZ3fmH+SlyBcf1qJztArnAzwG45JETXb2qhQOZTw=",
+        "lastModified": 1684881876,
+        "narHash": "sha256-WvyvVaNQtk3hG83N4O5VvCO5xQY5NjjV8UyFatystQo=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "36adaf5a9e8664bf6be6b5e5bc99408bfdae7720",
+        "rev": "1f542a1eba389112b9679b851056b8dedb99cc74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                    |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`30ddfcd2`](https://github.com/nix-community/lanzaboote/commit/30ddfcd2ceda86a952cbfae3cf99e7ce0796db4d) | `` tool: improve command error messages `` |