### PR TITLE
chore(flake/stylix): `5a7f3f15` -> `9bc1900b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -619,11 +619,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703880383,
-        "narHash": "sha256-YAIbWRAKOCaWDQ4A29xXr79VTuAk9lPJSPYhMBk/VjU=",
+        "lastModified": 1704308480,
+        "narHash": "sha256-88ICCdJyYYtsolRnPhI9IF+bhUIVUyhJ7nrKcKPgf6M=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "5a7f3f15ccc2a272e5873bb44fe378ab5d99e0ff",
+        "rev": "9bc1900b6888efdda39c2e02c7c8666911b72608",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                       |
| --------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`9bc1900b`](https://github.com/danth/stylix/commit/9bc1900b6888efdda39c2e02c7c8666911b72608) | `` Fix color consistency in WezTerm (#209) `` |