### PR TITLE
chore(flake/treefmt-nix): `14c092e0` -> `c9f97032`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -793,11 +793,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723303070,
-        "narHash": "sha256-krGNVA30yptyRonohQ+i9cnK+CfCpedg6z3qzqVJcTs=",
+        "lastModified": 1723402464,
+        "narHash": "sha256-xjunKUFQs9D7u0TpVoXhrRYb4tbVkutRoFUHj0lEydE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "14c092e0326de759e16b37535161b3cb9770cea3",
+        "rev": "c9f97032be6816fa234f24803b8ae79dc7753a91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                            |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`c9f97032`](https://github.com/numtide/treefmt-nix/commit/c9f97032be6816fa234f24803b8ae79dc7753a91) | `` fixup! fix: only eval enable option if visible (#214) (#218) `` |