### PR TITLE
chore(flake/nix-index-database): `4d5a3eec` -> `44337c30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688662462,
-        "narHash": "sha256-9TWWkhCWZQMQiZ8nzsVZNUh3r++xbT75iCozpYM8a+w=",
+        "lastModified": 1688680913,
+        "narHash": "sha256-jo/RDXXL7Zx6M36m0f0F+tQPJRzs31Y7gaDiTqqh4Ns=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "4d5a3eec1dc9dbc5c2718ea955a0928f1a3567fd",
+        "rev": "44337c30729a3616c7a71d485af70d231b29675a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`44337c30`](https://github.com/nix-community/nix-index-database/commit/44337c30729a3616c7a71d485af70d231b29675a) | `` update packages.nix to release 2023-07-06-220047 ``                     |
| [`b55bac3e`](https://github.com/nix-community/nix-index-database/commit/b55bac3e4eda652cf6f850a6bb25ed9377552b8b) | `` Use correct syntax to get the ref. ``                                   |
| [`c4b51ce6`](https://github.com/nix-community/nix-index-database/commit/c4b51ce669f1faf6a4d59f2d29cdea78d72f8dd1) | `` Checkout the HEAD of the current branch instead of the original SHA. `` |