### PR TITLE
chore(flake/home-manager): `67de98ae` -> `bfa7c064`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713818326,
-        "narHash": "sha256-aw3xbVPJauLk/bbrlakIYxKpeuMWzA2feGrkIpIuXd8=",
+        "lastModified": 1713906585,
+        "narHash": "sha256-fv84DCOkBtjF6wMATt0rfovu7e95L8rdEkSfNbwKR3U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "67de98ae6eed5ad6f91b1142356d71a87ba97f21",
+        "rev": "bfa7c06436771e3a0c666ccc6ee01e815d4c33aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`bfa7c064`](https://github.com/nix-community/home-manager/commit/bfa7c06436771e3a0c666ccc6ee01e815d4c33aa) | `` swayosd: add custom style option ``                |
| [`33a20182`](https://github.com/nix-community/home-manager/commit/33a20182e3164f451b6a4ac2ecadcab5c2c36703) | `` home-manager: improve session variables comment `` |