### PR TITLE
chore(flake/home-manager): `2f0db7d4` -> `1ab3cec3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,11 +390,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710349883,
-        "narHash": "sha256-bjbdS2mC76xNJwt1d/uZa+JdHR8CCyYbF4Ey/NgOJus=",
+        "lastModified": 1710423955,
+        "narHash": "sha256-6N/65EqYVqCaz5SVoPMx2HgA+DJZAlw5lW+U9VHSSbE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f0db7d418e781354d8a3c50e611e3b1cd413087",
+        "rev": "587719494ed18a184c98c4d55dde9469af4446bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`1ab3cec3`](https://github.com/nix-community/home-manager/commit/1ab3cec3a1bbb065b2d52b913d1431366028d5b5) | `` rbw: simplify 'pinentry' type ``           |
| [`01e4a514`](https://github.com/nix-community/home-manager/commit/01e4a5143e92251272850a8e0fbb4518bd099087) | `` gpg-agent: migrate to 'pinentryPackage' `` |