### PR TITLE
chore(flake/lovesegfault-vim-config): `86a67829` -> `607417b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726445379,
-        "narHash": "sha256-/mkydWKy0HSO7cBLKSRV9MV3pHsD7yV2yFd4NS95m5I=",
+        "lastModified": 1726531725,
+        "narHash": "sha256-7lJ2KEMPPFhk24szyzMRq/Br+S9ANIerFyrmodNl2G8=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "86a6782985eecb1d1a37e1fe4f73689d0e696b95",
+        "rev": "607417b27b6992a1a58c239c833af0fc49763b0c",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726441328,
-        "narHash": "sha256-WGZuGGjWq4Rac3MwdnXaojvTOMo2HjqXEWughqCYMAk=",
+        "lastModified": 1726502324,
+        "narHash": "sha256-I/WFSIBeIjlY3CgSJ6IRYxP2aEJ6b42Y1HAeATlBh48=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "95b322a5220744a5cac725e62fa4e612851edbc2",
+        "rev": "2e3083e42509c399b224239f6d7fa17976b18536",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`607417b2`](https://github.com/lovesegfault/vim-config/commit/607417b27b6992a1a58c239c833af0fc49763b0c) | `` chore(flake/nixvim): 95b322a5 -> 2e3083e4 `` |