### PR TITLE
chore(flake/lanzaboote): `f5a3a7df` -> `e7bd94e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -448,11 +448,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1722329086,
-        "narHash": "sha256-e/fSi0WER06N8WCvpht62fkGtWfe5ckDxr6zNYkwkFw=",
+        "lastModified": 1725379389,
+        "narHash": "sha256-qS1H/5/20ewJIXmf8FN2A5KTOKKU9elWvCPwdBi1P/U=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "f5a3a7dff44d131807fc1a89fbd8576cd870334a",
+        "rev": "e7bd94e0b5ff3c1e686f2101004ebf4fcea9d871",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                                               |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`8373faed`](https://github.com/nix-community/lanzaboote/commit/8373faed37a49eeff3a07f4ab4af1d11b10930fe) | `` chore: remove comment about error bubbling with sbsign ``                          |
| [`30713d76`](https://github.com/nix-community/lanzaboote/commit/30713d769ad9b990272a56870976b1283916369f) | `` chore(naming): rename LanzabooteSigner into Signer ``                              |
| [`99ccde60`](https://github.com/nix-community/lanzaboote/commit/99ccde609f53a801e9790652a4c219c67f2f6cba) | `` chore(docs): address documentation comments ``                                     |
| [`e965b604`](https://github.com/nix-community/lanzaboote/commit/e965b6044bfdda7f4afc352462baf96014663eb2) | `` fix: do not emit a temporary initrd location if it's not needed ``                 |
| [`3e146441`](https://github.com/nix-community/lanzaboote/commit/3e146441bb473ab81fecc8d763a71835f034492a) | `` tool(systemd): improve testing logic for overwrite unsigned images ``              |
| [`14b833b7`](https://github.com/nix-community/lanzaboote/commit/14b833b78ba3c548914973715f4fece0ee7b4e1d) | `` nix/tests: extract into a lanzaboote library some common functions ``              |
| [`0fa5e453`](https://github.com/nix-community/lanzaboote/commit/0fa5e453bd726b6eba366fd9f97784e1ba2dcfed) | `` tool(*): generalize signature mechanisms ``                                        |
| [`c462f632`](https://github.com/nix-community/lanzaboote/commit/c462f6328da582f2cb3cb7f12184b11fd5c95709) | `` tool(pe): extract stub parameters in their own structure ``                        |
| [`365092ac`](https://github.com/nix-community/lanzaboote/commit/365092ac6b44e03b09e305ae7f31bd10cd30f1d3) | `` flake: support fine-grained `buildRustApp` inside of the workspace wrt packages `` |