### PR TITLE
chore(flake/nixpkgs): `58a1abdb` -> `63c3a29c`

### DIFF
--- a/core/nix.nix
+++ b/core/nix.nix
@@ -1,6 +1,6 @@
 { hostType, lib, pkgs, ... }: {
   nix = {
-    package = pkgs.nixVersions.unstable;
+    package = pkgs.nixVersions.latest;
     settings = {
       accept-flake-config = true;
       # XXX: Causes annoying "cannot link ... to ...: File exists" errors on Darwin

--- a/flake.lock
+++ b/flake.lock
@@ -508,11 +508,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714253743,
-        "narHash": "sha256-mdTQw2XlariysyScCv2tTE45QSU9v/ezLcHJ22f0Nxc=",
+        "lastModified": 1714635257,
+        "narHash": "sha256-4cPymbty65RvF1DWQfc+Bc8B233A1BWxJnNULJKQ1EY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "58a1abdbae3217ca6b702f03d3b35125d88a2994",
+        "rev": "63c3a29ca82437c87573e4c6919b09a24ea61b0f",
         "type": "github"
       },
       "original": {

--- a/hosts/poincare/default.nix
+++ b/hosts/poincare/default.nix
@@ -29,7 +29,7 @@
         imports = [ ../../core/nix.nix ];
         _module.args.hostType = "nixos";
         virtualisation.host.pkgs = lib.mkForce (pkgs.extend (final: _: {
-          nix = final.nixVersions.unstable;
+          nix = final.nixVersions.latest;
         }));
       };
       maxJobs = 4;

--- a/nix/overlays/nix-latest.nix
+++ b/nix/overlays/nix-latest.nix
@@ -1,10 +1,10 @@
 final: prev:
 let
-  useUnstableNixFor = name:
-    { inherit name; value = prev.${name}.override { nix = final.nixVersions.unstable; }; };
-  useUnstableNix = names: builtins.listToAttrs (map useUnstableNixFor names);
+  useLatestNixFor = name:
+    { inherit name; value = prev.${name}.override { nix = final.nixVersions.latest; }; };
+  useLatestNix = names: builtins.listToAttrs (map useLatestNixFor names);
 in
-(useUnstableNix [
+(useLatestNix [
   "agenix"
   "nix-direnv"
   "nix-update"
@@ -12,7 +12,7 @@ in
 ]) // {
   # Workaround for electron depending on nix-prefetch-git at build-time via
   # prefetch-yarn-deps
-  nix-prefetch-git = prev.nix-prefetch-git.override { nix = final.nixVersions.unstable; };
+  nix-prefetch-git = prev.nix-prefetch-git.override { nix = final.nixVersions.latest; };
   nix-prefetch-git-stable = prev.nix-prefetch-git;
   prefetch-yarn-deps = prev.prefetch-yarn-deps.override { nix-prefetch-git = final.nix-prefetch-git-stable; };
 }


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`a1de57d6`](https://github.com/NixOS/nixpkgs/commit/a1de57d6fc1c292db47c2b0debf404d46dd6dc49) | `` nixos/all-tests: skip hibernate test for now ``                                      |
| [`f674b11e`](https://github.com/NixOS/nixpkgs/commit/f674b11e2a834f6413599731ff13a0821e11d6ab) | `` eza: 0.18.13 -> 0.18.14 ``                                                           |
| [`3a4c43db`](https://github.com/NixOS/nixpkgs/commit/3a4c43dbede05919c06df378f3d9b4b49ee5fe3e) | `` lttng-tools: 2.13.12 -> 2.13.13 ``                                                   |
| [`a48ef698`](https://github.com/NixOS/nixpkgs/commit/a48ef6982463206c95a07cdc4e3fc583e9ec5358) | `` emacs.pkgs.tree-sitter-langs: use stdenv.hostPlatform for sharedLibrary suffix ``    |
| [`3fff8ab2`](https://github.com/NixOS/nixpkgs/commit/3fff8ab27814f6c61072dd430364b720e3d40024) | `` nixVersions.latest: 2.21 -> 2.22 ``                                                  |
| [`8b7526b5`](https://github.com/NixOS/nixpkgs/commit/8b7526b5a47e07be824530018fceb651e89cb500) | `` mongoc: 1.26.2 -> 1.27.0 ``                                                          |
| [`1b35b3b6`](https://github.com/NixOS/nixpkgs/commit/1b35b3b6dc55c4f4b07702d1d385cbbadabfb061) | `` firefoxpwa: 2.11.1 -> 2.12.0 ``                                                      |
| [`85dfe83a`](https://github.com/NixOS/nixpkgs/commit/85dfe83a86658f3fba80c050a774195f08fb378d) | `` chromium: lower version range of `--ozone-platform-hint` patch ``                    |
| [`e04c4fc3`](https://github.com/NixOS/nixpkgs/commit/e04c4fc35049fa4486786df72cc503a6d92113a6) | `` python312Packages.pygame: unbreak with patch from upstream ``                        |
| [`a9bcf119`](https://github.com/NixOS/nixpkgs/commit/a9bcf1196ed1f0ee8bd0bca9ee7ae5123f530907) | `` act: 0.2.61 -> 0.2.62 ``                                                             |
| [`ad40b65f`](https://github.com/NixOS/nixpkgs/commit/ad40b65fd5b5c1bd8553f36c5947933765b5a27e) | `` python312Packages.sanix: init at 1.0.6 ``                                            |
| [`781f3d03`](https://github.com/NixOS/nixpkgs/commit/781f3d03d4cbccd5681f9f32c0790fe7c3fb65c3) | `` backblaze-b2: 3.18.0 -> 3.19.1 ``                                                    |
| [`98595738`](https://github.com/NixOS/nixpkgs/commit/9859573850b157dfd9f546c21e8e4314ad1050c3) | `` python3Packages.b2sdk: 2.0.0 -> 2.1.0 ``                                             |
| [`f4d376bb`](https://github.com/NixOS/nixpkgs/commit/f4d376bb4b9e8a974d70227809c84ccd322b115e) | `` quickgui: add quickemu to PATH ``                                                    |
| [`f1bf42d3`](https://github.com/NixOS/nixpkgs/commit/f1bf42d3f0ccd2f7e46187d4cd1f2fae8e62bb2e) | `` python312Packages.upb-lib: 0.5.4 -> 0.5.6 ``                                         |
| [`32a64614`](https://github.com/NixOS/nixpkgs/commit/32a6461448016cf20777aef5e49003522b2f1eb8) | `` usbimager: fix usbimager.desktop ``                                                  |
| [`b1c73868`](https://github.com/NixOS/nixpkgs/commit/b1c73868f1cdc8e455b1168dd54cf5694baa1ea4) | `` vscode-extensions.vue.vscode-typescript-vue-plugin: init 1.8.27 ``                   |
| [`b0b6fb6b`](https://github.com/NixOS/nixpkgs/commit/b0b6fb6b7aeb29aba444ea886d764655a2aebbae) | `` vscode-extensions.vue.volar: init 2.0.16 ``                                          |
| [`9580a22e`](https://github.com/NixOS/nixpkgs/commit/9580a22e28254f86922d15e7a779294aa3f640c8) | `` haproxy: 2.9.6 -> 2.9.7 (#307729) ``                                                 |
| [`a16ec6ba`](https://github.com/NixOS/nixpkgs/commit/a16ec6bad3f3205b769b9a1f0556ca73a2ba933d) | `` last: 1542 -> 1543 (#307730) ``                                                      |
| [`42c40d11`](https://github.com/NixOS/nixpkgs/commit/42c40d11806db2e24df77f6de29e4f2549a0dc8f) | `` kdePackages.mlt: 7.22.0 -> 7.24.0 (#307747) ``                                       |
| [`8b35a7cd`](https://github.com/NixOS/nixpkgs/commit/8b35a7cd1898de5f9a91b84e3122ce65f4c0dabe) | `` nixos/logrotate: typo in option name fixed (#307788) ``                              |
| [`b71eeb5b`](https://github.com/NixOS/nixpkgs/commit/b71eeb5b2d7a3c7aed0cb089bfad25b23cc008fc) | `` chromium: 124.0.6367.91 -> 124.0.6367.118 ``                                         |
| [`afbb7ba8`](https://github.com/NixOS/nixpkgs/commit/afbb7ba885cc133bc684deb9ab524890432d42a2) | `` flyctl: remove nested with from meta ``                                              |
| [`dcee79f8`](https://github.com/NixOS/nixpkgs/commit/dcee79f8e4259cba0adcd45f1d5fe5865375e04d) | `` libilbm: init at 0-unstable-2024-03-02 ``                                            |
| [`8fd0eefe`](https://github.com/NixOS/nixpkgs/commit/8fd0eefee3d4b4f77e7c43d9622cfc40ba10a98a) | `` libiff: init at 0-unstable-2024-03-02 ``                                             |
| [`3a0b4dff`](https://github.com/NixOS/nixpkgs/commit/3a0b4dffecc0a853e09d892e25d075fb0fedafda) | `` typesense: fix platforms attribute ``                                                |
| [`eaa057d2`](https://github.com/NixOS/nixpkgs/commit/eaa057d26874f84a92fa5df99e4815a9fac705ee) | `` typesense: add darwin support ``                                                     |
| [`13b3715c`](https://github.com/NixOS/nixpkgs/commit/13b3715cfbf5ff565355a8b6ef3ca0bed6779b23) | `` flyctl: 0.2.40 -> 0.2.46 ``                                                          |
| [`14662093`](https://github.com/NixOS/nixpkgs/commit/146620937748f5a7bf75c2678a5e4b50842d56f6) | `` ghciwatch: init at 0.5.10 ``                                                         |
| [`0ec04f5d`](https://github.com/NixOS/nixpkgs/commit/0ec04f5d0e43fea617332cc1b54b45c804ab83e5) | `` spaceship-prompt: 4.15.1 -> 4.15.2 ``                                                |
| [`c326dd2a`](https://github.com/NixOS/nixpkgs/commit/c326dd2aa8b230c988861b3978a134104d5d5e5a) | `` qpwgraph: 0.6.3 -> 0.7.1 ``                                                          |
| [`b40da1f0`](https://github.com/NixOS/nixpkgs/commit/b40da1f02add8ad329cb03cb51a72c386ab78f21) | `` vscode-extensions.reditorsupport.r: init 2.8.2 ``                                    |
| [`780ac74e`](https://github.com/NixOS/nixpkgs/commit/780ac74e4a8af8ff01139e5c213b75028e4cfac0) | `` python311Packages.spyder: 5.5.3 -> 5.5.4 ``                                          |
| [`7c8441a7`](https://github.com/NixOS/nixpkgs/commit/7c8441a712637ee2dc08219984308786ace6830c) | `` zed-editor: 0.132.4 -> 0.133.5 ``                                                    |
| [`75e2fd31`](https://github.com/NixOS/nixpkgs/commit/75e2fd312f557af2ee86538f9f79d815505a11dd) | `` python311Packages.milksnake: fix regex for python 3.11 ``                            |
| [`86814057`](https://github.com/NixOS/nixpkgs/commit/86814057f1fced54a6d4d57b640fdec8b7c6c364) | `` maintainers: add pandapip1 ``                                                        |
| [`8dbcc044`](https://github.com/NixOS/nixpkgs/commit/8dbcc044ac7e0a1f5329b1db923c93a783271867) | `` python312Packages.flynt: 0.66 -> 1.0.1 ``                                            |
| [`ea035e69`](https://github.com/NixOS/nixpkgs/commit/ea035e69642621cb3faf3930fcb4be164cd9cb6f) | `` vdrPlugins.softhddevice: 2.1.2 -> 2.2.0 ``                                           |
| [`90a3fb8f`](https://github.com/NixOS/nixpkgs/commit/90a3fb8ffe8016ca526af27eec904d14742aa5dd) | `` doc/release-notes: next batch of release note cleanups (#308279) ``                  |
| [`d58224e9`](https://github.com/NixOS/nixpkgs/commit/d58224e9a13c43ebe3a97c0d134dffac01e11049) | `` texlab: 5.15.0 -> 5.16.0 ``                                                          |
| [`b4df506a`](https://github.com/NixOS/nixpkgs/commit/b4df506a486a8ef2072129ec2cd44e548c041e4b) | `` nixos/openrazer: add additional battery notifier options (#273761) ``                |
| [`a586e82e`](https://github.com/NixOS/nixpkgs/commit/a586e82ef6c96b1425810550a43cfa4c1c947307) | `` nixos/nginx: don't add .well-known locations for acme when using DNS-01 challenge `` |
| [`33b24b30`](https://github.com/NixOS/nixpkgs/commit/33b24b308f6adad73e8f1df68cc9d481cab7d295) | `` planify: 4.6 -> 4.7 ``                                                               |
| [`1e7f2da6`](https://github.com/NixOS/nixpkgs/commit/1e7f2da6b00e81a3808f348d57879155d5a748ab) | `` mpvScripts.videoclip: init at 0-unstable-2024-03-08 (#269272) ``                     |
| [`e654c8fd`](https://github.com/NixOS/nixpkgs/commit/e654c8fd67583a1cfdc9b2f69493776781009d57) | `` nixos/vault: change type and default of devRootTokenID ``                            |
| [`53566504`](https://github.com/NixOS/nixpkgs/commit/535665044a867d63f9c7ed000a7a6fded9be8052) | `` github-runner: 2.315.0 -> 2.316.0 ``                                                 |
| [`3d2e9539`](https://github.com/NixOS/nixpkgs/commit/3d2e953979a83c933b0dc538fbca8db2737db7a3) | `` mpvScripts.mpv-slicing: add `updateScript` ``                                        |
| [`65a1a7c8`](https://github.com/NixOS/nixpkgs/commit/65a1a7c8f66528ff2f905445fa326e6c97f52f06) | `` python312Packages.langsmith: 0.1.51 -> 0.1.52 ``                                     |
| [`4b587803`](https://github.com/NixOS/nixpkgs/commit/4b5878033b857ac9528e37af9059ef3babd973d8) | `` mpvScripts.mpv-cheatsheet: add `updateScript` ``                                     |
| [`1fa0b7a8`](https://github.com/NixOS/nixpkgs/commit/1fa0b7a8f3f16dcc5cdb4c0f7ff85938033353aa) | `` python312Packages.langchain-community: 0.0.34 -> 0.0.36 ``                           |
| [`440bc6d3`](https://github.com/NixOS/nixpkgs/commit/440bc6d35926674b9196c5908e30f17b403264b7) | `` python312Packages.langchain-core: 0.1.46 -> 0.1.48 ``                                |
| [`66bc7f27`](https://github.com/NixOS/nixpkgs/commit/66bc7f27f1ebeb19ce69084df3f223e210b338d5) | `` gitlab-runner: 16.10.0 -> 16.11.0 ``                                                 |
| [`211cb102`](https://github.com/NixOS/nixpkgs/commit/211cb102a2f64355396dfeae4e16ac9a37ba5b03) | `` mpvScript.mpv-slicing: init at 0-unstable-2017-11-25 (#254415) ``                    |
| [`fce6f0dc`](https://github.com/NixOS/nixpkgs/commit/fce6f0dc7ec940795e075dceb7d55bc46b31e09c) | `` vscode-extensions.RoweWilsonFrederiskHolme.wikitext 3.8.0 -> 3.8.1 ``                |
| [`39646320`](https://github.com/NixOS/nixpkgs/commit/3964632056e638f1c3f8432e9efa1211e60f368e) | `` remind: 04.03.04 -> 04.03.07 ``                                                      |
| [`736c6be4`](https://github.com/NixOS/nixpkgs/commit/736c6be4623428ec0813243a7eaaeb3c269a9f73) | `` treewide: Move away from wiki.gnome.org ``                                           |
| [`ce6be556`](https://github.com/NixOS/nixpkgs/commit/ce6be556c684e56f7c105f9baf61e4ddd6ebf64f) | `` vouch-proxy: 0.39.0 -> 0.40.0 ``                                                     |
| [`e7806dbf`](https://github.com/NixOS/nixpkgs/commit/e7806dbfb2508b175addd315bf063f6f935febae) | `` signal-desktop-beta: 7.6.0-beta.3 -> 7.7.0-beta.1 ``                                 |
| [`bd91a0d4`](https://github.com/NixOS/nixpkgs/commit/bd91a0d4ddd7c60d788275364c49e2bc3e86bc8e) | `` maintainers: rename ayes-web -> BatteredBunny ``                                     |
| [`a6a01f8c`](https://github.com/NixOS/nixpkgs/commit/a6a01f8c995e6b59ace2e84de263d67ef74f696f) | `` pkgs/gnome: Move away from wiki.gnome.org ``                                         |
| [`afde4332`](https://github.com/NixOS/nixpkgs/commit/afde4332c323da699b4b2ea7aa60afcd30f19f24) | `` root: don't do anything specific for Python 2 ``                                     |
| [`ebce8ace`](https://github.com/NixOS/nixpkgs/commit/ebce8ace41c8ca0d1776de4c5be5c815fb2fb5f7) | `` maintainers: add guitargeek ``                                                       |
| [`5a5178ee`](https://github.com/NixOS/nixpkgs/commit/5a5178ee0d06c246d9fc997706a79a46d56ee1ab) | `` languagetool: 6.3 -> 6.4 ``                                                          |
| [`e81a95f9`](https://github.com/NixOS/nixpkgs/commit/e81a95f9802660ae4d47a19c96ba79bc3c73d0ff) | `` root: remove the hack that disables the splash screen by default ``                  |
| [`6665f67b`](https://github.com/NixOS/nixpkgs/commit/6665f67b4eef1f0e6ed467c80e86ed10c3553594) | `` root: remove some explicit disabling of compiler warnings on clang ``                |
| [`9792a8be`](https://github.com/NixOS/nixpkgs/commit/9792a8be2b7d63c3fd9161a0762d44ab49f3ca01) | `` root: remove deprecated build flags ``                                               |
| [`5c6453fd`](https://github.com/NixOS/nixpkgs/commit/5c6453fd97d9eb7906fded455c4921347991a6d6) | `` root: 6.30.04 -> 6.30.06 ``                                                          |
| [`e02a4df2`](https://github.com/NixOS/nixpkgs/commit/e02a4df2ba6590da2f11daf9ed9eff4c1cd9dc0a) | `` surrealdb: 1.3.1 → 1.4.2 ``                                                          |
| [`ecfbb79e`](https://github.com/NixOS/nixpkgs/commit/ecfbb79ecd5243b703973770065a91f49613ea3e) | `` igv: 2.17.3 -> 2.17.4 ``                                                             |
| [`2a8a6369`](https://github.com/NixOS/nixpkgs/commit/2a8a63690649db0f1a9212004783f1d61a107d4d) | `` qcad: 3.29.4.1 -> 3.29.6.2 ``                                                        |
| [`e7a4b848`](https://github.com/NixOS/nixpkgs/commit/e7a4b848861fedc8229e54c4ac2f034ca1b1a51f) | `` python312Packages.aiortm: 0.8.12 -> 0.8.13 ``                                        |
| [`63f1eccb`](https://github.com/NixOS/nixpkgs/commit/63f1eccb2bcf6ba513f4faa67d2eafc8ccee893b) | `` mariadb-galera: 26.4.17 -> 26.4.18 ``                                                |
| [`e26aa294`](https://github.com/NixOS/nixpkgs/commit/e26aa294d21b9a637c6cf534a8f675df1ddbaa32) | `` libreswan: 4.15 -> 5.0 ``                                                            |
| [`bcd44e22`](https://github.com/NixOS/nixpkgs/commit/bcd44e224fd68ce7d269b4f44d24c2220fd821e7) | `` fzf: 0.50.0 -> 0.51.0 (#308223) ``                                                   |
| [`739126ba`](https://github.com/NixOS/nixpkgs/commit/739126ba09fdc8c994bb758d533f1fae8cf5ad2d) | `` mednafen: 1.29.0 -> 1.32.1 (#308224) ``                                              |
| [`d945ea28`](https://github.com/NixOS/nixpkgs/commit/d945ea28fcc0f915e04c285f2bb11094151f1a92) | `` qsynth: 0.9.13 -> 0.9.90 (#308225) ``                                                |
| [`31867c0f`](https://github.com/NixOS/nixpkgs/commit/31867c0f82d53070dc473d7b6c8e62aebc29426f) | `` mpvScripts.quack: fix info (#308221) ``                                              |
| [`b0dd926e`](https://github.com/NixOS/nixpkgs/commit/b0dd926eec4d076663790002c30c6e7dff3363c2) | `` gtkwave: 3.3.118 -> 3.3.119 ``                                                       |
| [`dba2770f`](https://github.com/NixOS/nixpkgs/commit/dba2770f0d2a68134f5ac20e2dec396f9e9e5964) | `` kdePackages.ktextaddons: 1.5.3 -> 1.5.4 ``                                           |
| [`0b2b5922`](https://github.com/NixOS/nixpkgs/commit/0b2b59220c2156e22781505f8795eb4d26c7375e) | `` matcha-gtk-theme: 2023-10-30 -> 2024-05-01 ``                                        |
| [`1f333e02`](https://github.com/NixOS/nixpkgs/commit/1f333e022551e4e8e9d0415f8cee2af20cba224a) | `` whitesur-gtk-theme: 2024-02-26 -> 2024-05-01 ``                                      |
| [`04f503bb`](https://github.com/NixOS/nixpkgs/commit/04f503bbdda109a894f3999025628b51c357f755) | `` python312Packages.uart-devices: set to linux ``                                      |
| [`23610033`](https://github.com/NixOS/nixpkgs/commit/236100332c3b191d69fbe2da2abcc845a62d75c5) | `` mpvScripts.manga-reader: init at unstable-2024-03-17 (#298932) ``                    |
| [`154eef1e`](https://github.com/NixOS/nixpkgs/commit/154eef1e621907693a18da8b44e6e07bd771ee60) | `` jetty: 12.0.7 -> 12.0.8 ``                                                           |
| [`bebd9af5`](https://github.com/NixOS/nixpkgs/commit/bebd9af58e29ea54e54d8c33fa461fea77982b50) | `` gpt4all: 2.7.3 -> 2.7.4 ``                                                           |