### PR TITLE
chore(flake/nixos-hardware): `caabc425` -> `aab67495`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -510,11 +510,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1719322773,
-        "narHash": "sha256-BqPxtFwXrpJQDh65NOIHX99pz2rtIMshG9Mt2xnnc5c=",
+        "lastModified": 1719391814,
+        "narHash": "sha256-zlRvpIUQrxMSOi+1lVFuJNvIJt9LB93c05tYQ1KSdRg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "caabc425565bbd5c8640630b0bf6974961a49242",
+        "rev": "aab67495e34365045f9dfbe58725cc6fa03607b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`aab67495`](https://github.com/NixOS/nixos-hardware/commit/aab67495e34365045f9dfbe58725cc6fa03607b7) | `` fix: Add an upgrade ``                                 |
| [`1a59c3d5`](https://github.com/NixOS/nixos-hardware/commit/1a59c3d5ac53ed9266eba2bd65b09e6bfcc9ad7d) | `` fix: Improve doc for Tuxedo Pulse Gen3 power issues `` |