### PR TITLE
chore(flake/treefmt): `1cb529bf` -> `e75ba0a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -652,11 +652,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718139168,
-        "narHash": "sha256-1TZQcdETNdJMcfwwoshVeCjwWfrPtkSQ8y8wFX3it7k=",
+        "lastModified": 1718271476,
+        "narHash": "sha256-35hUMmFesmchb+u7heKHLG5B6c8fBOcSYo0jj0CHLes=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "1cb529bffa880746a1d0ec4e0f5076876af931f1",
+        "rev": "e75ba0a6bb562d2ce275db28f6a36a2e4fd81391",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                  |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`e75ba0a6`](https://github.com/numtide/treefmt-nix/commit/e75ba0a6bb562d2ce275db28f6a36a2e4fd81391) | `` ruff: enable --fix on check (#184) `` |