### PR TITLE
chore(flake/home-manager): `c514e862` -> `bbe6e947`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720135141,
-        "narHash": "sha256-1GHh1/WO+f42TXxb1WiZFMuepM7ITA9iT+6yJBbBNsY=",
+        "lastModified": 1720167120,
+        "narHash": "sha256-K9JYdlPiyaXp33JRg7CT8rMwH56e4ncXSsXW/YKnNXc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c514e862cd5705e51edb6fe8d01146fdeec661f2",
+        "rev": "bbe6e94737289c8cb92d4d8f9199fbfe4f11c0ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`bbe6e947`](https://github.com/nix-community/home-manager/commit/bbe6e94737289c8cb92d4d8f9199fbfe4f11c0ba) | `` dunst: fix warning for lib.cartesianProductOfSets `` |