### PR TITLE
chore(flake/git-hooks): `ed4ce202` -> `97c0dc86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718819804,
-        "narHash": "sha256-kq0ujzXsaB+/GekCh293ftS98laLywuiS9m2s4xXtDQ=",
+        "lastModified": 1718825512,
+        "narHash": "sha256-nz7idS/SZWcTUGJ+lOFL+eJayrL/LpkUiy7+FxThAh4=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "ed4ce202164abe17209a57f9d0ef4abf49e17b4b",
+        "rev": "97c0dc865fe9a062c5970f4bcf55bb9e6028bcf5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`7d16e393`](https://github.com/cachix/git-hooks.nix/commit/7d16e39360278891ba80ce1660f2963972298250) | `` feat: fix reuse not found in flake check `` |
| [`21e0e90f`](https://github.com/cachix/git-hooks.nix/commit/21e0e90ff4d64f6aa47a8439d0b39e746fe2e7c3) | `` feat: add reuse ``                          |