### PR TITLE
chore(flake/home-manager): `b0b0c3d9` -> `fe4180ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,11 +390,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709988192,
-        "narHash": "sha256-qxwIkl85P0I1/EyTT+NJwzbXdOv86vgZxcv4UKicjK8=",
+        "lastModified": 1710055150,
+        "narHash": "sha256-Nc8ojxTO2a70qnU8f6bVRs4WhuoFQL74gMTkRaCjg5M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b0b0c3d94345050a7f86d1ebc6c56eea4389d030",
+        "rev": "fe4180ad3f07a2064fed7875183509e7e0eb07cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`fe4180ad`](https://github.com/nix-community/home-manager/commit/fe4180ad3f07a2064fed7875183509e7e0eb07cd) | `` bat: handle existing cache in activation script `` |
| [`fbec8983`](https://github.com/nix-community/home-manager/commit/fbec89838763831bd92e1b09222dc9477942930f) | `` flake.lock: Update ``                              |