### PR TITLE
chore(flake/home-manager): `7923c691` -> `503af483`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726221057,
-        "narHash": "sha256-E0JYRNOcPNNVpgg/xrCyqH/Go2laDs6EOqxSieam9hI=",
+        "lastModified": 1726222338,
+        "narHash": "sha256-KuA8ciNR8qCF3dQaCaeh0JWyQUgEwkwDHr/f49Q5/e8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7923c691527d2ee85fe028c6e780ac3bf8606f06",
+        "rev": "503af483e1b328691ea3a434d331995595fb2e3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`503af483`](https://github.com/nix-community/home-manager/commit/503af483e1b328691ea3a434d331995595fb2e3d) | `` eza: add support for fish abbreviations `` |
| [`076c78ed`](https://github.com/nix-community/home-manager/commit/076c78edede4e7abc71af0b1610fb1fc1c0fac29) | `` fish: add `preferAbbrs` option ``          |