### PR TITLE
chore(flake/lanzaboote): `f641dcfc` -> `e9003f12`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1685182442,
-        "narHash": "sha256-gPcAwOAoxYpP5An0V3HTI2JnAb2wb1u90IT2FbAG6SQ=",
+        "lastModified": 1685227956,
+        "narHash": "sha256-OmCOMt1lHySoT3+WtW2ftIejhnHe5AkJ9IPf5kOAD6s=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "f641dcfc8b34729d241c95cc7e1c03b21b5b241b",
+        "rev": "e9003f12e63588736dde12acf95a4d0361b215e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                              |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`72b66bfc`](https://github.com/nix-community/lanzaboote/commit/72b66bfc69942e5b031527eb20a43b1cd403c64b) | `` docs: fixup stray ``` ``          |
| [`de80330e`](https://github.com/nix-community/lanzaboote/commit/de80330ec4408e38732a321b0ded8695af5838b8) | `` docs: update upstreaming state `` |