### PR TITLE
chore(flake/disko): `d32d1504` -> `a31fe5ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726590912,
-        "narHash": "sha256-5bxY85siOIqOcQ8TOMAWLkMUZvLUADS2i5TsZhzUIZY=",
+        "lastModified": 1726730453,
+        "narHash": "sha256-Kdi7liMdbr1/uyMhMDl19O5b9LESxcnYgBRZblrJi9E=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "d32d1504c77d7f6ba7e033357dcf638baceab9b7",
+        "rev": "a31fe5ef162f2f963308289e6e27d37e3948a983",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                 |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`c5853dcb`](https://github.com/nix-community/disko/commit/c5853dcb32ad4a7711af9513ddfc49da171d5f00) | `` module: throw if no disks are defined ``             |
| [`706a1722`](https://github.com/nix-community/disko/commit/706a1722f6844ec749d6557c034a9eb6cff18c48) | `` module: always populate `system.build` attributes `` |