### PR TITLE
chore(flake/nixpkgs): `c31898ad` -> `5633bcff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -577,11 +577,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728241625,
-        "narHash": "sha256-yumd4fBc/hi8a9QgA9IT8vlQuLZ2oqhkJXHPKxH/tRw=",
+        "lastModified": 1728492678,
+        "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c31898adf5a8ed202ce5bea9f347b1c6871f32d1",
+        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`31c987aa`](https://github.com/NixOS/nixpkgs/commit/31c987aae707d1667505daafb145124a9d436bd4) | `` go-task: 3.38.0 -> 3.39.2 (#347340) ``                                    |
| [`c2ec2109`](https://github.com/NixOS/nixpkgs/commit/c2ec2109937999bdcefd7d68c27974a731144f74) | `` monero-cli: update submodule version; disable aarch64-darwin ``           |
| [`b2324fbc`](https://github.com/NixOS/nixpkgs/commit/b2324fbcf6508c8ce388cd7531b179524dd017bc) | `` ocamlPackages.ctypes: 0.22.0 -> 0.23.0 ``                                 |
| [`0a5e80ec`](https://github.com/NixOS/nixpkgs/commit/0a5e80ec74495d0dcbaf5cc4fe9b930b5cddb3c3) | `` nbdkit: init at 1.40.4 ``                                                 |
| [`6b895f29`](https://github.com/NixOS/nixpkgs/commit/6b895f29bddbc0d7f94bbc801fe1d7a302a4ba28) | `` firefox-devedition-unwrapped: 131.0b9 -> 132.0b5 ``                       |
| [`c4a865cf`](https://github.com/NixOS/nixpkgs/commit/c4a865cf58932b8c230731cc94902042f8f95262) | `` firefox-beta-unwrapped: 131.0b9 -> 132.0b5 ``                             |
| [`8ef7cb10`](https://github.com/NixOS/nixpkgs/commit/8ef7cb10ba7a0f519772deb935524fbe7b895e0b) | `` firefox-esr-115-unwrapped: 115.16.0esr -> 115.16.1esr ``                  |
| [`955826bf`](https://github.com/NixOS/nixpkgs/commit/955826bf83ace52371924d94577c2d4bdc645074) | `` firefox-esr-128-unwrapped: 128.3.0 -> 128.3.1 ``                          |
| [`028e3f19`](https://github.com/NixOS/nixpkgs/commit/028e3f198b1400b73428ebf8aae32ce28bb64a64) | `` firefox-bin-unwrapped: 131.0 -> 131.0.2 ``                                |
| [`0436f0be`](https://github.com/NixOS/nixpkgs/commit/0436f0be4a2cf532fd600f526fb994f1164eb509) | `` firefox-unwrapped: 131.0 -> 131.0.2 ``                                    |
| [`8f50ca43`](https://github.com/NixOS/nixpkgs/commit/8f50ca43e6d9003c2c20845679c9d2fd819aaa32) | `` elixir-ls: 0.23.0 -> 0.24.0 ``                                            |
| [`0b60c7a3`](https://github.com/NixOS/nixpkgs/commit/0b60c7a362083604ed7d4e2c637fed5bb6e5b13d) | `` duckdb: disable tests that fail on x86_64 && aarch64 ``                   |
| [`d22ac6c3`](https://github.com/NixOS/nixpkgs/commit/d22ac6c35e9b8336c0a826f0966d434ed3cca0b9) | `` nushellPlugins.highlight: init at 1.3.1+0.98.0 ``                         |
| [`ca60a7c4`](https://github.com/NixOS/nixpkgs/commit/ca60a7c4313556ab1cdfcfd7811c913061ead1c3) | `` mycelium: 0.5.5 -> 0.5.6 ``                                               |
| [`692e3ee9`](https://github.com/NixOS/nixpkgs/commit/692e3ee9814b75c261ad5754e6c67b125aece30c) | `` rio: 0.1.16 -> 0.1.17 ``                                                  |
| [`ce83463c`](https://github.com/NixOS/nixpkgs/commit/ce83463c275817ea7d8b3f35dc80cd1a2e0e1c0a) | `` delly: 1.2.9 -> 1.3.1 ``                                                  |
| [`f762afc2`](https://github.com/NixOS/nixpkgs/commit/f762afc2dd1c405a85585ddddc0350fdd7a4c266) | `` renode-dts2repl: 0-unstable-2024-09-27 -> 0-unstable-2024-10-09 ``        |
| [`63669bdb`](https://github.com/NixOS/nixpkgs/commit/63669bdb75c392e73ea659af18204afe73a2a48c) | `` saucectl: init at 0.183.0 (#336737) ``                                    |
| [`cda08db3`](https://github.com/NixOS/nixpkgs/commit/cda08db3e1810631ffdab486ede239ece366f0c5) | `` bacon: 2.21.0 -> 3.0.0 ``                                                 |
| [`c2a2f68c`](https://github.com/NixOS/nixpkgs/commit/c2a2f68c8c652372fef1afb4a9d9821f6a2db44f) | `` nixosTests.openresty-lua: simplify ``                                     |
| [`c9f7e061`](https://github.com/NixOS/nixpkgs/commit/c9f7e06140de778521a021c2ff4e4cae22110e3a) | `` bacon: format ``                                                          |
| [`969e0857`](https://github.com/NixOS/nixpkgs/commit/969e08575668cf6ad5a7d70fcb183cd637ec865a) | `` bacon: move to pkgs/by-name ``                                            |
| [`0d71bb90`](https://github.com/NixOS/nixpkgs/commit/0d71bb909fd1de7cc43377ea7b0f9fa33e225acf) | `` python312Packages.tinygrad: patch cuda headers ``                         |
| [`73483c03`](https://github.com/NixOS/nixpkgs/commit/73483c03366e91c452b4675c032f80a6e8b87879) | `` jx: 3.10.155 -> 3.10.156 ``                                               |
| [`05e38dd5`](https://github.com/NixOS/nixpkgs/commit/05e38dd5a0d6d123a3ed315de5a490308cf7edab) | `` python312Packages.langfuse: 2.51.2 -> 2.51.5 ``                           |
| [`995ee2fa`](https://github.com/NixOS/nixpkgs/commit/995ee2fa2ca54fb6d46f0a03b9ab4172260c2e3e) | `` nuget-to-nix: add meta.mainProgram ``                                     |
| [`1535d725`](https://github.com/NixOS/nixpkgs/commit/1535d725fca3ef238e8c7ae0945b9faf21f27d32) | `` blackfire: 2.28.12 -> 2.28.13 ``                                          |
| [`34016e0a`](https://github.com/NixOS/nixpkgs/commit/34016e0abb3f100533a3c08a751c850fde0c2ec0) | `` v2ray: 5.19.0 -> 5.20.0 ``                                                |
| [`3fb311b7`](https://github.com/NixOS/nixpkgs/commit/3fb311b7f45f324859321df32d877777ea5a397c) | `` nushellPlugins.units: init at 0.1.2 ``                                    |
| [`f08c8867`](https://github.com/NixOS/nixpkgs/commit/f08c8867b330bbc903e391bbe59541103c8e4219) | `` xray: 1.8.24 -> 24.9.30 ``                                                |
| [`a28b2889`](https://github.com/NixOS/nixpkgs/commit/a28b2889824c83cf9576c7ec28925c38f1ae7817) | `` pulumi-bin: 3.134.1 -> 3.136.1 ``                                         |
| [`0ddbc8c6`](https://github.com/NixOS/nixpkgs/commit/0ddbc8c69e7455f2c579ccb479a4089684931be7) | `` vscode: 1.94.0 -> 1.94.1 ``                                               |
| [`7f63bcba`](https://github.com/NixOS/nixpkgs/commit/7f63bcba36ecf2442fbe1caaf64255e6d82aa2e7) | `` nixos/nncp: refactor configuration merging ``                             |
| [`180386b4`](https://github.com/NixOS/nixpkgs/commit/180386b443aebb2eb9d3bb6a84952940d8143461) | `` python312Packages.huggingface-hub: 0.25.1 -> 0.25.2 ``                    |
| [`8ffd2e88`](https://github.com/NixOS/nixpkgs/commit/8ffd2e8849bf3509792e54daad8191b9d6c495c0) | `` webcord: 4.9.2 -> 4.10.2 ``                                               |
| [`95bdf20d`](https://github.com/NixOS/nixpkgs/commit/95bdf20d2ea7acc18ea98d4f4fb7789b81c81e91) | `` hyprpicker: 0.3.0 -> 0.4.1 ``                                             |
| [`acb4f3cb`](https://github.com/NixOS/nixpkgs/commit/acb4f3cbb35563a90435fc2ba13a50732b3062dd) | `` hyprpicker: drop unused dependencies ``                                   |
| [`50c04156`](https://github.com/NixOS/nixpkgs/commit/50c0415679cf230cdd3d65be4a5fec9417e8feff) | `` hyprpicker: format ``                                                     |
| [`51b85c5d`](https://github.com/NixOS/nixpkgs/commit/51b85c5d18065941b05be44852034017279e28ec) | `` hyprland: 0.43.0 -> 0.44.0 ``                                             |
| [`359a25b1`](https://github.com/NixOS/nixpkgs/commit/359a25b1fa47cd89826bfae268440be007a7b866) | `` hyprland: use meson for building ``                                       |
| [`43bf9440`](https://github.com/NixOS/nixpkgs/commit/43bf94409f98b6a5cdb34bb1c461c80fbe6425f9) | `` hyprland: use moldLinker via stdenvAdapters ``                            |
| [`16f8bcfe`](https://github.com/NixOS/nixpkgs/commit/16f8bcfe708f6f49b715be4260c28d23425ce243) | `` hyprland: format ``                                                       |
| [`d817131b`](https://github.com/NixOS/nixpkgs/commit/d817131b089efbe557c8321b0643218eb5db9cf8) | `` python312Packages.auroranoaa: refactor ``                                 |
| [`e445306c`](https://github.com/NixOS/nixpkgs/commit/e445306c08d42d8183091f4398b27555d8970f52) | `` azure-cli-extensions.azure-iot: init at 0.25.0 ``                         |
| [`a4fbdf4c`](https://github.com/NixOS/nixpkgs/commit/a4fbdf4c4d034ff2f742754ac5d914ad98bdcac2) | `` python312Packages.azure-iot-device: init at 2.14.0 ``                     |
| [`dced7188`](https://github.com/NixOS/nixpkgs/commit/dced718864914be7f4d91290a822cae9b0ab277a) | `` vencord: 1.10.3 -> 1.10.4 ``                                              |
| [`70c1475e`](https://github.com/NixOS/nixpkgs/commit/70c1475e92b1e7dedeb5e9ce5d01992d5c963ef9) | `` eza: 0.20.1 -> 0.20.2 ``                                                  |
| [`fa40906e`](https://github.com/NixOS/nixpkgs/commit/fa40906e25d3da8a14deac85e2acc995590e550b) | `` python3Packages.ifcopenshell.tests: fix the eval ``                       |
| [`0cc0cd0f`](https://github.com/NixOS/nixpkgs/commit/0cc0cd0f09a444a0e2b9b3b3c548d0e62e0ab3dd) | `` lua-language-server: 3.10.6 -> 3.11.1 ``                                  |
| [`e4476dd7`](https://github.com/NixOS/nixpkgs/commit/e4476dd7a6b796b7b69f6b518b669ff25093bdce) | `` tigerbeetle: 0.16.3 -> 0.16.8 ``                                          |
| [`dd803f74`](https://github.com/NixOS/nixpkgs/commit/dd803f74d0917987e8c430cbaa60eb3a1d07eb62) | `` twilio-cli: 5.22.2 -> 5.22.3 ``                                           |
| [`5be594c3`](https://github.com/NixOS/nixpkgs/commit/5be594c3f00baab773c1113cd70fb35deb8bbf82) | `` knossosnet: 1.2.3 -> 1.2.4 ``                                             |
| [`f0a869c9`](https://github.com/NixOS/nixpkgs/commit/f0a869c9d21befae432842bd39a6c344480f1343) | `` pachyderm: 2.11.3 -> 2.11.4 ``                                            |
| [`2a55fe1f`](https://github.com/NixOS/nixpkgs/commit/2a55fe1f9210b41158be8a3e9beb4788cc3c128a) | `` anilibria-winmaclinux: 2.2.19 -> 2.2.20 ``                                |
| [`3b235d21`](https://github.com/NixOS/nixpkgs/commit/3b235d21bef84a85bd312ef236bae8f84daa12dd) | `` syft: 1.13.0 -> 1.14.0 ``                                                 |
| [`5b7de67c`](https://github.com/NixOS/nixpkgs/commit/5b7de67c5d5ce8c571a5dba91928c44cbf2efa54) | `` python312Packages.iminuit: 2.30.0 -> 2.30.1 ``                            |
| [`a1047559`](https://github.com/NixOS/nixpkgs/commit/a1047559594d7235a9965564ab809c144689dd41) | `` nginxMainline: 1.27.1 -> 1.27.2 ``                                        |
| [`dcb2271b`](https://github.com/NixOS/nixpkgs/commit/dcb2271b8b6ff9350334c69901b937e430acbabd) | `` redpanda-client: 24.2.5 -> 24.2.6 ``                                      |
| [`4caae1f6`](https://github.com/NixOS/nixpkgs/commit/4caae1f6b58c8dfec1805522bc82346046bb34b3) | `` python312Packages.pysqueezebox: 0.9.3 -> 0.9.4 ``                         |
| [`854acbf5`](https://github.com/NixOS/nixpkgs/commit/854acbf525d2885decb501ebd6373bf300928bab) | `` rasm: 2.2.7 -> 2.2.8 ``                                                   |
| [`65d98cb0`](https://github.com/NixOS/nixpkgs/commit/65d98cb037009203ae0e73972b9d0f3e1f23353e) | `` ocaml: default to version 5.2 ``                                          |
| [`106bc587`](https://github.com/NixOS/nixpkgs/commit/106bc5873edf464d57e85ef83686165f39ca6435) | `` clusterctl: 1.8.3 -> 1.8.4 ``                                             |
| [`ba7d35a1`](https://github.com/NixOS/nixpkgs/commit/ba7d35a1f00c3e0e8f11664f9dc360c82dd7f0b9) | `` snappymail: 2.38.0 -> 2.38.1 ``                                           |
| [`26ba35b0`](https://github.com/NixOS/nixpkgs/commit/26ba35b052672d4466b1859537866235612eaabd) | `` fastddsgen: 4.0.1 -> 4.0.2 ``                                             |
| [`8d1a2cca`](https://github.com/NixOS/nixpkgs/commit/8d1a2cca3190d2566459d7ad1e8ed92a031ec333) | `` python312Packages.pbs-installer: 2024.09.09 -> 2024.10.08 ``              |
| [`22a44e67`](https://github.com/NixOS/nixpkgs/commit/22a44e6782f29b2c0fd0454ce6535c93fd17af41) | `` reposilite: 3.5.17 -> 3.5.18 ``                                           |
| [`42fc1fc8`](https://github.com/NixOS/nixpkgs/commit/42fc1fc8d675606124e1831a33a22342a6c9d330) | `` codux: 15.34.0 -> 15.35.2 ``                                              |
| [`45805b62`](https://github.com/NixOS/nixpkgs/commit/45805b62ba583b239c7114e20b29db7d48ba9053) | `` zsh-abbr: 5.8.2 -> 5.8.3 ``                                               |
| [`ffae6343`](https://github.com/NixOS/nixpkgs/commit/ffae6343337eeeaff9648a6b51b3b8bcb9b0213f) | `` python312Packages.uplc: 1.0.6 -> 1.0.7 ``                                 |
| [`c6c4ea7f`](https://github.com/NixOS/nixpkgs/commit/c6c4ea7f022a3a94a32409d15440a76b354a01d4) | `` sem: 0.30.0 -> 0.30.1 ``                                                  |
| [`039a7c5f`](https://github.com/NixOS/nixpkgs/commit/039a7c5f50f7800e580e1a06ba283714db2dcb43) | `` python312Packages.motionblindsble: 0.1.1 -> 0.1.2 ``                      |
| [`9a2c44a9`](https://github.com/NixOS/nixpkgs/commit/9a2c44a943b93f1dc11f6f53a299f94c695f2e4a) | `` python312Packages.camel-converter: 4.0.0 -> 4.0.1 ``                      |
| [`81417b3f`](https://github.com/NixOS/nixpkgs/commit/81417b3f0322997fb771f2f9811d38394a217f3a) | `` runc: 1.1.14 -> 1.1.15 ``                                                 |
| [`202d66e6`](https://github.com/NixOS/nixpkgs/commit/202d66e6a8609963588eece544e4571e8b47eae2) | `` python312Packages.pipenv-poetry-migrate: 0.5.9 -> 0.5.10 ``               |
| [`3ae8bb3e`](https://github.com/NixOS/nixpkgs/commit/3ae8bb3e23cda0e2d1525db8e727b69db1a6375f) | `` mitmproxy: 10.4.2 -> 11.0.0 ``                                            |
| [`06047925`](https://github.com/NixOS/nixpkgs/commit/06047925bd9b38515504b79c4e0a2bc8709243eb) | `` emiluaPlugins.qt6: 1.0.3 -> 1.1.0 ``                                      |
| [`8c245619`](https://github.com/NixOS/nixpkgs/commit/8c245619f2fd4e0d07af454f9854a4621f131b3d) | `` kine: init at 0.13.2 ``                                                   |
| [`44d019c9`](https://github.com/NixOS/nixpkgs/commit/44d019c97385973a8f524a035685f783ea3885ea) | `` python312Packages.ytmusicapi: 1.8.1 -> 1.8.2 ``                           |
| [`1402514c`](https://github.com/NixOS/nixpkgs/commit/1402514c07b054ddc37730aab1d5b42b559daa40) | `` python312Packages.extract-msg: 0.49.0 -> 0.50.1 ``                        |
| [`d30fa2e2`](https://github.com/NixOS/nixpkgs/commit/d30fa2e21c064061ae5993a9fedb0f4c1a92246e) | `` python312Packages.aiostream: 0.6.2 -> 0.6.3 ``                            |
| [`a58161a1`](https://github.com/NixOS/nixpkgs/commit/a58161a1348952bca727f31db5401f05afd75d54) | `` web-eid-app: 2.5.0 -> 2.6.0 ``                                            |
| [`d6a5348f`](https://github.com/NixOS/nixpkgs/commit/d6a5348f9dd87b848b7556e27e59608aa0a041dd) | `` python312Packages.sphinx-tabs: 3.4.5 -> 3.4.7 ``                          |
| [`170e37a7`](https://github.com/NixOS/nixpkgs/commit/170e37a798547236e00105749119e3338c494531) | `` python312Packages.imgw-pib: 1.0.5 -> 1.0.6 ``                             |
| [`86b27948`](https://github.com/NixOS/nixpkgs/commit/86b2794824b636d1bc87d0fa6a98ce6629fd1f85) | `` python312Packages.auroranoaa: 0.0.3 -> 0.0.5 ``                           |
| [`b9b23b2a`](https://github.com/NixOS/nixpkgs/commit/b9b23b2a72edce22dc52e2b1ce69590a7fe7c703) | `` rl-2411: Mention Ceph upgrade ``                                          |
| [`24cf465f`](https://github.com/NixOS/nixpkgs/commit/24cf465f47706c3db8b7cfa7884d53bb1052f5e1) | `` python312Packages.coinmetrics-api-client: 2024.8.20.13 -> 2024.10.4.15 `` |
| [`c7482866`](https://github.com/NixOS/nixpkgs/commit/c7482866ccb3c1b7d181efac70e89b524119fcdd) | `` python312Packages.cle: 9.2.119 -> 9.2.122 ``                              |
| [`79df04f1`](https://github.com/NixOS/nixpkgs/commit/79df04f13a6d81b31b9dccb0b355a2eb56e237b7) | `` python312Packages.claripy: 9.2.119 -> 9.2.122 ``                          |
| [`dd280821`](https://github.com/NixOS/nixpkgs/commit/dd2808213c548c50720955fee3d79d13b10bd4a9) | `` CODEOWNERS: Fix non-matching patterns ``                                  |
| [`ac55fc4c`](https://github.com/NixOS/nixpkgs/commit/ac55fc4c8402da309d6a6e5139152b8527d122e0) | `` python312Packages.pyvex: 9.2.119 -> 9.2.122 ``                            |
| [`32611661`](https://github.com/NixOS/nixpkgs/commit/3261166103f12c96a8ad63c232764517f737027b) | `` python312Packages.ailment: 9.2.119 -> 9.2.122 ``                          |
| [`41b90af8`](https://github.com/NixOS/nixpkgs/commit/41b90af86c29fbae265de0734b0997d3a6384aea) | `` python312Packages.archinfo: 9.2.119 -> 9.2.122 ``                         |
| [`98722542`](https://github.com/NixOS/nixpkgs/commit/98722542d9a624e08ed7af62b8180fcf5c56ffde) | `` git-identity: init at 1.1.1 ``                                            |
| [`51aea273`](https://github.com/NixOS/nixpkgs/commit/51aea27321d331ffd79d1d1e75d0f31e2e29f7e0) | `` syndicate-server: 0.46.0 -> 0.48.0 ``                                     |
| [`93dcd42f`](https://github.com/NixOS/nixpkgs/commit/93dcd42f2b208390491099ec5db481e31a47097e) | `` OWNERS: placeholder init ``                                               |
| [`87a2986c`](https://github.com/NixOS/nixpkgs/commit/87a2986c1ab8ee64769c377e58c49113c2eecba6) | `` workflows/codeowners: init ``                                             |
| [`5695bf6c`](https://github.com/NixOS/nixpkgs/commit/5695bf6cfe406d84b514310b23bf9b2dcd5caec2) | `` ci: Add codeowners validator ``                                           |
| [`369cfa02`](https://github.com/NixOS/nixpkgs/commit/369cfa02da5b3e2b3c99ab33e09553c63d00ef71) | `` ci: Add review request scripts ``                                         |
| [`1700d005`](https://github.com/NixOS/nixpkgs/commit/1700d0058809db5fa3bf64cdde79c1f417d760ea) | `` ci: Add default.nix with exposed pkgs ``                                  |
| [`6b703e2f`](https://github.com/NixOS/nixpkgs/commit/6b703e2f6efdcc0ac5a19d3a5e277dcae02dad65) | `` python312Packages.azure-mgmt-eventhub: 11.0.0 -> 11.1.0 ``                |
| [`f4f2cdd6`](https://github.com/NixOS/nixpkgs/commit/f4f2cdd691a64705c56dabfbf744cb7394093f1f) | `` python312Packages.azure-mgmt-network: 26.0.0 -> 27.0.0 ``                 |
| [`ffd8d215`](https://github.com/NixOS/nixpkgs/commit/ffd8d215d27e4dfef75873abe91faf93b23a2a25) | `` python312Packages.azure-mgmt-batch: 17.3.0 -> 18.0.0 ``                   |