### PR TITLE
chore(flake/home-manager): `e9b9ecef` -> `e4dba0bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702735279,
-        "narHash": "sha256-SztEzDOE/6bDNnWWvnRbSHPVrgewLwdSei1sxoZFejM=",
+        "lastModified": 1702814335,
+        "narHash": "sha256-Qck7BAMi3eydzT1WFOzp/SgECetyPpOn1dLgmxH2ebQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e9b9ecef4295a835ab073814f100498716b05a96",
+        "rev": "e4dba0bd01956170667458be7b45f68170a63651",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`e4dba0bd`](https://github.com/nix-community/home-manager/commit/e4dba0bd01956170667458be7b45f68170a63651) | `` docs: set the manual version to "24.05 (unstable)" `` |
| [`a2e592cc`](https://github.com/nix-community/home-manager/commit/a2e592cc49850f32b59d0ab2a66ae0871f525c65) | `` home-manager: improve nix profile detection ``        |
| [`c22b41f0`](https://github.com/nix-community/home-manager/commit/c22b41f006d4c66d183d1e8baaca4b8f48062979) | `` docs: fix broken link text ``                         |
| [`59c15ebe`](https://github.com/nix-community/home-manager/commit/59c15ebe3df602432cff8454a4918465dd05c9d9) | `` docs: fix link texts in release notes ``              |