### PR TITLE
chore(flake/nixpkgs): `8cfef698` -> `e92039b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -474,11 +474,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701068326,
-        "narHash": "sha256-vmMceA+q6hG1yrjb+MP8T0YFDQIrW3bl45e7z24IEts=",
+        "lastModified": 1701253981,
+        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8cfef6986adfb599ba379ae53c9f5631ecd2fd9c",
+        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`41becba8`](https://github.com/NixOS/nixpkgs/commit/41becba8d22548cc15d7eabd8eb8737740fd3f54) | `` sysdig: 0.33.1 -> 0.34.1 ``                                                    |
| [`6007641a`](https://github.com/NixOS/nixpkgs/commit/6007641aff774f573a421d726a1cb2d38dd4903d) | `` dune_3: 3.11.1 -> 3.12.0 ``                                                    |
| [`edfc8aca`](https://github.com/NixOS/nixpkgs/commit/edfc8acaaf859b5101dad724b953cd84615379bb) | `` prefer-remote-fetch: add more fetchers which prefer local builds ``            |
| [`4177297b`](https://github.com/NixOS/nixpkgs/commit/4177297b141a3a8a8985dcb7dfb53550b95d3e8f) | `` ci: pin third party actions ``                                                 |
| [`621d7736`](https://github.com/NixOS/nixpkgs/commit/621d7736ae8200951063e0dba97cde59a26a4b6d) | `` azure-cli: 2.53.1 -> 2.54.0 ``                                                 |
| [`c687a129`](https://github.com/NixOS/nixpkgs/commit/c687a1297f731bfabfbf97dd45f33b9a4588fdf0) | `` kea: 2.4.0 -> 2.4.1 ``                                                         |
| [`9ad22d35`](https://github.com/NixOS/nixpkgs/commit/9ad22d35b67cf3bb03ffd56e96f38bcdbb9163a0) | `` Revert "nixos/switch-to-configuration: remove explicit tmpfiles invocation" `` |
| [`76c5738e`](https://github.com/NixOS/nixpkgs/commit/76c5738ef231b19072cd7b1c0fa6d65cb61b1208) | `` coqPackages.mathcomp-word: 2.1 → {2.2, 3.0} ``                                 |
| [`d6d41d40`](https://github.com/NixOS/nixpkgs/commit/d6d41d403c9821f863914a7903d778ca6264c84f) | `` readline63: fix clang build ``                                                 |
| [`c4ffc839`](https://github.com/NixOS/nixpkgs/commit/c4ffc83975e38459202145f18528aa602744775f) | `` ocamlPackages.bap: use LLVM 14 ``                                              |
| [`419a57cc`](https://github.com/NixOS/nixpkgs/commit/419a57cc60fd609991fce5faad7ccbe4c5517c1b) | `` gifski: fix version ``                                                         |
| [`6ed8feee`](https://github.com/NixOS/nixpkgs/commit/6ed8feeec15696a8e2350efe4a387f96e98da623) | `` hcloud: 1.38.3 -> 1.40.0 ``                                                    |
| [`369650ef`](https://github.com/NixOS/nixpkgs/commit/369650ef388e4a6488b1783dc747cab7559a90d4) | `` poco: fix static build ``                                                      |
| [`d341b7d9`](https://github.com/NixOS/nixpkgs/commit/d341b7d95cc9d571e2547850689682373b68603d) | `` gifski: 1.13.0 -> 1.31.1 ``                                                    |
| [`65a8ceb0`](https://github.com/NixOS/nixpkgs/commit/65a8ceb0a9fbef117c24b9c90fec3c3684d4e83d) | `` cargo-modules: 0.11.0 -> 0.11.2 ``                                             |
| [`c2abe3fd`](https://github.com/NixOS/nixpkgs/commit/c2abe3fd8087aa2ea97442d09e513887c39a819a) | `` cargo-show-asm: 0.2.22 -> 0.2.23 ``                                            |
| [`67456fd6`](https://github.com/NixOS/nixpkgs/commit/67456fd6ca7b7511e2ce07e820df89d3a7d054c4) | `` oxlint: 0.0.17 -> 0.0.18 ``                                                    |
| [`9c933f9d`](https://github.com/NixOS/nixpkgs/commit/9c933f9d855e443a7f46fcc09bbf777ebcb11579) | `` cargo-zigbuild: 0.17.5 -> 0.18.0 ``                                            |
| [`fa3cd52b`](https://github.com/NixOS/nixpkgs/commit/fa3cd52b3e4ef8ae07e4a01f1c2f2acb5fa32756) | `` drogon: 1.9.0 -> 1.9.1 ``                                                      |
| [`53850d6d`](https://github.com/NixOS/nixpkgs/commit/53850d6d440df52d16f6bc13ba8e9c487f910ba8) | `` cargo-shuttle: 0.33.0 -> 0.34.1 ``                                             |
| [`10ee18ca`](https://github.com/NixOS/nixpkgs/commit/10ee18ca9265cada45acfc7a6d7644cd22b82465) | `` certbot: 2.6.0 -> 2.7.4 (#267710) ``                                           |
| [`6923231a`](https://github.com/NixOS/nixpkgs/commit/6923231af9ab0ccdc07e78502816d1b0920f0b3d) | `` uuu: fix updateScript to pass specific version-regexp ``                       |
| [`b5514083`](https://github.com/NixOS/nixpkgs/commit/b5514083094a1f532fc654edb1190ad6cf81f587) | `` qovery-cli: 0.74.3 -> 0.74.4 ``                                                |
| [`d2977cb3`](https://github.com/NixOS/nixpkgs/commit/d2977cb3720ca01da1be744f3b3cb52dd0ab4034) | `` naabu: 2.1.9 -> 2.2.0 ``                                                       |
| [`09e9a8af`](https://github.com/NixOS/nixpkgs/commit/09e9a8afab2d081b2dfac5694a03029a5042364c) | `` python310Packages.oelint-parser: 2.11.4 -> 2.11.6 ``                           |
| [`684c68ea`](https://github.com/NixOS/nixpkgs/commit/684c68ead644b314d88d46c2c93506d551975fbe) | `` oelint-adv: 3.26.2 -> 3.26.4 ``                                                |
| [`b534bb47`](https://github.com/NixOS/nixpkgs/commit/b534bb4752e8c6a47ad0cfac1b5b31ee36b786e6) | `` ggshield: 1.22.0 -> 1.22.0 ``                                                  |
| [`e8ef76b3`](https://github.com/NixOS/nixpkgs/commit/e8ef76b37dfd11053eab2aa67cdd0bf7c507a8e7) | `` ldeep: 1.0.48 -> 1.0.49 ``                                                     |
| [`549d9cd5`](https://github.com/NixOS/nixpkgs/commit/549d9cd59d0a4744d8d2a53c69d02ddc9c9c8db4) | `` gotestwaf: 0.4.7 -> 0.4.8 ``                                                   |
| [`21672ccd`](https://github.com/NixOS/nixpkgs/commit/21672ccd691ebd2f18fa6b41446389c069adfdbb) | `` firefox-devedition-unwrapped: 121.0b3 -> 121.0b4 ``                            |
| [`2438f55f`](https://github.com/NixOS/nixpkgs/commit/2438f55f0989f1be60b292ef82fa1568b1b8967b) | `` firefox-beta-unwrapped: 121.0b3 -> 121.0b4 ``                                  |
| [`395c3204`](https://github.com/NixOS/nixpkgs/commit/395c32048e786ea4ff756ea6fd46cdb28b85c19a) | `` firefox: Adds patch for systems without a default page size (#270722) ``       |
| [`b5869682`](https://github.com/NixOS/nixpkgs/commit/b5869682246c587aa19ab0c9f4141217f7940f98) | `` nix-direnv: 2.4.0 -> 2.5.1 ``                                                  |
| [`7071bf24`](https://github.com/NixOS/nixpkgs/commit/7071bf24d415cf025c42eb6b60ff04d880905001) | `` mus: change upstream src; migrate to by-name ``                                |
| [`2a3d97bc`](https://github.com/NixOS/nixpkgs/commit/2a3d97bcb08324c14a06c0861e05673a16690015) | `` maintainers: sfr -> nbsp ``                                                    |
| [`bb05714d`](https://github.com/NixOS/nixpkgs/commit/bb05714df4e46528c1c72877e9f3529e5ae74b70) | `` maintainers: add brokenpip3 ``                                                 |
| [`8c747e39`](https://github.com/NixOS/nixpkgs/commit/8c747e39cc16dfaf9398b8e0ba825c757160ece7) | `` bats: use finalAttrs pattern ``                                                |
| [`d8743211`](https://github.com/NixOS/nixpkgs/commit/d87432110d39d3741b099f229c8ce38eed7026bc) | `` bats.libraries.bats-detik: init at 1.2.1 ``                                    |
| [`ce95d592`](https://github.com/NixOS/nixpkgs/commit/ce95d5928143ac7b957ea1dd8b43fb31aae109fe) | `` cloudlog: 2.5.1 -> 2.5.2 ``                                                    |
| [`e0311009`](https://github.com/NixOS/nixpkgs/commit/e03110096545ccd2504654d6d93242bb50893b25) | `` python311Packages.pubnub: 7.3.1 -> 7.3.2 ``                                    |
| [`22fc2c38`](https://github.com/NixOS/nixpkgs/commit/22fc2c38e2cdc424d8b4cc8be96cf0a2495b5454) | `` python311Packages.devpi-common: 4.0.2 -> 4.0.3 ``                              |
| [`7ff19330`](https://github.com/NixOS/nixpkgs/commit/7ff193305b852074d1ce1278e3bc008419c491be) | `` treewide: remove henrytill as maintainer from various pkgs ``                  |
| [`60bd6ad8`](https://github.com/NixOS/nixpkgs/commit/60bd6ad87f351fe9305f9c5420f71caee34148c5) | `` ipinfo: 3.1.2 -> 3.2.0 ``                                                      |
| [`30ebb761`](https://github.com/NixOS/nixpkgs/commit/30ebb76154f89d9d4383c2f8001ff313d00eadba) | `` python-bugzilla: update from version 2.3.0 to 3.2.0 ``                         |
| [`207d3c40`](https://github.com/NixOS/nixpkgs/commit/207d3c40815c0f51b6b367955532ac561aa2e39a) | `` playwright: 1.38.0 -> 1.40.0 ``                                                |
| [`d4021bfb`](https://github.com/NixOS/nixpkgs/commit/d4021bfb65f3f05feb4bf4807541e38c09beea51) | `` terragrunt: 0.53.6 -> 0.53.8 ``                                                |
| [`29175e61`](https://github.com/NixOS/nixpkgs/commit/29175e613e20bea94ffba87a310fd5ecfa492980) | `` cargo-tarpaulin: 0.27.1 -> 0.27.2 ``                                           |
| [`0864e05d`](https://github.com/NixOS/nixpkgs/commit/0864e05d727dc04acd6b3ba2aed89a4a607df3c8) | `` .github/CODEOWNERS: Add roberth to module system ``                            |
| [`9e445876`](https://github.com/NixOS/nixpkgs/commit/9e4458763fb51df6040a02c515a43a4e3cc3bf77) | `` python311Packages.altair: 5.1.2 -> 5.2.0 ``                                    |
| [`f9abf151`](https://github.com/NixOS/nixpkgs/commit/f9abf151855f04e2f35bf9c22f307f7e788d2ac7) | `` dnf5: tag was moved, fix hash ``                                               |
| [`1e1bd362`](https://github.com/NixOS/nixpkgs/commit/1e1bd362e50cd3d8729a170b084340701bcdd550) | `` timg: 1.5.2 -> 1.5.3 ``                                                        |
| [`acab2ad0`](https://github.com/NixOS/nixpkgs/commit/acab2ad0e77f1b9e27cd3217e69a004959487353) | `` release-notes: mention Nim changes ``                                          |
| [`1753744b`](https://github.com/NixOS/nixpkgs/commit/1753744b35ade75f329bd487d4397c7cb69e8f71) | `` nim_lk: wrap with nix-prefetch, nix-prefetch-git ``                            |
| [`8effb983`](https://github.com/NixOS/nixpkgs/commit/8effb98377496b3d17d34136cc494428d32b8a2e) | `` nim: 1.6.14 -> 2.0.0 ``                                                        |
| [`8672b5ca`](https://github.com/NixOS/nixpkgs/commit/8672b5cabdc10359cc6e9bc2c04fd281618ae2c5) | `` Remove nimPackages and nim2Packages ``                                         |
| [`7bd3fa9f`](https://github.com/NixOS/nixpkgs/commit/7bd3fa9faf6581a6167c63f721db0112245a0872) | `` emocli: use top-level buildNimPackage ``                                       |
| [`5dd13314`](https://github.com/NixOS/nixpkgs/commit/5dd133142ff17e74594eb6369b983e1c47bd540e) | `` snekim: build with lockfile ``                                                 |
| [`6240432c`](https://github.com/NixOS/nixpkgs/commit/6240432c4490fe941f65947930056dd4e011300b) | `` nimlsp: build with lockfile ``                                                 |
| [`862b9061`](https://github.com/NixOS/nixpkgs/commit/862b90618926848cc04b4d0061f0a45f1a237592) | `` nimmm: build with lockfile ``                                                  |
| [`607c5fdb`](https://github.com/NixOS/nixpkgs/commit/607c5fdb0433d316f24b756cbad7afca94d05b8f) | `` nim-atlas: migrate from nimPackages.atlas ``                                   |
| [`6f8f9a92`](https://github.com/NixOS/nixpkgs/commit/6f8f9a9254d9942d2e6b606ba6e2b506cefdda27) | `` nimble: migrate from nimPackages ``                                            |
| [`53c5ce37`](https://github.com/NixOS/nixpkgs/commit/53c5ce37bd39270f98bed6a9a8b87f869f521484) | `` base45: migrate from nimPackages ``                                            |
| [`3d5455ac`](https://github.com/NixOS/nixpkgs/commit/3d5455ac3b609bbdca913a523a94a327a00936f3) | `` eriscmd: migrate from nimPackages.eris ``                                      |
| [`6df86cc6`](https://github.com/NixOS/nixpkgs/commit/6df86cc655a99e9db0569b53054b20404b4eacba) | `` c2nim: move out of nimPackages ``                                              |
| [`0f2dc695`](https://github.com/NixOS/nixpkgs/commit/0f2dc695198d4bdaaecf1b29d878a390b7eb3646) | `` nrpl: use new buildNimPackage ``                                               |
| [`146947ca`](https://github.com/NixOS/nixpkgs/commit/146947ca3b1d703eac5f93803d442f25a8567820) | `` promexplorer: build with lockfile ``                                           |
| [`29b30270`](https://github.com/NixOS/nixpkgs/commit/29b302705b282bedde66f1fe7f199e4a46be842f) | `` swaycwd: use new buildNimPackage ``                                            |
| [`48840e17`](https://github.com/NixOS/nixpkgs/commit/48840e17625420eb9ab9a165a368379e600b3714) | `` nitch: use new buildNimPackage ``                                              |
| [`a7758d7d`](https://github.com/NixOS/nixpkgs/commit/a7758d7dd8222ae1e0187b41aa38b412d446d6dc) | `` tridactyl-native: build with lockfile ``                                       |
| [`dce1f58e`](https://github.com/NixOS/nixpkgs/commit/dce1f58e63342945dfedaf1fb1752ef422caad13) | `` nimdow: build with lockfile ``                                                 |
| [`0f089515`](https://github.com/NixOS/nixpkgs/commit/0f089515b15af25212c404ced278fa3e8e178270) | `` mosdepth: build with a lockfile ``                                             |
| [`cab3fd4d`](https://github.com/NixOS/nixpkgs/commit/cab3fd4d50a05becce0e4df3779c8d1b3e23586f) | `` nitter: build with buildNimPackage ``                                          |
| [`ee21b616`](https://github.com/NixOS/nixpkgs/commit/ee21b61658dd195be61e93b0937ad65d6e41fb6a) | `` ttop: build with lockfile ``                                                   |
| [`35f108c7`](https://github.com/NixOS/nixpkgs/commit/35f108c7d7742fc9119a03783f40dd44cf7f6251) | `` buildNimPackage: load lockfiles and overrides ``                               |
| [`39d4eace`](https://github.com/NixOS/nixpkgs/commit/39d4eace911f9e838df023ad80f52132380e01c2) | `` nimPackages.buildNimPackage: move to top-level ``                              |
| [`89153ceb`](https://github.com/NixOS/nixpkgs/commit/89153ceb44198bba7b6fc74451a7dbf38d0193dd) | `` nimPackages.nim_builder: move out to pkgs/by-name ``                           |
| [`9e00db7b`](https://github.com/NixOS/nixpkgs/commit/9e00db7b79b2deadab0dd056f117b339b9e19b63) | `` nim: invert nim1 to be a definition of nim2 ``                                 |
| [`9c24e11f`](https://github.com/NixOS/nixpkgs/commit/9c24e11f3a9c2eed56792e6288b7feabce265fe1) | `` nvidiaPackages.(settings|persistened): add fallback cdn ``                     |
| [`c953c85b`](https://github.com/NixOS/nixpkgs/commit/c953c85b9ebdd2773f95180254ec9429cb1426f8) | `` nix-unit: init at 2.18.0 ``                                                    |
| [`d97d2fb2`](https://github.com/NixOS/nixpkgs/commit/d97d2fb271e4d9d0f86cf704c6d9fb3aa851d80d) | `` nixos/clamav: ensure freshclam starts before clamav (if enabled) ``            |
| [`7afbfd38`](https://github.com/NixOS/nixpkgs/commit/7afbfd384d51cbb01230bc3ae3b2b88ee4713d44) | `` fbvnc: cleanup, fix cross compilation ``                                       |
| [`3281455a`](https://github.com/NixOS/nixpkgs/commit/3281455a2613ceb321e97e6560312b72214214ed) | `` nvidiaPackages: format generic.nix ``                                          |
| [`3b1db407`](https://github.com/NixOS/nixpkgs/commit/3b1db4070e930ae4e8110a39dfb5961a7e5c9616) | `` python311Packages.aiolifx-themes: 0.4.10 -> 0.4.11 ``                          |
| [`2270f822`](https://github.com/NixOS/nixpkgs/commit/2270f82205ff48c1faef5ee26a2bca5f0c5930ee) | `` python311Packages.ha-mqtt-discoverable: 0.12.0 -> 0.13.0 ``                    |
| [`e9d43e61`](https://github.com/NixOS/nixpkgs/commit/e9d43e61bf3d1de31fdcccb8fd3cf74819282399) | `` exploitdb: 2023-11-25 -> 2023-11-28 ``                                         |
| [`d65bcd72`](https://github.com/NixOS/nixpkgs/commit/d65bcd72f5d512b8412ca5aa861dc2dbe489b5b3) | `` python311Packages.evohome-async: 0.4.9 -> 0.4.11 ``                            |
| [`e3c83148`](https://github.com/NixOS/nixpkgs/commit/e3c831487b871207aeeddb74618f6907eb5394af) | `` checkov: 3.1.15 -> 3.1.18 ``                                                   |
| [`352d3a3a`](https://github.com/NixOS/nixpkgs/commit/352d3a3ad9345a0d9864c3923904b81a0e1f4ef7) | `` maubot: switch to ensureNewerSourcesForZipFilesHook ``                         |
| [`00070cf8`](https://github.com/NixOS/nixpkgs/commit/00070cf866af5945cefdb59803005de8a47abaf2) | `` nixos/maubot: init ``                                                          |