### PR TITLE
chore(flake/flake-utils): `f9e7cf81` -> `ff7b65b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                   |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`ff7b65b4`](https://github.com/numtide/flake-utils/commit/ff7b65b44d01cf9ba6a71320833626af21126384) | `` Bump cachix/install-nix-action from 22 to 23 (#106) `` |
| [`286e744c`](https://github.com/numtide/flake-utils/commit/286e744c9654ef158fd3b9ef2526966ba41ebf58) | `` Bump actions/checkout from 3 to 4 (#105) ``            |