### PR TITLE
chore(flake/home-manager): `4f02e35f` -> `ae896c81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695984718,
-        "narHash": "sha256-LQwKgaaaFOkIcxarf0xQXeDJFwZ5BZWcgmPeo3xp2CM=",
+        "lastModified": 1696063111,
+        "narHash": "sha256-F2IJEbyH3xG0eqyAYn9JoV+niqNz+xb4HICYNkkviNI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4f02e35f9d150573e1a710afa338846c2f6d850c",
+        "rev": "ae896c810f501bf0c3a2fd7fc2de094dd0addf01",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`ae896c81`](https://github.com/nix-community/home-manager/commit/ae896c810f501bf0c3a2fd7fc2de094dd0addf01) | `` home-manager: set profile path variables lazily `` |
| [`f1b7775d`](https://github.com/nix-community/home-manager/commit/f1b7775d2393f41acd2b46acaccf0ab6431dea8b) | `` awscli: add module ``                              |