### PR TITLE
chore(flake/nixos-hardware): `dfe45103` -> `c54cf53e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1723309411,
-        "narHash": "sha256-N66aj35PTGqlk4Aa0hrEIpVU/jPOGSTQGwyZU8Po80A=",
+        "lastModified": 1723310128,
+        "narHash": "sha256-IiH8jG6PpR4h9TxSGMYh+2/gQiJW9MwehFvheSb5rPc=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "dfe45103b691b66a9f5b22cbec99d32ee31e0a52",
+        "rev": "c54cf53e022b0b3c1d3b8207aa0f9b194c24f0cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [`c54cf53e`](https://github.com/NixOS/nixos-hardware/commit/c54cf53e022b0b3c1d3b8207aa0f9b194c24f0cf) | `` Tidy-up idents ``                                                                                                                                    |
| [`569b23fd`](https://github.com/NixOS/nixos-hardware/commit/569b23fd8271ec562652295bf67e7378cca6570e) | `` Simplify the diff, by moving the (mkIf ...) for the keyboard.autosuspend.enable option to within the associated services.udev.extraRules attr-set `` |
| [`6f38f857`](https://github.com/NixOS/nixos-hardware/commit/6f38f8576c0dd1cc76f158e56793323f9c7df773) | `` Test the kernel version, rather than the NixOS release version ``                                                                                    |
| [`d1966ef8`](https://github.com/NixOS/nixos-hardware/commit/d1966ef874040b83d654ab9c896430f3017a9ec1) | `` Clarify doc-comments ``                                                                                                                              |
| [`ddebede9`](https://github.com/NixOS/nixos-hardware/commit/ddebede97439b73e1ba746c0ce68b999bcbb49c0) | `` On ASUS Zephyrus GA402X, make enabling auto-suspend on the keyboard optional ``                                                                      |