### PR TITLE
chore(flake/flake-parts): `bffc4be1` -> `60c61400`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -280,11 +280,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1706551415,
-        "narHash": "sha256-15s36w8kG2XIdhGBdQVuPiY+gQxWrvcGA9AszmvHBGQ=",
+        "lastModified": 1706569497,
+        "narHash": "sha256-oixb0IDb5eZYw6BaVr/R/1pSoMh4rfJHkVnlgeRIeZs=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "bffc4be17f13c1e43aac906a62e1a6e5ae369c6b",
+        "rev": "60c614008eed1d0383d21daac177a3e036192ed8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`b60b914a`](https://github.com/hercules-ci/flake-parts/commit/b60b914ac6f706bdb6e55c0eadeffa732a60bd16) | `` dev: Make the test slightly more sensible ``  |
| [`14114c56`](https://github.com/hercules-ci/flake-parts/commit/14114c563acab4cee2828aa8dad9036d617e1ea2) | `` templates: make flake-parts input explicit `` |