### PR TITLE
chore(flake/pre-commit-hooks): `afe89ba2` -> `e8dc1b4f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -576,11 +576,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710830185,
-        "narHash": "sha256-s34SWPaBnFdkn67+itBFVeXKhJTBlqRwx3jZiZCugUA=",
+        "lastModified": 1710843117,
+        "narHash": "sha256-b6iKQeHegzpc697rxTPA3bpwGN3m50eLCgdQOmceFuE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "afe89ba28fae60eb8450b83ca2c93851044fb365",
+        "rev": "e8dc1b4fe80c6fcededde7700e6a23bcdf7f3347",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message            |
| ------------------------------------------------------------------------------------------------------------ | ------------------ |
| [`d0589a99`](https://github.com/cachix/pre-commit-hooks.nix/commit/d0589a997c1481c0d4bd31242196054fe18c61f4) | `` fix typstfmt `` |