### PR TITLE
chore(flake/pre-commit-hooks): `182af512` -> `5b6b54d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -374,11 +374,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1686213770,
-        "narHash": "sha256-Re6xXLEqQ/HRnThryumyGzEf3Uv0Pl4cuG50MrDofP8=",
+        "lastModified": 1686668298,
+        "narHash": "sha256-AADh9NqHh6X2LOem4BvI7oCkMm+JPCSCE7iIw5nn0VA=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "182af51202998af5b64ddecaa7ff9be06425399b",
+        "rev": "5b6b54d3f722aa95cbf4ddbe35390a0af8c0015a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                           |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
| [`1d657159`](https://github.com/cachix/pre-commit-hooks.nix/commit/1d6571590bacc8f62da19d68444a312fed7f2ee9) | `` `dune-opam-sync` should also trigger on opam template files `` |