### PR TITLE
chore(flake/darwin): `ace0ef2a` -> `53c6748f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687642959,
-        "narHash": "sha256-mrnYXgXOyiXNAxSDEdRjOFA0DmQollHYOSEvGHPscCg=",
+        "lastModified": 1687683133,
+        "narHash": "sha256-fEjLznHh9vXMphTKupjHX6AaCQYnpkG6f28+bSUNM10=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ace0ef2a26bc428e768a5926eae95a63cfcf8b52",
+        "rev": "53c6748f98fd1e91f1e10f8878f1513743990101",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                              |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`a62f16b9`](https://github.com/LnL7/nix-darwin/commit/a62f16b94dff6ad5835ec6beb992e09e76bc2fe6) | `` readme: update links for redirect ``              |
| [`df03a145`](https://github.com/LnL7/nix-darwin/commit/df03a145b36f4787ef033589159129a1c936a643) | `` ci: update manual updater to 23.05 ``             |
| [`f253b41d`](https://github.com/LnL7/nix-darwin/commit/f253b41de83c9f34fba9eda66cc42b90e10937c7) | `` buildkite-agent: fix launcd daemon environment `` |