### PR TITLE
chore(flake/nix-index-database): `412a5428` -> `55184c76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717901846,
-        "narHash": "sha256-PmuGHv86tMknr6l0sCaU1oz0oCRrsslA3MtyjEz/T5I=",
+        "lastModified": 1717902477,
+        "narHash": "sha256-lDzxXGZMD9ZAevogw5TsXz+0tovTi3mHs9qAHbYwk9o=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "412a5428da031950f767db91bf7864ac442cdcd8",
+        "rev": "55184c7660d580878f7a2bc344629b1b36b5de1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`55184c76`](https://github.com/nix-community/nix-index-database/commit/55184c7660d580878f7a2bc344629b1b36b5de1c) | `` update packages.nix to release 2024-06-09-030647 `` |