### PR TITLE
chore(flake/pre-commit-hooks): `ea96f0c0` -> `b0265634`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -538,11 +538,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704725188,
-        "narHash": "sha256-qq8NbkhRZF1vVYQFt1s8Mbgo8knj+83+QlL5LBnYGpI=",
+        "lastModified": 1704913983,
+        "narHash": "sha256-K/GuHFFriQhH3VPWMhm6bYelDuPyGGjGu1OF1EWUn5k=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ea96f0c05924341c551a797aaba8126334c505d2",
+        "rev": "b0265634df1dc584585c159b775120e637afdb41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                     |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
| [`fbc317bf`](https://github.com/cachix/pre-commit-hooks.nix/commit/fbc317bff97af4dc4c9b98b92c1679c125473300) | `` hooks: flake8: add settings to extend the ignore list `` |
| [`911536a7`](https://github.com/cachix/pre-commit-hooks.nix/commit/911536a7bae59e7dd9169133d4eaf25d97d6c83b) | `` hooks: sort hooks alphabetically ``                      |
| [`4cb6caa8`](https://github.com/cachix/pre-commit-hooks.nix/commit/4cb6caa8db49fc54de99592362c0d63958bcc12c) | `` hooks: sort settings alphabetically ``                   |