### PR TITLE
chore(flake/nixos-hardware): `96e5a0a0` -> `9910c698`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -327,11 +327,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1690704397,
-        "narHash": "sha256-sgIWjcz0e+x87xlKg324VtHgH55J5rIuFF0ZWRDvQoE=",
+        "lastModified": 1690954955,
+        "narHash": "sha256-ZMFPEx/8B/6RxoTeqSVBG8DvA8jDtWFVmLhtgbSlmXs=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "96e5a0a0e8568c998135ea05575a9ed2c87f5492",
+        "rev": "9910c6985687cf1c365bc10c95c5bacdaed81e3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`9910c698`](https://github.com/NixOS/nixos-hardware/commit/9910c6985687cf1c365bc10c95c5bacdaed81e3f) | `` GPD-P3: Remove S2 sleep kernel param, use S3 instead `` |