### PR TITLE
chore(flake/nix-index-database): `d1d9ae91` -> `5a200628`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -444,11 +444,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697943451,
-        "narHash": "sha256-9d1vprXXgj6Ll5lfSCPYExx351ma7QkBAPmFFNj9ISQ=",
+        "lastModified": 1697946153,
+        "narHash": "sha256-7k7qIwWLaYPgQ4fxmEdew3yCffhK6rM4I4Jo3X/79DA=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "d1d9ae914431177d3898605aabbaad0d37803649",
+        "rev": "5a2006282caaf32663cdcd582c5b18809c7d7d8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`5a200628`](https://github.com/nix-community/nix-index-database/commit/5a2006282caaf32663cdcd582c5b18809c7d7d8d) | `` update packages.nix to release 2023-10-22-034115 `` |