### PR TITLE
chore(flake/nix-index-database): `93aed672` -> `be659309`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -511,11 +511,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713067146,
-        "narHash": "sha256-9D20xjblGKEVRVCnM3qWhiizEa9i6OpK6xQJajwcwOQ=",
+        "lastModified": 1713668239,
+        "narHash": "sha256-1DM/COYAUYR6IL8UHbimyHrK5lyvZUCaU4lGT7K2Raw=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "93aed67288be60c9ef6133ba2f8de128f4ef265c",
+        "rev": "be6593097ad7635defd5e08560cf9952b75f0046",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                  |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`be659309`](https://github.com/nix-community/nix-index-database/commit/be6593097ad7635defd5e08560cf9952b75f0046) | `` flake.lock: Update `` |