### PR TITLE
chore(flake/home-manager): `503af483` -> `7edf6cca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726222338,
-        "narHash": "sha256-KuA8ciNR8qCF3dQaCaeh0JWyQUgEwkwDHr/f49Q5/e8=",
+        "lastModified": 1726298287,
+        "narHash": "sha256-wvtyOH5X2euU7CISBg2jNVpc2cGP1rJ2bsatBLDwjGc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "503af483e1b328691ea3a434d331995595fb2e3d",
+        "rev": "7edf6ccaec8001cb20368bf1bf6a677178cae07b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`7edf6cca`](https://github.com/nix-community/home-manager/commit/7edf6ccaec8001cb20368bf1bf6a677178cae07b) | `` Add translation using Weblate (Hindi) ``     |
| [`e94bee95`](https://github.com/nix-community/home-manager/commit/e94bee957400c8f871d9b9ea54308e15d664242c) | `` Translate using Weblate (Hindi) ``           |
| [`898eaef7`](https://github.com/nix-community/home-manager/commit/898eaef7ea906ddc8e86d57957f2a701878bfb05) | `` Translate using Weblate (Russian) ``         |
| [`f084d653`](https://github.com/nix-community/home-manager/commit/f084d653199345ad294abca921a0e25872bd75c0) | `` swaync: fix example configuration ``         |
| [`43845d04`](https://github.com/nix-community/home-manager/commit/43845d04f83d44d744206ea9884b8206e7640633) | `` git: add diff-highlight diff pager option `` |