### PR TITLE
chore(flake/lanzaboote): `a5e89456` -> `1e974f66`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -400,11 +400,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1698582829,
-        "narHash": "sha256-C+KgImlMD/39AlRtHr9KXEmhmAWrSMZmn/cagOgARQk=",
+        "lastModified": 1698624689,
+        "narHash": "sha256-2smQAo4GEyy9KMgS+QD6y8YFt4KttNFgejoaRZgW5dw=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "a5e89456fc931d89917eb1818371762481fead9f",
+        "rev": "1e974f66b1cc78abd1e6c05d467eeca691e43548",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                  |
| --------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`03c2f52e`](https://github.com/nix-community/lanzaboote/commit/03c2f52ee9409811cfe0ad6f2b4deb13814e8704) | `` fix(deps): update all dependencies `` |