### PR TITLE
chore(flake/home-manager): `f5b920f4` -> `7ee73f53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695149570,
-        "narHash": "sha256-6LrNG9ggW9zPKjEkX/JV8/VASTTk1Ot6xuOhG5skN/0=",
+        "lastModified": 1695155076,
+        "narHash": "sha256-8ITtjwGcGnjCJCJk53WNV1A3ckfrOuZwT92zb44ZLk4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f5b920f4d2f920a1982ca844cfd22c8f1e82ed7e",
+        "rev": "7ee73f5363bc0f4b0f8042665168c25c90dd16f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`7ee73f53`](https://github.com/nix-community/home-manager/commit/7ee73f5363bc0f4b0f8042665168c25c90dd16f9) | `` rofi-pass: add package option ``   |
| [`8aac47a1`](https://github.com/nix-community/home-manager/commit/8aac47a140de1153a90bcc509596c65f6d82d832) | `` waybar: fix service After value `` |