### PR TITLE
chore(flake/nixos-hardware): `abb44860` -> `10d5e0ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1726650330,
-        "narHash": "sha256-UbHzmaOQ18O/kCizipU70N0UQVFIfv8AiFKXw07oZ9Y=",
+        "lastModified": 1726724509,
+        "narHash": "sha256-sVeAM1tgVi52S1e29fFBTPUAFSzgQwgLon3CrztXGm8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "abb448608a56a60075468e90d8acec2a7cb689b1",
+        "rev": "10d5e0ecc32984c1bf1a9a46586be3451c42fd94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                             |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`10d5e0ec`](https://github.com/NixOS/nixos-hardware/commit/10d5e0ecc32984c1bf1a9a46586be3451c42fd94) | `` asus-rog-strix-x570: add nct6775 kernel module for temperature and fan sensor `` |
| [`1c8c4f2c`](https://github.com/NixOS/nixos-hardware/commit/1c8c4f2c79468be23fcd7f87f8cee519e564cba2) | `` apple/t2: bump kernel to 6.11 ``                                                 |