### PR TITLE
chore(flake/home-manager): `09a0c0c0` -> `802b3cb2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729260213,
-        "narHash": "sha256-jAvHoU/1y/yCuXzr2fNF+q6uKmr8Jj2xgAisK4QB9to=",
+        "lastModified": 1729321271,
+        "narHash": "sha256-sSDfM5ulUlrjUVeohBjItAfvLREZdxence0PxEDohqI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "09a0c0c02953318bf94425738c7061ffdc4cba75",
+        "rev": "802b3cb2d45ad66619ea8ad19b280baa460556d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`802b3cb2`](https://github.com/nix-community/home-manager/commit/802b3cb2d45ad66619ea8ad19b280baa460556d2) | `` espanso: use `launcher` command on Linux `` |