### PR TITLE
chore(flake/darwin): `b379bd4d` -> `8dbda106`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730184279,
-        "narHash": "sha256-6OB+WWR6gnaWiqSS28aMJypKeK7Pjc2Wm6L0MtOrTuA=",
+        "lastModified": 1730395835,
+        "narHash": "sha256-ADGhFqM8hCabAEx2PADy+vi+iynO9aq221PxDZwrhww=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "b379bd4d872d159e5189053ce9a4adf86d56db4b",
+        "rev": "8dbda1064b0678cf0679e4f4091e91f7497e69a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                           |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
| [`470f87c1`](https://github.com/LnL7/nix-darwin/commit/470f87c1827b51169ed4f91cdbdfd48417bfff3d) | `` zsh: enable by default as zsh is the default shell on macOS `` |