### PR TITLE
chore(flake/home-manager): `853e7bd2` -> `ffe2d07e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727381010,
-        "narHash": "sha256-2PqUwnZXjYiPUm5A4d8Z31mvLS4lvUeV/9gUhSMmNR4=",
+        "lastModified": 1727383923,
+        "narHash": "sha256-4/vacp3CwdGoPf8U4e/N8OsGYtO09WTcQK5FqYfJbKs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "853e7bd24f875bac2e3a0cf72f993e917d0f8cf5",
+        "rev": "ffe2d07e771580a005e675108212597e5b367d2d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`ffe2d07e`](https://github.com/nix-community/home-manager/commit/ffe2d07e771580a005e675108212597e5b367d2d) | `` direnv: hopefully final nushell fix ``          |
| [`0afc2f0f`](https://github.com/nix-community/home-manager/commit/0afc2f0f19470e45a3941926a330f2db55ac2fbf) | `` river: reduce risk of large rebuilds in test `` |