### PR TITLE
chore(flake/home-manager): `d4a5076e` -> `3b67ae3f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -363,11 +363,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697323135,
-        "narHash": "sha256-tlAv11c0NIRTk2IzpFxYknHrveeFXojVyCTAMg749Zg=",
+        "lastModified": 1697371398,
+        "narHash": "sha256-Tn5feZ5SoYHQM9BTjw5e06DuNu8wc21gC9+bq/kXA8Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d4a5076ea8c2c063c45e0165f9f75f69ef583e20",
+        "rev": "3b67ae3f665379c06999641f99d94dba75b53876",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`3b67ae3f`](https://github.com/nix-community/home-manager/commit/3b67ae3f665379c06999641f99d94dba75b53876) | `` services.cliphist: add module (#4445) `` |