### PR TITLE
chore(flake/nixpkgs): `5df4d78d` -> `9ca78564`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -326,11 +326,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689850295,
-        "narHash": "sha256-fUYf6WdQlhd2H+3aR8jST5dhFH1d0eE22aes8fNIfyk=",
+        "lastModified": 1689940971,
+        "narHash": "sha256-397xShPnFqPC59Bmpo3lS+/Aw0yoDRMACGo1+h2VJMo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5df4d78d54f7a34e9ea1f84a22b4fd9baebc68d0",
+        "rev": "9ca785644d067445a4aa749902b29ccef61f7476",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`3e8f4539`](https://github.com/NixOS/nixpkgs/commit/3e8f45393d5f34ff47ef1f55faa3cd76a195efe8) | `` Fix package ref ``                                                        |
| [`e43e2448`](https://github.com/NixOS/nixpkgs/commit/e43e2448161c0a2c4928abec4e16eae1516571bc) | `` ocamlPackages.ocamlformat-rpc-lib: 0.21.0 -> 0.26.0 ``                    |
| [`9140559d`](https://github.com/NixOS/nixpkgs/commit/9140559dd121ca98ce83cd8ba707ac8ba8d4ca9d) | `` faust1: drop ``                                                           |
| [`226cd70e`](https://github.com/NixOS/nixpkgs/commit/226cd70e036d3c03a91a8f0332a7e0821502dae0) | `` gleam: 0.30.1 -> 0.30.2 ``                                                |
| [`ce7cd063`](https://github.com/NixOS/nixpkgs/commit/ce7cd06305d9b370f1e1490536310fad094be885) | `` terraform-providers.vcd: 3.9.0 -> 3.10.0 ``                               |
| [`10179679`](https://github.com/NixOS/nixpkgs/commit/101796797804b8857595d9ecaa8a0152868ce1ce) | `` terraform-providers.scaleway: 2.25.0 -> 2.25.1 ``                         |
| [`9fd3e2c8`](https://github.com/NixOS/nixpkgs/commit/9fd3e2c8af63f1c5c73f88eee8734c1600e559a6) | `` terraform-providers.aws: 5.8.0 -> 5.9.0 ``                                |
| [`1380e076`](https://github.com/NixOS/nixpkgs/commit/1380e076e6450eae7f22a89ef6f82c6601deee53) | `` terraform-providers.datadog: 3.27.0 -> 3.28.0 ``                          |
| [`b46cb359`](https://github.com/NixOS/nixpkgs/commit/b46cb359cf459ce18087148f0ab754d8af3eb9b6) | `` terraform-providers.azurerm: 3.65.0 -> 3.66.0 ``                          |
| [`a6872d45`](https://github.com/NixOS/nixpkgs/commit/a6872d45fda701a422c9af93d5514f3e49f57df2) | `` python310Packages.pynisher: 1.0.5 -> 1.0.7 ``                             |
| [`e8818f10`](https://github.com/NixOS/nixpkgs/commit/e8818f1003d39c3e3f1fff7128ec8dd6bad22bd9) | `` esphome: 2023.6.5 -> 2023.7.0 ``                                          |
| [`ffc3eb7c`](https://github.com/NixOS/nixpkgs/commit/ffc3eb7c160c8bace077f0701ec6310ba0326fa0) | `` ebusd: new module ``                                                      |
| [`1f1dd245`](https://github.com/NixOS/nixpkgs/commit/1f1dd2457aa808aa5469e8aa71a0b05232ddafc6) | `` ebusd: init at 23.2 ``                                                    |
| [`324f713e`](https://github.com/NixOS/nixpkgs/commit/324f713eb92dbe7ca57c711b851332911a886684) | `` python310Packages.unstructured-inference: init at 0.5.5 ``                |
| [`156a238e`](https://github.com/NixOS/nixpkgs/commit/156a238e606906ab3c9cfb20d9c1a370a9911cc4) | `` exploitdb: 2023-07-18 -> 2023-07-21 ``                                    |
| [`f58e6874`](https://github.com/NixOS/nixpkgs/commit/f58e6874f3f06d4e5cdea58bec5da33f8b2f8ad3) | `` nixos/tests/installer: fix after #244449 ``                               |
| [`cfe43afc`](https://github.com/NixOS/nixpkgs/commit/cfe43afc0ab7ca3dc72443cfcc9312954572dcaa) | `` python311Packages.msoffcrypto-tool: update disabled ``                    |
| [`fac84fbd`](https://github.com/NixOS/nixpkgs/commit/fac84fbd5bd03d232d04a74636ece858bc97acbf) | `` python311Packages.identify: update disabled ``                            |
| [`8b511f5d`](https://github.com/NixOS/nixpkgs/commit/8b511f5d2c73779ea9ec79ab4a3a3fd223c36051) | `` python310Packages.types-urllib3: 1.26.25.13 -> 1.26.25.14 ``              |
| [`b5daaeea`](https://github.com/NixOS/nixpkgs/commit/b5daaeea906e2c38a560e09ab1acbee8dfc30b96) | `` codeberg-cli: init at v0.3.5 ``                                           |
| [`ba4fa2ae`](https://github.com/NixOS/nixpkgs/commit/ba4fa2ae17843ad9e542b05d9e4c04c76373f4c9) | `` qtcreator-qt6: 10.0.2 -> 11.0.0 ``                                        |
| [`26c30972`](https://github.com/NixOS/nixpkgs/commit/26c309724175a7fed5424fbedcf297b652e47577) | `` python310Packages.google-cloud-bigquery: 3.11.3 -> 3.11.4 ``              |
| [`55e7f425`](https://github.com/NixOS/nixpkgs/commit/55e7f425a2d8a8860d5746b36554064b5aabf7ea) | `` git-interactive-rebase-tool: 2.2.1 -> 2.3.0, drop intactive maintainer `` |
| [`93ce75f0`](https://github.com/NixOS/nixpkgs/commit/93ce75f033dc66635b99d14a491b6046879fde7f) | `` python310Packages.google-cloud-container: 2.26.0 -> 2.27.0 ``             |
| [`02ce2e9c`](https://github.com/NixOS/nixpkgs/commit/02ce2e9c86885fa0f46ae62a1f2675d54a6994be) | `` fetchsvnssh: clean up md5 references ``                                   |
| [`63804228`](https://github.com/NixOS/nixpkgs/commit/63804228e5656250afb0a8cee2f25370010cc2e2) | `` fetchgit: clean up md5 references ``                                      |
| [`a96b4663`](https://github.com/NixOS/nixpkgs/commit/a96b4663966302ec246face5652a81fc63377b40) | `` fetchdarcs: clean up md5 references ``                                    |
| [`4c9ed318`](https://github.com/NixOS/nixpkgs/commit/4c9ed3189c92355b7e6e25271c8a26b3277f4f51) | `` fetchhg: clean up md5 references ``                                       |
| [`eadaf810`](https://github.com/NixOS/nixpkgs/commit/eadaf81055e0595f7592ce422f6a31c108bde168) | `` fetchsvn: clean up md5 references ``                                      |
| [`6f30e0a9`](https://github.com/NixOS/nixpkgs/commit/6f30e0a9062685bd7aa3b9cf025b31f32af0463f) | `` fetchurl: clean up md5 references ``                                      |
| [`12ecdc25`](https://github.com/NixOS/nixpkgs/commit/12ecdc253bc6ed081268e3eaef86cd1a5c533773) | `` elixir_1_15: 1.15.2 -> 1.15.4 ``                                          |
| [`e36cfd89`](https://github.com/NixOS/nixpkgs/commit/e36cfd89164434d0674e9bdf4225963738c2d967) | `` maskromtool: 2023-06-17 -> 2023-07-20 ``                                  |
| [`ea15bdfe`](https://github.com/NixOS/nixpkgs/commit/ea15bdfef5c68ca12129f8199ffdbc5eb1f6deeb) | `` cartridges: 2.0.4 -> 2.0.5 ``                                             |
| [`280eb2a4`](https://github.com/NixOS/nixpkgs/commit/280eb2a4028a30dbd43e089e13fc1c0975e5294e) | `` cargo-expand: 1.0.61 -> 1.0.62 ``                                         |
| [`9f4b5b75`](https://github.com/NixOS/nixpkgs/commit/9f4b5b7530716f7e8eb03cf681e1d2d34da0fe30) | `` factorio: 1.1.80 -> 1.1.87 ``                                             |
| [`929e33d3`](https://github.com/NixOS/nixpkgs/commit/929e33d35763e386a7a5aacd40497b6c003ebb36) | `` static-web-server: 2.20.0 -> 2.20.1 ``                                    |
| [`4448782a`](https://github.com/NixOS/nixpkgs/commit/4448782a32c9186a6a875e55d9bff0c0e26d1a69) | `` nimPackages.eris: 20230201 -> 20230716 ``                                 |
| [`152ca726`](https://github.com/NixOS/nixpkgs/commit/152ca72688b645ed86dae95ccfc4110efecbb90a) | `` nimPackages.illwill: 0.3.0 -> 0.3.1 ``                                    |
| [`cff4e7d6`](https://github.com/NixOS/nixpkgs/commit/cff4e7d64c0ed0bfc376e6644a684ba6606913f3) | `` nimPackages.preserves, nimPackages.syndicate: 20221102 -> 20230530 ``     |
| [`ca774cbd`](https://github.com/NixOS/nixpkgs/commit/ca774cbdf19b2cc4c156783f00d24e09bdb95a34) | `` nimPackages.hashlib: init 1.0.1 ``                                        |
| [`5c2f41e5`](https://github.com/NixOS/nixpkgs/commit/5c2f41e5c9a0ebc8d3f75a8409cb7f684a2435b7) | `` nimPackages.cbor: 20230310 -> 20230619 ``                                 |
| [`7318bbd9`](https://github.com/NixOS/nixpkgs/commit/7318bbd95a6bce3b8f7ab88763bec7b6f78bea8b) | `` nimPackages.taps: 20221228 -> 20230331 ``                                 |
| [`bcebe4a1`](https://github.com/NixOS/nixpkgs/commit/bcebe4a1ee3ea727460a49dbc521ab4817da6cf1) | `` oculante: 0.6.68 -> 0.6.69 ``                                             |
| [`f8b4de3f`](https://github.com/NixOS/nixpkgs/commit/f8b4de3f94e1bbdc2162318de9f9481ca1918221) | `` unpoller: 2.7.14 -> 2.7.20 ``                                             |
| [`9b35822c`](https://github.com/NixOS/nixpkgs/commit/9b35822cc24912b7371f163098d4a85a15ee1c4e) | `` kalker: 2.0.3 -> 2.0.4 ``                                                 |
| [`5715a24a`](https://github.com/NixOS/nixpkgs/commit/5715a24aed375e171945073cfe5b205644056fca) | `` gruvbox-gtk-theme: unstable-2022-12-09 -> unstable-2023-5-26 ``           |
| [`3f34f371`](https://github.com/NixOS/nixpkgs/commit/3f34f3710fbf46703e4ed98fe5e6fbe1323382b3) | `` gtree: 1.8.6 -> 1.8.7 ``                                                  |
| [`ecfffdbb`](https://github.com/NixOS/nixpkgs/commit/ecfffdbba847b3b7ab64f0a8508ac6a383d5af1b) | `` runme: 1.5.0 -> 1.5.2 ``                                                  |
| [`b61919e5`](https://github.com/NixOS/nixpkgs/commit/b61919e5e0b4a6ad12eededfee4af703a9182c4e) | `` nixos/gitea: set service type to `notify` ``                              |
| [`e890b7ef`](https://github.com/NixOS/nixpkgs/commit/e890b7efb29ed7fd73928671ee9e280eb9698e77) | `` python311Packages.aiosomecomfort: 0.0.14 -> 0.0.15 ``                     |
| [`13b91eb1`](https://github.com/NixOS/nixpkgs/commit/13b91eb1a17177c4002739de7086091fea73a37b) | `` python311Packages.msoffcrypto-tool: 5.0.1 -> 5.1.1 ``                     |
| [`478a25b0`](https://github.com/NixOS/nixpkgs/commit/478a25b053de3ea1515601084cb3ad07606b0516) | `` python311Packages.aioesphomeapi: 15.1.6 -> 15.1.13 ``                     |
| [`275cc53e`](https://github.com/NixOS/nixpkgs/commit/275cc53e29b7520d990de2fe3879a7e078c9ec2a) | `` python311Packages.flux-led: 0.28.37 -> 1.0.0 ``                           |
| [`c5fed129`](https://github.com/NixOS/nixpkgs/commit/c5fed12944ca4ed90df837fe029bc7c615e24c58) | `` python311Packages.pipdeptree: 2.9.5 -> 2.10.2 ``                          |
| [`b404f612`](https://github.com/NixOS/nixpkgs/commit/b404f612d381427df4050579a4a5184102ea95dc) | `` python311Packages.pymazda: 0.3.9 -> 0.3.10 ``                             |
| [`d20ff6f7`](https://github.com/NixOS/nixpkgs/commit/d20ff6f764230148a2ce950b1e842e9634261bc5) | `` echidna: 2.0.5 -> 2.2.1 ``                                                |
| [`ef2752b8`](https://github.com/NixOS/nixpkgs/commit/ef2752b8068af39d6be9cc995a2e166cf182ef7d) | `` Remove inactive maintainer lluchs ``                                      |
| [`2014e8ca`](https://github.com/NixOS/nixpkgs/commit/2014e8cad073d7c82d9b7681fa7dc8f8204f9ada) | `` moltenvk: 1.2.3 -> 1.2.4 (#242096) ``                                     |
| [`26a9e6d4`](https://github.com/NixOS/nixpkgs/commit/26a9e6d48210528fce2d72bc647ca9814b68ad49) | `` cargo-leptos: 0.1.8 -> 0.1.11 ``                                          |
| [`3d774b44`](https://github.com/NixOS/nixpkgs/commit/3d774b445340d532d01ce968a29bf781d5459fd9) | `` util-linux: Fix build on non-Linux ``                                     |
| [`3fcbabcc`](https://github.com/NixOS/nixpkgs/commit/3fcbabcc2989cac8e026b2d4c3a9bcbcdc831578) | `` echidna: add new maintainer hellwolf ``                                   |
| [`885af0dc`](https://github.com/NixOS/nixpkgs/commit/885af0dcdbdf1ab79648f18b7fc89e48790a3297) | `` python311Packages.slither-analyzer: 0.9.2 -> 0.9.6 ``                     |
| [`6c35238e`](https://github.com/NixOS/nixpkgs/commit/6c35238e62ddeb763a783325a2e6969577726205) | `` python311Packages.slither-analyzer: add new maintainer hellwolf ``        |
| [`759d063e`](https://github.com/NixOS/nixpkgs/commit/759d063ee616fbf59b071a0e4e0d166e6c2a0fb9) | `` python311Packages.crytic-compile: 0.3.0 -> 0.3.3 ``                       |
| [`994d3aeb`](https://github.com/NixOS/nixpkgs/commit/994d3aeb30fe4d91da1f92543fae4b3f3b33948b) | `` python311Packages.crytic-compile: add new maintainer hellwolf ``          |
| [`ebcb6813`](https://github.com/NixOS/nixpkgs/commit/ebcb68135f00cda38f54a52ec3ca73db26fb4d7c) | `` openssh: 9.3p1 -> 9.3p2 (#244402) ``                                      |
| [`69267c22`](https://github.com/NixOS/nixpkgs/commit/69267c22f169133a4c16a91212f109974740d17a) | `` nixos/stage-1: fix stripping ``                                           |
| [`f7c9fe8e`](https://github.com/NixOS/nixpkgs/commit/f7c9fe8ebae37afa83a5f4c556330194bef53eab) | `` go-mockery: 2.20.2 -> 2.32.0 ``                                           |
| [`a6c10d43`](https://github.com/NixOS/nixpkgs/commit/a6c10d43457a1ae6c51929f0a09238b467510016) | `` gtkradiant: add packs for more games ``                                   |
| [`5f92ded4`](https://github.com/NixOS/nixpkgs/commit/5f92ded45956def60fe7f363053e7ee8cc8f7799) | `` gtkradiant: unstable-2022-07-31 -> unstable-2023-04-24 ``                 |
| [`199d7bd5`](https://github.com/NixOS/nixpkgs/commit/199d7bd52eb7e1e565298c24c32fa94df1395fb4) | `` trenchbroom: 2022.1 -> 2023.1 ``                                          |
| [`ff968f9f`](https://github.com/NixOS/nixpkgs/commit/ff968f9f24397efb3bfcaee45418ac178cd1e89a) | `` python311Packages.iocextract: 1.15.2 -> 1.16.0 ``                         |
| [`d9ba9731`](https://github.com/NixOS/nixpkgs/commit/d9ba9731a4b798c2814e8bf9e2fc9908085dd632) | `` python311Packages.identify: 2.5.24 -> 2.5.25 ``                           |
| [`ecf50319`](https://github.com/NixOS/nixpkgs/commit/ecf503196863c722109077b1afd558c4db5cf35e) | `` python311Packages.aiohomekit: 2.6.7 -> 2.6.9 ``                           |
| [`72a96c29`](https://github.com/NixOS/nixpkgs/commit/72a96c2970a42ded560ab47255d44d985a28162d) | `` python311Packages.bleak-retry-connector: 3.0.2 -> 3.1.0 ``                |
| [`35e4ca1c`](https://github.com/NixOS/nixpkgs/commit/35e4ca1c1116058cff28be6e3d670c7947ae5915) | `` python311Packages.bluetooth-adapters: 0.15.4 -> 0.16.0 ``                 |
| [`1991c4c2`](https://github.com/NixOS/nixpkgs/commit/1991c4c24118dda242c35ebface4341304a9bbe1) | `` python311Packages.bluetooth-data-tools: 1.3.0 -> 1.6.0 ``                 |
| [`7f365d7b`](https://github.com/NixOS/nixpkgs/commit/7f365d7b0ae3cf38ebfe30734618950a34ba9110) | `` python311Packages.xiaomi-ble: 0.18.2 -> 0.18.2 ``                         |
| [`14e5a57f`](https://github.com/NixOS/nixpkgs/commit/14e5a57fb973ec10402406f510ba5a8b4d836521) | `` python311Packages.sensor-state-data: 2.16.1 -> 2.17.1 ``                  |
| [`5db1d9b8`](https://github.com/NixOS/nixpkgs/commit/5db1d9b8c73c8c42a33134cbf9e814dc7e61703a) | `` python311Packages.yalexs-ble: 2.2.0 -> 2.2.2 ``                           |
| [`f94daad3`](https://github.com/NixOS/nixpkgs/commit/f94daad3168159f6198757060c40768fda428d61) | `` python311Packages.referencing: 0.29.1 -> 0.30.0 ``                        |
| [`9ad3f667`](https://github.com/NixOS/nixpkgs/commit/9ad3f66711aee9a5a0d18afff1c0c374c255a310) | `` python311Packages.pyvesync: 2.1.7 -> 2.1.8 ``                             |
| [`704db178`](https://github.com/NixOS/nixpkgs/commit/704db1784bcbf6bd6bc7382aaf206f46fde1b188) | `` python311Packages.pontos: 23.7.6 -> 23.7.7 ``                             |
| [`2c03126b`](https://github.com/NixOS/nixpkgs/commit/2c03126bc9147c9dd910946c57d3a063e8f9d9ef) | `` python311Packages.plugwise: 0.31.6 -> 0.31.7 ``                           |
| [`c4d7ae4e`](https://github.com/NixOS/nixpkgs/commit/c4d7ae4ebe7a30ed968862953021673f796dd25d) | `` python311Packages.peaqevcore: 19.0.0 -> 19.0.1 ``                         |
| [`8395641e`](https://github.com/NixOS/nixpkgs/commit/8395641e731ad997c8c880fc2f323de9ba459f19) | `` amass: 3.23.3 -> 4.0.1 ``                                                 |
| [`5689d776`](https://github.com/NixOS/nixpkgs/commit/5689d776c321ae741f5fa1596e2af638b1a86ede) | `` deno: 1.35.1 -> 1.35.2 ``                                                 |
| [`4b7ad2c7`](https://github.com/NixOS/nixpkgs/commit/4b7ad2c7eab37e3ade26e560a5c01a4b5a4321c3) | `` jesec-rtorrent: Add patch to prevent segfault ``                          |
| [`675e71c8`](https://github.com/NixOS/nixpkgs/commit/675e71c8f921a1c42a1865e44f8d7a374f5d11b2) | `` linux/hardened/patches/6.4: 6.4.3-hardened1 → 6.4.4-hardened1 ``          |
| [`455dbe71`](https://github.com/NixOS/nixpkgs/commit/455dbe71a272374870f53d699a8250ad8fdcb2b0) | `` linux/hardened/patches/6.3: 6.3.12-hardened1 → 6.3.13-hardened1 ``        |
| [`829b85f7`](https://github.com/NixOS/nixpkgs/commit/829b85f78056405e3a3e4eacebc9c58831e6228b) | `` linux/hardened/patches/6.1: 6.1.38-hardened1 → 6.1.39-hardened1 ``        |
| [`ad22fa6b`](https://github.com/NixOS/nixpkgs/commit/ad22fa6bab3f0d7f183b80321fc433a72cf7b095) | `` linux: 6.4.3 -> 6.4.4 ``                                                  |
| [`1ebfd26d`](https://github.com/NixOS/nixpkgs/commit/1ebfd26de10d8190ab5d964f65ba49bdd6c53a2c) | `` linux: 6.3.12 -> 6.3.13 ``                                                |
| [`bd015ca4`](https://github.com/NixOS/nixpkgs/commit/bd015ca446fe010d0c181b2c8df7a9606709350e) | `` linux: 6.1.38 -> 6.1.39 ``                                                |
| [`151c175a`](https://github.com/NixOS/nixpkgs/commit/151c175a8528864be449ba30df62ef4c2c93a25d) | `` jetbrains.goland: fix build with plugins ``                               |
| [`abd6d820`](https://github.com/NixOS/nixpkgs/commit/abd6d82002a13c0737ec3962254388c86a94eb0b) | `` jetbrains.clion: fix build with plugins ``                                |
| [`c9fbb6fe`](https://github.com/NixOS/nixpkgs/commit/c9fbb6fe87a7f34c43e307268dd4c59bf492c330) | `` jetbrains.*: fix build for most IDEs with plugins ``                      |
| [`ea023517`](https://github.com/NixOS/nixpkgs/commit/ea023517b7892242ff61866f093ef3edacc4aff5) | `` jetbrains.plugins.tests.default: init ``                                  |
| [`24833f08`](https://github.com/NixOS/nixpkgs/commit/24833f08a09c26f92f3f139e88cfce64211f3e1c) | `` jetbrains.plugins: add vscode keymap ``                                   |
| [`cc102eb9`](https://github.com/NixOS/nixpkgs/commit/cc102eb91666baefab71c1cd715fa1724e751d12) | `` jetbrains.dataspell: format ``                                            |
| [`c87e4eb5`](https://github.com/NixOS/nixpkgs/commit/c87e4eb5c3066be645994f3abf3b9da679b624fe) | `` cool-retro-term: 1.1.1 -> 1.2.0 ``                                        |
| [`e74c3b4a`](https://github.com/NixOS/nixpkgs/commit/e74c3b4a8e9ca8120a76ec4ab958abd9097eca29) | `` frogmouth: 0.7.0 -> 0.8.0 ``                                              |
| [`7c146071`](https://github.com/NixOS/nixpkgs/commit/7c14607112d36b6574dba2f82e9163537904b4c9) | `` runc: 1.1.7 -> 1.1.8 ``                                                   |
| [`4c6d4170`](https://github.com/NixOS/nixpkgs/commit/4c6d4170f2ac4c92dbf3cf60cd4c7b96cae18d2e) | `` blackbox-terminal: 0.13.2 -> 0.14.0 ``                                    |
| [`771c6008`](https://github.com/NixOS/nixpkgs/commit/771c6008a99696eb64438b4ff3645df3c2098f0e) | `` jami: 20230323.0 -> 20230619.1 ``                                         |
| [`c6b3caa1`](https://github.com/NixOS/nixpkgs/commit/c6b3caa1fdd87d7528daa8a26a0894ded828ddc4) | `` searxng: freeze version ``                                                |
| [`ffaadc7b`](https://github.com/NixOS/nixpkgs/commit/ffaadc7b70686e25af496c5ec2c4491ad3656b94) | `` aliases: remove edited suffix in comment ``                               |
| [`a63cd87d`](https://github.com/NixOS/nixpkgs/commit/a63cd87da97125f8509b82cd48c8256906556372) | `` pyload-ng: init at 0.5.0b3.dev72 ``                                       |
| [`812e0432`](https://github.com/NixOS/nixpkgs/commit/812e0432fd9f70d3d1ea463faa6a30d9340a8a59) | `` python3Packages.flask-themes2: init at 1.0.0 ``                           |
| [`d6ff2965`](https://github.com/NixOS/nixpkgs/commit/d6ff2965dbeb67fcfe49d386f235d14776d1b7d9) | `` terraform-providers.tencentcloud: 1.81.14 -> 1.81.15 ``                   |
| [`0a2e9d07`](https://github.com/NixOS/nixpkgs/commit/0a2e9d073bb4da93c8b77eab6fc69be98f8826d1) | `` terraform-providers.oci: 5.4.0 -> 5.5.0 ``                                |
| [`f38ecdcc`](https://github.com/NixOS/nixpkgs/commit/f38ecdcc5aa43048e868b7215de1ea5567b88dfc) | `` terraform-providers.spotinst: 1.126.0 -> 1.127.0 ``                       |
| [`93d16047`](https://github.com/NixOS/nixpkgs/commit/93d160476b4724d76002ea9a57e64c33bb7f2c57) | `` terraform-providers.scaleway: 2.24.0 -> 2.25.0 ``                         |
| [`3a7c90bb`](https://github.com/NixOS/nixpkgs/commit/3a7c90bb08b97db44efeabfe54a6f1009b5ff557) | `` terraform-providers.mongodbatlas: 1.10.1 -> 1.10.2 ``                     |
| [`bd95a7a6`](https://github.com/NixOS/nixpkgs/commit/bd95a7a68364c321bb472577383f3bdf917734aa) | `` terraform-providers.linode: 2.5.1 -> 2.5.2 ``                             |
| [`8781d90d`](https://github.com/NixOS/nixpkgs/commit/8781d90d7d2cbff1b470a8dad57d00433bbd461d) | `` terraform-providers.launchdarkly: 2.13.1 -> 2.13.2 ``                     |
| [`c118bb4f`](https://github.com/NixOS/nixpkgs/commit/c118bb4f9ad9497c951a9aa3fbe142df837fc329) | `` elixir: make mix interpreter path absolute ``                             |
| [`e1711462`](https://github.com/NixOS/nixpkgs/commit/e17114622d583332ae96e226a398a500df83878b) | `` nodePackages: update to latest ``                                         |
| [`afb157b3`](https://github.com/NixOS/nixpkgs/commit/afb157b3feadc843e6532ea080e1ed8a7087b59f) | `` cozette: 1.20.1 -> 1.21.0 ``                                              |
| [`c2f683a5`](https://github.com/NixOS/nixpkgs/commit/c2f683a58af2fa070d9579a0157c71e072f5a6e1) | `` hugo: 0.115.3 -> 0.115.4 ``                                               |
| [`913b78f8`](https://github.com/NixOS/nixpkgs/commit/913b78f8790b4710ccaabc124a5272d9d32dae02) | `` searxng: unstable-2023-06-26 -> unstable-2023-07-19 ``                    |
| [`1ca68dee`](https://github.com/NixOS/nixpkgs/commit/1ca68deebd5a6d14fde1428cfce16ccb36c11efc) | `` nixos/networkd: fix netdev MAC addresses asserts ``                       |
| [`6ffb2cbe`](https://github.com/NixOS/nixpkgs/commit/6ffb2cbeabbc780d8baf72f40b0731aa74bb664b) | `` git-backdate: init at 2023-07-19 ``                                       |
| [`45e44dd4`](https://github.com/NixOS/nixpkgs/commit/45e44dd407ba4b86191543b8108a4cd4a12cfb09) | `` linuxPackages: set IP_ROUTE_MULTIPATH to yes ``                           |
| [`1383fc0c`](https://github.com/NixOS/nixpkgs/commit/1383fc0c1c29f229734a10e580fdd0ed977305ba) | `` qt6: 6.5.1 -> 6.5.2 ``                                                    |
| [`839306d4`](https://github.com/NixOS/nixpkgs/commit/839306d4ce5f75820d611f6e7e2ac1a1c94c0ee6) | `` millet: 0.12.6 -> 0.12.7 ``                                               |
| [`f6a87304`](https://github.com/NixOS/nixpkgs/commit/f6a87304624454598dfcc51cbf672e9ed08148a9) | `` twspace-crawler: 1.12.3 -> 1.12.4 ``                                      |
| [`709083f2`](https://github.com/NixOS/nixpkgs/commit/709083f280530f66a702e7739f4b892056a6184c) | `` esbuild: 0.18.14 -> 0.18.15 ``                                            |
| [`7ae9f4f5`](https://github.com/NixOS/nixpkgs/commit/7ae9f4f58e4cbdcccd84546f640d13a635b1563f) | `` rbw: 1.8.1 -> 1.8.2 ``                                                    |
| [`277b8c0a`](https://github.com/NixOS/nixpkgs/commit/277b8c0ab423df2ca475d895ddad09b185473204) | `` ocamlPackages.bisect_ppx: 2.8.2 → 2.8.3 ``                                |
| [`6db3ad18`](https://github.com/NixOS/nixpkgs/commit/6db3ad18610ac01e5cda59f8209ae2f799718a2d) | `` python311Packages.islpy: 2023.1 -> 2023.1.2 ``                            |
| [`dd7ca986`](https://github.com/NixOS/nixpkgs/commit/dd7ca9860de0054d86ca0567e117ffc93f338165) | `` yor: 0.1.180 -> 0.1.182 ``                                                |
| [`c4d28ff1`](https://github.com/NixOS/nixpkgs/commit/c4d28ff16125c2a56ca9548799e25a659a28397e) | `` nixos/freshrss: authType option ``                                        |
| [`1d2a2dc7`](https://github.com/NixOS/nixpkgs/commit/1d2a2dc7d0396495e2bb3878dc62eab620425c85) | `` netdata: 1.40.1 -> 1.41.0 ``                                              |
| [`18010665`](https://github.com/NixOS/nixpkgs/commit/18010665ca0caffb7b8f4abdde49034b2657307e) | `` nixos/matrix-sliding-sync: init ``                                        |
| [`afa41f79`](https://github.com/NixOS/nixpkgs/commit/afa41f799a36dcd57fc6d1347ea4804d64d3fb8e) | `` docker-compose: 2.19.1 -> 2.20.2 ``                                       |
| [`d7740c24`](https://github.com/NixOS/nixpkgs/commit/d7740c24cb32a6dbeb1c4dab531f098d961c6dbc) | `` nixos/lib/make-disk-image: fix installBootLoader for disabled grub ``     |
| [`b628d6ee`](https://github.com/NixOS/nixpkgs/commit/b628d6ee917fee987bdf602227f7a53b59d4c8bf) | `` libspelling: init at unstable-2023-07-17 ``                               |
| [`f75f305d`](https://github.com/NixOS/nixpkgs/commit/f75f305d1eb39499dd550e1aae7d2cd86f247ee0) | `` vimPlugins.vim-astro: init at 2022-08-25 ``                               |
| [`643bc96b`](https://github.com/NixOS/nixpkgs/commit/643bc96bd668bc796507348abcd9dad0aaa50ce7) | `` heisenbridge: 1.14.2 -> 1.14.3 ``                                         |
| [`6d6d5aa6`](https://github.com/NixOS/nixpkgs/commit/6d6d5aa6f8fdcb91bd7242180dce329159e9be74) | `` icamerasrc: fix compilation ``                                            |
| [`2e7e6bdb`](https://github.com/NixOS/nixpkgs/commit/2e7e6bdb1471350043cefbcc8885ceeead4db37a) | `` tuba: 0.3.2 -> 0.4.0 ``                                                   |
| [`6c5f0ae8`](https://github.com/NixOS/nixpkgs/commit/6c5f0ae88669df31553eb27a8c7063a1d60065e8) | `` ipu6-camera-hal: fix compilation ``                                       |
| [`89da0b03`](https://github.com/NixOS/nixpkgs/commit/89da0b034df06fd2b7244a3db63dc783b85d4203) | `` twingate: use setup-hook instead of unpackCmd ``                          |
| [`0dc5b95e`](https://github.com/NixOS/nixpkgs/commit/0dc5b95e900dde388ab0b68322ba4706a866aed7) | `` aperture: add aperture v0.2-beta ``                                       |
| [`20edc4ff`](https://github.com/NixOS/nixpkgs/commit/20edc4ff4b6f8acd2332b867a6a7a6b4d33756f6) | `` python3Packages.bravado-core: 5.17.1 -> 6.1.0 ``                          |
| [`132f2c52`](https://github.com/NixOS/nixpkgs/commit/132f2c521f691f77274af8f357aa6303f6ac84b8) | `` qovery-cli: 0.60.0 -> 0.61.0 ``                                           |
| [`50fe7ed8`](https://github.com/NixOS/nixpkgs/commit/50fe7ed8d63577bf999832e0c16a63db0327bc0e) | `` mkchromecast: add qt5.qtwayland ``                                        |