### PR TITLE
chore(flake/nixpkgs): `8acef304` -> `6cee3b58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689444953,
-        "narHash": "sha256-0o56bfb2LC38wrinPdCGLDScd77LVcr7CrH1zK7qvDg=",
+        "lastModified": 1689534811,
+        "narHash": "sha256-jnSUdzD/414d94plCyNlvTJJtiTogTep6t7ZgIKIHiE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8acef304efe70152463a6399f73e636bcc363813",
+        "rev": "6cee3b5893090b0f5f0a06b4cf42ca4e60e5d222",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`6cee3b58`](https://github.com/NixOS/nixpkgs/commit/6cee3b5893090b0f5f0a06b4cf42ca4e60e5d222) | `` linuxPackages.trelay: init at 22.03.5 ``                                       |
| [`b50bd0f6`](https://github.com/NixOS/nixpkgs/commit/b50bd0f6fa5754027d5a97caa8b4b5019f74e0d8) | `` maintainers: add aprl ``                                                       |
| [`98686c14`](https://github.com/NixOS/nixpkgs/commit/98686c14dc207f3d1bdaf897139cdd36180ec420) | `` scrcpy: make server display nicer in nix store diff-closure ``                 |
| [`bb887636`](https://github.com/NixOS/nixpkgs/commit/bb887636a272c17a74758700f70f7a686f89303a) | `` python310Packages.vdirsyncer: update meta ``                                   |
| [`e251fec9`](https://github.com/NixOS/nixpkgs/commit/e251fec9004ec1a6de7d8f98707bd43084946a69) | `` python310Packages.vdirsyncer: 0.19.1 -> 0.19.2 ``                              |
| [`9aabc9f7`](https://github.com/NixOS/nixpkgs/commit/9aabc9f7f3e07ebb07537b6c95fb954af4c3a9a0) | `` nix-generate-from-cpan: generate SRI hashes ``                                 |
| [`ba414d53`](https://github.com/NixOS/nixpkgs/commit/ba414d53e9539f1d5c40a0c922484b5d7750fdd5) | `` conserve: init at 23.5.0 ``                                                    |
| [`435f37a8`](https://github.com/NixOS/nixpkgs/commit/435f37a824d0c31a0f1276fb4387b0a77e205981) | `` python3Packages.speechbrain: correct format ``                                 |
| [`5f05773c`](https://github.com/NixOS/nixpkgs/commit/5f05773cacd4b346e523f99c67ccb7f416b8cdd0) | `` perlPackages.PerlLanguageServer: init at 2.5.0 ``                              |
| [`0c2d9348`](https://github.com/NixOS/nixpkgs/commit/0c2d93482f91b1e8e819785cb9449ac730d26ba4) | `` perlPackages.ClassRefresh: init at 0.07 ``                                     |
| [`698b95c5`](https://github.com/NixOS/nixpkgs/commit/698b95c5a5e37ab1644db74b758669cdd4afd8cf) | `` python310Packages.blocksat-cli: 0.4.5 -> 0.4.6 ``                              |
| [`16233aaa`](https://github.com/NixOS/nixpkgs/commit/16233aaa7a308eb0200d4b962133d8cfcdf67c71) | `` python310Packages.generic: update meta ``                                      |
| [`3dfcf894`](https://github.com/NixOS/nixpkgs/commit/3dfcf894e93393c6fc9d2ff570a9888ae0d29013) | `` python310Packages.generic: 1.1.1 -> 1.1.2 ``                                   |
| [`18b001d8`](https://github.com/NixOS/nixpkgs/commit/18b001d8efbc37d628da9cfb3bab47a9d845913b) | `` python310Packages.tern: 2.12.0 -> 2.12.1 ``                                    |
| [`e180278f`](https://github.com/NixOS/nixpkgs/commit/e180278f4e20a58ea76bb1a447b9efa1860c2049) | `` nvitop: 1.0.0 -> 1.1.2 ``                                                      |
| [`83f9715a`](https://github.com/NixOS/nixpkgs/commit/83f9715ad8c30fd333ff3a16a71ceccee196138a) | `` mautrix-whatsapp: 0.8.6 -> 0.9.0 ``                                            |
| [`9892a91f`](https://github.com/NixOS/nixpkgs/commit/9892a91f8870ce7a14c026397d2b844b76a77ad9) | `` gnuradio: 3.10.6.0 -> 3.10.7.0 ``                                              |
| [`6d49e50f`](https://github.com/NixOS/nixpkgs/commit/6d49e50f5f25ec1325da8ac622f32795fac5355c) | `` inadyn: explicitly set localstatedir & sysconfdir ``                           |
| [`a8c6976a`](https://github.com/NixOS/nixpkgs/commit/a8c6976ac9d4addf4ef78b71bb4a9c84146fd781) | `` python310Packages.oci: 2.105.0 -> 2.106.0 ``                                   |
| [`4ae90dc2`](https://github.com/NixOS/nixpkgs/commit/4ae90dc2602eb57d85daad42248a54102b68b72a) | `` xfce.xfce4-verve-plugin: 2.0.1 -> 2.0.3 ``                                     |
| [`9f57f0f3`](https://github.com/NixOS/nixpkgs/commit/9f57f0f31df8e35a40c2cbb3346f41c33cef8914) | `` ocamlPackages.eio: 0.10 → 0.11 ``                                              |
| [`f678708b`](https://github.com/NixOS/nixpkgs/commit/f678708bd4de85adeb079fed86febdcdcf8ba68f) | `` perlPackages.DevelOverrideGlobalRequire: init at 0.001 ``                      |
| [`cc6f21d7`](https://github.com/NixOS/nixpkgs/commit/cc6f21d752afd64c746c9a45e9e8eb619a9f1fe6) | `` perlPackages.HashSafeKeys: init at 0.04 ``                                     |
| [`146f775f`](https://github.com/NixOS/nixpkgs/commit/146f775fe693625e77e4ea713b92af550e0c67c0) | `` perlPackages.CompilerLexer: init at 0.23 ``                                    |
| [`e79b9009`](https://github.com/NixOS/nixpkgs/commit/e79b9009e62e5db5cbfa9c9db522a8548207c8a4) | `` perlPackages.PLS: 0.897 -> 0.905 ``                                            |
| [`21c9f7de`](https://github.com/NixOS/nixpkgs/commit/21c9f7de2240cdb2391591ae929f64501be33fa9) | `` ocamlPackages.eio_main: depend on `eio_linux` instead of `uring` ``            |
| [`e7059632`](https://github.com/NixOS/nixpkgs/commit/e7059632c66003bc12d81559e471519a24481585) | `` nixos/trust-dns: init ``                                                       |
| [`aa804347`](https://github.com/NixOS/nixpkgs/commit/aa804347c4a6e2e13e44037dd5a733dd9348f0cd) | `` python311Packages.pyrainbird: update disabled ``                               |
| [`26e7964a`](https://github.com/NixOS/nixpkgs/commit/26e7964ad124b9ce910bd62e007887e807aafcdd) | `` lunarml: init at unstable-2023-06-25 ``                                        |
| [`66c99085`](https://github.com/NixOS/nixpkgs/commit/66c990850b878437510cc6096e6babce86de5dcb) | `` python310Packages.onnxruntime-tools: init at 1.7.0 ``                          |
| [`530b5df3`](https://github.com/NixOS/nixpkgs/commit/530b5df35c6007aef40bff37eb5b06db3904c718) | `` python310Packages.py3nvml: init at 0.2.7 ``                                    |
| [`79c848fd`](https://github.com/NixOS/nixpkgs/commit/79c848fd131d8114516b7478f4740c310a4df746) | `` python310Packages.ninja: init at 0.6 ``                                        |
| [`7bce1e4d`](https://github.com/NixOS/nixpkgs/commit/7bce1e4d7333d23f12ff7d50d0f482b721b7c760) | `` typstfmt: rename from typst-fmt, unstable-2023-04-26 -> unstable-2023-07-15 `` |
| [`afd6b815`](https://github.com/NixOS/nixpkgs/commit/afd6b815c41aaa75767ae328b57059144169ffa9) | `` trealla: 2.21.33 -> 2.22.11 ``                                                 |
| [`df5cfec1`](https://github.com/NixOS/nixpkgs/commit/df5cfec1cde1cf26aea55b1cc670bbe52a12fabe) | `` vivaldi: fix a typo in update script ``                                        |
| [`8524676c`](https://github.com/NixOS/nixpkgs/commit/8524676c5c85fe5d03420dd8b4b3a3ae9b619683) | `` vivaldi-ffmpeg-codecs: 104.0.5112.101 -> 112.0.5615.49 ``                      |
| [`ae38d7df`](https://github.com/NixOS/nixpkgs/commit/ae38d7dff85b3d9c94c5c6561ddc690f0b57c03b) | `` pocketbase: 0.16.7 -> 0.16.8 ``                                                |
| [`9aa25b99`](https://github.com/NixOS/nixpkgs/commit/9aa25b99bc94a401996c43102b393f7b266dfd78) | `` kubie: 0.19.3 -> 0.20.1 ``                                                     |
| [`3831e51c`](https://github.com/NixOS/nixpkgs/commit/3831e51c041ae511272fc3ddcd4c60dddd2e511e) | `` stripe-cli: 1.15.0 -> 1.16.0 ``                                                |
| [`7e281993`](https://github.com/NixOS/nixpkgs/commit/7e281993bbc6f09832c2018b3838fc4da14b32d6) | `` labwc: 0.6.3 -> 0.6.4 ``                                                       |
| [`94d1f330`](https://github.com/NixOS/nixpkgs/commit/94d1f330eee4c26e42ec04789f417b5c96418d41) | `` cargo-pgrx: 0.9.7 -> 0.9.8 ``                                                  |
| [`1519c6c4`](https://github.com/NixOS/nixpkgs/commit/1519c6c497649813d53beeece17d173abf7ebc84) | `` mongoc: 1.24.1 -> 1.24.2 ``                                                    |
| [`ead89b52`](https://github.com/NixOS/nixpkgs/commit/ead89b5269eee437ab25e406ab541f458b0a02b3) | `` anytype: 0.32.3 -> 0.33.0 ``                                                   |
| [`2894d0c7`](https://github.com/NixOS/nixpkgs/commit/2894d0c7c9dc4653accbcddaae00c915df224527) | `` phpunit: 10.2.2 -> 10.2.3 ``                                                   |
| [`3c946829`](https://github.com/NixOS/nixpkgs/commit/3c94682946f23ce6cd167e2179831c419999b186) | `` Revert "opendungeons: unstable-2021-11-06 -> unstable-2023-01-09" ``           |
| [`4b11baf2`](https://github.com/NixOS/nixpkgs/commit/4b11baf26c67c8f899bcd8cd7fd4094f624bb58c) | `` libudev-zero: 1.0.2 -> 1.0.3 ``                                                |
| [`5a79ce6a`](https://github.com/NixOS/nixpkgs/commit/5a79ce6a57ef96b636738bdc72dd5717a2436fb1) | `` pluto: 5.17.0 -> 5.18.1 ``                                                     |
| [`e77a7428`](https://github.com/NixOS/nixpkgs/commit/e77a74285de3d28fc80512689686f6ccbb96efe8) | `` step-kms-plugin: 0.9.0 -> 0.9.1 ``                                             |
| [`58a7237f`](https://github.com/NixOS/nixpkgs/commit/58a7237fbf4c246a142ed24280c9677009d09c2d) | `` sentry-native: 0.6.4 -> 0.6.5 ``                                               |
| [`c71fa0b8`](https://github.com/NixOS/nixpkgs/commit/c71fa0b88fdc767ee401f9ceb97089e339ee64e1) | `` mygui: 3.4.1 -> 3.4.2 ``                                                       |
| [`a90c72e8`](https://github.com/NixOS/nixpkgs/commit/a90c72e8eee365e0e10324ef93ad5a4d27ff0727) | `` cargo-insta: 1.30.0 -> 1.31.0 ``                                               |
| [`74baebfd`](https://github.com/NixOS/nixpkgs/commit/74baebfd401bcc1eb638bee267af18f8a889f700) | `` flyctl: 0.1.53 -> 0.1.56 ``                                                    |
| [`a0b8b2ff`](https://github.com/NixOS/nixpkgs/commit/a0b8b2ff73e52ec3e80c9fed572f7e7f9534e166) | `` cloudflared: 2023.6.1 -> 2023.7.0 ``                                           |
| [`7ff81c84`](https://github.com/NixOS/nixpkgs/commit/7ff81c846fc707c3801077b11a86fe0c9f97774a) | `` tesseract5: 5.3.1 -> 5.3.2 ``                                                  |
| [`9fb9bf7e`](https://github.com/NixOS/nixpkgs/commit/9fb9bf7e66597a9459bb5dcbb40e806ddf3190f3) | `` python311Packages.bond-async: 0.1.23 -> 0.2.1 ``                               |
| [`f1091c83`](https://github.com/NixOS/nixpkgs/commit/f1091c83ef9365899950ffb67dc746b73c0182fb) | `` python311Packages.twilio: 8.4.0 -> 8.5.0 ``                                    |
| [`999365be`](https://github.com/NixOS/nixpkgs/commit/999365be77c3fb2b91110c9bc61e1a71a1b59f5f) | `` python311Packages.pyrainbird: 2.1.0 -> 3.0.0 ``                                |
| [`da4c1488`](https://github.com/NixOS/nixpkgs/commit/da4c1488be002f098569b9f7a8c641451f7173cd) | `` nixpacks: 1.9.2 -> 1.10.0 ``                                                   |
| [`71548e46`](https://github.com/NixOS/nixpkgs/commit/71548e46396b5297d0835e1eecd322eb7cdcae7f) | `` opendungeons: unstable-2021-11-06 -> unstable-2023-01-09 ``                    |
| [`7e8aef5f`](https://github.com/NixOS/nixpkgs/commit/7e8aef5f2df5723deddc2e2390b800313c588b91) | `` python311Packages.pygtfs: 0.1.7 -> 0.1.9 ``                                    |
| [`a4928274`](https://github.com/NixOS/nixpkgs/commit/a492827472c16ea24b8231bd804272a85f87b3d6) | `` python311Packages.pysmartapp: 0.3.4 -> 0.3.5 ``                                |
| [`e9fb7c14`](https://github.com/NixOS/nixpkgs/commit/e9fb7c1417bfbdfedce3df6f55809b0fd8f1d485) | `` python311Packages.onvif-zeep-async: 3.1.9 -> 3.1.12 ``                         |
| [`b13c1e7c`](https://github.com/NixOS/nixpkgs/commit/b13c1e7c66f3dac9539a2f4e464cb96867c5ee79) | `` stylua: 0.18.0 -> 0.18.1 ``                                                    |
| [`a65eab9e`](https://github.com/NixOS/nixpkgs/commit/a65eab9e698e6b42c64d6702412d394c8236d3a3) | `` nvc: 1.9.2 -> 1.10.0 ``                                                        |
| [`0f8df96a`](https://github.com/NixOS/nixpkgs/commit/0f8df96a3ae1cb6f6914e6161d619e73373d7b1b) | `` glooctl: 1.14.10 -> 1.14.11 ``                                                 |
| [`af2bf610`](https://github.com/NixOS/nixpkgs/commit/af2bf61054015c9bc3982dd753bb74c22c86bc8d) | `` kubernetes-helm: 3.12.1 -> 3.12.2 ``                                           |
| [`8339d935`](https://github.com/NixOS/nixpkgs/commit/8339d93501ef6a05ca81807ad410c70b65bf1890) | `` python310Packages.pyvista: 0.40.0 -> 0.40.1 ``                                 |
| [`1d6af5dd`](https://github.com/NixOS/nixpkgs/commit/1d6af5dde1aaf79650af9ab4a20a9c44dd55570e) | `` unciv: 4.7.6-patch1 -> 4.7.8-patch1 ``                                         |
| [`5c5c7225`](https://github.com/NixOS/nixpkgs/commit/5c5c7225436dba7e187d4ccf46b5d37c800821a3) | `` python3Packages.mhcflurry: init at 2.0.6 ``                                    |
| [`d155fa8a`](https://github.com/NixOS/nixpkgs/commit/d155fa8ab346bff715c2cf204cbed604bce64c21) | `` prometheus-fastly-exporter: 7.6.0 -> 7.6.1 ``                                  |
| [`1cafc286`](https://github.com/NixOS/nixpkgs/commit/1cafc2862c01f7f66c5dfca55c59e6e760e06914) | `` pachyderm: 2.6.5 -> 2.6.6 ``                                                   |
| [`a223c2ac`](https://github.com/NixOS/nixpkgs/commit/a223c2ac279943712748593e3adc94ac3abfc738) | `` tmuxPlugins.catppuccin: unstable-2022-04-03 -> unstable-2023-07-15 ``          |
| [`2b692b1d`](https://github.com/NixOS/nixpkgs/commit/2b692b1d9d1e650fc74d5dcab24d559be2c52dc3) | `` freshBootstrapTools: fix build on darwin ``                                    |
| [`8b044c93`](https://github.com/NixOS/nixpkgs/commit/8b044c93a9c1686ef82f38e567016895d9567dca) | `` alfaview: 8.71.0 -> 8.72.0 ``                                                  |
| [`3ecdb1d3`](https://github.com/NixOS/nixpkgs/commit/3ecdb1d32d79cd6c123b679818549f39699c59a7) | `` survex: minor cleanup and refactor ``                                          |
| [`2c687f06`](https://github.com/NixOS/nixpkgs/commit/2c687f06f213f5d5b8904d19047cf1cf43f6f83c) | `` tunnelx: minor refactor and cleanup ``                                         |
| [`87478fdf`](https://github.com/NixOS/nixpkgs/commit/87478fdfdff0980ab8d14bc28940463c60abd436) | `` nodejs: use a response file with llvm-ar ``                                    |
| [`d2392222`](https://github.com/NixOS/nixpkgs/commit/d2392222d4bd461afef2267ed2333c9575bcb5f4) | `` python310Packages.cloup: 2.1.1 -> 3.0.0 ``                                     |
| [`605441fb`](https://github.com/NixOS/nixpkgs/commit/605441fb4fa0d8d8a81af9bc9bbd0dc024d2f8dd) | `` nyxt: 3.3.0 -> 3.4.0 ``                                                        |
| [`10648f36`](https://github.com/NixOS/nixpkgs/commit/10648f3694be3ed529079e97cd2f2f23fd61c46f) | `` lisp-modules: unpin nyxt's quri dependecy ``                                   |
| [`911a0a4a`](https://github.com/NixOS/nixpkgs/commit/911a0a4aa1e35d7bbbb5c01fbe3ec3d2309418ab) | `` lisp-modules: remove version name from nyxt dependecies ``                     |
| [`9895d0b0`](https://github.com/NixOS/nixpkgs/commit/9895d0b0c50d0db40454bc4d035cbfc2597568b8) | `` linuxPackages_testing_bcachefs: add raitobezarius as maintainer ``             |
| [`ddcc7078`](https://github.com/NixOS/nixpkgs/commit/ddcc70786f595fcbadcecc737a36b606999219be) | `` linuxPackages_testing_bcachefs: enable quota and POSIX ACL ``                  |
| [`470bc273`](https://github.com/NixOS/nixpkgs/commit/470bc2739f92ef2d8881f5f4d9f2b583921cc365) | `` devbox: 0.5.6 -> 0.5.7 ``                                                      |
| [`92a1cb52`](https://github.com/NixOS/nixpkgs/commit/92a1cb52aa673de83c6df0f10b9ccfedf8cf25e5) | `` python310Packages.nitransforms: 23.0.0 -> 23.0.1 ``                            |
| [`a903bb6e`](https://github.com/NixOS/nixpkgs/commit/a903bb6eb8e422b58a40b557be99507f2bc0a43a) | `` nicotine-plus: 3.2.8 -> 3.2.9 ``                                               |
| [`3f061ac5`](https://github.com/NixOS/nixpkgs/commit/3f061ac5841cdabc7588eb621367220585dacb01) | `` vgmtools: unstable-2023-06-29 -> unstable-2023-07-14 ``                        |
| [`e4918dba`](https://github.com/NixOS/nixpkgs/commit/e4918dbaab28cb802685812e269247bc0b4a39fb) | `` portfolio: 0.64.1 -> 0.64.4 ``                                                 |
| [`55151f5e`](https://github.com/NixOS/nixpkgs/commit/55151f5e353fd40287aba8eaaa51f732e17ca1f4) | `` dendrite: fix db lockup ``                                                     |
| [`2d677b22`](https://github.com/NixOS/nixpkgs/commit/2d677b222c63085d366befea7c55982f686f1ada) | `` minio: 2023-06-09T07-32-12Z -> 2023-07-11T21-29-34Z ``                         |
| [`a7199893`](https://github.com/NixOS/nixpkgs/commit/a719989392ae6e45b026333ec9b07fb78595abe8) | `` python311Packages.google-cloud-logging: 3.5.0 -> 3.6.0 ``                      |
| [`69e65419`](https://github.com/NixOS/nixpkgs/commit/69e6541912c91505407f319ba3f31dd90f224c0d) | `` url-parser: init at 1.0.4 ``                                                   |
| [`7bf94c50`](https://github.com/NixOS/nixpkgs/commit/7bf94c5050d8bee13444a39a305e9d7f1fed1c41) | `` python311Packages.google-cloud-datacatalog: 3.13.1 -> 3.14.0 ``                |
| [`9bf5aa4e`](https://github.com/NixOS/nixpkgs/commit/9bf5aa4eb7136d265121f0c2ba20d6d5cbbb047d) | `` boa: init at 0.17 ``                                                           |
| [`4e68587c`](https://github.com/NixOS/nixpkgs/commit/4e68587cdabc75b411ce6e6ada9591f16bf4de20) | `` pg_featureserv: 1.2.0 -> 1.3.0 unmark broken ``                                |
| [`9ff4a587`](https://github.com/NixOS/nixpkgs/commit/9ff4a587406b3e8470f4c633099a522d8c23c545) | `` fastlane: 2.213.0 -> 2.214.0 ``                                                |
| [`af1761de`](https://github.com/NixOS/nixpkgs/commit/af1761dec3baa7e87210aa92403020ba70e090e2) | `` buildkit: 0.11.6 -> 0.12.0 ``                                                  |
| [`63e49bdc`](https://github.com/NixOS/nixpkgs/commit/63e49bdc5000d88bab0dad911224d11570ede063) | `` twilio-cli: 5.10.0 -> 5.11.0 ``                                                |
| [`034573d4`](https://github.com/NixOS/nixpkgs/commit/034573d4a6a0d69e5e0c2ad1e67548e7113b8c95) | `` bundletool: 1.15.1 -> 1.15.2 ``                                                |
| [`d433e1db`](https://github.com/NixOS/nixpkgs/commit/d433e1db20730fd152b0de514ab36ab18e5a87e4) | `` gallery-dl: 1.25.7 -> 1.25.8 ``                                                |
| [`0fc2c5be`](https://github.com/NixOS/nixpkgs/commit/0fc2c5be22e1332f03550854ae4b41ef845a0b57) | `` nfpm: 2.31.0 -> 2.32.0 ``                                                      |
| [`ebb9df74`](https://github.com/NixOS/nixpkgs/commit/ebb9df744ff699d26ed13057b17aa2140a5c585e) | `` luau: 0.583 -> 0.584 ``                                                        |
| [`02f324ee`](https://github.com/NixOS/nixpkgs/commit/02f324ee9bc28c6d1966135d4e928ab59f01120b) | `` flow: 0.211.1 -> 0.212.0 ``                                                    |
| [`772d0ac3`](https://github.com/NixOS/nixpkgs/commit/772d0ac302364773de60f5ef09e1ae1bec658b62) | `` doppler: 3.63.1 -> 3.65.0 ``                                                   |
| [`ea14b7d4`](https://github.com/NixOS/nixpkgs/commit/ea14b7d487b4b569bc3341717c34eb16a2891d86) | `` libsolv: minor cleanup and reformat ``                                         |
| [`eb5117f4`](https://github.com/NixOS/nixpkgs/commit/eb5117f4083a2ff5f196074f3822babfa394f6ed) | `` dnf5: init at 5.0.15 ``                                                        |
| [`0851a2db`](https://github.com/NixOS/nixpkgs/commit/0851a2db0378d8849ea95ee741996eec0864db03) | `` protoc-gen-tonic: init at 0.3.0 ``                                             |
| [`f0521360`](https://github.com/NixOS/nixpkgs/commit/f0521360dbefb45815a3b6387d297497a634203d) | `` protoc-gen-prost-serde: init at 0.2.3 ``                                       |
| [`8104326c`](https://github.com/NixOS/nixpkgs/commit/8104326ce6281b363f7d54b57710a05a97cefd28) | `` protoc-gen-prost-crate: init at 0.3.1 ``                                       |
| [`3a83909e`](https://github.com/NixOS/nixpkgs/commit/3a83909e4cac94c1f7c06e3c589faa96c69d117e) | `` protoc-gen-prost: init at 0.2.3 ``                                             |
| [`fff76a5b`](https://github.com/NixOS/nixpkgs/commit/fff76a5bd1a6290d432de2a8303246e2e3a609b5) | `` maintainers: add sitaaax ``                                                    |
| [`4f52684c`](https://github.com/NixOS/nixpkgs/commit/4f52684c70a2391ac5f5f4f5f01dd88571e33d13) | `` avalanchego: 1.10.3 -> 1.10.4 ``                                               |
| [`406aee2b`](https://github.com/NixOS/nixpkgs/commit/406aee2b17480e46641ae822b2409aa50b4daf86) | `` maintainers: add malt3 ``                                                      |
| [`af40e90a`](https://github.com/NixOS/nixpkgs/commit/af40e90a49b6620b65a8159d20c103d58769fd92) | `` python3Packages.mhcgnomes: init at 1.8.6 ``                                    |
| [`bc184bf7`](https://github.com/NixOS/nixpkgs/commit/bc184bf7dce3bd588966860dd52d39fe37ced640) | `` python3Packages.serializable: init at unstable-2023-07-13 ``                   |
| [`76f72af6`](https://github.com/NixOS/nixpkgs/commit/76f72af638bc604f4cadc257738e8dfdc8c80ad3) | `` python3Packages.typechecks: init at unstable-2023-07-13 ``                     |
| [`33e8ff3f`](https://github.com/NixOS/nixpkgs/commit/33e8ff3f97c20fb01a7a626831862fb03fcb486c) | `` python3Packages.speechbrain: init at 0.5.14 ``                                 |
| [`fdce5ed2`](https://github.com/NixOS/nixpkgs/commit/fdce5ed26b28c32a24bece13fcca34ced8ebb7de) | `` python3Packages.hyperpyyaml: init at 1.2.1 ``                                  |
| [`cc9a5bb2`](https://github.com/NixOS/nixpkgs/commit/cc9a5bb2a3587dec875571120efea179fdee3a6c) | `` minio-client: 2023-06-28T21-54-17Z -> 2023-07-07T05-25-51Z ``                  |
| [`f60c7e8f`](https://github.com/NixOS/nixpkgs/commit/f60c7e8f74f947836acdde944e34bbcffb6e30d2) | `` lmdb: 0.9.30 -> 0.9.31 ``                                                      |
| [`adb14254`](https://github.com/NixOS/nixpkgs/commit/adb14254a27670a8daed55766866d71cea5fc7fe) | `` bloodhound-py: init at 1.6.1 ``                                                |
| [`71e2043b`](https://github.com/NixOS/nixpkgs/commit/71e2043bee019a4ba0cad84f1c8e9d18b354b0cd) | `` naev: 0.10.5 -> 0.10.6 ``                                                      |
| [`ec11bccf`](https://github.com/NixOS/nixpkgs/commit/ec11bccfca72f9860cc712d65c630ce5693cc8a6) | `` nsz: 4.2.1 -> 4.3.0 ``                                                         |
| [`91837d49`](https://github.com/NixOS/nixpkgs/commit/91837d49fde4bd8a4a211248451fb6aea674010c) | `` vips: Allow building without imagemagick support ``                            |
| [`9f5df22d`](https://github.com/NixOS/nixpkgs/commit/9f5df22dba9042492a6cb730d917d8a2b4c14778) | `` aws-sam-cli: 1.53.0 -> 1.90.0 ``                                               |
| [`aca7ed1b`](https://github.com/NixOS/nixpkgs/commit/aca7ed1b6b3c1b943cad1f68ea732c6cb0bfc8f3) | `` python310Packages.scikit-rf: 0.27.1 -> 0.28.0 ``                               |
| [`4cf80061`](https://github.com/NixOS/nixpkgs/commit/4cf80061735a4cb12d87fd8c5c9e90d1ecc3f040) | `` nixos/ananicy: take `listOf attrs` instead of `string` ``                      |
| [`a934eef3`](https://github.com/NixOS/nixpkgs/commit/a934eef3e84303475c18e2c7fe7f66ad1b6af9f0) | `` tome4: 1.7.5 -> 1.7.6 ``                                                       |
| [`b5785d2b`](https://github.com/NixOS/nixpkgs/commit/b5785d2b1ecb1617ab617102a51eb6be809f996f) | `` python310Packages.pytorch-lightning: 2.0.4 -> 2.0.5 ``                         |
| [`de2ac3cf`](https://github.com/NixOS/nixpkgs/commit/de2ac3cf0e2a38edc1e41d29bfe083c14c409f29) | `` kernelshark: 2.2.0 -> 2.2.1 ``                                                 |
| [`dd984954`](https://github.com/NixOS/nixpkgs/commit/dd9849546b370d98a3716329fc3336e7b47727cb) | `` lxd: add wrapper ``                                                            |
| [`67792127`](https://github.com/NixOS/nixpkgs/commit/6779212701c3d7ef78491b5bfd85d534e5724b7a) | `` python311Packages.tensorboard: enable ``                                       |
| [`f2699a0a`](https://github.com/NixOS/nixpkgs/commit/f2699a0ae5c757b910409141e4e282f2334be37e) | `` python3Packages.pypika: init at 0.48.9 ``                                      |
| [`1b1f2531`](https://github.com/NixOS/nixpkgs/commit/1b1f25312dea83efcea0307e6407af5d9adc93aa) | `` ananicy: unstable-2021-11-05 -> unstable-2023-03-21 ``                         |
| [`7b0df0c0`](https://github.com/NixOS/nixpkgs/commit/7b0df0c04225a107e283a210cbee95f462d8ad7d) | `` ananicy-cpp-rules: init at unstable-2023-06-28 ``                              |
| [`aae2268e`](https://github.com/NixOS/nixpkgs/commit/aae2268e0a451c16570962945fffa8876df883d5) | `` nixos/ananicy-cpp: add rulesProvider ``                                        |
| [`ff28d7a9`](https://github.com/NixOS/nixpkgs/commit/ff28d7a9823583812c4edc366dcd1d39647bd38c) | `` nixos/ananicy: don't error if $out/ananicy-cpp doesn't exist ``                |
| [`b04a0492`](https://github.com/NixOS/nixpkgs/commit/b04a04929cccfaabf811a8442b9b03da1c7ea9fe) | `` nixos/ananicy: add extraTypes, extraCgroups ``                                 |
| [`d615ce6c`](https://github.com/NixOS/nixpkgs/commit/d615ce6c71cda43cdcb82f57ad103f21513818e2) | `` f3d: 2.0.0 -> 2.1.0 ``                                                         |
| [`9be0bfb5`](https://github.com/NixOS/nixpkgs/commit/9be0bfb5e06ce2d88b40df1235142f99389b39c4) | `` runCommand: don't set meta.position if meta is given ``                        |
| [`2b89bab3`](https://github.com/NixOS/nixpkgs/commit/2b89bab3064427407e9df8ac632544d5bcf80b7c) | `` maintainers: add exploitoverload ``                                            |
| [`9258734d`](https://github.com/NixOS/nixpkgs/commit/9258734d718d3416bbf958dfff4da28b66f474b2) | `` srb2: 2.2.10 -> 2.2.11 ``                                                      |
| [`a0a4354a`](https://github.com/NixOS/nixpkgs/commit/a0a4354a13f7c25bad03173ffa528d220dec5a63) | `` doc/reviewing-contributions: Remove wrong fetchpatch detail ``                |
| [`4920af40`](https://github.com/NixOS/nixpkgs/commit/4920af40fce2c56ae2c4fd08ad1ff8b6f1dc80b1) | `` doc/reviewing-contributions: Add points about patches ``                       |
| [`77d4f4fe`](https://github.com/NixOS/nixpkgs/commit/77d4f4feee0798084925a9b2affe6fa37dee97e8) | `` discourse.assets: work around `cannot execute: required file not found` ``     |