### PR TITLE
chore(flake/nix-index-database): `39bc3e8c` -> `392828aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -547,11 +547,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723949845,
-        "narHash": "sha256-QX2GP2he3EQozkFDiku9AEnUa0A5fyzFF2ZWCis/QgA=",
+        "lastModified": 1723950649,
+        "narHash": "sha256-dHMkGjwwCGj0c2MKyCjRXVBXq2Sz3TWbbM23AS7/5Hc=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "39bc3e8c43432e8f6066cac179b30e3d58b3d4c5",
+        "rev": "392828aafbed62a6ea6ccab13728df2e67481805",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`392828aa`](https://github.com/nix-community/nix-index-database/commit/392828aafbed62a6ea6ccab13728df2e67481805) | `` update generated.nix to release 2024-08-18-025734 `` |