### PR TITLE
chore(flake/darwin): `792c2e01` -> `8b6ea26d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -100,11 +100,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696043447,
-        "narHash": "sha256-VbJ1dY5pVH2fX1bS+cT2+4+BYEk4lMHRP0+udu9G6tk=",
+        "lastModified": 1696360011,
+        "narHash": "sha256-HpPv27qMuPou4acXcZ8Klm7Zt0Elv9dgDvSJaomWb9Y=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "792c2e01347cb1b2e7ec84a1ef73453ca86537d8",
+        "rev": "8b6ea26d5d2e8359d06278364f41fbc4b903b28a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                         |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`3d65d139`](https://github.com/LnL7/nix-darwin/commit/3d65d1397403132bf95e8079074141f3d0ab7e37) | `` expose _module attr in realised sysconfig `` |