### PR TITLE
chore(flake/nixpkgs): `b12803b6` -> `ef99fa5c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1690179384,
-        "narHash": "sha256-+arbgqFTAtoeKtepW9wCnA0njCOyoiDFyl0Q0SBSOtE=",
+        "lastModified": 1690272529,
+        "narHash": "sha256-MakzcKXEdv/I4qJUtq/k/eG+rVmyOZLnYNC2w1mB59Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b12803b6d90e2e583429bb79b859ca53c348b39a",
+        "rev": "ef99fa5c5ed624460217c31ac4271cfb5cb2502c",
         "type": "github"
       },
       "original": {

--- a/graphical/fonts.nix
+++ b/graphical/fonts.nix
@@ -1,7 +1,7 @@
 { hostType, lib, pkgs, ... }: {
   fonts = {
     fontDir.enable = hostType == "darwin";
-    fonts = with pkgs; [
+    packages = with pkgs; [
       # FIXME: Make nix-darwin stop exploding when there are repeated fonts
       # dejavu_fonts
       # noto-fonts-extra
@@ -11,7 +11,7 @@
       unifont
     ];
   } // lib.optionalAttrs (hostType == "nixos") {
-    enableDefaultFonts = false;
+    enableDefaultPackages = false;
     enableGhostscriptFonts = false;
     fontconfig = {
       localConf = ''


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`5a5ddf79`](https://github.com/NixOS/nixpkgs/commit/5a5ddf79cc75e2f10a8d5b5dbaa31587ad8b6883) | `` linux-firmware: fix build, add explicit revision ``                               |
| [`b4da2293`](https://github.com/NixOS/nixpkgs/commit/b4da229372cbed279f72ba7c23a43dc201e2bcf1) | `` python310Packages.python-benedict: 0.31.0 -> 0.32.0 ``                            |
| [`f8812915`](https://github.com/NixOS/nixpkgs/commit/f881291531e6fb508bb7a7fb9fed21fc2f90cc1d) | `` sing-box: 1.3.3 -> 1.3.4 ``                                                       |
| [`0fd12ade`](https://github.com/NixOS/nixpkgs/commit/0fd12ade14c3215b512dc977f8400d6c06a6cfed) | `` skaffold: 2.6.1 -> 2.6.2 ``                                                       |
| [`7225fb14`](https://github.com/NixOS/nixpkgs/commit/7225fb140d5f941c5d65b86a42ca9f15a1e25923) | `` phpunit: 10.2.3 -> 10.2.6 ``                                                      |
| [`b3c41082`](https://github.com/NixOS/nixpkgs/commit/b3c41082e98dfde590c1e49df039109473f5441f) | `` cargo-make: 0.36.11 -> 0.36.12 ``                                                 |
| [`bb939f36`](https://github.com/NixOS/nixpkgs/commit/bb939f366650c7a642afa69cee6fcc829f7ceae5) | `` kubergrunt: 0.11.3 -> 0.12.0 ``                                                   |
| [`f86d493b`](https://github.com/NixOS/nixpkgs/commit/f86d493b5ad6bb8016bee21d4af803a4dcec0351) | `` python310Packages.plugwise: 0.31.7 -> 0.31.8 ``                                   |
| [`5be299a7`](https://github.com/NixOS/nixpkgs/commit/5be299a7ab90429185deaa4402765d2e64c624a1) | `` zrok: 0.4.0 -> 0.4.2 ``                                                           |
| [`20be59d0`](https://github.com/NixOS/nixpkgs/commit/20be59d08ad62f5bb89be95cbfbfc6757facf563) | `` python310Packages.pyrainbird: 3.0.0 -> 3.0.1 ``                                   |
| [`0c75a062`](https://github.com/NixOS/nixpkgs/commit/0c75a062bb27b20fc6003e4f7f8a4f093ed80676) | `` linux-firmware: 20230625 -> unstable-2023-07-24 ``                                |
| [`e998e521`](https://github.com/NixOS/nixpkgs/commit/e998e5216c0ce4a2b0c5c2f05e083df01f4c4cd3) | `` linux: 6.4.5 -> 6.4.6 ``                                                          |
| [`04141e98`](https://github.com/NixOS/nixpkgs/commit/04141e9828f4ad2db272f1aaca5a5ec5bc4f9247) | `` linux: 6.1.40 -> 6.1.41 ``                                                        |
| [`6da37409`](https://github.com/NixOS/nixpkgs/commit/6da374098b4d6b53b434e63f80338aaec6ba62f2) | `` linux: 5.4.249 -> 5.4.250 ``                                                      |
| [`c28af224`](https://github.com/NixOS/nixpkgs/commit/c28af224b5e2598ac76b30b8a5f44b84cb7cea17) | `` linux: 5.15.121 -> 5.15.122 ``                                                    |
| [`d5cddc3d`](https://github.com/NixOS/nixpkgs/commit/d5cddc3d2f0accbea6525c394855b4d5674f724d) | `` linux: 5.10.186 -> 5.10.187 ``                                                    |
| [`16c27410`](https://github.com/NixOS/nixpkgs/commit/16c27410de37364f08f2997231727089b29f23cb) | `` linux: 4.19.288 -> 4.19.289 ``                                                    |
| [`5c1906aa`](https://github.com/NixOS/nixpkgs/commit/5c1906aa2526facc27f04e4165afd2dee6194551) | `` terraform-providers.spotinst: 1.127.0 -> 1.128.0 ``                               |
| [`af494677`](https://github.com/NixOS/nixpkgs/commit/af494677d968639dcddd5c446c277e101ae66e1b) | `` terraform-providers.hcloud: 1.41.0 -> 1.42.0 ``                                   |
| [`91f2c5db`](https://github.com/NixOS/nixpkgs/commit/91f2c5db149e34cf1f13f2359d01ee29bd3b6582) | `` terraform-providers.google-beta: 4.74.0 -> 4.75.0 ``                              |
| [`99d7ed1b`](https://github.com/NixOS/nixpkgs/commit/99d7ed1b0eb96183d615f4d8da5d724ac858c2c9) | `` terraform-providers.google: 4.74.0 -> 4.75.0 ``                                   |
| [`46dfe90b`](https://github.com/NixOS/nixpkgs/commit/46dfe90bfe1ece5f7e418c100d2455f1876ffcba) | `` terraform-providers.github: 5.31.0 -> 5.32.0 ``                                   |
| [`8cefff16`](https://github.com/NixOS/nixpkgs/commit/8cefff16f0a1a12917ead68f4389400ddd758dfa) | `` terraform-providers.consul: 2.17.0 -> 2.18.0 ``                                   |
| [`f19af411`](https://github.com/NixOS/nixpkgs/commit/f19af411327306454b7c0cba51a88a26311bedad) | `` scummvm: 2.7.0 -> 2.7.1 ``                                                        |
| [`cac50294`](https://github.com/NixOS/nixpkgs/commit/cac50294ee0211f15c40c65147ac9d59b5e135fe) | `` twitch-cli: 1.1.19 -> 1.1.20 ``                                                   |
| [`173f8aa3`](https://github.com/NixOS/nixpkgs/commit/173f8aa342fc4c353212a629fcb7a3a9846eefe8) | `` cryfs: 0.11.3 -> 0.11.4 ``                                                        |
| [`fd6eae63`](https://github.com/NixOS/nixpkgs/commit/fd6eae6343483fa1e7e9717341e9ce80414023ec) | `` vipsdisp: 2.5.0 -> 2.5.1 ``                                                       |
| [`1b3feb10`](https://github.com/NixOS/nixpkgs/commit/1b3feb10442e3685ea60db844437cb596a0eb601) | `` ocamlPackages.dypgen: init at 0.2 for OCaml ≥ 4.07 ``                             |
| [`9ae366f1`](https://github.com/NixOS/nixpkgs/commit/9ae366f1792b26c35a07dcafc6ff1ada7d818fad) | `` podman: 4.5.1 -> 4.6.0 ``                                                         |
| [`7687b846`](https://github.com/NixOS/nixpkgs/commit/7687b8464f0770cc8a1d97e9082335bf84bb318b) | `` mosquitto: fix bug with firefox wss http/2 ``                                     |
| [`0dd9a9cf`](https://github.com/NixOS/nixpkgs/commit/0dd9a9cfed17041e6bdb1946da67962155f82cbe) | `` python310Packages.opentelemetry-instrumentation-aiohttp-client: init at 0.39b0 `` |
| [`4500316e`](https://github.com/NixOS/nixpkgs/commit/4500316e6333dfd210c42c86e319802837a2a625) | `` python310Packages.opentelemetry-instrumentation-grpc: init at 0.39b0 ``           |
| [`686af29f`](https://github.com/NixOS/nixpkgs/commit/686af29f95592fabbf2bb41cfe0095af448fad91) | `` gh: 2.32.0 -> 2.32.1 ``                                                           |
| [`7c411521`](https://github.com/NixOS/nixpkgs/commit/7c411521a542826bbd5a96935a4ac6de2c86f259) | `` tutanota-desktop: 3.113.3 -> 3.115.2 ``                                           |
| [`055d7833`](https://github.com/NixOS/nixpkgs/commit/055d78335d86af40cf1a3553eb11b9678cb5ddc6) | `` coqPackages.bignums: 8.17.0 → 9.0.0+coq8.17 ``                                    |
| [`dc70d2f6`](https://github.com/NixOS/nixpkgs/commit/dc70d2f61a836221631777fad9d5269e64ccb0a3) | `` meteo: 0.9.9.1 -> 0.9.9.2 ``                                                      |
| [`d12b1511`](https://github.com/NixOS/nixpkgs/commit/d12b1511014bb99d353dd4974a8ef7a353e82d9e) | `` stalwart-mail: init at 0.3.1 ``                                                   |
| [`35f43f95`](https://github.com/NixOS/nixpkgs/commit/35f43f9532c4485661cb30737c8e721aa647e04e) | `` python310Packages.unstructured: init at 0.8.1 ``                                  |
| [`73cd4671`](https://github.com/NixOS/nixpkgs/commit/73cd4671c90b86361047ced2458765e4188a4922) | `` kubecfg: 0.30.0 -> 0.31.4 ``                                                      |
| [`fb3c8210`](https://github.com/NixOS/nixpkgs/commit/fb3c82106d8f62bf7082aef77a88af7498452d9b) | `` babeld: 1.12.2 -> 1.13 ``                                                         |
| [`b2d51404`](https://github.com/NixOS/nixpkgs/commit/b2d514047e58e39b767ef5a208872b7ce9685454) | `` xeus-zmq: init at 1.1.0 ``                                                        |
| [`9a476c8e`](https://github.com/NixOS/nixpkgs/commit/9a476c8ea4729dd8d1a8b3d7d152183dca5af686) | `` xemu: 0.7.103 -> 0.7.104 ``                                                       |
| [`8f93629b`](https://github.com/NixOS/nixpkgs/commit/8f93629b373d183f060f6c17c096bb4752223f8b) | `` wtwitch: 2.6.2 -> 2.6.3 ``                                                        |
| [`a1ca2856`](https://github.com/NixOS/nixpkgs/commit/a1ca285684b3560348256e30fb407139c6510984) | `` jbang: 0.109.0 -> 0.110.0 ``                                                      |
| [`2e35954c`](https://github.com/NixOS/nixpkgs/commit/2e35954cd0a47ce0d34ba0f9224f239ceda7cba7) | `` runme: 1.5.2 -> 1.6.0 ``                                                          |
| [`3c070741`](https://github.com/NixOS/nixpkgs/commit/3c070741a9e39701961ec1bef5da725cad3da07a) | `` osm2pgsql: fix build ``                                                           |
| [`2edc744f`](https://github.com/NixOS/nixpkgs/commit/2edc744f3f37721f732dd2311c8f1178192137bf) | `` iosevka: 25.1.0 -> 25.1.1 ``                                                      |
| [`83793ca8`](https://github.com/NixOS/nixpkgs/commit/83793ca8980283a6f62c028ebed336b9d1bbf80f) | `` nixos/fonts: rename fonts.enableDefaultFonts to fonts.enableDefaultPackages ``    |
| [`8315db77`](https://github.com/NixOS/nixpkgs/commit/8315db77f6fcc5bbb1392065ba2f5721f120b656) | `` teams-for-linux: 1.2.4 -> 1.2.8 ``                                                |
| [`ee70eede`](https://github.com/NixOS/nixpkgs/commit/ee70eede34df4981fbc1272809fa470133c2a82c) | `` python310Packages.py-partiql-parser: 0.3.3 -> 0.3.5 ``                            |
| [`1269a601`](https://github.com/NixOS/nixpkgs/commit/1269a601e3253b99026aa473c7a5faef472ea62e) | `` ax25-apps: set localstatedir to /var/lib ``                                       |
| [`0d751200`](https://github.com/NixOS/nixpkgs/commit/0d75120022142ce867f2fa386853e84c471be18b) | `` ax25-tools: set localstatedir to /var/lib ``                                      |
| [`7a59cd3d`](https://github.com/NixOS/nixpkgs/commit/7a59cd3dc9a0a1353b835ed2c563a0e8ca09d5b6) | `` python310Packages.jsbeautifier: 1.14.8 -> 1.14.9 ``                               |
| [`12ad49a1`](https://github.com/NixOS/nixpkgs/commit/12ad49a130d7f7be7b832fddce93d37ee4460ddb) | `` wooting: clarify requirements for hardware option to work ``                      |
| [`519d8cf9`](https://github.com/NixOS/nixpkgs/commit/519d8cf92da9b6a2aec0205b3428982512868b15) | `` wooting: update udev rules ``                                                     |
| [`05f31b13`](https://github.com/NixOS/nixpkgs/commit/05f31b13153680de84cb13d7645d80df14938a4e) | `` lscolors: fix build to include the binary ``                                      |
| [`b34a51f5`](https://github.com/NixOS/nixpkgs/commit/b34a51f5a7ec2b7f57ed291fee7852f03634a409) | `` nixos/gogs: fix deprecations for 0.13.0 ``                                        |
| [`fc8f6d7f`](https://github.com/NixOS/nixpkgs/commit/fc8f6d7fdd4de35f67149950cf80e16cddd45380) | `` mission-center: init at 0.2.5 ``                                                  |
| [`0d0161c9`](https://github.com/NixOS/nixpkgs/commit/0d0161c9db563ad3378e41c4a83921e7b1bdf240) | `` forgejo: 1.19.4-0 -> 1.20.1-0 ``                                                  |
| [`3f996855`](https://github.com/NixOS/nixpkgs/commit/3f99685567ca047bd6d14502bba8725ffb5f4a19) | `` python310Packages.ijson: 3.2.2 -> 3.2.3 ``                                        |
| [`5f5090b3`](https://github.com/NixOS/nixpkgs/commit/5f5090b3f1cbd8690109e090caa677507cdeb642) | `` linuxPackages.nvidia_x11_vulkan_beta: 525.47.31 -> 525.47.34 ``                   |
| [`e2d32444`](https://github.com/NixOS/nixpkgs/commit/e2d324442ef85ef4a25ff02e9d95fff49619d7c9) | `` python310Packages.pynisher: 1.0.7 -> 1.0.8 ``                                     |
| [`98775d73`](https://github.com/NixOS/nixpkgs/commit/98775d735c80cb1019e5c607af75027c55608fdc) | `` jaq: 0.10.0 -> 0.10.1 ``                                                          |
| [`3e36355e`](https://github.com/NixOS/nixpkgs/commit/3e36355e44999d194185c4f974e3d3961b447986) | `` kops: 1.26.4 -> 1.27.0 (#245208) ``                                               |
| [`a10542b2`](https://github.com/NixOS/nixpkgs/commit/a10542b2418c60a3a0955328daec6f2015f9b150) | `` signalbackup-tools: 20230716 -> 20230723-1 ``                                     |
| [`d7e262cd`](https://github.com/NixOS/nixpkgs/commit/d7e262cd45f47540928fc924f50e1c7d9d8faf82) | `` python310Packages.tesserocr: 2.6.0 -> 2.6.1 ``                                    |
| [`073eb1fc`](https://github.com/NixOS/nixpkgs/commit/073eb1fcf630c5942b59a7c128a2e4bb547dd6da) | `` amass: 4.0.2 -> 4.0.3 ``                                                          |
| [`abd2beb0`](https://github.com/NixOS/nixpkgs/commit/abd2beb086cc0b7927f52f5f3f4da880f7abac5f) | `` dae: 0.2.1 -> 0.2.2 ``                                                            |
| [`3bcec2f5`](https://github.com/NixOS/nixpkgs/commit/3bcec2f5814002aa9006e5de2ebc6620dc59415f) | `` seaweedfs: 3.54 -> 3.55 ``                                                        |
| [`2cf16635`](https://github.com/NixOS/nixpkgs/commit/2cf16635698c958670f793ee7da323b2ef39fa49) | `` lscolors: 0.14.0 -> 0.15.0 ``                                                     |
| [`983e4778`](https://github.com/NixOS/nixpkgs/commit/983e477848a2f4ca8c51086ea9c3bdde37f8170a) | `` nvitop: 1.1.2 -> 1.2.0 ``                                                         |
| [`f9fdeb2d`](https://github.com/NixOS/nixpkgs/commit/f9fdeb2dbcf36636e2c2e537fe9eb1b31d84195b) | `` nixos/ghostscript: evaporate the extra whitespace ``                              |
| [`b0c67b4b`](https://github.com/NixOS/nixpkgs/commit/b0c67b4b6e0d21fd47097886f5c21cfb6bf27aad) | `` treewide: rename fonts.fonts to fonts.packages ``                                 |
| [`5162df32`](https://github.com/NixOS/nixpkgs/commit/5162df32399c7e9d77cc38702202983dbe9ad113) | `` nixos/fonts: rename fonts.fonts option to fonts.packages, other cleanups ``       |
| [`dd0b6dc8`](https://github.com/NixOS/nixpkgs/commit/dd0b6dc833ddd91791490bd81ffb8c1ae2a8b7f6) | `` homepage-dashboard: 0.6.21 -> 0.6.23 ``                                           |
| [`acc4cfd4`](https://github.com/NixOS/nixpkgs/commit/acc4cfd48b3bf17b50a8394ea0d6a12c6fc11b2a) | `` vorta: strip away output dependency on `qt5.qtwayland.dev` ``                     |
| [`04522024`](https://github.com/NixOS/nixpkgs/commit/045220244eb3234d507bbe27d4bf514f92d39f7a) | `` moonfire-nvr: init at 0.7.6 ``                                                    |
| [`1a2d2661`](https://github.com/NixOS/nixpkgs/commit/1a2d2661803baa43f223896fe043aa8b99f0ab27) | `` temporal-cli: fix missing meta.platforms preventing Hydra builds (#243518) ``     |
| [`0a47d548`](https://github.com/NixOS/nixpkgs/commit/0a47d548015ec7a2306c545ec1cf060348e7885e) | `` docs/python: clarify allowance of using toosl to autogenerate packages ``         |
| [`1b54927c`](https://github.com/NixOS/nixpkgs/commit/1b54927c85f63a5f8c2180de730f89c96540c018) | `` sbt: 1.9.2 -> 1.9.3 (#245161) ``                                                  |
| [`4d345751`](https://github.com/NixOS/nixpkgs/commit/4d345751990f2f37131230605f957d1d0ae9d22b) | `` spicetify-cli: 2.21.0 -> 2.22.0 ``                                                |
| [`c1a72eec`](https://github.com/NixOS/nixpkgs/commit/c1a72eec236d5ba4c7afabdcb6b117d9c1641a35) | `` vimPlugins.nvim-treesitter: update grammars ``                                    |
| [`c22e3427`](https://github.com/NixOS/nixpkgs/commit/c22e3427056932d3b93e72b3972db7104be08b29) | `` vimPlugins: update ``                                                             |
| [`e0a31e06`](https://github.com/NixOS/nixpkgs/commit/e0a31e067a758e2b4d091ca0c4016224d7a6b7c4) | `` vimPlugins.hover-nvim: init at 2023-07-10 ``                                      |
| [`dbdbd6c9`](https://github.com/NixOS/nixpkgs/commit/dbdbd6c97bf1713efdcb3f06cfac5f3713bccd5b) | `` cargo-diet: 1.2.5 -> 1.2.7 ``                                                     |
| [`df8d0648`](https://github.com/NixOS/nixpkgs/commit/df8d064819a5bb95a10875c781df197bf2bfbf57) | `` wazero: 1.3.0 -> 1.3.1 ``                                                         |
| [`048928fa`](https://github.com/NixOS/nixpkgs/commit/048928fa014fdeb76c65e0b96a3b8a6b03b11f66) | `` repgrep: 0.14.1 -> 0.14.2 ``                                                      |
| [`7d57cbdd`](https://github.com/NixOS/nixpkgs/commit/7d57cbddc613acd5df610c45a4228b8681af4110) | `` docker: remove mikroskeem from maintainers ``                                     |
| [`3428dd4b`](https://github.com/NixOS/nixpkgs/commit/3428dd4bef7ea4d81f6da347150281e0efb6d6c0) | `` docker: apply fix starting containers with a local connection with the CLI ``     |
| [`cb2f5313`](https://github.com/NixOS/nixpkgs/commit/cb2f5313320368ab0324958733d5f41cc59587c7) | `` nixos/xfce: allow exclusion of xfce4-notifyd ``                                   |
| [`9135e2d0`](https://github.com/NixOS/nixpkgs/commit/9135e2d0cccd186357d87bc5fc40572102ed88a9) | `` lazygit: 0.39.3 -> 0.39.4 ``                                                      |
| [`59236a39`](https://github.com/NixOS/nixpkgs/commit/59236a397915ad44a36c87e5d2b906cf9671de1a) | `` jackett: 0.21.484 -> 0.21.532 ``                                                  |
| [`4ec8ab12`](https://github.com/NixOS/nixpkgs/commit/4ec8ab12c5d59b514557300296f90946f7a13686) | `` jazz2: 2.0.0 -> 2.1.0 ``                                                          |
| [`27a83e4c`](https://github.com/NixOS/nixpkgs/commit/27a83e4cc42d1f224812d6a48ba15e993b297713) | `` sing-box: 1.3.0 -> 1.3.3 ``                                                       |
| [`49ecac85`](https://github.com/NixOS/nixpkgs/commit/49ecac852780039f7c040a3e8eccae7b8427adcb) | `` python310Packages.discogs-client: 2.6 -> 2.7 ``                                   |
| [`d6cdb6a4`](https://github.com/NixOS/nixpkgs/commit/d6cdb6a43ff374559d82c3429243a3eefa2aea03) | `` glabels-qt: init at unstable-2021-02-06 ``                                        |
| [`cb589b7e`](https://github.com/NixOS/nixpkgs/commit/cb589b7ec81b51498f92b916441e8163221319ed) | `` otus-lisp: init at 2.4 ``                                                         |
| [`d00a7933`](https://github.com/NixOS/nixpkgs/commit/d00a7933295d76378cbe967c45905d4515d2f7f7) | `` python310Packages.azure-mgmt-netapp: 10.0.0 -> 10.1.0 ``                          |
| [`fb9dba73`](https://github.com/NixOS/nixpkgs/commit/fb9dba73f3ef76847c6716a3c0c4a16673e99686) | `` opcua-client-gui: enable on darwin ``                                             |
| [`1264b312`](https://github.com/NixOS/nixpkgs/commit/1264b312da9b98478e16b5a4e5c0dbf831013305) | `` python3Packages.asyncua: fix build on darwin ``                                   |
| [`e1ebc51e`](https://github.com/NixOS/nixpkgs/commit/e1ebc51ef647d5d54f0ae002fd13edea0ae3ae94) | `` jabref: fix gapps wrapper ``                                                      |
| [`8a1a9ffe`](https://github.com/NixOS/nixpkgs/commit/8a1a9ffe48ee23fe0d5b9a46493f4dea9bf020ee) | `` balena-cli: 16.6.2 -> 16.7.5 ``                                                   |
| [`319e47f4`](https://github.com/NixOS/nixpkgs/commit/319e47f43d87a4bbd84a04fdd553b397c0eaea7a) | `` dotter: 0.12.16 -> 0.13.0 ``                                                      |
| [`121b60ae`](https://github.com/NixOS/nixpkgs/commit/121b60ae9deb4b392a29dfaa5eeace6bd1297666) | `` libqb: 2.0.7 -> 2.0.8 ``                                                          |
| [`2e1db341`](https://github.com/NixOS/nixpkgs/commit/2e1db341fc618873bd5ea36127854e3edc95a25f) | `` apkg: 0.4.0 -> 0.4.1 ``                                                           |
| [`1d0b3064`](https://github.com/NixOS/nixpkgs/commit/1d0b3064664e89edb4322348397bcdeb51bdb8e6) | `` cmusfm: 0.4.1 -> 0.5.0 ``                                                         |
| [`0310e3c7`](https://github.com/NixOS/nixpkgs/commit/0310e3c7ac017b9fb2600ef90f7141e4f0e67a41) | `` CODEOWNERS: add ajoseph for kernel/manual-config.nix ``                           |
| [`a6b6203b`](https://github.com/NixOS/nixpkgs/commit/a6b6203b6d2c85409eeea1a318910d1f6e6cfc66) | `` sv-lang: init at 3.0 ``                                                           |