### PR TITLE
chore(flake/nix-fast-build): `cfff239d` -> `02c50df6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1715803356,
-        "narHash": "sha256-wvsg/UMM/jekzgbggH56KLZJzRmwrB9ErevaXXyWyqc=",
+        "lastModified": 1719305207,
+        "narHash": "sha256-gxJ1xgkXe/iHpyYBtx96D7AKccQYqutC6R7cKv2uBNY=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "cfff239d93716e92f6467f8953d8f8c12da1892a",
+        "rev": "02c50df6881266f5425f06f475d504e90e491767",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`ac5d3923`](https://github.com/Mic92/nix-fast-build/commit/ac5d3923cb51c5d80283167b75ec8a96e2f7864e) | `` upgrade nixpkgs to version containing functional nix-eval-jobs ``           |
| [`1f7b7e90`](https://github.com/Mic92/nix-fast-build/commit/1f7b7e90e2b39fb897f4d3be076c020e31c804da) | `` install nix-eval-jobs for remote builds ``                                  |
| [`55283e29`](https://github.com/Mic92/nix-fast-build/commit/55283e292b2f397aaa747f36501cc18860664aa7) | `` only use fallback to nix shell if command is not installed on the system `` |
| [`f8946701`](https://github.com/Mic92/nix-fast-build/commit/f8946701fb0dffd9bb92b2205df8458341a3fd6e) | `` Revert "disable testing darwin" ``                                          |
| [`ed6b7831`](https://github.com/Mic92/nix-fast-build/commit/ed6b7831e06edbfd82c926fea871d5ba0d464238) | `` fix python linter warnings ``                                               |