### PR TITLE
chore(flake/nixos-hardware): `270ddd75` -> `abb44860`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1726650065,
-        "narHash": "sha256-QxEqcd7SuSs/TIO3alOvc57LhvhUa2VSI0wW63OtcLk=",
+        "lastModified": 1726650330,
+        "narHash": "sha256-UbHzmaOQ18O/kCizipU70N0UQVFIfv8AiFKXw07oZ9Y=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "270ddd75128efe52d668f58a28ec201ec67b7b62",
+        "rev": "abb448608a56a60075468e90d8acec2a7cb689b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`23a4ea7a`](https://github.com/NixOS/nixos-hardware/commit/23a4ea7a0d1c5cb52f6f3ace8ce5b85da9e3b9e6) | `` lenovo-yoga-6-13ALC6: add mkDefault for bluetooth `` |