### PR TITLE
chore(flake/home-manager): `3e7202c6` -> `0ed5f978`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695182357,
-        "narHash": "sha256-sdJvxsLLe/BpSQwasq5LhgvC765PhJ0Jlat9YbGkA30=",
+        "lastModified": 1695191928,
+        "narHash": "sha256-yXUtJZQweg6v9G5fXStqkVNwxT4Xf+cux37yBVpaYCY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3e7202c6387b744dca4feb4217459512886761b5",
+        "rev": "0ed5f9786bba801c59fb53eef497438040acd471",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`0ed5f978`](https://github.com/nix-community/home-manager/commit/0ed5f9786bba801c59fb53eef497438040acd471) | `` Add translation using Weblate (Thai) `` |
| [`8847dd8b`](https://github.com/nix-community/home-manager/commit/8847dd8bf35a50e012088d6eef6010a6884b3632) | `` Translate using Weblate (Thai) ``       |