### PR TITLE
chore(flake/nix-index-database): `2fc7cf56` -> `0cb43457`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -483,11 +483,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707620243,
-        "narHash": "sha256-Yvt41OOnaHeh9EAcYw90+OtmbeEQSVX60AnEGwcwO3A=",
+        "lastModified": 1707620986,
+        "narHash": "sha256-XE0tCSkSVBeJDWhjFwusNInwAhrnp+TloUNUpvnTiLw=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "2fc7cf56050f0d3e1f793cfee0f88f894870035e",
+        "rev": "0cb4345704123492e6d1f1068629069413c80de0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`0cb43457`](https://github.com/nix-community/nix-index-database/commit/0cb4345704123492e6d1f1068629069413c80de0) | `` update packages.nix to release 2024-02-11-030837 `` |