### PR TITLE
chore(flake/nixpkgs): `842d9d80` -> `bbe7d8f8`

### DIFF
--- a/core/nixos.nix
+++ b/core/nixos.nix
@@ -66,7 +66,10 @@
   systemd = {
     enableUnifiedCgroupHierarchy = true;
     network.wait-online.anyInterface = true;
-    services.tailscaled.after = [ "network-online.target" "systemd-resolved.service" ];
+    services.tailscaled = {
+      after = [ "network-online.target" "systemd-resolved.service" ];
+      wants = [ "network-online.target" "systemd-resolved.service" ];
+    };
   };
 
   users.mutableUsers = false;

--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705496572,
-        "narHash": "sha256-rPIe9G5EBLXdBdn9ilGc0nq082lzQd0xGGe092R/5QE=",
+        "lastModified": 1705677747,
+        "narHash": "sha256-eyM3okYtMgYDgmYukoUzrmuoY4xl4FUujnsv/P6I/zI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "842d9d80cfd4560648c785f8a4e6f3b096790e19",
+        "rev": "bbe7d8f876fbbe7c959c90ba2ae2852220573261",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`a34af9a9`](https://github.com/NixOS/nixpkgs/commit/a34af9a9556e205fe0a72014a335b96037b41823) | `` image/repart: add version and compression options ``                                     |
| [`c9e73449`](https://github.com/NixOS/nixpkgs/commit/c9e73449508b9ded9f7fdc0c8a0f81717139a669) | `` Update systemd-boot.nix ``                                                               |
| [`45f1aab3`](https://github.com/NixOS/nixpkgs/commit/45f1aab3d6a9e691dd687fd0df9b694875d114fd) | `` draco: 1.5.6 -> 1.5.7 ``                                                                 |
| [`9a45447a`](https://github.com/NixOS/nixpkgs/commit/9a45447ae2ae231b4e48318a083f13f0c4c5ca21) | `` ausweisapp: 2.0.2 -> 2.0.3 ``                                                            |
| [`e7fad70b`](https://github.com/NixOS/nixpkgs/commit/e7fad70b034489cc23e96148e7f46fdc16a6acfb) | `` tigerbeetle: fix build after 0.14.174 ``                                                 |
| [`a455c5fb`](https://github.com/NixOS/nixpkgs/commit/a455c5fb3ee513e2f443838a0e84d52b035adb67) | `` Revert "linux: drop XEN on 32-bit" ``                                                    |
| [`3fd2c02d`](https://github.com/NixOS/nixpkgs/commit/3fd2c02d5282ebf961086d5084fcf75781b801e8) | `` python311Packages.pulp: 2.7.0 -> 2.8.0 ``                                                |
| [`da74a753`](https://github.com/NixOS/nixpkgs/commit/da74a7530392893791ad28a2e4e58e6fc88f011f) | `` doc: fix typo ``                                                                         |
| [`8ef7c0b8`](https://github.com/NixOS/nixpkgs/commit/8ef7c0b86ad76d531c97209d2f0b9e49a3450352) | `` manticoresearch: 6.2.0 -> 6.2.12 ``                                                      |
| [`49e703cd`](https://github.com/NixOS/nixpkgs/commit/49e703cde28bc7cbd3042d4709db9a21f9f84537) | `` Add Coqeal 2.0.1 and algebra-tactics 1.2.3 ``                                            |
| [`a276e8b0`](https://github.com/NixOS/nixpkgs/commit/a276e8b09bf0eb21ff2f46cf8680edc16cc517c2) | ``  top-level: use callPackages where inheriting packages ``                                |
| [`5de9f63c`](https://github.com/NixOS/nixpkgs/commit/5de9f63c43f376d6be53e2b2d954c7d63c964b44) | `` python311Packages.pyprusalink: 2.0.0 -> 2.0.1 ``                                         |
| [`0dfcbed2`](https://github.com/NixOS/nixpkgs/commit/0dfcbed29d4ba623b5fb226ae3ea17770750463d) | `` python312Packages.trimesh: 4.0.8 -> 4.0.10 ``                                            |
| [`7574ea53`](https://github.com/NixOS/nixpkgs/commit/7574ea5310b9b41a6b13829b47498546afea9204) | `` python311Packages.aioswitcher: enable darwin build ``                                    |
| [`1323e311`](https://github.com/NixOS/nixpkgs/commit/1323e3115da413467ac973018af640ee216cab82) | `` nixos/tests: fix ssh-audit under network-online dep fix ``                               |
| [`e7451cac`](https://github.com/NixOS/nixpkgs/commit/e7451cacf995ffc11e4441605e435b4c63c8e5f8) | `` nixos/tests: fix installer under network-online dep fix ``                               |
| [`843b3e7a`](https://github.com/NixOS/nixpkgs/commit/843b3e7aa982e4c24407aabf2537ef529561b465) | `` nixos/tests: fix guix under network-online dep fix ``                                    |
| [`a8a9424e`](https://github.com/NixOS/nixpkgs/commit/a8a9424e4fc91dfc116e5f59df7e4c5f7dcb7dde) | `` nixos/tests: fix adguardhome under network-online dep fix ``                             |
| [`fe474ed6`](https://github.com/NixOS/nixpkgs/commit/fe474ed61a3436644828a9709e2db6ed006f92aa) | `` nixos: fix remaining services for network-online dep fix ``                              |
| [`1b514b3e`](https://github.com/NixOS/nixpkgs/commit/1b514b3e10319b2d596879467cb13efdc18d970f) | `` fix: rxe under network-online.target change [UNSURE IF CORRECT] ``                       |
| [`c80398e5`](https://github.com/NixOS/nixpkgs/commit/c80398e5d2325c31a4a884b407607b34aa752abc) | `` nixos/ircd-hybrid: fix evaluation error ``                                               |
| [`6c5ab28f`](https://github.com/NixOS/nixpkgs/commit/6c5ab28fcee342254aa9c8704008e2f33dc0dde1) | `` nixos: fix a bunch of services missing dep on network-online.target ``                   |
| [`b8da5d6a`](https://github.com/NixOS/nixpkgs/commit/b8da5d6a3c690909ea3721cded8b8bd0e8476e18) | `` nixos/tests: fix gitdaemon under network-online dep fix ``                               |
| [`174ffdcb`](https://github.com/NixOS/nixpkgs/commit/174ffdcbc4f0512b26053ed18b53af1661d9cf27) | `` nixos/tests: fix tayga under network-online dep fix ``                                   |
| [`9b29e5eb`](https://github.com/NixOS/nixpkgs/commit/9b29e5eb7efc7327f2ba5cb44a98df4196fb8ce3) | `` nixos/tests: fix owncast under network-online dep fix [BROKEN] ``                        |
| [`dbb2d3e2`](https://github.com/NixOS/nixpkgs/commit/dbb2d3e220915443caf65e347f525f2a6e6604c9) | `` nixos/tests: fix systemd-nspawm under network-online dep fix ``                          |
| [`42cda3b3`](https://github.com/NixOS/nixpkgs/commit/42cda3b36b2d2b78de480e23132778bee6c7319b) | `` nixos/tests: fix upnp under network-online dep fix ``                                    |
| [`5714c846`](https://github.com/NixOS/nixpkgs/commit/5714c8465a9ea0fb90b3ef8f0846c6ec01d3de5e) | `` nixos/tests: fix lemmy under network-online dep fix ``                                   |
| [`426d5046`](https://github.com/NixOS/nixpkgs/commit/426d5046b586fa63a5f78d5879bec32acea2f7d4) | `` nixos/tests: fix babeld under network-online dep fix ``                                  |
| [`3f074f7b`](https://github.com/NixOS/nixpkgs/commit/3f074f7b9f8f8454d4058e362ef5b20e86641903) | `` kubernetes-helmPlugins.helm-diff: 3.8.1 -> 3.9.2 ``                                      |
| [`f17bb90a`](https://github.com/NixOS/nixpkgs/commit/f17bb90abf062e9e1ca6c407c4baf1fda23102b1) | `` phpPackages.castor: 0.10.0 -> 0.11.1 ``                                                  |
| [`0d7a0262`](https://github.com/NixOS/nixpkgs/commit/0d7a026204a1289ed15ffb347e757663faae9175) | `` phpExtensions.spx: 0.4.14 -> 0.4.15 ``                                                   |
| [`ab0e6f9c`](https://github.com/NixOS/nixpkgs/commit/ab0e6f9c2cd1915cb0218f2e6fb2faa709cc77da) | `` crowdin-cli: 3.16.0 -> 3.16.1 ``                                                         |
| [`f3e17f3b`](https://github.com/NixOS/nixpkgs/commit/f3e17f3b0c7515f9e5b20d0f9cc456e20fe0d047) | `` python311Packages.telegram-text: drop support for python 3.7 ``                          |
| [`0b685d21`](https://github.com/NixOS/nixpkgs/commit/0b685d216ec1ba73555eba79f4c6aadddab6b4c8) | `` terrapin-scanner: 1.1.2 -> 1.1.3 ``                                                      |
| [`8f0e83be`](https://github.com/NixOS/nixpkgs/commit/8f0e83be499f3bac67efac9575159b87b1200ec9) | `` python311Packages.msoffcrypto-tool: 5.2.0 -> 5.3.1 ``                                    |
| [`ac31d424`](https://github.com/NixOS/nixpkgs/commit/ac31d42461f97f71703f3fe5b36a03a653969bdd) | `` python311Packages.dvc: add hdfs support ``                                               |
| [`08de99e0`](https://github.com/NixOS/nixpkgs/commit/08de99e0e222310e002c22485498fd3b34fe0e78) | `` python311Packages.dvc-hdfs: init at 3.0.0 ``                                             |
| [`938e217b`](https://github.com/NixOS/nixpkgs/commit/938e217b766898a1695831af9bc854b799e65df5) | `` python311Packages.dvc: add gdrive support ``                                             |
| [`fec956a7`](https://github.com/NixOS/nixpkgs/commit/fec956a70c7084497a7c6a0503661417c43ada89) | `` python311Packages.dvc-gdrive: init at 3.0.1 ``                                           |
| [`65e18256`](https://github.com/NixOS/nixpkgs/commit/65e182561bb6cf315047cdddd95cc20990663dc4) | `` python311Packages.pydrive2: set build system ``                                          |
| [`1b699df0`](https://github.com/NixOS/nixpkgs/commit/1b699df0595368b5801b7591d2c06736fe67389f) | `` python311Packages.dvc: disable on unsupported Python releases ``                         |
| [`f0af1613`](https://github.com/NixOS/nixpkgs/commit/f0af16131eadfe395985b6284797ce801fba3281) | `` python311Packages.dvc: 3.40.0 -> 3.40.1 ``                                               |
| [`fc76c16c`](https://github.com/NixOS/nixpkgs/commit/fc76c16c7869f527004a33ded9d6fd714cd25990) | `` clash-geoip: 20231212 -> 20240112 ``                                                     |
| [`0074fb0f`](https://github.com/NixOS/nixpkgs/commit/0074fb0f4747ee4a8981edbcd5123385fcd2061b) | `` python311Packages.python-tado: add changelog to meta ``                                  |
| [`2fb4dce9`](https://github.com/NixOS/nixpkgs/commit/2fb4dce9b56af6942d073640477e676a798e1003) | `` python311Packages.python-tado: remove comment ``                                         |
| [`c45beedc`](https://github.com/NixOS/nixpkgs/commit/c45beedcf1df2b0073220b5afb7bc3eb42d731b9) | `` python311Packages.aioswitcher: refactor ``                                               |
| [`5ea1493a`](https://github.com/NixOS/nixpkgs/commit/5ea1493afdb5838f6f58e9c4715a324f8c62e7a0) | `` python311Packages.aioswitcher: 3.4.1 -> 3.4.2 ``                                         |
| [`fa63ccce`](https://github.com/NixOS/nixpkgs/commit/fa63ccce212167d22d572f0f11a99f5f1685e875) | `` python311Packages.bthome-ble: 3.4.1 -> 3.5.0 ``                                          |
| [`40b5d606`](https://github.com/NixOS/nixpkgs/commit/40b5d606bcb732fb024b1373dc54b934e227f915) | `` checkov: 3.1.66 -> 3.1.67 ``                                                             |
| [`2eb556c0`](https://github.com/NixOS/nixpkgs/commit/2eb556c0377bf599153b68cebe529f7b6213350b) | `` python311Packages.pytest-ansible: 24.1.1 -> 24.1.2 ``                                    |
| [`a59134f9`](https://github.com/NixOS/nixpkgs/commit/a59134f91cd12bba6de98f3f8ade0e9a932ae90c) | `` python311Packages.python-tado: 0.17.3 -> 0.17.4 ``                                       |
| [`ff7cac1a`](https://github.com/NixOS/nixpkgs/commit/ff7cac1ac9d6aa011321717bc16d08ff4c7d3091) | `` netcat: correctly set mainProgram ``                                                     |
| [`abeb90a3`](https://github.com/NixOS/nixpkgs/commit/abeb90a37b4f77876e1fdf8edc9cfeae0da5ceb9) | `` apacheHttpdPackages.php: 8.2.14 -> 8.2.15 ``                                             |
| [`ed36e5cc`](https://github.com/NixOS/nixpkgs/commit/ed36e5cc8cfbe943bb27feee681ae166311f4d4f) | `` itk: patch to unbreak with GCC13 ``                                                      |
| [`b4cfeeb2`](https://github.com/NixOS/nixpkgs/commit/b4cfeeb20d9efbf9343ce88a57dbb78045ae2bbf) | `` python311Packages.telegram-text: 0.1.2 -> 0.2.0 ``                                       |
| [`959e8a24`](https://github.com/NixOS/nixpkgs/commit/959e8a2428503f2a6b0928e626d7955627a90ac6) | `` brave: 1.61.114 -> 1.61.120 ``                                                           |
| [`e4e1973b`](https://github.com/NixOS/nixpkgs/commit/e4e1973b0573003d5f315ccd52e09786b14dbd73) | `` govc: 0.34.1 -> 0.34.2 ``                                                                |
| [`e5aef59b`](https://github.com/NixOS/nixpkgs/commit/e5aef59b814053e9750762e744387289dc1e1842) | `` Revert "top-level: use callPackages where inheriting packages" ``                        |
| [`02da7261`](https://github.com/NixOS/nixpkgs/commit/02da7261b092e478e0e131f6fce984a3561ff247) | `` nuclei: 3.1.5 -> 3.1.6 ``                                                                |
| [`2f08cdc9`](https://github.com/NixOS/nixpkgs/commit/2f08cdc9275fa3ef13303a34d3540bf845641bf7) | `` alacritty-theme: unstable-2023-12-28 -> unstable-2024-01-15 ``                           |
| [`c413d90a`](https://github.com/NixOS/nixpkgs/commit/c413d90a111bd42e94b8a28bf17463a73f979502) | `` mpvScripts.blacklistExtensions: unstable-2023-12-18 -> unstable-2024-01-11 ``            |
| [`c11401bf`](https://github.com/NixOS/nixpkgs/commit/c11401bf4bf324a962190e3b13c0fc8154382322) | `` nixos/tests: fix trafficserver under network-online dep fix ``                           |
| [`f25957bb`](https://github.com/NixOS/nixpkgs/commit/f25957bb58b833cdeadd78269ef7e5e33d793310) | `` nixos/tests: fix 3proxy under network-online dep fix ``                                  |
| [`83ba37ca`](https://github.com/NixOS/nixpkgs/commit/83ba37ca2d566eb9c4748cd93e79d6838bb34147) | `` nixos/tests: fix ulogd under network-online dep fix ``                                   |
| [`58aa87fb`](https://github.com/NixOS/nixpkgs/commit/58aa87fb71d77a61fee0dc458f94b7185c37d8de) | `` nixos/tests: fix nfs/kerberos under network-online dep fix [BROKEN] ``                   |
| [`9fe27a95`](https://github.com/NixOS/nixpkgs/commit/9fe27a9567ab71284a4ea878f4fbe7320d8bd1ad) | `` nixos/tests: fix buildbot under network-online dep fix ``                                |
| [`274466d1`](https://github.com/NixOS/nixpkgs/commit/274466d1fc8e0d462fd1feaa95cd1580162b857d) | `` nixos/tests: fix acme under network-online dep fix ``                                    |
| [`9067ecf2`](https://github.com/NixOS/nixpkgs/commit/9067ecf283d13646c8272d03a88e96031a9a92fd) | `` nixos/tests: fix hostname under network-online dep fix [BROKEN] ``                       |
| [`cc63754f`](https://github.com/NixOS/nixpkgs/commit/cc63754f5677b318f2db9e0a2e70ca36b4931687) | `` nixos/tests: fix networking under network-online dep fix ``                              |
| [`deb9370b`](https://github.com/NixOS/nixpkgs/commit/deb9370b88baaad1816bb69d97fe977265ad499a) | `` nixos/tests: fix curl-impersonate under network-online dep fix ``                        |
| [`81a3fa04`](https://github.com/NixOS/nixpkgs/commit/81a3fa04cadaeec78299b0bb3c039fb38d13542a) | `` nixos/buildbot: master also wants network-online.target ``                               |
| [`ce602cc0`](https://github.com/NixOS/nixpkgs/commit/ce602cc0aa6ccf1f09d8ec30f480bd0d4b28561f) | `` nixos/kea: also want network-online.target ``                                            |
| [`7078a1b3`](https://github.com/NixOS/nixpkgs/commit/7078a1b3567c13f28c12d7a07c020719bb5376b2) | `` nixos/tests: fix systemd-networkd-ipv6-prefix-delegation under network-online dep fix `` |
| [`a80464ee`](https://github.com/NixOS/nixpkgs/commit/a80464eee4accc21304c1a0cfdcdb50a8749cd9f) | `` nixos/tests: fix bittorrent under network-online dep fix ``                              |
| [`05dc4bd1`](https://github.com/NixOS/nixpkgs/commit/05dc4bd146052188e2d40399dd5b3aa247e29625) | `` nixos/tests: fix ferm under network-online dep fix ``                                    |
| [`99813e78`](https://github.com/NixOS/nixpkgs/commit/99813e788b9eebf148f8e9b23a8fc86b53774b5d) | `` nixos/tests: fix corerad under network-online dep fix ``                                 |
| [`e4168ef9`](https://github.com/NixOS/nixpkgs/commit/e4168ef9ba69ecd60856550287ea1e1feac43c50) | `` nixos/tests: fix rspamd under network-online dep fix ``                                  |
| [`9ce6ff06`](https://github.com/NixOS/nixpkgs/commit/9ce6ff06c76257ad7e04c122b08253d7c3e5ebd7) | `` nixos/tests: fix kanidm under network-online dep fix ``                                  |
| [`367d1010`](https://github.com/NixOS/nixpkgs/commit/367d101073db523e88cbad02135ce3fd2b847b17) | `` nixos/systemd: assert After=network-online.target -> Wants= ``                           |
| [`062be413`](https://github.com/NixOS/nixpkgs/commit/062be41387b9d571fdb96102a2e676944abefe0d) | `` nixos/tests: fix zrepl under network-online dep fix ``                                   |
| [`d51e4a64`](https://github.com/NixOS/nixpkgs/commit/d51e4a6443c0deb29510ad23f3e0f180aa9ba5d5) | `` nixos/tests: fix uptermd under network-online dep fix ``                                 |
| [`c940ae65`](https://github.com/NixOS/nixpkgs/commit/c940ae656d842717c0aaecb90fee3b339e54dea0) | `` nixos/tests: fix opensmtpd under network-online dep fix ``                               |
| [`80edf319`](https://github.com/NixOS/nixpkgs/commit/80edf319fedd0a067e8145312140a76caf95731a) | `` nixos/paperless: fix network-online.target dependencies ``                               |
| [`c125c234`](https://github.com/NixOS/nixpkgs/commit/c125c234687dfecc225ee0560b0587287e934c1b) | `` nixos/tests: fix systemd-networkd-dhcpserver under network-online dep fix ``             |
| [`9ed2e58b`](https://github.com/NixOS/nixpkgs/commit/9ed2e58b7051c8a2193e9db0a92526427c61f006) | `` nixos/tests: fix rss2email under network-online dep fix ``                               |
| [`8169ded7`](https://github.com/NixOS/nixpkgs/commit/8169ded7a3b730495f9c63d7830aa6fa4b982ee3) | `` nixos/tests: fix qemu-vm-restrictnetwork under network-online dep fix ``                 |
| [`62f30634`](https://github.com/NixOS/nixpkgs/commit/62f30634db2146c23f9aff1c9b598524652bbeb7) | `` nixos/systemd: don't require network-online.target for multi-user.target ``              |
| [`bb8ec629`](https://github.com/NixOS/nixpkgs/commit/bb8ec62980552264574f9dccd997a99ccc382a8f) | `` xc: 0.7.0 -> 0.8.0 ``                                                                    |
| [`1e70382b`](https://github.com/NixOS/nixpkgs/commit/1e70382b81def87bd4d273a6ef504eae754450f2) | `` nixos/version: add options to identify images ``                                         |
| [`0c69a9bd`](https://github.com/NixOS/nixpkgs/commit/0c69a9bd64af0c31cc93529dd5eec01055a56550) | `` cargo-dist: 0.5.0 -> 0.7.2 ``                                                            |
| [`a256aea2`](https://github.com/NixOS/nixpkgs/commit/a256aea2544de97328e7fba77bc62e88f294d536) | `` kanata: add bmanuel as a maintainer ``                                                   |
| [`01ab71bf`](https://github.com/NixOS/nixpkgs/commit/01ab71bf03cd421155f2ab784f4b44007a2e14f4) | `` i2pd: 2.50.1 -> 2.50.2 ``                                                                |
| [`1562d11e`](https://github.com/NixOS/nixpkgs/commit/1562d11eba6a84366ccd48241570dd5f438f5c36) | `` maintainers: add bmanuel ``                                                              |
| [`4d3aa5bc`](https://github.com/NixOS/nixpkgs/commit/4d3aa5bc5f282980101149212245be955fc0654e) | `` wander: 1.0.0 -> 1.0.1 ``                                                                |
| [`00600006`](https://github.com/NixOS/nixpkgs/commit/006000061a5b1322a568cfd2ad87c178e97137af) | `` kanata: add support for darwin platforms ``                                              |
| [`c2d6d673`](https://github.com/NixOS/nixpkgs/commit/c2d6d673d7690b8449663f112caaabef6a8138f5) | `` eask: 0.9.2 -> 0.9.3 ``                                                                  |
| [`85e3f80b`](https://github.com/NixOS/nixpkgs/commit/85e3f80bee640a829b908835ae14fa7e79453c81) | `` nelua: unstable-2024-01-02 -> unstable-2024-01-13 ``                                     |
| [`744bd465`](https://github.com/NixOS/nixpkgs/commit/744bd465e000444e1c890a4bfefd485535439983) | `` vscode-extensions.mkhl.direnv: 0.15.2 -> 0.16.0 ``                                       |
| [`3b4bce89`](https://github.com/NixOS/nixpkgs/commit/3b4bce89d14c20b69aab39981920d9c0833ddb97) | `` vscode-extensions.donjaymanne.githistory: cleanup ``                                     |
| [`53e9309c`](https://github.com/NixOS/nixpkgs/commit/53e9309c69f12fa64d99bf684bd339201ba1f04f) | `` vscode-extensions.bmewburn.vscode-intelephense-client: 1.10.1 -> 1.10.2 ``               |
| [`dc0e32d8`](https://github.com/NixOS/nixpkgs/commit/dc0e32d82c5453e6b3d917acdc97faa498b7ade0) | `` vscode-extensions.github.vscode-pull-request-github: 0.75.2023101209 -> 0.78.1 ``        |
| [`40d39614`](https://github.com/NixOS/nixpkgs/commit/40d3961452f99f69baff69795109463fe739dc79) | `` vscode-extensions.github.vscode-github-actions: 0.25.6 -> 0.26.2 ``                      |
| [`4d10dfce`](https://github.com/NixOS/nixpkgs/commit/4d10dfce22e6023b829a5e2228e34337a0735c50) | `` bearer: 1.34.0 -> 1.35.0 ``                                                              |
| [`caa13d46`](https://github.com/NixOS/nixpkgs/commit/caa13d46a8e4d90a88842c77ec128071d1d6450a) | `` python311Packages.dvc: 3.39.0 -> 3.40.0 ``                                               |
| [`e869ea85`](https://github.com/NixOS/nixpkgs/commit/e869ea85a2861254230bae5006c52525a6c586f7) | `` vscode-extensions.github.copilot-chat: 0.11.2023111001 -> 0.11.2023120102 ``             |
| [`2f134383`](https://github.com/NixOS/nixpkgs/commit/2f134383ff099e9094a2dfe665e63f4643547b8b) | `` vscode-extensions.github.copilot: 1.143.601 -> 1.151.659 ``                              |
| [`c9d94691`](https://github.com/NixOS/nixpkgs/commit/c9d946913c6759ada56a5ae65268fd77351f1263) | `` hyprpaper: 0.5.0 -> 0.6.0 ``                                                             |
| [`14bf4020`](https://github.com/NixOS/nixpkgs/commit/14bf402065c391492c495dbfe0cba7e4ff83e467) | `` python311Packages.anywidget: 0.8.0 -> 0.8.1 ``                                           |
| [`02a38bf0`](https://github.com/NixOS/nixpkgs/commit/02a38bf0a3cd0622cd91880baf9a4f26a3464bfb) | `` python311Packages.withings-sync: 4.2.2 -> .4.2.4 ``                                      |
| [`0ba9e97f`](https://github.com/NixOS/nixpkgs/commit/0ba9e97fe5331d2c4d29db6786891a71eb33d80a) | `` telegram-desktop: 4.14.7 -> 4.14.8 ``                                                    |
| [`a3f7053c`](https://github.com/NixOS/nixpkgs/commit/a3f7053c0b8a48808eb66c7bd5f3caa68d2e22bd) | `` patchelfUnstable: unstable-2023-09-27 -> unstable-2024-01-15 ``                          |
| [`0da08a4f`](https://github.com/NixOS/nixpkgs/commit/0da08a4f9b51d27674fa2b0fb4a572252d1a8c4b) | `` nitter: unstable-2023-12-03 -> unstable-2024-01-12 ``                                    |
| [`12781302`](https://github.com/NixOS/nixpkgs/commit/12781302a75e19cd286fc7d4324b4680a58d579c) | `` sweet-folders: init at unstable-2023-03-18 ``                                            |
| [`7cd3b7e1`](https://github.com/NixOS/nixpkgs/commit/7cd3b7e1d1826c4078da58b8d1ddb3e499f3d78b) | `` mpdevil: 1.10.2 -> 1.11.0 ``                                                             |
| [`030a635e`](https://github.com/NixOS/nixpkgs/commit/030a635e2bef168a05173b97619d39b30ffed5ee) | `` pyspread: 2.2.2 -> 2.2.3 ``                                                              |
| [`ca17ef02`](https://github.com/NixOS/nixpkgs/commit/ca17ef02c34380ce9289fc984a48f8b1cfbb8117) | `` uxn: unstable-2024-01-04 -> unstable-2024-01-15 ``                                       |
| [`68d14ba2`](https://github.com/NixOS/nixpkgs/commit/68d14ba2a5c54ed931222079380f96de82489895) | `` ocamlPackages.eio: 0.13 → 0.14 ``                                                        |
| [`edda0a2c`](https://github.com/NixOS/nixpkgs/commit/edda0a2c8030808fe54b8e96076c5d7208fee5f4) | `` python311Packages.argilla: 1.21.0 -> 1.22.0 ``                                           |