### PR TITLE
chore(flake/nixos-hardware): `6f976e53` -> `5d48925b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -526,11 +526,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1713441075,
-        "narHash": "sha256-3GGeFsEO8ivD+TcDEqe4s/d0VLvMYGNDGtx0ZnBxkUs=",
+        "lastModified": 1713521961,
+        "narHash": "sha256-EwR8wW9AqJhSIY+0oxWRybUZ32BVKuZ9bjlRh8SJvQ8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "6f976e53752e5b9ab08f9a3b1b0b9c67815c9754",
+        "rev": "5d48925b815fd202781bfae8fb6f45c07112fdb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                       |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`5d48925b`](https://github.com/NixOS/nixos-hardware/commit/5d48925b815fd202781bfae8fb6f45c07112fdb2) | `` Removed commented dpi settings ``          |
| [`3638bc8f`](https://github.com/NixOS/nixos-hardware/commit/3638bc8fab3de21e116909423f289feb4950a0c8) | `` Redirected users to the fwupd wiki page `` |
| [`6f1e7c42`](https://github.com/NixOS/nixos-hardware/commit/6f1e7c42376cbc14c6a3d46e8471e58d36b8c5c7) | `` added framework 16 ``                      |