### PR TITLE
chore(flake/nix-index-database): `d626d2e1` -> `a91d228c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687088364,
-        "narHash": "sha256-DXFIXJZ1mdTdfMcc9mt1gS3VV0LXiVOWDT7ejf2uJQw=",
+        "lastModified": 1687096118,
+        "narHash": "sha256-fHI4gQv8UhMOfOaUMXNyBzxSy0lKxTHoII7MLKwJhGg=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "d626d2e15eec5641580502d852b521b7acad21cb",
+        "rev": "a91d228c7df8ff1d285f62b53a2cf2d658b9b877",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                           |
| ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`b94eda87`](https://github.com/nix-community/nix-index-database/commit/b94eda8739f8ac2d0dda6ad8e7f4e3d60bbf712a) | `` Update nix-install-action to get the latest version of nix. `` |
| [`2731e1d4`](https://github.com/nix-community/nix-index-database/commit/2731e1d49c88de4665c4862583767c0267f02069) | `` Exclude aarch64 VM test on Garnix. ``                          |
| [`fa662299`](https://github.com/nix-community/nix-index-database/commit/fa6622998c1723e9c9477d127c8411751ece8c4e) | `` Only update the flake lock once. ``                            |
| [`ff37ed46`](https://github.com/nix-community/nix-index-database/commit/ff37ed46d06f20e2031ede49f2e91d9b7e0e0e42) | `` Update the flake.lock before regenerating the index. ``        |
| [`225ddbe1`](https://github.com/nix-community/nix-index-database/commit/225ddbe120587fc0e28b1620ed124b1dbf7ab837) | `` flake.lock: Update ``                                          |
| [`35caa004`](https://github.com/nix-community/nix-index-database/commit/35caa0043bc36c391142db4dd9691bdbfdab2d6b) | `` Use nixos-unstable to avoid rebuilding the world in CI. ``     |
| [`eebe152c`](https://github.com/nix-community/nix-index-database/commit/eebe152ca1df785bce78a3f8f91fb38ef0b482d8) | `` Fix issue with checks during scheduled workflow. ``            |