### PR TITLE
chore(flake/home-manager): `44ba0184` -> `0cb3ac57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689791618,
-        "narHash": "sha256-+GbknQxvqytQDecu8vyAAUipP7DZexdckBbByykVJW0=",
+        "lastModified": 1689802112,
+        "narHash": "sha256-Se7oHV/L0dHTQ4xp8MvYafaVdkSzF04Hx5NeloUYHtM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "44ba0184376c1bf017b8f2646a6040fb66d9c3e8",
+        "rev": "0cb3ac57fca6b52c42e4c0f560185540ae1dfb6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`0cb3ac57`](https://github.com/nix-community/home-manager/commit/0cb3ac57fca6b52c42e4c0f560185540ae1dfb6c) | `` Translate using Weblate (Indonesian) ``              |
| [`2e2b24e5`](https://github.com/nix-community/home-manager/commit/2e2b24e5bcafad740a35ca07b2107624efa1c9e1) | `` Translate using Weblate (Ukrainian) ``               |
| [`975f5aa6`](https://github.com/nix-community/home-manager/commit/975f5aa643a08edf1c16a4510d1c3e008386976f) | `` Translate using Weblate (Spanish) ``                 |
| [`1c60851e`](https://github.com/nix-community/home-manager/commit/1c60851e5e50754e8547df22eab5e6d19aed7181) | `` Translate using Weblate (Swedish) ``                 |
| [`c707d4f5`](https://github.com/nix-community/home-manager/commit/c707d4f552bb91512c1df677b2d33ec6000c5230) | `` docs: hide `_module.*` from NixOS/nix-darwin docs `` |