### PR TITLE
chore(flake/home-manager): `2af7c78b` -> `b8d81ef1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -385,11 +385,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714377222,
-        "narHash": "sha256-UsDsjWCKlWn8vbXi8Zza9Hkq3xyk8fpvFNo2VM5S74E=",
+        "lastModified": 1714413357,
+        "narHash": "sha256-3lBvLp8aSfjlpRt0RZO9VExGh9qMPic+zE4rlshn9Zo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2af7c78b7bb9cf18406a193eba13ef9f99388f49",
+        "rev": "b8d81ef15ed8ec4c72ffc610279d39aa0c4ccbf0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                          |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`b8d81ef1`](https://github.com/nix-community/home-manager/commit/b8d81ef15ed8ec4c72ffc610279d39aa0c4ccbf0) | `` mpv: add extraInput option `` |