### PR TITLE
chore(flake/flake-parts): `1e6fc322` -> `af510d4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -267,11 +267,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1725011404,
-        "narHash": "sha256-EBDxPawECn+UA3zCk2RqVmuvXcGBQadgl/INHhDshJA=",
+        "lastModified": 1725024810,
+        "narHash": "sha256-ODYRm8zHfLTH3soTFWE452ydPYz2iTvr9T8ftDMUQ3E=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "1e6fc322ada6d6c62f33b9cf0be850c3a97e31cd",
+        "rev": "af510d4a62d071ea13925ce41c95e3dec816c01d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                             |
| -------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`f112e301`](https://github.com/hercules-ci/flake-parts/commit/f112e301b33a8c0fbe7f65eac7a793e2dd8d3bf6) | `` Fix test ``                                      |
| [`1728089f`](https://github.com/hercules-ci/flake-parts/commit/1728089f3e8a28df678f60cc52cff4219ade477d) | `` flakeModules.partitions: Improve and fix docs `` |
| [`358ab837`](https://github.com/hercules-ci/flake-parts/commit/358ab8370e9726e60c16cb299c8138228fb0301e) | `` reference to Nix manual ``                       |
| [`309636f1`](https://github.com/hercules-ci/flake-parts/commit/309636f1b058eb305c974882967577225a3ee29a) | `` correct typo ``                                  |
| [`4a41226e`](https://github.com/hercules-ci/flake-parts/commit/4a41226e755f18ff9cd0d3914698c680ee0b804c) | `` apps: Add `meta` option ``                       |