### PR TITLE
chore(flake/home-manager): `7db6291d` -> `efa36e89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702110869,
-        "narHash": "sha256-hgbzPjIMLYJf3Ekq9qZCpDcIZn1BZmOp7d6PMkIWknU=",
+        "lastModified": 1702110948,
+        "narHash": "sha256-GzK0k5kFgZLbeaOPPoFS4C2BP8vZ0fAH36UtbFRnrWs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7db6291d95693374d408f4877c265ec7481f222b",
+        "rev": "efa36e896951bec8d96e38ea40a22c010bd1bd8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`efa36e89`](https://github.com/nix-community/home-manager/commit/efa36e896951bec8d96e38ea40a22c010bd1bd8f) | `` Translate using Weblate (Czech) `` |