### PR TITLE
chore(flake/disko): `bad37694` -> `e8e8d9a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721007199,
-        "narHash": "sha256-Gof4Lj1rgTrX59bNu5b/uS/3X/marUGM7LYw31NoXEA=",
+        "lastModified": 1721266288,
+        "narHash": "sha256-MsyTzXu9CJVcBr44ct8ILKF/Ro7VlF+tVZTylzAoXSs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "bad376945de7033c7adc424c02054ea3736cf7c4",
+        "rev": "e8e8d9a3a9c1d0e654ccda7834bf0288a9d15c47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`e8e8d9a3`](https://github.com/nix-community/disko/commit/e8e8d9a3a9c1d0e654ccda7834bf0288a9d15c47) | `` flake.lock: Update `` |