### PR TITLE
chore(flake/nixos-hardware): `106d3fec` -> `3f7d0bca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1708091350,
-        "narHash": "sha256-o28BJYi68qqvHipT7V2jkWxDiMS1LF9nxUsou+eFUPQ=",
+        "lastModified": 1708594753,
+        "narHash": "sha256-c/gH7iXS/IYH9NrFOT+aJqTq+iEBkvAkpWuUHGU3+f0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "106d3fec43bcea19cb2e061ca02531d54b542ce3",
+        "rev": "3f7d0bca003eac1a1a7f4659bbab9c8f8c2a0958",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`3f7d0bca`](https://github.com/NixOS/nixos-hardware/commit/3f7d0bca003eac1a1a7f4659bbab9c8f8c2a0958) | `` Add links to FA507RM ``                 |
| [`27cca741`](https://github.com/NixOS/nixos-hardware/commit/27cca741bf6c532ea9ba394be806b04cbcbaefa1) | `` Add files for Asus TUF A15 (FA507RM) `` |
| [`3610be0d`](https://github.com/NixOS/nixos-hardware/commit/3610be0dca3a3f46224af37eca0a655688d080be) | `` Import Intel GPU module ``              |