### PR TITLE
chore(flake/stylix): `b5f4ca49` -> `76e7daf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -617,11 +617,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715516559,
-        "narHash": "sha256-xzUwP85yIYvVSKHY2MutzAt5/ZQwUzlhL5/Gfh7jySc=",
+        "lastModified": 1716037261,
+        "narHash": "sha256-eF0A36GdegKkEiwFArjCysGU/XEYvzj7x5jfkFMtmqM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "b5f4ca49df372c3d26ce04b1554fb02a0107cc8d",
+        "rev": "76e7daf5a16d442ac98e844582f7dc1354610886",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                        |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`76e7daf5`](https://github.com/danth/stylix/commit/76e7daf5a16d442ac98e844582f7dc1354610886) | `` doc: explain using `lib.stylix.colors` (#328) ``            |
| [`4a4c82f0`](https://github.com/danth/stylix/commit/4a4c82f03ccf71707550bca3b39928c68c40644e) | `` grub: use fc-match format option rather than grep (#368) `` |