### PR TITLE
chore(flake/darwin): `c806a736` -> `61662a63`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689281837,
-        "narHash": "sha256-msgwgot2/hxXzlpYltIZ7boAqBkN8XejNOhBJ07q3FY=",
+        "lastModified": 1689516967,
+        "narHash": "sha256-sFAa33wkQHanmij/uhfGduIDK8z4dJAita/rK6u9pvE=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "c806a73609e77f0c446fdad5d3ea6ca3b7ae6e5f",
+        "rev": "61662a63bfe1726588c1da6b412df86d8ca94d63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                 |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`4eb1c549`](https://github.com/LnL7/nix-darwin/commit/4eb1c549a9d43c4a85373dbf63986869aab9589b) | `` etc: check for existing files during checks stage `` |
| [`c91c3519`](https://github.com/LnL7/nix-darwin/commit/c91c3519435a267dc7bcfa78bbd6ba158435f7f4) | `` etc: rename activation script variables ``           |