### PR TITLE
chore(flake/treefmt-nix): `41266e63` -> `829338a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -793,11 +793,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726646204,
-        "narHash": "sha256-Ftjw+30n/HeFxtvw/c0+hzT6d3kbwPnGruhbrKnbwOI=",
+        "lastModified": 1726705685,
+        "narHash": "sha256-byl6ywTyQTUGiuwvBsDtQwUioQ5Kklxirj6YdiWTLdY=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "41266e63a00c55b488f8f977051d4bd20e77f644",
+        "rev": "829338a3df3dfd492c61abbd090ec1405329c943",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                     |
| ---------------------------------------------------------------------------------------------------- | --------------------------- |
| [`284529ce`](https://github.com/numtide/treefmt-nix/commit/284529cebe0f41f459210c617100d6d723ae37a7) | `` Add meson to README ``   |
| [`434a5069`](https://github.com/numtide/treefmt-nix/commit/434a50690c715fe3a2b35852433a29763f54fdf9) | `` Add meson example ``     |
| [`2ca2bf4e`](https://github.com/numtide/treefmt-nix/commit/2ca2bf4e3e821451e8936549279024f08ef5a139) | `` Add meson's formatter `` |