### PR TITLE
chore(flake/nixpkgs): `81e8f48e` -> `87828a0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -358,11 +358,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696375444,
-        "narHash": "sha256-Sv0ICt/pXfpnFhTGYTsX6lUr1SljnuXWejYTI2ZqHa4=",
+        "lastModified": 1696604326,
+        "narHash": "sha256-YXUNI0kLEcI5g8lqGMb0nh67fY9f2YoJsILafh6zlMo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "81e8f48ebdecf07aab321182011b067aafc78896",
+        "rev": "87828a0e03d1418e848d3dd3f3014a632e4a4f64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`e3d54cc7`](https://github.com/NixOS/nixpkgs/commit/e3d54cc7a272755d66814da329cdccf8725bd31f) | `` lefthook: 1.4.8 -> 1.5.1 ``                                                                   |
| [`42bea74b`](https://github.com/NixOS/nixpkgs/commit/42bea74b9f6ebd13c8b8d8512f3bd479c67b8910) | `` python311Packages.casbin: 1.31.0 -> 1.31.2 ``                                                 |
| [`c9e61619`](https://github.com/NixOS/nixpkgs/commit/c9e61619e216313b49944cc3ec81f7bd70da049c) | `` xfce.xfce4-session: Backport xfce-portals.conf support ``                                     |
| [`0b31c97a`](https://github.com/NixOS/nixpkgs/commit/0b31c97a009650af47bfbd627e92c611413e53f1) | `` xfce.thunar: Fix log spam with new GLib ``                                                    |
| [`26189ecc`](https://github.com/NixOS/nixpkgs/commit/26189ecc33c76ddcb6e81a3d5d881836c0366a41) | `` xfce.xfce4-taskmanager: 1.5.5 -> 1.5.6 ``                                                     |
| [`e1ee359d`](https://github.com/NixOS/nixpkgs/commit/e1ee359d16a1886f0771cc433a00827da98d861c) | `` gnome.gnome-session: fix session crash in gnome-boxes ``                                      |
| [`4ea79a8e`](https://github.com/NixOS/nixpkgs/commit/4ea79a8e31f82662ed1d20ca061488f532bceae0) | `` doomretro: 5.0.3 -> 5.0.4 ``                                                                  |
| [`69278aec`](https://github.com/NixOS/nixpkgs/commit/69278aecde858e76369e2ee2159cea2e82bb05ee) | `` rust-analyzer-unwrapped: 2023-09-25 -> 2023-10-02 ``                                          |
| [`ea1eb4ee`](https://github.com/NixOS/nixpkgs/commit/ea1eb4ee0fa44dd4cd37e8ece2634370d1c2b0d2) | `` nixos/nginx: add systemd-tmpfiles exclusion of temporary directories ``                       |
| [`040cf48d`](https://github.com/NixOS/nixpkgs/commit/040cf48d2855175006d20ba90efbea5e438b3543) | `` nixos/tests: add test for nginx temp directories removal ``                                   |
| [`5144dc26`](https://github.com/NixOS/nixpkgs/commit/5144dc266996a08fdd6f2ebeb88000308530e165) | `` cudatoolkit: fix evaluation with Nix 2.3 ``                                                   |
| [`075f8252`](https://github.com/NixOS/nixpkgs/commit/075f825288132da4ff2f70d2ad2a38a4762ad1ff) | `` xfce.xfce4-pulseaudio-plugin: 0.4.7 -> 0.4.8 ``                                               |
| [`2f244e36`](https://github.com/NixOS/nixpkgs/commit/2f244e3647bdf63b8aeca31a2f88091ffb3a9041) | `` python3.pkgs.xdot: 1.2 -> 1.3 ``                                                              |
| [`48febcc7`](https://github.com/NixOS/nixpkgs/commit/48febcc74f9514b1fa9c6873b9cab2f6804d2c82) | `` beancount: 2.3.5 -> 2.3.6 ``                                                                  |
| [`73688410`](https://github.com/NixOS/nixpkgs/commit/736884108d45daa6c41f123c6b318043a2c33ee1) | `` sgt-puzzles: rename all "sgtpuzzles" -> "sgt-puzzles" ``                                      |
| [`1cb1c88f`](https://github.com/NixOS/nixpkgs/commit/1cb1c88f9c41c3b3bc7c320ddf13b357931604a8) | `` phoc: add passthru.tests.phosh ``                                                             |
| [`c65ad2c4`](https://github.com/NixOS/nixpkgs/commit/c65ad2c49fc3c558823e753237da5c452cf1fbb0) | `` gzdoom: 4.10.0 -> 4.11.0 ``                                                                   |
| [`b68f1972`](https://github.com/NixOS/nixpkgs/commit/b68f1972fb05fa8a40746636f8cfd95dc92b8c20) | `` qcelemental: 0.25.1 -> 0.26.0 ``                                                              |
| [`d6ac2df6`](https://github.com/NixOS/nixpkgs/commit/d6ac2df61db7d814513b58132a8c1c4c297a0125) | `` python3.pkgs.astropy: 5.3.3 -> 5.3.4 ``                                                       |
| [`256c518a`](https://github.com/NixOS/nixpkgs/commit/256c518a8a810375141737012b1e6c89a76dcc0a) | `` dpdk: fixup shared compilation ``                                                             |
| [`86d6401d`](https://github.com/NixOS/nixpkgs/commit/86d6401d3e21dee72c7e2dd54eaf070c659d321d) | `` vencord: 1.5.3 -> 1.5.5 ``                                                                    |
| [`190a819e`](https://github.com/NixOS/nixpkgs/commit/190a819ecb16f39f349dbb34b7f50527c56e86c0) | `` nixosTests.gnome-flashback: Ensure gnome-flashback-media-keys starts ``                       |
| [`1045b894`](https://github.com/NixOS/nixpkgs/commit/1045b89402d7080fedaf64cdac2690c7038561fe) | `` tree-sitter-grammars: add typst ``                                                            |
| [`4b58af2f`](https://github.com/NixOS/nixpkgs/commit/4b58af2fcb4199e8d4e36584701cd6eac0e0b78f) | `` gitoxide: 0.29.0 -> 0.30.0 ``                                                                 |
| [`e4739c00`](https://github.com/NixOS/nixpkgs/commit/e4739c00ce497ed7cd82416d8e49e41e0ebbe726) | `` python311Packages.gitignore-parser: 0.1.8 -> 0.1.9 ``                                         |
| [`8bf81e23`](https://github.com/NixOS/nixpkgs/commit/8bf81e231ccbdd5112455128e4ddcb384b720cec) | `` python311Packages.garth: 0.4.37 -> 0.4.38 ``                                                  |
| [`7e75e495`](https://github.com/NixOS/nixpkgs/commit/7e75e4954b0d1cc14a921f1a1e921f1cde3a46a6) | `` python311Packages.camel-converter: 3.0.2 -> 3.0.3 ``                                          |
| [`9c8e91a6`](https://github.com/NixOS/nixpkgs/commit/9c8e91a6203338ceecf3dccfed7059f7ff30eeda) | `` python310Packages.django-reversion: add changelog to meta ``                                  |
| [`fa23afc1`](https://github.com/NixOS/nixpkgs/commit/fa23afc15e0267cc2875c51a3de4c0408e7367fc) | `` ocamlPackages.lwt: 5.6.1 → 5.7.0 ``                                                           |
| [`bbb8c889`](https://github.com/NixOS/nixpkgs/commit/bbb8c88974f7d0eab87840826d75b4d8da3c3528) | `` ocamlPackages.containers-data: disable tests with OCaml 5.0 ``                                |
| [`ff910956`](https://github.com/NixOS/nixpkgs/commit/ff910956e9ff28596537c604453c12c4bef5fd44) | `` ocamlPackages.kafka_lwt: disable for OCaml ≥ 5.0 ``                                           |
| [`b93cbab8`](https://github.com/NixOS/nixpkgs/commit/b93cbab840e09d167f52323ecd0666a497831c72) | `` wakapi: 2.8.1 -> 2.8.2 ``                                                                     |
| [`d6da67d4`](https://github.com/NixOS/nixpkgs/commit/d6da67d4c9cf5942a4f9bf64aa8c60ec91ccf5db) | `` python311Packages.whodap: 0.1.9 -> 0.1.10 ``                                                  |
| [`794774b8`](https://github.com/NixOS/nixpkgs/commit/794774b837b7c7cda86ab3da9458da272314478f) | `` python311Packages.pyfibaro: 0.7.4 -> 0.7.5 ``                                                 |
| [`61a4911e`](https://github.com/NixOS/nixpkgs/commit/61a4911e6886884dc1ec80b80ccb615bfe5dd93f) | `` memray: 1.9.1 -> 1.10.0 ``                                                                    |
| [`bdd178b5`](https://github.com/NixOS/nixpkgs/commit/bdd178b581e74b53a9e4480bb7f842578178373d) | `` checkov: 2.5.4 -> 2.5.6 ``                                                                    |
| [`f7d4c633`](https://github.com/NixOS/nixpkgs/commit/f7d4c633e1fe04a190aaa0fbba26206bdcd08b9e) | `` sentry-cli: 2.20.7 -> 2.21.1 ``                                                               |
| [`ba51d48e`](https://github.com/NixOS/nixpkgs/commit/ba51d48e591fe9f38b8bd71647cb1605fcc0a28e) | `` automatic-timezoned: 1.0.128 -> 1.0.129 ``                                                    |
| [`47056b66`](https://github.com/NixOS/nixpkgs/commit/47056b66563e65fd40395ee10ceae42c11fca060) | `` slirp4netns: 1.2.1 -> 1.2.2 ``                                                                |
| [`b0d82e52`](https://github.com/NixOS/nixpkgs/commit/b0d82e529f995b72a667a18422af6826179bd328) | `` sketchybar-app-font: 1.0.14 -> 1.0.16 ``                                                      |
| [`d1a63a9f`](https://github.com/NixOS/nixpkgs/commit/d1a63a9f087f755c67956cf90379af8f24a7c265) | `` r2modman: 3.1.43 -> 3.1.44 ``                                                                 |
| [`fc096a6d`](https://github.com/NixOS/nixpkgs/commit/fc096a6d9cd3736df7ea1ce9b369ccfeedf07746) | `` nixosTests.gnome-flashback: Fix eval ``                                                       |
| [`e347cca9`](https://github.com/NixOS/nixpkgs/commit/e347cca9f80bfbcc21c389e32c52c3f7bc3465bd) | `` delly: 1.1.6 -> 1.1.7 ``                                                                      |
| [`4f4086ab`](https://github.com/NixOS/nixpkgs/commit/4f4086ab6af903f49d79592a6d067519ae1eb10b) | `` wch-isp: 0.2.5 -> 0.3.0 ``                                                                    |
| [`588d774b`](https://github.com/NixOS/nixpkgs/commit/588d774bc96328e8568e1c278dff1edc3ad6156b) | `` python310Packages.magic-filter: 1.0.11 -> 1.0.12 ``                                           |
| [`e3948974`](https://github.com/NixOS/nixpkgs/commit/e3948974208d4f1f4d77b1a710ff05f2597d451e) | `` alsa-utils: fixes for musl ``                                                                 |
| [`302bb11b`](https://github.com/NixOS/nixpkgs/commit/302bb11b6f9a900065278a3a2798ef56f4db6c3d) | `` jackett: 0.21.938 -> 0.21.969 ``                                                              |
| [`3c80160c`](https://github.com/NixOS/nixpkgs/commit/3c80160c7b720049e9d1347fa6d263f29d4c1d90) | `` probe-rs: 0.20.0 -> 0.21.0 ``                                                                 |
| [`cfaec23b`](https://github.com/NixOS/nixpkgs/commit/cfaec23b23d9660eaa704a157693d0314f8de195) | `` python310Packages.junos-eznc: 2.6.7 -> 2.6.8 ``                                               |
| [`f513d95c`](https://github.com/NixOS/nixpkgs/commit/f513d95c336c1c750f643b52fd56334bc301402c) | `` python311Packages.transformers: 4.33.2 -> 4.34.0 ``                                           |
| [`451f8f54`](https://github.com/NixOS/nixpkgs/commit/451f8f542f44b2058f551800904d812055cb44ee) | `` python311Packages.tokenizers: 0.13.3 -> 0.14.0 ``                                             |
| [`55384de7`](https://github.com/NixOS/nixpkgs/commit/55384de7da9c3840fa9c2bc2bc8e61034777d02b) | `` libsmi: fix missing declaration for new clang ``                                              |
| [`41544a6e`](https://github.com/NixOS/nixpkgs/commit/41544a6e04f06182b7fd75729121e260c74fb477) | `` python310Packages.google-cloud-container: 2.31.0 -> 2.32.0 ``                                 |
| [`09325d24`](https://github.com/NixOS/nixpkgs/commit/09325d24b685a3ab5507dc906ab4019696d33d59) | `` nixos/security/wrappers: use musl rather than glibc and explicitly unset insecure env vars `` |
| [`392cf21d`](https://github.com/NixOS/nixpkgs/commit/392cf21de2dc6370e5c90a5331e8c1d85cc6e43a) | `` mdbook-katex: 0.5.7 -> 0.5.8 ``                                                               |
| [`fa845cc3`](https://github.com/NixOS/nixpkgs/commit/fa845cc3b6966c7c14d5d83d3b9e29120e8cf06f) | `` nushellPlugins: fix update script ``                                                          |
| [`be2e62a3`](https://github.com/NixOS/nixpkgs/commit/be2e62a36d5e5d40e8f836e0ff04f8f10d070998) | `` nushellPlugins: normalise formatting across similar derivations ``                            |
| [`eea9d62c`](https://github.com/NixOS/nixpkgs/commit/eea9d62c0a3cabc1cb0080437d12ca4409b40c23) | `` nushellPlugins: add passthru.updateScript to all packages ``                                  |
| [`b8300622`](https://github.com/NixOS/nixpkgs/commit/b830062237613fe0b76e2c25bd7336d57f83d8f2) | `` nushellPlugins: Add myself as maintainer ``                                                   |
| [`7f49fe88`](https://github.com/NixOS/nixpkgs/commit/7f49fe88bba613853c285da190077cec1fe66880) | `` nushellPlugins: inherit version from nushell ``                                               |
| [`f66847bb`](https://github.com/NixOS/nixpkgs/commit/f66847bb3758408908ba87a1d8763baed61a623f) | `` nushellPlugins: correct homepage URL ``                                                       |
| [`8024ef9b`](https://github.com/NixOS/nixpkgs/commit/8024ef9b1cdc7d58f5f5939d14a758989f682164) | `` nushellPlugins: fix check phases ``                                                           |
| [`48ae3d24`](https://github.com/NixOS/nixpkgs/commit/48ae3d24bc07d1079c2c78936b54d40a89f80cd4) | `` nushellPlugins: remove unnecessary let bindings ``                                            |
| [`90029bbd`](https://github.com/NixOS/nixpkgs/commit/90029bbdf3345d0afd548d97162add6809f25555) | `` cudatext: 1.199.0 -> 1.200.0 ``                                                               |
| [`df1882cd`](https://github.com/NixOS/nixpkgs/commit/df1882cd877a510025be5156d29a0794a762341d) | `` ctx: migrate to by-name ``                                                                    |
| [`f6c5e9a5`](https://github.com/NixOS/nixpkgs/commit/f6c5e9a5ef486c5018dbd2323277197800200f0e) | `` ctx: unstable-2023-06-05 -> unstable-2023-09-03 ``                                            |
| [`3b1224e9`](https://github.com/NixOS/nixpkgs/commit/3b1224e94a76df8fc51078ddbfbf6bdad7491958) | `` _1password-gui-beta: 8.10.16-45.BETA -> 8.10.18-19.BETA ``                                    |
| [`405b3a71`](https://github.com/NixOS/nixpkgs/commit/405b3a71a8f6661978686c41f47aab2731f0d82c) | `` moon-phases: init at 0.3.3 ``                                                                 |
| [`7843484d`](https://github.com/NixOS/nixpkgs/commit/7843484dc16fe4bf70b64920604ece2989b8011c) | `` licenses: add Anti-Capitalist Software License v1.4 ``                                        |
| [`ccd18bf7`](https://github.com/NixOS/nixpkgs/commit/ccd18bf7d5800c8d53a563a8070cde33aa71687f) | `` maintainers: add mirrorwitch ``                                                               |
| [`e6e341bb`](https://github.com/NixOS/nixpkgs/commit/e6e341bb5fa28d4b4a91cb8ae95ca55bbeb81367) | `` activate-linux: unstable-2022-05-22 -> 1.1.0 ``                                               |
| [`fb3c3775`](https://github.com/NixOS/nixpkgs/commit/fb3c37750f756f398623b49baa8b316917e9781e) | `` qcengine: 0.26.0 -> 0.28.1 ``                                                                 |
| [`7a385497`](https://github.com/NixOS/nixpkgs/commit/7a38549748580452148e6f08e55be27d5e816208) | `` python310Packages.django-reversion: 5.0.5 -> 5.0.6 ``                                         |
| [`99515b5c`](https://github.com/NixOS/nixpkgs/commit/99515b5c5071b358062a382d8b455633e7bfc76d) | `` electron: fix GSETTINGS_SCHEMAS_PATH (#259157) ``                                             |
| [`d9d7d3d4`](https://github.com/NixOS/nixpkgs/commit/d9d7d3d488e29f8220612a9ed03ea709a02b38f7) | `` php81Packages.phpstan: 1.10.33 -> 1.10.37 ``                                                  |
| [`50f2c183`](https://github.com/NixOS/nixpkgs/commit/50f2c1836f5d67c107ffe80e089a35972d17f262) | `` mozlz4a: 2018-08-23 -> 2022-03-19 ``                                                          |
| [`11f19b58`](https://github.com/NixOS/nixpkgs/commit/11f19b5804c45e44204b9a0bdac278d6c84bb693) | `` mozlz4a: format with nixpkgs-fmt ``                                                           |
| [`7e16aa5b`](https://github.com/NixOS/nixpkgs/commit/7e16aa5b9416132af95c7ae0af30e285c824410a) | `` wasmer: 4.2.0 -> 4.2.1 ``                                                                     |
| [`440959cb`](https://github.com/NixOS/nixpkgs/commit/440959cbbc3e68fa0cdedf15efcf80e27f00b2ce) | `` python311Packages.alexapy: update changelog entry ``                                          |
| [`9f325a47`](https://github.com/NixOS/nixpkgs/commit/9f325a47d3c30a3c4a3ae0b5a0328e44e575d3f4) | `` gradle_7: 7.6.2 -> 7.6.3 ``                                                                   |
| [`ea920c49`](https://github.com/NixOS/nixpkgs/commit/ea920c499a1c5d8ee07fc6fa4732de54952e33e0) | `` python310Packages.parver: 0.4 -> 0.5 ``                                                       |
| [`406df5b0`](https://github.com/NixOS/nixpkgs/commit/406df5b06997521ad9be4757e289490fcc73f90b) | `` python311Packages.pynetdicom: unbreak tests ``                                                |
| [`fe934468`](https://github.com/NixOS/nixpkgs/commit/fe9344689d3a536d6b2946520247cafc793069cf) | `` wxmacmolplt: fix linking ``                                                                   |
| [`f7ffd458`](https://github.com/NixOS/nixpkgs/commit/f7ffd458c0318face853d7c6d803edf5732965cf) | `` gradle: 8.3 -> 8.4 ``                                                                         |
| [`b4b216fe`](https://github.com/NixOS/nixpkgs/commit/b4b216fe8557918574fab52dfeb65d3e52b8098f) | `` python311Packages.tank-utility: add changelog to meta ``                                      |
| [`492576ac`](https://github.com/NixOS/nixpkgs/commit/492576aca28c65765633d2387f499e481bf3188b) | `` python311Packages.tank-utility: 1.4.1 -> 1.5.0 ``                                             |
| [`3088d0af`](https://github.com/NixOS/nixpkgs/commit/3088d0afb32eb0fb926b320c3fee04234c36f031) | `` python311Packages.pypoint: 2.3.1 -> 2.3.2 ``                                                  |
| [`f3dc2f3d`](https://github.com/NixOS/nixpkgs/commit/f3dc2f3d9be512614f17d1f75a55ef343fb16649) | `` python310Packages.y-py: 0.6.0 -> 0.6.2 ``                                                     |
| [`344c8f45`](https://github.com/NixOS/nixpkgs/commit/344c8f45495992402132b6fde956235b666b9af5) | `` snipe-it: 6.2.0 -> 6.2.1 ``                                                                   |
| [`957bbc2b`](https://github.com/NixOS/nixpkgs/commit/957bbc2bb9c04ce1d672edd0eac4857244d5a66c) | `` mkosi: 17.1 -> 18 ``                                                                          |
| [`9f75383a`](https://github.com/NixOS/nixpkgs/commit/9f75383a6d4a09b0fc48636bc566cc3e38428bf3) | `` pyrosimple: 2.11.1 -> 2.11.3 ``                                                               |
| [`c8999ca6`](https://github.com/NixOS/nixpkgs/commit/c8999ca614f89d6c0e27910afadc3673a817cefc) | `` keycloak: 22.0.3 -> 22.0.4 ``                                                                 |
| [`d2b457aa`](https://github.com/NixOS/nixpkgs/commit/d2b457aa9a7bc4f62fef4b3e6f3cd5646eb0277a) | `` jujutsu: 0.9.0 -> 0.10.0 ``                                                                   |
| [`2af70d8d`](https://github.com/NixOS/nixpkgs/commit/2af70d8de67a42852d7aabd084ecdddccc237abb) | `` opentelemetry-collector: 0.83.0 -> 0.86.0 ``                                                  |
| [`1206a7c8`](https://github.com/NixOS/nixpkgs/commit/1206a7c8464afab8351979557cba2681be85c3ae) | `` trealla: 2.28.1 -> 2.28.12 ``                                                                 |
| [`b17c0fc9`](https://github.com/NixOS/nixpkgs/commit/b17c0fc96aee62110080956d00367e28d1e7b117) | `` kitty: 0.30.0 -> 0.30.1 ``                                                                    |
| [`025a028c`](https://github.com/NixOS/nixpkgs/commit/025a028c471a1c2ae88bd846bdf25f74b9c29529) | `` fetchgit: fix private fetching via netrc ``                                                   |
| [`da6dea3c`](https://github.com/NixOS/nixpkgs/commit/da6dea3c55c13f7a7df6c072d0d9fa4ac87f7986) | `` elmPackages.elm-pages: update NEW patch for 3.0.x ``                                          |
| [`d5b90128`](https://github.com/NixOS/nixpkgs/commit/d5b901282e31c0e692a34b8e3073f3af3e868ae3) | `` elm-pages: set files/dirs as +w when copied during elm-init ``                                |
| [`800399a2`](https://github.com/NixOS/nixpkgs/commit/800399a2ce0c5cadf91600f40746cf7387059735) | `` elmPackages.elm-pages: update patch for 3.0.x ``                                              |
| [`e071414d`](https://github.com/NixOS/nixpkgs/commit/e071414dfccf9c3dd2ea6479b5a0dffaa3f8c46c) | `` elmPackages: update node-packages.nix ``                                                      |
| [`47abfd55`](https://github.com/NixOS/nixpkgs/commit/47abfd5581300eb9b29ba2a5f438795dbe9598ac) | `` elm: update registry ``                                                                       |
| [`36e507ac`](https://github.com/NixOS/nixpkgs/commit/36e507ac0e9eb3e9c0b0e9a03c2d9347dc05645d) | `` elm: add meta.mainProgram (matches update script) ``                                          |
| [`a60f6e99`](https://github.com/NixOS/nixpkgs/commit/a60f6e995f8ce18f90ba5d1db3a7367c4a6a2aa8) | `` elm: sort deps (matches update script) ``                                                     |
| [`266006df`](https://github.com/NixOS/nixpkgs/commit/266006dfcfe919a98fe92d0e516a46cd606bac97) | `` elm: sort elm-srcs (matches update script) ``                                                 |
| [`e62e83df`](https://github.com/NixOS/nixpkgs/commit/e62e83df1fd7527e4fdb85bb5cfff7cab9a6306a) | `` nmap-formatter: 2.1.1 -> 2.1.2 ``                                                             |
| [`db636bfb`](https://github.com/NixOS/nixpkgs/commit/db636bfb1e178db466b39dbbab9f11ce8413890b) | `` nvitop: 1.3.0 -> 1.3.1 ``                                                                     |
| [`3a40e8eb`](https://github.com/NixOS/nixpkgs/commit/3a40e8ebac4e5daea772d4a61925a5459cf8d146) | `` lobster: 2023.11 -> 2023.12 ``                                                                |
| [`c5f5e369`](https://github.com/NixOS/nixpkgs/commit/c5f5e36954d35edabd9257359ad9427636e9e05c) | `` moon: 1.13.4 -> 1.14.3 ``                                                                     |
| [`c3a6a37e`](https://github.com/NixOS/nixpkgs/commit/c3a6a37ed2688c8e1c355ec9ce0dc4054b9b5c1d) | `` nimPackages.atlas: fix building against nim2 ``                                               |
| [`fa268069`](https://github.com/NixOS/nixpkgs/commit/fa26806981c3480c472a009e1f3b50c1174a8e44) | `` nchat: 3.60 -> 3.67 ``                                                                        |
| [`275432f5`](https://github.com/NixOS/nixpkgs/commit/275432f57622307e7d829f82fee58a71d45129ca) | `` kitty-themes: unstable-2023-06-01 -> unstable-2023-09-15 ``                                   |
| [`893851c2`](https://github.com/NixOS/nixpkgs/commit/893851c2c859d32b3a24177981105e0366bf9151) | `` ledger-live-desktop: 2.66.0 -> 2.69.0 ``                                                      |
| [`37250559`](https://github.com/NixOS/nixpkgs/commit/37250559790d104450693425a49e5833834e9663) | `` turso-cli: enable tests, reordering ``                                                        |
| [`77544893`](https://github.com/NixOS/nixpkgs/commit/77544893d1171dc76c3dd625d4c817dd5be85ce5) | `` turso-cli: Add Fryuni as maintainer ``                                                        |
| [`d8abaa61`](https://github.com/NixOS/nixpkgs/commit/d8abaa6147ca60a5cb459df11f3126276009f874) | `` turso-cli: Install shell completions ``                                                       |
| [`e1ae770f`](https://github.com/NixOS/nixpkgs/commit/e1ae770fdf74c1490c7aa9ef27f5f0e850cd59f4) | `` ft2-clone: 1.69 -> 1.71 ``                                                                    |
| [`937a6594`](https://github.com/NixOS/nixpkgs/commit/937a6594cf76bdc1220e92af86ebb0d1342e4701) | `` gnuradio: enable tests on linux ``                                                            |
| [`52bdc845`](https://github.com/NixOS/nixpkgs/commit/52bdc84582b499de50f4f4af2035d9eb9bc5ba61) | `` lambda-lisp: init at 2022-08-18 ``                                                            |
| [`7f492d34`](https://github.com/NixOS/nixpkgs/commit/7f492d343e44c52e4b01e73c16554e2ec167230c) | `` syncthingtray: 1.4.6 -> 1.4.7 ``                                                              |
| [`99b48447`](https://github.com/NixOS/nixpkgs/commit/99b48447f978ca4829fbeb8f69c09f982d55d9d9) | `` syncthingtray: enable tests ``                                                                |
| [`9b76ebd1`](https://github.com/NixOS/nixpkgs/commit/9b76ebd1cd4763da1d7b9ef25bc1a2d71aa7e673) | `` ocamlPackages.algaeff: 0.2.1 → 1.1.0 ``                                                       |
| [`d5fc5429`](https://github.com/NixOS/nixpkgs/commit/d5fc54291fd5040e567c251f8e11ebecebc15be0) | `` matomo-beta: 4.14.3-b6 -> 5.0.0-rc3 ``                                                        |
| [`f4fbae56`](https://github.com/NixOS/nixpkgs/commit/f4fbae567b6d6a0cbe794528e597e5dd2f8c70f6) | `` tgpt: 1.9.0 -> 1.10.0 ``                                                                      |
| [`b0689618`](https://github.com/NixOS/nixpkgs/commit/b0689618eb28bcbff577bf452dfcb9999ea22dcf) | `` python311Packages.tagoio-sdk: 4.1.1 -> 4.2.0 ``                                               |
| [`a61a2f7b`](https://github.com/NixOS/nixpkgs/commit/a61a2f7b7dd78f1c78cc12baa6f27f88b3bf7ce1) | `` python310Packages.pytensor: fix src hash ``                                                   |