### PR TITLE
chore(flake/home-manager): `7edf6cca` -> `6c1a461a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726298287,
-        "narHash": "sha256-wvtyOH5X2euU7CISBg2jNVpc2cGP1rJ2bsatBLDwjGc=",
+        "lastModified": 1726308872,
+        "narHash": "sha256-d4vwO5N4RsLnCY7k5tY9xbdYDWQsY3RDMeUoIa4ms2A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7edf6ccaec8001cb20368bf1bf6a677178cae07b",
+        "rev": "6c1a461a444e6ccb3f3e42bb627b510c3a722a57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`6c1a461a`](https://github.com/nix-community/home-manager/commit/6c1a461a444e6ccb3f3e42bb627b510c3a722a57) | `` mopidy: reduce test closure size ``          |
| [`c6e4ec39`](https://github.com/nix-community/home-manager/commit/c6e4ec39df78245f7ce678476ff068515763345b) | `` z-lua: add support for fish abbreviations `` |
| [`0d118885`](https://github.com/nix-community/home-manager/commit/0d118885b2840447b5b7f2b6097b4511ed3d02e9) | `` lsd: add support for fish abbreviations ``   |
| [`f69e61a2`](https://github.com/nix-community/home-manager/commit/f69e61a2d77b721f28868b6fdc55706ca1bad49c) | `` pls: add support for fish abbreviations ``   |