### PR TITLE
chore(flake/nixos-hardware): `2e7d6c56` -> `9a20e17a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -490,11 +490,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1716715385,
-        "narHash": "sha256-fe6Z33pbfqu4TI5ijmcaNc5vRBs633tyxJ12HTghy3w=",
+        "lastModified": 1716798306,
+        "narHash": "sha256-s8+OhT1WSPMoqbTawT30hj4NVMg+w03/a+2HVqcNhY0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2e7d6c568063c83355fe066b8a8917ee758de1b8",
+        "rev": "9a20e17a73b052d6be912adcee220cb483477094",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`9a20e17a`](https://github.com/NixOS/nixos-hardware/commit/9a20e17a73b052d6be912adcee220cb483477094) | `` added lenovo legion 15ach6h to README ``    |
| [`6d24140f`](https://github.com/NixOS/nixos-hardware/commit/6d24140f51333fc5021dea0ae5faef1bd19020be) | `` added lenovo legion 15ach6h to flake.nix `` |