### PR TITLE
chore(flake/home-manager): `36e2f9da` -> `58268b4d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719992360,
-        "narHash": "sha256-SRq0ZRkqagqpMGVf4z9q9CIWRbPYjO7FTqSJyWh7nes=",
+        "lastModified": 1720042602,
+        "narHash": "sha256-KyGlWXEi4xRntmcpDJe8je6MQX0D+HOIHJtvcGOVdIY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "36e2f9da91ce8b63a549a47688ae60d47c50de4b",
+        "rev": "58268b4d7745f6747be18033e6f10011466ce8d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`58268b4d`](https://github.com/nix-community/home-manager/commit/58268b4d7745f6747be18033e6f10011466ce8d4) | `` flake.lock: Update ``                       |
| [`e9158314`](https://github.com/nix-community/home-manager/commit/e9158314725af06854009b829d2249d0d6c23c79) | `` yazi: allow literal string for `initLua` `` |
| [`269cc18d`](https://github.com/nix-community/home-manager/commit/269cc18d945dd44bcbc22d58df3876a5d0dbac0b) | `` sway: fix systemd variables example ``      |