### PR TITLE
chore(flake/nixos-hardware): `806e9d4a` -> `8251761f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -490,11 +490,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1716881121,
-        "narHash": "sha256-oTf3enbe/lbiNzsyZ8ria+422hx4e/FB3xQcY2LPnJw=",
+        "lastModified": 1716987116,
+        "narHash": "sha256-uuEkErFVsFdg2K0cKbNQ9JlFSAm/xYqPr4rbPLI91Y8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "806e9d4a933dd1e75592e88894d4bd2f296f5bbf",
+        "rev": "8251761f93d6f5b91cee45ac09edb6e382641009",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                      |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`9e060313`](https://github.com/NixOS/nixos-hardware/commit/9e0603134617ec23ce67e1806e905ca07abc92d3) | `` Revert "starfive visionfive2: use mainline kernel" ``     |
| [`1e3c2a85`](https://github.com/NixOS/nixos-hardware/commit/1e3c2a85da63a4eb6dae4fa978064e47bcdbbe74) | `` Revert "starfive visionfive2: enable required drivers" `` |