### PR TITLE
chore(flake/disko): `3163b272` -> `0e55423b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730125078,
-        "narHash": "sha256-Cowae06J+l8SfnQ0XMed5NTH72lJlXLX6Yuc3S4GrYs=",
+        "lastModified": 1730135292,
+        "narHash": "sha256-QUU1P8x42b8moaUsxJkamfcRXdyNjIq79ZThzT3CVUA=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "3163b2724c6adec071ce317e038ae71ce3ab5974",
+        "rev": "0e55423bf8c241cf18676a8b8424c7eadd170ffc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                            |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`0e55423b`](https://github.com/nix-community/disko/commit/0e55423bf8c241cf18676a8b8424c7eadd170ffc) | `` release: reset released flag `` |
| [`ab58501b`](https://github.com/nix-community/disko/commit/ab58501b2341bc5e0fc88f2f5983a679b075ddf5) | `` release: v1.9.0 ``              |