### PR TITLE
chore(flake/home-manager): `3c6f2dd5` -> `f65dcd6c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -373,11 +373,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707170620,
-        "narHash": "sha256-0LaSEAVyemXeFrhhz+071/0yx4ZKtTOgrReli7ciPMU=",
+        "lastModified": 1707172926,
+        "narHash": "sha256-EPVFupuUcSgZ9HD9T+kGVCPeAcZBtByT5f5iEZw23/A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3c6f2dd59cb8c0b06ed1fe01f297e75bbaec3003",
+        "rev": "f65dcd6c15db0fc2045d56ef8fdf4a03aa52e81f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`f65dcd6c`](https://github.com/nix-community/home-manager/commit/f65dcd6c15db0fc2045d56ef8fdf4a03aa52e81f) | `` neomutt: fix crypt_use_gpgme in newer versions ``      |
| [`7b4ea8d8`](https://github.com/nix-community/home-manager/commit/7b4ea8d82fdeaa71ab942a8a8f6f8add8afdfad0) | `` arrpc: add module ``                                   |
| [`13dbf262`](https://github.com/nix-community/home-manager/commit/13dbf2623d6465d5c4db54ce8a5a630dce79c3e9) | `` swayosd: update executable ``                          |
| [`b319781e`](https://github.com/nix-community/home-manager/commit/b319781e304c668da0ef144b1b4ee48977d4877d) | `` home-manager: Check VISUAL before EDITOR for editor `` |