### PR TITLE
chore(flake/treefmt-nix): `a10a0cbe` -> `4446c7a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -793,11 +793,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727941393,
-        "narHash": "sha256-GFOQZDSvF0l6Jp8DdCW8qW8oR5hR0XjdvHFkmSan1Vo=",
+        "lastModified": 1727984844,
+        "narHash": "sha256-xpRqITAoD8rHlXQafYZOLvUXCF6cnZkPfoq67ThN0Hc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "a10a0cbe2196120aa90e4f86d459376e1d108d58",
+        "rev": "4446c7a6fc0775df028c5a3f6727945ba8400e64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                      |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`4446c7a6`](https://github.com/numtide/treefmt-nix/commit/4446c7a6fc0775df028c5a3f6727945ba8400e64) | `` zig: include .zon (#244) ``                               |
| [`861c66dd`](https://github.com/numtide/treefmt-nix/commit/861c66ddc5f45e39a831222adeda3c0325c4e1b1) | `` buildifier: include all .bazel files by default (#245) `` |