### PR TITLE
chore(flake/nixos-hardware): `429f232f` -> `47dca15d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -298,11 +298,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1686838567,
-        "narHash": "sha256-aqKCUD126dRlVSKV6vWuDCitfjFrZlkwNuvj5LtjRRU=",
+        "lastModified": 1688798314,
+        "narHash": "sha256-MFG5rx7L756rtrPHsL662m64AZ4sKqUcApaiYgSKfNM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "429f232fe1dc398c5afea19a51aad6931ee0fb89",
+        "rev": "47dca15d86fdd2eabcf434d7cc0b5baa8d1a463c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`30f71ba6`](https://github.com/NixOS/nixos-hardware/commit/30f71ba6e0ce7c26d103bd383ca30c4c9d179a5a) | `` star64: init ``                                                              |
| [`ff35653b`](https://github.com/NixOS/nixos-hardware/commit/ff35653b1493d6ae27acb04bf6851e095b23ffea) | `` starfive visionfive2: update kernel to 6.4.0 ``                              |
| [`289a5af7`](https://github.com/NixOS/nixos-hardware/commit/289a5af77e624b29b9efd06de262b324c8018abe) | `` Additional blocked nvidia kernel modules ``                                  |
| [`8e28b9ee`](https://github.com/NixOS/nixos-hardware/commit/8e28b9ee431b265d1fc74b8b819ea0816344c4a1) | `` apple/t2: init ``                                                            |
| [`1d0b3cf2`](https://github.com/NixOS/nixos-hardware/commit/1d0b3cf27b8b57a6ccc758f111b863d87bab7851) | `` treewide: avoid alias usage for intel-vaapi-driver based on nixos version `` |
| [`ef7a2674`](https://github.com/NixOS/nixos-hardware/commit/ef7a2674a79909ae2ca08d1f46ab6d117dadd78c) | `` Update default.nix ``                                                        |
| [`ba74676d`](https://github.com/NixOS/nixos-hardware/commit/ba74676d675a4196ca728691e15536a60c94a257) | `` build(deps): bump cachix/install-nix-action from 21 to 22 ``                 |
| [`2d54ea30`](https://github.com/NixOS/nixos-hardware/commit/2d54ea30cfea085b64db92e6bf8848b73c1fac78) | `` macbook-air-6: remove mba6x_bl kernel module ``                              |