### PR TITLE
chore(flake/nixpkgs): `5ba549ea` -> `6500b458`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -377,11 +377,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695145219,
-        "narHash": "sha256-Eoe9IHbvmo5wEDeJXKFOpKUwxYJIOxKUesounVccNYk=",
+        "lastModified": 1695644571,
+        "narHash": "sha256-asS9dCCdlt1lPq0DLwkVBbVoEKuEuz+Zi3DG7pR/RxA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5ba549eafcf3e33405e5f66decd1a72356632b96",
+        "rev": "6500b4580c2a1f3d0f980d32d285739d8e156d92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                  |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
| [`6500b458`](https://github.com/NixOS/nixpkgs/commit/6500b4580c2a1f3d0f980d32d285739d8e156d92) | `` Revert "nixos/boot/rasbperrypi: add support for boot.initrd.secret with uboot (#240358)" (#257251) `` |
| [`3bf3656c`](https://github.com/NixOS/nixpkgs/commit/3bf3656cd084c806ee3b9e9a3247481829437c2a) | `` linux_testing: 6.6-rc2 -> 6.6-rc3 ``                                                                  |
| [`310c3a1e`](https://github.com/NixOS/nixpkgs/commit/310c3a1e26cd33defd3228383de12324da40e406) | `` clang-tools: add optional support for libcxx ``                                                       |
| [`ec9b9147`](https://github.com/NixOS/nixpkgs/commit/ec9b914767dcd589bc47d8ed73f21e429b95c4e6) | `` eza: 0.13.0 -> 0.13.1 ``                                                                              |
| [`c5c30274`](https://github.com/NixOS/nixpkgs/commit/c5c30274a30231438347f2ede1a504b9b5c86b9a) | `` nixosTests.tinywl: fix by adding Mesa drivers ``                                                      |
| [`54c3b0f1`](https://github.com/NixOS/nixpkgs/commit/54c3b0f1dae6a321b0f42bdd7ce1b3437c32dc25) | `` mattermost-desktop: 5.3.1 -> 5.5.0 ``                                                                 |
| [`897629a4`](https://github.com/NixOS/nixpkgs/commit/897629a42f8a105fd88b261821f8d1094f1d7e77) | `` pict-rs: 0.4.2 -> 0.4.3 ``                                                                            |
| [`de810c81`](https://github.com/NixOS/nixpkgs/commit/de810c814c751bd19aa055ded9ca36c2cd917a6f) | `` python310Packages.pinecone-client: 2.2.2 -> 2.2.4 ``                                                  |
| [`78d96b5c`](https://github.com/NixOS/nixpkgs/commit/78d96b5c8ba7ebbf6350cc0b0e08257eef0ef7a7) | `` cdo: 2.2.0 -> 2.2.2 (#257101) ``                                                                      |
| [`801e33f5`](https://github.com/NixOS/nixpkgs/commit/801e33f56288bbbac28acdfe783e9229441fb9a8) | `` neovim: pass wrapper args only once (#257136) ``                                                      |
| [`23e910bb`](https://github.com/NixOS/nixpkgs/commit/23e910bb7f22945d5e87ba9a65a5365fd6d57954) | `` ddnet: 17.2.1 -> 17.3 ``                                                                              |
| [`555db284`](https://github.com/NixOS/nixpkgs/commit/555db28461e9e590ce3173eb55ad21a544231e29) | `` gotify-server: 2.3.0 -> 2.4.0 (#257191) ``                                                            |
| [`fbba24df`](https://github.com/NixOS/nixpkgs/commit/fbba24df231a268138f60ba513cf2e8549128777) | `` pkg: 1.20.5 -> 1.20.7 ``                                                                              |
| [`a7e7daf6`](https://github.com/NixOS/nixpkgs/commit/a7e7daf60d360dd518903db8dd0874419ccc6f01) | `` qemu: 8.1.0 -> 8.1.1 ``                                                                               |
| [`7afff92b`](https://github.com/NixOS/nixpkgs/commit/7afff92bb5433924743b9b99b5a40b755f3e40eb) | `` python311Packages.pytest-md-report: 0.4.0 -> 0.4.1 ``                                                 |
| [`c0b75164`](https://github.com/NixOS/nixpkgs/commit/c0b7516465a16407337218faf778533edd4c00a8) | `` php81Extensions.mongodb: 1.16.1 -> 1.16.2 ``                                                          |
| [`110b0e7b`](https://github.com/NixOS/nixpkgs/commit/110b0e7b4269aa7aa00ef1294c9abe9c13780756) | `` python310Packages.unearth: 0.10.0 -> 0.11.0 ``                                                        |
| [`cc841fa4`](https://github.com/NixOS/nixpkgs/commit/cc841fa4302161b7e76f496686242f7d152fbcec) | `` inetutils: enable tests ``                                                                            |
| [`aa54e0d6`](https://github.com/NixOS/nixpkgs/commit/aa54e0d65df183b8914adf7c2db543055e060ecf) | `` inetutils: add patch for CVE-2023-40303 ``                                                            |
| [`48e2e83d`](https://github.com/NixOS/nixpkgs/commit/48e2e83db5ae5bb915d5956ba198ea0fb02f3b61) | `` ocamlPackages.ptime: fix evaluation ``                                                                |
| [`ff24f7f0`](https://github.com/NixOS/nixpkgs/commit/ff24f7f057475133f049c185db4ad131c9b37686) | `` tempo: 2.2.2 -> 2.2.3 ``                                                                              |
| [`45db1589`](https://github.com/NixOS/nixpkgs/commit/45db15894162298e37434a0184cb5caea2bb4262) | `` earthly: 0.7.17 -> 0.7.19 ``                                                                          |
| [`0ec8744e`](https://github.com/NixOS/nixpkgs/commit/0ec8744ee4ad02ec5f55dd0ea71aee190d7f6a77) | `` pinniped: 0.25.0 -> 0.26.0 ``                                                                         |
| [`1fe8e279`](https://github.com/NixOS/nixpkgs/commit/1fe8e279c6cda3f82928d35372a4f7fa8308301c) | `` zimfw: 1.12.0 -> 1.12.1 ``                                                                            |
| [`0a017f94`](https://github.com/NixOS/nixpkgs/commit/0a017f947fc9a060bfdd79a8e885f1d54fd8a592) | `` ppsspp-sdl: 1.16.1 -> 1.16.2 ``                                                                       |
| [`c144e291`](https://github.com/NixOS/nixpkgs/commit/c144e2919b2974f138031bccc0981a3570594388) | `` postman: 10.15.0 → 10.18.6 ``                                                                         |
| [`94a42157`](https://github.com/NixOS/nixpkgs/commit/94a42157f48abfe2c27b1afadd3bf8f94334f08d) | `` nixos/xonotic: init ``                                                                                |
| [`18ed405d`](https://github.com/NixOS/nixpkgs/commit/18ed405de1f077ab9faa5ae8eec86a293aebcb1e) | `` gitea-actions-runner: 0.2.5 -> 0.2.6 ``                                                               |
| [`4560afb3`](https://github.com/NixOS/nixpkgs/commit/4560afb3fdec2f9a37286b1825ff208b219ee0b1) | `` rectangle-pro: 3.0.9 -> 3.0.11 ``                                                                     |
| [`55446ef5`](https://github.com/NixOS/nixpkgs/commit/55446ef5abfb46ccf28ef94ba161ec8a0ba7ee1c) | `` msitools: 0.102 -> 0.103 ``                                                                           |
| [`e071b148`](https://github.com/NixOS/nixpkgs/commit/e071b148152e7ea5c7d63449cf7d10643a4033a2) | `` python310Packages.bibtexparser: 1.4.0 -> 1.4.1 ``                                                     |
| [`0ee7eda9`](https://github.com/NixOS/nixpkgs/commit/0ee7eda9f63f67baa8b5a24e0df21a1dd8807d33) | `` goreleaser: 1.20.0 -> 1.21.0 ``                                                                       |
| [`7a862f0a`](https://github.com/NixOS/nixpkgs/commit/7a862f0a660d5bd850457a0ad7772e1672109ccd) | `` websocat: 1.11.0 -> 1.12.0 ``                                                                         |
| [`1b26fc01`](https://github.com/NixOS/nixpkgs/commit/1b26fc011a0f136f05e4a2f3e6e5b5c6e0c5214e) | `` emacs: allow using as shebang on darwin ``                                                            |
| [`949ea042`](https://github.com/NixOS/nixpkgs/commit/949ea0426d78c433bbc8e630f254a45dc5f25e08) | `` emacs: remove unused makeWrapper dependency ``                                                        |
| [`c9555ed4`](https://github.com/NixOS/nixpkgs/commit/c9555ed4788ecfd2ba249c10d246ceee1b1e70a9) | `` python310Packages.python-lsp-jsonrpc: 1.1.1 -> 1.1.2 ``                                               |
| [`8f395bb3`](https://github.com/NixOS/nixpkgs/commit/8f395bb3b761417fc57520b2c859f628424e1a7c) | `` wallust: 2.6.1 -> 2.7.1 ``                                                                            |
| [`6972c1c3`](https://github.com/NixOS/nixpkgs/commit/6972c1c378ba876bfe4b9730f36d8f8c3c0a2483) | `` clonehero: fix invalid url ``                                                                         |
| [`a4e4c380`](https://github.com/NixOS/nixpkgs/commit/a4e4c38049fda70cd02e20278b2bfe4605161308) | `` maintainers: add rudolfvesely ``                                                                      |
| [`d1114bc0`](https://github.com/NixOS/nixpkgs/commit/d1114bc017646168fb52ff3141af6cce43547dfd) | `` postman: add openssl dependency ``                                                                    |
| [`d83fafb0`](https://github.com/NixOS/nixpkgs/commit/d83fafb0b90fe30966f279d3dc562c8b40f66a49) | `` slack: 4.34.115 -> 4.34.120 (linux), 4.34.115 -> 4.34.119 (darwin) ``                                 |
| [`c105d042`](https://github.com/NixOS/nixpkgs/commit/c105d04235201cad37ad078aa322df69b52e4ba8) | `` python310Packages.django-types: 0.17.0 -> 0.18.0 ``                                                   |
| [`e2e53d45`](https://github.com/NixOS/nixpkgs/commit/e2e53d45437d74653256bb8c6bd8d89294f57024) | `` osm2pgsql: 1.9.0 → 1.9.2 ``                                                                           |
| [`3407165c`](https://github.com/NixOS/nixpkgs/commit/3407165c59c19253da5575d529e03cbf80fa4b02) | `` libmcrypt: fix cross compilation ``                                                                   |
| [`928f19b4`](https://github.com/NixOS/nixpkgs/commit/928f19b461a895cd8023c7363159503b9b6c7569) | `` gifski: 1.11.0 -> 1.12.2 ``                                                                           |
| [`93e9acac`](https://github.com/NixOS/nixpkgs/commit/93e9acacc7d457cdd471af0afec5693ef7e1e7d2) | `` python3Packages.pyosmium: fix build ``                                                                |
| [`ade134ec`](https://github.com/NixOS/nixpkgs/commit/ade134ecd18904d03eec4dc7992a1b03389dd244) | `` nixpkgs manual: doc python: add hyperlinks to Python section (#252156) ``                             |
| [`1e4393e5`](https://github.com/NixOS/nixpkgs/commit/1e4393e5a257d7b6e16bfc0ebce23111ae04eb5d) | `` act: 0.2.50 -> 0.2.51 ``                                                                              |
| [`75d6a892`](https://github.com/NixOS/nixpkgs/commit/75d6a892f8844227548518afd7284d853237458d) | `` libretro.parallel-n64: add missing Make flags ``                                                      |
| [`e9c44cb2`](https://github.com/NixOS/nixpkgs/commit/e9c44cb2035879d14ed7fe37b0cb2e59f68228aa) | `` librepcb: 0.1.7 -> 1.0.0 ``                                                                           |
| [`2ed6ebe0`](https://github.com/NixOS/nixpkgs/commit/2ed6ebe0f993bcb11af6ea1768a2ccc6fc6fada5) | `` php.packages.castor: Build from source ``                                                             |
| [`caf860b2`](https://github.com/NixOS/nixpkgs/commit/caf860b2406178cd7ff05b322a7cc60a3bc78a77) | `` libretro.mupen64plus: add missing Make flags ``                                                       |
| [`60c81d33`](https://github.com/NixOS/nixpkgs/commit/60c81d33d786d2a23c9eb3f353551f6973170248) | `` php.packages.box: Build from source ``                                                                |
| [`52f53ba4`](https://github.com/NixOS/nixpkgs/commit/52f53ba40fc0bf957f76daeceb406ef594d4d1c8) | `` nodePackages.generator-code: drop ``                                                                  |
| [`1554c89a`](https://github.com/NixOS/nixpkgs/commit/1554c89a981a4b9ca45c34c43e0902a7c7892208) | `` fx: 30.0.3 -> 30.1.0 ``                                                                               |
| [`338bdeb4`](https://github.com/NixOS/nixpkgs/commit/338bdeb43a35aedad86c3b9dfc0c707e9a41530d) | `` libretro: unstable-2023-03-13 -> unstable-2023-09-24 ``                                               |
| [`716743c2`](https://github.com/NixOS/nixpkgs/commit/716743c2d0057fa466cf6e74b17dd4b1563566f1) | `` linuxKernel.kernels.linux_lqx: 6.5.4-lqx2 -> 6.5.5-lqx1 ``                                            |
| [`1c0908db`](https://github.com/NixOS/nixpkgs/commit/1c0908dbc76ad3b191a3efee1ee73458aaa32eb4) | `` linuxKernel.kernels.linux_zen: 6.5.4-zen2 -> 6.5.5-zen1 ``                                            |
| [`2d38d9ed`](https://github.com/NixOS/nixpkgs/commit/2d38d9edc09b530b3c10328dd7c722373947fef0) | `` nixos/garage: Add an environmentFile option ``                                                        |
| [`8a837dd7`](https://github.com/NixOS/nixpkgs/commit/8a837dd7faa7fdf63140dc1ee36d378bf10415d8) | `` owmods-cli: 0.10.0 -> 0.11.2 ``                                                                       |
| [`7e6f09d0`](https://github.com/NixOS/nixpkgs/commit/7e6f09d0c5067518074289ebd226d5897af3eb63) | `` python311Packages.argilla: 1.15.0 -> 1.16.0 ``                                                        |
| [`b6766564`](https://github.com/NixOS/nixpkgs/commit/b6766564edd0966cd9dc3c4ba4baaffc9413d9a0) | `` Update wg-quick.nix ``                                                                                |
| [`4a785348`](https://github.com/NixOS/nixpkgs/commit/4a785348750c5192edfb3a662d1437da43c1821e) | `` python311Packages.tabledata: 1.3.1 -> 1.3.3 ``                                                        |
| [`e040d4d8`](https://github.com/NixOS/nixpkgs/commit/e040d4d85060b40d51685e187c37804b4035d658) | `` morgen: 3.0.0 -> 3.0.1 ``                                                                             |
| [`c871ff7e`](https://github.com/NixOS/nixpkgs/commit/c871ff7e15c689548af36f7567e98d0ff27721b9) | `` weechat: 4.0.4 -> 4.0.5 ``                                                                            |
| [`1c884834`](https://github.com/NixOS/nixpkgs/commit/1c8848340544aa3c5ebfaa044d4760e0708f1563) | `` php81Packages.php-cs-fixer: 3.22.0 -> 3.28.0 ``                                                       |
| [`9f69adde`](https://github.com/NixOS/nixpkgs/commit/9f69adde0dcd1c707c7cfc1ff326ae5c058bbe68) | `` redis: use finalAttrs ``                                                                              |
| [`59361401`](https://github.com/NixOS/nixpkgs/commit/593614014796ebf270d1205f11864a3945a39dd4) | `` gopass-jsonapi: add meta.mainProgram ``                                                               |
| [`288c3128`](https://github.com/NixOS/nixpkgs/commit/288c3128f4f741033c1eaec1cb723d0dc0d1ba55) | `` gopass-hibp: add meta.mainProgram ``                                                                  |
| [`f4445bec`](https://github.com/NixOS/nixpkgs/commit/f4445bec23d09291d87b2357ef4f31f47c1a9405) | `` gopass-summon-provider: add meta.mainProgram ``                                                       |
| [`5b17920c`](https://github.com/NixOS/nixpkgs/commit/5b17920c3b7789051c47b624917f37bc328abc28) | `` git-credential-gopass: add meta.mainProgram ``                                                        |
| [`4c940253`](https://github.com/NixOS/nixpkgs/commit/4c940253098220378ec084d4a1075d456c86c927) | `` gopass: add meta.mainProgram ``                                                                       |
| [`d8105395`](https://github.com/NixOS/nixpkgs/commit/d8105395604995d2fe381ecb37773933994678d1) | `` gopass-summon-provider: 1.15.7 -> 1.15.8 ``                                                           |
| [`7831105f`](https://github.com/NixOS/nixpkgs/commit/7831105f511bacc9e69fb47cb48ced9830e0ffc5) | `` gopass-hibp: 1.15.7 -> 1.15.8 ``                                                                      |
| [`82e482bb`](https://github.com/NixOS/nixpkgs/commit/82e482bb7760c2c917f553256aa098356ca9c20d) | `` gopass: 1.15.7 -> 1.15.8 ``                                                                           |
| [`52a6bc0b`](https://github.com/NixOS/nixpkgs/commit/52a6bc0baadb7b48fe4d3cbf2265b9a4780754ed) | `` php83: 8.3.0RC1 -> 8.3.0RC2 ``                                                                        |
| [`794bae21`](https://github.com/NixOS/nixpkgs/commit/794bae21170074bed316ce4c24e96f87735a833e) | `` gopass-jsonapi: 1.15.7 -> 1.15.8 ``                                                                   |
| [`9ffff4d5`](https://github.com/NixOS/nixpkgs/commit/9ffff4d5403e0e5ce46862578d9872763aa86e72) | `` python310Packages.types-requests: 2.31.0.2 -> 2.31.0.4 ``                                             |
| [`bb8c1d67`](https://github.com/NixOS/nixpkgs/commit/bb8c1d675eb07712bee8f8a3eb47382f6b0159e5) | `` lunar-client: 3.0.10 -> 3.1.0 ``                                                                      |
| [`b3c6d02d`](https://github.com/NixOS/nixpkgs/commit/b3c6d02d1d356a04f3d0971f7681d2d1967f5a31) | `` libharu: 2.4.3 -> 2.4.4 ``                                                                            |
| [`05e485c7`](https://github.com/NixOS/nixpkgs/commit/05e485c70c39e5d77771530d16f8ac9aa6b4e483) | `` go2rtc: 1.7.0 -> 1.7.1 ``                                                                             |
| [`a1e21851`](https://github.com/NixOS/nixpkgs/commit/a1e218514296269c16c00f531ae66df5f3d1e3e1) | `` python311Packages.peaqevcore: 19.4.2 -> 19.5.0 ``                                                     |
| [`c4979319`](https://github.com/NixOS/nixpkgs/commit/c497931955af2ac89c77a0776bd07e8c8b410f4a) | `` cloud-hypervisor: 34.0 -> 35.0 ``                                                                     |
| [`8b1bd27c`](https://github.com/NixOS/nixpkgs/commit/8b1bd27c35c225eac5f47b6a2a35cdeb035c83c1) | `` python310Packages.autofaiss: 2.15.5 -> 2.15.8 ``                                                      |
| [`00a28d0e`](https://github.com/NixOS/nixpkgs/commit/00a28d0ed92631b16a17275099c78e25d80d74a6) | `` buildFHSEnv: add base paths to passthru ``                                                            |
| [`70785d59`](https://github.com/NixOS/nixpkgs/commit/70785d59376dc16083285c17c69e8a8f200c88ac) | `` arduino-cli: 0.33.0 -> 0.34.2 ``                                                                      |
| [`919ccaec`](https://github.com/NixOS/nixpkgs/commit/919ccaec317378d0426299cff71a9f44762d557a) | `` linuxKernel.kernels.linux_lqx: change BBR implementation ``                                           |
| [`7faf9821`](https://github.com/NixOS/nixpkgs/commit/7faf9821391e9bf315b4eaa40bc8cefc9a62b709) | `` amtterm: 1.6-1 -> 1.7-1 ``                                                                            |
| [`e5565406`](https://github.com/NixOS/nixpkgs/commit/e556540620ebf01df3cc7a117bc72726ab9cae28) | `` crosvm: 116.1 -> 117.0 ``                                                                             |
| [`4e587ac8`](https://github.com/NixOS/nixpkgs/commit/4e587ac82107962f291ee28a4329107bebd3efff) | `` mtr-exporter: support specifying multiple jobs ``                                                     |
| [`ef6c59c3`](https://github.com/NixOS/nixpkgs/commit/ef6c59c3bfdfd27d8ba47f9c1955f94fdadced07) | `` algol68g: 3.3.22 -> 3.3.23 ``                                                                         |
| [`e7dc3630`](https://github.com/NixOS/nixpkgs/commit/e7dc363060a17918420cbe5eb93a81ab5f39c78c) | `` zlib-ng: 2.1.2 -> 2.1.3 ``                                                                            |
| [`ad1fd1f8`](https://github.com/NixOS/nixpkgs/commit/ad1fd1f813bc1b7b8f158e0808235ebdc3afda0d) | `` jackett: 0.21.866 -> 0.21.887 ``                                                                      |
| [`0aa3284c`](https://github.com/NixOS/nixpkgs/commit/0aa3284cedc271fcefdf2326fda8e92df16c12c9) | `` oxtools: 1.1.3 -> 1.2.4 ``                                                                            |
| [`59c4461c`](https://github.com/NixOS/nixpkgs/commit/59c4461cf8ce800653f8783b531825431b5adfad) | `` gitmoji-cli: use fetchYarnDeps ``                                                                     |
| [`3b5bf997`](https://github.com/NixOS/nixpkgs/commit/3b5bf99721394e03456c656ac9ab4a7cab4e0af3) | `` werf: 1.2.255 -> 1.2.259 ``                                                                           |
| [`706007a0`](https://github.com/NixOS/nixpkgs/commit/706007a0d76dacb4a9583f76bd16eeece2f3a9b7) | `` microsoft-edge: 117.0.2045.35 -> 117.0.2045.40 ``                                                     |
| [`48426b5b`](https://github.com/NixOS/nixpkgs/commit/48426b5bb46d798b8515e69357aec96989e6b8df) | `` erg: 0.6.20 -> 0.6.21 ``                                                                              |
| [`d19f1ffd`](https://github.com/NixOS/nixpkgs/commit/d19f1ffdc1c43a283456ce43c0acbe4d534f0d26) | `` python310Packages.jplephem: 2.18 -> 2.19 ``                                                           |
| [`b289d79b`](https://github.com/NixOS/nixpkgs/commit/b289d79b8df0f6acfca1fb2367eb71438a3f8ed2) | `` hmmer: add changelog to meta ``                                                                       |
| [`272a0e1e`](https://github.com/NixOS/nixpkgs/commit/272a0e1edb97cbf7cd9903577e363396e54557a8) | `` hmmer: 3.3.2 -> 3.4 ``                                                                                |
| [`583dc103`](https://github.com/NixOS/nixpkgs/commit/583dc103aeceade75f2d0a8178693ea4f96ba377) | `` mloader: 1.1.9 -> 1.1.11 ``                                                                           |
| [`a6334b0e`](https://github.com/NixOS/nixpkgs/commit/a6334b0e7f804b649588d7407b8406a3b162939f) | `` yt-dlp: 2023.7.6 -> 2023.9.24 ``                                                                      |
| [`32a2d42c`](https://github.com/NixOS/nixpkgs/commit/32a2d42cc97fea8378faed3657a0485ecef64c00) | `` python310Packages.types-pytz: 2023.3.1.0 -> 2023.3.1.1 ``                                             |
| [`861f42fa`](https://github.com/NixOS/nixpkgs/commit/861f42fa6d79232959b493fe511d80ebde3b1a4b) | `` camunda-modeler: 5.14.0 -> 5.15.1 ``                                                                  |
| [`efeded00`](https://github.com/NixOS/nixpkgs/commit/efeded0094d6501b5c6c83f4c691948bf22d8834) | `` xplr: add desktop file and icons ``                                                                   |
| [`0db40e9d`](https://github.com/NixOS/nixpkgs/commit/0db40e9dc92b55096a7bd4c0eed3c03befebe804) | `` rain: 1.5.0 -> 1.6.0 ``                                                                               |
| [`198884d4`](https://github.com/NixOS/nixpkgs/commit/198884d46f3a8a3f8fc41cbc4ba57e0447bc45aa) | `` ctranslate2: 3.18.0 -> 3.20.0 ``                                                                      |
| [`ac9413a5`](https://github.com/NixOS/nixpkgs/commit/ac9413a5cf5b9ffcd3c2ef7b41781477507f0dc2) | `` samrewritten: init at unstable-2023-05-23 ``                                                          |
| [`491610cb`](https://github.com/NixOS/nixpkgs/commit/491610cb6d7b9fabd7bbcdcc41dd2037fc1dea1a) | `` mongosh: 1.10.6 -> 2.0.1 ``                                                                           |
| [`e84ed3c1`](https://github.com/NixOS/nixpkgs/commit/e84ed3c1d438058daeb587c5db24337802bbd2e9) | `` etcher: 1.7.9 -> 1.18.12 ``                                                                           |
| [`486f61a0`](https://github.com/NixOS/nixpkgs/commit/486f61a0d937ba6b73e015f3e928d1d364ec8cb6) | `` python310Packages.ctranslate2: unblock by using tensorflow-bin ``                                     |
| [`fc06d91d`](https://github.com/NixOS/nixpkgs/commit/fc06d91d324ccb88547daaab34da7da2d6e8964e) | `` grpc_cli: 1.58.0 -> 1.58.1 ``                                                                         |
| [`2506a14a`](https://github.com/NixOS/nixpkgs/commit/2506a14ab3b1cbd929ccb6a062ee74e2eacfd55d) | `` mdbook-emojicodes: 0.2.2 -> 0.3.0 ``                                                                  |
| [`2d54542a`](https://github.com/NixOS/nixpkgs/commit/2d54542af5f98baa5899eae2066eb0bee77eef78) | `` ghostie: 0.3.0 -> 0.3.1 ``                                                                            |
| [`7cd28027`](https://github.com/NixOS/nixpkgs/commit/7cd28027499aa201b10c4e78b919d1fa7a96a02d) | `` backlight-auto: init at 0.0.1 ``                                                                      |
| [`c40e164a`](https://github.com/NixOS/nixpkgs/commit/c40e164adf3fe552b68b660834ae28de8db3f271) | `` phosh: 0.30.0 -> 0.31.1 ``                                                                            |
| [`f7bcc514`](https://github.com/NixOS/nixpkgs/commit/f7bcc5148f43f35498865896c91eebca2d6521ec) | `` python3Packages.wandb: 0.15.10 -> 0.15.11 ``                                                          |
| [`a58ad071`](https://github.com/NixOS/nixpkgs/commit/a58ad07195ffac08ba10a50a5bdd9aefbc08ca66) | `` labwc: 0.6.4 -> 0.6.5 ``                                                                              |
| [`7bfc0272`](https://github.com/NixOS/nixpkgs/commit/7bfc02724f018a40e99e8943207c362fb40da82a) | `` labwc: migrate to by-name ``                                                                          |
| [`5365ecb4`](https://github.com/NixOS/nixpkgs/commit/5365ecb40b0e6f9cfc94ee58904373a09e856220) | `` rome: remove ``                                                                                       |
| [`340dc275`](https://github.com/NixOS/nixpkgs/commit/340dc275a7a07c9de783cdb5088f71196f143b9d) | `` faas-cli: 0.16.12 -> 0.16.14 ``                                                                       |
| [`a300f20b`](https://github.com/NixOS/nixpkgs/commit/a300f20b89994dd085a746d9df80437119b7abf1) | `` libsForQt5.kirigami-addons: 0.10.0 -> 0.11.0 ``                                                       |
| [`dd4b88da`](https://github.com/NixOS/nixpkgs/commit/dd4b88da6eecb7e9bf9ce8bd0335765ba0316f2c) | `` lemurs: 0.3.1 -> 0.3.2 ``                                                                             |
| [`4db135dd`](https://github.com/NixOS/nixpkgs/commit/4db135ddc349fa738a8800f0c35a8ecdefaecb61) | `` python310Packages.ffcv: sha256 -> hash ``                                                             |
| [`dbdb7271`](https://github.com/NixOS/nixpkgs/commit/dbdb72719509e5e2c59a0c260ae7eda13df7b5e8) | `` python310Packages.ffcv: remove outdated comment ``                                                    |
| [`e6329644`](https://github.com/NixOS/nixpkgs/commit/e63296443c08b8c0c169c230e392a82c23cef0f1) | `` libglibutil: 1.0.71 -> 1.0.74 ``                                                                      |
| [`63fb056b`](https://github.com/NixOS/nixpkgs/commit/63fb056bfe2e7200412cdce39941de162eee2a8e) | `` Revert "imagemagick: 7.1.1-15 -> 7.1.1-17" ``                                                         |
| [`c2f34d39`](https://github.com/NixOS/nixpkgs/commit/c2f34d397bc8b4d9634c15f79bbcfba2e26d5c2a) | `` cargo-expand: 1.0.70 -> 1.0.71 ``                                                                     |
| [`9609a4ae`](https://github.com/NixOS/nixpkgs/commit/9609a4ae5b3a7ebc5273fae7f9e0fbeeeda6dd5a) | `` cargo-llvm-lines: 0.4.33 -> 0.4.34 ``                                                                 |