### PR TITLE
chore(flake/nixos-hardware): `b493dfd4` -> `d0cb432a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1726905744,
-        "narHash": "sha256-xyNtG5C+xvfsnOVEamFe9zCCnuNwk93K/TlFC/4DmCI=",
+        "lastModified": 1727040444,
+        "narHash": "sha256-19FNN5QT9Z11ZUMfftRplyNN+2PgcHKb3oq8KMW/hDA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b493dfd4a8cf9552932179e56ff3b5819a9b8381",
+        "rev": "d0cb432a9d28218df11cbd77d984a2a46caeb5ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`230536ce`](https://github.com/NixOS/nixos-hardware/commit/230536ce884a14aab03518da71d417f57461805b) | `` update tests flake lock ``                   |
| [`cbcd0302`](https://github.com/NixOS/nixos-hardware/commit/cbcd0302c724608acbdbc6d1350c75014bcec272) | `` starfive visionfive2: use mainline kernel `` |