### PR TITLE
chore(flake/lanzaboote): `1255f8fc` -> `7f92dd1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -285,11 +285,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1694689807,
-        "narHash": "sha256-JUQlq33Pa61XLA8CgSUbxgC8CsEhwE87B1rJAMgfk5g=",
+        "lastModified": 1694697985,
+        "narHash": "sha256-tAa0pyDOazvMfEjDhajcyLadu5a3euSMzzwia37J8x8=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "1255f8fc49395022aac762fe89d1eed19fa3c0f4",
+        "rev": "7f92dd1e7b0ff92c65856cd9015f651c151f0229",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                          |
| --------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`3dab5531`](https://github.com/nix-community/lanzaboote/commit/3dab5531b1dfd252d5ede21659c2ea32a2e6ce74) | `` stub: remove TPM 1 support `` |