### PR TITLE
chore(flake/home-manager): `0f4e5b49` -> `9d4cdf8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695738267,
-        "narHash": "sha256-LTNAbTQ96xSj17xBfsFrFS9i56U2BMLpD0BduhrsVkU=",
+        "lastModified": 1695940289,
+        "narHash": "sha256-z9DItQvCasu7sexaz1GZ+uOymDRpuEehFwRKToCooJ8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0f4e5b4999fd6a42ece5da8a3a2439a50e48e486",
+        "rev": "9d4cdf8cc4da54beb5d2e927af7a259bb4a00645",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`9d4cdf8c`](https://github.com/nix-community/home-manager/commit/9d4cdf8cc4da54beb5d2e927af7a259bb4a00645) | `` Translate using Weblate (Danish) ``     |
| [`1d813ff5`](https://github.com/nix-community/home-manager/commit/1d813ff5a677c2e97a4cb0726bbb3b6ebce1c8ed) | `` qt: remove qtstyleplugin-kvantum-qt4 `` |