### PR TITLE
chore(flake/home-manager): `9b378afa` -> `928f2528`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -373,11 +373,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705794055,
-        "narHash": "sha256-mv/KrxEAZNhpPJcDqdQ709If9p2DTEYIDPo2r9xchlg=",
+        "lastModified": 1705823474,
+        "narHash": "sha256-2C4uRe9/U3QwSPC4dYKM1/njgCQk0Mltezy4VcjAqa4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9b378afae72cb07471e19aefc30e8e05ef2d7a61",
+        "rev": "928f2528f9ee952ba0a47bbb1ece8d93ed66e784",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------- |
| [`928f2528`](https://github.com/nix-community/home-manager/commit/928f2528f9ee952ba0a47bbb1ece8d93ed66e784) | `` mise: add module `` |