### PR TITLE
chore(flake/nixpkgs): `645ff62e` -> `0fbe93c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688231357,
-        "narHash": "sha256-ZOn16X5jZ6X5ror58gOJAxPfFLAQhZJ6nOUeS4tfFwo=",
+        "lastModified": 1688322751,
+        "narHash": "sha256-eW62dC5f33oKZL7VWlomttbUnOTHrAbte9yNUNW8rbk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "645ff62e09d294a30de823cb568e9c6d68e92606",
+        "rev": "0fbe93c5a7cac99f90b60bdf5f149383daaa615f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`b40eaf23`](https://github.com/NixOS/nixpkgs/commit/b40eaf233717e7f8d4368f974759c2a8f151052f) | `` buildkite-agent: 3.48.0 -> 3.49.0 (#241141) ``                              |
| [`ac4790a8`](https://github.com/NixOS/nixpkgs/commit/ac4790a84edc4ef5cf8ba3e97f1155190ee3eace) | `` nixos/jenkins-job-builder: Fix link to documentation, use mkEnableOption `` |
| [`ec0bc24a`](https://github.com/NixOS/nixpkgs/commit/ec0bc24ae9b4bc40476d7f2be0decea55af9498a) | `` osv-scanner: 1.3.4 -> 1.3.5 ``                                              |
| [`415c06ac`](https://github.com/NixOS/nixpkgs/commit/415c06ac3b9dd7b528e50d8470cca2d54c97e408) | `` dualsensectl: init at 0.3 (#240340) ``                                      |
| [`babe3c5d`](https://github.com/NixOS/nixpkgs/commit/babe3c5d59bfa36dc61a11b461393f2042a53a7e) | `` nats-top: add version test ``                                               |
| [`b538ea09`](https://github.com/NixOS/nixpkgs/commit/b538ea0971ebe1fdc58387fb79b9712610d44005) | `` nats-top: fix version ``                                                    |
| [`12b51efc`](https://github.com/NixOS/nixpkgs/commit/12b51efc76f10cfb77e98c803ae52acf0e0adc58) | `` leptonica: from 1.83.0 -> to 1.83.1 ``                                      |
| [`62d0b019`](https://github.com/NixOS/nixpkgs/commit/62d0b01901b420abd73dc5d8a63873d839e3f59e) | `` nix-derivation: add top-level entry that just has the static executable ``  |
| [`908a6c4a`](https://github.com/NixOS/nixpkgs/commit/908a6c4ad9f8e37b84f64dbf2f25d39293e6da13) | `` sox: use fetchgit instead of sourceforge unreliable snapshot url ``         |
| [`0f43b194`](https://github.com/NixOS/nixpkgs/commit/0f43b19454e73731b8dbe3c6bf2f10f906f526de) | `` nats-top: 0.6.0 -> 0.6.1 ``                                                 |
| [`02ccdac1`](https://github.com/NixOS/nixpkgs/commit/02ccdac17a3ab2de6317d6230d11fb1d06bd4303) | `` flix: 0.37.0 -> 0.38.0 ``                                                   |
| [`b477b770`](https://github.com/NixOS/nixpkgs/commit/b477b770c100ca38e2fce926f4f7d122e6da91a1) | `` upbound: 0.17.0 -> 0.18.0 ``                                                |
| [`01d60748`](https://github.com/NixOS/nixpkgs/commit/01d60748f601dd0ac256a29a253db8ad8fb9a289) | `` ockam: 0.89.0 -> 0.90.0 ``                                                  |
| [`9bde267e`](https://github.com/NixOS/nixpkgs/commit/9bde267e7fbd053c2c02df0e1c0815656a39285c) | `` automatic-timezoned: 1.0.102 -> 1.0.106 ``                                  |
| [`1861099f`](https://github.com/NixOS/nixpkgs/commit/1861099f1cf87577b6ad425fb1ba9d2abf85dba1) | `` diswall: 0.4.0 -> 0.4.1 ``                                                  |
| [`55183186`](https://github.com/NixOS/nixpkgs/commit/5518318695dcc3bf5837435d1630f36de5aee43c) | `` gopsuinfo: 0.1.4 -> 0.1.5 ``                                                |
| [`19fb558e`](https://github.com/NixOS/nixpkgs/commit/19fb558e75f94d6d2bb4977b250194fc47de675d) | `` arkade: 0.9.22 -> 0.9.23 ``                                                 |
| [`669ca0f2`](https://github.com/NixOS/nixpkgs/commit/669ca0f2a630689f2dd4af9efbdc8fa4732a2cce) | `` slint-lsp: 1.0.2 -> 1.1.0 ``                                                |
| [`a2b811fb`](https://github.com/NixOS/nixpkgs/commit/a2b811fb0509b9cd49183a9592b125a549dfded7) | `` tbls: 1.67.1 -> 1.68.0 ``                                                   |
| [`8bee0c00`](https://github.com/NixOS/nixpkgs/commit/8bee0c00fad7dcbd3bc05ae382799ad4bc12158d) | `` kode-mono: 1.017 -> 1.018 ``                                                |
| [`448ba394`](https://github.com/NixOS/nixpkgs/commit/448ba394587a3a10c313aca35a96d64a0254ebcb) | `` allure: 2.22.4 -> 2.23.0 ``                                                 |
| [`441bf670`](https://github.com/NixOS/nixpkgs/commit/441bf670e8f1e2e6a5fbaaec3b59ffcd7872f953) | `` xorg.*: prefer mirror://xorg urls ``                                        |
| [`fd830fa5`](https://github.com/NixOS/nixpkgs/commit/fd830fa53ec68d786252dd60ca56d6731b77c424) | `` talosctl: 1.4.5 -> 1.4.6 ``                                                 |
| [`c08c3818`](https://github.com/NixOS/nixpkgs/commit/c08c381840a64a0f404b8cc262e83f5b6ee92b00) | `` python311Packages.bimmer-connected: 0.13.7 -> 0.13.8 ``                     |
| [`0d894598`](https://github.com/NixOS/nixpkgs/commit/0d894598056081c3813df42c3f3f8d5a889391be) | `` python311Packages.griffe: 0.29.1 -> 0.30.0 ``                               |
| [`bc29512c`](https://github.com/NixOS/nixpkgs/commit/bc29512c02b76ef0f4385d13d25a35a7dee6f591) | `` python311Packages.fastapi-mail: 1.3.0 -> 1.3.1 ``                           |
| [`cad78a90`](https://github.com/NixOS/nixpkgs/commit/cad78a90eda09b72f92b0f7464260eb4c90f1e2b) | `` python310Packages.aiobiketrax: 1.0.0 -> 1.1.0 ``                            |
| [`0a29e243`](https://github.com/NixOS/nixpkgs/commit/0a29e2431f87f69c5e48429f0b08398c4f2948b9) | `` cargo-toml-lint: init at 0.1.1 ``                                           |
| [`431241d0`](https://github.com/NixOS/nixpkgs/commit/431241d0ba41e808779ca48c771e84b72e92ba32) | `` skaffold: 2.5.0 -> 2.6.0 ``                                                 |
| [`e3b9fee1`](https://github.com/NixOS/nixpkgs/commit/e3b9fee1c5393f8e89573356545233071508f60c) | `` python311Packages.sentry-sdk: 1.25.1 -> 1.26.0 ``                           |
| [`dd39a389`](https://github.com/NixOS/nixpkgs/commit/dd39a3893203491f9471dc4ce7709220a0cbfbef) | `` python310Packages.camel-converter: 3.0.2 -> 3.0.2 ``                        |
| [`d7f1e53e`](https://github.com/NixOS/nixpkgs/commit/d7f1e53e6b31f605c9058488b8f23d8395b04daf) | `` oauth2c: 1.8.0 -> 1.9.0 ``                                                  |
| [`63bd7437`](https://github.com/NixOS/nixpkgs/commit/63bd7437bd4c0df3f87368747424fe965672d9fe) | `` nixVersions: hide removed versions for allowAliases = false ``              |
| [`26afd529`](https://github.com/NixOS/nixpkgs/commit/26afd529e5503bd51b6df791f1a54ba526076009) | `` pkgsMusl.crosvm: fix build ``                                               |
| [`44d6f122`](https://github.com/NixOS/nixpkgs/commit/44d6f122232ce2dc88b4b16fd901f178c470cf98) | `` delve: 1.20.2 -> 1.21.0 ``                                                  |
| [`8836ad8b`](https://github.com/NixOS/nixpkgs/commit/8836ad8bcfd414280d1c3b7289b9569085a06eff) | `` ibus: fix SIGABRT[1] in X11 ``                                              |
| [`44c39f9a`](https://github.com/NixOS/nixpkgs/commit/44c39f9a309750d7fa079c8340b18e0fa1f21c99) | `` carapace: 0.24.5 -> 0.25.0 ``                                               |
| [`21cc07af`](https://github.com/NixOS/nixpkgs/commit/21cc07af0355ebef61718cff581d87aaaa5f0573) | `` monetdb: 11.45.17 -> 11.47.3 ``                                             |
| [`9ddaa0d4`](https://github.com/NixOS/nixpkgs/commit/9ddaa0d44bafbccbf6ce60dd5b9ea76650c7cb5e) | `` syft: 0.83.1 -> 0.84.0 ``                                                   |
| [`b6d2db81`](https://github.com/NixOS/nixpkgs/commit/b6d2db811bb6a3d891fd4621c9372b02539fbdc9) | `` dolt: 1.5.0 -> 1.7.0 ``                                                     |
| [`27a3fdb9`](https://github.com/NixOS/nixpkgs/commit/27a3fdb9745e8a725fd2c53dbafc0ace3143a790) | `` lightningcss: 1.21.1 → 1.21.2 ``                                            |
| [`0ec4902e`](https://github.com/NixOS/nixpkgs/commit/0ec4902ee3efc8505211ccd1606da36496dab4e8) | `` moon: 1.8.3 -> 1.9.1 ``                                                     |
| [`4b061cf3`](https://github.com/NixOS/nixpkgs/commit/4b061cf3902c196e0bbdf5f140629925f1b9d9fa) | `` terraform-providers.alicloud: 1.207.0 -> 1.207.1 ``                         |
| [`27fb3c8e`](https://github.com/NixOS/nixpkgs/commit/27fb3c8e5f28b583ea68bdbaf844d20f6732845d) | `` terraform-providers.aci: 2.8.0 -> 2.9.0 ``                                  |
| [`c49936a2`](https://github.com/NixOS/nixpkgs/commit/c49936a20ac67126d9251066d85e0789e9d16cf0) | `` netdata: 1.40.0 -> 1.40.1 ``                                                |
| [`c07b2c66`](https://github.com/NixOS/nixpkgs/commit/c07b2c6679d866c3776c1924718434275fbb869c) | `` cloudfox: 1.11.2 -> 1.11.3 ``                                               |
| [`68744247`](https://github.com/NixOS/nixpkgs/commit/6874424765fcb9330dabe573b04e65c09c212a3b) | `` xorg.xinit: drop upstreamed patch ``                                        |
| [`ac703953`](https://github.com/NixOS/nixpkgs/commit/ac70395304a1631e6260af12372260e9d7ba9dbd) | `` xorg.xdm: drop outdated patch ``                                            |
| [`7e77b37e`](https://github.com/NixOS/nixpkgs/commit/7e77b37e436f0f311cf757dfb2c43bc9e192dc7c) | `` bazel-remote: 2.4.0 -> 2.4.1 ``                                             |
| [`c22e8f1d`](https://github.com/NixOS/nixpkgs/commit/c22e8f1d0d8302f3708050bce0ee4afd41d46654) | `` pylyzer: 0.0.31 -> 0.0.33 ``                                                |
| [`ee11ba6b`](https://github.com/NixOS/nixpkgs/commit/ee11ba6bfea1bad8f44e375fe4c88fa9ec7d4929) | `` flyctl: 0.1.40 -> 0.1.43 ``                                                 |
| [`17300d6e`](https://github.com/NixOS/nixpkgs/commit/17300d6e49053e87596c205a40075d3cad10c3c6) | `` gotrue-supabase: 2.76.0 -> 2.77.1 ``                                        |
| [`e7dee7b6`](https://github.com/NixOS/nixpkgs/commit/e7dee7b60808fbe265b1e7c5eb0e704c96b9dd35) | `` netbird-ui: 0.21.7 -> 0.21.8 ``                                             |
| [`952c9e87`](https://github.com/NixOS/nixpkgs/commit/952c9e874c2ca79e1aa1d0d025a78ce5f741a275) | `` okteto: 2.16.3 -> 2.16.5 ``                                                 |
| [`bf9607a6`](https://github.com/NixOS/nixpkgs/commit/bf9607a69fbdc464fbb7eb0f330c127435b3b863) | `` okta-aws-cli: 1.0.1 -> 1.0.2 ``                                             |
| [`3c176486`](https://github.com/NixOS/nixpkgs/commit/3c176486ef173b050edcb44b71048be888873c33) | `` xorg.*: update all fonts ``                                                 |
| [`b9c4be7e`](https://github.com/NixOS/nixpkgs/commit/b9c4be7e414ea1d995a4b03442bd49e856d81620) | `` ttdl: 3.9.0 -> 3.10.0 ``                                                    |
| [`19f921cc`](https://github.com/NixOS/nixpkgs/commit/19f921ccdb3d2166e8cab5fcff2757fd81f778d9) | `` ko: 0.13.0 -> 0.14.1 ``                                                     |
| [`2f7be470`](https://github.com/NixOS/nixpkgs/commit/2f7be470282040897d3f593f5a585961cb650ad3) | `` gfold: 4.3.3 -> 4.4.0 ``                                                    |
| [`528afff1`](https://github.com/NixOS/nixpkgs/commit/528afff1f95bf82c4e3d4f24a8f740500c9bdebf) | `` xorg.*: update all individual apps ``                                       |
| [`5cc071d6`](https://github.com/NixOS/nixpkgs/commit/5cc071d6bb3d7c6cbe509d0857b3c9d98737889c) | `` trunk: 0.16.0 -> 0.17.1 ``                                                  |
| [`4f439bea`](https://github.com/NixOS/nixpkgs/commit/4f439bea95aa7a67134b988bc01be1438d1d216b) | `` gtree: 1.8.4 -> 1.8.5 ``                                                    |
| [`560dae86`](https://github.com/NixOS/nixpkgs/commit/560dae862f5c903df830e24a3fbef0c7d2008cf5) | `` rclone: 1.62.2 -> 1.63.0 (#240743) ``                                       |
| [`2e7a2ea3`](https://github.com/NixOS/nixpkgs/commit/2e7a2ea30d9e969d3f21ddffdf372520e8d974d8) | `` v2ray-domain-list-community: 20230621141418 -> 20230627034247 ``            |
| [`666666aa`](https://github.com/NixOS/nixpkgs/commit/666666aae4107a065721a19a285f07ef63be5adb) | `` ncpamixer: 1.3.3.4 -> 1.3.3.5, drop inactive maintainer ``                  |
| [`42424272`](https://github.com/NixOS/nixpkgs/commit/424242721cc1ca72a5ad1fde9956e404a36a21db) | `` python3Packages.nose3: init at 1.3.8 ``                                     |
| [`5b414c13`](https://github.com/NixOS/nixpkgs/commit/5b414c1307f6eecf3c8e928d68fd477cc67054b3) | `` dbip-country-lite: 2023-06 -> 2023-07 ``                                    |
| [`eacd9ad0`](https://github.com/NixOS/nixpkgs/commit/eacd9ad04d57f166a538d5642d5e1753c90f2416) | `` openjdk: init at 20+36 and openjfx: init at 20+19 ``                        |
| [`f1aea507`](https://github.com/NixOS/nixpkgs/commit/f1aea5075400803ba5c57e4964089316547033b9) | `` temurin-bin: init 20.0.1 ``                                                 |
| [`3e01bd32`](https://github.com/NixOS/nixpkgs/commit/3e01bd323bea602392247a0779f1e1c8158a7975) | `` temurin-bin/sources.json: regenerate ``                                     |
| [`f5c560df`](https://github.com/NixOS/nixpkgs/commit/f5c560df566f09f212370b830551b70b0e425ee1) | `` gvproxy: 0.6.1 -> 0.6.2 ``                                                  |
| [`6efe434d`](https://github.com/NixOS/nixpkgs/commit/6efe434d39b10a159d6d0cfbce5e90e29ee78c13) | `` netavark: 1.6.0 -> 1.7.0 ``                                                 |
| [`1057042c`](https://github.com/NixOS/nixpkgs/commit/1057042ccc0780c157ac756135e903865eeabe75) | `` aardvark-dns: 1.6.0 -> 1.7.0 ``                                             |
| [`885617e2`](https://github.com/NixOS/nixpkgs/commit/885617e288a03500abc46a6762214ae006db7430) | `` tailer: add version test ``                                                 |
| [`20bb9341`](https://github.com/NixOS/nixpkgs/commit/20bb934115dc1dd8074f5dc1f5992aafde355898) | `` tailer: unstable-2023-06-26 -> 0.1.1 ``                                     |
| [`d186c2cf`](https://github.com/NixOS/nixpkgs/commit/d186c2cff96a714feb3ae3f8a173dbd7286feb67) | `` intel-compute-runtime: 23.17.26241.15 -> 23.17.26241.24 ``                  |
| [`93c48e3b`](https://github.com/NixOS/nixpkgs/commit/93c48e3b0db6d6aa0fc1a00f01d0620e7e0d7b7d) | `` python310Packages.reolink-aio: 0.7.0 -> 0.7.2 ``                            |
| [`d3812c83`](https://github.com/NixOS/nixpkgs/commit/d3812c83070176a5503b8e75c7b0c3ade1a01038) | `` ghz: add version tests ``                                                   |
| [`2768f7d4`](https://github.com/NixOS/nixpkgs/commit/2768f7d4f0cbc2877bdd858933bed17f4010d7d2) | `` ghz: fix version ``                                                         |
| [`eda43a20`](https://github.com/NixOS/nixpkgs/commit/eda43a206a963ed641ed01fba4e9f8c5b295ed37) | `` pysolfc: 2.16.0 -> 2.20.1 ``                                                |
| [`cdab43d4`](https://github.com/NixOS/nixpkgs/commit/cdab43d496307c346409f190383d90f9bb800c91) | `` kamailio: init at 5.7.1 ``                                                  |
| [`b14d1e3c`](https://github.com/NixOS/nixpkgs/commit/b14d1e3cf2f11ba83da23f815da2aace75a816ec) | `` maintainers: add Matthias Wimmer ``                                         |
| [`7c75ba9f`](https://github.com/NixOS/nixpkgs/commit/7c75ba9ff2314a80bca070671f44c04127cfb73a) | `` diffoscope: 233 -> 243 ``                                                   |
| [`569e52ad`](https://github.com/NixOS/nixpkgs/commit/569e52ad024f83ebac2522d2ec9f99e57f1bb09e) | `` diffoscope: switch to python3.pkgs ``                                       |
| [`74aa74f3`](https://github.com/NixOS/nixpkgs/commit/74aa74f3784a6bb8586d65fb8d3730f4438e8980) | `` wolfstoneextract: init at 1.2 ``                                            |
| [`cdb73f38`](https://github.com/NixOS/nixpkgs/commit/cdb73f3806a77c54aa8291623b46242b205df4e4) | `` diffoscope: equalize the content ``                                         |
| [`9faaa2a3`](https://github.com/NixOS/nixpkgs/commit/9faaa2a3e2f51e7212e6801796529244c4ffc005) | `` ledfx: add openrgb-python ``                                                |
| [`19583037`](https://github.com/NixOS/nixpkgs/commit/1958303754a840765ed0c7a0e244ced6d8511e89) | `` python311Packages.openrgb-python: init at 0.2.15 ``                         |
| [`5e24dfe3`](https://github.com/NixOS/nixpkgs/commit/5e24dfe3ff50432078479a06144efb65503b5899) | `` python311Packages.referencing: init at 0.29.0 ``                            |
| [`693c5204`](https://github.com/NixOS/nixpkgs/commit/693c5204dc06b66e5a54d70f59c123811449a610) | `` linuxKernel.kernels.linux_lqx: 6.3.4-lqx1 -> 6.3.11-lqx2 ``                 |
| [`19ea13b2`](https://github.com/NixOS/nixpkgs/commit/19ea13b28871a346cc4b95d99058c248be99ce4e) | `` linuxKernel.kernels.linux_zen: 6.3.4-zen1 -> 6.4.1-zen1 ``                  |
| [`c58d7882`](https://github.com/NixOS/nixpkgs/commit/c58d788284e046403dac33d12e54613247799379) | `` python311Packages.rpds-py: init at 0.7.1 ``                                 |
| [`56a18057`](https://github.com/NixOS/nixpkgs/commit/56a180579004f0eee696be7654a12c64e294b58d) | `` pcsc-cyberjack: add flokli to maintainers ``                                |
| [`3d3525ec`](https://github.com/NixOS/nixpkgs/commit/3d3525ec94e15ab5de17cbc45946b21b61ea389e) | `` pcsc-cyberjack: 3.99.5_SP13 -> 3.99.5_SP15 ``                               |
| [`b03ec6c1`](https://github.com/NixOS/nixpkgs/commit/b03ec6c15f5886ebf8ed69228266bd750f48faa9) | `` verifpal: 0.26.1 -> 0.27.0 (#240880) ``                                     |
| [`47192222`](https://github.com/NixOS/nixpkgs/commit/47192222e8c7ff130c3ba23201a9d00f84450f9a) | `` python310Packages.auth0-python: 4.2.0 -> 4.3.0 ``                           |
| [`e8daa262`](https://github.com/NixOS/nixpkgs/commit/e8daa26290cb6ca0ed926073e7bb0ada76559746) | `` alacritty: 0.12.1 -> 0.12.2 (#240962) ``                                    |
| [`755b6640`](https://github.com/NixOS/nixpkgs/commit/755b664031761e9fc7c82556a4a4791785ce7966) | `` nim: 1.6.12 -> 1.6.14 ``                                                    |
| [`24b2fd66`](https://github.com/NixOS/nixpkgs/commit/24b2fd66f88e129b85df152c5c8edb3b853273c5) | `` colloid-icon-theme: 2023-03-28 -> 2023-07-01 ``                             |
| [`26b4a919`](https://github.com/NixOS/nixpkgs/commit/26b4a919207a2ce8520b8947d44cdcbd48701d4b) | `` python311Packages.natsort: 8.3.1 -> 8.4.0 ``                                |
| [`464e1a42`](https://github.com/NixOS/nixpkgs/commit/464e1a42e076fb9a289f8d51a9cadb53c53f0577) | `` python3Packages.django-compressor: add changelog to meta ``                 |
| [`96ac17cf`](https://github.com/NixOS/nixpkgs/commit/96ac17cf98a3b150f4c2ce58faad250241615731) | `` python311Packages.crc: disable on unsupported Python releases ``            |
| [`c370fa75`](https://github.com/NixOS/nixpkgs/commit/c370fa7514e1dca0ceed6740ab76cc9dc196e248) | `` python310Packages.openaiauth: add format ``                                 |
| [`bfb398b8`](https://github.com/NixOS/nixpkgs/commit/bfb398b80bf196b7177f3bac0ff0490d1eec4e15) | `` morgen: 2.7.3 -> 2.7.4 ``                                                   |
| [`5cd39960`](https://github.com/NixOS/nixpkgs/commit/5cd399600639bc2724a8ab9152cf4fc8b86d4e3b) | `` python310Packages.lightning-utilities: 0.8.0 -> 0.9.0 ``                    |
| [`5803226c`](https://github.com/NixOS/nixpkgs/commit/5803226cfef2489111a65b37569b8497d455f3b9) | `` python310Packages.openaiauth: 1.0.2 -> 2.0.0 ``                             |
| [`abaecff3`](https://github.com/NixOS/nixpkgs/commit/abaecff35863db2b103d1cddb30a92cfe9a91455) | `` python310Packages.wagtail-localize: 1.5 -> 1.5.1 ``                         |
| [`b1afa702`](https://github.com/NixOS/nixpkgs/commit/b1afa702b9adf6846f59c6793fd5dd7acc696a12) | `` ncpamixer: 1.3.3.3 -> 1.3.3.4 ``                                            |
| [`61cb4170`](https://github.com/NixOS/nixpkgs/commit/61cb4170fdd0c0f1002fc96cb905c0e7a7b94930) | `` nixos/static-web-server: create module which uses upstream systemd units `` |
| [`19c7a65e`](https://github.com/NixOS/nixpkgs/commit/19c7a65eefbbd11473da5030e5ad2352eabf14df) | `` python310Packages.calmjs-types: init at 1.0.1 ``                            |
| [`6a2abb1e`](https://github.com/NixOS/nixpkgs/commit/6a2abb1ea6ed6faa270e0e48edf58bed514d1017) | `` python310Packages.calmjs: init at 3.4.4 ``                                  |
| [`43b5e147`](https://github.com/NixOS/nixpkgs/commit/43b5e1479bf00fa229c4dd4fde7d8c281a98da0e) | `` python310Packages.django-sekizai: init at 4.1.0 ``                          |
| [`a61134c7`](https://github.com/NixOS/nixpkgs/commit/a61134c74c0d6a27ad61e93b04d5eec6088eb2bf) | `` python310Packages.django-compressor: Enable more tests ``                   |