### PR TITLE
chore(flake/darwin): `74ab0227` -> `3ac7acd3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -220,11 +220,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705452289,
-        "narHash": "sha256-i/WodLabBcmRr9hdSv5jzDigL1hRYuI8vNh+xTbGt+g=",
+        "lastModified": 1705796049,
+        "narHash": "sha256-zkqbujNu3ixEar79QJTpJeOG5MYse1uJdcjl9f96uBg=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "74ab0227ee495e526f2dd57ea684b34f6396445a",
+        "rev": "3ac7acd32db4f7111015e8d5349ff6067df01bf6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                 |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`f1d47fc2`](https://github.com/LnL7/nix-darwin/commit/f1d47fc2dd43166cd832cb618a43e575a3fe7d27) | `` fix: set shell for new users, and only known ones `` |
| [`888533c3`](https://github.com/LnL7/nix-darwin/commit/888533c35fb0b46a8b537528b9990ab838ee3efc) | `` fix: user shell path handling ``                     |
| [`5cec74da`](https://github.com/LnL7/nix-darwin/commit/5cec74dae1bf439a3d137152e77badc7214ddc7c) | `` fix shell escaping in networking config ``           |