### PR TITLE
chore(flake/nixos-hardware): `f0984a5a` -> `44bc0250`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -298,11 +298,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1688966833,
-        "narHash": "sha256-9ilzbSwArZmDjT/g1XYD+KYOFfmoS0WOYXSQBvZDIv4=",
+        "lastModified": 1689060619,
+        "narHash": "sha256-vODUkZLWFVCvo1KPK3dC2CbXjxa9antEn5ozwlcTr48=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f0984a5a303659bc9b73895c82a85fdfae40b87a",
+        "rev": "44bc025007e5fcc10dbc3d9f96dcbf06fc0e8c1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`39eac9bf`](https://github.com/NixOS/nixos-hardware/commit/39eac9bf9a5553ba0815f5824309fa00f9573820) | `` added 16IRX8H Lenovo Legion 7i Pro (2023) (#660) `` |
| [`bb7ba40a`](https://github.com/NixOS/nixos-hardware/commit/bb7ba40a67bfc8f4bbc23aad6e12d8df0e1df53f) | `` Update microchip/common/bsp/uboot.nix ``           |
| [`e5ea5821`](https://github.com/NixOS/nixos-hardware/commit/e5ea58213358b9037a00d0b1c2bcc5e4b0d46151) | `` Microchip uboot build failure with nixpkgs 23.05 `` |