### PR TITLE
chore(flake/lovesegfault-vim-config): `4aa3e707` -> `e68b726d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723939403,
-        "narHash": "sha256-r6aRu/bFpFVCidBWWDzO5l3CR7n0iXdjYQ0cSDysN8o=",
+        "lastModified": 1723947200,
+        "narHash": "sha256-ByH3iHs4A3qfni0JKBvcRTjTqngInKlqS43Vh+fZDdE=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "4aa3e7073212ae2ce39a2f40f91cff8835a13693",
+        "rev": "e68b726d228908bfb8671d926efbd126045de738",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`e68b726d`](https://github.com/lovesegfault/vim-config/commit/e68b726d228908bfb8671d926efbd126045de738) | `` chore(flake/treefmt-nix): 4a6d7dcc -> 1d077395 `` |