### PR TITLE
chore(flake/nix-index-database): `32058e91` -> `64227544`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -547,11 +547,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725161148,
-        "narHash": "sha256-WfAHq3Ag3vLNFfWxKHjFBFdPI6JIideWFJod9mx1eoo=",
+        "lastModified": 1725765290,
+        "narHash": "sha256-hwX53i24KyWzp2nWpQsn8lfGQNCP0JoW/bvQmcR1DPY=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "32058e9138248874773630c846563b1a78ee7a5b",
+        "rev": "642275444c5a9defce57219c944b3179bf2adaa9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`64227544`](https://github.com/nix-community/nix-index-database/commit/642275444c5a9defce57219c944b3179bf2adaa9) | `` update generated.nix to release 2024-09-08-030302 `` |
| [`0fbe4bbd`](https://github.com/nix-community/nix-index-database/commit/0fbe4bbdd0cd8b255f0182653814dec3accde827) | `` flake.lock: Update ``                                |