### PR TITLE
chore(flake/lanzaboote): `59e3ebb1` -> `823ad6b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -221,11 +221,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686559216,
-        "narHash": "sha256-8yFA8F8dqUziMgd94DUSM4ljCgudcMYyWeaqdHFUvWE=",
+        "lastModified": 1686692834,
+        "narHash": "sha256-EFjJ/r4iYVKO+XdL15g9bzOKbCExTGeqNEVHSn0H7/E=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "59e3ebb19fdd3fd235d8275b008538a72872bad7",
+        "rev": "823ad6b70bf09b91c3a9dd9a64678ec80ba3c1ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                  |
| --------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`77777777`](https://github.com/nix-community/lanzaboote/commit/77777777007deffdd7237f7ce0690325c6bcc0eb) | `` Fix eval when aliases are disabled `` |