### PR TITLE
chore(flake/home-manager): `230836bb` -> `4ab01785`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -373,11 +373,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707029945,
-        "narHash": "sha256-GA6IOAKouQlTbile9PvAa3UUh7s5mi6NsZMX8lpgozg=",
+        "lastModified": 1707074442,
+        "narHash": "sha256-+VOe+26+rK6ETNpVvwkFYlfC/skZe2XI2TixbsC6utE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "230836bb7ca318aec7bad8442954da611d06a172",
+        "rev": "4ab01785b85aac4dd0f0414f7c0ca4c007e64054",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`4ab01785`](https://github.com/nix-community/home-manager/commit/4ab01785b85aac4dd0f0414f7c0ca4c007e64054) | `` flake.lock: Update ``                |
| [`9291f28f`](https://github.com/nix-community/home-manager/commit/9291f28f93a818e4496a6f71f6c77f59108d4d46) | `` Translate using Weblate (Turkish) `` |