### PR TITLE
chore(flake/disko): `6af4e02b` -> `c7ef3964`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728638019,
-        "narHash": "sha256-eEga9ZYpWr4ippI8ntBdcNkXWY7qv1/9kK9jkemAyzQ=",
+        "lastModified": 1728659696,
+        "narHash": "sha256-xipqQdXMZdSln1WChUWFqcrghOMYCmdRo7rgf/MtEkg=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "6af4e02b9cf2a4126af542c9e299f13228cfe2e0",
+        "rev": "c7ef3964b6befa877e76316ae88f3ef251cae573",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                          |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`c7ef3964`](https://github.com/nix-community/disko/commit/c7ef3964b6befa877e76316ae88f3ef251cae573) | `` docs: add "latest" tag to flake references `` |
| [`aee84b5f`](https://github.com/nix-community/disko/commit/aee84b5fb390d713a98efed2b56bd7d6f873fb48) | `` disko cli: add --version command ``           |