### PR TITLE
chore(flake/disko): `c7b14da2` -> `64335715`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724163524,
-        "narHash": "sha256-3A06DYw47oSLYMalkWDLzTMHC0MKgm1mNfaca9sqUnI=",
+        "lastModified": 1724249543,
+        "narHash": "sha256-fD/N0Jt2HYyNOOrXdWXKSnU4HVgv9gQh3AN118+eLdw=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "c7b14da22e302e0f9d7aa4df26b61016bcedf738",
+        "rev": "64335715566fae8493bd65f045064617a22aa99a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`5715bc02`](https://github.com/nix-community/disko/commit/5715bc02df0a1fa0250bdda196fa2c4c697ddc9c) | `` Update docs/interactive-vm.md ``                                    |
| [`a7656d48`](https://github.com/nix-community/disko/commit/a7656d4827d69c8c4892ec95105f7793470cbe9b) | `` Update README.md ``                                                 |
| [`a574d68d`](https://github.com/nix-community/disko/commit/a574d68d370d84f2e526c7b4cb021e456bc72981) | `` module: add vmWithDisko output to system ``                         |
| [`5a9f2498`](https://github.com/nix-community/disko/commit/5a9f2498fbe02c51fb1359240f53966fb3534905) | `` luks: add testmode password "disko" ``                              |
| [`c5e5018a`](https://github.com/nix-community/disko/commit/c5e5018a046533570211b75af7fffcc12eeccc19) | `` make-disk-image: add testMode, copyNixStore & extraConfig params `` |
| [`6208b31a`](https://github.com/nix-community/disko/commit/6208b31a73805d8dda951c1d83e7d96a08a43a81) | `` nix fmt ``                                                          |