### PR TITLE
chore(flake/nixos-hardware): `430a56dd` -> `7f183653`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -327,11 +327,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1691871742,
-        "narHash": "sha256-6yDNjfbAMpwzWL4y75fxs6beXHRANfYX8BNSPjYehck=",
+        "lastModified": 1692373088,
+        "narHash": "sha256-EPgCecdc9I8aTdmDNoO1l7R72r2WPhZRcesV4nzxBj8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "430a56dd16fe583a812b2df44dca002acab2f4f6",
+        "rev": "7f1836531b126cfcf584e7d7d71bf8758bb58969",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`7f183653`](https://github.com/NixOS/nixos-hardware/commit/7f1836531b126cfcf584e7d7d71bf8758bb58969) | `` starfive visionfive2: use stable opensbi release ``   |
| [`d5bd79a4`](https://github.com/NixOS/nixos-hardware/commit/d5bd79a48b48a8a4d3daea9bfc71aff6d79ffc80) | `` starfive visionfive2: drop outdated kernel patches `` |