### PR TITLE
chore(flake/nixos-hardware): `057a7996` -> `58b52b0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -490,11 +490,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1717828156,
-        "narHash": "sha256-YvstO0lobf3JWQuAfZCLYRTROC2ZDEgtWeQtWbO49p4=",
+        "lastModified": 1717995329,
+        "narHash": "sha256-lQJXEFHHVsFdFLx0bvoRbZH3IXUBsle6EWj9JroTJ/s=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "057a7996d012f342a38a26261ee529cebb1755ef",
+        "rev": "58b52b0dd191af70f538c707c66c682331cfdffc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`58b52b0d`](https://github.com/NixOS/nixos-hardware/commit/58b52b0dd191af70f538c707c66c682331cfdffc) | `` Add configuration for Lenovo IdeaPad 5 Pro 16ACH6 `` |
| [`35f2177d`](https://github.com/NixOS/nixos-hardware/commit/35f2177d6656b4db8797f4dbb0f9a70e34fbbc8f) | `` apple/t2: update to kernel 6.9.3 ``                  |