### PR TITLE
chore(flake/lanzaboote): `9186a778` -> `47032189`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -401,11 +401,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1702288664,
-        "narHash": "sha256-7ZGNXYyV1TTtqOCf/ndOFQoH3/+c5dp1QQB7tFDKWw4=",
+        "lastModified": 1703546602,
+        "narHash": "sha256-V5UGPWD0eGiDE2rmqMxNZf6kbnW8+1f5pJV0uyw96mY=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "9186a77827d83c49557af564f7cb437ca197b739",
+        "rev": "47032189f75d36fd024cb46a285c116f483e1241",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                             |
| --------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`872f9f3e`](https://github.com/nix-community/lanzaboote/commit/872f9f3ea8b2359e31efa5916dbb3b09d3cbf97c) | `` fix(deps): update rust crate anyhow to 1.0.76 `` |