### PR TITLE
chore(flake/nixpkgs): `bf744fe9` -> `e4ad9895`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -474,11 +474,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699963925,
-        "narHash": "sha256-LE7OV/SwkIBsCpAlIPiFhch/J+jBDGEZjNfdnzCnCrY=",
+        "lastModified": 1700390070,
+        "narHash": "sha256-de9KYi8rSJpqvBfNwscWdalIJXPo8NjdIZcEJum1mH0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bf744fe90419885eefced41b3e5ae442d732712d",
+        "rev": "e4ad989506ec7d71f7302cc3067abd82730a4beb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`e4ad9895`](https://github.com/NixOS/nixpkgs/commit/e4ad989506ec7d71f7302cc3067abd82730a4beb) | `` gleam: 0.32.2 -> 0.32.4 ``                                                              |
| [`995b8019`](https://github.com/NixOS/nixpkgs/commit/995b80195053953e0daac32c16342161bea887b2) | `` displaycal: 3.9.10 -> 3.9.11 ``                                                         |
| [`fc1c762b`](https://github.com/NixOS/nixpkgs/commit/fc1c762b9f9085d5a2135d70bb468c5fdfa31cd2) | `` clap: 1.1.9 -> 1.1.10 ``                                                                |
| [`56245ef6`](https://github.com/NixOS/nixpkgs/commit/56245ef62796ba7b9dfffb9936539c9cfb470f8d) | `` git-workspace: 1.3.0 -> 1.4.0 ``                                                        |
| [`44d1ad8e`](https://github.com/NixOS/nixpkgs/commit/44d1ad8e600f683677112664422dda997f0a7723) | `` python311Packages.types-awscrt: 0.19.12 -> 0.19.13 ``                                   |
| [`887b38a0`](https://github.com/NixOS/nixpkgs/commit/887b38a0774fd48e4799283da4fbc13b36854ecd) | `` python311Packages.types-setuptools: 68.2.0.0 -> 68.2.0.1 ``                             |
| [`53aeb5c6`](https://github.com/NixOS/nixpkgs/commit/53aeb5c67b78a1bb565467043b79c3948afacbc9) | `` llama-cpp: 1483 -> 1538 ``                                                              |
| [`05967f9a`](https://github.com/NixOS/nixpkgs/commit/05967f9a2c5b8b7298a31b324064e4fe0f63be9b) | `` llama-cpp: fix build due to openblas update ``                                          |
| [`2a857063`](https://github.com/NixOS/nixpkgs/commit/2a85706366a87506b542b024bef39ede4d0f91ab) | `` pr-tracker: 1.3.0 -> 1.4.0 ``                                                           |
| [`d1bf6f6c`](https://github.com/NixOS/nixpkgs/commit/d1bf6f6cf1861a3a9e7c8954e7db18225125d457) | `` abaddon: don't restrict build to just x86_64 ``                                         |
| [`e25b908c`](https://github.com/NixOS/nixpkgs/commit/e25b908cce510e1d157ca957b24e16fb4fe8ecb8) | `` multitail: 7.1.1 -> 7.1.2 ``                                                            |
| [`54c9a08a`](https://github.com/NixOS/nixpkgs/commit/54c9a08aaf98d6d3fd94dc843003360077bee4cc) | `` lib.tests: build nix without flaky aws-sdk-cpp ``                                       |
| [`17845e58`](https://github.com/NixOS/nixpkgs/commit/17845e581d0dbe2f422466d062df9955408fa332) | `` nwg-drawer: 0.3.9 -> 0.4.1 ``                                                           |
| [`cda15ef3`](https://github.com/NixOS/nixpkgs/commit/cda15ef3d66429e23ae21a8b3ef0626813608ab0) | `` nwg-drawer: migrate to by-name ``                                                       |
| [`797f7d67`](https://github.com/NixOS/nixpkgs/commit/797f7d6749f2bfeba99edbe4cf010a0674254705) | `` signal-desktop: fix screensharing on wayland ``                                         |
| [`95bea318`](https://github.com/NixOS/nixpkgs/commit/95bea3180d61229485dee68be7c9521fd888c8f2) | `` cargo-dist: 0.4.2 -> 0.4.3 ``                                                           |
| [`6fed7003`](https://github.com/NixOS/nixpkgs/commit/6fed70035d5e260a515fd85ec5367d6112aa29f8) | `` ddnet: 17.3 -> 17.4 ``                                                                  |
| [`c76fbd16`](https://github.com/NixOS/nixpkgs/commit/c76fbd16eafd3e516da02de36171a3648fb3f718) | `` gql: 0.7.2 -> 0.8.0 ``                                                                  |
| [`88afa93e`](https://github.com/NixOS/nixpkgs/commit/88afa93e8e04f517338226047aecc160b885ff7c) | `` networkmanagerapplet: Use Ayatana app indicator instead of libappindicator (#190942) `` |
| [`3b032f6d`](https://github.com/NixOS/nixpkgs/commit/3b032f6dd4fa7657f08e57d8fb31a7134ce8a22c) | `` python3Packages.geomet: 1.0.0 -> 1.1.0 ``                                               |
| [`4da393a6`](https://github.com/NixOS/nixpkgs/commit/4da393a64ecab30cd67c59c7e85ed5d3c8e276f5) | `` python311Packages.scs: 3.2.3 -> 3.2.4 ``                                                |
| [`eb942c46`](https://github.com/NixOS/nixpkgs/commit/eb942c46f774d4e12077db4a2c2c8d6d5ca951e5) | `` maintainers: add a-n-n-a-l-e-e ``                                                       |
| [`f6cab26a`](https://github.com/NixOS/nixpkgs/commit/f6cab26a11dd6fe621ce2e399e3211754c39d5e7) | `` python311Packages.scs: add BLAS & LAPACK env vars; fix build ``                         |
| [`7a27a4c3`](https://github.com/NixOS/nixpkgs/commit/7a27a4c33a7677fc1dad95161a7301e18231694b) | `` biome: fix build on x86_64-darwin ``                                                    |
| [`8758e3a4`](https://github.com/NixOS/nixpkgs/commit/8758e3a4eb6282b14fff3fb955c7104cc09e4e2c) | `` flyctl: 0.1.117 -> 0.1.127 ``                                                           |
| [`9a869a85`](https://github.com/NixOS/nixpkgs/commit/9a869a8572c938ea124daf58b80a66a8ba5b4cfd) | `` cmospwd: set correct supported platforms ``                                             |
| [`a3c6a753`](https://github.com/NixOS/nixpkgs/commit/a3c6a75374ad46478262a2780c4e18ffdb8b657e) | `` flow: 0.221.0 -> 0.222.0 ``                                                             |
| [`ce8336f7`](https://github.com/NixOS/nixpkgs/commit/ce8336f706a660ee9c5a727f32de45745b66adcc) | `` flow: 0.219.5 -> 0.221.0 ``                                                             |
| [`9f1e5c1b`](https://github.com/NixOS/nixpkgs/commit/9f1e5c1baf9211420eed6ecc7637070099d88df2) | `` hp2p: 3.3 -> unstable-2023-10-25 (#267242) ``                                           |
| [`b489f2f9`](https://github.com/NixOS/nixpkgs/commit/b489f2f978224b5c61fc8e431610412b418c5e0d) | `` cargo-nextest: 0.9.62 -> 0.9.63 ``                                                      |
| [`9a5c5f6b`](https://github.com/NixOS/nixpkgs/commit/9a5c5f6b9dd6eebad76f1652197a24a7c2eba1c6) | `` norouter: unbreak, pin go ``                                                            |
| [`56bcfa33`](https://github.com/NixOS/nixpkgs/commit/56bcfa33259b72172353b76fb775572261bf1c06) | `` hifile: 0.9.9.5 -> 0.9.9.6 ``                                                           |
| [`f8e7a64b`](https://github.com/NixOS/nixpkgs/commit/f8e7a64bfb8bc38af22c5730eb02f138965c95b9) | `` libfprint-2-tod1-elan: init at 0.0.8 ``                                                 |
| [`2986221e`](https://github.com/NixOS/nixpkgs/commit/2986221ea772087d70be819df9afb0445e9f22b3) | `` ripdrag: 0.4.4 -> 0.4.5 ``                                                              |
| [`54a207cf`](https://github.com/NixOS/nixpkgs/commit/54a207cf2158990512746a9ca34ef21aaaa24ac3) | `` cargo-semver-checks: 0.24.2 -> 0.25.0 ``                                                |
| [`4b8521c4`](https://github.com/NixOS/nixpkgs/commit/4b8521c493a4e76b7a803bbbfa0a4c40daab5cda) | `` nixdoc: 2.5.1 -> 2.6.0, add infinisil as maintainer ``                                  |
| [`462ae9fa`](https://github.com/NixOS/nixpkgs/commit/462ae9fadc6fa5d9041a14d27077c9db90c10208) | `` perl538Packages.CSSDOM: fix test ``                                                     |
| [`36bec698`](https://github.com/NixOS/nixpkgs/commit/36bec69867617342c2f23883303a29cb49dfedfe) | `` gitlab-runner: 16.5.0 -> 16.6.0 ``                                                      |
| [`46df3f79`](https://github.com/NixOS/nixpkgs/commit/46df3f79c09838aea969027ecdb9bea2da6ef767) | `` fend: 1.3.1 -> 1.3.2 ``                                                                 |
| [`91567f63`](https://github.com/NixOS/nixpkgs/commit/91567f6314a5d919c75ade4956dad08463c437d4) | `` Revert "sharedown: mark broken" ``                                                      |
| [`9ed632b0`](https://github.com/NixOS/nixpkgs/commit/9ed632b074a2a1acd94f9d75ce6f2f7c97e88550) | `` sway-audio-idle-inhibit: init at unstable-2023-08-09 ``                                 |
| [`fdd16da0`](https://github.com/NixOS/nixpkgs/commit/fdd16da0bb94f570f950f9bd0b19671171658f1a) | `` cudatext: fix patch ``                                                                  |
| [`bac54b6e`](https://github.com/NixOS/nixpkgs/commit/bac54b6e1b8e91d2a25de628243a7cc463327a5f) | `` eigenmath: unstable-2023-10-26 -> unstable-2023-11-17 ``                                |
| [`1ed3858f`](https://github.com/NixOS/nixpkgs/commit/1ed3858f7cebb88bb6d0e598e218bce7fbd57152) | `` cmospwd: Fix static compilation ``                                                      |
| [`201a1b5b`](https://github.com/NixOS/nixpkgs/commit/201a1b5b70775d12c030a255a3301c4af4d4b0f1) | `` govc: 0.33.0 -> 0.33.1 ``                                                               |
| [`ab3c49d8`](https://github.com/NixOS/nixpkgs/commit/ab3c49d8036c58ad2adda6d0df69f1819fa4783f) | `` afew: fix build, use sphinxHook, use pep517 build ``                                    |
| [`6a34cdca`](https://github.com/NixOS/nixpkgs/commit/6a34cdca5f3f3e6f86b806df1d91566a05043d2f) | `` devbox: 0.7.1 -> 0.8.2 ``                                                               |
| [`e304af46`](https://github.com/NixOS/nixpkgs/commit/e304af46ac95ad2361a62a26a346d6530c0a83ab) | `` buildah-unwrapped: 1.32.1 -> 1.32.2 ``                                                  |
| [`c523bdc9`](https://github.com/NixOS/nixpkgs/commit/c523bdc9bb7adaf063733a965063a34f0421dd07) | `` copilot-cli: 1.31.0 -> 1.32.0 ``                                                        |
| [`6a7dc477`](https://github.com/NixOS/nixpkgs/commit/6a7dc477c37e045f4c7669e193fa468d633399f5) | `` arkade: 0.10.13 -> 0.10.15 ``                                                           |
| [`d04acae5`](https://github.com/NixOS/nixpkgs/commit/d04acae51053774fd33f6aa4c43c048d822eae36) | `` vale: 2.29.6 -> 2.29.7 ``                                                               |
| [`b79483b6`](https://github.com/NixOS/nixpkgs/commit/b79483b619f9fb77fa3544d7c83bac9ff80bee1d) | `` mfc465cn{lpr,cupswrapper}: init at 1.0.1-1 ``                                           |
| [`01aecec0`](https://github.com/NixOS/nixpkgs/commit/01aecec0b7d24930e3ad2a270a1116beb9411333) | `` nixpacks: 1.18.0 -> 1.19.0 ``                                                           |
| [`d581fb17`](https://github.com/NixOS/nixpkgs/commit/d581fb17d72e918ebe1a30f926ef24e74f776aca) | `` session-desktop: 1.11.3 -> 1.11.4 ``                                                    |
| [`3ef80b04`](https://github.com/NixOS/nixpkgs/commit/3ef80b04cf02d2f93a69c1f8ca6223b908f2c78e) | `` containerd: 1.7.8 -> 1.7.9 ``                                                           |
| [`e6657c95`](https://github.com/NixOS/nixpkgs/commit/e6657c95837944ef6ae14c67483d39dce9732592) | `` python311Packages.plaid-python: 17.0.0 -> 18.0.0 ``                                     |
| [`54fbb395`](https://github.com/NixOS/nixpkgs/commit/54fbb395981824764734afe93512f1601bd43c7d) | `` keepassrpc: use dontUnpack instead of placeholder unpackCmd/sourceRoot ``               |
| [`a8617e2b`](https://github.com/NixOS/nixpkgs/commit/a8617e2b0d26b16e91b224db9ebcb4a500c515cf) | `` nixos/networkd: allow configuring AckFilter for CAKE qdisc ``                           |
| [`7d82b932`](https://github.com/NixOS/nixpkgs/commit/7d82b9323faf59134f21ba4b163992785a021e2f) | `` python311Packages.succulent: 0.2.5 -> 0.2.6 ``                                          |
| [`8ebee6a7`](https://github.com/NixOS/nixpkgs/commit/8ebee6a76472cffbf6cfe28b1c0ff29ae9bdf1d1) | `` eksctl: 0.163.0 -> 0.164.0 ``                                                           |
| [`0d7b6f90`](https://github.com/NixOS/nixpkgs/commit/0d7b6f9064e606a802ebedf883ac49474cf7fc92) | `` python311Packages.circus: fix tests on darwin ``                                        |
| [`0dd2238a`](https://github.com/NixOS/nixpkgs/commit/0dd2238ac7fb39e9123ecc0c7332a6930397f5d2) | `` mitmproxy: fix macos build ``                                                           |
| [`05b65184`](https://github.com/NixOS/nixpkgs/commit/05b651843ef150eb134785762edd0ecd61cfc6a5) | `` rl-2311: Note bcachefs kernel deprecation changes ``                                    |
| [`c2450c45`](https://github.com/NixOS/nixpkgs/commit/c2450c45150d3a3f56f27f1d46e75e8a041f1842) | `` treewide: add bcachefsLinuxTesting and bcachefsLinuxTesting tests ``                    |
| [`890cf0a7`](https://github.com/NixOS/nixpkgs/commit/890cf0a79c936c49b06513e23cec7d375c456f7d) | `` nixos/bcachefs: soft-deprecate 'linuxPackages_testing_bcachefs' ``                      |
| [`39951cdd`](https://github.com/NixOS/nixpkgs/commit/39951cddc7f1a6ac03e65cb4581b1f51237f6ac4) | `` darwin.libiconv: set mainProgram ``                                                     |
| [`bf7ad8cf`](https://github.com/NixOS/nixpkgs/commit/bf7ad8cfbfa102a90463433e2c5027573b462479) | `` wine64Packages.minimal: mark broken on Darwin ``                                        |
| [`7d4eeb75`](https://github.com/NixOS/nixpkgs/commit/7d4eeb75fe4b9b5346cade097e7c286e7795fe0b) | `` wordpressPackages.tc-custom-javascript: init at 1.2.3 ``                                |
| [`99e233d3`](https://github.com/NixOS/nixpkgs/commit/99e233d3293b5b11690ce7b82336ef781f5cb2e5) | `` metasploit: 6.3.42 -> 6.3.43 ``                                                         |
| [`ef57e6b1`](https://github.com/NixOS/nixpkgs/commit/ef57e6b154daa84c8f7f0aebe2478104b08787d0) | `` nuclei: 3.0.3 -> 3.0.4 ``                                                               |
| [`fc285246`](https://github.com/NixOS/nixpkgs/commit/fc2852466d8c28b4757cf51789cfd19353880d2e) | `` wineWow64Packages: fix build on Darwin ``                                               |
| [`fd270313`](https://github.com/NixOS/nixpkgs/commit/fd2703130c48a494f85805ed91dc45bfcd73aea2) | `` wine64Packages: 8.17 -> 8.20 ``                                                         |
| [`577d271a`](https://github.com/NixOS/nixpkgs/commit/577d271a7707b2f425e4244b9c0228764a2b7add) | `` oneDNN: 3.3 -> 3.3.1 ``                                                                 |
| [`87c6a971`](https://github.com/NixOS/nixpkgs/commit/87c6a971de5f190405c62946fd3cef768ca518f2) | `` rio: fix build on darwin ``                                                             |
| [`3469b079`](https://github.com/NixOS/nixpkgs/commit/3469b0798c99ebb23b0b1e93be54d762ebe341be) | `` onionshare: add missing dependencies ``                                                 |
| [`f9d81734`](https://github.com/NixOS/nixpkgs/commit/f9d817349a784bf76ca175fb51e988c7f04aeff8) | `` kafkactl: 3.4.0 -> 3.5.1 ``                                                             |
| [`d5fcb6b7`](https://github.com/NixOS/nixpkgs/commit/d5fcb6b789a3bd3ebce4ae3534aa28083ba41ff5) | `` standardnotes: 3.178.4 -> 3.181.23 ``                                                   |
| [`0adbda28`](https://github.com/NixOS/nixpkgs/commit/0adbda28d3a65f4ec63360819f4203646a00b867) | `` nixos/bcachefs: remove 'with lib;' ``                                                   |
| [`edd51371`](https://github.com/NixOS/nixpkgs/commit/edd5137105ddbf76ed4a59a0a268090c5f2903d2) | `` invoice2data: 0.4.2 -> 0.4.4 ``                                                         |
| [`9dee3f84`](https://github.com/NixOS/nixpkgs/commit/9dee3f84f71db429486baeed23c74c01804bcd43) | `` invoice2data: add missing setuptools input ``                                           |
| [`ffb4d954`](https://github.com/NixOS/nixpkgs/commit/ffb4d9542a9fab7cc5fe34fdaa5378d398ab3a99) | `` kubernetes: 1.28.3 -> 1.28.4 ``                                                         |
| [`706ded37`](https://github.com/NixOS/nixpkgs/commit/706ded371187802498999c4a6dad8454438c17b6) | `` signal-desktop: 6.38.0 -> 6.39.0, 6.39.0-beta.2 -> 6.40.0-beta.1 ``                     |
| [`fab56442`](https://github.com/NixOS/nixpkgs/commit/fab56442243e83dfa4a6181c4c2c20177055df5f) | `` cagebreak: 1.9.1 -> 2.2.1 ``                                                            |
| [`5e4da3bc`](https://github.com/NixOS/nixpkgs/commit/5e4da3bc49db14f033a4e1c7783c6cdad2658b9a) | `` haproxy: 2.8.3 -> 2.8.4 ``                                                              |
| [`31525a81`](https://github.com/NixOS/nixpkgs/commit/31525a81376f031f05bfe1924ee3e2932316e49f) | `` pan: 0.154 -> 0.155 ``                                                                  |
| [`cb1aa46f`](https://github.com/NixOS/nixpkgs/commit/cb1aa46fc651104d30cd7ec07226386277d98cb8) | `` python311Packages.testrail-api: 1.12.0 -> 1.12.1 ``                                     |
| [`6d69feb3`](https://github.com/NixOS/nixpkgs/commit/6d69feb35edd13edaf7496d460e46ad36e63ed36) | `` google-compute-image: add the missing /boot filesystem ``                               |
| [`222b24ca`](https://github.com/NixOS/nixpkgs/commit/222b24cae59d7e166092f4a99d34b90533db4692) | `` python311Packages.strawberry-graphql: 0.208.0 -> 0.214.0 ``                             |
| [`c65b1f47`](https://github.com/NixOS/nixpkgs/commit/c65b1f47ab9362d9d38612ce837b6bb9d36bc2be) | `` python311Packages.stringparser: 0.6 -> 0.7 ``                                           |
| [`79125c7a`](https://github.com/NixOS/nixpkgs/commit/79125c7a2908124a8ea80ead66bb12cbc694cb21) | `` python311Packages.stripe: modernize ``                                                  |
| [`8b99032d`](https://github.com/NixOS/nixpkgs/commit/8b99032da035b8c4b588052e9dda11ffd60ac020) | `` python311Packages.stripe: 7.4.0 -> 7.5.0 ``                                             |
| [`71507b67`](https://github.com/NixOS/nixpkgs/commit/71507b6707b2fe52c9dfba21e569f7c03f99c86c) | `` python311Packages.siobrultech-protocols: 0.12.0 -> 0.13.0 ``                            |
| [`304742b5`](https://github.com/NixOS/nixpkgs/commit/304742b50bd638a8d5f7b698f8f5373c55cc78d6) | `` python311Packages.xlsxwriter: add changelog to meta ``                                  |
| [`c057e997`](https://github.com/NixOS/nixpkgs/commit/c057e9972d7fa554fdf79ea8b9fafaa579785dca) | `` python311Packages.ytmusicapi: 1.3.1 -> 1.3.2 ``                                         |
| [`d9327a53`](https://github.com/NixOS/nixpkgs/commit/d9327a53de76fe34739ce9eda3cc01240fe7321a) | `` Revert "python2/mk-python-derivation: disable catchConflictsHook" ``                    |
| [`43cde5c6`](https://github.com/NixOS/nixpkgs/commit/43cde5c6ac490dc2d4d3d98ca15af8f11442ed46) | `` python311Packages.xlsxwriter: 3.1.7 -> 3.1.9 ``                                         |
| [`f292ef49`](https://github.com/NixOS/nixpkgs/commit/f292ef4958bf9e1de18c62a315ed09f95954473a) | `` python/hooks: restore catchConflictHook for python<3.10 ``                              |
| [`73940917`](https://github.com/NixOS/nixpkgs/commit/739409177a3899ae3c131e49e3d9eb9868e5cb91) | `` plasma5Packages.discover: build without PackageKit backend ``                           |
| [`504c0396`](https://github.com/NixOS/nixpkgs/commit/504c03961da7e8284ca53ed80138a4b9c21c7d9a) | `` esphome: 2023.11.1 -> 2023.11.2 ``                                                      |
| [`5b19fa84`](https://github.com/NixOS/nixpkgs/commit/5b19fa843a9e8cd3cd8618c2145471f9d43a767d) | `` python311Packages.aioesphomeapi: 18.5.2 -> 18.5.3 ``                                    |
| [`f4131a43`](https://github.com/NixOS/nixpkgs/commit/f4131a43fa19fe90810b92de49dbd2569f2e83dc) | `` hof: init at 0.6.9-beta.1 ``                                                            |
| [`88387cff`](https://github.com/NixOS/nixpkgs/commit/88387cffd293ca956799123569cadab457db319e) | `` update sources ``                                                                       |
| [`0aeec365`](https://github.com/NixOS/nixpkgs/commit/0aeec365caf1496ecdb86b63e916d7d508e3431e) | `` openai-whisper: 20230918 -> 20231117 ``                                                 |