### PR TITLE
chore(flake/home-manager): `000df987` -> `0945875a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -209,11 +209,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686339152,
-        "narHash": "sha256-qb2mdIwZvK1vNhj5zxnx1iw28pn3Zt0F7SRpSXkOo5k=",
+        "lastModified": 1686342731,
+        "narHash": "sha256-GwCwviXcc5nrewuFwtsrxys8srrZcI+m8hdIGOt+fHY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "000df987957b459b4e3de9e8977f95028e627424",
+        "rev": "0945875a2a20de314093b0f9d4d5448e9b4fdccb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`0945875a`](https://github.com/nix-community/home-manager/commit/0945875a2a20de314093b0f9d4d5448e9b4fdccb) | `` boxxy: add module (#4075) ``                                     |
| [`2a69182c`](https://github.com/nix-community/home-manager/commit/2a69182c569b190ae0d95244707db4d1209de6cf) | `` Revert "maintainers: add rasmus-kirk as a maintainer" (#4076) `` |