### PR TITLE
chore(flake/home-manager): `fa8c16e2` -> `f46814ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713294767,
-        "narHash": "sha256-LmaabaQZdx52MPGKPRt9Opoc9Gd9RbwvCdysUUYQoXI=",
+        "lastModified": 1713391096,
+        "narHash": "sha256-5xkzsy+ILgQlmvDDipL5xqAehnjWBenAQXV4/NLg2dE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fa8c16e2452bf092ac76f09ee1fb1e9f7d0796e7",
+        "rev": "f46814ec7cbef9c2aef18ca1cbe89f2bb1e8c394",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`f46814ec`](https://github.com/nix-community/home-manager/commit/f46814ec7cbef9c2aef18ca1cbe89f2bb1e8c394) | `` treewide: prefer the official wiki `` |
| [`93b917d4`](https://github.com/nix-community/home-manager/commit/93b917d49f0b2ab75ff91e17573e112b95fdd95c) | `` flake.lock: Update ``                 |