### PR TITLE
chore(flake/darwin): `29b3096a` -> `50581970`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718662658,
-        "narHash": "sha256-AKG7BsqtVWDlefgzyKz7vjaKTLi4+bmTSBhowbQoZtM=",
+        "lastModified": 1719128254,
+        "narHash": "sha256-I7jMpq0CAOZA/i70+HDQO/ulLttyQu/K70cSESiMX7A=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "29b3096a6e283d7e6779187244cb2a3942239fdf",
+        "rev": "50581970f37f06a4719001735828519925ef8310",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                           |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
| [`4141697e`](https://github.com/LnL7/nix-darwin/commit/4141697ed2ec5ccd1f2807275f7a1dc456f89891) | `` checks.nix: disable verifyBuildUsers for auto-allocate-uids `` |