### PR TITLE
chore(flake/nixos-hardware): `b9ab7e57` -> `dc8b0296`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1726454253,
-        "narHash": "sha256-ikQs0QZGmCfk5cJ2N5nTT6oULMvWgxN6ebk4WsOq9io=",
+        "lastModified": 1726489388,
+        "narHash": "sha256-JBHtN+n1HzKawpnOQAz6jdgvrtYV9c/kyzgoIdguQGo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b9ab7e57c5d1d456cdeef252d345f3bca9c55851",
+        "rev": "dc8b0296f68f72f3fe77469c549a6f098555c2e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`4ee6bd22`](https://github.com/NixOS/nixos-hardware/commit/4ee6bd22af1bd75bb403e2f0e1af0161eb69cccc) | `` framework: fix outdated documentation on fw-ectool `` |