### PR TITLE
chore(flake/darwin): `c8d3157d` -> `7c4b53a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724994893,
-        "narHash": "sha256-yutISDGg6HUaZqCaa54EcsfTwew3vhNtt/FNXBBo44g=",
+        "lastModified": 1725189302,
+        "narHash": "sha256-IhXok/kwQqtusPsoguQLCHA+h6gKvgdCrkhIaN+kByA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "c8d3157d1f768e382de5526bb38e74d2245cad04",
+        "rev": "7c4b53a7d9f3a3df902b3fddf2ae245ef20ebcda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                         |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`75d14c62`](https://github.com/LnL7/nix-darwin/commit/75d14c62cbc4360cbd1a1b5c52dbd17b8bd08892) | `` gpg: Suppress stderr from gpg-connect-agent on shell init `` |