### PR TITLE
chore(flake/nix-index-database): `6bf1f559` -> `7e83b70f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -318,11 +318,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686570379,
-        "narHash": "sha256-h3ub8JsBa0n4EWQWkLjziUE/3sCNYkog2YHFAM9vGLM=",
+        "lastModified": 1686574167,
+        "narHash": "sha256-hxE8z+S9E4Qw03D2VQRaJUmj9zep3FvhKz316JUZuPA=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "6bf1f5593f768be3a6f3c86b256fa5e723b8155a",
+        "rev": "7e83b70f31f4483c07e6939166cb667ecb8d05d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`7e83b70f`](https://github.com/Mic92/nix-index-database/commit/7e83b70f31f4483c07e6939166cb667ecb8d05d5) | `` update packages.nix to release 2023-06-12-124826 `` |
| [`cd017305`](https://github.com/Mic92/nix-index-database/commit/cd017305c32fbaa80524414d2df42eb327dabe05) | `` drop i686-linux from ci ``                          |