### PR TITLE
chore(flake/home-manager): `b8d81ef1` -> `1a91cb7c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -385,11 +385,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714413357,
-        "narHash": "sha256-3lBvLp8aSfjlpRt0RZO9VExGh9qMPic+zE4rlshn9Zo=",
+        "lastModified": 1714427694,
+        "narHash": "sha256-0yiXQ4vvkgsmyS5VDRcnqQVeOdFval4YsFsSiO4Zkyk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b8d81ef15ed8ec4c72ffc610279d39aa0c4ccbf0",
+        "rev": "1a91cb7cdbcf6b18c27bbead57241baf279d4513",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`1a91cb7c`](https://github.com/nix-community/home-manager/commit/1a91cb7cdbcf6b18c27bbead57241baf279d4513) | `` neomutt: allow binds to override vimKeys ``      |
| [`7ec0ae18`](https://github.com/nix-community/home-manager/commit/7ec0ae18cda5e3aae80996d35f6d0ebd418f1ac8) | `` Translate using Weblate (Japanese) ``            |
| [`ba97ffcf`](https://github.com/nix-community/home-manager/commit/ba97ffcfb2bd3ef026bb0a14d8808e9926f57fd7) | `` Translate using Weblate (French) ``              |
| [`08d3cbfe`](https://github.com/nix-community/home-manager/commit/08d3cbfe4d400dad74e54815127fd67c76608a55) | `` firefox: update extensions option description `` |