### PR TITLE
chore(flake/darwin): `eb2b9b64` -> `0f1ad801`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699437533,
-        "narHash": "sha256-lMoPz9c89CpPVuJ95OFFesM9JagCF0soGbQatj3ZhqM=",
+        "lastModified": 1699704228,
+        "narHash": "sha256-NApWG385goidsXmsakWgFRjvbH+aw/n1CGGHn/UuXsc=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "eb2b9b64238349bd351561e32e260cac15db6f9a",
+        "rev": "0f1ad801387445fdda01d080db8ecf169be8e793",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                  |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
| [`4fa7b5cd`](https://github.com/LnL7/nix-darwin/commit/4fa7b5cdd14a0fee6edc8c8924e57422b0dcc9ef) | `` Add security.pki.installCACerts config ``             |
| [`a4b4cf70`](https://github.com/LnL7/nix-darwin/commit/a4b4cf70dcf93353ff49a227a012b62cdc9629f8) | `` Update pkgs/nix-tools/darwin-rebuild.sh ``            |
| [`26a59d50`](https://github.com/LnL7/nix-darwin/commit/26a59d504b69448c1a7f1527ffc3f5e4999821fb) | `` fix(#798): darwin-rebuild support for Cyberark EPM `` |