### PR TITLE
chore(flake/lanzaboote): `2eb19b87` -> `990e300e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -431,11 +431,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1716805126,
-        "narHash": "sha256-yqJWx74e16Gk4pwW5DWfI4orTKeWezKFNbW7eaojpLw=",
+        "lastModified": 1717686691,
+        "narHash": "sha256-LF4zVaSsJ83wq6j+4lm/olK2V71KAJHNJbD42mF+fr8=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "2eb19b872bc0a5f336b9b934ba96ea029e4da8c2",
+        "rev": "990e300ef9abe0eb8c86388683f8d7465e335626",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                               |
| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`01a5b2d6`](https://github.com/nix-community/lanzaboote/commit/01a5b2d62d349e95300e1d52e49896a358cfc477) | `` stub: Fix encoding of StubPcrKernelImage ``        |
| [`e7da28d2`](https://github.com/nix-community/lanzaboote/commit/e7da28d23d69570e65d73f356c3e91849ce213f9) | `` stub: Fix encoding of TPM log entries ``           |
| [`788f6df6`](https://github.com/nix-community/lanzaboote/commit/788f6df6870e0fc98be3bf5c81ded6e52d346a8e) | `` tests: Add regression tests for encoding issues `` |