### PR TITLE
chore(flake/home-manager): `e8b5f8f9` -> `e6d134ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687257796,
-        "narHash": "sha256-jWF0LtG4GczLGLsBvXIGaCX+JvTLfawVLLJPtB5CMW0=",
+        "lastModified": 1687296923,
+        "narHash": "sha256-kkd0T2999iVS5PuwCH5WIwbyAhdCw2poQ4EOsZ+tYFw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e8b5f8f9b3368dcc4814129d6f66c1af7cf3b6e5",
+        "rev": "e6d134ce12ed78c1ac31745853aa1e74310f1a7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`e6d134ce`](https://github.com/nix-community/home-manager/commit/e6d134ce12ed78c1ac31745853aa1e74310f1a7d) | `` home-environment: re-enable Nixpkgs release check ``   |
| [`ec58f8be`](https://github.com/nix-community/home-manager/commit/ec58f8bed77b2982560c66239ce170f3764f6a36) | `` borgmatic: add missing support for output and hooks `` |