### PR TITLE
chore(flake/nixos-hardware): `ecfcd787` -> `ca0662ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1728269138,
-        "narHash": "sha256-oKxDImsOvgUZMY4NwXVyUc/c1HiU2qInX+b5BU0yXls=",
+        "lastModified": 1728725702,
+        "narHash": "sha256-3+AFr6/1q8D3Siy6qrqBupxj00/CbuNsvlq8p2jQ9E8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ecfcd787f373f43307d764762e139a7cdeb9c22b",
+        "rev": "ca0662edb06f07d7b57c1b92037a112b4fc2c82f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                       |
| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`ca0662ed`](https://github.com/NixOS/nixos-hardware/commit/ca0662edb06f07d7b57c1b92037a112b4fc2c82f) | `` fix ordering ``            |
| [`664b7847`](https://github.com/NixOS/nixos-hardware/commit/664b784722aee2fb139bfe6542406f16c0c4c457) | `` add tuxedo aura 15 gen1 `` |