### PR TITLE
chore(flake/home-manager): `6b28ab2d` -> `e8481103`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -373,11 +373,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706080884,
-        "narHash": "sha256-qhxisCrSraN5YWVb0lNCFH8ovqnCw5W9ldac4Dzr0Nw=",
+        "lastModified": 1706099765,
+        "narHash": "sha256-pt98CX+WkTwtnDdu+9kGnuia/3s5krsUqYOSGOYbuHk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6b28ab2d798c1c84e24053d95f4ee1dd9d81e2fb",
+        "rev": "e84811035d7c8ec79ed6c687a97e19e2a22123c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`e8481103`](https://github.com/nix-community/home-manager/commit/e84811035d7c8ec79ed6c687a97e19e2a22123c1) | `` treewide: deprecate `VERBOSE_ECHO` ``                     |
| [`190c6f46`](https://github.com/nix-community/home-manager/commit/190c6f46090a62ad025828bd8e16799d8fcdab1e) | `` home-manager: avoid running empty `nix profile remove` `` |
| [`42567290`](https://github.com/nix-community/home-manager/commit/425672900691a16a897fc47b4d5c3013d2a822a0) | `` treewide: deprecate `DRY_RUN_CMD` and `DRY_RUN_NULL` ``   |