### PR TITLE
chore(flake/home-manager): `0d1e053c` -> `e4aa9fd8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686666709,
-        "narHash": "sha256-M0qa5qQ2PPqibWmT7bwwXQlNM8Kq1Ors7oS9ukv7Gs8=",
+        "lastModified": 1686666715,
+        "narHash": "sha256-lBYoA/AI22znVdwuRd1yFwixeAT9m0oudP4TVdhJiC0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0d1e053ce997f1dc181a0790c3b1ba2c76550ace",
+        "rev": "e4aa9fd83b5c2d43b3c9c9de979a8675fcb8e563",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`e4aa9fd8`](https://github.com/nix-community/home-manager/commit/e4aa9fd83b5c2d43b3c9c9de979a8675fcb8e563) | `` Translate using Weblate (Japanese) ``             |
| [`25230267`](https://github.com/nix-community/home-manager/commit/252302673da838acb7ea545c5b945037fce9ae22) | `` Translate using Weblate (Chinese (Simplified)) `` |