### PR TITLE
chore(flake/home-manager): `f6bb5c29` -> `b25161c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -363,11 +363,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697522331,
-        "narHash": "sha256-lfFRoFwTpgNRCtIAzV6cftWbwRnE0UgynwwVGkPXAAM=",
+        "lastModified": 1697526467,
+        "narHash": "sha256-xX+XzphGlGsNybVPIZHQXzEKCE3aBa/cafeEhHuyk3Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f6bb5c297372719a6ea1c369b2b1a1aa10580452",
+        "rev": "b25161c6a2c3b7cabb9cfdc70c35007c8ecb7241",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`b25161c6`](https://github.com/nix-community/home-manager/commit/b25161c6a2c3b7cabb9cfdc70c35007c8ecb7241) | `` darkman: add module ``             |
| [`132f9851`](https://github.com/nix-community/home-manager/commit/132f9851858986d78db0b08157256384bbc5738c) | `` home-manager: add .editorconfig `` |