### PR TITLE
chore(flake/darwin): `6460468e` -> `ace0ef2a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687517837,
-        "narHash": "sha256-Ea+JTy6NSf+wWIFrgC8gnOnyt01xwmtDEn2KecvaBkg=",
+        "lastModified": 1687642959,
+        "narHash": "sha256-mrnYXgXOyiXNAxSDEdRjOFA0DmQollHYOSEvGHPscCg=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "6460468e7a3e1290f132fee4170ebeaa127f6f32",
+        "rev": "ace0ef2a26bc428e768a5926eae95a63cfcf8b52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                 |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`9d6702cf`](https://github.com/LnL7/nix-darwin/commit/9d6702cf2b81f5d0ef9d628d99e8deb45f84b454) | `` eval-config: remove compatibility shims ``           |
| [`42d1643e`](https://github.com/LnL7/nix-darwin/commit/42d1643e7a79aa9a0c6bf50e5944fec4e5c492f2) | `` {ci,readme}: update stable nixpkgs to 23.05 ``       |
| [`69648c6c`](https://github.com/LnL7/nix-darwin/commit/69648c6cbbecf34c327d73e36b5aed32edfb9ed9) | `` doc/manual: use `nixos-render-docs` ``               |
| [`d37abf45`](https://github.com/LnL7/nix-darwin/commit/d37abf456b50b6252d1ca995b20a7add8c28cce6) | `` flake.nix: remove the nixpkgs pin ``                 |
| [`2903ceab`](https://github.com/LnL7/nix-darwin/commit/2903ceabb5ffe0968199bf3db80a9c6dd1d3d6de) | `` doc/manual: remove `optionsDocBook` export ``        |
| [`e65131e6`](https://github.com/LnL7/nix-darwin/commit/e65131e69cab1b18fb49b572b983a18720502e1b) | `` treewide: convert all option docs to Markdown ``     |
| [`efe314cd`](https://github.com/LnL7/nix-darwin/commit/efe314cdbabaf5cd210d9c658b4ad540437b7ee5) | `` treewide: manually convert some docs to Markdown ``  |
| [`c2716817`](https://github.com/LnL7/nix-darwin/commit/c2716817a8e5fb47889aaf625aa13b89d786da51) | `` {offlineimap,tailscale}: fix `enable` option docs `` |
| [`b97c235e`](https://github.com/LnL7/nix-darwin/commit/b97c235e37c91511c2e7533ab6794480e4cc445a) | `` treewide: tweak DocBook docs for conversion ``       |
| [`76ce9fac`](https://github.com/LnL7/nix-darwin/commit/76ce9faca6e16d348afb9d78a1a13eb19c381b76) | `` doc/manual: use `nixosOptionDoc` ``                  |
| [`96cb4913`](https://github.com/LnL7/nix-darwin/commit/96cb49133b813d9902f6417e5b725a01bbaacb2f) | `` wq-quick: document `publicKey` option ``             |
| [`f8c61f00`](https://github.com/LnL7/nix-darwin/commit/f8c61f00980867ead1bebd81ded0272cbcb6febb) | `` flake.nix: add checks for the docs ``                |
| [`b6893e7f`](https://github.com/LnL7/nix-darwin/commit/b6893e7f6d8c8e0d86ab46ac69250d34fb716d21) | `` eval-config: remove `lib.mdDoc` ``                   |
| [`b7ccefad`](https://github.com/LnL7/nix-darwin/commit/b7ccefadf9aa3e2f7dfc60ed61bfa90d2d224c93) | `` flake.nix: temporarily pin nixpkgs version ``        |