### PR TITLE
chore(flake/treefmt): `03b982b7` -> `3eb96ca1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -652,11 +652,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717182148,
-        "narHash": "sha256-Hi09/RoizxubRf3PHToT2Nm7TL8B/abSVa6q82uEgNI=",
+        "lastModified": 1717278143,
+        "narHash": "sha256-u10aDdYrpiGOLoxzY/mJ9llST9yO8Q7K/UlROoNxzDw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "03b982b77df58d5974c61c6022085bafe780c1cf",
+        "rev": "3eb96ca1ae9edf792a8e0963cc92fddfa5a87706",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                     |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`3eb96ca1`](https://github.com/numtide/treefmt-nix/commit/3eb96ca1ae9edf792a8e0963cc92fddfa5a87706) | `` hclfmt: only format .hcl files (#182) `` |