### PR TITLE
chore(flake/nixpkgs): `5e4c2ada` -> `7c9cc5a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -474,11 +474,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697059129,
-        "narHash": "sha256-9NJcFF9CEYPvHJ5ckE8kvINvI84SZZ87PvqMbH6pro0=",
+        "lastModified": 1697723726,
+        "narHash": "sha256-SaTWPkI8a5xSHX/rrKzUe+/uVNy6zCGMXgoeMb7T9rg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5e4c2ada4fcd54b99d56d7bd62f384511a7e2593",
+        "rev": "7c9cc5a6e5d38010801741ac830a3f8fd667a7a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`c9368669`](https://github.com/NixOS/nixpkgs/commit/c93686698322845b8057ed832460fd69a11b4cc7) | `` shopware-cli: 0.3.5 -> 0.3.6 ``                                                        |
| [`c22fed22`](https://github.com/NixOS/nixpkgs/commit/c22fed2281160f94c143eb26f0aeba238a6daa0d) | `` nixos/doc/manual/development/writing-documentation.xml: fix build command (#262044) `` |
| [`b83505ac`](https://github.com/NixOS/nixpkgs/commit/b83505ac38d2fd2649745a6c507342a81c13fd3d) | `` sentry-native: 0.6.5 -> 0.6.6 ``                                                       |
| [`399360be`](https://github.com/NixOS/nixpkgs/commit/399360bed39edaf3bdfa01a06bea08ad62ca6663) | `` sentry-cli: 2.21.1 -> 2.21.2 ``                                                        |
| [`347632b4`](https://github.com/NixOS/nixpkgs/commit/347632b4f87b47ee8ec507e047192cbf9ee4e30b) | `` sem: 0.28.3 -> 0.28.4 ``                                                               |
| [`1cc7ec13`](https://github.com/NixOS/nixpkgs/commit/1cc7ec134fe0d1ec5c67f815707980d8802edbec) | `` python311Packages.opower: 0.0.36 -> 0.0.37 ``                                          |
| [`ec0b3d14`](https://github.com/NixOS/nixpkgs/commit/ec0b3d1401ea6b88dbb813e07899f6f539864f4c) | `` python311Packages.griffe: 0.36.6 -> 0.36.7 ``                                          |
| [`d41a7b27`](https://github.com/NixOS/nixpkgs/commit/d41a7b2748973cdd7cd4b12382570139d09f5729) | `` checkov: 2.5.13 -> 2.5.14 ``                                                           |
| [`921aae99`](https://github.com/NixOS/nixpkgs/commit/921aae993b393436bde7fff2a805378fe02ce088) | `` python311Packages.casbin: 1.31.2 -> 1.32.0 ``                                          |
| [`8921ce61`](https://github.com/NixOS/nixpkgs/commit/8921ce61546a51cd880d0445080a94f2f2cb363e) | `` sqlfluff: 2.3.3 -> 2.3.4 ``                                                            |
| [`5855cb3f`](https://github.com/NixOS/nixpkgs/commit/5855cb3fb08c4956ec7a823022f9a082eeee06f7) | `` python311Packages.deezer-python: 6.1.0 -> 6.1.1 ``                                     |
| [`b9206dd7`](https://github.com/NixOS/nixpkgs/commit/b9206dd74679fc0d957bea8b8a7f1e12ad6fc119) | `` zookeeper: 3.7.1 -> 3.7.2 ``                                                           |
| [`67bfa339`](https://github.com/NixOS/nixpkgs/commit/67bfa339136ecfb9d7703e2c73d52f6430d40b25) | `` python311Packages.sagemaker: add changelog to meta ``                                  |
| [`a35ea2ee`](https://github.com/NixOS/nixpkgs/commit/a35ea2eea08aae3e8366d94daafda9e9678f60a0) | `` python311Packages.nbdev: update disabled ``                                            |
| [`73e6aff2`](https://github.com/NixOS/nixpkgs/commit/73e6aff26967f307007a730250108fdeac1d6894) | `` python311Packages.nbdev: add changelog to meta ``                                      |
| [`5f1d8b72`](https://github.com/NixOS/nixpkgs/commit/5f1d8b72555028a8c5cbc188f8ee39b233134254) | `` tusc-sh: 1.0.2 -> 1.1.0 ``                                                             |
| [`9f457bb6`](https://github.com/NixOS/nixpkgs/commit/9f457bb620528064d4cc4ecf477da3a60bc88638) | `` python311Packages.pyro5: update disabled ``                                            |
| [`2001590b`](https://github.com/NixOS/nixpkgs/commit/2001590b377c46376efbadc92266ff5122bd0b39) | `` opentracing-cpp: 1.5.1 -> 1.6.0 ``                                                     |
| [`97334912`](https://github.com/NixOS/nixpkgs/commit/9733491294820d9b2f3b680760a5b074bf484057) | `` python311Packages.unearth: 0.11.1 -> 0.11.2 ``                                         |
| [`354622b1`](https://github.com/NixOS/nixpkgs/commit/354622b10f53aeb97dd7ef56f267c6c18aabe3a9) | `` python311Packages.types-requests: 2.31.0.9 -> 2.31.0.10 ``                             |
| [`1a417539`](https://github.com/NixOS/nixpkgs/commit/1a417539fbb9fc69a2fa8d3394f5ca1c050489e5) | `` python311Packages.snowflake-connector-python: 3.2.0 -> 3.3.1 ``                        |
| [`e24eafee`](https://github.com/NixOS/nixpkgs/commit/e24eafeeab580dc3a0027be2adaa7b476a68b250) | `` emptty: 0.10.0 -> 0.11.0 ``                                                            |
| [`ca25eaf6`](https://github.com/NixOS/nixpkgs/commit/ca25eaf63196330e2778135edb28c2e3b5bb0e83) | `` python311Packages.slither-analyzer: 0.9.6 -> 0.10.0 ``                                 |
| [`a4ca8204`](https://github.com/NixOS/nixpkgs/commit/a4ca82044213c4df308618417fa1e31eb4897c52) | `` python311Packages.sagemaker: 2.192.1 -> 2.193.0 ``                                     |
| [`4a2788ea`](https://github.com/NixOS/nixpkgs/commit/4a2788ea2ad7f1607f272c829f37e79a396b4d1a) | `` appimageTools.extract: add postExtract option (#261190) ``                             |
| [`a3496cb6`](https://github.com/NixOS/nixpkgs/commit/a3496cb6d1c9bd3387c135aa133a2c2cbc728a6e) | `` python311Packages.pyro5: 5.14 -> 5.15 ``                                               |
| [`7ee3760c`](https://github.com/NixOS/nixpkgs/commit/7ee3760c985b40fe4e0edf79e27408d4a822441b) | `` scd2html: init at 1.0.0 ``                                                             |
| [`a59db2cc`](https://github.com/NixOS/nixpkgs/commit/a59db2cca8d6c27d00eb53f5d2b6a12cd8b6234e) | `` python311Packages.pyradios: 1.0.2 -> 2.0.0 ``                                          |
| [`3f11513c`](https://github.com/NixOS/nixpkgs/commit/3f11513c6c18150cf02e7857bf169b753fa4bca0) | `` python311Packages.plaid-python: 16.0.0 -> 17.0.0 ``                                    |
| [`0fd34941`](https://github.com/NixOS/nixpkgs/commit/0fd34941196d841c09fbb1919a6b1ed93b77ed8d) | `` python311Packages.tldextract: 5.0.0 -> 5.0.1 ``                                        |
| [`c2e470ff`](https://github.com/NixOS/nixpkgs/commit/c2e470ff235872d51fbe548c42a0dc8912e3744c) | `` python311Packages.python-roborock: 0.34.6 -> 0.35.0 ``                                 |
| [`8891e12c`](https://github.com/NixOS/nixpkgs/commit/8891e12c471281bf41ff44a3f4b2821a8f8bec9b) | `` python311Packages.niaarm: 0.3.2 -> 0.3.3 ``                                            |
| [`63ef7be0`](https://github.com/NixOS/nixpkgs/commit/63ef7be0e776b9d33e1ce2dd7d3f296145e072b7) | `` python311Packages.pyecoforest: 0.3.0 -> 0.4.0 ``                                       |
| [`6a843ce5`](https://github.com/NixOS/nixpkgs/commit/6a843ce58ef94a16146ea486e4803186ec3829d8) | `` python311Packages.kasa-crypt: 0.3.0 -> 0.4.0 ``                                        |
| [`8cfdfe88`](https://github.com/NixOS/nixpkgs/commit/8cfdfe88ef4a354ba80f0887a2fdefd161d90791) | `` python311Packages.censys: 2.2.7 -> 2.2.8 ``                                            |
| [`cdb90ef0`](https://github.com/NixOS/nixpkgs/commit/cdb90ef041d25a7fc8da9961c89718adb92ee96c) | `` wasm-tools: 1.0.45 -> 1.0.48 ``                                                        |
| [`40e50764`](https://github.com/NixOS/nixpkgs/commit/40e507645352e3e9efc7ce515d5f59ea531ae949) | `` python311Packages.nbdev: 2.3.12 -> 2.3.13 ``                                           |
| [`1dfc1763`](https://github.com/NixOS/nixpkgs/commit/1dfc176350a3f62057052925f8c6d61b1a05c014) | `` python311Packages.aiowaqi: 2.0.0 -> 2.1.0 ``                                           |
| [`f96f564d`](https://github.com/NixOS/nixpkgs/commit/f96f564d99d1f5c27484cf8811d9fe46af04867c) | `` python311Packages.dvc: 3.26.2 -> 3.27.0 ``                                             |
| [`8b4c7f7d`](https://github.com/NixOS/nixpkgs/commit/8b4c7f7d8fe1144f860b30958bfb88b607bb1b2e) | `` python311Packages.hvplot: 0.8.4 -> 0.9.0 ``                                            |
| [`5827f21f`](https://github.com/NixOS/nixpkgs/commit/5827f21fb87a4bd1fe376e867cfec1a5944150a2) | `` python311Packages.garth: 0.4.38 -> 0.4.39 ``                                           |
| [`db691047`](https://github.com/NixOS/nixpkgs/commit/db6910471f01fcf47a0680d1576d5a5bd3b78f3c) | `` alt-ergo: 2.5.1 -> 2.5.2 ``                                                            |
| [`52ed1bb8`](https://github.com/NixOS/nixpkgs/commit/52ed1bb836ec3f4bb258021b245174d1e92f9d6f) | `` fastly: 10.4.0 -> 10.5.0 ``                                                            |
| [`e1b21a43`](https://github.com/NixOS/nixpkgs/commit/e1b21a439eb52bd1eefcada950391ed058c3b4d9) | `` csdr: 0.18.1 -> 0.18.2 ``                                                              |
| [`cbe482b9`](https://github.com/NixOS/nixpkgs/commit/cbe482b9668a957bcc5825f68d180b1eb6fee475) | `` saga: 9.1.1 -> 9.2.0 ``                                                                |
| [`85546160`](https://github.com/NixOS/nixpkgs/commit/85546160d399a6fad03de8368aec06a705728823) | `` ryzenadj: 0.13.0 -> 0.14.0 ``                                                          |
| [`989c3f91`](https://github.com/NixOS/nixpkgs/commit/989c3f91b29908d367e4c93f96c8a0c39e6ec873) | `` rust-analyzer-unwrapped: 2023-10-02 -> 2023-10-16 ``                                   |
| [`31673ceb`](https://github.com/NixOS/nixpkgs/commit/31673ceb4def66010c547fe9801b0524ea7f08b4) | `` lightstep-tracer-cpp: drop ``                                                          |
| [`b40f7f31`](https://github.com/NixOS/nixpkgs/commit/b40f7f310c8b276ddbe34452f127e7e858e9603e) | `` rsclock: 0.1.9 -> 0.1.10 ``                                                            |
| [`7eaf47de`](https://github.com/NixOS/nixpkgs/commit/7eaf47dee26f36c131a7231436218203637d31fb) | `` roxctl: 4.2.0 -> 4.2.1 ``                                                              |
| [`ccff7d23`](https://github.com/NixOS/nixpkgs/commit/ccff7d233259eb02bf50125f23a17d35995a2475) | `` rofi-pass: unstable-2023-07-04 -> unstable-2023-07-07 ``                               |
| [`78d5ef88`](https://github.com/NixOS/nixpkgs/commit/78d5ef88dae11fb709710ec441069c05d280fc49) | `` octorpki: vendorSha256 -> vendorHash ``                                                |
| [`4c620881`](https://github.com/NixOS/nixpkgs/commit/4c620881013665ce47bcc9d33573453726b035e0) | `` python311Packages.horizon-eda: init at 2.5.0 ``                                        |
| [`e5c6a534`](https://github.com/NixOS/nixpkgs/commit/e5c6a53405792a9aa433718fc7d79de389d62608) | `` budgie.budgie-desktop: 10.8.1 -> 10.8.2 ``                                             |
| [`8a4fa377`](https://github.com/NixOS/nixpkgs/commit/8a4fa377e32fc9af319c8deb4a4cca5d8fcdf5bb) | `` python3Packages.flask-openid: drop disabled = !isPy3k after Python 2 EOL ``            |
| [`52482b26`](https://github.com/NixOS/nixpkgs/commit/52482b26fcfe985f90585784be16ab698c53bfd5) | `` onionshare: drop disabled = !isPy3k after Python2 EOL ``                               |
| [`115b7994`](https://github.com/NixOS/nixpkgs/commit/115b7994b0fa8c75de738ffdf564785e0f03c606) | `` pythonPackages: fix input argument typos ``                                            |
| [`3d06297a`](https://github.com/NixOS/nixpkgs/commit/3d06297aca045f383396985f0c761707ff4ba97d) | `` presenterm: init at 0.2.0 ``                                                           |
| [`14c9544e`](https://github.com/NixOS/nixpkgs/commit/14c9544e25d4e2bf8f16741d27a5819a08acf364) | `` qt6.qtwebengine: fix platform detection on darwin ``                                   |
| [`f203901b`](https://github.com/NixOS/nixpkgs/commit/f203901b4f1dd85920efdfeda801b54778186f0f) | `` horizon-eda: clarify package license ``                                                |
| [`0f7f84dc`](https://github.com/NixOS/nixpkgs/commit/0f7f84dc1b2dc1aa4a330422a2a0ed5568b376dd) | `` windmill: add happysalada as maintainer ``                                             |
| [`af185f46`](https://github.com/NixOS/nixpkgs/commit/af185f46539dd174d6609fb4599b587df2ded861) | `` windmill: 1.160.0 -> 1.184.0 ``                                                        |
| [`36226bf1`](https://github.com/NixOS/nixpkgs/commit/36226bf19dec23b6233d1c3fb842f30ce378c76b) | `` runme: 1.7.6 -> 1.7.7 ``                                                               |
| [`57431777`](https://github.com/NixOS/nixpkgs/commit/57431777829131d7283e26845781dbba3b9a1b80) | `` vpn-slice: switch maintainer to liketechnik ``                                         |
| [`9662c178`](https://github.com/NixOS/nixpkgs/commit/9662c1782bce2c8f57fae090486d699bbfe9bccd) | `` trufflehog: 3.60.0 -> 3.60.1 ``                                                        |
| [`a432920c`](https://github.com/NixOS/nixpkgs/commit/a432920cc0823d7cad4dc4a679ca261194e42f04) | `` python311Packages.bluetooth-data-tools: 1.12.0 -> 1.13.0 ``                            |
| [`c90b9bcf`](https://github.com/NixOS/nixpkgs/commit/c90b9bcfbfcb75e1f16ab703ced284e12f9c232b) | `` python311Packages.pyacaia-async: 0.0.7 -> 0.0.8 ``                                     |
| [`1470040d`](https://github.com/NixOS/nixpkgs/commit/1470040d407fd91d4e5fe65d07d5bb0bef970fc5) | `` python311Packages.pycatch22: update license ``                                         |
| [`5b0f6b31`](https://github.com/NixOS/nixpkgs/commit/5b0f6b316f4106c1a157ee54ec1744e45b86d12b) | `` python311Packages.aiowithings: 0.3.0 -> 0.4.4 ``                                       |
| [`8472b6b9`](https://github.com/NixOS/nixpkgs/commit/8472b6b915776f6e6cbd72ad0f7c3ea0520f5658) | `` checkov: 2.5.10 -> 2.5.13 ``                                                           |
| [`526d83ce`](https://github.com/NixOS/nixpkgs/commit/526d83ce109a039a51212d873957afb58acba6bb) | `` python311Packages.aioopenexchangerates: 0.4.2 -> 0.4.3 ``                              |
| [`bcbe5875`](https://github.com/NixOS/nixpkgs/commit/bcbe587526652810ed5d6f0c8896bf42df6f52dc) | `` rPackages.quarto: add quarto to propagatedBuildInputs ``                               |
| [`24ed4844`](https://github.com/NixOS/nixpkgs/commit/24ed4844019ad22449ea3239523df27a1adf8b69) | `` grafana-agent: 0.37.1 -> 0.37.2 ``                                                     |
| [`825dc0f5`](https://github.com/NixOS/nixpkgs/commit/825dc0f51c0675abec49d76d3d44fe29a41a62ce) | `` op-geth: 1.101200.1 -> 1.101301.1 ``                                                   |
| [`ac30ac80`](https://github.com/NixOS/nixpkgs/commit/ac30ac808a1425ebc1b7bd513b6e851f1311c249) | `` nixos/virt-manager: init ``                                                            |
| [`1a94590d`](https://github.com/NixOS/nixpkgs/commit/1a94590d27c6f544b475deb1ddfd8ded73af22a2) | `` zoom-us: 5.16.1.8561 -> 5.16.2.8828 ``                                                 |
| [`43564e5b`](https://github.com/NixOS/nixpkgs/commit/43564e5bd5d5b6f58a98fb62ece6730cb919cf28) | `` slippy: 0.1.0 -> 0.1.1 ``                                                              |
| [`5b670d83`](https://github.com/NixOS/nixpkgs/commit/5b670d83628a44ee1946c2f0826c7aac27012547) | `` rambox: 2.1.5 -> 2.2.0 ``                                                              |
| [`2ee12a93`](https://github.com/NixOS/nixpkgs/commit/2ee12a93de090b8b735d673228c9df3c0fa49511) | `` treewide: remove myself (ma27) from a few packages ``                                  |
| [`0aa2e8f9`](https://github.com/NixOS/nixpkgs/commit/0aa2e8f960e4296b731ef8d60f5a45b1c62691ed) | `` python310Packages.paddleocr: 2.7.0 -> 2.7.1 ``                                         |
| [`90475cef`](https://github.com/NixOS/nixpkgs/commit/90475ceff8dc3eef81313407629798417a2689ea) | `` nixos/tang: add to release notes ``                                                    |
| [`7f6e52f7`](https://github.com/NixOS/nixpkgs/commit/7f6e52f7fcd116a54d06e06bfcdc8f7d27ae8c67) | `` python311Packages.uhi: 0.3.3 -> 0.4.0 ``                                               |
| [`2e32e89b`](https://github.com/NixOS/nixpkgs/commit/2e32e89b7e078e9d4e8c1de501ca716605f276dc) | `` squeezelite: add meta.mainProgram ``                                                   |
| [`841c786d`](https://github.com/NixOS/nixpkgs/commit/841c786d523d136b387a303cfbd28385e2488d0d) | `` libbytesize: 2.9 -> 2.10 ``                                                            |
| [`dee28096`](https://github.com/NixOS/nixpkgs/commit/dee28096a4ec87e84a648dcc643ac27e65bacbd1) | `` bemoji: init at 0.3.0 ``                                                               |
| [`33430524`](https://github.com/NixOS/nixpkgs/commit/334305249f3eab41351ee907c3d08cfa82a1f4d2) | `` opentofu: 1.6.0-alpha2 -> 1.6.0-alpha3 ``                                              |
| [`770d1c5b`](https://github.com/NixOS/nixpkgs/commit/770d1c5bcdd664f5be3b74b8b0d0cdbb21da139b) | `` nixos/garage: drop default package ``                                                  |
| [`5b80b755`](https://github.com/NixOS/nixpkgs/commit/5b80b755aa60f8c5e3dd46d92a437d7f82628ca1) | `` nixos/garage: nixpkgs-fmt ``                                                           |
| [`45e438fd`](https://github.com/NixOS/nixpkgs/commit/45e438fd89ccb4bd36ea241b186dde7cb532ca48) | `` nixosTests.garage: fix ``                                                              |
| [`d9c73ef0`](https://github.com/NixOS/nixpkgs/commit/d9c73ef08774001f7c73fb6fbebaf5f29b9a869a) | `` garage: point garage to garage_0_9 ``                                                  |
| [`725d22d9`](https://github.com/NixOS/nixpkgs/commit/725d22d9c1fa8fca019d82b88ca69dfec3379c97) | `` garage: apply MacOS build patch ``                                                     |
| [`71040ea5`](https://github.com/NixOS/nixpkgs/commit/71040ea59e2837abcf6b42ca328460a41f4e960e) | `` garage: nixpkgs-fmt ``                                                                 |
| [`be85addb`](https://github.com/NixOS/nixpkgs/commit/be85addb7fda7fc2a1b1a51f1d285a90f8000c5b) | `` garage_0_9: init at 0.9.0 ``                                                           |
| [`e6dea398`](https://github.com/NixOS/nixpkgs/commit/e6dea3982e59336b39ba4eb6fa7fcb0608997f03) | `` garage_0_7: drop ``                                                                    |
| [`d97ec147`](https://github.com/NixOS/nixpkgs/commit/d97ec147f2a3ede6fb561e0a28ba1f9f5aafa7a6) | `` prometheus-ipmi-exporter: 1.6.1 -> 1.7.0 ``                                            |
| [`5b689b36`](https://github.com/NixOS/nixpkgs/commit/5b689b360b87d6192e4a252d908510660d364e04) | `` qView: fix failed build when x11Support is false ``                                    |
| [`f4e599a7`](https://github.com/NixOS/nixpkgs/commit/f4e599a7756807c8a23d96fb383c5b803fcc6f2a) | `` losslesscut-bin: 3.55.2 -> 3.58.0 ``                                                   |
| [`a4a20966`](https://github.com/NixOS/nixpkgs/commit/a4a209666e2dcd62245f205c90e0ae08fc5adc26) | `` qView: 5.0 -> 6.1 ``                                                                   |
| [`20319223`](https://github.com/NixOS/nixpkgs/commit/20319223ee069732df8fffcdf8937e30bcfbc0f5) | `` nixosTests.sssd: add aarch64-linux platform ``                                         |
| [`9de2a821`](https://github.com/NixOS/nixpkgs/commit/9de2a821a6c8602907860c70c85566bf5bf3bcaf) | `` python311Packages.unstructured: 0.10.23 -> 0.10.24 ``                                  |
| [`0c0b23b1`](https://github.com/NixOS/nixpkgs/commit/0c0b23b1d0ce1c4594e759be456f6106a977b2f8) | `` uiua386: init at 0.0.19 ``                                                             |
| [`f3720f2e`](https://github.com/NixOS/nixpkgs/commit/f3720f2e61345491e5f138bbafdf782306af451a) | `` kubevirt: 1.0.0 -> 1.0.1 ``                                                            |
| [`b887a4b9`](https://github.com/NixOS/nixpkgs/commit/b887a4b9381f7871d29330db71feb45983deb4f5) | `` kube-bench: 0.6.17 -> 0.6.18 ``                                                        |
| [`b4612f97`](https://github.com/NixOS/nixpkgs/commit/b4612f975b34f7dccec80e4988fa01027ac9f822) | `` nixVersions.nix_2_17: 2.17 -> 2.17.1 ``                                                |
| [`68adacd9`](https://github.com/NixOS/nixpkgs/commit/68adacd935e9d2c0b0398d058fff217ede7143d7) | `` google-cloud-sql-proxy: 2.7.0 -> 2.7.1 ``                                              |
| [`b843f75a`](https://github.com/NixOS/nixpkgs/commit/b843f75a559a91d8203e17a671bf0195cc7a599f) | `` enumer: 1.5.8 -> 1.5.9 ``                                                              |
| [`c3528adc`](https://github.com/NixOS/nixpkgs/commit/c3528adc2a8bdafe84d047a72c01e25f651f1634) | `` wb32-dfu-updater: apply suggestions from code review ``                                |
| [`0e7bf03d`](https://github.com/NixOS/nixpkgs/commit/0e7bf03d3ffc98a24ace2769d36f1469164ded1e) | `` findomain: 9.0.1 -> 9.0.2 ``                                                           |
| [`7e6d2586`](https://github.com/NixOS/nixpkgs/commit/7e6d2586641682d068bdcb5fbb0d2091ac6a388c) | `` minecraftia: init at 1.0 ``                                                            |
| [`21754df0`](https://github.com/NixOS/nixpkgs/commit/21754df096ffea71cd7e0a44d61b5e04e4cc3820) | `` turtle-build: 0.4.6 -> 0.4.7 ``                                                        |