### PR TITLE
chore(flake/home-manager): `c82fc8cf` -> `433e6866`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726209430,
-        "narHash": "sha256-ski2Is3VGChR1LR5U8qw8mqNfl5FDPCCAOsz2RrvJCE=",
+        "lastModified": 1726214280,
+        "narHash": "sha256-LqeIwfMuvAXV3DPZpd6BgOk/YfcJJyu5eredE/tEsJE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c82fc8cf3f75e667ad9dd3e5df721119b63723b3",
+        "rev": "433e686675ba24176fe3383916a4bd1c9799c676",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`433e6866`](https://github.com/nix-community/home-manager/commit/433e686675ba24176fe3383916a4bd1c9799c676) | `` autorandr: configModule.extraConfig ``              |
| [`ef506124`](https://github.com/nix-community/home-manager/commit/ef506124579ff6280a43a9596bb2a5049872bf8e) | `` gpg-agent: add launchd service agent and sockets `` |