### PR TITLE
chore(flake/nixos-hardware): `d9e0b262` -> `d789d9a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -490,11 +490,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1716173274,
-        "narHash": "sha256-FC21Bn4m6ctajMjiUof30awPBH/7WjD0M5yqrWepZbY=",
+        "lastModified": 1716713659,
+        "narHash": "sha256-anUvvePTGBMrkRB5Fx2suJDUZxqbte26TE2pqPYhLUU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d9e0b26202fd500cf3e79f73653cce7f7d541191",
+        "rev": "d789d9a2de2cea67655d38b7a37a30bdb1838e8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`d789d9a2`](https://github.com/NixOS/nixos-hardware/commit/d789d9a2de2cea67655d38b7a37a30bdb1838e8b) | `` Add Surface Pro 9 to Readme ``                                |
| [`1af5ef15`](https://github.com/NixOS/nixos-hardware/commit/1af5ef15469a55bef1a9136324437e4ddede2c5c) | `` Add Readme for Surface Pro 9 ``                               |
| [`7caa5b2a`](https://github.com/NixOS/nixos-hardware/commit/7caa5b2a35c4ae70328f853b3fe24870cb35a8a6) | `` Add Surface Pro 9 with Intel PSR disabled ``                  |
| [`449b3aba`](https://github.com/NixOS/nixos-hardware/commit/449b3abafabff9057de95d2f92fd2eaac4da024d) | `` fix error ``                                                  |
| [`d946893c`](https://github.com/NixOS/nixos-hardware/commit/d946893c3b99dab02f97dbde49d3c62223d4ef68) | `` add config for ASUS TUF FX506HM ``                            |
| [`888d915f`](https://github.com/NixOS/nixos-hardware/commit/888d915fe8aae23214a38833ccafb04a87d9177d) | `` Update readme for 16arha7 ``                                  |
| [`816528f0`](https://github.com/NixOS/nixos-hardware/commit/816528f00e287f7eadc57a0be382442516b89070) | `` Add kernel version check for Lenovo 16ARHA7 speaker fix ``    |
| [`33026a05`](https://github.com/NixOS/nixos-hardware/commit/33026a05f412560c0979f14b20fa397d6e08ea31) | `` framework: Add framework-laptop-kmod for 16" model as well `` |
| [`cedb27be`](https://github.com/NixOS/nixos-hardware/commit/cedb27beb1840e2856b0769025392ba82925bb5c) | `` Added config for Huawei Matebook X Pro (2020) (#957) ``       |