### PR TITLE
chore(flake/darwin): `90ae979e` -> `97d4a910`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688973178,
-        "narHash": "sha256-nsIzOjD3v5zuozWeUvifEQ778C8cLMqW5ga5cfrmxAA=",
+        "lastModified": 1688993191,
+        "narHash": "sha256-H+tNvCLgtBIyV+DvAVf6I0bZTrkXLOIlpWl9T32+uDw=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "90ae979e352d241a86b73f8c7193bf7f749f37e4",
+        "rev": "97d4a9102964aae7deac3290d755e6fbad9b94ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                    |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
| [`591446ca`](https://github.com/LnL7/nix-darwin/commit/591446ca945402044ad109990491ed87c42ba37a) | `` nix: Remove readOnlyStore option as it has no effect `` |
| [`4a7da05c`](https://github.com/LnL7/nix-darwin/commit/4a7da05c1ef53064d548742eddb1964cf4b3dda7) | `` Fix spelling ``                                         |