### PR TITLE
chore(flake/nixpkgs): `f1010e04` -> `062ca2a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -508,11 +508,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715266358,
-        "narHash": "sha256-doPgfj+7FFe9rfzWo1siAV2mVCasW+Bh8I1cToAXEE4=",
+        "lastModified": 1715447595,
+        "narHash": "sha256-VsVAUQOj/cS1LCOmMjAGeRksXIAdPnFIjCQ0XLkCsT0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f1010e0469db743d14519a1efd37e23f8513d714",
+        "rev": "062ca2a9370a27a35c524dc82d540e6e9824b652",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`f8210014`](https://github.com/NixOS/nixpkgs/commit/f8210014c03dbec018d66b3e8d4125900b754196) | `` snakemake: 8.11.2 -> 8.11.3 ``                                                             |
| [`3671a682`](https://github.com/NixOS/nixpkgs/commit/3671a682e950de9ed475d17c435ad164342c8c9d) | `` planify: 4.7 -> 4.7.2 ``                                                                   |
| [`50f296c0`](https://github.com/NixOS/nixpkgs/commit/50f296c0afcafb21fc938c6d72c0b03ef5b4220c) | `` ferm: Fix import-ferm error importing ferm wrapped script instead of perlFile (#310626) `` |
| [`e6cb2ba9`](https://github.com/NixOS/nixpkgs/commit/e6cb2ba900d1d33feec2ae85731263ce4a327c7b) | `` terra: LLVM16 pin ``                                                                       |
| [`0a9fb0a1`](https://github.com/NixOS/nixpkgs/commit/0a9fb0a17d148e0c6d55038d01941f0789dd9f4f) | `` ecdsatool: fix build ``                                                                    |
| [`0be93caf`](https://github.com/NixOS/nixpkgs/commit/0be93cafb796dc5adb9cf8dc5be653fa907b47b7) | `` nrr: 0.9.0 -> 0.9.1 ``                                                                     |
| [`15bdef7b`](https://github.com/NixOS/nixpkgs/commit/15bdef7bfd6b1027ed5b426128ad20ff2be41e34) | `` python312Packages.rq: fix tests on darwin ``                                               |
| [`9039081c`](https://github.com/NixOS/nixpkgs/commit/9039081ce7204c895a27615244fa7df396aad2d2) | `` fishPlugin.fish-git-abbr: init at 0.2.1-unstable-2023-06-19 (#297873) ``                   |
| [`d31f3b7a`](https://github.com/NixOS/nixpkgs/commit/d31f3b7a07a59ac41014d904cbdc42579c2e3d85) | `` alephone-infinity: 20240119 -> 20240510 ``                                                 |
| [`b6e785bf`](https://github.com/NixOS/nixpkgs/commit/b6e785bfad2833d1242a72d40effc9ff75fca864) | `` alephone-durandal: 20240119 -> 20240510 ``                                                 |
| [`2fa3a2b8`](https://github.com/NixOS/nixpkgs/commit/2fa3a2b8ad9c2f31be64c153dae38057132a60cc) | `` alephone-marathon: 20240119 -> 20240510 ``                                                 |
| [`95bc17d7`](https://github.com/NixOS/nixpkgs/commit/95bc17d7b11a73e230ccbcad3a96392a06d741a2) | `` podman-tui: 1.0.0 -> 1.0.1 ``                                                              |
| [`8935a264`](https://github.com/NixOS/nixpkgs/commit/8935a26420f83936e21510a4d46b946f41a57755) | `` panoply: 5.3.4 -> 5.4.0 ``                                                                 |
| [`c1697d1e`](https://github.com/NixOS/nixpkgs/commit/c1697d1e056086b96e898cd53e0cbbae65ba9af3) | `` ueberzugpp: 2.9.4 -> 2.9.5 ``                                                              |
| [`ed432646`](https://github.com/NixOS/nixpkgs/commit/ed43264631fec2a25e8b6ecc85864e487c98b886) | `` gh-markdown-preview: 1.4.2 -> 1.5.0 ``                                                     |
| [`91f0f1cb`](https://github.com/NixOS/nixpkgs/commit/91f0f1cb3f74d992bbb8f505584e492fd479ceb3) | `` halo: 2.15.1 -> 2.15.2 ``                                                                  |
| [`30722f06`](https://github.com/NixOS/nixpkgs/commit/30722f061459fef38d1d5e2b0f39730cc85ad058) | `` git-ps-rs: 7.0.0 -> 7.1.1 ``                                                               |
| [`76cdf716`](https://github.com/NixOS/nixpkgs/commit/76cdf716e13f8b74ce27027aa5a29ebf740bd2e0) | `` libretro.mame2000: unstable-2023-10-31 -> unstable-2024-05-07 ``                           |
| [`21dea711`](https://github.com/NixOS/nixpkgs/commit/21dea7112508e187a825d8c576f46826bf52460c) | `` python312Packages.dask-jobqueue: disable for python 3.12 ``                                |
| [`d4c673a9`](https://github.com/NixOS/nixpkgs/commit/d4c673a92bf722a783bf515b692eb05cc0088b7a) | `` build-support/meson: explicitly use ambiant CMake during cross compilation ``              |
| [`d216d87a`](https://github.com/NixOS/nixpkgs/commit/d216d87a311e499efa1281196ee4a68ac2b3d810) | `` python3Packages.binance-connector: init at v3.7.0 ``                                       |
| [`03ba2767`](https://github.com/NixOS/nixpkgs/commit/03ba27678d86cd0a1e8fac514fd69e3ee8c3a9fa) | `` maintainers: add trishtzy ``                                                               |
| [`8a4e4247`](https://github.com/NixOS/nixpkgs/commit/8a4e42474d253df596855300d2df4247ee05e010) | `` ent-go: 0.12.5 -> 0.13.1 ``                                                                |
| [`9f0b9de1`](https://github.com/NixOS/nixpkgs/commit/9f0b9de1e2ac086a57751719bbdac0c50d7c411f) | `` python312Packages.homeassistant-stubs: 2024.5.2 -> 2024.5.3 ``                             |
| [`c207a5ef`](https://github.com/NixOS/nixpkgs/commit/c207a5ef698dd95c63b241cae51a35911e989253) | `` python311Packages.gradio: 4.27.0 -> 4.29.0 ``                                              |
| [`2e1287b7`](https://github.com/NixOS/nixpkgs/commit/2e1287b70a5b53441f2f3874b2a2fa7869e27b82) | `` python311Packages.gradio-client: 0.14.0 -> 0.16.1 ``                                       |
| [`ce7467e3`](https://github.com/NixOS/nixpkgs/commit/ce7467e3034043cb047cd22b50bb0594ad041a38) | `` python312Packages.diffusers: fix build on python 3.12 ``                                   |
| [`d1220b4f`](https://github.com/NixOS/nixpkgs/commit/d1220b4f2912ffdc51e5b2341d20055a7f9dddef) | `` litmusctl: init at 1.5.0 ``                                                                |
| [`40bed463`](https://github.com/NixOS/nixpkgs/commit/40bed4630536b99ea1f2afb85f57801712d3c4a5) | `` flyctl: 0.2.51 -> 0.2.52 ``                                                                |
| [`d90deb29`](https://github.com/NixOS/nixpkgs/commit/d90deb29b8b78ec87834533152426111a0b4598a) | `` python312Packages.pandas-datareader: mark as broken on python 3.12 ``                      |
| [`55b80258`](https://github.com/NixOS/nixpkgs/commit/55b802581c1ea5e7c86cdfbb7643b8d06888af93) | `` fscan: 1.8.3-build3 -> 1.8.4 ``                                                            |
| [`0d67b550`](https://github.com/NixOS/nixpkgs/commit/0d67b5508d11f4c5314df646cb92a5a7863f8fbd) | `` duplicity: Fix finding Gio typelib ``                                                      |
| [`8b275b19`](https://github.com/NixOS/nixpkgs/commit/8b275b193ec6ad9941edf2b8001b298cbf7278a0) | `` goose: 3.19.2 -> 3.20.0 ``                                                                 |
| [`19bb0a96`](https://github.com/NixOS/nixpkgs/commit/19bb0a96f41e639ea0b33dc92f9caa94d27e5a38) | `` rutabaga_gfx: build for the right architecture ``                                          |
| [`81dd1c32`](https://github.com/NixOS/nixpkgs/commit/81dd1c32dd6af2f3f0848f18ca4ddd2f7d842e22) | `` oterm: format with nixfmt ``                                                               |
| [`2bf80d34`](https://github.com/NixOS/nixpkgs/commit/2bf80d3430aaaeeea08b266c7f8abb5ecbb7679e) | `` oterm: 0.2.7 -> 0.2.8 ``                                                                   |
| [`d891413d`](https://github.com/NixOS/nixpkgs/commit/d891413d42431c3b2ea7ac3840182b58aae8efca) | `` python311Packages.streamz: fix by adding missing test dependencies ``                      |
| [`02577a09`](https://github.com/NixOS/nixpkgs/commit/02577a094b9b6e06da100e0a91ec4bddbec1f153) | `` ft2-clone: 1.82 -> 1.83 ``                                                                 |
| [`29b607f4`](https://github.com/NixOS/nixpkgs/commit/29b607f43d01847a933f8a0f9b9f1021375fd81b) | `` nix-eval-jobs: 2.21.0 -> 2.22.0 (#310301) ``                                               |
| [`04898de2`](https://github.com/NixOS/nixpkgs/commit/04898de2a313084beae441ba54f5309c1958a35f) | `` qovery-cli: 0.92.3 -> 0.92.4 ``                                                            |
| [`ca97467e`](https://github.com/NixOS/nixpkgs/commit/ca97467e34648472601988813048fadbf344c5c9) | `` python312Packages.ollama: 0.1.9 -> 0.2.0 ``                                                |
| [`60929c19`](https://github.com/NixOS/nixpkgs/commit/60929c1912e29d9e5878964b9fc2b6a9a25668b8) | `` ome_zarr: fix by disabling failing tests ``                                                |
| [`135a2bee`](https://github.com/NixOS/nixpkgs/commit/135a2bee38ab6693af6be0b30a8e0a6fdbc4efdb) | `` exercism: 3.3.0 -> 3.4.0 ``                                                                |
| [`c22cb3fb`](https://github.com/NixOS/nixpkgs/commit/c22cb3fb9c6c86f9b3eff94d375a90d7c3ef2e72) | `` tig: 2.5.9 -> 2.5.10 ``                                                                    |
| [`992dc1ef`](https://github.com/NixOS/nixpkgs/commit/992dc1efa9c924723e4a297d3f756e6aa7630f68) | `` python312Packages.rnginline: add changelog to meta ``                                      |
| [`e66630e8`](https://github.com/NixOS/nixpkgs/commit/e66630e8c4256fcaf553f1b041600e2117ed4e61) | `` python312Packages.rnginline: refactor ``                                                   |
| [`0d56eb43`](https://github.com/NixOS/nixpkgs/commit/0d56eb4329414a8c4f737ffe68f05c798330d541) | `` python311Packages.meilisearch: format with nixfmt ``                                       |
| [`9539bc8d`](https://github.com/NixOS/nixpkgs/commit/9539bc8d7f4916ee1bd83fe3106340da31e03e9d) | `` python312Packages.meilisearch: refactor ``                                                 |
| [`c8bdca3a`](https://github.com/NixOS/nixpkgs/commit/c8bdca3a87fd1e04eb3933784b0aec758807bf60) | `` ensemble-chorus: unpin gcc8 ``                                                             |
| [`f53bfe8a`](https://github.com/NixOS/nixpkgs/commit/f53bfe8a52a08041225531906bf80305fe356c25) | `` shopware-cli: 0.4.42 -> 0.4.43 ``                                                          |
| [`7201c99b`](https://github.com/NixOS/nixpkgs/commit/7201c99b502438062ad3a182b70f1fff8363ee8e) | `` pyradio: 0.9.3.4 -> 0.9.3.6 ``                                                             |
| [`7055c625`](https://github.com/NixOS/nixpkgs/commit/7055c625360073f5142fd6bc86c51b1f8843dec4) | `` python312Packages.stim: update substitute pattern; unbreak ``                              |
| [`8d592191`](https://github.com/NixOS/nixpkgs/commit/8d5921913fff304ffba347e5aa4c7f58631fcf12) | `` snac2: 2.51 -> 2.52 ``                                                                     |
| [`9a868470`](https://github.com/NixOS/nixpkgs/commit/9a868470cb2a4fde08a176fe179270f557f28ab0) | `` python311Packages.types-beautifulsoup4: 4.12.0.20240504 -> 4.12.0.20240511 ``              |
| [`c5f92445`](https://github.com/NixOS/nixpkgs/commit/c5f92445b50924b451fe6ff2b3f2aeed42b2efd0) | `` python311Packages.dissect-executable: 1.5 -> 1.6 ``                                        |
| [`59729c24`](https://github.com/NixOS/nixpkgs/commit/59729c24fc6c469f08f38513416f8c61af62d033) | `` python312Packages.rnginline: relax deps; unbreak ``                                        |
| [`83d9726b`](https://github.com/NixOS/nixpkgs/commit/83d9726b1378a1232b6286e3de876aa7046917da) | `` nh: 3.5.14 -> 3.5.15 ``                                                                    |
| [`016e4990`](https://github.com/NixOS/nixpkgs/commit/016e4990cd7f0f584ee2dddd3bfef5e25aa49d38) | `` python311Packages.pubnub: 7.4.4 -> 8.0.0 ``                                                |
| [`e18a701d`](https://github.com/NixOS/nixpkgs/commit/e18a701d9d8430d729f74a8111f7e1fcea3bdcfe) | `` python311Packages.meilisearch: 0.31.0 -> 0.31.1 ``                                         |
| [`1ae75cc0`](https://github.com/NixOS/nixpkgs/commit/1ae75cc084a169ac262dc9041528825aeb9fc9de) | `` python312Packages.uqbar: add modules to unbreak tests ``                                   |
| [`5c8f30b5`](https://github.com/NixOS/nixpkgs/commit/5c8f30b56ec3d0ee7e0328b2fb5396c37e700d84) | `` arduino-ide: Fix .desktop file ``                                                          |
| [`00e5bca5`](https://github.com/NixOS/nixpkgs/commit/00e5bca5a44d728402fa5efa3696e14c4aabc52a) | `` python312Packages.wheel-inspect: add setuptools to checkInputs; unbreak ``                 |
| [`d68bc4d5`](https://github.com/NixOS/nixpkgs/commit/d68bc4d51657f846c24c8084565bc9549721e4a7) | `` python311Packages.zigpy: disable problematic test on x86_64-linux ``                       |
| [`dbea610a`](https://github.com/NixOS/nixpkgs/commit/dbea610adb066461707730968fcd629542357c61) | `` notation: add shell completions ``                                                         |
| [`2a1e58f2`](https://github.com/NixOS/nixpkgs/commit/2a1e58f2bcc74cd4e3ea17d899e134f574bf232a) | `` python312Packages.scikit-posthocs: remove patch; unbreak ``                                |
| [`da633c29`](https://github.com/NixOS/nixpkgs/commit/da633c2927b247417c48ead3d8464cb2de097e22) | `` vdrPlugins.softhddevice: 2.2.0 -> 2.3.0 ``                                                 |
| [`45f5ff5c`](https://github.com/NixOS/nixpkgs/commit/45f5ff5cdfb3057d9351c1205e97b01b74a1970c) | `` topicctl: 1.16.1 -> 1.17.0 ``                                                              |
| [`dc8c6ac0`](https://github.com/NixOS/nixpkgs/commit/dc8c6ac0feca96d7aebbf42f42253a0a5356420b) | `` ttdl: 4.2.1 -> 4.3.0 ``                                                                    |
| [`bb1ae846`](https://github.com/NixOS/nixpkgs/commit/bb1ae84684d14f24f440559253196ec9e25722fd) | `` python312Packages.pyslurm: remove patch; unbreak ``                                        |
| [`fe8fac54`](https://github.com/NixOS/nixpkgs/commit/fe8fac541d2be5e86b79bc186b2de5e19a74dc81) | `` python312Packages.python3-gnutls: 3.1.9 -> 3.1.10 ``                                       |
| [`101ffd27`](https://github.com/NixOS/nixpkgs/commit/101ffd27a08e50f9cb056d93691d7b34074797de) | `` python311Packages.python3-gnutls: switch to pyproject, unbreak ``                          |
| [`9c91790c`](https://github.com/NixOS/nixpkgs/commit/9c91790c187bfe10c5d001aca6f6fcc65c1e068d) | `` halo: init at 2.15.1 ``                                                                    |
| [`24fa114c`](https://github.com/NixOS/nixpkgs/commit/24fa114c9b82640ea0b996e4d2391777e69cf088) | `` maintainers: add yah ``                                                                    |
| [`08d7e310`](https://github.com/NixOS/nixpkgs/commit/08d7e3106f8eb2fc9fbc38952f82a018edc6201b) | `` python312Packages.succulent: add missing dependencies ``                                   |
| [`8c810f6f`](https://github.com/NixOS/nixpkgs/commit/8c810f6f55ed3175b54378707e283a0cb4ccd745) | `` reindeer: 2024.03.11.00 -> 2024.05.06.00 ``                                                |
| [`1a653a69`](https://github.com/NixOS/nixpkgs/commit/1a653a69a63d0e86da4b1b5eec9336faa31b96f7) | `` python311Packages.types-pyopenssl: 24.0.0.20240417 -> 24.1.0.20240425 ``                   |
| [`01e0f981`](https://github.com/NixOS/nixpkgs/commit/01e0f9811d921db6d162b8da022fbc01c2e4578f) | `` nuclei: 3.2.6 -> 3.2.7 ``                                                                  |
| [`2dd215d5`](https://github.com/NixOS/nixpkgs/commit/2dd215d5c37f8d1990e169533c11c310a7a10a69) | `` superfile: init at 1.1.2 ``                                                                |
| [`0c555b8e`](https://github.com/NixOS/nixpkgs/commit/0c555b8e68b8c90375d984340c1a1f5e995b816c) | `` labwc: 0.7.1 -> 0.7.2 ``                                                                   |
| [`517d5ef9`](https://github.com/NixOS/nixpkgs/commit/517d5ef9fa3bb75bdfecc7ea7dfc8d20c79c509d) | `` hyprland-workspaces: 2.0.0 -> 2.0.1 ``                                                     |
| [`3ad177d5`](https://github.com/NixOS/nixpkgs/commit/3ad177d549073aa960ef6a8e65b20c0fdec4d2c5) | `` home-assistant-custom-lovelace-modules.android-tv-card: 3.6.1 -> 3.7.0 ``                  |
| [`6f26f254`](https://github.com/NixOS/nixpkgs/commit/6f26f25421eddffe6f46c4ae079d7c711260dfaf) | `` texpresso: 0-unstable-2024-04-30 -> 0-unstable-2024-05-09 ``                               |
| [`0cd61c1b`](https://github.com/NixOS/nixpkgs/commit/0cd61c1ba150b1c823fcdf609c094a6542f72461) | `` pprof: unstable-2024-02-27 -> 0-unstable-2024-05-09 ``                                     |
| [`06ef4ffc`](https://github.com/NixOS/nixpkgs/commit/06ef4ffc67e6a480180e5727381ed73e67e5d20a) | `` k3s: fix a blank space making update script not match nixfmt ``                            |
| [`7a3c246e`](https://github.com/NixOS/nixpkgs/commit/7a3c246e2645d9168051fc402bbd8169bd4ae311) | `` quisk: 4.2.32 -> 4.2.33 ``                                                                 |
| [`6fc2f48c`](https://github.com/NixOS/nixpkgs/commit/6fc2f48cbaa43440320bbdfd71babb6b19210879) | `` nile: 1.0.2-unstable-2024-03-09 -> 1.0.3-unstable-2024-05-10 ``                            |
| [`d76288b0`](https://github.com/NixOS/nixpkgs/commit/d76288b0ddab1e744c9d37b1582f7bcc4ac87d28) | `` fontfor: 0.4.1 -> 0.4.3, modernize ``                                                      |
| [`fa3070c6`](https://github.com/NixOS/nixpkgs/commit/fa3070c647294aad4e2ff29d092bb414827fe1c5) | `` go-landlock: init at 0-unstable-2024-02-26 ``                                              |