### PR TITLE
chore(flake/darwin): `530f2650` -> `e7d7a7f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -220,11 +220,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709529365,
-        "narHash": "sha256-38/j4vqSkgvbBWDfz8iO0xrEYc2rN3VdRxMZX/erAv8=",
+        "lastModified": 1709529951,
+        "narHash": "sha256-KVqN0Dvf4bg87XYQCHdd1kuJkjA23y5wlTTSOnilLIU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "530f265072c35731e100a863efbf916ea902408f",
+        "rev": "e7d7a7f0c5a184c67b6bff56f95436d83d05fba5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                          |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`0b638a97`](https://github.com/LnL7/nix-darwin/commit/0b638a97c069ca331daf657eab2c47ce44aae916) | `` users: fix `forceRecreate` bash comparison `` |
| [`8e102a99`](https://github.com/LnL7/nix-darwin/commit/8e102a9991822b7688a2d7438483923941062257) | `` a few fixes for ipfs module ``                |