### PR TITLE
chore(flake/home-manager): `ef908825` -> `4a8545f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701369906,
-        "narHash": "sha256-WwICfQ661I2hL2m9s449PjCR74d+9JtrhQeBoIaQ8/Q=",
+        "lastModified": 1701433070,
+        "narHash": "sha256-Gf9JStfENaUQ7YWFz3V7x/srIwr4nlnVteqaAxtwpgM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ef9088253c120d9b4dc26c5e41dd6c3c781ee9f0",
+        "rev": "4a8545f5e737a6338814a4676dc8e18c7f43fc57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`4a8545f5`](https://github.com/nix-community/home-manager/commit/4a8545f5e737a6338814a4676dc8e18c7f43fc57) | `` swayidle: add systemd suspend to example ``              |
| [`9e869829`](https://github.com/nix-community/home-manager/commit/9e869829c263d611e3ece814ff2b826463833238) | `` swayidle: daemonize swaylock in example configuration `` |