### PR TITLE
chore(flake/treefmt-nix): `4446c7a6` -> `5307ba60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -787,11 +787,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727984844,
-        "narHash": "sha256-xpRqITAoD8rHlXQafYZOLvUXCF6cnZkPfoq67ThN0Hc=",
+        "lastModified": 1729077719,
+        "narHash": "sha256-zayHqZO9gA1U85c4CPvVSnLV8/cBgc2yVrSKWaKeBUs=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "4446c7a6fc0775df028c5a3f6727945ba8400e64",
+        "rev": "5307ba60125bb024d7e52d71d582eafd511f3fee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                    |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`5307ba60`](https://github.com/numtide/treefmt-nix/commit/5307ba60125bb024d7e52d71d582eafd511f3fee) | `` deno: include more supported files by default (#249) `` |