### PR TITLE
chore(flake/nixpkgs): `381e92a3` -> `a64b73e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -348,11 +348,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686135559,
-        "narHash": "sha256-pY8waAV8K/sbHBdLn5diPFnQKpNg0YS9w03MrD2lUGE=",
+        "lastModified": 1686226982,
+        "narHash": "sha256-nLuiPoeiVfqqzeq9rmXxpybh77VS37dsY/k8N2LoxVg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "381e92a35e2d196fdd6077680dca0cd0197e75cb",
+        "rev": "a64b73e07d4aa65cfcbda29ecf78eaf9e72e44bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`7cd807e5`](https://github.com/NixOS/nixpkgs/commit/7cd807e5883736e1eeddb091b5774ee95af29869) | `` ocamlPackages.pgocaml: fix for OCaml 5.0 ``                                                   |
| [`7b77c9ed`](https://github.com/NixOS/nixpkgs/commit/7b77c9ed6375fa070e5db921442098ed45d8ae3d) | `` ocamlPackages.wasm: disable for OCaml ≥ 5.0 ``                                                |
| [`e917f417`](https://github.com/NixOS/nixpkgs/commit/e917f41792013e0928be62932f6446f8d31b76f7) | `` ocamlPackages.vlq: disable for OCaml ≥ 5.0 ``                                                 |
| [`0788043a`](https://github.com/NixOS/nixpkgs/commit/0788043a77782a73781392f0bd9ad26bf64e1fd2) | `` ocamlPackages.twt: disable for OCaml ≥ 5.0 ``                                                 |
| [`125277ff`](https://github.com/NixOS/nixpkgs/commit/125277ff467578fe48918a4d0a24b9586693fdf7) | `` thunderbird-bin-unwrapped: patch future glxtest/vaapitest binaries ``                         |
| [`e0a901b1`](https://github.com/NixOS/nixpkgs/commit/e0a901b1e02926788cc92931cc0aedea4036ecad) | `` firefox-bin-unwrapped: patch new glxtest/vaapitest binaries ``                                |
| [`9e6b04f7`](https://github.com/NixOS/nixpkgs/commit/9e6b04f76357334fcfdf9103e8f7a99f8b62fe84) | `` hyperscan: 5.4.0 -> 5.4.2 ``                                                                  |
| [`acab7316`](https://github.com/NixOS/nixpkgs/commit/acab7316b34da1bb72dfeef81605ee3fa5583c57) | `` python3Packages.ibis-framework: ignore failing tests that are fixed in the next release ``    |
| [`98b2ad5c`](https://github.com/NixOS/nixpkgs/commit/98b2ad5cf2361eb0ff01a43337277b8de385cd64) | `` python3Packages.duckdb-engine: 0.7.0 -> 0.7.3 ``                                              |
| [`42f02700`](https://github.com/NixOS/nixpkgs/commit/42f027006f66bcc7b9fe3f277937fa0068b07081) | `` python3Packages.datafusion: 23.0.0 -> 25.0.0 ``                                               |
| [`342c6ce3`](https://github.com/NixOS/nixpkgs/commit/342c6ce3c9d0d14f5bde254f3cb671bbe9e05fb6) | `` python3Packages.sqlglot: 10.5.2 -> 15.0.0 ``                                                  |
| [`c46ddfe2`](https://github.com/NixOS/nixpkgs/commit/c46ddfe23fbfd0b20e98820ecc41dc06f9ad816c) | `` duckdb: 0.7.1 -> 0.8.0 ``                                                                     |
| [`58ca9865`](https://github.com/NixOS/nixpkgs/commit/58ca986543b591a8269cbce3328293ca8d64480f) | `` clusterctl: 1.4.2 -> 1.4.3 ``                                                                 |
| [`2cdbd288`](https://github.com/NixOS/nixpkgs/commit/2cdbd288f9ba8ff9ee5ac42711989a402d443e23) | `` python310Packages.jupyter-lsp: 2.0.0 -> 2.2.0 ``                                              |
| [`f69aff8f`](https://github.com/NixOS/nixpkgs/commit/f69aff8f89566faf3a03f4afca742c1b87e59419) | `` github-runner: add thomasjm as maintainer ``                                                  |
| [`49bba9ee`](https://github.com/NixOS/nixpkgs/commit/49bba9ee5dbf6502191213658fe4ff9cdddd1805) | `` cargo-public-api: 0.31.0 -> 0.31.1 ``                                                         |
| [`d7e5c6de`](https://github.com/NixOS/nixpkgs/commit/d7e5c6deaa9f62ad9900877bc0c368fcf96f91eb) | `` steam: add attr to fhsenv ``                                                                  |
| [`d77f9d90`](https://github.com/NixOS/nixpkgs/commit/d77f9d908eab8dfe8f7a2447384eb4752cf1e4e1) | `` recoll: use wrapProgram to set $PATH for recoll, recollindex ``                               |
| [`8d2530ec`](https://github.com/NixOS/nixpkgs/commit/8d2530ece4044cdbbef5114cd9d12a6ea88323f2) | `` recoll: factor out dependency list ``                                                         |
| [`2caced43`](https://github.com/NixOS/nixpkgs/commit/2caced438f2f31a304f1a78b947a83971904bb64) | `` python310Packages.django-oauth-toolkit: 2.2.0 -> 2.3.0 ``                                     |
| [`4071213c`](https://github.com/NixOS/nixpkgs/commit/4071213c89c0dfd84a6c399982c79d3e71699c2e) | `` cargo-make: 0.36.8 -> 0.36.9 ``                                                               |
| [`f09cd3b7`](https://github.com/NixOS/nixpkgs/commit/f09cd3b7de97224518dbded5af5fcf857aec1ee5) | `` coqPackages.QuickChick: 1.6.4 → 1.6.5 ``                                                      |
| [`fba73283`](https://github.com/NixOS/nixpkgs/commit/fba73283c16e4e0c327fddaa1ec7ae48dcb491aa) | `` coqPackages.simple-io: 1.7.0 → 1.8.0 ``                                                       |
| [`d275cd4f`](https://github.com/NixOS/nixpkgs/commit/d275cd4f26d73756b8e68acd3f7a22746a525583) | `` python311Packages.publicsuffixlist: 0.10.0.20230506 -> 0.10.0.20230608 ``                     |
| [`fa591a7b`](https://github.com/NixOS/nixpkgs/commit/fa591a7bb9bb744d64162e237403d8d0e6b5f96b) | `` python311Packages.pontos: 23.5.3 -> 23.6.0 ``                                                 |
| [`f8d718c6`](https://github.com/NixOS/nixpkgs/commit/f8d718c6898b5168ab6769095fb471097aba4f68) | `` python311Packages.plugwise: 0.31.4 -> 0.31.5 ``                                               |
| [`30e2263b`](https://github.com/NixOS/nixpkgs/commit/30e2263b521eb91762477aede517f5eb6a43e439) | `` exploitdb: 2023-06-07 -> 2023-06-08 ``                                                        |
| [`40b5309a`](https://github.com/NixOS/nixpkgs/commit/40b5309a01a65476f72583cc5f1a49ad89f8b5ca) | `` checkov: 2.3.281 -> 2.3.283 ``                                                                |
| [`6063afae`](https://github.com/NixOS/nixpkgs/commit/6063afae36ed835e5bf0350cdf93ba615067d768) | `` tutanota-desktop: 3.112.6 -> 3.113.3 ``                                                       |
| [`583394b8`](https://github.com/NixOS/nixpkgs/commit/583394b814a522ac0f4bfe10d0ec5d446807a7ff) | `` libremines: init at 1.9.1 (#236291) ``                                                        |
| [`b2ef3aa3`](https://github.com/NixOS/nixpkgs/commit/b2ef3aa3bfcf6afd39563e3df337fc28f899db0e) | `` cli-visualizer: mainProgram added ``                                                          |
| [`2aef5cd1`](https://github.com/NixOS/nixpkgs/commit/2aef5cd131b49b9e39135a5734fd7e64ce8d8bec) | `` virtiofsd: fix SIGSYS when seccomp is turned on ``                                            |
| [`71317efb`](https://github.com/NixOS/nixpkgs/commit/71317efbb568a58cc4168bda174662bb6fe2918f) | `` dune_3: 3.7.1 -> 3.8.1 (#233595) ``                                                           |
| [`c986d827`](https://github.com/NixOS/nixpkgs/commit/c986d8273e873a3b913a00c49c6d71352b86b088) | `` python310Packages.fastdownload: 0.0.6 -> 0.0.7 ``                                             |
| [`fe8aa9b7`](https://github.com/NixOS/nixpkgs/commit/fe8aa9b77968778c6adc132c5ed1603dcc56e8de) | `` fend: 1.1.6 -> 1.2.0 ``                                                                       |
| [`6b9299c6`](https://github.com/NixOS/nixpkgs/commit/6b9299c6f0c9288cd27e498158448a6e43a7692f) | `` sec: 2.9.1 -> 2.9.2 ``                                                                        |
| [`6a57114a`](https://github.com/NixOS/nixpkgs/commit/6a57114a310af1ca49c80f3b6a550b7ebd252942) | `` python310Packages.anthropic: 0.2.9 -> 0.2.10 ``                                               |
| [`65fcecc2`](https://github.com/NixOS/nixpkgs/commit/65fcecc2354e550ffb7dce322e744aa54ce0a888) | `` terraform-providers.vault: 3.15.2 -> 3.16.0 ``                                                |
| [`784981ad`](https://github.com/NixOS/nixpkgs/commit/784981adbb84e2a9bf98989ec0f8a96493978c31) | `` terraform-providers.spotinst: 1.122.0 -> 1.122.1 ``                                           |
| [`983ef591`](https://github.com/NixOS/nixpkgs/commit/983ef5914db7840794891533361da438ebb5d2e1) | `` terraform-providers.ibm: 1.53.0 -> 1.54.0 ``                                                  |
| [`1b7f3cf7`](https://github.com/NixOS/nixpkgs/commit/1b7f3cf730f87d1d53ce2bb2385e7699e4f780da) | `` terraform-providers.scaleway: 2.20.0 -> 2.21.0 ``                                             |
| [`720a00cb`](https://github.com/NixOS/nixpkgs/commit/720a00cb178a3cf029ae5825a73c080df32cc964) | `` terraform-providers.archive: 2.3.0 -> 2.4.0 ``                                                |
| [`4e6d141e`](https://github.com/NixOS/nixpkgs/commit/4e6d141e8af4c8ca4eaeaa6b362f9840b8b2ba23) | `` python310Packages.flask-restful: 0.3.9 -> 0.3.10 ``                                           |
| [`3331569a`](https://github.com/NixOS/nixpkgs/commit/3331569a779db75ee126dbe4dfc74ea0cc9a265f) | `` bat-extras.batman: remove util-linux on Darwin ``                                             |
| [`d2b7c8bd`](https://github.com/NixOS/nixpkgs/commit/d2b7c8bd529d88b10bd5a6db7387ef9505028645) | `` oxker: 0.3.0 -> 0.3.1 ``                                                                      |
| [`5e8d2045`](https://github.com/NixOS/nixpkgs/commit/5e8d204527437dfeb0b98bb811fb49b6e4845cdc) | `` moar: 1.15.1 -> 1.15.2 ``                                                                     |
| [`4847bf2c`](https://github.com/NixOS/nixpkgs/commit/4847bf2cf847939af645cff44f435696d01df77f) | `` pinniped: 0.23.0 -> 0.24.0 ``                                                                 |
| [`4dde8d38`](https://github.com/NixOS/nixpkgs/commit/4dde8d383222ec945af0fa73bc078519fb6df379) | `` assemblyscript: init at 0.27.5 ``                                                             |
| [`3de5f70c`](https://github.com/NixOS/nixpkgs/commit/3de5f70c7dba7c3db0b00d6eba9d5140ed0d8588) | `` zigbee2mqtt: 1.31.1 -> 1.31.2 ``                                                              |
| [`21fcc1de`](https://github.com/NixOS/nixpkgs/commit/21fcc1de89cd11cf5c1a587765fce0fea3d2328a) | `` python3Packages.langchain: 0.0.188 -> 0.0.193 ``                                              |
| [`e60f893a`](https://github.com/NixOS/nixpkgs/commit/e60f893ad40aaf01a2fb1e5c410ae5cf9add3b44) | `` python3Packages.langchainplus-sdk: init at 0.0.6 ``                                           |
| [`a3ce564a`](https://github.com/NixOS/nixpkgs/commit/a3ce564a9473353fd4acc60f1f099d2a95b1a05b) | `` raycast: 1.52.1 -> 1.53.0 ``                                                                  |
| [`1cc00e36`](https://github.com/NixOS/nixpkgs/commit/1cc00e361bdd395002e891eff9afaef39c355141) | `` abcmidi: 2023.03.24 -> 2023.05.30 ``                                                          |
| [`e39fc596`](https://github.com/NixOS/nixpkgs/commit/e39fc5963c08ad61e40fb0c8a22ad9d103e9644e) | `` python310Packages.bambi: disable failing tests ``                                             |
| [`2312d0f9`](https://github.com/NixOS/nixpkgs/commit/2312d0f9f03a296adcdfb4bd2b066c07c9fafa35) | `` python3Packages.torch-bin: only include Linux-specific dependencies when building on Linux `` |
| [`71efe02c`](https://github.com/NixOS/nixpkgs/commit/71efe02ca3cd7599e0eadfc104aa4491b036582c) | `` python311Packages.pyosf: remove pytest-runner ``                                              |
| [`a3492a94`](https://github.com/NixOS/nixpkgs/commit/a3492a94eaf25934b4604ea8ad4cab913b3b9642) | `` python311Packages.fastpair: remove pytest-runner ``                                           |
| [`50c3a639`](https://github.com/NixOS/nixpkgs/commit/50c3a639b62175f7a4c9efc5a14b73b2fccd04b6) | `` python311Packages.sseclient: remove pytest-runner ``                                          |
| [`a1dc86d6`](https://github.com/NixOS/nixpkgs/commit/a1dc86d6399dbb415567e196906bd9276fc48657) | `` static-web-server: 2.17.0 -> 2.18.0 ``                                                        |
| [`287ac1fc`](https://github.com/NixOS/nixpkgs/commit/287ac1fcbd82ae2ba2319fda74f5b021aa792d47) | `` python311Packages.slackclient: remove unused inputs ``                                        |
| [`904b372c`](https://github.com/NixOS/nixpkgs/commit/904b372cb475833b149b78487cddadcbbb103578) | `` python3Packages.pathspec: add key reverse dependencies to passthru.tests ``                   |
| [`f400b178`](https://github.com/NixOS/nixpkgs/commit/f400b178d202d387c566c83d7bd0b9f756674f24) | `` gmic-qt: 3.2.4 -> 3.2.5 ``                                                                    |
| [`ad9f6a15`](https://github.com/NixOS/nixpkgs/commit/ad9f6a15dfccef35f2dccb4d59fd3fc8e1f6e5e0) | `` gmic: 3.2.4 -> 3.2.5 ``                                                                       |
| [`f9dee9b3`](https://github.com/NixOS/nixpkgs/commit/f9dee9b385872f633020bbcd32d6aea604eaebd3) | `` python3Packages.oauthlib: add some key reverse dependencies to passthru.tests ``              |
| [`13f13b83`](https://github.com/NixOS/nixpkgs/commit/13f13b8302deb544359cc36cb964f75e0c0d3c22) | `` python311Packages.iso3166: 2.0.2 -> 2.1.1 ``                                                  |
| [`276c260d`](https://github.com/NixOS/nixpkgs/commit/276c260d63c895e22ddb4eb0592af0386a4b25d6) | `` python311Packages.pyoverkiz: 1.7.9 -> 1.8.0 ``                                                |
| [`40046542`](https://github.com/NixOS/nixpkgs/commit/400465427d6e69f4b39cbcdc8be74b276e4ef369) | `` ntlmrecon: add changelog to meta ``                                                           |
| [`ba522b45`](https://github.com/NixOS/nixpkgs/commit/ba522b459c60b310b24d602b8eae3c5f75d0302c) | `` python311Packages.google-i18n-address: 2.5.2 -> 3.0.0 ``                                      |
| [`a5d85074`](https://github.com/NixOS/nixpkgs/commit/a5d850748565edf4acc4b3c9d7aae0b0115867b1) | `` python311Packages.google-cloud-spanner: 3.35.1 -> 3.36.0 ``                                   |
| [`8000daca`](https://github.com/NixOS/nixpkgs/commit/8000daca5800d37fb7fa9ab6822204e9c67fba2c) | `` python311Packages.google-cloud-container: 2.22.0 -> 2.23.0 ``                                 |
| [`14de09ee`](https://github.com/NixOS/nixpkgs/commit/14de09ee8b9f18713f439a391c1b77f2d6cb802e) | `` python310Packages.gpyopt: remove ``                                                           |
| [`2c9092a3`](https://github.com/NixOS/nixpkgs/commit/2c9092a37779b1350f8f3b06afff2788dac78ec2) | `` gephi: 0.9.6 -> 0.10.1 ``                                                                     |
| [`09966984`](https://github.com/NixOS/nixpkgs/commit/09966984ebbf4f1fef1aee251a109aa7d77fbe42) | `` javaPackages: add jogl 2.4.0 ``                                                               |
| [`4ceeece5`](https://github.com/NixOS/nixpkgs/commit/4ceeece566327b66750d5bc97104afa9050db9f4) | `` exploitdb: set platforms ``                                                                   |
| [`163844f3`](https://github.com/NixOS/nixpkgs/commit/163844f3131b5234369c5a8dd216e6e249b85da3) | `` ArchiSteamFarm: 5.4.5.2 -> 5.4.6.3 ``                                                         |
| [`81a9774d`](https://github.com/NixOS/nixpkgs/commit/81a9774d92ad2a0290278c75b7667d19bbb5a3cf) | `` tuxedo-keyboard 3.1.4 -> 3.2.5 ``                                                             |
| [`d61bdc7d`](https://github.com/NixOS/nixpkgs/commit/d61bdc7ded28212cddbd0eaf870b43301bdbf974) | `` recoll: fix cross ``                                                                          |
| [`2c5682c9`](https://github.com/NixOS/nixpkgs/commit/2c5682c927e612b785a250fbcf774593943c6fad) | `` recoll: add withPython parameter ``                                                           |
| [`66b7d07c`](https://github.com/NixOS/nixpkgs/commit/66b7d07c852995cd84b9550071659e5f065c5f90) | `` cargo-bisect-rustc: 0.6.5 -> 0.6.6 ``                                                         |
| [`c613cd41`](https://github.com/NixOS/nixpkgs/commit/c613cd410243beb082139e2013d025c7641c2317) | `` kgt: 2021-04-07 -> 2023-06-03 ``                                                              |
| [`48fe5014`](https://github.com/NixOS/nixpkgs/commit/48fe50142614837c19d0cea604735ced216d4814) | `` ludusavi: 0.17.1 -> 0.19.0 ``                                                                 |
| [`a38a1641`](https://github.com/NixOS/nixpkgs/commit/a38a16419645446b984d40326e12bd05c93b1f04) | `` masari: unpin boost174 ``                                                                     |
| [`ae01b8ed`](https://github.com/NixOS/nixpkgs/commit/ae01b8ed8d1351c99e76dad737167d8ded8304d8) | `` gitRepo: 2.32 -> 2.34.1 ``                                                                    |
| [`c0db8548`](https://github.com/NixOS/nixpkgs/commit/c0db854816aaffd0b374e667465c6e3023dc39d6) | `` carla: switch to finalAttrs ``                                                                |
| [`54dc023f`](https://github.com/NixOS/nixpkgs/commit/54dc023f7ba5999cc4e494744e7bd64a9e1c71b2) | `` linux_rt_5_10: drop merged patch ``                                                           |
| [`72a47ca3`](https://github.com/NixOS/nixpkgs/commit/72a47ca34940ce3db0a2c3c24cfa552d3848f2c2) | `` lemmy: 0.17.2 -> 0.17.3 ``                                                                    |
| [`0b6b8d64`](https://github.com/NixOS/nixpkgs/commit/0b6b8d640ae8034f68030c11624021d8bc65acf0) | `` python310Packages.miniaudio: 1.58 -> 1.59 ``                                                  |
| [`7fa20d1c`](https://github.com/NixOS/nixpkgs/commit/7fa20d1cb4af2694d13f1fbdf1b2ecac9ab621dc) | `` pgadmin4: 7.2 -> 7.3 ``                                                                       |
| [`8ad28c72`](https://github.com/NixOS/nixpkgs/commit/8ad28c727b87a6f1564d6cf54fd98f6272cd7329) | `` exploitdb: 2023-06-05 -> 2023-06-07 ``                                                        |
| [`1a79c2d6`](https://github.com/NixOS/nixpkgs/commit/1a79c2d6c284e5ce12a3e37a1a6eee7dc76537a3) | `` spicetify-cli: 2.19.0 -> 2.20.0 ``                                                            |
| [`3f9a4f84`](https://github.com/NixOS/nixpkgs/commit/3f9a4f843c4aa7554277fd622e86bf506455b919) | `` lsp-bridge: 20230603.345 -> 20230607.135 ``                                                   |
| [`1d9af31e`](https://github.com/NixOS/nixpkgs/commit/1d9af31e266dbe95f2243d025b1c8e29419ba8eb) | `` signalbackup-tools: 20230603-2 -> 20230607 ``                                                 |
| [`d6e6d694`](https://github.com/NixOS/nixpkgs/commit/d6e6d694c32a3ae664bab5a756ee2e13dba93450) | `` vimPlugins.vim-crystal: init at 2023-03-15 ``                                                 |
| [`9b59981f`](https://github.com/NixOS/nixpkgs/commit/9b59981f40992cdb6f053a11d61093fb3306031b) | `` nushell: 0.80.0 -> 0.81.0 ``                                                                  |
| [`92d7b781`](https://github.com/NixOS/nixpkgs/commit/92d7b781be54fbc88ba9245ffd39f413d0958f74) | `` ttyper: 1.2.1 -> 1.2.2 ``                                                                     |
| [`0757162b`](https://github.com/NixOS/nixpkgs/commit/0757162b3af0243ca38ff3327235a1d2965073a7) | `` invidious: unstable-2023-05-25 -> unstable-2023-06-06 ``                                      |
| [`369940c1`](https://github.com/NixOS/nixpkgs/commit/369940c111f22d5b8a5c1153851bf8c2562fd25f) | `` brave: 1.52.117 -> 1.52.122 ``                                                                |
| [`d3036bb6`](https://github.com/NixOS/nixpkgs/commit/d3036bb60826c7bc1ca51360a6535c077f95ac72) | `` mediawiki: fix group used when apache2 is used ``                                             |
| [`700f91a9`](https://github.com/NixOS/nixpkgs/commit/700f91a9d5faaf8884e2e2792399f3445c34b547) | `` lightningcss: 1.20.0 → 1.21.0 ``                                                              |
| [`9c992236`](https://github.com/NixOS/nixpkgs/commit/9c992236665be78f24d8e472dde9fbef4d0c06fb) | `` lammps: Add backwards compatible link to lmp_serial ``                                        |
| [`64bed841`](https://github.com/NixOS/nixpkgs/commit/64bed841a96db4156b00e61b98d828fc0c56f5a3) | `` lammps: mark as broken for 32 bit lapack & blas ``                                            |
| [`eda942ec`](https://github.com/NixOS/nixpkgs/commit/eda942ec6f9b9bdc2b69927ebfb15daac3847290) | `` stratis-cli: 3.5.2 -> 3.5.3 ``                                                                |
| [`20999414`](https://github.com/NixOS/nixpkgs/commit/209994145da3e08db890082bbb4e3eda75e2ad5d) | `` minesweep-rs: init at 6.0.11 ``                                                               |
| [`abb1b96c`](https://github.com/NixOS/nixpkgs/commit/abb1b96c57c344f94dd3ecc8b5fd21e7fcaaf339) | `` stratisd: 3.5.5 -> 3.5.7 ``                                                                   |
| [`2ef54182`](https://github.com/NixOS/nixpkgs/commit/2ef54182a39463cbf50f0387d2493b98d3abb3c5) | `` cairo-lang: init at 1.1.0 ``                                                                  |
| [`bef5331d`](https://github.com/NixOS/nixpkgs/commit/bef5331d3cd9a6142c20736f6d6f9eaeeaeb37a3) | `` python310Packages.fenics: unpin boost172 ``                                                   |
| [`15c2e24d`](https://github.com/NixOS/nixpkgs/commit/15c2e24dc8bfda5bf034e4b13ade3ca1d0200074) | `` ocamlPackages.tdigest: init at 2.1.1 ``                                                       |
| [`263f2513`](https://github.com/NixOS/nixpkgs/commit/263f2513ee6cb9342f5529ad875530c51e0de301) | `` dnscontrol: 4.1.0 -> 4.1.1 ``                                                                 |
| [`eff73933`](https://github.com/NixOS/nixpkgs/commit/eff73933343496f2974b6f6baeb74a385cbcb979) | `` matrix-synapse: 1.84.1 -> 1.85.1 ``                                                           |
| [`2b105555`](https://github.com/NixOS/nixpkgs/commit/2b1055556f90e27d82bf58bcfd347008729798ec) | `` pot: 0.5.0 -> 1.1.0 ``                                                                        |
| [`900c093e`](https://github.com/NixOS/nixpkgs/commit/900c093e27418bc97b50e085154bc0100bcdff23) | `` zfs: 2.1.11 -> 2.1.12 ``                                                                      |
| [`f14a89d4`](https://github.com/NixOS/nixpkgs/commit/f14a89d482e5ccdb5167f940c9bed61bc6149064) | `` thunderbird: 102.10.1 -> 102.11.2 ``                                                          |
| [`f9418c4c`](https://github.com/NixOS/nixpkgs/commit/f9418c4c7fab906c52ae07cf27a618de7722d1e9) | `` lagrange-tui: fix build ``                                                                    |
| [`89662ae2`](https://github.com/NixOS/nixpkgs/commit/89662ae2b16d3c74d2f82b267083d59beeeebb3a) | `` thunderbird-bin: 102.10.1 -> 102.11.2 ``                                                      |
| [`0617a59c`](https://github.com/NixOS/nixpkgs/commit/0617a59c8be773f10b230d8236629169ee4888a6) | `` repgrep: 0.12.4 -> 0.13.0 ``                                                                  |
| [`3575231f`](https://github.com/NixOS/nixpkgs/commit/3575231f59ee9c8e102767fe95173015fe07a10a) | `` vte: 0.72.1 → 0.72.2 ``                                                                       |
| [`9e05589e`](https://github.com/NixOS/nixpkgs/commit/9e05589eee1da7bcc1effb67a260136f4430d341) | `` zigbee2mqtt: 1.31.0 -> 1.31.1 ``                                                              |