### PR TITLE
chore(flake/nixpkgs): `6e287913` -> `8353344d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691990649,
-        "narHash": "sha256-gMbKOiX1HwClRP9lADaaV/lnZr93NEaOFe4ApDx/zd8=",
+        "lastModified": 1692084312,
+        "narHash": "sha256-Za++qKVK6ovjNL9poQZtLKRM/re663pxzbJ+9M4Pgwg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e287913f7b1ef537c97aa301b67c34ea46b640f",
+        "rev": "8353344d3236d3fda429bb471c1ee008857d3b7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`2501addf`](https://github.com/NixOS/nixpkgs/commit/2501addf2d61a3052128659883fee33435edd669) | `` nix-doc: 0.5.9 -> 0.5.10 ``                                                                  |
| [`624607b3`](https://github.com/NixOS/nixpkgs/commit/624607b3a5cfa1d1e68b7b768ad925da142630b5) | `` postgresql11JitPackages.plr: 8.4.5 -> 8.4.6 ``                                               |
| [`d2a462ab`](https://github.com/NixOS/nixpkgs/commit/d2a462ababf64b2f4f36267eb1ed1e3749fb2fde) | `` python310Packages.mashumaro: 3.8.1 -> 3.9 ``                                                 |
| [`ea95c091`](https://github.com/NixOS/nixpkgs/commit/ea95c0917609e5c48023cc7c6141bea2fdf13970) | `` nltk-data: init at unstable-2023-02-02 ``                                                    |
| [`810ec794`](https://github.com/NixOS/nixpkgs/commit/810ec794359b1aa7439b337796a8d364b92b9b4e) | `` armcord: 3.2.1 -> 3.2.3 ``                                                                   |
| [`790f188d`](https://github.com/NixOS/nixpkgs/commit/790f188d604144270b42e96d700e24066cc461a1) | `` duperemove: 0.11.3 -> 0.12 ``                                                                |
| [`34fd05a0`](https://github.com/NixOS/nixpkgs/commit/34fd05a06581639e7ea677a0083bb1739dddb013) | `` python310Packages.cfgv: 3.3.1 -> 3.4.0 ``                                                    |
| [`fecb8c77`](https://github.com/NixOS/nixpkgs/commit/fecb8c7752d3f88eb5d83a0b0f24dccb09c8d897) | `` nixosTests.fcitx5: make use of the newly added settings option ``                            |
| [`2af24d44`](https://github.com/NixOS/nixpkgs/commit/2af24d44177b851b92f12697455071ee74ff4cc6) | `` nixos/fcitx5: fix evaluation ``                                                              |
| [`79118350`](https://github.com/NixOS/nixpkgs/commit/79118350b0eb4943c1a97cdb38efc6bad930cffb) | `` python311Packages.types-ujson: 5.8.0.0 -> 5.8.0.1 ``                                         |
| [`e543e81f`](https://github.com/NixOS/nixpkgs/commit/e543e81fae539c68e89431d82d2ff6ef26210dea) | `` budgie.budgie-backgrounds: 1.0 -> 2.0 ``                                                     |
| [`bdc5b90b`](https://github.com/NixOS/nixpkgs/commit/bdc5b90b324688f21c99ac6853d97f4dcc7be10e) | `` python311Packages.reolink-aio: 0.7.6 -> 0.7.7 ``                                             |
| [`1fbf8cf3`](https://github.com/NixOS/nixpkgs/commit/1fbf8cf3ba911af53495f098ccb54ebc581a9cff) | `` checkov: 2.3.364 -> 2.3.365 ``                                                               |
| [`19126813`](https://github.com/NixOS/nixpkgs/commit/1912681314d415cc28e25b7932d9e88dfec75cd3) | `` tests.cross.sanity: enable mbuffer test ``                                                   |
| [`64046f01`](https://github.com/NixOS/nixpkgs/commit/64046f019103677f9539b303bf7be0f9be12d29f) | `` glibcCross: use a libgcc built separately from gcc ``                                        |
| [`18c52d09`](https://github.com/NixOS/nixpkgs/commit/18c52d09bcd6c60bc60db81fe1a37d7663acaf27) | `` libgcc: make needed architecture-specific targets if isArmv7 ``                              |
| [`c0e4121b`](https://github.com/NixOS/nixpkgs/commit/c0e4121ba537c10ef0a5132777bb35ae94735658) | `` libgcc: make needed architecture-specific targets if isM68k ``                               |
| [`17ce8682`](https://github.com/NixOS/nixpkgs/commit/17ce8682d67de1977c0a9bc1ef9258a905aa5a1c) | `` libgcc: let-rename stdenvNoLibs to stdenv ``                                                 |
| [`8c37dae9`](https://github.com/NixOS/nixpkgs/commit/8c37dae9adf2c73cbd750566fef244398d5f87e9) | `` libgcc: gccConfigureFlags: minimize, fix ``                                                  |
| [`fa0ebe80`](https://github.com/NixOS/nixpkgs/commit/fa0ebe80f1e7b3d872b3814bfcb25f991217a5ef) | `` libgcc: configureFlags: minimize ``                                                          |
| [`da371c7c`](https://github.com/NixOS/nixpkgs/commit/da371c7c5a57a8a34c8bb3ec5336ff97977360de) | `` libgcc: use forceLibgccToBuildCrtStuff ``                                                    |
| [`92186a49`](https://github.com/NixOS/nixpkgs/commit/92186a49bf72a74e507549669cde90977c977efe) | `` gcc: factor out forceLibgccToBuildCrtStuff ``                                                |
| [`383d62d9`](https://github.com/NixOS/nixpkgs/commit/383d62d94c31a8094154a4b5346679d204a2f0f8) | `` libgcc: add glibc as a buildInput ``                                                         |
| [`b5893e70`](https://github.com/NixOS/nixpkgs/commit/b5893e70468246bcd0062631c0cde3fc5687b362) | `` libgcc: let-float gccConfigureFlags out of the derivation attrs ``                           |
| [`2ecf2d95`](https://github.com/NixOS/nixpkgs/commit/2ecf2d954becdd97d78d41d663d0007d72714a5e) | `` libgcc: use finalAttrs instead of rec ``                                                     |
| [`72fa5978`](https://github.com/NixOS/nixpkgs/commit/72fa5978fd45925df9e09b829e23bb429250b898) | `` libgcc: minor formatting adjustments ``                                                      |
| [`fcaa5a75`](https://github.com/NixOS/nixpkgs/commit/fcaa5a7556760d520dc78d99ada5a58fc13c7894) | `` libgcc: take from gcc unless explicitly overridden ``                                        |
| [`f445f642`](https://github.com/NixOS/nixpkgs/commit/f445f64207c41c8cb0f6bae31296ac10a561928f) | `` libgcc: (re)init at 12.3.0 ``                                                                |
| [`cc6ea4f1`](https://github.com/NixOS/nixpkgs/commit/cc6ea4f1b226c77c153847b426ed7aec8c737858) | `` cargo-fuzz: 0.11.0 -> 0.11.2 ``                                                              |
| [`4eceab09`](https://github.com/NixOS/nixpkgs/commit/4eceab09f427f6d5050dff286902ba728dfd1e11) | `` python311Packages.pyoverkiz: 1.9.1 -> 1.10.1 ``                                              |
| [`9bd3f4c0`](https://github.com/NixOS/nixpkgs/commit/9bd3f4c03057b8e6b8bed7843fc016fdf700014d) | `` python311Packages.backports-strenum: init at 1.2.4 ``                                        |
| [`bc018252`](https://github.com/NixOS/nixpkgs/commit/bc018252ffdfc8e4015aaa7ba938dbfbe015d21b) | `` python310Packages.ocrmypdf: 14.3.0 -> 14.4.0 ``                                              |
| [`6d3e7145`](https://github.com/NixOS/nixpkgs/commit/6d3e7145f7207679667b140db61c00ed146e26e5) | `` python311Packages.caldav: 1.2.1 -> 1.3.6 ``                                                  |
| [`64e8ab0c`](https://github.com/NixOS/nixpkgs/commit/64e8ab0cb598bd58163340b932b5ed52303cced4) | `` python311Packages.twilio: 8.5.0 -> 8.6.0 ``                                                  |
| [`89ca95f0`](https://github.com/NixOS/nixpkgs/commit/89ca95f00b482970ee8bc5f5f9c7febd746bdc31) | `` python311Packages.pyschlage: 2023.7.0 -> 2023.8.1 ``                                         |
| [`144482ae`](https://github.com/NixOS/nixpkgs/commit/144482aebd86aa64335772b2976d5fec29512a82) | `` python311Packages.pylitterbot: 2023.4.3 -> 2023.4.4 ``                                       |
| [`e48398df`](https://github.com/NixOS/nixpkgs/commit/e48398dfb99cac1bbf7ad4664a39084b771ff3de) | `` python311Packages.mypy-boto3-ebs: 1.28.13 -> 1.28.16 ``                                      |
| [`125aaaa2`](https://github.com/NixOS/nixpkgs/commit/125aaaa2519bb0e25338e4dd4017cd4e844da9a9) | `` python311Packages.bthome-ble: 3.0.0 -> 3.1.0 ``                                              |
| [`ebb53eb4`](https://github.com/NixOS/nixpkgs/commit/ebb53eb4220ed4753cb90ad8d8d33579780d86f4) | `` python311Packages.boschshcpy: 0.2.57 -> 0.2.60 ``                                            |
| [`6729fcf0`](https://github.com/NixOS/nixpkgs/commit/6729fcf0b457bed77bdae316392eff7f1a03218e) | `` maintainers/team-list: add GaetanLepage to jupyter team ``                                   |
| [`9e7f179d`](https://github.com/NixOS/nixpkgs/commit/9e7f179d416b424b147da79938e59b1c7d81108b) | `` python311Packages.vulcan-api: fix issue with cchardet/faust-cchardet ``                      |
| [`bc7c971b`](https://github.com/NixOS/nixpkgs/commit/bc7c971b7e53dd9be55612b4c2c2295e1e19f1f9) | `` python311Packages.okta: 2.8.0 -> 2.9.2 ``                                                    |
| [`a306dbd8`](https://github.com/NixOS/nixpkgs/commit/a306dbd89e1b6f2739fe39fb39a8b430bc65556b) | `` python311Packages.awesomeversion: add changelog to meta ``                                   |
| [`3af9ec4f`](https://github.com/NixOS/nixpkgs/commit/3af9ec4f579d3eb6dc666be25fc8adcfb9469719) | `` gst123: sort attributes and remove `with lib;` ``                                            |
| [`98f70a4d`](https://github.com/NixOS/nixpkgs/commit/98f70a4dadf25eb825b3efebe79e6247f160cd72) | `` gst123: add `meta.mainProgram` ``                                                            |
| [`737212ec`](https://github.com/NixOS/nixpkgs/commit/737212ecc8254b746b29302cd377e72eb78db070) | `` ocamlPackages.thread-table: 0.1.0 → 1.0.0 ``                                                 |
| [`2b50eb79`](https://github.com/NixOS/nixpkgs/commit/2b50eb792a0356d758fe597644c1739347831a40) | `` path-of-building: 2.30.1 -> 2.31.0 ``                                                        |
| [`c28d2906`](https://github.com/NixOS/nixpkgs/commit/c28d2906d454dee59918a0b8322a6fa1dc9aee58) | `` ztags: init at unstable-2023-08-03 ``                                                        |
| [`21c6da06`](https://github.com/NixOS/nixpkgs/commit/21c6da069e94ebd6a9e59c143302476a0c1ea0e3) | `` tmux: meta.mainProgram ``                                                                    |
| [`f53d2faa`](https://github.com/NixOS/nixpkgs/commit/f53d2faa867089c9220c21e0991972db94d21bbc) | `` tailscale: meta.mainProgram ``                                                               |
| [`5425b0dd`](https://github.com/NixOS/nixpkgs/commit/5425b0ddaf343316e3bbfd57ad8ca81e65113730) | `` mdadm: meta.mainProgram ``                                                                   |
| [`de5a39f5`](https://github.com/NixOS/nixpkgs/commit/de5a39f5e7d8ed4d9914e6e41de0834351ad3142) | `` CONTRIBUTING.md: Move boot loader-specific sentence to pkgs/README.md ``                     |
| [`2ce1e0b2`](https://github.com/NixOS/nixpkgs/commit/2ce1e0b2cc287799138439d04dee78af425b5c01) | `` CONTRIBUTING.md: Typos and formatting ``                                                     |
| [`237799aa`](https://github.com/NixOS/nixpkgs/commit/237799aa8ecb233e9a19e3d4f332cd1db04d1de0) | `` CONTRIBUTING.md: Minor content updates based on reviews ``                                   |
| [`1302818f`](https://github.com/NixOS/nixpkgs/commit/1302818fee73d235624135f55da320b2aeb8981c) | `` ripdrag: 0.4.0 -> 0.4.1 ``                                                                   |
| [`2249c1e5`](https://github.com/NixOS/nixpkgs/commit/2249c1e5dc72467dda4339a5d92759b6e94eba22) | `` linuxPackage.nvidia_x11.settings: nixpkgs-fmt and add opengl runpath ``                      |
| [`877980c4`](https://github.com/NixOS/nixpkgs/commit/877980c41089488cc5eb9684e127c998dcbfd932) | `` linuxPackage.nvidia_x11*: Remove another nvidia-settings library ``                          |
| [`14ae6da1`](https://github.com/NixOS/nixpkgs/commit/14ae6da134efb5e08ac584665c6bebb377da65ca) | `` gst123: init at 0.4.1 ``                                                                     |
| [`737c4e89`](https://github.com/NixOS/nixpkgs/commit/737c4e8931eb867ba3f109530fd7b7d5c4bcc832) | `` maintainers: add swesterfeld ``                                                              |
| [`10c6be32`](https://github.com/NixOS/nixpkgs/commit/10c6be32e42127c8fa3656c521dea02ac6717004) | `` nixos/tempo: add `extraFlags` option ``                                                      |
| [`b93da3f4`](https://github.com/NixOS/nixpkgs/commit/b93da3f4b77b0f3c441212c17bba02360f7fadee) | `` treewide: `overrideScope'` -> `overrideScope` ``                                             |
| [`3c1f82f9`](https://github.com/NixOS/nixpkgs/commit/3c1f82f99ee02dad4eb480f6216ae2ece445d11d) | `` lib.customisation.makeScope: Make `overrideScope` consistent with `makeScopeWithSplicing` `` |
| [`0b6d3959`](https://github.com/NixOS/nixpkgs/commit/0b6d395909219e21fbd55dd6b321fc1f06a424ab) | `` ncdu: 2.2.2 -> 2.3 ``                                                                        |
| [`d6c69dbd`](https://github.com/NixOS/nixpkgs/commit/d6c69dbd740aa602f619a7e793bfd12669e87ded) | `` dasel: set mainProgram ``                                                                    |
| [`edb0f26c`](https://github.com/NixOS/nixpkgs/commit/edb0f26c7db1b16db880f77f663e58a9e91dfcc5) | `` python310Packages.optimum: init at 1.11.1 ``                                                 |
| [`ce0123ad`](https://github.com/NixOS/nixpkgs/commit/ce0123ad6c2ab2e1510e234e16f491eae1eb9536) | `` typos: 1.16.4 -> 1.16.5 ``                                                                   |
| [`0e5416a4`](https://github.com/NixOS/nixpkgs/commit/0e5416a459907e48abc49050335b271f3e93bd90) | `` prometheus-postgres-exporter: 0.13.1 -> 0.13.2 ``                                            |
| [`75dda16d`](https://github.com/NixOS/nixpkgs/commit/75dda16dff1b1cc147ad6a2a30897531f1a566f2) | `` python311Packages.qcodes: 0.39.0 -> 0.39.1 ``                                                |
| [`1fce113b`](https://github.com/NixOS/nixpkgs/commit/1fce113b92e31f23d6966d5d51b02d15538edae6) | `` python311Packages.python-otbr-api: 2.3.0 -> 2.4.0 ``                                         |
| [`99827b83`](https://github.com/NixOS/nixpkgs/commit/99827b838f421a3f0250c24a3598cddd4eb2305a) | `` rizin, cutter: set meta.mainProgram ``                                                       |
| [`2fb2f399`](https://github.com/NixOS/nixpkgs/commit/2fb2f3994dec6be6196520cededa2c569b2cffa5) | `` rizin: wrapper fixes ``                                                                      |
| [`d2ebdcb1`](https://github.com/NixOS/nixpkgs/commit/d2ebdcb1bd10deb5949bc5e0a4f26e4d70d4f339) | `` typst-lsp: 0.9.0 -> 0.9.1 ``                                                                 |
| [`a37e23c8`](https://github.com/NixOS/nixpkgs/commit/a37e23c8caeff04f32ac0d98b6f53d5910d86a45) | `` plasma-desktop: add missing gsettings schemas on kaccess ``                                  |
| [`bf378019`](https://github.com/NixOS/nixpkgs/commit/bf378019c92de33e701d58aedd5cba47c509044b) | `` keepmenu: 1.3.1 -> 1.4.0 ``                                                                  |
| [`4424cfc6`](https://github.com/NixOS/nixpkgs/commit/4424cfc6cbd62dbea3a30c5e2f393fab5bcd3620) | `` python310Packages.pymilvus: 2.2.13 -> 2.2.15 ``                                              |
| [`6412ad95`](https://github.com/NixOS/nixpkgs/commit/6412ad95508413c06cd7ed95d9605936c560b682) | `` dbx: 0.8.11 -> 0.8.18 ``                                                                     |
| [`874e431f`](https://github.com/NixOS/nixpkgs/commit/874e431f7a46f80b938ef7ffeffcc7ebe261cf1f) | `` rl-2311: mention upgrade of html-proofer to major version 5 ``                               |
| [`b65f0cc8`](https://github.com/NixOS/nixpkgs/commit/b65f0cc8ef31ebe4fdc16649b4ff7f9d4e7d12fc) | `` html-proofer: 3.18.8 -> 5.0.8 ``                                                             |
| [`30cfb7d3`](https://github.com/NixOS/nixpkgs/commit/30cfb7d36737d766dad1e0d6dc551cfeedf7433f) | `` portfolio: 0.64.5 -> 0.65.0 ``                                                               |
| [`37458514`](https://github.com/NixOS/nixpkgs/commit/37458514ef694db5d3690475eb55cfc6fbf56d20) | `` icebreaker: init at unstable-2023-08-13 ``                                                   |
| [`51d84fd6`](https://github.com/NixOS/nixpkgs/commit/51d84fd6df693746fc9f57ccc00482db45e77539) | `` python310Packages.django-classy-tags: update disabled ``                                     |
| [`552bddf3`](https://github.com/NixOS/nixpkgs/commit/552bddf3ed68ca474419ab1c93105429333b1fd8) | `` ligo: 0.69.0 -> 0.71.1 ``                                                                    |
| [`6eb97ebb`](https://github.com/NixOS/nixpkgs/commit/6eb97ebbf9faf6faa52890b6dd11fee2ad3c032f) | `` ocamlPackages.linol: 2023-04-25 -> 2023-08-04 ``                                             |
| [`c53f98ef`](https://github.com/NixOS/nixpkgs/commit/c53f98ef630a5179b04fe4012f72e0fd4fd47fda) | `` hyprdim: 2.1.0 -> 2.2.1 ``                                                                   |
| [`39925296`](https://github.com/NixOS/nixpkgs/commit/399252962be9ea91c8307206635c7c9361fcd4c6) | `` nixVersions.nix_2_15: 2.15.1 -> 2.15.2 ``                                                    |
| [`0cb6b7cd`](https://github.com/NixOS/nixpkgs/commit/0cb6b7cd0b8d85f84824cbada1d1ec080e30fe9b) | `` python311Packages.python-engineio: 4.4.1 -> 4.5.1 ``                                         |
| [`6bbba9e1`](https://github.com/NixOS/nixpkgs/commit/6bbba9e1fa7e6734412c553c048fc2c800820c85) | `` python311Packages.flux-led: 1.0.1 -> 1.0.2 ``                                                |
| [`145bcb6d`](https://github.com/NixOS/nixpkgs/commit/145bcb6dbf2e76d86bec248d2744a8eb2de99f15) | `` python311Packages.jupyterlab-lsp: mark as broken for Jupyterlab > 4 ``                       |
| [`661d2a92`](https://github.com/NixOS/nixpkgs/commit/661d2a9275a14082e92d37942b93331e3dcce8a2) | `` pam_rssh: unstable-2023-03-18 -> 1.1.0 ``                                                    |
| [`6750d3cb`](https://github.com/NixOS/nixpkgs/commit/6750d3cbdd596505c54ffda9da634f0b39b1f0e0) | `` fcitx5-with-addons: add withConfigtool option ``                                             |
| [`f38a3fd6`](https://github.com/NixOS/nixpkgs/commit/f38a3fd6bd6a017b3ecfcd6b58bbf3b92dd9fbf1) | `` fcitx5: use makeBinaryWrapper ``                                                             |
| [`887665e9`](https://github.com/NixOS/nixpkgs/commit/887665e9cc881af5e22e6b65edb001171a29e97c) | `` python310Packages.django-classy-tags: 4.0.0 -> 4.1.0 ``                                      |
| [`c550f2bc`](https://github.com/NixOS/nixpkgs/commit/c550f2bcab60865ade81a3d09f57df72072931b1) | `` fcitx5: pass FCITX_ADDON_DIRS to fcitx5-qt via configtool ``                                 |
| [`0d472a62`](https://github.com/NixOS/nixpkgs/commit/0d472a62012364d064f0b75f1da491242c6ae9c6) | `` lib/modules: Report a good error when option tree has bare type ``                           |
| [`56b3d416`](https://github.com/NixOS/nixpkgs/commit/56b3d41655a93f7deca35e4b7dd4818821ba8982) | `` python311Packages.yfinance: 0.2.27 -> 0.2.28 ``                                              |
| [`30bb1515`](https://github.com/NixOS/nixpkgs/commit/30bb15152e0ee83d9be9be77b08af267966bb31c) | `` nixos/fcitx5: add settings ``                                                                |
| [`57909125`](https://github.com/NixOS/nixpkgs/commit/57909125148692d055362e8340b05f4ab6df372e) | `` bazel_6: installCheckPhase .bazelversion override ``                                         |
| [`38a8ec79`](https://github.com/NixOS/nixpkgs/commit/38a8ec790b5083fb97967056ed072540180fd699) | `` checkov: 2.3.361 -> 2.3.364 ``                                                               |
| [`db4fa683`](https://github.com/NixOS/nixpkgs/commit/db4fa6837790174e94f7c9d6f6aff8c92f7d4dbb) | `` python311Packages.textual: 0.28.1 -> 0.32.0 ``                                               |
| [`81326593`](https://github.com/NixOS/nixpkgs/commit/8132659329addbd711d8261fd2a2eed321b124e7) | `` liberation_ttf_v1: fix build after #248865 ``                                                |
| [`77d5156a`](https://github.com/NixOS/nixpkgs/commit/77d5156aa31b6fdac21e38fbc3f3933829f39606) | `` python311Packages.spdx-tools: set version ``                                                 |
| [`d8ef88b4`](https://github.com/NixOS/nixpkgs/commit/d8ef88b4b815c037a9d10b1953fdf8653a75309d) | `` yuzu: 1515 -> 1522, yuzu-ea: 3788 -> 3805 ``                                                 |
| [`f35cad25`](https://github.com/NixOS/nixpkgs/commit/f35cad251879310cd1bf6c65236462bdbef2dffc) | `` python311Packages.todoist: 8.1.3 -> 8.1.4 ``                                                 |
| [`7474ca6b`](https://github.com/NixOS/nixpkgs/commit/7474ca6b8169970852541a894b6df46db95acaad) | `` python310Packages.skl2onnx: 1.14.1 -> 1.15.0 (#249034) ``                                    |
| [`3b7deba8`](https://github.com/NixOS/nixpkgs/commit/3b7deba8c8a241eca2805d5f7e0aa26948795d1a) | `` beautysh: patch "poetry" reference in pyproject.toml (#248598) ``                            |
| [`db667927`](https://github.com/NixOS/nixpkgs/commit/db66792785b55e8701c72fce73f75daccde72305) | `` python311Packages.pygithub: 1.59.0 -> 1.59.1 ``                                              |
| [`4f368e05`](https://github.com/NixOS/nixpkgs/commit/4f368e05c11b8c7dfd4e8b1e93547195b3ca773f) | `` python311Packages.pylibftdi: 0.20.0 -> 0.21.0 ``                                             |
| [`87c78086`](https://github.com/NixOS/nixpkgs/commit/87c7808621e8f3ed38900c5afd88bc6091c06487) | `` python311Packages.pyfritzhome: 0.6.8 -> 0.6.9 ``                                             |
| [`1b4f3a49`](https://github.com/NixOS/nixpkgs/commit/1b4f3a495d7e0f74322cce095fc15f5aa1157f4b) | `` python311Packages.pyathena: 2.23.0 -> 3.0.6 ``                                               |
| [`f9b90d8c`](https://github.com/NixOS/nixpkgs/commit/f9b90d8c71748395f646e7766b1ffd80b093dd40) | `` python311Packages.publicsuffixlist: 0.10.0.20230811 -> 0.10.0.20230814 ``                    |
| [`9e27821d`](https://github.com/NixOS/nixpkgs/commit/9e27821dd143f7cad86da02b18e8789fd73bf287) | `` python310Packages.langchain: 0.0.254 -> 0.0.263 ``                                           |
| [`425df5b7`](https://github.com/NixOS/nixpkgs/commit/425df5b716e9301abaca5879dd7cf39049b0f504) | `` python311Packages.policyuniverse: 1.5.1.20230725 -> 1.5.1.20230813 ``                        |
| [`f02103d4`](https://github.com/NixOS/nixpkgs/commit/f02103d40cf9604d205e386b7e43ad0d7f5bace3) | `` python311Packages.oauthenticator: 15.1.0 -> 16.0.4 ``                                        |
| [`36078c2b`](https://github.com/NixOS/nixpkgs/commit/36078c2be72844f55e8ee3c02e6a0cbe6eb4f9fd) | `` python310Packages.dvc: 3.14.0 -> 3.15.2 ``                                                   |
| [`33525333`](https://github.com/NixOS/nixpkgs/commit/33525333cb2c7689de343adcdf44c09dd8a43975) | `` python311Packages.dvc-azure: 2.22.0 -> 2.22.1 ``                                             |
| [`e67b4c18`](https://github.com/NixOS/nixpkgs/commit/e67b4c18321dec844857eb6508ed5e04eabb696b) | `` python311Packages.dvc-ssh: 2.22.1 -> 2.22.2 ``                                               |
| [`e9abe69b`](https://github.com/NixOS/nixpkgs/commit/e9abe69b5e7f9e189a825294a8c71eddcda362a3) | `` python311Packages.dvc-studio-client: 0.12.0 -> 0.13.0 ``                                     |
| [`fe2866a6`](https://github.com/NixOS/nixpkgs/commit/fe2866a6566e7fcbbc6d5abe9d8bdfd650669826) | `` pistol: 0.4.1 -> 0.4.2 ``                                                                    |
| [`e3d74b30`](https://github.com/NixOS/nixpkgs/commit/e3d74b30b00321414f550522ec19eddf58a50377) | `` bpfmon: 2.51 -> 2.52 ``                                                                      |
| [`a0796740`](https://github.com/NixOS/nixpkgs/commit/a07967400560ccc8983d85bb3eeba727d43287d4) | `` cryptomator: 1.9.1 -> 1.9.4 ``                                                               |
| [`9fcc64eb`](https://github.com/NixOS/nixpkgs/commit/9fcc64eb9baefc8f2b2969ad1b374c3dd33c434e) | `` twilio-cli: 5.11.0 -> 5.12.0 ``                                                              |
| [`1ad146d6`](https://github.com/NixOS/nixpkgs/commit/1ad146d6279337331eb46bc9a94451c6b157dede) | `` flexget: 3.8.5 -> 3.8.6 ``                                                                   |
| [`2ea83536`](https://github.com/NixOS/nixpkgs/commit/2ea83536fcdbe0df075f5406f2332865badac6d5) | `` esbuild: 0.19.1 -> 0.19.2 ``                                                                 |
| [`a82adc89`](https://github.com/NixOS/nixpkgs/commit/a82adc890a3c03c8c298ddf0f507414a8683c921) | `` coloursum: 0.2.0 -> 0.3.0 ``                                                                 |
| [`9fffd676`](https://github.com/NixOS/nixpkgs/commit/9fffd676fc13da448189e378569148f31e3d1172) | `` morsel: 0.1.0 -> 0.1.1 ``                                                                    |
| [`5e1c46c2`](https://github.com/NixOS/nixpkgs/commit/5e1c46c2daa1f8168725c330870144708df204c1) | `` ast-grep: 0.10.0 -> 0.11.0 ``                                                                |
| [`28f665d9`](https://github.com/NixOS/nixpkgs/commit/28f665d9b250af1ae4f0053bee11f80b70c19984) | `` ast-grep: added cafkafk as maintainer ``                                                     |
| [`d04e4797`](https://github.com/NixOS/nixpkgs/commit/d04e4797e4446705aae9e88613e12411830af017) | `` sad: 0.4.22 -> 0.4.23 ``                                                                     |
| [`b0f61e3d`](https://github.com/NixOS/nixpkgs/commit/b0f61e3da26a3bda576852817f1f62fb6894f077) | `` CODEOWNERS: Add myself to the newly added files ``                                           |
| [`a9e28f71`](https://github.com/NixOS/nixpkgs/commit/a9e28f712b2630555e59f005e3d7aeb5d2e21582) | `` touchegg: 2.0.16 -> 2.0.17 ``                                                                |
| [`aafc9aee`](https://github.com/NixOS/nixpkgs/commit/aafc9aee385423a10d2ae56ddf8a807c37fbd5d1) | `` pkgs/README.md: Remove some mediocre duplicated sentences ``                                 |
| [`e2f4aedc`](https://github.com/NixOS/nixpkgs/commit/e2f4aedc423400c73064666ad44218b261a3f8b2) | `` added passthru version test ``                                                               |
| [`73743d45`](https://github.com/NixOS/nixpkgs/commit/73743d45e07eb00a57c0024725b4a919e6c4a16f) | `` leetcode-cli: 0.4.1 -> 0.4.2 ``                                                              |
| [`d5148f23`](https://github.com/NixOS/nixpkgs/commit/d5148f23330dce97d2edd14e1710d4ab4e3f59cb) | `` maintainer/README.md: GitHub markdown fixes ``                                               |
| [`15ca783f`](https://github.com/NixOS/nixpkgs/commit/15ca783f10e9558f922394f26fb36e508fce8111) | `` nixos/README.md: GitHub markdown fixes ``                                                    |
| [`553daaed`](https://github.com/NixOS/nixpkgs/commit/553daaed7323126e9945679d666f8dee9961e378) | `` doc/README.md: Cleanup ``                                                                    |
| [`e6307807`](https://github.com/NixOS/nixpkgs/commit/e6307807a8c84243b3bb2468660d5422a250b261) | `` pkgs/README.md: Minor header and link fixes ``                                               |
| [`d7c643b3`](https://github.com/NixOS/nixpkgs/commit/d7c643b3b5af3bb953e253e1cf4353a07070f50d) | `` clojure: 1.11.1.1347 -> 1.11.1.1356 ``                                                       |
| [`b069d2df`](https://github.com/NixOS/nixpkgs/commit/b069d2dfec737e0d22b8daa52bc2d6aac3e910ae) | `` CONTRIBUTING.md: Move sections around ``                                                     |
| [`16651342`](https://github.com/NixOS/nixpkgs/commit/16651342ea5cfe8a2cb1700865ed5e60ddae3603) | `` CONTRIBUTING.md: Minor fixes ``                                                              |
| [`0bd8c9b4`](https://github.com/NixOS/nixpkgs/commit/0bd8c9b4f9e2af62795dfbc257aa63bcb89e33e8) | `` CONTRIBUTING.md: New section on which branch to use ``                                       |
| [`b3e6bcb6`](https://github.com/NixOS/nixpkgs/commit/b3e6bcb605e7cc8e8fd3eee4abdb86be2e068c3c) | `` jmol: 16.1.13 -> 16.1.33 ``                                                                  |