### PR TITLE
chore(flake/nixos-hardware): `107bb46e` -> `dfe45103`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1723149858,
-        "narHash": "sha256-3u51s7jdhavmEL1ggtd8wqrTH2clTy5yaZmhLvAXTqc=",
+        "lastModified": 1723309411,
+        "narHash": "sha256-N66aj35PTGqlk4Aa0hrEIpVU/jPOGSTQGwyZU8Po80A=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "107bb46eef1f05e86fc485ee8af9b637e5157988",
+        "rev": "dfe45103b691b66a9f5b22cbec99d32ee31e0a52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`dfe45103`](https://github.com/NixOS/nixos-hardware/commit/dfe45103b691b66a9f5b22cbec99d32ee31e0a52) | `` lenovo/legion/16arha7: fix kernel check for speaker patch ``           |
| [`72b83c83`](https://github.com/NixOS/nixos-hardware/commit/72b83c838d756b6d019017cfafd645b314f85097) | `` asus-fx506hm: use nvidia-open by default ``                            |
| [`6ed55216`](https://github.com/NixOS/nixos-hardware/commit/6ed5521636c7b40b800a014f26f0eaaa210c2e30) | `` thinkpad-t14-gen1: add a kernel param for touchpad to work properly `` |
| [`f568ffb6`](https://github.com/NixOS/nixos-hardware/commit/f568ffb601d39e3aedae86b056b4cb8e9cb590a8) | `` apple/t2: bump kernel to 6.10.3 ``                                     |