### PR TITLE
chore(flake/lovesegfault-vim-config): `8229d116` -> `3b745af0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723507409,
-        "narHash": "sha256-QHA/sDva4Tm8Tazq1ljmu8S62IRhxr/KRp50Ub398vg=",
+        "lastModified": 1723570320,
+        "narHash": "sha256-WUXs9+/y14/JExgKGKHbhnurhLSqs1RnJN4qBraGk0E=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "8229d1162f3aabfb2759d92dca708efdba594a8d",
+        "rev": "3b745af0641d08cdbc8545da3559e0ad91230ed7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                |
| -------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`3b745af0`](https://github.com/lovesegfault/vim-config/commit/3b745af0641d08cdbc8545da3559e0ad91230ed7) | `` feat: enable codelldb and dap-ui `` |
| [`e697defb`](https://github.com/lovesegfault/vim-config/commit/e697defb6dadb87089d95c07c032f12c6b749c9e) | `` feat: enable noice ``               |