### PR TITLE
chore(flake/home-manager): `8b797c8e` -> `fb5ac0c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703155327,
-        "narHash": "sha256-Q25AEghhhOp+ImNN4PsAExi7DIB1INMlBSaggGz7q4w=",
+        "lastModified": 1703178811,
+        "narHash": "sha256-Orbqa8DvszYZ38XGWAs43hVs++czt2N6/Y0sFRLhJms=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8b797c8eea1eba7dfb47f6964103e6e0d134255f",
+        "rev": "fb5ac0c870a1b3ffea70e02ab1720d991ce812ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`fb5ac0c8`](https://github.com/nix-community/home-manager/commit/fb5ac0c870a1b3ffea70e02ab1720d991ce812ae) | `` nix-index: use interactive shell init for Fish `` |
| [`19a78437`](https://github.com/nix-community/home-manager/commit/19a784373439032363daeba0a991e5e59bbad178) | `` zoxide: use interactive shell init for Fish ``    |