### PR TITLE
chore(flake/flake-parts): `af510d4a` -> `567b938d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -267,11 +267,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1725024810,
-        "narHash": "sha256-ODYRm8zHfLTH3soTFWE452ydPYz2iTvr9T8ftDMUQ3E=",
+        "lastModified": 1725234343,
+        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "af510d4a62d071ea13925ce41c95e3dec816c01d",
+        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
         "type": "github"
       },
       "original": {
@@ -593,14 +593,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1722555339,
-        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
+        "lastModified": 1725233747,
+        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       }
     },
     "nixpkgs-stable": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                  |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`555010eb`](https://github.com/hercules-ci/flake-parts/commit/555010eb1a80b18ed63df534ce0efa8d0874601e) | `` dev/flake.lock: Update ``             |
| [`fb8a5210`](https://github.com/hercules-ci/flake-parts/commit/fb8a5210dd5aa6b6ef188b8efb9ac8e70cfd9c4d) | `` flake.lock: Update ``                 |
| [`a7b916ca`](https://github.com/hercules-ci/flake-parts/commit/a7b916caf630ea6124017f5045d9e694b2144e5b) | `` flake.nix: Update nixpkgs-lib tree `` |