### PR TITLE
chore(flake/nix-index-database): `5fe5b0cd` -> `bd8d2d4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720926593,
-        "narHash": "sha256-fW6e27L6qY6s+TxInwrS2EXZZfhMAlaNqT0sWS49qMA=",
+        "lastModified": 1721530660,
+        "narHash": "sha256-GOkcHHYRk2d7s8JevtPhbgGAb65Byrhg+9QrSv/QJ/8=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "5fe5b0cdf1268112dc96319388819b46dc051ef4",
+        "rev": "bd8d2d4adca7fc53dd1e8ae150bb6a26953eebb0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                  |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`bd8d2d4a`](https://github.com/nix-community/nix-index-database/commit/bd8d2d4adca7fc53dd1e8ae150bb6a26953eebb0) | `` flake.lock: Update `` |