### PR TITLE
chore(flake/nixos-hardware): `3f017311` -> `753176b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -493,11 +493,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1714746424,
-        "narHash": "sha256-Jdyw7VcM+jQ0uSXgjFj8UdXZ229yOvPNlYkKyKyHA4s=",
+        "lastModified": 1714885415,
+        "narHash": "sha256-LG+2IVqVi1fy724rSDAkgqae+f47fGGko4cJhtkN8PE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3f017311191fe6d501ca2496a835d012f656ee9c",
+        "rev": "753176b57b3fcddb140c1c012868e62c025120bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`753176b5`](https://github.com/NixOS/nixos-hardware/commit/753176b57b3fcddb140c1c012868e62c025120bd) | `` Add fingerprint support for Lenovo Legion 16ARHA7 `` |
| [`d623635b`](https://github.com/NixOS/nixos-hardware/commit/d623635bb7d9262c0422af8f74599c6b3cf60180) | `` surface: linux 6.8.6 -> 6.8.9 ``                     |