### PR TITLE
chore(flake/nixpkgs): `57e6b3a9` -> `2726f127`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711333969,
-        "narHash": "sha256-5PiWGn10DQjMZee5NXzeA6ccsv60iLu+Xtw+mfvkUAs=",
+        "lastModified": 1711523803,
+        "narHash": "sha256-UKcYiHWHQynzj6CN/vTcix4yd1eCu1uFdsuarupdCQQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "57e6b3a9e4ebec5aa121188301f04a6b8c354c9b",
+        "rev": "2726f127c15a4cc9810843b96cad73c7eb39e443",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                             |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [`7623f585`](https://github.com/NixOS/nixpkgs/commit/7623f5857661c9a779950a33389f3a71b249e5d1) | `` qt6.full: Fix qt6 quick projects by also linking missing metatypes jsons ``                      |
| [`378c25fb`](https://github.com/NixOS/nixpkgs/commit/378c25fbb7b7b99e489d4d0d8be10c15ced23c4e) | `` alt-ergo: 2.5.2 → 2.5.3 ``                                                                       |
| [`6593c00c`](https://github.com/NixOS/nixpkgs/commit/6593c00cee7145f1b190c64b074d34840da33756) | `` ocamlPackages.irmin: 3.5.1 → 3.7.2 ``                                                            |
| [`2fc5edd2`](https://github.com/NixOS/nixpkgs/commit/2fc5edd27bc9cf9655e11581eb95a4ec3a94f5a7) | `` cf-vault: add version string ``                                                                  |
| [`1824b0d6`](https://github.com/NixOS/nixpkgs/commit/1824b0d65d53f64e5d2676934c03d8c55d3417c3) | `` impl: 1.2.0 -> 1.3.0 ``                                                                          |
| [`1b4adc17`](https://github.com/NixOS/nixpkgs/commit/1b4adc17732fdbf398b709284cf165599b7c6737) | `` python311Packages.uproot: 5.3.1 -> 5.3.2 (#299315) ``                                            |
| [`4bf5c28a`](https://github.com/NixOS/nixpkgs/commit/4bf5c28ad1db23753cd8ab4cc61adb683b70aab5) | `` flow: 0.231.0 -> 0.232.0 ``                                                                      |
| [`be8502a9`](https://github.com/NixOS/nixpkgs/commit/be8502a95cb1f806d63690f0512b76fbec82b483) | `` ssh-tpm-agent: init at 0.3.1 ``                                                                  |
| [`319c6583`](https://github.com/NixOS/nixpkgs/commit/319c6583f5045f37b9865098da31fa7e96b9889e) | `` dust: 0.9.0 -> 1.0.0 ``                                                                          |
| [`73da35e3`](https://github.com/NixOS/nixpkgs/commit/73da35e3505f9b41aac7dbd8d0074eec4799a45e) | `` smuxi: init at unstable-2023-07-01 ``                                                            |
| [`153f55b9`](https://github.com/NixOS/nixpkgs/commit/153f55b947e4649e3c56a540a943703f61db79dd) | `` gtk-sharp-2_0: enable darwin ``                                                                  |
| [`1f6ff1de`](https://github.com/NixOS/nixpkgs/commit/1f6ff1de06d49a7981420c272ab60f68cd3ca2bf) | `` maintainers: add meebey ``                                                                       |
| [`e9200ffe`](https://github.com/NixOS/nixpkgs/commit/e9200ffef24c072e89036fa55bf2a305354d4cbb) | `` nvimpager: unbreak on darwin (#299252) ``                                                        |
| [`a20dc76e`](https://github.com/NixOS/nixpkgs/commit/a20dc76e95303314cef7b1af33a198594ebf3396) | `` vimPlugins.jupytext-nvim: init at 2024-01-24 ``                                                  |
| [`59daf9b0`](https://github.com/NixOS/nixpkgs/commit/59daf9b0b6a8c577cad7c0679380dda63485f1ad) | `` gnuradioPackages.osmosdr: fix source URL ``                                                      |
| [`3c31ed9f`](https://github.com/NixOS/nixpkgs/commit/3c31ed9feb40fc29b4c552f6f961188fbe393124) | `` ethercat: init at 1.6-alpha ``                                                                   |
| [`3b8cd8ad`](https://github.com/NixOS/nixpkgs/commit/3b8cd8ad708f72f237daf05b42a956184bf2996d) | `` installer/nixos-generate-config: correctly detect bcache ``                                      |
| [`a7a57b64`](https://github.com/NixOS/nixpkgs/commit/a7a57b640a8df418e41b183138b5dadae5ede919) | `` chromium: 123.0.6312.58 -> 123.0.6312.86 ``                                                      |
| [`802746d4`](https://github.com/NixOS/nixpkgs/commit/802746d46be6ce8ad1a8547bcbbbcb8b31ee3b79) | `` chromedriver: 123.0.6312.58 -> 123.0.6312.86 ``                                                  |
| [`eac815ac`](https://github.com/NixOS/nixpkgs/commit/eac815acde7e13076fb1f45e0ef2bf888e5d34bd) | `` Revert "python3Packages.rpyc4: 4.1.5 -> 6.0.0" ``                                                |
| [`21cdff52`](https://github.com/NixOS/nixpkgs/commit/21cdff528339ee4129994c5cf255cb6a556c588e) | `` steampipe: disable telemetry and update check by default ``                                      |
| [`e13c74e0`](https://github.com/NixOS/nixpkgs/commit/e13c74e0faa5fe960fd6fab85ac37884ed307012) | `` steampipe: fix meta.description ``                                                               |
| [`4be9ffcb`](https://github.com/NixOS/nixpkgs/commit/4be9ffcb2158792340ebeb50ab5dec0f8f88e62a) | `` steampipe: remove `with lib;`, use `--replace-fail` for substitutions ``                         |
| [`9cb5bf51`](https://github.com/NixOS/nixpkgs/commit/9cb5bf51e61b97b953ad515f7264e778282362c2) | `` steampipe: add anthonyroussel to maintainers ``                                                  |
| [`26f55980`](https://github.com/NixOS/nixpkgs/commit/26f559805907a466a5a23c15ec3ae6d06fcf585e) | `` steampipe: enable and skip some tests on darwin ``                                               |
| [`45af6b98`](https://github.com/NixOS/nixpkgs/commit/45af6b985fdc343b71b542fd20276c7f61ffd47c) | `` release-notes: document breaking changes for pipewire and wireplumber ``                         |
| [`eddbb793`](https://github.com/NixOS/nixpkgs/commit/eddbb7932f2c7aef24628d56ab538b9f52bdc227) | `` nixos/wireplumber: reuse local binding to simplify ``                                            |
| [`ff77d833`](https://github.com/NixOS/nixpkgs/commit/ff77d83327c280931d42562a18d3d4639d1d400b) | `` nixos/wireplumber: provide example for `services.pipewire.wireplumber.configPackages` ``         |
| [`f5b680b9`](https://github.com/NixOS/nixpkgs/commit/f5b680b97cb89f4db4151d6b2f5ab4675de3c4b8) | `` nixos/wireplumber: update `services.pipewire.wireplumber.configPackages` description for v0.5 `` |
| [`3aa01f7f`](https://github.com/NixOS/nixpkgs/commit/3aa01f7f13bd8b66e72779bd938f4d3951abf605) | `` nixos/wireplumber: inherit `lib` functions ``                                                    |
| [`d2843640`](https://github.com/NixOS/nixpkgs/commit/d2843640cb8024dd761825e04bc0aae2ac822edf) | `` nixos/wireplumber: remove `lib.mdDoc` (no-op) ``                                                 |
| [`ff8f1a1f`](https://github.com/NixOS/nixpkgs/commit/ff8f1a1f4ec92908fa42260700b9253a9d53865d) | `` nixos/pipewire: document example for `services.pipewire.configPackages` ``                       |
| [`27a2f2a4`](https://github.com/NixOS/nixpkgs/commit/27a2f2a4299b902d78a1038d51de31bad1046a4e) | `` nixos/pipewire: replace `with lib;` with `inherit` ``                                            |
| [`f3b74afd`](https://github.com/NixOS/nixpkgs/commit/f3b74afdc7250bb5a6394d8c5a0f94d35466ad34) | `` nixos/pipewire: remove `lib.mdDoc` (no-op) ``                                                    |
| [`56837f26`](https://github.com/NixOS/nixpkgs/commit/56837f26e277c3beb8f23afad551d6297badc438) | `` tests.nixpkgs-check-by-name: Remove now that a separate repo is used ``                          |
| [`b42fbdd7`](https://github.com/NixOS/nixpkgs/commit/b42fbdd7ea72e95fad3e7595b68b440b6f4665a7) | `` check-by-name: Remove now-unnecessary scripts/pinned-tool.json ``                                |
| [`f7ea336c`](https://github.com/NixOS/nixpkgs/commit/f7ea336cb2bd403bb0bc8ce9ce48479a1427de18) | `` workflows/check-by-name.yml: Switch to new separate repo ``                                      |
| [`60a6ba96`](https://github.com/NixOS/nixpkgs/commit/60a6ba968da5145e5476b854c2941b347457490f) | `` attic-client: remove `env` attribute ``                                                          |
| [`e437c05d`](https://github.com/NixOS/nixpkgs/commit/e437c05d7a1bcb0073946f8b57696a5f7ed74567) | `` python312Packages.sqlmodel: disable failing test ``                                              |
| [`9b8097a5`](https://github.com/NixOS/nixpkgs/commit/9b8097a5aa5dfd6a46ad7823530925b226a4d06f) | `` python312Packages.sqlmodel£: refactor ``                                                         |
| [`dbb6796c`](https://github.com/NixOS/nixpkgs/commit/dbb6796cd4a8e6df5d9da30853e920fe0528ae9a) | `` tetrio-desktop: move to `pkgs/by-name` ``                                                        |
| [`e7f6ab70`](https://github.com/NixOS/nixpkgs/commit/e7f6ab70bf066810ba780ae5ad92334dfac72f3c) | `` flint3: fix NTL test ``                                                                          |
| [`56ceb0cc`](https://github.com/NixOS/nixpkgs/commit/56ceb0cc7d7fb242736b3f1bbf15917046dca9c6) | `` singular: bump texinfo from 4 to 7 ``                                                            |
| [`8c860b09`](https://github.com/NixOS/nixpkgs/commit/8c860b090ac662854bec0135d3549a852448902e) | `` linbox: fix clang build ``                                                                       |
| [`c4e0bff9`](https://github.com/NixOS/nixpkgs/commit/c4e0bff9d7cfeb09839071d7bd18b3e25f8f202e) | `` python311Packages.fpylll: fix on aarch64-darwin ``                                               |
| [`4d8893de`](https://github.com/NixOS/nixpkgs/commit/4d8893dec288bd68d08442a8e066d7ac26a25217) | `` kdePackages.drkonqi: refresh patch ``                                                            |
| [`86f1d7be`](https://github.com/NixOS/nixpkgs/commit/86f1d7be55b8568e3dd726cb2fba33ae89ed7fd8) | `` plasma: 6.0.2 -> 6.0.3 ``                                                                        |
| [`30409af9`](https://github.com/NixOS/nixpkgs/commit/30409af9ef4ad20a8b081c6f2e1adfbb17b12d5c) | `` scripts/kde/generate-sources: fix shebang ``                                                     |
| [`12e150a1`](https://github.com/NixOS/nixpkgs/commit/12e150a15f538d0cb8a0c2b54b5f03de9d47dd4e) | `` pdfgrep: 2.1.2 -> 2.2.0 ``                                                                       |
| [`bf8d06ac`](https://github.com/NixOS/nixpkgs/commit/bf8d06ac5a116627c1e6d64d7f268d098449d168) | `` texpresso: init at 0-unstable-2024-03-24 (#299168) ``                                            |
| [`70fa188e`](https://github.com/NixOS/nixpkgs/commit/70fa188e175ab9d1034416374b2af15ad94decbc) | `` nixos/paperless: set OMP_NUM_THREADS=1 by default ``                                             |
| [`affd0b62`](https://github.com/NixOS/nixpkgs/commit/affd0b626ae223b6b25754adb8a19f81449566b0) | `` ruff: 0.3.2 -> 0.3.4 ``                                                                          |
| [`260cb37b`](https://github.com/NixOS/nixpkgs/commit/260cb37bd5e012f55b3f4f59a24f88b29621a481) | `` meld: 3.22.1 → 3.22.2 ``                                                                         |
| [`e1a7ec55`](https://github.com/NixOS/nixpkgs/commit/e1a7ec5583b2c1b5fef89153ee0727d1f4d61904) | `` graalvm-ce: make it a scope ``                                                                   |
| [`d3b17d0b`](https://github.com/NixOS/nixpkgs/commit/d3b17d0b54427fe55359313e451877cca790d537) | `` Avoid top-level `with ...;` in pkgs/development/interpreters/eff/default.nix ``                  |
| [`4fc3979c`](https://github.com/NixOS/nixpkgs/commit/4fc3979c5bffa637bdff4b30521a127b3020fd9d) | `` Avoid top-level `with ...;` in pkgs/development/tools/headache/default.nix ``                    |
| [`9df9593b`](https://github.com/NixOS/nixpkgs/commit/9df9593b0c743737ba36da33e17a8e958d37c0b6) | `` Avoid top-level `with ...;` in pkgs/development/tools/ocaml/ocaml-top/default.nix ``             |
| [`6938c6ae`](https://github.com/NixOS/nixpkgs/commit/6938c6ae788d9a807f76d539d0b7b8bfdb5be688) | `` Avoid top-level `with ...;` in pkgs/development/tools/ocaml/opam-publish/default.nix ``          |
| [`592c139b`](https://github.com/NixOS/nixpkgs/commit/592c139bdb42bf14ae13d183ec85221a4dbd9c81) | `` python311Packages.aioesphomeapi: 23.1.0 -> 23.2.0 (#299112) ``                                   |
| [`2fea2459`](https://github.com/NixOS/nixpkgs/commit/2fea2459368625067a730446fbd97f2ea8744042) | `` buildGraalvm: use macOS SDK 11 ``                                                                |
| [`3117888b`](https://github.com/NixOS/nixpkgs/commit/3117888b2345bef331f46e9ea1c5feb07c6829f0) | `` organicmaps: 2024.03.05-4 -> 2024.03.18-5 ``                                                     |
| [`74fb0ebc`](https://github.com/NixOS/nixpkgs/commit/74fb0ebcd66edaf61cbbffb68339fab0effad6d8) | `` python312Packages.reptor: refactor ``                                                            |
| [`f319e891`](https://github.com/NixOS/nixpkgs/commit/f319e891ed08d94fc1df6db66ebf749f3664efa2) | `` obs-cmd: 0.17.4 -> 0.17.5 ``                                                                     |
| [`a98e9f48`](https://github.com/NixOS/nixpkgs/commit/a98e9f4892660c164b910461dad1abd734382736) | `` buildGraalvm: fix native-image warnings in installCheckPhase ``                                  |
| [`47fe73f5`](https://github.com/NixOS/nixpkgs/commit/47fe73f5b6c87a6f80e1de2ed721fd43bb5bef0e) | `` jextract: unstable-2023-11-27 -> unstable-2024-03-13 ``                                          |
| [`6f5294be`](https://github.com/NixOS/nixpkgs/commit/6f5294be10a4636aeed86c478542901d97ced2b1) | `` katana: 1.0.5 -> 1.1.0 ``                                                                        |
| [`f862bd46`](https://github.com/NixOS/nixpkgs/commit/f862bd46d3020bcfe7195b3dad638329271b0524) | `` qt6: 6.6.2 -> 6.6.3 ``                                                                           |
| [`10ccdbf5`](https://github.com/NixOS/nixpkgs/commit/10ccdbf59b46424faed666de2f88c0ce1653fb93) | `` python311Packages.prisma: 0.13.0 -> 0.13.1 ``                                                    |
| [`c7fb03ad`](https://github.com/NixOS/nixpkgs/commit/c7fb03ad0ac2b3a09f7983ec35f5236a595283d5) | `` hacompanion: init at 1.0.11 ``                                                                   |
| [`bbb187be`](https://github.com/NixOS/nixpkgs/commit/bbb187be1401a89bfd4d7c31801bacd1acc05505) | `` python312Packages.reptor: 0.13 -> 0.14 ``                                                        |
| [`8701daf4`](https://github.com/NixOS/nixpkgs/commit/8701daf46b7545fd9e454067a6ec96b728ac9351) | `` typos-lsp: 0.1.15 -> 0.1.16 ``                                                                   |
| [`af60144b`](https://github.com/NixOS/nixpkgs/commit/af60144b41df222f52bb515100804094f228cc3c) | `` grafana: supports x86_64-{linux, darwin} and aarch64-{linux, darwin} only ``                     |
| [`70dbdf67`](https://github.com/NixOS/nixpkgs/commit/70dbdf67bfabd416926d39112c34e5df7964d488) | `` nbqa: 1.8.4 -> 1.8.5 ``                                                                          |
| [`692eea05`](https://github.com/NixOS/nixpkgs/commit/692eea054d4dad633c9a4b9392599e0e46ad1cd1) | `` python312Packages.ttn-client: 0.0.3 -> 0.0.4 ``                                                  |
| [`feb95b45`](https://github.com/NixOS/nixpkgs/commit/feb95b45f0f8d36a62d6e42cc7b0fe0e54bf8be2) | `` myanon: init at 0.5 ``                                                                           |
| [`310235f9`](https://github.com/NixOS/nixpkgs/commit/310235f90178fd438c590319167a4977115d75f4) | `` python312Packages.boto3-stubs: 1.34.69 -> 1.34.70 ``                                             |
| [`0d614441`](https://github.com/NixOS/nixpkgs/commit/0d61444119c8f49abe5ed141e1f7c4a91cd78b73) | `` python312Packages.duo-client: refactor ``                                                        |
| [`115de732`](https://github.com/NixOS/nixpkgs/commit/115de732c0443eb394ce344bed4d6493aef040c8) | `` graphite-cli: 1.2.3 -> 1.2.8 ``                                                                  |
| [`2fd0f31c`](https://github.com/NixOS/nixpkgs/commit/2fd0f31cf8d99c6f6ae0427a9fcf093a20cd5a6f) | `` jenkins: 2.440.1 -> 2.440.2 ``                                                                   |
| [`b6dfa1ce`](https://github.com/NixOS/nixpkgs/commit/b6dfa1ce7cc5d1b75f290a7972da4f31232aca9a) | `` python312Packages.pipdeptree: refactor ``                                                        |
| [`1b79305c`](https://github.com/NixOS/nixpkgs/commit/1b79305c94130273d1914aba5292c42c7d636ac9) | `` python312Packages.playwrightcapture: refactor ``                                                 |
| [`cebca858`](https://github.com/NixOS/nixpkgs/commit/cebca8587a9bccf7ad90bdea2dcbb47bb52cc5ec) | `` elixir-ls: 0.19.0 -> 0.20.0 ``                                                                   |
| [`bf8c1d1d`](https://github.com/NixOS/nixpkgs/commit/bf8c1d1dcd2c2534c5cbf1bc39f3dc542982ff37) | `` python312Packages.latexify-py: refactor ``                                                       |
| [`2b0efc9e`](https://github.com/NixOS/nixpkgs/commit/2b0efc9e41b4a7263d4646326d56c24b99b7dca0) | `` python312Packages.riscv-config: 3.17.0 -> 3.17.1 ``                                              |
| [`3bd94e76`](https://github.com/NixOS/nixpkgs/commit/3bd94e764eb93ccdf8356298e03b85ea2980ef2e) | `` python312Packages.pipdeptree: 2.16.1 -> 2.16.2 ``                                                |
| [`13be6bfc`](https://github.com/NixOS/nixpkgs/commit/13be6bfcf726ed3162461a5484f66a2bcd025a27) | `` python312Packages.playwrightcapture: 1.23.13 -> 1.23.14 ``                                       |
| [`4ae27611`](https://github.com/NixOS/nixpkgs/commit/4ae276119c43e92358dc6ac1a9376e33925e613c) | `` python312Packages.latexify-py: 0.4.2 -> 0.4.3-post1 ``                                           |
| [`4f39b5c3`](https://github.com/NixOS/nixpkgs/commit/4f39b5c3d9afc059a968dfa5b1de2e629c6e5349) | `` aws-workspaces: 4.6.0.4187 -> 4.7.0.4312 ``                                                      |
| [`4452b400`](https://github.com/NixOS/nixpkgs/commit/4452b400e3b0110a892664f34fe7df83f8e0b3b1) | `` checkov: 3.2.45 -> 3.2.47 ``                                                                     |
| [`a1944c0a`](https://github.com/NixOS/nixpkgs/commit/a1944c0a46e7ebfbd7dcbebbfedd1fd2186786ca) | `` python312Packages.tencentcloud-sdk-python: 3.0.1115 -> 3.0.1116 ``                               |
| [`b3246705`](https://github.com/NixOS/nixpkgs/commit/b3246705addbe566bb3877dd3a1f022eab463fd6) | `` python311Packages.clarifai: 10.1.1 -> 10.2.1 ``                                                  |
| [`637b74a7`](https://github.com/NixOS/nixpkgs/commit/637b74a736246662076f16d280bc151d703de015) | `` tomcat10: 10.1.19 -> 10.1.20 ``                                                                  |
| [`ba9407f1`](https://github.com/NixOS/nixpkgs/commit/ba9407f1bc0f5590f967ee87180f4bfc68f6c004) | `` oterm: 0.1.22 -> 0.2.4 ``                                                                        |
| [`5fb1b865`](https://github.com/NixOS/nixpkgs/commit/5fb1b865205d608f4e53b16b2cad07eb773f8dd6) | `` python311Packages.llama-index-core: 0.10.20 -> 0.10.23 ``                                        |
| [`4b2838b4`](https://github.com/NixOS/nixpkgs/commit/4b2838b4b9fb9c8c240022bd21b00338ded911c6) | `` python311Packages.llama-index-readers-database: init at 0.1.2 ``                                 |
| [`30ad336f`](https://github.com/NixOS/nixpkgs/commit/30ad336f7b03e7482dd7b0325faf8b34facf39b7) | `` python311Packages.llama-index-readers-twitter: init at 0.1.3 ``                                  |
| [`e766848d`](https://github.com/NixOS/nixpkgs/commit/e766848d816c0e3fef8643000e30008dd8d92960) | `` steampipe: move to pkgs/by-name ``                                                               |
| [`9f5caec3`](https://github.com/NixOS/nixpkgs/commit/9f5caec3abeceef36fbd12e44ff6d4123c291765) | `` steampipe: add passthru.{tests.version,updateScript} ``                                          |
| [`ee796938`](https://github.com/NixOS/nixpkgs/commit/ee7969386d3dda2541835151581aa8a1b006795c) | `` steampipe: add meta.mainProgram ``                                                               |
| [`bba1a41e`](https://github.com/NixOS/nixpkgs/commit/bba1a41e544688eac2f1460eb91e981ccc6ba0d7) | `` python311Packages.llama-index-embeddings-openai: 0.10.22 -> 0.1.7 ``                             |
| [`e5103b5b`](https://github.com/NixOS/nixpkgs/commit/e5103b5b1523b37a23a1acaf7b33dfaf043e3ef8) | `` python312Packages.duo-client: 5.2.0 -> 5.3.0 ``                                                  |
| [`792d5c61`](https://github.com/NixOS/nixpkgs/commit/792d5c613f8106dfd893bdab1b3a2aabeb316b5a) | `` python311Packages.llama-index-indices-managed-llama-cloud: 0.10.22 -> 0.1.5 ``                   |
| [`2d758427`](https://github.com/NixOS/nixpkgs/commit/2d7584272271c2da6da4d758dbc72d79a7709a80) | `` python311Packages.llama-index-llms-openai: disable tests ``                                      |
| [`81e32ce8`](https://github.com/NixOS/nixpkgs/commit/81e32ce83453c965d732ede6c8e4693de38664b3) | `` python311Packages.llama-index-llms-openai: 0.10.22 -> 0.1.12 ``                                  |
| [`2cebdeef`](https://github.com/NixOS/nixpkgs/commit/2cebdeefcf83b00e5729684c9e2a565cd4d3ce03) | `` steampipe: fix vendorHash ``                                                                     |
| [`d3610453`](https://github.com/NixOS/nixpkgs/commit/d3610453fbf8fd07fa9f04b9e626cc0fcb5c3c7b) | `` python311Packages.llama-index-multi-modal-llms-openai: 0.10.22 -> 0.1.4 ``                       |
| [`a00b075f`](https://github.com/NixOS/nixpkgs/commit/a00b075f0163b948dc2e2eff3675cc01b2e7a5be) | `` python311Packages.llama-index-program-openai: 0.10.22 -> 0.1.4 ``                                |
| [`e9019b3e`](https://github.com/NixOS/nixpkgs/commit/e9019b3eb3ad2b3c2012a8ad1004b2cba86d8421) | `` orchard: 0.15.1 -> 0.15.2 ``                                                                     |
| [`3e16b876`](https://github.com/NixOS/nixpkgs/commit/3e16b87687662f729c6e0f8d96c03f41af7bb93e) | `` python311Packages.llama-index-question-gen-openai: update ordering ``                            |
| [`58dc39aa`](https://github.com/NixOS/nixpkgs/commit/58dc39aa87bba7633eed0affbb0aa6e49c823436) | `` python311Packages.llama-index-readers-txtai: init at 0.1.2 ``                                    |
| [`59c89b4b`](https://github.com/NixOS/nixpkgs/commit/59c89b4b864e906e97bf2fbb840aed32fd4f6dfb) | `` python311Packages.llama-index-vector-stores-chroma: 0.1.4 -> 0.1.6 ``                            |
| [`3580815e`](https://github.com/NixOS/nixpkgs/commit/3580815ea850019cdb6a6196801ab334ed275b6c) | `` gvisor: `20231113.0` -> `20240311.0-unstable-2024-03-25` ``                                      |
| [`9a143ea1`](https://github.com/NixOS/nixpkgs/commit/9a143ea12062c871be2388c8660f8ddb260190dc) | `` python311Packages.llama-index-readers-weather: 0.1.4 -> 0.1.3 ``                                 |
| [`c2720c18`](https://github.com/NixOS/nixpkgs/commit/c2720c185fc0ace9bd6d0503a03c534ad821555a) | `` python311Packages.llama-index-readers-s3: refactor ``                                            |
| [`98f3dcf3`](https://github.com/NixOS/nixpkgs/commit/98f3dcf3406ca5d0d0dd6c6403c5540418cd16f2) | `` python311Packages.llama-index-readers-s3: init at 0.1.4 ``                                       |
| [`ebf712b1`](https://github.com/NixOS/nixpkgs/commit/ebf712b1b16e13a5a8234a6b2754e56de3ff8324) | `` python311Packages.llama-index-legacy: 0.10.22 -> 0.9.48 ``                                       |
| [`f5e48411`](https://github.com/NixOS/nixpkgs/commit/f5e484111ea5c475637b4749b36bba90be07dcc9) | `` grafana: fix the darwin build failure ``                                                         |
| [`505ad166`](https://github.com/NixOS/nixpkgs/commit/505ad166ec55d361807f165ddecf88af1e730281) | `` python311Packages.llama-index-embeddings-google: 0.10.22 -> 0.1.4 ``                             |
| [`a4502b84`](https://github.com/NixOS/nixpkgs/commit/a4502b847b749c594428df608e8b4adbd2fed155) | `` ddns-go: 6.2.2 -> 6.3.0 ``                                                                       |
| [`cef226e5`](https://github.com/NixOS/nixpkgs/commit/cef226e553390c05a4c43b379133fc67a8b4cf5b) | `` nixos/microsocks: init ``                                                                        |
| [`3508f57d`](https://github.com/NixOS/nixpkgs/commit/3508f57de7377d81563536bf4223f6d9214259de) | `` csvlens: 0.7.0 -> 0.8.1 ``                                                                       |
| [`18521d9d`](https://github.com/NixOS/nixpkgs/commit/18521d9d3034fdb358e2c855d741544d73511b8e) | `` androidStudioPackages.canary: 2023.3.2 Canary 1 -> 2023.3.2 Canary 2 ``                          |