### PR TITLE
chore(flake/home-manager): `11edf9ca` -> `a54e05bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,11 +390,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708292912,
-        "narHash": "sha256-/DbyiFfipjwrfE/G7/tzpX3U+Og6D63k4I3XvbAid7A=",
+        "lastModified": 1708294481,
+        "narHash": "sha256-DZtxmeb4OR7iCaKUUuq05ADV2rX8WReZEF7Tq//W0+Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "11edf9cad78cce49d09436c8d725ae36b65671dc",
+        "rev": "a54e05bc12d88ff2df941d0dc1183cb5235fa438",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`a54e05bc`](https://github.com/nix-community/home-manager/commit/a54e05bc12d88ff2df941d0dc1183cb5235fa438) | `` tealdeer: module improvements ``             |
| [`738527f8`](https://github.com/nix-community/home-manager/commit/738527f866e7848fa9fcef174ee78ec262fd00e5) | `` darwin: fonts: speed up font installation `` |