### PR TITLE
chore(flake/pre-commit-hooks): `8ae5bb63` -> `f3bb9549`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -576,11 +576,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1711978524,
-        "narHash": "sha256-5WIqUP06E3tal2NQ6R1Tmo1raa2r32dkBzNROt10q7Q=",
+        "lastModified": 1711981679,
+        "narHash": "sha256-pnbHEXJOdGkPrHBdkZLv/a2V09On+V3J4aPE/BfAJC8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "8ae5bb63f9bcd0472b67cf4ada414ae37f1f2bcc",
+        "rev": "f3bb95498eaaa49a93bacaf196cdb6cf8e872cdf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                |
| ----------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f3bb9549`](https://github.com/cachix/git-hooks.nix/commit/f3bb95498eaaa49a93bacaf196cdb6cf8e872cdf) | `` Fix link to docs `` |