### PR TITLE
chore(flake/disko): `b709e1cc` -> `037be889`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727531434,
-        "narHash": "sha256-b+GBgCWd2N6pkiTkRZaMFOPztPO4IVTaclYPrQl2uLk=",
+        "lastModified": 1727804056,
+        "narHash": "sha256-tX4LGnq/DKwIykL6nApPiKSOs4K4L87L++kteRQRpRs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "b709e1cc33fcde71c7db43850a55ebe6449d0959",
+        "rev": "037be88911eeebc756a5fa2f48ca7a80ca09c49a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                          |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`4e30bc79`](https://github.com/nix-community/disko/commit/4e30bc7921b913b66cd22fa7f0f0371d6519907b) | `` zfs-with-vdevs: increase pool import timeout ``                               |
| [`fc3ba698`](https://github.com/nix-community/disko/commit/fc3ba6985ff1d636b2ed5fda6553ebc7f1ed0c95) | `` only set boot.initrd.preDeviceCommands if we boot with script-based stage1 `` |
| [`91cd0916`](https://github.com/nix-community/disko/commit/91cd091669c469a4ba7f2934d52cdb646e37c0bd) | `` zpool: fix default value for cache ``                                         |