### PR TITLE
chore(flake/nixos-hardware): `fb08bde0` -> `8e8c6cba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1727540359,
-        "narHash": "sha256-U+225h1kJZpWb23+RaX1sBkqC4fA7aa7eBbgiQ5HcO4=",
+        "lastModified": 1727595438,
+        "narHash": "sha256-bAvkJYuZKeDwW/J/Ga/axplEbYbQhq6jdQBVdGcpuO8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "fb08bde00c20252b892a3e57fb094eb62b65ba61",
+        "rev": "8e8c6cbad12ef805268b4e380a7298fbc275898d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                          |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`8e8c6cba`](https://github.com/NixOS/nixos-hardware/commit/8e8c6cbad12ef805268b4e380a7298fbc275898d) | `` Add new profile for HP Laptop 14s dq2024nf `` |