### PR TITLE
chore(flake/home-manager): `3433206e` -> `c5c1ea85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -363,11 +363,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697662575,
-        "narHash": "sha256-fVtd4Le9edB831xyGWu0aqSfg6YVbkCNMX/IE3SUIdk=",
+        "lastModified": 1697688028,
+        "narHash": "sha256-d9CAOd9W2iTrgB31a8Dvyp6Vgn/gxASCNrD4Z9yzUOY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3433206e51766b4164dad368a81325efbf343fbe",
+        "rev": "c5c1ea85181d2bb44e46e8a944a8a3f56ad88f19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`c5c1ea85`](https://github.com/nix-community/home-manager/commit/c5c1ea85181d2bb44e46e8a944a8a3f56ad88f19) | `` Translate using Weblate (Portuguese) `` |
| [`a969307e`](https://github.com/nix-community/home-manager/commit/a969307eb96651c73cacbc38157144cd023eb78c) | `` Translate using Weblate (Lithuanian) `` |
| [`92bf9c25`](https://github.com/nix-community/home-manager/commit/92bf9c2585a1a3105d34becb2ed41ae5022d292c) | `` Translate using Weblate (Turkish) ``    |