### PR TITLE
chore(flake/darwin): `5c0c6aaa` -> `a55c84e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730070491,
-        "narHash": "sha256-+RYCbdU6l4E4pr40++lrdhdE3gNC/BR54AL7xWG/YRU=",
+        "lastModified": 1730165900,
+        "narHash": "sha256-svfZVrk3QV9adnDmgIhv887yAO1qPk3CfGt+xRHhcj4=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "5c0c6aaa797d6ccbb6cdab14de0248135735709d",
+        "rev": "a55c84e06f547b12710ad001f2ed2d21e8f902c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                               |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
| [`f380194f`](https://github.com/LnL7/nix-darwin/commit/f380194f3dac82e63dc72db160490dcb58208534) | `` users: create users with home directory `/var/empty` by default `` |
| [`c908607e`](https://github.com/LnL7/nix-darwin/commit/c908607e8a8ac1aaa0db60955800be4b02e500cc) | `` users: remove `users.forceRecreate` option ``                      |
| [`a15a3d9f`](https://github.com/LnL7/nix-darwin/commit/a15a3d9f1f9fadd455b38b3833e1ee6db6b59186) | `` users: fix unclosed string ``                                      |