### PR TITLE
chore(flake/disko): `099b6cca` -> `e55f9a86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725372374,
-        "narHash": "sha256-IrCekIHo376AE2mFYBd0+xqmhMIe4G7It1yedCKlWU4=",
+        "lastModified": 1725377834,
+        "narHash": "sha256-tqoAO8oT6zEUDXte98cvA1saU9+1dLJQe3pMKLXv8ps=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "099b6cca33cd283ca6b2aafe6ce96154f1b2300c",
+        "rev": "e55f9a8678adc02024a4877c2a403e3f6daf24fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                            |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`8f0f75f1`](https://github.com/nix-community/disko/commit/8f0f75f1a8a6764d52be25d2d2e89866b25502b4) | `` zpool: better error message if zpool has no assigned devices `` |
| [`736c8150`](https://github.com/nix-community/disko/commit/736c8150b93f413ff976b80e3e4d7970f408a4f3) | `` disk-deactivate: also clear zpool labels ``                     |
| [`c789d113`](https://github.com/nix-community/disko/commit/c789d113c623e2d162fbb19a87c29ba4518396c6) | `` disk-deactivate: only run zfs command if they are present ``    |
| [`cf5d451a`](https://github.com/nix-community/disko/commit/cf5d451adc87720753f5a85caac2c81e83550110) | `` test: Add cache specific test ``                                |
| [`071306e7`](https://github.com/nix-community/disko/commit/071306e76a7d1a05d0ffa4251a466c3d300e268d) | `` tidy: apply suggestions from code review ``                     |
| [`c9d3bc37`](https://github.com/nix-community/disko/commit/c9d3bc37553140444ad51df29a231aece29f97ea) | `` fix: properly apply oneOf ``                                    |
| [`ea3ce722`](https://github.com/nix-community/disko/commit/ea3ce722ea9bd569cee40d797f115f1e7489cc8b) | `` zfs: fix test and add documentation ``                          |
| [`cc2e2471`](https://github.com/nix-community/disko/commit/cc2e247193513a378fe0457374d4de7823aede1f) | `` zfs: make topology a mode type ``                               |
| [`540cd416`](https://github.com/nix-community/disko/commit/540cd416f689b2eaf482752bec1f0c0417b37537) | `` zfs: add ability to specify full path of to the disk. ``        |
| [`8d071db0`](https://github.com/nix-community/disko/commit/8d071db09b1cc5f4a31940a53bd287f63e915052) | `` test: fix and add stub test for zfs-with-vdevs ``               |
| [`f4843890`](https://github.com/nix-community/disko/commit/f484389085ea1ebd697516510d944dec55515288) | `` example: barebones example of zfs-with-vdevs ``                 |
| [`6bebcc72`](https://github.com/nix-community/disko/commit/6bebcc728e85efb22b639a1ac308e90764201f0d) | `` tidy: move relevant variables and format script block ``        |
| [`b2a106f8`](https://github.com/nix-community/disko/commit/b2a106f8ed84b948cbde5031ddc0942e709b8e1e) | `` zfs: Add topology attribute to zpool ``                         |