### PR TITLE
chore(flake/flake-parts): `c3c5ecc0` -> `4e358342`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -267,11 +267,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1719745305,
-        "narHash": "sha256-xwgjVUpqSviudEkpQnioeez1Uo2wzrsMaJKJClh+Bls=",
+        "lastModified": 1719877454,
+        "narHash": "sha256-g5N1yyOSsPNiOlFfkuI/wcUjmtah+nxdImJqrSATjOU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c3c5ecc05edc7dafba779c6c1a61cd08ac6583e9",
+        "rev": "4e3583423212f9303aa1a6337f8dffb415920e4f",
         "type": "github"
       },
       "original": {
@@ -541,14 +541,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1717284937,
-        "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
+        "lastModified": 1719876945,
+        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
       }
     },
     "nixpkgs-stable": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                  |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`2a2386ab`](https://github.com/hercules-ci/flake-parts/commit/2a2386ab386d4f920a50aa9f32d8c34d0a416241) | `` dev/flake.lock: Update ``             |
| [`3c880e0a`](https://github.com/hercules-ci/flake-parts/commit/3c880e0a306175727fcbf2f9865b540fbc6b3766) | `` flake.lock: Update ``                 |
| [`296e5e7d`](https://github.com/hercules-ci/flake-parts/commit/296e5e7da489077cb361feb4fe8f4c9274a5a29b) | `` flake.nix: Update nixpkgs-lib tree `` |