### PR TITLE
chore(flake/home-manager): `18791781` -> `75cfe974`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -205,11 +205,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692081771,
-        "narHash": "sha256-LWhyDz3gi1RzTcW6e6iwfs4VuDWFajOexBKygNIqvQM=",
+        "lastModified": 1692131549,
+        "narHash": "sha256-MFjI8NL63/6HjMZpvJgnB/Pgg2dht22t45jOYtipZig=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "18791781ea86cbec6bce8bcb847444b9c73b8b3b",
+        "rev": "75cfe974e2ca05a61b66768674032b4c079e55d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`75cfe974`](https://github.com/nix-community/home-manager/commit/75cfe974e2ca05a61b66768674032b4c079e55d4) | `` Translate using Weblate (German) `` |
| [`b84767a1`](https://github.com/nix-community/home-manager/commit/b84767a145e04d07ef699d266161cda605f48b11) | `` xplr: add module ``                 |