### PR TITLE
chore(flake/deploy-rs): `d0cfc042` -> `31c32fb2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -126,11 +126,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694158470,
-        "narHash": "sha256-yWx9eBDHt6WR3gr65+J85KreHdMypty/P6yM35tIYYM=",
+        "lastModified": 1694513707,
+        "narHash": "sha256-wE5kHco3+FQjc+MwTPwLVqYz4hM7uno2CgXDXUFMCpc=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "d0cfc042eba92eb206611c9e8784d41a2c053bab",
+        "rev": "31c32fb2959103a796e07bbe47e0a5e287c343a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                 |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`f26e888c`](https://github.com/serokell/deploy-rs/commit/f26e888c41d28107de9dbc5b4e1553c1dfcf83db) | `` [#201] Deduce profile directory during activation `` |