### PR TITLE
chore(flake/darwin): `f5927529` -> `bd7d1e39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726998041,
-        "narHash": "sha256-numF8CcPq1TSv8jSB+jllOAq4uPENl+gBohwiV6tZrU=",
+        "lastModified": 1727003835,
+        "narHash": "sha256-Cfllbt/ADfO8oxbT984MhPHR6FJBaglsr1SxtDGbpec=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "f59275298fbf950393c6bb7d746fce5f2d216450",
+        "rev": "bd7d1e3912d40f799c5c0f7e5820ec950f1e0b3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                       |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
| [`db92fac3`](https://github.com/LnL7/nix-darwin/commit/db92fac3a9552ac3338977dcaf4cd15acf4aac08) | `` flake: match NixOS definition of `nixpkgs.flake.source` `` |