### PR TITLE
chore(flake/darwin): `8220423c` -> `f4f18f3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726011153,
-        "narHash": "sha256-OOxKWn1ZgdBMW1RX2hoBqCirIJutbh1WpRF7BdiBsLs=",
+        "lastModified": 1726032244,
+        "narHash": "sha256-3VvRGPkpBJobQrFD3slQzMAwZlo4/UwxT8933U5tRVM=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "8220423c0220d4edcf62dec059ec41e84c7851ef",
+        "rev": "f4f18f3d7229845e1c9d517457b7a0b90a38b728",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                    |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
| [`88b97aa4`](https://github.com/LnL7/nix-darwin/commit/88b97aa49c451070d2978b291a6280f2e1c5c2b6) | `` {ids,checks}: update for new builder UID/GID values ``  |
| [`9c60c950`](https://github.com/LnL7/nix-darwin/commit/9c60c95008e2862c45d01d3d453508f644adeff6) | `` checks: make `oldBuildUsers` check fail hard ``         |
| [`2af5f0fb`](https://github.com/LnL7/nix-darwin/commit/2af5f0fb9e554ea3c85e57d35a5f2ed5a10b8867) | `` checks: factor out `nix.useDaemon` check ``             |
| [`98189683`](https://github.com/LnL7/nix-darwin/commit/98189683a4674d26fab2b5a7134bcfb5aa05cdf1) | `` ci: use Determinate Systems installer for stable Nix `` |
| [`f29c6fc0`](https://github.com/LnL7/nix-darwin/commit/f29c6fc015f3cf2b7fb8b6fc98e2471a2acc53d6) | `` ci: use Nix 2.24.6 for unstable jobs ``                 |
| [`bda49fe0`](https://github.com/LnL7/nix-darwin/commit/bda49fe089795d8d387419cd2ad877b345f3f840) | `` ci: update stable Nixpkgs to 24.05 ``                   |