### PR TITLE
chore(flake/treefmt): `8b63fe8c` -> `750dfb55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -674,11 +674,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720507012,
-        "narHash": "sha256-QIeZ43t9IVB4dLsFaWh2f4C7JSRfK7p+Y1U9dULsLXU=",
+        "lastModified": 1720645794,
+        "narHash": "sha256-vAeYp+WH7i/DlBM5xNt9QeWiOiqzzf5abO8DYGkbUxg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "8b63fe8cf7892c59b3df27cbcab4d5644035d72f",
+        "rev": "750dfb555b5abdab4d3266b3f9a05dec6d205c04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                        |
| ---------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`203f5aa1`](https://github.com/numtide/treefmt-nix/commit/203f5aa13af95a6f0b98e9659802ea05eff46755) | `` mypy: add package option `` |