### PR TITLE
chore(flake/nix): `13d91ca0` -> `a95057b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -275,11 +275,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1686944709,
-        "narHash": "sha256-fMUJ3UqY4vuIVhLf7Sq5BK8YHhcNXTyQEtsoI02ez9E=",
+        "lastModified": 1690384605,
+        "narHash": "sha256-6o85ruMaNQ3XibjdMuhMUN9j4myrgPTGGe5wOJ+LaFk=",
         "owner": "lovesegfault",
         "repo": "nix",
-        "rev": "13d91ca08e005c387cf5d62a52de0283a1bda816",
+        "rev": "a95057b7fcc33c52827503f4dbb1c759e42075e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                                         |
| ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`a95057b7`](https://github.com/lovesegfault/nix/commit/a95057b7fcc33c52827503f4dbb1c759e42075e1) | `` feat: add always-allow-substitutes ``                                        |
| [`8398872a`](https://github.com/lovesegfault/nix/commit/8398872ae0e750f45979854e586d94638360ead4) | `` doc: clarify release notes about nested attribute merges ``                  |
| [`07d1e304`](https://github.com/lovesegfault/nix/commit/07d1e304b4e608bd33ae6ff7ff1760adab7385a4) | `` Bump version ``                                                              |
| [`a212300a`](https://github.com/lovesegfault/nix/commit/a212300a1d9f9c7b0daf19c00c87fc50480f54f4) | `` Mark official release ``                                                     |
| [`c51be034`](https://github.com/lovesegfault/nix/commit/c51be0345eda59b93dc1bda09d1c125f3f84d716) | `` Release notes ``                                                             |
| [`60d8dd7a`](https://github.com/lovesegfault/nix/commit/60d8dd7aeaf7fc022a1b207012c94180f6732b45) | `` Clean up store hierarchy with `IndirectRootStore` ``                         |
| [`13269ba9`](https://github.com/lovesegfault/nix/commit/13269ba93b7453def7084b00eb4a34ad787a7c45) | `` Make `RemoteStore::ConnectionHandle` part of class and expose ``             |
| [`0a30b072`](https://github.com/lovesegfault/nix/commit/0a30b072779aa605b92f1961fe94218ccd183669) | `` Move `Store::Params` typedef to `StoreConfig::Params` ``                     |
| [`570a1a3a`](https://github.com/lovesegfault/nix/commit/570a1a3ad773d93aa2128a8fba49f98e1e115d5d) | `` parser: merge nested dynamic attributes ``                                   |
| [`6bc98c7f`](https://github.com/lovesegfault/nix/commit/6bc98c7fba9f783414692fcef41d90ed80928b6c) | `` Give `queryPartialDerivationOutputMap` an `evalStore` parameter ``           |
| [`f62543fe`](https://github.com/lovesegfault/nix/commit/f62543fe1cc544a5684af327f63a1aeb1bdeba94) | `` Remove unneeded copy ``                                                      |
| [`7b30293d`](https://github.com/lovesegfault/nix/commit/7b30293d389ea75ee24ec1f2a4a4187f175757ab) | `` Tighten `#include`s: `DerivedPath` doesn't care about `Realisation` ``       |
| [`85d0eb63`](https://github.com/lovesegfault/nix/commit/85d0eb63165e7d7f441fe3dd94bb548a40502e52) | `` fix broken links (#8722) ``                                                  |
| [`0e4f6dfc`](https://github.com/lovesegfault/nix/commit/0e4f6dfcf7303bfe3c5d8af6863d57b3e70d370a) | `` revert anchor prefix for builtin constants ``                                |
| [`b0173716`](https://github.com/lovesegfault/nix/commit/b0173716f6b27b4fb307ac9ded544e46e712ad22) | `` clarify wording on args@ default handling (#8596) ``                         |
| [`6c3cd429`](https://github.com/lovesegfault/nix/commit/6c3cd429a6aabe8673af99d6bc0653d376dd69b8) | `` fix broken links ``                                                          |
| [`0779005f`](https://github.com/lovesegfault/nix/commit/0779005f4945d373b81c933a6b7390c8bc7ad6cb) | `` expand on the `extra-platforms` option ``                                    |
| [`fcadac0a`](https://github.com/lovesegfault/nix/commit/fcadac0a02b30d1d876c804edf7f2745d880a10c) | `` mention `extra-platforms` ``                                                 |
| [`aba32def`](https://github.com/lovesegfault/nix/commit/aba32def7390432855401b815ff21915aba3eb81) | `` fix wording ``                                                               |
| [`1a220bed`](https://github.com/lovesegfault/nix/commit/1a220bed9361be2c360f83eb42025f9765c96f34) | `` do not mention output attributes ``                                          |
| [`c8f04e20`](https://github.com/lovesegfault/nix/commit/c8f04e2024d3e66f620ae38258fa86eb6103ce05) | `` note that naming convention is from Autotools ``                             |
| [`32de1192`](https://github.com/lovesegfault/nix/commit/32de11923e932b5bbda8ce4877542fb299de9b03) | `` add cross-links ``                                                           |
| [`4944e37e`](https://github.com/lovesegfault/nix/commit/4944e37ec04cc8c62f35aa9b1f4e97ee8f233eb8) | `` expand on the system type in hacking guide ``                                |
| [`3763c7bb`](https://github.com/lovesegfault/nix/commit/3763c7bb5ef5a7a1ddcf47169c9733edb7989e98) | `` shorten `system` setting description ``                                      |
| [`c8a42039`](https://github.com/lovesegfault/nix/commit/c8a42039eae4c046297517b67a3ce43685d3e756) | `` move docs of the current system to the system setting ``                     |
| [`0751c1bf`](https://github.com/lovesegfault/nix/commit/0751c1bfc6375ffbe94e90cfcfdb987e8b286f2e) | `` one line per sentence for easier review ``                                   |
| [`68b7bb1a`](https://github.com/lovesegfault/nix/commit/68b7bb1a062c6471b678d5488a71324e0486d405) | `` add information on the system type string ``                                 |
| [`e14c8a35`](https://github.com/lovesegfault/nix/commit/e14c8a359efcacd267064b9c7d28adb0f41a168e) | `` list moving parts of channels ``                                             |
| [`4bab5a62`](https://github.com/lovesegfault/nix/commit/4bab5a62081a792530de8c4ae2cd163c1bb581a5) | `` revert channel files overview ``                                             |
| [`cd0e39bd`](https://github.com/lovesegfault/nix/commit/cd0e39bd899b51d0b1f139117b1fd6c1280caa70) | `` remove redundant information from channel profile description ``             |
| [`ee72ede3`](https://github.com/lovesegfault/nix/commit/ee72ede389a7a8b9ac2d0f908b2524950d72f303) | `` remove the Channels section ``                                               |
| [`259e328d`](https://github.com/lovesegfault/nix/commit/259e328de81a91cf824efb0603f57fcde94ad3ff) | `` Introduce notion of a test group, use for CA tests ``                        |
| [`a5c88f86`](https://github.com/lovesegfault/nix/commit/a5c88f860987bd5dec8c96efed1e6c9d8ce7a669) | `` Nix Reference Manual: keep nix expressions uptodate with nixpkgs (#8703) ``  |
| [`0f7242ff`](https://github.com/lovesegfault/nix/commit/0f7242ff8712939e64f049dc8e14663d2b3e3585) | `` Test nested sandboxing, and make nicer error ``                              |
| [`adb28d4a`](https://github.com/lovesegfault/nix/commit/adb28d4a26598fbc342dd18d2dd42621953c7b6d) | `` move unset NIX_STORE_DIR in supplementary-groups.sh ``                       |
| [`1a137578`](https://github.com/lovesegfault/nix/commit/1a13757880479921966adeca839cf182b3ffcbd0) | `` Add comment regarding the unset of NIX_STORE_DIR ``                          |
| [`84c4e6f0`](https://github.com/lovesegfault/nix/commit/84c4e6f0acfc902955d580aa090aa52f20ee82ad) | `` Revert "Skip build-remote-trustless unless sandbox is supported." ``         |
| [`9e64f243`](https://github.com/lovesegfault/nix/commit/9e64f243406ff2b3fbe06adbc762cf965e6825a8) | `` Revert "Check _NIX_TEST_NO_SANDBOX when setting _canUseSandbox." ``          |
| [`e072e184`](https://github.com/lovesegfault/nix/commit/e072e18475bc461e522f34d63cc74fc5fbf1640e) | `` Fix race condition in the language tests ``                                  |
| [`2c3fb0eb`](https://github.com/lovesegfault/nix/commit/2c3fb0eb33d205d1937b7ed801bdb36bb301d1a8) | `` Move `BuiltPath` to its own header/C++ file in libcmd ``                     |
| [`a2acd234`](https://github.com/lovesegfault/nix/commit/a2acd23466108a1a10ed3b6b874c558bd95e7645) | `` Update src/libstore/globals.hh ``                                            |
| [`0309f6b5`](https://github.com/lovesegfault/nix/commit/0309f6b5b8ca354e1a43d320928d3d546ce7f878) | `` Update src/libstore/globals.hh ``                                            |
| [`c7048445`](https://github.com/lovesegfault/nix/commit/c70484454f52a3bba994ac0c155b4a6f35a5013c) | `` Expanded test suite ``                                                       |
| [`41412dc4`](https://github.com/lovesegfault/nix/commit/41412dc4ae0fec2d08335c19724276d99e0c6056) | `` Skip build-remote-trustless unless sandbox is supported. ``                  |
| [`c1d39de1`](https://github.com/lovesegfault/nix/commit/c1d39de1fbceebbb6b46abc4a21fb8e34423df99) | `` Check _NIX_TEST_NO_SANDBOX when setting _canUseSandbox. ``                   |
| [`b8e8dfc3`](https://github.com/lovesegfault/nix/commit/b8e8dfc3e8581a08bc179f75fbe61e04030088de) | `` Say a bit about default value in setting description. ``                     |
| [`a193ec40`](https://github.com/lovesegfault/nix/commit/a193ec4052d9efa895681c438cc335296c7affea) | `` Default should depend on whether we are root. ``                             |
| [`2b4c59dd`](https://github.com/lovesegfault/nix/commit/2b4c59dd997c72069b6039783fea4c3b35f5cee7) | `` Be clearer about the security implications. ``                               |
| [`0caf28f2`](https://github.com/lovesegfault/nix/commit/0caf28f2386b656b29a84ba83a20cf2abce8a606) | `` Update description for require-drop-supplementary-groups. ``                 |
| [`07dabcc9`](https://github.com/lovesegfault/nix/commit/07dabcc90ed8f2a2e7b98d858a47de3e75d2c3a2) | `` Always attempt setgroups but allow failure to be ignored. ``                 |
| [`c2c81871`](https://github.com/lovesegfault/nix/commit/c2c8187118c4bf2961aa175ff8667e1402a767c7) | `` Fix test file name ``                                                        |
| [`3fa0266e`](https://github.com/lovesegfault/nix/commit/3fa0266e7a736e85e2faaa6c92ab23e809f89930) | `` Fix some grammar in installables doc (#8682) ``                              |
| [`3d74e7b8`](https://github.com/lovesegfault/nix/commit/3d74e7b811ea8fc13e31127175be12ba8d39351c) | `` libexpr: remove std::move() for `basePath` in parser, it has no effect ``    |
| [`be518e73`](https://github.com/lovesegfault/nix/commit/be518e73ae331ac2f46e6b3a0ffdfeead26e3186) | `` Clean up `SearchPath` ``                                                     |
| [`87dcd090`](https://github.com/lovesegfault/nix/commit/87dcd090470ed6e56a2744cbe1490d2cf235d5c0) | `` Clean up `resolveSearchPathElem` ``                                          |
| [`d76bf29c`](https://github.com/lovesegfault/nix/commit/d76bf29c5f55f63f10741290c8d415c880a80ac2) | `` Choose a reasonable number similar to LimitNOFile ``                         |
| [`9fc82de4`](https://github.com/lovesegfault/nix/commit/9fc82de49388a58240234d10893673566432f7ab) | `` signing.sh: Revert test improvement because it fails on GHA + macOS ``       |
| [`903700c5`](https://github.com/lovesegfault/nix/commit/903700c5e168e2ab5bd6bee5e09b5908cb2908d6) | `` Simplify `ContentAddress` ``                                                 |
| [`b4b02d08`](https://github.com/lovesegfault/nix/commit/b4b02d084f066d6391074ac807e532e36e4eccd9) | `` fetchClosure: Interleave the examples in the docs ``                         |
| [`537e8beb`](https://github.com/lovesegfault/nix/commit/537e8beb770ed92dd1d5a20796a86620c4c61389) | `` fetchClosure: Apply suggestions from code review ``                          |
| [`4b2f155f`](https://github.com/lovesegfault/nix/commit/4b2f155f0a22179e46d2c55cb1bd074c885fd08e) | `` nix-daemon.service: Add TasksMax=infinity ``                                 |
| [`82d66999`](https://github.com/lovesegfault/nix/commit/82d6699976aa51cb6c06272d3455b32299b2c4ff) | `` Document the path flakeref format (#8640) ``                                 |
| [`5fbfbb4c`](https://github.com/lovesegfault/nix/commit/5fbfbb4c7c246090df3debf7688f5ee9f01a4cbb) | `` Fix test ``                                                                  |
| [`a353412c`](https://github.com/lovesegfault/nix/commit/a353412c43e776f4fdc709dc7affd1dbb9d588be) | `` nix profile list: Add --json flag ``                                         |
| [`b8e8f271`](https://github.com/lovesegfault/nix/commit/b8e8f27159251091141ccd6db12dd2d07204771a) | `` Rename 'resolvedRef' to 'lockedRef' ``                                       |
| [`3c90340f`](https://github.com/lovesegfault/nix/commit/3c90340fe64fb18e66f02a648ebce8ad629482a5) | `` libexpr: use `thread_local` to make the parser thread-safe ``                |
| [`87b82db8`](https://github.com/lovesegfault/nix/commit/87b82db8812736922de851a27681dd0b2955c2f0) | `` nix profile list: Improve readability of the output ``                       |
| [`a6c17097`](https://github.com/lovesegfault/nix/commit/a6c17097d2ee76a347d86c42a37fd6de0d0fd3ef) | `` tests: Don't install test-libstoreconsumer program ``                        |
| [`fefb9471`](https://github.com/lovesegfault/nix/commit/fefb94713295d63d30a8bba257c41c3eb54e0998) | `` tests/signing.sh: Check signature checking error message ``                  |
| [`1db81f71`](https://github.com/lovesegfault/nix/commit/1db81f710725eb83597b1761076e9ca28317a52e) | `` tests/fetchClosure: Improve coverage of new and some existing flows ``       |
| [`40052c76`](https://github.com/lovesegfault/nix/commit/40052c76132d79561aa50ec9349ad22b51c64505) | `` fetchClosure: Docs and error message improvements ``                         |
| [`50de11d6`](https://github.com/lovesegfault/nix/commit/50de11d662ced6bfef792af54ad57553f1c3208a) | `` doc: Improve `fetchClosure` documentation ``                                 |
| [`32c69e2b`](https://github.com/lovesegfault/nix/commit/32c69e2b17ad7bd9721b584c3733629fe6d8c7f7) | `` doc: Typo ``                                                                 |
| [`dc796360`](https://github.com/lovesegfault/nix/commit/dc79636007ff6982300980ba7eb1c2be3e45bece) | `` fetchClosure: Refactor: replace enableRewriting ``                           |
| [`5bdca461`](https://github.com/lovesegfault/nix/commit/5bdca46117c701cd1cd47700c755367442537157) | `` fetchClosure: Split into three cases ``                                      |
| [`55888633`](https://github.com/lovesegfault/nix/commit/55888633dd323c83cd1db3773d82dc954da34888) | `` makeContentAddressed: Add single path helper ``                              |
| [`8dca9538`](https://github.com/lovesegfault/nix/commit/8dca95386c9ab8b13886716ec31e1b2936a3ef10) | `` fetchClosure: Disallow toPath for inputAddressed = true ``                   |
| [`508aa58e`](https://github.com/lovesegfault/nix/commit/508aa58e671583bf06fa3597629839827c8d1bd7) | `` fetchClosure: Always check that inputAddressed matches the result ``         |
| [`ea30f152`](https://github.com/lovesegfault/nix/commit/ea30f152b738fe65f216f3173d3a19adaaef5323) | `` fetchClosure: Allow input addressed paths in pure mode ``                    |
| [`7e5b6d2c`](https://github.com/lovesegfault/nix/commit/7e5b6d2c4550a3007946271768e114531d7b89f0) | `` fetchClosure: Refactor: rename toCA -> enableRewriting ``                    |
| [`0f6d596d`](https://github.com/lovesegfault/nix/commit/0f6d596df5866d3f08e743ac0f1a282daf6b2155) | `` fetchClosure: Factor out attribute hint ``                                   |
| [`eebfe989`](https://github.com/lovesegfault/nix/commit/eebfe989a5dc3aac622b9b5f2edef4461d8968c1) | `` linkOrCopy: Fallback upon cross-device link error (EXDEV) ``                 |
| [`685f1bb3`](https://github.com/lovesegfault/nix/commit/685f1bb3864d52b80e74f920a150f8ffc7a479c3) | `` labeler.yml: tests -> with-tests ``                                          |
| [`3468cbaf`](https://github.com/lovesegfault/nix/commit/3468cbaf479e3a2e9b3c7d6b00b2cb1976cce43e) | `` libexpr: fix leaking `es2` in stripIndentation (parser.y) ``                 |
| [`ca49e134`](https://github.com/lovesegfault/nix/commit/ca49e13414b4d1d9b2cdd72e36920e28c4ef117e) | `` Split testing into its own page in the contribution guide ``                 |
| [`2ccc0251`](https://github.com/lovesegfault/nix/commit/2ccc02515f4a52d59f3473493f254942209fc81b) | `` Trailing commas in redirects ``                                              |
| [`80c92597`](https://github.com/lovesegfault/nix/commit/80c9259756811c1165167db1bb66c1fef0accb65) | `` Allow to sign path as unprivileged user ``                                   |
| [`22b278e0`](https://github.com/lovesegfault/nix/commit/22b278e011ab9c1328749a126514c57b89a39173) | `` Automatically document builtin constants ``                                  |
| [`d40f0e53`](https://github.com/lovesegfault/nix/commit/d40f0e534d657e619634ba204fb8970f4a01fbc5) | `` Don't say this when we still pollute the global scope ``                     |
| [`4da7c866`](https://github.com/lovesegfault/nix/commit/4da7c866181c699b43d3cd2fff0afd2505774be7) | `` Switch example to a primop this is less ill-advised ``                       |
| [`e8067daf`](https://github.com/lovesegfault/nix/commit/e8067daf0955c297f389c968dab3e927b395de07) | `` Generialize `showType` ``                                                    |
| [`559fd7ff`](https://github.com/lovesegfault/nix/commit/559fd7ffe7a8cb61b11bec081f14ce3c3ffb210d) | `` nix flake check: improve error message if overlay is not a lambda (#8582) `` |
| [`a7b49086`](https://github.com/lovesegfault/nix/commit/a7b49086c76bc181ab1cf1d3c7fba44b06d2f1dd) | `` Add `dirtyRev` and `dirtyShortRev` to `fetchGit` ``                          |
| [`484290a9`](https://github.com/lovesegfault/nix/commit/484290a9e05ea840f9bc6ba3cc98d64ccffe202b) | `` Use a struct not `std::pair` for `SearchPathElem` ``                         |
| [`9d8c4ac4`](https://github.com/lovesegfault/nix/commit/9d8c4ac446bed82eb22a989cd81982acd722c58a) | `` libexpr: remove unused token `ATTRPATH` in token declaration ``              |
| [`97df0605`](https://github.com/lovesegfault/nix/commit/97df060588e4d328a7e219107553087149a77bac) | `` Better document build failure exit codes ``                                  |
| [`1400fde1`](https://github.com/lovesegfault/nix/commit/1400fde144e1fdde2647fda5a7f9511f25572a35) | `` libexpr: extend `Value::print` to allow limited depth ``                     |
| [`c48277c1`](https://github.com/lovesegfault/nix/commit/c48277c1c15f0b6be6a47271a6f8399fad96f7fd) | `` libexpr: add tests for `nix::Value::print` ``                                |
| [`5cc22e33`](https://github.com/lovesegfault/nix/commit/5cc22e337023cee9cbffd3f9d2ff0eb3f18a4d12) | `` Clarify docs on deleting generations, including fixing a mistake ``          |
| [`5f9a921b`](https://github.com/lovesegfault/nix/commit/5f9a921bc1e6d3e6bf65601be565585cf0190e8f) | `` do not use "target", as it's a loaded term in the domain of compilers ``     |
| [`08510494`](https://github.com/lovesegfault/nix/commit/085104944b2957f4269fcbfaf0d1874ab0c9ce84) | `` add redirects to changed anchors ``                                          |
| [`a78f9290`](https://github.com/lovesegfault/nix/commit/a78f929065fd209e3d89853c6beb48942e3820e9) | `` fix anchor link ``                                                           |
| [`3a20c7c4`](https://github.com/lovesegfault/nix/commit/3a20c7c46c64d2feb8caba767724a78d7efa3279) | `` Update tests/linux-sandbox.sh ``                                             |
| [`71317162`](https://github.com/lovesegfault/nix/commit/71317162c50df91d421eacdf87d50b4ba6d37635) | `` use more self-descriptive section headings ``                                |
| [`e91d19db`](https://github.com/lovesegfault/nix/commit/e91d19db5f827cec56e32fe9b7c07c8d2c546ce6) | `` be more serious about security risks with trusted users ``                   |
| [`68c62193`](https://github.com/lovesegfault/nix/commit/68c62193439ec90d34a7988c6a1a73b3e553a435) | `` clarify setting options on the command line ``                               |
| [`bc7324e9`](https://github.com/lovesegfault/nix/commit/bc7324e912578cdbeb1f10bf1c8d9b447a416dbd) | `` clarify read order for configuration settings ``                             |
| [`38bd1cc9`](https://github.com/lovesegfault/nix/commit/38bd1cc9bc80e6dec59e56a7d1ce19379915a910) | `` split configuration file page into sections ``                               |
| [`f2b54e3b`](https://github.com/lovesegfault/nix/commit/f2b54e3b71891c29f951e46b00c6edc4807b3b63) | `` add links to environment variables documentation ``                          |
| [`6ae35534`](https://github.com/lovesegfault/nix/commit/6ae35534b7b6e10a26a0f2b2a0e37d7f7cfe47dd) | `` Support opening local store with database on read-only filesystem (#8356) `` |
| [`a6a75eca`](https://github.com/lovesegfault/nix/commit/a6a75ecad8c1a8bf264eb003b8c07c0fd66f80fb) | `` GC server: Clear O_NONBLOCK on the right file descriptor ``                  |
| [`33d38898`](https://github.com/lovesegfault/nix/commit/33d388983156e3cdd360a9bb87662da1b8a35f7a) | `` redirect old platform uninstall instruction links ``                         |
| [`3910430b`](https://github.com/lovesegfault/nix/commit/3910430b9d034c277650f4ff05a27008ede73c18) | `` Add more links in nix-build documentation (#8545) ``                         |
| [`3859cf6b`](https://github.com/lovesegfault/nix/commit/3859cf6b21dddd7e9de729dc42b2f52d8523c239) | `` Remove unused `#include` from `local-derivation-goal.cc` ``                  |
| [`9f69b7de`](https://github.com/lovesegfault/nix/commit/9f69b7dee9fc6035b8aa0cc718f5e74af460d9aa) | `` Create `worker_proto::{Read,Write}Conn` ``                                   |
| [`4e8b495a`](https://github.com/lovesegfault/nix/commit/4e8b495ad7dddabc35bf9d6afe3573426ffed15d) | `` Likewise namespace and `enum struct`-ify `ServeCommand` ``                   |
| [`95eae0c0`](https://github.com/lovesegfault/nix/commit/95eae0c002da5ef35e583b46a67818ebb95d3a1e) | `` Put worker protocol items inside a `WorkerProto` struct ``                   |
| [`469d06f9`](https://github.com/lovesegfault/nix/commit/469d06f9bc9b2543f48d8e633e47f9344fba35ab) | `` Split out worker protocol template definitions from declarations ``          |
| [`b6e74ea5`](https://github.com/lovesegfault/nix/commit/b6e74ea5a82e5c43d42bf8386236947408748a96) | `` maintainers: add note on marking PRs as draft ``                             |
| [`966e5dc9`](https://github.com/lovesegfault/nix/commit/966e5dc991e849d2cd26d19266ae3f065ec69c96) | `` CONTRIBUTING.md: add link to "good first issues" ``                          |
| [`c404623a`](https://github.com/lovesegfault/nix/commit/c404623a1d39431cf7b4ccd0b0b396a821a6eade) | `` Clean up a few things related to profiles (#8526) ``                         |
| [`7bf17f88`](https://github.com/lovesegfault/nix/commit/7bf17f8825b7aacde8b4e3c5e035f6d442d649c4) | `` Add description for file system objects (#8500) ``                           |
| [`6b06e97b`](https://github.com/lovesegfault/nix/commit/6b06e97bde3d2d87a750210d46086624dc96a0f8) | `` src/libexpr/eval.hh: add link for allowed-uris option ``                     |
| [`d2ce2e89`](https://github.com/lovesegfault/nix/commit/d2ce2e89b178e7e7467cf4c1e572704a4c2ca75e) | `` Split `OptionalPathSetting` from `PathSetting` ``                            |
| [`c8825e9d`](https://github.com/lovesegfault/nix/commit/c8825e9d8c3fa802811f3829d055e3ef9aae90e2) | `` Create nlohmann serializers for `std::optional` and use ``                   |
| [`b931d835`](https://github.com/lovesegfault/nix/commit/b931d83550b200676c36ae8d1038a281ae4aa0ad) | `` ci: bump install-nix-action, don't fail fast ``                              |
| [`741f7837`](https://github.com/lovesegfault/nix/commit/741f7837f85d1675efbcf43877bbcdfb9a862745) | `` Fix wikipedia links (#8533) ``                                               |
| [`f695a747`](https://github.com/lovesegfault/nix/commit/f695a74751c314cc426ff7bbc67ce5de8b58bbfd) | `` Update src/libstore/globals.hh ``                                            |
| [`b1ed9b4b`](https://github.com/lovesegfault/nix/commit/b1ed9b4b0cc037a8b14dcc37fd32f6a5a16e7ba3) | `` Apply suggestions from code review ``                                        |
| [`cab03fb7`](https://github.com/lovesegfault/nix/commit/cab03fb7794f6e20e02dc1460a78201ab3955c18) | `` Add docs ``                                                                  |
| [`baef05e6`](https://github.com/lovesegfault/nix/commit/baef05e6fefb46b3bdddb2785861bd7190920506) | `` fix typo ``                                                                  |
| [`126eea48`](https://github.com/lovesegfault/nix/commit/126eea48e300ab365c46ce062776e74a3907a7c8) | `` do not refer to `trusted-users` another time ``                              |
| [`1a8ca85d`](https://github.com/lovesegfault/nix/commit/1a8ca85d488ddacf26f2aeddddab926c0e081d98) | `` use "store URLs" consistently ``                                             |
| [`4a33d5fe`](https://github.com/lovesegfault/nix/commit/4a33d5fe3549137bacf9373e5ba7bfe11a421099) | `` fix link text ``                                                             |
| [`b2247ef4`](https://github.com/lovesegfault/nix/commit/b2247ef4f6b02cf4e666455eb9afc86398fff35d) | `` Don't assume the type of string::size_type ``                                |
| [`2ceacce4`](https://github.com/lovesegfault/nix/commit/2ceacce484e21ac116a79c74877327355fd153d0) | `` Update src/libstore/globals.hh ``                                            |
| [`d2696cdd`](https://github.com/lovesegfault/nix/commit/d2696cdd1ee404ef6c6bd532cb90007dd8ee3e9f) | `` Fix build hook error for libstore library users ``                           |
| [`e1fa48f1`](https://github.com/lovesegfault/nix/commit/e1fa48f17c0bb0f73e97e684077cec8dfa1d7a3d) | `` Update src/nix/daemon.cc ``                                                  |
| [`80451b76`](https://github.com/lovesegfault/nix/commit/80451b762d71bfbc14dbd2c2d88fda7dcb9571cf) | `` style: use plurals in uid ranges ``                                          |
| [`098fbf62`](https://github.com/lovesegfault/nix/commit/098fbf6273bb5ee69b8dc1a4354d45d9a605541a) | `` src/libexpr/eval.hh: fix typo ``                                             |
| [`b7d47e1d`](https://github.com/lovesegfault/nix/commit/b7d47e1d22e7ce2785487d325cc3dd35a43f16b5) | `` fix wording ``                                                               |
| [`c3c40763`](https://github.com/lovesegfault/nix/commit/c3c40763421e881ed5c326ed88a0539b6585c368) | `` make domain-specificity more specific ``                                     |
| [`52049160`](https://github.com/lovesegfault/nix/commit/520491607efb7b65704b600077e8fed21562597a) | `` docs issue template: move checklist down ``                                  |
| [`c453719d`](https://github.com/lovesegfault/nix/commit/c453719d6e9e1f96f4591b3da359d08b0ce11575) | `` rename files referring to antiquotation ``                                   |
| [`e09b40e0`](https://github.com/lovesegfault/nix/commit/e09b40e0d0b68ca7c3646ddffb50e1356daec997) | `` reword documentation on trusted users and substituters ``                    |
| [`4b487317`](https://github.com/lovesegfault/nix/commit/4b487317c30060024df436d010e6126be3a3d49e) | `` style: use mathematical interval notation ``                                 |
| [`5b7e2857`](https://github.com/lovesegfault/nix/commit/5b7e285727e23135a65597bcaab6d043d6d61ed6) | `` Improve `nix-collect-garbage` docs ``                                        |
| [`b55f26c6`](https://github.com/lovesegfault/nix/commit/b55f26c65f4ca0e80bd0f3c6436333f054acf6d6) | `` Improve `nix-env --delete-generations` docs ``                               |
| [`d4a2ced9`](https://github.com/lovesegfault/nix/commit/d4a2ced9cb99253a277c1507baf001d51871842f) | `` Split out `nix-collect-garbage -d` test to new file ``                       |
| [`ca5752d4`](https://github.com/lovesegfault/nix/commit/ca5752d4faecad8b87ba59892b9ca2a3d8350837) | `` Add another case to the `nix-collect-garbage -d` test ``                     |
| [`a1cf1656`](https://github.com/lovesegfault/nix/commit/a1cf16563f681b5cb3026f2bbca629996ed36d86) | `` Fixup description of substituters (#8291) ``                                 |
| [`a0c4d585`](https://github.com/lovesegfault/nix/commit/a0c4d585494ab80e9d0095a54cc46eb9e3977f2d) | `` Remove RegisterPrimOp constructor without support for documentation ``       |
| [`468add5a`](https://github.com/lovesegfault/nix/commit/468add5aa0b5b0a686cd07aa5417817bb8799602) | `` Remove dead code (#8504) ``                                                  |
| [`c73daea6`](https://github.com/lovesegfault/nix/commit/c73daea61eba8679a3281ac8e1af1e8eeefe9452) | `` darwin installer: remove the file before installing new one ``               |
| [`bfb5e0bd`](https://github.com/lovesegfault/nix/commit/bfb5e0bdcddc3ba4866d30c54de49248ca763951) | `` build: show UID and GID in welcome message ``                                |
| [`c6d7c4f9`](https://github.com/lovesegfault/nix/commit/c6d7c4f9ecb919cced435cf179d8ece5d25b5f06) | `` Document fromTOML, hasContext and getContext builtins ``                     |
| [`1ad3328c`](https://github.com/lovesegfault/nix/commit/1ad3328c5efea041990fa82e6ad24ae2b4e81c24) | `` Allow tarball URLs to redirect to a lockable immutable URL ``                |
| [`3402b650`](https://github.com/lovesegfault/nix/commit/3402b650cdce318e42acd4dc34f42423cafef587) | `` Add a generic check for rev attribute mismatches ``                          |
| [`d5e1eb20`](https://github.com/lovesegfault/nix/commit/d5e1eb20a2712eb17076c3ca2d30e5ac4a351d00) | `` Pass common ssh options in isMasterRunning ``                                |
| [`5454fdcc`](https://github.com/lovesegfault/nix/commit/5454fdcceb2004c67b0c829ae1ee447da9c81d00) | `` Add test of explicit ssh control path in nix-copy test ``                    |
| [`f961b044`](https://github.com/lovesegfault/nix/commit/f961b04484a5770d12ad7866d86d1d1f8e7c687c) | `` Bump zeebe-io/backport-action from 1.3.0 to 1.3.1 ``                         |
| [`0e3849dc`](https://github.com/lovesegfault/nix/commit/0e3849dc650250e36fb69c197a8a1fffe4f7d480) | `` test: add test for non-defaulting for stding installable input ``            |
| [`87c66f6b`](https://github.com/lovesegfault/nix/commit/87c66f6b0f35bc59749cad6bfb3dc2e23de8c86b) | `` Don't include uds-remote-store.md from a header file ``                      |
| [`8ec1ba02`](https://github.com/lovesegfault/nix/commit/8ec1ba02109eee7e8dfd89f3fbbf060497940469) | `` Register all PrimOps via the Info structure ``                               |
| [`08089fdd`](https://github.com/lovesegfault/nix/commit/08089fdd3284fcb27bcec347d6bf88ec2a79a8a0) | `` fix: Do not apply default installables when using --stdin ``                 |
| [`c51f3f1e`](https://github.com/lovesegfault/nix/commit/c51f3f1eb250dc006af3de340b1d20b759fed9d7) | `` nix actually needs c++20 now ``                                              |
| [`e54538c4`](https://github.com/lovesegfault/nix/commit/e54538c461e993827d9fbe3b8883d3887f184798) | `` restoreMountNamespace(): Restore the original root directory ``              |
| [`3c78920f`](https://github.com/lovesegfault/nix/commit/3c78920f7358957dba37a379e9d0b062dd3192e2) | `` Parse TOML timestamps (#8120) ``                                             |
| [`db680e0e`](https://github.com/lovesegfault/nix/commit/db680e0e5751828e788bff4becd89886bde71480) | `` refine wording on the purpose of the Nix language ``                         |
| [`76e032bc`](https://github.com/lovesegfault/nix/commit/76e032bcf8445dc6db1ebfa1e7a8a9b377dd4242) | `` Upload the manual to releases.nixos.org ``                                   |
| [`d14f993a`](https://github.com/lovesegfault/nix/commit/d14f993a768452e6dfc34e3534aac8878fc711e6) | `` Fix MIME type ``                                                             |
| [`42e908a3`](https://github.com/lovesegfault/nix/commit/42e908a3081a040619d5f65ce52d08cb1e29397d) | `` Upload fallback-paths.nix as part of the release ``                          |
| [`f5c6b299`](https://github.com/lovesegfault/nix/commit/f5c6b299407e2ad5d05670bf4e89e18ebb113070) | `` Fix SourcePath::resolveSymlinks() ``                                         |
| [`b37dd43d`](https://github.com/lovesegfault/nix/commit/b37dd43db4f0c9d675653c7d423407f368298173) | `` Add missing <sys/select.h> include ``                                        |