### PR TITLE
chore(flake/pre-commit-hooks): `87589fa4` -> `eb433bff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -374,11 +374,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1689553106,
-        "narHash": "sha256-RFFf6BbpqQB0l1ehAbgri9g9MGZkAY9UdiNotD9fG8Y=",
+        "lastModified": 1689668210,
+        "narHash": "sha256-XAATwDkaUxH958yXLs1lcEOmU6pSEIkatY3qjqk8X0E=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "87589fa438dd6d5b8c7c1c6ab2ad69e4663bb51f",
+        "rev": "eb433bff05b285258be76513add6f6c57b441775",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                          |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`f189105d`](https://github.com/cachix/pre-commit-hooks.nix/commit/f189105d2acf08f7719a4fe18cc347613fceedf3) | `` Handle package missing from stable channel `` |
| [`af02198e`](https://github.com/cachix/pre-commit-hooks.nix/commit/af02198e564aba9d4b4f3cf4683c66daf21bcb1d) | `` Add pre-commit-hook-ensure-sops ``            |