### PR TITLE
chore(flake/home-manager): `76dd6c66` -> `fb03fa55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -189,11 +189,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690027126,
-        "narHash": "sha256-DeUhQQxbu41Qn0uHyNazPBiTJ0lNsf26ThFopWBRRnM=",
+        "lastModified": 1690084763,
+        "narHash": "sha256-Nw680m/pyVoosSgXZW415Z657mfVM2BxaxDPjEk48Z0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "76dd6c66190db0d46ac6b3ca816cc17b581df42c",
+        "rev": "fb03fa5516d4e86059d24ab35a611ffa3a359547",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`fb03fa55`](https://github.com/nix-community/home-manager/commit/fb03fa5516d4e86059d24ab35a611ffa3a359547) | `` flake.lock: Update `` |