### PR TITLE
chore(flake/lovesegfault-vim-config): `4600f863` -> `afd8ff57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728259749,
-        "narHash": "sha256-DCOwynocKQpfKFMDLYeDwejP0kRqpdnZMTHP6yQP24k=",
+        "lastModified": 1728346085,
+        "narHash": "sha256-R10aFXDkqC00BLzld34Y4lsYFZyE/d26o2mxESwIC6E=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "4600f863795b8d45c5bde614541567586555d5c7",
+        "rev": "afd8ff57f9745ac15082f9df1281609323f720c7",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728245494,
-        "narHash": "sha256-bulK/Z+SEJaHM2PPk7W/kRvO51Ag9bTebcaWai9EEJc=",
+        "lastModified": 1728336850,
+        "narHash": "sha256-2RcPY41+UopyGwrPmsAFJC6CCobuuz4sNemC5cMb5GY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "33d030d23c9b88bb29e300d702aade58c3734612",
+        "rev": "abc7f450adc3b12d66c451972b1876d5194644bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`afd8ff57`](https://github.com/lovesegfault/vim-config/commit/afd8ff57f9745ac15082f9df1281609323f720c7) | `` chore(flake/nixvim): 33d030d2 -> abc7f450 `` |