### PR TITLE
chore(flake/home-manager): `4c0357ff` -> `fb0196ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,11 +390,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707591592,
-        "narHash": "sha256-sTFPBn9MnJHcoBcG+xpljsG/JGJxPaevpzhdOrW2uf0=",
+        "lastModified": 1707602461,
+        "narHash": "sha256-bcorq66MMPqkrTwk25ywn4Q2I2jDeUAExL9ASH6I6mE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4c0357ff874f8250fcae621d5626aba1c7161710",
+        "rev": "fb0196ad9d18554e035de27d4f2a906ba050b407",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`fb0196ad`](https://github.com/nix-community/home-manager/commit/fb0196ad9d18554e035de27d4f2a906ba050b407) | `` imapnotify: enable STARTTLS if enabled in email account config (#5013) `` |