### PR TITLE
chore(flake/darwin): `f61d5f20` -> `8c8388ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727707210,
-        "narHash": "sha256-8XZp5XO2FC6INZEZ2WlwErtvFVpl45ACn8CJ2hfTA0Y=",
+        "lastModified": 1727999297,
+        "narHash": "sha256-LTJuQPCsSItZ/8TieFeP30iY+uaLoD0mT0tAj1gLeyQ=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "f61d5f2051a387a15817007220e9fb3bbead57b3",
+        "rev": "8c8388ade72e58efdeae71b4cbb79e872c23a56b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                            |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
| [`239d8028`](https://github.com/LnL7/nix-darwin/commit/239d802869a30bb45d4403e8f63a57a61f6910d9) | `` netdata: add netdata service in nix-darwin. ``                                  |
| [`2893a1bc`](https://github.com/LnL7/nix-darwin/commit/2893a1bcf71891c1db934773bc3c7ed46b0a1448) | `` push change to jankyborders test ``                                             |
| [`5cd99952`](https://github.com/LnL7/nix-darwin/commit/5cd9995215f0bc183811f0e4be017afa9a9a5e56) | `` Update modules/services/jankyborders/default.nix ``                             |
| [`af95f7b7`](https://github.com/LnL7/nix-darwin/commit/af95f7b7ec80811cd5662d6b08b45f0160c85d1d) | `` add JankyBorders option order and set below by default (values: above/below) `` |