### PR TITLE
chore(flake/home-manager): `a0ddf43b` -> `d12c8fc8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694585439,
-        "narHash": "sha256-70BlfEsdURx5f8sioj8JuM+R4/SZFyE8UYrULMknxlI=",
+        "lastModified": 1694625190,
+        "narHash": "sha256-O7S55MRK7HF44/EobulbVBC0EldceprKih7CXjoHRCg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a0ddf43b6268f1717afcda54133dea30435eb178",
+        "rev": "d12c8fc85bf43436383fbb85194d5e8429baecc7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`d12c8fc8`](https://github.com/nix-community/home-manager/commit/d12c8fc85bf43436383fbb85194d5e8429baecc7) | `` emacs: fix emacs-extra-config test `` |
| [`c4c25944`](https://github.com/nix-community/home-manager/commit/c4c259442785ab79184184aad611ab56b439d3b0) | `` flake.lock: Update ``                 |