### PR TITLE
chore(flake/lanzaboote): `0c38cbfa` -> `4366cd1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -400,11 +400,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1697749166,
-        "narHash": "sha256-+cy5tRLk+6R6FOeDZjncZ7S8HQG7lU9R0pjunUidRaQ=",
+        "lastModified": 1697908998,
+        "narHash": "sha256-RDkIPCKcpEHfez3GoDoXYLCooautjeS3jpbl1LXMG9g=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "0c38cbfa6a59d228917d3d6c1fcbdd5dcec218e1",
+        "rev": "4366cd1b4caa87f0c061e28e65860c2a51b6ded4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                    |
| --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`ec05d707`](https://github.com/nix-community/lanzaboote/commit/ec05d707f3d1a3e1a1540b8dab8abfeb171f25c8) | `` tool: always include version in PRETTY_NAME ``          |
| [`3da3049b`](https://github.com/nix-community/lanzaboote/commit/3da3049bef08f0d3e48fbbe611f61b358ef04c31) | `` tool: remove unhelpful wrappers and lightly refactor `` |