### PR TITLE
chore(flake/nixpkgs): `a64b73e0` -> `ae766d59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -348,11 +348,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686226982,
-        "narHash": "sha256-nLuiPoeiVfqqzeq9rmXxpybh77VS37dsY/k8N2LoxVg=",
+        "lastModified": 1686319658,
+        "narHash": "sha256-tGWdoUAqKnE866mYFlEfc2a99kxFy31hOQJH5YQKrTQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a64b73e07d4aa65cfcbda29ecf78eaf9e72e44bd",
+        "rev": "ae766d59b07c450e0f1de8a1bfd6529089f40849",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`16f6a3bb`](https://github.com/NixOS/nixpkgs/commit/16f6a3bb7052dd8066ec33324a233be5be82ee84) | `` ical2orgpy: fix eval ``                                                         |
| [`652c7169`](https://github.com/NixOS/nixpkgs/commit/652c71692236f4d24a692b43d343fc9ba5ae306a) | `` frida-tools: fix eval ``                                                        |
| [`49de589a`](https://github.com/NixOS/nixpkgs/commit/49de589aea5036aef1878119aed0b7adb03463dd) | `` mailctl: init at 0.8.8 ``                                                       |
| [`0ac64816`](https://github.com/NixOS/nixpkgs/commit/0ac648164a79f99fa9f01b83bf7168df29d18ece) | `` python311Packages.pyschlage: 2023.5.0 -> 2023.6.0 ``                            |
| [`12384415`](https://github.com/NixOS/nixpkgs/commit/1238441581e602fb60c56414934f014aae15f119) | `` python311Packages.elkm1-lib: 2.2.2 -> 2.2.3 ``                                  |
| [`e87f290b`](https://github.com/NixOS/nixpkgs/commit/e87f290b64cc7f3cbce638762324668f91bdcbda) | `` frida-tools: use fetchPypi from top-level ``                                    |
| [`da20893f`](https://github.com/NixOS/nixpkgs/commit/da20893f54d05d9a4f9f582a0d4bff3a0d557900) | `` python3Packages.torch-bin: remove useless patchelf ``                           |
| [`87564f7c`](https://github.com/NixOS/nixpkgs/commit/87564f7c75f0860eccde59c61d579be27f186255) | `` scid-vs-pc: 4.22 -> 4.24 ``                                                     |
| [`7c7827cf`](https://github.com/NixOS/nixpkgs/commit/7c7827cf57547fa3a0c3231eac2ccaa1cf545add) | `` terraform-providers.rancher2: 3.0.0 -> 3.0.1 ``                                 |
| [`6f85caa2`](https://github.com/NixOS/nixpkgs/commit/6f85caa2bd7d2f4647cac0ce78a40f5dd622d7e0) | `` terraform-providers.selectel: 3.9.1 -> 3.10.0 ``                                |
| [`025e9159`](https://github.com/NixOS/nixpkgs/commit/025e9159f2d879ea4f736bc238d6cd8e4e4000af) | `` terraform-providers.newrelic: 3.24.0 -> 3.24.1 ``                               |
| [`607e12a5`](https://github.com/NixOS/nixpkgs/commit/607e12a54c2ca1e183fb4d6d00c5f7851f71ba35) | `` terraform-providers.keycloak: 4.3.0 -> 4.3.1 ``                                 |
| [`9743d70e`](https://github.com/NixOS/nixpkgs/commit/9743d70e8fd87a0d9e3de840367fbd1d9a469eea) | `` terraform-providers.exoscale: 0.48.0 -> 0.49.0 ``                               |
| [`42754a72`](https://github.com/NixOS/nixpkgs/commit/42754a724d486c2bb4888c7602fb4f7d90772931) | `` nodejs_20: 20.2.0 -> 20.3.0 ``                                                  |
| [`a8b62c1c`](https://github.com/NixOS/nixpkgs/commit/a8b62c1c2911f10fd597896311aacd51ea2a1267) | `` cargo-vet: 0.6.1 -> 0.7.0 ``                                                    |
| [`23fc7d64`](https://github.com/NixOS/nixpkgs/commit/23fc7d64220042d1fd6ef51c3be540f94bb3ac38) | `` squirrel-sql: 4.5.1 -> 4.6.0 ``                                                 |
| [`bd4871d9`](https://github.com/NixOS/nixpkgs/commit/bd4871d9d17d79b15d4823c03951a32434d7dd3e) | `` tshark: 4.0.5 -> 4.0.6 ``                                                       |
| [`60df441a`](https://github.com/NixOS/nixpkgs/commit/60df441affa43c5ca7554cccec7aa44fbfcfd35c) | `` python310Packages.wasabi: 1.1.1 -> 1.1.2 ``                                     |
| [`450f033b`](https://github.com/NixOS/nixpkgs/commit/450f033b012df75591c8b42b49538b07a40c9f58) | `` cairo: modernize patches ``                                                     |
| [`19aec0cb`](https://github.com/NixOS/nixpkgs/commit/19aec0cbcb71d2cec5f78d3c32b7039cdc531b36) | `` cairo: update outdated patch link ``                                            |
| [`dad63204`](https://github.com/NixOS/nixpkgs/commit/dad6320407c2970f6d1f590c693ccb2619231ec1) | `` fish: fix build with Darwin sandbox enabled ``                                  |
| [`61c98374`](https://github.com/NixOS/nixpkgs/commit/61c98374255d4604fc99e124cc68b3559117b7bf) | `` browserpass: add testVersion ``                                                 |
| [`4629209e`](https://github.com/NixOS/nixpkgs/commit/4629209e393125c373272fa043adcb49f5b8a98c) | `` python310Packages.pdm-backend: 2.0.7 -> 2.1.0 ``                                |
| [`ab73a8f0`](https://github.com/NixOS/nixpkgs/commit/ab73a8f0fbecae1c5feed47a08103f2390cbb444) | `` arx-libertatis: 2020-10-20 -> 1.2.1 ``                                          |
| [`7d02d8d3`](https://github.com/NixOS/nixpkgs/commit/7d02d8d3c9e6d6b37ba721c1c4be2e3c7fd96591) | `` goblob: init at 1.2.2 ``                                                        |
| [`282edfca`](https://github.com/NixOS/nixpkgs/commit/282edfca5bf6ed426a7333907ae139271511a04a) | `` browserpass: autopatchelf only on linux ``                                      |
| [`cbf5bf89`](https://github.com/NixOS/nixpkgs/commit/cbf5bf89d556e38710f3622d540e890e29696a10) | `` Revert "Merge pull request #235852 from thoughtpolice/nixpkgs/gvisor-update" `` |
| [`02f3bd9e`](https://github.com/NixOS/nixpkgs/commit/02f3bd9ef0573b065315233ab1b632aeb8a73405) | `` gotestwaf: 0.4.0 -> 0.4.3 ``                                                    |
| [`be263192`](https://github.com/NixOS/nixpkgs/commit/be26319236597cf5538f2afe397cdaf628206d8b) | `` xcodes: init at 1.3.0 ``                                                        |
| [`83cd2017`](https://github.com/NixOS/nixpkgs/commit/83cd2017b1d001bfef8a54ad8296f47bd90bb335) | `` runme: 1.2.2 -> 1.2.4 ``                                                        |
| [`3d0614dd`](https://github.com/NixOS/nixpkgs/commit/3d0614dda65a67adeb82b4a6293d3e253245f816) | `` genesys: init at 1.0.7 ``                                                       |
| [`0ccec0e6`](https://github.com/NixOS/nixpkgs/commit/0ccec0e6e7dd183a046810de6549ed6bd46b81d3) | `` python311Packages.mwparserfromhell: remove pytest-runner ``                     |
| [`c793615a`](https://github.com/NixOS/nixpkgs/commit/c793615ab8398f145f15211b59e0a201770ffcfc) | `` checkov: 2.3.283 -> 2.3.285 ``                                                  |
| [`6e1dfa18`](https://github.com/NixOS/nixpkgs/commit/6e1dfa189ff72cd3f0b146eb25ccb2a0d8f4c809) | `` unscii: 1.1 -> 2.1 ``                                                           |
| [`f3f38a21`](https://github.com/NixOS/nixpkgs/commit/f3f38a2130f2096b8da76e233765c1ca4e2b7862) | `` python310Packages.ansible-core: provide passlib ``                              |
| [`06fbea9a`](https://github.com/NixOS/nixpkgs/commit/06fbea9a570d6d04f5e06c8d2abc8259816dfa8a) | `` python311Packages.emoji: 2.4.0 -> 2.5.0 ``                                      |
| [`10457705`](https://github.com/NixOS/nixpkgs/commit/10457705d66daa35e876904fad057a2d516118cc) | `` python310Packages.dvclive: 2.11.0 -> 2.11.1 ``                                  |
| [`a5ce36d0`](https://github.com/NixOS/nixpkgs/commit/a5ce36d0c6509fd443eb009847d8cdcb7ff52a52) | `` python311Packages.dvc-data: 0.54.3 -> 0.55.0 ``                                 |
| [`9c6b8259`](https://github.com/NixOS/nixpkgs/commit/9c6b825963e11307d995965f6d3b659b17509625) | `` python311Packages.pyunifiprotect: 4.10.1 -> 4.10.2 ``                           |
| [`cde6018d`](https://github.com/NixOS/nixpkgs/commit/cde6018d83a8a9d5427045896919eaf3ccfeb971) | `` python311Packages.python-roborock: 0.23.4 -> 0.23.6 ``                          |
| [`3085e242`](https://github.com/NixOS/nixpkgs/commit/3085e24225814cee433d975233a7db18cebad1e9) | `` filebot: use finalAttrs pattern with mkDerivation instead of rec ``             |
| [`24114b5f`](https://github.com/NixOS/nixpkgs/commit/24114b5f834cfa732781e1cf901ab07ef995caab) | `` ldtk: use finalAttrs pattern with mkDerivation instead of rec ``                |
| [`0f40577f`](https://github.com/NixOS/nixpkgs/commit/0f40577f8b3b465d67c543c20e3732bdf42574cf) | `` python311Packages.aioairzone-cloud: 0.1.7 -> 0.1.8 ``                           |
| [`0f77f645`](https://github.com/NixOS/nixpkgs/commit/0f77f645aaa85fbe00b3adab2bbb21bb3d06cc38) | `` python311Packages.token-bucket: remove pytest-runner ``                         |
| [`5be7d1d2`](https://github.com/NixOS/nixpkgs/commit/5be7d1d23898b0ad7acd142ec13552a98f9a1ebf) | `` go2tv: 1.14.1 -> 1.15.0 ``                                                      |
| [`0c2eb01d`](https://github.com/NixOS/nixpkgs/commit/0c2eb01d10158e25f0af15b1cd0b6ea5960a1cfe) | `` python311Packages.reolink-aio: 0.5.16 -> 0.6.0 ``                               |
| [`3b1e9066`](https://github.com/NixOS/nixpkgs/commit/3b1e90660e185513734dc4721b1aeacafeb79b7d) | `` python311Packages.py-multibase: remove pytest-runner ``                         |
| [`b90237d6`](https://github.com/NixOS/nixpkgs/commit/b90237d64ebcb9a017e9d56b2219b6101a37af00) | `` vscode: 1.78.2 -> 1.79.0 ``                                                     |
| [`8b99f7b5`](https://github.com/NixOS/nixpkgs/commit/8b99f7b59da2316ef6e1e2b08035549988807188) | `` python311Packages.ndjson: adjust inputs ``                                      |
| [`17d63282`](https://github.com/NixOS/nixpkgs/commit/17d63282b27555fada48909a471c8b000e1c8f01) | `` haskell.compiler: allow overriding source with hadrian ``                       |
| [`4f78d954`](https://github.com/NixOS/nixpkgs/commit/4f78d9544a71ab8c3811092801f739d93d765154) | `` python311Packages.aiohomekit: 2.6.4 -> 2.6.5 ``                                 |
| [`a7546909`](https://github.com/NixOS/nixpkgs/commit/a754690981b3eb0c09460c2bcbf14331db18a352) | `` amdgpu_top: 0.1.8 -> 0.1.9 ``                                                   |
| [`55dbe9fb`](https://github.com/NixOS/nixpkgs/commit/55dbe9fbd23a8fd8fbbbecf549489f2300015497) | `` tor-browser-bundle-bin: add felschr & panicgh as maintainers ``                 |
| [`939969f4`](https://github.com/NixOS/nixpkgs/commit/939969f44c5cb843bc7c9231d9fafbb70d4696eb) | `` tor-browser-bundle-bin: remove inactive maintainers ``                          |
| [`13306bfd`](https://github.com/NixOS/nixpkgs/commit/13306bfd753d86233abc1dd8c6d2bb72efbb56eb) | `` tor-browser-bundle-bin: 12.0.6 -> 12.0.7 ``                                     |
| [`1dcbf1f6`](https://github.com/NixOS/nixpkgs/commit/1dcbf1f690b6a9da135a875bea9512ab94fb11b4) | `` python311Packages.py-multicodec: remove pytest-runner ``                        |
| [`6b0956d6`](https://github.com/NixOS/nixpkgs/commit/6b0956d6617bb6bff686e9c6ec74cc3903199a5f) | `` python311Packages.fontmath: remove pytest-runner ``                             |
| [`c45c1940`](https://github.com/NixOS/nixpkgs/commit/c45c1940c043465d90e9a1278e7b08294f93b7b1) | `` python311Packages.waterfurnace: remove pytest-runner ``                         |
| [`c69621b8`](https://github.com/NixOS/nixpkgs/commit/c69621b8bdc47d8baa5aaca7a0b61253d7568772) | `` gitea: Add coreutils binaries to PATH ``                                        |
| [`2a294648`](https://github.com/NixOS/nixpkgs/commit/2a294648ca23ee0f8b5d7692114fc9c99468eefa) | `` gitea: Fix substitution in wrong file after rebasing a patch ``                 |
| [`588e307c`](https://github.com/NixOS/nixpkgs/commit/588e307c659fe78c17d9d35e12d5226bfc0d3273) | `` kde/gear: 23.04.1 -> 23.04.2 ``                                                 |
| [`389cbc1e`](https://github.com/NixOS/nixpkgs/commit/389cbc1e22697a0cc48d2cc43d635ae167d815c6) | `` qutebrowser: 2.5.3 -> 2.5.4 ``                                                  |
| [`77f2a209`](https://github.com/NixOS/nixpkgs/commit/77f2a209e91931ecf2fe28352dcb4a0834030c6c) | `` ical2orgpy: init at 0.4.0 ``                                                    |
| [`c9e39860`](https://github.com/NixOS/nixpkgs/commit/c9e39860d8c5a16a963d0343099e2b6d5ede81a1) | `` minecraft-server: 1.19.4 -> 1.20 ``                                             |
| [`88e640fd`](https://github.com/NixOS/nixpkgs/commit/88e640fd68115e424b7f539bf2496b69db2563db) | `` jsonnet: Build with cmake (#236510) ``                                          |
| [`b9af135b`](https://github.com/NixOS/nixpkgs/commit/b9af135b1b08f18fcb87b9649f8be85ff0fe0869) | `` typos: 1.14.12 -> 1.15.0 ``                                                     |
| [`081b93ab`](https://github.com/NixOS/nixpkgs/commit/081b93ab2e742e821f2e8c77a211ff5ba1be2bce) | `` regreet: 0.1.0 -> 0.1.1 ``                                                      |
| [`7c99d4b1`](https://github.com/NixOS/nixpkgs/commit/7c99d4b1dc320e0c79bcbe447dbebb086f607989) | `` driftctl: 0.38.2 -> 0.39.0 ``                                                   |
| [`8369ba89`](https://github.com/NixOS/nixpkgs/commit/8369ba89a06d231ec5a583584d8584107d224fab) | `` kubetail: 1.6.16 -> 1.6.18 ``                                                   |
| [`0828a661`](https://github.com/NixOS/nixpkgs/commit/0828a6612d9815febf9fb4e92c567acac7fec284) | `` rrdtool: unpin tcl-8_5 ``                                                       |
| [`e8ef1bad`](https://github.com/NixOS/nixpkgs/commit/e8ef1bad1bffa4a6353260d3297a241a58cb95cb) | `` alpine: unpin tcl-8_5 ``                                                        |
| [`4b951d92`](https://github.com/NixOS/nixpkgs/commit/4b951d921e8d249a6f62fb4980bb9a9e152cdba4) | `` grafana-agent: 0.33.2 -> 0.34.0 ``                                              |
| [`97a5d1c9`](https://github.com/NixOS/nixpkgs/commit/97a5d1c93afc02b2b29e13fd7449855576b5504e) | `` xconq: add darwin support ``                                                    |
| [`89952f7b`](https://github.com/NixOS/nixpkgs/commit/89952f7bb678de4c51dcc8f42110fe9ad1f52260) | `` nixosTests.luks: mount the host Nix store ``                                    |
| [`ff3936e1`](https://github.com/NixOS/nixpkgs/commit/ff3936e14b727d3a29d1a3212d6919055ac61804) | `` nixos/tests/lvm2/systemd-stage-1: mount the host Nix store ``                   |
| [`59891e40`](https://github.com/NixOS/nixpkgs/commit/59891e405d1e6ac03d41d0ccc711fe6c0da7d192) | `` nixosTests.systemd-initrd-networkd-ssh: bootDevice -> rootDevice ``             |
| [`c1f0de6e`](https://github.com/NixOS/nixpkgs/commit/c1f0de6e2006b0c60f0fae602e073415574fd0eb) | `` nixosTests.systemd-initrd-luks-keyfile: mount the host Nix store ``             |
| [`bbfedea0`](https://github.com/NixOS/nixpkgs/commit/bbfedea0a147acc3593fe948cb5ac77fed7a0d51) | `` nixosTests.systemd-initrd-luks-password: mount the host Nix store ``            |
| [`efe64826`](https://github.com/NixOS/nixpkgs/commit/efe64826c9a9a7feb6148c60c888d7ce9d882011) | `` nixosTests.systemd-initrd-luks-tpm2: mount the host Nix store ``                |
| [`e190364f`](https://github.com/NixOS/nixpkgs/commit/e190364fd72815d636bc2c7a48752155643f75fc) | `` nixosTests.systemd-initrd-networkd-ssh: mount the host Nix store ``             |
| [`db811f12`](https://github.com/NixOS/nixpkgs/commit/db811f12eb5393c4a1113139713d4a4937209c22) | `` nixosTests.systemd-initrd-swraid: mount the host Nix store ``                   |
| [`de7f3cb2`](https://github.com/NixOS/nixpkgs/commit/de7f3cb2fa53380da6ef3da5c74e5b6a25e3e3c9) | `` nixosTests.systemd-initrd-luks-fido2: mount the host Nix store ``               |
| [`955a77e1`](https://github.com/NixOS/nixpkgs/commit/955a77e1c4ad08c1b5952718d1ef16b8bbbdbd60) | `` nixosTests.systemd-initrd-btrfs-raid: mount the host Nix store ``               |
| [`caf6f41e`](https://github.com/NixOS/nixpkgs/commit/caf6f41e2e1b05525e127f5ab5eb2c335ae40a91) | `` nixosTests.initrd-luks-empty-passphrase: mount the host nix store ``            |
| [`337bc223`](https://github.com/NixOS/nixpkgs/commit/337bc2233cf7c7bfb124cb04b98bc44116188d71) | `` dirdiff: add darwin support ``                                                  |
| [`e92a5c77`](https://github.com/NixOS/nixpkgs/commit/e92a5c7766ec2138670e7decf504ed78cb89ea53) | `` sniffnet: 1.2.0 -> 1.2.1 ``                                                     |
| [`c05f72e9`](https://github.com/NixOS/nixpkgs/commit/c05f72e9babe0cdd4eaea15e1f42ca6afa8b5996) | `` rxvt-unicode: 9.30 -> 9.31 ``                                                   |
| [`902f5754`](https://github.com/NixOS/nixpkgs/commit/902f57541619dba9e330f2adcb2be5d4f5cfd518) | `` burpsuite: 2023.5.2 -> 2023.5.3 ``                                              |
| [`116e050d`](https://github.com/NixOS/nixpkgs/commit/116e050d768f20ce07ec7e46c9454933139972d9) | `` spicetify-cli: change sha256 to hash and don't use pname ``                     |
| [`6ea0aa68`](https://github.com/NixOS/nixpkgs/commit/6ea0aa6814839f3a5236c90712ecc98837ca0561) | `` julia_19-bin: 1.9.0 -> 1.9.1 ``                                                 |
| [`648efce5`](https://github.com/NixOS/nixpkgs/commit/648efce549ee3b00ba9ffcb2c44c3c7197ea46fe) | `` boost1{68-74}: drop ``                                                          |
| [`92631433`](https://github.com/NixOS/nixpkgs/commit/926314334a782ccc3ae88ea771d02d5c87d2a8d9) | `` headache: move from ocamlPackages to top-level ``                               |
| [`93ef3c8c`](https://github.com/NixOS/nixpkgs/commit/93ef3c8c192411ad4c08d69fce29cf743675d8c9) | `` hblock: set platforms ``                                                        |
| [`93c3b2e7`](https://github.com/NixOS/nixpkgs/commit/93c3b2e75ae9892ff9420a868575a85a0a190271) | `` wiki-js: drop node version check ``                                             |
| [`08139a76`](https://github.com/NixOS/nixpkgs/commit/08139a76264623b824174fe4d1629e6f1283a812) | `` grafana: 9.5.2 -> 9.5.3 ``                                                      |
| [`b0613d65`](https://github.com/NixOS/nixpkgs/commit/b0613d65f1acfd9b4310b109e55b259524016001) | `` foundationdb: 7.1.30 -> 7.1.32 ``                                               |
| [`d4886a06`](https://github.com/NixOS/nixpkgs/commit/d4886a06894ea17d7f908a64184a72e44c8e58ed) | `` julia_19: 1.9.0 -> 1.9.1 ``                                                     |
| [`6b40b65c`](https://github.com/NixOS/nixpkgs/commit/6b40b65cca732d0931978d72252a44ccb2290165) | `` python310Packages.zigpy-znp: Remove xdist, rerun failed tests ``                |
| [`dd695d2d`](https://github.com/NixOS/nixpkgs/commit/dd695d2d3a9d711d2fab669a222169ae5e96127c) | `` frida-tools: init at 12.1.2 ``                                                  |
| [`d5994dc9`](https://github.com/NixOS/nixpkgs/commit/d5994dc91c226cc7ca9e869bad464805cf3d65c0) | `` python3Packages.frida-python: init at 16.0.19 ``                                |
| [`4b8f7098`](https://github.com/NixOS/nixpkgs/commit/4b8f7098da49ffdb3d663fdebd7cc5c6b762a52f) | `` foundationdb: cleanup ``                                                        |
| [`504b16b1`](https://github.com/NixOS/nixpkgs/commit/504b16b10ea225f0b2c1236669c786f1781eab26) | `` postfix: 3.8.0 -> 3.8.1 ``                                                      |
| [`33e6485a`](https://github.com/NixOS/nixpkgs/commit/33e6485a1c884337c7e707202278af695d36f7d9) | `` cinnamon.bulky: 2.8 -> 2.9 ``                                                   |
| [`e04a86f0`](https://github.com/NixOS/nixpkgs/commit/e04a86f07c4ac3b28d97d903fb344c3683f5db3d) | `` cinnamon.mint-cursor-themes: 1.0.1 -> 1.0.2 ``                                  |
| [`3b369e73`](https://github.com/NixOS/nixpkgs/commit/3b369e73789c607ef0f8a8521d7f12aad6077678) | `` cinnamon.warpinator: 1.6.2 -> 1.6.3 ``                                          |
| [`523b21a2`](https://github.com/NixOS/nixpkgs/commit/523b21a273961d356b6ccfdb59fb655ebe0b4acb) | `` cpp-utilities: 5.22.0 -> 5.23.0 ``                                              |
| [`a0aef0be`](https://github.com/NixOS/nixpkgs/commit/a0aef0bec7ef05e23b80a4ead5db5195b63053d8) | `` sticky: 1.14 -> 1.16 ``                                                         |
| [`4101d605`](https://github.com/NixOS/nixpkgs/commit/4101d605ceaefec0aa50b16a0428cd591ea4b722) | `` kubeconform: 0.6.1 -> 0.6.2 ``                                                  |
| [`64aa3024`](https://github.com/NixOS/nixpkgs/commit/64aa3024b585f5eb77d52cafe6476eaba0329197) | `` cinnamon.xapp: actually fix gtk3 module target dir ``                           |
| [`1e8e84a5`](https://github.com/NixOS/nixpkgs/commit/1e8e84a59fdbdcb6a053066eb04d5596feb266ac) | `` cinnamon.cinnamon-common: unbreak cinnamon-settings-users ``                    |
| [`f5a786a4`](https://github.com/NixOS/nixpkgs/commit/f5a786a4bbb5933b74013fc944a5e2feff77730a) | `` cinnamon.cinnamon-common: unbreak cinnamon-spice-updater ``                     |
| [`4fe17349`](https://github.com/NixOS/nixpkgs/commit/4fe173493a7c7786766b4394d37d6916f960e30d) | `` cinnamon.cinnamon-common: rewrite some substitutions with substituteInPlace ``  |
| [`ad888c99`](https://github.com/NixOS/nixpkgs/commit/ad888c99e5ca0521720f5e371b41dd8b86953706) | `` cinnamon.cinnamon-common: group and sort substitutions ``                       |
| [`924193b5`](https://github.com/NixOS/nixpkgs/commit/924193b5e31f19d58207c1e07a38ed30d43ecd92) | `` cinnamon.cinnamon-common: fix all hardcode absolute paths in applets ``         |
| [`cdc819e0`](https://github.com/NixOS/nixpkgs/commit/cdc819e0d5ec5732f93d136eab375192e0690c7b) | `` python310Packages.eccodes: 2.30.0 -> 2.30.2 ``                                  |
| [`4ae88178`](https://github.com/NixOS/nixpkgs/commit/4ae88178bbfc6853525bc31cac5ae76e7ef8eff5) | `` python310Packages.textual: 0.26.0 -> 0.27.0 ``                                  |
| [`ec2a492d`](https://github.com/NixOS/nixpkgs/commit/ec2a492d4ca2ebe3c9eeef906ee17a04331a7551) | `` python310Packages.trimesh: 3.21.7 -> 3.22.0 ``                                  |
| [`b422ca28`](https://github.com/NixOS/nixpkgs/commit/b422ca288c3e6a21e4c82c52936cbdde6fdaae0f) | `` php82: 8.2.6 -> 8.2.7 ``                                                        |
| [`678084e0`](https://github.com/NixOS/nixpkgs/commit/678084e0faeb9ccbd84e18afa45269780948fc72) | `` php81: 8.1.19 -> 8.1.20 ``                                                      |
| [`e6a26b90`](https://github.com/NixOS/nixpkgs/commit/e6a26b900caddb8c2a033b7fb65c0971ab129664) | `` php80: 8.0.28 -> 8.0.29 ``                                                      |
| [`67b191ad`](https://github.com/NixOS/nixpkgs/commit/67b191adcb15cdcc9f14b8beefb3b6608512623b) | `` python311Packages.homeassistant-stubs: 2023.5.4 -> 2023.6.0 ``                  |
| [`67c8d678`](https://github.com/NixOS/nixpkgs/commit/67c8d6782fa2638854144d37bb7762ef00338788) | `` hblock: 3.4.1 -> 3.4.2 ``                                                       |
| [`ee3e055b`](https://github.com/NixOS/nixpkgs/commit/ee3e055be9ee3cf2081861c86ae971e2c94eef4a) | `` liblouis: 3.25.0 -> 3.26.0 ``                                                   |
| [`52a6c282`](https://github.com/NixOS/nixpkgs/commit/52a6c282270e8acfc91d972063e34b2ec5f12275) | `` gitoxide: 0.25.0 -> 0.26.0 ``                                                   |
| [`fee71b7f`](https://github.com/NixOS/nixpkgs/commit/fee71b7f5970f5c46b18ac8f0beffb8bb400c26c) | `` telegram-desktop: patch for failing to open links on wayland ``                 |
| [`393f67fe`](https://github.com/NixOS/nixpkgs/commit/393f67fe88f5e3f7765868b3ed7a5703d178207d) | `` bdf2psf: 1.220 -> 1.221 ``                                                      |
| [`3dac2557`](https://github.com/NixOS/nixpkgs/commit/3dac2557ff0873f8afec1f336740a3f62bec76c8) | `` khal: 0.11.1 -> 0.11.2 ``                                                       |
| [`311da930`](https://github.com/NixOS/nixpkgs/commit/311da9300a53e5893730408880218c4681029c28) | `` monkeysAudio: 10.13 -> 10.14 ``                                                 |
| [`8deaa732`](https://github.com/NixOS/nixpkgs/commit/8deaa732a8a4521d81fbaf956a9039a42412b9ab) | `` refactor: Split `mkdir -m …` into `mkdir` + `chmod` ``                          |
| [`b0a9abed`](https://github.com/NixOS/nixpkgs/commit/b0a9abedea509018d76ef25312f18253eee4fd48) | `` refactor: Use dummy variable name for unused value ``                           |
| [`207180ad`](https://github.com/NixOS/nixpkgs/commit/207180add1e094ba70fce4cf83569a466364c9c9) | `` erg: init at 0.6.13 ``                                                          |
| [`5975b3f9`](https://github.com/NixOS/nixpkgs/commit/5975b3f92ab21e708c4b504ef2e2642b4ee65600) | `` python311Packages.pyzerproc: disable failing tests ``                           |
| [`c0ef3e61`](https://github.com/NixOS/nixpkgs/commit/c0ef3e612122f0874ab149df1c2b20e1140ef706) | `` python310Packages.python-tado: 0.12.0 -> 0.15.0 ``                              |