### PR TITLE
chore(flake/pre-commit-hooks): `543d006f` -> `e611897d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -576,11 +576,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710921752,
-        "narHash": "sha256-AHg+j4GwFdiOwGOwXbhKjwUU8jF7g23llT3N9ZOlsrg=",
+        "lastModified": 1710923068,
+        "narHash": "sha256-6hOpUiuxuwpXXc/xfJsBUJeqqgGI+JMJuLo45aG3cKc=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "543d006fef3a86e0887d2f2a213bffa7afbf19d1",
+        "rev": "e611897ddfdde3ed3eaac4758635d7177ff78673",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                      |
| ------------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
| [`e611897d`](https://github.com/cachix/pre-commit-hooks.nix/commit/e611897ddfdde3ed3eaac4758635d7177ff78673) | `` fix flakes example for enabledPackages `` |