### PR TITLE
chore(flake/nixos-hardware): `753176b5` -> `8a4adfe4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -493,11 +493,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1714885415,
-        "narHash": "sha256-LG+2IVqVi1fy724rSDAkgqae+f47fGGko4cJhtkN8PE=",
+        "lastModified": 1714979072,
+        "narHash": "sha256-OfShHRR4QmVwEof1EWuZUygw/SFnmxfHogtCKc4vNRM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "753176b57b3fcddb140c1c012868e62c025120bd",
+        "rev": "8a4adfe48b68b50ef62e9a299898093436269b6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`8a4adfe4`](https://github.com/NixOS/nixos-hardware/commit/8a4adfe48b68b50ef62e9a299898093436269b6d) | `` raspberry-pi/5: don't use overlay ``            |
| [`1d11c108`](https://github.com/NixOS/nixos-hardware/commit/1d11c108000d498af656dfa3ede9ce25839c9948) | `` raspberry-pi/5: add kernel version assertion `` |
| [`11d92d24`](https://github.com/NixOS/nixos-hardware/commit/11d92d24440b390d7d7998a383e4f64daf1fa1c3) | `` raspberry-pi/5: add to flake.nix ``             |
| [`7a7f2ea0`](https://github.com/NixOS/nixos-hardware/commit/7a7f2ea0f2822e59b2910fb2577c78bb6627913e) | `` raspberry-pi/5: add nvme module ``              |
| [`67b97914`](https://github.com/NixOS/nixos-hardware/commit/67b979143d80efef4ab2bff6f247c28f75f975e6) | `` raspberry-pi/5: add xserver configuration ``    |
| [`c4fa85b9`](https://github.com/NixOS/nixos-hardware/commit/c4fa85b9df1b719cc09fa1338f4a6aa61dc7384c) | `` raspberry-pi/5: init ``                         |