### PR TITLE
chore(flake/home-manager): `6b7ce96f` -> `2fb5c1e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720327769,
-        "narHash": "sha256-kAsg3Lg4YKKpGw+f1W2s5hzjP8B0y/juowvjK8utIag=",
+        "lastModified": 1720470846,
+        "narHash": "sha256-7ftA4Bv5KfH4QdTRxqe8/Hz2YTKo+7IQ9n7vbNWgv28=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6b7ce96f34b324e4e104abc30d06955d216bac71",
+        "rev": "2fb5c1e0a17bc6059fa09dc411a43d75f35bb192",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`2fb5c1e0`](https://github.com/nix-community/home-manager/commit/2fb5c1e0a17bc6059fa09dc411a43d75f35bb192) | `` tests: update to match new sd-switch version ``         |
| [`dfaf0ff2`](https://github.com/nix-community/home-manager/commit/dfaf0ff2e7e536e404a260845e436bd888c4bb5f) | `` systemd: only set old units directory when available `` |