### PR TITLE
chore(flake/nix-index-database): `8de10d21` -> `c1e6fc40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -296,11 +296,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690081046,
-        "narHash": "sha256-IfqnO370ZzI/IKh1rtCk9Z07blb4LzsyOZP/6Q1Dd80=",
+        "lastModified": 1690083300,
+        "narHash": "sha256-xnUtWO/5TuuHkIpmzMXGvHJqS06FSVADnAZ4bvqO4Zo=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "8de10d210a672af5d62af39cd2a60a80d09f34fa",
+        "rev": "c1e6fc40dd5c0d16940bc012421268b94e404b0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`c1e6fc40`](https://github.com/nix-community/nix-index-database/commit/c1e6fc40dd5c0d16940bc012421268b94e404b0b) | `` update packages.nix to release 2023-07-23-033400 `` |