### PR TITLE
chore(flake/nixos-hardware): `8e34f334` -> `03e00336`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -460,11 +460,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1704266875,
-        "narHash": "sha256-luA5SGmeIRZlgLfSLUuR3eacS63q2bJ0Yywqak5lj3E=",
+        "lastModified": 1704445197,
+        "narHash": "sha256-GGtUGSXlwWM3bNTlNgFtsM4TJ2xFMecLjKbfiqOgbZI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "8e34f33464d77bea2d5cf7dc1066647b1ad2b324",
+        "rev": "03e00336034c75e67609e953ded47c23de7f90f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`03e00336`](https://github.com/NixOS/nixos-hardware/commit/03e00336034c75e67609e953ded47c23de7f90f7) | `` framework amd: add pkgs import ``                                       |
| [`3a6288ef`](https://github.com/NixOS/nixos-hardware/commit/3a6288ef8332ea79b618d40c7f113363286fc161) | `` framework amd: apply headset mic fix on older kernels ``                |
| [`50944cf0`](https://github.com/NixOS/nixos-hardware/commit/50944cf03617a586ae0dfd445c991ac8833a8c20) | `` Add majorVersion option to 6.6.x ``                                     |
| [`7fd5585e`](https://github.com/NixOS/nixos-hardware/commit/7fd5585e07386e8cf1f335b3950e52dc1f7d4b5a) | `` framework AMD 7040: add instructions on how to update fingerprint fw `` |