### PR TITLE
chore(flake/nixpkgs): `78419eda` -> `f292b496`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688500189,
-        "narHash": "sha256-djYYiY4lzJOlXOnTHytH6BUugrxHDZjuGxTSrU4gt4M=",
+        "lastModified": 1688590700,
+        "narHash": "sha256-ZF055rIUP89cVwiLpG5xkJzx00gEuuGFF60Bs/LM3wc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "78419edadf0fabbe5618643bd850b2f2198ed060",
+        "rev": "f292b4964cb71f9dfbbd30dc9f511d6165cd109b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`23de9f3b`](https://github.com/NixOS/nixpkgs/commit/23de9f3b56e72632c628d92b71c47032e14a3d4d) | `` electron_25-bin: 25.1.1 -> 25.2.0 ``                                              |
| [`d05f851f`](https://github.com/NixOS/nixpkgs/commit/d05f851f77e889e934920c9986540332643da85b) | `` electron_24-bin: 24.4.1 -> 24.5.1 ``                                              |
| [`47dc06c0`](https://github.com/NixOS/nixpkgs/commit/47dc06c07e27c7cee5f416a07fa021ab4f47b850) | `` electron_23-bin: 23.3.7 -> 23.3.9 ``                                              |
| [`f9a0d8ce`](https://github.com/NixOS/nixpkgs/commit/f9a0d8ce77babe8bce373b2bbc7be199329de6b3) | `` electron_22-bin: 22.3.13 -> 22.3.15 ``                                            |
| [`db9b857e`](https://github.com/NixOS/nixpkgs/commit/db9b857e1d0be7241ec3120996f52fc0507f2635) | `` nixos/iso-image: fix syntax ``                                                    |
| [`f3b63e8d`](https://github.com/NixOS/nixpkgs/commit/f3b63e8db03e16686493585cbe324c4ed4956991) | `` eksctl: 0.146.0 -> 0.147.0 ``                                                     |
| [`5d03bfae`](https://github.com/NixOS/nixpkgs/commit/5d03bfae2d4986557844968aa69e2a2a5de2e72a) | `` home-assistant: update component-packages ``                                      |
| [`75c672ac`](https://github.com/NixOS/nixpkgs/commit/75c672ac23d3649d39e66aa013a7b2cc59819c97) | `` kamilalisp: 0.2 -> 0.2p ``                                                        |
| [`948d08a1`](https://github.com/NixOS/nixpkgs/commit/948d08a1f1b22ce4b1e4ebbd778e8f0616c7d00d) | `` vlc: disable parallel installing ``                                               |
| [`ce771049`](https://github.com/NixOS/nixpkgs/commit/ce771049d2088c407d9c8bcbf00a9b417efca59e) | `` moon: 1.9.1 -> 1.9.2 ``                                                           |
| [`4333f887`](https://github.com/NixOS/nixpkgs/commit/4333f887a60ffe2d884d6f85e42433f6380f334d) | `` waybar: 0.9.18 -> 0.9.19 ``                                                       |
| [`b7400c92`](https://github.com/NixOS/nixpkgs/commit/b7400c92ec3fd9b927a62f7d1224e471c2f02fd3) | `` vimPlugins: clean up overrides ``                                                 |
| [`cc0557bb`](https://github.com/NixOS/nixpkgs/commit/cc0557bb27dafc2e03dc69001a85a7c62688f9f2) | `` ocamlformat: Don't depend on ocaml-ng ``                                          |
| [`fb98ebb9`](https://github.com/NixOS/nixpkgs/commit/fb98ebb9a05fefa25585ef78000b40744e8d4d17) | `` ocamlPackages.ocamlformat: Move into 'ocamlPackages' ``                           |
| [`7db89d08`](https://github.com/NixOS/nixpkgs/commit/7db89d08516608e53bf777245375c19dd9627eef) | `` pyrosimple: 2.8.0 -> 2.9.0 ``                                                     |
| [`233696e8`](https://github.com/NixOS/nixpkgs/commit/233696e8ebca2d1bcddd330d8998682d9cb6134e) | `` python311Packages.oslo-log: disable failing test ``                               |
| [`53098560`](https://github.com/NixOS/nixpkgs/commit/53098560136f0702bead0681f9df08235d06efba) | `` matrix-synapse: 1.86.0 -> 1.87.0 ``                                               |
| [`f6408d2e`](https://github.com/NixOS/nixpkgs/commit/f6408d2e99575559f16a9efd38a1da1c39adec6c) | `` python311Packages.oslo-log: update disabled ``                                    |
| [`03b35e62`](https://github.com/NixOS/nixpkgs/commit/03b35e6284ab89a9617657bbe81e5dd5a645327f) | `` python310Packages.stevedore: 5.0.0 -> 5.1.0 ``                                    |
| [`8d80108d`](https://github.com/NixOS/nixpkgs/commit/8d80108d6d7b1c938f46a41700861a65c599f4a1) | `` nixos/gitlab: configure elasticsearch indexer path ``                             |
| [`f241d5fb`](https://github.com/NixOS/nixpkgs/commit/f241d5fbd9366dd5368042629a98360eea82fb30) | `` gitlab-elasticsearch-indexer: init at 4.3.5 ``                                    |
| [`2c9efde7`](https://github.com/NixOS/nixpkgs/commit/2c9efde7ffcd6f4c312ec5e2469afc5707b7e406) | `` tepl: Remove GNOME team from maintainers ``                                       |
| [`0201ef3c`](https://github.com/NixOS/nixpkgs/commit/0201ef3c15dbdf776b7b94cc3d2035ef34b7aca3) | `` gedit: Remove maintainers ``                                                      |
| [`6bbcd65c`](https://github.com/NixOS/nixpkgs/commit/6bbcd65c4486d09395e37ce10fbbcb9b3f58c371) | `` gedit: Move out of GNOME ``                                                       |
| [`4ae4dd49`](https://github.com/NixOS/nixpkgs/commit/4ae4dd49c64f6c1b825bb77e4525f844672e44a8) | `` inotify-tools: add fanotify support and refactor package expression (#233767) ``  |
| [`fe25c3de`](https://github.com/NixOS/nixpkgs/commit/fe25c3de63e3dec3afe317bb864272f7506c6887) | `` gitlab: 16.1.1 -> 16.1.2 (#241682) ``                                             |
| [`71be5933`](https://github.com/NixOS/nixpkgs/commit/71be5933cdd12aad759b2f5a08d12e5cb0b89117) | `` nixos/snipe-it: Use the pinned PHP package ``                                     |
| [`b10a6095`](https://github.com/NixOS/nixpkgs/commit/b10a6095263e624894e40bfd288cc1b7b56ce011) | `` snipe-it: Pin to PHP 8.1 ``                                                       |
| [`b671c277`](https://github.com/NixOS/nixpkgs/commit/b671c2774dc8bfb617f9b76ad4b007828984cce2) | `` k3s_1_27: 1.27.1+k3s1 -> 1.27.2+k3s1 ``                                           |
| [`dce6feaf`](https://github.com/NixOS/nixpkgs/commit/dce6feaf7711d623053633ec6e95d3deebae6cff) | `` k3s: update update-script to support multiple minor versions ``                   |
| [`687cef3a`](https://github.com/NixOS/nixpkgs/commit/687cef3a910d3374ea66e078a2d34627f23d8af1) | `` partio: 1.17.0 -> 1.17.1 ``                                                       |
| [`437e8e07`](https://github.com/NixOS/nixpkgs/commit/437e8e07346c8cdc668a0ee756b9d690228820f1) | `` lomiri.cmake-extras: Change default QML location back to CMAKE_INSTALL_PREFIX `` |
| [`3938d0b8`](https://github.com/NixOS/nixpkgs/commit/3938d0b8202968c409abd9a17696c87a3bc4bdc2) | `` osl: 1.12.12.0 -> 1.12.13.0 ``                                                    |
| [`19453b99`](https://github.com/NixOS/nixpkgs/commit/19453b99d49a319cf55a3e057275696919d28928) | `` deno: 1.34.2 -> 1.35.0 ``                                                         |
| [`f4a30bc1`](https://github.com/NixOS/nixpkgs/commit/f4a30bc16e8ede27268ed2878459be9cdf389246) | `` interactsh: 1.1.4 -> 1.1.5 ``                                                     |
| [`44779d9e`](https://github.com/NixOS/nixpkgs/commit/44779d9ee7605216c14a2c816c448db92262452f) | `` python310Packages.numcodecs: condition avx2 support ``                            |
| [`14f42104`](https://github.com/NixOS/nixpkgs/commit/14f42104c27692f6275d0cf04377e71d20b491d7) | `` lilypond-unstable: 2.25.5 -> 2.25.6 ``                                            |
| [`66043ec2`](https://github.com/NixOS/nixpkgs/commit/66043ec2cb4547279fc8ed39916ceefaef727ec4) | `` metabase: 0.46.5 -> 0.46.6 ``                                                     |
| [`bcd5fbf0`](https://github.com/NixOS/nixpkgs/commit/bcd5fbf074e06b1d95f658d00c1b4cb4255915ab) | `` linux_6_4: 6.4 -> 6.4.1 ``                                                        |
| [`25f6f293`](https://github.com/NixOS/nixpkgs/commit/25f6f293c803f665ef72a2bc74f269983e844fe4) | `` linux_6_3: 6.3.10 -> 6.3.11 ``                                                    |
| [`b65cfaf1`](https://github.com/NixOS/nixpkgs/commit/b65cfaf1ebc476263f9a0d84f2eef6ce767bdea4) | `` linux_6_1: 6.1.36 -> 6.1.37 ``                                                    |
| [`0c6feb64`](https://github.com/NixOS/nixpkgs/commit/0c6feb64d2e39de3f62deb6b5a14b4d25c5ff6c0) | `` python311Packages.jsonref: 1.0.1 -> 1.1.0 ``                                      |
| [`e3642adb`](https://github.com/NixOS/nixpkgs/commit/e3642adbb911d30b4c6a99dba58c18b2e12c454b) | `` python311Packages.hvac: 1.1.0 -> 1.1.1 ``                                         |
| [`f66b401f`](https://github.com/NixOS/nixpkgs/commit/f66b401fa3d98a7aeff33bd9b47058ed53cb4876) | `` lib/tests: invalidate hashes ``                                                   |
| [`1663d7d0`](https://github.com/NixOS/nixpkgs/commit/1663d7d028cc4dae9a4d979a24b3cf403be046dc) | `` python311Packages.cloudsmith-api: 2.0.2 -> 2.0.7 ``                               |
| [`963278d1`](https://github.com/NixOS/nixpkgs/commit/963278d147423bc536e6fda7abd13591e739d3af) | `` agdaPackages.cubical: unstable-2023-02-09 -> 0.5 ``                               |
| [`fe2acba9`](https://github.com/NixOS/nixpkgs/commit/fe2acba90ed618781075b43bf55188f29750f9fe) | `` python311Packages.configargparse: 1.5.3 -> 1.5.5 ``                               |
| [`7b514d21`](https://github.com/NixOS/nixpkgs/commit/7b514d217583079a782855c852c6dda62fcbd4cd) | `` nixos/lvm: toggle initrd enable option independently of main options ``           |
| [`b5c835a6`](https://github.com/NixOS/nixpkgs/commit/b5c835a69bf5bf5f1d17a3c3842950135ede6986) | `` dolt: 1.7.0 -> 1.7.2 ``                                                           |
| [`542d4162`](https://github.com/NixOS/nixpkgs/commit/542d4162a2ba7f0ac4340edcd4f1309dfa5d9c1c) | `` faudio: 23.06 -> 23.07 ``                                                         |
| [`f5e1b735`](https://github.com/NixOS/nixpkgs/commit/f5e1b735a353da86d2e4355fae04f6540562c9e0) | `` python310Packages.jug: add changelog to meta ``                                   |
| [`b1eef0d9`](https://github.com/NixOS/nixpkgs/commit/b1eef0d97477b1cbf444e6bd902fa1aa76afda24) | `` mutagen-compose: 0.17.1 -> 0.17.2 ``                                              |
| [`4158975e`](https://github.com/NixOS/nixpkgs/commit/4158975e66aefd9d07777d8ed357e6db3ef79c10) | `` mediamtx: 0.23.6 -> 0.23.7 ``                                                     |
| [`c6537df1`](https://github.com/NixOS/nixpkgs/commit/c6537df1c94d07167dd8288963b3c34aa0b10f9d) | `` CODEOWNERS: add myself for PHP related stuff ``                                   |
| [`d5bcbc3f`](https://github.com/NixOS/nixpkgs/commit/d5bcbc3fcb890212379e986310e2660964196608) | `` infracost: 0.10.22 -> 0.10.24 ``                                                  |
| [`2ae0e09f`](https://github.com/NixOS/nixpkgs/commit/2ae0e09fa9ba2871d9c5b40bcdf50d7c8b7ef1fd) | `` media-downloader: 3.2.0 -> 3.2.1 ``                                               |
| [`295ef95b`](https://github.com/NixOS/nixpkgs/commit/295ef95bba1fe077f5b45f69773a58cac6e97b08) | `` tfupdate: 0.6.8 -> 0.7.1 ``                                                       |
| [`a6211fbe`](https://github.com/NixOS/nixpkgs/commit/a6211fbe65c309ea0f574dfc7db530e6ae9da98e) | `` wpscan: 3.8.22 -> 3.8.24 ``                                                       |
| [`a60a5c50`](https://github.com/NixOS/nixpkgs/commit/a60a5c503eeedafe36480bb41197b3d0890097d6) | `` mullvad-browser: 12.5 -> 12.5.1 ``                                                |
| [`afd1a41b`](https://github.com/NixOS/nixpkgs/commit/afd1a41b0f3f8115e53ac74082e4b4acb5609606) | `` python311Packages.mypy-boto3-ebs: 1.26.0 -> 1.27.0 ``                             |
| [`a8e105cd`](https://github.com/NixOS/nixpkgs/commit/a8e105cd4908eff3614e15372e0402314b9db990) | `` python311Packages.sqlalchemy-mixins: 2.0.1 -> 2.0.3 ``                            |
| [`44674b97`](https://github.com/NixOS/nixpkgs/commit/44674b975622c25ba5f868a1b8015432062ea713) | `` python311Packages.seatconnect: 1.1.6 -> 1.1.7 ``                                  |
| [`d0a0ee19`](https://github.com/NixOS/nixpkgs/commit/d0a0ee19d5ca9f7c3c8e03753a606de575378541) | `` python311Packages.html-sanitizer: 2.1 -> 2.2 ``                                   |
| [`cd40d256`](https://github.com/NixOS/nixpkgs/commit/cd40d256c5759ec216dac0ca3ec69861dc805d1e) | `` tlsx: 1.1.0 -> 1.1.1 ``                                                           |
| [`134e6b14`](https://github.com/NixOS/nixpkgs/commit/134e6b14299f39736079b785d61227c8f4f0294e) | `` python311Packages.ssdp: 1.2.0 -> 1.3.0 ``                                         |
| [`de863e04`](https://github.com/NixOS/nixpkgs/commit/de863e04a7262a52be409a1e79fd11e4eeb48c9e) | `` python311Packages.zamg: 0.2.3 -> 0.2.4 ``                                         |
| [`62badb97`](https://github.com/NixOS/nixpkgs/commit/62badb9728e6ec62c225fc57e2f07b1f273533cb) | `` python311Packages.pynws: 1.4.1 -> 1.5.0 ``                                        |
| [`ce419ca6`](https://github.com/NixOS/nixpkgs/commit/ce419ca67bd381cb777ba08b693e7e9b11d7eca5) | `` python311Packages.pontos: 23.7.0 -> 23.7.2 ``                                     |
| [`9521e1f1`](https://github.com/NixOS/nixpkgs/commit/9521e1f13c5a608a8ad692fce44975a64ace7cb8) | `` python311Packages.policyuniverse: 1.5.1.20230608 -> 1.5.1.20230703 ``             |
| [`50ffd99c`](https://github.com/NixOS/nixpkgs/commit/50ffd99c8f14c7a68c2af3da11894c9de31d67e1) | `` python311Packages.meilisearch: 0.28.0 -> 0.28.1 ``                                |
| [`daee63d8`](https://github.com/NixOS/nixpkgs/commit/daee63d8232b5f68cfc60381fb6f74e8dba91b03) | `` python311Packages.angr: 9.2.57 -> 9.2.58 ``                                       |
| [`1abfc31f`](https://github.com/NixOS/nixpkgs/commit/1abfc31fc42b65a501fd3ceca28097808fc94245) | `` python311Packages.cle: 9.2.57 -> 9.2.58 ``                                        |
| [`ff4480a0`](https://github.com/NixOS/nixpkgs/commit/ff4480a015d18358f5d02814eb51b7f9dc4ae52e) | `` python311Packages.claripy: 9.2.57 -> 9.2.58 ``                                    |
| [`7f2f354f`](https://github.com/NixOS/nixpkgs/commit/7f2f354f2fefe61f6131ac0dab701df5d43168b1) | `` python311Packages.pyvex: 9.2.57 -> 9.2.58 ``                                      |
| [`055e295f`](https://github.com/NixOS/nixpkgs/commit/055e295f0f7fedb6d912db61d8e563b8c1c45606) | `` python311Packages.ailment: 9.2.57 -> 9.2.58 ``                                    |
| [`9c76a122`](https://github.com/NixOS/nixpkgs/commit/9c76a1225d3a2aa6d96e038ecb0d368ae03c9d3c) | `` python311Packages.archinfo: 9.2.57 -> 9.2.58 ``                                   |
| [`222778d5`](https://github.com/NixOS/nixpkgs/commit/222778d599a542fa74efe8bd349da06b351e8f69) | `` python311Packages.mechanicalsoup: 1.2.0 -> 1.3.0 ``                               |
| [`c438e620`](https://github.com/NixOS/nixpkgs/commit/c438e62013d4fab71a2d210fa8a5fa99146eaa91) | `` python311Packages.mechanicalsoup: add changelog to meta ``                        |
| [`3bf2d696`](https://github.com/NixOS/nixpkgs/commit/3bf2d696d6729628185b9db846573d391326a58f) | `` python311Packages.fakeredis: 2.15.0 -> 2.16.0 ``                                  |
| [`d8b7dcaa`](https://github.com/NixOS/nixpkgs/commit/d8b7dcaa58332d6e63410cdd243beaf2490f250c) | `` mitmproxy2swagger: 0.10.0 -> 0.10.1 ``                                            |
| [`6906893b`](https://github.com/NixOS/nixpkgs/commit/6906893b1691c4711889e5e9830f92f99fc81f43) | `` exploitdb: 2023-06-27 -> 2023-07-04 ``                                            |
| [`0b9f6980`](https://github.com/NixOS/nixpkgs/commit/0b9f6980d79ef351635478c9dbb796a27a8efa56) | `` checkov: 2.3.309 -> 2.3.311 ``                                                    |
| [`b530da7d`](https://github.com/NixOS/nixpkgs/commit/b530da7d5a751b27544f9a24f2f9221d2df8fc35) | `` python311Packages.awswrangler: 3.0.0 -> 3.2.1 ``                                  |
| [`c9aa3ee7`](https://github.com/NixOS/nixpkgs/commit/c9aa3ee7d7544df86aa72cdb876b03475f0f4c3e) | `` eartag: 0.4.1 -> 0.4.2 ``                                                         |
| [`3057085d`](https://github.com/NixOS/nixpkgs/commit/3057085d02c1c86e80cee46cedf9db4a8e5df66c) | `` python310Packages.nvidia-ml-py: 11.525.112 -> 11.525.131 ``                       |
| [`72fccb12`](https://github.com/NixOS/nixpkgs/commit/72fccb124830dfb86603470ad4d1d50f5b445120) | `` monkeysAudio: 10.14 -> 10.16 ``                                                   |
| [`756f6cc1`](https://github.com/NixOS/nixpkgs/commit/756f6cc1ef2da00e1e60ee86286fe6b22f6a5949) | `` unifi: 7.3.83 -> 7.4.156 ``                                                       |
| [`e48882a9`](https://github.com/NixOS/nixpkgs/commit/e48882a9bc9b4e17be2ce52579283d2626aa9930) | `` terraform-providers.yandex: 0.93.0 -> 0.94.0 ``                                   |
| [`ed991574`](https://github.com/NixOS/nixpkgs/commit/ed991574354723d3fefdc4bf42bd379eb0f309ec) | `` terraform-providers.scaleway: 2.22.0 -> 2.23.0 ``                                 |
| [`7c813a17`](https://github.com/NixOS/nixpkgs/commit/7c813a17e46858afc59aa4529d80172638a669d7) | `` terraform-providers.argocd: 5.5.0 -> 5.6.0 ``                                     |
| [`96626dbf`](https://github.com/NixOS/nixpkgs/commit/96626dbf5ed734f7bb4df49cdb3c540b52db52d2) | `` python310Packages.jug: 2.2.3 -> 2.3.0 ``                                          |
| [`90f30c19`](https://github.com/NixOS/nixpkgs/commit/90f30c1947391d5ccb7ef94c793f7a13950be62b) | `` atomic-swap: add lord-valen to maintainers ``                                     |
| [`91d08355`](https://github.com/NixOS/nixpkgs/commit/91d08355b0b032b25d3e3c263561ff318afbe052) | `` atomic-swap: ensure monero-cli is available ``                                    |
| [`3795c614`](https://github.com/NixOS/nixpkgs/commit/3795c6144019883c0a99553d32384345998aa61e) | `` snarkos: 2.1.3 -> 2.1.4 ``                                                        |
| [`cc928b17`](https://github.com/NixOS/nixpkgs/commit/cc928b17f0e925633553204b6b5a7a5a3c0010a4) | `` surrealdb-migrations: 0.9.10 -> 0.9.11 ``                                         |
| [`3fe4a882`](https://github.com/NixOS/nixpkgs/commit/3fe4a8820c73197704b71e94afff000721543fca) | `` libdbusmenu: require glib-2.0 in pkg-config ``                                    |
| [`1340cd4e`](https://github.com/NixOS/nixpkgs/commit/1340cd4e74ede3b4fffbdf82b7eb5a7b121d11c5) | `` python310Packages.dvc-data: 2.3.1 -> 2.3.3 ``                                     |
| [`361fea5b`](https://github.com/NixOS/nixpkgs/commit/361fea5b0cbbb4657d4eac93fce64ffa5f932edf) | `` radarr: 4.5.2.7388 -> 4.6.4.7568 ``                                               |
| [`023b1df8`](https://github.com/NixOS/nixpkgs/commit/023b1df882979a413a3f7e2009424db30d51a0fe) | `` baloo: patch to support btrfs better ``                                           |
| [`1bb7ce38`](https://github.com/NixOS/nixpkgs/commit/1bb7ce387b78ad59fa9292ef692632dc5a2ce9ce) | `` scaleway-cli: 2.16.1 -> 2.17.0 ``                                                 |
| [`8967531f`](https://github.com/NixOS/nixpkgs/commit/8967531fe2861c36297e999aecdfcaf37cd6fc94) | `` mmctl: 7.10.2 -> 7.10.3 ``                                                        |
| [`311365c7`](https://github.com/NixOS/nixpkgs/commit/311365c7ca7f6638f9b3e353a4ea51fb9273d036) | `` flowblade: 2.10.0.2 -> 2.10.0.3 ``                                                |
| [`360bb154`](https://github.com/NixOS/nixpkgs/commit/360bb1545b42f09bcdafe4aa0e78ca41689b4ca9) | `` ddccontrol-db: 20230424 -> 20230627 ``                                            |
| [`6be4122d`](https://github.com/NixOS/nixpkgs/commit/6be4122dd53324079074b7b929c0dbff119a8b9b) | `` rarian: remove ``                                                                 |
| [`b7a15cbc`](https://github.com/NixOS/nixpkgs/commit/b7a15cbc2bcb27d827ce4325dbbf49de49dd9197) | `` tailwindcss: rename and remove -bin ``                                            |
| [`94b586b8`](https://github.com/NixOS/nixpkgs/commit/94b586b8535190fb43d23774f3cef8b1360805be) | `` whisper-ctranslate2: init at 0.2.7 ``                                             |
| [`45e9658b`](https://github.com/NixOS/nixpkgs/commit/45e9658b0dc8b7a3a333ed7ed640e7d64a789c49) | `` python310Packages.glyphslib: 6.2.2 -> 6.2.3 ``                                    |
| [`063eb2a6`](https://github.com/NixOS/nixpkgs/commit/063eb2a60eb4592b666531e2479b40fd1a261604) | `` tor-browser-bundle-bin: 12.5 -> 12.5.1 ``                                         |
| [`c18a45a6`](https://github.com/NixOS/nixpkgs/commit/c18a45a6c7ebd38a79d5340458ef28edad13556a) | `` qovery-cli: 0.59.0 -> 0.60.0 ``                                                   |
| [`2323ba36`](https://github.com/NixOS/nixpkgs/commit/2323ba3677e22cccf852b95b58aef35455f1c156) | `` gitea: 1.19.3 -> 1.19.4 ``                                                        |
| [`403371ae`](https://github.com/NixOS/nixpkgs/commit/403371ae0714149bae1bc89b4e90e51ebc4953bd) | `` maintainers: add alxsimon ``                                                      |
| [`ddc7a6c8`](https://github.com/NixOS/nixpkgs/commit/ddc7a6c810e0731d7869258dbbd4e9b688ca94e2) | `` python310Packages.pyslim: init at version 1.0.3 ``                                |
| [`646d7c14`](https://github.com/NixOS/nixpkgs/commit/646d7c14cfd7fea32ef91e8fffcd00533e381098) | `` python310Packages.msprime: init at version 1.2.0 ``                               |
| [`24a4b76d`](https://github.com/NixOS/nixpkgs/commit/24a4b76dd45f7ec9d9a7cc93e8099fb36134ca7e) | `` python310Packages.newick: init at version 1.9.0 ``                                |
| [`dc172aee`](https://github.com/NixOS/nixpkgs/commit/dc172aee9bd96ec68d4365a3384d02410a02b627) | `` python310Packages.tskit: init at version 0.5.5 ``                                 |
| [`81b55891`](https://github.com/NixOS/nixpkgs/commit/81b55891f7d8e54ff42ff579f3ee2a7774276a9f) | `` python310Packages.demesdraw: init at version 0.4.0 ``                             |
| [`88c997ed`](https://github.com/NixOS/nixpkgs/commit/88c997ed52774e61a6790fda90931e05ecfb54f5) | `` opencolorio: fix build ``                                                         |
| [`99e0ddb6`](https://github.com/NixOS/nixpkgs/commit/99e0ddb69cd18d64db428aff1992099d5821e85c) | `` minizip-ng: reenable compatibility headers ``                                     |
| [`b5324488`](https://github.com/NixOS/nixpkgs/commit/b5324488242b60e201473e2d5ecc4f17c05623b5) | `` stgit: 1.5 -> 2.3.0 ``                                                            |
| [`49d6651d`](https://github.com/NixOS/nixpkgs/commit/49d6651dc80012ead6957478c40ea3da2ba79244) | `` roam-research: init at 0.0.18 ``                                                  |