### PR TITLE
chore(flake/home-manager): `958c0630` -> `ea59b79f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -205,11 +205,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692503956,
-        "narHash": "sha256-MOA6FKc1YgfGP3ESnjSYfsyJ1BXlwV5pGlY/u5XdJfY=",
+        "lastModified": 1692686040,
+        "narHash": "sha256-4GkXTC7sXpEL40QbJip49qsINAH+aKSciPT/1Pz6hfM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "958c06303f43cf0625694326b7f7e5475b1a2d5c",
+        "rev": "ea59b79f31beaf4a8cb0ea2fc4dfba5732e4212a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`ea59b79f`](https://github.com/nix-community/home-manager/commit/ea59b79f31beaf4a8cb0ea2fc4dfba5732e4212a) | `` bat: generate cache file in XDG cache home ``            |
| [`ca4126e3`](https://github.com/nix-community/home-manager/commit/ca4126e3c568be23a0981c4d69aed078486c5fce) | `` nixos: only refer to `users.users` if needed ``          |
| [`a0ad9817`](https://github.com/nix-community/home-manager/commit/a0ad98174c7a1f9747a76025a83b50e37181bbde) | `` home-cursor: remove IFD when linking icon directories `` |