### PR TITLE
chore(flake/nixpkgs): `3a2786ee` -> `ace5093e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -377,11 +377,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694422566,
-        "narHash": "sha256-lHJ+A9esOz9vln/3CJG23FV6Wd2OoOFbDeEs4cMGMqc=",
+        "lastModified": 1694767346,
+        "narHash": "sha256-5uH27SiVFUwsTsqC5rs3kS7pBoNhtoy9QfTP9BmknGk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3a2786eea085f040a66ecde1bc3ddc7099f6dbeb",
+        "rev": "ace5093e36ab1e95cb9463863491bee90d5a4183",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`100f1e09`](https://github.com/NixOS/nixpkgs/commit/100f1e09fe5fff917ee5c4be1fd1243d00f9c0b6) | `` vault: add `mainProgram` (#255100) ``                                         |
| [`576a61da`](https://github.com/NixOS/nixpkgs/commit/576a61dabb349f0e4c0d6c954abe6942d9ef7b28) | `` picard: 2.9.1 -> 2.9.2 ``                                                     |
| [`294422fe`](https://github.com/NixOS/nixpkgs/commit/294422fed551cb14510e0e89ad0e4148c7aabddb) | `` picard: refactor ``                                                           |
| [`295a5e1e`](https://github.com/NixOS/nixpkgs/commit/295a5e1e2bacd6e246db8b2bb35d2a9415883224) | `` fix capitalization (#254542) ``                                               |
| [`39e7ddaf`](https://github.com/NixOS/nixpkgs/commit/39e7ddaf19b18c5f21e7687b66dd0ceba31704ae) | `` recoll: use catdvi ``                                                         |
| [`5da2745e`](https://github.com/NixOS/nixpkgs/commit/5da2745e2429d6842e55448a7050e7c573bd65ff) | `` catdvi: init at 0.14 ``                                                       |
| [`ce1080f6`](https://github.com/NixOS/nixpkgs/commit/ce1080f65ccd779b63486b8b8531d0a87dcc4301) | `` php.packages.psysh: Build with new builder ``                                 |
| [`38f37080`](https://github.com/NixOS/nixpkgs/commit/38f37080c55027ff11c9e2ac4f34d6f46202e5d0) | `` nixos/lib/make-btrfs-fs: copy improvements from ``                            |
| [`1c77fbdb`](https://github.com/NixOS/nixpkgs/commit/1c77fbdbe80160e71bdbfd690fab95944dd4de8a) | `` thunderbird-bin: 115.2.1 -> 115.2.2 ``                                        |
| [`97b7acee`](https://github.com/NixOS/nixpkgs/commit/97b7aceef4bbe0917af1b42f92eb8ccc43cf54a6) | `` discord-ptb: 0.0.45 -> 0.0.46 ``                                              |
| [`99283f44`](https://github.com/NixOS/nixpkgs/commit/99283f44be1bff250dfb63e3746d4668b4f20454) | `` go: switch to finalAttrs ``                                                   |
| [`3bc2843b`](https://github.com/NixOS/nixpkgs/commit/3bc2843b776ad407310fe1c86b12aee5517c4abf) | `` python310Packages.softlayer: 6.1.7 -> 6.1.8 ``                                |
| [`5d866fe3`](https://github.com/NixOS/nixpkgs/commit/5d866fe3fb9e68eb53d57deb18c39fb194ba3fab) | `` robotfindskitten: migrate to by-name ``                                       |
| [`f61a9fa7`](https://github.com/NixOS/nixpkgs/commit/f61a9fa77930dc473f721c61529b80a76cd8a124) | `` robotfindskitten: refactor ``                                                 |
| [`b11499ad`](https://github.com/NixOS/nixpkgs/commit/b11499ad9bc7f1dee225a102edf9c3de4eccdaae) | `` python310Packages.minikerberos: 0.4.1 -> 0.4.2 ``                             |
| [`4b790413`](https://github.com/NixOS/nixpkgs/commit/4b790413b4cb67615f2efcdde5066d9c57138369) | `` eza: 0.11.1 -> 0.12.0 (#255159) ``                                            |
| [`7339c91a`](https://github.com/NixOS/nixpkgs/commit/7339c91a8139ff3d8b3fdee18c34f981a329b4c1) | `` vault-bin: 1.14.1 -> 1.14.3 ``                                                |
| [`bdf8c4b6`](https://github.com/NixOS/nixpkgs/commit/bdf8c4b61d175c86614a27e6344512df2ec441ec) | `` lldap: 0.4.3 -> 0.5.0 ``                                                      |
| [`544053a2`](https://github.com/NixOS/nixpkgs/commit/544053a21ee8b11cdb8581f0b72c8c9f413dbc84) | `` packwiz: unstable-2023-02-13 -> unstable-2023-08-28 ``                        |
| [`2ed69f9e`](https://github.com/NixOS/nixpkgs/commit/2ed69f9ec8a497b05ec51e93bdfea13ad7dfb238) | `` pkgsMusl.connman: use fetchurl for patch ``                                   |
| [`e5d8baaf`](https://github.com/NixOS/nixpkgs/commit/e5d8baafcdfb307c6438bf28f2fd7495fea9833d) | `` nixos/yubikey-touch-detector: init (#254947) ``                               |
| [`04714bfb`](https://github.com/NixOS/nixpkgs/commit/04714bfb57bf8788d02556fe7d82e48855c4edd0) | `` python311Packages.reolink-aio: 0.7.9 -> 0.7.10 ``                             |
| [`ed98252f`](https://github.com/NixOS/nixpkgs/commit/ed98252f00876849653b4b8f15adc01060389473) | `` python311Packages.zeroconf: 0.111.0 -> 0.112.0 ``                             |
| [`d7adac9b`](https://github.com/NixOS/nixpkgs/commit/d7adac9b2ad55adda901432356791db8126572d0) | `` python311Packages.zeroconf: 0.110.0 -> 0.111.0 ``                             |
| [`a2f86233`](https://github.com/NixOS/nixpkgs/commit/a2f8623363e186271cbe2abae1bcac429d49c340) | `` build-support/php: prevent the creation of symlinks ``                        |
| [`fd439a06`](https://github.com/NixOS/nixpkgs/commit/fd439a0686b9cd07941f340facded0cd9073150b) | `` remove "the the" from mpv plugin autoload.nix ``                              |
| [`06a793d4`](https://github.com/NixOS/nixpkgs/commit/06a793d4dbc649a12f62b809b594970db318a594) | `` python311Packages.zeroconf: 0.109.0 -> 0.110.0 ``                             |
| [`f4842876`](https://github.com/NixOS/nixpkgs/commit/f484287675c2fdd642414cee3d6e5a653a9ef23e) | `` python311Packages.zeroconf: 0.108.0 -> 0.109.0 ``                             |
| [`67601744`](https://github.com/NixOS/nixpkgs/commit/67601744b6c59f7c1aab25acd9a6271bba24a4d2) | `` pysimplesoap: Adjust for change in fetchDebianPatch's API ``                  |
| [`6190662a`](https://github.com/NixOS/nixpkgs/commit/6190662a4645147529769908494ca48c7d73db4d) | `` pdfchain: use upstream fetchDebianPatch ``                                    |
| [`0cfc319f`](https://github.com/NixOS/nixpkgs/commit/0cfc319f8362df42e5471a75e2e39d41dd69d2e7) | `` fetchDebianPatch: Require patch names with extensions ``                      |
| [`5576200a`](https://github.com/NixOS/nixpkgs/commit/5576200a5e4201ce14376aa7dc379e4baee25ba6) | `` gvm-libs: 22.7.0 -> 22.7.1 ``                                                 |
| [`c31ff4e8`](https://github.com/NixOS/nixpkgs/commit/c31ff4e832ecbedf841976b54b1b5f1ad0b269e3) | `` cirrus-cli: 0.102.0 -> 0.103.1 ``                                             |
| [`32c54441`](https://github.com/NixOS/nixpkgs/commit/32c54441c3f622685ca5cce689baed570ae51edb) | `` go-tools: 2023.1.5 -> 2023.1.6 ``                                             |
| [`a8cba393`](https://github.com/NixOS/nixpkgs/commit/a8cba393e94a3313d4938e91bd2f1b1fd30f9b7b) | `` element-{desktop,web}: 1.11.40 -> 1.11.42 (#254966) ``                        |
| [`91cbe3de`](https://github.com/NixOS/nixpkgs/commit/91cbe3de8088a152701948c4bf34078de11581f7) | `` wayland: remove unused substituteAll input ``                                 |
| [`eb52cb7d`](https://github.com/NixOS/nixpkgs/commit/eb52cb7d180f5bf83e2ee39e7612c74f781e70cc) | `` signalbackup-tools: 20230907 -> 20230914-1 ``                                 |
| [`5cdb92fd`](https://github.com/NixOS/nixpkgs/commit/5cdb92fd1b88536523d98fac73111bf629e9c354) | `` clightning: 23.08 -> 23.08.1 ``                                               |
| [`903ebdc0`](https://github.com/NixOS/nixpkgs/commit/903ebdc0a053a202fceb5de9d8a3cd5cf85e04a1) | `` nixos/nvidia: don't assume x11 is used.. ``                                   |
| [`52351762`](https://github.com/NixOS/nixpkgs/commit/52351762b78ee829c333afbaee47d8b8d3a73b56) | `` doc: remove mention of X11 license variant (#255081) ``                       |
| [`b414f942`](https://github.com/NixOS/nixpkgs/commit/b414f942e0379771422fd6e203a558ab7151eac5) | `` doc: link, instead of just mentioning, Nix manual (#255126) ``                |
| [`a29cf4ae`](https://github.com/NixOS/nixpkgs/commit/a29cf4aece7ed0f497f600faec9614c6feb5159b) | `` Link to usage of pkg description instead of referring to nix-env (#255127) `` |
| [`e24efaf7`](https://github.com/NixOS/nixpkgs/commit/e24efaf742a1db68433706396ae6b8ecf642a3a9) | `` signal-desktop: 6.30.1 -> 6.30.2 ``                                           |
| [`1a720364`](https://github.com/NixOS/nixpkgs/commit/1a720364911f00ee0d74610abed787ae8f7f39b0) | `` vscodium: 1.82.0.23250 -> 1.82.1.23255 ``                                     |
| [`961a90f4`](https://github.com/NixOS/nixpkgs/commit/961a90f4e5f7b1c6ff5cb32499f6e4972d732f78) | `` home-manager: 2023-05-30 -> 2023-09-14 ``                                     |
| [`fe245a5e`](https://github.com/NixOS/nixpkgs/commit/fe245a5e03d3d6a71121e5a1bbfc2894afeb1b8c) | `` phpactor: 2023.06.17 -> 2023.08.06-1 ``                                       |
| [`4afa887b`](https://github.com/NixOS/nixpkgs/commit/4afa887b8a69d8d8ac2bc23513fad75e82fbb466) | `` cloud-hypervisor: run more tests ``                                           |
| [`68d76f78`](https://github.com/NixOS/nixpkgs/commit/68d76f78b267a94adede279d823f1f46ced968ee) | `` s5: use sri hash ``                                                           |
| [`2f5ec79c`](https://github.com/NixOS/nixpkgs/commit/2f5ec79c5a4900ae68f6da79191cc1a5b4097475) | `` syft: 0.88.0 -> 0.90.0 ``                                                     |
| [`d1e3c1ac`](https://github.com/NixOS/nixpkgs/commit/d1e3c1acc7b9ed2e0e1a112a1f5600cee1397283) | `` neochat: add missing runtime dependencies ``                                  |
| [`9bd536f8`](https://github.com/NixOS/nixpkgs/commit/9bd536f8737e83708c6ccc05023774917d2411a3) | `` svg2pdf: 0.7.0 -> 0.7.1 ``                                                    |
| [`0a5a85af`](https://github.com/NixOS/nixpkgs/commit/0a5a85afd17b944d819994320016fe7fa150cb21) | `` python310Packages.peaqevcore: 19.3.2 -> 19.4.2 ``                             |
| [`9a51900c`](https://github.com/NixOS/nixpkgs/commit/9a51900c53f1ac257b606919bf3ac774a3564a9a) | `` gitnr: 0.1.1 -> 0.1.3 ``                                                      |
| [`5c64daa2`](https://github.com/NixOS/nixpkgs/commit/5c64daa240fc26705415ce05f983f8d330165500) | `` sbt-extras: 2023-08-28 -> 2023-09-13 (#255054) ``                             |
| [`90b23c45`](https://github.com/NixOS/nixpkgs/commit/90b23c45d0059c30bb8e6aec87fd4437f6c6bf4d) | `` pkgsMusl.connman: fix hash for patch ``                                       |
| [`c4550595`](https://github.com/NixOS/nixpkgs/commit/c45505950a2415d5d0835b644a4b1e3dcba7e2f7) | `` sublime4-dev: 4150 -> 4155 ``                                                 |
| [`ca5c75c6`](https://github.com/NixOS/nixpkgs/commit/ca5c75c6f9299aae0ec31cac9ca812c25e14e434) | `` goldendict-ng: improve description ``                                         |
| [`cb6ffbd8`](https://github.com/NixOS/nixpkgs/commit/cb6ffbd84cf2ce26a2626dc3e372e19c90c3359d) | `` goldendict-ng: set mainProgram ``                                             |
| [`39c114e5`](https://github.com/NixOS/nixpkgs/commit/39c114e504fc7a4e7e1806eef8470b9d25809fa9) | `` kde/gear: 23.08.0 -> 23.08.1 ``                                               |
| [`1e0e8df1`](https://github.com/NixOS/nixpkgs/commit/1e0e8df197429a436d799c470e9684d7f63e3f31) | `` nftables: add option to disable interactive ``                                |
| [`ba5e6180`](https://github.com/NixOS/nixpkgs/commit/ba5e6180a2c1f79cfd77c9a5df0065be53344f54) | `` python310Packages.pulumi-aws: 6.0.4 -> 6.1.0 ``                               |
| [`7f45e197`](https://github.com/NixOS/nixpkgs/commit/7f45e19779a0a999a8fe9b7f12f113bea9029bc8) | `` python310Packages.bugsnag: 4.5.0 -> 4.6.0 ``                                  |
| [`c232fe0a`](https://github.com/NixOS/nixpkgs/commit/c232fe0a65ca450756c895f95c76d260fa35211e) | `` fcitx5-with-addons: Fix eval when withConfigtool is false ``                  |
| [`b9f25128`](https://github.com/NixOS/nixpkgs/commit/b9f2512891e7a685887cc44cdd5d07be98ac8507) | `` auto-multiple-choice: 1.5.2 -> 1.6.0 ``                                       |
| [`17015392`](https://github.com/NixOS/nixpkgs/commit/170153921e1c35a0476d806d2aa6b814d1ffbd68) | `` awscli2: 2.13.15 -> 2.13.18 ``                                                |
| [`2f6fe7a2`](https://github.com/NixOS/nixpkgs/commit/2f6fe7a29c04ad00b5d368f32102857282245da3) | `` goldendict-ng: 23.07.23 -> 23.09.10 ``                                        |
| [`e975681d`](https://github.com/NixOS/nixpkgs/commit/e975681deb94b51f4f315112ec6b2622f84a81d0) | `` _4th: refactor ``                                                             |
| [`6affb7c8`](https://github.com/NixOS/nixpkgs/commit/6affb7c8d469f374e91f77280873aa4042a1c517) | `` libvlc: fix cross ``                                                          |
| [`f3e2492e`](https://github.com/NixOS/nixpkgs/commit/f3e2492e0ba3fb673bd4ae5a1d5e1d1a23b3f918) | `` python310Packages.pyaml: 23.9.3 -> 23.9.6 ``                                  |
| [`2e6b8c01`](https://github.com/NixOS/nixpkgs/commit/2e6b8c011708b441f005474b5692d5d633f115db) | `` vault: 1.14.2 -> 1.14.3 ``                                                    |
| [`724235e7`](https://github.com/NixOS/nixpkgs/commit/724235e7773fcaeb3c0da0cdec8a5a58d43c4514) | `` zsh-prezto: unstable-2023-06-22 -> unstable-2023-09-12 ``                     |
| [`cef44170`](https://github.com/NixOS/nixpkgs/commit/cef441709dead60341de1231c030204811ebe7fb) | `` nixos/hyprland: update portal override ``                                     |
| [`4dd9e988`](https://github.com/NixOS/nixpkgs/commit/4dd9e988a52d21e6159c17a39704e5fc932c5b4b) | `` xdg-desktop-portal-hyprland: 0.5.0 -> unstable-2023-09-10 ``                  |
| [`8f4341b1`](https://github.com/NixOS/nixpkgs/commit/8f4341b14454eb15477c3bb8403ae30f27cde280) | `` hyprland: unstable-2023-08-15 -> 0.29.1 ``                                    |
| [`f8ad7cd1`](https://github.com/NixOS/nixpkgs/commit/f8ad7cd1ef5df7087c15b8fe19b23c0cfae9f7a5) | `` deepin.deepin-icon-theme: 2021.11.24 -> 2023.04.03 ``                         |
| [`30c3bfaf`](https://github.com/NixOS/nixpkgs/commit/30c3bfaf306f169488e82f75b38ff80e10dbc6d8) | `` python310Packages.transmission-rpc: 6.0.0 -> 7.0.0 ``                         |
| [`fcbfef1e`](https://github.com/NixOS/nixpkgs/commit/fcbfef1e431e5fcdd400a7650b04a11699ebdb38) | `` buildMix: copy package.json to support phoenix builds ``                      |
| [`504148b1`](https://github.com/NixOS/nixpkgs/commit/504148b135c06f50d7b752f0efe946c16f74941f) | `` electron_25: 25.7.0 -> 25.8.1 (CVE-2023-4863, #254798) ``                     |
| [`e588b444`](https://github.com/NixOS/nixpkgs/commit/e588b4441e30883747b0f3607729f1326f84363c) | `` electron_24: 24.8.1 -> 24.8.3 (CVE-2023-4863, #254798) ``                     |
| [`dd928aaf`](https://github.com/NixOS/nixpkgs/commit/dd928aafc0b4e1cbd2dc112270aea9fd10d49831) | `` electron_22: 22.3.22 -> 22.3.24 (CVE-2023-4863, #254798) ``                   |
| [`1e335c51`](https://github.com/NixOS/nixpkgs/commit/1e335c516b7a2a9bc777bf3739da7557c726124e) | `` nixos/cfdyndns: dynamic user and loadcredentials ``                           |
| [`d989b040`](https://github.com/NixOS/nixpkgs/commit/d989b040da3e42f6f4a769547887974719939c42) | `` nixos/mobilizon: migrate to mdDoc ``                                          |
| [`1cb28fc8`](https://github.com/NixOS/nixpkgs/commit/1cb28fc8b4a8083e3bdcc22d4281042040a7bb06) | `` mobilizon: remove obsolete pinned version for beamPackages, elixir ``         |
| [`b6c033c7`](https://github.com/NixOS/nixpkgs/commit/b6c033c7656b787ef66087efbea9aa6292061d99) | `` minio-client: 2023-08-15T23-03-09Z -> 2023-09-07T22-48-55Z ``                 |
| [`6ba56be7`](https://github.com/NixOS/nixpkgs/commit/6ba56be7f92fdf0d8aa58e8af4ab3c6b8d062992) | `` tor-browser-bundle-bin: 12.5.3 -> 12.5.4 ``                                   |
| [`19392da6`](https://github.com/NixOS/nixpkgs/commit/19392da6da518d817a8f16a80f6d4fb89fba6f4b) | `` clickhouse-backup: 2.4.0 -> 2.4.1 ``                                          |
| [`e19e68c7`](https://github.com/NixOS/nixpkgs/commit/e19e68c7c9ac39413721322df92b235180ccb7aa) | `` mullvad-browser: 12.5.3 -> 12.5.4 ``                                          |
| [`3807ab24`](https://github.com/NixOS/nixpkgs/commit/3807ab24077dd827482cc76c2a0d598e12578119) | `` ocamlPackages.ocaml-protoc: 2.0.2 → 2.4 ``                                    |
| [`10dbeddc`](https://github.com/NixOS/nixpkgs/commit/10dbeddce2dc72aa3560f6cb1ccf857fe13913f6) | `` vimPlugins.nvim-window-picker: init at 2023-07-29 ``                          |
| [`3ab6f673`](https://github.com/NixOS/nixpkgs/commit/3ab6f673fc4c8ef23528f4965f547a727541879a) | `` linux_xanmod_latest: 6.4.15 -> 6.5.3 ``                                       |
| [`c73bbb05`](https://github.com/NixOS/nixpkgs/commit/c73bbb0587c17bb9486a422cc946485c86bcfbdd) | `` linux_xanmod: 6.1.52 -> 6.1.53 ``                                             |
| [`bce0e30b`](https://github.com/NixOS/nixpkgs/commit/bce0e30b1751783dac9ef87fd1c78cc6356cbeff) | `` python310Packages.types-redis: 4.6.0.5 -> 4.6.0.6 ``                          |
| [`20f87f26`](https://github.com/NixOS/nixpkgs/commit/20f87f261889fe728ef6310e7e09a6f9bbaa255f) | `` tabula-java: build from source ``                                             |
| [`2a19147a`](https://github.com/NixOS/nixpkgs/commit/2a19147aa450e2ae540a5dc240e52124a59bf533) | `` k3s: 1.27.4+k3s1 -> 1.27.5+k3s1 ``                                            |
| [`0d820b30`](https://github.com/NixOS/nixpkgs/commit/0d820b3047e4f679953fa596f85cee616658acd3) | `` python310Packages.mautrix: 0.20.1 -> 0.20.2 ``                                |
| [`10a7392f`](https://github.com/NixOS/nixpkgs/commit/10a7392f84f27cc22ba83f424a0201d81a7b1c83) | `` python310Packages.kaptan: 0.5.12 -> 0.6.0 ``                                  |
| [`d08d99e4`](https://github.com/NixOS/nixpkgs/commit/d08d99e4f6124b48c64846c25ad12e287b4bbe6c) | `` wlrobs: 2022-10-06 -> 23-08-23 ``                                             |
| [`f12c6681`](https://github.com/NixOS/nixpkgs/commit/f12c6681a0e707c1c9f3c31cb52b7c8d66c5b389) | `` ngrok: 3.3.0 -> 3.3.4 ``                                                      |
| [`e85841b1`](https://github.com/NixOS/nixpkgs/commit/e85841b10331a1218fd9dd64536d41f9f7eb160f) | `` python310Packages.authheaders: 0.15.2 -> 0.15.3 ``                            |
| [`d6578bcc`](https://github.com/NixOS/nixpkgs/commit/d6578bcc744788f0719b28884c9fe271025c1b94) | `` gst_all_1.gst-plugins-rs: check that system libwebp was linked (#254915) ``   |
| [`df9490d1`](https://github.com/NixOS/nixpkgs/commit/df9490d1d34aa815479be8998e842ac02a318bbb) | `` python310Packages.twisted: update patch URLs ``                               |
| [`246ab60d`](https://github.com/NixOS/nixpkgs/commit/246ab60dd47d88709c1862dd364c8c35a955ff48) | `` plexamp: 4.8.2 -> 4.8.3 ``                                                    |
| [`c1d62de1`](https://github.com/NixOS/nixpkgs/commit/c1d62de173c316426b817c48e104d810de60a8f8) | `` snowflake: add yayayayaka to maintainers ``                                   |
| [`f063e93d`](https://github.com/NixOS/nixpkgs/commit/f063e93d260513c5612b989508ed26f4a6cafe76) | `` snowflake: 2.5.1 -> 2.6.1 ``                                                  |
| [`126edb79`](https://github.com/NixOS/nixpkgs/commit/126edb794b30ef4c6153dc1df047166e07cc3538) | `` rust-cbindgen: 0.25.0 -> 0.26.0 ``                                            |
| [`dd885254`](https://github.com/NixOS/nixpkgs/commit/dd885254582d876e3b37ad1cd64712fe4bc3d60d) | `` synapse-admin: use fetchYarnDeps ``                                           |
| [`191f3e6f`](https://github.com/NixOS/nixpkgs/commit/191f3e6f5d3728ee894080fdba222971729210a6) | `` yabai: 5.0.7 -> 5.0.8 ``                                                      |
| [`667b9904`](https://github.com/NixOS/nixpkgs/commit/667b990475903154fa0559730ce5d55e1a0dbf69) | `` mpfi: switch source to INRIA GitLab ``                                        |
| [`923dd4e8`](https://github.com/NixOS/nixpkgs/commit/923dd4e8839f56642cea364aa2cae6fa6efd2cb5) | `` terragrunt: 0.50.14 -> 0.50.16 ``                                             |
| [`38dd9c57`](https://github.com/NixOS/nixpkgs/commit/38dd9c57bc2a6128e1b9081afa416076dcba4444) | `` linuxKernel.kernels.linux_lqx: 6.4.14-lqx1 -> 6.4.15-lqx1 ``                  |
| [`1cd990eb`](https://github.com/NixOS/nixpkgs/commit/1cd990ebb3cfdf7efe3c84f743d4df52befe8110) | `` linuxKernel.kernels.linux_zen: 6.5.2-zen1 -> 6.5.3-zen1 ``                    |
| [`65182a9f`](https://github.com/NixOS/nixpkgs/commit/65182a9f4f49cdd13bd576859d907222a398aada) | `` kops_1_27: 1.27.0 -> 1.27.1 ``                                                |
| [`453c5c25`](https://github.com/NixOS/nixpkgs/commit/453c5c2593780f5188c1313a97541fa496e3a1f7) | `` spago: mark broken ``                                                         |
| [`8a17ac4a`](https://github.com/NixOS/nixpkgs/commit/8a17ac4a03bb9b0c42d2a63b57db726f87fa761f) | `` python311Packages.dbus-fast: 2.6.0 -> 2.7.0 ``                                |
| [`1c031e25`](https://github.com/NixOS/nixpkgs/commit/1c031e25f62209ce738ded0c2c3be9e7fbfbcc60) | `` python311Packages.dbus-fast: 2.5.0 -> 2.6.0 ``                                |
| [`58389446`](https://github.com/NixOS/nixpkgs/commit/58389446fdeff3d4e73dcbc9a0f72f5bec010fa9) | `` python311Packages.dbus-fast: 2.4.0 -> 2.5.0 ``                                |
| [`6617b259`](https://github.com/NixOS/nixpkgs/commit/6617b259898108871782e3f295b2aadb043dca1d) | `` python311Packages.dbus-fast: 2.3.0 -> 2.4.0 ``                                |
| [`a9e6dbda`](https://github.com/NixOS/nixpkgs/commit/a9e6dbda91e1398d1ac50f8c20e4f90563ffcbd4) | `` python311Packages.dbus-fast: 2.2.0 -> 2.3.0 ``                                |
| [`2d239fa2`](https://github.com/NixOS/nixpkgs/commit/2d239fa2f689d54744d56ebd50d91b13d13f0835) | `` python311Packages.amcrest: add changelog ``                                   |
| [`f3cb38ef`](https://github.com/NixOS/nixpkgs/commit/f3cb38ef5b46b5c4eee9cb0213f709ac6ebf10df) | `` steamguard-cli: 0.12.0 -> 0.12.1 ``                                           |
| [`fb3d95c4`](https://github.com/NixOS/nixpkgs/commit/fb3d95c48db0a5d7e2c5e7cb40b04e02c80bc124) | `` python311Packages.millheater: 0.11.2 -> 0.11.5 ``                             |
| [`99687e1a`](https://github.com/NixOS/nixpkgs/commit/99687e1a713317b319eb8e555f486195dcfe15dd) | `` python311Packages.amcrest: 1.9.7 -> 1.9.8 ``                                  |
| [`b0409d7a`](https://github.com/NixOS/nixpkgs/commit/b0409d7aa514616857023d4ed5237f275c6c816e) | `` python311Packages.checkdmarc: 4.8.0 -> 4.8.4 ``                               |
| [`52009788`](https://github.com/NixOS/nixpkgs/commit/52009788c7430265391a07f7a9a4f400377ffc8d) | `` gotestwaf: 0.4.3 -> 0.4.6 ``                                                  |
| [`535268e3`](https://github.com/NixOS/nixpkgs/commit/535268e39f154903e70e0a2a64c385e1e92e76fe) | `` haskellPackages.hasura-ekg-core: mark broken ``                               |
| [`da61e87c`](https://github.com/NixOS/nixpkgs/commit/da61e87c86619e13e4d79ccb8fa7897044d43653) | `` haskellPackages.hasura-ekg-json: mark broken ``                               |
| [`0f549bb9`](https://github.com/NixOS/nixpkgs/commit/0f549bb91bb4b71c2516a4bc973eb5c77f1df5f3) | `` haskellPackages.pg-client: mark broken ``                                     |
| [`696353fc`](https://github.com/NixOS/nixpkgs/commit/696353fcf4b6c290003344e0e26802db7c2eaf51) | `` nixos/zfs: disable redundant scheduler ``                                     |
| [`b45794eb`](https://github.com/NixOS/nixpkgs/commit/b45794eb9681a0871e6d336eb9ab04e93e7fa74e) | `` haskellPackages.twain: unbreak by overriding http2 deeply ``                  |