### PR TITLE
chore(flake/disko): `3b2e19fe` -> `3b778f10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728902215,
-        "narHash": "sha256-toHnqv0orYpu+/IHN7CgtG4ckCrevY9UxMCAxJJ8MVY=",
+        "lastModified": 1728922573,
+        "narHash": "sha256-FegyBabjV4868aJUbvFtqH0zKDEtUpeCAfnB1vWXeBg=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "3b2e19fe7c667a4fb2da3d6bb5ae6ee3e3552f74",
+        "rev": "3b778f10eb275573da9f5c8a7a49e774200b87e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                    |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`3b778f10`](https://github.com/nix-community/disko/commit/3b778f10eb275573da9f5c8a7a49e774200b87e5) | `` docs: add docs on how to use imageName in disk type. `` |
| [`ef408f7f`](https://github.com/nix-community/disko/commit/ef408f7f9ada76d63de2b2260d613b2c3a07181c) | `` options: add imageName option to disk type. ``          |
| [`9938afb4`](https://github.com/nix-community/disko/commit/9938afb4350e214d3e720100688ec9979ba702e3) | `` options: make extraPostVM mergable. ``                  |