### PR TITLE
chore(flake/nixos-hardware): `fe0ea731` -> `793de77d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -362,11 +362,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1693588489,
-        "narHash": "sha256-hUGiONyurfBxmTtRUttdlkdq+ml16L1MiKKAS1047OE=",
+        "lastModified": 1693718952,
+        "narHash": "sha256-+nGdJlgTk0MPN7NygopipmyylVuAVi7OItIwTlwtGnw=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "fe0ea731b84b10143fc68cd557368ac70f0fb65c",
+        "rev": "793de77d9f83418b428e8ba70d1e42c6507d0d35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`793de77d`](https://github.com/NixOS/nixos-hardware/commit/793de77d9f83418b428e8ba70d1e42c6507d0d35) | `` purism librem5r4: add configuration option for audio ``          |
| [`3284d060`](https://github.com/NixOS/nixos-hardware/commit/3284d0605cce3e49e35a28924f4f6cfa9edd8a60) | `` purism librem5r4: update uboot ``                                |
| [`6a1fb218`](https://github.com/NixOS/nixos-hardware/commit/6a1fb21810cc075f33d55a134c84d1039db10291) | `` purism librem5r4: update kernel to 6.4.5 ``                      |
| [`658064ce`](https://github.com/NixOS/nixos-hardware/commit/658064ce36d028777e8d6643b02822a93834ca11) | `` Apply suggestions from @louib ``                                 |
| [`9070d234`](https://github.com/NixOS/nixos-hardware/commit/9070d2340c16508e81e68e037a775618bb28b8d4) | `` Add config for Librem 5 ``                                       |
| [`50dc4ef9`](https://github.com/NixOS/nixos-hardware/commit/50dc4ef9288a6b6ba1536fabe899090a91390945) | `` friendlyarm/nanopi-r5s: init config ``                           |
| [`7ed4fdbd`](https://github.com/NixOS/nixos-hardware/commit/7ed4fdbdb5aec0fefa5f8951a88ebe3e4d9b540a) | `` Add fgaz to star64 codeowners ``                                 |
| [`416249d1`](https://github.com/NixOS/nixos-hardware/commit/416249d1ba7f4312836fe7216a95cb06c288312a) | `` surface: add kernel 6.4.12 ``                                    |
| [`1ed1234a`](https://github.com/NixOS/nixos-hardware/commit/1ed1234ad682e90fda13d837ba68268399f207e3) | `` feat: add initial support for odroid-h3 hardware ``              |
| [`19cf623e`](https://github.com/NixOS/nixos-hardware/commit/19cf623e481f1a29d01101f6468f58aa96e36e08) | `` feat: add common config for intel elhart-lake and jasper-lake `` |
| [`6f081cd5`](https://github.com/NixOS/nixos-hardware/commit/6f081cd52a2e0c68ab371b439e964355efb3002c) | `` apple/t2: update to kernel 6.5 ``                                |