### PR TITLE
chore(flake/nixpkgs): `71e91c40` -> `12228ff1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -577,11 +577,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724819573,
-        "narHash": "sha256-GnR7/ibgIH1vhoy8cYdmXE6iyZqKqFxQSVkFgosBh6w=",
+        "lastModified": 1725103162,
+        "narHash": "sha256-Ym04C5+qovuQDYL/rKWSR+WESseQBbNAe5DsXNx5trY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
+        "rev": "12228ff1752d7b7624a54e9c1af4b222b3c1073b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`0cd631e6`](https://github.com/NixOS/nixpkgs/commit/0cd631e61f7ec34287faea382a9311419c2ca869) | `` tests/ceph: bluestore, dmcrypt, and IPv6 test ``                            |
| [`234267e6`](https://github.com/NixOS/nixpkgs/commit/234267e6a1dc2976a41093c666eaa92a7b8529ee) | `` ceph: Fix missing patch for Ceph with dmcrypt. Fixes #334975 ``             |
| [`322c9f1a`](https://github.com/NixOS/nixpkgs/commit/322c9f1a9ed25e13a1c7bd8ed614f2626ad8a547) | `` remnote: 1.16.101 -> 1.16.107 ``                                            |
| [`20766c84`](https://github.com/NixOS/nixpkgs/commit/20766c84e8fc29f9a3dff0e3a8091a8097d4fcbe) | `` wlvncc: fix build, missing wayland-scanner ``                               |
| [`c3b36527`](https://github.com/NixOS/nixpkgs/commit/c3b3652708b3959cfad88140731d03a94b2b60ea) | `` wlinhibit: fix build, missing wayland-scanner ``                            |
| [`9d522cf3`](https://github.com/NixOS/nixpkgs/commit/9d522cf362a7521064b3011986668351f27b7abc) | `` wl-kbptr: fix build, missing wayland-scanner ``                             |
| [`2703ea95`](https://github.com/NixOS/nixpkgs/commit/2703ea9572298b0b82ef88c28997fecfe0738f11) | `` wdisplays: fix build, missing wayland-scanner ``                            |
| [`f89e8650`](https://github.com/NixOS/nixpkgs/commit/f89e86506de299749e3f3e01f3750767a64ebf5c) | `` inlyne: 0.4.2 -> 0.4.3 ``                                                   |
| [`8210335f`](https://github.com/NixOS/nixpkgs/commit/8210335ff89888c3e33306082448ca8f6b05470b) | `` waylogout: fix build, missing wayland-scanner ``                            |
| [`ee7e849d`](https://github.com/NixOS/nixpkgs/commit/ee7e849d1ddbcac0f74ab5a6fdf55b79f50a7cb2) | `` roon-tui: 0.3.0 -> 0.3.2 ``                                                 |
| [`4478f423`](https://github.com/NixOS/nixpkgs/commit/4478f423e35b72c4450f00f418b618c92fd48896) | `` rtz: 0.5.3 -> 0.7.0 ``                                                      |
| [`5ff7fdc3`](https://github.com/NixOS/nixpkgs/commit/5ff7fdc39e127abc165ca9bdaa0a976ace1f88cd) | `` wayfirePlugins.wayfire-plugins-extra: fix build, missing wayland-scanner `` |
| [`748085ac`](https://github.com/NixOS/nixpkgs/commit/748085ac87701ec5dda7fd3a70a12b3e215d37a4) | `` sway-audio-idle-inhibit: fix build, missing wayland-scanner ``              |
| [`1bb8eb49`](https://github.com/NixOS/nixpkgs/commit/1bb8eb491cf50a26f5e1e91c9318006ff13bce3a) | `` sunshine: fix build, missing wayland-scanner ``                             |
| [`3012a229`](https://github.com/NixOS/nixpkgs/commit/3012a229a158e568d3ccbb147ce9cc268f817d60) | `` sfwbar: fix build, missing wayland-scanner ``                               |
| [`7462b432`](https://github.com/NixOS/nixpkgs/commit/7462b432b03acdc0e182fcdc68146f1d1e62eea5) | `` rivercarro: fix build, missing wayland-scanner ``                           |
| [`70d3f0c4`](https://github.com/NixOS/nixpkgs/commit/70d3f0c4ec1a60e03e43de85b02acc5a50e2e36b) | `` hypridle: fix build, missing wayland-scanner ``                             |
| [`fc288b57`](https://github.com/NixOS/nixpkgs/commit/fc288b57b78a2e226a0d33a824a0a323b4afe8c8) | `` clipboard-jh: fix build, missing wayland-scanner ``                         |
| [`463a971a`](https://github.com/NixOS/nixpkgs/commit/463a971ae0cc7d19f6a1d9f6c37bbf06c0402024) | `` cemu: fix build, missing wayland-scanner ``                                 |
| [`02f6fcb0`](https://github.com/NixOS/nixpkgs/commit/02f6fcb0398d13a921ed10c629ab5d97f2cbabb1) | `` eslint: 9.7.0 -> 9.9.1 ``                                                   |
| [`fcbfdce5`](https://github.com/NixOS/nixpkgs/commit/fcbfdce5a80dacc7f0f17227663d1991d8dc1802) | `` licensedigger: init at 0-unstable-2024-08-28 ``                             |
| [`d4a72a39`](https://github.com/NixOS/nixpkgs/commit/d4a72a39355e0de7fed3317bec95b5a83f5192c9) | `` lib.platforms.mesaPlatforms: remove ``                                      |
| [`d23e512a`](https://github.com/NixOS/nixpkgs/commit/d23e512adb68c6cb2eb55c6a5beb6e3253e5c7dd) | `` keymapper: fix build, missing wayland-scanner ``                            |
| [`cdc00446`](https://github.com/NixOS/nixpkgs/commit/cdc00446f832303fb211c8c3e94a8b0f58a66966) | `` spectacle: fix build, missing wayland-scanner ``                            |
| [`aeab0704`](https://github.com/NixOS/nixpkgs/commit/aeab07042efaa8badae3f7b9b001a42234043fc7) | `` pantheon.wingpanel-quick-settings: fix build, missing wayland-scanner ``    |
| [`a6728cf8`](https://github.com/NixOS/nixpkgs/commit/a6728cf83697f0550bf4e9e4e439e80d6573c153) | `` gwenview: fix build, missing wayland-scanner ``                             |
| [`7c3fb2d6`](https://github.com/NixOS/nixpkgs/commit/7c3fb2d64b26fd345e1a95ad04c89c2f420a82ab) | `` deepin.dde-network-core: fix build, missing wayland-scanner ``              |
| [`fc295def`](https://github.com/NixOS/nixpkgs/commit/fc295defd853379ced321fd0b313d6717b0642d6) | `` valgrind.meta.homepage: update ``                                           |
| [`027642ab`](https://github.com/NixOS/nixpkgs/commit/027642ab3634e2bbca5368cd157b443574d217da) | `` python3Packages.dulwich: skip problematic tests ``                          |
| [`e7cfe326`](https://github.com/NixOS/nixpkgs/commit/e7cfe326990909e795ccf3d69a03bcd1d05be0b3) | `` troubadix: 24.8.0 -> 24.8.2 ``                                              |
| [`405f15cc`](https://github.com/NixOS/nixpkgs/commit/405f15ccaec147b6cc7d696f049ea24ec38ae8b6) | `` python312Packages.uv: 0.4.0 -> 0.4.1 ``                                     |
| [`d5d25ea6`](https://github.com/NixOS/nixpkgs/commit/d5d25ea6a22518819678d544b1a2ff5ee32f3f8c) | `` python312Packages.langgraph-cli: 0.1.51 -> 0.1.52 ``                        |
| [`b273dc0b`](https://github.com/NixOS/nixpkgs/commit/b273dc0b743444444bcef20fbc4221c021945096) | `` python312Packages.sisyphus-control: 3.1.3 -> 3.1.4 ``                       |
| [`5d562365`](https://github.com/NixOS/nixpkgs/commit/5d562365384c42ff05dbcef2afe29c289f4d654b) | `` python312Packages.mkdocstrings-python: 1.10.8 -> 1.10.9 ``                  |
| [`4b3d4715`](https://github.com/NixOS/nixpkgs/commit/4b3d47156c9af53a89e87d82b2b2f9b7cb7c19ee) | `` python312Packages.fastcore: 1.7.1 -> 1.7.2 ``                               |
| [`08299251`](https://github.com/NixOS/nixpkgs/commit/0829925167838adf8923d07d5bc7cf31d88c491d) | `` python312Packages.python-kasa: 0.7.1 -> 0.7.2 ``                            |
| [`34246768`](https://github.com/NixOS/nixpkgs/commit/34246768cf64063c3439dc0fc6a6dade84400b96) | `` picocrypt: 1.40 -> 1.41 ``                                                  |
| [`821f18bb`](https://github.com/NixOS/nixpkgs/commit/821f18bb2e90a41b7b7f7f5c8601490e7e47c196) | `` matrix-commander-rs: 0.3.0 -> 0.4.1 ``                                      |
| [`0d3eb9d2`](https://github.com/NixOS/nixpkgs/commit/0d3eb9d2ec594cc10d07b7acc8c3b88f278468fe) | `` python312Packages.ruff-api: fix changelog ``                                |
| [`5860c5d9`](https://github.com/NixOS/nixpkgs/commit/5860c5d9d9170f88ddaf3abcc4bcd79f477a8a4c) | `` werf: 2.10.4 -> 2.10.5 ``                                                   |
| [`0abfc619`](https://github.com/NixOS/nixpkgs/commit/0abfc619bcb605299a0f3f01c1887bb65db61a6b) | `` lib.importApply: init (#230588) ``                                          |
| [`558fc2db`](https://github.com/NixOS/nixpkgs/commit/558fc2db774e371da51ea04043b948e53244a15b) | `` nuv: remove breakpointHook from nativeBuildInputs ``                        |
| [`1b9af797`](https://github.com/NixOS/nixpkgs/commit/1b9af797ec106b0b812c842d3734a4f6ed821dc9) | `` breakpointHook: move to by-name, mark broken instead of asserting ``        |
| [`5f816eeb`](https://github.com/NixOS/nixpkgs/commit/5f816eeb7e54a46d88d0e596882db63fc45effbc) | `` nixos.tests.audiobookshelf: remove `with lib;` ``                           |
| [`dcb2e4eb`](https://github.com/NixOS/nixpkgs/commit/dcb2e4eba4d92af6d72eb3c22ccdb12d0ed8e9df) | `` nixos/services.xe-guest-utilities: remove `with lib;` ``                    |
| [`3e5d6ba7`](https://github.com/NixOS/nixpkgs/commit/3e5d6ba7df849c02ab4d6a64d5f2058c6e68fe66) | `` nixos/virtualisation.vmware.image: remove `with lib;` ``                    |
| [`cd197ceb`](https://github.com/NixOS/nixpkgs/commit/cd197cebdfd50a4f2089d2c6ba9e8c4ec02e8915) | `` nixos/system.autoUpgrade: remove `with lib;` ``                             |
| [`10e8c2ce`](https://github.com/NixOS/nixpkgs/commit/10e8c2cecdb9df0fcbd5ba3dec974d3e715ddd99) | `` nixos/environment.etc: remove `with lib;` ``                                |
| [`f3dd1a8b`](https://github.com/NixOS/nixpkgs/commit/f3dd1a8bd539340a074a1382cae20ffba6d54b9e) | `` nixos/services.logind: remove `with lib;` ``                                |
| [`69ca7aa5`](https://github.com/NixOS/nixpkgs/commit/69ca7aa56f75d2d5f81cc16e9e1f2fc248dc1c93) | `` nixos/services.journald: remove `with lib;` ``                              |
| [`97070a2e`](https://github.com/NixOS/nixpkgs/commit/97070a2ea620165d61a332377df722a954926773) | `` nixos/services.libreswan: remove `with lib;` ``                             |
| [`92f17f01`](https://github.com/NixOS/nixpkgs/commit/92f17f012debc9d6a01ef05afd3ad884790cd226) | `` nixos/services.kresd: remove `with lib;` ``                                 |
| [`59603727`](https://github.com/NixOS/nixpkgs/commit/59603727420f632e06af2314ae3381c7fb4cb75a) | `` nixos/services.kea: remove `with lib;` ``                                   |
| [`717fa0de`](https://github.com/NixOS/nixpkgs/commit/717fa0dea53c07c8f0ca81e3cc876739e24ab7e1) | `` nixos/services.dnscrypt-wrapper: remove `with lib;` ``                      |
| [`0846124d`](https://github.com/NixOS/nixpkgs/commit/0846124d8b7d92f75128c0d651b01004011e6bf6) | `` nixos/services.owncast: remove `with lib;` ``                               |
| [`20496ce3`](https://github.com/NixOS/nixpkgs/commit/20496ce388a69eed95627abd8eb37f3da57b53bc) | `` nixos/services.osrm: remove `with lib;` ``                                  |
| [`eddc7384`](https://github.com/NixOS/nixpkgs/commit/eddc7384dbe02a08b85c6651ad485aa430312f81) | `` nixos/services.ombi: remove `with lib;` ``                                  |
| [`d40cf96f`](https://github.com/NixOS/nixpkgs/commit/d40cf96f750d38568991d807e1b76480e2fecc92) | `` nixos/services.octoprint: remove `with lib;` ``                             |
| [`a99bf845`](https://github.com/NixOS/nixpkgs/commit/a99bf845302c6d2f28314dc25e8ceeeb3724ad2f) | `` nixos/services.nzbhydra2: remove `with lib;` ``                             |
| [`2da17447`](https://github.com/NixOS/nixpkgs/commit/2da17447da0de7f4d2f05d8635a59d82ecea539e) | `` nixos/services.nzbget: remove `with lib;` ``                                |
| [`457b7563`](https://github.com/NixOS/nixpkgs/commit/457b7563d4776f085d30faf2fa7b4e502d4a1d7f) | `` nixos/services.ntfy-sh: remove `with lib;` ``                               |
| [`eeed115e`](https://github.com/NixOS/nixpkgs/commit/eeed115e37941d9e21adba217c125a3c8d8d41b0) | `` nixos/services.novacomd: remove `with lib;` ``                              |
| [`b48bee99`](https://github.com/NixOS/nixpkgs/commit/b48bee9985f8d39e690a2d6fbfec0d03947ab9a0) | `` nixos/nix.sshServe: remove `with lib;` ``                                   |
| [`42bdc30f`](https://github.com/NixOS/nixpkgs/commit/42bdc30f19a40cf41fba5ad4a6711a28e5cfd062) | `` nixos/services.n8n: remove `with lib;` ``                                   |
| [`e00ab210`](https://github.com/NixOS/nixpkgs/commit/e00ab2106aca2fd4bdb0524f969cf46fb6622ccb) | `` nixos/services.moonraker: remove `with lib;` ``                             |
| [`a4db992d`](https://github.com/NixOS/nixpkgs/commit/a4db992d510782ec5620e181354989297f1a94c0) | `` nixos/services.mbpfan: remove `with lib;` ``                                |
| [`68fd6937`](https://github.com/NixOS/nixpkgs/commit/68fd69371f99990060c27096e285857345f516d3) | `` nixos/services.mame: remove `with lib;` ``                                  |
| [`a11ac85d`](https://github.com/NixOS/nixpkgs/commit/a11ac85d651cc2a6fca2937731eadd219facd61d) | `` nixos/services.logkeys: remove `with lib;` ``                               |
| [`25e0bc25`](https://github.com/NixOS/nixpkgs/commit/25e0bc25f6d49c3fe90b707688d572dc0eeb87c9) | `` nixos/services.lifecycled: remove `with lib;` ``                            |
| [`d5624921`](https://github.com/NixOS/nixpkgs/commit/d562492115ae547ce54e7ec0f1222f5e1fc0dfa9) | `` nixos/services.lidarr: remove `with lib;` ``                                |
| [`4e1b387f`](https://github.com/NixOS/nixpkgs/commit/4e1b387f248f60ee43c0806f962b36027744b71f) | `` nixos/services.leaps: remove `with lib;` ``                                 |
| [`118d8962`](https://github.com/NixOS/nixpkgs/commit/118d8962d3bf6f2ca44f855a840df4629828d527) | `` nixos/services.languagetool: remove `with lib;` ``                          |
| [`14f18ffb`](https://github.com/NixOS/nixpkgs/commit/14f18ffb06b7bfcdd6b10d508540c851d4e26a49) | `` nixos/services.klipper: remove `with lib;` ``                               |
| [`cac7b5e2`](https://github.com/NixOS/nixpkgs/commit/cac7b5e2666d4ad88d6ebd4fdbb62859ed44522b) | `` nixos/services.jellyseerr: remove `with lib;` ``                            |
| [`2fbd3330`](https://github.com/NixOS/nixpkgs/commit/2fbd3330750d052b9a8643e4e3567bd5c1e79bee) | `` nixos/services.jackett: remove `with lib;` ``                               |
| [`a442c73b`](https://github.com/NixOS/nixpkgs/commit/a442c73bff962d2468f79d14324eb581e19cd26e) | `` nixos/services.irkerd: remove `with lib;` ``                                |
| [`bd471d7e`](https://github.com/NixOS/nixpkgs/commit/bd471d7eb10eee6adc99b499b49487afd1172cdc) | `` nixos/services.input-remapper: remove `with lib;` ``                        |
| [`70653368`](https://github.com/NixOS/nixpkgs/commit/7065336804b66b5318c8e8721c08a5066fe25274) | `` nixos/services.ihaskell: remove `with lib;` ``                              |
| [`22708739`](https://github.com/NixOS/nixpkgs/commit/2270873952fc07ebc24532634e79600248120f86) | `` nixos/services.heisenbridge: remove `with lib;` ``                          |
| [`0205ba83`](https://github.com/NixOS/nixpkgs/commit/0205ba83ab946e6d10d79106d9adf4b3305d4cca) | `` nixos/services.headphones: remove `with lib;` ``                            |
| [`a40bb432`](https://github.com/NixOS/nixpkgs/commit/a40bb4329ae7a17b1682ffceabed4829a5af8859) | `` nixos/services.greenclip: remove `with lib;` ``                             |
| [`01533f55`](https://github.com/NixOS/nixpkgs/commit/01533f55c4ea50e7087c54972cb631b7469c20bc) | `` nixos/services.gpsd: remove `with lib;` ``                                  |
| [`22d14ed8`](https://github.com/NixOS/nixpkgs/commit/22d14ed8a2e51684d4bb3c17295adabfa705691d) | `` nixos/services.gollum: remove `with lib;` ``                                |
| [`9358cb9b`](https://github.com/NixOS/nixpkgs/commit/9358cb9b7df2652139093d3dd4accb2981642807) | `` nixos/services.gitweb: remove `with lib;` ``                                |
| [`301dbd7f`](https://github.com/NixOS/nixpkgs/commit/301dbd7fdf0ee5a16a619510ded9dd160b1869e4) | `` nixos/services.fstrim: remove `with lib;` ``                                |
| [`1c84189d`](https://github.com/NixOS/nixpkgs/commit/1c84189d821daf6c296bbeec242074f8837e721a) | `` nixos/services.freeswitch: remove `with lib;` ``                            |
| [`df4cacf2`](https://github.com/NixOS/nixpkgs/commit/df4cacf2623cb1487e6f60b4a360fbaed9562ddb) | `` nixos/services.felix: remove `with lib;` ``                                 |
| [`9d570bce`](https://github.com/NixOS/nixpkgs/commit/9d570bce41f1f3344beecf94925df19c59d71ce9) | `` nixos/services.evdevremapkeys: remove `with lib;` ``                        |
| [`4233be95`](https://github.com/NixOS/nixpkgs/commit/4233be955da89cbcb18c24a3cdb5909e37a9c5d2) | `` nixos/services.etesync-dav: remove `with lib;` ``                           |
| [`ea8485f6`](https://github.com/NixOS/nixpkgs/commit/ea8485f6c92a4bfbeb037880e878e805396d9c41) | `` nixos/services.etebase-server: remove `with lib;` ``                        |
| [`0971178e`](https://github.com/NixOS/nixpkgs/commit/0971178e732e705183aba448201f774cda5ace21) | `` nixos/services.errbot: remove `with lib;` ``                                |
| [`57c0e188`](https://github.com/NixOS/nixpkgs/commit/57c0e18882ad3b7e11ea040ba9b73227f5721aca) | `` nixos/services.dysnomia: remove `with lib;` ``                              |
| [`0d85377a`](https://github.com/NixOS/nixpkgs/commit/0d85377af79ad64ff30e51f2f91c606a1aea2ac0) | `` marcel: 0.29.0 -> 0.30.1 ``                                                 |
| [`078a6f8d`](https://github.com/NixOS/nixpkgs/commit/078a6f8d496f9fcf40ea57a998f5ee4e388b306a) | `` nixos/services.dwm-status: remove `with lib;` ``                            |
| [`df640cd6`](https://github.com/NixOS/nixpkgs/commit/df640cd6add5ab85bad9846d45f2d13baf4485cf) | `` nixos/services.duckling: remove `with lib;` ``                              |
| [`393ce48b`](https://github.com/NixOS/nixpkgs/commit/393ce48b207c3a9ae4f31ff7c5eca732a3e1c3b1) | `` nixos/services.domoticz: remove `with lib;` ``                              |
| [`3b6190d1`](https://github.com/NixOS/nixpkgs/commit/3b6190d10dc2dc038378566ec1f064e47b269d08) | `` nixos/services.docker-registry: remove `with lib;` ``                       |
| [`7a6ef913`](https://github.com/NixOS/nixpkgs/commit/7a6ef913b71e54bdf79d497dfe5c952632775fb5) | `` nixos/services.disnix: remove `with lib;` ``                                |
| [`8b9a5020`](https://github.com/NixOS/nixpkgs/commit/8b9a5020db5857ea0f4c8b3f711e502bd24b2015) | `` nixos/services.dictd: remove `with lib;` ``                                 |
| [`c4c90f5f`](https://github.com/NixOS/nixpkgs/commit/c4c90f5fbe628926c8f917e74a787d7b8da06294) | `` nixos/services.devpi-server: remove `with lib;` ``                          |
| [`94b5a134`](https://github.com/NixOS/nixpkgs/commit/94b5a13466dfe7a2f0c7237f5314b6d647a31b05) | `` nixos/services.devmon: remove `with lib;` ``                                |
| [`ea5f93bf`](https://github.com/NixOS/nixpkgs/commit/ea5f93bf138e59e949fb6cae3d7eddc7a912e81d) | `` nixos/services.cpuminer-cryptonight: remove `with lib;` ``                  |
| [`f57be92d`](https://github.com/NixOS/nixpkgs/commit/f57be92dcbf0c5c5ffe9a905e0c978b659feda51) | `` nixos/services.confd: remove `with lib;` ``                                 |
| [`4948e0be`](https://github.com/NixOS/nixpkgs/commit/4948e0be37361354c164f744b661c7208e95d09a) | `` nixos/services.clipmenu: remove `with lib;` ``                              |
| [`1315c69d`](https://github.com/NixOS/nixpkgs/commit/1315c69dfe7d22a5566e77e111f1ba3f8b9f473c) | `` nixos/services.clipcat: remove `with lib;` ``                               |
| [`c3ef67ff`](https://github.com/NixOS/nixpkgs/commit/c3ef67ff5b1cd58b5a17f71353d3b30712f0c196) | `` nixos/services.cgminer: remove `with lib;` ``                               |
| [`9c487f98`](https://github.com/NixOS/nixpkgs/commit/9c487f98b96f004d7812be55c3b3ad9af5639e1c) | `` nixos/services.cfdyndns: remove `with lib;` ``                              |
| [`3c2fff40`](https://github.com/NixOS/nixpkgs/commit/3c2fff40ba7123eda37ed64d65a1b70179dab06c) | `` nixos/services.canto-daemon: remove `with lib;` ``                          |
| [`5e8ed975`](https://github.com/NixOS/nixpkgs/commit/5e8ed975efe26ea5273cbf2341d64ae98522a715) | `` nixos/services.calibre-server: remove `with lib;` ``                        |
| [`02617d5a`](https://github.com/NixOS/nixpkgs/commit/02617d5a2a0512d47c7d742f4fe58bafe272daca) | `` nixos/services.bepasty: remove `with lib;` ``                               |
| [`a2e269bc`](https://github.com/NixOS/nixpkgs/commit/a2e269bc377a1c24fbadf86eebc9b079d9029dc9) | `` nixos/services.bees: remove `with lib;` ``                                  |
| [`5a7fba40`](https://github.com/NixOS/nixpkgs/commit/5a7fba4027db28d4010b7b78d2a58f875b4a74ed) | `` nixos/services.beanstalkd: remove `with lib;` ``                            |
| [`11c69dd9`](https://github.com/NixOS/nixpkgs/commit/11c69dd99f6350b9cd67b193ee0b5a15b3de7439) | `` nixos/services.bcg: remove `with lib;` ``                                   |
| [`b8142ce7`](https://github.com/NixOS/nixpkgs/commit/b8142ce7cafe5eca9c0a4fd2c07457c4a1d4f9f1) | `` nixos/services.bazarr: remove `with lib;` ``                                |
| [`686be24d`](https://github.com/NixOS/nixpkgs/commit/686be24d1b45a5937e30362b4970e062204621d2) | `` nixos/services.autofs: remove `with lib;` ``                                |
| [`62e16752`](https://github.com/NixOS/nixpkgs/commit/62e1675246f51da517e076da7272ded3fe4bea2d) | `` nixos/services.apache-kafka: remove `with lib;` ``                          |
| [`febc5406`](https://github.com/NixOS/nixpkgs/commit/febc5406d80a265e2222530749781e0ea5b0746b) | `` nixos/services.ankisyncd: remove `with lib;` ``                             |
| [`542c6282`](https://github.com/NixOS/nixpkgs/commit/542c6282040ee348505675603656bc9ab0d1877b) | `` nixos/services.amazon-ssm-agent: remove `with lib;` ``                      |
| [`774f8cd0`](https://github.com/NixOS/nixpkgs/commit/774f8cd090f99371c8972ec051d442d64dde5b22) | `` nixos/services.airsonic: remove `with lib;` ``                              |
| [`0a78cd4f`](https://github.com/NixOS/nixpkgs/commit/0a78cd4f73b9dee641bb5b538231cdef547297ac) | `` nixos/services.pantalaimon-headless: remove `with lib;` ``                  |
| [`ec70164f`](https://github.com/NixOS/nixpkgs/commit/ec70164f244b00ac2d110aa513e128675953020f) | `` nixos/services.mx-puppet-discord: remove `with lib;` ``                     |
| [`0f517df9`](https://github.com/NixOS/nixpkgs/commit/0f517df99cb0432e835bb614e6eba2d629f83546) | `` nixos/services.mjolnir: remove `with lib;` ``                               |
| [`167cad74`](https://github.com/NixOS/nixpkgs/commit/167cad7457de8c6134822ba7c28421c72f7c81a2) | `` nixos/services.mautrix-telegram: remove `with lib;` ``                      |
| [`3bc24ab5`](https://github.com/NixOS/nixpkgs/commit/3bc24ab5d9d03f46e9db05b1d4079b2002904f9a) | `` nixos/services.mautrix-facebook: remove `with lib;` ``                      |
| [`24edb420`](https://github.com/NixOS/nixpkgs/commit/24edb420661deaac2545a5462dba84a33299bfd0) | `` nixos/services.matrix-conduit: remove `with lib;` ``                        |
| [`ca941e19`](https://github.com/NixOS/nixpkgs/commit/ca941e19f3e25f2f4ed2f92d1297792b9267143e) | `` nixos/services.matrix-appservice-irc: remove `with lib;` ``                 |
| [`0db184a1`](https://github.com/NixOS/nixpkgs/commit/0db184a1321a74fe289bc3d83e57fc43db726d5d) | `` nixos/services.matrix-appservice-discord: remove `with lib;` ``             |
| [`5b2cfbc9`](https://github.com/NixOS/nixpkgs/commit/5b2cfbc9690b63cad900edbdac67b4c745823a91) | `` nixos/services.zeyple: remove `with lib;` ``                                |
| [`6d0e4310`](https://github.com/NixOS/nixpkgs/commit/6d0e431080edec9ceb054473e7bd2f4159e1bf20) | `` nixos/services.stalwart-mail: remove `with lib;` ``                         |
| [`3d0cdfa3`](https://github.com/NixOS/nixpkgs/commit/3d0cdfa3c5757e6b0245b5ec40dffa850b4047c0) | `` nixos/services.spamassassin: remove `with lib;` ``                          |
| [`bd621731`](https://github.com/NixOS/nixpkgs/commit/bd621731060762666f8549e294abdb5a5b3a00fc) | `` nixos/services.roundcube: remove `with lib;` ``                             |
| [`47626f0f`](https://github.com/NixOS/nixpkgs/commit/47626f0fc84dc0e45d1b19fee5424a4dd703b673) | `` nixos/services.postsrsd: remove `with lib;` ``                              |
| [`dae6c6c5`](https://github.com/NixOS/nixpkgs/commit/dae6c6c58abba3ef8451e04d5eda785d122b8ff0) | `` nixos/services.postfixadmin: remove `with lib;` ``                          |
| [`8491fdcc`](https://github.com/NixOS/nixpkgs/commit/8491fdcc316d7fb9d9cd40b716639cf637e4ca51) | `` nixos/services.pfix-srsd: remove `with lib;` ``                             |
| [`1fbae04b`](https://github.com/NixOS/nixpkgs/commit/1fbae04bffe1a2e6ac7d841da6df7e404a5694f6) | `` nixos/services.opensmtpd: remove `with lib;` ``                             |
| [`eb261c5c`](https://github.com/NixOS/nixpkgs/commit/eb261c5c912befa78ef33ab0b2222b1591039af8) | `` nixos/services.opendkim: remove `with lib;` ``                              |
| [`02299617`](https://github.com/NixOS/nixpkgs/commit/02299617cdabfe2bf6b88cbc610969125c6f9f3f) | `` nixos/services.offlineimap: remove `with lib;` ``                           |
| [`e75cd5f9`](https://github.com/NixOS/nixpkgs/commit/e75cd5f98a35822a2bf714140ad9a738ba3d7ecd) | `` nixos/services.nullmailer: remove `with lib;` ``                            |
| [`2f79bd3b`](https://github.com/NixOS/nixpkgs/commit/2f79bd3b5caed0a958a019592e5029f7cc70875a) | `` nixos/services.mlmmj: remove `with lib;` ``                                 |
| [`0d8ce0d4`](https://github.com/NixOS/nixpkgs/commit/0d8ce0d47c98672a5783fb5cf5dc2c716147db8c) | `` nixos/services.mailhog: remove `with lib;` ``                               |
| [`b75b8780`](https://github.com/NixOS/nixpkgs/commit/b75b87803a65f1ba33e36c5299198fdb140edea0) | `` nixos/services.mail: remove `with lib;` ``                                  |
| [`aa0f1479`](https://github.com/NixOS/nixpkgs/commit/aa0f147937c832b1c81bb25c4eaa1cc0c75fd102) | `` nixos/services.maddy: remove `with lib;` ``                                 |
| [`3c36a6c4`](https://github.com/NixOS/nixpkgs/commit/3c36a6c44e0d80c0c07ea64cebfa8db30b6e0d32) | `` nixos/services.listmonk: remove `with lib;` ``                              |
| [`fb9694eb`](https://github.com/NixOS/nixpkgs/commit/fb9694eb65d39a4e60a6b2bdcb06d130a0391c85) | `` nixos/services.goeland: remove `with lib;` ``                               |
| [`c5f14998`](https://github.com/NixOS/nixpkgs/commit/c5f149982e8e17681a856a84864dd191c5bf4f22) | `` nixos/services.dspam: remove `with lib;` ``                                 |
| [`15d06237`](https://github.com/NixOS/nixpkgs/commit/15d06237b7bd28614f50fd6326c4f88ae8f08c72) | `` nixos/services.dkimproxy-out: remove `with lib;` ``                         |
| [`aa62d49b`](https://github.com/NixOS/nixpkgs/commit/aa62d49bd70058f862b0d8b614597400badc7e91) | `` nixos/services.davmail: remove `with lib;` ``                               |
| [`68dee151`](https://github.com/NixOS/nixpkgs/commit/68dee151ef64cd072f3167e60ad7119b8f3d038a) | `` nixos/services.clamsmtp: remove `with lib;` ``                              |
| [`2c2cb598`](https://github.com/NixOS/nixpkgs/commit/2c2cb598fe4e59edc310962517437cafe74d0896) | `` nixos/i18n.inputMethod.fcitx5: remove `with lib;` ``                        |
| [`76dd427c`](https://github.com/NixOS/nixpkgs/commit/76dd427ca99f0f53aa5b3af8b151f372ae96f1d1) | `` nixos/i18n.input-method: remove `with lib;` ``                              |
| [`0db2200f`](https://github.com/NixOS/nixpkgs/commit/0db2200f7e0569917e3f6b67c9a8a6d6805c717e) | `` nixos/hardware.xpadneo: remove `with lib;` ``                               |
| [`17fb9386`](https://github.com/NixOS/nixpkgs/commit/17fb9386add011250338c6f04e1d44abc8ee134f) | `` nixos/hardware.xone: remove `with lib;` ``                                  |
| [`d0bcf277`](https://github.com/NixOS/nixpkgs/commit/d0bcf277bf445c4c49af74f3f0eb34cde93bd5ac) | `` nixos/hardware.wooting: remove `with lib;` ``                               |
| [`bbe907f0`](https://github.com/NixOS/nixpkgs/commit/bbe907f0a9632e0a814ef41e30890286d3f68fab) | `` nixos/hardware.facetimehd: remove `with lib;` ``                            |
| [`4fa8726a`](https://github.com/NixOS/nixpkgs/commit/4fa8726a447f1925d9eb27ee553ce84560fce605) | `` nixos/hardware.uvcvideo: remove `with lib;` ``                              |
| [`500d530c`](https://github.com/NixOS/nixpkgs/commit/500d530cf84a6f9931d6d8410603a835b310feeb) | `` nixos/hardware.displaylink: remove `with lib;` ``                           |
| [`8470a581`](https://github.com/NixOS/nixpkgs/commit/8470a58158c1d9229b179bf42c6faa275d0b9b6a) | `` nixos/hardware.mwProCapture: remove `with lib;` ``                          |
| [`97d41bd9`](https://github.com/NixOS/nixpkgs/commit/97d41bd9af02f6ba950a844118a620208cef8605) | `` nixos/hardware.bumblebee: remove `with lib;` ``                             |
| [`09c8cfdd`](https://github.com/NixOS/nixpkgs/commit/09c8cfddd2392c95aa711439c660302eeda88086) | `` nixos/hardware.usb-storage: remove `with lib;` ``                           |
| [`1f149110`](https://github.com/NixOS/nixpkgs/commit/1f149110c4da322f3a18ba9464bac38803e05a94) | `` nixos/hardware.usb-modeswitch: remove `with lib;` ``                        |
| [`8f002345`](https://github.com/NixOS/nixpkgs/commit/8f0023457d46f4a243a3e909dc6635672084a50c) | `` nixos/hardware.ubertooth: remove `with lib;` ``                             |
| [`8623af5c`](https://github.com/NixOS/nixpkgs/commit/8623af5c38447608d5dc751e9e2ea45838e9fca1) | `` nixos/hardware.tuxedo-keyboard: remove `with lib;` ``                       |
| [`12a3b2f7`](https://github.com/NixOS/nixpkgs/commit/12a3b2f7af0c70202cc4b4ae3759428f16e5fba7) | `` nixos/hardware.steam-hardware: remove `with lib;` ``                        |
| [`024f4f89`](https://github.com/NixOS/nixpkgs/commit/024f4f89ae3ec096f2edbc5086f3cf6f31db1e11) | `` nixos/hardware.sensor.iio: remove `with lib;` ``                            |
| [`4d2a1391`](https://github.com/NixOS/nixpkgs/commit/4d2a1391deb76b9f87ab3d65d0672017f427efc3) | `` nixos/hpsa: remove `with lib;` ``                                           |
| [`22946376`](https://github.com/NixOS/nixpkgs/commit/22946376a95cbd78a8444e35e83402b07121821e) | `` nixos/hardware.printers: remove `with lib;` ``                              |
| [`ea6befd7`](https://github.com/NixOS/nixpkgs/commit/ea6befd73fa5a59ad533a812a0e90884f1d12f31) | `` nixos/hardware.pcmcia: remove `with lib;` ``                                |
| [`76c3bcd9`](https://github.com/NixOS/nixpkgs/commit/76c3bcd9e3c5f206498f98b1f6473c7d94bb661c) | `` nixos/hardware.opentabletdriver: remove `with lib;` ``                      |
| [`78026aca`](https://github.com/NixOS/nixpkgs/commit/78026acac23ba9a6ea8d94d81c3b971614dc2b81) | `` nixos/hardware.openrazer: remove `with lib;` ``                             |
| [`ef54fd07`](https://github.com/NixOS/nixpkgs/commit/ef54fd072b17798616179f11afc6cb49794945c7) | `` nixos/hardware.onlykey: remove `with lib;` ``                               |
| [`b9bdcccb`](https://github.com/NixOS/nixpkgs/commit/b9bdcccba7e05becd28ca553c60d0e57cd66ee58) | `` nixos/hardware.nitrokey: remove `with lib;` ``                              |
| [`cf7feaca`](https://github.com/NixOS/nixpkgs/commit/cf7feaca4795891a5a309f503b40e7a7da8af206) | `` nixos/hardware.new-lg4ff: remove `with lib;` ``                             |
| [`f31bf6ed`](https://github.com/NixOS/nixpkgs/commit/f31bf6ed293db39c2c8684f647cef917d0956208) | `` nixos/networking.enableB43Firmware: remove `with lib;` ``                   |
| [`e1e8351a`](https://github.com/NixOS/nixpkgs/commit/e1e8351aaa273518f7dedb450cc5b122369669fc) | `` nixos/networking.wireless.athUserRegulatoryDomain: remove `with lib;` ``    |
| [`21ed5697`](https://github.com/NixOS/nixpkgs/commit/21ed56970ef07d1a41e32cbed03f6d04fda14896) | `` nixos/hardware.mcelog: remove `with lib;` ``                                |
| [`94dbe54a`](https://github.com/NixOS/nixpkgs/commit/94dbe54a8d82fb099240fc6fa65c59faa3d91a3e) | `` nixos/hardware.logitech: remove `with lib;` ``                              |
| [`3036edd1`](https://github.com/NixOS/nixpkgs/commit/3036edd1c1d1604c2f218674416b2cd459532c23) | `` nixos/hardware.ledger: remove `with lib;` ``                                |
| [`55f4ce28`](https://github.com/NixOS/nixpkgs/commit/55f4ce28c889bfb03673a792db151f1f48adebbc) | `` nixos/hardware.ksm: remove `with lib;` ``                                   |
| [`d485dfec`](https://github.com/NixOS/nixpkgs/commit/d485dfece4c03f590d4856261df2105f62591e33) | `` nixos/hardware.digitalbitbox: remove `with lib;` ``                         |
| [`5a78f2c7`](https://github.com/NixOS/nixpkgs/commit/5a78f2c7729b6d6be966af22a02ecfc0742e86f1) | `` nixos/intel-sgx: remove `with lib;` ``                                      |
| [`9a213a3a`](https://github.com/NixOS/nixpkgs/commit/9a213a3a5b94d74793c7dffe4a7221d511c9d1a7) | `` nixos/intel-microcode: remove `with lib;` ``                                |
| [`921bb919`](https://github.com/NixOS/nixpkgs/commit/921bb919d8921a7f018201d20742008cd122bd0c) | `` nixos/amd.sev: remove `with lib;` ``                                        |
| [`4d249865`](https://github.com/NixOS/nixpkgs/commit/4d249865789407d17c50e5b6b3d0b63673aa82a8) | `` nixos/amd-microcode: remove `with lib;` ``                                  |
| [`6db0587b`](https://github.com/NixOS/nixpkgs/commit/6db0587bdb4cc5fb2e3d1a27042c3a9e612f489d) | `` nixos/sysctl: remove `with lib;` ``                                         |
| [`3ff6eebd`](https://github.com/NixOS/nixpkgs/commit/3ff6eebd21dfd22ba06dc783f5bd809d23662750) | `` nixos/shells-environment: remove `with lib;` ``                             |
| [`0657aa55`](https://github.com/NixOS/nixpkgs/commit/0657aa5509d0fc5ca79c9e2bf0621f7cc1623694) | `` nixos/i18n: remove `with lib;` ``                                           |
| [`b4bade47`](https://github.com/NixOS/nixpkgs/commit/b4bade477f4ff049caae5adcfcfe50eff30c8b87) | `` consul: 1.19.1 -> 1.19.2 ``                                                 |