### PR TITLE
chore(flake/home-manager): `0ee5ab61` -> `4c08f65a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687647343,
-        "narHash": "sha256-1/o/i9KEFOBdlF9Cs04kBcqDFbYMt6W4SMqGa+QnnaI=",
+        "lastModified": 1687856573,
+        "narHash": "sha256-rzC+5rRsy92Dhjb1q5e5tDjdhRfL1z4WFWwlcD3a+4Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0ee5ab611dc1fbb5180bd7d88d2aeb7841a4d179",
+        "rev": "4c08f65ab5105a55eed3fc9003f3e6874b69fe13",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`4c08f65a`](https://github.com/nix-community/home-manager/commit/4c08f65ab5105a55eed3fc9003f3e6874b69fe13) | `` broot: fix test (#4170) `` |
| [`3bc1bc40`](https://github.com/nix-community/home-manager/commit/3bc1bc40121eb0975dc3d96741300bb4fd16be29) | `` antidote: fix .dot path `` |