### PR TITLE
chore(flake/nixpkgs): `21951114` -> `75a5ebf4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -348,11 +348,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686412476,
-        "narHash": "sha256-inl9SVk6o5h75XKC79qrDCAobTD1Jxh6kVYTZKHzewA=",
+        "lastModified": 1686501370,
+        "narHash": "sha256-G0WuM9fqTPRc2URKP9Lgi5nhZMqsfHGrdEbrLvAPJcg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "21951114383770f96ae528d0ae68824557768e81",
+        "rev": "75a5ebf473cd60148ba9aec0d219f72e5cf52519",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`e85f0c7c`](https://github.com/NixOS/nixpkgs/commit/e85f0c7cf6f7319a91674f11fccbbc9a8d5ca30f) | `` python310Packages.dnachisel: add format ``                               |
| [`f09bde4c`](https://github.com/NixOS/nixpkgs/commit/f09bde4cd04ea035b199537b28ccc72985693cde) | `` python310Packages.dnachisel: add changelog to meta ``                    |
| [`9401a0c7`](https://github.com/NixOS/nixpkgs/commit/9401a0c780b49faf6c28adf55764f230301d0dce) | `` doc/contributing/review-contributions: fix small typo (#237186) ``       |
| [`55ae35dc`](https://github.com/NixOS/nixpkgs/commit/55ae35dc27b3ece4a910c41ce676d393fe136c51) | `` python310Packages.dnachisel: 3.2.10 -> 3.2.11 ``                         |
| [`4e652cea`](https://github.com/NixOS/nixpkgs/commit/4e652ceabaa4ec2d1ff6068ba175137305fd889d) | `` gosh: use release ``                                                     |
| [`5f4fe479`](https://github.com/NixOS/nixpkgs/commit/5f4fe47957a680fb0c170a76eb5e64cb8a264ddd) | `` smbmap: unstable-2023-03-29 -> 1.9.1 ``                                  |
| [`1e4c8b33`](https://github.com/NixOS/nixpkgs/commit/1e4c8b3336e3f36ce0dc969b252c1210b456c154) | `` txr: 285 -> 287 ``                                                       |
| [`55aaed3b`](https://github.com/NixOS/nixpkgs/commit/55aaed3b1c8a059898097df9549f3dc824565350) | `` cargo-pgrx: 0.9.2 -> 0.9.5 ``                                            |
| [`d7667bb1`](https://github.com/NixOS/nixpkgs/commit/d7667bb13f8764b1add125389d8ba4130e37ec5a) | `` nodePackages:update to latest ``                                         |
| [`66463108`](https://github.com/NixOS/nixpkgs/commit/664631085f26f5f730ade3c12fd77fa5f34979bc) | `` tbls: 1.65.3 -> 1.65.4 ``                                                |
| [`7b3ac2a1`](https://github.com/NixOS/nixpkgs/commit/7b3ac2a1fdaa2f24743195a3cf25046076322ddd) | `` python310Packages.python-otbr-api: 2.1.0 -> 2.2.0 ``                     |
| [`e072e61f`](https://github.com/NixOS/nixpkgs/commit/e072e61f7ade884df2f448e112a62982c958788e) | `` xorriso: 1.5.4.pl02 -> 1.5.6 ``                                          |
| [`e394dc22`](https://github.com/NixOS/nixpkgs/commit/e394dc22f95427311aa61b8b3cbf490483a4a753) | `` xray: allow binding lower ports ``                                       |
| [`954d3794`](https://github.com/NixOS/nixpkgs/commit/954d3794ae89e5cdd27714954e9d59c3f5de1aae) | `` fetchFromSourcehut: expose `gitRepoUrl` to consumers ``                  |
| [`e4c791fc`](https://github.com/NixOS/nixpkgs/commit/e4c791fcf90c05bcb099691584540d707e1e707a) | `` kubernetes-helmPlugins.helm-diff: 3.8.0 -> 3.8.1 ``                      |
| [`5f34b36b`](https://github.com/NixOS/nixpkgs/commit/5f34b36b9705caa88a4f7121777020e6aa7df3b6) | `` libjcat: 0.1.13 -> 0.1.14 ``                                             |
| [`9c17d3c5`](https://github.com/NixOS/nixpkgs/commit/9c17d3c5041948a3863317f8fd0b7f397e86e334) | `` system76-keyboard-configurator: 1.3.4 -> 1.3.6 ``                        |
| [`496bd08e`](https://github.com/NixOS/nixpkgs/commit/496bd08e3dc553bbf0689c8e95be9892561cc8ac) | `` nerd-font-patcher: 3.0.1 -> 3.0.2 ``                                     |
| [`b81d4086`](https://github.com/NixOS/nixpkgs/commit/b81d4086b56d83bb35e2089d295514220e11e9d3) | `` discord-canary: 0.0.154 -> 0.0.158 ``                                    |
| [`1c2e4767`](https://github.com/NixOS/nixpkgs/commit/1c2e4767d32a302fd58eb730920d712efe17a1ae) | `` python310Packages.concurrent-log-handler: 0.9.22 -> 0.9.24 ``            |
| [`0c4b36c8`](https://github.com/NixOS/nixpkgs/commit/0c4b36c8a60761a14f13f40891036750dfaef78d) | `` uxplay: 1.64 -> 1.65 ``                                                  |
| [`22800c2c`](https://github.com/NixOS/nixpkgs/commit/22800c2c65da399e9ffa41a0a0954f7b54b47feb) | `` python310Packages.weaviate-client: 3.18.0 -> 3.19.2 ``                   |
| [`9365ef23`](https://github.com/NixOS/nixpkgs/commit/9365ef23e9d8b93c898047a0d54dd5e99eb3c4af) | `` ain: init at 1.3.0 ``                                                    |
| [`92758fd6`](https://github.com/NixOS/nixpkgs/commit/92758fd677f1bce888da1497b8a703249335fe43) | `` cnspec: 8.12.1 -> 8.13.0 ``                                              |
| [`25e6cd03`](https://github.com/NixOS/nixpkgs/commit/25e6cd037c21b52f349c757aa8dd5f595097ee2c) | `` ani-cli: 4.3 -> 4.4 ``                                                   |
| [`158530e0`](https://github.com/NixOS/nixpkgs/commit/158530e0eac4788bf4498f16c480017c24b2ef75) | `` btcpayserver: 1.10.1 -> 1.10.2 ``                                        |
| [`fc9619c4`](https://github.com/NixOS/nixpkgs/commit/fc9619c48882d5d6242e0f735833a81d01258e5d) | `` deploy-rs: unstable-2023-05-05 -> unstable-2023-06-04 ``                 |
| [`462bd730`](https://github.com/NixOS/nixpkgs/commit/462bd73023981b7223d9770b3df2f4ac9dd5ab2a) | `` sawfish: refactor ``                                                     |
| [`c24a1a2f`](https://github.com/NixOS/nixpkgs/commit/c24a1a2fc72e260184ab08cb9902664a94f14b99) | `` rep-gtk: refactor ``                                                     |
| [`acf84a14`](https://github.com/NixOS/nixpkgs/commit/acf84a140f32413ed723621149e7c99d0057b82b) | `` librep: refactor ``                                                      |
| [`35e527fa`](https://github.com/NixOS/nixpkgs/commit/35e527fabb661cb999308ac442e5d61cc16a8d95) | `` aws-lambda-rie: 1.11 -> 1.12 ``                                          |
| [`1b6f6406`](https://github.com/NixOS/nixpkgs/commit/1b6f6406878da49a667a774d842f7e3aa6a84768) | `` doc: correct typos and spelling (#237098) ``                             |
| [`e6bdeb58`](https://github.com/NixOS/nixpkgs/commit/e6bdeb588dfd6c950b9e3c67bf9a15eb9a886325) | `` prometheus-influxdb-exporter: 0.11.3 -> 0.11.4 ``                        |
| [`c8a9300f`](https://github.com/NixOS/nixpkgs/commit/c8a9300f45419d296653e8c323e0d379ad30e4c5) | `` wego: 2.1 -> 2.2 ``                                                      |
| [`a9bbe8ed`](https://github.com/NixOS/nixpkgs/commit/a9bbe8edd41939f23ddc9dff28f08300fdba589b) | `` adguardian: 1.2.0 -> 1.5.0 ``                                            |
| [`1ec5a198`](https://github.com/NixOS/nixpkgs/commit/1ec5a198a3153ca56c29f0a9439e971ea8601f43) | `` datree: 1.9.3 -> 1.9.4 ``                                                |
| [`b2845167`](https://github.com/NixOS/nixpkgs/commit/b28451678994182dc213fa76afbc288479feba52) | `` go-musicfox: 4.1.1 -> 4.1.2 ``                                           |
| [`502e8096`](https://github.com/NixOS/nixpkgs/commit/502e8096528f959dab274468e52c977d8c20f642) | `` yor: 0.1.177 -> 0.1.180 ``                                               |
| [`65264758`](https://github.com/NixOS/nixpkgs/commit/65264758561a200048d2095c932f6a23b0a165b7) | `` python311Packages.gpustat: 1.0.0 -> 1.1 ``                               |
| [`324c3bc1`](https://github.com/NixOS/nixpkgs/commit/324c3bc11e239bf9917ed52fce2d6b0828cabf10) | `` ctx: 0.pre+date=2021-10-09 -> unstable-2023-06-05 ``                     |
| [`d15e598b`](https://github.com/NixOS/nixpkgs/commit/d15e598bd5d42abf73a4ce771daedc56e1453fb9) | `` rl-2305: fix typo in openjdk version note ``                             |
| [`2ca1c7cd`](https://github.com/NixOS/nixpkgs/commit/2ca1c7cd54346c21cca295153467cf72ddc2d278) | `` python3Packages.sv-ttk: disable on unsupported Python releases ``        |
| [`2da59ab0`](https://github.com/NixOS/nixpkgs/commit/2da59ab0b0555b300fbeec9d4f3dccab86767c91) | `` python311Packages.greeneye-monitor: 3.0.3 -> 4.0 ``                      |
| [`e103448c`](https://github.com/NixOS/nixpkgs/commit/e103448ce7a541fa141088816b9470b217f55b14) | `` python311Packages.siobrultech-protocols: add changelog to meta ``        |
| [`ec5f7bcc`](https://github.com/NixOS/nixpkgs/commit/ec5f7bcc4f4c3057d0cbf6ce1ca1ae746ebddd2f) | `` python311Packages.siobrultech-protocols: 0.9.0 -> 0.12.0 ``              |
| [`d08df272`](https://github.com/NixOS/nixpkgs/commit/d08df272003190c482dc1a664dcc8457d2fd8058) | `` python311Packages.johnnycanencrypt: 0.13.1 -> 0.14.1 ``                  |
| [`766d51a3`](https://github.com/NixOS/nixpkgs/commit/766d51a350c2c803d6b0ae75168372cd4d7c563b) | `` python311Packages.holidays: 0.25 -> 0.26 ``                              |
| [`54a02525`](https://github.com/NixOS/nixpkgs/commit/54a02525793b652518fc885f35263bbe6bacdda6) | `` python311Packages.azure-eventgrid: 4.11.0 -> 4.13.0 ``                   |
| [`7532b6dc`](https://github.com/NixOS/nixpkgs/commit/7532b6dcb4c53bf70c67cb0ff2cae47bbd580250) | `` python311Packages.pyobihai: enable tests ``                              |
| [`06f86c85`](https://github.com/NixOS/nixpkgs/commit/06f86c8578a75977abc9e2af25fd79cc16233212) | `` python311Packages.pyobihai: add changelog to meta ``                     |
| [`1fafca21`](https://github.com/NixOS/nixpkgs/commit/1fafca21455f3d35be68f7779421d394fd470c1e) | `` python311Packages.peaqevcore: 18.1.5 -> 18.1.7 ``                        |
| [`bb6069ec`](https://github.com/NixOS/nixpkgs/commit/bb6069ec20918fea1521bfb225d90e03d03ecee3) | `` dtc: fix overrides: use finalAttrs, not rec ``                           |
| [`f1e69789`](https://github.com/NixOS/nixpkgs/commit/f1e69789433f8954872f73a9ef4ef3fdd1dc02cc) | `` python311Packages.pyobihai: 1.4.1 -> 1.4.2 ``                            |
| [`befeb4ef`](https://github.com/NixOS/nixpkgs/commit/befeb4ef98c454343d9a567b54f9a25dc3ef5e83) | `` python311Packages.solax: 0.3.1 -> 0.3.2 ``                               |
| [`62136fac`](https://github.com/NixOS/nixpkgs/commit/62136facbee2dc09edc7c88ecaafdda3339a57b7) | `` python311Packages.elkm1-lib: 2.2.3 -> 2.2.4 ``                           |
| [`6218ea42`](https://github.com/NixOS/nixpkgs/commit/6218ea4252d513741f81f482a4fce59eb6985bb9) | `` python311Packages.aioslimproto: 2.2.2 -> 2.3.2 ``                        |
| [`d403c69b`](https://github.com/NixOS/nixpkgs/commit/d403c69b5620c517651af3d40cf41e3d400ac03b) | `` memray: 1.7.0 -> 1.8.0 ``                                                |
| [`cb665974`](https://github.com/NixOS/nixpkgs/commit/cb6659741a6ed8867650c3b407c9d50498c5ff1d) | `` Revert "python310Packages.keyutils: remove" ``                           |
| [`350697ad`](https://github.com/NixOS/nixpkgs/commit/350697ad5666e967da77885e47d18de231f98a8f) | `` python311Packages.python-opensky: 0.0.9 -> 0.0.10 ``                     |
| [`fb02e7c5`](https://github.com/NixOS/nixpkgs/commit/fb02e7c5cb3cc40e7fca366a896688122244692b) | `` calibre: 6.19.1 -> 6.20.0 ``                                             |
| [`ac5228f7`](https://github.com/NixOS/nixpkgs/commit/ac5228f786683d606b3bc3e42649d0694eed30e5) | `` python311Packages.xknxproject: 3.1.0 -> 3.1.1 ``                         |
| [`bf085810`](https://github.com/NixOS/nixpkgs/commit/bf0858109a03298d9d25ff6ad721e332344e5125) | `` python311Packages.google-nest-sdm: 2.2.4 -> 2.2.5 ``                     |
| [`40e1ff49`](https://github.com/NixOS/nixpkgs/commit/40e1ff499e06f2d182cbd2774fb3307b13561676) | `` xemu: 0.7.90 -> 0.7.92 ``                                                |
| [`6c771643`](https://github.com/NixOS/nixpkgs/commit/6c771643775d33efb50e4ac8b38b48041a783c5c) | `` sysdig: update drivers for latest kernel ``                              |
| [`c21fb567`](https://github.com/NixOS/nixpkgs/commit/c21fb56736ff5f986c5ad8d647a342cc34c1d200) | `` tagref: 1.8.2 -> 1.8.3 ``                                                |
| [`32b75d59`](https://github.com/NixOS/nixpkgs/commit/32b75d59964b40798df5019011c0e68130c2dc7a) | `` element-{web,desktop}: 1.11.32 -> 1.11.33 ``                             |
| [`2a8e901c`](https://github.com/NixOS/nixpkgs/commit/2a8e901c2f6ae0d19165536173c9e383ba5821da) | `` nyxt: 2.2.4 -> 3.1.0 ``                                                  |
| [`e577ef5d`](https://github.com/NixOS/nixpkgs/commit/e577ef5d6e4156bf7ef0ef533147118579d3f03a) | `` lisp-modules.nyxt-gtk: use gi-gtk system instead of gtk system ``        |
| [`e59c30b5`](https://github.com/NixOS/nixpkgs/commit/e59c30b59d83ad22dbbc99372f155d18347a12a5) | `` lisp-modules.prompter: init at 0.1.0 ``                                  |
| [`a71d35f7`](https://github.com/NixOS/nixpkgs/commit/a71d35f73ad9f64058049d3f41f2180c39fa38d4) | `` lisp-modules: add updated lispLibs for nyxt ``                           |
| [`71d34eb0`](https://github.com/NixOS/nixpkgs/commit/71d34eb0ee779306aa1f024c8d9f0bec0d966a9d) | `` python311Packages.pytest-pylint: remove pytest-runner ``                 |
| [`7096df96`](https://github.com/NixOS/nixpkgs/commit/7096df961f91fbd739e45f7cd84024c68106391b) | `` python311Packages.pynvim: remove pytest-runner ``                        |
| [`9cfb08f4`](https://github.com/NixOS/nixpkgs/commit/9cfb08f439eb01f5bd37c7ed26cb251cec35f33c) | `` python311Packages.packet-python: remove pytest-runner ``                 |
| [`a12e5c28`](https://github.com/NixOS/nixpkgs/commit/a12e5c2862f6c623ad9e46aa36473483516c11ce) | `` python311Packages.bacpypes: remove pytest-runner ``                      |
| [`0c3f4160`](https://github.com/NixOS/nixpkgs/commit/0c3f416096bdcd0b0673e3ab1885ee6a0849040a) | `` nixosTests.nixos-rebuild-specialisations: Fix ``                         |
| [`f938b6d1`](https://github.com/NixOS/nixpkgs/commit/f938b6d1f8d74751fd80070b9eec07c7829b1196) | `` python311Packages.setuptoolsTrial: remove pytest-runner ``               |
| [`ef85052f`](https://github.com/NixOS/nixpkgs/commit/ef85052f2b3434d69d9be730e3af588b8b05a8ed) | `` python311Packages.lyricwikia: remove pytest-runner ``                    |
| [`512df4a3`](https://github.com/NixOS/nixpkgs/commit/512df4a3abb775cdd1611056092971fc6d5fd4ab) | `` micronaut: set meta.mainProgram ``                                       |
| [`508fe7ba`](https://github.com/NixOS/nixpkgs/commit/508fe7ba92559fd53c29c9fd3eea32d3eb22d2af) | `` got: 0.88 -> 0.89 ``                                                     |
| [`a54e7d29`](https://github.com/NixOS/nixpkgs/commit/a54e7d299b1dc3af4d6393527c9194ec4dfc6d68) | `` nixosTests.systemd-boot.switch-test: Fix warnings ``                     |
| [`0d55eebc`](https://github.com/NixOS/nixpkgs/commit/0d55eebcf53fbdf2485429fb32956a60f6421e8d) | `` nixosTests.systemd-boot.switch-test: Fix test ``                         |
| [`a104da68`](https://github.com/NixOS/nixpkgs/commit/a104da6839ec96942a52a0e72cc32f8d74b3d2c4) | `` radare2: 5.8.6 -> 5.8.8 ``                                               |
| [`99a46b3e`](https://github.com/NixOS/nixpkgs/commit/99a46b3e9155ebedc60d87eaddf9ca0bd1e1250c) | `` python310Packages.keyutils: remove ``                                    |
| [`a3a197c1`](https://github.com/NixOS/nixpkgs/commit/a3a197c13d1a8ce92613a58070f06fa6c6d52576) | `` micronaut: 3.9.2 -> 3.9.3 ``                                             |
| [`da9e17e0`](https://github.com/NixOS/nixpkgs/commit/da9e17e01b6d4af910fdaa82c983053306939366) | `` open-stage-control: 1.25.0 -> 1.25.1 ``                                  |
| [`acf08ea1`](https://github.com/NixOS/nixpkgs/commit/acf08ea113b7fbd9a6f4895223cfe19c6a6025be) | `` python311Packages.gpustat: remove pytest-runner ``                       |
| [`91ee5862`](https://github.com/NixOS/nixpkgs/commit/91ee5862b12121c41bdf52df521122f430889f46) | `` exploitdb: 2023-06-08 -> 2023-06-10 ``                                   |
| [`118991ce`](https://github.com/NixOS/nixpkgs/commit/118991ce6d506beff4b887d3de0dbed5b9cc34d4) | `` mympd: 10.3.2 -> 10.3.3 ``                                               |
| [`c24713c8`](https://github.com/NixOS/nixpkgs/commit/c24713c8f8d7c42d4a6ef97c435b26ef36bc55cd) | `` sysdig: fix build ``                                                     |
| [`7d900c08`](https://github.com/NixOS/nixpkgs/commit/7d900c08973405f48f79a41a8697591c8c75e90c) | `` python311Packages.ci-py: remove pytest-runner ``                         |
| [`d8c76348`](https://github.com/NixOS/nixpkgs/commit/d8c763483060a71d3cdc3b6bda1e93d80e424111) | `` python311Packages.variants: remove pytest-runner ``                      |
| [`5c8b6b8e`](https://github.com/NixOS/nixpkgs/commit/5c8b6b8e437442abc4d65c65c90a88875e4c7886) | `` polypane: 13.1.2 -> 14.0.1 ``                                            |
| [`ed603f0e`](https://github.com/NixOS/nixpkgs/commit/ed603f0efb1139ac8496a7334608cf718cdb2e86) | `` nix-eval-jobs: 2.14.0 -> 2.16.0 ``                                       |
| [`ad78249d`](https://github.com/NixOS/nixpkgs/commit/ad78249de01eb21aeebbf7f9136dc13988442fec) | `` gnome.gnome-shell: 44.1 → 44.2 ``                                        |
| [`96363a96`](https://github.com/NixOS/nixpkgs/commit/96363a967992f7ff7c926a5c3636dcfb1ca7c631) | `` gnome.mutter: 44.1 → 44.2 ``                                             |
| [`eeef4269`](https://github.com/NixOS/nixpkgs/commit/eeef426972f59bc78256ab3f97e9fa654dad607a) | `` mpich: 4.1.1 -> 4.1.2 ``                                                 |
| [`c0970d03`](https://github.com/NixOS/nixpkgs/commit/c0970d034db0c9409d3bb446eb3a4032ebb26382) | `` ton: 2023.05 -> 2023.06 ``                                               |
| [`c108c6dd`](https://github.com/NixOS/nixpkgs/commit/c108c6dd5dcaaf18c7aea24ce0bdaa0bd4a23b8f) | `` teams-for-linux: 1.1.1 -> 1.1.2 ``                                       |
| [`227188b7`](https://github.com/NixOS/nixpkgs/commit/227188b7b304648a30faff33db57d2896703fc50) | `` bcompare: 4.4.4.27058 -> 4.4.6.27483 ``                                  |
| [`33196af1`](https://github.com/NixOS/nixpkgs/commit/33196af13e9336c942fb5834e3177a92b7703242) | `` tora: fix build after libmysqlclient -> mariadb ``                       |
| [`1bf6d6ac`](https://github.com/NixOS/nixpkgs/commit/1bf6d6ac3ae00e31fb707e61f2bb6cc3b87a0648) | `` linuxptp: 3.1.1 -> 4.0 ``                                                |
| [`4b21a20d`](https://github.com/NixOS/nixpkgs/commit/4b21a20d8281c66045610a6f725031cf5773d0e3) | `` invidious: fetch self-hosted sources ``                                  |
| [`00682408`](https://github.com/NixOS/nixpkgs/commit/00682408b17a0762587e8ce00cf4d960a233025c) | `` kde/frameworks: 5.106 -> 5.107 ``                                        |
| [`fd731ab0`](https://github.com/NixOS/nixpkgs/commit/fd731ab0821e22f9bf7d865c64fee39c61a77c3c) | `` diff-so-fancy: 1.4.3 -> 1.4.4 ``                                         |
| [`ddb77e5a`](https://github.com/NixOS/nixpkgs/commit/ddb77e5ac46480dd077236a8c72944c39ddce654) | `` xeus: 3.0.5 -> 3.1.1 ``                                                  |
| [`bc62c28b`](https://github.com/NixOS/nixpkgs/commit/bc62c28b22e80ad70c18cf184266eea8927cc23b) | `` jmol: 16.1.9 -> 16.1.13 ``                                               |
| [`7099d6b8`](https://github.com/NixOS/nixpkgs/commit/7099d6b8fbefddc146684f6c637b9d33f16f39ef) | `` home-assistant: update component-packages ``                             |
| [`1a5830b9`](https://github.com/NixOS/nixpkgs/commit/1a5830b94755ac424793513c3f86f2efebdddc1b) | `` python311Packages.sisyphus-control: init at 3.1.3 ``                     |
| [`7e66d21d`](https://github.com/NixOS/nixpkgs/commit/7e66d21d24e332061a8802df1ef92ee812bdf592) | `` muzika: init at unstable-2023-06-07 ``                                   |
| [`f9846702`](https://github.com/NixOS/nixpkgs/commit/f98467021814f4e67732bcb1803a0d5962e2535b) | `` linux/hardened/patches/6.1: 6.1.31-hardened1 -> 6.1.32-hardened1 ``      |
| [`0edae4c6`](https://github.com/NixOS/nixpkgs/commit/0edae4c6a22cc5c099774ffb758d511cd3938922) | `` linux/hardened/patches/5.4: 5.4.244-hardened1 -> 5.4.245-hardened1 ``    |
| [`8c28d094`](https://github.com/NixOS/nixpkgs/commit/8c28d094c3f9d9ced8fa243ea44415704e3e53b6) | `` linux/hardened/patches/5.15: 5.15.114-hardened1 -> 5.15.115-hardened1 `` |
| [`2ebb96aa`](https://github.com/NixOS/nixpkgs/commit/2ebb96aa75be2d6e65ce06fd46ebc4ad1a299cc0) | `` linux/hardened/patches/5.10: 5.10.181-hardened1 -> 5.10.182-hardened1 `` |
| [`cc63badb`](https://github.com/NixOS/nixpkgs/commit/cc63badb85e7bca49100946fc8ae59443ea53cd2) | `` linux-rt_5_10: 5.10.180-rt88 -> 5.10.78-rt55 ``                          |
| [`3143cda4`](https://github.com/NixOS/nixpkgs/commit/3143cda4d457a212b7021e693a68c30165f02d98) | `` linux: 6.3.6 -> 6.3.7 ``                                                 |
| [`e941c448`](https://github.com/NixOS/nixpkgs/commit/e941c4484db08fa3750f50e17aa047abae6b0455) | `` linux: 6.1.32 -> 6.1.33 ``                                               |
| [`2b4690b9`](https://github.com/NixOS/nixpkgs/commit/2b4690b98fbac808e92bda9f177e2477f84358ac) | `` linux: 5.4.245 -> 5.4.246 ``                                             |
| [`951e7e83`](https://github.com/NixOS/nixpkgs/commit/951e7e83aee6b1ad6a9fa7a5ec32ed4466a05a38) | `` linux: 5.15.115 -> 5.15.116 ``                                           |
| [`917d1827`](https://github.com/NixOS/nixpkgs/commit/917d18270c9037911baa3cac24710576b6f62774) | `` linux: 5.10.182 -> 5.10.183 ``                                           |
| [`2054a678`](https://github.com/NixOS/nixpkgs/commit/2054a678a36024ee6cb897b8739495a5865940e0) | `` linux: 4.19.284 -> 4.19.285 ``                                           |
| [`489678eb`](https://github.com/NixOS/nixpkgs/commit/489678eb8cbb15803cdd763edf7381eff948eda6) | `` linux: 4.14.316 -> 4.14.317 ``                                           |
| [`f6ffd144`](https://github.com/NixOS/nixpkgs/commit/f6ffd144d9e3866d8a322b4da36dd148afa5a572) | `` funzzy: 0.6.1 -> 1.0.0 ``                                                |
| [`610f6023`](https://github.com/NixOS/nixpkgs/commit/610f60231fde08ff5d458cfbe2f37cb9b5d70e7d) | `` nixos/qemu-vm: introduce `virtualisation.directBoot` ``                  |
| [`799cf36b`](https://github.com/NixOS/nixpkgs/commit/799cf36b7261a11c5c06f6e021670cfdcaa98e9c) | `` vimPlugins.nvim-treesitter: update grammars ``                           |
| [`102940d9`](https://github.com/NixOS/nixpkgs/commit/102940d9dda59e4996abbcc870b71a5098d33bc1) | `` vimPlugins: update ``                                                    |
| [`5a496dca`](https://github.com/NixOS/nixpkgs/commit/5a496dca643deb0405605f6b0599b5d7ffbda42b) | `` vimPlugins.git-conflict-nvim: init at 2023-05-23 ``                      |
| [`cbea2db5`](https://github.com/NixOS/nixpkgs/commit/cbea2db5ee335759c4760091c386f748f922490a) | `` python311Packages.python-opensky: init at 0.0.9 ``                       |
| [`32536650`](https://github.com/NixOS/nixpkgs/commit/3253665046f7a5ba6f68e50a3aa0c7ee762b507d) | `` multipass: 1.11.1 -> 1.12.0 ``                                           |
| [`4b967815`](https://github.com/NixOS/nixpkgs/commit/4b9678150e01108a38b4d2b53308a941f5b93910) | `` sbcl: add more heap size ``                                              |
| [`10b06ee6`](https://github.com/NixOS/nixpkgs/commit/10b06ee6fe017d50b7e402f27469b2c0d9f5d775) | `` maintainers: add dariof4 ``                                              |
| [`c79b173d`](https://github.com/NixOS/nixpkgs/commit/c79b173db5b4a61782d0afb8a798ac15ff355301) | `` linuxPackages.nvidia_x11_beta: fix optix denoiser ``                     |
| [`0ce8040f`](https://github.com/NixOS/nixpkgs/commit/0ce8040f6b55388b621b69a93077a0af79ea5349) | `` python3Packages.sv-ttk: init at 2.4.5 ``                                 |
| [`295ff35f`](https://github.com/NixOS/nixpkgs/commit/295ff35f2410dff5fb897567abe3b13fa621a2df) | `` cc-wrapper: try to better guess meta.mainProgram ``                      |