### PR TITLE
chore(flake/darwin): `ced9f58f` -> `0f9058e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690084208,
-        "narHash": "sha256-TVO0pj4U12XMFdzbbsqH7mUxYvCa1D8j6GHiuB+ierQ=",
+        "lastModified": 1690100173,
+        "narHash": "sha256-v3DT7u5KlW1ZoulvFQPndbg0gVD0zKGkJmPqGsBVQ3I=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ced9f58f874606f39a8dd301827e774e90707f10",
+        "rev": "0f9058e739dbefc676dee557b4b627962268d556",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                            |
| ------------------------------------------------------------------------------------------------ | ---------------------------------- |
| [`0dafe217`](https://github.com/LnL7/nix-darwin/commit/0dafe2170deb6a691255cecc212af4b1cdf8297b) | `` Add `darwin-version` command `` |