### PR TITLE
chore(flake/nixos-hardware): `72d3c007` -> `c5013aa7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -510,11 +510,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1720429258,
-        "narHash": "sha256-d6JI5IgJ1xdrk7DvYVx7y8ijcYz5I1nhCwOiDP6cq00=",
+        "lastModified": 1720737798,
+        "narHash": "sha256-G/OtEAts7ZUvW5lrGMXSb8HqRp2Jr9I7reBuvCOL54w=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "72d3c007024ce47d838bb38693c8773812f54bf2",
+        "rev": "c5013aa7ce2c7ec90acee5d965d950c8348db751",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`c5013aa7`](https://github.com/NixOS/nixos-hardware/commit/c5013aa7ce2c7ec90acee5d965d950c8348db751) | `` common/gpu/nvidia: use lib.mkDefault for hardware.nvidia.modesetting `` |
| [`6b745e23`](https://github.com/NixOS/nixos-hardware/commit/6b745e2331ba42e2f744434dcef1fe31ef9a4ced) | `` common-gpu-nvidia: enable modesetting by default ``                     |
| [`c5925d86`](https://github.com/NixOS/nixos-hardware/commit/c5925d86de15f5939c5f0de2945fdc736b28d4b1) | `` common-gpu-nvidia: drop libva-vdpau-driver ``                           |
| [`a111ce6b`](https://github.com/NixOS/nixos-hardware/commit/a111ce6b537df12a39874aa9672caa87f8677eda) | `` flake: Deprecate Intel generation-specific outputs ``                   |
| [`ba8294c0`](https://github.com/NixOS/nixos-hardware/commit/ba8294c0a1fc318ed4869bb63fd122c63881fff0) | `` common: Move Intel generation-specific config from cpu to gpu ``        |