### PR TITLE
chore(flake/nixos-hardware): `ae5c8dcc` -> `239c3864`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -490,11 +490,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1718349360,
-        "narHash": "sha256-SuPne4BMqh9/IkKIAG47Cu5qfmntAaqlHdX1yuFoDO0=",
+        "lastModified": 1718429294,
+        "narHash": "sha256-uhKuPVN8IZJCWwFhNupTxES7LMo8ot2KC6+VmVWwzyU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ae5c8dcc4d0182d07d75df2dc97112de822cb9d6",
+        "rev": "239c3864fef6292262d23cff58ce81674f309142",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`291c3ee6`](https://github.com/NixOS/nixos-hardware/commit/291c3ee610d94e39fa40f1051ebb14b56a57a5d9) | `` treewide: drop hardware.amdgpu.amdvlk option `` |