### PR TITLE
chore(flake/home-manager): `2e8634c2` -> `f06edaf1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -352,11 +352,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703995158,
-        "narHash": "sha256-oYMwbObpWheGeeNWY1LjO/+omrbAWDNdyzNDxTr2jo8=",
+        "lastModified": 1704099363,
+        "narHash": "sha256-tRFfi71My6lnLsCzvFEA4imaNlEaHr85lz7hMf4ZpPU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2e8634c252890cb38c60ab996af04926537cbc27",
+        "rev": "f06edaf18b119da7bb301eebbf87971bbb9fb162",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`f06edaf1`](https://github.com/nix-community/home-manager/commit/f06edaf18b119da7bb301eebbf87971bbb9fb162) | `` lorri: unbreak due to too tight sandboxing `` |
| [`b7ef79bc`](https://github.com/nix-community/home-manager/commit/b7ef79bcf47c002bd6ae81a52bd3f233297edbde) | `` Translate using Weblate (Ukrainian) ``        |