### PR TITLE
chore(flake/impermanence): `d0b38e55` -> `dff77f78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -411,11 +411,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1727649413,
-        "narHash": "sha256-FA53of86DjFdeQzRDVtvgWF9o52rWK70VHGx0Y8fElQ=",
+        "lastModified": 1729064351,
+        "narHash": "sha256-bINxHw0Z8oVRf9W6t1neJvNp9A5KP5Z1kgbtMKJJ1RU=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "d0b38e550039a72aff896ee65b0918e975e6d48e",
+        "rev": "dff77f78e2a969b559b1b1814f00e3779037f339",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                              |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`dff77f78`](https://github.com/nix-community/impermanence/commit/dff77f78e2a969b559b1b1814f00e3779037f339) | `` nixos: Create persistent storage directories and their parents `` |