### PR TITLE
chore(flake/pre-commit-hooks): `7f35ec30` -> `9d3d7e18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -538,11 +538,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1703426812,
-        "narHash": "sha256-aODSOH8Og8ne4JylPJn+hZ6lyv6K7vE5jFo4KAGIebM=",
+        "lastModified": 1703939133,
+        "narHash": "sha256-Gxe+mfOT6bL7wLC/tuT2F+V+Sb44jNr8YsJ3cyIl4Mo=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "7f35ec30d16b38fe0eed8005933f418d1a4693ee",
+        "rev": "9d3d7e18c6bc4473d7520200d4ddab12f8402d38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                        |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------ |
| [`dfb9eeec`](https://github.com/cachix/pre-commit-hooks.nix/commit/dfb9eeec99272fcb2776d39ac634275715bc1549) | `` feat: add juliaformatter `` |