### PR TITLE
chore(flake/nixos-hardware): `083823b7` -> `c3e48cbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -510,11 +510,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1718894893,
-        "narHash": "sha256-hxQBUtDbFOCCW1CsFZTS9Q5Ov1ZKdJgbBZHSez1M6iA=",
+        "lastModified": 1719145664,
+        "narHash": "sha256-+0bBlerLxsHUJcKPDWZM1wL3V9bzCFjz+VyRTG8fnUA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "083823b7904e43a4fc1c7229781417e875359a42",
+        "rev": "c3e48cbd88414f583ff08804eb57b0da4c194f9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                       |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`c3e48cbd`](https://github.com/NixOS/nixos-hardware/commit/c3e48cbd88414f583ff08804eb57b0da4c194f9e) | `` update macbookpro14,1 to 24.01 (2024) ``                                   |
| [`0cf592f5`](https://github.com/NixOS/nixos-hardware/commit/0cf592f520a4cbb6e8b4e84e38988bee5e939cab) | `` add new tests to mergify configuration ``                                  |
| [`7d87afd1`](https://github.com/NixOS/nixos-hardware/commit/7d87afd10b176dee02376c476cb916eb33e23d8b) | `` feat: spi thermal conf ``                                                  |
| [`4e59e4c9`](https://github.com/NixOS/nixos-hardware/commit/4e59e4c9e9fed47dc0517041eac0deb16711d9b9) | `` common/gpu/24.05-compat: don't create conflicts with user configuration `` |
| [`584a5e55`](https://github.com/NixOS/nixos-hardware/commit/584a5e551885382c1cf9b09a990fbcd2ccbc992f) | `` fix 24.05 evaluation ``                                                    |
| [`cc634b69`](https://github.com/NixOS/nixos-hardware/commit/cc634b69c8312c4e88469d3c7e8fb5ecc72e7dc6) | `` remove driSupport, opengl → graphics ``                                    |
| [`27487bcd`](https://github.com/NixOS/nixos-hardware/commit/27487bcd12139b8b20442252e1fc3895d4394ce1) | `` change iptsd and system-control to nixpkgs versions - fixes iptsd bug ``   |
| [`68ef79e8`](https://github.com/NixOS/nixos-hardware/commit/68ef79e804710488c4ba158ad14a529b12a65279) | `` apple/t2: update to kernel 6.9.4 ``                                        |