### PR TITLE
chore(flake/stylix): `0fe277a3` -> `43d23b16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -626,11 +626,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713821140,
-        "narHash": "sha256-/kGc9R01h8mTmZKhrVyGWaK/w9zgettmHIE3GZW8Khs=",
+        "lastModified": 1714555012,
+        "narHash": "sha256-WVUrm3TGVj6c8g5aG20OjJRHMvUtAZjpHQgukDhyOT8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "0fe277a3641a849478a94c7900c2d5a90609a306",
+        "rev": "43d23b1609b87f6a4100db2a09bd118c52c78766",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                              |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`43d23b16`](https://github.com/danth/stylix/commit/43d23b1609b87f6a4100db2a09bd118c52c78766) | `` bat: use config instead of env variable (#353) `` |