### PR TITLE
chore(flake/pre-commit-hooks): `cb770e93` -> `033453f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -438,11 +438,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1695576016,
-        "narHash": "sha256-71KxwRhTfVuh7kNrg3/edNjYVg9DCyKZl2QIKbhRggg=",
+        "lastModified": 1696158581,
+        "narHash": "sha256-h0vY4E7Lx95lpYQbG2w4QH4yG5wCYOvPJzK93wVQbT0=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "cb770e93516a1609652fa8e945a0f310e98f10c0",
+        "rev": "033453f85064ccac434dfd957f95d8457901ecd6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                      |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------- |
| [`d67283c4`](https://github.com/cachix/pre-commit-hooks.nix/commit/d67283c4d985d69a7cf421e5956d3bc87f6ab3ce) | `` Add support for eclint `` |