### PR TITLE
chore(flake/disko): `39792850` -> `486250f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730190761,
-        "narHash": "sha256-o5m5WzvY6cGIDupuOvjgNSS8AN6yP2iI9MtUC6q/uos=",
+        "lastModified": 1731274291,
+        "narHash": "sha256-cZ0QMpv5p2a6WEE+o9uu0a4ma6RzQDOQTbm7PbixWz8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "3979285062d6781525cded0f6c4ff92e71376b55",
+        "rev": "486250f404f4a4f4f33f8f669d83ca5f6e6b7dfc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                     |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`7d4cbcd2`](https://github.com/nix-community/disko/commit/7d4cbcd2352889f62b0944bdae84d09531de1732) | `` cli: Fix legacy aliases ``                                               |
| [`6bfa3a18`](https://github.com/nix-community/disko/commit/6bfa3a18d4625753bf653123e1d8a3b309eeaadd) | `` tests/interactive-cryptsetup: make waiting for passphrase more robust `` |
| [`21b2de0a`](https://github.com/nix-community/disko/commit/21b2de0a20037d3731d220c1e38e3c7ee6d3f007) | `` flake.lock: Update ``                                                    |
| [`a8bdb16b`](https://github.com/nix-community/disko/commit/a8bdb16b473f457609eb76d0dabb2fcb4e1f64b8) | `` tests/disko-install: fix eval ``                                         |
| [`dd3d2a5e`](https://github.com/nix-community/disko/commit/dd3d2a5e9310f109fa6d2b3e2c0e375cc4dbec07) | `` fix offline installation ``                                              |
| [`f3f8254f`](https://github.com/nix-community/disko/commit/f3f8254fccc321f4cac0d716f73203bfd5e02477) | `` docs: fix inconsistent disko-install cmd ``                              |
| [`3fc91a75`](https://github.com/nix-community/disko/commit/3fc91a757663073608ba6f0a5e4fd1844879a48b) | `` outputs: Deprecate all unused outputs ``                                 |
| [`94bc0f5b`](https://github.com/nix-community/disko/commit/94bc0f5bb0dff8b98597f1eb66a7156469932221) | `` mode destroy: Add confirmation dialogue ``                               |
| [`daca7be3`](https://github.com/nix-community/disko/commit/daca7be3092f253e5a3c9ce059d5a0225de6902d) | `` outputs: make compatible with nix run and package lists ``               |
| [`856a2902`](https://github.com/nix-community/disko/commit/856a2902156ba304efebd4c1096dbf7465569454) | `` docs: Remove non-existing flag ``                                        |
| [`380847d9`](https://github.com/nix-community/disko/commit/380847d94ff0fedee8b50ee4baddb162c06678df) | `` Add kmod to dependencies ``                                              |