### PR TITLE
chore(flake/lanzaboote): `bfc88266` -> `78f00a28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -221,11 +221,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689796182,
-        "narHash": "sha256-DTmddEfj/SK6G8nFMPtszj2vQTq00UQKjvP0dYzv568=",
+        "lastModified": 1689810112,
+        "narHash": "sha256-obnbGi7iSvJK77R2ZECgbWwYBFbS8n00czM4iO1zFx0=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "bfc88266639ffed2b61e8045ea71f4e02f713179",
+        "rev": "78f00a288f71765045db2c5dfc81165a2c7964f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                  |
| --------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`9cceec40`](https://github.com/nix-community/lanzaboote/commit/9cceec40088dc5cf3e62d5123c90aae0c53f2de4) | `` fix(deps): update all dependencies `` |