### PR TITLE
chore(flake/home-manager): `2d47379a` -> `3df2a80f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -373,11 +373,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705879479,
-        "narHash": "sha256-ZIohbyly1KOe+8I3gdyNKgVN/oifKdmeI0DzMfytbtg=",
+        "lastModified": 1706001011,
+        "narHash": "sha256-J7Bs9LHdZubgNHZ6+eE/7C18lZ1P6S5/zdJSdXFItI4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2d47379ad591bcb14ca95a90b6964b8305f6c913",
+        "rev": "3df2a80f3f85f91ea06e5e91071fa74ba92e5084",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`3df2a80f`](https://github.com/nix-community/home-manager/commit/3df2a80f3f85f91ea06e5e91071fa74ba92e5084) | `` zoxide: fix nushell 0.89 deprecation `` |
| [`3d0dc78e`](https://github.com/nix-community/home-manager/commit/3d0dc78e80031731240c979d87eed8e090d35439) | `` bemenu: allow floats in settings ``     |