### PR TITLE
chore(flake/stylix): `a9e3ce06` -> `423c819d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705668784,
-        "narHash": "sha256-U/1Qol9H5nb8FtWSXSiHY8T4Y7TOIo7NHuqe4uuiBec=",
+        "lastModified": 1706044714,
+        "narHash": "sha256-tkYtaYSfxwzmtRFozlYyaZ6SY43gi03Q5PjtcA0WO70=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a9e3ce064a778b386fb88fb152c02ae95aa2cbd2",
+        "rev": "423c819d7702a78c52a80df7721d6c04bcbf2eab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                           |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`423c819d`](https://github.com/danth/stylix/commit/423c819d7702a78c52a80df7721d6c04bcbf2eab) | `` bemenu: move over to upstream module (#206) `` |
| [`bf31640f`](https://github.com/danth/stylix/commit/bf31640f49cb115508c31bf3bd0b4b80bb8ab71d) | `` doc: specify commit message format ``          |