### PR TITLE
chore(flake/deploy-rs): `65211db6` -> `724463b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -80,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685948350,
-        "narHash": "sha256-1FldJ059so0X/rScdbIiOlQbjjSNCCTdj2cUr5pHU4A=",
+        "lastModified": 1686747123,
+        "narHash": "sha256-XUQK9kwHpTeilHoad7L4LjMCCyY13Oq383CoFADecRE=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "65211db63ba1199f09b4c9f27e5eba5ec50d76ac",
+        "rev": "724463b5a94daa810abfc64a4f87faef4e00f984",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                   |
| --------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`f28f8c60`](https://github.com/serokell/deploy-rs/commit/f28f8c6063dfdee3720a8841cc857df2c911dec8) | `` actually merge confirm_timeout into merged_settings `` |