### PR TITLE
chore(flake/lanzaboote): `6634ab61` -> `a71d589c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -448,11 +448,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1728833717,
-        "narHash": "sha256-GkS9SnKRb/PrdcqptLPNxweDdf3Zx2Lk5szEt07P4mE=",
+        "lastModified": 1728931061,
+        "narHash": "sha256-VTb2wsZ19j4RLdxSifQTMxojchaqLXe7wuBXRIPRpnw=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "6634ab618862f1d041c286567a58c554e6136068",
+        "rev": "a71d589ce0bce98ac8f7cbaf7d88b0badfbb6dd0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                            |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`cbf0eb96`](https://github.com/nix-community/lanzaboote/commit/cbf0eb969d461dcf2f6b09d48b8ac2f9aa0532e9) | `` linux-bootloader: Clean up remaining uses of RuntimeServices `` |