### PR TITLE
chore(flake/deploy-rs): `9c314763` -> `ea0aaeb2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -213,11 +213,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718020088,
-        "narHash": "sha256-zi/5nEeOiDEKWvXYlW4nYQIVQeLihytUn/c0dbIy5ek=",
+        "lastModified": 1718111523,
+        "narHash": "sha256-AeJpRoIT4H+MLLgd+F8HUPA+6hOXRiSOZ5RpmNP9Xvg=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "9c3147639c233f80d333fe81f463b0a87fc49764",
+        "rev": "ea0aaeb222ed07722b05ef2d8fbb840df4f77c49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                         |
| --------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`e7638a78`](https://github.com/serokell/deploy-rs/commit/e7638a7867b01739f24c73dfadc5e0b0a3a13b95) | `` better error messages: provide node names `` |