### PR TITLE
chore(flake/nixos-hardware): `80d98a7d` -> `3162c7c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -459,11 +459,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1698053470,
-        "narHash": "sha256-sP8D/41UiwC2qn0X40oi+DfuVzNHMROqIWdSdCI/AYA=",
+        "lastModified": 1698850670,
+        "narHash": "sha256-dOan2kGEZvG2sxuFsojlDPic8bht3mgnoSzZnPamBl4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "80d98a7d55c6e27954a166cb583a41325e9512d7",
+        "rev": "3162c7c1345f3d1b1c7d009cccdac9568a0fd990",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`f40197be`](https://github.com/NixOS/nixos-hardware/commit/f40197be9ad0142b8612c4e47366945667ae4ef4) | `` pine64-rockpro64: add fancontrol `` |