### PR TITLE
chore(flake/disko): `d39ee334` -> `4c298a03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728334376,
-        "narHash": "sha256-CTKEKPzD/j8FK6H4DO3EjyixZd3HHvgAgfnCwpGFP5c=",
+        "lastModified": 1728635848,
+        "narHash": "sha256-r5T2+ibfAyf2ZvKAdrhPr14Po1EY9xTu8zZtpuhGV04=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "d39ee334984fcdae6244f5a8e6ab857479cbaefe",
+        "rev": "4c298a031a0631c46b53f82d345763f14eb18f82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                            |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`4c298a03`](https://github.com/nix-community/disko/commit/4c298a031a0631c46b53f82d345763f14eb18f82) | `` Fix issue when config path contains spaces ``   |
| [`efe75285`](https://github.com/nix-community/disko/commit/efe752857867a85c5706bf0a0e50852d4c06bcee) | `` disko cli: remove requirement for leading ./ `` |