### PR TITLE
chore(flake/nixos-hardware): `05fc10e0` -> `a15b6e52`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -460,11 +460,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1703537399,
-        "narHash": "sha256-UXLtyffpCzEp3/ggsARM7VRpj84odwM4yh/clyZsz2I=",
+        "lastModified": 1703545041,
+        "narHash": "sha256-nvQA+k1rSszrf4kA4eK2i/SGbzoXyoKHzzyzq/Jca1w=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "05fc10e09377a5e28c54b723da8691daaf44b0b5",
+        "rev": "a15b6e525f5737a47b4ce28445c836996fb2ea8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`a15b6e52`](https://github.com/NixOS/nixos-hardware/commit/a15b6e525f5737a47b4ce28445c836996fb2ea8c) | `` apple-t2: avoid import-from-derivation `` |
| [`65753f5d`](https://github.com/NixOS/nixos-hardware/commit/65753f5d1144e3bf468a6bfe464011b12c840792) | `` speed up ci using nix-eval-jobs ``        |