### PR TITLE
chore(flake/nix-index-database): `6e4a2b3b` -> `ff80cb4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716692972,
-        "narHash": "sha256-gz3UiLa5mdd+AoOD/p//sdTty0vWk0BLOieTM+F6dGQ=",
+        "lastModified": 1716772633,
+        "narHash": "sha256-Idcye44UW+EgjbjCoklf2IDF+XrehV6CVYvxR1omst4=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "6e4a2b3b7c60aae5dac8c21117a134a4a56648da",
+        "rev": "ff80cb4a11bb87f3ce8459be6f16a25ac86eb2ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                    |
| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`ff80cb4a`](https://github.com/nix-community/nix-index-database/commit/ff80cb4a11bb87f3ce8459be6f16a25ac86eb2ac) | `` build(deps): bump cachix/cachix-action from 14 to 15 `` |