### PR TITLE
chore(flake/pre-commit-hooks): `bd38df3d` -> `dec10399`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -537,11 +537,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698227354,
-        "narHash": "sha256-Fi5H9jbaQLmLw9qBi/mkR33CoFjNbobo5xWdX4tKz1Q=",
+        "lastModified": 1698852633,
+        "narHash": "sha256-Hsc/cCHud8ZXLvmm8pxrXpuaPEeNaaUttaCvtdX/Wug=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "bd38df3d508dfcdff52cd243d297f218ed2257bf",
+        "rev": "dec10399e5b56aa95fcd530e0338be72ad6462a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                           |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`3db0e345`](https://github.com/cachix/pre-commit-hooks.nix/commit/3db0e3457be750234a1c6cb97e5ba4e63c592c26) | `` Specify files attribute for Elixir programs `` |