### PR TITLE
chore(flake/pre-commit-hooks): `642dce09` -> `e35aed5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -576,11 +576,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712033542,
-        "narHash": "sha256-werD6WtgYo+ZGopbLENP0phwoWyd73CWz01VgrFOSL0=",
+        "lastModified": 1712055707,
+        "narHash": "sha256-4XLvuSIDZJGS17xEwSrNuJLL7UjDYKGJSbK1WWX2AK8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "642dce09c85b1478b509416f83e72bd59b6b3ac2",
+        "rev": "e35aed5fda3cc79f88ed7f1795021e559582093a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                               |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`9715094e`](https://github.com/cachix/git-hooks.nix/commit/9715094e7af77f3090b11a43fa43c978a3f4d610) | `` Fix reference to renamed option ``                 |
| [`34fdf24f`](https://github.com/cachix/git-hooks.nix/commit/34fdf24f3e6b144c2dde7e7af605160cf477277e) | `` Add warnings for changed modules ``                |
| [`f94f8e27`](https://github.com/cachix/git-hooks.nix/commit/f94f8e27c38cacc906941063c66ac709014a7215) | `` Remove shadowing of `config` attribute in hooks `` |
| [`54189ae4`](https://github.com/cachix/git-hooks.nix/commit/54189ae45d1ced5bdc19c02ccdb36aacb67e6ef2) | `` Extend `yamllint` hook with more options ``        |