### PR TITLE
chore(flake/home-manager): `29872a1c` -> `68aebb45`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687600357,
-        "narHash": "sha256-9MAGSFJVMr06krOAiiocq02gXvGKEHyjyjCKZJR919s=",
+        "lastModified": 1687606638,
+        "narHash": "sha256-kloVhlQlholYXI6nfXkEa/4B+LZ+22YayxPoKZNkqRU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "29872a1c8f5ed2fde270afb0583d1fabce5e0459",
+        "rev": "68aebb45de644b81a71f0c7b8b22ad51c9a0df7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`68aebb45`](https://github.com/nix-community/home-manager/commit/68aebb45de644b81a71f0c7b8b22ad51c9a0df7a) | `` fish: follow links to find man pages ``                |
| [`b59f682e`](https://github.com/nix-community/home-manager/commit/b59f682e860185e0670148d44be290c469bcc300) | `` fish: consider man pages from extraOutputsToInstall `` |
| [`28b6c367`](https://github.com/nix-community/home-manager/commit/28b6c3670cbfab9ff78e6de8cd38f93ec42d253b) | `` docs: update nmd ``                                    |