### PR TITLE
chore(flake/nix-index-database): `5a200628` -> `1f0981f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -444,11 +444,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697946153,
-        "narHash": "sha256-7k7qIwWLaYPgQ4fxmEdew3yCffhK6rM4I4Jo3X/79DA=",
+        "lastModified": 1698550809,
+        "narHash": "sha256-Um8+Wi6EAH5dCgfgl7OqaVd4wFJn6FKLafcP5QPr/98=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "5a2006282caaf32663cdcd582c5b18809c7d7d8d",
+        "rev": "1f0981f5baeb78e3c89a8980ff1a39f06876fa8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`1f0981f5`](https://github.com/nix-community/nix-index-database/commit/1f0981f5baeb78e3c89a8980ff1a39f06876fa8c) | `` update packages.nix to release 2023-10-29-033859 `` |
| [`ef1a36f6`](https://github.com/nix-community/nix-index-database/commit/ef1a36f692d7324a9c3648ce616111ddcb5d2373) | `` flake.lock: Update ``                               |