### PR TITLE
chore(flake/home-manager): `05e6ba83` -> `5d151429`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -382,11 +382,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716711219,
-        "narHash": "sha256-TnZETiQPXbyT5mdCHMOyrJnx2+BwroMBRrguciz1vEo=",
+        "lastModified": 1716736760,
+        "narHash": "sha256-h3RmnNknKYtVA+EvUSra6QAwfZjC2q1G8YA7W0gat8Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "05e6ba83eb3585ce0aff7b41e4bd0e317d05ad4a",
+        "rev": "5d151429e1e79107acf6d06dcc5ace4e642ec239",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`5d151429`](https://github.com/nix-community/home-manager/commit/5d151429e1e79107acf6d06dcc5ace4e642ec239) | `` kanshi: fix configuration example `` |
| [`b2a4ddf6`](https://github.com/nix-community/home-manager/commit/b2a4ddf657e6ad87569665545ffaf7dd5e9a02af) | `` flake.lock: Update ``                |