### PR TITLE
chore(flake/git-hooks): `f451c193` -> `650538dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721042469,
-        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
+        "lastModified": 1722850348,
+        "narHash": "sha256-YJINMAih/G6YkclB6o5fAOxsLsf6vikHAZg6NJ3TQL8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
+        "rev": "650538dc782fe4457bd4458d392529af04c3554e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`2d366523`](https://github.com/cachix/git-hooks.nix/commit/2d366523b68afee27c0ddb40cd0f46c7c51ef563) | `` docs: add ruff-format to python list `` |
| [`509f5059`](https://github.com/cachix/git-hooks.nix/commit/509f50596bd654cbf4c124589d3a608879978341) | `` feat: add ruff-format ``                |