### PR TITLE
chore(flake/nix-index-database): `392828aa` -> `f65c9d6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -547,11 +547,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723950649,
-        "narHash": "sha256-dHMkGjwwCGj0c2MKyCjRXVBXq2Sz3TWbbM23AS7/5Hc=",
+        "lastModified": 1724555399,
+        "narHash": "sha256-OVX8nA446AcVvUzI2QXF0unkWb27u1CJpqeW02CCKWE=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "392828aafbed62a6ea6ccab13728df2e67481805",
+        "rev": "f65c9d6efae4ee39f4341aaed073cf2d56fb0ecb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`f65c9d6e`](https://github.com/nix-community/nix-index-database/commit/f65c9d6efae4ee39f4341aaed073cf2d56fb0ecb) | `` update generated.nix to release 2024-08-25-025816 `` |
| [`fc681ad7`](https://github.com/nix-community/nix-index-database/commit/fc681ad740f0adee9777504accce70a78d3a49b2) | `` flake.lock: Update ``                                |