### PR TITLE
chore(flake/nixpkgs): `e8057b67` -> `051f9206`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -505,11 +505,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717602782,
-        "narHash": "sha256-pL9jeus5QpX5R+9rsp3hhZ+uplVHscNJh8n8VpqscM0=",
+        "lastModified": 1717786204,
+        "narHash": "sha256-4q0s6m0GUcN7q+Y2DqD27iLvbcd1G50T2lv08kKxkSI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e8057b67ebf307f01bdcc8fba94d94f75039d1f6",
+        "rev": "051f920625ab5aabe37c920346e3e69d7d34400e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`443f72c7`](https://github.com/NixOS/nixpkgs/commit/443f72c74e3b4d6cc843fd2a2c5fd0fba30d4f5a) | `` vimPlugins.cinnamon-nvim: init at 2024-04-26 ``                                        |
| [`2a15fd81`](https://github.com/NixOS/nixpkgs/commit/2a15fd815a40e034524d911ad74a3e496075ddd6) | `` undertime: init at 4.0.0 ``                                                            |
| [`d226935f`](https://github.com/NixOS/nixpkgs/commit/d226935fd75012939397c83f6c385e4d6d832288) | `` nixos/ddclient: deprecate `use`, implement `use{v4,v6}` ``                             |
| [`3defde03`](https://github.com/NixOS/nixpkgs/commit/3defde037d00940998ec525e8b802a8fdcffebb2) | `` geesefs: 0.41.0 -> 0.41.1 ``                                                           |
| [`03675de6`](https://github.com/NixOS/nixpkgs/commit/03675de619e66a760e69e477b2f9dabe484c9ecb) | `` kdePackages: Frameworks 6.2.x -> 6.3 ``                                                |
| [`bae8a7af`](https://github.com/NixOS/nixpkgs/commit/bae8a7af1d489f7ff327d7ed1be01ab09ebd5516) | `` python312Packages.aioaladdinconnect: drop ``                                           |
| [`db78a2bd`](https://github.com/NixOS/nixpkgs/commit/db78a2bd59fbd199d9508e0057536eefe0488006) | `` python312Packages.ambiclimate: drop ``                                                 |
| [`0ff3189a`](https://github.com/NixOS/nixpkgs/commit/0ff3189a2002d19600f0e06b7b85911d648e8b8b) | `` python312Packages.homeassistant-stubs: 2024.5.5 -> 2024.6.0 ``                         |
| [`ecac5c9c`](https://github.com/NixOS/nixpkgs/commit/ecac5c9c7fd0172d90ec9d57e5f45ee2f2934620) | `` home-assistant-custom-components.homematicip_local: 1.62.0 -> 1.63.0 ``                |
| [`3ac328bb`](https://github.com/NixOS/nixpkgs/commit/3ac328bbd6fc8c47c8c8c6f1c1ea741edb890b9f) | `` python312Packages.hahomematic: 2024.5.4 -> 2024.6.0 ``                                 |
| [`d1aa5ac2`](https://github.com/NixOS/nixpkgs/commit/d1aa5ac2d818e1ae8d9f7c026cf128648d1f1edc) | `` home-assistant: 2024.5.5 -> 2024.6.0 ``                                                |
| [`9fec7dfc`](https://github.com/NixOS/nixpkgs/commit/9fec7dfcc50be7939a63ce6a806246933e52cb9a) | `` python312Packages.voluptuous-openapi: init at 0.0.4 ``                                 |
| [`73616685`](https://github.com/NixOS/nixpkgs/commit/73616685c5cc3209b38fe86f40cda03249415b07) | `` brickstore: init at 0-unstable-2024-05-02 ``                                           |
| [`35a78b02`](https://github.com/NixOS/nixpkgs/commit/35a78b023d367b13243bbe8aad167727e4792213) | `` python312Packages.aiohttp-fast-zlib: init at 0.1.0 ``                                  |
| [`5ebff117`](https://github.com/NixOS/nixpkgs/commit/5ebff117f5a7eb0100020be05600899576c80724) | `` python312Packages.python-matter-server: 6.0.1 -> 6.1.0 ``                              |
| [`91915127`](https://github.com/NixOS/nixpkgs/commit/9191512744365d106d192eb11ee56d61721d0e8f) | `` python311Packages.zwave-js-server-python: 0.55.4 -> 0.56.0 (#312592) ``                |
| [`95726af3`](https://github.com/NixOS/nixpkgs/commit/95726af3eb484a393fe3fad58f05603a70981abb) | `` wyoming-satellite: relax wyoming constriant ``                                         |
| [`902b6e27`](https://github.com/NixOS/nixpkgs/commit/902b6e27ab70bd6c54e8e5088fc7ddabcd67531c) | `` wyoming-openwakeword: relax wyoming constraint ``                                      |
| [`f2f64008`](https://github.com/NixOS/nixpkgs/commit/f2f64008102acb38ad7b8447f48828e68cd144f2) | `` python312Packages.wyoming: 1.5.3 -> 1.5.4 ``                                           |
| [`8c70d559`](https://github.com/NixOS/nixpkgs/commit/8c70d559a287c47753baabf63b481e3b8df1b067) | `` python312Packages.universal-silabs-flasher: 0.0.19 -> 0.0.20 ``                        |
| [`a16aaac2`](https://github.com/NixOS/nixpkgs/commit/a16aaac2f3c73e043dc62ebed317e89d61664941) | `` python312Packages.renault-api: 0.2.2 -> 0.2.3 (#317124) ``                             |
| [`4f414748`](https://github.com/NixOS/nixpkgs/commit/4f414748bc4c43940ac299617269b2beadb66525) | `` python-matter-server: 5.10.0 -> 6.0.1 ``                                               |
| [`631cc4c1`](https://github.com/NixOS/nixpkgs/commit/631cc4c15899088432b787d011a5744bc6ba3798) | `` python3Packages.home-assistant-chip-clusters: 2024.3.2 -> 2024.5.2 ``                  |
| [`08b13fe6`](https://github.com/NixOS/nixpkgs/commit/08b13fe6f7435cc2eae90aac12a420ac616e7a22) | `` python3Packages.home-assistant-chip-core: 2024.3.2 -> 2024.5.2 ``                      |
| [`b82b920d`](https://github.com/NixOS/nixpkgs/commit/b82b920da276ee624b857e2ca7284de7e015cda5) | `` python311Packages.python-homewizard-energy: 5.0.0 -> 6.0.0 (#313937) ``                |
| [`529336d2`](https://github.com/NixOS/nixpkgs/commit/529336d27580f2aa3d297d4ed5881ae1065d2424) | `` python312Packages.pylaunches: 1.4.0 -> 2.0.0 (#315806) ``                              |
| [`f3578bec`](https://github.com/NixOS/nixpkgs/commit/f3578becf836c5e1237ff5b8d046052eb0fa50ee) | `` python312Packages.pyefergy: 22.1.1 -> 22.5.0 ``                                        |
| [`d47e55f8`](https://github.com/NixOS/nixpkgs/commit/d47e55f87608456af3250f07ded2d3ccdaa2f4d6) | `` python312Packages.pydrawise: 2024.6.1 -> 2024.6.2 ``                                   |
| [`0e6b164f`](https://github.com/NixOS/nixpkgs/commit/0e6b164fe3eac43f1306fcb421641791356f083e) | `` python312Packages.nettigo-air-monitor: 3.0.1 -> 3.1.0 ``                               |
| [`c9debc32`](https://github.com/NixOS/nixpkgs/commit/c9debc32d3458e470f0930151aebe4cb97e3ac63) | `` home-assistant.intents: 2024.4.24 -> 2024.6.5 ``                                       |
| [`19f8ee54`](https://github.com/NixOS/nixpkgs/commit/19f8ee540d27f6ce0ba537da2310b1372e180b7b) | `` python312Packages.hdate: 0.10.4 -> 0.10.8 ``                                           |
| [`b51a6375`](https://github.com/NixOS/nixpkgs/commit/b51a63759f2b86775b5c94494a419c1061357c9d) | `` python312Packages.hassil: 1.6.1 -> 1.7.1 ``                                            |
| [`53567c06`](https://github.com/NixOS/nixpkgs/commit/53567c06c3a640452100df149acfa52e51713ada) | `` python312Packages.hass-nabucasa: 0.81.0 -> 0.81.1 ``                                   |
| [`8aa58d71`](https://github.com/NixOS/nixpkgs/commit/8aa58d71f6e80aef536660dc074615d09701e2f8) | `` python312Packages.home-assistant-bluetooth: fix habluetooth 3.0 compat ``              |
| [`444fa7e2`](https://github.com/NixOS/nixpkgs/commit/444fa7e26339de16e46919ebae4278d36a645bec) | `` python312Packages.bthome-ble: fix habluetooth 3.0 compat ``                            |
| [`cb046ed0`](https://github.com/NixOS/nixpkgs/commit/cb046ed0a57eaf53ffeeb9b303817a766918d9d5) | `` python312Packages.habluetooth: 2.8.1 -> 3.1.1 ``                                       |
| [`c6fcba64`](https://github.com/NixOS/nixpkgs/commit/c6fcba645eb6a210a08607357564a9a9b5272cb8) | `` python312Packages.habitipy: 0.3.0 -> 0.3.1 ``                                          |
| [`cf36eedc`](https://github.com/NixOS/nixpkgs/commit/cf36eedc49afda3d5d8cc065d124a387f233a596) | `` python312Packages.govee-local-api: 1.4.5 -> 1.5.0 ``                                   |
| [`cf8c1b98`](https://github.com/NixOS/nixpkgs/commit/cf8c1b9845254a979c846b619e28c21bcd1ed840) | `` python312Packages.google-nest-sdm: 3.0.4 -> 4.0.4 ``                                   |
| [`0b14227c`](https://github.com/NixOS/nixpkgs/commit/0b14227c074b9ee70c7158c758e73b3630615d8b) | `` python311Packages.bimmer-connected: 0.15.2 -> 0.15.3 (#315202) ``                      |
| [`62b11736`](https://github.com/NixOS/nixpkgs/commit/62b11736134eb61316957a60cc171eeeb4ca4544) | `` python311Packages.bellows: 0.38.4 -> 0.39.0 (#315291) ``                               |
| [`5b5e8957`](https://github.com/NixOS/nixpkgs/commit/5b5e8957eec05c5f4e72ca9482b3b14b4674f2e8) | `` python312Packages.arcam-fmj: 1.4.0 -> 1.5.2 ``                                         |
| [`535c6cd2`](https://github.com/NixOS/nixpkgs/commit/535c6cd2ac7d5d425ec59f9c49ff597507c765f6) | `` python312Packages.aioautomower: 2024.4.4 -> 2024.5.0 (#309638) ``                      |
| [`7316e2d8`](https://github.com/NixOS/nixpkgs/commit/7316e2d8796e6a00aa61133481fd9de5a0349669) | `` webp-pixbuf-loader: fix cross-comilation ``                                            |
| [`bebf27e5`](https://github.com/NixOS/nixpkgs/commit/bebf27e522546756fce284903f8038c6ac5f0f23) | `` telegram-desktop: 5.1.2 -> 5.1.5 ``                                                    |
| [`d38e5ce8`](https://github.com/NixOS/nixpkgs/commit/d38e5ce8cf742f32c82b81cbd7b6537470313b78) | `` python311Packages.uv: 0.2.6 -> 0.2.9 ``                                                |
| [`43212c70`](https://github.com/NixOS/nixpkgs/commit/43212c704a0cb395d3fcc4795c33984b650cf65c) | `` nwg-dock-hyprland: 0.1.8 -> 0.1.9 ``                                                   |
| [`8eb7a98b`](https://github.com/NixOS/nixpkgs/commit/8eb7a98bbb7ca7a7ac19e9b1609ec760cc649618) | `` mycelium: 0.5.2 -> 0.5.3 ``                                                            |
| [`6477cb49`](https://github.com/NixOS/nixpkgs/commit/6477cb49a5fd4e6bd2e15bad2f7e19f953f5d4f9) | `` nixos/lomiri: Add file manager ``                                                      |
| [`4a495ec7`](https://github.com/NixOS/nixpkgs/commit/4a495ec755c826f6b23147a6a77dd2148c934f18) | `` tests/lomiri-filemanager-app: init ``                                                  |
| [`7f084b0f`](https://github.com/NixOS/nixpkgs/commit/7f084b0fe1ec8daef5c77fe76d1407b57e4389bb) | `` lomiri.lomiri-filemanager-app: init at 1.0.4 ``                                        |
| [`4b572dec`](https://github.com/NixOS/nixpkgs/commit/4b572dece987b31c2581d79b679d80c0f0d87d7c) | `` mame: 0.265 -> 0.266 ``                                                                |
| [`3b6aab13`](https://github.com/NixOS/nixpkgs/commit/3b6aab1336a66f6a6457e47e6b9de5f3bec7a227) | `` mactop: init at 0.1.8 ``                                                               |
| [`902ca5b4`](https://github.com/NixOS/nixpkgs/commit/902ca5b470cf78d88b21d0c8fb6ba70dff055738) | `` nixos/opengl: fix typo ``                                                              |
| [`ae6f28ac`](https://github.com/NixOS/nixpkgs/commit/ae6f28ac9821ba4194f3c15926e337a65fc58428) | `` python311Packages.angr: 9.2.104 -> 9.2.105 ``                                          |
| [`2ce200b3`](https://github.com/NixOS/nixpkgs/commit/2ce200b317f32bf8b82b8f94c41d8443dfe59042) | `` python312Packages.claripy: 9.2.104 -> 9.2.105 ``                                       |
| [`191898d8`](https://github.com/NixOS/nixpkgs/commit/191898d89e0cd6493ea1cb6d264ff970585e4b77) | `` python312Packages.cle: 9.2.104 -> 9.2.105 ``                                           |
| [`f073ceac`](https://github.com/NixOS/nixpkgs/commit/f073ceac84308c5abab5f3d7c2506b586469b635) | `` python312Packages.pyvex: 9.2.104 -> 9.2.105 ``                                         |
| [`70e7cdb6`](https://github.com/NixOS/nixpkgs/commit/70e7cdb6843a8192ee617104aff4d88fbc416e36) | `` python312Packages.ailment: 9.2.104 -> 9.2.105 ``                                       |
| [`66c4c2c0`](https://github.com/NixOS/nixpkgs/commit/66c4c2c04a449ebeea5b79a3b118581c46e2e17c) | `` lix.tests: fix the eval ``                                                             |
| [`564d9773`](https://github.com/NixOS/nixpkgs/commit/564d97734c668121f9221270ba9b4efa6736d2ac) | `` python312Packages.archinfo: 9.2.104 -> 9.2.105 ``                                      |
| [`5ac829a1`](https://github.com/NixOS/nixpkgs/commit/5ac829a12b398c11d5821ed600e301b4c104ee41) | `` python311Packages.torchrl: disable flaky tests ``                                      |
| [`8e66e256`](https://github.com/NixOS/nixpkgs/commit/8e66e256f635155e68a34d625c2badda7bb0eb4e) | `` home-assistant-custom-lovelace-modules.mushroom: 3.6.1 -> 3.6.2 ``                     |
| [`5f661659`](https://github.com/NixOS/nixpkgs/commit/5f66165919eacdb011b9f6b4fc740bce66234d9a) | `` ghauri: refactor ``                                                                    |
| [`5fd3d5ab`](https://github.com/NixOS/nixpkgs/commit/5fd3d5abe12e1380e4022e34dc7c64d80664e2ba) | `` python312Packages.rich-argparse: refactor ``                                           |
| [`6fda200f`](https://github.com/NixOS/nixpkgs/commit/6fda200fa49ff324652eb0e6a51840d58e14849d) | `` nixos/inadyn: fix cache directory path ``                                              |
| [`d9dab762`](https://github.com/NixOS/nixpkgs/commit/d9dab762a00ec112eb139e7b9d806777a9b173b6) | `` mattermost: 9.5.5 → 9.5.6 (#317284) ``                                                 |
| [`4d7e6d5b`](https://github.com/NixOS/nixpkgs/commit/4d7e6d5bc406c135ba2563d6e6164fbf1f38e888) | `` govulncheck: add changelog to meta ``                                                  |
| [`9c7a39e6`](https://github.com/NixOS/nixpkgs/commit/9c7a39e691e19c8ae8e16c85bc215e6b1dacdb85) | `` python312Packages.twilio: 9.1.0 -> 9.1.1 ``                                            |
| [`505c2d8b`](https://github.com/NixOS/nixpkgs/commit/505c2d8bde011241cceff29539553014b00c4289) | `` python312Packages.lingva: 5.0.2 -> 5.0.3 ``                                            |
| [`a6574c05`](https://github.com/NixOS/nixpkgs/commit/a6574c05a915b37d3947563f45d0df2a6544c281) | `` python312Packages.tencentcloud-sdk-python: 3.0.1163 -> 3.0.1164 ``                     |
| [`891a44e6`](https://github.com/NixOS/nixpkgs/commit/891a44e68a296e81a77aa7b16315ffafe734df9a) | `` python312Packages.botocore-stubs: 1.34.120 -> 1.34.121 ``                              |
| [`9693ba8d`](https://github.com/NixOS/nixpkgs/commit/9693ba8dc8448e1bd60abe49f902d3a56bf48c51) | `` python312Packages.boto3-stubs: 1.34.120 -> 1.34.121 ``                                 |
| [`2be5bbe0`](https://github.com/NixOS/nixpkgs/commit/2be5bbe055bed0e89de821fe9b879b49b0dbf805) | `` python312Packages.adafruit-platformdetect: 3.68.0 -> 3.69.0 ``                         |
| [`e4ce30cc`](https://github.com/NixOS/nixpkgs/commit/e4ce30ccd8588e16e187e0922472eea3b75bb4f3) | `` python311Packages.securityreporter: 1.0.2 -> 1.1.0 ``                                  |
| [`ae7ffcf7`](https://github.com/NixOS/nixpkgs/commit/ae7ffcf742cbca15a3e09317a7cb578a6304020f) | `` python311Packages.rich-argparse: 1.4.0 -> 1.5.1 ``                                     |
| [`3ccd73d4`](https://github.com/NixOS/nixpkgs/commit/3ccd73d418c634588b54e898a25855c0e9e50ad2) | `` workout-tracker: 0.14.3 -> 0.15.0 ``                                                   |
| [`92555723`](https://github.com/NixOS/nixpkgs/commit/92555723b73f186b80c9ec89f366e6c52a560e1b) | `` python311Packages.mujoco: add TODO for updating the dependencies ``                    |
| [`3970550d`](https://github.com/NixOS/nixpkgs/commit/3970550db5728b85c66c7dbb4f28ed680881525d) | `` python311Packages.mujoco: add GaetanLepage to maintainers ``                           |
| [`da2ccbae`](https://github.com/NixOS/nixpkgs/commit/da2ccbae0d6082acf447bf33dcf78f41e9f7794c) | `` python311Packages.mujoco: 3.1.5 -> 3.1.6 ``                                            |
| [`7e7ddf4e`](https://github.com/NixOS/nixpkgs/commit/7e7ddf4e4cc4cbf4af00d3ea35a658d63ed03c19) | `` mujoco: add GaetanLepage to maintainers ``                                             |
| [`1dcda38e`](https://github.com/NixOS/nixpkgs/commit/1dcda38ec7aa24de2cc6b2ebe3c43b03a4616cf9) | `` mujoco: 3.1.5 -> 3.1.6 ``                                                              |
| [`db79845f`](https://github.com/NixOS/nixpkgs/commit/db79845fb209424e6516c3f5f102910e6e694d6a) | `` python311Packages.jupyter-nbextensions-configurator: remove useless nose dependency `` |
| [`317f3ebe`](https://github.com/NixOS/nixpkgs/commit/317f3ebe0a4c0f0eca138c530de7f9131ad0c8da) | `` usql: 0.19.1 -> 0.19.2 ``                                                              |
| [`f828b1cb`](https://github.com/NixOS/nixpkgs/commit/f828b1cb5d6a0a5df0cfc06bd4941d539ad7eeff) | `` checkov: 3.2.112 -> 3.2.128 ``                                                         |
| [`bc4bfcb8`](https://github.com/NixOS/nixpkgs/commit/bc4bfcb82b6ee62c0f56a4b8b16516dea8e2851b) | `` goperf: 0-unstable-2024-05-10 -> 0-unstable-2024-06-04 ``                              |
| [`e2bbb684`](https://github.com/NixOS/nixpkgs/commit/e2bbb6841ef64147d2a7d39fc8ed90f50ddd7a0b) | `` python311Packages.reolink-aio: 0.9.0 -> 0.9.1 ``                                       |
| [`236394a6`](https://github.com/NixOS/nixpkgs/commit/236394a6ba5648fb274ee571360d1bb39ee41221) | `` zpaqfranz: 59.6 -> 59.7 ``                                                             |
| [`54693ba6`](https://github.com/NixOS/nixpkgs/commit/54693ba6fb7f595bb955514aec9da83998931f3b) | `` home-manager: 0-unstable-2024-05-30 -> 0-unstable-2024-06-04 ``                        |
| [`ab58c8b5`](https://github.com/NixOS/nixpkgs/commit/ab58c8b5f712cd42aecec308001e0977cc04f27b) | `` php82Extensions.mongodb: 1.19.1 -> 1.19.2 ``                                           |
| [`6e5c9a80`](https://github.com/NixOS/nixpkgs/commit/6e5c9a8064826812096631ff364eb3622fa7efa6) | `` jujutsu: 0.17.1 -> 0.18.0 ``                                                           |
| [`5e97bc3b`](https://github.com/NixOS/nixpkgs/commit/5e97bc3b0a78cd37d4bf094933dee426a8e6cf62) | `` renovate: init at 37.393.0 ``                                                          |
| [`586c14ed`](https://github.com/NixOS/nixpkgs/commit/586c14ed04db9407eb406167837c1633e3c7521c) | `` govulncheck: 1.1.1 -> 1.1.2 ``                                                         |
| [`4ca55358`](https://github.com/NixOS/nixpkgs/commit/4ca55358d81873b9b268e268f85c768985ee69b0) | `` icewm: 3.5.0 -> 3.5.1 ``                                                               |
| [`1da44632`](https://github.com/NixOS/nixpkgs/commit/1da4463227a52d0f6be2291437d1f02653407d3f) | `` go2rtc: 1.9.2 -> 1.9.3 ``                                                              |
| [`4599a6f5`](https://github.com/NixOS/nixpkgs/commit/4599a6f571f39a03e84cb1d5813427a32984289f) | `` dub: 1.33.0 -> 1.38.0 ``                                                               |
| [`ce053c4b`](https://github.com/NixOS/nixpkgs/commit/ce053c4bc8e2636d23a957ab81a664894eb1abff) | `` dub: clean up ``                                                                       |
| [`93fdac5b`](https://github.com/NixOS/nixpkgs/commit/93fdac5bd41b676a81c40f8166fee7d0c8c17987) | `` chatgpt-shell-cli: init at unstable-2023-05-16 ``                                      |
| [`6f528eca`](https://github.com/NixOS/nixpkgs/commit/6f528eca318caff4ca953578256295e2ab9515e3) | `` python311Packages.dsmr-parser: 1.4.0 -> 1.4.1 ``                                       |
| [`db5f339e`](https://github.com/NixOS/nixpkgs/commit/db5f339eecfd56009fd1f6d147a0bb02e76f8de5) | `` fishPlugins.wakatime-fish: unbreak (#317803) ``                                        |
| [`06f646cb`](https://github.com/NixOS/nixpkgs/commit/06f646cbecb48678b6d1e6b8af887d26bc9c7742) | `` werf: 2.3.3 -> 2.4.1 ``                                                                |
| [`068dda73`](https://github.com/NixOS/nixpkgs/commit/068dda7325ade9e0fd73bbbb2e9a74f3ed0314fa) | `` nvidia-x11: move wrapGAppsHook3 to nativeBuildInputs ``                                |
| [`b7e9c3c1`](https://github.com/NixOS/nixpkgs/commit/b7e9c3c1765eecae846b91ee4f917a621673a23d) | `` php81Packages.phpstan: 1.11.2 -> 1.11.4 ``                                             |
| [`b6e0e270`](https://github.com/NixOS/nixpkgs/commit/b6e0e270bb0641d13a0412d70c8e7d2d572d85e4) | `` qovery-cli: 0.93.6 -> 0.94.4 ``                                                        |
| [`c54e9b19`](https://github.com/NixOS/nixpkgs/commit/c54e9b19936c72091e949f90167933603b707ffe) | `` redpanda-client: 24.1.4 -> 24.1.6 ``                                                   |
| [`7d8e5da3`](https://github.com/NixOS/nixpkgs/commit/7d8e5da3013c9af16c056b1ba0247d5a78492d4e) | `` rs-tftpd: 0.2.12 -> 0.2.13 ``                                                          |
| [`0fdf6e29`](https://github.com/NixOS/nixpkgs/commit/0fdf6e29177a68cd6d4307f2a57b8cce109af0b3) | `` nixos/netbird: fix defaults (#314656) ``                                               |
| [`ae2d3e68`](https://github.com/NixOS/nixpkgs/commit/ae2d3e6823f98b55dfa064fff5a81ed26be9343c) | `` python311Packages.rye: 2.23.0 -> 2.24.0 ``                                             |
| [`e70c4f3e`](https://github.com/NixOS/nixpkgs/commit/e70c4f3efb176c3192eb071745eff3520590304f) | `` maintainers: add legojames ``                                                          |
| [`3b58ac58`](https://github.com/NixOS/nixpkgs/commit/3b58ac5892203e264d7d66bbf866615b90762cf2) | `` php83: 8.3.7 -> 8.3.8 ``                                                               |
| [`68b4e2b8`](https://github.com/NixOS/nixpkgs/commit/68b4e2b8112c8d1dc3b7a0ed5942dead05a4b157) | `` php82: 8.2.19 -> 8.2.20 ``                                                             |
| [`f7dea8a8`](https://github.com/NixOS/nixpkgs/commit/f7dea8a84a7188e5e5d4f7c8e6fa440480e5ead0) | `` php81: 8.1.28 -> 8.1.29 ``                                                             |
| [`11cf96a1`](https://github.com/NixOS/nixpkgs/commit/11cf96a167b1bef2b09d948c2bd60ff7ec2d1037) | `` latexminted: 0.1.0b2 -> 0.1.0b5 ``                                                     |
| [`ac556616`](https://github.com/NixOS/nixpkgs/commit/ac556616107cd3b26db0369e3192a35848795bab) | `` pgrok: migrate to pnpm.fetchDeps ``                                                    |
| [`49e8fe03`](https://github.com/NixOS/nixpkgs/commit/49e8fe03c619aeab627476e693470c269b788d72) | `` cilium-cli: 0.16.8 -> 0.16.9 ``                                                        |
| [`cc84ae23`](https://github.com/NixOS/nixpkgs/commit/cc84ae23024ebf651f254ed2c1c78d417f370ac3) | `` ascii: 3.20 -> 3.30 ``                                                                 |
| [`64b9766d`](https://github.com/NixOS/nixpkgs/commit/64b9766dbaf33bc3fc1d55cb4054d3f25e69b13d) | `` ascii: refactor ``                                                                     |
| [`255eb15d`](https://github.com/NixOS/nixpkgs/commit/255eb15db3198790cc5ad5d98f39f7d37296c52f) | `` grafana-alloy: install shell completions ``                                            |
| [`c590fba5`](https://github.com/NixOS/nixpkgs/commit/c590fba5737787bcf175745a97067aafd449a852) | `` grafana-alloy: set mainProgram ``                                                      |
| [`3d235b4c`](https://github.com/NixOS/nixpkgs/commit/3d235b4c350f3740f105bef76f963456574d1dc9) | `` grafana-alloy: 1.0.0 -> 1.1.1 ``                                                       |
| [`0c88d126`](https://github.com/NixOS/nixpkgs/commit/0c88d126e7a7917e89a28279ae355fc92aec44d4) | `` grafana-alloy: fix build for darwin ``                                                 |
| [`700bf79c`](https://github.com/NixOS/nixpkgs/commit/700bf79c6b9ae1f2263756e28084e8e6b777e9a6) | `` grafana-alloy: init at 1.0.0 ``                                                        |
| [`a12b6b05`](https://github.com/NixOS/nixpkgs/commit/a12b6b0555c79c1d9b949ec01355d0565737e810) | `` pgrok: move to by-name ``                                                              |
| [`d816964f`](https://github.com/NixOS/nixpkgs/commit/d816964f24d4a93620fc144e569f7b9b14e889c8) | `` shopware-cli: 0.4.44 -> 0.4.47 ``                                                      |
| [`145900ec`](https://github.com/NixOS/nixpkgs/commit/145900ec1adb9fb6f271b3dbaba02a61255d12a4) | `` surrealdb: 1.5.1 -> 1.5.2 ``                                                           |
| [`b0ed5ce2`](https://github.com/NixOS/nixpkgs/commit/b0ed5ce2fc88c3482288eaf54fbb288ed486c220) | `` buffer: init at 0.9.2 ``                                                               |