### PR TITLE
chore(flake/lovesegfault-vim-config): `3215f516` -> `22c38239`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726963811,
-        "narHash": "sha256-cS5Y+I3/B0aWNGMZcxm5gRrwk/a8drje9erygDI9xSo=",
+        "lastModified": 1727137824,
+        "narHash": "sha256-uk6BRpdpSTfb0+uxtg1tAWJhB7nq8jGjKTD8VfnVGR8=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "3215f5168d2848a8f3fa35d1b066902dedebb3ea",
+        "rev": "22c382398e3e97e9c13ef28af0afcf72e1fa6c71",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726950811,
-        "narHash": "sha256-3ixqPAhMafMP70M4VjOKoLeCCNIvzv2WPzGuphxajcM=",
+        "lastModified": 1727118532,
+        "narHash": "sha256-nRzlwdPaSb1UCoqndT52AUNpx9e8wLCEjY28eAkCHIg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2bc6a949924319f61619d32695115a61394741f8",
+        "rev": "47364df49645e89d8aa03aa61c893e12ecbac366",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`22c38239`](https://github.com/lovesegfault/vim-config/commit/22c382398e3e97e9c13ef28af0afcf72e1fa6c71) | `` chore(flake/nixpkgs): c04d5652 -> 9357f4f2 `` |
| [`83a15b9f`](https://github.com/lovesegfault/vim-config/commit/83a15b9f5f8e5bfcaf44241fc0df85b31a1be629) | `` chore(flake/nixvim): b473bdc5 -> 47364df4 ``  |
| [`92faa9a7`](https://github.com/lovesegfault/vim-config/commit/92faa9a746be19530212f989bf1f62fb913a0449) | `` fix: enable web-devicons explicitly ``        |
| [`1c3b268e`](https://github.com/lovesegfault/vim-config/commit/1c3b268e0e3d0ac7cb3f84c516e678ae82429acc) | `` chore(flake/nixvim): 2bc6a949 -> b473bdc5 ``  |