### PR TITLE
chore(flake/nixpkgs): `f292b496` -> `3c748757`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688590700,
-        "narHash": "sha256-ZF055rIUP89cVwiLpG5xkJzx00gEuuGFF60Bs/LM3wc=",
+        "lastModified": 1688679045,
+        "narHash": "sha256-t3xGEfYIwhaLTPU8FLtN/pLPytNeDwbLI6a7XFFBlGo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f292b4964cb71f9dfbbd30dc9f511d6165cd109b",
+        "rev": "3c7487575d9445185249a159046cc02ff364bff8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`04eceedb`](https://github.com/NixOS/nixpkgs/commit/04eceedb4fe3641224e776efd7fc6d4a57aa5731) | `` fdm: Install helper script, manual, and examples (#241310) ``             |
| [`a123917a`](https://github.com/NixOS/nixpkgs/commit/a123917a0726974ea1bab1ffebb49201c6c1256f) | `` ocamlPackages.seqes: disable for OCaml < 4.14 & enable tests ``           |
| [`1502e8a5`](https://github.com/NixOS/nixpkgs/commit/1502e8a52cce39f9a31bfddefaf0b7aa3e0c8f32) | `` croc: 9.6.4 -> 9.6.5 ``                                                   |
| [`eed97e16`](https://github.com/NixOS/nixpkgs/commit/eed97e1623e30cd7b2c469d5197d1d148cdeac76) | `` angelfish: fixup cargo hash ``                                            |
| [`0413854c`](https://github.com/NixOS/nixpkgs/commit/0413854cfb3c8558c677be37ff411f65c1de75d0) | `` kde/gear: 23.04.2 -> 23.04.3 ``                                           |
| [`d94ee6a7`](https://github.com/NixOS/nixpkgs/commit/d94ee6a73b80bbc549c5f6246876c048f6e027c5) | `` python311Packages.referencing: 0.29.0 -> 0.29.1 ``                        |
| [`b8fd4784`](https://github.com/NixOS/nixpkgs/commit/b8fd47844067289106df4247a18ab3f704f6c37f) | `` python311Packages.pubnub: 7.1.0 -> 7.2.0 ``                               |
| [`fcea1056`](https://github.com/NixOS/nixpkgs/commit/fcea105698ee51f1af71f764d03d300b229ada7c) | `` buildEnv: Nix's buildEnv should be stable ``                              |
| [`8eb79338`](https://github.com/NixOS/nixpkgs/commit/8eb79338ca93b5bf2272e659909dd88e2142e78b) | `` python311Packages.opower: 0.0.12 -> 0.0.13 ``                             |
| [`4b017156`](https://github.com/NixOS/nixpkgs/commit/4b017156c87401b594e1f556d396d6684306bf0e) | `` slurm: 23.02.2.1 -> 23.02.3.1 ``                                          |
| [`db15bc80`](https://github.com/NixOS/nixpkgs/commit/db15bc807130925688f0c2c3b78fddabf3a8a9bd) | `` mastodon: 4.1.2 -> 4.1.3 ``                                               |
| [`3cbc4483`](https://github.com/NixOS/nixpkgs/commit/3cbc4483f39eaf4101f224b49d56609a66d6e8a2) | `` octopus: 12.2 -> 13.0 ``                                                  |
| [`81fae629`](https://github.com/NixOS/nixpkgs/commit/81fae6294b7eee8b816b072ec9b8add848ca1b50) | `` ligo: 0.68.0 -> 0.69.0 ``                                                 |
| [`06309b99`](https://github.com/NixOS/nixpkgs/commit/06309b998124440cca7bf7f8e02a36405a045e88) | `` psutils: set platforms ``                                                 |
| [`2f0dc352`](https://github.com/NixOS/nixpkgs/commit/2f0dc352412b9f3c099d266bbc3a12219f83fcaa) | `` python311Packages.google-cloud-asset: 3.19.0 -> 3.19.1 ``                 |
| [`e05431ce`](https://github.com/NixOS/nixpkgs/commit/e05431ce3309c3fef79c283f1be3b60aa159f7d0) | `` python311Packages.google-cloud-bigquery-datatransfer: 3.11.1 -> 3.11.2 `` |
| [`0afdb3cf`](https://github.com/NixOS/nixpkgs/commit/0afdb3cfa343da7d2d134f8d747ab04e6221759c) | `` python311Packages.google-cloud-automl: 2.11.1 -> 2.11.2 ``                |
| [`3b29138b`](https://github.com/NixOS/nixpkgs/commit/3b29138b25456a8f868279ac6ce2a1b6c69fef2b) | `` python311Packages.py-eth-sig-utils: mark broken ``                        |
| [`b7128ef5`](https://github.com/NixOS/nixpkgs/commit/b7128ef551494b9fc992ca55b56d6f54998edf09) | `` python311Packages.web3: 6.3.0 -> 6.5.0 ``                                 |
| [`7e9d3a7f`](https://github.com/NixOS/nixpkgs/commit/7e9d3a7f4642432637d01db8ff2592b7d698afa3) | `` python311Packages.eth-hash: 0.3.2 -> 0.5.2 ``                             |
| [`76922ee8`](https://github.com/NixOS/nixpkgs/commit/76922ee8503f1eff5862e9867e85d9ac14159453) | `` python311Packages.eth-account: 0.6.1 -> 0.9.0 ``                          |
| [`2ad0f0d0`](https://github.com/NixOS/nixpkgs/commit/2ad0f0d092ccf887dc23439c73064cdb9d3dc7e4) | `` python311Packages.eth-utils: 2.0.0 -> 2.1.1 ``                            |
| [`1498dbb8`](https://github.com/NixOS/nixpkgs/commit/1498dbb8d3fc24a38226acd54a5435df103a20df) | `` python311Packages.homeassistant-stubs: 2023.6.3 -> 2023.7.0 ``            |
| [`c6bbc823`](https://github.com/NixOS/nixpkgs/commit/c6bbc823b6647586a425582f54437d699accc972) | `` python311Packages.google-cloud-compute: 1.11.0 -> 1.12.0 ``               |
| [`e9b9d5c9`](https://github.com/NixOS/nixpkgs/commit/e9b9d5c94f5e6625dadca13abe317497a4f02f76) | `` python311Packages.google-cloud-container: 2.25.0 -> 2.26.0 ``             |
| [`cfd4b7b3`](https://github.com/NixOS/nixpkgs/commit/cfd4b7b35b543c5e190c182bae8803663a8cb9a9) | `` python311Packages.google-cloud-core: 2.3.2 -> 2.3.3 ``                    |
| [`fa3e6556`](https://github.com/NixOS/nixpkgs/commit/fa3e655680dbdfac628f93b2e47dcc33f06a0a72) | `` python311Packages.google-cloud-datacatalog: 3.13.0 -> 3.13.1 ``           |
| [`43e97897`](https://github.com/NixOS/nixpkgs/commit/43e9789706cd99428bb08ade106e91250900f28b) | `` python311Packages.google-cloud-dataproc: 5.4.1 -> 5.4.2 ``                |
| [`cbd45420`](https://github.com/NixOS/nixpkgs/commit/cbd454204f616b902052fe44e25bf93d9be681e9) | `` python311Packages.google-cloud-dlp: 3.12.1 -> 3.12.2 ``                   |
| [`2239bf96`](https://github.com/NixOS/nixpkgs/commit/2239bf96204f8cbcbbf7b56b42a298bf806541be) | `` python311Packages.google-cloud-error-reporting: 1.9.1 -> 1.9.2 ``         |
| [`0ab3df1f`](https://github.com/NixOS/nixpkgs/commit/0ab3df1f9e322e74b1eef21b104ca36b53470731) | `` python311Packages.google-cloud-iam: 2.12.0 -> 2.12.1 ``                   |
| [`3ffb56a7`](https://github.com/NixOS/nixpkgs/commit/3ffb56a7a464dd3e5b8885a9983e088dd0726d19) | `` python311Packages.google-cloud-iot: 2.9.1 -> 2.9.2 ``                     |
| [`be96b03f`](https://github.com/NixOS/nixpkgs/commit/be96b03f3858dc7279bb394074353752e888a192) | `` python311Packages.google-cloud-kms: 2.17.0 -> 2.18.0 ``                   |
| [`89a9344b`](https://github.com/NixOS/nixpkgs/commit/89a9344ba7f461c5727871bb29ae1c49c3270e59) | `` python311Packages.google-cloud-language: 2.10.0 -> 2.10.1 ``              |
| [`47f102ff`](https://github.com/NixOS/nixpkgs/commit/47f102ffcfdeea26e54dd017f9f7869de88c9602) | `` python311Packages.google-cloud-monitoring: 2.15.0 -> 2.15.1 ``            |
| [`513d58d9`](https://github.com/NixOS/nixpkgs/commit/513d58d9c1588060b9a1aec7a498420052fa1839) | `` python311Packages.google-cloud-org-policy: 1.8.1 -> 1.8.2 ``              |
| [`2a1eb93a`](https://github.com/NixOS/nixpkgs/commit/2a1eb93af6c8dc0d3d862a94fe2ddffe196c5869) | `` python311Packages.google-cloud-os-config: 1.15.1 -> 1.15.2 ``             |
| [`d1cd6c9c`](https://github.com/NixOS/nixpkgs/commit/d1cd6c9c49e8917fb480cf6ff167e54c2d8b8e2c) | `` python311Packages.google-cloud-redis: 2.13.0 -> 2.13.1 ``                 |
| [`561cfab9`](https://github.com/NixOS/nixpkgs/commit/561cfab9d879d1f2db5fe5ef774d797c73f4b014) | `` python311Packages.google-cloud-resource-manager: 1.10.1 -> 1.10.2 ``      |
| [`d241c87a`](https://github.com/NixOS/nixpkgs/commit/d241c87a45e16376a421fd2ed0ce13912b69afcb) | `` python311Packages.google-cloud-secret-manager: 2.16.1 -> 2.16.2 ``        |
| [`cd7462dd`](https://github.com/NixOS/nixpkgs/commit/cd7462dd714cc9a83d8301cbca3fc5e184e07f7f) | `` python311Packages.google-cloud-securitycenter: 1.23.0 -> 1.23.1 ``        |
| [`d6e370cf`](https://github.com/NixOS/nixpkgs/commit/d6e370cfd92323bf552415e52c1482658ddbb000) | `` python311Packages.google-cloud-speech: 2.20.0 -> 2.21.0 ``                |
| [`b6d3f81f`](https://github.com/NixOS/nixpkgs/commit/b6d3f81f39c32b30f7e6844dfb843afe4135b8bd) | `` python311Packages.google-cloud-tasks: 2.13.1 -> 2.13.2 ``                 |
| [`7e22b61f`](https://github.com/NixOS/nixpkgs/commit/7e22b61f31b93c1d7ba1733121bbd5fb550fabec) | `` python311Packages.google-cloud-trace: 1.11.1 -> 1.11.2 ``                 |
| [`d934af16`](https://github.com/NixOS/nixpkgs/commit/d934af16eddaa72dfaacb7bb823d909856dd386b) | `` python311Packages.google-cloud-translate: 3.11.1 -> 3.11.2 ``             |
| [`96f373cc`](https://github.com/NixOS/nixpkgs/commit/96f373cc982ec530a3732ef6c86aa4794924df5b) | `` python311Packages.google-cloud-vision: 3.4.3 -> 3.4.4 ``                  |
| [`1e7ee96d`](https://github.com/NixOS/nixpkgs/commit/1e7ee96d1fb48408b1400cbbd7a5a13ad5adf2b6) | `` python311Packages.google-cloud-websecurityscanner: 1.12.1 -> 1.12.2 ``    |
| [`3319d8a2`](https://github.com/NixOS/nixpkgs/commit/3319d8a2aca8c8fa31415f0a917df4eb38fd0749) | `` python311Packages.acquire: 3.6 -> 3.7 ``                                  |
| [`b294dc6e`](https://github.com/NixOS/nixpkgs/commit/b294dc6e47ffee727be2c07201c5b382002c7d5c) | `` python311Packages.dissect: 3.6 -> 3.7 ``                                  |
| [`5f17cb4c`](https://github.com/NixOS/nixpkgs/commit/5f17cb4c6ed9d311623484beedf14dd59a44e4a3) | `` python311Packages.dissect-squashfs: 1.2 -> 1.3 ``                         |
| [`585e41eb`](https://github.com/NixOS/nixpkgs/commit/585e41eb0e17501ef449d00a604172f2ef383395) | `` python311Packages.dissect-thumbcache: 1.4 -> 1.5 ``                       |
| [`f8790474`](https://github.com/NixOS/nixpkgs/commit/f87904747133eeede4a34441013c2c08c1e81c03) | `` python311Packages.dissect-xfs: 3.5 -> 3.6 ``                              |
| [`0375154f`](https://github.com/NixOS/nixpkgs/commit/0375154f60a760aff6d6750ec8d86a224bfe413a) | `` python311Packages.dissect-volume: 3.5 -> 3.6 ``                           |
| [`9dad9ccd`](https://github.com/NixOS/nixpkgs/commit/9dad9ccd58ebe0306041e265784daa67f084eba1) | `` python311Packages.dissect-vmfs: 3.5 -> 3.6 ``                             |
| [`2cfc65a9`](https://github.com/NixOS/nixpkgs/commit/2cfc65a99205684849f6767e3abf4f1330a2c5dc) | `` python311Packages.dissect-util: 3.8 -> 3.9 ``                             |
| [`0f116b21`](https://github.com/NixOS/nixpkgs/commit/0f116b214b9a023defd7e1627ae3e2fa17dff872) | `` python311Packages.dissect-sql: 3.5 -> 3.6 ``                              |
| [`7c9f29cb`](https://github.com/NixOS/nixpkgs/commit/7c9f29cb01f2c536ed297683838ecfbbc07aba23) | `` python311Packages.dissect-shellitem: 3.5 -> 3.6 ``                        |
| [`cc5ca16e`](https://github.com/NixOS/nixpkgs/commit/cc5ca16e565126e527691e397c84164a833eb439) | `` python311Packages.dissect-regf: 3.5 -> 3.6 ``                             |
| [`4de015a4`](https://github.com/NixOS/nixpkgs/commit/4de015a44b9ea32d4d995db9cb513635c8548754) | `` python311Packages.dissect-ole: 3.5 -> 3.6 ``                              |
| [`313b64be`](https://github.com/NixOS/nixpkgs/commit/313b64bef1176a1ef56b50da0bf37e56417e6aeb) | `` python311Packages.dissect-ntfs: 3.5 -> 3.6 ``                             |
| [`92e6dbe2`](https://github.com/NixOS/nixpkgs/commit/92e6dbe2dfccf565212fc6b824a67341ea1d415b) | `` python311Packages.dissect-hypervisor: 3.7 -> 3.8 ``                       |
| [`c8281362`](https://github.com/NixOS/nixpkgs/commit/c82813627821e58204e9284272a9b86ed23444a2) | `` python311Packages.dissect-ffs: 3.5 -> 3.6 ``                              |
| [`847a4ea4`](https://github.com/NixOS/nixpkgs/commit/847a4ea4b419827848542544d90bc3c8f17c1319) | `` python311Packages.dissect-fat: 3.5 -> 3.6 ``                              |
| [`d7ba7079`](https://github.com/NixOS/nixpkgs/commit/d7ba7079a97b25d0b34ca73b487331539a9405b7) | `` python311Packages.dissect-extfs: 3.5 -> 3.6 ``                            |
| [`38f5bf74`](https://github.com/NixOS/nixpkgs/commit/38f5bf745eeef29e5576c4a26d21650af9dab2b4) | `` python311Packages.dissect-executable: 1.3 -> 1.4 ``                       |
| [`15f4abc4`](https://github.com/NixOS/nixpkgs/commit/15f4abc4b5859f012638f60b6802eae233580c1c) | `` python311Packages.dissect-evidence: 3.5 -> 3.6 ``                         |
| [`6be48954`](https://github.com/NixOS/nixpkgs/commit/6be48954ef70d5b3a671b0b7ce8d38198d817abc) | `` python311Packages.dissect-eventlog: 3.5 -> 3.6 ``                         |
| [`09a24bac`](https://github.com/NixOS/nixpkgs/commit/09a24bacfd136f41d358523da40e670f782a22b5) | `` python311Packages.dissect-etl: 3.5 -> 3.6 ``                              |
| [`5be61c0b`](https://github.com/NixOS/nixpkgs/commit/5be61c0bf3e16b97f52cfdfa80134869c192916c) | `` python311Packages.dissect-esedb: 3.7 -> 3.8 ``                            |
| [`5525a7d8`](https://github.com/NixOS/nixpkgs/commit/5525a7d82ff08b17eda5182b8dc7c4b8ace996be) | `` python311Packages.dissect-cstruct: 3.7 -> 3.8 ``                          |
| [`18bce8c2`](https://github.com/NixOS/nixpkgs/commit/18bce8c2fb40ded5e63febee3d7e75739e900c93) | `` python311Packages.dissect-clfs: 1.5 -> 1.6 ``                             |
| [`c0ded27d`](https://github.com/NixOS/nixpkgs/commit/c0ded27d46aea34537879dbad75300612218f0ce) | `` python311Packages.dissect-cim: 3.6 -> 3.7 ``                              |
| [`9091f564`](https://github.com/NixOS/nixpkgs/commit/9091f56422f509c7f60ed727d8087656de5f60b9) | `` trufflehog: 3.42.0 -> 3.43.0 ``                                           |
| [`1f3ec798`](https://github.com/NixOS/nixpkgs/commit/1f3ec79814e463b4befae1a75aefd05ebd869711) | `` dvc: 2.58.2 -> 3.4.0 ``                                                   |
| [`558ff072`](https://github.com/NixOS/nixpkgs/commit/558ff072d570553f3d340c44226d4d917e1747c4) | `` python311Packages.sentry-sdk: 1.26.0 -> 1.27.0 ``                         |
| [`8eac1383`](https://github.com/NixOS/nixpkgs/commit/8eac138352e8c50a470a7bcdb3a62a6705ea3bdb) | `` python311Packages.dissect-target: 3.9 -> 3.10 ``                          |
| [`bfeb5a3b`](https://github.com/NixOS/nixpkgs/commit/bfeb5a3b2979471d047c40b5c2c378ba38f81fe9) | `` perlPackages.AppMusicChordPro: 0.977 -> 6.010 ``                          |
| [`3039c831`](https://github.com/NixOS/nixpkgs/commit/3039c8311da9e4f14429fd222c696fb300251886) | `` perlPackages.TextLayout: 0.019 -> 0.031 ``                                |
| [`e7f25514`](https://github.com/NixOS/nixpkgs/commit/e7f255145107c7f20cb29edafa5ece6724ddb3a4) | `` perlPackages.StringInterpolateNamed: 1.00 -> 1.03 ``                      |
| [`a7057bdc`](https://github.com/NixOS/nixpkgs/commit/a7057bdc2722ed7f7c59fea4bf54d1af56a43727) | `` perlPackages.PDFAPI2: 2.042 -> 2.044 ``                                   |
| [`1702b6ec`](https://github.com/NixOS/nixpkgs/commit/1702b6ec8d74a07f21ab33ece3d2a07ca619ea5f) | `` perlPackages.FileLoadLines: 1.01 -> 1.021 ``                              |
| [`af9cf1a1`](https://github.com/NixOS/nixpkgs/commit/af9cf1a17eb4fa7efc59f43d6c3f550b519f6c3b) | `` python311Packages.eth-abi: 3.0.1 -> 4.1.0 ``                              |
| [`0c2f90eb`](https://github.com/NixOS/nixpkgs/commit/0c2f90eb6ed61abcb21d2e14051d8db469cc8ad2) | `` python311Packages.dvc-studio-client: 0.10.0 -> 0.11.0 ``                  |
| [`ffd250be`](https://github.com/NixOS/nixpkgs/commit/ffd250befbab5abab5c0f04b3b31cfb38eb9b0af) | `` psutils: modernize package and change src url ``                          |
| [`19af5d54`](https://github.com/NixOS/nixpkgs/commit/19af5d54d1be81f06016656d0b06f98306c898f6) | `` psutils: fix build on Darwin ``                                           |
| [`c9df316a`](https://github.com/NixOS/nixpkgs/commit/c9df316a82f11266e8fc5ab10c8b7b63209ee70c) | `` desync: add changelog to meta ``                                          |
| [`30d116e2`](https://github.com/NixOS/nixpkgs/commit/30d116e27df8d0101ae7ef9ed53fd5d5fb217761) | `` python311Packages.vulcan-api: add changelog to meta ``                    |
| [`201021af`](https://github.com/NixOS/nixpkgs/commit/201021aff6dd22ce8b2a2e990f5a593193484507) | `` python311Packages.pyshark: 0.5.3 -> 0.6 ``                                |
| [`b3585af9`](https://github.com/NixOS/nixpkgs/commit/b3585af9d50827a28dba917d5b228ae114407c86) | `` python311Packages.pygithub: 1.59.0 -> 1.59.0 ``                           |
| [`d1861836`](https://github.com/NixOS/nixpkgs/commit/d1861836b31964da8415fd511ebac8a91a901cb1) | `` python311Packages.py-dmidecode: 0.1.0 -> 0.1.2 ``                         |
| [`88eefacc`](https://github.com/NixOS/nixpkgs/commit/88eefacce8c86109b274afb87766ff895bd56041) | `` python311Packages.pyunifiprotect: 4.10.3 -> 4.10.4 ``                     |
| [`e6ebe64c`](https://github.com/NixOS/nixpkgs/commit/e6ebe64c7b92891c7c741922c111091fd5364d75) | `` checkov: 2.3.311 -> 2.3.312 ``                                            |
| [`e79da053`](https://github.com/NixOS/nixpkgs/commit/e79da0534bc435e98bf6d213e211b5245b437629) | `` python311Packages.pyrainbird: 2.0.1 -> 2.1.0 ``                           |
| [`71e0934b`](https://github.com/NixOS/nixpkgs/commit/71e0934beb2d8fb9e673ae29235eea05bad0ca3f) | `` python311Packages.kasa-crypt: 0.2.0 -> 0.2.1 ``                           |
| [`19d53440`](https://github.com/NixOS/nixpkgs/commit/19d5344007fdbae7e0627ce24c15bb7eda9c163b) | `` exploitdb: 2023-07-04 -> 2023-07-05 ``                                    |
| [`7d834230`](https://github.com/NixOS/nixpkgs/commit/7d83423096d0f129a6deb70b8a1b82cbf54b2b0f) | `` python311Packages.google-ai-generativelanguage: 0.3.0 -> 0.3.1 ``         |
| [`2f197b7e`](https://github.com/NixOS/nixpkgs/commit/2f197b7e49c5ee00ce70198ced4840e633d2d9a9) | `` python311Packages.google-cloud-appengine-logging: 1.3.0 -> 1.3.1 ``       |
| [`92e19162`](https://github.com/NixOS/nixpkgs/commit/92e191626f0ad81d5d25677a829f2661dc5e11ba) | `` python311Packages.google-cloud-bigquery-logging: 1.2.1 -> 1.2.2 ``        |
| [`0d9c1c4b`](https://github.com/NixOS/nixpkgs/commit/0d9c1c4bc004af3d7bb88bfcf2ae1fa84961113a) | `` python311Packages.google-cloud-iam-logging: 1.2.0 -> 1.2.1 ``             |
| [`f0b8aac7`](https://github.com/NixOS/nixpkgs/commit/f0b8aac73d243ec748d03c9538fc0c011ce3bad5) | `` python311Packages.elastic-apm: 6.16.2 -> 6.17.0 ``                        |
| [`fb9eb7d0`](https://github.com/NixOS/nixpkgs/commit/fb9eb7d0ea5353e7676beb3e84b7a5279845f095) | `` python311Packages.btest: 1.0 -> 1.1 ``                                    |
| [`15a33403`](https://github.com/NixOS/nixpkgs/commit/15a3340326cc16590ec70eff51ed835f0e059fb7) | `` python311Packages.asyncwhois: 1.0.6 -> 1.0.7 ``                           |
| [`33224657`](https://github.com/NixOS/nixpkgs/commit/332246572e7dd314044e5c3219457c53f519519b) | `` python311Packages.aioesphomeapi: 15.1.1 -> 15.1.3 ``                      |
| [`21704fee`](https://github.com/NixOS/nixpkgs/commit/21704feeda78690981b3079863d0425624bb6adc) | `` python310Packages.psd-tools: 1.9.27 -> 1.9.28 ``                          |
| [`f7d24d71`](https://github.com/NixOS/nixpkgs/commit/f7d24d71aa15b751d6915802e60a7844a123cd16) | `` python311Packages.returns: add pythonImportsCheck ``                      |
| [`3af6ee75`](https://github.com/NixOS/nixpkgs/commit/3af6ee75ce71131511bd6021b9f97e9f7cd4916f) | `` python310Packages.returns: disable on unsupported Python releases ``      |
| [`f9edead1`](https://github.com/NixOS/nixpkgs/commit/f9edead13e65794d560f788d85f56cbeaca81e88) | `` python310Packages.returns: add changelog to meta ``                       |
| [`d8286eb9`](https://github.com/NixOS/nixpkgs/commit/d8286eb99e6812e65907941c61ae15376fb8c651) | `` python310Packages.pydyf: add changelog to meta ``                         |
| [`4aed2e3f`](https://github.com/NixOS/nixpkgs/commit/4aed2e3f69d44f8bb8e0e30af3f506f17ac7fbbb) | `` strawberry: 1.0.17 -> 1.0.18 ``                                           |
| [`beb158e3`](https://github.com/NixOS/nixpkgs/commit/beb158e360e9edbad7724cae6d5174ebca480f9f) | `` open-policy-agent: 0.53.1 -> 0.54.0 ``                                    |
| [`d515f621`](https://github.com/NixOS/nixpkgs/commit/d515f621023b242dcfe6317a187aeefb0fe0aa45) | `` python310Packages.publicsuffixlist: 0.10.0.20230701 -> 0.10.0.20230702 `` |
| [`bc9cdd0b`](https://github.com/NixOS/nixpkgs/commit/bc9cdd0b5aa060b89e91a00d086dad2527c28544) | `` python311Packages.types-redis: 4.6.0.1 -> 4.6.0.2 ``                      |