### PR TITLE
chore(flake/nixos-hardware): `ef811636` -> `a63273ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -460,11 +460,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1705187059,
-        "narHash": "sha256-dSj+iIYqLA+7/5rLXWfUxw9IXRm0w8Mrm39af8klUH0=",
+        "lastModified": 1705287728,
+        "narHash": "sha256-+Xq+nuLI0StP9JAa/V36WEIsjJCv5la4gYsC3Fyu/J8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ef811636cc847355688804593282078bac7758d4",
+        "rev": "a63273ffc77532cc3cbc482ad5b4f9706e5289b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`a63273ff`](https://github.com/NixOS/nixos-hardware/commit/a63273ffc77532cc3cbc482ad5b4f9706e5289b6) | `` build(deps): bump cachix/install-nix-action from 24 to 25 `` |