### PR TITLE
chore(flake/darwin): `afe83cbc` -> `eb2b9b64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698429334,
-        "narHash": "sha256-Gq3+QabboczSu7RMpcy79RSLMSqnySO3wsnHQk4DfbE=",
+        "lastModified": 1699437533,
+        "narHash": "sha256-lMoPz9c89CpPVuJ95OFFesM9JagCF0soGbQatj3ZhqM=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "afe83cbc2e673b1f08d32dd0f70df599678ff1e7",
+        "rev": "eb2b9b64238349bd351561e32e260cac15db6f9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
| [`70af8083`](https://github.com/LnL7/nix-darwin/commit/70af808347fbfd866e04da5fe2856cb1ae75eaa4) | `` linux-builder: change from `modules` to `config` `` |