### PR TITLE
chore(flake/home-manager): `3b67ae3f` -> `78125bc6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -363,11 +363,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697371398,
-        "narHash": "sha256-Tn5feZ5SoYHQM9BTjw5e06DuNu8wc21gC9+bq/kXA8Y=",
+        "lastModified": 1697410455,
+        "narHash": "sha256-jCs/ffIP3tUPN7HWWuae4BB8+haAw2NI02z5BQvWMGM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3b67ae3f665379c06999641f99d94dba75b53876",
+        "rev": "78125bc681d12364cb65524eaa887354134053d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`78125bc6`](https://github.com/nix-community/home-manager/commit/78125bc681d12364cb65524eaa887354134053d0) | `` firefox: add test for duplicate profile id assertion `` |
| [`f033205b`](https://github.com/nix-community/home-manager/commit/f033205b251439bda16fd9071b163b6eacb4fdf6) | `` firefox: extract an overlay common to all tests ``      |