### PR TITLE
chore(flake/home-manager): `b3acf1dc` -> `3433206e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -363,11 +363,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697555443,
-        "narHash": "sha256-nsq8A+adEdN7bvVdz09LFyrHkTW5GtOzo/ctlHhyaaE=",
+        "lastModified": 1697662575,
+        "narHash": "sha256-fVtd4Le9edB831xyGWu0aqSfg6YVbkCNMX/IE3SUIdk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b3acf1dc78b38a2fe03b287fead44d7ad25ac7c5",
+        "rev": "3433206e51766b4164dad368a81325efbf343fbe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`3433206e`](https://github.com/nix-community/home-manager/commit/3433206e51766b4164dad368a81325efbf343fbe) | `` qutebrowser: add greasemonkey userscript option ``       |
| [`54c1ca74`](https://github.com/nix-community/home-manager/commit/54c1ca74d949aa900f9723cef8408ddc32352a05) | `` flake.lock: Update ``                                    |
| [`84fa81c7`](https://github.com/nix-community/home-manager/commit/84fa81c7acb018c3c5a504dcefbc28a182c933c2) | `` fzf: add mkOrder for fish like we do for other shells `` |
| [`cffc9938`](https://github.com/nix-community/home-manager/commit/cffc9938c71ef5f80df032ff67f9f643f979579e) | `` fzf: fix fish integration ``                             |
| [`05649393`](https://github.com/nix-community/home-manager/commit/05649393ac1f34980a5cf6a6e89de77626c9182b) | `` recoll: update option descriptions ``                    |
| [`3e1f8df4`](https://github.com/nix-community/home-manager/commit/3e1f8df4f0036124e18a37ad227d3c97ba29d214) | `` thefuck: add instant mode option ``                      |