### PR TITLE
chore(flake/deploy-rs): `c8018991` -> `65211db6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683779844,
-        "narHash": "sha256-sIeOU0GsCeQEn5TpqE/jFRN4EGsPsjqVRsPdrzIDABM=",
+        "lastModified": 1685948350,
+        "narHash": "sha256-1FldJ059so0X/rScdbIiOlQbjjSNCCTdj2cUr5pHU4A=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "c80189917086e43d49eece2bd86f56813500a0eb",
+        "rev": "65211db63ba1199f09b4c9f27e5eba5ec50d76ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                                                 |
| --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`8ef5b948`](https://github.com/serokell/deploy-rs/commit/8ef5b948e308d809cb7882036007e0ef9743acc8) | `` fixup! [#210] Add activation script for darwin system and provide a usage example `` |
| [`f4062956`](https://github.com/serokell/deploy-rs/commit/f4062956807a0a9703de166ac4a160a7aca1133c) | `` [#210] Add activation script for darwin system and provide a usage example ``        |