### PR TITLE
chore(flake/stylix): `bad1af63` -> `fdf8fd26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -660,11 +660,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711784035,
-        "narHash": "sha256-NWKh+TEakGWO/Zdr97Gi0HpLpooMge0ksBMDM4jOAzE=",
+        "lastModified": 1711797803,
+        "narHash": "sha256-7CVR/L+sXNNuQtNG6djzgoaMlP1acFIn8p/gImlDwI4=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "bad1af63ff330b397b87fc243d479701417740da",
+        "rev": "fdf8fd261eba972e23e8926caeb3aa41c5e3ac68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                 |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`fdf8fd26`](https://github.com/danth/stylix/commit/fdf8fd261eba972e23e8926caeb3aa41c5e3ac68) | `` treewide: use Bash internal 'test' command (#311) `` |