### PR TITLE
chore(flake/darwin): `8c675759` -> `7840909b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729821670,
-        "narHash": "sha256-XBoA12kQc8ZMaSOlxICwCu2wC4U0j1u41JJaAVdRwHA=",
+        "lastModified": 1729826725,
+        "narHash": "sha256-w3WNlYxqWYsuzm/jgFPyhncduoDNjot28aC8j39TW0U=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "8c675759e94b243c45ac9c080c7af286da9a08c6",
+        "rev": "7840909b00fbd5a183008a6eb251ea307fe4a76e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                           |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
| [`c98bb238`](https://github.com/LnL7/nix-darwin/commit/c98bb238b16ba2cfc8eb9d5d5a18b79f8caacf25) | `` darwin-rebuild: Align usage description with implementation `` |