### PR TITLE
chore(flake/darwin): `8a15cb36` -> `17c2ca3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -220,11 +220,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709348262,
-        "narHash": "sha256-eYTA1uZtYGFKrDOKiAz1wlE6aIC9WSdBNF8bSS818zM=",
+        "lastModified": 1709434167,
+        "narHash": "sha256-2VLj0k4GNZCISN/1uf02GSaLwM1iBbTwWRLJWbjh/fw=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "8a15cb36fffa0b5fbe31ef16ede0a479bef4b365",
+        "rev": "17c2ca3c7537a2512224242b84e1ea3c08e79b92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                               |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
| [`3397ab3b`](https://github.com/LnL7/nix-darwin/commit/3397ab3b7736e345e168da0ecade5c96b8a7f042) | `` feat(nix): adapt nix.conf validation for different Nix versions `` |