### PR TITLE
chore(flake/pre-commit-hooks): `3e3d45c1` -> `7e3517c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -403,11 +403,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1692203373,
-        "narHash": "sha256-St6Ie93YMi8ugwnbIFLuse7KE9f7nwmwT+fo86Mk/8Y=",
+        "lastModified": 1692274144,
+        "narHash": "sha256-BxTQuRUANQ81u8DJznQyPmRsg63t4Yc+0kcyq6OLz8s=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3e3d45c1f26e212abe24188ece996871d94618d8",
+        "rev": "7e3517c03d46159fdbf8c0e5c97f82d5d4b0c8fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                              |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`cf2901f0`](https://github.com/cachix/pre-commit-hooks.nix/commit/cf2901f0b46b1f0461eba466bf2bc45d4df105c9) | `` Allow empty settings for mkdocs-linkcheck hook `` |
| [`c249b6eb`](https://github.com/cachix/pre-commit-hooks.nix/commit/c249b6eb997c274b7c7f5fa326c63ef53d3a62e6) | `` Add profile setting to isort hook ``              |