### PR TITLE
chore(flake/git-hooks): `4ebefcac` -> `06bb5971`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,11 +344,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728580416,
-        "narHash": "sha256-nKttjKg6lE7O5S+wlBOkXsUGdOgVxZ8SWaCOyodW5so=",
+        "lastModified": 1728651332,
+        "narHash": "sha256-lm+asqDSTj0m6j1dtEte1/XG+uzZbwxS3tn7JLaBw84=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4ebefcac44b5116cf5741be858245db769ddedd1",
+        "rev": "06bb5971c139959d9a951f34e4264d32f5d998e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`6a3d0eb6`](https://github.com/cachix/git-hooks.nix/commit/6a3d0eb6b64920b33683111bce68d1f4a9ef51dd) | `` statix: skip adding `--ignore` if empty ``   |
| [`1fe5afc7`](https://github.com/cachix/git-hooks.nix/commit/1fe5afc78489820f5586a9c90f91358a169604a7) | `` statix: fix broken list option `--ignore` `` |
| [`6ce0397f`](https://github.com/cachix/git-hooks.nix/commit/6ce0397f4bd8af17e83639f7c561a64799fd81ae) | `` feat(rustfmt): add settings ``               |