### PR TITLE
chore(flake/disko): `a3619332` -> `bdbdb725`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728673344,
-        "narHash": "sha256-Iqo1nHEkBeucGE48EWYbZkx9LAPAWyEkzAWH+fPXTUM=",
+        "lastModified": 1728687662,
+        "narHash": "sha256-D9TChzb00eTG1YWBx8eN2s6lJJnBjB5Y7RpxkAzGvyQ=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "a3619332369e1d254c68be5f019b3a8632e79bbc",
+        "rev": "bdbdb725d632863bdedb80baabf21327614dd237",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                               |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`bdbdb725`](https://github.com/nix-community/disko/commit/bdbdb725d632863bdedb80baabf21327614dd237) | `` fix: wrong attr path ``            |
| [`8c1668ed`](https://github.com/nix-community/disko/commit/8c1668edeccc0680d044453fd9612dac673b67b0) | `` release: fix wrong push command `` |