### PR TITLE
chore(flake/nixos-hardware): `42d7e506` -> `83ce5906`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1706767243,
-        "narHash": "sha256-0Am7wcB4Tt4t6IZLRWv9fivfgyKmVoMczigoetKeuiQ=",
+        "lastModified": 1706781693,
+        "narHash": "sha256-a0PuIeh+hUXXWWQWQ1wFWyNsCiUUCFKVXSUiHpyxlVQ=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "42d7e506777436d5e98ca02bd4a5f2da451cf485",
+        "rev": "83ce5906a5b9a798ef2e653ddc12491c1b9e9929",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`83ce5906`](https://github.com/NixOS/nixos-hardware/commit/83ce5906a5b9a798ef2e653ddc12491c1b9e9929) | `` ga401: disable hardware.nvidia.powerManagement.enable `` |
| [`80223acd`](https://github.com/NixOS/nixos-hardware/commit/80223acd7f2cfe4ea103bc7e0d671f8a23b35990) | `` ga401: enable nvidia.dynamicBoost ``                     |