### PR TITLE
chore(flake/home-manager): `8ff7bb3f` -> `b1a5b3d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713519169,
-        "narHash": "sha256-tfZMYmny9B5vDaDWaeelhbs7rVZ23cvX+JKDYxpUjbY=",
+        "lastModified": 1713524465,
+        "narHash": "sha256-T1ZUTzBv5QHjus49MpKk/KJ8LEyJI1g+2NhwUhRT6bY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8ff7bb3f4d82a05a52d5242ec454bba14f5d6cc6",
+        "rev": "b1a5b3d6a524c80c7dd20888bff227d52adf5f03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`b1a5b3d6`](https://github.com/nix-community/home-manager/commit/b1a5b3d6a524c80c7dd20888bff227d52adf5f03) | `` vdirsyncer: set `postHook` to null when not set (#5294) `` |
| [`b62cad68`](https://github.com/nix-community/home-manager/commit/b62cad68b754224caec1e3b0dbadf86821b0b255) | `` spotify-player: add module ``                              |
| [`b5b2b1ac`](https://github.com/nix-community/home-manager/commit/b5b2b1ac63458357e205bcb2df2d0840a2acca13) | `` helix: add ignores option ``                               |