### PR TITLE
chore(flake/nixos-hardware): `d3c993c8` -> `0b4d40f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -507,11 +507,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1721911538,
-        "narHash": "sha256-5OrkPJsiZmNe99C6+KX0qx9sphoVLvldFjuqDYAZ8GQ=",
+        "lastModified": 1722017959,
+        "narHash": "sha256-vkv3MtjRtJdqeWMLH874ngbC6/5wUYzsdw0pb96ZLRc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d3c993c851ad40bbab7e08d566138ff72cd8744f",
+        "rev": "0b4d40f95a68ef0a6785f6b938ac8c1383321dbf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`0b4d40f9`](https://github.com/NixOS/nixos-hardware/commit/0b4d40f95a68ef0a6785f6b938ac8c1383321dbf) | `` surface: linux 6.9.3 -> 6.9.9 ``                       |
| [`10917438`](https://github.com/NixOS/nixos-hardware/commit/109174381137e88eae61a3537e07e9ef58ba6a98) | `` surface: linux-surface arch-6.9.3-1 to arch-6.9.9-1 `` |