### PR TITLE
chore(flake/home-manager): `7b3fca5a` -> `baf76594`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,11 +390,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710714957,
-        "narHash": "sha256-eZCxuF58YWgaJMMRrn8oRkwRhxooe5kBS/s2wRVr9PA=",
+        "lastModified": 1710800522,
+        "narHash": "sha256-RPcufupTkBtZzeyfE4kQLTnK4MObDiZbs1Xyp/AKpY0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7b3fca5adcf6c709874a8f2e0c364fe9c58db989",
+        "rev": "6665da45dd03857a4ae600cf246435e6ae57407e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`baf76594`](https://github.com/nix-community/home-manager/commit/baf7659448ffa6ab6870dba1ca681a4868c3068a) | `` kime: remove documentation dependency on config `` |
| [`865bef34`](https://github.com/nix-community/home-manager/commit/865bef34355d7ad22141f44460ecf7f759f0ff77) | `` kime: fix configuration ``                         |