### PR TITLE
chore(flake/nixos-hardware): `9a763a7a` -> `f3b95962`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1711352745,
-        "narHash": "sha256-luvqik+i3HTvCbXQZgB6uggvEcxI9uae0nmrgtXJ17U=",
+        "lastModified": 1712324865,
+        "narHash": "sha256-+BatEWd4HlMeK7Ora+gYIkarjxFVCg9oKrIeybHIIX4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9a763a7acc4cfbb8603bb0231fec3eda864f81c0",
+        "rev": "f3b959627bca46a9f7052b8fbc464b8323e68c2c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                 |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`f3b95962`](https://github.com/NixOS/nixos-hardware/commit/f3b959627bca46a9f7052b8fbc464b8323e68c2c) | `` removed edid ``                                                      |
| [`a7825c5b`](https://github.com/NixOS/nixos-hardware/commit/a7825c5b9a9c69dddd1904789ebbe413c5b6bf15) | `` 15ach6h ``                                                           |
| [`a3746a14`](https://github.com/NixOS/nixos-hardware/commit/a3746a14c1240b57b2d08b99c796a1775ebffdf5) | `` feat: add dell latitude 7280 module ``                               |
| [`e1cbffcf`](https://github.com/NixOS/nixos-hardware/commit/e1cbffcf3a8b243fd6be880854fcd0169cd4165e) | `` ga401: use mkDefault for dynamicBoost ``                             |
| [`cac934be`](https://github.com/NixOS/nixos-hardware/commit/cac934beb389a967dcb95a98da8f2186cbbe179a) | `` fix(pine64/star64): resolve conflicting definition for Linux 5.15 `` |
| [`adcd458b`](https://github.com/NixOS/nixos-hardware/commit/adcd458b558915b80f628db7f88450f5f51ebf17) | `` protectli/vp4670: init ``                                            |
| [`823a8220`](https://github.com/NixOS/nixos-hardware/commit/823a82200c5367f14c56649315c27749153b88e8) | `` common/cpu/intel/comet-lake: init ``                                 |