### PR TITLE
chore(flake/nixos-hardware): `bb90787e` -> `d8bfbbf6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -510,11 +510,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1721331912,
-        "narHash": "sha256-h2yaU+QEU4pHxMySHPIsRV2T/pihDHnrXBca8BY6xgc=",
+        "lastModified": 1721403706,
+        "narHash": "sha256-nK3RQXJRFWCT3VBpyfF1FzhZxtNW7a9QcavkWKPhMGc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "bb90787ea034c8b9035dfcfc9b4dc23898d414be",
+        "rev": "d8bfbbf614881a110059f14bc2a5d28c5df115e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`d8bfbbf6`](https://github.com/NixOS/nixos-hardware/commit/d8bfbbf614881a110059f14bc2a5d28c5df115e5) | `` fix: Add more aliases to 24.05-compat ``             |
| [`3501b9c0`](https://github.com/NixOS/nixos-hardware/commit/3501b9c0962d0644041cd4e9243f817c1d7418ba) | `` flake.nix: export paths instead of imported files `` |