### PR TITLE
chore(flake/home-manager): `0144ac41` -> `9e37a1b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -209,11 +209,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686391840,
-        "narHash": "sha256-5S0APl6Mfm6a37taHwvuf11UHnAX0+PnoWQbsYbMUnc=",
+        "lastModified": 1686564129,
+        "narHash": "sha256-jzb2mHvQEZJL3a3ANhTeLIaa1nyjFJ/RzUJjCJme/V4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0144ac418ef633bfc9dbd89b8c199ad3a617c59f",
+        "rev": "9e37a1b6f9507ed27080518ff4007988a50c957e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`9e37a1b6`](https://github.com/nix-community/home-manager/commit/9e37a1b6f9507ed27080518ff4007988a50c957e) | `` programs.joshuto: add the joshuto file manager (#4004) `` |
| [`b0cdae4e`](https://github.com/nix-community/home-manager/commit/b0cdae4e9baa188d69ba84aa1b7406b7bebe37f6) | `` browserpass: test on Darwin again (#4081) ``              |