### PR TITLE
chore(flake/nixpkgs): `3efb0f6f` -> `e7f38be3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -377,11 +377,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693250523,
-        "narHash": "sha256-y3up5gXMTbnCsXrNEB5j+7TVantDLUYyQLu/ueiXuyg=",
+        "lastModified": 1693377291,
+        "narHash": "sha256-vYGY9bnqEeIncNarDZYhm6KdLKgXMS+HA2mTRaWEc80=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3efb0f6f404ec8dae31bdb1a9b17705ce0d6986e",
+        "rev": "e7f38be3775bab9659575f192ece011c033655f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                               |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
| [`76fd17ac`](https://github.com/NixOS/nixpkgs/commit/76fd17ac22d892099775c22d0d54e209d3df27e2) | `` terraform-providers.ibm: 1.56.1 -> 1.56.2 ``                                                                       |
| [`13268f92`](https://github.com/NixOS/nixpkgs/commit/13268f92d27edd5b7a53e8c694e10e76c45a7137) | `` terraform-providers.linode: 2.6.0 -> 2.7.0 ``                                                                      |
| [`6f8ebca0`](https://github.com/NixOS/nixpkgs/commit/6f8ebca05b042d59cc320951e9b2f6082e06cd7c) | `` terraform-providers.equinix: 1.15.0 -> 1.16.0 ``                                                                   |
| [`f412c44e`](https://github.com/NixOS/nixpkgs/commit/f412c44e09ab440fd3f04fb6366914e75b54cb1e) | `` terraform-providers.baiducloud: 1.19.13 -> 1.19.14 ``                                                              |
| [`0be98b25`](https://github.com/NixOS/nixpkgs/commit/0be98b25b49fe3ba7a9304b0b35de068fd328a4f) | `` terraform-providers.akamai: 5.1.0 -> 5.2.0 ``                                                                      |
| [`70aed6ed`](https://github.com/NixOS/nixpkgs/commit/70aed6ed62fd9e9872c939ddd4b2576c4a0b8d8f) | `` terraform-providers.aviatrix: 3.1.1 -> 3.1.2 ``                                                                    |
| [`9a63786b`](https://github.com/NixOS/nixpkgs/commit/9a63786b79dd7e2b1fdb1e115dcef860a5490590) | `` snd: 23.5 -> 23.6 ``                                                                                               |
| [`9262b8ab`](https://github.com/NixOS/nixpkgs/commit/9262b8ab0543b422fa6d88501bd8e14abcf32a27) | `` python310Packages.drf-yasg: 1.21.5 -> 1.21.7 ``                                                                    |
| [`020300a7`](https://github.com/NixOS/nixpkgs/commit/020300a756e75ea9ce86a8ab5ee259c31e28ed43) | `` go_1_21: bootstrap from 1.21 ``                                                                                    |
| [`0daa8bc0`](https://github.com/NixOS/nixpkgs/commit/0daa8bc0698a70625a5c457e11f46dc087f66b65) | `` viddy: 0.3.6 -> 0.3.7 ``                                                                                           |
| [`9b5a1f9a`](https://github.com/NixOS/nixpkgs/commit/9b5a1f9addc687ef8ac0d3707d32c2f463869f0d) | `` python310Packages.aioapns: 2.2 -> 3.0 ``                                                                           |
| [`90f5c4ea`](https://github.com/NixOS/nixpkgs/commit/90f5c4ea8ea1dbf7c35bdc80e624a325b35de896) | `` nix-doc: 0.5.10 -> 0.6.0 ``                                                                                        |
| [`26ee8b86`](https://github.com/NixOS/nixpkgs/commit/26ee8b86a18b150e28c442c39ec33c9215769f88) | `` rizin: 0.6.0 -> 0.6.1 ``                                                                                           |
| [`dd31ab5d`](https://github.com/NixOS/nixpkgs/commit/dd31ab5d804fed00727d145882b2fe07ed1b8c5d) | `` mg: 7.0 -> 7.3 ``                                                                                                  |
| [`d42ae665`](https://github.com/NixOS/nixpkgs/commit/d42ae665dc4a541f25a9bc810505025c2c090624) | `` tests.nixpkgs-check-by-name: Cleaner testing ``                                                                    |
| [`6f887c05`](https://github.com/NixOS/nixpkgs/commit/6f887c05e6764d764bb53cd8e47a1ffc706afba1) | `` python310Packages.xml2rfc: 3.17.3 -> 3.18.0 ``                                                                     |
| [`55c8f51a`](https://github.com/NixOS/nixpkgs/commit/55c8f51af5edeaa4d568df15e206601d233e8d33) | `` nixos/nncp: add caller and daemon services ``                                                                      |
| [`cd856f1f`](https://github.com/NixOS/nixpkgs/commit/cd856f1fad82746da78f832c0dee63d92ca912c3) | `` classicube: 1.3.5 -> 1.3.6 ``                                                                                      |
| [`4c360a02`](https://github.com/NixOS/nixpkgs/commit/4c360a02250c1634cb0d04e83016a9cd44a728d2) | `` pyenv: 2.3.24 -> 2.3.25 ``                                                                                         |
| [`c022ff0b`](https://github.com/NixOS/nixpkgs/commit/c022ff0b502e8081eaf20772b889d75ce48316f0) | `` gpsd: enable on darwin ``                                                                                          |
| [`0ed4dff7`](https://github.com/NixOS/nixpkgs/commit/0ed4dff7dd5a37ee89d8ca030eadb6c506d66a7e) | `` parsec-bin: avoid patching dylib in `share/parsec/skel` ``                                                         |
| [`61d66930`](https://github.com/NixOS/nixpkgs/commit/61d6693090da115bed79f14e10a445e0abc00569) | `` pythonPackages.debianbts: init at 4.0.1 ``                                                                         |
| [`b1979e6d`](https://github.com/NixOS/nixpkgs/commit/b1979e6d66830363609288d44e59919bcf831ad8) | `` pythonPackages.pysimplesoap: init at 1.16.2 ``                                                                     |
| [`3b8331a9`](https://github.com/NixOS/nixpkgs/commit/3b8331a9986b86ec7f9b2dcf8ab03c9bd7322719) | `` parsec-bin: update runtime dependencies ``                                                                         |
| [`e580181a`](https://github.com/NixOS/nixpkgs/commit/e580181a13b16c737ce8c63dbf55fc4f60da1e30) | `` raysession: Fix issues with qt not being patched (can’t find platform, qt version mismatch error etc) (#236762) `` |
| [`5d13f3f4`](https://github.com/NixOS/nixpkgs/commit/5d13f3f4e9822e068181d5186308122190793cd0) | `` mkvtoolnix: disable update check ``                                                                                |
| [`e6c47d3a`](https://github.com/NixOS/nixpkgs/commit/e6c47d3a25e9bb0a7f154cd6e9d44be5040699a4) | `` flrig: 2.0.02 -> 2.0.03 ``                                                                                         |
| [`56087449`](https://github.com/NixOS/nixpkgs/commit/56087449b1a661751c4236cff82c87f46d8a2d25) | `` where-is-my-sddm-theme: init at 1.3.0 ``                                                                           |
| [`20a15c79`](https://github.com/NixOS/nixpkgs/commit/20a15c7985768e0b0f7c1a2643e40b4516629569) | `` npm-check-updates: use buildNpmPackage ``                                                                          |
| [`56c65cbb`](https://github.com/NixOS/nixpkgs/commit/56c65cbb2ea963892de324e1064eeccc262769b4) | `` ocamlPackages.eio: 0.11 → 0.12 ``                                                                                  |
| [`5c6bfa6a`](https://github.com/NixOS/nixpkgs/commit/5c6bfa6a4b9032dca5d044def5e2c39a1433d0a0) | `` bitwarden-cli: 2023.7.0 -> 2023.8.2 ``                                                                             |
| [`0ff89e52`](https://github.com/NixOS/nixpkgs/commit/0ff89e52a41c5ef0f6fa81e08876b41ac2443731) | `` python311Packages.python-box: 7.0.1 -> 7.1.1 ``                                                                    |
| [`34c8b0a8`](https://github.com/NixOS/nixpkgs/commit/34c8b0a8e5fb87b6b36d19fa6684d8d3274de0e6) | `` nixos/release-combined.nix: Build pkgs/by-name tester ``                                                           |
| [`7875ccf6`](https://github.com/NixOS/nixpkgs/commit/7875ccf6a0794738cc2acbd1f8ad6ac0586f1a6d) | `` python310Packages.ansible-compat: 4.1.5 -> 4.1.8 ``                                                                |
| [`07f70f87`](https://github.com/NixOS/nixpkgs/commit/07f70f87f46ab6634170d69d32fd7d1784cbdc5a) | `` patchance: 1.0.0 -> 1.1.0 ``                                                                                       |
| [`4fa859c5`](https://github.com/NixOS/nixpkgs/commit/4fa859c5f1e5346870954e455afa52fc591fd5c5) | `` patchance: Fix issues with qt not being patched (see #236762) ``                                                   |
| [`271eb029`](https://github.com/NixOS/nixpkgs/commit/271eb0299503892944986eb381b79ec09ea2f2a4) | `` pkgs/test/nixpkgs-check-by-name: init ``                                                                           |
| [`5a354b6e`](https://github.com/NixOS/nixpkgs/commit/5a354b6ea6f33d715ade4b2683ed1baae9d38e31) | `` python310Packages.mkdocstrings-python: 1.5.2 -> 1.6.0 ``                                                           |
| [`0fd29ad6`](https://github.com/NixOS/nixpkgs/commit/0fd29ad676b88eeeb845b2c616702df11255610c) | `` sing-box: 1.3.6 -> 1.4.0 ``                                                                                        |
| [`58f06732`](https://github.com/NixOS/nixpkgs/commit/58f067329f0de9c99ccfff58e01886a85ec1b6b0) | `` firefox-esr-115-unwrapped: 115.1.0esr -> 115.2.0esr ``                                                             |
| [`504e70de`](https://github.com/NixOS/nixpkgs/commit/504e70de47145f4ed4bc463ee41bf2f7919611ff) | `` firefox-esr-102-unwrapped: 102.14.0esr -> 102.15.0esr ``                                                           |
| [`54c2919e`](https://github.com/NixOS/nixpkgs/commit/54c2919e5efa04eabd2c122ef0b64b76701c438a) | `` firefox-bin-unwrapped: 116.0.3 -> 117.0 ``                                                                         |
| [`c6cf5414`](https://github.com/NixOS/nixpkgs/commit/c6cf5414b6ba51c6ca62f6ee84f89c0037951b0d) | `` firefox-unwrapped: 116.0.3 -> 117.0 ``                                                                             |
| [`4a05d4a2`](https://github.com/NixOS/nixpkgs/commit/4a05d4a24ed3252e4ee7ab9153db76cf7e9a2747) | `` cargo-hack: 0.6.3 -> 0.6.4 ``                                                                                      |
| [`65f8fbba`](https://github.com/NixOS/nixpkgs/commit/65f8fbba272569bf6a45792d3fb0c0fc15c99285) | `` maintainers: update ludovicopiero's email ``                                                                       |
| [`dfd13420`](https://github.com/NixOS/nixpkgs/commit/dfd1342013c23ed949df294366381ee83a819f2f) | `` xorg.xrandr: Add mainProgram metadata ``                                                                           |
| [`f129e294`](https://github.com/NixOS/nixpkgs/commit/f129e294b3f51ddfc3d1c0e47aac8a3b29ceee07) | `` anki: mark as broken on darwin ``                                                                                  |
| [`9c577da7`](https://github.com/NixOS/nixpkgs/commit/9c577da750f49d00d41cadab9f9db0a35a66d45a) | `` anki: 2.1.61 -> 2.1.65 ``                                                                                          |
| [`90a07abb`](https://github.com/NixOS/nixpkgs/commit/90a07abbf868a8aaf086c39281d85cb8a7f710ac) | `` matrix-synapse-tools.synadm: 0.41.3 -> 0.42 ``                                                                     |
| [`4a4ea334`](https://github.com/NixOS/nixpkgs/commit/4a4ea33437a08ab7a3ce9927487997e7981f6f20) | `` mission-center: add meta.mainProgram ``                                                                            |
| [`8614e0e3`](https://github.com/NixOS/nixpkgs/commit/8614e0e392279c731d0eddd83a7ba8141b514ad2) | `` unciv: 4.7.13 -> 4.7.17-patch1 ``                                                                                  |
| [`3f9ea77d`](https://github.com/NixOS/nixpkgs/commit/3f9ea77d2f8f2d8fdba687667b7545519112eadd) | `` gitoxide: 0.28.0 -> 0.29.0 ``                                                                                      |
| [`e0c56c89`](https://github.com/NixOS/nixpkgs/commit/e0c56c8921948f3fd70b9fe61c10ecbcc6f33716) | `` python311Packages.asyncua: 1.0.4 -> 1.0.4 ``                                                                       |
| [`55209e51`](https://github.com/NixOS/nixpkgs/commit/55209e512b0205fa360c2f46354561c37d57e155) | `` keycloak.scim-for-keycloak: kc-15-b2 -> kc-20-b1 ``                                                                |
| [`a917cde4`](https://github.com/NixOS/nixpkgs/commit/a917cde4aa5f0948c11c3bdb23977cd5e5f8a2f9) | `` beep: add meta.mainProgam ``                                                                                       |
| [`17f1f8e2`](https://github.com/NixOS/nixpkgs/commit/17f1f8e22153184885df9f64ad767f07bd647e31) | `` micronaut: 4.0.4 -> 4.0.5 ``                                                                                       |
| [`2bbb18a2`](https://github.com/NixOS/nixpkgs/commit/2bbb18a2ce4b59a02d68a73d607fb04c8a2e32b4) | `` tidal-hifi: 5.6.0 -> 5.7.0 ``                                                                                      |
| [`69c148b7`](https://github.com/NixOS/nixpkgs/commit/69c148b755e1b564f1b126e650ccbb08726e4bb6) | `` rssguard: 4.4.0 -> 4.5.0 ``                                                                                        |
| [`8761b147`](https://github.com/NixOS/nixpkgs/commit/8761b1475b9d71fc21785bf1d703179fe77af58f) | `` nongnu-packages: updated 2023-08-26 (from overlay) ``                                                              |
| [`9e2d9858`](https://github.com/NixOS/nixpkgs/commit/9e2d98584daf64e33bd9ffe0e56318cd49852b35) | `` melpa-packages: updated 2023-08-26 (from overlay) ``                                                               |
| [`d751b58f`](https://github.com/NixOS/nixpkgs/commit/d751b58f9907cd5eb8d4f330f58a3b4fae296fd1) | `` elpa-devel-packages: updated 2023-08-26 (from overlay) ``                                                          |
| [`eff18386`](https://github.com/NixOS/nixpkgs/commit/eff18386fe88b8e350ff4deb2a4b70282802c6b6) | `` elpa-packages: updated 2023-08-26 (from overlay) ``                                                                |
| [`959c1b37`](https://github.com/NixOS/nixpkgs/commit/959c1b371ffa781b07767f23b8fa3ac352c04ca7) | `` python311Packages.aiohomekit: 2.6.16 -> 3.0.1 ``                                                                   |
| [`139c4530`](https://github.com/NixOS/nixpkgs/commit/139c45309454156581e6d5a09d5b5cc9ebc1db70) | `` moolticute: 1.01.0 -> 1.02.0 ``                                                                                    |
| [`a5299340`](https://github.com/NixOS/nixpkgs/commit/a529934027c05080f544c9c4504cd2de7b4563d8) | `` netbird-ui: 0.22.6 -> 0.22.7 ``                                                                                    |
| [`cff9c7a2`](https://github.com/NixOS/nixpkgs/commit/cff9c7a2a01234a1a66860ecde0025b363caf84a) | `` pantheon.wingpanel: 3.0.3 -> 3.0.4 ``                                                                              |
| [`455eddba`](https://github.com/NixOS/nixpkgs/commit/455eddbaab06c72d554c84bbbc5b42e6c3a25e90) | `` uncover: 1.0.5 -> 1.0.6 ``                                                                                         |
| [`caf1c274`](https://github.com/NixOS/nixpkgs/commit/caf1c274e41278f67834a721678844dfb6515693) | `` wlroots: set default to 0.16 ``                                                                                    |
| [`b5f80b41`](https://github.com/NixOS/nixpkgs/commit/b5f80b41c5c9a7ed23758b110c4de53c20a355a6) | `` charasay: 3.0.1 -> 3.1.0 ``                                                                                        |
| [`ab65d8c2`](https://github.com/NixOS/nixpkgs/commit/ab65d8c2dcac39c3729727256caa1833451c8434) | `` eksctl: 0.153.0 -> 0.154.0 ``                                                                                      |
| [`a37b4688`](https://github.com/NixOS/nixpkgs/commit/a37b4688063667e17d9bd36363ccf2f942c305aa) | `` python3Packages.pipenv-poetry-migrate: 0.3.2 -> 0.4.0 ``                                                           |
| [`05727304`](https://github.com/NixOS/nixpkgs/commit/05727304f8815825565c944d012f20a9a096838a) | `` anki-bin: 2.1.65 -> 2.1.66 ``                                                                                      |
| [`0c517cc8`](https://github.com/NixOS/nixpkgs/commit/0c517cc8109e10e4856c864e6814205bcbc277f3) | `` python311Packages.cobs: init at 1.2.0 ``                                                                           |
| [`259a2d51`](https://github.com/NixOS/nixpkgs/commit/259a2d5108fb984e2bec0934b3a41f2dfd9ba453) | `` dig: fix nix run usage ``                                                                                          |