### PR TITLE
chore(flake/nixpkgs): `75a5ebf4` -> `0eeebd64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686501370,
-        "narHash": "sha256-G0WuM9fqTPRc2URKP9Lgi5nhZMqsfHGrdEbrLvAPJcg=",
+        "lastModified": 1686592866,
+        "narHash": "sha256-riGg89eWhXJcPNrQGcSwTEEm7CGxWC06oSX44hajeMw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "75a5ebf473cd60148ba9aec0d219f72e5cf52519",
+        "rev": "0eeebd64de89e4163f4d3cf34ffe925a5cf67a05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                            |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`fbb732ae`](https://github.com/NixOS/nixpkgs/commit/fbb732aebc1f375f2b5fb8e5d938c995864e8d2e) | `` wamr: use finalAttrs pattern ``                                                                 |
| [`3b0f5393`](https://github.com/NixOS/nixpkgs/commit/3b0f5393d9eb3a90ce4e4b0ed8d671a5ac977a46) | `` neovimUtils.grammarToPlugin: install tree-sitter grammars for neovim without nvim-treesitter `` |
| [`662d9a40`](https://github.com/NixOS/nixpkgs/commit/662d9a407277a2d86465ffcbeeda1c957a33a4ac) | `` mdbook-toc: 0.9.0 -> 0.12.0 ``                                                                  |
| [`a88de40e`](https://github.com/NixOS/nixpkgs/commit/a88de40ede4b945ccf646777f9ea7054a504b9fd) | `` matrix-synapse: disable test parallelism on aarch64-linux ``                                    |
| [`143d2345`](https://github.com/NixOS/nixpkgs/commit/143d234583aa22d5e28bf07f93623d1af498f4a8) | `` matplotlib: add numpy to nativeBuildInputs to fix cross compilation (#237334) ``                |
| [`a09afc8d`](https://github.com/NixOS/nixpkgs/commit/a09afc8dacfcf4fe3a551f557268b8488cc7c675) | `` topiary: Add passthru.updateScript ``                                                           |
| [`8255903b`](https://github.com/NixOS/nixpkgs/commit/8255903b7179aba39506026f053190723e95f05e) | `` neovimUtils.buildNeovimPluginFrom2Nix: rename to buildNeovimPlugin ``                           |
| [`35964909`](https://github.com/NixOS/nixpkgs/commit/3596490914ec9f24b20a16366363f41ebe9059d0) | `` nushellPlugins.query: 0.80.0 -> 0.81.0 ``                                                       |
| [`06375c59`](https://github.com/NixOS/nixpkgs/commit/06375c5962ed3a4298bc91c1ac25fd121437a479) | `` doc/languages-frameworks/python: add missing back quote ``                                      |
| [`81b627fc`](https://github.com/NixOS/nixpkgs/commit/81b627fc5b71e6638227f10fd5995a9039542aff) | `` deck: init at 1.22.0 ``                                                                         |
| [`7cb8758c`](https://github.com/NixOS/nixpkgs/commit/7cb8758c67682150167b0c5c0501e9faaa5423a3) | `` lerpn: init at unstable-2023-06-08 ``                                                           |
| [`bd77d4ae`](https://github.com/NixOS/nixpkgs/commit/bd77d4ae46a32fda5d28c02b0f2cb33c7f722c8e) | `` nixos/lemmy: support nginx ``                                                                   |
| [`3fdaa004`](https://github.com/NixOS/nixpkgs/commit/3fdaa00460d722acee106cff629461511731c18f) | `` cannelloni: remove -DCMAKE_BUILD_TYPE=Release ``                                                |
| [`18095b8d`](https://github.com/NixOS/nixpkgs/commit/18095b8d94285d85312b85db2d31cb234b88ef77) | `` cannelloni: move cmake to nativeBuildInputs ``                                                  |
| [`8e640173`](https://github.com/NixOS/nixpkgs/commit/8e640173144746f9babe2bc3338e5d5eb79f1f70) | `` python310Packages.pynvim: fix & adopt ``                                                        |
| [`f2689c26`](https://github.com/NixOS/nixpkgs/commit/f2689c2617a32c81c170c2ffd53791cdb2fe2b04) | `` fclones: 0.31.1 -> 0.32.1 ``                                                                    |
| [`feb76c2a`](https://github.com/NixOS/nixpkgs/commit/feb76c2a63c5d90ee8a1f4bcc6d70cf237106a0a) | `` python310Packages.types-ujson: 5.7.0.5 -> 5.8.0.0 ``                                            |
| [`3c0a8a7d`](https://github.com/NixOS/nixpkgs/commit/3c0a8a7dfd283f28645d8aefa693dc68d68c8dd0) | `` boost: cleanup ``                                                                               |
| [`31eebcd4`](https://github.com/NixOS/nixpkgs/commit/31eebcd47bbc5dec0029f416545a65730c831dc0) | `` oh-my-posh: 16.9.1 -> 17.0.0 ``                                                                 |
| [`dbb0a93d`](https://github.com/NixOS/nixpkgs/commit/dbb0a93db7c33a43c09219db0d97ef7c02cbc34b) | `` timeular: 5.8.7 -> 5.9.0 ``                                                                     |
| [`f8664556`](https://github.com/NixOS/nixpkgs/commit/f86645566dcbab4cf57c312959844264f3694d69) | `` nixos/tests/systemd-nspawn-configfile: init ``                                                  |
| [`7ccb7998`](https://github.com/NixOS/nixpkgs/commit/7ccb7998d0e4cb88c18d84adbef0e37f2475f42f) | `` maintainers: add zi3m5f ``                                                                      |
| [`67f5dcfd`](https://github.com/NixOS/nixpkgs/commit/67f5dcfd94e7544f32cd7324a774cf61aa9401b8) | `` nixos/nspawn: fix spelling of systemd.nspawn MachineID option ``                                |
| [`7c3c8d3d`](https://github.com/NixOS/nixpkgs/commit/7c3c8d3d94cc9182eb8002de02e2f2c4349236a5) | `` gcr: use lib.meta.availableOn instead of isLinux ``                                             |
| [`98b94235`](https://github.com/NixOS/nixpkgs/commit/98b94235ef91c49553fe879eb168150c6652d53c) | `` libmilter: 8.17.1 -> 8.17.2 ``                                                                  |
| [`9f10b6a0`](https://github.com/NixOS/nixpkgs/commit/9f10b6a012f17fd0e51436ad49a3508a1e39301d) | `` python310Packages.nlpcloud: 1.0.41 -> 1.0.42 ``                                                 |
| [`c8cb1f7a`](https://github.com/NixOS/nixpkgs/commit/c8cb1f7a2df211360ff492b13ffdf896a8c25d00) | `` ocamlPackages.minisat: 0.4 -> 0.5 ``                                                            |
| [`25b2813b`](https://github.com/NixOS/nixpkgs/commit/25b2813b09576f3301e4e52733e8eca7d71470e9) | `` jbang: 0.107.0 -> 0.108.0 ``                                                                    |
| [`579dda9a`](https://github.com/NixOS/nixpkgs/commit/579dda9aecbb6dd339970e1e498af5cb7df28511) | `` syft: 0.82.0 -> 0.83.0 ``                                                                       |
| [`ea6957a7`](https://github.com/NixOS/nixpkgs/commit/ea6957a7eef612323c1803b654b4a28f80b7b56d) | `` parallel: 20230422 -> 20230522 ``                                                               |
| [`365f55d3`](https://github.com/NixOS/nixpkgs/commit/365f55d3444459b14d0c459f4d67a899aaa59cb4) | `` python311Packages.bitarray: 2.7.4 -> 2.7.5 ``                                                   |
| [`f78c7798`](https://github.com/NixOS/nixpkgs/commit/f78c77989ce65a25c3bd657996c22ed8abe917e1) | `` clightning: 23.05 -> 23.05.1 ``                                                                 |
| [`9d50d0a3`](https://github.com/NixOS/nixpkgs/commit/9d50d0a3db94b7117e27ee128d12604df94d4519) | `` keepalived: 2.2.7 -> 2.2.8 ``                                                                   |
| [`1bbb5689`](https://github.com/NixOS/nixpkgs/commit/1bbb56892d6a324a348c31031da3df07347fc839) | `` fluxcd: 2.0.0-rc.3 -> 2.0.0-rc.5 ``                                                             |
| [`dc8bbbf0`](https://github.com/NixOS/nixpkgs/commit/dc8bbbf0ddef96ffcc257e689b7465d9f4d449c9) | `` ueberzugpp: 2.8.6 -> 2.8.7 ``                                                                   |
| [`30620750`](https://github.com/NixOS/nixpkgs/commit/30620750e8915bc6ebebfa1da65a746d3b03717b) | `` coqPackages.Verdi: 20211026 → 20230503 ``                                                       |
| [`e59d94ef`](https://github.com/NixOS/nixpkgs/commit/e59d94ef4c54884223eba6369304ec51af5a1387) | `` coqPackages.Cheerios: 20200201 → 20230107 ``                                                    |
| [`00144a91`](https://github.com/NixOS/nixpkgs/commit/00144a917583836e965b69d7481bf4074c2ca200) | `` coqPackages.StructTact: 20210328 → 20230107 ``                                                  |
| [`bd28a38e`](https://github.com/NixOS/nixpkgs/commit/bd28a38ebff69e9ffc1eb5ffb7668c3637027d8f) | `` coqPackages.InfSeqExt: 20200131 → 20230107 ``                                                   |
| [`2d0b521a`](https://github.com/NixOS/nixpkgs/commit/2d0b521a7085a0dc90f6b4686005fb99e1c88528) | `` python311Packages.publicsuffixlist: 0.10.0.20230608 -> 0.10.0.20230611 ``                       |
| [`0e54476f`](https://github.com/NixOS/nixpkgs/commit/0e54476f40d2b2a4937dd920145095288676fac1) | `` python311Packages.peaqevcore: 18.1.7 -> 18.1.11 ``                                              |
| [`a85e561d`](https://github.com/NixOS/nixpkgs/commit/a85e561de7861d06df97597dd587289e683cbc31) | `` soju: 0.6.1 -> 0.6.2 ``                                                                         |
| [`e7fc5271`](https://github.com/NixOS/nixpkgs/commit/e7fc527121d07d33ea5bf0973d05bbe57ca77c50) | `` go-migrate: 4.16.0 -> 4.16.1 ``                                                                 |
| [`1bcccfa8`](https://github.com/NixOS/nixpkgs/commit/1bcccfa84fbe0af85a1ffc42a96db80566849537) | `` hysteria: 1.3.4 -> 1.3.5 ``                                                                     |
| [`cdcd3765`](https://github.com/NixOS/nixpkgs/commit/cdcd3765ae7f83675d04a84e6d9da28f9968b0a2) | `` mediamtx: 0.23.4 -> 0.23.5 ``                                                                   |
| [`4e3d46a3`](https://github.com/NixOS/nixpkgs/commit/4e3d46a3ea37d09c3d6dda557a0623c18ed58afe) | `` ocamlPackages.functoria: 4.3.4 → 4.3.6 ``                                                       |
| [`c98657f1`](https://github.com/NixOS/nixpkgs/commit/c98657f164494345d8466797528ad6f94b6a3bc9) | `` ocamlPackages.omd: fix for OCaml 5.0 ``                                                         |
| [`09c1d496`](https://github.com/NixOS/nixpkgs/commit/09c1d496d9cbf3dfdc97aa8fcef395ebcbc3d1fa) | `` ocamlPackages.qtest: fix for OCaml 5.0 ``                                                       |
| [`7bc75d30`](https://github.com/NixOS/nixpkgs/commit/7bc75d30327d5e4e886b5b2807756161fd6a60cc) | `` faas-cli: 0.16.4 -> 0.16.7 ``                                                                   |
| [`59f6636b`](https://github.com/NixOS/nixpkgs/commit/59f6636b3692e3f8f41e738dae292c3391b257e2) | `` brev-cli: 0.6.229 -> 0.6.236 ``                                                                 |
| [`f55ff4fc`](https://github.com/NixOS/nixpkgs/commit/f55ff4fc60958fe986b5be8d61336f12485a00d0) | `` minizinc: 2.7.4 -> 2.7.5 ``                                                                     |
| [`de66e21e`](https://github.com/NixOS/nixpkgs/commit/de66e21e768e4ac00f614f23284374d1dbe1ade5) | `` rust-analyzer-unwrapped: 2023-05-29 -> 2023-06-05 ``                                            |
| [`b0e31d08`](https://github.com/NixOS/nixpkgs/commit/b0e31d08e153cd2fccfea34d6e2461ac4395f5e5) | `` prometheus-json-exporter: 0.5.0 -> 0.6.0 ``                                                     |
| [`1115715e`](https://github.com/NixOS/nixpkgs/commit/1115715e8239ea35101b072beede2a225d4b7141) | `` raycast: 1.53.0 -> 1.53.2 ``                                                                    |
| [`2f20e0e1`](https://github.com/NixOS/nixpkgs/commit/2f20e0e13100f97cb382ebde88cc2215cfde255c) | `` nixos/nix-daemon: fix URL for nix.conf ``                                                       |
| [`271a8420`](https://github.com/NixOS/nixpkgs/commit/271a8420c7658152cc08a4ffa61a775a2c67669b) | `` eks-node-viewer: add version test ``                                                            |
| [`451d527a`](https://github.com/NixOS/nixpkgs/commit/451d527a2b8994b0118c5e49432b0284c4fd1669) | `` eks-node-viewer: fix version ``                                                                 |
| [`8e2beaf0`](https://github.com/NixOS/nixpkgs/commit/8e2beaf0f4cbd668a60576a3b88cc015d5505998) | `` aravis: 0.8.26 -> 0.8.27 ``                                                                     |
| [`4a5460f3`](https://github.com/NixOS/nixpkgs/commit/4a5460f3d95855a4075a6df3e5ca2977eee899b5) | `` eks-node-viewer: fix license ``                                                                 |
| [`170eb1dd`](https://github.com/NixOS/nixpkgs/commit/170eb1dd15868ab21ca94344055e8936b55ef16d) | `` antidote: 1.8.6 -> 1.8.7 ``                                                                     |
| [`abc07527`](https://github.com/NixOS/nixpkgs/commit/abc07527e04ad8f7f80f22180f07825173d5ba98) | `` dbus-broker: v32 -> v33 ``                                                                      |
| [`bdc99301`](https://github.com/NixOS/nixpkgs/commit/bdc9930174dc77a4dabb657061b38ddbaf1eaedd) | `` miller: 6.7.0 -> 6.8.0 ``                                                                       |
| [`b81eddec`](https://github.com/NixOS/nixpkgs/commit/b81eddec27d62ea37375d0454cf9a8bc78560988) | `` gotrue-supabase: 2.69.2 -> 2.70.0 ``                                                            |
| [`729752c2`](https://github.com/NixOS/nixpkgs/commit/729752c22ebcd771e5164390c84e04172b0ec2b8) | `` glooctl: 1.14.6 -> 1.14.7 ``                                                                    |
| [`8692fdbd`](https://github.com/NixOS/nixpkgs/commit/8692fdbd12ab451a6199703d792e4676c8a185c1) | `` pocketbase: 0.16.4 -> 0.16.5 ``                                                                 |
| [`f1bb5c6c`](https://github.com/NixOS/nixpkgs/commit/f1bb5c6cae5d885801522cc580830db6dcf08d8c) | `` argc: 1.4.0 -> 1.5.0 ``                                                                         |
| [`764e7266`](https://github.com/NixOS/nixpkgs/commit/764e7266f0296c91660b6187d99ee9580216cd85) | `` fclones-gui: 0.1.0 -> 0.1.2 ``                                                                  |
| [`b32d7b29`](https://github.com/NixOS/nixpkgs/commit/b32d7b2966fd7ecac74f8146639991f78b3ece5a) | `` bottom: 0.9.1 -> 0.9.2 ``                                                                       |
| [`94200258`](https://github.com/NixOS/nixpkgs/commit/942002584fbf20d9d51a16cb8612e216deb5e28c) | `` dnsproxy: 0.49.1 -> 0.50.1 ``                                                                   |
| [`95f29b40`](https://github.com/NixOS/nixpkgs/commit/95f29b40089976c321f730dee74b0e4e1772726b) | `` vimv-rs: 2.0.0 -> 3.0.0 ``                                                                      |
| [`63b422ac`](https://github.com/NixOS/nixpkgs/commit/63b422acc03ea1f5c58d94003ab44a4938e83067) | `` fclones-gui: init at 0.1.0 ``                                                                   |
| [`6527ea2d`](https://github.com/NixOS/nixpkgs/commit/6527ea2dd154b3ec989b8954f2481af679360707) | `` rare-regex: init at 0.3.1 ``                                                                    |
| [`b6dbd73a`](https://github.com/NixOS/nixpkgs/commit/b6dbd73a77ba76f2d14ac3b7e319c3dae1132a7b) | `` python310Packages.camelot: init at 0.11.0 (#222708) ``                                          |
| [`81c64e5a`](https://github.com/NixOS/nixpkgs/commit/81c64e5ab81343b0d704ba8e371681bfd31105df) | `` clipboard-jh: 0.7.1 -> 0.8.0 ``                                                                 |
| [`c0936ce9`](https://github.com/NixOS/nixpkgs/commit/c0936ce9ffeff665e3e23dcb729aec5f038b8e2f) | `` python3Packages.dask-awkward: 2023.4.2 -> 2023.6.1 ``                                           |
| [`c9c1132a`](https://github.com/NixOS/nixpkgs/commit/c9c1132a5443c173e3724eb90220275c6ff15b97) | `` python3Packages.awkward: 2.2.1 -> 2.2.2 ``                                                      |
| [`fa6c3680`](https://github.com/NixOS/nixpkgs/commit/fa6c36805e3210082f8369d10e2353c32753c96b) | `` oven-media-engine: 0.15.11 -> 0.15.12 ``                                                        |
| [`c7d4d261`](https://github.com/NixOS/nixpkgs/commit/c7d4d261e6e69006737b2f3d94b8dda3bddb0f87) | `` wayland-utils: set mainProgram to wayland-info ``                                               |
| [`7db587ba`](https://github.com/NixOS/nixpkgs/commit/7db587baa7a1830ee616dc7039e4330f3dcabbd9) | `` linkerd_stable: 2.13.3 -> 2.13.4 ``                                                             |
| [`f8c84577`](https://github.com/NixOS/nixpkgs/commit/f8c84577654b61fd9263809f5ba267b0102059f9) | `` gtree: init at 1.7.45 ``                                                                        |
| [`18a76127`](https://github.com/NixOS/nixpkgs/commit/18a7612792e784f13e625085fa7855a9b4f363f0) | `` granted: 0.13.0 -> 0.13.2 ``                                                                    |
| [`1f9be6a5`](https://github.com/NixOS/nixpkgs/commit/1f9be6a55c7ff8bc2e1f21f1ee29815053b3defc) | `` adguardhome: 0.107.29 -> 0.107.31 ``                                                            |
| [`aad51856`](https://github.com/NixOS/nixpkgs/commit/aad518563260400780a210725e14be22f7ddfa5a) | `` tauon: 7.6.4 -> 7.6.5 ``                                                                        |
| [`565efb4a`](https://github.com/NixOS/nixpkgs/commit/565efb4ad0b5c8c2ba1c212f75ae880787b7db82) | `` eks-node-viewer: 0.2.1 -> 0.4.0 ``                                                              |
| [`6b1b72c0`](https://github.com/NixOS/nixpkgs/commit/6b1b72c0f887a478a5aac355674ff6df0fc44f44) | `` svtplay-dl: 4.20 -> 4.22 ``                                                                     |
| [`abcd6f46`](https://github.com/NixOS/nixpkgs/commit/abcd6f469a67bf4737ca5c66b9fcd9c8b2d82b33) | `` python310Packages.cssutils: 2.6.0 -> 2.7.0 ``                                                   |
| [`6889144e`](https://github.com/NixOS/nixpkgs/commit/6889144e310c9f31f66bce22fbeda5ba0353b875) | `` nongnu-packages: updated 2023-06-11 (from overlay) ``                                           |
| [`8aa4d45e`](https://github.com/NixOS/nixpkgs/commit/8aa4d45ecc8553b38a3a5f6b14c7ccb4eb7faca8) | `` nongnu-packages: updated 2023-06-10 (from overlay) ``                                           |
| [`f7cbd9fc`](https://github.com/NixOS/nixpkgs/commit/f7cbd9fce255e76a8cabf186cca3243edea59943) | `` melpa-packages: updated 2023-06-11 (from overlay) ``                                            |
| [`51e5f35b`](https://github.com/NixOS/nixpkgs/commit/51e5f35b27adde869aa006d25479712e72b0ebc7) | `` melpa-packages: updated 2023-06-10 (from overlay) ``                                            |
| [`487476d4`](https://github.com/NixOS/nixpkgs/commit/487476d477f652171425bec9dbd6926b2fed5937) | `` elpa-devel-packages: updated 2023-06-11 (from overlay) ``                                       |
| [`110edeb8`](https://github.com/NixOS/nixpkgs/commit/110edeb87ee7fc39b5c77e5193fb5b84a7ed61c8) | `` elpa-packages: updated 2023-06-11 (from overlay) ``                                             |
| [`b5bb1a4b`](https://github.com/NixOS/nixpkgs/commit/b5bb1a4b471265e7e21e82a2b376a7689802aa75) | `` elpa-packages: updated 2023-06-10 (from overlay) ``                                             |
| [`4775531c`](https://github.com/NixOS/nixpkgs/commit/4775531c49d3550781fa2721eb8c1afe8daeef97) | `` emacs.pkgs.sunrise-commander: refactor ``                                                       |
| [`817356b2`](https://github.com/NixOS/nixpkgs/commit/817356b227abb882abbaccc12927ce6470f7cdf5) | `` emacs update-from-overlay: include elpa-devel ``                                                |
| [`6b74da4c`](https://github.com/NixOS/nixpkgs/commit/6b74da4cc33971a438bff8928bb053f3ffba4375) | `` ndi: unpackPhase without interpolation of src ``                                                |
| [`ee177f5d`](https://github.com/NixOS/nixpkgs/commit/ee177f5de3b9bca9f0cf4b1462493f1c8281986e) | `` python310Packages.django-scopes: 1.2.0.post1 -> 2.0.0 ``                                        |
| [`5ef2470f`](https://github.com/NixOS/nixpkgs/commit/5ef2470f1523554039b6b24706af0bc40d4209c4) | `` texlive: assert that all fixed hashes are present ``                                            |
| [`3e210b28`](https://github.com/NixOS/nixpkgs/commit/3e210b282fa40ca56678d8d616d77fd39e22f486) | `` texlive: generate "fixed-hashes.nix" from Nix expression ``                                     |
| [`af37dec0`](https://github.com/NixOS/nixpkgs/commit/af37dec087bf9da70ab32c1f26506f74b6d3fc9b) | `` electrum: 4.4.0 -> 4.4.4 ``                                                                     |
| [`e7eeb952`](https://github.com/NixOS/nixpkgs/commit/e7eeb9528993d1324341d5f683740b76a3c9b5e5) | `` prismlauncher: 6.3 -> 7.0 (#236705) ``                                                          |
| [`d16f5d92`](https://github.com/NixOS/nixpkgs/commit/d16f5d92cc71b941174ea6b54a26c5e5a6a73294) | `` python311Packages.elastic-apm: 6.16.0 -> 6.16.1 ``                                              |
| [`84b290c7`](https://github.com/NixOS/nixpkgs/commit/84b290c785583583f67b13a54d7ca62af49c983c) | `` python310Packages.trove-classifiers: 2023.4.22 -> 2023.5.24 ``                                  |
| [`99063868`](https://github.com/NixOS/nixpkgs/commit/99063868c35eb78b5b0e35200f140b7fd5368a17) | `` cargo-watch: update the homepage link ``                                                        |
| [`8afaa1ae`](https://github.com/NixOS/nixpkgs/commit/8afaa1ae0f3f5d18a9c3c715cf990f76d9dffa36) | `` python311Packages.structlog: disable on unsupported Python releases ``                          |