### PR TITLE
chore(flake/home-manager): `831b4fa3` -> `8765d4e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698896213,
-        "narHash": "sha256-u42NZt52F3o7pM5V7sYlLOp5tSN8z9+fO2wFcOs0EOQ=",
+        "lastModified": 1699025595,
+        "narHash": "sha256-e+o4PoSu2Z6Ww8y/AVUmMU200rNZoRK+p2opQ7Db8Rg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "831b4fa31749208e576050c563e9773aafd04941",
+        "rev": "8765d4e38aa0be53cdeee26f7386173e6c65618d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`8765d4e3`](https://github.com/nix-community/home-manager/commit/8765d4e38aa0be53cdeee26f7386173e6c65618d) | `` thefuck: add fish integration (#4535) `` |