### PR TITLE
chore(flake/nixos-hardware): `ace1cedf` -> `880be1ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1725470640,
-        "narHash": "sha256-xaIvCE8ZP65fj2HR7DlDX+iJMBxasfjEv+zc6Cuwf3I=",
+        "lastModified": 1725477728,
+        "narHash": "sha256-ahej1VRqKmWbG7gewty+GlrSBEeGY/J2Zy8Nt8+3fdg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ace1cedf3ecfbac81b29522d71009878951a69eb",
+        "rev": "880be1ab837e1e9fe0449dae41ac4d034694d4ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`c50dd00a`](https://github.com/NixOS/nixos-hardware/commit/c50dd00a787ad747c65153a24a3dbd1e638f7e26) | `` system76-gaze18: Add nvidia architecture ``                 |
| [`75ac0969`](https://github.com/NixOS/nixos-hardware/commit/75ac0969d8207867df3f541bf64133dd91e4a213) | `` omen-16-n0280nd: Add nvidia architecture ``                 |
| [`d6e07be2`](https://github.com/NixOS/nixos-hardware/commit/d6e07be2cd9e8fcbb47499475ed11cbe19645464) | `` omen-15-en1007sa: Add nvidia architecture ``                |
| [`b00ea308`](https://github.com/NixOS/nixos-hardware/commit/b00ea30831b2e7ea8e5ee8d0a4efb2ac0a0c9dec) | `` omen-15-en0010ca: Add nvidia architecture ``                |
| [`2a638da5`](https://github.com/NixOS/nixos-hardware/commit/2a638da50f8598283ae5e1012d283104269a8dfc) | `` omen-15-en0002np: Add nvidia architecture ``                |
| [`a6839042`](https://github.com/NixOS/nixos-hardware/commit/a68390425cc9224ad32ee23781335ad9ea4b8f5f) | `` omen-14-fb0798ng: Add nvidia architecture ``                |
| [`4588e111`](https://github.com/NixOS/nixos-hardware/commit/4588e111d1d2982f49d174ca618821599722f3e8) | `` msi-gl62: Add nvidia architecture ``                        |
| [`ded3bdaa`](https://github.com/NixOS/nixos-hardware/commit/ded3bdaa58d4419bd01259120bcc43765bc4385c) | `` focus-m2-gen1: Add nvidia architecture ``                   |
| [`561fe843`](https://github.com/NixOS/nixos-hardware/commit/561fe843e1254ed96d8ecc39f6216c80e5513b02) | `` apple-macbook-pro-10-1: Add nvidia architecture ``          |
| [`2aa46f02`](https://github.com/NixOS/nixos-hardware/commit/2aa46f02e2d1bcb9507ffc1385bb055d393c613a) | `` apple-imac-14-2: Add nvidia architecture ``                 |
| [`7ea5daa4`](https://github.com/NixOS/nixos-hardware/commit/7ea5daa492c082e27483854fae6aad600559702b) | `` common-gpu-nvidia: Add kepler ``                            |
| [`5fdecbf8`](https://github.com/NixOS/nixos-hardware/commit/5fdecbf814a0a9f75edd1a1bfbae5b8a50e507c0) | `` lenovo-yoga-7-14ARH7: Add nvidia architecture ``            |
| [`ab6053df`](https://github.com/NixOS/nixos-hardware/commit/ab6053dff37ea208df045a7c604cab3a37ae2976) | `` lenovo-thinkpad-p52: Add nvidia architecture ``             |
| [`2fc1e100`](https://github.com/NixOS/nixos-hardware/commit/2fc1e10076a377718bcfe8b24bc57da7fc211df1) | `` lenovo-thinkpad-p51: Add nvidia architecture ``             |
| [`595a4a84`](https://github.com/NixOS/nixos-hardware/commit/595a4a84a11c7911fb9d025c108751c29034fd54) | `` lenovo-thinkpad-p50: Add nvidia architecture ``             |
| [`3ffa6a4d`](https://github.com/NixOS/nixos-hardware/commit/3ffa6a4dea790b88b0f8d6951748489f29a70e96) | `` lenovo-thinkpad-p14s-intel-gen3: Add nvidia architecture `` |
| [`80598d90`](https://github.com/NixOS/nixos-hardware/commit/80598d9043adbfb11658d2eda63b354cd7938b1f) | `` lenovo-thinkpad-e470: Add nvidia architecture ``            |
| [`efc4789f`](https://github.com/NixOS/nixos-hardware/commit/efc4789f6647e4da927b8b700bf9443259bda2f0) | `` lenovo-legion-t526amr5: Use nvidia open ``                  |
| [`3cb0b3a7`](https://github.com/NixOS/nixos-hardware/commit/3cb0b3a708280b30155835ba013e0b1defd52987) | `` lenovo-legion-16ithg6: Add nvidia architecture ``           |
| [`ab4beae1`](https://github.com/NixOS/nixos-hardware/commit/ab4beae1748358dfd7ba1ece826055e7d163d30f) | `` lenovo-legion-16irx8h: Add nvidia architecture ``           |
| [`06355153`](https://github.com/NixOS/nixos-hardware/commit/06355153e53d0dd728986f6f0a048b58c0fdd391) | `` lenovo-legion-15ich: Add nvidia architecture ``             |
| [`ec5e8f29`](https://github.com/NixOS/nixos-hardware/commit/ec5e8f29ff4ac4a20809cc662c8e75799958dadf) | `` lenovo-legion-15ach6h: Add nvidia architecture ``           |
| [`feb83f6c`](https://github.com/NixOS/nixos-hardware/commit/feb83f6cd269fdee6b29dfe63716ebd37b9c807f) | `` lenovo-legion-15ach6: Add nvidia architecture ``            |
| [`d4c8e7fc`](https://github.com/NixOS/nixos-hardware/commit/d4c8e7fc42426ec04d1ea398f100a32b93c751bb) | `` lenovo-ideapad-16ach6: Add nvidia architecture ``           |
| [`b890093a`](https://github.com/NixOS/nixos-hardware/commit/b890093a86aeec6f0d503d798fd5ebd7902196b2) | `` lenovo-ideapad-15arh05: Add nvidia architecture ``          |
| [`bf95efcb`](https://github.com/NixOS/nixos-hardware/commit/bf95efcbea8b5112df480e7f20b8fd8b9dee6bc5) | `` lenovo-ideapad-15ach6: Add nvidia architecture ``           |