### PR TITLE
chore(flake/darwin): `72bbc11a` -> `980c7066`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722009762,
-        "narHash": "sha256-KV3H6BA9UNPDdkubDMQCWKz6Z4XokHsYazRkJJZZurA=",
+        "lastModified": 1722080315,
+        "narHash": "sha256-RRhLjW9Y8CVH6ozVupACX0/1vc8b9FpiI8/AnpmV1cw=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "72bbc11aedcaba6f9a748786bb0aff9213d8fb36",
+        "rev": "980c7066fc8f1cc020b503e2592ea67efdfac227",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                     |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------- |
| [`e88eb66c`](https://github.com/LnL7/nix-darwin/commit/e88eb66c2b5e7066786f5d6343f3737567a71734) | `` `mapAttrsFlatten` -> `mapAttrsToList` `` |