### PR TITLE
chore(flake/home-manager): `f80df90c` -> `4740f2cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -373,11 +373,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707086201,
-        "narHash": "sha256-H3GzLZhfAMgSRRZqXmM2z+KHdaOv3ySrBnV/h7K6Pjg=",
+        "lastModified": 1707088232,
+        "narHash": "sha256-nxPBAZ//BwKkBcjwLE5g9zTq29g7gccTnH5+CeMTxpA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f80df90c105d081a49d123c34a57ead9dac615b9",
+        "rev": "4740f2ccda184e9cc509d7a82b26d7271e0c79d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`4740f2cc`](https://github.com/nix-community/home-manager/commit/4740f2ccda184e9cc509d7a82b26d7271e0c79d9) | `` kitty: always export `KITTY_SHELL_INTEGRATION` ``    |
| [`1683c507`](https://github.com/nix-community/home-manager/commit/1683c507c2c58a502294330de940e2b4b51bdf75) | `` vdirsyncer: create postHook script when non-empty `` |