### PR TITLE
chore(flake/nixpkgs): `5e871d8a` -> `4f53efe3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -348,11 +348,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685383865,
-        "narHash": "sha256-3uQytfnotO6QJv3r04ajSXbEFMII0dUtw0uqYlZ4dbk=",
+        "lastModified": 1685564631,
+        "narHash": "sha256-8ywr3AkblY4++3lIVxmrWZFzac7+f32ZEhH/A8pNscI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5e871d8aa6f57cc8e0dc087d1c5013f6e212b4ce",
+        "rev": "4f53efe34b3a8877ac923b9350c874e3dcd5dc0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`28ecd175`](https://github.com/NixOS/nixpkgs/commit/28ecd1752334b467929ef3f565389fdf94c03f1e) | `` nixos/doc: Mention container registry deprecation in gitlab ``                |
| [`e9594e60`](https://github.com/NixOS/nixpkgs/commit/e9594e60319bae339c8cc7211e9f773d394839ae) | `` nixos/gitlab: Warn users who are still using an external registry ``          |
| [`014816cb`](https://github.com/NixOS/nixpkgs/commit/014816cbe46973336739c450b6b80cc00f0508fa) | `` nixos/gitlab: Add support for gitlab-container-registry ``                    |
| [`049d6805`](https://github.com/NixOS/nixpkgs/commit/049d68051078fe4a10d7672ec5ec29c27890eb4a) | `` nixos/dockerRegistry: add package option ``                                   |
| [`82d9c2e9`](https://github.com/NixOS/nixpkgs/commit/82d9c2e91f88f17d75204b7819f6be533e4e93e9) | `` nixosTests.gitlab: fix project ids ``                                         |
| [`75a7e0ed`](https://github.com/NixOS/nixpkgs/commit/75a7e0edea7095bf40c24c6afd2f4bfd4dba76ad) | `` gem-config: patch getconf path in prometheus-client-mmap ``                   |
| [`edc47cb9`](https://github.com/NixOS/nixpkgs/commit/edc47cb9994e17e51b4a13fb8fa38f72e228cffb) | `` nixos/doc: Mention PostgreSQL requirement for gitlab ``                       |
| [`2a453695`](https://github.com/NixOS/nixpkgs/commit/2a4536952a3d4481b22dfedeb0a8482083c321f4) | `` nixos/gitlab: Require at least postgresql 13.6 ``                             |
| [`4321e48b`](https://github.com/NixOS/nixpkgs/commit/4321e48b6851f187696bd4ef544cd2f6e6dfbd8b) | `` nixos/gitlab: Remove procps from gitaly service ``                            |
| [`33411f27`](https://github.com/NixOS/nixpkgs/commit/33411f27686e7535254879c0fddaa93a67ea4774) | `` nixos/gitlab: Update redis configuration ``                                   |
| [`a69b300b`](https://github.com/NixOS/nixpkgs/commit/a69b300bc1b7e4d8cee982d0f8d65d134b6d58e0) | `` gitlab: 15.11.6 -> 16.0.1 ``                                                  |
| [`6fed71ca`](https://github.com/NixOS/nixpkgs/commit/6fed71cab2f4d74863970377d3289487c9a19ec0) | `` gitaly: Remove ruby dependencies ``                                           |
| [`12ae1e6b`](https://github.com/NixOS/nixpkgs/commit/12ae1e6b6b7815e53e94349e79694e1c0e461d9c) | `` clblast: init (#234020) ``                                                    |
| [`76fbfa6a`](https://github.com/NixOS/nixpkgs/commit/76fbfa6a795e5aeed0be8e89e72f17544db57db5) | `` powerline-go: 1.23 -> 1.24 ``                                                 |
| [`f9a13aa3`](https://github.com/NixOS/nixpkgs/commit/f9a13aa3ccedc9c90480a8f2166f1b1288a1ef50) | `` vimPlugins.nvim-treesitter: update grammars ``                                |
| [`67854592`](https://github.com/NixOS/nixpkgs/commit/67854592f8f6a655730eeed6b781da20d2a0f504) | `` vimPlugins: update ``                                                         |
| [`2590dc1e`](https://github.com/NixOS/nixpkgs/commit/2590dc1ec6beacbfed0d45297a6b2c1b1fe7a620) | `` vimPlugins.vim-advanced-sorters: init at 2021-11-21 ``                        |
| [`670607c4`](https://github.com/NixOS/nixpkgs/commit/670607c49b951c76c84c309042b8e1009e1d0349) | `` python310Packages.python-matter-server: 3.4.1 -> 3.4.2 ``                     |
| [`8b4cc62c`](https://github.com/NixOS/nixpkgs/commit/8b4cc62cc833a539073a2267df592de1530049b5) | `` maintainers: Add nh2 to geospatial team (#235227) ``                          |
| [`397e6fea`](https://github.com/NixOS/nixpkgs/commit/397e6fea7cadb523c3c88982e4d6ea64bf6fe5f6) | `` erlang_24: 24.3.4.11 -> 24.3.4.12 ``                                          |
| [`538af4f9`](https://github.com/NixOS/nixpkgs/commit/538af4f9e3d1df4df697d4a9a697c5405426e83f) | `` reindeer: ensure date is based on universal time ``                           |
| [`e33fc115`](https://github.com/NixOS/nixpkgs/commit/e33fc1159365c5dbca1c765f5a6ad1e63aad201e) | `` reindeer: unstable-2023-05-18 -> unstable-2023-05-31 ``                       |
| [`80ecbbd3`](https://github.com/NixOS/nixpkgs/commit/80ecbbd3ebc12235b3a7b34a4cf519ec770c8c65) | `` ocaml-ng.ocamlPackages.utop: 2.10.0 -> 2.12.1 ``                              |
| [`30198951`](https://github.com/NixOS/nixpkgs/commit/301989511858e7789f1809a33910b2b213e84a23) | `` python310Packages.policyuniverse: 1.5.0.20230523 -> 1.5.1.20230526 ``         |
| [`1cc9346a`](https://github.com/NixOS/nixpkgs/commit/1cc9346a7224a1e36007bcb103c34728780ad22b) | `` lego: 4.11.0 -> 4.12.0 (#234664) ``                                           |
| [`60b63941`](https://github.com/NixOS/nixpkgs/commit/60b63941c60e3ce7fb7c59bebf4c353f906da4ba) | `` grub: backport patch to fix e2fsprogs 1.47 incompatibility ``                 |
| [`5b9c475a`](https://github.com/NixOS/nixpkgs/commit/5b9c475a74ef53ab2dda4539d9660071df4b09d9) | `` python311Packages.gaphas: 3.10.3 -> 3.11.1 ``                                 |
| [`c78bbdb3`](https://github.com/NixOS/nixpkgs/commit/c78bbdb38f750d2b51008a47ce7323ed6ec8a40f) | `` geoserver: 2.23.0 -> 2.23.1 ``                                                |
| [`04670928`](https://github.com/NixOS/nixpkgs/commit/0467092870b07f942a27f7f23aa56b01b17c2067) | `` vimPlugins.minsnip-nvim: init at 2022-01-04 ``                                |
| [`fa21828b`](https://github.com/NixOS/nixpkgs/commit/fa21828be54b29fcf1a0e93a3bdd1f7081c680b8) | `` nixosTests.acme-dns: init ``                                                  |
| [`d0af3952`](https://github.com/NixOS/nixpkgs/commit/d0af39521bf94f2e3649c1dcc24c3317320ca6a8) | `` nixos/acme-dns: init ``                                                       |
| [`85f1e0c0`](https://github.com/NixOS/nixpkgs/commit/85f1e0c0402d9c16a04f7f12d66e6baafd08a967) | `` acme-dns: init at 1.0 ``                                                      |
| [`5319ddf7`](https://github.com/NixOS/nixpkgs/commit/5319ddf7dc2adc3d54eb9d498804f5c1576764d4) | `` lib.concatMapAttrs: Simplify stack trace ``                                   |
| [`75dbeee4`](https://github.com/NixOS/nixpkgs/commit/75dbeee43499764c791a8caad14bf4369742d753) | `` tclx: 8.6.1 -> 8.6.2 ``                                                       |
| [`d7841949`](https://github.com/NixOS/nixpkgs/commit/d78419490afc4a59cd061eb9f5c9096380ba84cf) | `` python310Packages.google-cloud-monitoring: 2.14.2 -> 2.15.0 ``                |
| [`1807be40`](https://github.com/NixOS/nixpkgs/commit/1807be40049cc3008ee4248251d7e3fabac84a66) | `` tellico: 3.4.6 -> 3.5 ``                                                      |
| [`17684ef6`](https://github.com/NixOS/nixpkgs/commit/17684ef69de319dab53e0725fe53cb804229546a) | `` rl2305: Sync back changes that only went into 23.05 ``                        |
| [`d11c1779`](https://github.com/NixOS/nixpkgs/commit/d11c17797df63e2893c9a6ed433e60a717dd8933) | `` fabs: Mark broken ``                                                          |
| [`c1e2375d`](https://github.com/NixOS/nixpkgs/commit/c1e2375dbbb55ac4d23860530a80a26848f0dbef) | `` android-studio: 2022.2.1.19 -> 2022.2.1.20 ``                                 |
| [`a17e3e35`](https://github.com/NixOS/nixpkgs/commit/a17e3e356a2cb70bb167f3d2fcba9e6155894f09) | `` rl-2305: finalize the release notes ``                                        |
| [`ddf916ec`](https://github.com/NixOS/nixpkgs/commit/ddf916ec7aba47802de194cc7c6a6d2666c984d1) | `` spicetify-cli: 2.18.1 -> 2.19.0 ``                                            |
| [`8c3896f5`](https://github.com/NixOS/nixpkgs/commit/8c3896f5c80cd81bc23664ad002d6471e5c94024) | `` okteto: 2.15.4 -> 2.16.2 ``                                                   |
| [`69867f9d`](https://github.com/NixOS/nixpkgs/commit/69867f9de40f0d24276eeaf957b36a34541214fe) | `` transmission: drop myself from .meta.maintainers ``                           |
| [`8f850ea0`](https://github.com/NixOS/nixpkgs/commit/8f850ea08cfca1fb07c401fdf5ecb6c492127d91) | `` linux_testing: 6.4-rc3 -> 6.4-rc4 ``                                          |
| [`346111cd`](https://github.com/NixOS/nixpkgs/commit/346111cdfc1a45b17365f44f3fd64460c361485e) | `` notify: 1.0.4 -> 1.0.5 ``                                                     |
| [`2b63df0a`](https://github.com/NixOS/nixpkgs/commit/2b63df0a03510bd9579f9a53cc22f83be97996a3) | `` modules/sshd: print the offending keys when we detect duplicate sshd keys. `` |
| [`7d8e2453`](https://github.com/NixOS/nixpkgs/commit/7d8e24539daa5525e1d6e7104f69652a2b8b42a1) | `` chromium: 113.0.5672.126 -> 114.0.5735.90 ``                                  |
| [`895fcfb5`](https://github.com/NixOS/nixpkgs/commit/895fcfb51f980d928b083f8625a4b9870fb89c92) | `` exportarr: 1.3.2 -> 1.4.0 ``                                                  |
| [`4a6b1318`](https://github.com/NixOS/nixpkgs/commit/4a6b131836f8d5216ca7b49053dd0f21a55f8c1a) | `` coqPackages.corn: enable for Coq 8.17 ``                                      |
| [`810f901a`](https://github.com/NixOS/nixpkgs/commit/810f901a4e3f2d187869a0f180a8a04a27015395) | `` coqPackages.math-classes: 8.15.0 → 8.17.0 ``                                  |
| [`e5e2b16a`](https://github.com/NixOS/nixpkgs/commit/e5e2b16a89cfe526b2923a6deaed35505a8bced5) | `` ocamlPackages.benchmark: 1.4 → 1.6 ``                                         |
| [`d74ed5eb`](https://github.com/NixOS/nixpkgs/commit/d74ed5ebb0cbac08774bccfc6f07bdd3f544ac75) | `` ocamlPackages.rope: refactor ``                                               |
| [`1d7b0898`](https://github.com/NixOS/nixpkgs/commit/1d7b08986544edcc29ffed0d5f3db9bdb2bd75ab) | `` cage: fix segfault when called with -m last ``                                |
| [`5c3c1773`](https://github.com/NixOS/nixpkgs/commit/5c3c1773a9d73645beac4074a216b537c5db26cb) | `` v2ray: 5.4.1 -> 5.6.0 ``                                                      |
| [`7b929660`](https://github.com/NixOS/nixpkgs/commit/7b92966037d7268a589bc7077e689c403337e50f) | `` pdepend: 2.13.0 -> 2.14.0 ``                                                  |
| [`8600e714`](https://github.com/NixOS/nixpkgs/commit/8600e71498286a239e063e20f2acc55fa4172158) | `` gopls: 0.11.0 -> 0.12.0 (#235066) ``                                          |
| [`3175f401`](https://github.com/NixOS/nixpkgs/commit/3175f401b2c201f38710769a564a243834c2f157) | `` apx: specify license ``                                                       |
| [`01f12a56`](https://github.com/NixOS/nixpkgs/commit/01f12a564fb4923134d5142a73fa3eebac1d6fcc) | `` apx: add changelog to meta ``                                                 |
| [`083530b5`](https://github.com/NixOS/nixpkgs/commit/083530b5780c0427f15a3e74ba6d31c20c55fe2f) | `` gerbv: equalize ``                                                            |
| [`dd0a325d`](https://github.com/NixOS/nixpkgs/commit/dd0a325d945f044b7dfe60532ca7dd8134374c5a) | `` gerbv: specify license ``                                                     |
| [`d4497335`](https://github.com/NixOS/nixpkgs/commit/d4497335f08fb4503c6656fdc08dfa6b2c3b12c0) | `` otpclient: equalize ``                                                        |
| [`767579a8`](https://github.com/NixOS/nixpkgs/commit/767579a88a354b320a6e321cf98193c6d5dfad6b) | `` otpclient: add changelog to meta ``                                           |
| [`d1d32c41`](https://github.com/NixOS/nixpkgs/commit/d1d32c416c6fe326cfe6b313121bad5ad9235e30) | `` python311Packages.aioslimproto: 2.2.0 -> 2.2.1 ``                             |
| [`c400efcf`](https://github.com/NixOS/nixpkgs/commit/c400efcf3f7d84bf191ac5affb4b45fdc173a37f) | `` haskellPackages: mark builds failing on hydra as broken ``                    |
| [`97da8fa1`](https://github.com/NixOS/nixpkgs/commit/97da8fa1e8f752a52d08b0c3d681aa8955e7bfc5) | `` xfce.xfce4-screensaver: 4.18.1 -> 4.18.2 ``                                   |
| [`64ef8aea`](https://github.com/NixOS/nixpkgs/commit/64ef8aeabdaf7a7f9e6c4b0ee69aff8b7de407d1) | `` xfce.xfce4-power-manager: 4.18.1 -> 4.18.2 ``                                 |
| [`6b15bba9`](https://github.com/NixOS/nixpkgs/commit/6b15bba9103ae7f3918834ed48f914a8472f5306) | `` metasploit: 6.3.17 -> 6.3.18 ``                                               |
| [`f9506e92`](https://github.com/NixOS/nixpkgs/commit/f9506e92d2412dfc6bad2403240d7c634ef82d5a) | `` checkov: relax license-expression constraint ``                               |
| [`4da18afa`](https://github.com/NixOS/nixpkgs/commit/4da18afa67771736ad5dfb61d569a77f1049d69f) | `` python311Packages.pywerview: 0.4.1 -> 0.5.0 ``                                |
| [`777bfe5d`](https://github.com/NixOS/nixpkgs/commit/777bfe5d65531ee5d97d7982d68142cb28e83060) | `` python310Packages.ibm-cloud-sdk-core: 3.16.5 -> 3.16.6 ``                     |
| [`b5da7670`](https://github.com/NixOS/nixpkgs/commit/b5da7670cf2b014e1a71838e224b9e0879f21715) | `` webkitgtk: 2.40.1 → 2.40.2 ``                                                 |
| [`da2658d2`](https://github.com/NixOS/nixpkgs/commit/da2658d2c916994f0862d6c19704c286e1b3ce3b) | `` gerbv: 2.9.6 -> 2.9.7 ``                                                      |
| [`3b9bf00e`](https://github.com/NixOS/nixpkgs/commit/3b9bf00e38d68dd99908fb0c349951603e157cd8) | `` apx: 1.7.0-1 -> 1.8.2 ``                                                      |
| [`862163bd`](https://github.com/NixOS/nixpkgs/commit/862163bdf469f0dadec8c7539f507296efcba437) | `` otpclient: 3.1.6 -> 3.1.7 ``                                                  |
| [`5521be28`](https://github.com/NixOS/nixpkgs/commit/5521be288c7729e1653baddce52b8450dca1a4f1) | `` terraform-providers.snowflake: 0.64.0 -> 0.65.0 ``                            |
| [`7e218935`](https://github.com/NixOS/nixpkgs/commit/7e218935d04ded91e5712c47b342d9b5336ba440) | `` terraform-providers.pagerduty: 2.14.6 -> 2.15.0 ``                            |
| [`7142bc45`](https://github.com/NixOS/nixpkgs/commit/7142bc459039df3219f302e21759493df5357e57) | `` terraform-providers.newrelic: 3.23.0 -> 3.24.0 ``                             |
| [`5103f063`](https://github.com/NixOS/nixpkgs/commit/5103f063670628525ae7eabea90af3ab31751158) | `` terraform-providers.google-beta: 4.66.0 -> 4.67.0 ``                          |
| [`a6021738`](https://github.com/NixOS/nixpkgs/commit/a60217388e39d281d44d898de0f3c1020596b00a) | `` terraform-providers.google: 4.66.0 -> 4.67.0 ``                               |
| [`8848ac16`](https://github.com/NixOS/nixpkgs/commit/8848ac16a5c281ad76e542a43540cb126350f5d4) | `` terraform-providers.cloudflare: 4.6.0 -> 4.7.0 ``                             |
| [`3b629486`](https://github.com/NixOS/nixpkgs/commit/3b6294869a7cf6f340453346923287e6c2292a2f) | `` terraform-providers.akamai: 3.6.0 -> 4.0.0 ``                                 |
| [`92de5c30`](https://github.com/NixOS/nixpkgs/commit/92de5c308013b0f20bad474da5b0195e142c48c3) | `` millet: 0.9.8 -> 0.10.0 ``                                                    |
| [`02fe8fdf`](https://github.com/NixOS/nixpkgs/commit/02fe8fdf957e644a7e6bb98c7a7722942af69658) | `` resvg: 0.34.0 -> 0.34.1 ``                                                    |
| [`5cc2f9fc`](https://github.com/NixOS/nixpkgs/commit/5cc2f9fcfb426e24e8af4afa4bc03493cfd14d44) | `` opengrok: add changelog to meta ``                                            |
| [`c3f8d0ec`](https://github.com/NixOS/nixpkgs/commit/c3f8d0ec7c056050eaf9e5fb7fe6537f55ec6d40) | `` python310Packages.tubeup: 28.5.2023 -> 2023.5.29 ``                           |
| [`0faad578`](https://github.com/NixOS/nixpkgs/commit/0faad578fe6d6f9deff5ae2489f8c8a32dd1ddbe) | `` postgresqlPackages.pgroonga: add changelog to meta ``                         |
| [`bb56c9e9`](https://github.com/NixOS/nixpkgs/commit/bb56c9e98c9cf82b2870b13e9aa648e457083ece) | `` opengrok: 1.12.8 -> 1.12.9 ``                                                 |
| [`dd099ced`](https://github.com/NixOS/nixpkgs/commit/dd099cedf161007f8e2025ebcd0a427c3058d115) | `` postgresqlPackages.pgroonga: 3.0.3 -> 3.0.5 ``                                |
| [`3b666b41`](https://github.com/NixOS/nixpkgs/commit/3b666b41c39665dcfe19079692e0ef276f8f554d) | `` alt-ergo: 2.4.2 → 2.4.3 ``                                                    |
| [`5b2e7a9b`](https://github.com/NixOS/nixpkgs/commit/5b2e7a9be7b0d2b98aa3f082ac6e5f8e914cf846) | `` memos: 0.13.0 -> 0.13.1 ``                                                    |
| [`5912945b`](https://github.com/NixOS/nixpkgs/commit/5912945b2877a3d1518ad4d3750dd574c12aa8a7) | `` opengrok: 1.12.7 -> 1.12.8 ``                                                 |
| [`b66162ae`](https://github.com/NixOS/nixpkgs/commit/b66162ae56322fa57ddf7b2325af6d5716d44cbb) | `` juju: 3.1.2 -> 3.2.0 ``                                                       |
| [`ab7ef445`](https://github.com/NixOS/nixpkgs/commit/ab7ef4456c9a2921137b8c4657999d946533d013) | `` iosevka-bin: 23.0.0 -> 24.1.0 ``                                              |
| [`9c5f1f15`](https://github.com/NixOS/nixpkgs/commit/9c5f1f1554f1a7a0cf10e39c704e524c0d26af23) | `` copilot-cli: 1.27.0 -> 1.28.0 ``                                              |
| [`1baa9202`](https://github.com/NixOS/nixpkgs/commit/1baa9202b760a808c4affbbefa974d788f1d4423) | `` python3Packages.edk2-pytool-library: 0.15.0 -> 0.15.1 ``                      |
| [`b5ff721d`](https://github.com/NixOS/nixpkgs/commit/b5ff721d16cda9ed672b87127d379545dcae0521) | `` cargo-make: 0.36.7 -> 0.36.8 ``                                               |
| [`f7558009`](https://github.com/NixOS/nixpkgs/commit/f75580096c66668532a93347f432d2568a6be5a6) | `` python310Packages.openstacksdk: 1.1.0 -> 1.2.0 ``                             |
| [`6f49d895`](https://github.com/NixOS/nixpkgs/commit/6f49d895105895b26d33c8a7db723814e4d0e7a6) | `` erlang_odbc_javac: 25.3.2 -> 25.3.2.1 ``                                      |
| [`7041bc7a`](https://github.com/NixOS/nixpkgs/commit/7041bc7a1fef67cadafda2dcec55d79708310002) | `` haskellPackages.streamly-0.9.0: Add required framework on Darwin ``           |
| [`41090fe2`](https://github.com/NixOS/nixpkgs/commit/41090fe2acb5163a413235d8d00584c241180b4d) | `` vscode: fix typo ``                                                           |
| [`930537ad`](https://github.com/NixOS/nixpkgs/commit/930537ad55c3999b2a7c818f277a6e33d915b0b3) | `` shell_gpt: 0.9.0 -> 0.9.1 ``                                                  |
| [`025b14d2`](https://github.com/NixOS/nixpkgs/commit/025b14d24e2dce70f804243380a798eef75ab7b5) | `` ruby: fix typo ``                                                             |
| [`b0865ea9`](https://github.com/NixOS/nixpkgs/commit/b0865ea93da5dae242e5d7c1b663138249bf25f3) | `` helix: switch back to release tarball ``                                      |
| [`eb44b0ae`](https://github.com/NixOS/nixpkgs/commit/eb44b0ae8b5f33057426e75451e3279a24b6ce8b) | `` dontgo403: 0.9.1 -> 0.9.3 ``                                                  |
| [`3190a795`](https://github.com/NixOS/nixpkgs/commit/3190a7951967e8fa2216c1ad7bcd03bdbc3e27bb) | `` libcyaml: 1.4.0 -> 1.4.1 ``                                                   |
| [`2db499c0`](https://github.com/NixOS/nixpkgs/commit/2db499c00d945a83417648173bd09e888131ef77) | `` rustypaste: 0.9.1 -> 0.10.0 ``                                                |
| [`0bf7571e`](https://github.com/NixOS/nixpkgs/commit/0bf7571e2f7c063f0cf605cf137440c503d28975) | `` emacs: Enable SQLite3 and WebP for Emacs >=29 ``                              |
| [`b2164990`](https://github.com/NixOS/nixpkgs/commit/b2164990bdea411ffa246916b9c832d27b3eb599) | `` jackett: 0.21.34 -> 0.21.88 ``                                                |
| [`928cc104`](https://github.com/NixOS/nixpkgs/commit/928cc104f1289482d1133c6f4cda70535f58ff9d) | `` checkov: 2.3.261 -> 2.3.264 ``                                                |
| [`99c63490`](https://github.com/NixOS/nixpkgs/commit/99c6349077146c3c1392806deae1f832b28f48c3) | `` gh: 2.29.0 -> 2.30.0 ``                                                       |
| [`00ab6ea9`](https://github.com/NixOS/nixpkgs/commit/00ab6ea94e52a632c062961209d5bdadfe02ba0a) | `` python311Packages.aioesphomeapi: 13.7.5 -> 13.9.0 ``                          |
| [`a8b6f476`](https://github.com/NixOS/nixpkgs/commit/a8b6f476e40ba91e0deccefac025c356efc6c743) | `` python311Packages.pypykatz: 0.6.6 -> 0.6.8 ``                                 |
| [`b1579982`](https://github.com/NixOS/nixpkgs/commit/b15799824d11957c7667ecbb062ce029a96bc7f6) | `` python311Packages.aesedb: 0.1.3 -> 0.1.4 ``                                   |
| [`afe11259`](https://github.com/NixOS/nixpkgs/commit/afe1125900d8c6dacce39c6875a02d9abaf61e64) | `` python311Packages.msldap: 0.4.7 -> 0.5.5 ``                                   |
| [`765e75e5`](https://github.com/NixOS/nixpkgs/commit/765e75e521a2cccc773e2440da82a3d0d5521fba) | `` python311Packages.aiowinreg: 0.0.9 -> 0.0.10 ``                               |
| [`d598404f`](https://github.com/NixOS/nixpkgs/commit/d598404f6af259ab035f82028a45ca2c477c88e3) | `` python311Packages.aiosmb: 0.4.4 -> 0.4.6 ``                                   |
| [`3e3102c0`](https://github.com/NixOS/nixpkgs/commit/3e3102c092e188b2ee40e580e41d4b0b476467a9) | `` python311Packages.asyauth: 0.0.13 -> 0.0.14 ``                                |
| [`af3219c2`](https://github.com/NixOS/nixpkgs/commit/af3219c2edc429348dfd58e83f64b20891b7d750) | `` python311Packages.minikerberos: 0.4.0 -> 0.4.1 ``                             |
| [`2cf5223c`](https://github.com/NixOS/nixpkgs/commit/2cf5223c6c4c9a5dac11e6fcf56475f2be8863da) | `` python311Packages.asysocks: 0.2.5 -> 0.2.7 ``                                 |
| [`3b82683c`](https://github.com/NixOS/nixpkgs/commit/3b82683c8bada157cfa1922f31f32e9e8c7f1a94) | `` radarr: 4.4.4.7068 -> 4.5.2.7388 ``                                           |
| [`b3ec334e`](https://github.com/NixOS/nixpkgs/commit/b3ec334e71aed909d4eb83752f1c0c7eb940fef9) | `` python310Packages.angr: 9.2.52 -> 9.2.53 ``                                   |
| [`88f72b8a`](https://github.com/NixOS/nixpkgs/commit/88f72b8a9d4cec5083cf5acfcfce92c811458c4c) | `` python310Packages.cle: 9.2.52 -> 9.2.53 ``                                    |
| [`ab4a1a5a`](https://github.com/NixOS/nixpkgs/commit/ab4a1a5a1196440c50548afb60aaace1ddd9e152) | `` python310Packages.claripy: 9.2.52 -> 9.2.53 ``                                |
| [`31e03f7b`](https://github.com/NixOS/nixpkgs/commit/31e03f7bf943a6351fa7d932fa3e62a994a68a38) | `` python310Packages.pyvex: 9.2.52 -> 9.2.53 ``                                  |
| [`c694b919`](https://github.com/NixOS/nixpkgs/commit/c694b919b58b33310f780f66843ccef0df919b68) | `` python310Packages.ailment: 9.2.52 -> 9.2.53 ``                                |
| [`50c727eb`](https://github.com/NixOS/nixpkgs/commit/50c727ebf96d7d6ddb1ee63f79e4815f3dee620c) | `` python310Packages.archinfo: 9.2.52 -> 9.2.53 ``                               |
| [`e4575d3a`](https://github.com/NixOS/nixpkgs/commit/e4575d3a98d25b7a7570c730ce4450694673cb22) | `` vimPlugins: update sg-nvim-rust cargoHash ``                                  |
| [`dd5bc12f`](https://github.com/NixOS/nixpkgs/commit/dd5bc12f6bdf2864a2c300e79bbe855ca59f0db8) | `` mozillavpn: 2.14.1 → 2.15.0 ``                                                |
| [`58133faa`](https://github.com/NixOS/nixpkgs/commit/58133faaab4ee46f312e6d7221f43006419bef99) | `` automatic-timezoned: 1.0.92 -> 1.0.93 ``                                      |
| [`cea4ed7d`](https://github.com/NixOS/nixpkgs/commit/cea4ed7d2f12579aeb5ba2227256ce80b8097aa6) | `` linux/hardened/patches/6.1: 6.1.28-hardened1 -> 6.1.29-hardened1 ``           |
| [`03c9d2ad`](https://github.com/NixOS/nixpkgs/commit/03c9d2ad554dea09821848a1aef4137d510e2f97) | `` linux/hardened/patches/5.4: 5.4.242-hardened1 -> 5.4.243-hardened1 ``         |
| [`5e011d79`](https://github.com/NixOS/nixpkgs/commit/5e011d7966e8980563568ec7b698d2fcf1a79bb3) | `` linux/hardened/patches/5.15: 5.15.111-hardened1 -> 5.15.112-hardened1 ``      |
| [`aeaa6c28`](https://github.com/NixOS/nixpkgs/commit/aeaa6c28c5b436797d10770eaad3c0df9125b4b5) | `` linux/hardened/patches/5.10: 5.10.179-hardened1 -> 5.10.180-hardened1 ``      |
| [`6ce9746b`](https://github.com/NixOS/nixpkgs/commit/6ce9746babb74b5a96fa9930454f62a797b0fe35) | `` linux/hardened/patches/4.19: 4.19.282-hardened1 -> 4.19.283-hardened1 ``      |
| [`38ff81a6`](https://github.com/NixOS/nixpkgs/commit/38ff81a6d5737bc9a15a90dafc28f570eca171a3) | `` linux/hardened/patches/4.14: 4.14.314-hardened1 -> 4.14.315-hardened1 ``      |
| [`472de243`](https://github.com/NixOS/nixpkgs/commit/472de243e0f86222997c545ec3ef24eaa7d5139d) | `` linux_latest-libre: 19299 -> 19308 ``                                         |
| [`3bb1599a`](https://github.com/NixOS/nixpkgs/commit/3bb1599afc85b6c4b292625ac9f914fcd1200061) | `` linux-rt_5_15: 5.15.111-rt63 -> 5.15.113-rt64 ``                              |
| [`7d3ecc52`](https://github.com/NixOS/nixpkgs/commit/7d3ecc52b288ff4ee3b5ccba7594a1125446b1ba) | `` linux: 6.3.4 -> 6.3.5 ``                                                      |
| [`4f677242`](https://github.com/NixOS/nixpkgs/commit/4f677242b1a6e21a9666e6ffb0a5550dfd4e91b0) | `` linux: 6.1.30 -> 6.1.31 ``                                                    |
| [`9b8e1dbb`](https://github.com/NixOS/nixpkgs/commit/9b8e1dbb66bf8e013789fc275cf39671c6252f98) | `` linux: 5.4.243 -> 5.4.244 ``                                                  |
| [`d450c265`](https://github.com/NixOS/nixpkgs/commit/d450c265c5ea665846b4de1f79b79150a91d6e8d) | `` linux: 5.15.113 -> 5.15.114 ``                                                |
| [`6ec43cfc`](https://github.com/NixOS/nixpkgs/commit/6ec43cfc1970d893477e454d1e876e8f0a2e7da7) | `` linux: 5.10.180 -> 5.10.181 ``                                                |
| [`5ec4029b`](https://github.com/NixOS/nixpkgs/commit/5ec4029b2a9f661c66a5f0efe228ff84954aaf5e) | `` linux: 4.19.283 -> 4.19.284 ``                                                |
| [`f085e772`](https://github.com/NixOS/nixpkgs/commit/f085e77259072ae5d89df999cd0e84898fac6ae3) | `` linux: 4.14.315 -> 4.14.316 ``                                                |
| [`16f87c4c`](https://github.com/NixOS/nixpkgs/commit/16f87c4cdb1fe2388965cb5eb1f17e2d8192a0b9) | `` chromiumBeta: Fix the build with LLVM 16 by reverting a commit ``             |
| [`22c7651b`](https://github.com/NixOS/nixpkgs/commit/22c7651be85673519b6be5660a941d45667da823) | `` vimPlugins.nvim-treesitter: update grammars ``                                |
| [`0b975e9a`](https://github.com/NixOS/nixpkgs/commit/0b975e9ae5432ba2690e77c76359d9a0082ad658) | `` vimPlugins: update ``                                                         |
| [`8ef9bed8`](https://github.com/NixOS/nixpkgs/commit/8ef9bed8687df4f59a11efb16a57b66b125d93d7) | `` vimPlugins: remove deleted github repositories ``                             |