### PR TITLE
chore(flake/darwin): `ff988d78` -> `58b905ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718345812,
-        "narHash": "sha256-FJhA+YFsOFrAYe6EaiTEfomNf7jeURaPiG5/+a3DRSc=",
+        "lastModified": 1718440858,
+        "narHash": "sha256-iMVwdob8F6P6Ib+pnhMZqyvYI10ZxmvA885jjnEaO54=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ff988d78f2f55641efacdf9a585d2937f7e32a9b",
+        "rev": "58b905ea87674592aa84c37873e6c07bc3807aba",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -617,15 +617,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1718546905,
-        "narHash": "sha256-FmtNOW6Ng11TTgsXkQLqBcIE0j2SmlydHXu/DnWlS4k=",
-        "owner": "danth",
+        "lastModified": 1718632174,
+        "narHash": "sha256-Mf+qZqHAQ9FDPfrd+MgUZLkDNuKhE0QfSeAsmOBs6qo=",
+        "owner": "lovesegfault",
         "repo": "stylix",
-        "rev": "80e8e1e2f613bdc8749461899f0959312eb4a54e",
+        "rev": "eef4b3ece6f892c97ee1e1b3ae7db50d3b5c6ed8",
         "type": "github"
       },
       "original": {
-        "owner": "danth",
+        "owner": "lovesegfault",
+        "ref": "fix-darwin",
         "repo": "stylix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -103,7 +103,8 @@
     };
 
     stylix = {
-      url = "github:danth/stylix";
+      # FIXME: Rollback to danth/stylix once merged
+      url = "github:lovesegfault/stylix/fix-darwin";
       inputs = {
         flake-compat.follows = "flake-compat";
         home-manager.follows = "home-manager";

--- a/graphical/fonts.nix
+++ b/graphical/fonts.nix
@@ -1,18 +1,16 @@
 { hostType, lib, pkgs, ... }:
-let
-  fontPackages = with pkgs; [
-    dejavu_fonts
-    noto-fonts
-    noto-fonts-cjk-sans
-    noto-fonts-cjk-serif
-    noto-fonts-extra
-    unifont
-  ];
-in
 {
-  fonts = lib.optionalAttrs (hostType == "nixos")
+  fonts = {
+    packages = with pkgs; [
+      dejavu_fonts
+      noto-fonts
+      noto-fonts-cjk-sans
+      noto-fonts-cjk-serif
+      noto-fonts-extra
+      unifont
+    ];
+  } // lib.optionalAttrs (hostType == "nixos")
     {
-      packages = fontPackages;
       enableDefaultPackages = false;
       enableGhostscriptFonts = false;
       fontconfig = {
@@ -41,10 +39,7 @@ in
           </fontconfig>
         '';
       };
-    } // lib.optionalAttrs (hostType == "darwin") {
-    fonts = fontPackages;
-    fontDir.enable = true;
-  };
+    };
 
   stylix.fonts = {
     sansSerif = {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                 |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`7d4f8672`](https://github.com/LnL7/nix-darwin/commit/7d4f8672101536674ca5d75d91161474739a83e2) | `` fonts: remove `fonts.fontDir.enable` ``              |
| [`adf578e3`](https://github.com/LnL7/nix-darwin/commit/adf578e398445f981a36ad919928f23a1dd5ee12) | `` fonts: reimplement and rename to `fonts.packages` `` |
| [`27517d2d`](https://github.com/LnL7/nix-darwin/commit/27517d2d182629cf32020b9c77cffdc462a34c01) | `` fonts: refactor `system.build.fonts` ``              |
| [`09e72ff9`](https://github.com/LnL7/nix-darwin/commit/09e72ff9b9a2d888aac70bc8019e5a0696f4c24c) | `` fonts: remove `with lib` ``                          |
| [`eb2f62d0`](https://github.com/LnL7/nix-darwin/commit/eb2f62d0de9997b2f73b409a2843ac5968e1a6f3) | `` fonts: use non-standard path in test ``              |
| [`861af0fc`](https://github.com/LnL7/nix-darwin/commit/861af0fc94df9454f4e92d6892f75588763164bb) | `` fix(launchd): improve `StartCalendarInterval` ``     |