### PR TITLE
chore(flake/impermanence): `dff77f78` -> `e3374575`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -411,11 +411,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1729064351,
-        "narHash": "sha256-bINxHw0Z8oVRf9W6t1neJvNp9A5KP5Z1kgbtMKJJ1RU=",
+        "lastModified": 1729068498,
+        "narHash": "sha256-C2sGRJl1EmBq0nO98TNd4cbUy20ABSgnHWXLIJQWRFA=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "dff77f78e2a969b559b1b1814f00e3779037f339",
+        "rev": "e337457502571b23e449bf42153d7faa10c0a562",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`ee6d65f0`](https://github.com/nix-community/impermanence/commit/ee6d65f0b2060c92cf6658f89553d75629c02552) | `` add: default nixos module ``                     |
| [`f4aab16c`](https://github.com/nix-community/impermanence/commit/f4aab16cd83c5a354840c215d69e57b61274c1c5) | `` mount-file: allow file to exist if it's empty `` |