### PR TITLE
chore(flake/stylix): `ba5565d6` -> `0087f554`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,22 +28,20 @@
     },
     "base16": {
       "inputs": {
-        "nixpkgs": [
-          "stylix",
-          "nixpkgs"
-        ]
+        "fromYaml": "fromYaml"
       },
       "locked": {
-        "lastModified": 1658847131,
-        "narHash": "sha256-X6Mml7cT0YR3WCD5fkUhpRVV5ZPcwdcDsND8r8xMqTE=",
+        "lastModified": 1687651793,
+        "narHash": "sha256-AjV/f/grsR4y6t0aUviXxjeLAEYmpE/4XE08IIPhHag=",
         "owner": "SenchoPens",
         "repo": "base16.nix",
-        "rev": "6b404cda2e04ca3cf5ca7b877af9c469e1386acb",
+        "rev": "f493d8a8a6b4c1d814790e2189f26d4bcf433185",
         "type": "github"
       },
       "original": {
         "owner": "SenchoPens",
         "repo": "base16.nix",
+        "rev": "f493d8a8a6b4c1d814790e2189f26d4bcf433185",
         "type": "github"
       }
     },
@@ -145,6 +143,22 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "fromYaml": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1685846909,
+        "narHash": "sha256-ibxtG018Qq2Qjxir4Hai3Gr1hOOa+ad4V0EbFaHOj9Y=",
+        "owner": "SenchoPens",
+        "repo": "fromYaml",
+        "rev": "706176e156923d963ead81fe6bfba041f057cc65",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SenchoPens",
+        "repo": "fromYaml",
         "type": "github"
       }
     },
@@ -420,11 +434,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688822895,
-        "narHash": "sha256-QLs226av5K1v4gQYqxAWQs8nzrlN58p1KoSc9NRME/w=",
+        "lastModified": 1689347170,
+        "narHash": "sha256-3IO+37XkKKGILEFw60VeG7P+3za47SNXD3wIXzpNTlU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ba5565d6989954ad3846245a5b4b122e4dba76d0",
+        "rev": "0087f554ffe5293a2db7444145b1c54ee338399f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                  |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`0087f554`](https://github.com/danth/stylix/commit/0087f554ffe5293a2db7444145b1c54ee338399f) | `` Adjust Waybar style :lipstick: ``                     |
| [`d14076e4`](https://github.com/danth/stylix/commit/d14076e46f31c932e2a2998df0fb8ebff9d28a71) | `` Update flake inputs :arrow_up: ``                     |
| [`d3092bed`](https://github.com/danth/stylix/commit/d3092bed023406359d06ea9a6d1f8bd7bf93d447) | `` Set fonts for Fuzzel :sparkles: ``                    |
| [`cdf7e2de`](https://github.com/danth/stylix/commit/cdf7e2ded1149a24f1b38bbdcf7c6c20d6165571) | `` Support transparency in Helix :sparkles: ``           |
| [`952ba1c7`](https://github.com/danth/stylix/commit/952ba1c7567c97b984368c1b92d1e01b6e092465) | `` Add support for Fuzzel :sparkles: ``                  |
| [`2524c8ae`](https://github.com/danth/stylix/commit/2524c8ae027e4101b9a476c0b13fe05d3c8bdeb9) | `` Avoid dependency on KConfig :heavy_minus_sign: ``     |
| [`1726a19e`](https://github.com/danth/stylix/commit/1726a19ea4148fc9cb7a22361cb44b7f3070ed0e) | `` Support KDE lock screen :sparkles: ``                 |
| [`5e7b312b`](https://github.com/danth/stylix/commit/5e7b312b5fcc5beb5b9a36e73f96c438fa74fcc9) | `` Improve sliders and folder icons on KDE :lipstick: `` |
| [`96330392`](https://github.com/danth/stylix/commit/96330392d44b3e2a18405274cc91649385f1aba3) | `` Show when a button is disabled on KDE :bug: ``        |
| [`57dabc43`](https://github.com/danth/stylix/commit/57dabc434b529e35e02a93add3cb904561790d3d) | `` Adjust KDE fonts :bug: ``                             |
| [`f5c5e02d`](https://github.com/danth/stylix/commit/f5c5e02d70ad3f0bca719e121b0bccab499209e7) | `` Add support for KDE :sparkles: ``                     |