### PR TITLE
chore(flake/darwin): `a60ac02f` -> `a001f44c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728901530,
-        "narHash": "sha256-I9Qd0LnAsEGHtKE9+uVR0iDFmsijWSy7GT0g3jihG4Q=",
+        "lastModified": 1729382845,
+        "narHash": "sha256-REiWck1zIOnZIgGmmOWfwvkQw1f4UrBsxxOSKVSAG4w=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "a60ac02f9466f85f092e576fd8364dfc4406b5a6",
+        "rev": "a001f44cfc47164839eb61c6b1e7f4288813f7e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                         |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`4054d5ca`](https://github.com/LnL7/nix-darwin/commit/4054d5caea22367763a8cc7781d5723e86e3d1fb) | `` Use the correct file location for `SoftwareUpdate` plist. `` |