### PR TITLE
chore(flake/lanzaboote): `bccf7738` -> `ac43ac30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -285,11 +285,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1696363578,
-        "narHash": "sha256-a/HIEEG0EGAvqnfN+QPEXshgYPQBeGuLkMq6FZtD7uw=",
+        "lastModified": 1696410458,
+        "narHash": "sha256-ohrrFywK7WIHEGWosBVRFZF5D2q2AeIGFGp9mMZRc40=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "bccf7738d5be1d43e169b016003cd946b03f8f66",
+        "rev": "ac43ac3024f814fcf3a3bab41873019109521442",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`a78b9682`](https://github.com/nix-community/lanzaboote/commit/a78b9682b77cf0fb2d301f82d55ca5d887cbcafb) | `` docs: Improve troubleshooting documentation ``      |
| [`90a1adac`](https://github.com/nix-community/lanzaboote/commit/90a1adac54c083026d81eddc9e74b1d64754e5af) | `` tool: fix atomic write ``                           |
| [`4fd37670`](https://github.com/nix-community/lanzaboote/commit/4fd37670e28c990bc56abea2bfe45114fbdf7fc6) | `` tool: stop most overwriting in the ESP ``           |
| [`ca070a9e`](https://github.com/nix-community/lanzaboote/commit/ca070a9eec85125d49521e6ebff36e008026f262) | `` tool: make stubs input-addressed ``                 |
| [`240914d7`](https://github.com/nix-community/lanzaboote/commit/240914d763c64fb2e4b932804e7273a95d085862) | `` tool: make kernels and initrds content-addressed `` |