### PR TITLE
chore(flake/stylix): `ebaed9d4` -> `99bcaa55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -617,11 +617,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717184467,
-        "narHash": "sha256-d1m43p1Pvh6LMkSHcwDadVIAQrm+2HFhVjQ3m7wzf84=",
+        "lastModified": 1717201670,
+        "narHash": "sha256-7tXlevpGhg+73g53RAS8gEOglTf9fPdVMlTOn8r7XAk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ebaed9d4bf258f4eda7d0690c4092fadcbeefa9d",
+        "rev": "99bcaa552096ccff21658a9eb6a1e8397b10eb78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                          |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`99bcaa55`](https://github.com/danth/stylix/commit/99bcaa552096ccff21658a9eb6a1e8397b10eb78) | `` stylix: standardize `autoEnable` and `mkEnableTarget` documentation (#398) `` |