### PR TITLE
chore(flake/nixpkgs): `20f77aa0` -> `44d0940e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711001935,
-        "narHash": "sha256-URtGpHue7HHZK0mrHnSf8wJ6OmMKYSsoLmJybrOLFSQ=",
+        "lastModified": 1711163522,
+        "narHash": "sha256-YN/Ciidm+A0fmJPWlHBGvVkcarYWSC+s3NTPk/P+q3c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "20f77aa09916374aa3141cbc605c955626762c9a",
+        "rev": "44d0940ea560dee511026a53f0e2e2cde489b4d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`c31ec3d3`](https://github.com/NixOS/nixpkgs/commit/c31ec3d37737edce51790a2e5eac724599c1784b) | `` home-assistant: 2024.3.2 -> 2024.3.3 ``                                  |
| [`70c02166`](https://github.com/NixOS/nixpkgs/commit/70c02166cb56bd3039836396d9c8ac0ef2d1aedd) | `` python312Packages.axis: 57 -> 58 ``                                      |
| [`de382c9e`](https://github.com/NixOS/nixpkgs/commit/de382c9eb6531132eb0ee0f6b477623a8b0bdb14) | `` jackett: 0.21.2090 -> 0.21.2134 ``                                       |
| [`adc3a70b`](https://github.com/NixOS/nixpkgs/commit/adc3a70bccbd46e69cd99fc3249eff9acf18fc79) | `` easyeffects: 7.1.4 -> 7.1.5 ``                                           |
| [`816be61f`](https://github.com/NixOS/nixpkgs/commit/816be61fd4925184c1efa4fcdb23ca517188fb0b) | `` grafana-loki: 2.9.5 -> 2.9.6 ``                                          |
| [`6bae4bca`](https://github.com/NixOS/nixpkgs/commit/6bae4bcaf4e705d476cbac2a7386c087e5c4333b) | `` apt: 2.7.13 -> 2.7.14 ``                                                 |
| [`5cee8252`](https://github.com/NixOS/nixpkgs/commit/5cee82525bd7c8d1f6d3e7dd680c432881d4033a) | `` home-assistant: 2024.3.1 -> 2024.3.2 ``                                  |
| [`0814d0f0`](https://github.com/NixOS/nixpkgs/commit/0814d0f02e44f202ae0a42c62fa6324241415b69) | `` firefox-devedition-unwrapped: 124.0b9 -> 125.0b3 ``                      |
| [`40ac4de3`](https://github.com/NixOS/nixpkgs/commit/40ac4de3992fd88dfbffc08faddbe16e5ba0e007) | `` firefox-beta-unwrapped: 124.0b9 -> 125.0b3 ``                            |
| [`c9ee77b7`](https://github.com/NixOS/nixpkgs/commit/c9ee77b7762d288891c61cd99c6c25be62522f8b) | `` firefox-devedition-bin-unwrapped: 124.0b9 -> 125.0b3 ``                  |
| [`8d541806`](https://github.com/NixOS/nixpkgs/commit/8d541806d3a42132788334d6ec0189833454d2cb) | `` firefox-beta-bin-unwrapped: 124.0b9 -> 125.0b3 ``                        |
| [`1c46b74d`](https://github.com/NixOS/nixpkgs/commit/1c46b74dbca1f7b8cd836ebf00d31813820b1f6d) | `` hubble: 0.13.0 -> 0.13.2 ``                                              |
| [`f6b397ee`](https://github.com/NixOS/nixpkgs/commit/f6b397eed0767da4c99441853573dbf2a5f2ff8f) | `` doc: improve javascript conventions (#298127) ``                         |
| [`5daf927d`](https://github.com/NixOS/nixpkgs/commit/5daf927d227bd367564c897dff5ba5f602542a58) | `` squeezelite: 2.0.0.1468 -> 2.0.0.1473 ``                                 |
| [`a0a3a2af`](https://github.com/NixOS/nixpkgs/commit/a0a3a2af6b582b10a5e8e8199027fa7b0de9a4c1) | `` python311Packages.lmcloud: 1.1.1 -> 1.1.4 ``                             |
| [`13a4b8a4`](https://github.com/NixOS/nixpkgs/commit/13a4b8a463a15073aa54958788d0a8980b4d2ae6) | `` tippecanoe: 2.51.0 -> 2.52.0 ``                                          |
| [`795b959a`](https://github.com/NixOS/nixpkgs/commit/795b959a73801a728b99804e6eccdaa98a78e7a7) | `` temporal: 1.22.6 -> 1.23.0 ``                                            |
| [`a6bf0010`](https://github.com/NixOS/nixpkgs/commit/a6bf0010828eea267467d34246ffed052aa8e606) | `` python312Packages.hass-nabucasa: 0.78.0-unstable-2024-03-09 -> 0.79.0 `` |
| [`a3f54c2f`](https://github.com/NixOS/nixpkgs/commit/a3f54c2fcbee9e58570afd985a640217864d47ab) | `` python312Packages.aiodhcpwatcher: 0.8.1 -> 0.8.2 ``                      |
| [`d3db4d5d`](https://github.com/NixOS/nixpkgs/commit/d3db4d5df925deff8d4471770375ca0978deeaca) | `` prometheus-statsd-exporter: 0.26.0 -> 0.26.1 ``                          |
| [`5f3ff347`](https://github.com/NixOS/nixpkgs/commit/5f3ff347374e70728fbbb654227006ef486f0ee4) | `` prometheus-graphite-exporter: 0.15.0 -> 0.15.1 ``                        |
| [`41a0ab01`](https://github.com/NixOS/nixpkgs/commit/41a0ab011bc11a44f3136352c6b3e308e9b54e40) | `` gtree: 1.10.9 -> 1.10.10 ``                                              |
| [`9dd6bbfe`](https://github.com/NixOS/nixpkgs/commit/9dd6bbfe3f59b3a8bc40eff8d7ce0514ab3e790a) | `` hyprland-per-window-layout: 2.8.1 -> 2.9 ``                              |
| [`686126fe`](https://github.com/NixOS/nixpkgs/commit/686126fe9505a24935896d5b1064aae633638bed) | `` gitu: 0.7.2 -> 0.8.0 ``                                                  |
| [`ee181285`](https://github.com/NixOS/nixpkgs/commit/ee181285b1ed88c52d08fbecd36b913987526fd8) | `` vscode-extensions.jackmacwindows.craftos-pc: init at 1.2.2 ``            |
| [`6588a7e9`](https://github.com/NixOS/nixpkgs/commit/6588a7e950018d2355ce6c434b71d69edb7e53ef) | `` retool: unstable-2023-08-24 -> 2.02.2-unstable-2024-03-17 ``             |
| [`a12c8acd`](https://github.com/NixOS/nixpkgs/commit/a12c8acd8832be9a6b5a8e08c0175ec03723e0ac) | `` k9s: 0.32.3 -> 0.32.4 ``                                                 |
| [`cc614f97`](https://github.com/NixOS/nixpkgs/commit/cc614f97f038126bef43bdce188b58b3891675d2) | `` retool: move to pkgs/by-name ``                                          |
| [`858cc100`](https://github.com/NixOS/nixpkgs/commit/858cc1007b76e788dd68ba5f2fc69e19a17b4e16) | `` python311Packages.transformers: 4.39.0 -> 4.39.1 ``                      |
| [`a142f963`](https://github.com/NixOS/nixpkgs/commit/a142f9639132f50427f794c37e1810b3a0d0bcbf) | `` python311Packages.sshfs: refactor ``                                     |
| [`b1504df9`](https://github.com/NixOS/nixpkgs/commit/b1504df924f35aecb9efdbe811225f0e3503ff91) | `` python312Packages.scikit-hep-testdata: 0.4.40 -> 0.4.42 ``               |
| [`07ec1211`](https://github.com/NixOS/nixpkgs/commit/07ec121197ebf25a548b9e4db351fbd9f12c7ea1) | `` python312Packages.energyflow: 1.3.2 -> 1.3.3 ``                          |
| [`0d8ec7b2`](https://github.com/NixOS/nixpkgs/commit/0d8ec7b2262040251a155e85a5bcc0f4e9be5663) | `` eksctl: 0.174.0 -> 0.175.0 ``                                            |
| [`53877d4e`](https://github.com/NixOS/nixpkgs/commit/53877d4eae37ec51cf92cb0a2b434e92c30b25d3) | `` qgis-ltr: 3.34.4 -> 3.34.5 ``                                            |
| [`dc4cf2cc`](https://github.com/NixOS/nixpkgs/commit/dc4cf2ccc2055374bb9f78e9e38f1fea070d76b8) | `` firefox-esr-115-unwrapped: 115.9.0esr -> 115.9.1esr ``                   |
| [`fb3176d6`](https://github.com/NixOS/nixpkgs/commit/fb3176d66d94c51d8a6fbe541ead8b6cd262b265) | `` firefox-bin-unwrapped: 124.0 -> 124.0.1 ``                               |
| [`64f34481`](https://github.com/NixOS/nixpkgs/commit/64f344810f904b37e746d1e9fce227c0db17a057) | `` firefox-unwrapped: 124.0 -> 124.0.1 ``                                   |
| [`446f424c`](https://github.com/NixOS/nixpkgs/commit/446f424c0eb6463ffe99496eddfba7f7896ce1b8) | `` qgis: 3.36.0 -> 3.36.1 ``                                                |
| [`b2c76327`](https://github.com/NixOS/nixpkgs/commit/b2c7632745fe6433853a47f09ebbc57924cc0b3b) | `` tigerbeetle: 0.14.184 -> 0.15.3 (#297607) ``                             |
| [`c8f168d6`](https://github.com/NixOS/nixpkgs/commit/c8f168d66be374aa9de0503ab4dfb4e9703242ec) | `` python311Packages.tencentcloud-sdk-python: 3.0.1113 -> 3.0.1114 ``       |
| [`15efaa32`](https://github.com/NixOS/nixpkgs/commit/15efaa329da624c9ea3cd9c1855e3f4f6b2d421f) | `` python311Packages.tencentcloud-sdk-python: 3.0.1112 -> 3.0.1113 ``       |
| [`322e21e4`](https://github.com/NixOS/nixpkgs/commit/322e21e415d848cb78e3e594bd9d2f2bcbae1fa4) | `` python311Packages.scmrepo: 3.3.0 -> 3.3.1 ``                             |
| [`860e0080`](https://github.com/NixOS/nixpkgs/commit/860e008080a4a2c9694bcf9fb39419843ce4889e) | `` python312Packages.syncedlyrics: refactor ``                              |
| [`793062ab`](https://github.com/NixOS/nixpkgs/commit/793062ab1a46b0eab165a653e6b41d76f3ec7b9d) | `` python312Packages.yolink-api: refactor ``                                |
| [`7fcb6aca`](https://github.com/NixOS/nixpkgs/commit/7fcb6aca442c08ac52122c65846f865860b6d5f7) | `` python311Packages.dvclive: refactor ``                                   |
| [`7b51ebfa`](https://github.com/NixOS/nixpkgs/commit/7b51ebfa573806fa8d88fdfb23df82867f23d7a3) | `` python311Packages.dvclive: 3.44.0 -> 3.45.0 ``                           |
| [`9620f224`](https://github.com/NixOS/nixpkgs/commit/9620f224e87eb278e90f23f30065439df844b8b4) | `` python312Packages.yolink-api: 0.3.9 -> 0.4.1 ``                          |
| [`7df2cb20`](https://github.com/NixOS/nixpkgs/commit/7df2cb2083baa42758a7a1460b1be6d80ee41252) | `` python312Packages.syncedlyrics: 0.8.0 -> 0.9.0 ``                        |
| [`e4efaa11`](https://github.com/NixOS/nixpkgs/commit/e4efaa113b73a4d6484255b923f2ea2db6a79477) | `` python311Packages.aiopvapi: refactor ``                                  |
| [`da8f2444`](https://github.com/NixOS/nixpkgs/commit/da8f2444bb33d703e292f9a7f562b8fcaf1ecad3) | `` python311Packages.aiopvapi: 3.0.2 -> 3.1.0 ``                            |
| [`3fdcd887`](https://github.com/NixOS/nixpkgs/commit/3fdcd887ca6d15e1e8239e02a7f7bfc935482a18) | `` python312Packages.python-docs-theme: 2024.2 -> 2024.3 ``                 |
| [`1ab219bc`](https://github.com/NixOS/nixpkgs/commit/1ab219bc59bfd10a6afde08a818f4e3923f211dc) | `` python312Packages.argilla: 1.25.0 -> 1.26.0 ``                           |
| [`6ed8eda8`](https://github.com/NixOS/nixpkgs/commit/6ed8eda876c7212e940c9b682b38d4de4b5e9eef) | `` waypipe: 0.8.6 -> 0.9.0 ``                                               |
| [`74046952`](https://github.com/NixOS/nixpkgs/commit/740469524fbd89c7b9d6309ce190acb10e8da8de) | `` prometheus-php-fpm-exporter: fix non-spec compliant base64 hash ``       |
| [`46d7754b`](https://github.com/NixOS/nixpkgs/commit/46d7754bdbb23add9f6ef39378ead567da7ddb1d) | `` nss-mdns: Repository moved to the Avahi organisation ``                  |
| [`3b47da67`](https://github.com/NixOS/nixpkgs/commit/3b47da676562d6487ad28d957bcbad7bdccc8f5c) | `` nssmdns: Fix configuration location ``                                   |
| [`956cf5f6`](https://github.com/NixOS/nixpkgs/commit/956cf5f6124c0ee518562b547d92e7b498a87a9c) | `` python3Packages.leather: fix build ``                                    |
| [`8cd44165`](https://github.com/NixOS/nixpkgs/commit/8cd4416530394027b4199cfcb182fd6c70c27222) | `` perl536Packages.BerkeleyDB: use spec compliant base64 hash ``            |
| [`198d32f5`](https://github.com/NixOS/nixpkgs/commit/198d32f50b7c3740bec72c43dcf4f17f48dd5d14) | `` python3Packages.dbf: fix build ``                                        |
| [`3861b2a6`](https://github.com/NixOS/nixpkgs/commit/3861b2a6a34cdf8d11b623a715647ebddb503453) | `` lan-mouse: 0.6.0 -> 0.7.3 ``                                             |
| [`3a0e4294`](https://github.com/NixOS/nixpkgs/commit/3a0e429492fc33612f318a7bc2841bbc5ab2f7a9) | `` k8sgpt: 0.3.28 -> 0.3.29 ``                                              |
| [`9f62a4b1`](https://github.com/NixOS/nixpkgs/commit/9f62a4b1867941d8920d5f96182052c56e9f656b) | `` kodiPackages.youtube: 7.0.3.2 -> 7.0.4 ``                                |
| [`506939e9`](https://github.com/NixOS/nixpkgs/commit/506939e98cfec9315eb1c41a14943e20a72013c6) | `` payme: fix version number string (#297480) ``                            |
| [`f0e601a4`](https://github.com/NixOS/nixpkgs/commit/f0e601a4354e3371e5a2a16b4e9703aa6289b83f) | `` hugo: fix invalid vendorHash ``                                          |
| [`0bbf8e0e`](https://github.com/NixOS/nixpkgs/commit/0bbf8e0e9af7e595de2bd151f90bb4c006d281bc) | `` tenv: init at 1.2.0 ``                                                   |
| [`2b43d370`](https://github.com/NixOS/nixpkgs/commit/2b43d370b43d70da2d2ad2411f672b90dffdd887) | `` rye: 0.30.0 -> 0.31.0 ``                                                 |
| [`b65eea32`](https://github.com/NixOS/nixpkgs/commit/b65eea32a42e3d69dca9be2a2067b09b4a5ba6b7) | `` josm: 18969 -> 19017 ``                                                  |
| [`f5276917`](https://github.com/NixOS/nixpkgs/commit/f5276917c32a999a4d9d233d96dbc7d6c9cef9e2) | `` gitea: 1.21.8 -> 1.21.9 ``                                               |
| [`58f2ef77`](https://github.com/NixOS/nixpkgs/commit/58f2ef77175e17ca7e719044b5da084f3c245c94) | `` electron-bin: remove unused insecure versions ``                         |
| [`1bba8f62`](https://github.com/NixOS/nixpkgs/commit/1bba8f621ed994b5f7692d3927c3f52165bd423e) | `` python312Packages.albumentations: 1.4.1 -> 1.4.2 ``                      |
| [`fc7c9ffc`](https://github.com/NixOS/nixpkgs/commit/fc7c9ffcfa6d251bcd60c6b1f035cf8525b0ce0e) | `` python312Packages.axis: refactor ``                                      |
| [`128d516d`](https://github.com/NixOS/nixpkgs/commit/128d516d8e18db966536cdaaf62efee1d0547c24) | `` python312Packages.axis: 56 -> 57 ``                                      |
| [`00ecfd96`](https://github.com/NixOS/nixpkgs/commit/00ecfd9645918317084dfe2a895aba0247cf49b0) | `` tflint-plugins.tflint-ruleset-aws: 0.29.0 -> 0.30.0 ``                   |
| [`e3c8b84d`](https://github.com/NixOS/nixpkgs/commit/e3c8b84dae05192c45417ae92e38ebab02591053) | `` maintainers/scripts/bootstrap-files: fix nar extract on linux ``         |
| [`1ca59ad8`](https://github.com/NixOS/nixpkgs/commit/1ca59ad82f3c28b13dbb9f4e4626effebcecf081) | `` ls-lint: 2.2.2 -> 2.2.3 ``                                               |
| [`6e9e80e0`](https://github.com/NixOS/nixpkgs/commit/6e9e80e013ec47b787e9eb8529a901f9d43c28a9) | `` python312Packages.lmcloud: refactor ``                                   |
| [`a69158ae`](https://github.com/NixOS/nixpkgs/commit/a69158ae87608154f38b0611e5abc7ba9a169e72) | `` python312Packages.githubkit: refactor ``                                 |
| [`1756576c`](https://github.com/NixOS/nixpkgs/commit/1756576c4a113275b0d54a829fab7ba2ce338f22) | `` maintainers/scripts/bootstrap-files: update darwin information ``        |
| [`92a422a3`](https://github.com/NixOS/nixpkgs/commit/92a422a3957a89d048563b238bc10de4c19866c4) | `` gymnasium: disable doCheck on Darwin ``                                  |
| [`b779674d`](https://github.com/NixOS/nixpkgs/commit/b779674da5ed80059a884e04a583c8231432e3f1) | `` python312Packages.githubkit: 0.11.2 -> 0.11.3 ``                         |
| [`a24069b2`](https://github.com/NixOS/nixpkgs/commit/a24069b2fe9160a8d796e73d79d4acebee933d1f) | `` files-cli: 2.12.43 -> 2.12.44 ``                                         |
| [`62279fba`](https://github.com/NixOS/nixpkgs/commit/62279fba323eed98efa6177cddf8798a97a9c425) | `` devenv: add `meta` attributes ``                                         |
| [`31752f3b`](https://github.com/NixOS/nixpkgs/commit/31752f3b95c0ce8b7fe65bd95c4f9a280a59fa8d) | `` metasploit: 6.3.60 -> 6.4.0 ``                                           |
| [`caa71651`](https://github.com/NixOS/nixpkgs/commit/caa71651fa09250f78d333b57689d95070c0dc91) | `` python312Packages.aws-lambda-builders: disable failing tests ``          |
| [`45b4bcba`](https://github.com/NixOS/nixpkgs/commit/45b4bcbac36d811b3ec68188b26843df41c7da5a) | `` python312Packages.aws-lambda-builders: refactor ``                       |
| [`ab03bde7`](https://github.com/NixOS/nixpkgs/commit/ab03bde77feb35afff0b86ade9fbda538e44ea90) | `` python312Packages.lmcloud: 1.0.0 -> 1.1.1 ``                             |
| [`93dc788c`](https://github.com/NixOS/nixpkgs/commit/93dc788c28e6ca3fa6c926c0e19a0014cb9daa78) | `` aws-sam-cli: refactor ``                                                 |
| [`8a879f37`](https://github.com/NixOS/nixpkgs/commit/8a879f3759d9fd91021542cfcecae98ebc1c005c) | `` python312Packages.pytedee-async: refactor ``                             |
| [`c1978a1d`](https://github.com/NixOS/nixpkgs/commit/c1978a1d476e19b33a309e04c61e80e092c9983e) | `` python311Packages.google-generativeai: refactor ``                       |
| [`205ccf7d`](https://github.com/NixOS/nixpkgs/commit/205ccf7d9a6c13c76253e6076dbc5df8571131f7) | `` python311Packages.oauthenticator: refactor ``                            |
| [`4e7756b1`](https://github.com/NixOS/nixpkgs/commit/4e7756b157695430367979edc9d816a2ad27decb) | `` python312Packages.google-cloud-pubsub: refactor ``                       |
| [`c438574c`](https://github.com/NixOS/nixpkgs/commit/c438574c2d73b6dc7af8dcd5d92d794e3acfd6fd) | `` python312Packages.pyenphase: refactor ``                                 |