### PR TITLE
chore(flake/home-manager): `8e49b883` -> `3c0e381f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693713564,
-        "narHash": "sha256-00w2uwb4O6Y1e2W5LG5UFyl1ZN3KFG7aoRdYEvT/BqA=",
+        "lastModified": 1693895999,
+        "narHash": "sha256-yN1XVFltQxiwle833KCqWkZNfBuRLWkXyEnOD+ljoYY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8e49b883890ccb52c059abb152b00a416342ec1c",
+        "rev": "3c0e381fef63e4fbc6c3292c9e9cbcf479c01794",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`3c0e381f`](https://github.com/nix-community/home-manager/commit/3c0e381fef63e4fbc6c3292c9e9cbcf479c01794) | `` carapace: add module ``                             |
| [`886ea1d2`](https://github.com/nix-community/home-manager/commit/886ea1d213efd1082f419d066e89ef37635dc970) | `` accounts.email: fix runbox.com TLS setup (#4408) `` |