### PR TITLE
chore(flake/nixpkgs): `12303c65` -> `b12803b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -326,11 +326,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1690031011,
-        "narHash": "sha256-kzK0P4Smt7CL53YCdZCBbt9uBFFhE0iNvCki20etAf4=",
+        "lastModified": 1690179384,
+        "narHash": "sha256-+arbgqFTAtoeKtepW9wCnA0njCOyoiDFyl0Q0SBSOtE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "12303c652b881435065a98729eb7278313041e49",
+        "rev": "b12803b6d90e2e583429bb79b859ca53c348b39a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`7da39a7a`](https://github.com/NixOS/nixpkgs/commit/7da39a7a9e8849db860cd1adfad2bcb5539d4f76) | `` treewide .goModules: revert renaming the derivation ``                          |
| [`29e6553d`](https://github.com/NixOS/nixpkgs/commit/29e6553d1fa2b6849482486638ac85de9301b203) | `` ocamlPackages.dolog: 3.0 → 6.0.0 ``                                             |
| [`7fc27444`](https://github.com/NixOS/nixpkgs/commit/7fc27444daf36b95a063a6d89e759288c966305d) | `` ventoy: 1.0.93 -> 1.0.94 ``                                                     |
| [`f5724ae4`](https://github.com/NixOS/nixpkgs/commit/f5724ae4bed6d5cdf42a1e94a79ef1be848aed7b) | `` treewide: adopt a few packages that sandro dropped maintainership for ``        |
| [`fe89df18`](https://github.com/NixOS/nixpkgs/commit/fe89df18bf0e6136560fd81b17a7b92d7b87ca19) | `` xfce.xfce4-pulseaudio-plugin: enable playing sound with volume change ``        |
| [`4f22040d`](https://github.com/NixOS/nixpkgs/commit/4f22040dbd70cc39a572cd8bb3b808c13ab3dd06) | `` erg: 0.6.16 -> 0.6.17 ``                                                        |
| [`814584c3`](https://github.com/NixOS/nixpkgs/commit/814584c35b85d5d56b625133f6adbccc12798adc) | `` python310Packages.piccolo-theme: add asl20 to license for the bundled fonts ``  |
| [`91fa2044`](https://github.com/NixOS/nixpkgs/commit/91fa2044923854958b577b1e0614acd5847d436b) | `` plexamp: 4.7.4 -> 4.8.1 ``                                                      |
| [`b749dffa`](https://github.com/NixOS/nixpkgs/commit/b749dffa590edfbb86d5249c003cdad313601065) | `` youtube-tui: 0.7.2 -> 0.7.4 ``                                                  |
| [`4f2af2b9`](https://github.com/NixOS/nixpkgs/commit/4f2af2b9830994c3bad75a0e60a29b7ce837b125) | `` plantuml-server: 1.2023.8 -> 1.2023.10 ``                                       |
| [`77a87373`](https://github.com/NixOS/nixpkgs/commit/77a87373ae359ead5013b41e85d915e2f9afeb2c) | `` ncspot: 0.13.3 -> 0.13.4 ``                                                     |
| [`759c9d5a`](https://github.com/NixOS/nixpkgs/commit/759c9d5a461b916da3aa4ea558b112cfe2ae7480) | `` terragrunt: 0.48.1 -> 0.48.4 ``                                                 |
| [`a9a80133`](https://github.com/NixOS/nixpkgs/commit/a9a80133c12f0f343c2e103db371718cde4a6576) | `` mautrix-signal: 0.4.2 -> 0.4.3 ``                                               |
| [`58010207`](https://github.com/NixOS/nixpkgs/commit/580102072a464c253145d36c6cb7f46648014681) | `` pyp: init at 1.1.0 ``                                                           |
| [`1a161fbc`](https://github.com/NixOS/nixpkgs/commit/1a161fbc1666f6b6409da5cd89769c1f882f598a) | `` pg_tileserv: 1.0.9 → 1.0.10 ``                                                  |
| [`83eaf92b`](https://github.com/NixOS/nixpkgs/commit/83eaf92bf498ad992dd720ffc82e7992703718f8) | `` python311Packages.pytest-testinfra: fix build ``                                |
| [`1415f418`](https://github.com/NixOS/nixpkgs/commit/1415f418a32dcbd089d5a6c5aa0c8192935a94fe) | `` treewide: adopt a few packages that sandro dropped maintainership for ``        |
| [`62c8209b`](https://github.com/NixOS/nixpkgs/commit/62c8209b53895daebea584241fd04803a7958b24) | `` pc: init at 0.4 ``                                                              |
| [`5aa3c52e`](https://github.com/NixOS/nixpkgs/commit/5aa3c52e119965ad980fb2b6ef307fa96399fdd6) | `` nitter: unstable-2023-07-10 -> unstable-2023-07-21 ``                           |
| [`f61f5a8a`](https://github.com/NixOS/nixpkgs/commit/f61f5a8a40f7722f38a798c08040cbd3d807e8d4) | `` chromium: 114.0.5735.198 -> 115.0.5790.98 ``                                    |
| [`de2e43ac`](https://github.com/NixOS/nixpkgs/commit/de2e43ac7be51600336595ea99f0a087460ea54a) | `` portfolio: 0.64.4 -> 0.64.5 ``                                                  |
| [`5fa7ac31`](https://github.com/NixOS/nixpkgs/commit/5fa7ac315f9e173912d95a76f5be74c5c3fd529c) | `` pyenv: 2.3.22 -> 2.3.23 ``                                                      |
| [`c7c411ba`](https://github.com/NixOS/nixpkgs/commit/c7c411bab0875fd3c6bcb52129655744bac9d830) | `` phpExtensions.xdebug: 3.2.1 -> 3.2.2 ``                                         |
| [`d30f4fce`](https://github.com/NixOS/nixpkgs/commit/d30f4fce7f74666c16b6a12daf4e52601493cd70) | `` fsautocomplete: 0.60.1 -> 0.61.1 ``                                             |
| [`10b003f0`](https://github.com/NixOS/nixpkgs/commit/10b003f0a6414fd693eb10a24b65c19fa1d7417b) | `` python310Packages.mkdocstrings-python: 1.2.0 -> 1.2.1 ``                        |
| [`d3fd4ef5`](https://github.com/NixOS/nixpkgs/commit/d3fd4ef5b332a4715858434f99861f455a60c4e9) | `` cargo-local-registry: fix build on x86_64-darwin ``                             |
| [`b75f4d74`](https://github.com/NixOS/nixpkgs/commit/b75f4d748c20c3c6dc62dfa9a124360d49a90a5c) | `` codeql: 2.13.5 -> 2.14.0 ``                                                     |
| [`f70bc6e9`](https://github.com/NixOS/nixpkgs/commit/f70bc6e95bc636862fa3f95a7a56b3ddbdaf37f0) | `` opentabletdriver: fix hash for .deb ``                                          |
| [`66dbc843`](https://github.com/NixOS/nixpkgs/commit/66dbc843377ecf2a2218b8f6f83c000fbeea3053) | `` typioca: init at 2.4.2 ``                                                       |
| [`2995a890`](https://github.com/NixOS/nixpkgs/commit/2995a890b54758eea7fb5e78ea8ad6a219fe7a6e) | `` bitwarden-cli: build from source ``                                             |
| [`a4cdbf35`](https://github.com/NixOS/nixpkgs/commit/a4cdbf35126375f93596f3b2e23c362fc858dca8) | `` curl-impersonate: update goModules usage ``                                     |
| [`0ddc9d02`](https://github.com/NixOS/nixpkgs/commit/0ddc9d0250da0a58a2a28b922f9db3b771b23ca7) | `` zfs: Relate import services to zfs-import.target instead of local-fs ``         |
| [`4bfbc458`](https://github.com/NixOS/nixpkgs/commit/4bfbc45869b358a32cbd5b47c26326a08f9e34a7) | `` dbt: init at 1.5.3 ``                                                           |
| [`859e95e2`](https://github.com/NixOS/nixpkgs/commit/859e95e2bdd9889fd534d8edf64be99313a2361e) | `` python310Packages.dbt-snowflake: init at 1.5.2 ``                               |
| [`c0310c08`](https://github.com/NixOS/nixpkgs/commit/c0310c08d755809400366624c9ac77ecfef4266a) | `` python310Packages.snowflake-connector-python: add secure-local-storage extra `` |
| [`354ecddc`](https://github.com/NixOS/nixpkgs/commit/354ecddc47463a02587d1cf290a4552eae64e209) | `` python310Packages.dbt-redshift: init at 1.5.8 ``                                |
| [`b02c1afb`](https://github.com/NixOS/nixpkgs/commit/b02c1afb9b464e4f063d75679eb2a63527c20899) | `` python310Packages.dbt-bigquery: init at 1.5.3 ``                                |
| [`4f37dd2d`](https://github.com/NixOS/nixpkgs/commit/4f37dd2d18c6322fc5fd85b27060cd4efbe82f63) | `` python310Packages.dbt-postgres: init at 1.5.3 ``                                |
| [`e45ffeba`](https://github.com/NixOS/nixpkgs/commit/e45ffebad224d8007df8cf4d5009e27c4447652e) | `` python310Packages.dbt-core: init at 1.5.3 ``                                    |
| [`9ae3fb40`](https://github.com/NixOS/nixpkgs/commit/9ae3fb40e31e819f4dbcca9a5f33e8f75e58dc9d) | `` python310Packages.dbt-extractor: init at 0.4.1 ``                               |
| [`0b8b643e`](https://github.com/NixOS/nixpkgs/commit/0b8b643e85613b550f6f9868bb414bf6959cdb64) | `` python310Packages.minimal-snowplow-tracker: init at 0.0.2 ``                    |
| [`aa148a31`](https://github.com/NixOS/nixpkgs/commit/aa148a31bd62bc7208d018ce7dc667896a6f292b) | `` python310Packages.hologram: init at 0.0.16 ``                                   |
| [`6c98501e`](https://github.com/NixOS/nixpkgs/commit/6c98501e58f1eb72e7d91fd5bd110bcd08b16a8e) | `` python310Packages.python-gnupg: add changelog to meta ``                        |
| [`95ef9c42`](https://github.com/NixOS/nixpkgs/commit/95ef9c42d145ccb36136072378b5b74f516d557c) | `` python310Packages.python-gnupg: 0.5.0 -> 0.5.1 ``                               |
| [`0d561b51`](https://github.com/NixOS/nixpkgs/commit/0d561b5151fdb940098ed07bd95bcf4ab7dbac22) | `` spotify: 1.1.97.962 -> 1.2.15.828 ``                                            |
| [`82f7812a`](https://github.com/NixOS/nixpkgs/commit/82f7812a1653a3609070f87edd996ce2b63abfda) | `` python310Packages.google-cloud-spanner: 3.37.0 -> 3.38.0 ``                     |
| [`cf6c9653`](https://github.com/NixOS/nixpkgs/commit/cf6c96533bb52f6cd33651257a232269c48cd167) | `` treewide: reduce packages I maintainer ``                                       |
| [`13606dcd`](https://github.com/NixOS/nixpkgs/commit/13606dcd4639a04891eef831a022b0ab8e815b38) | `` python310Packages.ansible-core: 2.15.1 -> 2.15.2 ``                             |
| [`a11da2f1`](https://github.com/NixOS/nixpkgs/commit/a11da2f1d42223599ecd905c57b7ffdf9f09cbe3) | `` topgrade: 12.0.0 -> 12.0.1 ``                                                   |
| [`d0915ace`](https://github.com/NixOS/nixpkgs/commit/d0915ace9db0cc17c8ae53a418eb9472f64b5985) | `` swayosd: refactor build to install all files ``                                 |
| [`d3d9204c`](https://github.com/NixOS/nixpkgs/commit/d3d9204ce5b5e9659d121da20589da92098c6b43) | `` milkytracker: adopt, 1.03.00 -> 1.04.00 (#241669) ``                            |
| [`8126d5fa`](https://github.com/NixOS/nixpkgs/commit/8126d5fa6e9aeb823b37ee48fe6303a95679c2df) | `` nghttp3: 0.12.0 -> 0.13.0 ``                                                    |
| [`7d8dbdef`](https://github.com/NixOS/nixpkgs/commit/7d8dbdef6c37828873a56f1ef1b8024b7045ca58) | `` kubeseal: add changelog to meta ``                                              |
| [`4b01d24d`](https://github.com/NixOS/nixpkgs/commit/4b01d24d2b586a3de349c342be8b313e7d79d260) | `` kubeseal: 0.22.0 -> 0.23.0 ``                                                   |
| [`07b349fa`](https://github.com/NixOS/nixpkgs/commit/07b349fa0848015c255419213b31fbb3c44df288) | `` cargo-info: 0.7.3 -> 0.7.6 ``                                                   |
| [`5c731712`](https://github.com/NixOS/nixpkgs/commit/5c731712f2e9d60d36babe1f5494fd6e2630970c) | `` artem: 1.2.1 -> 2.0.0 ``                                                        |
| [`94aaa919`](https://github.com/NixOS/nixpkgs/commit/94aaa919d91bb986937a78a110fd164e25af0828) | `` vips: 8.14.2 -> 8.14.3 ``                                                       |
| [`96199b7b`](https://github.com/NixOS/nixpkgs/commit/96199b7b258e44b883086d4ce58579c6dd5a7a69) | `` imagemagick: 7.1.1-13 -> 7.1.1-14 ``                                            |
| [`582a3ed3`](https://github.com/NixOS/nixpkgs/commit/582a3ed37ed7c475375ae592a16d52875cd29c00) | `` ruff: 0.0.279 -> 0.0.280 ``                                                     |
| [`ae5661ba`](https://github.com/NixOS/nixpkgs/commit/ae5661ba8b494f83369d57d8d57c4d4e3c8c96e0) | `` yor: 0.1.182 -> 0.1.183 ``                                                      |
| [`6a5487e9`](https://github.com/NixOS/nixpkgs/commit/6a5487e94378e9e9faf7f8b763f344800bc05b1e) | `` frp: 0.51.0 -> 0.51.1 ``                                                        |
| [`45694c4e`](https://github.com/NixOS/nixpkgs/commit/45694c4e13a88345b788a67dbe0ae7ecc7ac5178) | `` maintainers: remove zgrannan ``                                                 |
| [`9c37be6d`](https://github.com/NixOS/nixpkgs/commit/9c37be6d84636106205dca0428d4d648324298f1) | `` markdown-pp: drop ``                                                            |
| [`7d9b2ace`](https://github.com/NixOS/nixpkgs/commit/7d9b2ace146548171d98aa193fa7f07fea59d108) | `` zsh-vi-mode: 0.9.0 -> 0.10.0 ``                                                 |
| [`326932c8`](https://github.com/NixOS/nixpkgs/commit/326932c8e14ed67e33ed94b0fb3f4b3b42296545) | `` age-plugin-ledger: init at 0.1.2 ``                                             |
| [`16b32782`](https://github.com/NixOS/nixpkgs/commit/16b32782b4a31a2f49a474d9ddc6eaa6ffd31739) | `` rstudio: supply missing #include <set> ``                                       |
| [`74e5a1a5`](https://github.com/NixOS/nixpkgs/commit/74e5a1a56b4d08d3d6eba8db2c3f13f74043a7da) | `` nfd: fixup build after boost version changes ``                                 |
| [`8e057e6e`](https://github.com/NixOS/nixpkgs/commit/8e057e6e858936ee694d47b5ea4245ab8e34095e) | `` gupnp-tools: fixup build after libxml2 upgrade ``                               |
| [`0cc6e62b`](https://github.com/NixOS/nixpkgs/commit/0cc6e62b351a27976807c9901904913a9774065d) | `` azure-cli: 2.49.0 → 2.50.0 ``                                                   |
| [`59aa11ce`](https://github.com/NixOS/nixpkgs/commit/59aa11ce8d08449c0cae44d5a9bbb5ea8bd77c90) | `` azure-cli: add akechishiro to maintainers ``                                    |
| [`c2e455f8`](https://github.com/NixOS/nixpkgs/commit/c2e455f854ff820542d1a90c8b386f7e757bb073) | `` maintainers: add akechishiro ``                                                 |
| [`510cd8c6`](https://github.com/NixOS/nixpkgs/commit/510cd8c618a07afc0ed0787795355638986c7323) | `` pot: 1.6.1 -> 1.10.0 ``                                                         |
| [`6bac82c5`](https://github.com/NixOS/nixpkgs/commit/6bac82c50482568030816cf0ed7ba1504f4f4d80) | `` clash-verge: 1.3.4 -> 1.3.5 ``                                                  |
| [`118c91d4`](https://github.com/NixOS/nixpkgs/commit/118c91d4bd4d89a26eef0b787b5aafe0f784bce2) | `` xfce.xfce4-cpugraph-plugin: 1.2.7 -> 1.2.8 ``                                   |
| [`a00e777b`](https://github.com/NixOS/nixpkgs/commit/a00e777b17d97db9b1ae533017c8b79b83bae5fe) | `` mmv: 2.4 -> 2.5 ``                                                              |
| [`ae246d5e`](https://github.com/NixOS/nixpkgs/commit/ae246d5e99eee698985caec08375b10f644ae306) | `` numix-icon-theme-square: 23.07.08 -> 23.07.21 ``                                |
| [`d31da8e6`](https://github.com/NixOS/nixpkgs/commit/d31da8e6d9aea2d775792438bdfcbfd7e2477879) | `` minimal-bootstrap.diffutils: init at 2.8.1 ``                                   |
| [`4a3ee99a`](https://github.com/NixOS/nixpkgs/commit/4a3ee99a784b553926bc040c66b58192b433f0a5) | `` wit-bindgen: 0.8.0 -> 0.9.0 ``                                                  |
| [`159ad4ca`](https://github.com/NixOS/nixpkgs/commit/159ad4ca18a548af74c6a13315408c6b0b4a19fd) | `` python310Packages.langchain: 0.0.229 -> 0.0.240 ``                              |
| [`bff379be`](https://github.com/NixOS/nixpkgs/commit/bff379bed81e9a1d0303697a315cf2c13c0f02e1) | `` python310Packages.grpcio-reflection: init at 1.56.2 ``                          |
| [`0c615db6`](https://github.com/NixOS/nixpkgs/commit/0c615db6d45564f549ac25c003ea5ea5b7adcbf4) | `` python310Packages.grpcio-health-checking: init at 1.56.2 ``                     |
| [`f266e42e`](https://github.com/NixOS/nixpkgs/commit/f266e42eea7cd1f3947c68c3cb765ac44bb7ea6d) | `` python310Packages.grpcio-channelz: init at 1.56.2 ``                            |
| [`5103cdf4`](https://github.com/NixOS/nixpkgs/commit/5103cdf48b725b5a45d5905c76ac6ed2cbbf2b56) | `` python310Packages.langsmith: init at 0.0.14 ``                                  |
| [`e54f06de`](https://github.com/NixOS/nixpkgs/commit/e54f06de69ef8f1a8e7c31e18facc161675c3b07) | `` dssp: 4.3.1 -> 4.4.2 ``                                                         |
| [`710796a1`](https://github.com/NixOS/nixpkgs/commit/710796a1b547784852a6713544653a28196bf942) | `` linuxPackages.rtl8821au: 2023-07-20 -> 2023-07-23 ``                            |
| [`784edf76`](https://github.com/NixOS/nixpkgs/commit/784edf766b8f30e4a395e7490d73811f23019874) | `` xemu: 0.7.97 -> 0.7.103 ``                                                      |
| [`9a238982`](https://github.com/NixOS/nixpkgs/commit/9a238982dcdea419f034ccc7191844750fad65f1) | `` alire: init at 1.2.2 ``                                                         |
| [`0ee251d5`](https://github.com/NixOS/nixpkgs/commit/0ee251d579280e05ee04f7d8aec74caaa274c899) | `` maintainers: add atalii ``                                                      |
| [`ca5fd1a0`](https://github.com/NixOS/nixpkgs/commit/ca5fd1a050c9d16bb2b2e7c16a0e346b7b37e02b) | `` cargo-cyclonedx: 0.3.7 -> 0.3.8 ``                                              |
| [`342e03ed`](https://github.com/NixOS/nixpkgs/commit/342e03edbf3fcdc13e8116dad8d2ee685e6b2031) | `` python310Packages.circus: enable checkPhase ``                                  |
| [`a326efe7`](https://github.com/NixOS/nixpkgs/commit/a326efe74c20b147981f6956a7385021c15288b4) | `` python310Packages.circus: reintroduce as python-modules ``                      |
| [`a15c2423`](https://github.com/NixOS/nixpkgs/commit/a15c24234fcc896151336e83069aecc980b44511) | `` circus: 0.16.1 -> 0.18.0 ``                                                     |
| [`478e0e9e`](https://github.com/NixOS/nixpkgs/commit/478e0e9e4a58b217731f42b9e841a888b74e82a1) | `` api-linter: init at 1.54.1 ``                                                   |
| [`03016d1f`](https://github.com/NixOS/nixpkgs/commit/03016d1fb089710a9d648607f8e1414fa532df05) | `` prometheus-node-exporter: add changelog to meta ``                              |
| [`b1544400`](https://github.com/NixOS/nixpkgs/commit/b15444007873527231090e09660bcd0dbefcfb6c) | `` prometheus-node-exporter: 1.6.0 -> 1.6.1 ``                                     |
| [`10dda399`](https://github.com/NixOS/nixpkgs/commit/10dda399503e7427ffc081bc493ef1107828e83b) | `` vimPlugins.sniprun: 1.3.4 -> 1.3.5 ``                                           |
| [`c50bb3bd`](https://github.com/NixOS/nixpkgs/commit/c50bb3bd16cd928fe5ea3876551d0332acba760d) | `` python310Packages.oci: 2.106.0 -> 2.107.0 ``                                    |
| [`1b516c5f`](https://github.com/NixOS/nixpkgs/commit/1b516c5f5d881ccaae0346223c06dae2257136f8) | `` s3fs: update meta ``                                                            |
| [`f18f3728`](https://github.com/NixOS/nixpkgs/commit/f18f372801ad10ec7d921e652e3682d72faf3d5d) | `` s3fs: 1.92 -> 1.93 ``                                                           |
| [`3c10b650`](https://github.com/NixOS/nixpkgs/commit/3c10b650b91ab6a6ca6839f5e280e091cba793aa) | `` virtualbox: 7.0.8 -> 7.0.10 ``                                                  |
| [`7e39636b`](https://github.com/NixOS/nixpkgs/commit/7e39636b1a79e8a14e177429bf6c14d5e482d743) | `` apt: add changelog to meta ``                                                   |
| [`d1277484`](https://github.com/NixOS/nixpkgs/commit/d127748498080a581dbff2c9f044f82b2850e771) | `` apt: 2.7.1 -> 2.7.2 ``                                                          |