### PR TITLE
chore(flake/stylix): `a15c3196` -> `dbeef75e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -618,11 +618,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700302760,
-        "narHash": "sha256-JpOJf9Nj260rTrVuYonP9CiGzj+43AGPOfhF72XkQvU=",
+        "lastModified": 1700920882,
+        "narHash": "sha256-51lnAxt8w2G6UTzJlJ0PfXyKnDkJb2yMRm70r7MMOrw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a15c3196c1d620c18cbee8229092598384a89fef",
+        "rev": "dbeef75ed5d5403b18be3418751d0f3bbca017c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                        |
| --------------------------------------------------------------------------------------------- | ------------------------------ |
| [`dbeef75e`](https://github.com/danth/stylix/commit/dbeef75ed5d5403b18be3418751d0f3bbca017c2) | `` Support GNOME 45 :alien: `` |