### PR TITLE
chore(flake/home-manager): `939375b3` -> `10c7c219`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -382,11 +382,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716847166,
-        "narHash": "sha256-00gIHRyT+YALwbvOjzpOLAQfPFnVx8X+yKebzLnYIaI=",
+        "lastModified": 1716847642,
+        "narHash": "sha256-rjEswRV0o23eBBils8lJXyIGha+l/VjV73IPg+ztxgk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "939375b39661c7b5d2533c9cd7be6117ed98896a",
+        "rev": "10c7c219b7dae5795fb67f465a0d86cbe29f25fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`10c7c219`](https://github.com/nix-community/home-manager/commit/10c7c219b7dae5795fb67f465a0d86cbe29f25fa) | `` listenbrainz-mpd: fix config example `` |
| [`90010df1`](https://github.com/nix-community/home-manager/commit/90010df15878762ff359e4fe391355a9dcad0bcf) | `` topgrade: update example config ``      |