### PR TITLE
chore(flake/pre-commit-hooks): `1e2443dd` -> `fcbf4705`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -403,11 +403,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1690628027,
-        "narHash": "sha256-OTSbA2hM6VmxyZ/4siYPANffMBzIsKu04GLjXcv8ST0=",
+        "lastModified": 1690743255,
+        "narHash": "sha256-dsJzQsyJGWCym1+LMyj2rbYmvjYmzeOrk7ypPrSFOPo=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "1e2443dd3f669eb65433b2fc26a3065e05a7dc9c",
+        "rev": "fcbf4705d98398d084e6cb1c826a0b90a91d22d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                  |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
| [`2759193c`](https://github.com/cachix/pre-commit-hooks.nix/commit/2759193c230c5c0c0767cda10e6d99937021ec8a) | `` Check that pkgs isn't used by docs `` |
| [`d3657e70`](https://github.com/cachix/pre-commit-hooks.nix/commit/d3657e7015550c8fd9231dde51ad5b042e783caa) | `` Fix doc ``                            |