### PR TITLE
chore(flake/home-manager): `58771949` -> `ec4096e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,11 +390,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710423955,
-        "narHash": "sha256-6N/65EqYVqCaz5SVoPMx2HgA+DJZAlw5lW+U9VHSSbE=",
+        "lastModified": 1710446098,
+        "narHash": "sha256-vz2xpLWKZyW30znsk0DrPCNknq/+Vw0LbQqDcDDgdgM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "587719494ed18a184c98c4d55dde9469af4446bf",
+        "rev": "ec4096e9000c0b3695c05576076449ad99e905e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`ec4096e9`](https://github.com/nix-community/home-manager/commit/ec4096e9000c0b3695c05576076449ad99e905e3) | `` eza: fix typo in docs ``            |
| [`bd9141ea`](https://github.com/nix-community/home-manager/commit/bd9141ea97d8ccd68b97aa2febfae44683881662) | `` fusuma: add missing dependencies `` |