### PR TITLE
chore(flake/nix-index-database): `71d840d8` -> `753d1e11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -347,11 +347,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694316990,
-        "narHash": "sha256-ql9bLSR+9rE3mJ/8sle1KUGMvPhjhtsVefRb1Ah3juk=",
+        "lastModified": 1694430224,
+        "narHash": "sha256-mf5+ndTTyMBA6jh0TSKcmolljUcWesT/HmT+4PodxRg=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "71d840d865b03ab1330d9b7f030a263991ee04e9",
+        "rev": "753d1e1119467393263cdd476f36bc91026edecf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                            |
| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`f4fc78e3`](https://github.com/nix-community/nix-index-database/commit/f4fc78e3b870344c6aa8a72d089d1cce100a3f23) | `` update mergify configuration `` |