### PR TITLE
chore(flake/disko): `43573714` -> `b09eb605`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724349583,
-        "narHash": "sha256-zgB1Cfk46irIsto8666yLdKjqKdBrjR48Dd3lhQ0CnQ=",
+        "lastModified": 1724639687,
+        "narHash": "sha256-L2h46/z8WExNvtCEdZ8YuMu5TwfAGsKXXgM7pyIShvs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "435737144be0259559ca3b43f7d72252b1fdcc1b",
+        "rev": "b09eb605e376c9e95c87c0ef3fcb8008e11c8368",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`b09eb605`](https://github.com/nix-community/disko/commit/b09eb605e376c9e95c87c0ef3fcb8008e11c8368) | `` flake.lock: Update `` |