### PR TITLE
chore(flake/nixpkgs): `7c67f006` -> `04af42f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686869522,
-        "narHash": "sha256-tbJ9B8WLCTnVP/LwESRlg0dII6Zyg2LmUU/mB9Lu98E=",
+        "lastModified": 1686960236,
+        "narHash": "sha256-AYCC9rXNLpUWzD9hm+askOfpliLEC9kwAo7ITJc4HIw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7c67f006ea0e7d0265f16d7df07cc076fdffd91f",
+        "rev": "04af42f3b31dba0ef742d254456dc4c14eedac86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`7c06e70c`](https://github.com/NixOS/nixpkgs/commit/7c06e70c29690f41b9adbf3be04c069fd2526f95) | `` code-server: 4.13.0 -> 4.14.0 ``                                            |
| [`992ccdd8`](https://github.com/NixOS/nixpkgs/commit/992ccdd822ecff0712ed0004f89df9e96f6a4963) | `` github-runner: 2.304.0 -> 2.305.0 (#238138) ``                              |
| [`adf6bc1f`](https://github.com/NixOS/nixpkgs/commit/adf6bc1fc310f6db7d4bbb783239bd7bc198ed24) | `` oh-my-zsh: 2023-05-23 -> 2023-06-16 ``                                      |
| [`6b5550f4`](https://github.com/NixOS/nixpkgs/commit/6b5550f4afd8c9fc1390321ae73f14d72683d62c) | `` gnomeExtensions.dash-to-dock: remove  manual packaging ``                   |
| [`f82da3ad`](https://github.com/NixOS/nixpkgs/commit/f82da3ad571d974ed98721785d45629674d72065) | `` djgpp: init at 12.2.0 ``                                                    |
| [`ce9f381f`](https://github.com/NixOS/nixpkgs/commit/ce9f381ffd15be139fe143b7ada8236bf8e1c528) | `` clipper2: init at 1.2.2 ``                                                  |
| [`4995485d`](https://github.com/NixOS/nixpkgs/commit/4995485df26a557fea339a7864cd8b497a5fa69e) | `` gnomeExtensions: auto-update ``                                             |
| [`72588581`](https://github.com/NixOS/nixpkgs/commit/725885819e2f7b2aff92ed2cf1c0a531d0b5087c) | `` python310Packages.psycopg: disable timing sensitive test ``                 |
| [`da7be531`](https://github.com/NixOS/nixpkgs/commit/da7be531659d263e71c9b4763dde36f6643dca88) | `` vimPlugins.nvim-treesitter: update grammars ``                              |
| [`7fcb40be`](https://github.com/NixOS/nixpkgs/commit/7fcb40be1d4c578869aef07ca32dbf7e7aa21648) | `` vimPlugins: update ``                                                       |
| [`f30c131a`](https://github.com/NixOS/nixpkgs/commit/f30c131a9e50b10ba7d31a42c355f30645c3a2d1) | `` caddy: Fix shell-completions ``                                             |
| [`67d1f272`](https://github.com/NixOS/nixpkgs/commit/67d1f272af931f6a3f3f558409031481a39beee6) | `` nextcloud: expose `nextcloudXXPackages` as `nextcloudXX.packages` ``        |
| [`3c7af053`](https://github.com/NixOS/nixpkgs/commit/3c7af053f2c0c442dad2349254e5dae66a1143c3) | `` nextcloudPackages: add cospend, user_saml & maps ``                         |
| [`c92902f5`](https://github.com/NixOS/nixpkgs/commit/c92902f5b1d2724d699b63957a00a6b5daad0fff) | `` nextcloudPackages: update 27.json ``                                        |
| [`94a36722`](https://github.com/NixOS/nixpkgs/commit/94a367224c1e3b412002cd30f190a1ec2d643104) | `` micromamba: 1.2.0 -> 1.4.4 ``                                               |
| [`72b445d9`](https://github.com/NixOS/nixpkgs/commit/72b445d91ee900a9fba30cf364ce27ffe8540a72) | `` tree-sitter-grammars: add cue ``                                            |
| [`e8d09fc8`](https://github.com/NixOS/nixpkgs/commit/e8d09fc809a932a1275042a954e2d0a876de8e2b) | `` opensmalltalk-vm: fix eval ``                                               |
| [`92a8261f`](https://github.com/NixOS/nixpkgs/commit/92a8261f5de4129cdd297d7fa11672f5b9017e11) | `` maintainers: update riotbib ``                                              |
| [`f9eed769`](https://github.com/NixOS/nixpkgs/commit/f9eed769cab46683e45b97b19c451cbb2e7d49f3) | `` calcmysky: add stellarium to tests ``                                       |
| [`c196ad4d`](https://github.com/NixOS/nixpkgs/commit/c196ad4df9b22cbbc78d3ac251767bb5e87c0eee) | `` calcmysky: 0.3.0 -> 0.3.1 ``                                                |
| [`2111ca11`](https://github.com/NixOS/nixpkgs/commit/2111ca11c1c6d2c6e30ab7b8413cf52184692ad7) | `` v2ray-domain-list-community: 20230601044045 -> 20230614081211 ``            |
| [`31fbc6eb`](https://github.com/NixOS/nixpkgs/commit/31fbc6eb9dab07450567b30bb6b3901232e6311d) | `` prismlauncher: 7.0 -> 7.1 ``                                                |
| [`395e5d76`](https://github.com/NixOS/nixpkgs/commit/395e5d76a7f45e4885ec4a405f695243bfcd7173) | `` opensmalltalk-vm: fix evaluation on darwin ``                               |
| [`64504701`](https://github.com/NixOS/nixpkgs/commit/645047019c0b1f20667035cc27c472fd15a98f4a) | `` mautrix-whatsapp: 0.8.5 -> 0.8.6 ``                                         |
| [`3df3a898`](https://github.com/NixOS/nixpkgs/commit/3df3a8989227c3635d0e695267644907bb53d470) | `` nixos/nextcloud: fix declarative cache configuration ``                     |
| [`5a2769d9`](https://github.com/NixOS/nixpkgs/commit/5a2769d981fefef1e3390932734172df42140492) | `` nextcloud27: init ``                                                        |
| [`9c16766e`](https://github.com/NixOS/nixpkgs/commit/9c16766ee06adc944b9d6b67ffb6d3a4893b54f1) | `` vscode-extensions.vadimcn.vscode-lldb: 1.9.1 -> 1.9.2 (#236915) ``          |
| [`1b4e5978`](https://github.com/NixOS/nixpkgs/commit/1b4e597822e2822afc4385f5e63eb5b60480eb2c) | `` vifm: drop util-linux ``                                                    |
| [`317c9a66`](https://github.com/NixOS/nixpkgs/commit/317c9a664bbe2b2ede47c6a75d3d823add796d51) | `` python310Packages.schema-salad: fix runtime errors ``                       |
| [`1616b478`](https://github.com/NixOS/nixpkgs/commit/1616b478aff0e3c36c08145535c7af5ec4423153) | `` drawio: 21.3.7 -> 21.4.0 ``                                                 |
| [`370f3e48`](https://github.com/NixOS/nixpkgs/commit/370f3e488352e02ffd797218c74c65ea529c3ca5) | `` nixos/lemmy: remove option removed upstream ``                              |
| [`fa8117a0`](https://github.com/NixOS/nixpkgs/commit/fa8117a0a6dddd487817b40dc8c4bcd12fea2b69) | `` byobu: add `gettext` to nativeBuildInputs ``                                |
| [`701679e9`](https://github.com/NixOS/nixpkgs/commit/701679e94e40ab4c3e08c4246e4ec9ee173e0e7a) | `` netdata: 1.39.1 -> 1.40.0 ``                                                |
| [`aab78854`](https://github.com/NixOS/nixpkgs/commit/aab788548af6131758c0b1807fd30ec63bfda7ef) | `` netdata/go.d.plugin: 0.53.0 -> 0.53.2 ``                                    |
| [`6d4cafca`](https://github.com/NixOS/nixpkgs/commit/6d4cafca680687c239fadf9bfef2905a2edecd24) | `` pwnat: 2014-09-08 -> 2023-03-31 ``                                          |
| [`b1f11a49`](https://github.com/NixOS/nixpkgs/commit/b1f11a494558a26085b18f167982f9966bd6ce29) | `` povray: unpin boost175 ``                                                   |
| [`b333c3f1`](https://github.com/NixOS/nixpkgs/commit/b333c3f133cc275e85f8ab3fafe4223e00765b15) | `` python311Packages.ciscoconfparse: relax loguru constraint ``                |
| [`2f02fa60`](https://github.com/NixOS/nixpkgs/commit/2f02fa6094cb2bcd5d08648ae57e070861025cc8) | `` checkov: 2.3.292 -> 2.3.294 ``                                              |
| [`88ecfcb8`](https://github.com/NixOS/nixpkgs/commit/88ecfcb8a191d4313f563b685214904996c95435) | `` python3Packages.clustershell: unmark as broken on aarch64-linux ``          |
| [`68f4a041`](https://github.com/NixOS/nixpkgs/commit/68f4a04143a7f08ec1f5a792624e5298b62b1f30) | `` extra-container: 0.11 -> 0.12 ``                                            |
| [`c269fa07`](https://github.com/NixOS/nixpkgs/commit/c269fa075a00a45d1298ff32cfb62afb880333ee) | `` wownero: 0.8.0.1 -> 0.11.0.1 ``                                             |
| [`3a74d25f`](https://github.com/NixOS/nixpkgs/commit/3a74d25f11337243d124191b99fe86895436cfec) | `` erlang_26: fix missing package ``                                           |
| [`a5f81ddc`](https://github.com/NixOS/nixpkgs/commit/a5f81ddc2feced17319db073399af0a6d11084c8) | `` vbam: fix build with openal 1.23.1 ``                                       |
| [`476f3f27`](https://github.com/NixOS/nixpkgs/commit/476f3f27883c526e919d6b7a3cc7b0fd20b09896) | `` python311Packages.loguru: unstable-2023-01-20 -> 0.7.0 ``                   |
| [`fd800d85`](https://github.com/NixOS/nixpkgs/commit/fd800d851f46953bf534000f95607f24ed8e12ba) | `` qownnotes: add tests ``                                                     |
| [`5e4d219c`](https://github.com/NixOS/nixpkgs/commit/5e4d219c9dda02d1edd26fded7b40e2cc9e37a59) | `` vimPlugins: update ``                                                       |
| [`35d0221e`](https://github.com/NixOS/nixpkgs/commit/35d0221ec4a398a3013873d7fa226eaeec44d5fb) | `` vimPlugins.vim-lexical: init at 2022-02-11 ``                               |
| [`13ab0007`](https://github.com/NixOS/nixpkgs/commit/13ab0007cacee0001fd05aa946e7ab77d9c88e2e) | `` terraform-providers.heroku: 5.2.2 -> 5.2.4 ``                               |
| [`49866d86`](https://github.com/NixOS/nixpkgs/commit/49866d86b2cee48a83e0a49e82b972c3dc38968a) | `` terraform-providers.heroku: set spdx to null ``                             |
| [`4b5f5fff`](https://github.com/NixOS/nixpkgs/commit/4b5f5fff362a95e4dd36472d6a48d8d76bf2ae32) | `` terraform-providers: skip updating spdx if null ``                          |
| [`9bfaad42`](https://github.com/NixOS/nixpkgs/commit/9bfaad424a3eb96e8794381c86fac52ba0609f44) | `` terraform-providers.yandex: drop proxyVendor ``                             |
| [`3852718d`](https://github.com/NixOS/nixpkgs/commit/3852718d32d43bc48ae5eff8e19b325cb70e3935) | `` terraform-providers.aws: 5.3.0 -> 5.4.0 ``                                  |
| [`222e748f`](https://github.com/NixOS/nixpkgs/commit/222e748f17076d483985f86fc9d044f03bcd1904) | `` terraform-providers.opentelekomcloud: 1.35.0 -> 1.35.1 ``                   |
| [`cd8fa97a`](https://github.com/NixOS/nixpkgs/commit/cd8fa97a1d0f4f97c13b557a2e0d1f0ccdfde0b0) | `` terraform-providers.mongodbatlas: 1.9.0 -> 1.10.0 ``                        |
| [`2b0b2c97`](https://github.com/NixOS/nixpkgs/commit/2b0b2c97a722af99be810eeed758df4a2f318c4f) | `` terraform-providers.github: 5.26.0 -> 5.27.0 ``                             |
| [`60e455d4`](https://github.com/NixOS/nixpkgs/commit/60e455d466d7a5c5d23a7c0d4a4a8abe67309fe4) | `` terraform-providers.acme: 2.14.0 -> 2.15.0 ``                               |
| [`df19d102`](https://github.com/NixOS/nixpkgs/commit/df19d102e2677fc7eaca3b0b0086f1eddc713376) | `` terraform-providers.aviatrix: 3.1.0 -> 3.1.1 ``                             |
| [`c17a0471`](https://github.com/NixOS/nixpkgs/commit/c17a04710364d124142b76a7df809759441c4cbb) | `` ctranslate2: add misuzu as maintainer ``                                    |
| [`a0f30da0`](https://github.com/NixOS/nixpkgs/commit/a0f30da0088b3a32ac4fdbde6ef3c9a1632e64d6) | `` ctranslate2: add withOneDNN, withOpenblas, withRuy ``                       |
| [`01d3f6f7`](https://github.com/NixOS/nixpkgs/commit/01d3f6f7a8d84a91cc1ab821a3b21e8c0ec5b8b7) | `` jasmin-compiler: 2022.09.3 → 2023.06.0 ``                                   |
| [`d080989a`](https://github.com/NixOS/nixpkgs/commit/d080989a58c6dbcdecb589a7a489f92d2cb3e545) | `` python311Packages.azure-data-tables: 12.4.2 -> 12.4.3 ``                    |
| [`6adb9e6c`](https://github.com/NixOS/nixpkgs/commit/6adb9e6cf1e407674523817e1aab86b12ee344ca) | `` python311Packages.azure-mgmt-dns: 8.0.0 -> 8.1.0 ``                         |
| [`e25bb93f`](https://github.com/NixOS/nixpkgs/commit/e25bb93f86003b256accde4b106d11241e8effbb) | `` python311Packages.azure-servicebus: 7.10.0 -> 7.11.0 ``                     |
| [`57dd497f`](https://github.com/NixOS/nixpkgs/commit/57dd497f017e2b1a522165368d30ca3aa2e41ae5) | `` python310Packages.pyorthanc: relax httpx dependency ``                      |
| [`757f67d1`](https://github.com/NixOS/nixpkgs/commit/757f67d1eaf16b93d7c0a34b6e722325289a5acc) | `` cirrus-cli: 0.100.0 -> 0.101.0 ``                                           |
| [`9c736644`](https://github.com/NixOS/nixpkgs/commit/9c736644506858cf69cd089144d01504ef57ea93) | `` actionlint: 1.6.24 -> 1.6.25 ``                                             |
| [`4a4ecf80`](https://github.com/NixOS/nixpkgs/commit/4a4ecf80235ebd92210f1fa7d669082d13101218) | `` twilio-cli: 5.8.1 -> 5.9.0 ``                                               |
| [`faab4a33`](https://github.com/NixOS/nixpkgs/commit/faab4a33ed43bf93baa664ec1aca011530eb4245) | `` esbuild: 0.18.2 -> 0.18.3 ``                                                |
| [`51d5e990`](https://github.com/NixOS/nixpkgs/commit/51d5e990371bb816719c408297a1466d02bae9b4) | `` cloud-nuke: 0.31.1 -> 0.31.2 ``                                             |
| [`936092be`](https://github.com/NixOS/nixpkgs/commit/936092be1a48e345c289baf0812bb59b752b586b) | `` Use propagatedBuildInputs for Python dependencies ``                        |
| [`2a1a1ea0`](https://github.com/NixOS/nixpkgs/commit/2a1a1ea0f56c54bf45e83e97e1c32623dc324d36) | `` python310Packages.schema-salad: 8.4.20230213094415 -> 8.4.20230606143604 `` |
| [`86ecee62`](https://github.com/NixOS/nixpkgs/commit/86ecee627a82a9893a41af45db06431c716d13ab) | `` typo ``                                                                     |
| [`b48ba787`](https://github.com/NixOS/nixpkgs/commit/b48ba787e5591a4e515b09af1bd0e67d4c5f7865) | `` semantic-release: init at 21.0.5 ``                                         |
| [`f5eb471c`](https://github.com/NixOS/nixpkgs/commit/f5eb471c4b3073dd438d081b65d11a58964196f4) | `` maintainers: add sestrella ``                                               |
| [`e965f22b`](https://github.com/NixOS/nixpkgs/commit/e965f22be85182f73f0cc302f094bc8f746a4093) | `` python3Packages.langchain: 0.0.195 -> 0.0.201 ``                            |
| [`f9842d2c`](https://github.com/NixOS/nixpkgs/commit/f9842d2c4c28dd5643fd0e047d9048bedaeff58c) | `` python3Packages.langchainplus-sdk: 0.0.6 -> 0.0.10 ``                       |
| [`af7ceb6c`](https://github.com/NixOS/nixpkgs/commit/af7ceb6cc9e322259d65b45bb79a935be1e5fc60) | `` python310Packages.weconnect-mqtt: relax weconnect constraint ``             |
| [`2dcb1b3e`](https://github.com/NixOS/nixpkgs/commit/2dcb1b3ed7defffd8cc418a94d33d32807f8fcf8) | `` nixos/zfs: assert that pool names are not empty ``                          |
| [`6cbf9635`](https://github.com/NixOS/nixpkgs/commit/6cbf9635cb5e13f2f5aea17fce3f1b07376362ed) | `` vscode: 1.79.1 -> 1.79.2 ``                                                 |
| [`5dc68846`](https://github.com/NixOS/nixpkgs/commit/5dc6884610123ff652f9b7c77fca19e2e2532800) | `` zrythm: fix failing build in qtPreHook phase ``                             |
| [`dd799e42`](https://github.com/NixOS/nixpkgs/commit/dd799e42f1140547734c11dd3ab626f11208f65e) | `` static-web-server: 2.18.0 -> 2.19.0 ``                                      |
| [`06289256`](https://github.com/NixOS/nixpkgs/commit/06289256ab01c111c29ae27f349d7f3dc6a99ece) | `` himalaya: 0.8.0 -> 0.8.1 ``                                                 |
| [`2281a4b8`](https://github.com/NixOS/nixpkgs/commit/2281a4b8841b148e75f4a185d89ef6685fc270d0) | `` stag: fixup build on aarch64-linux ``                                       |
| [`9a6ee48a`](https://github.com/NixOS/nixpkgs/commit/9a6ee48a3de1a0623d4f6b79d53e99b2da1ad38f) | `` build-rust-package: remove unused input ``                                  |
| [`ddad581c`](https://github.com/NixOS/nixpkgs/commit/ddad581c0d9d118dc2f376199ed5f65e44fd5950) | `` build-rust-crate: cleanup with statix ``                                    |
| [`172716fd`](https://github.com/NixOS/nixpkgs/commit/172716fd98986c80f82c40e5b87451e25295d20e) | `` python311Packages.twilio: 8.2.2 -> 8.3.0 ``                                 |
| [`9c2a0aeb`](https://github.com/NixOS/nixpkgs/commit/9c2a0aeb5d3985645c1c09d3ae9ba5a13a8865cf) | `` python311Packages.ssdp: 1.1.1 -> 1.2.0 ``                                   |
| [`ebf774e2`](https://github.com/NixOS/nixpkgs/commit/ebf774e241f16256e893dcd462460df39d02b5f3) | `` python311Packages.shtab: 1.6.1 -> 1.6.2 ``                                  |
| [`3aa59f7b`](https://github.com/NixOS/nixpkgs/commit/3aa59f7ba2feda801e096c89017e09b45aed729a) | `` python311Packages.rns: 0.5.4 -> 0.5.5 ``                                    |
| [`99002aba`](https://github.com/NixOS/nixpkgs/commit/99002aba8e4291c3037b10aa9658e2c6c24980ce) | `` mavproxy: 1.8.60 -> 1.8.62 ``                                               |
| [`600c22dd`](https://github.com/NixOS/nixpkgs/commit/600c22dde8e47f32822322ba3baa269df9930e7a) | `` python3Packages.pymavlink: 2.4.38 -> 2.4.39 ``                              |
| [`497a603c`](https://github.com/NixOS/nixpkgs/commit/497a603c6be97426c6f1bba26be55e23ae0a5d0d) | `` python311Packages.pyatv: 0.12.1 -> 0.13.0 ``                                |
| [`566e9319`](https://github.com/NixOS/nixpkgs/commit/566e9319a8c0e80c3aa44a54f3b78c8d0d1d9c4d) | `` wasmtime: 9.0.3 -> 9.0.4 ``                                                 |
| [`88225eaf`](https://github.com/NixOS/nixpkgs/commit/88225eaf8b4055ffac91aa6a6c01187f8fbd98dd) | `` trufflehog: 3.39.0 -> 3.40.0 ``                                             |
| [`94250fb0`](https://github.com/NixOS/nixpkgs/commit/94250fb0c6f0911ac5e283428ce681b76b2b9d2c) | `` python311Packages.ha-philipsjs: 3.0.1 -> 3.1.0 ``                           |
| [`227ae542`](https://github.com/NixOS/nixpkgs/commit/227ae542966495428d8d2179498663113f09740d) | `` fastly: 10.1.0 -> 10.2.0 ``                                                 |
| [`a4110665`](https://github.com/NixOS/nixpkgs/commit/a4110665896f97cb4eeea9985d3025c60b905aa7) | `` kubescape: 2.3.5 -> 2.3.6 ``                                                |
| [`4e2afe53`](https://github.com/NixOS/nixpkgs/commit/4e2afe53ff03dcad451be90d0c881bebf4533b52) | `` gitleaks: 8.16.4 -> 8.17.0 ``                                               |
| [`49477611`](https://github.com/NixOS/nixpkgs/commit/49477611edc4789ae0e5009bca59f5ed36cd98ff) | `` python311Packages.plugwise: 0.31.5 -> 0.31.6 ``                             |
| [`d5a73029`](https://github.com/NixOS/nixpkgs/commit/d5a730290b3f02d5fd47a5478517e2224a53610e) | `` openvscode-server: 1.79.0 -> 1.79.1 ``                                      |
| [`1cb9ad90`](https://github.com/NixOS/nixpkgs/commit/1cb9ad903695e5a6ba117fe3840c9cd44aec7cb2) | `` nextcloudPackages.apps.qownnotesapi: init at 23.6.0 ``                      |
| [`659f4872`](https://github.com/NixOS/nixpkgs/commit/659f4872589b4033a9c644a303f61fb35ab9019c) | `` openlens: 6.4.15 -> 6.5.2-309 ``                                            |
| [`794debf8`](https://github.com/NixOS/nixpkgs/commit/794debf8adad3a408a6013cc296291d5099f3f2a) | `` protonmail-bridge: 3.1.2 -> 3.2.0 ``                                        |
| [`87ebad10`](https://github.com/NixOS/nixpkgs/commit/87ebad10d6d90a6a72408d4bebb7912ce2b16485) | `` rustc: add armv6l-linux to platforms ``                                     |
| [`abf589ea`](https://github.com/NixOS/nixpkgs/commit/abf589eaf40f2a6533dc632ceab4f3e1414ae936) | `` vimPlugins.nvim-treesitter: update grammars ``                              |
| [`f8e21b9a`](https://github.com/NixOS/nixpkgs/commit/f8e21b9a431d1da12d35ad9e4954f17eacd35016) | `` vimPlugins: update ``                                                       |
| [`ad98e727`](https://github.com/NixOS/nixpkgs/commit/ad98e727f00e8ca04f21b22369e81ac9c4cc4c79) | `` _1password-gui-beta: 8.10.8-10 -> 8.10.8-13 ``                              |
| [`9eb870b0`](https://github.com/NixOS/nixpkgs/commit/9eb870b02e04304a8e3cb39b56962262b2885cda) | `` vimPlugins.restore-view-vim: init at 2014-11-21 ``                          |
| [`895dbf02`](https://github.com/NixOS/nixpkgs/commit/895dbf02a32fe84b664f9899ca8095604b525ee0) | `` sublime4-dev: 4149 -> 4150 ``                                               |
| [`8ea74861`](https://github.com/NixOS/nixpkgs/commit/8ea74861919c17003a269eb14051e64b61814c96) | `` chickenPackages: update ``                                                  |
| [`fcf1a7e0`](https://github.com/NixOS/nixpkgs/commit/fcf1a7e0377c44b85ce973e7097018974d82de96) | `` nextcloudPackages: update ``                                                |
| [`b802b761`](https://github.com/NixOS/nixpkgs/commit/b802b761008cb443ce162560c8452e0e429dfe95) | `` python310Packages.robotstatuschecker: 3.0.0 -> 3.0.1 ``                     |
| [`028155ae`](https://github.com/NixOS/nixpkgs/commit/028155ae12061187eb1c631931c4dc57b4469ea2) | `` gnu-config: add cannot-use-fetchpatch comment ``                            |
| [`22540da6`](https://github.com/NixOS/nixpkgs/commit/22540da6c19a41512dd6bc575858e1215baeb3f9) | `` golangci-lint: 1.53.2 -> 1.53.3 ``                                          |
| [`b497970a`](https://github.com/NixOS/nixpkgs/commit/b497970a8e17cb63fa924204440f7787f016ef2b) | `` linuxPackages.nvidia_x11_vulkan_beta: 525.47.26 -> 525.47.27 ``             |
| [`7b85087a`](https://github.com/NixOS/nixpkgs/commit/7b85087a31a1a8865555a6f414d5a1105f882575) | `` raycast: 1.53.2 -> 1.53.3 ``                                                |
| [`ac0251f8`](https://github.com/NixOS/nixpkgs/commit/ac0251f8737573f6634aad61c688c2ce387b487a) | `` zrok: support most of the arches ``                                         |
| [`9120f78e`](https://github.com/NixOS/nixpkgs/commit/9120f78e06b6276027a8131ad920f68d5d290032) | `` bppsuite: fix homepage ``                                                   |
| [`e2b89b6b`](https://github.com/NixOS/nixpkgs/commit/e2b89b6b34a1caa369868f03f42499a3a59c7670) | `` python311Packages.homeassistant-stubs: 2023.6.1 -> 2023.6.2 ``              |
| [`fef834c6`](https://github.com/NixOS/nixpkgs/commit/fef834c64176892379fe9ab28fb8dcd7fb819d4b) | `` bfc: unstable-2023-02-02 -> 1.10.0 ``                                       |
| [`4593488d`](https://github.com/NixOS/nixpkgs/commit/4593488d4dd8d34fd409bba9bda8597758c4ce16) | `` python310Packages.weconnect: relax requests constraint ``                   |
| [`e6f533ee`](https://github.com/NixOS/nixpkgs/commit/e6f533ee3d07cdeec7f5ba732eaaffc565cd303d) | `` python310Packages.flask-jwt-extended: 4.4.4 -> 4.5.2 ``                     |
| [`da83e766`](https://github.com/NixOS/nixpkgs/commit/da83e7667ee529670727d9cf679bb204ecb98618) | `` tanidvr: init at 1.4.1 ``                                                   |
| [`8b323771`](https://github.com/NixOS/nixpkgs/commit/8b323771bbebb28290ec61794543b83890d29680) | `` steam: add ncurses to game specific libraries ``                            |
| [`f7c95df6`](https://github.com/NixOS/nixpkgs/commit/f7c95df62f90f5ed765b9398f53119bc1d437c23) | `` reckon: 0.8.0 -> 0.9.2 ``                                                   |
| [`e5396c67`](https://github.com/NixOS/nixpkgs/commit/e5396c67e0f169ebab99d88659baec33e08cfc71) | `` home-assistant: 2023.6.1 -> 2023.6.2 ``                                     |
| [`786f1443`](https://github.com/NixOS/nixpkgs/commit/786f1443173095fc0ed3ac3bbce9cb1f93262261) | `` python310Packages.pyjwt: 2.6.0 -> 2.7.0 ``                                  |
| [`f71d4911`](https://github.com/NixOS/nixpkgs/commit/f71d4911cc157d7d7c758dd52cb79a353ccb016c) | `` python310Packages.poetry-dynamic-versioning: Add setup-hook ``              |
| [`35e5b06a`](https://github.com/NixOS/nixpkgs/commit/35e5b06a44a75d920bce0fc21ea9e9d2fd48de67) | `` python311Packages.pylitterbot: 2023.4.0 -> 2023.4.2 ``                      |
| [`9239f21e`](https://github.com/NixOS/nixpkgs/commit/9239f21e377e380891a27333d9ef9fadda68e5a9) | `` python311Packages.pyinsteon: 1.4.2 -> 1.4.3 ``                              |
| [`b3669be4`](https://github.com/NixOS/nixpkgs/commit/b3669be4b025d674e592a330484bcfa20fcaaced) | `` python310Packages.nitransforms: 22.0.0 -> 23.0.0 ``                         |
| [`b09cf37c`](https://github.com/NixOS/nixpkgs/commit/b09cf37c72bd361c41f827f2455a84e7ffefb38b) | `` ansible-lint: 6.17.0 -> 6.17.1 ``                                           |
| [`b77ea3c9`](https://github.com/NixOS/nixpkgs/commit/b77ea3c92eefb0c605994a742f5807bd5d71f211) | `` python311Packages.strawberry-graphql: disable failing tests ``              |
| [`b621cd74`](https://github.com/NixOS/nixpkgs/commit/b621cd74fe24ce362193d4e802749f6e55f72bc8) | `` python311Packages.strawberry-graphql: 0.176.3 -> 0.185.1 ``                 |
| [`d9cecd86`](https://github.com/NixOS/nixpkgs/commit/d9cecd8689ff7dd15cb033402b5d91b2a91beb91) | `` maintainers: add pho ``                                                     |
| [`0861c5d6`](https://github.com/NixOS/nixpkgs/commit/0861c5d62ba8756fbdd6eeac5311f516264a773e) | `` metasploit: 6.3.19 -> 6.3.20 ``                                             |
| [`a07a1272`](https://github.com/NixOS/nixpkgs/commit/a07a127237fc0137fb1d9bc1c48f8ea72a9b7de7) | `` libe-book: build with latest icu version ``                                 |
| [`3eafc525`](https://github.com/NixOS/nixpkgs/commit/3eafc5256e867156fb6ed5d9387f595b1e8d3d3c) | `` python311Packages.oracledb: 1.3.0 -> 1.3.1 ``                               |
| [`68aeac65`](https://github.com/NixOS/nixpkgs/commit/68aeac65f5ad323ebe8d7784cac8960f7ad4dafe) | `` wallust: init at 2.4.1 ``                                                   |
| [`eff41f42`](https://github.com/NixOS/nixpkgs/commit/eff41f420fea03f5a5ed656eb2973e6be3be1fd8) | `` maintainers: add onemoresuza ``                                             |
| [`fbcefb52`](https://github.com/NixOS/nixpkgs/commit/fbcefb52e00568d5f4569df2677536d192b7b0d8) | `` python311Packages.losant-rest: 1.17.4 -> 1.17.5 ``                          |
| [`15057eed`](https://github.com/NixOS/nixpkgs/commit/15057eeda4a81f12361fdd09021340201065f42b) | `` rustywind: init at 0.16.0 ``                                                |