### PR TITLE
chore(flake/nix-index-database): `58ecd98e` -> `45d82e0a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -444,11 +444,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702177733,
-        "narHash": "sha256-lr3hkmmuqDFPj3i41cHpaALF3Txo3kxsJ3L6jZLujJ8=",
+        "lastModified": 1702291765,
+        "narHash": "sha256-kfxavgLKPIZdYVPUPcoDZyr5lleymrqbr5G9PVfQ2NY=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "58ecd98e27e27fcbb27a51a588555c828b1ec56e",
+        "rev": "45d82e0a8b9dd6c5dd9da835ac0c072239af7785",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                         |
| ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`68ee1b79`](https://github.com/nix-community/nix-index-database/commit/68ee1b7918c21f396552f5f7dfc378afbc2229d5) | `` Avoid calling builtins.import on modules. `` |