### PR TITLE
chore(flake/impermanence): `9de98e03` -> `03fe473c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1724098307,
-        "narHash": "sha256-7SKGkqrXPLRD0jbs9IOnUhmjJZv2wawrlkgtzF0tMrw=",
+        "lastModified": 1724146542,
+        "narHash": "sha256-MLxtqDtu+y/4UDhXX5pFypX9/qbH54TDP6Z90oFzd/A=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "9de98e038ae91e15ea725700386044309b340299",
+        "rev": "03fe473c731cda2900bae9894b8dfc68e3492db5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`03fe473c`](https://github.com/nix-community/impermanence/commit/03fe473c731cda2900bae9894b8dfc68e3492db5) | `` nixos: Formatting fixes ``                                                |
| [`785dd659`](https://github.com/nix-community/impermanence/commit/785dd6597b4fdc7f9f3b96a8f351be611ed56757) | `` nixos: Add option to toggle warnings ``                                   |
| [`467e24bd`](https://github.com/nix-community/impermanence/commit/467e24bd041e16a9752de7700d067b2efb9329c9) | `` nixos: Make the /var/lib/nixos assertion a warning and include parents `` |