### PR TITLE
chore(flake/nixpkgs): `fdd898f8` -> `81e8f48e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -358,11 +358,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696193975,
-        "narHash": "sha256-mnQjUcYgp9Guu3RNVAB2Srr1TqKcPpRXmJf4LJk6KRY=",
+        "lastModified": 1696375444,
+        "narHash": "sha256-Sv0ICt/pXfpnFhTGYTsX6lUr1SljnuXWejYTI2ZqHa4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fdd898f8f79e8d2f99ed2ab6b3751811ef683242",
+        "rev": "81e8f48ebdecf07aab321182011b067aafc78896",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`141a0bd2`](https://github.com/NixOS/nixpkgs/commit/141a0bd2bd06e8f32b816d1f1109b5a6ea8f7f7e) | `` udiskie: install shell completions ``                                         |
| [`86aa82ce`](https://github.com/NixOS/nixpkgs/commit/86aa82cee24db88576d346d3e991844c17653ce8) | `` udiskie: 2.4.2 -> 2.5.0 ``                                                    |
| [`ad454fa3`](https://github.com/NixOS/nixpkgs/commit/ad454fa303d318d633ea0e75cd259554d8bee808) | `` conftest: 0.45.0 -> 0.46.0 ``                                                 |
| [`a96f15f9`](https://github.com/NixOS/nixpkgs/commit/a96f15f927a860106de5c6ba82b6bc29297108cc) | `` terragrunt: 0.51.0 -> 0.51.7 ``                                               |
| [`89819058`](https://github.com/NixOS/nixpkgs/commit/8981905890aa55c9af071909517189fd16c71516) | `` electron: don't track cache directory ``                                      |
| [`e5438605`](https://github.com/NixOS/nixpkgs/commit/e543860508a55d874ad405892eb99660e7c8d663) | `` electron: change directory to update script to place cache relative to it ``  |
| [`d5743d92`](https://github.com/NixOS/nixpkgs/commit/d5743d926818a3e8cb43158c827d4aff409bf12c) | `` lib.fileset.unions: Fix outdated docs ``                                      |
| [`1c20cc23`](https://github.com/NixOS/nixpkgs/commit/1c20cc23308ab8d08783c85a6405ff67dee1999d) | `` libotr: fix cross ``                                                          |
| [`67bd77f0`](https://github.com/NixOS/nixpkgs/commit/67bd77f0ea318f506c7384daff1d25f39c619fb2) | `` ligo: 0.72.0 -> 1.0.0 ``                                                      |
| [`d69860bf`](https://github.com/NixOS/nixpkgs/commit/d69860bf7f01c922a3f13b1a5763d005a54f7bca) | `` retroarchBare: 1.16.0 -> 1.16.0.3 ``                                          |
| [`b3a82e19`](https://github.com/NixOS/nixpkgs/commit/b3a82e19dc0aa60f3e0c6ef5e407db5985e0a3d6) | `` python3Packages.aioboto3: init at 11.3.0 ``                                   |
| [`57b9568f`](https://github.com/NixOS/nixpkgs/commit/57b9568f703e618aaf491aa22cf79e642b34a672) | `` obs-studio-plugins.obs-shaderfilter: v1.22 -> 2.0.0 (#248980) ``              |
| [`e0c85481`](https://github.com/NixOS/nixpkgs/commit/e0c854812b2c6a9e2ef713a4e16250a061be9916) | `` obs-studio-plugins.obs-move-transition: 2.9.1 -> 2.9.4 ``                     |
| [`0de039ce`](https://github.com/NixOS/nixpkgs/commit/0de039ceeefd72b6fa38a75b889942a3fa204d47) | `` gpx-viewer: 0.4.0 → 0.5.0 ``                                                  |
| [`7f224f59`](https://github.com/NixOS/nixpkgs/commit/7f224f59ea5cc159f588ebef0d780c54946f315e) | `` nixVersions.nix_2_18: 2.18.0 -> 2.18.1 ``                                     |
| [`73c14257`](https://github.com/NixOS/nixpkgs/commit/73c14257685d27dabc79f887e12d54d3c17a1718) | `` signalbackup-tools: 20231002-1 -> 20231003 ``                                 |
| [`ed77460c`](https://github.com/NixOS/nixpkgs/commit/ed77460cc1796a738f577732c4a7b0d207676054) | `` duckstation: unstable-2023-04-14 -> unstable-2023-09-30 ``                    |
| [`eefce3a7`](https://github.com/NixOS/nixpkgs/commit/eefce3a71ec846fca7c976f7df9c0a9075bfdfa4) | `` iptsd: 1.3.2 -> 1.4.0 ``                                                      |
| [`a7af91ff`](https://github.com/NixOS/nixpkgs/commit/a7af91ff76327b8dff7c7e4565eacd44b362ac35) | `` dcrwallet: 1.8.0 -> 1.8.1 ``                                                  |
| [`43e4d8a6`](https://github.com/NixOS/nixpkgs/commit/43e4d8a6a1402c67420e7bad3ba8237c5f3ed327) | `` lib.fileset: Link to user documentation from contributor docs ``              |
| [`90ce8cab`](https://github.com/NixOS/nixpkgs/commit/90ce8cab01b1a1bbc5cb93e413c4872a079512e0) | `` syncthing: 1.24.0 -> 1.25.0 ``                                                |
| [`80712090`](https://github.com/NixOS/nixpkgs/commit/80712090b193c4ffbabfc1738134f6e56588f7a4) | `` gitea: 1.20.4 -> 1.20.5 ``                                                    |
| [`074bbd4f`](https://github.com/NixOS/nixpkgs/commit/074bbd4f3a8c2f0d14850fd74ea3dcc51d07304f) | `` chiaki4deck: 1.3.3 -> 1.3.4 ``                                                |
| [`c02ab0ce`](https://github.com/NixOS/nixpkgs/commit/c02ab0ce6840dcb84b49f784982e4288fdddfa05) | `` luaPackages.middleclass: init at 4.1.1-0 ``                                   |
| [`deeb0772`](https://github.com/NixOS/nixpkgs/commit/deeb07725fb8ecefdccc30c8cb66d5489a67e0e0) | `` symfony-cli: 5.5.9 -> 5.5.10 ``                                               |
| [`4f35f003`](https://github.com/NixOS/nixpkgs/commit/4f35f003e6e5b800be75e3985054e5fce2dea50a) | `` lib.fileset: Internal representation v3, empty value without a base ``        |
| [`8d19fd63`](https://github.com/NixOS/nixpkgs/commit/8d19fd63b0db2d43f99221cbbbdabf36c12e345e) | `` kubectl-neat: init at 2.0.3 ``                                                |
| [`244be72e`](https://github.com/NixOS/nixpkgs/commit/244be72e19e96bdfb1e268d002af2e9c0036fbea) | `` atom*: drop ``                                                                |
| [`d6d69c2a`](https://github.com/NixOS/nixpkgs/commit/d6d69c2a559aa0757831d77f849ead1091bfb10a) | `` hakuneko: remove atomEnv ``                                                   |
| [`71e4764c`](https://github.com/NixOS/nixpkgs/commit/71e4764cee2a2edb4c4f9f98733769790731b8f0) | `` termius: remove atomEnv ``                                                    |
| [`bbd62ccd`](https://github.com/NixOS/nixpkgs/commit/bbd62ccd6cc60505ba66cfec4ce9ea3a493da2be) | `` electron-bin: use callPackage ``                                              |
| [`5d5e71a3`](https://github.com/NixOS/nixpkgs/commit/5d5e71a3acf6ec18dbf58c5d52cdc62eea4779e9) | `` electron-bin: remove atomEnv ``                                               |
| [`d1b31aab`](https://github.com/NixOS/nixpkgs/commit/d1b31aaba645fb95857a264c53f3cf386ddf4f3a) | `` sidequest: remove atomEnv ``                                                  |
| [`60464916`](https://github.com/NixOS/nixpkgs/commit/604649162f1a8cc7cc38b2cd7628bc491fa5b740) | `` simplenote: remove atomEnv ``                                                 |
| [`a52ccbe5`](https://github.com/NixOS/nixpkgs/commit/a52ccbe545206a0647c494b01134fd7014d131c7) | `` azuredatastudio: remove atomEnv ``                                            |
| [`33b832bd`](https://github.com/NixOS/nixpkgs/commit/33b832bd808be9679e5382384b17b3662df4ca35) | `` pulsar: remove atomEnv ``                                                     |
| [`73dca593`](https://github.com/NixOS/nixpkgs/commit/73dca593c4cca1b2d33f4e50a2cb30537b66913a) | `` vscode: remove atomEnv ``                                                     |
| [`cf1ff8be`](https://github.com/NixOS/nixpkgs/commit/cf1ff8be6b7c76e8934d64be0ae5b4688a1a080a) | `` trilium: remove atomEnv ``                                                    |
| [`a97aff3f`](https://github.com/NixOS/nixpkgs/commit/a97aff3fccbb66f45f9aa70a488a9ed9c749dd6c) | `` wire-desktop: remove atomEnv ``                                               |
| [`522cc0ad`](https://github.com/NixOS/nixpkgs/commit/522cc0ad746ec443cc56e58deb8774b0b92422d7) | `` teams: remove unused inputs ``                                                |
| [`dfc4125c`](https://github.com/NixOS/nixpkgs/commit/dfc4125c0231f8cadea5978fa425152095802287) | `` mattermost-desktop: remove no longer used atomEnv and autoPatchelfHook ``     |
| [`786a1bff`](https://github.com/NixOS/nixpkgs/commit/786a1bff54f158ab3bdbec1b8dc9e4d8b5ae1d34) | `` cargo-shuttle: 0.27.0 -> 0.28.0 ``                                            |
| [`b3314b31`](https://github.com/NixOS/nixpkgs/commit/b3314b317c1d9bb1849a671cfbb452fe3c9aca0f) | `` python3Packages.pyside6: fix building against qt 6.5.3 ``                     |
| [`3c9fb1be`](https://github.com/NixOS/nixpkgs/commit/3c9fb1befd1c3fa4935f391f97581b8ec151a929) | `` git-mit: 5.12.154 -> 5.12.155 ``                                              |
| [`45972b5a`](https://github.com/NixOS/nixpkgs/commit/45972b5abdb33fec81feb279cac26e9342241013) | `` changie: 1.13.1 -> 1.14.0 ``                                                  |
| [`8c801a04`](https://github.com/NixOS/nixpkgs/commit/8c801a04990931b3dd86b35054f47c9331c4d6ac) | `` grimblast: unstable-2023-09-06 -> unstable-2023-10-03 ``                      |
| [`f6d68391`](https://github.com/NixOS/nixpkgs/commit/f6d683919c1fb6503714c9c099c3b32189dd927d) | `` ocm: 0.1.68 -> 0.1.69 ``                                                      |
| [`1ced448f`](https://github.com/NixOS/nixpkgs/commit/1ced448fedbba2212fd89330942abe2083775918) | `` rye: 0.14.0 -> 0.15.0 ``                                                      |
| [`f9fa7059`](https://github.com/NixOS/nixpkgs/commit/f9fa7059a15d28762aa9d3055000b4bd75db2ee3) | `` python310Packages.gspread: 5.11.2 -> 5.11.3 ``                                |
| [`b369092b`](https://github.com/NixOS/nixpkgs/commit/b369092b3b93db8949191f708cd5a6241f26f24e) | `` xorg.libxcvt.meta.homepage: init ``                                           |
| [`d8469ef0`](https://github.com/NixOS/nixpkgs/commit/d8469ef08c864805badb4a21991b7f233f629b48) | `` pkgsStatic.xorg.libxcvt: mark unsupported ``                                  |
| [`425afd67`](https://github.com/NixOS/nixpkgs/commit/425afd675566a4b3493fb136f115d71455cf0612) | `` openmolcas: use getDev to pickup libxc includes ``                            |
| [`d5df7fc8`](https://github.com/NixOS/nixpkgs/commit/d5df7fc87fd5d9b606a9743beaea8a9dd61b2aaf) | `` elixir-ls: Include the debugger ``                                            |
| [`c6e3bbc5`](https://github.com/NixOS/nixpkgs/commit/c6e3bbc55046c7cea4b3fde2f80512d7fe6b79fc) | `` ocamlPackages.ppx_lun: init at 0.0.1 ``                                       |
| [`0c1938bf`](https://github.com/NixOS/nixpkgs/commit/0c1938bfd9917397196d291a9d4250cd4fa14567) | `` ocamlPackages.lun: init at 0.0.1 ``                                           |
| [`7b6b919f`](https://github.com/NixOS/nixpkgs/commit/7b6b919f3a707c566b8592106bb7ce070721b137) | `` neovim: patch liblpeg to work with clang on darwin (#257366) ``               |
| [`c987b40d`](https://github.com/NixOS/nixpkgs/commit/c987b40da55ea9bda7fd7c6b8cc38851bf0813a6) | `` mame: 0.258 -> 0.259 ``                                                       |
| [`76917ca3`](https://github.com/NixOS/nixpkgs/commit/76917ca3ae8fa50e49f774176e8d9b112aa00680) | `` nixos/sddm: add option to enable Wayland support via Weston ``                |
| [`d6537416`](https://github.com/NixOS/nixpkgs/commit/d6537416aa7533e3138dae0e712f0ca4190116f8) | `` sddm: backport a bunch of Wayland fixes ``                                    |
| [`91bc2e56`](https://github.com/NixOS/nixpkgs/commit/91bc2e56dc3727473c0f176c9c9b32db131d8839) | `` plasma5Packages.kio: backport fix for crashing on save ``                     |
| [`c403f5f0`](https://github.com/NixOS/nixpkgs/commit/c403f5f02d0f4a0c426ae41dcbee4a1e43eb9fca) | `` python310Packages.schedule: 1.2.0 -> 1.2.1 ``                                 |
| [`05914706`](https://github.com/NixOS/nixpkgs/commit/05914706637c8fc05a0617876fa47d0c62ea511e) | `` vscode-extensions.charliermarsh.ruff: 2023.38.0 → 2023.40.0 ``                |
| [`876e774c`](https://github.com/NixOS/nixpkgs/commit/876e774ce54fbdd21c649b12542bfca1ff06cf79) | `` papeer: 0.7.2 -> 0.8.1 ``                                                     |
| [`32c694e4`](https://github.com/NixOS/nixpkgs/commit/32c694e463490ae1ca0608a8ead9e37536578430) | `` littlefs-fuse: 2.4.1 -> 2.7.2 ``                                              |
| [`439ddf78`](https://github.com/NixOS/nixpkgs/commit/439ddf78b2f2ce263494b1fb84e15d8ee9ea964d) | `` esphome: 2023.9.2 -> 2023.9.3 ``                                              |
| [`5b4d701e`](https://github.com/NixOS/nixpkgs/commit/5b4d701e32e006e5c865f7eec2868daa47ee3145) | `` cloudlist: add changelog to meta ``                                           |
| [`66405ee9`](https://github.com/NixOS/nixpkgs/commit/66405ee9eecd7da65dea4018ba268e206a449324) | `` cloudlist: 1.0.3 -> 1.0.4 ``                                                  |
| [`c8c80e35`](https://github.com/NixOS/nixpkgs/commit/c8c80e3590c2f5a40f758bce196c4bac86b9a0fb) | `` mapcidr: 1.1.9 -> 1.1.10 ``                                                   |
| [`c5085c69`](https://github.com/NixOS/nixpkgs/commit/c5085c69d904df872b68c85b7bd4c9a558ec6757) | `` python311Packages.podcastparser: 0.6.5 -> 0.6.10 ``                           |
| [`d213b3c5`](https://github.com/NixOS/nixpkgs/commit/d213b3c5b6b8ba2e82081c586ade5cbd998f8cae) | `` python311Packages.pex: 2.1.147 -> 2.1.148 ``                                  |
| [`d7dff055`](https://github.com/NixOS/nixpkgs/commit/d7dff055fbd2709201184f5c3cffd90aec4f3ca8) | `` python311Packages.gitignore-parser: 0.1.6 -> 0.1.7 ``                         |
| [`378b8fc2`](https://github.com/NixOS/nixpkgs/commit/378b8fc2c7d5d55dbc9584963c9d99aa6c63c7e8) | `` python311Packages.google-cloud-bigquery-datatransfer: 3.12.0 -> 3.12.1 ``     |
| [`a9ac371e`](https://github.com/NixOS/nixpkgs/commit/a9ac371e7e2dc76214b070908f3dab3e6439e63b) | `` python311Packages.google-cloud-os-config: 1.15.2 -> 1.15.3 ``                 |
| [`5056c2dd`](https://github.com/NixOS/nixpkgs/commit/5056c2ddc8addb6983d98ca31a0e137101dc7cdc) | `` python311Packages.google-cloud-texttospeech: 2.14.1 -> 2.14.2 ``              |
| [`9e1fa44a`](https://github.com/NixOS/nixpkgs/commit/9e1fa44a44b19840fa9dba34c685c6f102467a96) | `` python311Packages.auth0-python: 4.4.0 -> 4.4.2 ``                             |
| [`e2484fe7`](https://github.com/NixOS/nixpkgs/commit/e2484fe737e7a8bfc3a873dea5874ab9aba22685) | `` ast-grep: fix darwin and aarch64_linux ``                                     |
| [`8c00548b`](https://github.com/NixOS/nixpkgs/commit/8c00548bbff251aadfa396b7d171a0b26f2a5111) | `` ast-grep: ignore test_unmatching_id ``                                        |
| [`f195a5e7`](https://github.com/NixOS/nixpkgs/commit/f195a5e7fad77b5128ebfaba0a6112cd9ddca0d2) | `` python311Packages.boto3-stubs: init at 1.28.28 ``                             |
| [`4b23e1b8`](https://github.com/NixOS/nixpkgs/commit/4b23e1b8f558d33ec6f27575704a800b3f08335c) | `` python311Packages.types-s3transfer: init at 0.7.0 ``                          |
| [`9282d27b`](https://github.com/NixOS/nixpkgs/commit/9282d27bf488f7a4afca004489d4a699c400b78d) | `` python311Packages.es-client: 8.10.0 -> 8.10.3 ``                              |
| [`d0bc48b1`](https://github.com/NixOS/nixpkgs/commit/d0bc48b1f111e315c97b2bce6cd2322aa7593cad) | `` python3Packages.cognito-idp: 1.28.36 -> 1.28.56 ``                            |
| [`0855c68d`](https://github.com/NixOS/nixpkgs/commit/0855c68d68f6a8afa2eeaf2d0ca4e2c061e409d1) | `` python311Packages.google-ai-generativelanguage: 0.3.3 -> 0.3.4 ``             |
| [`8121c7a3`](https://github.com/NixOS/nixpkgs/commit/8121c7a31c33f1ece2f9bcbf5ad774c212f93ce4) | `` ocamlPackages.checkseum: 0.4.0 → 0.5.2 ``                                     |
| [`7de04425`](https://github.com/NixOS/nixpkgs/commit/7de044258567dd2017d74c11ceb24b9d57781fe8) | `` python311Packages.google-cloud-appengine-logging: 1.3.1 -> 1.3.2 ``           |
| [`d43fcd65`](https://github.com/NixOS/nixpkgs/commit/d43fcd65cc8fb9afaa2f4ded8e50d5ae238d4ca5) | `` python311Packages.pylitterbot: 2023.4.8 -> 2023.4.9 ``                        |
| [`4c417fc6`](https://github.com/NixOS/nixpkgs/commit/4c417fc6dd36bbd9be56e9de877fdef1910be1f0) | `` python3Packages.mypy-boto3-workspaces-web: init at 1.28.36 ``                 |
| [`cdb540b4`](https://github.com/NixOS/nixpkgs/commit/cdb540b4eee9113967890cb7841af1a82bca7d35) | `` python3Packages.mypy-boto3-workspaces: init at 1.28.36 ``                     |
| [`d3019b10`](https://github.com/NixOS/nixpkgs/commit/d3019b106991f4f6985fdf4d4196522e35881d3d) | `` exploitdb: 2023-09-13 -> 2023-10-03 ``                                        |
| [`724fbebb`](https://github.com/NixOS/nixpkgs/commit/724fbebb67651d3f6c401dd9fa656138e0752516) | `` python3Packages.mypy-boto3-workmailmessageflow: init at 1.28.36 ``            |
| [`c0a14ba6`](https://github.com/NixOS/nixpkgs/commit/c0a14ba66c138cab29081e940b673cbe6fcac7b9) | `` python3Packages.mypy-boto3-workmail: init at 1.28.36 ``                       |
| [`764c822d`](https://github.com/NixOS/nixpkgs/commit/764c822d5e912eddc2e8506bbb8b37c4a41c557a) | `` python3Packages.mypy-boto3-worklink: init at 1.28.36 ``                       |
| [`74d2be03`](https://github.com/NixOS/nixpkgs/commit/74d2be0302fbd78bfeb2368ba411f960a7192ae3) | `` python3Packages.mypy-boto3-workdocs: init at 1.28.36 ``                       |
| [`7f656711`](https://github.com/NixOS/nixpkgs/commit/7f65671104b868ad7e463f4127b001caf33a94cb) | `` python3Packages.mypy-boto3-wisdom: init at 1.28.36 ``                         |
| [`3733f573`](https://github.com/NixOS/nixpkgs/commit/3733f573f84c46832f9ca9a174ff54e2bb79a18c) | `` python3Packages.mypy-boto3-wellarchitected: init at 1.28.36 ``                |
| [`50bc0f9e`](https://github.com/NixOS/nixpkgs/commit/50bc0f9e3b5635cbe6b59cf0d14bd5540f2b2d89) | `` python3Packages.mypy-boto3-wafv2: init at 1.28.36 ``                          |
| [`554e5766`](https://github.com/NixOS/nixpkgs/commit/554e5766103a7c4d0b3967eabc7d41846eb391fb) | `` python3Packages.mypy-boto3-waf-regional: init at 1.28.36 ``                   |
| [`37ce790b`](https://github.com/NixOS/nixpkgs/commit/37ce790b8c9e610f6e2754a82983a8a0917758a4) | `` python3Packages.mypy-boto3-waf: init at 1.28.36 ``                            |
| [`ba66edfd`](https://github.com/NixOS/nixpkgs/commit/ba66edfde528ffb4ee18ebcac689898309a6815a) | `` python3Packages.mypy-boto3-vpc-lattice: init at 1.28.36 ``                    |
| [`a785866b`](https://github.com/NixOS/nixpkgs/commit/a785866b3fefa84d9c36fe3814cbe2825830c500) | `` python3Packages.mypy-boto3-voice-id: init at 1.28.36 ``                       |
| [`bd568ba3`](https://github.com/NixOS/nixpkgs/commit/bd568ba3db37ca75b32a405a5d69f3afa8f3f9bb) | `` python3Packages.mypy-boto3-verifiedpermissions: init at 1.28.36 ``            |
| [`88f86879`](https://github.com/NixOS/nixpkgs/commit/88f86879cf37b47bc0bb710925bd87fa6b767cf9) | `` python3Packages.mypy-boto3-translate: init at 1.28.36 ``                      |
| [`755d02a4`](https://github.com/NixOS/nixpkgs/commit/755d02a421d4cee5d7f9446ebfb6128740ba53d7) | `` python3Packages.mypy-boto3-transfer: init at 1.28.36 ``                       |
| [`d10e4f96`](https://github.com/NixOS/nixpkgs/commit/d10e4f965c1f7d000ea03a667955c08ffeace21b) | `` python3Packages.mypy-boto3-transcribe: init at 1.28.36 ``                     |
| [`cbab639f`](https://github.com/NixOS/nixpkgs/commit/cbab639f8924674d4642d7d6aa8ab1e2fbce0ae0) | `` python3Packages.mypy-boto3-tnb: init at 1.28.36 ``                            |
| [`5a5fdaa4`](https://github.com/NixOS/nixpkgs/commit/5a5fdaa4263a57e216767a9ffd106665c6ced136) | `` python3Packages.mypy-boto3-timestream-write: init at 1.28.36 ``               |
| [`b83bf7f7`](https://github.com/NixOS/nixpkgs/commit/b83bf7f70bb376f4e0ceef7e1e46c6a5e8d4de6e) | `` python3Packages.mypy-boto3-timestream-query: init at 1.28.36 ``               |
| [`dce979e8`](https://github.com/NixOS/nixpkgs/commit/dce979e81e9ef406ca7b5014814822a3f5c381fa) | `` python3Packages.mypy-boto3-textract: init at 1.28.36 ``                       |
| [`b50133ef`](https://github.com/NixOS/nixpkgs/commit/b50133efff556773d7efe8c4c6a50c15fa7811a8) | `` python3Packages.mypy-boto3-synthetics: init at 1.28.36 ``                     |
| [`69ae3ecd`](https://github.com/NixOS/nixpkgs/commit/69ae3ecdbf6f114575889ad373e1f54e23b137f2) | `` python311Packages.censys: 2.2.6 -> 2.2.7 ``                                   |
| [`ead988fc`](https://github.com/NixOS/nixpkgs/commit/ead988fc7e5a3128477964716ec999b18c643f38) | `` python3Packages.mypy-boto3-swf: init at 1.28.36 ``                            |
| [`b8c77121`](https://github.com/NixOS/nixpkgs/commit/b8c771218ea31ee774d9c06e44545cf3b34241ca) | `` python3Packages.mypy-boto3-support-app: init at 1.28.36 ``                    |
| [`89c1129f`](https://github.com/NixOS/nixpkgs/commit/89c1129f61724cf7d380f594e0a6ded616947e16) | `` python3Packages.mypy-boto3-support: init at 1.28.36 ``                        |
| [`d80af446`](https://github.com/NixOS/nixpkgs/commit/d80af446533c317e0cc3785847c58a20a7ef3c12) | `` girouette: add cafkafk as maintainer ``                                       |
| [`bda96769`](https://github.com/NixOS/nixpkgs/commit/bda967694187fbff4d1d21cf75b5a429fbada033) | `` python3Packages.mypy-boto3-sts: init at 1.28.36 ``                            |
| [`4ecdbc57`](https://github.com/NixOS/nixpkgs/commit/4ecdbc57de4e1c569c118bbf7055bf52f24dd023) | `` python3Packages.mypy-boto3-storagegateway: init at 1.28.36 ``                 |
| [`694a87a8`](https://github.com/NixOS/nixpkgs/commit/694a87a8ed7773758a6f87245c412db810997dfe) | `` python3Packages.mypy-boto3-stepfunctions: init at 1.28.36 ``                  |
| [`b1f6ceb0`](https://github.com/NixOS/nixpkgs/commit/b1f6ceb075ceedfc214add6f2c63e3feba0d9743) | `` python3Packages.mypy-boto3-sso-oidc: init at 1.28.36 ``                       |
| [`53cdedf1`](https://github.com/NixOS/nixpkgs/commit/53cdedf1d7cffc423b3ca5617500a89abbd16de7) | `` python3Packages.mypy-boto3-sso-admin: init at 1.28.36 ``                      |
| [`51217a08`](https://github.com/NixOS/nixpkgs/commit/51217a08062c11aa99893cd88fb1269f944fa793) | `` python3Packages.mypy-boto3-sso: init at 1.28.36 ``                            |
| [`a8dfa483`](https://github.com/NixOS/nixpkgs/commit/a8dfa483ae9f0eba68900fa6eb12db653cf9d80c) | `` python3Packages.mypy-boto3-ssm-sap: init at 1.28.36 ``                        |
| [`c8da1773`](https://github.com/NixOS/nixpkgs/commit/c8da1773274aa4dc7dc23ff7a0bdf28bdad7fecc) | `` python3Packages.mypy-boto3-ssm-incidents: init at 1.28.36 ``                  |
| [`dfaadc71`](https://github.com/NixOS/nixpkgs/commit/dfaadc71204ae2d4ce419d1b88130a03022bdb9c) | `` python3Packages.mypy-boto3-ssm-contacts: init at 1.28.36 ``                   |
| [`bd76f641`](https://github.com/NixOS/nixpkgs/commit/bd76f641174c6f0853486a50a875e0cc8150b92a) | `` python3Packages.mypy-boto3-ssm: init at 1.28.36 ``                            |
| [`62c01d0f`](https://github.com/NixOS/nixpkgs/commit/62c01d0f9c832683069acaf360e7d4b745140cdb) | `` python3Packages.mypy-boto3-sqs: init at 1.28.36 ``                            |
| [`61ab95f9`](https://github.com/NixOS/nixpkgs/commit/61ab95f98611c7318e89dfd1982da962b895f7a2) | `` python3Packages.mypy-boto3-sns: init at 1.28.36 ``                            |
| [`819f4593`](https://github.com/NixOS/nixpkgs/commit/819f459301f74e0b7f62241d34457d38b176e075) | `` python3Packages.mypy-boto3-snowball: init at 1.28.36 ``                       |
| [`b71a8a5d`](https://github.com/NixOS/nixpkgs/commit/b71a8a5d1497059e5310867b732b0d20fc812e88) | `` python3Packages.mypy-boto3-snow-device-management: init at 1.28.36 ``         |
| [`fbe47f1a`](https://github.com/NixOS/nixpkgs/commit/fbe47f1ac41d468428c84975bf03e4dd8898182a) | `` python3Packages.mypy-boto3-sms-voice: init at 1.28.36 ``                      |
| [`fdc29894`](https://github.com/NixOS/nixpkgs/commit/fdc298945d5f6b4e6779e4e27a4d868e2308f362) | `` python3Packages.mypy-boto3-sms: init at 1.28.36 ``                            |
| [`70ba9f1b`](https://github.com/NixOS/nixpkgs/commit/70ba9f1bdf3e5a97bedb5e02b038a37a32f841d4) | `` python3Packages.mypy-boto3-simspaceweaver: init at 1.28.36 ``                 |
| [`5c4b01b3`](https://github.com/NixOS/nixpkgs/commit/5c4b01b39bf1d6b658a4db2073c6221a33f93de1) | `` python3Packages.mypy-boto3-signer: init at 1.28.36 ``                         |
| [`6d6a9b68`](https://github.com/NixOS/nixpkgs/commit/6d6a9b68e133f9e81479261a65e28be7f7e7e68f) | `` python3Packages.mypy-boto3-shield: init at 1.28.36 ``                         |
| [`751069cb`](https://github.com/NixOS/nixpkgs/commit/751069cb0754dbf7ae138ba5130765681b879118) | `` python3Packages.mypy-boto3-sesv2: init at 1.28.36 ``                          |
| [`a875a06f`](https://github.com/NixOS/nixpkgs/commit/a875a06f99d4468d10fbaf6c034116b06c743521) | `` python3Packages.mypy-boto3-ses: init at 1.28.36 ``                            |
| [`70eaf430`](https://github.com/NixOS/nixpkgs/commit/70eaf430b3cd9e04430fe4a18c326a9775358e68) | `` python3Packages.mypy-boto3-servicediscovery: init at 1.28.36 ``               |
| [`6c928cf3`](https://github.com/NixOS/nixpkgs/commit/6c928cf3aa7aefc5556f02f8936cc312a11de814) | `` python3Packages.mypy-boto3-servicecatalog-appregistry: init at 1.28.36 ``     |
| [`c64871c6`](https://github.com/NixOS/nixpkgs/commit/c64871c69274e2b396c7bf8f182bc1096efd952e) | `` python3Packages.mypy-boto3-servicecatalog: init at 1.28.36 ``                 |
| [`e13aa672`](https://github.com/NixOS/nixpkgs/commit/e13aa6725002f76d521a5fc5905775f1bea0a214) | `` python3Packages.mypy-boto3-service-quotas: init at 1.28.36 ``                 |
| [`c8fd65c0`](https://github.com/NixOS/nixpkgs/commit/c8fd65c02aa60322aadbdaba9bff4c544e421358) | `` python3Packages.mypy-boto3-serverlessrepo: init at 1.28.36 ``                 |
| [`8b55fe1e`](https://github.com/NixOS/nixpkgs/commit/8b55fe1ee40bd11d38e61252de8139bf7141b550) | `` python3Packages.mypy-boto3-securitylake: init at 1.28.36 ``                   |
| [`a8ce7643`](https://github.com/NixOS/nixpkgs/commit/a8ce76438cd63b1caeefb29b011032ea8ddb983d) | `` python3Packages.mypy-boto3-securityhub: init at 1.28.36 ``                    |
| [`fbad6e97`](https://github.com/NixOS/nixpkgs/commit/fbad6e97af4931b327bd5a1253c32296c839dfe6) | `` python3Packages.mypy-boto3-secretsmanager: init at 1.28.36 ``                 |
| [`6f9e1fc7`](https://github.com/NixOS/nixpkgs/commit/6f9e1fc7772a92ac466597e4950abbef49efd7d6) | `` python3Packages.mypy-boto3-sdb: init at 1.28.36 ``                            |
| [`d109145e`](https://github.com/NixOS/nixpkgs/commit/d109145e3e5129145ec40cd1963bbc0cf617c789) | `` python3Packages.mypy-boto3-schemas: init at 1.28.36 ``                        |
| [`066e3433`](https://github.com/NixOS/nixpkgs/commit/066e343381985fa85d77f573500053888f05802d) | `` python3Packages.mypy-boto3-scheduler: init at 1.28.36 ``                      |
| [`b68ff57d`](https://github.com/NixOS/nixpkgs/commit/b68ff57d5c83becd5be8fef1e214cceb59d27c2e) | `` python3Packages.mypy-boto3-savingsplans: init at 1.28.36 ``                   |
| [`78fefe40`](https://github.com/NixOS/nixpkgs/commit/78fefe40c8a88016e2d2ed36c8fff36302e42bae) | `` python3Packages.mypy-boto3-sagemaker-runtime: init at 1.28.36 ``              |
| [`120d7bda`](https://github.com/NixOS/nixpkgs/commit/120d7bdab721cbe29d5024d0e0b307cb428f7adb) | `` python3Packages.mypy-boto3-sagemaker-metrics: init at 1.28.36 ``              |
| [`4fbf45fe`](https://github.com/NixOS/nixpkgs/commit/4fbf45feff13cefc4762cdd831122ca909a94e3d) | `` python3Packages.mypy-boto3-sagemaker-geospatial: init at 1.28.36 ``           |
| [`14e75c45`](https://github.com/NixOS/nixpkgs/commit/14e75c45bf6c050284a2b1815adc317e4397efef) | `` python3Packages.mypy-boto3-sagemaker-featurestore-runtime: init at 1.28.36 `` |
| [`02b11560`](https://github.com/NixOS/nixpkgs/commit/02b11560ecd8c1d014b01a149be0b29206bd292e) | `` python3Packages.mypy-boto3-sagemaker-edge: init at 1.28.36 ``                 |
| [`325aae22`](https://github.com/NixOS/nixpkgs/commit/325aae2250517bbb9c6487dca4379ec426783ee2) | `` python3Packages.mypy-boto3-sagemaker-a2i-runtime: init at 1.28.36 ``          |
| [`058d7286`](https://github.com/NixOS/nixpkgs/commit/058d7286d56841274874de01ec0a6264cd9b2009) | `` python3Packages.mypy-boto3-sagemaker: init at 1.28.36 ``                      |