### PR TITLE
chore(flake/lanzaboote): `1197e51e` -> `850f2732`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -467,11 +467,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1713192402,
-        "narHash": "sha256-M2rleMvDJyhJEDWMcwhJNAuNFtvZhN3vadve7x2KiOk=",
+        "lastModified": 1713369831,
+        "narHash": "sha256-G4OGxvlIIjphpkxcRAkf1QInYsAeqbfNh6Yl1JLy2uM=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "1197e51e8f57135349bed4de791d8bab7f8cc150",
+        "rev": "850f27322239f8cfa56b122cc9a278ab99a49015",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                |
| --------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`0f252af9`](https://github.com/nix-community/lanzaboote/commit/0f252af9b8fe196c90d5680c84ce3bc81a333b4b) | `` fix: remove deprecated lib.mdDoc `` |