### PR TITLE
chore(flake/pre-commit-hooks): `61846354` -> `543d006f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -576,11 +576,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710903454,
-        "narHash": "sha256-PpkuGiqhkR6BlvDCPzUEqJk2kbxsyfcUJHBh7+diPQM=",
+        "lastModified": 1710921752,
+        "narHash": "sha256-AHg+j4GwFdiOwGOwXbhKjwUU8jF7g23llT3N9ZOlsrg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "61846354dc7e593dc4d74700ec51d0613e11b183",
+        "rev": "543d006fef3a86e0887d2f2a213bffa7afbf19d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
| [`543d006f`](https://github.com/cachix/pre-commit-hooks.nix/commit/543d006fef3a86e0887d2f2a213bffa7afbf19d1) | `` fix option ``                                                       |
| [`cf361f56`](https://github.com/cachix/pre-commit-hooks.nix/commit/cf361f562612258d5f6272b0c567aaf2b5ff93df) | `` fix #356: provide a way to access all packages for enabled hooks `` |