### PR TITLE
chore(flake/stylix): `b36fb34a` -> `5749cf16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -661,11 +661,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713427823,
-        "narHash": "sha256-ehqlyBoNi66fptxAEzV/p1uCd16ExxO+n77S/uIMG7o=",
+        "lastModified": 1713618874,
+        "narHash": "sha256-IKQ1DFfaQheiAndQofQg1Q94+FAp8DV2C+ihGEa5zeA=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "b36fb34a9c8fb728c7efe5dbbb222bb23dcaa967",
+        "rev": "5749cf162340b230e86fa75571b3cb6ce7f11441",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                            |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`5749cf16`](https://github.com/danth/stylix/commit/5749cf162340b230e86fa75571b3cb6ce7f11441) | `` nixos-icons: `white.svg` -> `nix-snowflake-white.svg` (#343) `` |