### PR TITLE
chore(flake/home-manager): `0eb314b4` -> `9b53a10f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -382,11 +382,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717097707,
-        "narHash": "sha256-HC5vJ3oYsjwsCaSbkIPv80e4ebJpNvFKQTBOGlHvjLs=",
+        "lastModified": 1717316182,
+        "narHash": "sha256-Xi0EpZcu39N0eW7apLjFfUOR9y80toyjYizez7J1wMI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0eb314b4f0ba337e88123e0b1e57ef58346aafd9",
+        "rev": "9b53a10f4c91892f5af87cf55d08fba59ca086af",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`9b53a10f`](https://github.com/nix-community/home-manager/commit/9b53a10f4c91892f5af87cf55d08fba59ca086af) | `` swayidle: wait for WAYLAND_DISPLAY ``   |
| [`62da78e1`](https://github.com/nix-community/home-manager/commit/62da78e1f8897706b9e5e890ffb86389b1d87333) | `` Translate using Weblate (Vietnamese) `` |
| [`bf381585`](https://github.com/nix-community/home-manager/commit/bf3815854e6c24d28ad4e7df96f2d3c3beda20f1) | `` Translate using Weblate (Finnish) ``    |
| [`c497bdc1`](https://github.com/nix-community/home-manager/commit/c497bdc12f591e57f85a6941976daec78db3f529) | `` flake.lock: Update ``                   |