### PR TITLE
chore(flake/nixpkgs): `5785b6bb` -> `4c2fcb09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -571,11 +571,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729070438,
-        "narHash": "sha256-KOTTUfPkugH52avUvXGxvWy8ibKKj4genodIYUED+Kc=",
+        "lastModified": 1729256560,
+        "narHash": "sha256-/uilDXvCIEs3C9l73JTACm4quuHUsIHcns1c+cHUJwA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5785b6bb5eaae44e627d541023034e1601455827",
+        "rev": "4c2fcb090b1f3e5b47eaa7bd33913b574a11e0a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`4c2fcb09`](https://github.com/NixOS/nixpkgs/commit/4c2fcb090b1f3e5b47eaa7bd33913b574a11e0a0) | `` ocamlPackages.uuidm: 0.9.8 → 0.9.9 ``                                                 |
| [`4d56f18a`](https://github.com/NixOS/nixpkgs/commit/4d56f18a82430e1bc51cb7f8dfa2ed61bdf0447a) | `` maintainers/team-list: remove asymmetric from jitsi ``                                |
| [`46ca4d55`](https://github.com/NixOS/nixpkgs/commit/46ca4d55c63f887b46e63450c90a27fd7ec192f9) | `` solo5: 0.8.1 -> 0.9.0 ``                                                              |
| [`1ddf2d83`](https://github.com/NixOS/nixpkgs/commit/1ddf2d83e38a1f17784e69fc0860dc3bc460d333) | `` docs/release-notes: document deprecations in Go ecosystem ``                          |
| [`6d431182`](https://github.com/NixOS/nixpkgs/commit/6d431182831597316374558b94c5bfe561befffe) | `` golly: 4.2 -> 4.3 ``                                                                  |
| [`ea9b0dae`](https://github.com/NixOS/nixpkgs/commit/ea9b0daeee2e14fce2578bc00115ac9f513e3473) | `` nixos/test-instrumentation: forward journald to correct tty also in systemd initrd `` |
| [`69ea6dbe`](https://github.com/NixOS/nixpkgs/commit/69ea6dbe940c3da4a307b6d57cda5a2df099cf41) | `` deepin.deepin-music: pin ffmpeg 6 ``                                                  |
| [`7273516f`](https://github.com/NixOS/nixpkgs/commit/7273516ff448f97de563725d065fe7ea68b747e4) | `` u-root: add minimal kernel in passthru for local testing ``                           |
| [`1bb473ae`](https://github.com/NixOS/nixpkgs/commit/1bb473ae6235e5e0f02b674f4e72c1e791e6cdc7) | `` mkuimage: init at 0-unstable-2024-02-28 ``                                            |
| [`c858402c`](https://github.com/NixOS/nixpkgs/commit/c858402c2a629211153137fb8d39be9fde4694ff) | `` libcpr: 1.10.5 -> 1.11.0 ``                                                           |
| [`890d1ec4`](https://github.com/NixOS/nixpkgs/commit/890d1ec4bafb9b4d1145b5ed19c6b6eecc33e52c) | `` tdom: 0.9.4 -> 0.9.5 ``                                                               |
| [`7f2652e7`](https://github.com/NixOS/nixpkgs/commit/7f2652e77c442f71774bf929acd7ab138e88d1d9) | `` php82Extensions.memcached: 3.2.0 -> 3.3.0 ``                                          |
| [`06b34fe3`](https://github.com/NixOS/nixpkgs/commit/06b34fe320590301917300e1e5621ffaca007610) | `` python312Packages.pdf2docx: fix license ``                                            |
| [`cd44a4ad`](https://github.com/NixOS/nixpkgs/commit/cd44a4ad1e1dea6ea9042e0b3de72f84588bcc84) | `` python312Packages.pdf2docx: modernize ``                                              |
| [`512fa854`](https://github.com/NixOS/nixpkgs/commit/512fa85477d84da18516f69056975f140a025710) | `` python312Packages.pdf2docx: fix build ``                                              |
| [`6b3d803d`](https://github.com/NixOS/nixpkgs/commit/6b3d803ddddc6ad7612e16986aaee95fdd243859) | `` ida-free: fix hash mismatchin of icon ``                                              |
| [`2dc3caa0`](https://github.com/NixOS/nixpkgs/commit/2dc3caa083b72b3f5d2fea1a08e3460eb96989d4) | `` python3Packages.bugzilla: renamed into python-bugzilla ``                             |
| [`c5d1d88d`](https://github.com/NixOS/nixpkgs/commit/c5d1d88d5faa688d5f801684f904519d2e978e78) | `` python312Packages.aiortm: 0.9.12 -> 0.9.17 ``                                         |
| [`df03b322`](https://github.com/NixOS/nixpkgs/commit/df03b32278b211d2398c8cb1bc693a70ca8f3d73) | `` nixos/jupyter: set user primary group ``                                              |
| [`0d9ec510`](https://github.com/NixOS/nixpkgs/commit/0d9ec5106270e3596f6fd93fa87d4d42c1598f42) | `` python312Packages.swisshydrodata: 0.1.0 -> 0.2.1 ``                                   |
| [`532871af`](https://github.com/NixOS/nixpkgs/commit/532871af725896be1891b5b58897823231fcdd6e) | `` python312Packages.mypy-boto3-workspaces: 1.35.32 -> 1.35.43 ``                        |
| [`bcf38da5`](https://github.com/NixOS/nixpkgs/commit/bcf38da5ce342909e1a4a5e990dcead6241bbfc6) | `` python312Packages.mypy-boto3-transfer: 1.35.0 -> 1.35.40 ``                           |
| [`acf12909`](https://github.com/NixOS/nixpkgs/commit/acf1290922d7da5f89197c55d143419bfc3adeb8) | `` python312Packages.mypy-boto3-sesv2: 1.35.29 -> 1.35.41 ``                             |
| [`8550114c`](https://github.com/NixOS/nixpkgs/commit/8550114ceee5ed9823031ca3600f55c4ef285ae2) | `` python312Packages.mypy-boto3-securitylake: 1.35.0 -> 1.35.40 ``                       |
| [`3bc56c63`](https://github.com/NixOS/nixpkgs/commit/3bc56c638e6be7728ceac9b9ace3328ee80c9ffa) | `` python312Packages.mypy-boto3-s3: 1.35.32 -> 1.35.42 ``                                |
| [`6f1ca6db`](https://github.com/NixOS/nixpkgs/commit/6f1ca6db12b4627006349c222236697ac1b22758) | `` python312Packages.mypy-boto3-resiliencehub: 1.35.0 -> 1.35.41 ``                      |
| [`088600fc`](https://github.com/NixOS/nixpkgs/commit/088600fcd3c5c48c705cb95284c87b0f2321f032) | `` python312Packages.mypy-boto3-redshift: 1.35.35 -> 1.35.41 ``                          |
| [`7b2e267a`](https://github.com/NixOS/nixpkgs/commit/7b2e267acedb96fdd172109d4c8eec862ee139ad) | `` python312Packages.mypy-boto3-rds: 1.35.31 -> 1.35.43 ``                               |
| [`52f29b5f`](https://github.com/NixOS/nixpkgs/commit/52f29b5fb48b374f3e1db4faa64ea79bc0adc748) | `` python312Packages.mypy-boto3-quicksight: 1.35.33 -> 1.35.43 ``                        |
| [`bbc54ff1`](https://github.com/NixOS/nixpkgs/commit/bbc54ff10ec6c8d485ef754b43e0518b11c400a0) | `` python312Packages.mypy-boto3-pipes: 1.35.16 -> 1.35.43 ``                             |
| [`6840f27e`](https://github.com/NixOS/nixpkgs/commit/6840f27e74d04fe138d221e1c541308ea4ffd008) | `` python312Packages.mypy-boto3-pinpoint-sms-voice-v2: 1.35.26 -> 1.35.43 ``             |
| [`90aa716c`](https://github.com/NixOS/nixpkgs/commit/90aa716c0e1e516f0bea51507a368220f59b3975) | `` python312Packages.mypy-boto3-ivs: 1.35.19 -> 1.35.41 ``                               |
| [`f86b185f`](https://github.com/NixOS/nixpkgs/commit/f86b185fcf78fa65662b8d2b925a053f693aadc1) | `` python312Packages.mypy-boto3-ecs: 1.35.38 -> 1.35.43 ``                               |
| [`6423f9bf`](https://github.com/NixOS/nixpkgs/commit/6423f9bf125805fe89af1cc532d8f6c6b11a64b9) | `` python312Packages.mypy-boto3-dataexchange: 1.35.0 -> 1.35.43 ``                       |
| [`5bf5d422`](https://github.com/NixOS/nixpkgs/commit/5bf5d42248e59b665442f5001ce140356701a3f5) | `` python312Packages.mypy-boto3-codepipeline: 1.35.37 -> 1.35.40 ``                      |
| [`f3663724`](https://github.com/NixOS/nixpkgs/commit/f36637246da91722f037ba95d0a4b247091cb41d) | `` python312Packages.mypy-boto3-codebuild: 1.35.21 -> 1.35.41 ``                         |
| [`45f6521d`](https://github.com/NixOS/nixpkgs/commit/45f6521d641b442fee34729b00d31c3de45e95da) | `` python312Packages.mypy-boto3-cloudformation: 1.35.0 -> 1.35.41 ``                     |
| [`65752282`](https://github.com/NixOS/nixpkgs/commit/657522822cb6167c9569b6e4616193b69e8c5a44) | `` python312Packages.mypy-boto3-amplify: 1.35.19 -> 1.35.41 ``                           |
| [`dcba7d34`](https://github.com/NixOS/nixpkgs/commit/dcba7d34c53234ddb2e4a027b5ff27f92a7587a7) | `` metasploit: 6.4.30 -> 6.4.31 ``                                                       |
| [`9c4b6a30`](https://github.com/NixOS/nixpkgs/commit/9c4b6a30b93cbeaa332f3e5721f79c09713b7240) | `` trufflehog: 3.82.8 -> 3.82.11 ``                                                      |
| [`f7adc837`](https://github.com/NixOS/nixpkgs/commit/f7adc837bce0cf296dcd525188fc8fed68b75a09) | `` python312Packages.typer-shell: 0.1.11 -> 0.1.12 ``                                    |
| [`8bfb3120`](https://github.com/NixOS/nixpkgs/commit/8bfb31201e9f1dc44a64d10d8768bc6b967426f8) | `` python312Packages.pwkit: 1.2.1 -> 1.2.2 ``                                            |
| [`7cb2e9d3`](https://github.com/NixOS/nixpkgs/commit/7cb2e9d3b758e1745ef180dc5a07f8c5686b3275) | `` python312Packages.pyexploitdb: 0.2.38 -> 0.2.39 ``                                    |
| [`655c7b0e`](https://github.com/NixOS/nixpkgs/commit/655c7b0e425c264a8699cbcf3e5c51d7bf2447d9) | `` python312Packages.pyjson5: 1.6.6 -> 1.6.7 ``                                          |
| [`8855536b`](https://github.com/NixOS/nixpkgs/commit/8855536bbb86a17f50c6dbe0920646e2893adf63) | `` python312Packages.reolink-aio: 0.9.11 -> 0.10.0 ``                                    |
| [`79e27211`](https://github.com/NixOS/nixpkgs/commit/79e27211a61a9b6aff12f8cc894e11ace9baa741) | `` python312Packages.pysmi: 1.5.0 -> 1.5.4 ``                                            |
| [`70d1b8a3`](https://github.com/NixOS/nixpkgs/commit/70d1b8a33eb1de39a8605d175e04b72226bf8134) | `` python312Packages.pyrisco: 0.6.4 -> 0.6.5 ``                                          |
| [`b11b9a19`](https://github.com/NixOS/nixpkgs/commit/b11b9a19bf8a6e4e33224ab498030d105d37d3db) | `` python312Packages.pyotgw: 2.2.1 -> 2.2.2 ``                                           |
| [`d6c72582`](https://github.com/NixOS/nixpkgs/commit/d6c72582bb7d51d14947809f323a62557e26ed76) | `` python312Packages.publicsuffixlist: 1.0.2.20241010 -> 1.0.2.20241017 ``               |
| [`46678b17`](https://github.com/NixOS/nixpkgs/commit/46678b17c5cc2c3fc91ebd94c32c5711a42ded9f) | `` python312Packages.plugwise: 1.4.1 -> 1.4.2 ``                                         |
| [`67a6f34c`](https://github.com/NixOS/nixpkgs/commit/67a6f34ca0281aaa7397738aeadf828fe654b3a3) | `` basex: 11.1 -> 11.4 ``                                                                |
| [`a24e412f`](https://github.com/NixOS/nixpkgs/commit/a24e412f3256fbf9fe73558ecbbdcbf7b29448d9) | `` python312Packages.mitogen: 0.3.13 -> 0.3.14 ``                                        |
| [`ebf552be`](https://github.com/NixOS/nixpkgs/commit/ebf552be094282be6646104ffab6eee7bca68521) | `` python312Packages.lxmf: 0.5.6 -> 0.5.7 ``                                             |
| [`12ca43ae`](https://github.com/NixOS/nixpkgs/commit/12ca43ae1ec5c28ef997ee7132b3b3aa4d1599ef) | `` python312Packages.ipwhois: 1.2.0 -> 1.3.0 ``                                          |
| [`626bc994`](https://github.com/NixOS/nixpkgs/commit/626bc994f02ebaae1f8293702826eebe65a92233) | `` python312Packages.censys: 2.2.14 -> 2.2.15 ``                                         |
| [`094125f7`](https://github.com/NixOS/nixpkgs/commit/094125f7508c16be29e092bf009feb5c7aa4ec6f) | `` python312Packages.dirigera: 1.2.0 -> 1.2.1 ``                                         |
| [`bc103338`](https://github.com/NixOS/nixpkgs/commit/bc1033387cdf29459829c0018b9f821bbc3cb334) | `` python312Packages.appthreat-vulnerability-db: 6.0.14 -> 6.1.0 ``                      |
| [`1313f9e8`](https://github.com/NixOS/nixpkgs/commit/1313f9e8f834cb34531e21007140c3a4ef841941) | `` python312Packages.aliyun-python-sdk-core: 2.15.2 -> 2.16.0 ``                         |
| [`7f5a6e88`](https://github.com/NixOS/nixpkgs/commit/7f5a6e887e3c2431087064834a8dca74a6312def) | `` python312Packages.aioopenexchangerates: 0.6.6 -> 0.6.7 ``                             |
| [`ba62342a`](https://github.com/NixOS/nixpkgs/commit/ba62342af9b6e8d3535e80d733ef8f742b8acf2a) | `` prowler: 4.3.7 -> 4.4.1 ``                                                            |
| [`54e338b5`](https://github.com/NixOS/nixpkgs/commit/54e338b51d1ac5e163c42ef3e76fa5dd225fc883) | `` ggshield: 1.32.1 -> 1.32.2 ``                                                         |
| [`e4d5f5cf`](https://github.com/NixOS/nixpkgs/commit/e4d5f5cfe503d38e8510321c45bc82e430c33126) | `` ldeep: 1.0.70 -> 1.0.72 ``                                                            |
| [`128e6ccc`](https://github.com/NixOS/nixpkgs/commit/128e6ccc67ab3392202b2cea18ab34dda375b9e8) | `` cloudfox: 1.14.2 -> 1.15.0 ``                                                         |
| [`1b376df9`](https://github.com/NixOS/nixpkgs/commit/1b376df9cfafc8f3246663617105493ac91d324d) | `` python3Packages.bugzilla: switch to buildPythonPackage:pyproject ``                   |
| [`bf3053df`](https://github.com/NixOS/nixpkgs/commit/bf3053dfc117a5e5f7c7d4e06e1fe7ffcd531504) | `` python3Packages.bugzilla: use fetchPypi.hash instead of sha256 ``                     |
| [`e9ddacf2`](https://github.com/NixOS/nixpkgs/commit/e9ddacf236687203430818c49a3eff17e0be3517) | `` grafana: 11.2.2 -> 11.2.2+security-01, fix CVE-2024-9264 ``                           |
| [`c4c95cac`](https://github.com/NixOS/nixpkgs/commit/c4c95cac8161486a52f901a27ccdb5f8e80380b1) | `` Revert "buildRustPackage: disable cargo-auditable on pkgsStatic aarch64" ``           |
| [`88c41d8a`](https://github.com/NixOS/nixpkgs/commit/88c41d8a918925f5ccc915734bb8095833496d82) | `` Revert "rust: allow linker to be different from compiler" ``                          |
| [`351899cd`](https://github.com/NixOS/nixpkgs/commit/351899cd4b3d03cc6c038597c0f0610cca321b7b) | `` Revert "rust: use lld on pkgsStatic aarch64" ``                                       |
| [`3e1b768e`](https://github.com/NixOS/nixpkgs/commit/3e1b768ec7a37ea0e0dec24242080586703dc720) | `` python312Packages.ruff-lsp: 0.0.57 -> 0.0.58 ``                                       |
| [`6f45e688`](https://github.com/NixOS/nixpkgs/commit/6f45e688f8f4be8424ea8ef5d50d583efc6da376) | `` python312Packages.jupyter-collaboration: 2.1.3 -> 2.1.4 ``                            |
| [`fe23a392`](https://github.com/NixOS/nixpkgs/commit/fe23a39256bd0c441c4867660bc522f2a01c50df) | `` ruff: 0.6.9 -> 0.7.0 ``                                                               |
| [`539c6f76`](https://github.com/NixOS/nixpkgs/commit/539c6f765492ab6e11d99e500347eb7eff5fc3fe) | `` vimPlugins.telekasten-nvim: add missing dependencies ``                               |
| [`8e650135`](https://github.com/NixOS/nixpkgs/commit/8e6501351cd4857cdff2d38a0e6304e8ed5955a7) | `` devenv: 1.3 -> 1.3.1 ``                                                               |
| [`c4aecf31`](https://github.com/NixOS/nixpkgs/commit/c4aecf316040e164c0ab49e974847932d90d2a5a) | `` aaphoto: fix src ``                                                                   |
| [`abca0a57`](https://github.com/NixOS/nixpkgs/commit/abca0a57ac2c1c69808fef2e8031c9c5701b75a5) | `` biome: 1.9.2 -> 1.9.3 ``                                                              |
| [`05172055`](https://github.com/NixOS/nixpkgs/commit/05172055a181b78e4d2a85f65a8ebdc9883b6521) | `` lxqt.libqtxdg: 4.0.0 -> 4.0.1 ``                                                      |
| [`403604ca`](https://github.com/NixOS/nixpkgs/commit/403604ca66e87e0886f179cba63699073a10fe3b) | `` resolvconf: use correct output files when used with dnsmasq ``                        |
| [`15fe493d`](https://github.com/NixOS/nixpkgs/commit/15fe493d6fcc60d2f5668db422621b57e245e0d7) | `` cosmic-icons: nixfmt-rfc-style ``                                                     |
| [`2fe3912f`](https://github.com/NixOS/nixpkgs/commit/2fe3912fdb9210a8ef64bbe26a4399ec52202f03) | `` quictls: 3.1.5 -> 3.3.0 ``                                                            |
| [`76e0284e`](https://github.com/NixOS/nixpkgs/commit/76e0284e88749dcf441819fd6dd0c3fd9b710219) | `` system76-power: migrate to pkgs/by-name format ``                                     |
| [`969102bd`](https://github.com/NixOS/nixpkgs/commit/969102bd1172bb00b0e0b694356ccdaa9224ada8) | `` system76-scheduler: migrate to pkgs/by-name format ``                                 |
| [`1d4df7ad`](https://github.com/NixOS/nixpkgs/commit/1d4df7adcc918f23c9c8fb357dd3bb7861270fed) | `` system76-scheduler: Move out of kernel category ``                                    |
| [`a1c03ab0`](https://github.com/NixOS/nixpkgs/commit/a1c03ab062da59936e7cc46e9ea7b204f864dea5) | `` system76-power: Move out of kernel category ``                                        |
| [`30297417`](https://github.com/NixOS/nixpkgs/commit/3029741718f4c765fbc5ebf76bea3d6c8ff15fe5) | `` buck2: unstable-2024-05-15 -> unstable-2024-10-15 ``                                  |
| [`5ee46b6e`](https://github.com/NixOS/nixpkgs/commit/5ee46b6e75417fcdf441226e00d2a020ebbffddc) | `` python312Packages.jupyter-ydoc: 2.1.1 -> 2.1.2 ``                                     |
| [`aec0a90d`](https://github.com/NixOS/nixpkgs/commit/aec0a90d2fc567712c79d1bbb7f986469ce31a4e) | `` python312Packages.pycrdt-websocket: 0.14.2 -> 0.15.1 ``                               |
| [`27ed4c52`](https://github.com/NixOS/nixpkgs/commit/27ed4c52c1802c543624988b845920e799ee6062) | `` python312Packages.pycrdt: 0.9.16 -> 0.10.3 ``                                         |
| [`6de674c9`](https://github.com/NixOS/nixpkgs/commit/6de674c9ccaf90e1c7678bc6255549e7fa721f48) | `` prometheus-redis-exporter: 1.63.0 -> 1.65.0 ``                                        |
| [`75e9810d`](https://github.com/NixOS/nixpkgs/commit/75e9810da8a272e23eb81bb08d21c6d2e64a4ccb) | `` linux: enable FF support for hid-nvidia-shield ``                                     |
| [`76d85375`](https://github.com/NixOS/nixpkgs/commit/76d85375cb1642f9525fbcc75b83ea6f5755470e) | `` python312Packages.pytensor: set version to 2.25.5 ``                                  |
| [`7c7ae6a3`](https://github.com/NixOS/nixpkgs/commit/7c7ae6a334944343385eceda1c2b8e089d3a48a4) | `` cosmic-icons: inline pname ``                                                         |
| [`bc6e6d98`](https://github.com/NixOS/nixpkgs/commit/bc6e6d9847423d78dcc25d507e5108d9a6e30351) | `` cosmic-icons: use nix-update-script instead of unstableGitUpdater ``                  |
| [`139cb739`](https://github.com/NixOS/nixpkgs/commit/139cb739fd98f62245c2c9ca45d1c0fb33ed47e3) | `` Use recommended version check ``                                                      |
| [`1a5b596d`](https://github.com/NixOS/nixpkgs/commit/1a5b596d5aa4594b9923a35bbfa1a09322143cd2) | `` sqruff: init at 0.17.0 ``                                                             |
| [`1d3c4e43`](https://github.com/NixOS/nixpkgs/commit/1d3c4e4324d3aeb6cf5b950e6175b5512fe0ce1a) | `` maintainers: add Hasnep ``                                                            |
| [`beb7aeec`](https://github.com/NixOS/nixpkgs/commit/beb7aeeca17873a52b00252ec07d89da7423f4e7) | `` linux-firmware: 20240909 -> 20241017 ``                                               |
| [`f0dce5f0`](https://github.com/NixOS/nixpkgs/commit/f0dce5f0ba4611c8e65a64ff060d7a72699213ef) | `` mkvtoolnix: fix build by backporting patch ``                                         |
| [`7f110cfc`](https://github.com/NixOS/nixpkgs/commit/7f110cfc7de92ca5f0af3ee368d29caca531fa74) | `` sql-formatter: 15.4.2 -> 15.4.3, migrate from nodePackages (#323304) ``               |
| [`fbef14a1`](https://github.com/NixOS/nixpkgs/commit/fbef14a19edfb564c2da2e933a06842e7af4da86) | `` errcheck: 1.7.0 -> 1.8.0 ``                                                           |
| [`71c64f8e`](https://github.com/NixOS/nixpkgs/commit/71c64f8ecc52879a5de35a920a57898331d483cb) | `` initrd: drop effectless modification of kmod-blacklist ``                             |
| [`1b212b8a`](https://github.com/NixOS/nixpkgs/commit/1b212b8a10a5d2c73c6f8aa64cb4500c3944c981) | `` pyflyby: init at 1.9.6 ``                                                             |
| [`31f217fb`](https://github.com/NixOS/nixpkgs/commit/31f217fbfe4431dda1ca96209d30b9bdbe33f4f4) | `` coroot: 1.5.8 -> 1.5.9 ``                                                             |
| [`2a1497e9`](https://github.com/NixOS/nixpkgs/commit/2a1497e916a4feae70ae495f22bac3c32408c9dd) | `` linux_5_10: 5.10.226 -> 5.10.227 ``                                                   |
| [`e3aaef14`](https://github.com/NixOS/nixpkgs/commit/e3aaef1472ccdd9568187b7f0cb909b96864d482) | `` linux_5_15: 5.15.167 -> 5.15.168 ``                                                   |
| [`d0227f7d`](https://github.com/NixOS/nixpkgs/commit/d0227f7da53cc7d3088eafaf67282fd3d85cd6c7) | `` linux_6_1: 6.1.112 -> 6.1.113 ``                                                      |
| [`0e4c64ff`](https://github.com/NixOS/nixpkgs/commit/0e4c64ff9cef5800c6a3f4838c66a918ceb61398) | `` linux_6_6: 6.6.56 -> 6.6.57 ``                                                        |
| [`0910e4bb`](https://github.com/NixOS/nixpkgs/commit/0910e4bbbb6dfb2b8a33b0dc09171ae53561d485) | `` linux_6_11: 6.11.3 -> 6.11.4 ``                                                       |
| [`055d124b`](https://github.com/NixOS/nixpkgs/commit/055d124b37a6c5f8d2c4dc454a64e449ac6c5560) | `` linux_testing: 6.12-rc2 -> 6.12-rc3 ``                                                |
| [`0551f61f`](https://github.com/NixOS/nixpkgs/commit/0551f61f0cc0608d56117f4d8b97d88dc0e233e2) | `` multipass: 1.14.0 -> 1.14.1 ``                                                        |
| [`04e39de6`](https://github.com/NixOS/nixpkgs/commit/04e39de6eb236b086e486193510069ffe683062b) | `` nixos/immich: do not set services.redis.servers.immich.user ``                        |
| [`66f3134f`](https://github.com/NixOS/nixpkgs/commit/66f3134f2e541373c1327aa0377cd2dd577a208e) | `` python3.pkgs.ibis-framework: remove dask input ``                                     |
| [`cdae25b0`](https://github.com/NixOS/nixpkgs/commit/cdae25b080b3abcf41c85441d304fe853ea4c336) | `` signal-desktop-beta: 7.29.0-beta.1 -> 7.30.0-beta.1 ``                                |
| [`2287e63e`](https://github.com/NixOS/nixpkgs/commit/2287e63efddd08de4c0fa7c44a75768344286f0e) | `` signal-desktop(darwin): 7.28.0 -> 7.29.0 ``                                           |
| [`25c4c172`](https://github.com/NixOS/nixpkgs/commit/25c4c17206af0b03da60e0652489f40d5caa9838) | `` signal-desktop(linux): 7.28.0 -> 7.29.0 ``                                            |
| [`82c53234`](https://github.com/NixOS/nixpkgs/commit/82c532349e08e30874e601674b8d24b80338fc91) | `` kdePackages.mpvqt: 1.0.0 -> 1.0.1 ``                                                  |
| [`76ae387f`](https://github.com/NixOS/nixpkgs/commit/76ae387ff3c75f4629f2b8643ce114be71699d6b) | `` sing-box: 1.10.0 -> 1.10.1 ``                                                         |
| [`ec4f809c`](https://github.com/NixOS/nixpkgs/commit/ec4f809cd5c718b9334459d32e940e02a3cdb9c8) | `` forgejo: 8.0.3 -> 9.0.0 ``                                                            |
| [`e1a60202`](https://github.com/NixOS/nixpkgs/commit/e1a60202156a760444347f514926388a8814dd5f) | `` forgejo: add marie to maintainers ``                                                  |
| [`ddbd7b7c`](https://github.com/NixOS/nixpkgs/commit/ddbd7b7c58b2c1340905ab142206159bfc49f179) | `` python312Packages.portion: 2.5.0 -> 2.6.0 ``                                          |
| [`f9d8517d`](https://github.com/NixOS/nixpkgs/commit/f9d8517d5d23305d82ef2ec7dd7659603b9812c5) | `` lenovo-legion: 0.0.12 -> 0.0.18 with patches in master ``                             |
| [`8de11d32`](https://github.com/NixOS/nixpkgs/commit/8de11d32de14d96e3a33c74dca59793801595bad) | `` maintainers: add chn ``                                                               |
| [`0a0c9e56`](https://github.com/NixOS/nixpkgs/commit/0a0c9e56cd7cfe1b18745fd5c6c741a3d1b6a0ca) | `` CONTRIBUTING: add section on getting the PR over the finish line ``                   |
| [`9b8aa25e`](https://github.com/NixOS/nixpkgs/commit/9b8aa25e9ccd8ac911c38c3ad8123eef4d382dce) | `` CONTRIBUTING: add section on getting your PR merged ``                                |
| [`b628bd00`](https://github.com/NixOS/nixpkgs/commit/b628bd00fbf8e2c5916a648ddc6e72a955af4e11) | `` ansiwrap: mark as broken ``                                                           |