### PR TITLE
chore(flake/nixpkgs): `63678e9f` -> `85f1ba3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -474,11 +474,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698318101,
-        "narHash": "sha256-gUihHt3yPD7bVqg+k/UVHgngyaJ3DMEBchbymBMvK1E=",
+        "lastModified": 1699099776,
+        "narHash": "sha256-X09iKJ27mGsGambGfkKzqvw5esP1L/Rf8H3u3fCqIiU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "63678e9f3d3afecfeafa0acead6239cdb447574c",
+        "rev": "85f1ba3e51676fa8cc604a3d863d729026a6b8eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`85eebf70`](https://github.com/NixOS/nixpkgs/commit/85eebf7001f3a115ba2a7231f0a62d5bdf666fba) | `` python310Packages.boxx: 0.10.10 -> 0.10.12 ``                                |
| [`474415f2`](https://github.com/NixOS/nixpkgs/commit/474415f2608aaed1d183a7be4a20220983b8a03a) | `` python310Packages.botocore-stubs: 1.31.64 -> 1.31.78 ``                      |
| [`3d65d447`](https://github.com/NixOS/nixpkgs/commit/3d65d447138d6112dedcdd0241c6778f5f7b9fb5) | `` python310Packages.boto3-stubs: 1.28.64 -> 1.28.78 ``                         |
| [`63817b77`](https://github.com/NixOS/nixpkgs/commit/63817b77d818ae3f7ed321ddb7af5f56a7cbd9ee) | `` signal-desktop: 6.36.0 -> 6.37.0 ``                                          |
| [`68f1f940`](https://github.com/NixOS/nixpkgs/commit/68f1f9409dd71035cb868b4ad6b015c4a680c334) | `` python310Packages.beartype: 0.15.0 -> 0.16.4 ``                              |
| [`96beed91`](https://github.com/NixOS/nixpkgs/commit/96beed91e1d57c366477e0046b76b573aaeeca54) | `` python310Packages.awscrt: 0.19.7 -> 0.19.8 ``                                |
| [`36f5b2e4`](https://github.com/NixOS/nixpkgs/commit/36f5b2e42b98688dea8b494ae02f3a09d73f54de) | `` gcc.libgcc: compare host and target platforms, rathern than their triples `` |
| [`72c279f4`](https://github.com/NixOS/nixpkgs/commit/72c279f477f42f66cf7013d5a01762d32d215bff) | `` lib.systems, test.cross.sanity: add test case for #264989 ``                 |
| [`b31564c6`](https://github.com/NixOS/nixpkgs/commit/b31564c6de2875c8bcb6cf81fccc99544bb8fde0) | `` python310Packages.atlassian-python-api: 3.41.1 -> 3.41.3 ``                  |
| [`af016cfe`](https://github.com/NixOS/nixpkgs/commit/af016cfe8ff7e41638d1da6a3278a3e1020ac753) | `` metabase: 0.47.3 -> 0.47.6 ``                                                |
| [`421d0397`](https://github.com/NixOS/nixpkgs/commit/421d0397bd251cf66246aa818c90f2214358afc3) | `` hcxdumptool: 6.3.1 -> 6.3.2 ``                                               |
| [`a6c6e32d`](https://github.com/NixOS/nixpkgs/commit/a6c6e32d7fd7223eee4a6d86a452a34bbcc403ae) | `` btrfs-progs: 6.5.3 -> 6.6 ``                                                 |
| [`5065a42e`](https://github.com/NixOS/nixpkgs/commit/5065a42e7504041012a99f628a2b364dd9bb2689) | `` python310Packages.anywidget: 0.7.0 -> 0.7.1 ``                               |
| [`d200fd64`](https://github.com/NixOS/nixpkgs/commit/d200fd643067f2e890323aba477834774d2e12e8) | `` linode-cli: 5.26.1 -> 5.45.0 ``                                              |
| [`10add799`](https://github.com/NixOS/nixpkgs/commit/10add799d8944ed438ba993f98b8d786e75932e7) | `` python311Packages.openapi3 init at 1.8.2 ``                                  |
| [`aa6353dd`](https://github.com/NixOS/nixpkgs/commit/aa6353dd6398c4e16d303ec7b30dbba0ba9d43ab) | `` python310Packages.aiortm: 0.6.3 -> 0.6.4 ``                                  |
| [`d4c723af`](https://github.com/NixOS/nixpkgs/commit/d4c723af0d865097d9eb6a32b756cebb00c1ac24) | `` python310Packages.aioairzone-cloud: 0.3.2 -> 0.3.4 ``                        |
| [`3b8a661a`](https://github.com/NixOS/nixpkgs/commit/3b8a661abf756241351d6366a512cc59b8775ff1) | `` jupyter team: add thomasjm ``                                                |
| [`aa5ce483`](https://github.com/NixOS/nixpkgs/commit/aa5ce483149fa191f476c351f209c87f00ac2b46) | `` python310Packages.aioairq: 0.3.0 -> 0.3.1 ``                                 |
| [`a0150ad3`](https://github.com/NixOS/nixpkgs/commit/a0150ad339b04e009f984b6af667b895cf1949e8) | `` python311Packages.timm: 0.9.8 -> 0.9.9 ``                                    |
| [`5a39df91`](https://github.com/NixOS/nixpkgs/commit/5a39df91c1a6f72cd75578406eb9d7f7e5f39c8e) | `` numbat: Add version tests ``                                                 |
| [`70902269`](https://github.com/NixOS/nixpkgs/commit/70902269fdc4cc8e24e6df1fd58e0672c2d930e7) | `` tests: fix eval failures ``                                                  |
| [`e76720c5`](https://github.com/NixOS/nixpkgs/commit/e76720c5371fa38d46314d789e3f27689a0c9d78) | `` numbat: 1.6.3 -> 1.7.0 ``                                                    |
| [`eb9fdf2a`](https://github.com/NixOS/nixpkgs/commit/eb9fdf2ad51107ca3b5b329cebb957967361a749) | `` python311Packages.aioairq: 0.3.0 -> 0.3.1 ``                                 |
| [`cabda34d`](https://github.com/NixOS/nixpkgs/commit/cabda34d4327d9181103e91c7fda1ad1a491dc8b) | `` python311Packages.httpx-ntlm: 1.1.0 -> 1.4.0 ``                              |
| [`d413b570`](https://github.com/NixOS/nixpkgs/commit/d413b570702f83ff27099ba6c09a13a96cfd4f64) | `` python311Packages.types-awscrt: 0.19.7 -> 0.19.8 ``                          |
| [`c336a551`](https://github.com/NixOS/nixpkgs/commit/c336a551b9aa1f25885e345ab7ea6065e908dd00) | `` python311Packages.xknxproject: 3.4.0 -> 3.4.1 ``                             |
| [`be5ef7a8`](https://github.com/NixOS/nixpkgs/commit/be5ef7a834bf284c6d5e5f8b988dd046a67e1fa2) | `` ruff: 0.1.3 -> 0.1.4 ``                                                      |
| [`3757febe`](https://github.com/NixOS/nixpkgs/commit/3757febe2fb80caa7f651828059f9af19c041d45) | `` python311Packages.aiosmtplib: add changelog to meta ``                       |
| [`450f52a7`](https://github.com/NixOS/nixpkgs/commit/450f52a79f9bd9c52593394b3139b1c9f4cf082b) | `` python311Packages.aiosmtplib: 3.0.0 -> 3.0.1 ``                              |
| [`de43277f`](https://github.com/NixOS/nixpkgs/commit/de43277fa11f80dd7a7fb63821ed9d540f5b3c86) | `` python311Packages.garth: 0.4.39 -> 0.4.41 ``                                 |
| [`3ce4c661`](https://github.com/NixOS/nixpkgs/commit/3ce4c661512bb86209fbce9ffda0a356e86b4822) | `` nixos/module-list: add virt-manager ``                                       |
| [`2e61f773`](https://github.com/NixOS/nixpkgs/commit/2e61f7733fbe9a9fe2acd028d4759fa410f90758) | `` python311Packages.rich-click: 1.7.0 -> 1.7.1 ``                              |
| [`97408c6d`](https://github.com/NixOS/nixpkgs/commit/97408c6db4443d5b4c336f01ef8e9a7ba7af966f) | `` python311Packages.python-smarttub: 0.0.33 -> 0.0.34 ``                       |
| [`09b5eab0`](https://github.com/NixOS/nixpkgs/commit/09b5eab0acee218cc2662d9e12a0318e1131e1e7) | `` python311Packages.pyschlage: 2023.10.0 -> 2023.11.0 ``                       |
| [`410f12cf`](https://github.com/NixOS/nixpkgs/commit/410f12cfaf6276f8018d1202b8cb46209d37f6ed) | `` python311Packages.pypitoken: 7.0.0 -> 7.0.1 ``                               |
| [`f19e7752`](https://github.com/NixOS/nixpkgs/commit/f19e77528d3aacb43f181fa159a82bbf300a8359) | `` python311Packages.neo4j: 5.14.0 -> 5.14.1 ``                                 |
| [`04da962f`](https://github.com/NixOS/nixpkgs/commit/04da962fdfa5d690d127a64e9965711adb3bb9c5) | `` python311Packages.pyduotecno: 2023.10.1 -> 2023.11.0 ``                      |
| [`311ce480`](https://github.com/NixOS/nixpkgs/commit/311ce480143f0acf95350a576a903c35d5896b18) | `` python311Packages.nomadnet: 0.4.1 -> 0.4.2 ``                                |
| [`03ab6e2b`](https://github.com/NixOS/nixpkgs/commit/03ab6e2b229f9e840b9062b449553d9b0317bf60) | `` python311Packages.lxmf: 0.3.7 -> 0.3.8 ``                                    |
| [`eba88ece`](https://github.com/NixOS/nixpkgs/commit/eba88ece4e1b3c8bb6b784cefe697352b24ea0f8) | `` python311Packages.rns: 0.6.3 -> 0.6.5 ``                                     |
| [`e458ccdf`](https://github.com/NixOS/nixpkgs/commit/e458ccdf40a9ae6774422d74a37a894f758910d2) | `` cnspec: 9.5.0 -> 9.5.1 ``                                                    |
| [`aea11e74`](https://github.com/NixOS/nixpkgs/commit/aea11e744907be01d76cc25f7206cb7c8b9a5c3b) | `` nuclei: 3.0.2 -> 3.0.3 ``                                                    |
| [`ca3b2650`](https://github.com/NixOS/nixpkgs/commit/ca3b265054471f80c9ea5fb7dcbf10238c74308f) | `` pv-migrate: 1.3.0 -> 1.7.1 ``                                                |
| [`a45773cf`](https://github.com/NixOS/nixpkgs/commit/a45773cff98dab762edbfd51ba41f324161b332b) | `` protonmail-bridge: 3.5.1 -> 3.6.1 ``                                         |
| [`4396643a`](https://github.com/NixOS/nixpkgs/commit/4396643abec38492b53973b5601edd5c6d3e45c9) | `` talosctl: pin golang ``                                                      |
| [`b4829c83`](https://github.com/NixOS/nixpkgs/commit/b4829c8372fc4d417dce6537fa0f419df5ae02b1) | `` guile: enable jit on aarch64-darwin ``                                       |
| [`f60921ae`](https://github.com/NixOS/nixpkgs/commit/f60921aeede3ea43ea9c2cecf818934f1c6abbb9) | `` ocamlPackages.eio: 0.12 → 0.13 (#265029) ``                                  |
| [`a4c808f5`](https://github.com/NixOS/nixpkgs/commit/a4c808f542aa504950394ecb02de532760701934) | `` fg-virgil: init at 0.16.1 ``                                                 |
| [`89bd672b`](https://github.com/NixOS/nixpkgs/commit/89bd672b8576719119202d4bbd56f6313b18c338) | `` python311Packages.symengine: fix build ``                                    |
| [`a40dab0e`](https://github.com/NixOS/nixpkgs/commit/a40dab0e6556b225dbe03f65f96a02e1062e5f8a) | `` eslint_d: fix meta.homepage ``                                               |
| [`9e8a009e`](https://github.com/NixOS/nixpkgs/commit/9e8a009e7d218201be754e13365d4bde45537dd5) | `` ghr: 0.16.1 -> 0.16.2 ``                                                     |
| [`00c5e32a`](https://github.com/NixOS/nixpkgs/commit/00c5e32a8576ee2d68a170539bf9e3e5430aa98a) | `` tmuxPlugins.tilish: unstable-2020-08-12 -> unstable-2023-09-20 ``            |
| [`b55d20d7`](https://github.com/NixOS/nixpkgs/commit/b55d20d7c496c0a454b7a8bb46a3ba51c67b059c) | `` treewide: remove myself as maintainer ``                                     |
| [`60b3abee`](https://github.com/NixOS/nixpkgs/commit/60b3abeeeca00a4e2915389305168cde4e30c2fe) | `` aspino: drop gcc10StdenvCompat ``                                            |
| [`f6fab894`](https://github.com/NixOS/nixpkgs/commit/f6fab894c3e763e863edae10f49b08458cd2a51f) | `` python311Packages.aiojobs: disable failing test ``                           |
| [`f3cef779`](https://github.com/NixOS/nixpkgs/commit/f3cef779c6390b9bce642a0db95ccf07da807057) | `` ecc: 1.0.11 -> 1.0.12 ``                                                     |
| [`c5743b48`](https://github.com/NixOS/nixpkgs/commit/c5743b480abc513c6e4c6224eb43902783ca80ad) | `` Revert "libdeltachat: 1.121.0 -> 1.128.0" ``                                 |
| [`cae83435`](https://github.com/NixOS/nixpkgs/commit/cae8343575a6a261f10e9b88f443932b55adcc9e) | `` Revert "deltachat-desktop: 1.40.4 -> unstable-2023-10-02" ``                 |
| [`d9f13926`](https://github.com/NixOS/nixpkgs/commit/d9f13926adfd1a0bc1f5bf63c46282acfd5662f4) | `` Revert "deltachat-cursed: 0.7.2 -> 0.8.0" ``                                 |
| [`4e530c29`](https://github.com/NixOS/nixpkgs/commit/4e530c29c8b860ddff42df8800279870d9ae93be) | `` Revert "libdeltachat: also install interactive repl" ``                      |
| [`3de81b07`](https://github.com/NixOS/nixpkgs/commit/3de81b07243b53baa6c47c79c8be23f6a12d6e44) | `` tusc-sh: 1.1.0 -> 1.1.1 ``                                                   |
| [`de9c7942`](https://github.com/NixOS/nixpkgs/commit/de9c794291cb05ad85ecf4b2fb7945056aeacc3f) | `` podman: 4.7.0 -> 4.7.2 ``                                                    |
| [`5016616e`](https://github.com/NixOS/nixpkgs/commit/5016616e6bdc347af514110c877cf3635c0020c6) | `` libdeltachat: also install interactive repl ``                               |
| [`60602f1d`](https://github.com/NixOS/nixpkgs/commit/60602f1d4b7f5bd03776c3bb3d105ccda7d198aa) | `` deltachat-cursed: 0.7.2 -> 0.8.0 ``                                          |
| [`3617ec51`](https://github.com/NixOS/nixpkgs/commit/3617ec51bc7f63099145dca125c0ed37c0375e16) | `` deltachat-desktop: 1.40.4 -> unstable-2023-10-02 ``                          |
| [`cf583676`](https://github.com/NixOS/nixpkgs/commit/cf583676b7add8fbc064065a0a14527ca5bcd9a6) | `` libdeltachat: 1.121.0 -> 1.128.0 ``                                          |
| [`71a17399`](https://github.com/NixOS/nixpkgs/commit/71a1739942b4bc19c6aa75fc12b83244face8e69) | `` asciinema: 2.3.0 -> 2.4.0 ``                                                 |
| [`7501546a`](https://github.com/NixOS/nixpkgs/commit/7501546a2e23891e7946403724bd9b358ef6c2db) | `` python311Packages.python-crontab: disable failing test ``                    |
| [`15ccb5d7`](https://github.com/NixOS/nixpkgs/commit/15ccb5d7c395f6525e183332c63f18f750283ad7) | `` pocketbase: 0.18.10 -> 0.19.2 ``                                             |
| [`c452705e`](https://github.com/NixOS/nixpkgs/commit/c452705e90c4019aee7b8e8bc8974b9fd0668ec9) | `` pnpm-lock-export: unstable-2023-07-31 -> unstable-2023-07-31 ``              |
| [`3be8b8b7`](https://github.com/NixOS/nixpkgs/commit/3be8b8b7d3223366fead4bed2cc9781c143c18f0) | `` python311Packages.aioairzone-cloud: 0.3.1 -> 0.3.2 ``                        |
| [`c9eed91c`](https://github.com/NixOS/nixpkgs/commit/c9eed91c4bddcafbdcd776df729af1abac28ca3f) | `` vector: 0.33.0 → 0.33.1 ``                                                   |
| [`1db18358`](https://github.com/NixOS/nixpkgs/commit/1db183588e26cdf1c15c32bcc4e82a5f47492040) | `` icewm: 3.4.3 -> 3.4.4 ``                                                     |
| [`1aab0ae6`](https://github.com/NixOS/nixpkgs/commit/1aab0ae6903e0b0c5dabc163aa01c53813bfc5db) | `` stalwart-mail: 0.4.0 -> 0.4.2 ``                                             |
| [`76ddbdf9`](https://github.com/NixOS/nixpkgs/commit/76ddbdf9f0d5adce14d3db7aa3b1c6b2528f7029) | `` vesktop: add pluiedev as maintainer ``                                       |
| [`778f31c1`](https://github.com/NixOS/nixpkgs/commit/778f31c1ad184b728b30505892437e2e11e54e88) | `` maintainers: add pluiedev ``                                                 |