### PR TITLE
chore(flake/stylix): `9c3b6122` -> `5a7f3f15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -619,11 +619,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703773575,
-        "narHash": "sha256-H7JYVnqK7EOa/xq45NCq+my4VAAyTUOlxW8++/Hxa1o=",
+        "lastModified": 1703880383,
+        "narHash": "sha256-YAIbWRAKOCaWDQ4A29xXr79VTuAk9lPJSPYhMBk/VjU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "9c3b61224afab35604508d063f6a27894bffc273",
+        "rev": "5a7f3f15ccc2a272e5873bb44fe378ab5d99e0ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                     |
| --------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`5a7f3f15`](https://github.com/danth/stylix/commit/5a7f3f15ccc2a272e5873bb44fe378ab5d99e0ff) | `` Add guide for creating modules :memo: `` |
| [`5b18f2a3`](https://github.com/danth/stylix/commit/5b18f2a33b4ea3fcf0cdea15b70f03afaf8e0d52) | `` Add screenshot of KDE :memo: ``          |