### PR TITLE
chore(flake/lovesegfault-vim-config): `e68b726d` -> `6fdcca6b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723947200,
-        "narHash": "sha256-ByH3iHs4A3qfni0JKBvcRTjTqngInKlqS43Vh+fZDdE=",
+        "lastModified": 1724025801,
+        "narHash": "sha256-1rW0PQSbZB7V+DmV3QzIEYGXNb1cuBUqmCTq5GvWZ2o=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "e68b726d228908bfb8671d926efbd126045de738",
+        "rev": "6fdcca6ba8b1088a64255d67d8e37a18174fcc77",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723923888,
-        "narHash": "sha256-w+/PG6KqB8en0x1JH5aMuf0QC78Nfei208EaaaRuYG4=",
+        "lastModified": 1724017104,
+        "narHash": "sha256-1pMyOYqBx7L/w1I/HEa8L01Wx7mZH3QrhDk/8XvDSSw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "78fc4be6a830e8dc01f3e66ddbe3243b4bfe8560",
+        "rev": "7a11b66f11d292b59571dad85fd1501dbd9bd0c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`6fdcca6b`](https://github.com/lovesegfault/vim-config/commit/6fdcca6ba8b1088a64255d67d8e37a18174fcc77) | `` chore(flake/nixvim): 78fc4be6 -> 7a11b66f `` |