### PR TITLE
chore(flake/lanzaboote): `1f542a1e` -> `dc52f035`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1684881876,
-        "narHash": "sha256-WvyvVaNQtk3hG83N4O5VvCO5xQY5NjjV8UyFatystQo=",
+        "lastModified": 1684917161,
+        "narHash": "sha256-8q6W6vYrV09bsBaaAfRkQrJ5h0AzDWfCkHJzi4bMXsY=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "1f542a1eba389112b9679b851056b8dedb99cc74",
+        "rev": "dc52f0352dfd44c11ffd8227803f175d53adc1e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                       |
| --------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`740f7f93`](https://github.com/nix-community/lanzaboote/commit/740f7f93142df2cb97d7e448b677f672bc346a6b) | `` flake: checkInputs -> nativeCheckInputs `` |
| [`8e4de789`](https://github.com/nix-community/lanzaboote/commit/8e4de7892abf47a0292012ca8b900c5bb9734b1a) | `` flake: add proper description ``           |