### PR TITLE
chore(flake/darwin): `a55c84e0` -> `b379bd4d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730165900,
-        "narHash": "sha256-svfZVrk3QV9adnDmgIhv887yAO1qPk3CfGt+xRHhcj4=",
+        "lastModified": 1730184279,
+        "narHash": "sha256-6OB+WWR6gnaWiqSS28aMJypKeK7Pjc2Wm6L0MtOrTuA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "a55c84e06f547b12710ad001f2ed2d21e8f902c0",
+        "rev": "b379bd4d872d159e5189053ce9a4adf86d56db4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                          |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`6eea6b4a`](https://github.com/LnL7/nix-darwin/commit/6eea6b4a759be83e6d9310408aebeea54c404094) | `` Reuse nixpkgs instead of accessing channel `` |