### PR TITLE
chore(flake/darwin): `4272af40` -> `4e3fc186`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688857248,
-        "narHash": "sha256-hvoc5uLtxMNh1qCZpM3ikiMNllNI9tff5ovBH0K5gM4=",
+        "lastModified": 1688882536,
+        "narHash": "sha256-JXhHLy3+OxRghen7X8no1/8Ab+NkYSxrCIB9IILKUUc=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "4272af4079164cc89a1c1d90d04b35a9f0da04f7",
+        "rev": "4e3fc1864712a534d30ef074d695e968f1fb1487",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                    |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------ |
| [`d9e825f1`](https://github.com/LnL7/nix-darwin/commit/d9e825f121784a7628ae177a04cb80709043e0fe) | `` linux-builder: fix evaluation errors `` |