### PR TITLE
chore(flake/home-manager): `6e277d95` -> `f61917cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -385,11 +385,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715077503,
-        "narHash": "sha256-AfHQshzLQfUqk/efMtdebHaQHqVntCMjhymQzVFLes0=",
+        "lastModified": 1715337759,
+        "narHash": "sha256-40LDJ1bgnIDHMq9ooNKAe6pg8ukxmecvfrF5yELPrWs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6e277d9566de9976f47228dd8c580b97488734d4",
+        "rev": "f61917cbaa6dba317e757aefd0bbb56403aff2f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                     |
| ----------------------------------------------------------------------------------------------------------- | --------------------------- |
| [`f61917cb`](https://github.com/nix-community/home-manager/commit/f61917cbaa6dba317e757aefd0bbb56403aff2f8) | `` fastfetch: add module `` |