### PR TITLE
chore(flake/disko): `b1d6bed2` -> `c61e50b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727097838,
-        "narHash": "sha256-URruiiuIyKzao6QcGXQXFaX3RRvlNFHHm19uOGmB0Dw=",
+        "lastModified": 1727156717,
+        "narHash": "sha256-Ef7UgoTdOB4PGQKSkHGu6SOxnTiArPHGcRf8qGFC39o=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "b1d6bed240abef5f5373e88fc7909f493013e557",
+        "rev": "c61e50b63ad50dda5797b1593ad7771be496efbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                       |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`6d2914c6`](https://github.com/nix-community/disko/commit/6d2914c62c5ca27276b75f1cc75e11356984cb0b) | `` Add binlore for disko and disko-install `` |