### PR TITLE
chore(flake/deploy-rs): `b3ea6f33` -> `9c314763`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -213,11 +213,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715699772,
-        "narHash": "sha256-sKhqIgucN5sI/7UQgBwsonzR4fONjfMr9OcHK/vPits=",
+        "lastModified": 1718020088,
+        "narHash": "sha256-zi/5nEeOiDEKWvXYlW4nYQIVQeLihytUn/c0dbIy5ek=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "b3ea6f333f9057b77efd9091119ba67089399ced",
+        "rev": "9c3147639c233f80d333fe81f463b0a87fc49764",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                              |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`20261c64`](https://github.com/serokell/deploy-rs/commit/20261c6428220b0a849e9745d682711144907b49) | `` add test for allow_hyphen_values of --ssh-opts `` |
| [`ddf42d72`](https://github.com/serokell/deploy-rs/commit/ddf42d723837cb8545aced7980f892947408e234) | `` allow --ssh-opts that starts with hyphen ``       |
| [`e8189232`](https://github.com/serokell/deploy-rs/commit/e8189232236e9ac5977dca025d2c9af651092b23) | `` Link to new official wiki ``                      |