### PR TITLE
chore(flake/nixos-hardware): `e8a2f6d5` -> `6906ac67`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -556,11 +556,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1729742320,
-        "narHash": "sha256-u3Of8xRkN//me8PU+RucKA59/6RNy4B2jcGAF36P4jI=",
+        "lastModified": 1730068391,
+        "narHash": "sha256-jlAGtfMuI8pUUoUmNkm2P/38pOtHZdcAf3Az8XQLAf4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e8a2f6d5513fe7b7d15701b2d05404ffdc3b6dda",
+        "rev": "6906ac67a1078cf950b8527341e229eeecb5bc30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`59b6e11b`](https://github.com/NixOS/nixos-hardware/commit/59b6e11bea99805b02ab38c8f9d8ba21fee58874) | `` Set missing lib.literalExpression `` |