### PR TITLE
chore(flake/lanzaboote): `e7246c6b` -> `f1384860`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -250,11 +250,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689889377,
-        "narHash": "sha256-ChBawisTCY3Cl06CSG+QNC2ES+G0ASiOxtOVif9uP/0=",
+        "lastModified": 1691761621,
+        "narHash": "sha256-xTPifd7/93/bmBEPMhb0zuU9nzRkUIZHr+PJUHoUld8=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "e7246c6bce1733d373059e6342f67fd53f90c198",
+        "rev": "f13848606f5a313c33b9c9ceb34e0ae4d51b6766",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                         |
| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`4a1b07d0`](https://github.com/nix-community/lanzaboote/commit/4a1b07d0a984f0dcc54d0d70f057613b07b8260f) | `` Fix lzbt build with recent nixos-unstable `` |