### PR TITLE
chore(flake/nixpkgs): `b60ebf54` -> `c00d587b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -525,11 +525,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718530797,
-        "narHash": "sha256-pup6cYwtgvzDpvpSCFh1TEUjw2zkNpk8iolbKnyFmmU=",
+        "lastModified": 1718714799,
+        "narHash": "sha256-FUZpz9rg3gL8NVPKbqU8ei1VkPLsTIfAJ2fdAf5qjak=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b60ebf54c15553b393d144357375ea956f89e9a9",
+        "rev": "c00d587b1a1afbf200b1d8f0b0e4ba9deb1c7f0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`1758e909`](https://github.com/NixOS/nixpkgs/commit/1758e909a40884b7acbee784accd62d3c46bbdc3) | `` kdePackages.marknote: remove duplicate dependency ``                                 |
| [`98f4cfff`](https://github.com/NixOS/nixpkgs/commit/98f4cfffa268dc17239c1b23e90fbeeb486170c9) | `` nixos/plasma6: install krdp ``                                                       |
| [`e2a7bc61`](https://github.com/NixOS/nixpkgs/commit/e2a7bc61f2d85fb2f3c45525a29a3bc1511bad5b) | `` kdePackages: Plasma 6.0.5 -> 6.1.0 ``                                                |
| [`818c7c21`](https://github.com/NixOS/nixpkgs/commit/818c7c211150ee192a91c995a3979762952081f8) | `` scripts/kde/collect-metadata: option to use unstable version ``                      |
| [`365e387c`](https://github.com/NixOS/nixpkgs/commit/365e387c4927b288ec58e6ba637afdd830e551c9) | `` treewide: remove friedelino as maintainer (#320728) ``                               |
| [`20c27d67`](https://github.com/NixOS/nixpkgs/commit/20c27d673389ec0defc11894bc2576be10fa304f) | `` python312PAckages.zha: relax dependency constraints ``                               |
| [`42ca92a2`](https://github.com/NixOS/nixpkgs/commit/42ca92a2b5fb4659163a484b551a310aabf79d46) | `` python312Packages.pyserial-asyncio-fast: 0.11 -> 0.12 ``                             |
| [`09931378`](https://github.com/NixOS/nixpkgs/commit/099313780f507eb39f28721bae7dfcb5db735f64) | `` gmic: correct hash for stdlib ``                                                     |
| [`5c65f916`](https://github.com/NixOS/nixpkgs/commit/5c65f9166181c321f2c940e0b39ef628d178e655) | `` fira: use version from fira-mono and update home page ``                             |
| [`6d999d06`](https://github.com/NixOS/nixpkgs/commit/6d999d06b93863f9046a66b71345d0a15efc594c) | `` fira-sans: 4.202 -> 4.301 ``                                                         |
| [`c25ea56e`](https://github.com/NixOS/nixpkgs/commit/c25ea56eb4baba104115667cb225434ad6206dcf) | `` fira-mono: 4.202 -> 3.2 ``                                                           |
| [`ce848ba9`](https://github.com/NixOS/nixpkgs/commit/ce848ba9a03e3cef1f179e8f1a2696cacc3bf9b3) | `` python311Packages.holidays: 0.50 -> 0.51 ``                                          |
| [`d14a54fc`](https://github.com/NixOS/nixpkgs/commit/d14a54fcef78d71441ff3864946be41d3893cee9) | `` nixos/oauth2-proxy: prevent redirect loop when running on single domain (#319305) `` |
| [`351cdbe4`](https://github.com/NixOS/nixpkgs/commit/351cdbe4f94fbee8e40f8bbe78458b91985cd3e6) | `` python311Packages.etils: 1.9.0 -> 1.9.2 ``                                           |
| [`9b233342`](https://github.com/NixOS/nixpkgs/commit/9b23334289bad2dee05b55269c52b0f9ce49e18d) | `` neovim-qt: move to pkgs/by-name  ``                                                  |
| [`7c1f5390`](https://github.com/NixOS/nixpkgs/commit/7c1f53909e4741d2133c006a2fe5fb4c900c57db) | `` unparam: unstable-2023-03-12 -> 0-unstable-2024-05-28 ``                             |
| [`81035029`](https://github.com/NixOS/nixpkgs/commit/810350291eba4750aa6a8224f21253defb2e4696) | `` cargo-depgraph: 1.5.0 -> 1.6.0 ``                                                    |
| [`8e4c724f`](https://github.com/NixOS/nixpkgs/commit/8e4c724f83c83f82bd356a58d5c57b37948157e1) | `` jellyfin: fix makeWrapperArgs after #313005 ``                                       |
| [`68cdd2ba`](https://github.com/NixOS/nixpkgs/commit/68cdd2ba25e6ec88323f7fd2ccec4105b5444d4f) | `` vimPlugins.copilot-vim: fix meta attrs ``                                            |
| [`68bc018a`](https://github.com/NixOS/nixpkgs/commit/68bc018ac27db15269b7cb9744f3ba4a9ed1f47d) | `` python311Packages.babeltrace2: init at 2.0.6 ``                                      |
| [`e4e8867d`](https://github.com/NixOS/nixpkgs/commit/e4e8867d5b5735a09ee23d21c209de327a073478) | `` babeltrace2: init at 2.0.6 ``                                                        |
| [`4e6ac655`](https://github.com/NixOS/nixpkgs/commit/4e6ac6559cdef29464fc9e479af6548d1853d96d) | `` cyme: 1.6.0 -> 1.6.1 ``                                                              |
| [`38f7bb34`](https://github.com/NixOS/nixpkgs/commit/38f7bb34e7fddbb9c940e372f0697ee4f7806bdf) | `` colloid-gtk-theme: 2024-05-13 -> 2024-06-18 ``                                       |
| [`d61c4d7e`](https://github.com/NixOS/nixpkgs/commit/d61c4d7e7a7945022e1a8399ae7f4f75c3154f27) | `` v2ray-domain-list-community: 20240508170917 -> 20240614093027 ``                     |
| [`cb4bdbd2`](https://github.com/NixOS/nixpkgs/commit/cb4bdbd20b7c1962251b56f9bdaf3ceb7bb82c88) | `` fsautocomplete: 0.73.1 -> 0.73.2 ``                                                  |
| [`1d49af5b`](https://github.com/NixOS/nixpkgs/commit/1d49af5bd0795caa1662aea60161658fc65b98d5) | `` python311Packages.casbin: 1.36.1 -> 1.36.2 ``                                        |
| [`90bafb7a`](https://github.com/NixOS/nixpkgs/commit/90bafb7aaf34641969e5c126d770851afe77d9d1) | `` nh: 3.5.16 -> 3.5.17 ``                                                              |
| [`be75c28c`](https://github.com/NixOS/nixpkgs/commit/be75c28ccca7dbd9b9334de0498a889286e17751) | `` vscode-extensions.nefrob.vscode-just-syntax: init at 0.3.0 ``                        |
| [`763d4128`](https://github.com/NixOS/nixpkgs/commit/763d41289bf05ce91d74ade8f17f5e5fbbafaa68) | `` vscode-extensions.zguolee.tabler-icons: init at 0.3.4 ``                             |
| [`353c49d2`](https://github.com/NixOS/nixpkgs/commit/353c49d265b385e9e7765f01994adc028746d9ec) | `` vscode-extensions.bmalehorn.vscode-fish: 1.0.35 -> 1.0.38 ``                         |
| [`5178d42e`](https://github.com/NixOS/nixpkgs/commit/5178d42e406873291061768a71e0a901de0fba35) | `` files-cli: 2.13.65 -> 2.13.72 ``                                                     |
| [`8d259297`](https://github.com/NixOS/nixpkgs/commit/8d2592979908035c63d1c53ebb689dd075a58f70) | `` havn: 0.1.11 -> 0.1.12 ``                                                            |
| [`272ce6bf`](https://github.com/NixOS/nixpkgs/commit/272ce6bfb45b02456e5718abb79b67fe73c386b3) | `` cni-plugins: 1.5.0 -> 1.5.1 ``                                                       |
| [`363a7998`](https://github.com/NixOS/nixpkgs/commit/363a7998d58fee0dc42a0faf6602a10479f0758c) | `` cni: 1.2.0 -> 1.2.1 ``                                                               |
| [`690578c8`](https://github.com/NixOS/nixpkgs/commit/690578c8eecaf4c1ff34a9e9e509fe5d6c205451) | `` bearer: 1.43.7 -> 1.43.8 ``                                                          |
| [`22a9feb3`](https://github.com/NixOS/nixpkgs/commit/22a9feb38570f0be3ba7e123d5dcc60cb4893fd7) | `` github/workflows/check-nix-format: add maintainers files ``                          |
| [`367d5f21`](https://github.com/NixOS/nixpkgs/commit/367d5f211d1d86380489bef5af8afa2501743785) | `` cargo-semver-checks: 0.31.0 -> 0.32.0 ``                                             |
| [`5cf83a58`](https://github.com/NixOS/nixpkgs/commit/5cf83a58da3ca8b51f70ce4c5ed8bbad4304586f) | `` maintainers/team-list: format with nixfmt ``                                         |
| [`35e96141`](https://github.com/NixOS/nixpkgs/commit/35e96141211569a6f5c7930dc7a763287726b585) | `` maintainers/maintainer-list: format with nixfmt ``                                   |
| [`42e48363`](https://github.com/NixOS/nixpkgs/commit/42e4836358c989caff5eec97cff9d64660173f5f) | `` vscode-extensions.fabiospampinato.vscode-open-in-github: init at 2.3.0 ``            |
| [`aaca757e`](https://github.com/NixOS/nixpkgs/commit/aaca757e135de9fdd09e72f25a6b8f35dfee7d6b) | `` vscode-extensions.bierner.markdown-preview-github-styles: init at 2.0.4 ``           |
| [`5abf8384`](https://github.com/NixOS/nixpkgs/commit/5abf8384ca65f56a20312aba342bb28c3d6201ec) | `` python312Packages.pyopenweathermap: 0.0.9 -> 0.0.10 ``                               |
| [`4bf6540a`](https://github.com/NixOS/nixpkgs/commit/4bf6540ad360be112b33c06502f06ef061a26a00) | `` flake.nix: remove power64 from from nixos check due to broken package ``             |
| [`ecf68270`](https://github.com/NixOS/nixpkgs/commit/ecf68270492148d085169a1f1e86b4e8a7ace7f9) | `` lib.systems.flakeExposed: exclude systems which are not bootstrapped ``              |
| [`3bbbe801`](https://github.com/NixOS/nixpkgs/commit/3bbbe801baf27633bced4ad68e2f235992679ea6) | `` expidus: use call packages and nix built flutter engine ``                           |
| [`dee58ad6`](https://github.com/NixOS/nixpkgs/commit/dee58ad6a8d73123d8ca30f32c13afce3f26e291) | `` python312Packages.vt-py: 0.18.2 -> 0.18.3 ``                                         |
| [`025af72e`](https://github.com/NixOS/nixpkgs/commit/025af72e612c44064fa0ba878793f1566893c916) | `` python312Packages.pysigma: 0.11.6 -> 0.11.7 ``                                       |
| [`e4d27c70`](https://github.com/NixOS/nixpkgs/commit/e4d27c70cf738dead979b3da93db3a2b4149b794) | `` python312Packages.pyrisco: 0.6.2 -> 0.6.3 ``                                         |
| [`a5435cdd`](https://github.com/NixOS/nixpkgs/commit/a5435cdd613cb2f8f67b11accc394128be4e3085) | `` python312Packages.incomfort-client: 0.6.1 -> 0.6.2 ``                                |
| [`98214991`](https://github.com/NixOS/nixpkgs/commit/98214991095205c4926bc3e1703687f07404d85c) | `` python312Packages.tencentcloud-sdk-python: 3.0.1169 -> 3.0.1170 ``                   |
| [`56b9dbf8`](https://github.com/NixOS/nixpkgs/commit/56b9dbf81129fe5d9d6e300e76c1b7e84c28493c) | `` python312Packages.botocore-stubs: 1.34.127 -> 1.34.128 ``                            |
| [`c88dc9e6`](https://github.com/NixOS/nixpkgs/commit/c88dc9e6887a27ae8f4116e05a18c8800f43e279) | `` python312Packages.boto3-stubs: 1.34.127 -> 1.34.128 ``                               |
| [`a90ca782`](https://github.com/NixOS/nixpkgs/commit/a90ca782e8c0fcabc1eb159330c3e799f89728a1) | `` python312Packages.adafruit-platformdetect: 3.69.0 -> 3.70.1 ``                       |
| [`ac00833e`](https://github.com/NixOS/nixpkgs/commit/ac00833e9a3a4a7bed247a362b632def5b3dd60a) | `` vscode-extensions.biomejs.biome: init at 2024.5.251958 ``                            |
| [`59f5a90d`](https://github.com/NixOS/nixpkgs/commit/59f5a90d522279a272bf701dcddb9048a5bc5e7c) | `` eask: add piotrkwiecinski to maintainers ``                                          |
| [`428cd145`](https://github.com/NixOS/nixpkgs/commit/428cd145eb5849c338238a0b0d15f27f7f26b01d) | `` eask: reformat with nixfmt-rfc-style ``                                              |
| [`89b6ee2b`](https://github.com/NixOS/nixpkgs/commit/89b6ee2b7616372ecb25ab8245345881b723fefb) | `` eask: migrate to pkgs/by-name ``                                                     |
| [`e91df802`](https://github.com/NixOS/nixpkgs/commit/e91df802987b7c83a0462ff7e997b88ed34782a3) | `` openvino: fix aarch64 build ``                                                       |
| [`04a04bf4`](https://github.com/NixOS/nixpkgs/commit/04a04bf44a322d134f984d400b12355708250a01) | `` tbb_2021_5: init ``                                                                  |
| [`519bd3ba`](https://github.com/NixOS/nixpkgs/commit/519bd3ba2763cd0785111e7677a9d0ca48ebd968) | `` openvino: 2024.1.0 -> 2024.2.0 ``                                                    |
| [`3c2f8dd1`](https://github.com/NixOS/nixpkgs/commit/3c2f8dd12ec6c246f0fd7e7d66579e2f7b5ebe77) | `` maintainers: add piotrkwiecinski ``                                                  |
| [`1fb71839`](https://github.com/NixOS/nixpkgs/commit/1fb71839a2fee231ebeac1facb5bdc3763c47c5c) | `` feishu: do not use native Wayland even when NIXOS_OZONE_WL is set ``                 |
| [`a654255f`](https://github.com/NixOS/nixpkgs/commit/a654255f86d186eb12fb282fdc873fb5ae6f07b7) | `` python311Packages.ucsmsdk: 0.9.17 -> 0.9.18 ``                                       |
| [`1340cddc`](https://github.com/NixOS/nixpkgs/commit/1340cddc2e8069e1eba82661c51088bb3dbac85b) | `` quickwit: 0.8.1 → 0.8.2 ``                                                           |
| [`e09452b5`](https://github.com/NixOS/nixpkgs/commit/e09452b585f9747c3c9d3f12f10b9e836d32e1ca) | `` python311Packages.babeltrace: init at 1.5.11 ``                                      |
| [`70e7ef6e`](https://github.com/NixOS/nixpkgs/commit/70e7ef6eb159182ddfdcc707dbf9cf3227ff3dc0) | `` vscode-extensions.vitaliymaz.vscode-svg-previewer: init at 0.7.0 ``                  |
| [`45037528`](https://github.com/NixOS/nixpkgs/commit/45037528bfd3644c3845b15241978fb259865523) | `` ungoogled-chromium: 126.0.6478.55-1 -> 126.0.6478.61-1 ``                            |
| [`b4bdda60`](https://github.com/NixOS/nixpkgs/commit/b4bdda60d55cc9420d4566b57fa0fdce22fab6e6) | `` vscode-extensions.fortran-lang.linter-gfortran: init at 3.4.2024061701 ``            |
| [`c1d8b655`](https://github.com/NixOS/nixpkgs/commit/c1d8b65552806eddcaa68c7b9287c3a7bc59f950) | `` vector: 0.38.0 → 0.39.0: ``                                                          |
| [`3760be88`](https://github.com/NixOS/nixpkgs/commit/3760be881c18292c29354dcba253c0c125ff5858) | `` c3c: migrate to finalAttrs pattern ``                                                |
| [`e44f0528`](https://github.com/NixOS/nixpkgs/commit/e44f0528f422979c4877620f29cb155b477a618c) | `` c3c: add version check ``                                                            |
| [`6d234ee6`](https://github.com/NixOS/nixpkgs/commit/6d234ee6a83fc3835ac374ecab4466de06f3c8ae) | `` unison-ucm: 0.5.21 -> 0.5.22 ``                                                      |
| [`5b616f8e`](https://github.com/NixOS/nixpkgs/commit/5b616f8e4d5cae51489cb3afb15e77e78c7d6f0e) | `` python3Packages.open-webui: add `rapidocr-onnxruntime` deps ``                       |
| [`cd8f5fcd`](https://github.com/NixOS/nixpkgs/commit/cd8f5fcd284560cf9749678bf99fcfd74e60f16a) | `` babeltrace: add myself as maintainer ``                                              |
| [`460afd47`](https://github.com/NixOS/nixpkgs/commit/460afd473b001af6bd715f6c5f4609e987ac1489) | `` babeltrace: 1.5.8 -> 1.5.11 ``                                                       |
| [`b0a25eca`](https://github.com/NixOS/nixpkgs/commit/b0a25eca28580c6751bc65f94f6f465b1386f468) | `` babeltrace: add update script ``                                                     |
| [`2a8ccf61`](https://github.com/NixOS/nixpkgs/commit/2a8ccf614465bbf78f399e33f8efa86c250b5aed) | `` nixos/invoiceplane: Ensure patching index.php ``                                     |
| [`0d7dc9e3`](https://github.com/NixOS/nixpkgs/commit/0d7dc9e3fecf9cb0567371eea3795267bfe7a0f7) | `` babeltrace: reformat with nixfmt-rfc-style ``                                        |
| [`08d67477`](https://github.com/NixOS/nixpkgs/commit/08d67477d60b29ee7dd03742daa4f213c017f086) | `` vscode-extensions.meganrogge.template-string-converter: init at 0.6.1 ``             |
| [`9e732be6`](https://github.com/NixOS/nixpkgs/commit/9e732be6c84b6f511da036c965fd2ac09e5de732) | `` python3Packages.rapidocr-onnxruntime: init at 1.3.22 ``                              |
| [`f841416d`](https://github.com/NixOS/nixpkgs/commit/f841416d21b3c3102b11eacba496adca88b1acdc) | `` wiringpi: 2.61-1 -> 3.6 ``                                                           |
| [`30cece05`](https://github.com/NixOS/nixpkgs/commit/30cece054c61327ef340fd0bda16262261843652) | `` wiringpi: format with nixfmt (RFC 166) ``                                            |