### PR TITLE
chore(flake/lovesegfault-vim-config): `b819b6c7` -> `b8d53aac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726791335,
-        "narHash": "sha256-+Qwb8IY5vgWsl+Qok61WAHCeEo+vnQSPY11GnlO694M=",
+        "lastModified": 1726877560,
+        "narHash": "sha256-pHT5D5DOhr6De0sLTKQo0xQNW4HTTM4cpsVNbkoAC7o=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "b819b6c74fdd248ee43fce3f1d0ac046a20348d1",
+        "rev": "b8d53aac054f6e75fd0545f588944c365647129e",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726785706,
-        "narHash": "sha256-eEa/EHO8UKYBTcQECyzF9pZm2ualqO8mr79djYJuYWE=",
+        "lastModified": 1726846628,
+        "narHash": "sha256-0CH44sEwiljiN2q7eIFCvabyUm1WeEiF8ofP/z5ca0Q=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "400d1d927d76791b46ae30d431d908c60e411a26",
+        "rev": "3211ce356be612ae89a38c60799992bde8a47127",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`b8d53aac`](https://github.com/lovesegfault/vim-config/commit/b8d53aac054f6e75fd0545f588944c365647129e) | `` chore(flake/nixpkgs): 99dc8785 -> c04d5652 `` |
| [`409993ec`](https://github.com/lovesegfault/vim-config/commit/409993ece9a9f47441cb39c2ee7e3ed9bc6d165b) | `` chore(flake/nixvim): 400d1d92 -> 3211ce35 ``  |