### PR TITLE
chore(flake/pre-commit-hooks): `a117a1cd` -> `6881eb2a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -409,11 +409,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1685970613,
-        "narHash": "sha256-sMbR4zPciUfQ6YHt6GNVxT/yhWJKngvZo8qHzYkaU6E=",
+        "lastModified": 1686050334,
+        "narHash": "sha256-R0mczWjDzBpIvM3XXhO908X5e2CQqjyh/gFbwZk/7/Q=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "a117a1cd2c280bf8d499f26370fddfe1923e75e6",
+        "rev": "6881eb2ae5d8a3516e34714e7a90d9d95914c4dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                               |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`a9f20d6d`](https://github.com/cachix/pre-commit-hooks.nix/commit/a9f20d6d1da97624e83a0053b69547b180e0c816) | `` fix(lua-ls): copied path to .luarc.json ``         |
| [`0af49116`](https://github.com/cachix/pre-commit-hooks.nix/commit/0af49116a254469c13b2f6946a519e39e268e245) | `` fix(lua-ls): correct typo ``                       |
| [`ac27fe1d`](https://github.com/cachix/pre-commit-hooks.nix/commit/ac27fe1daa19db5b78fda1d947de0b6859f21ddd) | `` Add workaround for when `core.hooksPath` is set `` |