### PR TITLE
chore(flake/home-manager): `6a9a1e51` -> `6b1f90a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719177087,
-        "narHash": "sha256-3TqSVmZINDBQVo0AazepUYnDEGDOMYX4WwdKb5siZGA=",
+        "lastModified": 1719180626,
+        "narHash": "sha256-vZAzm5KQpR6RGple1dzmSJw5kPivES2heCFM+ZWkt0I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6a9a1e51bbb8c301eae5aa63c9fc3c751ec5315b",
+        "rev": "6b1f90a8ff92e81638ae6eb48cd62349c3e387bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`6b1f90a8`](https://github.com/nix-community/home-manager/commit/6b1f90a8ff92e81638ae6eb48cd62349c3e387bb) | `` stalonetray: move config file to XDG_CONFIG_HOME ``                         |
| [`216d51eb`](https://github.com/nix-community/home-manager/commit/216d51eb22f9ce1a4c50a4737a4adcdb42fb6306) | `` yazi: Fix expected structure of flavors ``                                  |
| [`16f86c94`](https://github.com/nix-community/home-manager/commit/16f86c94ce2399ae09ae99b8f071f37bbc964b4f) | `` yazi: Assert plugin/flavor structure and warn about plugin/flavor suffix `` |
| [`09bc5c59`](https://github.com/nix-community/home-manager/commit/09bc5c5949c73cf6b217badaae25feb2b4a7a2e5) | `` yazi: plugin names should be in kebab case (test) ``                        |
| [`340b98c0`](https://github.com/nix-community/home-manager/commit/340b98c0abb56ae24d7ee7dee64104583ad8a8c6) | `` yazi: Assert that plugins have valid structure ``                           |
| [`5ccc3d67`](https://github.com/nix-community/home-manager/commit/5ccc3d6739b5e694841ced27cb5c06b50b163695) | `` yazi: Ensure plugin suffix `.yazi` ``                                       |