### PR TITLE
chore(flake/nixpkgs): `f9d39fb9` -> `a4d4fe8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707689078,
-        "narHash": "sha256-UUGmRa84ZJHpGZ1WZEBEUOzaPOWG8LZ0yPg1pdDF/yM=",
+        "lastModified": 1707956935,
+        "narHash": "sha256-ZL2TrjVsiFNKOYwYQozpbvQSwvtV/3Me7Zwhmdsfyu4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f9d39fb9aff0efee4a3d5f4a6d7c17701d38a1d8",
+        "rev": "a4d4fe8c5002202493e87ec8dbc91335ff55552c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`3b27f2ac`](https://github.com/NixOS/nixpkgs/commit/3b27f2ac6eba07a4c9bbbfb963fb020b25438bec) | `` xfitter: fix for recent clang (#288816) ``                                        |
| [`bc010914`](https://github.com/NixOS/nixpkgs/commit/bc010914b07ad0e5e25d4eecc1669c2565d63479) | `` elegant-sddm: init at unstable-2024-02-08 ``                                      |
| [`d0d9d482`](https://github.com/NixOS/nixpkgs/commit/d0d9d482fc7fe540d382b32395ba64f8713c2426) | `` robo: 4.0.4 -> 4.0.6 ``                                                           |
| [`ac35d418`](https://github.com/NixOS/nixpkgs/commit/ac35d418f439c499665836de5ef9b5c91c0bee05) | `` phpdocumentor: 3.4.1 -> 3.4.3, fix the build ``                                   |
| [`2ed28e8f`](https://github.com/NixOS/nixpkgs/commit/2ed28e8f2defd0fa6b9501efd1aabfb44313d282) | `` phpPackages.composer: apply patch for CVE-2024-24821 ``                           |
| [`943a0a26`](https://github.com/NixOS/nixpkgs/commit/943a0a26d265ecd14a2b23d420dc1ef8e16035e6) | `` cockpit: 310.2 -> 311 ``                                                          |
| [`fa9b05bc`](https://github.com/NixOS/nixpkgs/commit/fa9b05bc7907af726f4d1a3d9f168b2d45f4b872) | `` zoxide: unstable-2023-11-20 -> 0.9.3 ``                                           |
| [`ac6c0ae7`](https://github.com/NixOS/nixpkgs/commit/ac6c0ae75d205f037eabea4c096ddf1bf1eb0b6e) | `` python3Packages.lttng: Explain use of PYTHON environment variable ``              |
| [`9d897b26`](https://github.com/NixOS/nixpkgs/commit/9d897b2643c3a51b275792e9e9203cee59ebf0d0) | `` python3Packages.lttng: init at 2.13.11 ``                                         |
| [`c9214098`](https://github.com/NixOS/nixpkgs/commit/c92140986ffb768ded304de1f2d70b7bcc6a35ae) | `` lilypond-unstable: 2.25.12 -> 2.25.13 ``                                          |
| [`2b2cacf3`](https://github.com/NixOS/nixpkgs/commit/2b2cacf30be2a2b33095303fe47484b85475b524) | `` androidStudioPackages.canary: 2023.3.1.8 -> 2023.3.1.9 ``                         |
| [`9f708e32`](https://github.com/NixOS/nixpkgs/commit/9f708e32ddb35ef7b1c75704bfca7d621d72f03d) | `` androidStudioPackages.beta: 2023.2.1.21 -> 2023.2.1.22 ``                         |
| [`16cd4f0b`](https://github.com/NixOS/nixpkgs/commit/16cd4f0b38cc4e84481cceac399b90d059f7a128) | `` meilisearch: 1.6.1 -> 1.6.2 ``                                                    |
| [`aaefde6b`](https://github.com/NixOS/nixpkgs/commit/aaefde6b8eb01cfea742f984018c97bd9ebe66b7) | `` renode-dts2repl: unstable-2024-02-08 -> unstable-2024-02-14 ``                    |
| [`57be4965`](https://github.com/NixOS/nixpkgs/commit/57be4965f4cbcd5fee0c0a53ddffb0ee9e48e21f) | `` python312Packages.smtpdfix: disable blocking test ``                              |
| [`7428d205`](https://github.com/NixOS/nixpkgs/commit/7428d20516e30dfae7e24b7503cd4d10699a7db0) | `` circleci-cli: 0.1.29936 -> 0.1.30084 ``                                           |
| [`fca54ccb`](https://github.com/NixOS/nixpkgs/commit/fca54ccbf52650f380b59185cec6f14c4ad2a209) | `` mastodon: 4.2.5 -> 4.2.6 ``                                                       |
| [`db9aa515`](https://github.com/NixOS/nixpkgs/commit/db9aa515178cf3fa6f1c307c76e90eb909918469) | `` python311Packages.courlan: 0.9.5 -> 1.0.0 ``                                      |
| [`6e4d2b3d`](https://github.com/NixOS/nixpkgs/commit/6e4d2b3d476ec1c6fa87eda69f0055507f0ec489) | `` postgresql12JitPackages.tds_fdw: unstable-2023-12-04 -> unstable-2024-02-10 ``    |
| [`279bfa80`](https://github.com/NixOS/nixpkgs/commit/279bfa80e862efa6403d3b7a9b22cdeca16da5a9) | `` pdns-recursor: 4.9.2 -> 4.9.3 ``                                                  |
| [`7832456e`](https://github.com/NixOS/nixpkgs/commit/7832456e4c50a06f1944ce3aa296bbf588fa6ca3) | `` python311Packages.fastembed: fix build ``                                         |
| [`722ecf16`](https://github.com/NixOS/nixpkgs/commit/722ecf16d462bd73811f83406e8167c6fbfc8d61) | `` python311Packages.sphinx-book-theme: 1.1.1 -> 1.1.2 ``                            |
| [`46812072`](https://github.com/NixOS/nixpkgs/commit/46812072e8d7b4416f94d8f546a9dbc7a8856d99) | `` ledfx: fix formatting ``                                                          |
| [`13c42afc`](https://github.com/NixOS/nixpkgs/commit/13c42afcd20b96e04281eb63feeb1a6f699c9a6c) | `` mopidy-spotify: unstable-2024-01-02 -> unstable-2024-02-11 ``                     |
| [`d0aaa221`](https://github.com/NixOS/nixpkgs/commit/d0aaa22186933f72b436541cc70c290b8a3e59bc) | `` yor: 0.1.188 -> 0.1.189 ``                                                        |
| [`ce87169e`](https://github.com/NixOS/nixpkgs/commit/ce87169ec1ed5a0a525cd9472bf4d48c3ed5e586) | `` terragrunt: 0.55.1 -> 0.55.2 ``                                                   |
| [`e9db7312`](https://github.com/NixOS/nixpkgs/commit/e9db731286ee9ba1518f51e63c81ff28abe88e04) | `` podman: 4.9.2 -> 4.9.3 ``                                                         |
| [`334ee150`](https://github.com/NixOS/nixpkgs/commit/334ee1504bcad5ca8e1cf88083fa734de6fef61f) | `` simplotask: 1.13.0 -> 1.13.1 ``                                                   |
| [`76fd69c6`](https://github.com/NixOS/nixpkgs/commit/76fd69c674dcb3fe75e8ff97d8219f2392d7d5a0) | `` gdal: wrap executables in environment containing numpy ``                         |
| [`c5f2f034`](https://github.com/NixOS/nixpkgs/commit/c5f2f03426be8903a3ca4ff404752c7e67650035) | `` lemon-graph: fix C++17 build ``                                                   |
| [`a43509ab`](https://github.com/NixOS/nixpkgs/commit/a43509abb4d5da1372d40da0683f5e224fb2b873) | `` nextcloud-client: 3.11.1 -> 3.12.0 ``                                             |
| [`d3ab1559`](https://github.com/NixOS/nixpkgs/commit/d3ab155939addb6b6de5c05b146bd31e8c34a297) | `` python311Packages.crc: refactor ``                                                |
| [`3a95d50c`](https://github.com/NixOS/nixpkgs/commit/3a95d50c08c2200c96db5b81bed6c9d49b4139d6) | `` links2: fix darwin build ``                                                       |
| [`88375096`](https://github.com/NixOS/nixpkgs/commit/88375096b0e1b8de6a1ff25c0556690ca2f2185f) | `` python312Packages.uqbar: disable failing test on Python 3.12 ``                   |
| [`91414c63`](https://github.com/NixOS/nixpkgs/commit/91414c639fe1dc2f5dff6943ecf375e5b117e974) | `` openmvg: unstable-2022-12-30 -> 2.1 ``                                            |
| [`782350f9`](https://github.com/NixOS/nixpkgs/commit/782350f934e635ea08c00aca0ad20e757f777c3d) | `` cargo-tally: 1.0.35 -> 1.0.36 ``                                                  |
| [`3d8c54ee`](https://github.com/NixOS/nixpkgs/commit/3d8c54ee89cbbe4fa7034f01eeb50b5dda850470) | `` python311Packages.uqbar: 0.7.0 -> 0.7.1 ``                                        |
| [`dae81036`](https://github.com/NixOS/nixpkgs/commit/dae81036fea005e5c170463853c3152156fe42d9) | `` python311Packages.uqbar: refactor ``                                              |
| [`a3014c3e`](https://github.com/NixOS/nixpkgs/commit/a3014c3e9b4cddfbc8e2a840b5a436d0abcae105) | `` python311Packages.pytenable: 1.4.19 -> 1.4.20 ``                                  |
| [`c85fd10b`](https://github.com/NixOS/nixpkgs/commit/c85fd10b82c99c442c68178b5590e6700ebe7eeb) | `` gitkraken: 9.11.1 -> 9.12.0 ``                                                    |
| [`c3ed0024`](https://github.com/NixOS/nixpkgs/commit/c3ed002499f9fd61b31934797ebfc03db1ae14e9) | `` hyprlang: 0.3.0 -> 0.3.1 ``                                                       |
| [`31a78962`](https://github.com/NixOS/nixpkgs/commit/31a78962dbf7e16ad4598dfbc6491040f6a1b919) | `` multipass: 1.13.0 -> 1.13.1 ``                                                    |
| [`468aaeb3`](https://github.com/NixOS/nixpkgs/commit/468aaeb3a31c5c0538a2417acd6565b07d5a7591) | `` python311Packages.crc: 6.1.0 -> 6.1.1 ``                                          |
| [`fe36c13a`](https://github.com/NixOS/nixpkgs/commit/fe36c13a9142ec880c034ead5132daf1a30be915) | `` python311Packages.connexion: 3.0.5 -> 3.0.6 ``                                    |
| [`f4503afe`](https://github.com/NixOS/nixpkgs/commit/f4503afe9db2d07e7e3319aa47edab12cd45853b) | `` kokkos: 4.2.00 -> 4.2.01 ``                                                       |
| [`c63bb057`](https://github.com/NixOS/nixpkgs/commit/c63bb0578e986ff201a904228970f9a7d461e94b) | `` python311Packages.pymicrobot: 0.0.12 -> 0.0.15 ``                                 |
| [`da7cf0c5`](https://github.com/NixOS/nixpkgs/commit/da7cf0c515c0e07c856f312a77d19933769d8d3f) | `` spicetify-cli: 2.31.1 -> 2.31.2 ``                                                |
| [`ba631589`](https://github.com/NixOS/nixpkgs/commit/ba63158992f11f05fa387d4058b1bd8624877ccb) | `` dufs: 0.38.0 -> 0.40.0 ``                                                         |
| [`647b06d5`](https://github.com/NixOS/nixpkgs/commit/647b06d51cca7a502d27a206d7454b5a8e0a1545) | `` ocamlPackages.ocaml-lsp: 1.16.2 -> 1.17.0 ``                                      |
| [`58a5225e`](https://github.com/NixOS/nixpkgs/commit/58a5225e39167a40685f9206081efb1e912e6e3a) | `` dune_3: 3.13.1 -> 3.14.0 (#288510) ``                                             |
| [`54611541`](https://github.com/NixOS/nixpkgs/commit/54611541d9cb145c7c511ac70bc9ee146aca2433) | `` python3Packages.jaxlib-bin: use `autoAddOpenGLRunpathHook` ``                     |
| [`47818d76`](https://github.com/NixOS/nixpkgs/commit/47818d769850aa722a7cc6d51ff8dafdc9b94a0b) | `` netbird-ui: 0.25.7 -> 0.25.8 ``                                                   |
| [`8fa602a2`](https://github.com/NixOS/nixpkgs/commit/8fa602a2e7dd0b3381b8a802c4e0364c472d4dba) | `` python312Packages.posthog: 3.4.0 -> 3.4.1 ``                                      |
| [`877cd073`](https://github.com/NixOS/nixpkgs/commit/877cd07311181c446a68bbcaf8fb16259c5a952a) | `` weaviate: 1.23.8 -> 1.23.9 ``                                                     |
| [`ed0019f7`](https://github.com/NixOS/nixpkgs/commit/ed0019f7dd7fef1919d21ecb13b229d5c6775465) | `` tektoncd-cli: 0.35.0 -> 0.35.1 ``                                                 |
| [`946c87f3`](https://github.com/NixOS/nixpkgs/commit/946c87f3eeef9ab564896851f7cc48252b2346bd) | `` pscale: 0.182.0 -> 0.183.0 ``                                                     |
| [`6e9b5464`](https://github.com/NixOS/nixpkgs/commit/6e9b54646b50d8adee3b3f41317050b80a424a2b) | `` flarectl: 0.87.0 -> 0.88.0 ``                                                     |
| [`456ae1b2`](https://github.com/NixOS/nixpkgs/commit/456ae1b2e82b6d49f44ae839247e3b13138e8b65) | `` homepage-dashboard: 0.8.7 -> 0.8.8 ``                                             |
| [`363d2733`](https://github.com/NixOS/nixpkgs/commit/363d2733c372f000f3c10f0100b2c05a86a0e2b1) | `` raft-canonical: 0.18.0 -> 0.18.1 ``                                               |
| [`f160ed30`](https://github.com/NixOS/nixpkgs/commit/f160ed30f00b3c33db3c447c6611a1a8ab9f504c) | `` src-cli: 5.2.1 -> 5.3.0 ``                                                        |
| [`9ffc44f3`](https://github.com/NixOS/nixpkgs/commit/9ffc44f3ab1970dce31dd135da0c93490068d4e3) | `` got: 0.95 -> 0.96 ``                                                              |
| [`845f08fa`](https://github.com/NixOS/nixpkgs/commit/845f08fa625979033bd20e3843a17fc41e277409) | `` scalingo: 1.30.0 -> 1.30.1 ``                                                     |
| [`1185fc6f`](https://github.com/NixOS/nixpkgs/commit/1185fc6f1847a2c9b3a0129c5a04ef3e934a1b84) | `` kubernetes-polaris: 8.5.4 -> 8.5.5 ``                                             |
| [`5120d493`](https://github.com/NixOS/nixpkgs/commit/5120d4939d6bda0caaaa768f782f69eb44fa1182) | `` consul: 1.17.2 -> 1.17.3 ``                                                       |
| [`e02399bd`](https://github.com/NixOS/nixpkgs/commit/e02399bdd84c9bc2f2414f33e574ba1a8124704f) | `` nodejs_21: 21.6.1 -> 21.6.2 ``                                                    |
| [`19980fc8`](https://github.com/NixOS/nixpkgs/commit/19980fc8a500441da3b7831fae62f0dee139cb64) | `` hyperledger-fabric: 2.5.1 -> 2.5.5 ``                                             |
| [`60bbd39d`](https://github.com/NixOS/nixpkgs/commit/60bbd39dd746fbda929814e917b71e9c0378d5ef) | `` nodejs_20: 20.11.0 -> 20.11.1 ``                                                  |
| [`4ae7cfd8`](https://github.com/NixOS/nixpkgs/commit/4ae7cfd8954b8329def6126417daabc9c54644e1) | `` nodejs_18: 18.19.0 -> 18.19.1 ``                                                  |
| [`0cb84744`](https://github.com/NixOS/nixpkgs/commit/0cb84744d7f9564d85b1716cfea89ff626804267) | `` python312Packages.intbitset: 3.0.2 -> 3.1.0 ``                                    |
| [`df3a1a87`](https://github.com/NixOS/nixpkgs/commit/df3a1a871adcfeb846f42338707afbe019247915) | `` zfsUnstable: 2.2.3-unstable-2024-01-26 → 2.2.3-unstable-2024-02-12 ``             |
| [`b77dcf46`](https://github.com/NixOS/nixpkgs/commit/b77dcf46286a9213e1f62700fb2b9ab1ca882d96) | `` dmtx-utils: 0.7.6 -> 0.7.6-unstable-2023-09-21 ``                                 |
| [`f9ed0a47`](https://github.com/NixOS/nixpkgs/commit/f9ed0a47b017702b1758987866649611686af1ab) | `` python311Packages.stem: 1.8.3-unstable-2024-02-11 -> 1.8.3-unstable-2024-02-13 `` |
| [`6afe1135`](https://github.com/NixOS/nixpkgs/commit/6afe11355cf9b190de40f8cbca9d8eed5bb05830) | `` python311Packages.tensorflow: pin abseil-cpp_202301 ``                            |
| [`238be6ca`](https://github.com/NixOS/nixpkgs/commit/238be6ca117317d84c6f94aed82fdfaabc185757) | `` envoy: 1.27.2 -> 1.27.3 ``                                                        |
| [`5a98ac4b`](https://github.com/NixOS/nixpkgs/commit/5a98ac4bf055cb08d8771dffd5b4ee484431ef7c) | `` python311Packages.qcodes: disable flaky tests ``                                  |
| [`246a3db2`](https://github.com/NixOS/nixpkgs/commit/246a3db24d7266a97af0ff6bdce64f7cf722cba6) | `` ungoogled-chromium: 121.0.6167.160-1 -> 121.0.6167.184-1 ``                       |
| [`9bb6dc13`](https://github.com/NixOS/nixpkgs/commit/9bb6dc139dae38fb7043eb2c9308aa2de23ac2d7) | `` chromium: 121.0.6167.160 -> 121.0.6167.184 ``                                     |
| [`9e33ff71`](https://github.com/NixOS/nixpkgs/commit/9e33ff71831da6106fa01de7c617d495fdfd60c8) | `` chromium: use hashes in upstream-info.nix for tarballs in update script ``        |
| [`75aaea55`](https://github.com/NixOS/nixpkgs/commit/75aaea55f9ec218cb0324fef9bafa710e34087db) | `` maintainers: remove martingms ``                                                  |
| [`c5194c77`](https://github.com/NixOS/nixpkgs/commit/c5194c77ddcdb3b15bb50755fbd4e2242999ccc0) | `` nrr: 0.5.0 -> 0.5.2 ``                                                            |
| [`5eb227c3`](https://github.com/NixOS/nixpkgs/commit/5eb227c31fab2ab3828d1453671ff373fb7f8796) | `` chromium: cache chromium tarball hashes in update script ``                       |
| [`d4ed8d7e`](https://github.com/NixOS/nixpkgs/commit/d4ed8d7e27f40256f7b6ac8f7d3a932da9435f03) | `` python311Packages.numpyro: fix build by disabling failing test ``                 |
| [`5a048883`](https://github.com/NixOS/nixpkgs/commit/5a0488839d1dac10310fc0b44219da572fd31f0f) | `` python311Packages.jax: 0.4.23 -> 0.4.24 ``                                        |
| [`3720ce9c`](https://github.com/NixOS/nixpkgs/commit/3720ce9c3eda12160eab0e6c0ea0d8a706a8eb3b) | `` python311Packages.xrootd: init at 5.6.6 ``                                        |
| [`7b9e1199`](https://github.com/NixOS/nixpkgs/commit/7b9e11995df355b1fab5d116441c43f9515084f5) | `` xrootd: 5.5.5 -> 5.6.6 ``                                                         |
| [`d0977f36`](https://github.com/NixOS/nixpkgs/commit/d0977f36f9376b57a8868beb5433ed373ce723a2) | `` scitokens-cpp: enable on unix ``                                                  |
| [`95d4a838`](https://github.com/NixOS/nixpkgs/commit/95d4a838c8a268c8178823de6722ac781372c970) | `` gtkclipblock: use `stdenv` instead of `gcc13Stdenv` ``                            |
| [`40eee3c7`](https://github.com/NixOS/nixpkgs/commit/40eee3c747b9bbbeedd990fd4c4f74240491443c) | `` vesktop: use `stdenv` instead of `gcc13Stdenv` ``                                 |
| [`fc63f763`](https://github.com/NixOS/nixpkgs/commit/fc63f763d43914f4be7a7324e885f7df8100ee4b) | `` hyprland: use `stdenv` instead of `gcc13Stdenv` ``                                |
| [`32c95ed9`](https://github.com/NixOS/nixpkgs/commit/32c95ed9d53bc1827fc66082c89c0aca9ee0ecba) | `` ocamlPackages.ocamlfuse: 2.7.1_cvs8 -> 2.7.1_cvs9 ``                              |
| [`c5b54492`](https://github.com/NixOS/nixpkgs/commit/c5b544922979418b8ed0d25f66fe344c9ef96fa7) | `` scitoken-cpp -> scitokens-cpp (#288390) ``                                        |
| [`11b95169`](https://github.com/NixOS/nixpkgs/commit/11b95169a6f1df106a8a081a1f1fe2f767d5950a) | `` openrct2: 0.4.7 -> 0.4.8 ``                                                       |