### PR TITLE
chore(flake/darwin): `4e3fc186` -> `66a3047f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688882536,
-        "narHash": "sha256-JXhHLy3+OxRghen7X8no1/8Ab+NkYSxrCIB9IILKUUc=",
+        "lastModified": 1688898859,
+        "narHash": "sha256-NjvwXnMp8oMQ86FHVhzlmgGy2dVDMGVLpZ4+YVsJgMU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "4e3fc1864712a534d30ef074d695e968f1fb1487",
+        "rev": "66a3047fa88eb6aa5c5a2e675de91f0431fbe561",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                  |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
| [`f9724c45`](https://github.com/LnL7/nix-darwin/commit/f9724c4543035d6190c00168ebfa93f0b2e927d0) | `` eval-config: rationalize handling of Nixpkgs ``       |
| [`51ba5e61`](https://github.com/LnL7/nix-darwin/commit/51ba5e614acf1c94d519e6047814219082827faa) | `` version: rewrite Git revision logic ``                |
| [`72b7e866`](https://github.com/LnL7/nix-darwin/commit/72b7e8668c24950b8300ffe3d135dad1ae72a4f5) | `` version: default Git revision options to `null` ``    |
| [`e25eeff1`](https://github.com/LnL7/nix-darwin/commit/e25eeff158ceb415079e38f6e78a470c5664fa2f) | `` nixpkgs: rebase module on latest NixOS ``             |
| [`2d20e861`](https://github.com/LnL7/nix-darwin/commit/2d20e861112955cd2d102d0a0abf36d265001a5d) | `` documentation: use feature test for docs generator `` |