### PR TITLE
chore(flake/agenix): `572baca9` -> `7f9dfa30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694793763,
-        "narHash": "sha256-y6gTE1C9mIoSkymRYyzCmv62PFgy+hbZ5j8fuiQK5KI=",
+        "lastModified": 1695339232,
+        "narHash": "sha256-6wQHW3uHECpGIBolTccQ6x3/9b8E1SrO+VzTABKe2xM=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "572baca9b0c592f71982fca0790db4ce311e3c75",
+        "rev": "7f9dfa309f24dc74450ecab6e74bc3d11c7ce735",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                           |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`da763b2c`](https://github.com/ryantm/agenix/commit/da763b2c4bfac0310e8c1d972199e10967ad38b8) | `` Don't need concatStringSep if using jq to parse json arrays `` |
| [`eb1386f3`](https://github.com/ryantm/agenix/commit/eb1386f3b246ae563c99ecadaaeff6b6d36fc9a5) | `` Use jq instead of sed ``                                       |