### PR TITLE
chore(flake/home-manager): `6a35d196` -> `05e6ba83`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -382,11 +382,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716711215,
-        "narHash": "sha256-0koEdYN3XOE1ECwWvFdPgI/709jrXYNo8nKDoQe2p3U=",
+        "lastModified": 1716711219,
+        "narHash": "sha256-TnZETiQPXbyT5mdCHMOyrJnx2+BwroMBRrguciz1vEo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6a35d1969e4626a0f8d285e60b6cfd331e2687a9",
+        "rev": "05e6ba83eb3585ce0aff7b41e4bd0e317d05ad4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`05e6ba83`](https://github.com/nix-community/home-manager/commit/05e6ba83eb3585ce0aff7b41e4bd0e317d05ad4a) | `` Translate using Weblate (Danish) ``               |
| [`517682ed`](https://github.com/nix-community/home-manager/commit/517682ed21a19c193f09f043ecd8dc4002a962c3) | `` Translate using Weblate (Japanese) ``             |
| [`cd29501b`](https://github.com/nix-community/home-manager/commit/cd29501b799c2621276376fb714cd2532fb2f0f7) | `` Translate using Weblate (Japanese) ``             |
| [`943f1e97`](https://github.com/nix-community/home-manager/commit/943f1e97fc171476f0235d7657448f9315465f18) | `` Translate using Weblate (German) ``               |
| [`fb7feac5`](https://github.com/nix-community/home-manager/commit/fb7feac55b2b95692b58e388a608fc326ec66608) | `` Translate using Weblate (Chinese (Simplified)) `` |