### PR TITLE
chore(flake/lanzaboote): `990e300e` -> `2675cac7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -431,11 +431,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1717686691,
-        "narHash": "sha256-LF4zVaSsJ83wq6j+4lm/olK2V71KAJHNJbD42mF+fr8=",
+        "lastModified": 1717801185,
+        "narHash": "sha256-FleTVdWcOx1xINRp1L/pPsNIPQCs5B3tXY+p11SOF7c=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "990e300ef9abe0eb8c86388683f8d7465e335626",
+        "rev": "2675cac7fe2ef576c661c9e23ec23eeeb8e8e287",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                          |
| --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`8d5cb360`](https://github.com/nix-community/lanzaboote/commit/8d5cb360249f29983461d5cabec75633434087a1) | `` tests.systemd-pcrlock: simplify and make more reproducible `` |
| [`b98c3d51`](https://github.com/nix-community/lanzaboote/commit/b98c3d514112353355a170a90110672edf8b3527) | `` rust/uefi: add explicit resolver to remove warning ``         |
| [`0397e0ce`](https://github.com/nix-community/lanzaboote/commit/0397e0ce03e736936c9d3ebb8845a00598984f75) | `` fix(deps): update all dependencies ``                         |