### PR TITLE
chore(flake/nix): `a95057b7` -> `c659bb93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -326,11 +326,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1690384605,
-        "narHash": "sha256-6o85ruMaNQ3XibjdMuhMUN9j4myrgPTGGe5wOJ+LaFk=",
+        "lastModified": 1695403387,
+        "narHash": "sha256-Tzp+F6SBcxpS/aSikDyXfEhCG4eY5VXw8CT9bP84bPc=",
         "owner": "lovesegfault",
         "repo": "nix",
-        "rev": "a95057b7fcc33c52827503f4dbb1c759e42075e1",
+        "rev": "c659bb936465d93e55ca741f3f20ec0ccad4c6cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                                         |
| ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`c659bb93`](https://github.com/lovesegfault/nix/commit/c659bb936465d93e55ca741f3f20ec0ccad4c6cc) | `` feat: add always-allow-substitutes ``                                        |
| [`f3005632`](https://github.com/lovesegfault/nix/commit/f3005632c417615d2cf3a6d102d0f4f041d8b2b7) | `` Re-enable systemd-nspawn test ``                                             |
| [`40a01441`](https://github.com/lovesegfault/nix/commit/40a014416b245273e2d5ab50a372cd9468d63cb9) | `` Bump version ``                                                              |
| [`44fb1192`](https://github.com/lovesegfault/nix/commit/44fb1192185cdd03343da7faa08a1c605f773419) | `` Mark official release ``                                                     |
| [`10ad052f`](https://github.com/lovesegfault/nix/commit/10ad052f7d14101525daabbd63a147eb0247c3a1) | `` Release notes ``                                                             |
| [`b6b2a0ae`](https://github.com/lovesegfault/nix/commit/b6b2a0aea99995d73f0faa6115fb33a137e57b23) | `` Use "touch -h" ``                                                            |
| [`c6953d1f`](https://github.com/lovesegfault/nix/commit/c6953d1ff62fb6dc4fbd89c03e7949c552c19382) | `` Disable systemd-nspawn test ``                                               |
| [`126e2645`](https://github.com/lovesegfault/nix/commit/126e2645f2a060197655f9a699ffa4dc3a464bdd) | `` Disable rapidcheck tests in the coverage run ``                              |
| [`c8afa01b`](https://github.com/lovesegfault/nix/commit/c8afa01bc25ba81883f8007ef83532ca550c731d) | `` Try aws-sdk-cpp fix ``                                                       |
| [`dd3bf4db`](https://github.com/lovesegfault/nix/commit/dd3bf4dbda02b83a185efc1f8f4bced06a6b07ab) | `` Bump docker/login-action from 2 to 3 ``                                      |
| [`21783cff`](https://github.com/lovesegfault/nix/commit/21783cff1649f236cb31f27f788e3934802c42c9) | `` docs: make the nix develop --command example unambiguous (#8952) ``          |
| [`07545add`](https://github.com/lovesegfault/nix/commit/07545add53ab39b4560d8e7cec1748423ae1a22e) | `` Drop dead code ``                                                            |
| [`682dbcab`](https://github.com/lovesegfault/nix/commit/682dbcab9a7a81c210dc9c8aa3cfc58ccc1723aa) | `` Print parent activity field in json log ``                                   |
| [`2cdc9c32`](https://github.com/lovesegfault/nix/commit/2cdc9c32e746a620458a1dd87655d2a6c3800f64) | `` docs: fixed the default priority of nix-env --install (#8945) ``             |
| [`5473e102`](https://github.com/lovesegfault/nix/commit/5473e10249e02f95375b6126e232700d51bdf429) | `` fix: `nix shell` multiple commands example (#8950) ``                        |
| [`80d7994f`](https://github.com/lovesegfault/nix/commit/80d7994f52ccefca2f2fbe4ee64741a6f49884ff) | `` Special-case error message to add extra information ``                       |
| [`7ad66cb3`](https://github.com/lovesegfault/nix/commit/7ad66cb3ef7615b51a35a099e232640d528c006c) | `` Allow dynamic derivation deps in `inputDrvs` ``                              |
| [`829d4d3e`](https://github.com/lovesegfault/nix/commit/829d4d3e03e0f7935c1fd3e1ef760980c8cf6046) | `` fix invalid anchor link ``                                                   |
| [`b7edc209`](https://github.com/lovesegfault/nix/commit/b7edc2099fffd7d54638122d2d9950e3d3a751f6) | `` Improve derivation parsing ``                                                |
| [`d568877e`](https://github.com/lovesegfault/nix/commit/d568877eab59a490694e0bc3edec99d13049552c) | `` Retitle section as Robert suggests ``                                        |
| [`391f1806`](https://github.com/lovesegfault/nix/commit/391f18063c0279e2de189176335a1b2863b9533a) | `` add anchors to option listings ``                                            |
| [`02c2679f`](https://github.com/lovesegfault/nix/commit/02c2679f0e94013b5cae6305e0b15fce8d971eb8) | `` dedent common options listing; one sentence per line ``                      |
| [`5c23d3a9`](https://github.com/lovesegfault/nix/commit/5c23d3a90cb1a76a0ea464be380bb16dc9f999c7) | `` disambiguate output from output path ``                                      |
| [`2b3a1782`](https://github.com/lovesegfault/nix/commit/2b3a17820f202ea2108184a399f3c573ca11c1b9) | `` Fix globals.hh typo ``                                                       |
| [`880d9cab`](https://github.com/lovesegfault/nix/commit/880d9cabedf7ef1707dd64c44a0a76d61d0ca79a) | `` Test and begin documentation of the ATerm format for derivations ``          |
| [`3a9c1dc8`](https://github.com/lovesegfault/nix/commit/3a9c1dc8a3b872adaf30562fb28697b58be4be2b) | `` add checklist to contribution guide ``                                       |
| [`4f2b949b`](https://github.com/lovesegfault/nix/commit/4f2b949ba808e2161f652cd914cba2517f1faea5) | `` reorder list items ``                                                        |
| [`cc388fbc`](https://github.com/lovesegfault/nix/commit/cc388fbc3a084a1e400c7c65df08b8dc6281056d) | `` remove maintainers checklist in PR template ``                               |
| [`87508b10`](https://github.com/lovesegfault/nix/commit/87508b1065c38d77870f7894a64f4edac162f3bb) | `` Bump cachix/install-nix-action from 22 to 23 ``                              |
| [`73f6407e`](https://github.com/lovesegfault/nix/commit/73f6407eeaf0018519be5d4f9dcd87537450d277) | `` Bump actions/checkout from 3 to 4 ``                                         |
| [`5c95b32c`](https://github.com/lovesegfault/nix/commit/5c95b32c461da645826ff6bf248183f066c57b20) | `` Fix warning 'catching polymorphic type by value' ``                          |
| [`539cc5e5`](https://github.com/lovesegfault/nix/commit/539cc5e5f00c0d524dec6e73b08ab8cb0f5a9630) | `` flake: update nixpkgs: 22.11 -> 23.05 ``                                     |
| [`1ac18175`](https://github.com/lovesegfault/nix/commit/1ac181759d975e4faeaf9083259287562009b4ec) | `` revert some random change ``                                                 |
| [`d38a5394`](https://github.com/lovesegfault/nix/commit/d38a539437943f4ae6b1f72321c7dc29559547c5) | `` make description open-ended, add TODO ``                                     |
| [`894cbe43`](https://github.com/lovesegfault/nix/commit/894cbe43bc5caa339dab7f8af31bf065020c9f8d) | `` don't invent terms yet ``                                                    |
| [`b951e862`](https://github.com/lovesegfault/nix/commit/b951e862d0bdb93a64e2c85af8762a9294d575c9) | `` more meaningful tagline ``                                                   |
| [`cf4e14d5`](https://github.com/lovesegfault/nix/commit/cf4e14d58da04465c2afd05af6975d568f58ce1d) | `` accommodate "do nothing" branch ``                                           |
| [`d460dbdd`](https://github.com/lovesegfault/nix/commit/d460dbdd30e3b518de962314bcf183961caf7f53) | `` be more precise about substituting store derivations ``                      |
| [`6b3320ab`](https://github.com/lovesegfault/nix/commit/6b3320ab05cefe73c21a469d077b277cff47733b) | `` mention remote builders ``                                                   |
| [`0cd8f366`](https://github.com/lovesegfault/nix/commit/0cd8f36644042b41516e86e527ebfb19faebcbc9) | `` add anchor to `builder` ``                                                   |
| [`d50f1164`](https://github.com/lovesegfault/nix/commit/d50f116421f7c999748887955b2d3c2e8b934b28) | `` add reference link ``                                                        |
| [`b7e9e296`](https://github.com/lovesegfault/nix/commit/b7e9e2960566b8e21f4f69b6f222b945fababce7) | `` remove abstract description ``                                               |
| [`a57e0e8c`](https://github.com/lovesegfault/nix/commit/a57e0e8c5c1be81e9352499ac31dcfce87ca44be) | `` reword introductory sentence ``                                              |
| [`315a11bc`](https://github.com/lovesegfault/nix/commit/315a11bcc9ce97cb25a41dcdfb4a859c7384f74b) | `` remove superfluous word ``                                                   |
| [`1bc9257d`](https://github.com/lovesegfault/nix/commit/1bc9257d7c5980fb048b519eeaa2a2b2e8925099) | `` reword description of how realisation works ``                               |
| [`be3362e7`](https://github.com/lovesegfault/nix/commit/be3362e74782e47b9546de94be97f53540ddfe9e) | `` Fix nix-copy test ``                                                         |
| [`3384f70a`](https://github.com/lovesegfault/nix/commit/3384f70a3d5ee7bd1d1bf5fa48809c4eac5c8041) | `` nixpkgsLibTests: Only test our Nix ``                                        |
| [`46478b44`](https://github.com/lovesegfault/nix/commit/46478b44ffb477387235b3c597c24178845fb2a3) | `` docs/testing: point out the existence of `GTEST_FILTER` (#8883) ``           |
| [`56763ff9`](https://github.com/lovesegfault/nix/commit/56763ff918eb308db23080e560ed2ea3e00c80a7) | `` Document that redirected tarball flakerefs can specify lastModified ``       |
| [`151120a1`](https://github.com/lovesegfault/nix/commit/151120a1ae082c6460f9a54cf795c57d154f6c27) | `` Document nix-prefetch-url defaults (#8878) ``                                |
| [`736b9ced`](https://github.com/lovesegfault/nix/commit/736b9cede73692a1cf92a6c21c5259498a04c961) | `` Port the flags of nix-daemon to nix daemon (#8788) ``                        |
| [`1e08e12d`](https://github.com/lovesegfault/nix/commit/1e08e12d8138b09e6872cb498b723ade9ad71d68) | `` pathExists: isDir when endswith / ``                                         |
| [`d2e6cfa0`](https://github.com/lovesegfault/nix/commit/d2e6cfa0750cb38ceef7dc0b8bb31cf3b0387e9c) | `` tests/lang/eval-okay-pathexists: Add cases ``                                |
| [`5e3986f5`](https://github.com/lovesegfault/nix/commit/5e3986f59cb58f48186a49dcec7aa317b4787522) | `` Adapt scheduler to work with dynamic derivations ``                          |
| [`692074f7`](https://github.com/lovesegfault/nix/commit/692074f7142fcf8ede1266b6d8cbbd5feaf3221f) | `` Use `Worker::makeDerivationGoal` less ``                                     |
| [`1c4caef1`](https://github.com/lovesegfault/nix/commit/1c4caef14b51dbb4f749c45311c8e2c9acb75a60) | `` Throw `MissingRealisation` not plain `Error` in both `resolveDerivedPath` `` |
| [`2f5d3da8`](https://github.com/lovesegfault/nix/commit/2f5d3da8062ae58242a8de2bad470a66478edea4) | `` Introduce `OutputName` and `OutputNameView` type aliases ``                  |
| [`925a444b`](https://github.com/lovesegfault/nix/commit/925a444b925590df90e19d3c0071936f87d2b43d) | `` add nix-store --query --valid-derivers command ``                            |
| [`d5b130ef`](https://github.com/lovesegfault/nix/commit/d5b130ef13bd9a77d803950ca814ac9a612f77b8) | `` glossary: dedent list and do not use forced line breaks ``                   |
| [`7d823416`](https://github.com/lovesegfault/nix/commit/7d82341633d81f50f3e5e0b0896cfac5ea805d57) | `` update system definitions ``                                                 |
| [`4a435ad2`](https://github.com/lovesegfault/nix/commit/4a435ad2288bffd5c28d90758e4e26160b53fb8c) | `` Add introductory sentence to advanced topics  (#8861) ``                     |
| [`81045f24`](https://github.com/lovesegfault/nix/commit/81045f243f91adcd44da0080c9ac83d2c4176125) | `` Tarball trees: Propagate lastModified ``                                     |
| [`8130373b`](https://github.com/lovesegfault/nix/commit/8130373be9a10681a94b0546242843db158f30d3) | `` Bump zeebe-io/backport-action from 1.3.1 to 1.4.0 ``                         |
| [`fe71faa9`](https://github.com/lovesegfault/nix/commit/fe71faa920ef34b67f56232decc22cf5706a00dd) | `` Delete `EvalState::addToSearchPath` ``                                       |
| [`9121fed4`](https://github.com/lovesegfault/nix/commit/9121fed4b4d02c286166373fe9805773afb13694) | `` Fixing #7479 ``                                                              |
| [`75243c96`](https://github.com/lovesegfault/nix/commit/75243c96937b472665b94729df81f8296b262085) | `` test/flakes/follow-paths.sh: Quote ``                                        |
| [`73696ec7`](https://github.com/lovesegfault/nix/commit/73696ec71678433dac87863bab36b66701d4b6ed) | `` libutil: fix double-encoding of URLs ``                                      |
| [`1d7a57cf`](https://github.com/lovesegfault/nix/commit/1d7a57cfd9bf40658e2f35c13146d746a1011020) | `` libexpr/tests: test that parseFlakeRef doesn't percent-encode twice ``       |
| [`17ceec3a`](https://github.com/lovesegfault/nix/commit/17ceec3a91a57c77c8df51f380f3a8a0c88460c4) | `` Test repl formatting with and without :p ``                                  |
| [`d8079ee3`](https://github.com/lovesegfault/nix/commit/d8079ee3503b487af0769ad53398171e617869da) | `` Document jobCategory() ``                                                    |
| [`63e0b5d0`](https://github.com/lovesegfault/nix/commit/63e0b5d081fed582ac6a0a66f402dc525953524b) | `` GC root for fetched nixpkgs/lib content ``                                   |
| [`b13fc710`](https://github.com/lovesegfault/nix/commit/b13fc7101fb06a65935d145081319145f7fef6f9) | `` Add positive source filter ``                                                |
| [`20d9c672`](https://github.com/lovesegfault/nix/commit/20d9c672d14de3f05a791251a67618d679cf4173) | `` Update tests/flakes/follow-paths.sh ``                                       |
| [`b74962c9`](https://github.com/lovesegfault/nix/commit/b74962c92b2d8d9b957934e0aefcf4983169ae1e) | `` src/libexpr/search-path.cc: avoid out-of-bounds read on string_view ``       |
| [`37a509ca`](https://github.com/lovesegfault/nix/commit/37a509ca2d7ab4b6a94ba35462483494253bf231) | `` Add release notes for the previous commit ``                                 |
| [`1ef8008c`](https://github.com/lovesegfault/nix/commit/1ef8008ca7a7b38570f06abdbb7960e93ac044ef) | `` Fix follow path checking at depths greater than 2 ``                         |
| [`44c8d838`](https://github.com/lovesegfault/nix/commit/44c8d83831e310d445493d7071161c622bc302aa) | `` Create `outputOf` primop. ``                                                 |
| [`e7c39ff0`](https://github.com/lovesegfault/nix/commit/e7c39ff00b81dfdc48ebe7f41847db84ba779676) | `` Rework evaluator `SingleDerivedPath` infra ``                                |
| [`a04720e6`](https://github.com/lovesegfault/nix/commit/a04720e68ce45943ce0eae3d477f9d554b0d63a4) | `` Rename `optOutputPath` to `optStaticOutputPath` ``                           |
| [`c4dbb55b`](https://github.com/lovesegfault/nix/commit/c4dbb55ba93c9c81d798faa6a19285ebe2717a25) | `` initLibUtil: Add exception handling self-check ``                            |
| [`e78e9a6b`](https://github.com/lovesegfault/nix/commit/e78e9a6bd1c5f26684a9da0d94ede7d960788e0e) | `` SimpleLogger::log: fix unintended fallthrough ``                             |
| [`2e5096e4`](https://github.com/lovesegfault/nix/commit/2e5096e4f0959cb2974a17fe50ad5ad891b2384f) | `` FileTransfer::download: fix use-after-move ``                                |
| [`1ffb2631`](https://github.com/lovesegfault/nix/commit/1ffb26311b5d74e9f607ec31bee6c17bbae6fdae) | `` MultiCommand::toJSON: Fix use-after-move ``                                  |
| [`b9b51f95`](https://github.com/lovesegfault/nix/commit/b9b51f9579c15c9789814cd4b6969b0f85e13980) | `` Prevent overriding virtual methods that are called in a destructor ``        |
| [`60b7121d`](https://github.com/lovesegfault/nix/commit/60b7121d2c6d4322b7c2e8e7acfec7b701b2d3a1) | `` Make the Derived Path family of types inductive for dynamic derivations ``   |
| [`4b1bd822`](https://github.com/lovesegfault/nix/commit/4b1bd822ac7fd35b30f37c1b7705c523cc462761) | `` Try to realise CA derivations during queryMissing ``                         |
| [`afac001c`](https://github.com/lovesegfault/nix/commit/afac001c39aadedcbe52ce45fbde8220834cf13f) | `` Test the parallel copy over ssh-ng ``                                        |
| [`ad410abb`](https://github.com/lovesegfault/nix/commit/ad410abbe0d66a72927bd715af355d88a4e939d9) | `` Stabilize `discard-references` ``                                            |
| [`31a6e10f`](https://github.com/lovesegfault/nix/commit/31a6e10fe52fd4265501553ca479c51b510137e1) | `` Fix misread of source if path is already valid ``                            |
| [`3fefc2b2`](https://github.com/lovesegfault/nix/commit/3fefc2b28494468c7a6078430eaaf8a6c8f17230) | `` Fix derivation load assertion errors ``                                      |
| [`7c09104a`](https://github.com/lovesegfault/nix/commit/7c09104a943978a165885e10697b418f8bab2795) | `` nix/why-depends: fix output of `--precise` ``                                |
| [`3b592c88`](https://github.com/lovesegfault/nix/commit/3b592c880ae76707cc832e5f227e261be29661bf) | `` Add infra for experimental store implemenations ``                           |
| [`9b908fa7`](https://github.com/lovesegfault/nix/commit/9b908fa70a07219a110ddd63ec3593c2c2269918) | `` Factor out `nix-defexpr` path computation ``                                 |
| [`66550878`](https://github.com/lovesegfault/nix/commit/66550878dffe2a4bf55ea7ab694738aa14e6a01e) | `` Add comment explaining the use of `readDirectory(realStoreDir)` ``           |
| [`770d50e4`](https://github.com/lovesegfault/nix/commit/770d50e49cce4d8ce5e546fe31beaa253505bfa5) | `` local-store verifying: Rename `store` to something more clear ``             |
| [`d9e7758f`](https://github.com/lovesegfault/nix/commit/d9e7758f4756c10592407b3fe99dc253ef56eac9) | `` Don't require .tar/.zip extension for tarball flakerefs ``                   |
| [`b9615419`](https://github.com/lovesegfault/nix/commit/b9615419688353f4133520dc11456f7653e4cd08) | `` labeler: Stop removing labels ``                                             |
| [`6525265f`](https://github.com/lovesegfault/nix/commit/6525265f4640221efb0039ddbd6849a3b04babc9) | `` `LocalStore::verifyPath`: Try to clarify data flow with more scopes ``       |
| [`2a5f5fbb`](https://github.com/lovesegfault/nix/commit/2a5f5fbb1776f5086646407e5296c372321863b9) | `` `LocalStore::verifyPath`: Use `StorePathSet` for `store` local var ``        |
| [`c9a87ce7`](https://github.com/lovesegfault/nix/commit/c9a87ce7ca50b0a14c4c77fd2b6ca41a74ba6cb9) | `` Refactor verifyPath to take StorePath instead of Path. ``                    |
| [`1570e802`](https://github.com/lovesegfault/nix/commit/1570e80219df92461ede2a672f8997a013364f5c) | `` Move evaluator settings (type and global) to separate file/header ``         |
| [`33d58a90`](https://github.com/lovesegfault/nix/commit/33d58a90c26f9a62bb20863b767c0a505e6f997a) | `` toJSON: Add attribute path to trace ``                                       |
| [`2d1d8111`](https://github.com/lovesegfault/nix/commit/2d1d81114d72ace89ce08cd3bc93f4eb27a2975d) | `` Add `parseFlakeRef` and `flakeRefToString` builtins (#8670) ``               |
| [`1b756e30`](https://github.com/lovesegfault/nix/commit/1b756e300f98afe6a583f8bed3acd687d4a8abf9) | `` doc: clarify release notes about nested attribute merges ``                  |
| [`0c275558`](https://github.com/lovesegfault/nix/commit/0c275558e75b62beb53e8ada2c116643c7ecb0ba) | `` Bump version ``                                                              |
| [`caabc4f6`](https://github.com/lovesegfault/nix/commit/caabc4f64889d5a4c47d6102b3aa1d3c80bbc107) | `` Feature gate `DownstreamPlaceholder::unknownCaOutput` ``                     |
| [`3b3822ea`](https://github.com/lovesegfault/nix/commit/3b3822ea1ddf34f8fcb44c67cda2b778b5b41a34) | `` tests: Reformat exit code error message ``                                   |
| [`ab78d880`](https://github.com/lovesegfault/nix/commit/ab78d8804e35f889965a561719d84ba6cf904ddc) | `` .gitignore: Add .cache/ ``                                                   |
| [`2265901e`](https://github.com/lovesegfault/nix/commit/2265901e6e36b84276e71642c58c39f946badd08) | `` improved help command listing. ``                                            |