### PR TITLE
chore(flake/nixpkgs): `cf2004af` -> `a999c1cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -377,11 +377,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693099187,
-        "narHash": "sha256-FXCc6OIghv9k4xYOhSMZI6bj7o56S8BJKzKtTKzdUVQ=",
+        "lastModified": 1693158576,
+        "narHash": "sha256-aRTTXkYvhXosGx535iAFUaoFboUrZSYb1Ooih/auGp0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf2004afe4d4b95a295c63c911e949e40915eedb",
+        "rev": "a999c1cc0c9eb2095729d5aa03e0d8f7ed256780",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`c0d989e0`](https://github.com/NixOS/nixpkgs/commit/c0d989e039dafa1c4a2a2d45945f12b22c78d6cf) | `` python311Packages.json-tricks: 3.17.2 -> 3.17.3 ``                                   |
| [`6bccb528`](https://github.com/NixOS/nixpkgs/commit/6bccb5287af838353ef766450f4c5c1ff40412a6) | `` python311Packages.casbin: 1.23.1 -> 1.24.0 ``                                        |
| [`b5e8997e`](https://github.com/NixOS/nixpkgs/commit/b5e8997e3b0549dab177148b3886697d2aaa6208) | `` chopchop: use sri hash ``                                                            |
| [`94387ebc`](https://github.com/NixOS/nixpkgs/commit/94387ebcfa1fa9259cc28cfc60c1446110432422) | `` python3Packages.python3-saml: skip (more) tests with expired test data ``            |
| [`1496732e`](https://github.com/NixOS/nixpkgs/commit/1496732e755c4fc7199f3bd747805a4d55d21907) | `` gitRepo: 2.35 -> 2.36 ``                                                             |
| [`a112af67`](https://github.com/NixOS/nixpkgs/commit/a112af674db561a817cb05f645837f0d212a90a4) | `` logseq: 0.9.14 -> 0.9.15 ``                                                          |
| [`0e9d5797`](https://github.com/NixOS/nixpkgs/commit/0e9d57971c0bd3bec20481b8972f71b1ab782047) | `` tiledb: don't require AVX2 instructions ``                                           |
| [`8996dfe1`](https://github.com/NixOS/nixpkgs/commit/8996dfe1084a31fa9cea4960aae5e99889710622) | `` nvitop: 1.2.0 -> 1.3.0 ``                                                            |
| [`d374fc52`](https://github.com/NixOS/nixpkgs/commit/d374fc522c3fbb804ff2dbce8b4f65f3f2659c35) | `` juicity: 0.1.3 -> 0.2.1 ``                                                           |
| [`676fe5e0`](https://github.com/NixOS/nixpkgs/commit/676fe5e01b9a41fa14aaa48d87685677664104b1) | `` lemmy: fix ui commit_hash path ``                                                    |
| [`0782b000`](https://github.com/NixOS/nixpkgs/commit/0782b000d91bab97f62521cbd10974637246b0f8) | `` pkgs-lib/tests/formats: fix expected output ``                                       |
| [`bd9f4994`](https://github.com/NixOS/nixpkgs/commit/bd9f49947feb26b2cbc0b5e19c36250a6a0ec088) | `` python310Packages.getjump: relax pillow dependency constraint ``                     |
| [`659679bd`](https://github.com/NixOS/nixpkgs/commit/659679bddb9810bc6921202c1c9b264e4b003fcb) | `` languagetool-rust: 2.1.3 -> 2.1.4 ``                                                 |
| [`8aad9cf7`](https://github.com/NixOS/nixpkgs/commit/8aad9cf7f553f0cd9e64f01057d49a922f666f0a) | `` plasma-desktop: remove Discover from default panel ``                                |
| [`a253ead5`](https://github.com/NixOS/nixpkgs/commit/a253ead5689ab53f8289c7f902564f07c5d71919) | `` python311Packages.aws-sam-translator: 1.60.1 -> 1.73.0 ``                            |
| [`64a96d22`](https://github.com/NixOS/nixpkgs/commit/64a96d22604130f04c0453b9b10aed038df6419c) | `` azmq: init at unstable-2023-03-23 ``                                                 |
| [`b1fa4e74`](https://github.com/NixOS/nixpkgs/commit/b1fa4e747204e1253916dad649185396152453e9) | `` taskwarrior-tui: 0.25.1 -> 0.25.2 ``                                                 |
| [`5f6cd848`](https://github.com/NixOS/nixpkgs/commit/5f6cd8487a6fbddcd792b04d90bfec932aec9527) | `` python310Packages.vega: fully switch to poetry-core ``                               |
| [`a4f237cc`](https://github.com/NixOS/nixpkgs/commit/a4f237ccbce9b1c0c0d71a4b6895588d76d2c1aa) | `` yuzu: 1522 -> 1538, yuzu-ea: 3805 -> 3838 ``                                         |
| [`3e33d222`](https://github.com/NixOS/nixpkgs/commit/3e33d2227448296633b861ce62551d612bd8c8ba) | `` python310Packages.opentsne: add missing build dependencies ``                        |
| [`1f28d8b6`](https://github.com/NixOS/nixpkgs/commit/1f28d8b6cc05377a531151486a3f4b06f3033919) | `` notmuch: don’t check with emacs when withEmacs=false ``                              |
| [`b2401468`](https://github.com/NixOS/nixpkgs/commit/b24014685e8018895475a24626938e906220a754) | `` jackett: 0.21.674 -> 0.21.705 ``                                                     |
| [`e3d11af1`](https://github.com/NixOS/nixpkgs/commit/e3d11af1d2d3abf04bcbc8bd25d694cf51e2189a) | `` python310Packages.fe25519: remove patch leftover from merge ``                       |
| [`e50da263`](https://github.com/NixOS/nixpkgs/commit/e50da2639a593714015a04fafa51d56255e6e07a) | `` python310Packages.typecode: disable tests that fail against file 5.45 ``             |
| [`925de2f5`](https://github.com/NixOS/nixpkgs/commit/925de2f55855c088fdbcc6fbdee5c6d97834d2e1) | `` molecule: add missing build dependencies ``                                          |
| [`b7c80050`](https://github.com/NixOS/nixpkgs/commit/b7c800502a5b51e1f01046889766ca48e9fb179b) | `` glog: disable logging tests on aarch64-darwin ``                                     |
| [`43e3435a`](https://github.com/NixOS/nixpkgs/commit/43e3435a900d064e6b6500fb56ceec8f760b2284) | `` AusweisApp2: fix build ``                                                            |
| [`4eee509d`](https://github.com/NixOS/nixpkgs/commit/4eee509d25d5af666f05986a349ae8639c0adfcc) | `` odoo15: init at 15.0-20230720 ``                                                     |
| [`e256002e`](https://github.com/NixOS/nixpkgs/commit/e256002eb7c9c7a9f142ca80a5e14d548e8f1a69) | `` python310Packages.pallets-sphinx-themes: 2.1.0 -> 2.1.1 ``                           |
| [`c9e235a6`](https://github.com/NixOS/nixpkgs/commit/c9e235a6669eb22ec46f7b920d21046834e76cc9) | `` python310Packages.recipe-scrapers: 14.36.1 -> 14.43.0 ``                             |
| [`43b6f58d`](https://github.com/NixOS/nixpkgs/commit/43b6f58d036f5d5efa5708d2d106a101a0f3284e) | `` pikchr: set mainProgram ``                                                           |
| [`1159c64f`](https://github.com/NixOS/nixpkgs/commit/1159c64f588a5c04f6d61d2bd923e0dd7db9c824) | `` emacsPackages.pikchr-mode: replace program ``                                        |
| [`89c4fdc1`](https://github.com/NixOS/nixpkgs/commit/89c4fdc1abe35924aeff30ff3fdc0afe0af0c284) | `` webex: 43.5.0.26155 -> 43.8.0.26955 ``                                               |
| [`3bae1670`](https://github.com/NixOS/nixpkgs/commit/3bae1670eef3b0a0e3e522d9071573541629ce93) | `` python310Packages.patool: fix tests to be compatible with file 5.45 ``               |
| [`3005e695`](https://github.com/NixOS/nixpkgs/commit/3005e695d4eb4b072bfc4b631fe1277a7d71a997) | `` ocamlPackages.bwd: 2.1.0 -> 2.2.0 ``                                                 |
| [`70241939`](https://github.com/NixOS/nixpkgs/commit/702419396a9e3c96bbee40632664fc9e3216aa65) | `` ocamlPackages.zed: 3.2.0 -> 3.2.3 ``                                                 |
| [`451bf60c`](https://github.com/NixOS/nixpkgs/commit/451bf60c09ef15119832788922e6778c69b9d971) | `` python310Packages.globus-sdk: 3.26.0 -> 3.27.0 ``                                    |
| [`5d6f8daf`](https://github.com/NixOS/nixpkgs/commit/5d6f8daf25ac860de2d14308ab001b5a7bb52dda) | `` python310Packages.jellyfish: link to libiconv on darwin ``                           |
| [`21d85b1a`](https://github.com/NixOS/nixpkgs/commit/21d85b1a2f372ecabf72e596eb68c9a71c1c25b3) | `` python310Packages.appthreat-vulnerability-db: 5.2.1 -> 5.2.3 ``                      |
| [`b294823d`](https://github.com/NixOS/nixpkgs/commit/b294823df8dc844450448e9085ac94714fee5894) | `` python310Packages.teslajsonpy: 3.9.2 -> 3.9.3 ``                                     |
| [`91f17d3e`](https://github.com/NixOS/nixpkgs/commit/91f17d3ec8ba92c4709d4cb88c5c4b913f41d032) | `` python3Packages.zephyr-python-api: init at 0.0.3 ``                                  |
| [`8ec60030`](https://github.com/NixOS/nixpkgs/commit/8ec60030f37493cd97f3f545d4a4bfccfd488884) | `` shadowsocks-rust: 1.15.4 -> 1.16.0 ``                                                |
| [`871c30c1`](https://github.com/NixOS/nixpkgs/commit/871c30c1c56cf9c97a85ed6763f7b7effc40e30d) | `` vultr-cli: 2.17.0 -> 2.18.2 ``                                                       |
| [`bda11503`](https://github.com/NixOS/nixpkgs/commit/bda115030dfc94b17c5063f87ea06bba4ccc48e6) | `` grpc-tools: 1.11.2 -> 1.12.4 ``                                                      |
| [`e9f719a2`](https://github.com/NixOS/nixpkgs/commit/e9f719a2aa9c5a69b6ec1eb331ef9a70844a4635) | `` grpc-tools: add passthru.updateScript ``                                             |
| [`fe8d27a8`](https://github.com/NixOS/nixpkgs/commit/fe8d27a846a81bff71641e0ea3898f15f2cb410d) | `` python310Packages.pybtex-docutils: 1.0.2 -> 1.0.3 ``                                 |
| [`cefe6054`](https://github.com/NixOS/nixpkgs/commit/cefe605488c6dc22bda48fec6c7bd75127c62d61) | `` ps3iso-utils: init at 277db7de ``                                                    |
| [`6b008d64`](https://github.com/NixOS/nixpkgs/commit/6b008d645babc6cca457122de635a72a532145a9) | `` python310Packages.scikit-image: relax numpy dependency constraint ``                 |
| [`688ab669`](https://github.com/NixOS/nixpkgs/commit/688ab6699be6501e268caf585b6bb1a51de47917) | `` harsh: init at 0.8.28 ``                                                             |
| [`a22d41a7`](https://github.com/NixOS/nixpkgs/commit/a22d41a78dba07bf5e87ffbdf98446967ebdad44) | `` maintainers: add LAURAilway ``                                                       |
| [`ffe6183a`](https://github.com/NixOS/nixpkgs/commit/ffe6183ac224d73861fc0e7c3ddeae5dea8b4f14) | `` python310Packages.picosvg: 0.22.0 -> 0.22.1 ``                                       |
| [`f803a9c8`](https://github.com/NixOS/nixpkgs/commit/f803a9c83c13d204545615d342208ea07b1a9196) | `` python311Packages.pyslim: 1.0.3 -> 1.0.4 ``                                          |
| [`4a72b60b`](https://github.com/NixOS/nixpkgs/commit/4a72b60b834cd2140be0147c0fcb85e213cf44e7) | `` bottom: 0.9.5 -> 0.9.6 ``                                                            |
| [`fcfa6f73`](https://github.com/NixOS/nixpkgs/commit/fcfa6f73f8adccdcaa8ed1a908e834a3afa06505) | `` sqldef: init at 0.12.7 ``                                                            |
| [`cda5894d`](https://github.com/NixOS/nixpkgs/commit/cda5894d7e159e8755a4a6d8275b59a2bb8a5ef2) | `` maintainers: add kgtkr ``                                                            |
| [`c1a045e5`](https://github.com/NixOS/nixpkgs/commit/c1a045e556bdd46bd1e962d302b1526fc628b681) | `` python310Packages.pytelegrambotapi: 4.12.0 -> 4.13.0 ``                              |
| [`776cca23`](https://github.com/NixOS/nixpkgs/commit/776cca2395ff005229567d9220c1cdd7027bef74) | `` python310Packages.plaid-python: 15.4.0 -> 15.5.0 ``                                  |
| [`ef5182e9`](https://github.com/NixOS/nixpkgs/commit/ef5182e957d4cbceb6ee1e08a734d0e5d9ec6eee) | `` python310Packages.jupytext: 1.15.0 -> 1.15.1 ``                                      |
| [`ce63938d`](https://github.com/NixOS/nixpkgs/commit/ce63938d38eec74d95758fdc671b7a1ef9bb9972) | `` python310Packages.ansible-pylibssh: patch out setuptools_scm_git_archive ``          |
| [`0116e834`](https://github.com/NixOS/nixpkgs/commit/0116e8346cb8ad3d26dae892bd31dbf649550727) | `` python310Packages.fountains: remove patch leftover from merge ``                     |
| [`6623889d`](https://github.com/NixOS/nixpkgs/commit/6623889d4aa8854b458f2dcd99ac6796018c8968) | `` nginx-sso: 0.26.0 -> 0.27.1 ``                                                       |
| [`9e5cf7dd`](https://github.com/NixOS/nixpkgs/commit/9e5cf7ddb097c107535bccc8689a35f086509fc6) | `` python3Packages.recordlinkage: 0.15 -> 0.16 ``                                       |
| [`7beff147`](https://github.com/NixOS/nixpkgs/commit/7beff147aea303296111272c7f59b61acb25f050) | `` python310Packages.ytmusicapi: 1.1.1 -> 1.2.1 ``                                      |
| [`0a246323`](https://github.com/NixOS/nixpkgs/commit/0a246323595425d59028bdbc22f672f742764b7a) | `` python310Packages.pywbem: 1.6.1 -> 1.6.2 ``                                          |
| [`95b25f78`](https://github.com/NixOS/nixpkgs/commit/95b25f7803e17ae71ec4783f5b2ae18f6da109a8) | `` getmail6: 6.18.12 -> 6.18.13 ``                                                      |
| [`298a5428`](https://github.com/NixOS/nixpkgs/commit/298a5428b86b797e7a8ad81e602e3821e54f885b) | `` python310Packages.paste: 3.5.2 -> 3.5.3 ``                                           |
| [`fc7ab50b`](https://github.com/NixOS/nixpkgs/commit/fc7ab50b1911aee35e19b70690b91f6e44bdec76) | `` python310Packages.django-widget-tweaks: add format ``                                |
| [`21fbbe3d`](https://github.com/NixOS/nixpkgs/commit/21fbbe3d28a7dc3e2dbab2fc21e9205c6d492fed) | `` python310Packages.django-widget-tweaks: add changelog to meta ``                     |
| [`1e8351e8`](https://github.com/NixOS/nixpkgs/commit/1e8351e8f420cd423ecbeb1e2c00d8270808f37b) | `` python310Packages.django-widget-tweaks: 1.4.12 -> 1.5.0 ``                           |
| [`8d5f4d61`](https://github.com/NixOS/nixpkgs/commit/8d5f4d61a8ae9baf7a48ec2d4a89f8c05aa7ecc5) | `` mkosi: add missing build dependencies ``                                             |
| [`5d4857bc`](https://github.com/NixOS/nixpkgs/commit/5d4857bc3ba8fb4d1586493cda98ab19ef0bfdc3) | `` apachetomcatscanner: remove duplicate script ``                                      |
| [`30a4bbc8`](https://github.com/NixOS/nixpkgs/commit/30a4bbc896199a15089a0710b647336a0917f72f) | `` gphotos-sync: relax build dependencies ``                                            |
| [`118c2681`](https://github.com/NixOS/nixpkgs/commit/118c2681fb404de6703dc755990b3ff37005fb56) | `` python310Packages.soxr: add missing oldest-supported-numpy dependency ``             |
| [`d07f7a9c`](https://github.com/NixOS/nixpkgs/commit/d07f7a9cd1fafb3b0c5bebdef3dc78a65d731f1f) | `` python310Packages.qcodes-loop: relax versioningit dependency ``                      |
| [`f61a460f`](https://github.com/NixOS/nixpkgs/commit/f61a460fe2407f44b9e1fc78c88c10bb07b80126) | `` python310Packages.python-telegram-bot: switch to pyproject build ``                  |
| [`b7ad6c52`](https://github.com/NixOS/nixpkgs/commit/b7ad6c5259fd5aeac439edd3ee518e7449afd97f) | `` python310Packages.jupyter-collaboration: add missing jupyterlab dependency ``        |
| [`39c8049f`](https://github.com/NixOS/nixpkgs/commit/39c8049f064511cd48c2037463292eb9c62ee378) | `` python310Packages.django-scim2: fully move to poetry-core ``                         |
| [`06e603c6`](https://github.com/NixOS/nixpkgs/commit/06e603c610c51e59f42afdd1dcd69cc40ef66c03) | `` python310Packages.bqplot: relax jupyter build dependencies ``                        |
| [`d22022e1`](https://github.com/NixOS/nixpkgs/commit/d22022e15463ba25c3e10d1964a5633937fcf178) | `` python311Packages.python-bsblan: 0.5.13 -> 0.5.14 ``                                 |
| [`9d33433e`](https://github.com/NixOS/nixpkgs/commit/9d33433ed2a69c523aa7bbb7ba9f3fc193e525b6) | `` linuxPackages.{xpadneo, xone}: fix after simplifying sourceRoot ``                   |
| [`fbf2a555`](https://github.com/NixOS/nixpkgs/commit/fbf2a55563efa85c8a98386a87130dfdc7dbe2a5) | `` hack-font: unify output directory with other fonts ``                                |
| [`9cf3fb69`](https://github.com/NixOS/nixpkgs/commit/9cf3fb698d25af5e0fed289c0823449a3e409cf9) | `` kcov: 41 -> 42 ``                                                                    |
| [`38e03d3d`](https://github.com/NixOS/nixpkgs/commit/38e03d3df5ff9a0180ebfefc1714a9a1f503a64a) | `` python3Packages.streamlit: 1.24.1 -> 1.26.0 ``                                       |
| [`f691c7e2`](https://github.com/NixOS/nixpkgs/commit/f691c7e2e78f435c33a87a7e3cd8ef751169ea06) | `` python310Packages.rasterio: add missing build dependencies ``                        |
| [`d820bbdd`](https://github.com/NixOS/nixpkgs/commit/d820bbddedd91cda0321f049670c8c889c589165) | `` python310Packages.drms: add missing build dependencies ``                            |
| [`1be3c609`](https://github.com/NixOS/nixpkgs/commit/1be3c609c693275b81a6d6d4b6053c1485fb2fc3) | `` python310Packages.pint-pandas: add missing build dependencies ``                     |
| [`1fae3fed`](https://github.com/NixOS/nixpkgs/commit/1fae3fed49e554c9f76ffe450395cecab93614c2) | `` python310Packages.pymilvus: add missing build dependencies ``                        |
| [`d3ecc8f3`](https://github.com/NixOS/nixpkgs/commit/d3ecc8f3ef7b4f9550218867f1c4bcc15845d126) | `` python310Packages.reproject: add missing build dependencies and relax constraints `` |
| [`63ff0f7c`](https://github.com/NixOS/nixpkgs/commit/63ff0f7ca6cac5711e76c8d15b90ef736ab5adb7) | `` python310Packages.gpytorch: integrate setuptools-scm build dependency ``             |
| [`b5a3cf62`](https://github.com/NixOS/nixpkgs/commit/b5a3cf6235a2ea7f918426f4adf68f58693ae1aa) | `` python310Packages.ge25519: relax setuptools dependency ``                            |
| [`7418b09f`](https://github.com/NixOS/nixpkgs/commit/7418b09f49d6a0531f8cd8134e02acacecbba20a) | `` python310Packages.fe25519: relax setuptools dependency ``                            |
| [`fbed17d9`](https://github.com/NixOS/nixpkgs/commit/fbed17d90fbd0166eb6e2f9c4268bab5d744ff23) | `` python310Packages.stim: relax pybind11 and add build dependencies ``                 |
| [`8bfaf53f`](https://github.com/NixOS/nixpkgs/commit/8bfaf53f7beee5c9967d9589b211f82600044af6) | `` python310Packages.pytrends: add missing build dependencies ``                        |
| [`9d963635`](https://github.com/NixOS/nixpkgs/commit/9d963635dcab19d163b3a3cfb36749044bbb90d6) | `` python310Packages.pypandoc: switch to pyproject build ``                             |
| [`8d6f8f86`](https://github.com/NixOS/nixpkgs/commit/8d6f8f8622ea392c05fa3e22ae3753e590c2d753) | `` python310Packages.pyairvisual: clean up build dependencies ``                        |
| [`c9b9c327`](https://github.com/NixOS/nixpkgs/commit/c9b9c327366779fbb108c0e42ba1ab292247ca1b) | `` python310Packages.proxy-py: remove setuptools-scm-git-archive dependency ``          |
| [`891dc4b8`](https://github.com/NixOS/nixpkgs/commit/891dc4b83a2748a8d1b0a0ea06d2fce710cf93bb) | `` python310Packages.mip: add missing build dependencies ``                             |
| [`b36f3608`](https://github.com/NixOS/nixpkgs/commit/b36f3608671af35f57477af90730f64d872f4696) | `` python310Packages.fountains: relax setuptools dependency ``                          |
| [`a0fbc9fc`](https://github.com/NixOS/nixpkgs/commit/a0fbc9fc328d0208d7af3d75988177e50b334493) | `` onnxruntime: fix building with new re2 version ``                                    |
| [`a27fe291`](https://github.com/NixOS/nixpkgs/commit/a27fe291a4bb128d66abb37d0534a8f4fdfc88da) | `` qt6.qtwebengine: use vendored re2 ``                                                 |
| [`1dab0a05`](https://github.com/NixOS/nixpkgs/commit/1dab0a05987f7dabd4f2671959a2ede789008bff) | `` python310Packages.liquidctl: update disabled python version ``                       |
| [`92dd61a0`](https://github.com/NixOS/nixpkgs/commit/92dd61a019c962d66112db72f82ecf88befd0902) | `` python311Packages.dbus-fast: 1.93.0 -> 1.94.0 ``                                     |
| [`624ec84c`](https://github.com/NixOS/nixpkgs/commit/624ec84ce1c29750d2d8a21c1bf1261a074f446f) | `` jellyfin-media-player: remove modified mpv as the referenced bug is fixed ``         |
| [`48f8d976`](https://github.com/NixOS/nixpkgs/commit/48f8d976866e9f2a8b81462717fe42564cb173ca) | `` python310Packages.anthropic: 0.3.8 -> 0.3.10 ``                                      |
| [`2c5f2d67`](https://github.com/NixOS/nixpkgs/commit/2c5f2d6790a878107e4a3c9f182f261d5d06f94c) | `` libcint: 5.2.1 -> 5.4.0 ``                                                           |
| [`1bf9dce6`](https://github.com/NixOS/nixpkgs/commit/1bf9dce6651ce2976096ce50d462eec7f331eaed) | `` python3.pkgs.python-matter-server: relax setuptools dependency ``                    |
| [`e0958047`](https://github.com/NixOS/nixpkgs/commit/e0958047028818d6fa68de6143a493da5c5191b8) | `` wafHook: fix missing header id ``                                                    |
| [`92368fec`](https://github.com/NixOS/nixpkgs/commit/92368fec9446fabe5ee551d8a1c7301c4464dd93) | `` etesync-dav: pull patch into flask to work with setuptools 67.5.0+ ``                |
| [`003cfb2d`](https://github.com/NixOS/nixpkgs/commit/003cfb2dc7f51d06ff34dde42b7274cea5fa506a) | `` flatcam: do not pin setuptools in shapely ``                                         |
| [`73248724`](https://github.com/NixOS/nixpkgs/commit/73248724f156887562f3e12a1633e76626e5369b) | `` python3.pkgs.monai-deploy: replace versioneer-518 with versioneer ``                 |
| [`01578d59`](https://github.com/NixOS/nixpkgs/commit/01578d595acc35de1aad2c5fdc4c649c789a84ef) | `` tesh: replace poetry with poetry-core ``                                             |
| [`a81ac2a8`](https://github.com/NixOS/nixpkgs/commit/a81ac2a830d50e180b2c3df340ba93fcbe3af4f0) | `` python3.pkgs.xpath-expressions: replace poetry with poetry-core ``                   |
| [`db4ba9ac`](https://github.com/NixOS/nixpkgs/commit/db4ba9acad658206fd250b22b45bc508a3921f56) | `` python3.pkgs.xlsx2csv: add missing build dependencies ``                             |
| [`e8005351`](https://github.com/NixOS/nixpkgs/commit/e80053513f11b259d9aa54fc97ce755949896d60) | `` python3.pkgs.tweedledum: fix broken pyproject.toml ``                                |
| [`3c734d8c`](https://github.com/NixOS/nixpkgs/commit/3c734d8c47a9b51c3d9e8745ffe3b72510dd841c) | `` python3.pkgs.stravalib: add missing build dependencies ``                            |
| [`68d5e2e0`](https://github.com/NixOS/nixpkgs/commit/68d5e2e06e47fe6cb9e024f1ad787da7b1dd1d80) | `` python3.pkgs.sphinxcontrib-spelling: add missing build dependencies ``               |
| [`286e3eb1`](https://github.com/NixOS/nixpkgs/commit/286e3eb1c5235c2fc61dc08cf1378d96919c6321) | `` python3.pkgs.setupmeta: add missing dependencies ``                                  |
| [`24fcb504`](https://github.com/NixOS/nixpkgs/commit/24fcb50419c0c42ae84863106ac3365d93671d23) | `` python3.pkgs.scim2-filter-parser: replace poetry with poetry-core ``                 |
| [`87239a02`](https://github.com/NixOS/nixpkgs/commit/87239a023bf86c282a9ac3766afbc2dd54afb9be) | `` python3.pkgs.scikit-misc: add and relax build dependencies ``                        |
| [`8a79c8e8`](https://github.com/NixOS/nixpkgs/commit/8a79c8e839987dfcb5ca882b092ad518c50980dc) | `` python3.pkgs.rst2pdf: add missing build dependencies ``                              |
| [`f0ed49fd`](https://github.com/NixOS/nixpkgs/commit/f0ed49fd5089c60c98b77bcc878e54ad9061c0c4) | `` python3.pkgs.riscv-config: removing dangling pip import ``                           |
| [`f7d1a970`](https://github.com/NixOS/nixpkgs/commit/f7d1a9709cca3ba8ecf761f1fd51438c6f42abfe) | `` python3.pkgs.repoze_sphinx_autointerface: add missing test dependencies ``           |
| [`95197fe0`](https://github.com/NixOS/nixpkgs/commit/95197fe03b0be4891a4ab06368ed381ce00057cd) | `` python3.pkgs.pyvisa-sim: add missing build dependencies ``                           |
| [`5f00ddcf`](https://github.com/NixOS/nixpkgs/commit/5f00ddcf0bcb324c66b0680b7ba9a37d57b283f5) | `` python3.pkgs.python-vagrant: 1.0.0 -> 1.1.0 ``                                       |
| [`b7df9ed8`](https://github.com/NixOS/nixpkgs/commit/b7df9ed8df3b3e67098b4911ccc00a611bf4d9be) | `` python3.pkgs.python-otbr-api: relax setuptools dependency ``                         |
| [`f851b3a6`](https://github.com/NixOS/nixpkgs/commit/f851b3a62a96ac58690b4c8c6c422676e65fd6c6) | `` python3.pkgs.python-homewizard-energy: remove setuptools dependency ``               |
| [`333c180f`](https://github.com/NixOS/nixpkgs/commit/333c180f4a4a88cd7ccdb92a62822cebd1ad8e1a) | `` python3.pkgs.python-creole: replace poetry with poetry-core ``                       |
| [`a25d5530`](https://github.com/NixOS/nixpkgs/commit/a25d553044e1b8de35b3eb706a57ac266e8ff0a0) | `` python3.pkgs.pypck: relax setuptools dependency ``                                   |
| [`48050861`](https://github.com/NixOS/nixpkgs/commit/480508616dbbbf803b5e2ae02bd30d72bb48b4f1) | `` python3.pkgs.pyinsteon: relax setuptools dependency ``                               |
| [`137c4535`](https://github.com/NixOS/nixpkgs/commit/137c45359b0080443acb04038c25e649c1e01788) | `` python3.pkgs.flask-security-too: fix tests with setuptools 67.5.0+ ``                |
| [`58cc2257`](https://github.com/NixOS/nixpkgs/commit/58cc22577941fb63958856347e39e6ac034aa5ad) | `` python3.pkgs.flask-reverse-proxy: fix invalid version number when building ``        |
| [`7dee41de`](https://github.com/NixOS/nixpkgs/commit/7dee41dea46b874d46fcc3c3ca74bc2d2515aca2) | `` python3.pkgs.pydicom-seg: replace poetry with poetry-core ``                         |
| [`75e94e34`](https://github.com/NixOS/nixpkgs/commit/75e94e346bb1226e48c6c3c74b33b91a3245f7ea) | `` python3.pkgs.pydeck: add missing build dependencies ``                               |
| [`cc05774b`](https://github.com/NixOS/nixpkgs/commit/cc05774b30b62bab360aeb39a2ae4cafd9739cab) | `` python3.pkgs.py-dormakaba-dkey: relax setuptools dependency ``                       |
| [`269bf508`](https://github.com/NixOS/nixpkgs/commit/269bf5083d385dfaa962ed870b0b6982cec48d1e) | `` python3.pkgs.polyline: relax build dependencies ``                                   |
| [`42926ea7`](https://github.com/NixOS/nixpkgs/commit/42926ea7d899ed3c389288d8c27d5e2c3f7cbe45) | `` python3.pkgs.pipdeptree: fix propagatedBuildInputs typo ``                           |
| [`a2bb835e`](https://github.com/NixOS/nixpkgs/commit/a2bb835e2c9e7d05935ad5cba73fe16e826b2dbc) | `` python3.pkgs.nitime: add build dependencies and relax numpy constraint ``            |
| [`2b83a561`](https://github.com/NixOS/nixpkgs/commit/2b83a561808d6a079d474e3c4a6f5a400e0313aa) | `` python3.pkgs.newversion: remove setuptools dependency ``                             |
| [`9ca3487d`](https://github.com/NixOS/nixpkgs/commit/9ca3487d8b288378a51a768b60bc4fda91215c31) | `` python3.pkgs.netcdf4: add missing build dependencies ``                              |
| [`3e173827`](https://github.com/NixOS/nixpkgs/commit/3e173827d723984c0d372cfe153c9b112a63d55c) | `` python3.pkgs.napalm-hp-procurve: add pip dependency and other improvements ``        |
| [`4e481477`](https://github.com/NixOS/nixpkgs/commit/4e481477c11f8550d7ce10123d1f96cc580b365c) | `` python3.pkgs.multiset: relax setuptools-scm dependency ``                            |
| [`07fd57bf`](https://github.com/NixOS/nixpkgs/commit/07fd57bfb673945eb0cac2d3927387d3e5e43d41) | `` python3.pkgs.msprime: add missing build dependencies ``                              |
| [`a967c0f7`](https://github.com/NixOS/nixpkgs/commit/a967c0f7410d1e3ab4dbf32ba31afb59d03cd76c) | `` python3.pkgs.laszip: fix how cmake and ninja dependencies are consumed ``            |
| [`6258bfda`](https://github.com/NixOS/nixpkgs/commit/6258bfda1346a61cd6d14d8bb361cd3b3086d5ee) | `` python3.pkgs.knx-frontend: relax build dependencies ``                               |
| [`5c0c5312`](https://github.com/NixOS/nixpkgs/commit/5c0c5312a1a16de7ddb6ca6d8a7152bedc885032) | `` python3.pkgs.grpc-interceptor: replace poetry with poetry-core ``                    |
| [`51a34aee`](https://github.com/NixOS/nixpkgs/commit/51a34aeec958b4ad3905fb790c8488da1d0b3fcc) | `` python3.pkgs.cohere: replace poetry with poetry-core ``                              |