### PR TITLE
chore(flake/home-manager): `86157256` -> `b70db52f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688875170,
-        "narHash": "sha256-hNYMNl07J22c0K0NhVyvF6cF8mahOCzBTNKT/OEQN14=",
+        "lastModified": 1688892808,
+        "narHash": "sha256-AeWzyG37EqyHH2C1GmrV9y0ZQ4e7rAs9AUOnw8I4YUI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "86157256d2e0d257c53eefeb008230f043e12210",
+        "rev": "b70db52ff06f30e3de7f21b6ea47e75baa0c46f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`b70db52f`](https://github.com/nix-community/home-manager/commit/b70db52ff06f30e3de7f21b6ea47e75baa0c46f6) | `` imapnotify: move test ``                            |
| [`fad47555`](https://github.com/nix-community/home-manager/commit/fad475553ae2de3ba1dbcab980698ac070d04e72) | `` imapnotify: use direct nix store path for config `` |