### PR TITLE
chore(flake/home-manager): `3d65009e` -> `892f76bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -382,11 +382,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717931644,
-        "narHash": "sha256-Sz8Wh9cAiD5FhL8UWvZxBfnvxETSCVZlqWSYWaCPyu0=",
+        "lastModified": 1718141734,
+        "narHash": "sha256-cA+6l8ZCZ7MXGijVuY/1f55+wF/RT4PlTR9+g4bx86w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3d65009effd77cb0d6e7520b68b039836a7606cf",
+        "rev": "892f76bd0aa09a0f7f73eb41834b8a904b6d0fad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`892f76bd`](https://github.com/nix-community/home-manager/commit/892f76bd0aa09a0f7f73eb41834b8a904b6d0fad) | `` mpv: fix package if wrapMpv not found `` |