### PR TITLE
chore(flake/home-manager): `b2a2133c` -> `3c1d8758`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -235,11 +235,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696635169,
-        "narHash": "sha256-gOjLe7maQ58erN/9ykb6d2ePAU7QAT1D8u7qin9gt+c=",
+        "lastModified": 1696737557,
+        "narHash": "sha256-YD/pjDjj/BNmisEvRdM/vspkCU3xyyeGVAUWhvVSi5Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b2a2133c9a0b0aa4d06d72b5891275f263ee08df",
+        "rev": "3c1d8758ac3f55ab96dcaf4d271c39da4b6e836d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`3c1d8758`](https://github.com/nix-community/home-manager/commit/3c1d8758ac3f55ab96dcaf4d271c39da4b6e836d) | `` flake.lock: Update `` |