### PR TITLE
chore(flake/darwin): `83620edf` -> `eb22022b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688999459,
-        "narHash": "sha256-b0rFzeHWXGq2rrx+W93I1Lpb0HFq0T5Pfx7QLVcZ/jE=",
+        "lastModified": 1689116343,
+        "narHash": "sha256-eaYfwQTSEbuB7rs5/W227SbVeDP9cbcoT1TEbnmOgOk=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "83620edf499ba8033ad43d4f5edc50fdf3eeee5f",
+        "rev": "eb22022ba8faeeb7a9be8afe925511b88ad12ca5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
| [`63af129c`](https://github.com/LnL7/nix-darwin/commit/63af129cb56548edf8e620437443f8e8b57864f9) | `` etc: use `.before-nix-darwin` instead of `.orig` `` |
| [`ac9a366a`](https://github.com/LnL7/nix-darwin/commit/ac9a366aed7e0d4cbad304aa97d1a3da70f27fa5) | `` uninstaller: remove `/Applications/Nix Apps` ``     |
| [`cad8954f`](https://github.com/LnL7/nix-darwin/commit/cad8954f75809eda533cfb01dc92de8d32f5332d) | `` etc: fail if we can't add a file ``                 |
| [`4b90ea84`](https://github.com/LnL7/nix-darwin/commit/4b90ea84e4e90aab2bcaec117ceddf83e02d6adf) | `` doc: store a copy of known files ``                 |
| [`78817270`](https://github.com/LnL7/nix-darwin/commit/7881727017b0320ac14e7d253efe027676e7fa10) | `` installer: match flaky installation logic ``        |
| [`22620845`](https://github.com/LnL7/nix-darwin/commit/22620845fee1cc16f4ea639509c50fd989ccc1ce) | `` readme: update with new flaky instructions ``       |
| [`5288a723`](https://github.com/LnL7/nix-darwin/commit/5288a723540fdb25e34364518115e2ef32ed19ad) | `` Allow flaky installation with `darwin-rebuild` ``   |
| [`f70f90c4`](https://github.com/LnL7/nix-darwin/commit/f70f90c42207ede0c3b21b785e2650beeecc161c) | `` flake: add `packages.darwin-{option,rebuild}` ``    |
| [`aeaafcc8`](https://github.com/LnL7/nix-darwin/commit/aeaafcc88a65c6ca18c1b699afbb53e6ff0b5ae2) | `` flake: add `packages.darwin-uninstaller` ``         |