### PR TITLE
chore(flake/nixpkgs): `0e74ca98` -> `cbc4211f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708475490,
-        "narHash": "sha256-g1v0TsWBQPX97ziznfJdWhgMyMGtoBFs102xSYO4syU=",
+        "lastModified": 1708655239,
+        "narHash": "sha256-ZrP/yACUvDB+zbqYJsln4iwotbH6CTZiTkANJ0AgDv4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0e74ca98a74bc7270d28838369593635a5db3260",
+        "rev": "cbc4211f0afffe6dfd2478a62615dd5175a13f9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`f4e2bea8`](https://github.com/NixOS/nixpkgs/commit/f4e2bea85e4e4ae057f2aa786e18a932a2b0b658) | `` python311Packages.mplhep: 0.3.33 -> 0.3.34 ``                            |
| [`6ef28826`](https://github.com/NixOS/nixpkgs/commit/6ef28826d81340f19b8a97b4fa3f46504bdcad6f) | `` abcmidi: 2024.02.11 -> 2024.02.19 ``                                     |
| [`6add9650`](https://github.com/NixOS/nixpkgs/commit/6add9650436e4976300c2a57ce5c290b798b18e6) | `` s3proxy: init ``                                                         |
| [`3cbe64e9`](https://github.com/NixOS/nixpkgs/commit/3cbe64e9d15ef3f76ad8096c1dae1bdc45848378) | `` python3Packages.oscscreen: init at unstable-2023-03-23 ``                |
| [`77644168`](https://github.com/NixOS/nixpkgs/commit/776441686194acbd5c064838b6676b5f8082416e) | `` osc-cli: init at 1.11.0 ``                                               |
| [`c7254aed`](https://github.com/NixOS/nixpkgs/commit/c7254aed3b25aa79bee944a8a1a63a41bca6cc54) | `` nixos/scrutiny: add 24.05 'new service' release note ``                  |
| [`41a1acde`](https://github.com/NixOS/nixpkgs/commit/41a1acde71b88cb65b30acecab9696e0b0ff0b48) | `` nixosTests.scrutiny: init ``                                             |
| [`88d637c6`](https://github.com/NixOS/nixpkgs/commit/88d637c6dd82e487b067925f79f76cbddabde598) | `` nixos/scrutiny: init ``                                                  |
| [`96d9e2a1`](https://github.com/NixOS/nixpkgs/commit/96d9e2a14c5fa9aa8b80721ebdb31ce7e9ff2dd2) | `` scrutiny-collector: init at 0.7.2 ``                                     |
| [`41f9a37e`](https://github.com/NixOS/nixpkgs/commit/41f9a37ee4b3421f06c9d3b794cb07a05dd4fc96) | `` scrutiny: init at 0.7.2 ``                                               |
| [`e3707b36`](https://github.com/NixOS/nixpkgs/commit/e3707b3670525c9530567ecace6a088f7b0480a4) | `` mimic: update maintainer noneucat to fx-chun ``                          |
| [`73456284`](https://github.com/NixOS/nixpkgs/commit/734562845d98707c66950cba322552cb3738e81f) | `` polar-bookshelf: remove noneucat as maintainer ``                        |
| [`a39a8b17`](https://github.com/NixOS/nixpkgs/commit/a39a8b17e8860ea53e11ef5033a389dc7c345584) | `` maintainers: update noneucat to fx-chun ``                               |
| [`c12078df`](https://github.com/NixOS/nixpkgs/commit/c12078dfa0d9c807f7a9382a21e3c7a728e49f6c) | `` ddns-updater: init at 2.6.0 ``                                           |
| [`a937d4c3`](https://github.com/NixOS/nixpkgs/commit/a937d4c34203e7932191eca19760a40769c70d5f) | `` maintainers: add delliott ``                                             |
| [`72037293`](https://github.com/NixOS/nixpkgs/commit/72037293ece534f561760446368095329eb1a902) | `` forgejo: 1.21.5-0 -> 1.21.6-0 ``                                         |
| [`267ec790`](https://github.com/NixOS/nixpkgs/commit/267ec7909fb58134da081d4192bd673c7112c664) | `` python3Packages.jishaku: init at 2.5.2 ``                                |
| [`5f7ee210`](https://github.com/NixOS/nixpkgs/commit/5f7ee2108b26703e95e773a9b56003b11ad236a9) | `` cobang: 0.10.1 -> 0.10.5 ``                                              |
| [`8c85a553`](https://github.com/NixOS/nixpkgs/commit/8c85a553408668602d32490ef6553d8d2c9062cb) | `` python3Packages.import-expression: init at 1.1.4 ``                      |
| [`2a2b7fb8`](https://github.com/NixOS/nixpkgs/commit/2a2b7fb89f3bea983ff8da63eeaddd6b6e672c5c) | `` python311Packages.airium: init at 0.2.6 ``                               |
| [`2659d40a`](https://github.com/NixOS/nixpkgs/commit/2659d40affb3b315d79fb3c2fb4713d219385a68) | `` trezor-suite: 24.1.2 -> 24.2.2 ``                                        |
| [`3dd025b2`](https://github.com/NixOS/nixpkgs/commit/3dd025b28c1f608cba308930b77a70fb258235ed) | `` hoppscotch: init at 23.12.5 ``                                           |
| [`e480496b`](https://github.com/NixOS/nixpkgs/commit/e480496b9a92f4ccee005412edccd7b2b688de0f) | `` z-lua: 1.8.16 -> 1.8.17 ``                                               |
| [`ca32d7bd`](https://github.com/NixOS/nixpkgs/commit/ca32d7bd46185f45d511c645b53c0cfeb7c795b1) | `` ledfx: 2.0.93 -> 2.0.94 ``                                               |
| [`70756b6b`](https://github.com/NixOS/nixpkgs/commit/70756b6b02095c9de6a911afa1a79cc0c6df5292) | `` viceroy: 0.9.3 -> 0.9.4 ``                                               |
| [`72d795a3`](https://github.com/NixOS/nixpkgs/commit/72d795a330816978e552fbf2a0b70f8a2d9b8e09) | `` kube-linter: 0.6.7 -> 0.6.8 ``                                           |
| [`cd082f7f`](https://github.com/NixOS/nixpkgs/commit/cd082f7f388121bfdc96bc0f05428562ab59e223) | `` python311Packages.yamllint: refactor ``                                  |
| [`ee880939`](https://github.com/NixOS/nixpkgs/commit/ee880939759cd61909c663a558596128c2a33596) | `` python311Packages.yamllint: 1.33.0 -> 1.35.1 ``                          |
| [`27d33c33`](https://github.com/NixOS/nixpkgs/commit/27d33c33eda8c5c0b104cb70498099493b0b8b4f) | `` llvmPackages_git: 18.0.0-unstable-2023-12-13 -> 18.1.0-rc3 (#285786) ``  |
| [`e5819e1c`](https://github.com/NixOS/nixpkgs/commit/e5819e1cad7aef7ef89eefdbe2fab5e2571c55da) | `` python311Packages.reqif: 0.0.35 -> 0.0.40 ``                             |
| [`f6616d2e`](https://github.com/NixOS/nixpkgs/commit/f6616d2e3a8d16a7868de2b7c540b7ad6b4b8fcc) | `` gromacs: require single precssion when building with CUDA ``             |
| [`eb93eb95`](https://github.com/NixOS/nixpkgs/commit/eb93eb95ac6dc5d3514ae4e788554d4663b46e24) | `` gromacs: fix CUDA build ``                                               |
| [`d2161707`](https://github.com/NixOS/nixpkgs/commit/d216170770635164e272ff8991be428e17e0a606) | `` CODEOWNERS: Remove myself as codeowner from PHP ``                       |
| [`0eac6bf6`](https://github.com/NixOS/nixpkgs/commit/0eac6bf6793576c01cdd3f4156585e9c4a06674d) | `` maintainers: Remove myself from the PHP team ``                          |
| [`8d222b4c`](https://github.com/NixOS/nixpkgs/commit/8d222b4cdca1cd1116612e0d291c4884470f4d8a) | `` maintainers: Set the correct matrix handle ``                            |
| [`0c3eca26`](https://github.com/NixOS/nixpkgs/commit/0c3eca2682c1d38706f7ccaa8a8c77f1080d71ff) | `` doc/fetchers: document downloadToTemp for fetchurl (#288762) ``          |
| [`00f70f03`](https://github.com/NixOS/nixpkgs/commit/00f70f03b71aa39d8c8fa5c6842fe25bd6ed4aa1) | `` babashka-unwrapped: 1.3.188 -> 1.3.189 ``                                |
| [`3fb72425`](https://github.com/NixOS/nixpkgs/commit/3fb724257ee54a9595419338259e79d79e877a31) | `` reindeer: unstable-2024-02-16 -> unstable-2024-02-20 ``                  |
| [`43610746`](https://github.com/NixOS/nixpkgs/commit/436107469fc4d30742ce0bf8cd73a49df96411d9) | `` python311Packages.litellm: 1.23.9 -> 1.26.8 ``                           |
| [`8f46cabf`](https://github.com/NixOS/nixpkgs/commit/8f46cabf6cee6843f7bac9a1ebd69df2c230db4a) | `` nimlangserver: add missing newline ``                                    |
| [`5ea0c5bf`](https://github.com/NixOS/nixpkgs/commit/5ea0c5bf54a554ee381686b10897dcc3cfc8646e) | `` nixlangserver: add homepage ``                                           |
| [`a645afde`](https://github.com/NixOS/nixpkgs/commit/a645afde176ce835180f50854ee9a0b0fed4a03a) | `` nimlangserver: update lock.json with correct entries ``                  |
| [`5ae26373`](https://github.com/NixOS/nixpkgs/commit/5ae26373535db8611f157d2662322c51b3111372) | `` wiremock: 3.4.0 -> 3.4.1 ``                                              |
| [`24ff7d3e`](https://github.com/NixOS/nixpkgs/commit/24ff7d3eccad302f47290d13f16feb71512efbf7) | `` phpExtensions.mailparse: 3.1.4 -> 3.1.6 ``                               |
| [`9b0b5eab`](https://github.com/NixOS/nixpkgs/commit/9b0b5eab17f5a5b3d54b527972a6102fda1c1254) | `` vimPlugins.nvim-tree-lua: update on 2024-02-20 (#290403) ``              |
| [`eaf3b4f5`](https://github.com/NixOS/nixpkgs/commit/eaf3b4f5169d21dd3e810514252a6fbf042196d4) | `` fangfrisch: 1.8.0 -> 1.8.1 ``                                            |
| [`5b5aff3f`](https://github.com/NixOS/nixpkgs/commit/5b5aff3f40f81969e324b6b851d19672975f6e4e) | `` nwg-panel: 0.9.23 -> 0.9.24 ``                                           |
| [`da2ccc57`](https://github.com/NixOS/nixpkgs/commit/da2ccc5719c79b28f4bacd20c20ce897e87f605b) | `` Update pkgs/development/compilers/llvm/17/mlir/default.nix ``            |
| [`777f8c6a`](https://github.com/NixOS/nixpkgs/commit/777f8c6a12e3d2c7a3732618accfc29395432be0) | `` Update pkgs/development/compilers/llvm/17/mlir/default.nix ``            |
| [`439b5c0f`](https://github.com/NixOS/nixpkgs/commit/439b5c0fd9da314171368e8bf15b3a399b77e449) | `` imv: 4.4.0 -> 4.5.0 ``                                                   |
| [`7a42511e`](https://github.com/NixOS/nixpkgs/commit/7a42511e53874aa390137929f328f6f849073106) | `` vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.19.0 -> 0.20.0 ``       |
| [`a8069ff5`](https://github.com/NixOS/nixpkgs/commit/a8069ff58a856cf5e12e115420a2d9089b412e7b) | `` tests/morph-browser: Add standalone (non-Lomiri) test ``                 |
| [`2d73fbb9`](https://github.com/NixOS/nixpkgs/commit/2d73fbb9dd779159c6e71a841d2c27a35a40dbb3) | `` python311Packages.pex: 2.1.162 -> 2.2.1 ``                               |
| [`290bd4b2`](https://github.com/NixOS/nixpkgs/commit/290bd4b25897895270eb45e62af43562d476650a) | `` python311Packages.azure-mgmt-network: refactor ``                        |
| [`d250b7a6`](https://github.com/NixOS/nixpkgs/commit/d250b7a6c8367c134c2c00ed46ec7ce9bfb770bf) | `` python311Packages.azure-mgmt-network: 25.2.0 -> 25.3.0 ``                |
| [`82befbfa`](https://github.com/NixOS/nixpkgs/commit/82befbfaafd6f4a2585002b592ac84a4c85adb21) | `` python311Packages.aioairzone: refactor ``                                |
| [`154f625c`](https://github.com/NixOS/nixpkgs/commit/154f625c03a70308a1b8dc0fd3088d01dff41a31) | `` python311Packages.aioairzone: 0.7.2 -> 0.7.4 ``                          |
| [`33893ac9`](https://github.com/NixOS/nixpkgs/commit/33893ac9033f109effe7e2db8cb867295806d8b3) | `` thunderbird-unwrapped: 115.7.0 -> 115.8.0 ``                             |
| [`3743c6b4`](https://github.com/NixOS/nixpkgs/commit/3743c6b4d67d985d34cd0501cd511569fc550ae6) | `` codeium: 1.6.38 -> 1.6.39 ``                                             |
| [`80d8621d`](https://github.com/NixOS/nixpkgs/commit/80d8621dc2649efdee370a391be2e0e29dc4acca) | `` python311Packages.peaqevcore: 19.7.0 -> 19.7.1 ``                        |
| [`bbd41598`](https://github.com/NixOS/nixpkgs/commit/bbd41598f9739572c5a64a4207aa0065aa237d13) | `` trufflehog: 3.67.7 -> 3.68.0 ``                                          |
| [`fce2b72d`](https://github.com/NixOS/nixpkgs/commit/fce2b72d0eea2c099cb7ac3c8da3e42cb213c7c1) | `` flexget: 3.11.18 -> 3.11.19 ``                                           |
| [`c3d0e090`](https://github.com/NixOS/nixpkgs/commit/c3d0e090cab775004d2ffbd5d1e731551c92edeb) | `` python311Packages.pyschlage: refactor ``                                 |
| [`6d5459ed`](https://github.com/NixOS/nixpkgs/commit/6d5459ed043b08b87535181a9d1ee2bb37c3236b) | `` python311Packages.pyschlage: 2023.12.1 -> 2024.2.0 ``                    |
| [`b95489c6`](https://github.com/NixOS/nixpkgs/commit/b95489c6bb754c55f5bf40ebe38f91d9df0da696) | `` python312Packages.elasticsearch8: 8.12.0 -> 8.12.1 ``                    |
| [`9b28d818`](https://github.com/NixOS/nixpkgs/commit/9b28d8180fcc1d49bd847dd96189587ee158127e) | `` python312Packages.deebot-client: 5.2.1 -> 5.2.2 ``                       |
| [`36fe6596`](https://github.com/NixOS/nixpkgs/commit/36fe659631a122aa602c4889d0b2389214d37f38) | `` python312Packages.boto3-stubs: 1.34.46 -> 1.34.47 ``                     |
| [`c43594d6`](https://github.com/NixOS/nixpkgs/commit/c43594d6be070fb25e4356c3336ce7c7cf104aab) | `` zram-generator: 1.1.2 -> 1.1.2 ``                                        |
| [`3a9821ba`](https://github.com/NixOS/nixpkgs/commit/3a9821baa9c301fa1c14ad8ea87b437c8ca27e48) | `` gpt4all-chat: 2.7.0 -> 2.7.1 ``                                          |
| [`c5594450`](https://github.com/NixOS/nixpkgs/commit/c559445039b28e5ba8edb454d016953a64a90c51) | `` python312Packages.peaqevcore: refactor ``                                |
| [`07fbc0bb`](https://github.com/NixOS/nixpkgs/commit/07fbc0bb0f968fbb731bcf930ad45adef6da4e13) | `` coqPackages.coq-record-update: 0.3.1 -> 0.3.3 ``                         |
| [`fea24880`](https://github.com/NixOS/nixpkgs/commit/fea248807f71038527131f9471fbc9985e81ea65) | `` python311Packages.imagededup: fix build ``                               |
| [`4ed2297e`](https://github.com/NixOS/nixpkgs/commit/4ed2297e2f2fa7ec6d2b1c7c8a30969a6e0a8102) | `` libfive: update outdated version string and add passthru.updateScript `` |
| [`ed133953`](https://github.com/NixOS/nixpkgs/commit/ed1339536532ddc51c579c8e656059faf200245e) | `` libadwaita: Add meta.pkgConfigModules and tests.pkg-config ``            |
| [`9c0c72dd`](https://github.com/NixOS/nixpkgs/commit/9c0c72dd2bd9b1334a8abd34723330548e1438fb) | `` appstream: Add meta.pkgConfigModules ``                                  |
| [`bac7f13d`](https://github.com/NixOS/nixpkgs/commit/bac7f13dedb05bec53c396b39f1bc14692788f98) | `` wayland: Add meta.pkgConfigModules and corresponding test ``             |
| [`1bf46b32`](https://github.com/NixOS/nixpkgs/commit/1bf46b324fa5c6c2026efa187c4fa33c5f7eea86) | `` graphite2: Add meta.pkgConfigModules ``                                  |
| [`a0550305`](https://github.com/NixOS/nixpkgs/commit/a05503057cc5d53750529db139be5f4ef7edd2bc) | `` pixman: Add meta.pkgConfigModules ``                                     |
| [`d239ca5c`](https://github.com/NixOS/nixpkgs/commit/d239ca5ca15c4d7381e54bdd39501f86e5035be2) | `` libffi: Add meta.pkgConfigModules ``                                     |
| [`a20c0d56`](https://github.com/NixOS/nixpkgs/commit/a20c0d5675c121f644b62d41c07024c703f2a426) | `` xz: Add meta.pkgConfigModules ``                                         |
| [`35a202a6`](https://github.com/NixOS/nixpkgs/commit/35a202a65e4825f77c67de26879069b540e7b41f) | `` libdeflate: Add meta.pkgConfigModules ``                                 |
| [`6b3baaf8`](https://github.com/NixOS/nixpkgs/commit/6b3baaf8d64e804155d82a62a83f509debbc1939) | `` fontconfig: Add meta.pkgConfigModules ``                                 |
| [`c5a228e1`](https://github.com/NixOS/nixpkgs/commit/c5a228e1b16d3f47594dc1f6ca0fb585f09b328d) | `` expat: Add meta.pkgConfigModules ``                                      |
| [`eae3eed7`](https://github.com/NixOS/nixpkgs/commit/eae3eed78f3bcba5009c9a1228102c906681fec0) | `` vulkan-loader: add meta.pkgConfigModules ``                              |
| [`0ec43c6e`](https://github.com/NixOS/nixpkgs/commit/0ec43c6ebecf9612aef39314045fd135ccbe1179) | `` tracker: add meta.pkgConfigModules and tests.pkg-config ``               |
| [`bee5bd01`](https://github.com/NixOS/nixpkgs/commit/bee5bd01061f92c11ef85f2e6cedd7bdeb794318) | `` libxml2: add meta.pkgConfigModules and tests.pkg-config ``               |
| [`511914a5`](https://github.com/NixOS/nixpkgs/commit/511914a5fe00c6f4c36c4ce538da5c17dc194cc9) | `` libtiff: add pkgConfigModules metadata and corresponding test ``         |
| [`81bf7630`](https://github.com/NixOS/nixpkgs/commit/81bf7630b9eeb89851a801c9b1842e31af32428c) | `` libxkbcommon: add tests for pkg-config modules ``                        |
| [`51c7525a`](https://github.com/NixOS/nixpkgs/commit/51c7525a649cb24dd12d6e686a32150ab5cf4631) | `` libepoxy: added test for pkg-config modules ``                           |
| [`ae8b023a`](https://github.com/NixOS/nixpkgs/commit/ae8b023ac91648a2bec0d2bd71d284832a399df4) | `` fribidi: add pkgConfigModules metadata and corresponding test ``         |
| [`61b9b25d`](https://github.com/NixOS/nixpkgs/commit/61b9b25d42040f73fd0fcf23bb038f004b79ab9e) | `` pango: add tests for pkg-config modules ``                               |
| [`5649b4b8`](https://github.com/NixOS/nixpkgs/commit/5649b4b8293de5bcbbe5934580c2eb7c1c388556) | `` isocodes: add pkgConfigModules metadata and corresponding test ``        |
| [`7f52f0ab`](https://github.com/NixOS/nixpkgs/commit/7f52f0ab0a9239193a911a2f640c93b14212bcfb) | `` graphene: add pkgConfigModules metadata and corresponding test ``        |
| [`c28dc44c`](https://github.com/NixOS/nixpkgs/commit/c28dc44c0130d2bce00308e0e6d13f4f93d11aaa) | `` gtk4: add meta.pkgConfigModules and tests.pkg-config ``                  |