### PR TITLE
chore(flake/home-manager): `938357cb` -> `7c61e400`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713547559,
-        "narHash": "sha256-zju60y4pyYQoRmqhbgkw+jwmKZReVsCNvb8mZxID2Do=",
+        "lastModified": 1713547570,
+        "narHash": "sha256-i8tNz47Lfsq5QWFLyE3rIm0gs2UUvXXAxfWTC24e370=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "938357cb234e85da37109df2cdd9cc59ab9c1cc0",
+        "rev": "7c61e400a99f33cdff3118c1e4032bcb049e1a30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`7c61e400`](https://github.com/nix-community/home-manager/commit/7c61e400a99f33cdff3118c1e4032bcb049e1a30) | `` Translate using Weblate (Turkish) ``    |
| [`991f6faf`](https://github.com/nix-community/home-manager/commit/991f6fafce729e6d7d64107a66e445114194b778) | `` Translate using Weblate (Portuguese) `` |
| [`5682ccdc`](https://github.com/nix-community/home-manager/commit/5682ccdcaf72aef74be97e4b683545a9de27c386) | `` Translate using Weblate (Spanish) ``    |