### PR TITLE
chore(flake/disko): `4b866c99` -> `43573714`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724290508,
-        "narHash": "sha256-dtL4vielmrko/0XpZ3Wfd7czVvv3NC5oiwh8PKJN9hw=",
+        "lastModified": 1724349583,
+        "narHash": "sha256-zgB1Cfk46irIsto8666yLdKjqKdBrjR48Dd3lhQ0CnQ=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "4b866c9942d0f771ae934f04ca9859936f9bfbcf",
+        "rev": "435737144be0259559ca3b43f7d72252b1fdcc1b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                            |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`43573714`](https://github.com/nix-community/disko/commit/435737144be0259559ca3b43f7d72252b1fdcc1b) | `` swap: don't create filesystem if randomEncryption is enabled `` |
| [`f6b2e005`](https://github.com/nix-community/disko/commit/f6b2e0052d9c4a22c36e38a402c14f6f42603843) | `` zfs_fs: Fix errors when not changing mountpoint ``              |