### PR TITLE
chore(flake/darwin): `1c1dd8b0` -> `94212ebe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690329015,
-        "narHash": "sha256-cyRYHECh8JQL0HPW2LBEPtfmJ6oHZ6SrKgFvUXoUCAw=",
+        "lastModified": 1690368313,
+        "narHash": "sha256-1MG/pU2riawknpYaTfaynKJPaIKFnQiYTTCFJAjXM5Q=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "1c1dd8b0703feda8e7f1e7753088ae8307df5993",
+        "rev": "94212ebe32948471a1aa11baa5c576ce60d54589",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                               |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`6a00d1b5`](https://github.com/LnL7/nix-darwin/commit/6a00d1b59b2618c98977fb4200e71de28174d737) | `` Update modules/programs/bash/default.nix ``        |
| [`e21b70da`](https://github.com/LnL7/nix-darwin/commit/e21b70da3f9cd630629b83faa7762be5c6da23f2) | `` Don't run static bashrc only for pure nix-shell `` |