### PR TITLE
chore(flake/pre-commit-hooks): `52bf4046` -> `ebb43bda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -403,11 +403,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1691073619,
-        "narHash": "sha256-18/EyL9QuzwaA1iJZm0Qp6Lk7sh4YftfWIa2Is3UOSE=",
+        "lastModified": 1691093055,
+        "narHash": "sha256-sjNWYpDHc6vx+/M0WbBZKltR0Avh2S43UiDbmYtfHt0=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "52bf404674068e7f1ad8ee08bb95648be5a4fb19",
+        "rev": "ebb43bdacd1af8954d04869c77bc3b61fde515e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                      |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
| [`046d10f9`](https://github.com/cachix/pre-commit-hooks.nix/commit/046d10f9d395cd8ee81e20b55e764b7a63bed500) | `` Fix settings for typos and add some additional options `` |
| [`8346dc30`](https://github.com/cachix/pre-commit-hooks.nix/commit/8346dc308cf7192e1c1b645f1aac39ea69cba43e) | `` Fix wording of options and use `lib.mdDoc` ``             |