### PR TITLE
chore(flake/stylix): `73c6955b` -> `7941795d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -617,11 +617,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718292734,
-        "narHash": "sha256-XAwxzCDfExqIj0PIjEpjt3eOzsosxOCLx6sQWHPSrSg=",
+        "lastModified": 1718445778,
+        "narHash": "sha256-C4IhoX026Q5tEhbzmmlWZrLDK2rOqPtwZ7zoT9haDw8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "73c6955b4572346cc10f43a459949fe646efbde0",
+        "rev": "7941795d444c590f053ba64a84a9c5339e672a3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                            |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`7941795d`](https://github.com/danth/stylix/commit/7941795d444c590f053ba64a84a9c5339e672a3e) | `` vim: fix missing lib prefix (#433) ``           |
| [`64c5bd0f`](https://github.com/danth/stylix/commit/64c5bd0fbe410475b2cbfc3e8166c161432e69c0) | `` vscode: fix typo in template.mustache (#434) `` |
| [`76d6ca22`](https://github.com/danth/stylix/commit/76d6ca2224adef72f482e46fd61d66d2ef57fb66) | `` treewide: remove use of `with lib` (#425) ``    |