### PR TITLE
chore(flake/lovesegfault-vim-config): `6d65ecb8` -> `0fc330c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724976219,
-        "narHash": "sha256-Kc3+ETD8QdTWiZV8bxcZGhqcBQqnpSeI3hPW768pciQ=",
+        "lastModified": 1725062604,
+        "narHash": "sha256-dD2yia0pXV+Yrvihe0rc5763aZIaZzOyyod3tMPzVLo=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "6d65ecb853dca2f7154eee8aabcef21ed10f8645",
+        "rev": "0fc330c2c9f51cec12ed00a3ee0d65eacbe6bb04",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724968633,
-        "narHash": "sha256-eb2NCdLwfXL1MuTAkoDncSl2lCJwyylV5/NM1Ws2P/U=",
+        "lastModified": 1725048799,
+        "narHash": "sha256-NaCb/odkjPjILD1XqXsr1Q7d0iIgf87m8ixGrowfC2A=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2704133fe3ca616b22ed6685cc67180456eb4160",
+        "rev": "56208f9e3f46f034353636fa651df8663ec57fa3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`0fc330c2`](https://github.com/lovesegfault/vim-config/commit/0fc330c2c9f51cec12ed00a3ee0d65eacbe6bb04) | `` chore(flake/nixvim): 2704133f -> 56208f9e ``      |
| [`b33e85d2`](https://github.com/lovesegfault/vim-config/commit/b33e85d2a2b5389beac5dc0c08b1f4b4c9365245) | `` chore(flake/flake-parts): 8471fe90 -> af510d4a `` |