### PR TITLE
chore(flake/home-manager): `8bb5d53c` -> `342a1d68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728588172,
-        "narHash": "sha256-wCLcOMOyiFHa4MfAT1SR8jj47GcmCXiR93kgFs38bVY=",
+        "lastModified": 1728598744,
+        "narHash": "sha256-sSfvyO5xH3HObHHmh6lp/hcvo7tMjFKd/HXpxyrRnoE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8bb5d53c5847d9a9b2ad1bda49f9aa9df0de282a",
+        "rev": "342a1d682386d3a1d74f9555cb327f2f311dda6e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                     |
| ----------------------------------------------------------------------------------------------------------- | --------------------------- |
| [`342a1d68`](https://github.com/nix-community/home-manager/commit/342a1d682386d3a1d74f9555cb327f2f311dda6e) | `` flake.lock: Update ``    |
| [`03f8e0b3`](https://github.com/nix-community/home-manager/commit/03f8e0b3b3ca4f49d11bf0264dbff465d6ae9aae) | `` snixembed: add module `` |