### PR TITLE
chore(flake/nixos-hardware): `3162c7c1` -> `11d50c5d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -459,11 +459,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1698850670,
-        "narHash": "sha256-dOan2kGEZvG2sxuFsojlDPic8bht3mgnoSzZnPamBl4=",
+        "lastModified": 1698853384,
+        "narHash": "sha256-/FQ2WeCjdjdNo9eGTO7JruGAjO2Ccime8y1OU4/Aesk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3162c7c1345f3d1b1c7d009cccdac9568a0fd990",
+        "rev": "11d50c5d52472ed40d3cb109daad03c836d2b328",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                          |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`11d50c5d`](https://github.com/NixOS/nixos-hardware/commit/11d50c5d52472ed40d3cb109daad03c836d2b328) | `` raspberrypi."4": add DigiAMP+ overlay ``      |
| [`71e0de71`](https://github.com/NixOS/nixos-hardware/commit/71e0de7199f4117140ee6e9c699a0f160e9301d6) | `` feat(asus/rog-strix/g513im): added profile `` |