### PR TITLE
chore(flake/darwin): `4c96bd69` -> `8220423c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726007501,
-        "narHash": "sha256-4MhYqhyNhsZw5gc4Hetu9LoA7Dy7qQMcuymxKwZDTNM=",
+        "lastModified": 1726011153,
+        "narHash": "sha256-OOxKWn1ZgdBMW1RX2hoBqCirIJutbh1WpRF7BdiBsLs=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "4c96bd694bab9bd872bb2e1b738133342e77966d",
+        "rev": "8220423c0220d4edcf62dec059ec41e84c7851ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                 |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
| [`95f063ea`](https://github.com/LnL7/nix-darwin/commit/95f063ea069e1752ddede8c9823a1b75ddd7858a) | `` tests/users-groups: update for `lib.escapeShellArg` change ``        |
| [`dea497f6`](https://github.com/LnL7/nix-darwin/commit/dea497f67a641d2d85f5673c3695f0fe43d46f64) | `` tests/networking-hostname: update for `lib.escapeShellArg` change `` |