### PR TITLE
chore(flake/nixos-hardware): `2b68ccd7` -> `f1b2f71c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1707821782,
-        "narHash": "sha256-j5fSpKvEUNkELEQXnQbJHGa5QI7ChbMqWMsyUjc/Bo8=",
+        "lastModified": 1707842204,
+        "narHash": "sha256-M+HAq1qWQBi/gywaMZwX0odU+Qb/XeqVeANGKRBDOwU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2b68ccd7475362b8c8d6a1805b403033ba6273a8",
+        "rev": "f1b2f71c86a5b1941d20608db0b1e88a07d31303",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`f1b2f71c`](https://github.com/NixOS/nixos-hardware/commit/f1b2f71c86a5b1941d20608db0b1e88a07d31303) | `` Update repository path for nxp/imx `` |