### PR TITLE
chore(flake/nixos-hardware): `d3986e78` -> `f6e0cd5c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -556,11 +556,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1730520317,
-        "narHash": "sha256-IH+vuP/F4zdOwmbCNXtszaCbzAiqx5O72NwtlTv+Nco=",
+        "lastModified": 1730537918,
+        "narHash": "sha256-GJB1/aaTnAtt9sso/EQ77TAGJ/rt6uvlP0RqZFnWue8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d3986e78856a70d0b38d9e88dc39390556c2e962",
+        "rev": "f6e0cd5c47d150c4718199084e5764f968f1b560",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                   |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`f6e0cd5c`](https://github.com/NixOS/nixos-hardware/commit/f6e0cd5c47d150c4718199084e5764f968f1b560) | `` Updated README ``                      |
| [`bcf80dc1`](https://github.com/NixOS/nixos-hardware/commit/bcf80dc17c840b79625bea50bd40ab4332b9295e) | `` Added Lenovo Ideadpad Slim 5 16IAH8 `` |
| [`8a906c9d`](https://github.com/NixOS/nixos-hardware/commit/8a906c9d3471439853aa05f6ec8ee1d3e6618c0d) | `` Added Lenovo Ideadpad 16AHP9 ``        |