### PR TITLE
chore(flake/darwin): `eb22022b` -> `43ce0868`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689116343,
-        "narHash": "sha256-eaYfwQTSEbuB7rs5/W227SbVeDP9cbcoT1TEbnmOgOk=",
+        "lastModified": 1689163348,
+        "narHash": "sha256-qL3FnBauu3PmYf0OZzv2cKtVyRg4ELVXPQl0AAYqlqs=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "eb22022ba8faeeb7a9be8afe925511b88ad12ca5",
+        "rev": "43ce086813c83184b88f67fc544af2050a3035ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                  |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
| [`8eb09d4d`](https://github.com/LnL7/nix-darwin/commit/8eb09d4d0b3d820934d9871c884e0423bc95ba89) | `` uninstaller: fix removing `/Applications/Nix Apps` `` |