### PR TITLE
chore(flake/nix-index-database): `04f8a11f` -> `0e3a8778`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729394935,
-        "narHash": "sha256-2ntUG+NJKdfhlrh/tF+jOU0fOesO7lm5ZZVSYitsvH8=",
+        "lastModified": 1729999765,
+        "narHash": "sha256-LYsavZXitFjjyETZoij8usXjTa7fa9AIF3Sk3MJSX+Y=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "04f8a11f247ba00263b060fbcdc95484fd046104",
+        "rev": "0e3a8778c2ee218eff8de6aacf3d2fa6c33b2d4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`0e3a8778`](https://github.com/nix-community/nix-index-database/commit/0e3a8778c2ee218eff8de6aacf3d2fa6c33b2d4f) | `` update generated.nix to release 2024-10-27-031722 `` |
| [`17767638`](https://github.com/nix-community/nix-index-database/commit/17767638332b2de04e28ae1fecb931f40dd47c1e) | `` flake.lock: Update ``                                |