### PR TITLE
chore(flake/deploy-rs): `1776009f` -> `0a018779`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -246,11 +246,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704875591,
-        "narHash": "sha256-eWRLbqRcrILgztU/m/k7CYLzETKNbv0OsT2GjkaNm8A=",
+        "lastModified": 1708091384,
+        "narHash": "sha256-dTGGw2y8wvfjr+J9CjQbfdulOq72hUG17HXVNxpH1yE=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "1776009f1f3fb2b5d236b84d9815f2edee463a9b",
+        "rev": "0a0187794ac7f7a1e62cda3dabf8dc041f868790",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                          |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`5f694ef4`](https://github.com/serokell/deploy-rs/commit/5f694ef481610e8c4c77bb963b49e2d3b0d4db3c) | `` add support for entering password for sudo `` |