### PR TITLE
chore(flake/home-manager): `ac721691` -> `7db6291d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701728041,
-        "narHash": "sha256-x0pyrI1vC8evVDxCxyO6olOyr4wlFg9+VS3C3p4xFYQ=",
+        "lastModified": 1702110869,
+        "narHash": "sha256-hgbzPjIMLYJf3Ekq9qZCpDcIZn1BZmOp7d6PMkIWknU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ac7216918cd65f3824ba7817dea8f22e61221eaf",
+        "rev": "7db6291d95693374d408f4877c265ec7481f222b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`f10eb1b3`](https://github.com/nix-community/home-manager/commit/f10eb1b3ee8e5ee2891b34b6c9f12567f73f9693) | `` docs: apply nixfmt ``                             |
| [`613dbb35`](https://github.com/nix-community/home-manager/commit/613dbb35dbc142fd5cadca847f8677e64a502bfa) | `` docs: rename generated manual to `index.xhtml` `` |
| [`0a710464`](https://github.com/nix-community/home-manager/commit/0a710464932ae65238f583e69f887fea6bd72c0e) | `` docs: fix syntax highlighting ``                  |
| [`b006bf1d`](https://github.com/nix-community/home-manager/commit/b006bf1d7456912fbf886f197320468b0f7a850c) | `` docs: render DESCRIPTION and OPTIONS headings ``  |
| [`eff22a27`](https://github.com/nix-community/home-manager/commit/eff22a27e293809ea40ce004d6982ee6a099a1e0) | `` docs: replace `console` language with `shell` ``  |
| [`67b797a3`](https://github.com/nix-community/home-manager/commit/67b797a37723a7c059e8c366819ffe968456a713) | `` docs: update nmd version ``                       |
| [`5c2ef524`](https://github.com/nix-community/home-manager/commit/5c2ef5243d9c72b7804343c7e901f182f541120a) | `` docs: extend home-configuration.nix header ``     |
| [`be801227`](https://github.com/nix-community/home-manager/commit/be801227317673cff6bd818a99898758d76d0dac) | `` docs: include 3rd-party part ``                   |
| [`b5a47bd7`](https://github.com/nix-community/home-manager/commit/b5a47bd700f275dbede0b9a15b40d0dd599472c2) | `` docs: this is the `home-manager` manual ``        |
| [`32063973`](https://github.com/nix-community/home-manager/commit/32063973cc041c1a902d688765cdf83ad0c47179) | `` docs: fix note blocks ``                          |
| [`2098c6fe`](https://github.com/nix-community/home-manager/commit/2098c6fe915b6f393a311d6b9a920c2b4c268b5d) | `` docs: no justification in home-manager manpage `` |
| [`8dae2041`](https://github.com/nix-community/home-manager/commit/8dae2041eff0a59abe640b62da922aa4aa6f4483) | `` docs: use nixos-render-docs ``                    |
| [`e4d29039`](https://github.com/nix-community/home-manager/commit/e4d290396c116c75ae0b17aa49613d9bc4493936) | `` docs: update manual to refer to 23.11 ``          |
| [`f48a0062`](https://github.com/nix-community/home-manager/commit/f48a0062dfe9bbf42050b557a0a5de0f4706ac75) | `` docs: update paths to make manual tests pass ``   |
| [`0dcb7676`](https://github.com/nix-community/home-manager/commit/0dcb767676ec46602247fd89e423124075eeff96) | `` docs: add htmlOpenTool to manual ``               |
| [`728423e6`](https://github.com/nix-community/home-manager/commit/728423e6f46b862af34ed93c2440469aca6a69f2) | `` docs: add home-manager manpage ``                 |
| [`80ac72bf`](https://github.com/nix-community/home-manager/commit/80ac72bf03afc0177b30fdbe386b9f747bfea910) | `` docs: render without deprecated optionsDocBook `` |