### PR TITLE
chore(flake/nix-index-database): `c7515c2f` -> `a2ab1588`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -547,11 +547,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726975622,
-        "narHash": "sha256-bPDZosnom0+02ywmMZAvmj7zvsQ6mVv/5kmvSgbTkaY=",
+        "lastModified": 1727580512,
+        "narHash": "sha256-gEWoJ+027OwsNs6f1GkDPrCxBFr5Vky7vWKjHRJi60s=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "c7515c2fdaf2e1f3f49856cef6cec95bb2138417",
+        "rev": "a2ab1588541ae442bd3a682f8f6bbcbca2672f10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`a2ab1588`](https://github.com/nix-community/nix-index-database/commit/a2ab1588541ae442bd3a682f8f6bbcbca2672f10) | `` update generated.nix to release 2024-09-29-031659 `` |
| [`41c3f28c`](https://github.com/nix-community/nix-index-database/commit/41c3f28cd02b19a4a728d97ac1827353b90e3e36) | `` flake.lock: Update ``                                |