### PR TITLE
chore(flake/nixpkgs): `b85ed9dc` -> `cf2004af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -377,11 +377,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692734709,
-        "narHash": "sha256-SCFnyHCyYjwEmgUsHDDuU0TsbVMKeU1vwkR+r7uS2Rg=",
+        "lastModified": 1693099187,
+        "narHash": "sha256-FXCc6OIghv9k4xYOhSMZI6bj7o56S8BJKzKtTKzdUVQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b85ed9dcbf187b909ef7964774f8847d554fab3b",
+        "rev": "cf2004afe4d4b95a295c63c911e949e40915eedb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`a61f1915`](https://github.com/NixOS/nixpkgs/commit/a61f1915d4f4d0c0cc2f46438a8fff5f6593eaa8) | `` h: 1.0.3 -> 1.0.4 ``                                                        |
| [`3d6dd9b4`](https://github.com/NixOS/nixpkgs/commit/3d6dd9b4afb10ae8bf05f802922baef6fea516d8) | `` stacktile: init at 1.0.0 ``                                                 |
| [`38b9aaf6`](https://github.com/NixOS/nixpkgs/commit/38b9aaf6682015f1d2fc7b7f48da96992c30cfa3) | `` sketchybar: add meta.mainProgram ``                                         |
| [`75683e28`](https://github.com/NixOS/nixpkgs/commit/75683e28399bc25b5665d6d481e8f6e2e059cf9c) | `` sketchybar: 2.15.2 -> 2.16.1 ``                                             |
| [`6e898570`](https://github.com/NixOS/nixpkgs/commit/6e8985702ca9896dd6badc74a408db62bf175136) | `` Revert "qt5.qtbase: fix cross" ``                                           |
| [`7c2a4592`](https://github.com/NixOS/nixpkgs/commit/7c2a459244b0592fa36184c193193dde8d033297) | `` aseprite: drop free version and alias to unfree version ``                  |
| [`eeaa0526`](https://github.com/NixOS/nixpkgs/commit/eeaa0526a32383470a2160fa598237b3623a5d68) | `` aseprite-unfree: 1.2.16.3 -> 1.2.40 ``                                      |
| [`a8cbbd96`](https://github.com/NixOS/nixpkgs/commit/a8cbbd96fcccde6e5553d7554d52e3ea66b802a2) | `` lxgw-neoxihei: 1.103.1 -> 1.104 ``                                          |
| [`cc85ec87`](https://github.com/NixOS/nixpkgs/commit/cc85ec87da069dd5e7fb7e584767cee5181a341a) | `` python311Packages.aioaseko: 0.1.0 -> 0.1.1 ``                               |
| [`4e49e492`](https://github.com/NixOS/nixpkgs/commit/4e49e4928d44ce1ffc9a880ec035d1441a1b7650) | `` tests.texlive.fixedHashes: init (#248746) ``                                |
| [`b4803770`](https://github.com/NixOS/nixpkgs/commit/b48037703b23a38b619cca3ddc2802c1c4778f3b) | `` kitty: no need to disable strictoverflow hardening ``                       |
| [`f1ca6257`](https://github.com/NixOS/nixpkgs/commit/f1ca6257dca4ff3c192f2efdcaf19a9df914d13a) | `` Revert "Revert "qutebrowser: 2.5.4 -> 3.0.0"" ``                            |
| [`1550c824`](https://github.com/NixOS/nixpkgs/commit/1550c8247ac24ad794d24336337260f03b865f34) | `` rustypaste: 0.12.1 -> 0.13.0 ``                                             |
| [`fa688259`](https://github.com/NixOS/nixpkgs/commit/fa688259bde516cf94e6b203f0d29e343460c741) | `` Revert "qutebrowser: 2.5.4 -> 3.0.0" ``                                     |
| [`da11d355`](https://github.com/NixOS/nixpkgs/commit/da11d3550792fc8fcb598f1925bcedb450658528) | `` amazon-ec2-utils: add anthonyroussel to maintainers ``                      |
| [`8e08b604`](https://github.com/NixOS/nixpkgs/commit/8e08b604937b290e7b4a5920039ba78ff3e8ff24) | `` amazon-ec2-utils: 2.0 -> 2.1.0 ``                                           |
| [`3d476abe`](https://github.com/NixOS/nixpkgs/commit/3d476abe820600be3895f9889f722183d2d17e60) | `` python310Packages.pykeepass: 4.0.5 -> 4.0.6 ``                              |
| [`7ca7c71d`](https://github.com/NixOS/nixpkgs/commit/7ca7c71d47f597bb30a6d0fccb2c656d5b6651e5) | `` ugrep: 4.0.3 -> 4.0.4 ``                                                    |
| [`3eef22ee`](https://github.com/NixOS/nixpkgs/commit/3eef22ee670802a372a4589a41e399ee2e81d0e1) | `` python311Packages.fe25519: 1.4.2 -> 1.5.0 ``                                |
| [`f5c3db89`](https://github.com/NixOS/nixpkgs/commit/f5c3db89621c70c6b409debb35300b7345df5120) | `` bottom: 0.9.4 -> 0.9.5 ``                                                   |
| [`be755b5c`](https://github.com/NixOS/nixpkgs/commit/be755b5c622ac22335754acb7aa00d7b98529519) | `` libpkgconf: refactor ``                                                     |
| [`9cb225af`](https://github.com/NixOS/nixpkgs/commit/9cb225afe6535ecb1cf9dada45011dce805178df) | `` libpkgconf: 1.9.5 -> 2.0.2 ``                                               |
| [`f6a6dc80`](https://github.com/NixOS/nixpkgs/commit/f6a6dc801f7ca53e4d11ede38a6c937f644221dc) | `` emacs: refactor ``                                                          |
| [`9a74a042`](https://github.com/NixOS/nixpkgs/commit/9a74a042e101594d203988994dda7342ae0070c7) | `` complgen: unstable-2023-08-17 -> unstable-2023-08-22 ``                     |
| [`4aefd7f3`](https://github.com/NixOS/nixpkgs/commit/4aefd7f39ffd1c51347f7cee02b0e01462b6864c) | `` mmdoc: 0.15.0 -> 0.19.0 ``                                                  |
| [`0de3c547`](https://github.com/NixOS/nixpkgs/commit/0de3c547e13a727533491522cf3ad7b471d176c2) | `` cargo-bundle: unstable-2023-03-17 -> unstable-2023-08-18 ``                 |
| [`906836a6`](https://github.com/NixOS/nixpkgs/commit/906836a6acf6e06ac681371848a89d685165fd29) | `` vimPlugins.adwaita-nvim: init at 2023-06-22 ``                              |
| [`b424933a`](https://github.com/NixOS/nixpkgs/commit/b424933ae6bd7f213bd541a1bde594fe715da9a6) | `` egglog: unstable-2023-08-19 -> unstable-2023-08-23 ``                       |
| [`9f698f54`](https://github.com/NixOS/nixpkgs/commit/9f698f54aba4c69698aad2f84a764eed99282ee4) | `` vimPlugins.nvim-lilypond-suite: init at 2023-08-18 ``                       |
| [`ed68c1f0`](https://github.com/NixOS/nixpkgs/commit/ed68c1f0fcf1e2d8415d53bb7c593edaf3676e4b) | `` cyber: unstable-2023-08-11 -> unstable-2023-08-24 ``                        |
| [`f54ad0bb`](https://github.com/NixOS/nixpkgs/commit/f54ad0bbc682c91ce64df51e4b44eaf6578033ce) | `` cargo-component: unstable-2023-08-19 -> unstable-2023-08-24 ``              |
| [`20000961`](https://github.com/NixOS/nixpkgs/commit/200009610a4add0c79ca075b63d149f886b95c6c) | `` rdiff-backup: 2.0.5 -> 2.2.5 ``                                             |
| [`3b5da635`](https://github.com/NixOS/nixpkgs/commit/3b5da63572036a0a27c9d4bc5b009a4db4cbe912) | `` typstfmt: unstable-2023-08-15 -> unstable-2023-08-22 ``                     |
| [`1d04d32a`](https://github.com/NixOS/nixpkgs/commit/1d04d32a021ffb40d1a8343a4c705b240c77a115) | `` python310Packages.trimesh: 3.23.3 -> 3.23.5 ``                              |
| [`6af4c05c`](https://github.com/NixOS/nixpkgs/commit/6af4c05caccfee403e1663ecc3008a63fc297582) | `` python311Packages.griffe: 0.35.0 -> 0.35.1 ``                               |
| [`72a282bb`](https://github.com/NixOS/nixpkgs/commit/72a282bbd93ac4c5ddf3c20f677a621c636fecf1) | `` lcrq: 0.1.1 -> 0.1.2 ``                                                     |
| [`1225f34b`](https://github.com/NixOS/nixpkgs/commit/1225f34b931915930b27021fc3040f3d66906122) | `` python311Packages.whirlpool-sixth-sense: 0.18.4 -> 0.18.5 ``                |
| [`54c3babe`](https://github.com/NixOS/nixpkgs/commit/54c3babe6e656d6028d24579e5c5e5badfd31122) | `` python311Packages.airthings-ble: 0.5.6-2 -> 0.5.6-4 ``                      |
| [`f9aa8c55`](https://github.com/NixOS/nixpkgs/commit/f9aa8c555fb257bf53d12810ea6f4b36e7020b2e) | `` gnome.gnome-maps: 44.3 → 44.4 ``                                            |
| [`6e58abaf`](https://github.com/NixOS/nixpkgs/commit/6e58abafa0188fc27254757487484100724dac94) | `` url-parser: add changelog to meta ``                                        |
| [`f08fa387`](https://github.com/NixOS/nixpkgs/commit/f08fa38713094f81921f8ba1659250b1d3db4827) | `` gokrazy: init at unstable-2023-08-12 ``                                     |
| [`7f08d0bd`](https://github.com/NixOS/nixpkgs/commit/7f08d0bdf51c0dbf2fd97625c9ad41e97be97dd2) | `` maintainers: add shayne ``                                                  |
| [`b7177a79`](https://github.com/NixOS/nixpkgs/commit/b7177a792c8b617f602bdc016ab55f2b4277d98e) | `` python311Packages.filedepot: add patch for Pillow 10 support ``             |
| [`d9a6e4d4`](https://github.com/NixOS/nixpkgs/commit/d9a6e4d41bf6d20cb05af1827cef75a38c483dcb) | `` typst: set mainProgram ``                                                   |
| [`faeb7ac6`](https://github.com/NixOS/nixpkgs/commit/faeb7ac63ade165aa94156e8983ede46295bf886) | `` emacsPackages.typst-mode: replace program ``                                |
| [`a5d63c36`](https://github.com/NixOS/nixpkgs/commit/a5d63c365f3b08e0be8c797eccf11904ad377792) | `` python311Packages.opower: 0.0.31 -> 0.0.32 ``                               |
| [`56c7025b`](https://github.com/NixOS/nixpkgs/commit/56c7025b4ee260e946ed797d747e04b87921cf1f) | `` aws-sam-cli: relax aws-lambda-builders constraint ``                        |
| [`549cdad3`](https://github.com/NixOS/nixpkgs/commit/549cdad38971e32417dc99b16fdab83e2a1fe0e5) | `` python311Packages.aws-lambda-builders: ensure that the version is set ``    |
| [`96db5f78`](https://github.com/NixOS/nixpkgs/commit/96db5f789e1a568490275ea9be3ab83076b0a41b) | `` gtree: 1.9.5 -> 1.9.6 ``                                                    |
| [`0af1a3b6`](https://github.com/NixOS/nixpkgs/commit/0af1a3b6ced4db22e0cf86b46daa6241ee3f3ff5) | `` freeswitch: 1.10.9 -> 1.10.10 ``                                            |
| [`f9f22f04`](https://github.com/NixOS/nixpkgs/commit/f9f22f04a7fe30aa137200c0e17b4fa1c707b115) | `` fastfetch: 2.0.4 -> 2.0.5 ``                                                |
| [`1249d49e`](https://github.com/NixOS/nixpkgs/commit/1249d49eb364132be57f2620b04ce4c759e067f5) | `` aws-sam-cli: add changelog to meta ``                                       |
| [`c709ea86`](https://github.com/NixOS/nixpkgs/commit/c709ea868a530a64b9146df2f8a6c21a28b51da2) | `` python311Packages.aws-lambda-builders: 1.34.0 -> 1.36.0 ``                  |
| [`6175a329`](https://github.com/NixOS/nixpkgs/commit/6175a329d29f290924587ba7a02572a05055f331) | `` lxd: fix passthru test building ``                                          |
| [`c09b6018`](https://github.com/NixOS/nixpkgs/commit/c09b601800f8543697f5c341f927108fc1e7ff93) | `` multiviewer-for-f1: 1.26.1 -> 1.26.2 ``                                     |
| [`89da73e9`](https://github.com/NixOS/nixpkgs/commit/89da73e92edec4b1bc77722284f4b00a2e5071e4) | `` tests.texlive.opentype-fonts: use scheme-small ``                           |
| [`996a94d9`](https://github.com/NixOS/nixpkgs/commit/996a94d959672c9e17df20b4e800ea2b229be93b) | `` tests.texlive.opentype-fonts: use mkTeXTest ``                              |
| [`89868116`](https://github.com/NixOS/nixpkgs/commit/898681161a7620d6bd6c7d2c256146d0aa8b185d) | `` tests.texlive.allLanguages: init ``                                         |
| [`3096052a`](https://github.com/NixOS/nixpkgs/commit/3096052a54dfbfaaa7830abaacb170c51c0347f8) | `` tests.texlive.defaultLanguage: init ``                                      |
| [`1ff046e3`](https://github.com/NixOS/nixpkgs/commit/1ff046e333c0a6aa4e43f2de9d39d37bb9ece301) | `` tests.texlive.mkTeXTest: init ``                                            |
| [`ba73f1c5`](https://github.com/NixOS/nixpkgs/commit/ba73f1c5f72040d1000e92957e77aaf539d677f1) | `` diesel-cli: 2.1.0 -> 2.1.1 ``                                               |
| [`8f1e7645`](https://github.com/NixOS/nixpkgs/commit/8f1e76455141194a9a68b9a201b914d741a5cfdf) | `` treewide: add meta.mainProgram (#251487) ``                                 |
| [`face05ad`](https://github.com/NixOS/nixpkgs/commit/face05ad58b99ca1755da9bd36b05c38a8b0e992) | `` nuclei: 2.9.12 -> 2.9.13 ``                                                 |
| [`7207b250`](https://github.com/NixOS/nixpkgs/commit/7207b25099d0a199d438dde143c67de4074a586a) | `` nixos/tests/dolibarr: use -X GET instead -X POST to test for redirection `` |
| [`bae907f6`](https://github.com/NixOS/nixpkgs/commit/bae907f638d71f649db35e325ffa4f3056c42477) | `` python311Packages.particle: 0.21.2 -> 0.23.0 ``                             |
| [`4b9f347f`](https://github.com/NixOS/nixpkgs/commit/4b9f347f336a65f4b3d64a2083afdc0418a8f45a) | `` cairo-lang: 2.0.2 -> 2.2.0 ``                                               |
| [`f4c48224`](https://github.com/NixOS/nixpkgs/commit/f4c4822443a5bd975520a66456c7efb93752e5ab) | `` sq: 0.40.0 -> 0.42.0 ``                                                     |
| [`b07febf8`](https://github.com/NixOS/nixpkgs/commit/b07febf83e2c102dc7aa9bab02a3e7847854e3ed) | `` python3Packages.web3: remove myself from maintainers ``                     |
| [`20423599`](https://github.com/NixOS/nixpkgs/commit/20423599cfb990b956f343d7a6ee91315ef19cd1) | `` netbox: 3.5.7 -> 3.5.8 ``                                                   |
| [`242c5e57`](https://github.com/NixOS/nixpkgs/commit/242c5e57ae6660dd0df44991dcdfe1cd6e6775f6) | `` python3Packages.cairo-lang: drop ``                                         |
| [`eeb214eb`](https://github.com/NixOS/nixpkgs/commit/eeb214eb89402002aadf418181f24949c0a99684) | `` python3Packages.rustworkx: 0.12.1 -> 0.13.1 ``                              |
| [`81ec72df`](https://github.com/NixOS/nixpkgs/commit/81ec72df04046579b1328d0b51ab63efc1e6bd42) | `` python3Packages.jellyfish: 0.9.0 -> 1.0.0 ``                                |
| [`bc06fc06`](https://github.com/NixOS/nixpkgs/commit/bc06fc0671bd5c5abd07b8cb7eb418606228911e) | `` url-parser: 1.0.4 -> 1.0.5 ``                                               |
| [`c1bb32ee`](https://github.com/NixOS/nixpkgs/commit/c1bb32ee723b7dfe84d643cb93cb0c62092b6cc1) | `` catcli: 0.8.7 -> 0.9.6 ``                                                   |
| [`f036cc78`](https://github.com/NixOS/nixpkgs/commit/f036cc78a5dcf1e4f312b17aadc7953a146cadc5) | `` python311Packages.types-docopt: init at 0.6.11.4 ``                         |
| [`d9e42ac4`](https://github.com/NixOS/nixpkgs/commit/d9e42ac41bec0a2d99ca70e6fbe4f9300a4ae11f) | `` emscripten: 3.1.42 -> 3.1.45 ``                                             |
| [`8a418f16`](https://github.com/NixOS/nixpkgs/commit/8a418f166f9a8d2da58ff205d6348d4f3d997e08) | `` gh-dash: 3.10.0 -> 3.11.0 ``                                                |
| [`6d6210ee`](https://github.com/NixOS/nixpkgs/commit/6d6210ee9b9e8c9ecf47421675fb6396c992e467) | `` llvmPackages_git.libcxxabi: fix build on Linux and Darwin ``                |
| [`e5e3e6e4`](https://github.com/NixOS/nixpkgs/commit/e5e3e6e4d6a643d89ddaa156786eb2cb2fd3c7ea) | `` llvmPackages_16.libcxxabi: fix build on Linux and Darwin ``                 |
| [`56bb8b73`](https://github.com/NixOS/nixpkgs/commit/56bb8b73a62b5c3684f48225fe54b2c95cd6a884) | `` llvmPackages_15.libcxxabi: fix build on Linux and Darwin ``                 |
| [`b5e72c13`](https://github.com/NixOS/nixpkgs/commit/b5e72c133a626ae3dd28bfd34bd740596a112f41) | `` python311Packages.oauthenticator: 16.0.6 -> 16.0.7 ``                       |
| [`15e7e402`](https://github.com/NixOS/nixpkgs/commit/15e7e402dcbc78785f81531b4d723f9036e20c78) | `` python311Packages.mdformat-mkdocs: add changelog to meta ``                 |
| [`565af459`](https://github.com/NixOS/nixpkgs/commit/565af45965315b97ad8e44504c3b0e230e3a1fed) | `` python311Packages.mdformat-mkdocs: 1.0.2 -> 1.0.4 ``                        |
| [`5000fb7c`](https://github.com/NixOS/nixpkgs/commit/5000fb7c4791b4948b41ce906e5a5db0e4ecb62c) | `` kcp: init at 1.7 ``                                                         |
| [`b793df56`](https://github.com/NixOS/nixpkgs/commit/b793df565b99e6617917e8c800dcd5d5b0326c1b) | `` path-of-building.data: 2.33.2 -> 2.33.3 ``                                  |
| [`9b30d7b2`](https://github.com/NixOS/nixpkgs/commit/9b30d7b2b20a05a60ea3c9da7c6993e576ef8708) | `` zerotierone: 1.10.6 -> 1.12.1 (#251523) ``                                  |
| [`1d67c02f`](https://github.com/NixOS/nixpkgs/commit/1d67c02fc341d236704b3bf67a4439268ea6884a) | `` python311Packages.awacs: 2.3.0 -> 2.4.0 ``                                  |
| [`49d00dd6`](https://github.com/NixOS/nixpkgs/commit/49d00dd6d6461587f51bbf2fae4c233b0e092634) | `` python311Packages.anytree: 2.8.0 -> 2.9.0 ``                                |
| [`30153560`](https://github.com/NixOS/nixpkgs/commit/30153560e10d46bb06b0b7948a44fa0c93423bd5) | `` python311Packages.apptools: 5.1.0 -> 5.2.1 ``                               |
| [`1939a9af`](https://github.com/NixOS/nixpkgs/commit/1939a9af87b614662b778c37feeb4551512f8daa) | `` python311Packages.apptools: add changelog to meta ``                        |
| [`19d74541`](https://github.com/NixOS/nixpkgs/commit/19d745412302813c7cf87ccc827ad74303d0a07b) | `` odoo: 15.20230317 -> 16.20230722 ``                                         |
| [`a5f7cae6`](https://github.com/NixOS/nixpkgs/commit/a5f7cae6088d44d629e161bf07be3406692757c0) | `` python311Packages.approvaltests: 8.3.1 -> 8.4.1 ``                          |
| [`72069257`](https://github.com/NixOS/nixpkgs/commit/72069257bf9e72a8cc6a65c2f4b504922d8e915f) | `` phpExtensions.opentelemetry: init at 1.0.0beta6 ``                          |
| [`98d9acd3`](https://github.com/NixOS/nixpkgs/commit/98d9acd376c1ffcde0b5c418f5739cb24bb8e99d) | `` python2Packages.ninja: alias it to ninja build tool ``                      |
| [`6fb63efc`](https://github.com/NixOS/nixpkgs/commit/6fb63efc6140d39ab1817aa485d1c890e747a985) | `` python311Packages.smbus2: migrate to pytestCheckHook ``                     |
| [`1498e729`](https://github.com/NixOS/nixpkgs/commit/1498e72925aa36b4fb3f3656869df6033bf964d1) | `` python311Packages.smbus2: add format ``                                     |
| [`2426ca91`](https://github.com/NixOS/nixpkgs/commit/2426ca915b888a491c1bb595da825241514610d3) | `` python311Packages.smbus2: add changelog to meta ``                          |
| [`2ea678ed`](https://github.com/NixOS/nixpkgs/commit/2ea678ed48b5c710b6561530d6a40808d7dc4d7b) | `` default-crate-overrides: add libseat-sys ``                                 |
| [`0819c77d`](https://github.com/NixOS/nixpkgs/commit/0819c77def1849b57187b10f90368c2ff2aeda49) | `` checkov: 2.4.7 -> 2.4.10 ``                                                 |
| [`c6634623`](https://github.com/NixOS/nixpkgs/commit/c663462360b89eae2b5155adb8645e6d7cb20f30) | `` qovery-cli: 0.65.1 -> 0.66.1 ``                                             |
| [`bad873c0`](https://github.com/NixOS/nixpkgs/commit/bad873c04766b2749733918a301ae46202a53396) | `` python311Packages.smbus2: 0.4.2 -> 0.4.3 ``                                 |
| [`fcb7d7e8`](https://github.com/NixOS/nixpkgs/commit/fcb7d7e878c67ba11c6196d902c44d34d5dd351a) | `` cargo-run-bin: init at 1.1.5 ``                                             |
| [`c481af10`](https://github.com/NixOS/nixpkgs/commit/c481af100598e4dedb8d9b137db3eae0d6babe9e) | `` python311Packages.meshtastic: 2.2.1 -> 2.2.2 ``                             |
| [`d580c355`](https://github.com/NixOS/nixpkgs/commit/d580c355d11db33ff8141105c8baf63b5c571650) | `` python311Packages.fountains: 2.1.0 -> 2.2.0 ``                              |
| [`b0e5c80c`](https://github.com/NixOS/nixpkgs/commit/b0e5c80cd64f145e384105195ba59f63f9b12122) | `` heroic: keep IPC namespace ``                                               |
| [`9dee811c`](https://github.com/NixOS/nixpkgs/commit/9dee811c7c25b13ce2f628cf24a089b9a738a9e6) | `` python311Packages.appthreat-vulnerability-db: 5.2.0 -> 5.2.1 ``             |
| [`9f604715`](https://github.com/NixOS/nixpkgs/commit/9f60471520e9d5385928a4bb70ef80eadc7c2be1) | `` path-of-building.data: 2.33.1 -> 2.33.2 ``                                  |
| [`1ebb37fb`](https://github.com/NixOS/nixpkgs/commit/1ebb37fbe83600601096cdadb13569be3861f315) | `` nwg-dock-hyprland: 0.1.4 -> 0.1.5 ``                                        |
| [`857610bc`](https://github.com/NixOS/nixpkgs/commit/857610bcd1b5c57ae157bc4e49122e14329215d9) | `` mox: 0.0.5 -> 0.0.6 ``                                                      |
| [`94b9eb30`](https://github.com/NixOS/nixpkgs/commit/94b9eb30d957db779fff130fd27a83e626f6410e) | `` tidb: 7.2.0 -> 7.3.0 ``                                                     |
| [`d7575827`](https://github.com/NixOS/nixpkgs/commit/d75758279f1a3588ddeb0439b975ae277606fa31) | `` linuxPackages.nvidiaPackages.production: 535.98 -> 535.104.05 ``            |