### PR TITLE
chore(flake/darwin): `8a5af0da` -> `ed275afb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687110393,
-        "narHash": "sha256-SnkdWeZ8PZd3Dc74iFF8xiE7qDp5+z3Yps2mE79tsM0=",
+        "lastModified": 1687290953,
+        "narHash": "sha256-PF0VGsuLxozDPLEGajGnb5usoO1v7YzzqOcG6k4ndQ4=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "8a5af0da9d8dab8a188436750489e304ac682085",
+        "rev": "ed275afbbaad9b0670e2aeac3ae542595255d604",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                   |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`cd87d923`](https://github.com/LnL7/nix-darwin/commit/cd87d92320bb32f250aefb2bc039c43bb3ffb7e2) | `` GHActions: Bump install-nix-action to v22 ``           |
| [`1fc5d125`](https://github.com/LnL7/nix-darwin/commit/1fc5d125fb14835ee12122395adb85b26c8f732e) | `` docs: clarify how to use inputs with flakes ``         |
| [`51b8bdfc`](https://github.com/LnL7/nix-darwin/commit/51b8bdfc0e43e24ebe097f167778d4e7fe88dd77) | `` nix: Add build machines protocol option. ``            |
| [`d20ba9bf`](https://github.com/LnL7/nix-darwin/commit/d20ba9bf9c72835cc9b9ddf57adf527e7e2f504f) | `` Document font overriding behaviour ``                  |
| [`cfcfcc53`](https://github.com/LnL7/nix-darwin/commit/cfcfcc535e74ff41e07789625040f7c38a8d40d9) | `` feat: use enum instead of str for constraints nicer `` |
| [`df00ca18`](https://github.com/LnL7/nix-darwin/commit/df00ca18a35b0b9fdcdb1d862410af92582f5b61) | `` feat: add `AppleWindowTabbingMode` option ``           |
| [`ce785cca`](https://github.com/LnL7/nix-darwin/commit/ce785ccacf2723d3ffbcaf23e5a339b8c5ed88eb) | `` feat: add `AppleScrollerPagingBehavior` option ``      |
| [`7bf15660`](https://github.com/LnL7/nix-darwin/commit/7bf15660ca1febda3b43390d10797e5ad6771323) | `` fix: type ``                                           |
| [`0ad226e8`](https://github.com/LnL7/nix-darwin/commit/0ad226e8c37560c971672b87f6632a7bd328ab13) | `` feat: add `mouseDriverCursorSize` option ``            |