### PR TITLE
chore(flake/home-manager): `8aef005d` -> `68f7d8c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -235,11 +235,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696409884,
-        "narHash": "sha256-hz3i4wFJHoTIAEI19oF1fiPn6TpV+VuTSOrSHUoJMgs=",
+        "lastModified": 1696446489,
+        "narHash": "sha256-xSjMKdNR+q/3hdSPyg/LUMsZT/WIoUi8dcm5zT4SMUQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8aef005d44ee726911e9f793495bb40f2fbf5a05",
+        "rev": "68f7d8c0fb0bfc67d1916dd7f06288424360d43a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`68f7d8c0`](https://github.com/nix-community/home-manager/commit/68f7d8c0fb0bfc67d1916dd7f06288424360d43a) | `` firefox: set ADD_DATE and LAST_MODIFIED of bookmarks to 1 `` |