### PR TITLE
chore(flake/nixos-hardware): `aab67495` -> `901bc809`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -510,11 +510,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1719391814,
-        "narHash": "sha256-zlRvpIUQrxMSOi+1lVFuJNvIJt9LB93c05tYQ1KSdRg=",
+        "lastModified": 1719413427,
+        "narHash": "sha256-WS087+fEO804gWvwqEfclbLFw6xdrrtZZULSyQafMdg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "aab67495e34365045f9dfbe58725cc6fa03607b7",
+        "rev": "901bc809b5d3e73a609a167385df23311d81b39c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`901bc809`](https://github.com/NixOS/nixos-hardware/commit/901bc809b5d3e73a609a167385df23311d81b39c) | `` asus/zephyrus/ga402x: drop redundand vdpau drivers ``    |
| [`b7d8d5c7`](https://github.com/NixOS/nixos-hardware/commit/b7d8d5c78812a0a82fdfc817208e530d476d2313) | `` lenovo/yoga/7/14ARH7: remove redundant vdpau packages `` |
| [`a5abf337`](https://github.com/NixOS/nixos-hardware/commit/a5abf3379dc986f6952cc8c6999ddc1bf9d0ee13) | `` zephyrus/ga402x: switch to amd gpu module ``             |
| [`5fe15835`](https://github.com/NixOS/nixos-hardware/commit/5fe1583567b2ec9f4f7f7547bed809b08bfebd89) | `` gpu/amd: remove unused pkgs ``                           |
| [`4677bf5e`](https://github.com/NixOS/nixos-hardware/commit/4677bf5e89551d05f7983f2691590b0f7ab1a63a) | `` gpu/intel: remove outdated libvdpau-va-gl driver ``      |
| [`ae13b376`](https://github.com/NixOS/nixos-hardware/commit/ae13b3761c4994579b7d334e9d425096f411647c) | `` lenovo/yoga/6/13ALC6: drop video acceleration driver ``  |
| [`f140ca62`](https://github.com/NixOS/nixos-hardware/commit/f140ca626b8d10a584c1db3c3f9df9e7c57b843d) | `` Dell Optiplex 3050: init ``                              |