### PR TITLE
chore(flake/disko): `88b015b9` -> `d32d1504`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726581763,
-        "narHash": "sha256-c/BN0hg0Hza1rj5I+FeNrz/L1zBHwG3BZlBCxsBTbXs=",
+        "lastModified": 1726590912,
+        "narHash": "sha256-5bxY85siOIqOcQ8TOMAWLkMUZvLUADS2i5TsZhzUIZY=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "88b015b9eb65edefc0b6501980a3d53cd1764637",
+        "rev": "d32d1504c77d7f6ba7e033357dcf638baceab9b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`d32d1504`](https://github.com/nix-community/disko/commit/d32d1504c77d7f6ba7e033357dcf638baceab9b7) | `` zpool: support updating zfsprops on root dataset `` |
| [`a9eeea33`](https://github.com/nix-community/disko/commit/a9eeea33793bc8c16fd72d4d7db60c5d51a419d6) | `` zfs_fs: support updating mountpoint properly ``     |