### PR TITLE
chore(flake/home-manager): `1fefd7bb` -> `a4817894`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687365523,
-        "narHash": "sha256-2l/cPXDCDVcLNm+EvCRGJcJ9YxxyLbc2vfTah/t8Qwc=",
+        "lastModified": 1687421788,
+        "narHash": "sha256-CgoHjiUBnru0bV4PE8z1R6ZD9KeWtuAaUkyYWYJmQUE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1fefd7bb8da0eec6755747f410fa491411a94296",
+        "rev": "a4817894576f9cd01d784e60a0bfb143c81fc2be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                            |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`a4817894`](https://github.com/nix-community/home-manager/commit/a4817894576f9cd01d784e60a0bfb143c81fc2be) | `` treewide: remove marsam as maintainer (#4136) ``                                |
| [`29358e8b`](https://github.com/nix-community/home-manager/commit/29358e8be7e93c75cc0248a077db528e8617a507) | `` starship: Remove INSIDE_EMACS checks when enabling shell integration (#4135) `` |