### PR TITLE
chore(flake/darwin): `0a3afdc6` -> `1a41453c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -201,11 +201,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703887437,
-        "narHash": "sha256-awkp9jyXf8aV9eDWhLdKUqUdg9HfZKe0NdQebSiC0VA=",
+        "lastModified": 1703990467,
+        "narHash": "sha256-LItEeQVwDfLnavNskwdfRnonbEdq8DYiJlWRtF+bwng=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "0a3afdc60042d8e1c2deb63bdfa017acc424a397",
+        "rev": "1a41453cba42a3a1af2fff003be455ddbd75386c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message              |
| ------------------------------------------------------------------------------------------------ | -------------------- |
| [`59bef440`](https://github.com/LnL7/nix-darwin/commit/59bef44059fbd0b80aed887c26f4cf74e517244a) | `` Fix type error `` |