### PR TITLE
chore(flake/nixpkgs): `e92039b5` -> `91050ea1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -474,11 +474,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701253981,
-        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
+        "lastModified": 1701436327,
+        "narHash": "sha256-tRHbnoNI8SIM5O5xuxOmtSLnswEByzmnQcGGyNRjxsE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
+        "rev": "91050ea1e57e50388fa87a3302ba12d188ef723a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`ca9b6bc0`](https://github.com/NixOS/nixpkgs/commit/ca9b6bc0a755702153910fd8fe7228517957de5d) | `` nixVersions.nix_2_19: 2.19.1 -> 2.19.2 ``                                   |
| [`709a9f6f`](https://github.com/NixOS/nixpkgs/commit/709a9f6f065569451cd2ffd904cf2ffba7454529) | `` nixVersions.unstable: 2.18 -> 2.19 ``                                       |
| [`3773ebf4`](https://github.com/NixOS/nixpkgs/commit/3773ebf41aecaa303cd21da71a121530ac146528) | `` nixVersions.nix_2_19: init at 2.19.1 ``                                     |
| [`0da4150a`](https://github.com/NixOS/nixpkgs/commit/0da4150a0d5918a045120bb070cd521acfaea54f) | `` rancid: init at 3.13 ``                                                     |
| [`3fde91cc`](https://github.com/NixOS/nixpkgs/commit/3fde91cc1311dd0e74226ca67aa32c15276cf622) | `` sway-assign-cgroups: init at 0.4.0 (#268949) ``                             |
| [`75701e0b`](https://github.com/NixOS/nixpkgs/commit/75701e0b2f8dd1d7f900ce313cf38e0416a3edbe) | `` openocd-rp2040: override openocd package instead ``                         |
| [`6d39261d`](https://github.com/NixOS/nixpkgs/commit/6d39261dc25406cd529d23ebf178ec98d7e67b5e) | `` mattermost: 8.1.4 -> 8.1.7 (#269691) ``                                     |
| [`8fe28ecb`](https://github.com/NixOS/nixpkgs/commit/8fe28ecb250fcd75ff53ebd46a04f4ca952896f0) | `` preserves-tools: init at 4.992.2 ``                                         |
| [`e1c0473d`](https://github.com/NixOS/nixpkgs/commit/e1c0473dc494e1ddc5760f74d6eb6170cdb22ed2) | `` nixos/oddjobd: add SohamG as maintainer ``                                  |
| [`d30f0a66`](https://github.com/NixOS/nixpkgs/commit/d30f0a66eb74cda30893592fd41e2ad935814c69) | `` deepin.deepin-gtk-theme: unstable-2022-07-26 -> 23.11.23 ``                 |
| [`d45c30f1`](https://github.com/NixOS/nixpkgs/commit/d45c30f1c611395bd5a77c480ce015a0485b865b) | `` ocamlPackages.tls: 0.17.1 → 0.17.3 ``                                       |
| [`7bf3f335`](https://github.com/NixOS/nixpkgs/commit/7bf3f335a3885770758803ad99c4f102fe575961) | `` resholve: 0.9.0 -> 0.9.1 ``                                                 |
| [`d14a7881`](https://github.com/NixOS/nixpkgs/commit/d14a788127e6587425bc61ff7aa81560ec67a81f) | `` nixos/pulseaudio: set permission of pulse home directory ``                 |
| [`975e0ed9`](https://github.com/NixOS/nixpkgs/commit/975e0ed9851190ec430f4c6cee87105e65dab775) | `` spotdl: 4.2.1 -> 4.2.2 ``                                                   |
| [`3af3e96d`](https://github.com/NixOS/nixpkgs/commit/3af3e96de8788e91803f963ade54258f50141fdc) | `` libwacom: disable tests if isPower ``                                       |
| [`cdc13875`](https://github.com/NixOS/nixpkgs/commit/cdc1387527b9666188713e4c60e6c9fd891bb060) | `` maintainers: add ajwhouse ``                                                |
| [`5c2dd96d`](https://github.com/NixOS/nixpkgs/commit/5c2dd96da8dcb2c5604364dfa11774b184f01b35) | `` litterbox: init at 1.9 ``                                                   |
| [`a9b20703`](https://github.com/NixOS/nixpkgs/commit/a9b207033988bcac06b5c5d780668b3a96011b72) | `` moreutils: 0.67 -> 0.68 ``                                                  |
| [`9c0ec467`](https://github.com/NixOS/nixpkgs/commit/9c0ec46777db80451da1f8d88b37f3d73993711f) | `` python310Packages.drms: 0.6.4 -> 0.7.0 ``                                   |
| [`76b013db`](https://github.com/NixOS/nixpkgs/commit/76b013db0005475a04830075d3083a07429bbbef) | `` liberasurecode: remove -Werror ``                                           |
| [`f6d192e9`](https://github.com/NixOS/nixpkgs/commit/f6d192e9b4401b9f10278bf6f27687c903ad06ee) | `` onefetch: 2.18.1 -> 2.19.0 ``                                               |
| [`79fb03cb`](https://github.com/NixOS/nixpkgs/commit/79fb03cbd4fa32e062fd10499ec51f8b87a55b8a) | `` corrosion: 0.4.4 -> 0.4.5 ``                                                |
| [`d3b5271d`](https://github.com/NixOS/nixpkgs/commit/d3b5271dc92f97a35c77d2caaedb61e38095da58) | `` zfs_2_1: 2.1.13 -> 2.1.14 ``                                                |
| [`c3fa6659`](https://github.com/NixOS/nixpkgs/commit/c3fa6659dd6a01c32f9a0c8430e9a6d1c316e9dd) | `` zfsStable/zfsUnstable: 2.2.1 -> 2.2.2 ``                                    |
| [`2123ab85`](https://github.com/NixOS/nixpkgs/commit/2123ab85ed9a371bc9a088f3bfb45cd65ff0285f) | `` ledfx: add python-{mbedtls,osc} dependency ``                               |
| [`3c99c6c9`](https://github.com/NixOS/nixpkgs/commit/3c99c6c99343afc4b7c30a441fd1a94324e9d7ac) | `` python3Packages.python-mbedtls: init at 2.8.0 ``                            |
| [`acb4a24d`](https://github.com/NixOS/nixpkgs/commit/acb4a24d83e9ee5f0a37a2f41d9d3e2ee2c8097b) | `` hybridreverb2: enableParallelBuilding=true ``                               |
| [`73c42a12`](https://github.com/NixOS/nixpkgs/commit/73c42a12538c2cd57ad99bfdb832487f8b8750ba) | `` hybridreverb2: 2.1.2 -> 2.1.2-unstable-2021-12-19 ``                        |
| [`7c64bf4d`](https://github.com/NixOS/nixpkgs/commit/7c64bf4da746376df49628ec9653f6e8048842c1) | `` nuclei: 3.0.4 -> 3.1.0 ``                                                   |
| [`330c1bdb`](https://github.com/NixOS/nixpkgs/commit/330c1bdbbd2ca56295508d9baeef2065f5084429) | `` deno: 1.38.2 -> 1.38.4 ``                                                   |
| [`a93d0cfe`](https://github.com/NixOS/nixpkgs/commit/a93d0cfecbfc40b454d23ef7ff5865f7e473219a) | `` python310Packages.django-rq: 2.8.1 -> 2.9.0 ``                              |
| [`602e6247`](https://github.com/NixOS/nixpkgs/commit/602e6247733f42e8aa55233be791628055ff0cf6) | `` osu-lazer-bin: 2023.1114.1 -> 2023.1130.0 ``                                |
| [`8d0f0ca3`](https://github.com/NixOS/nixpkgs/commit/8d0f0ca32319439fe9940b1de917dbbdcb8e6f3d) | `` tipidee: 0.0.1.0 -> 0.0.2.0 ``                                              |
| [`1cdbb538`](https://github.com/NixOS/nixpkgs/commit/1cdbb538811e928da27b6f0a5f70eb96c92653a9) | `` s6-networking: 2.6.0.0 -> 2.7.0.0 ``                                        |
| [`5784fa51`](https://github.com/NixOS/nixpkgs/commit/5784fa51f252230dfd2c94272f440545d5a52b3c) | `` s6-dns: 2.3.6.0 -> 2.3.7.0 ``                                               |
| [`44c1e78c`](https://github.com/NixOS/nixpkgs/commit/44c1e78ccbdf00e7a19fe21b2985e826e093eb79) | `` s6: 2.12.0.0 -> 2.12.0.2 ``                                                 |
| [`f78ad50e`](https://github.com/NixOS/nixpkgs/commit/f78ad50e0b03d79a94504a3e0413360dcdb8bc06) | `` skalibs: 2.14.0.0 -> 2.14.0.1 ``                                            |
| [`32917e04`](https://github.com/NixOS/nixpkgs/commit/32917e044124805dff96c6f6eb3273d0770ea657) | `` certmgr: 1.6.4 -> 3.0.3, migrate to buildGoModule and by-name ``            |
| [`37333640`](https://github.com/NixOS/nixpkgs/commit/373336400cb7a91ba217b37efe5750b9d370ff32) | `` python311Packages.tuf: init at 3.1.0 ``                                     |
| [`1e281d22`](https://github.com/NixOS/nixpkgs/commit/1e281d2212956910097636dff355c3b6a2477271) | `` python311Packages.securesystemslib: init at 0.30.0 ``                       |
| [`fc6d65a3`](https://github.com/NixOS/nixpkgs/commit/fc6d65a3016fb1a2ea7c42d1fadd07c5f6c33fc5) | `` python311Packages.pyspx: init at 0.5.2 ``                                   |
| [`a9e83267`](https://github.com/NixOS/nixpkgs/commit/a9e832671b66c08b80238c03ac8be4b1e2297cc7) | `` python311Packages.id: init at 1.1.0 ``                                      |
| [`c7475ce0`](https://github.com/NixOS/nixpkgs/commit/c7475ce01c634f884993e51fc34ee409b8008aa7) | `` python311Packages.sigstore-protobuf-specs: init at 0.2.2 ``                 |
| [`8bbf4118`](https://github.com/NixOS/nixpkgs/commit/8bbf41185ebb55d72c2600f695a215af0801e5ef) | `` python311Packages.sigstore-rekor-types: init 0.0.11 ``                      |
| [`acbfdb5a`](https://github.com/NixOS/nixpkgs/commit/acbfdb5a96bf4c8dea7fcc2b397ef4c4cdf5bbad) | `` python310Packages.torchvision-bin: 0.15.2 -> 0.16.1 ``                      |
| [`b0317464`](https://github.com/NixOS/nixpkgs/commit/b03174641225f8fc62c6973b8825f72b282886b8) | `` python310Packages.torchvision: 0.15.2 -> 0.16.1 ``                          |
| [`2a33d391`](https://github.com/NixOS/nixpkgs/commit/2a33d391c9de8e2ba7f36296a3edad9f3afd3049) | `` python310Packages.torchaudio-bin: 2.0.2 -> 2.1.1 ``                         |
| [`b77b6d1b`](https://github.com/NixOS/nixpkgs/commit/b77b6d1bf8b488b11ac8f75f7913adc2d902631c) | `` python310Packages.torchaudio: 2.0.2 -> 2.1.1 ``                             |
| [`0c2ce32d`](https://github.com/NixOS/nixpkgs/commit/0c2ce32d2a857cdf318423ef1b953b60053cca0f) | `` python310Packages.torch-bin: 2.0.1 -> 2.1.1 ``                              |
| [`8cb8035e`](https://github.com/NixOS/nixpkgs/commit/8cb8035e87d758a466f0b02b2b9fb90a5a23149d) | `` python310Packages.torch: 2.0.1 -> 2.1.1 ``                                  |
| [`b27987aa`](https://github.com/NixOS/nixpkgs/commit/b27987aabf561d049e0ba2ccadccc53fac4d4b7d) | `` python310Packages.django-ipware: 5.0.2 -> 6.0.1 ``                          |
| [`b1e74538`](https://github.com/NixOS/nixpkgs/commit/b1e74538b77cf206829dcf26db0b8436f70876cc) | `` python310Packages.django-import-export: 3.3.1 -> 3.3.3 ``                   |
| [`f5100278`](https://github.com/NixOS/nixpkgs/commit/f5100278dfdce0dfa95f23513e6ff300a832125c) | `` qrtool: use `rustPlatform.buildRustPackage rec {` ``                        |
| [`63422646`](https://github.com/NixOS/nixpkgs/commit/63422646a359ab0d248ab55d895b24f91534bef1) | `` gemstash: 2.1.0 -> 2.7.1 ``                                                 |
| [`60508802`](https://github.com/NixOS/nixpkgs/commit/60508802527176bd2489b25c4fd963bc36db71e3) | `` gdal: 3.7.3 -> 3.8.1 (#271240) ``                                           |
| [`a233133b`](https://github.com/NixOS/nixpkgs/commit/a233133b1a0813fe2021afdf5c9fbfa21d02f159) | `` conan: add xcrun to nativeCheckInputs on darwin ``                          |
| [`073a55f2`](https://github.com/NixOS/nixpkgs/commit/073a55f214ad69521307bb8dd29ca354b5b72c64) | `` nodePackages.postcss-cli: improve meta.license ``                           |
| [`61f6b9af`](https://github.com/NixOS/nixpkgs/commit/61f6b9af5e1e651ec147f225d9e2001a5c14c5bc) | `` changedetection-io: 0.45.7.3 -> 0.45.8.1 ``                                 |
| [`44c2bd88`](https://github.com/NixOS/nixpkgs/commit/44c2bd88f4abf9950f208cb5098c61d88b70f77b) | `` tlrc: 1.7.1 -> 1.8.0 ``                                                     |
| [`7877e5db`](https://github.com/NixOS/nixpkgs/commit/7877e5db49be6e5bdeaf8672d6fc401c51b68068) | `` python311Packages.cle: 9.2.78 -> 9.2.79 ``                                  |
| [`34adc1a2`](https://github.com/NixOS/nixpkgs/commit/34adc1a277a834cc60b900e37c1b2af1f0914583) | `` python311Packages.angr: 9.2.78 -> 9.2.79 ``                                 |
| [`f2f7cf6e`](https://github.com/NixOS/nixpkgs/commit/f2f7cf6e5af1614bbac5dcf7705e41424fc009a9) | `` python311Packages.claripy: 9.2.78 -> 9.2.79 ``                              |
| [`ba342d01`](https://github.com/NixOS/nixpkgs/commit/ba342d01ab705baadb2fc47ac2990bc7787f5b89) | `` python311Packages.pyvex: 9.2.78 -> 9.2.79 ``                                |
| [`2a6c54b6`](https://github.com/NixOS/nixpkgs/commit/2a6c54b69955c94d9f9824ee5918a9ebab56fbe2) | `` python311Packages.ailment: 9.2.78 -> 9.2.79 ``                              |
| [`46afbf88`](https://github.com/NixOS/nixpkgs/commit/46afbf881c6a8c6c2c6a25b27791e00c19d9bee8) | `` python311Packages.archinfo: 9.2.78 -> 9.2.79 ``                             |
| [`5f4ee9b5`](https://github.com/NixOS/nixpkgs/commit/5f4ee9b5feafa94430a1e2d4520fc73caf187200) | `` pdf2odt: 20170207 -> 20220827 ``                                            |
| [`437ced83`](https://github.com/NixOS/nixpkgs/commit/437ced8331f8db91a30decf563d02b354f292e7b) | `` wp-cli: allow overriding entire config file ``                              |
| [`d86e5471`](https://github.com/NixOS/nixpkgs/commit/d86e547133a97984256479f47421e28414370dd1) | `` python311Packages.netutils: remove napalm from propagatedBuildInputs ``     |
| [`4960e685`](https://github.com/NixOS/nixpkgs/commit/4960e6854956757e052d11c3049a2a2dbba3c5bd) | `` python310Packages.diffsync: 1.9.0 -> 1.10.0 ``                              |
| [`6de74f02`](https://github.com/NixOS/nixpkgs/commit/6de74f02e07dc9a79e548c35e84b30b4e811fbc5) | `` cargo-udeps: set meta.mainProgram ``                                        |
| [`a5ea86a0`](https://github.com/NixOS/nixpkgs/commit/a5ea86a0dcc6bc60463397430d92a5f0e56f688b) | `` python311Packages.napalm-hp-procurve: disable failing test ``               |
| [`8c9009a2`](https://github.com/NixOS/nixpkgs/commit/8c9009a24a58f26997ed0e428920de68308aa54c) | `` python311Packages.napalm-hp-procurve: refactor ``                           |
| [`a5646708`](https://github.com/NixOS/nixpkgs/commit/a5646708ff2947dc5f21fbfb8fab9eed3d38901c) | `` python310Packages.deepl: 1.15.0 -> 1.16.1 ``                                |
| [`138270eb`](https://github.com/NixOS/nixpkgs/commit/138270eb58e871c711d80e7249da571787f92c9c) | `` fractal: drop drawin support ``                                             |
| [`b06b8857`](https://github.com/NixOS/nixpkgs/commit/b06b8857e021a601bb8a2d8891194ab2dbaad0fe) | `` rio: 0.0.27 -> 0.0.28 ``                                                    |
| [`0eb0100a`](https://github.com/NixOS/nixpkgs/commit/0eb0100afb9458579f780fbff8f11af4f6674f4c) | `` libva: add pkg-config test ``                                               |
| [`d64556c9`](https://github.com/NixOS/nixpkgs/commit/d64556c9900596ae2131cd81c748befbee3fcca2) | `` libva: convert to finalAttrs ``                                             |
| [`cd467f92`](https://github.com/NixOS/nixpkgs/commit/cd467f92e5e2d50e6285c898c141a3b33118ea6b) | `` srt: Add mingw32 build support ``                                           |
| [`b7e03b1c`](https://github.com/NixOS/nixpkgs/commit/b7e03b1c50235179fc64fec1c82089d922b69737) | `` firefox-devedition-unwrapped: 121.0b4 -> 121.0b5 ``                         |
| [`0ec4c74c`](https://github.com/NixOS/nixpkgs/commit/0ec4c74c352268d05396430910475210a755dc94) | `` firefox-beta-unwrapped: 121.0b4 -> 121.0b5 ``                               |
| [`87b3a98c`](https://github.com/NixOS/nixpkgs/commit/87b3a98c36607596f9c4fc1fa5d51ffd9b12894f) | `` nixos/opensearch: check plugins directory exists before checking content `` |
| [`79d3d59f`](https://github.com/NixOS/nixpkgs/commit/79d3d59f58cccc6c1d167b8f6b8b6bd27b663aa7) | `` treewide: replace `mkPackageOptionMD` with `mkPackageOption` ``             |
| [`967f4fc8`](https://github.com/NixOS/nixpkgs/commit/967f4fc844e84a7c2feb58427529a1046188bf24) | `` python311Packages.mirakuru: 2.5.1 -> 2.5.2 ``                               |
| [`eb2163ae`](https://github.com/NixOS/nixpkgs/commit/eb2163aea9cba8c5833848929301b8a2aafaf6f0) | `` python311Packages.mashumaro: 3.10 -> 3.11 ``                                |
| [`8c7245f5`](https://github.com/NixOS/nixpkgs/commit/8c7245f5b98e87ec9c2e6365adb49e179033b5c0) | `` python311Packages.mashumaro: refactor ``                                    |
| [`d3ccd1aa`](https://github.com/NixOS/nixpkgs/commit/d3ccd1aa2fc906dd71d44b29dc9b7817c05cfa03) | `` nixos/sysctl: Move changelog entry for yama ``                              |
| [`35f4c6b9`](https://github.com/NixOS/nixpkgs/commit/35f4c6b9b17dd649db038171729b715b0064283a) | `` python311Packages.jupyterhub: add jupyter team as maintainers ``            |
| [`2bf65b9a`](https://github.com/NixOS/nixpkgs/commit/2bf65b9a984a41faef5dc2ac0d5665c77e5012cc) | `` python311Packages.html5-parser: 0.4.11 -> 0.4.12 ``                         |
| [`3da9fa3a`](https://github.com/NixOS/nixpkgs/commit/3da9fa3ad3bdb6b7b3f4917b9bc0d47001de9e12) | `` qrtool: add shell completions and man pages ``                              |
| [`9714b1bd`](https://github.com/NixOS/nixpkgs/commit/9714b1bdf446dea5dffa6b7f079a01fca3fb820c) | `` python311Packages.headerparser: 0.4.0 -> 0.5.1 ``                           |
| [`1843618d`](https://github.com/NixOS/nixpkgs/commit/1843618d4861d1e6b36f544fa63a7acd28af3dc6) | `` python311Packages.playwright: manually add version file ``                  |
| [`7115d8a7`](https://github.com/NixOS/nixpkgs/commit/7115d8a728d44b4121c6b56be0d71072d135a3a4) | `` paperless-ngx: 1.17.4 -> 2.0.1 ``                                           |
| [`46e2ccb9`](https://github.com/NixOS/nixpkgs/commit/46e2ccb9abf1e3a5f45afb82b8819394ca11c2e2) | `` wavebox: 10.118.5-2 -> 10.119.8-2 ``                                        |
| [`9c4dd01d`](https://github.com/NixOS/nixpkgs/commit/9c4dd01dea631e494d46885a0a8f64bd7bbbbefc) | `` screenly-cli: init at 0.2.3 ``                                              |
| [`d183d6c2`](https://github.com/NixOS/nixpkgs/commit/d183d6c20b18035c555d6508ec93c8386b8e1875) | `` python311Packages.auditwheel: 5.1.2 -> 5.4.0 ``                             |
| [`4bba00b7`](https://github.com/NixOS/nixpkgs/commit/4bba00b7b9c0ab30310203734c9836a16b8f0eef) | `` python311Packages.auditwheel: add meta.mainProgram ``                       |
| [`5e93ac23`](https://github.com/NixOS/nixpkgs/commit/5e93ac23677bc29ab45a332bf146a7c25607b523) | `` auditwheel: move to python3Packages ``                                      |
| [`b474de47`](https://github.com/NixOS/nixpkgs/commit/b474de47797ef17172dfb1b4c0015696c59cf82d) | `` nixos/anki-sync-server: minor cleanup ``                                    |
| [`f0f6c777`](https://github.com/NixOS/nixpkgs/commit/f0f6c7778197ad6e8bd775e2dbfcbe74a00f3aa1) | `` nixos/tests/anki-sync-server: add anki sync test ``                         |
| [`8fe9c18e`](https://github.com/NixOS/nixpkgs/commit/8fe9c18ed3986a8e0f4e738db1ee7b82d30ce68b) | `` nixos/anki-sync-server: init ``                                             |
| [`0a92d24a`](https://github.com/NixOS/nixpkgs/commit/0a92d24ab964708b2f5f60c688096d76bde9294b) | `` pythonPackages.qdarkstyle: 3.1 -> 3.2.3 ``                                  |
| [`6b20d38e`](https://github.com/NixOS/nixpkgs/commit/6b20d38e0126b5fbc95fb34b9d7c9006e415cf2d) | `` qrtool: 0.8.4 -> 0.8.5 ``                                                   |
| [`4b324167`](https://github.com/NixOS/nixpkgs/commit/4b324167cfaa7382e52758a1ca47013f772d1378) | `` fastly: 10.6.4 -> 10.7.0 ``                                                 |