### PR TITLE
chore(flake/pre-commit-hooks): `5b6b54d3` -> `7807e185`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -374,11 +374,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1686668298,
-        "narHash": "sha256-AADh9NqHh6X2LOem4BvI7oCkMm+JPCSCE7iIw5nn0VA=",
+        "lastModified": 1687251716,
+        "narHash": "sha256-+sFS41thsB5U+lY/dBYPSmU4AJ7nz/VdM1WD35fXVeM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "5b6b54d3f722aa95cbf4ddbe35390a0af8c0015a",
+        "rev": "7807e1851d95828ed98491930d2d9e7ddbe65da4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                         |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`a63f7150`](https://github.com/cachix/pre-commit-hooks.nix/commit/a63f71505767530fef5fa5fce49edf8957f7a825) | `` maint: Don't use literalDocBook ``                           |
| [`39f2e2ca`](https://github.com/cachix/pre-commit-hooks.nix/commit/39f2e2cacc567fc5b793e2155f2772a0722e96aa) | `` chore(deps): bump cachix/install-nix-action from 21 to 22 `` |
| [`bbe94664`](https://github.com/cachix/pre-commit-hooks.nix/commit/bbe9466465593877e9d9c070942932120531788e) | `` Add option to run clippy with all features enabled ``        |