### PR TITLE
chore(flake/home-manager): `c7ce343d` -> `b2f56952`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -373,11 +373,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706221476,
-        "narHash": "sha256-T4b8YafVjHXvtDY8ARec1WrXO8uyyNZOpNgv9yoQy2M=",
+        "lastModified": 1706306660,
+        "narHash": "sha256-lZvgkHtVeduGByPb0Tz9LpAi4olfkEm8XPgv0o7GRsk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c7ce343d9bf1a329056a4dd5b32ea8cc43b55e15",
+        "rev": "b2f56952074cb46e93902ecaabfb04dd93733434",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`b2f56952`](https://github.com/nix-community/home-manager/commit/b2f56952074cb46e93902ecaabfb04dd93733434) | `` network-manager-applet: add XDG data directory `` |
| [`690764d2`](https://github.com/nix-community/home-manager/commit/690764d2dcfccf01ddfc9f19220c88182339f40f) | `` firefox: Reimplement FF native messaging ``       |