### PR TITLE
chore(flake/nixpkgs): `ef99fa5c` -> `c9cf0708`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1690272529,
-        "narHash": "sha256-MakzcKXEdv/I4qJUtq/k/eG+rVmyOZLnYNC2w1mB59Y=",
+        "lastModified": 1690367991,
+        "narHash": "sha256-2VwOn1l8y6+cu7zjNE8MgeGJNNz1eat1HwHrINeogFA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ef99fa5c5ed624460217c31ac4271cfb5cb2502c",
+        "rev": "c9cf0708f00fbe553319258e48ca89ff9a413703",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`539e08e1`](https://github.com/NixOS/nixpkgs/commit/539e08e12a1a96a0513d71694a2acc8574f9984e) | `` tts: 0.15.6 -> 0.16.0 ``                                                                       |
| [`9770f6a2`](https://github.com/NixOS/nixpkgs/commit/9770f6a23aadfe10b7072c014a7e3da43a106075) | `` python310Packages.trainer: 0.0.27 -> 0.0.29 ``                                                 |
| [`1571a1aa`](https://github.com/NixOS/nixpkgs/commit/1571a1aacffb491372880efffef8fc404d7c2a73) | `` rustdesk-server: fix darwin builds ``                                                          |
| [`a403fd85`](https://github.com/NixOS/nixpkgs/commit/a403fd8565f6ec92b06d34c43315febb7540a856) | `` rustdesk-server: add tjni as a maintainer ``                                                   |
| [`c2b8bf7f`](https://github.com/NixOS/nixpkgs/commit/c2b8bf7f4e5c0aff908b61e25cc7b60ef7a18df2) | `` feat: implement redirect for fetch-yarn-deps ``                                                |
| [`41680f83`](https://github.com/NixOS/nixpkgs/commit/41680f83ea143f3ce4bd774ff53cca91f1dac826) | `` pulumi-bin: 3.72.1 -> 3.76.0 ``                                                                |
| [`b8ce54a6`](https://github.com/NixOS/nixpkgs/commit/b8ce54a61fe10b2d6582c0c5614555b7834d2bb5) | `` twspace-crawler: 1.12.4 -> 1.12.6 ``                                                           |
| [`81217587`](https://github.com/NixOS/nixpkgs/commit/81217587e6cd50d5a51c82302485016d0587bfe2) | `` neovim-unwrapped: fix cross ``                                                                 |
| [`ef4360b9`](https://github.com/NixOS/nixpkgs/commit/ef4360b98eef19e874c771f42291d2b8a687d5c6) | `` python310Packages.types-protobuf: 4.23.0.1 -> 4.23.0.2 ``                                      |
| [`e749b0c4`](https://github.com/NixOS/nixpkgs/commit/e749b0c4f9bade8372441afbd6dd01f256d27ab5) | `` argc: 1.7.0 -> 1.8.0 ``                                                                        |
| [`87b9b9f5`](https://github.com/NixOS/nixpkgs/commit/87b9b9f5729df340677adb7c19095c9a857388e0) | `` blisp: init at unstable-2023-06-03 ``                                                          |
| [`29196fa1`](https://github.com/NixOS/nixpkgs/commit/29196fa1f36dd945afa347c2cb7a6e93b6ab2498) | `` blackfire: 2.17.0 -> 2.18.0 ``                                                                 |
| [`2c1afd4d`](https://github.com/NixOS/nixpkgs/commit/2c1afd4d769b66afc1f2da13a4e318f1f82d9b05) | `` iosevka-bin: 25.0.1 -> 25.1.1 ``                                                               |
| [`dc3cedd3`](https://github.com/NixOS/nixpkgs/commit/dc3cedd33299452f10d4770dc8f20eabe0267b7e) | `` cartridges: 2.0.5 -> 2.1 ``                                                                    |
| [`f747a635`](https://github.com/NixOS/nixpkgs/commit/f747a635d6f0bd5c588382cddf0ed923c8d7abe0) | `` ldgallery: drop package ``                                                                     |
| [`7f200e3f`](https://github.com/NixOS/nixpkgs/commit/7f200e3f4a9bb871448765fde211ce399f30b7ea) | `` python310Packages.scmrepo: 1.0.4 -> 1.1.0 ``                                                   |
| [`b72044c1`](https://github.com/NixOS/nixpkgs/commit/b72044c1138a24239123d337dbc7c181fbaafa9c) | `` nixos/emacs: don't set EDITOR to store path ``                                                 |
| [`fb231d2f`](https://github.com/NixOS/nixpkgs/commit/fb231d2fbad92dfc981aca634b1f973d79de5741) | `` python310Packages.policyuniverse: 1.5.1.20230703 -> 1.5.1.20230725 ``                          |
| [`4d50a535`](https://github.com/NixOS/nixpkgs/commit/4d50a5352eb05bc435aec4525bccc47a5ec8a4b0) | `` rtz: 0.3.2 -> 0.4.2 ``                                                                         |
| [`259bd12f`](https://github.com/NixOS/nixpkgs/commit/259bd12f22749d188b212114a89cc70096207db4) | `` git-machete: 3.17.6 -> 3.17.8 ``                                                               |
| [`781b5dfa`](https://github.com/NixOS/nixpkgs/commit/781b5dfaf37da6ff955c2bcec724426a7f4d2fa2) | `` vimPlugins.sg-nvim: fix cargoHash ``                                                           |
| [`f0723fff`](https://github.com/NixOS/nixpkgs/commit/f0723fff85baffc2c106d4f0a2b42fb19760d025) | `` typst-lsp: 0.7.1 -> 0.7.2, fix license ``                                                      |
| [`4076c4f6`](https://github.com/NixOS/nixpkgs/commit/4076c4f668ca521a09262693a4f9a231a9206a88) | `` urh: enable on unix ``                                                                         |
| [`827bb4b2`](https://github.com/NixOS/nixpkgs/commit/827bb4b2a7578ec7f9c4f09479f6490f77648c36) | `` hop-cli: 0.2.35 -> 0.2.52 ``                                                                   |
| [`c93a5c8e`](https://github.com/NixOS/nixpkgs/commit/c93a5c8e684b41bacd2ef21cd46343b3b5fb30df) | `` teamspeak_client: 3.6.0 -> 3.6.1 ``                                                            |
| [`59921f9e`](https://github.com/NixOS/nixpkgs/commit/59921f9ee196246caabfa15bb8e98757b0a7533c) | `` gex: 0.5.0 -> 0.6.0 ``                                                                         |
| [`76c96656`](https://github.com/NixOS/nixpkgs/commit/76c96656d4d8bc645c4045c3df231c026af2552e) | `` python310Packages.teslajsonpy: 3.9.0 -> 3.9.1 ``                                               |
| [`3fbcc9f0`](https://github.com/NixOS/nixpkgs/commit/3fbcc9f0c20be9af12282fe049e0ed7028f99cd6) | `` bitwarden-cli: add passthru.tests ``                                                           |
| [`8c8d1164`](https://github.com/NixOS/nixpkgs/commit/8c8d1164de84808c61a233ead50e1ee27f78a0a5) | `` bitwarden-cli: 2023.5.0 -> 2023.7.0 ``                                                         |
| [`b77627bb`](https://github.com/NixOS/nixpkgs/commit/b77627bb64753596282cf872af8479e674dc2bc7) | `` vimPlugins.nvim-treesitter: update grammars ``                                                 |
| [`d286aef1`](https://github.com/NixOS/nixpkgs/commit/d286aef1b1b5fb771816a92e519d3b4eca0b460b) | `` vimPlugins: resolve github repository redirects ``                                             |
| [`2c9bd9bc`](https://github.com/NixOS/nixpkgs/commit/2c9bd9bcfca002c083770fefe9630523780a1ded) | `` vimPlugins: update ``                                                                          |
| [`5950306f`](https://github.com/NixOS/nixpkgs/commit/5950306f92d873f71b4312c96039381a785f1570) | `` nodePackages.bitwarden-cli: add alias ``                                                       |
| [`1c268457`](https://github.com/NixOS/nixpkgs/commit/1c26845771f8384e1a93149386fc45709627c1ad) | `` node-packages/remove-attr.py: fix shebang ``                                                   |
| [`6847b194`](https://github.com/NixOS/nixpkgs/commit/6847b194588be88315fca29621db59a1342e0959) | `` topgrade: 12.0.1 -> 12.0.2 ``                                                                  |
| [`a7e43128`](https://github.com/NixOS/nixpkgs/commit/a7e43128154c5d6854e8c4f6ec67ce60add94432) | `` maintainers: add lurkki ``                                                                     |
| [`8d34b31b`](https://github.com/NixOS/nixpkgs/commit/8d34b31b3179d45e107ec9cca99b0de9585eba76) | `` omorfi: init at 0.9.9 ``                                                                       |
| [`67424e70`](https://github.com/NixOS/nixpkgs/commit/67424e70c8a9f43140e69ae1852a7841b42e1663) | `` hfst-ospell: init at 0.5.3 ``                                                                  |
| [`b02e3765`](https://github.com/NixOS/nixpkgs/commit/b02e3765e7fcaabc5971af82e51221a065da062b) | `` hfst: init at 3.16.0 ``                                                                        |
| [`22f9b7b2`](https://github.com/NixOS/nixpkgs/commit/22f9b7b279417a8b83a3356f5bd3ed3a51b1de82) | `` libvoikko: init at 4.3.2 ``                                                                    |
| [`408ece7d`](https://github.com/NixOS/nixpkgs/commit/408ece7d3d5b68f5c0d870abb936ee8950a1b9f9) | `` libreoffice-fresh: strip away BUILDCONFIG, reduce runtime closure size by ~20% ``              |
| [`69a56c91`](https://github.com/NixOS/nixpkgs/commit/69a56c9162f0701024816847de20cf3e0d2fe185) | `` zerotierone: mark as linux only ``                                                             |
| [`28d4ded6`](https://github.com/NixOS/nixpkgs/commit/28d4ded6b0bd9e440042f94ccbf1b42fd6b0ec05) | `` ripdrag: 0.3.0 -> 0.3.1 ``                                                                     |
| [`887828e3`](https://github.com/NixOS/nixpkgs/commit/887828e3ca3c29902cd58450bf8cb4f55a59805d) | `` sqlboiler-crbd: init at unstable-2022-06-12 ``                                                 |
| [`fcf915b0`](https://github.com/NixOS/nixpkgs/commit/fcf915b0629095c7e00f305a3f78279072c89e40) | `` ripdrag: add wrapGAppsHook4 ``                                                                 |
| [`251d2cbf`](https://github.com/NixOS/nixpkgs/commit/251d2cbfc25c41c9abd55929ace7b57a7e0f546c) | `` pkgs/tools/networking: remove dead code ``                                                     |
| [`fca9a919`](https://github.com/NixOS/nixpkgs/commit/fca9a919a8bae82f973c1a80eca7a4479209b8cf) | `` pkgs/tools/misc: remove dead code ``                                                           |
| [`a95c1c82`](https://github.com/NixOS/nixpkgs/commit/a95c1c82d32d3debc31ea99195ec6513d62b0ecc) | `` mqtt_cpp: init at 13.2.1 ``                                                                    |
| [`7c309898`](https://github.com/NixOS/nixpkgs/commit/7c309898bcac42058a4e80e7f8bb69436cefb265) | `` nixos/usb-modeswitch: Rename module from usbWwan ``                                            |
| [`a494e457`](https://github.com/NixOS/nixpkgs/commit/a494e4572b5537de0f4358b98fc6f54d26f4bc9e) | `` maintainers: add spalf ``                                                                      |
| [`f05bd97e`](https://github.com/NixOS/nixpkgs/commit/f05bd97e61e4e7e2264af78705472affe03836fb) | `` pdm: 2.7.4 -> 2.8.0 ``                                                                         |
| [`e1823135`](https://github.com/NixOS/nixpkgs/commit/e1823135fd76b3751015eb3e8043eff0d4f14332) | `` python3Packages.macaddress: init at 2.0.2 ``                                                   |
| [`3575aa76`](https://github.com/NixOS/nixpkgs/commit/3575aa76c5e0c59284e341d2f5f6343ec4a14223) | `` python3Packages.reprshed: init at 1.0.6 ``                                                     |
| [`18733782`](https://github.com/NixOS/nixpkgs/commit/18733782adc0b2c952d0d1d1174a19b7921b476e) | `` nixos/conduit: improve state directory permissions ``                                          |
| [`412b0166`](https://github.com/NixOS/nixpkgs/commit/412b0166dfb3d737d9e4d220187ffa877a511f57) | `` AusweisApp2: 1.26.4 -> 1.26.5 ``                                                               |
| [`b7e6f5aa`](https://github.com/NixOS/nixpkgs/commit/b7e6f5aaee6bc8939029424b4a55f20df327e30c) | `` python310Packages.django-celery-results: normalize pname ``                                    |
| [`b558fa79`](https://github.com/NixOS/nixpkgs/commit/b558fa791a9eb05509321c1c3479ba7e153e319a) | `` python310Packages.django-modelcluster: normalize dirname ``                                    |
| [`095369e5`](https://github.com/NixOS/nixpkgs/commit/095369e5578a521b72ebdd259d9fe9472829d9ed) | `` python310Packages.django-environ: normalize dirname ``                                         |
| [`80391145`](https://github.com/NixOS/nixpkgs/commit/80391145e9bf09c541ee8c2b91b49d5d0e1c429b) | `` python310Packages.django-classy-tags: rename from django_classytags ``                         |
| [`0bc95af5`](https://github.com/NixOS/nixpkgs/commit/0bc95af579dc9bd4a9bcd475148bbdf6e22ef5ed) | `` python310Packages.django-treebeard: rename from django_treebeard ``                            |
| [`5b7d8aea`](https://github.com/NixOS/nixpkgs/commit/5b7d8aea9805f3fa7944a2234886a36623794654) | `` python310Packages.django-tagging: rename from django_tagging ``                                |
| [`aa11efcf`](https://github.com/NixOS/nixpkgs/commit/aa11efcfb681a453001ef6242941d2db0e2c4665) | `` python310Packages.django-silk: rename from django_silk ``                                      |
| [`a3d2300c`](https://github.com/NixOS/nixpkgs/commit/a3d2300ccb5e5ad35b66ec24a504716412753028) | `` python310Packages.django-nose: rename from django_nose ``                                      |
| [`dff9f186`](https://github.com/NixOS/nixpkgs/commit/dff9f186603f762422e94e83796eef2c3bf72bcf) | `` python310Packages.django-contrib-comments: rename from django_contrib_comments ``              |
| [`98ede2a3`](https://github.com/NixOS/nixpkgs/commit/98ede2a30132dd2b07d7d5ec3565469f91307ece) | `` python310Packages.django-compat: rename from django_compat ``                                  |
| [`3d717e82`](https://github.com/NixOS/nixpkgs/commit/3d717e820ca31115ba490622d0a1301a5da53cfc) | `` python310Packages.django-colorful: rename from django_colorful ``                              |
| [`c4c444a5`](https://github.com/NixOS/nixpkgs/commit/c4c444a59f3c73a81540087a17174dde6ac807b9) | `` gtree: 1.9.1 -> 1.9.2 ``                                                                       |
| [`700eb9d6`](https://github.com/NixOS/nixpkgs/commit/700eb9d652acc5b02e2ab25178ca05371eb50f93) | `` exploitdb: 2023-07-21 -> 2023-07-22 ``                                                         |
| [`b92a4819`](https://github.com/NixOS/nixpkgs/commit/b92a4819212f2d43848ac37db430341e406730c6) | `` age-plugin-tpm: add myself as maintainer ``                                                    |
| [`863e7e20`](https://github.com/NixOS/nixpkgs/commit/863e7e200b4de8361bacadca23a8016fa0da7351) | `` python310Packages.async-upnp-client: 0.34.0 -> 0.34.1 ``                                       |
| [`37c12cbd`](https://github.com/NixOS/nixpkgs/commit/37c12cbd33fbe6233a22add0578d9d34bc341e04) | `` protoc-gen-twirp_typescript: unstable-2021-03-29 -> unstable-2022-08-14 ``                     |
| [`12cea064`](https://github.com/NixOS/nixpkgs/commit/12cea064d18220b94313d27941204fc368403807) | `` maintainers: add dgollings ``                                                                  |
| [`5153d9c6`](https://github.com/NixOS/nixpkgs/commit/5153d9c6aea6efe1b1ed33ed75a25237dda627b4) | `` aliases: add qtcreator-qt6 ``                                                                  |
| [`4c07356e`](https://github.com/NixOS/nixpkgs/commit/4c07356e3da7c79f13be438c853d0d5b27243b96) | `` nixos/packages: fix typo preventing mkRenamedOptionModule from working ``                      |
| [`d6cb7c46`](https://github.com/NixOS/nixpkgs/commit/d6cb7c46b2f9f10183b68f9abb48daa23b783302) | `` hedgedoc: 1.9.7 -> 1.9.8 and redo package ``                                                   |
| [`dc061bb0`](https://github.com/NixOS/nixpkgs/commit/dc061bb01c6e342ba4b1e477e2ef4b3668cd6933) | `` qtcreator-qt6: rename to qtcreator ``                                                          |
| [`9a7e9b07`](https://github.com/NixOS/nixpkgs/commit/9a7e9b077ef14cb67d64387caf5058b5af609dab) | `` qtcreator-qt5: remove ``                                                                       |
| [`e99e032c`](https://github.com/NixOS/nixpkgs/commit/e99e032c2ea3833531a01951efa0068364182b1a) | `` zerotierone: only include iproute2 on linux ``                                                 |
| [`6d1576b3`](https://github.com/NixOS/nixpkgs/commit/6d1576b36a7a51af9b23f23d83ccc4436fbaaa9e) | `` gitlab-runner: 16.1.0 -> 16.2.0 (#245366) ``                                                   |
| [`a5ecbb10`](https://github.com/NixOS/nixpkgs/commit/a5ecbb101f302d5999add2f21f3c5453ef282a05) | `` obs-studio: remove miangraham from maintainers ``                                              |
| [`183e7ca1`](https://github.com/NixOS/nixpkgs/commit/183e7ca1b7dc0d165923614226fa0b4373203980) | `` kingstvis: init at 3.6.1 ``                                                                    |
| [`fe22d02a`](https://github.com/NixOS/nixpkgs/commit/fe22d02aec74a421a73e8d3a225a074e42df7a8b) | `` python310Packages.arpeggio: add nickcao to maintainers ``                                      |
| [`cb688d49`](https://github.com/NixOS/nixpkgs/commit/cb688d49bfa170abd7ae3c2625bb93e07cd15917) | `` python310Packages.arpeggio: 2.0.0 -> 2.0.2 ``                                                  |
| [`0c626b14`](https://github.com/NixOS/nixpkgs/commit/0c626b147d9ca6e03c8f42686f986fe744e7f899) | `` diffoscope: no more unfree dep ``                                                              |
| [`ef8e1c48`](https://github.com/NixOS/nixpkgs/commit/ef8e1c480e7b57c60c5e5e5d4d2b260da11dba49) | `` apktool: 2.8.0 -> 2.8.1 ``                                                                     |
| [`a660f5bc`](https://github.com/NixOS/nixpkgs/commit/a660f5bcb50fcf01e71f96360cd08be66c961a0e) | `` aapt: init at 8.0.2-9289358 ``                                                                 |
| [`821c7274`](https://github.com/NixOS/nixpkgs/commit/821c72743ceae44bdd09718d47cab98fd5fd90af) | `` cereal: "revert" update ``                                                                     |
| [`49c49041`](https://github.com/NixOS/nixpkgs/commit/49c49041eb66fba2223894663b7398b125ae1a30) | `` python311Packages.aiomisc: 17.3.4 -> 17.3.21 ``                                                |
| [`acadc01a`](https://github.com/NixOS/nixpkgs/commit/acadc01a086961d9f9a4255b52544dd496e9ac87) | `` python311Packages.identify: 2.5.25 -> 2.5.26 ``                                                |
| [`7c50cae0`](https://github.com/NixOS/nixpkgs/commit/7c50cae0a36707ccbeab70f85dfcbef667293136) | `` woodpecker-plugin-git: init at 2.1.0 ``                                                        |
| [`b66aba88`](https://github.com/NixOS/nixpkgs/commit/b66aba88a59bf430c4ea3dcdf684331ed1bb2c48) | `` ibus-engines.table-others: 1.3.15 -> 1.3.16 ``                                                 |
| [`77160c83`](https://github.com/NixOS/nixpkgs/commit/77160c83ca034746cff85f60cf51002da2c320a6) | `` winePackages: fix gecko32 and staging hash ``                                                  |
| [`1f5a92dd`](https://github.com/NixOS/nixpkgs/commit/1f5a92ddfca0cdb9e4a21d3e76aa67814e43d8a1) | `` blackbox-terminal: fix closing confirm dialog ``                                               |
| [`7d6c38a3`](https://github.com/NixOS/nixpkgs/commit/7d6c38a3827588e0c3b70670ec8423a266d19e64) | `` gexiv2: 0.14.1 → 0.14.2 ``                                                                     |
| [`2f87358e`](https://github.com/NixOS/nixpkgs/commit/2f87358e8198d347f883ed321ccf2b40c7f7501e) | `` httpx: 1.3.3 -> 1.3.4 ``                                                                       |
| [`3b75cb1e`](https://github.com/NixOS/nixpkgs/commit/3b75cb1e46284f4a455cb57cc78a21a7e032a928) | `` pip-audit: 2.6.0 -> 2.6.1 ``                                                                   |
| [`eba3d761`](https://github.com/NixOS/nixpkgs/commit/eba3d761649a5344c390fbf51318b1dbf69e7394) | `` python310Packages.types-redis: 4.6.0.2 -> 4.6.0.3 ``                                           |
| [`3565949c`](https://github.com/NixOS/nixpkgs/commit/3565949c0bcc91714652421c53bf2c9c4c09aa37) | `` wallust: refactor src fetching ``                                                              |
| [`2f6b174a`](https://github.com/NixOS/nixpkgs/commit/2f6b174a503bd563c915092b9c69af73a8e8d886) | `` lazydocker: 0.20.0 -> 0.21.0 ``                                                                |
| [`b22316ae`](https://github.com/NixOS/nixpkgs/commit/b22316ae00bfd59584c9a5b66c748f6a25fb1baa) | `` python310Packages.ipyniivue: 1.0.2 -> 1.1.0 ``                                                 |
| [`4d5e3e4a`](https://github.com/NixOS/nixpkgs/commit/4d5e3e4a5bc4470366c4f5a22f79d1388c6bcf19) | `` ocamlPackages.wasm: 2.0.0 → 2.0.1 ``                                                           |
| [`40b736f0`](https://github.com/NixOS/nixpkgs/commit/40b736f0e836d0a189d26bb457007029bc67bd17) | `` last: 1456 -> 1460 ``                                                                          |
| [`7d1ed7a7`](https://github.com/NixOS/nixpkgs/commit/7d1ed7a7884ea27c44325d43f7b6fc09329cf2d3) | `` ocamlPackages.cmdliner: 1.1.1 -> 1.2.0 ``                                                      |
| [`31f992d3`](https://github.com/NixOS/nixpkgs/commit/31f992d386162638634280bdccaa3a8243dca23b) | `` pantheon.elementary-notifications: Backport fix for broken notification filter ``              |
| [`bdb0a583`](https://github.com/NixOS/nixpkgs/commit/bdb0a58369b22a8288474705928cf29cdbaa5abc) | `` pantheon.switchboard-plug-keyboard: 3.1.1 -> 3.2.0 ``                                          |
| [`3cce91e6`](https://github.com/NixOS/nixpkgs/commit/3cce91e692d99fae8affc820799e1138279440d4) | `` pantheon.switchboard-plug-pantheon-shell: 6.4.0 -> 6.5.0 ``                                    |
| [`09ac4e27`](https://github.com/NixOS/nixpkgs/commit/09ac4e278469a50e84b9dc3489ca78ff54514de2) | `` pantheon.switchboard-plug-sound: 2.3.2 -> 2.3.3 ``                                             |
| [`eda2ca13`](https://github.com/NixOS/nixpkgs/commit/eda2ca13b38b23f58f64576aaeed4ceec62deb0c) | `` pantheon.elementary-calendar: 6.1.2 -> 7.0.0 ``                                                |
| [`1ad62e1b`](https://github.com/NixOS/nixpkgs/commit/1ad62e1b314be2399059f8313ab5a2ed6e47bb71) | `` pantheon.elementary-tasks: 6.3.1 -> 6.3.2 ``                                                   |
| [`208aa1b0`](https://github.com/NixOS/nixpkgs/commit/208aa1b09626aec182961a9420b3d5731ab70769) | `` pantheon.elementary-settings-daemon: 1.2.0 -> 1.3.0 ``                                         |
| [`72c7597d`](https://github.com/NixOS/nixpkgs/commit/72c7597d20881c1755a38536a20bc645779186fe) | `` coqPackages.parsec: 0.1.1 → 0.1.2 ``                                                           |
| [`335de715`](https://github.com/NixOS/nixpkgs/commit/335de7152a0ac17d05fff55cbc30cee49c81c50b) | `` coqPackages.ceres: 0.4.0 → 0.4.1 ``                                                            |
| [`d082e927`](https://github.com/NixOS/nixpkgs/commit/d082e9270463af942f16af719ae7ef96f12eae1d) | `` vimPlugins.sg-nvim: fix vendor hash ``                                                         |
| [`64bb2055`](https://github.com/NixOS/nixpkgs/commit/64bb20559cf4e211a3897954aacfb8fc917dd40a) | `` vimPlugins: update ``                                                                          |
| [`4b251ef3`](https://github.com/NixOS/nixpkgs/commit/4b251ef318b74e12b0026955296ced0807d0f8a1) | `` vimPlugins.nvim-treesitter: update grammars ``                                                 |
| [`77ef2bda`](https://github.com/NixOS/nixpkgs/commit/77ef2bdad6fec360bb97d95eb3d39f48bfdd08eb) | `` vimPlugins.yescapsquit-vim: init at 2022-08-31 ``                                              |
| [`5040aa7d`](https://github.com/NixOS/nixpkgs/commit/5040aa7df42cf73a7652943e9685ac325b6bbd33) | `` vimPlugins.preto: init at 2023-02-10 ``                                                        |
| [`0a316e72`](https://github.com/NixOS/nixpkgs/commit/0a316e72b3df8896d3476ab51e7897f827a35428) | `` vimPlugins.vim-paper: init at 2023-03-16 ``                                                    |
| [`08ed19ef`](https://github.com/NixOS/nixpkgs/commit/08ed19ef7519241b01bf69c46e9cd7928c2711dc) | `` vimPlugins.starrynight: init at 2021-09-09 ``                                                  |
| [`df4d4190`](https://github.com/NixOS/nixpkgs/commit/df4d4190de92f26d22bcc2a586d0e353bdbbf21b) | `` nixVersions.unstable: 2.16 -> 2.17 ``                                                          |
| [`a5e12bb6`](https://github.com/NixOS/nixpkgs/commit/a5e12bb624287e3754705d7aae3d1a5af9a23b00) | `` nixVersions.nix_2_17: init at 2.17.0 ``                                                        |
| [`099935b6`](https://github.com/NixOS/nixpkgs/commit/099935b62402f4328d96ff0331d25f98414e45ae) | `` treewide: use lib.optionalAttrs ``                                                             |
| [`6937f7e4`](https://github.com/NixOS/nixpkgs/commit/6937f7e4e808cdb9224647cb2e2897aae7e56c77) | `` psitop: init at 1.0.0 ``                                                                       |
| [`a02597d3`](https://github.com/NixOS/nixpkgs/commit/a02597d3b26dfc902354c9d5a8c836d83113d0ee) | `` gtree: 1.8.7 -> 1.9.1 ``                                                                       |
| [`a4397122`](https://github.com/NixOS/nixpkgs/commit/a4397122848f847f33a5960ecbbcc9049dead253) | `` ssw: 0.6 -> 0.8 ``                                                                             |
| [`c161060d`](https://github.com/NixOS/nixpkgs/commit/c161060dc7e17f427cbb6e79e88248fdf3c57539) | `` goofys: update vendor hash ``                                                                  |
| [`b825f65c`](https://github.com/NixOS/nixpkgs/commit/b825f65c90107d5ae49cb5fdcd0c52532f60fc42) | `` nixos/nix-channel: only try to remove the nix-channel binary if it exists ``                   |
| [`a1854817`](https://github.com/NixOS/nixpkgs/commit/a18548174bda3d76790be07c74888d14aed6c565) | `` gnmic: init at 0.31.3 ``                                                                       |
| [`1ef31a70`](https://github.com/NixOS/nixpkgs/commit/1ef31a70de16f76fbaac4df2b213cd79bdba6893) | `` python310Packages.pytest-md-report: 0.3.1 -> 0.4.0 ``                                          |
| [`668e2daf`](https://github.com/NixOS/nixpkgs/commit/668e2dafb6b1aa2d57cd438979ad25b98d5e5764) | `` nixos/nix-channel: fix editorconfig warnings and apply nixpkgs-fmt ``                          |
| [`504e42b5`](https://github.com/NixOS/nixpkgs/commit/504e42b559d74b013e95d93f5fc3868f756fd46b) | `` writers: introduce data writers ``                                                             |
| [`d0c7ffc5`](https://github.com/NixOS/nixpkgs/commit/d0c7ffc596bd8da9298d693d1bdd0559c6777311) | `` writers: make room for other types of writers ``                                               |
| [`73ee03cb`](https://github.com/NixOS/nixpkgs/commit/73ee03cbc5a20c6c3d61946558e7aea4a48c5119) | `` writers: split out the tests ``                                                                |
| [`383fa81e`](https://github.com/NixOS/nixpkgs/commit/383fa81e6f910d797b79161bac6d825e0034da2f) | `` lib/generators/toKeyValue: add `indent` parameter ``                                           |
| [`c04c43cc`](https://github.com/NixOS/nixpkgs/commit/c04c43ccd1f7b789ffc3363d9c46fb98e79afd41) | `` writers: fix fsharp writer ``                                                                  |
| [`774e250a`](https://github.com/NixOS/nixpkgs/commit/774e250ab3f1c1b4664d8d4e72456d4b4a7d332d) | `` grandperspective: 3.0.1 -> 3.4.1 ``                                                            |
| [`32b64278`](https://github.com/NixOS/nixpkgs/commit/32b642781c950d6d1eb2d56dda8c6b848ff56e6b) | `` flare-signal: 0.8.0 -> 0.9.0 ``                                                                |
| [`c4c0a7e9`](https://github.com/NixOS/nixpkgs/commit/c4c0a7e9222a36c061878406237774789c87446d) | `` gamescope: 3.12.0-beta9 -> 3.12.0-beta10 ``                                                    |
| [`2cbd486c`](https://github.com/NixOS/nixpkgs/commit/2cbd486c248371e86d5d24201e5f9b2bb0662fd1) | `` netbox: 3.5.4 -> 3.5.6 ``                                                                      |
| [`16fe763e`](https://github.com/NixOS/nixpkgs/commit/16fe763e739f11ada09f9b5e82cb57eb25994560) | `` python3Packages.django-tables2: 2.4.1 -> 2.6.0 ``                                              |
| [`471dbe9b`](https://github.com/NixOS/nixpkgs/commit/471dbe9bcfb844fb045f5591c35967f15e161657) | `` treewide: consume config.cudaSupport as required ``                                            |
| [`13399321`](https://github.com/NixOS/nixpkgs/commit/133993211b39907a09986b338e9394908de223f2) | `` config.cudaSupport: init option ``                                                             |
| [`a17baa5d`](https://github.com/NixOS/nixpkgs/commit/a17baa5db4f809809e4ae8cae66f2935cd37f2ab) | `` doc: update #cuda to reflect the recommended config.cudaSupport style ``                       |
| [`bf9e6fe9`](https://github.com/NixOS/nixpkgs/commit/bf9e6fe9b852ea9185b9d495dc974491d4fbf355) | `` tree-wide: rm `cudaSupport ? false` formal parameters ``                                       |
| [`74549ec6`](https://github.com/NixOS/nixpkgs/commit/74549ec63bb6b125590bbb0fa2db24106c257a11) | `` tree-wide: 'enableCuda ? false' -> 'config.cudaSupport or false' to respect global defaults `` |
| [`4fafb3b9`](https://github.com/NixOS/nixpkgs/commit/4fafb3b90b877263bf7674a77ed7be6cd235f5e1) | `` tree-wide: incorporate common out-of-tree cudaSupport overlays ``                              |
| [`be333da5`](https://github.com/NixOS/nixpkgs/commit/be333da51f4547fd662aaf69f6db3aaf802f70c9) | `` nixos/evdevremapkeys: init ``                                                                  |
| [`251d3166`](https://github.com/NixOS/nixpkgs/commit/251d3166c5b706eb33b985da6332fa6dfd5e43a3) | `` cudaPackages.saxpy: init at unstable-2023-07-11 ``                                             |
| [`4df8614c`](https://github.com/NixOS/nixpkgs/commit/4df8614c048509ee21bc66405394107498bb03a0) | `` magma: symlinkJoin -> CUDAToolkit_ROOT ``                                                      |
| [`bfb24acb`](https://github.com/NixOS/nixpkgs/commit/bfb24acbd0804c9fd7964eadebde8f6d53eff7f9) | `` cudaPackages_10.cudatoolkit: fix infinite recursion in setupCudaHook ``                        |
| [`9f46beb6`](https://github.com/NixOS/nixpkgs/commit/9f46beb6a7ea29625a029d5a96cc1df51aa74edf) | `` cudaPackages.setupCudaHook: init ``                                                            |
| [`56c79e60`](https://github.com/NixOS/nixpkgs/commit/56c79e60ce4bdb7e9d6fde1c98039dba39717ab2) | `` ispc: 1.18.1 -> 1.19.0 ``                                                                      |
| [`9d8f99b1`](https://github.com/NixOS/nixpkgs/commit/9d8f99b18d4527cbb939a18c25c3df0be4bf2376) | `` python310Packages.sqlalchemy-continuum: 1.3.14 -> 1.4.0 ``                                     |