### PR TITLE
chore(flake/darwin): `00538eec` -> `91b9daf6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -220,11 +220,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706497381,
-        "narHash": "sha256-VzzLBvm4ejehe42yKlCUjG3op3NLXq78MKS8u/W3NLQ=",
+        "lastModified": 1706581965,
+        "narHash": "sha256-1H7dRdK9LJ7+2X1XQtbwXr+QMqtVVo/ZF0/LIvkjdK8=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "00538eecf2d1a8f98a53a71c9c84f913003ec5e8",
+        "rev": "91b9daf672c957ef95a05491a75f62e6a01d5aaf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                        |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
| [`30311b6f`](https://github.com/LnL7/nix-darwin/commit/30311b6f90b333fcef1967a5fd139340c301b6f0) | `` services/yabai: Remove --check-sa and --install-sa flags `` |