### PR TITLE
chore(flake/darwin): `50581970` -> `ec12b881`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719128254,
-        "narHash": "sha256-I7jMpq0CAOZA/i70+HDQO/ulLttyQu/K70cSESiMX7A=",
+        "lastModified": 1719845423,
+        "narHash": "sha256-ZLHDmWAsHQQKnmfyhYSHJDlt8Wfjv6SQhl2qek42O7A=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "50581970f37f06a4719001735828519925ef8310",
+        "rev": "ec12b88104d6c117871fad55e931addac4626756",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                           |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`e0089646`](https://github.com/LnL7/nix-darwin/commit/e00896468a4723c799b3904e2d10f0cf9a0ff847) | `` chore: remove mkpackageoptionmd deprecation `` |