### PR TITLE
chore(flake/darwin): `5f05c2c3` -> `04193f18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729727404,
-        "narHash": "sha256-NwBlKkNCgDnD0lSebVGjCSPUHyUTj8JjAAaQueSGvGw=",
+        "lastModified": 1729757100,
+        "narHash": "sha256-x+8uGaX66V5+fUBHY23Q/OQyibQ38nISzxgj7A7Jqds=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "5f05c2c3d296c358dbdee8591528959d5360c247",
+        "rev": "04193f188e4144d7047f83ad1de81d6034d175cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                       |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
| [`b089e7e7`](https://github.com/LnL7/nix-darwin/commit/b089e7e7266403ddda9f96bfd8c5adf9a0f0f6b5) | `` users: switch back to using `dscl` for deleting users ``                   |
| [`b7027502`](https://github.com/LnL7/nix-darwin/commit/b702750226a86abb029440641bfa994ff650cf99) | `` users: ensure Full Disk Access is granted before trying to create users `` |
| [`2be05de0`](https://github.com/LnL7/nix-darwin/commit/2be05de06ed8e634c839ad58ffb895d5bed98c0a) | `` users: add missing newlines for FDA prompt ``                              |
| [`467a0d3d`](https://github.com/LnL7/nix-darwin/commit/467a0d3d0c27ed7e688c040281aced98d37120d2) | `` users: prevent deleting the user calling `darwin-rebuild` ``               |
| [`bbe19172`](https://github.com/LnL7/nix-darwin/commit/bbe1917238b3ea22890e5aa3fe51ed6910ee9429) | `` users: ensure users' shells are installed ``                               |