### PR TITLE
chore(flake/nixpkgs): `e44462d6` -> `bf744fe9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -474,11 +474,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699781429,
-        "narHash": "sha256-UYefjidASiLORAjIvVsUHG6WBtRhM67kTjEY4XfZOFs=",
+        "lastModified": 1699963925,
+        "narHash": "sha256-LE7OV/SwkIBsCpAlIPiFhch/J+jBDGEZjNfdnzCnCrY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e44462d6021bfe23dfb24b775cc7c390844f773d",
+        "rev": "bf744fe90419885eefced41b3e5ae442d732712d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`f642d01e`](https://github.com/NixOS/nixpkgs/commit/f642d01e41fe3e90f480292ffcfb69cbb82ae515) | `` Revert "python311Packages.pyuavcan: add deprecation warning" ``                            |
| [`43402041`](https://github.com/NixOS/nixpkgs/commit/434020410f9735e5aada9761d88721b1370c94ee) | `` usql: 0.15.2 -> 0.16.0 ``                                                                  |
| [`bffc19bd`](https://github.com/NixOS/nixpkgs/commit/bffc19bd18bebcba12e06bc8eba820f16bfe7bb2) | `` usql: move to by-name ``                                                                   |
| [`fc3f56f2`](https://github.com/NixOS/nixpkgs/commit/fc3f56f2febb5bc7270eee2390f5756a250430ff) | `` release notes: Mention removal of `services.plausible.releaseCookiePath` ``                |
| [`65a47171`](https://github.com/NixOS/nixpkgs/commit/65a471717c53c5b8fa617680140a045da336dabc) | `` plausible, nixos/plausible: Add `listenAddress` option. ``                                 |
| [`9290bb56`](https://github.com/NixOS/nixpkgs/commit/9290bb56546e4c9b99f7960ce08943a10108d65a) | `` gh: 2.38.0 -> 2.39.0 ``                                                                    |
| [`2699f5c4`](https://github.com/NixOS/nixpkgs/commit/2699f5c424b6700124831c429d6319fd4586e9ae) | `` harmonia: 0.7.2 -> 0.7.3 ``                                                                |
| [`54fd8665`](https://github.com/NixOS/nixpkgs/commit/54fd86656959c3107bca5e0dd1a72ee72b8c0a63) | `` nixos/harmonia: set extra-allowed-users ``                                                 |
| [`6fe1a0f6`](https://github.com/NixOS/nixpkgs/commit/6fe1a0f6f6ab6c6574392dfd94c458090354775b) | `` sgt-puzzles: 20230918.2d9e414 -> 20231025.35f7965 ``                                       |
| [`d2e6096c`](https://github.com/NixOS/nixpkgs/commit/d2e6096caf186c96843395285857bcec6aa3ecf4) | `` mediamtx: 1.2.0 -> 1.3.0 ``                                                                |
| [`c3104c4c`](https://github.com/NixOS/nixpkgs/commit/c3104c4cad14301c1866f76f0d374364feae4d29) | `` buildGoModule: deprecate vendorSha256 attribute ``                                         |
| [`f263c609`](https://github.com/NixOS/nixpkgs/commit/f263c60908265008e3799d605bc2d7e08bfebe04) | `` amazon-ssm-agent: add darwin support ``                                                    |
| [`a02ff694`](https://github.com/NixOS/nixpkgs/commit/a02ff694bec1c4764d123bcb7c38e35790679f0e) | `` amazon-ssm-agent: 3.2.1705.0 -> 3.2.1798.0 ``                                              |
| [`b69ef74c`](https://github.com/NixOS/nixpkgs/commit/b69ef74c95d0f09ba414e549a9947ffff243fc42) | `` collectd: fix building with python3.11 ``                                                  |
| [`7a2db9d9`](https://github.com/NixOS/nixpkgs/commit/7a2db9d98a840231d1fc74133c8bb6d8f134e420) | `` python311Packages.simple-salesforce: adjust inputs ``                                      |
| [`28cc46db`](https://github.com/NixOS/nixpkgs/commit/28cc46dbdb0fe14a3628b4054a805e07ee833ddb) | `` python311Packages.pyperf: 2.6.1 -> 2.6.2 ``                                                |
| [`e1113395`](https://github.com/NixOS/nixpkgs/commit/e1113395d27668875f910f9ea487d36c358a30a1) | `` python311Packages.duo-client: disable failing tests ``                                     |
| [`74971b13`](https://github.com/NixOS/nixpkgs/commit/74971b137da907366cfb20f51b279c5bb6b5247d) | `` home-assistant: update component-packages ``                                               |
| [`6c6f2931`](https://github.com/NixOS/nixpkgs/commit/6c6f2931e4dc5c46cf48a4915e50dd245d185b8d) | `` python311Packages.pysuez: init at 0.2.0 ``                                                 |
| [`e08445b3`](https://github.com/NixOS/nixpkgs/commit/e08445b3e0f03a4f16f0aea2b1d0f8dde6545c60) | `` certspotter: 0.17.0 -> 0.18.0 ``                                                           |
| [`9f806fc3`](https://github.com/NixOS/nixpkgs/commit/9f806fc312b403415cee24e3290338a3706baa29) | `` libhugetlbfs: fix cross compile ``                                                         |
| [`2387a37f`](https://github.com/NixOS/nixpkgs/commit/2387a37fa0c686f4541838843d07ae1104e180d7) | `` nixos/flexget: remove TZ envvar ``                                                         |
| [`95b0f085`](https://github.com/NixOS/nixpkgs/commit/95b0f0858cd372bc062626d8f200f0d852cb4f00) | `` qq: 3.2.1-17412 -> 3.2.2-18394 ``                                                          |
| [`dc70869c`](https://github.com/NixOS/nixpkgs/commit/dc70869c1c3e991ba833a211693923fce91bbb37) | `` qq: fix update script ``                                                                   |
| [`3a7da750`](https://github.com/NixOS/nixpkgs/commit/3a7da75011762c512755f5c72c61c4f8dbde4391) | `` blis: fix so version ``                                                                    |
| [`e93a3d7b`](https://github.com/NixOS/nixpkgs/commit/e93a3d7b586022f900f176cf46e7a3bf211cfaf9) | `` doc: separate commit header conventions for each area, info on docs changes. ``            |
| [`560e4156`](https://github.com/NixOS/nixpkgs/commit/560e41562c23ded077b5a8b6df4dd627d50a98d2) | `` sslh: 2.0.0 -> 2.0.1 ``                                                                    |
| [`b6e15091`](https://github.com/NixOS/nixpkgs/commit/b6e15091e550f4e70b92ed96dfe4e54ffff48d9c) | `` linuxKernel.kernels.linux_lqx: 6.5.11-lqx1 -> 6.5.11-lqx2 ``                               |
| [`882ce2cd`](https://github.com/NixOS/nixpkgs/commit/882ce2cde4df9931f66e500c69243a0ea00d2dd5) | `` sqldef: 0.16.9 -> 0.16.10 ``                                                               |
| [`6276c26a`](https://github.com/NixOS/nixpkgs/commit/6276c26abf05fd95776f633878d3cc001125c7b0) | `` spicy-parser-generator: 1.8.1 -> 1.9.0 ``                                                  |
| [`99cfb556`](https://github.com/NixOS/nixpkgs/commit/99cfb55694a474074ce40c6e782db55ef04995bf) | `` sketchybar: 2.19.2 -> 2.19.3 ``                                                            |
| [`5d6c7322`](https://github.com/NixOS/nixpkgs/commit/5d6c73222280b7f69109dfa5c9572f4b74c3453c) | `` jujutsu: 0.10.0 -> 0.11.0 ``                                                               |
| [`656bfcec`](https://github.com/NixOS/nixpkgs/commit/656bfceca30138e19cc82984b5698f56c0d8f6eb) | `` amd-libflame: fix LIBAOCLUTILS_LIBRARY_PATH ``                                             |
| [`2318de70`](https://github.com/NixOS/nixpkgs/commit/2318de70529d5b15293037943e470c1d77c4cb2c) | `` docker: move default from 20.10 to 24 ``                                                   |
| [`9ec104bb`](https://github.com/NixOS/nixpkgs/commit/9ec104bb2d35314ffdf2f59c58c80e08c926d27b) | `` lib.fileset: Very minor changes ``                                                         |
| [`7d3f0fde`](https://github.com/NixOS/nixpkgs/commit/7d3f0fde7c0ec7a60967728ab85bdbb2ae51eb17) | `` motion: 4.5.1 -> 4.6.0 ``                                                                  |
| [`d025bbad`](https://github.com/NixOS/nixpkgs/commit/d025bbad7e88b37c22eb08b835056ac6b8810328) | `` sing-box: 1.6.3 -> 1.6.4 ``                                                                |
| [`9f0859bc`](https://github.com/NixOS/nixpkgs/commit/9f0859bce85a075c31f8874a79901464ed5f6ca4) | `` open-interpreter: 0.1.7 -> 0.1.11 ``                                                       |
| [`e455148e`](https://github.com/NixOS/nixpkgs/commit/e455148e44854187be52a70d4a2bb61ecef9ac4a) | `` php83: 8.3.0RC5 -> 8.3.0RC6 ``                                                             |
| [`19e77cfb`](https://github.com/NixOS/nixpkgs/commit/19e77cfbebbf98e4a13b8c401465a9860fe235fa) | `` shopware-cli: 0.3.6 -> 0.3.12 ``                                                           |
| [`7a7e3acc`](https://github.com/NixOS/nixpkgs/commit/7a7e3acc8ccc995313c87004184fd16e3f050f85) | `` gdcm: unvendor some dependencies (openjpeg, zlib, uuid, expat) ``                          |
| [`437cb56f`](https://github.com/NixOS/nixpkgs/commit/437cb56fc6707457d4249fb437d5dab75d38345a) | `` python311Packages.equinox: 0.11.1 -> 0.11.2 ``                                             |
| [`5c6e85ee`](https://github.com/NixOS/nixpkgs/commit/5c6e85ee472d37c904dd43f8f76b680602b9128f) | `` cosmic-comp: unstable-2023-10-04 -> unstable-2023-11-13 ``                                 |
| [`c6a23d42`](https://github.com/NixOS/nixpkgs/commit/c6a23d421c41a04771566998f0e445d14ab9939a) | `` cosmic-panel: unstable-2023-09-22 -> unstable-2023-11-13 ``                                |
| [`40a621af`](https://github.com/NixOS/nixpkgs/commit/40a621afbeecc93747542af5e9bc03c82b0ec3e9) | `` cosmic-panel: move to pkgs/by-name ``                                                      |
| [`a3625db6`](https://github.com/NixOS/nixpkgs/commit/a3625db6c40e13ed08c68611f7d3602c814c43c3) | `` db-rest: init at 6.0.3 ``                                                                  |
| [`4bb73088`](https://github.com/NixOS/nixpkgs/commit/4bb73088ed30564c3ba6b9c867a40a151846cec5) | `` cowsql: 1.15.3 -> 1.15.4 ``                                                                |
| [`8301203f`](https://github.com/NixOS/nixpkgs/commit/8301203f6f6ac00fdc6d95c161a116956e1f1fc1) | `` radarr: 5.0.3.8127 -> 5.1.3.8246 ``                                                        |
| [`bf92b7d7`](https://github.com/NixOS/nixpkgs/commit/bf92b7d76dad6d3906978ba09fc98b2263aeb3c0) | `` oculante: add wrapGAppsHook, set meta.mainProgram (#263238) ``                             |
| [`35459ba8`](https://github.com/NixOS/nixpkgs/commit/35459ba8060a6c70d3d55106bd4390c379febcd3) | `` thunderbird-bin: 115.4.1 -> 115.4.2 ``                                                     |
| [`92576ad1`](https://github.com/NixOS/nixpkgs/commit/92576ad1701a3e1c15f17a5616558dec9afe5389) | `` thunderbird: 115.4.1 -> 115.4.2 ``                                                         |
| [`e622df9b`](https://github.com/NixOS/nixpkgs/commit/e622df9bb8b31dc0d6178b874e9eeebe082b3408) | `` onlykey: fix missing wrapGAppsHook causing GLib-GIO-ERROR #181500 ``                       |
| [`13fe0ce7`](https://github.com/NixOS/nixpkgs/commit/13fe0ce71bfb523e79055f54ba9e676787274c54) | `` haskellPackages.ema(-note): Take maintainership ``                                         |
| [`41731a01`](https://github.com/NixOS/nixpkgs/commit/41731a01e3b402786430691fc59d433a9bf45736) | `` noto-fonts-cjk-serif: 2.001 -> 0.002 ``                                                    |
| [`2e182d41`](https://github.com/NixOS/nixpkgs/commit/2e182d41d732104cab72dc7336f1a6c289af6818) | `` open-interpreter: add missing dependencies ``                                              |
| [`a77b0d66`](https://github.com/NixOS/nixpkgs/commit/a77b0d666588339939870e544155aba179530f51) | `` kew: init at 1.5.2 (#267234) ``                                                            |
| [`3c19b6d4`](https://github.com/NixOS/nixpkgs/commit/3c19b6d4c213ed61d9ea357a011d345f1222d26d) | `` python3Packages.django-crontab: init at 0.7.1 ``                                           |
| [`2b7e21b3`](https://github.com/NixOS/nixpkgs/commit/2b7e21b32c5dce9993045a408a89bb88140df391) | `` op-geth: 1.101301.1 -> 1.101304.0 ``                                                       |
| [`0cf0e671`](https://github.com/NixOS/nixpkgs/commit/0cf0e6713406eb083fb673acacb7c5751e600bd6) | `` python311Packages.bentoml: 1.1.7 -> 1.1.9 ``                                               |
| [`25eead4f`](https://github.com/NixOS/nixpkgs/commit/25eead4fccfef7e0ae29d8ced3d943b8019add92) | `` python311Packages.qcelemental: update meta ``                                              |
| [`0374da07`](https://github.com/NixOS/nixpkgs/commit/0374da07c9f00f4e205849dd7099a672b9e2c60a) | `` hurl: set meta.mainProgram ``                                                              |
| [`c8fcb5f5`](https://github.com/NixOS/nixpkgs/commit/c8fcb5f50fdf04499311de3f3a01e9b1a1231bbe) | `` python311Packages.dvc-data: 2.20.0 -> 2.21.0 ``                                            |
| [`9cec5c80`](https://github.com/NixOS/nixpkgs/commit/9cec5c807af15237c3cbf377268d3611424d5bd3) | `` nixos/mailman: restart services on failure and increase mailman timeouts ``                |
| [`22211cbe`](https://github.com/NixOS/nixpkgs/commit/22211cbeb66b003b572315ead90bb0fa77f75d5c) | `` amd-libflame: enable withAMDOpt by default ``                                              |
| [`dd79cbcd`](https://github.com/NixOS/nixpkgs/commit/dd79cbcd2fe1e3f8e37b5e812f8612453e418328) | `` amd-libflame: fix cmakeFlags options ``                                                    |
| [`d1df7665`](https://github.com/NixOS/nixpkgs/commit/d1df76655ee684d4ef7e802577a7a7bf07bc8c3f) | `` tplay: init at 0.4.5 (#266300) ``                                                          |
| [`771cae09`](https://github.com/NixOS/nixpkgs/commit/771cae0903f05ad58ee5831c03d898a4a26550bd) | `` python3.pkgs.django-q: fix for Hyperkitty ``                                               |
| [`92fb22dc`](https://github.com/NixOS/nixpkgs/commit/92fb22dc0ac91ece2232f7205217bad187a921d4) | `` carla: add missing lib for carla-bridge-lv2-gtk2 ``                                        |
| [`d0e0f196`](https://github.com/NixOS/nixpkgs/commit/d0e0f196fef632264d9878bfff3e7f06bd6caf59) | `` linux-rt_5_10: 5.10.197-rt96 -> 5.10.199-rt97 ``                                           |
| [`2e891693`](https://github.com/NixOS/nixpkgs/commit/2e891693f2d429e1f54b224619038cfc4659271d) | `` linux_testing: 6.6-rc7 -> 6.7-rc1 ``                                                       |
| [`ee137e01`](https://github.com/NixOS/nixpkgs/commit/ee137e017ce5c73113f83506f588d3e2cdbce95d) | `` linux: enable the NIST SP800-90A DRBG ``                                                   |
| [`8e96c7e2`](https://github.com/NixOS/nixpkgs/commit/8e96c7e227ea84b77555a7680febcc437a3d81da) | `` sbt-extras: 2023-09-18 -> 2023-10-24 ``                                                    |
| [`d992fbfd`](https://github.com/NixOS/nixpkgs/commit/d992fbfdb6c7431669f8d88e28c154790c260416) | `` numbat: add myself as maintainer ``                                                        |
| [`97a35938`](https://github.com/NixOS/nixpkgs/commit/97a3593893f8e01d5b3a3f5f6236c5d726d35315) | `` tenacity: 1.3.2 -> 1.3.3 ``                                                                |
| [`ba43705c`](https://github.com/NixOS/nixpkgs/commit/ba43705c8ffa2e78369ffc247d7803a3e7a49381) | `` rust-analyzer-unwrapped: 2023-10-16 -> 2023-11-13 ``                                       |
| [`aefffb67`](https://github.com/NixOS/nixpkgs/commit/aefffb674c88524ce8b5c22bc6d97fa90504b7cc) | `` bk: init at 0.6.0 ``                                                                       |
| [`afaf6396`](https://github.com/NixOS/nixpkgs/commit/afaf6396660d626699c6a505d7939431bec87b0e) | `` build(deps): bump korthout/backport-action from 2.1.0 to 2.1.1 ``                          |
| [`f5619ed4`](https://github.com/NixOS/nixpkgs/commit/f5619ed43614284212b74d5915d68bebb29a2b72) | `` signal-desktop: 6.37.0 -> 6.38.0, signal-desktop-beta: 6.38.0-beta1 -> ``                  |
| [`8feb68f9`](https://github.com/NixOS/nixpkgs/commit/8feb68f9653d3ed6f371d307b1f740f14f7602a0) | `` {pkgs,nixos}/README.md: Hotlink package and module reviewing guidelines, fix references `` |
| [`cd631134`](https://github.com/NixOS/nixpkgs/commit/cd631134df2ba3440634354fd8839683200992a8) | `` AusweisApp2: 1.26.7 -> 2.0.1 ``                                                            |
| [`1b3f0506`](https://github.com/NixOS/nixpkgs/commit/1b3f05067df2fa07f9c01076ea4ab85d1f1b939b) | `` rtx: 2023.10.2 -> 2023.11.2 ``                                                             |
| [`b4a90bcd`](https://github.com/NixOS/nixpkgs/commit/b4a90bcdc2172aadaab97e7c2687ea9153c2ded6) | `` python311Packages.weconnect-mqtt: 0.47.0 -> 0.48.2 ``                                      |
| [`8906b66a`](https://github.com/NixOS/nixpkgs/commit/8906b66ad2e30cf1c135d2765fae5b2322523c24) | `` python311Packages.weconnect: 0.59.1 -> 0.59.4 ``                                           |
| [`a76575ad`](https://github.com/NixOS/nixpkgs/commit/a76575adaf1d214ee72357b6375977f11ba6798c) | `` python311Packages.webdav4: disable CLI tests ``                                            |
| [`6ed37e8e`](https://github.com/NixOS/nixpkgs/commit/6ed37e8e041cf94df958a42912a89f55e1b78446) | `` jack_capture: 0.9.73 -> 0.9.73.2023-01-04 (#264941) ``                                     |
| [`83217c6f`](https://github.com/NixOS/nixpkgs/commit/83217c6fe1b73276065378a8f7cab64ff307e3cf) | `` raycast: 1.60.1 -> 1.61.2 ``                                                               |
| [`5e45b7c3`](https://github.com/NixOS/nixpkgs/commit/5e45b7c356ba14f9524929622e86aa3238d812a9) | `` scrcpy: migrate to use hash ``                                                             |
| [`44597331`](https://github.com/NixOS/nixpkgs/commit/44597331aa7f0078f453d8105098ab0581385619) | `` scrcpy: add changelog to meta ``                                                           |
| [`95b40d0f`](https://github.com/NixOS/nixpkgs/commit/95b40d0ffdb292be563c3abc54cba4c68376abf3) | `` python311Packages.python-twitch-client: fix build ``                                       |
| [`91de96e0`](https://github.com/NixOS/nixpkgs/commit/91de96e0986e78799418ad6c24a2d02ee66483ff) | `` python311Packages.pytenable: disable tests which requires network access ``                |
| [`d7e9509d`](https://github.com/NixOS/nixpkgs/commit/d7e9509df7d1333ec82513eb2992a6d6b33b7a22) | `` pulumi-bin: 3.92.0 -> 3.93.0 ``                                                            |
| [`08ef1603`](https://github.com/NixOS/nixpkgs/commit/08ef1603a520d6d58a5b1b1f63085509cd578f29) | `` python311Packages.pytest-json-report: disable failing test ``                              |
| [`113a2aca`](https://github.com/NixOS/nixpkgs/commit/113a2aca06f8df98998969dadf311948649c9a3d) | `` fscan: 1.8.2 -> 1.8.3 ``                                                                   |
| [`73a65850`](https://github.com/NixOS/nixpkgs/commit/73a65850e012de139fe30611436c98f6f8090e9d) | `` svtplay-dl: use nose3 for Python 3.11 ``                                                   |
| [`4335400d`](https://github.com/NixOS/nixpkgs/commit/4335400d78125100cc00c56b31adec997044859a) | `` magic-vlsi: 8.3.446 -> 8.3.447 ``                                                          |
| [`b95bcba2`](https://github.com/NixOS/nixpkgs/commit/b95bcba22ab5b881e3c9df3fa5af2612f729eb92) | `` cargo-binstall: 1.4.4 -> 1.4.5 ``                                                          |
| [`723d1269`](https://github.com/NixOS/nixpkgs/commit/723d12699e3b79d4b705f2185a9cba13019273a6) | `` pb: 0.2.0 -> 0.3.0 ``                                                                      |
| [`279b52e0`](https://github.com/NixOS/nixpkgs/commit/279b52e05b37d19e4a96ffec501105bc792b7103) | `` scrcpy: 2.1.1 -> 2.2 ``                                                                    |
| [`a83d9dc7`](https://github.com/NixOS/nixpkgs/commit/a83d9dc773871689bbdea9c0a3d23aa0a557c1b0) | `` spglib: enable Fortran support ``                                                          |
| [`f0e0d4a5`](https://github.com/NixOS/nixpkgs/commit/f0e0d4a58cc683d276b50b9bc95dc45d711cc37b) | `` python311Packages.pyenphase: 1.14.2 -> 1.14.3 ``                                           |
| [`53fd9067`](https://github.com/NixOS/nixpkgs/commit/53fd90673ee028763965ab3c504626d9d9742fa1) | `` maintainers/team-list: update team configuration ``                                        |
| [`49c89858`](https://github.com/NixOS/nixpkgs/commit/49c89858e9c717d3c22ce031c02ffb300f07d601) | `` python311Packages.genanki: update disabled ``                                              |
| [`4dc51ec2`](https://github.com/NixOS/nixpkgs/commit/4dc51ec2105043ccd155ef41f67e25ba020984af) | `` python311Packages.sqlmap: 1.7.10 -> 1.7.11 ``                                              |
| [`88388701`](https://github.com/NixOS/nixpkgs/commit/883887013afb868099aa7c4c8fef5eb1dd97336b) | `` python311Packages.rokuecp: 0.18.1 -> 0.18.2 ``                                             |
| [`063db260`](https://github.com/NixOS/nixpkgs/commit/063db26001b4ea315931df627f9d0c1340efdd2c) | `` python311Packages.prayer-times-calculator: 0.0.9 -> 0.0.10 ``                              |
| [`75384bfe`](https://github.com/NixOS/nixpkgs/commit/75384bfe277a04f7d265d2c9892f451ee1ba7af9) | `` python311Packages.genanki: 0.13.0 -> 0.13.1 ``                                             |
| [`170def09`](https://github.com/NixOS/nixpkgs/commit/170def098468dc4071f0922020c52f3288b8a399) | `` podman-tui: 0.11.0 -> 0.12.0 ``                                                            |
| [`d2c3b779`](https://github.com/NixOS/nixpkgs/commit/d2c3b7799abceebadbe9b742b4e1652533949306) | `` emacs: Add withSmallJaDic flag ``                                                          |
| [`559939a5`](https://github.com/NixOS/nixpkgs/commit/559939a531a6c95b43bfbf85b1ecc55af599a68b) | `` krabby: 0.1.7 -> 0.1.8 ``                                                                  |
| [`d098a554`](https://github.com/NixOS/nixpkgs/commit/d098a55492d5ecef72ad7ed62a5766ef1e6c3d6a) | `` i3bar-river: 0.1.3 -> 0.1.5 ``                                                             |
| [`b72efb2b`](https://github.com/NixOS/nixpkgs/commit/b72efb2bc15937c9bdf43878fdb10f1be968087c) | `` unstructured-api: 0.0.53 -> 0.0.57 ``                                                      |
| [`c392ad59`](https://github.com/NixOS/nixpkgs/commit/c392ad5963a5384b9136f61a8d078b4e59ae8377) | `` python311Packages.unstructured-inference: 0.7.5 -> 0.7.11 ``                               |
| [`39e7a952`](https://github.com/NixOS/nixpkgs/commit/39e7a9525a1248edf27e720221b3b287441939f2) | `` python311Packages.unstructured: 0.10.24 -> 0.10.30 ``                                      |
| [`e16ad523`](https://github.com/NixOS/nixpkgs/commit/e16ad5231480a6d7e026bb890e4372efc2261cf6) | `` python310Packages.nose2: 0.13.0 -> 0.14.0 ``                                               |
| [`2e91c8ba`](https://github.com/NixOS/nixpkgs/commit/2e91c8ba2e806edb140637290b5a5dd5b864c334) | `` moonlight-qt: 5.0.0 -> 5.0.1 ``                                                            |
| [`b8bed3f3`](https://github.com/NixOS/nixpkgs/commit/b8bed3f3d8b401aceea62c406f29346f742b98d4) | `` kube-bench: 0.6.18 -> 0.6.19 ``                                                            |
| [`a0345726`](https://github.com/NixOS/nixpkgs/commit/a0345726dfb8d8a83ac412c4643d00ebdd498c0e) | `` python311Packages.unstructured: 0.10.24 -> 0.10.30 ``                                      |
| [`d8dd4d92`](https://github.com/NixOS/nixpkgs/commit/d8dd4d92b4a103c08878846a629568fec0f7c59d) | `` warp-terminal: init at 0.2023.11.07.08.02.stable_00 ``                                     |
| [`419b6b2d`](https://github.com/NixOS/nixpkgs/commit/419b6b2d5cf2ee247dbd90d02def42270d4dc95b) | `` fzf: 0.43.0 -> 0.44.0 ``                                                                   |
| [`aba1457d`](https://github.com/NixOS/nixpkgs/commit/aba1457d5b56cc5bf05f04206a10b944ccbf33c0) | `` pterm: mark as broken on Darwin ``                                                         |
| [`971718f1`](https://github.com/NixOS/nixpkgs/commit/971718f1d9e1534f96a5377840197a2fc9e0adf8) | `` ocamlPackages.gettext-stub: disable for OCaml ≥ 5.0 ``                                     |
| [`b03530d2`](https://github.com/NixOS/nixpkgs/commit/b03530d28701c07e9f543b45384490f8e45f8f30) | `` ocamlPackages.erm_xml: disable for OCaml ≥ 5.0 ``                                          |
| [`7c77641b`](https://github.com/NixOS/nixpkgs/commit/7c77641bf675856e83bf292b0e2b72e6e8dc6f8d) | `` ocamlPackages.gd4o: disable for OCaml ≥ 5.0 ``                                             |
| [`6cd24b01`](https://github.com/NixOS/nixpkgs/commit/6cd24b0187e9a3546c556c5a332aa92039da3567) | `` ocamlPackages.functory: disable for OCaml ≥ 5.0 ``                                         |
| [`f3fca40f`](https://github.com/NixOS/nixpkgs/commit/f3fca40fd1088d8bd3fe01772ae96148a5339dbc) | `` ocamlPackages.fontconfig: fix build with OCaml ≥ 5.0 ``                                    |
| [`2d4c9ed3`](https://github.com/NixOS/nixpkgs/commit/2d4c9ed30ff4a0f50d54301692c9af26245b1620) | `` pyenv: 2.3.31 -> 2.3.32 ``                                                                 |
| [`6037e18f`](https://github.com/NixOS/nixpkgs/commit/6037e18ff0426743bd23931678e585bbe65a02b7) | `` prometheus-node-exporter: 1.6.1 -> 1.7.0 ``                                                |