### PR TITLE
chore(flake/nixos-hardware): `8772491e` -> `a89745ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -459,11 +459,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1701250978,
-        "narHash": "sha256-ohu3cz4edjpGxs2qUTgbs0WrnewOX4crnUJNEB6Jox4=",
+        "lastModified": 1701598471,
+        "narHash": "sha256-kHdJ2qc4qKeMTzUIHEcP41ah/dBIhCgvWgrjllt2G78=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "8772491ed75f150f02552c60694e1beff9f46013",
+        "rev": "a89745edd5f657e2e5be5ed1bea86725ca78d92e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`a89745ed`](https://github.com/NixOS/nixos-hardware/commit/a89745edd5f657e2e5be5ed1bea86725ca78d92e) | `` surface: Allow specifying major versions for kernel `` |
| [`eb4e5743`](https://github.com/NixOS/nixos-hardware/commit/eb4e5743609d36c673a979850af2d90d5e3e26fa) | `` framework intel: Disable cros-usbpd-charger ``         |