### PR TITLE
chore(flake/nixpkgs): `b2852eb9` -> `2741b4b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -525,11 +525,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719506693,
-        "narHash": "sha256-C8e9S7RzshSdHB7L+v9I51af1gDM5unhJ2xO1ywxNH8=",
+        "lastModified": 1719690277,
+        "narHash": "sha256-0xSej1g7eP2kaUF+JQp8jdyNmpmCJKRpO12mKl/36Kc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b2852eb9365c6de48ffb0dc2c9562591f652242a",
+        "rev": "2741b4b489b55df32afac57bc4bfd220e8bf617e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`3e9099f2`](https://github.com/NixOS/nixpkgs/commit/3e9099f2ec2a47c1cd4cdc6e9898566ff6470f8d) | `` zeal: 0.7.0 -> 0.7.1 ``                                                            |
| [`6a4da10b`](https://github.com/NixOS/nixpkgs/commit/6a4da10b0b7d6924fd7a5bc973c7af628a8a5a7d) | `` signal-desktop-beta: 7.14.0-beta.1 -> 7.15.0-beta.1 ``                             |
| [`eac59516`](https://github.com/NixOS/nixpkgs/commit/eac595161a60da7d695d46469e2e849d82da57d6) | `` john: add OpenCL support ``                                                        |
| [`56c2439a`](https://github.com/NixOS/nixpkgs/commit/56c2439a45ba7784676c6ec6ac01d6c6bda5a574) | `` openbsd.libc: Create from constituent pkgs not hack ``                             |
| [`716d8a75`](https://github.com/NixOS/nixpkgs/commit/716d8a752a886019f32b6783b54666a55656ffda) | `` openbsd: Remove `STRIP` hack ``                                                    |
| [`b98dc9f0`](https://github.com/NixOS/nixpkgs/commit/b98dc9f0efff5667debcf1f7d1b655268c27b8db) | `` bsdSetupHook: Do not define empty `DESTDIR` ``                                     |
| [`aba73f3d`](https://github.com/NixOS/nixpkgs/commit/aba73f3de32efa5019f56bfb8a84dd4c5264db0c) | `` magic-enum: 0.9.5 -> 0.9.6 ``                                                      |
| [`72e6c167`](https://github.com/NixOS/nixpkgs/commit/72e6c1678022d03bb10e4c712689701fbb3b100f) | `` vimPlugins.sniprun: 1.3.13 -> 1.3.14 ``                                            |
| [`55013b42`](https://github.com/NixOS/nixpkgs/commit/55013b4213436c1d50a917d2d1e006c4ed78a136) | `` terragrunt: 0.58.2 -> 0.59.3 (#319855) ``                                          |
| [`cf2f7895`](https://github.com/NixOS/nixpkgs/commit/cf2f7895b74473d197e7b877ce8807f766747414) | `` devcontainer: 0.64.0 -> 0.65.0 ``                                                  |
| [`55211c17`](https://github.com/NixOS/nixpkgs/commit/55211c178c7a0478cb0205261a92ce094564fb0d) | `` mprocs: 0.7.0 -> 0.7.1 ``                                                          |
| [`0974bfcb`](https://github.com/NixOS/nixpkgs/commit/0974bfcbe03930f54f399ec028ff25d300434d50) | `` python311Packages.graph-tool: 2.70 -> 2.71 ``                                      |
| [`dbd2e834`](https://github.com/NixOS/nixpkgs/commit/dbd2e83458269d21a30c5a3976428d19d07062cc) | `` libliftoff: fix `override` mechanism by using `callPackage` ``                     |
| [`f9dbc8f8`](https://github.com/NixOS/nixpkgs/commit/f9dbc8f83eebfa20faac1f373c5d3586e2b5378b) | `` netbsd.libcMinimal: Cut down on deps, don't build tags ``                          |
| [`c148010f`](https://github.com/NixOS/nixpkgs/commit/c148010f3638dcc8d4caacfb655e37cb5557c3fc) | `` CuboCore.coreterminal: fix dependency on qt5 version of qtermwidget ``             |
| [`c78f81fd`](https://github.com/NixOS/nixpkgs/commit/c78f81fdb95d2bf1f30a15e8285f644c4e9259f1) | `` ncdu: use zig from buildPackages ``                                                |
| [`58f3c9e9`](https://github.com/NixOS/nixpkgs/commit/58f3c9e95936ecc6e238b8099b9c1e6cec21ea54) | `` backlight-auto: use zig from buildPackages ``                                      |
| [`f22a6436`](https://github.com/NixOS/nixpkgs/commit/f22a643625e9f42883c602e26f470cb5a95a4191) | `` cargo-zigbuild: use zig from buildPackages ``                                      |
| [`1d64220c`](https://github.com/NixOS/nixpkgs/commit/1d64220c335e6f4bdb294e70708e925576dfcd4f) | `` cargo-lambda: use zig from buildPackages ``                                        |
| [`a203987d`](https://github.com/NixOS/nixpkgs/commit/a203987d72540df7c375985b792c07e39f7b7d3b) | `` clipbuzz: use zig from buildPackages ``                                            |
| [`6899567e`](https://github.com/NixOS/nixpkgs/commit/6899567eb97fd7c396a840dfe21e8de26f1e39b1) | `` cinnamon.mint-artwork: 1.8.2 -> 1.8.3 ``                                           |
| [`31be2ec6`](https://github.com/NixOS/nixpkgs/commit/31be2ec63ce5f0998b3efa4e41ebe2fe25b40229) | `` pineapple-pictures: 0.7.4 -> 0.8.0 ``                                              |
| [`650be515`](https://github.com/NixOS/nixpkgs/commit/650be5155b0ee012cc4584577872da8d57d3b330) | `` john: format with nixfmt-rfc-style ``                                              |
| [`0edbce6f`](https://github.com/NixOS/nixpkgs/commit/0edbce6f436a775743ee0ae209081edef893411b) | `` clickable: 7.11.0 -> 8.2.0 ``                                                      |
| [`3fb9151e`](https://github.com/NixOS/nixpkgs/commit/3fb9151e436711f4b491dbf8ed69ab568bf7dfcd) | `` clickable: Add updateScript & more precise changelog link ``                       |
| [`25df9942`](https://github.com/NixOS/nixpkgs/commit/25df994263fb9193345f1aceb8f18d9ac085c8e3) | `` clickable: Format with nixfmt-rfc-style ``                                         |
| [`1b5cf9d0`](https://github.com/NixOS/nixpkgs/commit/1b5cf9d0be7eddbb19ab6971f2d4872c814bb854) | `` clickable: Add Lomiri team to maintainers ``                                       |
| [`11caffc5`](https://github.com/NixOS/nixpkgs/commit/11caffc507cbdac11f3803c84da6fbee9bc1b4f9) | `` clickable: Move to by-name ``                                                      |
| [`93ff8f23`](https://github.com/NixOS/nixpkgs/commit/93ff8f23fc96805330196f50bd8d89d734ec2185) | `` clickable: Switch to buildPythonApplication ``                                     |
| [`9035d80c`](https://github.com/NixOS/nixpkgs/commit/9035d80c17768e7e5a02957c4f278dbb4cf939f8) | `` offpunk: 2.2 -> 2.3 ``                                                             |
| [`26099084`](https://github.com/NixOS/nixpkgs/commit/26099084eaa929e413143ace5ec61e837d76ce6b) | `` python311Packages.laspy: 2.5.3 -> 2.5.4 ``                                         |
| [`c1f2645c`](https://github.com/NixOS/nixpkgs/commit/c1f2645c3d7bbfe76f7d93c4f91f00246dde93a0) | `` unifiedpush-common-proxies: 2.0.0 -> 2.0.1 ``                                      |
| [`acf32e6e`](https://github.com/NixOS/nixpkgs/commit/acf32e6e782c9b7660a9a94d64a245eafb41c7dd) | `` shopware-cli: 0.4.47 -> 0.4.48 ``                                                  |
| [`76c537ed`](https://github.com/NixOS/nixpkgs/commit/76c537ed6efff87e51649c5b78083814ec3cdd62) | `` nilaway: 0-unstable-2024-04-04 -> 0-unstable-2024-06-29 ``                         |
| [`9e6157f0`](https://github.com/NixOS/nixpkgs/commit/9e6157f07cc9ee499d9d0870a166a7ac98fecf45) | `` turso-cli: 0.95.0 -> 0.96.0 ``                                                     |
| [`40ca33e6`](https://github.com/NixOS/nixpkgs/commit/40ca33e6156014f045b213afdddf1eba707b7bc1) | `` andromeda-gtk-theme: add maintainer ``                                             |
| [`bcd2f001`](https://github.com/NixOS/nixpkgs/commit/bcd2f0016d4f4f23bce8ef040bae83b12020d1cd) | `` nordic: 2.2.0-unstable-2024-05-24 -> 2.2.0-unstable-2024-06-25 ``                  |
| [`184882c8`](https://github.com/NixOS/nixpkgs/commit/184882c8bafcd13981b91917100e0b8af18c02c6) | `` pyprland: 2.3.8 -> 2.4.0 ``                                                        |
| [`b657832d`](https://github.com/NixOS/nixpkgs/commit/b657832db7f9d52b756bd15006a1985c38f0db46) | `` saunasfs: init at 4.2.0 ``                                                         |
| [`edbf7340`](https://github.com/NixOS/nixpkgs/commit/edbf73401a6f837b30965a5d23ff026135821367) | `` python312Packages.aioymaps: 1.2.3 -> 1.2.4 ``                                      |
| [`a5e8a399`](https://github.com/NixOS/nixpkgs/commit/a5e8a3991fa580378b5a6d5d3fe6714597c35b08) | `` lnav: 0.11.2 -> 0.12.2 ``                                                          |
| [`f7d0c482`](https://github.com/NixOS/nixpkgs/commit/f7d0c482a2e29861aeb2fc8e00b6ecce16584acc) | `` clever-tools: init 3.7.0 ``                                                        |
| [`a90e61f9`](https://github.com/NixOS/nixpkgs/commit/a90e61f9c576c1af97283bfcdf9bfde3aea37f53) | `` CODEOWNERS: add corngood to dotnet paths ``                                        |
| [`71e728d3`](https://github.com/NixOS/nixpkgs/commit/71e728d3b8ad736e4a909231e2d657eeb12a3b6d) | `` maintainers: remove ivar ``                                                        |
| [`c8cd4c1c`](https://github.com/NixOS/nixpkgs/commit/c8cd4c1ced11f550084ce736f310752a24c06519) | `` lndhub-go: 1.0.1 -> 1.0.2 ``                                                       |
| [`243e565d`](https://github.com/NixOS/nixpkgs/commit/243e565d757dc19bcf3990cc468ce952e2d5cd86) | `` treewide: fix name for appimages ``                                                |
| [`2ea3d91d`](https://github.com/NixOS/nixpkgs/commit/2ea3d91d462a43516cec888bd8b2d2e09b8d07ec) | `` xlights: 2024.11 -> 2024.12 ``                                                     |
| [`466788f4`](https://github.com/NixOS/nixpkgs/commit/466788f47037b302f94357f6aeaca01dd4cd1907) | `` alarm-clock-applet: add gst-plugins-base input ``                                  |
| [`eb86b2ca`](https://github.com/NixOS/nixpkgs/commit/eb86b2ca8c17ee8aed114a71558a51ba008fb895) | `` multimon-ng: 1.3.0 -> 1.3.1 ``                                                     |
| [`adb9b607`](https://github.com/NixOS/nixpkgs/commit/adb9b60790ced95feee8ceb2d313425c3d4c2dc0) | `` kustomize-sops: 4.3.1 -> 4.3.2 ``                                                  |
| [`6a2adb6c`](https://github.com/NixOS/nixpkgs/commit/6a2adb6c3857f71bb30e2a37676f26e9596e3112) | `` grpc_cli: 1.64.2 -> 1.65.0 ``                                                      |
| [`f1f5c708`](https://github.com/NixOS/nixpkgs/commit/f1f5c708316752ae4ec94b48cf11302a784ec23f) | `` python311Packages.hg-evolve: 11.1.3 -> 11.1.4 ``                                   |
| [`6f0ca679`](https://github.com/NixOS/nixpkgs/commit/6f0ca67934d7c6e9ffd2b79124e9c128f6f7fc5f) | `` klipper: 0.12.0-unstable-2024-06-21 -> 0.12.0-unstable-2024-06-27 ``               |
| [`b8f40d0a`](https://github.com/NixOS/nixpkgs/commit/b8f40d0a271edf1aff395607721eb94bddbc1b4a) | `` linuxKernel.kernels.linux_lqx: 6.9.5-lqx1 -> 6.9.7-lqx1 ``                         |
| [`7a59249e`](https://github.com/NixOS/nixpkgs/commit/7a59249e27be7360a65315b2024762216e788034) | `` linuxKernel.kernels.linux_zen: 6.9.6-zen1 -> 6.9.7-zen1 ``                         |
| [`ecd9a575`](https://github.com/NixOS/nixpkgs/commit/ecd9a5753a5078132dc9bfb95902abecbed31eef) | `` kubernetes-helmPlugins.helm-diff: 3.9.5 -> 3.9.8 ``                                |
| [`3016a5b8`](https://github.com/NixOS/nixpkgs/commit/3016a5b8946eb4b54d8e58451fdd4bb8465d4a9a) | `` terraform-docs: 0.17.0 -> 0.18.0 (#323120) ``                                      |
| [`947bf848`](https://github.com/NixOS/nixpkgs/commit/947bf848ad9cf50293e69331f5a67c21a309f4c7) | `` python311Packages.trezor: Add changelog ``                                         |
| [`d9999db7`](https://github.com/NixOS/nixpkgs/commit/d9999db7abf8417a23b1a631a15a7001ff7a7b04) | `` vulkan-caps-viewer: 3.40 -> 3.41 ``                                                |
| [`047d87ec`](https://github.com/NixOS/nixpkgs/commit/047d87ec7f6fe638f6f7d7f900e2bbce1d46ab91) | `` vencord: 1.9.0 -> 1.9.3 ``                                                         |
| [`e4725ab1`](https://github.com/NixOS/nixpkgs/commit/e4725ab1adee1c8e9be350374fa4d25c9936e5db) | `` spicedb-zed: 0.18.1 -> 0.18.2 ``                                                   |
| [`71335ffb`](https://github.com/NixOS/nixpkgs/commit/71335ffb9baddd0404635d27e86157a44ebd726d) | `` redka: 0.5.1 -> 0.5.2 ``                                                           |
| [`d76ad79b`](https://github.com/NixOS/nixpkgs/commit/d76ad79b4ddfaea3dfd5dc01f72e5fd345591b07) | `` nixos/scion: use RuntimeDirectory instead of StateDirectory (#323200) ``           |
| [`a59a1eea`](https://github.com/NixOS/nixpkgs/commit/a59a1eea8ac10444fe8b1c58f741a326ce79a82e) | `` bmake: 20240520 -> 20240625 ``                                                     |
| [`bc3de68a`](https://github.com/NixOS/nixpkgs/commit/bc3de68a7843f05b93042902d106c24baf81faf5) | `` albert: 0.23.0 -> 0.24.1 ``                                                        |
| [`376eacd8`](https://github.com/NixOS/nixpkgs/commit/376eacd832723a7ddbabd0a23de168931c114bfe) | `` albert: format with nixfmt ``                                                      |
| [`a41f1605`](https://github.com/NixOS/nixpkgs/commit/a41f160584c6457dbad983e932e815fb19da7f19) | `` albert: add eljamm as maintainer ``                                                |
| [`831527da`](https://github.com/NixOS/nixpkgs/commit/831527daf046ab733936999a99ba219e705966bc) | `` CODEOWNERS: remove samueldr ``                                                     |
| [`02274889`](https://github.com/NixOS/nixpkgs/commit/02274889c497295556b8b422e6308fe917099f66) | `` pyright: 1.1.368 -> 1.1.369 ``                                                     |
| [`8964bef6`](https://github.com/NixOS/nixpkgs/commit/8964bef6a1b04d7d6b30d296bbef02bb90c5b92e) | `` wireplumber: 0.5.4 -> 0.5.5 ``                                                     |
| [`a643284f`](https://github.com/NixOS/nixpkgs/commit/a643284f2b5ab233a76418ba6cb330fd1e20577f) | `` httpx: 1.6.4 -> 1.6.5 ``                                                           |
| [`ea2066e4`](https://github.com/NixOS/nixpkgs/commit/ea2066e48cfd85a88a86f9ff6c4d6030b6914829) | `` ligolo-ng: 0.6 -> 0.6.1 ``                                                         |
| [`a52ef73d`](https://github.com/NixOS/nixpkgs/commit/a52ef73d4946ca9ab82f6a80e17622dd653c6355) | `` lwgrp: 1.0.5 -> 1.0.6 ``                                                           |
| [`6d52cd02`](https://github.com/NixOS/nixpkgs/commit/6d52cd02be4cbd3bfcf24ff8de8d32f6bd55f310) | `` glooctl: 1.16.16 -> 1.16.17 ``                                                     |
| [`e99c7d81`](https://github.com/NixOS/nixpkgs/commit/e99c7d81a2c967f195696f07fb133c5c6d622261) | `` jitsi-excalidraw: 17 -> 21 ``                                                      |
| [`f992a17e`](https://github.com/NixOS/nixpkgs/commit/f992a17e58db88c0ce8c132da80c917317675996) | `` viber: 16.1.0.37 -> 21.8.0.11 ``                                                   |
| [`c46c5aef`](https://github.com/NixOS/nixpkgs/commit/c46c5aef8116595e850203934b2927f384ad4f0c) | `` viber: reformat with nixfmt-rfc-style ``                                           |
| [`e103a731`](https://github.com/NixOS/nixpkgs/commit/e103a73117b5575c738981e7bde62da821b571c7) | `` andromeda-gtk-theme: 0-unstable-2024-06-08 -> 0-unstable-2024-06-24 ``             |
| [`af2c0c85`](https://github.com/NixOS/nixpkgs/commit/af2c0c85ed89c5f0940477e3999371e4f6a72749) | `` cat9: unstable-2023-11-06 -> 0-unstable-2024-06-17 ``                              |
| [`cf8d0c34`](https://github.com/NixOS/nixpkgs/commit/cf8d0c34cc8f6db19e31b8f591768c51c4471176) | `` durden: unstable-2023-10-23 -> 0-unstable-2024-06-23 ``                            |
| [`ed12d8f5`](https://github.com/NixOS/nixpkgs/commit/ed12d8f5e0d6e88570ae8a024c19bc7f77fceb16) | `` arcan: declare upstream tracy alongside letoram fork ``                            |
| [`6a6ce229`](https://github.com/NixOS/nixpkgs/commit/6a6ce2296446f4939b5ad1d25c38cedfa9370b04) | `` arcan: 0.6.2.1-unstable-2023-11-18 -> 0.6.3 ``                                     |
| [`dda2d767`](https://github.com/NixOS/nixpkgs/commit/dda2d7672ee3168fc13514485213ae1bde30e7d0) | `` arcan: refactor ``                                                                 |
| [`b8b519c2`](https://github.com/NixOS/nixpkgs/commit/b8b519c2cffc797a5f3bb37cb61a76551845e3c8) | `` topfew: 0.9.0 -> 2.0.0 ``                                                          |
| [`e83a3f4a`](https://github.com/NixOS/nixpkgs/commit/e83a3f4afc3735a81b510939384d4ce942b26fc3) | `` python312Packages.greeclimate: 1.4.1 -> 1.4.6 ``                                   |
| [`51e0ef85`](https://github.com/NixOS/nixpkgs/commit/51e0ef8568a9b07bde43ec0e477435215d2ddca9) | `` arcan: move sources to sources.nix ``                                              |
| [`f1c05944`](https://github.com/NixOS/nixpkgs/commit/f1c059446bae15b5a0e5cf028cf440bba0d57cb3) | `` python312Packages.p1monitor: 3.0.0 -> 3.0.1 ``                                     |
| [`48f5622c`](https://github.com/NixOS/nixpkgs/commit/48f5622c20f05c2576fc0b66eb428ebee656799b) | `` python312Packages.aiowithings: 3.0.1 -> 3.0.2 ``                                   |
| [`fdb80a89`](https://github.com/NixOS/nixpkgs/commit/fdb80a894ed3fe7151cc476fd962f265202e4770) | `` python312Packages.sense-energy: 0.12.3 -> 0.12.4 ``                                |
| [`4140a422`](https://github.com/NixOS/nixpkgs/commit/4140a42204df829d7ce2b3bc3713f5c3e0d6e344) | `` python312Packages.ttls: 1.8.2 -> 1.8.3 ``                                          |
| [`cab3bda8`](https://github.com/NixOS/nixpkgs/commit/cab3bda859603aef57d2167ad7872ef8b23a946c) | `` lpairs2: 2.3 -> 2.3.1 ``                                                           |
| [`370fe129`](https://github.com/NixOS/nixpkgs/commit/370fe1292e4c27052a9d866f7527faaa73b394ef) | `` beanhub-cli: 1.1.3 -> 1.2.2 ``                                                     |
| [`ad7883f1`](https://github.com/NixOS/nixpkgs/commit/ad7883f1fa35663091a9d237d01917fd43fe34fc) | `` beanhub-import: 0.1.5 -> 0.3.2 ``                                                  |
| [`2a712c86`](https://github.com/NixOS/nixpkgs/commit/2a712c867b39e8f4299f43337674ad66b99abfc1) | `` beanhub-extract: 0.0.7 -> 0.1.3 ``                                                 |
| [`4721ab1d`](https://github.com/NixOS/nixpkgs/commit/4721ab1de84b2449544637024a78a28eefc61a67) | `` python311Packages.vowpalwabbit: unbreak on `aarch64-darwin` ``                     |
| [`0cd8bd9a`](https://github.com/NixOS/nixpkgs/commit/0cd8bd9aa0616dfe715d9f9c64b3619b6876e8dd) | `` python311Packages.sfepy: unbreak on Darwin ``                                      |
| [`ec95f77a`](https://github.com/NixOS/nixpkgs/commit/ec95f77a6bf0a1d1fbbf3694e5de30c5e96c0384) | `` python311Packages.wrf-python: unbreak on Darwin ``                                 |
| [`0b707fbb`](https://github.com/NixOS/nixpkgs/commit/0b707fbb50a27b1ea92c3b42964d659d31847a48) | `` python311Packages.streamz: unbreak on Darwin ``                                    |
| [`2cde6548`](https://github.com/NixOS/nixpkgs/commit/2cde6548686fcc3e94cfee4bef9fc15a015111a9) | `` python311Packages.ducc0: unbreak on Darwin ``                                      |
| [`6858527e`](https://github.com/NixOS/nixpkgs/commit/6858527eef0ad82885a41a2cb1d28a25f36c58e8) | `` python311Packages.streamdeck: unbreak on Darwin ``                                 |
| [`7759c2cc`](https://github.com/NixOS/nixpkgs/commit/7759c2cc6c31d6dc7d61aa799e9c20c5d8dbbbe3) | `` python311Packages.shiboken2: unbreak on Darwin ``                                  |
| [`0a62b686`](https://github.com/NixOS/nixpkgs/commit/0a62b686eecd7de5c37cb510860d914842c48006) | `` python311Packages.sphinx-markdown-parser: unbreak on Darwin and `aarch64-linux` `` |
| [`edbe783b`](https://github.com/NixOS/nixpkgs/commit/edbe783b175bdeb7b0fdec56bae4925fe2d9fa66) | `` cyclonedds-cxx: init at v0.10.4 ``                                                 |
| [`981a03b6`](https://github.com/NixOS/nixpkgs/commit/981a03b60b3b6d74d46395842d51edaed0b5c064) | `` python311Packages.pynetdicom: unbreak on `aarch64-darwin` ``                       |
| [`0f3cb3b4`](https://github.com/NixOS/nixpkgs/commit/0f3cb3b48152336a33bf5202a41a7312d74326f0) | `` python311Packages.selectors2: unbreak on Darwin and `aarch64-linux` ``             |
| [`4333977d`](https://github.com/NixOS/nixpkgs/commit/4333977d55cab024b2316c00b270920de4702614) | `` python311Packages.pytikz-allefeld: unbreak on Darwin ``                            |
| [`e04e2a4c`](https://github.com/NixOS/nixpkgs/commit/e04e2a4c925b1c20c15f3e1ea17df8c4bf718621) | `` python311Packages.ropper: unbreak on Darwin ``                                     |
| [`3210549d`](https://github.com/NixOS/nixpkgs/commit/3210549dd5552e4fda817cab9a2ce5840260e4f8) | `` python311Packages.pyttsx3: unbreak on Darwin ``                                    |
| [`afd4c442`](https://github.com/NixOS/nixpkgs/commit/afd4c442b1ad714906d70c88854f30a185297bb9) | `` python311Packages.python3-application: unbreak on Darwin ``                        |
| [`c5bbefb0`](https://github.com/NixOS/nixpkgs/commit/c5bbefb0d813ccaa2472dd07ddd86a125a1d0170) | `` python311Packages.pytest-annotate: unbreak on Darwin ``                            |
| [`e6615377`](https://github.com/NixOS/nixpkgs/commit/e6615377bcae7bd9a12f521398deb1a3b3561340) | `` python311Packages.pysendfile: unbreak on Darwin ``                                 |
| [`e361661c`](https://github.com/NixOS/nixpkgs/commit/e361661cdd602fdae345b45ac2cd6081b8536207) | `` python311Packages.pydmd: unbreak on `aarch64-{darwin,linux}` ``                    |
| [`fb7858ba`](https://github.com/NixOS/nixpkgs/commit/fb7858ba5d5dd33a0082f94f485a1a3f7669de81) | `` python311Packages.pylibjpeg: unbreak on Darwin ``                                  |
| [`f2568e41`](https://github.com/NixOS/nixpkgs/commit/f2568e4132717e62861ad421c9745a6b61ae210d) | `` maintainers: add linbreux ``                                                       |
| [`2cb7c68f`](https://github.com/NixOS/nixpkgs/commit/2cb7c68f1c8c8a73b9c643bc805c8069b53bbabb) | `` python311Packages.proxy-py: unbreak on Darwin and `aarch64-linux` ``               |
| [`587ef56c`](https://github.com/NixOS/nixpkgs/commit/587ef56ca56244b2c247a31b40493a23d282d50d) | `` python311Packages.pescea: unbreak on Darwin ``                                     |
| [`6aa3b3ed`](https://github.com/NixOS/nixpkgs/commit/6aa3b3ed4585511db31fae33cbce0edd8fa89d72) | `` python311Packages.persim: unbreak on Darwin ``                                     |
| [`88ab4caf`](https://github.com/NixOS/nixpkgs/commit/88ab4caf1429246e970d2dbf9d7953e53bf28601) | `` python311Packages.power: unbreak on Darwin ``                                      |
| [`edab1b8c`](https://github.com/NixOS/nixpkgs/commit/edab1b8c48bd33830f54a3f99959d2bb8c881e09) | `` python311Packages.numba-scipy: unbreak on Darwin ``                                |
| [`044f0293`](https://github.com/NixOS/nixpkgs/commit/044f02937864b2ad2a56e81183e1f94ddae05dc4) | `` python311Packages.oslo-log: unbreak on Darwin ``                                   |
| [`56163917`](https://github.com/NixOS/nixpkgs/commit/561639176830302096f9973ada3b0d2ab3256c00) | `` python311Packages.nnpdf: unbreak on `aarch64-{darwin,linux}` ``                    |
| [`82e5f404`](https://github.com/NixOS/nixpkgs/commit/82e5f40490c079b363973c7dd0fb718ba79d3503) | `` python311Packages.oslo-concurrency: unbreak on Darwin ``                           |
| [`3daee89c`](https://github.com/NixOS/nixpkgs/commit/3daee89c841394990bd5b2e93a7bcb09667e1f44) | `` python311Packages.omorfi: unbreak on Darwin ``                                     |
| [`292a3184`](https://github.com/NixOS/nixpkgs/commit/292a31846d006c9888cfb24f3d21ac6d1cf0ee11) | `` python311Packages.netutils: unbreak on Darwin ``                                   |
| [`27c7d52f`](https://github.com/NixOS/nixpkgs/commit/27c7d52f1df4d3c27afc6250c57eaf3e62eb69dc) | `` python311Packages.mouseinfo: unbreak on Darwin ``                                  |
| [`28874370`](https://github.com/NixOS/nixpkgs/commit/28874370ae4496495dbfad3c7aa45bdd5503579e) | `` principia: 2024.02.29 -> 2024.06.28 ``                                             |
| [`848699d4`](https://github.com/NixOS/nixpkgs/commit/848699d4c1f669af01918b7cfdb438329667ddc2) | `` root: fix darwin build ``                                                          |