### PR TITLE
chore(flake/home-manager): `1aabb0a3` -> `134deb46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700553346,
-        "narHash": "sha256-kW7uWsCv/lxuA824Ng6EYD9hlVYRyjuFn0xBbYltAeQ=",
+        "lastModified": 1700695018,
+        "narHash": "sha256-MAiPLgBF4GLzSOlhnPCDWkWW5CDx4i7ApIYaR+TwTVg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1aabb0a31b25ad83cfaa37c3fe29053417cd9a0f",
+        "rev": "134deb46abd5d0889d913b8509413f6f38b0811e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`134deb46`](https://github.com/nix-community/home-manager/commit/134deb46abd5d0889d913b8509413f6f38b0811e) | `` bat: support boolean flags in config `` |
| [`1bd1e864`](https://github.com/nix-community/home-manager/commit/1bd1e8646473235dfe76831812f8662b837cb184) | `` ruff: add module ``                     |