### PR TITLE
chore(flake/nixpkgs): `04af42f3` -> `3ae20aa5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686960236,
-        "narHash": "sha256-AYCC9rXNLpUWzD9hm+askOfpliLEC9kwAo7ITJc4HIw=",
+        "lastModified": 1687502512,
+        "narHash": "sha256-dBL/01TayOSZYxtY4cMXuNCBk8UMLoqRZA+94xiFpJA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "04af42f3b31dba0ef742d254456dc4c14eedac86",
+        "rev": "3ae20aa58a6c0d1ca95c9b11f59a2d12eebc511f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`3ae20aa5`](https://github.com/NixOS/nixpkgs/commit/3ae20aa58a6c0d1ca95c9b11f59a2d12eebc511f) | `` ocamlPackages.domain-local-await: 0.2.0 → 0.2.1 ``                     |
| [`826f484b`](https://github.com/NixOS/nixpkgs/commit/826f484b8de1f2d8dff4b7156a09d675e9e4b8d1) | `` ocamlPackages.thread-table: init at 0.1.0 ``                           |
| [`0e07d132`](https://github.com/NixOS/nixpkgs/commit/0e07d132c5a562f43e823b6b4a0004ed2d91f40e) | `` terraform-providers.snowflake: 0.66.2 -> 0.67.0 ``                     |
| [`bd99dfbc`](https://github.com/NixOS/nixpkgs/commit/bd99dfbc3c257e44a81b46e86cc53a0f24294c37) | `` terraform-providers.sumologic: 2.23.0 -> 2.24.0 ``                     |
| [`e86d43c0`](https://github.com/NixOS/nixpkgs/commit/e86d43c0e0873f899f71fe7d3b31480b50c71fbb) | `` terraform-providers.aws: 5.4.0 -> 5.5.0 ``                             |
| [`64013062`](https://github.com/NixOS/nixpkgs/commit/64013062a05c7c2aa1e1aea51a4a95cd914be22d) | `` terraform-providers.hcloud: 1.40.0 -> 1.41.0 ``                        |
| [`54ced59b`](https://github.com/NixOS/nixpkgs/commit/54ced59ba093f7e209463b3d1a738dcb4b972721) | `` terraform-providers.gitlab: 16.0.3 -> 16.1.0 ``                        |
| [`3fa0eec1`](https://github.com/NixOS/nixpkgs/commit/3fa0eec1f4fb34e333347c5e55c7f95005fbc36b) | `` terraform-providers.github: 5.28.0 -> 5.28.1 ``                        |
| [`7c1bd691`](https://github.com/NixOS/nixpkgs/commit/7c1bd69160f14eefe2045f10f8cc6a077fbb1189) | `` terraform-providers.fly: 0.0.22 -> 0.0.23 ``                           |
| [`595fa4ec`](https://github.com/NixOS/nixpkgs/commit/595fa4eca89e35f15f13556e848ab91e44f72c7e) | `` terraform-providers.fastly: 5.1.0 -> 5.2.0 ``                          |
| [`ffb64029`](https://github.com/NixOS/nixpkgs/commit/ffb64029e255c01206703879abc9787972d3af10) | `` terraform-providers.azurerm: 3.61.0 -> 3.62.0 ``                       |
| [`7a8d1572`](https://github.com/NixOS/nixpkgs/commit/7a8d157237ab87c0939300739086d77409f81879) | `` python310Packages.azure-batch: 13.0.0 -> 14.0.0 ``                     |
| [`5d0e19c6`](https://github.com/NixOS/nixpkgs/commit/5d0e19c6db83321814e298870cd8dc37a3da5c7a) | `` python310Packages.atlassian-python-api: 3.38.0 -> 3.39.0 ``            |
| [`ed0455a9`](https://github.com/NixOS/nixpkgs/commit/ed0455a96cf85d7b7cca70836a896bdbc7d3eae2) | `` python310Packages.trytond: 6.8.1 -> 6.8.2 ``                           |
| [`e37e1550`](https://github.com/NixOS/nixpkgs/commit/e37e1550dfb191917e243edc859300fc783ee274) | `` python310Packages.fakeredis: 2.14.1 -> 2.15.0 ``                       |
| [`168800d1`](https://github.com/NixOS/nixpkgs/commit/168800d19d505a059203dde99f91f1d16ece7a46) | `` python310Packages.pytest-mypy-plugins: 1.10.1 -> 1.11.1 ``             |
| [`644fed22`](https://github.com/NixOS/nixpkgs/commit/644fed2285c00e2b232f271773b2c1d0d26e7234) | `` easyabc: init at 1.3.8.6 ``                                            |
| [`514ed5c3`](https://github.com/NixOS/nixpkgs/commit/514ed5c3b60b5c268bebaac0e92f1bf54e3ff4f2) | `` jackett: 0.21.258 -> 0.21.275 ``                                       |
| [`3c570911`](https://github.com/NixOS/nixpkgs/commit/3c570911c316c3ba203936ae19762f9603d838bf) | `` python310Packages.holidays: 0.26 -> 0.27.1 ``                          |
| [`5d56c70b`](https://github.com/NixOS/nixpkgs/commit/5d56c70b55a7fc12101244c2fa2e7d960106aa56) | `` python310Packages.graphtage: 0.2.7 -> 0.2.8 ``                         |
| [`d451f851`](https://github.com/NixOS/nixpkgs/commit/d451f8512feaccd1e5a1282060e0b58fe11d6f04) | `` yaml2json: 1.3 -> 1.3.2 ``                                             |
| [`e5088024`](https://github.com/NixOS/nixpkgs/commit/e508802456623b99437167672ec438f6fc532cba) | `` abcl: enable for darwin ``                                             |
| [`08b159c9`](https://github.com/NixOS/nixpkgs/commit/08b159c92d9146323dd43c8f695ac956f211743a) | `` rio: don't use lib.optional with a list ``                             |
| [`7aab14ce`](https://github.com/NixOS/nixpkgs/commit/7aab14cef1318162bb044537a4a3fd377b3276a2) | `` buildMozillaMach: don't use lib.optional with a list ``                |
| [`6990430c`](https://github.com/NixOS/nixpkgs/commit/6990430cf61ba8526b47715e901944aef6a403bf) | `` opensmalltalk-vm: convert buildFlags to a list ``                      |
| [`035bbb7f`](https://github.com/NixOS/nixpkgs/commit/035bbb7f96e03f9abe4d8b36b8600d41204fc6f1) | `` djgpp: move makeWrapper to nativeBuildInputs ``                        |
| [`0ffc9ae0`](https://github.com/NixOS/nixpkgs/commit/0ffc9ae0a344f3ebd36ba0e4fc4c33c30426d6c9) | `` esphome: 2023.6.0 -> 2023.6.1 ``                                       |
| [`d0d3fe37`](https://github.com/NixOS/nixpkgs/commit/d0d3fe37ed6969e743c6d86367eb5c6a956471e8) | `` symengine: v0.9.0 -> v0.10.1 ``                                        |
| [`cbdad241`](https://github.com/NixOS/nixpkgs/commit/cbdad241922397d792911b13fbee2cd2e80125a0) | `` rust-analyzer-unwrapped: 2023-06-05 -> 2023-06-19 ``                   |
| [`44222ff8`](https://github.com/NixOS/nixpkgs/commit/44222ff8847b113c243aa133032007f5e26f5050) | `` xdgmenumaker: 2.0 -> 2.1 ``                                            |
| [`ab9c0009`](https://github.com/NixOS/nixpkgs/commit/ab9c0009de475f5dc53a5e547752e86f06cf438d) | `` python310Packages.bimmer-connected: 0.13.6 -> 0.13.7 ``                |
| [`faef939f`](https://github.com/NixOS/nixpkgs/commit/faef939f4688e702dcc950dc2bb35dd175aa2a32) | `` python3Packages.langchain: 0.0.201 -> 0.0.207 ``                       |
| [`f2decfee`](https://github.com/NixOS/nixpkgs/commit/f2decfeee2bcc37ba47f82c7061e8e49d7d543f7) | `` python3Packages.langchainplus-sdk: 0.0.10 -> 0.0.16 ``                 |
| [`7bb634f6`](https://github.com/NixOS/nixpkgs/commit/7bb634f6bb0bd99a42aba3a47a29ac6f667c1673) | `` python310Packages.google-cloud-bigquery: 3.11.1 -> 3.11.2 ``           |
| [`8f34dc07`](https://github.com/NixOS/nixpkgs/commit/8f34dc07d8c39d2c7f5701bfc511da64f946413a) | `` typos: 1.15.3 -> 1.15.5 ``                                             |
| [`0311d3f5`](https://github.com/NixOS/nixpkgs/commit/0311d3f5c0b0459e41c5cea8b1dd11f90fd85276) | `` ruff: 0.0.274 -> 0.0.275 ``                                            |
| [`a65fb207`](https://github.com/NixOS/nixpkgs/commit/a65fb2077f92f990b7486164ab2be94001e20070) | `` typst-lsp: 0.7.0 -> 0.7.1 ``                                           |
| [`1bc2ea51`](https://github.com/NixOS/nixpkgs/commit/1bc2ea5194d88256601a91182f7144d674303bf1) | `` awscli2: 2.12.0 -> 2.12.2 ``                                           |
| [`4fa45e42`](https://github.com/NixOS/nixpkgs/commit/4fa45e42782ee3897406f8bf75ac896360bcad68) | `` linux_testing: 6.4-rc6 -> 6.4-rc7 ``                                   |
| [`95929ef8`](https://github.com/NixOS/nixpkgs/commit/95929ef8f80c34fed2653dd244d5be708beb9993) | `` python310Packages.tinydb: 4.7.1 -> 4.8.0 ``                            |
| [`0ed1db3e`](https://github.com/NixOS/nixpkgs/commit/0ed1db3ee52c42adb38b23751cf895e48915cf2f) | `` bird: 2.13 -> 2.13.1 ``                                                |
| [`b8f05fdf`](https://github.com/NixOS/nixpkgs/commit/b8f05fdfb366f8edf537faf4d615b6ccdc7ac14c) | `` utsushi: fix build with SANE 1.1 and above ``                          |
| [`08239744`](https://github.com/NixOS/nixpkgs/commit/08239744dbcc1aa0b2be21eee9076cd25d8c294a) | `` klipper: unstable-2023-04-24 -> unstable-2023-06-21 ``                 |
| [`0e8450ca`](https://github.com/NixOS/nixpkgs/commit/0e8450caa9ab996c736cb26679d6ebdb6ecfad27) | `` klipper: enable can support ``                                         |
| [`da4008cb`](https://github.com/NixOS/nixpkgs/commit/da4008cb4f38921fc0d677d250042d7be5a39f3a) | `` python310Packages.arcam-fmj: 1.3.0 -> 1.4.0 ``                         |
| [`82e6dcef`](https://github.com/NixOS/nixpkgs/commit/82e6dcefb978a70a9fd12ed8cd882d71cacd4468) | `` python311Packages.tkinter: fix runtime error on darwin ``              |
| [`2d1721ea`](https://github.com/NixOS/nixpkgs/commit/2d1721eaa55797dcaa376f1a5bf427b20a94b9c8) | `` python310Packages.amply: 0.1.5 -> 0.1.6 ``                             |
| [`53a3ddfa`](https://github.com/NixOS/nixpkgs/commit/53a3ddfab88c4e45be8fe4d69f70fa11672c2c90) | `` vault: set coredump ulimit to 0 ``                                     |
| [`955a13b5`](https://github.com/NixOS/nixpkgs/commit/955a13b55223865c34046808954d40d44151904c) | `` python311Packages.aranet4: 2.1.3 -> 2.2.0 ``                           |
| [`ed555245`](https://github.com/NixOS/nixpkgs/commit/ed55524562e14131250b8362f47ccfe2d6e5a328) | `` nixos/malloc: add back maybe unnecessary line ``                       |
| [`d84d9648`](https://github.com/NixOS/nixpkgs/commit/d84d9648d33d0956012c19daab9dadf04b7d7b93) | `` obs-studio-plugins.obs-rgb-levels-filter: init at 1.0.0 ``             |
| [`0415163b`](https://github.com/NixOS/nixpkgs/commit/0415163b68ff3e7e16d07c52bdd3d7ab84268d09) | `` nixpkgs-lint-community: init at 0.3.0 ``                               |
| [`27aafa68`](https://github.com/NixOS/nixpkgs/commit/27aafa685255036e2b62155b6cf7b6b4a1773274) | `` python3Packages.yamllint: 1.31.0 -> 1.32.0, switch to github source `` |
| [`597d7dbe`](https://github.com/NixOS/nixpkgs/commit/597d7dbe116b2a79e0ef5ef967a384f2c85ea842) | `` v2ray-domain-list-community: 20230614081211 -> 20230621141418 ``       |
| [`1935d01c`](https://github.com/NixOS/nixpkgs/commit/1935d01ca763108bb2faa2c8989af35506b7cbd3) | `` python311Packages.malduck: 4.3.0 -> 4.3.2 ``                           |
| [`5c5e5e2f`](https://github.com/NixOS/nixpkgs/commit/5c5e5e2f1f47d9b0e6c48defe25aeba0bbf04d2c) | `` linuxManualConfig: set badPlatforms ``                                 |
| [`aaf80087`](https://github.com/NixOS/nixpkgs/commit/aaf800875e3d09d5d89d345095d8216cbf7f19ee) | `` python311Packages.karton-classifier: 1.4.0 -> 2.0.0 ``                 |
| [`64b25014`](https://github.com/NixOS/nixpkgs/commit/64b25014367bae25dc745324cf2d3682154a8556) | `` qrcodegen: use llvm-ar when cc is clang ``                             |
| [`0e168d15`](https://github.com/NixOS/nixpkgs/commit/0e168d159ffd3107a068102210d2fad777d7a636) | `` qrcodegen: use sourceRoot instead of preBuild cd ``                    |
| [`eadfb133`](https://github.com/NixOS/nixpkgs/commit/eadfb133a48e50fc30b234ea5e4967e6e897654e) | `` mariadb-galera: add passthru.tests ``                                  |
| [`b27f7c60`](https://github.com/NixOS/nixpkgs/commit/b27f7c60129fa45e81a4b39663471786d82d3683) | `` mariadb-galera: 26.4.14 -> 26.4.15 ``                                  |
| [`f7fd5a2f`](https://github.com/NixOS/nixpkgs/commit/f7fd5a2fadb8918541730dfff03d6ba29be4eee4) | `` kubefirst: 2.1.4 -> 2.1.5 ``                                           |
| [`a695c109`](https://github.com/NixOS/nixpkgs/commit/a695c109a2c0135cf0876958981cf271f9237132) | `` tailscale: 1.42.0 -> 1.44.0 ``                                         |
| [`c35e9553`](https://github.com/NixOS/nixpkgs/commit/c35e9553a449c1d2292a7b58a6553d91a44d0510) | `` yt-dlp: 2023.6.21 -> 2023.6.22 ``                                      |
| [`9987030e`](https://github.com/NixOS/nixpkgs/commit/9987030e778faf74d10a86c960d7555bd5647c46) | `` goocanvas2: fix cross ``                                               |
| [`485f278c`](https://github.com/NixOS/nixpkgs/commit/485f278c558be723aabcf0fdb22f4f8a49ce49e1) | `` libmongo-client: drop as upstream has gone ``                          |
| [`59f47410`](https://github.com/NixOS/nixpkgs/commit/59f47410c809cc272a6151216a30ccf4f65dd057) | `` memray: 1.8.0 -> 1.8.1 ``                                              |
| [`effafa68`](https://github.com/NixOS/nixpkgs/commit/effafa6846fdf4b2c50ac7e7e4ddf6dbdffc09e4) | `` ansible-language-server: 1.0.5 -> 1.1.0 ``                             |
| [`c5740913`](https://github.com/NixOS/nixpkgs/commit/c5740913e5148826a9b15bab18eb9a536bc936e2) | `` grype: 0.62.3 -> 0.63.0 ``                                             |
| [`29cc0fa0`](https://github.com/NixOS/nixpkgs/commit/29cc0fa0f410e81699eed969a5467ffc4bcd12b2) | `` exploitdb: 2023-06-20 -> 2023-06-22 ``                                 |
| [`ac031478`](https://github.com/NixOS/nixpkgs/commit/ac031478cbf68a019327c48abbfe0e37dbc8256f) | `` stdenv: use lib.isX instead of typeOf Y == X ``                        |
| [`3afcfff8`](https://github.com/NixOS/nixpkgs/commit/3afcfff88ed17ec2d8609d350e03b28db5d813fd) | `` esphome: 2023.5.5 -> 2023.6.0 ``                                       |
| [`83cdc619`](https://github.com/NixOS/nixpkgs/commit/83cdc619332a2bdca1a54bf74ed5ac5fa0245976) | `` python310Packages.textual: 0.28.0 -> 0.28.1 ``                         |
| [`155e0eff`](https://github.com/NixOS/nixpkgs/commit/155e0efff1f8413b9208b2c2f06e2a4b956d0654) | `` rsyslog: remove dependency on libmongo-client ``                       |
| [`09f573ca`](https://github.com/NixOS/nixpkgs/commit/09f573ca2adc7988966f23f7a65230ed690280b0) | `` python310Packages.google-cloud-datastore: 2.15.2 -> 2.16.0 ``          |
| [`7d73228d`](https://github.com/NixOS/nixpkgs/commit/7d73228de8c26b36dc4f0fe9539ddb7e35ba2080) | `` eigenmath: unstable-2023-05-12 -> unstable-2023-06-16 ``               |
| [`4330cec2`](https://github.com/NixOS/nixpkgs/commit/4330cec2eed36461958c1d4ad3c04fd2ec25c083) | `` libxdg_basedir: 1.2.0 -> 1.2.3 ``                                      |
| [`56aabf8a`](https://github.com/NixOS/nixpkgs/commit/56aabf8aa5a56c1432e378a4c5c9fdaabbda9a27) | `` wrangler: autopatchelf bundled binaries ``                             |
| [`be359d1e`](https://github.com/NixOS/nixpkgs/commit/be359d1ea4e7fb8fdc40eb619e97d293be48675c) | `` plocate: 1.1.17 -> 1.1.19 ``                                           |
| [`a1004060`](https://github.com/NixOS/nixpkgs/commit/a1004060805ca8042b039a091309164df93c3fa0) | `` python310Packages.python-utils: 3.6.0 -> 3.7.0 ``                      |
| [`4973ac5a`](https://github.com/NixOS/nixpkgs/commit/4973ac5ada0bbcf855e9a6089bb4f67efe778484) | `` miniflux: 2.0.44 -> 2.0.45 ``                                          |
| [`9befc024`](https://github.com/NixOS/nixpkgs/commit/9befc0242e9235406da2265fc9c3301ef4a1fbfe) | `` snappymail: 2.28.1 -> 2.28.2 ``                                        |
| [`88185e77`](https://github.com/NixOS/nixpkgs/commit/88185e77701b11536b7c1ae27fe613b6e4ff456c) | `` python310Packages.pydata-google-auth: 1.7.0 -> 1.8.0 ``                |
| [`1ef7b169`](https://github.com/NixOS/nixpkgs/commit/1ef7b1691c71592d86426dcf18efddacb5d38aa1) | `` ircdog: 0.5.0 -> 0.5.1 ``                                              |
| [`593258bf`](https://github.com/NixOS/nixpkgs/commit/593258bffc7cdc7c225450bb3d153fd00d6c4bdb) | `` porsmo: init at 0.2.0 ``                                               |
| [`b75eba84`](https://github.com/NixOS/nixpkgs/commit/b75eba84d93fe9b520d6dd0cd1602b4b2440dd91) | `` inspircd: 3.16.0 -> 3.16.1 ``                                          |
| [`7dabd502`](https://github.com/NixOS/nixpkgs/commit/7dabd5025e162c70bca9af60e5e96942ba0b89cc) | `` acr: 2.1.1 -> 2.1.2 ``                                                 |
| [`a0056ef6`](https://github.com/NixOS/nixpkgs/commit/a0056ef6ece8a6a50732b5402155a83a3b1bb462) | `` emacs.pkgs.exwm: Prefer exwm from elpa devel ``                        |
| [`e122cc58`](https://github.com/NixOS/nixpkgs/commit/e122cc5840b807ef4a5766abe0e7618f19f76e13) | `` python3Packages.pint-pandas: unstable-2022-11-24 -> 0.4 ``             |
| [`7f5a1033`](https://github.com/NixOS/nixpkgs/commit/7f5a1033099ccdb4d7e52fd6691599d9b70b7858) | `` extremetuxracer: 0.8.2 -> 0.8.3 ``                                     |
| [`65e6d9ef`](https://github.com/NixOS/nixpkgs/commit/65e6d9eff6857543d4d6c432d101aa49cb83684c) | `` katana: 1.0.1 -> 1.0.2 ``                                              |
| [`437666c1`](https://github.com/NixOS/nixpkgs/commit/437666c1dcccb8be76756b5de47f83993b335c8f) | `` cargo-ndk: 3.1.2 -> 3.2.0 ``                                           |
| [`66cb54c7`](https://github.com/NixOS/nixpkgs/commit/66cb54c7fc67a0f79aa2e59f504c6cd015d7cbdc) | `` nixos/supergfxd: add pciutils to path ``                               |
| [`aa790d08`](https://github.com/NixOS/nixpkgs/commit/aa790d08efc0a00c9e136d828bc64069641b349d) | `` python310Packages.ijson: 3.2.0.post0 -> 3.2.2 ``                       |
| [`2e7dfd3a`](https://github.com/NixOS/nixpkgs/commit/2e7dfd3a2f01d4aa812e7dd41e0d43eb759de68d) | `` lpairs2: 2.2 -> 2.2.1 ``                                               |
| [`c0b5213d`](https://github.com/NixOS/nixpkgs/commit/c0b5213df3667ee71aa7c44d663229fb9f9f880b) | `` dolphin-emu: fix build on darwin (#238959) ``                          |
| [`42075be6`](https://github.com/NixOS/nixpkgs/commit/42075be601a972883cd8faea84cee56d8d3e6e7d) | `` freefilesync: 12.3 -> 12.4 (#239051) ``                                |
| [`34888bcd`](https://github.com/NixOS/nixpkgs/commit/34888bcd3c2cdc27deb5be8e0c7a5e1842aa04a1) | `` deadd-notification-center: 2.0.3 -> 2.0.4 ``                           |
| [`ef49c2cd`](https://github.com/NixOS/nixpkgs/commit/ef49c2cd45d00bd258be8bcc37fc969e02343aef) | `` python3Packages.tkinter: Improve meta.description (#239047) ``         |
| [`f1d9a741`](https://github.com/NixOS/nixpkgs/commit/f1d9a741626ccea86edd030e9b2d287a16da9e20) | `` xapian: 1.4.21 -> 1.4.22 (#239016) ``                                  |
| [`2ad637ab`](https://github.com/NixOS/nixpkgs/commit/2ad637ab77a4f75152e7b59c095f2c4bcf79c933) | `` eksctl: 0.144.0 -> 0.145.0 ``                                          |
| [`70829ee9`](https://github.com/NixOS/nixpkgs/commit/70829ee9bcb746f197873da45afc9de10e17d387) | `` fb303: 2023.04.24.00 -> 2023.06.12.00 ``                               |
| [`7edd99b9`](https://github.com/NixOS/nixpkgs/commit/7edd99b96e22edf83a99b5194b7aa7412693b7d3) | `` terraform-providers.tencentcloud: 1.81.8 -> 1.81.9 ``                  |
| [`c68ecfc4`](https://github.com/NixOS/nixpkgs/commit/c68ecfc4932a56444d9554fe435c2f56d88799a5) | `` terraform-providers.vault: 3.16.0 -> 3.17.0 ``                         |
| [`889360f6`](https://github.com/NixOS/nixpkgs/commit/889360f667022218662fe718b084874504ab6ccc) | `` terraform-providers.oci: 5.1.0 -> 5.2.1 ``                             |
| [`524aa3d0`](https://github.com/NixOS/nixpkgs/commit/524aa3d0ffb968db5aff0f01eea832b86e851043) | `` terraform-providers.spotinst: 1.122.2 -> 1.123.0 ``                    |
| [`cf0659fd`](https://github.com/NixOS/nixpkgs/commit/cf0659fd9a33b9a9c39603dca7e18c9be0c280ba) | `` terraform-providers.scaleway: 2.21.0 -> 2.22.0 ``                      |
| [`8a245489`](https://github.com/NixOS/nixpkgs/commit/8a2454895c0bc42865713dab4f010949765908b3) | `` terraform-providers.newrelic: 3.24.2 -> 3.25.0 ``                      |
| [`07bce345`](https://github.com/NixOS/nixpkgs/commit/07bce3454c71923a97ac7c4f88d601fe70cf81e4) | `` terraform-providers.http: 3.3.0 -> 3.4.0 ``                            |
| [`774f29b3`](https://github.com/NixOS/nixpkgs/commit/774f29b33ba336d62d317b354b480ba06acbb348) | `` terraform-providers.gridscale: 1.19.0 -> 1.20.0 ``                     |
| [`1447a580`](https://github.com/NixOS/nixpkgs/commit/1447a5804b36cd8c40a8969ef540a486ffdb2ed2) | `` qt6.qtwebengine: unbreak on x86_64-darwin ``                           |
| [`abdd303e`](https://github.com/NixOS/nixpkgs/commit/abdd303edd0a6734bd92cc2a1645bb4680f2c69d) | `` pt2-clone: 1.59 -> 1.60 ``                                             |
| [`4dd398bb`](https://github.com/NixOS/nixpkgs/commit/4dd398bb8f332347238bc11cd39700667eff76fe) | `` frr: 8.5.1 -> 8.5.2 ``                                                 |
| [`6eed9214`](https://github.com/NixOS/nixpkgs/commit/6eed9214bbf249542259439b64406935ea426dd9) | `` xemu: 0.7.95 -> 0.7.96 ``                                              |
| [`a9e5e732`](https://github.com/NixOS/nixpkgs/commit/a9e5e732b09715ae2db738672d1af8aa9e84cbc9) | `` featherpad: 1.4.0 -> 1.4.1 ``                                          |
| [`b0e0561d`](https://github.com/NixOS/nixpkgs/commit/b0e0561de896bdbc4b193d7b422171a1ca98cd68) | `` webcamoid: 9.0.0 -> 9.1.1 ``                                           |
| [`3113ac35`](https://github.com/NixOS/nixpkgs/commit/3113ac359f3bf16957ed02b5bd04f408fd18d082) | `` riffdiff: init at 2.23.3 ``                                            |