### PR TITLE
chore(flake/home-manager): `e0825ea2` -> `f69bf670`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -385,11 +385,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714865296,
-        "narHash": "sha256-02r2Qzh4fGYBPB/3Lj8vwPMtE6H/UchZnN7A/dQMHIA=",
+        "lastModified": 1714894674,
+        "narHash": "sha256-2ZTadZuy42JtuvchRLh5HnQ4943Xkc+I5LVGQGPRFbc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e0825ea2112d09d9f0680833cd716f6aee3b973f",
+        "rev": "f69bf670d29d3921e00cc626d174654769d743c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`f69bf670`](https://github.com/nix-community/home-manager/commit/f69bf670d29d3921e00cc626d174654769d743c6) | `` cliphist: add extraOptions option `` |
| [`2a44f4d0`](https://github.com/nix-community/home-manager/commit/2a44f4d09f891d8a9d72b9a7331fa8d94b066119) | `` flake.lock: Update ``                |