### PR TITLE
chore(flake/impermanence): `e3374575` -> `32800b01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -411,11 +411,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1729068498,
-        "narHash": "sha256-C2sGRJl1EmBq0nO98TNd4cbUy20ABSgnHWXLIJQWRFA=",
+        "lastModified": 1730398040,
+        "narHash": "sha256-1M0uYGgEHZhDJhRh5GYSGXr241JL8tYN+qNEtQn8J/4=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "e337457502571b23e449bf42153d7faa10c0a562",
+        "rev": "32800b01f8ae9ec5ebf295d7fff1430762be30db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`2b84c693`](https://github.com/nix-community/impermanence/commit/2b84c693b9cf192807ecf910883b4ee16db7390a) | `` Update README.md with home-manager example ``         |
| [`21d60a0d`](https://github.com/nix-community/impermanence/commit/21d60a0db992bbad818ae26a145b23171399a1a1) | `` Use plural attribute names and add default modules `` |
| [`7a207dd3`](https://github.com/nix-community/impermanence/commit/7a207dd317524d86d8b2aa846072b703aec12f11) | `` Add home manager module ``                            |