### PR TITLE
chore(flake/disko): `9788e5d4` -> `a3619332`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728672978,
-        "narHash": "sha256-igSdTXrThwLCXEcpQ9ek8E1hBZy87BFuLtu9HZkGMyk=",
+        "lastModified": 1728673344,
+        "narHash": "sha256-Iqo1nHEkBeucGE48EWYbZkx9LAPAWyEkzAWH+fPXTUM=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "9788e5d45805aee2c3bece9c17d6715668c5ed95",
+        "rev": "a3619332369e1d254c68be5f019b3a8632e79bbc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                            |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`a3619332`](https://github.com/nix-community/disko/commit/a3619332369e1d254c68be5f019b3a8632e79bbc) | `` release: reset released flag `` |
| [`ff0a4717`](https://github.com/nix-community/disko/commit/ff0a471763faaaca1859fd6de80f44fa0fce91a6) | `` release: v1.8.2 ``              |