### PR TITLE
chore(flake/nixos-hardware): `3ccd87fc` -> `850b04d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -362,11 +362,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1694591211,
-        "narHash": "sha256-NPP7XGZH+Q5ey7nE2zGLrBrzKmLYPhj8YgsTSdhH0D4=",
+        "lastModified": 1694681873,
+        "narHash": "sha256-ajOF6dGmJ+CRKxIHvtcVW9Xh0C6FWmN/crlq1sa4qhU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3ccd87fcdae4732fe33773cefa4375c641a057e7",
+        "rev": "850b04d59cbc003158b5258932dab6e26ed0b388",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`850b04d5`](https://github.com/NixOS/nixos-hardware/commit/850b04d59cbc003158b5258932dab6e26ed0b388) | `` star64: use stable opensbi release `` |
| [`16b8c06f`](https://github.com/NixOS/nixos-hardware/commit/16b8c06fd3d20dc52f867d44a3bf1aa75d911c7f) | `` star64: add mmc firmware updater ``   |