### PR TITLE
chore(flake/stylix): `feceaa9d` -> `b2f73724`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697094532,
-        "narHash": "sha256-SvTC0wNCGpoUBvo9//IoTv5NQjozY0Y5ViTziRO+vt8=",
+        "lastModified": 1697720625,
+        "narHash": "sha256-4/k6fyBWWJktsyPVnaa+olOR0PRpn3GDa9YiNyFzTso=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "feceaa9d81725c0ca28ab46326b6dd1310a10dea",
+        "rev": "b2f73724d11868d020207fb87fb2d9c3ae96976d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                     |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`b2f73724`](https://github.com/danth/stylix/commit/b2f73724d11868d020207fb87fb2d9c3ae96976d) | `` Add font support for Xfce4 (#171) ``                     |
| [`4c1acb81`](https://github.com/danth/stylix/commit/4c1acb81642fc1721a0059232ebc41d254b5149b) | `` Zathura: remove default recolor configurations (#174) `` |