### PR TITLE
chore(flake/home-manager): `b406b8d1` -> `2f78e6fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688467264,
-        "narHash": "sha256-AUQP1WtmBb36bRc41p5ieTwq6Y8pgiKurbdrsPeP3fg=",
+        "lastModified": 1688538658,
+        "narHash": "sha256-clmdd/NB9jqhuB9TlSyj9nI1dW2rqroPQCsHGYfD1jU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b406b8d1bc90f6cd3e120d189b3e929f17ca4aea",
+        "rev": "2f78e6fcba61ce81536d19e6c662e55ab272d539",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`2f78e6fc`](https://github.com/nix-community/home-manager/commit/2f78e6fcba61ce81536d19e6c662e55ab272d539) | `` antidote: static file move to /tmp ``   |
| [`b66af0ac`](https://github.com/nix-community/home-manager/commit/b66af0ac666d01f95c8f83e60b02a851700c048c) | `` Translate using Weblate (Indonesian) `` |