### PR TITLE
chore(flake/agenix): `93cec0ce` -> `564595d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703088186,
-        "narHash": "sha256-o8L0fFZl7gC6NMVnCnIH7PsIZgHpGWtJky74yo8N310=",
+        "lastModified": 1703089996,
+        "narHash": "sha256-ipqShkBmHKC9ft1ZAsA6aeKps32k7+XZSPwfxeHLsAU=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "93cec0ce6ed1061bf0973c5fef76b2d8e76d4810",
+        "rev": "564595d0ad4be7277e07fa63b5a991b3c645655d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                       |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`564595d0`](https://github.com/ryantm/agenix/commit/564595d0ad4be7277e07fa63b5a991b3c645655d) | `` version 0.15.0 ``                          |
| [`9d3b37a1`](https://github.com/ryantm/agenix/commit/9d3b37a1177fedcce0a6c72ff4d337283a393fe2) | `` fix: update keys functions in agenix.sh `` |