### PR TITLE
chore(flake/nixpkgs): `85f1ba3e` -> `e44462d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -474,11 +474,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699099776,
-        "narHash": "sha256-X09iKJ27mGsGambGfkKzqvw5esP1L/Rf8H3u3fCqIiU=",
+        "lastModified": 1699781429,
+        "narHash": "sha256-UYefjidASiLORAjIvVsUHG6WBtRhM67kTjEY4XfZOFs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "85f1ba3e51676fa8cc604a3d863d729026a6b8eb",
+        "rev": "e44462d6021bfe23dfb24b775cc7c390844f773d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`2e5993d5`](https://github.com/NixOS/nixpkgs/commit/2e5993d508e9e1aaf89e118854ccb5d1e829b8d7) | `` nixos/tests/udisks2: actually start udisks ``                                      |
| [`bab997db`](https://github.com/NixOS/nixpkgs/commit/bab997db72a94fd58c6d3864f71ad8a81544cc6a) | `` wolfssl: 5.6.3 -> 5.6.4 ``                                                         |
| [`56fd7f00`](https://github.com/NixOS/nixpkgs/commit/56fd7f00cb4341c001b93d52f4e488e218c4f823) | `` linux_latest-libre: 19438 -> 19441 ``                                              |
| [`24008785`](https://github.com/NixOS/nixpkgs/commit/240087854f5071a5e76ece4737f0549ff620f91f) | `` linux_5_10: 5.10.199 -> 5.10.200 ``                                                |
| [`7e42bbd5`](https://github.com/NixOS/nixpkgs/commit/7e42bbd56c17f46988577120f48f55bf50fa3101) | `` linux_5_15: 5.15.137 -> 5.15.138 ``                                                |
| [`e65455a3`](https://github.com/NixOS/nixpkgs/commit/e65455a3b46c72511ba0df93608e9d164b8290e6) | `` ocamlPackages.lablgl: 1.06 → 1.07 ``                                               |
| [`f933bfc6`](https://github.com/NixOS/nixpkgs/commit/f933bfc6c8b18628ab7a3eddd112add0027f0cc0) | `` ocamlPackages.ocamlsdl: remove at 0.9.1 ``                                         |
| [`782e4f66`](https://github.com/NixOS/nixpkgs/commit/782e4f664dc923b7c851cd92f3ab6cd823806e2f) | `` python310Packages.vector: 1.1.1 -> 1.1.1.post1 ``                                  |
| [`dd48a8a8`](https://github.com/NixOS/nixpkgs/commit/dd48a8a89226563f0a18ebdd6d331113b1e715d8) | `` texlive.pkgs.tex4ebook: add html-tidy to PATH (#266861) ``                         |
| [`6f314053`](https://github.com/NixOS/nixpkgs/commit/6f314053897165a8c629484836a45d1de1a0e965) | `` python310Packages.txtai: 6.1.0 -> 6.2.0 ``                                         |
| [`3ab49b59`](https://github.com/NixOS/nixpkgs/commit/3ab49b59e1e996e97e443b5eae1a1dd51a181293) | `` python3Packages.hdf5plugin: 4.2.0 -> 4.3.0 ``                                      |
| [`0335f734`](https://github.com/NixOS/nixpkgs/commit/0335f7348c567fa73b00244c5a8263efeb320fad) | `` python3Packages.pycardano: 0.9.0 -> 0.10.0 ``                                      |
| [`1e47c87f`](https://github.com/NixOS/nixpkgs/commit/1e47c87fd239258c2e5e8259765053c24b5f50d9) | `` newlib: fix newlib host/target workaround ``                                       |
| [`4c5a455c`](https://github.com/NixOS/nixpkgs/commit/4c5a455ca5c09a15edca42e83e8b65773da4394a) | `` newlib: always pass --with-newlib ``                                               |
| [`ca96ce42`](https://github.com/NixOS/nixpkgs/commit/ca96ce427b900f053d91c7bf9e38578bb8db515f) | `` sqlcl: change license to unfreeRedistributable ``                                  |
| [`3358e7ac`](https://github.com/NixOS/nixpkgs/commit/3358e7ac3ab6a7044deaab39a895cb6292011a19) | `` ngtcp2-gnutls: 1.0.0 -> 1.0.1 ``                                                   |
| [`396a7590`](https://github.com/NixOS/nixpkgs/commit/396a7590c317e60553c808c897edd60d267aa4d7) | `` cpu-x: 5.0.0 -> 5.0.1 ``                                                           |
| [`31e03288`](https://github.com/NixOS/nixpkgs/commit/31e03288b5d95af88fb0fe9b31d2b816b1b50ee7) | `` mpvScripts.thumbfast: Simplify with `lib.getExe` ``                                |
| [`620d5c14`](https://github.com/NixOS/nixpkgs/commit/620d5c14dad5fc673b5449e6c7fa56fdb5a2dd6f) | `` mpv: Set `meta.mainProgram` ``                                                     |
| [`895f82c6`](https://github.com/NixOS/nixpkgs/commit/895f82c6def4827e4032193914b90ab731ae44e4) | `` python311Packages.chacha20poly1305-reuseable: 0.10.2 -> 0.11.0 ``                  |
| [`2c6f7fa5`](https://github.com/NixOS/nixpkgs/commit/2c6f7fa5e69307fbbbc6a79dfec4d4f3b0ce837b) | `` python311Packages.aioesphomeapi: 18.3.0 -> 18.4.0 ``                               |
| [`1a521036`](https://github.com/NixOS/nixpkgs/commit/1a52103661cf12a3ec3bd45485fe1cf7fa632ee0) | `` python310Packages.steamship: 2.17.28 -> 2.17.32 ``                                 |
| [`f3d5d725`](https://github.com/NixOS/nixpkgs/commit/f3d5d7250fc1fee7dbdc4cb0cc9f44de6bb309a6) | `` maintainers: remove robert-manchester ``                                           |
| [`84f386b7`](https://github.com/NixOS/nixpkgs/commit/84f386b7d1b74d1ad87260013070bf5a36e80008) | `` tkdiff: update maintainers ``                                                      |
| [`c653aae3`](https://github.com/NixOS/nixpkgs/commit/c653aae360f8a10b790646ff11e189e3342478fb) | `` rubber: add mainProgram ``                                                         |
| [`22369c94`](https://github.com/NixOS/nixpkgs/commit/22369c94e264e57735afdaf5f101175eb6e2f681) | `` passage: add mainProgram ``                                                        |
| [`8a321dbf`](https://github.com/NixOS/nixpkgs/commit/8a321dbfb4d3b35eab9b64a9b19f0dd76f3fc671) | `` profile-cleaner: add mainProgram ``                                                |
| [`caeda292`](https://github.com/NixOS/nixpkgs/commit/caeda29217d272e04a1ef7853ffccb2fbda8f031) | `` grc: add mainProgram ``                                                            |
| [`da49b6d7`](https://github.com/NixOS/nixpkgs/commit/da49b6d7d2d72bb713fbc0d32b29a2175ba6af55) | `` dynamic-colors: add mainProgram ``                                                 |
| [`77890c8b`](https://github.com/NixOS/nixpkgs/commit/77890c8b886de4d995ae434cfb8e432caf0e45cd) | `` vips: add mainProgram ``                                                           |
| [`feadb213`](https://github.com/NixOS/nixpkgs/commit/feadb21353bfcb77177975d2a1651f900b2293af) | `` duperemove: add mainProgram ``                                                     |
| [`03fe07bf`](https://github.com/NixOS/nixpkgs/commit/03fe07bf4f6b15f5d96a1743e1f5efac4c7c17d2) | `` vdirsyncer: add mainProgram ``                                                     |
| [`1fd787f5`](https://github.com/NixOS/nixpkgs/commit/1fd787f5f4b9edf23c348d4041475931a84eb160) | `` podman: add mainProgram ``                                                         |
| [`703b9db6`](https://github.com/NixOS/nixpkgs/commit/703b9db6c5154530264bd7b6b09552596d0e5ede) | `` hikounomizu: 1.0 -> 1.0.1 ``                                                       |
| [`65410694`](https://github.com/NixOS/nixpkgs/commit/65410694e22e1fcdb1a981e2d5b39f01f2e7e49e) | `` warzone2100: 4.3.5 -> 4.4.0 ``                                                     |
| [`10b64a28`](https://github.com/NixOS/nixpkgs/commit/10b64a28c42d6b1e6819ca8baa63eec2e498bbfc) | `` sdcc: refactor ``                                                                  |
| [`2423baa7`](https://github.com/NixOS/nixpkgs/commit/2423baa7f189f0777d7bc55f9ca7d833927b4102) | `` sdcc: migrate to by-name ``                                                        |
| [`4a84d357`](https://github.com/NixOS/nixpkgs/commit/4a84d357b3f2bbaafd03275b3c627bc02f96057e) | `` nongnu-packages: updated 2023-11-10 (from overlay) ``                              |
| [`2881bede`](https://github.com/NixOS/nixpkgs/commit/2881bede15e5e426870a8618172fef2a85795e00) | `` melpa-packages: updated 2023-11-10 (from overlay) ``                               |
| [`3b84cfd7`](https://github.com/NixOS/nixpkgs/commit/3b84cfd7457afb9a345b5b4ebbb1439d65ea1898) | `` elpa-devel-packages: updated 2023-11-10 (from overlay) ``                          |
| [`9de8336e`](https://github.com/NixOS/nixpkgs/commit/9de8336e135870c6341aadc6f4bb0c6fe4379ec4) | `` elpa-packages: updated 2023-11-10 (from overlay) ``                                |
| [`8bcd650e`](https://github.com/NixOS/nixpkgs/commit/8bcd650eded018e9b96e932640911e668a1e4287) | `` worker: adopt and refactor ``                                                      |
| [`db740136`](https://github.com/NixOS/nixpkgs/commit/db7401360a30a65a6afe38828404d630908f9611) | `` maintainers: remove skeidel ``                                                     |
| [`daad29f9`](https://github.com/NixOS/nixpkgs/commit/daad29f97e9e144e0a4ed81851bdf7edfd1f7bd9) | `` upnp-router-control: 0.3.3 -> 0.3.4 ``                                             |
| [`5d9e3ac0`](https://github.com/NixOS/nixpkgs/commit/5d9e3ac039b2c2fd62b71256e7368c212b6f475e) | `` opensubdiv: Fix flaky build with CUDA and high parallelism ``                      |
| [`2fa56fcb`](https://github.com/NixOS/nixpkgs/commit/2fa56fcb3024dcdcc680493cb1d92628e214116a) | `` nixos/tests/tandoor-recipes: use SQLite ``                                         |
| [`3a99d1b6`](https://github.com/NixOS/nixpkgs/commit/3a99d1b6424cb4b9c431bec279ee6c832b16948f) | `` nix-prefetch-git: respect NETRC ``                                                 |
| [`99298c3d`](https://github.com/NixOS/nixpkgs/commit/99298c3da07f53464bc1a24b4b7d0882f1acf060) | `` mu: 1.10.7 -> 1.10.8 ``                                                            |
| [`ea90b7a7`](https://github.com/NixOS/nixpkgs/commit/ea90b7a798b70443ea2c71aca598b48fa8b2fb82) | `` python310Packages.sagemaker: 2.193.0 -> 2.197.0 ``                                 |
| [`580fc8a9`](https://github.com/NixOS/nixpkgs/commit/580fc8a960816d4f3feab9492aadbad617f0a1fb) | `` mpvScripts.thumbnail: Refactor with buildLua ``                                    |
| [`d6179b96`](https://github.com/NixOS/nixpkgs/commit/d6179b962527013836a98f3ad7e55e223d42c889) | `` vtk: cleanup ``                                                                    |
| [`f860a724`](https://github.com/NixOS/nixpkgs/commit/f860a72464e0f1f32a853531bce63b37f98a8f74) | `` clockify: 2.0.3 -> 2.1.6 ``                                                        |
| [`984006af`](https://github.com/NixOS/nixpkgs/commit/984006af697f705a93abe8e5e4c9ee5fe94293e0) | `` inferno: 0.11.17 -> 0.11.18 ``                                                     |
| [`1cedf179`](https://github.com/NixOS/nixpkgs/commit/1cedf179735a8fed30053ac1ec761eafc4723fa9) | `` zpaqfranz: 58.10 -> 58.11 ``                                                       |
| [`62ff1ef2`](https://github.com/NixOS/nixpkgs/commit/62ff1ef2393b28001eb8c4223c36ebf8a337651f) | `` refind: 0.13.3.1 -> 0.14.0.2 ``                                                    |
| [`6d9c572b`](https://github.com/NixOS/nixpkgs/commit/6d9c572be2b199be0456845a61d7e4b3e3ac6280) | `` supercollider: use bash from nixpkgs for popen ``                                  |
| [`fef6f31f`](https://github.com/NixOS/nixpkgs/commit/fef6f31f8c14c26fad85f2ce4422641a743bd363) | `` python310Packages.rns: 0.6.6 -> 0.6.7 ``                                           |
| [`a768cb9a`](https://github.com/NixOS/nixpkgs/commit/a768cb9a38caae316196399d5019421745148dd2) | `` python310Packages.rich-argparse: 1.3.0 -> 1.4.0 ``                                 |
| [`db49a7fc`](https://github.com/NixOS/nixpkgs/commit/db49a7fc01dcf5a3e5f17782a058f16f8c513338) | `` linux-firmware: 20231030 -> 20231111 ``                                            |
| [`37f3260f`](https://github.com/NixOS/nixpkgs/commit/37f3260f557283c0263dd54e9c5340afaa2ccf43) | `` ungoogled-chromium: 119.0.6045.105-1 -> 119.0.6045.123-1 ``                        |
| [`15eb951a`](https://github.com/NixOS/nixpkgs/commit/15eb951a10b940b076e4ff825c55fb82db983212) | `` chromium: 119.0.6045.105 -> 119.0.6045.123 ``                                      |
| [`88a3d2a0`](https://github.com/NixOS/nixpkgs/commit/88a3d2a0b43e80f9275af1952a9b94b6ddcd88af) | `` sourcehut: fix postgresql database permission for postgresql >= 15 ``              |
| [`f9611764`](https://github.com/NixOS/nixpkgs/commit/f9611764c699fe98ad45996f3c87b9bdd14db716) | `` manual: Fix QEMU_NET_OPTS VM-side address. ``                                      |
| [`c271196d`](https://github.com/NixOS/nixpkgs/commit/c271196d42a99c038472994b0fd0bfd9028b4423) | `` sharedown: unbreak build ``                                                        |
| [`e669065e`](https://github.com/NixOS/nixpkgs/commit/e669065eb3477beb67c294489a42fdae4414ecaa) | `` python310Packages.qpsolvers: 4.0.0 -> 4.0.1 ``                                     |
| [`66b86f8a`](https://github.com/NixOS/nixpkgs/commit/66b86f8a2e665832a431d7a69c6ab806c74eec88) | `` sourcehut: de-duplicate nginx `add_header` directives ``                           |
| [`acd21dad`](https://github.com/NixOS/nixpkgs/commit/acd21dad52d61370abd384b45eb8233ca3b7b4af) | `` sourcehut: use systemd.tmpfiles instead of manually creating logfiles ``           |
| [`79dc7c3c`](https://github.com/NixOS/nixpkgs/commit/79dc7c3c101f9b18c8ff3da4f5c5ecba05092528) | `` sourcehut: add overrides for `flask-sqlalchemy` and `factory-boy` ``               |
| [`47127ce6`](https://github.com/NixOS/nixpkgs/commit/47127ce66e7f7c7dff3541fdd1bd7f80a339af5e) | `` signal-export: init at 1.6.1 (#266722) ``                                          |
| [`e434c762`](https://github.com/NixOS/nixpkgs/commit/e434c7622cc94665605b04221dff34203661a9a8) | `` wolfssl: backport patch to fix tests ``                                            |
| [`00f1b94d`](https://github.com/NixOS/nixpkgs/commit/00f1b94db19afa8e5d429bf32f59256a8d31890b) | `` crosvm: backport page size fix for tests ``                                        |
| [`d20c21c8`](https://github.com/NixOS/nixpkgs/commit/d20c21c8a1e80fcd13c554f84b771f6a58327c07) | `` libvirt: 9.7.0 -> 9.9.0 ``                                                         |
| [`7876c91d`](https://github.com/NixOS/nixpkgs/commit/7876c91d5b80be9832897f55f58c10f0864f5bc8) | `` freecad: add passthru.tests.python-path to test patch ``                           |
| [`e51b7f68`](https://github.com/NixOS/nixpkgs/commit/e51b7f68ee63b3995e0877014a1849774f9315ea) | `` freecad: switch back to isolated config with env vars turned on ``                 |
| [`c3e6ad5c`](https://github.com/NixOS/nixpkgs/commit/c3e6ad5c94cd2093b847dc953c86e92bce4734e3) | `` buildNpmPackage: replace nodejs override ``                                        |
| [`993c8f16`](https://github.com/NixOS/nixpkgs/commit/993c8f162dec33b826fd0eaf4f80b6284e0e5e63) | `` mixRelease: improve the implementation (#266397) ``                                |
| [`530ef262`](https://github.com/NixOS/nixpkgs/commit/530ef262c507e1ebfcd377ba24c7a5ed21e08903) | `` python310Packages.python-pptx: 0.6.22 -> 0.6.23 ``                                 |
| [`641e54bb`](https://github.com/NixOS/nixpkgs/commit/641e54bb289d708f45f11e156bf4ffa251a2b4b2) | `` sourcehut: create logs directory unconditionally ``                                |
| [`fc6addb1`](https://github.com/NixOS/nixpkgs/commit/fc6addb147839dffc2532d111f0a5ab4175a2555) | `` sourcehut: reword `api-origin` option description ``                               |
| [`589b75bd`](https://github.com/NixOS/nixpkgs/commit/589b75bdc8038edce0486829ff556004881eee70) | `` sourcehut: disable IPv6 completely for tests ``                                    |
| [`78cc2783`](https://github.com/NixOS/nixpkgs/commit/78cc2783c8e8322e80cd0ee68409cd537e7202a6) | `` sourcehut: drop obsolete `services` array in favor of indivdual `enable` flags ``  |
| [`6b25e09d`](https://github.com/NixOS/nixpkgs/commit/6b25e09d2dfe8b92db9ae148989d6d7aaad2dd7f) | `` sourcehut: fix up some more bin paths ``                                           |
| [`5841d274`](https://github.com/NixOS/nixpkgs/commit/5841d27497905b0411cba48f0f4cc8c1a1c1edd4) | `` sourcehut: explicitly disallow openssh to socket-active ``                         |
| [`c39ba7f5`](https://github.com/NixOS/nixpkgs/commit/c39ba7f5b17747f34a7806c49cf91ccbaf9c81be) | `` sourcehut: remove `set -x` from ssh commands ``                                    |
| [`66484883`](https://github.com/NixOS/nixpkgs/commit/6648488333f66dd8fee678f27fb33016b046090f) | `` sourcehut: fix logging of git/hg ssh commands ``                                   |
| [`6e518021`](https://github.com/NixOS/nixpkgs/commit/6e51802196d4b3f60e65b061c637d90cbc5fceb8) | `` sourcehut: fix `repos` path by using actual settings value ``                      |
| [`12fe05f0`](https://github.com/NixOS/nixpkgs/commit/12fe05f0e30baefa18b890420df7628a213f77ec) | `` sourcehut: add override for SQLAlchemy 1.x ``                                      |
| [`90066487`](https://github.com/NixOS/nixpkgs/commit/900664876c724d0ec8f14486c96462cb4953d5f2) | `` sourcehut: default gqlgenVersion 0.17.2 -> 0.17.20 ``                              |
| [`c0c73555`](https://github.com/NixOS/nixpkgs/commit/c0c73555a5d19052cf5e22cadfb5c040be5101e3) | `` sourcehut.todosrht: 0.72.2 -> 0.74.6 ``                                            |
| [`f53540af`](https://github.com/NixOS/nixpkgs/commit/f53540afddd67ccdb44ba3e8174d7722e5d60940) | `` sourcehut.scmsrht: 0.22.22 -> 0.22.23 ``                                           |
| [`8d573f2d`](https://github.com/NixOS/nixpkgs/commit/8d573f2df8aa625c198650034fd3980e72368f4a) | `` sourcehut.pastesrht: 0.13.8 -> 0.15.1 ``                                           |
| [`b916bbd1`](https://github.com/NixOS/nixpkgs/commit/b916bbd1ea3634fc20a8f7ca1b57679150f1b868) | `` sourcehut.pagessrht: 0.7.4 -> 0.13.0 ``                                            |
| [`558767f9`](https://github.com/NixOS/nixpkgs/commit/558767f939ac61c04457e4429711bc4f3215a855) | `` sourcehut.metasrht: 0.61.3 -> 0.64.8 ``                                            |
| [`30054093`](https://github.com/NixOS/nixpkgs/commit/30054093c9f080b8dcb6022b384824ff1dbebc61) | `` sourcehut.mansrht: 0.15.26 -> 0.16.1 ``                                            |
| [`b0fb4dc3`](https://github.com/NixOS/nixpkgs/commit/b0fb4dc3a9bd487e0543e77fdc595472e1137ef4) | `` sourcehut.listssrht: 0.51.11 -> 0.57.8 ``                                          |
| [`1a7c5a81`](https://github.com/NixOS/nixpkgs/commit/1a7c5a811250ae1ba8bd5daab129100e80e0d6f3) | `` sourcehut.hubsrht: 0.14.14 -> 0.17.2 ``                                            |
| [`a9730572`](https://github.com/NixOS/nixpkgs/commit/a9730572cb3df0685d93a5d608fa19c04d4091f5) | `` sourcehut.hgsrht: 0.31.3 -> 0.32.4 ``                                              |
| [`c123a37b`](https://github.com/NixOS/nixpkgs/commit/c123a37be6b224a48466f6e4329927f366a72efd) | `` sourcehut.gitsrht: 0.78.20 -> 0.84.2 ``                                            |
| [`869781c2`](https://github.com/NixOS/nixpkgs/commit/869781c2f43acdf917479941aa21983a69af3ddf) | `` sourcehut.buildsrht: 0.83.0 -> 0.86.10 ``                                          |
| [`8d569593`](https://github.com/NixOS/nixpkgs/commit/8d5695930e20260a7b778a013ba32e5bf1441403) | `` sourcehut.srht: 0.69.0 -> 0.69.15 ``                                               |
| [`d7031735`](https://github.com/NixOS/nixpkgs/commit/d70317352043d4db2264285a18b1fce40446ab22) | `` sourcehut: make /query endpoint config common to all services ``                   |
| [`395cc85b`](https://github.com/NixOS/nixpkgs/commit/395cc85b360bc161bb74d4b4f248de7357a79e05) | `` sourcehut: make script work with non-python modules ``                             |
| [`7e414951`](https://github.com/NixOS/nixpkgs/commit/7e414951031f6772b3ec6d6e4b238d9fa660d3b3) | `` Revert "bazel: use bash with fallback $PATH consisting of basic shell utils" ``    |
| [`50411697`](https://github.com/NixOS/nixpkgs/commit/504116975ff079dc7a27a93ee743a85d3bbf073d) | `` ruby-modules/gem-config: relax hardening to avoid google-protobuf build failure `` |
| [`c83bc912`](https://github.com/NixOS/nixpkgs/commit/c83bc912c805e49ae8a7ad91c4cc5f1a2233a40f) | `` python311Packages.setuptools-trial: adopt pypa build ``                            |
| [`a701be8b`](https://github.com/NixOS/nixpkgs/commit/a701be8b5263e5ea3d156f17ae70307cb7e5fd26) | `` python311Packages.setuptools-trial: rename from setuptoolsTrial ``                 |
| [`cf7ed5d3`](https://github.com/NixOS/nixpkgs/commit/cf7ed5d3df05bc869968d858b0f96bab739700ea) | `` geany: 1.38 -> 2.0 ``                                                              |
| [`75dc87e7`](https://github.com/NixOS/nixpkgs/commit/75dc87e7b4000382d465e88c1d22e63ae8343e82) | `` sqlint: 0.2.1 -> 0.3.0 ``                                                          |
| [`b94cefd3`](https://github.com/NixOS/nixpkgs/commit/b94cefd3b91695e97ba8b26848dc798aa47cb5c3) | `` python311Packages.google-cloud-firestore: 2.13.0 -> 2.13.1 ``                      |
| [`fe4646cf`](https://github.com/NixOS/nixpkgs/commit/fe4646cf673cbd32d28c77cbb21fb3a4a37dd64d) | `` python311Packages.google-cloud-dns: 0.34.1 -> 0.34.2 ``                            |
| [`48072c69`](https://github.com/NixOS/nixpkgs/commit/48072c6935d770d11cc2c7b1f6c9c971cacf9c48) | `` python310Packages.python-lsp-server: 1.8.2 -> 1.9.0 ``                             |
| [`16b5253c`](https://github.com/NixOS/nixpkgs/commit/16b5253cac48df7bda5745d630989a660e9fa12d) | `` recoll: 1.35.0 -> 1.36.0 ``                                                        |
| [`20b95b6c`](https://github.com/NixOS/nixpkgs/commit/20b95b6c3db20126bc648afa8be8d781006d9cfa) | `` python311Packages.cyclonedx-python-lib: collect failing tests ``                   |
| [`e30f48be`](https://github.com/NixOS/nixpkgs/commit/e30f48be948272df2d57237ef955023f937f4421) | `` treewide: fix redirected and broken URLs ``                                        |
| [`a012069e`](https://github.com/NixOS/nixpkgs/commit/a012069eeb24686c24ae86e400558e5d30198e90) | `` checkov: 3.0.15 -> 3.0.32 ``                                                       |
| [`8577a724`](https://github.com/NixOS/nixpkgs/commit/8577a724e5f004cc3f77b88e8896f1520445d5d2) | `` vscodium: 1.83.1.23285 -> 1.84.2.23314 ``                                          |
| [`93900ac8`](https://github.com/NixOS/nixpkgs/commit/93900ac8efe1599b2b74741e73bbda8e2c47a1c7) | `` python311Packages.pygnmi: disable on unsupported Python releases ``                |
| [`d159ddbc`](https://github.com/NixOS/nixpkgs/commit/d159ddbc058d51e03f489c63742ab2bc5db31e45) | `` python311Packages.cyclonedx-python-lib: 5.1.0 -> 5.1.1 ``                          |
| [`2a074ffe`](https://github.com/NixOS/nixpkgs/commit/2a074ffe328b6de7729a0e6e36c3d9bd280bead9) | `` python311Packages.canals: remove optional dependencies ``                          |
| [`06eb18da`](https://github.com/NixOS/nixpkgs/commit/06eb18daf5eecc145cfdfbf936a40cb24ccb7848) | `` python311Packages.lupupy: 0.3.0 -> 0.3.1 ``                                        |
| [`400e3e8b`](https://github.com/NixOS/nixpkgs/commit/400e3e8b0493121542c56c03db0ed7ea46b54d50) | `` python311Packages.holidays: 0.35 -> 0.36 ``                                        |
| [`6a11dc0a`](https://github.com/NixOS/nixpkgs/commit/6a11dc0aeeb39960b7ac561b24522377102437ea) | `` python311Packages.backports-strenum: 1.2.8 -> 1.2.8 ``                             |
| [`e0c3b8c3`](https://github.com/NixOS/nixpkgs/commit/e0c3b8c31b4a90987d7831ec02298182cf04af90) | `` python311Packages.dvc-objects: 1.1.0 -> 1.2.0 ``                                   |
| [`8ec9e344`](https://github.com/NixOS/nixpkgs/commit/8ec9e34409bcbe99390451fb5965eda6309b4ab2) | `` python311Packages.aioesphomeapi: 18.2.4 -> 18.3.0 ``                               |
| [`4cf0b05e`](https://github.com/NixOS/nixpkgs/commit/4cf0b05ea1bcdafbc4f1568c00e5a92bdea26ad2) | `` ggshield: 1.20.0 -> 1.21.0 ``                                                      |
| [`4a5cbdc7`](https://github.com/NixOS/nixpkgs/commit/4a5cbdc75fa0cb29721c8f23ab1f231acbc10ba0) | `` metasploit: 6.3.41 -> 6.3.42 ``                                                    |
| [`a855c842`](https://github.com/NixOS/nixpkgs/commit/a855c8421bc073b0689a1771d22bbdb1f1fc8789) | `` chainsaw: 2.7.3 -> 2.8.0 ``                                                        |
| [`a0d48d95`](https://github.com/NixOS/nixpkgs/commit/a0d48d958a821945308bae16d1d08fe06ca02a6b) | `` exploitdb: 2023-11-08 -> 2023-11-11 ``                                             |
| [`9a757b83`](https://github.com/NixOS/nixpkgs/commit/9a757b8304314927db6c881114ed9abb0d30dd6f) | `` cnspec: 9.5.2 -> 9.6.1 ``                                                          |
| [`c7cb9bc1`](https://github.com/NixOS/nixpkgs/commit/c7cb9bc17c60590ab4b32d4f6be97227e3d021a6) | `` python310Packages.python-lsp-ruff: 1.5.2 -> 1.6.0 ``                               |
| [`84b8b952`](https://github.com/NixOS/nixpkgs/commit/84b8b952085f71c1d3184e99b85806417fbc850f) | `` libsForQt5: Remove incorrect override attributes ``                                |
| [`99c89117`](https://github.com/NixOS/nixpkgs/commit/99c891175d45b53c1be4d0703f7b9609ea61d8f8) | `` libsForQt5: use makeScopeWithSplicing ``                                           |
| [`2c9764d6`](https://github.com/NixOS/nixpkgs/commit/2c9764d64e6d77d0d4f8697453e71c36f3897b09) | `` python311Packages.nibe: modernize ``                                               |
| [`09caa467`](https://github.com/NixOS/nixpkgs/commit/09caa467133ed37cf68f139e012355a344d92e18) | `` nb: 7.7.1 -> 7.8.0 ``                                                              |
| [`0bc5ca54`](https://github.com/NixOS/nixpkgs/commit/0bc5ca54c340e70878ba18d18218a231fbfed45b) | `` python311Packages.pydexcom: disable on unsupported Python releases ``              |
| [`12a8d4e5`](https://github.com/NixOS/nixpkgs/commit/12a8d4e5e1ccf134d43aa3fe85bb2b66c329ab13) | `` python311Packages.pydexcom: equalize content ``                                    |
| [`45404169`](https://github.com/NixOS/nixpkgs/commit/454041694df6054e3f09eed1fc8c913d2c6743c5) | `` python311Packages.pydexcom: add changelog to meta ``                               |
| [`4cde58f0`](https://github.com/NixOS/nixpkgs/commit/4cde58f0124d6d2b919ff76b4d8f3a316d39e425) | `` python311Packages.pymetno: remove pytz ``                                          |
| [`77784427`](https://github.com/NixOS/nixpkgs/commit/77784427cb0d78b5ed48cd22ccf97a45425718dd) | `` python311Packages.pymetno: disable on unsupported Python releaes ``                |
| [`839ef09e`](https://github.com/NixOS/nixpkgs/commit/839ef09e3add5df1da8485844b83074618fa6a60) | `` python311Packages.pymetno: add changelog to meta ``                                |
| [`5d94872a`](https://github.com/NixOS/nixpkgs/commit/5d94872a446caedb2f34816ace8accf94776a5cb) | `` python310Packages.pygnmi: add changelog to meta ``                                 |
| [`269aaa46`](https://github.com/NixOS/nixpkgs/commit/269aaa466f3fc9f11a20bc0e64ae8c72927a1531) | `` python311Packages.jupyterlab_launcher: remove ``                                   |
| [`d183e697`](https://github.com/NixOS/nixpkgs/commit/d183e6970909d4690271597fc96472cae54d9a0f) | `` openbrf: fix build ``                                                              |
| [`dfa45288`](https://github.com/NixOS/nixpkgs/commit/dfa45288afac9d3565e7784abc520fccdbbb9e69) | `` maintainers: ninjatrappeur -> picnoir ``                                           |
| [`0b4517b4`](https://github.com/NixOS/nixpkgs/commit/0b4517b48e7ae7c83e1477cdbfbd6da2327d4210) | `` python311Packages.pytest-testmon: update license and required python version ``    |
| [`02c9e322`](https://github.com/NixOS/nixpkgs/commit/02c9e322d79e9652b547ba6bc9beb61ee7ae2c5d) | `` python311Packages.nlpcloud: 1.1.44 -> 1.1.45 ``                                    |