### PR TITLE
chore(flake/nixpkgs): `fd281bd6` -> `ff0dbd94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712163089,
-        "narHash": "sha256-Um+8kTIrC19vD4/lUCN9/cU9kcOsD1O1m+axJqQPyMM=",
+        "lastModified": 1712439257,
+        "narHash": "sha256-aSpiNepFOMk9932HOax0XwNxbA38GOUVOiXfUVPOrck=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fd281bd6b7d3e32ddfa399853946f782553163b5",
+        "rev": "ff0dbd94265ac470dda06a657d5fe49de93b4599",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`23f0bd2b`](https://github.com/NixOS/nixpkgs/commit/23f0bd2b4144f35a618d3d0fb8a21da2f473cd22) | `` home-assistant: adjust dependencies ``                                  |
| [`2975aecb`](https://github.com/NixOS/nixpkgs/commit/2975aecbcb393299cbde06034264090f459eb545) | `` nixos/tests/switch-test: s/dbus.service/dbus-broker.service/g ``        |
| [`998a60e1`](https://github.com/NixOS/nixpkgs/commit/998a60e1768c5f080e251b8b583f2c1f7bddec89) | `` monero-{cli,gui}: 0.18.3.2 -> 0.18.3.3 ``                               |
| [`4d92f8bc`](https://github.com/NixOS/nixpkgs/commit/4d92f8bcc678496085c1dea945d023b426c460e9) | `` luaPackages.pathlib-nvim: init at 2.2.0-1 ``                            |
| [`8042fcec`](https://github.com/NixOS/nixpkgs/commit/8042fcecd013c570c9095bd89035070149143cc9) | `` doc: update name of luarocks update package in codedoc ``               |
| [`17f8a375`](https://github.com/NixOS/nixpkgs/commit/17f8a37578754ec84fc97acef10cfef37476f51c) | `` python311Packages.whirlpool-sixth-sense: format with nixfmt ``          |
| [`f595d4f2`](https://github.com/NixOS/nixpkgs/commit/f595d4f2691c41ec8d036dca18c1822728c1e463) | `` python311Packages.whirlpool-sixth-sense: refactor ``                    |
| [`53342ebf`](https://github.com/NixOS/nixpkgs/commit/53342ebf9242812be78cfec1557892d18b4be5ff) | `` python312Packages.ping3: format with nixfmt ``                          |
| [`f5474cbb`](https://github.com/NixOS/nixpkgs/commit/f5474cbbcc5ed4a89e8083e0248840b9c95dd194) | `` python312Packages.ping3: refactor ``                                    |
| [`3f2a8fea`](https://github.com/NixOS/nixpkgs/commit/3f2a8fea9275c059c3bbd1de1cc417732a8ea316) | `` python311Packages.types-requests: 2.31.0.20240403 -> 2.31.0.20240406 `` |
| [`2c4f1bd7`](https://github.com/NixOS/nixpkgs/commit/2c4f1bd74186da41fded0ea9d8ab11d2cd3c7937) | `` python311Packages.ping3: 4.0.5 -> 4.0.7 ``                              |
| [`aad2a8af`](https://github.com/NixOS/nixpkgs/commit/aad2a8af943b0f1d31cc53ada83437fc1386ae5d) | `` gprbuild: add comment on headerpad_max_install_names ``                 |
| [`e599123b`](https://github.com/NixOS/nixpkgs/commit/e599123b09749b9be4271fd7709abfbe7f62b392) | `` wayland-proxy-virtwl: unstable-2023-12-09 -> unstable-2024-04-05 ``     |
| [`4b26760a`](https://github.com/NixOS/nixpkgs/commit/4b26760adea35063d41c74eb444156868c8a0e1a) | `` ocamlPackages.wayland: 2.0 -> 2.1 ``                                    |
| [`5aa8dd33`](https://github.com/NixOS/nixpkgs/commit/5aa8dd335306f313ac8b4ee6609d05be863ea4ef) | `` rnote: 0.10.1 -> 0.10.2 ``                                              |
| [`152d684f`](https://github.com/NixOS/nixpkgs/commit/152d684fbf6ccc844675436b5624a98c8111a312) | `` python312Packages.b2sdk: format with nixfmt ``                          |
| [`2c95edc3`](https://github.com/NixOS/nixpkgs/commit/2c95edc35bd0c5e1848c119cdf2526c0ff482ab5) | `` python312Packages.b2sdk: refactor ``                                    |
| [`52a69d19`](https://github.com/NixOS/nixpkgs/commit/52a69d191fa5e2d5ea8ec4fa97874ecf0a321995) | `` backblaze-b2: 3.17.0 -> 3.18.0 ``                                       |
| [`9262c37d`](https://github.com/NixOS/nixpkgs/commit/9262c37d59043758a3c85b08be8386e3f2313cec) | `` sublime-music: disable semver override checks ``                        |
| [`e7fa0eb0`](https://github.com/NixOS/nixpkgs/commit/e7fa0eb042d3a80d950429215d5ac9aa660d70da) | `` dracula-theme: unstable-2024-03-13 -> unstable-2024-03-31 ``            |
| [`f1b8ec7b`](https://github.com/NixOS/nixpkgs/commit/f1b8ec7b340da1859530f986bf42e7ad83fcd2bc) | `` python312Packages.aiolifx: format with nixfmt ``                        |
| [`6774faa4`](https://github.com/NixOS/nixpkgs/commit/6774faa424e864668e485609a2ab1cb0a53a4b1a) | `` python312Packages.aiolifx: refactor ``                                  |
| [`7c5fe7a6`](https://github.com/NixOS/nixpkgs/commit/7c5fe7a652ddfa274c82a8714f762161e4d79494) | `` python312Packages.garminconnect: format with nixfmt ``                  |
| [`1310a6f1`](https://github.com/NixOS/nixpkgs/commit/1310a6f103778bb1dbc9c3f20a80b9a7927be4c4) | `` python312Packages.garminconnect: refactor ``                            |
| [`8bfc15f1`](https://github.com/NixOS/nixpkgs/commit/8bfc15f1ceaac7e5abb158b0b4933b81cdedb5b0) | `` python312Packages.yolink-api: format with nixfmt ``                     |
| [`ecf24e1b`](https://github.com/NixOS/nixpkgs/commit/ecf24e1b7cf4fdb5643d55154b24edfebe415968) | `` python311Packages.clickhouse-connect: 0.7.4 -> 0.7.7 ``                 |
| [`a3b621af`](https://github.com/NixOS/nixpkgs/commit/a3b621afffc1d6fff22646b560353542b5f63faa) | `` fwupd: 1.9.15 -> 1.9.16 ``                                              |
| [`131ea263`](https://github.com/NixOS/nixpkgs/commit/131ea2631ea82a5149f3c027449f29dd278a5c13) | `` home-assistant.intents: 2024.3.12 -> 2024.4.3 ``                        |
| [`7d6d8201`](https://github.com/NixOS/nixpkgs/commit/7d6d820172739b4ddbb0c77fa292bbde840df0f1) | `` home-assistant: 2024.3.3 -> 2024.4.0 ``                                 |
| [`2707694d`](https://github.com/NixOS/nixpkgs/commit/2707694daa1284b2bc66f8492becc0b219340ad1) | `` python311Packages.fyta-cli: init at 0.3.4 ``                            |
| [`141dcf1d`](https://github.com/NixOS/nixpkgs/commit/141dcf1ddccc1297b7e4d85f680b29f339bdf4cc) | `` python311Packages.aionut: init at 4.3.2 ``                              |
| [`61b8fc92`](https://github.com/NixOS/nixpkgs/commit/61b8fc92b396bda3650c003a4cef5d7e52800344) | `` python312Packages.whirlpool-sixth-sense: 0.18.5 -> 0.18.7 ``            |
| [`43118ee9`](https://github.com/NixOS/nixpkgs/commit/43118ee972e824f28cd243140c337459dcb8c3d1) | `` python311Packages.zha: init at 0.0.5 ``                                 |
| [`1f76b6f5`](https://github.com/NixOS/nixpkgs/commit/1f76b6f5c664c454a1a02e379b5e240b7dc2ee88) | `` python312Packages.universal-silabs-flasher: refactor ``                 |
| [`fb15a387`](https://github.com/NixOS/nixpkgs/commit/fb15a387ca2fe9f4c440c0d8734d11f0051f1a0e) | `` python312Packages.bellows: refactor ``                                  |
| [`426c70b8`](https://github.com/NixOS/nixpkgs/commit/426c70b8b3b3b2ea5fc936e3fae18156b525e5f0) | `` python312Packages.zha-quirks: 0.0.112 -> 0.0.113 ``                     |
| [`63ce6d15`](https://github.com/NixOS/nixpkgs/commit/63ce6d15a9feb975b4b3407a8bed186987aeb1ae) | `` python312Packages.zigpy: refactor ``                                    |
| [`87c0e628`](https://github.com/NixOS/nixpkgs/commit/87c0e628e1eb109aab5098dd9260704596016680) | `` python312Packages.zigpy: 0.63.4 -> 0.63.5 ``                            |
| [`962421a9`](https://github.com/NixOS/nixpkgs/commit/962421a9e71c747a5fc75dfcd50541641cd7c107) | `` python312Packages.zeroconf: 0.131.0 -> 0.132.0 (#300791) ``             |
| [`ab559665`](https://github.com/NixOS/nixpkgs/commit/ab5596659fd5993ecb7eb4ad03051bd57b45a7e3) | `` python312Packages.vilfo-api-client: 0.4.1 -> 0.5.0 ``                   |
| [`a48689b7`](https://github.com/NixOS/nixpkgs/commit/a48689b7ed561371d537d1c33d38fbc7b92b3e34) | `` python311Packages.tololib: 0.1.0b4 -> 1.1.0 ``                          |
| [`45fded6f`](https://github.com/NixOS/nixpkgs/commit/45fded6fdbf5ebdac0c69dcf139a89e268df5027) | `` python312Packages.roombapy: 1.7.0 -> 1.8.1 ``                           |
| [`2055d6e3`](https://github.com/NixOS/nixpkgs/commit/2055d6e33680d5fb59852d7db6c637cc6887d196) | `` python312Packages.python-homewizard-energy: 4.3.1 -> 5.0.0 ``           |
| [`2110e197`](https://github.com/NixOS/nixpkgs/commit/2110e197e8cafe302bbdcbdb4b9c28c16a78e1c3) | `` python312Packages.pyrisco: 0.5.10 -> 0.6.0 ``                           |
| [`75b9d815`](https://github.com/NixOS/nixpkgs/commit/75b9d815a7fdc3e0bd2f6e68ec73708ee576ca32) | `` python312Packages.axis: 58 -> 60 ``                                     |
| [`5401a75a`](https://github.com/NixOS/nixpkgs/commit/5401a75a1ddf254de328597eee53c262f5283f5f) | `` python312Packages.aiodhcpwatcher: 0.8.2 -> 1.0.1 ``                     |
| [`2c7b03c0`](https://github.com/NixOS/nixpkgs/commit/2c7b03c09bd5fa9eed1c32bc9e9629ee030bec8b) | `` python312Packages.aioautomower: 2024.3.3 -> 2024.4.0 ``                 |
| [`783e0638`](https://github.com/NixOS/nixpkgs/commit/783e0638076de0e8f0e7429d0094a4d739f33962) | `` python312Packages.yolink-api: 0.4.1 -> 0.4.2 ``                         |
| [`099f9374`](https://github.com/NixOS/nixpkgs/commit/099f937475889ccee8712ecdc2c44f48ef70c691) | `` python312Packages.riscv-config: 3.17.1 -> 3.18.0 ``                     |
| [`bf6ea5c0`](https://github.com/NixOS/nixpkgs/commit/bf6ea5c0d4e1a6665c742b1129534911dde822fd) | `` mpvScripts.modernx-zydezu: 0.2.8 -> 0.2.9 ``                            |
| [`3cd90fa9`](https://github.com/NixOS/nixpkgs/commit/3cd90fa957ded09bcdc0481b86c10bac6cf73b3e) | `` python312Packages.garminconnect: 0.2.15 -> 0.2.16 ``                    |
| [`78614122`](https://github.com/NixOS/nixpkgs/commit/786141228f3a7d00dc696ae6600f36953710053a) | `` nixos/borgbackup: fix directory ownership regression ``                 |
| [`edb818b2`](https://github.com/NixOS/nixpkgs/commit/edb818b2b22e5d2a08da67a0427fb7539d8bbc40) | `` drawterm: unstable-2024-03-20 -> unstable-2024-03-31 ``                 |
| [`ececef9c`](https://github.com/NixOS/nixpkgs/commit/ececef9cce0975c2303f8b511a4eecad64c9a90e) | `` python312Packages.aiolifx: 1.0.1 -> 1.0.2 ``                            |
| [`3dc91a5f`](https://github.com/NixOS/nixpkgs/commit/3dc91a5f145b440cb186f99c926aa100563f690c) | `` python312Packages.brother: 4.0.2 -> 4.1.0 ``                            |
| [`5c319e2e`](https://github.com/NixOS/nixpkgs/commit/5c319e2eb593318c164911ca81a62d3e2709438d) | `` python312Packages.twilio: format with nixfmt ``                         |
| [`3b38b95d`](https://github.com/NixOS/nixpkgs/commit/3b38b95d7840deaafbae7889d8175e6a38fb6352) | `` python312Packages.twilio: 9.0.3 -> 9.0.4 ``                             |
| [`e90f9dfd`](https://github.com/NixOS/nixpkgs/commit/e90f9dfd460b7ca09fefc6218dae33fa1ea158f2) | `` python312Packages.whispers: format with nixfmt ``                       |
| [`b81d35be`](https://github.com/NixOS/nixpkgs/commit/b81d35be35e0bb7cfde62de6eb703ebfcb4c7b01) | `` python312Packages.whispers: 2.2.0 -> 2.2.1 ``                           |
| [`8d002ae7`](https://github.com/NixOS/nixpkgs/commit/8d002ae768580af5dff7030e96e57fa3a88c2ccd) | `` protolint: 0.49.3 -> 0.49.4 ``                                          |
| [`43e85c55`](https://github.com/NixOS/nixpkgs/commit/43e85c55ae18e21bd0b7e324a6f6ebbfe1c826f8) | `` sssd: fix build ``                                                      |
| [`4f61b586`](https://github.com/NixOS/nixpkgs/commit/4f61b586c6ea06e5fcb1aedc02c0be5b62fdf4ed) | `` stackit-cli: 0.1.0-prerelease.2 -> 0.1.0 ``                             |
| [`f8654bdc`](https://github.com/NixOS/nixpkgs/commit/f8654bdccbe36a47534282b3beb8379ad09140d5) | `` clipcat: 0.16.4 -> 0.16.5 ``                                            |
| [`4d69fb7e`](https://github.com/NixOS/nixpkgs/commit/4d69fb7e121322c617cb59bf95b06a6fef7162fc) | `` clightning: 24.02.1 -> 24.02.2 ``                                       |
| [`f82d3e1a`](https://github.com/NixOS/nixpkgs/commit/f82d3e1a9924ed6ea9d99aadaf6cb4e6415e5978) | `` abaddon: 0.2.0 -> 0.2.1 ``                                              |
| [`bac21a53`](https://github.com/NixOS/nixpkgs/commit/bac21a53390e16b710b0f715a15d75041f341ae2) | `` kalker: 2.1.0 -> 2.2.0 ``                                               |
| [`41f1e78c`](https://github.com/NixOS/nixpkgs/commit/41f1e78ccb9db5003f30573c772325ef761993b3) | `` cnquery;: format with nixfmt ``                                         |
| [`aa9ccb46`](https://github.com/NixOS/nixpkgs/commit/aa9ccb46e17064c61bd80777794d7c9994f1b44e) | `` python311Packages.pplpy: 0.8.9 -> 0.8.10 ``                             |
| [`28a00f8e`](https://github.com/NixOS/nixpkgs/commit/28a00f8e585e19714cee74dd96757fd56e70f8f4) | `` python312Packages.oras: format with nixfmt ``                           |
| [`63f8445d`](https://github.com/NixOS/nixpkgs/commit/63f8445d0be7c427a4201afc4082d3b94eb9b855) | `` python312Packages.oras: refactor ``                                     |
| [`e24370fc`](https://github.com/NixOS/nixpkgs/commit/e24370fc158b36e5a8387fb2082c348adb998bec) | `` trufflehog: format with nixfmt ``                                       |
| [`add9bb4b`](https://github.com/NixOS/nixpkgs/commit/add9bb4beafd24302643f91bc18bdae73776eb8b) | `` python312Packages.tencentcloud-sdk-python: format with nixfmt ``        |
| [`d98a8ed7`](https://github.com/NixOS/nixpkgs/commit/d98a8ed78206a04b5e9c74acade8c51afaaa152a) | `` python312Packages.tencentcloud-sdk-python: 3.0.1122 -> 3.0.1123 ``      |
| [`42e6e72f`](https://github.com/NixOS/nixpkgs/commit/42e6e72f93bfd96f222b503b1d8a942265d42e35) | `` trufflehog: 3.71.2 -> 3.72.0 ``                                         |
| [`14447b49`](https://github.com/NixOS/nixpkgs/commit/14447b49fdce8ce0b9183988fd2fac93f54864f7) | `` python312Packages.sse-starlette: format with nixfmt ``                  |
| [`c3dedbee`](https://github.com/NixOS/nixpkgs/commit/c3dedbee6f5c3e00d9799011f22aa08f2aceac26) | `` python312Packages.sse-starlette: 2.1.0 -> 2.1.0 ``                      |
| [`5bcb08ea`](https://github.com/NixOS/nixpkgs/commit/5bcb08ea0326908bee7ffda009d46da7da1f2668) | `` lib.hasAttrByPath: fix typo (#302042) ``                                |
| [`ef3a4392`](https://github.com/NixOS/nixpkgs/commit/ef3a4392ff9fe86a5a58c7ab60fbe5971869b32b) | `` python3Packages.wagtail-localize: 1.8.2 -> 1.9 ``                       |
| [`70b940fe`](https://github.com/NixOS/nixpkgs/commit/70b940febc55fcc8d508621d9c80704efe24efc7) | `` python3Packages.wagtail: fix package ``                                 |
| [`46887d05`](https://github.com/NixOS/nixpkgs/commit/46887d055345803f0ab6a9d081221f7e7d4a3b48) | `` crowdin-cli: 3.19.1 -> 3.19.2 ``                                        |
| [`a5a78c10`](https://github.com/NixOS/nixpkgs/commit/a5a78c1074b5b420ead5da1f1ad6503c9b19e585) | `` python311Packages.moderngl-window: 2.4.5 -> 2.4.6 ``                    |
| [`9e1bfea6`](https://github.com/NixOS/nixpkgs/commit/9e1bfea631bb43bba88132136d60036c234ef1c6) | `` terragrunt: 0.55.20 -> 0.56.2 ``                                        |
| [`44f7c4ca`](https://github.com/NixOS/nixpkgs/commit/44f7c4cac1f8eea1f09cfec56a0d78f19818a92d) | `` python312Packages.semver: format with nixfmt ``                         |
| [`e39ea8cf`](https://github.com/NixOS/nixpkgs/commit/e39ea8cf62e8edaabd5ca14a660d7ffdcd86d71c) | `` btdu: add cybershadow to maintainers ``                                 |
| [`8bb8cb8f`](https://github.com/NixOS/nixpkgs/commit/8bb8cb8f13dc2ba120e101d574cd27b82601cf3c) | `` hax11: add cybershadow to maintainers ``                                |
| [`0f27c8a4`](https://github.com/NixOS/nixpkgs/commit/0f27c8a4ac5ce085fb1989dd0ea421b758ff8b9b) | `` python312Packages.semver: refactor ``                                   |
| [`3c3a001a`](https://github.com/NixOS/nixpkgs/commit/3c3a001afb6d93eaeb980b9a383fd2dc94b39a00) | `` zncModules.clientbuffer: add cybershadow to maintainers ``              |
| [`2d73e107`](https://github.com/NixOS/nixpkgs/commit/2d73e107d6c5783e1304d957f082a827ad7860fb) | `` grandperspective: 3.4.1 -> 3.4.2 ``                                     |
| [`b7b759af`](https://github.com/NixOS/nixpkgs/commit/b7b759af7d6db692532e0e346d3b9fc3343059a3) | `` python312Packages.aiopvapi: format with nixfmt ``                       |
| [`ad19fcbd`](https://github.com/NixOS/nixpkgs/commit/ad19fcbd8c7989236f8286e957b3a4436f64e75d) | `` python312Packages.aiopvapi: 3.1.0 -> 3.1.1 ``                           |
| [`6e9d3767`](https://github.com/NixOS/nixpkgs/commit/6e9d3767c16dd251b81bed996d2acfbb416da6ec) | `` pg_activity: 3.5.0 -> 3.5.1 ``                                          |
| [`c89ec171`](https://github.com/NixOS/nixpkgs/commit/c89ec171bb4cb4cbd170790a8a083e0016070da3) | `` python311Packages.memory-allocator: 0.1.3 -> 0.1.4 ``                   |
| [`9e5bb67f`](https://github.com/NixOS/nixpkgs/commit/9e5bb67ff4d9554a755b9fadb34d673b9a5f17bf) | `` docker-compose: 2.26.0 -> 2.26.1 ``                                     |
| [`510eb511`](https://github.com/NixOS/nixpkgs/commit/510eb5118acff1546bb0037c6f3168496675e1e8) | `` maintainers: add l0b0 to geospatial team ``                             |
| [`d22b03c7`](https://github.com/NixOS/nixpkgs/commit/d22b03c7bcafc34f93190dbf524b81bf3d6acc0d) | `` refinery-cli: 0.8.13 -> 0.8.14 ``                                       |
| [`373b3756`](https://github.com/NixOS/nixpkgs/commit/373b3756c98e9127e9dbe5b1c2b824650d80cad4) | `` psst: unstable-2024-02-11 -> unstable-2024-04-01 ``                     |
| [`926848d9`](https://github.com/NixOS/nixpkgs/commit/926848d9abf72184182be0159490ecbf9d803acf) | `` python311Packages.types-docutils: format with nixfmt ``                 |
| [`1e98aa3c`](https://github.com/NixOS/nixpkgs/commit/1e98aa3c882dbb7a250e450a29f93ad149afc5ab) | `` kuma: 2.6.3 -> 2.6.4 ``                                                 |
| [`bfa0e69c`](https://github.com/NixOS/nixpkgs/commit/bfa0e69c067b999ccab89fb15ef68d3dcff92dbf) | `` amphetype: fix qt wrapping ``                                           |
| [`c3ee3341`](https://github.com/NixOS/nixpkgs/commit/c3ee3341fb446da5e2d3b989cf5482a5de75082c) | `` git-town: 13.0.1 -> 13.0.2 ``                                           |
| [`f0667a3c`](https://github.com/NixOS/nixpkgs/commit/f0667a3c0258b1bcc76d820b6cf1919b4b9ff2ad) | `` nezha-agent: 0.16.3 -> 0.16.4 ``                                        |
| [`076464c9`](https://github.com/NixOS/nixpkgs/commit/076464c9e8828016d181cfa286feb8ee6820bcfa) | `` amazon-qldb-shell: mark as broken ``                                    |
| [`12fddfdb`](https://github.com/NixOS/nixpkgs/commit/12fddfdb3dc4d6cec323679e38e164b4d13859ea) | `` typesense: 0.25.2 -> 26.0 ``                                            |
| [`48e2c126`](https://github.com/NixOS/nixpkgs/commit/48e2c126fdbb76e9cffde265a25787b82172d3e7) | `` python311Packages.types-docutils: 0.20.0.20240331 -> 0.20.0.20240406 `` |
| [`4c77dcf4`](https://github.com/NixOS/nixpkgs/commit/4c77dcf4c2efa23b0e30dda84f28ef3f8b26452f) | `` squeezelite: 2.0.0.1476 -> 2.0.0.1481 ``                                |
| [`6e7791ee`](https://github.com/NixOS/nixpkgs/commit/6e7791eec9ce0c7c02881b4b1cf6eed927efd4ee) | `` netbird: 0.26.6 -> 0.27.1 ``                                            |
| [`d7884c9d`](https://github.com/NixOS/nixpkgs/commit/d7884c9d9d2010c5f4ae0ceb7040c78fd17f963c) | `` weaviate: 1.24.6 -> 1.24.7 ``                                           |
| [`065e6c9f`](https://github.com/NixOS/nixpkgs/commit/065e6c9f2b294d02893c4074c71679961d4544e9) | `` zincsearch: fix build ``                                                |
| [`f60032a9`](https://github.com/NixOS/nixpkgs/commit/f60032a9ac4ee068d1ef70a013bf7fbad2ac1aa1) | `` btrfs-assistant: 1.9 -> 2.0 ``                                          |
| [`54b40341`](https://github.com/NixOS/nixpkgs/commit/54b40341d5fc73849144cc7717d3bce950ab7dff) | `` unconvert: fix build ``                                                 |
| [`a1c577fb`](https://github.com/NixOS/nixpkgs/commit/a1c577fba9279bb9a666bfb16ddbffd76d1e1b80) | `` zoekt: fix build ``                                                     |
| [`6dadffaf`](https://github.com/NixOS/nixpkgs/commit/6dadffaf61ace970dc32d63378ec1291e69355b5) | `` ungit: 1.5.25 -> 1.5.26 ``                                              |
| [`59eb5bd7`](https://github.com/NixOS/nixpkgs/commit/59eb5bd7ac2447e1efc64ec539b7608e529781e7) | `` topicctl: 1.14.2 -> 1.16.0 ``                                           |
| [`e8e7d70d`](https://github.com/NixOS/nixpkgs/commit/e8e7d70dca9066ac7e6e83285d027edadebc5968) | `` python312Packages.oras: 0.1.28 -> 0.1.29 ``                             |
| [`c94f55eb`](https://github.com/NixOS/nixpkgs/commit/c94f55eb481bd59fa8c0a2ed9fda7db06773ae44) | `` python312Packages.moderngl-window: 2.4.5 -> 2.4.6 ``                    |