### PR TITLE
chore(flake/nixpkgs): `b0d36bd0` -> `bd645e86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703961334,
-        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
+        "lastModified": 1704194953,
+        "narHash": "sha256-RtDKd8Mynhe5CFnVT8s0/0yqtWFMM9LmCzXv/YKxnq4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
+        "rev": "bd645e8668ec6612439a9ee7e71f7eac4099d4f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`4a703f10`](https://github.com/NixOS/nixpkgs/commit/4a703f1081fdb3736d56f343c0f8689511cc56b3) | `` emacsPackages.codeium: init at 1.6.13 ``                                   |
| [`86530be0`](https://github.com/NixOS/nixpkgs/commit/86530be0e330944072493b275ec534e229d7d2e5) | `` python310Packages.apprise: 1.7.0 -> 1.7.1 ``                               |
| [`a8cdcb94`](https://github.com/NixOS/nixpkgs/commit/a8cdcb9427def647e707056002cf0e06019239e9) | `` ocamlPackages.js_of_ocaml: 5.4.0 -> 5.5.2 ``                               |
| [`b462bbfc`](https://github.com/NixOS/nixpkgs/commit/b462bbfc5d20aca4716ff7fc7954df0ebb0f721f) | `` atlas: 0.16.0 -> 0.17.0 ``                                                 |
| [`1276ce9b`](https://github.com/NixOS/nixpkgs/commit/1276ce9b5ec0687cdceea897643f127a25cce836) | `` panoply: 5.3.0 -> 5.3.1 ``                                                 |
| [`6f5773d2`](https://github.com/NixOS/nixpkgs/commit/6f5773d213a50584521986e08ada523fe1b0950e) | `` maintainers: update handle for dixslyf ``                                  |
| [`f7e083c2`](https://github.com/NixOS/nixpkgs/commit/f7e083c2c43072087789f5b7995ac26b4a607f3f) | `` php81Packages.php-cs-fixer: 3.42.0 -> 3.45.0 ``                            |
| [`18a01f3f`](https://github.com/NixOS/nixpkgs/commit/18a01f3fd956de7fc6d32e5e241e949671e7e8bf) | `` haskellPackages: mark builds failing on hydra as broken ``                 |
| [`c60ed181`](https://github.com/NixOS/nixpkgs/commit/c60ed18170048087f93d0305f11e2db571e66eb0) | `` terraform-providers.migadu: init at 2023.12.21 ``                          |
| [`01a20633`](https://github.com/NixOS/nixpkgs/commit/01a20633176204d89da07c550c4fa4cd7c7cf7c4) | `` doc/python: update buildPythonApplication example ``                       |
| [`111c8d73`](https://github.com/NixOS/nixpkgs/commit/111c8d73a479f707e920307564c0a16285d1d41a) | `` haskellPackages.postgrest: Add more build-depends for 12.0.2 ``            |
| [`677d868c`](https://github.com/NixOS/nixpkgs/commit/677d868ca34ccf131ec0c1b3a18e5fa5ee79af00) | `` haskellPackages.postgrest: 11.2.2 -> 12.0.2 ``                             |
| [`d9e17456`](https://github.com/NixOS/nixpkgs/commit/d9e1745681105a35cf50bc4ddb1052edaa622c7e) | `` postgrest: add top-level package ``                                        |
| [`36f775a9`](https://github.com/NixOS/nixpkgs/commit/36f775a9bcc6be3195ddceb304183c647478afab) | `` haskellPackages.postgrest: 10.1.1 -> 11.2.2 and fix build ``               |
| [`86d4d1ad`](https://github.com/NixOS/nixpkgs/commit/86d4d1ad174b228b0a56e639b20abc11bc30ac0b) | `` bambu-studio: add gst-plugins-good (#274383) ``                            |
| [`c6d5e289`](https://github.com/NixOS/nixpkgs/commit/c6d5e289ecd09af438cd69299f18dad7fd1ce6eb) | `` mimir: 2.10.5 -> 2.11.0 ``                                                 |
| [`4bcd4d5e`](https://github.com/NixOS/nixpkgs/commit/4bcd4d5e45b7bded2c86e9fc9fc720f80ce82237) | `` nextcloud.packages.apps.user_oidc: init at 1.3.5 ``                        |
| [`33eccb05`](https://github.com/NixOS/nixpkgs/commit/33eccb059a5a2b09fe6ff9fd930c4902c3868a67) | `` nextcloud*.packages.apps: update ``                                        |
| [`57f8b6a7`](https://github.com/NixOS/nixpkgs/commit/57f8b6a77fccc0ad6ae630cc1d0ab7334f481e24) | `` theharvester: replace orjson with ujson ``                                 |
| [`5ff78113`](https://github.com/NixOS/nixpkgs/commit/5ff7811393346a6d6e50e29ab3aade411a5cc3fe) | `` makeInitrdNGTool: 0.1.0 -> 0.1.0 ``                                        |
| [`ccac72b1`](https://github.com/NixOS/nixpkgs/commit/ccac72b1471e56c9cfa96ba61f89ee715c87ee47) | `` satty: add myself as maintainer ``                                         |
| [`c82f8a6e`](https://github.com/NixOS/nixpkgs/commit/c82f8a6ed73ec33590b8e809b4e4a799d7b71442) | `` satty: add shell completions ``                                            |
| [`9e33a4c6`](https://github.com/NixOS/nixpkgs/commit/9e33a4c688915a1a105b09650e49ee232da6d8d0) | `` baboossh: 1.2.0 -> 1.2.1 ``                                                |
| [`4985198d`](https://github.com/NixOS/nixpkgs/commit/4985198defdc9f3c85fcaa459da31de2056184a7) | `` the-way: 0.20.1 -> 0.20.2 ``                                               |
| [`38f96462`](https://github.com/NixOS/nixpkgs/commit/38f96462bf8db319baaf9a59c93f37c3f822116c) | `` newsraft: refactor ``                                                      |
| [`2ee82b8b`](https://github.com/NixOS/nixpkgs/commit/2ee82b8bb13551577468dc899035fd05ba188b78) | `` licensure: init at 0.3.2 ``                                                |
| [`5518af0a`](https://github.com/NixOS/nixpkgs/commit/5518af0a558dde9ce869098799be461bc74485ab) | `` haskellPackages: Fix eval errors ``                                        |
| [`7b4156ed`](https://github.com/NixOS/nixpkgs/commit/7b4156eddac0142fc02dba8f88c958f71e9d0baa) | `` haskellPackages: Fix eval errors ``                                        |
| [`dffa76ad`](https://github.com/NixOS/nixpkgs/commit/dffa76ad6e59a366e08a30e6d81fb4a320e0452e) | `` release-haskell.nix: Cleanup missing compiler names ``                     |
| [`2684e3ea`](https://github.com/NixOS/nixpkgs/commit/2684e3ea4ba048d751f1b60cd45554fa7fa3ea1d) | `` haskellPackages: mark builds failing on hydra as broken ``                 |
| [`823ca129`](https://github.com/NixOS/nixpkgs/commit/823ca129c50a150505d6485de1ed23e32c7b1f70) | `` cockpit: 306 -> 307 ``                                                     |
| [`15257e45`](https://github.com/NixOS/nixpkgs/commit/15257e4500f260e7cbfb3783db2d8aabd17e4114) | `` haskellPackages: regenerate package set based on current config ``         |
| [`ca53b826`](https://github.com/NixOS/nixpkgs/commit/ca53b82688e52bcb1600646b10a0802696bf6281) | `` fzf-make: 0.13.0 -> 0.14.0 ``                                              |
| [`79b42007`](https://github.com/NixOS/nixpkgs/commit/79b42007faf67d2dd13a6761b8356f941116dc10) | `` trompeloeil: 46 -> 47 ``                                                   |
| [`4f9e9890`](https://github.com/NixOS/nixpkgs/commit/4f9e98905e1ba032cd0fa76145994448d86f107f) | `` nixos/auditd: fix typo ``                                                  |
| [`309913ce`](https://github.com/NixOS/nixpkgs/commit/309913ce73327a0e2e424efd08b050c544adbd10) | `` templ: 0.2.476 -> 0.2.501 ``                                               |
| [`c8b5413f`](https://github.com/NixOS/nixpkgs/commit/c8b5413fa6838f65a62a0682a1cd56008fd028bb) | `` haskell.packages.ghc865Binary: drop unevaluatable packages ``              |
| [`e649d536`](https://github.com/NixOS/nixpkgs/commit/e649d536183f9839afe0f42fec628bfbd0af0271) | `` haskell.packages.ghc810: drop unevaluatable packages ``                    |
| [`aa84d903`](https://github.com/NixOS/nixpkgs/commit/aa84d903e16ebfe60fecac34133c091045a8f29a) | `` haskellPackages.compact: Unmark broken ``                                  |
| [`8345efda`](https://github.com/NixOS/nixpkgs/commit/8345efdaae25188aba8123cdafd3b623e0631aac) | `` dump1090: fix build on darwin ``                                           |
| [`6f10b0ed`](https://github.com/NixOS/nixpkgs/commit/6f10b0edb23c09fa308799146054096915d5fff3) | `` redis-plus-plus: 1.3.10 -> 1.3.11 ``                                       |
| [`258151d1`](https://github.com/NixOS/nixpkgs/commit/258151d138300f381bf1d94ddd4228045ceec901) | `` haskellPackages.update-nix-fetchgit: Fix build ``                          |
| [`a55180dc`](https://github.com/NixOS/nixpkgs/commit/a55180dc5f14ab9b03e09cef6f222fa9b759c7bd) | `` mlib: 0.7.0 -> 0.7.2 ``                                                    |
| [`9f37ee33`](https://github.com/NixOS/nixpkgs/commit/9f37ee33d7bbda521af2e4b6b5106f11216bbcc8) | `` zigbee2mqtt: 1.34.0 -> 1.35.0 ``                                           |
| [`9d21cb87`](https://github.com/NixOS/nixpkgs/commit/9d21cb87393ba0d70ad7ca1abec2a9e34c280905) | `` mainsail: 2.9.0 -> 2.9.1 ``                                                |
| [`b629581d`](https://github.com/NixOS/nixpkgs/commit/b629581dc93787c611962c0b2580e8295b2991ac) | `` release-haskell: Correctly disable hls jobs on ghc 8.10.7 ``               |
| [`a02e31d0`](https://github.com/NixOS/nixpkgs/commit/a02e31d0a59efcbad44903b019845e7b0ce4a836) | `` gimoji: 0.7.1 -> 0.7.2 ``                                                  |
| [`f86e2d36`](https://github.com/NixOS/nixpkgs/commit/f86e2d36bdb8dd56d4c4f64d32d919a44c76c4ec) | `` fzf-make: 0.12.0 -> 0.13.0 ``                                              |
| [`c83c12f4`](https://github.com/NixOS/nixpkgs/commit/c83c12f444f6ed4e8351cd249e3ad4840cfe3f29) | `` go2rtc: 1.8.4 -> 1.8.5 ``                                                  |
| [`393a1229`](https://github.com/NixOS/nixpkgs/commit/393a1229937944b1a1aaae93b0dd0fbf40d24f5f) | `` dq: 20230101 -> 20240101 ``                                                |
| [`48d6f26d`](https://github.com/NixOS/nixpkgs/commit/48d6f26deb058a929061d71fbc7807edd037f5f5) | `` libayatana-common: 0.9.9 -> 0.9.10 ``                                      |
| [`2e55cb9b`](https://github.com/NixOS/nixpkgs/commit/2e55cb9b289cef71a988fbaf0db4a4c12ee6a7c6) | `` cansina: init at 0.9 ``                                                    |
| [`0c9dbdf9`](https://github.com/NixOS/nixpkgs/commit/0c9dbdf9a5d92bcfbab9e9a357d99a6dc10c7396) | `` cargo-tally: 1.0.32 -> 1.0.33 ``                                           |
| [`46139347`](https://github.com/NixOS/nixpkgs/commit/46139347fa759767b22465ed3f78eca0659479cf) | `` trueseeing: refactor ``                                                    |
| [`4b0b110a`](https://github.com/NixOS/nixpkgs/commit/4b0b110a090532b6dceb7292dfcb4804cd4c8563) | `` trueseeing: 2.1.7 -> 2.1.9 ``                                              |
| [`ed9ebf83`](https://github.com/NixOS/nixpkgs/commit/ed9ebf8375f14c8a4b5d296c9bd92ff69cca3a8c) | `` gtksourceview4: Backport Nix syntax highlighting support ``                |
| [`b813848d`](https://github.com/NixOS/nixpkgs/commit/b813848d317724cb98c76bf2a70d839cb666bdb1) | `` miniaudicle: 1.5.0.7 -> 1.5.2.0 ``                                         |
| [`14183718`](https://github.com/NixOS/nixpkgs/commit/1418371835e49be9cb191ccc92cdd541672ee9b7) | `` python311Packages.plugwise: refactor ``                                    |
| [`695eb35d`](https://github.com/NixOS/nixpkgs/commit/695eb35d6d220f76b344fe3484cc6b776cd8cf1b) | `` python311Packages.plugwise: 0.35.4 -> 0.36.2 ``                            |
| [`ab1ab1e4`](https://github.com/NixOS/nixpkgs/commit/ab1ab1e437fc1fa8c0d79579786f6edf2beb8ae9) | `` keybase: 6.2.3 -> 6.2.4 ``                                                 |
| [`10c06cb0`](https://github.com/NixOS/nixpkgs/commit/10c06cb0608bfad0ad3b1e83017f208fca859cdb) | `` nginx: enable ktls support by default ``                                   |
| [`23a4b38a`](https://github.com/NixOS/nixpkgs/commit/23a4b38ac8d2d0d12e0256dbb15ccc3c8f622fb4) | `` openresty: 1.21.4.1 -> 1.21.4.3 ``                                         |
| [`709a88aa`](https://github.com/NixOS/nixpkgs/commit/709a88aa440570f203b0622b2d990109b3d227e5) | `` fzf: 0.44.1 -> 0.45.0 ``                                                   |
| [`94d804a2`](https://github.com/NixOS/nixpkgs/commit/94d804a2c98abf0360964dea5609d02dd51f626a) | `` act: 0.2.56 -> 0.2.57 ``                                                   |
| [`cb12e6ca`](https://github.com/NixOS/nixpkgs/commit/cb12e6cac5f8f13ddd32df8419f50dc95dad550c) | `` wmfocus: 1.4.0 -> 1.5.0 ``                                                 |
| [`c4d3826a`](https://github.com/NixOS/nixpkgs/commit/c4d3826a946c420116973a4fbd7dd1d3bd76a36a) | `` spicetify-cli: 2.28.1 -> 2.29.1 ``                                         |
| [`79489683`](https://github.com/NixOS/nixpkgs/commit/79489683b0c57c896c777ce3b53e34a16621d7df) | `` python311Packages.sanic-routing: 23.6.0 -> 23.12.0 ``                      |
| [`ae04b3b5`](https://github.com/NixOS/nixpkgs/commit/ae04b3b5457ffbff907962264b2cf9bfe6072cad) | `` python311Packages.pyschlage: 2023.12.0 -> 2023.12.1 ``                     |
| [`d6515b70`](https://github.com/NixOS/nixpkgs/commit/d6515b70b349da586c922efc43a25c8abde73cba) | `` python311Packages.mdformat-mkdocs: 1.1.0 -> 1.1.2 ``                       |
| [`9e9e68f4`](https://github.com/NixOS/nixpkgs/commit/9e9e68f4086fd59cbee925101a55ea9f84dfb720) | `` python311Packages.gspread: 5.12.3 -> 5.12.4 ``                             |
| [`a279d74f`](https://github.com/NixOS/nixpkgs/commit/a279d74f99d44f3a20748b39cdb7a3a55cc1c062) | `` plocate: 1.1.19 -> 1.1.20 ``                                               |
| [`914edb9f`](https://github.com/NixOS/nixpkgs/commit/914edb9f66f64d1ba5e84588a076be871bf298b6) | `` ibus-engines.typing-booster-unwrapped: 2.24.5 -> 2.24.10 ``                |
| [`eeae22ce`](https://github.com/NixOS/nixpkgs/commit/eeae22cecc71765269b3e7f46a2cc9a4fa35eb24) | `` dump1090: 8.2 -> 9.0 ``                                                    |
| [`7c70bf80`](https://github.com/NixOS/nixpkgs/commit/7c70bf8082afea729ddeaf620279b002315233b1) | `` arping: 2.23 -> 2.24 ``                                                    |
| [`6115d4af`](https://github.com/NixOS/nixpkgs/commit/6115d4af56e1f25572f028890482071aac75e7e4) | `` fend: 1.3.3 -> 1.4.0 ``                                                    |
| [`0d1851c0`](https://github.com/NixOS/nixpkgs/commit/0d1851c0c9f2dd2cd3a694bd500a8ce9ab2d3a77) | `` maintainers: add shard7 ``                                                 |
| [`47705cf8`](https://github.com/NixOS/nixpkgs/commit/47705cf81cf0f13ecd4e80bdd1b29725bf4acf35) | `` git-mit: 5.12.181 -> 5.12.182 ``                                           |
| [`e9591a61`](https://github.com/NixOS/nixpkgs/commit/e9591a61dab61dd824678eb93c8394a29b5f830b) | `` gickup: 0.10.24 -> 0.10.25 ``                                              |
| [`3e1111f2`](https://github.com/NixOS/nixpkgs/commit/3e1111f227d977e181e9dd88774b9873ddb61bf8) | `` go: set meta.mainProgram to go ``                                          |
| [`04e49fa8`](https://github.com/NixOS/nixpkgs/commit/04e49fa8ecf11e1739c2de43fd22d934038cbdf5) | `` maintainers/maintainer-list.nix: Update details for OPNA2608 ``            |
| [`0ef56bec`](https://github.com/NixOS/nixpkgs/commit/0ef56bec7281e2372338f2dfe7c13327ce96f6bb) | `` codux: 15.16.2 -> 15.17.2 ``                                               |
| [`a318f323`](https://github.com/NixOS/nixpkgs/commit/a318f323b5e369b2ca4cd233bd685a03d6a5c2e0) | `` broot: 1.30.2 -> 1.31.0 ``                                                 |
| [`b0291f7e`](https://github.com/NixOS/nixpkgs/commit/b0291f7e32d028fd251e340e536b7b955da8e09b) | `` audiobookshelf: 2.7.0 -> 2.7.1 ``                                          |
| [`53682610`](https://github.com/NixOS/nixpkgs/commit/5368261014def1ba113f1d67128df863bfdc4f26) | `` liferea: enable parallel builds ``                                         |
| [`c5be9c5b`](https://github.com/NixOS/nixpkgs/commit/c5be9c5bb60a4dff813a0f8209971604616d94e4) | `` ruff: use `ruff-lsp`, not the `python3.pkgs.ruff-lsp` alias ``             |
| [`592a779f`](https://github.com/NixOS/nixpkgs/commit/592a779f3c5e7bce1a02027abe11b7996816223f) | `` erlang_26: 26.2 -> 26.2.1 ``                                               |
| [`4c1d5da1`](https://github.com/NixOS/nixpkgs/commit/4c1d5da1b298f6f0316a52349c5b085c6c02db8e) | `` bruno: package from source ``                                              |
| [`4b1dcd35`](https://github.com/NixOS/nixpkgs/commit/4b1dcd356d0db6e6952f6fbe0f920cac6d02b376) | `` maltego: init at 4.6.0 ``                                                  |
| [`2a2c4edd`](https://github.com/NixOS/nixpkgs/commit/2a2c4edd4f587c7b74b4401236f49e9adbc56c57) | `` erlang_24: 24.3.4.14 -> 24.3.4.15 ``                                       |
| [`fe404786`](https://github.com/NixOS/nixpkgs/commit/fe40478617e57befb064f42de8e14e62f9bcb95f) | `` erlang_25: 25.3.2.7 -> 25.3.2.8 ``                                         |
| [`5adbbf17`](https://github.com/NixOS/nixpkgs/commit/5adbbf17285ed5eda804b2829b23d1248492d82e) | `` flare-signal: 0.11.0 -> 0.11.1 ``                                          |
| [`d996dfce`](https://github.com/NixOS/nixpkgs/commit/d996dfce0985bfa9cff280ce91f3ffef6f56b80d) | `` prismlauncher: fix meta using lib.version instead of finalAttrs.version `` |
| [`e79af9e6`](https://github.com/NixOS/nixpkgs/commit/e79af9e68ddaa1c531aaa04eaf7082e3c426e6d5) | `` eigenmath: unstable-2023-12-12 -> unstable-2023-12-31 ``                   |
| [`3b4bd150`](https://github.com/NixOS/nixpkgs/commit/3b4bd150c643adfe1fa9f3b886e55f687f7d92e5) | `` aliyun-cli: 3.0.190 -> 3.0.191 ``                                          |
| [`8a527465`](https://github.com/NixOS/nixpkgs/commit/8a527465d3823b3bc7f22a7d324a511f2acaddd7) | `` python311Packages.unidata-blocks: 0.0.8 -> 0.0.9 ``                        |
| [`46553919`](https://github.com/NixOS/nixpkgs/commit/465539197794e0f0250cad662d1c5de2d25de51e) | `` home-assistant: update component packages ``                               |
| [`6af26577`](https://github.com/NixOS/nixpkgs/commit/6af265770334659e9487c9ac5b3e4f711eec49ec) | `` python311Packages.vacuum-map-parser-roborock: init at 0.1.1 ``             |
| [`950bd2aa`](https://github.com/NixOS/nixpkgs/commit/950bd2aa0b4286db62338de3678212cf6bc40c26) | `` python311Packages.vacuum-map-parser-base: init at 0.1.2 ``                 |
| [`2207adf4`](https://github.com/NixOS/nixpkgs/commit/2207adf4f7d9fa2535bdf77deccf59f74c102a21) | `` ncpamixer: 1.3.3.3 -> 1.3.7 ``                                             |