### PR TITLE
chore(flake/nixpkgs): `aa8aa7e2` -> `e5699088`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -377,11 +377,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693565476,
-        "narHash": "sha256-ya00zHt7YbPo3ve/wNZ/6nts61xt7wK/APa6aZAfey0=",
+        "lastModified": 1693663421,
+        "narHash": "sha256-ImMIlWE/idjcZAfxKK8sQA7A1Gi/O58u5/CJA+mxvl8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aa8aa7e2ea35ce655297e8322dc82bf77a31d04b",
+        "rev": "e56990880811a451abd32515698c712788be5720",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`3690d7f9`](https://github.com/NixOS/nixpkgs/commit/3690d7f945bcd34e10a6e318ce534f9d384f4d54) | `` linux-rt_5_15: 5.15.125-rt66 -> 5.15.129-rt67 ``                            |
| [`265e6de1`](https://github.com/NixOS/nixpkgs/commit/265e6de15a7f817a5f21badc79882acfd83e122f) | `` ttop: 1.0.1 → 1.2.0 ``                                                      |
| [`6c9c7470`](https://github.com/NixOS/nixpkgs/commit/6c9c7470be852ed37663fdced1af65dbe263c4b8) | `` python310Packages.python-novaclient: 18.3.0 -> 18.4.0 ``                    |
| [`afee17a4`](https://github.com/NixOS/nixpkgs/commit/afee17a45708414a54f36449590f46c3fb0693c3) | `` python310Packages.python-pptx: 0.6.21 -> 0.6.22 ``                          |
| [`872a3dc6`](https://github.com/NixOS/nixpkgs/commit/872a3dc60cb6f4e85147f13a02e047f8895b0d93) | `` yazi: 0.1.3 -> 0.1.4 ``                                                     |
| [`a5facc94`](https://github.com/NixOS/nixpkgs/commit/a5facc94c82894e2a23f922d541a3a1d66d951e2) | `` juicity: 0.2.1 -> 0.3.0 ``                                                  |
| [`4804af5e`](https://github.com/NixOS/nixpkgs/commit/4804af5e390712f34f8028e83f84801a4a291ce7) | `` python311Packages.coinmetrics-api-client: 2023.8.24.13 -> 2023.8.30.20 ``   |
| [`0a097d17`](https://github.com/NixOS/nixpkgs/commit/0a097d173a0d92f5833b8ed87d697235f0d298b8) | `` python310Packages.atlassian-python-api: 3.41.0 -> 3.41.1 ``                 |
| [`789046ef`](https://github.com/NixOS/nixpkgs/commit/789046ef13d68f109901085f61c850f00b1416a0) | `` python311Packages.gvm-tools: 23.4.0 -> 23.9.0 ``                            |
| [`01528e17`](https://github.com/NixOS/nixpkgs/commit/01528e1773a371f3dd9b963e2358ca605de890c2) | `` python311Packages.pyvesync: 2.1.9 -> 2.1.10 ``                              |
| [`f0e34ad6`](https://github.com/NixOS/nixpkgs/commit/f0e34ad6fe469616fdce6599bbac74fccb7f55f7) | `` python311Packages.griffe: 0.35.2 -> 0.36.0 ``                               |
| [`a2c74a94`](https://github.com/NixOS/nixpkgs/commit/a2c74a94d95826abe3867723376f7090ed986786) | `` python311Packages.certipy-ad: 4.7.0 -> 4.8.0 ``                             |
| [`79ffe616`](https://github.com/NixOS/nixpkgs/commit/79ffe616fad39888e807d324133454c10ced6429) | `` n98-magerun2: 6.1.1 -> 7.1.0 ``                                             |
| [`4a97379a`](https://github.com/NixOS/nixpkgs/commit/4a97379a91bed37e16316084291444366945e44a) | `` n98-magerun: update `src` and minor refactor ``                             |
| [`2d94555e`](https://github.com/NixOS/nixpkgs/commit/2d94555e5d030cd218148dc08d3a016fd344bced) | `` linux: 6.5 -> 6.5.1 ``                                                      |
| [`f77a564a`](https://github.com/NixOS/nixpkgs/commit/f77a564a4465ff2b12f2f6adb86789ad198dff5f) | `` linux: 6.4.13 -> 6.4.14 ``                                                  |
| [`3da23fab`](https://github.com/NixOS/nixpkgs/commit/3da23fab25009a8be8109ea383a87f93e243c982) | `` linux: 6.1.50 -> 6.1.51 ``                                                  |
| [`afec48ee`](https://github.com/NixOS/nixpkgs/commit/afec48eeb264c96ffa0800bb0cafea7940436376) | `` linux: 5.4.255 -> 5.4.256 ``                                                |
| [`fbb89f9d`](https://github.com/NixOS/nixpkgs/commit/fbb89f9d4396a25fc34de583692bbb8c78bd6e4b) | `` linux: 5.15.129 -> 5.15.130 ``                                              |
| [`e3af9c78`](https://github.com/NixOS/nixpkgs/commit/e3af9c78b8d48360bd43ff2287e3b2f3544faae1) | `` linux: 5.10.193 -> 5.10.194 ``                                              |
| [`17bf2848`](https://github.com/NixOS/nixpkgs/commit/17bf2848f915cd431be8f1ce2b1bd35e9402acca) | `` linux: 4.19.293 -> 4.19.294 ``                                              |
| [`dc66c610`](https://github.com/NixOS/nixpkgs/commit/dc66c610852e5b6d700a1ea001ffe715131b3b75) | `` linux: 4.14.324 -> 4.14.325 ``                                              |
| [`dbc33a45`](https://github.com/NixOS/nixpkgs/commit/dbc33a4528bfab85d593ddbfebac29ba403a6117) | `` tgpt: 1.7.4 -> 1.7.5 ``                                                     |
| [`aecda065`](https://github.com/NixOS/nixpkgs/commit/aecda065dd082df4bc9a2d81e7189c2b76842922) | `` python311Packages.bellows: 0.35.9 -> 0.36.1 ``                              |
| [`dd822af4`](https://github.com/NixOS/nixpkgs/commit/dd822af4232242b719086ec8c4d5ef66e59ed9c6) | `` nnn: 4.8 → 4.9 ``                                                           |
| [`89ff0e57`](https://github.com/NixOS/nixpkgs/commit/89ff0e57e42c18e9378885c3b30e370d789a4fe5) | `` nimPackages.safeseq: init at 1.0.0 ``                                       |
| [`2d42597b`](https://github.com/NixOS/nixpkgs/commit/2d42597b7736d27a25296daed0001dbfe618cd9b) | `` nimdow: 0.7.36->0.7.37 ``                                                   |
| [`8928ac9f`](https://github.com/NixOS/nixpkgs/commit/8928ac9f37c7c13b8cb0cce4667b5e5fea59bcb0) | `` python311Packages.aliyun-python-sdk-config: 2.2.11 -> 2.2.12 ``             |
| [`131447ef`](https://github.com/NixOS/nixpkgs/commit/131447efebd84dd35913de00246b6baab36d642a) | `` python310Packages.peft: 0.4.0 -> 0.5.0 ``                                   |
| [`0cde4755`](https://github.com/NixOS/nixpkgs/commit/0cde47556236ce59db893e4cced48694305a27f8) | `` ipfs-upload-client: 0.1.1 -> 0.1.2 ``                                       |
| [`62cc4c61`](https://github.com/NixOS/nixpkgs/commit/62cc4c613673d218e38c1cf42122add4dd8b5164) | `` bililiverecorder: 2.6.3 -> 2.8.2 ``                                         |
| [`c7e87ffd`](https://github.com/NixOS/nixpkgs/commit/c7e87ffd6d506de11c2e877ff1ae49bd4f7cc9bf) | `` bilibili: 1.10.1-4 -> 1.11.4-1 ``                                           |
| [`60b22810`](https://github.com/NixOS/nixpkgs/commit/60b2281050e167b36fde54abb83fa237bc6e3c55) | `` aws-nuke: 2.24.1 -> 2.24.2 ``                                               |
| [`accb86de`](https://github.com/NixOS/nixpkgs/commit/accb86debec1ae4802ac934bbc581eff8665a551) | `` _86Box: 3.11 -> 4.0 ``                                                      |
| [`6fed30b6`](https://github.com/NixOS/nixpkgs/commit/6fed30b63d86c500693668e912139860b8ee9bf2) | `` allure: 2.23.1 -> 2.24.0 ``                                                 |
| [`0acb350c`](https://github.com/NixOS/nixpkgs/commit/0acb350c7fdc8437e2ca23b61fc8e4f16a3d5857) | `` cordless: use sri hash ``                                                   |
| [`c4277221`](https://github.com/NixOS/nixpkgs/commit/c4277221c600a1a2657e43fc5c6d073fe5113fd4) | `` base16384: 2.2.4 -> 2.2.5 ``                                                |
| [`74f02b8b`](https://github.com/NixOS/nixpkgs/commit/74f02b8b25834c814867b4f9bc0c47eab40b6529) | `` arkade: 0.9.27 -> 0.10.0 ``                                                 |
| [`7192c8f4`](https://github.com/NixOS/nixpkgs/commit/7192c8f4870c77f3f696f3bde4f9ad952d1d2eda) | `` aws-sso-cli: 1.13.0 -> 1.13.1 ``                                            |
| [`7cd0af52`](https://github.com/NixOS/nixpkgs/commit/7cd0af5228f60277230a87c543dc10607d10ad1f) | `` bearer: 1.19.2 -> 1.21.0 ``                                                 |
| [`2cff2d52`](https://github.com/NixOS/nixpkgs/commit/2cff2d52f351d161d0c8f373980fa8dfdbf4d3e2) | `` python311Packages.botocore-stubs: 1.31.39 -> 1.31.40 ``                     |
| [`4cfb2020`](https://github.com/NixOS/nixpkgs/commit/4cfb20202cbae57034e692e0ff6ac83de93d1f51) | `` python310Packages.mercadopago: 2.2.0 -> 2.2.1 ``                            |
| [`eb8f24da`](https://github.com/NixOS/nixpkgs/commit/eb8f24da86f5467712fc808392d9db9797d38e05) | `` python310Packages.pytesseract: 0.3.10 -> 0.3.11 ``                          |
| [`50190b7f`](https://github.com/NixOS/nixpkgs/commit/50190b7f813ff233cb5addb08be4cf59dbf583b1) | `` kubectl-node-shell: 1.7.0 -> 1.8.0 ``                                       |
| [`16383268`](https://github.com/NixOS/nixpkgs/commit/163832681ea15f5f7646a19b61670d031f58d198) | `` steampipe: 0.20.10 -> 0.20.11 ``                                            |
| [`5e723cca`](https://github.com/NixOS/nixpkgs/commit/5e723cca173620e69123a510fac15b555e029ca5) | `` typos: 1.16.9 -> 1.16.10 ``                                                 |
| [`5bd05aee`](https://github.com/NixOS/nixpkgs/commit/5bd05aeea3b96ef125231e32e6f4d001b739ab1e) | `` hax11: init at unstable-2022-12-10 ``                                       |
| [`29afe512`](https://github.com/NixOS/nixpkgs/commit/29afe5123001aee2539c8f5db930c964f941f478) | `` python3Packages.tpm2-pytss: disable hardening ``                            |
| [`d760b830`](https://github.com/NixOS/nixpkgs/commit/d760b8309649d5f1f99238f88404eb4326d00a19) | `` python310Packages.zigpy: 0.57.0 -> 0.57.1 ``                                |
| [`7c9f832e`](https://github.com/NixOS/nixpkgs/commit/7c9f832e38dc216eb0da826c28e16d0a9148844e) | `` maui-shell: set platforms ``                                                |
| [`153e573a`](https://github.com/NixOS/nixpkgs/commit/153e573ae33798f8e84f8ddd28dcba1d9f2b51bd) | `` typst-live: unstable-2023-05-27 -> 0.6.0 ``                                 |
| [`e90c4d8d`](https://github.com/NixOS/nixpkgs/commit/e90c4d8d01539239a73298fa0a223cc33f436ad5) | `` egglog: unstable-2023-08-23 -> unstable-2023-08-29 ``                       |
| [`078db4eb`](https://github.com/NixOS/nixpkgs/commit/078db4ebf524387ecbdba9521f0be8ed6ddac31b) | `` cargo-component: unstable-2023-08-24 -> unstable-2023-08-31 ``              |
| [`4d489605`](https://github.com/NixOS/nixpkgs/commit/4d489605f07d58f33cf10eec25cda7f2bb9f7907) | `` ztags: unstable-2023-08-03 -> unstable-2023-08-29 ``                        |
| [`9fcb9d57`](https://github.com/NixOS/nixpkgs/commit/9fcb9d577fe7376111bfb75f14ac76bfede44272) | `` cyber: unstable-2023-08-24 -> unstable-2023-09-01 ``                        |
| [`715cf28c`](https://github.com/NixOS/nixpkgs/commit/715cf28c7d27f431a4cb45758729826b9ce027bb) | `` godns: 2.9.8 -> 2.9.9 ``                                                    |
| [`06af5be0`](https://github.com/NixOS/nixpkgs/commit/06af5be0144223488d7b13de8b170e8c6430b181) | `` surrealdb: 1.0.0-beta.9 -> 1.0.0-beta.10 ``                                 |
| [`a31d8be5`](https://github.com/NixOS/nixpkgs/commit/a31d8be5fcd1f5a6cb0a6d5daf618c8e57d2a0ae) | `` gitnr: init at 0.1.0 ``                                                     |
| [`da2da3ad`](https://github.com/NixOS/nixpkgs/commit/da2da3adce343a29fa41f2ec7fa907e74284a6df) | `` fh: init at 0.1.1 ``                                                        |
| [`48da6eb9`](https://github.com/NixOS/nixpkgs/commit/48da6eb9c1126893773d86d142fe306332867ff7) | `` pkgs/README.md: slight rewording (#252820) ``                               |
| [`e43cc09f`](https://github.com/NixOS/nixpkgs/commit/e43cc09fa792e9511409cce16196c9775f356c87) | `` matrix-sliding-sync: 0.99.7 -> 0.99.8 ``                                    |
| [`53271b32`](https://github.com/NixOS/nixpkgs/commit/53271b32b51079c11271fff6d8a097fc4745028f) | `` sparrow: 1.7.8 -> 1.7.9 ``                                                  |
| [`95ced283`](https://github.com/NixOS/nixpkgs/commit/95ced283da4f2eef8ce51f807c4f06c8421b71d9) | `` ruff: 0.0.286 -> 0.0.287 ``                                                 |
| [`c0ba71be`](https://github.com/NixOS/nixpkgs/commit/c0ba71be06e65ce44af33b1bdf929d5cf62f440a) | `` i3status-rust: 0.31.9 -> 0.32.0 ``                                          |
| [`10481cb0`](https://github.com/NixOS/nixpkgs/commit/10481cb0cf0496ca61e5de9fddeffed900390b43) | `` maintainers: document expectations (#250344) ``                             |
| [`e396e6a2`](https://github.com/NixOS/nixpkgs/commit/e396e6a2d845793cc0ae26d2bc0ebbaa49dcd64c) | `` papirus-icon-theme: 20230801 -> 20230901 ``                                 |
| [`2922a9b0`](https://github.com/NixOS/nixpkgs/commit/2922a9b04273f2cfb978411bfff1ffb838fbae6c) | `` python310Packages.oslo-log: 5.2.0 -> 5.3.0 ``                               |
| [`fe4d4467`](https://github.com/NixOS/nixpkgs/commit/fe4d446758746be57cc78ebf5a0909cb55e900d8) | `` Add `meta.mainProgram` (#252060) ``                                         |
| [`7c83ddb1`](https://github.com/NixOS/nixpkgs/commit/7c83ddb1819da66e62f6c536cff825436a2a2d20) | `` river: add meta.mainProgram ``                                              |
| [`710f09dc`](https://github.com/NixOS/nixpkgs/commit/710f09dc96928cd149998054790d224422f1964f) | `` python311Packages.orange3: adjust nativeBuildInputs ``                      |
| [`c0a742d3`](https://github.com/NixOS/nixpkgs/commit/c0a742d35af177c1d5d5f6b59150b5236525b243) | `` python311Packages.orange3: update meta ``                                   |
| [`85906693`](https://github.com/NixOS/nixpkgs/commit/85906693f1b0ace4b130d5fa6d2c42770c2ee44b) | `` vals: 0.27.0 -> 0.27.1 ``                                                   |
| [`c681218a`](https://github.com/NixOS/nixpkgs/commit/c681218af74b0f721ace9f1e3d10513446988461) | `` python311Packages.heudiconv: relax versioningit constraint ``               |
| [`dcca536d`](https://github.com/NixOS/nixpkgs/commit/dcca536d149a47ae32f16647bef438f39480211a) | `` phpPackages.castor: init at 0.8.0 ``                                        |
| [`b1c6e859`](https://github.com/NixOS/nixpkgs/commit/b1c6e8595ebdc650da0b4746eeac38d9c9d3e42c) | `` orbiton: 2.63.1 -> 2.64.3 ``                                                |
| [`2b95e588`](https://github.com/NixOS/nixpkgs/commit/2b95e588930409cbce0e16acb9b128fa89fa8185) | `` python311Packages.tlds: 2023050900 -> 2023080900 ``                         |
| [`5ff65c85`](https://github.com/NixOS/nixpkgs/commit/5ff65c85aab93078e93221b9dbc661e3d0ef436c) | `` python311Packages.tempora: update disabled ``                               |
| [`bd8e1dff`](https://github.com/NixOS/nixpkgs/commit/bd8e1dff0e194e1949c9be9c865633406d55b51b) | `` python311Packages.tempora: add changelog to meta ``                         |
| [`ddc7f4fb`](https://github.com/NixOS/nixpkgs/commit/ddc7f4fbfbefcd29ada8b273b97424cdd12a14c3) | `` python311Packages.tempora: 5.2.1 -> 5.5.0 ``                                |
| [`3955eace`](https://github.com/NixOS/nixpkgs/commit/3955eacec80cc0cee832e3b3d255a26a9d432957) | `` python311Packages.snscrape: 0.6.0.20230303 -> 0.7.0.20230622 ``             |
| [`3d3251d4`](https://github.com/NixOS/nixpkgs/commit/3d3251d43c9ba102299042576f7bf19ddc5f1b99) | `` blackbox-terminal: add mainProgram ``                                       |
| [`9fe31c87`](https://github.com/NixOS/nixpkgs/commit/9fe31c872842b040b641e0709c529a5f920252cc) | `` coreboot-toolchain: 4.20 -> 4.21 ``                                         |
| [`de810abf`](https://github.com/NixOS/nixpkgs/commit/de810abff360a1c0861d9f3c7b283663ca648aee) | `` python311Packages.schema-salad: 8.4.20230606143604 -> 8.4.20230808163024 `` |
| [`a0cec24e`](https://github.com/NixOS/nixpkgs/commit/a0cec24eb6882e7e255ca863dac6dc1967ed3ca0) | `` uxn: unstable-2023-08-10 -> unstable-2023-08-30 ``                          |
| [`1b5342ae`](https://github.com/NixOS/nixpkgs/commit/1b5342ae3a0816f310bf282a629dcc174e443803) | `` python311Packages.slack-bolt: add changelog to meta ``                      |
| [`133fa25e`](https://github.com/NixOS/nixpkgs/commit/133fa25eccb1d5aced1c58ac46d22e7dd434edbd) | `` python311Packages.slack-bolt: add optional-dependencies ``                  |
| [`5fd650cb`](https://github.com/NixOS/nixpkgs/commit/5fd650cb094bd7eb7d63d82d01850e4a93d12011) | `` python311Packages.slack-bolt: disable failing tests ``                      |
| [`b64f5766`](https://github.com/NixOS/nixpkgs/commit/b64f57662dd82843e95f5f110ad1824070a159ce) | `` python311Packages.slack-bolt: disable on unsupported Python releases ``     |
| [`38ae97bd`](https://github.com/NixOS/nixpkgs/commit/38ae97bdb2aa2d19f7ce8e8510be967c6bed2ac4) | `` python311Packages.returns: 0.21.0 -> 0.22.0 ``                              |
| [`465e05c0`](https://github.com/NixOS/nixpkgs/commit/465e05c0c5f63d48b3257b0a42e7739a235aa775) | `` lib.fileset.toSource: init ``                                               |
| [`9870f334`](https://github.com/NixOS/nixpkgs/commit/9870f334cbf2f822d273eba1cd05ef061d21d46a) | `` freecad: 0.21.0 -> 0.21.1 ``                                                |
| [`7b19fde3`](https://github.com/NixOS/nixpkgs/commit/7b19fde30783fe9f306e674b9376b4661cb169b3) | `` freecad: 0.20.2 -> 0.21.0 ``                                                |
| [`0efb400a`](https://github.com/NixOS/nixpkgs/commit/0efb400ade2ece459645763853f98b055a11fcf7) | `` emacs: add missing `libXi`  dependency when enabling `withXinput2` ``       |
| [`8a866283`](https://github.com/NixOS/nixpkgs/commit/8a866283bc3d18448d57c3bede64e3d9934c88dc) | `` grafana: 10.1.0 -> 10.1.1 ``                                                |
| [`e8df7d32`](https://github.com/NixOS/nixpkgs/commit/e8df7d3247a70556ec17bdb8c63c368ddc769ee5) | `` python310Packages.cmaes: add changelog to meta ``                           |
| [`d6c89ca1`](https://github.com/NixOS/nixpkgs/commit/d6c89ca17c8b4f16db671ee75d69ddee38a1725f) | `` jftui: 0.7.1 -> 0.7.2 ``                                                    |
| [`26265ccd`](https://github.com/NixOS/nixpkgs/commit/26265ccd8940823eccfe1c369166601e0abe7001) | `` cargo-audit: 0.17.6 -> 0.18.1 ``                                            |
| [`e57b1cea`](https://github.com/NixOS/nixpkgs/commit/e57b1ceab32aeb1a9c3a73b3405f489cc352e26c) | `` cargo-generate: 0.18.3 -> 0.18.4 ``                                         |
| [`201145aa`](https://github.com/NixOS/nixpkgs/commit/201145aaceccfeea037108c3e442a8e64189a2d5) | `` complgen: unstable-2023-08-22 -> 0.1.2 ``                                   |
| [`c320fe64`](https://github.com/NixOS/nixpkgs/commit/c320fe642e4d0b0b7ae1ba74d560f5afe05eed22) | `` python311Packages.prettytable: 3.5.0 -> 3.8.0 ``                            |
| [`17403b1e`](https://github.com/NixOS/nixpkgs/commit/17403b1ef1a0fc1b6e533e0914bfeebf9c6dfb39) | `` python310Packages.cmaes: 0.9.1 -> 0.10.0 ``                                 |