### PR TITLE
chore(flake/lovesegfault-vim-config): `af31a493` -> `6fc87452`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728000518,
-        "narHash": "sha256-Y0pocjCAhD5mvDKykwIEyYltg5LDdlgZ8mgd4PbwQx0=",
+        "lastModified": 1728173527,
+        "narHash": "sha256-5XQ8uwQDyy7boE8y1y8CvbENvuHZ6UCtJaHv/ut3OPk=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "af31a493ce3062619ab9b2c25d988f572fba0e8e",
+        "rev": "6fc8745297a8f2514ab6123f21cd624ed1d82322",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                            |
| -------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`6fc87452`](https://github.com/lovesegfault/vim-config/commit/6fc8745297a8f2514ab6123f21cd624ed1d82322) | `` chore(flake/nixpkgs): 06cf0e1d -> bc947f54 ``   |
| [`2088ae46`](https://github.com/lovesegfault/vim-config/commit/2088ae46e70c87e9980fb2a22fb9288b8b97d702) | `` chore(flake/git-hooks): 5f58871c -> 1211305a `` |