### PR TITLE
chore(flake/lovesegfault-vim-config): `e6bde458` -> `8b884663`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723695302,
-        "narHash": "sha256-rVneRCLMD91guxypL6AUguP0lWB2OoRzPZ1AKwWm+iE=",
+        "lastModified": 1723766612,
+        "narHash": "sha256-JJtdB9v+SNNYbDb2KQnk/XwXBOzNoVEwXpRD03s6+1Y=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "e6bde458eed8ca3821d9d1b57a2f2e237b2e017c",
+        "rev": "8b88466382a22ea68c722344ce660c43bb4a437e",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723670331,
-        "narHash": "sha256-bQaWqflbYdOn28NJHMTMMPgswlQRXhZh+a3WQAeyaFE=",
+        "lastModified": 1723754845,
+        "narHash": "sha256-gzso/eDMTitt3gUzpLuQRFB/bwvxz2ukq301ASOEtc4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a96aa9730af8c85dd7ed15e359ac23e9686f0a9a",
+        "rev": "ebd2182b44150fcab0f92cdc4be8ff2ed93fd2cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`8b884663`](https://github.com/lovesegfault/vim-config/commit/8b88466382a22ea68c722344ce660c43bb4a437e) | `` chore(flake/nixpkgs): 5e0ca229 -> c3aa7b89 `` |
| [`6d9262f1`](https://github.com/lovesegfault/vim-config/commit/6d9262f183fe70fd498129362aaa73dc93c97865) | `` chore(flake/nixvim): a96aa973 -> ebd2182b ``  |