### PR TITLE
chore(flake/darwin): `e1cacc63` -> `8bf083c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716204319,
-        "narHash": "sha256-3KL5dRGk89SUaeODFO6B9lxymCVav3UzqsNxOzAbwVY=",
+        "lastModified": 1716240091,
+        "narHash": "sha256-++gJuNv0X8naF1VkaO2sAiM3T4wLx1NtdfubEsRzX7U=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "e1cacc63e6e324ae95e65e8aaea62dec74686208",
+        "rev": "8bf083c992e2bc0a8c07f5860d3866739b698883",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                    |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
| [`93913d14`](https://github.com/LnL7/nix-darwin/commit/93913d14a310efc40fc84d58d278b96c73c37c65) | `` Add file or directory tile to Dock persistent others `` |