### PR TITLE
chore(flake/impermanence): `32800b01` -> `0d09341b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -411,11 +411,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1730398040,
-        "narHash": "sha256-1M0uYGgEHZhDJhRh5GYSGXr241JL8tYN+qNEtQn8J/4=",
+        "lastModified": 1730403150,
+        "narHash": "sha256-W1FH5aJ/GpRCOA7DXT/sJHFpa5r8sq2qAUncWwRZ3Gg=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "32800b01f8ae9ec5ebf295d7fff1430762be30db",
+        "rev": "0d09341beeaa2367bac5d718df1404bf2ce45e6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| [`e447a0e8`](https://github.com/nix-community/impermanence/commit/e447a0e827c3b9b3dd482bef8561cc26f4cd0a7d) | `` Allow disabling of persistant storage location in home-manager like is possible in the nixos version. `` |