### PR TITLE
chore(flake/stylix): `83866ed8` -> `b36fb34a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -661,11 +661,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713025302,
-        "narHash": "sha256-za4w2wYt1fg9EdTv5fYLwEqAyHgPmPq88HmlxirXuEk=",
+        "lastModified": 1713427823,
+        "narHash": "sha256-ehqlyBoNi66fptxAEzV/p1uCd16ExxO+n77S/uIMG7o=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "83866ed8800ed39519a79ea30b18c8eb21f26080",
+        "rev": "b36fb34a9c8fb728c7efe5dbbb222bb23dcaa967",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                    |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`b36fb34a`](https://github.com/danth/stylix/commit/b36fb34a9c8fb728c7efe5dbbb222bb23dcaa967) | `` stylix: add testbeds for desktop environments (#320) `` |