### PR TITLE
chore(flake/nixos-hardware): `58b52b0d` -> `9e848e17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -490,11 +490,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1717995329,
-        "narHash": "sha256-lQJXEFHHVsFdFLx0bvoRbZH3IXUBsle6EWj9JroTJ/s=",
+        "lastModified": 1718207430,
+        "narHash": "sha256-/eO2NTRvrrdYWMI06plS8ANDGOhTZBA+C3H3KwbBI1w=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "58b52b0dd191af70f538c707c66c682331cfdffc",
+        "rev": "9e848e173ca83adf884815c66edc08652ef9ade8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`9e848e17`](https://github.com/NixOS/nixos-hardware/commit/9e848e173ca83adf884815c66edc08652ef9ade8) | `` add Dell Latitude 9430 ``                                                   |
| [`f17f79c7`](https://github.com/NixOS/nixos-hardware/commit/f17f79c796381b93e13a6d83580be780da8f9697) | `` rpi4: bluetooth fix ``                                                      |
| [`5ca7d128`](https://github.com/NixOS/nixos-hardware/commit/5ca7d128e6d8e6bd8ac59aa8af0486915d40771e) | `` surface: linux 6.8.9 -> 6.9.3 ``                                            |
| [`7738cb40`](https://github.com/NixOS/nixos-hardware/commit/7738cb40f6a42e2bb398f07964d1df53a683d27e) | `` surface: linux-surface arch-6.8.6-1 -> arch-6.9.3-1 ``                      |
| [`43e369c6`](https://github.com/NixOS/nixos-hardware/commit/43e369c6d57ea78632147ed1cd2ffc8ac54d97c5) | `` chuwi/minibook-x: add comment why we specify kernelParams ``                |
| [`3b5f843e`](https://github.com/NixOS/nixos-hardware/commit/3b5f843e923ac20ea32ce398cfb7f0b8967d75ea) | `` Add Chuwi MiniBook X ``                                                     |
| [`624f88c6`](https://github.com/NixOS/nixos-hardware/commit/624f88c6c0905829b02355839989c134143e6789) | `` purism librem5r4: fix uboot build ``                                        |
| [`7e148208`](https://github.com/NixOS/nixos-hardware/commit/7e148208c45511054e2f7ae6212863ae2e0eb299) | `` purism librem5r4: linuxPackages_librem5: 6.6.6-librem5 -> 6.6.29-librem5 `` |