### PR TITLE
chore(flake/git-hooks): `2ac4dcbf` -> `6fb82e44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713775815,
-        "narHash": "sha256-Wu9cdYTnGQQwtT20QQMg7jzkANKQjwBD9iccfGKkfls=",
+        "lastModified": 1713954846,
+        "narHash": "sha256-RWFafuSb5nkWGu8dDbW7gVb8FOQOPqmX/9MlxUUDguw=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "2ac4dcbf55ed43f3be0bae15e181f08a57af24a4",
+        "rev": "6fb82e44254d6a0ece014ec423cb62d92435336f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`9052a48b`](https://github.com/cachix/git-hooks.nix/commit/9052a48b2ad895e0cb3d28d874fe1d423566bd54) | `` refactor: move `rec` keyword to minimize formatting impact `` |
| [`bf98b7f1`](https://github.com/cachix/git-hooks.nix/commit/bf98b7f1d0983c091376d5191994d29927d51075) | `` feat: add deprecation warning for `rome` hook ``              |
| [`8f2d990b`](https://github.com/cachix/git-hooks.nix/commit/8f2d990b994d242f53fd725b50ec8ef9a4d8c512) | `` refactor: deprecate `rome` with `mkRenamedOptionModule` ``    |
| [`d2b7a5b4`](https://github.com/cachix/git-hooks.nix/commit/d2b7a5b4b8e1ecfd12cedd2e4a4de01bd5a7b5aa) | `` fix: alias rome to biome without formatting ``                |
| [`ba2d5199`](https://github.com/cachix/git-hooks.nix/commit/ba2d51990f42e4c48e3390d138bb072ac29b5fa9) | `` revert: "fix: alias "rome" to "biome"" ``                     |
| [`59d884a4`](https://github.com/cachix/git-hooks.nix/commit/59d884a4487bbf6347223977463b72e1cd3fb08c) | `` fix(alejandra): one `--exclude` flag per file ``              |
| [`05c3a4ea`](https://github.com/cachix/git-hooks.nix/commit/05c3a4eaf1ac8f564b8c6aae34912996cd7c551b) | `` fix: alias "rome" to "biome" ``                               |
| [`a6538a8d`](https://github.com/cachix/git-hooks.nix/commit/a6538a8d3d4cdde13a5b8d4a11c6db2262703596) | `` feat: create "biome" hook ``                                  |