### PR TITLE
chore(flake/nixos-hardware): `968952f9` -> `1e679b9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1710622004,
-        "narHash": "sha256-6zR642tXcZzzk3C8BHxlCrR0yh8z8zMXLiuXpWDIpX0=",
+        "lastModified": 1710783728,
+        "narHash": "sha256-eIsfu3c9JUBgm3cURSKTXLEI9Dlk1azo+MWKZVqrmkc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "968952f950a59dee9ed1e8799dda38c6dfa1bad3",
+        "rev": "1e679b9a9970780cd5d4dfe755a74a8f96d33388",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`1e679b9a`](https://github.com/NixOS/nixos-hardware/commit/1e679b9a9970780cd5d4dfe755a74a8f96d33388) | `` Update readme ``                                 |
| [`5bf55b85`](https://github.com/NixOS/nixos-hardware/commit/5bf55b853241737b047af62a90ed2e9cf41bb892) | `` Add msi-b350-tomahawk module to flake ``         |
| [`1568f005`](https://github.com/NixOS/nixos-hardware/commit/1568f005e12aee4bfe815750cac888ef6cb81a4d) | `` add support for MSI B350 TOMAHAWK Motherboard `` |