### PR TITLE
chore(flake/home-manager): `47c2adc6` -> `a7002d6b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687945268,
-        "narHash": "sha256-Fto5zvy6/mjFLF8cOFUdZkZOwQnQ9snpaAf6qSBP8/8=",
+        "lastModified": 1687969886,
+        "narHash": "sha256-tC2qFLmuM0PFaw0tMHVcFmzsG/351q09qa1EpuL2n1U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "47c2adc6b31e9cff335010f570814e44418e2b3e",
+        "rev": "a7002d6bfca54742d5fc9b485a1879953b4585b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`a7002d6b`](https://github.com/nix-community/home-manager/commit/a7002d6bfca54742d5fc9b485a1879953b4585b9) | `` kakoune: add defaultEditor option `` |