### PR TITLE
chore(flake/lovesegfault-vim-config): `a83bf1f8` -> `8ba5f379`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727309634,
-        "narHash": "sha256-diABCoX0jaqNQpwGJ9UGTDorBgK08AioEYsSSe2R+ro=",
+        "lastModified": 1727396034,
+        "narHash": "sha256-y3a3296dsRSURHqtf/XnLdhGU6lgGS5VigUWIAH3mB4=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "a83bf1f85437ee8205fd08d4a65c5c2e10ca78ac",
+        "rev": "8ba5f379fa2668ae4aed4de8fac2278a2a9eae02",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727286212,
-        "narHash": "sha256-iab+k8m6+MBkwQoyqMcMYggwILHCkMSkgNYd1GN0FbM=",
+        "lastModified": 1727370276,
+        "narHash": "sha256-CgMTCzKYilIzRSTCrui/4OvMj3yYXjPV+uSFPT9d2MM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7bda0f1ce49e9da252bcee20b5f700e6dcd3cf8d",
+        "rev": "6a1bf6bdc30e0d92139165d30977db9d6ace4c69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`8ba5f379`](https://github.com/lovesegfault/vim-config/commit/8ba5f379fa2668ae4aed4de8fac2278a2a9eae02) | `` chore(flake/nixpkgs): 9357f4f2 -> 30439d93 `` |
| [`5fa1c022`](https://github.com/lovesegfault/vim-config/commit/5fa1c022df9bc71fda4e90b384f013980984fcf0) | `` chore(flake/nixvim): 7bda0f1c -> 6a1bf6bd ``  |