### PR TITLE
chore(flake/disko): `c1c472f4` -> `1879e489`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727249977,
-        "narHash": "sha256-lAqOCDI4B6hA+t+KHSm/Go8hQF/Ob5sgXaIRtMAnMKw=",
+        "lastModified": 1727347829,
+        "narHash": "sha256-y7cW6TjJKy+tu7efxeWI6lyg4VVx/9whx+OmrhmRShU=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "c1c472f4cd91e4b0703e02810a8c7ed30186b6fa",
+        "rev": "1879e48907c14a70302ff5d0539c3b9b6f97feaa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                         |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`18c5410f`](https://github.com/nix-community/disko/commit/18c5410fdfa506cab20e678c58a4fecfd1d47006) | `` make-disk-image: use memSize as default build-memory in diskoImagesScript `` |