### PR TITLE
chore(flake/lanzaboote): `b627ccd9` -> `f93f71dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -167,11 +167,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717535930,
-        "narHash": "sha256-1hZ/txnbd/RmiBPNUs7i8UQw2N89uAK3UzrGAWdnFfU=",
+        "lastModified": 1718078026,
+        "narHash": "sha256-LbQabH6h86ZzTvDnaZHmMwedRZNB2jYtUQzmoqWQoJ8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "55e7754ec31dac78980c8be45f8a28e80e370946",
+        "rev": "a3f0c63eed74a516298932b9b1627dd80b9c3892",
         "type": "github"
       },
       "original": {
@@ -431,11 +431,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1718178907,
-        "narHash": "sha256-eSZyrQ9uoPB9iPQ8Y5H7gAmAgAvCw3InStmU3oEjqsE=",
+        "lastModified": 1718212504,
+        "narHash": "sha256-N5Oagzm0EAAZ2j9k5l/1BRYTErfYtJjqOKDPeMQE3iQ=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "b627ccd97d0159214cee5c7db1412b75e4be6086",
+        "rev": "f93f71dd12d925c860cc22a4bc997a1dfdfb8705",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                  |
| --------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`17051193`](https://github.com/nix-community/lanzaboote/commit/17051193f58400777f00e38084b494a17aa11f51) | `` flake.lock: Update `` |