### PR TITLE
chore(flake/nixos-hardware): `772de835` -> `ff1be1e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -490,11 +490,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1715875452,
-        "narHash": "sha256-U1GoGjtiyAQhBn58wYBj3qPw72KgOxdSPBw8TDMsrSg=",
+        "lastModified": 1715881912,
+        "narHash": "sha256-e4LJk5uV1wvrRkffGFZekPWvFUx29NnnOahBlLaq8Ek=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "772de835d56f2f83277c57fcf1afb5a280c08589",
+        "rev": "ff1be1e3cdf884df0935ab28745ab13c3c26d828",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`ff1be1e3`](https://github.com/NixOS/nixos-hardware/commit/ff1be1e3cdf884df0935ab28745ab13c3c26d828) | `` Add missing default xps-15-9570 module to flake.nix ``          |
| [`d68be3e5`](https://github.com/NixOS/nixos-hardware/commit/d68be3e5e21d829ebce080d96747508fc27ea4e3) | `` Fixed error ``                                                  |
| [`9f730206`](https://github.com/NixOS/nixos-hardware/commit/9f7302060cdf9fa7e306bf00815b7188346c9d13) | `` Made modifications related to AMD CPU and nvidia GPU changes `` |