### PR TITLE
chore(flake/base16-schemes): `3d8cf655` -> `2b6f2d06`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -127,11 +127,11 @@
     "base16-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1702663984,
-        "narHash": "sha256-vuNqzoJECGL6lvwX+QIabDALSDd7SPv2RhJm6Rj5Z8c=",
+        "lastModified": 1702718998,
+        "narHash": "sha256-VTczZi1C4WSzejpTFbneMonAdarRLtDnFehVxWs6ad0=",
         "owner": "tinted-theming",
         "repo": "base16-schemes",
-        "rev": "3d8cf655eeb4ad741746c5abb3cc96454e68ef41",
+        "rev": "2b6f2d0677216ddda50c9cabd6ee70fae4665f81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                |
| -------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`2b6f2d06`](https://github.com/tinted-theming/base16-schemes/commit/2b6f2d0677216ddda50c9cabd6ee70fae4665f81) | `` Add deprecation notice to README `` |