### PR TITLE
chore(flake/nixpkgs): `52ec9ac3` -> `9f918d61`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -522,11 +522,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722185531,
-        "narHash": "sha256-veKR07psFoJjINLC8RK4DiLniGGMgF3QMlS4tb74S6k=",
+        "lastModified": 1722421184,
+        "narHash": "sha256-/DJBI6trCeVnasdjUo9pbnodCLZcFqnVZiLUfqLH4jA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "52ec9ac3b12395ad677e8b62106f0b98c1f8569d",
+        "rev": "9f918d616c5321ad374ae6cb5ea89c9e04bf3e58",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`2920bc8d`](https://github.com/NixOS/nixpkgs/commit/2920bc8d9fc0f29a7f3a4065d7fc7c862223c011) | `` recoll: 1.37.5 -> 1.39.1 ``                                                                 |
| [`fcb2a4a5`](https://github.com/NixOS/nixpkgs/commit/fcb2a4a5fff1903d403955a9753a34f79bb24455) | `` nixos/zoneminder: set fcgiwrap socket owner ``                                              |
| [`efc7aebd`](https://github.com/NixOS/nixpkgs/commit/efc7aebda7f85f67b52cc334066c6dd344371103) | `` nixos/fcgiwrap: require explicit owner for UNIX sockets ``                                  |
| [`4f2da6c9`](https://github.com/NixOS/nixpkgs/commit/4f2da6c9c17d75ba43fbe85d5243a57735a5e4eb) | `` nixos/fcgiwrap: add option migration instruction errors ``                                  |
| [`c3392ad3`](https://github.com/NixOS/nixpkgs/commit/c3392ad349a5227f4a3464dce87bcc5046692fce) | `` nixos/prometheus-smartctl-exporter: providing the path to the binary is no longer needed `` |
| [`0bab1a6d`](https://github.com/NixOS/nixpkgs/commit/0bab1a6d6e9bb6a0e7d4ae1b06ffeca97c30d842) | `` prometheus-smartctl-exporter: fix path to smartctl ``                                       |
| [`c3837ef0`](https://github.com/NixOS/nixpkgs/commit/c3837ef025a35877dec9f58de3dfe33d4d278a63) | `` dnf5: 5.1.15 -> 5.2.5.0 ``                                                                  |
| [`0358591a`](https://github.com/NixOS/nixpkgs/commit/0358591a761a15ce52dd213fdaad11bf3740ca1f) | `` librepo: 1.15.1 -> 1.18.0 ``                                                                |
| [`f4916f0c`](https://github.com/NixOS/nixpkgs/commit/f4916f0c3a1c06f5f92586af77aa9ae9e34fd783) | `` novelwriter: 2.4.4 -> 2.5.1 ``                                                              |
| [`7ce56e26`](https://github.com/NixOS/nixpkgs/commit/7ce56e26c4f9ab04dfcaf20a733cd3343c58d953) | `` grass: 8.3.2 -> 8.4.0 ``                                                                    |
| [`5a353f15`](https://github.com/NixOS/nixpkgs/commit/5a353f15cc0dce64519ebd88a5134c644507aec6) | `` nixos/nar-serve: add domain option ``                                                       |
| [`091f5f65`](https://github.com/NixOS/nixpkgs/commit/091f5f6540853eee1190ddce5b16bd6bc1fbf6da) | `` nar-serve: 0.6.1 -> 0.7.0 ``                                                                |
| [`ed47bba9`](https://github.com/NixOS/nixpkgs/commit/ed47bba9adbea3ab361f12d557d45359f2ace64e) | `` nixos/nar-serve: add package option ``                                                      |
| [`e7d21288`](https://github.com/NixOS/nixpkgs/commit/e7d212886b54420a5ea94ce2be88071124838c38) | `` beanstalkd: move to by-name ``                                                              |
| [`62ace478`](https://github.com/NixOS/nixpkgs/commit/62ace478a658b4c7c7d53ede4d1d099f5366f0f2) | `` bupc: move to by-name ``                                                                    |
| [`3a7201a0`](https://github.com/NixOS/nixpkgs/commit/3a7201a0f6fc78276f570dd0ba8c5008b00294b0) | `` ronn: move to by-name ``                                                                    |
| [`13cd4d68`](https://github.com/NixOS/nixpkgs/commit/13cd4d68642dcf85295dbd991f5ce1fb5815abdd) | `` pigeon: move to by-name ``                                                                  |
| [`7d7fd842`](https://github.com/NixOS/nixpkgs/commit/7d7fd84248b387be5f21e07b3db0548e0d021505) | `` buildkite-agent: move to by-name ``                                                         |
| [`af16288e`](https://github.com/NixOS/nixpkgs/commit/af16288ebb02b9053d9e083343129bd9f61c8006) | `` coz: move to by-name ``                                                                     |
| [`5d61acb7`](https://github.com/NixOS/nixpkgs/commit/5d61acb71b48a794caa327c82f4f781352d1134c) | `` packer: move to by-name ``                                                                  |
| [`f3edb08a`](https://github.com/NixOS/nixpkgs/commit/f3edb08a2880a070401df9f9285ec03de6f4f1a7) | `` aws-vault: move to by-name ``                                                               |
| [`009f33ce`](https://github.com/NixOS/nixpkgs/commit/009f33ce925c530ae0d42a9d4dc57cc4e0b0f954) | `` gitlab-runner: move to by-name ``                                                           |
| [`15c4b52a`](https://github.com/NixOS/nixpkgs/commit/15c4b52a8e5582b9fe8f9ab10808838c1e412ecf) | `` hclfmt: move to by-name ``                                                                  |
| [`e1681750`](https://github.com/NixOS/nixpkgs/commit/e1681750202da216f47b9dd95a2a605a6d8f2b03) | `` gopls: move to by-name ``                                                                   |
| [`1efdf816`](https://github.com/NixOS/nixpkgs/commit/1efdf8162a7393d05cdc778a8d2ab39551cc20d4) | `` tmux-cssh: move to by-name ``                                                               |
| [`1ccc99fe`](https://github.com/NixOS/nixpkgs/commit/1ccc99fe9e1b5b916c2f98600098cb16169730ad) | `` dispad: move to by-name ``                                                                  |
| [`43ab2b48`](https://github.com/NixOS/nixpkgs/commit/43ab2b48b3d1268e049d61d676a16afd8a9ebd17) | `` ovh-ttyrec: move to by-name ``                                                              |
| [`66194de3`](https://github.com/NixOS/nixpkgs/commit/66194de349468815f3e4f5fcdcdd1f20e9dd4335) | `` gifsicle: move to by-name ``                                                                |
| [`3d2cee1c`](https://github.com/NixOS/nixpkgs/commit/3d2cee1c04d420572c81abe4e32c86e3dcf7e1aa) | `` direnv: move to by-name ``                                                                  |
| [`840dc890`](https://github.com/NixOS/nixpkgs/commit/840dc890e9a3bba40e5a963c318ea4961c2b97f9) | `` zerotierone: move to by-name ``                                                             |
| [`ec7188d7`](https://github.com/NixOS/nixpkgs/commit/ec7188d73d959d4cad5342db6114d5ac176b7adc) | `` bundix: move to by-name ``                                                                  |
| [`caa12efa`](https://github.com/NixOS/nixpkgs/commit/caa12efaf425a4b5fd083daf96401e002e10869a) | `` keycard-cli: move to by-name ``                                                             |
| [`7724b648`](https://github.com/NixOS/nixpkgs/commit/7724b648cf2c6b4cf379dcaab1fe63f190d9c813) | `` kubectl-doctor: move to by-name ``                                                          |
| [`e6717ef3`](https://github.com/NixOS/nixpkgs/commit/e6717ef35b7bf4d67865a388c60b28b642a3853b) | `` terraform-docs: move to by-name ``                                                          |
| [`65a6b8ed`](https://github.com/NixOS/nixpkgs/commit/65a6b8edc6a5b62dd0eea5a8c2416e19ca694d62) | `` git-codeowners: move to by-name ``                                                          |
| [`7b8adc06`](https://github.com/NixOS/nixpkgs/commit/7b8adc065a9c17d1204008df1371c0905ba69bd2) | `` su-exec: move to by-name ``                                                                 |
| [`159042ff`](https://github.com/NixOS/nixpkgs/commit/159042ff69e64df4c0e99581e2ff82332d469537) | `` verifpal: move to by-name ``                                                                |
| [`dd69ea8e`](https://github.com/NixOS/nixpkgs/commit/dd69ea8ebd5866a71beed304aa34283d4e88c49c) | `` gerrit: move to by-name ``                                                                  |
| [`feb8a6f0`](https://github.com/NixOS/nixpkgs/commit/feb8a6f0517dab497934ac029475d4191735467e) | `` confd: move to by-name ``                                                                   |
| [`1629c2ea`](https://github.com/NixOS/nixpkgs/commit/1629c2eac051952a09d87e5a0174dc83d1ed3382) | `` foreman: move to by-name ``                                                                 |
| [`4cfef992`](https://github.com/NixOS/nixpkgs/commit/4cfef992fa857e2a5f56b89f574016e981085950) | `` goreman: move to by-name ``                                                                 |
| [`ebed8837`](https://github.com/NixOS/nixpkgs/commit/ebed8837b50e7ecdf3d009ba1ed9063b713d9233) | `` shab: move to by-name ``                                                                    |
| [`06e0eef0`](https://github.com/NixOS/nixpkgs/commit/06e0eef0f743a587aa74ff778729ae230d8198a8) | `` gist: move to by-name ``                                                                    |
| [`7266ad59`](https://github.com/NixOS/nixpkgs/commit/7266ad59cea0683d4e336bc9b3e7b9460d664d55) | `` nar-serve: move to by-name ``                                                               |
| [`31e5e88a`](https://github.com/NixOS/nixpkgs/commit/31e5e88a9334a2e180ca0369bf481c8a1709f94e) | `` nix-store-gcs-proxy: move to by-name ``                                                     |
| [`99dc6c2e`](https://github.com/NixOS/nixpkgs/commit/99dc6c2efa30ba13bd24321fb47fb33c19fd0467) | `` nixpkgs-fmt: move to by-name ``                                                             |
| [`8b6aed7e`](https://github.com/NixOS/nixpkgs/commit/8b6aed7ed3df0a720fa58d2ba3287505f9ca048c) | `` webfs: move to by-name ``                                                                   |
| [`2bd7cf6c`](https://github.com/NixOS/nixpkgs/commit/2bd7cf6cca82d777f715949b84120a682b82398b) | `` vpsfree-client: move to by-name ``                                                          |
| [`832fe147`](https://github.com/NixOS/nixpkgs/commit/832fe14732b313cae870b078f582b77615a25104) | `` nixpkgs/release-checks: shut up GC ``                                                       |
| [`bcba08a2`](https://github.com/NixOS/nixpkgs/commit/bcba08a2864a7f26ab930aa8abebbff0b68e29a1) | `` nixpkgs/release-checks: remove debug print ``                                               |
| [`2327299e`](https://github.com/NixOS/nixpkgs/commit/2327299ec4766da88a0e530c9d140b03a14cffd7) | `` nixpkgs/release-checks: actually log the warnings ``                                        |
| [`230fcec8`](https://github.com/NixOS/nixpkgs/commit/230fcec81e42e17c968eec3c0c5452ea891ed0e0) | `` openconnect: fix build on darwin ``                                                         |
| [`5622ff23`](https://github.com/NixOS/nixpkgs/commit/5622ff23c9e6aef821249fa053d62e0bb0b3ba1d) | `` mopsa: init at 1.0 ``                                                                       |
| [`eeb23d8a`](https://github.com/NixOS/nixpkgs/commit/eeb23d8a44efc7b0293b8c941d554f13f3ebc607) | `` python312Packages.h5py: mark as broken on x86_64-darwin ``                                  |
| [`3d84f9b4`](https://github.com/NixOS/nixpkgs/commit/3d84f9b40eafd73a0c0bc8963e383fb4175430ef) | `` coqPackages.metacoq: 1.3.1 → 1.3.2 ``                                                       |
| [`3beb8cad`](https://github.com/NixOS/nixpkgs/commit/3beb8cad2e3417c44b6d064f93f9500cd57f2a2d) | `` google-java-format: 1.22.0 -> 1.23.0 ``                                                     |
| [`0e844071`](https://github.com/NixOS/nixpkgs/commit/0e844071c4cca6e11c08186d2b13c76b7c1b1e2d) | `` python3Packages.uxsim: 1.3.1 -> 1.4.0 ``                                                    |
| [`d968402c`](https://github.com/NixOS/nixpkgs/commit/d968402cd5a533604b6b4c57332f083cce6bcad7) | `` tests/armagetronad: increase timeout for busy Hydra server ``                               |
| [`78a61378`](https://github.com/NixOS/nixpkgs/commit/78a6137855fe089f3898000cca460bc2d830f2f5) | `` mdbook-yml-header: init at 0.1.4 ``                                                         |
| [`0bb48f17`](https://github.com/NixOS/nixpkgs/commit/0bb48f173217968b6640e2e2c5016312e7cbdd10) | `` flyctl: 0.2.94 -> 0.2.101 ``                                                                |
| [`a191e88a`](https://github.com/NixOS/nixpkgs/commit/a191e88a1afda4a731181943e1aab1c33a40fb62) | `` nixos/gotify-server: update test ``                                                         |
| [`0c2918fc`](https://github.com/NixOS/nixpkgs/commit/0c2918fc912c25bce8896e70bd2905052d214b47) | `` nixos/gotify-server: add environment and environmentFiles options ``                        |
| [`e1ced8b1`](https://github.com/NixOS/nixpkgs/commit/e1ced8b12c3be230bf9e23e42e330e0133a4f512) | `` nixos/gotify-server: add package option ``                                                  |
| [`b5a051f6`](https://github.com/NixOS/nixpkgs/commit/b5a051f69490d32e55f0ac737cad78bc9fcaeb23) | `` nixos/gotify-server: add maintainer ``                                                      |
| [`2079eeb8`](https://github.com/NixOS/nixpkgs/commit/2079eeb882face7366c17486907ed45f25d913a0) | `` nixos/gotify-server: clean up and reformat module ``                                        |
| [`670ac560`](https://github.com/NixOS/nixpkgs/commit/670ac5606ce26f56a46f2b63f54a9e59b13f4f6a) | `` faiss: mv test.pytest to python3Packages.test, fix eval ``                                  |
| [`4b35b26d`](https://github.com/NixOS/nixpkgs/commit/4b35b26dad10bc2bb57c86ff17536a6e92e1ba3c) | `` stdenv/darwin/make-bootstrap-tools.nix: add libcodedirectory.1.dylib ``                     |
| [`7ea0a934`](https://github.com/NixOS/nixpkgs/commit/7ea0a9346155e373fbe6c6c5ac04afb077d5d6f0) | `` nwjs-ffmpeg-prebuilt: init at 0.89.0 ``                                                     |
| [`f3b5635d`](https://github.com/NixOS/nixpkgs/commit/f3b5635d2566f37ac8c4ceb75a01134f04a2eb60) | `` cmd-polkit: fix meta.mainProgram binary ``                                                  |
| [`8abfb83a`](https://github.com/NixOS/nixpkgs/commit/8abfb83a312c4ded2efce4c4963532cb6a917175) | `` armagetronad: use libxml2 with HTTP support ``                                              |
| [`da4c9eb4`](https://github.com/NixOS/nixpkgs/commit/da4c9eb47b5af5e64bd10836b133cab71e731bcb) | `` tests/armagetronad: increase memory allocation ``                                           |
| [`105bb49c`](https://github.com/NixOS/nixpkgs/commit/105bb49c4ba26b5d806e842415b2f2279f8a31ad) | `` armagetronad: add passthru.tests ``                                                         |
| [`204cb87e`](https://github.com/NixOS/nixpkgs/commit/204cb87e31874a44193613139471831159a74492) | `` armagetronad: fix installCheckPhase on hydra ``                                             |
| [`73064231`](https://github.com/NixOS/nixpkgs/commit/7306423158ba8d6e5d5674c4d6a7fcfea3c75f84) | `` nixos/pam: fully-qualify `modulePath` ``                                                    |
| [`7511ed26`](https://github.com/NixOS/nixpkgs/commit/7511ed266c9ccf2aec06fd391dbc6fcecd1bb76c) | `` nixos/pam: add `security.pam.package` option ``                                             |
| [`cb15b280`](https://github.com/NixOS/nixpkgs/commit/cb15b280ab099e2de3b4a2d45b289c71596180c4) | `` sudo-rs: 0.2.2 -> 0.2.3 ``                                                                  |
| [`a8fb07ff`](https://github.com/NixOS/nixpkgs/commit/a8fb07ff7915197903c7a324f2326695e6d970d8) | `` pretix: relax django-compressor dep ``                                                      |
| [`9bd006b1`](https://github.com/NixOS/nixpkgs/commit/9bd006b18ed1c748e98c92f475335a04c1eb9a45) | `` picat: 3.6 -> 3.6#8 ``                                                                      |
| [`3b97575e`](https://github.com/NixOS/nixpkgs/commit/3b97575e8ae35b025134c9bf502d6697c001cfac) | `` restic-integrity: add networkexception as maintainer ``                                     |
| [`b012a148`](https://github.com/NixOS/nixpkgs/commit/b012a14847e6ff488ac562c270381740ca00bbe2) | `` restic-integrity: 1.2.2 -> 1.3.0 ``                                                         |
| [`bbb542ea`](https://github.com/NixOS/nixpkgs/commit/bbb542ea66ada974b20b6234f821f7f0aea2d3e5) | `` nixos/ollama: add missing nvidia device group name (#331125) ``                             |
| [`3f6d2e02`](https://github.com/NixOS/nixpkgs/commit/3f6d2e0275f317ff532ed0b351ecfa818e9e6e81) | `` flatcc: fix build on clang ``                                                               |
| [`ea8c4f36`](https://github.com/NixOS/nixpkgs/commit/ea8c4f36a0f2dd3407e9b7b6b7ea553e7ff29b9c) | `` mysql-workbench: fix build ``                                                               |
| [`1257f927`](https://github.com/NixOS/nixpkgs/commit/1257f92777bcc320e3390f04de2dc88102fbfc16) | `` pkgsMusl.systemd: fix build ``                                                              |
| [`3d45adb1`](https://github.com/NixOS/nixpkgs/commit/3d45adb1fbb68d28d2a512625d8551d9cf890698) | `` snapper: fix build ``                                                                       |
| [`309eb346`](https://github.com/NixOS/nixpkgs/commit/309eb346d6d2141c6395cdaf33de1a69489fa90c) | `` grass: fix build by using libxml2 with http support ``                                      |
| [`12bf1207`](https://github.com/NixOS/nixpkgs/commit/12bf120747c39ad19cfdd7e3c31fba833cb77532) | `` discourse: update plugins ``                                                                |
| [`cf1df147`](https://github.com/NixOS/nixpkgs/commit/cf1df147c5d4befae1240c13a1a7d280000aa0f6) | `` koboldcpp: 1.70.1 -> 1.71.1 ``                                                              |
| [`326c8790`](https://github.com/NixOS/nixpkgs/commit/326c87902e2c7e92a0a5050c32ace9b09a175588) | `` discourse: 3.2.4 -> 3.2.5 ``                                                                |
| [`7b67b4be`](https://github.com/NixOS/nixpkgs/commit/7b67b4bebce9207c76cd3ef5f2f8de1673bfab34) | `` darktable: fix build ``                                                                     |
| [`aab1113d`](https://github.com/NixOS/nixpkgs/commit/aab1113d4ab7dd26923cdd6646000ca0f29cf755) | `` treewide: normalize maintainers list formatting ``                                          |
| [`f85e1e1d`](https://github.com/NixOS/nixpkgs/commit/f85e1e1d18b16dc8c15f864d364eba0448e8105a) | `` nushell: 0.96.0 -> 0.96.1 ``                                                                |
| [`204e7776`](https://github.com/NixOS/nixpkgs/commit/204e7776920d95f2203ff8e2ad3d544b2ef0c5d4) | `` python3Packages: remove unused arguments ``                                                 |
| [`0920d006`](https://github.com/NixOS/nixpkgs/commit/0920d0062b15f8b757f5e439b2e3012d1e0fc585) | `` python312Packages.homeassistant-stubs: 2024.7.3 -> 2024.7.4 ``                              |
| [`52764879`](https://github.com/NixOS/nixpkgs/commit/52764879d1ed2b3b645b06b8a35f01c83ce124ed) | `` python312Packages.shiny: init at 0.10.2 ``                                                  |
| [`bda99fed`](https://github.com/NixOS/nixpkgs/commit/bda99fed15646195796bd15b0c5e82f6260f434d) | `` wpsoffice{-cn}: 11.1.0.11720 -> 11.1.0.11723 ``                                             |
| [`68d8d204`](https://github.com/NixOS/nixpkgs/commit/68d8d204b5f64fdbe1521dbb3604369fa965d88d) | `` python312Packages.greatfet: add missing dependencies ``                                     |
| [`85bb3a2f`](https://github.com/NixOS/nixpkgs/commit/85bb3a2fba6562ef0683489075cb20f566123284) | `` river: 0.3.4 -> 0.3.5 ``                                                                    |
| [`a9265d24`](https://github.com/NixOS/nixpkgs/commit/a9265d241682124368fca2ed813ee6efbb271b7a) | `` home-assistant: 2024.7.3 -> 2024.7.4 ``                                                     |
| [`18d13117`](https://github.com/NixOS/nixpkgs/commit/18d131170b014fe166bd9b99416ba8916739f599) | `` emacs.pkgs.nongnuDevelPackages: init ``                                                     |
| [`7316070b`](https://github.com/NixOS/nixpkgs/commit/7316070b1595c3ca056183b3403bc8f58397faf1) | `` lan-mouse: 0.8.0 -> 0.9.1 ``                                                                |
| [`42e81cc7`](https://github.com/NixOS/nixpkgs/commit/42e81cc7a766798c9da9dcca50763daf3a198f67) | `` sigtop: 0.11.0 -> 0.12.0 ``                                                                 |
| [`939b79dd`](https://github.com/NixOS/nixpkgs/commit/939b79dd3519368b0c10a5b504c4b6b8c3bd8c9c) | `` teams: remove AndersonTorres from zig.members ``                                            |
| [`dcfb2006`](https://github.com/NixOS/nixpkgs/commit/dcfb20066aad536d7c7f4637f7018290589d4221) | `` python312Packages.aiohue: 4.7.1 -> 4.7.2 ``                                                 |
| [`d1c49901`](https://github.com/NixOS/nixpkgs/commit/d1c49901cfc3f5a3ce7648735f1a0cbd4d5657e2) | `` dotfiles: 0.6.4 -> 0.6.5 ``                                                                 |
| [`4fecea8f`](https://github.com/NixOS/nixpkgs/commit/4fecea8f121bbb35fedef4e78ab8c130403ed1ac) | `` ollama: 0.3.0 -> 0.3.1 ``                                                                   |
| [`739ceab3`](https://github.com/NixOS/nixpkgs/commit/739ceab3d09382af733ef8fdf3f63ce441467ae4) | `` qogir-kde: 0-unstable-2024-06-28 -> 0-unstable-2024-07-29 ``                                |
| [`7aee8976`](https://github.com/NixOS/nixpkgs/commit/7aee8976d6abd429e3857c2bf3dc34d396ae4095) | `` python312Packages.pykeepass: 4.1.0 -> 4.1.0-post1 ``                                        |
| [`95eb0504`](https://github.com/NixOS/nixpkgs/commit/95eb05041a4833786095a2b381af7732d3a61a59) | `` nodePackages.prisma: add meta.mainProgram ``                                                |
| [`0315139c`](https://github.com/NixOS/nixpkgs/commit/0315139cac9f92ea714684556d758f4cfaa8a5af) | `` emacs: format generated code for elisp packages ``                                          |
| [`bb4d6cad`](https://github.com/NixOS/nixpkgs/commit/bb4d6cad3e0d34e3135b426e6de4f50854bbe60e) | `` emacs: do formatting in the elisp update scripts ``                                         |
| [`3d54e5af`](https://github.com/NixOS/nixpkgs/commit/3d54e5af5c02fd5bbb31d81287df5810228d231c) | `` bindfs: fix macos build by disabling system binding ``                                      |
| [`7ece6d21`](https://github.com/NixOS/nixpkgs/commit/7ece6d213ef26ab778072d51f90972bc546b0eeb) | `` linuxPackages.ena: 2.12.1 -> 2.12.3 ``                                                      |
| [`910be19a`](https://github.com/NixOS/nixpkgs/commit/910be19a0528be41bafa4776de130190e630b973) | `` igir: remove TheBrainScrambler as maintainer ``                                             |
| [`c4319073`](https://github.com/NixOS/nixpkgs/commit/c43190734315001f7d66e06e818e1286b9db7f7a) | `` trrntzip: remove TheBrainScrambler as maintainer ``                                         |
| [`a3de45ec`](https://github.com/NixOS/nixpkgs/commit/a3de45ecf0505262296e69fea24751555a394068) | `` libeduvpn-common: 2.0.2 -> 2.1.0 ``                                                         |
| [`52bb7f5c`](https://github.com/NixOS/nixpkgs/commit/52bb7f5c579fbcb6e879db9f6df78e905c62b76c) | `` eduvpn-client: 4.3.1 -> 4.4.0 ``                                                            |
| [`af6dd4a1`](https://github.com/NixOS/nixpkgs/commit/af6dd4a125e09353053b3abba502ba95de24f220) | `` weaviate: 1.25.8 -> 1.25.9 ``                                                               |
| [`d44b3f0e`](https://github.com/NixOS/nixpkgs/commit/d44b3f0e75859effb3fd40c5d5c440f461f44411) | `` linux/update-mainline: fix -rc version spelling, clean up a bit ``                          |
| [`6b6d39d4`](https://github.com/NixOS/nixpkgs/commit/6b6d39d4d0359f5d0ea9ba89d79782bb3390c174) | `` linux-rt_6_6: 6.6.41-rt37 -> 6.6.43-rt38 ``                                                 |