### PR TITLE
chore(flake/stylix): `dcf3bcf0` -> `34a6d389`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -433,11 +433,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689766231,
-        "narHash": "sha256-g5CcdKonVAEOh1pefloIUW442BNKEGTd4krZmZP+qU4=",
+        "lastModified": 1690028952,
+        "narHash": "sha256-r/1ywiJzbyXq2OQEHs8tYFlcViL0IOruxovrYqO08y4=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "dcf3bcf0ba8a72356e95339a6f0d4e7057815746",
+        "rev": "34a6d389f34b2548b3ae9fad77508620a0358817",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                           |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`34a6d389`](https://github.com/danth/stylix/commit/34a6d389f34b2548b3ae9fad77508620a0358817) | `` Disable Linux-only modules on Darwin (#130) `` |