### PR TITLE
chore(flake/pre-commit-hooks): `ffa9a5b9` -> `f56597d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -559,11 +559,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705229514,
-        "narHash": "sha256-itILy0zimR/iyUGq5Dgg0fiW8plRDyxF153LWGsg3Cw=",
+        "lastModified": 1705757126,
+        "narHash": "sha256-Eksr+n4Q8EYZKAN0Scef5JK4H6FcHc+TKNHb95CWm+c=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ffa9a5b90b0acfaa03b1533b83eaf5dead819a05",
+        "rev": "f56597d53fd174f796b5a7d3ee0b494f9e2285cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                       |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------- |
| [`35ba4e74`](https://github.com/cachix/pre-commit-hooks.nix/commit/35ba4e74d7ad7f3475a1484f3b993ff7a3336aef) | `` fix(stylua): add --respect-ignores flag `` |