### PR TITLE
chore(flake/nixpkgs): `0ad13a68` -> `d691274a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710272261,
-        "narHash": "sha256-g0bDwXFmTE7uGDOs9HcJsfLFhH7fOsASbAuOzDC+fhQ=",
+        "lastModified": 1710451336,
+        "narHash": "sha256-pP86Pcfu3BrAvRO7R64x7hs+GaQrjFes+mEPowCfkxY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0ad13a6833440b8e238947e47bea7f11071dc2b2",
+        "rev": "d691274a972b3165335d261cc4671335f5c67de9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`4c61ee21`](https://github.com/NixOS/nixpkgs/commit/4c61ee21b2824e774b051c62ba534062353fd05d) | `` gtkpod, gnome.anjuta: drop ``                                                    |
| [`0dc027a2`](https://github.com/NixOS/nixpkgs/commit/0dc027a2ee90517daf61ed2ca6991c0031a49e1d) | `` ddnet: 18.0.3 -> 18.1 ``                                                         |
| [`2ddf3f58`](https://github.com/NixOS/nixpkgs/commit/2ddf3f58efd3de3dcc7550b3650960ea9c7d3325) | `` ivsc-firmware: add a1_prod symbolic links to fix ipu6 webcams  (#295508) ``      |
| [`ea3c2e26`](https://github.com/NixOS/nixpkgs/commit/ea3c2e26d3f954038edc0f0d05f62770679ae84c) | `` maintainers: remove shanesveller ``                                              |
| [`743e0976`](https://github.com/NixOS/nixpkgs/commit/743e097694f4046ec9ef4c207af2f18bc91e516a) | `` audion: init at 0.2.0 ``                                                         |
| [`1a738f6c`](https://github.com/NixOS/nixpkgs/commit/1a738f6cb296bdb042af0a32e8b273737ccb5785) | `` python311Packages.boto3-stubs: 1.34.61 -> 1.34.62 ``                             |
| [`1fa47f4b`](https://github.com/NixOS/nixpkgs/commit/1fa47f4b035038cc0d757bc35cfa7dd039b3dcb1) | `` zkar: add changelog to meta ``                                                   |
| [`cbb2518a`](https://github.com/NixOS/nixpkgs/commit/cbb2518af75503d7fc3e8ac7708b4a41ec3f16ba) | `` whalebird: 5.0.7 -> 6.0.4 (#284125) ``                                           |
| [`fbecf06d`](https://github.com/NixOS/nixpkgs/commit/fbecf06d81b18e6bf436f1de6b31e9a28f899fd9) | `` python312Packages.python-ptrace: 0.9.8 -> 0.9.9 ``                               |
| [`9353fb23`](https://github.com/NixOS/nixpkgs/commit/9353fb2309902387c16130c97f27242ef24bc4c6) | `` nixos/nextcloud: remove opcache.enable_cli=1 ``                                  |
| [`28897450`](https://github.com/NixOS/nixpkgs/commit/28897450f4786eb6fec0a6fcc708fc91a9c250fd) | `` python311Packages.pykaleidescape: refactor ``                                    |
| [`c18d322d`](https://github.com/NixOS/nixpkgs/commit/c18d322dc6f2020b20ac1b552a396f9ea01a0d9c) | `` python311Packages.pykaleidescape: 2022.2.3 -> 1.0.1 ``                           |
| [`367ff623`](https://github.com/NixOS/nixpkgs/commit/367ff623c791e720f07cb1eaa19a39a67bc76bae) | `` python311Packages.ttn-client: init at 0.0.3 ``                                   |
| [`b075a4d4`](https://github.com/NixOS/nixpkgs/commit/b075a4d414217c748441650794bb1f6201d2b006) | `` python311Packages.python-lsp-server: 1.10.0 -> 1.10.1 ``                         |
| [`ef1d55bb`](https://github.com/NixOS/nixpkgs/commit/ef1d55bb790aacdc32017f66200463a5c4df4028) | `` evcc: 0.124.9 -> 0.124.10 ``                                                     |
| [`d451cbcf`](https://github.com/NixOS/nixpkgs/commit/d451cbcfd7679a924ebda65e2136771a144376f5) | `` xrdp: 0.9.25 -> 0.9.25.1 ``                                                      |
| [`55e4d6e4`](https://github.com/NixOS/nixpkgs/commit/55e4d6e446f2f2c6c3bc530e81a04eb62190c6b6) | `` rwpspread: 0.2.3 -> 0.2.4 ``                                                     |
| [`1f391d4b`](https://github.com/NixOS/nixpkgs/commit/1f391d4be0ae17beaac275155434ca7aa7e03ea0) | `` k3s_1_24, k3s_1_25: add removal alias ``                                         |
| [`18d2b24a`](https://github.com/NixOS/nixpkgs/commit/18d2b24a844b5658aa4a1662b6d8f23d1b3df1b7) | `` mqttmultimeter: 1.7.0.211 -> 1.8.2.272 ``                                        |
| [`ce411f4f`](https://github.com/NixOS/nixpkgs/commit/ce411f4f32fbd75085d5e9c41eee6ef601b5356b) | `` wofi-pass: 23.1.4 -> 24.0.0 ``                                                   |
| [`2b19e47c`](https://github.com/NixOS/nixpkgs/commit/2b19e47c8b29ae2c28bd62c2267ffc26a4cc59f5) | `` josh: 23.02.14 -> 23.12.04 ``                                                    |
| [`f69a1151`](https://github.com/NixOS/nixpkgs/commit/f69a1151e70a8ac6b0f3d9c21d588bbbec04ae22) | `` tagref: 1.9.1 -> 1.10.0 ``                                                       |
| [`5b882503`](https://github.com/NixOS/nixpkgs/commit/5b882503cf54001a2f1d7efdd0d289f5d2828826) | `` kanidm: 1.1.0-rc.16 backports ``                                                 |
| [`83b17bde`](https://github.com/NixOS/nixpkgs/commit/83b17bdeae2e8349d97f643df6d09370d8fc41aa) | `` python312Packages.timezonefinder: 6.4.1 -> 6.5.0 ``                              |
| [`b4c94217`](https://github.com/NixOS/nixpkgs/commit/b4c942176214ed83a87f969106d425fdb4eb8bb6) | `` python312Packages.scikit-hep-testdata: 0.4.39 -> 0.4.40 ``                       |
| [`222e17b6`](https://github.com/NixOS/nixpkgs/commit/222e17b62bea3c1c3b90e89209b2e5da904d2d76) | `` ungoogled-chromium: 122.0.6261.111-1 -> 122.0.6261.128-1 ``                      |
| [`656c6732`](https://github.com/NixOS/nixpkgs/commit/656c67320e6ccf24fd7b779769c578877eac3173) | `` hyper-haskell: remove (#295854) ``                                               |
| [`f5c9d083`](https://github.com/NixOS/nixpkgs/commit/f5c9d0835301c298b6050ab6158c7d7837032243) | `` python312Packages.clickhouse-connect: 0.7.2 -> 0.7.3 ``                          |
| [`da14f856`](https://github.com/NixOS/nixpkgs/commit/da14f856e0df2cbb8a2ccd6c9db8efe7d34ad280) | `` sitespeed-io: 33.1.1 -> 33.2.0 ``                                                |
| [`42e1dea3`](https://github.com/NixOS/nixpkgs/commit/42e1dea38d77d5854d26817c8af8d0922f4add10) | `` nu_scripts: unstable-2024-03-09 -> unstable-2024-03-12 ``                        |
| [`912172bb`](https://github.com/NixOS/nixpkgs/commit/912172bbb321cc7399119814eea53d6f59fc1ea6) | `` python311Packages.dbt-core: 1.7.9 -> 1.7.10 ``                                   |
| [`f02039b3`](https://github.com/NixOS/nixpkgs/commit/f02039b3c604c614616ec31c6040fc4fa4a345f4) | `` lightburn: 1.5.02 -> 1.5.03 ``                                                   |
| [`fd67de45`](https://github.com/NixOS/nixpkgs/commit/fd67de45178893851a1b5cf4434d2f451f2b01fd) | `` lxgw-neoxihei: 1.120 -> 1.120.1 ``                                               |
| [`4396209b`](https://github.com/NixOS/nixpkgs/commit/4396209baf57399d459542c7bbeb0da745cb0a5b) | `` k8sgpt: 0.3.27 -> 0.3.28 ``                                                      |
| [`c9be2672`](https://github.com/NixOS/nixpkgs/commit/c9be2672ed591e51f2399bb77f4fc819e2ce1063) | `` etcher: remove (#295853) ``                                                      |
| [`ae86a507`](https://github.com/NixOS/nixpkgs/commit/ae86a507edd30911f2dfb1359ad83b448cbddb28) | `` npmHooks.npmInstallHook: ignore bundle deps when calculating files to install `` |
| [`6cd749a3`](https://github.com/NixOS/nixpkgs/commit/6cd749a33a3911c3797ef6f3e910c4b9f958d939) | `` python312Packages.types-docutils: 0.20.0.20240311 -> 0.20.0.20240314 ``          |
| [`194b4f6f`](https://github.com/NixOS/nixpkgs/commit/194b4f6f77c9ea107e27805c1e788304c351529d) | `` hcl2json: 0.6.1 -> 0.6.2 ``                                                      |
| [`f1861b33`](https://github.com/NixOS/nixpkgs/commit/f1861b332885d6776d806fe955e6b24262673721) | `` bearer: 1.41.0 -> 1.42.0 ``                                                      |
| [`83b59271`](https://github.com/NixOS/nixpkgs/commit/83b59271e360fe8ede638712d92964c742d12d1d) | `` sketchybar: 2.20.1 -> 2.21.0 ``                                                  |
| [`00841498`](https://github.com/NixOS/nixpkgs/commit/0084149862e8a00c1e3b89adf74ecf2857903e51) | `` lefthook: 1.6.5 -> 1.6.6 ``                                                      |
| [`8eb1338a`](https://github.com/NixOS/nixpkgs/commit/8eb1338a05ca4511a411b8d9edd068bc747f0937) | `` time-ghc-modules: 1.0.1 -> 2.0.0 ``                                              |
| [`9a0a8314`](https://github.com/NixOS/nixpkgs/commit/9a0a83148d80472922328960579d79e1477d1058) | `` zkar: 1.3.0 -> 1.4.0 ``                                                          |
| [`dab2c7c8`](https://github.com/NixOS/nixpkgs/commit/dab2c7c88ed28080cc47da05ec121ef5d1bbe039) | `` python311Packages.gvm-tools: 24.1.0 -> 24.3.0 ``                                 |
| [`f0ef0e96`](https://github.com/NixOS/nixpkgs/commit/f0ef0e967f8efe6cdf226103555d38bee5974f64) | `` python312Packages.gassist-text: 0.0.10 -> 0.0.11 ``                              |
| [`95f5fbdb`](https://github.com/NixOS/nixpkgs/commit/95f5fbdbfdc3b7853cfbb2cea3649c378e193e68) | `` fretboard: fix build on darwin ``                                                |
| [`a944f116`](https://github.com/NixOS/nixpkgs/commit/a944f116b929c7d69d17219b6a87cef6eb81f0b3) | `` python312Packages.restrictedpython: 7.0 -> 7.1 ``                                |
| [`6cabf8e2`](https://github.com/NixOS/nixpkgs/commit/6cabf8e212d0bb63da63917a97299bfbea0c576a) | `` git-instafix: init at 0.2.1 ``                                                   |
| [`fe9f697f`](https://github.com/NixOS/nixpkgs/commit/fe9f697fc469e944868a853db392b1996d232918) | `` opencomposite{,-helper}: move to pkgs/by-name ``                                 |
| [`9f26152c`](https://github.com/NixOS/nixpkgs/commit/9f26152cc3d7e90c7f2a5908de4d1aab069ed6ce) | `` electron: small refactors ``                                                     |
| [`c076cc21`](https://github.com/NixOS/nixpkgs/commit/c076cc21571c0572715a6ddbd794558f0578878d) | `` electron_26-bin: mark as insecure ``                                             |
| [`044c4aa3`](https://github.com/NixOS/nixpkgs/commit/044c4aa3c3d50cc63d0d45798a63adb0ca2a196c) | `` electron-source.electron_26: remove ``                                           |
| [`a3351dba`](https://github.com/NixOS/nixpkgs/commit/a3351dbafd5edc699f2e5f282a21a6a498a93c95) | `` electron: change default to 29.x ``                                              |
| [`d8545300`](https://github.com/NixOS/nixpkgs/commit/d8545300ef41072615cf010d51fcfdbbe3d09a55) | `` electron_29: init at 29.1.2 ``                                                   |
| [`46eff962`](https://github.com/NixOS/nixpkgs/commit/46eff9624590ff8472343d73a86fccf75a3765f1) | `` electron_27: 27.3.2 -> 27.3.5 ``                                                 |
| [`29c0b6e0`](https://github.com/NixOS/nixpkgs/commit/29c0b6e090457cfe11d203a134d6e8637673c420) | `` electron_28: 28.2.2 -> 28.2.6 ``                                                 |
| [`3a7feda6`](https://github.com/NixOS/nixpkgs/commit/3a7feda68d750ad99f236d0b49ed22f6e0ab0638) | `` Update Folding@home client to 8.3.7 (#295745) ``                                 |
| [`0a3812d6`](https://github.com/NixOS/nixpkgs/commit/0a3812d6b64cf28f817c2ca07304ca16c46e21af) | `` switcheroo: 2.0.1 -> 2.1.0 ``                                                    |
| [`81c42da3`](https://github.com/NixOS/nixpkgs/commit/81c42da3c322b7d9433141e97e5130166fbffa19) | `` php: use `--replace-fail` ``                                                     |
| [`f1219eb4`](https://github.com/NixOS/nixpkgs/commit/f1219eb40fcdf4774fffd04b59cea03c30b95875) | `` openobserve: 0.8.1 -> 0.9.1 ``                                                   |
| [`89650507`](https://github.com/NixOS/nixpkgs/commit/89650507a0a7aa8dc36341db08d56367eb64df5f) | `` polypane: 18.0.0 -> 18.0.4 ``                                                    |
| [`36c3b097`](https://github.com/NixOS/nixpkgs/commit/36c3b097e3ed9598789a5e32b1aebd4798ec4dfb) | `` element-{web,desktop}: 1.11.59 -> 1.11.60 (#295640) ``                           |
| [`07e16643`](https://github.com/NixOS/nixpkgs/commit/07e1664393c102687be7669176bbd277447c2316) | `` arxiv-latex-cleaner: 1.0.4 -> 1.0.5 ``                                           |
| [`aca93d82`](https://github.com/NixOS/nixpkgs/commit/aca93d8268af76b54dddc89f9f2f8234306b63ea) | `` clash-verge-rev: 1.5.7 -> 1.5.8 ``                                               |
| [`efbcf8ff`](https://github.com/NixOS/nixpkgs/commit/efbcf8ff4b032a878a461a89b4a721d3ae39f1a3) | `` clash-verge: add update script ``                                                |
| [`fdf475c5`](https://github.com/NixOS/nixpkgs/commit/fdf475c585151fad6d361129eca6255e07035763) | `` prometheus-smokeping-prober: 0.7.2 -> 0.7.3 ``                                   |
| [`aadadf37`](https://github.com/NixOS/nixpkgs/commit/aadadf379bf8e94fcdd203328f4474a072ddc594) | `` python311Packages.tencentcloud-sdk-python: 3.0.1107 -> 3.0.1108 ``               |
| [`74c6eba4`](https://github.com/NixOS/nixpkgs/commit/74c6eba43b3cafe9ed58d593848a27be7167cf3a) | `` python311Packages.roombapy: 1.6.13 -> 1.7.0 ``                                   |
| [`70488c92`](https://github.com/NixOS/nixpkgs/commit/70488c926831b33c438dbeb5cf4c48f396c1fcf1) | `` python311Packages.mypy-boto3-s3: 1.34.14 -> 1.34.62 ``                           |
| [`0ae8353a`](https://github.com/NixOS/nixpkgs/commit/0ae8353a1daea4482b34f08cf7c49e3a6eaf9280) | `` python311Packages.mypy-boto3-kinesisanalyticsv2: 1.34.0 -> 1.34.62 ``            |
| [`bac3795c`](https://github.com/NixOS/nixpkgs/commit/bac3795c93a50fe7c46ee27560b612ce72a842e9) | `` python311Packages.mypy-boto3-ivs-realtime: 1.34.0 -> 1.34.62 ``                  |
| [`10070151`](https://github.com/NixOS/nixpkgs/commit/1007015166384dbdc892db87d0fa1d9c898a6a51) | `` python311Packages.botocore-stubs: 1.34.61 -> 1.34.62 ``                          |
| [`fdcf51d1`](https://github.com/NixOS/nixpkgs/commit/fdcf51d12cc7957cbb0e9b696916109762f9ca3f) | `` python311Packages.gassist-text: 0.0.10 -> 0.0.11 ``                              |
| [`c159e72b`](https://github.com/NixOS/nixpkgs/commit/c159e72b1faa203324ab1ac371c8ebda8e4efdcb) | `` python311Packages.aioslimproto: 2.3.3 -> 3.0.1 ``                                |
| [`9e58aca5`](https://github.com/NixOS/nixpkgs/commit/9e58aca561e18f5197029926db8dbde1738a2ff5) | `` helix-gpt: 0.28 -> 0.31 ``                                                       |
| [`894e262d`](https://github.com/NixOS/nixpkgs/commit/894e262ddb52a37481165b87ea9847030c74ef3b) | `` exploitdb: 2024-03-11 -> 2024-03-13 ``                                           |
| [`1284aa6e`](https://github.com/NixOS/nixpkgs/commit/1284aa6ec67452de4e14d81cd0694ae89365cbc0) | `` checkov: 3.2.37 -> 3.2.38 ``                                                     |
| [`2b75931c`](https://github.com/NixOS/nixpkgs/commit/2b75931c561250975b8a46cc3b9efe3a8d5d35d2) | `` terraform: 1.7.4 -> 1.7.5 ``                                                     |
| [`aedc7e26`](https://github.com/NixOS/nixpkgs/commit/aedc7e268950ea82ac27e68b5c07dad57f7514ea) | `` python311Packages.hahomematic: 2024.3.0 -> 2024.3.1 ``                           |
| [`afe1beeb`](https://github.com/NixOS/nixpkgs/commit/afe1beebee26c394d5e7743c57d669fa829cd846) | `` python312Packages.ha-ffmpeg: refactor ``                                         |
| [`a70b27ad`](https://github.com/NixOS/nixpkgs/commit/a70b27ad4dd271241ea7316eab8033f60cd65591) | `` python311Packages.ha-ffmpeg: 3.1.0 -> 3.2.0 ``                                   |
| [`2fc732df`](https://github.com/NixOS/nixpkgs/commit/2fc732dfa05b874436b277e589ba46c12ec31231) | `` cnspec: 10.7.0 -> 10.7.1 ``                                                      |
| [`826978bd`](https://github.com/NixOS/nixpkgs/commit/826978bd97ff2ac31bd52c45f547421d7dd9a261) | `` python311Packages.axis: 53 -> 54 ``                                              |
| [`0d57783b`](https://github.com/NixOS/nixpkgs/commit/0d57783b424224f835583c14de5fe497cc23b8a0) | `` python311Packages.botocore-stubs: 1.34.61 -> 1.34.62 ``                          |
| [`26465212`](https://github.com/NixOS/nixpkgs/commit/2646521247d56a94fa16b4bdaa633945f04d8be8) | `` s3proxy: skip tests on Darwin ``                                                 |
| [`2ac4e778`](https://github.com/NixOS/nixpkgs/commit/2ac4e77894c86a0b5c693690792e51a8a1c4f64c) | `` gauge: 1.6.3 -> 1.6.4 ``                                                         |
| [`187a5731`](https://github.com/NixOS/nixpkgs/commit/187a57316da9dd5b5e2ab4a84b12b51f175e67ef) | `` changedetection-io: 0.45.14 -> 0.45.16 ``                                        |
| [`916a7118`](https://github.com/NixOS/nixpkgs/commit/916a71187a0048fcdc5aa0420ea37e02f147e017) | `` python311Packages.bluetooth-auto-recovery: refactor ``                           |
| [`40409d4a`](https://github.com/NixOS/nixpkgs/commit/40409d4ab25db7cf2bf28b97726d549e802c281a) | `` python311Packages.bluetooth-auto-recovery: 1.3.0 -> 1.4.0 ``                     |
| [`783df5be`](https://github.com/NixOS/nixpkgs/commit/783df5be3355804f4af12506faa487cb27ca88c0) | `` timeular: 6.7.3 -> 6.7.5 ``                                                      |
| [`f70437fd`](https://github.com/NixOS/nixpkgs/commit/f70437fd0166063b96798fc718e50da6a976c07c) | `` glooctl: 1.16.6 -> 1.16.7 ``                                                     |