### PR TITLE
chore(flake/home-manager): `178e2689` -> `ff1c3646`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713453913,
-        "narHash": "sha256-vbXq52VRlL1defMHrwhsoeHm95O3mFefsSSJyNEghbA=",
+        "lastModified": 1713479280,
+        "narHash": "sha256-e8+ZgayVccw6h8ay15jM9hXh+sjZDc1XdBGLn3pdYdc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "178e26895b3aef028a00a32fb7e7ed0fc660645c",
+        "rev": "ff1c3646541316258b1ca64e9b25d4c9cca8e587",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`54e35e0e`](https://github.com/nix-community/home-manager/commit/54e35e0e1c1b6b4888c34423335a448ab3ec78d5) | `` qt: use warnings API ``             |
| [`be2b1761`](https://github.com/nix-community/home-manager/commit/be2b17615c536c31d0ea4989a959298b115353b3) | `` qt: fix adwaita decorations link `` |
| [`b31019d6`](https://github.com/nix-community/home-manager/commit/b31019d64f9ddd1a869fa8fdb371c32c7ed9b578) | `` qt: add adwaita platform theme ``   |
| [`7cebe921`](https://github.com/nix-community/home-manager/commit/7cebe921eaffd5f9880f0dab7a23789d15f6169b) | `` Update translation files ``         |