### PR TITLE
chore(flake/home-manager): `afd2021b` -> `635563f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721135958,
-        "narHash": "sha256-H548rpPMsn25LDKn1PCFmPxmWlClJJGnvdzImHkqjuY=",
+        "lastModified": 1721534365,
+        "narHash": "sha256-XpZOkaSJKdOsz1wU6JfO59Rx2fqtcarQ0y6ndIOKNpI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "afd2021bedff2de92dfce0e257a3d03ae65c603d",
+        "rev": "635563f245309ef5320f80c7ebcb89b2398d2949",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`635563f2`](https://github.com/nix-community/home-manager/commit/635563f245309ef5320f80c7ebcb89b2398d2949) | `` flake.lock: Update `` |