### PR TITLE
chore(flake/pre-commit-hooks): `9d3d7e18` -> `44493e2b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -538,11 +538,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1703939133,
-        "narHash": "sha256-Gxe+mfOT6bL7wLC/tuT2F+V+Sb44jNr8YsJ3cyIl4Mo=",
+        "lastModified": 1704668415,
+        "narHash": "sha256-BMzNHFod53iiU4lkR5WHwqQCFmaCLq85sUCskXneXlA=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "9d3d7e18c6bc4473d7520200d4ddab12f8402d38",
+        "rev": "44493e2b3c3ebcd39a9947e9ed9f2c2af164ec4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message          |
| ------------------------------------------------------------------------------------------------------------ | ---------------- |
| [`a44c73ba`](https://github.com/cachix/pre-commit-hooks.nix/commit/a44c73ba3e41ed048363c6aff972185a9c7b641e) | `` add cljfmt `` |