### PR TITLE
chore(flake/darwin): `e56d80b2` -> `f203352c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730560543,
-        "narHash": "sha256-Ny8bMwoQH2JmLr2/+Zqer1Aizk5nCIXLPGUL1YyFS3I=",
+        "lastModified": 1730586190,
+        "narHash": "sha256-OWGw7LsffScfxocmMTtLTRZDABvzOnK3FavqnDqeBao=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "e56d80b28314643da5a0a27c6371c0682ab8389f",
+        "rev": "f203352cc035dad4a49242d9296ce4272badcefa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                              |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
| [`63f4d40e`](https://github.com/LnL7/nix-darwin/commit/63f4d40e551e7b29fbe586967c03eea1e6a70ce4) | `` tmux: remove `programs.tmux.defaultCommand` ``                    |
| [`1588cb2e`](https://github.com/LnL7/nix-darwin/commit/1588cb2e997fb37a4eab78da13808faf49df903f) | `` environment: remove misleading `environment.loginShell` option `` |