### PR TITLE
chore(flake/nixpkgs): `0eeebd64` -> `0d2cf7fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686592866,
-        "narHash": "sha256-riGg89eWhXJcPNrQGcSwTEEm7CGxWC06oSX44hajeMw=",
+        "lastModified": 1686776226,
+        "narHash": "sha256-o6WbKvENj98QJz9Mco6T6SZGrjPewMDAFyKg0Lp8avU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0eeebd64de89e4163f4d3cf34ffe925a5cf67a05",
+        "rev": "0d2cf7fe5fa05d5271a15a8933414ee0a1570648",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`1c1a4c22`](https://github.com/NixOS/nixpkgs/commit/1c1a4c22de045a3ec53e16e2686007c55b421833) | `` Revert "quartoMinimal: 1.2.475 -> 1.3.361" ``                              |
| [`6a964f99`](https://github.com/NixOS/nixpkgs/commit/6a964f9965667667e4bfd243656b3165972fafb7) | `` docker-buildx: 0.10.5 -> 0.11.0 ``                                         |
| [`cc7f31d8`](https://github.com/NixOS/nixpkgs/commit/cc7f31d895199f5cb344d092c3d8c3ae8f7d390e) | `` logseq: 0.9.8 -> 0.9.9 ``                                                  |
| [`ff1cd885`](https://github.com/NixOS/nixpkgs/commit/ff1cd885da89c8f27091d7cf45af95b97970170f) | `` weave-gitops: init at 0.23.0 (#231426) ``                                  |
| [`dcf789f5`](https://github.com/NixOS/nixpkgs/commit/dcf789f53e4a671c51bd18632ae44d727a03869b) | `` flutter: 3.10.0 -> 3.10.5 ``                                               |
| [`3bc51b29`](https://github.com/NixOS/nixpkgs/commit/3bc51b29e6a842a0df1c2ce48b57f36561210929) | `` linux/hardened/patches/6.1: 6.1.32-hardened1 -> 6.1.33-hardened1 ``        |
| [`1aff8181`](https://github.com/NixOS/nixpkgs/commit/1aff8181e0d36f5f45ce84ca48812c34368a76c7) | `` linux/hardened/patches/5.4: 5.4.245-hardened1 -> 5.4.246-hardened1 ``      |
| [`1d5c213a`](https://github.com/NixOS/nixpkgs/commit/1d5c213afcd7fffed94120928f2820f191a48bd6) | `` linux/hardened/patches/5.15: 5.15.115-hardened1 -> 5.15.116-hardened1 ``   |
| [`087c4f26`](https://github.com/NixOS/nixpkgs/commit/087c4f2668d7aea922ff59ff6abad050af9d5838) | `` linux/hardened/patches/5.10: 5.10.182-hardened1 -> 5.10.183-hardened1 ``   |
| [`8dd2fe33`](https://github.com/NixOS/nixpkgs/commit/8dd2fe337e857b4e500c3c1c65c3889fb7b523f2) | `` linux/hardened/patches/4.19: 4.19.284-hardened1 -> 4.19.285-hardened1 ``   |
| [`4e5af239`](https://github.com/NixOS/nixpkgs/commit/4e5af239fbc542ba307883fe317be30c048b8e24) | `` linux/hardened/patches/4.14: 4.14.316-hardened1 -> 4.14.317-hardened1 ``   |
| [`4439ae58`](https://github.com/NixOS/nixpkgs/commit/4439ae58440b39548d245d43b428c8e581c33d97) | `` linux_latest-libre: 19308 -> 19331 ``                                      |
| [`9038fbbb`](https://github.com/NixOS/nixpkgs/commit/9038fbbb8485781ebe0a0e002d3128b035b8d335) | `` linux-rt_6_1: 6.1.28-rt10 -> 6.1.33-rt11 ``                                |
| [`87531c7d`](https://github.com/NixOS/nixpkgs/commit/87531c7d800feb9693c9d67fd0dfe174357cc40b) | `` linux: 6.3.7 -> 6.3.8 ``                                                   |
| [`31891bd7`](https://github.com/NixOS/nixpkgs/commit/31891bd7adfe8eb1ac0f977d4dc86ab214c99c86) | `` linux: 6.1.33 -> 6.1.34 ``                                                 |
| [`e4d88ebd`](https://github.com/NixOS/nixpkgs/commit/e4d88ebd7ef6accc300323e4b722ed5f6148127d) | `` linux: 5.4.246 -> 5.4.247 ``                                               |
| [`4b9cbe96`](https://github.com/NixOS/nixpkgs/commit/4b9cbe9628696a85807f347f5df899ecf2b1ff61) | `` linux: 5.15.116 -> 5.15.117 ``                                             |
| [`46cf3ed0`](https://github.com/NixOS/nixpkgs/commit/46cf3ed06698bbfea67f873c3037e2d15bfcfd6c) | `` linux: 5.10.183 -> 5.10.184 ``                                             |
| [`2ece3d45`](https://github.com/NixOS/nixpkgs/commit/2ece3d45fab9b3a67ff4fa1a8d2b5e703aa8e428) | `` linux: 4.19.285 -> 4.19.286 ``                                             |
| [`eadc0471`](https://github.com/NixOS/nixpkgs/commit/eadc04712fd06a02feae76fef66505ab4041ff02) | `` linux: 4.14.317 -> 4.14.318 ``                                             |
| [`60772dfe`](https://github.com/NixOS/nixpkgs/commit/60772dfe01b0aacbe1546e627be5bd9e121572a3) | `` comical: refactor ``                                                       |
| [`f2bfcdd2`](https://github.com/NixOS/nixpkgs/commit/f2bfcdd27b80afe0e863b652b464ef45ca7a913b) | `` gnome.zenity: 3.92.0 → 3.99.0 ``                                           |
| [`b0aac89f`](https://github.com/NixOS/nixpkgs/commit/b0aac89f1fb85773dc6f65b3f2f27f68c7fba4e5) | `` digikam: 7.10.0 -> 8.0.0 ``                                                |
| [`2e582d4e`](https://github.com/NixOS/nixpkgs/commit/2e582d4edc753613cf4af77814440831a5c97785) | `` nixos/invidious: add automaticRestart option ``                            |
| [`fe6d0354`](https://github.com/NixOS/nixpkgs/commit/fe6d03548f1de01c340969ba3bc65213a2ffdc6a) | `` obs-studio-plugins.obs-mute-filter: init at 0.2.2 ``                       |
| [`0e3b14bf`](https://github.com/NixOS/nixpkgs/commit/0e3b14bf51fad124ddfdad20f8091084bce3de34) | `` telegram-desktop: 4.8.3 -> 4.8.4 ``                                        |
| [`adb66130`](https://github.com/NixOS/nixpkgs/commit/adb66130e7727296afd42fcde374368ab07b2c10) | `` lemmy-ui: set meta.platforms to nodejs.meta.platforms ``                   |
| [`2e7eea8e`](https://github.com/NixOS/nixpkgs/commit/2e7eea8e386477cc95f6716ca34a2d6f03390ca8) | `` lemmy: 0.17.3 -> 0.17.4 ``                                                 |
| [`a980e1d3`](https://github.com/NixOS/nixpkgs/commit/a980e1d387991520866356621b973119c982c463) | `` zoom-us: 5.14.7.2928 -> 5.14.10.3738 ``                                    |
| [`b5abb77a`](https://github.com/NixOS/nixpkgs/commit/b5abb77a5864632e839e199cd9f7ca365a92e20d) | `` obs-studio-plugins.obs-websocket: init at 4.9.1-compat ``                  |
| [`9c37f5ae`](https://github.com/NixOS/nixpkgs/commit/9c37f5aeb64c1d3461fe78eb9534d7b4fd69bbdc) | `` python38Packages.httplib2: resurrect ``                                    |
| [`b50af45b`](https://github.com/NixOS/nixpkgs/commit/b50af45b4cd6eabc8eeb6fea9001b5f9887553cf) | `` openimageio_1: drop ``                                                     |
| [`2bdeec6f`](https://github.com/NixOS/nixpkgs/commit/2bdeec6f846129932d9921d2192fdbcfb190b036) | `` coq: use dune_3 ``                                                         |
| [`8af638e3`](https://github.com/NixOS/nixpkgs/commit/8af638e3d76af0c750cffb43744481690072c0f2) | `` haskellPackages.ghcWithHoogle: Use overrides ``                            |
| [`447099ec`](https://github.com/NixOS/nixpkgs/commit/447099ec5d684e6f3feaba0b6cbaa54e962bcc24) | `` kamilalisp: init at 0.2 ``                                                 |
| [`e1d5503d`](https://github.com/NixOS/nixpkgs/commit/e1d5503d4d163529d1249a1f8c01d176bb2558a6) | `` python310Packages.hvplot: 0.8.3 -> 0.8.4 ``                                |
| [`ccdd853b`](https://github.com/NixOS/nixpkgs/commit/ccdd853b64f08a2aceb623bd9ff3fb3e7d0418d0) | `` 23.05 changelog typo fix: buildFHSEnvChrootenv -> buildFHSEnvChroot ``     |
| [`32a722d1`](https://github.com/NixOS/nixpkgs/commit/32a722d17aeae6a083c397746b9d0990ba627dbe) | `` osu-lazer: 2023.610.0 -> 2023.614.1 ``                                     |
| [`f92449ef`](https://github.com/NixOS/nixpkgs/commit/f92449ef6a317a55aa0a616fd925d3002e9fcb8f) | `` osu-lazer-bin: 2023.610.0 -> 2023.614.1 ``                                 |
| [`077d8a34`](https://github.com/NixOS/nixpkgs/commit/077d8a3447e25cd2d6664ae187667701de42cd75) | `` buildNimPackage: refactor to use overlay-style overrideAttrs ``            |
| [`8700152e`](https://github.com/NixOS/nixpkgs/commit/8700152e8a7062953dbc375a723acc0643bbd854) | `` python310Packages.datashader: 0.14.4 -> 0.15.0 ``                          |
| [`cfc46cf1`](https://github.com/NixOS/nixpkgs/commit/cfc46cf12f0ce5b077814e05a6ed777f48402dac) | `` python310Packages.dash: 2.10.1 -> 2.10.2 ``                                |
| [`a97fe899`](https://github.com/NixOS/nixpkgs/commit/a97fe8990df0809a75c9f37c5de268dc176e292d) | `` switch-to-configuration.pl: fix inverted dry-activate logic for swap ``    |
| [`8bc7d72e`](https://github.com/NixOS/nixpkgs/commit/8bc7d72e501c43ee1899c6568c542e2e96cf8493) | `` kodiPackages.arteplussept: 1.1.9 -> 1.1.10 ``                              |
| [`b17c3a5b`](https://github.com/NixOS/nixpkgs/commit/b17c3a5bea673b60cb3bd1d4cda29ac04879b3c1) | `` python3Packages.pytest-annotate unmark broken aarch64-linux ``             |
| [`3d29cabb`](https://github.com/NixOS/nixpkgs/commit/3d29cabb20b781c54d79ba99ebc8a76a34c4237e) | `` i3status-rust: 0.31.6 -> 0.31.7 ``                                         |
| [`2c6ebabe`](https://github.com/NixOS/nixpkgs/commit/2c6ebabe8d89a81dbaa50d3562ed681e67236ca5) | `` valent: unstable-2023-05-01 -> unstable-2023-06-11 ``                      |
| [`1b31f969`](https://github.com/NixOS/nixpkgs/commit/1b31f969c2ada5c2b84e4696478f9026a235e6c0) | `` opensearch: 2.7.0 -> 2.8.0 ``                                              |
| [`8ecdb204`](https://github.com/NixOS/nixpkgs/commit/8ecdb2048d182b3bca8ec07e11ddf5339ba58c1e) | `` insync: fix launching issue on wayland ``                                  |
| [`1180e9d0`](https://github.com/NixOS/nixpkgs/commit/1180e9d05a4bf4ce9a41e8be6cc72c53c10d04a6) | `` python311Packages.yalexs-ble: 2.1.17 -> 2.1.18 ``                          |
| [`a2ad9baa`](https://github.com/NixOS/nixpkgs/commit/a2ad9baaaf3af43d2124ee4f9b22b95a0ae23d96) | `` httpx: 1.3.1 -> 1.3.2 ``                                                   |
| [`ff8c1f1c`](https://github.com/NixOS/nixpkgs/commit/ff8c1f1cd6f0ff86f631f1dd2820f648903a711e) | `` gnuplot: 5.4.6 -> 5.4.8 ``                                                 |
| [`46ed4fc8`](https://github.com/NixOS/nixpkgs/commit/46ed4fc8306465cd872f6742b04c65acc4f74d08) | `` terraform-providers.aws: 5.2.0 -> 5.3.0 ``                                 |
| [`d29cdfa0`](https://github.com/NixOS/nixpkgs/commit/d29cdfa0aa9a98bf6040eebce3b4ef29b2a8784d) | `` terraform-providers.snowflake: 0.66.1 -> 0.66.2 ``                         |
| [`f955c728`](https://github.com/NixOS/nixpkgs/commit/f955c728d50f25f0038b9a7f4ea3011d737415ea) | `` terraform-providers.huaweicloud: 1.49.0 -> 1.50.0 ``                       |
| [`c3578f48`](https://github.com/NixOS/nixpkgs/commit/c3578f48bdd90a0e5ef288064c2bd01a19fb44b4) | `` terraform-providers.hcloud: 1.39.0 -> 1.40.0 ``                            |
| [`cc058b44`](https://github.com/NixOS/nixpkgs/commit/cc058b44dda820d27e6696a4ecd12e5fd691516e) | `` terraform-providers.fastly: 5.0.0 -> 5.1.0 ``                              |
| [`4b71c412`](https://github.com/NixOS/nixpkgs/commit/4b71c412071563c3231c62d3ce21d189379577d2) | `` terraform-providers.azurerm: 3.60.0 -> 3.61.0 ``                           |
| [`fd682cd3`](https://github.com/NixOS/nixpkgs/commit/fd682cd36d549089e7d44f2d21bfc5edf74109f4) | `` python310Packages.publicsuffixlist: 0.10.0.20230611 -> 0.10.0.20230614 ``  |
| [`68bff62c`](https://github.com/NixOS/nixpkgs/commit/68bff62c79428540e7cf2bc6182c38fbdd0a6d7c) | `` acorn: 0.6.0 -> 0.7.0 ``                                                   |
| [`54c38003`](https://github.com/NixOS/nixpkgs/commit/54c380037f0f95fc849e2206768dc779d7b640a6) | `` mozjpeg: 4.1.1 -> 4.1.3 ``                                                 |
| [`7b103e1e`](https://github.com/NixOS/nixpkgs/commit/7b103e1eebe71fa178c80ce5c8b0abab07cdb2f6) | `` acme-client: 1.3.1 -> 1.3.2 ``                                             |
| [`ba1a6ec5`](https://github.com/NixOS/nixpkgs/commit/ba1a6ec548000d4a50719d14e6f73f63016674d5) | `` ocamlPackages.merlin: Add versions 4.9-414, 4.9-500 ``                     |
| [`522b18e7`](https://github.com/NixOS/nixpkgs/commit/522b18e7436b0856bf7f22c4df841917d0203c3a) | `` vim: Add option for sodium ``                                              |
| [`e523281f`](https://github.com/NixOS/nixpkgs/commit/e523281f3b89159aa25f5c6a9d6c76eca3d4bcec) | `` pueue: 3.1.2 -> 3.2.0 ``                                                   |
| [`3923f0a3`](https://github.com/NixOS/nixpkgs/commit/3923f0a3643fa5ea733b7552c8c9f58b721d43c8) | `` lbreakouthd: 1.1.2 -> 1.1.3 ``                                             |
| [`1455ac53`](https://github.com/NixOS/nixpkgs/commit/1455ac5377781b56a166b6dbfbe3c8f1f538d376) | `` gendef: init at 11.0.1 ``                                                  |
| [`d9f25dbe`](https://github.com/NixOS/nixpkgs/commit/d9f25dbe07c62cb3762076ab3cbe0a2d8c492fed) | `` lightdm-slick-greeter: 1.6.1 -> 1.8.1 ``                                   |
| [`cc3eb83a`](https://github.com/NixOS/nixpkgs/commit/cc3eb83a47f4aaf4c2ebd73b517951a98deeab00) | `` python310Packages.cloup: 2.1.0 -> 2.1.1 ``                                 |
| [`337fb24f`](https://github.com/NixOS/nixpkgs/commit/337fb24f1f578051906a255cbe25d276679fe590) | `` lnd: 0.16.2-beta -> 0.16.3-beta ``                                         |
| [`7b396875`](https://github.com/NixOS/nixpkgs/commit/7b396875bb5cfcc0a7c747e5a90dbe2a0044db8f) | `` nixos-render-docs: De-lint using `ruff --fix` ``                           |
| [`c55163f4`](https://github.com/NixOS/nixpkgs/commit/c55163f47e909052d282af6b51d067ee8a6e90d8) | `` elf-dissector: unstable-2020-11-14 -> unstable-2023-06-06 ``               |
| [`e9704d9d`](https://github.com/NixOS/nixpkgs/commit/e9704d9d4f151850aaa9ed1912a1d3c059933642) | `` clash-geoip: 20230512 -> 20230612 ``                                       |
| [`68ec85eb`](https://github.com/NixOS/nixpkgs/commit/68ec85ebeb8196dd31c170ca749f926ff9a1583c) | `` quickwit: init at 0.6.1 ``                                                 |
| [`151d8300`](https://github.com/NixOS/nixpkgs/commit/151d8300bf2483188c78a10dd6a9667297bdd5b6) | `` scaleway-cli: 2.16.0 -> 2.16.1 ``                                          |
| [`ad1cd54c`](https://github.com/NixOS/nixpkgs/commit/ad1cd54cfeb0ea1e126d4a4dd70f25bab2641047) | `` scaleway-cli: 2.15.0 -> 2.16.0 ``                                          |
| [`ac6557e6`](https://github.com/NixOS/nixpkgs/commit/ac6557e6cef0d6ba6e5360c784afb5b47d8770e0) | `` kubernetes-polaris: 8.0.0 -> 8.2.1 ``                                      |
| [`efc6dbd2`](https://github.com/NixOS/nixpkgs/commit/efc6dbd2d7d7e602da2f2b6635aa3520334ddc8d) | `` liquibase: 4.9.0 -> 4.17.2 ``                                              |
| [`7701c98b`](https://github.com/NixOS/nixpkgs/commit/7701c98ba63c60efe31bebf142a59d21920e8dbe) | `` vscode: 1.79.0 -> 1.79.1 ``                                                |
| [`fb942419`](https://github.com/NixOS/nixpkgs/commit/fb9424192b28b028240e29b404d1584e5f7f2784) | `` python311Packages.deepl: 1.14.0 -> 1.15.0 ``                               |
| [`490ebb6d`](https://github.com/NixOS/nixpkgs/commit/490ebb6d65cc160e530ec74906f6fa482f0995f2) | `` aws-crt-cpp: 0.20.1 -> 0.20.2 ``                                           |
| [`bbd0efed`](https://github.com/NixOS/nixpkgs/commit/bbd0efed7457463264991cfc622909dcd5d0bbf0) | `` chromiumDev: 116.0.5803.2 -> 116.0.5817.0 ``                               |
| [`df795e15`](https://github.com/NixOS/nixpkgs/commit/df795e15856007bd4e627fc50b3331715f747a11) | `` chromiumBeta: 115.0.5790.13 -> 115.0.5790.24 ``                            |
| [`3062dce2`](https://github.com/NixOS/nixpkgs/commit/3062dce2016c82b81b7a2afca5f88fe14d2665b2) | `` chromium: 114.0.5735.106 -> 114.0.5735.133 ``                              |
| [`580b08fd`](https://github.com/NixOS/nixpkgs/commit/580b08fd0f39669d6f8bebc0d75704d5a177e840) | `` python310Packages.openaiauth: 0.3.6 -> 1.0.2 ``                            |
| [`31e42afc`](https://github.com/NixOS/nixpkgs/commit/31e42afc36690ba0aef7292a8e7730684e9901a2) | `` python311Packages.fakeredis: 2.12.1 -> 2.14.1 ``                           |
| [`d40add3b`](https://github.com/NixOS/nixpkgs/commit/d40add3bc57e399983d0f9c3cbab64668c005129) | `` sway: remove unused build inputs (#237625) ``                              |
| [`9914ebc9`](https://github.com/NixOS/nixpkgs/commit/9914ebc9c14bbf6e408091a9ae38c5bfe5ef295f) | `` pwsafe: 1.16.0 -> 1.17.0 ``                                                |
| [`77562692`](https://github.com/NixOS/nixpkgs/commit/7756269294910b60d85a0a093b12e68271e0db0e) | `` arc_unpacker: drop boost175 ``                                             |
| [`e90081b6`](https://github.com/NixOS/nixpkgs/commit/e90081b6c5a9c3f5fe9170d8511119f1ebd8169d) | `` dapr-cli: 1.10.0 -> 1.11.0 ``                                              |
| [`15bce5c2`](https://github.com/NixOS/nixpkgs/commit/15bce5c2049dd2f19fcb4fc9d80196f81d46af2c) | `` natron: cleanup ``                                                         |
| [`3d1b9f08`](https://github.com/NixOS/nixpkgs/commit/3d1b9f0819990ed51ddde2a7f81755913935351d) | `` macs2: rename from MACS2 ``                                                |
| [`12cab182`](https://github.com/NixOS/nixpkgs/commit/12cab182ae8f8aceca060de7a56d51ebe8c86898) | `` MACS2: 2.2.7.1 -> 2.2.8 ``                                                 |
| [`2e306780`](https://github.com/NixOS/nixpkgs/commit/2e3067801781ab61556aa80b3ccb353cce624820) | `` nextcloudPackages: update ``                                               |
| [`945e82bf`](https://github.com/NixOS/nixpkgs/commit/945e82bfb72a6f462dfb30a96ba249a55c5cae41) | `` numix-icon-theme-square: 23.05.15 -> 23.06.11 ``                           |
| [`b506b408`](https://github.com/NixOS/nixpkgs/commit/b506b408c1c5900afb45de19058cea7c4e63662b) | `` quartoMinimal: 1.2.475 -> 1.3.361 ``                                       |
| [`904d6a0b`](https://github.com/NixOS/nixpkgs/commit/904d6a0b6252b834927d9c82018d8f43f1e2e06a) | `` nextcloud-client: 3.8.2 -> 3.9.0 ``                                        |
| [`144ef637`](https://github.com/NixOS/nixpkgs/commit/144ef637a6c989943d81eddc2da5090a10514590) | `` nixosTests.coturn: wait_for_open_port ``                                   |
| [`c23b26e9`](https://github.com/NixOS/nixpkgs/commit/c23b26e93eb86808ca17a2974eca2d701cb05ed4) | `` coturn: 4.6.1 -> 4.6.2 ``                                                  |
| [`c32dedc7`](https://github.com/NixOS/nixpkgs/commit/c32dedc741e1d5f6643203a4f02794575cfb7742) | `` netbird-ui: 0.21.0 -> 0.21.3 ``                                            |
| [`28af3205`](https://github.com/NixOS/nixpkgs/commit/28af3205bc11efef07a84e708729db1fa259c923) | `` gplates: drop python39 ``                                                  |
| [`ae350463`](https://github.com/NixOS/nixpkgs/commit/ae3504632697eb76852a623f44678b5e11118df3) | `` treewide: treewide: use lib.optionalAttrs instead of 'then {}' ``          |
| [`eb3f1f13`](https://github.com/NixOS/nixpkgs/commit/eb3f1f13b82855a3aa20b6d9a827a262d61fc4cc) | `` cloudfox: 1.10.3 -> 1.11.1 ``                                              |
| [`596d8fff`](https://github.com/NixOS/nixpkgs/commit/596d8fff5fbfbf2aab7d21539260d4f430fe9650) | `` minio: 2023-05-27T05-56-19Z -> 2023-06-09T07-32-12Z ``                     |
| [`20926278`](https://github.com/NixOS/nixpkgs/commit/20926278783ccacf3f3b84eed9af349b6004829c) | `` numix-icon-theme-circle: 23.05.15 -> 23.06.11 ``                           |
| [`123283d1`](https://github.com/NixOS/nixpkgs/commit/123283d1ad3bd9b8d13cf5dcaaefa632975030f7) | `` codespelunker: 1.0.0 -> 1.2.0 ``                                           |
| [`d1556ade`](https://github.com/NixOS/nixpkgs/commit/d1556ade024422dc546e7fa2f20c8a7a202adf9b) | `` code-server: use `finalAttrs` pattern ``                                   |
| [`a80629ec`](https://github.com/NixOS/nixpkgs/commit/a80629ec9d8ce6511742da911a110ba0b535ca5d) | `` linuxPackages.apfs: drop obsolete kernel reference ``                      |
| [`84b442b1`](https://github.com/NixOS/nixpkgs/commit/84b442b179d62d16ad26f467327beb852aa67efb) | `` openttd-jgrpp: 0.53.1 -> 0.54.1 ``                                         |
| [`de847f99`](https://github.com/NixOS/nixpkgs/commit/de847f9917c0cab84a86e5e1e86ba0cfb7135ad9) | `` openttd: 13.1 -> 13.3 ``                                                   |
| [`4bcb858f`](https://github.com/NixOS/nixpkgs/commit/4bcb858f37137266857239906f492857ce9d015a) | `` tone: fix compatibility with .NET 6.0.18 libraries ``                      |
| [`db6d8458`](https://github.com/NixOS/nixpkgs/commit/db6d845831f08ca800614a5e2da64c5cd0453080) | `` space-station-14-launcher: fix compatibility with .NET 6.0.18 libraries `` |
| [`eb9eeea5`](https://github.com/NixOS/nixpkgs/commit/eb9eeea5d3ccc97851f94269edabad17901481e1) | `` dotnet-sdk_8: 8.0.100-preview.4.23260.5 -> 8.0.100-preview.5.23303.2 ``    |
| [`e65a30f8`](https://github.com/NixOS/nixpkgs/commit/e65a30f825fdf5eb59270dd16ae8c6905035150c) | `` cariddi: 1.3.1 -> 1.3.2 ``                                                 |
| [`1c456517`](https://github.com/NixOS/nixpkgs/commit/1c45651756a8c2619b8753075a2ec1656dfc6e1c) | `` spacer: init at 0.1.1 ``                                                   |
| [`6ed7e686`](https://github.com/NixOS/nixpkgs/commit/6ed7e686b263fe44251b6ebd3617b133473220fd) | `` gvm-libs: 22.5.0 -> 22.6.2 ``                                              |