### PR TITLE
chore(flake/home-manager): `2f336776` -> `4de84265`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,11 +390,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709204054,
-        "narHash": "sha256-U1idK0JHs1XOfSI1APYuXi4AEADf+B+ZU4Wifc0pBHk=",
+        "lastModified": 1709445365,
+        "narHash": "sha256-DVv6nd9FQBbMWbOmhq0KVqmlc3y3FMSYl49UXmMcO+0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f3367769a93b226c467551315e9e270c3f78b15",
+        "rev": "4de84265d7ec7634a69ba75028696d74de9a44a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`4de84265`](https://github.com/nix-community/home-manager/commit/4de84265d7ec7634a69ba75028696d74de9a44a7) | `` fcitx5: fix tests ``                           |
| [`0992b38e`](https://github.com/nix-community/home-manager/commit/0992b38e5e1f3fba5cf7d386a20a39ce8ea6ee3f) | `` tests: add mkStubPackage in Nixpkgs overlay `` |