### PR TITLE
chore(flake/nixos-hardware): `d830ad47` -> `c1f051bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1727437159,
-        "narHash": "sha256-v4qLwEw5OmprgQZTT7KZMNU7JjXJzRypw8+Cw6++fWk=",
+        "lastModified": 1727528503,
+        "narHash": "sha256-wZd8OqPeQt9h7VU2VxsW4Vx0Ze+3hDLHql3pNbIMYEU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d830ad47cc992b4a46b342bbc79694cbd0e980b2",
+        "rev": "c1f051bf032273b9f0e707c8826eb25122d279fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`c1f051bf`](https://github.com/NixOS/nixos-hardware/commit/c1f051bf032273b9f0e707c8826eb25122d279fa) | `` Add 'mkDefault' to several settings for Asus Zephyrus GA402X ``             |
| [`1c62abd2`](https://github.com/NixOS/nixos-hardware/commit/1c62abd2dd79652fedebebe196ed194a4573f573) | `` Disable USB wakeup on the 8295 ITE Device on Asus Zephyrus GA402X laptop `` |