### PR TITLE
chore(flake/darwin): `e236a1e5` -> `792c2e01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -100,11 +100,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695686713,
-        "narHash": "sha256-rJATx5B/nwlBpt7CJUf85LV27qWPbul5UVV8fu6ABPg=",
+        "lastModified": 1696043447,
+        "narHash": "sha256-VbJ1dY5pVH2fX1bS+cT2+4+BYEk4lMHRP0+udu9G6tk=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "e236a1e598a9a59265897948ac9874c364b9555f",
+        "rev": "792c2e01347cb1b2e7ec84a1ef73453ca86537d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                             |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
| [`ab817e5d`](https://github.com/LnL7/nix-darwin/commit/ab817e5d0e8561949dbc1a9640f88cde2990d862) | `` darwin-rebuild: add `-H` to sudo for `$systemConfig/activate` `` |