### PR TITLE
chore(flake/nixos-hardware): `8ff521ac` -> `f61352cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -327,11 +327,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1691566999,
-        "narHash": "sha256-c4G++nXzVgJbXe5tuUZxSS+SbDqynO/nG3wocRcP6YE=",
+        "lastModified": 1691730710,
+        "narHash": "sha256-q/UBet5RdX8CBjOIpI2Y8EB8DXYr9cb7WuNGTP9HKf8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "8ff521acd2c8132c62141c2990deb7406e32b335",
+        "rev": "f61352cf8066ddd3dfe9058e62184bae7382672d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                               |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`f61352cf`](https://github.com/NixOS/nixos-hardware/commit/f61352cf8066ddd3dfe9058e62184bae7382672d) | `` framework: add 13th gen to flake.nix ``            |
| [`161c91c0`](https://github.com/NixOS/nixos-hardware/commit/161c91c01ab55a199b78c5014eedd0cedcd7a482) | `` framework: fix references to 13th gen in README `` |