### PR TITLE
chore(flake/darwin): `283d5977` -> `c2751db9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -220,11 +220,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709112925,
-        "narHash": "sha256-5y8Dhw1HYdc+BWv+qQjJUIwc+ByoudtoGaHEcrXYlXw=",
+        "lastModified": 1709270649,
+        "narHash": "sha256-ox/QjE33yeC9ESx9viogCH8bWlB7Odkmp0mLy2PJD30=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "283d59778e6b8c41cac4bdeac5b2512d6de51150",
+        "rev": "c2751db910d47a0f08e989fe1360897d90fc3961",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                               |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`ad98aebc`](https://github.com/LnL7/nix-darwin/commit/ad98aebc0f900fa9bef8dfa8f5bdb328ab93ccd3) | `` Fix doc render problem ``                          |
| [`2ffb75f9`](https://github.com/LnL7/nix-darwin/commit/2ffb75f9423eb85c4ba5fa043b356f83e0586163) | `` defaults: Add options for dragOnGesture feature `` |