### PR TITLE
chore(flake/treefmt): `8df5ff62` -> `a103c909`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -674,11 +674,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719749022,
-        "narHash": "sha256-ddPKHcqaKCIFSFc/cvxS14goUhCOAwsM1PbMr0ZtHMg=",
+        "lastModified": 1719846448,
+        "narHash": "sha256-UucUMHrTLSVryb8r2cqJFsYnKleK2586SmwD4uRdxmY=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "8df5ff62195d4e67e2264df0b7f5e8c9995fd0bd",
+        "rev": "a103c909a918b95e25cde52fd08da2d012a64299",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                        |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`e37341c3`](https://github.com/numtide/treefmt-nix/commit/e37341c358cd47be849d30dae50d16eb52c4b572) | `` flake: add comment why we need allowUnfree ``               |
| [`6762408e`](https://github.com/numtide/treefmt-nix/commit/6762408e830ac5c87c2f7c904344d4f85b7d54f4) | `` terraform: default on opensource opentofu for formatting `` |