### PR TITLE
chore(flake/nixpkgs): `b8697e57` -> `9df3e30c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709479366,
-        "narHash": "sha256-n6F0n8UV6lnTZbYPl1A9q1BS0p4hduAv1mGAP17CVd0=",
+        "lastModified": 1709703039,
+        "narHash": "sha256-6hqgQ8OK6gsMu1VtcGKBxKQInRLHtzulDo9Z5jxHEFY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b8697e57f10292a6165a20f03d2f42920dfaf973",
+        "rev": "9df3e30ce24fd28c7b3e2de0d986769db5d6225d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`8ca587c4`](https://github.com/NixOS/nixpkgs/commit/8ca587c437949f417082d6c0d6e9f54fd1a64a65) | `` dotnetCorePackages.dotnet_8.sdk: remove `updateScript` to fix eval ``          |
| [`4b2a7dc3`](https://github.com/NixOS/nixpkgs/commit/4b2a7dc32b01697940efb39af5f9b4d558140f9f) | `` nodePackages.grammarly-languageserver: mark broken ``                          |
| [`be2aa8ba`](https://github.com/NixOS/nixpkgs/commit/be2aa8babf336fe283d32a22fc0cb64dd82f1e8f) | `` rPackages.asciicast: Use xz.dev, not lzma.dev ``                               |
| [`da001b2e`](https://github.com/NixOS/nixpkgs/commit/da001b2ed64a4aef6d53c323a1da536fab854fe1) | `` fit-trackee: relax sqlalchemy constraint ``                                    |
| [`bb4f1f04`](https://github.com/NixOS/nixpkgs/commit/bb4f1f0422ef43ddc7221ceb47f6a2a8324c4d4a) | `` squirreldisk: add missing desktop item ``                                      |
| [`75b569f0`](https://github.com/NixOS/nixpkgs/commit/75b569f0a1bf5a6686bf1a4eca234b75e18d67a3) | `` terraform-providers.yandex: 0.106.0 -> 0.110.0 ``                              |
| [`5866fd2d`](https://github.com/NixOS/nixpkgs/commit/5866fd2dddadf6d1be55088e231ce17478d7ba46) | `` terraform-providers.venafi: 0.17.2 -> 0.18.0 ``                                |
| [`437737e9`](https://github.com/NixOS/nixpkgs/commit/437737e9229536faa5c0f4e436314620db6cdf42) | `` terraform-providers.vault: 3.24.0 -> 3.25.0 ``                                 |
| [`aea44593`](https://github.com/NixOS/nixpkgs/commit/aea44593f31c52ecd2083f7cc34328969c86d63e) | `` terraform-providers.utils: 1.15.0 -> 1.18.0 ``                                 |
| [`9a94d9f5`](https://github.com/NixOS/nixpkgs/commit/9a94d9f5443b7595f5502bec1687c8661cb04630) | `` terraform-providers.ucloud: 1.38.3 -> 1.38.6 ``                                |
| [`44570564`](https://github.com/NixOS/nixpkgs/commit/445705644868f29d7bc46a703b537e6ddf63242f) | `` terraform-providers.turbot: 1.10.0 -> 1.10.1 ``                                |
| [`899c5829`](https://github.com/NixOS/nixpkgs/commit/899c58298546e007e097dc687cad7a845fc7cf8f) | `` terraform-providers.tfe: 0.51.1 -> 0.52.0 ``                                   |
| [`4cd895f1`](https://github.com/NixOS/nixpkgs/commit/4cd895f186118390b02de3c840b180c1c3cd58d0) | `` terraform-providers.tencentcloud: 1.81.71 -> 1.81.77 ``                        |
| [`1a8473b3`](https://github.com/NixOS/nixpkgs/commit/1a8473b3d883513f323d8bc9ae493660dfd09b19) | `` terraform-providers.sumologic: 2.28.1 -> 2.28.2 ``                             |
| [`44f18a7c`](https://github.com/NixOS/nixpkgs/commit/44f18a7c5446d589075d4bd3007fa2788dd9bca3) | `` terraform-providers.spotinst: 1.160.0 -> 1.162.0 ``                            |
| [`b7dc09de`](https://github.com/NixOS/nixpkgs/commit/b7dc09de366e8c1b4d5d311da6890af6475bf084) | `` terraform-providers.snowflake: 0.84.1 -> 0.87.0 ``                             |
| [`ce43804d`](https://github.com/NixOS/nixpkgs/commit/ce43804d6666da1230149478b34ea89edde4da5f) | `` terraform-providers.signalfx: 9.0.1 -> 9.1.1 ``                                |
| [`14a7c114`](https://github.com/NixOS/nixpkgs/commit/14a7c11422b41b7484b57e301f97d050aa2ccc7f) | `` terraform-providers.scaleway: 2.36.0 -> 2.37.0 ``                              |
| [`d802fc71`](https://github.com/NixOS/nixpkgs/commit/d802fc717b841e7dfbe92cc14572441b0bb1e0cf) | `` terraform-providers.rancher2: 3.2.0 -> 4.0.0 ``                                |
| [`0c26579b`](https://github.com/NixOS/nixpkgs/commit/0c26579b568723e445efafb13baac6a6cbfd5cc8) | `` terraform-providers.project: 1.3.4 -> 1.4.0 ``                                 |
| [`c7716815`](https://github.com/NixOS/nixpkgs/commit/c7716815f877ab764a1b5ba8269c9cdff53d5046) | `` terraform-providers.postgresql: 1.21.0 -> 1.22.0 ``                            |
| [`28ea198e`](https://github.com/NixOS/nixpkgs/commit/28ea198e2b045f1cf12321faa33761c8412ea7a1) | `` terraform-providers.pagerduty: 3.6.0 -> 3.9.0 ``                               |
| [`691e8c3d`](https://github.com/NixOS/nixpkgs/commit/691e8c3d5c079058c06222f3d0d59a5818065b9a) | `` terraform-providers.ovh: 0.36.1 -> 0.37.0 ``                                   |
| [`f0a7254d`](https://github.com/NixOS/nixpkgs/commit/f0a7254dad8a15f4c2722b833c8fb274fd5f5df0) | `` terraform-providers.opentelekomcloud: 1.36.0 -> 1.36.2 ``                      |
| [`e1c68fa5`](https://github.com/NixOS/nixpkgs/commit/e1c68fa53b6bd8e234776388a13bbf51f4058a1d) | `` terraform-providers.openstack: 1.53.0 -> 1.54.1 ``                             |
| [`f5faa966`](https://github.com/NixOS/nixpkgs/commit/f5faa966437da78b55caae3fa19b918fb6eff156) | `` terraform-providers.okta: 4.6.3 -> 4.8.0 ``                                    |
| [`667c0db2`](https://github.com/NixOS/nixpkgs/commit/667c0db2fe9b04e7a2db4c79445d178a8508fc60) | `` terraform-providers.oci: 5.26.0 -> 5.31.0 ``                                   |
| [`437a857d`](https://github.com/NixOS/nixpkgs/commit/437a857d18d8e1437aa227f05a66a5828355d35f) | `` terraform-providers.nomad: 2.1.0 -> 2.1.1 ``                                   |
| [`1c1a0739`](https://github.com/NixOS/nixpkgs/commit/1c1a0739c4ecdd7041a6dc48d6795fb752f19606) | `` terraform-providers.newrelic: 3.29.0 -> 3.32.0 ``                              |
| [`a0038fce`](https://github.com/NixOS/nixpkgs/commit/a0038fce790825761678d7c45515c97e3c968c52) | `` terraform-providers.namecheap: 2.1.1 -> 2.1.2 ``                               |
| [`641c3ef6`](https://github.com/NixOS/nixpkgs/commit/641c3ef68b75c1f2bce028d4f029c10d91555033) | `` terraform-providers.mongodbatlas: 1.14.0 -> 1.15.1 ``                          |
| [`45861b47`](https://github.com/NixOS/nixpkgs/commit/45861b47c76dd1c2e5285a2117bd4e5f081bec27) | `` terraform-providers.linode: 2.13.0 -> 2.16.0 ``                                |
| [`df9c270a`](https://github.com/NixOS/nixpkgs/commit/df9c270a9fca0f8652210a837e913cac5ab21c99) | `` terraform-providers.launchdarkly: 2.17.0 -> 2.18.0 ``                          |
| [`e73346ac`](https://github.com/NixOS/nixpkgs/commit/e73346ac165b0558076dc01da5c7c689d430b4ea) | `` terraform-providers.kubernetes: 2.25.2 -> 2.26.0 ``                            |
| [`7ce0969d`](https://github.com/NixOS/nixpkgs/commit/7ce0969d96b9bff5073cad804fed10aa813a4139) | `` terraform-providers.kafka: 0.5.4 -> 0.6.0 ``                                   |
| [`e0ba916d`](https://github.com/NixOS/nixpkgs/commit/e0ba916def759018b8b0a1451407f858a5c103cb) | `` terraform-providers.incus: 0.0.2 -> 0.1.0 ``                                   |
| [`2dacb167`](https://github.com/NixOS/nixpkgs/commit/2dacb167e62d7baa47ff44bc71ff1393fdef62e1) | `` terraform-providers.huaweicloud: 1.60.1 -> 1.62.0 ``                           |
| [`78fd9912`](https://github.com/NixOS/nixpkgs/commit/78fd9912e85f93feff8fe365c5e85159c7bcf493) | `` terraform-providers.http: 3.4.1 -> 3.4.2 ``                                    |
| [`f6b06c1c`](https://github.com/NixOS/nixpkgs/commit/f6b06c1c76e9bfd5fc5c00488b13766ecc399deb) | `` terraform-providers.gridscale: 1.23.0 -> 1.23.2 ``                             |
| [`83811819`](https://github.com/NixOS/nixpkgs/commit/838118195704bea2044f36949076c254b2ab1746) | `` terraform-providers.grafana: 2.10.0 -> 2.12.2 ``                               |
| [`24dd1c92`](https://github.com/NixOS/nixpkgs/commit/24dd1c92fed14781b4be5e8f271f5f07a86b61f9) | `` terraform-providers.google-beta: 5.13.0 -> 5.19.0 ``                           |
| [`0e277ab0`](https://github.com/NixOS/nixpkgs/commit/0e277ab0320ce1080ced4b7f1e1dbcce34820617) | `` terraform-providers.google: 5.13.0 -> 5.19.0 ``                                |
| [`66179066`](https://github.com/NixOS/nixpkgs/commit/66179066a4f78d15d60206fd1c1a4be2de31fd34) | `` terraform-providers.github: 5.43.0 -> 6.0.0 ``                                 |
| [`e4227ce6`](https://github.com/NixOS/nixpkgs/commit/e4227ce6e3454ccce84f059cda546ada7cd1ced2) | `` terraform-providers.fortios: 1.18.1 -> 1.19.0 ``                               |
| [`5569a36d`](https://github.com/NixOS/nixpkgs/commit/5569a36d080c979ec37475d9400a6e1a25729be5) | `` terraform-providers.fastly: 5.6.0 -> 5.7.0 ``                                  |
| [`41a51ed9`](https://github.com/NixOS/nixpkgs/commit/41a51ed990a1b55d2416f03c1fd2ed526008bf8f) | `` terraform-providers.external: 2.3.2 -> 2.3.3 ``                                |
| [`d526116f`](https://github.com/NixOS/nixpkgs/commit/d526116f7f80c35c212843298a01a14259d5c911) | `` terraform-providers.exoscale: 0.55.0 -> 0.56.0 ``                              |
| [`ea0ccc2f`](https://github.com/NixOS/nixpkgs/commit/ea0ccc2f631b21785dd96064312f71bdce88613c) | `` terraform-providers.doppler: 1.4.0 -> 1.6.2 ``                                 |
| [`1a052cd6`](https://github.com/NixOS/nixpkgs/commit/1a052cd675b1ba61061e30231faf9a5c0042ff15) | `` terraform-providers.datadog: 3.35.0 -> 3.37.0 ``                               |
| [`84821ead`](https://github.com/NixOS/nixpkgs/commit/84821ead47ef9905f52d588622dd921cfeed350d) | `` terraform-providers.cloudscale: 4.2.2 -> 4.2.3 ``                              |
| [`bb7b4bcb`](https://github.com/NixOS/nixpkgs/commit/bb7b4bcbad017ff230267be700040dbf5f41906a) | `` terraform-providers.cloudflare: 4.23.0 -> 4.25.0 ``                            |
| [`f063658e`](https://github.com/NixOS/nixpkgs/commit/f063658ea25d1034f3abd95a7d787b95fdc458a6) | `` terraform-providers.cloudamqp: 1.29.3 -> 1.29.4 ``                             |
| [`9b6a3f64`](https://github.com/NixOS/nixpkgs/commit/9b6a3f64c69b83f7cbd5bae7f198544328fda5e7) | `` terraform-providers.checkly: 1.7.3 -> 1.7.6 ``                                 |
| [`f40ea663`](https://github.com/NixOS/nixpkgs/commit/f40ea6638ca53cc8a306738092f0b0b4eb1232d5) | `` terraform-providers.buildkite: 1.3.0 -> 1.5.0 ``                               |
| [`3d618cf7`](https://github.com/NixOS/nixpkgs/commit/3d618cf7997786f7c185260df433819645487278) | `` terraform-providers.bitbucket: 2.38.0 -> 2.40.0 ``                             |
| [`d427bc25`](https://github.com/NixOS/nixpkgs/commit/d427bc25ea49830de6060efb8a48f557bd203144) | `` terraform-providers.bigip: 1.20.2 -> 1.21.0 ``                                 |
| [`36bdcbab`](https://github.com/NixOS/nixpkgs/commit/36bdcbab03b19385e4d121678d067d37fafc797a) | `` terraform-providers.baiducloud: 1.19.31 -> 1.19.37 ``                          |
| [`644dbcdf`](https://github.com/NixOS/nixpkgs/commit/644dbcdf4c9d94acb91676f330e09decc21c3787) | `` terraform-providers.azurerm: 3.89.0 -> 3.94.0 ``                               |
| [`a40b73ce`](https://github.com/NixOS/nixpkgs/commit/a40b73cea229cae2539296b8a600495d3b716ffa) | `` terraform-providers.aws: 5.34.0 -> 5.39.1 ``                                   |
| [`f698d525`](https://github.com/NixOS/nixpkgs/commit/f698d525676bf7e4fd413a34754e94a938f34315) | `` terraform-providers.auth0: 1.1.2 -> 1.2.0 ``                                   |
| [`f6a15cfd`](https://github.com/NixOS/nixpkgs/commit/f6a15cfd5f97f2bf1773f2a56c951f44c62c708b) | `` terraform-providers.artifactory: 10.1.2 -> 10.1.5 ``                           |
| [`7beaca88`](https://github.com/NixOS/nixpkgs/commit/7beaca88d22981c7aeedb4c3a21575285acb8f92) | `` terraform-providers.alicloud: 1.215.0 -> 1.217.2 ``                            |
| [`2a777049`](https://github.com/NixOS/nixpkgs/commit/2a77704900d436709aa394c37ffef865aad1a419) | `` terraform-providers.akamai: 5.5.0 -> 5.6.0 ``                                  |
| [`8d5518ef`](https://github.com/NixOS/nixpkgs/commit/8d5518ef9eb659503eabe688b5d0a76ecb703c89) | `` terraform-providers.acme: 2.19.1 -> 2.20.2 ``                                  |
| [`9fbb5dfa`](https://github.com/NixOS/nixpkgs/commit/9fbb5dfae22fba790cbde2816baf8f0cc2911fe8) | `` terraform-providers.aci: 2.13.0 -> 2.13.2 ``                                   |
| [`0873ccf9`](https://github.com/NixOS/nixpkgs/commit/0873ccf9d78be52df6cc9d69565397933dd7296a) | `` buildbot: add buildbot-plugins.react-wsgi-dashboards to update script ``       |
| [`8f7f11da`](https://github.com/NixOS/nixpkgs/commit/8f7f11daef2bfd448877af9964fc34e2dbff936a) | `` buildbot: 3.11.0 -> 3.11.1 ``                                                  |
| [`5a4abe8f`](https://github.com/NixOS/nixpkgs/commit/5a4abe8f77eb866300e591e268fb76f75b78e129) | `` python3Packages.dj-rest-auth: add patch to support django-allauth 0.61.0 ``    |
| [`e20a2dfe`](https://github.com/NixOS/nixpkgs/commit/e20a2dfe2c019495f4affdb982ade9efed6f5e1c) | `` home-assistant-custom-lovelace-modules.mushroom: 3.4.2 -> 3.5.0 ``             |
| [`0ce9aacf`](https://github.com/NixOS/nixpkgs/commit/0ce9aacffe65db64af135c2850ec6fb6e95633d4) | `` python3Packages.django-allauth: 0.60.0 -> 0.61.1 ``                            |
| [`33c109bd`](https://github.com/NixOS/nixpkgs/commit/33c109bd29ec9e6b948dd25c8897875f7296a402) | `` go_1_22: 1.22.0 -> 1.22.1 ``                                                   |
| [`e61a8070`](https://github.com/NixOS/nixpkgs/commit/e61a80700d8398ed2458b088e436dd941940f46c) | `` python311Packages.flask-marshmallow: refactor ``                               |
| [`981be4fd`](https://github.com/NixOS/nixpkgs/commit/981be4fd16e3eecf3db938d7f31823655529318f) | `` nh: 3.5.2 -> 3.5.3 ``                                                          |
| [`36a212c8`](https://github.com/NixOS/nixpkgs/commit/36a212c8496aaf06a3e29962ce05652b9ae2bbf8) | `` audiness: 0.2.0 -> 0.2.1 ``                                                    |
| [`6a04adcc`](https://github.com/NixOS/nixpkgs/commit/6a04adccdddf869eeff79a01c02fb11a3f0e0bf9) | `` katago: expose CMake options new in 1.14.0 (#277390) ``                        |
| [`9b90f685`](https://github.com/NixOS/nixpkgs/commit/9b90f685e58c1483cbdea6388069e1ed8f57edae) | `` citra: remove package ``                                                       |
| [`6284603c`](https://github.com/NixOS/nixpkgs/commit/6284603ca6c904a3b521a88e5180ae1c2eee0243) | `` sourcehut: add override for python3 flask dependency ``                        |
| [`bc627a6a`](https://github.com/NixOS/nixpkgs/commit/bc627a6acad591f05e8b879a9388137859e10855) | `` build-support/php: move functions around (dry) ``                              |
| [`cf9e77ef`](https://github.com/NixOS/nixpkgs/commit/cf9e77ef8e6c7b903c7dd5b37d3753c65b3c6a13) | `` phpPackages.composer: 2.6.6 -> 2.7.1 ``                                        |
| [`39502e7a`](https://github.com/NixOS/nixpkgs/commit/39502e7aa718377973117333caeafa38f5108ae8) | `` build-support/php/composer-local-repo-plugin: 1.0.3 -> 1.1.0 ``                |
| [`a07dd748`](https://github.com/NixOS/nixpkgs/commit/a07dd748d9591d00f53d0ea741fc0dd00397a879) | `` nixos-option: update to nix 2.18 ``                                            |
| [`1c85d220`](https://github.com/NixOS/nixpkgs/commit/1c85d220c969285865ac14f69d671d4b813979ec) | `` taplo: 0.8.1 -> 0.9.0 ``                                                       |
| [`8195cd82`](https://github.com/NixOS/nixpkgs/commit/8195cd8227b62734ef632ebaa58305cf439075f3) | `` pacman: 6.0.2 -> 6.1.0 ``                                                      |
| [`2b194563`](https://github.com/NixOS/nixpkgs/commit/2b194563932b4321d2fdb37012fa0ec3dbcf5d46) | `` libsForQt5.qtutilities: 6.13.4 -> 6.13.5 ``                                    |
| [`53e51f97`](https://github.com/NixOS/nixpkgs/commit/53e51f97f6085ffa8793d9b8f6d7aaecc5d3ebcf) | `` pythonPackages.nbxmpp: 4.5.3 → 4.5.4 ``                                        |
| [`a8979c1d`](https://github.com/NixOS/nixpkgs/commit/a8979c1d4169cbaae26b1bad5e97482899eb703b) | `` renode-unstable: 1.14.0+20240226git732d357b4 -> 1.14.0+20240305gitcec51e561 `` |
| [`91089a32`](https://github.com/NixOS/nixpkgs/commit/91089a327cf2b43b555a305b7083a2f0abdac48b) | `` dnf5: 5.1.13 -> 5.1.14 ``                                                      |
| [`0b39e86c`](https://github.com/NixOS/nixpkgs/commit/0b39e86cbc509bbe7d6e0a5c10f4860e68483e53) | `` nixosTests.homepage-dashboard: test managed and unmanaged configs ``           |
| [`183bc82c`](https://github.com/NixOS/nixpkgs/commit/183bc82cca1e3175cc3bfda91fb2525bb3b88c05) | `` nixos/homepage-dashboard: add breaking change notice to release notes ``       |
| [`c0330351`](https://github.com/NixOS/nixpkgs/commit/c0330351a06ffebc70e4bbcfe9bad43449aab4b7) | `` nixos/homepage-dashboard: support structured config ``                         |
| [`cba3d0d2`](https://github.com/NixOS/nixpkgs/commit/cba3d0d236d6e121e88fa14056489ac080d9a4fe) | `` homepage-dashboard: patch to enable control of log targets ``                  |
| [`849a7118`](https://github.com/NixOS/nixpkgs/commit/849a71182181159796f4cc5aef24c1d811f67181) | `` julia-mono: 0.053 -> 0.054 ``                                                  |
| [`4163445f`](https://github.com/NixOS/nixpkgs/commit/4163445f942f3c9a02b2cbdbf4db4cf3c27d07b7) | `` ocamlPackages.ctypes: 0.21.1 → 0.22.0 ``                                       |
| [`d6d96bdf`](https://github.com/NixOS/nixpkgs/commit/d6d96bdff4fa095c7ea43e94229c3847852205c0) | `` ocamlPackages.ctypes: 0.20.2 → 0.21.1 ``                                       |
| [`73d23678`](https://github.com/NixOS/nixpkgs/commit/73d23678db77626623867ca4e7eb66331d346156) | `` werf: 1.2.295 -> 1.2.296 ``                                                    |
| [`4c10873f`](https://github.com/NixOS/nixpkgs/commit/4c10873f37a96d98fb51072b6f9e39b53ddc6429) | `` arkade: 0.11.2 -> 0.11.4 ``                                                    |
| [`95cbbb66`](https://github.com/NixOS/nixpkgs/commit/95cbbb664810225dd2ee410a5eee1e3aeb773a92) | `` pict-rs: 0.5.6 -> 0.5.7 ``                                                     |
| [`4e8e7e49`](https://github.com/NixOS/nixpkgs/commit/4e8e7e497a56f3d025a20dce0dc1c4a0525233e5) | `` cloudrecon: 1.0.3 -> 1.0.4 ``                                                  |
| [`a61e8e9a`](https://github.com/NixOS/nixpkgs/commit/a61e8e9af7a5ede03fc3dee676ecab504e49c724) | `` python311Packages.marshmallow-oneofschema: 3.0.2 -> 3.1.1 ``                   |
| [`e5e6a178`](https://github.com/NixOS/nixpkgs/commit/e5e6a178b73886cb3371e231964267a353ca4177) | `` python311Packages.marshmallow: 3.20.0 -> 3.21.1 ``                             |
| [`d06d6684`](https://github.com/NixOS/nixpkgs/commit/d06d66849582c6a8b4f92550a21d22749edc0828) | `` python311Packages.hstspreload: 2024.2.1 -> 2024.3.1 ``                         |
| [`829e7868`](https://github.com/NixOS/nixpkgs/commit/829e7868aa1206e7eaa4eb6fb6da2e341ede7dc0) | `` python311Packages.oauthenticator: refactor ``                                  |
| [`14a12cae`](https://github.com/NixOS/nixpkgs/commit/14a12caecffdba81e6ccba5cba9cd3b38cb4571e) | `` python38: remove ``                                                            |
| [`aebabc6e`](https://github.com/NixOS/nixpkgs/commit/aebabc6e3ae855e97793c00fcc8c09f06257bb1a) | `` hugo: 0.123.6 -> 0.123.7 ``                                                    |
| [`bd5bb902`](https://github.com/NixOS/nixpkgs/commit/bd5bb902576f4801399756b2a2a45c199ec1cbc2) | `` python311Packages.django-storages: disable failing tests ``                    |
| [`272c9ded`](https://github.com/NixOS/nixpkgs/commit/272c9ded0434c3646fe97e6cbebe28b02505e0d5) | `` python311Packages.django-storages: 1.14 -> 1.14.2 ``                           |
| [`0bf17537`](https://github.com/NixOS/nixpkgs/commit/0bf175376ee260ab04653525e6121c32ea68cc7a) | `` python311Packages.django-storages: refactor ``                                 |
| [`3b2adba3`](https://github.com/NixOS/nixpkgs/commit/3b2adba3f3ce877f5635e070b9effc342701c17e) | `` evcc: 0.124.4 -> 0.124.6 ``                                                    |
| [`e1d31c86`](https://github.com/NixOS/nixpkgs/commit/e1d31c8699e4ee4fe5990f0d35fdf812d14595c4) | `` wit-bindgen: 0.20.0 -> 0.21.0 ``                                               |
| [`5333a8f8`](https://github.com/NixOS/nixpkgs/commit/5333a8f8579f7a1ac7c90975f9c2c44fa8b7b4a6) | `` goattracker,goattracker-stereo: add newlines to hooks ``                       |
| [`3d008ce3`](https://github.com/NixOS/nixpkgs/commit/3d008ce3ff711f4aafbf725ebe601bb0dfea0d64) | `` goattracker,goattracker-stereo: set mainProgram ``                             |
| [`55418c60`](https://github.com/NixOS/nixpkgs/commit/55418c6077b5a3272cbcf27e982283667e471bff) | `` goattracker,goattracker-stereo: install manual ``                              |
| [`ee411f2c`](https://github.com/NixOS/nixpkgs/commit/ee411f2c1ba132a5d96199b6e3132611b7443293) | `` VictoriaMetrics: 1.97.1 -> 1.99.0 (#293328) ``                                 |
| [`bdc45d7d`](https://github.com/NixOS/nixpkgs/commit/bdc45d7d790d834dab15dc603fb4ffc59029cfaa) | `` python311Packages.dm-haiku: 0.0.11 -> 0.0.12 ``                                |
| [`21fb808a`](https://github.com/NixOS/nixpkgs/commit/21fb808a9014ea2fca15cf19ae8f1f516b64d685) | `` python311Packages.google-cloud-bigquery: 3.17.1 -> 3.18.0 ``                   |
| [`36ab4385`](https://github.com/NixOS/nixpkgs/commit/36ab4385d2d13e81e487379e835799dcc6860dcd) | `` python311Packages.google-cloud-storage: 2.14.0 -> 2.15.0 ``                    |
| [`addb4093`](https://github.com/NixOS/nixpkgs/commit/addb4093545f9596f2863f602e2d916badf4f9b0) | `` python311Packages.google-cloud-securitycenter: 1.27.0 -> 1.28.0 ``             |
| [`6f3768e0`](https://github.com/NixOS/nixpkgs/commit/6f3768e03ac55b235ebdaa7bb304225818df8b46) | `` hivelytracker: set mainProgram ``                                              |