### PR TITLE
chore(flake/agenix): `8cb01a0e` -> `1381a759`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707830867,
-        "narHash": "sha256-PAdwm5QqdlwIqGrfzzvzZubM+FXtilekQ/FA0cI49/o=",
+        "lastModified": 1712079060,
+        "narHash": "sha256-/JdiT9t+zzjChc5qQiF+jhrVhRt8figYH29rZO7pFe4=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "8cb01a0e717311680e0cbca06a76cbceba6f3ed6",
+        "rev": "1381a759b205dff7a6818733118d02253340fd5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`3fd98a2c`](https://github.com/ryantm/agenix/commit/3fd98a2c3b1a9a46341a975ee0a4b488194ecb56) | `` doc: fix wrong ssh-keyscan usage `` |