### PR TITLE
chore(flake/lanzaboote): `da243579` -> `e422970c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1685652233,
-        "narHash": "sha256-Dk9CQcrWqzty8t6zIFLjESjtCG0HMt6QdyaRQe598+Q=",
+        "lastModified": 1685709197,
+        "narHash": "sha256-ASoXZVoXj6L9PzNDfuDrAxrqaDuH7e1qTzdzkOODu4M=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "da24357977d65265977a25481d754e0e22a551c8",
+        "rev": "e422970c1bc3351bb7a20cf6e30e78d975280ed3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                               |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`88aeb61d`](https://github.com/nix-community/lanzaboote/commit/88aeb61d853953a3a5e4232c06db8777315630d3) | `` stub: upgrade to uefi-rs 0.22.0 `` |