### PR TITLE
chore(flake/nixpkgs): `8efd5d1e` -> `63678e9f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -474,11 +474,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698134075,
-        "narHash": "sha256-foCD+nuKzfh49bIoiCBur4+Fx1nozo+4C/6k8BYk4sg=",
+        "lastModified": 1698318101,
+        "narHash": "sha256-gUihHt3yPD7bVqg+k/UVHgngyaJ3DMEBchbymBMvK1E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8efd5d1e283604f75a808a20e6cde0ef313d07d4",
+        "rev": "63678e9f3d3afecfeafa0acead6239cdb447574c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`9954349d`](https://github.com/NixOS/nixpkgs/commit/9954349db2fa51d060843af9c92d77f55b158989) | `` breakpad: unstable-3b3469e -> 2023.01.27 ``                                              |
| [`8173b255`](https://github.com/NixOS/nixpkgs/commit/8173b255dc1ba7b24aa6d9fa80d3a2a3f1c1747e) | `` python3Packages.tblite: fix toml-f 0.4 compatibility ``                                  |
| [`5438b830`](https://github.com/NixOS/nixpkgs/commit/5438b83028a83e320f5fae9b11a11478b149c391) | `` nixos/acme: fix assertion, add actual values to message (#263543) ``                     |
| [`3bccc246`](https://github.com/NixOS/nixpkgs/commit/3bccc246edef07617842ad0205f8d703a4df236c) | `` trayscale: 0.9.7 -> 0.10.4 ``                                                            |
| [`6a60bf09`](https://github.com/NixOS/nixpkgs/commit/6a60bf095c56182710e5e79d784fb35e7de93c49) | `` dolt: 1.18.1 -> 1.21.4 ``                                                                |
| [`9761feba`](https://github.com/NixOS/nixpkgs/commit/9761feba42b3a198a30e440cbfbcd2cd33ebb45b) | `` check-jsonschema: 0.23.3 -> 0.25.0 ``                                                    |
| [`ff7db125`](https://github.com/NixOS/nixpkgs/commit/ff7db1253cf0ddc8d257008837228ed9ddb63604) | `` python311Packages.screenlogicpy: 0.9.3 -> 0.9.4 ``                                       |
| [`7031dd49`](https://github.com/NixOS/nixpkgs/commit/7031dd49c7f7d0d54a1bcb909cd4cd83afcae9ea) | `` python311Packages.publicsuffixlist: 0.10.0.20231022 -> 0.10.0.20231026 ``                |
| [`410bbcd2`](https://github.com/NixOS/nixpkgs/commit/410bbcd2c90f7eb53e5a3aa75ac034921612055f) | `` python311Packages.peaqevcore: 19.5.6 -> 19.5.10 ``                                       |
| [`5257cb0a`](https://github.com/NixOS/nixpkgs/commit/5257cb0a756dcda7d3703bd9c7c93be3c6854ae2) | `` ocamlPackages.cooltt: 2022-04-28 → 2023-10-03 ``                                         |
| [`7b4f9b74`](https://github.com/NixOS/nixpkgs/commit/7b4f9b740eca05add3db5cf70df3d9d68070208e) | `` ocamlPackages.yuujinchou: 4.0.0 → 5.1.0 ``                                               |
| [`90fbf7f2`](https://github.com/NixOS/nixpkgs/commit/90fbf7f2ffcc095e46da8ead5e8b67385bb42ec8) | `` velero: 1.12.0 -> 1.12.1 ``                                                              |
| [`85b1e7e4`](https://github.com/NixOS/nixpkgs/commit/85b1e7e4f000e18434ce06d415615142cebcac84) | `` scalr-cli: 0.15.1 -> 0.15.2 ``                                                           |
| [`b4371a5c`](https://github.com/NixOS/nixpkgs/commit/b4371a5cea9ce20942653d18d432f5d18dd4f456) | `` glibc: weaken host==build check to canExecute ``                                         |
| [`27a73cd1`](https://github.com/NixOS/nixpkgs/commit/27a73cd1769ca05e9a1eb184edc9df9c844af733) | `` glibc: use (lib.getBin pkgsBuildBuild.glibc) to generate locales ``                      |
| [`ca2a9305`](https://github.com/NixOS/nixpkgs/commit/ca2a93057462e4398ed7de04d32eb86509ded805) | `` python311Packages.whispers: 2.1.5 -> 2.2.0 ``                                            |
| [`9a6cbc15`](https://github.com/NixOS/nixpkgs/commit/9a6cbc1524e314f141bed0ef24d6a04e0376746a) | `` iosevka-bin: 27.2.1 -> 27.3.1 ``                                                         |
| [`ae4ea4a1`](https://github.com/NixOS/nixpkgs/commit/ae4ea4a1fa49f5b727f51f3f872f5f99121b6c91) | `` python311Packages.sphinxcontrib-openapi: 0.8.1 -> 0.8.3 ``                               |
| [`98dc4cfa`](https://github.com/NixOS/nixpkgs/commit/98dc4cfa9c59fb407e208d5a125c77b36d1d0bbf) | `` libretro.mame2016: fix build on Python 3.11+ ``                                          |
| [`0b8da5fd`](https://github.com/NixOS/nixpkgs/commit/0b8da5fde3a371f9d34bc27da3def771ef0d5401) | `` libretro.mame2015: fix build on Python 3.11+ ``                                          |
| [`b5575a6c`](https://github.com/NixOS/nixpkgs/commit/b5575a6c66f2797a7fb2eb7a6671fe9bbad8b0c6) | `` python311Packages.qcelemental: 0.26.0 -> 0.27.0 ``                                       |
| [`d3713f15`](https://github.com/NixOS/nixpkgs/commit/d3713f15af70c48e7873ec7133e93c16d47bff25) | `` python311Packages.pylint-venv: 3.0.2 -> 3.0.3 ``                                         |
| [`12a6c541`](https://github.com/NixOS/nixpkgs/commit/12a6c541aa2e54467f18bc61dab79a3d20c648d6) | `` python311Packages.paypalrestsdk: 1.13.1 -> 1.13.2 ``                                     |
| [`c8deed91`](https://github.com/NixOS/nixpkgs/commit/c8deed91c76df63ce16a8cf45558cbd197df65df) | `` kweathercore: 0.6 -> 0.7 ``                                                              |
| [`9a44f7f5`](https://github.com/NixOS/nixpkgs/commit/9a44f7f5e696e746e93bc4c9bfe61c97ae17f4f1) | `` python311Packages.casa-formats-io: 0.2.1 -> 0.2.2 ``                                     |
| [`75368305`](https://github.com/NixOS/nixpkgs/commit/75368305af5c40ff0d75148fa12fc7cf50d241c4) | `` libvarlink: fix cross compilation by using the correct python3 for varlink-wrapper.py `` |
| [`c8c3423a`](https://github.com/NixOS/nixpkgs/commit/c8c3423a38e672dd2fd63e9ccfb372639a63ca27) | `` dart: update homepage link ``                                                            |
| [`9063bc67`](https://github.com/NixOS/nixpkgs/commit/9063bc67fc934c1e23d0c33d288838f4eab23ffb) | `` python311Packages.aws-adfs: 2.8.2 -> 2.9.0 ``                                            |
| [`15981fa4`](https://github.com/NixOS/nixpkgs/commit/15981fa4fe4b8d3a686bfb4f57456491c3253f0a) | `` pythonPackages.pyslurm: use getLib/getDev ``                                             |
| [`66855302`](https://github.com/NixOS/nixpkgs/commit/668553027f1b0e5e5695b3c8703e208867dbcaa1) | `` pythonPackages.pyslurm: add patch to fix build ``                                        |
| [`6c41b2d4`](https://github.com/NixOS/nixpkgs/commit/6c41b2d4f8b6b4ad515becda4e89c59c9d396b9a) | `` vscode-extensions.uiua-lang.uiua-vscode: 0.0.19 -> 0.0.21 ``                             |
| [`3904aea3`](https://github.com/NixOS/nixpkgs/commit/3904aea328dc1a81abc43717ee1f0ab30bad71e6) | `` uiua: 0.0.22 -> 0.0.23 ``                                                                |
| [`28955a33`](https://github.com/NixOS/nixpkgs/commit/28955a3339c07c5fb148c4d874a621290c7d41cc) | `` python311Packages.aiostream: 0.5.1 -> 0.5.2 ``                                           |
| [`8c462229`](https://github.com/NixOS/nixpkgs/commit/8c462229c330e18c5bb1ec7b4e30719db5546b74) | `` ceph: drop sqlalchemy override ``                                                        |
| [`5b1ef640`](https://github.com/NixOS/nixpkgs/commit/5b1ef640e39e54b0521dfe99b0eb6f6084fc8359) | `` kubeshark: 50.4 -> 51.0.14 ``                                                            |
| [`f756e946`](https://github.com/NixOS/nixpkgs/commit/f756e946a525a0aa89d40fd6c74ab8613a942300) | `` python311Packages.accuweather: 1.0.0 -> 2.0.0 ``                                         |
| [`a80b2643`](https://github.com/NixOS/nixpkgs/commit/a80b2643842fde2405a45847f12651d314c1b90b) | `` helix: 23.05 -> 23.10 ``                                                                 |
| [`dbc13a6b`](https://github.com/NixOS/nixpkgs/commit/dbc13a6b4ffe32e4c2bde41fdfc3fdd01fb01e9d) | `` python311Packages.aiosmtplib: 2.0.2 -> 3.0.0 ``                                          |
| [`88b3918f`](https://github.com/NixOS/nixpkgs/commit/88b3918f563ab468be1dcc563c2a4e55650e48bf) | `` ospd-openvas: 22.6.0 -> 22.6.1 ``                                                        |
| [`8942d300`](https://github.com/NixOS/nixpkgs/commit/8942d3009cb87fc22d6a7436861c2346bd3043e2) | `` trufflehog: 3.60.1 -> 3.60.3 ``                                                          |
| [`bc6de050`](https://github.com/NixOS/nixpkgs/commit/bc6de050b4071a6a39ec879a0eeda729776b182a) | `` syncstorage-rs: remove unused openssl input ``                                           |
| [`bc1cced1`](https://github.com/NixOS/nixpkgs/commit/bc1cced11141e1f8e8be131d7e0cb0595b186488) | `` kickoff: 0.7.0 -> 0.7.1 ``                                                               |
| [`413011dd`](https://github.com/NixOS/nixpkgs/commit/413011ddf46265756c0ba417c8722952eab853c6) | `` kea: use separate runtime directories for each service ``                                |
| [`7464a8bc`](https://github.com/NixOS/nixpkgs/commit/7464a8bc8d1b7944d9acd8b95d400e36b7c3e2e6) | `` python311Packages.pysolcast: 1.0.14 -> 1.0.15 ``                                         |
| [`37cd6d59`](https://github.com/NixOS/nixpkgs/commit/37cd6d59dfb35329c6c5a1441d5536be7f2096b8) | `` python311Packages.pyenphase: 1.13.1 -> 1.14.0 ``                                         |
| [`e1fd6d16`](https://github.com/NixOS/nixpkgs/commit/e1fd6d16bdf354f89c2fbc3939da4b348f1ee9b3) | `` python311Packages.winacl: 0.1.7 -> 0.1.8 ``                                              |
| [`00df4241`](https://github.com/NixOS/nixpkgs/commit/00df4241523ab948aff55f88c815863a8c33f3d2) | `` python311Packages.zha-quirks: 0.0.105 -> 0.0.106 ``                                      |
| [`bc3db43b`](https://github.com/NixOS/nixpkgs/commit/bc3db43b9ce10763a97a804ae165257d12f46374) | `` python311Packages.pyeconet: 0.1.20 -> 0.1.21 ``                                          |
| [`9fbb1213`](https://github.com/NixOS/nixpkgs/commit/9fbb12132d123f3b22997eafd6da064cfb524ec5) | `` python311Packages.nats-py: 2.4.0 -> 2.5.0 ``                                             |
| [`5b1e7e3c`](https://github.com/NixOS/nixpkgs/commit/5b1e7e3cf9b38c4c465fe780d8ca0b93946001f2) | `` python311Packages.nettigo-air-monitor: 2.1.0 -> 2.2.0 ``                                 |
| [`e37b0fa2`](https://github.com/NixOS/nixpkgs/commit/e37b0fa269dcef2b4bdb5d5d15428bbcaf09e2c7) | `` python311Packages.homematicip: 1.0.15 -> 1.0.16 ``                                       |
| [`e9788d21`](https://github.com/NixOS/nixpkgs/commit/e9788d2132bab882ffcfa42618f983e30d840003) | `` python311Packages.griffe: 0.36.7 -> 0.36.8 ``                                            |
| [`af7ef223`](https://github.com/NixOS/nixpkgs/commit/af7ef223f46eaecfa7458dbeba361b561a216bdf) | `` protoc-gen-connect-go: 1.11.0 -> 1.12.0 ``                                               |
| [`6e6951ce`](https://github.com/NixOS/nixpkgs/commit/6e6951ce4d35533330af412027babf94e96ab226) | `` python311Packages.gios: 3.1.0 -> 3.2.0 ``                                                |
| [`e82f00fb`](https://github.com/NixOS/nixpkgs/commit/e82f00fb82edf1ede3153dbd34416395804a8f5f) | `` python311Packages.dvc-data: 2.18.1 -> 2.18.2 ``                                          |
| [`4957a8c1`](https://github.com/NixOS/nixpkgs/commit/4957a8c18b9a6227eb4d47fa6161cfa985661847) | `` python311Packages.autoit-ripper: 1.1.0 -> 1.1.1 ``                                       |
| [`f9d24562`](https://github.com/NixOS/nixpkgs/commit/f9d24562e8906a2e223d18355aa2039b8dddf5c1) | `` syncstorage-rs: 0.14.0 -> 0.14.1 ``                                                      |
| [`b6fe563b`](https://github.com/NixOS/nixpkgs/commit/b6fe563b5faaab67c387f8590635c602fb813e9d) | `` libyang: 2.1.111 -> 2.1.128 (#263123) ``                                                 |
| [`8c2f678f`](https://github.com/NixOS/nixpkgs/commit/8c2f678ff6041cd98f38fdfa6bcfa371b786bb88) | `` nixos/cardboard: use `mkPackageOptionMD` ``                                              |
| [`b7aff47b`](https://github.com/NixOS/nixpkgs/commit/b7aff47b6caaee5d659c6c65a4613dbce880613c) | `` openasar: unstable-2023-07-07 → unstable-2023-10-24 ``                                   |
| [`8b37735e`](https://github.com/NixOS/nixpkgs/commit/8b37735e0e1485d4ba44f33f96d390f9b5203284) | `` nixos/acme: add s3Bucket option (#262806) ``                                             |
| [`68fdc029`](https://github.com/NixOS/nixpkgs/commit/68fdc029f5c480e1e4f5736c1631c01ff1fa1b49) | `` pineapple-pictures: 0.7.2 -> 0.7.3 ``                                                    |
| [`9d860cda`](https://github.com/NixOS/nixpkgs/commit/9d860cda51806beffa8192bf37bce8d1b172b247) | `` cargo-shuttle: 0.29.1 -> 0.30.1 ``                                                       |
| [`63d59f9b`](https://github.com/NixOS/nixpkgs/commit/63d59f9bded7d5cdd2c30aeeaf7767e15b19642f) | `` cargo-component: 0.2.0 -> 0.3.0 ``                                                       |
| [`96419969`](https://github.com/NixOS/nixpkgs/commit/96419969bf4c9847f3aa118193bc759f61db04a4) | `` git-mit: 5.12.164 -> 5.12.166 ``                                                         |
| [`010bdd89`](https://github.com/NixOS/nixpkgs/commit/010bdd89c460878cdda253f2ee52295a8d2b5f2d) | `` cargo-zigbuild: 0.17.3 -> 0.17.4 ``                                                      |
| [`6297a2c9`](https://github.com/NixOS/nixpkgs/commit/6297a2c94f591fc84f79f79f21289ef255472ba0) | `` mbtileserver: 0.9.0 -> 0.10.0 ``                                                         |
| [`94f03a0c`](https://github.com/NixOS/nixpkgs/commit/94f03a0c81e6573c8de39ca8a73da4bbdfb39d0c) | `` cargo-dist: 0.3.1 -> 0.4.0 ``                                                            |
| [`0ede6c69`](https://github.com/NixOS/nixpkgs/commit/0ede6c69721531256479f89eca50225fbf65372a) | `` steamguard-cli: 0.12.2 -> 0.12.3 ``                                                      |
| [`9854418b`](https://github.com/NixOS/nixpkgs/commit/9854418b24074d14eae6c3fd93ae4ce3e992e0e0) | `` stalwart-mail: 0.3.6 -> 0.4.0 ``                                                         |
| [`6b2f0db2`](https://github.com/NixOS/nixpkgs/commit/6b2f0db2566071c4f796fce75b5d03794c27990d) | `` nixos/cardboard: init ``                                                                 |
| [`347ed6dc`](https://github.com/NixOS/nixpkgs/commit/347ed6dca8e6ca4d9b7cf9455097f4a66663f4ea) | `` cardboard: unbreak ``                                                                    |
| [`ec099771`](https://github.com/NixOS/nixpkgs/commit/ec099771e3ad3d44e963ae43fd77a35ba1cd89ce) | `` bomber-go: 0.4.4 -> 0.4.5 ``                                                             |
| [`663a3c9e`](https://github.com/NixOS/nixpkgs/commit/663a3c9e9fc021311a988c1e91ba4ab9892cd446) | `` grass: 8.3.0 -> 8.3.1 ``                                                                 |
| [`0540b299`](https://github.com/NixOS/nixpkgs/commit/0540b299093e9b398b06cfb29b53c67b45fff7a7) | `` Update pkgs/development/coq-modules/extructures/default.nix ``                           |
| [`e5de9895`](https://github.com/NixOS/nixpkgs/commit/e5de9895e8980f94fd784d81cf9218915c9fe32c) | `` coqPackages.extructures: 0.3.1 -> 0.4.0 ``                                               |
| [`b9652ce1`](https://github.com/NixOS/nixpkgs/commit/b9652ce18d1d1dae7f190201f7573233c21e8172) | `` setzer: 60 -> 61 ``                                                                      |
| [`c0c78361`](https://github.com/NixOS/nixpkgs/commit/c0c78361164a6601c8c0ce0b8560891f42c053f0) | `` Add mathcomp 2.1.0 ``                                                                    |
| [`4fd85fe0`](https://github.com/NixOS/nixpkgs/commit/4fd85fe0b6de04a454c32994105ff1be8e89f8b0) | `` matterircd: 0.27.1 -> 0.28.0 ``                                                          |
| [`637560f8`](https://github.com/NixOS/nixpkgs/commit/637560f8467954f37223efe20b5a7f806e41f32f) | `` libhv: 1.3.1 -> 1.3.2 ``                                                                 |
| [`e645607b`](https://github.com/NixOS/nixpkgs/commit/e645607b64e76e10fe72e893bb6b0f3bd4c5a264) | `` nfs-ganesha: 5.5.3 -> 5.6 ``                                                             |
| [`2b45630e`](https://github.com/NixOS/nixpkgs/commit/2b45630e445fb0123c04fd85c68d438ebcaf252e) | `` vesktop: use hash instead of sha256 ``                                                   |
| [`966c0d2a`](https://github.com/NixOS/nixpkgs/commit/966c0d2ac42ea3b8df9062549d9bee94aebfafd7) | `` vesktop: mark aarch64-linux as broken ``                                                 |
| [`54ff6977`](https://github.com/NixOS/nixpkgs/commit/54ff6977e8a72bcb22128e1ba279c9efebbec1e0) | `` vesktop: better specify platforms ``                                                     |
| [`9d65f633`](https://github.com/NixOS/nixpkgs/commit/9d65f633bfa2c8d3091a805079a1d4044fdbc9ab) | `` vesktop: 0.3.3 -> 0.4.1 ``                                                               |
| [`d82ca98b`](https://github.com/NixOS/nixpkgs/commit/d82ca98b7caaef2ee3c7780e80f2e091a2d43566) | `` diffoscope: drop unused `test_fit` patch ``                                              |
| [`ea262022`](https://github.com/NixOS/nixpkgs/commit/ea262022777d4394f2a3a3be5ddd79c44ec3fd9a) | `` infra-arcana: 22.0.0 -> 22.1.0 ``                                                        |
| [`de22144f`](https://github.com/NixOS/nixpkgs/commit/de22144f9bc54c4ba7311187a086d491966172ce) | `` goimapnotify: 2.3.7 -> 2.3.9 ``                                                          |