### PR TITLE
chore(flake/pre-commit-hooks): `dec10399` -> `ea758da1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -537,11 +537,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1698852633,
-        "narHash": "sha256-Hsc/cCHud8ZXLvmm8pxrXpuaPEeNaaUttaCvtdX/Wug=",
+        "lastModified": 1699271226,
+        "narHash": "sha256-8Jt1KW3xTjolD6c6OjJm9USx/jmL+VVmbooADCkdDfU=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "dec10399e5b56aa95fcd530e0338be72ad6462a0",
+        "rev": "ea758da1a6dcde6dc36db348ed690d09b9864128",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                 |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------- |
| [`fe1e555f`](https://github.com/cachix/pre-commit-hooks.nix/commit/fe1e555fc51f01568212180d519f36c569254ef0) | `` Add git-annex hook ``                |
| [`841208dd`](https://github.com/cachix/pre-commit-hooks.nix/commit/841208dd849019fc3d9d0c8cc0e892e2cf69d483) | `` Add .editorconfig with used style `` |