### PR TITLE
chore(flake/base16-schemes): `d95123ca` -> `876ed8cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
     "base16-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1689473676,
-        "narHash": "sha256-L0RhUr9+W5EPWBpLcmkKpUeCEWRs/kLzVMF3Vao2ZU0=",
+        "lastModified": 1695567727,
+        "narHash": "sha256-bY/k0BU7GFvzkZzL2Fuc0rtm/1HVl1bAHB/vO6+O2HQ=",
         "owner": "tinted-theming",
         "repo": "base16-schemes",
-        "rev": "d95123ca6377cd849cfdce92c0a24406b0c6a789",
+        "rev": "876ed8cf1e27354027ccf140b045132b67452378",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                   |
| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`876ed8cf`](https://github.com/tinted-theming/base16-schemes/commit/876ed8cf1e27354027ccf140b045132b67452378) | `` Add gallery link to README.md (#31) `` |