### PR TITLE
chore(flake/nixpkgs): `9ca78564` -> `12303c65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -326,11 +326,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689940971,
-        "narHash": "sha256-397xShPnFqPC59Bmpo3lS+/Aw0yoDRMACGo1+h2VJMo=",
+        "lastModified": 1690031011,
+        "narHash": "sha256-kzK0P4Smt7CL53YCdZCBbt9uBFFhE0iNvCki20etAf4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ca785644d067445a4aa749902b29ccef61f7476",
+        "rev": "12303c652b881435065a98729eb7278313041e49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`12303c65`](https://github.com/NixOS/nixpkgs/commit/12303c652b881435065a98729eb7278313041e49) | `` xfce.mousepad: allow to disable polkit ``                                       |
| [`03042003`](https://github.com/NixOS/nixpkgs/commit/030420030dcd00238420e628d39ab96fcbc12213) | `` netsurf.browser: add the infamous -fcommon compiler flag ``                     |
| [`fc415c59`](https://github.com/NixOS/nixpkgs/commit/fc415c59b6ec7e59140ca548e834874238dffdc1) | `` circleci-cli: 0.1.27054 -> 0.1.27660 ``                                         |
| [`3e9e5d9e`](https://github.com/NixOS/nixpkgs/commit/3e9e5d9e94989996949dd549463d94b84c12bfd5) | `` languagetool: 6.1 -> 6.2 ``                                                     |
| [`f63d863f`](https://github.com/NixOS/nixpkgs/commit/f63d863fde0106cb2380de182a1e217e339abe12) | `` nixos/pgbouncer: init (#241578) ``                                              |
| [`2ec97286`](https://github.com/NixOS/nixpkgs/commit/2ec9728688bbfc326dff013549d4ae0ceaef0841) | `` codux: 15.4.4 -> 15.6.1 ``                                                      |
| [`69312c61`](https://github.com/NixOS/nixpkgs/commit/69312c61c1886167f4c1115a8b6939b70f3900f6) | `` python311Packages.turnt: 1.10.0 -> 1.11.0 ``                                    |
| [`4fe0dfd1`](https://github.com/NixOS/nixpkgs/commit/4fe0dfd1ea244116d4b08b7e67fd61e718bf1ccf) | `` ebpf-verifier: init at 2023-07-15 ``                                            |
| [`648c4f6a`](https://github.com/NixOS/nixpkgs/commit/648c4f6a77ee3b53554bfcfb7f8d0f024e0d92d2) | `` python311Packages.sshfs: 2023.4.1 -> 2023.7.0 ``                                |
| [`2fbdcbee`](https://github.com/NixOS/nixpkgs/commit/2fbdcbeee9613b75250dc89924caae28dfdba950) | `` python310Packages.hcloud: 1.25.0 -> 1.26.0 ``                                   |
| [`6cd594dc`](https://github.com/NixOS/nixpkgs/commit/6cd594dcec0d4006be012f4e03a6e838a0693605) | `` python310Packages.galois: add changelog to meta ``                              |
| [`9519400d`](https://github.com/NixOS/nixpkgs/commit/9519400dbce63ecc7177e031180c81b36ab954fd) | `` python310Packages.galois: 0.3.4 -> 0.3.5 ``                                     |
| [`f9dcbee5`](https://github.com/NixOS/nixpkgs/commit/f9dcbee583066a281ba9ba11d8bbd26a3fa2a76f) | `` hexfiend: fix platform meta ``                                                  |
| [`a16bd569`](https://github.com/NixOS/nixpkgs/commit/a16bd569fdbed19a014ee17052171d0d74a4e067) | `` miniflux: 2.0.45 -> 2.0.46 ``                                                   |
| [`c8fe7b0e`](https://github.com/NixOS/nixpkgs/commit/c8fe7b0ebe93f0cf20bc8af53465b1b65037a536) | `` cemu: 2.0-44 -> 2.0-45 ``                                                       |
| [`5a6f37d7`](https://github.com/NixOS/nixpkgs/commit/5a6f37d706fc9c72f149741abb9ed2d96364e780) | `` python310Packages.pymilvus: 2.2.8 -> 2.2.13 ``                                  |
| [`8449b47e`](https://github.com/NixOS/nixpkgs/commit/8449b47eebcade8a676da84b466c026ac886b86e) | `` flyway: 9.18.0 -> 9.21.0 ``                                                     |
| [`4295b1ba`](https://github.com/NixOS/nixpkgs/commit/4295b1baf2e62e70cc1ebd1ef41ab32ee7e3dddd) | `` jadx: add desktop item ``                                                       |
| [`2b577387`](https://github.com/NixOS/nixpkgs/commit/2b577387871f420082a2ec77e9711490dd754853) | `` obs-studio-plugins.obs-vertical-canvas: 1.2.4 -> 1.2.5 ``                       |
| [`c1fe55bf`](https://github.com/NixOS/nixpkgs/commit/c1fe55bf449d48b4c392be87004460b7ab95a306) | `` cnspec: 8.18.0 -> 8.19.0 ``                                                     |
| [`97971e7c`](https://github.com/NixOS/nixpkgs/commit/97971e7ce3aee765d178b4b5ad712147c4f3312f) | `` grml-zsh-config: 0.19.5 -> 0.19.6 ``                                            |
| [`05d07a1a`](https://github.com/NixOS/nixpkgs/commit/05d07a1adb480998e767fa91ee716f7f91cfb6df) | `` python311Packages.types-deprecated: 1.2.9.2 -> 1.2.9.3 ``                       |
| [`ff526a06`](https://github.com/NixOS/nixpkgs/commit/ff526a06996790006ef870af661e6e43a5ac7c49) | `` firefox: remove app.partner.nixos ``                                            |
| [`b3705caa`](https://github.com/NixOS/nixpkgs/commit/b3705caa68da4a3edb82a279e128f1170431f76f) | `` python311Packages.pyfuse3: 3.2.2 -> 3.2.3 ``                                    |
| [`57e49fa1`](https://github.com/NixOS/nixpkgs/commit/57e49fa1057264791d33ba6db9b20aeb356be259) | `` python3Packages.rauth: init at 0.7.2 ``                                         |
| [`07a7be2a`](https://github.com/NixOS/nixpkgs/commit/07a7be2a9cadae2237acc23e4be2ddce59b87aff) | `` mdbook-katex: 0.5.4 -> 0.5.5 ``                                                 |
| [`875ec026`](https://github.com/NixOS/nixpkgs/commit/875ec026c9d3670c9138b903e86f7f3d672a03c2) | `` mpv: add `NoDisplay=true` to umpv.desktop ``                                    |
| [`db4e0e2b`](https://github.com/NixOS/nixpkgs/commit/db4e0e2b259bb7d027b5e08a710d8bfa35f511c6) | `` rsyslog: 8.2304.0 -> 8.2306.0 ``                                                |
| [`c4a47dac`](https://github.com/NixOS/nixpkgs/commit/c4a47dac8d39b547cced26aa0b2b09181c12f8ba) | `` terraform-providers.tencentcloud: 1.81.15 -> 1.81.16 ``                         |
| [`6d42510a`](https://github.com/NixOS/nixpkgs/commit/6d42510a869d10728672be6c3e5fdd793c87898b) | `` terraform-providers.alicloud: 1.207.2 -> 1.208.0 ``                             |
| [`cebd81fb`](https://github.com/NixOS/nixpkgs/commit/cebd81fb62fa315e5a5a12274304091f6ab6852a) | `` terraform-providers.pagerduty: 2.15.1 -> 2.15.2 ``                              |
| [`bc8f2497`](https://github.com/NixOS/nixpkgs/commit/bc8f2497c5e9207d75106ff0faff315b30643dc6) | `` terraform-providers.nutanix: 1.9.1 -> 1.9.2 ``                                  |
| [`97a51713`](https://github.com/NixOS/nixpkgs/commit/97a51713804e5e0d9609203bb077008cc75a2935) | `` gum: 0.10.0 -> 0.11.0 ``                                                        |
| [`59d02622`](https://github.com/NixOS/nixpkgs/commit/59d0262238425b045996933672bd1537c61f929e) | `` reaper: use ffmpeg4 ``                                                          |
| [`3a3e2bb4`](https://github.com/NixOS/nixpkgs/commit/3a3e2bb4ff14259adfda18dd6c28b36548401ca9) | `` eksctl: 0.148.0 -> 0.150.0 ``                                                   |
| [`a64809bb`](https://github.com/NixOS/nixpkgs/commit/a64809bb5f5d64b6cca2f9d7930ba8011125a833) | `` linuxPackages.lttng-modules: 2.13.8 -> 2.13.10 ``                               |
| [`af39a65a`](https://github.com/NixOS/nixpkgs/commit/af39a65adbcb9bf07ec3175b537143e00f587778) | `` linuxPackages.rtl88x2bu: unstable-2023-03-17 -> unstable-2023-07-20 ``          |
| [`067d3fb7`](https://github.com/NixOS/nixpkgs/commit/067d3fb75ea70a8eeb103f54ccc87066f62d389b) | `` linuxPackages.rtl8821au: unstable-2023-03-22 -> unstable-2023-07-20 ``          |
| [`abdc48a1`](https://github.com/NixOS/nixpkgs/commit/abdc48a1238f83604e969a14e455857d4e3d5778) | `` linuxPackages.rtl8812au: unstable-2023-05-11 -> unstable-2023-07-20 ``          |
| [`8c514e6a`](https://github.com/NixOS/nixpkgs/commit/8c514e6a19ebbe7d3a8b534b32105c23b9d336c1) | `` linuxPackages.mba6x_bl: unstable-2016-12-08 -> unstable-2017-12-30 ``           |
| [`efba841a`](https://github.com/NixOS/nixpkgs/commit/efba841aeb5d3b71384ccda561aa068ea9ab75f1) | `` nixos/hostapd: add AF_PACKET to RestrictAddressFamilies ``                      |
| [`6c92ab80`](https://github.com/NixOS/nixpkgs/commit/6c92ab80ca692fe69aea5af80719160972a45d3c) | `` edit: 20180228 -> unstable-2021-04-05 ``                                        |
| [`ab5d3388`](https://github.com/NixOS/nixpkgs/commit/ab5d3388dbe7988be343963b94f0d1a437afb3c9) | `` foot: 1.15.0 -> 1.15.1 ``                                                       |
| [`22f70453`](https://github.com/NixOS/nixpkgs/commit/22f70453aff63ffb19689d95d39f068c3bc4e4c2) | `` apktool: 2.7.0 -> 2.8.0 ``                                                      |
| [`7cecff4e`](https://github.com/NixOS/nixpkgs/commit/7cecff4e808286022198cea2de5b4302991ec682) | `` bun: use blog for changelog ``                                                  |
| [`2746e75e`](https://github.com/NixOS/nixpkgs/commit/2746e75e643570fbac6a86fa1ae0e9a03ececa11) | `` bun: 0.6.14 -> 0.7.0 ``                                                         |
| [`bba423a1`](https://github.com/NixOS/nixpkgs/commit/bba423a11e0ad5ea579eb33381a0bf32eaee2d77) | `` maintainers: add cdmistman ``                                                   |
| [`4e409b58`](https://github.com/NixOS/nixpkgs/commit/4e409b58d2c287c43d0a238374d514e92fdf497a) | `` python311Packages.homeassistant-stubs: 2023.7.1 -> 2023.7.2 ``                  |
| [`aa982f39`](https://github.com/NixOS/nixpkgs/commit/aa982f397620ed7e743234d2f5fec5127369ca4a) | `` home-assistant: relax pyyaml constraint ``                                      |
| [`4f8c6e90`](https://github.com/NixOS/nixpkgs/commit/4f8c6e90015f9803903c692e28060bc115100146) | `` home-assistant: 2023.7.2 -> 2023.7.3 ``                                         |
| [`87ceb553`](https://github.com/NixOS/nixpkgs/commit/87ceb553af01736ce3e4a8fe48d5f5ebc90d82c0) | `` python310Packages.python-roborock: 0.30.0 -> 0.30.2 ``                          |
| [`e4b2ca7f`](https://github.com/NixOS/nixpkgs/commit/e4b2ca7f89506b5d333d06e217b60c71c0252c5c) | `` python310Packages.pyfibaro: 0.7.1 -> 0.7.2 ``                                   |
| [`bb52ea6f`](https://github.com/NixOS/nixpkgs/commit/bb52ea6f789d23f6a08a54b3dde865792fe72053) | `` python310Packages.env-canada: 0.5.35 -> 0.5.36 ``                               |
| [`a6ed356a`](https://github.com/NixOS/nixpkgs/commit/a6ed356ab04e6bfc68f291a45ace8c80270d5206) | `` python310Packages.asyncinotify: 4.0.1 -> 4.0.2 ``                               |
| [`baf8c120`](https://github.com/NixOS/nixpkgs/commit/baf8c1206216777f41b9b4855538914de213d94d) | `` felix-fm: 2.5.0 -> 2.6.0 ``                                                     |
| [`644ad682`](https://github.com/NixOS/nixpkgs/commit/644ad6823c42f05f1a25ae0ab6972dfeff30d2a2) | `` nurl: 0.3.12 -> 0.3.13 ``                                                       |
| [`fde0d8e4`](https://github.com/NixOS/nixpkgs/commit/fde0d8e485a558048f31b7c2804cbacf0e6644a4) | `` maestro: v1.30.3 -> v1.30.4 ``                                                  |
| [`6c65f34e`](https://github.com/NixOS/nixpkgs/commit/6c65f34ee9d5e25079e8058d5c576eff2f017c94) | `` qmplay2: 23.06.04 -> 23.06.17 ``                                                |
| [`f5bc37b9`](https://github.com/NixOS/nixpkgs/commit/f5bc37b95dfb32d95fe0967d5774b00b406158d1) | `` qmplay2: 23.02.05 -> 23.06.04 ``                                                |
| [`e57a7a59`](https://github.com/NixOS/nixpkgs/commit/e57a7a5924695babf3475ec44af54e02209bc314) | `` qmplay2: update dependencies ``                                                 |
| [`2a7cfff9`](https://github.com/NixOS/nixpkgs/commit/2a7cfff98f42bb9d26cef78278dd06dedf1ef4d5) | `` python311Packages.aioesphomeapi: 15.1.13 -> 15.1.14 ``                          |
| [`a9df2ff8`](https://github.com/NixOS/nixpkgs/commit/a9df2ff821173231124a75b39a4e00ef936076d9) | `` seaweedfs: 3.53 -> 3.54 ``                                                      |
| [`a823067e`](https://github.com/NixOS/nixpkgs/commit/a823067e2e0dece9b986891fa6e4364e7daafab1) | `` _1password: fix aarch64 hash ``                                                 |
| [`d0ee850c`](https://github.com/NixOS/nixpkgs/commit/d0ee850cc6bb8c70d01e50de61b679c72da10861) | `` python310Packages.compreffor: 0.5.3 -> 0.5.4 ``                                 |
| [`cef29a29`](https://github.com/NixOS/nixpkgs/commit/cef29a298f83d775c56a6774e58e58c8d795e71b) | `` python310Packages.immutabledict: 2.2.5 -> 3.0.0 ``                              |
| [`c68b0b6e`](https://github.com/NixOS/nixpkgs/commit/c68b0b6eb091aee5583a3a7e108acb5bf5c20540) | `` python310Packages.weconnect: 0.56.2 -> 0.57.0 ``                                |
| [`760d222c`](https://github.com/NixOS/nixpkgs/commit/760d222c52d33b0eb8775d164c810ee2dbe87287) | `` dwl: fix so that man pages show up ``                                           |
| [`2116a711`](https://github.com/NixOS/nixpkgs/commit/2116a71151cfe5e5c782d7f65d56ce0c37fc5155) | `` python310Packages.dockerfile-parse: 2.0.0 -> 2.0.1 ``                           |
| [`b0db3b7c`](https://github.com/NixOS/nixpkgs/commit/b0db3b7c11223ac087c5f7e13ea5f1f101f37167) | `` nixos/twingate: fix cp (-n -> --update=none) ``                                 |
| [`4c251b10`](https://github.com/NixOS/nixpkgs/commit/4c251b10d47c7ccef57b4a8fc683afac1137422c) | `` fanout: init at unstable-2023-07-21 ``                                          |
| [`ebf4e874`](https://github.com/NixOS/nixpkgs/commit/ebf4e87429ce7faa51a86a36a7b2e615c8bcc735) | `` weaviate: init at 1.19.8 ``                                                     |
| [`fad7e5dd`](https://github.com/NixOS/nixpkgs/commit/fad7e5dd38e69acdd11318816f3c191435d83ccc) | `` lua-language-server: 3.6.23 -> 3.6.24 ``                                        |
| [`ad812ca2`](https://github.com/NixOS/nixpkgs/commit/ad812ca2c6ecfc1ebd728714b48f958c01516373) | `` cargo-binstall: 1.1.1 -> 1.1.2 ``                                               |
| [`e7fac60f`](https://github.com/NixOS/nixpkgs/commit/e7fac60f88c6614927f4593301d32940d8eda13e) | `` linuxwave: 0.1.4 -> 0.1.5 ``                                                    |
| [`3bc5f78d`](https://github.com/NixOS/nixpkgs/commit/3bc5f78d8bb1f03d0e0f40d776af41713fa56e98) | `` wallust: 2.5.0 -> 2.5.1 ``                                                      |
| [`7e579351`](https://github.com/NixOS/nixpkgs/commit/7e579351e4232338b8e30538c51046f70142a2b5) | `` symfony-cli: 5.5.6 -> 5.5.7 ``                                                  |
| [`a0465cdf`](https://github.com/NixOS/nixpkgs/commit/a0465cdf054a9476898a87301350ee467955ed09) | `` sqlx-cli: replace `native-tls` with `rustls` ``                                 |
| [`9adfaee1`](https://github.com/NixOS/nixpkgs/commit/9adfaee104f3d0a3b639eab5b7ef8d7cbca5320b) | `` sqlx-cli: install shell completions ``                                          |
| [`33947999`](https://github.com/NixOS/nixpkgs/commit/33947999a3c48ee3ce6b23d397d04839a732e7cb) | `` metasploit: 6.3.25 -> 6.3.26 ``                                                 |
| [`4059e5bd`](https://github.com/NixOS/nixpkgs/commit/4059e5bdbba2352ade72f3379706ce779f0159f1) | `` python311Packages.trimesh: disable on unsupported Python releases ``            |
| [`2a19ecf5`](https://github.com/NixOS/nixpkgs/commit/2a19ecf59f67462fe0e44aaf366fc0a6fd36b13a) | `` thunderbird-unwrapped: 115.0 -> 115.0.1 ``                                      |
| [`2180ed10`](https://github.com/NixOS/nixpkgs/commit/2180ed10de7e39d3682aa23dfc79c5a4aa897616) | `` swayosd: unstable-2023-05-09 -> unstable-2023-07-18 ``                          |
| [`e90c8654`](https://github.com/NixOS/nixpkgs/commit/e90c865475d9188b2c1d149aa507d6e2270cc77a) | `` python310Packages.trimesh: 3.22.4 -> 3.22.5 ``                                  |
| [`edf7c640`](https://github.com/NixOS/nixpkgs/commit/edf7c64087198b9db413e9b7e8b1619578ca102a) | `` maintainers: add gpg key for gigglesquid ``                                     |
| [`a2c4b78d`](https://github.com/NixOS/nixpkgs/commit/a2c4b78d9d98f03fabb79ff919bb2b8380e0c870) | `` mkgmap: 4909 -> 4910 ``                                                         |
| [`c463763f`](https://github.com/NixOS/nixpkgs/commit/c463763f002216c536d755b9388aff5510dc642a) | `` libcef: 114.2.12 -> 114.2.13 ``                                                 |
| [`fcab750e`](https://github.com/NixOS/nixpkgs/commit/fcab750e04e78c44a974cc69c52ef05942a925f5) | `` tuba: add spell check ``                                                        |
| [`0527714b`](https://github.com/NixOS/nixpkgs/commit/0527714b6eb8efba30e5382fc05a2a7533b84bd7) | `` taler: unstable -> 0.9.2 ``                                                     |
| [`44c5419d`](https://github.com/NixOS/nixpkgs/commit/44c5419dadd548ad0f3daedbcfb311d2761d97c0) | `` flip-link: 0.1.6 -> 0.1.7 ``                                                    |
| [`d1584bdd`](https://github.com/NixOS/nixpkgs/commit/d1584bdd4caa2c1259e4d4b016380f665ce0c3b9) | `` got: 0.90 -> 0.91 ``                                                            |
| [`29b4a924`](https://github.com/NixOS/nixpkgs/commit/29b4a92458d2b3c872b6aac6d6ea9f585dc98b38) | `` stdenvAdapters: Remove 6 year old comment ``                                    |
| [`cb29bc6a`](https://github.com/NixOS/nixpkgs/commit/cb29bc6ace2c037a70facbea481f46704b37022d) | `` stdenvAdapters: Fix condition ``                                                |
| [`1a060934`](https://github.com/NixOS/nixpkgs/commit/1a0609341002775e240fefc452d350e2498ec55c) | `` python310Packages.python-youtube: 0.9.0 -> 0.9.1 ``                             |
| [`9167341e`](https://github.com/NixOS/nixpkgs/commit/9167341e3f15eb249608363630cddd02ec740645) | `` nextcloudPackages: update ``                                                    |
| [`450f7836`](https://github.com/NixOS/nixpkgs/commit/450f78363145f4fe7887be23a5473915db3afd83) | `` nextcloud27: 27.0.0 -> 27.0.1 ``                                                |
| [`cf94e752`](https://github.com/NixOS/nixpkgs/commit/cf94e7529ca5ff863675c90f07f70ab8e3c4849f) | `` nextcloud26: 26.0.3 -> 26.0.4 ``                                                |
| [`84232105`](https://github.com/NixOS/nixpkgs/commit/84232105ade4f4a4067ac560417f6ada41721d5f) | `` nextcloud25: 25.0.8 -> 25.0.9 ``                                                |
| [`f3d335e9`](https://github.com/NixOS/nixpkgs/commit/f3d335e9be634483f725759c272b6071d52705df) | `` tint2: 17.0.2 -> 17.1.3, switch to fork, fix compatibility with glib >= 2.76 `` |
| [`24b79210`](https://github.com/NixOS/nixpkgs/commit/24b79210443547ee292ae7eae8d79067ed5e66d6) | `` apache-jena-fuseki: 4.8.0 -> 4.9.0, add a test ``                               |
| [`bcc7a4d7`](https://github.com/NixOS/nixpkgs/commit/bcc7a4d78f05ab6f35677ccd771f5bec5eee9c55) | `` flexget: 3.7.9 -> 3.7.10 ``                                                     |
| [`9267d4fa`](https://github.com/NixOS/nixpkgs/commit/9267d4fae557c36920a440ab1a009a7f0a351468) | `` nodejs_20: 20.4.0 -> 20.5.0 ``                                                  |
| [`19fcc259`](https://github.com/NixOS/nixpkgs/commit/19fcc259f04aaff9e3fc97b18b9b08847c32330a) | `` apache-jena: 4.8.0 -> 4.9.0 ``                                                  |
| [`693eaad9`](https://github.com/NixOS/nixpkgs/commit/693eaad9e6076a41bd7d3883b4dfec49a43966cb) | `` brave: 1.52.130 -> 1.56.9 ``                                                    |
| [`0da1869b`](https://github.com/NixOS/nixpkgs/commit/0da1869b15a1036f0b5cc7ba642cd86f6f461f61) | `` fcft: 3.1.5 -> 3.1.6 ``                                                         |
| [`3acd144f`](https://github.com/NixOS/nixpkgs/commit/3acd144f0a0c5f3a660ea843fbc5c458df396835) | `` oranda: 0.1.1 -> 0.2.0 ``                                                       |
| [`8712bcf8`](https://github.com/NixOS/nixpkgs/commit/8712bcf86cebb3457a63b1f61c637eaee2b237d1) | `` ov: 0.30.0 -> 0.31.0 ``                                                         |
| [`ac00d5bb`](https://github.com/NixOS/nixpkgs/commit/ac00d5bb609c75e27afb9aff036a96fea03be33c) | `` python311Packages.fakeredis: 2.16.0 -> 2.17.0 ``                                |
| [`40a1d22a`](https://github.com/NixOS/nixpkgs/commit/40a1d22a0330af03d0a0b81130ca92bf53eca583) | `` qdrant: 1.3.0 -> 1.3.2 ``                                                       |
| [`c2130ffc`](https://github.com/NixOS/nixpkgs/commit/c2130ffc7364fc8676de6c1777896109f7045942) | `` mongodb-compass: 1.38.2 -> 1.39.0 ``                                            |
| [`9b1bda6f`](https://github.com/NixOS/nixpkgs/commit/9b1bda6fffae0a2683e8c5381eeff9f7f0862b33) | `` python3Packages.gocardless-pro: init at 1.45.0 ``                               |
| [`08a0cb20`](https://github.com/NixOS/nixpkgs/commit/08a0cb20b46dedbe7efc42a3a28f9f2f4dc8ea16) | `` python3Packages.wandb: 0.15.3 -> 0.15.5 ``                                      |
| [`af4b2dee`](https://github.com/NixOS/nixpkgs/commit/af4b2deeb47aee00407088804b0f30fa402edd38) | `` python3Packages.google-cloud-artifact-registry: init at 1.8.2 ``                |
| [`3cb419b2`](https://github.com/NixOS/nixpkgs/commit/3cb419b2ac5dfc2c978d434dc892aa38f11d690b) | `` gnunet-gtk: 0.15.0 -> 0.19.0 ``                                                 |
| [`71632b0d`](https://github.com/NixOS/nixpkgs/commit/71632b0dace3db1ac9a1a459e49b2f52a018861c) | `` pict-rs: Use main ffmpeg attribute ``                                           |
| [`9986d2cc`](https://github.com/NixOS/nixpkgs/commit/9986d2cc90396fbafc154323dc820be9a7bc4ae9) | `` mox: init at 0.0.5 ``                                                           |
| [`9aff2cad`](https://github.com/NixOS/nixpkgs/commit/9aff2cad80a635bee007a47833ca1255f7327c69) | `` python3Packages.slack-bolt: init at 1.18.0 ``                                   |
| [`eaeb1f21`](https://github.com/NixOS/nixpkgs/commit/eaeb1f21e739f45274ce30d3a8b554a3b7b548c2) | `` python3Packages.slack-sdk: 3.20.2 -> 3.21.3 ``                                  |
| [`f9236b37`](https://github.com/NixOS/nixpkgs/commit/f9236b37e820e0ed8197f1aed7d908c6b6fc73bd) | `` python3Packages.slack-sdk: fix build ``                                         |
| [`3be5b19b`](https://github.com/NixOS/nixpkgs/commit/3be5b19b3cb052eb32edaabc0f4611752be6ac6f) | `` gnunet: 0.17.6 -> 0.19.4 ``                                                     |
| [`da58b136`](https://github.com/NixOS/nixpkgs/commit/da58b136157c8bfd6e2d90db8c4609939cef8bb9) | `` nixos/gitea: revert change to RuntimeDirectoryMode ``                           |
| [`076f6c09`](https://github.com/NixOS/nixpkgs/commit/076f6c0945f07fd71c8fdfb7eda342de4602173e) | `` easyrpg-player: 0.7.0 -> 0.8, enable on Darwin ``                               |
| [`6543a56a`](https://github.com/NixOS/nixpkgs/commit/6543a56a0e77d2da8f610cd5cfe3bc6c4adf307b) | `` Revert "teamspeak_client: use llvmPackages_10" ``                               |
| [`4535fcd6`](https://github.com/NixOS/nixpkgs/commit/4535fcd653bf5f88b95067f567ed46c3e96403f2) | `` teamspeak_client: add myself to maintainers ``                                  |
| [`bca6b6ac`](https://github.com/NixOS/nixpkgs/commit/bca6b6ac984ed6ff86dd2be0480778c0f70ff6ad) | `` teamspeak_client: 3.5.6 -> 3.6.0 ``                                             |
| [`4d462ed5`](https://github.com/NixOS/nixpkgs/commit/4d462ed57210b63a147574668e2116e14c720701) | `` capnproto-rust: 0.17.1 -> 0.17.2 ``                                             |
| [`41b8228d`](https://github.com/NixOS/nixpkgs/commit/41b8228d5dee849528a451d892f4fb4312b87fab) | `` liblcf: 0.7.0 -> 0.8 ``                                                         |
| [`71a96bd9`](https://github.com/NixOS/nixpkgs/commit/71a96bd985dcaa116a0c59f5f19f811b44461849) | `` mastodon: simplify update script ``                                             |
| [`9d941d80`](https://github.com/NixOS/nixpkgs/commit/9d941d80f641bd176b34dc78b52ac8921ae27d24) | `` fanficfare: 4.24.0 -> 4.25.0 ``                                                 |
| [`e7707372`](https://github.com/NixOS/nixpkgs/commit/e770737241360cdfd09b421eea83160dce02c212) | `` Update nixos/modules/services/networking/libreswan.nix ``                       |
| [`7cc9ced7`](https://github.com/NixOS/nixpkgs/commit/7cc9ced775f83af14c97a9cccc5ad0dee1f33299) | `` Update nixos/modules/services/misc/cgminer.nix ``                               |
| [`eef9190d`](https://github.com/NixOS/nixpkgs/commit/eef9190d2b25b766297a2798f28223550e6217ac) | `` nixosTests.syncthing-no-settings: init ``                                       |
| [`345745b6`](https://github.com/NixOS/nixpkgs/commit/345745b6da9693adecfc69cc55c5753646d63060) | `` nixos/syncthing: fix syncthing-init running by default ``                       |
| [`c42a7b66`](https://github.com/NixOS/nixpkgs/commit/c42a7b668c340fb32bc40cf8dfd0214f85dbb0d1) | `` Revert "Merge pull request #233377 from ncfavier/revert-226088" ``              |
| [`f3719756`](https://github.com/NixOS/nixpkgs/commit/f3719756b550113c1acbbab00c89a56fb77256f2) | `` treewide: use optionalString instead of 'then ""' ``                            |
| [`83bad4c6`](https://github.com/NixOS/nixpkgs/commit/83bad4c63120591a822446e6a2823ccb0a5d0fd0) | `` trilium-desktop: add startupWMClass to desktop icon ``                          |
| [`f6c5e4c2`](https://github.com/NixOS/nixpkgs/commit/f6c5e4c27352c349ee4d45d7f6ca0cdf02f90deb) | `` firefox: late-bind xdg-utils if broken ``                                       |