### PR TITLE
chore(flake/pre-commit-hooks): `e558068c` -> `e5ee5c5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -537,11 +537,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1700064067,
-        "narHash": "sha256-1ZWNDzhu8UlVCK7+DUN9dVQfiHX1bv6OQP9VxstY/gs=",
+        "lastModified": 1700922917,
+        "narHash": "sha256-ej2fch/T584b5K9sk1UhmZF7W6wEfDHuoUYpFN8dtvM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e558068cba67b23b4fbc5537173dbb43748a17e8",
+        "rev": "e5ee5c5f3844550c01d2131096c7271cec5e9b78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                 |
| ------------------------------------------------------------------------------------------------------------ | ----------------------- |
| [`0067c7ce`](https://github.com/cachix/pre-commit-hooks.nix/commit/0067c7ce77ef4e8d671237f938c48716f9810df8) | `` Add golangci-lint `` |