### PR TITLE
chore(flake/nixpkgs): `bc3575c6` -> `6df37dc6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703213509,
-        "narHash": "sha256-BDVzvjPwKk4/yvdCNzjmm1wlDf7Pdbhsf+hV2ybKkrY=",
+        "lastModified": 1703255338,
+        "narHash": "sha256-Z6wfYJQKmDN9xciTwU3cOiOk+NElxdZwy/FiHctCzjU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bc3575c6cda0c5fc9e322c05d97df6a787066b3e",
+        "rev": "6df37dc6a77654682fe9f071c62b4242b5342e04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`6df37dc6`](https://github.com/NixOS/nixpkgs/commit/6df37dc6a77654682fe9f071c62b4242b5342e04) | `` vimPlugins.guard-nvim: init at 2023-11-27 ``                                   |
| [`d09d2d6a`](https://github.com/NixOS/nixpkgs/commit/d09d2d6a7a2fdfc3d39e5bcfe3dcbbd322597fd8) | `` vimPlugins.guard-collection: init at 2023-11-13 ``                             |
| [`6ee48dce`](https://github.com/NixOS/nixpkgs/commit/6ee48dcedd948cc9b1f29a2ebeb5f0cde5180e4d) | `` ocamlPackages.cryptokit: 1.18 → 1.19 ``                                        |
| [`9610ad2f`](https://github.com/NixOS/nixpkgs/commit/9610ad2feed0429be3bae67089f7187415c871ec) | `` ocamlPackages.janestreet: use 0.16.0 tag rather than 0.16 branch ``            |
| [`3dbd0292`](https://github.com/NixOS/nixpkgs/commit/3dbd0292da754d0a8a75dfa93056ecf08927b7ce) | `` python310Packages.ring-doorbell: 0.8.3 -> 0.8.5 ``                             |
| [`6acbbb27`](https://github.com/NixOS/nixpkgs/commit/6acbbb27345c72fee35dc74f1b4eede736e0a264) | `` python310Packages.rapidgzip: 0.10.4 -> 0.11.0 ``                               |
| [`5023c10c`](https://github.com/NixOS/nixpkgs/commit/5023c10cbf0938fd7c4bc178e08b69471e83eeca) | `` php.packages.grumphp: 2.1.0 -> 2.4.0 ``                                        |
| [`7af913d5`](https://github.com/NixOS/nixpkgs/commit/7af913d5dc8a60e5cc22a6192f773b12c5cde79b) | `` python310Packages.qdrant-client: 1.6.2 -> 1.7.0 ``                             |
| [`df22fb01`](https://github.com/NixOS/nixpkgs/commit/df22fb01dfdd4e35ddb6b8edbb3c709deaa353a2) | `` julia.withPackages: better error message on missing nix-sha256 hash ``         |
| [`820f1a3b`](https://github.com/NixOS/nixpkgs/commit/820f1a3bbed58ce341b63b1fe6678a36059fbafe) | `` julia.withPackages: bump the augmented registry to pick up a few hash fixes `` |
| [`ded8563f`](https://github.com/NixOS/nixpkgs/commit/ded8563fb360bf5c7b1283236cfaef1772903ee9) | `` llama-cpp: assert that only one of the *Support arguments is true ``           |
| [`4ef37025`](https://github.com/NixOS/nixpkgs/commit/4ef37025e674dfe5bf362d22e64c64d6d5a58c04) | `` python310Packages.pytile: 2023.10.0 -> 2023.12.0 ``                            |
| [`5381f312`](https://github.com/NixOS/nixpkgs/commit/5381f312a6cbad38ea2b68ee35a04ee4bf3384a4) | `` python310Packages.python-gvm: 23.11.0 -> 23.12.0 ``                            |
| [`a4fcc87a`](https://github.com/NixOS/nixpkgs/commit/a4fcc87af0bb09d6f95339625c89737120ee2c23) | `` ocamlPackages.minttea: init at 0.0.1 ``                                        |
| [`d6706ffa`](https://github.com/NixOS/nixpkgs/commit/d6706ffac7501d62ab0c57b87727c39520a43f20) | `` python310Packages.pytenable: 1.4.14 -> 1.4.16 ``                               |
| [`aa73ab5c`](https://github.com/NixOS/nixpkgs/commit/aa73ab5c6a6d6df8244429a1254583c0a4023576) | `` python310Packages.pytelegrambotapi: 4.14.0 -> 4.14.1 ``                        |
| [`cef1da4d`](https://github.com/NixOS/nixpkgs/commit/cef1da4d3257f61aef75e75ceddcb36da5593f63) | `` python310Packages.pyswitchbot: 0.41.0 -> 0.42.0 ``                             |
| [`8cd0f10b`](https://github.com/NixOS/nixpkgs/commit/8cd0f10bbdfd1ce502f4ed97ad51d0087d437a1b) | `` cri-o-unwrapped: 1.28.2 -> 1.29.0 ``                                           |
| [`2eee8ab5`](https://github.com/NixOS/nixpkgs/commit/2eee8ab5a1ab94228d2cad45d2eecdc111192616) | `` cargo-component: 0.5.0 -> 0.6.0 ``                                             |
| [`412d278e`](https://github.com/NixOS/nixpkgs/commit/412d278e2acb3fe8fe645ee5475eaa4497942ec1) | `` python310Packages.pysigma: 0.10.9 -> 0.10.10 ``                                |
| [`be7eb56f`](https://github.com/NixOS/nixpkgs/commit/be7eb56fe07ebad22eb9ce71ae3ea2ee2a5830ff) | `` python310Packages.pyreadstat: 1.2.5 -> 1.2.6 ``                                |
| [`a6851f8d`](https://github.com/NixOS/nixpkgs/commit/a6851f8df33c9bbe84ad6dadd1994b2d636a351b) | `` linuxptp: 4.1 -> 4.2 ``                                                        |
| [`adf74e11`](https://github.com/NixOS/nixpkgs/commit/adf74e11438ad4e1d6349c920476e1ab6fb8bfda) | `` giada: 0.26.0 -> 0.26.1 ``                                                     |
| [`be64b52d`](https://github.com/NixOS/nixpkgs/commit/be64b52d294fefabf3009d189947927de34bb2fa) | `` grype: 0.73.4 -> 0.73.5 ``                                                     |
| [`cc61f62d`](https://github.com/NixOS/nixpkgs/commit/cc61f62dfe25bec07f85c3c298e6a42dd5036bde) | `` python310Packages.pyoverkiz: 1.13.3 -> 1.13.4 ``                               |
| [`f0020814`](https://github.com/NixOS/nixpkgs/commit/f00208148de5ea9440e0bcf8a6cf852cbe88f635) | `` cryptowatch-desktop: remove ``                                                 |
| [`d48eb1e7`](https://github.com/NixOS/nixpkgs/commit/d48eb1e795c177ac0613c32ab6d96df9b916f5ed) | `` nuclei: 3.1.2 -> 3.1.3 ``                                                      |
| [`a6ac7f52`](https://github.com/NixOS/nixpkgs/commit/a6ac7f52ce043d50004476f61ff7040adf6cf3ee) | `` python310Packages.pyopenuv: 2023.11.0 -> 2023.12.0 ``                          |
| [`8d36d938`](https://github.com/NixOS/nixpkgs/commit/8d36d9384e1572902d4da64f01ad5fa5164a6dfb) | `` ungoogled-chromium: 120.0.6099.109-1 -> 120.0.6099.129-1 ``                    |
| [`027ec17c`](https://github.com/NixOS/nixpkgs/commit/027ec17c01327a7db9ef1d4946f9294cf22b9c50) | `` chromium: 120.0.6099.109 -> 120.0.6099.129 ``                                  |
| [`f96d36a2`](https://github.com/NixOS/nixpkgs/commit/f96d36a28db7d6ba9549a45d0af3407b55dd5547) | `` chromedriver: 120.0.6099.71 -> 120.0.6099.109 ``                               |
| [`5d14747f`](https://github.com/NixOS/nixpkgs/commit/5d14747fdc3032a92d0d686d574f8da856eacb09) | `` systemd: Add withBootloader to ukify assertion ``                              |
| [`1a39d6d1`](https://github.com/NixOS/nixpkgs/commit/1a39d6d109385b6a157882e59222865465c7fc99) | `` python310Packages.pyngo: 1.6.0 -> 1.7.0 ``                                     |
| [`7d1f2d40`](https://github.com/NixOS/nixpkgs/commit/7d1f2d40afac2b7fe58b7d9fe7d5196720467b96) | `` python311Packages.cacheyou: remove ``                                          |
| [`237011e6`](https://github.com/NixOS/nixpkgs/commit/237011e6d8a541359ffc24b0477fc72410176b73) | `` python311Packages.optuna: 3.4.0 -> 3.5.0 ``                                    |
| [`c2f8e670`](https://github.com/NixOS/nixpkgs/commit/c2f8e670dd138deb783e6f212f706d5e1976780b) | `` python310Packages.pymc: 5.10.2 -> 5.10.3 ``                                    |
| [`4ecc674e`](https://github.com/NixOS/nixpkgs/commit/4ecc674e46bb7bf93eed4ca89fbb4ab2dd036c89) | `` tailscale-nginx-auth: Remove unneeded definition in all-packages.nix ``        |
| [`e3ca8030`](https://github.com/NixOS/nixpkgs/commit/e3ca8030852cd391fdba9eed9dd3da88c83e9538) | `` maintainers: add r-burns to geospatial team ``                                 |
| [`c69f16c8`](https://github.com/NixOS/nixpkgs/commit/c69f16c8ef5a5da94affb329474f9cdbc870bc19) | `` python310Packages.pyinsteon: 1.5.2 -> 1.5.3 ``                                 |
| [`f2449d80`](https://github.com/NixOS/nixpkgs/commit/f2449d80e4e256eb1c258c1bf57cda28736a3ca5) | `` python310Packages.pyiqvia: 2023.10.0 -> 2023.12.0 ``                           |
| [`4b01795b`](https://github.com/NixOS/nixpkgs/commit/4b01795b389ef461fa9e9b4ccacfa1d8a5ccd027) | `` python310Packages.pygtkspellcheck: 5.0.2 -> 5.0.3 ``                           |
| [`6b3932ed`](https://github.com/NixOS/nixpkgs/commit/6b3932ed4ac315951f8fdcbf7bd42ebace6b56a0) | `` harmonia: fix build on darwin ``                                               |
| [`32957cdf`](https://github.com/NixOS/nixpkgs/commit/32957cdfabd1dcae65351000f2139583b3506fdb) | `` python311Packages.slackclient: 3.26.0 -> 3.26.1 ``                             |
| [`03735b2b`](https://github.com/NixOS/nixpkgs/commit/03735b2b3dacb683737abbb18b536d774bf6a29f) | `` python310Packages.pydrive2: 1.17.0 -> 1.18.1 ``                                |
| [`c4933514`](https://github.com/NixOS/nixpkgs/commit/c493351419cceb59cdda786095fd58f2ece38ba0) | `` python310Packages.pydrawise: 2023.11.0 -> 2023.12.0 ``                         |
| [`a0f1bb16`](https://github.com/NixOS/nixpkgs/commit/a0f1bb16a2a40200b41344457fe1495658fb2eb3) | `` python311Packages.devialet: 1.4.3 -> 1.4.5 ``                                  |
| [`74e47e4b`](https://github.com/NixOS/nixpkgs/commit/74e47e4bf3c95ac378ba7aa876cbd9e8dfab2902) | `` python311Packages.habluetooth: 1.0.0 -> 2.0.0 ``                               |
| [`ad07fbfa`](https://github.com/NixOS/nixpkgs/commit/ad07fbfa1e65d96927f880f91a3a316faa2493a4) | ``  python310Packages.ocifs: update changelog entry ``                            |
| [`e016ac8b`](https://github.com/NixOS/nixpkgs/commit/e016ac8b741fcee62c3527d81315ef747356205a) | `` python310Packages.pyairvisual: remove postPatch section ``                     |
| [`062a0f6f`](https://github.com/NixOS/nixpkgs/commit/062a0f6f61e685edfc3671113a10d4b9148ec7db) | `` python310Packages.pyairvisual: 2023.11.0 -> 2023.12.0 ``                       |
| [`7225eb64`](https://github.com/NixOS/nixpkgs/commit/7225eb645b94f8598b6cc13a87a74ab2e95cc4df) | `` python310Packages.publicsuffixlist: 0.10.0.20231122 -> 0.10.0.20231214 ``      |
| [`c757971d`](https://github.com/NixOS/nixpkgs/commit/c757971da1e72fba651fd0e77488bbe172b05420) | `` clang17Stdenv: add definition ``                                               |
| [`666c6b29`](https://github.com/NixOS/nixpkgs/commit/666c6b294424f5631ec70e5282e1cc915e51a90d) | `` cinnamon.cinnamon-screensaver: 6.0.0 -> 6.0.1 ``                               |
| [`ec93a698`](https://github.com/NixOS/nixpkgs/commit/ec93a69823ef0b8cc45b0134f8b6bafbe371f0ca) | `` cinnamon.mint-y-icons: 1.7.0 -> 1.7.1 ``                                       |
| [`97ae679e`](https://github.com/NixOS/nixpkgs/commit/97ae679e7fccad1003a3bfd72664aa2d13245130) | `` pcsx2: 1.7.5004 -> 1.7.5318 ``                                                 |
| [`ee2d46a2`](https://github.com/NixOS/nixpkgs/commit/ee2d46a2e08b3bc31319db7e47fc9e5c6e3f7df7) | `` python310Packages.ocifs: 1.3.0 -> 1.3.1 ``                                     |
| [`212e92aa`](https://github.com/NixOS/nixpkgs/commit/212e92aa347036aa4bab949ffa42fedee0adbed8) | `` python311Packages.bellows: 0.37.3 -> 0.37.4 ``                                 |
| [`c011e919`](https://github.com/NixOS/nixpkgs/commit/c011e919a16dc48a51ed215f5621f492962e4b41) | `` python311Packages.zha-quirks: 0.0.107 -> 0.0.108 ``                            |
| [`4fbdd6f5`](https://github.com/NixOS/nixpkgs/commit/4fbdd6f51478fc702c88757b66c053bba0682777) | `` python311Packages.zigpy-deconz: 0.22.2 -> 0.22.3 ``                            |
| [`c730dc55`](https://github.com/NixOS/nixpkgs/commit/c730dc55cad37ea0f76581ee400ae7cee17eba28) | `` python311Packages.zigpy-znp: 0.12.0 -> 0.12.1 ``                               |
| [`72c9b045`](https://github.com/NixOS/nixpkgs/commit/72c9b045fc6c2df52f2e47f4d775cc09bd4088cb) | `` python311Packages.zigpy: 0.60.1 -> 0.60.2 ``                                   |
| [`7ae4918c`](https://github.com/NixOS/nixpkgs/commit/7ae4918c7dc1511f6b74e710ba0fb8a203198465) | `` linkerd_stable: 2.14.6 -> 2.14.7 ``                                            |
| [`6963cd0d`](https://github.com/NixOS/nixpkgs/commit/6963cd0de2ae49218be23d2fb16354c8b87126c5) | `` grub: 2.12-rc1 -> 2.12 ``                                                      |
| [`3c2cd1b1`](https://github.com/NixOS/nixpkgs/commit/3c2cd1b1c0558e66a32e3a78c2892acf2f5322e0) | `` grafana-image-renderer: pacify editorconfig ``                                 |
| [`49a62430`](https://github.com/NixOS/nixpkgs/commit/49a624307e155608dece57afe3d92e6c9c10f8e6) | `` grafana-image-renderer: 3.8.4 -> 3.9.0 ``                                      |
| [`3eb45a22`](https://github.com/NixOS/nixpkgs/commit/3eb45a22ca8795b9ef2e9805a5070908fd5f0098) | `` grafana: 10.2.2 -> 10.2.3 ``                                                   |
| [`55d2403b`](https://github.com/NixOS/nixpkgs/commit/55d2403b81641a558dd859f59e25a63e084a8b1a) | `` polkadot: 1.4.0 -> 1.5.0 ``                                                    |
| [`61c85d99`](https://github.com/NixOS/nixpkgs/commit/61c85d997031e77e11f86643fb90268f1e10463b) | `` gdal: call correct binaries in tests ``                                        |
| [`411b15e1`](https://github.com/NixOS/nixpkgs/commit/411b15e1e5630d36d6e18ea8b2e21112b1df0825) | `` mongodb-compass: 1.40.4 -> 1.41.0 ``                                           |
| [`cc4b2b36`](https://github.com/NixOS/nixpkgs/commit/cc4b2b36df2209252233147350c7c8d36ab099e5) | `` plantuml-server: 1.2023.12 -> 1.2023.13 ``                                     |
| [`6d031527`](https://github.com/NixOS/nixpkgs/commit/6d031527a039e93861138ff9c6b56e500364afc9) | `` vte: 0.74.1 → 0.74.2 ``                                                        |
| [`0b1dbca5`](https://github.com/NixOS/nixpkgs/commit/0b1dbca50f472d837e6f3c4d6d65664ca61fafb6) | `` loupe: 45.2 → 45.3 ``                                                          |
| [`7a4db40a`](https://github.com/NixOS/nixpkgs/commit/7a4db40a47939292cc7d05a853b02ad0194f05f5) | `` linkerd_edge: 23.11.4 -> 23.12.2 ``                                            |
| [`5c6786bc`](https://github.com/NixOS/nixpkgs/commit/5c6786bc3bba7c9780f9ed5f46f76ff2a0012f67) | `` kubeswitch: 0.8.0 -> 0.8.1 ``                                                  |
| [`2e3c2705`](https://github.com/NixOS/nixpkgs/commit/2e3c2705b98351bc95d01d42ab535f3dc230c593) | `` Remove "-s" and "-w" from the ldflags example ``                               |
| [`2da5fe61`](https://github.com/NixOS/nixpkgs/commit/2da5fe614fc80ba9b15472d41570e44555747ab0) | `` parsec-bin: 150_90c -> 150_91a ``                                              |
| [`2166416e`](https://github.com/NixOS/nixpkgs/commit/2166416e4e19831ce158aa23bd4ccce2dfbd5524) | `` parsec-bin: use ffmpeg_5 ``                                                    |
| [`cac5a123`](https://github.com/NixOS/nixpkgs/commit/cac5a123257c790a00d0e84ae97aad3a11fcc613) | `` parsec-bin: add pabloaul to maintainers ``                                     |
| [`dd5bcbfb`](https://github.com/NixOS/nixpkgs/commit/dd5bcbfb998d39f38619b51e0c7ff999c9013f1c) | `` maintainers: add pabloaul ``                                                   |
| [`342c7949`](https://github.com/NixOS/nixpkgs/commit/342c7949e93c2b730ed9d6c244351391b3fe3412) | `` transmission_4: 4.0.4 -> 4.0.5 ``                                              |
| [`accbc67b`](https://github.com/NixOS/nixpkgs/commit/accbc67b046c4391d6bb6340044b79fb15f34020) | `` nixos/transmission: use mkDefault on PrivateMounts and PrivateUsers ``         |
| [`dd77a799`](https://github.com/NixOS/nixpkgs/commit/dd77a799f813dfb7a49aba2aacfbfb69d79b92b3) | `` nixos/transmission: /run/host must be writable, fixes #258793 ``               |