### PR TITLE
chore(flake/nix-index-database): `a157a81d` -> `ab78ec24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717919703,
-        "narHash": "sha256-4i/c31+dnpv6KdUA3BhbMDS9Lvg/CDin78caYJlq0bY=",
+        "lastModified": 1717995391,
+        "narHash": "sha256-lcJ7McLYCOZGmoUqWubg739iFIqVtPD+qDNQx6GPWCY=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "a157a81d0a4bc909b2b6666dd71909bcdc8cd0d6",
+        "rev": "ab78ec24f803bab7a18370220ae3db92d6d33c94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                   |
| ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`44e1ea50`](https://github.com/nix-community/nix-index-database/commit/44e1ea50a6146ebba87645d8ae36227589ebcee9) | `` drop version nix-index 0.1.6 checks `` |