### PR TITLE
chore(flake/disko): `8262659f` -> `48580409`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718588625,
-        "narHash": "sha256-8ZbrJq1jcmyzJ4SDkvd8JOZD4/fNUHpL4cpqVe4w3CU=",
+        "lastModified": 1718822777,
+        "narHash": "sha256-Y+YlmSc7ME+xDue3SJKEyUhwC3ZMLMvZrXsRr7rindM=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "8262659fc990cecdf6a8de74c3de7b6ec58c2276",
+        "rev": "48580409a2df1b0364116541228df3bcc84fc3a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                 |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`48580409`](https://github.com/nix-community/disko/commit/48580409a2df1b0364116541228df3bcc84fc3a4) | `` also add indentation to the hooks `` |
| [`248f65b9`](https://github.com/nix-community/disko/commit/248f65b9c40f3f6e62bb1079b598553fcc321758) | `` fix option type in `mkHook` ``       |