### PR TITLE
chore(flake/nixos-hardware): `3f7d0bca` -> `01467901`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1708594753,
-        "narHash": "sha256-c/gH7iXS/IYH9NrFOT+aJqTq+iEBkvAkpWuUHGU3+f0=",
+        "lastModified": 1709110790,
+        "narHash": "sha256-qUk0G9vWX90beOKB1EtLFdeImXAujNi5SP5zTyIEATc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3f7d0bca003eac1a1a7f4659bbab9c8f8c2a0958",
+        "rev": "01467901ec51dd92774040f2b3dff4f21f4e1c45",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                          |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`01467901`](https://github.com/NixOS/nixos-hardware/commit/01467901ec51dd92774040f2b3dff4f21f4e1c45) | `` dell-xps-15-9570: init ``                     |
| [`f12e5fd7`](https://github.com/NixOS/nixos-hardware/commit/f12e5fd7ec032da50b16417a907db84c90e109c8) | `` nxp imx8mp-evk/imx8mq-evk documentation ``    |
| [`53e2a96a`](https://github.com/NixOS/nixos-hardware/commit/53e2a96a9edb28bc5b6c0428cf1230b06b9aec8f) | `` nxp imx8m quad evaluation platform support `` |
| [`5c2a5c00`](https://github.com/NixOS/nixos-hardware/commit/5c2a5c00a017d067118d91bf54d7b7b96747ce8b) | `` nxp imx8mp-evk platform support ``            |
| [`55b794ba`](https://github.com/NixOS/nixos-hardware/commit/55b794ba77cad6f7314027786911ebebbe6a4eca) | `` microchip icicle-kit README update ``         |