### PR TITLE
chore(flake/stylix): `266db7f0` -> `3befd5d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -617,11 +617,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717212835,
-        "narHash": "sha256-fSNsRokB3YaTmJOcSdDzKJOFWq/bQ/FCoMGpF12sF5c=",
+        "lastModified": 1717268716,
+        "narHash": "sha256-hKM/D6Ni3+Ihvmy8pF+rOFgIqhphOEHUWqxJd+5ZV6Y=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "266db7f00cad4a465e0ce43d91798fda10716212",
+        "rev": "3befd5d693a2669dc7d2086b57298838ff71f24b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                 |
| --------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`3befd5d6`](https://github.com/danth/stylix/commit/3befd5d693a2669dc7d2086b57298838ff71f24b) | `` vim: interface colorscheme (#401) `` |