### PR TITLE
chore(flake/nixos-hardware): `2b00bc76` -> `c3abafb0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -459,11 +459,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1700392353,
-        "narHash": "sha256-KARn8aVJu5fdW0jdJYoOQ1SPqWlNdz4l7r90NbArWSY=",
+        "lastModified": 1700559156,
+        "narHash": "sha256-gL4epO/qf+wo30JjC3g+b5Bs8UrpxzkhNBBsUYxpw2g=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2b00bc76dc893cd996a3d76a2f059d657a5ef37a",
+        "rev": "c3abafb01cd7045dba522af29b625bd1e170c2fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                              |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`c3abafb0`](https://github.com/NixOS/nixos-hardware/commit/c3abafb01cd7045dba522af29b625bd1e170c2fb) | `` chore: Add switcheroo service for Dual GPU ``     |
| [`fc126177`](https://github.com/NixOS/nixos-hardware/commit/fc126177f68500a53155a2b3a6bd2d711f5495d2) | `` chore: Activate nvidia powermanagement ``         |
| [`82cf9ae3`](https://github.com/NixOS/nixos-hardware/commit/82cf9ae3f663471552610e6ece2eeb3b43908a13) | `` framework/13-inch/12th-gen-intel: ec crash fix `` |