### PR TITLE
chore(flake/home-manager): `92364581` -> `ee9f5dc8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695103414,
-        "narHash": "sha256-/kr1AQ8aPWl3OaTzZARhGPSS044vZq1Vh4wYX77T1DE=",
+        "lastModified": 1695139541,
+        "narHash": "sha256-tz5UGS2Td0bhbso/g1HnUvKGDQ8ocL4UCfJ/Ro0q3gw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "92364581dd3ada6981c4ddc5def8a35a1b945e75",
+        "rev": "ee9f5dc8f691c69f9bd84194fdbf63d41efb6649",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`ee9f5dc8`](https://github.com/nix-community/home-manager/commit/ee9f5dc8f691c69f9bd84194fdbf63d41efb6649) | `` flake.lock: Update `` |