### PR TITLE
chore(flake/lovesegfault-vim-config): `8962b84c` -> `a3f57937`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725149019,
-        "narHash": "sha256-6XQ4ykE3/p1O85W+COJCsqS2yHLT/1DgJd7JtccT+vo=",
+        "lastModified": 1725235430,
+        "narHash": "sha256-hveXQoJ7NnztUxkGDZ1hC6UZCtNuVGsUbqonN6ayI+o=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "8962b84c3b1d4bef743ff9bf79204529ad80f772",
+        "rev": "a3f57937438b766945b3c973355f166134a98af5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`a3f57937`](https://github.com/lovesegfault/vim-config/commit/a3f57937438b766945b3c973355f166134a98af5) | `` chore(flake/nixpkgs): 71e91c40 -> 12228ff1 ``     |
| [`6abc9f5d`](https://github.com/lovesegfault/vim-config/commit/6abc9f5dfc8394d1de46e9541f463866c5bdf2e9) | `` chore(flake/flake-parts): af510d4a -> 567b938d `` |