### PR TITLE
chore(flake/nixpkgs): `684c17c4` -> `5df4d78d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -326,11 +326,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689679375,
-        "narHash": "sha256-LHUC52WvyVDi9PwyL1QCpaxYWBqp4ir4iL6zgOkmcb8=",
+        "lastModified": 1689850295,
+        "narHash": "sha256-fUYf6WdQlhd2H+3aR8jST5dhFH1d0eE22aes8fNIfyk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "684c17c429c42515bafb3ad775d2a710947f3d67",
+        "rev": "5df4d78d54f7a34e9ea1f84a22b4fd9baebc68d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`5a3eb102`](https://github.com/NixOS/nixpkgs/commit/5a3eb10245e6fbbbfc21b20a3a71f7f6279ace31) | `` kubevpn: init at 1.1.34 ``                                                 |
| [`d345ddaf`](https://github.com/NixOS/nixpkgs/commit/d345ddaf65bbada63057752ebf6f2efa58817db3) | `` nomad_1_5: 1.5.6 -> 1.5.7 ``                                               |
| [`2e60058b`](https://github.com/NixOS/nixpkgs/commit/2e60058b9539a05001f6b76f178c9e9857478f8a) | `` Revert "nixos/boot/stage-1: chase symlinks when copying binaries" ``       |
| [`d60110fd`](https://github.com/NixOS/nixpkgs/commit/d60110fd977181eb70c85534b88f757d4755a2f1) | `` ocamlPackages.js_of_ocaml: 5.3.0 → 5.4.0 ``                                |
| [`c6244cdd`](https://github.com/NixOS/nixpkgs/commit/c6244cdd0cba75e1aa98e33089baac39bd85cee4) | `` iperf: 3.13 -> 3.14 (#244367) ``                                           |
| [`29328e90`](https://github.com/NixOS/nixpkgs/commit/29328e90271cd1f3c1e980866f25a78cc6046ba6) | `` python310Packages.grad-cam: 1.4.6 -> 1.4.8 ``                              |
| [`68ff0a04`](https://github.com/NixOS/nixpkgs/commit/68ff0a0408e35398efe437142d9790b82bbd14fd) | `` maintainers: add mig4ng ``                                                 |
| [`ccb96418`](https://github.com/NixOS/nixpkgs/commit/ccb9641855ab3321fbc04a11fb9381acb5e4b479) | `` docker: 20.10.23 -> 20.10.25 ``                                            |
| [`3ec081d5`](https://github.com/NixOS/nixpkgs/commit/3ec081d54ebed5f8f308efbc0644f9e65ef297d9) | `` buck2: unstable-2023-07-15 -> unstable-2023-07-18 ``                       |
| [`5fb1e1c3`](https://github.com/NixOS/nixpkgs/commit/5fb1e1c3fa0d673f181cd8cac4d8b387f3d208cc) | `` buck2: add generated tag in update.sh script output ``                     |
| [`f1128f8c`](https://github.com/NixOS/nixpkgs/commit/f1128f8c73691d941e7a7ffcc82bc5689564d0ec) | `` logseq: 0.9.10 -> 0.9.11 ``                                                |
| [`8770c486`](https://github.com/NixOS/nixpkgs/commit/8770c4869711d2debc33573a6585e6b078393f7e) | `` fulcio: 1.3.3 -> 1.3.4 ``                                                  |
| [`ccad4417`](https://github.com/NixOS/nixpkgs/commit/ccad4417ae273538927169916c16d799cd1108ed) | `` anytype: 0.33.0 -> 0.33.3 ``                                               |
| [`c941659c`](https://github.com/NixOS/nixpkgs/commit/c941659cd3f286ce113cd83bfbd98119dcacf76c) | `` gitolite: 3.6.12 -> 3.6.13 ``                                              |
| [`eb7b7179`](https://github.com/NixOS/nixpkgs/commit/eb7b717920d9e885fa5794138d1de52758c36226) | `` gql: 0.4.0 -> 0.4.1 ``                                                     |
| [`9f15a356`](https://github.com/NixOS/nixpkgs/commit/9f15a356a9223b7a5be946754fcb08b825edf095) | `` minio-client: 2023-07-07T05-25-51Z -> 2023-07-11T23-30-44Z ``              |
| [`f403d880`](https://github.com/NixOS/nixpkgs/commit/f403d8801edf9ca88193a6dc5ebecb6327bb8d24) | `` cargo-binstall: 1.1.0 -> 1.1.1 ``                                          |
| [`f6aee698`](https://github.com/NixOS/nixpkgs/commit/f6aee698798e55c0c7f77853c66e1614b6ad83f9) | `` nomad_1_6: init ``                                                         |
| [`984a19f3`](https://github.com/NixOS/nixpkgs/commit/984a19f393afe3bf52c9d06083d00a1253210b1e) | `` ocamlformat: 0.25.1 -> 0.26.0 ``                                           |
| [`8dff9f64`](https://github.com/NixOS/nixpkgs/commit/8dff9f64ecb309e362b59dc099c090ae4f633481) | `` nixos/tests/osquery: init ``                                               |
| [`da65d1dd`](https://github.com/NixOS/nixpkgs/commit/da65d1dd20ab7cc0f5019d8357770b7ade2ceb0c) | `` nixos/osquery: init ``                                                     |
| [`a0393ca3`](https://github.com/NixOS/nixpkgs/commit/a0393ca30c4a4595ef3afa2bd3cd3e9ce49d182a) | `` osquery: init at 5.5.1 ``                                                  |
| [`c64b6656`](https://github.com/NixOS/nixpkgs/commit/c64b6656722a74467f5d6c53369e2a163b0ad765) | `` opensbi: 1.3 -> 1.3.1 ``                                                   |
| [`23c2d861`](https://github.com/NixOS/nixpkgs/commit/23c2d86124bb55a8d1024b25e9859347f7398a13) | `` grafana-agent: 0.34.3 -> 0.35.0 ``                                         |
| [`8c8ab9ee`](https://github.com/NixOS/nixpkgs/commit/8c8ab9ee573d63c7276ea2369d937b39a4f87bc2) | `` botan: add thillux as maintainer ``                                        |
| [`dc7750f6`](https://github.com/NixOS/nixpkgs/commit/dc7750f637911166f6ca5f03b5ee461c3b11499c) | `` botan3: flag macos as bad platform for now ``                              |
| [`47d94e86`](https://github.com/NixOS/nixpkgs/commit/47d94e8641cf03707fdfd8d686351d6b6b510410) | `` minesweep-rs: 6.0.14 -> 6.0.16 ``                                          |
| [`c42179e1`](https://github.com/NixOS/nixpkgs/commit/c42179e1c8d23cb667ce516b6e2bc67b5aaa7fce) | `` python310Packages.mkdocs-redirects: 1.2.0 -> 1.2.1 ``                      |
| [`f438d650`](https://github.com/NixOS/nixpkgs/commit/f438d650b48d7e92c762debc9c005ae325c33131) | `` waybar: 0.9.19 -> 0.9.20 ``                                                |
| [`65df0cb1`](https://github.com/NixOS/nixpkgs/commit/65df0cb1686d6e48f61e999b3dbc8c638949816f) | `` ledger-live-desktop: 2.62.2->2.64.1 ``                                     |
| [`120c81ac`](https://github.com/NixOS/nixpkgs/commit/120c81ac3f1378ce26e2fb4a7df3b7cc1beadb4a) | `` python310Packages.glyphslib: 6.2.3 -> 6.2.5 ``                             |
| [`9d793505`](https://github.com/NixOS/nixpkgs/commit/9d793505b9e2b5d58f50e60ebfa74d7bd0665cc4) | `` retroarch: auto-detect joypads ``                                          |
| [`310c1a14`](https://github.com/NixOS/nixpkgs/commit/310c1a143d6b5a083e0be5b899c7c4d6b00e3b88) | `` python3Packages.mkdocstrings-python: Remove upstreamed postPatch ``        |
| [`35c3c816`](https://github.com/NixOS/nixpkgs/commit/35c3c81655802b4d039754e0b2ba0248583e11b3) | `` retroarch-joypad-autoconfig: init at 1.15.0 ``                             |
| [`801cc447`](https://github.com/NixOS/nixpkgs/commit/801cc447659ee28e15b521f08e84df9c3d5f1bb6) | `` retroarch: add support for declarative settings ``                         |
| [`da8cdd13`](https://github.com/NixOS/nixpkgs/commit/da8cdd1332ba32363edce80d0c09a1f03555e66d) | `` python311Packages.dvc-objects: 0.23.0 -> 0.23.1 ``                         |
| [`9130b3ce`](https://github.com/NixOS/nixpkgs/commit/9130b3ce85477065f5dbdf14717ccf893f2e645a) | `` python310Packages.griffe: 0.32.1 -> 0.32.3 ``                              |
| [`fe6304df`](https://github.com/NixOS/nixpkgs/commit/fe6304df54d94a12b12ab9bdee04fdf325bf7851) | `` nixos/nexus: use mkPackageOption, cleanup ``                               |
| [`c317c0da`](https://github.com/NixOS/nixpkgs/commit/c317c0da89b0dfc4b1adb5021669e9d86a534639) | `` docker-buildx: 0.11.1 -> 0.11.2 ``                                         |
| [`60869e35`](https://github.com/NixOS/nixpkgs/commit/60869e358d6b1480e82d7e10c2e28a2a2aad0ff9) | `` python310Packages.pytomorrowio: 0.3.5 -> 0.3.6 ``                          |
| [`3702b173`](https://github.com/NixOS/nixpkgs/commit/3702b1734c7bef43eeb3160fb710f9f8b148c640) | `` jetbrains.plugins: update ``                                               |
| [`7f323a04`](https://github.com/NixOS/nixpkgs/commit/7f323a04505efe09080fdadeea0e454fc73d435b) | `` jetbrains: 2023.1.3 -> 2023.1.5 ``                                         |
| [`f4902e0f`](https://github.com/NixOS/nixpkgs/commit/f4902e0f677b31bceb2ad70c30d6f287204b0234) | `` maintainers/team-list: add nickcao to matrix ``                            |
| [`c9473da2`](https://github.com/NixOS/nixpkgs/commit/c9473da2a02ce02b4f732e6e3f93468f9fef715e) | `` dae: add support for geolocation databases ``                              |
| [`c0a57ce3`](https://github.com/NixOS/nixpkgs/commit/c0a57ce34fe2e503c789a52bfb25cc141bb516b3) | `` ueberzugpp: 2.8.8 -> 2.8.9 ``                                              |
| [`9bd452d3`](https://github.com/NixOS/nixpkgs/commit/9bd452d384b1e74d0b4afe6ee6a25e6f04d52233) | `` rambox: 2.1.3 -> 2.1.5 ``                                                  |
| [`00759717`](https://github.com/NixOS/nixpkgs/commit/007597179526ac13e3fd7a39169f6dc9b0ee03f1) | `` smb3-foundry: init at 1.2 ``                                               |
| [`22b12ba6`](https://github.com/NixOS/nixpkgs/commit/22b12ba6054a18ab6327fe3e82785fcccf2becf4) | `` py65: use toPythonApplication ``                                           |
| [`b437788d`](https://github.com/NixOS/nixpkgs/commit/b437788daf0e7022d1da393fe55a1dd558368ee4) | `` python310Packages.py65: use fetchFromGitHub and buildPythonPackage ``      |
| [`7b175966`](https://github.com/NixOS/nixpkgs/commit/7b175966e3c4eeeb42fae6d01c641b08cb5f9eae) | `` Move py65 to python-modules ``                                             |
| [`ceee0a21`](https://github.com/NixOS/nixpkgs/commit/ceee0a217ed1405820e57efa5600045d8605797b) | `` maintainers: add tomasajt ``                                               |
| [`02fdd607`](https://github.com/NixOS/nixpkgs/commit/02fdd60779bdcc1ef8e7a53df38da5c4208c830f) | `` python310Packages.findpython: 0.3.0 -> 0.3.1 ``                            |
| [`c0f68c48`](https://github.com/NixOS/nixpkgs/commit/c0f68c484e84a65fdd981eddb57d64f866697de6) | `` lefthook: 1.4.4 -> 1.4.5 ``                                                |
| [`16741d85`](https://github.com/NixOS/nixpkgs/commit/16741d85e3d1fc89808f778eb50b88cc52f3b5fc) | `` python310Packages.trimesh: 3.22.3 -> 3.22.4 ``                             |
| [`31dd174a`](https://github.com/NixOS/nixpkgs/commit/31dd174a9b16b75e5ee6ca3e1debc0aa3e343433) | `` verifpal: remove platform restriction (#244245) ``                         |
| [`ebefd134`](https://github.com/NixOS/nixpkgs/commit/ebefd134e5fc425c443b58b8c7b4eb7efbee3243) | `` hashcat: support darwin (#244289) ``                                       |
| [`df21f9e3`](https://github.com/NixOS/nixpkgs/commit/df21f9e39c902de6ba0cb9bd1f90869072582023) | `` collision: init at 3.5.0 ``                                                |
| [`c73f1019`](https://github.com/NixOS/nixpkgs/commit/c73f1019b91f1a04e08713f2d20b30ec1f8f6c60) | `` surrealdb-migrations: 0.9.11 -> 0.9.12 ``                                  |
| [`0a5d6328`](https://github.com/NixOS/nixpkgs/commit/0a5d6328384d4a2299f1d91cbe09ab0644adfb97) | `` python311Packages.angr: 9.2.59 -> 9.2.60 ``                                |
| [`d9ab7c6c`](https://github.com/NixOS/nixpkgs/commit/d9ab7c6c1552d1e0b92c36083bee892a3d2ae5b9) | `` python311Packages.cle: 9.2.59 -> 9.2.60 ``                                 |
| [`2a5b15da`](https://github.com/NixOS/nixpkgs/commit/2a5b15da30c6155dc914cdfd4edf43a604ecb6d6) | `` python311Packages.claripy: 9.2.59 -> 9.2.60 ``                             |
| [`8fe0c752`](https://github.com/NixOS/nixpkgs/commit/8fe0c752edfe559c34c191571c5b707f2216992c) | `` python311Packages.pyvex: 9.2.59 -> 9.2.60 ``                               |
| [`8e3e68cc`](https://github.com/NixOS/nixpkgs/commit/8e3e68cc05e44c160fd98bed95c046caff4e8b99) | `` python311Packages.ailment: 9.2.59 -> 9.2.60 ``                             |
| [`1316f404`](https://github.com/NixOS/nixpkgs/commit/1316f404291946ad9597a85968788c7eda0fccb3) | `` python311Packages.archinfo: 9.2.59 -> 9.2.60 ``                            |
| [`2b1d01d4`](https://github.com/NixOS/nixpkgs/commit/2b1d01d4553ef14e1c5be10f46a16320a41aeead) | `` rye: 0.6.0 -> 0.11.0 ``                                                    |
| [`ace6acaf`](https://github.com/NixOS/nixpkgs/commit/ace6acaf523f3d1fc5de88ab5f0e39eee6daa2bc) | `` python311Packages.rpds-py: 0.8.10 -> 0.9.2 ``                              |
| [`c6ab700c`](https://github.com/NixOS/nixpkgs/commit/c6ab700ce705fe17e0cda57cdebaa31de92e0aa2) | `` quark-engine: 23.4.1 -> 23.6.1 ``                                          |
| [`1f892619`](https://github.com/NixOS/nixpkgs/commit/1f892619d5c1440db305fd2bd9dfe7d4ad2f15f8) | `` microsoft-edge: ensure stable order for upstream sources ``                |
| [`3675a26b`](https://github.com/NixOS/nixpkgs/commit/3675a26bc66a3dce7227976728afcb54ffd6c808) | `` trealla: 2.22.11 -> 2.22.17 ``                                             |
| [`fd3f5471`](https://github.com/NixOS/nixpkgs/commit/fd3f5471b0c215c8e724d6670272baa166e6eee4) | `` nixos/mqtt2influxdb: init module ``                                        |
| [`dd4eec64`](https://github.com/NixOS/nixpkgs/commit/dd4eec64aba5101114d0d36ec138d864afd046e5) | `` nixos/bcg: init module ``                                                  |
| [`61a503c2`](https://github.com/NixOS/nixpkgs/commit/61a503c2fa941f3077ff0d6cd5ad264c592aab3b) | `` mqtt2influxdb: init at 1.5.2 ``                                            |
| [`c92947c2`](https://github.com/NixOS/nixpkgs/commit/c92947c26676732e77b9cab9a5d6120239240636) | `` bcf: init at 1.9.0 ``                                                      |
| [`b2ed9427`](https://github.com/NixOS/nixpkgs/commit/b2ed94276b282aa7788aaf9ba41c93e74297c2d2) | `` bcg: init at 1.17.0 ``                                                     |
| [`b225ae4a`](https://github.com/NixOS/nixpkgs/commit/b225ae4a611bbab4b0a6c047f3aa895d52ee9cc1) | `` bch: init at 1.2.1 ``                                                      |
| [`83352e93`](https://github.com/NixOS/nixpkgs/commit/83352e935ed628bc1d9599921fe73a877af8b0d6) | `` py-expression-eval: init with version 0.3.14 ``                            |
| [`4a526a90`](https://github.com/NixOS/nixpkgs/commit/4a526a901c3da5092e0ac7278ad49fe00940f0b4) | `` docker: fix starting containers with a local connection ``                 |
| [`d17441d1`](https://github.com/NixOS/nixpkgs/commit/d17441d10b5bd6cb6d7d7568fa15b16c4c4d1a4c) | `` python310Packages.gymnasium: 0.28.1 -> 0.29.0 ``                           |
| [`423dbe4c`](https://github.com/NixOS/nixpkgs/commit/423dbe4cb2e8a98dec0523fd79a58104f6e07ec1) | `` python310Packages.pynina: 0.3.0 -> 0.3.1 ``                                |
| [`d14e3684`](https://github.com/NixOS/nixpkgs/commit/d14e3684ee3b81ac1a02723bf7f12fb488249ca2) | `` sftpgo: 2.5.3 -> 2.5.4 ``                                                  |
| [`264c2b9b`](https://github.com/NixOS/nixpkgs/commit/264c2b9b0bd921228c49ed667cc47a8fabbc9a50) | `` sdrangel: 7.15.0 -> 7.15.1 ``                                              |
| [`d67a5ba2`](https://github.com/NixOS/nixpkgs/commit/d67a5ba2dd4c1cb53f543362a38880dd7da6904a) | `` kubernetes-polaris: 8.3.0 -> 8.4.0 ``                                      |
| [`0580710f`](https://github.com/NixOS/nixpkgs/commit/0580710f2379119b7a935e6319951d25439fddd7) | `` ocamlPackages.iri: 0.6.0 → 0.7.0 ``                                        |
| [`5849c65c`](https://github.com/NixOS/nixpkgs/commit/5849c65c52596b630c7e048666d7bda2127c5e66) | `` re-flex: 3.3.5 -> 3.3.6 ``                                                 |
| [`93da236e`](https://github.com/NixOS/nixpkgs/commit/93da236e055c2cde21d10226bdba6a510bec5f65) | `` terraform-providers.utils: 1.8.0 -> 1.9.0 ``                               |
| [`b0f3447c`](https://github.com/NixOS/nixpkgs/commit/b0f3447c6c9a70853311b755b3b961c7ccb023b8) | `` terraform-providers.snowflake: 0.68.1 -> 0.68.2 ``                         |
| [`af1b8fc7`](https://github.com/NixOS/nixpkgs/commit/af1b8fc7cf5feffb16996c8647ddc2898775ce4e) | `` terraform-providers.tfe: 0.46.0 -> 0.47.0 ``                               |
| [`18e4055b`](https://github.com/NixOS/nixpkgs/commit/18e4055b3d255e88f9e2b2d7298829a7f56da2bb) | `` terraform-providers.ovh: 0.31.0 -> 0.32.0 ``                               |
| [`9cfe0199`](https://github.com/NixOS/nixpkgs/commit/9cfe0199933bac84871ac1b6193d14b37c5775b0) | `` terraform-providers.huaweicloud: 1.52.0 -> 1.52.1 ``                       |
| [`73106d18`](https://github.com/NixOS/nixpkgs/commit/73106d18fc67c0575b230708505074e1f71ce768) | `` terraform-providers.launchdarkly: 2.12.2 -> 2.13.1 ``                      |
| [`91b805d3`](https://github.com/NixOS/nixpkgs/commit/91b805d301e040621ce720249cb33459974ed5a5) | `` terraform-providers.google-beta: 4.73.2 -> 4.74.0 ``                       |
| [`bf3ba035`](https://github.com/NixOS/nixpkgs/commit/bf3ba035c7b1d2e44ebbed603e31080b1ca8aa20) | `` terraform-providers.google: 4.73.2 -> 4.74.0 ``                            |
| [`227e851d`](https://github.com/NixOS/nixpkgs/commit/227e851dbacbf4aa9564fa4ac190af277dfe7a2f) | `` grpc_cli: 1.56.1 -> 1.56.2 ``                                              |
| [`a7de3966`](https://github.com/NixOS/nixpkgs/commit/a7de3966fa8459ae2f7355383dc98316493afd1f) | `` spicetify-cli: 2.20.3 -> 2.21.0 ``                                         |
| [`baf2e9b0`](https://github.com/NixOS/nixpkgs/commit/baf2e9b03656b6d4782916ee2c7a7cd7a6938478) | `` opensmt: 2.5.1 -> 2.5.2 ``                                                 |
| [`8613c713`](https://github.com/NixOS/nixpkgs/commit/8613c713110a1e4ecc3265c0557a0db5e08d9b27) | `` python310Packages.pinecone-client: 2.2.1 -> 2.2.2 ``                       |
| [`829e7cad`](https://github.com/NixOS/nixpkgs/commit/829e7cadb7dd82c93b72754078fb499c7da1a8ca) | `` bacon: 2.11.0 -> 2.11.1 ``                                                 |
| [`e9be50ab`](https://github.com/NixOS/nixpkgs/commit/e9be50aba8b9449c3e23ea63f142a884accc4014) | `` railway: 3.3.1 -> 3.4.0 ``                                                 |
| [`6c8a9a42`](https://github.com/NixOS/nixpkgs/commit/6c8a9a4263ed852c6126f8d1f43e0a8a65acff06) | `` evcxr: 0.15.0 -> 0.15.1 ``                                                 |
| [`9e011fc6`](https://github.com/NixOS/nixpkgs/commit/9e011fc60cb5b006dd253dcdce3e366e015d91e1) | `` tenacity: 1.3-beta2 -> 1.3.1 ``                                            |
| [`e482beb7`](https://github.com/NixOS/nixpkgs/commit/e482beb77b791c131e13b588978e46ae10fb3ba7) | `` qpwgraph: 0.4.4 -> 0.4.5 ``                                                |
| [`fa985950`](https://github.com/NixOS/nixpkgs/commit/fa9859507ba72b72f157b42da4ef0cc89a082074) | `` cereal: 1.3.0 -> 1.3.2 ``                                                  |
| [`ca2913d4`](https://github.com/NixOS/nixpkgs/commit/ca2913d463ec0f395e7d35b330278d1f10a45f5f) | `` nls: disable checks on Darwin ``                                           |
| [`0d6512ec`](https://github.com/NixOS/nixpkgs/commit/0d6512ecb1e26a948c2163b9e51365485998827c) | `` nickel: disable checks on Darwin ``                                        |
| [`578a1dc4`](https://github.com/NixOS/nixpkgs/commit/578a1dc41b2ff11c1b425f8f4fdfd1dc9fd1e94c) | `` rtx: 1.34.0 -> 1.34.1 ``                                                   |
| [`ac690207`](https://github.com/NixOS/nixpkgs/commit/ac6902075050a3656e29e192059a322aa0c16249) | `` treewide: remove unused nix-prefetch-github from shebangs ``               |
| [`551db130`](https://github.com/NixOS/nixpkgs/commit/551db1309ce4a9e4da588966d0f1623a948fed74) | `` plausible: adapt update script to new nix-prefetch-github ``               |
| [`205803c1`](https://github.com/NixOS/nixpkgs/commit/205803c1eed2ee6cf6480fae98a623162291775f) | `` lemmy-server, lemmy-ui: small update script cleanup ``                     |
| [`4fb8ca74`](https://github.com/NixOS/nixpkgs/commit/4fb8ca742045a67208da743fe13a88f5e6adac73) | `` lemmy-server, lemmy-ui: adapt update script to new nix-prefetch-github ``  |
| [`412b28f7`](https://github.com/NixOS/nixpkgs/commit/412b28f7b2b45370d393c55ec27ce8e7bc780083) | `` memos: adapt update script to new nix-prefetch-github ``                   |
| [`68d6f72e`](https://github.com/NixOS/nixpkgs/commit/68d6f72e5977ef9c379af35d45bae4034ab8f8a8) | `` matrix-hookshot: adapt update script to new nix-prefetch-github ``         |
| [`095ad569`](https://github.com/NixOS/nixpkgs/commit/095ad56963431f45ea9dcfb467889b12645fd739) | `` matrix-appservice-slack: adapt update script to new nix-prefetch-github `` |