### PR TITLE
chore(flake/home-manager): `25988610` -> `b18f3ebc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723986931,
-        "narHash": "sha256-Fy+KEvDQ+Hc8lJAV3t6leXhZJ2ncU5/esxkgt3b8DEY=",
+        "lastModified": 1724412708,
+        "narHash": "sha256-tLr1k+UZLVumyqXRU8E5lBtLjsvHSy8e2NiamfkjpYg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2598861031b78aadb4da7269df7ca9ddfc3e1671",
+        "rev": "b18f3ebc4029c22d437e3424014c8597a8b459a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`b18f3ebc`](https://github.com/nix-community/home-manager/commit/b18f3ebc4029c22d437e3424014c8597a8b459a0) | `` systemd: fully deprecate legacy switcher `` |
| [`25c12f07`](https://github.com/nix-community/home-manager/commit/25c12f07366fb98008326cc3910d4231ccf889e9) | `` tests: fix escaping of wait command ``      |
| [`40ddec2f`](https://github.com/nix-community/home-manager/commit/40ddec2f8a71d9fb92735f0553dc81a8825596c4) | `` zsh: add option: history.append ``          |