### PR TITLE
chore(flake/disko): `96073e64` -> `85538a44`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725242307,
-        "narHash": "sha256-a2iTMBngegEZvaNAzzxq5Gc5Vp3UWoGUqWtK11Txbic=",
+        "lastModified": 1725371818,
+        "narHash": "sha256-wexhGBRNkcBCnKDk2XWWHoo1TZFnd7iTFefr6TN5HaU=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "96073e6423623d4a8027e9739d2af86d6422ea7a",
+        "rev": "85538a44dede26cdf0359dd6e4656594cb3e7880",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                      |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`70a22d25`](https://github.com/nix-community/disko/commit/70a22d25a2695caca52379aa94c514941fe687c3) | `` Switch to qcow2 in the interactive VM. `` |