### PR TITLE
chore(flake/stylix): `beb35709` -> `c3c9f478`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -510,11 +510,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1691942466,
-        "narHash": "sha256-bK6FFbsKtyLKJLwgHerWp/EMMoWqE0UJk0KEbgYICbY=",
+        "lastModified": 1694375893,
+        "narHash": "sha256-oJGESNjJ/6o6tfuUavBZ7go4Oun7g9YKv7OqaQaY/80=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "beb35709c9a769a5f279d3177af778a15dcbda46",
+        "rev": "c3c9f4784b4f08f6676340126858d936edbce1fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                            |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`c3c9f478`](https://github.com/danth/stylix/commit/c3c9f4784b4f08f6676340126858d936edbce1fa) | `` Add support for Hyprland (#145) ``              |
| [`c3d11959`](https://github.com/danth/stylix/commit/c3d119590887c16fcf9b003200aded139e454d3d) | `` epkgs.trivialBuild: set dummy version (#150) `` |