### PR TITLE
chore(flake/home-manager): `efa36e89` -> `e6b7303b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702110948,
-        "narHash": "sha256-GzK0k5kFgZLbeaOPPoFS4C2BP8vZ0fAH36UtbFRnrWs=",
+        "lastModified": 1702159252,
+        "narHash": "sha256-4mYOL1EhOmt92OtYsHXRViWrSHvR5obLfCllMmQsUzY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "efa36e896951bec8d96e38ea40a22c010bd1bd8f",
+        "rev": "e6b7303bd149723c57ca23f5a9428482d6b07306",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`e6b7303b`](https://github.com/nix-community/home-manager/commit/e6b7303bd149723c57ca23f5a9428482d6b07306) | `` docs: fix broken links in README ``             |
| [`fa91c109`](https://github.com/nix-community/home-manager/commit/fa91c109b0dd12e680dd29010e262884f7b26186) | `` docs: use relative paths to static resources `` |