### PR TITLE
chore(flake/nixpkgs): `3c748757` -> `408c0e8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688679045,
-        "narHash": "sha256-t3xGEfYIwhaLTPU8FLtN/pLPytNeDwbLI6a7XFFBlGo=",
+        "lastModified": 1688918189,
+        "narHash": "sha256-f8ZlJ67LgEUDnN7ZsAyd1/Fyby1VdOXWg4XY/irSGrQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3c7487575d9445185249a159046cc02ff364bff8",
+        "rev": "408c0e8c15a1c9cf5c3226931b6f283c9867c484",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`2fc57ae6`](https://github.com/NixOS/nixpkgs/commit/2fc57ae6702b9f74d18a8cd94746962816984904) | `` nixos/tests: adjust everything I missed for sddm update ``                          |
| [`7d0994b5`](https://github.com/NixOS/nixpkgs/commit/7d0994b59b7d568e566f320131b0dc3aba81c5b5) | `` zsh-powerlevel9k: fix longdescription ``                                            |
| [`618c1a7a`](https://github.com/NixOS/nixpkgs/commit/618c1a7ab50a3d70213531783a7d4daccdcb9e1b) | `` caffeine: init at 1.1.3 ``                                                          |
| [`f4984cb5`](https://github.com/NixOS/nixpkgs/commit/f4984cb5ba7c3e9c08301cc6c624bca1144030c6) | `` automatic-timezoned: 1.0.107 -> 1.0.108 ``                                          |
| [`12b8cf53`](https://github.com/NixOS/nixpkgs/commit/12b8cf53e453ef4130c4f8936d1240659db9ff28) | `` wasmedge: 0.12.1 -> 0.13.0 ``                                                       |
| [`8f216662`](https://github.com/NixOS/nixpkgs/commit/8f216662cbe2ff680108e2fc0d49f419fd1e4ef1) | `` sage: import singular 4.3.2p2 update patch ``                                       |
| [`69cc6c07`](https://github.com/NixOS/nixpkgs/commit/69cc6c07ac8fd4a652fd6480e9e567bda7265c6a) | `` singular: 4.3.2p1 -> 4.3.2p2 ``                                                     |
| [`1104a229`](https://github.com/NixOS/nixpkgs/commit/1104a229626fecfffe25e172201567ee8c6ec791) | `` sage: refresh patches ``                                                            |
| [`78593c83`](https://github.com/NixOS/nixpkgs/commit/78593c83f7b69e1f08a8cb6e3d1e8f5cfa6f3905) | `` x265: enable unit tests on x64 only ``                                              |
| [`8703c30b`](https://github.com/NixOS/nixpkgs/commit/8703c30b5398eb25456b81ff0f2eda35f78783df) | `` kube-score: 1.16.1 -> 1.17.0 ``                                                     |
| [`eca89b07`](https://github.com/NixOS/nixpkgs/commit/eca89b077f22a5ebd4837bf4fd0f90b49476d6b6) | `` dotool: init at 1.3 ``                                                              |
| [`123a27cd`](https://github.com/NixOS/nixpkgs/commit/123a27cdac274114a7e16767cefa5f6bc30e2a92) | `` trivy: 0.43.0 -> 0.43.1 ``                                                          |
| [`3124e11b`](https://github.com/NixOS/nixpkgs/commit/3124e11bac971e659542b5e971f83864b18588c4) | `` cairo-lang: 1.1.1 -> 2.0.1 ``                                                       |
| [`f603066c`](https://github.com/NixOS/nixpkgs/commit/f603066c335db93957d778d7a805286362ddb2cc) | `` ctranslate2: 3.16.0 -> 3.16.1 ``                                                    |
| [`2e10bddd`](https://github.com/NixOS/nixpkgs/commit/2e10bdddec186590c96f1a8801294fa073361c0e) | `` nixpacks: 1.9.1 -> 1.9.2 ``                                                         |
| [`e71c26cc`](https://github.com/NixOS/nixpkgs/commit/e71c26ccbcf34a5e007d711b1cf228ea5c51e343) | `` pyenv: 2.3.21 -> 2.3.22 ``                                                          |
| [`e15f252f`](https://github.com/NixOS/nixpkgs/commit/e15f252fb9dac31a30cfc4ea050a2a951df5d96f) | `` xonotic: fix icon installation ``                                                   |
| [`7d48263e`](https://github.com/NixOS/nixpkgs/commit/7d48263e1232a7ac63e4ae5ab79a18c1bd633334) | `` vmagent: 1.91.2 -> 1.91.3 ``                                                        |
| [`2fed004f`](https://github.com/NixOS/nixpkgs/commit/2fed004f958826071d03e6a7f2a47278aa54457c) | `` sentry-cli: 2.19.1 -> 2.19.4 ``                                                     |
| [`119ba5ce`](https://github.com/NixOS/nixpkgs/commit/119ba5ce80e6ae814e3aa88121565df7537cd5a9) | `` milkytracker: apply patch for CVE-2022-34927 ``                                     |
| [`460b62a1`](https://github.com/NixOS/nixpkgs/commit/460b62a16d07e7f284781ddf2c2649ee227f7fe5) | `` vlc: fix eval on aarch64 after #242080 ``                                           |
| [`70ec5657`](https://github.com/NixOS/nixpkgs/commit/70ec5657a0a55822cbbb14cd0f8b2c9a37e22afd) | `` blobby: 1.0 -> 1.1 ``                                                               |
| [`6fa09ab3`](https://github.com/NixOS/nixpkgs/commit/6fa09ab33f727e1ac25eda0bfcf4f97599e941b6) | `` sq: 0.39.1 -> 0.40.0 ``                                                             |
| [`69946ea4`](https://github.com/NixOS/nixpkgs/commit/69946ea4cf13fdcc95b0df3c682d4977ffbc9699) | `` luajit: set BUILDMODE flag for static builds ``                                     |
| [`ec8867cd`](https://github.com/NixOS/nixpkgs/commit/ec8867cd7d9c63344ca260633686b0e6062c3690) | `` minesweep-rs: 6.0.11 -> 6.0.13 ``                                                   |
| [`953b1107`](https://github.com/NixOS/nixpkgs/commit/953b1107ef3bdfe7612e52a145b17ceb7afbc879) | `` frp: 0.50.0 -> 0.51.0 ``                                                            |
| [`bd9844b9`](https://github.com/NixOS/nixpkgs/commit/bd9844b9ad18a514767def3c45297eff9fe7751b) | `` pritunl-client: 1.3.3484.2 -> 1.3.3584.5 ``                                         |
| [`8c70df85`](https://github.com/NixOS/nixpkgs/commit/8c70df85b511386ea04f28c3a733d8c36994a02a) | `` werf: 1.2.241 -> 1.2.242 ``                                                         |
| [`5c1583bf`](https://github.com/NixOS/nixpkgs/commit/5c1583bfd754ea6a668d2b76efef855201aa3ea8) | `` nixos/plymouth: fix minor doc rendering issue ``                                    |
| [`ca9e7a24`](https://github.com/NixOS/nixpkgs/commit/ca9e7a2416a587d8fce5dd500502079826d81129) | `` polymake: 4.9 -> 4.10 ``                                                            |
| [`00e54b06`](https://github.com/NixOS/nixpkgs/commit/00e54b06323ff4bfe1161a706ba838ae2937e2e5) | `` python310Packages.hap-python: update source hash to fix build ``                    |
| [`1f2493e5`](https://github.com/NixOS/nixpkgs/commit/1f2493e5b668c0ffb505ce77ee15bb2c79da943b) | `` python310Packages.effdet: init at 0.4.1 ``                                          |
| [`8533b231`](https://github.com/NixOS/nixpkgs/commit/8533b231599034d223a80b1799d219e093ac3a93) | `` nixos/networkd: fix mismerge of #240969 and #241362 ``                              |
| [`02756b75`](https://github.com/NixOS/nixpkgs/commit/02756b75a44333f8b1af9ee4b9fa838fef46353f) | `` flink: 1.17.0 -> 1.17.1 ``                                                          |
| [`185b5132`](https://github.com/NixOS/nixpkgs/commit/185b5132445bc675b4c3aafc1274a2bdbd4ead7d) | `` rnote: 0.7.0 -> 0.7.1 ``                                                            |
| [`9a73da8f`](https://github.com/NixOS/nixpkgs/commit/9a73da8f03453f2f6789eb37d6e58328f404aafd) | `` haproxy: 2.8.0 -> 2.8.1 ``                                                          |
| [`28ed9b14`](https://github.com/NixOS/nixpkgs/commit/28ed9b141ffb252c04d1e146c7219ea627eb3889) | `` poetry: 1.4.2 -> 1.5.1 ``                                                           |
| [`e01711b3`](https://github.com/NixOS/nixpkgs/commit/e01711b319d9dfa24a27b0afb77d432433e2c773) | `` timeshift: 23.06.2 -> 23.07.1 ``                                                    |
| [`b142e9fe`](https://github.com/NixOS/nixpkgs/commit/b142e9fe9002172c11bd25fa41210872ae933866) | `` cinnamon.mint-y-icons: 1.6.6 -> 1.6.7 ``                                            |
| [`a0a702cf`](https://github.com/NixOS/nixpkgs/commit/a0a702cf33364ac6e0c603cef9e988d66daf50b3) | `` cinnamon.mint-l-icons: 1.6.4 -> 1.6.5 ``                                            |
| [`22950904`](https://github.com/NixOS/nixpkgs/commit/22950904fcfc1df71f7abb26cc5e8f2a904aff8a) | `` cinnamon.cinnamon-translations: 5.8.1 -> 5.8.2 ``                                   |
| [`cd3c0a64`](https://github.com/NixOS/nixpkgs/commit/cd3c0a6452fcd697cd99613cf114a412b6572ed6) | `` moar: 1.15.2 -> 1.15.3 ``                                                           |
| [`e7e3cd85`](https://github.com/NixOS/nixpkgs/commit/e7e3cd85cea16d0058f7457a16875a58be60f028) | `` python310Packages.poetry-plugin-export: move to poetryPlugins ``                    |
| [`7c231bd5`](https://github.com/NixOS/nixpkgs/commit/7c231bd5e899d5c444bd783525ffc32b5493b468) | `` python310Packages.poetry-plugin-export: 1.3.1 -> 1.4.0 ``                           |
| [`15d805ea`](https://github.com/NixOS/nixpkgs/commit/15d805ea1114460c137ed449547ebe1785deb2bd) | `` poetryPlugins.poetry-plugin-up: make compatible with poetry 1.5 ``                  |
| [`6f6687ee`](https://github.com/NixOS/nixpkgs/commit/6f6687ee24a26ef33b47aec23d804e998ca00964) | `` darwin.stdenv: only run `install_name_tool` on files ``                             |
| [`feb89eed`](https://github.com/NixOS/nixpkgs/commit/feb89eed00eb848da8c9eb56f5dad9fa1e79d536) | `` darwin.stdenv: fix portable libsystem hook with sandboxing ``                       |
| [`6d398316`](https://github.com/NixOS/nixpkgs/commit/6d398316c773de00d830dc65143296aca1ba11a0) | `` poetry: pin cachecontrol to 0.12.14 ``                                              |
| [`0690545f`](https://github.com/NixOS/nixpkgs/commit/0690545f05ffc007f70ec0a77c92b0c8a7534d9e) | `` libdivecomputer: 0.7.0 -> 0.8.0 ``                                                  |
| [`4aff21f2`](https://github.com/NixOS/nixpkgs/commit/4aff21f203c3a12bdb7405e5cbd20a2e9dc981f2) | `` sound-of-sorting: refactor ``                                                       |
| [`9b662595`](https://github.com/NixOS/nixpkgs/commit/9b6625953113a84560313a157293feb24c6156d5) | `` aliases.nix: cosmetic ``                                                            |
| [`439952f5`](https://github.com/NixOS/nixpkgs/commit/439952f5610b0e9a782c7438faa0891e5438b1b4) | `` skaffold: 2.6.0 -> 2.6.1 ``                                                         |
| [`12418710`](https://github.com/NixOS/nixpkgs/commit/12418710ec5f584b2a6bfcc6a13c9ea44d995ab4) | `` python310Packages.canals: init at 0.2.2 ``                                          |
| [`0a158d0a`](https://github.com/NixOS/nixpkgs/commit/0a158d0a5c84d6c18c8d9971119b3e89b09a2878) | `` imgui: 1.89.6 -> 1.89.7 ``                                                          |
| [`3279a248`](https://github.com/NixOS/nixpkgs/commit/3279a248abeb848426aa974e23c2ef1db569eea5) | `` codeql: 2.13.3 -> 2.13.5 ``                                                         |
| [`530f45d4`](https://github.com/NixOS/nixpkgs/commit/530f45d4133f3854a63541f6f4151cd427a43446) | `` docker-buildx: 0.11.0 -> 0.11.1 ``                                                  |
| [`f7ab2c35`](https://github.com/NixOS/nixpkgs/commit/f7ab2c355d942f969c5198d8f081e37810180920) | `` capnproto-java: 0.1.5 -> 0.1.15 ``                                                  |
| [`a987b671`](https://github.com/NixOS/nixpkgs/commit/a987b671bb86d9ed94904e5a77d10e60d87d3268) | `` earthly: 0.7.9 -> 0.7.10 ``                                                         |
| [`d3b3f1b2`](https://github.com/NixOS/nixpkgs/commit/d3b3f1b296e922ee16667ea943f2fa5d962f1ec8) | `` pylyzer: 0.0.34 -> 0.0.37 ``                                                        |
| [`f13d8e3e`](https://github.com/NixOS/nixpkgs/commit/f13d8e3ede9b5f059d44a74a7cda5da1b25da952) | `` usql: 0.14.8 -> 0.14.10 ``                                                          |
| [`651beb2a`](https://github.com/NixOS/nixpkgs/commit/651beb2a23fb0ae7939c5e0d3c645f487fdaa448) | `` wlay: init at unstable-2022-01-26 ``                                                |
| [`02fb17b3`](https://github.com/NixOS/nixpkgs/commit/02fb17b3f3ccca018afc6d61556e0e474f729267) | `` yas: init at 7.1.0 ``                                                               |
| [`eec22319`](https://github.com/NixOS/nixpkgs/commit/eec223190766e02a3a1127a18341876a243f8226) | `` maintainers: add ee2500 ``                                                          |
| [`1ddd2341`](https://github.com/NixOS/nixpkgs/commit/1ddd2341b3ba0bbdea4f1409cc9ee1eaaa06c77f) | `` asciidoctor: fix build ``                                                           |
| [`17e26fcf`](https://github.com/NixOS/nixpkgs/commit/17e26fcf49a6aa8fb0f87d113a24a7a5d242cef6) | `` ft2-clone: 1.67 -> 1.68 ``                                                          |
| [`d485da9d`](https://github.com/NixOS/nixpkgs/commit/d485da9d0034a72ceb9679c2ab0156c073f66b82) | `` zig_0_10: refactor ``                                                               |
| [`cc08d736`](https://github.com/NixOS/nixpkgs/commit/cc08d73612538545738d6fa5c339781e65896431) | `` zig_0_9: refactor ``                                                                |
| [`3ed42e6a`](https://github.com/NixOS/nixpkgs/commit/3ed42e6ac892f7ffebb8fbf96eee9be69813c43a) | `` goa: 3.11.3 -> 3.12.1 ``                                                            |
| [`48469f82`](https://github.com/NixOS/nixpkgs/commit/48469f8286a31ff58b2f398a0fcecd0793a93b04) | `` pocketbase: 0.16.5 -> 0.16.7 ``                                                     |
| [`39a72d2c`](https://github.com/NixOS/nixpkgs/commit/39a72d2c254d74539c45456d527a60d1a4306d88) | `` chezmoi: 2.34.2 -> 2.34.3 ``                                                        |
| [`009a073b`](https://github.com/NixOS/nixpkgs/commit/009a073bbe5b188e1d0263c75757bbb54c0b2270) | `` kubecfg: 0.29.2 -> 0.30.0 ``                                                        |
| [`c222707a`](https://github.com/NixOS/nixpkgs/commit/c222707a5ba1ba1b1fc2b1ffc9019339210e35ff) | `` bun: 0.6.12 -> 0.6.13 ``                                                            |
| [`576367be`](https://github.com/NixOS/nixpkgs/commit/576367be5a8e43f7be1fddfb0c23ab092db99648) | `` entwine: 2022-08-03 -> 2023-04-27 ``                                                |
| [`2c05ecb0`](https://github.com/NixOS/nixpkgs/commit/2c05ecb0c163fce6fb83ae1ba119d75e7c62694c) | `` fits-cloudctl: 0.11.9 -> 0.11.10 ``                                                 |
| [`3ab10e0c`](https://github.com/NixOS/nixpkgs/commit/3ab10e0c19b97902220136616d824dae5a0eac31) | `` photofield: 0.10.3 -> 0.10.4 ``                                                     |
| [`11b2909e`](https://github.com/NixOS/nixpkgs/commit/11b2909e09d75d5ed2bcf2c655f69e862dfd7a48) | `` oh-my-posh: update ldflags ``                                                       |
| [`97d0d7aa`](https://github.com/NixOS/nixpkgs/commit/97d0d7aa655b0204a66d15cf01154f94c9754512) | `` oh-my-posh: 17.5.2 -> 17.6.0 ``                                                     |
| [`55fca2c9`](https://github.com/NixOS/nixpkgs/commit/55fca2c9c94e3762b150b7d229f88cd71db5e43d) | `` snd: 23.4 -> 23.5 ``                                                                |
| [`7d7c7bc3`](https://github.com/NixOS/nixpkgs/commit/7d7c7bc3f6698d784d33df8bca8fa50eab15d610) | `` librewolf: 114.0.2-1 -> 115.0-1 ``                                                  |
| [`7100097e`](https://github.com/NixOS/nixpkgs/commit/7100097e78fe50379cbd29276b03a25438c620f9) | `` a2ps: 4.15.4 -> 4.15.5 ``                                                           |
| [`93d9c279`](https://github.com/NixOS/nixpkgs/commit/93d9c279dc585e9577980ee002b35baec73ea808) | `` vkbasalt: 0.3.2.9 -> 0.3.2.10 ``                                                    |
| [`cc8fda9e`](https://github.com/NixOS/nixpkgs/commit/cc8fda9e12e9cb68f460d4b763994e041c35c3ef) | `` python310Packages.django-rosetta: fix changelog ``                                  |
| [`8b41523f`](https://github.com/NixOS/nixpkgs/commit/8b41523f78426529d8766058e918f2f038521c62) | `` python310Packages.django-rosetta: 0.9.8 -> 0.9.9 ``                                 |
| [`4d1cc452`](https://github.com/NixOS/nixpkgs/commit/4d1cc452b6eacd102173bd5a1b3dcd3efbf7641b) | `` maptool: 1.13.1 -> 1.13.2 ``                                                        |
| [`29516578`](https://github.com/NixOS/nixpkgs/commit/2951657846c53b6cef7c4efb7ee6266faa7f1fba) | `` obs-studio-plugins.obs-move-transition: 2.9.0 -> 2.9.1 ``                           |
| [`79982e88`](https://github.com/NixOS/nixpkgs/commit/79982e885c17c7252603c99d73f662fecab87e07) | `` syncthingtray: 1.4.3 -> 1.4.4 ``                                                    |
| [`2fb26348`](https://github.com/NixOS/nixpkgs/commit/2fb26348bab1669cf22149d47e14d1237cc3f315) | `` libsForQt5.qtutilities: 6.12.2 -> 6.13.0 ``                                         |
| [`e2ccfa8d`](https://github.com/NixOS/nixpkgs/commit/e2ccfa8d8145d91fa8124e511ef7a57d8163a129) | `` rustypaste-cli: 0.5.0 -> 0.6.0 ``                                                   |
| [`a983f438`](https://github.com/NixOS/nixpkgs/commit/a983f438accec19c96c82b429f175d2dcab53317) | `` iosevka-bin: 24.1.4 -> 25.0.0 ``                                                    |
| [`701495af`](https://github.com/NixOS/nixpkgs/commit/701495af10ccf96fa8debdad1fc5f11ed24f25f7) | `` iperf3d: init at 1.0.0 (#241947) ``                                                 |
| [`5a31759c`](https://github.com/NixOS/nixpkgs/commit/5a31759c54243040d19e8dff4dac2005c11ad624) | `` hsqldb: 2.7.1 -> 2.7.2 ``                                                           |
| [`38583d8b`](https://github.com/NixOS/nixpkgs/commit/38583d8bdb9ce2fc608ed1dd9ab858960aacc4e5) | `` Share dropbox PID ``                                                                |
| [`be39519d`](https://github.com/NixOS/nixpkgs/commit/be39519da74af2cbb4fa9e4b47baa06dcd289292) | `` abcmidi: 2023.05.30 -> 2023.06.25 ``                                                |
| [`008f9f0c`](https://github.com/NixOS/nixpkgs/commit/008f9f0cd419bd66e922239e2319fd2b1f347ad8) | `` nixos/test-driver: actually use the backdoor message to wait for backdoor ``        |
| [`788704d9`](https://github.com/NixOS/nixpkgs/commit/788704d97495c47adbf4e06c4ef43dbc32814688) | `` ser2net: 4.3.12 -> 4.3.13 ``                                                        |
| [`81bc889c`](https://github.com/NixOS/nixpkgs/commit/81bc889cc3ac6c2f8ca320c94914b258c0fef262) | `` prettierd: init at 0.23.4 ``                                                        |
| [`aa1beb0a`](https://github.com/NixOS/nixpkgs/commit/aa1beb0ab589b017a80927282d3ab60553071f71) | `` doc: Render lib.fixedPoints ``                                                      |
| [`bd091b3a`](https://github.com/NixOS/nixpkgs/commit/bd091b3a9210f5682033d1d9e9b86800dff6306a) | `` kde/frameworks: 5.107.0 -> 5.108.0 ``                                               |
| [`1c1c8bfb`](https://github.com/NixOS/nixpkgs/commit/1c1c8bfb1469b95076bd3331e830a9f749a78a22) | `` php81Packages.php-cs-fixer: 3.16.0 -> 3.21.1 ``                                     |
| [`ccd91f8c`](https://github.com/NixOS/nixpkgs/commit/ccd91f8c8df4f5d8ec049a25b3412f10597676c3) | `` python310Packages.ytmusicapi: 1.1.0 -> 1.1.1 ``                                     |
| [`a07433c1`](https://github.com/NixOS/nixpkgs/commit/a07433c1fbd3f195ece7993da3c85a9cc506e9bc) | `` terragrunt: 0.48.0 -> 0.48.1 ``                                                     |
| [`ead7b780`](https://github.com/NixOS/nixpkgs/commit/ead7b7800d7401f09017aa7f8079e782a78838a3) | `` nest-mpi: 3.4 -> 3.5 ``                                                             |
| [`8fb44a49`](https://github.com/NixOS/nixpkgs/commit/8fb44a4928fbeda9b38d81108fca25b04418d309) | `` python3Packages.django-cachalot: init at 2.5.3 ``                                   |
| [`40c09afe`](https://github.com/NixOS/nixpkgs/commit/40c09afe5fb800f32780827b9050412c9932e352) | `` ls-lint: 2.0.0 -> 2.0.1 ``                                                          |
| [`c1527906`](https://github.com/NixOS/nixpkgs/commit/c1527906f7a07f603278043200b904c4301c6f63) | `` python310Packages.ipyparallel: cleanup dependencies ``                              |
| [`e3340263`](https://github.com/NixOS/nixpkgs/commit/e3340263050b0e4cf409ab329396268e4716e794) | `` theforceengine: 1.09.200 -> 1.09.300 ``                                             |
| [`26cbcfeb`](https://github.com/NixOS/nixpkgs/commit/26cbcfeb589c016b69b9bda99a54feec3009cbd5) | `` syncthing-discovery: 1.23.5 -> 1.23.6 ``                                            |
| [`1785fe6c`](https://github.com/NixOS/nixpkgs/commit/1785fe6c01def91e5adfb3eb4460f96a9fe33f94) | `` nixos/i18n: correct defaultText for supportedLocales ``                             |
| [`c9bde7e9`](https://github.com/NixOS/nixpkgs/commit/c9bde7e93fd8d44f18ca4e9433931ead64a3db11) | `` gobgpd: 3.15.0 -> 3.16.0 (#242273) ``                                               |
| [`ed20d944`](https://github.com/NixOS/nixpkgs/commit/ed20d94473a7811ee9f8c045c6be326176fd648d) | `` zigbee2mqtt: 1.32.0 -> 1.32.1 (#242257) ``                                          |
| [`469b7f7b`](https://github.com/NixOS/nixpkgs/commit/469b7f7b2b5eb5244711fe187cb837bbe19112d1) | `` iina: 1.3.1 -> 1.3.2 ``                                                             |
| [`d4ea9d17`](https://github.com/NixOS/nixpkgs/commit/d4ea9d17a7819710b4625f31c51048cccbe9f4ed) | `` cfripper: 1.13.1 -> 1.13.2 ``                                                       |
| [`235fde44`](https://github.com/NixOS/nixpkgs/commit/235fde44a5a18d1e3a0c264f27904a920958cc18) | `` vscode-langservers-extracted: expose vscode-eslint, switch to vscodium (#239650) `` |