### PR TITLE
chore(flake/disko): `037be889` -> `6c5ba9ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727804056,
-        "narHash": "sha256-tX4LGnq/DKwIykL6nApPiKSOs4K4L87L++kteRQRpRs=",
+        "lastModified": 1727809780,
+        "narHash": "sha256-7W5HE2IRiZglMBKcn9JtC6bveE6/F7IzQyV2XDanGFA=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "037be88911eeebc756a5fa2f48ca7a80ca09c49a",
+        "rev": "6c5ba9ec9d470c1ca29e7735762c9c366e28f7f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                 |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`b9c99485`](https://github.com/nix-community/disko/commit/b9c99485aa0c6fb4021cbb4a7556b832ac6d8c65) | `` Fix and comment luks-encrypted btrfs raid example `` |
| [`ba436edc`](https://github.com/nix-community/disko/commit/ba436edc9dafb10733d00b1da5fcb0415c4d9f46) | `` Test luks-encrypted btrfs raid ``                    |
| [`c312692a`](https://github.com/nix-community/disko/commit/c312692abe6441fc8e9ac21f76a607e9f2cfb3f7) | `` Create luks-btrfs-raid.nix ``                        |