### PR TITLE
chore(flake/stylix): `f060e405` -> `e59d2c17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -617,11 +617,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718068864,
-        "narHash": "sha256-Qjfu3bHVexzJVq0++UiuOa56a7ZvOmJ9wu1UpNvCuOE=",
+        "lastModified": 1718122552,
+        "narHash": "sha256-A+dBkSwp8ssHKV/WyXb9uqIYrHBqHvtSedU24Lq9lqw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f060e4059b408b2cc1891ce655d0f6bef4e21a5b",
+        "rev": "e59d2c1725b237c362e4a62f5722f5b268d566c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                       |
| --------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`e59d2c17`](https://github.com/danth/stylix/commit/e59d2c1725b237c362e4a62f5722f5b268d566c7) | `` swaylock: remove `optionalAttrs` (#420) `` |