### PR TITLE
chore(flake/stylix): `17a452c5` -> `b5ad31b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -618,11 +618,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701532764,
-        "narHash": "sha256-Jrizp/nITbul2HBIraQRDw5lyJnzTsj0K9wZUFYX2gg=",
+        "lastModified": 1702242258,
+        "narHash": "sha256-DSiwYD1DZY+YJALahnCVKacWk2AGy+s1pd3Z07tEF/U=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "17a452c5d58bb90057d49c7e3e613b5e6dc1c0f4",
+        "rev": "b5ad31b710294038f9ed70efdf787db6a82d7327",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                               |
| --------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`b5ad31b7`](https://github.com/danth/stylix/commit/b5ad31b710294038f9ed70efdf787db6a82d7327) | `` Set font face for kmscon (#195) `` |