### PR TITLE
chore(flake/lanzaboote): `7ef2b137` -> `45b529ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -285,11 +285,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1694683444,
-        "narHash": "sha256-zEUeaXsFo7889GLtyZ/h3wR7kpp7Y5RAbInvDPyIOm4=",
+        "lastModified": 1694688327,
+        "narHash": "sha256-d/s2XT2/GB+DPrnRWOTEwVBFUo5QJhIswY4bsBRCkoc=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "7ef2b13780a25a3b11c6ccb35c34c76cf3fb1e50",
+        "rev": "45b529ca584411a6dc05ee7eb516012b6ba970b4",
         "type": "github"
       },
       "original": {
@@ -483,11 +483,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1689906077,
-        "narHash": "sha256-2tjLXKoSK7O0LYHlA6GCWL0gy2kZZno4krg+KZpDh6U=",
+        "lastModified": 1694657451,
+        "narHash": "sha256-cRZa9ZmUi0EFKcmzpsOXLVhiMQD8XLrku8v+U1YiGm8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c88b28944129eeff5e819bdc21248dc07eb0625d",
+        "rev": "7c4f46f0b3597e3c4663285e6794194e55574879",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                                        |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`ff442cd0`](https://github.com/nix-community/lanzaboote/commit/ff442cd03266f8b982a7eb7f40c38c88c62d1f7d) | `` tool: introduce some more whitespace ``                                     |
| [`143a000f`](https://github.com/nix-community/lanzaboote/commit/143a000f369f829c23a720bafc5ba38048562347) | `` tool: separates use statements correctly with whitespace ``                 |
| [`baf2f5f6`](https://github.com/nix-community/lanzaboote/commit/baf2f5f6bbf8a6a0bf667bb51f560538c4e6ca00) | `` tool: use workspace values in Cargo.toml ``                                 |
| [`efd8c502`](https://github.com/nix-community/lanzaboote/commit/efd8c502140adeafc0b542233eb3150f79c960f4) | `` tool: remove superfluous lock file ``                                       |
| [`726524d2`](https://github.com/nix-community/lanzaboote/commit/726524d2d75050d3d8e89896673d72b08d76f0c5) | `` readme: update about lzbt ``                                                |
| [`f9cb4257`](https://github.com/nix-community/lanzaboote/commit/f9cb4257c7a45881b08a5be1ea6ea13ed497995a) | `` flake: fix lanzaboote-tool → lzbt-systemd ``                                |
| [`eba963b6`](https://github.com/nix-community/lanzaboote/commit/eba963b6f1b51f9a0d8cb45fc7d62853fd00fbf4) | `` tool/shared: make clippy happy ``                                           |
| [`fd188a0e`](https://github.com/nix-community/lanzaboote/commit/fd188a0e32878b4c51d22a0b6f1f6df36d95dc37) | `` tool/shared: make constraints less concrete and drop lockfile ``            |
| [`923567d0`](https://github.com/nix-community/lanzaboote/commit/923567d08a1ef3c1c448c4c6c6681858ff212769) | `` systemd-tool: make integration test pass ``                                 |
| [`8029449c`](https://github.com/nix-community/lanzaboote/commit/8029449cba637aed6efd8fc1c2eab468e6834477) | `` tool: split systemd into a new crate and make tool into a lib-only crate `` |
| [`efe7b40f`](https://github.com/nix-community/lanzaboote/commit/efe7b40f5c2e434a9fa8be42526e3dc7dcfdaa1c) | `` lzbt: abstraction for multiple backends ``                                  |