### PR TITLE
chore(flake/home-manager): `8fdf3295` -> `630a0992`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713019815,
-        "narHash": "sha256-jzTo97VeKMNfnKw3xU+uiU5C7wtnLudsbwl/nwPLC7s=",
+        "lastModified": 1713077896,
+        "narHash": "sha256-Noot8H0EZEAFRQWyGxh9ryvhK96xpIqKbh78X447JWs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8fdf329526f06886b53b94ddf433848a0d142984",
+        "rev": "630a0992b3627c64e34f179fab68e3d48c6991c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`630a0992`](https://github.com/nix-community/home-manager/commit/630a0992b3627c64e34f179fab68e3d48c6991c0) | `` nushell: fix nushell config path on darwin `` |
| [`4cc3c916`](https://github.com/nix-community/home-manager/commit/4cc3c91601b6083c3715516d5d891fa46c679e59) | `` flake.lock: Update ``                         |
| [`f33d5086`](https://github.com/nix-community/home-manager/commit/f33d5086d3f9128aba126135ea2a901c121ebf06) | `` rio: remove redundant `lib.mdDoc` call ``     |