### PR TITLE
chore(flake/pre-commit-hooks): `9fc61b5e` -> `ffbf4694`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -576,11 +576,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711850184,
-        "narHash": "sha256-rs5zMkTO+AlVBzgOaskAtY4zix7q3l8PpawfznHotcQ=",
+        "lastModified": 1711957905,
+        "narHash": "sha256-8aEIBDbVyntFs0yzfo3uJ7SpvFoMABhAp4URoD8daZ0=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "9fc61b5eb0e50fc42f1d358f5240722907b79726",
+        "rev": "ffbf46949fcf41378498141341998b60fdbb2a32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`d2f6f937`](https://github.com/cachix/git-hooks.nix/commit/d2f6f9376c38fb0c48526720793a17f10cd3ac10) | `` Add `package` options for hooks ``        |
| [`6caf5b27`](https://github.com/cachix/git-hooks.nix/commit/6caf5b27b7ef4ce9746a8ec08592c609ccde34a2) | `` Fix sort-file-contents description ``     |
| [`c6189c3d`](https://github.com/cachix/git-hooks.nix/commit/c6189c3db3343985cdb5223b12b920172ee22b03) | `` Revert unintended changes ``              |
| [`73a4e8d7`](https://github.com/cachix/git-hooks.nix/commit/73a4e8d765e7ebfdd6ea1e2e18488012403093f0) | `` Fix `nix flake check`s ``                 |
| [`317fc48c`](https://github.com/cachix/git-hooks.nix/commit/317fc48c250158a80fc5844f69a4bf135c784f2c) | `` Fix Markdown formatting and sort hooks `` |
| [`910b6db2`](https://github.com/cachix/git-hooks.nix/commit/910b6db22ec9b006b89f31d0cfa568ac4e171077) | `` Add default hooks to README ``            |
| [`754397c7`](https://github.com/cachix/git-hooks.nix/commit/754397c75a61707e20384b07e2c387778672a890) | `` Add pre-commit default hooks ``           |