### PR TITLE
chore(flake/home-manager): `c77c3bb2` -> `0c0268a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729848063,
-        "narHash": "sha256-1uGIPOSJq4IzoDvgfOF6A3sw5it1WX3ZdYl2+jCkjv8=",
+        "lastModified": 1729864948,
+        "narHash": "sha256-CeGSqbN6S8JmzYJX/HqZjr7dMGlvHLLnJJarwB45lPs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c77c3bb23390a9ba91860e721edde54856fc5f7a",
+        "rev": "0c0268a3c80d30b989d0aadbd65f38d4fa27a9a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`0c0268a3`](https://github.com/nix-community/home-manager/commit/0c0268a3c80d30b989d0aadbd65f38d4fa27a9a0) | `` eza: add color option ``                       |
| [`c0e23159`](https://github.com/nix-community/home-manager/commit/c0e23159872e2e2135c7eb5cf96cd36cfe6ee1f4) | `` git-credential-oauth: add extraFlags option `` |
| [`6cc03e33`](https://github.com/nix-community/home-manager/commit/6cc03e337aa1d0222e5942f58839d965075a9781) | `` nix-gc: add `randomizedDelaySec` option ``     |