### PR TITLE
chore(flake/nix-index-database): `274a40db` -> `49aaeecf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -445,11 +445,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705201750,
-        "narHash": "sha256-0umjkDiAoXDsIhaFlIIhKFTX/q7sMhfzvhNuY6wFdZo=",
+        "lastModified": 1705282324,
+        "narHash": "sha256-LnURMA7yCM5t7et9O2+2YfGQh0FKAfE5GyahNDDzJVM=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "274a40dbf8be212697f3988471a4473987f8a886",
+        "rev": "49aaeecf41ae0a0944e2c627cb515bcde428a1d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                            |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`49aaeecf`](https://github.com/nix-community/nix-index-database/commit/49aaeecf41ae0a0944e2c627cb515bcde428a1d1) | `` Bump cachix/install-nix-action from 24 to 25 `` |
| [`b211687b`](https://github.com/nix-community/nix-index-database/commit/b211687b4ff3a1e5f35bc545484db9d9ad866794) | `` Bump cachix/cachix-action from 13 to 14 ``      |