### PR TITLE
chore(flake/flake-utils): `b1d9ab70` -> `c1dfcf08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -287,11 +287,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`fa06cc1b`](https://github.com/numtide/flake-utils/commit/fa06cc1b3d9f8261138ab7e1bc54d115cfcdb6ea) | `` lib: eachDefaultSystemPassThrough/eachSystemPassThrough: init ``      |
| [`58351e44`](https://github.com/numtide/flake-utils/commit/58351e44283ebaf4fa49c4ec1e50754f6ec9ed5e) | `` lib: eachSystem: optimize hot path by assuming rare --impure usage `` |
| [`db82e07b`](https://github.com/numtide/flake-utils/commit/db82e07bd4c49c5e191d4a913f5875668f30fe63) | `` lib: eachSystem: simplify boolean expression ``                       |
| [`ce5c962a`](https://github.com/numtide/flake-utils/commit/ce5c962a8c847c67cf066f054237d0163eb1649d) | `` lib: eachSystem: inline single-use local variables ``                 |
| [`274ed073`](https://github.com/numtide/flake-utils/commit/274ed073aa7c8923b300cf909befd308ee7aa2d6) | `` lib: eachSystem: improve comments ``                                  |
| [`e8a5a7ba`](https://github.com/numtide/flake-utils/commit/e8a5a7ba2172cc268d144b1c56b419e303add1ab) | `` lib: eachSystem: reformat using 'nixfmt-rfc-style --width 80' ``      |
| [`b1606d7d`](https://github.com/numtide/flake-utils/commit/b1606d7d734203290a39f38a17b9126ca40e6df7) | `` lib: lib: sort inherit statements ``                                  |
| [`988e455b`](https://github.com/numtide/flake-utils/commit/988e455b6f84396a721f8c0b96bbf1264a4da3c0) | `` readme: remove trailing whitespaces ``                                |