### PR TITLE
chore(flake/nix-index-database): `2917972e` -> `6d61f720`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719832725,
-        "narHash": "sha256-dr8DkeS74KVNTgi8BE0BiUKALb+EKlMIV86G2xPYO64=",
+        "lastModified": 1720321047,
+        "narHash": "sha256-eRlYfOxdlxhAkIKY9mhLnSHtCH54nA2/5iVI6ZOyA/A=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "2917972ed34ce292309b3a4976286f8b5c08db27",
+        "rev": "6d61f72020aa748ed1cec87b21e6739be71b13c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                  |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`6d61f720`](https://github.com/nix-community/nix-index-database/commit/6d61f72020aa748ed1cec87b21e6739be71b13c5) | `` flake.lock: Update `` |