### PR TITLE
chore(flake/lanzaboote): `8edc9ef7` -> `781303ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -400,11 +400,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1698664033,
-        "narHash": "sha256-A1AiuSipWN3VqP9IwsHo7c9WIyUeFBcWxzc9Es17Pzs=",
+        "lastModified": 1698669922,
+        "narHash": "sha256-qgx17PQkAwF4S2jdXk2bs2wifOhjesiAdVAmFqL5GNM=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "8edc9ef7716824cc99d650295bad64f6aad166ec",
+        "rev": "781303ad7ca3e41d38d18b6fd293163a61d4b319",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                    |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`18594916`](https://github.com/nix-community/lanzaboote/commit/1859491609d879b9403273684fb0aa41e980f283) | `` tests: add 5 minutes default timeout `` |