### PR TITLE
chore(flake/home-manager): `54a9d645` -> `f1490b8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -209,11 +209,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685480784,
-        "narHash": "sha256-pkk3J9gX745LEkkeTGhSRJqPJkmCPQzwI/q7a720XaY=",
+        "lastModified": 1685553090,
+        "narHash": "sha256-DsAYE1AaR4NcZeeotEIE1XlNVXAv8NxUVDxOb7t4wxU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "54a9d6456eaa6195998a0f37bdbafee9953ca0fb",
+        "rev": "f1490b8caf2ef6f59205c78cf1a8b68e776214a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`f1490b8c`](https://github.com/nix-community/home-manager/commit/f1490b8caf2ef6f59205c78cf1a8b68e776214a3) | `` Switch current unstable version to 23.11 `` |
| [`33ccc5c2`](https://github.com/nix-community/home-manager/commit/33ccc5c28572d200f1e8d93fccba17e084e5f587) | `` Switch stable branch to release-23.05 ``    |
| [`b2a6cf7b`](https://github.com/nix-community/home-manager/commit/b2a6cf7b59343f4c1c29f5777b16ccd8f6e6495b) | `` docs: update copyright years ``             |