### PR TITLE
chore(flake/stylix): `81df8443` -> `e7543c51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -617,11 +617,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716206302,
-        "narHash": "sha256-5Qc3aQGVyPEOuN82zVamStaV81HebHvLjk3fGfpyCPY=",
+        "lastModified": 1716395969,
+        "narHash": "sha256-Qse5s/R8QKdI6yYnDv9pcDSrR8qVWzJ2m1QMjkuVxuU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "81df8443556335016d6f0bc22630a95776a56d8b",
+        "rev": "e7543c51eff9e73c85450c473e1f24513a5e0a0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                    |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`e7543c51`](https://github.com/danth/stylix/commit/e7543c51eff9e73c85450c473e1f24513a5e0a0f) | `` doc: fix link for "Installing Home Manager as a NixOS module" (#385) `` |
| [`23cbb966`](https://github.com/danth/stylix/commit/23cbb966386dda61720266ec4406b6633ba07317) | `` doc: refresh screenshots (#382) ``                                      |
| [`f9bf9764`](https://github.com/danth/stylix/commit/f9bf97645b41c5fcf28f044ab2b72f1b60a8ef9c) | `` doc: mention YouTube video guide (#384) ``                              |