### PR TITLE
chore(flake/disko): `d7d57edb` -> `a6a3179d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729099656,
-        "narHash": "sha256-VftVIg7UXTy1bq+tzi1aVYOWl7PQ35IpjW88yMYjjpc=",
+        "lastModified": 1729281548,
+        "narHash": "sha256-MuojlSnwAJAwfhgmW8ZtZrwm2Sko4fqubCvReqbUzYw=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "d7d57edb72e54891fa67a6f058a46b2bb405663b",
+        "rev": "a6a3179ddf396dfc28a078e2f169354d0c137125",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                   |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`a6a3179d`](https://github.com/nix-community/disko/commit/a6a3179ddf396dfc28a078e2f169354d0c137125) | `` cli: stop using system dependencies in destroy step `` |