### PR TITLE
chore(flake/home-manager): `7c61e400` -> `057117a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713547570,
-        "narHash": "sha256-i8tNz47Lfsq5QWFLyE3rIm0gs2UUvXXAxfWTC24e370=",
+        "lastModified": 1713566308,
+        "narHash": "sha256-7Y91t8pheIzjJveUMAPyeh5NOq5F49Nq4Hl2532QpJs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7c61e400a99f33cdff3118c1e4032bcb049e1a30",
+        "rev": "057117a401a34259c9615ce62218aea7afdee4d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                      |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`057117a4`](https://github.com/nix-community/home-manager/commit/057117a401a34259c9615ce62218aea7afdee4d3) | `` kdeconnect: fix "tray.target" requires `` |
| [`a2040822`](https://github.com/nix-community/home-manager/commit/a20408227466032a16e73893b09a67092258cf67) | `` firefox: fix test ``                      |
| [`3a435342`](https://github.com/nix-community/home-manager/commit/3a435342e2e5e2bff1d3331c2bd9e70f25693ea2) | `` sway: check config file validity ``       |
| [`95888b15`](https://github.com/nix-community/home-manager/commit/95888b153c24c36971c4b4b66beecf32593064fb) | `` sway: writeText -> writeTextFile ``       |