### PR TITLE
chore(flake/lovesegfault-vim-config): `28bc2ed3` -> `e6bde458`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723680205,
-        "narHash": "sha256-s5e4kyqubOT5ZgJienW/QhPh4a6A4WvyVVnL0FkvSZg=",
+        "lastModified": 1723695302,
+        "narHash": "sha256-rVneRCLMD91guxypL6AUguP0lWB2OoRzPZ1AKwWm+iE=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "28bc2ed3770fae8da6f1dc64e81b6badb853a818",
+        "rev": "e6bde458eed8ca3821d9d1b57a2f2e237b2e017c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                   |
| -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`e6bde458`](https://github.com/lovesegfault/vim-config/commit/e6bde458eed8ca3821d9d1b57a2f2e237b2e017c) | `` fix: bufferline diagnostics rename ``                  |
| [`12012c61`](https://github.com/lovesegfault/vim-config/commit/12012c6199c0384ef247bec993f868b65bd4bf1c) | `` Revert "chore(flake/nixpkgs): 5e0ca229 -> a58bc8ad" `` |