### PR TITLE
chore(flake/stylix): `a7fbda1f` -> `29044a02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -617,11 +617,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718457106,
-        "narHash": "sha256-sVpsAuvXaSRHhcCw8XbVKlZe8GqB5jpGj4oyZaHAI/Y=",
+        "lastModified": 1718546517,
+        "narHash": "sha256-gGUPG6Ryew7r5a6l58N0bsJdcbXLWunZB3+unxCtuIY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a7fbda1fd965cc22e62463896a4af0342cb00e6a",
+        "rev": "29044a02428f12c9d590a8f424ef2024b4f0898c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                            |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`29044a02`](https://github.com/danth/stylix/commit/29044a02428f12c9d590a8f424ef2024b4f0898c) | `` plymouth: use logo from `nixos-icons` (#424) `` |
| [`25106f20`](https://github.com/danth/stylix/commit/25106f203f1fc711e26e75fc6eaab4a6e18805a7) | `` emacs: change 256 color source (#436) ``        |