### PR TITLE
chore(flake/lovesegfault-vim-config): `92b2c8b4` -> `9ea2edc4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727704259,
-        "narHash": "sha256-z3I9EzqyuBkUsuJVY6jAeH2uiZVrVyMZVrNVB5wvpZ8=",
+        "lastModified": 1727741392,
+        "narHash": "sha256-LGbS3VpQsZ+XK3df6Xgqfbbv1z2Sml2DwnncwIEsx+0=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "92b2c8b4b305d8966a0fa535cd2d1b4dfba2c850",
+        "rev": "9ea2edc4f3721607176857f5a5f0e945a8454060",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`9ea2edc4`](https://github.com/lovesegfault/vim-config/commit/9ea2edc4f3721607176857f5a5f0e945a8454060) | `` chore(flake/nixpkgs): 1925c603 -> 06cf0e1d `` |