### PR TITLE
chore(flake/disko): `57440000` -> `48ebb577`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727977578,
-        "narHash": "sha256-DBORKcmQ7ZjA4qE1MsnF1MmZSokOGrw4W9vTCioOv2U=",
+        "lastModified": 1728109432,
+        "narHash": "sha256-wmbErh8FG7dRKOtMMpHUqDtFjeqt9Zjx4zssSeTalwU=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "574400001b3ffe555c7a21e0ff846230759be2ed",
+        "rev": "48ebb577855fb2398653f033b3b2208a9249203d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                           |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`48ebb577`](https://github.com/nix-community/disko/commit/48ebb577855fb2398653f033b3b2208a9249203d) | `` docs/interactive-vms: simplify usage to just one nix run ``    |
| [`28c5af1e`](https://github.com/nix-community/disko/commit/28c5af1e16f4f34ad1a2c0356f20f5742857789d) | `` interactive-vm: allow to override virtualisation.memorySize `` |