### PR TITLE
chore(flake/pre-commit-hooks): `1fa438ee` -> `5843cf06`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -374,11 +374,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1687779420,
-        "narHash": "sha256-noueZE/Z5qx6NF/grg46qlpZ/1nuPpc92RvqgCmRaLI=",
+        "lastModified": 1688056373,
+        "narHash": "sha256-2+SDlNRTKsgo3LBRiMUcoEUb6sDViRNQhzJquZ4koOI=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "1fa438eee82f35bdd4bc30a9aacd7648d757b388",
+        "rev": "5843cf069272d92b60c3ed9e55b7a8989c01d4c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                            |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
| [`719c2bb0`](https://github.com/cachix/pre-commit-hooks.nix/commit/719c2bb08ffa0e086bbba17d5f7ff095cef326fe) | `` fix(tflint): Fix warning running tflint ``      |
| [`56449b45`](https://github.com/cachix/pre-commit-hooks.nix/commit/56449b45a9a354b29a094d1fcf9540067d0e69a6) | `` Bad merge commit ``                             |
| [`b4dfb08e`](https://github.com/cachix/pre-commit-hooks.nix/commit/b4dfb08ee36df8858edc8880ae7608b61b9f1fb4) | `` Adding support for Elixir pre-commits ``        |
| [`9bbe706b`](https://github.com/cachix/pre-commit-hooks.nix/commit/9bbe706b097072cb3fc2a5964255411c7234b31e) | `` Lost a close bracket in there ``                |
| [`600cbdfd`](https://github.com/cachix/pre-commit-hooks.nix/commit/600cbdfdcf4bae2bb41f0856faacd9292dd19a70) | `` Correct typo on `description` attribute name `` |
| [`eb04c337`](https://github.com/cachix/pre-commit-hooks.nix/commit/eb04c337a18135afca8125da9aaf73ecc1f48524) | `` Adding support for Elixir pre-commits ``        |