### PR TITLE
chore(flake/lanzaboote): `e9003f12` -> `2e62c11b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1685227956,
-        "narHash": "sha256-OmCOMt1lHySoT3+WtW2ftIejhnHe5AkJ9IPf5kOAD6s=",
+        "lastModified": 1685349926,
+        "narHash": "sha256-c1rKI1glJWdJIPefp9aiyhAkEZ4Sc6Rh/J5VumEXu1M=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "e9003f12e63588736dde12acf95a4d0361b215e5",
+        "rev": "2e62c11babeead4b26efbb7f2cd4488baaa2e897",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                          |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`f1d199d0`](https://github.com/nix-community/lanzaboote/commit/f1d199d0b4ec62180044bdaa781818be585b2b10) | `` fix(deps): update rust crate log to 0.4.18 `` |