### PR TITLE
chore(flake/deploy-rs): `e3f41832` -> `660180bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -226,11 +226,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695052866,
-        "narHash": "sha256-agn7F9Oww4oU6nPiw+YiYI9Xb4vOOE73w8PAoBRP4AA=",
+        "lastModified": 1698921442,
+        "narHash": "sha256-7KmvhQ7FuXlT/wG4zjTssap6maVqeAMBdtel+VjClSM=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "e3f41832680801d0ee9e2ed33eb63af398b090e9",
+        "rev": "660180bbbeae7d60dad5a92b30858306945fd427",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                                                  |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`50d640f4`](https://github.com/serokell/deploy-rs/commit/50d640f4032c32d5bddab31af493670ba1773518) | `` fixup! [Chore] Make activation wait timeout configurable ``                           |
| [`aeeee3c1`](https://github.com/serokell/deploy-rs/commit/aeeee3c1e3e9bfc38462cb315b6e19ee9fe6db70) | `` [Chore] Make activation wait timeout configurable ``                                  |
| [`6f77c65c`](https://github.com/serokell/deploy-rs/commit/6f77c65c258043f65ec203f895fe17cc613fcaae) | `` [Chore] fix error messages claiming to have rolled back when not actually doing so `` |