### PR TITLE
chore(flake/pre-commit-hooks): `61e567d6` -> `8e2c1a5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1684842236,
-        "narHash": "sha256-rYWsIXHvNhVQ15RQlBUv67W3YnM+Pd+DuXGMvCBq2IE=",
+        "lastModified": 1685355253,
+        "narHash": "sha256-cQdHhcE630f1VTg4IP18sJqyYhjPchHyqRBJ9THj/hY=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "61e567d6497bc9556f391faebe5e410e6623217f",
+        "rev": "8e2c1a5a62b698224c6f745599a9ec6b74283881",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                         |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`efa74788`](https://github.com/cachix/pre-commit-hooks.nix/commit/efa74788c82377f2b0c6698ad6017fb6c80014f5) | `` feat: add verbose option for hooks ``                        |
| [`131abfcc`](https://github.com/cachix/pre-commit-hooks.nix/commit/131abfccf3a9d86bb55ce591ab43db32ec001537) | `` chore(deps): bump cachix/install-nix-action from 20 to 21 `` |
| [`ffb25fcc`](https://github.com/cachix/pre-commit-hooks.nix/commit/ffb25fccec4fe95b57f1c33cfe8719ea10ecebcc) | `` feat: add convco check ``                                    |
| [`85083bae`](https://github.com/cachix/pre-commit-hooks.nix/commit/85083baeb406e7c572604f1ca911b04bc7979988) | `` fix(deadnix): fix typo in deadnix arguments ``               |