### PR TITLE
chore(flake/nixpkgs): `1c9db971` -> `6b3d1b1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687681650,
-        "narHash": "sha256-M2If+gRcfpmaJy/XbfSsRzLlPpoU4nr0NHnKKl50fd8=",
+        "lastModified": 1687807295,
+        "narHash": "sha256-7TUD0p0m4mZpIi1O+Cyk5NCqpJUnhv/CJOAuHOndjao=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c9db9710cb23d60570ad4d7ab829c2d34403de3",
+        "rev": "6b3d1b1cf13f407fef5e634b224d575eb7211975",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`5f85fe1e`](https://github.com/NixOS/nixpkgs/commit/5f85fe1e8ae2a00004e854c7585bc0f8840c0009) | `` php83: init at 8.3.0alpha2 (#239151) ``                                    |
| [`cd3b6581`](https://github.com/NixOS/nixpkgs/commit/cd3b658167f4ada7e3d2bcd57cb0ec361fffcb27) | `` starship: Remove INSIDE_EMACS checks (#239039) ``                          |
| [`0bc45479`](https://github.com/NixOS/nixpkgs/commit/0bc45479528827c6321e5ff1fb7a2dc27a46ae2f) | `` typescript: repackage using buildNpmPackage (#239189) ``                   |
| [`89a9b36d`](https://github.com/NixOS/nixpkgs/commit/89a9b36d69b7ee03fbf4e9275431559ad083c89d) | `` jetbrains: fix application icon (#239416) ``                               |
| [`ba6c2290`](https://github.com/NixOS/nixpkgs/commit/ba6c2290374dbf1f9a10b22e71a13ad08564d5f9) | `` texlive: fix licensing information for doc-only-packages (#239528) ``      |
| [`f3db0b9e`](https://github.com/NixOS/nixpkgs/commit/f3db0b9eecbfd3476985e4a027037494683f955a) | `` grass: 8.2.1 -> 8.3.0 (#239901) ``                                         |
| [`c7bb1914`](https://github.com/NixOS/nixpkgs/commit/c7bb191426b5d3676e389954b38683ec8c0458d3) | `` scaphandre: init at 0.5.0 (#238462) ``                                     |
| [`54aa8027`](https://github.com/NixOS/nixpkgs/commit/54aa80274903dc870a92242cc837b298daa571c2) | `` signalbackup-tools: 20230625 -> 20230626 ``                                |
| [`29f4668b`](https://github.com/NixOS/nixpkgs/commit/29f4668bf6506aa36ffe3a587f32d113fe8ec1b8) | `` gopls: 0.12.2 -> 0.12.4 (#239950) ``                                       |
| [`6ff0f1b4`](https://github.com/NixOS/nixpkgs/commit/6ff0f1b4d8ea5a68bf5da79af45f572a043b45b5) | `` python310Packages.stdlib-list: 0.8.0 -> 0.9.0 ``                           |
| [`9ee81287`](https://github.com/NixOS/nixpkgs/commit/9ee812871e60ce198eecd3da8a4ee71603cf9b6b) | `` python310Packages.trainer: 0.0.26 -> 0.0.27 ``                             |
| [`67145257`](https://github.com/NixOS/nixpkgs/commit/671452579d56e0cace9a666a41c57ef1a3d09c7b) | `` fastddsgen: 2.5.0 -> 2.5.1 ``                                              |
| [`d954e015`](https://github.com/NixOS/nixpkgs/commit/d954e0153f63085334cfa4b08769b228af493281) | `` notation: init at 1.0.0-rc.7 ``                                            |
| [`820cdadd`](https://github.com/NixOS/nixpkgs/commit/820cdadd03c85c7f699148d7a7015fa14c29dd1c) | `` python310Packages.ttp: 0.9.4 -> 0.9.5 ``                                   |
| [`c8fff7bf`](https://github.com/NixOS/nixpkgs/commit/c8fff7bfc92f3b4bd4861c230dee9d1dbf6d3256) | `` python310Packages.pdm-backend: 2.1.0 -> 2.1.1 ``                           |
| [`c74fd7d1`](https://github.com/NixOS/nixpkgs/commit/c74fd7d1f80bd351265db9f2ed5d9dbff239501f) | `` postgresqlPackages.pgroonga: 3.0.7 -> 3.0.8, use msgpack-c ``              |
| [`5e94616b`](https://github.com/NixOS/nixpkgs/commit/5e94616bdbf99eae27a5274f7bcc845ef07ffe0d) | `` cockpit: specify --with-admin-group ``                                     |
| [`b508e902`](https://github.com/NixOS/nixpkgs/commit/b508e902eb3b23a793650ff9d12423e38a5b0f6e) | `` aaaaxy: 1.4.8 -> 1.4.18 ``                                                 |
| [`f06c6f75`](https://github.com/NixOS/nixpkgs/commit/f06c6f75232bef6535f608900c8c05c10a52ba18) | `` typos: 1.15.5 -> 1.15.6 ``                                                 |
| [`cd22d95a`](https://github.com/NixOS/nixpkgs/commit/cd22d95a54eda5030c078c5a7ddf60d5c3ff89e0) | `` proxysql: set platforms ``                                                 |
| [`9075cd9e`](https://github.com/NixOS/nixpkgs/commit/9075cd9e11d22d72362fa363229a441a49bce02b) | `` nixos/pixelfed: Fix missing php modules for pixelfed-horizon ``            |
| [`387db5f6`](https://github.com/NixOS/nixpkgs/commit/387db5f6d269fdd49598f95edda63e6cfc0d8f04) | `` sssd: 2.9.0 -> 2.9.1 ``                                                    |
| [`c1f7bff1`](https://github.com/NixOS/nixpkgs/commit/c1f7bff15f58bb52a049a878346ebe38993716f5) | `` saml2aws: 2.36.8 -> 2.36.9 ``                                              |
| [`be10d3e7`](https://github.com/NixOS/nixpkgs/commit/be10d3e74bde445af511a399d082dc7dc5c1c89a) | `` gnucash: 5.1 -> 5.2 ``                                                     |
| [`a7e6734a`](https://github.com/NixOS/nixpkgs/commit/a7e6734a25a28f22be134370ad44d5e4610370e2) | `` openai-whisper-cpp: refactor ``                                            |
| [`d4619023`](https://github.com/NixOS/nixpkgs/commit/d4619023df6f2d124a971492f700ca8b398d468b) | `` python310Packages.matplotx: init at 0.3.10 (#227075) ``                    |
| [`95639352`](https://github.com/NixOS/nixpkgs/commit/95639352ac4b94b2a049e09cef928accdad6d3ff) | `` tmuxp: remove pypkgs binding to avoid indirection ``                       |
| [`643ed535`](https://github.com/NixOS/nixpkgs/commit/643ed5356431bc81d538c845f61e04336b58b633) | `` tmuxp: fix shell completion generation ``                                  |
| [`2c8970cd`](https://github.com/NixOS/nixpkgs/commit/2c8970cdec95dda7ddcbf1ba6cfe2da7597c8380) | `` fclones-gui: 0.1.2 -> 0.1.3 ``                                             |
| [`4d3fa827`](https://github.com/NixOS/nixpkgs/commit/4d3fa82730ebf949a8fb85a18285126ca0247bdf) | `` firefox-devedition-unwrapped: 115.0b7 -> 115.0b9 ``                        |
| [`787a4063`](https://github.com/NixOS/nixpkgs/commit/787a40631ee043cb31283a5945ae5565b08d1504) | `` firefox-beta-unwrapped: 115.0b7 -> 115.0b9 ``                              |
| [`cb8fdc49`](https://github.com/NixOS/nixpkgs/commit/cb8fdc49eade981922d2618e00b9c834c3c9eab8) | `` qjackctl: 0.9.10 -> 0.9.11 ``                                              |
| [`d5999dd3`](https://github.com/NixOS/nixpkgs/commit/d5999dd34144275cd20e0cd1d05bcb5fce04a9a1) | `` buildbot: unset SQLALCHEMY_SILENCE_UBER_WARNING ``                         |
| [`2ae9035a`](https://github.com/NixOS/nixpkgs/commit/2ae9035ab3698cdcf44966646e19b5d3d7792705) | `` cargo-nextest: 0.9.53 -> 0.9.54 ``                                         |
| [`65709bc7`](https://github.com/NixOS/nixpkgs/commit/65709bc7104d22c31d739e4b2af235bba0e9ef80) | `` cargo-hakari: 0.9.25 -> 0.9.26 ``                                          |
| [`dcf3973d`](https://github.com/NixOS/nixpkgs/commit/dcf3973ddda395e15ce3bccb6908e61b198bbc20) | `` cargo-guppy: unstable-2023-06-19 -> unstable-2023-06-26 ``                 |
| [`f4810094`](https://github.com/NixOS/nixpkgs/commit/f4810094ecd07eff5e59c52a15c47439100966b6) | `` python310Packages.pyglet: 2.0.7 -> 2.0.8 ``                                |
| [`44ecf1cd`](https://github.com/NixOS/nixpkgs/commit/44ecf1cd185ca7a6d0349d09b95e638ade605bf0) | `` openai-whisper-cpp: enable CoreML support ``                               |
| [`7d7d7c75`](https://github.com/NixOS/nixpkgs/commit/7d7d7c754d886369a7dbc66d34a11344f00dbc7c) | `` libnatpmp: fix install ``                                                  |
| [`597d5f8d`](https://github.com/NixOS/nixpkgs/commit/597d5f8dc58c3edda5cd0e6b731b78a971986eb0) | `` Revert "mupdf: actually build and install the shared libraries version" `` |
| [`79c340db`](https://github.com/NixOS/nixpkgs/commit/79c340db2e2183a629a785d5c6876e1f7c5c8693) | `` git-relevant-history: init package at 2022-09-15 (#238952) ``              |
| [`466af506`](https://github.com/NixOS/nixpkgs/commit/466af5066e11492309bf7cf2af0a8ea51bdca90c) | `` ligo: Fix hash after tag mutation ``                                       |
| [`42e6f4ca`](https://github.com/NixOS/nixpkgs/commit/42e6f4ca71f594937a2dc15a93e733fd9ee5a41e) | `` gst_all_1.gst-plugins-rs: add temporary fix for cargo-c test issue ``      |
| [`c6a67ebb`](https://github.com/NixOS/nixpkgs/commit/c6a67ebb4b9ee8164b88731c69f0d721b3d6d4c0) | `` oh-my-zsh: 2023-06-20 -> 2023-06-26 ``                                     |
| [`9bfe8ede`](https://github.com/NixOS/nixpkgs/commit/9bfe8edebf5ffa38701d6830331debb71feac730) | `` python310Packages.plaid-python: 13.0.0 -> 14.1.0 ``                        |
| [`232c3e58`](https://github.com/NixOS/nixpkgs/commit/232c3e580486db48cec638d65211ea3cde41064c) | `` megapixels: 1.6.0 -> 1.6.1 ``                                              |
| [`58b2aca0`](https://github.com/NixOS/nixpkgs/commit/58b2aca074931f09de1732ba41d8a010ccafcbf8) | `` python310Packages.pydrive2: 1.15.4 -> 1.16.0 ``                            |
| [`d6ac0eda`](https://github.com/NixOS/nixpkgs/commit/d6ac0eda244d44017fda5f4464f13c99953ea716) | `` basu: supply missing getent after PR #236458 ``                            |
| [`e17f4dae`](https://github.com/NixOS/nixpkgs/commit/e17f4dae6f3c7cb176804be4c5a610ce0612dd71) | `` lib/path/tests/prop.sh: Add --show-trace ``                                |
| [`050e7e29`](https://github.com/NixOS/nixpkgs/commit/050e7e29aac1606a64b7a189b0affbc6a8e497df) | `` lib/path/tests: Add --show-trace ``                                        |
| [`a28d962e`](https://github.com/NixOS/nixpkgs/commit/a28d962e11d39961552c3f6bad2e65816c2dcc31) | `` seafile-client: 8.0.7 -> 9.0.2 ``                                          |
| [`ecb84855`](https://github.com/NixOS/nixpkgs/commit/ecb8485514605749222e0f99c40168d97df0d4c7) | `` seafile-shared: 8.0.3 -> 9.0.2 ``                                          |
| [`60551488`](https://github.com/NixOS/nixpkgs/commit/6055148854621134dcca323014715e76d2103d15) | `` libsearpc: 3.2.0 -> 3.3-20230626 ``                                        |
| [`24711148`](https://github.com/NixOS/nixpkgs/commit/24711148d4c74b862dd3dcf7d900005932e24e5b) | `` openmvg: fixup build ``                                                    |
| [`bce7225a`](https://github.com/NixOS/nixpkgs/commit/bce7225aa91ae798d9028e36451e34219ebd09b2) | `` weechat-unwrapped: fix build with missing features ``                      |
| [`13262165`](https://github.com/NixOS/nixpkgs/commit/13262165469ec7ba8181e8888757dc47e6c64ae9) | `` jackett: 0.21.314 -> 0.21.327 ``                                           |
| [`2e7efc14`](https://github.com/NixOS/nixpkgs/commit/2e7efc14f29d4f67eb479349ba2d8e4f6ec4f11f) | `` drawio: 21.4.0 -> 21.5.0 ``                                                |
| [`3959a7be`](https://github.com/NixOS/nixpkgs/commit/3959a7bef56c7ee9caefb04a5722569460b0a36b) | `` nixos/qemu: set qemuSerialDevice for loongarch64 ``                        |
| [`d542764a`](https://github.com/NixOS/nixpkgs/commit/d542764a22e0b3f4fa026642f8bb286d3b778fd2) | `` btcd: 0.23.3 -> 0.23.4 ``                                                  |
| [`e3cbd650`](https://github.com/NixOS/nixpkgs/commit/e3cbd650f503ffe059cac271b20e47fd6afebcc1) | `` stratovirt: add micro_vm-allow-SYS_clock_gettime.patch ``                  |
| [`4ef8777e`](https://github.com/NixOS/nixpkgs/commit/4ef8777e3c0b3634039208c0d9e69200b5adbf9b) | `` openvscode-server: 1.79.1 -> 1.79.2 ``                                     |
| [`d6ad2260`](https://github.com/NixOS/nixpkgs/commit/d6ad2260206b164a1d74ec2166cde7ae3b9dc343) | `` awsume: init at 4.5.3 ``                                                   |
| [`9a6b99ec`](https://github.com/NixOS/nixpkgs/commit/9a6b99ec5acb7e6cb572f54dd2a92dade66680e8) | `` cod: mark package as not broken on linux ``                                |
| [`109633be`](https://github.com/NixOS/nixpkgs/commit/109633bef055415528456848bbbe93fdfdfb73ba) | `` gst_all_1.gst-plugins-rs: drop the raptorq test everywhere ``              |
| [`6b8cefb4`](https://github.com/NixOS/nixpkgs/commit/6b8cefb40bf149dddfa51c7c3c38301b7894006d) | `` python310Packages.ytmusicapi: 1.0.2 -> 1.1.0 ``                            |
| [`be3f9ce9`](https://github.com/NixOS/nixpkgs/commit/be3f9ce9e2f75ed49782036a7df2de3d81d5d3d9) | `` python311Packages.pyezviz: 0.2.1.3 -> 0.2.1.6 ``                           |
| [`b7abbd1a`](https://github.com/NixOS/nixpkgs/commit/b7abbd1a242a839bfe28cd1fbcab9c8a4c40397a) | `` snac2: 2.31 -> 2.35 ``                                                     |
| [`88703715`](https://github.com/NixOS/nixpkgs/commit/8870371562828a4f18bdda5b559fcdbeeede6a3e) | `` knot-dns: 3.2.7 -> 3.2.8 ``                                                |
| [`d123c351`](https://github.com/NixOS/nixpkgs/commit/d123c351d107e7043528dbebbf4f812ae194412e) | `` libgbinder: 1.1.33 -> 1.1.34 ``                                            |
| [`d127b831`](https://github.com/NixOS/nixpkgs/commit/d127b831b50b0cd8880c06ac946ffdf0d5997b07) | `` fastjet: 3.4.0 -> 3.4.1 ``                                                 |
| [`eb9c56e3`](https://github.com/NixOS/nixpkgs/commit/eb9c56e3c401f21ee8b045fb646230b0c561804d) | `` python311Packages.mt-940: enable tests ``                                  |
| [`f76121ff`](https://github.com/NixOS/nixpkgs/commit/f76121ffe4ffbc77ef7e2dfcab1f3adc707f2e0b) | `` python310Packages.mt-940: add changelog to meta ``                         |
| [`b9ddf070`](https://github.com/NixOS/nixpkgs/commit/b9ddf07050dfa9c58090e5e06245a774a791e6a9) | `` python311Packages.hahomematic: 2023.6.0 -> 2023.6.1 ``                     |
| [`4fee5002`](https://github.com/NixOS/nixpkgs/commit/4fee50025618c4e8135fccce190c62afce1546c9) | `` python311Packages.fastapi-mail: 1.2.8 -> 1.3.0 ``                          |
| [`8b3bdd95`](https://github.com/NixOS/nixpkgs/commit/8b3bdd95800f373474abeebf3bcad77a17c4ce84) | `` python311Packages.env-canada: 0.5.34 -> 0.5.35 ``                          |
| [`b3cdc496`](https://github.com/NixOS/nixpkgs/commit/b3cdc49627b4ef8dcf32a012555437d97ecc2854) | `` python310Packages.rq: 1.15 -> 1.15.1 ``                                    |
| [`dc7641c3`](https://github.com/NixOS/nixpkgs/commit/dc7641c3fd8ad4cc4c21d94cb2081b39130701a3) | `` yaydl: init at 0.13.0 ``                                                   |
| [`12bd7ee3`](https://github.com/NixOS/nixpkgs/commit/12bd7ee3e0e7886af5648441d2e370face79b8a6) | `` erlang_26: 26.0 -> 26.0.1 ``                                               |
| [`cb26e423`](https://github.com/NixOS/nixpkgs/commit/cb26e4230dedb788f9612d00332b11efac003da7) | `` clickhouse: 23.3.3.52 -> 23.3.5.9 ``                                       |
| [`850cfffa`](https://github.com/NixOS/nixpkgs/commit/850cfffabc40ce79dbaec027be15c8d57749e35b) | `` python3Packages.tensorly: 0.8.0 -> 0.8.1 re-enabled tests ``               |
| [`0836e162`](https://github.com/NixOS/nixpkgs/commit/0836e1621d5e27e009fcb773ca6815d10f919d00) | `` hydra_unstable: 2023-03-27 -> 2023-06-25 ``                                |
| [`8396ec6f`](https://github.com/NixOS/nixpkgs/commit/8396ec6f6d68c2eff29b5a74aee1f47c0c26b35b) | `` python310Packages.mt-940: 4.28.0 -> 4.30.0 ``                              |
| [`9d746127`](https://github.com/NixOS/nixpkgs/commit/9d746127bc6a7e3d8f52dbf4811f5344cba75b50) | `` esbuild: 0.18.8 -> 0.18.9 ``                                               |
| [`713324f5`](https://github.com/NixOS/nixpkgs/commit/713324f5fd59833f5c5c4e0cc840fb8119baf8db) | `` duckscript: 0.8.19 -> 0.8.20 ``                                            |
| [`85b47261`](https://github.com/NixOS/nixpkgs/commit/85b47261a17a6b27bd75cf33a4d076ad6395d00c) | `` maintainers: add earthengine ``                                            |
| [`c01687ad`](https://github.com/NixOS/nixpkgs/commit/c01687ad363828bc4bb288c13090c1fe56c32ac6) | `` maintainers/team-list: add siraben to minimal-bootstrap ``                 |
| [`8c581c40`](https://github.com/NixOS/nixpkgs/commit/8c581c406832d14d572e17a4cd53d8ff9fc0bf76) | `` chezmoi: 2.34.1 -> 2.34.2 ``                                               |