### PR TITLE
chore(flake/pre-commit-hooks): `7e3517c0` -> `58e22ea8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -438,11 +438,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1692274144,
-        "narHash": "sha256-BxTQuRUANQ81u8DJznQyPmRsg63t4Yc+0kcyq6OLz8s=",
+        "lastModified": 1694345285,
+        "narHash": "sha256-RZbTA5lmiRdy+XHk32+vk5ePDUrsV3lRFQaJBf/KgBs=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "7e3517c03d46159fdbf8c0e5c97f82d5d4b0c8fa",
+        "rev": "58e22ea8634a50292c8c2f29dc0652b11f2c5006",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                    |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
| [`ca16236a`](https://github.com/cachix/pre-commit-hooks.nix/commit/ca16236a0e6930760e0562501ceb4e8796878a70) | `` Add hook for vale (linter for prose) `` |
| [`e38142d2`](https://github.com/cachix/pre-commit-hooks.nix/commit/e38142d21ea9b5af8e77602edb1cc41677a4c477) | `` Add flags to isort hook ``              |