### PR TITLE
chore(flake/disko): `e55f9a86` -> `495c2d76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725377834,
-        "narHash": "sha256-tqoAO8oT6zEUDXte98cvA1saU9+1dLJQe3pMKLXv8ps=",
+        "lastModified": 1726127872,
+        "narHash": "sha256-c/R4K4wjLooiyZc5k8lwYNpf4NXUuvRF41ZVtpgsasw=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "e55f9a8678adc02024a4877c2a403e3f6daf24fe",
+        "rev": "495c2d7673bf5dea4610cf29a800dc2f64aa3290",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                              |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`0943a50e`](https://github.com/nix-community/disko/commit/0943a50ee76a889623c6f9e8d21f60c3bdbeed55) | `` interactive-vm: convert into NixOS module ``      |
| [`ba66c22e`](https://github.com/nix-community/disko/commit/ba66c22ec110eed24ff0010b5623e18a2a5f128d) | `` Add `virtualisation.vmVariantWithDisko` option `` |