### PR TITLE
chore(flake/home-manager): `6a844446` -> `691cbcc0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699368917,
-        "narHash": "sha256-nUtGIWf86BOkUbtksWtfglvCZ/otP0FTZlQH8Rzc7PA=",
+        "lastModified": 1699663185,
+        "narHash": "sha256-hI3CZPINBWstkMN+ptyzWibw5eRtFCiEvO7zR61bGBs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6a8444467c83c961e2f5ff64fb4f422e303c98d3",
+        "rev": "691cbcc03af6ad1b5384c0e0e0b5f2298f58c5ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`691cbcc0`](https://github.com/nix-community/home-manager/commit/691cbcc03af6ad1b5384c0e0e0b5f2298f58c5ce) | `` k9s: add aliases, plugins, views ``                 |
| [`e27be9db`](https://github.com/nix-community/home-manager/commit/e27be9db7b4ae5791f53d241b3661353c51a9677) | `` systemd: avoid creating an empty user.conf ``       |
| [`f5182ffc`](https://github.com/nix-community/home-manager/commit/f5182ffc4211860348fc7c78e0ba3a9d36f13aeb) | `` emacs: Fix socket activation ``                     |
| [`47226ec7`](https://github.com/nix-community/home-manager/commit/47226ec7e791d8080a63c170ab50bf27539117cf) | `` emacs: Remove obsolete socket file workaround ``    |
| [`54586daa`](https://github.com/nix-community/home-manager/commit/54586daa59e4d46968fbec498b31bf992e557e43) | `` firefox: add container support ``                   |
| [`858fe2f0`](https://github.com/nix-community/home-manager/commit/858fe2f09a4149a8ec5494a501324a8b97e2e51c) | `` firefox: refactor duplicate profile ID detection `` |