### PR TITLE
chore(flake/nixpkgs): `91a22f76` -> `b85ed9dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692638711,
-        "narHash": "sha256-J0LgSFgJVGCC1+j5R2QndadWI1oumusg6hCtYAzLID4=",
+        "lastModified": 1692734709,
+        "narHash": "sha256-SCFnyHCyYjwEmgUsHDDuU0TsbVMKeU1vwkR+r7uS2Rg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "91a22f76cd1716f9d0149e8a5c68424bb691de15",
+        "rev": "b85ed9dcbf187b909ef7964774f8847d554fab3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`22e5560c`](https://github.com/NixOS/nixpkgs/commit/22e5560c8e789172ca7f78b1917c964e6cc0776c) | `` klipper-genconf: remove AVR cross-compiler dependency ``                       |
| [`53771fcb`](https://github.com/NixOS/nixpkgs/commit/53771fcb75525d9a25abf3f8f57e31e87a4fd339) | `` nitter: unstable-2023-07-21 -> unstable-2023-08-08 ``                          |
| [`044e8c4e`](https://github.com/NixOS/nixpkgs/commit/044e8c4e443c6f5c9e4a8f763c6e6314bf90732c) | `` llvmPackages_git: Port stdenv fix for cxx-headers ``                           |
| [`6ba1b5b0`](https://github.com/NixOS/nixpkgs/commit/6ba1b5b0b3e57a7def4e837f5599aa3ac68589a8) | `` llvmPackages_15, llvmPackages_16: Make the pkgsLLVM.stdenv work ``             |
| [`434fe8e1`](https://github.com/NixOS/nixpkgs/commit/434fe8e1ce5c8fd2ad58402da85bab0aed6ad94e) | `` maintainers: remove @alexeyre from maintainers-list.nix ``                     |
| [`cb14c825`](https://github.com/NixOS/nixpkgs/commit/cb14c825c81f45a057ec44839e3863d91a62368f) | `` scli: remove @alexeyre from maintainers ``                                     |
| [`be152a84`](https://github.com/NixOS/nixpkgs/commit/be152a8457a80070ee6fda868a274bf252f6b4d7) | `` nimbo: remove @alexeyre from maintainers ``                                    |
| [`be74b2f6`](https://github.com/NixOS/nixpkgs/commit/be74b2f61e9314459f7381aab2f265857a6c5f2d) | `` clima: init at 1.1.0 ``                                                        |
| [`23733b59`](https://github.com/NixOS/nixpkgs/commit/23733b59b6771c0f1c668f632f494b958325cdbd) | `` python3Packages.protonvpn-nm-lib: 3.14.0 -> 3.16.0 ``                          |
| [`1a0cd8ae`](https://github.com/NixOS/nixpkgs/commit/1a0cd8ae4f6df3642c0aa2c91474d0f5f1fe2b34) | `` xc: 0.4.1 -> 0.5.0 ``                                                          |
| [`ff51f307`](https://github.com/NixOS/nixpkgs/commit/ff51f307f5fbdf5cc3328c8903da10bb6c834256) | `` dysk: 2.7.2 -> 2.8.0 ``                                                        |
| [`80018aaa`](https://github.com/NixOS/nixpkgs/commit/80018aaa2955777edadcbed6efae5ea91a2c4776) | `` yazi: init at 0.1.3 ``                                                         |
| [`a88fa29c`](https://github.com/NixOS/nixpkgs/commit/a88fa29c897d595f7bcd3c64e4c123257ea5a838) | `` arkade: 0.9.23 -> 0.9.26 ``                                                    |
| [`0bcaa8a4`](https://github.com/NixOS/nixpkgs/commit/0bcaa8a46495585bdc332ee93a68bb540f75bd77) | `` python310Packages.readability-lxml: disable broken test on darwin (#250407) `` |
| [`3eb02145`](https://github.com/NixOS/nixpkgs/commit/3eb0214551f0b4a3add6daefee2f15b868902079) | `` modules/image/repart: Fix stripNixStorePrefix ``                               |
| [`e679b6db`](https://github.com/NixOS/nixpkgs/commit/e679b6dbee9cb2eee2f77e7f5c38fddccc1bd8e6) | `` eza: 0.10.7 -> 0.10.8 ``                                                       |
| [`3b6bef44`](https://github.com/NixOS/nixpkgs/commit/3b6bef448e40f979f922318094971f3f18ee8be0) | `` zig.hook: clean up ``                                                          |
| [`fcdf10cd`](https://github.com/NixOS/nixpkgs/commit/fcdf10cd12c106d1f8e2fb0def3941abda504233) | `` zig: restore `with lib.maintainers;` ``                                        |
| [`1c505f6b`](https://github.com/NixOS/nixpkgs/commit/1c505f6bb3d0fa56df1308faa4f8c9d9861ddc5a) | `` knot-resolver: 5.6.0 -> 5.7.0 ``                                               |
| [`c5e6c8ad`](https://github.com/NixOS/nixpkgs/commit/c5e6c8adc4c242010c6968b90d921e30b5e5cbcd) | `` weechat-unwrapped: 4.0.3 -> 4.0.4 ``                                           |
| [`2f13febc`](https://github.com/NixOS/nixpkgs/commit/2f13febc35d508b4534b5178928d0d2b3c9eac7d) | `` salt: fix duplicate scripts in wheel ``                                        |
| [`f8737ca5`](https://github.com/NixOS/nixpkgs/commit/f8737ca5baf37a34273ff5feaddc75441993cc73) | `` python311Packages.python-bsblan: 0.5.11 -> 0.5.12 ``                           |
| [`b9a318ca`](https://github.com/NixOS/nixpkgs/commit/b9a318cad1652cef0b9a10795b5c5e41f2086329) | `` bpftune: unstable-2023-08-02 -> unstable-2023-08-22 ``                         |
| [`7369a9e0`](https://github.com/NixOS/nixpkgs/commit/7369a9e03adefecb47b9f470ff826f5fde4836a8) | `` python311Packages.datasette-publish-fly: 1.3 -> 1.3.1 ``                       |
| [`db75fab6`](https://github.com/NixOS/nixpkgs/commit/db75fab6b54ed9f2cfaccd73bbeeb8d622e98bb2) | `` python311Packages.pontos: 23.8.2 -> 23.8.4 ``                                  |
| [`6c33c701`](https://github.com/NixOS/nixpkgs/commit/6c33c701eba7c01f082b776cd03306d9f8501ee0) | `` python311Packages.meshtastic: 2.2.0 -> 2.2.1 ``                                |
| [`41d1f44b`](https://github.com/NixOS/nixpkgs/commit/41d1f44b9da378c95cd82428aa568a2719fe397c) | `` python311Packages.scmrepo: 1.2.1 -> 1.3.1 ``                                   |
| [`93cdb92a`](https://github.com/NixOS/nixpkgs/commit/93cdb92abd76e364b0fab313a379227304b543a7) | `` chezmoi: 2.37.0 -> 2.38.0 ``                                                   |
| [`dc3b8749`](https://github.com/NixOS/nixpkgs/commit/dc3b874953b5e294a6db557d98f9fd4bc65a1c8f) | `` python311Packages.odp-amsterdam: 5.2.0 -> 5.3.1 ``                             |
| [`544941c5`](https://github.com/NixOS/nixpkgs/commit/544941c5f464900563e2b8e46955c8511c4793d9) | `` python311Packages.identify: 2.5.26 -> 2.5.27 ``                                |
| [`eab40575`](https://github.com/NixOS/nixpkgs/commit/eab405751b36473d1de86d952add1bfef5bcc018) | `` beautysh, python3.pkgs.beautysh: move into python-modules ``                   |
| [`fdf4e6f8`](https://github.com/NixOS/nixpkgs/commit/fdf4e6f8025d45f0ac7fde4351be395ebeb247d9) | `` liferea: add yayayayaka to maintainers ``                                      |
| [`49b34610`](https://github.com/NixOS/nixpkgs/commit/49b346105a56c3a0524d9e088a8ebeb78e0b1f00) | `` salt: 3006.1 -> 3006.2 ``                                                      |
| [`79b8b876`](https://github.com/NixOS/nixpkgs/commit/79b8b876e5d33db33c1bf33d6db9edb164b0a393) | `` liferea: 1.15.0 -> 1.15.1 ``                                                   |
| [`8813ba71`](https://github.com/NixOS/nixpkgs/commit/8813ba71fba4a77bb1ec64012456d8c530c6dabc) | `` cutter: 2.3.0 -> 2.3.1 ``                                                      |
| [`81dfcaff`](https://github.com/NixOS/nixpkgs/commit/81dfcaff3cbed30ab005d071bd4c49e23b96b31b) | `` dftd4: 3.5.0 -> 3.6.0 ``                                                       |
| [`8ae1e455`](https://github.com/NixOS/nixpkgs/commit/8ae1e455fa9048b631b79407ae6ab998144a9c10) | `` bosh-cli: 7.3.1 -> 7.4.0 ``                                                    |
| [`ba15cacd`](https://github.com/NixOS/nixpkgs/commit/ba15cacd5498f8fcd683bf525c2b5652787f6f0a) | `` cirrus-cli: 0.101.2 -> 0.102.0 ``                                              |
| [`3cd98eab`](https://github.com/NixOS/nixpkgs/commit/3cd98eabd533684052e34d98a5433d669c6ef00a) | `` dgraph: 23.0.1 -> 23.1.0 ``                                                    |
| [`004d05e1`](https://github.com/NixOS/nixpkgs/commit/004d05e15bc65be42369cd2e395dcbe8a62faa50) | `` ctlptl: 0.8.20 -> 0.8.21 ``                                                    |
| [`7828a994`](https://github.com/NixOS/nixpkgs/commit/7828a9947f13f13fdd7bd6d1545ebea13c1a7967) | `` esphome: 2023.8.1 -> 2023.8.2 ``                                               |
| [`b2df84ff`](https://github.com/NixOS/nixpkgs/commit/b2df84ffde8e179806d0977200d289420036e740) | `` python310Packages.hwi: remove postPatch section ``                             |
| [`c5d339d7`](https://github.com/NixOS/nixpkgs/commit/c5d339d789fdced8f6a98e0f7078c2e21a2eb90d) | `` python310Packages.hwi: disable on unsupported Python releases ``               |
| [`728a6486`](https://github.com/NixOS/nixpkgs/commit/728a648676525028fe1be3429d589bc88e37f702) | `` python310Packages.hwi: add changelog to meta ``                                |
| [`34d152b7`](https://github.com/NixOS/nixpkgs/commit/34d152b7b5bf8a3ac3eb8181f725ac7adb4917d3) | `` python310Packages.hwi: 2.2.1 -> 2.3.1 ``                                       |
| [`df2dcf61`](https://github.com/NixOS/nixpkgs/commit/df2dcf61225128b08140e75ead7a17f314941485) | `` ocamlPackages.ppxlib: 0.28.0 → 0.30.0 ``                                       |
| [`0f4fcbe6`](https://github.com/NixOS/nixpkgs/commit/0f4fcbe60d9642d9c90ecc4bfa7fb6652235e7c9) | `` ocamlPackages.ppxlib: do not (always) depend on OMP ``                         |
| [`6b5f1432`](https://github.com/NixOS/nixpkgs/commit/6b5f1432ad9171ae72f589155b7023e4b0ca52bb) | `` ocamlPackages.ppx_cstruct: minor cleaning ``                                   |
| [`0beaeb38`](https://github.com/NixOS/nixpkgs/commit/0beaeb3813b7e741b53570dd4bea61ed23c16b7b) | `` python310Packages.dvc-objects: 1.0.0 -> 1.0.1 ``                               |
| [`60f03a0e`](https://github.com/NixOS/nixpkgs/commit/60f03a0e0999e35d38e62a564e9d6d28b802b577) | `` svd2rust: 0.29.0 -> 0.30.0 ``                                                  |
| [`3b2c5a11`](https://github.com/NixOS/nixpkgs/commit/3b2c5a111095eb55d919daa36152557d6f231b2d) | `` terraform-providers.vsphere: 2.4.1 -> 2.4.2 ``                                 |
| [`bfd4528c`](https://github.com/NixOS/nixpkgs/commit/bfd4528c6173a533305964c9c9e9b8d3e399b439) | `` terraform-providers.snowflake: 0.69.0 -> 0.70.0 ``                             |
| [`d546a588`](https://github.com/NixOS/nixpkgs/commit/d546a588b3745d8ecfe433f1d114e44f5a6ad7ba) | `` terraform-providers.scaleway: 2.26.0 -> 2.27.0 ``                              |
| [`4878ad1e`](https://github.com/NixOS/nixpkgs/commit/4878ad1ec67ae54324a0ba5ef212d48572e4755a) | `` terraform-providers.ibm: 1.56.0 -> 1.56.1 ``                                   |
| [`224c72f3`](https://github.com/NixOS/nixpkgs/commit/224c72f329b0435c077fc08219aeb6d7933ea849) | `` terraform-providers.pagerduty: 2.15.3 -> 2.16.0 ``                             |
| [`eb838644`](https://github.com/NixOS/nixpkgs/commit/eb83864410224a5fbbd7459c696a313186802231) | `` terraform-providers.kafka: 0.5.3 -> 0.5.4 ``                                   |
| [`c452d891`](https://github.com/NixOS/nixpkgs/commit/c452d891de573430cb1917e1652e1812874205b5) | `` terraform-providers.google-beta: 4.78.0 -> 4.79.0 ``                           |
| [`fd72caf8`](https://github.com/NixOS/nixpkgs/commit/fd72caf8f3ae41b9d8b4818d3bccab21fc71d1c1) | `` terraform-providers.google: 4.78.0 -> 4.79.0 ``                                |
| [`98bd3a70`](https://github.com/NixOS/nixpkgs/commit/98bd3a70248cff8bbc8cf0f46e2154c6011c73b5) | `` terraform-providers.equinix: 1.14.6 -> 1.14.7 ``                               |
| [`ddc5cbb5`](https://github.com/NixOS/nixpkgs/commit/ddc5cbb5219312003167b97baacd7bcc813b1d6e) | `` terraform-providers.baiducloud: 1.19.12 -> 1.19.13 ``                          |
| [`5f7deca0`](https://github.com/NixOS/nixpkgs/commit/5f7deca07811395911893d07e7ed464fa0700586) | `` python310Packages.pydeps: 1.12.13 -> 1.12.17 ``                                |
| [`2e80470a`](https://github.com/NixOS/nixpkgs/commit/2e80470a1122a2120be91013feba0ab1bfbef442) | `` python3.pkgs.jupytext: relax build dependencies ``                             |
| [`92cbf5e6`](https://github.com/NixOS/nixpkgs/commit/92cbf5e6a08bdeb743828357294e22f02203c52b) | `` pantheon.elementary-feedback: 7.0.0 -> 7.1.0 ``                                |
| [`1d942ec8`](https://github.com/NixOS/nixpkgs/commit/1d942ec8eac20c01826c065dd503b8103005d286) | `` pantheon.elementary-notifications: 7.0.0 -> 7.0.1 ``                           |
| [`3b4550a5`](https://github.com/NixOS/nixpkgs/commit/3b4550a55a31f07912e5c43efe228e7f86e679d4) | `` pantheon.switchboard-plug-keyboard: 3.2.0 -> 3.2.1 ``                          |
| [`ee29c376`](https://github.com/NixOS/nixpkgs/commit/ee29c376c039e2c3c4ec1eadaa5f104b35e56132) | `` swaynag-battery: use sri hash ``                                               |
| [`2e8d7c3f`](https://github.com/NixOS/nixpkgs/commit/2e8d7c3f646e8559e352087f044a88a411fb617b) | `` python310Packages.pydrive2: 1.16.1 -> 1.17.0 ``                                |
| [`bf5e23f4`](https://github.com/NixOS/nixpkgs/commit/bf5e23f44127bcdda62e296878eed48e350817d6) | `` pantheon.xdg-desktop-portal-pantheon: 7.1.0 -> 7.1.1 ``                        |
| [`4b645383`](https://github.com/NixOS/nixpkgs/commit/4b645383ce2bae4968879477a15ecf6cacae48f8) | `` clash: 1.17.0 -> 1.18.0 ``                                                     |
| [`b9d877aa`](https://github.com/NixOS/nixpkgs/commit/b9d877aa268209ca3f1cfec5f06adf7601381411) | `` numlockx: Add meta.mainProgram and clean up ``                                 |
| [`b44f0138`](https://github.com/NixOS/nixpkgs/commit/b44f01382118b47c9ddb161238af7ad9fb59c313) | `` xfce.xfce4-screensaver: Unbreak xfce4-screensaver-configure ``                 |
| [`e1bc5215`](https://github.com/NixOS/nixpkgs/commit/e1bc5215870ff4914018eb3dbdeeffac4b28d781) | `` deepin.deepin-editor: 6.0.10 -> 6.0.11 ``                                      |
| [`ebb4d8a1`](https://github.com/NixOS/nixpkgs/commit/ebb4d8a13f5f73d878543ad94d1b4c557c6f7a08) | `` zig-shell-completions: refactor ``                                             |
| [`fd774bd8`](https://github.com/NixOS/nixpkgs/commit/fd774bd82bfb9ec60f4c9a33971ce97f76028155) | `` zig.hook: reword ``                                                            |
| [`b058a2fc`](https://github.com/NixOS/nixpkgs/commit/b058a2fc2908aa9f7bd5abb66392a53e9e7eeeff) | `` zig: remove with lib ``                                                        |
| [`761aa9bf`](https://github.com/NixOS/nixpkgs/commit/761aa9bf9f0ff6e9600e0178ecfe6740428f71b9) | `` llvmPackages_16.compiler-rt: fix static build on Darwin ``                     |
| [`473bf6de`](https://github.com/NixOS/nixpkgs/commit/473bf6de0148ac53587bf18a6aedd09c86313d64) | `` eartag: 0.4.2 -> 0.4.3 ``                                                      |
| [`17173e96`](https://github.com/NixOS/nixpkgs/commit/17173e961e77e4d539d550cac570a4273adab290) | `` starry: init at 2.0.1 ``                                                       |
| [`3dd5066d`](https://github.com/NixOS/nixpkgs/commit/3dd5066dd323c0ecb40765c7192ccf0de512bed8) | `` csv2svg: init at 0.1.9 ``                                                      |
| [`065f90d2`](https://github.com/NixOS/nixpkgs/commit/065f90d25c2265f6daf2fe2ba4c56c579eba3d48) | `` cudaPackages.autoAddOpenGLRunpathHook: don't skip shared libraries ``          |
| [`4d6982dc`](https://github.com/NixOS/nixpkgs/commit/4d6982dcedf20ff76b3e34321df32a768737c601) | `` klipper: unstable-2023-08-15 -> unstable-2023-08-21 ``                         |
| [`12593047`](https://github.com/NixOS/nixpkgs/commit/12593047a06c462b63f184c70e1c459341ec6e77) | `` python310Packages.dvclive: 2.14.0 -> 2.15.2 ``                                 |
| [`9b562802`](https://github.com/NixOS/nixpkgs/commit/9b562802e0a1ce7c0412bf230bc24fccdfcd94c7) | `` Revert "buildGoModule: set GOPROXY to go default" ``                           |
| [`be4967cc`](https://github.com/NixOS/nixpkgs/commit/be4967cc4e554ec2ecfb87e06b41fe9411892664) | `` colorpicker: switch to Jack12816's fork ``                                     |
| [`51407081`](https://github.com/NixOS/nixpkgs/commit/51407081cd393ce765c9831fd51c501f0623de8a) | `` gh: 2.32.1 -> 2.33.0 ``                                                        |
| [`7cb58cc1`](https://github.com/NixOS/nixpkgs/commit/7cb58cc1532a43fd85ef680381b592ce1abd2187) | `` python311Packages.pysaml2: 7.4.1 -> 7.4.2 ``                                   |
| [`e0e0063d`](https://github.com/NixOS/nixpkgs/commit/e0e0063decbe916d0f38f50218b66ebad1cf4674) | `` USE_SYSTEM_PYBIND11 instead of USE_SYSTEM_BIND11 in torch ``                   |
| [`97ebbdef`](https://github.com/NixOS/nixpkgs/commit/97ebbdef918efcb1875b086d135b965bf9953609) | `` sapling: teach gen-deps.py script to update Cargo.lock ``                      |
| [`74067bbf`](https://github.com/NixOS/nixpkgs/commit/74067bbf9d3b84e8f2db5f612634a69aab41c7ba) | `` python311Packages.xkcdpass: 1.19.3 -> 1.19.4 ``                                |
| [`90979d80`](https://github.com/NixOS/nixpkgs/commit/90979d8013558c8975c0ae8bdca82d9da0f32c6c) | `` oculante: 0.6.69 -> 0.7.2 ``                                                   |
| [`98dc97a1`](https://github.com/NixOS/nixpkgs/commit/98dc97a14cdf8eca42ad8c38ac99e6b98af6ba66) | `` govulncheck: 1.0.0 -> 1.0.1 ``                                                 |
| [`b79f7ccd`](https://github.com/NixOS/nixpkgs/commit/b79f7ccd520dd47a4ef8a31fe1b2ea6b6ff990ac) | `` pest-ide-tools: init at 0.3.3 (#249102) ``                                     |
| [`c66dba33`](https://github.com/NixOS/nixpkgs/commit/c66dba335b44cdae8590f51ebae8acaae3220753) | `` home-assistant: update component-packages ``                                   |
| [`6104a9ef`](https://github.com/NixOS/nixpkgs/commit/6104a9ef2499479a2b3b7798c54c649600045a1d) | `` python311Packages.pyduotecno: init at 2023.8.3 ``                              |
| [`cbdf9c66`](https://github.com/NixOS/nixpkgs/commit/cbdf9c6692ab773b77c9045a6e80165482986d5d) | `` expr: 1.14.1 -> 1.14.3 ``                                                      |
| [`dfa87519`](https://github.com/NixOS/nixpkgs/commit/dfa87519afd30c8d083b854c1fda67efb3650288) | `` fastfetch: 2.0.0 -> 2.0.1 ``                                                   |
| [`4aeaaae5`](https://github.com/NixOS/nixpkgs/commit/4aeaaae5cfa48dd7e3c6cbeff26b1275c437a041) | `` php83: 8.3.0beta2 -> 8.3.0beta3 ``                                             |
| [`c488309e`](https://github.com/NixOS/nixpkgs/commit/c488309eb556aeec1007e40cca8b3093676ce840) | `` home-assistant: update component-packages ``                                   |
| [`95f95dc6`](https://github.com/NixOS/nixpkgs/commit/95f95dc66e129e24c80acdb7b9c3b6df7ac4fc43) | `` python311Packages.aiobafi6: init at 0.8.2 ``                                   |
| [`8b987d57`](https://github.com/NixOS/nixpkgs/commit/8b987d57e0ae0e8324de41d5dbe31c9790640176) | `` abracadabra: 2.2.1 -> 2.2.2 ``                                                 |
| [`b4bf3a54`](https://github.com/NixOS/nixpkgs/commit/b4bf3a54f2ba9b7dac23ac1f542240e7e5f215f3) | `` weechat-unwrapped: patch for perl 5.38 locale issues ``                        |
| [`e55d5188`](https://github.com/NixOS/nixpkgs/commit/e55d51881ea16623b1efb799f5c002ee3c78e379) | `` ocamlPackages.hack_parallel: fix for OCaml 5.0 ``                              |
| [`18ad9d33`](https://github.com/NixOS/nixpkgs/commit/18ad9d33321ebe5b42f21c095d593dcd33dc3f5a) | `` jackett: 0.21.635 -> 0.21.674 ``                                               |
| [`8f508af8`](https://github.com/NixOS/nixpkgs/commit/8f508af8dce8fa5145ef6562449564a6b583da1c) | `` urbanterror: fix `configurePhase` phase ``                                     |
| [`b2871a6c`](https://github.com/NixOS/nixpkgs/commit/b2871a6ca8cfb0e40f74bf004c0f292b9057a08b) | `` ioquake3: fix `preConfigure` phase ``                                          |
| [`5bff7db9`](https://github.com/NixOS/nixpkgs/commit/5bff7db9fcd540318d39685517500caedf8e77c4) | `` nextcloud-client 3.9.2 -> 3.9.3 ``                                             |
| [`a39526b3`](https://github.com/NixOS/nixpkgs/commit/a39526b3ef4488fdb98eabb0cef0985e671a2b5c) | `` nixos/grub: Add submenu for each generation with specialisation ``             |
| [`bff703de`](https://github.com/NixOS/nixpkgs/commit/bff703de2a7c3611c7b00ef15b3d0fb8bd6e5708) | `` rhai-doc: init at 0.2.3 ``                                                     |
| [`7f7b3ef4`](https://github.com/NixOS/nixpkgs/commit/7f7b3ef4a5663623b3c199e774ccd98009d3ecfe) | `` yubikey-manager: 5.1.1 -> 5.2.0 ``                                             |
| [`c0e0d121`](https://github.com/NixOS/nixpkgs/commit/c0e0d1218e806d60332c560e15766a84152c6b2e) | `` python311Packages.dbus-fast: 1.92.0 -> 1.93.0 ``                               |
| [`4920a168`](https://github.com/NixOS/nixpkgs/commit/4920a168dc96f1ea8cc94768f03c8fece6358391) | `` geogebra6: 6-0-785-0 -> 6-0-794-0 ``                                           |
| [`3209524b`](https://github.com/NixOS/nixpkgs/commit/3209524b4b813c0a613750ea288807a17b3a6692) | `` python310Packages.pex: 2.1.142 -> 2.1.143 ``                                   |
| [`b9e923ea`](https://github.com/NixOS/nixpkgs/commit/b9e923ea351145bf4f904e132fcfdbeed45dbe0f) | `` waybar: remove waybar-hyprland ``                                              |
| [`7b864dc3`](https://github.com/NixOS/nixpkgs/commit/7b864dc3ea3c7d25e8968cb959978968171ee128) | `` waybar: add khaneliman to maintainers ``                                       |
| [`c96f76a2`](https://github.com/NixOS/nixpkgs/commit/c96f76a20b1e591d1c8cd261736333cb10cb2017) | `` tokio-console: 0.1.7 -> 0.1.9 ``                                               |
| [`2758be52`](https://github.com/NixOS/nixpkgs/commit/2758be52b51adb40f1b74ce45f0f7902290384b7) | `` gimoji: 0.5.1 -> 0.6.1 ``                                                      |