### PR TITLE
chore(flake/darwin): `bc346a67` -> `6460468e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687385522,
-        "narHash": "sha256-GR8mqsqYcdZ67dCcII5SWcwHqPAJRWXPmqsuMl7+KA4=",
+        "lastModified": 1687517837,
+        "narHash": "sha256-Ea+JTy6NSf+wWIFrgC8gnOnyt01xwmtDEn2KecvaBkg=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "bc346a67d34a336ca3c507570875cc88038e6120",
+        "rev": "6460468e7a3e1290f132fee4170ebeaa127f6f32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                         |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`fbb3ab94`](https://github.com/LnL7/nix-darwin/commit/fbb3ab94e67bab73e721d5bbbcc6b05b0cf60f2f) | `` activity monitor: change settings to null `` |