### PR TITLE
chore(flake/disko): `b09eb605` -> `b89a6112`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724639687,
-        "narHash": "sha256-L2h46/z8WExNvtCEdZ8YuMu5TwfAGsKXXgM7pyIShvs=",
+        "lastModified": 1724769572,
+        "narHash": "sha256-K+HQbC2/hnGngIB019mX6f4XUrf7dB1eBfiUHW4Vx48=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "b09eb605e376c9e95c87c0ef3fcb8008e11c8368",
+        "rev": "b89a61129f3976d6440e2356ac5d3e30930f7012",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                |
| ---------------------------------------------------------------------------------------------------- | ---------------------- |
| [`517664d2`](https://github.com/nix-community/disko/commit/517664d2fd762ea53f63fcf5f60e73dfd2a8566b) | `` Fix writeDashBin `` |