### PR TITLE
chore(flake/treefmt): `52b66cad` -> `03b982b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -652,11 +652,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717078125,
-        "narHash": "sha256-V68CsekhPCF6Oz84t2FHY5jin4smKrmsS208Xw057zs=",
+        "lastModified": 1717182148,
+        "narHash": "sha256-Hi09/RoizxubRf3PHToT2Nm7TL8B/abSVa6q82uEgNI=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "52b66cade760e93276146eb057122b8011ab9057",
+        "rev": "03b982b77df58d5974c61c6022085bafe780c1cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                 |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`03b982b7`](https://github.com/numtide/treefmt-nix/commit/03b982b77df58d5974c61c6022085bafe780c1cf) | `` feat(dprint): allow custom options for external formatters (#180) `` |