### PR TITLE
chore(flake/nixpkgs): `4ffc4dc9` -> `645ff62e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688141540,
-        "narHash": "sha256-xh2aLD8R6gau+O+9h1ad+OAjCAj07lCKsY44+p/bJS8=",
+        "lastModified": 1688231357,
+        "narHash": "sha256-ZOn16X5jZ6X5ror58gOJAxPfFLAQhZJ6nOUeS4tfFwo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4ffc4dc91838df228c8214162c106c24ec8fe03f",
+        "rev": "645ff62e09d294a30de823cb568e9c6d68e92606",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                  |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
| [`e470bc2b`](https://github.com/NixOS/nixpkgs/commit/e470bc2b48321381838625d9782efa651fd5c0ad) | `` turbovnc: 3.0.1 -> 3.0.3 ``                                                                           |
| [`e824b1bd`](https://github.com/NixOS/nixpkgs/commit/e824b1bd18d8c548e313555104ab9273d2a86432) | `` gimoji: 0.5.0 -> 0.5.1 ``                                                                             |
| [`af579561`](https://github.com/NixOS/nixpkgs/commit/af57956199bc26612c6d443c101374f7ed5c1ee9) | `` nixos/test/bcachefs: fix password input ``                                                            |
| [`4d719f10`](https://github.com/NixOS/nixpkgs/commit/4d719f101c28bede334298c026a7fcb3e19553a5) | `` nixos/bcachefs: add new mount.bcachefs util ``                                                        |
| [`871e0059`](https://github.com/NixOS/nixpkgs/commit/871e00591399d420154373f2a72cb681d996b570) | `` linuxKernel.kernels.linux_testing_bcachefs: 6.1.3-unstable-2023-02-01 -> 6.4.0-unstable-2023-06-28 `` |
| [`c252f828`](https://github.com/NixOS/nixpkgs/commit/c252f82800904690d21735b53396a50f51e9b2ff) | `` bcachefs-tools: unstable-2023-01-31 -> unstable-2023-06-28 ``                                         |
| [`be19c4c3`](https://github.com/NixOS/nixpkgs/commit/be19c4c3700bc20e4a98ffe1f7a012854a40a322) | `` bun: 0.6.9 -> 0.6.12 ``                                                                               |
| [`ab10439c`](https://github.com/NixOS/nixpkgs/commit/ab10439c511348d01c305f4f28256a845cd7cb9e) | `` gping: 1.3.2 -> 1.12.0 ``                                                                             |
| [`080757c6`](https://github.com/NixOS/nixpkgs/commit/080757c6c53d748717e86ab5faf15f62fc1e42a6) | `` nixos/vaultwarden: Bind to localhost by default. See #100192 ``                                       |
| [`ab4c76ab`](https://github.com/NixOS/nixpkgs/commit/ab4c76ab9e484f4e00cfd95df0b315e472f3d218) | `` erdtree: 3.0.2 -> 3.1.1 ``                                                                            |
| [`0c9fb905`](https://github.com/NixOS/nixpkgs/commit/0c9fb905cbaf4bbc64ebe098aa42a1dbbc4149fd) | `` doc/using/overrides: Relate addition to preceding text ``                                             |
| [`f86dfc57`](https://github.com/NixOS/nixpkgs/commit/f86dfc576c8fd01a1c99878edb69802b61149000) | `` jql: 6.0.9 -> 7.0.0 ``                                                                                |
| [`ad719a80`](https://github.com/NixOS/nixpkgs/commit/ad719a802b77fb23fec0bf167654911c35576dc4) | `` tilt: 0.32.4 -> 0.33.1 ``                                                                             |
| [`7fdd8a19`](https://github.com/NixOS/nixpkgs/commit/7fdd8a19b53e03bb0a09ff345ceff8f5ed51ee1a) | `` halftone: 0.3.0 -> 0.3.1 ``                                                                           |
| [`6e95ba22`](https://github.com/NixOS/nixpkgs/commit/6e95ba2260cee9c76a533aac0a9c452227834f6d) | `` docs: clarify videoDrivers breakage in release notes ``                                               |
| [`878d8647`](https://github.com/NixOS/nixpkgs/commit/878d86471a87dae78d4dd85c4cbe7fa6db4d7fc5) | `` zigbee2mqtt: 1.31.2 -> 1.32.0 ``                                                                      |
| [`dd481f2e`](https://github.com/NixOS/nixpkgs/commit/dd481f2ee3bcf8e0555968dbdaa03a45bd5ae56e) | `` pdns: Changed paths in /etc to use pdns instead of powerdns ``                                        |
| [`8ab22ad2`](https://github.com/NixOS/nixpkgs/commit/8ab22ad2ad166a75e517bc3d0a6625d3e3f4517a) | `` nixos/tests/powerdns: Stop manually configuring config path ``                                        |
| [`d25e5e21`](https://github.com/NixOS/nixpkgs/commit/d25e5e21070cbacaa33361254a6a0b1e2e7c0e04) | `` nixos/powerdns, nixos/pdns-recurser: Symlink configuration into /etc ``                               |
| [`64e3b623`](https://github.com/NixOS/nixpkgs/commit/64e3b6239b658a7ce1ce316330fe3c7d018da089) | `` pdns, pdns-recurser: Look for configuration in /etc ``                                                |
| [`ca65297f`](https://github.com/NixOS/nixpkgs/commit/ca65297f311472b31b3ce9fef401c8e8d76cdc64) | `` gnome.evince: Change meta.platforms to unix ``                                                        |
| [`620d57c6`](https://github.com/NixOS/nixpkgs/commit/620d57c63a4c0158000190009ca0520e8c2c7e73) | `` clusterctl: 1.4.3 -> 1.4.4 ``                                                                         |
| [`7db362f2`](https://github.com/NixOS/nixpkgs/commit/7db362f221f8c8ab8edc75d64d47fe9048c4a08b) | `` fastgron: init at 0.6.2 ``                                                                            |
| [`7bba50f5`](https://github.com/NixOS/nixpkgs/commit/7bba50f51452bf41cba233114bac4f5812695eb1) | `` secretscanner: add changelog to meta ``                                                               |
| [`03b3056f`](https://github.com/NixOS/nixpkgs/commit/03b3056f25c25ca204a307e1e92d8070462d7669) | `` haskell.packages: use `pkgs` fix point for package set aliases ``                                     |
| [`242c6734`](https://github.com/NixOS/nixpkgs/commit/242c67349b079c337ed3a056600d3303774b4170) | `` secretscanner: 20210214-42a38f9 -> 1.2.0 ``                                                           |
| [`8bb3326a`](https://github.com/NixOS/nixpkgs/commit/8bb3326a906a6730fd51aff3a8e9d5f7be12e371) | `` snowcrash: unstable-2021-04-29 -> unstable-2022-08-15 ``                                              |
| [`cac6d289`](https://github.com/NixOS/nixpkgs/commit/cac6d289dbd61c0bc6ad2f6c83a0449222abda1f) | `` spyre: 1.2.4 -> 1.2.5 ``                                                                              |
| [`c94163aa`](https://github.com/NixOS/nixpkgs/commit/c94163aa233314d6f38c76ffba13f3b953681d10) | `` zdns: 2022-03-14-unstable -> 2023-04-09-unstable ``                                                   |
| [`11046142`](https://github.com/NixOS/nixpkgs/commit/1104614287bc58398844e9fddfcdb1fda446d08c) | `` systemd-journal2gelf: unstable-2022-02-15 -> unstable-2023-03-10 ``                                   |
| [`54769c6f`](https://github.com/NixOS/nixpkgs/commit/54769c6fa1c6a984d5923d746b57e5461a0c2bba) | `` hashcat: add CUDA support (#240735) ``                                                                |
| [`0abba24d`](https://github.com/NixOS/nixpkgs/commit/0abba24dccba20c6232307e92e4c21789cdd598c) | `` svlint: 0.7.2 -> 0.8.0 ``                                                                             |
| [`e1b8adea`](https://github.com/NixOS/nixpkgs/commit/e1b8adeab3002e1f0f75e658dcd8b33efd3dce79) | `` python311Packages.cloudsplaining: 0.5.1 -> 0.6.0 ``                                                   |
| [`dd556d1e`](https://github.com/NixOS/nixpkgs/commit/dd556d1eb620e4bb35d0b63d38eb4d0229f2502f) | `` python311Packages.pymazda: 0.3.8 -> 0.3.9 ``                                                          |
| [`58a6c2d3`](https://github.com/NixOS/nixpkgs/commit/58a6c2d3554d4cb90cd851a0d0019362511f6370) | `` grype: 0.63.0 -> 0.63.1 ``                                                                            |
| [`ebdd860c`](https://github.com/NixOS/nixpkgs/commit/ebdd860cd4fdbe6711b9441b4bb719e5a4ba6ef1) | `` python311Packages.publicsuffixlist: 0.10.0.20230617 -> 0.10.0.20230701 ``                             |
| [`324036b3`](https://github.com/NixOS/nixpkgs/commit/324036b3d7cac775374843df9e26edd627509892) | `` rtx: 1.32.0 -> 1.32.1 ``                                                                              |
| [`e8f97f0f`](https://github.com/NixOS/nixpkgs/commit/e8f97f0ff1bc062c28dedb278ff004ee73154417) | `` gifsicle: 1.93 -> 1.94 (#240801) ``                                                                   |
| [`44bed90d`](https://github.com/NixOS/nixpkgs/commit/44bed90d4c0939fa656a7f39e8625bba47af38c6) | `` bacon: 2.9.0 -> 2.10.0 ``                                                                             |
| [`2e3fe5a3`](https://github.com/NixOS/nixpkgs/commit/2e3fe5a346d4576e9e37201f0703f49566a8a621) | `` python311Packages.dparse: update disabled ``                                                          |
| [`662e208e`](https://github.com/NixOS/nixpkgs/commit/662e208e696d2fa549a3208980e50ef3e33a62fa) | `` python311Packages.dparse: add changelog to meta ``                                                    |
| [`7c083c0d`](https://github.com/NixOS/nixpkgs/commit/7c083c0df195cd894aaa1b7e9d20c9db8b0474ff) | `` python310Packages.qutip: add changelog to meta ``                                                     |
| [`d34df5d8`](https://github.com/NixOS/nixpkgs/commit/d34df5d874e845af6990dd70c4ffd1f178c7a7f0) | `` protoc-gen-validate: 1.0.1 -> 1.0.2 ``                                                                |
| [`3b02da69`](https://github.com/NixOS/nixpkgs/commit/3b02da698bcab3f5568346bae8335f3a69356510) | `` metasploit: 6.3.22 -> 6.3.23 ``                                                                       |
| [`dd0ce00a`](https://github.com/NixOS/nixpkgs/commit/dd0ce00a69b62b6605ecf1632bae768de036ba25) | `` python310Packages.bellows: 0.35.5 -> 0.35.8 ``                                                        |
| [`ae9f5e2a`](https://github.com/NixOS/nixpkgs/commit/ae9f5e2acdeee298e1bb275477ea555975feac15) | `` vimPlugins.nvim-treesitter: update grammars ``                                                        |
| [`f069dc92`](https://github.com/NixOS/nixpkgs/commit/f069dc92af0a13350fb3b57ab9cf746e5870c251) | `` vimPlugins: resolve github repository redirects ``                                                    |
| [`46e817f7`](https://github.com/NixOS/nixpkgs/commit/46e817f799fb57c8a7af05bac94309b07877f415) | `` vimPlugins: update ``                                                                                 |
| [`91b5ea6a`](https://github.com/NixOS/nixpkgs/commit/91b5ea6ac60ccd6fafc83e9e731f1f21b984a78a) | `` vimPlugins.quickmath-nvim: init at 2023-03-12 ``                                                      |
| [`1af3bc22`](https://github.com/NixOS/nixpkgs/commit/1af3bc22aed6856492dcfa4b6528565b3c22f3dc) | `` python310Packages.qutip: 4.7.1 -> 4.7.2 ``                                                            |
| [`8277b539`](https://github.com/NixOS/nixpkgs/commit/8277b539d371bf4308fc5097911aa58bfac1794f) | `` terraform-providers.aws: 5.6.1 -> 5.6.2 ``                                                            |
| [`f3225373`](https://github.com/NixOS/nixpkgs/commit/f322537373c5e298bdabe7eb84f0218aeda96f4e) | `` terraform-providers.tencentcloud: 1.81.9 -> 1.81.10 ``                                                |
| [`63fcc0fa`](https://github.com/NixOS/nixpkgs/commit/63fcc0fa1903961a1f1093fb01fa0245e25c476d) | `` terraform-providers.spotinst: 1.124.0 -> 1.125.0 ``                                                   |
| [`b0ade8a2`](https://github.com/NixOS/nixpkgs/commit/b0ade8a206dc3d46b156e28817470100f12b8b23) | `` terraform-providers.selectel: 3.10.0 -> 3.11.0 ``                                                     |
| [`bb50c254`](https://github.com/NixOS/nixpkgs/commit/bb50c25415cb93ed1784edf3e6985be88ca7ae89) | `` terraform-providers.huaweicloud: 1.50.0 -> 1.51.0 ``                                                  |
| [`4fe02d87`](https://github.com/NixOS/nixpkgs/commit/4fe02d87656cee30f15d062b8bf491d57dde813f) | `` millet: 0.12.0 -> 0.12.2 ``                                                                           |
| [`58e8f741`](https://github.com/NixOS/nixpkgs/commit/58e8f741483814ded31383b86bc8b3ebde889388) | `` esbuild: 0.18.10 -> 0.18.11 ``                                                                        |
| [`7eec1ead`](https://github.com/NixOS/nixpkgs/commit/7eec1ead92df7a5b1e084a655bf4f3c21d29aa8c) | `` twspace-crawler: 1.11.13 -> 1.12.1 ``                                                                 |
| [`1908a08b`](https://github.com/NixOS/nixpkgs/commit/1908a08b71b126ac0a580b212b365da9125ae9d9) | `` lxgw-neoxihei: 1.101 -> 1.102.1 ``                                                                    |
| [`ef11bcb5`](https://github.com/NixOS/nixpkgs/commit/ef11bcb51c5504df8d1c4a3ad9a436f92665dab0) | `` kubeclarity: 2.18.1 -> 2.19.0 ``                                                                      |
| [`547458d3`](https://github.com/NixOS/nixpkgs/commit/547458d335fe2ec84566082964f3983dbccbcd30) | `` python310Packages.graphtage: 0.2.8 -> 0.2.9 ``                                                        |
| [`15c6a9ff`](https://github.com/NixOS/nixpkgs/commit/15c6a9fffd3237b79f01d45c1322b36b67803401) | `` python311Packages.dparse: 0.6.2 -> 0.6.3 ``                                                           |
| [`31d682db`](https://github.com/NixOS/nixpkgs/commit/31d682db903189dd76b58c528419d440da797588) | `` python310Packages.mmengine: 0.7.3 -> 0.7.4 ``                                                         |
| [`8e8cd4ef`](https://github.com/NixOS/nixpkgs/commit/8e8cd4ef411b22d9f1efaffea9fddab20622861b) | `` maintainers.openstack: remove emilytrau ``                                                            |
| [`9e6a9376`](https://github.com/NixOS/nixpkgs/commit/9e6a937659697501c99ad73f07f2f5653cc6260b) | `` nchat: 3.39 -> 3.60 ``                                                                                |
| [`ae75dfca`](https://github.com/NixOS/nixpkgs/commit/ae75dfca126c8d1fce6ae6e5831f9c1830c96101) | `` fulcio: 1.3.1 -> 1.3.2 ``                                                                             |
| [`36164b3e`](https://github.com/NixOS/nixpkgs/commit/36164b3e12db677b65e44cc82939359f1436786d) | `` cairo-lang: 1.1.0 -> 1.1.1 ``                                                                         |
| [`e5b5bdae`](https://github.com/NixOS/nixpkgs/commit/e5b5bdae73c27cb2f565bce4b08d9520c8c46f71) | `` chamber: 2.13.0 -> 2.13.1 ``                                                                          |
| [`82e01c97`](https://github.com/NixOS/nixpkgs/commit/82e01c97dc34d5b46be9880298a717dc2d935dc2) | `` kluctl: 2.20.6 -> 2.20.7 ``                                                                           |
| [`95f62079`](https://github.com/NixOS/nixpkgs/commit/95f62079ff863e7824c2ae484cc0587f1937748f) | `` python311Packages.gitignore-parser: 0.1.3 -> 0.1.4 ``                                                 |
| [`2871d942`](https://github.com/NixOS/nixpkgs/commit/2871d942e0f206266005740632882e6e0d46e57f) | `` vimix-icon-theme: 2023-01-18 -> 2023-06-26 ``                                                         |
| [`bd15d5ab`](https://github.com/NixOS/nixpkgs/commit/bd15d5ab5bea770cf43930fa3238ce4503d6cb0e) | `` python311Packages.elastic-apm: 6.16.1 -> 6.16.2 ``                                                    |
| [`963c74ab`](https://github.com/NixOS/nixpkgs/commit/963c74ab200a4c845fd26a5722c172254b353ede) | `` python311Packages.pysigma-backend-elasticsearch: 1.0.3 -> 1.0.4 ``                                    |
| [`50bcd0be`](https://github.com/NixOS/nixpkgs/commit/50bcd0bed0ca5d9a96a8910974dd068d3dcbca9b) | `` python310Packages.awkward: add changelog to meta ``                                                   |
| [`70402b2f`](https://github.com/NixOS/nixpkgs/commit/70402b2f35897ce385d6bc74d26bb5a10ddd389b) | `` libsForQt5.maui-core: 0.5.6 -> 0.6.6 ``                                                               |
| [`7b1af4da`](https://github.com/NixOS/nixpkgs/commit/7b1af4daed58cb6544de7710cb31802a4cee0a6b) | `` python310Packages.awkward: 2.2.3 -> 2.2.4 ``                                                          |
| [`39e70ab2`](https://github.com/NixOS/nixpkgs/commit/39e70ab2a60aade7b6f638de9565574c3f0a75a2) | `` pdfposter: move out of python-modules ``                                                              |
| [`7cc71cc9`](https://github.com/NixOS/nixpkgs/commit/7cc71cc9489c05672c1eacb5705b31e0208cbfff) | `` python310Packages.hcloud: 1.22.0 -> 1.23.1 ``                                                         |
| [`fb643f32`](https://github.com/NixOS/nixpkgs/commit/fb643f3260823fa715cee14c2741dbdbfc522dc0) | `` doc/using/overrides: it is possible to use previous arguments in .override ``                         |
| [`0fdae315`](https://github.com/NixOS/nixpkgs/commit/0fdae315315686d180d924a7c33066fbc5b4c14d) | `` stdenv: let overrideAttrs accept attrset OR function ``                                               |
| [`36ca205e`](https://github.com/NixOS/nixpkgs/commit/36ca205e44d839306b8ce1ba1c3f217d90d26738) | `` nixos/gdm: fix plymouth-quit bootup error message ``                                                  |
| [`73ce3387`](https://github.com/NixOS/nixpkgs/commit/73ce338715dc4c99fb52d542b2221c8d90b3d73c) | `` python310Packages.netapp-ontap: 9.12.1.0 -> 9.13.1.0 ``                                               |
| [`2151defe`](https://github.com/NixOS/nixpkgs/commit/2151defed00e45c9a4a43cdb6d1119a07be07d0f) | `` searx: fix for flask-babel 3.0 ``                                                                     |
| [`975085dc`](https://github.com/NixOS/nixpkgs/commit/975085dc4e43cb85dbaec458c6dbd31d380ddc78) | `` weechat-unwrapped: 4.0.0 -> 4.0.1 ``                                                                  |
| [`f001506b`](https://github.com/NixOS/nixpkgs/commit/f001506b014a2bfb92ee18c026e3e4dec6dd1c17) | `` python310Packages.mediapy: 1.1.6 -> 1.1.8 ``                                                          |
| [`cf1b7c4d`](https://github.com/NixOS/nixpkgs/commit/cf1b7c4d5c027837e71d284a838fbeb05b3fcb7f) | `` newlib: fix build of nano variant on non-ARM architectures ``                                         |
| [`51861b76`](https://github.com/NixOS/nixpkgs/commit/51861b76b4aca740d437161d3076d9912a31d3ba) | `` furtherance: 1.8.0 -> 1.8.1 ``                                                                        |
| [`b5eac33a`](https://github.com/NixOS/nixpkgs/commit/b5eac33a5990d6f91c3686dff561a85b258d98f7) | `` python311Packages.heatshrink2: add format ``                                                          |
| [`ebfcf3d9`](https://github.com/NixOS/nixpkgs/commit/ebfcf3d9bdda5e98f32e4cad47c6c3e21b9417b5) | `` python311Packages.heatshrink2: 0.11.0 -> 0.12.0 ``                                                    |
| [`3414f7da`](https://github.com/NixOS/nixpkgs/commit/3414f7da25556d3af484c65fc59de0c5eb966bfd) | `` python311Packages.hexbytes: add format ``                                                             |
| [`709fe22b`](https://github.com/NixOS/nixpkgs/commit/709fe22bab1ad2aa55f7a06589e09bcb86e614f1) | `` python311Packages.hexbytes: 0.3.0 -> 0.3.1 ``                                                         |
| [`64d0029e`](https://github.com/NixOS/nixpkgs/commit/64d0029e285983c599516e1ec62d9997bb28ab53) | `` alacritty: --add-rpath instead of --set-rpath ``                                                      |
| [`65e06297`](https://github.com/NixOS/nixpkgs/commit/65e06297fb2ee9f04fea8fa7b7fd24f97ebce0fb) | `` gtree: 1.8.2 -> 1.8.3 ``                                                                              |
| [`c8c9b781`](https://github.com/NixOS/nixpkgs/commit/c8c9b781221e365816cf6dd2509df63dfbe57d55) | `` python311Packages.mss: 7.0.1 -> 9.0.1 ``                                                              |
| [`60765c11`](https://github.com/NixOS/nixpkgs/commit/60765c1112ef844d58b1fa0d83b57f316147c109) | `` python311Packages.odp-amsterdam: 5.1.0 -> 5.1.1 ``                                                    |
| [`867cca0e`](https://github.com/NixOS/nixpkgs/commit/867cca0ef46e47d245d0a1402ad6f289a5457e65) | `` Update maintainers/maintainer-list.nix ``                                                             |
| [`ba2968d2`](https://github.com/NixOS/nixpkgs/commit/ba2968d2933f65d6e5fd9455e0d4ebb26f267233) | `` python311Packages.pontos: 23.6.1 -> 23.6.2 ``                                                         |
| [`91612045`](https://github.com/NixOS/nixpkgs/commit/91612045b81bc1ccd29ed4287c7d82900b951143) | `` mswatch: Use fetchsvn as a more reliable src ``                                                       |
| [`9b9ec7b1`](https://github.com/NixOS/nixpkgs/commit/9b9ec7b106776569676a0b650e807305ae3909bb) | `` flat-remix-gnome: update 20230508 -> 20230606. ``                                                     |
| [`d0837b6b`](https://github.com/NixOS/nixpkgs/commit/d0837b6bdfebabe4964d3b3b7a501737a07c0a41) | `` python3Packages.litemapy: init at 0.7.2b0 ``                                                          |
| [`3afa2163`](https://github.com/NixOS/nixpkgs/commit/3afa21632fd510afe4cd9646e317b082c153bc3d) | `` python3Packages.nbtlib: init at 2.0.4 ``                                                              |
| [`9c546517`](https://github.com/NixOS/nixpkgs/commit/9c54651749aaf47490ade490865491fca0dee72f) | `` maintainers: add gdd ``                                                                               |
| [`2048a8ca`](https://github.com/NixOS/nixpkgs/commit/2048a8ca0250abf51192ebc9c51c92a802cbf9b2) | `` nixos/proxmox-image: fix example rendering ``                                                         |
| [`0000004f`](https://github.com/NixOS/nixpkgs/commit/0000004f80927e7a92630218c5716ab57e10577f) | `` nixos/ttyd: fix example rendering ``                                                                  |
| [`271969a1`](https://github.com/NixOS/nixpkgs/commit/271969a12e4bbab47fc31b3541604a5b9bf5fb08) | `` coconutbattery: init at 3.9.12 ``                                                                     |
| [`000004d1`](https://github.com/NixOS/nixpkgs/commit/000004d123ec74e7a443d7190eac550d2d914c25) | `` nixos/thelounge: fix example rendering ``                                                             |
| [`9999996f`](https://github.com/NixOS/nixpkgs/commit/9999996fd6f33c12f2f341dcdbac7a9c926d0a87) | `` nixos/sshd: fix example rendering ``                                                                  |
| [`64825363`](https://github.com/NixOS/nixpkgs/commit/6482536377fbe0013fb52abd44377bf4d28efcbd) | `` bartender: init at 4.2.21 ``                                                                          |
| [`a799ad04`](https://github.com/NixOS/nixpkgs/commit/a799ad04a69f358a078b0345777e535cca73d359) | `` mswatch: Remove rec and . from end of meta.description ``                                             |
| [`e0e729b3`](https://github.com/NixOS/nixpkgs/commit/e0e729b300eb19e30ab8a80f2eddfae1692e2a82) | `` airbuddy: init at 2.6.3 ``                                                                            |
| [`120eb0a1`](https://github.com/NixOS/nixpkgs/commit/120eb0a154a245272fa283010fdc366e7007772e) | `` dprint: 0.36.1 -> 0.37.1 ``                                                                           |
| [`335e2b82`](https://github.com/NixOS/nixpkgs/commit/335e2b822d67a4b0ae5f9e0d99dfde839214a0a0) | `` python311Packages.mypy-boto3-s3: 1.26.155 -> 1.26.163 ``                                              |
| [`a892154d`](https://github.com/NixOS/nixpkgs/commit/a892154d2a019e727123cb41fab36bc5f96a5a34) | `` python311Packages.neo4j: 5.9.0 -> 5.10.0 ``                                                           |
| [`8079c9ac`](https://github.com/NixOS/nixpkgs/commit/8079c9ac60279d0f12b3eb0be6ea12b106b4ce7c) | `` nixos: append ccid as a plugin ``                                                                     |
| [`4a0bb282`](https://github.com/NixOS/nixpkgs/commit/4a0bb282a539e872ba9dc7bf91e77f52a61a8033) | `` bluetuith: 0.1.3 -> 0.1.5 ``                                                                          |
| [`d0fd3e47`](https://github.com/NixOS/nixpkgs/commit/d0fd3e475e0338edff2a529783404a053dcc6071) | `` maintainers: add Yvan Sraka ``                                                                        |
| [`32d12036`](https://github.com/NixOS/nixpkgs/commit/32d120363d9d27f9f0776ce42627068d7b02f413) | `` maintainers: add Inigo Querejeta-Azurmendi ``                                                         |
| [`5bbd8577`](https://github.com/NixOS/nixpkgs/commit/5bbd857794eb48c4a9ec75227e56e7631ae6822f) | `` blst: init at 0.3.10 ``                                                                               |
| [`b6449719`](https://github.com/NixOS/nixpkgs/commit/b6449719d40be266f0666de55eaac60ca09eac1d) | `` typst: 0.5.0 -> 0.6.0 ``                                                                              |
| [`f44013b1`](https://github.com/NixOS/nixpkgs/commit/f44013b169ba340931a6fca5e8fcd2ac200b95bd) | `` sftpgo: 2.5.2 -> 2.5.3 ``                                                                             |
| [`9ebebd7b`](https://github.com/NixOS/nixpkgs/commit/9ebebd7b2229203c51eeb1f2e021c70a18c06b40) | `` typos: 1.15.8 -> 1.15.9 ``                                                                            |
| [`244f7cb1`](https://github.com/NixOS/nixpkgs/commit/244f7cb1ad765996427564051072270ffd0cfdcc) | `` vkdt: 0.5.4 -> 0.6.0 ``                                                                               |
| [`08700573`](https://github.com/NixOS/nixpkgs/commit/087005737917978dea67287757ce2afbbbaef48d) | `` vimPlugins.alpha-nvim: add missing dependency ``                                                      |
| [`b800b9c5`](https://github.com/NixOS/nixpkgs/commit/b800b9c509b7602d05ff732ec4e9366f1aec5352) | `` urbit: 2.9 -> 2.10 ``                                                                                 |
| [`fa93045a`](https://github.com/NixOS/nixpkgs/commit/fa93045a5b843395f510e7739197badf9a42004e) | `` nss_latest: 3.90 -> 3.91 ``                                                                           |
| [`19302e5e`](https://github.com/NixOS/nixpkgs/commit/19302e5e28cdf6a1ebf0035d398dbc0d24b3aaf2) | `` biscuit-cli: 0.2.0 -> 0.4.0 ``                                                                        |
| [`0aa5adef`](https://github.com/NixOS/nixpkgs/commit/0aa5adef62d97468a40bb839f81f6ac6fddb8316) | `` nixos/searx: add configuration for redis and limiter settings ``                                      |
| [`85aed1cb`](https://github.com/NixOS/nixpkgs/commit/85aed1cbbbd88011daa41982ca4ab37f0da96325) | `` browsh: 1.8.0 -> 1.8.2 ``                                                                             |
| [`07f1e43b`](https://github.com/NixOS/nixpkgs/commit/07f1e43b3daac8d8597c3b06e38d97bfe54aa524) | `` azure-cli: 2.44.1 -> 2.49.0 ``                                                                        |
| [`071e45ea`](https://github.com/NixOS/nixpkgs/commit/071e45ea88e97eb4ef23bb361f91788a3ca1eb81) | `` azure-mgmt-appcontainers: init at 2.0.0 ``                                                            |
| [`72991ff7`](https://github.com/NixOS/nixpkgs/commit/72991ff74733aff0f21503e1b6836d92a703394e) | `` jetbrains.clion: dont replace cmake and gdb, patch gdb instead ``                                     |
| [`708b8c91`](https://github.com/NixOS/nixpkgs/commit/708b8c91226490544e0cf0a0b8ed22a24b5a3263) | `` udisks2: 2.9.4 -> 2.10.0 ``                                                                           |
| [`7a8ae42b`](https://github.com/NixOS/nixpkgs/commit/7a8ae42b3bfb590bd8f1f277d33a71dba288393b) | `` libblockdev: 2.28 -> 3.0 ``                                                                           |
| [`0c4eec62`](https://github.com/NixOS/nixpkgs/commit/0c4eec625d448143ba1de2d98a7d564b6ca04e4d) | `` fishPlugins.sdkman-for-fish: 1.4.0 -> 2.0.0 ``                                                        |
| [`f797b35d`](https://github.com/NixOS/nixpkgs/commit/f797b35da37958d5a247302ede3e2abe0bc04e1b) | `` jetbrains: add plugin support ``                                                                      |
| [`275579cf`](https://github.com/NixOS/nixpkgs/commit/275579cfe76b2d031b8553a1ffd70bf4b6ee314e) | `` spotdl: 4.1.10 -> 4.1.11 ``                                                                           |
| [`4c85d73e`](https://github.com/NixOS/nixpkgs/commit/4c85d73eeaa9a5f80316c8d3e4cd7f0f4be48478) | `` python310Packages.pytorch-lightning: 2.0.2 -> 2.0.4 ``                                                |
| [`57ca44c0`](https://github.com/NixOS/nixpkgs/commit/57ca44c0aea940569d367af13894a0cb0975c502) | `` lib: simplify stringToCharacters ``                                                                   |
| [`6d284bd5`](https://github.com/NixOS/nixpkgs/commit/6d284bd5621c7b49770aae252881f480f857476a) | `` python310Packages.jenkins-job-builder: 4.3.0 -> 5.0.2 ``                                              |
| [`dcb997cf`](https://github.com/NixOS/nixpkgs/commit/dcb997cfa7ab86a27ad6ce402a4308613ff486e4) | `` svt-av1: 1.5.0 -> 1.6.0 ``                                                                            |
| [`0e1992f5`](https://github.com/NixOS/nixpkgs/commit/0e1992f5e1985a96d88878b7b86885c237cdcf2e) | `` ast-grep: 0.5.2 -> 0.6.6 ``                                                                           |
| [`a2b597dd`](https://github.com/NixOS/nixpkgs/commit/a2b597dd56a270c4717d3e80c5218c7e2a8f9085) | `` audiobookshelf: 2.2.20 -> 2.2.23 ``                                                                   |
| [`676bcc14`](https://github.com/NixOS/nixpkgs/commit/676bcc14c79f2c14cd018527d804024375e49b45) | `` ayatana-ido: 0.9.2 -> 0.10.0 ``                                                                       |
| [`a8e31419`](https://github.com/NixOS/nixpkgs/commit/a8e31419dd5e02302c945a39f80407d5147cab9c) | `` python310Packages.pamela: 1.0.0 -> 1.1.0 ``                                                           |