### PR TITLE
chore(flake/home-manager): `433120e4` -> `3bfaacf4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703072477,
-        "narHash": "sha256-I2g7o+J26iK3sGk53iuaYiMWryzAYx0zhNQUFzTID/A=",
+        "lastModified": 1703113217,
+        "narHash": "sha256-7ulcXOk63TIT2lVDSExj7XzFx09LpdSAPtvgtM7yQPE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "433120e47d016c9960dd9c2b1821e97d223a6a39",
+        "rev": "3bfaacf46133c037bb356193bd2f1765d9dc82c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`3bfaacf4`](https://github.com/nix-community/home-manager/commit/3bfaacf46133c037bb356193bd2f1765d9dc82c1) | `` direnv: Make lines shorter ``                           |
| [`bc52cdd5`](https://github.com/nix-community/home-manager/commit/bc52cdd5795e60850e860b5ccce7e8b9537d86f9) | `` direnv: Use ${getExe pkg} instead of ${pkg}/bin/pkg ``  |
| [`67c4c05c`](https://github.com/nix-community/home-manager/commit/67c4c05c29d2bd72cef7376c38351cb30af4d708) | `` direnv: Apply nushell env transformations ``            |
| [`8f38f1a2`](https://github.com/nix-community/home-manager/commit/8f38f1a231547a9d9bc9f0233eb9c92cfb89f025) | `` docs: fix broken home-manager options link ``           |
| [`0360475e`](https://github.com/nix-community/home-manager/commit/0360475ee0fc870bc450874da5b5d7b2a85a091b) | `` gradle: temporarily comment out the maintainer entry `` |
| [`4f258945`](https://github.com/nix-community/home-manager/commit/4f258945de476b54471b07645013f6aa6c8219bb) | `` thefuck: fix test case ``                               |
| [`c8c6a527`](https://github.com/nix-community/home-manager/commit/c8c6a52702a81ba01b905b2b3aa64f06d246f905) | `` sway: fix failing tests ``                              |