### PR TITLE
chore(flake/lovesegfault-vim-config): `a6a3a09e` -> `2f1e0073`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729383226,
-        "narHash": "sha256-Ml3bJogc2PG8UqcBzk6i5JkQLp/SGF9FNchYhxey5kk=",
+        "lastModified": 1729469365,
+        "narHash": "sha256-BIX7kYsXPhtXKn9DWEwfUxQ08ggXR8WMzXjleboKeJ4=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "a6a3a09e1e01020bd257df9da355996e31f63d9e",
+        "rev": "2f1e0073e89c8fc5b6ca268271e4c6b31f493d0f",
         "type": "github"
       },
       "original": {
@@ -649,11 +649,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729368702,
-        "narHash": "sha256-KW+NFU0woUYpiVsdbXO5YAKCnKZ743BJlnG4ZEflvfs=",
+        "lastModified": 1729438888,
+        "narHash": "sha256-TGTDOX2/5OIoSzlcRReVn4BbbfL6Ami/eassiPPGqNA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c4ad4d0b2e7de04fa9ae0652b006807f42062080",
+        "rev": "47b563d4e1410bff6a9481b3dd8b01b1e5ed70d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`2f1e0073`](https://github.com/lovesegfault/vim-config/commit/2f1e0073e89c8fc5b6ca268271e4c6b31f493d0f) | `` chore(flake/nixvim): c4ad4d0b -> 47b563d4 `` |