### PR TITLE
chore(flake/nixos-hardware): `ba7bb376` -> `85810799`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1725436345,
-        "narHash": "sha256-sWfTgSJ3Wq/L7jEZHiU82NaBjpMMmBR1y+MSvx88WeE=",
+        "lastModified": 1725457709,
+        "narHash": "sha256-haDuGfkIJccuEjI1qk4IGBtE/u3o6F3S6H7wQ43lu3g=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ba7bb3761c960793001ed153a333e543345f34cf",
+        "rev": "858107998e8a679830474333eb9bc5ebc6bc2ec1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                               |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`3b6e461e`](https://github.com/NixOS/nixos-hardware/commit/3b6e461e6d4ef6c6f419172626b4296e143d58e9) | `` lenovo-legion-15arh05h: add NVIDIA architecture `` |
| [`6776df50`](https://github.com/NixOS/nixos-hardware/commit/6776df50ee0b5ae8ce8d5f3f652b101934eeb2b7) | `` Adding Asus Zephyrus G16 GU605MY ``                |