### PR TITLE
chore(flake/home-manager): `89670e27` -> `d34aaf7b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722226883,
-        "narHash": "sha256-bCCH8YDJ8Ws623VDQo9/PW8jb3hh5yrRuYFayDx/ZZQ=",
+        "lastModified": 1722318880,
+        "narHash": "sha256-uVzUJbkVrFnLbDTx1ht4Jz7aET9o4pBhf6fku9AYWFo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "89670e27e101b9b30f5900fc1eb6530258d316b1",
+        "rev": "d34aaf7b3b4c98f2aefe0429b8946f2bcd36a59a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`d34aaf7b`](https://github.com/nix-community/home-manager/commit/d34aaf7b3b4c98f2aefe0429b8946f2bcd36a59a) | `` nix-gc: set service type to oneshot ``                |
| [`db40fead`](https://github.com/nix-community/home-manager/commit/db40fead89db185dfd863aed5dad1d675f82a3fc) | `` nix-gc: call nix-collect-garbage in a shell script `` |