### PR TITLE
chore(flake/impermanence): `0c893cf0` -> `f1fe8fcf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -366,11 +366,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1702948936,
-        "narHash": "sha256-pWG4bn5idGphFspC9RBIMHPXvRf0aQb5JG0pAKpUedE=",
+        "lastModified": 1702983493,
+        "narHash": "sha256-nCjR/kvDg/P8r1RrwyTaLM43qJihKiO6DKt+vtuw3fA=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "0c893cf08a6c9559e482466340e82ac1f569937d",
+        "rev": "f1fe8fcf3e3b5279e67863d03ac67335172a1c6e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`554d7e6f`](https://github.com/nix-community/impermanence/commit/554d7e6fd13d5ff43e8738c128a2bd09b51c78d9) | `` forgot te replace `persistentStoragePath` occurrence `` |
| [`dc6d092d`](https://github.com/nix-community/impermanence/commit/dc6d092da5fb31a0cdb7ee430e99e1cc94ec1d00) | `` home-manager: add persistentStoragePath option ``       |