### PR TITLE
chore(flake/home-manager): `4cec20db` -> `ad83c154`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713682182,
-        "narHash": "sha256-2RSqVmQMFmn6OjQ21SXnWC+HuSeqDLWLftRv/ZhEDZE=",
+        "lastModified": 1713707619,
+        "narHash": "sha256-g73hSx1osp8G7pbFQbiz7OCosAogf0WrLSOWyEF+F9M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4cec20dbf5c0a716115745ae32531e34816ecbbe",
+        "rev": "ad83c154bdfedad9807e86dd0633729ea3b116c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                      |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`ad83c154`](https://github.com/nix-community/home-manager/commit/ad83c154bdfedad9807e86dd0633729ea3b116c5) | `` qt: fix `qt.platformTheme = "gtk3"` ``    |
| [`147b5a5e`](https://github.com/nix-community/home-manager/commit/147b5a5e1c04e1f27e30b6df720966422fb4bc09) | `` qt: fix platform theme package install `` |