### PR TITLE
chore(flake/home-manager): `9db5b89f` -> `aa59f917`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -205,11 +205,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692200694,
-        "narHash": "sha256-A8hHkA+sJ04Agvu9OoVJ3ouak1e2hze9Ev+c71oGLAk=",
+        "lastModified": 1692218471,
+        "narHash": "sha256-gHt4lmFjKZdRAHYVWZEE4QNo560tD6cCXIqzj+9ulZg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9db5b89f40736943d017a761da044479044be182",
+        "rev": "aa59f917462f2d25ffd1f3128a063d4d3d1642d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`aa59f917`](https://github.com/nix-community/home-manager/commit/aa59f917462f2d25ffd1f3128a063d4d3d1642d4) | `` fcitx5: add `fcitx5-config-qt` to test stub `` |
| [`1ccd0c93`](https://github.com/nix-community/home-manager/commit/1ccd0c935ca8ade5e0826da8ac4f1bff3f473da6) | `` pqiv: only run tests on Linux platforms ``     |