### PR TITLE
chore(flake/treefmt): `c6aaf729` -> `af8e54c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -652,11 +652,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714058656,
-        "narHash": "sha256-Qv4RBm4LKuO4fNOfx9wl40W2rBbv5u5m+whxRYUMiaA=",
+        "lastModified": 1715939528,
+        "narHash": "sha256-arSsmnSSUlrsdk1hbc5aTUYnqG1yKMSgQUnaadRpAig=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "c6aaf729f34a36c445618580a9f95a48f5e4e03f",
+        "rev": "af8e54c9622fd902b0f34d6988955ece73ba82a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                 |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`af8e54c9`](https://github.com/numtide/treefmt-nix/commit/af8e54c9622fd902b0f34d6988955ece73ba82a1) | `` choose local that is compatible with macOS (#176) `` |