### PR TITLE
chore(flake/darwin): `bbde06be` -> `6c06334f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -220,11 +220,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708737761,
-        "narHash": "sha256-sR/1cYjpgr71ZSrt6Kp5Dg4Ul3mo6pZIG400tuzYks8=",
+        "lastModified": 1709001452,
+        "narHash": "sha256-FnZ54wkil54hKvr1irdKic1TE27lHQI9dKQmOJRrtlU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "bbde06bed1b72eddff063fa42f18644e90a0121e",
+        "rev": "6c06334f0843c7300d1678726bb607ce526f6b36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                               |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`44888312`](https://github.com/LnL7/nix-darwin/commit/44888312de4de6f9a922d0681dccd2241a45af59) | `` security.sudo.extraConfig: fix default behavior `` |