### PR TITLE
chore(flake/home-manager): `34db2f05` -> `050d01a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688731042,
-        "narHash": "sha256-D1p/LLP1SpDYjutt9W+O5Ek+XGdszsjYjvL30ad++OY=",
+        "lastModified": 1688805105,
+        "narHash": "sha256-UfRRqGq5z04WOAs9mfXrb+waXxYbIuInNGHGlVdOWBU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "34db2f05219bcb0e41cc85490e4c338e2405546c",
+        "rev": "050d01a62cfe19642fb193084acf34a428a67223",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`050d01a6`](https://github.com/nix-community/home-manager/commit/050d01a62cfe19642fb193084acf34a428a67223) | `` darcs: add module ``                               |
| [`af715ed8`](https://github.com/nix-community/home-manager/commit/af715ed857f9d94086e4ef833949944bf0322521) | `` tests: some minor cleanups ``                      |
| [`f288310b`](https://github.com/nix-community/home-manager/commit/f288310b7adf9775e405f251eb4920969fd8afa5) | `` goimapnotify: remove test dependency on notmuch `` |