### PR TITLE
chore(flake/home-manager): `70ac1887` -> `d2b6f2d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687473300,
-        "narHash": "sha256-4LflQpktYFiub8xVhEN9EZf1cYsr09md01rBJZRCGCc=",
+        "lastModified": 1687506590,
+        "narHash": "sha256-CSou9mrG9h/WVRjCptfTrATVxvhmtdQXElmWV/ZkrAs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "70ac18872a5f1a57a4546ff58888bf67a8bbb5b3",
+        "rev": "d2b6f2d154bf6b27a93ed895392f80c503df7cfa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`d2b6f2d1`](https://github.com/nix-community/home-manager/commit/d2b6f2d154bf6b27a93ed895392f80c503df7cfa) | `` zellij: fix module description for shell integrations `` |
| [`491f74db`](https://github.com/nix-community/home-manager/commit/491f74db894b5c5843a9e4b123aa773e1b21583f) | `` antidote: fix package source path ``                     |