### PR TITLE
chore(flake/home-manager): `373ead20` -> `a9b36cbe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -382,11 +382,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716908526,
-        "narHash": "sha256-Zl6e/sEVDh07K47XxDGPsXTYT4nI6llUDbQ4xMIwp7k=",
+        "lastModified": 1716930911,
+        "narHash": "sha256-t4HT5j3Jy7skRB5PINnxcEBCkgE89rGBpwTI7YS4Ffo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "373ead20606efa9181cd15ba19a5deac7ead1492",
+        "rev": "a9b36cbe9292a649222b89fdb9ae9907e9c74086",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`a9b36cbe`](https://github.com/nix-community/home-manager/commit/a9b36cbe9292a649222b89fdb9ae9907e9c74086) | `` gpg-agent: fix usage of splitString `` |