### PR TITLE
chore(flake/nixos-hardware): `316bc983` -> `f752581d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -460,11 +460,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1704061647,
-        "narHash": "sha256-M/Kxfmb/fkgOz94jQ9eLFpXOhjQJ3CRmdPhVIVXqJmg=",
+        "lastModified": 1704124233,
+        "narHash": "sha256-lBHs/yUtkcGgapHRS31oOb5NqvnVrikvktGOW8rK+sE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "316bc98323fe3a7e7f72dbbbe68dce0cce3d4984",
+        "rev": "f752581d6723a10da7dfe843e917a3b5e4d8115a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`f752581d`](https://github.com/NixOS/nixos-hardware/commit/f752581d6723a10da7dfe843e917a3b5e4d8115a) | `` Added file for HP EliteBook 845 G8 and updated flake and README `` |