### PR TITLE
chore(flake/nixos-hardware): `ca0662ed` -> `a8dd1b21`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1728725702,
-        "narHash": "sha256-3+AFr6/1q8D3Siy6qrqBupxj00/CbuNsvlq8p2jQ9E8=",
+        "lastModified": 1728729581,
+        "narHash": "sha256-oazkQ/z7r43YkDLLQdMg8oIB3CwWNb+2ZrYOxtLEWTQ=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ca0662edb06f07d7b57c1b92037a112b4fc2c82f",
+        "rev": "a8dd1b21995964b115b1e3ec639dd6ce24ab9806",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`a8dd1b21`](https://github.com/NixOS/nixos-hardware/commit/a8dd1b21995964b115b1e3ec639dd6ce24ab9806) | `` add dell inspiron 7460 (#1177) `` |
| [`6f71da56`](https://github.com/NixOS/nixos-hardware/commit/6f71da566f481d1593d447c31556759732299d13) | `` apple/t2: add tiny-dfr option ``  |