### PR TITLE
chore(flake/nixpkgs): `408c0e8c` -> `4a729ce4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688918189,
-        "narHash": "sha256-f8ZlJ67LgEUDnN7ZsAyd1/Fyby1VdOXWg4XY/irSGrQ=",
+        "lastModified": 1689008574,
+        "narHash": "sha256-VFMgyHDiqsGDkRg73alv6OdHJAqhybryWHv77bSCGIw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "408c0e8c15a1c9cf5c3226931b6f283c9867c484",
+        "rev": "4a729ce4b1fe5ec4fffc71c67c96aa5184ebb462",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`5d8f9910`](https://github.com/NixOS/nixpkgs/commit/5d8f9910f51b9f1e054c4bcfb2be274103cabdbc) | `` python310Packages.django-mysql: 4.10.0 -> 4.11.0 ``                                 |
| [`193583c2`](https://github.com/NixOS/nixpkgs/commit/193583c2415a0f129655d51e818a32e5ab92e0a5) | `` sbt: 1.9.1 -> 1.9.2 (#242598) ``                                                    |
| [`47d3edc4`](https://github.com/NixOS/nixpkgs/commit/47d3edc400bd6df6db485187fdaf257f1482b755) | `` python310Packages.layoutparser: init at 0.3.4 ``                                    |
| [`5416f26e`](https://github.com/NixOS/nixpkgs/commit/5416f26eee04e9bd0d7720c93366e21603d2c35d) | `` phpExtensions.mongodb: 1.15.0 -> 1.16.1 ``                                          |
| [`c8bb2d35`](https://github.com/NixOS/nixpkgs/commit/c8bb2d35d957ef3f838808f4a1bd99f9603d85ec) | `` phpExtensions.datadog_trace: 0.82.0 -> 0.89.0 ``                                    |
| [`4dcd4c38`](https://github.com/NixOS/nixpkgs/commit/4dcd4c38e80d62fbd123caeadf16e9efc32c4130) | `` btop: cleanup ``                                                                    |
| [`ea1d1a8f`](https://github.com/NixOS/nixpkgs/commit/ea1d1a8f5283dd585149e61215cb40650304722c) | `` bup: don't error out on implicit-function-declaration on darwin ``                  |
| [`a3092152`](https://github.com/NixOS/nixpkgs/commit/a3092152a22e413bad38de5757510ea8b4e1c44b) | `` py-spy: make fixes more legal ``                                                    |
| [`ca90d55f`](https://github.com/NixOS/nixpkgs/commit/ca90d55f0f03a2a12be3aba6f0c75c3a64deeaee) | `` yabai: 5.0.4 -> 5.0.6 ``                                                            |
| [`43121245`](https://github.com/NixOS/nixpkgs/commit/431212450d0713ba71aa37ba4a11778356de1e20) | `` github-runner: 2.305.0 -> 2.306.0 (#242515) ``                                      |
| [`34b3a809`](https://github.com/NixOS/nixpkgs/commit/34b3a809efcd30bf1508cd246af4e9d0c6357259) | `` buildLuarocksPackage: rename file to match its role ``                              |
| [`bd489764`](https://github.com/NixOS/nixpkgs/commit/bd489764b007da4c8bcc1c89a80fdfd6a6505ab6) | `` mu: 1.10.4 -> 1.10.5 ``                                                             |
| [`bfb26144`](https://github.com/NixOS/nixpkgs/commit/bfb26144e7fb8c6839d076252ddc405fe3199700) | `` timetagger: unbreak ``                                                              |
| [`a8b1bb8b`](https://github.com/NixOS/nixpkgs/commit/a8b1bb8bdea5b00dc8c6f7dd6510e890a5558905) | `` python310Packages.pyvista: 0.39.1 -> 0.40.0 ``                                      |
| [`724040fe`](https://github.com/NixOS/nixpkgs/commit/724040fe18c59d8ab93d805f8572e58f716d56d5) | `` citrix_workspace: remove obsolete version checks ``                                 |
| [`93681ae8`](https://github.com/NixOS/nixpkgs/commit/93681ae822f40dbfab43d9b9cd9533a26a557542) | `` python310Packages.quantulum3: init at 0.9.0 ``                                      |
| [`e422f19d`](https://github.com/NixOS/nixpkgs/commit/e422f19d9dedfb8fe7fa772905762c4907971c87) | `` python310Packages.stemming: init at 1.0.1 ``                                        |
| [`61dcc12a`](https://github.com/NixOS/nixpkgs/commit/61dcc12ab787e497354adfad71b264cf87031978) | `` python310Packages.boilerpy3: init at 1.0.6 ``                                       |
| [`c6a50bb8`](https://github.com/NixOS/nixpkgs/commit/c6a50bb86f6087ac6d4c8096dba09d976e3bb430) | `` python310Packages.rank_bm25: init at 0.2.2 ``                                       |
| [`ef115853`](https://github.com/NixOS/nixpkgs/commit/ef1158539c27f6a09e5b9c61079b1111e8973ea4) | `` python310Packages.prompthub-py: init at 4.0.0 ``                                    |
| [`9f915755`](https://github.com/NixOS/nixpkgs/commit/9f915755ba06cd3520a80c6ca62801cd0b825bdf) | `` python310Packages.lazy_imports: ini at 0.3.1 ``                                     |
| [`dab0c5cc`](https://github.com/NixOS/nixpkgs/commit/dab0c5cc6ca071ac65613e3d8d46b02b71b33c1c) | `` python310Packages.iopath: init at 0.1.9 ``                                          |
| [`8b49fc8e`](https://github.com/NixOS/nixpkgs/commit/8b49fc8efb8af985a2c2f33a3b52259b5e35f00f) | `` python310Packages.pdfplumber: init at 0.9.0 ``                                      |
| [`dc8c60ec`](https://github.com/NixOS/nixpkgs/commit/dc8c60ecb18c4392beca17629bb88053a265a496) | `` python310Packages.nbexec: init at 0.2.0 ``                                          |
| [`7e5faf7e`](https://github.com/NixOS/nixpkgs/commit/7e5faf7e4e46e35e59c8b6893b9295dcf6fce98c) | `` python310Packages.pytest-parallel: init at 0.1.1 ``                                 |
| [`31b0d9b1`](https://github.com/NixOS/nixpkgs/commit/31b0d9b169ce496b797c40e554d89a10d5b8270e) | `` citrix_workspace: 23.02.0 -> 23.07.0 ``                                             |
| [`79899a0b`](https://github.com/NixOS/nixpkgs/commit/79899a0b24795ea252b55b8206ec9848983c5190) | `` jackett: 0.21.364 -> 0.21.449 ``                                                    |
| [`92317986`](https://github.com/NixOS/nixpkgs/commit/92317986be606cb086640384f99b1cc99e6a8743) | `` hwloc: 2.9.1 -> 2.9.2 ``                                                            |
| [`9d6e454b`](https://github.com/NixOS/nixpkgs/commit/9d6e454b857fb472fa35fc8b098fa5ac307a0d7d) | `` gptcommit: 0.5.8 -> 0.5.10 ``                                                       |
| [`58201154`](https://github.com/NixOS/nixpkgs/commit/5820115420a388ef79bb156b9738b8c030452d5b) | `` vivaldi: 6.0.2979.22 -> 6.1.3035.111 ``                                             |
| [`c3d60b00`](https://github.com/NixOS/nixpkgs/commit/c3d60b00cee75c60888dd1a05999663427f270fd) | `` php81Packages.psalm: 5.9.0 -> 5.13.1 ``                                             |
| [`29f96cc8`](https://github.com/NixOS/nixpkgs/commit/29f96cc801de8e2efd80f76ca80a389f548d3595) | `` vala-lint: unstable-2022-09-15 -> unstable-2023-05-25 ``                            |
| [`35209747`](https://github.com/NixOS/nixpkgs/commit/35209747ccd58dd2e1a751b958f7703164c212b7) | `` python310Packages.zigpy-znp: 0.11.2 -> 0.11.3 ``                                    |
| [`9249df1f`](https://github.com/NixOS/nixpkgs/commit/9249df1ff0bdcf708a34a97ee36e84b8bdeb2e42) | `` python310Packages.timetagger: 23.6.1 -> 23.7.1 ``                                   |
| [`1ac5b46e`](https://github.com/NixOS/nixpkgs/commit/1ac5b46eff61c1d93a9dee4427db95d01b2ad2ff) | `` neo-cowsay: 2.0.1 -> 2.0.4 ``                                                       |
| [`79567351`](https://github.com/NixOS/nixpkgs/commit/79567351195e4c9136cb39d6bcfbe4e61ef72478) | `` kubefirst: 2.2.0 -> 2.2.2 ``                                                        |
| [`267caf59`](https://github.com/NixOS/nixpkgs/commit/267caf599d053d859e0290d588b617fe407b2cff) | `` kubepug: 1.4.0 -> 1.5.0 ``                                                          |
| [`f91df581`](https://github.com/NixOS/nixpkgs/commit/f91df581608f5f33e7ef4c6831348dcf2a6a539c) | `` psi-plus: 1.5.1646 -> 1.5.1650 ``                                                   |
| [`51c6a069`](https://github.com/NixOS/nixpkgs/commit/51c6a06979391c685e8e605ea364f7d053e1acb4) | `` iwd: 2.6 -> 2.7 ``                                                                  |
| [`ccfa7487`](https://github.com/NixOS/nixpkgs/commit/ccfa748760553f1734ea027474fcb32eb6f1404f) | `` kubeshark: 41.1 -> 41.3 ``                                                          |
| [`28c1cede`](https://github.com/NixOS/nixpkgs/commit/28c1cede03e63a16e3ad45823e0db0bddc167f4f) | `` threatest: 1.2.0 -> 1.2.1 ``                                                        |
| [`54252e95`](https://github.com/NixOS/nixpkgs/commit/54252e95cd9d8da905b5dd9849e670a4265aed9d) | `` labctl: 0.0.20 -> 0.0.22 ``                                                         |
| [`d6a0a466`](https://github.com/NixOS/nixpkgs/commit/d6a0a4662788044a4e6f0933f56aad04b5f6074e) | `` lux: 0.18.0 -> 0.19.0 ``                                                            |
| [`cb34ad4c`](https://github.com/NixOS/nixpkgs/commit/cb34ad4c161f33d95888a91e9ccdb0096e63e516) | `` fuse-archive: init at 0.1.14 ``                                                     |
| [`6cd4468d`](https://github.com/NixOS/nixpkgs/commit/6cd4468d96ad049ab2fbc67312ea84dee6799180) | `` texlive: use lib.recursiveUpdate for tlpdb overrides (#242118) ``                   |
| [`19c40caf`](https://github.com/NixOS/nixpkgs/commit/19c40caf2c4743d48c28fb413af6422cfb4de4a9) | `` cargo-espflash: 1.7.0 -> 2.0.0 (#242381) ``                                         |
| [`77777777`](https://github.com/NixOS/nixpkgs/commit/77777777dc42299b7efdf4be48e50978b938bd0d) | `` pypy3Packages.skia-pathops: mark broken, update homepage ``                         |
| [`33333335`](https://github.com/NixOS/nixpkgs/commit/33333335763f3109950ef0d9f009b8308f59bd7c) | `` matrix-synapse: limit parallelism to 4 cores to be improve stability, formatting `` |
| [`a6af9565`](https://github.com/NixOS/nixpkgs/commit/a6af956520903fdbb764dfd8b8c5a4a6188e23c0) | `` iina: fix 1.3.2 hash mismatch and add passthru.updateScript ``                      |
| [`a99c630c`](https://github.com/NixOS/nixpkgs/commit/a99c630c27626d5a15ef11634d1999af63a3bdb4) | `` nut: build with libusb 1.0 ``                                                       |
| [`eef54766`](https://github.com/NixOS/nixpkgs/commit/eef5476659f1a4990e892122fcd9aa4e6157328f) | `` nut: add support for SNMP and CGI ``                                                |
| [`552efeba`](https://github.com/NixOS/nixpkgs/commit/552efeba59d5e7b75046161a91679d273eda1e8a) | `` nut: actually update to 2.8.0 ``                                                    |
| [`0000010b`](https://github.com/NixOS/nixpkgs/commit/0000010be9d79d75de0bb742d2a2d0f31152043b) | `` wander: 0.9.0 -> 0.10.1 ``                                                          |
| [`ac19ddee`](https://github.com/NixOS/nixpkgs/commit/ac19ddeefb10253701dfa5dfafc80d0af836527a) | `` python310Packages.pyipp: 0.14.1 -> 0.14.2 ``                                        |
| [`7d114338`](https://github.com/NixOS/nixpkgs/commit/7d11433876f37d30e8cbf0748ac8a249c68c858b) | `` botan: split dev ``                                                                 |
| [`0e4e1588`](https://github.com/NixOS/nixpkgs/commit/0e4e158866864d08f85be5a7197676e431671666) | `` raycast: 1.54.1 -> 1.55.1 ``                                                        |
| [`1dca2bd4`](https://github.com/NixOS/nixpkgs/commit/1dca2bd42727b1400952609e392686141c65b28e) | `` python311Packages.rns: 0.5.5 -> 0.5.6 ``                                            |
| [`727c1725`](https://github.com/NixOS/nixpkgs/commit/727c172591002f53625c0b54d4eda6a0a56b1654) | `` rc-9front: enable parallel builds ``                                                |
| [`5f97e78c`](https://github.com/NixOS/nixpkgs/commit/5f97e78c64c672361cb18b67c1383363274d7521) | `` pam_dp9ik: init at 1.5 ``                                                           |
| [`17b5dc87`](https://github.com/NixOS/nixpkgs/commit/17b5dc87059840742cbdd60b259f2201b8ba3020) | `` tlsclient: init at 1.5 ``                                                           |
| [`19e8e87b`](https://github.com/NixOS/nixpkgs/commit/19e8e87be08d8cbee9167786a8767a746bf64d4b) | `` mpd-discord-rpc: 1.7.0 -> 1.7.1 ``                                                  |
| [`f35c48d9`](https://github.com/NixOS/nixpkgs/commit/f35c48d921b88df142958b332f7e27e5bde3ba46) | `` cargo-crev: 0.24.2 -> 0.24.3 ``                                                     |
| [`7f86c125`](https://github.com/NixOS/nixpkgs/commit/7f86c125e69d7df9db27b9bc4dde330cf3631427) | `` showmethekey: 1.8.0 -> 1.8.1 ``                                                     |
| [`aca01299`](https://github.com/NixOS/nixpkgs/commit/aca01299e9410ef6bf3b958902bd004a20c38b72) | `` nwg-dock: 0.3.4 -> 0.3.5 ``                                                         |
| [`d4ade4dd`](https://github.com/NixOS/nixpkgs/commit/d4ade4dde8ecb7f459ba51355c9e5db667c8bf54) | `` kics: 1.7.2 -> 1.7.3 ``                                                             |
| [`b5e04f0b`](https://github.com/NixOS/nixpkgs/commit/b5e04f0bc7dd8dc1f0db335e4288895e080c3b60) | `` kallisto: 0.48.0 -> 0.50.0 ``                                                       |
| [`efb1fc70`](https://github.com/NixOS/nixpkgs/commit/efb1fc7025d7079e26628332360a7976322ca2bb) | `` ddosify: 1.0.3 -> 1.0.4 ``                                                          |
| [`c67c8dbc`](https://github.com/NixOS/nixpkgs/commit/c67c8dbc5ae4a74af6c40dda9d3b3d7b8b54f80d) | `` ddnet: 17.1 -> 17.1.1 ``                                                            |
| [`1701fdcf`](https://github.com/NixOS/nixpkgs/commit/1701fdcfbc3baa1a2b0b9d4981acb79a43df0d00) | `` sqlcmd: 1.1.0 -> 1.2.0 ``                                                           |
| [`dd93b8a0`](https://github.com/NixOS/nixpkgs/commit/dd93b8a0cab90ed1d0ef36b494e058896a6dbfdb) | `` linuxPackages_latest.prl-tools: 18.3.1-53614 -> 18.3.2-53621 ``                     |
| [`bc36fadf`](https://github.com/NixOS/nixpkgs/commit/bc36fadf84703d25b1f28b82baaedf8d4e3abb21) | `` python310Packages.ansible-runner: 2.3.1 -> 2.3.3 ``                                 |
| [`d4538789`](https://github.com/NixOS/nixpkgs/commit/d45387899136ccb498be4bf5e414c1dc75e5cd57) | `` python39Packages.ansible-core: add importlib-resources to python 3.9 build ``       |
| [`6216aa01`](https://github.com/NixOS/nixpkgs/commit/6216aa01f30090be4552374453563ed2061cfbd7) | `` argocd: 2.7.6 -> 2.7.7 ``                                                           |
| [`d638a393`](https://github.com/NixOS/nixpkgs/commit/d638a3934bd56c7a1143963e430bae64e5142c0d) | `` pineapple-pictures: 0.7.0 -> 0.7.1 ``                                               |
| [`a112a598`](https://github.com/NixOS/nixpkgs/commit/a112a598a3cd0dd65399486287201705c2ee16c0) | `` kube-score: add version test ``                                                     |
| [`b9fb0b5d`](https://github.com/NixOS/nixpkgs/commit/b9fb0b5d60be3fa46b391c1f29940aed18ba0b4b) | `` kube-score: fix version ``                                                          |
| [`2d69c0df`](https://github.com/NixOS/nixpkgs/commit/2d69c0df8f6fb760e75192beb4c58433f8855e3f) | `` lineselect: 0.1.3 -> 0.1.6 ``                                                       |
| [`87a22b18`](https://github.com/NixOS/nixpkgs/commit/87a22b1807c39c53b56368a6775c710db810ebbd) | `` python310Packages.google-cloud-compute: 1.12.0 -> 1.12.1 ``                         |
| [`e82a7d86`](https://github.com/NixOS/nixpkgs/commit/e82a7d86f393224511fd8bc0742e732274a921ea) | `` ode: 0.16.3 -> 0.16.4 ``                                                            |
| [`33c64b52`](https://github.com/NixOS/nixpkgs/commit/33c64b520ad0d5233165e0190ecb77b972fe811b) | `` lapce: use upstream .desktop file ``                                                |
| [`0675fa07`](https://github.com/NixOS/nixpkgs/commit/0675fa07701a2ba3123d529ba14beea511ac6d0b) | `` python310Packages.vallox-websocket-api: 3.2.1 -> 3.3.0 ``                           |
| [`65219ede`](https://github.com/NixOS/nixpkgs/commit/65219ede1c7bf12c229ad2f38c42960d1ce8bc87) | `` python311Packages.google-auth: 2.19.1 -> 2.21.0 ``                                  |
| [`8859693c`](https://github.com/NixOS/nixpkgs/commit/8859693cf49ccec545650ef318c1ad6227041ba0) | `` timg: 1.4.5 -> 1.5.0 ``                                                             |
| [`2d4dd7c4`](https://github.com/NixOS/nixpkgs/commit/2d4dd7c4f889367dd254a9ed83985464bb15f07f) | `` libmediainfo: add changelog to meta ``                                              |
| [`32c71104`](https://github.com/NixOS/nixpkgs/commit/32c711043ea9b14fd4e9094ffdbd5124956ba420) | `` libmediainfo: 23.04 -> 23.06 ``                                                     |
| [`edb06020`](https://github.com/NixOS/nixpkgs/commit/edb060209ac72de4257cc95b466172baebd75ae2) | `` catnip-gtk4: init at unstable-2023-06-17 ``                                         |
| [`3cbfddbc`](https://github.com/NixOS/nixpkgs/commit/3cbfddbc692b14bf238d14723f13e22b355d3a88) | `` k8sgpt: 0.3.8 -> 0.3.9 ``                                                           |
| [`79ceb03e`](https://github.com/NixOS/nixpkgs/commit/79ceb03e0316d69eeb19833f994f0a5f678a7a59) | `` vencord: 1.2.8 -> 1.3.4 ``                                                          |
| [`7d630c5c`](https://github.com/NixOS/nixpkgs/commit/7d630c5c6b029dbde2f538d3c947d6c3730a63b5) | `` latex2html: 2023 -> 2023.2 ``                                                       |
| [`6bf00092`](https://github.com/NixOS/nixpkgs/commit/6bf000927a82623251e430dac23723a2ee6c5afa) | `` vimPlugins.cmp-rg: remove ripgrep from dependencies ``                              |
| [`f1e10e2c`](https://github.com/NixOS/nixpkgs/commit/f1e10e2cd0ab9dbc1138971f9534b1c569dbfdb9) | `` vimPlugins.cmp-pandoc-nvim: remove pandoc from dependencies ``                      |
| [`90d05786`](https://github.com/NixOS/nixpkgs/commit/90d05786232c444c1bf6be48146b82078be16b36) | `` vimPlugins.cmp-npm: remove nodejs from dependencies ``                              |
| [`71d08c7a`](https://github.com/NixOS/nixpkgs/commit/71d08c7af6c9dc483f451aadf4204c725e33d4ed) | `` vimPlugins.cmp-git: remove curl and git from dependencies ``                        |
| [`485762b3`](https://github.com/NixOS/nixpkgs/commit/485762b3f1da8e20d52bb9a5019938cf36c6228d) | `` vimPlugins.cmp-fish: remove fish from dependencies ``                               |
| [`6975e32f`](https://github.com/NixOS/nixpkgs/commit/6975e32fc40f0a44dbc337795cf0ff69a0780899) | `` .github/labeler.yml: Add module system label ``                                     |
| [`8dea8eee`](https://github.com/NixOS/nixpkgs/commit/8dea8eeed97cc2dee5b48056917f677935e80c7f) | `` virter: init at 0.25.0 ``                                                           |
| [`6ac252c0`](https://github.com/NixOS/nixpkgs/commit/6ac252c041f6cb38d7ad9f93a2714db09d20f04c) | `` .github/labeler.yml: Add lib label ``                                               |
| [`6acad9dd`](https://github.com/NixOS/nixpkgs/commit/6acad9dd01cfd85263298e38ce4d9dd1fbb9f728) | `` prometheus-lnd-exporter: unstable-2021-03-26 -> 0.2.7 ``                            |
| [`04a952d3`](https://github.com/NixOS/nixpkgs/commit/04a952d36293c6988d57cc356d5b1f14566f999d) | `` prometheus-rabbitmq-exporter: 1.0.0-RC8 -> 1.0.0-RC19 ``                            |
| [`d0b989dd`](https://github.com/NixOS/nixpkgs/commit/d0b989dd16b837f2a44b97df0d2e41fa6d007a45) | `` go-license-detector: 4.3.0 -> 4.3.1 ``                                              |
| [`6666666f`](https://github.com/NixOS/nixpkgs/commit/6666666f37d071158547241d8bfccc5ee5a6358e) | `` python3Packages.validictory: remove ``                                              |
| [`555555d0`](https://github.com/NixOS/nixpkgs/commit/555555d0dd7ff4927b88b0be7cff20c10278bf55) | `` python3Packages.py-radix: remove ``                                                 |
| [`fdf0c98f`](https://github.com/NixOS/nixpkgs/commit/fdf0c98ff44782c16c0eff45d58d2fdde50dc50e) | `` nixos-rebuild: make --use-substitutes work with flakes ``                           |
| [`67e41201`](https://github.com/NixOS/nixpkgs/commit/67e412012d182f994cb63d7551c882bfb278bc0b) | `` github-commenter: 0.9.0 -> 0.19.0 ``                                                |
| [`a79e7890`](https://github.com/NixOS/nixpkgs/commit/a79e78905d88c5c80db99159b16554b36aa03633) | `` betterbird: 102.8.0-bb30 -> 102.12.0-bb37 ``                                        |
| [`5b77f8a2`](https://github.com/NixOS/nixpkgs/commit/5b77f8a209a40a55f192072f5e8e097b32c81462) | `` robustirc-bridge: 1.8 -> 1.9.0 ``                                                   |
| [`7b337580`](https://github.com/NixOS/nixpkgs/commit/7b337580a3e56dfb7cfde8fe8cc31e2e71cc74eb) | `` pypy3Packages.sphinx: disable broken tests ``                                       |
| [`28216d7d`](https://github.com/NixOS/nixpkgs/commit/28216d7debb565a85bb308a34081b1bf4b691d5d) | `` python311Packages.nose3: disable tests also on python 3.11 ``                       |
| [`0000006f`](https://github.com/NixOS/nixpkgs/commit/0000006fe82e889af95a716d02702866968187f1) | `` python310Packages.matplotlib: disable tkinter for PyPy ``                           |
| [`9269d582`](https://github.com/NixOS/nixpkgs/commit/9269d5823d1b8ef09d2fe042d34716b294f6bcd2) | `` tlaplus18: init at 1.8.0 ``                                                         |
| [`831a625b`](https://github.com/NixOS/nixpkgs/commit/831a625b9542b3d26eb387c4d78732d80dae2e29) | `` python310Packages.requests-unixsocket: patch to make compatible with urllib3 2+ ``  |
| [`c4939290`](https://github.com/NixOS/nixpkgs/commit/c493929058118b0b28dbccfc059f45782383121d) | `` opustags: 1.8.0 -> 1.9.0 ``                                                         |
| [`d64e1f0b`](https://github.com/NixOS/nixpkgs/commit/d64e1f0b405bee479b191cdde71ddfdce2c4387d) | `` nixos/ceph: add options to configure package used by each component ``              |
| [`e1fedfdf`](https://github.com/NixOS/nixpkgs/commit/e1fedfdf455e381d2657c84fe4ea41478d5a5479) | `` nixos/ceph: run statix fix ``                                                       |
| [`a7fc0b6e`](https://github.com/NixOS/nixpkgs/commit/a7fc0b6e7016aa62c8a1e1f038d28d4b33f96e5c) | `` mod_tile: testing enabled ``                                                        |
| [`e6bbace6`](https://github.com/NixOS/nixpkgs/commit/e6bbace6236aa6b3cda1df667b19d7d1ec2e18b0) | `` eventstore: add meta.mainProgram ``                                                 |
| [`6ccf7944`](https://github.com/NixOS/nixpkgs/commit/6ccf7944210698b57371819148c4fbc64f9188e1) | `` Cardinal: 22.12 -> 23.02 ``                                                         |