### PR TITLE
chore(flake/home-manager): `aed5ed97` -> `b62f5496`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694636981,
-        "narHash": "sha256-nRy7migOn3i3NZwSlCepol1Bx/xZ/XEigy2O15+COrw=",
+        "lastModified": 1694642908,
+        "narHash": "sha256-0Opzs/56VW03COlVdoBrHJZGxQ7gzLDEWADnccC8ras=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "aed5ed979eced3790a39d069f08884061bda3c82",
+        "rev": "b62f549653e97d78392c1e282b8ca76546a86585",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`a8cde785`](https://github.com/nix-community/home-manager/commit/a8cde785062bdc2a6a52e330dfb461f969f4558d) | `` home-manager: update translation templates `` |
| [`f07207f8`](https://github.com/nix-community/home-manager/commit/f07207f8cab92d52b3871c760b8007ab32ff66cb) | `` home-manager: fix typo ``                     |
| [`5f5cb7a6`](https://github.com/nix-community/home-manager/commit/5f5cb7a61360ba6555cf0875c590c0fe0f698d5e) | `` carapace: add xgettext workaround ``          |