### PR TITLE
chore(flake/home-manager): `a7eab56b` -> `f5c15668`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693389467,
-        "narHash": "sha256-CKu2gujCc1jMVqrgo0sQ5Xf/KaXIOtZUakFkBHigHCU=",
+        "lastModified": 1693399033,
+        "narHash": "sha256-yXhiMo8MnE86sGtPIHAKaLHhmhe8v9tqGGotlUgKJvY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a7eab56be526bb0c052ffe187177268efabc4808",
+        "rev": "f5c15668f9842dd4d5430787d6aa8a28a07f7c10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`f5c15668`](https://github.com/nix-community/home-manager/commit/f5c15668f9842dd4d5430787d6aa8a28a07f7c10) | `` tests: update to match latest TOML output `` |