### PR TITLE
chore(flake/nixpkgs): `bbe7d8f8` -> `612f9723`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705677747,
-        "narHash": "sha256-eyM3okYtMgYDgmYukoUzrmuoY4xl4FUujnsv/P6I/zI=",
+        "lastModified": 1705856552,
+        "narHash": "sha256-JXfnuEf5Yd6bhMs/uvM67/joxYKoysyE3M2k6T3eWbg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bbe7d8f876fbbe7c959c90ba2ae2852220573261",
+        "rev": "612f97239e2cc474c13c9dafa0df378058c5ad8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
| [`f3b08ca5`](https://github.com/NixOS/nixpkgs/commit/f3b08ca5a6be42e01f668a9f6224f403ccb08bb6) | `` nixos/clamav: fix network-online requires assert ``                                                 |
| [`e3839f3e`](https://github.com/NixOS/nixpkgs/commit/e3839f3e9042ef541ac713cd79d1c3eb359be1c4) | `` rye: 0.18.0 -> 0.19.0 ``                                                                            |
| [`1d24d54e`](https://github.com/NixOS/nixpkgs/commit/1d24d54ef4582e3645108f88ae23b3fb4c3b2f62) | `` cudaPackages.backendStdenv: fix eval error blocking the channel ``                                  |
| [`a96d88df`](https://github.com/NixOS/nixpkgs/commit/a96d88dfd564852e6480ba470516a235239ef5dd) | `` csharp-ls: 0.10.0 -> 0.11.0 ``                                                                      |
| [`b02939ff`](https://github.com/NixOS/nixpkgs/commit/b02939ff0a42aaa784f742f95f259d69e06a82b4) | `` python311Packages.django-sesame: 3.2.1 -> 3.2.2 ``                                                  |
| [`85c1d08c`](https://github.com/NixOS/nixpkgs/commit/85c1d08cb5358a5567abacb83fc7aa238b6e977b) | `` python311Packages.pytest-random-order: refactor ``                                                  |
| [`ef711256`](https://github.com/NixOS/nixpkgs/commit/ef7112566398f7c3e2eb014dbe93036fe3bbf900) | `` kapp: 0.59.2 -> 0.60.0 ``                                                                           |
| [`ee127c92`](https://github.com/NixOS/nixpkgs/commit/ee127c9256b947ef260b23ebea0d3ba1eda3b7b1) | `` podman-tui: 0.15.0 -> 0.16.0 ``                                                                     |
| [`a9f8122a`](https://github.com/NixOS/nixpkgs/commit/a9f8122a9e8061d3ec92dec019a5a258232aa444) | `` mujoco: 3.1.0 -> 3.1.1 ``                                                                           |
| [`c036475d`](https://github.com/NixOS/nixpkgs/commit/c036475d1adc4a965dd8b2dfd81c9ef12a33406f) | `` python311Packages.mujoco: fix build for aarch64-linux ``                                            |
| [`07b244db`](https://github.com/NixOS/nixpkgs/commit/07b244db749c91c7f7171661c5225e7719e65208) | `` python311Packages.mujoco: fix build (add missing dependencies) ``                                   |
| [`81d7d934`](https://github.com/NixOS/nixpkgs/commit/81d7d934187f2cd5e26e7d6f44bd3c7fc9f05870) | `` socialscan: 2.0.0 -> 2.0.1 ``                                                                       |
| [`60a720ae`](https://github.com/NixOS/nixpkgs/commit/60a720aebb90a06a4a2d17e982408ed7bd02ba22) | `` python311Packages.thermopro-ble: 0.58.0 -> 0.8.0 ``                                                 |
| [`8849eade`](https://github.com/NixOS/nixpkgs/commit/8849eade2b3a9c5bafdd4cee42cf645b02248f3b) | `` paralus-cli: 0.1.4 -> 0.1.5 ``                                                                      |
| [`ed211ff4`](https://github.com/NixOS/nixpkgs/commit/ed211ff44369811ad591a11897f2c7f00ad6839a) | `` home-assistant-custom-components.gpio: init at 0.0.2 ``                                             |
| [`61569a33`](https://github.com/NixOS/nixpkgs/commit/61569a336101c7e625af8a0da949604a415d01b5) | `` fastfetch: 2.6.0 -> 2.6.1 ``                                                                        |
| [`3ac135b6`](https://github.com/NixOS/nixpkgs/commit/3ac135b6a9bd9a606a7057e0c10b017f7ba11ed6) | `` buf: 1.27.0 -> 1.28.1 ``                                                                            |
| [`7f359041`](https://github.com/NixOS/nixpkgs/commit/7f3590412b146e661e83587b7537bb3d3cc56b20) | `` ov: 0.33.0 -> 0.33.1 ``                                                                             |
| [`9b51929e`](https://github.com/NixOS/nixpkgs/commit/9b51929ee926d2ac6355ffd3b3b253c365f78c17) | `` roundcube: 1.6.5 -> 1.6.6 ``                                                                        |
| [`0f9615ef`](https://github.com/NixOS/nixpkgs/commit/0f9615ef9e70a46698076ac1b5c3cd0f7913c0c9) | `` weechat-unwrapped: 4.1.3 -> 4.2.0 ``                                                                |
| [`a24b376b`](https://github.com/NixOS/nixpkgs/commit/a24b376bf347bd574c0c028b0e7637b3d506c5d8) | `` libnbd: 1.18.1 -> 1.18.2 ``                                                                         |
| [`382ad385`](https://github.com/NixOS/nixpkgs/commit/382ad3858a34c3854723498fe2ab93a3b65a8511) | `` python311Packages.simplisafe-python: 2023.12.0 -> 2024.01.0 ``                                      |
| [`4dee73ee`](https://github.com/NixOS/nixpkgs/commit/4dee73eeb979de564d76a4467ab711ea6f7ab0f2) | `` python312Packages.types-awscrt: 0.20.0 -> 0.20.2 ``                                                 |
| [`0f626e57`](https://github.com/NixOS/nixpkgs/commit/0f626e57caa36cd03f4802362bbbac97ec86523f) | `` pur: refactor ``                                                                                    |
| [`b3ef821c`](https://github.com/NixOS/nixpkgs/commit/b3ef821c72c1a6caecbf5b12e269f3797e7e5f0c) | `` keepwn: refactor ``                                                                                 |
| [`967804c8`](https://github.com/NixOS/nixpkgs/commit/967804c827904704ac7ad7b5334fb1258e6e81b2) | `` lbreakouthd: 1.1.5 -> 1.1.6 ``                                                                      |
| [`111c638e`](https://github.com/NixOS/nixpkgs/commit/111c638ea232197b1e2db7727988636517f2b207) | `` cloudhunter: 0.7.0 -> 0.7.1 ``                                                                      |
| [`988da3f5`](https://github.com/NixOS/nixpkgs/commit/988da3f5fc613d0ac1c161de616c639f3f9d8b88) | `` texlab: 5.12.1 -> 5.12.2 ``                                                                         |
| [`722ecbcf`](https://github.com/NixOS/nixpkgs/commit/722ecbcf1abbb1cf413ec36f828eeab4f6602ab7) | `` naabu: add ldflags ``                                                                               |
| [`160098e6`](https://github.com/NixOS/nixpkgs/commit/160098e6364b0bca1ae3142cc9b2b5cfbccd31eb) | `` php81Packages.php-cs-fixer: 3.45.0 -> 3.48.0 ``                                                     |
| [`dcd2330f`](https://github.com/NixOS/nixpkgs/commit/dcd2330f3f699a15ba4665efb7537244a6358ef7) | `` codeql: 2.15.5 -> 2.16.0 ``                                                                         |
| [`5d97f177`](https://github.com/NixOS/nixpkgs/commit/5d97f17791fcdb60534e62b298d16855221c9f6f) | `` avro-tools: 1.11.1 -> 1.11.3 ``                                                                     |
| [`65dd0fcc`](https://github.com/NixOS/nixpkgs/commit/65dd0fcc22dc4d6ae46087d4789020e97a446524) | `` python312Packages.xstatic: 1.0.2 -> 1.0.3 ``                                                        |
| [`766f3b44`](https://github.com/NixOS/nixpkgs/commit/766f3b4485bb15725e7624dc3ce21d7d86d68e5d) | `` naabu: 2.2.0 -> 2.2.1 ``                                                                            |
| [`aae99145`](https://github.com/NixOS/nixpkgs/commit/aae991455e3750dccdfdd324e158cbd9e6aa0417) | `` ffcast: 2.5.0 -> 2.5.1 ``                                                                           |
| [`9a0ea920`](https://github.com/NixOS/nixpkgs/commit/9a0ea920a0c4a81e795ebaf8e1f63db0e5cdcd65) | `` python312Packages.pytest-random-order: 1.1.0 -> 1.1.1 ``                                            |
| [`e6213e65`](https://github.com/NixOS/nixpkgs/commit/e6213e65ff764c0203a1474e5f21ea7219f8d3cd) | `` apktool: 2.9.2 -> 2.9.3 ``                                                                          |
| [`8749af1b`](https://github.com/NixOS/nixpkgs/commit/8749af1bf2e9cb49bc2b648dc2bcca07051a235d) | `` python311Packages.bx-py-utils: 88 -> 91 ``                                                          |
| [`67ee06ea`](https://github.com/NixOS/nixpkgs/commit/67ee06ea993b7605f6436cd890545a6be251bf08) | `` cppcheck: 2.13.0 -> 2.13.1 ``                                                                       |
| [`f2f0e24f`](https://github.com/NixOS/nixpkgs/commit/f2f0e24f7cde1fe4438bb0705af5f72b83acc872) | `` qownnotes: do not inherit appname ``                                                                |
| [`59f54470`](https://github.com/NixOS/nixpkgs/commit/59f5447085ef48aae038de990b573c4c5c926807) | `` steampipe: 0.21.2 -> 0.21.3 ``                                                                      |
| [`5fd17173`](https://github.com/NixOS/nixpkgs/commit/5fd171739134f6d03e807262f14937b03bd6a537) | `` kikit: 1.3.0 -> 1.4.0 ``                                                                            |
| [`5fed8db3`](https://github.com/NixOS/nixpkgs/commit/5fed8db3544e0b55723a55eb1dc98d1093049d42) | `` python311Packages.flet: 0.18.0 -> 0.19.0 ``                                                         |
| [`01a15443`](https://github.com/NixOS/nixpkgs/commit/01a15443c95a510ded03e7d195003f2e39a2fbda) | `` python311Packages.flet-runtime: 0.18.0 -> 0.19.0 ``                                                 |
| [`b799dd54`](https://github.com/NixOS/nixpkgs/commit/b799dd5429d19f510e8338e9780905619f78a4f9) | `` python311Packages.flet-core: 0.18.0 -> 0.19.0 ``                                                    |
| [`ae19d5dc`](https://github.com/NixOS/nixpkgs/commit/ae19d5dce06d4cb24650c5bf2a927999eb7749c7) | `` python311Packages.riscv-config: 3.14.3 -> 3.17.0 ``                                                 |
| [`5e9d51ce`](https://github.com/NixOS/nixpkgs/commit/5e9d51cecb89ff4c63eb41798fbfbaf2e11aa13f) | `` mudlet: Fix build on darwin (#281657) ``                                                            |
| [`e4dd0f53`](https://github.com/NixOS/nixpkgs/commit/e4dd0f5333dfcec664bd4c14600e8e6e9989614e) | `` python311Packages.asyncsleepiq: 1.5.1 -> 1.5.2 ``                                                   |
| [`c1d19e5f`](https://github.com/NixOS/nixpkgs/commit/c1d19e5fbabc8c0221ab06d3917a5c668956029e) | `` minify: 2.20.10 -> 2.20.14 ``                                                                       |
| [`48cbbf55`](https://github.com/NixOS/nixpkgs/commit/48cbbf55548af9d56c7b25cc934b6dd58ab2b60e) | `` tflint: 0.50.1 -> 0.50.2 ``                                                                         |
| [`ce359b4e`](https://github.com/NixOS/nixpkgs/commit/ce359b4e4a49a50dd9b9cc8835790821dc89a8ed) | `` docker-slim: 1.40.9 -> 1.40.10 ``                                                                   |
| [`45b5c34b`](https://github.com/NixOS/nixpkgs/commit/45b5c34b2b6797abd5454daf72ebeb5d8e0367fd) | `` rqbit: 5.4.1 -> 5.4.2 ``                                                                            |
| [`36ad1f82`](https://github.com/NixOS/nixpkgs/commit/36ad1f827904479ddccd5cd0bfaca37359babaff) | `` android-udev-rules: 20231207 -> 20240114 ``                                                         |
| [`48c41974`](https://github.com/NixOS/nixpkgs/commit/48c419741e48bd79d2a7db2116114753547ad1fe) | `` qownnotes: 24.1.2 -> 24.1.4 ``                                                                      |
| [`28dbc86c`](https://github.com/NixOS/nixpkgs/commit/28dbc86c498e4da9a4e44949e82a583627273319) | `` texlive: create outputsToInstall outputs in main derivation (#270232) ``                            |
| [`26d442de`](https://github.com/NixOS/nixpkgs/commit/26d442de0481926e6fc2620460cc18a8eca55927) | `` python311Packages.pykwalify: fix tests with ruamel.yaml 0.18+ ``                                    |
| [`c0ac2d5c`](https://github.com/NixOS/nixpkgs/commit/c0ac2d5cd4e848af2c00b74d17a6faed7add1d5f) | `` python311Packages.flet: relax websockets version constraint ``                                      |
| [`de3f6321`](https://github.com/NixOS/nixpkgs/commit/de3f6321d2b0986362240046d4b163407fdec2c4) | `` python311Packages.flet-runtime: relax httpx version constraint ``                                   |
| [`f9a23bcc`](https://github.com/NixOS/nixpkgs/commit/f9a23bcc442dce253219fc461a9d85f025a0cdd3) | `` jasper: 4.1.0 -> 4.1.2 ``                                                                           |
| [`8d39a979`](https://github.com/NixOS/nixpkgs/commit/8d39a979310ef291036625f180c273118a927495) | `` dart-sass: 1.69.0 -> 1.70.0 ``                                                                      |
| [`5d3f444f`](https://github.com/NixOS/nixpkgs/commit/5d3f444f49f5bb542acec01f6cb3b0384bb945db) | `` dart-sass: add passthru.updateScript ``                                                             |
| [`fe61cef1`](https://github.com/NixOS/nixpkgs/commit/fe61cef1ba7cb4f5c668fb9caa178433f5fd4a7f) | `` http-server: use buildNpmPackage ``                                                                 |
| [`98088d71`](https://github.com/NixOS/nixpkgs/commit/98088d718328340721e81705ed3c78fad978d09b) | `` picom-{allusive,jonaburg}: fix build by adding pcre ``                                              |
| [`5f30854c`](https://github.com/NixOS/nixpkgs/commit/5f30854c548015b993534669267fd272858364a4) | `` python311Packages.blurhash-python: init at 1.2.1 ``                                                 |
| [`31f65565`](https://github.com/NixOS/nixpkgs/commit/31f65565433484d9ec64da448fed47cb0fac9f76) | `` kdeltachat: unstable-2023-01-31 -> unstable-2024-01-14 ``                                           |
| [`86f3497a`](https://github.com/NixOS/nixpkgs/commit/86f3497ae08773c35743e63a7825be5d4315e922) | `` corrosion: 0.4.6 -> 0.4.7 ``                                                                        |
| [`8d956b17`](https://github.com/NixOS/nixpkgs/commit/8d956b1725be2b21116ba8e267c0f892e1d08a76) | `` nixos/ollama: Add listenAddress ``                                                                  |
| [`524351dc`](https://github.com/NixOS/nixpkgs/commit/524351dc9aab59cf41932e30f3f75bfb930dbd21) | `` python311Packages.qdrant-client: 1.7.0 -> 1.7.1 ``                                                  |
| [`ba5b895d`](https://github.com/NixOS/nixpkgs/commit/ba5b895db511528f1e4bbf47865f3cc2d315b9eb) | `` mongodb: add new dependencies for bundled enterprise modules (#281440) ``                           |
| [`6b236a19`](https://github.com/NixOS/nixpkgs/commit/6b236a198c48880767530613c4899a184deee493) | `` grype: 0.74.1 -> 0.74.2 ``                                                                          |
| [`45393d9f`](https://github.com/NixOS/nixpkgs/commit/45393d9f179a400a9367d810431e987a92b82540) | `` python312Packages.aliyun-python-sdk-iot: 8.57.0 -> 8.58.0 ``                                        |
| [`eb9a982f`](https://github.com/NixOS/nixpkgs/commit/eb9a982f97313428f957ef3a7fb63f3abd7a8f64) | `` weechat-unwrapped: 4.1.2 -> 4.1.3 ``                                                                |
| [`9083a8f0`](https://github.com/NixOS/nixpkgs/commit/9083a8f02f3afe1350465f2cb2a7bd6842b2b22e) | `` picom: add maintainer gepbird ``                                                                    |
| [`0659bf8c`](https://github.com/NixOS/nixpkgs/commit/0659bf8c1f01a635f3e7b87d598e65452becb992) | `` picom: 10.2 -> 11 ``                                                                                |
| [`21742dba`](https://github.com/NixOS/nixpkgs/commit/21742dba967ada095b84469b8006bed62792e005) | `` python311Packages.rki-covid-parser: refactor ``                                                     |
| [`466deea4`](https://github.com/NixOS/nixpkgs/commit/466deea413c416f8e351c5b77072380f2a143aef) | `` python311Packages.demetriek: relax pydantic ``                                                      |
| [`6f29ff4a`](https://github.com/NixOS/nixpkgs/commit/6f29ff4a369d941fa51b775153df332e41ca07fc) | `` hydrus: 557 -> 559 ``                                                                               |
| [`2183dc90`](https://github.com/NixOS/nixpkgs/commit/2183dc904c928dc859fdfddfb0fbaef4fa4f4013) | `` cosmic-term: update formatting and add mainProgram ``                                               |
| [`98b1b813`](https://github.com/NixOS/nixpkgs/commit/98b1b8134c629d641f2f0239f47d733a0cdf63c2) | `` rye: 0.17.0 -> 0.18.0 ``                                                                            |
| [`b022bc7d`](https://github.com/NixOS/nixpkgs/commit/b022bc7dd745e7027e68c5a9150b0ad41ced90a9) | `` python311Packages.pysolcast: relax responses ``                                                     |
| [`3d0a1fef`](https://github.com/NixOS/nixpkgs/commit/3d0a1fef9f6a0d128dd7d8bef83f340cad83ab0a) | `` python311Packages.flask-caching: disable more tests on darwin ``                                    |
| [`76384d4d`](https://github.com/NixOS/nixpkgs/commit/76384d4d3b167772bfea28416bfa99d532021e68) | `` baresip: 3.8.0 -> 3.8.1 ``                                                                          |
| [`62f108d0`](https://github.com/NixOS/nixpkgs/commit/62f108d0dead28a5aeff91157b823d897beaf290) | `` python311Packages.google-cloud-bigquery: unbreak ``                                                 |
| [`3db3f245`](https://github.com/NixOS/nixpkgs/commit/3db3f2455ffd3d8c0facc85e635e9781b1fe11da) | `` libretro.mupen64-plus: fix build under GCC 13 ``                                                    |
| [`a880396a`](https://github.com/NixOS/nixpkgs/commit/a880396af1e29a6ed32c3c64332728d289a46cc7) | `` python311Packages.schema-salad: 8.5.20231201181309 -> 8.5.20240102191336.dev7+g8e95468 (#281925) `` |
| [`90cae4d9`](https://github.com/NixOS/nixpkgs/commit/90cae4d942269df2d9a5909e7a2f9bb7179926f2) | `` qt6.qtwebengine: force signing darwin binaires ``                                                   |
| [`60875811`](https://github.com/NixOS/nixpkgs/commit/6087581124ef38967d6424754b90603a69f086fa) | `` python311Packages.plugwise: 0.36.2 -> 0.36.3 ``                                                     |
| [`400bbf68`](https://github.com/NixOS/nixpkgs/commit/400bbf68c65348fe79cf3e7061adb54ec85a8755) | `` eza: 0.17.1 -> 0.17.2 ``                                                                            |
| [`41ad0e47`](https://github.com/NixOS/nixpkgs/commit/41ad0e477d7ed96affdea49f6224034eda281296) | `` SPAdes: fix build ``                                                                                |
| [`49468786`](https://github.com/NixOS/nixpkgs/commit/49468786179f3f9b7897f5ae6b44666a5427fa45) | `` buck2: unstable-2023-10-15 -> unstable-2024-01-15 (#282344) ``                                      |
| [`8406235c`](https://github.com/NixOS/nixpkgs/commit/8406235c376d1fe30557227acda8bb92351be630) | `` python311Packages.mypy-boto3-builder: refactor ``                                                   |
| [`fb6b8460`](https://github.com/NixOS/nixpkgs/commit/fb6b84603e01b0e33b80fbab3ea41aea50f69fc0) | `` cudaPackages.backendStdenv: drop the commented out code ``                                          |
| [`46692a15`](https://github.com/NixOS/nixpkgs/commit/46692a1507472db12656c1e15fec8692e144bc8c) | `` yosys: 0.36 -> 0.37 ``                                                                              |
| [`a6f96f04`](https://github.com/NixOS/nixpkgs/commit/a6f96f04c802608b46b70715f70d5cc25ebc77ec) | `` sapling: 0.2.20231113-145254 -> 0.2.20240116-133042 ``                                              |
| [`e48abe92`](https://github.com/NixOS/nixpkgs/commit/e48abe92fdff087e6e6755edab9ccd2fe0166b8d) | `` cudaPackages.cuda_nvcc: back-end cc already exposes the c++ stdlib ``                               |
| [`1588f246`](https://github.com/NixOS/nixpkgs/commit/1588f246c2470a838dd4a68f166450f7a8072fa3) | `` allegro5: 5.2.9.0 -> 5.2.9.1 ``                                                                     |
| [`b47e7bf3`](https://github.com/NixOS/nixpkgs/commit/b47e7bf35c9d363687a7830777bee9261793b434) | `` fac: move to by-name ``                                                                             |
| [`5fc2b855`](https://github.com/NixOS/nixpkgs/commit/5fc2b855c16df768145cc39f4030ea4bb5fbc213) | `` fast-ssh: fix build issue due to ambiguous trait impls ``                                           |
| [`de6d7c37`](https://github.com/NixOS/nixpkgs/commit/de6d7c3774d44bdf3413d0e0df4856437a0adf63) | `` python311Packages.pylint-django: refactor ``                                                        |
| [`4b2a6659`](https://github.com/NixOS/nixpkgs/commit/4b2a66591c2c17ea47a447a1f7c4d4e39dc4ade5) | `` python311Packages.pylint-plugin-utils: 0.7 -> 0.8.2 ``                                              |
| [`814f8574`](https://github.com/NixOS/nixpkgs/commit/814f85740eba8d7f1e480028f9abba83c76e8bad) | `` python311Packages.pylint-plugin-utils: refactor ``                                                  |
| [`f1557a2d`](https://github.com/NixOS/nixpkgs/commit/f1557a2d2c2c3cb59b6cdb5ff36b60be19a8832c) | `` python310Packages.pyatspi: 2.46.0 -> 2.46.1 ``                                                      |