### PR TITLE
chore(flake/nix-index-database): `a91d228c` -> `c8210cb3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687096118,
-        "narHash": "sha256-fHI4gQv8UhMOfOaUMXNyBzxSy0lKxTHoII7MLKwJhGg=",
+        "lastModified": 1687097842,
+        "narHash": "sha256-NPAaRZx5foWLgIPfEaiEZMr9JIlEQhLEVEXpx09341Q=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "a91d228c7df8ff1d285f62b53a2cf2d658b9b877",
+        "rev": "c8210cb3fcde6860255b54ddba74dc177e6232cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`75b3af82`](https://github.com/nix-community/nix-index-database/commit/75b3af8233366046bac5c15dbb7af6553b9fa49c) | `` Add --all-systems to nix flake show. ``             |
| [`5c566904`](https://github.com/nix-community/nix-index-database/commit/5c566904add58b532da327ffe0070889eef87618) | `` update packages.nix to release 2023-06-18-141259 `` |