### PR TITLE
chore(flake/home-manager): `70688f19` -> `c7ce343d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -373,11 +373,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706219816,
-        "narHash": "sha256-f4Dyog4XQHWuq6ElFN+tOYrpHeiHdfAQ2qSABQTULXY=",
+        "lastModified": 1706221476,
+        "narHash": "sha256-T4b8YafVjHXvtDY8ARec1WrXO8uyyNZOpNgv9yoQy2M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "70688f195a294a09d31d6bfe339bb090d443e949",
+        "rev": "c7ce343d9bf1a329056a4dd5b32ea8cc43b55e15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`c7ce343d`](https://github.com/nix-community/home-manager/commit/c7ce343d9bf1a329056a4dd5b32ea8cc43b55e15) | `` home-manager: add extendModules attribute `` |
| [`c82e52b0`](https://github.com/nix-community/home-manager/commit/c82e52b0d96eb9f1c8334add871dce8e837d043b) | `` flake.lock: Update ``                        |
| [`03958aff`](https://github.com/nix-community/home-manager/commit/03958aff4415a5278d0ea462db370e9d770e904e) | `` firefox: add default containers ``           |