### PR TITLE
chore(flake/nix-index-database): `27edc98a` -> `4605ccd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -444,11 +444,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702782546,
-        "narHash": "sha256-Y/y9Xpd8W2CSFIAXJExAvg72J8STmGk7CP2Vv91t930=",
+        "lastModified": 1702864432,
+        "narHash": "sha256-xR5Igg2hnm979W3YgMDrSjErHFhHo4rbMboF6DC0mbc=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "27edc98a32959b003e4bcef9719ad6f24e312343",
+        "rev": "4605ccd764fac78b9e4b5b058698cb9f04430b91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                          |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`4605ccd7`](https://github.com/nix-community/nix-index-database/commit/4605ccd764fac78b9e4b5b058698cb9f04430b91) | `` Bump actions/upload-artifact from 3 to 4 ``   |
| [`4efa7c36`](https://github.com/nix-community/nix-index-database/commit/4efa7c3666cbae719e94b9c51f1284a11653b718) | `` Bump actions/download-artifact from 3 to 4 `` |