### PR TITLE
chore(flake/nixpkgs): `4a6b83b0` -> `6c0b7a92`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -505,11 +505,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715961556,
-        "narHash": "sha256-+NpbZRCRisUHKQJZF3CT+xn14ZZQO+KjxIIanH3Pvn4=",
+        "lastModified": 1716137900,
+        "narHash": "sha256-sowPU+tLQv8GlqtVtsXioTKeaQvlMz/pefcdwg8MvfM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4a6b83b05df1a8bd7d99095ec4b4d271f2956b64",
+        "rev": "6c0b7a92c30122196a761b440ac0d46d3d9954f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`9215d3b1`](https://github.com/NixOS/nixpkgs/commit/9215d3b1f767ffe16ccf88238c8d6768dcb88b1f) | `` haskell.packages.ghc98.haskell-language-server: fix ``                         |
| [`f31f3398`](https://github.com/NixOS/nixpkgs/commit/f31f33987b20759f06c56fcbb34537d42ca2df5b) | `` texinfo: Fix build on native FreeBSD ``                                        |
| [`3e388dda`](https://github.com/NixOS/nixpkgs/commit/3e388ddad1a0ab5897da6a01686643895c35dddc) | `` haskellPackages: mark builds failing on hydra as broken ``                     |
| [`b10ba2db`](https://github.com/NixOS/nixpkgs/commit/b10ba2dbc2685abcffb8d2cbd26105ab3da6404e) | `` haskellPackages: regenerate package set based on current config ``             |
| [`f497bacf`](https://github.com/NixOS/nixpkgs/commit/f497bacfa0e1f689927215e5d82ec39e44bab7f5) | `` bombsquad: add coffeeispower maintainer ``                                     |
| [`7c470de6`](https://github.com/NixOS/nixpkgs/commit/7c470de6acb95420e52825e69d7db001375bdaae) | `` chore: Unmark haskellPackage.language-thrift as broken ``                      |
| [`8597b332`](https://github.com/NixOS/nixpkgs/commit/8597b3328bd1bc3e0bbbe821b66947dc4fa26f7f) | `` python311Packages.phe: 1.5.0 -> 1.5.1 ``                                       |
| [`b7eb7e3c`](https://github.com/NixOS/nixpkgs/commit/b7eb7e3c2a0ec498932d67f7ef372815fb59a737) | `` opustags: 1.10.0 -> 1.10.1 ``                                                  |
| [`61a7c8cf`](https://github.com/NixOS/nixpkgs/commit/61a7c8cf4fd30b4d03b62ee3aeec09b4da82e41b) | `` mcfly: 0.8.5 -> 0.8.6 ``                                                       |
| [`d269556c`](https://github.com/NixOS/nixpkgs/commit/d269556c7282c922ec4aa41885e453371ba4b9fd) | `` moon: 1.24.4 -> 1.24.5 ``                                                      |
| [`8e008e15`](https://github.com/NixOS/nixpkgs/commit/8e008e152c91c58ed99e5affcfb273f805958a32) | `` cargo-crev: 0.25.6 -> 0.25.9 ``                                                |
| [`d5c6653e`](https://github.com/NixOS/nixpkgs/commit/d5c6653e2487ce3fe83e83d337a3e4e008f0b9fd) | `` proto: 0.35.1 -> 0.35.2 ``                                                     |
| [`0d713721`](https://github.com/NixOS/nixpkgs/commit/0d71372195679eb949283ecaacde0daa71b5bd78) | `` cdk-go: 1.5.2 -> 1.5.3 ``                                                      |
| [`def1398f`](https://github.com/NixOS/nixpkgs/commit/def1398f86987078be87169c68a71b628a4bd78b) | `` stalwart-mail_0_6: init at 0.6.0 ``                                            |
| [`1f4329cd`](https://github.com/NixOS/nixpkgs/commit/1f4329cde6c6400801443d7a2e783cafe111d76a) | `` nixos/stalwart-mail: pin module to package version 0.6 ``                      |
| [`45a8c715`](https://github.com/NixOS/nixpkgs/commit/45a8c7151728b7577751c35c1e2857929497a42f) | `` haskellPackages.erebos-tester: only on Linux ``                                |
| [`10e1e11b`](https://github.com/NixOS/nixpkgs/commit/10e1e11b8e84474b07f8ff3bc54c75b4ce6bccdb) | `` haskellPackages: regenerate package set based on current config ``             |
| [`4dcdfe98`](https://github.com/NixOS/nixpkgs/commit/4dcdfe98f6c0ce227a61a948583d3b2c96c7da57) | `` robo: 4.0.7 -> 5.0.0 ``                                                        |
| [`1ee63219`](https://github.com/NixOS/nixpkgs/commit/1ee63219e28b290c16acfdfc2611fc35aabc8515) | `` haskellPackages: fix eval ``                                                   |
| [`bcdbb17a`](https://github.com/NixOS/nixpkgs/commit/bcdbb17a41d8fab94e8031a7c5e180fa5acd0809) | `` php81Packages.phpstan: 1.11.0 -> 1.11.1 ``                                     |
| [`94d257a7`](https://github.com/NixOS/nixpkgs/commit/94d257a7faf56af7cec10d4237bf8d4c3a45d0f7) | `` transifex-cli: 1.6.12 -> 1.6.13 ``                                             |
| [`747f8f51`](https://github.com/NixOS/nixpkgs/commit/747f8f5159053c3e45a34542d0485248b7e802be) | `` twitch-dl: 2.3.0 -> 2.3.1 ``                                                   |
| [`c2781a62`](https://github.com/NixOS/nixpkgs/commit/c2781a62a594984e412034b0d692ab382644325c) | `` omnictl: 0.35.0 -> 0.35.1 ``                                                   |
| [`789d2b88`](https://github.com/NixOS/nixpkgs/commit/789d2b8871115bdf40eded982de728f1edf3f0b7) | `` taffybar: Drop obsolete patch ``                                               |
| [`01737f49`](https://github.com/NixOS/nixpkgs/commit/01737f49e1aebe41b62bdaa9bd351b58ac925cf9) | `` git-annex: Update hash ``                                                      |
| [`a7ea379d`](https://github.com/NixOS/nixpkgs/commit/a7ea379d4e7e99adc9685f4462cd9670e2969564) | `` prometheus-cloudflare-exporter: 0.0.15 -> 0.0.16 ``                            |
| [`75719bd1`](https://github.com/NixOS/nixpkgs/commit/75719bd1a86bac7e453888596ea902d50902f5cc) | `` treesheets: 0-unstable-2024-05-04 -> 0-unstable-2024-05-18 ``                  |
| [`acdea8cc`](https://github.com/NixOS/nixpkgs/commit/acdea8cc6758295ef224e1c57dbcd5df18e191f8) | `` python311Packages.heudiconv: 1.1.0 -> 1.1.3 ``                                 |
| [`ccbe3627`](https://github.com/NixOS/nixpkgs/commit/ccbe3627e30b10e5155520924313c3b78e020e07) | `` aliyun-cli: 3.0.205 -> 3.0.206 ``                                              |
| [`78189e06`](https://github.com/NixOS/nixpkgs/commit/78189e06e1e8a73c9458c7f922a5f766f5f11b71) | `` racket: reformat using `nixfmt-rfc-style` ``                                   |
| [`de106b66`](https://github.com/NixOS/nixpkgs/commit/de106b66b4ed05ad705c2ab9d5710cb2102a13f8) | `` racket-minimal: 8.12 -> 8.13 ``                                                |
| [`a14d0471`](https://github.com/NixOS/nixpkgs/commit/a14d0471a77eb15a83ee55d8e9f8332951cdc4a2) | `` python312Packages.character-encoding-utils: format with nixfmt ``              |
| [`7049481c`](https://github.com/NixOS/nixpkgs/commit/7049481c0878d4600ccceed2adbf24dba004ebb0) | `` python312Packages.character-encoding-utils: refactor ``                        |
| [`11fb14f7`](https://github.com/NixOS/nixpkgs/commit/11fb14f79b8f05a6c8490dbdee0f339f6cc3ef7e) | `` python312Packages.plexapi: format with nixfmt ``                               |
| [`801ec601`](https://github.com/NixOS/nixpkgs/commit/801ec601b1aaed4946c81da4a944f86c5f6158d9) | `` python312Packages.plexapi: 4.15.12 -> 4.15.13 ``                               |
| [`23f917a8`](https://github.com/NixOS/nixpkgs/commit/23f917a8528da7d2943670f461fd59772785c9f7) | `` renode-dts2repl: 0-unstable-2024-05-09 -> 0-unstable-2024-05-16 ``             |
| [`03dc987e`](https://github.com/NixOS/nixpkgs/commit/03dc987e7c6992d58892782b80728ae9293978c4) | `` openjump: use `makeBinaryWrapper` ``                                           |
| [`120a1ee1`](https://github.com/NixOS/nixpkgs/commit/120a1ee1260136cce385d450866cc432f2b78a94) | `` openjump: sort `meta` attributes ``                                            |
| [`1c82c619`](https://github.com/NixOS/nixpkgs/commit/1c82c619e6def18f456a31892d24cdf027c26790) | `` openjump: add missing phase hooks ``                                           |
| [`c3ccab0b`](https://github.com/NixOS/nixpkgs/commit/c3ccab0b92eec5962449c5469271f5966009d459) | `` openjump: use `finalAttrs` pattern ``                                          |
| [`9c32070f`](https://github.com/NixOS/nixpkgs/commit/9c32070f1f2090c4d5320b684792213d2cf6316b) | `` openjump: reformat with `nixfmt-rfc-style` ``                                  |
| [`27ce0d6e`](https://github.com/NixOS/nixpkgs/commit/27ce0d6e0f5ba3783a0aaabe86b0356d26856eac) | `` typstyle: 0.11.16 -> 0.11.21 ``                                                |
| [`d6c6097a`](https://github.com/NixOS/nixpkgs/commit/d6c6097aac5de3d527ef5e89b3f9644b976e69ac) | `` python311Packages.stone: 3.3.3 -> 3.3.6 ``                                     |
| [`0f4f8ccc`](https://github.com/NixOS/nixpkgs/commit/0f4f8ccccf6128dba91fa90bc8df3d4fd57daf06) | `` typst-preview: 0.11.4 -> 0.11.6 ``                                             |
| [`da0e973a`](https://github.com/NixOS/nixpkgs/commit/da0e973a7fc2aa3bef532578dec462e392a58b5e) | `` commitizen: 3.25.0 -> 3.26.0 ``                                                |
| [`dc23055a`](https://github.com/NixOS/nixpkgs/commit/dc23055ae33b621da7cedb8bf38c3be203f87799) | `` ghauri: 1.3.1 -> 1.3.2 ``                                                      |
| [`0e0f6e2e`](https://github.com/NixOS/nixpkgs/commit/0e0f6e2e2d0a312583018c12d866b701a346199a) | `` python311Packages.pynws: 1.8.0 -> 1.8.1 ``                                     |
| [`0c068a00`](https://github.com/NixOS/nixpkgs/commit/0c068a007b934c58100bfc964b0c17ce15823a01) | `` sequoia-sqop: 0.32.0 -> 0.33.0 ``                                              |
| [`60626235`](https://github.com/NixOS/nixpkgs/commit/60626235f4d2786f2cdf632d8951aae105217160) | `` webcord: 4.9.1 -> 4.9.2 ``                                                     |
| [`1146e332`](https://github.com/NixOS/nixpkgs/commit/1146e332865701e5e85c0660356025d0a5ca70e2) | `` python311Packages.character-encoding-utils: 0.0.7 -> 0.0.8 ``                  |
| [`b8175944`](https://github.com/NixOS/nixpkgs/commit/b8175944c8b90cd18848d7452c9c99882d9caa7b) | `` rcp: 0.7.0 -> 0.9.0 ``                                                         |
| [`70e4cf23`](https://github.com/NixOS/nixpkgs/commit/70e4cf2354cc94fc9351d477c302c5d3247863cc) | `` netcdffortran: fix darwin build (#312683) ``                                   |
| [`0f97efdf`](https://github.com/NixOS/nixpkgs/commit/0f97efdf0b8b443fed1be86e43e7241452f6e344) | `` twitch-tui: 2.6.8 -> 2.6.9 ``                                                  |
| [`b94bc3b0`](https://github.com/NixOS/nixpkgs/commit/b94bc3b0c45d723a62703b2d74aef68144868a30) | `` nixos/rl-2405: k3s was upgraded to 1.30 ``                                     |
| [`d9ce8510`](https://github.com/NixOS/nixpkgs/commit/d9ce851075643956fb3e3130cde3657019239866) | `` nwg-displays: 0.3.18 -> 0.3.19 ``                                              |
| [`d95a9f09`](https://github.com/NixOS/nixpkgs/commit/d95a9f092c37c20952c145063581dc1897e05112) | `` k3s_1_26: remove package ``                                                    |
| [`05e7a44e`](https://github.com/NixOS/nixpkgs/commit/05e7a44e94212100b5a34110b37d6319e8739d1d) | `` python311Packages.griffe: 0.45.0 -> 0.45.1 ``                                  |
| [`9d4fec5d`](https://github.com/NixOS/nixpkgs/commit/9d4fec5daf41f0850d7bbdbb1e43480d50558c63) | `` eigenmath: 0-unstable-2024-05-12 -> 0-unstable-2024-05-18 ``                   |
| [`100c1501`](https://github.com/NixOS/nixpkgs/commit/100c1501e12b095f7fafa9ae17c59a07bd79acb4) | `` nixos/loki: skip config validation when it's impossible to validate ``         |
| [`7fc78a81`](https://github.com/NixOS/nixpkgs/commit/7fc78a816dffb8bfbc61ef9422a5be98cd3bd672) | `` vscode-extensions.mgt19937.typst-preview: 0.11.4 -> 0.11.6 ``                  |
| [`e621565f`](https://github.com/NixOS/nixpkgs/commit/e621565f8374130c0658a41ccb801b02136443aa) | `` python311Packages.pyduotecno: 2024.5.0 -> 2024.5.1 ``                          |
| [`adc820cb`](https://github.com/NixOS/nixpkgs/commit/adc820cb05dab48ea77c74bfd7fce2ab01bfbf4a) | `` python311Packages.pcffont: 0.0.11 -> 0.0.13 ``                                 |
| [`57b25e46`](https://github.com/NixOS/nixpkgs/commit/57b25e46eead1b6a366ca3727e6434600108b31b) | `` badkeys: 0.0.10 -> 0.0.11 ``                                                   |
| [`bb7577a3`](https://github.com/NixOS/nixpkgs/commit/bb7577a307c2c158de0a6e98f651b46b6aa36639) | `` oneshot: 2.0.1 -> 2.0.2 ``                                                     |
| [`5f8a448a`](https://github.com/NixOS/nixpkgs/commit/5f8a448aa7ac38904b08acec9af9aeb1f5d61eb6) | `` sherlock: unstable-2024-05-12 -> 0-unstable-2024-05-15 ``                      |
| [`7ff2cf96`](https://github.com/NixOS/nixpkgs/commit/7ff2cf96e2ae8769bcbfe37279c803f8422d1ef0) | `` nezha-agent: 0.16.7 -> 0.16.8 ``                                               |
| [`2ecce462`](https://github.com/NixOS/nixpkgs/commit/2ecce462e96b34cf63f132eba53dfabaf8fea6f8) | `` racket: 8.12 -> 8.13 ``                                                        |
| [`e89e2da3`](https://github.com/NixOS/nixpkgs/commit/e89e2da38f5affe7516fb03ce868e4e085103293) | `` goa: 3.16.1 -> 3.16.2 ``                                                       |
| [`46ac1593`](https://github.com/NixOS/nixpkgs/commit/46ac1593a81056913a36585c83453bbbd017fbca) | `` munin: 2.0.75 -> 2.0.76 ``                                                     |
| [`0b073454`](https://github.com/NixOS/nixpkgs/commit/0b073454231a19db2ee189cfcade1443228faaa9) | `` pretalx: relax rules constraint ``                                             |
| [`f9f118d4`](https://github.com/NixOS/nixpkgs/commit/f9f118d44c0bebcb646b28282db35d377ef5b316) | `` python312Packages.rules: 3.3.0 -> 3.4.0 ``                                     |
| [`fc5e8862`](https://github.com/NixOS/nixpkgs/commit/fc5e886209665b23bd7c5cc2a30068fc09d41a32) | `` python311Packages.duecredit: 0.9.3 -> 0.10.1 ``                                |
| [`9569479f`](https://github.com/NixOS/nixpkgs/commit/9569479fddfe7945b35992890078c5b426877edf) | `` python311Packages.pyvista: 0.43.7 -> 0.43.8 ``                                 |
| [`74dbcb53`](https://github.com/NixOS/nixpkgs/commit/74dbcb53bdde54d54c528ddded6552bceed1cb99) | `` python311Packages.softlayer: 6.2.0 -> 6.2.2 ``                                 |
| [`24a74aba`](https://github.com/NixOS/nixpkgs/commit/24a74abad714f04b391e0df3a48491d152146682) | `` python311Packages.cliff: 4.6.0 -> 4.7.0 ``                                     |
| [`1faadcf5`](https://github.com/NixOS/nixpkgs/commit/1faadcf5147b9789aa05bdb85b35061b642500a4) | `` haskell-language-server: Fix build ``                                          |
| [`4582b524`](https://github.com/NixOS/nixpkgs/commit/4582b524ba35b8186a9b3a366eaba8cbe31d140f) | `` pgadmin: Use systemd's LoadCredential for password files (#312569) ``          |
| [`6318b309`](https://github.com/NixOS/nixpkgs/commit/6318b3093eac900300a600898a5587364f2c4f0f) | `` oelint-adv: 5.3.1 -> 5.3.2 ``                                                  |
| [`bdba8499`](https://github.com/NixOS/nixpkgs/commit/bdba8499f0aba0c91383d5bf516b4f9f7d285d10) | `` cnquery: 11.3.1 -> 11.4.3 ``                                                   |
| [`953fa53c`](https://github.com/NixOS/nixpkgs/commit/953fa53c2a5f3e4a86728134d7eaa1320eb9c4dc) | `` niri: 0.1.5 -> 0.1.6 ``                                                        |
| [`57bf7a08`](https://github.com/NixOS/nixpkgs/commit/57bf7a089624bf59ba7322e3dc08019c85be6399) | `` tracexec: Packaging improvements from #310158 ``                               |
| [`52743c88`](https://github.com/NixOS/nixpkgs/commit/52743c88f5af69d2f64a5de6c7144a2aae76098b) | `` nixos/step-ca: Added test case for finding package version in journald logs `` |
| [`fb1675a3`](https://github.com/NixOS/nixpkgs/commit/fb1675a382b576270ac14a6cd9b8a415ef5550bd) | `` haskellPackages.pandoc-crossref: Don‘t check ``                                |
| [`391dfcf9`](https://github.com/NixOS/nixpkgs/commit/391dfcf9af4d46d6bffea00c83bb407b2d152c2b) | `` nixos/steam: fix maintainers ``                                                |
| [`2eed47a6`](https://github.com/NixOS/nixpkgs/commit/2eed47a6b577b0b9c98ac4b392d2371dde36a7bd) | `` python311Packages.gflanguages: 0.6.0 -> 0.6.1 ``                               |
| [`082b2c1f`](https://github.com/NixOS/nixpkgs/commit/082b2c1fcfd11123f7f759166e89f40472159835) | `` python311Packages.skorch: unbreak by patching out failing test ``              |
| [`9db58e6a`](https://github.com/NixOS/nixpkgs/commit/9db58e6a8f991ab2ea484da23909412fb193a990) | `` python312Packages.foobot-async: format with nixfmt ``                          |
| [`065a82e2`](https://github.com/NixOS/nixpkgs/commit/065a82e20783c76001b3408b312f10d80face338) | `` python312Packages.foobot-async: refactor ``                                    |
| [`dcab6ab9`](https://github.com/NixOS/nixpkgs/commit/dcab6ab9b3e779aa3f8c80c04edb3a3f842b0bc6) | `` python312Packages.moviepy: format with nixfmt ``                               |
| [`e79fd752`](https://github.com/NixOS/nixpkgs/commit/e79fd7526593114bc3678219978a077bdb7dca4b) | `` python311Packages.pytest-postgresql: 5.0.0 -> 6.0.0 ``                         |
| [`a03c87ba`](https://github.com/NixOS/nixpkgs/commit/a03c87ba76d6cc3838ba2789a640143c91a31776) | `` python312Packages.moviepy: refactor ``                                         |
| [`ccaeceb7`](https://github.com/NixOS/nixpkgs/commit/ccaeceb7082583bd0cff49884efeb3a5b74e3bd5) | `` python312Packages.hickle: remove disabled tests ``                             |
| [`7c0b3127`](https://github.com/NixOS/nixpkgs/commit/7c0b3127529cd1ad2d30090f1afad2e6d1320d97) | `` python311Packages.torchgpipe: remove at 0.0.7 ``                               |
| [`61acf326`](https://github.com/NixOS/nixpkgs/commit/61acf32683b20077a110712bc5732e94be836877) | `` python312Packages.msgraph-core: format with nixfmt ``                          |
| [`2cbd830c`](https://github.com/NixOS/nixpkgs/commit/2cbd830c439435665c73af6da3d0c45bb8cd949c) | `` python312Packages.msgraph-core: refactor ``                                    |
| [`8438ebc4`](https://github.com/NixOS/nixpkgs/commit/8438ebc4eddbcf89bbda45f6a9b7000e5d2e6a87) | `` python311Packages.msgraph-core: 1.0.0 -> 1.1.0 ``                              |
| [`3156917d`](https://github.com/NixOS/nixpkgs/commit/3156917d2368103d117cc40b9d8c82dd6e77ab72) | `` python311Packages.openhomedevice: format with nixfmt ``                        |