### PR TITLE
chore(flake/home-manager): `b2ac1d2c` -> `86dd48d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -205,11 +205,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690982105,
-        "narHash": "sha256-32AzoLuwhtxBItcULRiCnxRfJcbVXbPZSH9TDVg21mU=",
+        "lastModified": 1691039228,
+        "narHash": "sha256-iPNZJ1LvfUf1Y456ewC0DXgf99TNssG8OLObOyqxO6M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b2ac1d2c32ac11b8d231d23622cdc4b2f28d07d2",
+        "rev": "86dd48d70a2e2c17e84e747ba4faa92453e68d4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`86dd48d7`](https://github.com/nix-community/home-manager/commit/86dd48d70a2e2c17e84e747ba4faa92453e68d4a) | `` Translate using Weblate (Korean) ``   |
| [`9b0bc4ce`](https://github.com/nix-community/home-manager/commit/9b0bc4ce7917f7b6f597fbe00b655fd992f63147) | `` Translate using Weblate (Romanian) `` |
| [`e79f416b`](https://github.com/nix-community/home-manager/commit/e79f416b61da725fe167e74a33f344b2edee61f7) | `` Translate using Weblate (German) ``   |