### PR TITLE
chore(flake/disko): `624fd864` -> `0fe77990`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726775926,
-        "narHash": "sha256-5zShvCy9S4tuISFjNSjb+TWpPtORqPbRZ0XwbLbPLho=",
+        "lastModified": 1726838624,
+        "narHash": "sha256-SU40aZ/UyK4bhuanaWvqlhIw2/kiDrGYcKxCkTn5FP8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "624fd86460e482017ed9c3c3c55a3758c06a4e7f",
+        "rev": "0fe779905ffe730eace0bf7ecf56938c625012a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                   |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`9adb48e6`](https://github.com/nix-community/disko/commit/9adb48e682a42a52b83f9093b55020913a0f911f) | `` add workaround for flakey zfs tests `` |
| [`93c1dde4`](https://github.com/nix-community/disko/commit/93c1dde4190ecde415de3a47ba42163306b06998) | `` tests/f2fs: add compression ``         |
| [`da8bfaf1`](https://github.com/nix-community/disko/commit/da8bfaf1d5b8b4ca1d1a46aea116ebabf35d8d2a) | `` shellcheck: also disable SC2054 ``     |
| [`bc7fd723`](https://github.com/nix-community/disko/commit/bc7fd7238a6596dfd0eb1d194f8ca73217d25e01) | `` filesystem: escape shell args ``       |