### PR TITLE
chore(flake/pre-commit-hooks): `fa01fdab` -> `9289996d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -403,11 +403,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1690457930,
-        "narHash": "sha256-+5MFyb8C99X8HLpo3tXTwxfCCm49rZ/LdA+dKY5GJw4=",
+        "lastModified": 1690464206,
+        "narHash": "sha256-38V4kmOh6ikpfGiAS+Kt2H/TA2DubSqE66veP/jmB4Q=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "fa01fdab28612f67f24f56184ea94ec78022656e",
+        "rev": "9289996dcac62fd45836db7c07b87d2521eb526d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                              |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------ |
| [`47b6bb15`](https://github.com/cachix/pre-commit-hooks.nix/commit/47b6bb155e162d57e4c93834a21bf530e86d4cec) | `` Add `deno lint` and `deno fmt` `` |