### PR TITLE
chore(flake/lanzaboote): `7ada9263` -> `bd01eac8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -442,11 +442,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1729009906,
-        "narHash": "sha256-KxYn0+WNginUmpmt2U9qJia0C3EievHViOyOyRSJFV4=",
+        "lastModified": 1729028850,
+        "narHash": "sha256-eOhjiU+3TCaSYZESYhU2ZTUQKrBcer9cQ/XpVkergAg=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "7ada9263166655d14dae7a836326dfda6ac72d47",
+        "rev": "bd01eac8c7cfa9b7e25304f0e7f0fed80de63f9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                      |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`84ae860b`](https://github.com/nix-community/lanzaboote/commit/84ae860be74b5e2b2843dffac06848bdf0657334) | `` stub: Drop handle and table params from main ``           |
| [`998d1270`](https://github.com/nix-community/lanzaboote/commit/998d1270bfe7a93b6ca322cf289c62785cfecbf4) | `` stub: Drop SystemTable param from boot_linux ``           |
| [`ed4cd445`](https://github.com/nix-community/lanzaboote/commit/ed4cd445135a1d6eb57a579d171e8c3d17f0e153) | `` uefi: Drop SystemTable param from export_efi_variables `` |
| [`afeb78b9`](https://github.com/nix-community/lanzaboote/commit/afeb78b93817cb4f0b33d6be66e144aeeb88ef7d) | `` linux-bootloader: Drop remaining use of SystemTable ``    |
| [`07028410`](https://github.com/nix-community/lanzaboote/commit/070284106c59ef6dedcf0a36a95385da7d3efdaf) | `` uefi: Drop SystemTable param from Image::start ``         |