### PR TITLE
chore(flake/nix-index-database): `851fcfd1` -> `e76ff2df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -483,11 +483,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710040110,
-        "narHash": "sha256-PNAV8VdZkNoSGQHGQWDefNarl0BtKjVMCCzu16+vsr4=",
+        "lastModified": 1710120787,
+        "narHash": "sha256-tlLuB73OCOKtU2j83bQzSYFyzjJo3rjpITZE5MoofG8=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "851fcfd130597c5c91071d46275111522d4fd595",
+        "rev": "e76ff2df6bfd2abe06abd8e7b9f217df941c1b07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                            |
| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`e76ff2df`](https://github.com/nix-community/nix-index-database/commit/e76ff2df6bfd2abe06abd8e7b9f217df941c1b07) | `` Bump softprops/action-gh-release from 1 to 2 `` |
| [`5f50845a`](https://github.com/nix-community/nix-index-database/commit/5f50845a681aa04f9235d28540419227a19dc6e6) | `` Bump cachix/install-nix-action from 25 to 26 `` |