### PR TITLE
chore(flake/home-manager): `c1609d58` -> `02002a08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -385,11 +385,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714203603,
-        "narHash": "sha256-eT7DENhYy7EPLOqHI9zkIMD9RvMCXcqh6gGqOK5BWYQ=",
+        "lastModified": 1714337029,
+        "narHash": "sha256-VCy6XjpojlzgmYuHewdxUYExS3olKjY9WNdM5uXUvAw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c1609d584a6b5e9e6a02010f51bd368cb4782f8e",
+        "rev": "02002a08b489b43e3ac1400609a9bf1b7c08e384",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`02002a08`](https://github.com/nix-community/home-manager/commit/02002a08b489b43e3ac1400609a9bf1b7c08e384) | `` flake.lock: Update `` |
| [`d1980931`](https://github.com/nix-community/home-manager/commit/d1980931de8252b6ac1104b7191fd68bbbe3a291) | `` psd: add module ``    |