### PR TITLE
chore(flake/lovesegfault-vim-config): `142695a6` -> `580d5885`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730246926,
-        "narHash": "sha256-o1GyDJx6MmiHKLOxq4YEZg8Oi8XOS3Bemd9Nwbfa7dM=",
+        "lastModified": 1730333542,
+        "narHash": "sha256-d+NLJmcwZsCVFE0WxXko8oUf1ZnbYoGP22TuIV6hsOw=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "142695a6394aa1199f5c63276b0f9fe935dcda88",
+        "rev": "580d58859ee52084c5983f5f621f36f252bee671",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`580d5885`](https://github.com/lovesegfault/vim-config/commit/580d58859ee52084c5983f5f621f36f252bee671) | `` chore(flake/treefmt-nix): 9ef337e4 -> 746901bb `` |
| [`4ba2615e`](https://github.com/lovesegfault/vim-config/commit/4ba2615e58cb793f32f58735837f3e8b7e012559) | `` chore(flake/git-hooks): 3c3e88f0 -> af8a16fe ``   |