### PR TITLE
chore(flake/nixos-hardware): `8251761f` -> `7b49d396`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -490,11 +490,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1716987116,
-        "narHash": "sha256-uuEkErFVsFdg2K0cKbNQ9JlFSAm/xYqPr4rbPLI91Y8=",
+        "lastModified": 1717248095,
+        "narHash": "sha256-e8X2eWjAHJQT82AAN+mCI0B68cIDBJpqJ156+VRrFO0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "8251761f93d6f5b91cee45ac09edb6e382641009",
+        "rev": "7b49d3967613d9aacac5b340ef158d493906ba79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                      |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`7b49d396`](https://github.com/NixOS/nixos-hardware/commit/7b49d3967613d9aacac5b340ef158d493906ba79) | `` starfive visionfive2: drop dtb overlay for 8GB version `` |
| [`69fe2563`](https://github.com/NixOS/nixos-hardware/commit/69fe256333b66ba6814290a0e1fda7cdba61807d) | `` starfive visionfive2: let u-boot set device tree name ``  |