### PR TITLE
chore(flake/nixpkgs): `0fbe93c5` -> `78419eda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688322751,
-        "narHash": "sha256-eW62dC5f33oKZL7VWlomttbUnOTHrAbte9yNUNW8rbk=",
+        "lastModified": 1688500189,
+        "narHash": "sha256-djYYiY4lzJOlXOnTHytH6BUugrxHDZjuGxTSrU4gt4M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0fbe93c5a7cac99f90b60bdf5f149383daaa615f",
+        "rev": "78419edadf0fabbe5618643bd850b2f2198ed060",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`9ef5b7d7`](https://github.com/NixOS/nixpkgs/commit/9ef5b7d793a0ac1f1742696b5ec668169ff9c80d) | `` nixos/x11: change the description of the display manager service ``               |
| [`bd3da6b6`](https://github.com/NixOS/nixpkgs/commit/bd3da6b6f2afda870927f55290169f91198675be) | `` csvquote: fix typo ``                                                             |
| [`af5be901`](https://github.com/NixOS/nixpkgs/commit/af5be9016d00f2694b20cf0a5f9fa6ea111dce6c) | `` static-web-server: fix typo ``                                                    |
| [`8934558a`](https://github.com/NixOS/nixpkgs/commit/8934558abf86544fa8e77b137398f906478c9abf) | `` nixos/gitlab: fix unit test result display (#241322) ``                           |
| [`b6bc8950`](https://github.com/NixOS/nixpkgs/commit/b6bc8950f7130073f6eda05cc6c55e73217084c7) | `` tgpt: 1.6.11 -> 1.6.12 ``                                                         |
| [`6ca03804`](https://github.com/NixOS/nixpkgs/commit/6ca03804b621c2a82ebdd20cc87f6d397dda2e23) | `` firefox-esr-102-unwrapped: 102.12.0esr -> 102.13.0esr ``                          |
| [`10c0b4ef`](https://github.com/NixOS/nixpkgs/commit/10c0b4ef9688622eea1b5e0f7a09b728dd0229f9) | `` pythonPackages.cligj: meta.description: fix typo ``                               |
| [`c3aaeac5`](https://github.com/NixOS/nixpkgs/commit/c3aaeac51790410684b9923d687e1aa7f0282306) | `` unbound: fix comment typo ``                                                      |
| [`85a56839`](https://github.com/NixOS/nixpkgs/commit/85a56839aaaf17a66a02f4b6d5acf750b23f5334) | `` perl: meta.description: fix typo ``                                               |
| [`31bbf919`](https://github.com/NixOS/nixpkgs/commit/31bbf919d3dcace0841156ce8524512731bf229f) | `` spidermonkey_102: 102.12.0 -> 102.13.0 ``                                         |
| [`cb376285`](https://github.com/NixOS/nixpkgs/commit/cb3762857d1aa0951b3bd4b427994eab9002e517) | `` nss: update passthru tests for firefox-esr-115 ``                                 |
| [`1635aae3`](https://github.com/NixOS/nixpkgs/commit/1635aae3cd72cb83cfdc782e5966089ebb248b3e) | `` nspr: update passthru tests with firefox-esr-115 ``                               |
| [`06f0af1f`](https://github.com/NixOS/nixpkgs/commit/06f0af1f0a46c163f7599de77e7d64020fe2152f) | `` firefox-esr-115-unwrapped: init at 115.0esr ``                                    |
| [`0d411bf7`](https://github.com/NixOS/nixpkgs/commit/0d411bf79387e564750663119f8cb4a7f9bbd4bc) | `` firefox-bin-unwrapped: 114.0.2 -> 115.0 ``                                        |
| [`02d750dc`](https://github.com/NixOS/nixpkgs/commit/02d750dcde55bc65ff8570cbefd718882f464602) | `` firefox-unwrapped: 114.0.2 -> 115.0 ``                                            |
| [`748309b4`](https://github.com/NixOS/nixpkgs/commit/748309b4ae952c7e557d1bdfab37cb2997987cac) | `` uptime-kuma: 1.22.0 -> 1.22.1 ``                                                  |
| [`695909a2`](https://github.com/NixOS/nixpkgs/commit/695909a226ef287c5753edef3b676d77bfc96973) | `` frp: 0.49.0 -> 0.50.0 ``                                                          |
| [`fac18fdb`](https://github.com/NixOS/nixpkgs/commit/fac18fdb2ce36419d07297cc2b097e31fd620958) | `` autodock-vina: 1.2.3 -> 1.2.5 ``                                                  |
| [`14fdc5f7`](https://github.com/NixOS/nixpkgs/commit/14fdc5f74397a880d7b0217868ae1898a0e8d075) | `` pylyzer: 0.0.33 -> 0.0.34 ``                                                      |
| [`fa7be255`](https://github.com/NixOS/nixpkgs/commit/fa7be255628165a8a2381ec6e6a861e64c856a76) | `` hcxtools: 6.3.0 -> 6.3.1 ``                                                       |
| [`ca61eca7`](https://github.com/NixOS/nixpkgs/commit/ca61eca7badd359008606f7d9789ddcdced1274b) | `` python310Packages.immutabledict: 2.2.4 -> 2.2.5 ``                                |
| [`0836f8a2`](https://github.com/NixOS/nixpkgs/commit/0836f8a266cc59ef9a97caacc1b374aba633a427) | `` syft: 0.84.0 -> 0.84.1 ``                                                         |
| [`c31bda50`](https://github.com/NixOS/nixpkgs/commit/c31bda504ca006eb4cbb2c40177396a69819e98e) | `` lib/trivial: Bump oldestSupportedReleaseto to 23.05 ``                            |
| [`19a12763`](https://github.com/NixOS/nixpkgs/commit/19a1276370bb0a05de5528bd24e414098a0c6a96) | `` workflows/periodic-merge: drop 22.11 jobs ``                                      |
| [`be9da40a`](https://github.com/NixOS/nixpkgs/commit/be9da40ad57e24f4f85754f9a445ff58ef3b9eec) | `` operator-sdk: 1.29.0 -> 1.30.0 ``                                                 |
| [`9b6cd14a`](https://github.com/NixOS/nixpkgs/commit/9b6cd14a40a063c1ce44e713e7daeb1fb6d157f3) | `` kubecm: 0.23.0 -> 0.24.1 ``                                                       |
| [`92151063`](https://github.com/NixOS/nixpkgs/commit/921510632d2172766c9d7d6653e010540bbf0973) | `` wayshot: 1.2.2 -> 1.3.0 ``                                                        |
| [`ba3b1b6b`](https://github.com/NixOS/nixpkgs/commit/ba3b1b6befb5e6fee0bc70e630087b9a95df21be) | `` cargo-pgrx: 0.9.6 -> 0.9.7 ``                                                     |
| [`1a890328`](https://github.com/NixOS/nixpkgs/commit/1a890328fc5ea3106a7155bbaac5cf98ea77fed4) | `` doppler: 3.62.0 -> 3.63.0 ``                                                      |
| [`1ab3101c`](https://github.com/NixOS/nixpkgs/commit/1ab3101cb43a908ad4309c113ff7bbef5b0e3e4b) | `` dnsproxy: 0.50.2 -> 0.51.0 ``                                                     |
| [`8c35f9ac`](https://github.com/NixOS/nixpkgs/commit/8c35f9ac5806c6061bda049afdc134f050c79cdb) | `` esphome: 2023.6.3 -> 2023.6.4 ``                                                  |
| [`65fd312a`](https://github.com/NixOS/nixpkgs/commit/65fd312a00a68299aba65a27cef636d0dc254c72) | `` python310Packages.django-simple-captcha: 0.5.17 -> 0.5.18 ``                      |
| [`8d922319`](https://github.com/NixOS/nixpkgs/commit/8d922319b7732c152890504df92bf439ea7b828e) | `` geomyidae: fix build on darwin (#241438) ``                                       |
| [`07f07296`](https://github.com/NixOS/nixpkgs/commit/07f072968ca17e9e5f018a9b2042be5f2b582662) | `` passage: fix getopt path on darwin ``                                             |
| [`f7b9340a`](https://github.com/NixOS/nixpkgs/commit/f7b9340a7256d08380ccfa4810ee908d304b7b38) | `` nwg-dock-hyprland: 0.1.2 -> 0.1.3 ``                                              |
| [`06e93417`](https://github.com/NixOS/nixpkgs/commit/06e9341752d178a2cd42ba3ba714504825dcdb6c) | `` sexp: 0.8.6 -> sexpp 0.8.7 ``                                                     |
| [`4da27723`](https://github.com/NixOS/nixpkgs/commit/4da27723f3135a769ca52aff05148c76b7bb5123) | `` mullvad-vpn: support `aarch64-linux` ``                                           |
| [`0daabae8`](https://github.com/NixOS/nixpkgs/commit/0daabae8e7b441f563192884c4dcdf2fa771412f) | `` hcxdumptool: 6.3.0 -> 6.3.1 ``                                                    |
| [`71d96f5d`](https://github.com/NixOS/nixpkgs/commit/71d96f5d59d0f180729c07d6c4201f16c01b3e10) | `` konstraint: 0.29.1 -> 0.30.0 ``                                                   |
| [`9cf1e8c1`](https://github.com/NixOS/nixpkgs/commit/9cf1e8c111137e582c7bd96de8cc1b63b5be93a7) | `` symfony-cli: add meta.mainProgram ``                                              |
| [`f43320fb`](https://github.com/NixOS/nixpkgs/commit/f43320fb1f1a44b840e4456ba572fbc0e1c91b7a) | `` cardinal: set mainProgram in meta ``                                              |
| [`fae866cf`](https://github.com/NixOS/nixpkgs/commit/fae866cfcb9846f27cccaa514b054a233b371a31) | `` clightning: 23.05.1 -> 23.05.2 ``                                                 |
| [`7fa32147`](https://github.com/NixOS/nixpkgs/commit/7fa3214703352ebd39a800b7f79d6f30753e06e9) | `` ankisyncd: 1.1.3 -> 1.1.4 ``                                                      |
| [`fbe3e3b4`](https://github.com/NixOS/nixpkgs/commit/fbe3e3b44e64f20236c568bd11c0e5c82f5c1792) | `` replace ankisyncd with ankisyncd-rs ``                                            |
| [`668f528b`](https://github.com/NixOS/nixpkgs/commit/668f528b6ca75a0a80ab5bb137d85a4ba677c603) | `` nixos/ankisyncd: use ankisyncd-rs instead of the old python one ``                |
| [`5c7df30c`](https://github.com/NixOS/nixpkgs/commit/5c7df30c0aae8ec6dcb96edfd661643d5a25fd9b) | `` ankisyncd-rs: add package for anki-sync-server-rs ``                              |
| [`010d2011`](https://github.com/NixOS/nixpkgs/commit/010d201115c29274294f4b3301817906a2d58546) | `` ardour: set mainProgram in meta ``                                                |
| [`ab139747`](https://github.com/NixOS/nixpkgs/commit/ab1397475c5f21cdb78e91e1a4a782cb8f6935c1) | `` jami: use fmt_9 and msgpack ``                                                    |
| [`bb625eb4`](https://github.com/NixOS/nixpkgs/commit/bb625eb45c21990e5c268ee4a7d02b9c5abd737c) | `` pulsarctl: 2.10.3.3 -> 2.11.1.3 ``                                                |
| [`77ccd192`](https://github.com/NixOS/nixpkgs/commit/77ccd192b3b92b52658b7df5d306b290163e07c7) | `` git-codereview: 1.2.0 -> 1.3.0 ``                                                 |
| [`441e925d`](https://github.com/NixOS/nixpkgs/commit/441e925d48165eea0f262c2e9ccb6deecf85d7f5) | `` prometheus-fastly-exporter: 7.5.1 -> 7.6.0 ``                                     |
| [`041a1248`](https://github.com/NixOS/nixpkgs/commit/041a124886908f0fe9c9d4fa4ba4f82c27426787) | `` gex: 0.3.8 -> 0.4.0 ``                                                            |
| [`5109666f`](https://github.com/NixOS/nixpkgs/commit/5109666fad662f8ba9316e318645713f4aec2efd) | `` sonic-pi: 4.3.0 -> 4.4.0 ``                                                       |
| [`95cca6d2`](https://github.com/NixOS/nixpkgs/commit/95cca6d266935d3f2650385e54ec20b34b54c52a) | `` gucci: 1.6.6 -> 1.6.10 ``                                                         |
| [`7e681d7f`](https://github.com/NixOS/nixpkgs/commit/7e681d7f668e033fff1c660a3d3b442de7e5947b) | `` slowlorust: fix build on darwin ``                                                |
| [`1a6370f6`](https://github.com/NixOS/nixpkgs/commit/1a6370f64c97a65c1422bf467575b47116c33a02) | `` wagyu: update tag to disambiguate revision ``                                     |
| [`f3a22964`](https://github.com/NixOS/nixpkgs/commit/f3a2296445df5ca6b8aa6aac6132365c0735c751) | `` passage: use getopt from nix on darwin (#241293) ``                               |
| [`16c79f5f`](https://github.com/NixOS/nixpkgs/commit/16c79f5f3011894a4214da4642bfc2381bb76758) | `` fitnesstrax: remove since it is gone upstream ``                                  |
| [`c6759017`](https://github.com/NixOS/nixpkgs/commit/c67590170e771cd23fe40353dff55fadf9fb963d) | `` php81Packages.box: 4.2.0 -> 4.3.8 (#241427) ``                                    |
| [`dc3fa5c6`](https://github.com/NixOS/nixpkgs/commit/dc3fa5c6af73d9f5651416bc63a4ea773ccc6149) | `` python310Packages.holidays: update disabled ``                                    |
| [`3095204c`](https://github.com/NixOS/nixpkgs/commit/3095204c38fd8f837ef0660d2254b56a0d382007) | `` python311Packages.python-kasa: 0.5.1 -> 0.5.2 ``                                  |
| [`bc25e988`](https://github.com/NixOS/nixpkgs/commit/bc25e988284a1f9e539ea1acb4573519e3bd21f4) | `` nuclei: update rev ``                                                             |
| [`5d180a74`](https://github.com/NixOS/nixpkgs/commit/5d180a74db22b06b7bb3651804871e2b0d9a3eec) | `` python310Packages.nlpcloud: 1.0.42 -> 1.0.43 ``                                   |
| [`8d68d951`](https://github.com/NixOS/nixpkgs/commit/8d68d951af287d61d560af4894aaebceb3f1cd28) | `` dex-oidc: 2.36.0 -> 2.37.0 ``                                                     |
| [`7f85c39b`](https://github.com/NixOS/nixpkgs/commit/7f85c39b8b4792434dafc45961b670b75937d0e1) | `` vtm: 0.9.9o -> 0.9.9q ``                                                          |
| [`45170fdb`](https://github.com/NixOS/nixpkgs/commit/45170fdb53589871f3e4a13f0080c61113b15580) | `` lib3mf: fix building tests on aarch64-darwin ``                                   |
| [`1b5ad64b`](https://github.com/NixOS/nixpkgs/commit/1b5ad64b5220fc9cff92300162ed4c909a66d480) | `` errcheck: unstable-2022-03-26 -> 1.6.3 ``                                         |
| [`80d1952b`](https://github.com/NixOS/nixpkgs/commit/80d1952b0130d453aa643bbf09f79fce51a267f0) | `` gotrue-supabase: 2.77.1 -> 2.78.0 ``                                              |
| [`f6dc216e`](https://github.com/NixOS/nixpkgs/commit/f6dc216ee26c2e92558992074c81148f7f500ba3) | `` deck: 1.22.0 -> 1.23.0 (#241292) ``                                               |
| [`75acb2f1`](https://github.com/NixOS/nixpkgs/commit/75acb2f184869deb2d22e104afb6a30a16b99000) | `` gobgp: 3.15.0 -> 3.16.0 ``                                                        |
| [`a07e4358`](https://github.com/NixOS/nixpkgs/commit/a07e435835cebcc17dd27373b79b0c21c6718f08) | `` unciv: 4.6.19 -> 4.7.6-patch1 ``                                                  |
| [`4b4a5a4b`](https://github.com/NixOS/nixpkgs/commit/4b4a5a4b294dc8e460719ce2e78ae44b90b1c85c) | `` terraform-providers.tfe: 0.45.0 -> 0.46.0 ``                                      |
| [`4215c51e`](https://github.com/NixOS/nixpkgs/commit/4215c51e792aedbbd6fca1334a7595a63ca5b277) | `` terraform-providers.google-beta: 4.71.0 -> 4.72.0 ``                              |
| [`98a3c57b`](https://github.com/NixOS/nixpkgs/commit/98a3c57b72d9c7f6488139d5ac10e43cf577796c) | `` terraform-providers.google: 4.71.0 -> 4.72.0 ``                                   |
| [`da318056`](https://github.com/NixOS/nixpkgs/commit/da318056bdf5fd91c603b097a4823af4c9fcd9fc) | `` terraform-providers.datadog: 3.26.0 -> 3.27.0 ``                                  |
| [`4f25c0c2`](https://github.com/NixOS/nixpkgs/commit/4f25c0c242b275838e37e81a5b0b10ea86e4d42c) | `` terraform-providers.checkly: 1.6.6 -> 1.6.7 ``                                    |
| [`eb4ec1d4`](https://github.com/NixOS/nixpkgs/commit/eb4ec1d4d80e1796e925ee45632838a7035b52bd) | `` terraform-providers.baiducloud: 1.19.7 -> 1.19.8 ``                               |
| [`1d750c36`](https://github.com/NixOS/nixpkgs/commit/1d750c3699f81974ade7540ae770ca10e498e4ac) | `` orbuculum: 2.0.0 -> 2.1.0 ``                                                      |
| [`82875aa7`](https://github.com/NixOS/nixpkgs/commit/82875aa714948887a2144ca699d1ec5a0fe729dc) | `` pantheon.elementary-notifications: 6.0.3 -> 7.0.0 ``                              |
| [`497220bb`](https://github.com/NixOS/nixpkgs/commit/497220bbb83c1d9235d8cb837e88c552c51bd7a2) | `` pantheon.wingpanel-indicator-nightlight: 2.1.1 -> 2.1.2 ``                        |
| [`d3923d6a`](https://github.com/NixOS/nixpkgs/commit/d3923d6ad37722971876d25e47e8da74ceecd3fa) | `` python310Packages.holidays: 0.27.1 -> 0.28 ``                                     |
| [`46aeca61`](https://github.com/NixOS/nixpkgs/commit/46aeca6159a6a1b3e65860261edaf9c3c3a0c366) | `` gofu: unstable-2022-04-01 -> unstable-2023-04-25 ``                               |
| [`c9471b21`](https://github.com/NixOS/nixpkgs/commit/c9471b21465e21c24d2de211d23fd29242e04270) | `` hvm: fix build ``                                                                 |
| [`40d8e0c4`](https://github.com/NixOS/nixpkgs/commit/40d8e0c4297966ba1aeca0ab85dfff77698b3374) | `` kind2: fix build ``                                                               |
| [`05bb118a`](https://github.com/NixOS/nixpkgs/commit/05bb118a996239c61c505166660f84b1d19cb282) | `` python310Packages.lanms-neo: init at 1.0.2 ``                                     |
| [`939f0c5b`](https://github.com/NixOS/nixpkgs/commit/939f0c5b90f6bea76c563a03a2fd7fdfb110fc09) | `` python310Packages.Polygon3: init at 3.0.9 ``                                      |
| [`e4ec073f`](https://github.com/NixOS/nixpkgs/commit/e4ec073f07d66b530681ead7b946a3fd7d43d8bf) | `` cargo-component: unstable-2023-06-20 -> unstable-2023-06-22 ``                    |
| [`475f2428`](https://github.com/NixOS/nixpkgs/commit/475f2428cbf185aa28abeac87bb11b52f8591f5f) | `` geomyidae: 0.51 -> 0.69 (#241307) ``                                              |
| [`9da2e4a8`](https://github.com/NixOS/nixpkgs/commit/9da2e4a8842e68e7030596eef88d41405e4c16cb) | `` rars: 1.5 -> 1.6 (#241306) ``                                                     |
| [`34181be0`](https://github.com/NixOS/nixpkgs/commit/34181be0248331fa3acd3dc4e4be01074cd731d3) | `` stdenvAdapters: don't use lib.optional with a list ``                             |
| [`83f4ce50`](https://github.com/NixOS/nixpkgs/commit/83f4ce50aa4fc42af387fe406bea235374b73264) | `` rust-analyzer-unwrapped: 2023-06-26 -> 2023-07-03 ``                              |
| [`d6d9a9a8`](https://github.com/NixOS/nixpkgs/commit/d6d9a9a8b879f8de3b7a61ea2d8c531742565c09) | `` benthos: 4.17.0 -> 4.18.0 ``                                                      |
| [`e0ca6a14`](https://github.com/NixOS/nixpkgs/commit/e0ca6a14deb173272fd600f84fb2f3e650c6dfc3) | `` open-pdf-sign: 0.1.4 -> 0.1.5 (#241366) ``                                        |
| [`fc431f15`](https://github.com/NixOS/nixpkgs/commit/fc431f1530314832c07b756122a7ed19c77ba28a) | `` teams-for-linux: 1.1.9 -> 1.1.11 (#241371) ``                                     |
| [`c36301bc`](https://github.com/NixOS/nixpkgs/commit/c36301bcc0433a1acb6e1815d346239381ae7630) | `` input-leap: init at unstable-2023-05-24 ``                                        |
| [`93ae7729`](https://github.com/NixOS/nixpkgs/commit/93ae7729be038a4969ae01760c83bf16029c7907) | `` maintainers: add @shymega ``                                                      |
| [`74588d77`](https://github.com/NixOS/nixpkgs/commit/74588d77b49697ef86027284dce641256316bf12) | `` squashfuse: 0.1.105 -> 0.2.0 ``                                                   |
| [`e60e8125`](https://github.com/NixOS/nixpkgs/commit/e60e8125bb9ff9518d618eddbd9f2b6275eb6024) | `` flutter2: Add throwing alias ``                                                   |
| [`309f54ae`](https://github.com/NixOS/nixpkgs/commit/309f54ae5b69a9c4f47f516fadc4fc1c568c822b) | `` flutter: Remove Flutter 2 ``                                                      |
| [`fb15b4ac`](https://github.com/NixOS/nixpkgs/commit/fb15b4ac4ed0f757c574bdba240607c2a9201f46) | `` tqsl: add wrapGAppsHook, remove cmakeWrapper ``                                   |
| [`28e0f926`](https://github.com/NixOS/nixpkgs/commit/28e0f9265eb0341e02509d798cc1977590eb0ee1) | `` python310Packages.wsgi-intercept: 1.12.0 -> 1.12.1 ``                             |
| [`47c98868`](https://github.com/NixOS/nixpkgs/commit/47c98868cd70d278e992259810a909866bc3447e) | `` clightd: 5.7 -> 5.8 (#240816) ``                                                  |
| [`283674ec`](https://github.com/NixOS/nixpkgs/commit/283674ec6e87017ccf44b7f5d83c967cf7873f63) | `` vscode-extensions-betterthantomorrow.calva: 2.0.205 -> 2.0.374 (#240946) ``       |
| [`11f27bda`](https://github.com/NixOS/nixpkgs/commit/11f27bda2d6f502fde5f39557ee6399439d8461e) | `` signal-desktop: 6.21.0 -> 6.23.0, signal-desktop-beta: 6.22.0-beta.3 (#240986) `` |
| [`cf6bc18b`](https://github.com/NixOS/nixpkgs/commit/cf6bc18bed822f721348b3bd753b26c261079e3b) | `` nuclei: 2.9.7 -> 2.9.8 (#241301) ``                                               |
| [`532a7d3f`](https://github.com/NixOS/nixpkgs/commit/532a7d3f1d67781c06a5bd9be8a89a9198ea91fc) | `` cudaPackages_12_2.cudatoolkit: init at 12.2.0 ``                                  |
| [`8e1c9ca8`](https://github.com/NixOS/nixpkgs/commit/8e1c9ca8d17b5fc9223c17821c6a5b8e374ada73) | `` nixpkgs-review: 2.9.2 -> 2.9.3 ``                                                 |
| [`57c8cf04`](https://github.com/NixOS/nixpkgs/commit/57c8cf047ccdf827cae33e8b76729bd4e881c0fc) | `` sqlfluff: 2.1.1 -> 2.1.2 ``                                                       |
| [`d667de92`](https://github.com/NixOS/nixpkgs/commit/d667de92a310f730a9c122083879f47051a1c066) | `` python3Packages.pyamg: enable tests ``                                            |
| [`c337948b`](https://github.com/NixOS/nixpkgs/commit/c337948beaeb68dad8dcf7fb2f116d139902b05a) | `` trivy: 0.42.1 -> 0.43.0 ``                                                        |
| [`de9800a8`](https://github.com/NixOS/nixpkgs/commit/de9800a8a8d4d7f7d6513a4ff466aa54da624854) | `` python311Packages.pyezviz: 0.2.1.6 -> 0.2.1.7 ``                                  |
| [`445b2f27`](https://github.com/NixOS/nixpkgs/commit/445b2f276ff1f10a16bac69a398b87347924d7ff) | `` ubpm: init at 1.7.3 (#224593) ``                                                  |
| [`5ef952ae`](https://github.com/NixOS/nixpkgs/commit/5ef952ae13ecd729f689f23e19937277c9556393) | `` rio: enable Wayland by default ``                                                 |
| [`c689e7f7`](https://github.com/NixOS/nixpkgs/commit/c689e7f7e1b4dc905a5f204c0157965da983d7c9) | `` rio: 0.0.7 -> 0.0.8 ``                                                            |
| [`5904ce8e`](https://github.com/NixOS/nixpkgs/commit/5904ce8eb1f5ae60eba33eae6f5787b19e8d76dd) | `` evcxr: 0.14.2 -> 0.15.0 (#241253) ``                                              |
| [`e920956b`](https://github.com/NixOS/nixpkgs/commit/e920956b117a61e19d7ace53af4f776c2d1dbb1a) | `` python310Packages.avro: 1.11.1 -> 1.11.2 ``                                       |
| [`2920b6fc`](https://github.com/NixOS/nixpkgs/commit/2920b6fc16a9ed5d51429e94238b28306ceda79e) | `` ciscoPacketTracer8: 8.2.0 -> 8.2.1, refactor ``                                   |
| [`5eb9c438`](https://github.com/NixOS/nixpkgs/commit/5eb9c438ddc68aa6a02c788a82a53d0a975b2c11) | `` ruff: 0.0.275 -> 0.0.276 ``                                                       |
| [`ce04f4b0`](https://github.com/NixOS/nixpkgs/commit/ce04f4b021ff6f620a45df95759132bb3302c913) | `` python310Packages.pyamg: add format ``                                            |
| [`23578c3d`](https://github.com/NixOS/nixpkgs/commit/23578c3d7dbb5be065c48633af59e880559de2a8) | `` python310Packages.pyamg: add changelog to meta ``                                 |
| [`17a6a914`](https://github.com/NixOS/nixpkgs/commit/17a6a914bb8bd301a05db4ef894e622f653f60ee) | `` mediaelch: 2.10.0 -> 2.10.2 ``                                                    |
| [`42c94d06`](https://github.com/NixOS/nixpkgs/commit/42c94d06fdb683ab9bd72a9cd624868386d0f0cd) | `` stdenv: fix overriding with attrset when finalAttrs isn't used ``                 |
| [`f7f55552`](https://github.com/NixOS/nixpkgs/commit/f7f55552165fe2eac627f2afea72a8a180001f05) | `` sipexer: 1.0.3 -> 1.1.0 (#240929) ``                                              |
| [`c98011e6`](https://github.com/NixOS/nixpkgs/commit/c98011e6ef750084a8c8927d199bda6c7f4a6675) | `` python310Packages.pyamg: 5.0.0 -> 5.0.1 ``                                        |
| [`2ae8e338`](https://github.com/NixOS/nixpkgs/commit/2ae8e33832a3e0996a44e3cc06deea0f97c15325) | `` {libqalculate, qalculate-gtk, qalculate-qt}: 4.6.1 -> 4.7.0 ``                    |
| [`37eb3cb5`](https://github.com/NixOS/nixpkgs/commit/37eb3cb5e3803097b2963213c7ffb2c5cc52f744) | `` poedit: 3.3.1 -> 3.3.2 ``                                                         |