### PR TITLE
chore(flake/darwin): `d99f9ae9` -> `5f05c2c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729694034,
-        "narHash": "sha256-nGBcMeL6iB20z8Gz/H6roGa/WRmKAmipY0/iXCq4DCo=",
+        "lastModified": 1729727404,
+        "narHash": "sha256-NwBlKkNCgDnD0lSebVGjCSPUHyUTj8JjAAaQueSGvGw=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "d99f9ae9fdfbcc36b81d264678bf58004464892e",
+        "rev": "5f05c2c3d296c358dbdee8591528959d5360c247",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                             |
| ------------------------------------------------------------------------------------------------ | ----------------------------------- |
| [`7ebf95a7`](https://github.com/LnL7/nix-darwin/commit/7ebf95a73e3b54e0f9c48f50fde29e96257417ac) | `` style fixes ``                   |
| [`72e93853`](https://github.com/LnL7/nix-darwin/commit/72e93853c2d16d1ce04a5e8eee6695e2493ca80d) | `` module: add aerospace service `` |