### PR TITLE
chore(flake/darwin): `980c7066` -> `0413754b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722080315,
-        "narHash": "sha256-RRhLjW9Y8CVH6ozVupACX0/1vc8b9FpiI8/AnpmV1cw=",
+        "lastModified": 1722082646,
+        "narHash": "sha256-od8dBWVP/ngg0cuoyEl/w9D+TCNDj6Kh4tr151Aax7w=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "980c7066fc8f1cc020b503e2592ea67efdfac227",
+        "rev": "0413754b3cdb879ba14f6e96915e5fdf06c6aab6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                  |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
| [`a5662388`](https://github.com/LnL7/nix-darwin/commit/a566238826fc77b2322b62cd52c321db8c30a1f4) | `` defaults: only restart Dock when user is logged in `` |