### PR TITLE
chore(flake/nixos-hardware): `e88d3715` -> `f5c239fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1727598569,
-        "narHash": "sha256-xGn/LxSQ+Ujnoeupc1ZzdQNal9qceHETcIGfwBZvz7Y=",
+        "lastModified": 1727613673,
+        "narHash": "sha256-qqIffTQfxMYo3MKQ9BoY2s2mdKZNnUiksdnxv81js9U=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e88d37154f74e2bc2545514612dd20a16bb3e2f0",
+        "rev": "f5c239fa9acb27f0a5326ba2949c00fada89ca9f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`f5c239fa`](https://github.com/NixOS/nixos-hardware/commit/f5c239fa9acb27f0a5326ba2949c00fada89ca9f) | `` asus/zephyrus/ga402x/shared.nix: no need to override default of mkEnableOption `` |
| [`1bc47d8a`](https://github.com/NixOS/nixos-hardware/commit/1bc47d8abfb98fda9e90d357d14abded85163b6c) | `` asus/zenbook/ux371: enable xe driver explicitly ``                                |
| [`9fe0e21c`](https://github.com/NixOS/nixos-hardware/commit/9fe0e21c9936c1078427bc95f2f6a6d6d281ff75) | `` thinkpad/x1-extreme/gen3: add module ``                                           |
| [`25e16f6c`](https://github.com/NixOS/nixos-hardware/commit/25e16f6c661d71d0cc2e2818c59a0c254fde9f2a) | `` Framework 16: udev rules for keyboard config ``                                   |