### PR TITLE
chore(flake/nixpkgs): `e5699088` -> `3c15feef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -377,11 +377,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693663421,
-        "narHash": "sha256-ImMIlWE/idjcZAfxKK8sQA7A1Gi/O58u5/CJA+mxvl8=",
+        "lastModified": 1693844670,
+        "narHash": "sha256-t69F2nBB8DNQUWHD809oJZJVE+23XBrth4QZuVd6IE0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e56990880811a451abd32515698c712788be5720",
+        "rev": "3c15feef7770eb5500a4b8792623e2d6f598c9c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`3c15feef`](https://github.com/NixOS/nixpkgs/commit/3c15feef7770eb5500a4b8792623e2d6f598c9c1) | `` root: 6.26.10 -> 6.28.06 (#215187) ``                                       |
| [`238a2f85`](https://github.com/NixOS/nixpkgs/commit/238a2f85cf6a2a610acd02791fdf5acc9f1f701a) | `` kraft: 0.6.4 -> 0.6.6 ``                                                    |
| [`85cd8cae`](https://github.com/NixOS/nixpkgs/commit/85cd8caee853dc525f2a280a6a1003b36b17d348) | `` sketchybar: 2.16.1 -> 2.16.3 ``                                             |
| [`8c603d5a`](https://github.com/NixOS/nixpkgs/commit/8c603d5a8c9479177c8dd0993e9884eb9cf88ec0) | `` yosys-symbiflow: 1.20230425 -> 1.20230808 ``                                |
| [`7d1ddd1d`](https://github.com/NixOS/nixpkgs/commit/7d1ddd1dfb104285155f303aaf954a47347d8734) | `` surelog: 1.57 -> 1.73 ``                                                    |
| [`ad71d310`](https://github.com/NixOS/nixpkgs/commit/ad71d3105c02faa55517d67cc047b8a572159fbf) | `` uhdm: 1.57 -> 1.73 ``                                                       |
| [`3ff4ec19`](https://github.com/NixOS/nixpkgs/commit/3ff4ec19b643efd5bd7fa80dfea84e7c1742cf0b) | `` vault-ssh-plus: 0.7.0 -> 0.7.1 ``                                           |
| [`f69a37cd`](https://github.com/NixOS/nixpkgs/commit/f69a37cdb4371c95f204de7660f1c7f274ea7771) | `` cargo-hack: 0.6.4 -> 0.6.5 ``                                               |
| [`311ce2ad`](https://github.com/NixOS/nixpkgs/commit/311ce2ad111e9abe4215ad6bf8503ffb9be48f3c) | `` nixosTests.custom-ca: resolve out of memory situations ``                   |
| [`eedffc8c`](https://github.com/NixOS/nixpkgs/commit/eedffc8c7fcc6a32652e539fc5b977b78c544a4c) | `` bililiverecorder: add mainProgram metadata ``                               |
| [`9afd8341`](https://github.com/NixOS/nixpkgs/commit/9afd83416855cf3afcc795ee0f48a130e4f8b1d6) | `` dssi: remove optional qt4 support ``                                        |
| [`9b85f8d6`](https://github.com/NixOS/nixpkgs/commit/9b85f8d67cb41c36354130fe560d013fe5f0e5e5) | `` instead-launcher: remove ``                                                 |
| [`f5753523`](https://github.com/NixOS/nixpkgs/commit/f57535235be77732da1c00cecc4ea6a8352e4038) | `` flatcam: build with python39 ``                                             |
| [`7f728d40`](https://github.com/NixOS/nixpkgs/commit/7f728d409f0d88e28f3d72adfe8ee4692950ba47) | `` flatcam: fix after daf490f1f9b5abd9ef9fe115e4d11a2b55a2ccbd ``              |
| [`1bd59b1e`](https://github.com/NixOS/nixpkgs/commit/1bd59b1e614f69efb6f787ce6704c626f38a2c8d) | `` lisp-modules: drop qt4 stuff ``                                             |
| [`5211e5be`](https://github.com/NixOS/nixpkgs/commit/5211e5be8c067d6a6087cac4d304f8b3b08ab710) | `` yate: drop gui support ``                                                   |
| [`2ab41bea`](https://github.com/NixOS/nixpkgs/commit/2ab41bea09072e618e4bf0524c07dc1abc7b33ad) | `` Revert "smokegen: init at v4.14.3" ``                                       |
| [`2b85e7e9`](https://github.com/NixOS/nixpkgs/commit/2b85e7e9b8735246da30d80359df82b15217e8be) | `` Revert "smokeqt: init at v4.14.3" ``                                        |
| [`1be50b50`](https://github.com/NixOS/nixpkgs/commit/1be50b5017aa3777ab09b0f4244b79fa6814bde6) | `` Revert "smokegen,smokeqt: enable strictDeps and don't use pkgs" ``          |
| [`10fdd2c9`](https://github.com/NixOS/nixpkgs/commit/10fdd2c9493d3431b0cb4dec4df206ae3a7526a5) | `` Revert "sbclPackages: fix build of qt, qt-libs and qtools" ``               |
| [`5f9b7b33`](https://github.com/NixOS/nixpkgs/commit/5f9b7b331703922b50d91c371f0174ad43902173) | `` Revert "nrfconnect: init at 3.11.1" ``                                      |
| [`5bf895d1`](https://github.com/NixOS/nixpkgs/commit/5bf895d1067772ab57f27c3d2e4d690e473562bc) | `` Revert "nrf-command-line-tools: init at 10.16.0" ``                         |
| [`002c11bf`](https://github.com/NixOS/nixpkgs/commit/002c11bf75e90af717a631ece4642dee68a08648) | `` Revert "segger-jlink: init at 7.66" ``                                      |
| [`048adf01`](https://github.com/NixOS/nixpkgs/commit/048adf01c95f59c8afa962296698c6698d10aab7) | `` qt4: remove ``                                                              |
| [`1b4c4704`](https://github.com/NixOS/nixpkgs/commit/1b4c4704ceebdeb687fc73f0ab12f82277055b59) | `` pyqt4: remove ``                                                            |
| [`80192466`](https://github.com/NixOS/nixpkgs/commit/80192466619ecdcd91e7d4af334a60e5762be5ad) | `` python3.pkgs.ete3: remove pyqt4 ``                                          |
| [`ea9b800d`](https://github.com/NixOS/nixpkgs/commit/ea9b800dde09c7c6ce96bce0784f68d757ac66e4) | `` python3.pkgs.Nuitka: remove unused pyqt4 dependency ``                      |
| [`3d1d7419`](https://github.com/NixOS/nixpkgs/commit/3d1d7419d49b0fe86d757123f63d772218afe844) | `` qucs: remove ``                                                             |
| [`9a87752f`](https://github.com/NixOS/nixpkgs/commit/9a87752f0b1fd2ea5fd8d0a0995ef812a018a601) | `` pyside*: remove ``                                                          |
| [`045f8c5b`](https://github.com/NixOS/nixpkgs/commit/045f8c5b66e81f6e7bb3561ad41aa4f24e41317f) | `` fmbt: remove ``                                                             |
| [`6d581655`](https://github.com/NixOS/nixpkgs/commit/6d581655101e824e926040e59163855090b41b98) | `` hydrogen_0: remove ``                                                       |
| [`f72bd506`](https://github.com/NixOS/nixpkgs/commit/f72bd5065d73f69cd6858f96d2567ffa0246c03e) | `` qfsm: remove ``                                                             |
| [`f1ca7eec`](https://github.com/NixOS/nixpkgs/commit/f1ca7eecbb1346bb67741850b359ea0778fcddab) | `` avogadro: remove ``                                                         |
| [`fd9213cf`](https://github.com/NixOS/nixpkgs/commit/fd9213cf753a19cc371b215d29edabf31e1ac4cb) | `` aliza: remove ``                                                            |
| [`141579b8`](https://github.com/NixOS/nixpkgs/commit/141579b8a2ae2605fef8294244d1802899477e5c) | `` seexpr: remove ``                                                           |
| [`76eb2c64`](https://github.com/NixOS/nixpkgs/commit/76eb2c64b1f33f91b28521d091f598ba35003038) | `` libjreen: remove ``                                                         |
| [`61abba66`](https://github.com/NixOS/nixpkgs/commit/61abba66e29285518d80e946715e42085836c668) | `` ntrack: remove ``                                                           |
| [`e60b6e18`](https://github.com/NixOS/nixpkgs/commit/e60b6e18bec93875fb4894b04a70f802c9162c98) | `` prison: remove ``                                                           |
| [`869eda7c`](https://github.com/NixOS/nixpkgs/commit/869eda7c26da9eca03284cfc3efa6743277e878d) | `` qt-mobility: remove ``                                                      |
| [`a7d78e6b`](https://github.com/NixOS/nixpkgs/commit/a7d78e6be3f6e3a4796ef8dc9982f10c2550ac68) | `` qimageblitz: remove ``                                                      |
| [`0141f9ac`](https://github.com/NixOS/nixpkgs/commit/0141f9aca023444eabcf4669c94bb37036208765) | `` eql: remove ``                                                              |
| [`5dbd4333`](https://github.com/NixOS/nixpkgs/commit/5dbd4333f2a2586439736f25f6a46ea8cefe8cbc) | `` subdownloader: remove ``                                                    |
| [`b861791b`](https://github.com/NixOS/nixpkgs/commit/b861791b642479a334cbb1295352fa838388d59d) | `` ibus-qt: remove ``                                                          |
| [`9f648b8a`](https://github.com/NixOS/nixpkgs/commit/9f648b8a42cc821adfd019d5b98859c4b9064d72) | `` scribus_1_4: remove ``                                                      |
| [`c8e5c5c2`](https://github.com/NixOS/nixpkgs/commit/c8e5c5c2228ddd58f01b7229e0bb4a92a9585990) | `` screencloud: remove ``                                                      |
| [`20e37855`](https://github.com/NixOS/nixpkgs/commit/20e3785582ce82cec1b5d3138413f410a16d747a) | `` gambatte: remove ``                                                         |
| [`cf0862e5`](https://github.com/NixOS/nixpkgs/commit/cf0862e525546119835b212e72754968b5e2ef5d) | `` qwt6_qt4: remove ``                                                         |
| [`0fcbbbb7`](https://github.com/NixOS/nixpkgs/commit/0fcbbbb772a4e18f07a721b1a1a69b5c87015434) | `` qtstyleplugin-kvantum-qt4: remove ``                                        |
| [`7e09025e`](https://github.com/NixOS/nixpkgs/commit/7e09025e465eb110f6105213882929d88942adcc) | `` qscintilla-qt4: remove ``                                                   |
| [`4ec86689`](https://github.com/NixOS/nixpkgs/commit/4ec86689f777024990a7f03aa0506552cd9f1619) | `` sqliteman: remove ``                                                        |
| [`c189ea39`](https://github.com/NixOS/nixpkgs/commit/c189ea39cf9b6b609c1d241e7b2083e6d2d482a0) | `` scantailor: remove ``                                                       |
| [`bf64cf4c`](https://github.com/NixOS/nixpkgs/commit/bf64cf4ca3cac9a590f5891aea8f647902af44bd) | `` navipowm: remove ``                                                         |
| [`4ab15dde`](https://github.com/NixOS/nixpkgs/commit/4ab15ddeda8bd5e8d3c07ee70b0b865cf723df42) | `` qmetro: remove ``                                                           |
| [`32e055ac`](https://github.com/NixOS/nixpkgs/commit/32e055ac0d2769f17e54e1f2100f48f17ada36cf) | `` animbar: remove ``                                                          |
| [`b4ad3f98`](https://github.com/NixOS/nixpkgs/commit/b4ad3f983c3b85d99fdedf29aa7e57b49a842c6a) | `` resim: remove ``                                                            |
| [`e0a6d462`](https://github.com/NixOS/nixpkgs/commit/e0a6d4627c5a9af0ad5fb8fffcc4cd5a9d707bca) | `` qtscrobbler: remove ``                                                      |
| [`10e80ccb`](https://github.com/NixOS/nixpkgs/commit/10e80ccb52ac6c2ab36680328c9d54f79c1fb054) | `` qmidiroute: remove ``                                                       |
| [`85f01126`](https://github.com/NixOS/nixpkgs/commit/85f0112696f56ab0b8ac34b2f3a76bb49c137526) | `` ssr: remove ``                                                              |
| [`0a293e70`](https://github.com/NixOS/nixpkgs/commit/0a293e705ee08d7e99227579de090a8fd53afd06) | `` valkyrie: remove ``                                                         |
| [`35ffde90`](https://github.com/NixOS/nixpkgs/commit/35ffde90e53c7801ab02b09a2faf67a70058d434) | `` tworld2: remove ``                                                          |
| [`44c3cb96`](https://github.com/NixOS/nixpkgs/commit/44c3cb965f58883a6802c28b4aac29b880d86106) | `` windows.jom: remove ``                                                      |
| [`2b77e759`](https://github.com/NixOS/nixpkgs/commit/2b77e759facf3c621f5d45d20aaa607e3cc3da3b) | `` acoustidFingerprinter: remove ``                                            |
| [`f3fe2513`](https://github.com/NixOS/nixpkgs/commit/f3fe251344c0a1e3977f8cefb814050a69709052) | `` structure-synth: remove ``                                                  |
| [`608ed10f`](https://github.com/NixOS/nixpkgs/commit/608ed10f046f97525a843da65f3306c4eec3b23c) | `` omapd: remove ``                                                            |
| [`faee0c0e`](https://github.com/NixOS/nixpkgs/commit/faee0c0e0fa5427e43bb23454bd272539a883e51) | `` hime: remove qt4 support ``                                                 |
| [`6c62a211`](https://github.com/NixOS/nixpkgs/commit/6c62a2116194bd0356e744a25c0d62c152cc8ebe) | `` namecoin: remove GUI support ``                                             |
| [`308baf30`](https://github.com/NixOS/nixpkgs/commit/308baf304984fb5bb94f0b69f4b4dc8d5030405d) | `` uim: remove qt4, fix qt5 ``                                                 |
| [`79ff04f3`](https://github.com/NixOS/nixpkgs/commit/79ff04f384c49225dc1128ea4401507895af3335) | `` lutris: remove qt4 ``                                                       |
| [`173409fb`](https://github.com/NixOS/nixpkgs/commit/173409fbc9fc264d6f923798d99255e901e5c710) | `` texmacs: remove darwin version, because it depends on qt4 ``                |
| [`85d2adb0`](https://github.com/NixOS/nixpkgs/commit/85d2adb0cda26fb677f20573d56355b3b6aa7c04) | `` flatcam: 8.5 -> unstable-2022-02-02 ``                                      |
| [`de1d98ca`](https://github.com/NixOS/nixpkgs/commit/de1d98cabef2f251a28241abf9432d8e1bb18b72) | `` vite: 1.2pre1543 -> unstable-2022-05-17 ``                                  |
| [`d5107300`](https://github.com/NixOS/nixpkgs/commit/d510730093d2977639beb5a87b85a7f76aeb48e5) | `` qscreenshot: 1.0 -> unstable-2021-10-18 ``                                  |
| [`1607621a`](https://github.com/NixOS/nixpkgs/commit/1607621a5a82e1967deaf998ec3d6f0634cafc08) | `` tagainijisho: misc cleanups ``                                              |
| [`f7d4fbd9`](https://github.com/NixOS/nixpkgs/commit/f7d4fbd94a135210d0f4f0df80d6dc2953c46d1d) | `` qjoypad: misc cleanups ``                                                   |
| [`a6b0593e`](https://github.com/NixOS/nixpkgs/commit/a6b0593e97349d622612c7f9c0f83d7d6dc0da0f) | `` python310Packages.python-cinderclient: 9.3.0 -> 9.4.0 ``                    |
| [`7acdac76`](https://github.com/NixOS/nixpkgs/commit/7acdac7610eff04fde1f9a013e70acc31c8d4c45) | `` elementary-cmake-modules: remove ``                                         |
| [`4fd0172a`](https://github.com/NixOS/nixpkgs/commit/4fd0172a49042a062a3d8f5841d9025f8c804d46) | `` okta-aws-cli: 1.1.0 -> 1.2.1 ``                                             |
| [`971a08f3`](https://github.com/NixOS/nixpkgs/commit/971a08f34e51bffde9a4fa6b99f2895f4f993bb0) | `` gitRepo: 2.36 -> 2.36.1 ``                                                  |
| [`8c27922a`](https://github.com/NixOS/nixpkgs/commit/8c27922a0e2de18f1fadb4f2bd65d5cb9de16b64) | `` qemu: 8.0.4 -> 8.1.0 ``                                                     |
| [`ae24e3e5`](https://github.com/NixOS/nixpkgs/commit/ae24e3e528c90aee944c5ca23fab715d72d6b1f2) | `` Add a few packages for Coq 8.18 and MathComp 2.0 ``                         |
| [`02643fe4`](https://github.com/NixOS/nixpkgs/commit/02643fe422c8b7a25acc7df31fc6b44efe9a616a) | `` coq_8_18: init at 8.18+rc1 ``                                               |
| [`7e87f6c5`](https://github.com/NixOS/nixpkgs/commit/7e87f6c593e5aef7f13fdf10082795854778af0d) | `` topology: 9.0.0 -> 10.2.0 ``                                                |
| [`62441cb5`](https://github.com/NixOS/nixpkgs/commit/62441cb5daf98a01b1eab80c2dd5e719fd2bd65d) | `` cvc5: 1.0.6 → 1.0.7 ``                                                      |
| [`df5202c2`](https://github.com/NixOS/nixpkgs/commit/df5202c24cc5140ef0c9a891bf31875da8c2178d) | `` python310Packages.python-swiftclient: 4.3.0 -> 4.4.0 ``                     |
| [`cad449e0`](https://github.com/NixOS/nixpkgs/commit/cad449e0652f524c84ff0a200b2f72072a929bba) | `` karmor: 0.13.13 -> 0.13.15 ``                                               |
| [`0f847958`](https://github.com/NixOS/nixpkgs/commit/0f847958a5c7cc82484155a6739f9ba8ac1ce540) | `` kaniko: 1.14.0 -> 1.15.0 ``                                                 |
| [`8ccbd9fd`](https://github.com/NixOS/nixpkgs/commit/8ccbd9fd3dc6ba9636ac9b92bea0366b974f3066) | `` k8sgpt: 0.3.13 -> 0.3.14 ``                                                 |
| [`9624bf57`](https://github.com/NixOS/nixpkgs/commit/9624bf57366d27bfd686b113c57b5a7dcc88f0ed) | `` ldid-procursus: install zsh completion ``                                   |
| [`a69062ae`](https://github.com/NixOS/nixpkgs/commit/a69062aebc6b47115cb7731629a2b42a237b412f) | `` treesheets: unstable-2023-08-17 -> unstable-2023-08-31 ``                   |
| [`93f70364`](https://github.com/NixOS/nixpkgs/commit/93f70364095ec2a3bbede24fc8b474dd78b261d6) | `` veilid: 0.2.0 -> 0.2.1 ``                                                   |
| [`300cc1bd`](https://github.com/NixOS/nixpkgs/commit/300cc1bdad8e1219fa917306b602bae85a4ecf28) | `` gex: 0.6.2 -> 0.6.3 ``                                                      |
| [`12aaefa7`](https://github.com/NixOS/nixpkgs/commit/12aaefa78d85ac6a3de62e5ac51a4e2d834e5ae5) | `` release-notes: add entry for new stalwart-mail module ``                    |
| [`c6808723`](https://github.com/NixOS/nixpkgs/commit/c6808723b0d8765b667ef358ba26c1328d92eb53) | `` nixos/stalwart-mail: add vm test ``                                         |
| [`f6961de6`](https://github.com/NixOS/nixpkgs/commit/f6961de63743f850ce423ccb9748e1d5442a8594) | `` nixos/stalwart-mail: add module ``                                          |
| [`6eb25e11`](https://github.com/NixOS/nixpkgs/commit/6eb25e11a882ad25d895ad55422339e53b3ef119) | `` stalwart-mail: 0.3.4 -> 0.3.6 ``                                            |
| [`2df6de05`](https://github.com/NixOS/nixpkgs/commit/2df6de059e3079537a694fd17c5d2685d292d53c) | `` buck2: unstable-2023-08-15 -> unstable-2023-09-01 ``                        |
| [`ca297a76`](https://github.com/NixOS/nixpkgs/commit/ca297a76d5dce2026943f51f504f7e2a89a96d1c) | `` yor: 0.1.183 -> 0.1.185 ``                                                  |
| [`2c39c216`](https://github.com/NixOS/nixpkgs/commit/2c39c216f6ee98690076948ec037f081ba7c4848) | `` editorconfig-checker: 2.7.0 -> 2.7.1 ``                                     |
| [`efd1605b`](https://github.com/NixOS/nixpkgs/commit/efd1605be6a14d0c169d20b6cbea191b0aa7eb99) | `` nixos/lxd: add virtual-machine support, image and module ``                 |
| [`2b2cb749`](https://github.com/NixOS/nixpkgs/commit/2b2cb749d66122a849a41d62e123935011e3ab85) | `` v2ray-domain-list-community: 20230825070717 -> 20230902035830 ``            |
| [`4fb82121`](https://github.com/NixOS/nixpkgs/commit/4fb8212162e1e90489412ab2ddabe6fcfdcce341) | `` nixos/mautrix-whatsapp: log to the journal only ``                          |
| [`5fc70937`](https://github.com/NixOS/nixpkgs/commit/5fc70937a127092c48645d6f5061c0be9d45c69a) | `` nixos/mautrix-whatsapp: set default homeserver address ``                   |
| [`035f9051`](https://github.com/NixOS/nixpkgs/commit/035f90512492114e001f54438a47614d69da23e0) | `` nixos/mautrix-whatsapp: fix merging of default settings ``                  |
| [`245e0846`](https://github.com/NixOS/nixpkgs/commit/245e08466695448d727f466e194c60a3374c7e89) | `` asusctl: 4.7.0 -> 4.7.1 ``                                                  |
| [`9ee75852`](https://github.com/NixOS/nixpkgs/commit/9ee75852d207067c0b1c72663336efd5300e51e7) | `` budgie.budgie-gsettings-overrides: Update defaults ``                       |
| [`9e045711`](https://github.com/NixOS/nixpkgs/commit/9e0457115e7eb3f106b9ea60ab3ca92daed5b03f) | `` nixos/mautrix-whatsapp: use  static user and group ``                       |
| [`6fa55ab5`](https://github.com/NixOS/nixpkgs/commit/6fa55ab582931e991bec76e5dabb4c8581d0d2c8) | `` php81Packages.psysh: 0.11.18 -> 0.11.20 ``                                  |
| [`0c136c38`](https://github.com/NixOS/nixpkgs/commit/0c136c38a54fdcb01c3ddf1ce8eb0061eea6dc49) | `` broot: 1.25.0 -> 1.25.1 ``                                                  |
| [`467c3fc9`](https://github.com/NixOS/nixpkgs/commit/467c3fc9c83f0b709166335f00f18c799b1848fa) | `` python311Packages.peaqevcore: 19.2.1 -> 19.3.2 ``                           |
| [`44a43142`](https://github.com/NixOS/nixpkgs/commit/44a43142ef57e8551daca3ef8c594b0db091d97d) | `` python311Packages.hahomematic: 2023.8.14 -> 2023.9.0 ``                     |
| [`e932745c`](https://github.com/NixOS/nixpkgs/commit/e932745cb865454a3c97c846a35f8ec02d73c61d) | `` nixos/mautrix-whatsapp: fix docbook description ``                          |
| [`a86bf765`](https://github.com/NixOS/nixpkgs/commit/a86bf765a99243a47f8f7af2932c148527f262d9) | `` slingshot: 0.2.3 -> 0.3.0 ``                                                |
| [`fbe97534`](https://github.com/NixOS/nixpkgs/commit/fbe9753456c935aea340bed1fe1f893d1658f953) | `` degit: use buildNpmPackage ``                                               |
| [`f4c5b874`](https://github.com/NixOS/nixpkgs/commit/f4c5b8747c85b4a8df0bf0f851e931ef55278161) | `` nodePackages.hs-client: make alias of hsd ``                                |
| [`06095dd1`](https://github.com/NixOS/nixpkgs/commit/06095dd1850a9044e1a62bbe8adc0780853f170f) | `` hsd: use buildNpmPackage ``                                                 |
| [`8a099ecd`](https://github.com/NixOS/nixpkgs/commit/8a099ecda875326378ced659f4aaddc3d2bc38df) | `` star-history: 1.0.13 -> 1.0.14 ``                                           |
| [`79a48bec`](https://github.com/NixOS/nixpkgs/commit/79a48bec1ed6198dbef98db0e1d37692f850a6fa) | `` python311Packages.bleak-retry-connector: 3.1.1 -> 3.1.2 ``                  |
| [`d5447edb`](https://github.com/NixOS/nixpkgs/commit/d5447edb4005291b9bf80d916044e7a5197ceadf) | `` python311Packages.bleak: 0.20.2 -> 0.21.0 ``                                |
| [`de7b43c6`](https://github.com/NixOS/nixpkgs/commit/de7b43c66c31e220097be417839a96b9c9968661) | `` cargo-expand: 1.0.66 -> 1.0.67 ``                                           |
| [`01a94e55`](https://github.com/NixOS/nixpkgs/commit/01a94e55a2527794b1b0ee49b065486fcbb7855b) | `` kicad: clean up meta and comments ``                                        |
| [`378f10ad`](https://github.com/NixOS/nixpkgs/commit/378f10ad818ae9d6ba38db4c7c807d0177362c84) | `` kicad: remove kiwi maintainer ``                                            |
| [`29bf6c5c`](https://github.com/NixOS/nixpkgs/commit/29bf6c5ca536288b5692157199f28ddab9f4a352) | `` kicad.libraries.packages3d: use stepreduce & stepZ ``                       |
| [`d204d558`](https://github.com/NixOS/nixpkgs/commit/d204d5581324b56ddae5691ad15cdba3a98ae7d0) | `` stepreduce: init at unstable-2020-04-30 ``                                  |
| [`df688627`](https://github.com/NixOS/nixpkgs/commit/df688627b5fa0e245828fbb391bc3d9e66b28ece) | `` nodePackages.musescore-downloader: make alias of dl-librescore ``           |
| [`8c9f2722`](https://github.com/NixOS/nixpkgs/commit/8c9f272219be1a3c15a3929ca526675e0b323996) | `` dl-librescore: init at 0.34.47 ``                                           |
| [`28ff9fc5`](https://github.com/NixOS/nixpkgs/commit/28ff9fc5282b8c565b35f07ee21c57271520edf7) | `` i3status-rust: 0.32.0 -> 0.32.1 ``                                          |
| [`b3ce7589`](https://github.com/NixOS/nixpkgs/commit/b3ce7589842bc277e7d7915f2bacad2edab694ef) | `` python310Packages.openai: 0.27.9 -> 0.28.0 ``                               |
| [`3a5ff9a6`](https://github.com/NixOS/nixpkgs/commit/3a5ff9a68c9dbb8b707555d44988575b3e9544bf) | `` nixos/release.nix: remove warning about missing state version for images `` |
| [`be871dd2`](https://github.com/NixOS/nixpkgs/commit/be871dd218a62813361c16dcc7c1f115ff4e53c0) | `` python310Packages.openllm: init at 0.2.27 ``                                |
| [`04ce30e6`](https://github.com/NixOS/nixpkgs/commit/04ce30e6279873cbad01bca8bf8d9af69ffcafe6) | `` python310Packages.openllm-client: init at 0.2.27 ``                         |
| [`89be295e`](https://github.com/NixOS/nixpkgs/commit/89be295e69873c79dd4fee9c0f621d8bda9f773e) | `` python310Packages.openllm-core: init at 0.2.27 ``                           |
| [`3163d1f3`](https://github.com/NixOS/nixpkgs/commit/3163d1f389a25b90ee5a9c68b9caa17e73068f81) | `` python310Packages.steamship: 2.17.22 -> 2.17.27 ``                          |
| [`061398e5`](https://github.com/NixOS/nixpkgs/commit/061398e5054b3f3ca5678e713288001540299bbe) | `` python3Packages.antlr4-python3-runtime: fix build ``                        |
| [`a41f02d0`](https://github.com/NixOS/nixpkgs/commit/a41f02d0b0a2a081a8d618263fa05ecd4936d11f) | `` oculante: 0.7.3 -> 0.7.4 ``                                                 |
| [`ec9549da`](https://github.com/NixOS/nixpkgs/commit/ec9549daf549f7a98a7d5015145a5b840ff6f22c) | `` cargo-expand: 1.0.65 -> 1.0.66 ``                                           |
| [`765f5461`](https://github.com/NixOS/nixpkgs/commit/765f546100c4bd714ffcd783af77ca13aff1bcbb) | `` complgen: 0.1.2 -> 0.1.3 ``                                                 |
| [`5ca54e95`](https://github.com/NixOS/nixpkgs/commit/5ca54e9579d4a47cac5036be47b69e1bbadf66e6) | `` antlr4: default to antlr4_13 ``                                             |
| [`ca9144be`](https://github.com/NixOS/nixpkgs/commit/ca9144be02b24d912a371e9b67e42c1099eede86) | `` antlr4_13: init at 4.13.0 ``                                                |