### PR TITLE
chore(flake/nixos-hardware): `9821d2c5` -> `53db5e10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -493,11 +493,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1714201004,
-        "narHash": "sha256-YkghzeQv3KzDOIpUv0Dh+A5ZNIIvgoNEP2CbN8gHAsU=",
+        "lastModified": 1714201532,
+        "narHash": "sha256-nk0W4rH7xYdDeS7k1SqqNtBaNrcgIBYNmOVc8P2puEY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9821d2c5438edbb567190377bcec4b640ad100c6",
+        "rev": "53db5e1070d07e750030bf65f1b9963df8f0c678",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`53db5e10`](https://github.com/NixOS/nixos-hardware/commit/53db5e1070d07e750030bf65f1b9963df8f0c678) | `` protectli/vp4670: add Super I/O kernel module `` |