### PR TITLE
chore(flake/nixpkgs): `9e1960bc` -> `66aedfd0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1690881714,
-        "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
+        "lastModified": 1691006197,
+        "narHash": "sha256-DbtxVWPt+ZP5W0Usg7jAyTomIM//c3Jtfa59Ht7AV8s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9e1960bc196baf6881340d53dccb203a951745a2",
+        "rev": "66aedfd010204949cb225cf749be08cb13ce1813",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`5eaeb7eb`](https://github.com/NixOS/nixpkgs/commit/5eaeb7eb5a6469b5c814698949fad93f255a71e5) | `` python3Packages.dask-awkward: 2023.6.3 -> 2023.8.0 (#246671) ``            |
| [`41501361`](https://github.com/NixOS/nixpkgs/commit/415013610e49b64668ad8e0dc36eb73391abc4cb) | `` vscode-extensions.eamodio.gitlens: 13.4.0 -> 14.1.1 ``                     |
| [`6e5a922b`](https://github.com/NixOS/nixpkgs/commit/6e5a922b38e1b635a26b2ed3d93babada55964a0) | `` vscode-extensions.gruntfuggly.todo-tree: 0.0.224 -> 0.0.226 ``             |
| [`766ddf75`](https://github.com/NixOS/nixpkgs/commit/766ddf754a9c3dea44d273a1f61cb94d6ff2dbbe) | `` vscode-extensions.tyriar.sort-lines: 1.9.1 -> 1.10.2 ``                    |
| [`972ac0f0`](https://github.com/NixOS/nixpkgs/commit/972ac0f055ef5540d3fc25c71a13e24b637f4687) | `` vscode-extensions.rust-lang.rust-analyzer: 0.3.1426 -> 0.3.1607 ``         |
| [`563e9d4b`](https://github.com/NixOS/nixpkgs/commit/563e9d4bfa147e794d7b276c98968b56a0102696) | `` vscode-extensions.esbenp.prettier-vscode: 9.19.0 -> 10.1.0 ``              |
| [`e82756d4`](https://github.com/NixOS/nixpkgs/commit/e82756d4f50273d92433e1d57e85738029042209) | `` tamatool: init at 0.1 ``                                                   |
| [`e4235192`](https://github.com/NixOS/nixpkgs/commit/e4235192047a058776b3680f559579bf885881da) | `` osquery: fix openssl src hash permanently ``                               |
| [`bc706c03`](https://github.com/NixOS/nixpkgs/commit/bc706c03a53cddd95b4676df433332f4f7940711) | `` catppuccin-sddm-corners: init at unstable-2023-02-17 ``                    |
| [`db7572d9`](https://github.com/NixOS/nixpkgs/commit/db7572d92d18a8e9153c6ff545936354851f9b92) | `` dae: 0.2.2 -> 0.2.3 ``                                                     |
| [`120d2b58`](https://github.com/NixOS/nixpkgs/commit/120d2b5821407e023c68c32793286c9122bb95af) | `` vscode-extensions.jnoortheen.nix-ide: 0.2.1 -> 0.2.2 ``                    |
| [`c206eafb`](https://github.com/NixOS/nixpkgs/commit/c206eafba8022039bdc296a940acdaf8ffdb221b) | `` vscode-extensions.pkief.material-icon-theme: 4.25.0 -> 4.29.0 ``           |
| [`7792a18b`](https://github.com/NixOS/nixpkgs/commit/7792a18b629e3786ba03ae084da35ed17b1d9c26) | `` vscode-extensions.github.vscode-pull-request-github: 0.66.0 -> 0.68.1 ``   |
| [`abdb474a`](https://github.com/NixOS/nixpkgs/commit/abdb474a21a17233a9270797e3f07cf5fed766a5) | `` libblockdev: use `finalAttrs` pattern ``                                   |
| [`800e9231`](https://github.com/NixOS/nixpkgs/commit/800e92312bba3ef19b81469190970268f9ea67c4) | `` vscode-extensions.bmalehorn.vscode-fish: 1.0.33 -> 1.0.35 ``               |
| [`e9a424e8`](https://github.com/NixOS/nixpkgs/commit/e9a424e856349062aa7c26dc99ece5c13288499b) | `` vscode-extensions.tamasfe.even-better-toml: 0.19.0 -> 0.19.2 ``            |
| [`9a772d76`](https://github.com/NixOS/nixpkgs/commit/9a772d76581cd1573e7c213a4340587197693226) | `` veryfasttree: use `finalAttrs` pattern ``                                  |
| [`bc39d290`](https://github.com/NixOS/nixpkgs/commit/bc39d290769650b1696c72aad28298e4baf44de8) | `` lemurs: init at 0.3.1 ``                                                   |
| [`1fd16883`](https://github.com/NixOS/nixpkgs/commit/1fd16883d4c6593dfc7fdf88bb3476e1fa3b8587) | `` veryfasttree: 4.0.1 -> 4.0.2 ``                                            |
| [`44707b28`](https://github.com/NixOS/nixpkgs/commit/44707b28ea8e2ead566df246412593366a371fa3) | `` frp: 0.51.1 -> 0.51.2 ``                                                   |
| [`0307dd36`](https://github.com/NixOS/nixpkgs/commit/0307dd36253abf2e853bae791f03663806073330) | `` python310Packages.django_4: 4.2.3 -> 4.2.4 ``                              |
| [`7272b583`](https://github.com/NixOS/nixpkgs/commit/7272b583c3c1e99d5ea2740d7ad689dc7418f64d) | `` cargo-deny: 0.14.0 -> 0.14.1 ``                                            |
| [`1d323e3d`](https://github.com/NixOS/nixpkgs/commit/1d323e3d9dcc473426a8d58b1a79ef4f9ec48377) | `` chroma: 2.7.0 -> 2.8.0 ``                                                  |
| [`0f56755f`](https://github.com/NixOS/nixpkgs/commit/0f56755fd86fcccd130e62e868e176af0f53f529) | `` libblockdev: 3.0.1 -> 3.0.2 ``                                             |
| [`6baffa02`](https://github.com/NixOS/nixpkgs/commit/6baffa029e49847ce2038438b64e5af9349aab93) | `` gping: add manpage to output ``                                            |
| [`a9f9cdeb`](https://github.com/NixOS/nixpkgs/commit/a9f9cdeb72bce4b0cac369a4996e0e799be9be18) | `` gping: 1.13.1 -> 1.14.0 ``                                                 |
| [`77c63fae`](https://github.com/NixOS/nixpkgs/commit/77c63faef4dcb80d81af3291190b2314417268df) | `` fw: 2.17.0 -> 2.17.1 ``                                                    |
| [`07a29bba`](https://github.com/NixOS/nixpkgs/commit/07a29bba66db835f088bce7b48ff4ff8510c2bfe) | `` vnote: fix changelog ``                                                    |
| [`9ef03257`](https://github.com/NixOS/nixpkgs/commit/9ef03257bb6c3c4f5855547b0aef8fbd3646af30) | `` mongodb: fix build ``                                                      |
| [`a9a30c19`](https://github.com/NixOS/nixpkgs/commit/a9a30c19a3f3ae0ad7f591b3658957585d8c8e11) | `` kronosnet: 1.25 -> 1.26 ``                                                 |
| [`bcd27e49`](https://github.com/NixOS/nixpkgs/commit/bcd27e495e3fab072d5f1a781b67a40d2da17fd7) | `` gopls: 0.13.0 -> 0.13.1 (#246737) ``                                       |
| [`3cdc3346`](https://github.com/NixOS/nixpkgs/commit/3cdc3346106e80110b2acb044d38ec3b913f66ef) | `` treesheets: unstable-2023-07-28 -> unstable-2023-08-01 ``                  |
| [`0f01bba3`](https://github.com/NixOS/nixpkgs/commit/0f01bba32174fa0b2f6159e5ddf8337c000d7a28) | `` plots: init at 0.8.5 ``                                                    |
| [`cb3eb0d3`](https://github.com/NixOS/nixpkgs/commit/cb3eb0d35bebbe8c2aa59af42e5043d63af8f531) | `` pyglm: init at 2.7.0 ``                                                    |
| [`b805fe3d`](https://github.com/NixOS/nixpkgs/commit/b805fe3d6f3e702ecee01710ee552e3ed39d16c8) | `` webkitgtk: 2.40.4 → 2.40.5 ``                                              |
| [`e0390ce2`](https://github.com/NixOS/nixpkgs/commit/e0390ce209a966d5c01ee220755db804a35f8f78) | `` ikos: 3.0 → 3.1 ``                                                         |
| [`4caa6fd0`](https://github.com/NixOS/nixpkgs/commit/4caa6fd07f6c55eefdacc0843fb83066130a3db9) | `` ikos: fix build ``                                                         |
| [`2b9b52d1`](https://github.com/NixOS/nixpkgs/commit/2b9b52d193bbf7c886dc7198cc0a9bc6dc0a10fd) | `` goose: 3.13.4 -> 3.14.0 (#246748) ``                                       |
| [`6f3d85ff`](https://github.com/NixOS/nixpkgs/commit/6f3d85ff35e0cf29bf33dc2f6b3c5ca2d292f108) | `` eris: 20230716 -> 20230722 ``                                              |
| [`7163f2ab`](https://github.com/NixOS/nixpkgs/commit/7163f2ab740c9d975cb7db8b0be2e07166d2d7f6) | `` flix: 0.38.0 -> 0.39.0 ``                                                  |
| [`774a6f23`](https://github.com/NixOS/nixpkgs/commit/774a6f236af0219352c2c1a840f60e44223a3271) | `` terraform-providers.dexidp: init at 0.2.1 ``                               |
| [`b958bdf1`](https://github.com/NixOS/nixpkgs/commit/b958bdf1b96881f0a73a9dd4d12d6e8c275ddff4) | `` jdt-language-server: set platforms ``                                      |
| [`cb4e0a8d`](https://github.com/NixOS/nixpkgs/commit/cb4e0a8d4e5a9042855ef60e6cfe15ff50a76215) | `` fwup: 1.10.0 -> 1.10.1 ``                                                  |
| [`cb10b111`](https://github.com/NixOS/nixpkgs/commit/cb10b111f3c236622bf3c2416e1841bfa46a89eb) | `` obs-studio: fix #226468 ``                                                 |
| [`6eeae9d1`](https://github.com/NixOS/nixpkgs/commit/6eeae9d1c2bbb637dfa8d749d565df209c0de3b2) | `` obs-studio-plugins.obs-source-record: 2022-11-10 -> 0.3.2 ``               |
| [`9bf10ac3`](https://github.com/NixOS/nixpkgs/commit/9bf10ac3c54d6cb5a1df732b7711773180ea4012) | `` obs-studio: 29.0.2 -> 29.1.3 ``                                            |
| [`0d0aae2d`](https://github.com/NixOS/nixpkgs/commit/0d0aae2d0b6f5bb09d0c3daf092c1334d0c7162d) | `` kyverno: 1.10.1 -> 1.10.2 ``                                               |
| [`bd94ce14`](https://github.com/NixOS/nixpkgs/commit/bd94ce1422fdc0868474678039073ce7786f3659) | `` dagger: 0.6.3 -> 0.6.4 ``                                                  |
| [`a3cfb658`](https://github.com/NixOS/nixpkgs/commit/a3cfb6589cb4f4b834ae329418b58ca0f21589d8) | `` compilers/nim: do not modify hardening flags ``                            |
| [`cf0f865c`](https://github.com/NixOS/nixpkgs/commit/cf0f865c7165c2c1a368580e2610c603a9ecc075) | `` nimPackages.unicodeplus: do check ``                                       |
| [`6afa4f43`](https://github.com/NixOS/nixpkgs/commit/6afa4f43be0627cb5591e886a1310ae8a383a358) | `` nimPackages.segmentation: do check ``                                      |
| [`83ecef02`](https://github.com/NixOS/nixpkgs/commit/83ecef0234b03cd5594295b769bc4a3af11baa86) | `` nimPackages.regex: eeefb4f -> 0.20.2 ``                                    |
| [`6a369a77`](https://github.com/NixOS/nixpkgs/commit/6a369a77e0e325c5dc1468316fc3c4929da87c6b) | `` nimPackages.ws: init 0.5.0 ``                                              |
| [`880d4219`](https://github.com/NixOS/nixpkgs/commit/880d421944b2ee7c7a5cd5f9469b22eb453082ed) | `` nimPackages.unicodedb: 0.9.0 -> 0.12.0 ``                                  |
| [`7a00eb64`](https://github.com/NixOS/nixpkgs/commit/7a00eb64548a98f273fc320ba40321fd3ca3dffd) | `` nimPackages.noise: 0.1.4 -> 0.1.8 ``                                       |
| [`68c59791`](https://github.com/NixOS/nixpkgs/commit/68c59791fb6644ac733d99d0147b09bce4cb8319) | `` chromium,ungoogled-chromium: fix ofborg maintainer pings ``                |
| [`2d7d5ac2`](https://github.com/NixOS/nixpkgs/commit/2d7d5ac2a48d7b46f0ac2657439aad919f8cde85) | `` shiori: 1.5.4 -> 1.5.5 ``                                                  |
| [`e6dcb5cb`](https://github.com/NixOS/nixpkgs/commit/e6dcb5cb8e341ca39bb92a8ed297b0fc33e3f0da) | `` fits-cloudctl: 0.11.11 -> 0.11.13 ``                                       |
| [`f97f08c1`](https://github.com/NixOS/nixpkgs/commit/f97f08c1b6bae7a63e96bce51ad8c8b0e09e0f30) | `` zziplib: fix build with clang 15+ ``                                       |
| [`b20ffc17`](https://github.com/NixOS/nixpkgs/commit/b20ffc17bd082ca8630df5f759391efa089b4306) | `` owncast: fix ffmpeg issues with systemd ``                                 |
| [`9f29a81a`](https://github.com/NixOS/nixpkgs/commit/9f29a81aa4407fc69d7025c8399ffad70abfe0d2) | `` grpc-gateway: 2.16.1 -> 2.16.2 ``                                          |
| [`0980e847`](https://github.com/NixOS/nixpkgs/commit/0980e847725266a71ea7a670b4f7d278edd12e7d) | `` mainsail: 2.6.0 -> 2.6.2 ``                                                |
| [`e1d395d3`](https://github.com/NixOS/nixpkgs/commit/e1d395d39b3960df4c741979bfbc15fa1889bc6d) | `` erlang: 25.3.2.4 -> 25.3.2.5 ``                                            |
| [`64ccc1bd`](https://github.com/NixOS/nixpkgs/commit/64ccc1bdab4d7df0cd87769b6e63121adebc0a65) | `` python311Packages.unstructured-inference: 0.5.5 -> 0.5.7 ``                |
| [`d4602c2f`](https://github.com/NixOS/nixpkgs/commit/d4602c2f3c82529d717c6363e749091667340c22) | `` kanata: 1.3.0 -> 1.4.0 ``                                                  |
| [`61d7bd05`](https://github.com/NixOS/nixpkgs/commit/61d7bd058557b5818743b5dde61e857659764662) | `` aws-sso-cli: 1.9.10 -> 1.10.0 ``                                           |
| [`7da7963d`](https://github.com/NixOS/nixpkgs/commit/7da7963dbad25f4309e31b4e815ea63eecda81ea) | `` transifex-cli: 1.6.9 -> 1.6.10 ``                                          |
| [`46dcf746`](https://github.com/NixOS/nixpkgs/commit/46dcf7469f5422d638a9882ae9e4466b5244e333) | `` maintainers: update cafkafk ``                                             |
| [`f354d2a0`](https://github.com/NixOS/nixpkgs/commit/f354d2a0934ca7f35fe35e54bc0f8c26305d59c7) | `` cloud-init: 23.2.1 -> 23.2.2 ``                                            |
| [`92a0dc99`](https://github.com/NixOS/nixpkgs/commit/92a0dc99cf566fda5a607f4f54b5f3b596a3cddd) | `` josm: 18772 -> 18789 ``                                                    |
| [`62dd6993`](https://github.com/NixOS/nixpkgs/commit/62dd69937333358d8805c2447a24d1eed1ca5e0d) | `` shipments: use fetchFromSourcehut ``                                       |
| [`d61cc625`](https://github.com/NixOS/nixpkgs/commit/d61cc625fa0a536ca4b6ac8bfd9ddc178078b2ac) | `` nixos-install: fix removal of non-empty `/mnt` ``                          |
| [`85bdf60c`](https://github.com/NixOS/nixpkgs/commit/85bdf60c63677039b16a3b6fdbc1ea60c844dd98) | `` deck: 1.23.0 -> 1.25.0 ``                                                  |
| [`a50d55db`](https://github.com/NixOS/nixpkgs/commit/a50d55db311419a0b369d8b07f76dcf5327e0149) | `` confy: noop - use fetchFromSourcehut ``                                    |
| [`1be87287`](https://github.com/NixOS/nixpkgs/commit/1be872871553a1369fb3e5a901127c2670ea060f) | `` budgie.budgie-control-center: 1.2.0 -> 1.3.0 ``                            |
| [`64530ce8`](https://github.com/NixOS/nixpkgs/commit/64530ce89aca40370b8c7bd3553316068873a5d1) | `` tor: 0.4.7.13 -> 0.4.7.14 ``                                               |
| [`60a381a8`](https://github.com/NixOS/nixpkgs/commit/60a381a85f18b7f8cdc74ad2712196f948ab78e7) | `` python310Packages.jsonmerge: run all tests ``                              |
| [`26f7e301`](https://github.com/NixOS/nixpkgs/commit/26f7e301327d1bf080d691978d2da368622ea19e) | `` postgresqlPackages.plv8: build on aarch64-linux ``                         |
| [`7f7166b1`](https://github.com/NixOS/nixpkgs/commit/7f7166b1898a1e61d1eca91c473bb25489a10954) | `` wander: 0.10.1 -> 0.11.1 ``                                                |
| [`8f7ec7ba`](https://github.com/NixOS/nixpkgs/commit/8f7ec7ba3e65e100ccd6743917209f5b9feea5b4) | `` logseq: 0.9.11 -> 0.9.13 ``                                                |
| [`a3aff4b4`](https://github.com/NixOS/nixpkgs/commit/a3aff4b4b93daf308719eef53dc7a8db9c83a97d) | `` sequoia-sq: 0.30.1 -> 0.31.0 ``                                            |
| [`48a7f9bd`](https://github.com/NixOS/nixpkgs/commit/48a7f9bde1cf771f2f854eb7fde7e52c8b51ee56) | `` mdbook-toc: 0.12.0 -> 0.13.0 ``                                            |
| [`96112a3e`](https://github.com/NixOS/nixpkgs/commit/96112a3ed5d12bb1758b42c63b924c004b6c0bc9) | `` edge-runtime: 1.7.2 -> 1.8.1 ``                                            |
| [`f5b0553e`](https://github.com/NixOS/nixpkgs/commit/f5b0553e9087ce158e533ed8aa7566460d9f3c46) | `` oven-media-engine: 0.15.13 -> 0.15.14 ``                                   |
| [`74d8b613`](https://github.com/NixOS/nixpkgs/commit/74d8b6132810ba846632b9322ff25c4a4da64218) | `` eks-node-viewer: 0.4.1 -> 0.4.2 ``                                         |
| [`9d10b637`](https://github.com/NixOS/nixpkgs/commit/9d10b637e46e87fd3dcb40402ea6418e60ac433c) | `` terraform-providers.wavefront: 4.0.0 -> 4.2.0 ``                           |
| [`5f5d59c5`](https://github.com/NixOS/nixpkgs/commit/5f5d59c5bc598dc5bd4208904875d85e42aba78e) | `` terraform-providers.spotinst: 1.130.0 -> 1.131.0 ``                        |
| [`172cb6d7`](https://github.com/NixOS/nixpkgs/commit/172cb6d7870d9b0cd24d8289368453a70f09599a) | `` terraform-providers.flexibleengine: 1.39.0 -> 1.40.0 ``                    |
| [`f8a36650`](https://github.com/NixOS/nixpkgs/commit/f8a3665041444e7a48c23689515beadc3fea1c27) | `` terraform-providers.grafana: 2.1.0 -> 2.2.0 ``                             |
| [`57ba3061`](https://github.com/NixOS/nixpkgs/commit/57ba3061c03539c79d2a7917a33dc0683e7dc0be) | `` terraform-providers.akamai: 5.0.1 -> 5.1.0 ``                              |
| [`6309570a`](https://github.com/NixOS/nixpkgs/commit/6309570ac1687bffb21091c6497fa9d99b493805) | `` terraform-providers.aci: 2.9.0 -> 2.10.0 ``                                |
| [`b293d5e3`](https://github.com/NixOS/nixpkgs/commit/b293d5e34d3b9366ad6f775b3531e1efa810a319) | `` istioctl: 1.18.1 -> 1.18.2 ``                                              |
| [`c498d2d4`](https://github.com/NixOS/nixpkgs/commit/c498d2d4d52e066b9ac17660370312dc469d4620) | `` vnote: 3.15.1 -> 3.16.0 ``                                                 |
| [`3ab93f44`](https://github.com/NixOS/nixpkgs/commit/3ab93f4411840c673cd6ebd9124def99fa41029d) | `` google-guest-agent: 20230711.00 -> 20230726.00 ``                          |
| [`8253b074`](https://github.com/NixOS/nixpkgs/commit/8253b0741e6637ac4beb80c688224be587af25ba) | `` jc: 1.23.3 -> 1.23.4 ``                                                    |
| [`8423edb1`](https://github.com/NixOS/nixpkgs/commit/8423edb179dea2f55e013a985a806dcb6bca60ea) | `` Revert "Update JAX" ``                                                     |
| [`e5719ffb`](https://github.com/NixOS/nixpkgs/commit/e5719ffb0db766bf57c15a0415e36171e3c96d96) | `` simple-dftd3: 0.7.0 -> 1.0.0 ``                                            |
| [`2787d9f3`](https://github.com/NixOS/nixpkgs/commit/2787d9f3fbf9968b199227a9a0362cfe4239e6db) | `` fw: 2.16.1 -> 2.17.0 ``                                                    |
| [`89679e5c`](https://github.com/NixOS/nixpkgs/commit/89679e5c761e6ffe3d932045eef21ccfc99a18a8) | `` minio-client: 2023-07-11T23-30-44Z -> 2023-07-21T20-44-27Z ``              |
| [`bab1e1d7`](https://github.com/NixOS/nixpkgs/commit/bab1e1d7aa9862b85081c660e8ad3ed494e371ad) | `` open-policy-agent: 0.54.0 -> 0.55.0 ``                                     |
| [`8acd2ac8`](https://github.com/NixOS/nixpkgs/commit/8acd2ac8b0424f7239316cba9912ad32bce49359) | `` squashfuse: 0.2.0 -> 0.4.0 ``                                              |
| [`09f64b15`](https://github.com/NixOS/nixpkgs/commit/09f64b15588729d023a3227027cef891d63b24e9) | `` nixpacks: 1.10.1 -> 1.12.0 ``                                              |
| [`0bd15d8f`](https://github.com/NixOS/nixpkgs/commit/0bd15d8fd2a37759c66b683e037dfba548e36899) | `` spire: 1.7.0 -> 1.7.1 ``                                                   |
| [`65df5d04`](https://github.com/NixOS/nixpkgs/commit/65df5d04abe7f8957c26a4ba8281450d459f451e) | `` proxify: 0.0.10 -> 0.0.11 ``                                               |
| [`1b2461f2`](https://github.com/NixOS/nixpkgs/commit/1b2461f29d568613ef3196f6facf14ebe7701c51) | `` nix-your-shell: 1.1.1 -> 1.3.0 ``                                          |
| [`5a68ba25`](https://github.com/NixOS/nixpkgs/commit/5a68ba2578a8cfe12abe0bba9a8013b7f9a3452d) | `` texlab: 5.7.0 -> 5.8.0 ``                                                  |
| [`48e83e2d`](https://github.com/NixOS/nixpkgs/commit/48e83e2d85644b272060f77426708c59c145d301) | `` cypress: 12.17.2 -> 12.17.3 ``                                             |
| [`96f54dd9`](https://github.com/NixOS/nixpkgs/commit/96f54dd9947eb534ea458cd524c0acb7d371c26d) | `` python310Packages.shtab: 1.6.2 -> 1.6.3 ``                                 |
| [`5aeb601d`](https://github.com/NixOS/nixpkgs/commit/5aeb601daec87e5cefb01b68266282d5072aed34) | `` gitlab: 16.1.2 -> 16.1.3 (#246628) ``                                      |
| [`d07a0698`](https://github.com/NixOS/nixpkgs/commit/d07a0698fc142a93ad61f1ac47d9726abdd3a1ff) | `` gitlab-container-registry: 3.77.0 -> 3.79.0 (#246629) ``                   |
| [`7f70abf8`](https://github.com/NixOS/nixpkgs/commit/7f70abf80ce03ac5b25175df57fe73eb71d20966) | `` nixos/image: write `systemd-repart` output to `$out/repart-output.json` `` |
| [`26a11bdc`](https://github.com/NixOS/nixpkgs/commit/26a11bdc905685fcbfb526965a67a70ac6e15809) | `` maintainers: add jeremiahs ``                                              |
| [`9bca1398`](https://github.com/NixOS/nixpkgs/commit/9bca13980fae8b6362646a4ce86a9eeabec23bf1) | `` davinci-resolve: remove host header restrictions for blob download ``      |
| [`48284913`](https://github.com/NixOS/nixpkgs/commit/48284913a2e017a5e9bf0b119bcfd594a88482df) | `` haproxy: use `finalAttrs` pattern ``                                       |
| [`6c12007b`](https://github.com/NixOS/nixpkgs/commit/6c12007b07fd8cfa976fe9726de94ec6524e2b93) | `` cargo-all-features: 1.9.0 -> 1.10.0 ``                                     |
| [`fbe83582`](https://github.com/NixOS/nixpkgs/commit/fbe83582ce61e8c67827c564bccf7191cc360881) | `` rustywind: 0.16.0 -> 0.17.0 ``                                             |
| [`1c353c50`](https://github.com/NixOS/nixpkgs/commit/1c353c50ff6fa3df770007de622de165f5302874) | `` docker: add glibc buildInput only on >=23.x ``                             |
| [`503953bd`](https://github.com/NixOS/nixpkgs/commit/503953bd0055016817b9a96998c404a070b3e481) | `` docker: disable man pages building ``                                      |
| [`1f202ea2`](https://github.com/NixOS/nixpkgs/commit/1f202ea20d0b402aaf1f2c8ea3524bded536969c) | `` docker: clean up buildInputs for cli ``                                    |
| [`c13044c9`](https://github.com/NixOS/nixpkgs/commit/c13044c93c59db741c53f18086bcb441967bcf35) | `` docker: zfs patch is in >= 23.x ``                                         |
| [`3b6b6477`](https://github.com/NixOS/nixpkgs/commit/3b6b64775dda990b9092205ff7a12b9f4b702417) | `` docker_24: init at 24.0.5 ``                                               |
| [`77ff9b72`](https://github.com/NixOS/nixpkgs/commit/77ff9b727c4bcb883f8d118815dfc02916fc896a) | `` buck2: unstable-2023-07-18 -> unstable-2023-08-01 ``                       |
| [`0b6ee2c7`](https://github.com/NixOS/nixpkgs/commit/0b6ee2c78369833f6c208ad6c4431b615e17432f) | `` foot: 1.15.1 -> 1.15.2 (#246561) ``                                        |
| [`72a5376d`](https://github.com/NixOS/nixpkgs/commit/72a5376da3a3051138b8f48a224f0149b147acd6) | `` element-{desktop,web}: 1.11.36 -> 1.11.37 (#246606) ``                     |