### PR TITLE
chore(flake/lanzaboote): `f0039ede` -> `f143c542`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -439,11 +439,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1710149224,
-        "narHash": "sha256-Ysw6x1VgeLOZHuyJ0UjON/ms8tzCjkcKCZ85A9O016U=",
+        "lastModified": 1710167759,
+        "narHash": "sha256-7iuX4VPUh5E/mdLmuyKU47rB6It2w2cxMlJ861WAiMY=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "f0039ede99adf0027b796065350566a1ef9e4a78",
+        "rev": "f143c5423584089b24608fd67f955c1df0da4b24",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                          |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`674773cf`](https://github.com/nix-community/lanzaboote/commit/674773cf74cf0ebe62ee230b28e3533286db5b55) | `` docs: add more framework-specific hints ``    |
| [`e92f808e`](https://github.com/nix-community/lanzaboote/commit/e92f808ea1c180fb182da201ecbb530b6e2d4454) | `` fix(deps): update rust crate clap to 4.5.2 `` |