### PR TITLE
chore(flake/nixos-hardware): `a8dd1b21` -> `f682feda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -556,11 +556,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1728729581,
-        "narHash": "sha256-oazkQ/z7r43YkDLLQdMg8oIB3CwWNb+2ZrYOxtLEWTQ=",
+        "lastModified": 1729331227,
+        "narHash": "sha256-OT51IFK2+LjHC7xgt6n9+Z5ML6o3kFgxnAgOdgXhXrE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a8dd1b21995964b115b1e3ec639dd6ce24ab9806",
+        "rev": "f682fedae05303287c07c859423203c578db4213",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`f682feda`](https://github.com/NixOS/nixos-hardware/commit/f682fedae05303287c07c859423203c578db4213) | `` gpd-win-max-2-2023/bmi260: 0.0.2 -> 1.0.0 ``                                   |
| [`99918dfb`](https://github.com/NixOS/nixos-hardware/commit/99918dfbd7a86e18071ddc72e81a2f3ffe5bcea5) | `` dell-precision-5490: make force_probe conditional ``                           |
| [`b2f6701f`](https://github.com/NixOS/nixos-hardware/commit/b2f6701f91a06e7e641eed8602ec5cd67cc8d4da) | `` dell-precision-5490: fix tests and update README ``                            |
| [`2d125b6c`](https://github.com/NixOS/nixos-hardware/commit/2d125b6c56bf301393a46474f52b8f958711908e) | `` Add basic dell precision 5490 ``                                               |
| [`a825917e`](https://github.com/NixOS/nixos-hardware/commit/a825917eadfd78fe66728890c72fee00edcc8c28) | `` README tidy-up ``                                                              |
| [`98a46074`](https://github.com/NixOS/nixos-hardware/commit/98a46074e8c13ad845dd19469a9f2f9f26c86c5c) | `` Deprecation warning for QCA6174 firmware ``                                    |
| [`efb12d7f`](https://github.com/NixOS/nixos-hardware/commit/efb12d7f4648986c17bb6674a4136d20eac01bbf) | `` Remove archived repo ``                                                        |
| [`3e40c449`](https://github.com/NixOS/nixos-hardware/commit/3e40c4491684447706165de0c73cd323cffa051b) | `` microsoft/surface/go: Add comment about obsolete kvalo/ath10k-firmware repo `` |
| [`963cf21d`](https://github.com/NixOS/nixos-hardware/commit/963cf21d30fb28a79fdba2d87d8bd744f78bea54) | `` enable thermald, the temperature management daemon. ``                         |