### PR TITLE
chore(flake/nix-index-database): `d7b713a5` -> `34519f3b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -483,11 +483,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711249049,
-        "narHash": "sha256-g2cBcu5bUIGhUZK8OGKcSwuhxH6Vgx0eShfC1UlGWjc=",
+        "lastModified": 1711249705,
+        "narHash": "sha256-h/NQECj6mIzF4XR6AQoSpkCnwqAM+ol4+qOdYi2ykmQ=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "d7b713a5fed6f7c8d21de9c510ccd782cb36cd74",
+        "rev": "34519f3bb678a5abbddf7b200ac5347263ee781b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`34519f3b`](https://github.com/nix-community/nix-index-database/commit/34519f3bb678a5abbddf7b200ac5347263ee781b) | `` update packages.nix to release 2024-03-24-030726 `` |