### PR TITLE
chore(flake/home-manager): `ed0770e9` -> `b2a2133c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -235,11 +235,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696628087,
-        "narHash": "sha256-ozdCbI2cpBg1Bw4OOYCrFNF2IexWMiJaBjOGsW8Luvs=",
+        "lastModified": 1696635169,
+        "narHash": "sha256-gOjLe7maQ58erN/9ykb6d2ePAU7QAT1D8u7qin9gt+c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ed0770e96225f998ea128549ad446d9b1568cb2c",
+        "rev": "b2a2133c9a0b0aa4d06d72b5891275f263ee08df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`b2a2133c`](https://github.com/nix-community/home-manager/commit/b2a2133c9a0b0aa4d06d72b5891275f263ee08df) | `` flake: fix nixpkgs `config` ``                   |
| [`31a27e48`](https://github.com/nix-community/home-manager/commit/31a27e48062742241ab06ccdbed189f28040cdaf) | `` fish: query pname and version for completions `` |