### PR TITLE
chore(flake/nixpkgs): `ace5093e` -> `970a59bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -377,11 +377,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694767346,
-        "narHash": "sha256-5uH27SiVFUwsTsqC5rs3kS7pBoNhtoy9QfTP9BmknGk=",
+        "lastModified": 1694959747,
+        "narHash": "sha256-CXQ2MuledDVlVM5dLC4pB41cFlBWxRw4tCBsFrq3cRk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ace5093e36ab1e95cb9463863491bee90d5a4183",
+        "rev": "970a59bd19eff3752ce552935687100c46e820a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`f5966ce3`](https://github.com/NixOS/nixpkgs/commit/f5966ce35f0d56b5a8a6bf62fb412b1532506cff) | `` replxx: init at 0.0.4 ``                                                  |
| [`df39696f`](https://github.com/NixOS/nixpkgs/commit/df39696f6b35b4e21cf15bb65518ee1b5f67ee3d) | `` chromium: temporarily work around stdenv/patchShebangs.sh bug ``          |
| [`c6201300`](https://github.com/NixOS/nixpkgs/commit/c62013004e42033c5f11cfff99d3ce5d0d1f09be) | `` chromedriver: 116.0.5845.96 -> 117.0.5938.88 ``                           |
| [`b677e255`](https://github.com/NixOS/nixpkgs/commit/b677e255d9934a9ec9d4056d2f20543e9757daba) | `` ungoogled-chromium: 116.0.5845.187 -> 117.0.5938.88 ``                    |
| [`e4514334`](https://github.com/NixOS/nixpkgs/commit/e4514334bb72b7300eec9ec55a2140162a5cf2b6) | `` chromium: 116.0.5845.187 -> 117.0.5938.88 ``                              |
| [`742ce579`](https://github.com/NixOS/nixpkgs/commit/742ce579ba0a4ae3b65147e1a93dc27feecc474c) | `` python311Packages.gehomesdk: 0.5.20 -> 0.5.23 ``                          |
| [`88cdc60f`](https://github.com/NixOS/nixpkgs/commit/88cdc60f06b8b7ab4e938598e6336d0d231f7d73) | `` sbt-extras: 2023-09-13 -> 2023-09-14 ``                                   |
| [`01c56051`](https://github.com/NixOS/nixpkgs/commit/01c56051f8865524c15ede9c16633ec61b6d1586) | `` python311Packages.garminconnect: 0.1.55 -> 0.2.4 ``                       |
| [`6d490538`](https://github.com/NixOS/nixpkgs/commit/6d490538c6fcf3efc06c97d9bc30ed41aab07174) | `` sbt: 1.9.4 -> 1.9.6 ``                                                    |
| [`30e1bb0d`](https://github.com/NixOS/nixpkgs/commit/30e1bb0d4d5445f6d0ca5c4a3abc23afee3aed6a) | `` python311Packages.garth: init at 0.4.25 ``                                |
| [`c18d373a`](https://github.com/NixOS/nixpkgs/commit/c18d373a00b8937c4bf7f7356c9a1e01278d8291) | `` oauth2c: 1.10.0 -> 1.11.0 ``                                              |
| [`b9547bc2`](https://github.com/NixOS/nixpkgs/commit/b9547bc21cc6814da5b9d02a2a2476f6d0911535) | `` heroic: 2.9.1 -> 2.9.2 ``                                                 |
| [`ae56b64b`](https://github.com/NixOS/nixpkgs/commit/ae56b64b7168cfedd314eb59bbada72244cb4210) | `` vulkan-helper: init at 2023-08-09 ``                                      |
| [`9c7e6991`](https://github.com/NixOS/nixpkgs/commit/9c7e69910443998e74538723db0479053d9b8404) | `` terragrunt: 0.50.16 -> 0.50.17 ``                                         |
| [`1c6d1907`](https://github.com/NixOS/nixpkgs/commit/1c6d1907ac7284da2d371f05973cccf812dbdb02) | `` gegl: 0.4.44 → 0.4.46 ``                                                  |
| [`ee5b8f10`](https://github.com/NixOS/nixpkgs/commit/ee5b8f10e000d8c7912cb0ea206774a71326e576) | `` matcha-rss-digest: 0.6 -> 0.6.1 ``                                        |
| [`b0cda01c`](https://github.com/NixOS/nixpkgs/commit/b0cda01cdb55204374eff1ab585539a7b9301fb5) | `` lxgw-neoxihei: 1.104 -> 1.105 ``                                          |
| [`f024453e`](https://github.com/NixOS/nixpkgs/commit/f024453ecfd7042d8ceaf7946d7cabbe68352c39) | `` python311Packages.dvc-render: 0.5.3 -> 0.6.0 ``                           |
| [`d0d198f0`](https://github.com/NixOS/nixpkgs/commit/d0d198f0be8e0a2e3b030531fb3db941b6ce93d0) | `` python311Packages.dnfile: 0.13.0 -> 0.14.1 ``                             |
| [`b668b2d4`](https://github.com/NixOS/nixpkgs/commit/b668b2d4e89edc24700b14f4f992575209e58344) | `` nixos-anywhere: init at 1.0.0 ``                                          |
| [`75d0578e`](https://github.com/NixOS/nixpkgs/commit/75d0578ec16a4487819c262db12194a49de163f9) | `` python311Packages.devolo-plc-api: 1.4.0 -> 1.4.1 ``                       |
| [`16f54706`](https://github.com/NixOS/nixpkgs/commit/16f5470688cb35904e21f34a1b8e6105a22dccb1) | `` python311Packages.cyclonedx-python-lib: 4.1.0 -> 4.2.2 ``                 |
| [`8bff4b7e`](https://github.com/NixOS/nixpkgs/commit/8bff4b7e405836f7451e3b4792a2728a22ef2803) | `` entr: fix cross compilation ``                                            |
| [`664e6826`](https://github.com/NixOS/nixpkgs/commit/664e682617e0f8d38cc1316b6a04fa08b5c09451) | `` python311Packages.confection: 0.1.1 -> 0.1.3 ``                           |
| [`4dac63ba`](https://github.com/NixOS/nixpkgs/commit/4dac63ba4a1b993b486373cb1ddfe41546b74176) | `` python311Packages.asysocks: 0.2.7 -> 0.2.9 ``                             |
| [`66720dd5`](https://github.com/NixOS/nixpkgs/commit/66720dd54379e662fbda307014724fdc13a4875b) | `` python311Packages.asyauth: 0.0.14 -> 0.0.15 ``                            |
| [`a12dd073`](https://github.com/NixOS/nixpkgs/commit/a12dd07376b7152ee74181ca5dcbfe8863a291ec) | `` kubie: 0.21.2 -> 0.22.0 ``                                                |
| [`e08636ec`](https://github.com/NixOS/nixpkgs/commit/e08636ec31f16fb3504e5cb5a7cbcea115eb80ff) | `` python311Packages.opower: 0.0.33 -> 0.0.34 ``                             |
| [`b53e5a64`](https://github.com/NixOS/nixpkgs/commit/b53e5a64791d77aef7d8d644b14acc1048cbbf8a) | `` nixos/frp: add test and link to package ``                                |
| [`6cd38e43`](https://github.com/NixOS/nixpkgs/commit/6cd38e43cdaf1bd02013186bbb201f5c62132a77) | `` nixos/frp: init ``                                                        |
| [`49f0ffe4`](https://github.com/NixOS/nixpkgs/commit/49f0ffe4fdb4053c0a64bf86a1773b9ef87c3162) | `` moar: 1.16.1 -> 1.16.2 ``                                                 |
| [`077e2436`](https://github.com/NixOS/nixpkgs/commit/077e243626acff23a4796a4f8b8b49df62b9878d) | `` python310Packages.cloup: 3.0.1 -> 3.0.2 ``                                |
| [`93101509`](https://github.com/NixOS/nixpkgs/commit/9310150944051a6e01be13a24b991092403be86f) | `` python310Packages.apycula: 0.8.3 -> 0.9.0 ``                              |
| [`e8c23726`](https://github.com/NixOS/nixpkgs/commit/e8c237263b7ec78e1d7fbecb972ce239595efc16) | `` python310Packages.textual: 0.36.0 -> 0.37.1 ``                            |
| [`33894a20`](https://github.com/NixOS/nixpkgs/commit/33894a20809c0e72145de84e98b2d75d0d125912) | `` librime: 1.8.5 -> 1.9.0 ``                                                |
| [`c092d9aa`](https://github.com/NixOS/nixpkgs/commit/c092d9aa95f2e4f26938a7a2ab59218320854a0d) | `` python310Packages.pyswitchbot: 0.39.1 -> 0.40.0 ``                        |
| [`fd264ba8`](https://github.com/NixOS/nixpkgs/commit/fd264ba8a2a7795cac06eb8243eab6a178b159ee) | `` nixos/zfs: fix tests on zfsUnstable ``                                    |
| [`e67126c2`](https://github.com/NixOS/nixpkgs/commit/e67126c2ef65b914d30c68ab29a1036673a62b96) | `` libadwaita: 1.3.4 -> 1.3.5 ``                                             |
| [`7e70581f`](https://github.com/NixOS/nixpkgs/commit/7e70581f8b949103f05678245cfe63563c6ca294) | `` iredis: 1.13.1 -> 1.13.2 ``                                               |
| [`7338ab60`](https://github.com/NixOS/nixpkgs/commit/7338ab600fd2d326d4a92f8ce36d9f632fe32e50) | `` python310Packages.md2gemini: mark broken ``                               |
| [`9a3403ba`](https://github.com/NixOS/nixpkgs/commit/9a3403ba4153266e8c068496b5a552225d7a06ab) | `` python310Packages.schema-salad: mark broken ``                            |
| [`89c9ba0c`](https://github.com/NixOS/nixpkgs/commit/89c9ba0c81316ab16a76fdfb7ddd40946a56d1a2) | `` python310Packages.flake8-bugbear: 23.7.10 -> 23.9.16 ``                   |
| [`5055d528`](https://github.com/NixOS/nixpkgs/commit/5055d528065ab37a57bddd23104dedb09d73762b) | `` rlaunch: 1.3.13 -> 1.3.14 ``                                              |
| [`157c2a0b`](https://github.com/NixOS/nixpkgs/commit/157c2a0bcb9fb6ccf16ea81d63ded2c895dbe924) | `` python310Packages.ttls: 1.6.1 -> 1.7.0 ``                                 |
| [`93081fb5`](https://github.com/NixOS/nixpkgs/commit/93081fb5f2f1a5c10a689dbe9dc1cf8b2033ac24) | `` buildbot: sqlalchemy: 1.4.40 -> 1.4.49 ``                                 |
| [`e2159763`](https://github.com/NixOS/nixpkgs/commit/e21597632e2e7349bb40761915bf6c684b2dd372) | `` Revert "buildbot: unset SQLALCHEMY_SILENCE_UBER_WARNING" ``               |
| [`97bf3058`](https://github.com/NixOS/nixpkgs/commit/97bf3058c967faa4c3d06be61d9759ef56c517ee) | `` nuclei: 2.9.14 -> 2.9.15 ``                                               |
| [`f4b9b0d2`](https://github.com/NixOS/nixpkgs/commit/f4b9b0d24847d4c815444d33d774672d67c882f4) | `` emacsPackages.ebuild-mode: 1.65 -> 1.67 ``                                |
| [`7d6f1282`](https://github.com/NixOS/nixpkgs/commit/7d6f1282a451fa6a2555b7ff0bcf4a19aeb9c4c6) | `` nongnu-packages: updated 2023-09-16 (from overlay) ``                     |
| [`d45df06d`](https://github.com/NixOS/nixpkgs/commit/d45df06da0f863735f7cddc9f7811bc5daaa691b) | `` melpa-packages: updated 2023-09-16 (from overlay) ``                      |
| [`6520416b`](https://github.com/NixOS/nixpkgs/commit/6520416b4fbf5cc777379395d349a190cb216543) | `` elpa-devel-packages: updated 2023-09-16 (from overlay) ``                 |
| [`432c172d`](https://github.com/NixOS/nixpkgs/commit/432c172d47f5dcee7b44d370591486c00d7454ef) | `` elpa-packages: updated 2023-09-16 (from overlay) ``                       |
| [`f468d80e`](https://github.com/NixOS/nixpkgs/commit/f468d80ee1387b9efc7e96701300826f12fc7835) | `` treesheets: unstable-2023-09-07 -> unstable-2023-09-15 ``                 |
| [`14e1d43d`](https://github.com/NixOS/nixpkgs/commit/14e1d43dad062e4467946acfc67b0bfafd265021) | `` osmo-ggsn: 1.10.0 -> 1.11.0 ``                                            |
| [`b072f5ff`](https://github.com/NixOS/nixpkgs/commit/b072f5ff2281ba8cb041b9101ab28172693a32d5) | `` osmo-pcu: 1.2.0 -> 1.3.1 ``                                               |
| [`2bbc3f46`](https://github.com/NixOS/nixpkgs/commit/2bbc3f46c0a528842350aba6268de2137540e570) | `` osmo-ggsn: 1.10.1 -> 1.10.2 ``                                            |
| [`d83af26b`](https://github.com/NixOS/nixpkgs/commit/d83af26bb147d97a9ddf3efc9992502a947ecdd2) | `` iosevka: 26.3.3 -> 27.0.0 ``                                              |
| [`15c12fdf`](https://github.com/NixOS/nixpkgs/commit/15c12fdf9696329a97ba014cb5c5e738096a07b2) | `` osmo-sip-connector: 1.6.2 -> 1.6.3 ``                                     |
| [`fc112041`](https://github.com/NixOS/nixpkgs/commit/fc1120418433e2bbbbb8ff320652c692c386ba2a) | `` freedv: 1.9.1 -> 1.9.2 ``                                                 |
| [`a96ab952`](https://github.com/NixOS/nixpkgs/commit/a96ab95219cc2346e979be9852ac8d67f686bc3e) | `` osmo-msc: 1.10.0 -> 1.11.0 ``                                             |
| [`391939fa`](https://github.com/NixOS/nixpkgs/commit/391939fa160f1c1883cebab2933ab57166b941c2) | `` osmo-hlr: 1.6.1 -> 1.7.0 ``                                               |
| [`2c2c64d3`](https://github.com/NixOS/nixpkgs/commit/2c2c64d33a414aa27cb7b22a1dd7d8fcca809865) | `` osmo-bts: 1.6.0 -> 1.7.0 ``                                               |
| [`2f24163a`](https://github.com/NixOS/nixpkgs/commit/2f24163ac90af4e99e49ec284f6c8a285045e581) | `` osmo-bsc: 1.9.1 -> 1.11.0 ``                                              |
| [`cc6ec3e6`](https://github.com/NixOS/nixpkgs/commit/cc6ec3e6d18419445e273009f8853769d9170f13) | `` osmo-mgw: 1.11.1 -> 1.12.0 ``                                             |
| [`a5bfbcc0`](https://github.com/NixOS/nixpkgs/commit/a5bfbcc027ca4bae185d7db72fdcab377f997366) | `` libasn1c: 0.9.35 -> 0.9.36 ``                                             |
| [`3e8f8b7b`](https://github.com/NixOS/nixpkgs/commit/3e8f8b7b77404b28a09d0e7780877545f80acd9f) | `` libosmoabis: 1.4.0 -> 1.5.0 ``                                            |
| [`32ec634c`](https://github.com/NixOS/nixpkgs/commit/32ec634cedeacf10e49c531139191efac526bbe3) | `` inferno: 0.11.16 -> 0.11.17 ``                                            |
| [`166c2151`](https://github.com/NixOS/nixpkgs/commit/166c2151ecfb0bd6ff5380d04b4ba6e905c01564) | `` trilium-desktop: fix missing metadata on Linux ``                         |
| [`9734ff35`](https://github.com/NixOS/nixpkgs/commit/9734ff3543ed882013d4eab983d5d57601a25d3c) | `` bespokesynth: unstable-2023-08-17 -> 1.2.1 ``                             |
| [`3a67b2b3`](https://github.com/NixOS/nixpkgs/commit/3a67b2b30bb58bdec16c4125c2943e00f7259bba) | `` libosmo-sccp: 1.7.0 -> 1.8.0 ``                                           |
| [`c55fa611`](https://github.com/NixOS/nixpkgs/commit/c55fa611e297e19f9b00f33206bc7047e944635a) | `` libosmo-netif: 1.3.0 -> 1.4.0 ``                                          |
| [`eca7d3ef`](https://github.com/NixOS/nixpkgs/commit/eca7d3ef5b012b7c0109bbeffc81f88437384b52) | `` libosmocore: 1.8.0 -> 1.9.0 ``                                            |
| [`05a7bfed`](https://github.com/NixOS/nixpkgs/commit/05a7bfedfdfe86cc650b4b960482dff82bfdb798) | `` nix-init: 0.2.4 -> 0.3.0 ``                                               |
| [`32658f90`](https://github.com/NixOS/nixpkgs/commit/32658f902e016215d34c65ad5fb3a3fa7b588518) | `` nawk: refactor ``                                                         |
| [`33c49693`](https://github.com/NixOS/nixpkgs/commit/33c496936d7056b5234ed769c43d53a30cee6c46) | `` nawk: migrate to by-name hierarchy ``                                     |
| [`1e556a63`](https://github.com/NixOS/nixpkgs/commit/1e556a63b5a96c27024ca318052a967b88e2fc1a) | `` fleng: 16 -> 17 ``                                                        |
| [`fa5109d7`](https://github.com/NixOS/nixpkgs/commit/fa5109d7740a2d6b22affebefa4c1d13a6c25029) | `` fleng: 15 -> 16 ``                                                        |
| [`83ab8840`](https://github.com/NixOS/nixpkgs/commit/83ab8840f3b1828469d5b71e27475c95f3638560) | `` fleng: 14 -> 15 ``                                                        |
| [`de1073b6`](https://github.com/NixOS/nixpkgs/commit/de1073b68e91f470050933852607a91d1742ebca) | `` fleng: migrate to by-name ``                                              |
| [`3f328509`](https://github.com/NixOS/nixpkgs/commit/3f3285096c9359be59a97c1d1c261ab73a812165) | `` vimPlugins.nvim-treesitter: update grammars ``                            |
| [`62d2d7b8`](https://github.com/NixOS/nixpkgs/commit/62d2d7b8f36f9e494192e79ec22de78e68b58f18) | `` vimPlugins: update ``                                                     |
| [`3a39b2c7`](https://github.com/NixOS/nixpkgs/commit/3a39b2c727880a67b02e66f26ddaa21f3be9983e) | `` maintainers: Remove stepech ``                                            |
| [`b1165ffe`](https://github.com/NixOS/nixpkgs/commit/b1165ffeb8fa0a6446340fe25286f60113ab6e5d) | `` vimPlugins.vim-enmasse: init at 2018-04-03 ``                             |
| [`69880549`](https://github.com/NixOS/nixpkgs/commit/698805491cf76d681c05b1f9394179b9594f018f) | `` changie: 1.13.0 -> 1.13.1 ``                                              |
| [`ceafdc92`](https://github.com/NixOS/nixpkgs/commit/ceafdc92d53629c0570582f859db1336aa09ec46) | `` python311Packages.yolink-api: 0.3.0 -> 0.3.1 ``                           |
| [`228c6b16`](https://github.com/NixOS/nixpkgs/commit/228c6b16082133cb6f32f912b23d98b6d4e4e6ef) | `` python311Packages.pywaze: 0.4.0 -> 0.5.0 ``                               |
| [`2bbea49c`](https://github.com/NixOS/nixpkgs/commit/2bbea49cb228741681734dd19628c53b26b10176) | `` python311Packages.sense-energy: 0.12.1 -> 0.12.2 ``                       |
| [`ffe7bd00`](https://github.com/NixOS/nixpkgs/commit/ffe7bd0016fdc744a56ea5615d2bc1fd8ba49e62) | `` python310Packages.geopandas: 0.13.2 -> 0.14.0 ``                          |
| [`a2c1688a`](https://github.com/NixOS/nixpkgs/commit/a2c1688ac44b114bfcf4a375ed40353b546147cc) | `` hyperlink: init at 0.1.31 ``                                              |
| [`2f499947`](https://github.com/NixOS/nixpkgs/commit/2f4999470be903518ca16a9bfc7eebce2e000ba2) | `` Add @rossabaker as a maintainer ``                                        |
| [`25e50be6`](https://github.com/NixOS/nixpkgs/commit/25e50be6e26f431b7985b909e36589e88e46a670) | `` deploy-rs: unstable-2023-06-04 -> unstable-2023-09-12 ``                  |
| [`9a98cd21`](https://github.com/NixOS/nixpkgs/commit/9a98cd21e8c8c920830acfa55c5acdc82ea1b7a6) | `` vimPlugins: vim-sensible patch vimrc detection ``                         |
| [`4a4017d9`](https://github.com/NixOS/nixpkgs/commit/4a4017d9a1341826a1eea0d724659a123609f521) | `` python3Packages.pyrender: init at 0.1.45 ``                               |
| [`52d4d31f`](https://github.com/NixOS/nixpkgs/commit/52d4d31fa200d4c3c29dae115c2ae6e83193f9f9) | `` python3Packages.pyopengl: support the EGL platform, link libGLESv{1,2} `` |
| [`6ef86654`](https://github.com/NixOS/nixpkgs/commit/6ef86654ef004a35c8548b3363f709950cbc6318) | `` python311Packages.findpython: 0.3.1 -> 0.4.0 ``                           |
| [`ae5b96f3`](https://github.com/NixOS/nixpkgs/commit/ae5b96f3ab6aabb60809ab78c2c99f8dd51ee678) | `` postgresql_16: init at 16.0 ``                                            |
| [`7733b261`](https://github.com/NixOS/nixpkgs/commit/7733b261ef522b7c396768f5b2bc44579709b77f) | `` robo: init at 4.0.4 ``                                                    |
| [`294d0010`](https://github.com/NixOS/nixpkgs/commit/294d00100ba759e87985f95d5152182baac778a8) | `` phpdocumentor: init at 3.4.1 ``                                           |
| [`78933d5b`](https://github.com/NixOS/nixpkgs/commit/78933d5bc7867ffe91dad380dd0bc5d241156413) | `` python311Packages.dvc-studio-client: 0.13.0 -> 0.15.0 ``                  |
| [`7006d973`](https://github.com/NixOS/nixpkgs/commit/7006d97373cbaf64e522dd2673c6c2220ebf81a9) | `` boogie: 2.15.7 -> 3.0.4 ``                                                |
| [`b0d00352`](https://github.com/NixOS/nixpkgs/commit/b0d00352bbd47f347a4997a8d61f8956607710ae) | `` boogie: move out of dotnet-packages.nix ``                                |
| [`3c00191a`](https://github.com/NixOS/nixpkgs/commit/3c00191aababd51048ad1dcff9ab78b405d7dfe0) | `` xrdp: restore 0.9.23 src hash ``                                          |
| [`2f665624`](https://github.com/NixOS/nixpkgs/commit/2f665624dcc1f8552874385f6bab07d7d23d4440) | `` nextcloud-client: 3.9.4 -> 3.10.0 ``                                      |
| [`74489d7f`](https://github.com/NixOS/nixpkgs/commit/74489d7ff66172e843ec1e1d07ad2a958afa746d) | `` algol68g: 2.8.4 -> 3.3.22 ``                                              |
| [`057496d1`](https://github.com/NixOS/nixpkgs/commit/057496d1b240d2ce5670979cbacb9700eb91d600) | `` algol68g: refactor ``                                                     |
| [`39c2bcdf`](https://github.com/NixOS/nixpkgs/commit/39c2bcdf1a8a4c9e17ade5eb50844904adf0b798) | `` algol68g: migrate to by-name ``                                           |
| [`942d0482`](https://github.com/NixOS/nixpkgs/commit/942d0482e31ec6fb6383c7b976cbba3c7db2242c) | `` python3.pkgs.msprime: use pytestCheckHook ``                              |
| [`54931faf`](https://github.com/NixOS/nixpkgs/commit/54931faf9a276818bc4a9d88562b0010da534577) | `` font-manager: allow building without webkit ``                            |
| [`d7b87590`](https://github.com/NixOS/nixpkgs/commit/d7b87590ea3a17476dd28650706d527b335511c3) | `` font-manager: use the authoritative repo name ``                          |
| [`65f9151f`](https://github.com/NixOS/nixpkgs/commit/65f9151f4e0fde3932d78d7bfe8437f46fc29f4e) | `` python310Packages.pyipma: 3.0.6 -> 3.0.7 ``                               |
| [`c28990b0`](https://github.com/NixOS/nixpkgs/commit/c28990b0b91ccd809af9d3e9a331793b17ed186d) | `` liferea: 1.15.2 -> 1.15.3 ``                                              |
| [`60a554ec`](https://github.com/NixOS/nixpkgs/commit/60a554ec8401c983e4d64c4bce5461b6759e4d8d) | `` python310Packages.pyathena: 3.0.6 -> 3.0.7 ``                             |
| [`93dd304d`](https://github.com/NixOS/nixpkgs/commit/93dd304d02157a6e9a20bd57f87a4dbcaef00c9e) | `` python310Packages.jsonpath-ng: adjust inputs ``                           |
| [`fae75190`](https://github.com/NixOS/nixpkgs/commit/fae75190d3bdd7703cbf2f06eabba90ccc80a4a7) | `` python310Packages.jsonpath-ng: clean-up ``                                |
| [`e1037626`](https://github.com/NixOS/nixpkgs/commit/e103762649222542f4627b3fbefe13f82583c7a4) | `` python310Packages.jsonpath-ng: add changelog to meta ``                   |
| [`fb3845ef`](https://github.com/NixOS/nixpkgs/commit/fb3845ef38b556006af865bff8e0f3891cd6a845) | `` checkov: 2.4.33 -> 2.4.39 ``                                              |