### PR TITLE
chore(flake/darwin): `0108864c` -> `00538eec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -220,11 +220,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706405065,
-        "narHash": "sha256-femlVBNWgr9a6HfBUzhBF/9S8VBlaHDKcEm8B89O+zc=",
+        "lastModified": 1706497381,
+        "narHash": "sha256-VzzLBvm4ejehe42yKlCUjG3op3NLXq78MKS8u/W3NLQ=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "0108864c15bb68ad57d17fb2e7d3a3e025751d79",
+        "rev": "00538eecf2d1a8f98a53a71c9c84f913003ec5e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                               |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`492944b0`](https://github.com/LnL7/nix-darwin/commit/492944b0f2c539240dc99392eb07f9064cb93c93) | `` Update darwin-rebuild.zsh-completions ``           |
| [`0f0478ef`](https://github.com/LnL7/nix-darwin/commit/0f0478efa68e442dd46fc64d46889da7c0859ad5) | `` Add zsh completions to darwin-rebuld by default `` |