### PR TITLE
chore(flake/darwin): `80bb201f` -> `afeddc41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -100,11 +100,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694810318,
-        "narHash": "sha256-LuvrVj2oj9TzdnnwtQUClqcXjpgwCP01FFVBM7azGV8=",
+        "lastModified": 1695114819,
+        "narHash": "sha256-/aIfbZxP39QZ8m7qX2RzQTy5PWzz2e22cCcZ+AOO7lA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "80bb201f4925cdda5a7a3c7b1900fb26bb2af2e8",
+        "rev": "afeddc412b3a3b0e7c9ef7ea5fbdf2186781d102",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                          |
| ------------------------------------------------------------------------------------------------ | -------------------------------- |
| [`8caf3af9`](https://github.com/LnL7/nix-darwin/commit/8caf3af927d94b573920a860ce683653e5065d04) | `` Create $out/darwin-version `` |