### PR TITLE
chore(flake/flake-utils): `4022d587` -> `1ef2e671`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -279,11 +279,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                   |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`1ef2e671`](https://github.com/numtide/flake-utils/commit/1ef2e671c3b0c19053962c07dbda38332dcebf26) | `` Update README.md (#111) ``                             |
| [`c8eb208c`](https://github.com/numtide/flake-utils/commit/c8eb208c255400b59b60ad5de17e9f8f7ef8ae30) | `` Bump cachix/install-nix-action from 24 to 25 (#113) `` |