### PR TITLE
chore(flake/darwin): `4338bc86` -> `40e4b85b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -87,11 +87,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685559570,
-        "narHash": "sha256-MNIQvLRoq92isMLR/ordKNCl+aXNiuwBM4QyqmS8d00=",
+        "lastModified": 1686210161,
+        "narHash": "sha256-cgP8P2Gk4WtOzd/Y7nEmweLpPOtMKVvHCIcq9zm9qMk=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "4338bc869e9874d54a4c89539af72f16666b2abe",
+        "rev": "40e4b85baac86969f94d6dba893aeae015c562c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                   |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`257b5c19`](https://github.com/LnL7/nix-darwin/commit/257b5c199490aa073ab60c1d22d213025661dd44) | `` ssh: fix public keys in home directory not working ``  |
| [`9c7a07b8`](https://github.com/LnL7/nix-darwin/commit/9c7a07b8b2d476b6b9f574c8f35000c7c7fbbaf4) | `` system/checks: allow disabling the buildUsers check `` |