### PR TITLE
chore(flake/nixpkgs): `d30264c2` -> `f91ee306`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684844536,
-        "narHash": "sha256-M7HhXYVqAuNb25r/d3FOO0z4GxPqDIZp5UjHFbBgw0Q=",
+        "lastModified": 1684935479,
+        "narHash": "sha256-6QMMsXMr2nhmOPHdti2j3KRHt+bai2zw+LJfdCl97Mk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d30264c2691128adc261d7c9388033645f0e742b",
+        "rev": "f91ee3065de91a3531329a674a45ddcb3467a650",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`8d3ecfc3`](https://github.com/NixOS/nixpkgs/commit/8d3ecfc309178032e739961cfd6fd0451540b353) | `` gotrue-supabase: fix version ``                                                 |
| [`663049c3`](https://github.com/NixOS/nixpkgs/commit/663049c30229b24cbba610ef51c74cb46d17658a) | `` srsran: fix version ``                                                          |
| [`695797d5`](https://github.com/NixOS/nixpkgs/commit/695797d5bb3bcad6c2b3e31aa449cfd0f3f8eab8) | `` clash-geoip: set platforms ``                                                   |
| [`7081f6d8`](https://github.com/NixOS/nixpkgs/commit/7081f6d8dfa3d386337d066e44396f64a97fcb6e) | `` lefthook: 1.3.13 -> 1.4.0 ``                                                    |
| [`729a169d`](https://github.com/NixOS/nixpkgs/commit/729a169debd08243b5c79cbbd3b6d95c5ee341aa) | `` microsoft-edge: 113.0.1774.42 -> 113.0.1774.50 ``                               |
| [`86ddf0a8`](https://github.com/NixOS/nixpkgs/commit/86ddf0a83710287a74e07e3867070f6b4bf4c644) | `` kube-linter: 0.6.3 -> 0.6.4 ``                                                  |
| [`94495fa6`](https://github.com/NixOS/nixpkgs/commit/94495fa63c5723697702152350b181d68a1435f9) | `` python310Packages.homeassistant-stubs: 2023.5.3 -> 2023.5.4 ``                  |
| [`12aae0c6`](https://github.com/NixOS/nixpkgs/commit/12aae0c63fa2f02e6831a1316f95e127133f9d9a) | `` python310Packages.sanic-testing: fix tests ``                                   |
| [`87a5cfa1`](https://github.com/NixOS/nixpkgs/commit/87a5cfa1cad1b0b3e9bdc960a0defed16028551e) | `` python311Packages.google-cloud-pubsub: 2.17.0 -> 2.17.1 ``                      |
| [`82d6ac09`](https://github.com/NixOS/nixpkgs/commit/82d6ac09a7126f52bacec2cee8bf091b26e39213) | `` python311Packages.google-cloud-spanner: 3.34.0 -> 3.35.0 ``                     |
| [`8e655eca`](https://github.com/NixOS/nixpkgs/commit/8e655eca6257a41d85d127a0eabae80fa5de7c05) | `` opengrok: set platforms ``                                                      |
| [`e27b18a9`](https://github.com/NixOS/nixpkgs/commit/e27b18a9b72e0aa0f102fa53dfbcfa31e079096c) | `` gtklock-userinfo-module: fix homepage ``                                        |
| [`217bf86d`](https://github.com/NixOS/nixpkgs/commit/217bf86dc01f4b6e407bf7b92a90d3a26455faad) | `` coqPackages.aac-tactics: init at 8.17.0 ``                                      |
| [`a7cd664d`](https://github.com/NixOS/nixpkgs/commit/a7cd664d2b5002c974abb62b75785bc984a40966) | `` less: 608 -> 633 ``                                                             |
| [`500c214b`](https://github.com/NixOS/nixpkgs/commit/500c214b938a08a46d33fe9bb57e394e2eed31e1) | `` anki-bin: 2.1.63 -> 2.1.64 ``                                                   |
| [`b3c7ae8a`](https://github.com/NixOS/nixpkgs/commit/b3c7ae8a3d3eee428c1eacfa806cb9d422f11ec9) | `` python311Packages.pysnooz: 0.8.3 -> 0.8.4 ``                                    |
| [`c93171d2`](https://github.com/NixOS/nixpkgs/commit/c93171d2f4e024313c907f1cd8ccb29b448e2211) | `` python3*.pkgs.dlib: remove patches that are included in the latest release ``   |
| [`7a95c56c`](https://github.com/NixOS/nixpkgs/commit/7a95c56cf230b82a8934e81559c7e06924e8c1fd) | `` zk: 0.13.0 -> 0.14.0 ``                                                         |
| [`f028b111`](https://github.com/NixOS/nixpkgs/commit/f028b111327978168e3e3d51051cdd0ca3fa6e0d) | `` python311Packages.gitignore-parser: 0.1.2 -> 0.1.3 ``                           |
| [`d0944941`](https://github.com/NixOS/nixpkgs/commit/d094494158957b0e6ab46b143855b294de941c44) | `` jsonnet-language-server: 0.12.0 -> 0.12.1 ``                                    |
| [`4ec2b91a`](https://github.com/NixOS/nixpkgs/commit/4ec2b91ac0d5a273b0ecd57403a4223d96e5d857) | ``  python310Packages.pytapo: disable uinsupported Python releases ``              |
| [`56219af8`](https://github.com/NixOS/nixpkgs/commit/56219af82241a2d15306d0423ebf4b98b1bae360) | `` python310Packages.pypinyin: update meta ``                                      |
| [`640adffa`](https://github.com/NixOS/nixpkgs/commit/640adffa8d78094dd79639c4ab01ddc7fe19dc22) | `` python311Packages.sonos-websocket: 0.1.1 -> 0.1.2 ``                            |
| [`18299c28`](https://github.com/NixOS/nixpkgs/commit/18299c280592485e9b58260a5dccc6ed45d76c57) | `` opengrok: 1.12.6 -> 1.12.7 ``                                                   |
| [`00f098b1`](https://github.com/NixOS/nixpkgs/commit/00f098b14b0676d6972d58c566167247bf40f92f) | `` libtorrent-rasterbar-2_0_x: 2.0.8 -> 2.0.9 ``                                   |
| [`2a2d7043`](https://github.com/NixOS/nixpkgs/commit/2a2d7043e4c6c5e71e47782d1e85b7f27d49ebc4) | `` vassal: 3.6.17 -> 3.6.19 ``                                                     |
| [`65a80df2`](https://github.com/NixOS/nixpkgs/commit/65a80df22c46a3e6021d0f592ff71f493003bd9c) | `` sshportal: 1.19.3 -> 1.19.5 ``                                                  |
| [`4d21a7cd`](https://github.com/NixOS/nixpkgs/commit/4d21a7cdd82beeff54815fb4c691178120717f49) | `` flacon: 10.0.0 -> 11.0.0 ``                                                     |
| [`3d98b7bf`](https://github.com/NixOS/nixpkgs/commit/3d98b7bf0e0347bdd26c7eea316330f5bd177f77) | `` suricata: 6.0.11 -> 6.0.12 ``                                                   |
| [`852cdf16`](https://github.com/NixOS/nixpkgs/commit/852cdf166a3967c4926589a992d18c7b99583f60) | `` amberol: 0.10.2 -> 0.10.3 ``                                                    |
| [`43a7b9d6`](https://github.com/NixOS/nixpkgs/commit/43a7b9d6ad079e9de0750213263eebb69975e74c) | `` buttercup-desktop: 2.19.1 -> 2.20.2 ``                                          |
| [`dd08d9b7`](https://github.com/NixOS/nixpkgs/commit/dd08d9b721ea03bd6ea325dbb3339032614c7c85) | `` python310Packages.pypinyin: 0.48.0 -> 0.49.0 ``                                 |
| [`c26ad319`](https://github.com/NixOS/nixpkgs/commit/c26ad319b39232a0cd4a2680a7d7e62e43af1a80) | `` ocamlPackages.lsp: add missing input ``                                         |
| [`6c31436b`](https://github.com/NixOS/nixpkgs/commit/6c31436baae0df3ca41077a4a6cc2052173608e1) | `` ocamlPackages.dot-merlin-reader: add missing input ``                           |
| [`9d9fe997`](https://github.com/NixOS/nixpkgs/commit/9d9fe9971d4a71712c1a154b1dc14ff315fb9bf2) | `` ocamlPackages.polynomial: disable for OCaml < 4.08 ``                           |
| [`44f1205e`](https://github.com/NixOS/nixpkgs/commit/44f1205e994f6e35c11048cef07e16ba7b829620) | `` python310Packages.pytapo: 3.1.7 -> 3.1.13 ``                                    |
| [`f3cb641a`](https://github.com/NixOS/nixpkgs/commit/f3cb641a8c8561b17dc40d43a5d233e02c28af4b) | `` python311Packages.atom: 0.9.0 -> 0.10.0 ``                                      |
| [`cf4d9fc6`](https://github.com/NixOS/nixpkgs/commit/cf4d9fc60da8e02c7ecb6aa0d8cb213a983a1288) | `` python311Packages.ansible-compat: 4.0.4 -> 4.0.5 ``                             |
| [`7a697fef`](https://github.com/NixOS/nixpkgs/commit/7a697fefe2f3ef5185e84f15a03229991f6e5c3f) | `` nixosTests.etcd-cluster: update name ``                                         |
| [`3865e5f4`](https://github.com/NixOS/nixpkgs/commit/3865e5f46e79d53bab721ce5739f4d2f76b010fb) | `` nixosTests.etcd-cluster: fix test ``                                            |
| [`153da9ab`](https://github.com/NixOS/nixpkgs/commit/153da9ab8c9a221b0ead8ee42bad196765c2a20c) | `` jackett: 0.20.4199 -> 0.21.17 ``                                                |
| [`b69c6cf6`](https://github.com/NixOS/nixpkgs/commit/b69c6cf6ea6e4aa78e9b21aa8e52431bddd7aa2f) | `` terraform-providers.spotinst: 1.117.0 -> 1.119.0 ``                             |
| [`2bea22d4`](https://github.com/NixOS/nixpkgs/commit/2bea22d4872b5d5966d08326cd3a7f55b835e4be) | `` terraform-providers.opsgenie: 0.6.20 -> 0.6.22 ``                               |
| [`cc18900b`](https://github.com/NixOS/nixpkgs/commit/cc18900b6f07d70a2f66ba0d0d94ce43df589824) | `` terraform-providers.gitlab: 16.0.0 -> 16.0.2 ``                                 |
| [`a0f7acf6`](https://github.com/NixOS/nixpkgs/commit/a0f7acf6c68e3dc6536b2c4bc52f1d1e3c9a68cc) | `` terraform-providers.aiven: 4.3.0 -> 4.4.0 ``                                    |
| [`0f2d93f3`](https://github.com/NixOS/nixpkgs/commit/0f2d93f36696216ebb582cb824399bb6f5a10912) | `` cargo-update: 13.0.2 -> 13.0.4 ``                                               |
| [`6c0ea0ca`](https://github.com/NixOS/nixpkgs/commit/6c0ea0cabade7d13d19c55a44957b690136a4e33) | `` nixpkgs-review: 2.9.1 -> 2.9.2 ``                                               |
| [`dfc509bc`](https://github.com/NixOS/nixpkgs/commit/dfc509bc1b89020a52a61f322c5ee7909e927536) | `` kubernetes: 1.27.1 -> 1.27.2 ``                                                 |
| [`9b143d02`](https://github.com/NixOS/nixpkgs/commit/9b143d027d7344f4b69e65a7233466f36f1677b0) | `` python310Packages.types-protobuf: 4.22.0.2 -> 4.23.0.1 ``                       |
| [`eeda9950`](https://github.com/NixOS/nixpkgs/commit/eeda99508b2a1b484ef13e3d0795ef9b9985d3b4) | `` python311Packages.dpath: 2.1.5 -> 2.1.6 ``                                      |
| [`f623e281`](https://github.com/NixOS/nixpkgs/commit/f623e28102bdd293fe97101b207962895e7e45bc) | `` wasmedge: 0.12.0 -> 0.12.1 ``                                                   |
| [`5f2d849c`](https://github.com/NixOS/nixpkgs/commit/5f2d849cefc26cb58744a8af5e959732c9941e31) | `` minder: 1.15.1 -> 1.15.2 ``                                                     |
| [`e69867cf`](https://github.com/NixOS/nixpkgs/commit/e69867cf92f73acb66f46be6a484e2f65de2bb01) | `` wireproxy: 1.0.5 -> 1.0.6 ``                                                    |
| [`ad617cad`](https://github.com/NixOS/nixpkgs/commit/ad617cad83cbed749f994b109fa46e59cfa5cbb5) | `` qt6.qt5compat: clear up build inputs ``                                         |
| [`28cfb798`](https://github.com/NixOS/nixpkgs/commit/28cfb79883f206feebfdba4ec8a92b952ce3f74f) | `` exploitdb: 2023-05-19 -> 2023-05-24 ``                                          |
| [`d54a186b`](https://github.com/NixOS/nixpkgs/commit/d54a186be7a34a153bbb06619225856babf84ece) | `` double-conversion: 3.2.1 -> 3.3.0 ``                                            |
| [`655fd26b`](https://github.com/NixOS/nixpkgs/commit/655fd26b4bd9cb110e11d032d9a0a3948eac7d6c) | `` openai: 0.27.6v2 -> 0.27.7 ``                                                   |
| [`ab387160`](https://github.com/NixOS/nixpkgs/commit/ab387160368ed04ad6497653039d74ee87164007) | `` kustomize-sops: 4.1.3 -> 4.2.0 ``                                               |
| [`84269637`](https://github.com/NixOS/nixpkgs/commit/8426963753f3b4beb692b3c33a140af69a874df0) | `` kodelife: 1.0.8.170 -> 1.1.0.173 ``                                             |
| [`b59730db`](https://github.com/NixOS/nixpkgs/commit/b59730dbc699535fe2c1eac4809b11bf4fd5e75c) | `` touchosc: 1.1.9.163 -> 1.2.0.166 ``                                             |
| [`63835289`](https://github.com/NixOS/nixpkgs/commit/638352894503225177e2d1909a8a0385bbaecd7b) | `` ucx: 1.14.0 -> 1.14.1 ``                                                        |
| [`76f8700f`](https://github.com/NixOS/nixpkgs/commit/76f8700f2a029b0b44f0d4c2ec60292f8f113bcd) | `` pscale: 0.143.0 -> 0.144.0 ``                                                   |
| [`9de1dc4a`](https://github.com/NixOS/nixpkgs/commit/9de1dc4a7b46522d579bd4f709b1e07bf6580314) | `` glooctl: 1.14.4 -> 1.14.5 ``                                                    |
| [`5146b261`](https://github.com/NixOS/nixpkgs/commit/5146b26105b8f07c32e1b26882b09cc0f5687f5c) | `` alpine-make-vm-image: add rsync to path ``                                      |
| [`07a435b7`](https://github.com/NixOS/nixpkgs/commit/07a435b75be67e030b3612568decdc33b151c1e9) | `` 86Box: include desktop entry ``                                                 |
| [`786996d8`](https://github.com/NixOS/nixpkgs/commit/786996d8f2322ef5b1916083f1d924120220e110) | `` broot: 1.22.0 -> 1.22.1 ``                                                      |
| [`25fa902f`](https://github.com/NixOS/nixpkgs/commit/25fa902f9ea51eaf56067ad8e816a826da17f891) | `` home-assistant: 2023.5.3 -> 2023.5.4 ``                                         |
| [`7f188bac`](https://github.com/NixOS/nixpkgs/commit/7f188bac2675d729325681909bc77523e5cf671f) | `` python310Packages.zwave-js-server-python: 0.48.0 -> 0.48.1 ``                   |
| [`bd163c93`](https://github.com/NixOS/nixpkgs/commit/bd163c9308b2ece009f3f250addadaef81f7f1ba) | `` python310Packages.yalexs: 1.3.3 -> 1.5.1 ``                                     |
| [`f948ec3c`](https://github.com/NixOS/nixpkgs/commit/f948ec3cde9b7ee08a35461f8c2c6374fcd1c838) | `` python310Packages.python-matter-server: 3.3.1 -> 3.4.1 ``                       |
| [`95cad7b0`](https://github.com/NixOS/nixpkgs/commit/95cad7b006baf94774b03f98afe056c9291dcc3f) | `` python310Packages.home-assistant-chip-clusters: 2023.4.1 -> 2023.5.1 ``         |
| [`fc87002a`](https://github.com/NixOS/nixpkgs/commit/fc87002a50007414a2ec031d81475e15e12f7b94) | `` python310Packages.home-assistant-chip-core: 2023.4.1 -> 2023.5.2 ``             |
| [`399b65d5`](https://github.com/NixOS/nixpkgs/commit/399b65d5a94c51c53802c1a0297f055c0cec2155) | `` python310Packages.async-upnp-client: 0.33.1 -> 0.33.2 ``                        |
| [`9918bf29`](https://github.com/NixOS/nixpkgs/commit/9918bf29321e6c23fb2a905040db9c9a02dfa715) | `` python311Packages.aionotion: 2023.05.4 -> 2023.05.5 ``                          |
| [`9e516dfc`](https://github.com/NixOS/nixpkgs/commit/9e516dfc90f4d887cff8b80b5976016752d1a6a7) | `` logseq: 0.9.6 -> 0.9.8 ``                                                       |
| [`37f8b583`](https://github.com/NixOS/nixpkgs/commit/37f8b58349ff0bd0104373a0be5d26e3630def0d) | `` hugo: 0.122.0 -> 0.122.1 ``                                                     |
| [`3f736fae`](https://github.com/NixOS/nixpkgs/commit/3f736faef072091710a1a6fb4f64f9c239551107) | `` python312: 3.12.0a7 -> 3.12.0b1 ``                                              |
| [`a13dfb7e`](https://github.com/NixOS/nixpkgs/commit/a13dfb7e5ff19dac69f689293a7c2ef96f47d1bf) | `` vyper: 0.3.6 -> 0.3.8 ``                                                        |
| [`9a95780e`](https://github.com/NixOS/nixpkgs/commit/9a95780ef94fa249012897ddb6cde1df9d35dc19) | `` minio-client: 2023-05-04T18-10-16Z -> 2023-05-18T16-59-00Z ``                   |
| [`3c7eb7a1`](https://github.com/NixOS/nixpkgs/commit/3c7eb7a1bc559409e59bb74263b1519c137dccd7) | `` etcd_3_5: 3.5.7 -> 3.5.9 ``                                                     |
| [`d1fe3c01`](https://github.com/NixOS/nixpkgs/commit/d1fe3c0133262d99ac2b98d6706692ad733dca32) | `` redpanda: 23.1.7 -> 23.1.10 ``                                                  |
| [`875dff11`](https://github.com/NixOS/nixpkgs/commit/875dff11a481f6c682fb8a7d7625ba48497541b8) | `` firefox-bin-unwrapped: 113.0.1 -> 113.0.2 ``                                    |
| [`ae0526b2`](https://github.com/NixOS/nixpkgs/commit/ae0526b224fdf7dbc5c129e913fefbee4bb2a295) | `` firefox-unwrapped: 113.0.1 -> 113.0.2 ``                                        |
| [`0a18d122`](https://github.com/NixOS/nixpkgs/commit/0a18d122220577128743f55f1f88587719fc014e) | `` python310Packages.pulsectl: 23.5.1 -> 23.5.2 ``                                 |
| [`35273f66`](https://github.com/NixOS/nixpkgs/commit/35273f66f709857f0c8f23fac904f8a14de3cb0f) | `` minio: 2023-05-04T21-44-30Z -> 2023-05-18T00-05-36Z ``                          |
| [`5595e88d`](https://github.com/NixOS/nixpkgs/commit/5595e88de982474ba6cc9c4d7f4a7a246edb4980) | `` harec: unstable-2023-02-18 -> unstable-2023-04-25 ``                            |
| [`78833707`](https://github.com/NixOS/nixpkgs/commit/78833707a68d7b3f0eeffc91f04d19a49414e961) | `` xplr: 0.21.1 -> 0.21.2 ``                                                       |
| [`cdea9097`](https://github.com/NixOS/nixpkgs/commit/cdea9097fd6afb43751e42f1cd1b50e2bffb4d58) | `` hare: unstable-2023-03-15 -> unstable-2023-04-23 ``                             |
| [`516ac3f4`](https://github.com/NixOS/nixpkgs/commit/516ac3f4026bdc936953f9f7be5990ebe2d2e22a) | `` lagrange: 1.15.9 -> 1.16.1 ``                                                   |
| [`50c7fbc9`](https://github.com/NixOS/nixpkgs/commit/50c7fbc96c5a4612e829235c419dc663027ba5d3) | `` gleam: 0.28.3 -> 0.29.0 ``                                                      |
| [`5bb66abf`](https://github.com/NixOS/nixpkgs/commit/5bb66abf2babc92151390be8a309640c33173a05) | `` fira: Fix permissions of installed files ``                                     |
| [`aad3d940`](https://github.com/NixOS/nixpkgs/commit/aad3d94069db1225428e24bdd3fcbbe13da5e87e) | `` tuba: add aleksana as maintainer ``                                             |
| [`be326077`](https://github.com/NixOS/nixpkgs/commit/be326077e41ec3e62318af6da20ef41b8fe8c82f) | `` tuba: 0.3.0 -> 0.3.2 ``                                                         |
| [`93bc9a2c`](https://github.com/NixOS/nixpkgs/commit/93bc9a2ce08cb73cf5ad69e7d810903120dffb06) | `` python3Packages.wxPython_4_{0,1}: cleanup ``                                    |
| [`49fb0298`](https://github.com/NixOS/nixpkgs/commit/49fb0298225a4215c4d56e8c4222beb58052906b) | `` libguestfs-appliance: 1.40.1 -> 1.46.0 ``                                       |
| [`1789d590`](https://github.com/NixOS/nixpkgs/commit/1789d590623ab5e6c35b4ba40f9c9d7fb4af6659) | `` gnomeExtensions.easyeffects-preset-selector: patch EasyEffects schema source `` |
| [`02c8450a`](https://github.com/NixOS/nixpkgs/commit/02c8450a59f007a4ff41c9c79c00fcdde2c1e172) | `` csslint: 0.10.0 → 1.0.5, fix broken executable ``                               |
| [`27d53b81`](https://github.com/NixOS/nixpkgs/commit/27d53b81ccf85de20656408fbda5181ce0795867) | `` nginxQuic: share src and version with nginxMainline ``                          |
| [`91ecb7d7`](https://github.com/NixOS/nixpkgs/commit/91ecb7d7ff07358874873e0cd7f8ef1f77157e61) | `` nginxMainline: 1.24.0 -> 1.25.0 ``                                              |
| [`ae282d67`](https://github.com/NixOS/nixpkgs/commit/ae282d672e7c4f9bea3fac8caf6b58bf795a6946) | `` cargo-expand: 1.0.49 -> 1.0.51 ``                                               |
| [`a1e84c45`](https://github.com/NixOS/nixpkgs/commit/a1e84c454d5920f2bb35541e7556f9c73e00dfb5) | `` matrix-synapse: 1.83.0 -> 1.84.0 ``                                             |
| [`f5363e76`](https://github.com/NixOS/nixpkgs/commit/f5363e768c0243404f59ce3436b2b438ff1a81af) | `` oh-my-zsh: 2023-04-21 -> 2023-05-23 ``                                          |
| [`f10d1afb`](https://github.com/NixOS/nixpkgs/commit/f10d1afbabb7a98250a87e630f0000254fba1711) | `` funzzy: 0.6.0 -> 0.6.1 ``                                                       |
| [`3208faf6`](https://github.com/NixOS/nixpkgs/commit/3208faf65908db782e998e11a12924567426b5ef) | `` python311Packages.policyuniverse: 1.5.0.20220613 -> 1.5.0.20230523 ``           |
| [`eaade3c4`](https://github.com/NixOS/nixpkgs/commit/eaade3c4582565285eae8f3def1add69307d2d69) | `` blahaj: 2.0.1 -> 2.0.2 ``                                                       |
| [`c5ac5b5a`](https://github.com/NixOS/nixpkgs/commit/c5ac5b5ab749f31ae636bf213e5cae3e808f188d) | `` python3Packages.rasterio: 1.3.6 -> 1.3.7 ``                                     |
| [`0d451198`](https://github.com/NixOS/nixpkgs/commit/0d451198b4004f21c6b18e7328ceb89d8e0e8005) | `` cargo-shuttle: 0.16.0 -> 0.17.0 ``                                              |
| [`234dc595`](https://github.com/NixOS/nixpkgs/commit/234dc5956c42e9afd5a79638f9b61071f5924391) | `` sccache: 0.4.2 -> 0.5.0 ``                                                      |
| [`f92e700f`](https://github.com/NixOS/nixpkgs/commit/f92e700f6c5e55555d9a18ed796a20e6f7686172) | `` outline: use nodejs 18 ``                                                       |
| [`032b768c`](https://github.com/NixOS/nixpkgs/commit/032b768c9e3ce33f51d9a627f2acd53a26c5bcea) | `` python311Packages.zwave-me-ws: 0.4.2 -> 0.4.3 ``                                |
| [`e184d27c`](https://github.com/NixOS/nixpkgs/commit/e184d27c2223909d568bf3bd98848796e1c14920) | `` python311Packages.msgspec: 0.15.0 -> 0.15.1 ``                                  |
| [`00000767`](https://github.com/NixOS/nixpkgs/commit/0000076781762ded383aa820c15e820467f199a5) | `` mopidy: use headless GApps wrapper, cleanup meta.description ``                 |
| [`8fbf4aa9`](https://github.com/NixOS/nixpkgs/commit/8fbf4aa9bec5fd2c5545ba1b0e7b1769bd1ed4a9) | `` patray: fix segfault ``                                                         |
| [`3aed3e03`](https://github.com/NixOS/nixpkgs/commit/3aed3e03cabe80ce37d24c707395d1a2f3fe10bc) | `` python311Packages.requests-pkcs12: 1.15 -> 1.16 ``                              |
| [`bac076eb`](https://github.com/NixOS/nixpkgs/commit/bac076eb94a58bed33161e7bc9c8282a8942f04b) | `` unciv: 4.6.8 -> 4.6.13 ``                                                       |
| [`a5f795f7`](https://github.com/NixOS/nixpkgs/commit/a5f795f79e47adc4ed7148624ffff227f04be7eb) | `` python310Packages.dm-sonnet: fix build ``                                       |
| [`789c38f8`](https://github.com/NixOS/nixpkgs/commit/789c38f8651536ba67798c9194efab83f8dfcf6f) | `` outline: add xanderio to maintainers ``                                         |
| [`5ade0816`](https://github.com/NixOS/nixpkgs/commit/5ade08168ac56d453865fd6ebe4c960aa4e59868) | `` outline: add nixos test ``                                                      |
| [`b82d8c98`](https://github.com/NixOS/nixpkgs/commit/b82d8c980850720b516d4a836034d0253d0954ad) | `` inadyn: 2.10.0 -> 2.11.0 ``                                                     |
| [`74bc4261`](https://github.com/NixOS/nixpkgs/commit/74bc42615c1ebb79fea3b4ea614f2fbc4754f62d) | `` outline: 0.68.1 -> 0.69.2 ``                                                    |