### PR TITLE
chore(flake/nix-index-database): `2c1a58ea` -> `c782f2a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -466,11 +466,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706410643,
-        "narHash": "sha256-L7ebEULKK8ZWkMfuZJQgxYIYx3+V7SXm0mE8EM8ZRJo=",
+        "lastModified": 1706411424,
+        "narHash": "sha256-BzziJYucEZvdCE985vjPoo3ztWcmUiSQ1wJ2CoT6jCc=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "2c1a58ea29af0bd3da947c6bb3e7a7704a2f972b",
+        "rev": "c782f2a4f6fc94311ab5ef31df2f1149a1856181",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`c782f2a4`](https://github.com/nix-community/nix-index-database/commit/c782f2a4f6fc94311ab5ef31df2f1149a1856181) | `` update packages.nix to release 2024-01-28-030920 `` |