### PR TITLE
chore(flake/nixos-hardware): `9da64c8f` -> `9fcf30fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -556,11 +556,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1729454199,
-        "narHash": "sha256-bc6swhbI2P4Wa0FZNRXfVcSQfug+HBULPmLycO/9vPw=",
+        "lastModified": 1729455275,
+        "narHash": "sha256-THqzn/7um3oMHUEGXyq+1CJQE7EogwR3HjLMNOlhFBE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9da64c8fd97274d6cd2fda6bc161abc229aeb6c9",
+        "rev": "9fcf30fccf8435f6390efec4a4d38e69c2268a36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`9fcf30fc`](https://github.com/NixOS/nixos-hardware/commit/9fcf30fccf8435f6390efec4a4d38e69c2268a36) | `` Make starfive-visionfive-2 merge with sd-image module `` |