### PR TITLE
chore(flake/home-manager): `0a30138c` -> `c514e862`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720045378,
-        "narHash": "sha256-lmE7B+QXw7lWdBu5GQlUABSpzPk3YBb9VbV+IYK5djk=",
+        "lastModified": 1720135141,
+        "narHash": "sha256-1GHh1/WO+f42TXxb1WiZFMuepM7ITA9iT+6yJBbBNsY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0a30138c694ab3b048ac300794c2eb599dc40266",
+        "rev": "c514e862cd5705e51edb6fe8d01146fdeec661f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`c514e862`](https://github.com/nix-community/home-manager/commit/c514e862cd5705e51edb6fe8d01146fdeec661f2) | `` treewide: fix eval after Nixpkgs maintainer changes `` |
| [`6ea6fafa`](https://github.com/nix-community/home-manager/commit/6ea6fafa3e0f1691ec1555ce4281d7d993546131) | `` mpv: remove tadeokondrak as maintainer ``              |
| [`c23060ce`](https://github.com/nix-community/home-manager/commit/c23060ce95c4856157789b0636e1b6206be335c4) | `` hyprland: emphasize usage of the NixOS module ``       |