### PR TITLE
chore(flake/darwin): `7c4b53a7` -> `92bd25c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725189302,
-        "narHash": "sha256-IhXok/kwQqtusPsoguQLCHA+h6gKvgdCrkhIaN+kByA=",
+        "lastModified": 1725516679,
+        "narHash": "sha256-p6Cr1+dfS/mRZFPXAg3EPKVoQYRDzeEYOlcmzN5S+Xc=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "7c4b53a7d9f3a3df902b3fddf2ae245ef20ebcda",
+        "rev": "92bd25c29f3be33bc0d47acb7b5db0cae43bb7d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                  |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
| [`e1b6f307`](https://github.com/LnL7/nix-darwin/commit/e1b6f307ecfa88e9759646b22c8b9ece580e1b78) | `` linux-builder: make `package.nixosConfig` accurate `` |