### PR TITLE
chore(flake/nixos-hardware): `d4ea64f2` -> `ba9650b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1689320556,
-        "narHash": "sha256-vODUkZLWFVCvo1KPK3dC2CbXjxa9antEn5ozwlcTr48=",
+        "lastModified": 1690200740,
+        "narHash": "sha256-aRkEXGmCbAGcvDcdh/HB3YN+EvoPoxmJMOaqRZmf6vM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d4ea64f2063820120c05f6ba93ee02e6d4671d6b",
+        "rev": "ba9650b14e83b365fb9e731f7d7c803f22d2aecf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`ba9650b1`](https://github.com/NixOS/nixos-hardware/commit/ba9650b14e83b365fb9e731f7d7c803f22d2aecf) | `` deciso/dec: init, tested with DEC2750 `` |
| [`20f2efe6`](https://github.com/NixOS/nixos-hardware/commit/20f2efe651b7bf812cc26ae8bb4c3daf5927cd96) | `` ga402: remove useless kernel flags ``    |
| [`70325e39`](https://github.com/NixOS/nixos-hardware/commit/70325e398b4cf1410ed024d9dea486f61446878b) | `` Added Asus Zephyrus GA502 ``             |