### PR TITLE
chore(flake/darwin): `44a6ec1f` -> `74ab0227`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -201,11 +201,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705356404,
-        "narHash": "sha256-0/WnHU5S9GXOJD2HGe/mFNmGGE+8UGnhwofsyJQVoDA=",
+        "lastModified": 1705452289,
+        "narHash": "sha256-i/WodLabBcmRr9hdSv5jzDigL1hRYuI8vNh+xTbGt+g=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "44a6ec1faeff61a6404c25ef1a263fc2d98d081b",
+        "rev": "74ab0227ee495e526f2dd57ea684b34f6396445a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                           |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`4051e302`](https://github.com/LnL7/nix-darwin/commit/4051e3027dd0235eadb66b5f59d397f6db06f5dc) | `` Add type definition on fonts.fontDir.enable `` |