### PR TITLE
chore(flake/home-manager): `14b54157` -> `09587fbb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698162493,
-        "narHash": "sha256-Zehw3cWiTXGGlDDjzTgIX1BhWG+049D/RcSMAiypAcM=",
+        "lastModified": 1698250431,
+        "narHash": "sha256-qs2gTeH4wpnWPO6Oi6sOhp2IhG0i0DzcnrJxIY3/CP8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "14b54157201fd574b0fa1b3ce7394c9d3a87fbc1",
+        "rev": "09587fbbc6a669f7725613e044c2577dc5d43ab5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`09587fbb`](https://github.com/nix-community/home-manager/commit/09587fbbc6a669f7725613e044c2577dc5d43ab5) | `` hyprland: add tray.target ``       |
| [`9d0f799c`](https://github.com/nix-community/home-manager/commit/9d0f799c669833677df31306149d763dbff00e6f) | `` helix: add extraPackages option `` |