### PR TITLE
chore(flake/nixos-hardware): `05aa46a1` -> `805adee8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -526,11 +526,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1712695607,
-        "narHash": "sha256-rXb3onsPMiv00FrGSpIJyYa8x53W0dlbJ5Ka3xvje/c=",
+        "lastModified": 1712739139,
+        "narHash": "sha256-I8fw3ot29H9TXClIJHmPfQXaq2dEXHs2VmZeMEw7sb4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "05aa46a1f3b5ac92bfe84807868ba9670d48b031",
+        "rev": "805adee81c82efbe50cac7398c4de05769488ed9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`805adee8`](https://github.com/NixOS/nixos-hardware/commit/805adee81c82efbe50cac7398c4de05769488ed9) | `` Add Lenovo legion 16ARHA7 (#906) `` |