### PR TITLE
chore(flake/nixos-hardware): `ba9650b1` -> `96e5a0a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -327,11 +327,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1690200740,
-        "narHash": "sha256-aRkEXGmCbAGcvDcdh/HB3YN+EvoPoxmJMOaqRZmf6vM=",
+        "lastModified": 1690704397,
+        "narHash": "sha256-sgIWjcz0e+x87xlKg324VtHgH55J5rIuFF0ZWRDvQoE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ba9650b14e83b365fb9e731f7d7c803f22d2aecf",
+        "rev": "96e5a0a0e8568c998135ea05575a9ed2c87f5492",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                               |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`96e5a0a0`](https://github.com/NixOS/nixos-hardware/commit/96e5a0a0e8568c998135ea05575a9ed2c87f5492) | `` t14s: reformat ``                                  |
| [`67b0b87f`](https://github.com/NixOS/nixos-hardware/commit/67b0b87fd8e77a0b0bb6b37b09e5b70fa7cea713) | `` p14s, t14s: remove linux-firmware version check `` |