### PR TITLE
chore(flake/nixos-hardware): `030edbb6` -> `fef05bf9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -459,11 +459,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1702245580,
-        "narHash": "sha256-tTVRB42Ljo2uWGP7ei5h5/qQjOsdXoz0GHRy9hrVrdw=",
+        "lastModified": 1702336390,
+        "narHash": "sha256-BRO8J8QbmyuS0XMh4UfY11akgTGZj1YhkqNvR83JrsI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "030edbb68e69f2b97231479f98a9597024650df2",
+        "rev": "fef05bf9c8e818f4ca1425ef4c18e6680becd072",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`fef05bf9`](https://github.com/NixOS/nixos-hardware/commit/fef05bf9c8e818f4ca1425ef4c18e6680becd072) | `` surface: linux 6.5.11 -> 6.6.6 `` |