### PR TITLE
chore(flake/nixpkgs): `4e37b4e5` -> `5e871d8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685290091,
-        "narHash": "sha256-GGQYNZ7POoqPTtXgPOLUuSiHkOKFRWYpCoWUOSeSRoU=",
+        "lastModified": 1685383865,
+        "narHash": "sha256-3uQytfnotO6QJv3r04ajSXbEFMII0dUtw0uqYlZ4dbk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4e37b4e55b60fb7d43d2b62deb51032a489bcbe8",
+        "rev": "5e871d8aa6f57cc8e0dc087d1c5013f6e212b4ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                      |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
| [`93707532`](https://github.com/NixOS/nixpkgs/commit/93707532366ba2bc6b4b8ae920ba31246b20a613) | `` xcp: 0.9.4 -> 0.10.0 ``                                                                                   |
| [`4358d2ac`](https://github.com/NixOS/nixpkgs/commit/4358d2ac4feaff46846bb3b908c72497e8146d50) | `` kyverno: 1.9.4 -> 1.9.5 ``                                                                                |
| [`0ad8dd62`](https://github.com/NixOS/nixpkgs/commit/0ad8dd62975cb44ed2f5d8a122f756529798bec5) | `` BeatSaberModManager: suffix PATH with xdg-utils rather than prefix ``                                     |
| [`47f21185`](https://github.com/NixOS/nixpkgs/commit/47f21185eab61487c234bf0cb951876586842188) | `` glooctl: 1.14.5 -> 1.14.6 ``                                                                              |
| [`4b77b29b`](https://github.com/NixOS/nixpkgs/commit/4b77b29b0a6dc85352eea90f17400c8dc2fd9d92) | `` bearer: 1.8.0 -> 1.8.1 ``                                                                                 |
| [`96315531`](https://github.com/NixOS/nixpkgs/commit/963155315341bac20371b791fa356d1e53628cf1) | `` Revert "nixos/ntfy-sh: add defaults, use dynamic user" ``                                                 |
| [`63fa43ae`](https://github.com/NixOS/nixpkgs/commit/63fa43aeb29a4e2bb9a0a5a47610825e78b9f19c) | `` gl2ps: drop mesa on darwin ``                                                                             |
| [`041094ad`](https://github.com/NixOS/nixpkgs/commit/041094ad2ff90eab7d3d044c3eaad463666d2caa) | `` ocamlPackages.ppx_yojson_conv_lib: 0.15.0 -> 0.16.0 ``                                                    |
| [`41437056`](https://github.com/NixOS/nixpkgs/commit/41437056f77cc7683348955078ef7f84b9e6dc4c) | `` vtk: drop mesa on darwin ``                                                                               |
| [`48a6774e`](https://github.com/NixOS/nixpkgs/commit/48a6774e27122dab8a7c10d518bd810b8b702994) | `` wxGTK32: drop mesa on darwin ``                                                                           |
| [`e5b4371b`](https://github.com/NixOS/nixpkgs/commit/e5b4371bd200aad001c7f1ad2c17edc1bbb6ddba) | `` wxGTK31: drop mesa on darwin ``                                                                           |
| [`38c9e233`](https://github.com/NixOS/nixpkgs/commit/38c9e2336affada19048dea68d7e6b014817f632) | `` xfsprogs: add liburcu to nativeBuildInputs with is required by crc32selftest, fixing cross compilation `` |
| [`ee55a7e0`](https://github.com/NixOS/nixpkgs/commit/ee55a7e0b6739d2f5419d2fd779e442dfad4f02e) | `` xfsprogs: removed unneeded make configure invocation and build inputs ``                                  |
| [`d72e8ab7`](https://github.com/NixOS/nixpkgs/commit/d72e8ab75d243bb9afbdd5a172b02acf6500a41c) | `` python310Packages.pytest-md-report: raise minimal python version to 3.7 ``                                |
| [`ea47685d`](https://github.com/NixOS/nixpkgs/commit/ea47685d8a02715067c05de97aa148f489e3e8bb) | `` cargo-expand: 1.0.51 -> 1.0.52 ``                                                                         |
| [`afd309e2`](https://github.com/NixOS/nixpkgs/commit/afd309e2a6c313902e98691eda6a0980e68cf105) | `` ocamlPackages.oseq: 0.4 -> 0.5 ``                                                                         |
| [`b9a58b4a`](https://github.com/NixOS/nixpkgs/commit/b9a58b4ade8418d7d2675648c007981d4560edab) | `` ocamlPackages.gapi-ocaml: 0.4.3 -> 0.4.4 ``                                                               |
| [`c1071ec8`](https://github.com/NixOS/nixpkgs/commit/c1071ec8c212b327af7677d9ffc6eef330bbfe6d) | `` hugo: 0.112.4 -> 0.112.5 ``                                                                               |
| [`1c4d9e9a`](https://github.com/NixOS/nixpkgs/commit/1c4d9e9a752232eb35579ab9d213ab217897cb6f) | `` ocamlPackages.ocamlfuse: 2.7.1_cvs7 -> 2.7.1_cvs8 ``                                                      |
| [`35cb10f8`](https://github.com/NixOS/nixpkgs/commit/35cb10f82eed240c1e67bb50aee6722f5d6aaa47) | `` gtkcord4: 0.0.10 -> 0.0.11 ``                                                                             |
| [`8dcbea47`](https://github.com/NixOS/nixpkgs/commit/8dcbea47ed6907a79cd30eabaf51f70b8754f18a) | `` raycast: 1.52.0 -> 1.52.1 ``                                                                              |
| [`cc62398c`](https://github.com/NixOS/nixpkgs/commit/cc62398c925d6f4482d640242a7076841902bb66) | `` pomerium: 0.22.1 -> 0.22.2 ``                                                                             |
| [`6e9531b9`](https://github.com/NixOS/nixpkgs/commit/6e9531b9131da0c6542119f8d700e76d9c2eb1f4) | `` alephone-apotheosis-x: init at 1.1 ``                                                                     |
| [`9d2ed18e`](https://github.com/NixOS/nixpkgs/commit/9d2ed18ece8e1e4f54395ed06a1fcabce5235218) | `` New Aleph One scenario alephone-yuge ``                                                                   |
| [`1d73a587`](https://github.com/NixOS/nixpkgs/commit/1d73a58776f0ff58fa6c4b5181771130c4825875) | `` alephone: 1.4 -> 1.6.1 ``                                                                                 |
| [`de432ab2`](https://github.com/NixOS/nixpkgs/commit/de432ab2c2a6ce206396a6c3e1de407691fe97f9) | `` insomnia: 2023.2.0 -> 2023.2.2 ``                                                                         |
| [`d8e449e4`](https://github.com/NixOS/nixpkgs/commit/d8e449e4618fff15896d30ac40d9820527eeb8a2) | `` python310Packages.pytest-md-report: 0.3.0 -> 0.3.1 ``                                                     |
| [`21a36d67`](https://github.com/NixOS/nixpkgs/commit/21a36d6727c6a5f2921e8265252edc5c20d472f3) | `` python3Packages.libsixel: fix build on darwin ``                                                          |
| [`c06568b8`](https://github.com/NixOS/nixpkgs/commit/c06568b84482e42e1a486bc9135c40790cb51f4f) | `` python310Packages.pytorch-metric-learning: 2.1.1 -> 2.1.2 ``                                              |
| [`2a8e5b25`](https://github.com/NixOS/nixpkgs/commit/2a8e5b25be099bba16bbecf36a00d1de7d829969) | `` highlight: 4.5 -> 4.6 ``                                                                                  |
| [`c81f3c71`](https://github.com/NixOS/nixpkgs/commit/c81f3c71e803418fbdf5a73a2fca7cf57ce7285d) | `` python310Packages.shlib: 1.5 -> 1.6 ``                                                                    |
| [`6d93b778`](https://github.com/NixOS/nixpkgs/commit/6d93b7783264d34b424b6ef7c6271775d8bbe7aa) | `` mqttmultimeter: init at 1.7.211 ``                                                                        |
| [`0143b169`](https://github.com/NixOS/nixpkgs/commit/0143b169358e0729e8f3503dc2d64605c812e00c) | `` nixos/pufferpanel: buildFHSUserEnv -> buildFHSEnv ``                                                      |
| [`9eeb6bbf`](https://github.com/NixOS/nixpkgs/commit/9eeb6bbfecab77944c61b732183d12bddcd85df7) | `` darwin.openwith: mark broken on x86_64 ``                                                                 |
| [`8a029042`](https://github.com/NixOS/nixpkgs/commit/8a0290424007adc588b5e69edcedaf351b87b309) | `` python310Packages.ariadne: fix build ``                                                                   |
| [`2b16a73b`](https://github.com/NixOS/nixpkgs/commit/2b16a73b02c6ea6349e2170ee47ff419f8cdea23) | `` obs-studio-plugins.obs-source-clone: 0.1.3 -> 0.1.4 ``                                                    |
| [`8fa14075`](https://github.com/NixOS/nixpkgs/commit/8fa14075fbcf6495f48adf5db9bcdad9d3f9679d) | `` indent: fix build with clang 13 or newer ``                                                               |
| [`3dcca62a`](https://github.com/NixOS/nixpkgs/commit/3dcca62a5ed895d84482875be94d0d8256fda503) | `` nixos/ntfy-sh: add defaults, use dynamic user ``                                                          |
| [`4a04b823`](https://github.com/NixOS/nixpkgs/commit/4a04b823fb2dbd98baf5e345a8905cacb3d740ee) | `` pythonPackages.tftpy: init 0.8.2 ``                                                                       |
| [`84de8e15`](https://github.com/NixOS/nixpkgs/commit/84de8e15a2dd16dafc0e869b8a525f1b77292e58) | `` nodePackages: update to latest ``                                                                         |
| [`25b9e543`](https://github.com/NixOS/nixpkgs/commit/25b9e543da9add39a2224206b8f3771cee12bd30) | `` python3Packages.langchain: 0.0.180 -> 0.0.183 ``                                                          |
| [`d78aec40`](https://github.com/NixOS/nixpkgs/commit/d78aec407c6848845abb6d136343709b5090a693) | `` pylyzer: 0.0.28 -> 0.0.29 ``                                                                              |
| [`588f16c9`](https://github.com/NixOS/nixpkgs/commit/588f16c917d580563159122f05b6ec0dd4f7f807) | `` darwin.apple_sdk_11_0: deprecate clang*Stdenv ``                                                          |
| [`91aa9d22`](https://github.com/NixOS/nixpkgs/commit/91aa9d22480aefc16cef85590f16b313bf90a46f) | `` akkoma-emoji.blobs_gg: convert to stdenvNoCC.mkDerivation ``                                              |
| [`6b7434d3`](https://github.com/NixOS/nixpkgs/commit/6b7434d32e252a9b01d2770081cfb7da3874a18a) | `` esphome: 2023.5.4 -> 2023.5.5 ``                                                                          |
| [`eded68eb`](https://github.com/NixOS/nixpkgs/commit/eded68eb202280ee0f22efcaf6a7080bce9f2050) | `` botamusique: substitute version information ``                                                            |
| [`69677348`](https://github.com/NixOS/nixpkgs/commit/6967734863fda2f611590e533150535243739eaa) | `` python311Packages.solax: add format:  ``                                                                  |
| [`c42debb8`](https://github.com/NixOS/nixpkgs/commit/c42debb8d15dd2f2000f07522958212a41b2de62) | `` python311Packages.slixmpp: add changelog to meta ``                                                       |
| [`42846a13`](https://github.com/NixOS/nixpkgs/commit/42846a1387cc95595dd5004d042ffb98da16f239) | `` python311Packages.slixmpp: remove patch ``                                                                |
| [`1166edde`](https://github.com/NixOS/nixpkgs/commit/1166eddee69cf6b67dcdecf7401a9134b36bb81b) | `` python311Packages.slixmpp: 1.8.3 -> 1.8.4 ``                                                              |
| [`19970af6`](https://github.com/NixOS/nixpkgs/commit/19970af60878670d7e05380734cede3690bc4c84) | `` python311Packages.solax: 0.3.0 -> 0.3.1 ``                                                                |
| [`045659a6`](https://github.com/NixOS/nixpkgs/commit/045659a6b61c04839671ff9526723a91f868d9c5) | `` hugo: 0.112.3 -> 0.112.4 ``                                                                               |
| [`09dbd2dd`](https://github.com/NixOS/nixpkgs/commit/09dbd2dd15aac9befbdbfc2a28ee226b8a48e399) | `` python311Packages.xknx: 2.9.0 -> 2.10.0 ``                                                                |
| [`3869e535`](https://github.com/NixOS/nixpkgs/commit/3869e5358960f428816c22e445de602a767db093) | `` containerlab: init at 0.41.2 ``                                                                           |
| [`bcbb670c`](https://github.com/NixOS/nixpkgs/commit/bcbb670c152ce4ed6404bf6d7e3fc1b1d4e91b99) | `` BeatSaberModManager: wrap with xdg-utils ``                                                               |
| [`d875bcb2`](https://github.com/NixOS/nixpkgs/commit/d875bcb2921e09c6e10502729a9d06da4d7b4dd1) | `` labctl: init at 0.0.15 ``                                                                                 |
| [`c1c8d0ca`](https://github.com/NixOS/nixpkgs/commit/c1c8d0caf0adf4b6db2cae38271675dd48694091) | `` linuxKernel.packages.linux_lqx: 6.2.14 -> 6.3.4 ``                                                        |
| [`5e545dd9`](https://github.com/NixOS/nixpkgs/commit/5e545dd95dfc6bbadb3fcb240172d6bf9771bfcb) | `` linuxKernel.packages.linux_zen: 6.3.1 -> 6.3.4 ``                                                         |
| [`15602624`](https://github.com/NixOS/nixpkgs/commit/156026245b66fe29461e0da919930bf75cc9f9ca) | `` home-assistant: update component-packages ``                                                              |
| [`82b12bc8`](https://github.com/NixOS/nixpkgs/commit/82b12bc8613b910f2bb6a37acb70a54514f4b3f2) | `` meilisearch: remove unused darwin frameworks ``                                                           |
| [`db00ba76`](https://github.com/NixOS/nixpkgs/commit/db00ba762570b1f6cbfbb61e53d87460130bec71) | `` python311Packages.androidtvremote2: init at 0.0.9 ``                                                      |
| [`c7114ec5`](https://github.com/NixOS/nixpkgs/commit/c7114ec51a454c0b1d4c6bb552580ea6af58610a) | `` meilisearch: fix build on x86_64-darwin ``                                                                |
| [`8fa3aadd`](https://github.com/NixOS/nixpkgs/commit/8fa3aadd99eedbc7f68f5e78547208e16cf64ac7) | `` python311Packages.pysqueezebox: 0.6.1 -> 0.7.0 ``                                                         |
| [`a20a458b`](https://github.com/NixOS/nixpkgs/commit/a20a458b5a1c65629951e1afc06584cfc840ed35) | `` python311Packages.pyezviz: 0.2.0.12 -> 0.2.0.15 ``                                                        |
| [`f4d48ec7`](https://github.com/NixOS/nixpkgs/commit/f4d48ec7d62136af80a4138bb7c0211886421377) | `` python311Packages.pydaikin: 2.9.0 -> 2.9.1 ``                                                             |
| [`6f1b4c0e`](https://github.com/NixOS/nixpkgs/commit/6f1b4c0e3e2a828205af9b24973ada037f88eb74) | `` checkov: 2.3.259 -> 2.3.261 ``                                                                            |
| [`95f2ed0f`](https://github.com/NixOS/nixpkgs/commit/95f2ed0fc6badfe6cd6e3bbadd9f3a374e720359) | `` python311Packages.bc-detect-secrets: 1.4.28 -> 1.4.29 ``                                                  |
| [`ad420b31`](https://github.com/NixOS/nixpkgs/commit/ad420b311c745438233b4e4387135bca14bbeed2) | `` tml: add changelog to meta ``                                                                             |
| [`1d62ec32`](https://github.com/NixOS/nixpkgs/commit/1d62ec322c094707085c7d339dacdf1df2f8029d) | `` python310Packages.pyipp: 0.12.1 -> 0.13.0 ``                                                              |
| [`507f9c4d`](https://github.com/NixOS/nixpkgs/commit/507f9c4d85ccb3f33bfd4a595462b1bfed5ee602) | `` alfaview: 8.65.0 -> 8.67.1 (#224618) ``                                                                   |
| [`658c0496`](https://github.com/NixOS/nixpkgs/commit/658c04960286b5afcb268a2f402d6ab0ce737d07) | `` python310Packages.trio-websocket: fix/disable tests on darwin ``                                          |
| [`6aab92f4`](https://github.com/NixOS/nixpkgs/commit/6aab92f42a4409cea3b7c96161f1bfa5921a7cd5) | `` pkgsMusl.intel-gpu-tools: fix build (#233223) ``                                                          |
| [`0ba170d0`](https://github.com/NixOS/nixpkgs/commit/0ba170d016ce5d16ba76ca733b2df5898717ccc8) | `` kicad: 7.0.4 -> 7.0.5 ``                                                                                  |
| [`d456b861`](https://github.com/NixOS/nixpkgs/commit/d456b861b84abaa38cea6470f9ef41b20a2ca478) | `` fetchCrate: fix registryDl ``                                                                             |
| [`def36b7b`](https://github.com/NixOS/nixpkgs/commit/def36b7b17c6b13a10ed38b186b26a0508e26971) | `` balena-cli: 16.0.0 -> 16.2.7 ``                                                                           |
| [`ad31856b`](https://github.com/NixOS/nixpkgs/commit/ad31856bd90ca84443b706d4ed37763b254b4c77) | `` nixosTests.public-inbox: extend sleep ``                                                                  |
| [`e5f0e14c`](https://github.com/NixOS/nixpkgs/commit/e5f0e14c9aa9dc0330c4e869c933a991b0f98c3c) | `` gpxsee: 13.0 → 13.3 ``                                                                                    |
| [`3720991c`](https://github.com/NixOS/nixpkgs/commit/3720991c06f1e8d97c091b897881aa1d562269c7) | `` rl-2305: mention buildFHSEnv switch to bubblewrap ``                                                      |
| [`84d528fe`](https://github.com/NixOS/nixpkgs/commit/84d528fe2f2054753fbef4fe3e604edc00a5c65f) | `` kubescape: 2.3.3 -> 2.3.4 ``                                                                              |
| [`af8b9846`](https://github.com/NixOS/nixpkgs/commit/af8b984617fb414a342b2dfece762d20932fc579) | `` sbcl: 2.3.4 -> 2.3.5 ``                                                                                   |
| [`6a32ac7c`](https://github.com/NixOS/nixpkgs/commit/6a32ac7c6909741dd7bc4c40a209eee987ef9edc) | `` telegraf: add version test ``                                                                             |
| [`a0215e28`](https://github.com/NixOS/nixpkgs/commit/a0215e28ead5f41cd758f187e2a37a33ac016d63) | `` telegraf: fix version ``                                                                                  |
| [`80344645`](https://github.com/NixOS/nixpkgs/commit/80344645bf23a489cdbe58ea73f20b034ede5ffa) | `` lightspark: 0.8.6.1 -> 0.8.7 ``                                                                           |
| [`f67273a5`](https://github.com/NixOS/nixpkgs/commit/f67273a587862f2fa0e7d3b1c769980fb0c9432c) | `` libei: 1.0.0rc1 -> 1.0.0rc2 ``                                                                            |
| [`7298fef0`](https://github.com/NixOS/nixpkgs/commit/7298fef041a629169d64b5b3ba930160f19f4343) | `` vulkan-caps-viewer: 3.30 -> 3.31 ``                                                                       |
| [`a5472cf9`](https://github.com/NixOS/nixpkgs/commit/a5472cf9b5b72c8e2fbd12ee9c7ad493cd1eb6cd) | `` shattered-pixel-dungeon: 1.1.2 -> 2.0.2 ``                                                                |
| [`b5a0bd48`](https://github.com/NixOS/nixpkgs/commit/b5a0bd48146e6caaed47d7916f52c38b74827fb6) | `` tboot: 1.11.0 -> 1.11.1 ``                                                                                |
| [`10fd1468`](https://github.com/NixOS/nixpkgs/commit/10fd14685ffa5b0af6c6b6290fb8d1661215d9c7) | `` urbackup-client: 2.5.20 -> 2.5.24 ``                                                                      |
| [`3f3c3166`](https://github.com/NixOS/nixpkgs/commit/3f3c3166a8fdbb2ecb68f48af7e7bef651865d91) | `` python311Packages.django-webpack-loader: 1.8.1 -> 2.0.0 ``                                                |
| [`d243c193`](https://github.com/NixOS/nixpkgs/commit/d243c193a789d7dc41a84b030b51b5f108059a75) | `` open-policy-agent: 0.52.0 -> 0.53.0 ``                                                                    |
| [`14df2b8d`](https://github.com/NixOS/nixpkgs/commit/14df2b8df8fcf0c95d7ece2ef7e988eb0b429661) | `` qownnotes: use system botan ``                                                                            |
| [`0c0b0da5`](https://github.com/NixOS/nixpkgs/commit/0c0b0da52ea1c48656a3d63965ed78417e4ef665) | `` opentelemetry-collector: 0.77.0 -> 0.78.2 ``                                                              |
| [`0ba12430`](https://github.com/NixOS/nixpkgs/commit/0ba12430d1cd5301ad39b0d51649a9762c822774) | `` libsForQt5.mauiPackages: 2.2.2 -> 3.0.0 ``                                                                |
| [`b79b4f29`](https://github.com/NixOS/nixpkgs/commit/b79b4f294e070dafa106eba4d121d29b59b4b359) | `` pacemaker: 2.1.5 -> 2.1.6 ``                                                                              |
| [`50282cd3`](https://github.com/NixOS/nixpkgs/commit/50282cd3cc93b772a6713e58b9b210ba0cb43732) | `` qFlipper: 1.3.0 -> 1.3.1 ``                                                                               |
| [`ac38c4d5`](https://github.com/NixOS/nixpkgs/commit/ac38c4d5d0c9a0a6cf279fcdb04f022cc1bddba7) | `` python310Packages.tubeup: use pythonRelaxDepsHook ``                                                      |
| [`19ff71d1`](https://github.com/NixOS/nixpkgs/commit/19ff71d1670ed89b78e7c9f5f9a36fae445638ca) | `` python310Packages.tubeup: 0.0.35 -> 28.5.2023 ``                                                          |
| [`7642db27`](https://github.com/NixOS/nixpkgs/commit/7642db276ab8fec3b8e50cc4a78b9ee5165b219a) | `` ryujinx: 1.1.819 -> 1.1.826 ``                                                                            |
| [`93a55400`](https://github.com/NixOS/nixpkgs/commit/93a55400242b07e9af086a0e9887d52b3231d0cf) | `` tml: init at 0.6.0 ``                                                                                     |
| [`a4c6fca3`](https://github.com/NixOS/nixpkgs/commit/a4c6fca3200aaffd5e96d5770af049bec8c42eb4) | `` k8sgpt: init at 0.3.5 ``                                                                                  |
| [`ea0b4a69`](https://github.com/NixOS/nixpkgs/commit/ea0b4a694aeacc4d2f28a001af14c0e9d85fd7ee) | `` nixos/test/networking: test unusual interface names ``                                                    |
| [`4b94ae4b`](https://github.com/NixOS/nixpkgs/commit/4b94ae4bc62e7fb2b05da58ca997fd6c3c218a85) | `` writeTextFile: set meta.mainProgram based on destination ``                                               |
| [`2ede3cb6`](https://github.com/NixOS/nixpkgs/commit/2ede3cb62147cc3a6b46d143187610a8eab59dcb) | `` nextcloud26: 26.0.1 -> 26.0.2 ``                                                                          |
| [`67321062`](https://github.com/NixOS/nixpkgs/commit/6732106210fe87ecb497b86dfa7a451ead65cdb4) | `` network-interfaces-scripted: fix interface cleanup ``                                                     |
| [`5703ff7d`](https://github.com/NixOS/nixpkgs/commit/5703ff7dfb42ebffa95c6e57be890be8c7522d98) | `` qc71_laptop: 2022-06-01 -> 2023-03-02 ``                                                                  |
| [`780c1018`](https://github.com/NixOS/nixpkgs/commit/780c1018b81c8b6842459fd3a27fb8c8c819108e) | `` brakeman: 5.4.1 -> 6.0.0 ``                                                                               |
| [`1a176b06`](https://github.com/NixOS/nixpkgs/commit/1a176b0657b1a1a2cfd796cdd689d261955bf4f1) | `` python311Packages.neo4j: 5.8.1 -> 5.9.0 ``                                                                |
| [`7f3706f7`](https://github.com/NixOS/nixpkgs/commit/7f3706f7e1cd6a9ef388733ae4c6d3b83df1ccc4) | `` nixops_unstable: Set meta.mainProgram ``                                                                  |
| [`bd5568b0`](https://github.com/NixOS/nixpkgs/commit/bd5568b0d66e913bdff88e239f0289a7e6ae2021) | `` nixops_unstable: update ``                                                                                |
| [`7d621d6b`](https://github.com/NixOS/nixpkgs/commit/7d621d6be533025270fcb59fd65445a789233648) | `` nixos/shadowsocks: wait for nginx to prevent race condition ``                                            |
| [`79ac113a`](https://github.com/NixOS/nixpkgs/commit/79ac113a2cff33d4f3a8f2a04443bfe4449c3f2a) | `` rtl8189fs: 2022-10-30 -> 2023-03-27 ``                                                                    |
| [`1b2c716b`](https://github.com/NixOS/nixpkgs/commit/1b2c716b6801654686a5e86efce70eb4eae46ba1) | `` python311Packages.opentracing: disable ``                                                                 |
| [`1b130c8a`](https://github.com/NixOS/nixpkgs/commit/1b130c8ababc2db6e8f4ae18b37c9b1601f13e6c) | `` python310Packages.trio-websocket: 0.9.2 -> 0.10.2 ``                                                      |
| [`545206f9`](https://github.com/NixOS/nixpkgs/commit/545206f93686934998f2f6e74b8d2380f5e2477d) | `` fetchCrate: allow overriding `registryDl` ``                                                              |
| [`a33c726a`](https://github.com/NixOS/nixpkgs/commit/a33c726a6644a9b422cf28411ecff11ac4ac2ca9) | `` gnomeExtensions: auto-update ``                                                                           |
| [`eb1c777c`](https://github.com/NixOS/nixpkgs/commit/eb1c777cef1c21767aa27ae69d09733f785a6f7a) | `` stumpwm-unwrapped: init ``                                                                                |
| [`e9c0fffb`](https://github.com/NixOS/nixpkgs/commit/e9c0fffbefdadac6a943d324a0ae628db0203d86) | `` ovftool: replace libxcrypt with libxcrypt-legacy ``                                                       |
| [`7daa2b14`](https://github.com/NixOS/nixpkgs/commit/7daa2b144f6f7ea8fa0d030e13b2e60650136972) | `` ansible_2_13: 2.13.9 -> 2.13.10 ``                                                                        |
| [`bc4250f4`](https://github.com/NixOS/nixpkgs/commit/bc4250f411bb2616b4243487e5dde3f760c8e5b3) | `` ansible_2_14: 2.14.5 -> 2.14.6 ``                                                                         |
| [`fa8d4324`](https://github.com/NixOS/nixpkgs/commit/fa8d4324f61a54c413cab259a9e14a8e968999e7) | `` stumpwm: Fix package conflict and HOME errors when loading modules ``                                     |
| [`abc55e61`](https://github.com/NixOS/nixpkgs/commit/abc55e615af2a60391131196dbe95dffc101b39a) | `` libremidi: init at unstable-2023-05-05 ``                                                                 |
| [`e8d796f8`](https://github.com/NixOS/nixpkgs/commit/e8d796f8abcb536834e690ddf5cdc4aca2e583cd) | `` fiano: add jmbaur as maintainer ``                                                                        |
| [`0d425b79`](https://github.com/NixOS/nixpkgs/commit/0d425b7946a4d73a791a2c8b869ca3d85572a1e2) | `` fiano: init at 1.2.0 ``                                                                                   |
| [`65dfad9a`](https://github.com/NixOS/nixpkgs/commit/65dfad9a5bf8c82866531bfe8057e84a9cf33d27) | `` python3Packages.langchain: enable google-search-results ``                                                |
| [`e4bee97b`](https://github.com/NixOS/nixpkgs/commit/e4bee97bdd8b6a7bf40436b861a01d85261c2210) | `` python3Packages.google-search-results: init at 2.4.2 ``                                                   |
| [`22b4111e`](https://github.com/NixOS/nixpkgs/commit/22b4111ea9d9728c62819993263875062ecb399c) | `` vkbasalt: add bitness suffix to layer name ``                                                             |
| [`a9fb7b6c`](https://github.com/NixOS/nixpkgs/commit/a9fb7b6cdee967659505d08be3449bb1c9742f36) | `` mitscheme: 11.2 -> 12.1 ``                                                                                |
| [`9dd76ff7`](https://github.com/NixOS/nixpkgs/commit/9dd76ff79cf5d6d8939a170787b0dfdec42a129b) | `` wolfram-engine: add 13.2.0 ``                                                                             |
| [`5e692f20`](https://github.com/NixOS/nixpkgs/commit/5e692f20ab3b66d780231565caa735412b412a39) | `` coze: init at 0.0.3 ``                                                                                    |
| [`61f8876d`](https://github.com/NixOS/nixpkgs/commit/61f8876da746ef5aa1325822b8d2ecaf0467b40c) | `` libuv: add some key reverse-dependencies to passthru.tests ``                                             |
| [`9e16748a`](https://github.com/NixOS/nixpkgs/commit/9e16748aa7e1413517e55a5d7108a6b35a2e656b) | `` python310Packages.soxr: 0.3.4 -> 0.3.5 ``                                                                 |