### PR TITLE
chore(flake/darwin): `ffc01182` -> `e1cacc63`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715901937,
-        "narHash": "sha256-eMyvWP56ZOdraC2IOvZo0/RTDcrrsqJ0oJWDC76JTak=",
+        "lastModified": 1716204319,
+        "narHash": "sha256-3KL5dRGk89SUaeODFO6B9lxymCVav3UzqsNxOzAbwVY=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ffc01182f90118119930bdfc528c1ee9a39ecef8",
+        "rev": "e1cacc63e6e324ae95e65e8aaea62dec74686208",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                               |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`c8a8faed`](https://github.com/LnL7/nix-darwin/commit/c8a8faedbc2ae80951fe4b5a92fb10de003d6aed) | `` Change zsh default prompt ``                       |
| [`24f7a3fd`](https://github.com/LnL7/nix-darwin/commit/24f7a3fdf4e7079284130f8311e300e499b311f1) | `` Move --offline to group of same behaviour flags `` |
| [`2a2a311f`](https://github.com/LnL7/nix-darwin/commit/2a2a311fca4fbaca43b85b2c6f3ca2c9235ebb89) | `` Fix help ``                                        |
| [`3524643c`](https://github.com/LnL7/nix-darwin/commit/3524643c3dee8304872de281dc1f748fb452210f) | `` Fix --offline ``                                   |
| [`bb17a88b`](https://github.com/LnL7/nix-darwin/commit/bb17a88bc09e67a2604501940438b2573c24820c) | `` Add offline flag to darwin-rebuild.sh ``           |