### PR TITLE
chore(flake/nixos-hardware): `10d5e0ec` -> `b493dfd4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1726724509,
-        "narHash": "sha256-sVeAM1tgVi52S1e29fFBTPUAFSzgQwgLon3CrztXGm8=",
+        "lastModified": 1726905744,
+        "narHash": "sha256-xyNtG5C+xvfsnOVEamFe9zCCnuNwk93K/TlFC/4DmCI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "10d5e0ecc32984c1bf1a9a46586be3451c42fd94",
+        "rev": "b493dfd4a8cf9552932179e56ff3b5819a9b8381",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`b493dfd4`](https://github.com/NixOS/nixos-hardware/commit/b493dfd4a8cf9552932179e56ff3b5819a9b8381) | `` update flakes ``                                    |
| [`1e27e79a`](https://github.com/NixOS/nixos-hardware/commit/1e27e79ab2697ec1b7b84edccd32d5f4e79946e6) | `` CONTRIBUTING.md: Update testing instructions ``     |
| [`d64ae016`](https://github.com/NixOS/nixos-hardware/commit/d64ae0165303096700cb101f8d7e35eb9ba3aa4e) | `` test/run: format file and remove unused variable `` |