### PR TITLE
chore(flake/pre-commit-hooks): `c75cea79` -> `61846354`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -576,11 +576,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710897503,
-        "narHash": "sha256-3tgm+kofe6YWIkkFn9DAcyPblWD6HQyw5rdd5EEAZZU=",
+        "lastModified": 1710903454,
+        "narHash": "sha256-PpkuGiqhkR6BlvDCPzUEqJk2kbxsyfcUJHBh7+diPQM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "c75cea79141996c7da9e31187c238ad04de5e88f",
+        "rev": "61846354dc7e593dc4d74700ec51d0613e11b183",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                           |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------- |
| [`8fc4dd7c`](https://github.com/cachix/pre-commit-hooks.nix/commit/8fc4dd7c1f12aeda9b1d001f18e243de563b357c) | `` feat: introduce black flags `` |