### PR TITLE
chore(flake/nixpkgs): `ae766d59` -> `21951114`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -348,11 +348,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686319658,
-        "narHash": "sha256-tGWdoUAqKnE866mYFlEfc2a99kxFy31hOQJH5YQKrTQ=",
+        "lastModified": 1686412476,
+        "narHash": "sha256-inl9SVk6o5h75XKC79qrDCAobTD1Jxh6kVYTZKHzewA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ae766d59b07c450e0f1de8a1bfd6529089f40849",
+        "rev": "21951114383770f96ae528d0ae68824557768e81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`9967f8a7`](https://github.com/NixOS/nixpkgs/commit/9967f8a79680b98788d5e1eb765c9f3e12850c8b) | `` emacsPackages.beancount: init at 20230205.436 ``                              |
| [`dabcf529`](https://github.com/NixOS/nixpkgs/commit/dabcf529135db0708319c39eba05af2a8d639b73) | `` katriawm: 22.12 -> 23.04 ``                                                   |
| [`ca2cb9f6`](https://github.com/NixOS/nixpkgs/commit/ca2cb9f644458b1a7836eb49fd98a7eafdbe560c) | `` treewide: "libary" -> "library" ``                                            |
| [`f4dc3a34`](https://github.com/NixOS/nixpkgs/commit/f4dc3a341f755184032c4922bdcb8e8b67f819ce) | `` python310Packages.nunavut: add changelog to meta ``                           |
| [`d9a45f20`](https://github.com/NixOS/nixpkgs/commit/d9a45f2034384da4279c38d3212eb7eedc1f82e7) | `` cannelloni: init at 1.1.0 ``                                                  |
| [`7e82832f`](https://github.com/NixOS/nixpkgs/commit/7e82832f71eefda442c94da5d2482c6c28bff15d) | `` nix-index-unwrapped: 0.1.5 -> 0.1.6 ``                                        |
| [`c39d76e2`](https://github.com/NixOS/nixpkgs/commit/c39d76e24de174d4b30196f6bf9b748f036c196a) | `` liblinphone: disable -Werror ``                                               |
| [`60cc874f`](https://github.com/NixOS/nixpkgs/commit/60cc874f4efac1bd8564c4c842e8152558fb5ed0) | `` mani: 0.24.0 -> 0.25.0 ``                                                     |
| [`34a8e66c`](https://github.com/NixOS/nixpkgs/commit/34a8e66ca0f97547953149c20490cc3422591d04) | `` wayland-utils: 1.1.0 -> 1.2.0 ``                                              |
| [`4b06b747`](https://github.com/NixOS/nixpkgs/commit/4b06b747f266e66ac0697ea8fa59504fc7990f10) | `` dupd: 1.7.2 -> 1.7.3 ``                                                       |
| [`d9e5d586`](https://github.com/NixOS/nixpkgs/commit/d9e5d586be6f38adcfebead4f1fd9d8ee1403d51) | `` python311Packages.jsbeautifier: add changelog to meta ``                      |
| [`83663467`](https://github.com/NixOS/nixpkgs/commit/8366346779919433c91b56e4d9e909853773a22b) | `` open-policy-agent: 0.53.0 -> 0.53.1 ``                                        |
| [`652e1b50`](https://github.com/NixOS/nixpkgs/commit/652e1b5019e119b20253ed85351372b05f97d99e) | `` python311Packages.nessclient: 0.10.0 -> 1.0.0 ``                              |
| [`347436cf`](https://github.com/NixOS/nixpkgs/commit/347436cff807c80b935daeadb12d398953cf86e5) | `` python311Packages.peaqevcore: 18.1.4 -> 18.1.5 ``                             |
| [`6761a552`](https://github.com/NixOS/nixpkgs/commit/6761a5528948d70140836ae7263c50a6fee2ac14) | `` python311Packages.pyatv: 0.12.0 -> 0.12.1 ``                                  |
| [`f652a92b`](https://github.com/NixOS/nixpkgs/commit/f652a92b9385946578c196ca8ebb8db17e7a3992) | `` ksnip: 1.10.0 -> 1.10.1 ``                                                    |
| [`7b859bd9`](https://github.com/NixOS/nixpkgs/commit/7b859bd9647150474c5a1f01f366096675279912) | `` wavm: use finalAttrs pattern ``                                               |
| [`ded510ed`](https://github.com/NixOS/nixpkgs/commit/ded510eddcc6447f3095bbb3b0c7f30414adde36) | `` unison: use finalAttrs pattern ``                                             |
| [`346b9c85`](https://github.com/NixOS/nixpkgs/commit/346b9c85bb4a4f38c90cde2fef1a61d3503cd94b) | `` eksctl: 0.143.0 -> 0.144.0 ``                                                 |
| [`12e19456`](https://github.com/NixOS/nixpkgs/commit/12e19456dab457ea3d4dab3c19e28ed24e4c32b1) | `` opengrok: 1.12.9 -> 1.12.11 ``                                                |
| [`17041f96`](https://github.com/NixOS/nixpkgs/commit/17041f967bb4f3b41ee27be05681205f43b449b0) | `` jf: 0.3.3 -> 0.6.2 ``                                                         |
| [`e4e10d02`](https://github.com/NixOS/nixpkgs/commit/e4e10d02f346f28fadbcde4a9869f329256e26db) | `` prometheus-bird-exporter: 1.4.1 -> 1.4.2 ``                                   |
| [`74d7c4e5`](https://github.com/NixOS/nixpkgs/commit/74d7c4e565930bb585df8c58ae2d662c03886c9e) | `` python311Packages.sqltrie: 0.4.0 -> 0.5.0 ``                                  |
| [`71900911`](https://github.com/NixOS/nixpkgs/commit/71900911d5faaa6735aa54ed446c8d0e4f9f53ca) | `` usql: 0.14.7 -> 0.14.8 ``                                                     |
| [`c4980c2b`](https://github.com/NixOS/nixpkgs/commit/c4980c2bb667a320843497f31933cf21fa939a92) | `` rymdport: 3.3.6 -> 3.4.0 ``                                                   |
| [`14e242ad`](https://github.com/NixOS/nixpkgs/commit/14e242ad66288410112c4f6dad85d6b2150fa08e) | `` ooniprobe-cli: 3.17.3 -> 3.17.5 ``                                            |
| [`72a64d07`](https://github.com/NixOS/nixpkgs/commit/72a64d07734255fddc457f6e517ff81c778dd288) | `` qFlipper: 1.3.1 -> 1.3.2 ``                                                   |
| [`6fd6dd6f`](https://github.com/NixOS/nixpkgs/commit/6fd6dd6f9caed02377fc2b379ac707a9b598bfdc) | `` kotlin{-native}: 1.8.21 -> 1.8.22 ``                                          |
| [`9830f1e0`](https://github.com/NixOS/nixpkgs/commit/9830f1e055413e3922040fbe06914e1219fb6359) | `` python310Packages.jsbeautifier: 1.14.7 -> 1.14.8 ``                           |
| [`ff05379d`](https://github.com/NixOS/nixpkgs/commit/ff05379d4270ac8c1c1a967c5e02e81165fd3659) | `` tectonic: 0.12.0 -> 0.13.1 ``                                                 |
| [`4825491b`](https://github.com/NixOS/nixpkgs/commit/4825491bd456507cf2dab3cd22a0ce5e582416b6) | `` python310Packages.limnoria: 2023.1.28 -> 2023.5.27 ``                         |
| [`9a88d6ef`](https://github.com/NixOS/nixpkgs/commit/9a88d6ef366d285d27d8350ce54460200739f6b3) | `` phpunit: 10.1.3 -> 10.2.1 ``                                                  |
| [`65ad3488`](https://github.com/NixOS/nixpkgs/commit/65ad3488ad66f75684d2fd421c7accff9f945886) | `` terraform-providers.aws: 5.1.0 -> 5.2.0 ``                                    |
| [`721a40cb`](https://github.com/NixOS/nixpkgs/commit/721a40cb400b1dd9236a999cfd6ace07b7f80cf8) | `` terraform-providers.tencentcloud: 1.81.5 -> 1.81.6 ``                         |
| [`9f48e4dc`](https://github.com/NixOS/nixpkgs/commit/9f48e4dce5303d089380db4a38ee8b3caf79222a) | `` terraform-providers.azurerm: 3.59.0 -> 3.60.0 ``                              |
| [`e91d6a6c`](https://github.com/NixOS/nixpkgs/commit/e91d6a6c3a029f2123351ec6096063dc1893dabe) | `` terraform-providers.argocd: 5.4.0 -> 5.5.0 ``                                 |
| [`f45f57c4`](https://github.com/NixOS/nixpkgs/commit/f45f57c4b039844a9f6fc40af88b98dd08e3c152) | `` python310Packages.yfinance: 0.2.19b1 -> 0.2.20 ``                             |
| [`bba6ef47`](https://github.com/NixOS/nixpkgs/commit/bba6ef4710228f66898fb78ce2ae644bdce7b69a) | `` python310Packages.jira: 3.5.0 -> 3.5.1 ``                                     |
| [`4f3a7da2`](https://github.com/NixOS/nixpkgs/commit/4f3a7da22805aab22c539a858a9ea5869594afe0) | `` python310Packages.scikit-hep-testdata: 0.4.30 -> 0.4.31 ``                    |
| [`c501fa4a`](https://github.com/NixOS/nixpkgs/commit/c501fa4a456e47b8c7880e3f7f713361de5df024) | `` localsend: 1.9.1 -> 1.10.0 ``                                                 |
| [`43deb587`](https://github.com/NixOS/nixpkgs/commit/43deb587541d08794f88d62a67afebb6bfa806ee) | `` python310Packages.manifest-ml: 0.1.7 -> 0.1.8 ``                              |
| [`4232f8fd`](https://github.com/NixOS/nixpkgs/commit/4232f8fdf851d31586a85f1b7a434eee17669eae) | `` zulu: set `meta.sourceProvenance` ``                                          |
| [`62fefcc9`](https://github.com/NixOS/nixpkgs/commit/62fefcc9e63ac6eb255e47ba4ba89585e4837c55) | `` python310Packages.nunavut: 2.0.9 -> 2.1.0 ``                                  |
| [`bfe7fa00`](https://github.com/NixOS/nixpkgs/commit/bfe7fa00aaa9046910dac6233828f79a8b15ce08) | `` python310Packages.langchain: 0.0.193 -> 0.0.195 ``                            |
| [`eea4b866`](https://github.com/NixOS/nixpkgs/commit/eea4b866b96b4174d733d96074b8e84a8799764e) | `` python310Packages.sphinxcontrib-katex: 0.9.4 -> 0.9.5 ``                      |
| [`8b18b83e`](https://github.com/NixOS/nixpkgs/commit/8b18b83ea38a11a7cb7a74d16c55720641a7d887) | `` arkade: 0.9.18 -> 0.9.19 ``                                                   |
| [`68dc4d48`](https://github.com/NixOS/nixpkgs/commit/68dc4d485bc022b6fff2d2d3b7cc6ff74fc164ba) | `` pgpool: 4.4.2 -> 4.4.3 ``                                                     |
| [`f10ee90d`](https://github.com/NixOS/nixpkgs/commit/f10ee90dd2863f873a08e52ba7fd6e55fac24910) | `` hubble: 0.11.5 -> 0.11.6 ``                                                   |
| [`2cbdbea0`](https://github.com/NixOS/nixpkgs/commit/2cbdbea01653d22e40594862ed32c76e2c5aad66) | `` cargo-workspaces: 0.2.35 -> 0.2.42 ``                                         |
| [`ce6a4dad`](https://github.com/NixOS/nixpkgs/commit/ce6a4dad80ceef98d7485df25b278ac2b541e089) | `` python310Packages.types-pyopenssl: 23.1.0.3 -> 23.2.0.0 ``                    |
| [`2163573a`](https://github.com/NixOS/nixpkgs/commit/2163573a469f374efaa460b7e4a48121a7d3782f) | `` python310Packages.easyocr: 1.6.2 -> 1.7.0 ``                                  |
| [`5a257a12`](https://github.com/NixOS/nixpkgs/commit/5a257a12e2713013b174f92550d384dfc284cc1b) | `` erigon: 2.43.0 -> 2.45.1 ``                                                   |
| [`ca70f524`](https://github.com/NixOS/nixpkgs/commit/ca70f524da4a3f738a0132dca14d4ed46ab8c998) | `` erlang_odbc: 25.3.2.1 -> 25.3.2.2 ``                                          |
| [`fdcc9a2e`](https://github.com/NixOS/nixpkgs/commit/fdcc9a2e8fe74268840df53684f6d992a0dca702) | `` python311Packages.google-cloud-bigtable: 2.18.1 -> 2.19.0 ``                  |
| [`2613f870`](https://github.com/NixOS/nixpkgs/commit/2613f870fbcb62e25cf936e294faa13e580154dc) | `` python311Packages.easyocr: add format ``                                      |
| [`02697fa8`](https://github.com/NixOS/nixpkgs/commit/02697fa8ac0967025f2615d9aa86f43d11b9e408) | `` python311Packages.easyocr: add changelog to meta ``                           |
| [`bb50a8ec`](https://github.com/NixOS/nixpkgs/commit/bb50a8ecebbcd09aa82ccc3a3da0a423bb212f44) | `` maskromtool: init at v2023-05-30 ``                                           |
| [`b3f05ffd`](https://github.com/NixOS/nixpkgs/commit/b3f05ffdc1e6ef8107fc2abf5115b3f88ff48060) | `` python310Packages.etuples: add format ``                                      |
| [`3095e153`](https://github.com/NixOS/nixpkgs/commit/3095e1533986e570d79d0c7baba75ff5eb2ceca1) | `` home-assistant: update component-packages ``                                  |
| [`f2a6152b`](https://github.com/NixOS/nixpkgs/commit/f2a6152b154d35a3ec294a7a591744bf74f0eb08) | `` python311Packages.sensirion-ble: init at 0.1.0 ``                             |
| [`08184028`](https://github.com/NixOS/nixpkgs/commit/08184028fcc16d8c7e1b9291b836e14241ee372f) | `` maintainers: adding evanrichter ``                                            |
| [`b6088ea2`](https://github.com/NixOS/nixpkgs/commit/b6088ea2f32335978f366708440b0f4ded5b7f9f) | `` Enable tests for Halide; replace llvmPackages.stdenv with stdenv (#224473) `` |
| [`63ea80b6`](https://github.com/NixOS/nixpkgs/commit/63ea80b6da70c6da2ca2c0747d638fd0e85e926f) | `` python310Packages.etuples: 0.3.8 -> 0.3.9 ``                                  |
| [`89d2bd9d`](https://github.com/NixOS/nixpkgs/commit/89d2bd9d9119ccf54b2e362bb31e4112eb133984) | `` ccloud-cli: remove ``                                                         |
| [`280b1d57`](https://github.com/NixOS/nixpkgs/commit/280b1d57296c973e6f61ad934e6705e98b42fc06) | `` confluent-cli: 2.4.0 > 3.17.0 ``                                              |
| [`11111141`](https://github.com/NixOS/nixpkgs/commit/11111141795ff271c99837f4094599cd343588a8) | `` bitwarden: 2023.4.0 -> 2023.5.0 ``                                            |
| [`66c418d2`](https://github.com/NixOS/nixpkgs/commit/66c418d299cd454bd74644eaad905ec4ba2f81a1) | `` nitch: fix nerdfont icons ``                                                  |
| [`d34bb4ea`](https://github.com/NixOS/nixpkgs/commit/d34bb4ea41bec3f93d42fcb2d262d985e90d7008) | `` vault: 1.13.2 -> 1.13.3 ``                                                    |
| [`7d99f4bc`](https://github.com/NixOS/nixpkgs/commit/7d99f4bc1a3e3551b418882589b6021bf46ffd70) | `` sidplayfp: 2.4.1 -> 2.5.0 ``                                                  |
| [`0983c18e`](https://github.com/NixOS/nixpkgs/commit/0983c18e6aba9d09da393ec131dabc53cc9a1181) | `` nixos/go2rtc: add support for v4l2 video sources ``                           |
| [`dc7e92ba`](https://github.com/NixOS/nixpkgs/commit/dc7e92baaef2345dd8b6f635434ad421d0bf2d58) | `` libsForQt5.qtutilities: 6.12.0 -> 6.12.2 ``                                   |
| [`01c3da6f`](https://github.com/NixOS/nixpkgs/commit/01c3da6f20fee4e14250be35aa5e9daac6d6f11a) | `` git-credential-oauth: 0.7.0 -> 0.8.0 ``                                       |
| [`18d624d0`](https://github.com/NixOS/nixpkgs/commit/18d624d085a944d03e9338b7c007603ee3008c8e) | `` phrase-cli: 2.8.0 -> 2.8.2 ``                                                 |
| [`5e3827d5`](https://github.com/NixOS/nixpkgs/commit/5e3827d5bd33ab17fe04823e7150ea977bccf538) | `` python311Packages.diceware: remove pytest-runner ``                           |
| [`a6ce8b92`](https://github.com/NixOS/nixpkgs/commit/a6ce8b92fc736c165870a5aa8143841e28b315f2) | `` python311Packages.libais: remove pytest-runner ``                             |
| [`f332d4f7`](https://github.com/NixOS/nixpkgs/commit/f332d4f776bdc661c677651cbfb353852bc10c0a) | `` python310Packages.hdf5plugin: 4.1.1 -> 4.1.2 ``                               |
| [`5372429b`](https://github.com/NixOS/nixpkgs/commit/5372429b00dc95f3cf08a5a935ee982c748cacc9) | `` trivy: 0.42.0 -> 0.42.1 ``                                                    |
| [`a4d32cd5`](https://github.com/NixOS/nixpkgs/commit/a4d32cd50accbbb304837748d79c69415474c14d) | `` aiac: 2.4.0 -> 2.5.0 ``                                                       |
| [`c00a2433`](https://github.com/NixOS/nixpkgs/commit/c00a24332c943580a8588a168414c1b3ba2126e0) | `` python311Packages.dynalite-devices: 0.47 -> 0.1.48 ``                         |
| [`e7583c9d`](https://github.com/NixOS/nixpkgs/commit/e7583c9d83da2b49afbfe2b9c3772bd041a2a533) | `` k0sctl: 0.15.1 -> 0.15.2 ``                                                   |
| [`bbc56fd1`](https://github.com/NixOS/nixpkgs/commit/bbc56fd1c7311b69abf0e206fc00378ca170abe9) | `` gnunet: fix systemd service config (#151269) ``                               |
| [`1b8ab59f`](https://github.com/NixOS/nixpkgs/commit/1b8ab59fc0625c8bb6aeac0255925ccba15d51a3) | `` python310Packages.pysrim: remove pytest-runner ``                             |
| [`7460edb0`](https://github.com/NixOS/nixpkgs/commit/7460edb07b52d6b8ab24466240e90ff5f095b706) | `` eventstore: 22.10.0 -> 22.10.2 ``                                             |
| [`7136944f`](https://github.com/NixOS/nixpkgs/commit/7136944f15d3e1ba438e88b43f190ce4c3b41697) | `` urbit: 2.8 -> 2.9 ``                                                          |
| [`9a0f0fc2`](https://github.com/NixOS/nixpkgs/commit/9a0f0fc2dd5c68f1dda227f78a57079fdb3610df) | `` slweb: 0.5.6 -> 0.6.1 ``                                                      |
| [`8bf9d7b0`](https://github.com/NixOS/nixpkgs/commit/8bf9d7b02db6606910e96f1d7fb577a773c1d4e2) | `` sbt: 1.8.3 -> 1.9.0 (#235691) ``                                              |
| [`b87ff9f9`](https://github.com/NixOS/nixpkgs/commit/b87ff9f99721229bb8a883af03259ff3aaae7fad) | `` firefox-bin-unwrapped: 114.0 -> 114.0.1 ``                                    |
| [`2806c350`](https://github.com/NixOS/nixpkgs/commit/2806c350b1e322eea1efaa0f89afddb3cdad8199) | `` firefox-unwrapped: 114.0 -> 114.0.1 ``                                        |
| [`e04c13a7`](https://github.com/NixOS/nixpkgs/commit/e04c13a720d1d57d7031b0faeb71bd76912faaa7) | `` mullvad-browser: add panicgh as maintainer ``                                 |
| [`d6600ec1`](https://github.com/NixOS/nixpkgs/commit/d6600ec13d10ba8ed01643ec68f4746f8b8de2fe) | `` tml: 0.6.0 -> 0.6.1 ``                                                        |
| [`64b66bd7`](https://github.com/NixOS/nixpkgs/commit/64b66bd77f691a61004d6fdb12e79edcef4a9883) | `` mullvad-browser: 12.0.6 -> 12.0.7 ``                                          |
| [`54419329`](https://github.com/NixOS/nixpkgs/commit/5441932945f73b7869fa376a3c03627e02aa666e) | `` acme-sh: 3.0.5 -> 3.0.6 ``                                                    |
| [`a464f05e`](https://github.com/NixOS/nixpkgs/commit/a464f05ebaaf080b3afa8514c3154ccbab3ca75f) | `` qownnotes: 23.6.0 -> 23.6.4 ``                                                |
| [`c943a4a5`](https://github.com/NixOS/nixpkgs/commit/c943a4a5051b07ab6b7b228f1c8596e88f1b2914) | `` ansible-lint: 6.16.1 -> 6.17.0 ``                                             |
| [`149ec670`](https://github.com/NixOS/nixpkgs/commit/149ec670d92238beda62eb0d29f2e00832ff8d3c) | `` opentelemetry-collector: 0.78.2 -> 0.79.0 ``                                  |
| [`d46120e0`](https://github.com/NixOS/nixpkgs/commit/d46120e0978b8cae285905cf69d91694fc15e3d1) | `` netmaker: 0.20.0 -> 0.20.1 ``                                                 |
| [`adf532bf`](https://github.com/NixOS/nixpkgs/commit/adf532bfdcf5bbe9ce6099fec32447e4211f016f) | `` python311Packages.pycategories: remove pytest-runner ``                       |
| [`bcb903cc`](https://github.com/NixOS/nixpkgs/commit/bcb903cce86402edbd8bbdea5645eef3d624a7e3) | `` nixos/tests/lvm2/thinpool: fix xfs creation on older kernels ``               |
| [`3bf06829`](https://github.com/NixOS/nixpkgs/commit/3bf06829ff84303fc7122aada24568a9885ac28c) | `` nixos/tests/lvm2: also build for new LTS kernel ``                            |
| [`1e09392c`](https://github.com/NixOS/nixpkgs/commit/1e09392c23231749763cd2dbbb674c994f6993fa) | `` python311Packages.tatsu: remove pytest-runner ``                              |
| [`15553ec2`](https://github.com/NixOS/nixpkgs/commit/15553ec2026bbbdb9a62f67de2412eeaf6705baf) | `` python311Packages.srptools: remove pytest-runner ``                           |
| [`3c6a167a`](https://github.com/NixOS/nixpkgs/commit/3c6a167a640836d5d09f1a343495823ba472ebdb) | `` python311Packages.tldextract: 3.4.2 -> 3.4.4 ``                               |
| [`347dbf48`](https://github.com/NixOS/nixpkgs/commit/347dbf48ee7b341b916367f5b4c5f1eea29de1d8) | `` python311Packages.policyuniverse: 1.5.1.20230526 -> 1.5.1.20230608 ``         |
| [`d121669f`](https://github.com/NixOS/nixpkgs/commit/d121669fd6592c4eccd379e9249ff666b7651e76) | `` go-callvis: init at 0.7.0 ``                                                  |
| [`476d6eca`](https://github.com/NixOS/nixpkgs/commit/476d6ecaf7d466b0bc7f09ace45eaa2b7ce10f55) | `` zprint: 1.2.6 -> 1.2.7 ``                                                     |
| [`8d8d9154`](https://github.com/NixOS/nixpkgs/commit/8d8d9154d74dc81b3838075a9e269943a78a3763) | `` earthly: 0.7.7 -> 0.7.8 ``                                                    |
| [`02ea919a`](https://github.com/NixOS/nixpkgs/commit/02ea919a89de89569c036f9de11ff64ab91e8fc1) | `` shipwright: init at 7.0.2 ``                                                  |
| [`35cc0f9e`](https://github.com/NixOS/nixpkgs/commit/35cc0f9e71d92e7d2ecdff33da58f608f6da406d) | `` matrix-synapse: 1.85.1 -> 1.85.2 ``                                           |
| [`58f4fa39`](https://github.com/NixOS/nixpkgs/commit/58f4fa3903aaeda8069a9a4376a44727ced7f3a7) | `` fclones: 0.31.0 -> 0.31.1 ``                                                  |
| [`1b5b5e45`](https://github.com/NixOS/nixpkgs/commit/1b5b5e451edfe6ac1b851ac3f987311e418d2583) | `` uutils-coreutils: 0.0.17 -> 0.0.19 ``                                         |
| [`5d6ea734`](https://github.com/NixOS/nixpkgs/commit/5d6ea734a18203895360f6ea767ee47f7be22e00) | `` systemd stage 1 networking: Stop systemd-networkd on switch-root ``           |
| [`a9e34ff9`](https://github.com/NixOS/nixpkgs/commit/a9e34ff905798ec1a727312de4137e48a7b8dd2f) | `` systemd stage 1 networking: Add network-pre to flush tests ``                 |
| [`9bdbfb1b`](https://github.com/NixOS/nixpkgs/commit/9bdbfb1b76744a643ea8bc37b371444c10299ae0) | `` typst-live: init at unstable-2023-05-27 ``                                    |
| [`513023c1`](https://github.com/NixOS/nixpkgs/commit/513023c117fc28a88c8002e24312959018f3a7e4) | `` python38: 3.8.16 -> 3.8.17 ``                                                 |
| [`1eecd856`](https://github.com/NixOS/nixpkgs/commit/1eecd85622cd230c3234a288d1736d9cb6468e2f) | `` python39: 3.9.16 -> 3.9.17 ``                                                 |
| [`966069ed`](https://github.com/NixOS/nixpkgs/commit/966069ed8100ae1f126df96e5cf1a3dbd134d60a) | `` python312: 3.12.0b1 -> 3.12.0b2 ``                                            |
| [`9883fd26`](https://github.com/NixOS/nixpkgs/commit/9883fd26cdf1b5476837f6351616a90bc59534ad) | `` minimal-bootstrap.heirloom: init at 070715 ``                                 |
| [`fb7ca344`](https://github.com/NixOS/nixpkgs/commit/fb7ca344ad5116261be724aa3325c2358d7b3b5d) | `` minimal-bootstrap.heirloom-devtools: init at 070527 ``                        |
| [`9d83529d`](https://github.com/NixOS/nixpkgs/commit/9d83529d7f1d359a90040069f7040f429288ab06) | `` licenses: add Caldera and Info-Zip ``                                         |
| [`af903dfb`](https://github.com/NixOS/nixpkgs/commit/af903dfb0ce6b7e38bf94b6773113387db8ad002) | `` chirp: unstable-2023-03-15 -> unstable-2023-06-02 ``                          |
| [`7af30ade`](https://github.com/NixOS/nixpkgs/commit/7af30ade700b87cdc6f75754faeb00f3c44a1bca) | `` brutefir: init at 1.0o ``                                                     |
| [`d06ff9a1`](https://github.com/NixOS/nixpkgs/commit/d06ff9a1e11a8260d197484d235d7bd6ff29c61e) | `` s5: init at 0.1.12 ``                                                         |