### PR TITLE
chore(flake/nix-index-database): `753d1e11` -> `9a5c4996`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -347,11 +347,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694430224,
-        "narHash": "sha256-mf5+ndTTyMBA6jh0TSKcmolljUcWesT/HmT+4PodxRg=",
+        "lastModified": 1694430658,
+        "narHash": "sha256-8+OZ98kD63e/GaOiJimXHR/VYiTYwr25jTYGEHHOfq4=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "753d1e1119467393263cdd476f36bc91026edecf",
+        "rev": "9a5c4996d0918a151269600dfdf6ad3b3748f6a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                            |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`9a5c4996`](https://github.com/nix-community/nix-index-database/commit/9a5c4996d0918a151269600dfdf6ad3b3748f6a4) | `` Bump cachix/install-nix-action from 22 to 23 `` |
| [`e18bb7ff`](https://github.com/nix-community/nix-index-database/commit/e18bb7ff330f3ddc132e0dd7331c6cd6ee3e65e9) | `` Bump actions/checkout from 3 to 4 ``            |