### PR TITLE
chore(flake/nixpkgs): `f91ee306` -> `e1080230`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684935479,
-        "narHash": "sha256-6QMMsXMr2nhmOPHdti2j3KRHt+bai2zw+LJfdCl97Mk=",
+        "lastModified": 1685168767,
+        "narHash": "sha256-wQgnxz0PdqbyKKpsWl/RU8T8QhJQcHfeC6lh1xRUTfk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f91ee3065de91a3531329a674a45ddcb3467a650",
+        "rev": "e10802309bf9ae351eb27002c85cfdeb1be3b262",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                  |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`decb072d`](https://github.com/NixOS/nixpkgs/commit/decb072d37813bb3e37246530a0aa7656829c70f) | `` killport: 0.8.0 -> 0.9.0 ``                                           |
| [`bee7cb59`](https://github.com/NixOS/nixpkgs/commit/bee7cb59046bbb5ff9d4ad21ffbd97c56fd56862) | `` powerstat: 0.03.01 -> 0.03.03 ``                                      |
| [`8d908a2e`](https://github.com/NixOS/nixpkgs/commit/8d908a2ed404652abaaa48ac2a438955a1f57af9) | `` terraform-providers.tencentcloud: 1.81.1 -> 1.81.2 ``                 |
| [`160cc272`](https://github.com/NixOS/nixpkgs/commit/160cc272655b8fa5def2d582d80558068b45a389) | `` terraform-providers.aws: 5.0.0 -> 5.0.1 ``                            |
| [`ba932314`](https://github.com/NixOS/nixpkgs/commit/ba93231494e109399c29761a101ce5cb343e9a72) | `` terraform-providers.spotinst: 1.119.1 -> 1.120.0 ``                   |
| [`7fa6787c`](https://github.com/NixOS/nixpkgs/commit/7fa6787c6671bc06e7fe5116e88907050dc7b0b1) | `` terraform-providers.opsgenie: 0.6.22 -> 0.6.23 ``                     |
| [`317bcc15`](https://github.com/NixOS/nixpkgs/commit/317bcc15c0bcd451f4fbd99be9bb009699d55e57) | `` terraform-providers.nutanix: 1.8.1 -> 1.9.0 ``                        |
| [`50e18c95`](https://github.com/NixOS/nixpkgs/commit/50e18c957025014fa5cc037a0050c1c6a9b13f23) | `` terraform-providers.linode: 2.2.0 -> 2.3.0 ``                         |
| [`45e210ec`](https://github.com/NixOS/nixpkgs/commit/45e210ece2a2a114ced5abcacfc17d682b029af6) | `` terraform-providers.azurerm: 3.57.0 -> 3.58.0 ``                      |
| [`568f92cb`](https://github.com/NixOS/nixpkgs/commit/568f92cbff307adeefb31cead4c8a5cadfdf797a) | `` python310Packages.subarulink: 0.7.6 -> 0.7.6-1 ``                     |
| [`8c3d981f`](https://github.com/NixOS/nixpkgs/commit/8c3d981fe8c727cc6f9716cffbd363db3476fd7e) | `` automatic-timezoned: 1.0.91 -> 1.0.92 ``                              |
| [`517da6a9`](https://github.com/NixOS/nixpkgs/commit/517da6a94abf564ee0251cb5e0516dae55f6fc34) | `` cargo-binstall: 0.23.0 -> 0.23.1 ``                                   |
| [`dfa7b1e0`](https://github.com/NixOS/nixpkgs/commit/dfa7b1e0542b47916e23bc75ed7002aecd2ecdaa) | `` terraform-providers: drop outdated aliases and throws ``              |
| [`d6a1aea1`](https://github.com/NixOS/nixpkgs/commit/d6a1aea19bddac079efbfde6c373dff8709739cd) | `` vector: enable sources-dnstap feature ``                              |
| [`fe53f209`](https://github.com/NixOS/nixpkgs/commit/fe53f2096b74e8f5c853a23436b041a0dcdf4c2b) | `` surrealdb-migrations: cleanup ``                                      |
| [`442a6dbd`](https://github.com/NixOS/nixpkgs/commit/442a6dbd36aa50e043353fe9ff3f530a74a7b38a) | `` surrealdb: fix build on aarch64-linux ``                              |
| [`5685291a`](https://github.com/NixOS/nixpkgs/commit/5685291a7b5a9968f7e79e25cccce89e8670bb99) | `` sentry-cli: 2.18.0 -> 2.18.1 ``                                       |
| [`cbb545fb`](https://github.com/NixOS/nixpkgs/commit/cbb545fbba21d23e53872d9c6e1465d6d6157094) | `` sonic-server: migrate to bindgenHook ``                               |
| [`2c62cc62`](https://github.com/NixOS/nixpkgs/commit/2c62cc62cc1f681704d46a67ea2768b7e9c83fb2) | `` easyrsa: 3.1.2 -> 3.1.4 ``                                            |
| [`6b024e4e`](https://github.com/NixOS/nixpkgs/commit/6b024e4eff1315e63310e00bc825e16e60720a95) | `` parinfer-rust: migrate to bindgenHook ``                              |
| [`81c82de9`](https://github.com/NixOS/nixpkgs/commit/81c82de9fa0a37e966e6a41c567288ca027c0af3) | `` coreth: 0.12.1 -> 0.12.2 ``                                           |
| [`db7ee2e5`](https://github.com/NixOS/nixpkgs/commit/db7ee2e5deb3af6657ad9d79301af89aad67fc81) | `` rdedup: migrate to bindgenHook ``                                     |
| [`223edbb4`](https://github.com/NixOS/nixpkgs/commit/223edbb43496cd36c7d6694dc772dc1709bcd52e) | `` orbiton: 2.61.0 -> 2.62.0 ``                                          |
| [`0ba51a51`](https://github.com/NixOS/nixpkgs/commit/0ba51a51f800f620a581affc9caae85cb30b68bf) | `` buildGoModule: alias vendorSha256 to vendorHash ``                    |
| [`ed89912d`](https://github.com/NixOS/nixpkgs/commit/ed89912d7c622c975c902987437a2ac3a86d5c48) | `` supertag: migrate to bindgenHook ``                                   |
| [`5f05b9d8`](https://github.com/NixOS/nixpkgs/commit/5f05b9d85396d6527636699befd19e25c402777a) | `` eksctl: 0.141.0 -> 0.142.0 ``                                         |
| [`b954ef28`](https://github.com/NixOS/nixpkgs/commit/b954ef286d275c6720874f62380e0922a8fc5bd1) | `` opensmt: 2.5.0 -> 2.5.1 ``                                            |
| [`e3db5e86`](https://github.com/NixOS/nixpkgs/commit/e3db5e86e056297aef94b0224fe2bf5f537e8a97) | `` xq: 0.2.42 -> 0.2.44 ``                                               |
| [`02795f6c`](https://github.com/NixOS/nixpkgs/commit/02795f6c6490af405a805686690d070ffbf5f6c7) | `` silicon: migrate to bindgenHook ``                                    |
| [`e886c75f`](https://github.com/NixOS/nixpkgs/commit/e886c75fb0b9756b83b05518442413828a1ba000) | `` clj-kondo: 2023.04.14 -> 2023.05.18 ``                                |
| [`2cad500d`](https://github.com/NixOS/nixpkgs/commit/2cad500d792c93f878be5c818e7b324d8dc2ae19) | `` amazon-qldb-shell: migrate to bindgenHook ``                          |
| [`ba79d2aa`](https://github.com/NixOS/nixpkgs/commit/ba79d2aa0c10ab526fd5331b8c8ccf7f4e3b8552) | `` fido2luks: migrate to bindgenHook ``                                  |
| [`39d68202`](https://github.com/NixOS/nixpkgs/commit/39d6820231611eca09d2b2dacda02af54bb46e7c) | `` python310Packages.mastodon-py: 1.8.0 -> 1.8.1 ``                      |
| [`785d16a7`](https://github.com/NixOS/nixpkgs/commit/785d16a7ebd770231f05e30b9887d383b69af769) | `` zenith: migrate to bindgenHook ``                                     |
| [`3a3242d0`](https://github.com/NixOS/nixpkgs/commit/3a3242d0464646ccab18afae2c2cfacdf6738d1e) | `` pods: 1.2.0 -> 1.2.1 ``                                               |
| [`ad4d864a`](https://github.com/NixOS/nixpkgs/commit/ad4d864a9316578687254895940d42416578fdb4) | `` apt: 2.6.0 -> 2.7.1 ``                                                |
| [`51120fc6`](https://github.com/NixOS/nixpkgs/commit/51120fc6e776a7253961ba49fab0a69be208905f) | `` helmfile: 0.153.1 -> 0.154.0 ``                                       |
| [`eb532cff`](https://github.com/NixOS/nixpkgs/commit/eb532cffacd58cdc74ff53776fe9612e06154770) | `` coreboot-utils: 4.19 -> 4.20 (#234054) ``                             |
| [`8109a456`](https://github.com/NixOS/nixpkgs/commit/8109a45641d7f432291dda1af105e22bd26a21b2) | `` wasm-tools: 1.0.30 -> 1.0.35 ``                                       |
| [`86cd1b3f`](https://github.com/NixOS/nixpkgs/commit/86cd1b3f6f2dd147235510b1e53579698e3198a1) | `` innernet: migrate to bindgenHook ``                                   |
| [`2b579eb6`](https://github.com/NixOS/nixpkgs/commit/2b579eb628b27d6ac4832cf550c01b47c199b6da) | `` zim-tools: 3.1.3 -> 3.2.0 ``                                          |
| [`92656bb9`](https://github.com/NixOS/nixpkgs/commit/92656bb952909a43bf3e3292b2c5c0f5d8da5e68) | `` nordzy-icon-theme: 1.8.4 -> 1.8.5 ``                                  |
| [`5a01f798`](https://github.com/NixOS/nixpkgs/commit/5a01f798cd01651c4352f82dbf99b76a18152414) | `` kime: migrate to bindgenHook ``                                       |
| [`5c042401`](https://github.com/NixOS/nixpkgs/commit/5c042401b47fc25f6d52d0525ac69b55a9c9ea87) | `` flatcam: fix build ``                                                 |
| [`b5de94e8`](https://github.com/NixOS/nixpkgs/commit/b5de94e8a7b98669fa56d79275e289de83b7a11e) | `` cups-filters: 1.28.15 -> 1.28.17 ``                                   |
| [`5fd7da06`](https://github.com/NixOS/nixpkgs/commit/5fd7da06bdee993dd78020eb85457dcb361daae0) | `` epiphany: 44.2 → 44.3 (#234118) ``                                    |
| [`854214ec`](https://github.com/NixOS/nixpkgs/commit/854214ec56853be850830a1ee6c59bb5899728a7) | `` python311Packages.faraday-plugins: 1.11.0 -> 1.12.0 ``                |
| [`c352a8b2`](https://github.com/NixOS/nixpkgs/commit/c352a8b20ef26a719e1630b6771f94c11ac39c78) | `` figma-agent: remove explicit libclang path ``                         |
| [`cfa11fae`](https://github.com/NixOS/nixpkgs/commit/cfa11faeb77ac011e097a5b3ed52b924c2451ddb) | `` dablin: 1.14.0 -> 1.15.0 ``                                           |
| [`00000271`](https://github.com/NixOS/nixpkgs/commit/00000271a05799f6e5d7187e282d8456fa210e97) | `` dbus-broker: remove prefix from dependency's version attribute ``     |
| [`f3a4973a`](https://github.com/NixOS/nixpkgs/commit/f3a4973aeb8891c786ef31463ab77641b5e8d982) | `` meilisearch: allow builds on aarch64-linux ``                         |
| [`69bb0f94`](https://github.com/NixOS/nixpkgs/commit/69bb0f94dee27c8beddcf786beb89148c51e2e8c) | `` nixos/nginx: first-class PROXY protocol support ``                    |
| [`6a2828e3`](https://github.com/NixOS/nixpkgs/commit/6a2828e3ecfc6ecc39053d7c2ad265b2489b0fac) | `` libhv: 1.3.0 → 1.3.1 ``                                               |
| [`3df253a9`](https://github.com/NixOS/nixpkgs/commit/3df253a9b97afe09c07e1e0a73a182d429417e7d) | `` woob: 3.5 -> 3.6 ``                                                   |
| [`b447d9bb`](https://github.com/NixOS/nixpkgs/commit/b447d9bb53d7e47aae0d370d47d21f99dba6d51d) | `` python311Packages.pysigma-backend-insightidr: 0.1.8 -> 0.1.9 ``       |
| [`8b25d4ef`](https://github.com/NixOS/nixpkgs/commit/8b25d4ef4e135a5618d48f7806f47a777eccce12) | `` checkov: 2.3.257 -> 2.3.259 ``                                        |
| [`651e7767`](https://github.com/NixOS/nixpkgs/commit/651e776772502b2c2c2f4765683d45e46f90006a) | `` qovery-cli: 0.58.12 -> 0.58.15 ``                                     |
| [`48bfaeb8`](https://github.com/NixOS/nixpkgs/commit/48bfaeb87cfc209b0d2f77bcec1e6c7d0a33320e) | `` python311Packages.pydeps: 1.12.7 -> 1.12.8 ``                         |
| [`7aa999a7`](https://github.com/NixOS/nixpkgs/commit/7aa999a7215f1e7624176005f5301d1d5e974d67) | `` python311Packages.python-otbr-api: 1.1.0 -> 1.2.0 ``                  |
| [`bd54c725`](https://github.com/NixOS/nixpkgs/commit/bd54c7251283a3a35d634363adc486e621fff041) | `` python311Packages.reolink-aio: 0.5.15 -> 0.5.16 ``                    |
| [`32bce83e`](https://github.com/NixOS/nixpkgs/commit/32bce83e4014fbdb5c3e89a6ff5c0638f0ead417) | `` python311Packages.onvif-zeep-async: 3.1.7 -> 3.1.8 ``                 |
| [`5242aea6`](https://github.com/NixOS/nixpkgs/commit/5242aea64f6820d615b406c69f5f2c6ba0ca732b) | `` nixos.mautrix-facebook: Fix appservice name ``                        |
| [`2d000936`](https://github.com/NixOS/nixpkgs/commit/2d000936a4976b8675ee5a8beabb2ad51c7be9a7) | `` python311Packages.aliyun-python-sdk-config: 2.2.8 -> 2.2.9 ``         |
| [`09a8c1d7`](https://github.com/NixOS/nixpkgs/commit/09a8c1d7419356138adcbf8e14d5856fbffedacc) | `` sget: remove package ``                                               |
| [`02b23559`](https://github.com/NixOS/nixpkgs/commit/02b2355964f55ad7e095d37ead2b95efdf60cd3a) | `` angle-grinder: 0.19.0 -> 0.19.2 ``                                    |
| [`e655d031`](https://github.com/NixOS/nixpkgs/commit/e655d0318cefedac078bf541a30494a7d828ac3a) | `` rekor-cli, rekor-server: 1.1.1 -> 1.2.1 ``                            |
| [`c4433d4a`](https://github.com/NixOS/nixpkgs/commit/c4433d4ae0cab318d8c02ee7c906863d67eee169) | `` vscode-extensions.ionide.ionide-fsharp: 7.5.2 -> 7.5.4 ``             |
| [`192871cf`](https://github.com/NixOS/nixpkgs/commit/192871cfc55b518c59352de2ec31ac322b621c4e) | `` cirrus-cli: 0.98.0 -> 0.99.0 ``                                       |
| [`c9bcecf0`](https://github.com/NixOS/nixpkgs/commit/c9bcecf0abb486220c3556b4a0f38aefbbb967b4) | `` kernelPatches.make-maple-state-reusable-after-mas_empty_area: drop `` |
| [`517e2be6`](https://github.com/NixOS/nixpkgs/commit/517e2be611c337c0c6aa897b81463712b8cae198) | `` s3fs: 1.91 -> 1.92 ``                                                 |
| [`dd6d9553`](https://github.com/NixOS/nixpkgs/commit/dd6d95536c97aa40d139f69e47a3854ef76c76f5) | `` python3Packages.stopit: added setuptools dependency (#234153) ``      |
| [`101d8b7b`](https://github.com/NixOS/nixpkgs/commit/101d8b7ba8026d77d24c66ef9e8fa4c98e79ee67) | `` linux_6_2: drop ``                                                    |
| [`224a8d3d`](https://github.com/NixOS/nixpkgs/commit/224a8d3d7ee304dd550ea44ad07f7736823bfcc4) | `` scala-cli: 1.0.0-RC2 -> 1.0.0 ``                                      |
| [`de87ba42`](https://github.com/NixOS/nixpkgs/commit/de87ba42c977b6487e48016286fea76afe327627) | `` ueberzugpp: drop mainProgram ``                                       |
| [`7f9057a1`](https://github.com/NixOS/nixpkgs/commit/7f9057a13336b98481df78973c40a51e76949d9e) | `` ueberzugpp: adjust options ``                                         |
| [`b388107d`](https://github.com/NixOS/nixpkgs/commit/b388107dd5344389c7f5e6d38cc5a1aec4c678a1) | `` ueberzugpp: 2.8.4 -> 2.8.5 ``                                         |
| [`32e70652`](https://github.com/NixOS/nixpkgs/commit/32e70652392f3b6532a166f7bc6c5e3a2e3e99fe) | `` ueberzugpp: 2.8.3 -> 2.8.4 ``                                         |
| [`f5df7df0`](https://github.com/NixOS/nixpkgs/commit/f5df7df08cb9b1929c0e565d8af1243b4ca0cef6) | `` pkgsStatic.mkl: change tools dir to lib ``                            |
| [`8a16017d`](https://github.com/NixOS/nixpkgs/commit/8a16017d40e703c2a85d522cab98f425c110031e) | `` maintainers: update yayayayaka ``                                     |
| [`0645048f`](https://github.com/NixOS/nixpkgs/commit/0645048f9e8f2854b81c82563558d4da2355e11c) | `` python3Packages.owslib: 0.28.1 -> 0.29.2 ``                           |
| [`a615eb5a`](https://github.com/NixOS/nixpkgs/commit/a615eb5a75f5892439ee71c9f645022b2acdca7e) | `` taco: init at 02-08-2022_unstable ``                                  |
| [`cf5538a4`](https://github.com/NixOS/nixpkgs/commit/cf5538a4ba9ce1223ce05a0e6944764af7c4aa5c) | `` gpac: 2.2.0 -> 2.2.1 ``                                               |
| [`5bafafe3`](https://github.com/NixOS/nixpkgs/commit/5bafafe369db3d6db24e526cc5a0a1945ded7d1e) | `` treewide: microsoft_gsl -> microsoft-gsl ``                           |
| [`dc576102`](https://github.com/NixOS/nixpkgs/commit/dc5761025468f7f6684f41a303c515aeb2d53187) | `` _389-ds-base: 2.3.1 -> 2.4.1 ``                                       |
| [`bc4ec570`](https://github.com/NixOS/nixpkgs/commit/bc4ec570ec14bb9fe53476f3b78390783212df86) | `` apko: use checkflags and minor cleanup ``                             |
| [`83da7af2`](https://github.com/NixOS/nixpkgs/commit/83da7af2ca641cd6e64c685ccd70169e68757ed5) | `` bitcoin: 24.1 -> 25.0 ``                                              |
| [`2641ec09`](https://github.com/NixOS/nixpkgs/commit/2641ec0949d9c5803baae684e0931dd131fa398c) | `` kyverno: 1.9.3 -> 1.9.4 ``                                            |
| [`bbf92135`](https://github.com/NixOS/nixpkgs/commit/bbf921352f7e654abe87fa694b330f80d19cc9b4) | `` apko: 0.4.0 -> 0.8.0 (#228007) ``                                     |
| [`938e5e2f`](https://github.com/NixOS/nixpkgs/commit/938e5e2fbe162d27c2eee74252f9d9cc1f5fb414) | `` timescaledb_toolkit: mark broken on darwin ``                         |
| [`f1b4964b`](https://github.com/NixOS/nixpkgs/commit/f1b4964b9063661b9c2c243b46566ca442571d8e) | `` gotrue-supabase: 2.67.1 -> 2.69.1 ``                                  |
| [`f0c46678`](https://github.com/NixOS/nixpkgs/commit/f0c46678677d0be3c74a67fe6d49aa85d35f8e0c) | `` qtcreator-qt6: fix build with qt 6.5.1 ``                             |
| [`60849da9`](https://github.com/NixOS/nixpkgs/commit/60849da99ace9040f454eb616488293a63f6b0ab) | `` gnushogi: refactor, unbreak on darwin ``                              |
| [`bf12e00b`](https://github.com/NixOS/nixpkgs/commit/bf12e00bac0a0470f6d6a63a8e3f468eeec89e87) | `` deno: 1.33.3 -> 1.34.0 ``                                             |
| [`a73769cc`](https://github.com/NixOS/nixpkgs/commit/a73769cc5b524b1a9156258cecc8273446ac7d35) | `` sdrangel: 7.13.0 -> 7.14.1 ``                                         |
| [`366e85cf`](https://github.com/NixOS/nixpkgs/commit/366e85cf69a5f655662d8b3f1f5f87037e0bfdbe) | `` tagref: 1.8.1 -> 1.8.2 ``                                             |
| [`04f05e32`](https://github.com/NixOS/nixpkgs/commit/04f05e328dbba916b23604eaa59dc9341ad6d2f5) | `` nfs-ganesha: 5.1 -> 5.2 ``                                            |
| [`81580d40`](https://github.com/NixOS/nixpkgs/commit/81580d40ab77aa7e4ff012713be925ddd88190a2) | `` sqlite-utils: 3.31 -> 3.32.1 ``                                       |
| [`ae6b1df6`](https://github.com/NixOS/nixpkgs/commit/ae6b1df643c932a6a714f2938148baf570739826) | `` vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.14.5 -> 0.14.7 ``    |
| [`fe813d96`](https://github.com/NixOS/nixpkgs/commit/fe813d960c65e3ecdf33974e6a731b47e9b3e004) | `` interactsh: 1.1.3 -> 1.1.4 ``                                         |
| [`55ccaf28`](https://github.com/NixOS/nixpkgs/commit/55ccaf28475c0852f62e3aac0efb37aae8c2a6b6) | `` flyctl: 0.1.8 -> 0.1.18 ``                                            |
| [`a8885fae`](https://github.com/NixOS/nixpkgs/commit/a8885faef7642d7b9373f4de6b0b72b5b5119884) | `` arkade: fix version ``                                                |
| [`693e831f`](https://github.com/NixOS/nixpkgs/commit/693e831f4f9e64a84962a89d0613e781b1c295e2) | `` khal: change dependency vdirsyncer from application to module ``      |
| [`532f47f2`](https://github.com/NixOS/nixpkgs/commit/532f47f28b4a7883100f2e6ef544e4d397a3c842) | `` tailscale: 1.40.1 -> 1.42.0 ``                                        |
| [`983762e3`](https://github.com/NixOS/nixpkgs/commit/983762e3357f0f2922eeb987babbbd7119b8b23a) | `` docker-buildx: 0.10.4 -> 0.10.5 ``                                    |
| [`e4533da9`](https://github.com/NixOS/nixpkgs/commit/e4533da96287421cca2188d3cd4e7d04e42c7387) | `` plan9port: 2022-09-12 -> 2023-03-31 ``                                |
| [`06a7ece7`](https://github.com/NixOS/nixpkgs/commit/06a7ece7bb739b76eb16eb0f09a794bcb99e955b) | `` gitlab: Fix commit option in update.py ``                             |
| [`5e369bab`](https://github.com/NixOS/nixpkgs/commit/5e369bab42b1857b4ca5bd875fde333a73ae241d) | `` gitlab: 15.11.5 -> 15.11.6 ``                                         |
| [`4d28c34f`](https://github.com/NixOS/nixpkgs/commit/4d28c34fff1b51b3f91f2980158b32eb69217da0) | `` martin: 0.8.2 -> 0.8.3 ``                                             |
| [`05eadbac`](https://github.com/NixOS/nixpkgs/commit/05eadbac251db9cf07c42195fa68b2bf3101b482) | `` plantuml: 1.2023.7 -> 1.2023.8 ``                                     |
| [`67ec520e`](https://github.com/NixOS/nixpkgs/commit/67ec520e073ebb5ba2d96af888837d450244a09d) | `` openvscode-server: 1.78.1 -> 1.78.2 ``                                |