### PR TITLE
chore(flake/nix-index-database): `75711474` -> `22fa44b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -283,11 +283,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688874465,
-        "narHash": "sha256-BUwl+tq40EjkufTZkqf3lWFzxOA/mYBTHz+p5uJtjaY=",
+        "lastModified": 1689479461,
+        "narHash": "sha256-Ak+PTYdmfOQEmcOsOEnrwqdP0HP20PLraRwpjSAzSeE=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "757114749d4613cf71f3748e780a1be8a67a5d3c",
+        "rev": "22fa44b7f14684d184733fb26a628f3878ff7aaf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`22fa44b7`](https://github.com/nix-community/nix-index-database/commit/22fa44b7f14684d184733fb26a628f3878ff7aaf) | `` update packages.nix to release 2023-07-16-035005 `` |
| [`2be67445`](https://github.com/nix-community/nix-index-database/commit/2be674457c62798a6b25ce26214835a04287c64c) | `` flake.lock: Update ``                               |