### PR TITLE
chore(flake/nixos-hardware): `d8bfbbf6` -> `71b92eab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -510,11 +510,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1721403706,
-        "narHash": "sha256-nK3RQXJRFWCT3VBpyfF1FzhZxtNW7a9QcavkWKPhMGc=",
+        "lastModified": 1721405141,
+        "narHash": "sha256-jquaoTnhgr7xlSATa3DtSn4nUJgw/5HCibDKneIG4P4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d8bfbbf614881a110059f14bc2a5d28c5df115e5",
+        "rev": "71b92eab15920df202dd6256c2e2a58cc6e48641",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`71b92eab`](https://github.com/NixOS/nixos-hardware/commit/71b92eab15920df202dd6256c2e2a58cc6e48641) | `` asus-rog-strix-x570: init `` |