### PR TITLE
chore(flake/home-manager): `d0240a06` -> `a11cfcd0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722119539,
-        "narHash": "sha256-2kU90liMle0vKR8exJx1XM4hZh9CdNgZGHCTbeA9yzY=",
+        "lastModified": 1722200457,
+        "narHash": "sha256-sVb0JSGB3OffqTDEiFM61/KjqXIVmY88JJs4DLns/uw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d0240a064db3987eb4d5204cf2400bc4452d9922",
+        "rev": "a11cfcd0a18fdf6257808da631a956800af764bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`a11cfcd0`](https://github.com/nix-community/home-manager/commit/a11cfcd0a18fdf6257808da631a956800af764bf) | `` micro: add package option ``                               |
| [`ea72cf54`](https://github.com/nix-community/home-manager/commit/ea72cf548fafb2876232a3ae22fcc03d5fb354de) | `` jujutsu: support darwin guidelines for config placement `` |
| [`9fdadb1c`](https://github.com/nix-community/home-manager/commit/9fdadb1cb65093015fc8cd65a592c983b490c75c) | `` flake.lock: Update ``                                      |
| [`cd520fbd`](https://github.com/nix-community/home-manager/commit/cd520fbd31934deaa1cda11297a99ef1fa369dbf) | `` maintainers: remove polykernel ``                          |