### PR TITLE
chore(flake/treefmt-nix): `3ffd842a` -> `23c2b0d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -793,11 +793,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724833132,
-        "narHash": "sha256-F4djBvyNRAXGusJiNYInqR6zIMI3rvlp6WiKwsRISos=",
+        "lastModified": 1725271338,
+        "narHash": "sha256-FuP8Im+wj4xxaUp1bffhgvJvXtUT6TapkMfRcjaIAK4=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3ffd842a5f50f435d3e603312eefa4790db46af5",
+        "rev": "23c2b0d953710939487ec878d70495d73b2c9bb3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                         |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`14b9565b`](https://github.com/numtide/treefmt-nix/commit/14b9565b02f77e3c1c89293a05e703942d62fbde) | `` mypy: fix python path not beeing set ``                      |
| [`966dfb4a`](https://github.com/numtide/treefmt-nix/commit/966dfb4afff31af74f5a7a9a34d80f869fb3b4af) | `` mypy: don't set any PYTHONPATH if we don't have a package `` |
| [`c8a2bda8`](https://github.com/numtide/treefmt-nix/commit/c8a2bda80cd465167f4ccc021d91877a84205fe4) | `` mypy: fix include when no module is specified ``             |