### PR TITLE
chore(flake/home-manager): `1b74e367` -> `a82cdd28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,11 +390,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710329147,
-        "narHash": "sha256-ExKfXL6PURo5VJ9bNPkOxCNBlRDoPILeCfUrMyJ20i0=",
+        "lastModified": 1710334051,
+        "narHash": "sha256-eD5uXXOgdu+okeYIGdAKeF+jEjFlKVf6o9xGX3tSV6A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1b74e3679e90fe7ad142bb5f66610a0d92ac0165",
+        "rev": "a82cdd288e3570ac52cffe0abaf28fac7d967b68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`a82cdd28`](https://github.com/nix-community/home-manager/commit/a82cdd288e3570ac52cffe0abaf28fac7d967b68) | `` offlineimap: disable starttls if tls is disabled `` |
| [`0906e8df`](https://github.com/nix-community/home-manager/commit/0906e8dfe7a4a530799681be4be8ac5b48fddc0b) | `` eza: use `mkDefault` for aliases ``                 |
| [`31abb4f6`](https://github.com/nix-community/home-manager/commit/31abb4f6bc540dfa82562e81312cfdc77770f001) | `` docs: fix broken link ``                            |