### PR TITLE
chore(flake/stylix): `423c819d` -> `81de262b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706044714,
-        "narHash": "sha256-tkYtaYSfxwzmtRFozlYyaZ6SY43gi03Q5PjtcA0WO70=",
+        "lastModified": 1706101148,
+        "narHash": "sha256-LkBGT5bIUsDcnThwLsbqgzCQeq0RoiW7mjBsziPgxC0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "423c819d7702a78c52a80df7721d6c04bcbf2eab",
+        "rev": "81de262bf170ce4152950402e17eba1453a3ebfe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                        |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`81de262b`](https://github.com/danth/stylix/commit/81de262bf170ce4152950402e17eba1453a3ebfe) | `` rofi: allow theme customizability (#230) `` |
| [`606a7983`](https://github.com/danth/stylix/commit/606a7983a0199004bdbeab898472e2ffd963dde5) | `` doc: update 'base16.nix' URL (#227) ``      |