### PR TITLE
chore(flake/nix-index-database): `14eede94` -> `e11c6107`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686671165,
-        "narHash": "sha256-q3Poq8FlulxDMCETXL0ehb9J3h5Naf5yGh1x42RXXRI=",
+        "lastModified": 1686740472,
+        "narHash": "sha256-b668DY2qGdBCUwIkk6Z32bcpCsUISQJrEEvhtn1gGgY=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "14eede9450dc45b92adc9f1dfac873eac7e1a5de",
+        "rev": "e11c61073b777e025993c5ef63ddbf776a9cca15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                      |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`fa3b6fa5`](https://github.com/Mic92/nix-index-database/commit/fa3b6fa51075a76fe3f1e949850ac55782834e3f) | `` add mergify ``                                            |
| [`5ca82658`](https://github.com/Mic92/nix-index-database/commit/5ca826583aae491e8c315adc348523825342e3c9) | `` flake.lock: Update ``                                     |
| [`7a4eef28`](https://github.com/Mic92/nix-index-database/commit/7a4eef2856307efecdde4db9b02ecbab9f812827) | `` Comma: use the NIX_INDEX_DATABASE env var if possible. `` |
| [`e6782460`](https://github.com/Mic92/nix-index-database/commit/e678246010d235874f22118c2bd2f54891f3de7f) | `` Use the NIX_INDEX_DATABASE env var if possible. ``        |