### PR TITLE
chore(flake/deploy-rs): `2ccd5d99` -> `91532751`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -226,11 +226,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702378423,
-        "narHash": "sha256-tuJ8NWjaH/OuZSZukS6T+suia7E1QIPXW2nzkuUCCNA=",
+        "lastModified": 1702460489,
+        "narHash": "sha256-H6s6oVLvx7PCjUcvfkB89Bb+kbaiJxTAgWfMjiQTjA0=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "2ccd5d9939d41ac797c3ce769a689fdbc76fdebb",
+        "rev": "915327515f5fd1b7719c06e2f1eb304ee0bdd803",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                     |
| --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`6d70659c`](https://github.com/serokell/deploy-rs/commit/6d70659c846b94e2ba4fef80441ae94b7fb2b5ea) | `` Automatically update flake.lock to the latest version `` |