### PR TITLE
chore(flake/treefmt-nix): `5a3a9f95` -> `14c092e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -793,11 +793,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723296071,
-        "narHash": "sha256-jmM54BP93MJPL4jpuDnEMFDPvkGfDtfW3k/dHON5y70=",
+        "lastModified": 1723303070,
+        "narHash": "sha256-krGNVA30yptyRonohQ+i9cnK+CfCpedg6z3qzqVJcTs=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "5a3a9f956673111759d9643cf1a3ab81ee94cbf4",
+        "rev": "14c092e0326de759e16b37535161b3cb9770cea3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                        |
| ---------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`14c092e0`](https://github.com/numtide/treefmt-nix/commit/14c092e0326de759e16b37535161b3cb9770cea3) | `` Add renovate.json (#215) `` |