### PR TITLE
chore(flake/flake-compat): `4f910c98` -> `0f9255e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,11 +142,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696267196,
-        "narHash": "sha256-AAQ/2sD+0D18bb8hKuEEVpHUYD1GmO2Uh/taFamn6XQ=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "4f910c9827911b1ec2bf26b5a062cd09f8d89f85",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                          |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
| [`0f9255e0`](https://github.com/edolstra/flake-compat/commit/0f9255e01c2351cc7d116c072cb317785dd33b33) | `` Force root sources like "./." into the Nix store ``           |
| [`5a16547d`](https://github.com/edolstra/flake-compat/commit/5a16547d46553d7bdd1dfc2cf418f5f7d236f6ad) | `` Prevent double copying and work around an apparent Nix bug `` |