### PR TITLE
chore(flake/home-manager): `c3ab5ea0` -> `da6874e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -205,11 +205,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1691882297,
-        "narHash": "sha256-e1/LAQSGLnBywfA1TfMl0Vj3tvYka73XOZ/D2/CJowE=",
+        "lastModified": 1691998815,
+        "narHash": "sha256-HuFgb+W1Dvd0mjjudpTf0hVg/YKKiMRpX14t7dJeTm8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c3ab5ea047e6dc73df530948f7367455749d8906",
+        "rev": "da6874e8bb82204323b94154585a1471c739f73e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`da6874e8`](https://github.com/nix-community/home-manager/commit/da6874e8bb82204323b94154585a1471c739f73e) | `` Translate using Weblate (Romanian) ``            |
| [`d08812fe`](https://github.com/nix-community/home-manager/commit/d08812fe1a850b5948b2101cb4adcb6f8c4faa94) | `` Translate using Weblate (Portuguese (Brazil)) `` |
| [`88067b9b`](https://github.com/nix-community/home-manager/commit/88067b9b148ed86f81d80d13e49f0f848dbd96e0) | `` hyprland: remove xwayland.hidpi (#4302) ``       |