### PR TITLE
chore(flake/home-manager): `ac1c7c34` -> `5171f5ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694463461,
-        "narHash": "sha256-kON7EGYsfKhGnCkMEq0E7r1kafUwkmaIthjxMgH6Wc0=",
+        "lastModified": 1694469544,
+        "narHash": "sha256-eqZng5dZnAUyb7xXyFk5z871GY/++KVv3Gyld5mVh20=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ac1c7c34dbf4f3f213f47a4cb8d09a4b4bb18b18",
+        "rev": "5171f5ef654425e09d9c2100f856d887da595437",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`5171f5ef`](https://github.com/nix-community/home-manager/commit/5171f5ef654425e09d9c2100f856d887da595437) | `` swaylock: document the need for host PAM configuration `` |
| [`ae2cc6a8`](https://github.com/nix-community/home-manager/commit/ae2cc6a88c19a61c23dba9faf64df85ddd09c510) | `` ci: bump actions/checkout from 3 to 4 ``                  |
| [`bfe38782`](https://github.com/nix-community/home-manager/commit/bfe38782355f2f10bd705c31ff2e71b6471d3f8f) | `` flake.lock: Update ``                                     |
| [`edda5599`](https://github.com/nix-community/home-manager/commit/edda5599d6bb6e6b7689e7f283c5b12b420dd7da) | `` ci: bump cachix/install-nix-action from 22 to 23 ``       |