### PR TITLE
chore(flake/home-manager): `45854459` -> `c24c2985`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -352,11 +352,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703674883,
-        "narHash": "sha256-Jna6MOmLdfgot+AopHv28L+wpwVDfaiafLtO7E4bkj0=",
+        "lastModified": 1703754036,
+        "narHash": "sha256-JpJdcj9Tg4lMuYikXDpajA8wOp+rHyn9RD2rKBEM4cQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "458544594ba7f0333cf5718045ee7a8eaf5de433",
+        "rev": "c24c298562fe41b39909f632c5a7151bbf6b4628",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`c24c2985`](https://github.com/nix-community/home-manager/commit/c24c298562fe41b39909f632c5a7151bbf6b4628) | `` zsh.prezto: fix path in example for 'pmoduleDirs' `` |
| [`0f11c140`](https://github.com/nix-community/home-manager/commit/0f11c140657cc1d78febec4d6aca3836422600d2) | `` osmscout-server: add module ``                       |