### PR TITLE
chore(flake/nixpkgs): `87828a0e` -> `f99e5f03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -486,11 +486,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696604326,
-        "narHash": "sha256-YXUNI0kLEcI5g8lqGMb0nh67fY9f2YoJsILafh6zlMo=",
+        "lastModified": 1696879762,
+        "narHash": "sha256-Ud6bH4DMcYHUDKavNMxAhcIpDGgHMyL/yaDEAVSImQY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "87828a0e03d1418e848d3dd3f3014a632e4a4f64",
+        "rev": "f99e5f03cc0aa231ab5950a15ed02afec45ed51a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`1f0dbe5f`](https://github.com/NixOS/nixpkgs/commit/1f0dbe5f10c3a15abbddcb0ea3358d4280f77af2) | `` fwupd: drop removed dell option ``                                        |
| [`41acc257`](https://github.com/NixOS/nixpkgs/commit/41acc25766fbc611cd10cb043bc7cab91d2fd088) | `` by-name: make the way of adding packages clearer ``                       |
| [`3e4c990c`](https://github.com/NixOS/nixpkgs/commit/3e4c990c91e212185da0868655fab15b613884cb) | `` media-downloader: 3.3.0 -> 3.4.0 ``                                       |
| [`3104b340`](https://github.com/NixOS/nixpkgs/commit/3104b34067ba90e1736accc0d6aa25c7c0806e21) | `` kapp: 0.58.0 -> 0.59.0 ``                                                 |
| [`7903ffce`](https://github.com/NixOS/nixpkgs/commit/7903ffce5bd8762e688ae059b26335d807bc950b) | `` linux_testing: 6.6-rc4 -> 6.6-rc5 ``                                      |
| [`0b369006`](https://github.com/NixOS/nixpkgs/commit/0b36900606b9be03ccb554be867ae2405f6ba428) | `` libdnf: 0.70.2 -> 0.71.0 ``                                               |
| [`9f1d4b79`](https://github.com/NixOS/nixpkgs/commit/9f1d4b79e3f02e95423aebdaa0c0cd7ffc984065) | `` nixos/postgresql: fix `identMap` example ``                               |
| [`1d3c3d4f`](https://github.com/NixOS/nixpkgs/commit/1d3c3d4f5bb7e0f91d9524f716b23e030a1db567) | `` python: simplify ABI name detection ``                                    |
| [`515781b1`](https://github.com/NixOS/nixpkgs/commit/515781b1b99f5603114434342f8c7526de0d1289) | `` lunatask: 1.7.6 -> 1.7.7 ``                                               |
| [`fb204bc8`](https://github.com/NixOS/nixpkgs/commit/fb204bc8ee6ab84e26e84cd678e1c2ea049ad86e) | `` maintainers: add haruki7049 ``                                            |
| [`90534906`](https://github.com/NixOS/nixpkgs/commit/905349064876dcd7a762bd60d586591dc67556b5) | `` nixos/netclient: init ``                                                  |
| [`202f059e`](https://github.com/NixOS/nixpkgs/commit/202f059e7ddd843ea79b11e5392dd73adac30a06) | `` netclient: init at 0.21.0 ``                                              |
| [`5eeab0e7`](https://github.com/NixOS/nixpkgs/commit/5eeab0e71a04551ec859cb3cec8967fccda3b61c) | `` kdoctor: init at 1.0.1 ``                                                 |
| [`526bc6a0`](https://github.com/NixOS/nixpkgs/commit/526bc6a00b3d670bc4b85aa84a38aec0890baed7) | `` maintainers: add sironheart ``                                            |
| [`2351c568`](https://github.com/NixOS/nixpkgs/commit/2351c568e15c1b10f5d2c79323befa4e4d45d91d) | `` hqplayerd: 4.34.0-100sse42 -> 5.2.0-6 ``                                  |
| [`ed1a3545`](https://github.com/NixOS/nixpkgs/commit/ed1a3545d64e7f5181858ab5d4328e42af90c70e) | `` asap: 5.3.0 -> 6.0.0 ``                                                   |
| [`0e835238`](https://github.com/NixOS/nixpkgs/commit/0e8352388dc039d32076c7056854d54573bffb6b) | `` drawio: fix startupWMClass ``                                             |
| [`16ea502f`](https://github.com/NixOS/nixpkgs/commit/16ea502fbc46648d767bf15a027df2b98eb89c61) | `` drawio: 21.7.5 -> 22.0.2 ``                                               |
| [`cce6560f`](https://github.com/NixOS/nixpkgs/commit/cce6560fe5c252314518078c8dd1cd8a2e82bfe0) | `` armadillo: 12.6.0 -> 12.6.4 ``                                            |
| [`50219fdc`](https://github.com/NixOS/nixpkgs/commit/50219fdc7a3d6ac63852c9acd2c2435987d8a417) | `` icewm: 3.4.2 -> 3.4.3 ``                                                  |
| [`a7145832`](https://github.com/NixOS/nixpkgs/commit/a71458323a87669b09692059a96082473a534be3) | `` anytype: 0.35.2 -> 0.35.4 ``                                              |
| [`89c0b251`](https://github.com/NixOS/nixpkgs/commit/89c0b25177f37f693ccd3343dbb94d4c2ea6c338) | `` altair: 5.2.2 -> 5.2.5 ``                                                 |
| [`83a5c7e5`](https://github.com/NixOS/nixpkgs/commit/83a5c7e5480b531b67f109f3035f678d69a797dc) | `` rye: add completion ``                                                    |
| [`a073d008`](https://github.com/NixOS/nixpkgs/commit/a073d008b0ec6a59e95d55d714589eb2c503560e) | `` libayatana-common: 0.9.8 -> 0.9.9 ``                                      |
| [`67252742`](https://github.com/NixOS/nixpkgs/commit/67252742c17b87e04bda10babbdadbe872c7f084) | `` plasma5Packages.kio: use a better homepage ``                             |
| [`d9532fa4`](https://github.com/NixOS/nixpkgs/commit/d9532fa4b537d373ee159ba12e1aa273f1212b2c) | `` plasma5Packages.kio: enable debug info ``                                 |
| [`14b1fec1`](https://github.com/NixOS/nixpkgs/commit/14b1fec1f38478e507ac83c50470e59052a43a0d) | `` lbreakouthd: 1.1.3 -> 1.1.4 ``                                            |
| [`c1cfe33b`](https://github.com/NixOS/nixpkgs/commit/c1cfe33b7bb37beb833fd80abee2dafffb0de112) | `` whois: 5.5.18 -> 5.5.19 ``                                                |
| [`0009f654`](https://github.com/NixOS/nixpkgs/commit/0009f65473bc3d0c4bf30a9bf95b3cf7673d31fe) | `` last-resort: 15.000 -> 15.100 ``                                          |
| [`ec88e979`](https://github.com/NixOS/nixpkgs/commit/ec88e9799a04f6920d50cacdb1e353bb7b499323) | `` kubevpn: 1.2.0 -> 2.0.0 ``                                                |
| [`3218c0e8`](https://github.com/NixOS/nixpkgs/commit/3218c0e86ab1f2018be63a7e7eb711de1a8bc535) | `` lidarr: 1.3.5.3530 -> 1.4.5.3639 ``                                       |
| [`09785cfb`](https://github.com/NixOS/nixpkgs/commit/09785cfbdf626c823b45cd541c7ed056cc9dbdc9) | `` kubeseal: 0.24.0 -> 0.24.1 ``                                             |
| [`b3e07b55`](https://github.com/NixOS/nixpkgs/commit/b3e07b55ac0715dde128ddbf6b79b09a9cb6ec94) | `` kubectl-gadget: 0.20.0 -> 0.21.0 ``                                       |
| [`73b05392`](https://github.com/NixOS/nixpkgs/commit/73b0539254dc9a2d37d39ec83faf37b86de02483) | `` kubecfg: 0.34.0 -> 0.34.1 ``                                              |
| [`2a77e7c3`](https://github.com/NixOS/nixpkgs/commit/2a77e7c3a770e8cac0db4d27ba666a617b58e080) | `` komga: 1.4.0 -> 1.5.1 ``                                                  |
| [`3b6416b4`](https://github.com/NixOS/nixpkgs/commit/3b6416b483e0b9cd9a37603d54a4a3ec52c85d45) | `` kodiPackages.keymap: 1.1.4 -> 1.1.5 ``                                    |
| [`42cdd150`](https://github.com/NixOS/nixpkgs/commit/42cdd1507f0e4b3436eb3da14a4b4f81d8d9cd70) | `` waycheck: init at 0.1.3 ``                                                |
| [`2b82a1fe`](https://github.com/NixOS/nixpkgs/commit/2b82a1fe8f2704a21c6e15434ac7863aaf48723b) | `` theforceengine: 1.09.300 -> 1.09.540 ``                                   |
| [`dcd7efd1`](https://github.com/NixOS/nixpkgs/commit/dcd7efd1f993419527a63313d7158cef746b0106) | `` cp2k: enable GPU offloading, sirius planewaves and optimisations ``       |
| [`7b50f783`](https://github.com/NixOS/nixpkgs/commit/7b50f783336f57e5d39b160d78b8aa24d6b07ca3) | `` sirius: init at 7.4.3 ``                                                  |
| [`3a787953`](https://github.com/NixOS/nixpkgs/commit/3a7879533e3d3d8f0ddbb1945942575b3a812d8b) | `` costa: init at 2.2.2 ``                                                   |
| [`0365c4b1`](https://github.com/NixOS/nixpkgs/commit/0365c4b1d07ad7d67388068d19e1d5055aec8dc7) | `` spfft: init at 1.0.6 ``                                                   |
| [`5b7e0ad0`](https://github.com/NixOS/nixpkgs/commit/5b7e0ad0962ca3e50879d008f0ea98ead9ee051f) | `` spla: init at 1.0.6 ``                                                    |
| [`2f021def`](https://github.com/NixOS/nixpkgs/commit/2f021def6e0a58e159e34b27b7796b2b5d0d0560) | `` nixos/oci-containers: add labels option ``                                |
| [`e53e0363`](https://github.com/NixOS/nixpkgs/commit/e53e036331a199dceeca26cf2f885e039610276b) | `` python311Packages.deep_merge: remove ``                                   |
| [`88cb436d`](https://github.com/NixOS/nixpkgs/commit/88cb436dd5cb58a3e157102628d2055546a0ae65) | `` checkov: remove an unneeded dependency ``                                 |
| [`a14b87d5`](https://github.com/NixOS/nixpkgs/commit/a14b87d558f279e05e9a7aafc784299cce39a286) | `` terragrunt: 0.52.0 -> 0.52.1 ``                                           |
| [`624495f5`](https://github.com/NixOS/nixpkgs/commit/624495f59515a505a2a004210e7e2a487557bb36) | `` phpPackages.psalm: use `buildComposerProject` builder ``                  |
| [`dfa9e40a`](https://github.com/NixOS/nixpkgs/commit/dfa9e40a0fbcefc1fc07e74b2dbdbbc8e80b81d8) | `` phpunit: 10.3.3 -> 10.4.1 ``                                              |
| [`a1e85db7`](https://github.com/NixOS/nixpkgs/commit/a1e85db798ac1078a2e71925b41ca5b4d4776bfc) | `` phpPackages.phpstan: use `buildComposerProject` builder ``                |
| [`043a094c`](https://github.com/NixOS/nixpkgs/commit/043a094c3bd1b85742079a5c589beaaa5f7f47aa) | `` php.buildComposerProject: add missing `COMPOSER_ROOT_VERSION` env var. `` |
| [`4f1206ff`](https://github.com/NixOS/nixpkgs/commit/4f1206ff05bd5601e6f05439cbc216915e0e52f9) | `` glow: 1.5.0 -> 1.5.1 ``                                                   |
| [`e4d2934e`](https://github.com/NixOS/nixpkgs/commit/e4d2934eec806317f67b40bdbd6d0a85563766fc) | `` python3Packages.pywlroots: 0.16.5 -> 0.16.6 ``                            |
| [`8c9e646f`](https://github.com/NixOS/nixpkgs/commit/8c9e646fb4f7b174cb1c388ba273a55a16e89c23) | `` hclfmt: 2.18.0 -> 2.18.1 (#259906) ``                                     |
| [`da6cb410`](https://github.com/NixOS/nixpkgs/commit/da6cb41087f1e3a4866e5c21e6b0c81d01b1c688) | `` jackett: 0.21.969 -> 0.21.993 ``                                          |
| [`be295800`](https://github.com/NixOS/nixpkgs/commit/be2958005a35f2da0046eeb7c7e322bcdbcdd933) | `` python3Packages.radon: init at 6.0.1 ``                                   |
| [`812887a7`](https://github.com/NixOS/nixpkgs/commit/812887a713adb712a17ecca78416ffd6b5bc8fff) | `` python3Packages.mando: init at 0.7.1 ``                                   |
| [`21824ab3`](https://github.com/NixOS/nixpkgs/commit/21824ab3a65a227ec5f54a7c899852c86cf40909) | `` python311Packages.pysml: 0.0.12 -> 0.1.0 ``                               |
| [`39385491`](https://github.com/NixOS/nixpkgs/commit/3938549162ed74cec7d2311bdee3e8c543a58240) | `` iosevka-bin: 27.1.0 -> 27.2.0 ``                                          |
| [`fb884fde`](https://github.com/NixOS/nixpkgs/commit/fb884fde6cf2c7c89fffde847508a7b0aee72d68) | `` python311Packages.hahomematic: 2023.10.4 -> 2023.10.6 ``                  |
| [`83f4bb94`](https://github.com/NixOS/nixpkgs/commit/83f4bb948190b7d1b6456f4b4aefa1a445a31f5b) | `` iotop-c: 1.23 -> 1.24 ``                                                  |
| [`5acb67e5`](https://github.com/NixOS/nixpkgs/commit/5acb67e57be26163fccac07e9afeb850ded145ad) | `` python311Packages.meshtastic: 2.2.8 -> 2.2.9 ``                           |
| [`0b55e764`](https://github.com/NixOS/nixpkgs/commit/0b55e764ad79ed4ed6f00d0a71baad323db6bc70) | `` picom-allusive: init for 0.3.1 ``                                         |
| [`acf6f9c8`](https://github.com/NixOS/nixpkgs/commit/acf6f9c869b3b3b582bebba4902bb59f20946ac5) | `` maintainers: add allusive ``                                              |
| [`32d8376c`](https://github.com/NixOS/nixpkgs/commit/32d8376cc5320a6c5143e2d6f3c5016050f1743e) | `` httplib: 0.14.0 -> 0.14.1 ``                                              |
| [`71199c4a`](https://github.com/NixOS/nixpkgs/commit/71199c4a4bd9b6f5de08ac082b3a29e3d0bb6c48) | `` txt2tags: 3.8 -> 3.9 ``                                                   |
| [`840b0698`](https://github.com/NixOS/nixpkgs/commit/840b0698a4f637f9781ffbfeb6b4ab0e0ea47008) | `` fsatrace: 0.0.1 -> 0.0.5 ``                                               |
| [`ab32d2ba`](https://github.com/NixOS/nixpkgs/commit/ab32d2baf88e758e00fc1ab1fd53e8c05f08ba7e) | `` helm-ls: 0.0.5 -> 0.0.6 ``                                                |
| [`a30f5330`](https://github.com/NixOS/nixpkgs/commit/a30f53308eb537b087b7e54a2fe806d035134e48) | `` corrosion: 0.4.3 -> 0.4.4 ``                                              |
| [`d86e09da`](https://github.com/NixOS/nixpkgs/commit/d86e09da998df8d3310785c1e2f713ae9e7eb7e0) | `` hax11: unstable-2022-12-10 -> unstable-2023-09-25 ``                      |
| [`9cde37b3`](https://github.com/NixOS/nixpkgs/commit/9cde37b3139b412d4a7299e5713f68ecfdb3b9ec) | `` gvproxy: 0.7.0 -> 0.7.1 ``                                                |
| [`2df9f018`](https://github.com/NixOS/nixpkgs/commit/2df9f0182ee9b2d9c31817932b694c69625bb93e) | `` eudev: refactor ``                                                        |
| [`8c90bdda`](https://github.com/NixOS/nixpkgs/commit/8c90bddab1c359ac10fb84657efd3fa1a7fa5da1) | `` eudev: migrate to by-name ``                                              |
| [`7822e066`](https://github.com/NixOS/nixpkgs/commit/7822e066da487d8c48dc61b539a3f5f6a68d43cc) | `` grpc_cli: 1.59.0 -> 1.59.1 ``                                             |
| [`dfa9ad7f`](https://github.com/NixOS/nixpkgs/commit/dfa9ad7fbe7fb7e73775bbae68d33f219b7a405d) | `` grpcui: 1.3.1 -> 1.3.2 ``                                                 |
| [`bd63680a`](https://github.com/NixOS/nixpkgs/commit/bd63680ad1ec16146c25a11ed3a30eae5d49822d) | `` gpxsee: 13.7 -> 13.9 ``                                                   |
| [`f4ebc306`](https://github.com/NixOS/nixpkgs/commit/f4ebc3060ab04c29bdbda5f7b4017a7a61580f38) | `` gotrue-supabase: 2.96.0 -> 2.99.0 ``                                      |
| [`5121858e`](https://github.com/NixOS/nixpkgs/commit/5121858e8b8d7a3359ee1b638bb7d33d90da6949) | `` google-java-format: 1.17.0 -> 1.18.1 ``                                   |
| [`68a6ee74`](https://github.com/NixOS/nixpkgs/commit/68a6ee74128fcdc7703296f77112883e83ea3e92) | `` difftastic: 0.51.1 -> 0.52.0 ``                                           |
| [`d5893e7e`](https://github.com/NixOS/nixpkgs/commit/d5893e7e72dcb7986eef03a3b0a2dd6d4f9280de) | `` go-task: 3.29.1 -> 3.31.0 ``                                              |
| [`b1bea581`](https://github.com/NixOS/nixpkgs/commit/b1bea5813f60522c3b0e73e7e705c9b5bb665ae5) | `` go-mockery: 2.34.1 -> 2.35.2 ``                                           |
| [`c4e5fa47`](https://github.com/NixOS/nixpkgs/commit/c4e5fa4766e4dab0f361db288e9d2614f081d431) | `` orogene: 0.3.33 -> 0.3.34 ``                                              |
| [`c93291db`](https://github.com/NixOS/nixpkgs/commit/c93291dbe59b750cc07fb9460f13d85819864fea) | `` maintainers: update yayayayaka's email ``                                 |
| [`12417d69`](https://github.com/NixOS/nixpkgs/commit/12417d690136130749091430fde43ea04da63699) | `` gnmic: 0.32.0 -> 0.33.0 ``                                                |
| [`b1a7c30d`](https://github.com/NixOS/nixpkgs/commit/b1a7c30da98d27056067b6eed9ac1256141859c1) | `` glooctl: 1.15.7 -> 1.15.9 ``                                              |
| [`6eb660c2`](https://github.com/NixOS/nixpkgs/commit/6eb660c22f49ed2414d1be6f4e1cd2cd96b84f43) | `` minimal-bootstrap: remove glibc and gcc2 ``                               |
| [`1c0c8f48`](https://github.com/NixOS/nixpkgs/commit/1c0c8f483202281cf7bac43aed65dbf85a9fc7ac) | `` prometheus-pgbouncer-exporter: vendorSha256 -> vendorHash ``              |
| [`25722bf5`](https://github.com/NixOS/nixpkgs/commit/25722bf5ba4aabcb462337a21b1012817005446b) | `` maintainers: add wexder ``                                                |
| [`a527510a`](https://github.com/NixOS/nixpkgs/commit/a527510a09f514e99e4c84394308a979544b8e8a) | `` oculante: 0.7.6 -> 0.7.7 ``                                               |
| [`180462df`](https://github.com/NixOS/nixpkgs/commit/180462df115c47baa0875e93df18e8716c5d7dec) | `` ft2-clone: 1.71 -> 1.72.1 ``                                              |
| [`b8d7c9d5`](https://github.com/NixOS/nixpkgs/commit/b8d7c9d5f11c9cfe0b16f393875ee644d68a8b08) | `` flyctl: 0.1.102 -> 0.1.104 ``                                             |
| [`bf1bd46d`](https://github.com/NixOS/nixpkgs/commit/bf1bd46d9b77e949eab55c3eaa90007eb8f9ddbd) | `` rio: set meta.mainProgram ``                                              |
| [`0fc6faf9`](https://github.com/NixOS/nixpkgs/commit/0fc6faf92b490eea1342b3de7105cdab63d8ad80) | `` hugs: fix meta.mainProgram ``                                             |
| [`1172ad61`](https://github.com/NixOS/nixpkgs/commit/1172ad611e81143faab628c1c356520123512b75) | `` tfupdate: 0.7.2 -> 0.8.0 ``                                               |
| [`9b657939`](https://github.com/NixOS/nixpkgs/commit/9b657939d4f338f4512b0d1b61e749b50eb9a947) | `` flow: 0.217.2 -> 0.218.0 ``                                               |
| [`9acfe162`](https://github.com/NixOS/nixpkgs/commit/9acfe16294b6b22ffc07d5c6bcc15ae3178759da) | `` python311Packages.pyvista: 0.42.2 -> 0.42.3 ``                            |
| [`e1996b9f`](https://github.com/NixOS/nixpkgs/commit/e1996b9f9626b066add4a39cf721975a85523137) | `` photoqt: 3.3 -> 3.4 ``                                                    |
| [`18c9af9f`](https://github.com/NixOS/nixpkgs/commit/18c9af9f378bc9684cb0a047ab18758e4f86118f) | `` zulu21: deduplicate expressions ``                                        |
| [`f3e89bab`](https://github.com/NixOS/nixpkgs/commit/f3e89babd4a963df36371b026ebc377221692982) | `` zulu21: init at 21.0.0 ``                                                 |
| [`473e0875`](https://github.com/NixOS/nixpkgs/commit/473e08752304b1c4957e5c563c39d6aa3ccd30ad) | `` zulu17: init at 17.0.8.1 ``                                               |
| [`82c294f1`](https://github.com/NixOS/nixpkgs/commit/82c294f13af5b364083f6043a6b0ac8a4581cfc2) | `` openjdk21, openjfx21: init at 21 (#258507) ``                             |
| [`abe2da41`](https://github.com/NixOS/nixpkgs/commit/abe2da41ad4a0c473b05851b21cdd76b430eba6c) | `` containerlab: 0.45.1 -> 0.46.0 ``                                         |
| [`51b89430`](https://github.com/NixOS/nixpkgs/commit/51b894301b062857f38dc87eef110fee4ff3c216) | `` python311Packages.tblite: don't override configure ``                     |
| [`7e511ea1`](https://github.com/NixOS/nixpkgs/commit/7e511ea1cc502ba58e278da80f9c50d1e99eb6d5) | `` apktool: 2.8.1 -> 2.9.0 ``                                                |