### PR TITLE
chore(flake/darwin): `426d3871` -> `3fcd8378`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1691640097,
-        "narHash": "sha256-6vPsJYjtt2hs4mkiR46yt8c/Spdm/UiUKoSCIlc7iJw=",
+        "lastModified": 1691963303,
+        "narHash": "sha256-zqvt4N4Ic06BrGo02itCIPTEKzVnGT0BtGbIr+aUGqE=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "426d38710b656b0a31f8eaae6e0002206a3b96d7",
+        "rev": "3fcd83783a1e2ddad0f14821da4186a95bc76c50",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                       |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
| [`d21a7e30`](https://github.com/LnL7/nix-darwin/commit/d21a7e30e60521de9d69b56686588697fbf8f19a) | `` Update pkgs/darwin-installer/default.nix ``                                |
| [`5c22b241`](https://github.com/LnL7/nix-darwin/commit/5c22b241f7bd998941248210bbf1340b5f38baff) | `` chore(installer): capitalize the default option when reading user input `` |