### PR TITLE
chore(flake/pre-commit-hooks): `54d60d19` -> `274ae397`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -538,11 +538,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705056064,
-        "narHash": "sha256-pi9UtBFD5/U48Jrc6uvA8ZCmW4xnceUDp2QysBEkZCw=",
+        "lastModified": 1705072518,
+        "narHash": "sha256-90dERRuG781f0EWjn2AOtScZqsTcpIFLpY8TN2VbkL8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "54d60d191aa8ba0629f662d8873a892cbe3d65ad",
+        "rev": "274ae3979a0eacae422e1bbcf63b8b7a335e1114",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
| [`59ed918b`](https://github.com/cachix/pre-commit-hooks.nix/commit/59ed918be7dfa25c489be21c57b7ea707f8023eb) | `` doc: fix readme for clang-format `` |
| [`e4f7f070`](https://github.com/cachix/pre-commit-hooks.nix/commit/e4f7f070353728a823435aee17362128c1234967) | `` hooks: init cmake-format ``         |
| [`b46eab58`](https://github.com/cachix/pre-commit-hooks.nix/commit/b46eab585ea06f8f4980844f1b65aca7606ac15d) | `` hooks: unify pkgs -> tools ``       |