### PR TITLE
chore(flake/nixos-hardware): `5bd0371d` -> `d3c993c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -507,11 +507,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1721900127,
-        "narHash": "sha256-Rk+zRS8HCK0Kd9CAklqywB2LOgOehC3xblppHuLxVUs=",
+        "lastModified": 1721911538,
+        "narHash": "sha256-5OrkPJsiZmNe99C6+KX0qx9sphoVLvldFjuqDYAZ8GQ=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "5bd0371d3ff4c121b03450de8cfd643547b11fe1",
+        "rev": "d3c993c851ad40bbab7e08d566138ff72cd8744f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`d3c993c8`](https://github.com/NixOS/nixos-hardware/commit/d3c993c851ad40bbab7e08d566138ff72cd8744f) | `` Lenovo ThinkPad X1 (12th Gen): init ``                                        |
| [`60d3bae3`](https://github.com/NixOS/nixos-hardware/commit/60d3bae3845050d36328fbfc9a0e95b82a25f2f1) | `` Add deprecation explanation ``                                                |
| [`13d6cbde`](https://github.com/NixOS/nixos-hardware/commit/13d6cbde4dc271aa35747c5cee4926280c330a26) | `` Create asus-zephyrus-ga402x-amdgpu and asus-zephyrus-ga402x-nvidia entries `` |