### PR TITLE
chore(flake/darwin): `d9ea313b` -> `bcc8afd0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -220,11 +220,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710281379,
-        "narHash": "sha256-uFo9hxt982L3nFJeweW4Gip2esiGrIQlbvEGrNTh4AY=",
+        "lastModified": 1710717205,
+        "narHash": "sha256-Wf3gHh5uV6W1TV/A8X8QJf99a5ypDSugY4sNtdJDe0A=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "d9ea313bc4851670dc99c5cc979cb79750e7d670",
+        "rev": "bcc8afd06e237df060c85bad6af7128e05fd61a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                           |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
| [`576be431`](https://github.com/LnL7/nix-darwin/commit/576be4317c780b48f44b83bf45fa79d139eed026) | `` Remove override.css as done in https://github.com/NixOS/nixpkgs/pull/295847 `` |