### PR TITLE
chore(flake/home-manager): `017b12de` -> `a500de54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,11 +390,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710164657,
-        "narHash": "sha256-l64+ZjaQAVkHDVaK0VHwtXBdjcBD6nLBD+p7IfyBp/w=",
+        "lastModified": 1710273215,
+        "narHash": "sha256-AfVYEQIhOK6vaYVndgqFV4Vb5REXG9R0ylv83QInsT0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "017b12de5b899ef9b64e2c035ce257bfe95b8ae2",
+        "rev": "a500de54b2e3067201a40cefa5f210f719423ddf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`a500de54`](https://github.com/nix-community/home-manager/commit/a500de54b2e3067201a40cefa5f210f719423ddf) | `` eza: replace enableAliases with integration options `` |