### PR TITLE
chore(flake/nixos-hardware): `11c43c83` -> `b7ca02c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1727665282,
-        "narHash": "sha256-oKtfbQB1MBypqIyzkC8QCQcVGOa1soaXaGgcBIoh14o=",
+        "lastModified": 1728056216,
+        "narHash": "sha256-IrO06gFUDTrTlIP3Sz+mRB6WUoO2YsgMtOD3zi0VEt0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "11c43c830e533dad1be527ecce379fcf994fbbb5",
+        "rev": "b7ca02c7565fbf6d27ff20dd6dbd49c5b82eef28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`b7ca02c7`](https://github.com/NixOS/nixos-hardware/commit/b7ca02c7565fbf6d27ff20dd6dbd49c5b82eef28) | `` add dell xps 9315 ``                                        |
| [`a53ca667`](https://github.com/NixOS/nixos-hardware/commit/a53ca667df44b1e02659f73f720bb20fc4b202bd) | `` lenovo/thinkpad/t480s: add hardware acceleration support `` |
| [`7200fdc7`](https://github.com/NixOS/nixos-hardware/commit/7200fdc70facade9676f8548de37ab23f71a4687) | `` comon/gpu/intel: Add VAAPI support for older iGPUs ``       |