### PR TITLE
chore(flake/home-manager): `9706fb8e` -> `f8c5fd75`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693108765,
-        "narHash": "sha256-U1btmyF7SMX+y80EXYva5Xj6lpn20xPbHbuoe/2bSIw=",
+        "lastModified": 1693125758,
+        "narHash": "sha256-7u591OQ1nzQ/IRMDBix8Ox1q+u3OyPQHs2HDZnR89qk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9706fb8e441a7c56c68bb079480938ed505e8102",
+        "rev": "f8c5fd75092448ac134d7fb823556b37d3c821f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                      |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`f8c5fd75`](https://github.com/nix-community/home-manager/commit/f8c5fd75092448ac134d7fb823556b37d3c821f5) | `` chromium: add support for dictionaries `` |