### PR TITLE
chore(flake/darwin): `43ce0868` -> `795492c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689163348,
-        "narHash": "sha256-qL3FnBauu3PmYf0OZzv2cKtVyRg4ELVXPQl0AAYqlqs=",
+        "lastModified": 1689178160,
+        "narHash": "sha256-TVR0hn/JWo1qmtvgzqjfNerLPsIxfdFR3hf3QrnEj7U=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "43ce086813c83184b88f67fc544af2050a3035ba",
+        "rev": "795492c9a895762f36f6c1ff43d6e0de66fdffa8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                      |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
| [`c80294ef`](https://github.com/LnL7/nix-darwin/commit/c80294ef26ff5c896534101f8aa8d9f30bd1f3d5) | `` Update modules/services/cachix-agent.nix ``               |
| [`adc6a88f`](https://github.com/LnL7/nix-darwin/commit/adc6a88ff17e55ec6a6522c9a37a2ead26a3ed7a) | `` cachix-agent: clarify what should be in the token file `` |