### PR TITLE
chore(flake/lanzaboote): `547c7bfe` -> `56ed078d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -431,11 +431,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1717939038,
-        "narHash": "sha256-4ikPv/aoEdNH7fSWGHX/c1uMud+cf/hYOzWi+xo/Aqk=",
+        "lastModified": 1717943411,
+        "narHash": "sha256-43QN3+P7UjAz5ZjjUeYGKAyRfv6BLw7jjdc8Ric/6UQ=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "547c7bfe330aded64a20444a6cd3bc8c8b0b41d0",
+        "rev": "56ed078dc92baf72813d55dcfe399715a632bc41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                         |
| --------------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`1b4d62e1`](https://github.com/nix-community/lanzaboote/commit/1b4d62e1555fcb67b3e8c8f2a7070d946bbeee06) | `` rust: update 1.75 -> 1.78 `` |