### PR TITLE
chore(flake/home-manager): `c0ef0dab` -> `30f2ec39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,11 +390,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711625603,
-        "narHash": "sha256-W+9dfqA9bqUIBV5u7jaIARAzMe3kTq/Hp2SpSVXKRQw=",
+        "lastModified": 1711868868,
+        "narHash": "sha256-QpZanlbVu6Gb2K96u3vgu0F2BvZD74+fOsIFWcYEXoY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c0ef0dab55611c676ad7539bf4e41b3ec6fa87d2",
+        "rev": "30f2ec39519f4f5a8a96af808c439e730c15aeab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`30f2ec39`](https://github.com/nix-community/home-manager/commit/30f2ec39519f4f5a8a96af808c439e730c15aeab) | `` flake.lock: Update ``                   |
| [`c09deb86`](https://github.com/nix-community/home-manager/commit/c09deb869b2e7a4612e489d4bbb11517f78b618e) | `` Translate using Weblate (Vietnamese) `` |