### PR TITLE
chore(flake/deploy-rs): `31c32fb2` -> `57d5071e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -126,11 +126,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694513707,
-        "narHash": "sha256-wE5kHco3+FQjc+MwTPwLVqYz4hM7uno2CgXDXUFMCpc=",
+        "lastModified": 1695029081,
+        "narHash": "sha256-1jpJoeDbxYXWViVRkiSyDxsT4SqqsxgYu5Cg7xisKrA=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "31c32fb2959103a796e07bbe47e0a5e287c343a8",
+        "rev": "57d5071e60c1318ec27eb987f96504ce3d58cb34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                            |
| --------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`b5625de9`](https://github.com/serokell/deploy-rs/commit/b5625de9c918d4ea318627fc1a18943ac8c1e1b1) | `` Replace jsonschema-cli with check-jsonschema `` |