### PR TITLE
chore(flake/lanzaboote): `614b538f` -> `eeb45682`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -439,11 +439,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1709281447,
-        "narHash": "sha256-YUC12DAhE5RJtGVg0CDXyHBycccjp82HP99t7AViJFU=",
+        "lastModified": 1709332019,
+        "narHash": "sha256-kJAoPvpVRO3WR1dCZQKJpUMYoyA/6u9iUDX9gGEkjGI=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "614b538f0fcd4eda423abc36819a57eb4b241b1b",
+        "rev": "eeb45682dd4b2a921a3cab286f13101c9750d6bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                   |
| --------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`d470342a`](https://github.com/nix-community/lanzaboote/commit/d470342af6fb149ee5a7685f2ec3a984ddc68112) | `` tests: remove custom OVMF overrides `` |