### PR TITLE
chore(flake/nixpkgs): `2741b4b4` -> `00d80d13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -525,11 +525,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719690277,
-        "narHash": "sha256-0xSej1g7eP2kaUF+JQp8jdyNmpmCJKRpO12mKl/36Kc=",
+        "lastModified": 1719848872,
+        "narHash": "sha256-H3+EC5cYuq+gQW8y0lSrrDZfH71LB4DAf+TDFyvwCNA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2741b4b489b55df32afac57bc4bfd220e8bf617e",
+        "rev": "00d80d13810dbfea8ab4ed1009b09100cca86ba8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`a28173cf`](https://github.com/NixOS/nixpkgs/commit/a28173cf76309e2da256a8f505e6b6a5eba5d845) | `` agdaPackages.generics: init at 1.0.1 ``                                   |
| [`b294dd81`](https://github.com/NixOS/nixpkgs/commit/b294dd81ccb8a17352b31d98ec22942c1b4db94f) | `` shotwell: 0.32.6 -> 0.32.7 ``                                             |
| [`d1e0f30c`](https://github.com/NixOS/nixpkgs/commit/d1e0f30cb2b0f4fd69b81ea189ea9fa035d8711c) | `` Fix SSH in scripted initrd ``                                             |
| [`79d81166`](https://github.com/NixOS/nixpkgs/commit/79d81166713174e8e49df67f866cf1123c86b8ec) | `` Fix ssh in initrd for systemd-initrd ``                                   |
| [`6b1ba8e6`](https://github.com/NixOS/nixpkgs/commit/6b1ba8e6c22b1cfc887009d2fc9a52c0e8ce68b1) | `` maintainers: update mguentner's contact info ``                           |
| [`1553f7e3`](https://github.com/NixOS/nixpkgs/commit/1553f7e3245d90adb3f664efeff0f4ef1c8b8884) | `` qalculate-{gtk, qt}: 5.1.0 -> 5.2.0 ``                                    |
| [`1035576c`](https://github.com/NixOS/nixpkgs/commit/1035576c77b875907da8239423dcf5b795d26bcb) | `` seaweedfs: 3.68 -> 3.69 ``                                                |
| [`364b0797`](https://github.com/NixOS/nixpkgs/commit/364b07979d6d742dd3da64eb3734cd19fbc5519c) | `` ledger-live-desktop: 2.81.2 -> 2.83.0 ``                                  |
| [`fe58d084`](https://github.com/NixOS/nixpkgs/commit/fe58d0847b89569d15b42360e6fcffc17a1282c8) | `` open-pdf-sign: 0.2.0 -> 0.2.1 ``                                          |
| [`262a6fe7`](https://github.com/NixOS/nixpkgs/commit/262a6fe785d56a5748ba590484f3499b370dbbb8) | `` vimPlugins.Preview-nvim: init at 2024-06-01 ``                            |
| [`0e4209dd`](https://github.com/NixOS/nixpkgs/commit/0e4209dd43baaa8469cba3c6d366b5481d3f8af5) | `` networkmanager: fix building without systemd ``                           |
| [`e328c863`](https://github.com/NixOS/nixpkgs/commit/e328c86314b0d68638970cd674abb857cda83c35) | `` openssh_{hpn,gssapi}: add backported security fix patches ``              |
| [`529919e9`](https://github.com/NixOS/nixpkgs/commit/529919e9d5d04001b065ce662a28e6a74653fa36) | `` inotify-info: v0.0.2 -> v0.0.3 ``                                         |
| [`68e0666e`](https://github.com/NixOS/nixpkgs/commit/68e0666e06a216b8ebf2296690cd97f930da76ac) | `` graalvmCEPackages: remove unnecessary recurseIntoAttrs ``                 |
| [`468007ea`](https://github.com/NixOS/nixpkgs/commit/468007ea5e60638d8f9f8e87a9caab0bfc449b3d) | `` paper-plane: add missing gstreamer plugins ``                             |
| [`60677bae`](https://github.com/NixOS/nixpkgs/commit/60677baeaee1814320c21b15bc4701abc7ed4b3d) | `` wapp: unstable-2023-05-05 -> 0-unstable-2024-05-23 ``                     |
| [`814ed4b9`](https://github.com/NixOS/nixpkgs/commit/814ed4b9e572f8fa7c19dbe734d2defc8affd479) | `` herbstluftwm: fix unable to be started (#271198) ``                       |
| [`7f993cdf`](https://github.com/NixOS/nixpkgs/commit/7f993cdf26ccef564eabf31fdb40d140821e12bc) | `` openssh: 9.7p1 -> 9.8p1 ``                                                |
| [`452b0b9c`](https://github.com/NixOS/nixpkgs/commit/452b0b9cc9c2e0a4670a999c453a98250856be08) | `` libretro.fmsx: unstable-2024-02-08 -> unstable-2024-06-28 ``              |
| [`6f76e25c`](https://github.com/NixOS/nixpkgs/commit/6f76e25c04e8bac97715d9a664547178c9854fb8) | `` werf: 2.6.2 -> 2.6.4 ``                                                   |
| [`ef35e86b`](https://github.com/NixOS/nixpkgs/commit/ef35e86b434ccfb31dd37fea5b0ecc409c7f6d13) | `` libretro.dosbox-pure: unstable-2024-06-03 -> unstable-2024-06-29 ``       |
| [`9f910d23`](https://github.com/NixOS/nixpkgs/commit/9f910d23b4529c1b10fddd0dc7de7da391489dfa) | `` ollama: switch to `autoAddDriverRunpath` ``                               |
| [`bf91b72c`](https://github.com/NixOS/nixpkgs/commit/bf91b72c06d5fefae1987d3d5e7e49a7550a7118) | `` nixos/ollama: remove `linuxPackages` override ``                          |
| [`02a1df47`](https://github.com/NixOS/nixpkgs/commit/02a1df4741c6e8efe26f307e14239f499b51d0e2) | `` python311Packages.jaxlib: refactor: move meta down ``                     |
| [`8ed0c5e9`](https://github.com/NixOS/nixpkgs/commit/8ed0c5e90da1cb22128ed4b8bebde158ebf6cbaf) | `` libretro.gambatte: unstable-2024-06-21 -> unstable-2024-06-29 ``          |
| [`fc3807da`](https://github.com/NixOS/nixpkgs/commit/fc3807da505b836d8567fd60599b481e21ad853a) | `` libretro.vba-next: unstable-2023-06-03 -> unstable-2024-06-28 ``          |
| [`8cf3e953`](https://github.com/NixOS/nixpkgs/commit/8cf3e953e80b8503ece08d1384640de6915b7add) | `` libretro.swanstation: unstable-2024-05-30 -> unstable-2024-06-29 ``       |
| [`a8e47d08`](https://github.com/NixOS/nixpkgs/commit/a8e47d08cf9c88f5a06112454edc61300313cd32) | `` libretro.o2em: unstable-2023-10-19 -> unstable-2024-06-28 ``              |
| [`323baed9`](https://github.com/NixOS/nixpkgs/commit/323baed95d39a4a849dc91c8d6e44e00c61d2d73) | `` libretro.vecx: unstable-2024-03-17 -> unstable-2024-06-28 ``              |
| [`486e0fd6`](https://github.com/NixOS/nixpkgs/commit/486e0fd6717a682e87ed18f5f8ddaa00a1ae1aed) | `` python3Packages.osc: 1.7.0 -> 1.8.0 ``                                    |
| [`3e0efdb7`](https://github.com/NixOS/nixpkgs/commit/3e0efdb7ccfa7c55f2ef97edccf7c8a579c7f838) | `` libretro.sameboy: unstable-2022-08-19 -> unstable-2024-06-28 ``           |
| [`0381b1f4`](https://github.com/NixOS/nixpkgs/commit/0381b1f4c5d2ef2e6328b0b597ee1c9ea91325d6) | `` libretro.beetle-wswan: unstable-2023-11-01 -> unstable-2024-06-28 ``      |
| [`7233def4`](https://github.com/NixOS/nixpkgs/commit/7233def47357a3c7a8f81c3f48a88f01f7491e44) | `` libretro.fceumm: unstable-2024-06-15 -> unstable-2024-06-28 ``            |
| [`4e2f34b8`](https://github.com/NixOS/nixpkgs/commit/4e2f34b8598090e334f6febae60d9c6f59e4472b) | `` libretro.genesis-plus-gx: unstable-2024-06-21 -> unstable-2024-06-29 ``   |
| [`64393448`](https://github.com/NixOS/nixpkgs/commit/6439344846a69b08e116e61606399f0687d69db4) | `` libretro.nxengine: unstable-2023-02-21 -> unstable-2024-06-28 ``          |
| [`f136ad96`](https://github.com/NixOS/nixpkgs/commit/f136ad9609952fbcc0ff780ecafb6b1ee6e176c4) | `` lib/trivial: update oldestSupportedRelease ``                             |
| [`7c8efe63`](https://github.com/NixOS/nixpkgs/commit/7c8efe638cfee7e2059d12b85f75135b1800a68f) | `` treewide: replace deprecated aliases ``                                   |
| [`06810517`](https://github.com/NixOS/nixpkgs/commit/0681051769c729c31b7576eccf746399f6dedd4c) | `` dino: 0.4.3 -> 0.4.4 ``                                                   |
| [`ce079c05`](https://github.com/NixOS/nixpkgs/commit/ce079c05d0ccd7a519623a049ed7a64c449053b5) | `` envoy: 1.30.3 -> 1.30.4 ``                                                |
| [`fd177b02`](https://github.com/NixOS/nixpkgs/commit/fd177b0240bc5d7c7dc9045be8cdf5adafeebd4e) | `` libretro.ppsspp: unstable-2024-06-24 -> unstable-2024-06-29 ``            |
| [`abffef87`](https://github.com/NixOS/nixpkgs/commit/abffef871b5372d1261812236fd9411adb31eb6f) | `` libretro.handy: unstable-2024-01-01 -> unstable-2024-06-28 ``             |
| [`ef159696`](https://github.com/NixOS/nixpkgs/commit/ef159696e13bd65a31b2bdeb7cd4d55d5ebc0a8f) | `` libretro.gpsp: unstable-2024-02-10 -> unstable-2024-06-28 ``              |
| [`9d0785e2`](https://github.com/NixOS/nixpkgs/commit/9d0785e2ae32a0401f9262c60688dd0afe6c40fa) | `` libretro.mame2003-plus: unstable-2024-06-08 -> unstable-2024-06-30 ``     |
| [`383e9b56`](https://github.com/NixOS/nixpkgs/commit/383e9b5696798029f18360701c6d3fb3e673b918) | `` coq-elpi: 2.0.1 -> 2.2.0 (#323590) ``                                     |
| [`1009a8c9`](https://github.com/NixOS/nixpkgs/commit/1009a8c96a0fc86fe726512afc5d6cbfe01dcdf5) | `` libretro.beetle-supergrafx: unstable-2024-06-14 -> unstable-2024-06-28 `` |
| [`40779788`](https://github.com/NixOS/nixpkgs/commit/407797885999bd7dd702062c131ef6e3660b1ebc) | `` libretro.gw: unstable-2023-05-28 -> unstable-2024-06-28 ``                |
| [`6988cb3b`](https://github.com/NixOS/nixpkgs/commit/6988cb3b989dd68691b934cf68bc1b16c82ab65d) | `` libretro.beetle-pce-fast: unstable-2024-06-14 -> unstable-2024-06-28 ``   |
| [`752566b9`](https://github.com/NixOS/nixpkgs/commit/752566b9ddd5539a7f54d1247fd96d010225ab58) | `` libretro.vba-m: unstable-2023-08-18 -> unstable-2024-06-28 ``             |
| [`c530f70b`](https://github.com/NixOS/nixpkgs/commit/c530f70b1077317ddc8161e176ab9633bdf87fe9) | `` libretro.mame2003: unstable-2024-06-07 -> unstable-2024-06-29 ``          |
| [`05ac3b84`](https://github.com/NixOS/nixpkgs/commit/05ac3b842a4e75988f98acb466f8c1bfd9135504) | `` eza: 0.18.20 -> 0.18.21 ``                                                |
| [`4122d145`](https://github.com/NixOS/nixpkgs/commit/4122d145ee9520fdf5e9b2b1673d59534252931a) | `` topgrade: 14.0.1 -> 15.0.0 ``                                             |
| [`c34e5b8a`](https://github.com/NixOS/nixpkgs/commit/c34e5b8a7af2b506bbfbe0776a9efac8c7f4c786) | `` libretro.beetle-psx-hw: unstable-2024-06-14 -> unstable-2024-06-29 ``     |
| [`f05a4603`](https://github.com/NixOS/nixpkgs/commit/f05a460373d9042dedc9fee1cb5ae4e68bf3a8fa) | `` libretro.pcsx-rearmed: unstable-2024-06-17 -> unstable-2024-06-29 ``      |
| [`f0c193c6`](https://github.com/NixOS/nixpkgs/commit/f0c193c668fc2f0b7ed0448b9de3d6621f0eb884) | `` libretro.prosystem: unstable-2023-08-17 -> unstable-2024-06-28 ``         |
| [`42f337ef`](https://github.com/NixOS/nixpkgs/commit/42f337ef20040188209ee7192aa054075bef9613) | `` libretro.stella: unstable-2024-06-23 -> unstable-2024-06-30 ``            |
| [`9c0ca7b4`](https://github.com/NixOS/nixpkgs/commit/9c0ca7b43883ace420b90c4cb0cf5753044b8836) | `` libretro.beetle-pcfx: unstable-2023-05-28 -> unstable-2024-06-28 ``       |
| [`88974740`](https://github.com/NixOS/nixpkgs/commit/889747400864f94ccd43f645c02e80a8ea56c2f4) | `` libretro.eightyone: unstable-2023-11-01 -> unstable-2024-06-28 ``         |
| [`ae9373a9`](https://github.com/NixOS/nixpkgs/commit/ae9373a93748738d3e7998cac60babc99e4520b9) | `` libretro.picodrive: unstable-2024-06-15 -> unstable-2024-06-30 ``         |
| [`d3663550`](https://github.com/NixOS/nixpkgs/commit/d36635503ef7eee2dcbb6e73e813989c6af62183) | `` libretro.nestopia: unstable-2024-06-22 -> unstable-2024-06-28 ``          |
| [`ecb07fc0`](https://github.com/NixOS/nixpkgs/commit/ecb07fc0cffc19d4d232adde97191b996f674484) | `` libretro.beetle-vb: unstable-2023-11-01 -> unstable-2024-06-28 ``         |
| [`8498c23a`](https://github.com/NixOS/nixpkgs/commit/8498c23aec3d2194bcb38eac10dc82eb31452d2f) | `` libretro.mupen64plus: unstable-2024-05-21 -> unstable-2024-06-28 ``       |
| [`1923a18e`](https://github.com/NixOS/nixpkgs/commit/1923a18eb45137b8f622a3575902fdd61e81e84c) | `` libretro.beetle-lynx: unstable-2023-11-01 -> unstable-2024-06-28 ``       |
| [`bae1f7c5`](https://github.com/NixOS/nixpkgs/commit/bae1f7c50efa5ebeef8182be9a2c516379d3a795) | `` libretro.prboom: unstable-2024-05-23 -> unstable-2024-06-28 ``            |
| [`8a45ecfb`](https://github.com/NixOS/nixpkgs/commit/8a45ecfb497c8c578a9c88730756143d661d6dc9) | `` libretro.snes9x2005: unstable-2022-07-25 -> unstable-2024-06-28 ``        |
| [`b72816ed`](https://github.com/NixOS/nixpkgs/commit/b72816ed53d3193a98015d7021455c5044a2630c) | `` libretro.beetle-ngp: unstable-2023-11-01 -> unstable-2024-06-28 ``        |
| [`b111f6b7`](https://github.com/NixOS/nixpkgs/commit/b111f6b7b833256c64f1a472a102e64096be383a) | `` gnomeExtensions: make manually packages extensions overridable ``         |
| [`5c44ad4d`](https://github.com/NixOS/nixpkgs/commit/5c44ad4d0d4c4f337b606ede1ec7220da051c47e) | `` cloudflare-utils: init at 1.2.1 ``                                        |
| [`50b3a1e0`](https://github.com/NixOS/nixpkgs/commit/50b3a1e0e9f187fcb96dd6ba9d8c731d2741f239) | `` llvmPackages_git: 19.0.0-git-2024-06-23 -> 19.0.0-git-2024-06-30 ``       |
| [`58d63778`](https://github.com/NixOS/nixpkgs/commit/58d63778b00f3cb1963cc681785a6802d7fd95b5) | `` wyoming-piper: fix changelog and homepage ``                              |
| [`ed48cec6`](https://github.com/NixOS/nixpkgs/commit/ed48cec6fbd31d4ea43e459b138ac5aa80f6fed3) | `` python311Packages.jaxlib: expose bazel-build in passthru ``               |
| [`7c5d24b3`](https://github.com/NixOS/nixpkgs/commit/7c5d24b3769493013ac63fcb04a748668834b13c) | `` python311Packages.jaxlib: nuke non-reproducible artifacts ``              |
| [`80972b3d`](https://github.com/NixOS/nixpkgs/commit/80972b3deabed7f0cf57d6b7a021684ea2058bee) | `` home-assistant-custom-component-epex_spot: 2.3.7 -> 2.3.8 ``              |
| [`e02af181`](https://github.com/NixOS/nixpkgs/commit/e02af181fc6d975399bfb651666a0ec6a5ea8189) | `` mistral-rs: init at 0.1.18 ``                                             |
| [`34fe9ad3`](https://github.com/NixOS/nixpkgs/commit/34fe9ad338461ba21cbd6ffdcc72ca94b249b3e7) | `` worldofgoo: fix typo in help message ``                                   |
| [`de6273da`](https://github.com/NixOS/nixpkgs/commit/de6273da664abba0d1ad4ddde0de82dc488dc8b5) | `` python3Packages.s2clientprotocol: fix `meta.homepage` url ``              |
| [`fa659ed7`](https://github.com/NixOS/nixpkgs/commit/fa659ed79ecffca1f2b2ffce6670b426c573fa10) | `` feh: 3.10.2 -> 3.10.3 ``                                                  |
| [`b10c5732`](https://github.com/NixOS/nixpkgs/commit/b10c573212e7616ce413514c28c3a81f5bb64692) | `` workflows: remove 23.11 merges ``                                         |
| [`5e32cc28`](https://github.com/NixOS/nixpkgs/commit/5e32cc2824c0b42bc46912f83f7d657ed77b2a92) | `` fixjson: move out of node-packages ``                                     |
| [`f560e20c`](https://github.com/NixOS/nixpkgs/commit/f560e20cb6c677d17920593faf955314c58c4bcd) | `` luaPackages.dkjson: fix hash manually ``                                  |
| [`8ead224a`](https://github.com/NixOS/nixpkgs/commit/8ead224a2bd9c78fc1ae97c67ddde9159d6b3416) | `` luaPackages.lua-zlib: fix meta ``                                         |
| [`4462ffb9`](https://github.com/NixOS/nixpkgs/commit/4462ffb96bcb02284e06d880bf96d74ad8bc5a42) | `` luaPackages.lua-resty-jwt: mark as broken ``                              |
| [`92300388`](https://github.com/NixOS/nixpkgs/commit/923003885813437a5f9499ddc3eac7f2c3bd2bf1) | `` luaPackages.toml: remove ``                                               |
| [`293cbbb9`](https://github.com/NixOS/nixpkgs/commit/293cbbb94757ad4bf02e15935ae877883819df62) | `` luaPackages: update on 2024-06-24 ``                                      |
| [`984e0aa1`](https://github.com/NixOS/nixpkgs/commit/984e0aa182b1bb13c01c07582ff9ee1e557ae468) | `` python312Packages.python-opensky: 1.0.0 -> 1.0.1 ``                       |
| [`e8dac341`](https://github.com/NixOS/nixpkgs/commit/e8dac3419448a3b069e318fb4ba37f9d97a7d615) | `` erigon: 2.60.1 -> 2.60.2 ``                                               |
| [`063bd10d`](https://github.com/NixOS/nixpkgs/commit/063bd10de5a6594fa4478b49c4b2351d2bf2c3b2) | `` neocmakelsp: 0.7.6 -> 0.7.7 ``                                            |
| [`62da9048`](https://github.com/NixOS/nixpkgs/commit/62da9048d614e8c7f19657e58e9a02eff51a8ef2) | `` crate2nix: rewrite expression ``                                          |
| [`51e69413`](https://github.com/NixOS/nixpkgs/commit/51e69413cfc928d02e19c27c9342af2931166d4d) | `` neovimUtils.grammarToPlugin: also move the queries (#321550) ``           |
| [`fe621855`](https://github.com/NixOS/nixpkgs/commit/fe62185512feb2baff04b58aa7bf792c0472574b) | `` boulder: skip individual failing tests ``                                 |
| [`5614cb99`](https://github.com/NixOS/nixpkgs/commit/5614cb997de9c8f918c423dc2f9c658f34698087) | `` sbcl: 2.4.5 -> 2.4.6 ``                                                   |
| [`be1b3b3e`](https://github.com/NixOS/nixpkgs/commit/be1b3b3e149786b54c822e3abdb74d694ed30e8f) | `` sarasa-gothic: 1.0.14 -> 1.0.15 ``                                        |
| [`df628c5b`](https://github.com/NixOS/nixpkgs/commit/df628c5b017dbe5e80ad43164314dc33d161f5d3) | `` fcitx5-pinyin-zhwiki: init at 0.2.5 ``                                    |
| [`74bc5097`](https://github.com/NixOS/nixpkgs/commit/74bc5097dd56009a06621a604084b236ee8d58e0) | `` fcitx5-pinyin-moegirl: init at 20240609 ``                                |
| [`2ce0bf0e`](https://github.com/NixOS/nixpkgs/commit/2ce0bf0eb20a6b65232b1cb64bb7a62863ba67d2) | `` fcitx5-pinyin-minecraft: init at 0.1.20240629 ``                          |
| [`0f37bcbc`](https://github.com/NixOS/nixpkgs/commit/0f37bcbc3855d9d97e6ca57485ad35e248f01cb9) | `` carapace: 1.0.3 -> 1.0.4 ``                                               |
| [`a8963a20`](https://github.com/NixOS/nixpkgs/commit/a8963a20604fa05e2f0546d13c28575a2b0cef1c) | `` crate2nix: move to pkgs/by-name ``                                        |
| [`ca3b72fe`](https://github.com/NixOS/nixpkgs/commit/ca3b72fe62d972fbbd12a94e90d5d51ce918c44b) | `` libretro.twenty-fortyeight: unstable-2023-02-20 -> unstable-2024-06-28 `` |