### PR TITLE
chore(flake/nix): `6904fe14` -> `13d91ca0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1685631877,
-        "narHash": "sha256-lVLj3I0L7vuK5/76n8oxhwnaWKg4yz6QxiThP/tWYwk=",
+        "lastModified": 1686944709,
+        "narHash": "sha256-fMUJ3UqY4vuIVhLf7Sq5BK8YHhcNXTyQEtsoI02ez9E=",
         "owner": "lovesegfault",
         "repo": "nix",
-        "rev": "6904fe14667914ae927234361291e2787af26a83",
+        "rev": "13d91ca08e005c387cf5d62a52de0283a1bda816",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                 |
| ------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`13d91ca0`](https://github.com/lovesegfault/nix/commit/13d91ca08e005c387cf5d62a52de0283a1bda816) | `` feat: add always-allow-substitutes ``                |
| [`567a5f01`](https://github.com/lovesegfault/nix/commit/567a5f01465d83359cb57c0f265b90e849452415) | `` Remove old default from docs for `hashed-mirrors` `` |
| [`5b1b2569`](https://github.com/lovesegfault/nix/commit/5b1b25695c37087d214ea1cc32b91d7b5825754d) | `` Fix SourcePath::resolveSymlinks() ``                 |