### PR TITLE
chore(flake/disko): `64335715` -> `74a12fdf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724249543,
-        "narHash": "sha256-fD/N0Jt2HYyNOOrXdWXKSnU4HVgv9gQh3AN118+eLdw=",
+        "lastModified": 1724252836,
+        "narHash": "sha256-Y0PfeVEa8hwCaxO8dZCCm5IGPlvrDxrAcnAg7ZQeaBo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "64335715566fae8493bd65f045064617a22aa99a",
+        "rev": "74a12fdf533640cd4a14272ed1cf6dcab534253d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                      |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`5b36e65c`](https://github.com/nix-community/disko/commit/5b36e65c7c6eea6d4452e9e4f1f72ea376d8928f) | `` Fix the manual by fixing string escape `` |