### PR TITLE
chore(flake/pre-commit-hooks): `5df5a70a` -> `844ae66b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -576,11 +576,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708018599,
-        "narHash": "sha256-M+Ng6+SePmA8g06CmUZWi1AjG2tFBX9WCXElBHEKnyM=",
+        "lastModified": 1710820290,
+        "narHash": "sha256-kzFqKNa9rOlYwZjhjQx5ZDufdlYBM0iYq26myQpy1E0=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "5df5a70ad7575f6601d91f0efec95dd9bc619431",
+        "rev": "844ae66b2d2c23f7e38031a575736db78a8b5579",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                           |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
| [`fc79a53e`](https://github.com/cachix/pre-commit-hooks.nix/commit/fc79a53eceac62d582fd0f4a098aae065106f619) | `` README: refresh ``                                             |
| [`b9fb64c3`](https://github.com/cachix/pre-commit-hooks.nix/commit/b9fb64c31a82d2b681a561db8c9e09c0a13ca594) | `` Update hook descriptions ``                                    |
| [`df4a2111`](https://github.com/cachix/pre-commit-hooks.nix/commit/df4a2111ffded723a6fe466b218d22d1ddca5d28) | `` Implement packageOverrides and add formatters to treefmt ``    |
| [`0b32cd7a`](https://github.com/cachix/pre-commit-hooks.nix/commit/0b32cd7a293c325be07f88a33568d50271521132) | `` Add packageInputs to allow overriding complex wrapper hooks `` |
| [`6b405259`](https://github.com/cachix/pre-commit-hooks.nix/commit/6b4052594b3428b20e8085d41c23555e11de807f) | `` Add a todo for treefmt ``                                      |
| [`bf780cc3`](https://github.com/cachix/pre-commit-hooks.nix/commit/bf780cc3809df61370c5c8ab42a6b8fa61704b40) | `` Migrate binPath to use the package option by default ``        |
| [`6b2bed05`](https://github.com/cachix/pre-commit-hooks.nix/commit/6b2bed05a2dd0844b3cc12a2d0adf41abf40633e) | `` Add assertions and warnings to the pre-commit module ``        |
| [`8af5964b`](https://github.com/cachix/pre-commit-hooks.nix/commit/8af5964b74f112edd6bdafaa07924842e1e27eec) | `` Add a description to each hook ``                              |
| [`87a38530`](https://github.com/cachix/pre-commit-hooks.nix/commit/87a3853010a80090362d9246e138ef0c445edf06) | `` Fix option remap ``                                            |
| [`22683d3f`](https://github.com/cachix/pre-commit-hooks.nix/commit/22683d3fc907e18cfd5a174d84cd131a16175e41) | `` Remove `package` from the raw options ``                       |
| [`db697eb3`](https://github.com/cachix/pre-commit-hooks.nix/commit/db697eb3025f16a4c8d24418203572b5d568b62d) | `` Migrate `settings.<name>.package` to `hooks.<name>.package` `` |
| [`d84404d0`](https://github.com/cachix/pre-commit-hooks.nix/commit/d84404d088b2051c952c43dcf3a7af6483f290cc) | `` Apply mkDefault to built-in hooks ``                           |
| [`f069ad80`](https://github.com/cachix/pre-commit-hooks.nix/commit/f069ad80f6d80ca8041abd9308fb517c8dd3752c) | `` Fix package typos ``                                           |
| [`72bc75c4`](https://github.com/cachix/pre-commit-hooks.nix/commit/72bc75c47a1fe4f765ca81af1c0d867f3c4fc77f) | `` Remove unused arg ``                                           |
| [`27f30f03`](https://github.com/cachix/pre-commit-hooks.nix/commit/27f30f03f58e21d4aa2efc08af5fae27697c5dee) | `` Add default packages ``                                        |
| [`de16d2f6`](https://github.com/cachix/pre-commit-hooks.nix/commit/de16d2f6c625a5aa18599e76af09ed2f539fb97f) | `` Add package to raw config ``                                   |
| [`4d53d13f`](https://github.com/cachix/pre-commit-hooks.nix/commit/4d53d13ff581737b42491ebc2f9205243d1910cb) | `` Move hook-specific settings under hooks.<name>.settings ``     |
| [`bc05acff`](https://github.com/cachix/pre-commit-hooks.nix/commit/bc05acff3c120531130e1e0a9b0c4c9dac254f88) | `` Make run command backwards-compatible ``                       |
| [`22d19cf1`](https://github.com/cachix/pre-commit-hooks.nix/commit/22d19cf1d647bde40ad67f0bea9baf7f5db4f51d) | `` Rename options ``                                              |
| [`3833dfde`](https://github.com/cachix/pre-commit-hooks.nix/commit/3833dfde314828046f89b76255bdb53bdc394045) | `` Try passing default_stages again ``                            |
| [`3d416f0d`](https://github.com/cachix/pre-commit-hooks.nix/commit/3d416f0ddc32462a217203ba64496b206d556984) | `` Pass down default_states to each hook ``                       |
| [`ce684eb2`](https://github.com/cachix/pre-commit-hooks.nix/commit/ce684eb2e56f411e089e0d45b84947846dc15174) | `` Fix ``                                                         |
| [`2545f40f`](https://github.com/cachix/pre-commit-hooks.nix/commit/2545f40fa5f08e5acc43e90e9f7f1a0b77eb8601) | `` Set raw ``                                                     |
| [`94283df0`](https://github.com/cachix/pre-commit-hooks.nix/commit/94283df0a7d5c49c30d7c3534968221f46bd6c8e) | `` Add placeholder descriptions ``                                |
| [`4f427b47`](https://github.com/cachix/pre-commit-hooks.nix/commit/4f427b47fb35f15899139b7845a1eed21a1f7880) | `` Annotate and fix errors ``                                     |
| [`15330bec`](https://github.com/cachix/pre-commit-hooks.nix/commit/15330bec112feb157a25091a5a88b788c477dad0) | `` Implement new module design ``                                 |