### PR TITLE
chore(flake/lovesegfault-vim-config): `731717e8` -> `d8cb12c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725457351,
-        "narHash": "sha256-B5DLrU7xrZCC/EzleiE0IgUlIHs35BH7s2MI6irXcqc=",
+        "lastModified": 1725916343,
+        "narHash": "sha256-nLs1UocXTPHGsWKSBSYwoOpMpunqOTcdP0oWhIMDtqA=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "731717e8d5159c1dc8469ee547da2cc1d9d908e9",
+        "rev": "d8cb12c9f7e5ea34ec82cd367099387348cb5b21",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725391554,
-        "narHash": "sha256-m8NSagGZpMAQ8LZ+fLxAtD0Miwzy0nJoLSRf41k+3SE=",
+        "lastModified": 1725838501,
+        "narHash": "sha256-hL20ZHRwkjp0e+9khPkuREocmWBmpZrrOSRLP9MkvM4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "3f9cf9f961ba734d85021248c01b38cd8f2aa173",
+        "rev": "5330427e2bac6cea0be59e8de0d1b1c119306073",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                             |
| -------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`d8cb12c9`](https://github.com/lovesegfault/vim-config/commit/d8cb12c9f7e5ea34ec82cd367099387348cb5b21) | `` fix(lualine): rework to use settings pattern ``  |
| [`e724b744`](https://github.com/lovesegfault/vim-config/commit/e724b744596889140d1f1046173cdaadb7448881) | `` chore(flake/nixvim): 810eacf5 -> 5330427e ``     |
| [`32e0feef`](https://github.com/lovesegfault/vim-config/commit/32e0feefd5e426f351f6f92e55d3bb55ef8a16d7) | `` chore(flake/nixpkgs): ad416d06 -> 574d1eac ``    |
| [`9179450e`](https://github.com/lovesegfault/vim-config/commit/9179450ec2ef7adbd6b1d22bbedf228842733e66) | `` chore(flake/nixvim): 9a156ae6 -> 810eacf5 ``     |
| [`a3fc65ae`](https://github.com/lovesegfault/vim-config/commit/a3fc65ae09f87b49a557ee7d4dd5eb223c9601d7) | `` chore(flake/nixvim): 84249a9d -> 9a156ae6 ``     |
| [`a61c2991`](https://github.com/lovesegfault/vim-config/commit/a61c29915f72f5f6d04da19ed8b6a7a0798be3f7) | `` chore(flake/nixpkgs): 12228ff1 -> ad416d06 ``    |
| [`12596cbc`](https://github.com/lovesegfault/vim-config/commit/12596cbc51d3a8798fd5f8c10229473885fe4ebd) | `` chore(flake/git-hooks): 4509ca64 -> 7570de7b ``  |
| [`9ea9a5d1`](https://github.com/lovesegfault/vim-config/commit/9ea9a5d13251f6ab27e3cc0abea00fb0d4452b61) | `` chore(flake/nixvim): cdb2e79e -> 84249a9d ``     |
| [`7ecb6ab6`](https://github.com/lovesegfault/vim-config/commit/7ecb6ab6e2586aeb81a0f02485b4df36ab4a9624) | `` fix(lualine): navic.lsp -> navic.settings.lsp `` |
| [`3a30bc74`](https://github.com/lovesegfault/vim-config/commit/3a30bc7451b31ef89dc5f10b7bca9b806fc99d24) | `` chore(flake/nixvim): 3f9cf9f9 -> cdb2e79e ``     |