### PR TITLE
chore(flake/nix-index-database): `44337c30` -> `75711474`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688680913,
-        "narHash": "sha256-jo/RDXXL7Zx6M36m0f0F+tQPJRzs31Y7gaDiTqqh4Ns=",
+        "lastModified": 1688874465,
+        "narHash": "sha256-BUwl+tq40EjkufTZkqf3lWFzxOA/mYBTHz+p5uJtjaY=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "44337c30729a3616c7a71d485af70d231b29675a",
+        "rev": "757114749d4613cf71f3748e780a1be8a67a5d3c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`75711474`](https://github.com/nix-community/nix-index-database/commit/757114749d4613cf71f3748e780a1be8a67a5d3c) | `` update packages.nix to release 2023-07-09-034646 `` |
| [`0f0adadf`](https://github.com/nix-community/nix-index-database/commit/0f0adadf026172cef1d7eef9011baaaf7d8b4cad) | `` flake.lock: Update ``                               |