### PR TITLE
chore(flake/treefmt-nix): `349de7bc` -> `4a6d7dcc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -793,11 +793,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723454642,
-        "narHash": "sha256-S0Gvsenh0II7EAaoc9158ZB4vYyuycvMGKGxIbERNAM=",
+        "lastModified": 1723656612,
+        "narHash": "sha256-6Sx+/VhRPLR+kRf6rnNUFMQ66DUz1DMYajixYUe+CUU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "349de7bc435bdff37785c2466f054ed1766173be",
+        "rev": "4a6d7dccf80a1aa2d04cfaa88d9e5511542a2486",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                            |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`fc6a179f`](https://github.com/numtide/treefmt-nix/commit/fc6a179f7a48fbf33c8c704dcda9f8435454089d) | `` mypy: allow adding custom paths to the shell `` |