### PR TITLE
chore(flake/home-manager): `f5b03feb` -> `232fe3d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689447223,
-        "narHash": "sha256-A5vQBtWYamvGf3c2IEhAmwIkXBzuzrkpnMYbLvc+lEY=",
+        "lastModified": 1689495077,
+        "narHash": "sha256-hmAqKvtDGlwNa41pZHP6mUoZq0yBnhkawcr8dxRzo6g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f5b03feb33629cb2b6dd513935637e8cc718a5ba",
+        "rev": "232fe3d450dac73e55cf6fd2d73600c6cb82cd8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`232fe3d4`](https://github.com/nix-community/home-manager/commit/232fe3d450dac73e55cf6fd2d73600c6cb82cd8b) | `` flake.lock: Update ``                              |
| [`1e7ba710`](https://github.com/nix-community/home-manager/commit/1e7ba7102e62cec727e1579a157e510bf123b350) | `` home-manager: remove Home Manager default paths `` |