### PR TITLE
chore(flake/nix-index-database): `f4d70d09` -> `4e3e9483`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -312,11 +312,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1691897365,
-        "narHash": "sha256-jvWIU4ht3YAmF8TDVM2Ps2+Gf4MtNGLL1zEWQZdTrzU=",
+        "lastModified": 1692500434,
+        "narHash": "sha256-DCfXMxzELkSsJ9DpDFfl0FGXscUUEgJYNO2qbX78FMk=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "f4d70d098f066a30c7087144063dca179495f7d6",
+        "rev": "4e3e9483620334a08f942d61cc834b45d12505aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                  |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`4e3e9483`](https://github.com/nix-community/nix-index-database/commit/4e3e9483620334a08f942d61cc834b45d12505aa) | `` flake.lock: Update `` |