### PR TITLE
chore(flake/nixos-hardware): `cc65e276` -> `83e571bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1706782449,
-        "narHash": "sha256-8hEkOJDqR+7gJvXzwIM/VhR9iQzZyrNeh68u+Et2TzA=",
+        "lastModified": 1706834982,
+        "narHash": "sha256-3CfxA7gZ+DVv/N9Pvw61bV5Oe/mWfxYPyVQGqp9TMJA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "cc65e27670abccced5997d4a93c4c930aef6fd0b",
+        "rev": "83e571bb291161682b9c3ccd48318f115143a550",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
| [`88712a12`](https://github.com/NixOS/nixos-hardware/commit/88712a124b9a15e8b487d9bec9847ba0aa876d2c) | `` Pick a better name than "versionsOfOption" ``                                                                                      |
| [`85a2b554`](https://github.com/NixOS/nixos-hardware/commit/85a2b5542eed00c5d3362394cc1aca575b963e3a) | `` Restore the "majorVersion" functionality ``                                                                                        |
| [`c5214dc0`](https://github.com/NixOS/nixos-hardware/commit/c5214dc06a29ce79fbd22e256037e4852ad8a29f) | `` Add some functions to allow for a major.minor kernel version to be able to auto-allow the major.minor.patch to be auto-selected `` |
| [`606b6a27`](https://github.com/NixOS/nixos-hardware/commit/606b6a270e7b9aed4164b088ce8d6c0c9458c7d9) | `` Drop the kernel version override for Surface Go hardware ``                                                                        |
| [`7def5339`](https://github.com/NixOS/nixos-hardware/commit/7def5339687ab801e11c8e1395b533ba270e3748) | `` Drop the deprecated "linuxPackage1" function, rename "linuxPackage2" to "linuxPackage" ``                                          |
| [`62b6776b`](https://github.com/NixOS/nixos-hardware/commit/62b6776b46ef2ae54e529f3b511e9be0736c3837) | `` Fix rev and sha256 for the current linux-surface patches ``                                                                        |
| [`7dcae71f`](https://github.com/NixOS/nixos-hardware/commit/7dcae71f6107a92991c5c37e7f090684cc3b10c2) | `` Fix typos ``                                                                                                                       |
| [`0e169f3d`](https://github.com/NixOS/nixos-hardware/commit/0e169f3d58c8b8f088aff60cb8a8cdfb49254caa) | `` Use kernel 6.6.2 by default ``                                                                                                     |
| [`0516b822`](https://github.com/NixOS/nixos-hardware/commit/0516b822878bb28639bc1c9176f4889e7fbd83bb) | `` Add kernel 6.6 ``                                                                                                                  |
| [`8605f354`](https://github.com/NixOS/nixos-hardware/commit/8605f354e2409ce5f7a9ad3589427e3d11937674) | `` Use a new linuxPackage function ``                                                                                                 |