### PR TITLE
chore(flake/lanzaboote): `82530e53` -> `778e2173`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -412,11 +412,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1697381239,
-        "narHash": "sha256-eWq9IToEq8wVpmREERX89EhHJzCBFc63J82o3sl2z0o=",
+        "lastModified": 1697447002,
+        "narHash": "sha256-SEirTeG4nOa78j8f/bvwyykUiURYPIQc/gkdxycDKSc=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "82530e530b8aba52ded2b124c978ed663c6b6a2c",
+        "rev": "778e21733b2b7d11771caee2b4678524042dfd51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                   |
| --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`bb5b2de5`](https://github.com/nix-community/lanzaboote/commit/bb5b2de5450ab6a725f35ab1512b59cbbcaf7830) | `` stub: pin goblin (again) ``                            |
| [`ace18ed4`](https://github.com/nix-community/lanzaboote/commit/ace18ed4bde61df6ab0d5fec2492f5170e9d4f39) | `` renovate: ignore goblin updates ``                     |
| [`eabbae0e`](https://github.com/nix-community/lanzaboote/commit/eabbae0e0cc4949c7da0e83d4052c3e4abd8b835) | `` fix(deps): update all dependencies ``                  |
| [`b02a7e2a`](https://github.com/nix-community/lanzaboote/commit/b02a7e2a7f5f91054ac1dbac3d271cfd613698a2) | `` stub: use command line from loader in insecure mode `` |
| [`db39223a`](https://github.com/nix-community/lanzaboote/commit/db39223a7c8a479d80c266fddfcb48f277f28052) | `` stub: make handling of insecure boot more explicit ``  |