### PR TITLE
chore(flake/nixos-hardware): `da14839a` -> `be00f015`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -556,11 +556,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1730368399,
-        "narHash": "sha256-F8vJtG389i9fp3k2/UDYHMed3PLCJYfxCqwiVP7b9ig=",
+        "lastModified": 1730519544,
+        "narHash": "sha256-F1QQ6AsFvnohoNPOe5yms5E8HtF1C83MrlL3CExwlxQ=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "da14839ac5f38ee6adbdb4e6db09b5eef6d6ccdc",
+        "rev": "be00f01542ad0a2b9962ec691c5709944847686c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`be00f015`](https://github.com/NixOS/nixos-hardware/commit/be00f01542ad0a2b9962ec691c5709944847686c) | `` framework/bluetooth.nix: add EOL remark ``               |
| [`e4ad9ce3`](https://github.com/NixOS/nixos-hardware/commit/e4ad9ce38fa09e2f28ba15e830e17e367bf39a6c) | `` Framework: add workaround for Bluetooth device issues `` |