### PR TITLE
chore(flake/nix-fast-build): `e76d62f7` -> `1ff0e1be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -424,11 +424,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1698400065,
-        "narHash": "sha256-TNpIpdZ3ycpkgUWFCzxVYjc15OHD9FeVtIc4Tsssp70=",
+        "lastModified": 1698912268,
+        "narHash": "sha256-sF1d+veVZ84eRe+UqDCAqjOZJwmpzMcMHV117lyKQCs=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "e76d62f7d0e67c93b41f16f2a72afc862cfa1a88",
+        "rev": "1ff0e1beb6ff70419a1269248325417eaae294a9",
         "type": "github"
       },
       "original": {
@@ -654,11 +654,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697388351,
-        "narHash": "sha256-63N2eBpKaziIy4R44vjpUu8Nz5fCJY7okKrkixvDQmY=",
+        "lastModified": 1698438538,
+        "narHash": "sha256-AWxaKTDL3MtxaVTVU5lYBvSnlspOS0Fjt8GxBgnU0Do=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "aae39f64f5ecbe89792d05eacea5cb241891292a",
+        "rev": "5deb8dc125a9f83b65ca86cf0c8167c46593e0b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`1ff0e1be`](https://github.com/Mic92/nix-fast-build/commit/1ff0e1beb6ff70419a1269248325417eaae294a9) | `` use nix bundled with nix-eval-jobs `` |
| [`013ccd65`](https://github.com/Mic92/nix-fast-build/commit/013ccd659ee944fa0be8e9324548958b8caa8616) | `` flake.lock: Update ``                 |