### PR TITLE
chore(flake/nixos-hardware): `f3b95962` -> `1e3b3a35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1712324865,
-        "narHash": "sha256-+BatEWd4HlMeK7Ora+gYIkarjxFVCg9oKrIeybHIIX4=",
+        "lastModified": 1712566108,
+        "narHash": "sha256-c9nT2ZODGqobISP41kUwCQ84Srwg7a/1TmPFQuol2/8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f3b959627bca46a9f7052b8fbc464b8323e68c2c",
+        "rev": "1e3b3a35b7083f4152f5a516798cf9b21e686465",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`218ab789`](https://github.com/NixOS/nixos-hardware/commit/218ab789fdabbed9a755539b1520a9c628e153ce) | `` milkv/pioneer: fix u-root cross-compilation `` |
| [`f4a07223`](https://github.com/NixOS/nixos-hardware/commit/f4a07223a336f966eb6546b42eadfd288c4c5e2e) | `` milkv/pioneer: init ``                         |