### PR TITLE
chore(flake/home-manager): `1a91cb7c` -> `f8e6694e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -385,11 +385,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714427694,
-        "narHash": "sha256-0yiXQ4vvkgsmyS5VDRcnqQVeOdFval4YsFsSiO4Zkyk=",
+        "lastModified": 1714430505,
+        "narHash": "sha256-SSJQ/KOy8uISnoZgqDoRha7g7PFLSFP/BtMWm0wUz8Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1a91cb7cdbcf6b18c27bbead57241baf279d4513",
+        "rev": "f8e6694edabe4aaa7a85aac47b43ea5d978b116d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`f8e6694e`](https://github.com/nix-community/home-manager/commit/f8e6694edabe4aaa7a85aac47b43ea5d978b116d) | `` files: make collision error message more helpful `` |
| [`56326598`](https://github.com/nix-community/home-manager/commit/563265988637c27ba3abe39acb9be3ba2cb35a29) | `` swaync: add module ``                               |
| [`0125041f`](https://github.com/nix-community/home-manager/commit/0125041fc9ca3127fe95cf53f15c49c482ebaf70) | `` maintainers: add abayomi185 as maintainer ``        |
| [`4fe1f064`](https://github.com/nix-community/home-manager/commit/4fe1f064bd1a37754266eb4c190eac784ca4aaa9) | `` hyprland: use lib.generators.toHyprconf ``          |
| [`9fdd301a`](https://github.com/nix-community/home-manager/commit/9fdd301a5e4d8cf4d4cf3f990e799000a54a3737) | `` lib/generators: toHyprconf init ``                  |