### PR TITLE
chore(flake/home-manager): `afcedcf2` -> `3c6f2dd5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -373,11 +373,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707114923,
-        "narHash": "sha256-LDYPWa+BgxHSNEye93SyIPgz5u3RAfh78P9KyO+rQzI=",
+        "lastModified": 1707170620,
+        "narHash": "sha256-0LaSEAVyemXeFrhhz+071/0yx4ZKtTOgrReli7ciPMU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "afcedcf2c8e424d0465e823cf833eb3adebe1db7",
+        "rev": "3c6f2dd59cb8c0b06ed1fe01f297e75bbaec3003",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`3c6f2dd5`](https://github.com/nix-community/home-manager/commit/3c6f2dd59cb8c0b06ed1fe01f297e75bbaec3003) | `` himalaya: adjust module for v1.0.0-beta `` |
| [`274bd470`](https://github.com/nix-community/home-manager/commit/274bd470a544647d90d7491037fdf8af61b7d8d0) | `` nix-gc: add service ``                     |