### PR TITLE
chore(flake/nixpkgs): `c04d5652` -> `9357f4f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -577,11 +577,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726755586,
-        "narHash": "sha256-PmUr/2GQGvFTIJ6/Tvsins7Q43KTMvMFhvG6oaYK+Wk=",
+        "lastModified": 1726937504,
+        "narHash": "sha256-bvGoiQBvponpZh8ClUcmJ6QnsNKw0EMrCQJARK3bI1c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c04d5652cfa9742b1d519688f65d1bbccea9eb7e",
+        "rev": "9357f4f23713673f310988025d9dc261c20e70c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                            |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`9357f4f2`](https://github.com/NixOS/nixpkgs/commit/9357f4f23713673f310988025d9dc261c20e70c6) | `` plexRaw: 1.40.5.8921-836b34c27 -> 1.41.0.8992-8463ad060 ``                                      |
| [`aa1433bb`](https://github.com/NixOS/nixpkgs/commit/aa1433bbe50da30269e90fab9f3a9c96eb2233cd) | `` organicmaps: 2024.08.16-5 -> 2024.09.08-7 ``                                                    |
| [`5a9dcfd1`](https://github.com/NixOS/nixpkgs/commit/5a9dcfd10ac62bfe826624aaf193a2c79d91b6ee) | `` nix-serve: 77ffa33d8 -> 0.0.2 (#343319) ``                                                      |
| [`790e9c6e`](https://github.com/NixOS/nixpkgs/commit/790e9c6e7b324b25549fe621777bd33e2cd7c3ce) | `` tippecanoe: 2.62.2 -> 2.62.3 ``                                                                 |
| [`1f9fc918`](https://github.com/NixOS/nixpkgs/commit/1f9fc918cedc855bd106696d9b2038a0dbdcf52c) | `` treewide: use pkgs.nixos-enter instead of config.system.build.nixos-enter ``                    |
| [`5dcbab6b`](https://github.com/NixOS/nixpkgs/commit/5dcbab6b74178077d22f7f716d1080d45e999439) | `` nixos/tools: continue cleanup ``                                                                |
| [`cb4e1988`](https://github.com/NixOS/nixpkgs/commit/cb4e198872c8925d13b4e45608caa3b952dc4cf2) | `` sing-box: 1.9.5 -> 1.9.6 ``                                                                     |
| [`110d71aa`](https://github.com/NixOS/nixpkgs/commit/110d71aa98372d68513578ebde4e4312c947db95) | `` sieve-editor-gui: init at 0.6.1 ``                                                              |
| [`f305e717`](https://github.com/NixOS/nixpkgs/commit/f305e717d38a278d533d3431efd71fcfdee1622d) | `` quartus-prime-lite: run tests with NIXPKGS_QUARTUS_REPRODUCIBLE_BUILD=1 ``                      |
| [`25ce61d6`](https://github.com/NixOS/nixpkgs/commit/25ce61d6f2196d33170f96bf7d3e54e31ce0337b) | `` quartus-prime-lite: implement the SOURCE_DATE_EPOCH specification ``                            |
| [`0bb32ac5`](https://github.com/NixOS/nixpkgs/commit/0bb32ac5ae6aab0cdf586700ef56b298c185c756) | `` labwc-menu-generator: 0.1.0-unstable-2024-07-09 -> 0.1.0-unstable-2024-09-19 ``                 |
| [`f7ed0918`](https://github.com/NixOS/nixpkgs/commit/f7ed0918af7fd24cb554891a4f8cb145acf018e3) | `` emacsPackages.zig-mode: replace program ``                                                      |
| [`a4a742b6`](https://github.com/NixOS/nixpkgs/commit/a4a742b6b6b65c570be2f723cbad0d467f5acc69) | `` maintainers: add fnune ``                                                                       |
| [`ca3c9deb`](https://github.com/NixOS/nixpkgs/commit/ca3c9deb90fd83a44d013b92c34e78c2383b4a2b) | `` kdeApplications.koi: init at 0.3.1 ``                                                           |
| [`e5d8c15c`](https://github.com/NixOS/nixpkgs/commit/e5d8c15cbfce36194e8516b633556cfe60e1d0b2) | `` python312Packages.pysqueezebox: refactor ``                                                     |
| [`67830228`](https://github.com/NixOS/nixpkgs/commit/67830228e3edad48eeb43174dd913908a5d03e15) | `` python312Packages.pysqueezebox: 0.8.1 -> 0.9.2 ``                                               |
| [`1f24291c`](https://github.com/NixOS/nixpkgs/commit/1f24291cc975207a21bdce471834ae94068541f1) | `` gitleaks: 8.19.0 -> 8.19.2 ``                                                                   |
| [`48991cb7`](https://github.com/NixOS/nixpkgs/commit/48991cb789c49641d985153d73f89d3995789783) | `` graphw00f: refactor ``                                                                          |
| [`7273a5d3`](https://github.com/NixOS/nixpkgs/commit/7273a5d35af744cf7b19dc0daa6daa8eb33544e5) | `` jx: 3.10.154 -> 3.10.155 ``                                                                     |
| [`c9f8285f`](https://github.com/NixOS/nixpkgs/commit/c9f8285f0566553fe9f4e6b829afd77d26ee7cb9) | `` nixos/nautilus-open-any-terminal: only set NAUTILUS_4_EXTENSION_DIR in non GNOME environment `` |
| [`a50a0a04`](https://github.com/NixOS/nixpkgs/commit/a50a0a046aad4019307554e0e2ca0fdae3567cd4) | `` s3scanner: 3.1.0 -> 3.1.1 ``                                                                    |
| [`991fd5f4`](https://github.com/NixOS/nixpkgs/commit/991fd5f4620bc4499e1ccd937afc9b60a11009dd) | `` nixos/yggdrasil: add nagy as maintainer ``                                                      |
| [`cb763561`](https://github.com/NixOS/nixpkgs/commit/cb7635612e5fe9b98eba671f85d4124d6d6feb16) | `` nixos/yggdrasil: remove `with lib;` ``                                                          |
| [`18337306`](https://github.com/NixOS/nixpkgs/commit/18337306f0c5d7a6b6975bfa334d0d3dfd1e4c30) | `` vscode: 1.93.0 -> 1.93.1 ``                                                                     |
| [`926d62de`](https://github.com/NixOS/nixpkgs/commit/926d62deca61e490803ce74fc3143883455c8d56) | `` graphw00f: 1.1.17 -> 1.1.18 ``                                                                  |
| [`745ca3a8`](https://github.com/NixOS/nixpkgs/commit/745ca3a8291eb71ae8cf87f7cc534cf78dff940e) | `` zoxide: 0.9.5 -> 0.9.6 ``                                                                       |
| [`1ded0c6d`](https://github.com/NixOS/nixpkgs/commit/1ded0c6d933a9049ff219c643c669bb936459458) | `` esphome: 2024.8.3 -> 2024.9.0 ``                                                                |
| [`f33dd654`](https://github.com/NixOS/nixpkgs/commit/f33dd654c669600569e67121717fc0db53e4ac7d) | `` python3Packages.nodriver: refactor to use fetchPypi ``                                          |
| [`6b72d38b`](https://github.com/NixOS/nixpkgs/commit/6b72d38b8a3733d52d1e0d90cb2e771128809b6f) | `` cloud-utils: 0.32 -> 0.33 ``                                                                    |
| [`e13ecfb1`](https://github.com/NixOS/nixpkgs/commit/e13ecfb12f4672a11a7831aba44d9a150f17a4d4) | `` python312Packages.pysmlight: 0.1.0 -> 0.1.1 ``                                                  |
| [`3ac00ab2`](https://github.com/NixOS/nixpkgs/commit/3ac00ab2f16cd714cab18261c95f900c30a4b40c) | `` weaver: 0.9.2 -> 0.10.0 ``                                                                      |
| [`634d74de`](https://github.com/NixOS/nixpkgs/commit/634d74deb091761622f03aaeaf30d6a32cfa9ef9) | `` ytarchive: 0.4.0 -> 0.5.0 ``                                                                    |
| [`e34095c3`](https://github.com/NixOS/nixpkgs/commit/e34095c332483daed597b10a8c11f46d8707f185) | `` redpanda-client: 24.2.4 -> 24.2.5 ``                                                            |
| [`33d7c222`](https://github.com/NixOS/nixpkgs/commit/33d7c2226c833e136e1143c87f08c0b2a9b36318) | `` python312Packages.langchain-ollama: init at 0.2.0 ``                                            |
| [`c7ad6be1`](https://github.com/NixOS/nixpkgs/commit/c7ad6be1aea142d960b73a87aadad498f02bfa0e) | `` python312Packages.yalesmartalarmclient: 0.4.2 -> 0.4.3 ``                                       |
| [`6b4efdfe`](https://github.com/NixOS/nixpkgs/commit/6b4efdfe2c1f0636fcf4298ff279d0930ca127ab) | `` python3Packages.zulip-emoji-mapping: remove python3Packages usage ``                            |
| [`3b6147c3`](https://github.com/NixOS/nixpkgs/commit/3b6147c39e3cc44af16606e22f6a97fa2f285357) | `` python312Packages.mitogen: 0.3.9 -> 0.3.10 ``                                                   |
| [`7bc8fbcb`](https://github.com/NixOS/nixpkgs/commit/7bc8fbcbe0b0abb8e2e4d1028dab3aefb11b8e30) | `` python312Packages.great-tables: 0.11.0 -> 0.11.1 ``                                             |
| [`78d6f58d`](https://github.com/NixOS/nixpkgs/commit/78d6f58d61143878d5b238e5d65c0c70ac7f82da) | `` python312Packages.faraday-agent-parameters-types: 1.7.0 -> 1.7.1 ``                             |
| [`c95656bd`](https://github.com/NixOS/nixpkgs/commit/c95656bd7ea4124422f97fea226ae03d573fa482) | `` parallel-hashmap: 1.3.12 -> 1.4.0 ``                                                            |
| [`2e5d14f5`](https://github.com/NixOS/nixpkgs/commit/2e5d14f50fbe16a3dd584e4493a021d1ae74bbce) | `` overskride: 0.5.7 -> 0.6.0 ``                                                                   |
| [`3fdf8a8f`](https://github.com/NixOS/nixpkgs/commit/3fdf8a8f68b98831a068736d220f920dca4460ed) | `` sourceHighlight: fix tests with llvm ``                                                         |
| [`bde47c66`](https://github.com/NixOS/nixpkgs/commit/bde47c6635d9fe17dbea590ad0faa79b47762ff9) | `` tanka: 0.27.1 -> 0.28.0 (#340060) ``                                                            |
| [`82ec7913`](https://github.com/NixOS/nixpkgs/commit/82ec791318c97e87a7a68c7dfc79dcb0fbd4c80b) | `` cirrus-cli: 0.126.0 -> 0.126.1 ``                                                               |
| [`c231f3ca`](https://github.com/NixOS/nixpkgs/commit/c231f3caeb5486756ed3e1b64fe2a1990d24ac8d) | `` twilio-cli: 5.22.0 -> 5.22.1 ``                                                                 |
| [`bebbda4e`](https://github.com/NixOS/nixpkgs/commit/bebbda4ec3d5ef6ac9af28ac240c713e651b70eb) | `` python312Packages.mozart-api: 3.4.1.8.7 -> 3.4.1.8.8 ``                                         |
| [`f8066873`](https://github.com/NixOS/nixpkgs/commit/f8066873a68a432166eb5f79736bc5b5038e2862) | `` mob: 5.1.1 -> 5.2.0 ``                                                                          |
| [`cce84343`](https://github.com/NixOS/nixpkgs/commit/cce8434364c11d9d77d8b6033c8070bb1cc17b8c) | `` python312Packages.ucsmsdk: 0.9.19 -> 0.9.20 ``                                                  |
| [`c9c79741`](https://github.com/NixOS/nixpkgs/commit/c9c7974117d15ba5e550cb1d3caf54f774f41065) | `` tmux-fingers: 2.1.1 -> 2.2.2 ``                                                                 |
| [`d073ded1`](https://github.com/NixOS/nixpkgs/commit/d073ded13384bd75dce5d2d3685d426f688c7821) | `` maintainers: add casaca ``                                                                      |
| [`9e4efdd7`](https://github.com/NixOS/nixpkgs/commit/9e4efdd76b3afadc1e1253271ba6765f2670123c) | `` klong: init at 20221212 ``                                                                      |
| [`acdaa52c`](https://github.com/NixOS/nixpkgs/commit/acdaa52c188e9509ad89e35b9726433faf06177c) | `` maintainers: add sshine ``                                                                      |
| [`619e9e20`](https://github.com/NixOS/nixpkgs/commit/619e9e200c01c582d4319c5ae4e5bf403f830a1b) | `` diagrams-as-code: fix build failure due to pyyaml constraint (#343308) ``                       |
| [`dc750b82`](https://github.com/NixOS/nixpkgs/commit/dc750b823725a2c13bf9f94b15e86c6e7e72864e) | `` postgresqlPackages.postgis: 3.4.2 -> 3.4.3 ``                                                   |
| [`74437ce9`](https://github.com/NixOS/nixpkgs/commit/74437ce96449c0140f0d8cfda31cd17b10d16f43) | `` rasm: 2.2.6 -> 2.2.7 ``                                                                         |
| [`cfe68dd6`](https://github.com/NixOS/nixpkgs/commit/cfe68dd60539225412eadbb720dac4c861d1d4db) | `` python312Packages.apkinspector: 1.3.1 -> 1.3.2 ``                                               |
| [`1bbe1fee`](https://github.com/NixOS/nixpkgs/commit/1bbe1fee60c10d628efbc639783197d1020c5463) | `` code-cursor: 0.40.0 -> 0.41.1 ``                                                                |
| [`415a29ab`](https://github.com/NixOS/nixpkgs/commit/415a29abac3b341a51277f72de7a04a6f9493c4d) | `` python312Packages.blockdiag: Disable failing test from dependency ``                            |
| [`fcd82800`](https://github.com/NixOS/nixpkgs/commit/fcd82800bc3f0a4d7cf94faeb2de780e1892092c) | `` woodpecker-plugin-git: 2.5.2 -> 2.6.0 ``                                                        |
| [`29ec9214`](https://github.com/NixOS/nixpkgs/commit/29ec9214c673301d789c6a36b7bbe5571bdb6d40) | `` python3Packages.rio-tiler: 6.6.1 -> 6.7.0 ``                                                    |
| [`c26ca03c`](https://github.com/NixOS/nixpkgs/commit/c26ca03c4d305f5a0615ed44cc0ff9a921ea83b6) | `` nixos/dnsmasq: remove deprecated option "extraConfig" ``                                        |
| [`95568022`](https://github.com/NixOS/nixpkgs/commit/95568022517fdc051fa153243d880eb9d3a5020a) | `` python312Packages.faraday-plugins: 1.19.0 -> 1.19.1 ``                                          |
| [`fb99290f`](https://github.com/NixOS/nixpkgs/commit/fb99290f193db7cd34542fc517c834eae0fa383a) | `` pritunl-client: 1.3.3785.81 -> 1.3.4026.10 ``                                                   |
| [`dca59258`](https://github.com/NixOS/nixpkgs/commit/dca59258343eb3da0da1c42a743dc644a9ff85ee) | `` python312Packages.pyosmium: modernize ``                                                        |
| [`cf7a6f79`](https://github.com/NixOS/nixpkgs/commit/cf7a6f79f101cbcdcb760e84c1f42c79c2faff23) | `` python312Packages.pyduotecno: 2024.5.1 -> 2024.9.0 ``                                           |
| [`00347a54`](https://github.com/NixOS/nixpkgs/commit/00347a54a72af384172552fead611d0727303be0) | `` showmethekey: 1.13.1 -> 1.14.0 ``                                                               |
| [`c04358b8`](https://github.com/NixOS/nixpkgs/commit/c04358b80fa153912d99e1a39f10ea1ed1887f0c) | `` python3Packages.notobuilder: init at 0-unstable-2024-08-03 ``                                   |
| [`4b585d51`](https://github.com/NixOS/nixpkgs/commit/4b585d516135533526d01f3f344bc48f01b27500) | `` python312Packages.python-gnupg: 0.5.2 -> 0.5.3 ``                                               |
| [`00cc3523`](https://github.com/NixOS/nixpkgs/commit/00cc352311acebecf0cbb487edc3e27388853281) | `` hoppscotch: fix meta.changelog ``                                                               |
| [`2f1d85fa`](https://github.com/NixOS/nixpkgs/commit/2f1d85fa7318af9a28dd6fd7b9867af595a3138e) | `` python312Packages.pyosmium: 3.7.0 -> 4.0.0 ``                                                   |
| [`80cafc99`](https://github.com/NixOS/nixpkgs/commit/80cafc9988961a538e76ed2e484d6f7d5fff4ae2) | `` protoc-gen-connect-go: 1.16.2 -> 1.17.0 ``                                                      |
| [`1bef9437`](https://github.com/NixOS/nixpkgs/commit/1bef9437362c8fd63c2901ddfb8512872f03943e) | `` prometheus-elasticsearch-exporter: 1.7.0 -> 1.8.0 ``                                            |
| [`e235e390`](https://github.com/NixOS/nixpkgs/commit/e235e390ce122fce104391f73d89876c6282cb36) | `` python3Packages.mapclassify: 2.6.1 -> 2.8.0 ``                                                  |
| [`2ed0caae`](https://github.com/NixOS/nixpkgs/commit/2ed0caae234def089c1149a71112db25ba07ff59) | `` geesefs: 0.41.2 -> 0.41.3 ``                                                                    |
| [`c602e93d`](https://github.com/NixOS/nixpkgs/commit/c602e93db66674d51c1086733582fb58df643d34) | `` hyprland-workspaces: 2.0.1 -> 2.0.2 ``                                                          |
| [`43562226`](https://github.com/NixOS/nixpkgs/commit/43562226127965e388e7e66f9af6b3225850c68d) | `` githooks: 3.0.2 -> 3.0.3 ``                                                                     |
| [`3115573f`](https://github.com/NixOS/nixpkgs/commit/3115573f29eee151e6a72481c3fc89bb2e328350) | `` zutty: init at 0.16-unstable-2024-08-18 ``                                                      |
| [`32561135`](https://github.com/NixOS/nixpkgs/commit/325611350ccfde0f7200c37afc5923905d499fc3) | `` microsoft-edge: 128.0.2739.67 -> 129.0.2792.52 ``                                               |
| [`0f6ced7f`](https://github.com/NixOS/nixpkgs/commit/0f6ced7fefbef98eadbdd73f57c53a316a64b061) | `` nixos-install: add meta ``                                                                      |
| [`95d65298`](https://github.com/NixOS/nixpkgs/commit/95d652982dfbe623802834d2ded878c92c113613) | `` nix-enter: add meta ``                                                                          |
| [`1b414a4a`](https://github.com/NixOS/nixpkgs/commit/1b414a4a0be338d6d2cab1bf9a2934b44846c3fd) | `` python3Packages.langchain*: Move  dependencies of langchain-core to a common update script ``   |
| [`727404bb`](https://github.com/NixOS/nixpkgs/commit/727404bba32d4a4b386f9a31ad8b67f67e4b5963) | `` vimPlugins.earthly-vim: init at 2024-04-02 ``                                                   |
| [`54a555af`](https://github.com/NixOS/nixpkgs/commit/54a555af496c1fbbab02a459be753ce8cfc436af) | `` papertrail: testVersion ``                                                                      |
| [`ebb35da6`](https://github.com/NixOS/nixpkgs/commit/ebb35da60b9c89323812315a530b2ccbe728e697) | `` papertrail: 0.10.1 -> 0.11.2 ``                                                                 |
| [`8acb9188`](https://github.com/NixOS/nixpkgs/commit/8acb91888a909cf41d13932c25e3e52c2a6d16b3) | `` arc-browser: 1.58.1-53264 -> 1.61.0-53949 ``                                                    |
| [`f10c881e`](https://github.com/NixOS/nixpkgs/commit/f10c881e74d35a68d0069c87cf9f36a081e6ce1c) | `` clightning: 24.08 -> 24.08.1 ``                                                                 |