### PR TITLE
chore(flake/nix-index-database): `693705f2` -> `6e4a2b3b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716692245,
-        "narHash": "sha256-5cqLGLxaKZ8RzKUtQWcQw4RtTI26sVnOy9zdb7Vhvq8=",
+        "lastModified": 1716692972,
+        "narHash": "sha256-gz3UiLa5mdd+AoOD/p//sdTty0vWk0BLOieTM+F6dGQ=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "693705f22a9d378c203ad5304a7e630c6b03048f",
+        "rev": "6e4a2b3b7c60aae5dac8c21117a134a4a56648da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`6e4a2b3b`](https://github.com/nix-community/nix-index-database/commit/6e4a2b3b7c60aae5dac8c21117a134a4a56648da) | `` update packages.nix to release 2024-05-26-030820 `` |