### PR TITLE
chore(flake/home-manager): `46833c31` -> `e2e7ea9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713789879,
-        "narHash": "sha256-4Wt3Bg6uOnvwZcECBZaFEdzlWRlGLgd8DqLL4ugLdxg=",
+        "lastModified": 1713799279,
+        "narHash": "sha256-Ybnv/zl3Ovj3Bmy9iSPTnrmrQFCMoYWwWxF2Dssj/zU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "46833c3115e8858370880d892748f0927d8193c3",
+        "rev": "e2e7ea9b8f3de1e6a09f4fc512eae75f6e413a10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`e2e7ea9b`](https://github.com/nix-community/home-manager/commit/e2e7ea9b8f3de1e6a09f4fc512eae75f6e413a10) | `` kconfig: fix missing quoting ``      |
| [`2ad154bd`](https://github.com/nix-community/home-manager/commit/2ad154bd1be2441ac8c624704587734dddb9f41a) | `` Translate using Weblate (Swedish) `` |