### PR TITLE
chore(flake/lanzaboote): `be623b70` -> `5667bbc1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -401,11 +401,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1705338418,
-        "narHash": "sha256-KtSIxFkwlk3W4I+Hyyk+AjrMxbhXpuF0TrJFwmg1zbc=",
+        "lastModified": 1705341977,
+        "narHash": "sha256-gDV6qK2yBM6o/m09RVDXiBmwXx5oy3H5dO4vsiHxoaA=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "be623b70c21a5f2a766eed177d08728217704e12",
+        "rev": "5667bbc1f40df129dc093ad73a29e0c39c3dcbee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                               |
| --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`d7d63e6b`](https://github.com/nix-community/lanzaboote/commit/d7d63e6b6c58e14ddcab9eb9a26d0e2873f6ba87) | `` disable synthesis test on aarch64-linux ``                         |
| [`65330d81`](https://github.com/nix-community/lanzaboote/commit/65330d8172799ba0baf8dcfc17adb81f795a7b97) | `` fix hardcoded efi arch in tests ``                                 |
| [`1d3f28ac`](https://github.com/nix-community/lanzaboote/commit/1d3f28acef416b6bc2e0333596fa75e4b1e49b35) | `` Revert "feat(flake): perform final fixups to the flake outputs" `` |
| [`7dfc5f07`](https://github.com/nix-community/lanzaboote/commit/7dfc5f07ce0a37254ea1dc4adfc59a189e336924) | `` Revert "flake: remove moving away the `unsupportedChecks`" ``      |