### PR TITLE
chore(flake/home-manager): `4e6d25a5` -> `4ee704cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,11 +390,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708803051,
-        "narHash": "sha256-J3Zl24HSaLvKPH7X3NzOfje7JiJmUAfiWBb552eAnwc=",
+        "lastModified": 1708806879,
+        "narHash": "sha256-MSbxtF3RThI8ANs/G4o1zIqF5/XlShHvwjl9Ws0QAbI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4e6d25a51bb3035af7db54cc8f7fcac23e9467dc",
+        "rev": "4ee704cb13a5a7645436f400b9acc89a67b9c08a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`4ee704cb`](https://github.com/nix-community/home-manager/commit/4ee704cb13a5a7645436f400b9acc89a67b9c08a) | `` xscreensaver: add package option `` |
| [`ae7a3b51`](https://github.com/nix-community/home-manager/commit/ae7a3b5137ca3522f2802b3183de8fe5287b13d2) | `` hyprland: fix reloading ``          |