### PR TITLE
chore(flake/nix-index-database): `c1b0fa0b` -> `c7515c2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -547,11 +547,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726449931,
-        "narHash": "sha256-1AX7MyYzP7sNgZiGF8jwehCCI75y2kBGwACeryJs+yE=",
+        "lastModified": 1726975622,
+        "narHash": "sha256-bPDZosnom0+02ywmMZAvmj7zvsQ6mVv/5kmvSgbTkaY=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "c1b0fa0bec5478185eae2fd3f39b9e906fc83995",
+        "rev": "c7515c2fdaf2e1f3f49856cef6cec95bb2138417",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`c7515c2f`](https://github.com/nix-community/nix-index-database/commit/c7515c2fdaf2e1f3f49856cef6cec95bb2138417) | `` update generated.nix to release 2024-09-22-031442 `` |
| [`f7043801`](https://github.com/nix-community/nix-index-database/commit/f7043801a7090b50b0dd22e139581044e88d9667) | `` flake.lock: Update ``                                |