### PR TITLE
chore(flake/darwin): `884f3fe6` -> `72bbc11a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721719500,
-        "narHash": "sha256-nnkqjv4Y37Hydjh6HE9wW4kSkV5Q7q4iIXlL5lwUFOw=",
+        "lastModified": 1722009762,
+        "narHash": "sha256-KV3H6BA9UNPDdkubDMQCWKz6Z4XokHsYazRkJJZZurA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "884f3fe6d9bf056ba0017c132c39c1f0d07d4fec",
+        "rev": "72bbc11aedcaba6f9a748786bb0aff9213d8fb36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
| [`be14a2ad`](https://github.com/LnL7/nix-darwin/commit/be14a2add172621f1d02b0457e50a6a96fd9b73b) | `` Add inline prediction option mirroring the capitalization option `` |