### PR TITLE
chore(flake/nix-index-database): `7e83b70f` -> `14eede94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686574167,
-        "narHash": "sha256-hxE8z+S9E4Qw03D2VQRaJUmj9zep3FvhKz316JUZuPA=",
+        "lastModified": 1686671165,
+        "narHash": "sha256-q3Poq8FlulxDMCETXL0ehb9J3h5Naf5yGh1x42RXXRI=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "7e83b70f31f4483c07e6939166cb667ecb8d05d5",
+        "rev": "14eede9450dc45b92adc9f1dfac873eac7e1a5de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                       |
| --------------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`2ebbb294`](https://github.com/Mic92/nix-index-database/commit/2ebbb2943f3bdd8b1955ff7b90aca0ae1a2ea5eb) | `` flake.lock: Update ``      |
| [`53055ecf`](https://github.com/Mic92/nix-index-database/commit/53055ecfd65f4e0ad8c6b65bbfe568896fbe2a12) | `` Add a basic nixos test. `` |