### PR TITLE
chore(flake/lovesegfault-vim-config): `9cbe04cc` -> `d4aae470`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728484948,
-        "narHash": "sha256-8Tp/VO8IFzeiQWpbzVFADGCyxxt8yC6flwAeeTkHbN8=",
+        "lastModified": 1728518926,
+        "narHash": "sha256-f68ZI8j/WvbzEl+D1TBKV1McDR8QclkTttNnyZdQvDI=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "9cbe04cc7d549cf4359887dfc75d448c700150d7",
+        "rev": "d4aae470a6a90b720f9d931e8eaea0969f13a180",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728428263,
-        "narHash": "sha256-TG/ojDMLuLJI4nEo0waZawgAq4r30n7xJ8klEKpFcd0=",
+        "lastModified": 1728485062,
+        "narHash": "sha256-+2e9hAM2GVDF3gywdQI/OA7s4f0Z9rvFuiVxePI41QM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "eda14029813906b1ef355823de237d86fea59908",
+        "rev": "61ec39764fbe1e4f21cf801ea7b9209d527c8135",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`d4aae470`](https://github.com/lovesegfault/vim-config/commit/d4aae470a6a90b720f9d931e8eaea0969f13a180) | `` chore(flake/nixvim): eda14029 -> 61ec3976 `` |