### PR TITLE
chore(flake/git-hooks): `6fb82e44` -> `2849da03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -327,11 +327,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713954846,
-        "narHash": "sha256-RWFafuSb5nkWGu8dDbW7gVb8FOQOPqmX/9MlxUUDguw=",
+        "lastModified": 1714478972,
+        "narHash": "sha256-q//cgb52vv81uOuwz1LaXElp3XAe1TqrABXODAEF6Sk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "6fb82e44254d6a0ece014ec423cb62d92435336f",
+        "rev": "2849da033884f54822af194400f8dff435ada242",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                             |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`091eaa3a`](https://github.com/cachix/git-hooks.nix/commit/091eaa3a4130a2d447901e4f14a2b0f061fcd90e) | `` Fix and document lacheck hook `` |