### PR TITLE
chore(flake/pre-commit-hooks): `2ddd4dbc` -> `fa01fdab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -403,11 +403,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1690452200,
-        "narHash": "sha256-Sx0/TOPXrvtsPLbymNAwxF5Gkc6ldnKZ9Yknzh6IfkY=",
+        "lastModified": 1690457930,
+        "narHash": "sha256-+5MFyb8C99X8HLpo3tXTwxfCCm49rZ/LdA+dKY5GJw4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "2ddd4dbc39a9448d04f274800cbcc84bbe6058ec",
+        "rev": "fa01fdab28612f67f24f56184ea94ec78022656e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                 |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
| [`73954b2d`](https://github.com/cachix/pre-commit-hooks.nix/commit/73954b2d7c28ead19fa25d60599254dda25ba9a8) | `` Make the generated configuration depend on the pre-commit package `` |