### PR TITLE
chore(flake/nix-index-database): `c8210cb3` -> `4d5a3eec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687097842,
-        "narHash": "sha256-NPAaRZx5foWLgIPfEaiEZMr9JIlEQhLEVEXpx09341Q=",
+        "lastModified": 1688662462,
+        "narHash": "sha256-9TWWkhCWZQMQiZ8nzsVZNUh3r++xbT75iCozpYM8a+w=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "c8210cb3fcde6860255b54ddba74dc177e6232cd",
+        "rev": "4d5a3eec1dc9dbc5c2718ea955a0928f1a3567fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`4d5a3eec`](https://github.com/nix-community/nix-index-database/commit/4d5a3eec1dc9dbc5c2718ea955a0928f1a3567fd) | `` flake.lock: Update ``               |
| [`bb486d01`](https://github.com/nix-community/nix-index-database/commit/bb486d01163c91c0c0b8f18557dadc518c5a9934) | `` Fix flake lock step in workflow. `` |