### PR TITLE
chore(flake/home-manager): `b9046172` -> `70ac1887`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687462135,
-        "narHash": "sha256-CNfqXAktt5ULY9W/Y7ZvdzCZaYBo/i/5Zs9cJtawebQ=",
+        "lastModified": 1687473300,
+        "narHash": "sha256-4LflQpktYFiub8xVhEN9EZf1cYsr09md01rBJZRCGCc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b9046172a580a648045e7c2f7077cc143936ad8f",
+        "rev": "70ac18872a5f1a57a4546ff58888bf67a8bbb5b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------- |
| [`70ac1887`](https://github.com/nix-community/home-manager/commit/70ac18872a5f1a57a4546ff58888bf67a8bbb5b3) | `` antidote: add module `` |