### PR TITLE
chore(flake/nix-index-database): `afc8f5a6` -> `a157a81d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717916109,
-        "narHash": "sha256-RsnoWp6Qvj+WVH0r7L7JljO5t3HUc3lGLJsTcru3CE4=",
+        "lastModified": 1717919703,
+        "narHash": "sha256-4i/c31+dnpv6KdUA3BhbMDS9Lvg/CDin78caYJlq0bY=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "afc8f5a6a2c00a89a6d6bdcaf4157797960f10f7",
+        "rev": "a157a81d0a4bc909b2b6666dd71909bcdc8cd0d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`a157a81d`](https://github.com/nix-community/nix-index-database/commit/a157a81d0a4bc909b2b6666dd71909bcdc8cd0d6) | `` update generated.nix to release 2024-06-09-074536 `` |
| [`25d61492`](https://github.com/nix-community/nix-index-database/commit/25d61492b32cc4eb46b0854c8a0c79b685d5e9f2) | `` reformat with nixfmt ``                              |
| [`b26661c0`](https://github.com/nix-community/nix-index-database/commit/b26661c0b9d25622ff70030f77e6c91d817471e0) | `` switch to nixfmt as a formatter ``                   |
| [`2d96e703`](https://github.com/nix-community/nix-index-database/commit/2d96e70391edb6a2e17211cfd21aacd943486e2f) | `` add nix 2.18 as a requirement ``                     |
| [`2a2e1acc`](https://github.com/nix-community/nix-index-database/commit/2a2e1acc4a1d698c72fb77c69798c4894174a935) | `` misc: remove dead code ``                            |
| [`24089882`](https://github.com/nix-community/nix-index-database/commit/2408988240f6706906f7b1c6e36424e81e8e3431) | `` flake: warn about legacyPackages ``                  |
| [`7e312cd4`](https://github.com/nix-community/nix-index-database/commit/7e312cd4442a63228c8008d0300c9438f4dc7118) | `` packages: use nixpkgs fetchers ``                    |
| [`b6dddcb5`](https://github.com/nix-community/nix-index-database/commit/b6dddcb5bed8af7e748131424d5062e8aec76882) | `` workflow: rework ``                                  |
| [`ca7e10c6`](https://github.com/nix-community/nix-index-database/commit/ca7e10c63d06c7a66d58a1db48b3ba3bd1fd0adf) | `` modules: don't set _module.args ``                   |