### PR TITLE
chore(flake/home-manager): `47717650` -> `613384a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,11 +390,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709725074,
-        "narHash": "sha256-xhhvktDOTDE34KHVXpaJKg7LVGPRvLftjHO1J3FGRgU=",
+        "lastModified": 1709726282,
+        "narHash": "sha256-4S5EFTLeI90XzOT4MdEC+3emCdR8B7/OPSiwC6/3cKg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "477176502a6e099192da61984cd5be896d0b5659",
+        "rev": "613384a51119ea34af58eb5e611e7f31dd3970d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`613384a5`](https://github.com/nix-community/home-manager/commit/613384a51119ea34af58eb5e611e7f31dd3970d6) | `` tests: include a service in integration tests `` |
| [`950673ce`](https://github.com/nix-community/home-manager/commit/950673cec79298d9a1072499e0181849545376e2) | `` pueue: always write configuration file ``        |