### PR TITLE
chore(flake/flake-utils): `d465f481` -> `b1d9ab70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -300,11 +300,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709126324,
-        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                   |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`b1d9ab70`](https://github.com/numtide/flake-utils/commit/b1d9ab70662946ef0850d488da1c9019f3a9752a) | `` Bump cachix/install-nix-action from 25 to 26 (#116) `` |