### PR TITLE
chore(flake/home-manager): `993fb02d` -> `1aabb0a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700419052,
-        "narHash": "sha256-U6a5f9ynbzcp8PMIHULbHPkbwp7YfPKOYmTcLqlalD4=",
+        "lastModified": 1700553346,
+        "narHash": "sha256-kW7uWsCv/lxuA824Ng6EYD9hlVYRyjuFn0xBbYltAeQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "993fb02d20760067b8ee19c713d94cee07037759",
+        "rev": "1aabb0a31b25ad83cfaa37c3fe29053417cd9a0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`1aabb0a3`](https://github.com/nix-community/home-manager/commit/1aabb0a31b25ad83cfaa37c3fe29053417cd9a0f) | `` picom: use getExe instead of hardcoded binary ``           |
| [`3de857fa`](https://github.com/nix-community/home-manager/commit/3de857fa7d996a60966cccb44fbfce8d3c4544d8) | `` qt: fix `qt.platformTheme = "gtk3"` ``                     |
| [`fff5204e`](https://github.com/nix-community/home-manager/commit/fff5204e5dbe8403d5ad1816c183f7b663d9fe1d) | `` qt: fix basic usage when just `qt.enable = true` is set `` |