### PR TITLE
chore(flake/home-manager): `edf9cf65` -> `28c82303`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687041769,
-        "narHash": "sha256-lPDVNMrDF/hOVy+P8pEtKzvSN/Akk9RbDcyNuvW1T+M=",
+        "lastModified": 1687081547,
+        "narHash": "sha256-/JV70TxhvP2r4xYtTlbQ2rrRDcj7MqHnF13r5ZE0oFc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "edf9cf65238609db16680be74fe28d4d4858476e",
+        "rev": "28c823032cabfaa340a09e1d84cf45d11375c644",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                      |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`28c82303`](https://github.com/nix-community/home-manager/commit/28c823032cabfaa340a09e1d84cf45d11375c644) | `` Bump install-nix-action to v22 (#4111) `` |