### PR TITLE
chore(flake/home-manager): `f2942f33` -> `b84191db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705169127,
-        "narHash": "sha256-j9OEtNxOIPWZWjbECVMkI1TO17SzlpHMm0LnVWKOR/g=",
+        "lastModified": 1705535278,
+        "narHash": "sha256-V5+XKfNbiY0bLKLQlH+AXyhHttEL7XcZBH9iSbxxexA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f2942f3385f1b35cc8a1abb03a45e29c9cb4d3c8",
+        "rev": "b84191db127c16a92cbdf7f7b9969d58bb456699",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`b84191db`](https://github.com/nix-community/home-manager/commit/b84191db127c16a92cbdf7f7b9969d58bb456699) | `` gh: add github gist to default credential hosts ``        |
| [`d9c86968`](https://github.com/nix-community/home-manager/commit/d9c869681db7171a1ffb6f88489e4a5170fd0fb5) | `` sway: include cursor environment variables ``             |
| [`62856932`](https://github.com/nix-community/home-manager/commit/62856932af0c75c5be7a5ba23441e16a305423b3) | `` gradle: Don't enable programs.java ``                     |
| [`9fed3282`](https://github.com/nix-community/home-manager/commit/9fed3282e9d5fdc106001a20a84d4e3d8c86dd13) | `` gradle: re-add britter as maintainer ``                   |
| [`646c243e`](https://github.com/nix-community/home-manager/commit/646c243e6f8426b37e45cbd6263f607fe046808a) | `` flake.lock: Update ``                                     |
| [`16cefa78`](https://github.com/nix-community/home-manager/commit/16cefa78cc801911ebd4ff1faddc6280ab3c9228) | `` flake.lock: Update ``                                     |
| [`37d6eece`](https://github.com/nix-community/home-manager/commit/37d6eeceee464adc03585404eebd68765b3c8615) | `` flake.lock: Update ``                                     |
| [`bf4b576f`](https://github.com/nix-community/home-manager/commit/bf4b576f84e1ce54ec886836bae7695738aa5a6c) | `` firefox: restore compatibility for extraPolicies ``       |
| [`fa152fd7`](https://github.com/nix-community/home-manager/commit/fa152fd745b816dcfc751962f2e20c8669aed8f1) | `` xsession: allow xplugd to restart on failure ``           |
| [`8c3b2a0c`](https://github.com/nix-community/home-manager/commit/8c3b2a0cab64a464de9e41a470eecf1318ccff57) | `` flake: update release notes URL ``                        |
| [`b989db59`](https://github.com/nix-community/home-manager/commit/b989db5900df4bd1a786f8afd8063dae09d89a8c) | `` home-manager: check profile exists in nixProfileRemove `` |
| [`846200eb`](https://github.com/nix-community/home-manager/commit/846200eb574faa2af808ed02e653c2b8ed51fd71) | `` docs: use nmd from Nixpkgs ``                             |
| [`8ae3bfe2`](https://github.com/nix-community/home-manager/commit/8ae3bfe2bffe0b058b3158f83eaa53bf14ca347b) | `` tests: use nmt from Nixpkgs ``                            |