### PR TITLE
chore(flake/nixpkgs): `e4ad9895` -> `19cbff58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -474,11 +474,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700390070,
-        "narHash": "sha256-de9KYi8rSJpqvBfNwscWdalIJXPo8NjdIZcEJum1mH0=",
+        "lastModified": 1700612854,
+        "narHash": "sha256-yrQ8osMD+vDLGFX7pcwsY/Qr5PUd6OmDMYJZzZi0+zc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e4ad989506ec7d71f7302cc3067abd82730a4beb",
+        "rev": "19cbff58383a4ae384dea4d1d0c823d72b49d614",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`cf9a7cd4`](https://github.com/NixOS/nixpkgs/commit/cf9a7cd48adb81814dd5d92747a06b4854e5f908) | `` xeus-cling: init at 0.15.3 ``                                            |
| [`1383b84d`](https://github.com/NixOS/nixpkgs/commit/1383b84d37d3dbca82c4c07bd0afe5d6e2ebaf35) | `` coq_kernel: init at 1.6.0 ``                                             |
| [`72edcc74`](https://github.com/NixOS/nixpkgs/commit/72edcc748a92377d0568c9536ece114dbabb948c) | `` wrapFirefox: unpin ffmpeg version (#269038) ``                           |
| [`86eb3a99`](https://github.com/NixOS/nixpkgs/commit/86eb3a994ed6f101ed4b3c19025e8133423bcca8) | `` jupyter: fix runtime error ``                                            |
| [`a03080d3`](https://github.com/NixOS/nixpkgs/commit/a03080d35eba89a5b16d707f196480e0c00d4800) | `` vimPlugins.neotest: fix typo in overrides ``                             |
| [`ab99231a`](https://github.com/NixOS/nixpkgs/commit/ab99231a3648b0ba903b956d071aeea5d8d3e12f) | `` prefetch-yarn-deps: add cacert to provide certificates during fetches `` |
| [`625c4500`](https://github.com/NixOS/nixpkgs/commit/625c450024e24c55cac035372bc49b39f8df005b) | `` nixos/release: fix versionSuffix eval ``                                 |
| [`decdfde0`](https://github.com/NixOS/nixpkgs/commit/decdfde0114b12928cf1791836524cff49a60780) | `` improve documentation of new options ``                                  |
| [`87cc0698`](https://github.com/NixOS/nixpkgs/commit/87cc06983c14876bb56a6a84935d1a3968f35999) | `` 24.05 is Uakari ``                                                       |
| [`648ffcec`](https://github.com/NixOS/nixpkgs/commit/648ffcecaec71d992ac714b07fe4bee2e482737f) | `` fix some errors ``                                                       |
| [`dc7b3feb`](https://github.com/NixOS/nixpkgs/commit/dc7b3febf8d862328d8704de5c8437d2df442c76) | `` 23.11 beta release ``                                                    |
| [`21565a7d`](https://github.com/NixOS/nixpkgs/commit/21565a7def19247ecb90aa29c0d7de23adbecdb1) | `` maizzle: 1.5.6 -> 1.5.7 ``                                               |
| [`e9bddc49`](https://github.com/NixOS/nixpkgs/commit/e9bddc495d5f54ee275da46e284a590f777236df) | `` pdk: init at 3.0.0 ``                                                    |
| [`b88576b3`](https://github.com/NixOS/nixpkgs/commit/b88576b3b47c6338d826384008ddea208a003a0b) | `` fwupd: 1.9.8 -> 1.9.9 ``                                                 |
| [`4b4336c9`](https://github.com/NixOS/nixpkgs/commit/4b4336c986aeba33b66e783ad84292289e079951) | `` tile38: 1.32.0 -> 1.32.1 ``                                              |
| [`c4106756`](https://github.com/NixOS/nixpkgs/commit/c4106756313c48e6488eea024ec8a4c8bf1679ac) | `` deepin.deepin-icon-theme: update icon cache before fixup ``              |
| [`7ddfd3f6`](https://github.com/NixOS/nixpkgs/commit/7ddfd3f64f73fa065ebae80bff13998009d35005) | `` afew: propagate setuptools, add version test ``                          |
| [`c26a9e5f`](https://github.com/NixOS/nixpkgs/commit/c26a9e5fa2cf7d608f6ab26678479ce677903267) | `` yggdrasil: 0.5.1 -> 0.5.2 ``                                             |
| [`78623653`](https://github.com/NixOS/nixpkgs/commit/786236539cc9ab630e961195f009a4ca8da274b0) | `` v2ray-domain-list-community: 20231118232758 -> 20231121082246 ``         |
| [`f35046bb`](https://github.com/NixOS/nixpkgs/commit/f35046bba7eef2b63f0952bd5f8752bbf86a3046) | `` sing-box: 1.6.5 -> 1.6.6 ``                                              |
| [`ed31e023`](https://github.com/NixOS/nixpkgs/commit/ed31e0235e97a20ab013c3f1c3fed04041cd146e) | `` treewide: replace broken udev paths with systemd ``                      |
| [`2125339f`](https://github.com/NixOS/nixpkgs/commit/2125339fec061101f220c67bbebe068e0836c36b) | `` python311Packages.aioopenexchangerates: modernize ``                     |
| [`e459cf2c`](https://github.com/NixOS/nixpkgs/commit/e459cf2c3272fd5e48396d3516c8f9762ff83518) | `` python311Packages.asf-search: add tenacity ``                            |
| [`7070f402`](https://github.com/NixOS/nixpkgs/commit/7070f402ba1d40c7a57f93fb7d32caba49b18c8d) | `` Revert "bazecor: init at 1.3.2" ``                                       |
| [`c4d5c9a7`](https://github.com/NixOS/nixpkgs/commit/c4d5c9a79406a1f7a04751fdb1f2b70f694aac9a) | `` python311Packages.imageio: disable failing tests on darwin ``            |
| [`bad9e110`](https://github.com/NixOS/nixpkgs/commit/bad9e110668bd1a0107c13918afae465e1c39aca) | `` python311Packages.av: disable crashing tests on darwin ``                |
| [`5e60de4c`](https://github.com/NixOS/nixpkgs/commit/5e60de4c9551a9bca925f7bdac02a921de688b1c) | `` python311Packages.aioopenexchangerates: 0.4.3 -> 0.4.4 ``                |
| [`3bb0c1e6`](https://github.com/NixOS/nixpkgs/commit/3bb0c1e6cfdb0cb0076d63f9253b8f7c136481d8) | `` exploitdb: 2023-11-18 -> 2023-11-21 ``                                   |
| [`c5a16aee`](https://github.com/NixOS/nixpkgs/commit/c5a16aee02703016bb0ed2c60e3123b4de792adf) | `` cfripper: 1.14.0 -> 1.15.0 ``                                            |
| [`5d94a9c4`](https://github.com/NixOS/nixpkgs/commit/5d94a9c49a48d8d937dc44dc779100eb6568360f) | `` goredo: 2.3.0 -> 2.4.0 ``                                                |
| [`008fa150`](https://github.com/NixOS/nixpkgs/commit/008fa1502f0d62ce452ed9b8883fb6f46cc95755) | `` deepin.deepin-editor: 6.0.11 -> 6.0.15 ``                                |
| [`78cbf53e`](https://github.com/NixOS/nixpkgs/commit/78cbf53e821616d3e63756ff83fa092a4914b23e) | `` perlPackages.Hailo: fix tests ``                                         |
| [`b16e02b4`](https://github.com/NixOS/nixpkgs/commit/b16e02b405d635bbb15629b874a57549f2eeeb94) | `` mdbook-footnote: init at 0.1.1 ``                                        |
| [`0fd6535b`](https://github.com/NixOS/nixpkgs/commit/0fd6535b4c6b528dc5062fc5fac139f66e629d64) | `` clamtk: add ShamrockLee as a maintainer ``                               |
| [`0d42e5bc`](https://github.com/NixOS/nixpkgs/commit/0d42e5bc5f30352bcf5fc1142dfe9974e0ed055c) | `` python311Packages.openllm-core: 0.3.9 -> 0.4.22 ``                       |
| [`e289901d`](https://github.com/NixOS/nixpkgs/commit/e289901d064a034967ec2e252642caa7f3fc88c7) | `` python311Packages.httpx-auth: init at 0.18.0 ``                          |
| [`4b195917`](https://github.com/NixOS/nixpkgs/commit/4b195917312a61bae43fb6adc5351d2bfc526197) | `` rnote: 0.8.2 -> 0.9.2 ``                                                 |
| [`db3c02e0`](https://github.com/NixOS/nixpkgs/commit/db3c02e07503deb7aa1e3748d8aacb7b4943fa1c) | `` wasmtime: 14.0.4 -> 15.0.0 ``                                            |
| [`30bdf7a7`](https://github.com/NixOS/nixpkgs/commit/30bdf7a79ee57c084b98f881f7279b1f8c0a5a59) | `` libdeltachat: do not use __FILE__ as a path to headers location ``       |
| [`76c900bc`](https://github.com/NixOS/nixpkgs/commit/76c900bc7f33e806370aa28759fe07e2905bfa87) | `` unifi-protect-backup: 0.10.1 -> 0.10.2 ``                                |
| [`08c47e8d`](https://github.com/NixOS/nixpkgs/commit/08c47e8d91723f13e092cea2dd6e58499c0428c2) | `` python311Packages.imageio: 2.32.0 -> 2.33.0 ``                           |
| [`9440ea51`](https://github.com/NixOS/nixpkgs/commit/9440ea5159a8b126c0b255ecc3fd1959f1fdc0dd) | `` maintainers: Add brianmcgillion ``                                       |
| [`48bda0f6`](https://github.com/NixOS/nixpkgs/commit/48bda0f6242e273adbdc1715c448dcf146befa66) | `` davmail: add coreutils gnugrep ``                                        |
| [`99faccd2`](https://github.com/NixOS/nixpkgs/commit/99faccd2e7b8fe308d0df7e2ff6c9215789fc0a4) | `` davmail: 6.1.0 -> 6.2.0 ``                                               |
| [`8dcd50a2`](https://github.com/NixOS/nixpkgs/commit/8dcd50a29df57f960bd0a8e02bfd00c3712e1a0a) | `` python311Packages.jupyterlab-git: 0.42.0 -> 0.50.0rc0 ``                 |
| [`aa41b196`](https://github.com/NixOS/nixpkgs/commit/aa41b196bd7399365225b6a08368aef8ca11a91a) | `` python311Packages.timm: 0.9.10 -> 0.9.11 ``                              |
| [`b16be474`](https://github.com/NixOS/nixpkgs/commit/b16be474e930d64b4e4c46a1e33d70129b86c029) | `` qbittorrent: 4.6.0 -> 4.6.1 ``                                           |
| [`419085f8`](https://github.com/NixOS/nixpkgs/commit/419085f8b1df8a13790325af99d0b7bce3654545) | `` ntfy-sh: 2.7.0 -> 2.8.0 ``                                               |
| [`a0cd9771`](https://github.com/NixOS/nixpkgs/commit/a0cd9771a89857be1abbe367cefd4b3384285f9c) | `` python311Packages.google-cloud-automl: 2.11.3 -> 2.11.4 ``               |
| [`26cc8bad`](https://github.com/NixOS/nixpkgs/commit/26cc8bad277a8c9efca9b1503b4282dd439d4f35) | `` python311Packages.boschshcpy: 0.2.75 -> 0.2.77 ``                        |
| [`0f8f62e7`](https://github.com/NixOS/nixpkgs/commit/0f8f62e7735b1890609baee5f3888e100877c856) | `` python311Packages.azure-mgmt-web: 7.1.0 -> 7.2.0 ``                      |
| [`0edd4585`](https://github.com/NixOS/nixpkgs/commit/0edd45851f4dad51e068de409028d795e7a0b93a) | `` telegram-desktop: Switch to regular glibmm ``                            |
| [`8182c92a`](https://github.com/NixOS/nixpkgs/commit/8182c92af90cc35d06e67b05bea02d2434e3737e) | `` gnomeExtensions: automatic update ``                                     |
| [`3b45e2be`](https://github.com/NixOS/nixpkgs/commit/3b45e2be92e525fcc86ec4977ea13d409bcb70b3) | `` libportal: 0.6 → 0.7.1 ``                                                |
| [`f962d04e`](https://github.com/NixOS/nixpkgs/commit/f962d04ed30ea26dac20ee782f13df897c829d8e) | `` nixos/rl-2311: Mention default application changes in GNOME 45 ``        |
| [`b32a490b`](https://github.com/NixOS/nixpkgs/commit/b32a490b14e103187ee37e168c7c9b81a93dd32b) | `` nixos/gnome: Do not install Photos ``                                    |
| [`d1993b45`](https://github.com/NixOS/nixpkgs/commit/d1993b45b128f9d669ae10f046de5d87ef0ec2d2) | `` chromium: Fix build with at-spi2-core 2.49 ``                            |
| [`2378029b`](https://github.com/NixOS/nixpkgs/commit/2378029bb3c4c98fa00255e18920fdded7d1fb3e) | `` python311Packages.bimmer-connected: 0.14.2 -> 0.14.3 ``                  |
| [`57b5c5c8`](https://github.com/NixOS/nixpkgs/commit/57b5c5c861ceaea5997952686fe905897338ac92) | `` python311Packages.aiosomecomfort: refactor ``                            |
| [`0ebedb70`](https://github.com/NixOS/nixpkgs/commit/0ebedb70440881b1f7c70a84da8ec2d1171b63aa) | `` python311Packages.aiosomecomfort: 0.0.17 -> 0.0.22 ``                    |
| [`5adcb43d`](https://github.com/NixOS/nixpkgs/commit/5adcb43d51fb63e17e27e0d1beda35e7a2569a46) | `` python311Packages.xkcdpass: 1.19.5 -> 1.19.6 ``                          |
| [`fc1a171e`](https://github.com/NixOS/nixpkgs/commit/fc1a171e8872af2804c504570a40b0258f06d542) | `` checkov: 3.0.40 -> 3.1.4 ``                                              |
| [`fcfb09e3`](https://github.com/NixOS/nixpkgs/commit/fcfb09e32558bfe478476beff0e29142c4c01519) | `` pv: 1.8.0 -> 1.8.5 ``                                                    |
| [`37e6adc9`](https://github.com/NixOS/nixpkgs/commit/37e6adc926fc74e270e86a544a41aecabb0effb1) | `` dayon: 12.0.1 -> 13.0.0 ``                                               |
| [`d1a2cdd3`](https://github.com/NixOS/nixpkgs/commit/d1a2cdd3220abdae6995c2c27bdb3a25b41d519f) | `` tokei: add zlib to checkInputs on Darwin ``                              |
| [`293382ef`](https://github.com/NixOS/nixpkgs/commit/293382ef8a25b7a08481feb2a2c9911b106ed8c5) | `` influxdb: 1.10.0 -> 1.10.5; fix build ``                                 |
| [`30f3d0d9`](https://github.com/NixOS/nixpkgs/commit/30f3d0d98fe5012316f80643ee8a09f9295bb053) | `` organicmaps: 2023.08.18-8 -> 2023.11.17-17 ``                            |
| [`9b4a8464`](https://github.com/NixOS/nixpkgs/commit/9b4a8464096fde24a37c3e2aa4373961d87a45fd) | `` nixos/xdg/portal: Fix link to portals.conf documentation ``              |
| [`a4f2ad82`](https://github.com/NixOS/nixpkgs/commit/a4f2ad82d5e04525f00c1cb4eff8f60c084c7ffb) | `` glib: 2.78.0 → 2.78.1 ``                                                 |
| [`245cdc27`](https://github.com/NixOS/nixpkgs/commit/245cdc279f4bb47c504e915cbc5aca971a3a8c26) | `` vala_0_56: 0.56.13 → 0.56.14 ``                                          |
| [`da410137`](https://github.com/NixOS/nixpkgs/commit/da4101374f22830635f73512389dcd622f525218) | `` libsoup_3: 3.4.3 → 3.4.4 ``                                              |
| [`23ddb9d8`](https://github.com/NixOS/nixpkgs/commit/23ddb9d87c174b778b60a038440e86c7dd339c19) | `` sysprof: 45.0 → 45.1 ``                                                  |
| [`ba088b55`](https://github.com/NixOS/nixpkgs/commit/ba088b55506c76d4b27d3b243c1058f54982f315) | `` gupnp_1_6: 1.6.5 → 1.6.6 ``                                              |
| [`1c20577e`](https://github.com/NixOS/nixpkgs/commit/1c20577e3d90aa068845862a8f495579a4e7f95e) | `` gssdp_1_6: 1.6.2 → 1.6.3 ``                                              |
| [`90f8ccf0`](https://github.com/NixOS/nixpkgs/commit/90f8ccf06ca03317fa156a43fc5db79fd529acfd) | `` gnumeric: 1.12.55 → 1.12.56 ``                                           |
| [`08a26773`](https://github.com/NixOS/nixpkgs/commit/08a2677387c8c3c25e57e8bb1c373064028f7d75) | `` goffice: 0.10.55 → 0.10.56 ``                                            |
| [`0f434de5`](https://github.com/NixOS/nixpkgs/commit/0f434de52c4198f7854980329c5df37b4c633468) | `` libgsf: 1.14.50 → 1.14.51 ``                                             |
| [`a5a41e0f`](https://github.com/NixOS/nixpkgs/commit/a5a41e0f547aff9666e05806ae8884b1e7c5a0a0) | `` shotwell: 0.32.2 → 0.32.3 ``                                             |
| [`6d646062`](https://github.com/NixOS/nixpkgs/commit/6d646062c8636178e03a4eeea8b75ab7110bcf0f) | `` xdg-desktop-portal-gtk: 1.14.1 → 1.15.1 ``                               |
| [`c6881320`](https://github.com/NixOS/nixpkgs/commit/c688132081fcf57434b8691dab10fe8210dd3ab9) | `` gnome.gucharmap: 15.0.4 → 15.1.2 ``                                      |
| [`f7f21f84`](https://github.com/NixOS/nixpkgs/commit/f7f21f844e9322ff735f1f51b51cdbfc6f1661a1) | `` unihan-database: 15.0.0 → 15.1.0 ``                                      |
| [`8509ff19`](https://github.com/NixOS/nixpkgs/commit/8509ff199c34085bec500db2c13af5598fc43b85) | `` unicode-character-database: 15.0.0 → 15.1.0 ``                           |
| [`bea8e13c`](https://github.com/NixOS/nixpkgs/commit/bea8e13cb0e2ffdd05e9dd57e606726da1af0637) | `` gnome.gnome-bluetooth: 42.6 → 42.7 ``                                    |
| [`7b0e23e6`](https://github.com/NixOS/nixpkgs/commit/7b0e23e6a6ff93658af0e70afcff17c6509f3d26) | `` gnome.aisleriot: 3.22.29 → 3.22.30 ``                                    |
| [`e11af6c7`](https://github.com/NixOS/nixpkgs/commit/e11af6c7563f9cb8b892d16d86e1474dd186c6c4) | `` gupnp-igd: freeze updates ``                                             |
| [`03c8301d`](https://github.com/NixOS/nixpkgs/commit/03c8301dc5a8a0d53fed06a9340d07045d6eb0a2) | `` ashpd-demo: 0.3.0 → 0.4.1 ``                                             |
| [`a1bf4b1b`](https://github.com/NixOS/nixpkgs/commit/a1bf4b1b608d6d1408e551584f611cda29c81b84) | `` nixos/rl-2311: Mention XDG Portal changes ``                             |
| [`e81eea42`](https://github.com/NixOS/nixpkgs/commit/e81eea4229562bc6cb314cf946f47504e7f9339e) | `` loupe: 45.0 → 45.1 ``                                                    |
| [`dd137904`](https://github.com/NixOS/nixpkgs/commit/dd137904abf9cc7dcec2884c40f04239f8076a2b) | `` glycin-loaders: 0.1.1 → 0.1.2 ``                                         |
| [`dd011a2e`](https://github.com/NixOS/nixpkgs/commit/dd011a2e79438be7ce9d157d57e46482acc68962) | `` evolution-data-server: Actually drop tentative settings constructor ``   |
| [`549c51d5`](https://github.com/NixOS/nixpkgs/commit/549c51d541b78e0ed87f7f12e75114b6fe3554bc) | `` gnome.ghex: 45.0 → 45.1 ``                                               |
| [`bc41b2db`](https://github.com/NixOS/nixpkgs/commit/bc41b2db3db188be72ab71919893b160d44c98d9) | `` makeHardcodeGsettingsPatch: Support applying patches ``                  |
| [`6f695f3d`](https://github.com/NixOS/nixpkgs/commit/6f695f3d92be6b9994d69f3de2eaffb9d6b94f92) | `` makeHardcodeGsettingsPatch: Improve docs ``                              |
| [`81283429`](https://github.com/NixOS/nixpkgs/commit/81283429b7a1aa3f5ed96700ac4401509aa3df31) | `` xdg-desktop-portal: 1.18.0 → 1.18.1 ``                                   |
| [`ecaba20e`](https://github.com/NixOS/nixpkgs/commit/ecaba20e6577d0f39a65837a2d8d2a9fd928edd5) | `` libcloudproviders: 0.3.4 → 0.3.5 ``                                      |
| [`fe4b52e6`](https://github.com/NixOS/nixpkgs/commit/fe4b52e60a080099209258bd4368d37d3d1cbb1b) | `` epiphany: 45.0 → 45.1 ``                                                 |
| [`e4271d0b`](https://github.com/NixOS/nixpkgs/commit/e4271d0b7290dcd8707023194426eb4933e4b97a) | `` tracker-miners: 3.6.1 → 3.6.2 ``                                         |
| [`4dc50d60`](https://github.com/NixOS/nixpkgs/commit/4dc50d60097745ed53e0bce9d683ecc75093ed7e) | `` libshumate: 1.1.1 → 1.1.2 ``                                             |
| [`dab6a33c`](https://github.com/NixOS/nixpkgs/commit/dab6a33c740f36c6077bd3230b398c40983dcc89) | `` gnome-text-editor: 45.0 → 45.1 ``                                        |
| [`ee2f32a4`](https://github.com/NixOS/nixpkgs/commit/ee2f32a4c81e16e121ccc1a4011723ea3696bb3a) | `` gnome.mutter: 45.0 → 45.1 ``                                             |
| [`464762c5`](https://github.com/NixOS/nixpkgs/commit/464762c58443e5862da38cc7ddef4205c2650839) | `` gnome.gnome-shell: 45.0 → 45.1 ``                                        |
| [`41c7211b`](https://github.com/NixOS/nixpkgs/commit/41c7211b5d95bf5557456a79a65b511017adf1c5) | `` gnome.gnome-shell-extensions: 45.0 → 45.1 ``                             |
| [`0a152330`](https://github.com/NixOS/nixpkgs/commit/0a15233070b11229acc247a2c44113cd78c4b2ed) | `` gnome.gnome-terminal: 3.50.0 → 3.50.1 ``                                 |
| [`e54cf978`](https://github.com/NixOS/nixpkgs/commit/e54cf97884c3d13d59076a3d31b7df4bd35a3d7a) | `` orca: 45.0 → 45.1 ``                                                     |
| [`0d3ae9f7`](https://github.com/NixOS/nixpkgs/commit/0d3ae9f7d546114ecabd6003100e4b260d5ce9cf) | `` gtranslator: 45.2 → 45.3 ``                                              |
| [`6eede279`](https://github.com/NixOS/nixpkgs/commit/6eede2794c24edc429eb8294a4ab898dbd96d71a) | `` gvfs: 1.52.0 → 1.52.1 ``                                                 |
| [`f723d2ab`](https://github.com/NixOS/nixpkgs/commit/f723d2ab0f4a27fda8944ffd4b71dd167cbdfb90) | `` gnome.eog: 45.0 → 45.1 ``                                                |
| [`ba4a077f`](https://github.com/NixOS/nixpkgs/commit/ba4a077f55f07f53ec5897a627d1437e79b65c26) | `` gnome.accerciser: 3.40.0 → 3.42.0 ``                                     |
| [`f1c90591`](https://github.com/NixOS/nixpkgs/commit/f1c90591fa0c5e54e5b156fa58317d2590414824) | `` vte: 0.74.0 → 0.74.1 ``                                                  |
| [`a7f6f982`](https://github.com/NixOS/nixpkgs/commit/a7f6f98246c90fe043dbe138baf77795bec050b0) | `` libshumate: 1.1.0 → 1.1.1 ``                                             |
| [`554fcd56`](https://github.com/NixOS/nixpkgs/commit/554fcd563d5bfad1a24c2bc00f3f4fc8b693fc82) | `` libdex: 0.4.0 → 0.4.1 ``                                                 |
| [`462d8cbc`](https://github.com/NixOS/nixpkgs/commit/462d8cbca2edf3365647a9e0becba16f8fb93685) | `` gnome-user-docs: 45.0 → 45.1 ``                                          |
| [`9f1e7964`](https://github.com/NixOS/nixpkgs/commit/9f1e7964878ed07ce29ae1051f8b1507394ae05c) | `` gnome.nautilus: 45.0 → 45.1 ``                                           |
| [`d5269b52`](https://github.com/NixOS/nixpkgs/commit/d5269b522a2675cc472e24464660039db177f9d0) | `` gnome.gnome-sudoku: 45.1 → 45.2 ``                                       |
| [`3c18a64e`](https://github.com/NixOS/nixpkgs/commit/3c18a64ea71d5d8259f53821eed7db77d3f89ac5) | `` gnome.gnome-software: 45.0 → 45.1 ``                                     |
| [`5ad73097`](https://github.com/NixOS/nixpkgs/commit/5ad73097dba8c88266f7afc2798241ee18e2a80e) | `` gnome.gnome-remote-desktop: 45.0 → 45.1 ``                               |
| [`f10a2b5a`](https://github.com/NixOS/nixpkgs/commit/f10a2b5a271a5556df9de7d841b46f0169c75111) | `` gnome.gnome-maps: 45.0 → 45.1 ``                                         |
| [`80028f1b`](https://github.com/NixOS/nixpkgs/commit/80028f1b31a671603f13de03d7394231f3a7bec9) | `` gnome.gnome-control-center: 45.0 → 45.1 ``                               |
| [`56cadcfb`](https://github.com/NixOS/nixpkgs/commit/56cadcfbc7d9093725b91213017a065421666ebd) | `` gnome.gnome-calendar: 45.0 → 45.1 ``                                     |
| [`a1473757`](https://github.com/NixOS/nixpkgs/commit/a1473757b8346eaf6c01c7ef864afdf3aed7d247) | `` evolution-ews: 3.50.0 → 3.50.1 ``                                        |
| [`461f8800`](https://github.com/NixOS/nixpkgs/commit/461f88000068b200f5b714e192e893bbfcbebf47) | `` evolution-data-server: 3.50.0 → 3.50.1 ``                                |
| [`634f8d80`](https://github.com/NixOS/nixpkgs/commit/634f8d80193303d3a9f1441df6b2ce42ea6c97d3) | `` evolution: 3.50.0 → 3.50.1 ``                                            |
| [`fc495aea`](https://github.com/NixOS/nixpkgs/commit/fc495aea1faba0c33055011ec6df963571717684) | `` gnomeExtensions: Update for GNOME 45 ``                                  |
| [`573f967c`](https://github.com/NixOS/nixpkgs/commit/573f967c39075f60b0ad78708b8f00f48d9bd62b) | `` gnomeExtension: Reformat extension.json ``                               |
| [`cec1751c`](https://github.com/NixOS/nixpkgs/commit/cec1751cbdf9ffc749fee0d198a189ca69f196da) | `` nixosTests.gnome-extensions: Init ``                                     |
| [`27be325d`](https://github.com/NixOS/nixpkgs/commit/27be325d3933b368f06c86201ef1d60f46ef4a14) | `` nixosTests.gnome: Small cleanup ``                                       |
| [`95ee935a`](https://github.com/NixOS/nixpkgs/commit/95ee935a64023322d945d3c2cfc0e42db60a8904) | `` gnome.gnome-sudoku: 45.0 → 45.1 ``                                       |
| [`7f040374`](https://github.com/NixOS/nixpkgs/commit/7f04037480e34c184b369934aa70999535bdb857) | `` gnome.ghex: 45.beta → 45.0 ``                                            |
| [`4b2f0057`](https://github.com/NixOS/nixpkgs/commit/4b2f005797bc3b76248aff9e599ee975c837cb42) | `` gtranslator: 45.1 → 45.2 ``                                              |
| [`6c4b1f0d`](https://github.com/NixOS/nixpkgs/commit/6c4b1f0d512f1798f177546efbdc0619a9b74e1f) | `` gnome.gnome-remote-desktop: 45.rc → 45.0 ``                              |
| [`9f18ead6`](https://github.com/NixOS/nixpkgs/commit/9f18ead6cc3288ab606d13b3d24a958648cc45f5) | `` tracker-miners: 3.6.0 → 3.6.1 ``                                         |
| [`f8a0c712`](https://github.com/NixOS/nixpkgs/commit/f8a0c712cc244d0273f7d2d4d8e8221a0cfc37cf) | `` libsigcxx30: 3.4.0 → 3.6.0 ``                                            |
| [`9a44fb8a`](https://github.com/NixOS/nixpkgs/commit/9a44fb8a040f7b7fde4c883ff2690559e250e772) | `` libsigcxx: 2.10.8 → 2.12.1 ``                                            |
| [`6d4d42f6`](https://github.com/NixOS/nixpkgs/commit/6d4d42f6ee6220bcc4bc87707da8abdbe140808e) | `` gtk4: 4.12.2 → 4.12.3 ``                                                 |
| [`e84395a6`](https://github.com/NixOS/nixpkgs/commit/e84395a61444244e6ddf18559ca14f82d0dc7c8c) | `` cairomm: 1.14.4 → 1.14.5 ``                                              |
| [`c0b2918c`](https://github.com/NixOS/nixpkgs/commit/c0b2918c4b8462d316773e852fd7dfaefafd6223) | `` cairomm_1_16: 1.16.2 → 1.18.0 ``                                         |
| [`fac853bb`](https://github.com/NixOS/nixpkgs/commit/fac853bb80dfb7b50e34d821a7ccb194abdd5000) | `` gnote: 45.rc → 45.0 ``                                                   |
| [`937a7bac`](https://github.com/NixOS/nixpkgs/commit/937a7bac8cdc2057b2a8fc77636f217856e1b5b5) | `` foliate: Force WebkitGtk 4.1 ABI ``                                      |
| [`80ead5df`](https://github.com/NixOS/nixpkgs/commit/80ead5dfaf7e767ee55dc11da5ca517b298c707f) | `` librsvg: 2.56.93 → 2.57.0 ``                                             |
| [`5333b5ff`](https://github.com/NixOS/nixpkgs/commit/5333b5ffad015fa1adc98302d394ae1340088056) | `` gtk4: 4.12.1 → 4.12.2 ``                                                 |
| [`741df7dc`](https://github.com/NixOS/nixpkgs/commit/741df7dc59883b0d63ce7f6e4ae6ee6b85156890) | `` tracker-miners: 3.6.rc → 3.6.0 ``                                        |
| [`93956822`](https://github.com/NixOS/nixpkgs/commit/939568224738de2412128b30ea5a8170e9c57e89) | `` tracker: 3.6.beta → 3.6.0 ``                                             |
| [`211250ed`](https://github.com/NixOS/nixpkgs/commit/211250edb44225a6a232dcdd7a995355d19fd0af) | `` sysprof: 45.rc → 45.0 ``                                                 |
| [`5ad03b9b`](https://github.com/NixOS/nixpkgs/commit/5ad03b9bec6566c0658fd9ab5d8f323454e5e023) | `` python3.pkgs.pygobject3: 3.44.1 → 3.46.0 ``                              |
| [`c12caaee`](https://github.com/NixOS/nixpkgs/commit/c12caaee56cdbd467296a3a288ad09f9b91fbf65) | `` libsoup_3: 3.4.2 → 3.4.3 ``                                              |
| [`2a9ff7aa`](https://github.com/NixOS/nixpkgs/commit/2a9ff7aaf6bf39627162cf20571c65c65f2c06b6) | `` libsecret: 0.21.0 → 0.21.1 ``                                            |
| [`bdd0d54a`](https://github.com/NixOS/nixpkgs/commit/bdd0d54a0886904928353df7704b4d4a72cbf10a) | `` json-glib: 1.6.6 → 1.8.0 ``                                              |
| [`8de2a665`](https://github.com/NixOS/nixpkgs/commit/8de2a6658d4bb9ccea31006ae478900ee0e5c525) | `` gobject-introspection: 1.76.1 → 1.78.1 ``                                |
| [`9b1e2d43`](https://github.com/NixOS/nixpkgs/commit/9b1e2d439f6cc25df7510d3aef58cd4d2bfa68e0) | `` gsettings-desktop-schemas: 45.alpha → 45.0 ``                            |
| [`422b36dc`](https://github.com/NixOS/nixpkgs/commit/422b36dc0f5c1aa6f7ac15552eb6065ef945f0af) | `` gnome-console: 45.beta → 45.0 ``                                         |
| [`cf3dfb57`](https://github.com/NixOS/nixpkgs/commit/cf3dfb57b35c9bb3988816fc780bc23ca80d11f3) | `` glibmm_2_68: 2.77.0 → 2.78.0 ``                                          |
| [`ecbb5bb0`](https://github.com/NixOS/nixpkgs/commit/ecbb5bb00c757055a30bb088e15794d41e503792) | `` gnome.adwaita-icon-theme: 45.rc → 45.0 ``                                |
| [`3e4ca2e5`](https://github.com/NixOS/nixpkgs/commit/3e4ca2e5cbfd4c015fa63be849fe7079ed85a378) | `` glib: 2.77.3 → 2.78.0 ``                                                 |
| [`56f2696a`](https://github.com/NixOS/nixpkgs/commit/56f2696aecfcbf203887fc16bc5fa0f85473a8d6) | `` glib-networking: 2.76.1 → 2.78.0 ``                                      |
| [`44d10a3e`](https://github.com/NixOS/nixpkgs/commit/44d10a3e5d95d0d72dadf77f779acdb032f86fbf) | `` gjs: 1.77.90 → 1.78.0 ``                                                 |
| [`f6073183`](https://github.com/NixOS/nixpkgs/commit/f6073183d5cf854ec607459028a45995bda79df0) | `` at-spi2-core: 2.49.91 → 2.50.0 ``                                        |
| [`5537cbb1`](https://github.com/NixOS/nixpkgs/commit/5537cbb16512b1bef13efbf6cbcc9255d31bb9af) | `` xdg-desktop-portal: 1.17.2 → 1.18.0 ``                                   |
| [`503d5427`](https://github.com/NixOS/nixpkgs/commit/503d5427b29192825b857e8acd9c0b623621e544) | `` gnome-usage: 3.38.1 → 45.0 ``                                            |
| [`25a6b019`](https://github.com/NixOS/nixpkgs/commit/25a6b0196966beec22f21fcf58def7cf7101b5e0) | `` gnote: 45.alpha → 45.rc ``                                               |
| [`9044e661`](https://github.com/NixOS/nixpkgs/commit/9044e66197fe50c3995617aa93c8946bb170814a) | `` gnome.metacity: 3.49.1 → 3.50.0 ``                                       |
| [`626bdb94`](https://github.com/NixOS/nixpkgs/commit/626bdb9460cda1020bd8b29d832ada264d993583) | `` gnome.gnome-applets: 3.49.1 → 3.50.0 ``                                  |
| [`c95c875f`](https://github.com/NixOS/nixpkgs/commit/c95c875fd6c71b77d32df8ebcdc6b093699ab1a5) | `` gnome.gnome-tweaks: 42.beta → 45.0 ``                                    |
| [`704246e3`](https://github.com/NixOS/nixpkgs/commit/704246e3231d646fbdf4e3f30790d19d57e080d6) | `` gnome.gnome-panel: 3.49.1 → 3.50.0 ``                                    |
| [`c5d1f64a`](https://github.com/NixOS/nixpkgs/commit/c5d1f64a0d1fc2db6cfcdd02bf1564f1e4f96398) | `` gnome.gnome-flashback: 3.49.1 → 3.50.0 ``                                |
| [`30271ad0`](https://github.com/NixOS/nixpkgs/commit/30271ad0a0eb6ec2033207a4255c7a2e623b528a) | `` glycin-loaders: 0.1.0 → 0.1.1 ``                                         |
| [`23e48340`](https://github.com/NixOS/nixpkgs/commit/23e483408fee00479496927fa4069879667a6ca0) | `` nixos/rl-2311: Mention GNOME 45 ``                                       |
| [`3545d01c`](https://github.com/NixOS/nixpkgs/commit/3545d01c5aace81921c75520445ab424f862ac94) | `` gnome.gnome-terminal: 3.48.2 → 3.50.0 ``                                 |