### PR TITLE
chore(flake/git-hooks): `650538dc` -> `06939f6b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722850348,
-        "narHash": "sha256-YJINMAih/G6YkclB6o5fAOxsLsf6vikHAZg6NJ3TQL8=",
+        "lastModified": 1722857853,
+        "narHash": "sha256-3Zx53oz/MSIyevuWO/SumxABkrIvojnB7g9cimxkhiE=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "650538dc782fe4457bd4458d392529af04c3554e",
+        "rev": "06939f6b7ec4d4f465bf3132a05367cccbbf64da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`54ac8605`](https://github.com/cachix/git-hooks.nix/commit/54ac86058e30d476ae0ff4c428d40a8c3eb2581e) | `` fix: change ruff format hook name `` |