### PR TITLE
chore(flake/home-manager): `5514ed32` -> `d7682620`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -385,11 +385,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715376598,
-        "narHash": "sha256-tEg2NA5nrXtnw5pM6RKaCsgYMcNCoiCETXsEeUbHGNQ=",
+        "lastModified": 1715380449,
+        "narHash": "sha256-716+f9Rj3wjSyD1xitCv2FcYbgPz1WIVDj+ZBclH99Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5514ed321087f0b5af42564352d135acad4ff055",
+        "rev": "d7682620185f213df384c363288093b486b2883f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`d7682620`](https://github.com/nix-community/home-manager/commit/d7682620185f213df384c363288093b486b2883f) | `` jujutsu: switch to XDG config home ``                 |
| [`d939ce58`](https://github.com/nix-community/home-manager/commit/d939ce585c611c00ca44145a74acab04c20619ad) | `` mopidy: make scan service depend on `mopidy-local` `` |
| [`15d7ec30`](https://github.com/nix-community/home-manager/commit/15d7ec30511199349c6cf8b6cbdc5e205a6a15e8) | `` darwin: misc defaults (dock, menu clock, finder) ``   |