### PR TITLE
chore(flake/lovesegfault-vim-config): `8ba5f379` -> `f4329332`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727396034,
-        "narHash": "sha256-y3a3296dsRSURHqtf/XnLdhGU6lgGS5VigUWIAH3mB4=",
+        "lastModified": 1727482416,
+        "narHash": "sha256-AsjPFZVGm23xL2Tzb+RG913Z0XI05Xi4hR00V8qC+uY=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "8ba5f379fa2668ae4aed4de8fac2278a2a9eae02",
+        "rev": "f432933228f6a631d960db3628fb5d8773909646",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727370276,
-        "narHash": "sha256-CgMTCzKYilIzRSTCrui/4OvMj3yYXjPV+uSFPT9d2MM=",
+        "lastModified": 1727471696,
+        "narHash": "sha256-3r/VNQp5aJK9Gj8hKdfSYqeXcc0kqpfFYhEg8ioWttE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6a1bf6bdc30e0d92139165d30977db9d6ace4c69",
+        "rev": "b5c19b6abb0fb0156b1cb76793b363e430e2cb47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`f4329332`](https://github.com/lovesegfault/vim-config/commit/f432933228f6a631d960db3628fb5d8773909646) | `` chore(flake/treefmt-nix): 1bff2ba6 -> 879b29ae `` |
| [`fec70dab`](https://github.com/lovesegfault/vim-config/commit/fec70dabff2aa89b0993ad8582d9d1890f24667c) | `` chore(flake/nixvim): 6a1bf6bd -> b5c19b6a ``      |