### PR TITLE
chore(flake/home-manager): `9dd107a1` -> `47c2adc6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687901550,
-        "narHash": "sha256-p0AWnbv6+6dxBgvTZuvMHu9FW/spaISiT9k+r4bWm2g=",
+        "lastModified": 1687945268,
+        "narHash": "sha256-Fto5zvy6/mjFLF8cOFUdZkZOwQnQ9snpaAf6qSBP8/8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9dd107a1d5395fae9b969597e02f3ef3a43ddd47",
+        "rev": "47c2adc6b31e9cff335010f570814e44418e2b3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`47c2adc6`](https://github.com/nix-community/home-manager/commit/47c2adc6b31e9cff335010f570814e44418e2b3e) | `` docs: update link to allowed users setting (#4176) ``           |
| [`f5f64ac0`](https://github.com/nix-community/home-manager/commit/f5f64ac022ed379442286a4e81a2a7cdc552cb28) | `` zsh: allow setting custom syntax highlighting styles (#4122) `` |