### PR TITLE
chore(flake/nixpkgs): `f2406198` -> `8acef304`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -327,11 +327,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689098530,
-        "narHash": "sha256-fxc/9f20wRyo/5ydkmZkX/Sh/ULa7RcT8h+cUv8p/44=",
+        "lastModified": 1689444953,
+        "narHash": "sha256-0o56bfb2LC38wrinPdCGLDScd77LVcr7CrH1zK7qvDg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f2406198ea0e4e37d4380d0e20336c575b8f8ef9",
+        "rev": "8acef304efe70152463a6399f73e636bcc363813",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`e16a75d3`](https://github.com/NixOS/nixpkgs/commit/e16a75d3be094fe120724e49b53adf64e684ef2c) | `` redis: use system jemalloc (#243398) ``                                        |
| [`e123d6f4`](https://github.com/NixOS/nixpkgs/commit/e123d6f4c40ba6eb6de6df38a17ca81e849c60d2) | `` spicedb: 1.22.2 -> 1.23.0 ``                                                   |
| [`27406971`](https://github.com/NixOS/nixpkgs/commit/27406971272524c301612b27eb670fe694fbd906) | `` python310Packages.pydeps: 1.12.10 -> 1.12.12 ``                                |
| [`e6c5017b`](https://github.com/NixOS/nixpkgs/commit/e6c5017b25b10668a83998fd693330cc3b952b08) | `` firefox-beta-bin-unwrapped: 116.0b2 -> 116.0b5 ``                              |
| [`ff8d08cc`](https://github.com/NixOS/nixpkgs/commit/ff8d08cc60eb652ef261b180ce3707b2ff5579c5) | `` python310Packages.hcloud: 1.24.0 -> 1.25.0 ``                                  |
| [`22732725`](https://github.com/NixOS/nixpkgs/commit/227327259226b49de7f54dabe89398af28255cce) | `` python310Packages.dm-haiku: 0.0.9 -> 0.0.10 ``                                 |
| [`61bb4823`](https://github.com/NixOS/nixpkgs/commit/61bb4823feedc78539fef19698ab52209f57be54) | `` python310Packages.clize: 5.0.0 -> 5.0.2 ``                                     |
| [`1319cc35`](https://github.com/NixOS/nixpkgs/commit/1319cc3520efd82596415411c15b254f0d22ec82) | `` python310Packages.diff-cover: 7.6.0 -> 7.7.0 ``                                |
| [`fc2f254a`](https://github.com/NixOS/nixpkgs/commit/fc2f254a1bb147e26625fc19f81de9f83f446fdf) | `` terraformer: 0.8.22 -> 0.8.24 ``                                               |
| [`c74628ad`](https://github.com/NixOS/nixpkgs/commit/c74628adfa68c73a3ba79accb5138db6bc24b8b7) | `` opera: 100.0.4815.21 -> 100.0.4815.47 ``                                       |
| [`8eda7130`](https://github.com/NixOS/nixpkgs/commit/8eda713040d71d0b3c19b0dbeb9a21fc2bdb84b6) | `` mmctl: 7.10.3 -> 7.10.4 ``                                                     |
| [`13360954`](https://github.com/NixOS/nixpkgs/commit/133609542150dac01ac0d8ae64e88031873a1e66) | `` amf-headers: 1.4.29 -> 1.4.30 ``                                               |
| [`77daf4da`](https://github.com/NixOS/nixpkgs/commit/77daf4daeebda76aff951006e368c7c2822a858c) | `` conftest: 0.44.0 -> 0.44.1 ``                                                  |
| [`07b4156a`](https://github.com/NixOS/nixpkgs/commit/07b4156af448b846d7b1cbfe3f5bcf34b0a6b5b7) | `` bazel-gazelle: 0.31.1 -> 0.32.0 ``                                             |
| [`14cba544`](https://github.com/NixOS/nixpkgs/commit/14cba54488a0cfd5d40e855588176b96682c34d8) | `` python310Packages.metakernel: 0.29.4 -> 0.29.5 ``                              |
| [`2d3bf200`](https://github.com/NixOS/nixpkgs/commit/2d3bf20086bf1b8d15f60c92f34d6e4b8565f07a) | `` nixos/keyd: add support for multi-file configuration ``                        |
| [`45ad1240`](https://github.com/NixOS/nixpkgs/commit/45ad1240e800b6420105a4cb98fbb7c14e1941fc) | `` lemmy-server: 0.18.1 -> 0.18.2 ``                                              |
| [`ced78b33`](https://github.com/NixOS/nixpkgs/commit/ced78b33391473d6ba97756ea8f50e6498368cd1) | `` lemmy-{server,ui}: Use tag to get latest release for both server and ui ``     |
| [`e989daa6`](https://github.com/NixOS/nixpkgs/commit/e989daa65f2dd9827d56bee6a14a1965471f0597) | `` shadowfox: fix build ``                                                        |
| [`7d804177`](https://github.com/NixOS/nixpkgs/commit/7d80417710a9077b9142b479b02d07200d71d9db) | `` wuzz: unbreak ``                                                               |
| [`1c807356`](https://github.com/NixOS/nixpkgs/commit/1c807356b6c603887be693b4afdbe1e85bef8e27) | `` hubble: unbreak on aarch64-linux ``                                            |
| [`9d4dab5d`](https://github.com/NixOS/nixpkgs/commit/9d4dab5df84d0ee1d973d563415d9bf6de8563bd) | `` doggo: unpin go ``                                                             |
| [`50f20488`](https://github.com/NixOS/nixpkgs/commit/50f2048830d02405244af838abbda1628543fc5b) | `` terraform-providers.postgresql: 1.19.0 -> 1.20.0 ``                            |
| [`ea1a65bd`](https://github.com/NixOS/nixpkgs/commit/ea1a65bd342b59f1aa3ea08f88c9f60691197e2f) | `` terraform-providers.huaweicloud: 1.51.0 -> 1.52.0 ``                           |
| [`77c1ece6`](https://github.com/NixOS/nixpkgs/commit/77c1ece6083693f575e11df9c0ab18b3bc7c6213) | `` terraform-providers.github: 5.30.1 -> 5.31.0 ``                                |
| [`d641aa33`](https://github.com/NixOS/nixpkgs/commit/d641aa3314f243856d0e6242cbcb8ae7dc5031d3) | `` terraform-providers.grafana: 2.0.0 -> 2.1.0 ``                                 |
| [`394a1d26`](https://github.com/NixOS/nixpkgs/commit/394a1d260b4f3103bce4dad0cbe81ac97c94ee46) | `` terraform-providers.cloudfoundry: 0.50.8 -> 0.51.2 ``                          |
| [`c04e9ece`](https://github.com/NixOS/nixpkgs/commit/c04e9ece46e38d5cb5802f3fa3bd955267b58402) | `` terraform-providers.brightbox: 3.4.2 -> 3.4.3 ``                               |
| [`06cb588e`](https://github.com/NixOS/nixpkgs/commit/06cb588ed78d3f3a8dd677d2833d46b3a997673b) | `` terraform-providers.bigip: 1.18.0 -> 1.18.1 ``                                 |
| [`4a8ac857`](https://github.com/NixOS/nixpkgs/commit/4a8ac8577cb8ddfa7db0bb9e5ca5bb8409b597cf) | `` terraform-providers.bitbucket: 2.34.0 -> 2.35.0 ``                             |
| [`ff369049`](https://github.com/NixOS/nixpkgs/commit/ff3690490fadcd46b555407fa4ffadf2bf7d8ac4) | `` alfis: 0.8.3 -> 0.8.4 ``                                                       |
| [`36a0dfc4`](https://github.com/NixOS/nixpkgs/commit/36a0dfc4c502265f4945f0e9dae7c326dd8270f5) | `` python310Packages.pytest-testmon: 2.0.9 -> 2.0.12 ``                           |
| [`adf22d21`](https://github.com/NixOS/nixpkgs/commit/adf22d21c9d428f42f90e66c187e25708bbd519e) | `` fulcrum: pin older rocksdb ``                                                  |
| [`b2051317`](https://github.com/NixOS/nixpkgs/commit/b2051317a88ee1820f44975fee7cf500219c563e) | `` surrealdb: pin older rocksdb ``                                                |
| [`8f47d38a`](https://github.com/NixOS/nixpkgs/commit/8f47d38ac860f39b8c76d65bb21ae7af2f8e025b) | `` rocksdb_7_10: init at 7.10.2 ``                                                |
| [`7dbbfb67`](https://github.com/NixOS/nixpkgs/commit/7dbbfb676434a42a3c48fe3ea413b9f57cd2c6af) | `` rocksdb_lite: remove ``                                                        |
| [`933c4517`](https://github.com/NixOS/nixpkgs/commit/933c4517220c3d816055c57c8825b0bce9f3f897) | `` rocksdb: 7.10.2 -> 8.3.2 ``                                                    |
| [`604c2608`](https://github.com/NixOS/nixpkgs/commit/604c2608b42b2eee7fee70d883e4feaacc8611d1) | `` tuxedo-keyboard: set it as broken for kernel <= 5.4 ``                         |
| [`42be0b1b`](https://github.com/NixOS/nixpkgs/commit/42be0b1bfedbc7f0201fee944174c8844adc31f8) | `` chafa: fixup build with libwebp-1.3.1 ``                                       |
| [`88e87869`](https://github.com/NixOS/nixpkgs/commit/88e87869c0c2b37b1df1441c5fc8d1c76d6486a9) | `` swayimg: patch build with libwebp-1.3.1 ``                                     |
| [`336ba443`](https://github.com/NixOS/nixpkgs/commit/336ba443ef1f4615fd0944f804030a7a0452573b) | `` python310Packages.flake8-bugbear: 23.6.5 -> 23.7.10 ``                         |
| [`3e583687`](https://github.com/NixOS/nixpkgs/commit/3e583687e0ae939b635a09884b42d9d0474af728) | `` python310Packages.dvc-data: 2.3.3 -> 2.5.0 ``                                  |
| [`17157597`](https://github.com/NixOS/nixpkgs/commit/1715759771a737ec8e5275aed25bff6e7920a03e) | `` python310Packages.globus-sdk: 3.22.0 -> 3.23.0 ``                              |
| [`dfd30dea`](https://github.com/NixOS/nixpkgs/commit/dfd30dea6f4a3451ac86a1dcc8e2ad25da23617a) | `` netdata-go-plugins: 0.53.2 -> 0.54.0 ``                                        |
| [`05313029`](https://github.com/NixOS/nixpkgs/commit/053130292caa8bbe9246845bd38a9aa8d012613b) | `` restic-rest-server: 0.12.0 -> 0.12.1 ``                                        |
| [`bbd16e79`](https://github.com/NixOS/nixpkgs/commit/bbd16e798cdb7bb1bfdbae1c293f688813e19de8) | `` python3Packages.dissect-target: disable failing tests ``                       |
| [`162039a2`](https://github.com/NixOS/nixpkgs/commit/162039a2336d88affd2542cb67f82672078ae029) | `` nixos/swraid: Add missing mkRenamedOption ``                                   |
| [`03f4e727`](https://github.com/NixOS/nixpkgs/commit/03f4e727c53322064592b1af75df946a65f2f26c) | `` python310Packages.plantuml-markdown: 3.9.1 -> 3.9.2 ``                         |
| [`5829ef37`](https://github.com/NixOS/nixpkgs/commit/5829ef37cc07aa3c7da58654a7f7f2e8bc2012ea) | `` calibre: 6.22.0 -> 6.23.0 ``                                                   |
| [`351417c6`](https://github.com/NixOS/nixpkgs/commit/351417c686d73ea36aa9c8e6a7ce4219f86d6d57) | `` libxmp: 4.5.0 -> 4.6.0 ``                                                      |
| [`a0892e08`](https://github.com/NixOS/nixpkgs/commit/a0892e08588058ab1cc3e1911ae7178806a623c4) | `` deno: 1.35.0 -> 1.35.1 ``                                                      |
| [`70ae1f4f`](https://github.com/NixOS/nixpkgs/commit/70ae1f4f8b2ac2a1a2775c73a3ddbb83274f6d38) | `` httplz: 1.12.6 -> 1.13.0 ``                                                    |
| [`c5240d97`](https://github.com/NixOS/nixpkgs/commit/c5240d9775abf5ae48cc792048ef6966c719aeae) | `` asterisk: update the update script version regex ``                            |
| [`85331ccd`](https://github.com/NixOS/nixpkgs/commit/85331ccd98261180fc9de5388ef180e87f0380e2) | `` doc/../haskell.section.md: Make a bit clearer and more beginner friendly ``    |
| [`81b354ce`](https://github.com/NixOS/nixpkgs/commit/81b354ceb05728eee931e95183f3b9d0fce77306) | `` keybase: fix build on x86_64-darwin ``                                         |
| [`7764e287`](https://github.com/NixOS/nixpkgs/commit/7764e28784180311051541497bc19a7ec890dbda) | `` python310Packages.xformers: init at 0.0.20 ``                                  |
| [`3d19582e`](https://github.com/NixOS/nixpkgs/commit/3d19582ebe18c4b9a710d30ce666ce44d403cae2) | `` python310Packages.pyre-extensions: init at 0.0.30 ``                           |
| [`dfdbcc42`](https://github.com/NixOS/nixpkgs/commit/dfdbcc428f365071f0ca3888f6ec8c25c3792885) | `` 9pfs: 2015-09-18 -> 0.3 (#241801) ``                                           |
| [`0c38ea41`](https://github.com/NixOS/nixpkgs/commit/0c38ea41406316d4562170e98630b3d7a5c01bc1) | `` nodehun: init at 3.0.2 ``                                                      |
| [`0563baa0`](https://github.com/NixOS/nixpkgs/commit/0563baa02ed2f4f232299d4b0dc4d87a2ad38130) | `` gopatch: 0.2.0 -> 0.3.0 ``                                                     |
| [`7e9f41c2`](https://github.com/NixOS/nixpkgs/commit/7e9f41c295c2fae84fa0d40efacf1bfa933220d2) | `` scrcpy: 2.1 -> 2.1.1 ``                                                        |
| [`c48d319a`](https://github.com/NixOS/nixpkgs/commit/c48d319ac6d676bf56cf29c2362e61e705e43d77) | `` jenkins: 2.401.1 -> 2.401.2 ``                                                 |
| [`ee38adc8`](https://github.com/NixOS/nixpkgs/commit/ee38adc8e2fa43ab2f8553cf47205ff750c81abf) | `` keepalived: use `ints.between` ``                                              |
| [`d1a9aa51`](https://github.com/NixOS/nixpkgs/commit/d1a9aa51f7159ea548d687801f34f99735311c83) | `` grails: 5.3.2 -> 5.3.3 ``                                                      |
| [`8a6d5acb`](https://github.com/NixOS/nixpkgs/commit/8a6d5acb5f021ac5ee314a4f5954fb9f48ed3855) | `` cytoscape: Dependency openjdk11 -> openjdk17 ``                                |
| [`80a75c8a`](https://github.com/NixOS/nixpkgs/commit/80a75c8ad2cb7b458f1b1017eb44ca95542b07e4) | `` tfupdate: 0.7.1 -> 0.7.2 ``                                                    |
| [`48cbc7ae`](https://github.com/NixOS/nixpkgs/commit/48cbc7ae740e3cfb0a7fbf809048f68cb8805316) | `` phpExtensions.msgpack: 2.2.0RC2 -> 2.2.0 ``                                    |
| [`f448f095`](https://github.com/NixOS/nixpkgs/commit/f448f0959c70879c8950094f42652a5888947ee8) | `` bun: 0.6.13 -> 0.6.14 ``                                                       |
| [`996c9544`](https://github.com/NixOS/nixpkgs/commit/996c95449c0819c512197f72f274727f6fb06473) | `` dolt: 1.7.4 -> 1.7.5 ``                                                        |
| [`19ac5194`](https://github.com/NixOS/nixpkgs/commit/19ac5194268c876a4a58aa37b2e96e7010e8b6b9) | `` grafana-dash-n-grab: 0.4.3 -> 0.4.5 ``                                         |
| [`2376ec39`](https://github.com/NixOS/nixpkgs/commit/2376ec3971b4081dac65fa7d4675b3ba3d8fee6a) | `` typos: 1.16.0 -> 1.16.1 ``                                                     |
| [`ec7dea44`](https://github.com/NixOS/nixpkgs/commit/ec7dea44bf0e6086cd62f0d90ef7d9e0789d7127) | `` cl-gtk4.webkit2: mark as broken ``                                             |
| [`acd0161b`](https://github.com/NixOS/nixpkgs/commit/acd0161ba27062a0e72b2faf81662ef36dde1827) | `` sbcl.pkgs: use Quicklisp versions of tar and tar-file ``                       |
| [`0d84933b`](https://github.com/NixOS/nixpkgs/commit/0d84933bfe2fec2a5de540c07287ab69428409da) | `` sbcl.pkgs: update to Quicklisp dist from June 2023 ``                          |
| [`2a9010bf`](https://github.com/NixOS/nixpkgs/commit/2a9010bfb42d4f9d4ad082fde409e39255f174a9) | `` betterbird: inherit from correct thunderbird ``                                |
| [`8980fdd9`](https://github.com/NixOS/nixpkgs/commit/8980fdd9b57b2b43592058cbda2e866148e14ab5) | `` nixos/cgit: fix \v and \f in regexEscape ``                                    |
| [`e7ec942d`](https://github.com/NixOS/nixpkgs/commit/e7ec942dea0ee69c24e46a8b70bc4c3993eef634) | `` fsuae-launcher: fix find executable ``                                         |
| [`a347027a`](https://github.com/NixOS/nixpkgs/commit/a347027ace06cabc55e56df57e07ab3ba18e41ce) | `` python310Packages.yfinance: 0.2.22 -> 0.2.24 ``                                |
| [`91153952`](https://github.com/NixOS/nixpkgs/commit/9115395261bf5b8d38d1075bba03744601084361) | `` brave: add kerberos authentication ``                                          |
| [`bb219736`](https://github.com/NixOS/nixpkgs/commit/bb219736e42a0311fcd959a6f639ea53ce1d62ec) | `` stdenvBootstrapTools: in darwin, only run install_name_tool on Mach-O files `` |
| [`6454fb1b`](https://github.com/NixOS/nixpkgs/commit/6454fb1bc0b5884d0c11c98a8a99735ef5a0cae8) | `` haskell.compiler.ghc962: fix build on Darwin after stdenv rework merge ``      |
| [`4fae5e76`](https://github.com/NixOS/nixpkgs/commit/4fae5e769a2f5ddd313e9bf27de791a2f6a9f941) | `` buck2: add passthru.tests ``                                                   |
| [`67442c13`](https://github.com/NixOS/nixpkgs/commit/67442c1394f2a09027f01c1c82e1f88ca0f5c1ea) | `` critcmp: 0.1.7 -> 0.1.8 ``                                                     |
| [`3d37f6e0`](https://github.com/NixOS/nixpkgs/commit/3d37f6e0c162b2351fc52405dd2f0231335fa073) | `` popsicle: 1.3.1 -> 1.3.2 ``                                                    |
| [`c44f64c5`](https://github.com/NixOS/nixpkgs/commit/c44f64c508359d4c6da418a565d356df04147893) | `` complgen: unstable-2023-07-05 -> unstable-2023-07-10 ``                        |
| [`f6793ae4`](https://github.com/NixOS/nixpkgs/commit/f6793ae4af293302840c75e192b83905193efb28) | `` egglog: unstable-2023-06-26 -> unstable-2023-07-11 ``                          |
| [`1fa18909`](https://github.com/NixOS/nixpkgs/commit/1fa18909cab5f385f54b450ac2b3e72f324fd60e) | `` python3Packages.python3-application 3.0.4 -> 3.0.6 ``                          |
| [`07919ff7`](https://github.com/NixOS/nixpkgs/commit/07919ff7215444b0087832a6665cac14daf5d9d6) | `` doq: init at 0.9.1 ``                                                          |
| [`4ffb691f`](https://github.com/NixOS/nixpkgs/commit/4ffb691f8f6abeb9dedee64489f1cfc4ee88a672) | `` cargo-local-registry: 0.2.3 -> 0.2.5 ``                                        |
| [`88c4aa0c`](https://github.com/NixOS/nixpkgs/commit/88c4aa0c1e364a1e6593ace8c46c997754fa70ca) | `` reindeer: unstable-2023-06-20 -> unstable-2023-07-14 ``                        |
| [`f3a1c560`](https://github.com/NixOS/nixpkgs/commit/f3a1c560c60c980ab605a2c42cbaa8ab8a14cbe7) | `` vscode-extensions.mgt19937.typst-preview: 0.6.0 -> 0.6.1 ``                    |
| [`6d157073`](https://github.com/NixOS/nixpkgs/commit/6d157073cf3caebeeeb0964749cfee085c8d655e) | `` piston-cli: use Python 3.10 ``                                                 |
| [`01fc7c52`](https://github.com/NixOS/nixpkgs/commit/01fc7c527c3a07a0b464e48e9b0ce6e61fef005f) | `` piston-cli: fix build ``                                                       |
| [`aae4350c`](https://github.com/NixOS/nixpkgs/commit/aae4350c5bedcc3ef1a312b378b5febc65fc9328) | `` openipmi: use Python 3.10 ``                                                   |
| [`776af907`](https://github.com/NixOS/nixpkgs/commit/776af907f086e0b76ea2ecd8f9f8d86be83d0f83) | `` bisq-desktop: 1.9.10 -> 1.9.12 ``                                              |
| [`2289a489`](https://github.com/NixOS/nixpkgs/commit/2289a489c2d0ba213692b388e643c7b3fb8aaeeb) | `` asterisk: use latest python for update script ``                               |
| [`7aba3238`](https://github.com/NixOS/nixpkgs/commit/7aba3238803ae8c6d65b26b7fc2df69790f888cc) | `` mandelbulber: 2.29 -> 2.30 ``                                                  |
| [`aa23f045`](https://github.com/NixOS/nixpkgs/commit/aa23f04560b8e15d69095c1b0bba0e4aed1c24c6) | `` sumokoin: don't override boost ``                                              |
| [`639dfdec`](https://github.com/NixOS/nixpkgs/commit/639dfdecd031c4deff056f2964536c1bdb9cd1f4) | `` vertcoin: don't override boost ``                                              |
| [`230170ee`](https://github.com/NixOS/nixpkgs/commit/230170eecabc4f249dcea111cb9ea29c0510a12f) | `` monero-gui: don't override boost ``                                            |
| [`5aefc56f`](https://github.com/NixOS/nixpkgs/commit/5aefc56fb85cca599a79467587a5acdce2779a39) | `` groestlcoin: don't override boost ``                                           |
| [`5c6057d9`](https://github.com/NixOS/nixpkgs/commit/5c6057d946bdf351ae86466ac0810702c78008a4) | `` dogecoin: don't override boost ``                                              |
| [`43021050`](https://github.com/NixOS/nixpkgs/commit/430210502a1a963f197a15a867bea65b03bab8bb) | `` bitcoind-abc: don't override boost ``                                          |
| [`da4f87c0`](https://github.com/NixOS/nixpkgs/commit/da4f87c04df48a9fcc649214d28f7a5d39d3ec88) | `` bitcoind-knots: don't override boost ``                                        |
| [`cef4da0b`](https://github.com/NixOS/nixpkgs/commit/cef4da0bd832977025725a895ea07e09a08174e0) | `` bitcoin: don't override boost ``                                               |
| [`ff0e55ff`](https://github.com/NixOS/nixpkgs/commit/ff0e55ff2267ea973a7bcd4a92c99c73513e65fc) | `` vimPlugins.cmp-beancount: init at 2022-11-27 ``                                |