### PR TITLE
chore(flake/nixpkgs): `ce5e4a6e` -> `100a1550`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691654369,
-        "narHash": "sha256-gSILTEx1jRaJjwZxRlnu3ZwMn1FVNk80qlwiCX8kmpo=",
+        "lastModified": 1691899779,
+        "narHash": "sha256-IBf4KVr/UQJlzrqB2/IHtlvmwsvyIVLPerSzCPU/6Xk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ce5e4a6ef2e59d89a971bc434ca8ca222b9c7f5e",
+        "rev": "100a1550b0e7a64b960c625b656f9229bdef5f87",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                             |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
| [`100a1550`](https://github.com/NixOS/nixpkgs/commit/100a1550b0e7a64b960c625b656f9229bdef5f87) | `` terraform-providers.acme: 2.15.1 -> 2.16.1 ``                                                                    |
| [`1cce3064`](https://github.com/NixOS/nixpkgs/commit/1cce30649512915739f9d634ff043dfdbd0e2e57) | `` alsa-project: expose the scope as a top-level package to support overrides ``                                    |
| [`857f57ff`](https://github.com/NixOS/nixpkgs/commit/857f57ffd8202674eeaf602004a987c32efc0773) | `` CONTRIBUTING.md: highlight the need for setting `meta.mainProgram` ``                                            |
| [`d97e83ff`](https://github.com/NixOS/nixpkgs/commit/d97e83ff6f7e5565d0aa03d15c418e5f43887295) | `` mangohud: backport gcc-13 fix ``                                                                                 |
| [`0db7ab3a`](https://github.com/NixOS/nixpkgs/commit/0db7ab3a741e03c2d91f16b3e0696ab68663c0bc) | `` python3.pkgs.liquidctl: add build dependencies ``                                                                |
| [`74b66861`](https://github.com/NixOS/nixpkgs/commit/74b66861c0790a1a9e99614af4d479ad311089ed) | `` treewide: add meta.mainProgram (#248750) ``                                                                      |
| [`8a4c8563`](https://github.com/NixOS/nixpkgs/commit/8a4c856373c0157631aaa284da3ad7c9fd89da70) | `` python3.pkgs.shap: add missing build dependencies ``                                                             |
| [`a1d1159d`](https://github.com/NixOS/nixpkgs/commit/a1d1159daf340c5b0533998c77170b0a34f5556c) | `` mdbook-toc: 0.13.0 -> 0.14.1 ``                                                                                  |
| [`c9791d9a`](https://github.com/NixOS/nixpkgs/commit/c9791d9a0b9a253fa5cc1c9f2c9fe27a88ef1bd5) | `` libstrangle: pull gcc-13 fix pending upstream inclusion ``                                                       |
| [`55ee834b`](https://github.com/NixOS/nixpkgs/commit/55ee834beab768101c0ef9e89b96e2d68b9af6b6) | `` linuxPackages.mwprocapture: 1.3.0.4328 -> 1.3.0.4373 ``                                                          |
| [`3c2b7cae`](https://github.com/NixOS/nixpkgs/commit/3c2b7caea1f5d8012e0672ae572afbd1b9f2e113) | `` hcl2json: 0.5.0 -> 0.6.0 ``                                                                                      |
| [`bb72dfdb`](https://github.com/NixOS/nixpkgs/commit/bb72dfdb81dbcd338658a11c2e46e357b8b221a6) | `` vimPlugins.image-nvim: init at 2023-07-17 ``                                                                     |
| [`101b2b4e`](https://github.com/NixOS/nixpkgs/commit/101b2b4eb7faef77cdd523ad2d167f79f3621e05) | `` hyprland: fix wrong patch location ``                                                                            |
| [`95eca362`](https://github.com/NixOS/nixpkgs/commit/95eca362d9ece03f819a5fc74dc3bc7e8f5082b0) | `` idasen: replace reference to poetry with poetry-core ``                                                          |
| [`60200a61`](https://github.com/NixOS/nixpkgs/commit/60200a618363d9b89a24c3186736d013aa219e2e) | `` python310Packages.amazon-kclpy: rename from amazon_kclpy ``                                                      |
| [`08d24204`](https://github.com/NixOS/nixpkgs/commit/08d242047cc34c9c624c8ae507211671cf45f464) | `` iso_gnome: Fix evaluation ``                                                                                     |
| [`025db9a1`](https://github.com/NixOS/nixpkgs/commit/025db9a160591dfa17ff023b7b33fba365b8bd30) | `` rustypaste-cli: 0.6.0 -> 0.7.0 ``                                                                                |
| [`8951442c`](https://github.com/NixOS/nixpkgs/commit/8951442c6e56270e1de41f3110c8311ba73ee447) | `` sudo: backport fix for missing newlines ``                                                                       |
| [`efc8403b`](https://github.com/NixOS/nixpkgs/commit/efc8403bb5b003b0ca751afde7db4976fb4ccdee) | `` bun: 0.7.1 -> 0.7.3 ``                                                                                           |
| [`dfe2f4cd`](https://github.com/NixOS/nixpkgs/commit/dfe2f4cd0fa509c30ed9529e6bc2737149c16c35) | `` nvidia-system-monitor-qt: init at 1.5 (#202844) ``                                                               |
| [`5672875f`](https://github.com/NixOS/nixpkgs/commit/5672875f42853c191a6966c9a46c9439544a1865) | `` python310Packages.numba: add meta.mainProgram ``                                                                 |
| [`3a94dd18`](https://github.com/NixOS/nixpkgs/commit/3a94dd18bd6221e884016f0febc3db6008f58fd0) | `` python310Packages.numba: unstable-2023-08-02 -> unstable-2023-08-11 ``                                           |
| [`f0451844`](https://github.com/NixOS/nixpkgs/commit/f0451844bbdf545f696f029d1448de4906c7f753) | `` cryptomator: fail more gracefully on darwin ``                                                                   |
| [`1599ac29`](https://github.com/NixOS/nixpkgs/commit/1599ac29d14f2b3795afc47d515262469d1e2d7d) | `` cargo-llvm-cov: 0.5.25 -> 0.5.26 ``                                                                              |
| [`08f2b6b2`](https://github.com/NixOS/nixpkgs/commit/08f2b6b221e31a4ab648faaa403f493cb00f903f) | `` lagrange: 1.16.6 -> 1.16.7 ``                                                                                    |
| [`8b5a084a`](https://github.com/NixOS/nixpkgs/commit/8b5a084a259ef44e3b594375a903f79e2bb21ad4) | `` minio: 2023-07-11T21-29-34Z -> 2023-08-09T23-30-22Z ``                                                           |
| [`bcb66d4e`](https://github.com/NixOS/nixpkgs/commit/bcb66d4e4cdbadc208b9fbb8638867e402186832) | `` owamp: 3.5.6 -> 4.4.6 (#248339) ``                                                                               |
| [`cbb4cd0a`](https://github.com/NixOS/nixpkgs/commit/cbb4cd0a9cab670b0a0648e203cee3eb103f1b4f) | `` chezmoi: 2.36.1 -> 2.37.0 ``                                                                                     |
| [`20ea3d87`](https://github.com/NixOS/nixpkgs/commit/20ea3d87e4605cb9ecffa947cc2fd5b683ab9cfd) | `` pytrainer: 2.1.0 -> 2.2.1 ``                                                                                     |
| [`3d9de1ab`](https://github.com/NixOS/nixpkgs/commit/3d9de1ab72ca797f2631683460e77817794f5f6e) | `` svtplay-dl: 4.24 -> 4.25 ``                                                                                      |
| [`f556a505`](https://github.com/NixOS/nixpkgs/commit/f556a505525671aefa2f196ad2379eb24042b814) | `` oha: 0.6.1 -> 0.6.2 ``                                                                                           |
| [`fce4c512`](https://github.com/NixOS/nixpkgs/commit/fce4c512bb143a881a4110604868fa56ffaf18c0) | `` rustywind: 0.17.0 -> 0.18.0 ``                                                                                   |
| [`9b8bf3eb`](https://github.com/NixOS/nixpkgs/commit/9b8bf3ebf486ac854ee15b9b6ecec91e3d5c031e) | `` faudio: add changelog to meta ``                                                                                 |
| [`5ccc6da2`](https://github.com/NixOS/nixpkgs/commit/5ccc6da23324361f081139ace405150ce7f3d031) | `` faudio: 23.07 -> 23.08 ``                                                                                        |
| [`13373818`](https://github.com/NixOS/nixpkgs/commit/133738183ae1ba4ad58dcfea5722b75bd2b7cf1e) | `` clickhouse-backup: 2.3.1 -> 2.3.2 ``                                                                             |
| [`c544d29d`](https://github.com/NixOS/nixpkgs/commit/c544d29ddbaabca0e8d8adf738eb1de8304ad171) | `` dendrite: add updateScript ``                                                                                    |
| [`ab899c4d`](https://github.com/NixOS/nixpkgs/commit/ab899c4d0b61b01ad5cd8410d1d21686cec74719) | `` nextcloud-client: 3.9.1 -> 3.9.2 ``                                                                              |
| [`5427788a`](https://github.com/NixOS/nixpkgs/commit/5427788aa74413e9d4ccdf96a79a61471aa1ed63) | `` git-stack: 0.10.16 -> 0.10.17 ``                                                                                 |
| [`f9f0f062`](https://github.com/NixOS/nixpkgs/commit/f9f0f062309da1a55523f1e260698e13c80022ce) | `` openvr: use `finalAttrs` pattern ``                                                                              |
| [`5088e63d`](https://github.com/NixOS/nixpkgs/commit/5088e63daf5faa801e318034f201add6d0796858) | `` cppcheck: code style format update using nixpkgs-fmt ``                                                          |
| [`71fc406d`](https://github.com/NixOS/nixpkgs/commit/71fc406d35b097eb6b0e48da2004eeb000b10dad) | `` cppreference-doc: 20220730 -> 20230810 ``                                                                        |
| [`e0a83024`](https://github.com/NixOS/nixpkgs/commit/e0a830245b80c7e2b1ba3401877744bc71175b45) | `` cppcheck: use `finalAttrs` pattern ``                                                                            |
| [`f5d7bcf7`](https://github.com/NixOS/nixpkgs/commit/f5d7bcf7424f25e86c25849de8c985302e9b4596) | `` icewm: 3.4.0 -> 3.4.1 ``                                                                                         |
| [`9c6481ab`](https://github.com/NixOS/nixpkgs/commit/9c6481abfc2a31c8acb4787e61d4212c18345422) | `` dnf5: 5.1.0 -> 5.1.1 ``                                                                                          |
| [`b3218a10`](https://github.com/NixOS/nixpkgs/commit/b3218a102fbfce135e780bb273998b97ebbaaf19) | `` duperemove: encode absolute path to `lscpu` ``                                                                   |
| [`8f8835c5`](https://github.com/NixOS/nixpkgs/commit/8f8835c5303fee07ab641f2cc6d5625eaee705da) | `` vieb: 10.1.1 -> 10.2.0 ``                                                                                        |
| [`6c3431e7`](https://github.com/NixOS/nixpkgs/commit/6c3431e7cad7ad8ba4defed1e3f85bebc9869d6c) | `` eaglemode: 0.96.0 -> 0.96.1, add updateScript ``                                                                 |
| [`bb92c025`](https://github.com/NixOS/nixpkgs/commit/bb92c025caf7d421f8eb8eea67b57ebc3ac5abf3) | `` adwaita-qt, qgnomeplatform: drop gnome team from maintainers ``                                                  |
| [`62274594`](https://github.com/NixOS/nixpkgs/commit/622745942bc7b7cc056bfbb0bc6004dd823fa4f5) | `` nixos/gnome: Do not force Qt apps to Adwaita ``                                                                  |
| [`e282b894`](https://github.com/NixOS/nixpkgs/commit/e282b894e9078c0f37921f85347c0e66ae8bb2dd) | `` tanka: 0.25.0 -> 0.26.0 ``                                                                                       |
| [`5d2e3301`](https://github.com/NixOS/nixpkgs/commit/5d2e3301e7306d63fd656acefccea431e36edad3) | `` datree: 1.9.17 -> 1.9.19 ``                                                                                      |
| [`e119316b`](https://github.com/NixOS/nixpkgs/commit/e119316bf44a1f0433dacdcc552c0924058646db) | `` werf: 1.2.248 -> 1.2.249 ``                                                                                      |
| [`4590bb92`](https://github.com/NixOS/nixpkgs/commit/4590bb92bdaacad896a7caf9eacdb5ebb740f88a) | `` pylyzer: 0.0.39 -> 0.0.40 ``                                                                                     |
| [`0cba05b8`](https://github.com/NixOS/nixpkgs/commit/0cba05b8ed7e5c7b275ece4296427e5d11876376) | `` python311Packages.dvc-data: 2.12.2 -> 2.13.1 ``                                                                  |
| [`19728ebe`](https://github.com/NixOS/nixpkgs/commit/19728ebeb2bda1a38f05b9388f1a4bca51fb8507) | `` terrascan: 1.18.2 -> 1.18.3 ``                                                                                   |
| [`bc1c462d`](https://github.com/NixOS/nixpkgs/commit/bc1c462de333ab88dcfa03972625a392ae874105) | `` python311Packages.govee-ble: 0.23.0 -> 0.24.0 ``                                                                 |
| [`9d23f365`](https://github.com/NixOS/nixpkgs/commit/9d23f3651426c73d4de760d730a87308f45ab874) | `` openvr: 1.23.6 -> 1.26.7 ``                                                                                      |
| [`10f0225b`](https://github.com/NixOS/nixpkgs/commit/10f0225bdd258fa52cf719bae0d05046cb805ff2) | `` cppcheck: 2.11 -> 2.11.1 ``                                                                                      |
| [`8ed1c5a5`](https://github.com/NixOS/nixpkgs/commit/8ed1c5a5985504cabdc2303229eeb53149409968) | `` python311Packages.schema-salad: add missing dependency ``                                                        |
| [`7ccfe56d`](https://github.com/NixOS/nixpkgs/commit/7ccfe56d631b35ccdfafe3cf5352fdd138dc0c6d) | `` treesheets: unstable-2023-08-08 -> unstable-2023-08-10 ``                                                        |
| [`b93d1827`](https://github.com/NixOS/nixpkgs/commit/b93d18275c3e0ea8a5e471319420734bc07b808b) | `` linux: disable KUNIT only at 5.5 and later ``                                                                    |
| [`a71d13dc`](https://github.com/NixOS/nixpkgs/commit/a71d13dc74d5217f51b71718db3a372bc77777d3) | `` f2: 1.9.0 -> 1.9.1 ``                                                                                            |
| [`1dff6b71`](https://github.com/NixOS/nixpkgs/commit/1dff6b719f1cfe8c44e9206f59ebbdd2130704a5) | `` oh-my-posh: 18.1.0 -> 18.3.3 ``                                                                                  |
| [`116eff37`](https://github.com/NixOS/nixpkgs/commit/116eff3741fddc077cfcbb2d382f3ce490871590) | `` librecad: 2.2.0.1 -> 2.2.0.2 ``                                                                                  |
| [`d391d317`](https://github.com/NixOS/nixpkgs/commit/d391d3173a66985c8ec4521de651d39812fd8eeb) | `` gotrue-supabase: 2.83.1 -> 2.92.0 ``                                                                             |
| [`7249e2e0`](https://github.com/NixOS/nixpkgs/commit/7249e2e0c203e59f8e5454418e49c5b25826531c) | `` linkerd: 2.13.5 -> 2.13.6 ``                                                                                     |
| [`1e2d0390`](https://github.com/NixOS/nixpkgs/commit/1e2d0390653ff6ff6a68305dcec76bde55012727) | `` jumppad: 0.5.35 -> 0.5.38 ``                                                                                     |
| [`3e9c7257`](https://github.com/NixOS/nixpkgs/commit/3e9c7257f3e3682661d8c9476177ef48af91ab4e) | `` python311Packages.homeassistant-stubs: 2023.8.0 -> 2023.8.2 ``                                                   |
| [`9144202a`](https://github.com/NixOS/nixpkgs/commit/9144202a04aa4dd5de84b676c1ace45d2d8c850c) | `` ctre: 3.7.2 -> 3.8 ``                                                                                            |
| [`30df053e`](https://github.com/NixOS/nixpkgs/commit/30df053e77ac12c00a3b67f60950fa55923d0edd) | `` python3.pkgs.jupyter-packaging: fix tests with setuptools 67.5.0+ (#246919) ``                                   |
| [`7ad1b2d4`](https://github.com/NixOS/nixpkgs/commit/7ad1b2d4e1eb8f7b127271f2540db60eee0c6be0) | `` python3.pkgs.single-version: use poetry-core instead of poetry (#248626) ``                                      |
| [`cbe3b1e5`](https://github.com/NixOS/nixpkgs/commit/cbe3b1e50dcc9bf59382f045557d11ab27683f1d) | `` goflow2: 1.3.4 -> 2.0.0 ``                                                                                       |
| [`afc5878c`](https://github.com/NixOS/nixpkgs/commit/afc5878c556602bddf840fa46293ae8f24abdc4d) | `` credhub-cli: 2.9.18 -> 2.9.19 ``                                                                                 |
| [`34616cd8`](https://github.com/NixOS/nixpkgs/commit/34616cd80a3edc6f57d795e9f6e8ed815d24b429) | `` exoscale-cli: 1.71.2 -> 1.72.0 ``                                                                                |
| [`ac7f4710`](https://github.com/NixOS/nixpkgs/commit/ac7f4710983438113882e2c6b98245253009b367) | `` terraform-providers.tencentcloud: 1.81.19 -> 1.81.20 ``                                                          |
| [`042c8faa`](https://github.com/NixOS/nixpkgs/commit/042c8faa6b3502517e163af80e7bd8a70db7bb88) | `` terraform-providers.spotinst: 1.132.0 -> 1.133.0 ``                                                              |
| [`85edb500`](https://github.com/NixOS/nixpkgs/commit/85edb500d8fe9b36031403d20c1f321b3e603d85) | `` terraform-providers.launchdarkly: 2.14.0 -> 2.15.0 ``                                                            |
| [`01f7348a`](https://github.com/NixOS/nixpkgs/commit/01f7348aa240f457956f5b8afa7d46702edafcd4) | `` terraform-providers.github: 5.32.0 -> 5.33.0 ``                                                                  |
| [`0c89c5d8`](https://github.com/NixOS/nixpkgs/commit/0c89c5d8ec0bdee9f4f043be5eb9dc2ea7d23b12) | `` terraform-providers.equinix: 1.14.5 -> 1.14.6 ``                                                                 |
| [`be61fc97`](https://github.com/NixOS/nixpkgs/commit/be61fc97288204f0b8752f9df34fdd061b952fa6) | `` qownnotes: 23.7.3 -> 23.8.0 ``                                                                                   |
| [`c5bd0d6c`](https://github.com/NixOS/nixpkgs/commit/c5bd0d6c7658212192dd00818d44fbc77f759d97) | `` llhttp: 8.1.1 -> 9.0.0 ``                                                                                        |
| [`7df3af4a`](https://github.com/NixOS/nixpkgs/commit/7df3af4acd170286f3b774ec0fa9f54cbd5499d9) | `` nixd: add marsam to maintainers ``                                                                               |
| [`759f52b1`](https://github.com/NixOS/nixpkgs/commit/759f52b1afb83602e205dd1b07628771b2cfad98) | `` zsh-forgit: 23.07.0 -> 23.08.1 ``                                                                                |
| [`ce74a47d`](https://github.com/NixOS/nixpkgs/commit/ce74a47db90c03dc4960a0f8624b7e20ee560f44) | `` python310Packages.dremel3dpy: propagate decorator ``                                                             |
| [`920915ea`](https://github.com/NixOS/nixpkgs/commit/920915eaec56cde7c0ed7543ddb99ae55dddee84) | `` python3.pkgs.cwlformat: fix build after ruamel-yaml update ``                                                    |
| [`7f3c7b4b`](https://github.com/NixOS/nixpkgs/commit/7f3c7b4b484dd9b31ce2e2950452a0824d710e92) | `` base16-universal-manager: use sri hash ``                                                                        |
| [`7ecc712e`](https://github.com/NixOS/nixpkgs/commit/7ecc712e79d0ecfd8b599f169d80c61b587a54dd) | `` vimPlugins.sg-nvim: fix cargoHash ``                                                                             |
| [`97368d91`](https://github.com/NixOS/nixpkgs/commit/97368d9172753627208f57df745e5514916cf411) | `` vimPlugins.vim-pluto: add denops-vim to dependencies ``                                                          |
| [`3fa48f5a`](https://github.com/NixOS/nixpkgs/commit/3fa48f5a078dbcf7f4e3e00391a0d7a083e331a7) | `` vimPlugins.nvim-treesitter: update grammars ``                                                                   |
| [`091b5a7a`](https://github.com/NixOS/nixpkgs/commit/091b5a7a6ca339e21a4c3fc5c691e8dfd6edf17b) | `` vimPlugins: update ``                                                                                            |
| [`ec9c86cf`](https://github.com/NixOS/nixpkgs/commit/ec9c86cf599bf5caf6c05114bd4693555c64cdb1) | `` typos: 1.16.3 -> 1.16.4 ``                                                                                       |
| [`bbbf38ad`](https://github.com/NixOS/nixpkgs/commit/bbbf38adc231951d4c875bdcb25046dc43c7d081) | `` home-assistnat: 2023.8.1 -> 2023.8.2 ``                                                                          |
| [`0d0a8352`](https://github.com/NixOS/nixpkgs/commit/0d0a8352e5109bc4d9f5f9192ab62c10e41076bc) | `` python311Packages.python-roborock: 0.32.0 -> 0.32.2 ``                                                           |
| [`24515960`](https://github.com/NixOS/nixpkgs/commit/24515960d771fc98f4e4b8b914d453202820e7fb) | `` python310Packages.pyairvisual: 2022.12.1 -> 2023.08.1 ``                                                         |
| [`6826f429`](https://github.com/NixOS/nixpkgs/commit/6826f4293ea8acc8385d3b47b6d3e290522dd755) | `` python310Packages.opower: 0.0.26 -> 0.0.26 ``                                                                    |
| [`09d7be2f`](https://github.com/NixOS/nixpkgs/commit/09d7be2f721b58014e1043759cb40aac5df8aa13) | `` pwvucontrol: init at 0.2 ``                                                                                      |
| [`0d237f70`](https://github.com/NixOS/nixpkgs/commit/0d237f7011002e40313febabeea9d99cf3038bc8) | `` typeshare: 1.6.0 -> 1.7.0 ``                                                                                     |
| [`16227341`](https://github.com/NixOS/nixpkgs/commit/16227341cfbe8ecaf023e410854697e6faa30761) | `` brotab: patch out unnecessary "import pip" in setup.py ``                                                        |
| [`3d1703e5`](https://github.com/NixOS/nixpkgs/commit/3d1703e5767fd0612e66e7e39b15670b3e983869) | `` treewide: add matthiasbeyer to a bunch of packages (#248566) ``                                                  |
| [`8563252c`](https://github.com/NixOS/nixpkgs/commit/8563252c01ae28c60b9525ca6fb4933b430cf079) | `` kodi: fix build with fmt10 ``                                                                                    |
| [`851d2f6b`](https://github.com/NixOS/nixpkgs/commit/851d2f6b95cef3d6e3bb9a919b4143fdd457d700) | `` macs2: 2.2.8 -> 2.2.9.1 ``                                                                                       |
| [`eec1488f`](https://github.com/NixOS/nixpkgs/commit/eec1488f889b7be6906a1e795b70c0787c342365) | `` grafana-agent: 0.35.2 -> 0.35.3 ``                                                                               |
| [`5284124f`](https://github.com/NixOS/nixpkgs/commit/5284124f4620d3916c1ff4cd366c5900019c464b) | `` python311Packages.pyrainbird: 3.0.1 -> 4.0.0 ``                                                                  |
| [`9203d7fb`](https://github.com/NixOS/nixpkgs/commit/9203d7fb6be1010efce039af4762ed98f82c3bfb) | `` ablog: 0.10.33.post1 -> 0.11.14.post1 ``                                                                         |
| [`a7d51907`](https://github.com/NixOS/nixpkgs/commit/a7d51907883cec22577f4df3706ee023c740db79) | `` vimPlugins.vim-pluto: init at 2022-02-01 ``                                                                      |
| [`bbac87a2`](https://github.com/NixOS/nixpkgs/commit/bbac87a2ddf95029b8be2c9d3f8d44708ccc8b38) | `` nixos/hostapd: add missing stringification of path in INI format ``                                              |
| [`999d52eb`](https://github.com/NixOS/nixpkgs/commit/999d52eb20c4fd7e549ed4d4d123d02d699a3d5e) | `` stellar-core: use `finalAttrs` pattern ``                                                                        |
| [`b584e3aa`](https://github.com/NixOS/nixpkgs/commit/b584e3aab584442765a1322ccc00297172ec435d) | `` tidal-hifi: use `finalAttrs` pattern ``                                                                          |
| [`43e4540c`](https://github.com/NixOS/nixpkgs/commit/43e4540c49c20c9c681e85168ee20c9dbd864455) | `` media-downloader: use `finalAttrs` pattern ``                                                                    |
| [`52fbc287`](https://github.com/NixOS/nixpkgs/commit/52fbc287ca19be766fa4e9db4f5d46bc51d11c32) | `` gnome.gnome-shell: Provide schema compiler path ``                                                               |
| [`494522a2`](https://github.com/NixOS/nixpkgs/commit/494522a2a4bd2f0efc86b2d48e0a9cd987680c05) | `` treewide: noop: refer to `src.name` or similar in `sourceRoot` where appropriate, part 4: leftovers (#248528) `` |
| [`8a84833c`](https://github.com/NixOS/nixpkgs/commit/8a84833c2eb1a5ba5ce60ff8e8f4a89db0008a72) | `` osu-lazer: 2023.803.0 -> 2023.811.0 ``                                                                           |
| [`0b4ba660`](https://github.com/NixOS/nixpkgs/commit/0b4ba6603489a3da840fe1d94b98fc66602f2ca4) | `` osu-lazer-bin: 2023.803.0 -> 2023.811.0 ``                                                                       |
| [`aba5b377`](https://github.com/NixOS/nixpkgs/commit/aba5b377bfb5cfbc53fc30cf4f9b4fb9d2e0ec2b) | `` frozen: init at unstable-2021-02-23 ``                                                                           |
| [`fb5e5361`](https://github.com/NixOS/nixpkgs/commit/fb5e53615b4734ca6eaeeb54b84b8000cdae0389) | `` hol_light: use default version of OCaml ``                                                                       |
| [`032f6c6f`](https://github.com/NixOS/nixpkgs/commit/032f6c6f936589f3020ffc303dea4c566bfd281f) | `` ocamlPackages.camlp5: 7.14 → 8.00.05 ``                                                                          |