### PR TITLE
chore(flake/stylix): `b5ad31b7` -> `41d21859`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -618,11 +618,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702242258,
-        "narHash": "sha256-DSiwYD1DZY+YJALahnCVKacWk2AGy+s1pd3Z07tEF/U=",
+        "lastModified": 1702559747,
+        "narHash": "sha256-d6AmQp3M00WMPJquNfGVzIol5iojD1pi9slek+4N9VY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "b5ad31b710294038f9ed70efdf787db6a82d7327",
+        "rev": "41d218597590a89324a4b7c50cf0bf088a7214ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                         |
| --------------------------------------------------------------------------------------------- | ------------------------------- |
| [`41d21859`](https://github.com/danth/stylix/commit/41d218597590a89324a4b7c50cf0bf088a7214ba) | `` Add Firefox module (#191) `` |