### PR TITLE
chore(flake/nixpkgs): `6cee3b58` -> `684c17c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689534811,
-        "narHash": "sha256-jnSUdzD/414d94plCyNlvTJJtiTogTep6t7ZgIKIHiE=",
+        "lastModified": 1689679375,
+        "narHash": "sha256-LHUC52WvyVDi9PwyL1QCpaxYWBqp4ir4iL6zgOkmcb8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6cee3b5893090b0f5f0a06b4cf42ca4e60e5d222",
+        "rev": "684c17c429c42515bafb3ad775d2a710947f3d67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`3f751bfd`](https://github.com/NixOS/nixpkgs/commit/3f751bfdf6d1086317d175b628a17690605cccd1) | `` nixos/bpftune: drop flaky tests ``                                               |
| [`d31e7c52`](https://github.com/NixOS/nixpkgs/commit/d31e7c52820c76402cacbfebb6634f51f0012a6c) | `` rclone: 1.63.0 -> 1.63.1 (#244073) ``                                            |
| [`62f5b9ee`](https://github.com/NixOS/nixpkgs/commit/62f5b9eeec65cc23e5e63ccd916afca6b80a3ca2) | `` gr-framework: init at 0.72.9 ``                                                  |
| [`f89973e3`](https://github.com/NixOS/nixpkgs/commit/f89973e36a307788f0edf4ab1729ba6f0a6258f6) | `` python310Packages.paddle_bfloat: build from source (#243898) ``                  |
| [`e5a20914`](https://github.com/NixOS/nixpkgs/commit/e5a20914cae9e8ac162f9bc557ce5e6bfcb869b6) | `` omnisharp-roslyn: 1.39.7 -> 1.39.8 ``                                            |
| [`71de4bca`](https://github.com/NixOS/nixpkgs/commit/71de4bcaecbfb839df1ad77ad030ffc9ef136883) | `` monsoon: fix rev ``                                                              |
| [`5938996c`](https://github.com/NixOS/nixpkgs/commit/5938996c18d800b98f4965698a8d02d46b7c427c) | `` python310Packages.casbin: 1.21.0 -> 1.22.0 ``                                    |
| [`5dd736df`](https://github.com/NixOS/nixpkgs/commit/5dd736dff724d87cd2df3e733b6cc389dd0f5a1a) | `` python310Packages.detectron2: cleanup ``                                         |
| [`083a9cb4`](https://github.com/NixOS/nixpkgs/commit/083a9cb41fcc9058d669e9aa6960cd8b2f1c36ff) | `` erlang_25: 25.3.2.3 -> 25.3.2.4 ``                                               |
| [`bb904f2a`](https://github.com/NixOS/nixpkgs/commit/bb904f2a21f162c441244610a34b8e7e2c03879c) | `` python310Packages.peaqevcore: 18.1.11 -> 19.0.0 ``                               |
| [`ebae1b9b`](https://github.com/NixOS/nixpkgs/commit/ebae1b9bc0f0f830e1e96a78b0fd8a9c5ca1f147) | `` python310Packages.chiavdf: 1.0.8 -> 1.0.9 ``                                     |
| [`d710935c`](https://github.com/NixOS/nixpkgs/commit/d710935cd424840efbf504ff9e18c3bc96e82cbb) | `` mergerfs: 2.35.1 -> 2.36.0 ``                                                    |
| [`0ec6cf51`](https://github.com/NixOS/nixpkgs/commit/0ec6cf5107516ecdd53ee5d2a7486d3b4fd80d6a) | `` terraform-providers.spotinst: 1.125.1 -> 1.126.0 ``                              |
| [`04146b0d`](https://github.com/NixOS/nixpkgs/commit/04146b0debc2c4b9fe9a063663915607c21d8118) | `` terraform-providers.signalfx: 7.0.0 -> 8.0.0 ``                                  |
| [`5c2c70be`](https://github.com/NixOS/nixpkgs/commit/5c2c70be4405cb1756940b686126ad884e5fc322) | `` terraform-providers.google-beta: 4.73.1 -> 4.73.2 ``                             |
| [`f925c283`](https://github.com/NixOS/nixpkgs/commit/f925c283afd63c6d93263d32dbf0668b281eb88c) | `` terraform-providers.gridscale: 1.21.0 -> 1.21.1 ``                               |
| [`0db56a3f`](https://github.com/NixOS/nixpkgs/commit/0db56a3f3033b3b7c4aa00f6c8cccd872580a2de) | `` terraform-providers.google: 4.73.1 -> 4.73.2 ``                                  |
| [`51a1351d`](https://github.com/NixOS/nixpkgs/commit/51a1351d0e7f1ea9fc74ae18fc6c3a8d20c57df6) | `` terraform-providers.gitlab: 16.1.0 -> 16.1.1 ``                                  |
| [`3e7753c8`](https://github.com/NixOS/nixpkgs/commit/3e7753c8e9bfa0d43f9af78ec6d990bd88d48dee) | `` terraform-providers.digitalocean: 2.28.1 -> 2.29.0 ``                            |
| [`1edff8f0`](https://github.com/NixOS/nixpkgs/commit/1edff8f04f47a29ecb7ae1d81a3776de503dfced) | `` esbuild: 0.18.13 -> 0.18.14 ``                                                   |
| [`1881de65`](https://github.com/NixOS/nixpkgs/commit/1881de655849efc0e1ae42da7c1416d049eb4190) | `` raycast: 1.55.1 -> 1.55.2 ``                                                     |
| [`5e3dcc35`](https://github.com/NixOS/nixpkgs/commit/5e3dcc35f4d43c2e522e7d8727abdf81fd0f321e) | `` supabase-cli: 1.75.6 -> 1.79.0 ``                                                |
| [`1334681c`](https://github.com/NixOS/nixpkgs/commit/1334681c75df3137dfeeaa31e96db82cf242b247) | `` datree: 1.9.10 -> 1.9.17 ``                                                      |
| [`2ed31639`](https://github.com/NixOS/nixpkgs/commit/2ed3163991e4723130c72456970c2643688567ee) | `` google-guest-agent: 20230707.00 -> 20230711.00 ``                                |
| [`6259ca2e`](https://github.com/NixOS/nixpkgs/commit/6259ca2edd76902d5c84225d6169fb32bcf4e44c) | `` topicctl: 1.9.1 -> 1.10.1 ``                                                     |
| [`5ea3d52b`](https://github.com/NixOS/nixpkgs/commit/5ea3d52bd6c1d2cd3e745232dac898706c4d4e08) | `` tbls: 1.68.0 -> 1.68.1 ``                                                        |
| [`4f5c68d9`](https://github.com/NixOS/nixpkgs/commit/4f5c68d977ab8c43b3e1a3298ed0d441f3a7c2a1) | `` griffe: 0.32.0 -> 0.32.1 ``                                                      |
| [`87f1c4f3`](https://github.com/NixOS/nixpkgs/commit/87f1c4f3f32c42ab35e8ce9be50fae068b3c4d99) | `` cargo-espflash: 2.0.0 -> 2.0.1 ``                                                |
| [`63213db6`](https://github.com/NixOS/nixpkgs/commit/63213db6158669a391a7e46f0b96537d0f56ce1a) | `` jackett: 0.21.462 -> 0.21.484 ``                                                 |
| [`b2827ad2`](https://github.com/NixOS/nixpkgs/commit/b2827ad23e14041d67be72998d7c7da6d8bcb904) | `` clj-kondo: 2023.05.26 -> 2023.07.13 ``                                           |
| [`775b0efe`](https://github.com/NixOS/nixpkgs/commit/775b0efe7b107e9a7363d439917f266a364eb84b) | `` prometheus-nginxlog-exporter: 1.10.0 -> 1.11.0 ``                                |
| [`a268072f`](https://github.com/NixOS/nixpkgs/commit/a268072f4ec055d0e96cd05f4642e0871b5b15c5) | `` msgpack-cxx: use finalAttrs pattern ``                                           |
| [`5107d158`](https://github.com/NixOS/nixpkgs/commit/5107d158ab05cb3ccac57ce224c23375e05d4aeb) | `` msgpack-c: use finalAttrs pattern ``                                             |
| [`40b2fa5e`](https://github.com/NixOS/nixpkgs/commit/40b2fa5ead8f28a37ac2ba04bb78868cf458703b) | `` python3Packages.duct-py: init at 0.6.4 ``                                        |
| [`9a654c1e`](https://github.com/NixOS/nixpkgs/commit/9a654c1e64286e7f23de9d8bdcefa26f92ca46d4) | `` Add zmitchell to maintainers ``                                                  |
| [`a22d4de3`](https://github.com/NixOS/nixpkgs/commit/a22d4de3a5989afcbcee9d7ef1ffa592e6b8818e) | `` erigon: 2.48.0 -> 2.48.1 ``                                                      |
| [`e1d0d9a0`](https://github.com/NixOS/nixpkgs/commit/e1d0d9a0cdb7dd7c11d302da776d6e29c390ff27) | `` istioctl: 1.18.0 -> 1.18.1 ``                                                    |
| [`0d0283a6`](https://github.com/NixOS/nixpkgs/commit/0d0283a6fab39fa6f4cf983d3595ecb35ca49251) | `` tailwindcss: 3.3.2 -> 3.3.3 ``                                                   |
| [`e3932a30`](https://github.com/NixOS/nixpkgs/commit/e3932a3040ee82717ca0c17afc29c97378629c21) | `` pineapple-pictures: support wayland ``                                           |
| [`3297ece1`](https://github.com/NixOS/nixpkgs/commit/3297ece10cb7cdcc5c166f2fdaeb8fc5f84d3ec6) | `` cri-o-unwrapped: 1.27.0 -> 1.27.1 ``                                             |
| [`5e586714`](https://github.com/NixOS/nixpkgs/commit/5e586714147b4160b4d1762d67f6400dfe5eee80) | `` vintagestory: add gigglesquid as maintainer ``                                   |
| [`38176f81`](https://github.com/NixOS/nixpkgs/commit/38176f81b00c02317d9d1cfdf52ff2e27f174202) | `` vintagestory: add support for experimental .net 7 build ``                       |
| [`c39f24e4`](https://github.com/NixOS/nixpkgs/commit/c39f24e4df69ded4f3c08507f08545905f0b5d52) | `` nextcloudApps: update package sets ``                                            |
| [`e44e079e`](https://github.com/NixOS/nixpkgs/commit/e44e079e806e49a42a82726982fbcdff63b9ba1d) | `` nextcloud-apps.json: adds memories ``                                            |
| [`2cd443b6`](https://github.com/NixOS/nixpkgs/commit/2cd443b691ce9bc9f3cb22b5207c9c7c8538e17d) | `` recyclarr: 5.1.0 -> 5.1.1 ``                                                     |
| [`41d57564`](https://github.com/NixOS/nixpkgs/commit/41d57564703300a5d795b380165d1cd4ee708b97) | `` python3Packages.maxminddb: fix build on Darwin ``                                |
| [`dbf9f5c0`](https://github.com/NixOS/nixpkgs/commit/dbf9f5c0db56b00589b21d273628992cedb8b0cd) | `` python3.pkgs.django-cacheops: fix on darwin (#243941) ``                         |
| [`9858973d`](https://github.com/NixOS/nixpkgs/commit/9858973daddbccb53a926265a5458e7e81791f8f) | `` nixos/vaultwarden: Fix Markdown syntax of link ``                                |
| [`85ea4214`](https://github.com/NixOS/nixpkgs/commit/85ea4214a3e63670dc0b8af56f16e03e78a05e5a) | `` sumo: 1.17.0 -> 1.18.0 ``                                                        |
| [`5136088b`](https://github.com/NixOS/nixpkgs/commit/5136088b472fb723588f62df6f59467d36b0e2c2) | `` sxhkd: apply patch for multiple layouts ``                                       |
| [`25a4bfde`](https://github.com/NixOS/nixpkgs/commit/25a4bfde79494db8a64ebecfdd3320d153034197) | `` python3Packages.pyramid-chameleon: unmark broken ``                              |
| [`6bfa5436`](https://github.com/NixOS/nixpkgs/commit/6bfa54365ba1e1be09a5545dcf91b55fdf08b41a) | `` maestro: 1.30.0 -> 1.30.3 ``                                                     |
| [`907421e6`](https://github.com/NixOS/nixpkgs/commit/907421e622cee1a3436b5e57dd9aa4a814b60d49) | `` dae: 0.2.0 -> 0.2.1 ``                                                           |
| [`a6aae555`](https://github.com/NixOS/nixpkgs/commit/a6aae555e2ae851ccf86c2b18df693258b0a35de) | `` ezquake: 3.2.3 -> 3.6.2 (#226174) ``                                             |
| [`1179c6c3`](https://github.com/NixOS/nixpkgs/commit/1179c6c3705509ba25bd35196fca507d2a227bd0) | `` bosh-cli: 7.3.0 -> 7.3.1 ``                                                      |
| [`7277d9a1`](https://github.com/NixOS/nixpkgs/commit/7277d9a1a6530729282d9a4cb084fcf76af4db81) | `` sqlcmd: 1.2.0 -> 1.2.1 ``                                                        |
| [`4be0901a`](https://github.com/NixOS/nixpkgs/commit/4be0901a28000af08dba62912d73ac62ffd89294) | `` runme: 1.4.1 -> 1.5.0 ``                                                         |
| [`422aa836`](https://github.com/NixOS/nixpkgs/commit/422aa836426d18951e2a107d5eb0ffa78fdd44b6) | `` micronaut: 3.9.4 -> 4.0.0 ``                                                     |
| [`162485b1`](https://github.com/NixOS/nixpkgs/commit/162485b1de0e570a1ee0a4717f3fda770d540f08) | `` monsoon: add changelog to meta ``                                                |
| [`4a716c50`](https://github.com/NixOS/nixpkgs/commit/4a716c50feec750263bee793ceb571be536dff19) | `` xastir: switch from imagemagick6 to graphicsmagick ``                            |
| [`99ce6d1b`](https://github.com/NixOS/nixpkgs/commit/99ce6d1bb5b84e48e33f3ae7f5492fdf0dfcf449) | `` qgroundcontrol: 4.2.6 -> 4.2.8 ``                                                |
| [`28f90732`](https://github.com/NixOS/nixpkgs/commit/28f90732f42c27fea2cc5ddbd66c27684be6b22a) | `` fluent-bit: 2.1.6 -> 2.1.7 ``                                                    |
| [`184dfbc8`](https://github.com/NixOS/nixpkgs/commit/184dfbc8a1c627a09fee4529c9c9b0e8ae64b81e) | `` bcc: 0.26.0 -> 0.28.0 (#240520) ``                                               |
| [`5aa2794e`](https://github.com/NixOS/nixpkgs/commit/5aa2794e179ece6066a20b7af8487960111709d0) | `` sozu: 0.15.1 -> 0.15.2 ``                                                        |
| [`655d4aae`](https://github.com/NixOS/nixpkgs/commit/655d4aae458c5b70fd1083ac80ef7c06f7976578) | `` okta-aws-cli: 1.0.2 -> 1.1.0 ``                                                  |
| [`52ba084d`](https://github.com/NixOS/nixpkgs/commit/52ba084db960522411d9427b32804ba371ffd9ba) | `` imgproxy: 3.18.1 -> 3.18.2 ``                                                    |
| [`e6dc17c3`](https://github.com/NixOS/nixpkgs/commit/e6dc17c315d747f810be36cb7de87b7e55c96cf5) | `` signalbackup-tools: 20230707 -> 20230716 ``                                      |
| [`14ef6934`](https://github.com/NixOS/nixpkgs/commit/14ef6934ca5cdf2a17c0dda30d4bf3d3e8ecff23) | `` ferretdb: 1.5.0 -> 1.6.0 (#243986) ``                                            |
| [`76a0d092`](https://github.com/NixOS/nixpkgs/commit/76a0d0928d5de933153e1709a5404dedeff4d808) | `` gridcoin-research: init at 5.4.5.0 ``                                            |
| [`08fda9a3`](https://github.com/NixOS/nixpkgs/commit/08fda9a34df44f3d7d279645846b3cd0038ceed4) | `` maintainers: add gigglesquid ``                                                  |
| [`456c0392`](https://github.com/NixOS/nixpkgs/commit/456c0392a0ebbf16b4cca1f63570c47d87de6ccf) | `` linux/patches: drop obsolete CVE-2023-32233 patch ``                             |
| [`10ff0a07`](https://github.com/NixOS/nixpkgs/commit/10ff0a076bdb4ba3138cc69e39f38e6e577c4d1d) | `` nixos/tests/kernel-generic: also expose rt kernels and linux_libre ``            |
| [`4a4636b5`](https://github.com/NixOS/nixpkgs/commit/4a4636b54448fbee76cc6cdfe96d429495f92928) | `` linux_rt_5_4: remove now-applied patch ``                                        |
| [`a8a1252b`](https://github.com/NixOS/nixpkgs/commit/a8a1252b0919c9d4f2b6d5f58c04412cffcae309) | `` nodePackages: update to latest ``                                                |
| [`080e97c7`](https://github.com/NixOS/nixpkgs/commit/080e97c7f970544d5dbb94164b1df3a5a62da864) | `` build-support: Add fetchpijul function. ``                                       |
| [`139259a3`](https://github.com/NixOS/nixpkgs/commit/139259a37711f4a38371ef47c391535ea8d00e90) | `` slskd: init module (#233648) ``                                                  |
| [`ae910ed9`](https://github.com/NixOS/nixpkgs/commit/ae910ed9b8b6fd040c452a968c8cd0dc0b2f5c75) | `` papermc: 1.19.3.375 -> 1.20.1.83 ``                                              |
| [`414c4b69`](https://github.com/NixOS/nixpkgs/commit/414c4b691ee66332e347d3b7cd48f1e83f459663) | `` monkeysAudio: 10.16 -> 10.17 ``                                                  |
| [`8a0d4e51`](https://github.com/NixOS/nixpkgs/commit/8a0d4e5106ea4bf0d9dae020fe049251e3ff3a29) | `` confetty: init at unstable-2022-11-05 ``                                         |
| [`196a89e1`](https://github.com/NixOS/nixpkgs/commit/196a89e1fe6567ad39a620a0f8eeb10262b9ece0) | `` yq-go: 4.34.1 -> 4.34.2 ``                                                       |
| [`b673a2ea`](https://github.com/NixOS/nixpkgs/commit/b673a2eaeba61b331b475078eb244d9a3a28ecfe) | `` python310Packages.tidalapi: 0.7.1 -> 0.7.2 ``                                    |
| [`0b1845d4`](https://github.com/NixOS/nixpkgs/commit/0b1845d417992f6419f416b0548e769855013a8f) | `` typer: init at unstable-2023-02-08 ``                                            |
| [`2fd1640d`](https://github.com/NixOS/nixpkgs/commit/2fd1640d60014b501933fc1e5e851639ed3640b4) | `` urbit: 2.10 -> 2.11 ``                                                           |
| [`f86bdb48`](https://github.com/NixOS/nixpkgs/commit/f86bdb48b7a8a91d89292ed21a3ec2881ebc0d08) | `` python310Packages.looseversion: 1.2.0 -> 1.3.0 ``                                |
| [`d237a731`](https://github.com/NixOS/nixpkgs/commit/d237a7318c3613b55469e80ae2c0d7ded901fca2) | `` nixos/samba-wsdd: add openFirewall option ``                                     |
| [`9fb59f21`](https://github.com/NixOS/nixpkgs/commit/9fb59f211deac5980b25638f08ecdbc4e227ac22) | `` libjwt: 1.15.3 -> 1.16.0 ``                                                      |
| [`2383c38e`](https://github.com/NixOS/nixpkgs/commit/2383c38e4e80c0869b019053dfab668a2771c4d3) | `` python311Packages.unearth: 0.9.1 -> 0.9.2 ``                                     |
| [`ff6db138`](https://github.com/NixOS/nixpkgs/commit/ff6db138bb780f58c1ee83c177636d04ba8be23d) | `` plantuml: 1.2023.9 -> 1.2023.10 ``                                               |
| [`529febf3`](https://github.com/NixOS/nixpkgs/commit/529febf315c3dc45a745b1326f0234633a1f92f3) | `` wishlist: 0.11.0 -> 0.12.0 ``                                                    |
| [`db975582`](https://github.com/NixOS/nixpkgs/commit/db975582f12570b51ab856f33499ed6a56c7b8cb) | `` cargo-local-registry: 0.2.5 -> 0.2.6 ``                                          |
| [`2bc81837`](https://github.com/NixOS/nixpkgs/commit/2bc8183744c426dc503ed6b6b34c8628ac091fd7) | `` xlockmore: 5.71 -> 5.72 ``                                                       |
| [`15edec16`](https://github.com/NixOS/nixpkgs/commit/15edec16c93a6c591855078ea8acb762f4966784) | `` VictoriaMetrics: 1.91.0 -> 1.91.3 (#242354) ``                                   |
| [`a88798a9`](https://github.com/NixOS/nixpkgs/commit/a88798a9907dbd61bcd7780e079cc6b75ef13374) | `` pulsar: 1.106.0 -> 1.107.1 ``                                                    |
| [`1c52dbd0`](https://github.com/NixOS/nixpkgs/commit/1c52dbd0f1a46f6a0eec88f2d54f746ee90aa020) | `` neovim-qt: fix desktop icon passthrough ``                                       |
| [`32610b4e`](https://github.com/NixOS/nixpkgs/commit/32610b4ecb5348f488e43eb4ffd71b9a9ef5deb6) | `` cargo-show-asm: 0.2.19 -> 0.2.20 ``                                              |
| [`167a5853`](https://github.com/NixOS/nixpkgs/commit/167a5853acbe8b2e4699d68b0d11bb2cdbf01b5e) | `` python310Packages.webargs: 8.2.0 -> 8.3.0 ``                                     |
| [`1f14a267`](https://github.com/NixOS/nixpkgs/commit/1f14a26765861a6dd071187b40b91ac42070e2ac) | `` activemq: 5.18.1 -> 5.18.2 ``                                                    |
| [`b8e23112`](https://github.com/NixOS/nixpkgs/commit/b8e231128d29387fd9f0c2f0f9e3fee3a4d5b9fd) | `` krew: 0.4.3 -> 0.4.4 ``                                                          |
| [`e096745b`](https://github.com/NixOS/nixpkgs/commit/e096745b76623c9d19ec6e588d34f68f3a1313db) | `` oh-my-posh: 17.9.0 -> 17.11.2 ``                                                 |
| [`1dafcf11`](https://github.com/NixOS/nixpkgs/commit/1dafcf11b3c9044ef237c2649136c0e83f205090) | `` riemann-c-client: fix sources location ``                                        |
| [`7a9d01d4`](https://github.com/NixOS/nixpkgs/commit/7a9d01d44c0ebfb00fb314f05fa2755888a0e18f) | `` seqkit: 2.4.0 -> 2.5.0 ``                                                        |
| [`e75ee0e2`](https://github.com/NixOS/nixpkgs/commit/e75ee0e29ca2da0bbbe1d210244e829286a04ba1) | `` clash-geoip: 20230612 -> 20230712 ``                                             |
| [`5e73f0c1`](https://github.com/NixOS/nixpkgs/commit/5e73f0c1c96cd09f1961d0d102d12c2641d0ac62) | `` nixos/lxd: fix default ui package ``                                             |
| [`66688cb7`](https://github.com/NixOS/nixpkgs/commit/66688cb7a13f365876da3cd0e944be75dd584b83) | `` chiaki4deck: init at 1.3.3 ``                                                    |
| [`f2c07100`](https://github.com/NixOS/nixpkgs/commit/f2c07100a75cdd03f2173e1b639a3392ed949ffe) | `` teams-for-linux: 1.1.11 -> 1.2.4 ``                                              |
| [`d914f16b`](https://github.com/NixOS/nixpkgs/commit/d914f16b33f3019f0c1dbe91330586388c74b20f) | `` scaleway-cli: 2.17.0 -> 2.18.0 ``                                                |
| [`6dc07a31`](https://github.com/NixOS/nixpkgs/commit/6dc07a318fb753c8be0bc9a68b9d609794aae7da) | `` nats-server: 2.9.19 -> 2.9.20 ``                                                 |
| [`5a4e1c0f`](https://github.com/NixOS/nixpkgs/commit/5a4e1c0f2a086c436b43679e4bf8a767a3e211fd) | `` thedesk: 24.1.2 -> 24.1.3 ``                                                     |
| [`b8e27780`](https://github.com/NixOS/nixpkgs/commit/b8e27780849944891f34def632cc25b4ab70addb) | `` steampipe: 0.20.8 -> 0.20.9 ``                                                   |
| [`0509afee`](https://github.com/NixOS/nixpkgs/commit/0509afee4ff3a6627070d17182227f988930f72d) | `` monsoon: 0.7.0 -> 0.8.0 ``                                                       |
| [`929965d6`](https://github.com/NixOS/nixpkgs/commit/929965d6ca206f1011771668ce47b6c80ccec0a6) | `` linkerd_edge: 23.7.1 -> 23.7.2 ``                                                |
| [`d77d4807`](https://github.com/NixOS/nixpkgs/commit/d77d48074020b16884211af0b47ef55c7c7da146) | `` v2ray-domain-list-community: 20230707041058 -> 20230717050659 ``                 |
| [`a08da459`](https://github.com/NixOS/nixpkgs/commit/a08da4592ce2448f4099f35c0a948f6eb8705bd5) | `` hydra_unstable: 2023-06-25 -> 2023-07-17 ``                                      |
| [`be25742a`](https://github.com/NixOS/nixpkgs/commit/be25742af91a797efcefcf8283a06630e9dbb1ad) | `` gleam: 0.30.0 -> 0.30.1 ``                                                       |
| [`bc8224ca`](https://github.com/NixOS/nixpkgs/commit/bc8224cab6eb57117193f3ac06fcc46d5775cd4c) | `` bpftune: unstable-2023-07-11 -> unstable-2023-07-14, enable parallel building `` |
| [`975bd53d`](https://github.com/NixOS/nixpkgs/commit/975bd53d395a4fb674d02ce7ccff82045e9fcd67) | `` bpftune: unstable-2023-05-30 -> unstable-2023-07-11 ``                           |
| [`4cd70e12`](https://github.com/NixOS/nixpkgs/commit/4cd70e125d1baabb0846bdbfd4d87cf69e5fed8a) | `` nixos/bpftune: init basic test ``                                                |
| [`b47c483b`](https://github.com/NixOS/nixpkgs/commit/b47c483bf8860ac9dbcc7d72a80f98bfd2b1584a) | `` nixos/bpftune: init ``                                                           |