### PR TITLE
chore(flake/nix-index-database): `be659309` -> `07ece11b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -511,11 +511,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713668239,
-        "narHash": "sha256-1DM/COYAUYR6IL8UHbimyHrK5lyvZUCaU4lGT7K2Raw=",
+        "lastModified": 1713668931,
+        "narHash": "sha256-rVlwWQlgFGGK3aPVcKmtYqWgjYnPah5FOIsYAqrMN2w=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "be6593097ad7635defd5e08560cf9952b75f0046",
+        "rev": "07ece11b22217b8459df589f858e92212b74f1a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`07ece11b`](https://github.com/nix-community/nix-index-database/commit/07ece11b22217b8459df589f858e92212b74f1a1) | `` update packages.nix to release 2024-04-21-030753 `` |