### PR TITLE
chore(flake/home-manager): `28614ed7` -> `39c7d0a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -209,11 +209,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685999310,
-        "narHash": "sha256-gaRMZhc7z4KeU/xS3IWv3kC+WhVcAXOLXXGKLe5zn1Y=",
+        "lastModified": 1686142265,
+        "narHash": "sha256-IP0xPa0VYqxCzpqZsg3iYGXarUF+4r2zpkhwdHy9WsM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "28614ed7a1e3ace824c122237bdc0e5e0b62c5c3",
+        "rev": "39c7d0a97a77d3f31953941767a0822c94dc01f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`39c7d0a9`](https://github.com/nix-community/home-manager/commit/39c7d0a97a77d3f31953941767a0822c94dc01f5) | `` imv: add module (#4032) `` |
| [`3512a6da`](https://github.com/nix-community/home-manager/commit/3512a6dafb7836cfceef00dcb29ce6f01c2ce280) | `` rtx: add module (#4051) `` |