### PR TITLE
chore(flake/nix-index-database): `55184c76` -> `afc8f5a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717902477,
-        "narHash": "sha256-lDzxXGZMD9ZAevogw5TsXz+0tovTi3mHs9qAHbYwk9o=",
+        "lastModified": 1717916109,
+        "narHash": "sha256-RsnoWp6Qvj+WVH0r7L7JljO5t3HUc3lGLJsTcru3CE4=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "55184c7660d580878f7a2bc344629b1b36b5de1c",
+        "rev": "afc8f5a6a2c00a89a6d6bdcaf4157797960f10f7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                   |
| ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`afc8f5a6`](https://github.com/nix-community/nix-index-database/commit/afc8f5a6a2c00a89a6d6bdcaf4157797960f10f7) | `` flake: capitalize NixOS ``             |
| [`4949c3ea`](https://github.com/nix-community/nix-index-database/commit/4949c3eac75f949bf3a0f8cb40e63b98009dff67) | `` modules: lint and standardize ``       |
| [`a1578050`](https://github.com/nix-community/nix-index-database/commit/a1578050b6d24e3525135d60c227d322c70abed9) | `` wrappers: rework to use symlinkJoin `` |