### PR TITLE
chore(flake/home-manager): `4855bfb6` -> `22374331`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -385,11 +385,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715337997,
-        "narHash": "sha256-ve562FlHVa7xhLfkFc1ihg1kuuq55IMfkxAgBQcFUY0=",
+        "lastModified": 1715348159,
+        "narHash": "sha256-nP0PJZ3dR0ols1V+w+sYBki7JlSRFvFJ8J8B00Oa7BM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4855bfb6ce20225a1b0e2aae2379da909ab38350",
+        "rev": "223743313bab8b0b44a57eaf9573de9f69082b4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                     |
| ----------------------------------------------------------------------------------------------------------- | --------------------------- |
| [`22374331`](https://github.com/nix-community/home-manager/commit/223743313bab8b0b44a57eaf9573de9f69082b4d) | `` hyprpaper: add module `` |
| [`c6ddd80f`](https://github.com/nix-community/home-manager/commit/c6ddd80fb1e5a286b3a5cb32ef94a2e4e346a9d3) | `` hyprlock: add module ``  |