### PR TITLE
chore(flake/nixpkgs): `4a729ce4` -> `f2406198`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689008574,
-        "narHash": "sha256-VFMgyHDiqsGDkRg73alv6OdHJAqhybryWHv77bSCGIw=",
+        "lastModified": 1689098530,
+        "narHash": "sha256-fxc/9f20wRyo/5ydkmZkX/Sh/ULa7RcT8h+cUv8p/44=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4a729ce4b1fe5ec4fffc71c67c96aa5184ebb462",
+        "rev": "f2406198ea0e4e37d4380d0e20336c575b8f8ef9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`a3bd43a6`](https://github.com/NixOS/nixpkgs/commit/a3bd43a6dd8f7f64f6f36438d5b04ed9de33bd27) | `` evcc: 0.118.7 -> 0.118.8 (#242852) ``                                  |
| [`a4f7840e`](https://github.com/NixOS/nixpkgs/commit/a4f7840e1813bc389995083fac2b3bcd0ca6823d) | `` redmine: fix Gemfile ``                                                |
| [`4d8e3794`](https://github.com/NixOS/nixpkgs/commit/4d8e3794dfa2c3e6d8fd5d3718d877ba7c3cc3c2) | `` blesh: 0.3.4 -> 0.4.0-devel3 ``                                        |
| [`477dab6b`](https://github.com/NixOS/nixpkgs/commit/477dab6b5c29299a92fca1d306c4c4e9979149b9) | `` firefox-bin-unwrapped: 115.0.1 -> 115.0.2 ``                           |
| [`cebf20a1`](https://github.com/NixOS/nixpkgs/commit/cebf20a1a161ad2981f1a8768925327ec1b19e3d) | `` firefox-unwrapped: 115.0esr -> 115.0.2esr ``                           |
| [`4bf04dcd`](https://github.com/NixOS/nixpkgs/commit/4bf04dcdbd061e2257793a77ef41134c2a0f3ac8) | `` firefox-unwrapped: 115.0.1 -> 115.0.2 ``                               |
| [`4a1fb162`](https://github.com/NixOS/nixpkgs/commit/4a1fb16290799c5d9acf2a677f71b36c54330e66) | `` ani-cli: 4.4 -> 4.5 ``                                                 |
| [`5bb032cb`](https://github.com/NixOS/nixpkgs/commit/5bb032cb23965aa6bb05d2e8327a71eb7fca0251) | `` goose: 3.13.0 -> 3.13.4 (#242848) ``                                   |
| [`53c66b42`](https://github.com/NixOS/nixpkgs/commit/53c66b42c5714f97125e9fe670c91151ab5193ee) | `` vimPlugins.nvim-coverage: 2023-07-09 -> 2023-05-26 ``                  |
| [`170b6714`](https://github.com/NixOS/nixpkgs/commit/170b6714ad98897c95ba26b58e1e693e1274a903) | `` poppler: 23.02.0 → 23.07.0 ``                                          |
| [`578b8eac`](https://github.com/NixOS/nixpkgs/commit/578b8eac37b13862a8273fce97c4b68d4ed2fb08) | `` game-devices-udev-rules: 0.21 -> 0.22 ``                               |
| [`d5cf1aad`](https://github.com/NixOS/nixpkgs/commit/d5cf1aadb431e05bcec58f96d23b9344b5da5c7c) | `` vrc-get: init at 1.1.1 (#234279) ``                                    |
| [`9cf6fd89`](https://github.com/NixOS/nixpkgs/commit/9cf6fd89654cf1a0a4fecb6ce62904923165759d) | `` grub2; unstable-2023-07-03 -> 2.12-rc1 ``                              |
| [`8227a956`](https://github.com/NixOS/nixpkgs/commit/8227a956a90f0f4b81c60ef78c9f1499585e75da) | `` fvwm3: 1.0.6a -> 1.0.7 ``                                              |
| [`8a14c954`](https://github.com/NixOS/nixpkgs/commit/8a14c95463bd1ec6a3b3232d3e3c7dea46c42cb0) | `` fn-cli: 0.6.25 -> 0.6.26 ``                                            |
| [`29bc7675`](https://github.com/NixOS/nixpkgs/commit/29bc76758f81f6999377f20380f22ce9ff559983) | `` sish: 2.8.1 -> 2.9.2 ``                                                |
| [`b20da498`](https://github.com/NixOS/nixpkgs/commit/b20da498a62fc1fd0c3aa63cd9c3237b94f56f4e) | `` redli: 0.7.0 -> 0.9.0 ``                                               |
| [`94cd157e`](https://github.com/NixOS/nixpkgs/commit/94cd157e28d800c46b1c55b2a3e9e3d0737e0990) | `` faas-cli: 0.16.11 -> 0.16.12 ``                                        |
| [`861aa4a1`](https://github.com/NixOS/nixpkgs/commit/861aa4a1f1229f8bc82d04870cc4a270a5b7f6d3) | `` earthly: 0.7.10 -> 0.7.11 ``                                           |
| [`ef59ce64`](https://github.com/NixOS/nixpkgs/commit/ef59ce6401f102d29b15555b1d4e48bde4ff8b8e) | `` sile: 0.14.9 → 0.14.10 ``                                              |
| [`beccfc84`](https://github.com/NixOS/nixpkgs/commit/beccfc847b7959009450483cac132729f7eb4e36) | `` gotrue-supabase: 2.78.0 -> 2.82.2 ``                                   |
| [`8014460c`](https://github.com/NixOS/nixpkgs/commit/8014460c4dbf26d6f962c01920b2c25fc00e0d03) | `` lib.mergeModules: Add context to error message ``                      |
| [`8f700580`](https://github.com/NixOS/nixpkgs/commit/8f700580b984290adefa4b32ce1abafda04af6cf) | `` lib/modules.nix: Format ``                                             |
| [`c9e19143`](https://github.com/NixOS/nixpkgs/commit/c9e191434b5918319ddc7cc7641d876d275afebe) | `` shairport-sync: fix cross compilation ``                               |
| [`94b55ad8`](https://github.com/NixOS/nixpkgs/commit/94b55ad8593af823efa8e04995f6cba72acf9c3e) | `` epubcheck: 5.0.1 -> 5.1.0 ``                                           |
| [`b04d2fc9`](https://github.com/NixOS/nixpkgs/commit/b04d2fc96b8ef5d975ba74937337aaeddc3da550) | `` desync: 0.9.4 -> 0.9.5 ``                                              |
| [`4dd51a9a`](https://github.com/NixOS/nixpkgs/commit/4dd51a9acec772931976d325c7021b7156c13335) | `` lib/modules.nix: Inline single-use `subtree` bindings ``               |
| [`68dd30b7`](https://github.com/NixOS/nixpkgs/commit/68dd30b73feb05dc168a6e2b0b88c41c6eaa8bfb) | `` eksctl: 0.147.0 -> 0.148.0 ``                                          |
| [`6acc3114`](https://github.com/NixOS/nixpkgs/commit/6acc3114c30564d112c2c83836c9eb0685165d9a) | `` lib/modules.nix: Make entire definition list strict in config check `` |
| [`c28dd7d9`](https://github.com/NixOS/nixpkgs/commit/c28dd7d9210731257775e8bd8722e27eb260c00e) | `` lib/modules.nix: Rename defnsByName -> pushedDownDefinitionsByName ``  |
| [`448b153f`](https://github.com/NixOS/nixpkgs/commit/448b153f819c1fc43db5954ee9788f6f51b93b27) | `` lib/modules.nix: Rename defnsByName' -> rawDefinitionsByName ``        |
| [`fb988c61`](https://github.com/NixOS/nixpkgs/commit/fb988c6193788f57ab4d53d8cbc8c014e88952ae) | `` lib/modules.nix: Apply argument `module` of old f ``                   |
| [`eb410eab`](https://github.com/NixOS/nixpkgs/commit/eb410eab821b013017196cc39a401c030051937c) | `` lib/modules.nix: Apply argument `modules` of old old old byName ``     |
| [`65de1821`](https://github.com/NixOS/nixpkgs/commit/65de18210d67a513ffd90d17b91738b597476f7a) | `` lib/modules.nix: Apply argument `f` of old old byName ``               |
| [`c70a5e92`](https://github.com/NixOS/nixpkgs/commit/c70a5e922322f081c6cfb249a6cf4fbf291e53ee) | `` lib/modules.nix: Apply argument `attr` of old byName ``                |
| [`3f1c1883`](https://github.com/NixOS/nixpkgs/commit/3f1c188330f8f7f8cf7c4876ac0cd4d6cb14982e) | `` antidote: 1.8.9 -> 1.9.0 ``                                            |
| [`f76f2d5b`](https://github.com/NixOS/nixpkgs/commit/f76f2d5b9b19be642eb2f8f37cc8e6c44987bf32) | `` obs-studio-plugins.waveform: init at 1.7.0 ``                          |
| [`b2bbed2f`](https://github.com/NixOS/nixpkgs/commit/b2bbed2f792ce2ca82bffd4ab0c111b792d22fb2) | `` ns-3: v35 -> v39 ``                                                    |
| [`d1e18a36`](https://github.com/NixOS/nixpkgs/commit/d1e18a369a6c89d150a503c599d11674fa18a581) | `` lib/modules.nix: Inline byName ``                                      |
| [`6c3c21ea`](https://github.com/NixOS/nixpkgs/commit/6c3c21eaa8b84ba582ef45bc457bcd2bb5b2e503) | `` vscode-extensions.mgt19937.typst-preview: init at 0.6.0 ``             |
| [`4ac37707`](https://github.com/NixOS/nixpkgs/commit/4ac377076f426b637fd2734841daf4028b67e435) | `` flowblade: 2.10.0.3 -> 2.10.0.4 ``                                     |
| [`6d2e7cb9`](https://github.com/NixOS/nixpkgs/commit/6d2e7cb9d9754979cfc97f6fa5d4b07f4cb36216) | `` act: 0.2.46 -> 0.2.48 ``                                               |
| [`35881fdd`](https://github.com/NixOS/nixpkgs/commit/35881fdd9de7c0a4c33c462ab2d4a6896546944a) | `` obs-tuna: init at 1.9.6 ``                                             |
| [`34b396fe`](https://github.com/NixOS/nixpkgs/commit/34b396feef90b1930decab6ae08cb213d14a8100) | `` maintainers: add shortcord ``                                          |
| [`a0ace46e`](https://github.com/NixOS/nixpkgs/commit/a0ace46ec0825338c10eeaa6566506a5e0c53620) | `` karmor: 0.13.7 -> 0.13.11 ``                                           |
| [`bf852a38`](https://github.com/NixOS/nixpkgs/commit/bf852a38e6a7eb52da2d50775191cb8f3f9212f1) | `` python310Packages.hydrus-api: 5.0.0 -> 5.0.1 ``                        |
| [`80f1bea8`](https://github.com/NixOS/nixpkgs/commit/80f1bea8bc6c5bd98489cf1fd9af3b0795de63e1) | `` linux: 6.4.2 -> 6.4.3 ``                                               |
| [`4ccdd2d0`](https://github.com/NixOS/nixpkgs/commit/4ccdd2d01731c792f70f580a20f04ccf00fbf2e5) | `` python3Packages.experiment-utilities: init at 0.3.3 ``                 |
| [`9a762384`](https://github.com/NixOS/nixpkgs/commit/9a7623847e972a2c839126d1d04eeba6b5fbc42a) | `` python3Packages.qgrid: init at 1.3.1 ``                                |
| [`cf6c1fb1`](https://github.com/NixOS/nixpkgs/commit/cf6c1fb1852b225b64f01f118813e50cda7d2158) | `` dagger: 0.6.2 -> 0.6.3 ``                                              |
| [`68c5d276`](https://github.com/NixOS/nixpkgs/commit/68c5d276f1254ec5827f2118b12016f289841847) | `` cbmc: 5.86.0 -> 5.87.0 ``                                              |
| [`547a7502`](https://github.com/NixOS/nixpkgs/commit/547a750222e2dc5a07a3d085dc5a165b7b44cdd8) | `` terraform-providers.tencentcloud: 1.81.12 -> 1.81.13 ``                |
| [`e1ff0c46`](https://github.com/NixOS/nixpkgs/commit/e1ff0c46fea02c438a2453977d6554bcbecbf747) | `` terraform-providers.ibm: 1.54.0 -> 1.55.0 ``                           |
| [`f1bcb173`](https://github.com/NixOS/nixpkgs/commit/f1bcb173b6e1ed901e0eaba54bf46c8670f3a853) | `` terraform-providers.google-beta: 4.72.1 -> 4.73.0 ``                   |
| [`c385a816`](https://github.com/NixOS/nixpkgs/commit/c385a8168d97a47b4c027c1fcd02c79132d69db4) | `` terraform-providers.google: 4.72.1 -> 4.73.0 ``                        |
| [`f8cbb456`](https://github.com/NixOS/nixpkgs/commit/f8cbb4568e1c5c2cf5e84b5958271224da86d90c) | `` thermald: 2.5.2 -> 2.5.3 ``                                            |
| [`ab5d13ef`](https://github.com/NixOS/nixpkgs/commit/ab5d13ef49d0819ed35b80e582cbf7cd0be45e06) | `` iosevka-bin: 25.0.0 -> 25.0.1 ``                                       |
| [`727f936b`](https://github.com/NixOS/nixpkgs/commit/727f936b840267f14d6ba6e43653aba4ee383f9a) | `` ast-grep: 0.7.2 -> 0.8.0 ``                                            |
| [`f6929215`](https://github.com/NixOS/nixpkgs/commit/f6929215e1e411dbb6cbf214ca29917560e2be13) | `` ast-grep: 0.6.6 -> 0.7.2 ``                                            |
| [`8742e41f`](https://github.com/NixOS/nixpkgs/commit/8742e41f50277a7353c0ab5b93bf01d42a97f39f) | `` python310Packages.robomachine: fix build ``                            |
| [`834ed320`](https://github.com/NixOS/nixpkgs/commit/834ed32062fddd7bb1d85e883458a9d54093ee26) | `` python310Packages.allpairspy: add changelog to meta ``                 |
| [`03848975`](https://github.com/NixOS/nixpkgs/commit/03848975178ba9fe61ad2e5b62a63f0cb581479f) | `` python310Packages.allpairspy: use pyproject format ``                  |
| [`8d0f2453`](https://github.com/NixOS/nixpkgs/commit/8d0f24539192c22a86ab58b2e2603a2aeb28eaa8) | `` dyff: 1.5.7 -> 1.5.8 ``                                                |
| [`a187ec43`](https://github.com/NixOS/nixpkgs/commit/a187ec43efbeec0f3be6f9d13a6836fcbb914a9d) | `` nodePackages: update to latest ``                                      |
| [`ab78ab62`](https://github.com/NixOS/nixpkgs/commit/ab78ab62131d1bf22f3eb1519d97568bf5bab1a9) | `` b3sum: 1.4.0 -> 1.4.1 ``                                               |
| [`7725bae4`](https://github.com/NixOS/nixpkgs/commit/7725bae47790df188298189b6d4a35a636e6e4d6) | `` python310Packages.langchain: 0.0.220 -> 0.0.229 ``                     |
| [`9c642f9a`](https://github.com/NixOS/nixpkgs/commit/9c642f9a682d1a0e11f58f869d650fd5fda035df) | `` python310Packages.langchainplus-sdk: 0.0.17 -> 0.0.20 ``               |
| [`abbb7ed8`](https://github.com/NixOS/nixpkgs/commit/abbb7ed8dc2d2ab36c4de290b19e90852440f71a) | `` python310Packages.pycookiecheat: fix darwin ``                         |
| [`a5b7dcfd`](https://github.com/NixOS/nixpkgs/commit/a5b7dcfd2ccb9e8bffd24add225b6883d55cd135) | `` ryujinx: 1.1.952 -> 1.1.958 ``                                         |
| [`1473a98d`](https://github.com/NixOS/nixpkgs/commit/1473a98df47445b7f2f614183193c2e6496b6731) | `` v2ray-domain-list-community: 20230627034247 -> 20230707041058 ``       |
| [`d48573ec`](https://github.com/NixOS/nixpkgs/commit/d48573ec1f67b644a4b1d9b0247840045e23dc49) | `` gedit: fix cross compilation ``                                        |
| [`9f35ab95`](https://github.com/NixOS/nixpkgs/commit/9f35ab953bc2be03373de3ff08cf629317446f64) | `` python310Packages.imgaug: remove ``                                    |
| [`49b8dbf0`](https://github.com/NixOS/nixpkgs/commit/49b8dbf0e6f654a4182fcda54cb888d1579ed599) | `` python310Packages.mask-rcnn: remove ``                                 |
| [`4c2141f9`](https://github.com/NixOS/nixpkgs/commit/4c2141f91aed4e3ecc5b18d08e2c3270f2c123c1) | `` sqlx-cli: 0.6.2 -> 0.7.0 ``                                            |
| [`233a8f00`](https://github.com/NixOS/nixpkgs/commit/233a8f00a3d01f56b88ee5653aa781a0077092ce) | `` sqlx-cli: add xrelkd as maintainer ``                                  |
| [`b5daa1cc`](https://github.com/NixOS/nixpkgs/commit/b5daa1cc8dc43783c2d92d99eec2684f012ec6c7) | `` pantheon.elementary-files: 6.4.0 -> 6.4.1 ``                           |
| [`66fb236f`](https://github.com/NixOS/nixpkgs/commit/66fb236fabd92e463fc24744058da81790f76ba6) | `` jove: 4.17.4.9 -> 4.17.5.3 ``                                          |
| [`f152e6f8`](https://github.com/NixOS/nixpkgs/commit/f152e6f861baf093bc27b48ca924b7b95b1e9fcf) | `` sakura: 3.8.5 -> 3.8.7 ``                                              |
| [`deb25e39`](https://github.com/NixOS/nixpkgs/commit/deb25e39fa9c5842e06f5f741b2e371bc263c575) | `` librewolf-unwrapped: 115.0-1 -> 115.0.1-1 ``                           |
| [`4e2f40d6`](https://github.com/NixOS/nixpkgs/commit/4e2f40d64e57e8bd9d5d8e85cf54c663b031661e) | `` python310Packages.mlflow: 2.4.1 -> 2.4.2 ``                            |
| [`529285f6`](https://github.com/NixOS/nixpkgs/commit/529285f6718eb549e13414180f29a8176e4f96d9) | `` fastgron: 0.6.3 -> 0.6.4 ``                                            |
| [`2cc4331f`](https://github.com/NixOS/nixpkgs/commit/2cc4331f03642f5c04b3f4e916c1fa439a588ccb) | `` ugrep: 3.12.1 -> 3.12.2 ``                                             |
| [`b2beb5cc`](https://github.com/NixOS/nixpkgs/commit/b2beb5cc272cc398c60612c758eaa3f8552b82ef) | `` xemu: 0.7.96 -> 0.7.97 ``                                              |
| [`995fe666`](https://github.com/NixOS/nixpkgs/commit/995fe666a57fd81f89ef34eef79e934da38bf96c) | `` doomrunner: 1.7.2 -> 1.7.3 ``                                          |
| [`38e60b74`](https://github.com/NixOS/nixpkgs/commit/38e60b74ce84ebcc27c7405f084449a7f0a9cd52) | `` chromiumDev: 116.0.5845.4 -> 116.0.5845.14 ``                          |
| [`0b96527d`](https://github.com/NixOS/nixpkgs/commit/0b96527d9a2d19c5055d8540918f2dce8a1fe9da) | `` wrapGAppsHook4: fix gtk4 for the wrong system ``                       |
| [`ce0bdd56`](https://github.com/NixOS/nixpkgs/commit/ce0bdd56873121c5c4e0ae8e0d91ad4e3256d5e8) | `` python311Packages.nibe: 2.2.0 -> 2.3.0 ``                              |
| [`a876b31e`](https://github.com/NixOS/nixpkgs/commit/a876b31e5a6286d0d74224f865b4f2626c78c0fe) | `` python311Packages.griffe: 0.30.0 -> 0.31.0 ``                          |
| [`6d4d3ccc`](https://github.com/NixOS/nixpkgs/commit/6d4d3ccc2502be4e0b3aab2d9ff67eb257cb969c) | `` checkov: 2.3.312 -> 2.3.318 ``                                         |
| [`5a7603fc`](https://github.com/NixOS/nixpkgs/commit/5a7603fcffec8f7ffde3b9f4fb9869b7285f2ef7) | `` ocamlPackages.tdigest: 2.1.1 -> 2.1.2 ``                               |
| [`2ff236ef`](https://github.com/NixOS/nixpkgs/commit/2ff236efb5e6412c8d51fd3606ea42848933b086) | `` ocamlPackages.tdigest: add passthru.updateScript ``                    |
| [`c6a783d6`](https://github.com/NixOS/nixpkgs/commit/c6a783d6c4cffd15c7a9ed63f31e7124eac125e8) | `` python311Packages.aiomisc: 17.3.2 -> 17.3.4 ``                         |
| [`a53e2257`](https://github.com/NixOS/nixpkgs/commit/a53e2257c2bdb798a5d119f639ac038ab9ff3d07) | `` python311Packages.time-machine: 2.10.0 -> 2.11.0 ``                    |
| [`69b3dc11`](https://github.com/NixOS/nixpkgs/commit/69b3dc11f607e61fb8d9cf1ce65108e20a5edd2f) | `` tgpt: 1.6.12 -> 1.7.0 ``                                               |
| [`65384b45`](https://github.com/NixOS/nixpkgs/commit/65384b45f805d9c89ea6a48abd69f8c31f6af607) | `` python311Packages.sentry-sdk: 1.27.1 -> 1.28.0 ``                      |
| [`2f7bf343`](https://github.com/NixOS/nixpkgs/commit/2f7bf343c386718ba4a710a90282d690f82d843b) | `` python311Packages.rpds-py: 0.8.8 -> 0.8.10 ``                          |
| [`358bfca0`](https://github.com/NixOS/nixpkgs/commit/358bfca06a42cb8117a216cc1a0baaea8eb97bb9) | `` python311Packages.pontos: 23.7.5 -> 23.7.6 ``                          |
| [`d1daf261`](https://github.com/NixOS/nixpkgs/commit/d1daf2612e699dd23e3eb5d7a448b5ae859893fb) | `` python311Packages.meshtastic: 2.1.9 -> 2.1.10 ``                       |
| [`cc4bcc83`](https://github.com/NixOS/nixpkgs/commit/cc4bcc832db99ee63a9e5b852d9c1a1b926849e5) | `` python311Packages.aioesphomeapi: 15.1.3 -> 15.1.4 ``                   |
| [`24f6749d`](https://github.com/NixOS/nixpkgs/commit/24f6749d624a158d7a4d89ed2fdb96bc1c6cba76) | `` numix-icon-theme-square: 23.06.21 -> 23.07.08 ``                       |
| [`64fc7918`](https://github.com/NixOS/nixpkgs/commit/64fc7918243e4785272bf60076ce37c1b77dc09f) | `` python310Packages.pyoverkiz: 1.9.0 -> 1.9.1 ``                         |
| [`ae55861e`](https://github.com/NixOS/nixpkgs/commit/ae55861ec2eb626fa71289156ade12ef5575173b) | `` nixos/tests: add myself to maintainers of erofs test ``                |
| [`0f9bf615`](https://github.com/NixOS/nixpkgs/commit/0f9bf615a485302b55e23cec66913e2ee11b8725) | `` nixos/tests: add squashfs test ``                                      |
| [`3b6bc9b5`](https://github.com/NixOS/nixpkgs/commit/3b6bc9b536dd09c91de596b3028fe6a468372865) | `` nixos/filesystems: init squashfs ``                                    |
| [`d3e87f9e`](https://github.com/NixOS/nixpkgs/commit/d3e87f9e9d75f68831dc9d5d1c2e4ce91a1534e1) | `` python310Packages.pydrive2: 1.16.0 -> 1.16.1 ``                        |
| [`f93ea48c`](https://github.com/NixOS/nixpkgs/commit/f93ea48c582b4608647f4decfc3e2cb4bdf2966f) | `` findimagedupes: drop ``                                                |
| [`4b21d79c`](https://github.com/NixOS/nixpkgs/commit/4b21d79c830da885c465b59ac609dcf299a0d3d1) | `` boxxy: 0.7.2 -> 0.8.0 ``                                               |
| [`0123e9d4`](https://github.com/NixOS/nixpkgs/commit/0123e9d47067ad4306bde9c706b2ec3e8c2ac7e1) | `` taplo: 0.8.0 -> 0.8.1 ``                                               |
| [`4127a265`](https://github.com/NixOS/nixpkgs/commit/4127a265589c0612227380fc2392d975369989f6) | `` python310Packages.total-connect-client: 2023.2 -> 2023.7 ``            |
| [`76a2c098`](https://github.com/NixOS/nixpkgs/commit/76a2c09872b82b0dc2aed3635b4c83cd55ffcbb4) | `` linkerd_edge: 23.6.3 -> 23.7.1 ``                                      |
| [`a9e20ed1`](https://github.com/NixOS/nixpkgs/commit/a9e20ed1e0568ddebc89b01afd93424ea578260d) | `` {nickel,nls}: 1.0.0 -> 1.1.1 ``                                        |
| [`3ff52713`](https://github.com/NixOS/nixpkgs/commit/3ff5271315a29e26f666774b81e888e5f05ad240) | `` typos: 1.15.10 -> 1.16.0 ``                                            |
| [`c86eb69b`](https://github.com/NixOS/nixpkgs/commit/c86eb69b639870622e9f3f11200d1e908d60c6f7) | `` python310Packages.uproot: 5.0.9 -> 5.0.10 ``                           |
| [`7e9c6274`](https://github.com/NixOS/nixpkgs/commit/7e9c6274d69dd41473e37ffeecf126790a02f72f) | `` brave: 1.52.129 -> 1.52.130 ``                                         |
| [`bc13dcae`](https://github.com/NixOS/nixpkgs/commit/bc13dcae857706ac5fb63f4f3109eb7ad5970890) | `` signalbackup-tools: 20230628 -> 20230707 ``                            |
| [`685f2907`](https://github.com/NixOS/nixpkgs/commit/685f290786f872dc11336abe8624368b7ae3f264) | `` yabai: fix hash ``                                                     |
| [`f7817725`](https://github.com/NixOS/nixpkgs/commit/f78177251824680bf23cf348e28d16367568911f) | `` circt: 1.44.0 -> 1.45.0 ``                                             |
| [`099ad1be`](https://github.com/NixOS/nixpkgs/commit/099ad1be50110c2405527554feeb32b64692da15) | `` firefox_decrypt: unstable-2023-05-14 -> unstable-2023-07-06 ``         |
| [`f92063b1`](https://github.com/NixOS/nixpkgs/commit/f92063b129045e37361aba9b111d5b7f8f849791) | `` kodiPackages.chardet: 4.0.0+matrix.1 -> 5.1.0 ``                       |
| [`19a6554e`](https://github.com/NixOS/nixpkgs/commit/19a6554e28dab9015c300a904528a342c8ea6275) | `` xilinx-bootgen: unstable-2019-10-23 -> xilinx_v2023.1 ``               |
| [`daae938f`](https://github.com/NixOS/nixpkgs/commit/daae938fb12eebe9070c0652ef1dc7089051b701) | `` python310Packages.pytest-pudb: init at 0.7.0 ``                        |
| [`db9ff9eb`](https://github.com/NixOS/nixpkgs/commit/db9ff9eb8a5a60b9484e7780684bb0e89c471224) | `` blender: 3.5.1 -> 3.6.0 ``                                             |
| [`de3cc624`](https://github.com/NixOS/nixpkgs/commit/de3cc6244aec1d0c339ffc7f6cdf4c477db6d797) | `` coloquinte: init at version 0.3.1 ``                                   |
| [`e647fd4b`](https://github.com/NixOS/nixpkgs/commit/e647fd4bf4c9bfe284f6b5ae07fac65da6378639) | `` mullvad-closest: init at unstable-2023-07-09 ``                        |
| [`1662bdef`](https://github.com/NixOS/nixpkgs/commit/1662bdeff58b6ac3e28b733430377578615623ee) | `` nitter: unstable-2023-05-19 -> unstable-2023-07-10 ``                  |