### PR TITLE
chore(flake/nixos-hardware): `a15b6e52` -> `1bace8ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -460,11 +460,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1703545041,
-        "narHash": "sha256-nvQA+k1rSszrf4kA4eK2i/SGbzoXyoKHzzyzq/Jca1w=",
+        "lastModified": 1703850206,
+        "narHash": "sha256-2oJ6XMp1sR+uZstsWDVxzs0E8HULGXBMdx8cLJsj9+8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a15b6e525f5737a47b4ce28445c836996fb2ea8c",
+        "rev": "1bace8cedd4fa4ea9efb5ea17a06b9d92af86206",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                       |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`1bace8ce`](https://github.com/NixOS/nixos-hardware/commit/1bace8cedd4fa4ea9efb5ea17a06b9d92af86206) | `` feat: add dell latitude 7390 module ``                                     |
| [`8ae5b3ff`](https://github.com/NixOS/nixos-hardware/commit/8ae5b3ff81d4c1e57f76e3237efeb0438f9d4f71) | `` purism librem5r4: linuxPackages_librem5: 6.5.6-librem5 -> 6.6.6-librem5 `` |