### PR TITLE
chore(flake/home-manager): `310c0063` -> `89df56fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -205,11 +205,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690846843,
-        "narHash": "sha256-sfguzocpi42+juoiUNLMtXws33DeEZkbEVTLtx/LKC8=",
+        "lastModified": 1690879813,
+        "narHash": "sha256-LmRhzSkQgFWpt8skFiwLeOPNXbZTVSKitD2Q3yEEXhc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "310c0063b2558e94ad8bc3c1f2ddead82e0872cd",
+        "rev": "89df56fefe728bed13b4b5b99af196017e330dd5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`89df56fe`](https://github.com/nix-community/home-manager/commit/89df56fefe728bed13b4b5b99af196017e330dd5) | `` fish: fix session vars build in cross-compiled system (#4293) `` |