### PR TITLE
chore(flake/nixos-hardware): `d0cb432a` -> `d830ad47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1727040444,
-        "narHash": "sha256-19FNN5QT9Z11ZUMfftRplyNN+2PgcHKb3oq8KMW/hDA=",
+        "lastModified": 1727437159,
+        "narHash": "sha256-v4qLwEw5OmprgQZTT7KZMNU7JjXJzRypw8+Cw6++fWk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d0cb432a9d28218df11cbd77d984a2a46caeb5ac",
+        "rev": "d830ad47cc992b4a46b342bbc79694cbd0e980b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`d830ad47`](https://github.com/NixOS/nixos-hardware/commit/d830ad47cc992b4a46b342bbc79694cbd0e980b2) | `` feat: add galp5-1650 ``                                                         |
| [`f4d60b37`](https://github.com/NixOS/nixos-hardware/commit/f4d60b3777bef2b3f11d5c87c78d5c4b510145cb) | `` Remove fonts.fontconfig.dpi in Lenovo Thinkpad X1 6th Gen QHD ``                |
| [`8d839c16`](https://github.com/NixOS/nixos-hardware/commit/8d839c167229210efb80697fdbb59a440afb980a) | `` only incrase font size for older kernel ``                                      |
| [`b169e35b`](https://github.com/NixOS/nixos-hardware/commit/b169e35bee1f6f2184b3de4984b828e59d27fee6) | `` asus-rog-strix-x570: add troubleshooting notice for bluetooth device missing `` |