### PR TITLE
chore(flake/treefmt): `8db8970b` -> `768acdb0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -667,11 +667,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721769617,
-        "narHash": "sha256-6Pqa0bi5nV74IZcENKYRToRNM5obo1EQ+3ihtunJ014=",
+        "lastModified": 1722330636,
+        "narHash": "sha256-uru7JzOa33YlSRwf9sfXpJG+UAV+bnBEYMjrzKrQZFw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "8db8970be1fb8be9c845af7ebec53b699fe7e009",
+        "rev": "768acdb06968e53aa1ee8de207fd955335c754b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                      |
| ---------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`768acdb0`](https://github.com/numtide/treefmt-nix/commit/768acdb06968e53aa1ee8de207fd955335c754b7) | `` feat: add gleam (#206) `` |