### PR TITLE
chore(flake/home-manager): `1c2c5e4c` -> `179f6aca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,11 +390,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711133180,
-        "narHash": "sha256-WJOahf+6115+GMl3wUfURu8fszuNeJLv9qAWFQl3Vmo=",
+        "lastModified": 1711554349,
+        "narHash": "sha256-RypwcWEIFePBI0Hubfj4chanbM/G2yzJzC6wgz+dmS4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1c2c5e4cabba4c43504ef0f8cc3f3dfa284e2dbb",
+        "rev": "179f6acaf7c068c7870542cdae72afec9427a5b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`179f6aca`](https://github.com/nix-community/home-manager/commit/179f6acaf7c068c7870542cdae72afec9427a5b0) | `` antidote: Use builtins.storeDir (#5182) `` |
| [`eb869521`](https://github.com/nix-community/home-manager/commit/eb869521cb6c895b6d351be0b9e010c578de0e4b) | `` darkman: allow no configuration ``         |