### PR TITLE
chore(flake/darwin): `8a832127` -> `0a3afdc6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -201,11 +201,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703649338,
-        "narHash": "sha256-n2MkBotGgTQsfB+wH09R+otBwYCvGCsnHX7eUMGkKL0=",
+        "lastModified": 1703887437,
+        "narHash": "sha256-awkp9jyXf8aV9eDWhLdKUqUdg9HfZKe0NdQebSiC0VA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "8a8321271f0835fae2cb195e1137cb381fdbcc8e",
+        "rev": "0a3afdc60042d8e1c2deb63bdfa017acc424a397",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                            |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
| [`f6cf46f7`](https://github.com/LnL7/nix-darwin/commit/f6cf46f7bc02650fb027b4e997dfc1365f4c8ff9) | `` GlobalPreferences: fix mouse scaling example `` |