### PR TITLE
chore(flake/darwin): `92bd25c2` -> `76559183`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725516679,
-        "narHash": "sha256-p6Cr1+dfS/mRZFPXAg3EPKVoQYRDzeEYOlcmzN5S+Xc=",
+        "lastModified": 1725628909,
+        "narHash": "sha256-xI0OSqPHcs/c/utJsU0Zvcp1VhejMI9mgwr68uHHlPs=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "92bd25c29f3be33bc0d47acb7b5db0cae43bb7d3",
+        "rev": "76559183801030451e200c90a1627c1d82bb4910",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                    |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
| [`c3341753`](https://github.com/LnL7/nix-darwin/commit/c334175319949f6887dcab89afb32f1bb38e9f88) | `` nixos/github-runner: quote comma separators so as to pass shellcheck `` |
| [`97e0f727`](https://github.com/LnL7/nix-darwin/commit/97e0f7275966cfab018aaee1a0d1e5ce74cd8901) | `` users: allow arbitrary group IDs ``                                     |