### PR TITLE
chore(flake/git-hooks): `40e6053e` -> `2ac4dcbf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -360,11 +360,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712897695,
-        "narHash": "sha256-nMirxrGteNAl9sWiOhoN5tIHyjBbVi5e2tgZUgZlK3Y=",
+        "lastModified": 1713775815,
+        "narHash": "sha256-Wu9cdYTnGQQwtT20QQMg7jzkANKQjwBD9iccfGKkfls=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "40e6053ecb65fcbf12863338a6dcefb3f55f1bf8",
+        "rev": "2ac4dcbf55ed43f3be0bae15e181f08a57af24a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                       |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`f0dcdc1b`](https://github.com/cachix/git-hooks.nix/commit/f0dcdc1b204360250028d6496e265a73049b0e14) | `` Update modules/hooks.nix ``                                                |
| [`f3a2deee`](https://github.com/cachix/git-hooks.nix/commit/f3a2deee819fe462affd678758c969ec4516923e) | `` Remove packageOverrides from the base hook module ``                       |
| [`c4e3cd4c`](https://github.com/cachix/git-hooks.nix/commit/c4e3cd4ca89d60be6c6e9b7338e9e3442266000b) | `` Add Flake Checker ``                                                       |
| [`bc5491d5`](https://github.com/cachix/git-hooks.nix/commit/bc5491d571291052763e34dde78155f59f70e0eb) | `` `config` -> `config.settings` ``                                           |
| [`00a90e7b`](https://github.com/cachix/git-hooks.nix/commit/00a90e7bbaffeeecc05a1c8ba814d9edeec84701) | `` Add `extraPackages` for `clippy`, `rustfmt`, `dune-fmt` ``                 |
| [`dc1ffda6`](https://github.com/cachix/git-hooks.nix/commit/dc1ffda6986db8c2ef49e361a1dfb0e800f51083) | `` Add `extraPackages` option for packages propagated to `enabledPackages` `` |