### PR TITLE
chore(flake/lanzaboote): `a71d589c` -> `97ad865c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -448,11 +448,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1728931061,
-        "narHash": "sha256-VTb2wsZ19j4RLdxSifQTMxojchaqLXe7wuBXRIPRpnw=",
+        "lastModified": 1728983114,
+        "narHash": "sha256-4Axy2UDl9Y625ugz1qCCf1p0S9vSDO6t3vo0z/E8G2I=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "a71d589ce0bce98ac8f7cbaf7d88b0badfbb6dd0",
+        "rev": "97ad865ceb0d189a96b8121fc2265df5ee6cb4fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                                          |
| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`da466293`](https://github.com/nix-community/lanzaboote/commit/da466293dcc80abc666ddf1bfc30d2e26068d238) | `` uefi: Use system_table_boot when calling convert_device_path_to_text ``       |
| [`3f78a16e`](https://github.com/nix-community/lanzaboote/commit/3f78a16e19189ff096a2c008533fc3effe86bdf4) | `` linux-bootloader: Drop most uses of BootServices from export_efi_variables `` |
| [`118e3dc4`](https://github.com/nix-community/lanzaboote/commit/118e3dc437d2bfb9559d8e8212c079d518d1a124) | `` linux-bootloader: Drop BootServices param from disk_get_part_uuid ``          |
| [`140472a2`](https://github.com/nix-community/lanzaboote/commit/140472a202befa969d529aac66e0972efcba990b) | `` uefi: Drop BootServices param from booted_image_file ``                       |
| [`8e6306fc`](https://github.com/nix-community/lanzaboote/commit/8e6306fc5e597307834a4b3d05dc099c7292f4a1) | `` linux-bootloader: Drop use of BootServices from Image::start ``               |
| [`be97fa91`](https://github.com/nix-community/lanzaboote/commit/be97fa915d2f37eb831e04a9f9ce99ff9fa8df62) | `` uefi: Drop BootServices param from Image::load ``                             |
| [`93cf61b1`](https://github.com/nix-community/lanzaboote/commit/93cf61b163a3d8b18c259d62bf8f2e6c2f4ddb61) | `` uefi: Drop BootServices param from InitrdLoader methods ``                    |
| [`438e5dbb`](https://github.com/nix-community/lanzaboote/commit/438e5dbb69a3aec81f0b3d87dd997fa277ebc827) | `` stub: Drop BootServices param from get_cmdline ``                             |
| [`5dbe9e54`](https://github.com/nix-community/lanzaboote/commit/5dbe9e54931c4c5d1a6804d380ce581975c97e49) | `` uefi: Drop BootServices param from functions in the tpm module ``             |
| [`bd3b1b16`](https://github.com/nix-community/lanzaboote/commit/bd3b1b169020235b624a68b32fd849c9fefc4d2d) | `` uefi: Replace BootServices::image_handle with boot::image_handle ``           |