### PR TITLE
chore(flake/nixos-hardware): `a63273ff` -> `bee2202b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -460,11 +460,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1705287728,
-        "narHash": "sha256-+Xq+nuLI0StP9JAa/V36WEIsjJCv5la4gYsC3Fyu/J8=",
+        "lastModified": 1705312285,
+        "narHash": "sha256-rd+dY+v61Y8w3u9bukO/hB55Xl4wXv4/yC8rCGVnK5U=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a63273ffc77532cc3cbc482ad5b4f9706e5289b6",
+        "rev": "bee2202bec57e521e3bd8acd526884b9767d7fa0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`bee2202b`](https://github.com/NixOS/nixos-hardware/commit/bee2202bec57e521e3bd8acd526884b9767d7fa0) | `` Add support for Yoga Slim 7 Gen8 `` |