### PR TITLE
chore(flake/nixpkgs): `970a59bd` -> `5ba549ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -377,11 +377,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694959747,
-        "narHash": "sha256-CXQ2MuledDVlVM5dLC4pB41cFlBWxRw4tCBsFrq3cRk=",
+        "lastModified": 1695145219,
+        "narHash": "sha256-Eoe9IHbvmo5wEDeJXKFOpKUwxYJIOxKUesounVccNYk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "970a59bd19eff3752ce552935687100c46e820a5",
+        "rev": "5ba549eafcf3e33405e5f66decd1a72356632b96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`ae4acddb`](https://github.com/NixOS/nixpkgs/commit/ae4acddbb6fd69f29373731694213c425bd7c2d9) | `` prismlauncher: include libusb1 as a runtime dependency (#256124) ``      |
| [`c4604341`](https://github.com/NixOS/nixpkgs/commit/c4604341046500273fa1ab5366d07d509d2ff8c2) | `` nixos/vaultwarden: Fix doubly-nested `config` value. Fixes evaluation `` |
| [`fca4826d`](https://github.com/NixOS/nixpkgs/commit/fca4826dcd399813f85b61fec1442c781e345759) | `` team-list.nix: grammar ``                                                |
| [`f9a5d84f`](https://github.com/NixOS/nixpkgs/commit/f9a5d84f4aadc1f0150a95db9e453b95bcd2c671) | `` cloud-hypervisor: disable vmm tests ``                                   |
| [`79a23c6c`](https://github.com/NixOS/nixpkgs/commit/79a23c6c0841d49cad98ec952bb8b830f670e0ee) | `` python311Packages.qrant-client: 1.5.0 -> 1.5.4 ``                        |
| [`44f22143`](https://github.com/NixOS/nixpkgs/commit/44f22143b7cbe1de57ed445fb690dca2a4e2d1db) | `` outputcheck: init at 0.4.2 ``                                            |
| [`7fe536fa`](https://github.com/NixOS/nixpkgs/commit/7fe536fa2d72c350c6f2e8ad6793ad4ebf322a3f) | `` bandwhich: unstable-2023-09-11 -> 0.21.0 ``                              |
| [`55d4ea4b`](https://github.com/NixOS/nixpkgs/commit/55d4ea4be306f59feeef66bb172f2e5708f5ed8f) | `` actionlint: 1.6.25 -> 1.6.26 ``                                          |
| [`cd5f56c8`](https://github.com/NixOS/nixpkgs/commit/cd5f56c821ec127d367951f6c453744cc0b7b8d1) | `` gh: 2.34.0 -> 2.35.0 ``                                                  |
| [`e43f06a8`](https://github.com/NixOS/nixpkgs/commit/e43f06a8bcd8acc894a6edea95e733845102ea75) | `` systeroid: 0.4.3 -> 0.4.4 ``                                             |
| [`01ea9ea3`](https://github.com/NixOS/nixpkgs/commit/01ea9ea3e6b872a7c363c2422d8828638bd99ffb) | `` argc: 1.9.0 -> 1.10.0 ``                                                 |
| [`309c92d4`](https://github.com/NixOS/nixpkgs/commit/309c92d4eb196b2ec14b1ad01d510a20e4b1cff9) | `` python310Packages.jax: 0.4.14 -> 0.4.15 ``                               |
| [`ad9c1e95`](https://github.com/NixOS/nixpkgs/commit/ad9c1e952a06b9bc0ea57c0902b61982e61f2676) | `` python310Packages.jaxlib-bin: 0.4.14 -> 0.4.15 ``                        |
| [`043cbacb`](https://github.com/NixOS/nixpkgs/commit/043cbacb519d179010042d52f3b5c3af155b178e) | `` python310Packages.jaxlib: 0.4.14 -> 0.4.15 ``                            |
| [`e9352a18`](https://github.com/NixOS/nixpkgs/commit/e9352a18e43d969183f748846f7e8347c94fc913) | `` sway-launcher-desktop: 1.6.0 -> 1.7.0 ``                                 |
| [`6b2ef5d6`](https://github.com/NixOS/nixpkgs/commit/6b2ef5d639bff49875791223efc3c25f51c415b4) | `` obs-studio-plugins.obs-vkcapture: 1.4.1 -> 1.4.3 ``                      |
| [`7629da12`](https://github.com/NixOS/nixpkgs/commit/7629da1298d85379466acf80cad36e701cc6aaa8) | `` linux/hardened/patches/6.4: 6.4.15-hardened1 -> 6.4.16-hardened1 ``      |
| [`25627939`](https://github.com/NixOS/nixpkgs/commit/2562793942b1cb6e13b940f73d0552b985c58226) | `` linux/hardened/patches/6.1: 6.1.52-hardened1 -> 6.1.53-hardened1 ``      |
| [`41d7b6b9`](https://github.com/NixOS/nixpkgs/commit/41d7b6b90788ca4a7c98e5044c73054c926a2bc3) | `` linux_latest-libre: 19397 -> 19408 ``                                    |
| [`a3f94d23`](https://github.com/NixOS/nixpkgs/commit/a3f94d23e545e34ec6a0918c5f2baf5bc2265999) | `` linux-rt_6_1: 6.1.46-rt13 -> 6.1.46-rt14 ``                              |
| [`b0ff9b40`](https://github.com/NixOS/nixpkgs/commit/b0ff9b40b4a73cd867b279f130124768e978031b) | `` linux: 6.5.3 -> 6.5.4 ``                                                 |
| [`9fbd1182`](https://github.com/NixOS/nixpkgs/commit/9fbd118235420dcaf1498126351e301741f87072) | `` linux: 6.1.53 -> 6.1.54 ``                                               |
| [`db947047`](https://github.com/NixOS/nixpkgs/commit/db9470470f8b976cdac377f7db4bfb01612bfe4c) | `` linux: 5.15.131 -> 5.15.132 ``                                           |
| [`cdc7c3a9`](https://github.com/NixOS/nixpkgs/commit/cdc7c3a9f50b073633a57a4d7880916651ce6244) | `` linux: 5.10.194 -> 5.10.195 ``                                           |
| [`2c73000e`](https://github.com/NixOS/nixpkgs/commit/2c73000ef028fe16f8d242bf1727fd0cdbb9d272) | `` linux-6.5: hash -> sha256 ``                                             |
| [`85fd8746`](https://github.com/NixOS/nixpkgs/commit/85fd87463918c383c46f8725b96eea6e63cf5d4f) | `` compcert: add aarch64 support ``                                         |
| [`cc289ff6`](https://github.com/NixOS/nixpkgs/commit/cc289ff682c55fbd9ec2592472065d979562b5b6) | `` code-maat: 1.0.3 -> 1.0.4 ``                                             |
| [`5dacf3a0`](https://github.com/NixOS/nixpkgs/commit/5dacf3a0d80dab7bc04a376db04e81369134e241) | `` bitcoin: add shell completions ``                                        |
| [`bb2bb095`](https://github.com/NixOS/nixpkgs/commit/bb2bb09564e5c23126eae8cf9562666a2f0f8885) | `` easyocr: 1.7.0 -> 1.7.1 ``                                               |
| [`a49246ae`](https://github.com/NixOS/nixpkgs/commit/a49246aef97d2902ea432107724af36516c66863) | `` gitlab: 16.3.3 -> 16.3.4 ``                                              |
| [`0b432768`](https://github.com/NixOS/nixpkgs/commit/0b4327681fc23512f35f44ff8a1c43f6e92ff7db) | `` cilium-cli: 0.15.7 -> 0.15.8 ``                                          |
| [`2a87473d`](https://github.com/NixOS/nixpkgs/commit/2a87473dbbf721d5a03e9466c3c7b1a36e5c677e) | `` trdl-client: 0.6.5 -> 0.7.0 ``                                           |
| [`2339c121`](https://github.com/NixOS/nixpkgs/commit/2339c121cfe14d6648eea935bd861998b2164321) | `` python310Packages.nocaselist: 1.1.1 -> 2.0.0 ``                          |
| [`4da06a2e`](https://github.com/NixOS/nixpkgs/commit/4da06a2ec81198050c0b0569588b71e7c5d4a649) | `` harsh: 0.8.28 -> 0.8.29 ``                                               |
| [`7c76105a`](https://github.com/NixOS/nixpkgs/commit/7c76105a0a0f6fb66d8be5b27b47012dec02f380) | `` python3Packages.geopandas: drop Python 3.8 support ``                    |
| [`d9d1ed16`](https://github.com/NixOS/nixpkgs/commit/d9d1ed167583941a009035c50669ab29c7eb4a2a) | `` bloat: unstable-2022-12-17 -> unstable-2023-09-18 ``                     |
| [`3eb91e96`](https://github.com/NixOS/nixpkgs/commit/3eb91e96ba5253d8fdf459802eedfa86cd8b951b) | `` python310Packages.metakernel: 0.30.0 -> 0.30.1 ``                        |
| [`e3a6b0c4`](https://github.com/NixOS/nixpkgs/commit/e3a6b0c4eb15f003b3d7890230bd1a15fe4531e3) | `` python3Packages.django-ninja: init at 0.22.2 ``                          |
| [`90040cd3`](https://github.com/NixOS/nixpkgs/commit/90040cd36a1c01cf407f93315b268c1ead75e494) | `` linux/hardened/patches/6.5: init at 6.5.3-hardened1 ``                   |
| [`9bfe6dbe`](https://github.com/NixOS/nixpkgs/commit/9bfe6dbee7e0b9a83e8b2cb9e89e9b3fcd95c973) | `` python311Packages.ossfs: 2023.5.0 -> 2023.8.0 ``                         |
| [`28a4b953`](https://github.com/NixOS/nixpkgs/commit/28a4b95339798f2c4f62796c7fe0c56771db861f) | `` checkSSLCert: 2.72.0 -> 2.74.0 ``                                        |
| [`e4a18671`](https://github.com/NixOS/nixpkgs/commit/e4a186713d25e6d7b888f4f4f55e80317727af99) | `` qovery-cli: 0.70.0 -> 0.70.1 ``                                          |
| [`660af05e`](https://github.com/NixOS/nixpkgs/commit/660af05e145bbef61dbfbbcc86703ce387225ea3) | `` python311Packages.requests-pkcs12: 1.18 -> 1.21 ``                       |
| [`026c784c`](https://github.com/NixOS/nixpkgs/commit/026c784c2e653a0c20ff27c7239fd3587afa431b) | `` python311Packages.hahomematic: 2023.9.2 -> 2023.9.3 ``                   |
| [`80245697`](https://github.com/NixOS/nixpkgs/commit/802456973b5bd0cb4a77ce6ff08445d17abfca44) | `` qc: 0.5.0 -> 0.5.1 ``                                                    |
| [`3e88dd24`](https://github.com/NixOS/nixpkgs/commit/3e88dd245d64f692f549471d97c95b05df3fba96) | `` pocketbase: 0.18.3 -> 0.18.6 ``                                          |
| [`1e2db104`](https://github.com/NixOS/nixpkgs/commit/1e2db1049e380d53380ba8929727db7e8f42448a) | `` ruplacer: 0.8.1 -> 0.8.2 ``                                              |
| [`835736de`](https://github.com/NixOS/nixpkgs/commit/835736de35faba3e57a7a4becc6b7e472ae72317) | `` coder: fix broken pkg (#255964) ``                                       |
| [`42cfdd46`](https://github.com/NixOS/nixpkgs/commit/42cfdd46b35f4a5ad58d9eed4eb0761ea3a76984) | `` cargo-crev: 0.24.3 -> 0.25.0 ``                                          |
| [`3dd248db`](https://github.com/NixOS/nixpkgs/commit/3dd248db21547e8f1daa8cf4807e20d40b1f4358) | `` ocamlPackages.ocamlgraph: 2.0.0 → 2.1.0 ``                               |
| [`f58d86bf`](https://github.com/NixOS/nixpkgs/commit/f58d86bf7ee06eacec444b805ba0731df382428b) | `` archiver: use sri hash ``                                                |
| [`73f56ebb`](https://github.com/NixOS/nixpkgs/commit/73f56ebb44169721b73fe01ba9af305ad2c6817b) | `` sd-local: 1.0.48 -> 1.0.49 ``                                            |
| [`0656a6bb`](https://github.com/NixOS/nixpkgs/commit/0656a6bbe25431fb1289066eefe266760b5c6bd0) | `` python310Packages.devito: 4.8.1 -> 4.8.2 ``                              |
| [`cd0f8741`](https://github.com/NixOS/nixpkgs/commit/cd0f8741040c151636d218954d237db89dfd349f) | `` python310Packages.adafruit-platformdetect: 3.52.0 -> 3.52.1 ``           |
| [`c3f4c7f5`](https://github.com/NixOS/nixpkgs/commit/c3f4c7f54ce38f1bf69d2a557c4c37c036436073) | `` elvish: refactor ``                                                      |
| [`88a627e0`](https://github.com/NixOS/nixpkgs/commit/88a627e01273c4301e3ab533a5e85fea51d5ecd9) | `` rc: migrate to by-name ``                                                |
| [`fd09de7b`](https://github.com/NixOS/nixpkgs/commit/fd09de7be5279da58b5f6b417cc9f40def8d4b7d) | `` mksh: migrate to by-name ``                                              |
| [`068c6d4e`](https://github.com/NixOS/nixpkgs/commit/068c6d4e036f7ad67e7661d6dbd5a95822229bcd) | `` typst-lsp: 0.9.5 -> 0.10.0 ``                                            |
| [`78cccac7`](https://github.com/NixOS/nixpkgs/commit/78cccac71c66d3a8115a8ce61ca016d7dc4ecabf) | `` less: 633 -> 643 ``                                                      |
| [`1e581837`](https://github.com/NixOS/nixpkgs/commit/1e581837434fe188c1baec98f0d3c40ae1cc9094) | `` less: migrate to by-name ``                                              |
| [`4d9a02ac`](https://github.com/NixOS/nixpkgs/commit/4d9a02acc8827d32219e044d43be9ec2f5a8e9c4) | `` spicedb: 1.23.0 -> 1.25.0 ``                                             |
| [`c14d62f2`](https://github.com/NixOS/nixpkgs/commit/c14d62f2729e8a1cef3f542aded5f4881578abaa) | `` sudo-font: 0.69 -> 0.74 ``                                               |
| [`f276974e`](https://github.com/NixOS/nixpkgs/commit/f276974e8d117279efdc396ae1cc7f9f75994ede) | `` ncmpc: 0.48 -> 0.49 ``                                                   |
| [`7d112f7d`](https://github.com/NixOS/nixpkgs/commit/7d112f7da3312cb07116b5f9bac647f0f943a596) | `` luksroot: fix issue when yubikey is detached during boot process ``      |
| [`b271eb8a`](https://github.com/NixOS/nixpkgs/commit/b271eb8aabdfd45d23a5fdac3fa747c95916b1d7) | `` lightningcss: add mainProgram ``                                         |
| [`0b5a25c9`](https://github.com/NixOS/nixpkgs/commit/0b5a25c9afda77a66b2fbe52ae15bc2abde83711) | `` lightningcss: 1.21.8 → 1.22.0 ``                                         |
| [`67786d3c`](https://github.com/NixOS/nixpkgs/commit/67786d3c299c0f70cfa0f8f0f8ef6d48b4c745c1) | `` eksctl: 0.156.0 -> 0.157.0 ``                                            |
| [`65033fea`](https://github.com/NixOS/nixpkgs/commit/65033fea280074d45e7aca7d8e5c26d361a10f59) | `` mosdepth: 0.3.4 -> 0.3.5 ``                                              |
| [`1ab0c301`](https://github.com/NixOS/nixpkgs/commit/1ab0c3013048ad2cd8d3e57c1f473f44bff94f5c) | `` zpaqfranz: init at 58.9 ``                                               |
| [`c54fc2a4`](https://github.com/NixOS/nixpkgs/commit/c54fc2a40f7807bb7ef23c548202cfef10ffda3f) | `` gpsprune: add media type associations ``                                 |
| [`d102d7c2`](https://github.com/NixOS/nixpkgs/commit/d102d7c2ec58eb9d101def4336ad72968d7a550e) | `` python3.pkgs.deploykit: 1.1.0 -> 1.1.1 ``                                |
| [`d30d4b9c`](https://github.com/NixOS/nixpkgs/commit/d30d4b9ca3f058121252e3e9149befdcba98dd5a) | `` spacer: 0.2 -> 0.3.0 ``                                                  |
| [`a11c1555`](https://github.com/NixOS/nixpkgs/commit/a11c1555527f64f9ff34a0af0abae5044e47be69) | `` python3Packages.torch: add descriptive messages when marked broken ``    |
| [`113b904e`](https://github.com/NixOS/nixpkgs/commit/113b904e4eeb71d2c2317bbb0c675bc46426975c) | `` thc-hydra: patch to build on darwin ``                                   |
| [`b703fb03`](https://github.com/NixOS/nixpkgs/commit/b703fb03614010cd1feb529cb1acd80045bacd48) | `` geos: add package tests ``                                               |
| [`66867a88`](https://github.com/NixOS/nixpkgs/commit/66867a88354d9db75a72e0d1460b1437f12ed5df) | `` solc: 0.8.19 -> 0.8.21 ``                                                |
| [`9867c0da`](https://github.com/NixOS/nixpkgs/commit/9867c0da21def5493993c5f84946266222443608) | `` python310Packages.objax: switch back to GitHub for sources ``            |
| [`057cd2a7`](https://github.com/NixOS/nixpkgs/commit/057cd2a739428b4c7b5168f1f39a67bc9f3d44e1) | `` rocketchat-desktop: 3.8.11 -> 3.9.7 ``                                   |
| [`23e1d1e4`](https://github.com/NixOS/nixpkgs/commit/23e1d1e4dae96ebe63ea64753e6bea95c4554ba5) | `` spglib: 2.0.2 -> 2.1.0 ``                                                |
| [`8e11eef3`](https://github.com/NixOS/nixpkgs/commit/8e11eef3146ae19873ee9ff4e7590a0250fdee15) | `` python311Packages.onnx: protobuf 3.x -> 4.x ``                           |
| [`ad07cd4f`](https://github.com/NixOS/nixpkgs/commit/ad07cd4fc2e37cdeca8f6b920f4d955fa280f595) | `` treewide: add version tests (#255781) ``                                 |
| [`3b605d20`](https://github.com/NixOS/nixpkgs/commit/3b605d204dae49e76fb3bc790f49df569abade39) | `` jna: add macos platforms ``                                              |
| [`8e0d9713`](https://github.com/NixOS/nixpkgs/commit/8e0d97130a1cc0087f37f5c7308e38abfbc32d7a) | `` typos: 1.16.11 -> 1.16.12 ``                                             |
| [`c5e032fd`](https://github.com/NixOS/nixpkgs/commit/c5e032fda7deeecd1a3855a8c44a139f13c73d0b) | `` vectorscan: fix changelog url ``                                         |
| [`4e2fcbf7`](https://github.com/NixOS/nixpkgs/commit/4e2fcbf7ee7004690cc9e5a0e71e09cb27e3b8a7) | `` team-list.nix: remove members who did not join ``                        |
| [`682493b2`](https://github.com/NixOS/nixpkgs/commit/682493b2c4f2d31c7503774d913e12e01c30f52c) | `` team-list.nix: nixos-modules -> module-system ``                         |
| [`229e2253`](https://github.com/NixOS/nixpkgs/commit/229e2253f2cde7baecbe267f1f33556b0ce71a93) | `` python310Packages.mkdocstrings-python: 1.6.3 -> 1.7.0 ``                 |
| [`2a550d8c`](https://github.com/NixOS/nixpkgs/commit/2a550d8ccddefcd1d2bbf51e5e29e18f9e15e9a1) | `` fluffychat: 1.13.0 -> 1.14.1 ``                                          |
| [`73983b3d`](https://github.com/NixOS/nixpkgs/commit/73983b3d62d3a50b72a126b0c786b8e4af899e2a) | `` eza: 0.12.0 -> 0.13.0 ``                                                 |
| [`3fd75f93`](https://github.com/NixOS/nixpkgs/commit/3fd75f93ab155e6d9467e19d31d777b76ccd3183) | `` treewide: add meta.mainProgram (#255932) ``                              |
| [`c53164b1`](https://github.com/NixOS/nixpkgs/commit/c53164b1d7b67639e7addae8f388067a3bee5240) | `` buck2: unstable-2023-09-01 -> unstable-2023-09-15 ``                     |
| [`62f5b69e`](https://github.com/NixOS/nixpkgs/commit/62f5b69eca7bb8b91237d6dc121bf4b27ed6c14b) | `` reindeer: unstable-2023-08-14 -> unstable-2023-09-16 ``                  |
| [`af8dfc58`](https://github.com/NixOS/nixpkgs/commit/af8dfc58f9e783eb0cbaa99c4ab13990c8c9b03f) | `` easyeffects: 7.0.5 -> 7.1.0 ``                                           |
| [`f9757692`](https://github.com/NixOS/nixpkgs/commit/f975769295f7f71a4d549debd6995d30d08ee89b) | `` python311Packages.ical: 5.0.1 -> 5.1.0 ``                                |
| [`27ebcf32`](https://github.com/NixOS/nixpkgs/commit/27ebcf326e531249c99337fdc756ecb8716d8bcc) | `` python311Packages.google-cloud-dlp: 3.12.2 -> 3.12.3 ``                  |
| [`d9dda8f4`](https://github.com/NixOS/nixpkgs/commit/d9dda8f4ba7e148998db866a47302dca28334546) | `` python311Packages.google-cloud-dataproc: 5.5.0 -> 5.5.1 ``               |
| [`66212346`](https://github.com/NixOS/nixpkgs/commit/66212346b2fd83eeed7d57b347793183367f1f25) | `` python311Packages.google-auth-httplib2: 0.1.0 -> 0.1.1 ``                |
| [`bddaaf18`](https://github.com/NixOS/nixpkgs/commit/bddaaf18f15bf38f032df4d807ebb63c6bc9e27a) | `` python311Packages.google-cloud-compute: 1.14.0 -> 1.14.1 ``              |
| [`642de174`](https://github.com/NixOS/nixpkgs/commit/642de1740b230bb57407b763480f825a84cc7ab1) | `` python311Packages.clevercsv: 0.8.0 -> 0.8.1 ``                           |
| [`017a7431`](https://github.com/NixOS/nixpkgs/commit/017a7431a5c79c09e308b12dd55677a5dbdac933) | `` python311Packages.azure-storage-queue: 12.6.0 -> 12.7.1 ``               |
| [`839ff463`](https://github.com/NixOS/nixpkgs/commit/839ff463f07d47a8e650eccb62ae00f1ef186e2f) | `` python311Packages.casbin: 1.27.0 -> 1.28.0 ``                            |
| [`5570c265`](https://github.com/NixOS/nixpkgs/commit/5570c265acd23ebcc09e67b3aef51e6c61251fb0) | `` python311Packages.aiolifx-themes: 0.4.8 -> 0.4.9 ``                      |
| [`ff404e6b`](https://github.com/NixOS/nixpkgs/commit/ff404e6b415aa67dfcdc8c8cec63bbe78d72d362) | `` nextcloud27: 27.0.2 -> 27.1.0 ``                                         |
| [`3f292985`](https://github.com/NixOS/nixpkgs/commit/3f2929850f3dcd236298251adc3cd4deb63274a9) | `` nextcloud26: 26.0.5 -> 26.0.6 ``                                         |
| [`d8f4c08f`](https://github.com/NixOS/nixpkgs/commit/d8f4c08f371f72e6bea1b4106fc852d2b9e6e4ce) | `` nextcloud25: 25.0.10 -> 25.0.11 ``                                       |
| [`f7671768`](https://github.com/NixOS/nixpkgs/commit/f76717681dc50a9541cc889a67b3286c1103143a) | `` python311Packages.hsluv: 5.0.3 -> 5.0.4 ``                               |
| [`03d6f353`](https://github.com/NixOS/nixpkgs/commit/03d6f3538902af1aae6e8b953a76ccdf710befce) | `` python311Packages.hahomematic: 2023.9.1 -> 2023.9.2 ``                   |
| [`9e043994`](https://github.com/NixOS/nixpkgs/commit/9e0439949a379e2a9a6fc7fda3402350befa26a5) | `` python311Packages.appthreat-vulnerability-db: 5.4.1 -> 5.4.2 ``          |
| [`35d066de`](https://github.com/NixOS/nixpkgs/commit/35d066de5f78498696e570615505b1c872602c17) | `` rewrite `runCommand` interface docs ``                                   |
| [`1b721a90`](https://github.com/NixOS/nixpkgs/commit/1b721a908ca5fdd08be919eb5959db301b8f316b) | `` upscayl: 2.7.5 -> 2.8.1 ``                                               |
| [`2ed9b44d`](https://github.com/NixOS/nixpkgs/commit/2ed9b44d0c5249d1d17f5ff542030a380d7eca07) | `` libsForQt5.qtkeychain: fix build on x86_64-darwin ``                     |
| [`be057ad0`](https://github.com/NixOS/nixpkgs/commit/be057ad0256d08728fdb9201bcffdc0d7f8ddb05) | `` risor: 0.17.0 -> 1.1.1 ``                                                |
| [`00a68ebf`](https://github.com/NixOS/nixpkgs/commit/00a68ebfd3ca6b0f68fe36278ade963289c207d7) | `` snazy: 0.52.0 -> 0.52.1 ``                                               |