### PR TITLE
chore(flake/home-manager): `a4353cc4` -> `eea1bc60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729716953,
-        "narHash": "sha256-FbRKGRRd0amsk/WS/UV9ukJ8jT1dZ2pJBISxkX+uq6A=",
+        "lastModified": 1729842821,
+        "narHash": "sha256-TOLiSoV9h3+Qn9sVNFCQyKo+1a1IhKj4LYqv1VOHDQk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a4353cc43d1b4dd6bdeacea90eb92a8b7b78a9d7",
+        "rev": "eea1bc607249f0b79fb437b5e9709aa6d2218bac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`eea1bc60`](https://github.com/nix-community/home-manager/commit/eea1bc607249f0b79fb437b5e9709aa6d2218bac) | `` gpg-agent: use $TTY parameter in zsh integration `` |
| [`454e8d6b`](https://github.com/nix-community/home-manager/commit/454e8d6b15aafb02fd22bba0edc4cc0b06dd0f41) | `` granted: use assume directly ``                     |
| [`0a0b1b18`](https://github.com/nix-community/home-manager/commit/0a0b1b18bdd16d3f810178c7aec9eca730699631) | `` maintainers: remove omernaveedxyz ``                |