### PR TITLE
chore(flake/nixos-hardware): `fb6af288` -> `72d53d51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -471,11 +471,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1697100850,
-        "narHash": "sha256-qSAzJVzNRIo+r3kBjL8TcpJctcgcHlnZyqdzpWgtg0M=",
+        "lastModified": 1697748412,
+        "narHash": "sha256-5VSB63UE/O191cuZiGHbCJ9ipc7cGKB8cHp0cfusuyo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "fb6af288f6cf0f00d3af60cf9d5110433b954565",
+        "rev": "72d53d51704295f1645d20384cd13aecc182f624",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`72d53d51`](https://github.com/NixOS/nixos-hardware/commit/72d53d51704295f1645d20384cd13aecc182f624) | `` starfive visionfive2: combine 8gb dtb overlays ``                           |
| [`32264b21`](https://github.com/NixOS/nixos-hardware/commit/32264b21bb23fbc00672b3ed6fcfaa5489d03991) | `` purism/librem5r4: linuxPackages_librem5: 6.5.4-librem5 -> 6.5.6-librem5 ``  |
| [`82804ab7`](https://github.com/NixOS/nixos-hardware/commit/82804ab7108754ee961f868facaafa88341cf881) | `` purism/librem5r4: linuxPackages_librem5: 6.4.14-librem5 -> 6.5.4-librem5 `` |
| [`e40b26d8`](https://github.com/NixOS/nixos-hardware/commit/e40b26d814e9c8490d6f1be42c8d9c2864097212) | `` ROG Ally: Add basic config as default.nix ``                                |
| [`6e1fd3d5`](https://github.com/NixOS/nixos-hardware/commit/6e1fd3d5c267b10f44b59e437422f11cc8a3790c) | `` Add amd pstate to all omen laptops (#763) ``                                |