### PR TITLE
chore(flake/home-manager): `7a0e9a67` -> `89d10f8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688218897,
-        "narHash": "sha256-qIBOgrUoQjWzbzC/SOQDGQHnyNkFPGnV3FWOgGKYNGY=",
+        "lastModified": 1688220547,
+        "narHash": "sha256-cNKKLPaEOxd6t22Mt3tHGubyylbKGdoi2A3QkMTKes0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7a0e9a67824aa05f972459aefc2caafe6fdc0f88",
+        "rev": "89d10f8adce369a80e046c2fd56d1e7b7507bb5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`89d10f8a`](https://github.com/nix-community/home-manager/commit/89d10f8adce369a80e046c2fd56d1e7b7507bb5b) | `` news: fix typo in programs.zsh.antidote entry `` |
| [`2d9210f2`](https://github.com/nix-community/home-manager/commit/2d9210f25ed18d5d4e11e6b886de4027c0c51a94) | `` ssh-agent: init module (#4178) ``                |