### PR TITLE
chore(flake/stylix): `75fd2477` -> `bad1af63`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -660,11 +660,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711615973,
-        "narHash": "sha256-43KrbzuVf4ZnJ849OInG/yt+Fq6hIiITxRj02U5mUeM=",
+        "lastModified": 1711784035,
+        "narHash": "sha256-NWKh+TEakGWO/Zdr97Gi0HpLpooMge0ksBMDM4jOAzE=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "75fd247712ac54d756b7c0bb7150dc6858d29522",
+        "rev": "bad1af63ff330b397b87fc243d479701417740da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                       |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`bad1af63`](https://github.com/danth/stylix/commit/bad1af63ff330b397b87fc243d479701417740da) | `` kde: remove internal debugging logs (#304) ``              |
| [`504c54db`](https://github.com/danth/stylix/commit/504c54dbf1d91857b52133ee9c9bd4c526b3275c) | `` kde: remove redundant function declaration space (#305) `` |