### PR TITLE
chore(flake/pre-commit-hooks): `844ae66b` -> `afe89ba2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -353,11 +353,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703887061,
-        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {
@@ -547,11 +547,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1704874635,
-        "narHash": "sha256-YWuCrtsty5vVZvu+7BchAxmcYzTMfolSPP5io8+WYCg=",
+        "lastModified": 1710695816,
+        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3dc440faeee9e889fe2d1b4d25ad0f430d449356",
+        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
         "type": "github"
       },
       "original": {
@@ -576,11 +576,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710820290,
-        "narHash": "sha256-kzFqKNa9rOlYwZjhjQx5ZDufdlYBM0iYq26myQpy1E0=",
+        "lastModified": 1710830185,
+        "narHash": "sha256-s34SWPaBnFdkn67+itBFVeXKhJTBlqRwx3jZiZCugUA=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "844ae66b2d2c23f7e38031a575736db78a8b5579",
+        "rev": "afe89ba28fae60eb8450b83ca2c93851044fb365",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                          |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------- |
| [`99c274e8`](https://github.com/cachix/pre-commit-hooks.nix/commit/99c274e8e29df2618a95a3a241eb08835494e70e) | `` fix eval ``                   |
| [`db909b7f`](https://github.com/cachix/pre-commit-hooks.nix/commit/db909b7fb34ceb79e480cad059326fb43240f74b) | `` README: use the new module `` |
| [`f6d4ab20`](https://github.com/cachix/pre-commit-hooks.nix/commit/f6d4ab20505775b6cb1413e365d5eaf369f5e1c1) | `` bump deps ``                  |