### PR TITLE
chore(flake/home-manager): `03863036` -> `d47d3325`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728337164,
-        "narHash": "sha256-VdRTjJFyq4Q9U7Z/UoC2Q5jK8vSo6E86lHc2OanXtvc=",
+        "lastModified": 1728584964,
+        "narHash": "sha256-40093uJyc+pf0CaOtbj5dDiyL0PQ7c5pmnGkfO6Q/hw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "038630363e7de57c36c417fd2f5d7c14773403e4",
+        "rev": "d47d33254fbf4fdbdee9f1f14095f689662e479d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`d47d3325`](https://github.com/nix-community/home-manager/commit/d47d33254fbf4fdbdee9f1f14095f689662e479d) | `` home-manager-manual: expose options.json `` |
| [`d3ee25c0`](https://github.com/nix-community/home-manager/commit/d3ee25c07848725e924a74a4813de2ad0f5d0878) | `` Translate using Weblate (Hindi) ``          |