### PR TITLE
chore(flake/nixpkgs): `db9208ab` -> `3a2786ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -377,11 +377,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694183432,
-        "narHash": "sha256-YyPGNapgZNNj51ylQMw9lAgvxtM2ai1HZVUu3GS8Fng=",
+        "lastModified": 1694422566,
+        "narHash": "sha256-lHJ+A9esOz9vln/3CJG23FV6Wd2OoOFbDeEs4cMGMqc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "db9208ab987cdeeedf78ad9b4cf3c55f5ebd269b",
+        "rev": "3a2786eea085f040a66ecde1bc3ddc7099f6dbeb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`5a31db94`](https://github.com/NixOS/nixpkgs/commit/5a31db94ce0922c4c75a0178b782a58aa6ba7814) | `` zeal: 0.6.1.20230320 -> 0.6.1.20230907 ``                                                  |
| [`5bac46e3`](https://github.com/NixOS/nixpkgs/commit/5bac46e3f928bac7d0a36921072ca4d4d3dfef92) | `` crowdin-cli: 3.13.0 -> 3.14.0 ``                                                           |
| [`2ab03da4`](https://github.com/NixOS/nixpkgs/commit/2ab03da4fdfebfb5c408a9ca90968e1c06184bd6) | `` eterm: remove ``                                                                           |
| [`09587329`](https://github.com/NixOS/nixpkgs/commit/0958732966b9f1652d07bd7509adec902323099d) | `` lutgen: init at 0.8.3 ``                                                                   |
| [`77671b68`](https://github.com/NixOS/nixpkgs/commit/77671b681ce37f62461c82b566d1c0527bb76abf) | `` oroborus: remove ``                                                                        |
| [`1b3bdf7f`](https://github.com/NixOS/nixpkgs/commit/1b3bdf7fce8f2e0f3de1f1027787d75e2b35d741) | `` performous: 1.2.0 -> 1.3.0 ``                                                              |
| [`cefb386e`](https://github.com/NixOS/nixpkgs/commit/cefb386e7813b26c67196b8966991a971b9e2dce) | `` cargo-llvm-cov: document test failure modes ``                                             |
| [`eae65c5f`](https://github.com/NixOS/nixpkgs/commit/eae65c5f85a3d23908f72adb653fa2e2fbc89a7d) | `` cargo-llvm-cov: refactor to fix tests ``                                                   |
| [`8ad79505`](https://github.com/NixOS/nixpkgs/commit/8ad7950576b691cf29b397c34c93767a64951cae) | `` cargo-llvm-cov: mark as broken on some platforms ``                                        |
| [`0bf98c46`](https://github.com/NixOS/nixpkgs/commit/0bf98c46997e48e5e8e9ad651e52a30bae362d7b) | `` cargo-llvm-cov: add myself as a maintainer ``                                              |
| [`2c5f722c`](https://github.com/NixOS/nixpkgs/commit/2c5f722cfc65ae5a57c896598f6b0137af35ff22) | `` engage: 0.1.2 -> 0.1.3 ``                                                                  |
| [`5582592a`](https://github.com/NixOS/nixpkgs/commit/5582592a36da50880580f98b6be7a4c19f5af82b) | `` gpg-tui: 0.9.6 -> 0.10.0 ``                                                                |
| [`12903b9e`](https://github.com/NixOS/nixpkgs/commit/12903b9edfd0ad3e57c5bb72aa594af228c4f13f) | `` engage: migrate to by-name ``                                                              |
| [`27da2924`](https://github.com/NixOS/nixpkgs/commit/27da29240e4382850f0f6e804102fe7280db1033) | `` rsonpath: 0.7.1 -> 0.8.0 ``                                                                |
| [`07582585`](https://github.com/NixOS/nixpkgs/commit/07582585396f2a6499c79c0d93565fde07316087) | `` vulkan-caps-viewer: 3.31 -> 3.32 ``                                                        |
| [`f9af0191`](https://github.com/NixOS/nixpkgs/commit/f9af019191c66a5f09eb142eecde2a17b32ca325) | `` appflowy: 0.3.0 -> 0.3.1 ``                                                                |
| [`61c03f58`](https://github.com/NixOS/nixpkgs/commit/61c03f5811d71ef236d04d820ed69899389281df) | `` corrosion: 0.4.2 -> 0.4.3 ``                                                               |
| [`612fd13a`](https://github.com/NixOS/nixpkgs/commit/612fd13a450e8de6943135a9523ce9a41912a9e4) | `` nawk: 20220122 -> 20230909 ``                                                              |
| [`7b542daa`](https://github.com/NixOS/nixpkgs/commit/7b542daa76684121f1aeb77b14480b84e1457659) | `` home-assistant: 2023.9.0 -> 2023.9.1 ``                                                    |
| [`dfafdce0`](https://github.com/NixOS/nixpkgs/commit/dfafdce00edfb20ac914cd692ba34ec46c7de66c) | `` python311Packages.bleak-retry-connector: 3.1.2 -> 3.1.3 ``                                 |
| [`40d71b9c`](https://github.com/NixOS/nixpkgs/commit/40d71b9ccd416f521d6269795351e97ecc5da11a) | `` python311Packages.aiovodafone: 0.0.8 -> 0.1.0 ``                                           |
| [`110bc355`](https://github.com/NixOS/nixpkgs/commit/110bc355ec2a3803283e36e9ad7c9cab1ced8452) | `` blisp: unstable-2023-06-03 -> 0.0.4 ``                                                     |
| [`bc573b32`](https://github.com/NixOS/nixpkgs/commit/bc573b32873ed413ba824f32c665fd24952f0ea9) | `` python311Packages.bluetooth-adapters: 0.16.0 -> 0.16.1 ``                                  |
| [`b2897ae1`](https://github.com/NixOS/nixpkgs/commit/b2897ae1703d7966ff1708748ef5e7648ca79a9e) | `` dict: enable on darwin ``                                                                  |
| [`cd4b9629`](https://github.com/NixOS/nixpkgs/commit/cd4b9629161fd79d7386aa87373d830eb3135843) | `` libmaa: enable on darwin ``                                                                |
| [`eea12fdf`](https://github.com/NixOS/nixpkgs/commit/eea12fdf8c2ccfcf6eccabc62535a06bd8e472be) | `` doc/hooks/zig.section.md: rewrite ``                                                       |
| [`a0b25e25`](https://github.com/NixOS/nixpkgs/commit/a0b25e2566f205e11402d0caba4b48eb520873b1) | `` doc/hooks/waf.section.md: rewrite ``                                                       |
| [`e9d19aa4`](https://github.com/NixOS/nixpkgs/commit/e9d19aa4df18dea5eca3e77514bdaf06d45d8277) | `` openpgp-card-tools: 0.9.3 -> 0.9.4 ``                                                      |
| [`d3784a34`](https://github.com/NixOS/nixpkgs/commit/d3784a34d88e4b1a3305537c00a87279de8b781f) | `` waypaper: 1.5 -> 1.9 ``                                                                    |
| [`8a286fcd`](https://github.com/NixOS/nixpkgs/commit/8a286fcd38465b91194aea82a247b2eb62cbacb0) | `` stylua: 0.18.1 -> 0.18.2 ``                                                                |
| [`1367bd5d`](https://github.com/NixOS/nixpkgs/commit/1367bd5d2ab45dba76abd3621ec536ba04ee1adf) | `` wfa2-lib: init at 2.3.3 ``                                                                 |
| [`7c62fc86`](https://github.com/NixOS/nixpkgs/commit/7c62fc8661ecefffd76ab2c29a07ad2e033c3a5e) | `` python3Packages.diffsync: init at 1.8.0 ``                                                 |
| [`43d1a2fc`](https://github.com/NixOS/nixpkgs/commit/43d1a2fc3ea67ef5d2eb7588a5035c0a15cd1820) | `` qcard: init at 0.7.1 ``                                                                    |
| [`93033641`](https://github.com/NixOS/nixpkgs/commit/930336411cd02eef7363f06bd777bcee3d26b739) | `` qcal: move sample config to prevent collision ``                                           |
| [`0e1a8027`](https://github.com/NixOS/nixpkgs/commit/0e1a8027d128f993a323878d34b1bf453f7cb636) | `` nixos/swraid: fix regression for old initrd and add test coverage ``                       |
| [`15a16144`](https://github.com/NixOS/nixpkgs/commit/15a16144bd81691815c8048ec950b468ea33f21a) | `` cargo-zigbuild: 0.17.1 -> 0.17.2 ``                                                        |
| [`216b7a7f`](https://github.com/NixOS/nixpkgs/commit/216b7a7f90798982324136b8c53fecd540331b4b) | `` quark-engine: 23.6.1 -> 23.8.1 ``                                                          |
| [`b7b77b65`](https://github.com/NixOS/nixpkgs/commit/b7b77b65a52872d09e8aafff3ba9d2d1180ef058) | `` pocketbase: 0.16.10 -> 0.18.3 ``                                                           |
| [`64790884`](https://github.com/NixOS/nixpkgs/commit/64790884bf877f8f77f29f7bbd5aa8c2769500cc) | `` python311Packages.python-telegram-bot: 20.4 -> 20.5 (#254398) ``                           |
| [`94d364b4`](https://github.com/NixOS/nixpkgs/commit/94d364b429193e92845704ab9f53c9c4b0ca8e6f) | `` python3Packages.python-yate: init at 0.4.1 ``                                              |
| [`3959f7c7`](https://github.com/NixOS/nixpkgs/commit/3959f7c72331f2ae09b00b42cf9dc5d267a30a02) | `` pwgen: add meta.mainProgram ``                                                             |
| [`7e8a5f34`](https://github.com/NixOS/nixpkgs/commit/7e8a5f3403981b0eba8c58c5dd116afaa43f6beb) | `` matrix-synapse.plugins.matrix-synapse-s3-storage-provider: use matrix-synapse-unwrapped `` |
| [`86655c6b`](https://github.com/NixOS/nixpkgs/commit/86655c6b75c749d8a30ef19eff1a6499996f84af) | `` matrix-synapse.plugins.matrix-synapse-s3-storage-provider: add format ``                   |
| [`4c2b3458`](https://github.com/NixOS/nixpkgs/commit/4c2b34580c38475d015973d382da69dc8749ed83) | `` matrix-synapse.plugins.matrix-synapse-s3-storage-provider: equalize content ``             |
| [`19ca99a3`](https://github.com/NixOS/nixpkgs/commit/19ca99a309b03010648d350dff8809a787ad76e5) | `` matrix-synapse.plugins.matrix-synapse-s3-storage-provider: add changelog to meta ``        |
| [`126992bb`](https://github.com/NixOS/nixpkgs/commit/126992bb33f96c1f5c6cf4f21ee00a0d978d02da) | `` teams-for-linux: 1.3.2 -> 1.3.8 ``                                                         |
| [`dd0f821e`](https://github.com/NixOS/nixpkgs/commit/dd0f821ea6d7e378763b2234be3e7ec6f27d95f9) | `` teams-for-linux: use electron_24 for now ``                                                |
| [`8e4b53be`](https://github.com/NixOS/nixpkgs/commit/8e4b53be9d76c2fce89afea250efa4e204193ddd) | `` linux: fix hash for 6.5.2 ``                                                               |
| [`227d1d1e`](https://github.com/NixOS/nixpkgs/commit/227d1d1e65cf0b8bd942e04f2f456b808e4755e0) | `` python311Packages.nats-py: 2.2.0 -> 2.3.1 ``                                               |
| [`709e91af`](https://github.com/NixOS/nixpkgs/commit/709e91af421164e7e12869b0315822e1d00b14d3) | `` python311Packages.dvc-data: 2.16.0 -> 2.16.1 ``                                            |
| [`6fed5bca`](https://github.com/NixOS/nixpkgs/commit/6fed5bcac6303255fb6ba01a070f4ef506943742) | `` pam_mount: 2.19 -> 2.20 (#254389) ``                                                       |
| [`7f341bb4`](https://github.com/NixOS/nixpkgs/commit/7f341bb4502e2dbb3b7541af0e517b22817e9ba1) | `` nixos/swraid: fix monitor service ``                                                       |
| [`566e32dd`](https://github.com/NixOS/nixpkgs/commit/566e32dd4290d951267e2a4d44a45c4c99f04efb) | `` nixos/bcache: add a `boot.bcache.enable` kill switch ``                                    |
| [`cc625486`](https://github.com/NixOS/nixpkgs/commit/cc625486c48890c37ced7759727c51dd17d20fd3) | `` nixos-rebuild: Add list-generations ``                                                     |
| [`b9e8491c`](https://github.com/NixOS/nixpkgs/commit/b9e8491c8436f78f9f334c8d25ddb6440f50e35f) | `` nwg-look: updated repo argument to string literal ``                                       |
| [`9ee10432`](https://github.com/NixOS/nixpkgs/commit/9ee10432a4b7464f0b068065a278e61ad61d0387) | `` rust: cargo: Use rustc and cargo built on Build ``                                         |
| [`7d3ee725`](https://github.com/NixOS/nixpkgs/commit/7d3ee7253328ac97986402f6390ca9418d6ce291) | `` bochs: move to by-name hierarchy ``                                                        |
| [`50bb03d9`](https://github.com/NixOS/nixpkgs/commit/50bb03d92ce7dbe3467fde757da703f5790e59ef) | `` python311Packages.mutagen: 1.46.0 -> 1.47.0 ``                                             |
| [`62e31beb`](https://github.com/NixOS/nixpkgs/commit/62e31beb718b83cea619a7e31a4384d8ff39dd43) | `` python311Packages.locationsharinglib: 5.0.1 -> 5.0.2 ``                                    |
| [`a4aac358`](https://github.com/NixOS/nixpkgs/commit/a4aac35874512e730937010e34e61328fe195ed4) | `` python311Packages.pypoint: 2.3.0 -> 2.3.1 ``                                               |
| [`d1dabb4b`](https://github.com/NixOS/nixpkgs/commit/d1dabb4be4b25ead855d819336637de57ad3302a) | `` python311Packages.python-homewizard-energy: 2.1.0 -> 2.1.0 ``                              |
| [`ca5e5519`](https://github.com/NixOS/nixpkgs/commit/ca5e5519f06e1a3c59de9828cca4efd4c10a0074) | `` influxdb2: 2.5.1 -> 2.7.1 ``                                                               |
| [`ee4c9a54`](https://github.com/NixOS/nixpkgs/commit/ee4c9a54c4d6ead5062f80f85e997163ad7f8f7d) | `` python311Packages.twilio: 8.7.0 -> 8.8.0 ``                                                |
| [`ba9b323f`](https://github.com/NixOS/nixpkgs/commit/ba9b323fd8698a54888ca2aac41f94c82b8ef2a1) | `` python311Packages.pytrafikverket: 0.3.5 -> 0.3.6 ``                                        |
| [`41b498c1`](https://github.com/NixOS/nixpkgs/commit/41b498c1601c30be1b2717b9b9b8018b29559ddb) | `` windowmaker: 0.95.9 -> 0.96.0 ``                                                           |
| [`144d4c5c`](https://github.com/NixOS/nixpkgs/commit/144d4c5cfd344e378cea3e985e54d2d33e80a92e) | `` windowmaker: migrate to by-name ``                                                         |
| [`0d9479d2`](https://github.com/NixOS/nixpkgs/commit/0d9479d298f4eaad7d5d13eb82f554316f63b686) | `` windowmaker: rewrite ``                                                                    |
| [`ba4d3fd9`](https://github.com/NixOS/nixpkgs/commit/ba4d3fd93fbaf35f60ba05816e445dfa2ae5eab3) | `` python310Packages.geventhttpclient: disable tests on darwin ``                             |
| [`893558c9`](https://github.com/NixOS/nixpkgs/commit/893558c92e9720dcda8fab030943cf4d1203e061) | `` python310Packages.geventhttpclient: 2.0.9 -> 2.0.10 ``                                     |
| [`1641e577`](https://github.com/NixOS/nixpkgs/commit/1641e577c92a902a574a1b31ba9687d93314d61e) | `` python311Packages.geventhttpclient: add changelog to meta ``                               |
| [`ee2f5909`](https://github.com/NixOS/nixpkgs/commit/ee2f590994b2646a6e62addcd6671106a21cb41c) | `` python311Packages.geventhttpclient: 2.0.8 -> 2.0.9 ``                                      |
| [`0ec0e829`](https://github.com/NixOS/nixpkgs/commit/0ec0e829a52fd2d9693e021faa078f054fbdc5bc) | `` rl-2311: add note about electron path change ``                                            |
| [`5d7c7549`](https://github.com/NixOS/nixpkgs/commit/5d7c754943c8e28dc631748128906161b62f4e96) | `` electron-bin: place electron files in libexec/ ``                                          |
| [`df1bdafd`](https://github.com/NixOS/nixpkgs/commit/df1bdafdbeda6065c48e78173df17cc961ccb6d5) | `` python311Packages.greeneye-monitor: 4.0.1 -> 5.0 ``                                        |
| [`a50af49d`](https://github.com/NixOS/nixpkgs/commit/a50af49da0a33eef0d86f6b6df9a7eb0650f32cd) | `` team-list: fix eval ``                                                                     |
| [`4fe741f3`](https://github.com/NixOS/nixpkgs/commit/4fe741f3fcb00854f1360739f186d284eaa9e718) | `` python311Packages.dbus-fast: 2.0.0 -> 2.0.1 ``                                             |
| [`6bb4538e`](https://github.com/NixOS/nixpkgs/commit/6bb4538e5d034fc071eedeb7a02d4071044646b8) | `` quakespasm: 0.95.1 -> 0.96.0 ``                                                            |
| [`f002de68`](https://github.com/NixOS/nixpkgs/commit/f002de6834fdde9c864f33c1ec51da7df19cd832) | `` github-copilot-cli: mark as unfree ``                                                      |
| [`2c3cc382`](https://github.com/NixOS/nixpkgs/commit/2c3cc38221e100f416d73173085f1b9b37bffc4c) | `` airscan: init at 0.3 ``                                                                    |
| [`2421c9cf`](https://github.com/NixOS/nixpkgs/commit/2421c9cfa2bdfe320908df1930d33ee03e894580) | `` karmor: 0.13.15 -> 0.13.16 ``                                                              |
| [`c109edf4`](https://github.com/NixOS/nixpkgs/commit/c109edf44dfa6804d7388ebc8675a39a3e0270b8) | `` maintainers: add johannwagner ``                                                           |
| [`15c0fcb6`](https://github.com/NixOS/nixpkgs/commit/15c0fcb6335f17de2ddb26bf9ddd770f68939335) | `` svt-av1: unbreak on aarch64-darwin ``                                                      |
| [`a79571be`](https://github.com/NixOS/nixpkgs/commit/a79571beca0ba89f184262947fc18e5121f56739) | `` maintainers/teams: add flyingcircus ``                                                     |
| [`8483f97d`](https://github.com/NixOS/nixpkgs/commit/8483f97dd6ffe2fc8f8986e65d3a0a61011a528c) | `` python311Packages.pyweatherflowrest: 1.0.10 -> 1.0.11 ``                                   |
| [`25b1e638`](https://github.com/NixOS/nixpkgs/commit/25b1e638f40f40c0ec217d5aaaeb16e92e5a7ca5) | `` python311Packages.python-lsp-server: 1.7.4 -> 1.8.0 ``                                     |
| [`789fcd7b`](https://github.com/NixOS/nixpkgs/commit/789fcd7be280e5fa36c332c197f06eabd8eac632) | `` python311Packages.python-lsp-jsonrpc: 1.0.0 -> 1.1.1 ``                                    |
| [`d637fab3`](https://github.com/NixOS/nixpkgs/commit/d637fab3b477f03698b21d73c5e079dfc7a04dec) | `` metasploit: 6.3.32 -> 6.3.33 ``                                                            |
| [`965513be`](https://github.com/NixOS/nixpkgs/commit/965513bea59b5892d127608829707948df3263c0) | `` sn0int: 0.25.0 -> 0.26.0 ``                                                                |
| [`7c7b05f3`](https://github.com/NixOS/nixpkgs/commit/7c7b05f357c7a7a4532c36794daa5d95ab3e896d) | `` phpPackages.composer: 2.5.8 -> 2.6.2 ``                                                    |
| [`175e33c8`](https://github.com/NixOS/nixpkgs/commit/175e33c8f55ef43d936731ce84515a1334fc5d9e) | `` exploitdb: 2023-09-08 -> 2023-09-09 ``                                                     |
| [`2a4f454f`](https://github.com/NixOS/nixpkgs/commit/2a4f454f7b8f8f0dbd07f89acd99ff0c898cf325) | `` trufflehog: 3.54.3 -> 3.54.4 ``                                                            |
| [`88a50ee9`](https://github.com/NixOS/nixpkgs/commit/88a50ee9112cac4712a993672e4c6e601fef5389) | `` tgpt: 1.7.6 -> 1.8.0 ``                                                                    |
| [`78ec172f`](https://github.com/NixOS/nixpkgs/commit/78ec172f65381f9044fcbac870be4e3f83994261) | `` vhdl-ls: 0.65.0 -> 0.66.0 ``                                                               |
| [`6aa431fa`](https://github.com/NixOS/nixpkgs/commit/6aa431fa0cf01c46fe6adbcdf175da364b93e2e5) | `` python311Packages.fakeredis: 2.18.0 -> 2.18.1 ``                                           |
| [`5bfc71fa`](https://github.com/NixOS/nixpkgs/commit/5bfc71fa40113c11de37250eaa6e3aaa9fbf9e7f) | `` pot: 2.1.0 -> 2.2.0 ``                                                                     |
| [`a51f74ac`](https://github.com/NixOS/nixpkgs/commit/a51f74ac23ad77a04cb0a61e0034f09cca381b32) | `` python311Packages.ypy-websocket: 0.12.2 -> 0.12.3 ``                                       |
| [`2804bb11`](https://github.com/NixOS/nixpkgs/commit/2804bb117145408d59f015d20b8627251b4a8750) | `` python311Packages.truststore: add pythonImportsCheck ``                                    |
| [`edd58ef4`](https://github.com/NixOS/nixpkgs/commit/edd58ef4875a1dcc33ecc9879c9c87cb1d9a6a04) | `` python311Packages.truststore: disable on unsupported Python releases ``                    |
| [`e384e38e`](https://github.com/NixOS/nixpkgs/commit/e384e38ee357ddf767c219c95f5864c78cd707cb) | `` python311Packages.truststore: update changelog entry ``                                    |
| [`74e7320c`](https://github.com/NixOS/nixpkgs/commit/74e7320caf8374bb663a07461a699f0aa02b8ae2) | `` python311Packages.truststore: 0.7.0 -> 0.8.0 ``                                            |
| [`4bf9efa9`](https://github.com/NixOS/nixpkgs/commit/4bf9efa9b7dfa735a5fc15159e6f38a230d162be) | `` python311Packages.sseclient-py: add pythonImportsCheck ``                                  |
| [`29b2feda`](https://github.com/NixOS/nixpkgs/commit/29b2fedaa65875c6c44ab7ac6bfdd8283853438b) | `` python311Packages.sseclient-py: add format ``                                              |
| [`10ea760f`](https://github.com/NixOS/nixpkgs/commit/10ea760fc484fe86aed3e1bf6f82276795909907) | `` python311Packages.sseclient-py: add changelog to meta ``                                   |
| [`8a8ec7b0`](https://github.com/NixOS/nixpkgs/commit/8a8ec7b023c55437e13b4df9840f5efc3d5e748f) | `` python311Packages.sseclient-py: 1.7.2 -> 1.8.0 ``                                          |
| [`278ae921`](https://github.com/NixOS/nixpkgs/commit/278ae9210aa71632ebf220c25c30333ec3e9ea5d) | `` python311Packages.flask-socketio: 5.3.5 -> 5.3.6 ``                                        |
| [`ba254c17`](https://github.com/NixOS/nixpkgs/commit/ba254c17d5887d8eadd4bd378029ad9f36939d35) | `` mutt: 2.2.11 -> 2.2.12 ``                                                                  |
| [`7e7a2ac2`](https://github.com/NixOS/nixpkgs/commit/7e7a2ac2491ecb5fb010e4f0b389d5a4dd6f7e95) | `` python311Packages.yalexs-ble: 2.2.3 -> 2.3.0 ``                                            |
| [`165f8ef5`](https://github.com/NixOS/nixpkgs/commit/165f8ef5ff4b68b3b3cc2f1a9001584e3213b9eb) | `` python311Packages.aiodiscover: 1.4.16 -> 1.5.1 ``                                          |
| [`88cb5104`](https://github.com/NixOS/nixpkgs/commit/88cb510461106ce3d8497ac3998c791504c9a9b6) | `` python311Packages.zeroconf: 0.102.0 -> 0.103.0 ``                                          |
| [`3f9cc712`](https://github.com/NixOS/nixpkgs/commit/3f9cc712281a3b194cdb037e1778ebc54280d07b) | `` nixos/networkd: Fix incorrectly treating attrset as list ``                                |
| [`f49b186d`](https://github.com/NixOS/nixpkgs/commit/f49b186df24d55d8d16040a1c8b90a14ede76eb2) | `` tcsh: migrate to by-name ``                                                                |
| [`3b518dc9`](https://github.com/NixOS/nixpkgs/commit/3b518dc9aca7c96eb71a5c9343edd31dd59fc9d1) | `` forgejo: 1.20.3-0 -> 1.20.4-0 ``                                                           |
| [`220b395b`](https://github.com/NixOS/nixpkgs/commit/220b395b7f671cc5637752af6e8643d3215b36a9) | `` protoc-gen-go-vtproto: 0.4.0 -> 0.5.0 ``                                                   |
| [`f1e11899`](https://github.com/NixOS/nixpkgs/commit/f1e11899defd59e409c0cfd3738d2026ef4cfb3a) | `` go2rtc: 1.6.2 -> 1.7.0 ``                                                                  |
| [`1daab5ec`](https://github.com/NixOS/nixpkgs/commit/1daab5ecaf2908d63f6167413c28c2b510a7a495) | `` gci: 0.11.0 -> 0.11.1 ``                                                                   |