### PR TITLE
chore(flake/stylix): `7a7987c7` -> `07795247`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -618,11 +618,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698499630,
-        "narHash": "sha256-OGJUX84240wSlhRyXjrJikXmHX1VeN2ZXvfdLvrAh0o=",
+        "lastModified": 1698846025,
+        "narHash": "sha256-crZer9Qgr7GptKjIN/1aAT1bCtGA+/+9eG+aoKuIQPg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "7a7987c7828050ef9a8ca6af07ca98485053776b",
+        "rev": "07795247c2db08711bbd9503e01752c315be0805",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                     |
| --------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`07795247`](https://github.com/danth/stylix/commit/07795247c2db08711bbd9503e01752c315be0805) | `` Add cursor support (#172) ``             |
| [`43809559`](https://github.com/danth/stylix/commit/43809559494bec520d2892afc4f385616dc540d3) | `` Disable xfconf by default :ambulance: `` |