### PR TITLE
chore(flake/lovesegfault-vim-config): `9a3e5efd` -> `b1eff05d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728864713,
-        "narHash": "sha256-rbAnVHzOy6ioTdNf89R8kAUIQZ1kK/A1MvbM/OVhJew=",
+        "lastModified": 1729037625,
+        "narHash": "sha256-nr3alYAKjUVJXBlx12sfuW3PuEWjxMBLVpRQqKqpqNQ=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "9a3e5efdab1a94976700ef49bae53c394ecbb36c",
+        "rev": "b1eff05d91deea3ea79738a089dfaa200442eeb0",
         "type": "github"
       },
       "original": {
@@ -649,11 +649,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728829992,
-        "narHash": "sha256-722PdOQ4uTTAOyS3Ze4H7LXDNVi9FecKbLEvj3Qu0hM=",
+        "lastModified": 1729015933,
+        "narHash": "sha256-raKxsI2SGe/vF2PvzFatd/Sl9eVUCuCUUVg7cINFVbQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "619e24366e8ad34230d65a323d26ca981bfa6927",
+        "rev": "429f2e8d1aa61181c0ec72bdafe022fbb6a092d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`b1eff05d`](https://github.com/lovesegfault/vim-config/commit/b1eff05d91deea3ea79738a089dfaa200442eeb0) | `` chore(flake/nixpkgs): 5633bcff -> a3c0b3b2 `` |
| [`e29ac01e`](https://github.com/lovesegfault/vim-config/commit/e29ac01e1f2aa138a67ea46f7b00cab7e2037427) | `` chore(flake/nixvim): 619e2436 -> 429f2e8d ``  |