### PR TITLE
chore(flake/home-manager): `6dfbdc97` -> `6bba6478`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -363,11 +363,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696776279,
-        "narHash": "sha256-PRJiq+DSq5o/Dzd7ZYWTA8larDg4btkTICPzfjjalig=",
+        "lastModified": 1696940889,
+        "narHash": "sha256-p2Wic74A1tZpFcld1wSEbFQQbrZ/tPDuLieCnspamQo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6dfbdc977e059f30376e23f70f67d9726d5c91b8",
+        "rev": "6bba64781e4b7c1f91a733583defbd3e46b49408",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`6bba6478`](https://github.com/nix-community/home-manager/commit/6bba64781e4b7c1f91a733583defbd3e46b49408) | `` password-store-sync: remove module `` |