### PR TITLE
chore(flake/agenix): `8d37c5bd` -> `c2fc0762`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715290355,
-        "narHash": "sha256-2T7CHTqBXJJ3ZC6R/4TXTcKoXWHcvubKNj9SfomURnw=",
+        "lastModified": 1716561646,
+        "narHash": "sha256-UIGtLO89RxKt7RF2iEgPikSdU53r6v/6WYB0RW3k89I=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "8d37c5bdeade12b6479c85acd133063ab53187a0",
+        "rev": "c2fc0762bbe8feb06a2e59a364fa81b3a57671c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`1746e4f5`](https://github.com/ryantm/agenix/commit/1746e4f5ec0849a50c2b7b634b4b84e3e09c6f87) | `` agenix: fix installCheckPhase with Nix 2.3 `` |