### PR TITLE
chore(flake/nixos-hardware): `fef05bf9` -> `7763c6fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -459,11 +459,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1702336390,
-        "narHash": "sha256-BRO8J8QbmyuS0XMh4UfY11akgTGZj1YhkqNvR83JrsI=",
+        "lastModified": 1702453208,
+        "narHash": "sha256-0wRi9SposfE2wHqjuKt8WO2izKB/ASDOV91URunIqgo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "fef05bf9c8e818f4ca1425ef4c18e6680becd072",
+        "rev": "7763c6fd1f299cb9361ff2abf755ed9619ef01d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`7763c6fd`](https://github.com/NixOS/nixos-hardware/commit/7763c6fd1f299cb9361ff2abf755ed9619ef01d6) | `` Lenovo Legion 16achg6 support (#796) `` |