### PR TITLE
chore(flake/lanzaboote): `7cb05fab` -> `662482b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -431,11 +431,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1718218065,
-        "narHash": "sha256-fKC7Ryg3AYykDrS2ilS1VqA8/9B2m3yFZcshK+7tIEc=",
+        "lastModified": 1718624537,
+        "narHash": "sha256-ESsK+A7SVZgeGy2WkjeWgoVYF7f8w4Fv+MtiYP8w4iU=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "7cb05fab896bd542c0ca4260d74d9d664cd7b56e",
+        "rev": "662482b24668b0126e72b71e6cfa73c9617b6b81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                     |
| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`4567a8f6`](https://github.com/nix-community/lanzaboote/commit/4567a8f6dd01d31f202c79485cd1a361aa0d3f68) | `` module: revert sort-key from lanzaboote back to lanza `` |