### PR TITLE
chore(flake/nix-index-database): `41afa8d1` -> `ca1f1798`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -444,11 +444,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701572887,
-        "narHash": "sha256-oCPwQZT0Inis4zcYhtFHUp7Rym1zglKPLDcRird35q8=",
+        "lastModified": 1701980277,
+        "narHash": "sha256-qSMnoUIZl3lyaAXgXGQ4qnA5jufnNrBAI0bYw7kJgtE=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "41afa8d1c061beda68502bcc67f2788f3a77042b",
+        "rev": "ca1f1798f63ada20dffcb8b23039b00a597dafe9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                       |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`ca1f1798`](https://github.com/nix-community/nix-index-database/commit/ca1f1798f63ada20dffcb8b23039b00a597dafe9) | `` mergify: also merge dependabot ``                          |
| [`89f4a957`](https://github.com/nix-community/nix-index-database/commit/89f4a957a09b945eae6cc5032833b756ef155a11) | `` Bump cachix/install-nix-action from 23 to 24 ``            |
| [`9cbd0781`](https://github.com/nix-community/nix-index-database/commit/9cbd07817bef6c3d6f720f5e82b676ebeca7ad72) | `` Bump cachix/cachix-action from 12 to 13 ``                 |
| [`62cfdc06`](https://github.com/nix-community/nix-index-database/commit/62cfdc062620c7a6ec657cb6cca7c77fb0cebba6) | `` Define the nix-index package with mkDefault for HM too. `` |
| [`d5245f55`](https://github.com/nix-community/nix-index-database/commit/d5245f559e0a750e7d0aca9943f40d4feb092bba) | `` Add an overlay exposing the packages. ``                   |
| [`d769f441`](https://github.com/nix-community/nix-index-database/commit/d769f441d4ab4bf04f11a5b5bee1ba0030cf07d4) | `` Make nix-index-unwrapped and comma overridable. ``         |