### PR TITLE
chore(flake/disko): `a6a3179d` -> `4be2aadf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729281548,
-        "narHash": "sha256-MuojlSnwAJAwfhgmW8ZtZrwm2Sko4fqubCvReqbUzYw=",
+        "lastModified": 1729588208,
+        "narHash": "sha256-PNONdMd+sG7JWzNIDerX7oVZXL8FTVlSAZ1BmUo2HjE=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "a6a3179ddf396dfc28a078e2f169354d0c137125",
+        "rev": "4be2aadf13b67ffbb993deb73adff77c46b728fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                           |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`4be2aadf`](https://github.com/nix-community/disko/commit/4be2aadf13b67ffbb993deb73adff77c46b728fc) | `` lib: use lib.escapeShellArg for concatenated paths ``                          |
| [`ca47da60`](https://github.com/nix-community/disko/commit/ca47da60e569c7d355b5ccbaebb2a407231bacd8) | `` disko: fix improper handling of whitespace ``                                  |
| [`78d685c1`](https://github.com/nix-community/disko/commit/78d685c123bd9ea7e3b6c23be65224c28db57251) | `` tests: Add failing test to demonstrate issues with whitespace in part names `` |