### PR TITLE
chore(flake/disko): `89e458a3` -> `3163b272`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730045523,
-        "narHash": "sha256-W5Avk1THhZALXITHGazKfZbIZ5+Bc4nSYvAYHUn96EU=",
+        "lastModified": 1730125078,
+        "narHash": "sha256-Cowae06J+l8SfnQ0XMed5NTH72lJlXLX6Yuc3S4GrYs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "89e458a3bb3693e769bfb2b2447c3fe72092d498",
+        "rev": "3163b2724c6adec071ce317e038ae71ce3ab5974",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                             |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`bba79f6b`](https://github.com/nix-community/disko/commit/bba79f6b5eea35713f27815acbcda8775025e4c3) | `` disk-image: Fix "unexpected argument 'customQemu'" eval error `` |