### PR TITLE
chore(flake/lanzaboote): `71fb5122` -> `96181a46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -439,11 +439,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1707742806,
-        "narHash": "sha256-rYDoODYqYphsYJBs2EOkDNfLxe6Boq9BGtaCE4tVAI0=",
+        "lastModified": 1707777617,
+        "narHash": "sha256-gU2TLJuSNENQ8e61YayDcBUyWwAKbyO8VCosAklxuGc=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "71fb51225c124a84847a01300d605b91ab318621",
+        "rev": "96181a4667a811e4408cbc45092ac42a17a46d74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                            |
| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`5de0b3e5`](https://github.com/nix-community/lanzaboote/commit/5de0b3e54a05aaf0faa3ab42fea5ac09008109aa) | `` stub: rename sections for UKI compatibility ``  |
| [`14afe7ce`](https://github.com/nix-community/lanzaboote/commit/14afe7ce9b71560e2edd26ac78bba32145c0b593) | `` tests: check whether our UKIs are recognized `` |