### PR TITLE
chore(flake/deploy-rs): `724463b5` -> `d0cfc042`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -126,11 +126,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686747123,
-        "narHash": "sha256-XUQK9kwHpTeilHoad7L4LjMCCyY13Oq383CoFADecRE=",
+        "lastModified": 1694158470,
+        "narHash": "sha256-yWx9eBDHt6WR3gr65+J85KreHdMypty/P6yM35tIYYM=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "724463b5a94daa810abfc64a4f87faef4e00f984",
+        "rev": "d0cfc042eba92eb206611c9e8784d41a2c053bab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                       |
| --------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`d0cfc042`](https://github.com/serokell/deploy-rs/commit/d0cfc042eba92eb206611c9e8784d41a2c053bab) | `` Update README.md (#227) `` |