### PR TITLE
chore(flake/nixos-hardware): `6e253f12` -> `72d3c007`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -510,11 +510,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1719895800,
-        "narHash": "sha256-xNbjISJTFailxass4LmdWeV4jNhAlmJPwj46a/GxE6M=",
+        "lastModified": 1720429258,
+        "narHash": "sha256-d6JI5IgJ1xdrk7DvYVx7y8ijcYz5I1nhCwOiDP6cq00=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "6e253f12b1009053eff5344be5e835f604bb64cd",
+        "rev": "72d3c007024ce47d838bb38693c8773812f54bf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`72d3c007`](https://github.com/NixOS/nixos-hardware/commit/72d3c007024ce47d838bb38693c8773812f54bf2) | `` Added new model to flake.nix and README ``                         |
| [`00f9c4bb`](https://github.com/NixOS/nixos-hardware/commit/00f9c4bb0628983bc017d7644f67d49ae66bdbfa) | `` Fix Lenovo Thinkpad T14s not powering off ``                       |
| [`da0aa7b5`](https://github.com/NixOS/nixos-hardware/commit/da0aa7b533d49e6319c603e07b46a5690082f65f) | `` apple/t2: bump kernel to 6.9.8 ``                                  |
| [`c1cdb2f8`](https://github.com/NixOS/nixos-hardware/commit/c1cdb2f8282818808fd6e0726620c7cd54c8a260) | `` apple/t2: update patches repo ref ``                               |
| [`f75ab8b2`](https://github.com/NixOS/nixos-hardware/commit/f75ab8b22cf73522330cd23c8312ead6fbca8093) | `` apple/t2: factor out kernel definition for improved readability `` |