### PR TITLE
chore(flake/base16-schemes): `876ed8cf` -> `a9112eaa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
     "base16-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1695567727,
-        "narHash": "sha256-bY/k0BU7GFvzkZzL2Fuc0rtm/1HVl1bAHB/vO6+O2HQ=",
+        "lastModified": 1696158499,
+        "narHash": "sha256-5yIHgDTPjoX/3oDEfLSQ0eJZdFL1SaCfb9d6M0RmOTM=",
         "owner": "tinted-theming",
         "repo": "base16-schemes",
-        "rev": "876ed8cf1e27354027ccf140b045132b67452378",
+        "rev": "a9112eaae86d9dd8ee6bb9445b664fba2f94037a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                              |
| -------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`a9112eaa`](https://github.com/tinted-theming/base16-schemes/commit/a9112eaae86d9dd8ee6bb9445b664fba2f94037a) | `` Add everforest dark hard (#35) `` |
| [`4fa3a1b6`](https://github.com/tinted-theming/base16-schemes/commit/4fa3a1b6b40a2dc441935369f7295fa957a89238) | `` Add Oxocarbon (#34) ``            |