### PR TITLE
chore(flake/lanzaboote): `e8850266` -> `547c7bfe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -431,11 +431,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1717801791,
-        "narHash": "sha256-CEotbHLdhkltv8OsHojqN1cJynVMNOX+0lJgqIoD6Gk=",
+        "lastModified": 1717939038,
+        "narHash": "sha256-4ikPv/aoEdNH7fSWGHX/c1uMud+cf/hYOzWi+xo/Aqk=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "e8850266af6aedfd73c46c7518fd54c1f6c89e7b",
+        "rev": "547c7bfe330aded64a20444a6cd3bc8c8b0b41d0",
         "type": "github"
       },
       "original": {
@@ -583,11 +583,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717726729,
-        "narHash": "sha256-2WDKLjVRKWXbadnJHSOUb46PTq3D5nS89vhHTphRw1M=",
+        "lastModified": 1717813066,
+        "narHash": "sha256-wqbRwq3i7g5EHIui0bIi84mdqZ/It1AXBSLJ5tafD28=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7f52ac9ae95bd60c0780d6e32baea22e542e11e1",
+        "rev": "6dc3e45fe4aee36efeed24d64fc68b1f989d5465",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                     |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`b1589082`](https://github.com/nix-community/lanzaboote/commit/b158908292e5376d08cf1af432d7db08c5e8d994) | `` flake.nix: remove superfluous follow ``  |
| [`c93ca771`](https://github.com/nix-community/lanzaboote/commit/c93ca7718839fc5fef024da4983ae304fd7fa1d0) | `` uefi: rename config to remove warning `` |
| [`3028f853`](https://github.com/nix-community/lanzaboote/commit/3028f853d93398866ef7c5143dec951016140a34) | `` flake.nix: remove craneLib warning ``    |
| [`ad6af755`](https://github.com/nix-community/lanzaboote/commit/ad6af75547de842868e605c3c999b47d08d244a1) | `` flake.lock: Update ``                    |