### PR TITLE
chore(flake/home-manager): `e6d134ce` -> `9a76fb9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687296923,
-        "narHash": "sha256-kkd0T2999iVS5PuwCH5WIwbyAhdCw2poQ4EOsZ+tYFw=",
+        "lastModified": 1687301540,
+        "narHash": "sha256-vFbCrE9WlOSVpyAT5VNR3bqMB7W7sDzMNDcO6JqtmBw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e6d134ce12ed78c1ac31745853aa1e74310f1a7d",
+        "rev": "9a76fb9a852fdf9edd3b0aabc119efa1d618f969",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`9a76fb9a`](https://github.com/nix-community/home-manager/commit/9a76fb9a852fdf9edd3b0aabc119efa1d618f969) | `` home-environment: allow skipping sanity checks `` |
| [`1b615306`](https://github.com/nix-community/home-manager/commit/1b615306089aafcf6b375adb1cb568511c00b143) | `` Translate using Weblate (German) ``               |
| [`da27ee44`](https://github.com/nix-community/home-manager/commit/da27ee446b7160081be1ef089c7843641a01d52e) | `` flake.lock: Update ``                             |