### PR TITLE
chore(flake/nixpkgs): `0d2cf7fe` -> `7c67f006`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686776226,
-        "narHash": "sha256-o6WbKvENj98QJz9Mco6T6SZGrjPewMDAFyKg0Lp8avU=",
+        "lastModified": 1686869522,
+        "narHash": "sha256-tbJ9B8WLCTnVP/LwESRlg0dII6Zyg2LmUU/mB9Lu98E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0d2cf7fe5fa05d5271a15a8933414ee0a1570648",
+        "rev": "7c67f006ea0e7d0265f16d7df07cc076fdffd91f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`89afe706`](https://github.com/NixOS/nixpkgs/commit/89afe706797a64bebddc558e7b50d2862c15a40e) | `` libraspberrypi: build all binaries on 32-bit ARM ``                                 |
| [`5d486408`](https://github.com/NixOS/nixpkgs/commit/5d486408b510035c76b31d8d880c830d773b40a4) | `` opensmalltalk-vm: init at 202206021410 (#215158) ``                                 |
| [`5a27d7f4`](https://github.com/NixOS/nixpkgs/commit/5a27d7f4f292d4fc576a13ad0df639d7aa37316c) | `` maintainers: add code-asher ``                                                      |
| [`b7d596c1`](https://github.com/NixOS/nixpkgs/commit/b7d596c1409fef13d3191048c92abd4a0e18b495) | `` code-server: 4.12.0 -> 4.13.0 ``                                                    |
| [`6d402731`](https://github.com/NixOS/nixpkgs/commit/6d402731689fbeb403b03a0f486b8c8a26530d5a) | `` libuv: use finalAttrs instead of rec (#237140) ``                                   |
| [`7a53daed`](https://github.com/NixOS/nixpkgs/commit/7a53daed2a71fd4b7b177bc48f2f9c996a5bb4b2) | `` documentation-highlighter: less weird source filter ``                              |
| [`cc3e5198`](https://github.com/NixOS/nixpkgs/commit/cc3e5198707b9b5523643e791677d4135fb3aee7) | `` nixd: init at 1.0.0 ``                                                              |
| [`b55b4151`](https://github.com/NixOS/nixpkgs/commit/b55b4151987280cfb6936522a56854183387b0d2) | `` lemmy: fix update script (hash + running dir) ``                                    |
| [`2cfab788`](https://github.com/NixOS/nixpkgs/commit/2cfab788a67b8ef56ec51e5bc2a4f2fc8a3ff65e) | `` tree: 2.0.4 -> 2.1.1 ``                                                             |
| [`a76847f3`](https://github.com/NixOS/nixpkgs/commit/a76847f3aa4181819a4bff9f1c8cec8b6f04d2d7) | `` _1password-gui: fix newline escape after #237925 ``                                 |
| [`d2c4d21c`](https://github.com/NixOS/nixpkgs/commit/d2c4d21c2f661fb8d1cc8536e84c5e4372416051) | `` whalebird: 4.7.4 -> 5.0.7 ``                                                        |
| [`bc8af837`](https://github.com/NixOS/nixpkgs/commit/bc8af837c8e9b4554e23933f5389fb9881ee8530) | `` ungoogled-chromium: 114.0.5735.106 -> 114.0.5735.133 ``                             |
| [`19d28fc4`](https://github.com/NixOS/nixpkgs/commit/19d28fc464aa1070d4d302af3d59af15bbc3aaf4) | `` capstone: build with cmake ``                                                       |
| [`5e31617e`](https://github.com/NixOS/nixpkgs/commit/5e31617e2206423a30c79de2d3c2fe705c559b20) | `` maintainers: add ryane ``                                                           |
| [`a133d0b4`](https://github.com/NixOS/nixpkgs/commit/a133d0b429cb1ec5d9082d0a01ec87d278823f29) | `` kfilt: init at 0.0.8 ``                                                             |
| [`7c6e6a29`](https://github.com/NixOS/nixpkgs/commit/7c6e6a29a789bcc1f6edea912bc0ff6328ad25f9) | `` polygon-cli: init at 1.1.11 ``                                                      |
| [`f5b5fe0c`](https://github.com/NixOS/nixpkgs/commit/f5b5fe0c905b0802fc3def4772248bde1eaa05e4) | `` maintainers: add khaser ``                                                          |
| [`fc732173`](https://github.com/NixOS/nixpkgs/commit/fc732173dc8fb0c8fec49da55f3916fb707386d6) | `` linux_testing: 6.4-rc4 -> 6.4-rc6 ``                                                |
| [`c430464f`](https://github.com/NixOS/nixpkgs/commit/c430464f0ad0140b91f57a2ff4cca41f5fdcd6d6) | `` all-packages: recurse into geph ``                                                  |
| [`a5a73963`](https://github.com/NixOS/nixpkgs/commit/a5a73963dd913a55dfee7175d12554ccb54eeffb) | `` _1password-gui: disable wayland for now ``                                          |
| [`219c23a1`](https://github.com/NixOS/nixpkgs/commit/219c23a1af664f18ecce3a6a18c0cd2e65b90a95) | `` ssdfs-utils: 4.24 -> 4.27 ``                                                        |
| [`f4c243b1`](https://github.com/NixOS/nixpkgs/commit/f4c243b1200d4b068a97e4847ecff9f342872ca8) | `` ssdfs-utils: init at 4.24 ``                                                        |
| [`7f528f2f`](https://github.com/NixOS/nixpkgs/commit/7f528f2f6c018d4737df20e6a3c8342b272a0c3b) | `` licenses: add BSD-3-Clause-Clear ``                                                 |
| [`169cb594`](https://github.com/NixOS/nixpkgs/commit/169cb594982b69bbcf3bc61103d1d51661cae86d) | `` calc: replace util-linux with unixtools.col ``                                      |
| [`683f2f5b`](https://github.com/NixOS/nixpkgs/commit/683f2f5ba2ea54abb633d0b17bc9f7f6dede5799) | `` ocamlPackage.{cohttp,github-unix}: fix for OCaml 5.0 (#237686) ``                   |
| [`e4a754b0`](https://github.com/NixOS/nixpkgs/commit/e4a754b012578df4042a40a73c11f387d906f114) | `` vpsfree-client: add aither64 to maintainers ``                                      |
| [`215c4e19`](https://github.com/NixOS/nixpkgs/commit/215c4e19d0938cd2cb7a2b3348be143f4d16db98) | `` vpsfree-client: 0.11.0 -> 0.17.1 ``                                                 |
| [`af585658`](https://github.com/NixOS/nixpkgs/commit/af585658b89d2533350d50a47e61f3d81ea6dacf) | `` nixos/lemmy: reduce moving parts ``                                                 |
| [`fa9306c0`](https://github.com/NixOS/nixpkgs/commit/fa9306c041acbf3f17286cf195aa726481263f2b) | `` nixos/lemmy: allow overriding packages ``                                           |
| [`b1853ecf`](https://github.com/NixOS/nixpkgs/commit/b1853ecfcda559eb9e62c1a64e45a56e77a8b5d1) | `` nixos/lemmy: only use env var when instructed ``                                    |
| [`dd0b5a7e`](https://github.com/NixOS/nixpkgs/commit/dd0b5a7e08919a3976d0bdada4d856830f8cd2dc) | `` nixos/lemmy: warn for option removed upstream ``                                    |
| [`9fb9774d`](https://github.com/NixOS/nixpkgs/commit/9fb9774d9362f455683089f7615e0bf43000431a) | `` nixos/tests/systemd-initrd-vconsole: fix test and improve reliability ``            |
| [`f1f0d4fb`](https://github.com/NixOS/nixpkgs/commit/f1f0d4fbddcec38d999fb5390f481c20f2b5fd77) | `` nixos/test-driver: fix `timeout` option for `wait_for_console_text` ``              |
| [`685ba364`](https://github.com/NixOS/nixpkgs/commit/685ba364b48119857ce6f26a2e203ee01ccc0359) | `` tauri-mobile: ustable-2023-04-25 -> unstable-2023-06-06 ``                          |
| [`e45eeed3`](https://github.com/NixOS/nixpkgs/commit/e45eeed3410ad8a1d7369c35f8f60432e08d37d5) | `` vscode-langservers-extracted: use buildNpmPackage ``                                |
| [`55f736e3`](https://github.com/NixOS/nixpkgs/commit/55f736e3373d78fa98532270a44ad69f7431b997) | `` python310Packages.sqlmap: 1.7.5 -> 1.7.6 ``                                         |
| [`a4f237bf`](https://github.com/NixOS/nixpkgs/commit/a4f237bfadf4842cbd07bc5b489401639d827426) | `` cryfs: unpin boost175 ``                                                            |
| [`ad6dca08`](https://github.com/NixOS/nixpkgs/commit/ad6dca08f572763aba0600c9ea591c3272be8f3e) | `` python310Packages.python-lsp-black: 1.2.1 -> 1.3.0 ``                               |
| [`05d2db44`](https://github.com/NixOS/nixpkgs/commit/05d2db449848898a91c829501acc58e23173ae98) | `` ondir: init at 0.2.3 ``                                                             |
| [`6575871b`](https://github.com/NixOS/nixpkgs/commit/6575871b37cfb51fdcc57bc22f3a838cba291874) | `` shopware-cli: 0.1.78 -> 0.2.0 ``                                                    |
| [`30ee65ee`](https://github.com/NixOS/nixpkgs/commit/30ee65ee2fd883f0d176ad19e24fe2eeb4a262e4) | `` coqPackages.reglang: 1.1.2 → 1.1.3 ``                                               |
| [`22514cd3`](https://github.com/NixOS/nixpkgs/commit/22514cd3469f1ff6e6712b8515275c4583fe53e2) | `` python3Packages.aws-lambda-builders: unmark broken on aarch64 ``                    |
| [`5ac7371b`](https://github.com/NixOS/nixpkgs/commit/5ac7371bd1b99ca76930decc457e79fbae7e49ea) | `` nixos/nix-ld: use mkPackageOptionMD ``                                              |
| [`b60f21e1`](https://github.com/NixOS/nixpkgs/commit/b60f21e1356efe71a8f6f5688b4aa2fbbe13eb7c) | `` nixos/nix-ld: also include ld.so in nixos profile ``                                |
| [`f3ae11b0`](https://github.com/NixOS/nixpkgs/commit/f3ae11b096bfd522de2c1afb69a4e53b4a71d188) | `` nixos/nix-ld: also test NIX_LD fallback ``                                          |
| [`c6e8899d`](https://github.com/NixOS/nixpkgs/commit/c6e8899d9eed425dc1bdcde7a008f30e2947d814) | `` nix-ld: 1.1.0 -> 1.2.1 ``                                                           |
| [`f54948a0`](https://github.com/NixOS/nixpkgs/commit/f54948a04efe019f421251b856309ed8b99be9da) | `` oneDNN: remove alexarice as maintainer ``                                           |
| [`95a4cdab`](https://github.com/NixOS/nixpkgs/commit/95a4cdaba53fdbf5b7d713f0bac390964eb78bd8) | `` zbar: fix cross compilation ``                                                      |
| [`a7b9356b`](https://github.com/NixOS/nixpkgs/commit/a7b9356bc40a2386376d4c83a426eb2736bb5a25) | `` python310Packages.python-gitlab: 3.14.0 -> 3.15.0 ``                                |
| [`00371b02`](https://github.com/NixOS/nixpkgs/commit/00371b022162621594f940da42054ee2dc7ee741) | `` python310Packages.ibm-cloud-sdk-core: 3.16.6 -> 3.16.7 ``                           |
| [`80e36cd3`](https://github.com/NixOS/nixpkgs/commit/80e36cd3c8ed3907e9d8176361afc66ccd3a6c3a) | `` python310Packages.west: 1.0.0 -> 1.1.0 ``                                           |
| [`a08dec0c`](https://github.com/NixOS/nixpkgs/commit/a08dec0c4b5a6bbd938638d1408f5737bc932e7e) | `` babashka: 1.3.180 -> 1.3.181 ``                                                     |
| [`7c7edf16`](https://github.com/NixOS/nixpkgs/commit/7c7edf164392463dbc3516bbe227d953ebe68a35) | `` python310Packages.z3c-checkversions: 2.0 -> 2.1 ``                                  |
| [`805ab72d`](https://github.com/NixOS/nixpkgs/commit/805ab72d52e2bde5b942b2739bcaa13161b6e254) | `` python311Packages.yaramod: 3.19.1 -> 3.20.0 ``                                      |
| [`764464d2`](https://github.com/NixOS/nixpkgs/commit/764464d2c75793ecc58e189d507f54cd65ad8248) | `` terraform-providers.yandex: 0.92.0 -> 0.93.0 ``                                     |
| [`441640f1`](https://github.com/NixOS/nixpkgs/commit/441640f1f29d67aaff2eb246007cb32d9be556f7) | `` terraform-providers.tencentcloud: 1.81.6 -> 1.81.7 ``                               |
| [`161c4120`](https://github.com/NixOS/nixpkgs/commit/161c4120cb597e25ba7981d78a222c11f25444f0) | `` terraform-providers.oci: 5.0.0 -> 5.1.0 ``                                          |
| [`408e198c`](https://github.com/NixOS/nixpkgs/commit/408e198c58cb7c1ca1e402654b61814afc3414d0) | `` terraform-providers.spotinst: 1.122.1 -> 1.122.2 ``                                 |
| [`9a5c4cc8`](https://github.com/NixOS/nixpkgs/commit/9a5c4cc88b8cf5d8b5c7f0345124ce4d82599586) | `` terraform-providers.nutanix: 1.9.0 -> 1.9.1 ``                                      |
| [`3fdfa011`](https://github.com/NixOS/nixpkgs/commit/3fdfa0119aed5de0a879f85b2bf0091f001502a5) | `` terraform-providers.cloudflare: 4.7.1 -> 4.8.0 ``                                   |
| [`6faa68a4`](https://github.com/NixOS/nixpkgs/commit/6faa68a4c50c602d076d2d85b038c61c4f955fa4) | `` terraform-providers.aiven: 4.4.1 -> 4.5.0 ``                                        |
| [`73eeb281`](https://github.com/NixOS/nixpkgs/commit/73eeb28174521d0b0a4cc73c9c0a477e97b2d049) | `` terraform-providers.auth0: 0.48.0 -> 0.49.0 ``                                      |
| [`cc2fb2c1`](https://github.com/NixOS/nixpkgs/commit/cc2fb2c1e4363f0f8eeef0d68ffc61453c8a9db6) | `` coqPackages.itauto: init at 8.17.0 for Coq 8.17 ``                                  |
| [`d08861a0`](https://github.com/NixOS/nixpkgs/commit/d08861a050a3c2f446042d76145a051fef474c23) | `` python310Packages.hcloud: 1.19.0 -> 1.20.0 ``                                       |
| [`b43bbe8b`](https://github.com/NixOS/nixpkgs/commit/b43bbe8bb24b6b0b5754580ae8300c822352049e) | `` python310Packages.logical-unification: 0.4.5 -> 0.4.6 ``                            |
| [`e6333583`](https://github.com/NixOS/nixpkgs/commit/e6333583be8ebfc2de09e16ead6490d3e8558450) | `` fzf: 0.41.1 -> 0.42.0 ``                                                            |
| [`2d4d206e`](https://github.com/NixOS/nixpkgs/commit/2d4d206e3b427d4d9724046bb6be4021bbcbdb07) | `` python310Packages.pymupdf: 1.21.1 -> 1.22.3 ``                                      |
| [`a1fdcfe6`](https://github.com/NixOS/nixpkgs/commit/a1fdcfe62a4e55c552f17f540c41224d6f238cf9) | `` python310Packages.xmodem: 0.4.6 -> 0.4.7 ``                                         |
| [`3cda91a8`](https://github.com/NixOS/nixpkgs/commit/3cda91a80ce779172d03a8c0c7f5127f75552c5e) | `` Update elpa-devel-generated ``                                                      |
| [`9c53e33e`](https://github.com/NixOS/nixpkgs/commit/9c53e33ed656394ba4ac2021db29a09b235db813) | `` Update emacs2nix ``                                                                 |
| [`12098193`](https://github.com/NixOS/nixpkgs/commit/12098193f97f475f84e306e79e2c09164826949b) | `` libsciter: run deadnix, statix ``                                                   |
| [`8b853833`](https://github.com/NixOS/nixpkgs/commit/8b8538338af8c6216b0a4328fcd7cebf6be8f3fa) | `` fcitx5: Remove unused variable ``                                                   |
| [`0822545b`](https://github.com/NixOS/nixpkgs/commit/0822545ba81049977bb164a8095ed19f9d0d0bf5) | `` fcitx5: Remove unused import ``                                                     |
| [`ef3e16c7`](https://github.com/NixOS/nixpkgs/commit/ef3e16c79cf11461bdbbe370498d9720b5bbb825) | `` python310Packages.httpx-socks: 0.7.5 -> 0.7.6 ``                                    |
| [`ce51b2bb`](https://github.com/NixOS/nixpkgs/commit/ce51b2bb02068ac6227e2512feea61ec00129c8e) | `` python310Packages.tiny-proxy: init at 0.2.0 ``                                      |
| [`625e6657`](https://github.com/NixOS/nixpkgs/commit/625e6657c1ee66c52ea966b12808fe129d0486b3) | `` kakoune: Remove no-op `if`/`else` ``                                                |
| [`39b3b83d`](https://github.com/NixOS/nixpkgs/commit/39b3b83df88adaff0030ac61d5ce5b10a60ec99d) | `` surrealdb-migrations: 0.9.9 -> 0.9.10 ``                                            |
| [`aac07377`](https://github.com/NixOS/nixpkgs/commit/aac07377aa556bace1e7a18d0af79d4b004abc7e) | `` electron_25-bin: 25.0.1 -> 25.1.1 ``                                                |
| [`94a5c3c2`](https://github.com/NixOS/nixpkgs/commit/94a5c3c244dbef476e57ae01be23ddf85343577a) | `` electron_24-bin: 24.4.1 -> 24.5.1 ``                                                |
| [`1293cece`](https://github.com/NixOS/nixpkgs/commit/1293cece3df7fef7ce29498bd495826447c50939) | `` electron_23-bin: 23.3.5 -> 23.3.7 ``                                                |
| [`79fc4c0f`](https://github.com/NixOS/nixpkgs/commit/79fc4c0f9cf181d8cbf423d101b9dc22ab3a33d1) | `` electron_22-bin: 22.3.12 -> 22.3.13 ``                                              |
| [`791438ea`](https://github.com/NixOS/nixpkgs/commit/791438ea989c0e63eb9e22d9577fad28c6eeaa7a) | `` rare-regex: 0.3.1 -> 0.3.2 ``                                                       |
| [`9b9b6c29`](https://github.com/NixOS/nixpkgs/commit/9b9b6c291b4437d45176b31023bc075aa8e3be04) | `` netbox2netshot: init at 0.1.12 ``                                                   |
| [`fd60d6dc`](https://github.com/NixOS/nixpkgs/commit/fd60d6dc794f8f499142a9b4628719d7df4e6dbf) | `` pre-commit: 3.3.2 -> 3.3.3 ``                                                       |
| [`d86f79a1`](https://github.com/NixOS/nixpkgs/commit/d86f79a17dd1182f2fbd7393ec5ae9146217d59a) | `` python311Packages.openhomedevice: enable tests ``                                   |
| [`4830b54e`](https://github.com/NixOS/nixpkgs/commit/4830b54ec99277cc6c28465f90d98bfeba86301a) | `` faust2sc: remove workaround ``                                                      |
| [`4bc3590c`](https://github.com/NixOS/nixpkgs/commit/4bc3590c0334c2f966b51e2fd6ef7056d8177976) | `` python311Packages.openhomedevice: add changelog to meta ``                          |
| [`797d6adc`](https://github.com/NixOS/nixpkgs/commit/797d6adcba7f2e3f6988c7606df4c492dd217c55) | `` python311Packages.openhomedevice: 2.0.2 -> 2.1 ``                                   |
| [`993ceb63`](https://github.com/NixOS/nixpkgs/commit/993ceb637bbc106abade42ee303479a96477dcbf) | `` python311Packages.google-cloud-bigquery: 3.11.0 -> 3.11.1 ``                        |
| [`c6dfb267`](https://github.com/NixOS/nixpkgs/commit/c6dfb26702fa23aaa1c289af3cf5b61ff0915c73) | `` age-plugin-tpm: init at unstable-2023-05-02 ``                                      |
| [`c38a804c`](https://github.com/NixOS/nixpkgs/commit/c38a804c226c48d1a4a94d441f63d9ba1cb90e70) | `` python311Packages.google-cloud-container: 2.23.0 -> 2.24.0 ``                       |
| [`e1e5733d`](https://github.com/NixOS/nixpkgs/commit/e1e5733d93d4c859237cbfb035b863d8d7364a01) | `` python311Packages.google-cloud-securitycenter: 1.21.0 -> 1.22.0 ``                  |
| [`09858c0a`](https://github.com/NixOS/nixpkgs/commit/09858c0a653ee27fab1cb44b02a21c2288118ce4) | `` chickenPackages_5.chickenEggs.scheme2c-compatibility: fix build on x86_64-darwin `` |
| [`b518881d`](https://github.com/NixOS/nixpkgs/commit/b518881d73cc11c5898e226408009bd14bb80115) | `` linuxPackages.nvidia_x11_production: 525.116.04 -> 535.54.03 ``                     |
| [`419b8347`](https://github.com/NixOS/nixpkgs/commit/419b83474c2465e70c5e983e83cf08b01f658b42) | `` refmt: init at 1.16.0 ``                                                            |
| [`23651a5f`](https://github.com/NixOS/nixpkgs/commit/23651a5fce7b5fc974652c79839a6d50d5b52da8) | `` postman: 10.12.0 -> 10.15.0 ``                                                      |
| [`542f2105`](https://github.com/NixOS/nixpkgs/commit/542f210592d9e0b77c7cb03b7c982b3790809896) | `` mpd-discord-rpc: 1.6.0 -> 1.7.0 ``                                                  |
| [`ee70d829`](https://github.com/NixOS/nixpkgs/commit/ee70d829be3bbb1d0c7493353d63851ea2646fa2) | `` dart-sass: 1.62.1 -> 1.63.3 ``                                                      |
| [`bbbf5574`](https://github.com/NixOS/nixpkgs/commit/bbbf5574c02132b050b859af2be6db461d99bcc2) | `` buildDartApplication: add sigtool on darwin ``                                      |
| [`dad0bcaf`](https://github.com/NixOS/nixpkgs/commit/dad0bcafda27f7bbf74148c6d9f5baf5317161cb) | `` checkov: 2.3.288 -> 2.3.292 ``                                                      |
| [`ec45fd03`](https://github.com/NixOS/nixpkgs/commit/ec45fd031821a8cea0ec8c0a70c40c2576814eb3) | `` synadm: 0.41.2 -> 0.41.3 ``                                                         |
| [`1de6e195`](https://github.com/NixOS/nixpkgs/commit/1de6e195edd9e772a6e742672acca67a15a019b7) | `` exploitdb: 2023-06-10 -> 2023-06-14 ``                                              |
| [`07c3776e`](https://github.com/NixOS/nixpkgs/commit/07c3776e3fe8ed1ab35f4f96d3b07382808e9534) | `` libxisf: 0.2.3 -> 0.2.8 ``                                                          |
| [`099f503f`](https://github.com/NixOS/nixpkgs/commit/099f503f90b8976bfa9b10b7658268eace1a68a1) | `` browsr: fix build ``                                                                |
| [`91be46f7`](https://github.com/NixOS/nixpkgs/commit/91be46f7f9391a32e0303d59e2a020314f9f9244) | `` python310Packages.art: 5.9 -> 6.0 ``                                                |
| [`5390997c`](https://github.com/NixOS/nixpkgs/commit/5390997c8383e0b9205210d528b969ecd063e87b) | `` skate: 0.2.1 -> 0.2.2 ``                                                            |
| [`96d7a8de`](https://github.com/NixOS/nixpkgs/commit/96d7a8de5f023fd5fda310703d4ee03b1c22f3cd) | `` sch_cake: remove ``                                                                 |
| [`615e9d9d`](https://github.com/NixOS/nixpkgs/commit/615e9d9d6a6d10209b9021b707ea1549dceb4d29) | `` spacer: 0.1.1 -> 0.1.6 ``                                                           |
| [`228bb539`](https://github.com/NixOS/nixpkgs/commit/228bb53928808f77445e3edf1af5c293055c14b9) | `` lua-language-server: 3.6.21 -> 3.6.22 ``                                            |
| [`90ccf242`](https://github.com/NixOS/nixpkgs/commit/90ccf242053a90d52f68f007d2dcfe7b5ffe7e27) | `` stylua: 0.17.1 -> 0.18.0 ``                                                         |
| [`f326ab44`](https://github.com/NixOS/nixpkgs/commit/f326ab4463fc1bf8289fc71c8c4bfc7564b458f6) | `` hunspellDicts: add pt_BR ``                                                         |
| [`17984299`](https://github.com/NixOS/nixpkgs/commit/17984299b98195636529808af0d1d591a3290349) | `` buildNimPackage: doCheck by default ``                                              |
| [`cd6c817a`](https://github.com/NixOS/nixpkgs/commit/cd6c817a8c6f6fc8530de54ac152b81055ffa67a) | `` vscode-extensions.davidanson.vscode-markdownlint: 0.50.0 -> 0.51.0 ``               |
| [`7d588741`](https://github.com/NixOS/nixpkgs/commit/7d588741c2cf1e129a816c439b20f56b8e43db54) | `` libvgm: unstable-2023-04-22 -> unstable-2023-05-17 ``                               |
| [`b74268b7`](https://github.com/NixOS/nixpkgs/commit/b74268b7b813614f3c5696b026af95ffc3476ad2) | `` python310Packages.oci: 2.100.0 -> 2.104.2 ``                                        |
| [`4e51c7b1`](https://github.com/NixOS/nixpkgs/commit/4e51c7b1a8b72357a6fdd030fc0929d8895fae9d) | `` python311Packages.regenmaschine: 2023.05.1 -> 2023.06.0 ``                          |
| [`30d897c0`](https://github.com/NixOS/nixpkgs/commit/30d897c0ffeebb3c654f1a1a0a9eed4a6208a678) | `` nixos/cinnamon: enable touchegg by default ``                                       |
| [`664601d8`](https://github.com/NixOS/nixpkgs/commit/664601d8198875ca0a370feade7558dac8d7333a) | `` nixos/cinnamon: enable switcherooControl by default ``                              |
| [`bc559b4c`](https://github.com/NixOS/nixpkgs/commit/bc559b4ca3bfbcc161cd484859a3c5651be1b710) | `` nixos/cinnamon: install mint-l by default ``                                        |
| [`3dde9f36`](https://github.com/NixOS/nixpkgs/commit/3dde9f36d8dc42a21f7022df584b5bb9d12a2259) | `` hypnotix: 3.2 -> 3.4 ``                                                             |
| [`74e7732d`](https://github.com/NixOS/nixpkgs/commit/74e7732dc31a0462282f8e2fd408ed31186dfad6) | `` cinnamon.pix: 2.8.9 -> 3.0.1 ``                                                     |
| [`ad38f06a`](https://github.com/NixOS/nixpkgs/commit/ad38f06a3eb437b1833e2e32bdc028a46c2d3af8) | `` cinnamon.mint-x-icons: 1.6.4 -> 1.6.5 ``                                            |
| [`503800b1`](https://github.com/NixOS/nixpkgs/commit/503800b1fa0b7d4d4bed80dddbe9ff86f1d58fa3) | `` cinnamon.mint-y-icons: 1.6.5 -> 1.6.6 ``                                            |
| [`21b308be`](https://github.com/NixOS/nixpkgs/commit/21b308be5f6a611c60f59c8d104889dd667f8785) | `` cinnamon.mint-themes: 2.0.9 -> 2.1.2 ``                                             |
| [`9447fa6d`](https://github.com/NixOS/nixpkgs/commit/9447fa6d244de3cb35f917699e6c3bd86f328455) | `` cinnamon.cinnamon-common: 5.6.8 -> 5.8.2 ``                                         |
| [`ac5791cf`](https://github.com/NixOS/nixpkgs/commit/ac5791cffb3b475ac5111fd7b73da94d1c61e67c) | `` cinnamon.muffin: 5.6.4 -> 5.8.0 ``                                                  |
| [`c73f809c`](https://github.com/NixOS/nixpkgs/commit/c73f809c618f1fbc147c63d5980928167b2a1799) | `` cinnamon.nemo: 5.6.5 -> 5.8.2 ``                                                    |
| [`067a8989`](https://github.com/NixOS/nixpkgs/commit/067a8989e5ad1961f7b9c67a9464fda71328ad11) | `` cinnamon.nemo-extensions: don't duplicate version and src ``                        |
| [`a26bc72f`](https://github.com/NixOS/nixpkgs/commit/a26bc72ff06bc9e915e49bbaa923604dab8a9785) | `` cinnamon.nemo-python: 5.6.0 -> 5.8.0 ``                                             |
| [`ddf80f11`](https://github.com/NixOS/nixpkgs/commit/ddf80f1103108439380b5e59addb8e321283f048) | `` cinnamon.nemo-fileroller: 5.6.1 -> 5.8.0 ``                                         |
| [`5b962021`](https://github.com/NixOS/nixpkgs/commit/5b962021f44e551d9dc460757c624d0ac1481378) | `` cinnamon.nemo-emblems: 5.6.0 -> 5.8.0 ``                                            |
| [`8e145212`](https://github.com/NixOS/nixpkgs/commit/8e145212c76fbd2f44e73c7474c7e7f9889b53c1) | `` cinnamon.cinnamon-control-center: 5.6.1 -> 5.8.1 ``                                 |
| [`f92b997a`](https://github.com/NixOS/nixpkgs/commit/f92b997ab24ed5708c0f2407b3786978570283c2) | `` cinnamon.cinnamon-screensaver: 5.6.3 -> 5.8.0 ``                                    |
| [`a72e1fda`](https://github.com/NixOS/nixpkgs/commit/a72e1fda8488ad4fe6fd7189803593d7d279b283) | `` cinnamon.cinnamon-session: 5.6.0 -> 5.8.1 ``                                        |
| [`f0ef70e1`](https://github.com/NixOS/nixpkgs/commit/f0ef70e1a821bbb6ce7b853e2f514e1296e915df) | `` cinnamon.cinnamon-translations: 5.6.1 -> 5.8.1 ``                                   |
| [`51fec464`](https://github.com/NixOS/nixpkgs/commit/51fec464f02e357efef729769f301422ae183efb) | `` cinnamon.cinnamon-desktop: 5.6.2 -> 5.8.0 ``                                        |
| [`70cc177a`](https://github.com/NixOS/nixpkgs/commit/70cc177a30287b2675a7cf99854b31704e942653) | `` cinnamon.cinnamon-settings-daemon: 5.6.2 -> 5.8.1 ``                                |
| [`515be6dd`](https://github.com/NixOS/nixpkgs/commit/515be6dd13ec973ffca1be007bc3790421e7951d) | `` python310Packages.angr: 9.2.54 -> 9.2.55 ``                                         |
| [`0e4f341e`](https://github.com/NixOS/nixpkgs/commit/0e4f341e47510aa6a4e7a776d089bd1d5b62b779) | `` python310Packages.cle: 9.2.54 -> 9.2.55 ``                                          |
| [`f9491b1d`](https://github.com/NixOS/nixpkgs/commit/f9491b1dd8bb7aaf4936aa805027f301756c2d34) | `` python310Packages.claripy: 9.2.54 -> 9.2.55 ``                                      |
| [`7fe85410`](https://github.com/NixOS/nixpkgs/commit/7fe8541056639aca8b08279582065c949b297a26) | `` python310Packages.pyvex: 9.2.54 -> 9.2.55 ``                                        |
| [`70dbe9db`](https://github.com/NixOS/nixpkgs/commit/70dbe9dbb19a170462b4f4a01f8fe92faed75b24) | `` python310Packages.ailment: 9.2.54 -> 9.2.55 ``                                      |
| [`03aa1de3`](https://github.com/NixOS/nixpkgs/commit/03aa1de36a98d577978dc3676596efc0f4f551da) | `` python310Packages.archinfo: 9.2.54 -> 9.2.55 ``                                     |
| [`5d1d5574`](https://github.com/NixOS/nixpkgs/commit/5d1d55743df51c49a50110cb8f5c66db8c1e463a) | `` maintainers: add deemp ``                                                           |
| [`91e2d863`](https://github.com/NixOS/nixpkgs/commit/91e2d86304560c55bb7f3034be1579cb8f3978b8) | `` cinnamon.cinnamon-menus: 5.6.0 -> 5.8.0 ``                                          |
| [`5f362f76`](https://github.com/NixOS/nixpkgs/commit/5f362f7689f519d39324c9250e441319125083e7) | `` cinnamon.cjs: 5.6.1 -> 5.8.0 ``                                                     |
| [`e0034fb2`](https://github.com/NixOS/nixpkgs/commit/e0034fb28417e76c613baf5e79d124c39d513686) | `` cinnamon.mint-artwork: 1.7.3 -> 1.7.5 ``                                            |
| [`79b41ca7`](https://github.com/NixOS/nixpkgs/commit/79b41ca7c1e35bbb8fcbe10f1b6ca125187ef122) | `` cinnamon.folder-color-switcher: 1.5.5 -> 1.5.7 ``                                   |
| [`c33ef407`](https://github.com/NixOS/nixpkgs/commit/c33ef407cdea9a63490dcb20bb7817696489d7ad) | `` xdg-desktop-portal-xapp: 1.0.0 -> 1.0.1 ``                                          |
| [`da20b8bc`](https://github.com/NixOS/nixpkgs/commit/da20b8bc4adabba546e04962ce36a74cf9dedaa8) | `` xed-editor: 3.2.8 -> 3.4.1 ``                                                       |
| [`ab005b65`](https://github.com/NixOS/nixpkgs/commit/ab005b65dc21c15c8270bea78d106ee4e5f4a04e) | `` cinnamon.xviewer: 3.2.12 -> 3.4.1 ``                                                |
| [`a15f3418`](https://github.com/NixOS/nixpkgs/commit/a15f3418cfc57b31a7aade92a376dd3892ab7d0b) | `` cinnamon.xreader: 3.6.3 -> 3.8.1 ``                                                 |
| [`312a38af`](https://github.com/NixOS/nixpkgs/commit/312a38afbeba76ad80d37683c02eaa625abcc467) | `` cinnamon.xapp: 2.4.3 -> 2.6.1 ``                                                    |
| [`d5ff51f8`](https://github.com/NixOS/nixpkgs/commit/d5ff51f8f37acebd096c0b135c8dd65fed7cb992) | `` easyrsa: 3.1.4 -> 3.1.5 ``                                                          |
| [`e624b4f1`](https://github.com/NixOS/nixpkgs/commit/e624b4f1ae8c2adf3d374eaae6c76f54dc9ced17) | `` sympa: 6.2.70 -> 6.2.72 ``                                                          |
| [`074f8daf`](https://github.com/NixOS/nixpkgs/commit/074f8daf2ad59267163d9fb87d93bb0d4f6a9b4e) | `` klayout: 0.28.8 -> 0.28.9-2 ``                                                      |
| [`555a3905`](https://github.com/NixOS/nixpkgs/commit/555a3905b6573e0e4f29580db0dab630f6e2757b) | `` mkgmap: 4907 -> 4909 ``                                                             |
| [`4017ae36`](https://github.com/NixOS/nixpkgs/commit/4017ae36a215fb6124d370a6bc254db595d4be77) | `` pkgs/cfs-zen-tweaks: fix exec permission ``                                         |
| [`3150f25f`](https://github.com/NixOS/nixpkgs/commit/3150f25faa599c6c6215295144f5c6b4a87eea6e) | `` lib/tests/release.nix: Run systems tests on OfBorg ``                               |
| [`14401854`](https://github.com/NixOS/nixpkgs/commit/144018541b20a0aa74ce32120b3a27660fab93dd) | `` lib.systems.equals: Ignore all function attributes reflectively ``                  |