### PR TITLE
chore(flake/nixpkgs): `bd645e86` -> `46ae0210`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704194953,
-        "narHash": "sha256-RtDKd8Mynhe5CFnVT8s0/0yqtWFMM9LmCzXv/YKxnq4=",
+        "lastModified": 1704538339,
+        "narHash": "sha256-1734d3mQuux9ySvwf6axRWZRBhtcZA9Q8eftD6EZg6U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bd645e8668ec6612439a9ee7e71f7eac4099d4f6",
+        "rev": "46ae0210ce163b3cba6c7da08840c1d63de9c701",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`b67fc24e`](https://github.com/NixOS/nixpkgs/commit/b67fc24e4acf7189590d229c2f286896527f849e) | `` electron_28: 28.1.0 -> 28.1.1 ``                                              |
| [`093a19a0`](https://github.com/NixOS/nixpkgs/commit/093a19a07c42f8d90c1b91825f4e7235010c3035) | `` electron_27: 27.2.0 -> 27.2.1 ``                                              |
| [`01aef81d`](https://github.com/NixOS/nixpkgs/commit/01aef81d1bee5ef14827c6151e9025e250b247a8) | `` electron_26: 26.6.3 -> 26.6.4 ``                                              |
| [`610af56d`](https://github.com/NixOS/nixpkgs/commit/610af56da4680dd5b6f195b3066d3ad8907aa7ed) | `` nixos/tests/sway: fix alacritty xwayland test ``                              |
| [`f6c220ab`](https://github.com/NixOS/nixpkgs/commit/f6c220abd4a0c5ee47066501b64a2e750e4d9744) | `` ocamlPackages.ocamlbuild: 0.14.2 -> 0.14.3 ``                                 |
| [`338a8dc6`](https://github.com/NixOS/nixpkgs/commit/338a8dc6c108e5cae1e2d24dc131bdef4f6e24c1) | `` gitlab: 16.5.3 -> 16.5.4 (#279044) ``                                         |
| [`1fe3d710`](https://github.com/NixOS/nixpkgs/commit/1fe3d7105b78a54d65f92b93ff0a54d923847d46) | `` python311Packages.homeassistant-stubs: 2024.1.0 -> 2024.1.1 ``                |
| [`d7bccab0`](https://github.com/NixOS/nixpkgs/commit/d7bccab0bf72b952fde6e17c8da9f606f1e55dd2) | `` release-note: change binary name and desktop entry for firefox-* ``           |
| [`23b33e39`](https://github.com/NixOS/nixpkgs/commit/23b33e39cc33ad034a647ae575e7fa1960179aa7) | `` firefox-esr: change binary name and desktop entry ``                          |
| [`0a39005d`](https://github.com/NixOS/nixpkgs/commit/0a39005deafd2dde10f0b0b721f0ee956c34f3e4) | `` firefox-beta: change binary name and desktop entry ``                         |
| [`8de91807`](https://github.com/NixOS/nixpkgs/commit/8de91807c079fa480d0ec004944a61e325fa35ae) | `` firefox-devedition: change binary name and desktop entry ``                   |
| [`f3b2842c`](https://github.com/NixOS/nixpkgs/commit/f3b2842c082771996b4d94eb0daa8481ed3e464d) | `` ruff-lsp: 0.0.48 -> 0.0.49 ``                                                 |
| [`a1bbf986`](https://github.com/NixOS/nixpkgs/commit/a1bbf98643e851f0a6ff40e0082c34e263190641) | `` python311Packages.homeassistant-pyozw: remove ``                              |
| [`94f7520b`](https://github.com/NixOS/nixpkgs/commit/94f7520bb6e457e8a1f076a0a3f5f739470e8142) | `` home-assistant: update disabled tests and dependencies ``                     |
| [`c3393e3a`](https://github.com/NixOS/nixpkgs/commit/c3393e3a4b79cc5300664bc1cb9908e302071955) | `` home-assistant: 2024.1.0 -> 2024.1.1 ``                                       |
| [`501f76b6`](https://github.com/NixOS/nixpkgs/commit/501f76b695da1065081080511a968fcf8e1a5a36) | `` python311Packages.zwave-js-server-python: 0.55.2 -> 0.55.3 ``                 |
| [`b8631ec6`](https://github.com/NixOS/nixpkgs/commit/b8631ec6ddf7786e4048da72ceb4019ac940d420) | `` python311Packages.python-tado: 0.17.2 -> 0.17.3 ``                            |
| [`efa9d685`](https://github.com/NixOS/nixpkgs/commit/efa9d6852c863ca5b9ef4651c639e9014bc690c2) | `` python311Packages.openwebifpy: 4.0.2 -> 4.0.4 ``                              |
| [`325617f0`](https://github.com/NixOS/nixpkgs/commit/325617f0066ae61d28b9821ddd3e38ebed754d6e) | `` python311Packages.orvibo: 1.1.1 -> 1.1.2 ``                                   |
| [`9121ed44`](https://github.com/NixOS/nixpkgs/commit/9121ed447f1f95b1d320e9d586eb72a01a787a8a) | `` python311Packages.dask-awkward: 2023.12.2 -> 2024.1.0 (#278949) ``            |
| [`0b882efc`](https://github.com/NixOS/nixpkgs/commit/0b882efce578e0273885cd735e49adee52687b84) | `` slurm: 23.11.0.1 -> 23.11.1.1 ``                                              |
| [`6b0de30a`](https://github.com/NixOS/nixpkgs/commit/6b0de30acc8b85caf2389468bc6f4428aedde835) | `` tt-rss-theme-feedly: fix license ``                                           |
| [`46796330`](https://github.com/NixOS/nixpkgs/commit/46796330dc624cfb60d694e4578a84c835ff563a) | `` tt-rss-theme-feedly: 3.1.0 -> 4.1.0 ``                                        |
| [`86fda41d`](https://github.com/NixOS/nixpkgs/commit/86fda41d8a052fc0ee2018e6e2fcbab6703ea019) | `` eclipse-mat: 1.13.0.20220615 -> 1.14.0.20230315 ``                            |
| [`63bdb6b2`](https://github.com/NixOS/nixpkgs/commit/63bdb6b2c2afa0744aad3d9ef73a7c06d73d48d7) | `` palemoon-bin: 32.5.1 -> 32.5.2 ``                                             |
| [`ca6b7b1b`](https://github.com/NixOS/nixpkgs/commit/ca6b7b1b6dd0af0d47b6c53f9ab1fbe5fc4e4a08) | `` libuev: restrict platforms ``                                                 |
| [`6998653d`](https://github.com/NixOS/nixpkgs/commit/6998653dd0a1679827b66ed24af0a849fd386e0e) | `` linux_latest-libre: 19453 -> 19459 ``                                         |
| [`a9686a80`](https://github.com/NixOS/nixpkgs/commit/a9686a8009ede52e55bb0701edf2c73ab3a4ebc3) | `` linux-rt_6_1: 6.1.67-rt20 -> 6.1.70-rt21 ``                                   |
| [`05632cd9`](https://github.com/NixOS/nixpkgs/commit/05632cd997bc21701a739d44c251a5511a99b481) | `` python311Packages.habluetooth: 2.0.1 -> 2.0.2 ``                              |
| [`cd3b8e76`](https://github.com/NixOS/nixpkgs/commit/cd3b8e76fc6c6ad65ae61e4c47d307c5b7271915) | `` python311Packages.habluetooth: drop dependency on home-assistant-bluetooth `` |
| [`50d7d58e`](https://github.com/NixOS/nixpkgs/commit/50d7d58e997240a10ce86bb970b45fb10e44b2f6) | `` python311Packages.home-assistant-bluetooth: 1.10.4 -> 1.11.0 ``               |
| [`f04b356c`](https://github.com/NixOS/nixpkgs/commit/f04b356c191ce84f910a7a48a369d22bc26fda68) | `` python311Packages.aiohomekit: 3.1.1 -> 3.1.2 ``                               |
| [`f91b4c1b`](https://github.com/NixOS/nixpkgs/commit/f91b4c1b9bc36b2a3a0d5d48d56c5ea9b0036ad1) | `` linux-rt_5_4: 5.4.257-rt87 -> 5.4.264-rt88 ``                                 |
| [`7a3b0bad`](https://github.com/NixOS/nixpkgs/commit/7a3b0badbf248ef11edcc18fe6318e8d77f23e5e) | `` linux-rt_5_15: 5.15.141-rt72 -> 5.15.145-rt73 ``                              |
| [`8c163c0d`](https://github.com/NixOS/nixpkgs/commit/8c163c0de372be1c54e13ecaaf8b3c8577cde9a6) | `` linux_5_10: 5.10.205 -> 5.10.206 ``                                           |
| [`7be7d002`](https://github.com/NixOS/nixpkgs/commit/7be7d0024b20f837f346466eaf78aa1b857abb43) | `` linux_5_15: 5.15.145 -> 5.15.146 ``                                           |
| [`897a5686`](https://github.com/NixOS/nixpkgs/commit/897a5686c05d8fa3ca7730e2f14968e1e927a220) | `` linux_6_1: 6.1.69 -> 6.1.71 ``                                                |
| [`d65452f5`](https://github.com/NixOS/nixpkgs/commit/d65452f59e7c314346261869cc9ad3f5137f0b64) | `` linux_6_6: 6.6.8 -> 6.6.10 ``                                                 |
| [`70d02d94`](https://github.com/NixOS/nixpkgs/commit/70d02d944d07cee6ed109fb8b5a84a1263f03ad7) | `` linux_testing: 6.7-rc7 -> 6.7-rc8 ``                                          |
| [`150aab9d`](https://github.com/NixOS/nixpkgs/commit/150aab9d0a6745c67b32013ed11f0d9f40f22757) | `` pythonPackages.sabctools: 7.1.2 -> 8.1.0 ``                                   |
| [`a72a7ad7`](https://github.com/NixOS/nixpkgs/commit/a72a7ad723ce2fa1f6c3a5e6d6563b7143cf60a9) | `` nixos/tests/slimserver: regex squeezelite number in log ``                    |
| [`f6813efd`](https://github.com/NixOS/nixpkgs/commit/f6813efd67f213d9f64bfa3644f869dc82f4d257) | `` morgen: 3.0.1 -> 3.1.6 ``                                                     |
| [`c74ab161`](https://github.com/NixOS/nixpkgs/commit/c74ab161ff32b3922d5893553a7dc5867597379a) | `` morgen: add updateScript and mainProgram ``                                   |
| [`852831a9`](https://github.com/NixOS/nixpkgs/commit/852831a9cd6780efd34676cc70f374bc934bdfc8) | `` maintainers: add justanotherariel ``                                          |
| [`d374e0f0`](https://github.com/NixOS/nixpkgs/commit/d374e0f0614b09416737ee8244a6dda6515107e2) | `` lightburn: vendor qt libraries ``                                             |
| [`a6a93bd7`](https://github.com/NixOS/nixpkgs/commit/a6a93bd71e77050a843c87e9ea28da39e1dae3d8) | `` lightburn: 1.2.01 -> 1.4.05 ``                                                |
| [`781a005d`](https://github.com/NixOS/nixpkgs/commit/781a005d9ed919bd0061ba876cf3fbcc51678d18) | `` resolve-march-native: 2.2.0 -> 5.0.2 ``                                       |
| [`d163ea41`](https://github.com/NixOS/nixpkgs/commit/d163ea4133312f04ebf8eb4875ea4b61400b4b5e) | `` ungoogled-chromium: 120.0.6099.129-1 -> 120.0.6099.199-1 ``                   |
| [`bfb4abb9`](https://github.com/NixOS/nixpkgs/commit/bfb4abb9eb8da927a02155e4f417b59080e6b7a1) | `` emacsPackages.codeium: refactor with melpaBuild ``                            |
| [`1922bc42`](https://github.com/NixOS/nixpkgs/commit/1922bc428b23986d9716fee48ae3ecdeb79bb3ec) | `` libiconvReal: 1.16 -> 1.17 ``                                                 |
| [`c9d145fa`](https://github.com/NixOS/nixpkgs/commit/c9d145fa2a584d04db8995f4401d44a103ebf183) | `` streamlink-twitch-gui-bin: 2.1.0 -> 2.4.1 ``                                  |
| [`a2f22ece`](https://github.com/NixOS/nixpkgs/commit/a2f22ececf5875e682c72b837804ef9648823d89) | `` pipe-viewer: 0.3.0 -> 0.4.8 ``                                                |
| [`c1d8fd1a`](https://github.com/NixOS/nixpkgs/commit/c1d8fd1a899280f7a92914b4ebdeb538842e98e0) | `` nixos/ddclient: make ExecStartPre a list ``                                   |
| [`26319774`](https://github.com/NixOS/nixpkgs/commit/26319774635104e7fea5db4318ae7180e6229674) | `` odin: dev-2023-12 -> dev-2024-01 ``                                           |
| [`e1695859`](https://github.com/NixOS/nixpkgs/commit/e16958593a16a89f3472583d644637a753fdb779) | `` cosmic-launcher: init at unstable-2023-12-13 ``                               |
| [`b2e4fd10`](https://github.com/NixOS/nixpkgs/commit/b2e4fd1049a3e92c898c99adc8832361fa7e1397) | `` graphicsmagick: fix passthru.tests ``                                         |
| [`e43872df`](https://github.com/NixOS/nixpkgs/commit/e43872dfc0f26e5408f11dbacf8ff7f539bd5b98) | `` wireshark: 4.2.1 -> 4.2.2 ``                                                  |
| [`71c0dd30`](https://github.com/NixOS/nixpkgs/commit/71c0dd30ae967cf8911f12f477055702616697ba) | `` resources: 1.2.1 -> 1.3.0 ``                                                  |
| [`1252d2f8`](https://github.com/NixOS/nixpkgs/commit/1252d2f807c0c7029bf32d0ebdfec22615b32661) | `` rustdesk: 1.2.2 -> 1.2.3 ``                                                   |
| [`e11317b0`](https://github.com/NixOS/nixpkgs/commit/e11317b03a50a543a02c6eab30d262e1caeeb92a) | `` {gnome-,}resources: merge, fix up ``                                          |
| [`74b2cb1e`](https://github.com/NixOS/nixpkgs/commit/74b2cb1e9f46daa904d3e8b0c7deee9681384d5f) | `` maintainers: update email address for getpsyched ``                           |
| [`7168adee`](https://github.com/NixOS/nixpkgs/commit/7168adee043daa15243eb4f2509a1617fa6891af) | `` flock: add mainProgram ``                                                     |
| [`46113713`](https://github.com/NixOS/nixpkgs/commit/46113713030bb9d6072cf1ec52b9f2aa16524314) | `` treewide: scale back maintainership for various packages ``                   |
| [`1144b60f`](https://github.com/NixOS/nixpkgs/commit/1144b60f2cc5d432269c5582f289f57f2824759c) | `` python311Packages.pyhs100: remove ``                                          |
| [`a25af76b`](https://github.com/NixOS/nixpkgs/commit/a25af76bb756311608d046d0d28a3620ead70cd6) | `` python311Packages.pyxb: remove ``                                             |
| [`2b1cad43`](https://github.com/NixOS/nixpkgs/commit/2b1cad4389ae5ac7da707c2d5ad7a2f2eaedcb7b) | `` python311Packages.zipstream-new: remove ``                                    |
| [`4704eabb`](https://github.com/NixOS/nixpkgs/commit/4704eabb5e4a57241d8ea80e39b45c7cd8de6bd5) | `` python311Packages.ukrainealarm: remove ``                                     |
| [`70a5e9c2`](https://github.com/NixOS/nixpkgs/commit/70a5e9c22eb75a05c55555e3d4ec8c28ae607ccf) | `` python311Packages.python-openzwave-mqtt: remove ``                            |
| [`ec7ed36a`](https://github.com/NixOS/nixpkgs/commit/ec7ed36af4c7d6af00a5f5f0a70172f08d6ddbb0) | `` python311Packages.fritzprofiles: remove ``                                    |
| [`e381fef2`](https://github.com/NixOS/nixpkgs/commit/e381fef2a845672af40d8028b94c3163dba3e26e) | `` eff: 5.0 → 5.1 ``                                                             |
| [`ee131404`](https://github.com/NixOS/nixpkgs/commit/ee131404efec2c50ee04c4563c0f87de2db160c7) | `` vscode-extensions.ms-vsliveshare.vsliveshare: 1.0.5834 -> 1.0.5900 ``         |
| [`0e7a6eeb`](https://github.com/NixOS/nixpkgs/commit/0e7a6eeb41d586688410ce53305afe4b45afb834) | `` gocode: remove ``                                                             |
| [`5280b6ef`](https://github.com/NixOS/nixpkgs/commit/5280b6ef6c1c9e95114b1bb0eb163c3eeb1c5565) | `` cinnamon.bulky: 3.1 -> 3.2 ``                                                 |
| [`80b77e9d`](https://github.com/NixOS/nixpkgs/commit/80b77e9db06c5618ad1bc8f10ed9760f2bb338ea) | `` nixos/release: add i686-linux mesa to channel blockers ``                     |
| [`d1a3004c`](https://github.com/NixOS/nixpkgs/commit/d1a3004c22c4138ab460683b5b08fa9d11ad61e9) | `` asusctl: 5.0.6 -> 5.0.7 ``                                                    |
| [`9c51fb06`](https://github.com/NixOS/nixpkgs/commit/9c51fb0606181c9b6b35ccfd8bd8e368d388c154) | `` nvidia-x11: add an assert that `useSettings` implies more than `libsOnly` ``  |
| [`fc72865a`](https://github.com/NixOS/nixpkgs/commit/fc72865ab86d6d02e53caa3a70a53ccfa09f8a48) | `` automatic-timezoned: 1.0.138 -> 1.0.139 ``                                    |
| [`9aac98d2`](https://github.com/NixOS/nixpkgs/commit/9aac98d2f85897de14cd25036809af3b7c6a079d) | `` libcifpp: 6.0.0 -> 6.1.0 ``                                                   |
| [`851da59d`](https://github.com/NixOS/nixpkgs/commit/851da59daaab65978b405853232a0b7f17d67104) | `` url-parser: 2.0.1 -> 2.0.2 ``                                                 |
| [`ab261a05`](https://github.com/NixOS/nixpkgs/commit/ab261a05855419ee10465f1f36caea403fe65d06) | `` trivy: 0.48.1 -> 0.48.2 ``                                                    |
| [`1ed5e047`](https://github.com/NixOS/nixpkgs/commit/1ed5e047af84055afac988e081e54a5c96581f08) | `` civo: 1.0.70 -> 1.0.72 ``                                                     |
| [`9ed34e2e`](https://github.com/NixOS/nixpkgs/commit/9ed34e2ec38d9fa5c47621b4b755254ed2ef5ce4) | `` nvc: 1.11.1 -> 1.11.2 ``                                                      |
| [`f10ff4a1`](https://github.com/NixOS/nixpkgs/commit/f10ff4a12ccbda56b8b2c74630f905ae87802097) | `` ledger-live-desktop: 2.73.0 -> 2.73.1 ``                                      |
| [`930c431d`](https://github.com/NixOS/nixpkgs/commit/930c431df7517a151e9122653fff944f9746ebc9) | `` feather: 2.6.1 -> 2.6.2 ``                                                    |
| [`f30bdc7b`](https://github.com/NixOS/nixpkgs/commit/f30bdc7b063b5989d7b89d9b2bba56e7b6a63491) | `` hyprland-per-window-layout: 2.4 -> 2.5 ``                                     |
| [`77f646e2`](https://github.com/NixOS/nixpkgs/commit/77f646e293a0e1e56e49febc98086b4c84dc32db) | `` just: 1.21.0 -> 1.22.0 ``                                                     |
| [`d7635701`](https://github.com/NixOS/nixpkgs/commit/d7635701af7cb02ccd31c926cf229c9f390bba5d) | `` xcb-imdkit: 1.0.5 -> 1.0.6 ``                                                 |
| [`0a86b18d`](https://github.com/NixOS/nixpkgs/commit/0a86b18d8b59b7a6a09d3c8c9f4404a3176539e4) | `` xeus: 3.1.4 -> 3.1.5 ``                                                       |
| [`e6ecfff4`](https://github.com/NixOS/nixpkgs/commit/e6ecfff4509422504ae1f35b2f4eeafc30371db8) | `` tgt: 1.0.89 -> 1.0.90 ``                                                      |
| [`f65e066a`](https://github.com/NixOS/nixpkgs/commit/f65e066a9bded37ca2cb3bb157b71ee7bb508c61) | `` tellico: 3.5.2 -> 3.5.3 ``                                                    |
| [`e9bbedd9`](https://github.com/NixOS/nixpkgs/commit/e9bbedd91a6beb0023105bb074d0ceaaba91a5d2) | `` rwc: 0.2 -> 0.3 ``                                                            |
| [`2481ef21`](https://github.com/NixOS/nixpkgs/commit/2481ef2113f1ea9b3f9fac7881623695a256d856) | `` python310Packages.flowlogs-reader: 5.0.0 -> 5.0.1 ``                          |
| [`26c6b9f5`](https://github.com/NixOS/nixpkgs/commit/26c6b9f5394b2e64649ff18394d61ce5594874e2) | `` rymdport: 3.5.1 -> 3.5.2 ``                                                   |
| [`aa853816`](https://github.com/NixOS/nixpkgs/commit/aa8538161c87bacd00dab74749d2f69a1a5e982b) | `` sqldef: 0.16.13 -> 0.16.14 ``                                                 |
| [`da5b9fb2`](https://github.com/NixOS/nixpkgs/commit/da5b9fb2c7d383fa9a24e2ec8dccbd1ac4d842c3) | `` revive: 1.3.4 -> 1.3.5 ``                                                     |
| [`88cab94b`](https://github.com/NixOS/nixpkgs/commit/88cab94bd9491368f0605dc28135b55dac7e587d) | `` wallabag: 2.6.7 -> 2.6.8 ``                                                   |
| [`1b498f74`](https://github.com/NixOS/nixpkgs/commit/1b498f741dc8345d5d9540a680f2a2fcb8eb0763) | `` codeium: 1.6.16 -> 1.6.18 ``                                                  |
| [`ddb6aac5`](https://github.com/NixOS/nixpkgs/commit/ddb6aac521ba3665ff565d0974af8296480489e5) | `` sddm: 0.20.0 -> 0.20.0-unstable-2023-12-29, add Qt6 support ``                |
| [`646b43f8`](https://github.com/NixOS/nixpkgs/commit/646b43f8c52feb8833add707c057710cd7d36f6e) | `` libuev: 2.4.0 -> 2.4.1 ``                                                     |
| [`197f4b11`](https://github.com/NixOS/nixpkgs/commit/197f4b1116960dd98c186f0b123f43bdb1a7c516) | `` golangci-lint-langserver: 0.0.8 -> 0.0.9 ``                                   |
| [`da0c998a`](https://github.com/NixOS/nixpkgs/commit/da0c998a8a02ca852a5193c7ac19ff0a3f711c11) | `` gh-dash: 3.11.0 -> 3.11.1 ``                                                  |
| [`54bda945`](https://github.com/NixOS/nixpkgs/commit/54bda945d515e6f8b77eabd04a63ea7420133824) | `` goldwarden: 0.2.7 -> 0.2.9 ``                                                 |
| [`54e2f7e4`](https://github.com/NixOS/nixpkgs/commit/54e2f7e4d6aea5ef7b90adefd9bac5e2b09397b5) | `` crowdin-cli: 3.15.0 -> 3.16.0 ``                                              |
| [`745a56a2`](https://github.com/NixOS/nixpkgs/commit/745a56a2e9c4955cdcbd69df980f342986e04ab3) | `` crow-translate: 2.11.0 -> 2.11.1 ``                                           |
| [`1d2f1699`](https://github.com/NixOS/nixpkgs/commit/1d2f1699b78da960d227fc60ff323385edce6b0d) | `` uptime-kuma: 1.23.10 -> 1.23.11 ``                                            |
| [`1cf54a8c`](https://github.com/NixOS/nixpkgs/commit/1cf54a8ce76a1cef6fcb7bde7faf7ce0675efc01) | `` drone-scp: 1.6.13 -> 1.6.14 ``                                                |
| [`4f2230a4`](https://github.com/NixOS/nixpkgs/commit/4f2230a4a3a0f2b8f501975971db023777cd5f4f) | `` typesense: 0.25.1 -> 0.25.2 ``                                                |
| [`4d8faaaf`](https://github.com/NixOS/nixpkgs/commit/4d8faaaf225a7393ea9b4efc9f214e9be11a6b25) | `` turso-cli: 0.87.7 -> 0.87.8 ``                                                |
| [`df468502`](https://github.com/NixOS/nixpkgs/commit/df4685029e45c39cef68fb8a6f0ed4e80b81a063) | `` treesheets: unstable-2023-12-24 -> unstable-2024-01-03 ``                     |
| [`09ade8db`](https://github.com/NixOS/nixpkgs/commit/09ade8db9b00833df22d0b8b67e0aed1a8fea2e6) | `` texlab: 5.12.0 -> 5.12.1 ``                                                   |
| [`60a04bf3`](https://github.com/NixOS/nixpkgs/commit/60a04bf3809e2865907a0090914e3db1e489d23e) | `` anytype: 0.37.0 -> 0.37.3 ``                                                  |
| [`a4d0aa07`](https://github.com/NixOS/nixpkgs/commit/a4d0aa0797f148a77b50f7539553840051c4f525) | `` taproot-assets: 0.2.3 -> 0.3.2 ``                                             |
| [`c2b81a51`](https://github.com/NixOS/nixpkgs/commit/c2b81a51b3ae6e43c52547ef14fda61aff7ae8f8) | `` mint: 0.15.1 -> 0.15.3 ``                                                     |
| [`f9f9155f`](https://github.com/NixOS/nixpkgs/commit/f9f9155f67df9f7ea684c6203f6ecb0424621c65) | `` svd2rust: 0.31.3 -> 0.31.4 ``                                                 |
| [`4664f806`](https://github.com/NixOS/nixpkgs/commit/4664f806a93ea05560c7b1e21f8d53d0bd3e7165) | `` brave: 1.61.109 -> 1.61.114 ``                                                |
| [`07072e24`](https://github.com/NixOS/nixpkgs/commit/07072e248d98ea9763d85ca450814e637ea63728) | `` python3Packages.datadog: unbreak, run subset of tests ``                      |
| [`f08ab3d5`](https://github.com/NixOS/nixpkgs/commit/f08ab3d52802a0319c8b4eaa8555965fafc82da7) | `` vcsh: 2.0.6 -> 2.0.7 ``                                                       |
| [`9051cab2`](https://github.com/NixOS/nixpkgs/commit/9051cab202f52bedd15eb5e73b464884133ba391) | `` buildbot-plugins.react-grid-view: init at 3.10.1 ``                           |
| [`6b6eb045`](https://github.com/NixOS/nixpkgs/commit/6b6eb04575ec6123a234e29f038509558cf4a6cf) | `` buildbot-plugins.react-waterfall-view: init at 3.10.1 ``                      |
| [`a64cc468`](https://github.com/NixOS/nixpkgs/commit/a64cc4682ee541fc76726e0d90a7e527b7b80fb0) | `` buildbot-plugins.react-console-view: init at 3.10.1 ``                        |
| [`43a88eef`](https://github.com/NixOS/nixpkgs/commit/43a88eef2ed0cbcfe3640a62a36176a833f3b2b2) | `` .github/CODEOWNERS: add buildbot ``                                           |
| [`3d0b034e`](https://github.com/NixOS/nixpkgs/commit/3d0b034e8794ad419a1d2615c77ff20ccd0acfd9) | `` maintainers/teams: add buildbot ``                                            |