### PR TITLE
chore(flake/lovesegfault-vim-config): `9ea2edc4` -> `81103783`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727741392,
-        "narHash": "sha256-LGbS3VpQsZ+XK3df6Xgqfbbv1z2Sml2DwnncwIEsx+0=",
+        "lastModified": 1727827867,
+        "narHash": "sha256-ZUofZgxxZ7V9q7d2vrGSC/oARmzV9Z0LxdLeue5eKNY=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "9ea2edc4f3721607176857f5a5f0e945a8454060",
+        "rev": "81103783792f4984e2012fb992df1f730da1e84f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`81103783`](https://github.com/lovesegfault/vim-config/commit/81103783792f4984e2012fb992df1f730da1e84f) | `` chore(flake/git-hooks): 85f7a717 -> 2f5ae3fc ``   |
| [`462fc9ee`](https://github.com/lovesegfault/vim-config/commit/462fc9eecc3761b37f498db77661ccf4c664906b) | `` chore(flake/flake-parts): bcef6817 -> 3d04084d `` |