### PR TITLE
chore(flake/nixos-hardware): `793de77d` -> `ca41b8a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -362,11 +362,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1693718952,
-        "narHash": "sha256-+nGdJlgTk0MPN7NygopipmyylVuAVi7OItIwTlwtGnw=",
+        "lastModified": 1694432324,
+        "narHash": "sha256-bo3Gv6Cp40vAXDBPi2XiDejzp/kyz65wZg4AnEWxAcY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "793de77d9f83418b428e8ba70d1e42c6507d0d35",
+        "rev": "ca41b8a227dd235b1b308217f116c7e6e84ad779",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                                                                                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [`ca41b8a2`](https://github.com/NixOS/nixos-hardware/commit/ca41b8a227dd235b1b308217f116c7e6e84ad779) | `` build(deps): bump cachix/install-nix-action from 22 to 23 ``                                                                                                                                |
| [`2d1a0da5`](https://github.com/NixOS/nixos-hardware/commit/2d1a0da5e3fdb1585874273907f152c1ca5ba242) | `` asus/zephyrus/ga401: fix keymapping ``                                                                                                                                                      |
| [`bec613e1`](https://github.com/NixOS/nixos-hardware/commit/bec613e179dfa03cb43ca47802bb9d6775896d7c) | `` purism librem5r4: update README and install u-boot-install-librem5 as system package ``                                                                                                     |
| [`ab68d63b`](https://github.com/NixOS/nixos-hardware/commit/ab68d63b92b044263bbf1f1c927e80771f279a7b) | `` purism librem5r4: firmware-imx: 8.15 -> 8.20 ``                                                                                                                                             |
| [`e507801b`](https://github.com/NixOS/nixos-hardware/commit/e507801ba79a13639c85c9ecc402b077e9fb33ed) | `` purism librem5r4 linux: 6.4.5-librem5 -> 6.4.14-librem5 ``                                                                                                                                  |
| [`4cd9ced7`](https://github.com/NixOS/nixos-hardware/commit/4cd9ced7fa0c10668a321546912adb8cbdc9369b) | `` surface: linux 6.4.12 -> 6.4.14 ``                                                                                                                                                          |
| [`88348cb5`](https://github.com/NixOS/nixos-hardware/commit/88348cb5c1e6bdad2f9879663dd9c12ef281a3be) | `` framework laptop 11th gen: change `mem_sleep_default=deep` kernel parameter to `acpi_osi="!Windows 2020"` (fixes a regression in s2idle, making it more power efficient than deep sleep) `` |
| [`9e28985b`](https://github.com/NixOS/nixos-hardware/commit/9e28985b44dc1d636b78ad0df6d1e5eecfcb2ffb) | `` build(deps): bump actions/checkout from 3 to 4 ``                                                                                                                                           |
| [`edf89861`](https://github.com/NixOS/nixos-hardware/commit/edf8986157a59d9e8f80dfa21aafea8707a4326a) | `` surface: Remove 0015-intel-thread-director.patch ``                                                                                                                                         |