### PR TITLE
chore(flake/home-manager): `78125bc6` -> `f6bb5c29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -363,11 +363,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697410455,
-        "narHash": "sha256-jCs/ffIP3tUPN7HWWuae4BB8+haAw2NI02z5BQvWMGM=",
+        "lastModified": 1697522331,
+        "narHash": "sha256-lfFRoFwTpgNRCtIAzV6cftWbwRnE0UgynwwVGkPXAAM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "78125bc681d12364cb65524eaa887354134053d0",
+        "rev": "f6bb5c297372719a6ea1c369b2b1a1aa10580452",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`f6bb5c29`](https://github.com/nix-community/home-manager/commit/f6bb5c297372719a6ea1c369b2b1a1aa10580452) | `` docs: add stateVersion to the NixOS/nix-darwin example `` |