### PR TITLE
chore(flake/nixpkgs): `0bffda19` -> `db9208ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -377,11 +377,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693985761,
-        "narHash": "sha256-K5b+7j7Tt3+AqbWkcw+wMeqOAWyCD1MH26FPZyWXpdo=",
+        "lastModified": 1694183432,
+        "narHash": "sha256-YyPGNapgZNNj51ylQMw9lAgvxtM2ai1HZVUu3GS8Fng=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0bffda19b8af722f8069d09d8b6a24594c80b352",
+        "rev": "db9208ab987cdeeedf78ad9b4cf3c55f5ebd269b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`a4f6862f`](https://github.com/NixOS/nixpkgs/commit/a4f6862fb17a1a325090a309b362cddba7292a61) | `` klipper: fix cross compilation ``                                                              |
| [`b90ab315`](https://github.com/NixOS/nixpkgs/commit/b90ab315c1407e6eb0dc53917c2d866d65e0eab2) | `` unit: remove `withPerldevel` option ``                                                         |
| [`9f815be6`](https://github.com/NixOS/nixpkgs/commit/9f815be60520665e139fb8575a64218fc7994ecc) | `` perldevel: remove ``                                                                           |
| [`a68dc64e`](https://github.com/NixOS/nixpkgs/commit/a68dc64ea14e01781c09d88a2333d642f2c960dd) | `` xpra: depend on libappindicator ``                                                             |
| [`345a334e`](https://github.com/NixOS/nixpkgs/commit/345a334e9e5f1b871101df8ff88628f5ba0c51d9) | `` sd-local: 1.0.46 -> 1.0.48 ``                                                                  |
| [`127ddbae`](https://github.com/NixOS/nixpkgs/commit/127ddbae4a8bc78fdf712a2434d414e8f2150ac0) | `` atomic-swap: 0.4.1 -> 0.4.2 ``                                                                 |
| [`95fd689f`](https://github.com/NixOS/nixpkgs/commit/95fd689f85add9a871fedcb896104330236b338f) | `` php: run `genfiles` for building extensions too ``                                             |
| [`636f8009`](https://github.com/NixOS/nixpkgs/commit/636f80091e5e861055a413c7e43a453bc7e466fe) | `` unstructured-api: 0.0.41 -> 0.0.42 ``                                                          |
| [`b02edfa6`](https://github.com/NixOS/nixpkgs/commit/b02edfa6f948e0b6f3c5bc6b4368a53bb0d0aacb) | `` python310Packages.unstructured-inference: 0.5.7 -> 0.5.22 ``                                   |
| [`350a1b3e`](https://github.com/NixOS/nixpkgs/commit/350a1b3e022c3d05dba9e3ddf4050409a49ee474) | `` home-assistant: propagate packaging ``                                                         |
| [`dd57b3f2`](https://github.com/NixOS/nixpkgs/commit/dd57b3f25042f3fe7852d0e6a817da440aebfe98) | `` php: fix path to `genfiles` ``                                                                 |
| [`d1f1457e`](https://github.com/NixOS/nixpkgs/commit/d1f1457e3f66a757526da0cb49e5f93ba2c5dfc3) | `` ocamlPackages.tls: 0.16.0 → 0.17.1 ``                                                          |
| [`f538d909`](https://github.com/NixOS/nixpkgs/commit/f538d909705432475dd3a81b965883426636cfee) | `` oh-my-posh: 18.3.5 -> 18.7.0 ``                                                                |
| [`01d9ff8c`](https://github.com/NixOS/nixpkgs/commit/01d9ff8cbf26b94430774c15c6f901bd4bfa29ff) | `` julia-mono: 0.050 -> 0.051 ``                                                                  |
| [`b3da5e68`](https://github.com/NixOS/nixpkgs/commit/b3da5e68a18f456ec57d9b1ea16713ba9d041d6c) | `` home-assistant: pin zeroconf at 0.91.1 ``                                                      |
| [`e40439b0`](https://github.com/NixOS/nixpkgs/commit/e40439b029cd0ac25aebac8e3d101b5a6a604d0e) | `` python311Packages.zeroconf: 0.99.0 -> 0.102.0 ``                                               |
| [`e7d3f6bc`](https://github.com/NixOS/nixpkgs/commit/e7d3f6bc3644d889049bbab40c43a9bc6117248e) | `` home-assistant: pin plexapi at 4.13.2 ``                                                       |
| [`c85eef94`](https://github.com/NixOS/nixpkgs/commit/c85eef94d291b29a369d9054c45ea7ef703d902f) | `` python310Packages.bimmer-connected: provide test responses ``                                  |
| [`de5fa879`](https://github.com/NixOS/nixpkgs/commit/de5fa879ed6fe0869b38fe93d15a87fb12620652) | `` python311Packages.homeassistant-stubs: 2023.8.4 -> 2023.9.0 ``                                 |
| [`4deda2a9`](https://github.com/NixOS/nixpkgs/commit/4deda2a9c8768ee52ac6ffc262d94bbb46596cab) | `` python310Packages.pyruckus: remove ``                                                          |
| [`b24287dd`](https://github.com/NixOS/nixpkgs/commit/b24287dde88c21108880d08bdd5dbc03240bd900) | `` home-assistant: 2023.8.4 -> 2023.9.0 ``                                                        |
| [`e381dfc8`](https://github.com/NixOS/nixpkgs/commit/e381dfc8156f4201ba9f7695704562cea033788a) | `` sentry-cli: 2.20.5 -> 2.20.7 ``                                                                |
| [`d056e2a9`](https://github.com/NixOS/nixpkgs/commit/d056e2a92bab392ada4d3f64affc47ee720f6284) | `` imgui: 1.89.8 -> 1.89.9 ``                                                                     |
| [`83b955f8`](https://github.com/NixOS/nixpkgs/commit/83b955f828f46061da86e8c334518f99e71ab431) | `` python311Packages.dbus-fast: 1.95.2 -> 2.0.0 ``                                                |
| [`5265e886`](https://github.com/NixOS/nixpkgs/commit/5265e8864a7006b8d441fce343a4f3812bd5a6fb) | `` mssql_jdbc: 12.4.0 -> 12.4.1 ``                                                                |
| [`7539360c`](https://github.com/NixOS/nixpkgs/commit/7539360ce3c64cd6a71fb9ff63d96a265c39e5df) | `` python311Packages.dbus-fast: 1.95.1 -> 1.95.2 ``                                               |
| [`c6915a43`](https://github.com/NixOS/nixpkgs/commit/c6915a43902b3f5d7e52bb5ad172173614cb4b21) | `` exoscale-cli: 1.72.1 -> 1.72.2 ``                                                              |
| [`82ea1d46`](https://github.com/NixOS/nixpkgs/commit/82ea1d463128e5f1716fee180beab1371a6cc8c2) | `` python311Packages.dbus-fast: 1.95.0 -> 1.95.1 ``                                               |
| [`1e6c8f18`](https://github.com/NixOS/nixpkgs/commit/1e6c8f18cb35305cf6fa6b79cb3a4ed18d907af1) | `` dolt: 1.8.8 -> 1.14.0 ``                                                                       |
| [`fd18c9fb`](https://github.com/NixOS/nixpkgs/commit/fd18c9fb9d85f2cf33d04f1f94f9fe8174a30ede) | `` python310Packages.nvidia-ml-py: 12.535.77 -> 12.535.108 ``                                     |
| [`3c3299bd`](https://github.com/NixOS/nixpkgs/commit/3c3299bdc2d866c5b3d3d13f98f52d1c7743bd9d) | `` jotta-cli: 0.15.84961 -> 0.15.89752 ``                                                         |
| [`0342a519`](https://github.com/NixOS/nixpkgs/commit/0342a5194b62f5c5375dbae9f065cb33722dc466) | `` jupyter-console: expose as a tool for launching kernels ``                                     |
| [`29c7ce56`](https://github.com/NixOS/nixpkgs/commit/29c7ce56873f050560f90bd99c116f1334d4723c) | `` toybox: 0.8.9 -> 0.8.10 ``                                                                     |
| [`6d208146`](https://github.com/NixOS/nixpkgs/commit/6d208146f8b4ed6ca7f2793a6e729147a2e62897) | `` brotab: add missing dependency `setuptools` ``                                                 |
| [`1171ea9c`](https://github.com/NixOS/nixpkgs/commit/1171ea9cc2a023858922cd1f4bdfe20052d52759) | `` exploitdb: 2023-09-07 -> 2023-09-08 ``                                                         |
| [`9acbef97`](https://github.com/NixOS/nixpkgs/commit/9acbef97fa4f1b2255808a0b750021936d1343b7) | `` crun: 1.8.7 -> 1.9 ``                                                                          |
| [`cb686eeb`](https://github.com/NixOS/nixpkgs/commit/cb686eeb00c8d0e270f90adbd915564139baad4b) | `` ibus-engines.typing-booster-unwrapped: 2.23.4 -> 2.24.0 ``                                     |
| [`d2d7504a`](https://github.com/NixOS/nixpkgs/commit/d2d7504a4a88191da105f89726e96adb880fe620) | `` dotnet-sdk_7: 7.0.306 -> 7.0.400 ``                                                            |
| [`71c971b0`](https://github.com/NixOS/nixpkgs/commit/71c971b0f1eafaf0c428a5138c8192d0cf87a94f) | `` dotnet-sdk: 6.0.412 -> 6.0.413 ``                                                              |
| [`bcfcff9a`](https://github.com/NixOS/nixpkgs/commit/bcfcff9ad15c6bbb4147655d9281b393250038b5) | `` hashcat: patch to build on apple silicon ``                                                    |
| [`6f085ddc`](https://github.com/NixOS/nixpkgs/commit/6f085ddcfe983d6ca025bf27434015ee5dc4cb6f) | `` python310Packages.hvac: 1.1.1 -> 1.2.0 ``                                                      |
| [`ca72defe`](https://github.com/NixOS/nixpkgs/commit/ca72defe5fdde324c3bc28495bd7084fd878d4a3) | `` syncthingtray-minimal: 1.4.5 -> 1.4.6 ``                                                       |
| [`7b6bc252`](https://github.com/NixOS/nixpkgs/commit/7b6bc2521bc539c3a4ff479c0ec4ab902eee8594) | `` poetry2nix: mark poetry insecure ``                                                            |
| [`c306ac2b`](https://github.com/NixOS/nixpkgs/commit/c306ac2b6c67ab7e79b4e3f736af4cc350d18257) | `` millet: 0.13.0 -> 0.13.1 ``                                                                    |
| [`da2a0af1`](https://github.com/NixOS/nixpkgs/commit/da2a0af17aaabe0e7a21078721d4c45ec9d1b28b) | `` twilio-cli: 5.13.0 -> 5.14.0 ``                                                                |
| [`6ce024fd`](https://github.com/NixOS/nixpkgs/commit/6ce024fd01ebf160b8176281e33c9410abaad7fb) | `` sarasa-gothic: 0.41.8 -> 0.41.9 ``                                                             |
| [`8db30464`](https://github.com/NixOS/nixpkgs/commit/8db304643574ca24fdf31c8a99ccaa207107baf8) | `` scaleway-cli: 2.19.0 -> 2.20.0 ``                                                              |
| [`03631d72`](https://github.com/NixOS/nixpkgs/commit/03631d72d71f269e2dac3661be74da9a90e2e227) | `` gobgpd: 3.17.0 -> 3.18.0 ``                                                                    |
| [`497e8979`](https://github.com/NixOS/nixpkgs/commit/497e897975617597822200d8e03332ed2f701c40) | `` gef: 2023.06 -> 2023.08 ``                                                                     |
| [`811b4628`](https://github.com/NixOS/nixpkgs/commit/811b46283ad2fe4170feafb9d75dcec21c92a6d6) | `` git-credential-oauth: 0.10.0 -> 0.10.1 ``                                                      |
| [`3526a837`](https://github.com/NixOS/nixpkgs/commit/3526a837bf16ea6f329301c18eb32261600abfa1) | `` bililiverecorder: 2.8.2 -> 2.9.0 ``                                                            |
| [`07d688c9`](https://github.com/NixOS/nixpkgs/commit/07d688c98d610aacc2230b2e7295a3169e60826b) | `` sqlx-cli: use openssl instead of rustls ``                                                     |
| [`2bd22521`](https://github.com/NixOS/nixpkgs/commit/2bd2252183593fefdbadf4aeed1cbadcafb135ca) | `` streamdeck-ui: 3.0.1 -> 3.1.0 ``                                                               |
| [`3d7fb679`](https://github.com/NixOS/nixpkgs/commit/3d7fb6794ebd23c598be39b0f875eab279c54ff7) | `` emacsPackages.ebuild-mode: switch to melpaBuild ``                                             |
| [`6bcca55e`](https://github.com/NixOS/nixpkgs/commit/6bcca55e0cf2e6ca52f19acf9b77fc2ac30044c8) | `` python310Packages.adafruit-platformdetect: 3.49.0 -> 3.51.0 ``                                 |
| [`0251e264`](https://github.com/NixOS/nixpkgs/commit/0251e2645a0e06a033a436b1064891de2881cb5c) | `` llvmPackages_15.libcxx: fix the generated linker script ``                                     |
| [`2a54f595`](https://github.com/NixOS/nixpkgs/commit/2a54f59560ac85ca40573d3f44b2085dda131f3b) | `` python310Packages.bellows: 0.36.2 -> 0.36.3 ``                                                 |
| [`bf68b20e`](https://github.com/NixOS/nixpkgs/commit/bf68b20e5654c19489aa39d9bbf73ff92e6edd19) | `` tfsec: 1.28.1 -> 1.28.2 ``                                                                     |
| [`3009e9fb`](https://github.com/NixOS/nixpkgs/commit/3009e9fb922285afe72ab530f752381d525a89f9) | `` prometheus-rtl_433-exporter: use sri hash ``                                                   |
| [`17c3168b`](https://github.com/NixOS/nixpkgs/commit/17c3168b41a6fef55f4d07ae133f540b40e0abf3) | `` python310Packages.seatconnect: 1.1.7 -> 1.1.9 ``                                               |
| [`cb1d6c17`](https://github.com/NixOS/nixpkgs/commit/cb1d6c17a3b0325a1a564fac31dd61078afcf337) | `` zef: 0.18.3 -> 0.19.1 ``                                                                       |
| [`0a1748bf`](https://github.com/NixOS/nixpkgs/commit/0a1748bfaa89fc5e97fbd70fa84e674a044e4c88) | `` papeer: 0.7.1 -> 0.7.2 ``                                                                      |
| [`1a25f677`](https://github.com/NixOS/nixpkgs/commit/1a25f677044bd036ccd2edcdbdfe81f5dbf3fa92) | `` tagparser: 12.0.0 -> 12.1.0 ``                                                                 |
| [`e4110a5e`](https://github.com/NixOS/nixpkgs/commit/e4110a5ebf50ba1f9fa6397b83db986de84350fb) | `` figma-linux: Add missing wrapGAppsHook ``                                                      |
| [`74cce928`](https://github.com/NixOS/nixpkgs/commit/74cce92876075a577ea8186e6715765253601b02) | `` deltachat-desktop: 1.40.1 -> 1.40.2 ``                                                         |
| [`2d150393`](https://github.com/NixOS/nixpkgs/commit/2d15039387a2212f6718bffb937ebe04d7464ce5) | `` tests.cc-wrapper: add supported and move tests to subsets ``                                   |
| [`a236e5f8`](https://github.com/NixOS/nixpkgs/commit/a236e5f81a5fbfdc9365527d4695cdb3e9b97180) | `` python310Packages.gspread: 5.11.0 -> 5.11.1 ``                                                 |
| [`c5c4ba32`](https://github.com/NixOS/nixpkgs/commit/c5c4ba3280302d83f62efd8da21f9065d4396be6) | `` python311Packages.pywaze: init at 0.3.0 ``                                                     |
| [`f2e1a4b0`](https://github.com/NixOS/nixpkgs/commit/f2e1a4b0cdab05a2744a3e44ee1675f077167b9c) | `` python311Packages.aiowaqi: init at 1.1.0 ``                                                    |
| [`c1985b81`](https://github.com/NixOS/nixpkgs/commit/c1985b815f3ac2cb411567a184beb6fd73ab442f) | `` python311Packages.aioruckus: init at 0.34 ``                                                   |
| [`ee9e52a5`](https://github.com/NixOS/nixpkgs/commit/ee9e52a52ea4b1987ea03f7217c3e65b6e616c1c) | `` python311Packages.universal-silabs-flasher: init at 0.0.13 ``                                  |
| [`5646d24e`](https://github.com/NixOS/nixpkgs/commit/5646d24e0c5df907b8797a49f741861dee6ff3bc) | `` python311Packages.aiovodafone: init at 0.0.8 ``                                                |
| [`3734044c`](https://github.com/NixOS/nixpkgs/commit/3734044c2d048fa7bda10ddd6ef0528d818a696b) | `` python311Packages.aiocomelit: init at 0.0.6 ``                                                 |
| [`0ae97cda`](https://github.com/NixOS/nixpkgs/commit/0ae97cda12672463103fa49fbd539152b94c0abd) | `` python311Packages.zwave-js-server-python: 0.49.0 -> 0.51.1 ``                                  |
| [`1028115c`](https://github.com/NixOS/nixpkgs/commit/1028115c8e0dfb0cfd1b5cbb9a44a75680c0b264) | `` python311Packages.reolink-aio: 0.7.8 -> 0.7.9 ``                                               |
| [`9187dc14`](https://github.com/NixOS/nixpkgs/commit/9187dc141c8cfd9913818e9085bc4bcad3972699) | `` python311Packages.python-bsblan: 0.5.15 -> 0.5.16 ``                                           |
| [`f3cf0585`](https://github.com/NixOS/nixpkgs/commit/f3cf0585eb928af7971cb297f4d1b4eb25310b9f) | `` python311Packages.aiotractive: 0.5.5 -> 0.5.6 ``                                               |
| [`18a30be8`](https://github.com/NixOS/nixpkgs/commit/18a30be86a903cdf73eab74f3679a2c50913b918) | `` python311Packages.pymodbus: 3.3.2 -> 3.5.0 ``                                                  |
| [`31b59a1f`](https://github.com/NixOS/nixpkgs/commit/31b59a1fc08bc535d691fe62cd9e7069fc1b7de4) | `` python311Packages.hatasmota: 0.6.5 -> 0.7.0 ``                                                 |
| [`83659c7c`](https://github.com/NixOS/nixpkgs/commit/83659c7c6eb4afdc3ab312aa51283717d329cf53) | `` python311Packages.aiounifi: 61 -> 61 ``                                                        |
| [`5fd9190d`](https://github.com/NixOS/nixpkgs/commit/5fd9190d3b99910b3c5ac11ffbd1c8c7517d665f) | `` python311Packages.aioshelly: 5.4.0 -> 6.0.0 ``                                                 |
| [`73052ba9`](https://github.com/NixOS/nixpkgs/commit/73052ba9249659ea29aadc215b313cca26c6040a) | `` python311Packages.aiolyric: 1.0.10 -> 1.1.0 ``                                                 |
| [`51297922`](https://github.com/NixOS/nixpkgs/commit/5129792275086d46968d064ea246f31ee6bc9bb3) | `` python311Packages.aioesphomeapi: 16.0.3 -> 16.0.5 ``                                           |
| [`51f25f51`](https://github.com/NixOS/nixpkgs/commit/51f25f51fe038a90288cfbca370cec12997ce35b) | `` python311Packages.aioairzone: 0.6.7 -> 0.6.8 (#253489) ``                                      |
| [`a26de147`](https://github.com/NixOS/nixpkgs/commit/a26de14753637e131685fd1913096113bd20d72f) | `` python311Packages.aemet-opendata: 0.2.2 -> 0.4.4 (#251325) ``                                  |
| [`2d6497dc`](https://github.com/NixOS/nixpkgs/commit/2d6497dc5b02e5b13396cf9815c998be8b17dba2) | `` python311Packages.pyvista: 0.42.0 -> 0.42.1 ``                                                 |
| [`e55c80af`](https://github.com/NixOS/nixpkgs/commit/e55c80af27282a37feb886e2a99f92ac898c3f7c) | `` python310Packages.snowflake-connector-python: 3.1.1 -> 3.2.0 ``                                |
| [`e67b7b6a`](https://github.com/NixOS/nixpkgs/commit/e67b7b6ab5e1c8055597d5c02ad6d3c489f0f134) | `` go_1_21: 1.21.0 -> 1.21.1 ``                                                                   |
| [`21dc6b70`](https://github.com/NixOS/nixpkgs/commit/21dc6b70520308846d8e7e6a17155fb17d1b1451) | `` go_1_19: 1.19.12 -> 1.19.13 ``                                                                 |
| [`5472b080`](https://github.com/NixOS/nixpkgs/commit/5472b08075855a32ae254ac4f4777e139100bebc) | `` lib/systems: disable pipewireSupport in qemu-user ``                                           |
| [`06182888`](https://github.com/NixOS/nixpkgs/commit/061828884688c580c909734db7305245f3ad87cb) | `` cargo-semver-checks: 0.22.1 -> 0.23.0 ``                                                       |
| [`138565e8`](https://github.com/NixOS/nixpkgs/commit/138565e8df3ff7673a383dfa7a66a069ddc2c310) | `` apache-airflow: fix passthru overriding ``                                                     |
| [`62596733`](https://github.com/NixOS/nixpkgs/commit/62596733c0c433af06dfc13ee89a98a26ce7b532) | `` screentest: init at unstable-2021-05-10 ``                                                     |
| [`08a73576`](https://github.com/NixOS/nixpkgs/commit/08a735768a510fea71c62337ccfc492d2a68b864) | `` tandoor-recipes: 1.5.4 -> 1.5.6 ``                                                             |
| [`494ecbdd`](https://github.com/NixOS/nixpkgs/commit/494ecbdd32f6dc2a4ce46d6d5c8c4d1459aa164e) | `` python310Packages.idasen: 0.10.1 -> 0.10.2 ``                                                  |
| [`abe4d983`](https://github.com/NixOS/nixpkgs/commit/abe4d9830fd29c10e49ffc05bc6b3058dae32f39) | `` ttop: 1.2.2 -> 1.2.3 ``                                                                        |
| [`8221ee67`](https://github.com/NixOS/nixpkgs/commit/8221ee6705203a007e73e49b41baa91c9f056000) | `` terraform: also, add qjoly as maintainer ``                                                    |
| [`39ed4b64`](https://github.com/NixOS/nixpkgs/commit/39ed4b64ba5929e8e9221d06b719a758915e619b) | `` terraform: 1.5.6 -> 1.5.7 ``                                                                   |
| [`b2411cd2`](https://github.com/NixOS/nixpkgs/commit/b2411cd2d1dbbee4111792c12bc9dbec739f9b05) | `` treesheets: unstable-2023-08-31 -> unstable-2023-09-07 ``                                      |
| [`137c5eec`](https://github.com/NixOS/nixpkgs/commit/137c5eec37acafc17298db62c0dba859c2883ebb) | `` cargo-expand: 1.0.67 -> 1.0.68 ``                                                              |
| [`7115a4d3`](https://github.com/NixOS/nixpkgs/commit/7115a4d3c9735bce1a5969b16524c6c7d389a3aa) | `` python310Packages.karton-config-extractor: 2.1.1 -> 2.2.0 ``                                   |
| [`d5c95c05`](https://github.com/NixOS/nixpkgs/commit/d5c95c05020f668b0e0ce317c0785624a1fe2b08) | `` python310Packages.sdds: 0.3.1 -> 0.4.0 ``                                                      |
| [`b61cc0d5`](https://github.com/NixOS/nixpkgs/commit/b61cc0d5e562555594ea174c5abd5de8e2f42fd7) | `` biome: 1.1.1 -> 1.1.2 ``                                                                       |
| [`bcd62ff9`](https://github.com/NixOS/nixpkgs/commit/bcd62ff9eb0c07280063388847cf640c4c27ca10) | `` Revert "tests.cc-wrapper: filter unavailable gcc" ``                                           |
| [`e0898be1`](https://github.com/NixOS/nixpkgs/commit/e0898be1c52d62d89071f95fffc39ee468201fbe) | `` tests.cc-wrapper: filter unavailable gcc ``                                                    |
| [`686516e0`](https://github.com/NixOS/nixpkgs/commit/686516e0bce756185b9709e51be1fd810c40565a) | `` tests.cc-wrapper: filter out *MultiStdenv when not on and not building for linux and x86_64 `` |
| [`535447e2`](https://github.com/NixOS/nixpkgs/commit/535447e289be901fb309952e7bfc1c913083241d) | `` tests.cc-wrapper: show command output on different line ``                                     |
| [`1b6c3aed`](https://github.com/NixOS/nixpkgs/commit/1b6c3aed6336efd056f5e3e0165e3e74f04b169f) | `` tests.cc-wrapper: show more prominently what cc is being tested ``                             |
| [`8d650ed2`](https://github.com/NixOS/nixpkgs/commit/8d650ed2294e0fbc8c8fbe5b5b568eaedc9a1a86) | `` pkgs/top-level/release: update cc-wrapper attr names ``                                        |
| [`626c8c32`](https://github.com/NixOS/nixpkgs/commit/626c8c3224893df4b6eab1ff01df8abaad1c3476) | `` tests.cc-wrapper: rework the logic, test newer `gcc` stdenvs too ``                            |
| [`b10a9b22`](https://github.com/NixOS/nixpkgs/commit/b10a9b22db67ff8f36e369d7aaf5abe49301173a) | `` checkov: 2.4.29 -> 2.4.30 ``                                                                   |
| [`e15d196a`](https://github.com/NixOS/nixpkgs/commit/e15d196ac2aaea7648a8d857136088bb933b4ceb) | `` cargo-component: unstable-2023-08-31 -> unstable-2023-09-06 ``                                 |
| [`788dc509`](https://github.com/NixOS/nixpkgs/commit/788dc509e1c22981dfc98e869676bea85c94d884) | `` cyber: unstable-2023-09-01 -> unstable-2023-09-07 ``                                           |
| [`cd7b1642`](https://github.com/NixOS/nixpkgs/commit/cd7b1642e058be1260b8980eb342a42a3612194e) | `` scarab: 1.34.0.0 -> 2.1.0.0 ``                                                                 |
| [`407f8a38`](https://github.com/NixOS/nixpkgs/commit/407f8a380647942b8fc3ee67bb59d55820e5f8b5) | `` emacs: use llvmPackages_14 from `apple_sdk_11_0` ``                                            |
| [`fa8cf9b3`](https://github.com/NixOS/nixpkgs/commit/fa8cf9b370f07a3ea5cd2c2076b3e2e67a87e851) | `` erg: 0.6.19 -> 0.6.20 ``                                                                       |
| [`b8c87147`](https://github.com/NixOS/nixpkgs/commit/b8c871475afd0e529f1e2bc6f56763d2b9487f25) | `` nixos/infiniband: add support for configurable guids ``                                        |
| [`08d84537`](https://github.com/NixOS/nixpkgs/commit/08d84537592bd541e78622d2101050f9409ef562) | `` djlint: init at 1.32.1 ``                                                                      |
| [`cb936ef0`](https://github.com/NixOS/nixpkgs/commit/cb936ef04107de448bf96d82c70ec255e0f8e4e8) | `` python310Packages.html-void-elements: init at 0.1.0 ``                                         |
| [`dcf69ccc`](https://github.com/NixOS/nixpkgs/commit/dcf69ccc4fb9ede3c8e815119dd45579962c06cd) | `` python310Packages.html-tag-names: init at 0.1.2 ``                                             |
| [`df53ba2c`](https://github.com/NixOS/nixpkgs/commit/df53ba2ca036dda30f3736ee6dbed79a18226800) | `` python310Packages.cssbeautifier: init at 1.14.9 ``                                             |
| [`618299f8`](https://github.com/NixOS/nixpkgs/commit/618299f8b89a7b75660b7f98f688468ebac48cc8) | `` libdeltachat: 1.120.0 -> 1.121.0 ``                                                            |
| [`e6f31513`](https://github.com/NixOS/nixpkgs/commit/e6f315132dbd8d6c44a9eaee09c3966ee2e211bb) | `` python310Packages.pyaml: 23.9.1 -> 23.9.3 ``                                                   |
| [`a2f7bdde`](https://github.com/NixOS/nixpkgs/commit/a2f7bddec7aaf31dc4277bc279eb23c45b232f0c) | `` pyenv: 2.3.25 -> 2.3.26 ``                                                                     |
| [`b310a15b`](https://github.com/NixOS/nixpkgs/commit/b310a15bc38cf01196365a720cb2d61385fa7f4f) | `` v2ray-domain-list-community: 20230902035830 -> 20230905081311 ``                               |
| [`1f0b2214`](https://github.com/NixOS/nixpkgs/commit/1f0b22147ee17028bb83823a21fe2d55c0abcd7b) | `` python310Packages.ansible-runner: 2.3.3 -> 2.3.4 ``                                            |
| [`9c912844`](https://github.com/NixOS/nixpkgs/commit/9c912844847c1f182363fdd0fe68a920ed6a68cf) | `` greybird: 3.23.2 -> 3.23.3 ``                                                                  |