### PR TITLE
chore(flake/flake-compat): `2bf43d60` -> `4f910c98`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696255748,
-        "narHash": "sha256-Xi/24LAaUA+EAWv6Iu8DN9KU+SoSLPXcqnaFVbTaRQA=",
+        "lastModified": 1696267196,
+        "narHash": "sha256-AAQ/2sD+0D18bb8hKuEEVpHUYD1GmO2Uh/taFamn6XQ=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "2bf43d60c7596e26d6f56dde17a466b158a6abb4",
+        "rev": "4f910c9827911b1ec2bf26b5a062cd09f8d89f85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                           |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`4f910c98`](https://github.com/edolstra/flake-compat/commit/4f910c9827911b1ec2bf26b5a062cd09f8d89f85) | `` Doh ``                                         |
| [`7ae5ae62`](https://github.com/edolstra/flake-compat/commit/7ae5ae625a69a4c160e7f5e975e8d5c06a7aee92) | `` Drop "flake = false" and suggest flakehub ``   |
| [`bc5e257a`](https://github.com/edolstra/flake-compat/commit/bc5e257a8d0c4df04652ecff9053d05b0dc9484e) | `` nix#7796: Ensure that `self.outPath == ./.` `` |