### PR TITLE
chore(flake/darwin): `8b6ea26d` -> `19f75c2b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -212,11 +212,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696360011,
-        "narHash": "sha256-HpPv27qMuPou4acXcZ8Klm7Zt0Elv9dgDvSJaomWb9Y=",
+        "lastModified": 1697723594,
+        "narHash": "sha256-W7lTC+kHGS1YCOutGpxUHF0cK66iY/GYr3INaTyVa/I=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "8b6ea26d5d2e8359d06278364f41fbc4b903b28a",
+        "rev": "19f75c2b45fbfc307ecfeb9dadc41a4c1e4fb980",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                              |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
| [`e621b5ae`](https://github.com/LnL7/nix-darwin/commit/e621b5aea75810e7228a9ebc93f82b8b41008e7e) | `` Provide 'supportedFeatures' option to the linux builder module `` |