### PR TITLE
chore(flake/home-manager): `194086df` -> `e0034971`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686777974,
-        "narHash": "sha256-ih/KlrOMutdcnG33bZN/wS1cpwE3h1UEYmo1nEA6gFo=",
+        "lastModified": 1686778999,
+        "narHash": "sha256-3qBtOJdznerw33LgwJTSUL6u8/j1Ot83fcc0f6oHKmk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "194086df82d235919c1f8da68c4af2490d4675f9",
+        "rev": "e0034971f9def16bbc32124147787bc0f09f0e59",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------- |
| [`e0034971`](https://github.com/nix-community/home-manager/commit/e0034971f9def16bbc32124147787bc0f09f0e59) | `` comodoro: add module `` |