### PR TITLE
chore(flake/darwin): `6374cd7e` -> `c03f85fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726616680,
-        "narHash": "sha256-i0h300W3t7Q7PltJPmucj+ub45SE/bNQ+pf83tasYAQ=",
+        "lastModified": 1726742753,
+        "narHash": "sha256-QclpWrIFIg/yvWRiOUaMp1WR+TGUE9tb7RE31xHlxWc=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "6374cd7e50aa057a688142eed2345083047ad884",
+        "rev": "c03f85fa42d68d1056ca1740f3113b04f3addff2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                       |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
| [`e92cc015`](https://github.com/LnL7/nix-darwin/commit/e92cc01524b68028d449e9dbb56a8a644ede3ab4) | `` add tests for finder options ``                            |
| [`2841f496`](https://github.com/LnL7/nix-darwin/commit/2841f496312a3e9b4d48e18af435ee46a11a1bb6) | `` fix description typo in `dock.nix` ``                      |
| [`3d48a989`](https://github.com/LnL7/nix-darwin/commit/3d48a9893a12929d48f3ca4279fcfb8a8d4aac96) | `` add `finder._FXSortFoldersFirst` option ``                 |
| [`3b087efc`](https://github.com/LnL7/nix-darwin/commit/3b087efcbdb72f89e0c80a3ebdf4e091b7a48e41) | `` add `NSGlobalDomain.AppleSpacesSwitchOnActivate` option `` |