### PR TITLE
chore(flake/nixpkgs): `7409480d` -> `4729ffac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -348,11 +348,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685931219,
-        "narHash": "sha256-8EWeOZ6LKQfgAjB/USffUSELPRjw88A+xTcXnOUvO5M=",
+        "lastModified": 1686020360,
+        "narHash": "sha256-Wee7lIlZ6DIZHHLiNxU5KdYZQl0iprENXa/czzI6Cj4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7409480d5c8584a1a83c422530419efe4afb0d19",
+        "rev": "4729ffac6fd12e26e5a8de002781ffc49b0e94b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`8549e37e`](https://github.com/NixOS/nixpkgs/commit/8549e37ebcff8916da2977416941dc521f24da16) | `` bilibili: 1.10.1-1 -> 1.10.1-4 ``                                                        |
| [`e58b4a10`](https://github.com/NixOS/nixpkgs/commit/e58b4a101ba50a0a7e10015ec9996c39038e94c9) | `` bun: 0.6.6 -> 0.6.7 ``                                                                   |
| [`14d96ff6`](https://github.com/NixOS/nixpkgs/commit/14d96ff665fb5f95b97f828c93b64a7159edd632) | `` icewm: 3.3.5 -> 3.4.0 ``                                                                 |
| [`e0402159`](https://github.com/NixOS/nixpkgs/commit/e0402159c1329156d6b225fd4cf2e357b8c05bca) | `` chezmoi: 2.33.6 -> 2.34.0 ``                                                             |
| [`1e3c63e8`](https://github.com/NixOS/nixpkgs/commit/1e3c63e8ad1c25ce9d00e833b3550bcb2d0c8804) | `` gobgp: 3.14.0 -> 3.15.0 ``                                                               |
| [`3219e1b6`](https://github.com/NixOS/nixpkgs/commit/3219e1b609291884efd13ded7b3a04cb1cd3f9a6) | `` netbird: 0.20.8 -> 0.21.0 ``                                                             |
| [`374bc6b4`](https://github.com/NixOS/nixpkgs/commit/374bc6b470df5a4057b09a9eacb49559c83c9a7a) | `` duckscript: 0.8.18 -> 0.8.19 ``                                                          |
| [`2f3f758b`](https://github.com/NixOS/nixpkgs/commit/2f3f758b346ed03be56527ece34cad22ce31187f) | `` sarasa-gothic: 0.40.7 -> 0.41.0 ``                                                       |
| [`58feedd1`](https://github.com/NixOS/nixpkgs/commit/58feedd1df098d6daa9d78f2bf9bf0e6fb0aeb41) | `` erlang-ls: 0.46.2 -> 0.47.1 ``                                                           |
| [`03951cc2`](https://github.com/NixOS/nixpkgs/commit/03951cc24a04b6662083bfc62f7b4188d4e9a73b) | `` _1password-gui: 8.10.6 -> 8.10.7 ``                                                      |
| [`4fd6968b`](https://github.com/NixOS/nixpkgs/commit/4fd6968b01aa07064156dfba9eb66619bdff71b2) | `` python310Packages.fenics: migrate to boost172 ``                                         |
| [`d334c136`](https://github.com/NixOS/nixpkgs/commit/d334c136dedb03b4ff8292a2a14d16401ce3abd1) | `` codespelunker: init at 1.0.0 ``                                                          |
| [`c282d8e5`](https://github.com/NixOS/nixpkgs/commit/c282d8e5a39d4760fe487e1c59d7a611192a56bf) | ``  clickhouse: compress src to not exceed hydra limit (#236060) ``                         |
| [`d7d559e9`](https://github.com/NixOS/nixpkgs/commit/d7d559e9dc9d0dc3928889bb157890203416c042) | `` python310Packages.asyncmy: 0.2.7 -> 0.2.8 ``                                             |
| [`7b48fd90`](https://github.com/NixOS/nixpkgs/commit/7b48fd902d695e3a100c34912b7e5323ecbc1be7) | `` python310Packages.pytest-testmon: 2.0.6 -> 2.0.8 ``                                      |
| [`491a6bed`](https://github.com/NixOS/nixpkgs/commit/491a6bed5f720ef335353fc85d395f73a5dd654b) | `` python310Packages.pydrive2: 1.15.3 -> 1.15.4 ``                                          |
| [`802dccb9`](https://github.com/NixOS/nixpkgs/commit/802dccb900b9b86a210cfc849b1862be01b32f9b) | `` vimPlugins.nvim-treesitter: update grammars ``                                           |
| [`1d72634c`](https://github.com/NixOS/nixpkgs/commit/1d72634c0aaa6a6fa287b75b4382dedb5924cb74) | `` vimPlugins: resolve github repository redirects ``                                       |
| [`aae1c913`](https://github.com/NixOS/nixpkgs/commit/aae1c913c8c2265af445a84c4babe56c6d6e7c90) | `` vimPlugins: update ``                                                                    |
| [`6eea0513`](https://github.com/NixOS/nixpkgs/commit/6eea0513e4b62703062356442ce28f3817b4448b) | `` python310Packages.wagtail-factories: 4.0.0 -> 4.1.0 ``                                   |
| [`c9c6853c`](https://github.com/NixOS/nixpkgs/commit/c9c6853ceda3b2027a1f2490e8ecded2854d7240) | `` rye: unstable-2023-04-23 -> 0.6.0 ``                                                     |
| [`5c816ce3`](https://github.com/NixOS/nixpkgs/commit/5c816ce341d32b10f7900e7e966b8b7694d33525) | `` python3Packages.apache-airflow: add entry to python-aliases.nix declaring its removal `` |
| [`70c41b8d`](https://github.com/NixOS/nixpkgs/commit/70c41b8db192c8d807a9e2bee6dfa543237be9fe) | `` python310Packages.apscheduler: 3.10.0 -> 3.10.1 ``                                       |
| [`08126bf3`](https://github.com/NixOS/nixpkgs/commit/08126bf314038095936690896a81f0d6a7385b4e) | `` apache-airflow: remove from main pythonPackages ``                                       |
| [`29112957`](https://github.com/NixOS/nixpkgs/commit/29112957e03fade73fc1f318f3ced5f9c7e8d049) | `` libsForQt5.kimageannotator: 0.6.0 -> 0.6.1 ``                                            |
| [`a6ccec37`](https://github.com/NixOS/nixpkgs/commit/a6ccec371af23fe382170e623eef70d9e2d1f115) | `` python310Packages.django_4: 4.2.1 -> 4.2.2 ``                                            |
| [`05ba2c2a`](https://github.com/NixOS/nixpkgs/commit/05ba2c2a0112c9c3c7f6380975bd344248d5ce91) | `` cardboard: set meta.knownVulnerabilities ``                                              |
| [`573b91a2`](https://github.com/NixOS/nixpkgs/commit/573b91a20db4b6000f9f411e80e734a8c8ec2145) | `` cargo-shuttle: 0.17.0 -> 0.18.0 ``                                                       |
| [`4f9b6e18`](https://github.com/NixOS/nixpkgs/commit/4f9b6e18708359d0906bda81b3c805ad17603de2) | `` speedtest-go: 1.6.2 -> 1.6.3 ``                                                          |
| [`4a5db704`](https://github.com/NixOS/nixpkgs/commit/4a5db704ee15647b738c22f90525ddc128614683) | `` aaaaxy: 1.4.2 -> 1.4.6 ``                                                                |
| [`9b804b89`](https://github.com/NixOS/nixpkgs/commit/9b804b8941f64fc979470081e7c2048934a88c77) | `` cudaPackages.cudatoolkit: mark libnvrtc-builtins needed for libnvrtc ``                  |
| [`d083027e`](https://github.com/NixOS/nixpkgs/commit/d083027ea596861f06ed3cf4f274fd857047c24a) | `` firefox-esr-102-unwrapped: 102.11.0esr -> 102.12.0esr ``                                 |
| [`8030e154`](https://github.com/NixOS/nixpkgs/commit/8030e154caa9971aa4387e1bdb25f8af1b0c6355) | `` firefox-bin-unwrapped: 113.0.2 -> 114.0 ``                                               |
| [`1c56e6a8`](https://github.com/NixOS/nixpkgs/commit/1c56e6a840c6be18da089b93c102a06fedfb8562) | `` firefox-unwrapped: 113.0.2 -> 114.0 ``                                                   |
| [`9f3e0de1`](https://github.com/NixOS/nixpkgs/commit/9f3e0de184cd5efa6fe7012db2a3d6a98f6907c7) | `` cypthon: moduralize so it can be called with other versions ``                           |
| [`b4222d66`](https://github.com/NixOS/nixpkgs/commit/b4222d66617edc4eb3e31fd515c0704165eae806) | `` python: add conditionals to be able to compile with 3.6 or older ``                      |
| [`a1caaaf7`](https://github.com/NixOS/nixpkgs/commit/a1caaaf7a432c85f84d92371d76a22020510cd12) | `` libnest2d: unpin boost174 ``                                                             |
| [`6f6b3e3f`](https://github.com/NixOS/nixpkgs/commit/6f6b3e3f1bbc85705a65ea3e02e21625e0156f4f) | `` librime: unpin boost174 ``                                                               |
| [`eaf0edf4`](https://github.com/NixOS/nixpkgs/commit/eaf0edf4af0586a381220fca9e0a692a0f83e7c0) | `` ycmd: unpin boost174 ``                                                                  |
| [`af702af3`](https://github.com/NixOS/nixpkgs/commit/af702af3527f37f3c47fd765f82053092b5572c1) | `` cpp-netlib: unpin boost169 ``                                                            |
| [`da072c0d`](https://github.com/NixOS/nixpkgs/commit/da072c0d594456cd309f79785b4a97408e3562ac) | `` gluesql: init at 0.14.0 ``                                                               |
| [`6a050b80`](https://github.com/NixOS/nixpkgs/commit/6a050b80fa37f59ca8de60170a0571cd85cb78df) | `` fetchMixDeps: transition to hash ``                                                      |
| [`b28dd99d`](https://github.com/NixOS/nixpkgs/commit/b28dd99d9e1e255172b7e95813c83b23695a941a) | `` rgp: 1.15 -> 1.15.1 ``                                                                   |
| [`e86547dd`](https://github.com/NixOS/nixpkgs/commit/e86547dd43445bb31e56067543ccf6022980215a) | `` blink: use checkTarget ``                                                                |
| [`ba9cb938`](https://github.com/NixOS/nixpkgs/commit/ba9cb93813ec9e912f6f1ba9b13eddbabe476299) | `` Revert "emscripten: 3.1.24 -> 3.1.39" (part of PR #229718) ``                            |
| [`fe6850b6`](https://github.com/NixOS/nixpkgs/commit/fe6850b67cbe820997532fa2021e323d04740b3d) | `` Revert "binaryen: 112 -> 113" (part of PR #229718) ``                                    |
| [`0c2d8f11`](https://github.com/NixOS/nixpkgs/commit/0c2d8f11c01457cc65b6390dac376f303d365dfe) | `` monotone: unpin boost170 ``                                                              |
| [`465a8b33`](https://github.com/NixOS/nixpkgs/commit/465a8b33d508ccc32610272e149eec2964177526) | `` nerdfonts: 3.0.1 -> 3.0.2 ``                                                             |
| [`11f7b66f`](https://github.com/NixOS/nixpkgs/commit/11f7b66fdf3a094bc5499f10e1bf34717e4382b3) | `` filebrowser: init at 2.23.0 ``                                                           |
| [`e695f6af`](https://github.com/NixOS/nixpkgs/commit/e695f6af174339c7e3c53ad0254323b8464ea9a9) | `` python3Packages.geopandas: 0.13.0 -> 0.13.1 ``                                           |
| [`8d630481`](https://github.com/NixOS/nixpkgs/commit/8d630481b36500d65d6b5b8bb5e419e0314bb00b) | `` mkvtoolnix: 76.0 -> 77.0 ``                                                              |
| [`50511e0a`](https://github.com/NixOS/nixpkgs/commit/50511e0a272f7f3ddc80277601b8f5c70615cb70) | `` ansible-language-server: 1.0.4 -> 1.0.5 ``                                               |
| [`522463b4`](https://github.com/NixOS/nixpkgs/commit/522463b4f22f04ee870cff8b8eb1c80b0ae3b6a9) | `` python310Packages.pyopengl: unbreak on darwin ``                                         |
| [`748cb091`](https://github.com/NixOS/nixpkgs/commit/748cb0913f4d40f21406aaeaeb06737630ad939f) | `` rabbitmq-server: 3.11.10 -> 3.12.0 ``                                                    |
| [`f3e5af36`](https://github.com/NixOS/nixpkgs/commit/f3e5af3683d16e1fc1ae928f0a41f333f2e64f68) | `` alacritty: unbreak on darwin ``                                                          |
| [`a68ba824`](https://github.com/NixOS/nixpkgs/commit/a68ba8249129c9b48066cc04d16d0cce2bcb71f4) | `` diesel-cli: 2.0.1 -> 2.1.0 ``                                                            |
| [`0d8edf79`](https://github.com/NixOS/nixpkgs/commit/0d8edf794256da892a3b49cd99593f39d64219dd) | `` python311Packages.blinkpy: 0.20.0 -> 0.21.0 ``                                           |
| [`72a51aa1`](https://github.com/NixOS/nixpkgs/commit/72a51aa1b1c7a32cf3fa2e93a801d6df4bc378f5) | `` python311Packages.pyipp: 0.13.0 -> 0.14.1 ``                                             |
| [`4e59b918`](https://github.com/NixOS/nixpkgs/commit/4e59b91865dfe66ac336ecbd757253c04dfe6a3b) | `` flrig: 2.0.0 -> 2.0.01 ``                                                                |
| [`898d1c18`](https://github.com/NixOS/nixpkgs/commit/898d1c18f560a20c3749bcf1d7f4dea3ca745cc4) | `` python311Packages.getmac: 0.9.3 -> 0.9.4 ``                                              |
| [`77318633`](https://github.com/NixOS/nixpkgs/commit/77318633ba6b2eb2e0c32417ad03244397624edf) | `` python311Packages.pyquil: 3.5.2 -> 3.5.4 ``                                              |
| [`1c6dd060`](https://github.com/NixOS/nixpkgs/commit/1c6dd06094ebbd959974aee877e4e77c32851690) | `` python311Packages.peaqevcore: 18.0.6 -> 18.1.1 ``                                        |
| [`b97dce16`](https://github.com/NixOS/nixpkgs/commit/b97dce16bdfc480ee761b3a3f906c0ccabda93b8) | `` python311Packages.dvc-data: 0.54.2 -> 0.54.3 ``                                          |
| [`0bc9fe18`](https://github.com/NixOS/nixpkgs/commit/0bc9fe18cfb9d9780c8d08c44c681a3337c5b464) | `` unparam: unstable-2021-12-14 -> unstable-2023-03-12 ``                                   |
| [`2bfa0ebd`](https://github.com/NixOS/nixpkgs/commit/2bfa0ebd131dc2ee8fa077a87401d8bd9c94ca72) | `` blink: fix build on x86_64-darwin ``                                                     |
| [`92fae8aa`](https://github.com/NixOS/nixpkgs/commit/92fae8aa90a6a7b69a684342c916a888e14ea253) | `` dnsx: 1.1.1 -> 1.1.4 ``                                                                  |
| [`a49f2aa0`](https://github.com/NixOS/nixpkgs/commit/a49f2aa0450a6681ef6aaf4fc62562d475103513) | `` python310Packages.imageio: unbreak on darwin ``                                          |
| [`4a1b4968`](https://github.com/NixOS/nixpkgs/commit/4a1b4968e368591a0b598ff678d61afa6fc91607) | `` sing-geoip.generator: unstable-2022-07-05 -> 20230512 ``                                 |
| [`04ed5679`](https://github.com/NixOS/nixpkgs/commit/04ed5679329ac6863f655fdeca332a18c36b621d) | `` subtitlr: 0.1.0 -> 0.1.1 ``                                                              |
| [`24251811`](https://github.com/NixOS/nixpkgs/commit/24251811ad81788b76cd1a45f69b2b9719904ac1) | `` kubescape: 2.3.4 -> 2.3.5 ``                                                             |
| [`9047bfe2`](https://github.com/NixOS/nixpkgs/commit/9047bfe2cda86edd00e67c90891a163a410b6b82) | `` exploitdb: 2023-06-03 -> 2023-06-05 ``                                                   |
| [`a73a51b4`](https://github.com/NixOS/nixpkgs/commit/a73a51b43e826da500932ff7251bab4fee770f1c) | `` zed: 1.7.0 -> 1.8.1 ``                                                                   |
| [`ee29a69f`](https://github.com/NixOS/nixpkgs/commit/ee29a69fce242f263c516c4a2fe9cdfd77e98b0b) | `` jackett: 0.21.114 -> 0.21.128 ``                                                         |
| [`39e30fa4`](https://github.com/NixOS/nixpkgs/commit/39e30fa40e26b2e7a0afbee4689c57519dc6e165) | `` wasmtime: 9.0.2 -> 9.0.3 ``                                                              |
| [`7789efcf`](https://github.com/NixOS/nixpkgs/commit/7789efcfd34c29d217e1a29dbe715de6ef1e3093) | `` Revert "Merge #235219: llvmPackages_16: 16.0.1 -> 16.0.5" ``                             |
| [`6ecc0520`](https://github.com/NixOS/nixpkgs/commit/6ecc05202e27151addd53042f1a174ccaa84ebe5) | `` nebula: 1.7.1 -> 1.7.2 ``                                                                |
| [`d31ea9f4`](https://github.com/NixOS/nixpkgs/commit/d31ea9f454db93212a451c0b0a88b4cba9a99237) | `` zsh-forgit: 23.05.0 -> 23.06.0 ``                                                        |
| [`0aa6a144`](https://github.com/NixOS/nixpkgs/commit/0aa6a144bd31199d2e1904483f43ad579d0620e0) | `` faudio: 23.05 -> 23.06 ``                                                                |
| [`4f21db7e`](https://github.com/NixOS/nixpkgs/commit/4f21db7edf268744ab28d3de5843507e33ae2f7e) | `` containerd: 1.7.1 -> 1.7.2 ``                                                            |
| [`b4975023`](https://github.com/NixOS/nixpkgs/commit/b497502357c0f944c839e645097f44a7c3279971) | `` nixos: Use systemd-growfs for autoResize ``                                              |
| [`5176a4f1`](https://github.com/NixOS/nixpkgs/commit/5176a4f11356a338331d82e63563f8510b67317d) | `` nixos: Use systemd-makefs for autoFormat ``                                              |
| [`14aa5c4d`](https://github.com/NixOS/nixpkgs/commit/14aa5c4db195dfaf9923be8dda9e5bb85fe175ab) | `` python311Packages.django-stubs-ext: drop outdated postPatch ``                           |
| [`e86d6235`](https://github.com/NixOS/nixpkgs/commit/e86d62355e5913e5d46d6d47344851bc32aeb911) | `` kora-icon-theme: 1.5.6 -> 1.5.7 ``                                                       |
| [`d1a74753`](https://github.com/NixOS/nixpkgs/commit/d1a7475301e9ccff1f6eb1925dfc8a55d7918df0) | `` hcloud: 1.34.0 -> 1.34.1 ``                                                              |
| [`45cb7359`](https://github.com/NixOS/nixpkgs/commit/45cb7359f825ea18ba5f6e482089fb71ccc032f1) | `` dufs: 0.33.0 -> 0.34.1 ``                                                                |
| [`93fc2ce7`](https://github.com/NixOS/nixpkgs/commit/93fc2ce7c0dcbbc036d3148fc7c51f8caea89887) | `` python311Packages.django-stubs-ext: 4.2.0 -> 4.2.1 ``                                    |
| [`88411048`](https://github.com/NixOS/nixpkgs/commit/884110484c03073ad5ff8f8505dd401a093bbbbb) | `` signalbackup-tools: 20230531 -> 20230603-2 ``                                            |
| [`af17209b`](https://github.com/NixOS/nixpkgs/commit/af17209b793318646a8c4c2bfe588755a89eb502) | `` renderdoc: 1.26 -> 1.27 ``                                                               |
| [`241f5259`](https://github.com/NixOS/nixpkgs/commit/241f52592899b42e42a1bfe861228f4686335203) | `` cctools-apple: fix download source ``                                                    |
| [`ab1a5558`](https://github.com/NixOS/nixpkgs/commit/ab1a55581989d069a4bbccf2c951d3c48a34f099) | `` bookletimposer: fix "ValueError: Namespace Gtk not available" ``                         |
| [`74f880ba`](https://github.com/NixOS/nixpkgs/commit/74f880ba5ea6b5f3768d8d4c6a09c1baad863bae) | `` python311Packages.python-roborock: 0.20.2 -> 0.21.0 ``                                   |
| [`a4a21c6e`](https://github.com/NixOS/nixpkgs/commit/a4a21c6e15234bc5903d56651027e08528af7d85) | `` python311Packages.asyncstdlib: 3.10.7 -> 3.10.8 ``                                       |
| [`b9ed2ba5`](https://github.com/NixOS/nixpkgs/commit/b9ed2ba5165ec0a18f0c338074fe22a05b7f32d3) | `` plasma5Packages: relax platforms ``                                                      |
| [`8f7d2c18`](https://github.com/NixOS/nixpkgs/commit/8f7d2c182909a46058deaf56903aeee032684222) | `` plasma5Packages.ktexteditor: add darwin support ``                                       |
| [`8902dfbe`](https://github.com/NixOS/nixpkgs/commit/8902dfbe468700847ce8bcd7b6c0e3ee79843e20) | `` plasma5Packages.qqc2-desktop-style: add darwin support ``                                |
| [`845ed634`](https://github.com/NixOS/nixpkgs/commit/845ed6342efc552afd6b58d7b4cb37868b5173fa) | `` plasma5Packages.kcoreaddons: add darwin support ``                                       |
| [`37b72120`](https://github.com/NixOS/nixpkgs/commit/37b721206e8cfaa635d2415f2b91056e55577acd) | `` fclones: 0.30.0 -> 0.31.0, add figsoda as a maintainer ``                                |
| [`07310e59`](https://github.com/NixOS/nixpkgs/commit/07310e59a62ae8e5b7e15580e06e085cd9ea0a70) | `` Revert "google-cloud-cpp: schedule on big-parallel machines" ``                          |
| [`add8dd84`](https://github.com/NixOS/nixpkgs/commit/add8dd840205aa9539d37591829eff3b48dd1359) | `` google-cloud-cpp: schedule on big-parallel machines ``                                   |
| [`efd6f2ac`](https://github.com/NixOS/nixpkgs/commit/efd6f2ac3085883b07b539227180550fc2456838) | `` google-cloud-cpp: downgrade a warning on aarch64-linux ``                                |
| [`1dbc3047`](https://github.com/NixOS/nixpkgs/commit/1dbc3047591787a4b8cd4001124ee0a3389d77d4) | `` google-cloud-cpp: extend .meta.platforms ``                                              |
| [`2d6b28f0`](https://github.com/NixOS/nixpkgs/commit/2d6b28f0680eb5a03c95d51101788ea7f0d70a33) | `` emacsPackages.elpaDevelPackages: init ``                                                 |
| [`1f3cc522`](https://github.com/NixOS/nixpkgs/commit/1f3cc522ba37076f4912a5a785cb424003ab4540) | `` iosevka: 24.1.0 -> 24.1.1 ``                                                             |
| [`3cf373b2`](https://github.com/NixOS/nixpkgs/commit/3cf373b299655179c92cb2705b5b36ead1af480e) | `` comodoro: init at 0.0.8 ``                                                               |
| [`7da24051`](https://github.com/NixOS/nixpkgs/commit/7da24051923f23ebe22ea176a7b826b07bd77eef) | `` python3Packages.apsw: 3.41.0 -> 3.42.0 (#233027) ``                                      |
| [`46f30a03`](https://github.com/NixOS/nixpkgs/commit/46f30a032e1d83c552e1d50356f0ff4ff596e285) | `` libvlc: fix build by providing openssl ``                                                |
| [`ac0254d4`](https://github.com/NixOS/nixpkgs/commit/ac0254d4c8299b9dff24c18206274dd102d059a7) | `` sccache: 0.5.2 -> 0.5.3 ``                                                               |
| [`f9599292`](https://github.com/NixOS/nixpkgs/commit/f95992929d5e17427322a6997a236316bedcc05c) | `` python3Packages.rich-argparse: init at 1.1.0 ``                                          |
| [`33d6d0cc`](https://github.com/NixOS/nixpkgs/commit/33d6d0cce80c0f68f0212d09d381d2c8eef39f1b) | `` python3Packages.python-daemon: 2.3.0 -> 3.0.1 ``                                         |
| [`092fc911`](https://github.com/NixOS/nixpkgs/commit/092fc91112e01e5568384454846bea0d4f2dd0b0) | `` python3Packages.flask-appbuilder: 4.2.1 -> 4.3.1 ``                                      |
| [`48a0434a`](https://github.com/NixOS/nixpkgs/commit/48a0434ae792d78c343bc6cdae14250537ea8348) | `` python3Packages.apache-airflow: 2.5.1 -> 2.6.0 ``                                        |
| [`08d9e34f`](https://github.com/NixOS/nixpkgs/commit/08d9e34f03e1cdd25b25e2d55f278ea99faf628e) | `` bluez-alsa: 4.0.0 -> 4.1.0 ``                                                            |
| [`37a9952b`](https://github.com/NixOS/nixpkgs/commit/37a9952b431535a71dc43a144ccad556755216f0) | `` unifiedpush-common-proxies: unpin go ``                                                  |
| [`b2138be2`](https://github.com/NixOS/nixpkgs/commit/b2138be293b56ceefa391bf42d81c8040a656a5e) | `` unifiedpush-common-proxies: 1.3.0 -> 1.5.0 ``                                            |
| [`ca78d062`](https://github.com/NixOS/nixpkgs/commit/ca78d062a73ffa7f37bfdc9c863467355cf60a11) | `` ocserv: 1.1.6 -> 1.1.7 ``                                                                |
| [`62de9b1c`](https://github.com/NixOS/nixpkgs/commit/62de9b1c93ff3f2cfd2e5a99b0181f28d17080a8) | `` krill: 0.13.0 -> 0.13.1 ``                                                               |
| [`52f3a1c4`](https://github.com/NixOS/nixpkgs/commit/52f3a1c42ce20135eb7074e2d325daa09126d83f) | `` fetchgit: require sparseCheckout be a list of strings ``                                 |
| [`ef06a18b`](https://github.com/NixOS/nixpkgs/commit/ef06a18b11c3d47791b463d6659ea5033c6c68c5) | `` galene: 0.7.0 -> 0.7.1 ``                                                                |
| [`513dc55d`](https://github.com/NixOS/nixpkgs/commit/513dc55db61fe9c8a15f862d640b2d3ed724318d) | `` intel-cmt-cat: 4.5.0 -> 4.6.0 ``                                                         |
| [`5d126b14`](https://github.com/NixOS/nixpkgs/commit/5d126b145a4861193947dd0a39da56d755fc7ebe) | `` vyper: 0.3.8 -> 0.3.9 ``                                                                 |
| [`9c04f9ec`](https://github.com/NixOS/nixpkgs/commit/9c04f9ec7d03dcfcbe22eb927991a34123c40067) | `` git-credential-keepassxc: 0.12.0 -> 0.13.0 ``                                            |
| [`1f3b4712`](https://github.com/NixOS/nixpkgs/commit/1f3b4712f5a87a7b02f2f72f1d08578f668195f2) | `` egglog: init at unstable-2023-05-22 ``                                                   |
| [`4c101ed3`](https://github.com/NixOS/nixpkgs/commit/4c101ed35764fbd7efcd2eadd56bf2a4ff51ea24) | `` photoprism: 230513-0b780defb -> 230603-378d4746a ``                                      |
| [`c48a125f`](https://github.com/NixOS/nixpkgs/commit/c48a125faae225aeb1dd6c6699241520a1ac39ca) | `` planus: init at 0.4.0 ``                                                                 |
| [`5d92bfbb`](https://github.com/NixOS/nixpkgs/commit/5d92bfbb4c3180cb2b4343d01a0f92d896fad8f6) | `` gnome.mutter43: 43.5 → 43.6 ``                                                           |
| [`9ea7d9a4`](https://github.com/NixOS/nixpkgs/commit/9ea7d9a4ce244f36598cbe83270a37c05818a1a4) | `` Revert Merge #234128: gnu-efi: patch to fix build for riscv64 ``                         |
| [`16eb3e00`](https://github.com/NixOS/nixpkgs/commit/16eb3e00ca3e7e02964b57e13a17b9a88d154988) | `` mdbook: 0.4.29 -> 0.4.30 ``                                                              |
| [`6bd9402c`](https://github.com/NixOS/nixpkgs/commit/6bd9402c5ff2e6450689666e5fd6ae8c8ef3c70a) | `` cups: fix build on darwin ``                                                             |
| [`36613013`](https://github.com/NixOS/nixpkgs/commit/36613013753cd58cb1f934090db6dc49233a5587) | `` tandoor-recipes: 1.4.9 -> 1.4.12 ``                                                      |