### PR TITLE
chore(flake/pre-commit-hooks): `b039621a` -> `66c352d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -421,11 +421,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1696510682,
-        "narHash": "sha256-Nki3ersvzmy9iQBkUI0yIRBHg6cQEHCT0oCd5BQMibg=",
+        "lastModified": 1696516544,
+        "narHash": "sha256-8rKE8Je6twTNFRTGF63P9mE3lZIq917RAicdc4XJO80=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "b039621ad7536841c8da7b12f59af588360f7725",
+        "rev": "66c352d33e0907239e4a69416334f64af2c685cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                  |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
| [`03843c0e`](https://github.com/cachix/pre-commit-hooks.nix/commit/03843c0e6e577e51e840f3e0475c1bb6c48aa559) | `` Add hook for mdl (Markdown linter) `` |