### PR TITLE
chore(flake/nixos-hardware): `c478b3d5` -> `b34a6075`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -460,11 +460,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1704632650,
-        "narHash": "sha256-83J/nd/NoLqo3vj0S0Ppqe8L+ijIFiGL6HNDfCCUD/Q=",
+        "lastModified": 1704786394,
+        "narHash": "sha256-aJM0ln9fMGWw1+tjyl5JZWZ3ahxAA2gw2ZpZY/hkEMs=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c478b3d56969006e015e55aaece4931f3600c1b2",
+        "rev": "b34a6075e9e298c4124e35c3ccaf2210c1f3a43b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`b34a6075`](https://github.com/NixOS/nixos-hardware/commit/b34a6075e9e298c4124e35c3ccaf2210c1f3a43b) | `` xps-15-9560: disable broken bumblebee for now ``        |
| [`fe76fc35`](https://github.com/NixOS/nixos-hardware/commit/fe76fc35f7e4900718be13d15e3370a50b0fc79a) | `` framework amd: only apply suspend workaround on <6.7 `` |