### PR TITLE
chore(flake/pre-commit-hooks): `e5ee5c5f` -> `f99ed852`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -537,11 +537,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1700922917,
-        "narHash": "sha256-ej2fch/T584b5K9sk1UhmZF7W6wEfDHuoUYpFN8dtvM=",
+        "lastModified": 1702290759,
+        "narHash": "sha256-DUPtcei6GJlrC05Y3cqwLLSst+sp07334aAZw4Uk118=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e5ee5c5f3844550c01d2131096c7271cec5e9b78",
+        "rev": "f99ed8523fc3aef67a7c838ca31f4b94ef902837",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                   |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
| [`d3708281`](https://github.com/cachix/pre-commit-hooks.nix/commit/d37082815fea8febd96babebf75eb4294cb899ff) | `` hooks: fix deno fmt/lint configPath `` |