### PR TITLE
chore(flake/home-manager): `e0c70942` -> `2d27bdcd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695495225,
-        "narHash": "sha256-4i4XCjN60llr7U6/03bhPKsFoeKecLnW4WScQEc4n+A=",
+        "lastModified": 1695509808,
+        "narHash": "sha256-rW6kfjLLYDB9xGJwoFkSNzcmLJCcN7VcD+YnDPbEM2c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e0c70942c0e7178a56289adea20c056a3cda7c5e",
+        "rev": "2d27bdcd640759a5fb1b48125fee7280adad95f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                      |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`2d27bdcd`](https://github.com/nix-community/home-manager/commit/2d27bdcd640759a5fb1b48125fee7280adad95f7) | `` direnv: fix nushell syntax ``             |
| [`7413408b`](https://github.com/nix-community/home-manager/commit/7413408b047c12125cf3b76e5d8fa53c297ac1ee) | `` yazi: add fish and nushell integration `` |