### PR TITLE
chore(flake/nixos-hardware): `71b92eab` -> `ece5b120`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -510,11 +510,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1721405141,
-        "narHash": "sha256-jquaoTnhgr7xlSATa3DtSn4nUJgw/5HCibDKneIG4P4=",
+        "lastModified": 1721411914,
+        "narHash": "sha256-kq+Ot9SGmwLpUD9oPIrPz3GtRSnFNUUpVByJD7lBA2Q=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "71b92eab15920df202dd6256c2e2a58cc6e48641",
+        "rev": "ece5b120143233d5d19a5e6034ae8bc879c21e7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`ece5b120`](https://github.com/NixOS/nixos-hardware/commit/ece5b120143233d5d19a5e6034ae8bc879c21e7a) | `` update README for omen 16-n0280nd `` |
| [`89a33c8e`](https://github.com/NixOS/nixos-hardware/commit/89a33c8e93a64d4f65ca3a2c7bc9da24216aa0b9) | `` omen 16-n0280nd: init ``             |