### PR TITLE
chore(flake/nixpkgs): `4729ffac` -> `381e92a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -348,11 +348,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686020360,
-        "narHash": "sha256-Wee7lIlZ6DIZHHLiNxU5KdYZQl0iprENXa/czzI6Cj4=",
+        "lastModified": 1686135559,
+        "narHash": "sha256-pY8waAV8K/sbHBdLn5diPFnQKpNg0YS9w03MrD2lUGE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4729ffac6fd12e26e5a8de002781ffc49b0e94b7",
+        "rev": "381e92a35e2d196fdd6077680dca0cd0197e75cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`381e92a3`](https://github.com/NixOS/nixpkgs/commit/381e92a35e2d196fdd6077680dca0cd0197e75cb) | `` jasmin-compiler: 2022.09.2 → 2022.09.3 ``                                           |
| [`ffd47a04`](https://github.com/NixOS/nixpkgs/commit/ffd47a047d63053cbf327b9fbc9867fbbb21a113) | `` coqPackages.relation-algebra: init at 1.7.9 for Coq 8.17 ``                         |
| [`06d62606`](https://github.com/NixOS/nixpkgs/commit/06d62606e08ccd4403dcea77e8d516874eed459d) | `` ocamlPackages.memtrace: init at 0.2.2 (#236273) ``                                  |
| [`d804ca62`](https://github.com/NixOS/nixpkgs/commit/d804ca626ac8914ed9218014a3c499ea1d8b4342) | `` nixos/atuin: add database.createLocally ``                                          |
| [`3f2965dc`](https://github.com/NixOS/nixpkgs/commit/3f2965dc575c4f030d9426b1629faa4fd3ff2608) | ``  takethetime: fetch from PyPI and disable checks (#233694) ``                       |
| [`23b16256`](https://github.com/NixOS/nixpkgs/commit/23b1625664efc29e3ad89ffd645b2140b1888ba1) | `` embree: unbreak on aarch64-linux ``                                                 |
| [`bfafd5c8`](https://github.com/NixOS/nixpkgs/commit/bfafd5c86a09c6c57c43a0b79b4ec51bedc60183) | `` cargo-pgrx: init at 0.9.2 ``                                                        |
| [`66f57b6c`](https://github.com/NixOS/nixpkgs/commit/66f57b6c181c3ad3ac9692664b4a210d074d47c6) | `` Improve `fetchFromGitLab` manual (#236111) ``                                       |
| [`0912ad92`](https://github.com/NixOS/nixpkgs/commit/0912ad928f862e2e901f509e6b84c19dc930095d) | `` treewide: fix nodejs-18_x references ``                                             |
| [`22d66165`](https://github.com/NixOS/nixpkgs/commit/22d66165a941c2a2f57b00be50dccafaa2fb7ee1) | `` anki-bin: 2.1.64 -> 2.1.65 ``                                                       |
| [`5067b12a`](https://github.com/NixOS/nixpkgs/commit/5067b12ac5b0ae3282820df0aff61a5f3645bcad) | `` python311Packages.pyunifiprotect: 4.9.1 -> 4.10.1 ``                                |
| [`a70b93f1`](https://github.com/NixOS/nixpkgs/commit/a70b93f1d7c6c1423401a54792774f807d92a8d3) | `` haskellPackages: mark builds failing on hydra as broken ``                          |
| [`5a96c1e3`](https://github.com/NixOS/nixpkgs/commit/5a96c1e3e060e8766efb82726d417ebdb2852fbe) | `` python310Packages.in-n-out: 0.1.6 -> 0.1.7 ``                                       |
| [`e107e02e`](https://github.com/NixOS/nixpkgs/commit/e107e02eadd62e45a4a686691e322854f21e9c3c) | `` nuraft: unpin boost172 ``                                                           |
| [`a895bfe9`](https://github.com/NixOS/nixpkgs/commit/a895bfe9519297803bd6c98db47758b69463c630) | `` nuclei: 2.9.5 -> 2.9.6 ``                                                           |
| [`fd6441fd`](https://github.com/NixOS/nixpkgs/commit/fd6441fde6c990d248d86e25ff1ba912f83f7040) | `` bombono: unpin boost172 ``                                                          |
| [`97d8a9ea`](https://github.com/NixOS/nixpkgs/commit/97d8a9ea3e71b6a72dc4ef3739c3e85200ef541f) | `` gitleaks: 8.16.3 -> 8.16.4 ``                                                       |
| [`07a26773`](https://github.com/NixOS/nixpkgs/commit/07a26773b89ae3d64cdbe0f9ce5ff040acbdf085) | `` rtx: 1.30.5 -> 1.32.0 ``                                                            |
| [`b57e7daa`](https://github.com/NixOS/nixpkgs/commit/b57e7daa50b48b6379bc6a11f66ec9ef1878dcdd) | `` trivy: 0.41.0 -> 0.42.0 ``                                                          |
| [`a3dc53e3`](https://github.com/NixOS/nixpkgs/commit/a3dc53e3fcc08971073f9de6322c0dd449993e6a) | `` nixos/amazon-image: embiggen ``                                                     |
| [`f87892b5`](https://github.com/NixOS/nixpkgs/commit/f87892b50b335a276bd7275057ae3953980dff3b) | `` nixos/modules/web-servers/nginx/default.nix: fix minor typo ``                      |
| [`a2271ff3`](https://github.com/NixOS/nixpkgs/commit/a2271ff3d305af6dee1ae3aa481276b3debb8853) | `` terraform-providers.oci: 4.123.0 -> 5.0.0 ``                                        |
| [`0e234993`](https://github.com/NixOS/nixpkgs/commit/0e234993f91e02759703aa4ec558078b5562ebcd) | `` terraform-providers.linode: 2.3.0 -> 2.4.0 ``                                       |
| [`a79b99cc`](https://github.com/NixOS/nixpkgs/commit/a79b99ccd8fbb4221959c7d7a0cf63c3dddfb8de) | `` terraform-providers.checkly: 1.6.5 -> 1.6.6 ``                                      |
| [`40cbd9de`](https://github.com/NixOS/nixpkgs/commit/40cbd9dec6df124f4e04dfdbc1370b06b6642639) | `` telegraf: add maintainer ``                                                         |
| [`7eb512bf`](https://github.com/NixOS/nixpkgs/commit/7eb512bfdc3300c1f506b09995b56d2919717a57) | `` openraPackages.engines.devtest: init at 20230414 ``                                 |
| [`a1c71338`](https://github.com/NixOS/nixpkgs/commit/a1c713386ff2e28bbe91318e03f55287be429a7e) | `` openra: init at release-20230225 ``                                                 |
| [`dff77371`](https://github.com/NixOS/nixpkgs/commit/dff7737184f81aef0727d69c1ba7b1d9a35c97a1) | `` openra: move old openra packages to the openra_2019 namespace ``                    |
| [`3019a101`](https://github.com/NixOS/nixpkgs/commit/3019a101c7f77f507080629ec25dcc748b35ac00) | `` haskell: mark more darwin packages as broken that depend on mesa ``                 |
| [`71385813`](https://github.com/NixOS/nixpkgs/commit/7138581355582241eb9357a9898d6f9ae689e538) | `` haskell: mark darwin packages as broken that depend on mesa ``                      |
| [`388d127c`](https://github.com/NixOS/nixpkgs/commit/388d127c4b181b7dafb3454d7ea75b443d3f6910) | `` home-assistant: update component packages ``                                        |
| [`5f6be296`](https://github.com/NixOS/nixpkgs/commit/5f6be2960ff9a0c455635bf93f3cd3e8002d188f) | `` python310Packages.wyoming: init at 0.0.1 ``                                         |
| [`9f7503e4`](https://github.com/NixOS/nixpkgs/commit/9f7503e491c5c067fdf159cb47084e546666cf07) | `` packages310Packages.blobfile: fix license ``                                        |
| [`22097430`](https://github.com/NixOS/nixpkgs/commit/2209743004acca58398904b66a90b38e4cc351a2) | `` python311Packages.jaxopt: disable failing tests ``                                  |
| [`67954264`](https://github.com/NixOS/nixpkgs/commit/679542641122765010da85ec7cbdb73d40297463) | `` haskell.packages.ghc94.gtk2hs-buildtools: remove patch for upstream fix ``          |
| [`39f220b6`](https://github.com/NixOS/nixpkgs/commit/39f220b6dffd9a1bd5520d7f1de9e890c43751f3) | `` nixos/grafana: add jsonData datasource option (#234364) ``                          |
| [`20933bf3`](https://github.com/NixOS/nixpkgs/commit/20933bf34a73af35b4e92957a99c63dd6d852a05) | `` slic3r: unpin boost172 ``                                                           |
| [`0deb0714`](https://github.com/NixOS/nixpkgs/commit/0deb0714564aff18af5873b1cca1d95edbcb249f) | `` python310Packages.pyramid-jinja2: rename from pyramid_jinja2 ``                     |
| [`54ea6f60`](https://github.com/NixOS/nixpkgs/commit/54ea6f60f0b98cad6dc1af5eeed82ee354adb90e) | `` element-{web,desktop}: 1.11.31 -> 1.11.32 (#236312) ``                              |
| [`5cb42972`](https://github.com/NixOS/nixpkgs/commit/5cb42972d2b44e93cae2b91b897c049be6bdd8f3) | `` ferretdb: 1.2.1 -> 1.3.0 (#236333) ``                                               |
| [`3e85b02c`](https://github.com/NixOS/nixpkgs/commit/3e85b02cbe1dfa366bd86dc0665de55c87ad9832) | `` python310Packages.pyramid_jinja2: mark not broken ``                                |
| [`57741577`](https://github.com/NixOS/nixpkgs/commit/577415779fe0ab7c8c58dccc5bea5a5008a1b93f) | `` maintainers: remove me from matrix list (#236334) ``                                |
| [`31b940ea`](https://github.com/NixOS/nixpkgs/commit/31b940ea0dfb0b75215fd0bc2170e7d25eb38403) | `` onlykey: 5.3.4 -> 5.5.0 ``                                                          |
| [`4e3e6656`](https://github.com/NixOS/nixpkgs/commit/4e3e66561e9b8f9f04b5c1b97b396c4b2553e48b) | `` onlykey: build with NodeJS-18 ``                                                    |
| [`4ea32dba`](https://github.com/NixOS/nixpkgs/commit/4ea32dbaa1596b6b8a06267c2c2e8e02dcc672ee) | `` gdu: 5.24.0 -> 5.25.0 ``                                                            |
| [`78f983af`](https://github.com/NixOS/nixpkgs/commit/78f983afc3a1bfe2947a637046093c1ab4a1ee72) | `` python311Packages.azure-mgmt-frontdoor: 1.0.1 -> 1.1.0 ``                           |
| [`81616d5a`](https://github.com/NixOS/nixpkgs/commit/81616d5a0c5664f343f203241f564c434a35ab81) | `` python311Packages.azure-mgmt-keyvault: 10.2.1 -> 10.2.2 ``                          |
| [`f8716bb1`](https://github.com/NixOS/nixpkgs/commit/f8716bb12cff73f80bcbbae44d4715f9364f5cc5) | `` python311Packages.azure-mgmt-network: 23.0.1 -> 23.1.0 ``                           |
| [`13c05284`](https://github.com/NixOS/nixpkgs/commit/13c0528442e7e710531af37b57e80c6bd8a1fb8d) | `` python311Packages.azure-multiapi-storage: 1.1.0 -> 1.2.0 ``                         |
| [`5d02a87b`](https://github.com/NixOS/nixpkgs/commit/5d02a87bf7ae5bedacb95b9e91e37b61ee735b59) | `` python311Packages.adb-enhanced: 2.5.18 -> 2.5.21 ``                                 |
| [`b2b97be2`](https://github.com/NixOS/nixpkgs/commit/b2b97be21e209f3e9490016eab047f0e166be5c1) | `` checkov: 2.3.273 -> 2.3.281 ``                                                      |
| [`389455b9`](https://github.com/NixOS/nixpkgs/commit/389455b9aab629582ec7ffead7552af7c9dc6961) | `` python311Packages.peaqevcore: 18.1.1 -> 18.1.4 ``                                   |
| [`82ff4bf6`](https://github.com/NixOS/nixpkgs/commit/82ff4bf6a4cbcfa647fc9e221ebecf799b69418f) | `` python311Packages.python-roborock: 0.21.1 -> 0.23.4 ``                              |
| [`b6fbd319`](https://github.com/NixOS/nixpkgs/commit/b6fbd3191186760fbf7bbd76f66863212dd5059f) | `` python311Packages.meilisearch: 0.27.0 -> 0.28.0 ``                                  |
| [`cb4163d1`](https://github.com/NixOS/nixpkgs/commit/cb4163d13e6fa8b9d502e54addb11b9cf9dd268e) | `` python311Packages.sqltrie: 0.3.1 -> 0.4.0 ``                                        |
| [`c30b0ce0`](https://github.com/NixOS/nixpkgs/commit/c30b0ce0dd0b91ce9f9336ab38e91c60ceec6c3c) | `` python311Packages.waqiasync: 1.0.0 -> 1.1.0 ``                                      |
| [`4b83e76d`](https://github.com/NixOS/nixpkgs/commit/4b83e76de022d2afa44774558dbf0e1220317032) | `` python310Packages.angr: 9.2.53 -> 9.2.54 ``                                         |
| [`a900f821`](https://github.com/NixOS/nixpkgs/commit/a900f821c4dc3de87e3a7a724819b9acf804e158) | `` python310Packages.cle: 9.2.53 -> 9.2.54 ``                                          |
| [`28d6078b`](https://github.com/NixOS/nixpkgs/commit/28d6078bf3513c7f86b5564b72b24399d0e90008) | `` python310Packages.claripy: 9.2.53 -> 9.2.54 ``                                      |
| [`31ff747e`](https://github.com/NixOS/nixpkgs/commit/31ff747eee80ef30f5dc175ed2d05aa3ce5a09c7) | `` python310Packages.pyvex: 9.2.53 -> 9.2.54 ``                                        |
| [`845500ac`](https://github.com/NixOS/nixpkgs/commit/845500ac3c0a2641730f7b315438b5713eac0147) | `` python310Packages.ailment: 9.2.53 -> 9.2.54 ``                                      |
| [`4a2beb98`](https://github.com/NixOS/nixpkgs/commit/4a2beb98fcacc682543af5e4bae7a83acc6cc724) | `` python310Packages.archinfo: 9.2.53 -> 9.2.54 ``                                     |
| [`446cd80f`](https://github.com/NixOS/nixpkgs/commit/446cd80f70e4922c7dbc598c4ad3d80bfa07fe54) | `` python311Packages.aiofile: 3.8.5 -> 3.8.6 ``                                        |
| [`dc7d4dec`](https://github.com/NixOS/nixpkgs/commit/dc7d4dece5b16e2ea9f2524dd2a14eb88d17a88d) | `` Document how to use packages with extensions. (#145011) ``                          |
| [`7efb781c`](https://github.com/NixOS/nixpkgs/commit/7efb781c3a9d96f1c0a69f3b0507b74f0632151e) | `` surrealdb-migrations: 0.9.8 -> 0.9.9 ``                                             |
| [`808342dc`](https://github.com/NixOS/nixpkgs/commit/808342dc01cb48e946819a3d6ae10b59f899a51c) | `` 1password-gui-beta: 8.10.7-11 -> 8.10.8-10 ``                                       |
| [`e2c55579`](https://github.com/NixOS/nixpkgs/commit/e2c555799cc9c6037af7d29ee083dda3560c268d) | `` doas: drop patch, use dontAddStaticConfigureFlags instead ``                        |
| [`e82afd43`](https://github.com/NixOS/nixpkgs/commit/e82afd434c94d9e6f0f651d42b450d1f69695fb2) | `` pulseeffects-legacy: unpin boost172 ``                                              |
| [`bf727ca4`](https://github.com/NixOS/nixpkgs/commit/bf727ca45dfebefe6bf70ecc056356df072e298b) | `` openconnect_unstable: remove ``                                                     |
| [`013cd176`](https://github.com/NixOS/nixpkgs/commit/013cd176ff901e75439d45abce7137f87b15c10b) | `` vim-full: configurable.nix → full.nix ``                                            |
| [`e261eb15`](https://github.com/NixOS/nixpkgs/commit/e261eb152ba8aa72a139a15e9856495ba348f8af) | `` vim-full: remove redundant nix support patches ``                                   |
| [`767b6299`](https://github.com/NixOS/nixpkgs/commit/767b62993cfc5ddf79498fb0ce418017ca0330fe) | `` PlistCpp: unpin boost172 ``                                                         |
| [`d29e6a52`](https://github.com/NixOS/nixpkgs/commit/d29e6a52554718691c8b5b0f16d68fad20c3110b) | `` variety: fix script shell ``                                                        |
| [`1092087a`](https://github.com/NixOS/nixpkgs/commit/1092087ad57051df5ac2428bd699ccbd297570ca) | `` ungoogled-chromium: 113.0.5672.126 -> 114.0.5735.90 ``                              |
| [`96f2f1be`](https://github.com/NixOS/nixpkgs/commit/96f2f1bef3dc81098c4679b7364aea5269100d7f) | `` solc: unpin boost172 ``                                                             |
| [`0253af55`](https://github.com/NixOS/nixpkgs/commit/0253af550f3fc56a84b24dd24e15fddf608f0742) | `` enblend-enfuse: unpin boost172 ``                                                   |
| [`3e6aebfc`](https://github.com/NixOS/nixpkgs/commit/3e6aebfcd2b7e8de9052fb90c2cf0a02e47e1eff) | `` maven: specify mainProgram ``                                                       |
| [`71237251`](https://github.com/NixOS/nixpkgs/commit/7123725134f153cb069bba16f12f9b15b10c90eb) | `` libLAS: unpin boost172 ``                                                           |
| [`e4445839`](https://github.com/NixOS/nixpkgs/commit/e4445839264ca212d27af37c875fcf8832233d78) | `` cargo-semver-checks: 0.20.1 -> 0.21.0 ``                                            |
| [`858583a9`](https://github.com/NixOS/nixpkgs/commit/858583a95853fb35f8ddd98e7afbc4602223b4be) | `` doc/language-frameworks/haskell: fix argument order of setBuildTargets (#236252) `` |
| [`4779646d`](https://github.com/NixOS/nixpkgs/commit/4779646dd0bee783ee1c6c0b30af6edc4054aeff) | `` nova-filters: refactor ``                                                           |
| [`a582371e`](https://github.com/NixOS/nixpkgs/commit/a582371e003da3e2584bffa52c4820d150b21008) | `` plex: 1.32.2.7100-248a2daf0 -> 1.32.3.7162-b0a36929b ``                             |
| [`9790e701`](https://github.com/NixOS/nixpkgs/commit/9790e70150c83693fa2bcdc65814d01536bf4915) | `` lib.list.findFirst: Make lazier ``                                                  |
| [`6996f768`](https://github.com/NixOS/nixpkgs/commit/6996f76885d81fbc1b066fe346713630e6ac9e1b) | `` lib/tests: Add findFirst tests ``                                                   |
| [`5153f780`](https://github.com/NixOS/nixpkgs/commit/5153f78041cc9aa3a38ed13251af39570048b30d) | `` joplin-desktop: 2.10.18 -> 2.10.19 ``                                               |
| [`03972059`](https://github.com/NixOS/nixpkgs/commit/03972059c325fe3783c812043b45025cfa10ba6b) | `` nixVersions.nix_2_16: 2.16.0 -> 2.16.1 ``                                           |
| [`3a952222`](https://github.com/NixOS/nixpkgs/commit/3a9522220fd72b66058a1c35d63af5312ec198ed) | `` tfautomv: 0.5.1 -> 0.5.2 ``                                                         |
| [`4e6190be`](https://github.com/NixOS/nixpkgs/commit/4e6190bec3fac06953919f5e3af5579d178aee5b) | `` worker-build: 0.0.16 -> 0.0.17 ``                                                   |
| [`47d1a746`](https://github.com/NixOS/nixpkgs/commit/47d1a74603aa23283fc205c63059f7fc32714755) | `` python3Packages.geopandas: 0.13.1 -> 0.13.2 ``                                      |
| [`a830a587`](https://github.com/NixOS/nixpkgs/commit/a830a5871386fa773334cf985b6f5f444fe65d27) | `` chromium: 114.0.5735.90 -> 114.0.5735.106 ``                                        |
| [`33c50b88`](https://github.com/NixOS/nixpkgs/commit/33c50b885b0e8b64e7f3e0f08638f18caa8638cb) | `` browserpass: fix dynamic loader ``                                                  |
| [`aa5acfed`](https://github.com/NixOS/nixpkgs/commit/aa5acfed2758882ee14ae79ce506d9459552a1b9) | `` egl-wayland: 1.1.11 -> 1.1.12 ``                                                    |
| [`e5ebd5de`](https://github.com/NixOS/nixpkgs/commit/e5ebd5ded6c8d6a321feceb25895d6d849053f22) | `` rustic-rs: 0.5.3 -> 0.5.4 ``                                                        |
| [`f27a1e68`](https://github.com/NixOS/nixpkgs/commit/f27a1e6871599031d12677da8f82ce79e475e575) | `` meilisearch: 1.1.1 -> 1.2.0 ``                                                      |
| [`8cfe61fb`](https://github.com/NixOS/nixpkgs/commit/8cfe61fbbf7a7a8c167f92caaa1930212095e044) | `` rustus: init at 0.7.2 ``                                                            |
| [`c64d697b`](https://github.com/NixOS/nixpkgs/commit/c64d697b3fdf52e55f8c262b157ac3be87528282) | `` surrealdb-migrations: 0.9.5 -> 0.9.8 ``                                             |
| [`f868530b`](https://github.com/NixOS/nixpkgs/commit/f868530bcc48eff8188804428adc9d4a5c56ffdc) | `` seaweedfs: 3.51 -> 3.52 ``                                                          |
| [`5120d113`](https://github.com/NixOS/nixpkgs/commit/5120d113c8b4b50d4e4b3a270dbbf7a2f7b6583c) | `` mirtk: unpin boost16x ``                                                            |
| [`e97e82f8`](https://github.com/NixOS/nixpkgs/commit/e97e82f83125aa7f6e96203764b3d10e480e1b76) | `` python310Packages.pdm-backend: set package version through setup-hook ``            |
| [`a97ce491`](https://github.com/NixOS/nixpkgs/commit/a97ce4912be9f02bab63c6ba927578119ab750f8) | `` ciftilib: unpin boost16x ``                                                         |
| [`e092318a`](https://github.com/NixOS/nixpkgs/commit/e092318a9f5f247fbb63fbb78e2f17d97f88fbd7) | `` dae: 0.1.10 -> 0.1.10.p1 ``                                                         |
| [`84b084b8`](https://github.com/NixOS/nixpkgs/commit/84b084b884a880abd4fe6b9556cb192e05ff478f) | `` ispike: unpin boost16x ``                                                           |
| [`962a2fd8`](https://github.com/NixOS/nixpkgs/commit/962a2fd8c5b8a5f83dd3c00387c6879f16ebbe9b) | `` iosevka-bin: 24.1.0 -> 24.1.1 ``                                                    |
| [`48c729b0`](https://github.com/NixOS/nixpkgs/commit/48c729b0aee20cc5ed7474ffe04418f2e6558652) | `` python311Packages.elastic-apm: 6.15.1 -> 6.16.0 ``                                  |
| [`e2a1c654`](https://github.com/NixOS/nixpkgs/commit/e2a1c6547a18f81956013c5b8b083a03af952513) | `` freedv: 1.8.9 -> 1.8.10.1 ``                                                        |
| [`18c17409`](https://github.com/NixOS/nixpkgs/commit/18c1740930d80ec1943865659167be26f388241c) | `` sioclient: init at unstable-2023-02-13 ``                                           |
| [`5d7bc2de`](https://github.com/NixOS/nixpkgs/commit/5d7bc2defd32a899579358a19bd8cd3664c65699) | `` emulationstation: unpin boost169 ``                                                 |
| [`eda3b244`](https://github.com/NixOS/nixpkgs/commit/eda3b244e0923f5d0d1ddcde6aa48ab75bff6126) | `` ddnet: 17.0.2 -> 17.0.3 ``                                                          |
| [`aa884b8f`](https://github.com/NixOS/nixpkgs/commit/aa884b8f3d5e5a3afb6bdcd21ebab8e55512f025) | `` improve documentation for `nix.settings.sandbox` (#188541) ``                       |
| [`04c41a12`](https://github.com/NixOS/nixpkgs/commit/04c41a12cfcf2ec67a88e3ace841f1b51863a063) | `` coqPackages.mathcomp-word: 2.0 → 2.1 ``                                             |
| [`eacc7be1`](https://github.com/NixOS/nixpkgs/commit/eacc7be1e93a2b9b9c710ec8ccf8ba05db5b4bea) | `` pigz: 2.6 -> 2.7 (#223504) ``                                                       |
| [`afdb5e26`](https://github.com/NixOS/nixpkgs/commit/afdb5e26aa37805036964d6e1afb6f658cdf923e) | `` goawk: 1.23.1 -> 1.23.2 ``                                                          |