### PR TITLE
chore(flake/lanzaboote): `1e974f66` -> `9c8d7c56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -180,11 +180,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697840921,
-        "narHash": "sha256-zXHwu104SQOxogkMgg+w22c3+zI/FvK83TAkfLmeKw0=",
+        "lastModified": 1698166613,
+        "narHash": "sha256-y4rdN4flxRiROqNi1waMYIZj/Fs7L2OrszFk/1ry9vU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "758ae442227103fa501276e8225609a11c99718e",
+        "rev": "b7db46f0f1751f7b1d1911f6be7daf568ad5bc65",
         "type": "github"
       },
       "original": {
@@ -400,11 +400,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1698624689,
-        "narHash": "sha256-2smQAo4GEyy9KMgS+QD6y8YFt4KttNFgejoaRZgW5dw=",
+        "lastModified": 1698658315,
+        "narHash": "sha256-6dH5y00E9nA9MDAStmcqVDoU63Oz9GcxTWdru+ovdek=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "1e974f66b1cc78abd1e6c05d467eeca691e43548",
+        "rev": "9c8d7c56b3ca9ff831d46fa4c83905206abd214e",
         "type": "github"
       },
       "original": {
@@ -584,11 +584,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697940838,
-        "narHash": "sha256-eyk92QqAoRNC0V99KOcKcBZjLPixxNBS0PRc4KlSQVs=",
+        "lastModified": 1698545594,
+        "narHash": "sha256-Bf0UKNXBOg1OWe3GkfUNKpAlihiuuhcyzPDcMfJvUOg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a3e829c06eadf848f13d109c7648570ce37ebccd",
+        "rev": "66eb7c2fb4597c94e66a4124ee77d9827e46c14f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                  |
| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`3cb657f5`](https://github.com/nix-community/lanzaboote/commit/3cb657f5c3e6f8e009e5bf2854d60dd0360c4889) | `` tool: silence resolver version warning ``             |
| [`87d2087a`](https://github.com/nix-community/lanzaboote/commit/87d2087a7a5dfacb37579d2b4060c7334804d6f8) | `` tool: drop unused dependencies via machete ``         |
| [`1e5145a0`](https://github.com/nix-community/lanzaboote/commit/1e5145a0fad64518f1d3982a43e237e7ce34d6c3) | `` nix: trim down shell environment ``                   |
| [`2ee75d5d`](https://github.com/nix-community/lanzaboote/commit/2ee75d5d913a7a3c9242a847533de5ccdbb1f5cc) | `` docs: clarify migration path for new installations `` |
| [`e94d9822`](https://github.com/nix-community/lanzaboote/commit/e94d982208cb5e273eed53848cd5178c221dae09) | `` chore(deps): lock file maintenance ``                 |