### PR TITLE
chore(flake/nixos-hardware): `c4e1b82a` -> `95c3dfe6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1724863014,
-        "narHash": "sha256-hRwyTHJaT8hCq4B6P17ppBQTbPZn0Gqc+fYEKWJpAb4=",
+        "lastModified": 1724878143,
+        "narHash": "sha256-UjpKo92iZ25M05kgSOw/Ti6VZwpgdlOa73zHj8OcaDk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "c4e1b82a91c7b1b4c74aa39c573ddbf31a49d3e9",
+        "rev": "95c3dfe6ef2e96ddc1ccdd7194e3cda02ca9a8ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------- |
| [`95c3dfe6`](https://github.com/NixOS/nixos-hardware/commit/95c3dfe6ef2e96ddc1ccdd7194e3cda02ca9a8ef) | `` Apple iMac 14,2: init `` |