### PR TITLE
chore(flake/nixos-hardware): `5d48925b` -> `797f8d80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -493,11 +493,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1713521961,
-        "narHash": "sha256-EwR8wW9AqJhSIY+0oxWRybUZ32BVKuZ9bjlRh8SJvQ8=",
+        "lastModified": 1713864415,
+        "narHash": "sha256-/BPDMJEkrsFAFOsQWhwm31wezlgshPFlLBn34KEUdVA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "5d48925b815fd202781bfae8fb6f45c07112fdb2",
+        "rev": "797f8d8082c7cc3259cba7275c699d4991b09ecc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`797f8d80`](https://github.com/NixOS/nixos-hardware/commit/797f8d8082c7cc3259cba7275c699d4991b09ecc) | `` TUXEDO Pulse 14 Gen3: init `` |
| [`c056352c`](https://github.com/NixOS/nixos-hardware/commit/c056352c4c63f8b9707ebf4f8a8fcc1d5b7950a8) | `` fix mergify configuration ``  |