### PR TITLE
chore(flake/nixos-hardware): `f6e0cd5c` -> `f6581f1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -556,11 +556,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1730537918,
-        "narHash": "sha256-GJB1/aaTnAtt9sso/EQ77TAGJ/rt6uvlP0RqZFnWue8=",
+        "lastModified": 1731403644,
+        "narHash": "sha256-T9V7CTucjRZ4Qc6pUEV/kpgNGzQbHWfGcfK6JJLfUeI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f6e0cd5c47d150c4718199084e5764f968f1b560",
+        "rev": "f6581f1c3b137086e42a08a906bdada63045f991",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [`f6581f1c`](https://github.com/NixOS/nixos-hardware/commit/f6581f1c3b137086e42a08a906bdada63045f991) | `` framework: workaround display issues on AMD GPUs ``                                                                                                          |
| [`863e3ca9`](https://github.com/NixOS/nixos-hardware/commit/863e3ca9988f34c370bd660a5efc3e20eb7ad38b) | `` apple/t2: bump kernel from 6.11 to 6.11.7 ``                                                                                                                 |
| [`f3049523`](https://github.com/NixOS/nixos-hardware/commit/f3049523c09dbcffdebb281a3bbaec33fec60089) | `` framework: Fix kernel version comparison for preventWakeOnAC ``                                                                                              |
| [`e1cc1f64`](https://github.com/NixOS/nixos-hardware/commit/e1cc1f6483393634aee94514186d21a4871e78d7) | `` apple/t2: deprecate enableTinyDfr option and conflict with `hardware.apple.touchBar` ``                                                                      |
| [`912e5b8a`](https://github.com/NixOS/nixos-hardware/commit/912e5b8a0023898a2f025084e99fa31734a9c465) | `` tuxedo/aura/15-gen1: migrate renamed option ``                                                                                                               |
| [`36ed775c`](https://github.com/NixOS/nixos-hardware/commit/36ed775c1e10ab120f0629676c61369881a109fc) | `` tests: update flake lock ``                                                                                                                                  |
| [`90642a0d`](https://github.com/NixOS/nixos-hardware/commit/90642a0deae927fa911d49d4f7c5616257105141) | `` Adding a sound speaker fix. Issue #1039 ``                                                                                                                   |
| [`684d64c6`](https://github.com/NixOS/nixos-hardware/commit/684d64c67de1ea348a94ec487a5bad7d437ed610) | `` Apply suggestions from code review ``                                                                                                                        |
| [`1881126e`](https://github.com/NixOS/nixos-hardware/commit/1881126e2d8c5d6af04b62d7be957be57b3507ce) | `` Adding the Legion Pro 7 16IRX9H model. Initially, I simply copied it from the 16IRX8H, but I am still having issues with WiFi and sound (to be resolved). `` |
| [`12ad8c1b`](https://github.com/NixOS/nixos-hardware/commit/12ad8c1bf13ff15ffa6afe82c59b4af0b9226035) | `` apple/macbook-pro/11-1: add comment why we include broadcom driver ``                                                                                        |
| [`7a9364e7`](https://github.com/NixOS/nixos-hardware/commit/7a9364e705e61d0c7fc25b3756457a6caf3b9db8) | `` apple: init MacBookPro11,1 ``                                                                                                                                |
| [`f372fa6c`](https://github.com/NixOS/nixos-hardware/commit/f372fa6cfa45eb24552a2c1bdba2de0f14cd5a0e) | `` fix eval with 24.05 ``                                                                                                                                       |
| [`2e22e4ad`](https://github.com/NixOS/nixos-hardware/commit/2e22e4ad70ea47ad9642e9232329d28a3342b928) | `` tests: fix unused importPath in unfreeNixpkgs function ``                                                                                                    |
| [`df8450fa`](https://github.com/NixOS/nixos-hardware/commit/df8450fa268551003c0b29abc455cd9a5c494d9d) | `` microsoft/surface: Remove old kernel version ``                                                                                                              |
| [`097c476b`](https://github.com/NixOS/nixos-hardware/commit/097c476b076300e0f44e2a804ad472ca3da395d4) | `` microsoft/surface: Update to kernel 6.11.4 ``                                                                                                                |