### PR TITLE
chore(flake/disko): `0d510fe4` -> `f1e929d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723426710,
-        "narHash": "sha256-yrS9al6l3fYfFfvovnyBWnyELDQOdfKyai4K/jKgoBw=",
+        "lastModified": 1723669711,
+        "narHash": "sha256-MBPUhgK5fiL1+MCmQaHnJxM6w9vDeK13az/7hIlhnHA=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "0d510fe40b56ed74907a021d7e1ffd0042592914",
+        "rev": "f1e929d12182deb34e3900477f914da4a3b86e56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                                |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`d8a1d5e1`](https://github.com/nix-community/disko/commit/d8a1d5e1f0885d151801ef3e35251a475f53691e) | `` make-disk-image: allow vmTools qemu usage to be overriden by disko configuration `` |
| [`de015d2a`](https://github.com/nix-community/disko/commit/de015d2a44632ea1102522e609c0beba0e57a18b) | `` make-disk-image: allow pkgs to be overriden by disko configuration ``               |
| [`f5cc4b55`](https://github.com/nix-community/disko/commit/f5cc4b55e5adc8a19b1e986245f632e006226e01) | `` make-disk-image: allow kernel to be overriden by disko configuration ``             |