### PR TITLE
chore(flake/nixos-hardware): `9fcf30fc` -> `7495e877`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -556,11 +556,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1729455275,
-        "narHash": "sha256-THqzn/7um3oMHUEGXyq+1CJQE7EogwR3HjLMNOlhFBE=",
+        "lastModified": 1729501257,
+        "narHash": "sha256-q6ofDeqzv1/mLe+ru7lJbgerOMDOT83PXy84vsi+Jhg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9fcf30fccf8435f6390efec4a4d38e69c2268a36",
+        "rev": "7495e877539919988c9ebe4ae0f47343982da0e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`7495e877`](https://github.com/NixOS/nixos-hardware/commit/7495e877539919988c9ebe4ae0f47343982da0e5) | `` treewide: Switch from gpu/intel to cpu/intel where applicable `` |
| [`c058019c`](https://github.com/NixOS/nixos-hardware/commit/c058019ce1b72c7d450f5e2b3f0921bd205e9f79) | `` common/cpu/intel: add architecture-specific modules ``           |