### PR TITLE
chore(flake/home-manager): `bfa7c064` -> `0c5704ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713906585,
-        "narHash": "sha256-fv84DCOkBtjF6wMATt0rfovu7e95L8rdEkSfNbwKR3U=",
+        "lastModified": 1714042918,
+        "narHash": "sha256-4AItZA3EQIiSNAxliuYEJumw/LaVfrMv84gYyrs0r3U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bfa7c06436771e3a0c666ccc6ee01e815d4c33aa",
+        "rev": "0c5704eceefcb7bb238a958f532a86e3b59d76db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`0c5704ec`](https://github.com/nix-community/home-manager/commit/0c5704eceefcb7bb238a958f532a86e3b59d76db) | `` home-manager: make newsReadIdsFile more reliable ``       |
| [`6864ca2d`](https://github.com/nix-community/home-manager/commit/6864ca2d2657d57a041110dcaf8be0c4b71346c0) | `` Add translation using Weblate (Icelandic) ``              |
| [`3ebcff8d`](https://github.com/nix-community/home-manager/commit/3ebcff8d1219c9e0fb3c880ef7959feca7ea2c4a) | `` Translate using Weblate (Icelandic) ``                    |
| [`4c157f84`](https://github.com/nix-community/home-manager/commit/4c157f84e8fbd6a0fd1688b458c6ce04d047a165) | `` flake.lock: Update ``                                     |
| [`2f072c12`](https://github.com/nix-community/home-manager/commit/2f072c127c041eec36621b8e38a531fe0fe07961) | `` zsh: use correct autosuggestion color variable (#5320) `` |