### PR TITLE
chore(flake/treefmt): `888bfb10` -> `8db8970b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -667,11 +667,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721458737,
-        "narHash": "sha256-wNXLQ/ATs1S4Opg1PmuNoJ+Wamqj93rgZYV3Di7kxkg=",
+        "lastModified": 1721769617,
+        "narHash": "sha256-6Pqa0bi5nV74IZcENKYRToRNM5obo1EQ+3ihtunJ014=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "888bfb10a9b091d9ed2f5f8064de8d488f7b7c97",
+        "rev": "8db8970be1fb8be9c845af7ebec53b699fe7e009",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                   |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`8db8970b`](https://github.com/numtide/treefmt-nix/commit/8db8970be1fb8be9c845af7ebec53b699fe7e009) | `` feat(module): add meta.maintainers attribute (#205) `` |
| [`b3ee1836`](https://github.com/numtide/treefmt-nix/commit/b3ee183659bdd73bb2297cd130385a9554482ea2) | `` swift-format: remove broken formatter from checks ``   |
| [`499d9b8a`](https://github.com/numtide/treefmt-nix/commit/499d9b8a947bbf62b5d52f0d265d1059ac179b66) | `` feat: update nixpkgs input ``                          |