### PR TITLE
chore(flake/stylix): `b2f73724` -> `9e88d05a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -618,11 +618,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697720625,
-        "narHash": "sha256-4/k6fyBWWJktsyPVnaa+olOR0PRpn3GDa9YiNyFzTso=",
+        "lastModified": 1697999074,
+        "narHash": "sha256-XOGeMMRsF8RywSiiGLkKe60vtG4b+1pGTe64XPhetmQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "b2f73724d11868d020207fb87fb2d9c3ae96976d",
+        "rev": "9e88d05a851d4919ad5c729fdf0993817efacb02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                       |
| --------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`9e88d05a`](https://github.com/danth/stylix/commit/9e88d05a851d4919ad5c729fdf0993817efacb02) | `` Apply dark mode to Qutebrowser (#175) ``   |
| [`71c2eb22`](https://github.com/danth/stylix/commit/71c2eb2214a90a3a75efa78b7176f614a9a7eb4c) | `` Fix cursor foreground in WezTerm (#177) `` |