### PR TITLE
chore(flake/nixpkgs): `e6351928` -> `dd498255`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -348,11 +348,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685655444,
-        "narHash": "sha256-6EujQNAeaUkWvpEZZcVF8qSfQrNVWFNNGbUJxv/A5a8=",
+        "lastModified": 1685836261,
+        "narHash": "sha256-rpxEPGeW4JZJcH58SQApJUtJ7w78VPtkF6Cut/Pq6Kg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e635192892f5abbc2289eaac3a73cdb249abaefd",
+        "rev": "dd4982554e18b936790da07c4ea2db7c7600f283",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`dd498255`](https://github.com/NixOS/nixpkgs/commit/dd4982554e18b936790da07c4ea2db7c7600f283) | `` hyperfine: 1.16.1 -> 0.17.0 (#235842) ``                                 |
| [`6ddd842a`](https://github.com/NixOS/nixpkgs/commit/6ddd842a4a90a700a6f997befd5f1d241f57873d) | `` python310Packages.bitarray: 2.7.3 -> 2.7.4 ``                            |
| [`12d0400e`](https://github.com/NixOS/nixpkgs/commit/12d0400e9b73c19145df3635a94e45ecc228dc09) | `` python310Packages.rns: 0.5.3 -> 0.5.4 ``                                 |
| [`037db8f0`](https://github.com/NixOS/nixpkgs/commit/037db8f0b6dc8d72818829fb933cdf62969f8b14) | `` qovery-cli: 0.58.15 -> 0.59.0 ``                                         |
| [`eacc2ade`](https://github.com/NixOS/nixpkgs/commit/eacc2adee83794177d181160c79b160b3a67b591) | `` kubedog: 0.9.11 -> 0.9.12 ``                                             |
| [`a1cfd90e`](https://github.com/NixOS/nixpkgs/commit/a1cfd90e10d129d093aa5917326718d43d0a3661) | `` thelounge: fix sqlite logging ``                                         |
| [`c99d4fc4`](https://github.com/NixOS/nixpkgs/commit/c99d4fc4d0bc5343cf7b7e6b94261082e6aefff3) | `` thelounge: reorder/cleanup imports ``                                    |
| [`449a4627`](https://github.com/NixOS/nixpkgs/commit/449a46278e821babb4fac2a39f669dbf3046e5f1) | `` strip-nondeterminism: fix zip handler ``                                 |
| [`f7d28825`](https://github.com/NixOS/nixpkgs/commit/f7d28825d3429e0635c8a9b0f6ae283802048c5f) | `` gh-markdown-preview: 1.4.0 -> 1.4.1 ``                                   |
| [`a903a11e`](https://github.com/NixOS/nixpkgs/commit/a903a11e38092b5f8c683cf7fdad102a7f37c84c) | `` swayfx: 0.3 -> 0.3.1 ``                                                  |
| [`b8c7d0de`](https://github.com/NixOS/nixpkgs/commit/b8c7d0de3107d8f7e4db4d70ff8d220d94da1ebe) | `` ferdium: 6.2.6 -> 6.3.0 ``                                               |
| [`03c74cf4`](https://github.com/NixOS/nixpkgs/commit/03c74cf46ebd9e913389f0875c1b3a6e529d2fb5) | `` ddosify: 1.0.1 -> 1.0.3 ``                                               |
| [`55936ead`](https://github.com/NixOS/nixpkgs/commit/55936ead43b9cfe0568694f46b49cea610811b42) | `` terragrunt: 0.45.16 -> 0.45.18 ``                                        |
| [`229e4bd2`](https://github.com/NixOS/nixpkgs/commit/229e4bd29a63ddeb2aed3cfa0a7f373b929a34a9) | `` jackett: 0.21.88 -> 0.21.114 ``                                          |
| [`98473585`](https://github.com/NixOS/nixpkgs/commit/9847358579aab54965520a742c7c960abece50b8) | `` odo: 3.10.0 -> 3.11.0 ``                                                 |
| [`b575d76c`](https://github.com/NixOS/nixpkgs/commit/b575d76ce129408f9765d59b8bc5d9e34d96d2df) | `` nixos/gdm: Do not require GTK for account-service-util ``                |
| [`3c7688a8`](https://github.com/NixOS/nixpkgs/commit/3c7688a81400685ec507fcaba4579b5017c0a7ec) | `` sing-geoip: use dbip-country-lite instead of unfree clash-geoip ``       |
| [`8b00d7f0`](https://github.com/NixOS/nixpkgs/commit/8b00d7f098eac0e1bb5eb52dad65146c251cdb13) | `` dbip-country-lite: init at 2023-06 ``                                    |
| [`8ebcb96e`](https://github.com/NixOS/nixpkgs/commit/8ebcb96e4ab9f54920396c6e1db6dd4738a902fe) | `` pre-commit: prevent propagating inputs ``                                |
| [`2bfb2f04`](https://github.com/NixOS/nixpkgs/commit/2bfb2f045a966f63a918d03afa61af3dbc0c552b) | `` pypi2nix: remove ``                                                      |
| [`2f181d6f`](https://github.com/NixOS/nixpkgs/commit/2f181d6f062e6bd0b794e7978a1ec56188be95bb) | `` python3.doc: build offline documentation ``                              |
| [`b15a887b`](https://github.com/NixOS/nixpkgs/commit/b15a887b59066953745fb10fc776d17bd361841a) | `` python3.pkgs.python_docs_theme: init at 2023.3.1 ``                      |
| [`4604fcea`](https://github.com/NixOS/nixpkgs/commit/4604fceae34c3b6c4f97f6fe64b50b75042fa0a9) | `` python311Packages.aiopvpc: 4.1.0 -> 4.2.1 ``                             |
| [`51b7a236`](https://github.com/NixOS/nixpkgs/commit/51b7a2368852877603d26094d8ea81173b68f1eb) | `` python311Packages.aiokafka: 0.8.0 -> 0.8.1 ``                            |
| [`bae4cfee`](https://github.com/NixOS/nixpkgs/commit/bae4cfeef94ea60fbb0e4fe9c49acf3ab60964c6) | `` python311Packages.aio-pika: 9.0.7 -> 9.1.2 ``                            |
| [`bb3fca1a`](https://github.com/NixOS/nixpkgs/commit/bb3fca1a870ef7184fadc441513159b0e02364d1) | `` pip-audit: 2.5.5 -> 2.5.6 ``                                             |
| [`604210ed`](https://github.com/NixOS/nixpkgs/commit/604210ed34edcab2f7c1d604e75889c6438b3d2d) | `` delta: 0.16.4 -> 0.16.5, add figsoda as a maintainer ``                  |
| [`808a56e5`](https://github.com/NixOS/nixpkgs/commit/808a56e56d07dad427fac535eb71a3cb01aa745c) | `` grpc-gateway: 2.15.2 -> 2.16.0 ``                                        |
| [`dcadcaf7`](https://github.com/NixOS/nixpkgs/commit/dcadcaf7f8888611e64cfb66223d10b2677336a7) | `` python311Packages.python-benedict: 0.30.1 -> 0.30.2 ``                   |
| [`05087faf`](https://github.com/NixOS/nixpkgs/commit/05087faf4d6f808fd5e619d9290ea36dc5f01dbd) | `` exodus: 23.5.8 -> 23.5.22 ``                                             |
| [`ff22fdef`](https://github.com/NixOS/nixpkgs/commit/ff22fdef1e004138dc7fc7f58fe4365134b4e53f) | `` gamepad-tool: init at 1.2 ``                                             |
| [`54ec98af`](https://github.com/NixOS/nixpkgs/commit/54ec98af128f4a53c8113bf5cd55e745658ef176) | `` vimPlugins.nvim-treesitter: update grammars ``                           |
| [`cacbc872`](https://github.com/NixOS/nixpkgs/commit/cacbc872a9a0b30dcf692bfc815afe7b68d71449) | `` vimPlugins: resolve github repository redirects ``                       |
| [`37ef2f1e`](https://github.com/NixOS/nixpkgs/commit/37ef2f1e2f3230abeca796e89142e23a70b8aced) | `` vimPlugins: update ``                                                    |
| [`94c628ca`](https://github.com/NixOS/nixpkgs/commit/94c628ca003846a580c2b003327b4f4f6942e1f5) | `` python310Packages.aioslimproto: 2.2.1 -> 2.2.2 ``                        |
| [`62629254`](https://github.com/NixOS/nixpkgs/commit/626292547cac3cef3221d3e06ff1c8361769dd64) | `` reproxy: 0.11.0 -> 1.0.0 ``                                              |
| [`5e944d53`](https://github.com/NixOS/nixpkgs/commit/5e944d53bd4a7b55c3bd2667062a131f1c799654) | `` talosctl: 1.4.4 -> 1.4.5 ``                                              |
| [`bddbcf5d`](https://github.com/NixOS/nixpkgs/commit/bddbcf5df155eda61341fcf8a27c6bc5381e95bf) | `` sccache: 0.5.1 -> 0.5.2 ``                                               |
| [`79a27706`](https://github.com/NixOS/nixpkgs/commit/79a277061338560b3a8f8619d5c05e0e95e12188) | `` makemkv 1.17.3 -> 1.17.4 ``                                              |
| [`cc0d724c`](https://github.com/NixOS/nixpkgs/commit/cc0d724c2db97ba2ec057cc1c2f23662734d2abd) | `` hunt: 1.7.6 -> 2.0.0 ``                                                  |
| [`c3d6e8a8`](https://github.com/NixOS/nixpkgs/commit/c3d6e8a8a76e01490d2727363723e06e0b720710) | `` python310Packages.minio: 7.1.14 -> 7.1.15 ``                             |
| [`5b721f59`](https://github.com/NixOS/nixpkgs/commit/5b721f59b1392a465c095eb527f13b8e51fd1e80) | `` nodePackages.@babel/cli: Init at 7.21.5. ``                              |
| [`94eb9a52`](https://github.com/NixOS/nixpkgs/commit/94eb9a52effd62ce8bbe9d2a5ee8bf2723a32907) | `` operator-sdk: 1.28.1 -> 1.29.0 ``                                        |
| [`459d9a66`](https://github.com/NixOS/nixpkgs/commit/459d9a66a216cb30130aea32a3f1e87e270bd1df) | `` bearer: 1.8.1 -> 1.9.0 ``                                                |
| [`ec232e69`](https://github.com/NixOS/nixpkgs/commit/ec232e6930b0f981b8f5f1f87bc46e4d32917bcd) | `` arcanist: 20230401 -> 20230530 ``                                        |
| [`1b3317ce`](https://github.com/NixOS/nixpkgs/commit/1b3317ce17fce8241d7bcd49954b5518ece721a9) | `` cargo-public-api: 0.30.0 -> 0.31.0 ``                                    |
| [`23353f80`](https://github.com/NixOS/nixpkgs/commit/23353f802559cb41bf7cbe0ea6e44d49ef45f6b8) | `` mongodb-4_4: 4.4.19 -> 4.4.22 ``                                         |
| [`ba3d0f7a`](https://github.com/NixOS/nixpkgs/commit/ba3d0f7a95ca81be992e485b67c574b1c059c34a) | `` nixos/gitea: requires database ``                                        |
| [`3af487a9`](https://github.com/NixOS/nixpkgs/commit/3af487a9f70c7701dae19d28255189883c29bf5e) | `` python310Packages.apycula: add changelog to meta ``                      |
| [`dbb0330c`](https://github.com/NixOS/nixpkgs/commit/dbb0330c64972a4606c1f6f5203f822b9ee31aa0) | `` josh: 22.06.22 -> 23.02.14 ``                                            |
| [`789271b2`](https://github.com/NixOS/nixpkgs/commit/789271b2c8a4cc01398316c211b0d597cde8324d) | `` python3Packages.hickle: fixed failing unit tests ``                      |
| [`85cd8ee1`](https://github.com/NixOS/nixpkgs/commit/85cd8ee17c6675a2c094b4173681b155764c6e8a) | `` cnspec: 8.11.0 -> 8.12.1 ``                                              |
| [`a5dcc37c`](https://github.com/NixOS/nixpkgs/commit/a5dcc37cd41dfda3c10ce4acd85526d05935389d) | `` php82Packages.composer: 2.5.5 -> 2.5.7 ``                                |
| [`ac5dd2f1`](https://github.com/NixOS/nixpkgs/commit/ac5dd2f150a8bc16708885e539573b21dafa4c51) | `` python310Packages.coinmetrics-api-client: 2023.5.2.20 -> 2023.5.26.17 `` |
| [`8fd5c68f`](https://github.com/NixOS/nixpkgs/commit/8fd5c68f51c8270ca794aa1f62b9cc99d57ebb97) | `` lightningcss: 1.19.0 → 1.20.0 ``                                         |
| [`e74c4962`](https://github.com/NixOS/nixpkgs/commit/e74c4962109d2594518291e4974e85e755067216) | `` python310Packages.apycula: 0.8 -> 0.8.1 ``                               |
| [`c9a4e738`](https://github.com/NixOS/nixpkgs/commit/c9a4e7388420bc9b93b3759b7f144adc3d574f33) | `` spotify-player: 0.13.1 -> 0.14.1 ``                                      |
| [`92c2458f`](https://github.com/NixOS/nixpkgs/commit/92c2458f00e0377dfffb02e7b998599e7afcbf19) | `` python310Packages.atlassian-python-api: 3.37.0 -> 3.38.0 ``              |
| [`70ce7f48`](https://github.com/NixOS/nixpkgs/commit/70ce7f48aaffd8e443ca688341c16c516b9fe2f0) | `` kdiff3: 1.10.1 -> 1.10.4 ``                                              |
| [`1bdd709c`](https://github.com/NixOS/nixpkgs/commit/1bdd709caaabe3e46e6694f54c18e5ecb202fa57) | `` python310Packages.fastavro: fix version ``                               |
| [`344f0a73`](https://github.com/NixOS/nixpkgs/commit/344f0a7361d69c8b933b0a9ea1190b690f81aabd) | `` gotrue-supabase: 2.69.1 -> 2.69.2 ``                                     |
| [`f96dd8db`](https://github.com/NixOS/nixpkgs/commit/f96dd8dbe51cd3c2fabc28f6550104084bd8b50c) | `` curlie: 1.6.9 -> 1.7.1 ``                                                |
| [`80db190c`](https://github.com/NixOS/nixpkgs/commit/80db190c9f51cdd620f2614cd2f40fa8f58d5742) | `` maestral: 1.7.2 -> 1.7.3 ``                                              |
| [`dc851dae`](https://github.com/NixOS/nixpkgs/commit/dc851daecc44e408605659d31a4222e027047edf) | `` orbiton: 2.62.0 -> 2.62.1 ``                                             |
| [`743ac20a`](https://github.com/NixOS/nixpkgs/commit/743ac20a6d7dbca45c5a90b67a375aa92f805c42) | `` python310Packages.ansible-compat: 4.0.5 -> 4.1.2 ``                      |
| [`0a7144ca`](https://github.com/NixOS/nixpkgs/commit/0a7144cada3daa172cc096a08f68c3b35a10933a) | `` xml2rfc: 3.17.1 -> 3.17.2 ``                                             |
| [`e5a3b488`](https://github.com/NixOS/nixpkgs/commit/e5a3b48834ef9c53442d947d893fb2834808c65c) | `` python310Packages.pytest-relaxed: 2.0.0 -> 2.0.1 ``                      |
| [`0cad02d6`](https://github.com/NixOS/nixpkgs/commit/0cad02d6da928e86307df9095c1b0a7d7f696d54) | `` emacsPackages.acm-terminal: 20230215.414 -> 20230601.1326 ``             |
| [`44f6f0e4`](https://github.com/NixOS/nixpkgs/commit/44f6f0e4041ae753b7d5d2aced6e978160d0fa1c) | `` emacsPackages.lsp-bridge: 20230424.1642 -> 20230603.345 ``               |
| [`e023125b`](https://github.com/NixOS/nixpkgs/commit/e023125bb09f2570ae044c7d3e9298d9dee68deb) | `` rootlesskit: 1.1.0 -> 1.1.1 ``                                           |
| [`7b006dd9`](https://github.com/NixOS/nixpkgs/commit/7b006dd9b84da5c7596f0766868dc888006ef4ab) | `` has: init at 1.4.0 ``                                                    |
| [`0829d1ba`](https://github.com/NixOS/nixpkgs/commit/0829d1baaee34db9a90a618de9911c56fb1f3915) | `` terraform-providers.tencentcloud: 1.81.4 -> 1.81.5 ``                    |
| [`8e34bb2e`](https://github.com/NixOS/nixpkgs/commit/8e34bb2e8c4261edb4925d829826f4c0a5f44851) | `` terraform-providers.oci: 4.122.0 -> 4.123.0 ``                           |
| [`d987ad27`](https://github.com/NixOS/nixpkgs/commit/d987ad2782b8415e2e2193763c401d29f3c16365) | `` terraform-providers.snowflake: 0.65.0 -> 0.66.1 ``                       |
| [`ef0bb6b1`](https://github.com/NixOS/nixpkgs/commit/ef0bb6b1e6b8385170d41f14953d119598018e3c) | `` terraform-providers.alicloud: 1.205.0 -> 1.206.0 ``                      |
| [`466a666d`](https://github.com/NixOS/nixpkgs/commit/466a666d5588e55e6d20066bc59c55835c3d4246) | `` terraform-providers.kubernetes: 2.20.0 -> 2.21.0 ``                      |
| [`8db748fc`](https://github.com/NixOS/nixpkgs/commit/8db748fc7e3dd2383155af1e7854f36e5444b65a) | `` python310Packages.huggingface-hub: 0.14.1 -> 0.15.1 ``                   |
| [`1ab30dc4`](https://github.com/NixOS/nixpkgs/commit/1ab30dc4bf1050dc270b9e7f8b4ab845a45c8a30) | `` speedtest-go: 1.6.0 -> 1.6.2 ``                                          |
| [`9e0974ed`](https://github.com/NixOS/nixpkgs/commit/9e0974edcd8b7853e622ef2ce95a0ec5691f2979) | `` werf: 1.2.238 -> 1.2.239 ``                                              |
| [`b0fb43ab`](https://github.com/NixOS/nixpkgs/commit/b0fb43ab750902426eca3aed5e2c67fdd5426cdb) | `` octosql: 0.12.1 -> 0.12.2 ``                                             |
| [`ecf3a99c`](https://github.com/NixOS/nixpkgs/commit/ecf3a99c6dae9c782691ebbc196683c2a09d20ca) | `` checkmate: 0.8.4 -> 0.9.3 ``                                             |
| [`78576e1a`](https://github.com/NixOS/nixpkgs/commit/78576e1a6fc61ff80253ddcef6fbe1c86abf066e) | `` windmill: init at 1.100.1 ``                                             |
| [`0c6a3aa6`](https://github.com/NixOS/nixpkgs/commit/0c6a3aa6b7a7b03b27d8eeec9d8d6ff1245f22c9) | `` swagger-cli: init at 4.0.4 ``                                            |
| [`4ff3a579`](https://github.com/NixOS/nixpkgs/commit/4ff3a5795b66dfb34107db0d427584835c850aad) | `` nixos/tests/prometheus-exporters: add graphite ``                        |
| [`dff2e184`](https://github.com/NixOS/nixpkgs/commit/dff2e184f42537f1f67d20a98442f2bc17eabf23) | `` nixos/prometheus.exporters.graphite: init ``                             |
| [`ee9d2678`](https://github.com/NixOS/nixpkgs/commit/ee9d2678d77cf9359df58b16570daf8a1d8ac9d8) | `` prometheus-graphite-exporter: init at 0.13.3 ``                          |
| [`147668b8`](https://github.com/NixOS/nixpkgs/commit/147668b8cf978878c3456a0bc5347c06edfad0fb) | `` nixos/sitespeed-io: init ``                                              |
| [`cf615b05`](https://github.com/NixOS/nixpkgs/commit/cf615b059a915874572a1474b50a489c03dad849) | `` sitespeed-io: init at 27.3.1 ``                                          |
| [`cf79a07e`](https://github.com/NixOS/nixpkgs/commit/cf79a07e56b4b42bada6e2eec0fd41223d35ab1e) | `` balena-cli: 16.2.7 -> 16.5.0 ``                                          |
| [`1ee6b374`](https://github.com/NixOS/nixpkgs/commit/1ee6b3749e92cba6a07f5edde9459c25bb955854) | `` zprint: 1.2.5 -> 1.2.6 ``                                                |
| [`b28a63d6`](https://github.com/NixOS/nixpkgs/commit/b28a63d612d7195e6fb0b43b60ce5d3237c89169) | `` lagrange-tui: 1.16.1 -> 1.16.2 ``                                        |
| [`8f93f851`](https://github.com/NixOS/nixpkgs/commit/8f93f851f412cea23f342b1bebee3bcc04fa8bd0) | `` nexttrace: 1.1.5 -> 1.1.6 ``                                             |
| [`eeb2a479`](https://github.com/NixOS/nixpkgs/commit/eeb2a479da524c49c6d5473ca0dc39f0f79ecef8) | `` whatsapp-emoji-font: 2.22.8.79-1 -> 2.23.2.72-1 ``                       |
| [`67636994`](https://github.com/NixOS/nixpkgs/commit/676369941c11c164502d1beadc00518e20d62bf1) | `` shopware-cli: 0.1.73 -> 0.1.74 ``                                        |
| [`aae46b3b`](https://github.com/NixOS/nixpkgs/commit/aae46b3b3437319cca2335baed7d87b90eef1022) | `` vokoscreen: use ffmpeg full variant ``                                   |
| [`4fb5325f`](https://github.com/NixOS/nixpkgs/commit/4fb5325fdffde1eb457d819a46d8fe08ee1ca4a2) | `` telegram-desktop: 4.8.1 -> 4.8.3 ``                                      |
| [`9eee76ae`](https://github.com/NixOS/nixpkgs/commit/9eee76ae0d5961994183eba52326320e467b74b4) | `` telegram-desktop: use nix-update-script ``                               |
| [`2be3cc84`](https://github.com/NixOS/nixpkgs/commit/2be3cc84acdfa47712c0c4714d9f5550eada4338) | `` panoply: 5.2.6 -> 5.2.7 ``                                               |
| [`ea6de8fa`](https://github.com/NixOS/nixpkgs/commit/ea6de8fa4f6ee2944edb2f6d4f475423af23260e) | `` martin: 0.8.3 -> 0.8.4 ``                                                |
| [`7e91fee0`](https://github.com/NixOS/nixpkgs/commit/7e91fee072d093a73535ef698ffc3df994688df0) | `` crd2pulumi: 1.2.4 -> 1.2.5 ``                                            |
| [`5ff8cfd9`](https://github.com/NixOS/nixpkgs/commit/5ff8cfd9e6133283068febcf361840099b95a06b) | `` delta: 0.15.1 -> 0.16.4 ``                                               |
| [`a9be9ddb`](https://github.com/NixOS/nixpkgs/commit/a9be9ddb0e1828f65bd3909c2f1118fdfe4712ab) | `` calc: 2.14.1.5 -> 2.14.1.6 ``                                            |
| [`22513042`](https://github.com/NixOS/nixpkgs/commit/22513042e6c2905f3f749088a2c4aaeb650a1716) | `` nixos/syncthing: Remove unnecessary patch note ``                        |
| [`2c4779d1`](https://github.com/NixOS/nixpkgs/commit/2c4779d1065194208bc944244b2c449bef8ec922) | `` home-assistant: Fix python-vultr src ``                                  |
| [`c12c6247`](https://github.com/NixOS/nixpkgs/commit/c12c624739f42a7c01b22473de3df45475454353) | `` usql: 0.14.6 -> 0.14.7 ``                                                |
| [`78077c91`](https://github.com/NixOS/nixpkgs/commit/78077c91b98205a98e676994f20fa7e2ccc20405) | `` static-web-server: 2.16.0 -> 2.17.0 ``                                   |
| [`44a7bea5`](https://github.com/NixOS/nixpkgs/commit/44a7bea53cab76c10eef840bbe7b15873252c93a) | `` automatic-timezoned: 1.0.93 -> 1.0.94 ``                                 |
| [`15eea4aa`](https://github.com/NixOS/nixpkgs/commit/15eea4aafdd941ab4ffe44075f7da70970dcb48f) | `` checkSSLCert: 2.69.0 -> 2.70.0 ``                                        |
| [`f9959e8a`](https://github.com/NixOS/nixpkgs/commit/f9959e8a6e69b387b1c210bb8de33b0385c20ffc) | `` codeql: 2.13.1 -> 2.13.3 ``                                              |
| [`bac8045d`](https://github.com/NixOS/nixpkgs/commit/bac8045d33f998b8236fbd4df96626c9aec53d95) | `` python311Packages.asyncwhois: 1.0.5 -> 1.0.6 ``                          |
| [`6a933d13`](https://github.com/NixOS/nixpkgs/commit/6a933d138b71f5b1681286938f52568c9ea6a781) | `` namaka: 0.1.1 -> 0.2.0 ``                                                |
| [`fcbe7d56`](https://github.com/NixOS/nixpkgs/commit/fcbe7d56036ed34a21e25680afbae17b268c4a43) | `` linux_xanmod: 6.3.3 -> 6.3.5 ``                                          |
| [`7be69384`](https://github.com/NixOS/nixpkgs/commit/7be6938489bbe266b423e556c5146143ee095d85) | `` linux_xanmod: 6.1.30 -> 6.1.31 ``                                        |