### PR TITLE
chore(flake/treefmt): `0fb28f23` -> `50104496`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -674,11 +674,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721059077,
-        "narHash": "sha256-gCICMMX7VMSKKt99giDDtRLkHJ0cwSgBtDijJAqTlto=",
+        "lastModified": 1721382922,
+        "narHash": "sha256-GYpibTC0YYKRpFR9aftym9jjRdUk67ejw1IWiaQkaiU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "0fb28f237f83295b4dd05e342f333b447c097398",
+        "rev": "50104496fb55c9140501ea80d183f3223d13ff65",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`50104496`](https://github.com/numtide/treefmt-nix/commit/50104496fb55c9140501ea80d183f3223d13ff65) | `` actionlint: revert including action files (#203) `` |