### PR TITLE
chore(flake/home-manager): `0cb3ac57` -> `1443abd2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -189,11 +189,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689802112,
-        "narHash": "sha256-Se7oHV/L0dHTQ4xp8MvYafaVdkSzF04Hx5NeloUYHtM=",
+        "lastModified": 1689875525,
+        "narHash": "sha256-fgUrFH3bMZ6R7qgBTfuTRGlkZXIkdyjndl6ZbExbjE8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0cb3ac57fca6b52c42e4c0f560185540ae1dfb6c",
+        "rev": "1443abd2696ec6bd6fb9701e6c26b277a27b4a3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`1443abd2`](https://github.com/nix-community/home-manager/commit/1443abd2696ec6bd6fb9701e6c26b277a27b4a3e) | `` script-directory: fix documentation link (#4258) `` |