### PR TITLE
chore(flake/pre-commit-hooks): `ffbf4694` -> `8ae5bb63`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -576,11 +576,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711957905,
-        "narHash": "sha256-8aEIBDbVyntFs0yzfo3uJ7SpvFoMABhAp4URoD8daZ0=",
+        "lastModified": 1711978524,
+        "narHash": "sha256-5WIqUP06E3tal2NQ6R1Tmo1raa2r32dkBzNROt10q7Q=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ffbf46949fcf41378498141341998b60fdbb2a32",
+        "rev": "8ae5bb63f9bcd0472b67cf4ada414ae37f1f2bcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                              |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`8ae5bb63`](https://github.com/cachix/git-hooks.nix/commit/8ae5bb63f9bcd0472b67cf4ada414ae37f1f2bcc) | `` Update hook module import for default hooks ``    |
| [`cc709e51`](https://github.com/cachix/git-hooks.nix/commit/cc709e51ce0dfaac452dbacbd4c5a9b40e89c79f) | `` refactor: DRY hookModule and upgrade to option `` |
| [`054c86ce`](https://github.com/cachix/git-hooks.nix/commit/054c86ce12e439240292d086a66a243c7d714fc7) | `` flake-module.nix: Update comment ``               |