### PR TITLE
chore(flake/home-manager): `d9297efd` -> `5e9d1fe1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702423270,
-        "narHash": "sha256-3ZA5E+b2XBP+c9qGhWpRApzPq/PZtIPgkeEDpTBV4g8=",
+        "lastModified": 1702510888,
+        "narHash": "sha256-+7Bd9j47gDjD1DD0K9zKwA+8TjnTdTRGMVCERh6w2L0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d9297efd3a1c3ebb9027dc68f9da0ac002ae94db",
+        "rev": "5e9d1fe19f2d17cdfeb3b7e5e668f763e430cd28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`5e9d1fe1`](https://github.com/nix-community/home-manager/commit/5e9d1fe19f2d17cdfeb3b7e5e668f763e430cd28) | `` flake.lock: Update ``             |
| [`7a69b3e7`](https://github.com/nix-community/home-manager/commit/7a69b3e738a587915a374994e05e8e10f1216721) | `` ssh: add addKeysToAgent option `` |