### PR TITLE
chore(flake/disko): `85538a44` -> `099b6cca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725371818,
-        "narHash": "sha256-wexhGBRNkcBCnKDk2XWWHoo1TZFnd7iTFefr6TN5HaU=",
+        "lastModified": 1725372374,
+        "narHash": "sha256-IrCekIHo376AE2mFYBd0+xqmhMIe4G7It1yedCKlWU4=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "85538a44dede26cdf0359dd6e4656594cb3e7880",
+        "rev": "099b6cca33cd283ca6b2aafe6ce96154f1b2300c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                 |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`099b6cca`](https://github.com/nix-community/disko/commit/099b6cca33cd283ca6b2aafe6ce96154f1b2300c) | `` btrfs: add swap priority, options `` |
| [`39b40917`](https://github.com/nix-community/disko/commit/39b4091769fd4c7974c6866e9c8448da92e45ccf) | `` swap: add mountOptions ``            |