### PR TITLE
chore(flake/lanzaboote): `8154cef1` -> `bccf7738`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -285,11 +285,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1696021232,
-        "narHash": "sha256-YtbcN4I5S85XRdYFnORCJfbd5z6l8uVp8r3wI48vPs0=",
+        "lastModified": 1696363578,
+        "narHash": "sha256-a/HIEEG0EGAvqnfN+QPEXshgYPQBeGuLkMq6FZtD7uw=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "8154cef11cdde65a7a1f75319c95dfe038b2df46",
+        "rev": "bccf7738d5be1d43e169b016003cd946b03f8f66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                       |
| --------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`7b4d1250`](https://github.com/nix-community/lanzaboote/commit/7b4d1250b7cc1db7e7014f2ec6e206ab07e6c1f4) | `` docs: Add troubleshooting documentation `` |