### PR TITLE
chore(flake/nixos-hardware): `e4b34b90` -> `70d5f55f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -333,11 +333,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1686217350,
-        "narHash": "sha256-Nb9b3m/GEK8jyFsYfUkXGsqj6rH05GgJ2QWcNNbK7dw=",
+        "lastModified": 1686396027,
+        "narHash": "sha256-gE+csxJoXuNn5ZnlgNj0GnMQ2y4heBtDqkB1af8vfjU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e4b34b90f27696ec3965fa15dcbacc351293dc67",
+        "rev": "70d5f55faee9c1e141e32e6be1e77d13e5a570db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`cc942923`](https://github.com/NixOS/nixos-hardware/commit/cc942923915d500c83822b72edef50b6c649ab35) | `` starfive visionfive2: Add firmware update script. `` |
| [`54cc1a6c`](https://github.com/NixOS/nixos-hardware/commit/54cc1a6c79dd2cdb7698816cb2d40e257f2939d3) | `` hp.14-df0023: init ``                                |