### PR TITLE
chore(flake/nixos-hardware): `366ddc33` -> `f7e31ff8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1725384549,
-        "narHash": "sha256-A9TMja7Ly70BOGcbcqJ0EUusQSFEQaKbrHJxNXfSFYY=",
+        "lastModified": 1725388496,
+        "narHash": "sha256-X7ClCNPP0dVmE8x5FN9Pt/UDCDHPR/cCZit4aEWo9gg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "366ddc33ff1b93d95ef3809d12ce0fba74c8d316",
+        "rev": "f7e31ff8efd7d450c3a9c6379963f333f32889a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`12acfdef`](https://github.com/NixOS/nixos-hardware/commit/12acfdefc1d352a382f5e875fc9a6c48ab989e08) | `` dell-xps-17-9700: Add nvidia architecture `` |
| [`dec757bf`](https://github.com/NixOS/nixos-hardware/commit/dec757bf4ebd310df00b19e54daa6ef1b241ec21) | `` dell-xps-15-9560: Add nvidia architecture `` |
| [`9f9cf89d`](https://github.com/NixOS/nixos-hardware/commit/9f9cf89d3370df3ffc307e77ca881b9a4dd76095) | `` dell-xps-15-9550: Add nvidia architecture `` |
| [`30584336`](https://github.com/NixOS/nixos-hardware/commit/30584336012b279813bf842ad27acf77fef33ae9) | `` dell-xps-15-9520: Add nvidia architecture `` |
| [`c75b52ac`](https://github.com/NixOS/nixos-hardware/commit/c75b52ace8305b2d64b16ec45335545a15062031) | `` dell-xps-15-9510: Add nvidia architecture `` |
| [`32979d22`](https://github.com/NixOS/nixos-hardware/commit/32979d223a3747f4a2683774db0d6cdfe6d1bf1a) | `` dell-xps-15-9500: Add nvidia architecture `` |
| [`b1ee64a4`](https://github.com/NixOS/nixos-hardware/commit/b1ee64a4eae363724f064a1e1536dd27a80c9e9b) | `` dell-g3-3779: Add nvidia architecture ``     |
| [`6d6022fa`](https://github.com/NixOS/nixos-hardware/commit/6d6022faac1c3d2995c3ca47fac0b5a29b2380ed) | `` tests: Update flake.lock ``                  |