### PR TITLE
chore(flake/lanzaboote): `823ad6b7` -> `9044916b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -221,11 +221,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686692834,
-        "narHash": "sha256-EFjJ/r4iYVKO+XdL15g9bzOKbCExTGeqNEVHSn0H7/E=",
+        "lastModified": 1687095371,
+        "narHash": "sha256-ZszSc/rytJKEQgO6Xflzj+CVXykgnvchpOr1kS8ld+4=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "823ad6b70bf09b91c3a9dd9a64678ec80ba3c1ee",
+        "rev": "9044916b9e37f44b6cc29b586673f2109c67a4f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                      |
| --------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`19a73124`](https://github.com/nix-community/lanzaboote/commit/19a731246292c333f6e19d5c56b3a5f3471a6422) | `` remove QUICK_START.md bootspec section `` |