### PR TITLE
chore(flake/disko): `58cd8324` -> `89e458a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729942962,
-        "narHash": "sha256-xzt7tb4YUw6VZXSCGw4sukirJSfYsIcFyvmhK5KMiKw=",
+        "lastModified": 1730045523,
+        "narHash": "sha256-W5Avk1THhZALXITHGazKfZbIZ5+Bc4nSYvAYHUn96EU=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "58cd832497f9c87cb4889744b86aba4284fd0474",
+        "rev": "89e458a3bb3693e769bfb2b2447c3fe72092d498",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                           |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`89e458a3`](https://github.com/nix-community/disko/commit/89e458a3bb3693e769bfb2b2447c3fe72092d498) | `` UX: be specific if disko-install failed or succeeded (#847) `` |