### PR TITLE
chore(flake/git-hooks): `96364697` -> `fa606ccc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -317,9 +317,6 @@
         "flake-compat": [
           "flake-compat"
         ],
-        "flake-utils": [
-          "flake-utils"
-        ],
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
@@ -327,11 +324,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715850717,
-        "narHash": "sha256-HGY8w2Glb5xe4/l69Auv6R1kxbAQehB1vWFGnvzvSR8=",
+        "lastModified": 1715870890,
+        "narHash": "sha256-nacSOeXtUEM77Gn0G4bTdEOeFIrkCBXiyyFZtdGwuH0=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "963646978438e31c0925e16c4eca089fda69bac2",
+        "rev": "fa606cccd7b0ccebe2880051208e4a0f61bfc8c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`8803a39a`](https://github.com/cachix/git-hooks.nix/commit/8803a39afa8b3bfc88b7e3646a07450b57f4e27a) | `` readme: remove flake-utils reference `` |
| [`de8ccbdc`](https://github.com/cachix/git-hooks.nix/commit/de8ccbdc89a9a344a5821b252f66fb3cb1c9ec39) | `` flake: remove flake-utils dependency `` |