### PR TITLE
chore(flake/home-manager): `0c73c1b8` -> `782eed8b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -390,11 +390,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712266167,
-        "narHash": "sha256-gr2CBgT8t+utDqzWSp2vSjX/c39Q0BNtrWE6/cDhhEE=",
+        "lastModified": 1712317700,
+        "narHash": "sha256-rnkQ6qMhlxfjpCECkTMlFXHU/88QvC5KpdJWq5H6F1E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0c73c1b8da28a24c4fe842ced3f2548d5828b550",
+        "rev": "782eed8bb64b27acaeb7c17be4a095c85e65717f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`782eed8b`](https://github.com/nix-community/home-manager/commit/782eed8bb64b27acaeb7c17be4a095c85e65717f) | `` programs.khal: add "addresses" option + tidy up (#5221) `` |
| [`1ffd393c`](https://github.com/nix-community/home-manager/commit/1ffd393cba9eb12df94641238f4436cabb285c9b) | `` Translate using Weblate (Catalan) ``                       |