### PR TITLE
chore(flake/disko): `423b86a7` -> `d185770e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719640067,
-        "narHash": "sha256-ZEJFGHnElbMH3JgnFANxOlJgniFamu9MemvHCMQZtpA=",
+        "lastModified": 1719733833,
+        "narHash": "sha256-6h2EqZU9bL9rHlXE+2LCBgnDImejzbS+4dYsNDDFlkY=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "423b86a7f756421325e71663ada79a199bf13408",
+        "rev": "d185770ea261fb5cf81aa5ad1791b93a7834d12c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                           |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`d185770e`](https://github.com/nix-community/disko/commit/d185770ea261fb5cf81aa5ad1791b93a7834d12c) | `` examples: drop priority as we now have a reasonable default `` |
| [`05f4e223`](https://github.com/nix-community/disko/commit/05f4e223b59c03c04bc757d51ce17662bb69f115) | `` gpt: move boot partitions to the front of disko ``             |