### PR TITLE
chore(flake/disko): `22ee467a` -> `88b015b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726524467,
-        "narHash": "sha256-xkPPPvfHhHK7BNX5ZrQ9N6AIEixCmFzRZHduDf0zv30=",
+        "lastModified": 1726581763,
+        "narHash": "sha256-c/BN0hg0Hza1rj5I+FeNrz/L1zBHwG3BZlBCxsBTbXs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "22ee467a54a3ab7fa9d637ccad5330c6c087e9dc",
+        "rev": "88b015b9eb65edefc0b6501980a3d53cd1764637",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                          |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`88b015b9`](https://github.com/nix-community/disko/commit/88b015b9eb65edefc0b6501980a3d53cd1764637) | `` make-disk-image: fix spelling for `--help` `` |
| [`d52ca376`](https://github.com/nix-community/disko/commit/d52ca37645b7bd48efeea0e40299713f1c9e04ba) | `` docs: rename `vdb` -> `main` ``               |