### PR TITLE
chore(flake/nixpkgs): `66adc1e4` -> `7bb2ccd8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -492,11 +492,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713297878,
-        "narHash": "sha256-hOkzkhLT59wR8VaMbh1ESjtZLbGi+XNaBN6h49SPqEc=",
+        "lastModified": 1714076141,
+        "narHash": "sha256-Drmja/f5MRHZCskS6mvzFqxEaZMeciScCTFxWVLqWEY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "66adc1e47f8784803f2deb6cacd5e07264ec2d5c",
+        "rev": "7bb2ccd8cdc44c91edba16c48d2c8f331fb3d856",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`0fc77d81`](https://github.com/NixOS/nixpkgs/commit/0fc77d811dc3c8a8a35737bf5fd616164d0033ee) | `` vscode-extensions.discloud.discloud: init 2.21.2 ``                           |
| [`b3145763`](https://github.com/NixOS/nixpkgs/commit/b3145763b917cbd9cce55661496c192cdc447902) | `` maintainers: adding asindev ``                                                |
| [`23490fbc`](https://github.com/NixOS/nixpkgs/commit/23490fbc6b26b6d35afbd5c397261073b5e6027e) | `` vintagestory: 1.19.5 -> 1.19.7 ``                                             |
| [`73c3aa5b`](https://github.com/NixOS/nixpkgs/commit/73c3aa5bd09bed5c3d3bf1cf3640917c0ec9220d) | `` coder: fix update script to use highest stable version (#306284) ``           |
| [`20401067`](https://github.com/NixOS/nixpkgs/commit/204010679128c9462eeb68bf38a932789a226aff) | `` klipper: unstable-2024-04-15 -> unstable-2024-04-20 (#306646) ``              |
| [`781b363d`](https://github.com/NixOS/nixpkgs/commit/781b363dec379e9e9119ffe126c44988b860de60) | `` nuclei: 3.2.4 -> 3.2.5 ``                                                     |
| [`189f5df5`](https://github.com/NixOS/nixpkgs/commit/189f5df5cb91e1835a7cd159bb7daaf68e0a3015) | `` jan: 0.4.11 -> 0.4.12 ``                                                      |
| [`e7fa73d6`](https://github.com/NixOS/nixpkgs/commit/e7fa73d6b1bb5505c0e29ae2839e2589961cb1b8) | `` python312Packages.botocore-stubs: 1.34.90 -> 1.34.91 ``                       |
| [`f71af5d4`](https://github.com/NixOS/nixpkgs/commit/f71af5d4d911ac534b4f240201c339ce3c88cde3) | `` python312Packages.boto3-stubs: 1.34.90 -> 1.34.91 ``                          |
| [`5ce4222a`](https://github.com/NixOS/nixpkgs/commit/5ce4222a3a43768a3b37a27f3bcb385ba9a16824) | `` python312Packages.botocore-stubs: 1.34.89 -> 1.34.90 ``                       |
| [`5fa3ba98`](https://github.com/NixOS/nixpkgs/commit/5fa3ba989e6aa0cdab2e1644af3b215f445fdc96) | `` python312Packages.boto3-stubs: 1.34.89 -> 1.34.90 ``                          |
| [`4c51051b`](https://github.com/NixOS/nixpkgs/commit/4c51051b98af8fe432cfb39872c795064d8e4e0f) | `` oh-my-zsh: 2024-04-12 -> 2024-04-23 (#305062) ``                              |
| [`237bf91a`](https://github.com/NixOS/nixpkgs/commit/237bf91a2b82a6a3c84c7813fc762c2157a2fc8b) | `` eksctl: 0.175.0 -> 0.176.0 ``                                                 |
| [`10c1537f`](https://github.com/NixOS/nixpkgs/commit/10c1537fb953afd8969dcb2bf8e639798bfc18d7) | `` bee: 2.0.0 -> 2.0.1 ``                                                        |
| [`14d0b8e5`](https://github.com/NixOS/nixpkgs/commit/14d0b8e5eb7ef3cc562fab22a6de3ace789dd91c) | `` erlang-ls: 0.51.0 -> 0.52.0 ``                                                |
| [`fd20c25f`](https://github.com/NixOS/nixpkgs/commit/fd20c25f9b09313e0372ee82925111593128cc59) | `` pspg: 5.8.4 -> 5.8.5 ``                                                       |
| [`aebbcc12`](https://github.com/NixOS/nixpkgs/commit/aebbcc12e40c3d27cc5d885c6e64463776468d29) | `` snes9x: migrate to by-name ``                                                 |
| [`306c53df`](https://github.com/NixOS/nixpkgs/commit/306c53df2ee02531f13804a65195eecc9c60f7ff) | `` snes9x: 1.62.3 -> 1.62.3-unstable-2024-04-22 ``                               |
| [`0b3e707f`](https://github.com/NixOS/nixpkgs/commit/0b3e707fb3d347ce99f90cec5205c53164959b8e) | `` supabase-cli: 1.162.6 -> 1.163.4 ``                                           |
| [`1e80d764`](https://github.com/NixOS/nixpkgs/commit/1e80d764301da0a8d80a180f6e5b24e17b4254fd) | `` python311Packages.llama-parse: 0.4.1 -> 0.4.2 ``                              |
| [`11c14b16`](https://github.com/NixOS/nixpkgs/commit/11c14b16da8eaa21e3d5caa56ff289e8edc2c83c) | `` python311Packages.litellm: 1.35.15 -> 1.35.26 ``                              |
| [`16285077`](https://github.com/NixOS/nixpkgs/commit/16285077726def7236527e3d3118f87ecf254c50) | `` mongosh: 2.2.4 -> 2.2.5 ``                                                    |
| [`88651b11`](https://github.com/NixOS/nixpkgs/commit/88651b11190915e973d8ca9cd7cd7f7440d576e5) | `` maintainers: xgwq change email and add key ``                                 |
| [`caf54e37`](https://github.com/NixOS/nixpkgs/commit/caf54e3774aa244aa8355cd7ae1b4b53b3679d94) | `` htb-toolkit: unstable-2024-01-17 -> 0-unstable-2024-04-22 ``                  |
| [`8f2e1c0a`](https://github.com/NixOS/nixpkgs/commit/8f2e1c0a52af3a95806d1678d287e1b9b0837ded) | `` python311Packages.sshfs: 2023.10.0 -> 2024.4.1 ``                             |
| [`b4d35e27`](https://github.com/NixOS/nixpkgs/commit/b4d35e2746f8a306151fd9f99b9e75bafc878437) | `` rifiuti: init at 20040505_1 ``                                                |
| [`f5ffe147`](https://github.com/NixOS/nixpkgs/commit/f5ffe147c8779f61be0290949c9ee35327e9e983) | `` mac-robber: init at 1.02 ``                                                   |
| [`73f6e499`](https://github.com/NixOS/nixpkgs/commit/73f6e499a3bd0b406654991d21992686b6e9d17d) | `` kubelogin: 0.1.2 -> 0.1.3 ``                                                  |
| [`f3d8eed0`](https://github.com/NixOS/nixpkgs/commit/f3d8eed045b13ea5e317ea8ab0c42e3e86a8914c) | `` laudanum: init at 1.0-unstable-2017-12-15 ``                                  |
| [`e4a57fcb`](https://github.com/NixOS/nixpkgs/commit/e4a57fcbe0d0426cab84901428e85f71942dd8cb) | `` hb-honeypot: init at 0-unstable-2024-02-13 ``                                 |
| [`1d1f7440`](https://github.com/NixOS/nixpkgs/commit/1d1f74402ae08349d5a821c8b9897600aaf831ef) | `` brave: 1.65.114 -> 1.65.122 ``                                                |
| [`6b83feeb`](https://github.com/NixOS/nixpkgs/commit/6b83feebdf3aca0843a46f4cdb97e826699f1f2c) | `` gigalixir: 1.12.0 -> 1.12.1 ``                                                |
| [`966f79be`](https://github.com/NixOS/nixpkgs/commit/966f79bea66d16694316885ba5407a22e1c7bead) | `` pkgsMusl.ostree: fix build ``                                                 |
| [`f044a8cd`](https://github.com/NixOS/nixpkgs/commit/f044a8cde2d5c01d36e3a9cf63a48824a89461b5) | `` maltego: apply review comments from maltego init PR ``                        |
| [`c6395ee0`](https://github.com/NixOS/nixpkgs/commit/c6395ee0f3b3c628cf959e4267338207e3137674) | `` python311Packages.vt-py: 0.18.1 -> 0.18.2 ``                                  |
| [`470a0888`](https://github.com/NixOS/nixpkgs/commit/470a0888fc2648d6d0103143eddbedbbc6275d46) | `` pkgsMusl.patchutils_0_4_2: fix build ``                                       |
| [`8c1fa131`](https://github.com/NixOS/nixpkgs/commit/8c1fa13170395d810ca0858786b96f917c741cf8) | `` bundletool: 1.15.6 -> 1.16.0 ``                                               |
| [`7c611d24`](https://github.com/NixOS/nixpkgs/commit/7c611d248cba506c4af23c511bc7bfd6bfd7577f) | `` python311Packages.craft-application: refactor ``                              |
| [`eca2675d`](https://github.com/NixOS/nixpkgs/commit/eca2675dba160f38e07877a718f08bc21a0c316e) | `` python311Packages.id: format with nixfmt ``                                   |
| [`1727612f`](https://github.com/NixOS/nixpkgs/commit/1727612fcbc2e3a9cc73620967a3290f714ab4ce) | `` python311Packages.id: refactor ``                                             |
| [`93c62e38`](https://github.com/NixOS/nixpkgs/commit/93c62e38b952005f792767178171f8a259f8818b) | `` python311Packages.meross-iot: format with nixfmt ``                           |
| [`4c7c3bbf`](https://github.com/NixOS/nixpkgs/commit/4c7c3bbfa1a7ef0fb21ad1836240c8e6a9864b46) | `` python311Packages.meross-iot: refactor ``                                     |
| [`3fef7c09`](https://github.com/NixOS/nixpkgs/commit/3fef7c093dd2930a7dfa2ec591458d6aa7ab4e90) | `` wiremock: 3.5.3 -> 3.5.4 ``                                                   |
| [`54e547ff`](https://github.com/NixOS/nixpkgs/commit/54e547ff5df2f457b0a0962acb1679a55fba6bcf) | `` nixos/singularity: format using nixfmt (Nix RFC 166) ``                       |
| [`7b62cf00`](https://github.com/NixOS/nixpkgs/commit/7b62cf00cb1d04388a25da98bde829cc010a16e5) | `` apptainer, singularity: avoid list absorption when appended by two more ++ `` |
| [`39db1c03`](https://github.com/NixOS/nixpkgs/commit/39db1c03ef2ff50a8fb33e60b444be3ab1fef22a) | `` apptainer, singularity: format Nix expression with nixfmt ``                  |
| [`770818b7`](https://github.com/NixOS/nixpkgs/commit/770818b715de2fe20a8d6a03ea572ffda4998b74) | `` singhularity: add comment to defaultToSuid ``                                 |
| [`5dd187f3`](https://github.com/NixOS/nixpkgs/commit/5dd187f3b7967b6942273fd25d8bc261de5129ff) | `` mediamtx: 1.7.0 -> 1.8.0 ``                                                   |
| [`78b67db7`](https://github.com/NixOS/nixpkgs/commit/78b67db73c5bb221880a9de31a5f2fe7895ad675) | `` gitlab-container-registry: 3.92.0 -> 3.93.0 ``                                |
| [`3aa3e255`](https://github.com/NixOS/nixpkgs/commit/3aa3e255bc1923412b2a9f29285ee37dfc8fd656) | `` gitlab: 16.10.3 -> 16.10.4 ``                                                 |
| [`5e950c58`](https://github.com/NixOS/nixpkgs/commit/5e950c58ad15eeddd867ac344e55b521890c5b4f) | `` garnet: 1.0.1 -> 1.0.5 ``                                                     |
| [`6a6985eb`](https://github.com/NixOS/nixpkgs/commit/6a6985ebf5c844e157cf497170e0de336bf8123b) | `` python311Packages.types-redis: 4.6.0.20240417 -> 4.6.0.20240425 ``            |
| [`a2169b8f`](https://github.com/NixOS/nixpkgs/commit/a2169b8f59fca53738c49d9dbc206dbdec302378) | `` python311Packages.id: 1.3.0 -> 1.4.0 ``                                       |
| [`54e8d70d`](https://github.com/NixOS/nixpkgs/commit/54e8d70db7626d6fd1cb554efe8845de01c5be52) | `` python311Packages.meross-iot: 0.4.6.2 -> 0.4.7.0 ``                           |
| [`cc9362ac`](https://github.com/NixOS/nixpkgs/commit/cc9362acebb8dda1ff4f9136bfdd0bea4ae99591) | `` gamescope: 3.14.4 -> 3.14.6 ``                                                |
| [`ae8ede5a`](https://github.com/NixOS/nixpkgs/commit/ae8ede5a9739f7ab3850f3898cf0c89e4b681cfa) | `` losslesscut-bin.x86_64-appimage: fix overriding ``                            |
| [`484782e7`](https://github.com/NixOS/nixpkgs/commit/484782e7f4314190d18c73d9f69d6a9b98e61303) | `` apptainer: rearrange dependencies ``                                          |
| [`4b84fdd7`](https://github.com/NixOS/nixpkgs/commit/4b84fdd7677384051dde81f5670a5249912a661e) | `` regal: init at 0.21.0 ``                                                      |
| [`74b865e2`](https://github.com/NixOS/nixpkgs/commit/74b865e2e216a1b4485d3caf7a2146991bcbfaf8) | `` maintainers: add rinx ``                                                      |
| [`92b8ed4a`](https://github.com/NixOS/nixpkgs/commit/92b8ed4ab347b26be005795a88454f7d687868ef) | `` sickgear: 3.30.17 -> 3.30.18 ``                                               |
| [`3b609eb8`](https://github.com/NixOS/nixpkgs/commit/3b609eb81963d86a6815700b36b28d96facc3ffa) | `` twitch-tui: 2.6.6 -> 2.6.7 ``                                                 |
| [`a6225470`](https://github.com/NixOS/nixpkgs/commit/a622547006e760c4ecc0971589df0123a4d66e36) | `` speedtest-go: 1.6.10 -> 1.6.11 ``                                             |
| [`147c7754`](https://github.com/NixOS/nixpkgs/commit/147c7754001e3037091fc7fef381dbe63284ea05) | `` typos: 1.20.9 -> 1.20.10 ``                                                   |
| [`4793074c`](https://github.com/NixOS/nixpkgs/commit/4793074c8e6f1e8aed2cbc4c7f872c80b0349042) | `` python311Packages.flake8-bugbear: 24.2.6 -> 24.4.21 ``                        |
| [`6421226a`](https://github.com/NixOS/nixpkgs/commit/6421226aa5a59fa63aa43e8fc6d2d7ca33a26ca8) | `` lib/systems: add microblaze-embedded ``                                       |
| [`ce80359d`](https://github.com/NixOS/nixpkgs/commit/ce80359d9ff0e1578169d7263b2af8482be7c4ad) | `` deviceTree: ensure file symlinks are included in applyOverlays output ``      |
| [`b4a4f4da`](https://github.com/NixOS/nixpkgs/commit/b4a4f4daa2745e99c0fb3cefd301405361f6eccf) | `` pwru: 1.0.5 -> 1.0.6 ``                                                       |
| [`7f1e0b01`](https://github.com/NixOS/nixpkgs/commit/7f1e0b011d0a59b1d9e86cad725648692cc142dd) | `` protonup-qt: 2.9.1 -> 2.9.2 ``                                                |
| [`2f8bd3f4`](https://github.com/NixOS/nixpkgs/commit/2f8bd3f466f2633cd05d45bab39a51a9ff186121) | `` level-zero: 1.16.14 -> 1.16.15 ``                                             |
| [`70e52348`](https://github.com/NixOS/nixpkgs/commit/70e52348e971f8ff97c1e512049141c06917d11f) | `` miru: 5.0.3 -> 5.1.0 ``                                                       |
| [`fecb57b1`](https://github.com/NixOS/nixpkgs/commit/fecb57b15baea2cc4ef047c6579a89d8427cfd65) | `` kubectl-cnpg: 1.22.2 -> 1.23.0 ``                                             |
| [`625eab0d`](https://github.com/NixOS/nixpkgs/commit/625eab0dd36c4fb0d328f3533ba662be87e69f62) | `` earthly: 0.8.8 -> 0.8.9 ``                                                    |
| [`2c54f461`](https://github.com/NixOS/nixpkgs/commit/2c54f4613b1ba74d704df5134283ab7e26d2f561) | `` extism-cli: 1.2.0 -> 1.3.0 ``                                                 |
| [`183cf1d7`](https://github.com/NixOS/nixpkgs/commit/183cf1d79de01cf70be8c3a13e81a41b9ec4cb93) | `` codeql: 2.17.0 -> 2.17.1 ``                                                   |
| [`acaca2a3`](https://github.com/NixOS/nixpkgs/commit/acaca2a34735eab3c535cfa78f76c0f1b270f96b) | `` cyberchef: 10.17.0 -> 10.18.3 ``                                              |
| [`76897400`](https://github.com/NixOS/nixpkgs/commit/7689740036c970ccbdbefdbf26345c4750f3f8d0) | `` allure: 2.28.0 -> 2.29.0 ``                                                   |
| [`8acf2281`](https://github.com/NixOS/nixpkgs/commit/8acf2281cf61b50dc6cfcfec221dc51a32a6e848) | `` codux: 15.23.1 -> 15.25.0 ``                                                  |
| [`bc1a8d57`](https://github.com/NixOS/nixpkgs/commit/bc1a8d57988cb99fd9fd235cf8573021cdbbf720) | `` cassowary: 0.16.0 -> 0.17.0 ``                                                |
| [`7c219aea`](https://github.com/NixOS/nixpkgs/commit/7c219aea662aab2e6ee3d37b4e3f641c8a088ce9) | `` nelua: unstable-2024-02-03 -> unstable-2024-04-20 ``                          |
| [`921527b8`](https://github.com/NixOS/nixpkgs/commit/921527b8658e1e319d40d6adf4f473343a738f64) | `` terraform: 1.8.1 -> 1.8.2 ``                                                  |
| [`19d43941`](https://github.com/NixOS/nixpkgs/commit/19d439419d7e92789b12933463a2df31c0784c71) | `` fcitx5-anthy: 5.1.3 -> 5.1.4 ``                                               |
| [`8611d11d`](https://github.com/NixOS/nixpkgs/commit/8611d11d2c95e0997559821ad495ffe948c9b448) | `` fcitx5-rime: 5.1.5 -> 5.1.6 ``                                                |
| [`0bdb251b`](https://github.com/NixOS/nixpkgs/commit/0bdb251b435a4dd58eda8fb8b824c622d5c5b086) | `` fcitx5-unikey: 5.1.3 -> 5.1.4 ``                                              |
| [`b604c630`](https://github.com/NixOS/nixpkgs/commit/b604c630941f90d2c6ab0b1b1ce56ea8934356f8) | `` fcitx5-table-other: 5.1.1 -> 5.1.2 ``                                         |
| [`aadd93bd`](https://github.com/NixOS/nixpkgs/commit/aadd93bd5ce205a10a974c6544a847071105c6b6) | `` fcitx5-table-extra: 5.1.4 -> 5.1.5 ``                                         |
| [`57ae43bd`](https://github.com/NixOS/nixpkgs/commit/57ae43bdcaffa12a56d386e48a15b80616479dc1) | `` fcitx5-skk: 5.1.2 -> 5.1.3 ``                                                 |