### PR TITLE
chore(flake/treefmt-nix): `1bff2ba6` -> `879b29ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -793,11 +793,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727252110,
-        "narHash": "sha256-3O7RWiXpvqBcCl84Mvqa8dXudZ1Bol1ubNdSmQt7nF4=",
+        "lastModified": 1727431250,
+        "narHash": "sha256-uGRlRT47ecicF9iLD1G3g43jn2e+b5KaMptb59LHnvM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "1bff2ba6ec22bc90e9ad3f7e94cca0d37870afa3",
+        "rev": "879b29ae9a0378904fbbefe0dadaed43c8905754",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                               |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`879b29ae`](https://github.com/numtide/treefmt-nix/commit/879b29ae9a0378904fbbefe0dadaed43c8905754) | `` feat: add nixfmt-classic (#238) `` |