### PR TITLE
chore(flake/pre-commit-hooks): `7d47a32e` -> `c11e43ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -576,11 +576,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711519547,
-        "narHash": "sha256-Q7YmSCUJmDl71fJv/zD9lrOCJ1/SE/okZ2DsrmRjzhY=",
+        "lastModified": 1711760932,
+        "narHash": "sha256-DqUTQ2iAAqSDwMhKBqvi24v0Oc7pD3LCK/0FCG//TdA=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "7d47a32e5cd1ea481fab33c516356ce27c8cef4a",
+        "rev": "c11e43aed6f17336c25cd120eac886b96c455731",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`0d676ca9`](https://github.com/cachix/git-hooks.nix/commit/0d676ca9ca9df7f2d4d5fb0de511fed3a4b67fdf) | `` free up space on ci ``                |
| [`5da7bab7`](https://github.com/cachix/git-hooks.nix/commit/5da7bab7c34586b8a0a8c397d8c6b257fcceb96e) | `` Fix `nix flake check` on macOS ``     |
| [`dc6812ea`](https://github.com/cachix/git-hooks.nix/commit/dc6812ea2c8a21cca091ecb9ae0433d89e03efe4) | `` Silence git commit summary ``         |
| [`6c48d19a`](https://github.com/cachix/git-hooks.nix/commit/6c48d19a93ed6891c6d99cdcc1f712917a763622) | `` Silence git default branch warning `` |
| [`a130d70f`](https://github.com/cachix/git-hooks.nix/commit/a130d70f832e59799a2e86c1f8ff063b0fef9daa) | `` Fix typos and add pre-commit check `` |