### PR TITLE
chore(flake/darwin): `7c16d313` -> `8a5af0da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686307493,
-        "narHash": "sha256-R4VEFnDn7nRmNxAu1LwNbjns5DPM8IBsvnrWmZ8ymPs=",
+        "lastModified": 1687110393,
+        "narHash": "sha256-SnkdWeZ8PZd3Dc74iFF8xiE7qDp5+z3Yps2mE79tsM0=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "7c16d31383a90e0e72ace0c35d2d66a18f90fb4f",
+        "rev": "8a5af0da9d8dab8a188436750489e304ac682085",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                           |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`1711db73`](https://github.com/LnL7/nix-darwin/commit/1711db734e29a2df3b1b72ec1e15bd50b0629fd1) | `` add ipfs service ``                            |
| [`8d13a55f`](https://github.com/LnL7/nix-darwin/commit/8d13a55f1c3020825400ef066ab13ef62ca441bf) | `` workflows: fix Nix install on `macos-12` ``    |
| [`f532e43f`](https://github.com/LnL7/nix-darwin/commit/f532e43f7efa58a0202956fac19f402893ae0ecd) | `` templates.flake: add contents of simple.nix `` |
| [`fc955520`](https://github.com/LnL7/nix-darwin/commit/fc955520dd26ddbed189f19edc438f7c408e470e) | `` flake: add template with basic flake config `` |