### PR TITLE
chore(flake/nixos-hardware): `5bf829d7` -> `8e34f334`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -460,11 +460,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1704228290,
-        "narHash": "sha256-M3y1ADeFVdPTV/bJXvO5QHDYFujzpJNblkfIgECTxGc=",
+        "lastModified": 1704266875,
+        "narHash": "sha256-luA5SGmeIRZlgLfSLUuR3eacS63q2bJ0Yywqak5lj3E=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "5bf829d72ccdc05be3343afd81bd922d5748ef4e",
+        "rev": "8e34f33464d77bea2d5cf7dc1066647b1ad2b324",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`8e34f334`](https://github.com/NixOS/nixos-hardware/commit/8e34f33464d77bea2d5cf7dc1066647b1ad2b324) | `` starfive visionfive2: write u-boot.itb to mtd2 ``                        |
| [`dd78777e`](https://github.com/NixOS/nixos-hardware/commit/dd78777e1275a646a214e66f9b9157d304250030) | `` starfive visionfive2: rework firmware build/update scripts ``            |
| [`637fba09`](https://github.com/NixOS/nixos-hardware/commit/637fba094214ce2e3ea71c1c2e73d1a2ba95bfd1) | `` starfive visionfive2: use upstream u-boot v2024.01-rc5 ``                |
| [`db4589c6`](https://github.com/NixOS/nixos-hardware/commit/db4589c6aa99135e320429e203e1b45de2f98d3e) | `` starfive visionfive2: adjust opensbi build params to match u-boot doc `` |