### PR TITLE
chore(flake/nixos-hardware): `5689f3eb` -> `1721da31`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -459,11 +459,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1699997707,
-        "narHash": "sha256-ugb+1TGoOqqiy3axyEZpfF6T4DQUGjfWZ3Htry1EfvI=",
+        "lastModified": 1700315735,
+        "narHash": "sha256-zlSLW6dX5XwBEwN87CIVtMr8zDSKvTRFmWmIQ9FfWgo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "5689f3ebf899f644a1aabe8774d4f37eb2f6c2f9",
+        "rev": "1721da31f9b30cbf4460c4ec5068b3b6174a4694",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`1721da31`](https://github.com/NixOS/nixos-hardware/commit/1721da31f9b30cbf4460c4ec5068b3b6174a4694) | `` starfive visionfive2: update kernel to 6.6.0 ``              |
| [`e27bf85b`](https://github.com/NixOS/nixos-hardware/commit/e27bf85b46cb6325d6052144d63a26935f8b1cfb) | `` starfive visionfive2: update u-boot to SDK version v3.8.2 `` |
| [`eb903ed8`](https://github.com/NixOS/nixos-hardware/commit/eb903ed873af4063bf400ac988b03465fef51129) | `` Update README.md ``                                          |
| [`f2d7c0b2`](https://github.com/NixOS/nixos-hardware/commit/f2d7c0b23c507e0823508948f3b002c9c6d5a586) | `` framework AMD 7040: Add config option for wake-on-AC fix ``  |
| [`c0fa269f`](https://github.com/NixOS/nixos-hardware/commit/c0fa269fe95b48af852ff93263ef5a5f57721086) | `` Update README.md ``                                          |
| [`a6426241`](https://github.com/NixOS/nixos-hardware/commit/a6426241a5e003a6ff22ac24a896e43332d4a6cc) | `` feat(framework): add suspend udev hint ``                    |