### PR TITLE
chore(flake/home-manager): `b2f56952` -> `ebba24a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -373,11 +373,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706306660,
-        "narHash": "sha256-lZvgkHtVeduGByPb0Tz9LpAi4olfkEm8XPgv0o7GRsk=",
+        "lastModified": 1706435169,
+        "narHash": "sha256-YKAeTJI17WCteT1MC01VXU1qmIzR9T0Hej6bSmnmgsA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b2f56952074cb46e93902ecaabfb04dd93733434",
+        "rev": "ebba24a6fefa3d749291be7192ef817736a10bd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`ebba24a6`](https://github.com/nix-community/home-manager/commit/ebba24a6fefa3d749291be7192ef817736a10bd1) | `` wob: add module ``                              |
| [`7a461c70`](https://github.com/nix-community/home-manager/commit/7a461c70ed20e7e4a2af1710fdfb89ec70473e47) | `` firefox: fix darwin NativeMessagingHostsPath `` |
| [`e5f2a059`](https://github.com/nix-community/home-manager/commit/e5f2a0590a9387e17e6433b280e45d14f82683b4) | `` flake.lock: Update (#4964) ``                   |