### PR TITLE
chore(flake/home-manager): `e6a31590` -> `f2c5ba5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -385,11 +385,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715358385,
-        "narHash": "sha256-/IQ5UheQ2Ehm79nqn8KUuxZo5mk768gZ9uV6lHIKP8s=",
+        "lastModified": 1715359697,
+        "narHash": "sha256-FJYyXqulIbCdsUCTFBTu/bIH4aN+7jzjQAn52Qc6qPg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e6a315900db775da3bb3138bab8caa70dafdaf9e",
+        "rev": "f2c5ba5e720fd584d83f2f97399dac0d26ae60b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                      |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`f2c5ba5e`](https://github.com/nix-community/home-manager/commit/f2c5ba5e720fd584d83f2f97399dac0d26ae60b9) | `` fontconfig: add defaultFonts.* options `` |