### PR TITLE
chore(flake/nixos-hardware): `8e8c6cba` -> `e88d3715`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1727595438,
-        "narHash": "sha256-bAvkJYuZKeDwW/J/Ga/axplEbYbQhq6jdQBVdGcpuO8=",
+        "lastModified": 1727598569,
+        "narHash": "sha256-xGn/LxSQ+Ujnoeupc1ZzdQNal9qceHETcIGfwBZvz7Y=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "8e8c6cbad12ef805268b4e380a7298fbc275898d",
+        "rev": "e88d37154f74e2bc2545514612dd20a16bb3e2f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                      |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`e88d3715`](https://github.com/NixOS/nixos-hardware/commit/e88d37154f74e2bc2545514612dd20a16bb3e2f0) | `` Framework 16: use upstream libinput keyboard detection `` |