### PR TITLE
chore(flake/nixos-hardware): `47dca15d` -> `f0984a5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -298,11 +298,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1688798314,
-        "narHash": "sha256-MFG5rx7L756rtrPHsL662m64AZ4sKqUcApaiYgSKfNM=",
+        "lastModified": 1688966833,
+        "narHash": "sha256-9ilzbSwArZmDjT/g1XYD+KYOFfmoS0WOYXSQBvZDIv4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "47dca15d86fdd2eabcf434d7cc0b5baa8d1a463c",
+        "rev": "f0984a5a303659bc9b73895c82a85fdfae40b87a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                      |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`7f46848e`](https://github.com/NixOS/nixos-hardware/commit/7f46848ea6f8755264be8cd37376bb068c185142) | `` lenovo legion 7 slim 15ach6: remove brightness service `` |
| [`4259025d`](https://github.com/NixOS/nixos-hardware/commit/4259025da1308836a5c978ee8015f47b7185334b) | `` apple/t2: update to kernel 6.4.2 ``                       |