### PR TITLE
chore(flake/darwin): `97d4a910` -> `83620edf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688993191,
-        "narHash": "sha256-H+tNvCLgtBIyV+DvAVf6I0bZTrkXLOIlpWl9T32+uDw=",
+        "lastModified": 1688999459,
+        "narHash": "sha256-b0rFzeHWXGq2rrx+W93I1Lpb0HFq0T5Pfx7QLVcZ/jE=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "97d4a9102964aae7deac3290d755e6fbad9b94ab",
+        "rev": "83620edf499ba8033ad43d4f5edc50fdf3eeee5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                      |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
| [`b70656af`](https://github.com/LnL7/nix-darwin/commit/b70656affa5e63efcf0a0a728c6f9a26911c7ef4) | `` Add system.systemBuilderCommands and systemBuilderArgs `` |