### PR TITLE
chore(flake/home-manager): `f69bf670` -> `3dfe05aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -385,11 +385,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714894674,
-        "narHash": "sha256-2ZTadZuy42JtuvchRLh5HnQ4943Xkc+I5LVGQGPRFbc=",
+        "lastModified": 1714931954,
+        "narHash": "sha256-QXpLmgmisNK2Zgpnu9DiO9ScrKJuJ4zmiMTNpObVIuk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f69bf670d29d3921e00cc626d174654769d743c6",
+        "rev": "3dfe05aa9b5646995ace887931fa60269a039777",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`3dfe05aa`](https://github.com/nix-community/home-manager/commit/3dfe05aa9b5646995ace887931fa60269a039777) | `` wlsunset: update options `` |
| [`fdaaf543`](https://github.com/nix-community/home-manager/commit/fdaaf543bad047639ef0b356ea2e6caec2f1215c) | `` hypridle: add module ``     |