### PR TITLE
chore(flake/home-manager): `613384a5` -> `8d9fde0f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,11 +390,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709726282,
-        "narHash": "sha256-4S5EFTLeI90XzOT4MdEC+3emCdR8B7/OPSiwC6/3cKg=",
+        "lastModified": 1709731606,
+        "narHash": "sha256-VS17VGD5s4ijFh5mEzpWWgTPujaCvHxuG5L5FyMG3L0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "613384a51119ea34af58eb5e611e7f31dd3970d6",
+        "rev": "8d9fde0fba21425729905f795fe72c2840a20442",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`8d9fde0f`](https://github.com/nix-community/home-manager/commit/8d9fde0fba21425729905f795fe72c2840a20442) | `` i3/sway: remove sebtm maintainer ``               |
| [`692726d2`](https://github.com/nix-community/home-manager/commit/692726d2ad5727cf14c563d0f1d2c015c021d7a5) | `` Translate using Weblate (German) ``               |
| [`d19bf3ae`](https://github.com/nix-community/home-manager/commit/d19bf3ae21686854760cfc5e81f269ea51072563) | `` Add translation using Weblate (Vietnamese) ``     |
| [`f30d23fa`](https://github.com/nix-community/home-manager/commit/f30d23faccdeb8237168525be65f55e44811e4c1) | `` Translate using Weblate (French) ``               |
| [`572b0706`](https://github.com/nix-community/home-manager/commit/572b070627c62eee20b9f0254128890a69894fc2) | `` Add translation using Weblate (Vietnamese) ``     |
| [`c7e50657`](https://github.com/nix-community/home-manager/commit/c7e50657fb167023a79d6dd3d15be577ea97baab) | `` Translate using Weblate (Chinese (Simplified)) `` |
| [`571ac919`](https://github.com/nix-community/home-manager/commit/571ac9199c80e42c8e49b9095d5a93a58a17e770) | `` Translate using Weblate (German) ``               |
| [`ae84f4fd`](https://github.com/nix-community/home-manager/commit/ae84f4fd2c56c0766c5b12c3efda102b749aed56) | `` Translate using Weblate (Italian) ``              |
| [`40c57ce0`](https://github.com/nix-community/home-manager/commit/40c57ce052cc8ef1bf0c836b87263a43b69e1fb6) | `` programs.khal: Simplify calendar setup (#5073) `` |