### PR TITLE
chore(flake/nixos-hardware): `04a1cda0` -> `755813cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1725716377,
-        "narHash": "sha256-7NzW9O/cAw7iWzRfh7Oo/SuSudL4a1YTKS6yoh3tMck=",
+        "lastModified": 1725876232,
+        "narHash": "sha256-wAtiyksylNzQONG47ZD0KuxPPm0kyuoR0ssns6ME4M4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "04a1cda0c1725094a4db703cccbb956b7558f5a6",
+        "rev": "755813cba87f62a9da1492d9473efea2b17b9386",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                       |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`755813cb`](https://github.com/NixOS/nixos-hardware/commit/755813cba87f62a9da1492d9473efea2b17b9386) | `` asus/zephyrus/gu605my: enable asusd by default and fix mic mute button ``                  |
| [`cfb3537b`](https://github.com/NixOS/nixos-hardware/commit/cfb3537b1562e45d9ddfb2b26896b6d12fe525ca) | `` asus/zephyrus/gu605my: fixed architecture and added dynamic boost as enabled by default `` |
| [`aac7c508`](https://github.com/NixOS/nixos-hardware/commit/aac7c50858a21636ddfd39831ccc221cf9d59827) | `` malibal/aon/s1: Add initial intel-only support. ``                                         |