### PR TITLE
chore(flake/nixos-hardware): `71ce8537` -> `4cc688ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -291,11 +291,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1684169666,
-        "narHash": "sha256-N5jrykeSxLVgvm3Dd3hZ38/XwM/jU+dltqlXgrGlYxk=",
+        "lastModified": 1684899633,
+        "narHash": "sha256-NtwerXX8UFsoNy6k+DukJMriWtEjQtMU/Urbff2O2Dg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "71ce85372a614d418d5e303dd5702a79d1545c04",
+        "rev": "4cc688ee711159b9bcb5a367be44007934e1a49d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`e2864d99`](https://github.com/NixOS/nixos-hardware/commit/e2864d99fddc26c2ab11f6937f493c6390b0ad12) | `` starfive visionfive2: replace 8GB memory patch with overlay `` |
| [`ee1055d8`](https://github.com/NixOS/nixos-hardware/commit/ee1055d80ce5fcfe556e4c7185d9afcf922a7caf) | `` [FocusGen1M2] Disable TPM interrupt due to upstream bug ``     |