### PR TITLE
chore(flake/treefmt): `5b002f8a` -> `b92afa15`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -674,11 +674,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720818892,
-        "narHash": "sha256-f52x9srIcqQm1Df3T+xYR5P6VfdnDFa2vkkcLhlTp6U=",
+        "lastModified": 1720930114,
+        "narHash": "sha256-VZK73b5hG5bSeAn97TTcnPjXUXtV7j/AtS4KN8ggCS0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "5b002f8a53ed04c1a4177e7b00809d57bd2c696f",
+        "rev": "b92afa1501ac73f1d745526adc4f89b527595f14",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`ea771188`](https://github.com/numtide/treefmt-nix/commit/ea771188cdd4b2b3461e032301e2bc4c58980117) | `` format md/yaml ``                   |
| [`c737821f`](https://github.com/numtide/treefmt-nix/commit/c737821f24582d11de2dd121ac91bead4d254d05) | `` enable formatter for all files ``   |
| [`ec5432d4`](https://github.com/numtide/treefmt-nix/commit/ec5432d416a20c6489ef20e2968a5623340c1d47) | `` clang-format: add *.hh extension `` |