### PR TITLE
chore(flake/darwin): `9e7c20ff` -> `230a1970`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713543876,
-        "narHash": "sha256-olEWxacm1xZhAtpq+ZkEyQgR4zgfE7ddpNtZNvubi3g=",
+        "lastModified": 1713946171,
+        "narHash": "sha256-lc75rgRQLdp4Dzogv5cfqOg6qYc5Rp83oedF2t0kDp8=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "9e7c20ffd056e406ddd0276ee9d89f09c5e5f4ed",
+        "rev": "230a197063de9287128e2c68a7a4b0cd7d0b50a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                     |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
| [`ec06ea88`](https://github.com/LnL7/nix-darwin/commit/ec06ea883757c6075c61d1426f40719742d51f59) | `` nix-daemon: increase SoftResourceLimits.NumberOfFiles `` |