### PR TITLE
chore(flake/home-manager): `517601b3` -> `0b69d574`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,11 +390,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708451036,
-        "narHash": "sha256-tgZ38NummEdnXvxj4D0StHBzXgceAw8CptytHljH790=",
+        "lastModified": 1708558280,
+        "narHash": "sha256-w1ns8evB6N9VTrAojcdXLWenROtd77g3vyClrqeFdG8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "517601b37c6d495274454f63c5a483c8e3ca6be1",
+        "rev": "0b69d574162cfa6eb7919d5614a48d0185550891",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`0b69d574`](https://github.com/nix-community/home-manager/commit/0b69d574162cfa6eb7919d5614a48d0185550891) | `` Translate using Weblate (Spanish) `` |
| [`3dda8e79`](https://github.com/nix-community/home-manager/commit/3dda8e795f12a4f67c287cef155939e1c5fbd0a3) | `` river: add module ``                 |