### PR TITLE
chore(flake/home-manager): `36317d4d` -> `59ce796b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719677234,
-        "narHash": "sha256-qO9WZsj/0E6zcK4Ht1y/iJ8XfwbBzq7xdqhBh44OP/M=",
+        "lastModified": 1719827439,
+        "narHash": "sha256-tneHOIv1lEavZ0vQ+rgz67LPNCgOZVByYki3OkSshFU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "36317d4d38887f7629876b0e43c8d9593c5cc48d",
+        "rev": "59ce796b2563e19821361abbe2067c3bb4143a7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`59ce796b`](https://github.com/nix-community/home-manager/commit/59ce796b2563e19821361abbe2067c3bb4143a7d) | `` flake.lock: Update ``                                          |
| [`ef74bacb`](https://github.com/nix-community/home-manager/commit/ef74bacbb48cf5f33dda7b7565a7986fbc489a45) | `` ci: bump DeterminateSystems/update-flake-lock from 22 to 23 `` |