### PR TITLE
chore(flake/disko): `4ef99d8e` -> `3632080c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726219040,
-        "narHash": "sha256-u/2xSCp/7sE7XViv6QR2jMw7Rrx/PXJtmeVLYv+Qbpo=",
+        "lastModified": 1726325969,
+        "narHash": "sha256-Mlw7009cdFry9OHpS6jy294lXhb+gcRa0iS2hYhkC6s=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "4ef99d8ec41369b6fbe83479b5566c2b8856972c",
+        "rev": "3632080c41d7a657995807689a08ef6c4bcb2c72",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                    |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`1eb54f6e`](https://github.com/nix-community/disko/commit/1eb54f6efc1f34073d9a641a6d6d16a534c36555) | `` build(deps): bump DeterminateSystems/update-flake-lock from 23 to 24 `` |