### PR TITLE
chore(flake/nixos-hardware): `24bc1f98` -> `366ddc33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1725382810,
-        "narHash": "sha256-bkyT2mAl7dSaqTyd2njwCgIF2BQvTbJ+BjTjmM0S9wQ=",
+        "lastModified": 1725384549,
+        "narHash": "sha256-A9TMja7Ly70BOGcbcqJ0EUusQSFEQaKbrHJxNXfSFYY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "24bc1f98d8db75306bceb82cdb345a1189bc2064",
+        "rev": "366ddc33ff1b93d95ef3809d12ce0fba74c8d316",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                               |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
| [`366ddc33`](https://github.com/NixOS/nixos-hardware/commit/366ddc33ff1b93d95ef3809d12ce0fba74c8d316) | `` flake.nix: don't expose nvidia modules ``                                                         |
| [`ca005ac1`](https://github.com/NixOS/nixos-hardware/commit/ca005ac1e8392f1da8bb06f64b84dfee226f543a) | `` fix: spelling errors ``                                                                            |
| [`04567f4e`](https://github.com/NixOS/nixos-hardware/commit/04567f4ebcc9d4f90a7f527713ec7a3cd51e9cab) | `` fix: Update NVIDIA GPU configurations to use mkOverride ``                                         |
| [`5cbf7922`](https://github.com/NixOS/nixos-hardware/commit/5cbf79226baf922b3a4b64edc46b642ca0e10fb7) | `` feat: Add support for NVIDIA microarchitecture to xps 7590 and 9570 ``                             |
| [`4ac71504`](https://github.com/NixOS/nixos-hardware/commit/4ac71504155c4ac80d2f37bc0401c9b3aa75fadb) | `` feat: Add configurations for nvidia microarchitectures with configs for the open source drivers `` |