### PR TITLE
chore(flake/nixos-hardware): `b689465d` -> `df9bb8a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -459,11 +459,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1699701045,
-        "narHash": "sha256-mDzUXK7jNO/utInWpSWEX1NgEEunVIpJg+LyPsDTfy0=",
+        "lastModified": 1699954245,
+        "narHash": "sha256-CSnfeOHc/wco8amdA0j268OaLrMcI5gGtK6Zm+y3lT0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b689465d0c5d88e158e7d76094fca08cc0223aad",
+        "rev": "df9bb8a436607da124e8cfa0fd19e70e9d9e0b7b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`df9bb8a4`](https://github.com/NixOS/nixos-hardware/commit/df9bb8a436607da124e8cfa0fd19e70e9d9e0b7b) | `` surface: linux 6.5.7 -> 6.5.11 ``                              |
| [`8bb2d5ca`](https://github.com/NixOS/nixos-hardware/commit/8bb2d5ca134832da48fe515a60a039d192f071a5) | `` surface: linux 6.1.57 -> 6.1.62 ``                             |
| [`27ac7d57`](https://github.com/NixOS/nixos-hardware/commit/27ac7d57bcfe6609281c1a31a1577470bcfd5db9) | `` surface: linux 6.1.55 -> 6.1.57 ``                             |
| [`9eb41407`](https://github.com/NixOS/nixos-hardware/commit/9eb41407ab93fd7f2876defdf459945f24f1b54c) | `` surface: linux 6.5.5 -> 6.5.7 ``                               |
| [`502d05fc`](https://github.com/NixOS/nixos-hardware/commit/502d05fcf628c76ccdbecbd645f2808529e55b5d) | `` framework: Add notice to README.md ``                          |
| [`ec3609cc`](https://github.com/NixOS/nixos-hardware/commit/ec3609cc5977c39362fb8460470f31d39ebe891b) | `` Explicitly speak of 11th gen Intel Framework new profile ``    |
| [`a14a7746`](https://github.com/NixOS/nixos-hardware/commit/a14a7746f971f1c1e34b659c8cbbca4aa1717275) | `` Fix module paths for common framework modules ``               |
| [`87d3381c`](https://github.com/NixOS/nixos-hardware/commit/87d3381c789dca7d87c99ebf009307c8ac8666e1) | `` Add assertion for default framework import ``                  |
| [`de0c9310`](https://github.com/NixOS/nixos-hardware/commit/de0c9310d397fa9f954d364ef738f5b11935c7b3) | `` Move common modules into folder ``                             |
| [`5f6b8752`](https://github.com/NixOS/nixos-hardware/commit/5f6b875273c1725eda9c2163c1e729a1a0b92168) | `` Fix common module imports for fw13 common module ``            |
| [`da7e364c`](https://github.com/NixOS/nixos-hardware/commit/da7e364c3dd71cda04828ddad511f0f60c905fa5) | `` Reorganize current framework modules into 13-inch directory `` |