### PR TITLE
chore(flake/home-manager): `928f2528` -> `2d47379a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -373,11 +373,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705823474,
-        "narHash": "sha256-2C4uRe9/U3QwSPC4dYKM1/njgCQk0Mltezy4VcjAqa4=",
+        "lastModified": 1705879479,
+        "narHash": "sha256-ZIohbyly1KOe+8I3gdyNKgVN/oifKdmeI0DzMfytbtg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "928f2528f9ee952ba0a47bbb1ece8d93ed66e784",
+        "rev": "2d47379ad591bcb14ca95a90b6964b8305f6c913",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`2d47379a`](https://github.com/nix-community/home-manager/commit/2d47379ad591bcb14ca95a90b6964b8305f6c913) | `` flake.lock: Update ``                   |
| [`4af6720f`](https://github.com/nix-community/home-manager/commit/4af6720fff6cdc6188ccd4533365a202f6adeccc) | `` k9s: fix unnecessary test dependency `` |
| [`020399c2`](https://github.com/nix-community/home-manager/commit/020399c287afa853136b8089c315e238bf4b161d) | `` k9s: v0.29/v0.30 compatibility ``       |
| [`0021558d`](https://github.com/nix-community/home-manager/commit/0021558dba313b6f494cd16362dcd4071f407535) | `` mise: fix test ``                       |