### PR TITLE
chore(flake/darwin): `f4f18f3d` -> `21fe31f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726032244,
-        "narHash": "sha256-3VvRGPkpBJobQrFD3slQzMAwZlo4/UwxT8933U5tRVM=",
+        "lastModified": 1726188813,
+        "narHash": "sha256-Vop/VRi6uCiScg/Ic+YlwsdIrLabWUJc57dNczp0eBc=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "f4f18f3d7229845e1c9d517457b7a0b90a38b728",
+        "rev": "21fe31f26473c180390cfa81e3ea81aca0204c80",
         "type": "github"
       },
       "original": {

--- a/hosts/poincare/default.nix
+++ b/hosts/poincare/default.nix
@@ -26,7 +26,7 @@
   nix = {
     gc.automatic = true;
     linux-builder = {
-      enable = false;
+      enable = true;
       ephemeral = true;
       config = { ... }: {
         imports = [ ../../core/nix.nix ];

--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -11,7 +11,6 @@ let
           (../hosts + "/${hostname}")
           {
             nix.registry = {
-              nixpkgs.flake = nixpkgs;
               p.flake = nixpkgs;
             };
           }


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                    |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
| [`953d02ba`](https://github.com/LnL7/nix-darwin/commit/953d02ba5958df017d9682f727d10a75cb8a0391) | `` {bash,zsh}: remove nix-shell early return in /etc/{bashrc,zshenv} ``    |
| [`04e3cfc8`](https://github.com/LnL7/nix-darwin/commit/04e3cfc822568d354b540a3207121af27b699057) | `` version: make `system.stateVersion` mandatory ``                        |
| [`537097b3`](https://github.com/LnL7/nix-darwin/commit/537097b3312b6089535d715b5f4a6e22ce4c5b41) | `` ci/update-manual: use Nixpkgs 24.05 ``                                  |
| [`b64c1d03`](https://github.com/LnL7/nix-darwin/commit/b64c1d036ffb9a4c4eaaea056e132775de62fc1d) | `` tools: fix darwin-rebuild changelog ``                                  |
| [`6ad463a7`](https://github.com/LnL7/nix-darwin/commit/6ad463a76421022de6762e6f50128febb970dcfc) | `` zsh: don't be noisy when scripts are run with -u ``                     |
| [`7e6c548e`](https://github.com/LnL7/nix-darwin/commit/7e6c548eef2372cef1287ef45350e29ca5740159) | `` zsh: let children shells set their fpath ``                             |
| [`8714f9e2`](https://github.com/LnL7/nix-darwin/commit/8714f9e28529183d65d9f42ac92cdc5d70dbb6f7) | `` flake: put nixpkgs in NIX_PATH and system registry for flake configs `` |