### PR TITLE
chore(flake/nix-index-database): `d189d05f` -> `bd3aec0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -444,11 +444,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700967448,
-        "narHash": "sha256-sWVi7Nm/fuTgwN8R7Tt3GM3vBP3r6M1/lhX0+LK3p7E=",
+        "lastModified": 1700968077,
+        "narHash": "sha256-Lax+2g7G3Fe+ckMrHLYTl+97unbmNDmN1qS9MLBkxr4=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "d189d05f9de237d3b554c91029f9cb78efec8ace",
+        "rev": "bd3aec0ecb0fdde863a7ed2c6caa220c47e22c07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`bd3aec0e`](https://github.com/nix-community/nix-index-database/commit/bd3aec0ecb0fdde863a7ed2c6caa220c47e22c07) | `` update packages.nix to release 2023-11-26-030655 `` |