### PR TITLE
chore(flake/nixpkgs): `b211b392` -> `f1010e04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -508,11 +508,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715087517,
-        "narHash": "sha256-CLU5Tsg24Ke4+7sH8azHWXKd0CFd4mhLWfhYgUiDBpQ=",
+        "lastModified": 1715266358,
+        "narHash": "sha256-doPgfj+7FFe9rfzWo1siAV2mVCasW+Bh8I1cToAXEE4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b211b392b8486ee79df6cdfb1157ad2133427a29",
+        "rev": "f1010e0469db743d14519a1efd37e23f8513d714",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`29182918`](https://github.com/NixOS/nixpkgs/commit/29182918b105d6743994f2bfdcbdd6a97c963f2a) | `` various: remove eclairevoyant from meta.maintainers ``                    |
| [`e5457f65`](https://github.com/NixOS/nixpkgs/commit/e5457f657bbbc558cd953e4d34239f7dde8601a0) | `` lua51Packages.nfd: feat added postInstallCheck for test ``                |
| [`c4bd61ba`](https://github.com/NixOS/nixpkgs/commit/c4bd61ba34c99e77ac65cc6238559acb3068ba3f) | `` lua51Packages.nfd: fix module not loading ``                              |
| [`ab56210e`](https://github.com/NixOS/nixpkgs/commit/ab56210eb89551807f1b2fbbae06abf11287d4bb) | `` python3Packages.pynetbox: add packaging as dep ``                         |
| [`bdd78d73`](https://github.com/NixOS/nixpkgs/commit/bdd78d731a849d8fdbe6a15625214fc12bad7a76) | `` openvr: 2.2.3 -> 2.5.1 ``                                                 |
| [`5510aae4`](https://github.com/NixOS/nixpkgs/commit/5510aae4c83dda1992d2b6af2870d078123b4894) | `` openvr: add update script ``                                              |
| [`e8f3c743`](https://github.com/NixOS/nixpkgs/commit/e8f3c74367d91b6dc9677c62552e5e6a938968c6) | `` luaPackages.tree-sitter-norg: init at 0.2.4-1 ``                          |
| [`7d5b333d`](https://github.com/NixOS/nixpkgs/commit/7d5b333dcdf12dc51b7df052ca0fe1969d91e7d4) | `` nixos/incus: add support for soft daemon restart ``                       |
| [`01b405c5`](https://github.com/NixOS/nixpkgs/commit/01b405c59d6eba8ecd1b6d02b4558b6a2e8437ee) | `` gitlab-container-registry: 3.93.0 -> 4.1.0 ``                             |
| [`ca8ea04c`](https://github.com/NixOS/nixpkgs/commit/ca8ea04cd4fb325a349abda7619829f6a5f57fc9) | `` gitlab: 16.10.4 -> 16.10.5 ``                                             |
| [`1bbd237c`](https://github.com/NixOS/nixpkgs/commit/1bbd237c04dcc6e2c92ed1986bc508f69a2363ea) | `` python312Packages.homeassistant-stubs: 2024.5.1 -> 2024.5.2 ``            |
| [`3f8ff2f0`](https://github.com/NixOS/nixpkgs/commit/3f8ff2f06b24a379a193f79046c65a744d8776bd) | `` home-assistant: pin sigstore at 1.1.2 ``                                  |
| [`bcd68927`](https://github.com/NixOS/nixpkgs/commit/bcd689277f0de79c60ba75642e00eea3f954aafa) | `` spicedb: 1.31.0 -> 1.32.0 ``                                              |
| [`e72edcd8`](https://github.com/NixOS/nixpkgs/commit/e72edcd85085cd788d797ecd21ef8b8449bf7d74) | `` gitlab-runner: 16.11.0 -> 16.11.1 ``                                      |
| [`06667e02`](https://github.com/NixOS/nixpkgs/commit/06667e028f776b03062a128db4b14b1f4ae92ef5) | `` nixos/portunus: fix dangling service files for dex ``                     |
| [`13472345`](https://github.com/NixOS/nixpkgs/commit/13472345563f49623d0d5f264c81d684dd2b81d2) | `` python312Packages.wktutils: format with nixfmt ``                         |
| [`89367b28`](https://github.com/NixOS/nixpkgs/commit/89367b288689bb4da17a43d8fde71441dd919221) | `` python312Packages.wktutils: refactor ``                                   |
| [`fc92e060`](https://github.com/NixOS/nixpkgs/commit/fc92e0605f62ab34c70953f5330fc1dd8dd4d596) | `` qcad: 3.29.6.2 -> 3.29.6.4 ``                                             |
| [`8baf4267`](https://github.com/NixOS/nixpkgs/commit/8baf42676a6430674a4f38494aea94ba596bb7f3) | `` mindustry: add .desktop category ``                                       |
| [`5caf4b9c`](https://github.com/NixOS/nixpkgs/commit/5caf4b9c39057a8d6df0c2d397032bce552e9769) | `` liquidsoap: add meta.changelog ``                                         |
| [`1a964af2`](https://github.com/NixOS/nixpkgs/commit/1a964af2b298cf68d9a354a99983ca62da69f782) | `` liquidsoap: 2.2.4 -> 2.2.5 ``                                             |
| [`96d18bf7`](https://github.com/NixOS/nixpkgs/commit/96d18bf71b2ecb971b2cbb92559b6ec66e33a26c) | `` python312Packages.json-schema-for-humans: format with nixfmt ``           |
| [`fe6d7b04`](https://github.com/NixOS/nixpkgs/commit/fe6d7b04bd879d782b172e6efbef502a294b9ea0) | `` python312Packages.json-schema-for-humans: refactor ``                     |
| [`6c7320a2`](https://github.com/NixOS/nixpkgs/commit/6c7320a2e2aa5fa216fdab5ff93a70e142491e0e) | `` mtr: add meta.mainProgram ``                                              |
| [`96a608f3`](https://github.com/NixOS/nixpkgs/commit/96a608f3d2f1ae2044cc1b08936ff39df246e6fc) | `` kubescape: format with nixfmt ``                                          |
| [`93f99c29`](https://github.com/NixOS/nixpkgs/commit/93f99c29199aad4d7610639dd6c5fb50fd9291e8) | `` python3Packages.curl-cffi: init at 0.6.3 ``                               |
| [`6786f11a`](https://github.com/NixOS/nixpkgs/commit/6786f11afb32786abab5541b8ce9309f64173c15) | `` curl-impersonate: install headers ``                                      |
| [`7d414b93`](https://github.com/NixOS/nixpkgs/commit/7d414b938fa31580fc3352465eeb2a2fde31f201) | `` tbs: 20231210 -> 20240506 ``                                              |
| [`5de1fb48`](https://github.com/NixOS/nixpkgs/commit/5de1fb484354f877a1714e998986d7f05ac663b2) | `` monkeysAudio: 10.71 -> 10.72 ``                                           |
| [`4e295b64`](https://github.com/NixOS/nixpkgs/commit/4e295b648eb40e76c841aa0e9f0875d2ae73e6a3) | `` cargo-whatfeatures: 0.9.11 -> 0.9.12 ``                                   |
| [`d1467846`](https://github.com/NixOS/nixpkgs/commit/d14678461f9a10586367b4658cdf4b1d94d949de) | `` galene: 0.8.1 -> 0.8.2 ``                                                 |
| [`fac6b8cf`](https://github.com/NixOS/nixpkgs/commit/fac6b8cf3a1b231fb57be8947a3e917f6ca109db) | `` nano: 7.2 -> 8.0 ``                                                       |
| [`c16af617`](https://github.com/NixOS/nixpkgs/commit/c16af617a88662fb702cd26f3556bb267e36ca64) | `` opentofu: 1.7.0 -> 1.7.1 ``                                               |
| [`6a81ed72`](https://github.com/NixOS/nixpkgs/commit/6a81ed72f17b7d3694292086f25a2cef15765040) | `` gh: 2.49.0 -> 2.49.1 ``                                                   |
| [`c3a95d6d`](https://github.com/NixOS/nixpkgs/commit/c3a95d6d5de09b682d63090f13c7f48253fdb0ea) | `` terraform: 1.8.2 -> 1.8.3 ``                                              |
| [`f33d36cf`](https://github.com/NixOS/nixpkgs/commit/f33d36cfc50b7a6578b2c06a7b98f9b7011f978d) | `` flyctl: 0.2.46 -> 0.2.51 ``                                               |
| [`ca5b495b`](https://github.com/NixOS/nixpkgs/commit/ca5b495b3075218380bf7307cf8e6e40a36c29c2) | `` gitu: 0.19.2 -> 0.20.1 ``                                                 |
| [`6db0481e`](https://github.com/NixOS/nixpkgs/commit/6db0481e0e41952a65e4e22fbf71acd6bde73d39) | `` sourcehut: Fix werkzueg patch hash ``                                     |
| [`17e855ae`](https://github.com/NixOS/nixpkgs/commit/17e855ae2494ed0a14e81a8ff21476838ee49a7a) | `` fn-cli: 0.6.32 -> 0.6.33 ``                                               |
| [`b0985f75`](https://github.com/NixOS/nixpkgs/commit/b0985f752f050775491a0e3ec917885cdb0efb25) | `` cpp-utilities: 5.24.7 -> 5.24.8 ``                                        |
| [`f3364d32`](https://github.com/NixOS/nixpkgs/commit/f3364d323d4e7220b09323fa87446c0ce62a7412) | `` python311Packages.mplhep: 0.3.47 -> 0.3.48 ``                             |
| [`91b51a82`](https://github.com/NixOS/nixpkgs/commit/91b51a827a8912de0e224c399eca5015b37c314a) | `` antares: 0.7.23 -> 0.7.24 ``                                              |
| [`e6905b10`](https://github.com/NixOS/nixpkgs/commit/e6905b108aa5f6bf2aa72ef6f7e82ea0a12fc065) | `` pyprland: 2.2.16 -> 2.2.17 ``                                             |
| [`c3bcd140`](https://github.com/NixOS/nixpkgs/commit/c3bcd14096ce642aa52ff39917fd221aba6aad87) | `` vscode-extensions.jackmacwindows.vscode-computercraft: init at 1.1.1 ``   |
| [`27b7517d`](https://github.com/NixOS/nixpkgs/commit/27b7517d8716e231286cbe835d476067c0ab28f9) | `` cargo-tarpaulin: 0.29.0 -> 0.29.2 ``                                      |
| [`344c714c`](https://github.com/NixOS/nixpkgs/commit/344c714c3610f0c3eec800a73c10920e7f989716) | `` tbls: 1.74.1 -> 1.74.3 ``                                                 |
| [`3e97f97e`](https://github.com/NixOS/nixpkgs/commit/3e97f97eddaeb499a49250ff0cee32c4d7fe5b06) | `` mongoc: 1.27.0 -> 1.27.1 ``                                               |
| [`2f04c5f8`](https://github.com/NixOS/nixpkgs/commit/2f04c5f8a3063206c66fa69a346d2776b8074115) | `` linux: always use xz for compressing modules ``                           |
| [`2bd868a1`](https://github.com/NixOS/nixpkgs/commit/2bd868a110fc9caecc32863e1c1f1912928765f8) | `` wails: 2.8.1 -> 2.8.2 ``                                                  |
| [`3dce9266`](https://github.com/NixOS/nixpkgs/commit/3dce926637afa80181c042561fa0956939d65cd1) | `` consul-template: 0.37.5 -> 0.37.6 ``                                      |
| [`68998c80`](https://github.com/NixOS/nixpkgs/commit/68998c804f04d36c2c5abde3c29f3a4ba144449f) | `` sabnzbd: 4.3.0 -> 4.3.1 ``                                                |
| [`4a398361`](https://github.com/NixOS/nixpkgs/commit/4a398361da0161f7ed641f375bcac0cbee9cf88c) | `` kubescape: 3.0.9 -> 3.0.10 ``                                             |
| [`0a95f1e6`](https://github.com/NixOS/nixpkgs/commit/0a95f1e6a72272ba363adf3b1386ed9c90947afd) | `` ols: 0-unstable-2024-04-28 -> 0-unstable-2024-05-06 ``                    |
| [`f9af5a73`](https://github.com/NixOS/nixpkgs/commit/f9af5a734243ee0eb34dfa0d84cdb07d4232cb1b) | `` ungoogled-chromium: 124.0.6367.118-1 -> 124.0.6367.155-1 ``               |
| [`2ce0ea4f`](https://github.com/NixOS/nixpkgs/commit/2ce0ea4f3def048cb12a36e60db87ebd129608ca) | `` python311Packages.openai: 1.23.6 -> 1.27.0 ``                             |
| [`afe1dfbc`](https://github.com/NixOS/nixpkgs/commit/afe1dfbc00b05036d767ec6731b60d72bdb958a2) | `` python311Packages.botorch: 0.10.0 -> 0.11.0 ``                            |
| [`fce49b0d`](https://github.com/NixOS/nixpkgs/commit/fce49b0dfa84bd724ff1a8ae81aa75febd70567b) | `` pcmanfm-qt: support svg icons ``                                          |
| [`fd93e8c0`](https://github.com/NixOS/nixpkgs/commit/fd93e8c04ad83a41f3b64731784c3fe26addbae2) | `` snakemake: 8.11.0 -> 8.11.2 ``                                            |
| [`50c34a30`](https://github.com/NixOS/nixpkgs/commit/50c34a306800c12c440ec97462a12bbdda46a163) | `` libqalculate: 5.1.0 -> 5.1.1 ``                                           |
| [`cf3c73e7`](https://github.com/NixOS/nixpkgs/commit/cf3c73e7776a8359e13fcc20e5c83dfce7202dd1) | `` dmarc-report-converter: 0.7.2 -> 0.8.0 ``                                 |
| [`6b5513c8`](https://github.com/NixOS/nixpkgs/commit/6b5513c812af1269ec123c6651e7ff75c6326847) | `` openlierox: 0.58rc3 -> 0.58_rc5, unbreak, refactor, adopt ``              |
| [`9f9f4ddd`](https://github.com/NixOS/nixpkgs/commit/9f9f4ddd85cdecf92abaff3e2fe0bde1825a3295) | `` python31{1,2}Packages.xarray-dataclasses: relax xarray dep ``             |
| [`3e30a24a`](https://github.com/NixOS/nixpkgs/commit/3e30a24a9b01a8eee71b973e52423f6affe61321) | `` sketchybar-app-font: 2.0.17 -> 2.0.18 ``                                  |
| [`ce7904a8`](https://github.com/NixOS/nixpkgs/commit/ce7904a8e95841034e1260f548bc9da494e92e22) | `` python31{1,2}Packages.shap: 0.45.0 -> 0.45.1 ``                           |
| [`d78764a6`](https://github.com/NixOS/nixpkgs/commit/d78764a623931b10f07a5d6919ab9559a65ffbc3) | `` wasmtime: 20.0.1 -> 20.0.2 ``                                             |
| [`871d98d9`](https://github.com/NixOS/nixpkgs/commit/871d98d964b538474eebc97bcbcc34a5f344cce8) | `` python31{1,2}Packages.mandown,mandown: unbreak -- relax lxml dep ``       |
| [`8aa68474`](https://github.com/NixOS/nixpkgs/commit/8aa68474fc1572ce08fe85af889f637ed0dc64a7) | `` lxqt.lxqt-panel: 2.0.0 -> 2.0.1 ``                                        |
| [`156f07b0`](https://github.com/NixOS/nixpkgs/commit/156f07b05ffb52f547e7c3659acca4d7b7a7f763) | `` python31{1,2}Packages.comicon: unbreak -- relax pypdf dep ``              |
| [`1551b684`](https://github.com/NixOS/nixpkgs/commit/1551b68456345987dd8bf21cf4130f758337614c) | `` lxqt.libfm-qt: 2.0.1 -> 2.0.2 ``                                          |
| [`ffd0198c`](https://github.com/NixOS/nixpkgs/commit/ffd0198c413d41935043cce2fde2305639bb3268) | `` python312Packages.fuzzytm: format with nixfmt ``                          |
| [`a381bb05`](https://github.com/NixOS/nixpkgs/commit/a381bb051228a38f28e18282695bb69c7ddad232) | `` python312Packages.fuzzytm: refactor ``                                    |
| [`9808270a`](https://github.com/NixOS/nixpkgs/commit/9808270ad40be66b92a930e9784aaa523a50eb2d) | `` python312Packages.fuzzytm: 2.0.5 -> 2.0.9 ``                              |
| [`639984a4`](https://github.com/NixOS/nixpkgs/commit/639984a46c36f784d2d1dda611a29bded5cc10d7) | `` python31{1,2}Packages.slicer: unbreak -- remove old patches ``            |
| [`fcab43ac`](https://github.com/NixOS/nixpkgs/commit/fcab43ace79b5cebfc545227ec8cc11e9a1651a7) | `` python312Packages.python-homeassistant-analytics: fix url ``              |
| [`ecd72ef0`](https://github.com/NixOS/nixpkgs/commit/ecd72ef063af793ef86f3e64987af1ee53cbe1d3) | `` python312Packages.pysqlitecipher: fix url ``                              |
| [`1e11f462`](https://github.com/NixOS/nixpkgs/commit/1e11f4625a7535e217ab6039de5bc089c80663b6) | `` python312Packages.dnfile: fix url ``                                      |
| [`17e5c883`](https://github.com/NixOS/nixpkgs/commit/17e5c8831d3cebf4e339d9a17aa2627b983dac95) | `` openrocket: fix url ``                                                    |
| [`6e25c801`](https://github.com/NixOS/nixpkgs/commit/6e25c8015691260d63e5760abfbe385d37e5109c) | `` onlyoffice-documentserver: fix url ``                                     |
| [`e12fbc0b`](https://github.com/NixOS/nixpkgs/commit/e12fbc0bc8d41a80ee3289335ead063d97b4bd45) | `` python312Packages.publicsuffixlist: 0.10.0.20240506 -> 0.10.0.20240508 `` |
| [`53e423ed`](https://github.com/NixOS/nixpkgs/commit/53e423eddb187e4f726c72c4c8a1b8213bc0b8fe) | `` librsvg: fix url ``                                                       |
| [`3af5beb0`](https://github.com/NixOS/nixpkgs/commit/3af5beb0e2bae77b450bc70291353e39ab4a82f8) | `` libasn1c: fix url ``                                                      |
| [`36eae19b`](https://github.com/NixOS/nixpkgs/commit/36eae19b00a92cd043db2e5b52c8b92b303c3a89) | `` python312Packages.pyenphase: 1.20.2 -> 1.20.3 ``                          |
| [`58be3dc4`](https://github.com/NixOS/nixpkgs/commit/58be3dc4d0b56445426703d4831d554855b8cd27) | `` python312Packages.mayavi: mark as broken ``                               |
| [`4832da44`](https://github.com/NixOS/nixpkgs/commit/4832da44cbf493890a654323a5a8d74415267b75) | `` castnow: fix url ``                                                       |
| [`43cc6801`](https://github.com/NixOS/nixpkgs/commit/43cc6801e302748486e5c3fa401e18cf76b7fd7f) | `` python312Packages.rokuecp: format with nixfmt ``                          |
| [`79c39130`](https://github.com/NixOS/nixpkgs/commit/79c39130b2ea815ea7713fac1bc57e260f535fc8) | `` adbtuifm: fix url ``                                                      |
| [`25d02076`](https://github.com/NixOS/nixpkgs/commit/25d0207632ab17b827025d746827793f979a45b4) | `` python312Packages.rokuecp: refactor ``                                    |
| [`5a1cb299`](https://github.com/NixOS/nixpkgs/commit/5a1cb2997c4cbed04c71af35cd8c5e2b7ea3e04c) | `` python312Packages.rokuecp: 0.19.2 -> 0.19.3 ``                            |
| [`a76f3ae0`](https://github.com/NixOS/nixpkgs/commit/a76f3ae05d470b2806a2ad66ca756156b4ed050b) | `` ratslap: make linux-only, use finalAttrs ``                               |
| [`f867fae8`](https://github.com/NixOS/nixpkgs/commit/f867fae833b56df00f6b3f7ec31e9f12dc1ee70e) | `` xml-tooling-c: adopt, migrate to by-name, refactor ``                     |
| [`3fb880f3`](https://github.com/NixOS/nixpkgs/commit/3fb880f337248535fe73eae1564d4d1a634d7b64) | `` syncthing: 1.27.6 -> 1.27.7 ``                                            |
| [`a9dca140`](https://github.com/NixOS/nixpkgs/commit/a9dca1409d65dd0cabd77a9c25f58fcbd6336955) | `` unciv: 4.11.9 -> 4.11.10 ``                                               |
| [`56391351`](https://github.com/NixOS/nixpkgs/commit/56391351b414c73cde0db5642524ec3fa6023fca) | `` home-assistant-custom-component.ntfy: fix typo ``                         |
| [`dfd8445b`](https://github.com/NixOS/nixpkgs/commit/dfd8445b5951c4044aaa1263630306c778d7006c) | `` python311Packages.fpdf2: disable failing tests (#309846) ``               |
| [`2144e155`](https://github.com/NixOS/nixpkgs/commit/2144e15546076c6890ca6f389e5b34cbc190d119) | `` home-assistant-custom-component.ntfy: init at 1.0.2 ``                    |
| [`cb1aaa2a`](https://github.com/NixOS/nixpkgs/commit/cb1aaa2aad731e0b28b0086d57f75c64200a6b72) | `` jwhois: fix darwin build, format, refactor ``                             |
| [`e4e3ee2e`](https://github.com/NixOS/nixpkgs/commit/e4e3ee2e61c02e1571e1ba425d9bec402a5eb574) | `` clight-gui: init at unstable-2023-02-21 (#286973) ``                      |
| [`92e4518b`](https://github.com/NixOS/nixpkgs/commit/92e4518b8c30a0ac855a37b851441d81df90ca87) | `` colobot: apply upstream patch with gcc13 fixes ``                         |
| [`bc72be2e`](https://github.com/NixOS/nixpkgs/commit/bc72be2e10c8df053351ca9c3a4eb4048d300384) | `` Revert "python3Packages.mayavi: disable for python 3.11" ``               |
| [`61803430`](https://github.com/NixOS/nixpkgs/commit/61803430ca414c12073f194e4402b4733def2201) | `` python312Packages.loopy: add missing deps, clean up and adopt ``          |
| [`050435e9`](https://github.com/NixOS/nixpkgs/commit/050435e9aa48133bde2b3b1ce300bcc2f0531dff) | `` python312Packages.islpy: fix build, refactor and adopt ``                 |
| [`5c0b2dc2`](https://github.com/NixOS/nixpkgs/commit/5c0b2dc2e96f082705a3c3dcb3cddee768cea40e) | `` python312Packages.betterproto: increase file descriptor limit ``          |
| [`e9653e7e`](https://github.com/NixOS/nixpkgs/commit/e9653e7e2075c34637075dc7895581757d72ecc3) | `` xml-security-c: fix build on darwin, small clean up ``                    |
| [`e7d0b599`](https://github.com/NixOS/nixpkgs/commit/e7d0b599e1401b1c95c5332e4a43e3b5c0b250fe) | `` xml-security-c: format with nixfmt ``                                     |
| [`8d267125`](https://github.com/NixOS/nixpkgs/commit/8d26712551512a758f5606d852650145839be01f) | `` python311Packages.type-infer: add required dep py3langid ``               |
| [`82cd9ea4`](https://github.com/NixOS/nixpkgs/commit/82cd9ea4846b0472dc574b158afac35014c19372) | `` texpresso: 0-unstable-2024-04-18 -> 0-unstable-2024-04-30 (#308746) ``    |
| [`1ad23e24`](https://github.com/NixOS/nixpkgs/commit/1ad23e2400a38ca5e95b7539ac0a980cc419b3a4) | `` pgadmin: 8.5 -> 8.6 ``                                                    |
| [`43396e55`](https://github.com/NixOS/nixpkgs/commit/43396e552aee214419b3d29b5abe134456de46c8) | `` python311Packages.libgravatar: init at 1.0.4 ``                           |
| [`81dea6df`](https://github.com/NixOS/nixpkgs/commit/81dea6df5c7aa2df54fefba6b76ce44c1b409e92) | `` python3Packages.latex2mathml: refactor ``                                 |
| [`0f15aa9d`](https://github.com/NixOS/nixpkgs/commit/0f15aa9de6eea173135a7b7c908f186ae54882a0) | `` gamescope: 3.14.11 -> 3.14.13 ``                                          |
| [`eaab3424`](https://github.com/NixOS/nixpkgs/commit/eaab3424803f961bd09034ce84880a10805b7af6) | `` dub-to-nix,buildDubPackage: allow git-type dependencies ``                |