### PR TITLE
chore(flake/disko): `49b22d48` -> `b1d6bed2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727086915,
-        "narHash": "sha256-mqoWnKQRbA3AsyW9cg9ttqKvOY0IvdEz+/lf1qwsKnE=",
+        "lastModified": 1727097838,
+        "narHash": "sha256-URruiiuIyKzao6QcGXQXFaX3RRvlNFHHm19uOGmB0Dw=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "49b22d486c2bd1ce3102881c948e58c14b58152a",
+        "rev": "b1d6bed240abef5f5373e88fc7909f493013e557",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                     |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`b1d6bed2`](https://github.com/nix-community/disko/commit/b1d6bed240abef5f5373e88fc7909f493013e557) | `` interactive-vm: use host pkgs in the launcher script. `` |
| [`e72de070`](https://github.com/nix-community/disko/commit/e72de0702d21b62ffd384b6da4ba46a274242458) | `` add workaround for failing zpool import test ``          |