### PR TITLE
chore(flake/home-manager): `9ba7b399` -> `edf9cf65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686922395,
-        "narHash": "sha256-ysevinohPxdKp0RXyhDRsz1/vh1eXazg4AWp0n5X/U4=",
+        "lastModified": 1687041769,
+        "narHash": "sha256-lPDVNMrDF/hOVy+P8pEtKzvSN/Akk9RbDcyNuvW1T+M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9ba7b3990eb1f4782ea3f5fe7ac4f3c88dd7a32c",
+        "rev": "edf9cf65238609db16680be74fe28d4d4858476e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`edf9cf65`](https://github.com/nix-community/home-manager/commit/edf9cf65238609db16680be74fe28d4d4858476e) | `` home-manager: prioritize `-I` parameters ``            |
| [`f7c4dae2`](https://github.com/nix-community/home-manager/commit/f7c4dae2c818dc281ab73567f2fb6820c3597fb9) | `` Translate using Weblate (French) ``                    |
| [`162c17b0`](https://github.com/nix-community/home-manager/commit/162c17b0c9b9e3d80c7e731c03ad24157364432d) | `` fontconfig: minor update of generated configuration `` |