### PR TITLE
chore(flake/lovesegfault-vim-config): `f1cc1f3b` -> `a83bf1f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727223134,
-        "narHash": "sha256-yMzJ9E2HmG1E/OCTGWvnDgL+INpYF50lc9Yko/VlZPc=",
+        "lastModified": 1727309634,
+        "narHash": "sha256-diABCoX0jaqNQpwGJ9UGTDorBgK08AioEYsSSe2R+ro=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "f1cc1f3bed7fccf75e2de1d9dd10da4b845ebf79",
+        "rev": "a83bf1f85437ee8205fd08d4a65c5c2e10ca78ac",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727186381,
-        "narHash": "sha256-T6vSJAvbYSBsaUkwh2adbIt7liE2xpcRhmlosMNZnDo=",
+        "lastModified": 1727286212,
+        "narHash": "sha256-iab+k8m6+MBkwQoyqMcMYggwILHCkMSkgNYd1GN0FbM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8f991cc8bc417ddbd1d5c7732268255557c13f4a",
+        "rev": "7bda0f1ce49e9da252bcee20b5f700e6dcd3cf8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`a83bf1f8`](https://github.com/lovesegfault/vim-config/commit/a83bf1f85437ee8205fd08d4a65c5c2e10ca78ac) | `` chore(flake/treefmt-nix): 35dfece1 -> 1bff2ba6 `` |
| [`b43ad19d`](https://github.com/lovesegfault/vim-config/commit/b43ad19d67eaa80cf0cb567f4de363a9f3d22926) | `` chore(flake/nixvim): 8f991cc8 -> 7bda0f1c ``      |