### PR TITLE
chore(flake/disko): `1879e489` -> `67dc29be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727347829,
-        "narHash": "sha256-y7cW6TjJKy+tu7efxeWI6lyg4VVx/9whx+OmrhmRShU=",
+        "lastModified": 1727359191,
+        "narHash": "sha256-5PltTychnExFwzpEnY3WhOywaMV/M6NxYI/y3oXuUtw=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "1879e48907c14a70302ff5d0539c3b9b6f97feaa",
+        "rev": "67dc29be3036cc888f0b9d4f0a788ee0f6768700",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                      |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`72c867c4`](https://github.com/nix-community/disko/commit/72c867c4396b4ba81de13049191210b6ff065702) | `` Run nix fmt ``                            |
| [`4c4c869c`](https://github.com/nix-community/disko/commit/4c4c869c2de0fe697ec1e3a50f245c8f31f8b49a) | `` flake: add --check option to formatter `` |