### PR TITLE
chore(flake/nixpkgs): `6b3d1b1c` -> `4ffc4dc9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687807295,
-        "narHash": "sha256-7TUD0p0m4mZpIi1O+Cyk5NCqpJUnhv/CJOAuHOndjao=",
+        "lastModified": 1688141540,
+        "narHash": "sha256-xh2aLD8R6gau+O+9h1ad+OAjCAj07lCKsY44+p/bJS8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6b3d1b1cf13f407fef5e634b224d575eb7211975",
+        "rev": "4ffc4dc91838df228c8214162c106c24ec8fe03f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                  |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`7f9d0dca`](https://github.com/NixOS/nixpkgs/commit/7f9d0dcaccf83c7592bf42fe5b304f669eae3a36) | `` labeler: label nodejs pull-requests ``                                |
| [`78e7de27`](https://github.com/NixOS/nixpkgs/commit/78e7de270c22bde17f24b70952604e4b6a5b53c7) | `` charasay: 2.1.0 -> 3.0.0 ``                                           |
| [`fd42e163`](https://github.com/NixOS/nixpkgs/commit/fd42e1630e8ee0985cea8f67a51e6a09a940d729) | `` nexus: 3.45.0-01 -> 3.52.0-01 ``                                      |
| [`9888b3e9`](https://github.com/NixOS/nixpkgs/commit/9888b3e981de7e781f1d18d66038e8346c2f02ed) | `` teams-for-linux: 1.1.6 -> 1.1.8 ``                                    |
| [`ca3ba6dc`](https://github.com/NixOS/nixpkgs/commit/ca3ba6dc3ecda0971f916f3b19fa9aad0bd168d0) | `` exoscale-cli: 1.70.0 -> 1.71.0 (#240707) ``                           |
| [`9def595d`](https://github.com/NixOS/nixpkgs/commit/9def595d0070564f673ab25c6d0c398172eec957) | `` doc: add a note about automatic maven upgrades (#238774) ``           |
| [`cdc986c9`](https://github.com/NixOS/nixpkgs/commit/cdc986c996d388a1688debd29d51140118a62859) | `` gusb: Re-introduce API docs ``                                        |
| [`d19ab9f1`](https://github.com/NixOS/nixpkgs/commit/d19ab9f1da330769690476120432e060893c4f25) | `` nixos/gnupg: fix pinentryFlavor documentation and add release note `` |
| [`eb9322a0`](https://github.com/NixOS/nixpkgs/commit/eb9322a008b65d51bb9c0bd028afad11a4dc547e) | `` erlang_odbc: 25.3.2.2 -> 25.3.2.3 ``                                  |
| [`b97e1851`](https://github.com/NixOS/nixpkgs/commit/b97e1851ddce6af486c89642780014c3c9e3a71e) | `` i3status-rust: 0.31.7 -> 0.31.8 ``                                    |
| [`51dbaf51`](https://github.com/NixOS/nixpkgs/commit/51dbaf51b201eb3b6a0f4561e0e6d448a90b3146) | `` python310Packages.fipy: 3.4.3 -> 3.4.4 (#240581) ``                   |
| [`9ee9f2cc`](https://github.com/NixOS/nixpkgs/commit/9ee9f2ccc486f969e56ebc8b1f3ffd75e286a93f) | `` sitespeed-io: fix npmDepsHash ``                                      |
| [`04ae8fff`](https://github.com/NixOS/nixpkgs/commit/04ae8fffa73f05a25e14ff5ca4f0e51958bfe0a1) | `` beets: disable failing test ``                                        |
| [`6cd1d0b3`](https://github.com/NixOS/nixpkgs/commit/6cd1d0b3795880238357161044d3e020bc32d4f7) | `` kubefirst: 2.1.7 -> 2.2.0 ``                                          |
| [`2f934fb7`](https://github.com/NixOS/nixpkgs/commit/2f934fb7cf2bb73c13e1730cf05f63fc1e1e6ed2) | `` endlessh-go: 20230613 -> 20230625-3 ``                                |
| [`78ca8b7d`](https://github.com/NixOS/nixpkgs/commit/78ca8b7d75b2a6f615dba1d4cd978ab9ca663464) | `` stripe-cli: 1.14.7 -> 1.15.0 ``                                       |
| [`7c8e8c24`](https://github.com/NixOS/nixpkgs/commit/7c8e8c249874c28e8f5f2195ed95ebb351d2297b) | `` perlPackages.LatexIndent: init at 3.21 ``                             |
| [`dc4d580d`](https://github.com/NixOS/nixpkgs/commit/dc4d580db26690ba375069a73b4fa9fc14b1a64c) | `` erlang_26: 26.0.1 -> 26.0.2 ``                                        |
| [`a50a0424`](https://github.com/NixOS/nixpkgs/commit/a50a0424eddd45241ff950ed263b740c2d676622) | `` vhdl-ls: 0.64.0 -> 0.65.0 ``                                          |
| [`ce668812`](https://github.com/NixOS/nixpkgs/commit/ce6688126fc79e3e640c03d143bb70988a56bf97) | `` rssguard: add changelog to meta ``                                    |
| [`3d4f3068`](https://github.com/NixOS/nixpkgs/commit/3d4f3068fd2df3a6268f4f5a952026932991a6f0) | `` nixos/gnupg: fix gpg-agent when pinentryFlavor is null ``             |
| [`8247ce5c`](https://github.com/NixOS/nixpkgs/commit/8247ce5cb990008c3e73b492a638398abfc3b3ff) | `` discord: make desktopItem overrideable ``                             |
| [`025d3fe5`](https://github.com/NixOS/nixpkgs/commit/025d3fe5a5bd30bf210bd6a83c6fc27128babcc5) | `` python3Packages.asyncinotify: init at 4.0.1 ``                        |
| [`e94b17e9`](https://github.com/NixOS/nixpkgs/commit/e94b17e9be031a6941dd0d0c36b00531d84d52d3) | `` rssguard: 4.3.4 -> 4.4.0 ``                                           |
| [`28eef09b`](https://github.com/NixOS/nixpkgs/commit/28eef09b57ecd16f2008560565ebb92454c89d19) | `` cnspec: 8.15.0 -> 8.16.0 ``                                           |
| [`2e55bb1b`](https://github.com/NixOS/nixpkgs/commit/2e55bb1b2d45c210bd155c4208e11301303a60a2) | `` roxctl: 4.0.2 -> 4.1.0 ``                                             |
| [`5c4696df`](https://github.com/NixOS/nixpkgs/commit/5c4696df8a3daea0d5a00380267406ef45ef980c) | `` coeurl: Add upstream commits that fix build ``                        |
| [`47011874`](https://github.com/NixOS/nixpkgs/commit/47011874388d6d084d2bb4f411128e500aed0fcb) | `` terragrunt: 0.47.0 -> 0.48.0 ``                                       |
| [`4ae51c85`](https://github.com/NixOS/nixpkgs/commit/4ae51c8576357bd8d2681dd96cb3ad0dcaa4696d) | `` snabb: 2023.04 -> 2023.06 ``                                          |
| [`503e9f3d`](https://github.com/NixOS/nixpkgs/commit/503e9f3d972c82ea3529597e218d8b8bd04571a4) | `` erlang_24: 24.3.4.12 -> 24.3.4.13 ``                                  |
| [`0b4473b6`](https://github.com/NixOS/nixpkgs/commit/0b4473b6cadbc38099d037662f57fa2a6ad4ca10) | `` datree: 1.9.6 -> 1.9.8 ``                                             |
| [`149d54be`](https://github.com/NixOS/nixpkgs/commit/149d54be5cc82b556826b44a75b07013ed5d8d39) | `` regctl: 0.4.8 -> 0.5.0 ``                                             |
| [`9e111b28`](https://github.com/NixOS/nixpkgs/commit/9e111b2820c3b6ec887999401fb826a82deacf8f) | `` lieer: add format ``                                                  |
| [`2f8b76be`](https://github.com/NixOS/nixpkgs/commit/2f8b76be563dbce1e05efdc6b147649618e255e2) | `` ocamlPackages.sedlex: 3.1 -> 3.2 ``                                   |
| [`39e075ba`](https://github.com/NixOS/nixpkgs/commit/39e075baed5ea842623d3b9d86b3d428dbf78452) | `` python310Packages.solc-select: 1.0.3 -> 1.0.4 ``                      |
| [`9afae37e`](https://github.com/NixOS/nixpkgs/commit/9afae37e497b363e4d56a57dc9e942457c902bf5) | `` moonlight-qt: fix build on x86_64-darwin ``                           |
| [`077f3cef`](https://github.com/NixOS/nixpkgs/commit/077f3cef68b9abfba685353ca795c742a11f4a66) | `` python310Packages.django-vite: 2.1.1 -> 2.1.3 ``                      |
| [`0b6f6e18`](https://github.com/NixOS/nixpkgs/commit/0b6f6e184eb40e67a53746af4cd3c24c995441ee) | `` github-backup: add format ``                                          |
| [`2915aa91`](https://github.com/NixOS/nixpkgs/commit/2915aa91188739c90bbcb5d0fbba886c78f38b8a) | `` github-backup: add changelog to meta ``                               |
| [`1adc3782`](https://github.com/NixOS/nixpkgs/commit/1adc378290f65391da2dcff5841232eba1bebe5e) | `` github-backup: 0.42.0 -> 0.43.1 ``                                    |
| [`f33ce791`](https://github.com/NixOS/nixpkgs/commit/f33ce791bdba58bb75b381824d205643254d6652) | `` python311Packages.google-cloud-bigquery: 3.11.2 -> 3.11.3 ``          |
| [`d9aedfc3`](https://github.com/NixOS/nixpkgs/commit/d9aedfc39d712cf877f46c37fc0a2167b387b48a) | `` python311Packages.google-cloud-container: 2.24.0 -> 2.25.0 ``         |
| [`5551481e`](https://github.com/NixOS/nixpkgs/commit/5551481e9698b4972dca5cb45f73f9c7161019df) | `` python311Packages.google-cloud-securitycenter: 1.22.0 -> 1.23.0 ``    |
| [`55c45755`](https://github.com/NixOS/nixpkgs/commit/55c457557a6a29bf6074f24a66a3c35be810b26b) | `` python311Packages.elementpath: 4.1.3 -> 4.1.4 ``                      |
| [`bd25195c`](https://github.com/NixOS/nixpkgs/commit/bd25195c849d03ec827791e02f0a5f34ebcc6973) | `` python311Packages.emoji: 2.5.1 -> 2.6.0 ``                            |
| [`4fe16da9`](https://github.com/NixOS/nixpkgs/commit/4fe16da9ba836cb2a70753f51f0f2f6106ac97d5) | `` python311Packages.strenum: 0.4.10 -> 0.4.15 ``                        |
| [`ea30de5d`](https://github.com/NixOS/nixpkgs/commit/ea30de5da887784a5f60c86683d2120e261c4b34) | `` python311Packages.html-sanitizer: 1.9.3 -> 2.1 ``                     |
| [`b8319214`](https://github.com/NixOS/nixpkgs/commit/b83192144f73b0fe664157bda143e4a93944d043) | `` python311Packages.html-sanitizer: add format ``                       |
| [`1473d85e`](https://github.com/NixOS/nixpkgs/commit/1473d85ec01cab2e68b253556a9ffb60274042eb) | `` python311Packages.html-sanitizer: add changelog to meta ``            |
| [`ddc113bd`](https://github.com/NixOS/nixpkgs/commit/ddc113bd3d19f3876e96c2b67eb3e1a92b1320ee) | `` python311Packages.cyclonedx-python-lib: 4.0.0 -> 4.0.1 ``             |
| [`6be497ab`](https://github.com/NixOS/nixpkgs/commit/6be497ab1914241fb0dbfc50ea4bbd66dc76b72c) | `` trufflehog: 3.41.1 -> 3.42.0 ``                                       |
| [`c2714040`](https://github.com/NixOS/nixpkgs/commit/c2714040e32bdc02f8ef9d7dcfe5add8e749d0b8) | `` checkov: 2.3.303 -> 2.3.309 ``                                        |
| [`d5e43d9d`](https://github.com/NixOS/nixpkgs/commit/d5e43d9dae33c36301483f6f393aa92084afffb3) | `` python311Packages.confection: 0.0.4 -> 0.1.0 ``                       |
| [`bbdd411a`](https://github.com/NixOS/nixpkgs/commit/bbdd411abf9d1449614cba319cc153b29663c87b) | `` python310Packages.deep-translator: 1.11.1 -> 1.11.4 ``                |
| [`5ff9c5aa`](https://github.com/NixOS/nixpkgs/commit/5ff9c5aaa972c8c999eae5de629a547114849519) | `` python311Packages.dvc-data: 2.3.0 -> 2.3.1 ``                         |
| [`0e1aec56`](https://github.com/NixOS/nixpkgs/commit/0e1aec56d35468d80dbb1db4576402c74a29fcf2) | `` python311Packages.appthreat-vulnerability-db: 5.1.3 -> 5.1.4 ``       |
| [`2c022937`](https://github.com/NixOS/nixpkgs/commit/2c0229372e69686c9a42bcd94803f5a2318b084d) | `` python311Packages.django-cacheops: mark as broken ``                  |
| [`e4e42fb2`](https://github.com/NixOS/nixpkgs/commit/e4e42fb274cce53a9c4a5a03d4a30e31c1637124) | `` vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.15.1 -> 0.15.2 ``    |
| [`f76db9c2`](https://github.com/NixOS/nixpkgs/commit/f76db9c2e77bc2e8236056a3a911ee75d67f3d81) | `` phpExtensions.yaml: fix build ``                                      |
| [`6098bec8`](https://github.com/NixOS/nixpkgs/commit/6098bec8da3cd7dec38bd14c5bd4af67c7d17fcf) | `` phpExtensions.yaml: 2.2.2 -> 2.2.3 ``                                 |
| [`5eab4d20`](https://github.com/NixOS/nixpkgs/commit/5eab4d200a08348fcffc73baf136cd839d410c95) | `` awscli2: 2.12.3 -> 2.12.5 ``                                          |
| [`ac1c6209`](https://github.com/NixOS/nixpkgs/commit/ac1c6209f5f95209475041b6bdc76ca435331d51) | `` mdbook: 0.4.30 -> 0.4.31 ``                                           |
| [`c9e5e693`](https://github.com/NixOS/nixpkgs/commit/c9e5e69390bbda63b3af40a42d3c3dd8f4d42f36) | `` terraform-providers.signalfx: 6.24.0 -> 7.0.0 ``                      |
| [`e999f059`](https://github.com/NixOS/nixpkgs/commit/e999f0598c230203211049e3524d6b4adefdc468) | `` terraform-providers.opentelekomcloud: 1.35.1 -> 1.35.2 ``             |
| [`6024d285`](https://github.com/NixOS/nixpkgs/commit/6024d285c6641a71e8a2d3f4590d64c6edc8b3ef) | `` terraform-providers.opsgenie: 0.6.25 -> 0.6.26 ``                     |
| [`c69567e9`](https://github.com/NixOS/nixpkgs/commit/c69567e915e07ebc3d8bb2fed3add7e751cb8b4b) | `` terraform-providers.aws: 5.5.0 -> 5.6.1 ``                            |
| [`a910bcf5`](https://github.com/NixOS/nixpkgs/commit/a910bcf570e193889518da3ec2adbb4f0254b0cf) | `` terraform-providers.openstack: 1.51.1 -> 1.52.1 ``                    |
| [`45df9084`](https://github.com/NixOS/nixpkgs/commit/45df90842df16ad9c5a28d3dcf44ff695ce89347) | `` terraform-providers.linode: 2.5.0 -> 2.5.1 ``                         |
| [`1e34e34d`](https://github.com/NixOS/nixpkgs/commit/1e34e34d01166338f67049bbd23d9c984815567f) | `` terraform-providers.fastly: 5.2.1 -> 5.2.2 ``                         |
| [`6738295d`](https://github.com/NixOS/nixpkgs/commit/6738295d2d28e516434c025f7ee5d78ad5ac2e5a) | `` terraform-providers.azurerm: 3.62.1 -> 3.63.0 ``                      |
| [`7a85effd`](https://github.com/NixOS/nixpkgs/commit/7a85effdc482861787a0c4f456c91b512a3e8bf1) | `` terraform-providers.aiven: 4.5.0 -> 4.6.0 ``                          |
| [`1d1180f2`](https://github.com/NixOS/nixpkgs/commit/1d1180f293d362f8316e5be168a30921b7f60ec4) | `` libisofs: 1.5.4 -> 1.5.6.pl01 ``                                      |
| [`25ed414b`](https://github.com/NixOS/nixpkgs/commit/25ed414b2be0e7b9a5adbacc07a198653a72b019) | `` gusb: 0.3.10 -> 0.4.6 ``                                              |
| [`7d3ddc5d`](https://github.com/NixOS/nixpkgs/commit/7d3ddc5d1b7187ba26a4318990c97e822d21c37b) | `` cargo-llvm-voc: 0.5.20 -> 0.5.22 ``                                   |
| [`5d5ff000`](https://github.com/NixOS/nixpkgs/commit/5d5ff000209bc15bdd23fbc50afe52be48208818) | `` libeatmydata: 105 -> 131 ``                                           |
| [`067aec55`](https://github.com/NixOS/nixpkgs/commit/067aec55893b052e834c04b5b1df9c9f67e50fcd) | `` python310Packages.thorlabspm100: init at 1.2.2 ``                     |
| [`002ffb88`](https://github.com/NixOS/nixpkgs/commit/002ffb885a6b62e3ee2073145722fe616bf07757) | `` coq: 8.17.0 → 8.17.1 ``                                               |
| [`3c614fbc`](https://github.com/NixOS/nixpkgs/commit/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb) | `` teyjus: unstable-2019-07-26 -> 2.1.1 ``                               |
| [`789c8ea1`](https://github.com/NixOS/nixpkgs/commit/789c8ea11c5550ccbbb98ae73ebc78f0d8adf2c9) | `` webkitgtk: 2.40.2 → 2.40.3 ``                                         |
| [`8794b4fa`](https://github.com/NixOS/nixpkgs/commit/8794b4fa5ccceee6ae07e1525f31a4211754e2fc) | `` iwd: 2.5 -> 2.6 ``                                                    |
| [`e5bcc773`](https://github.com/NixOS/nixpkgs/commit/e5bcc7737676fb0785105ee7fc299294d43dd0e5) | `` imgproxy: 3.18.0 -> 3.18.1 ``                                         |
| [`6579b429`](https://github.com/NixOS/nixpkgs/commit/6579b42989b94b2973ad0fde08ea0df360f3a291) | `` blahaj: 2.0.2 -> 2.1.0 ``                                             |
| [`75c2378e`](https://github.com/NixOS/nixpkgs/commit/75c2378e59ec589400c825a64c0ea8cc989a0af1) | `` scalafmt: 3.7.3 -> 3.7.5 ``                                           |
| [`474ac5bb`](https://github.com/NixOS/nixpkgs/commit/474ac5bb6d36e6cc786eda1544017917aa210e10) | `` hugo: 0.114.1 -> 0.115.0 ``                                           |
| [`f633ed07`](https://github.com/NixOS/nixpkgs/commit/f633ed072aa77fefbc97f0e6f5d0079283f53719) | `` nixosTests.deepin: raise virtualisation.memorySize to 2048 ``         |
| [`2faf7f57`](https://github.com/NixOS/nixpkgs/commit/2faf7f5770abc4d9a2a796df88e25d63aba9bcb8) | `` muffet: 2.9.1 -> 2.9.2 ``                                             |
| [`0c72d079`](https://github.com/NixOS/nixpkgs/commit/0c72d079424c8b7a01bc6a11db3471303ea2a70a) | `` kubectl-view-secret: 0.10.1 -> 0.11.0 ``                              |
| [`02189ff9`](https://github.com/NixOS/nixpkgs/commit/02189ff9d6f1e19fae8b74807fb9c450a69ea8c5) | `` kubectl-example: 1.1.0 -> 1.2.0 ``                                    |
| [`a1b9fe3c`](https://github.com/NixOS/nixpkgs/commit/a1b9fe3c11444f0eeb652841f9227930ca1bd835) | `` deepin.deepin-music: 6.2.27 -> 6.2.28 ``                              |
| [`76b2087b`](https://github.com/NixOS/nixpkgs/commit/76b2087b537ede2bc271d7429344655a4e2ddaec) | `` deepin.deepin-movie-reborn: 5.10.23 -> 5.10.28 ``                     |
| [`2fed757b`](https://github.com/NixOS/nixpkgs/commit/2fed757bef3e9b88ca5f31957d5b7c1190cbe6fc) | `` deepin.deepin-image-viewer: 5.9.11 -> 5.9.13 ``                       |
| [`b3f867c8`](https://github.com/NixOS/nixpkgs/commit/b3f867c8ef867f4551f7a8c80d1bdd8541e9c0de) | `` deepin.deepin-camera: 1.4.11 -> 1.4.13 ``                             |
| [`d20d08c6`](https://github.com/NixOS/nixpkgs/commit/d20d08c6672992c3778e418ae862faca8424b1fa) | `` deepin.deepin-calculator: 5.8.23 -> 5.8.24 ``                         |
| [`15bb390a`](https://github.com/NixOS/nixpkgs/commit/15bb390a82a6782f5259643320813baaeea03e62) | `` pantheon.gnome-bluetooth-contract: drop ``                            |
| [`9f2a6f76`](https://github.com/NixOS/nixpkgs/commit/9f2a6f7626fe1cbfe72ba4750c4edc87976f54ae) | `` python310Packages.aiobotocore: 2.5.0 -> 2.5.1 ``                      |
| [`506a7e4b`](https://github.com/NixOS/nixpkgs/commit/506a7e4b178ecb84ebcaffe251bcf6edce42153c) | `` libcef: 114.2.11 -> 114.2.12 ``                                       |
| [`2fc81794`](https://github.com/NixOS/nixpkgs/commit/2fc817946be5e9c2b3204fccdaf881fdae2840c3) | `` tpm2-tss: add maintainer ``                                           |
| [`9cf407a5`](https://github.com/NixOS/nixpkgs/commit/9cf407a570dcc8f33bc288d875349692c32d2821) | `` pantheon.switchboard-plug-onlineaccounts: 6.5.2 -> 6.5.3 ``           |
| [`ea638149`](https://github.com/NixOS/nixpkgs/commit/ea63814905f7462749d88794aee9a27ac01c90b5) | `` pantheon.sideload: 6.2.0 -> 6.2.1 ``                                  |
| [`80cd4628`](https://github.com/NixOS/nixpkgs/commit/80cd4628eb198225b498e5695517008303e6b841) | `` pantheon.wingpanel-indicator-bluetooth: 7.0.0 -> 7.0.1 ``             |
| [`366eb414`](https://github.com/NixOS/nixpkgs/commit/366eb41450f7b8722d37f2b1421db377e88668c5) | `` pantheon.elementary-files: 6.3.1 -> 6.4.0 ``                          |
| [`cdc2ae13`](https://github.com/NixOS/nixpkgs/commit/cdc2ae13c3977000627ba57419067ffff1c67f87) | `` klipper: unstable-2023-06-23 -> unstable-2023-06-29 ``                |
| [`5253398b`](https://github.com/NixOS/nixpkgs/commit/5253398b78bd4e024fd766588cf18a79bf9a1aa2) | `` poetry2nix: 1.41.0 -> 1.42.1 ``                                       |
| [`fac7cebe`](https://github.com/NixOS/nixpkgs/commit/fac7cebe76c94643cdbf8844c462162ad899d2e3) | `` python310Packages.pygit2: 1.12.0 -> 1.12.2 ``                         |
| [`d7a27f31`](https://github.com/NixOS/nixpkgs/commit/d7a27f31892896029919f71f1d2353bc5147c433) | `` haskellPackages.streamly-lmdb: drop obsolete override ``              |
| [`95d5c0c2`](https://github.com/NixOS/nixpkgs/commit/95d5c0c21b1df93d254657fdf26c0ec072dcfdde) | `` haskellPackages.streamly-lmdb: obtain deps from haskell fixpoint ``   |
| [`8088e14e`](https://github.com/NixOS/nixpkgs/commit/8088e14e12f21093cdb143c2234d34af7d331cde) | `` doc/haskell: FAQ entry on changing profiling settings globally ``     |
| [`1db464d4`](https://github.com/NixOS/nixpkgs/commit/1db464d40ae572a0613361aa761d7e9bbd6878e6) | `` doc/haskell: document {enable,disable}*Profiling functions ``         |
| [`1908685b`](https://github.com/NixOS/nixpkgs/commit/1908685b0871fb9d29589dd09ac4a8b364ee275c) | `` python310Packages.psd-tools: 1.9.26 -> 1.9.27 ``                      |
| [`1cdf0bdd`](https://github.com/NixOS/nixpkgs/commit/1cdf0bddc87728e9f7e54eff693f0d62e0377096) | `` moonlight-qt: Support darwin (#239600) ``                             |
| [`88888899`](https://github.com/NixOS/nixpkgs/commit/88888899e5327c11b28afaa3bc64171f9ac8203e) | `` binary-cache: use lib.makeBinPath ``                                  |
| [`159c8b95`](https://github.com/NixOS/nixpkgs/commit/159c8b9570b2d222a7f8494f928f553be3f8400a) | `` octoprint: 1.9.0 -> 1.9.1 ``                                          |
| [`aa85ee88`](https://github.com/NixOS/nixpkgs/commit/aa85ee889f29a0e99e7368f80dc389f8145370ad) | `` python310Packages.spacy: 3.5.3 -> 3.5.4 ``                            |
| [`50ebee7c`](https://github.com/NixOS/nixpkgs/commit/50ebee7c49b20b535943a54f5473f55e42ffd193) | `` netpbm: 11.2.0 -> 11.3.0 ``                                           |
| [`c57bc5f8`](https://github.com/NixOS/nixpkgs/commit/c57bc5f8129dd25337ad155f22fed3e3809dfe67) | `` python310Packages.dask-awkward: 2023.6.1 -> 2023.6.3 (#240267) ``     |
| [`5a865046`](https://github.com/NixOS/nixpkgs/commit/5a8650469a9f8a1958ff9373bd27fb8e54c4365d) | `` python310Packages.awkward: 2.2.2 -> 2.2.3 (#240266) ``                |
| [`30db1543`](https://github.com/NixOS/nixpkgs/commit/30db154395ef62e75758c966ad4f1d9d671344ae) | `` python310Packages.zeroc-ice: 3.7.9 -> 3.7.9.1 ``                      |
| [`a3cdf318`](https://github.com/NixOS/nixpkgs/commit/a3cdf3186fd7e2a8dde319cea656ddf0958421bf) | `` texlive.bin.core-big: fix luajittex on aarch64-linux (#240577) ``     |
| [`0dbbee7a`](https://github.com/NixOS/nixpkgs/commit/0dbbee7aba5ee2df834fad3a1cc66f0e3d72959f) | `` dvc: add pythonImportsCheck ``                                        |
| [`c8c5b63e`](https://github.com/NixOS/nixpkgs/commit/c8c5b63e7f7cd003cfc8c23da01503a31187f4fa) | `` jackett: 0.21.327 -> 0.21.341 ``                                      |
| [`906102c9`](https://github.com/NixOS/nixpkgs/commit/906102c9115bc350ee95e1d5bc3c4c171c1a3af1) | `` doc/languages-frameworks/python: don't use full `pkgs` in attrs ``    |
| [`4cb579b5`](https://github.com/NixOS/nixpkgs/commit/4cb579b5369a5a0029460bf11f5e17f4ef44ba2d) | `` lib.systems: add gnuabin32 to isGnu ``                                |
| [`86a3b523`](https://github.com/NixOS/nixpkgs/commit/86a3b52396b3c58072c7a634c9389999d13f30e7) | `` python311Packages.bluetooth-data-tools: 1.2.0 -> 1.3.0 ``             |
| [`ce754078`](https://github.com/NixOS/nixpkgs/commit/ce754078f5b73076ba96514f6affebf2bcd20081) | `` python310Packages.pyspark: 3.4.0 -> 3.4.1 ``                          |
| [`b54924c3`](https://github.com/NixOS/nixpkgs/commit/b54924c377d2e15ea2ff84f3ba9baf4db38839b1) | `` python310Packages.jira: 3.5.1 -> 3.5.2 ``                             |
| [`ee8816dc`](https://github.com/NixOS/nixpkgs/commit/ee8816dcb68348e804b72baf951881b816903f9b) | `` home-assistant: update component-packages ``                          |
| [`a31849c9`](https://github.com/NixOS/nixpkgs/commit/a31849c980a4dfbf0264e2bebb6e1cc1411b3697) | `` python311Packages.google-generativeai: init at 0.1.0 ``               |
| [`4d521ebc`](https://github.com/NixOS/nixpkgs/commit/4d521ebc2afb76ba547baec476b4ecf594aaf333) | `` linuxwave: 0.1.3 -> 0.1.4 ``                                          |
| [`665f414a`](https://github.com/NixOS/nixpkgs/commit/665f414a220d3cdb9cc6bd92f2482964d83f4681) | `` python311Packages.google-ai-generativelanguage: init at 0.3.0 ``      |
| [`648e7618`](https://github.com/NixOS/nixpkgs/commit/648e76181a1de444749fe50d34b57f0f5ed2a91d) | `` python310Packages.trimesh: 3.22.1 -> 3.22.2 ``                        |