### PR TITLE
chore(flake/nixpkgs): `1355a0cb` -> `4f807e89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -577,11 +577,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725983898,
-        "narHash": "sha256-4b3A9zPpxAxLnkF9MawJNHDtOOl6ruL0r6Og1TEDGCE=",
+        "lastModified": 1726062873,
+        "narHash": "sha256-IiA3jfbR7K/B5+9byVi9BZGWTD4VSbWe8VLpp9B/iYk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1355a0cbfeac61d785b7183c0caaec1f97361b43",
+        "rev": "4f807e8940284ad7925ebd0a0993d2a1791acb2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                             |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
| [`97849be3`](https://github.com/NixOS/nixpkgs/commit/97849be3fa9372233e63f363c1f62af176a3fc50) | `` glasgow: 0-unstable-2024-07-13 -> 0-unstable-2024-09-10 ``                                                       |
| [`c29ef942`](https://github.com/NixOS/nixpkgs/commit/c29ef94279196e90b732abd41712562889aa004d) | `` sapling: pin to Python 3.11 ``                                                                                   |
| [`48cdd61a`](https://github.com/NixOS/nixpkgs/commit/48cdd61a0aabaaa986dad50dd5039a8342d00500) | `` feishin: 0.8.1 -> 0.9.0 ``                                                                                       |
| [`0e6a2434`](https://github.com/NixOS/nixpkgs/commit/0e6a2434a572fd583cac02e142ab0689895e395a) | `` coqPackages.ssprove: 0.2.0 → 0.2.1 ``                                                                            |
| [`63da9c21`](https://github.com/NixOS/nixpkgs/commit/63da9c21a83e4ff3965ebbe8409cb2aa70625aba) | `` n8n: drop myself from maintainers ``                                                                             |
| [`89edc98b`](https://github.com/NixOS/nixpkgs/commit/89edc98b936400029cfcca46de501dd87df70127) | `` python312Packages.dissect-ntfs: refactor ``                                                                      |
| [`159be5db`](https://github.com/NixOS/nixpkgs/commit/159be5db480d1df880a0135ca0bfed84c2f88353) | `` coqPackages_8_20.serapi: init at 8.20.0+0.20.0 ``                                                                |
| [`4b2a32a5`](https://github.com/NixOS/nixpkgs/commit/4b2a32a53cd3065988cb66f23898dbfbe13fc9f3) | `` coqPackages.coq-lsp: enable for Coq 8.20 ``                                                                      |
| [`0fabf4f0`](https://github.com/NixOS/nixpkgs/commit/0fabf4f0914f97f7a120f27d73e22049d8b3d05a) | `` coqPackages_8_20.itauto: init at 8.20.0 ``                                                                       |
| [`0491865b`](https://github.com/NixOS/nixpkgs/commit/0491865b516f4424827ae00f57ee4702aa2ab602) | `` coqPackages.gappalib: enable for Coq 8.20 ``                                                                     |
| [`efd9b31d`](https://github.com/NixOS/nixpkgs/commit/efd9b31d09687e6e09ffa41c58524e9698d20a5e) | `` devenv: fix build on darwin ``                                                                                   |
| [`d2df1fd9`](https://github.com/NixOS/nixpkgs/commit/d2df1fd9415aecc5959965c16f6af3941deb3b8b) | `` coqPackages.metacoq: update for coq 8.20 ``                                                                      |
| [`0d319ecd`](https://github.com/NixOS/nixpkgs/commit/0d319ecd53b646985675c699deab7097e572e1ac) | `` coqPackages.ElmExtraction: init at 0.1.0 (#326305) ``                                                            |
| [`f92d7e03`](https://github.com/NixOS/nixpkgs/commit/f92d7e0351d7d683b707e0ea4d68f0535a0bdce4) | `` sqlitestudio: init at 3.4.4 ``                                                                                   |
| [`3f4c2cdd`](https://github.com/NixOS/nixpkgs/commit/3f4c2cdd133148fc397e500bd6e81f47a98bcc7f) | `` xen: 4.18.2 -> 4.18.3 ``                                                                                         |
| [`bb25a6d4`](https://github.com/NixOS/nixpkgs/commit/bb25a6d4d3bc709eb81ece06530822e7473c2c3d) | `` xen: 4.17.4 -> 4.17.5 ``                                                                                         |
| [`9b9eefe6`](https://github.com/NixOS/nixpkgs/commit/9b9eefe6be28f2eba9f182d0952441cbe42195fb) | `` pdm: 2.18.1 -> 2.18.2 ``                                                                                         |
| [`db267c9b`](https://github.com/NixOS/nixpkgs/commit/db267c9be834ee2439787d964ff97fe2afa6c064) | `` vscode-extensions.ms-python.python: 2024.5.11021008 -> 2024.15.2024091001 ``                                     |
| [`7bbb2246`](https://github.com/NixOS/nixpkgs/commit/7bbb22467ed4f30c59c612db3e430c1bb8708a60) | `` python312Packages.pytest-twisted: 1.14.2-unstable-2024-08-22 -> 1.14.3 ``                                        |
| [`d699dd0f`](https://github.com/NixOS/nixpkgs/commit/d699dd0f075b1f6b1c4c63c61f6d735685e9a158) | `` music-assistant: 2.2.2 -> 2.2.3 ``                                                                               |
| [`5d569f0b`](https://github.com/NixOS/nixpkgs/commit/5d569f0bf31e22170d1ed2effee6c3673ec57a60) | `` swiftlint: 0.56.1 -> 0.57.0 ``                                                                                   |
| [`09e885cf`](https://github.com/NixOS/nixpkgs/commit/09e885cfda8b4cf45388c552c9c9840d5b597a79) | `` pcsx2-bin: 2.1.116 -> 2.1.136 ``                                                                                 |
| [`0206930c`](https://github.com/NixOS/nixpkgs/commit/0206930c80f517e01b2745061f134b3601c4ffa3) | `` devenv: 1.0.8 -> 1.1 ``                                                                                          |
| [`8e4b8f8b`](https://github.com/NixOS/nixpkgs/commit/8e4b8f8bed16ce54197db43c139b808b64e47067) | `` xml2rfc: 3.21.0 -> 3.23.0 ``                                                                                     |
| [`a99c3349`](https://github.com/NixOS/nixpkgs/commit/a99c3349650f6a79ee58fd520a9844631f4b08b9) | `` treewide: Fix remaining Android sdkVer and ndkVer references (#341106) ``                                        |
| [`8dcc6f23`](https://github.com/NixOS/nixpkgs/commit/8dcc6f23e34253ad37c750d591fafcd0ecd78d6d) | `` ffmpegthumbnailer: Make thumbnailer file point to absolute path ``                                               |
| [`8ad810aa`](https://github.com/NixOS/nixpkgs/commit/8ad810aa5d432cf9e5e3dfb51dd129f0e07ecdfa) | `` python312Packages.kafka-python: drop ``                                                                          |
| [`45c1cd78`](https://github.com/NixOS/nixpkgs/commit/45c1cd7888f253b1dfe4d707c682df8161f1d40b) | `` python312Packages.aiokafka: refactor ``                                                                          |
| [`eb81486b`](https://github.com/NixOS/nixpkgs/commit/eb81486b9f6d55250f70a071ecdb5d84abda3898) | `` python312Packages.dazl: 7.11.0 -> 7.12.0 ``                                                                      |
| [`8f8a3016`](https://github.com/NixOS/nixpkgs/commit/8f8a301679d513958df485dd29d40592ff64bd56) | `` vscode-extensions.asvetliakov.vscode-neovim: 1.18.10 -> 1.18.11 ``                                               |
| [`cf5a4636`](https://github.com/NixOS/nixpkgs/commit/cf5a46368bfdef67223de8206c01370b106e12ab) | `` lib/types: fix toCoerced's typeMerge ``                                                                          |
| [`10fb383c`](https://github.com/NixOS/nixpkgs/commit/10fb383ce194379f15c069c042f0ac7d4d986cea) | `` fantomas: 6.3.12 -> 6.3.13 ``                                                                                    |
| [`c748c30e`](https://github.com/NixOS/nixpkgs/commit/c748c30eb9e1570f6d2712b80e7853ae987c46d2) | `` ad-miner: 1.5.2 -> 1.6.0 ``                                                                                      |
| [`93439057`](https://github.com/NixOS/nixpkgs/commit/9343905733cd6b5cce2a54cce99ea1e29c84ee07) | `` emacsPackages.units-mode: replace program ``                                                                     |
| [`6c18083a`](https://github.com/NixOS/nixpkgs/commit/6c18083a43d3a8ab0b2f9726de0b1cfeab050fc3) | `` zed-editor: 0.151.2 -> 0.152.3 ``                                                                                |
| [`5456bfa9`](https://github.com/NixOS/nixpkgs/commit/5456bfa9e72e0d3004d79c6046ba6ff088acbb10) | `` python312Packages.robotframework: 7.0.1 -> 7.1 ``                                                                |
| [`c978371c`](https://github.com/NixOS/nixpkgs/commit/c978371cc398210c6297e2fddcd6c6ac3ac27476) | `` minio-client: 2024-08-26T10-49-58Z -> 2024-09-09T07-53-10Z ``                                                    |
| [`c7bb47aa`](https://github.com/NixOS/nixpkgs/commit/c7bb47aac18f30a4f1780089f189f47a65e283c4) | `` makeInitrdNG: fixup `contents` documentation ``                                                                  |
| [`d244f9a9`](https://github.com/NixOS/nixpkgs/commit/d244f9a98d206f596d7cc0a96c534c462d165899) | `` home-assistant-custom-components.waste_collection_schedule: 2.1.0 -> 2.2.0 ``                                    |
| [`d14c5f66`](https://github.com/NixOS/nixpkgs/commit/d14c5f66fc3700834eecb234ea28e02b685d8b63) | `` microcode-intel: 20240813 -> 20240910 ``                                                                         |
| [`1129c559`](https://github.com/NixOS/nixpkgs/commit/1129c559f5a3558e52e0d23d268da18a0a84232c) | `` fedifetcher: 7.1.6 -> 7.1.7 ``                                                                                   |
| [`5bc1418a`](https://github.com/NixOS/nixpkgs/commit/5bc1418a2b31c70a8c0b6f7aea8c8b8899c2b8ff) | `` python312Packages.brother-ql: Use pypa infrastructure to build ``                                                |
| [`fb8f922c`](https://github.com/NixOS/nixpkgs/commit/fb8f922cc534153513ae96337e661649c1038d09) | `` python312Packages.brother-ql: Correct license from gpl3 to gpl3only ``                                           |
| [`a2ca5085`](https://github.com/NixOS/nixpkgs/commit/a2ca508592569366c94531bbd850b36a113228f6) | `` python312Packages.brother-ql: 0.11.1 -> 0.11.2 ``                                                                |
| [`af48f8f0`](https://github.com/NixOS/nixpkgs/commit/af48f8f0c69779b8074147cc7cf304c22901188b) | `` python312Packages.brother-ql: switch to maintained fork ``                                                       |
| [`fb6b0fc2`](https://github.com/NixOS/nixpkgs/commit/fb6b0fc2a79f158b0048a7d606daa31ed8e1fe24) | `` route-detect: init at 0.8.0 ``                                                                                   |
| [`4bc803e6`](https://github.com/NixOS/nixpkgs/commit/4bc803e67d88bf80241523a73f19bc3e658d32f0) | `` python312Packages.unstructured: 0.15.9 -> 0.15.10 ``                                                             |
| [`6316f217`](https://github.com/NixOS/nixpkgs/commit/6316f217591e1e04411d0a322420fd7265006129) | `` fastly: 10.13.3 -> 10.14.0 ``                                                                                    |
| [`c6fa7e48`](https://github.com/NixOS/nixpkgs/commit/c6fa7e48fee0dbd532213eb34e972286bc828f7c) | `` keycloak: 25.0.4 -> 25.0.5 ``                                                                                    |
| [`20545106`](https://github.com/NixOS/nixpkgs/commit/205451066098a5ada6b4335a62c5fb6994075c74) | `` systemfd: 0.4.3 -> 0.4.4 ``                                                                                      |
| [`dcd22533`](https://github.com/NixOS/nixpkgs/commit/dcd22533a08494dec7dd7e6dcb0c5421ac46b9b4) | `` python312Packages.dissect-shellitem: 3.9 -> 3.10 ``                                                              |
| [`b58824e4`](https://github.com/NixOS/nixpkgs/commit/b58824e4e61040a70e561c46db4554468093f177) | `` python312Packages.dissect-ntfs: 3.11 -> 3.12 ``                                                                  |
| [`d02fecd7`](https://github.com/NixOS/nixpkgs/commit/d02fecd72f5621f2d44c85c6e26a04eac9f53944) | `` python312Packages.dissect-squashfs: 1.6 -> 1.7 ``                                                                |
| [`e260da83`](https://github.com/NixOS/nixpkgs/commit/e260da83c577037cfc81a96fd367d043753de0ba) | `` python312Packages.dissect-hypervisor: 3.14 -> 3.15 ``                                                            |
| [`45fe13ed`](https://github.com/NixOS/nixpkgs/commit/45fe13ed73582df7a06939a158cd7fa8680d95ee) | `` python312Packages.acquire: 3.15 -> 3.16 ``                                                                       |
| [`607ff34a`](https://github.com/NixOS/nixpkgs/commit/607ff34a7eb5f154ea199f5392c86d1d4a6210d4) | `` zsh-wd: 0.7.1 -> 0.8.0 ``                                                                                        |
| [`951dc5a3`](https://github.com/NixOS/nixpkgs/commit/951dc5a32597c41e2c6a10f6f9355c62aac3288d) | `` python312Packages.iottycloud: 0.1.3 -> 0.2.1 ``                                                                  |
| [`fd27888c`](https://github.com/NixOS/nixpkgs/commit/fd27888c61a7069fd0ccf8089fe1f974dd0fe152) | `` maintainers: add targeted fix for missing pkgs/by-name/.../package.nix files to maintainers/scripts/build.nix `` |
| [`74787857`](https://github.com/NixOS/nixpkgs/commit/74787857f812116406bf53c56b16ba2c1df55ace) | `` nixVersions.git: disable test on aarch64-linux ``                                                                |
| [`9103a4d9`](https://github.com/NixOS/nixpkgs/commit/9103a4d978ddc60e165fa26b22a471b7d50840fd) | `` nixVersions.git: 2.25.0pre20240807 -> 2.25.0pre20240910 ``                                                       |
| [`7eab263a`](https://github.com/NixOS/nixpkgs/commit/7eab263a5d1b8b5dfe39a899dbba1b626dd54ff7) | `` userborn: limit to Linux ``                                                                                      |
| [`615eec08`](https://github.com/NixOS/nixpkgs/commit/615eec08af5a2a7769fc16d67f41907c1b930d2d) | `` userborn: 0.1.0 -> 0.2.0 ``                                                                                      |
| [`e31bb099`](https://github.com/NixOS/nixpkgs/commit/e31bb09912ed813c97dacd483f67b120dad2c35b) | `` nixos/tests/userborn: add pwck and grpck ``                                                                      |
| [`128fd810`](https://github.com/NixOS/nixpkgs/commit/128fd810043f4b67fd53626181b3b47fb220f186) | `` gopls: 0.16.1 -> 0.16.2 ``                                                                                       |
| [`6e872264`](https://github.com/NixOS/nixpkgs/commit/6e87226440bf24037fc7cbc36708ae3f00e5745c) | `` recyclarr: 7.2.1 -> 7.2.3 ``                                                                                     |
| [`55ff4178`](https://github.com/NixOS/nixpkgs/commit/55ff4178e82ec85588895c19dadb7cb7e6ff4cd0) | `` ffcast: add awk to path ``                                                                                       |
| [`3615fbc9`](https://github.com/NixOS/nixpkgs/commit/3615fbc9ae66a92ad417912c5e130842a05dee72) | `` python312Packages.dissect: 3.15 -> 3.16 ``                                                                       |