### PR TITLE
chore(flake/stylix): `383d7306` -> `7dfce721`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -420,11 +420,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687088160,
-        "narHash": "sha256-llpm6lUqvEZI4cQq62eO6lD8V3VOt2h6ZHiEY6LXVZM=",
+        "lastModified": 1687876430,
+        "narHash": "sha256-c1fXtnyQNm9HQ74NSsrvTi1ZrbRpIyIRrR2+4Ozg2j0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "383d7306df0450603816852baf9b992a431bb82e",
+        "rev": "7dfce721b923549a773bf32c16515ebf1a509dae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                              |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`7dfce721`](https://github.com/danth/stylix/commit/7dfce721b923549a773bf32c16515ebf1a509dae) | `` Fix Zellij selection highlight (#112) ``                          |
| [`91979967`](https://github.com/danth/stylix/commit/9197996704df974a073d83e3c793b8e11282fa11) | `` Fix Actions workflow on MacOS :construction_worker: :arrow_up: `` |