### PR TITLE
chore(flake/nixpkgs): `f5892dda` -> `fdd898f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -377,11 +377,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696019113,
-        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "lastModified": 1696193975,
+        "narHash": "sha256-mnQjUcYgp9Guu3RNVAB2Srr1TqKcPpRXmJf4LJk6KRY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "rev": "fdd898f8f79e8d2f99ed2ab6b3751811ef683242",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`ba7d3435`](https://github.com/NixOS/nixpkgs/commit/ba7d34357137e50a2c5f32b8f05b4c96c9bd4942) | `` gitignore: add .nixos-test-history produced by test driver (#258456) `` |
| [`404d4db3`](https://github.com/NixOS/nixpkgs/commit/404d4db375715bce999ae4084c55873427e63022) | `` docs: clarify maintainer name format ``                                 |
| [`3e9edb76`](https://github.com/NixOS/nixpkgs/commit/3e9edb76cff800c8ce9a3b7bd076af2fd3ad6c93) | `` fastcdr: init at 1.1.1 ``                                               |
| [`f4599fea`](https://github.com/NixOS/nixpkgs/commit/f4599feae4160285c5ce4e4364bd147df83e780c) | `` gnucash: 5.3 -> 5.4 ``                                                  |
| [`70068d17`](https://github.com/NixOS/nixpkgs/commit/70068d171eff8f2be97073c68c391b7ec92aed22) | `` pkgsStatic.valgrind: mark unsupported ``                                |
| [`4d7239c2`](https://github.com/NixOS/nixpkgs/commit/4d7239c20e49ec123ec201263a1afa0af4b0830e) | `` electron-source: version updates for CVE-2023-5217 (#258459) ``         |
| [`15cace14`](https://github.com/NixOS/nixpkgs/commit/15cace145e9bcc687379b493f51fcd5b75aaa73c) | `` shopware-cli: 0.2.8 -> 0.3.4 ``                                         |
| [`4d4cd30a`](https://github.com/NixOS/nixpkgs/commit/4d4cd30a2ea2a271bbcbd3d1c577b33534202651) | `` php82Extensions.blackfire: 1.89.0 -> 1.90.0 ``                          |
| [`a1a26d01`](https://github.com/NixOS/nixpkgs/commit/a1a26d01859800c09192f71d6c243c652c510abe) | `` opensearch: 2.9.0 -> 2.10.0 ``                                          |
| [`755f8a3d`](https://github.com/NixOS/nixpkgs/commit/755f8a3ddb90886fa966373d15922025e63c2f8f) | `` python311Packages.aioesphomeapi: 17.0.0 -> 17.0.1 ``                    |
| [`4cb52f9c`](https://github.com/NixOS/nixpkgs/commit/4cb52f9cdcf266aa71a1814eb9ea246df98923be) | `` i3status: set `meta.mainProgram` ``                                     |
| [`940516df`](https://github.com/NixOS/nixpkgs/commit/940516dfa53fb09797910129c910c726593dea03) | `` php82Extensions.redis: 5.3.7 -> 6.0.1 ``                                |
| [`e53c99eb`](https://github.com/NixOS/nixpkgs/commit/e53c99eb17265d7000d95db909cd1494618deefa) | `` treewide: use `pkgs.config` instead of `config.nixpkgs.config` ``       |
| [`3590470f`](https://github.com/NixOS/nixpkgs/commit/3590470fef786cd92dde2b65b0189e770dab4e64) | `` djgpp: Add darwin support ``                                            |
| [`7c139daa`](https://github.com/NixOS/nixpkgs/commit/7c139daa07566f52947e242d1513d547f3d15d50) | `` speexdsp: add withFftw3 flag ``                                         |
| [`44ae97bf`](https://github.com/NixOS/nixpkgs/commit/44ae97bf7ddc8a3864deaadd3917a3658113ba79) | `` lunatask: 1.7.5 -> 1.7.6 ``                                             |
| [`505cde4d`](https://github.com/NixOS/nixpkgs/commit/505cde4d198cb363b781d28b358983615725605d) | `` thunderbird-bin: 115.3.0 -> 115.3.1 ``                                  |
| [`0ea03f13`](https://github.com/NixOS/nixpkgs/commit/0ea03f139c5ab4abd5fd96723ecb1735d0c99aae) | `` python3Packages.wikipedia-api: init at 0.6.0 ``                         |
| [`187496d9`](https://github.com/NixOS/nixpkgs/commit/187496d97f234dd1e91de1366788f5373172b62d) | `` python3Packages.treelib: init at 1.7.0 ``                               |
| [`62fe6266`](https://github.com/NixOS/nixpkgs/commit/62fe6266e69fe072b9425eef8c831999578b44e7) | `` Revert "nixVersions.unstable: 2.17 -> 2.18" ``                          |
| [`09fed847`](https://github.com/NixOS/nixpkgs/commit/09fed847aa87f4ea39efcfc545ca736ca9a20659) | `` pkgsStatic.pulseaudio: mark unsupported ``                              |
| [`607cf64e`](https://github.com/NixOS/nixpkgs/commit/607cf64e8218fc8dad270b3e8ededdea92b127b0) | `` python311Packages.denonavr: 0.11.3 -> 0.11.4 ``                         |
| [`98d623ff`](https://github.com/NixOS/nixpkgs/commit/98d623ff2ee7527a32b76bfd337f9cbd0ab7548a) | `` python311Packages.bellows: 0.36.4 -> 0.36.5 ``                          |
| [`318a07ad`](https://github.com/NixOS/nixpkgs/commit/318a07adf874d4472ee385089fb02c5912ba2f26) | `` clojure: improve updateScript error behavior ``                         |
| [`3a50c2da`](https://github.com/NixOS/nixpkgs/commit/3a50c2dac5d0edd8b1e3be5894217db793a7a7a3) | `` yabai: 5.0.8 -> 5.0.9 ``                                                |
| [`b0449a7f`](https://github.com/NixOS/nixpkgs/commit/b0449a7fe7f943c391d5366d33ec313baa7eb6db) | `` python311Packages.pyswitchbot: 0.40.0 -> 0.40.1 ``                      |
| [`5538abc0`](https://github.com/NixOS/nixpkgs/commit/5538abc07209f6d4279a244598de13ff29943ab8) | `` python311Packages.mkdocstrings-python: 1.7.0 -> 1.7.1 ``                |
| [`ac81a7bf`](https://github.com/NixOS/nixpkgs/commit/ac81a7bfea14622a49d8ebd78233d56e4bda9da9) | `` reindeer: unstable-2023-09-16 -> unstable-2023-09-20 ``                 |
| [`1103de10`](https://github.com/NixOS/nixpkgs/commit/1103de10d24215ca46bc588ebe5d76795a23e6fb) | `` python311Packages.identify: 2.5.29 -> 2.5.30 ``                         |
| [`a183e545`](https://github.com/NixOS/nixpkgs/commit/a183e54599516e3f3273a7ede7e331d3ae098954) | `` buck2: unstable-2023-09-15 -> unstable-2023-10-01 ``                    |
| [`80f41b4b`](https://github.com/NixOS/nixpkgs/commit/80f41b4ba0a6307ed3c5c4209766b6bef7df54b6) | `` complgen: 0.1.4 -> 0.1.5 ``                                             |
| [`8f7d856f`](https://github.com/NixOS/nixpkgs/commit/8f7d856f16c5bbc5f94f429f5cf0baadf61d0de5) | `` spicedb-zed: 0.12.1 -> 0.14.0 ``                                        |
| [`4158c91f`](https://github.com/NixOS/nixpkgs/commit/4158c91f7be7af1c1ffecaca08282c1562c844cc) | `` linux_xanmod: add zzzsy as maintainer ``                                |
| [`b9f40ea9`](https://github.com/NixOS/nixpkgs/commit/b9f40ea9c8b0cde5099c510acbce60497dc1593e) | `` qtcreator: 11.0.2 -> 11.0.3 ``                                          |
| [`5d861cc1`](https://github.com/NixOS/nixpkgs/commit/5d861cc17287f5a23483ead730f82d422cc1a98c) | `` ppsspp-qt: 1.16.2 -> 1.16.5 ``                                          |
| [`752027a4`](https://github.com/NixOS/nixpkgs/commit/752027a450eb17c59b152875c08f77a9169e6ef8) | `` fvwm3: 1.0.7 -> 1.0.8 ``                                                |
| [`225a6b08`](https://github.com/NixOS/nixpkgs/commit/225a6b08ccfbcd44e4cc7bd08706d3af16bf24d1) | `` cgreen: 1.6.2 -> 1.6.3 ``                                               |
| [`fb679281`](https://github.com/NixOS/nixpkgs/commit/fb67928155e15bfdf657aa20314c71746c1811b2) | `` python310Packages.rapidfuzz: make `numpy` optional ``                   |
| [`86accb0f`](https://github.com/NixOS/nixpkgs/commit/86accb0fea519a513703a45d2281256ddf786e4b) | `` nwg-dock-hyprland: 0.1.6 -> 0.1.7 ``                                    |
| [`e96528be`](https://github.com/NixOS/nixpkgs/commit/e96528be838948f06eb767abdc289769a315a236) | `` kubecfg: 0.33.0 -> 0.34.0 ``                                            |
| [`edbf15cd`](https://github.com/NixOS/nixpkgs/commit/edbf15cd9d22f69a48857af9731c2c91c002b8c2) | `` steamguard-cli: 0.12.1 -> 0.12.2 ``                                     |
| [`b2f9a712`](https://github.com/NixOS/nixpkgs/commit/b2f9a7122421aea7c2497893951503bb5096f8ff) | `` goreleaser: 1.21.1 -> 1.21.2 ``                                         |
| [`3fecaf71`](https://github.com/NixOS/nixpkgs/commit/3fecaf7177b057adfb437ac0deb5861644e04641) | `` limesctl: 3.2.0 -> 3.2.1 ``                                             |
| [`ae3ea8c1`](https://github.com/NixOS/nixpkgs/commit/ae3ea8c12ab192e7942e0fea82c4aa2306c2ab9e) | `` or-tools: fix string_view compilation issue (#258332) ``                |
| [`c4c40cea`](https://github.com/NixOS/nixpkgs/commit/c4c40cea8a395609209d563535b493aace2a7fc7) | `` structorizer: 3.32-11 → 3.32-12 ``                                      |
| [`ad026a9d`](https://github.com/NixOS/nixpkgs/commit/ad026a9d4e850fef0003e913aedeb7509c305c22) | `` arjun: init at 2.2.1 ``                                                 |
| [`c890002d`](https://github.com/NixOS/nixpkgs/commit/c890002d685325f96274dc753ffb59154911805f) | `` python311Packages.walrus: disable on unsupported Python releases ``     |
| [`5587474b`](https://github.com/NixOS/nixpkgs/commit/5587474b0930cb39e8127afbdcde0f92a1b851da) | `` python311Packages.pycatch22: use new parameter ``                       |
| [`182d3818`](https://github.com/NixOS/nixpkgs/commit/182d3818309cee0a4cc512a0946727667baa1940) | `` awsbck: 0.3.4 -> 0.3.5 ``                                               |
| [`1231c764`](https://github.com/NixOS/nixpkgs/commit/1231c76417b709f177b93d50bc6da825babc539b) | `` phpPackages.composer: use `fetchgit` ``                                 |
| [`fc1e2847`](https://github.com/NixOS/nixpkgs/commit/fc1e28475117051a06fdc98faa86738cdb57dd12) | `` python311Packages.setuptools-odoo: 3.2.0 -> 3.2.1 ``                    |
| [`113566d0`](https://github.com/NixOS/nixpkgs/commit/113566d06d0519619ef39123b0a534bffcfc1442) | `` python310Packages.setuptools-odoo: clean-up ``                          |
| [`636f8ab8`](https://github.com/NixOS/nixpkgs/commit/636f8ab84120632a05dbba4a32159be24f2ade08) | `` raspberrypi-eeprom: add awk to wrapper ``                               |
| [`bc9bca19`](https://github.com/NixOS/nixpkgs/commit/bc9bca1905fbe9c6e1b0a8123ee8e924638aaa30) | `` python310Packages.radish-bdd: update meta ``                            |
| [`9cfc707b`](https://github.com/NixOS/nixpkgs/commit/9cfc707b162117b806f742fc6e38f3385d7c0322) | `` python311Packages.types-requests: 2.31.0.6 -> 2.31.0.7 ``               |
| [`0396a7bd`](https://github.com/NixOS/nixpkgs/commit/0396a7bd337459eec1e704e9ee8ffcbf359f25b8) | `` python311Packages.millheater: 0.11.5 -> 0.11.6 ``                       |
| [`3320d3bc`](https://github.com/NixOS/nixpkgs/commit/3320d3bcf4e39f15966f2aeef0ae288ab46a2fc8) | `` python311Packages.garth: 0.4.33 -> 0.4.34 ``                            |
| [`80e68045`](https://github.com/NixOS/nixpkgs/commit/80e68045d9d0481b7c0c632555152fff5248b72f) | `` nwg-dock: 0.3.7 -> 0.3.9 ``                                             |
| [`ec913b78`](https://github.com/NixOS/nixpkgs/commit/ec913b7895eb47299f9bd50fecb17a05fba087f5) | `` python310Packages.python-utils: 3.7.0 -> 3.8.1 ``                       |
| [`d82f947a`](https://github.com/NixOS/nixpkgs/commit/d82f947afbfe1959ffc91a06ad117e54eeb554b4) | `` godns: 2.9.9 -> 3.0.1 ``                                                |
| [`9ded3efc`](https://github.com/NixOS/nixpkgs/commit/9ded3efcb75f8c52ebfe91788a1673823f95c456) | `` sdrangel: 7.15.4 -> 7.16.0 ``                                           |
| [`e5eccc60`](https://github.com/NixOS/nixpkgs/commit/e5eccc6074117310456663abb1846a3797d183f5) | `` infamousPlugins: 0.3.0 -> 0.3.2 ``                                      |
| [`41cdf35c`](https://github.com/NixOS/nixpkgs/commit/41cdf35c23d2fcb7e16c089075807c7cc79ac195) | `` python310Packages.pymyq: 3.1.9 -> 3.1.10 ``                             |
| [`dd8af63f`](https://github.com/NixOS/nixpkgs/commit/dd8af63ff7683947008161126020971ddc5091d6) | `` op-geth: 1.101200.0 -> 1.101200.1 ``                                    |
| [`4c5fde1c`](https://github.com/NixOS/nixpkgs/commit/4c5fde1c6aec17ea257549e5f247c9c1609dfe67) | `` step-ca: 0.24.2 -> 0.25.0 ``                                            |
| [`f75342f2`](https://github.com/NixOS/nixpkgs/commit/f75342f2d9fa0dd69e10d08ecc332db2ea8eb2c2) | `` zsv: 0.3.7-alpha -> 0.3.8-alpha ``                                      |
| [`7ea0a17b`](https://github.com/NixOS/nixpkgs/commit/7ea0a17b9a9c3c52d350720b3922c859a7b11d85) | `` buildpack: 0.30.0 -> 0.31.0 ``                                          |
| [`a26f11d2`](https://github.com/NixOS/nixpkgs/commit/a26f11d23647cfd96ddb773ab896dbfa6027399a) | `` dufs: install completions ``                                            |
| [`e37f793f`](https://github.com/NixOS/nixpkgs/commit/e37f793f662c63281b96128900552c39c9a379df) | `` linuxKernel.kernels.linux_lqx: 6.5.5-lqx1 -> 6.5.5-lqx2 ``              |
| [`1ab80641`](https://github.com/NixOS/nixpkgs/commit/1ab8064141165c8fb55369715b0219463e411bad) | `` tor: 0.4.8.6 -> 0.4.8.7 ``                                              |
| [`e6991dae`](https://github.com/NixOS/nixpkgs/commit/e6991dae5e4f0ec97edeff0ead584c7060c375ac) | `` python310Packages.srsly: 2.4.7 -> 2.4.8 ``                              |
| [`59ecfbd8`](https://github.com/NixOS/nixpkgs/commit/59ecfbd8196a7391552c42145d7efafa37f324b7) | `` terramate: 0.4.1 -> 0.4.2 ``                                            |
| [`f0f8b8a5`](https://github.com/NixOS/nixpkgs/commit/f0f8b8a5e0a990d826b27e315d4077b609c63f32) | `` go-ios: 1.0.115 -> 1.0.117 ``                                           |
| [`6d94fa46`](https://github.com/NixOS/nixpkgs/commit/6d94fa46cd6c3d80939dc76636d3d13c45ad0de8) | `` jumppad: 0.5.38 -> 0.5.51 ``                                            |
| [`4d93f6e3`](https://github.com/NixOS/nixpkgs/commit/4d93f6e3a3bd6ea02b6dc4a075b49e6b3c39b6df) | `` wireguard-exporter: fix static build ``                                 |
| [`2814ef24`](https://github.com/NixOS/nixpkgs/commit/2814ef246f3aefb666bb4b029a53abee8630b8d5) | `` protobuf3_19: remove ``                                                 |
| [`ce1c2ac4`](https://github.com/NixOS/nixpkgs/commit/ce1c2ac4cbe4f9e5393f6a641205c2a1d74f8aa4) | `` edk2: fix build on x86_64-darwin ``                                     |
| [`8a28376b`](https://github.com/NixOS/nixpkgs/commit/8a28376b6952e8111f1ced9732aab2a53ff33416) | `` flow: 0.217.0 -> 0.217.2 ``                                             |
| [`293062bb`](https://github.com/NixOS/nixpkgs/commit/293062bbdbd9335b44560405b95888f215afb850) | `` stacks: set platforms ``                                                |
| [`1e79034d`](https://github.com/NixOS/nixpkgs/commit/1e79034dfb62a76c3c1201f0fd6d4dbc355b0065) | `` python310Packages.tempest: 35.0.0 -> 36.0.0 ``                          |
| [`634e9127`](https://github.com/NixOS/nixpkgs/commit/634e9127938b845a052daa782835f032aac58eb1) | `` joplin-desktop: 2.12.16 -> 2.12.18 ``                                   |
| [`a2e2e61b`](https://github.com/NixOS/nixpkgs/commit/a2e2e61bb1c681bb04cc2c934102107ea7930047) | `` twitch-tui: set mainProgram (#258289) ``                                |
| [`ff5c45fd`](https://github.com/NixOS/nixpkgs/commit/ff5c45fd2ec903b02ca146380ae7708d9a3ebf73) | `` regbot: 0.5.1 -> 0.5.2 ``                                               |
| [`d65cd59e`](https://github.com/NixOS/nixpkgs/commit/d65cd59e3c3990472de82bb03faee71e64c91f07) | `` s5cmd: 2.2.0 -> 2.2.2 ``                                                |
| [`10fa3455`](https://github.com/NixOS/nixpkgs/commit/10fa3455b12301bdf3a1a144b46d264bf0b72546) | `` sarasa-gothic: 0.41.10 -> 0.42.0 ``                                     |
| [`f6583fb0`](https://github.com/NixOS/nixpkgs/commit/f6583fb0cfcfe637339acc8cd80ff6ae85b589bf) | `` snipe-it: 6.1.1 -> 6.2.0 ``                                             |
| [`5919729f`](https://github.com/NixOS/nixpkgs/commit/5919729f460d369490af28018ec5118b47cad538) | `` snipe-it: Add options to the updater script ``                          |
| [`5a9a7eb3`](https://github.com/NixOS/nixpkgs/commit/5a9a7eb345d9975526ee145737cbdf8dfb615aff) | `` photoqt: 3.1 -> 3.3 ``                                                  |
| [`78cb8e54`](https://github.com/NixOS/nixpkgs/commit/78cb8e54f37e8f09f781e0127d6b12ac0743d13d) | `` python3Packages.pykalman: init at 0.9.5 ``                              |
| [`9d682765`](https://github.com/NixOS/nixpkgs/commit/9d6827659258b829c58831a8bdb56fb5b79e2b3f) | `` clusterctl: 1.5.1 -> 1.5.2 ``                                           |
| [`032719d0`](https://github.com/NixOS/nixpkgs/commit/032719d0c58e607213638ca35af797a06fb8979d) | `` siril: 1.0.6 -> 1.2.0 ``                                                |
| [`880b7a5f`](https://github.com/NixOS/nixpkgs/commit/880b7a5f153a1411be8eb02e68bef75a96eb60e6) | `` nufraw: refactor, add patch for exiv2 0.28 ``                           |
| [`e94e70e8`](https://github.com/NixOS/nixpkgs/commit/e94e70e870f0c8ccbee4d33ce37b7cecef06e0e0) | `` netbird-ui: 0.23.1 -> 0.23.6 ``                                         |
| [`d2b87332`](https://github.com/NixOS/nixpkgs/commit/d2b8733206945fbf65495aa18209f0c80bd5a376) | `` python310Packages.setuptools-odoo: 3.1.12 -> 3.2.0 ``                   |
| [`fb3df1c9`](https://github.com/NixOS/nixpkgs/commit/fb3df1c9f953e81aa33c37052e476828e4bd3857) | `` phototonic: refactor, add patch for exiv2 0.28 ``                       |
| [`7cdd86dc`](https://github.com/NixOS/nixpkgs/commit/7cdd86dc087553a9eb5013b19bd2c4e242e30bad) | `` tuxmux: init at version 0.1.0 ``                                        |
| [`508d0ac3`](https://github.com/NixOS/nixpkgs/commit/508d0ac3b95cf7401c1cd838d2ae16e8bc068986) | `` maintainers: add edeneast ``                                            |
| [`c687c1f2`](https://github.com/NixOS/nixpkgs/commit/c687c1f2468a4c6d3e047da1331f3119616629a2) | `` librtprocess: refactor, add darwin support ``                           |