### PR TITLE
chore(flake/disko): `da8f4924` -> `568727a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727856734,
-        "narHash": "sha256-YGKkZJGZiopMia83mf04zbK2p2OHdtbyJq05jkmGGis=",
+        "lastModified": 1727872461,
+        "narHash": "sha256-4Pw3fVhN6xey5+2gUBm9nQJAjBqivffr+a5ZsXYjzJ8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "da8f49246ce226b70feaf132d9b73a4cb7595f10",
+        "rev": "568727a884ae7cd9f266bd19aea655def8cafd78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                          |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`568727a8`](https://github.com/nix-community/disko/commit/568727a884ae7cd9f266bd19aea655def8cafd78) | `` build(deps): bump cachix/install-nix-action from V28 to 29 `` |
| [`fa0c181a`](https://github.com/nix-community/disko/commit/fa0c181a83ea8e8dc3eb5e632f2cd7a2bf5e51ea) | `` docs: Fix grammar in offline installer ``                     |