### PR TITLE
chore(flake/nixpkgs): `c9cf0708` -> `2a9d660f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1690367991,
-        "narHash": "sha256-2VwOn1l8y6+cu7zjNE8MgeGJNNz1eat1HwHrINeogFA=",
+        "lastModified": 1690548937,
+        "narHash": "sha256-x3ZOPGLvtC0/+iFAg9Kvqm/8hTAIkGjc634SqtgaXTA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c9cf0708f00fbe553319258e48ca89ff9a413703",
+        "rev": "2a9d660ff0f7ffde9d73be328ee6e6f10ef66b28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`6c05a4c7`](https://github.com/NixOS/nixpkgs/commit/6c05a4c70ca92a313486e4a54d47489b6c05c7e5) | `` wttrbar: init at 0.3.2 ``                                              |
| [`7bc72fa4`](https://github.com/NixOS/nixpkgs/commit/7bc72fa4711a80ed5ef9f5de42dae2bce1dd2382) | `` maintainers: add khaneliman ``                                         |
| [`bfbd4a3f`](https://github.com/NixOS/nixpkgs/commit/bfbd4a3fa66d5859cf1da95c3f8032c802ee6b4c) | `` dhall-yaml: add package ``                                             |
| [`6d879434`](https://github.com/NixOS/nixpkgs/commit/6d8794342c1a16749b451845b512184d756777f1) | `` firefox_decrypt: unstable-2023-07-06 -> 1.1.0 ``                       |
| [`abe17e74`](https://github.com/NixOS/nixpkgs/commit/abe17e7422a66c75c34f8348e3b3afbb89ebedad) | `` jetbrains.plugins: update ``                                           |
| [`fa843303`](https://github.com/NixOS/nixpkgs/commit/fa843303150bb35565f1e682240906160dca236f) | `` python310Packages.openshift: 0.13.1 -> 0.13.2 ``                       |
| [`db337899`](https://github.com/NixOS/nixpkgs/commit/db337899569eb3f5fca729188c7d320f0e2d46ee) | `` psudohash: init at unstable-2023-05-15 ``                              |
| [`0f4b09d4`](https://github.com/NixOS/nixpkgs/commit/0f4b09d438743cf9fef748c908c90e47430d2b45) | `` python310Packages.socid-extractor: 0.0.24 -> 0.0.25 ``                 |
| [`318d8cc4`](https://github.com/NixOS/nixpkgs/commit/318d8cc4c5f9d176bc4795459b854d2bd4cf13d3) | `` nixos/lemmy: limit impurity by secrets ``                              |
| [`cf25fdfa`](https://github.com/NixOS/nixpkgs/commit/cf25fdfac063650e98b9459ada8d1b48fd2e3b75) | `` fio: fix cross-compilation ``                                          |
| [`29408329`](https://github.com/NixOS/nixpkgs/commit/294083298ec82b2e7d26301fe4ae798487ec0ddd) | `` python310Packages.peaqevcore: 19.0.1 -> 19.0.2 ``                      |
| [`91d48bf4`](https://github.com/NixOS/nixpkgs/commit/91d48bf4bdb3ae2744b86d9588dac61678a5e300) | `` terraform-providers.tencentcloud: 1.81.16 -> 1.81.17 ``                |
| [`ae2bce3a`](https://github.com/NixOS/nixpkgs/commit/ae2bce3a9fa2a6830e2d8398d75bf307ff429fee) | `` terraform-providers.wavefront: 3.6.0 -> 4.0.0 ``                       |
| [`02219f3f`](https://github.com/NixOS/nixpkgs/commit/02219f3fd0c31335058f0d3fa65e2c61f3f59e32) | `` terraform-providers.turbot: 1.9.1 -> 1.10.0 ``                         |
| [`5109f854`](https://github.com/NixOS/nixpkgs/commit/5109f85403704bdff4e0ab9ec9247b12c62340fa) | `` terraform-providers.spotinst: 1.129.0 -> 1.130.0 ``                    |
| [`eeb5d817`](https://github.com/NixOS/nixpkgs/commit/eeb5d817f6048cb59f90687d44374b9607267950) | `` terraform-providers.opentelekomcloud: 1.35.3 -> 1.35.4 ``              |
| [`0f3fdff0`](https://github.com/NixOS/nixpkgs/commit/0f3fdff0062a48edd0e7e18e4c154bd55f93a573) | `` terraform-providers.opsgenie: 0.6.28 -> 0.6.29 ``                      |
| [`a355bae9`](https://github.com/NixOS/nixpkgs/commit/a355bae97f657f192e900b7085ea45b621780198) | `` terraform-providers.ns1: 2.0.4 -> 2.0.5 ``                             |
| [`1cf94f61`](https://github.com/NixOS/nixpkgs/commit/1cf94f6109e02e1ea50db98b46b817081d057cb1) | `` terraform-providers.minio: 1.16.0 -> 1.17.0 ``                         |
| [`acdbb82a`](https://github.com/NixOS/nixpkgs/commit/acdbb82ab3967fb45837495699535eb9352c3a04) | `` terraform-providers.google-beta: 4.75.0 -> 4.75.1 ``                   |
| [`c3f7f34b`](https://github.com/NixOS/nixpkgs/commit/c3f7f34b0b046452333dd3ce72d2c7c6d6a4a7fe) | `` terraform-providers.google: 4.75.0 -> 4.75.1 ``                        |
| [`e04b7dae`](https://github.com/NixOS/nixpkgs/commit/e04b7dae8c5e7b570c106428b5517c2c6eb6d2ba) | `` terraform-providers.aws: 5.9.0 -> 5.10.0 ``                            |
| [`f98c417b`](https://github.com/NixOS/nixpkgs/commit/f98c417be39dea73f172670ae975cd3a7b53c150) | `` terraform-providers.equinix: 1.14.4 -> 1.14.5 ``                       |
| [`15f49349`](https://github.com/NixOS/nixpkgs/commit/15f4934905ca0786ac1b11a296216437219e4950) | `` terraform-providers.azurerm: 3.66.0 -> 3.67.0 ``                       |
| [`17112f15`](https://github.com/NixOS/nixpkgs/commit/17112f1567e35f7df1db18c1759bbe828e17a397) | `` terraform-providers.azuread: 2.40.0 -> 2.41.0 ``                       |
| [`6ec777a0`](https://github.com/NixOS/nixpkgs/commit/6ec777a06208fc6417d440dc8377d5a9bbb7d6e3) | `` framac: 26.1 (Iron) → 27.1 (Cobalt) ``                                 |
| [`d6352701`](https://github.com/NixOS/nixpkgs/commit/d63527018827ccc7d6e96685daaf237d9b32c541) | `` ocamlPackages.ppx_deriving_yaml: 0.1.1 → 0.2.1 ``                      |
| [`025af473`](https://github.com/NixOS/nixpkgs/commit/025af4730357856f6639cef0b2e75255d7b9c30d) | `` writers: use runCommand instead of runCommandNoCC ``                   |
| [`dadcfacb`](https://github.com/NixOS/nixpkgs/commit/dadcfacb516ea3a68197c2cb3ad2c2851c37621d) | `` python310Packages.slack-bolt: fix build ``                             |
| [`99a80c69`](https://github.com/NixOS/nixpkgs/commit/99a80c6981a9a235917f74356248741729720e57) | `` tailscale: 1.46.0 -> 1.46.1 ``                                         |
| [`56c08f0d`](https://github.com/NixOS/nixpkgs/commit/56c08f0d5dc52b948d1b63083b61bf33a20b60a2) | `` cargo-component: unstable-2023-07-05 -> unstable-2023-07-28 ``         |
| [`09dd9739`](https://github.com/NixOS/nixpkgs/commit/09dd97398783f4240029bd219de53d42e8de2473) | `` writers: use callPackages to import sub-groups of writers ``           |
| [`71c77f1f`](https://github.com/NixOS/nixpkgs/commit/71c77f1f1bcda3713159fb9d51a9b79f43dd3c08) | `` pprof: unstable-2022-05-09 -> unstable-2023-07-05 ``                   |
| [`242c4025`](https://github.com/NixOS/nixpkgs/commit/242c4025eddd0635d9f7ca76c459126ef6fe1afd) | `` python310Packages.unstructured-api-tools: init at 0.10.10 ``           |
| [`69551511`](https://github.com/NixOS/nixpkgs/commit/69551511202f1a6506088f2866bdedd1fbd4fb46) | `` python310Packages.onnxmltools: init at 1.11.2 ``                       |
| [`525595eb`](https://github.com/NixOS/nixpkgs/commit/525595ebff10594d3d6071ca9953ba15f7e8b19c) | `` vscode: 1.80.1 -> 1.80.2 ``                                            |
| [`bfc44cf9`](https://github.com/NixOS/nixpkgs/commit/bfc44cf9fe18198d826a49b1ac2db70cd2733391) | `` nushellPlugins.query: 0.82.0 -> 0.83.0 ``                              |
| [`4c78dfbf`](https://github.com/NixOS/nixpkgs/commit/4c78dfbf6f6a89a1b1ed49a775a8d8213ba2c4b3) | `` sbt-extras: 2023-07-11 -> 2023-07-25 ``                                |
| [`99782d46`](https://github.com/NixOS/nixpkgs/commit/99782d462f5b63ef1cbec807cbe3f6ea3f687b05) | `` knit: init at 1.1.1 ``                                                 |
| [`6ed5db6e`](https://github.com/NixOS/nixpkgs/commit/6ed5db6e094fb6b90f4fa00d54c24bdb492ae38a) | `` maintainers: add DrSensor ``                                           |
| [`8a9257d4`](https://github.com/NixOS/nixpkgs/commit/8a9257d4c0311e2e0aae290a65da7052559f6565) | `` cartridges: 2.1 -> 2.1.1 ``                                            |
| [`c604f839`](https://github.com/NixOS/nixpkgs/commit/c604f8394a992463d38a6b7b7dec77df2149fc05) | `` cozette: 1.21.0 -> 1.22.0 ``                                           |
| [`b62bafb0`](https://github.com/NixOS/nixpkgs/commit/b62bafb08fdd7bb0c1d53af4a0f6be3596eaaae3) | `` gst_all_1.gst-plugins-good: fix comment typo ``                        |
| [`47f75ef1`](https://github.com/NixOS/nixpkgs/commit/47f75ef1bf24902cda73187863ad5e5502f75a6b) | `` wasmtime: 11.0.0 -> 11.0.1 ``                                          |
| [`9998bf75`](https://github.com/NixOS/nixpkgs/commit/9998bf752cfe2e6467cc1632abcaa4125499ac36) | `` yambar: enable strictDeps ``                                           |
| [`ba75ea45`](https://github.com/NixOS/nixpkgs/commit/ba75ea457f1041b87ff80fe181836d9640f09d51) | `` yambar: 1.9.0 -> 1.10.0 ``                                             |
| [`4fb0a77d`](https://github.com/NixOS/nixpkgs/commit/4fb0a77d60efacd10f18ef5c907fbefd968f7e63) | `` psitransfer: use buildNpmPackage ``                                    |
| [`77430102`](https://github.com/NixOS/nixpkgs/commit/77430102c7c2eed11a712f403e0b5c203fa9f220) | `` btrfs-progs: 6.3.2 -> 6.3.3 ``                                         |
| [`14a23314`](https://github.com/NixOS/nixpkgs/commit/14a23314a49f2d609a03d082a2274f6b6ec64172) | `` Update cloud-sql-proxy to use hash option ``                           |
| [`8c3e9127`](https://github.com/NixOS/nixpkgs/commit/8c3e91278e9e3adb5ca25ba7a1fa749448635677) | `` grafana-agent: 0.35.0 -> 0.35.2 ``                                     |
| [`f2954a87`](https://github.com/NixOS/nixpkgs/commit/f2954a87e2f933f8ab64da95b00dc6bc67feb34c) | `` dart-sass: 1.63.3 -> 1.64.1 ``                                         |
| [`7e96794e`](https://github.com/NixOS/nixpkgs/commit/7e96794e1439e551e5cf571a339413cdadab3ec4) | `` cloudflared: 2023.7.0 -> 2023.7.3 ``                                   |
| [`ff8b6994`](https://github.com/NixOS/nixpkgs/commit/ff8b69941a5e4138e4da553b54dbf44a326a2bdf) | `` nixos/qt: install qt6gtk2 when using gtk2 ``                           |
| [`415cd929`](https://github.com/NixOS/nixpkgs/commit/415cd9298ded0f9454de1ac5abcbc899be34618b) | `` qt6Packages.qt6gtk2: init at 0.2 ``                                    |
| [`538f593b`](https://github.com/NixOS/nixpkgs/commit/538f593b2153e5250ef3a93bb549fcb864c0d429) | `` jetbrains: 2023.1.2 -> 2023.2 ``                                       |
| [`eea1ec76`](https://github.com/NixOS/nixpkgs/commit/eea1ec76f5121f68c559b5159aa953ab118806af) | `` blackfire: 2.18.0 -> 2.19.0 ``                                         |
| [`c36cc928`](https://github.com/NixOS/nixpkgs/commit/c36cc92818e76bdbfb575089bd72f5b682b2691b) | `` ruwudu: 2.000 → 3.000 ``                                               |
| [`f4d870c8`](https://github.com/NixOS/nixpkgs/commit/f4d870c84aea10c8930db7fe4b24b8834b3dcef8) | `` kbt: 1.0.0 -> 1.1.0 ``                                                 |
| [`126ea613`](https://github.com/NixOS/nixpkgs/commit/126ea613fbbfc2c58875ce908a6162f1eb2593e1) | `` rust-script: 0.29.0 -> 0.30.0 ``                                       |
| [`1cdde769`](https://github.com/NixOS/nixpkgs/commit/1cdde769c8a88dffb025330d057c1d666dae133e) | `` Revert "pkgs.formats.toml: fix TOML semantics by upgrading tomlkit" `` |
| [`d3a0a255`](https://github.com/NixOS/nixpkgs/commit/d3a0a255edc590be5839da5e437249ec35c681d6) | `` probe-rs: 0.19.0 -> 0.20.0 ``                                          |
| [`3086313e`](https://github.com/NixOS/nixpkgs/commit/3086313e4c2acdce255315881a3e0e6a1de70e88) | `` nixos/frigate: fix recording and serving of clips/recordings ``        |
| [`6774f3fc`](https://github.com/NixOS/nixpkgs/commit/6774f3fc04adfd6245a84f02cd0c7ed1af02c89b) | `` services.postgresql: fix example ``                                    |
| [`661f33ec`](https://github.com/NixOS/nixpkgs/commit/661f33eced52e951b6af9aafe576ad972e6a03fa) | `` cloud-sql-proxy: 2.5.0 -> 2.6.0 ``                                     |
| [`98db1a43`](https://github.com/NixOS/nixpkgs/commit/98db1a434ce282def857d6eec698a5b9f811efe9) | `` jackett: 0.21.532 -> 0.21.547 ``                                       |
| [`70b2632c`](https://github.com/NixOS/nixpkgs/commit/70b2632c491ecdfb3d76051a7307a3157a581126) | `` spicetify-cli: 2.22.0 -> 2.22.1 ``                                     |
| [`8af93820`](https://github.com/NixOS/nixpkgs/commit/8af93820f79d23b94ca97b9ebf160124fb992f9a) | `` patchelfUnstable: unstable-2023-06-08 -> unstable-2023-07-20 ``        |
| [`2d96880b`](https://github.com/NixOS/nixpkgs/commit/2d96880b56efd6ddad7b7912d47dc62de6beba54) | `` boundary: 0.13.0 -> 0.13.1 ``                                          |
| [`6c28e7cf`](https://github.com/NixOS/nixpkgs/commit/6c28e7cf19bd2410fe3d57878160dba2c92f92b4) | `` zeronet-conservancy: 0.7.9 -> 0.7.10 ``                                |
| [`6067e44b`](https://github.com/NixOS/nixpkgs/commit/6067e44b773c98743fc5c2f2e7fdbaa51a55d3c1) | `` qownnotes: 23.7.2 -> 23.7.3 ``                                         |
| [`ffb9b68b`](https://github.com/NixOS/nixpkgs/commit/ffb9b68bd3629d81d082193db000959039347518) | `` pkgs.format.toml: introduce test for checking semantics ``             |
| [`f6899564`](https://github.com/NixOS/nixpkgs/commit/f68995642f6efc4fb0d4b208a5e90864237407ba) | `` tomlkit: 0.11.6 -> 0.11.8 ``                                           |
| [`97f82c9d`](https://github.com/NixOS/nixpkgs/commit/97f82c9d6308995e22042adbc7991d84c8b3af20) | `` tomlkit: build with poetry-core ``                                     |
| [`d086feb4`](https://github.com/NixOS/nixpkgs/commit/d086feb468b35a7d40926c6dc535cfd9facf79c7) | `` python310Packages.teslajsonpy: 3.9.1 -> 3.9.2 ``                       |
| [`8314d9f4`](https://github.com/NixOS/nixpkgs/commit/8314d9f45731906a879bb7f0205e9e586badeda5) | `` kitty: 0.29.1 -> 0.29.2 ``                                             |
| [`e1ab69eb`](https://github.com/NixOS/nixpkgs/commit/e1ab69eb4a0aa1d0fa7803e6a007dfb53e1b4b61) | `` readarr: 0.1.9.1905 -> 0.2.4.1999 ``                                   |
| [`4635b36a`](https://github.com/NixOS/nixpkgs/commit/4635b36ac86237fc2ea4cf8e063aba82ef067ae3) | `` lxd: 5.15 -> 5.16 ``                                                   |
| [`e53c0de8`](https://github.com/NixOS/nixpkgs/commit/e53c0de8dd1cfd156b796bdb726a9c784d5f51cf) | `` lxd: statically compile agent and migration tools ``                   |
| [`fdf98371`](https://github.com/NixOS/nixpkgs/commit/fdf9837118199344adbbb3682f1d425e92a36784) | `` lxd: URLs have changed to canonical ``                                 |
| [`327bfef3`](https://github.com/NixOS/nixpkgs/commit/327bfef31d2c2b712d2ac348b3cd7ebe2db0f199) | `` crun: 1.8.5 -> 1.8.6 ``                                                |
| [`2fd5473a`](https://github.com/NixOS/nixpkgs/commit/2fd5473a4601d3657ed756a6c27db57dbcbf4330) | `` python310Packages.bitarray: 2.7.6 -> 2.8.0 ``                          |
| [`e9f77c19`](https://github.com/NixOS/nixpkgs/commit/e9f77c190aa3390424e4b63add2cc27533fb91ea) | `` kubefirst: 2.2.2 -> 2.2.5 ``                                           |
| [`13cbc0d4`](https://github.com/NixOS/nixpkgs/commit/13cbc0d4139c1fe0dd88671eac2203cc11ebbe9f) | `` gradle_7: 7.6.1 -> 7.6.2 ``                                            |
| [`2ced733d`](https://github.com/NixOS/nixpkgs/commit/2ced733dc1d3b574bc52fbe41007580e1e9aaad1) | `` gron: set version at build time ``                                     |
| [`d7cab065`](https://github.com/NixOS/nixpkgs/commit/d7cab065ca68165386551b44096ea6b07fff1584) | `` enc: 1.1.0 -> 1.1.2 ``                                                 |
| [`a9c33b3f`](https://github.com/NixOS/nixpkgs/commit/a9c33b3f98fa49da5b85ceae212fa1621c056fff) | `` gdb: fix charset issue on darwin, missing libiconv (#245576) ``        |
| [`7a22d278`](https://github.com/NixOS/nixpkgs/commit/7a22d278811801b0c024c2e2edfe1b74848848ea) | `` python310Packages.optax: 0.1.5 -> 0.1.7 ``                             |
| [`ab5229ec`](https://github.com/NixOS/nixpkgs/commit/ab5229ec4d052ccd9ca7137f0653f4a0994c65c6) | `` python3Packages.fontawesomefree: init at 6.4.0 ``                      |
| [`65d0e651`](https://github.com/NixOS/nixpkgs/commit/65d0e651223571a7f06613f380287a1d7cdccd6e) | `` debian-devscripts: change platforms to platforms.unix ``               |
| [`813479df`](https://github.com/NixOS/nixpkgs/commit/813479df3952ab7a21d02ce5a9400529a62224ca) | `` python3Packages.pywayland: 0.4.15 -> 0.4.16 ``                         |
| [`7ea62c59`](https://github.com/NixOS/nixpkgs/commit/7ea62c59a2f75351899975e0e97eefece1f6a8d7) | `` python311Packages.yalexs-ble: 2.2.2 -> 2.2.3 ``                        |
| [`d9248a45`](https://github.com/NixOS/nixpkgs/commit/d9248a45f0941e763b1c90340060fabde726d3b4) | `` python311Packages.pypitoken: update disabled ``                        |
| [`5e2cea42`](https://github.com/NixOS/nixpkgs/commit/5e2cea4213541535aefd147a133a092cd43442ce) | `` unison: match version with tag, cleanup ``                             |
| [`f372775a`](https://github.com/NixOS/nixpkgs/commit/f372775ad26b46112e56b0c8abf71fc810ada5d3) | `` intel-media-driver: fix hash mismatch ``                               |
| [`30795991`](https://github.com/NixOS/nixpkgs/commit/30795991b5929e135bcd93ef716b09a7a8c36526) | `` authz0: 1.1.1 -> 1.1.2 ``                                              |
| [`e09a216a`](https://github.com/NixOS/nixpkgs/commit/e09a216abeb0e712293df6328324d4de93d631ff) | `` python311Packages.bluetooth-data-tools: 1.6.0 -> 1.6.1 ``              |
| [`c379f0cd`](https://github.com/NixOS/nixpkgs/commit/c379f0cd4731cba1376f70fb46e5cc8e7097e570) | `` python311Packages.home-assistant-bluetooth: 1.10.0 -> 1.10.2 ``        |
| [`17f7ef5b`](https://github.com/NixOS/nixpkgs/commit/17f7ef5bf22af16df7b3c24de9434061224d99d1) | `` aws-iam-authenticator: 0.5.9 -> 0.6.11 ``                              |
| [`987b0b7e`](https://github.com/NixOS/nixpkgs/commit/987b0b7e7d06146e9a4067caa15363df60931ac1) | `` python311Packages.aioslimproto: 2.3.2 -> 2.3.3 ``                      |
| [`abedcc80`](https://github.com/NixOS/nixpkgs/commit/abedcc80a1eead0a4369e07731ead64484f2caa5) | `` python310Packages.meshtastic: 2.1.10 -> 2.1.11 ``                      |
| [`c696779e`](https://github.com/NixOS/nixpkgs/commit/c696779e0553c28cf5e01c5dc66f4c136e790df4) | `` trufflehog: 3.44.0 -> 3.45.1 ``                                        |
| [`a9729124`](https://github.com/NixOS/nixpkgs/commit/a9729124ef6e94b30c4a5eed83a33fcc123051df) | `` amass: 4.0.3 -> 4.0.4 ``                                               |
| [`a2c1f741`](https://github.com/NixOS/nixpkgs/commit/a2c1f741b8d9e528726f827267a3eff20e2419fe) | `` python310Packages.bentoml: init at 1.1.0 ``                            |
| [`c4c54d52`](https://github.com/NixOS/nixpkgs/commit/c4c54d525e4c1fe68e4daac2d527b700e5505a7f) | `` python310Packages.auth0-python: 4.3.0 -> 4.4.0 ``                      |
| [`9d6f1799`](https://github.com/NixOS/nixpkgs/commit/9d6f1799e29e49f26b39135dc81b046e9af5ef0d) | `` knot-dns: 3.2.8 -> 3.2.9 ``                                            |
| [`4a5e0223`](https://github.com/NixOS/nixpkgs/commit/4a5e022304756fde96374b085100c3e3b24f73eb) | `` coqPackages.trakt: fix documented license ``                           |
| [`53ef5765`](https://github.com/NixOS/nixpkgs/commit/53ef5765adb2ab37a4ca2b4c1bf5bac57d76b156) | `` coqPackages.trakt: add recent versions ``                              |
| [`d6e6c8f7`](https://github.com/NixOS/nixpkgs/commit/d6e6c8f7fc3263f56f64ceb23199eca296e7ce38) | `` python310Packages.elastic-apm: 6.17.0 -> 6.18.0 ``                     |
| [`1084044a`](https://github.com/NixOS/nixpkgs/commit/1084044a6c1fc8a46f2d66c08b05ebda85a8da6b) | `` python310Packages.pytorch-lightning: 2.0.5 -> 2.0.6 ``                 |
| [`497229d3`](https://github.com/NixOS/nixpkgs/commit/497229d3c2e56c72ef582c0575d0dcf5a2320731) | `` nixos/pantheon: Install orca ``                                        |
| [`1a5e7012`](https://github.com/NixOS/nixpkgs/commit/1a5e7012a09b532ca2fdd73b3f38be8a4a738a50) | `` catppuccin-catwalk: init at 0.4.0 ``                                   |
| [`a627a4f8`](https://github.com/NixOS/nixpkgs/commit/a627a4f8545158e846861ba72797f3b23988ae79) | `` dnf5: 5.0.15 -> 5.1.0 ``                                               |
| [`bd4cca1c`](https://github.com/NixOS/nixpkgs/commit/bd4cca1c33f65c5339ee7c40cfd06a475ba182c5) | `` oh-my-posh: 18.0.1 -> 18.1.0 ``                                        |
| [`18f721a9`](https://github.com/NixOS/nixpkgs/commit/18f721a91ea9581143d4ea23d2963db148293271) | `` oh-my-posh: 17.12.0 -> 18.0.1 ``                                       |
| [`d6c3d7d6`](https://github.com/NixOS/nixpkgs/commit/d6c3d7d6f08a9278d79e459c7798c7efc7b756d4) | `` clifm: 1.10 -> 1.13 ``                                                 |
| [`875b0197`](https://github.com/NixOS/nixpkgs/commit/875b01971ef8ec56518a04b61c0e98bbfd4ddacf) | `` nfs-ganesha: 5.2 -> 5.4 ``                                             |
| [`44928e34`](https://github.com/NixOS/nixpkgs/commit/44928e3448b51d7379e4817c75ccb5f73afd6598) | `` nova: 3.6.4 -> 3.7.0 ``                                                |
| [`3d3ceb52`](https://github.com/NixOS/nixpkgs/commit/3d3ceb52acb4c06e6df5dc2bce039286b71db32e) | `` orbiton: 2.62.6 -> 2.62.7 ``                                           |
| [`1b58cab2`](https://github.com/NixOS/nixpkgs/commit/1b58cab2a9ae1701d46de17d4f33f42bfad24ebd) | `` micronaut: 4.0.0 -> 4.0.1 ``                                           |
| [`2dd3cda4`](https://github.com/NixOS/nixpkgs/commit/2dd3cda40f19dca7ad7657a9affd7c95fb03f321) | `` elan: 2.0.0 -> 2.0.1 ``                                                |
| [`8523db58`](https://github.com/NixOS/nixpkgs/commit/8523db58448add6e3e0c39c5b53fbefd93c98a37) | `` python310Packages.chiavdf: 1.0.9 -> 1.0.10 ``                          |