### PR TITLE
chore(flake/nixos-hardware): `89c6109a` -> `6d05cccc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -343,11 +343,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1696483774,
-        "narHash": "sha256-cnNCH1MCmla7TDXcm5tu8FpqElneFX3flXc2gY8r0ZA=",
+        "lastModified": 1696488240,
+        "narHash": "sha256-m9H4XDHaO7fGXLWTgNFrKFbBbMvrJpB7Sj6BcTM/2UE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "89c6109adceb6fabf2ccda62ddfc4aa4fa19f25b",
+        "rev": "6d05cccc80feaf93d5f3d6837f8c2db582b29cf8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`6d05cccc`](https://github.com/NixOS/nixos-hardware/commit/6d05cccc80feaf93d5f3d6837f8c2db582b29cf8) | `` star64: set governor to schedutil `` |