### PR TITLE
chore(flake/nixpkgs): `8a86b98f` -> `f5892dda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -377,11 +377,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695830400,
-        "narHash": "sha256-gToZXQVr0G/1WriO83olnqrLSHF2Jb8BPcmCt497ro0=",
+        "lastModified": 1696019113,
+        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a86b98f0ba1c405358f1b71ff8b5e1d317f5db2",
+        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`86dbce6d`](https://github.com/NixOS/nixpkgs/commit/86dbce6d0788d602df543d08dfd9b692e69739e3) | `` audiobookshelf: init module ``                                                      |
| [`8d8e78c9`](https://github.com/NixOS/nixpkgs/commit/8d8e78c9c22952cce42e09de7e095137ffcedd0b) | `` maintainers: add wietsedv ``                                                        |
| [`35fc5a6b`](https://github.com/NixOS/nixpkgs/commit/35fc5a6b76777e23f89961ea9d07b39e435d58bc) | `` ocamlPackages.re: 1.10.4 → 1.11.0 ``                                                |
| [`aa063ec6`](https://github.com/NixOS/nixpkgs/commit/aa063ec6e97e86dbfa38f9b7294b05255d8f8da7) | `` eclipses: 2023-03 -> 2023-06 ``                                                     |
| [`8a770778`](https://github.com/NixOS/nixpkgs/commit/8a77077879c91eae16b74f6ecc771a9a09afa584) | `` eclipses: create minimal update.sh ``                                               |
| [`ca0c8dc6`](https://github.com/NixOS/nixpkgs/commit/ca0c8dc60891214290f5038407e88c7298740a2f) | `` shelldap: 1.4.0 -> 1.5.1 (#257777) ``                                               |
| [`3b14971f`](https://github.com/NixOS/nixpkgs/commit/3b14971fd492642ede108b9246cc8a6a1f7c7d17) | `` mps: 1.117.0 -> 1.118.0 ``                                                          |
| [`2aaf9f24`](https://github.com/NixOS/nixpkgs/commit/2aaf9f24c44207c2854e85331ee6e4a5e020032a) | `` slweb: 0.6.9 → 0.6.11 ``                                                            |
| [`152b5f5b`](https://github.com/NixOS/nixpkgs/commit/152b5f5bded3915205e10648aafcd3ef4ee3e20e) | `` git-mit: 5.12.152 -> 5.12.153 ``                                                    |
| [`d5142778`](https://github.com/NixOS/nixpkgs/commit/d5142778565a45b2f84e9fdc6eb1d814e9231361) | `` direwolf: add maintainer sarcasticadmin ``                                          |
| [`d70fb085`](https://github.com/NixOS/nixpkgs/commit/d70fb0855e76c1fd4d417c8388dd3412ef73cb39) | `` direwolf: set hamlib, gpsd, and extraScripts as optional ``                         |
| [`ba0d5f21`](https://github.com/NixOS/nixpkgs/commit/ba0d5f213bd389c0d59398a0e53a2830d2f85261) | `` direwolf: nixpkgs-fmt ``                                                            |
| [`f7cdd3d8`](https://github.com/NixOS/nixpkgs/commit/f7cdd3d804e4baa3198d157f31bf43a722b394eb) | `` ttyper: 1.2.2 -> 1.3.0 ``                                                           |
| [`67e05d18`](https://github.com/NixOS/nixpkgs/commit/67e05d189128bfc6e3ab49aa962b5bfa592ee22e) | `` mold: Add meta.mainProgram entry ``                                                 |
| [`e1a87375`](https://github.com/NixOS/nixpkgs/commit/e1a87375a7abadf7606c158eadeb509371e23177) | `` python310Packages.pyvmomi: 8.0.1.0.2 -> 8.0.2.0 ``                                  |
| [`ab7256be`](https://github.com/NixOS/nixpkgs/commit/ab7256bef3da43c06f8c78011c1c461757e269a1) | `` element-{web,desktop}: 1.11.43 -> 1.11.45 (#258020) ``                              |
| [`cc82590e`](https://github.com/NixOS/nixpkgs/commit/cc82590e008230c3fd0a4fa1636efd9b8f65d12a) | `` pycapnp: mark as broken ``                                                          |
| [`4b74bcbc`](https://github.com/NixOS/nixpkgs/commit/4b74bcbc406e3677e5f620ad675afdd71681d1b3) | `` python310Packages.pyathena: 3.0.7 -> 3.0.8 ``                                       |
| [`ed895961`](https://github.com/NixOS/nixpkgs/commit/ed895961d176b724d5d4ccd3c609a926d04c1ab9) | `` systemd: fix build on musl (#257928) ``                                             |
| [`c36da54a`](https://github.com/NixOS/nixpkgs/commit/c36da54a797b1ca0db690b29b11b1d293a730ed7) | `` python310Packages.hcloud: 1.29.0 -> 1.29.1 ``                                       |
| [`3c46dee9`](https://github.com/NixOS/nixpkgs/commit/3c46dee9eb4ae236e81eb5d86196ef28612bbdb3) | `` sgtpuzzles: 20220913 -> 20230918 ``                                                 |
| [`973afead`](https://github.com/NixOS/nixpkgs/commit/973afead498c157c1088b1104c86fd18af2fc0b3) | `` cargo-deny: 0.14.2 -> 0.14.3 ``                                                     |
| [`e0001002`](https://github.com/NixOS/nixpkgs/commit/e00010020ac94bf7dbae3806422a2fcaacf89e6e) | `` vivaldi: support for Kerberos authentication ``                                     |
| [`d8df8597`](https://github.com/NixOS/nixpkgs/commit/d8df859780df08e10c60cbcfe1655506de9dcaf7) | `` python310Packages.oci: 2.112.1 -> 2.112.2 ``                                        |
| [`3ad25700`](https://github.com/NixOS/nixpkgs/commit/3ad25700f30bed47583756ec670e5e0ab97c1bbe) | `` typst-lsp: set meta.mainProgram ``                                                  |
| [`ec119ed5`](https://github.com/NixOS/nixpkgs/commit/ec119ed57a5118ff8b0f6e7a5f5a67d32e93329a) | `` python310Packages.nextcord: 2.5.0 -> 2.6.1 ``                                       |
| [`b2005fdc`](https://github.com/NixOS/nixpkgs/commit/b2005fdc8d2269515f68b3a99c728dedac4f62d7) | `` game-rs: init at 0.1.3 ``                                                           |
| [`e42b5b74`](https://github.com/NixOS/nixpkgs/commit/e42b5b74e2e09746d05062718c10601cffb5114e) | `` maintainers: add amanse ``                                                          |
| [`e1b71e0d`](https://github.com/NixOS/nixpkgs/commit/e1b71e0d52ae2d758ef375b49c935912bf0e639d) | `` dmlive: 5.3.0 -> 5.3.1 ``                                                           |
| [`b96541c7`](https://github.com/NixOS/nixpkgs/commit/b96541c710fef92e78da3c3171bc211ceca9be63) | `` oelint-adv: init at 3.25.0 ``                                                       |
| [`87c3f38d`](https://github.com/NixOS/nixpkgs/commit/87c3f38de72c511e9630b47b7b25f93a71edd79c) | `` pythonPackages.oelint-parser: init at 2.11.3 ``                                     |
| [`327def42`](https://github.com/NixOS/nixpkgs/commit/327def423fdbc343037e44c712662eeda0e77456) | `` utahfs: remove ``                                                                   |
| [`b6963f86`](https://github.com/NixOS/nixpkgs/commit/b6963f86638f35fe1b87601ad9ad23c0fa57978b) | `` btcpayserver: 1.11.4 -> 1.11.6 ``                                                   |
| [`2a9be520`](https://github.com/NixOS/nixpkgs/commit/2a9be520a407f745637c64f1822137b644ed3e5e) | `` nbxplorer: 2.3.65 -> 2.3.66 ``                                                      |
| [`a39417a6`](https://github.com/NixOS/nixpkgs/commit/a39417a6732cc5d2db0579d4d01a7f1a4f48a408) | `` phpPackages.composer: 2.6.3 -> 2.6.4 ``                                             |
| [`341ed8af`](https://github.com/NixOS/nixpkgs/commit/341ed8af6fc3129b3f0f0c58cd885f102caff291) | `` python311Packages.aiomisc: 17.3.21 -> 17.3.23 ``                                    |
| [`eb32c482`](https://github.com/NixOS/nixpkgs/commit/eb32c482817ee2423b00483887dafd038ab9f951) | `` python310Packages.piccolo-theme: 0.17.0 -> 0.18.0 ``                                |
| [`368f9510`](https://github.com/NixOS/nixpkgs/commit/368f95104b7df5603dc08ca050a996dc1f56c8ff) | `` easycrypt: 2022.04 → 2023.09 ``                                                     |
| [`cbd17485`](https://github.com/NixOS/nixpkgs/commit/cbd1748558e8708a3931d178b8fbd8f2d10869df) | `` nixpkgs manual: add an alternative example in stdenv-separateDebugInfo (#257861) `` |
| [`ebfac7d5`](https://github.com/NixOS/nixpkgs/commit/ebfac7d56693adc64c30de4c4f41ceabc2bce062) | `` quorum: 2.5.0 -> 23.4.0 ``                                                          |
| [`20e5c9f7`](https://github.com/NixOS/nixpkgs/commit/20e5c9f7ae54d7ea7290d7a93e1e22254fe761fd) | `` treefmt: 0.5.0 -> 0.6.0 (#257815) ``                                                |
| [`cc1bc258`](https://github.com/NixOS/nixpkgs/commit/cc1bc258ceab4fc39c8ae411e630424f0d29b0cf) | `` python311Packages.py-nextbusnext: disable on unsupported Python releases ``         |
| [`55a79dcf`](https://github.com/NixOS/nixpkgs/commit/55a79dcfee38687c4f66f5575618873b90fad9a7) | `` python311Packages.py-nextbusnext: 0.1.5 -> 1.0.0 ``                                 |
| [`f5baf924`](https://github.com/NixOS/nixpkgs/commit/f5baf9242c0e101e403e836b6eefa9f026fb0a2d) | `` gh-screensaver: init at 2.0.1 ``                                                    |
| [`15c7030b`](https://github.com/NixOS/nixpkgs/commit/15c7030b5a65cffea9370293f1c635d46a7fec94) | `` guile-semver: init at 0.1.1 ``                                                      |
| [`259512e6`](https://github.com/NixOS/nixpkgs/commit/259512e64aac4301cb412feda51a72a7d6c200ad) | `` guile-zlib: init at 0.1.0 ``                                                        |
| [`bce49cd4`](https://github.com/NixOS/nixpkgs/commit/bce49cd4c0a12ca946df0563b30b9149d026be83) | `` guile-lzma: init at 0.1.1 ``                                                        |
| [`35220987`](https://github.com/NixOS/nixpkgs/commit/3522098710277f92a60000ef5f6443b84df57561) | `` guile-avahi: fix build on darwin ``                                                 |
| [`cef731a6`](https://github.com/NixOS/nixpkgs/commit/cef731a640b1293fcc1fa7209fdb497a0767e2b4) | `` guile-avahi: init at 0.4.1 ``                                                       |
| [`c6367070`](https://github.com/NixOS/nixpkgs/commit/c6367070a1d2d1ee6888f2dd006bb469a371478b) | `` python311Packages.plexapi: 4.15.1 -> 4.15.3 ``                                      |
| [`acc74f93`](https://github.com/NixOS/nixpkgs/commit/acc74f930f0c0ff0033f004adfd8c6692a8dd55e) | `` uiua: add darwin support ``                                                         |
| [`782af557`](https://github.com/NixOS/nixpkgs/commit/782af557b635e9a90c6f82dd96ffa474d47942e4) | `` uiua: init at unstable-2023-09-28 ``                                                |
| [`46447031`](https://github.com/NixOS/nixpkgs/commit/464470318a98d60da676bc264b731f5de7b9453c) | `` python311Packages.json-schema-for-humans: 0.45.2 -> 0.46 ``                         |
| [`e17ddf9f`](https://github.com/NixOS/nixpkgs/commit/e17ddf9fbcbf2aab4c6977b11c51d668cd4bf33e) | `` vivaldi: 6.2.3105.48 -> 6.2.3105.54 ``                                              |
| [`133b5d23`](https://github.com/NixOS/nixpkgs/commit/133b5d2343e03c900fa22fba9ab69df3bd4783a1) | `` teams: remove (linux) ``                                                            |
| [`a13482af`](https://github.com/NixOS/nixpkgs/commit/a13482af3dd0b6ea81463ea43b19e092e76351fc) | `` firefox-bin: use patchelfUnstable with --no-clobber-old-sections ``                 |
| [`8ea58e0a`](https://github.com/NixOS/nixpkgs/commit/8ea58e0ab186f86a9565226ef76c6137f66547ea) | `` moar: 1.16.2 -> 1.17.0 ``                                                           |
| [`88fc33d3`](https://github.com/NixOS/nixpkgs/commit/88fc33d348bbd400aa30ad9ef15e771697acfbcf) | `` nvidia-{docker,podman}: use buildGoModule ``                                        |
| [`db63f935`](https://github.com/NixOS/nixpkgs/commit/db63f9358fdcf7faa52f2bcf08b11aa7cb420b78) | `` eza: use by-name ``                                                                 |
| [`1d7ac8ab`](https://github.com/NixOS/nixpkgs/commit/1d7ac8ab85301cae222d46ac7ad33d9c6cc19083) | `` patchelfUnstable: unstable-2023-09-19 -> unstable-2023-09-27 ``                     |
| [`4f5b49c7`](https://github.com/NixOS/nixpkgs/commit/4f5b49c7e4aebc98538547a7a04b32eefff50784) | `` mangohud: make lowerBitnessSupport use isx86_64 instead of is64bit ``               |
| [`82aaf637`](https://github.com/NixOS/nixpkgs/commit/82aaf63703b1d875a97a0271f7516fa5028bbce2) | `` alt-ergo: 2.4.3 → 2.5.1 ``                                                          |
| [`d0829e58`](https://github.com/NixOS/nixpkgs/commit/d0829e587e66221a423a3cf261a9d81151c03caa) | `` nodejs_20: 20.7.0 -> 20.8.0 ``                                                      |
| [`0d7a1fd3`](https://github.com/NixOS/nixpkgs/commit/0d7a1fd3fd3fae491a8f4677831db566fd8033e6) | `` controku: init at 1.1.0 ``                                                          |
| [`2aa55c67`](https://github.com/NixOS/nixpkgs/commit/2aa55c67567c3952d3217dfcc5428b8544b018fc) | `` ssdpy: init at 0.4.1 ``                                                             |
| [`7c9bf7cb`](https://github.com/NixOS/nixpkgs/commit/7c9bf7cb9b4f787f597b0267ba66cc16a3b1df9c) | `` maintainers: add mjm ``                                                             |
| [`e098f1c1`](https://github.com/NixOS/nixpkgs/commit/e098f1c1b59c45271a75c77be3f2ffe8b530cded) | `` wireplumber: use lib.meson* functions ``                                            |
| [`8681edfa`](https://github.com/NixOS/nixpkgs/commit/8681edfaa7b89032858eb96111b619d92d07fea2) | `` platinum-searcher: use buildGoModule ``                                             |
| [`c130b9b1`](https://github.com/NixOS/nixpkgs/commit/c130b9b122c6ed19a0f7cad8de35875c30a4f9ed) | `` python310Packages.django-sesame: 3.1 -> 3.2.1 ``                                    |
| [`a17537a1`](https://github.com/NixOS/nixpkgs/commit/a17537a16a95f8f1d21a225dba64c51fdba04c37) | `` python310Packages.ua-parser: 0.16.1 -> 0.18.0 ``                                    |
| [`025ca8a3`](https://github.com/NixOS/nixpkgs/commit/025ca8a3e1561a0b482082d4e06f9b7386923880) | `` firefox-beta-bin-unwrapped: 118.0b9 -> 119.0b2 ``                                   |
| [`d92d9f76`](https://github.com/NixOS/nixpkgs/commit/d92d9f76e11443b9713aae8d22fddc2ae1d5aa8e) | `` firefox-bin-unwrapped: 118.0 -> 118.0.1 ``                                          |
| [`b916623e`](https://github.com/NixOS/nixpkgs/commit/b916623e55dd0547b2f1b783b5d74af6bc08988a) | `` firefox-esr-115-unwrapped: 115.3.0esr -> 115.3.1esr ``                              |
| [`61b404d2`](https://github.com/NixOS/nixpkgs/commit/61b404d2638b06cf0649151ab119f0075710780b) | `` firefox-unwrapped: 118.0 -> 118.0.1 ``                                              |
| [`de0efefe`](https://github.com/NixOS/nixpkgs/commit/de0efefeb1797782a0c4e47af1981a8dae97a4c5) | `` cargo-binstall: 1.4.1 -> 1.4.2 ``                                                   |
| [`54b7559f`](https://github.com/NixOS/nixpkgs/commit/54b7559f87d36dab4aafa7fa93ef3198e2af357e) | `` libvpx: Fix heap buffer overflow in vp8 encoder ``                                  |
| [`b18d2a9a`](https://github.com/NixOS/nixpkgs/commit/b18d2a9aef15012767c1d7616b6e5f2a8100bd19) | `` cargo-dist: 0.3.0 -> 0.3.1 ``                                                       |
| [`cafcbb18`](https://github.com/NixOS/nixpkgs/commit/cafcbb1873ed6f46c11760db498973046286d7fd) | `` orogene: 0.3.27 -> 0.3.31 ``                                                        |
| [`06582285`](https://github.com/NixOS/nixpkgs/commit/065822853270944bfc313d7ea678fea36ab345f3) | `` python310Packages.sqlparse: fix eval w/o aliases ``                                 |
| [`81becd3c`](https://github.com/NixOS/nixpkgs/commit/81becd3c441771c9c85ec983ba73b4ec3174b56a) | `` nixos/lib/test-driver: reduce spam at boot hangs ``                                 |
| [`4378713c`](https://github.com/NixOS/nixpkgs/commit/4378713c466a4f1546752475040e113daf148a8b) | `` boohu: 0.13.0 -> 0.14.0 ``                                                          |
| [`f65ef7ff`](https://github.com/NixOS/nixpkgs/commit/f65ef7fff4ba4b60f076eb0f4e9877f97283a93a) | `` alsa-utils: 1.2.9 -> 1.2.10 ``                                                      |
| [`43bad2a8`](https://github.com/NixOS/nixpkgs/commit/43bad2a81976d09c22f605a91512e208ba82164c) | `` colorized-logs: init at 2.6 ``                                                      |
| [`12cb2f57`](https://github.com/NixOS/nixpkgs/commit/12cb2f573a8c0bf38b4f8da6eb32a66bfc43791f) | `` yabasic: 2.90.3 -> 2.90.4 ``                                                        |
| [`67b39e72`](https://github.com/NixOS/nixpkgs/commit/67b39e72c6b1de650bd2233786b39d61814832fa) | `` pscale: 0.155.0 -> 0.156.0 ``                                                       |
| [`8c4e6ab1`](https://github.com/NixOS/nixpkgs/commit/8c4e6ab1436118816334c89f3fcc34b290e44c27) | `` doomretro: 4.9.2 -> 5.0.3 ``                                                        |
| [`729852cd`](https://github.com/NixOS/nixpkgs/commit/729852cd12724c7fa6c1f8427a2111b5680d1eba) | `` syft: 0.91.0 -> 0.92.0 ``                                                           |
| [`d171f5dc`](https://github.com/NixOS/nixpkgs/commit/d171f5dc90356ac508e3681a748d1dcbce172257) | `` terragrunt: 0.50.16 -> 0.51.0 ``                                                    |
| [`87c64a21`](https://github.com/NixOS/nixpkgs/commit/87c64a21e403fca4332cea4365aac9afc6045696) | `` python3Packages.sqlparse: add some key reverse-dependencies to passthru.tests ``    |
| [`e1e6ce78`](https://github.com/NixOS/nixpkgs/commit/e1e6ce7877c4077621c6a25c2ce5c8ad14aa727a) | `` erigon: 2.48.1 -> 2.50.0 ``                                                         |
| [`dce4dd93`](https://github.com/NixOS/nixpkgs/commit/dce4dd939a6b971f185d125d148056e756290e65) | `` python311Packages.azure-mgmt-compute: 30.2.0 -> 30.3.0 ``                           |
| [`0c4a07bf`](https://github.com/NixOS/nixpkgs/commit/0c4a07bf9f3cc6438c0c5e00dd6d6055bd65e0bf) | `` blender: enable path guiding support ``                                             |
| [`b1460e25`](https://github.com/NixOS/nixpkgs/commit/b1460e25c5f967fe886849d560b11d406b8f0dcc) | `` openpgl: init at 0.5.0 ``                                                           |
| [`ecdfebba`](https://github.com/NixOS/nixpkgs/commit/ecdfebba19ba2cb365bb03d8fc09f5547f3167d0) | `` librewolf-unwrapped: 117.0.1-1 -> 118.0.1-1 ``                                      |
| [`f72c9d48`](https://github.com/NixOS/nixpkgs/commit/f72c9d488b76ce2d0b62dcd9c14e96eddcf5d332) | `` pat: add maintainer sarcasticadmin ``                                               |
| [`4be0eae9`](https://github.com/NixOS/nixpkgs/commit/4be0eae955e545485fd59142e5ad3fc850341c49) | `` pat: support libax25 ``                                                             |
| [`5b9cdda1`](https://github.com/NixOS/nixpkgs/commit/5b9cdda1c2ae43315574bbe9950470be9911b0cd) | `` nixos/nano: add enable, package option, do not create /etc/nanorc by default ``     |
| [`b2073789`](https://github.com/NixOS/nixpkgs/commit/b20737893a29bcc1bbf80370be61c37f18de9796) | `` python311Packages.oss2: 2.18.1 -> 2.18.2 ``                                         |
| [`11c0c188`](https://github.com/NixOS/nixpkgs/commit/11c0c188d7b130e5d81dc6a9ad03b695e79ddc24) | `` python311Packages.botocore-stubs: 1.31.56 -> 1.31.57 ``                             |
| [`312da242`](https://github.com/NixOS/nixpkgs/commit/312da242aaf37cd190d0ee11287b37aace48743d) | `` python311Packages.garth: 0.4.29 -> 0.4.31 ``                                        |
| [`42bee1ae`](https://github.com/NixOS/nixpkgs/commit/42bee1ae245e8ad87d2da5ca3392312f943ca803) | `` python311Packages.python-fx: 0.3.0 -> 0.3.1 ``                                      |
| [`3ff5a0c8`](https://github.com/NixOS/nixpkgs/commit/3ff5a0c8647adb9dc8a42e52b8761b7862569913) | `` python311Packages.opower: 0.0.34 -> 0.0.35 ``                                       |
| [`bd00dac6`](https://github.com/NixOS/nixpkgs/commit/bd00dac6b49a6fb6e63a7e5db58766d4c04da8db) | `` checkov: 2.4.51 -> 2.4.55 ``                                                        |
| [`1da4d864`](https://github.com/NixOS/nixpkgs/commit/1da4d864dd6d8dbab34911ba71167652b35fa264) | `` tlsx: 1.1.4 -> 1.1.5 ``                                                             |
| [`f542fae8`](https://github.com/NixOS/nixpkgs/commit/f542fae87f8f793fe1825347737f0d488ac07cc3) | `` python311Packages.neo4j: 5.12.0 -> 5.13.0 ``                                        |
| [`6fcb7618`](https://github.com/NixOS/nixpkgs/commit/6fcb761837ad94c0539da8d302fdf1f574eaa6f2) | `` python311Packages.griffe: 0.36.2 -> 0.36.4 ``                                       |
| [`fb96078a`](https://github.com/NixOS/nixpkgs/commit/fb96078a8182ed0148cbf4a23a469b82f6b41993) | `` python311Packages.dvc-data: 2.16.4 -> 2.17.1 ``                                     |
| [`43ddd6cd`](https://github.com/NixOS/nixpkgs/commit/43ddd6cd9b301af71054b55668ef3e6431280213) | `` python311Packages.boschshcpy: 0.2.68 -> 0.2.69 ``                                   |
| [`f2b35b76`](https://github.com/NixOS/nixpkgs/commit/f2b35b7625a83c5f7987ae424223665af1570565) | `` cargo-i18n: fix build on darwin ``                                                  |
| [`ef3e6b6e`](https://github.com/NixOS/nixpkgs/commit/ef3e6b6e877b1c8016ad1d7422216aa5ac364da6) | `` tomcat-native: 1.2.31 -> 2.0.5 ``                                                   |
| [`e5141783`](https://github.com/NixOS/nixpkgs/commit/e514178339da1b3bfb32d48c192bbc3dfffc6bd1) | `` nixos/virtualisation: use mkDefault in networking.useNetworkd in oci-common ``      |
| [`e6cad8da`](https://github.com/NixOS/nixpkgs/commit/e6cad8da445ddab1b54a982774641866bd33ab90) | `` cargo-i18n: init at 0.2.12 ``                                                       |
| [`e93279e0`](https://github.com/NixOS/nixpkgs/commit/e93279e0fc5570299067a4fab44e81b52c209a34) | `` gopls: explicitly set mainProgram ``                                                |
| [`8004b0ed`](https://github.com/NixOS/nixpkgs/commit/8004b0ed17eabf2dc8541e271a2a77136070a8ab) | `` scaphandre: cleanup ``                                                              |
| [`27c60c8b`](https://github.com/NixOS/nixpkgs/commit/27c60c8b3784735e662261b67a1cedadfd5086a6) | `` slurm-nm: cleanup ``                                                                |
| [`cc3c0655`](https://github.com/NixOS/nixpkgs/commit/cc3c06554b0bcf77e073a4debf16f2a9e50f2132) | `` delta: explicitly set mainProgram ``                                                |
| [`717da270`](https://github.com/NixOS/nixpkgs/commit/717da2702aaf44e3503d5a86fe13d1497e58c1b3) | `` librist: 0.2.7 -> 0.2.8 ``                                                          |
| [`300a6fda`](https://github.com/NixOS/nixpkgs/commit/300a6fda7724be412f55c286cd209bb6b0301ac3) | `` mastodon: apply suggestion ``                                                       |
| [`591d32cd`](https://github.com/NixOS/nixpkgs/commit/591d32cdb14b34e4a4bf5b5bbff3ddc96aadbfb0) | `` mastodon: reduce the amount of files information is spread across ``                |