### PR TITLE
chore(flake/home-manager): `5c232267` -> `f58889c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -205,11 +205,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690629157,
-        "narHash": "sha256-hsZC4tPH4Ab/ynuswApNFzshbfG79Ctbrc4Qa0z9sek=",
+        "lastModified": 1690652600,
+        "narHash": "sha256-Dy09g7mezToVwtFPyY25fAx1hzqNXv73/QmY5/qyR44=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5c23226768abd3402636f4d3c65aea8450997102",
+        "rev": "f58889c07efa8e1328fdf93dc1796ec2a5c47f38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`f58889c0`](https://github.com/nix-community/home-manager/commit/f58889c07efa8e1328fdf93dc1796ec2a5c47f38) | `` gnome-terminal: add assertion on profile names `` |