### PR TITLE
chore(flake/nixpkgs): `42c25608` -> `8ecc900b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692264070,
-        "narHash": "sha256-WepAkIL2UcHOj7JJiaFS/vxrA9lklQHv8p+xGL+7oQ0=",
+        "lastModified": 1692356644,
+        "narHash": "sha256-AYkPFT+CbCVSBmh0WwIzPpwhEJ4Yy3A7JZvUkGJIg5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "42c25608aa2ad4e5d3716d8d63c606063513ba33",
+        "rev": "8ecc900b2f695d74dea35a92f8a9f9b32c8ea33d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`5ad01f1b`](https://github.com/NixOS/nixpkgs/commit/5ad01f1b6f1c3a9b0ebe0d81b51761cc80291f82) | `` lib/modules: Report a better error when option tree has bare type ``                           |
| [`e95c64de`](https://github.com/NixOS/nixpkgs/commit/e95c64de4ebbb48700fac130617fa342c73fd9f5) | `` mutt: 2.2.10 -> 2.2.11 ``                                                                      |
| [`809dd083`](https://github.com/NixOS/nixpkgs/commit/809dd083fded871067ac432587bf572acf6012e8) | `` k3d: 5.5.1 -> 5.5.2 ``                                                                         |
| [`ca128263`](https://github.com/NixOS/nixpkgs/commit/ca12826333effc1f79123f2ce49d7d0f612e6dba) | `` mozillavpn: 2.16.0 → 2.16.1 ``                                                                 |
| [`3be1e256`](https://github.com/NixOS/nixpkgs/commit/3be1e25615f95b05405f8c9183390dca3454a407) | `` haskellPackages.streamly_0_9_0: remove override ``                                             |
| [`520c6703`](https://github.com/NixOS/nixpkgs/commit/520c6703d11e733ef88d0d2337b7cde3b4a030cf) | `` helvum: 0.4.0 -> 0.4.1 ``                                                                      |
| [`5d5f0314`](https://github.com/NixOS/nixpkgs/commit/5d5f03140644c578b816fa1f7aacc7633f1af4dd) | `` wayland-proxy-virtwl.updateScript: init ``                                                     |
| [`be50c0e3`](https://github.com/NixOS/nixpkgs/commit/be50c0e37887e53e41027a7671c580b550867c7e) | `` wayland-proxy-virtwl: unstable-2022-09-22 -> unstable-2023-08-13; adopt ``                     |
| [`cba1a49c`](https://github.com/NixOS/nixpkgs/commit/cba1a49c1792c755fa8a53468a7373580cc1eba8) | `` atlauncher: 3.4.28.1 -> 3.4.30.0 ``                                                            |
| [`bcbbd7de`](https://github.com/NixOS/nixpkgs/commit/bcbbd7deee0f44a38477bb5b8ceaf41b471dd793) | `` atlauncher: add --no-launcher-update flag ``                                                   |
| [`49acf60d`](https://github.com/NixOS/nixpkgs/commit/49acf60d72790fa584fe7011857359bcbcbd8fa4) | `` python311Packages.coredis: disable on unsupported Python releases ``                           |
| [`18afd630`](https://github.com/NixOS/nixpkgs/commit/18afd6303664cde157b4753dee2aac1a1143aded) | `` python311Packages.coredis: 4.14.0 -> 4.15.1 ``                                                 |
| [`946dd4c1`](https://github.com/NixOS/nixpkgs/commit/946dd4c1b1262cc75a419e92144b2263833243b0) | `` python311Packages.configargparse: 1.5.5 -> 1.7 ``                                              |
| [`5a96e2dc`](https://github.com/NixOS/nixpkgs/commit/5a96e2dc176df666843770a513e1767119ccafcc) | `` linuxPackages.nvidia_x11_vulkan_beta: 525.47.35 -> 535.43.08 ``                                |
| [`a64a0a37`](https://github.com/NixOS/nixpkgs/commit/a64a0a3755450c42a6667fc1526b8aab3cec69c4) | `` python311Packages.google-cloud-spanner: 3.40.0 -> 3.40.1 ``                                    |
| [`f4170f6a`](https://github.com/NixOS/nixpkgs/commit/f4170f6ab75db36d0ff2536bc6a77a78107b8a54) | `` python311Packages.model-bakery: init at 1.14.0 ``                                              |
| [`babf56d5`](https://github.com/NixOS/nixpkgs/commit/babf56d5b24a91526a208cad1dde3d6ddbe4878c) | `` fractal-next: 5.beta1 -> 5.beta2 ``                                                            |
| [`04ce4237`](https://github.com/NixOS/nixpkgs/commit/04ce4237b3e457c4afc23629d926cae2e998c00a) | `` logseq: 0.9.13 -> 0.9.14 ``                                                                    |
| [`7cf81fca`](https://github.com/NixOS/nixpkgs/commit/7cf81fcadd0130e656aafd57ffb3d586c95caae1) | `` klipper: unstable-2023-08-01 -> unstable-2023-08-15 ``                                         |
| [`d789c729`](https://github.com/NixOS/nixpkgs/commit/d789c729e3acaa37afa0f0517bdf8047890ab769) | `` maintainers: add jacbart ``                                                                    |
| [`cce160ed`](https://github.com/NixOS/nixpkgs/commit/cce160ed3e79e4e059e59986ebc22cc841b4b09b) | `` metasploit: 6.3.29 -> 6.3.30 ``                                                                |
| [`1fdbd4ab`](https://github.com/NixOS/nixpkgs/commit/1fdbd4ab390bf7027f0cf9da38f424247681d2c5) | `` checkov: 2.4.1 -> 2.4.2 ``                                                                     |
| [`385157ce`](https://github.com/NixOS/nixpkgs/commit/385157ced7442ba8c2b66a63ee04341bdc5fe102) | `` trufflehog: 3.52.0 -> 3.52.1 ``                                                                |
| [`8104447c`](https://github.com/NixOS/nixpkgs/commit/8104447c15c488af758eded5587f1b4d671cb293) | `` trufflehog: 3.51.0 -> 3.52.0 ``                                                                |
| [`fb1b76d4`](https://github.com/NixOS/nixpkgs/commit/fb1b76d47e93e1655d84c9c86f87353b47a98463) | `` trufflehog: 3.50.0 -> 3.51.0 ``                                                                |
| [`c82ab5ff`](https://github.com/NixOS/nixpkgs/commit/c82ab5ff26a8f0da77dd7964fed0e65e23e2ac16) | `` python310Packages.django-debug-toolbar: 4.1 -> 4.2 ``                                          |
| [`e19e2222`](https://github.com/NixOS/nixpkgs/commit/e19e2222d7700c12df75f099adfe4486d08ccbd9) | `` python3Packages.pythonNamespacesHook: use findutils from buildPackages (#249864) ``            |
| [`23b16d3f`](https://github.com/NixOS/nixpkgs/commit/23b16d3f2a80704f864696c3ddb94589d131bc48) | `` python310Packages.apycula: 0.8.1 -> 0.8.3 ``                                                   |
| [`cf7ed561`](https://github.com/NixOS/nixpkgs/commit/cf7ed5615df2e96f46e5f4d7e830b00d3ddbd995) | `` terraform-providers.aws: 5.12.0 -> 5.13.0 ``                                                   |
| [`bc9794c4`](https://github.com/NixOS/nixpkgs/commit/bc9794c4f4a9b79b7340f121f9b4de85ec6397f8) | `` terraform-providers.huaweicloud: 1.54.0 -> 1.54.1 ``                                           |
| [`8f24cf5c`](https://github.com/NixOS/nixpkgs/commit/8f24cf5ca12fa7e9da77ef4854005b0bd91c7a5b) | `` terraform-providers.baiducloud: 1.19.11 -> 1.19.12 ``                                          |
| [`91bedaf6`](https://github.com/NixOS/nixpkgs/commit/91bedaf6ded13bf84e63919214af6e982e1bdff2) | `` terraform-providers.azurerm: 3.69.0 -> 3.70.0 ``                                               |
| [`3a928177`](https://github.com/NixOS/nixpkgs/commit/3a928177666b7f0ce8576c7a198c642477c1f655) | `` python310Packages.gridnet: 4.2.0 -> 4.3.0 ``                                                   |
| [`0ab916fb`](https://github.com/NixOS/nixpkgs/commit/0ab916fb41d24df5cfe04e64aba6f30db9cee52d) | `` terraform-providers.talos: 0.2.1 -> 0.3.0 ``                                                   |
| [`6d72a90d`](https://github.com/NixOS/nixpkgs/commit/6d72a90de9d5b2b55dafb15a2d5cacc35dc2686a) | `` grype: added kashw2 as maintainer ``                                                           |
| [`a8983633`](https://github.com/NixOS/nixpkgs/commit/a8983633d95d66aba1435c67f1f9fb5acfe6e264) | `` grype: 0.65.1 -> 0.65.2 ``                                                                     |
| [`f88e10fe`](https://github.com/NixOS/nixpkgs/commit/f88e10fe5999f9d8fb369f5de7167034ea32d144) | `` maintainers: add kashw2 ``                                                                     |
| [`a7aed5b8`](https://github.com/NixOS/nixpkgs/commit/a7aed5b8abe2824a58690627dd77965567654c80) | `` lcsync: init at 0.2.1 ``                                                                       |
| [`ca5c1811`](https://github.com/NixOS/nixpkgs/commit/ca5c18110767a5ac3b23c7c93ba7adb38adc7378) | `` cve-bin-tool: add wheel dependency to pinned packaging ``                                      |
| [`bf15db13`](https://github.com/NixOS/nixpkgs/commit/bf15db136f804fd147b4ddc890577034f3833f0a) | `` cobang: minor fix to patch replacing poetry with poetry-core ``                                |
| [`b8784ade`](https://github.com/NixOS/nixpkgs/commit/b8784ade9e56a9b3c9b78701cbc5ee101fccefa6) | `` python3.pkgs.bitlist: 1.1.0 -> 1.2.0 ``                                                        |
| [`b70fa47a`](https://github.com/NixOS/nixpkgs/commit/b70fa47a8f7ddc51d3df7c37065424eba65440ad) | `` python3.pkgs.parts: 1.6.0 -> 1.7.0 ``                                                          |
| [`7849e3cb`](https://github.com/NixOS/nixpkgs/commit/7849e3cbf9b6720a4c084d89d0a27d6293ca90b5) | `` trufflehog: 3.49.0 -> 3.50.0 ``                                                                |
| [`12cdfb86`](https://github.com/NixOS/nixpkgs/commit/12cdfb86b69b358814a7ccc616f4572ae3902060) | `` corrscope: remove setuptools dependency ``                                                     |
| [`bc86c9e2`](https://github.com/NixOS/nixpkgs/commit/bc86c9e2d5dcb96e6569467409d54e0f4d30017b) | ``  python311Packages.pyflume: update disabled ``                                                 |
| [`dfb7a607`](https://github.com/NixOS/nixpkgs/commit/dfb7a6070b73620d2c5b822112ae0f723ab4f59d) | `` python311Packages.pyflume: add changelog to meta ``                                            |
| [`aeb682fc`](https://github.com/NixOS/nixpkgs/commit/aeb682fc00301ac8f4397850bf54cf727826fab1) | `` python311Packages.pyflume: 0.7.1 -> 0.7.2 ``                                                   |
| [`9401ed5d`](https://github.com/NixOS/nixpkgs/commit/9401ed5d36e7b887c9ff48569e606880a26f5d40) | `` python311Packages.renault-api: 0.1.13 -> 0.2.0 ``                                              |
| [`8d1ddf63`](https://github.com/NixOS/nixpkgs/commit/8d1ddf6356c8196b649de663c8546083268df1a6) | `` python311Packages.peaqevcore: 19.0.2 -> 19.0.3 ``                                              |
| [`3cd4b3b7`](https://github.com/NixOS/nixpkgs/commit/3cd4b3b7d08f97c0bb88abbdf4f80d46386c8f8d) | `` ruff: 0.0.284 -> 0.0.285 ``                                                                    |
| [`4db9bf51`](https://github.com/NixOS/nixpkgs/commit/4db9bf514b10ce1e7014475a9ce6801f5d49e027) | `` python311Packages.pontos: 23.7.7 -> 23.8.2 ``                                                  |
| [`f9a4c63e`](https://github.com/NixOS/nixpkgs/commit/f9a4c63e953337c8c56316c89c57813473e930d5) | `` python311Packages.policyuniverse: 1.5.1.20230813 -> 1.5.1.20230817 ``                          |
| [`c3ab95fd`](https://github.com/NixOS/nixpkgs/commit/c3ab95fd0ae24cc7444924f4189f8226f116ae93) | `` python311Packages.mypy-boto3-s3: 1.28.19 -> 1.28.27 ``                                         |
| [`1b37a6d4`](https://github.com/NixOS/nixpkgs/commit/1b37a6d482ea2172ba0fa26e2f911235388ad47e) | `` python311Packages.mypy-boto3-builder: 7.17.2 -> 7.17.3 ``                                      |
| [`5ca4089d`](https://github.com/NixOS/nixpkgs/commit/5ca4089d6fb8ed73fd0859d6c2052aad0ce72055) | `` aws-mfa: fix script duplication when installing with installer ``                              |
| [`c59f86ca`](https://github.com/NixOS/nixpkgs/commit/c59f86ca6d118ec24f397aeb44c14ce54d60cc96) | `` python311Packages.dbus-fast: 1.91.2 -> 1.91.4 ``                                               |
| [`7b593fbf`](https://github.com/NixOS/nixpkgs/commit/7b593fbfd4db7b02475a93fef10611fbdd80b175) | `` python311Packages.boschshcpy: 0.2.65 -> 0.2.66 ``                                              |
| [`0fce2ea3`](https://github.com/NixOS/nixpkgs/commit/0fce2ea3f28da352df891f56aacb352bac7ccdd7) | `` qt6Packages.kcoreaddons: drop ``                                                               |
| [`ec6b3cee`](https://github.com/NixOS/nixpkgs/commit/ec6b3ceeecf7ba5f6de8c5da7f92089f96fce684) | `` kde/frameworks: 5.108 -> 5.109 ``                                                              |
| [`4e1be9a1`](https://github.com/NixOS/nixpkgs/commit/4e1be9a17b5c37db671b775cf6e633aaee5313d6) | `` elasticsearch-curator: 8.0.4 -> 8.0.8 ``                                                       |
| [`c2297926`](https://github.com/NixOS/nixpkgs/commit/c22979269f89c3cc576ce1f8f28fb01aa2fd896c) | `` python311Packages.elasticsearch8: 8.7.0 -> 8.9.0 ``                                            |
| [`82a6aa80`](https://github.com/NixOS/nixpkgs/commit/82a6aa8061481a8f621d1bc80482ecc09368999e) | `` treesheets: unstable-2023-08-10 -> unstable-2023-08-17 ``                                      |
| [`cf0aa676`](https://github.com/NixOS/nixpkgs/commit/cf0aa676349f9dd3745e820fc1edaf3bd9cceb4d) | `` python311Packages.es-client: 8.7.0 -> 8.9.0 ``                                                 |
| [`3bbc6e4d`](https://github.com/NixOS/nixpkgs/commit/3bbc6e4da35476bc2c780981c9099f676f357c8a) | `` tailspin: 0.1.1 -> 1.4.0 ``                                                                    |
| [`5208e8e4`](https://github.com/NixOS/nixpkgs/commit/5208e8e4997e3e4424628ef2b4977af18ba0a567) | `` python311Packages.irc: enable tests ``                                                         |
| [`48fb6b9c`](https://github.com/NixOS/nixpkgs/commit/48fb6b9ca318f4c089e6d6bdc1ae6580a2771204) | `` python3.pkgs.schwifty: add missing build dependencies ``                                       |
| [`baf834d4`](https://github.com/NixOS/nixpkgs/commit/baf834d40d5451aae537fee946aa9adcfe0ffa2b) | `` python310Packages.irc: add changelog to meta ``                                                |
| [`20af1d2d`](https://github.com/NixOS/nixpkgs/commit/20af1d2d9f3c1264fd278a5cbc853a0f336333fb) | `` python3.pkgs.versionfinder: add pip to test dependencies ``                                    |
| [`fed40d2a`](https://github.com/NixOS/nixpkgs/commit/fed40d2a10a554cd58298ebac75c929dc4ba1cae) | `` python310Packages.jupyterhub-tmpauthenticator: update disabled ``                              |
| [`cc4ecf1e`](https://github.com/NixOS/nixpkgs/commit/cc4ecf1ef26df974e29439976126214055553a46) | `` python310Packages.jupyterhub-tmpauthenticator: add changelog to meta ``                        |
| [`5953a946`](https://github.com/NixOS/nixpkgs/commit/5953a946eac43a458cd37826022ef3265379d0eb) | `` maizzle: use buildNpmPackage ``                                                                |
| [`f834047d`](https://github.com/NixOS/nixpkgs/commit/f834047dec88e06a937c0be025e6b251b6127ff7) | `` awscli2: enable building without pip in the environment ``                                     |
| [`e2a27bf7`](https://github.com/NixOS/nixpkgs/commit/e2a27bf705825f39f734c391671847083394d785) | `` python3.pkgs.pylint: unpin setuptools ``                                                       |
| [`6e81ef54`](https://github.com/NixOS/nixpkgs/commit/6e81ef545b19868a10bca8a32c98e9728c2e8e2c) | `` ocamlPackages.ppx_inline_test: 0.15.0 → 0.15.1 ``                                              |
| [`778e5e88`](https://github.com/NixOS/nixpkgs/commit/778e5e88025101ab1f9835555d927de3960abe44) | `` ocamlPackages.ocamlformat: disable old versions for OCaml ≥ 5.0 ``                             |
| [`428862de`](https://github.com/NixOS/nixpkgs/commit/428862de06da5bb7a402b945560dd1d021f4291f) | `` ocamlPackages.odoc-parser: disable old versions for OCaml ≥ 5.0 ``                             |
| [`c671d94b`](https://github.com/NixOS/nixpkgs/commit/c671d94bdad805f0d3e1df9810a04695dee7b83c) | `` libvgm: unstable-2023-05-17 -> unstable-2023-08-14 ``                                          |
| [`bd0b732b`](https://github.com/NixOS/nixpkgs/commit/bd0b732befccb5dc1ecccef1df1f29bb5902479f) | `` dwm: use correct hash in example ``                                                            |
| [`9fd74d2f`](https://github.com/NixOS/nixpkgs/commit/9fd74d2f9ad8fe26dcaa0a2e0210f6320787390a) | `` ip2unix: 2.1.4 -> 2.2.0 ``                                                                     |
| [`2a14e196`](https://github.com/NixOS/nixpkgs/commit/2a14e196d64bac3f9573932283183a65daa0a9d6) | `` python310Packages.types-redis: 4.6.0.3 -> 4.6.0.4 ``                                           |
| [`caa3aefd`](https://github.com/NixOS/nixpkgs/commit/caa3aefddd98eaf349c3097c978f85ad11a97904) | `` python3.pkgs.levenshtein: update to cython 3 ``                                                |
| [`e2d726c1`](https://github.com/NixOS/nixpkgs/commit/e2d726c1517224d92673829fc30ccc98b38db332) | `` python3Packages.unidic: init at 1.1.0 ``                                                       |
| [`3f41c7d4`](https://github.com/NixOS/nixpkgs/commit/3f41c7d4df3c263bd1f0f5f98d496594cc31baab) | `` python3Packages.ipadic: init at 1.0.0 ``                                                       |
| [`89fac5de`](https://github.com/NixOS/nixpkgs/commit/89fac5de507942fd738462ec0ed0e1dadd8d4483) | `` python3Packages.fugashi: init at 1.2.1 ``                                                      |
| [`1a7ec392`](https://github.com/NixOS/nixpkgs/commit/1a7ec392918216d897da75c4eb67e2a0d9a89392) | `` python3.pkgs.libtmux: remove setuptools build dependency ``                                    |
| [`f7b23c20`](https://github.com/NixOS/nixpkgs/commit/f7b23c206a0c0869676880f7fb85bb1587a0ecbc) | `` python310Packages.irc: 20.1.0 -> 20.3.0 ``                                                     |
| [`eb2901d5`](https://github.com/NixOS/nixpkgs/commit/eb2901d582733d83e326bb5f025aab1858219ff9) | `` eask: use buildNpmPackage ``                                                                   |
| [`9d441104`](https://github.com/NixOS/nixpkgs/commit/9d441104d3c2b8617c3f2c335f8d1e7ccad30697) | `` public-inbox: fix tests ``                                                                     |
| [`3e28a234`](https://github.com/NixOS/nixpkgs/commit/3e28a234fb5ee2562b4c9206354b38970e2be57e) | `` python310Packages.flower: 2.0.0 -> 2.0.1 ``                                                    |
| [`f1096ca5`](https://github.com/NixOS/nixpkgs/commit/f1096ca538292d7523e95dc114dd27589ca7c0bc) | `` timg: 1.5.1 -> 1.5.2 ``                                                                        |
| [`6e484b9d`](https://github.com/NixOS/nixpkgs/commit/6e484b9de75676468f071d439abd29183264eb4a) | `` python3.pkgs.plux: 1.3.1 -> 1.4.0 ``                                                           |
| [`677f8529`](https://github.com/NixOS/nixpkgs/commit/677f85296c2ec7e2cf2e0e183f1ccff19926debd) | `` cava: 0.9.0 -> 0.9.1 ``                                                                        |
| [`bad4b37c`](https://github.com/NixOS/nixpkgs/commit/bad4b37c7e6a1ce459dd6de6d8fb02d8050e8e1f) | `` Remove turion (myself) as maintainer from some packages ``                                     |
| [`e7a42f41`](https://github.com/NixOS/nixpkgs/commit/e7a42f41939c0a6188a5aa9b96486ee69212b3d5) | `` python310Packages.jupyterhub-tmpauthenticator: 0.6 -> 1.0.0 ``                                 |
| [`c4ed81e1`](https://github.com/NixOS/nixpkgs/commit/c4ed81e15b8e401258ca628e6fd1d1090749c19a) | `` google-cursor: init at 2.0.0 ``                                                                |
| [`2b980e53`](https://github.com/NixOS/nixpkgs/commit/2b980e53c3ea1353c2ae7fdc0a8ae7dc3c6155b9) | `` tui-journal: 0.3.0 -> 0.3.1 ``                                                                 |
| [`ca6560f6`](https://github.com/NixOS/nixpkgs/commit/ca6560f60187b73b5c6ecd8b7207deaf7a0a14e4) | `` alass: make meta.description 'subtitle' plural, and add mainProgram ``                         |
| [`fc446828`](https://github.com/NixOS/nixpkgs/commit/fc446828bfab11b309ac7117e1d5bf67d71c5f46) | `` cargo-zigbuild: 0.17.0 -> 0.17.1 ``                                                            |
| [`067cf755`](https://github.com/NixOS/nixpkgs/commit/067cf755987629a10ff823b0f0b5de5ea8bfd46c) | `` thunderbird: 115.1.0 -> 115.1.1 ``                                                             |
| [`01e59d08`](https://github.com/NixOS/nixpkgs/commit/01e59d081addf84fdf7f664b21bc5a7f8adce3c2) | `` thunderbird-bin: 115.1.0 -> 115.1.1 ``                                                         |
| [`26d2c8bb`](https://github.com/NixOS/nixpkgs/commit/26d2c8bbea353c87461a91cdf056e8facded5418) | `` python3Packages.datefinder: init at 0.7.3 ``                                                   |
| [`b22003dc`](https://github.com/NixOS/nixpkgs/commit/b22003dcc4fd4e6227e3e784a07944456bb6aca4) | `` twingate: 1.0.83 -> 2023.227.93198 (#249324) ``                                                |
| [`8cd56a3b`](https://github.com/NixOS/nixpkgs/commit/8cd56a3b7a2c4bbb7a9b8b117fdaab08db39ea30) | `` Documentation: nixpkgs manual: move Python reference to the top of Python chapter (#247117) `` |
| [`1d89d45e`](https://github.com/NixOS/nixpkgs/commit/1d89d45e25c8e2be7f89a04c956013465752ec1d) | `` python310Packages.plaid-python: 15.2.0 -> 15.4.0 ``                                            |
| [`35473208`](https://github.com/NixOS/nixpkgs/commit/35473208fefcdb049a6ac3ad3febb112a3f8c741) | `` ligo: 0.71.1 -> 0.72.0 ``                                                                      |
| [`fbedb8d6`](https://github.com/NixOS/nixpkgs/commit/fbedb8d6e01320d05173c708422f66f884e9911f) | `` nvd: reformat using `nixpkgs-fmt` and update minor things ``                                   |
| [`f6c1d1d5`](https://github.com/NixOS/nixpkgs/commit/f6c1d1d593ce67c826336a3962cd4e77a8f3c471) | `` schemacrawler: init at 16.20.4 ``                                                              |
| [`e0b33a99`](https://github.com/NixOS/nixpkgs/commit/e0b33a99960d68bfab67352982902a5349b92a3c) | `` rust-analyzer-unwrapped: 2023-08-07 -> 2023-08-14 ``                                           |
| [`5da7c5ad`](https://github.com/NixOS/nixpkgs/commit/5da7c5adee784ed040861f740546f715121d3060) | `` nvd: add `meta.mainProgram` ``                                                                 |
| [`5e29c709`](https://github.com/NixOS/nixpkgs/commit/5e29c709a07120cab1d928de1f8aaf2ba1f555da) | `` nvd: use `finalAttrs` pattern ``                                                               |
| [`ba50fb0b`](https://github.com/NixOS/nixpkgs/commit/ba50fb0bbb47285dba05317e9f3d95d11288814c) | `` python310Packages.ecs-logging: 2.0.2 -> 2.1.0 ``                                               |
| [`959d8a84`](https://github.com/NixOS/nixpkgs/commit/959d8a84bff0f9bff8525b9b074085269ddf5d79) | `` fix version ``                                                                                 |
| [`08ab4629`](https://github.com/NixOS/nixpkgs/commit/08ab4629b1144915f66fc7dc71260a5fc5be5070) | `` leafnode: 20121101 -> 20140727; leafnode1: init at 1.12 ``                                     |
| [`07afac88`](https://github.com/NixOS/nixpkgs/commit/07afac881c8faa97614b60fe19f28d551b206f41) | `` added passthru tests ``                                                                        |
| [`b0a71c5f`](https://github.com/NixOS/nixpkgs/commit/b0a71c5f75dd6ca700426e8bda03e8031d8f153c) | `` stig: 0.12.2a0 -> 0.12.5a0 ``                                                                  |
| [`8d96cbfd`](https://github.com/NixOS/nixpkgs/commit/8d96cbfdcad1bd42c02611e93900cf5763cc6728) | `` ocaml-protoc-plugin: init at 4.3.1 ``                                                          |
| [`02bbd3d8`](https://github.com/NixOS/nixpkgs/commit/02bbd3d845de685c0fe059e8e6498d392dced64b) | `` maintainers: add GirardR1006 ``                                                                |
| [`650d6258`](https://github.com/NixOS/nixpkgs/commit/650d6258c833427c4af0d652ce84edfd0b8ebfed) | `` libxc: increase test timeout ``                                                                |
| [`dbe4fc5f`](https://github.com/NixOS/nixpkgs/commit/dbe4fc5f79accc87046b33f6ea80e58f36ef4018) | `` python310Packages.pex: 2.1.141 -> 2.1.142 ``                                                   |
| [`00f2f4b7`](https://github.com/NixOS/nixpkgs/commit/00f2f4b727151ae4031e82a572ccbe5f8b54c4f3) | `` mpremote: init at 1.20.0 ``                                                                    |
| [`48a8812b`](https://github.com/NixOS/nixpkgs/commit/48a8812b6e995151c676cd19259f887e8448e23d) | `` gosec: 2.16.0 -> 2.17.0 ``                                                                     |
| [`57c54aff`](https://github.com/NixOS/nixpkgs/commit/57c54aff55b9e382689dd2e4e8006e8d5949ee5e) | `` chromium: 115.0.5790.170 -> 116.0.5845.96 ``                                                   |
| [`aea1ac02`](https://github.com/NixOS/nixpkgs/commit/aea1ac02dbf8c1325364ae6ca8107e76af20cebb) | `` ungoogled-chromium: 115.0.5790.170 -> 116.0.5845.96 ``                                         |
| [`e321070e`](https://github.com/NixOS/nixpkgs/commit/e321070ea719b0fea42bb42e1cbc196d2aa4e418) | `` python310Packages.mkdocs-mermaid2-plugin: add format ``                                        |
| [`a3236cd2`](https://github.com/NixOS/nixpkgs/commit/a3236cd260ac8832283f4a453cbaa8473aa65eef) | `` python310Packages.mkdocs-mermaid2-plugin: add changelog to meta ``                             |
| [`8660fdf5`](https://github.com/NixOS/nixpkgs/commit/8660fdf5140d46029a6ba6f0bc0c568980c3d6f1) | `` pyscf: 2.2.0 -> 2.3.0 ``                                                                       |
| [`4f42b135`](https://github.com/NixOS/nixpkgs/commit/4f42b1358c30b849db2fe797239551efb55e90e4) | `` python310Packages.mkdocs-mermaid2-plugin: 0.6.0 -> 1.0.1 ``                                    |
| [`c7b994dd`](https://github.com/NixOS/nixpkgs/commit/c7b994dd5f088c8eea6a9e954af36865a3aa56cd) | `` mautrix-whatsapp: 0.9.0 -> 0.10.0 ``                                                           |
| [`83842abd`](https://github.com/NixOS/nixpkgs/commit/83842abd0dc0e3f768b3fc93065e94208276c9db) | `` python311Packages.json-stream-rs-tokenizer: 0.4.16 -> 0.4.22 ``                                |
| [`fc2d02fe`](https://github.com/NixOS/nixpkgs/commit/fc2d02fe670060eea4b92febf6bf068b1e0a3b4a) | `` python311Packages.json-stream: 2.3.0 -> 2.3.2 ``                                               |
| [`c9c28279`](https://github.com/NixOS/nixpkgs/commit/c9c282791d7d3934203a40979e34c9ef218712a5) | `` asciinema: 2.2.0 -> 2.3.0 ``                                                                   |
| [`73846153`](https://github.com/NixOS/nixpkgs/commit/73846153396e6019fafcff1a07380abe3998fed0) | `` ocamlPackages.dscheck: 0.1.0 → 0.2.0 ``                                                        |
| [`728dff52`](https://github.com/NixOS/nixpkgs/commit/728dff52cf312910cbdfa8aca41ee78aea5446da) | `` python310Packages.apache-beam: mark as broken ``                                               |
| [`69a9a727`](https://github.com/NixOS/nixpkgs/commit/69a9a727ad058d13ff54383748811bfd6807fb26) | `` python3.pkgs.gcal-sync: fix sandbox darwin build ``                                            |
| [`28b79ea6`](https://github.com/NixOS/nixpkgs/commit/28b79ea664bac7a354860e4d667769cf1548e761) | `` vimPlugins.nvim-treesitter-textsubjects: init at 2023-08-03 ``                                 |
| [`ef82c696`](https://github.com/NixOS/nixpkgs/commit/ef82c69693a25d682b078d422fd08951ecc73c67) | `` vimPlugins.nvim-treesitter: update grammars ``                                                 |
| [`dba90241`](https://github.com/NixOS/nixpkgs/commit/dba9024143b5b7027c66d3358164b54b5449c043) | `` vimPlugins: update ``                                                                          |