### PR TITLE
chore(flake/darwin): `40e4b85b` -> `7c16d313`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -87,11 +87,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686210161,
-        "narHash": "sha256-cgP8P2Gk4WtOzd/Y7nEmweLpPOtMKVvHCIcq9zm9qMk=",
+        "lastModified": 1686307493,
+        "narHash": "sha256-R4VEFnDn7nRmNxAu1LwNbjns5DPM8IBsvnrWmZ8ymPs=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "40e4b85baac86969f94d6dba893aeae015c562c1",
+        "rev": "7c16d31383a90e0e72ace0c35d2d66a18f90fb4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
| [`1ba9ae3d`](https://github.com/LnL7/nix-darwin/commit/1ba9ae3d217c2285909232d635caeaf0e16ecd54) | `` darwin-installer: fix `/run` not getting created `` |