### PR TITLE
chore(flake/nix-index-database): `e11c6107` -> `d626d2e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686740472,
-        "narHash": "sha256-b668DY2qGdBCUwIkk6Z32bcpCsUISQJrEEvhtn1gGgY=",
+        "lastModified": 1687088364,
+        "narHash": "sha256-DXFIXJZ1mdTdfMcc9mt1gS3VV0LXiVOWDT7ejf2uJQw=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "e11c61073b777e025993c5ef63ddbf776a9cca15",
+        "rev": "d626d2e15eec5641580502d852b521b7acad21cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                        |
| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`849bc2be`](https://github.com/nix-community/nix-index-database/commit/849bc2be2a760d4d5f81a57167dcf8f2e7ddc1aa) | `` enable kvm system-feature for evaluation `` |