### PR TITLE
chore(flake/nixpkgs): `5a8e9243` -> `ce5e4a6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691368598,
-        "narHash": "sha256-ia7li22keBBbj02tEdqjVeLtc7ZlSBuhUk+7XTUFr14=",
+        "lastModified": 1691654369,
+        "narHash": "sha256-gSILTEx1jRaJjwZxRlnu3ZwMn1FVNk80qlwiCX8kmpo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a8e9243812ba528000995b294292d3b5e120947",
+        "rev": "ce5e4a6ef2e59d89a971bc434ca8ca222b9c7f5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`c445b079`](https://github.com/NixOS/nixpkgs/commit/c445b079d40d7d6c19182a5a31847aef7157dc56) | `` flameshot: provide meta.mainProgram ``                                   |
| [`960b8c5c`](https://github.com/NixOS/nixpkgs/commit/960b8c5ce77fc6d9edc9fe0a1553aefbfc7ff432) | `` betterlockscreen: provide meta.mainProgram ``                            |
| [`1d56cde4`](https://github.com/NixOS/nixpkgs/commit/1d56cde48b77bd4536e5de0042e80729fcd8989f) | `` scrot: provide meta.mainProgram ``                                       |
| [`9c2e30ce`](https://github.com/NixOS/nixpkgs/commit/9c2e30ce4facebc2f6684e234305d6b929fc8722) | `` kaniko: 1.12.1 -> 1.13.0 ``                                              |
| [`9145d268`](https://github.com/NixOS/nixpkgs/commit/9145d268ceea2372966abfa4b148529b02665642) | `` php81Packages.phpstan: 1.10.26 -> 1.10.28 ``                             |
| [`4ffc2204`](https://github.com/NixOS/nixpkgs/commit/4ffc22049fd45e25b16fff9401b5516817ab8786) | `` k3sup: 0.12.13 -> 0.12.14 ``                                             |
| [`7741d3a9`](https://github.com/NixOS/nixpkgs/commit/7741d3a9f9fce1784938468ecf8ea3e75266fa86) | `` deck: 1.25.0 -> 1.26.0 ``                                                |
| [`bf8891d6`](https://github.com/NixOS/nixpkgs/commit/bf8891d61dc99b83fda9dd0489caa78796d51785) | `` git-town: 9.0.0 -> 9.0.1 ``                                              |
| [`15fde858`](https://github.com/NixOS/nixpkgs/commit/15fde8584757a4ae62acc73cc4d3b7e121f1444c) | `` python310Packages.google-cloud-datacatalog: 3.14.0 -> 3.15.0 ``          |
| [`4408f28d`](https://github.com/NixOS/nixpkgs/commit/4408f28d8703dc53a50d32786c0c0e65486605ff) | `` php81Packages.php-cs-fixer: 3.21.1 -> 3.22.0 ``                          |
| [`2a681d0c`](https://github.com/NixOS/nixpkgs/commit/2a681d0cb854841a6ef575ea074423b06c84b07d) | `` domoticz: 2023.1 -> 2023.2 ``                                            |
| [`867d332b`](https://github.com/NixOS/nixpkgs/commit/867d332bd5a90b48306840e6695b798ccde85b8b) | `` scorecard: 4.10.5 -> 4.12.0 ``                                           |
| [`6d530a63`](https://github.com/NixOS/nixpkgs/commit/6d530a638991c7ec728e1f5e67390e895d48ce3d) | `` seqkit: 2.5.0 -> 2.5.1 ``                                                |
| [`7be45ec8`](https://github.com/NixOS/nixpkgs/commit/7be45ec8ad11d8dd9fda3a3f6c6db3da1cb8885f) | `` rspamd: 3.5 -> 3.6 ``                                                    |
| [`5663dc29`](https://github.com/NixOS/nixpkgs/commit/5663dc29dc39c9ae8dec41b9f7655c30f0c2eab3) | `` vdrPlugins.softhddevice: 1.11.1 -> 1.11.2 ``                             |
| [`b4c7b7e5`](https://github.com/NixOS/nixpkgs/commit/b4c7b7e5aab416e39eeed8944b64416a71fca0d4) | `` terraform-providers.oci: 5.7.0 -> 5.8.0 ``                               |
| [`a2495b2c`](https://github.com/NixOS/nixpkgs/commit/a2495b2c5da2748e3cdf38db03be14530f2a6fee) | `` terraform-providers.fastly: 5.3.0 -> 5.3.1 ``                            |
| [`1680a9bf`](https://github.com/NixOS/nixpkgs/commit/1680a9bf825e68b7fac14bb5a3604372453e92d5) | `` terraform-providers.exoscale: 0.50.0 -> 0.51.0 ``                        |
| [`58bc54ca`](https://github.com/NixOS/nixpkgs/commit/58bc54ca2a00a253a79b33deecc76d37e811a454) | `` terraform-providers.cloudflare: 4.11.0 -> 4.12.0 ``                      |
| [`4c08e9d6`](https://github.com/NixOS/nixpkgs/commit/4c08e9d62264127994cc337d581342040ce1d482) | `` python311Packages.unstructured: 0.8.1 -> 0.9.1 ``                        |
| [`96944e1f`](https://github.com/NixOS/nixpkgs/commit/96944e1fbad3fdca5c838bf7ff935c672d11d8a6) | `` chatty: 0.7.2 -> 0.7.3 ``                                                |
| [`11cb8539`](https://github.com/NixOS/nixpkgs/commit/11cb8539dc66e5aeb30a2c303d7aaa485fa71e52) | `` dpic: 2023.02.01 -> 2023.06.01 ``                                        |
| [`484cd7bb`](https://github.com/NixOS/nixpkgs/commit/484cd7bbff82f768b5ee41e1d62b484a23532226) | `` flexget: 3.8.2 -> 3.8.3 ``                                               |
| [`a39b2d94`](https://github.com/NixOS/nixpkgs/commit/a39b2d941612606cee56862b50089de6e6ea3335) | `` compactor: 1.2.2 -> 1.2.3 ``                                             |
| [`76513b24`](https://github.com/NixOS/nixpkgs/commit/76513b24d7ee22bfc213e24b45f6b3b4ec356b56) | `` openmsx: 18.0 -> 19.0 ``                                                 |
| [`1b8dd84f`](https://github.com/NixOS/nixpkgs/commit/1b8dd84fa1972029390dcb4de0f99f01888bcab4) | `` waypoint: 0.11.2 -> 0.11.4 ``                                            |
| [`527a7a0e`](https://github.com/NixOS/nixpkgs/commit/527a7a0ec2998bd11e9f32f27cab65ae91dd22ca) | `` stalwart-mail: 0.3.2 -> 0.3.4 ``                                         |
| [`1bb57576`](https://github.com/NixOS/nixpkgs/commit/1bb5757696ac14aecd96054fb54a869d84b943c1) | `` kube-bench: 0.6.15 -> 0.6.17 ``                                          |
| [`59eb0211`](https://github.com/NixOS/nixpkgs/commit/59eb02116f61a70a8bdeb125329833133ef36a06) | `` treewide: use zig_0_11 instead of zig for zig packages ``                |
| [`17d404ee`](https://github.com/NixOS/nixpkgs/commit/17d404ee80589efa8473cf1b50d031487329419a) | `` zig.hook: rename from zigHook ``                                         |
| [`ca2530aa`](https://github.com/NixOS/nixpkgs/commit/ca2530aa4ba2551dfb73b29b85d6cc41e09fffb3) | `` buf: 1.25.0 -> 1.26.1 ``                                                 |
| [`e0990758`](https://github.com/NixOS/nixpkgs/commit/e09907580bb2d9b863671bdfaf7e3ddc6c019ded) | `` darklua: 0.9.0 -> 0.10.2 ``                                              |
| [`5f8e75fe`](https://github.com/NixOS/nixpkgs/commit/5f8e75fe6f3262eed8eb8a93ef1a4bfc81d2a4b9) | `` cargo-spellcheck: 0.12.4 -> 0.13.0 ``                                    |
| [`7ddf5887`](https://github.com/NixOS/nixpkgs/commit/7ddf588700eaad0545d9eb9541ca8346d8669787) | `` go-camo: 2.4.3 -> 2.4.4 ``                                               |
| [`a78c4457`](https://github.com/NixOS/nixpkgs/commit/a78c4457f0cf8be156d9893e2498631ea50c5fc8) | `` trunk-io: 1.2.6 -> 1.2.7 ``                                              |
| [`50e7a02e`](https://github.com/NixOS/nixpkgs/commit/50e7a02e671cc4e5af49732b53d5d26f987cb314) | `` nixos/chrony: add simple test ``                                         |
| [`c13c1412`](https://github.com/NixOS/nixpkgs/commit/c13c1412bfeacf3df757a82476a57f8c3d2c2ba5) | `` nixos/chrony: add enableMemoryLocking option ``                          |
| [`cef068f3`](https://github.com/NixOS/nixpkgs/commit/cef068f3b3b0a9fdd68c45adc6847220ab988727) | `` Revert "nixos/malloc: add back maybe unnecessary line" ``                |
| [`f1a866e9`](https://github.com/NixOS/nixpkgs/commit/f1a866e92b81632ce0997074c798a9499fa7a44c) | `` python311Packages.coinmetrics-api-client: 2023.7.11.17 -> 2023.8.2.13 `` |
| [`d8247503`](https://github.com/NixOS/nixpkgs/commit/d8247503ab593eca5a5636084ec0f43f591d703b) | `` vrrtest: init at 2.1.0 ``                                                |
| [`0706a28c`](https://github.com/NixOS/nixpkgs/commit/0706a28c362e63c0a86f691ac788deb88ed91bf0) | `` bmake: 20230711 -> 20230723 ``                                           |
| [`43b06e74`](https://github.com/NixOS/nixpkgs/commit/43b06e740364cb267d383fca2991d85636063646) | `` infracost: 0.10.27 -> 0.10.28 ``                                         |
| [`c27f08aa`](https://github.com/NixOS/nixpkgs/commit/c27f08aa6c12bc9a4ea45e43c1e29695e339b214) | `` zig: default to zig 0.11 ``                                              |
| [`fdab18b7`](https://github.com/NixOS/nixpkgs/commit/fdab18b7b470ec6331b24a5bd8782aab22c34886) | `` jet: 0.6.26 -> 0.7.27 ``                                                 |
| [`5143a50a`](https://github.com/NixOS/nixpkgs/commit/5143a50a545d6fbc26f2e64e4f89f8132b30321b) | `` terragrunt: 0.48.4 -> 0.48.6 ``                                          |
| [`4c07af8f`](https://github.com/NixOS/nixpkgs/commit/4c07af8f4c2e86be0e3abdf0750380d165790471) | `` chrony: 4.3 -> 4.4 ``                                                    |
| [`1bf35f93`](https://github.com/NixOS/nixpkgs/commit/1bf35f9327d5fa752583b3fe9c602199926a6d0f) | `` erg: 0.6.17 -> 0.6.18 ``                                                 |
| [`2c98a795`](https://github.com/NixOS/nixpkgs/commit/2c98a795dbdfa7db18a7af2872ee3b070ec885fc) | `` engelsystem: substitute version in URL ``                                |
| [`20e4fbb3`](https://github.com/NixOS/nixpkgs/commit/20e4fbb34c1f5b12cd19313f1b2e03c1e316f3fd) | `` gptcommit: 0.5.10 -> 0.5.11 ``                                           |
| [`13e897eb`](https://github.com/NixOS/nixpkgs/commit/13e897eb3b64e9d7671221356ba643df88d05e6b) | `` spicetify-cli: 2.22.1 -> 2.22.2 ``                                       |
| [`6dd19a72`](https://github.com/NixOS/nixpkgs/commit/6dd19a7267254477fdc5340b8623e3b618e23532) | `` gopass-summon-provider: 1.15.5 -> 1.15.7 ``                              |
| [`4ff2823d`](https://github.com/NixOS/nixpkgs/commit/4ff2823dbf986d60c7b788bd5e50060917669c0c) | `` gopass-jsonapi: 1.15.5 -> 1.15.7 ``                                      |
| [`614c2be7`](https://github.com/NixOS/nixpkgs/commit/614c2be7a217627015d15718738d9a06af85af56) | `` gopass-hibp: 1.15.5 -> 1.15.7 ``                                         |
| [`73aa1ca9`](https://github.com/NixOS/nixpkgs/commit/73aa1ca9c29917f6532af64304714f803f87549a) | `` git-credential-gopass: 1.15.5 -> 1.15.7 ``                               |
| [`32225a26`](https://github.com/NixOS/nixpkgs/commit/32225a2638c0efcd7c5951330d56c1ae78897ea4) | `` gopass: 1.15.6 -> 1.15.7 ``                                              |
| [`c1d7d431`](https://github.com/NixOS/nixpkgs/commit/c1d7d4315b08fe7810c61b8a0c586066f64a45bf) | `` tgpt: 1.7.0 -> 1.7.1 ``                                                  |
| [`dcfccf12`](https://github.com/NixOS/nixpkgs/commit/dcfccf1221cca677ca02a7ac1d48f36dd93df01a) | `` checkov: 2.3.359 -> 2.3.360 ``                                           |
| [`bf91143e`](https://github.com/NixOS/nixpkgs/commit/bf91143e2f4b5cac0452130ec51c975ab53ed60a) | `` roxctl: 4.1.0 -> 4.1.2 ``                                                |
| [`f8438ab7`](https://github.com/NixOS/nixpkgs/commit/f8438ab7019c6fcc6723ed232ce84e921fd6967c) | `` sozu: update platforms ``                                                |
| [`fcb9f773`](https://github.com/NixOS/nixpkgs/commit/fcb9f7734aeec009bbbe19d190abe6d43331080d) | `` obs-studio-plugins.advanced-scene-switcher: 1.23.0 -> 1.23.1 ``          |
| [`c6901916`](https://github.com/NixOS/nixpkgs/commit/c6901916a9a7cabb9598f3b88a534be976b51b94) | `` xdiskusage: init at 1.60 ``                                              |
| [`bd09401d`](https://github.com/NixOS/nixpkgs/commit/bd09401dfab278f135a008715dbc71f6047ee030) | `` maintainers: add fuzzdk ``                                               |
| [`0233827d`](https://github.com/NixOS/nixpkgs/commit/0233827dc0ce27e178cc42e12c3d655553860a3a) | `` just: add meta.mainProgram ``                                            |
| [`a07dbc1e`](https://github.com/NixOS/nixpkgs/commit/a07dbc1e45d71648cc9ac3c77d99018dc8f9c80b) | `` git: add meta.mainProgram ``                                             |
| [`0f883e52`](https://github.com/NixOS/nixpkgs/commit/0f883e52f8a9395aad1689bbc869a523260e6460) | `` complgen: unstable-2023-07-20 -> unstable-2023-08-07 ``                  |
| [`991accaa`](https://github.com/NixOS/nixpkgs/commit/991accaa4f1c04795ed6dece1e1f0b112d386faa) | `` cotton: unstable-2023-07-04 -> unstable-2023-08-09 ``                    |
| [`b2ac1c2b`](https://github.com/NixOS/nixpkgs/commit/b2ac1c2b81de433932538a3abee653a90d7393dc) | `` python310Packages.bitsandbytes: 0.38.0 -> 0.41.0 ``                      |
| [`46a69716`](https://github.com/NixOS/nixpkgs/commit/46a69716f5352236be2b436beadc44be6a1a8063) | `` cargo-component: unstable-2023-07-28 -> unstable-2023-08-03 ``           |
| [`a69648b5`](https://github.com/NixOS/nixpkgs/commit/a69648b581d1e089cdb80f6e30dae6b79c2bc5f7) | `` egglog: unstable-2023-07-19 -> unstable-2023-08-09 ``                    |
| [`6d17450f`](https://github.com/NixOS/nixpkgs/commit/6d17450f9af59f018372c77f760dce96565605c3) | `` picosnitch: 0.12.0 -> 0.14.0 ``                                          |
| [`c23d32d8`](https://github.com/NixOS/nixpkgs/commit/c23d32d881949f1e53277badb9053e43a61f4b01) | `` fly: 7.9.1 -> 7.10.0 ``                                                  |
| [`d97871fa`](https://github.com/NixOS/nixpkgs/commit/d97871fadb2c00c26083ddb51a7da09ecb99e549) | `` python311Packages.pymazda: 0.3.10 -> 0.3.11 ``                           |
| [`0a2db713`](https://github.com/NixOS/nixpkgs/commit/0a2db7139f8f11b64fdfef50e48c69eff849e4c0) | `` python311Packages.energyzero: 0.4.2 -> 0.5.0 ``                          |
| [`5b4c560b`](https://github.com/NixOS/nixpkgs/commit/5b4c560bfee68e72ab7991c6b1229d880747d4d2) | `` python311Packages.aliyun-python-sdk-config: 2.2.9 -> 2.2.10 ``           |
| [`9c8a3968`](https://github.com/NixOS/nixpkgs/commit/9c8a3968561c1f81a31032086b3c6546c6bd308a) | `` python310Packages.pyintesishome: add format ``                           |
| [`262fe5d0`](https://github.com/NixOS/nixpkgs/commit/262fe5d026534ac3510dbebad1b539b4e62df799) | `` python310Packages.pyintesishome:  add changelog to meta ``               |
| [`0d149464`](https://github.com/NixOS/nixpkgs/commit/0d1494643a1a194bdaa201cd803d54ce026cba80) | `` Revert "invidious: unstable-2023-06-06 -> unstable-2023-07-05" ``        |
| [`ad7aae4b`](https://github.com/NixOS/nixpkgs/commit/ad7aae4be4116117ae85985fc86b7b1ec160115a) | `` python3Packages.polars: 0.18.0 -> 0.18.13 ``                             |
| [`8af49f9f`](https://github.com/NixOS/nixpkgs/commit/8af49f9fbd6031b9cff0ef4c237ca72e5e73f7f9) | `` python310Packages.rzpipe: adjust changelog entry ``                      |
| [`525544aa`](https://github.com/NixOS/nixpkgs/commit/525544aa4436d103381287f1c81d18c25fc16fa4) | `` python310Packages.rzpipe: add format ``                                  |
| [`9ebbac37`](https://github.com/NixOS/nixpkgs/commit/9ebbac3799c9854ed1bf526ad2196b095b39d864) | `` python310Packages.rzpipe: add changelog to meta ``                       |
| [`bea77f9a`](https://github.com/NixOS/nixpkgs/commit/bea77f9a71398ed22a900eb23477de2e7f9260bc) | `` mu: fix deprecation warning (main-program) ``                            |
| [`a2009884`](https://github.com/NixOS/nixpkgs/commit/a2009884df53b3e89f77aaa57dc7feb80075dfc6) | `` ruff: 0.0.283 -> 0.0.284 ``                                              |
| [`afeb87f0`](https://github.com/NixOS/nixpkgs/commit/afeb87f095126636fdad19536ff8f20bb2deb616) | `` rex: 1.14.0 -> 1.14.3 ``                                                 |
| [`ad701598`](https://github.com/NixOS/nixpkgs/commit/ad7015980ee11c707495e614e05e78c20c67115d) | `` python310Packages.globus-sdk: 3.25.0 -> 3.26.0 ``                        |
| [`21a3163c`](https://github.com/NixOS/nixpkgs/commit/21a3163cc44aea29be2e51c68354a85106e8cfb6) | `` python310Packages.rzpipe: 0.5.1 -> 0.6.0 ``                              |
| [`2644f7e8`](https://github.com/NixOS/nixpkgs/commit/2644f7e83c3e97ce973b95c2ae1e7ceff5a336bf) | `` python3Packages.pyunpack: init at 0.3 ``                                 |
| [`69bbcbb0`](https://github.com/NixOS/nixpkgs/commit/69bbcbb06110c9d95a2c5fc2bc636cc8a444ab7b) | `` CODEOWNERS: Add myself to PULL_REQUEST_TEMPLATE ``                       |
| [`0d4e8459`](https://github.com/NixOS/nixpkgs/commit/0d4e8459aea27861560b5055ad08c706f4ee1d97) | `` CODEOWNERS: Remove non-existent file ``                                  |
| [`cf78a8c3`](https://github.com/NixOS/nixpkgs/commit/cf78a8c3e76bfab552d4853a0c7f67f2ceda431e) | `` CODEOWNERS: Add myself to the contributing documentation ``              |
| [`77ecbf8b`](https://github.com/NixOS/nixpkgs/commit/77ecbf8be87454678375c176fba800fa4b9519e8) | `` kubo: 0.21.0 -> 0.22.0 ``                                                |
| [`960c4e36`](https://github.com/NixOS/nixpkgs/commit/960c4e36bdd119b207bdf9912789f2618a00b16c) | `` openra: drop rardiol maintainership ``                                   |
| [`de88bd94`](https://github.com/NixOS/nixpkgs/commit/de88bd94d67b1bbc3ff6464912f1405081c54b6e) | `` anki-bin: pass command-line arguments through anki-wrapper ``            |
| [`735d9c7f`](https://github.com/NixOS/nixpkgs/commit/735d9c7fc3d34cba643d89965b938180375645f0) | `` python3.pkgs.async-generator: rename from async_generator ``             |
| [`784b4a8b`](https://github.com/NixOS/nixpkgs/commit/784b4a8b70ec5f2809e7be0b058c943349b64ac1) | `` nil: 2023-05-09 -> 2023-08-09 ``                                         |
| [`1b1c7d6b`](https://github.com/NixOS/nixpkgs/commit/1b1c7d6b57cd31cdb3b632316503a7bc3a27ffa2) | `` manticoresearch: 6.0.4 -> 6.2.0 ``                                       |
| [`e7417ae1`](https://github.com/NixOS/nixpkgs/commit/e7417ae1c2c37680834993e7b1c4f914db507fb3) | `` vimPlugins.sg-nvim: fix cargoHash ``                                     |
| [`fa45115a`](https://github.com/NixOS/nixpkgs/commit/fa45115a262e308f2930bbc48f9703bb407434a7) | `` vimPlugins.nvim-treesitter: update grammars ``                           |
| [`04715813`](https://github.com/NixOS/nixpkgs/commit/0471581350afcb3e17f9cbd71e60acacc0c8fb48) | `` vimPlugins: update ``                                                    |
| [`701af8d9`](https://github.com/NixOS/nixpkgs/commit/701af8d9374c4fc316b5617e8b6907d2b36a678f) | `` vimPlugins.replacer-nvim: init at 2023-07-29 ``                          |
| [`14f7b116`](https://github.com/NixOS/nixpkgs/commit/14f7b1161d334ff77fb98bdc876c6aea04445656) | `` nixos/tests/nextcloud: Fix deprecation warning ``                        |
| [`7ea06dd8`](https://github.com/NixOS/nixpkgs/commit/7ea06dd8332be07d13b61aff6eea44960a7bfe40) | `` n8n: 0.227.1 -> 1.1.1 ``                                                 |
| [`be8e5400`](https://github.com/NixOS/nixpkgs/commit/be8e54009a81decb25dc69829f163541892d3dca) | `` leptosfmt: init at 0.1.12 ``                                             |
| [`9d519307`](https://github.com/NixOS/nixpkgs/commit/9d519307e3fe4c799c46ff17384046611586f766) | `` zitadel-tools: init at 0.4.0 ``                                          |
| [`33bf1c92`](https://github.com/NixOS/nixpkgs/commit/33bf1c9273e1addc93085f72c84d2bd2067f9a6f) | `` anytone-emu: init at unstable-2023-06-15 ``                              |
| [`a2f6d8db`](https://github.com/NixOS/nixpkgs/commit/a2f6d8db5205160e093855d326420d59b1dea32b) | `` vimPlugins.lspsaga-nvim-original: mark as deprecated ``                  |
| [`c99e492f`](https://github.com/NixOS/nixpkgs/commit/c99e492f004c56c4cb6415964d502468e573a40b) | `` linux-firmware: 20230804 -> (unstable-)20230809 ``                       |
| [`f3168488`](https://github.com/NixOS/nixpkgs/commit/f31684880ef198c5a852ba21d00dfaee0717d4da) | `` zarf: 0.28.2 -> 0.28.4 ``                                                |
| [`34ce871b`](https://github.com/NixOS/nixpkgs/commit/34ce871bbd8fd0f587ff196762e2279749c6d936) | `` wazero: 1.3.1 -> 1.4.0 ``                                                |
| [`1c5c22ec`](https://github.com/NixOS/nixpkgs/commit/1c5c22ec136c65f8b14c5d42180375e9870aaa19) | `` kool: add version test ``                                                |
| [`efa532e5`](https://github.com/NixOS/nixpkgs/commit/efa532e530ad62a3c96e8e1734634af22332dd2b) | `` kool: 2.1.0 -> 2.1.1 ``                                                  |
| [`48e1d3e9`](https://github.com/NixOS/nixpkgs/commit/48e1d3e91f0ca2c9be7be2fc39f7a844db598a28) | `` typos: 1.16.2 -> 1.16.3 ``                                               |
| [`65a80902`](https://github.com/NixOS/nixpkgs/commit/65a8090215e93812ba5ca5c43ff3aaa5e78be9aa) | `` hunspellDictsChromium: init at 115.0.5790.170 ``                         |
| [`abc3cc0a`](https://github.com/NixOS/nixpkgs/commit/abc3cc0ac6f44ebbd997464c2e1460c9001d7743) | `` golangci-lint: 1.53.3 -> 1.54.0 ``                                       |