### PR TITLE
chore(flake/home-manager): `bec87d53` -> `c1cdce3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689359668,
-        "narHash": "sha256-NY4CSTKB8WgcMeF+ng+7QV5fj3bGxGC/IUV1rBanJCA=",
+        "lastModified": 1689362769,
+        "narHash": "sha256-5V7Z7T9019pGsFnYH6va5h6Wveq8FKmXa/xLfj0DhNI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bec87d536c9f441ffeb603fc821fa7e613585d00",
+        "rev": "c1cdce3d89741d402d8fd2c93e3d2643ff85b053",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`c1cdce3d`](https://github.com/nix-community/home-manager/commit/c1cdce3d89741d402d8fd2c93e3d2643ff85b053) | `` i3-sway: allow arbitrary floating modifier (#4229) ``                             |
| [`f63b39a6`](https://github.com/nix-community/home-manager/commit/f63b39a67dcfeae4ed326acba181c898753ae7ad) | `` i3-sway: multiple outputs (#4223) ``                                              |
| [`d2e47de5`](https://github.com/nix-community/home-manager/commit/d2e47de53650d48fd95eb0ec92049d1cb7f09520) | `` home-cursor.nix: enable gtk module when enabling gtk config generation (#4144) `` |