### PR TITLE
chore(flake/nix-fast-build): `9ebfd443` -> `79908fc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -308,11 +308,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1696407543,
-        "narHash": "sha256-OQ6TmIFOZFS++vBXAp5LApAiWbUIN4e9jwGjNkPHVSA=",
+        "lastModified": 1696606406,
+        "narHash": "sha256-cCDMZshU0UC/V8uPVUKr/GD7MTwTVPsQa1pSrmd0YJ8=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "9ebfd443483595bea4644e421ce334706088a7d4",
+        "rev": "79908fc2a9768ac9b2ad14e8b94f37bb4ee3b71b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`79908fc2`](https://github.com/Mic92/nix-fast-build/commit/79908fc2a9768ac9b2ad14e8b94f37bb4ee3b71b) | `` don't propagated python when included in a devshell `` |