### PR TITLE
chore(flake/agenix): `0d8c5325` -> `d8c973fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689334118,
-        "narHash": "sha256-djk5AZv1yU84xlKFaVHqFWvH73U7kIRstXwUAnDJPsk=",
+        "lastModified": 1690228878,
+        "narHash": "sha256-9Xe7JV0krp4RJC9W9W9WutZVlw6BlHTFMiUP/k48LQY=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "0d8c5325fc81daf00532e3e26c6752f7bcde1143",
+        "rev": "d8c973fd228949736dedf61b7f8cc1ece3236792",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`91220a70`](https://github.com/ryantm/agenix/commit/91220a701d0bf8055547620baa765b36d885db7a) | `` Rephrase cli app summary ``                  |
| [`2bee5c98`](https://github.com/ryantm/agenix/commit/2bee5c988c41387ef61879927206e1bc98aae978) | `` Extend tutorial section ``                   |
| [`1d7fd156`](https://github.com/ryantm/agenix/commit/1d7fd1569043356d9c64d81e8b40177e164f2017) | `` Extend flake install section ``              |
| [`6d20bf81`](https://github.com/ryantm/agenix/commit/6d20bf81f8ed177281e72cc3f1cbb73637d3ad35) | `` Fix intro indentation ``                     |
| [`b91dfbaf`](https://github.com/ryantm/agenix/commit/b91dfbaf769b51d69edbee9971234087eca10d3a) | `` Fix indentation ``                           |
| [`78733d6d`](https://github.com/ryantm/agenix/commit/78733d6d09ffc49fc7bfcab29abd5d9676e1182a) | `` Make intro section more beginner friendly `` |