### PR TITLE
chore(flake/nixos-hardware): `be00f015` -> `d3986e78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -556,11 +556,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1730519544,
-        "narHash": "sha256-F1QQ6AsFvnohoNPOe5yms5E8HtF1C83MrlL3CExwlxQ=",
+        "lastModified": 1730520317,
+        "narHash": "sha256-IH+vuP/F4zdOwmbCNXtszaCbzAiqx5O72NwtlTv+Nco=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "be00f01542ad0a2b9962ec691c5709944847686c",
+        "rev": "d3986e78856a70d0b38d9e88dc39390556c2e962",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------- |
| [`d3986e78`](https://github.com/NixOS/nixos-hardware/commit/d3986e78856a70d0b38d9e88dc39390556c2e962) | `` minisforum/v3: init `` |