### PR TITLE
chore(flake/nixpkgs): `3ae20aa5` -> `1c9db971`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687502512,
-        "narHash": "sha256-dBL/01TayOSZYxtY4cMXuNCBk8UMLoqRZA+94xiFpJA=",
+        "lastModified": 1687681650,
+        "narHash": "sha256-M2If+gRcfpmaJy/XbfSsRzLlPpoU4nr0NHnKKl50fd8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3ae20aa58a6c0d1ca95c9b11f59a2d12eebc511f",
+        "rev": "1c9db9710cb23d60570ad4d7ab829c2d34403de3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                        |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`e43d080e`](https://github.com/NixOS/nixpkgs/commit/e43d080ed7a97347e4a58ef9d8402f9cfcfb79bd) | `` python310Packages.mkdocs-swagger-ui-tag: 0.6.1 -> 0.6.2 ``  |
| [`636db898`](https://github.com/NixOS/nixpkgs/commit/636db898ebbb8856320fe6d2472d79e18f88d5c7) | `` lib.licenses: add Sustainable Use License (#239455) ``      |
| [`3a3654c8`](https://github.com/NixOS/nixpkgs/commit/3a3654c83678de3fbe59bca88483a5bb2b435f0b) | `` jellyfin-media-player: add aarch64-linux platform ``        |
| [`1ba93d3f`](https://github.com/NixOS/nixpkgs/commit/1ba93d3fc51af7ea29e024b78d230fddbd5bbc46) | `` terraform-providers.fortios: 1.16.0 -> 1.17.0 ``            |
| [`788443fb`](https://github.com/NixOS/nixpkgs/commit/788443fb50397e15c1aaa4b49612aa080224d854) | `` terraform-providers.opsgenie: 0.6.24 -> 0.6.25 ``           |
| [`9c9724fb`](https://github.com/NixOS/nixpkgs/commit/9c9724fb83676ae69d90ba28ce732d0d5f8313a0) | `` doppler: 3.61.0 -> 3.62.0 ``                                |
| [`3c38ae8d`](https://github.com/NixOS/nixpkgs/commit/3c38ae8dcb40434d46f8bb8e1a8c293d9c314f04) | `` bacon: 2.8.1 -> 2.9.0 ``                                    |
| [`f3161731`](https://github.com/NixOS/nixpkgs/commit/f316173121366298ba8e66dd3f1b64b61862c43b) | `` python310Packages.argilla: init at 1.8.0 ``                 |
| [`89ed610e`](https://github.com/NixOS/nixpkgs/commit/89ed610ece92796f781133d227ba5bb9fbe9f5dc) | `` python310Packages.cleanlab: init at 2.4.0 ``                |
| [`42e360cb`](https://github.com/NixOS/nixpkgs/commit/42e360cbc41f92a8ffccd54b876d2a4e9fe0bf83) | `` python310Packages.snorkel: init at 0.9.9 ``                 |
| [`4659f761`](https://github.com/NixOS/nixpkgs/commit/4659f76177823c3717a06640c410cae18eb82a61) | `` pythonPackages.luqum: init at 0.13.0 ``                     |
| [`e1e97d0a`](https://github.com/NixOS/nixpkgs/commit/e1e97d0a46ae0d5b8b4b152c4b6de23309b99b41) | `` pythonPackages.msg-parser: init at 1.2.0 ``                 |
| [`cd93642b`](https://github.com/NixOS/nixpkgs/commit/cd93642b9e808b74897a081ab664eaa83ea28e10) | `` cargo-udeps: 0.1.39 -> 0.1.40 ``                            |
| [`565df52d`](https://github.com/NixOS/nixpkgs/commit/565df52dd94525f973acc614c5a5e9858798c128) | `` kodiPackages.inputstream-adaptive: 20.3.8 -> 20.3.9 ``      |
| [`26bbadc5`](https://github.com/NixOS/nixpkgs/commit/26bbadc5e2c1c1fcec37a0d119f9055d02700b48) | `` cargo-expand: 1.0.55 -> 1.0.56 ``                           |
| [`e93c794e`](https://github.com/NixOS/nixpkgs/commit/e93c794e277cbe6e154a00f3324883d2d75eb38c) | `` python310Packages.dvc-task: 0.2.1 -> 0.3.0 ``               |
| [`60e49372`](https://github.com/NixOS/nixpkgs/commit/60e49372ed461a90fe1a7f14ca436d5a7309f24d) | `` dnsperf: 2.12.0 -> 2.13.0 ``                                |
| [`d520215e`](https://github.com/NixOS/nixpkgs/commit/d520215e42fa3bb2f86d846e65852f8511928960) | `` river-luatile: 0.1.2 -> 0.1.3 ``                            |
| [`19e54d77`](https://github.com/NixOS/nixpkgs/commit/19e54d7763d7de827e9d55744923f4ffab31ea58) | `` terraform-providers.azurerm: 3.62.0 -> 3.62.1 ``            |
| [`f66cb78b`](https://github.com/NixOS/nixpkgs/commit/f66cb78b806f6bd928c2afb8647f6ea2e17a57dd) | `` terraform-providers.fastly: 5.2.0 -> 5.2.1 ``               |
| [`5da8ece4`](https://github.com/NixOS/nixpkgs/commit/5da8ece499391510c86868fb7dc348f1a802a487) | `` terraform-providers.buildkite: 0.19.0 -> 0.19.1 ``          |
| [`de1efff2`](https://github.com/NixOS/nixpkgs/commit/de1efff279d47ecc6e8766973ce47a828ffb2b0d) | `` argc: 1.5.0 -> 1.6.0 ``                                     |
| [`4d86b6ab`](https://github.com/NixOS/nixpkgs/commit/4d86b6ab44d8eff99bb9bf1defeb6133f7f16fe4) | `` gtree: 1.8.1 -> 1.8.2 ``                                    |
| [`cb2e5a4b`](https://github.com/NixOS/nixpkgs/commit/cb2e5a4bc0acf1be79d906fbc1f2915ccfc2c67a) | `` shotgun: 2.5.0 -> 2.5.1 ``                                  |
| [`db68c9d3`](https://github.com/NixOS/nixpkgs/commit/db68c9d3cf4dbbc096ded505bcf9ca24d43812c1) | `` cargo-expand: 1.0.53 -> 1.0.55 ``                           |
| [`54da55e0`](https://github.com/NixOS/nixpkgs/commit/54da55e07f57621f60600981a0cb907272f7dd2d) | `` cargo-outdated: fix changelog ``                            |
| [`72f0b8fb`](https://github.com/NixOS/nixpkgs/commit/72f0b8fba439e484fdbc0bb0e993ab03547f9a1b) | `` flow: 0.209.0 -> 0.209.1 ``                                 |
| [`863c584f`](https://github.com/NixOS/nixpkgs/commit/863c584fca837182f3674ebb5842928d0967463b) | `` fn-cli: 0.6.24 -> 0.6.25 ``                                 |
| [`8e8704a3`](https://github.com/NixOS/nixpkgs/commit/8e8704a341ceebf27ff890c55c8d3b9a3562b3bc) | `` cargo-outdated: 0.11.2 -> 0.13.1 ``                         |
| [`e3ce26ce`](https://github.com/NixOS/nixpkgs/commit/e3ce26ce802455fd63cff5bfda0161125eb29739) | `` jmeter: 5.5 -> 5.6 ``                                       |
| [`4ca419cd`](https://github.com/NixOS/nixpkgs/commit/4ca419cd4ff6189b4c739aa47d96e324f5f48b29) | `` python310Packages.jwcrypto: add changelog to meta ``        |
| [`8db05aa5`](https://github.com/NixOS/nixpkgs/commit/8db05aa52f74ba4aa54819eda6565e8903831bf2) | `` nixos/rustus: inital module ``                              |
| [`9d228d71`](https://github.com/NixOS/nixpkgs/commit/9d228d71b55fc04fb4ef872db9dbc00d5c281216) | `` dufs: 0.34.1 -> 0.34.2 ``                                   |
| [`7b458a77`](https://github.com/NixOS/nixpkgs/commit/7b458a775273b574c97a9ac04c4a438239bc9bba) | `` granted: 0.13.2 -> 0.14.0 ``                                |
| [`9af11af6`](https://github.com/NixOS/nixpkgs/commit/9af11af665d0f7a37235698df8306092e2cc3bcc) | `` python310Packages.typepy: combine inputs ``                 |
| [`20efb1b6`](https://github.com/NixOS/nixpkgs/commit/20efb1b60450bc8ac38d9cafb789300e5ae70ff1) | `` python310Packages.typepy: add format ``                     |
| [`10549898`](https://github.com/NixOS/nixpkgs/commit/10549898743de632c6947eba7562d00a98c2669b) | `` python310Packages.typepy: add changelog to meta ``          |
| [`cf7edf0c`](https://github.com/NixOS/nixpkgs/commit/cf7edf0cc00c2c3d3995b2515c22f3658e206b47) | `` python311Packages.nxt-python: 3.0.1 -> 3.2.0 ``             |
| [`8ca4d1ba`](https://github.com/NixOS/nixpkgs/commit/8ca4d1baa69dccc12a394e5aaeabd45406e4e85b) | `` python311Packages.nxt-python: add changelog to meta ``      |
| [`f706cd2a`](https://github.com/NixOS/nixpkgs/commit/f706cd2a9de5ea72b5a1be62abbd8187765f89ed) | `` python311Packages.nxt-python: specify license ``            |
| [`ee88cb35`](https://github.com/NixOS/nixpkgs/commit/ee88cb35ac1289e3b7d9b73aa8e59b3fd5dc6736) | `` pulsar: 1.105.0 -> 1.106.0 ``                               |
| [`524d0f71`](https://github.com/NixOS/nixpkgs/commit/524d0f7142d4e3a1a1d3496cdcae6963994beb05) | `` tmuxp: 1.27.0 -> 1.28.1 ``                                  |
| [`8f62341d`](https://github.com/NixOS/nixpkgs/commit/8f62341db1061a0a798dc30e63d02efe96af9b6b) | `` python310Packages.libtmux: 0.21.1 -> 0.22.1 ``              |
| [`b31ed195`](https://github.com/NixOS/nixpkgs/commit/b31ed1953c177809e2a2c6774fd9cac24000a2d4) | `` gtree: 1.7.51 -> 1.8.1 ``                                   |
| [`dcefe5cd`](https://github.com/NixOS/nixpkgs/commit/dcefe5cdedf24dbd2a99583e5bbab7881fbef6ef) | `` libytnef: 1.2.1 -> 1.2.2 ``                                 |
| [`d7de5f25`](https://github.com/NixOS/nixpkgs/commit/d7de5f25807583bcba04f9524c0ada5409ea27a3) | `` cloudflare-warp: 2023.3.398 -> 2023.3.470 ``                |
| [`c890237f`](https://github.com/NixOS/nixpkgs/commit/c890237f94f8dee56bd7fbee50c3cb6b5b98c1fd) | `` postgresql11JitPackages.pgroonga: 3.0.6 -> 3.0.7 ``         |
| [`24e62839`](https://github.com/NixOS/nixpkgs/commit/24e62839091313184d8727302c77077dd552ed48) | `` python310Packages.embedding-reader: 1.5.0 -> 1.5.1 ``       |
| [`b3e9e652`](https://github.com/NixOS/nixpkgs/commit/b3e9e652a802532e064ced1ff4bb1883c4838f58) | `` iosevka: 24.1.3 -> 24.1.4 ``                                |
| [`73d46a9a`](https://github.com/NixOS/nixpkgs/commit/73d46a9a7ee5a1193252bc4b1473d1e7243af131) | `` python310Packages.typepy: 1.3.0 -> 1.3.1 ``                 |
| [`2b8a48c7`](https://github.com/NixOS/nixpkgs/commit/2b8a48c7e8ef5c205085e8edfd107e3e8f2cd70a) | `` oha: 0.5.9 -> 0.6.0 ``                                      |
| [`a264297a`](https://github.com/NixOS/nixpkgs/commit/a264297aed33f3df4eda79637201dadf067e8d2f) | `` ergo: 5.0.11 -> 5.0.12 ``                                   |
| [`c317609b`](https://github.com/NixOS/nixpkgs/commit/c317609b5d6b6bebe1ed69c5b0155cad5a7cb9e1) | `` sdrangel: 7.14.2 -> 7.15.0 ``                               |
| [`885c4377`](https://github.com/NixOS/nixpkgs/commit/885c43778bb4d33d840035f46376e9f5c743a7fc) | `` kubeseal: 0.21.0 -> 0.22.0 ``                               |
| [`275d4da0`](https://github.com/NixOS/nixpkgs/commit/275d4da0c6220e843c5da577d6ec9bf458012749) | `` fselect: 0.8.3 -> 0.8.4 ``                                  |
| [`3bb38590`](https://github.com/NixOS/nixpkgs/commit/3bb385904959bdb0910d75904ce620b0e34bde0e) | `` php: Upgrade from PHP 8.1 to 8.2 as default PHP ``          |
| [`0677e7a8`](https://github.com/NixOS/nixpkgs/commit/0677e7a85572cefb98270be928c50d069e4de1e3) | `` python310Packages.jwcrypto: 1.4.2 -> 1.5.0 ``               |
| [`3629194c`](https://github.com/NixOS/nixpkgs/commit/3629194c33dcb18bc08c23ce8fbd0269ae872114) | `` rshim-user-space: 2.0.8 -> 2.0.9 ``                         |
| [`1410783f`](https://github.com/NixOS/nixpkgs/commit/1410783ff5df4169b2a1fe468905e6c9488c688a) | `` vencord: set standalone build mode ``                       |
| [`de162486`](https://github.com/NixOS/nixpkgs/commit/de1624865fb4d14df27ffd6029891136c7a43f8d) | `` vencord: fix version number patch ``                        |
| [`16ca6c79`](https://github.com/NixOS/nixpkgs/commit/16ca6c79eb78b0cad87822c907cee601c3571664) | `` vencord: disable updater ``                                 |
| [`d2061e12`](https://github.com/NixOS/nixpkgs/commit/d2061e126a3b09a3a3ba2e63e5a9ad564b9b283f) | `` terraspace: 2.2.3 -> 2.2.7 ``                               |
| [`e2bea347`](https://github.com/NixOS/nixpkgs/commit/e2bea3470ca6689c3e08a350e91bb48f0771adf4) | `` toast: 0.47.4 -> 0.47.5 ``                                  |
| [`64746262`](https://github.com/NixOS/nixpkgs/commit/6474626221a32cadcb72501aad11aaee187fe21e) | `` cargo-pgrx: 0.9.5 -> 0.9.6 ``                               |
| [`ca392353`](https://github.com/NixOS/nixpkgs/commit/ca392353ef2c226d3546e91ce02de59f473e09eb) | `` gotrue-supabase: 2.70.0 -> 2.74.2 ``                        |
| [`82d0c61e`](https://github.com/NixOS/nixpkgs/commit/82d0c61e3aa4235ad2a13d3ced609f4a08a3d482) | `` julia-mono: 0.049 -> 0.050 ``                               |
| [`42637bd8`](https://github.com/NixOS/nixpkgs/commit/42637bd82223ba0e8c21e8ce5ec6b905b2967593) | `` jhead: 3.06.0.1 -> 3.08 ``                                  |
| [`a99252a1`](https://github.com/NixOS/nixpkgs/commit/a99252a16a3933cf55ce6c71e4bcb164f4e20979) | `` open-vm-tools-headless: 12.2.0 -> 12.2.5 ``                 |
| [`e7a2b323`](https://github.com/NixOS/nixpkgs/commit/e7a2b32301482044bc85cc852557e8d193a305e2) | `` moon: 1.5.1 -> 1.8.3 ``                                     |
| [`792b9aac`](https://github.com/NixOS/nixpkgs/commit/792b9aac0858958cd6f50ecf22b2c883bfb35da9) | `` maintainers: add devpikachu ``                              |
| [`3ee40ad7`](https://github.com/NixOS/nixpkgs/commit/3ee40ad7238898811adb3937797151333e5312d2) | `` eks-node-viewer: 0.4.0 -> 0.4.1 ``                          |
| [`d6cf4d15`](https://github.com/NixOS/nixpkgs/commit/d6cf4d15f21c467c796908f8868e4bf71f535e4c) | `` fastly: 10.2.0 -> 10.2.2 ``                                 |
| [`0bfbdf64`](https://github.com/NixOS/nixpkgs/commit/0bfbdf64340486ace7f092485f3e21c21119fea6) | `` brev-cli: 0.6.236 -> 0.6.244 ``                             |
| [`11775a23`](https://github.com/NixOS/nixpkgs/commit/11775a23b8021704c79b1c0e4c9744488a076dd2) | `` oh-my-posh: 17.0.0 -> 17.4.0 ``                             |
| [`3488cf6a`](https://github.com/NixOS/nixpkgs/commit/3488cf6aa3158b36a8197ab120610491bbc9af70) | `` broot: 1.22.1 -> 1.23.0 ``                                  |
| [`e9e7adff`](https://github.com/NixOS/nixpkgs/commit/e9e7adffe8eb32818a3d76a2e51fb087c3619e85) | `` kustomize: 5.0.3 -> 5.1.0 ``                                |
| [`b1af6b46`](https://github.com/NixOS/nixpkgs/commit/b1af6b46139ca62e48873ef24b10954d695a8cb0) | `` ugs: 2.0.17 -> 2.0.18 ``                                    |
| [`75556483`](https://github.com/NixOS/nixpkgs/commit/755564839c9b337d3d07b830365e6fcfada88040) | `` confy: 0.6.4 -> 0.6.5 ``                                    |
| [`691a2ad0`](https://github.com/NixOS/nixpkgs/commit/691a2ad003722cbf965a8f19f93302f13e6b0401) | `` process-compose: 0.51.0 -> 0.51.4 ``                        |
| [`d64015e0`](https://github.com/NixOS/nixpkgs/commit/d64015e0e3e0aea73c48d586579ac64c2fa45f97) | `` dqlite: 1.14.0 -> 1.15.1 ``                                 |
| [`7e3de69d`](https://github.com/NixOS/nixpkgs/commit/7e3de69d4edc30848cdc2cfe0529308f7e5d399f) | `` argocd: 2.7.4 -> 2.7.6 ``                                   |
| [`e6f60fd9`](https://github.com/NixOS/nixpkgs/commit/e6f60fd9e737dbc9d2845cd555c17df152a65bdc) | `` github-runner: skip OOM test (#239398) ``                   |
| [`eb3fb757`](https://github.com/NixOS/nixpkgs/commit/eb3fb7578b0b076c5a1549fac478f8898bcea799) | `` discord-canary: 0.0.160 -> 0.0.161 ``                       |
| [`0a40cd1f`](https://github.com/NixOS/nixpkgs/commit/0a40cd1f961a515c61e5ddc67c4052913e7f9b5e) | `` cosign: 2.0.2 -> 2.1.0 ``                                   |
| [`27c42fd9`](https://github.com/NixOS/nixpkgs/commit/27c42fd91887d161685673966df99f1f0a5ab370) | `` python311Packages.aiooncue: 0.3.4 -> 0.3.5 ``               |
| [`b91e2a67`](https://github.com/NixOS/nixpkgs/commit/b91e2a67c5a497b3e71696b61397bc6dcb938958) | `` python311Packages.aioairzone-cloud: 0.1.8 -> 0.1.9 ``       |
| [`e662405e`](https://github.com/NixOS/nixpkgs/commit/e662405e73bd9132ee85fa5bf09c6ee5b9e39741) | `` slade: 3.2.3 -> 3.2.4 ``                                    |
| [`367a76ef`](https://github.com/NixOS/nixpkgs/commit/367a76ef165b9ea3e0724541349866b25ce3360a) | `` go-migrate: 4.16.1 -> 4.16.2 ``                             |
| [`115a731e`](https://github.com/NixOS/nixpkgs/commit/115a731e5efe769a24cc9072c8a610a37b9f79a3) | `` twitch-tui: 2.2.1 -> 2.4.0 ``                               |
| [`4bce6e28`](https://github.com/NixOS/nixpkgs/commit/4bce6e28c27e294f3504e3a443b387d5798599c1) | `` python311Packages.spectral-cube: unbreak ``                 |
| [`d0868bd5`](https://github.com/NixOS/nixpkgs/commit/d0868bd5f1ff7294a140ea9108bbbbde6fceaa7f) | `` appflowy: 0.2.2 -> 0.2.4 ``                                 |
| [`dfc20342`](https://github.com/NixOS/nixpkgs/commit/dfc20342ab64dc090824f30aa3a2021ab53e8e49) | `` cppzmq: 4.9.0 -> 4.10.0 ``                                  |
| [`051916f0`](https://github.com/NixOS/nixpkgs/commit/051916f0930bdbfc0697866096d89da8b9e91f8d) | `` python310Packages.gsd: 2.8.1 -> 3.0.1 ``                    |
| [`e0f71123`](https://github.com/NixOS/nixpkgs/commit/e0f71123e7088557a906de6d68ceb772a97cb456) | `` python310Packages.pathy: 0.10.1 -> 0.10.2 ``                |
| [`8df1532d`](https://github.com/NixOS/nixpkgs/commit/8df1532d0b80b57f8e3e27dd428316c6d6b405e0) | `` python310Packages.flake8-bugbear: 23.5.9 -> 23.6.5 ``       |
| [`5ebf1cf5`](https://github.com/NixOS/nixpkgs/commit/5ebf1cf5d4e10bcf905bd0ee9c024446d859a5c6) | `` zsh-prezto: unstable-2023-04-13 -> unstable-2023-06-22 ``   |
| [`a39736aa`](https://github.com/NixOS/nixpkgs/commit/a39736aa4c5653ea306aee08744164c23a4294d1) | `` wasmtime: 9.0.4 -> 10.0.1 ``                                |
| [`2158b8ed`](https://github.com/NixOS/nixpkgs/commit/2158b8eda14a2fd16e83e36d1520d5be05d853ea) | `` wasmi: init at 0.30.0 ``                                    |
| [`c77972de`](https://github.com/NixOS/nixpkgs/commit/c77972de35eaa7d0acd28d9b03fdb70681053e95) | `` gimme-aws-creds: 2.6.1 -> 2.7.0 ``                          |
| [`ca3fe351`](https://github.com/NixOS/nixpkgs/commit/ca3fe35107a3d47a431d77b250c264631e1b37b3) | `` esbuild: 0.18.7 -> 0.18.8 ``                                |
| [`922d55bf`](https://github.com/NixOS/nixpkgs/commit/922d55bf2df6f73ed24a98a479f0feffa7d9187d) | `` fetchgit: add a default NIX_BUILD_CORES variable ``         |
| [`f137da12`](https://github.com/NixOS/nixpkgs/commit/f137da12ddae928f2c3a29b55494412cc9096bf5) | `` scheme-manpages: 2023-03-26 -> 2023-06-04 ``                |
| [`a8c6640a`](https://github.com/NixOS/nixpkgs/commit/a8c6640a9c6f92e3b9445ddb2450c5bbfce8b1d1) | `` rubyPackages: update ``                                     |
| [`c3d3fa51`](https://github.com/NixOS/nixpkgs/commit/c3d3fa512fd1740a7cf174a4f3628fa6364fca96) | `` fluent-bit: 2.1.5 -> 2.1.6 ``                               |
| [`6838b3c6`](https://github.com/NixOS/nixpkgs/commit/6838b3c6472e15c620c3dc62f051f549ac06a392) | `` millet: 0.11.1 -> 0.11.3 ``                                 |
| [`7a36cb56`](https://github.com/NixOS/nixpkgs/commit/7a36cb5631bf7a53781c112b7728d5e444cff225) | `` esbuild: 0.18.6 -> 0.18.7 ``                                |
| [`4fce246b`](https://github.com/NixOS/nixpkgs/commit/4fce246b9f16896987f096f2d78cc649cc042eab) | `` scheme-manpages: add updateScript ``                        |
| [`0bb16f97`](https://github.com/NixOS/nixpkgs/commit/0bb16f97e91a740ba49b9cc3495c12532e3e3d72) | `` fluent-bit: add changelog to meta ``                        |
| [`5651d57b`](https://github.com/NixOS/nixpkgs/commit/5651d57bada9cd3d84ec289105b0be15a1224a5a) | `` vieb: 10.0.0 -> 10.1.0 ``                                   |
| [`da1b5e43`](https://github.com/NixOS/nixpkgs/commit/da1b5e43ef4adea2f6b3b2d1964465b42d361411) | `` planify: unstable-2023-04-20 -> 4.1 ``                      |
| [`b721d272`](https://github.com/NixOS/nixpkgs/commit/b721d2721487613940b2ac1f676360ba65d6dc2f) | `` planify: renamed from elementary-planner ``                 |
| [`a1ebe618`](https://github.com/NixOS/nixpkgs/commit/a1ebe618ab2dd23e0214b88c94cea9b1362c92ef) | `` python310Packages.google-cloud-vision: 3.4.2 -> 3.4.3 ``    |
| [`998b322e`](https://github.com/NixOS/nixpkgs/commit/998b322eac8d3900304554a77e43c209098b8125) | `` mimir: 2.8.0 -> 2.9.0 ``                                    |
| [`990e8b42`](https://github.com/NixOS/nixpkgs/commit/990e8b42395a55a5ebecf40f06fe9f3604b87d75) | `` dhcpdump: 1.8 -> 1.9, change upstream to maintained fork `` |
| [`2b792f74`](https://github.com/NixOS/nixpkgs/commit/2b792f74fdae6a7a2c1940c8bcedc02ed1b3404a) | `` python310Packages.psd-tools: 1.9.24 -> 1.9.26 ``            |
| [`bee3439a`](https://github.com/NixOS/nixpkgs/commit/bee3439ada66d82d98f21b228fb9a818d816498b) | `` lagrange: 1.16.4 -> 1.16.5 ``                               |