### PR TITLE
chore(flake/lanzaboote): `f143c542` -> `19ad7fd5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -439,11 +439,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1710167759,
-        "narHash": "sha256-7iuX4VPUh5E/mdLmuyKU47rB6It2w2cxMlJ861WAiMY=",
+        "lastModified": 1710171982,
+        "narHash": "sha256-WFMB+Yohcvego1/vOtaq+MJ8Wvp5meOANfNifg26Ie4=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "f143c5423584089b24608fd67f955c1df0da4b24",
+        "rev": "19ad7fd5724f30868748b8156ff25be838cd2bc5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                      |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`acf7fffc`](https://github.com/nix-community/lanzaboote/commit/acf7fffcc9f332d62b83e00764f8ec6f7ef96532) | `` tests: refactor into separate files called via runTest `` |
| [`e17ed9d6`](https://github.com/nix-community/lanzaboote/commit/e17ed9d6da110dd1b6203c36e43b917b718929de) | `` nix/modules/uki: use upstream systemdUkify ``             |