### PR TITLE
chore(flake/lovesegfault-vim-config): `fac3b211` -> `e8106163`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726099727,
-        "narHash": "sha256-IFBpJlU+AwczUX3ZdGp4ioQmzqnHUM2DuWxqQx8dU+I=",
+        "lastModified": 1726186304,
+        "narHash": "sha256-Plc0j6EBRCNThvkjJw5gURGBBwDS+aRrFVwabhrr4o4=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "fac3b211f41bb802be009e6188aa744f4d7b639f",
+        "rev": "e8106163a47025ffcd8af2acafbecff934d72cdd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`e8106163`](https://github.com/lovesegfault/vim-config/commit/e8106163a47025ffcd8af2acafbecff934d72cdd) | `` chore(flake/flake-parts): 567b938d -> bcef6817 `` |