### PR TITLE
chore(flake/agenix): `daf42cb3` -> `13ac9ac6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696775529,
-        "narHash": "sha256-TYlE4B0ktPtlJJF9IFxTWrEeq+XKG8Ny0gc2FGEAdj0=",
+        "lastModified": 1701216516,
+        "narHash": "sha256-jKSeJn+7hZ1dZdiH1L+NWUGT2i/BGomKAJ54B9kT06Q=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "daf42cb35b2dc614d1551e37f96406e4c4a2d3e4",
+        "rev": "13ac9ac6d68b9a0896e3d43a082947233189e247",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                       |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`4c486060`](https://github.com/ryantm/agenix/commit/4c4860609491a98c1e4a6f03e0ba27c0a23982c0) | `` only backup cleartext file if it exists `` |