### PR TITLE
chore(flake/nixos-hardware): `7f183653` -> `817e297f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -327,11 +327,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1692373088,
-        "narHash": "sha256-EPgCecdc9I8aTdmDNoO1l7R72r2WPhZRcesV4nzxBj8=",
+        "lastModified": 1692952286,
+        "narHash": "sha256-TsrtPv3+Q1KR0avZxpiJH+b6fX/R/hEQVHbjl1ebotY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "7f1836531b126cfcf584e7d7d71bf8758bb58969",
+        "rev": "817e297fc3352fadc15f2c5306909aa9192d7d97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                               |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`817e297f`](https://github.com/NixOS/nixos-hardware/commit/817e297fc3352fadc15f2c5306909aa9192d7d97) | `` Dell XPS 9560: More formatting in README ``        |
| [`79a18928`](https://github.com/NixOS/nixos-hardware/commit/79a189283ebaf2a6d384002aeab3a45588c151cc) | `` Dell XPS 9560: Fix README headers ``               |
| [`2455827f`](https://github.com/NixOS/nixos-hardware/commit/2455827f552d9ac86a939e47c4c59187e30b2036) | `` Dell XPS 9560: Fix README links ``                 |
| [`4cc314ad`](https://github.com/NixOS/nixos-hardware/commit/4cc314ad675726df2d7884648ff64ddeb18cd216) | `` Dell XPS 9560: Add information and tweak config `` |