### PR TITLE
chore(flake/pre-commit-hooks): `0db2e67e` -> `5df5a70a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -576,11 +576,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1707297608,
-        "narHash": "sha256-ADjo/5VySGlvtCW3qR+vdFF4xM9kJFlRDqcC9ZGI8EA=",
+        "lastModified": 1708018599,
+        "narHash": "sha256-M+Ng6+SePmA8g06CmUZWi1AjG2tFBX9WCXElBHEKnyM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "0db2e67ee49910adfa13010e7f012149660af7f0",
+        "rev": "5df5a70ad7575f6601d91f0efec95dd9bc619431",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                   |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`f441d089`](https://github.com/cachix/pre-commit-hooks.nix/commit/f441d0892f47d199a1a96b0c0efec13fdbff01ee) | `` Remove pass_filenames from typos hook ``               |
| [`845c8661`](https://github.com/cachix/pre-commit-hooks.nix/commit/845c86613e112caf5d6b599b64b8634901b35de8) | `` Add option to typos hook for ignoring list of words `` |
| [`7a06a898`](https://github.com/cachix/pre-commit-hooks.nix/commit/7a06a898fe9f9cabf2418f8397e4c4e72446207c) | `` Add more options to typos hook ``                      |