### PR TITLE
chore(flake/pre-commit-hooks): `274ae397` -> `ffa9a5b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "lastModified": 1703887061,
+        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
         "type": "github"
       },
       "original": {
@@ -509,16 +509,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1685801374,
-        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
+        "lastModified": 1704874635,
+        "narHash": "sha256-YWuCrtsty5vVZvu+7BchAxmcYzTMfolSPP5io8+WYCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
+        "rev": "3dc440faeee9e889fe2d1b4d25ad0f430d449356",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -538,11 +538,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705072518,
-        "narHash": "sha256-90dERRuG781f0EWjn2AOtScZqsTcpIFLpY8TN2VbkL8=",
+        "lastModified": 1705229514,
+        "narHash": "sha256-itILy0zimR/iyUGq5Dgg0fiW8plRDyxF153LWGsg3Cw=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "274ae3979a0eacae422e1bbcf63b8b7a335e1114",
+        "rev": "ffa9a5b90b0acfaa03b1533b83eaf5dead819a05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
| [`1e702924`](https://github.com/cachix/pre-commit-hooks.nix/commit/1e702924c524d782ddaf18551a0900eccaf6e804) | `` fix: add/fix all the missing hooks, for real this time ``               |
| [`05a6b4ce`](https://github.com/cachix/pre-commit-hooks.nix/commit/05a6b4ceef7f50d38c8295cad1c42deb06fef9d9) | `` feat: add check to ensure all hooks evaluate ``                         |
| [`fb4b6d03`](https://github.com/cachix/pre-commit-hooks.nix/commit/fb4b6d03418ddf4dafbca01a1148e62d7a412bef) | `` fix(phpstan): disable lockfile validation ``                            |
| [`1d3eac11`](https://github.com/cachix/pre-commit-hooks.nix/commit/1d3eac111dcf0dab2f9e4e6884c38234c96d8957) | `` fix(headache): avoid meta.mainProgram as it may not be set ``           |
| [`2c6c9d0f`](https://github.com/cachix/pre-commit-hooks.nix/commit/2c6c9d0fb9688e65520c7b56e973219172ce7ef0) | `` fix: use opentofu instead of terraform ``                               |
| [`0b6fdb09`](https://github.com/cachix/pre-commit-hooks.nix/commit/0b6fdb0941e4dc283ff0e79e2d0aea74d713f2fc) | `` chore: update to nixos 23.11 ``                                         |
| [`33676735`](https://github.com/cachix/pre-commit-hooks.nix/commit/3367673535a9a68fa244c9f74679df080db3a5ae) | `` fix: fix up tools indirections, ensure the used tools actually exist `` |