### PR TITLE
chore(flake/pre-commit-hooks): `522fd47a` -> `42587d34`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -374,11 +374,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1688137124,
-        "narHash": "sha256-ramG4s/+A5+t/QG2MplTNPP/lmBWDtbW6ilpwb9sKVo=",
+        "lastModified": 1688386108,
+        "narHash": "sha256-Vffto9QaVonzYAcPlAzd0soqWYpPpKk60dfNLSIXcFA=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "522fd47af79b66cdd04b92618e65c7a11504650a",
+        "rev": "42587d3414d1747999a5f71e92a83cf6547b62da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                        |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------ |
| [`27375222`](https://github.com/cachix/pre-commit-hooks.nix/commit/27375222d4e4e4a5b0516249aa44374b5baeeb48) | `` hooks.nix: string -> str `` |