### PR TITLE
chore(flake/darwin): `bdbae6ec` -> `44f50a5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -220,11 +220,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706833576,
-        "narHash": "sha256-w7BL0EWRts+nD1lbLECIuz6fRzmmV+z8oWwoY7womR0=",
+        "lastModified": 1707707289,
+        "narHash": "sha256-YuDt/eSTXMEHv8jS8BEZJgqCcG8Tr3cyqaZjJFXZHsw=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "bdbae6ecff8fcc322bf6b9053c0b984912378af7",
+        "rev": "44f50a5ecaab72a61d5fd8e5c5717bc4bf9c25dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                               |
| ------------------------------------------------------------------------------------------------ | ------------------------------------- |
| [`37eb625d`](https://github.com/LnL7/nix-darwin/commit/37eb625dd4a4ab6ea09d31ca1b159526aaa85ec6) | `` security.sudo.extraConfig: init `` |