### PR TITLE
chore(flake/darwin): `511177ff` -> `4496ab26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -100,11 +100,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692248770,
-        "narHash": "sha256-tZeFpETKQGbgnaSIO1AGWD27IyTcBm4D+A9d7ulQ4NM=",
+        "lastModified": 1694497842,
+        "narHash": "sha256-z03v/m0OwcLBok97KcUgMl8ZFw5Xwsi2z+n6nL7JdXY=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "511177ffe8226c78c9cf6a92a7b5f2df3684956b",
+        "rev": "4496ab26628c5f43d2a5c577a06683c753e32fe2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                             |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
| [`06257926`](https://github.com/LnL7/nix-darwin/commit/0625792671837155708eed2af4cad43dc9c9d825) | `` Add `homebrew.onActivation.extraFlags` option `` |
| [`ba92c4d3`](https://github.com/LnL7/nix-darwin/commit/ba92c4d307b54f172103163272e21f7c39542e60) | `` add support for dfont to the fonts module ``     |