### PR TITLE
chore(flake/impermanence): `27979f1c` -> `363b3e86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1717932370,
-        "narHash": "sha256-7C5lCpiWiyPoIACOcu2mukn/1JRtz6HC/1aEMhUdcw0=",
+        "lastModified": 1719067779,
+        "narHash": "sha256-c8UPWKErzLtukeZ2xdyeZZTkEtg7cP8ApvMgYvjT1ss=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "27979f1c3a0d3b9617a3563e2839114ba7d48d3f",
+        "rev": "363b3e8622e964a96db90ab6430ddcc338212e79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                   |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`d8feb6f8`](https://github.com/nix-community/impermanence/commit/d8feb6f8bf957b1bbcf4fd568881ebb98d9a0be4) | `` nixos: Disable module if no persistent storage paths are defined... `` |
| [`8ea418ec`](https://github.com/nix-community/impermanence/commit/8ea418ec4f149e420788e9f42e007fa3a40610a2) | `` nixos: Remove unused library function imports ``                       |