### PR TITLE
chore(flake/darwin): `f203352c` -> `e30d226a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730586190,
-        "narHash": "sha256-OWGw7LsffScfxocmMTtLTRZDABvzOnK3FavqnDqeBao=",
+        "lastModified": 1731424394,
+        "narHash": "sha256-J+POQgWQdjhuF1pEnkVKWPJ+dM62FTepk6TmJdj3O5U=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "f203352cc035dad4a49242d9296ce4272badcefa",
+        "rev": "e30d226a24e4079d068321f935dbf30626f08dc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                         |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
| [`32df51bf`](https://github.com/LnL7/nix-darwin/commit/32df51bf2b82dab724b845f4ad2d45bc1a0d0b9e) | `` fix(defaults): fixing #1107 ``                                               |
| [`d71aa30b`](https://github.com/LnL7/nix-darwin/commit/d71aa30b41bac3b2e38bd4b8f49e12811cd27ec1) | `` feat(defaults): adding support to control center ``                          |
| [`5a1ae6a6`](https://github.com/LnL7/nix-darwin/commit/5a1ae6a6e41362fb52a682fd3d5f19585131d5de) | `` readme: add prerequisites section ``                                         |
| [`050b7db4`](https://github.com/LnL7/nix-darwin/commit/050b7db4451bbca9798d09661f098cb0033779b5) | `` installer: don't tell users to source bashrc ``                              |
| [`2fe3de58`](https://github.com/LnL7/nix-darwin/commit/2fe3de580e02a3d867134d6632525cf93ffaf0cb) | `` readme: fix badge ``                                                         |
| [`ae09d7ba`](https://github.com/LnL7/nix-darwin/commit/ae09d7ba528760f9c9b4f92d905d35c46d50ddca) | `` readme: remove outdated instructions for manually managing `/etc/bashrc` ``  |
| [`534ca069`](https://github.com/LnL7/nix-darwin/commit/534ca06930039a616934b6d9dd8316e8df799622) | `` docs: use `nix-darwin` instead of `Darwin` ``                                |
| [`29358906`](https://github.com/LnL7/nix-darwin/commit/293589065dd0f6bbfd6f83fcdc4f2d74543337c9) | `` ci: fix manual not being regenerated when non-Nix files are updated ``       |
| [`a89c8519`](https://github.com/LnL7/nix-darwin/commit/a89c85192354229d9fc0adfe11f3f89620eb9487) | `` ci: don't override nixpkgs when building the manual ``                       |
| [`2ff55ab1`](https://github.com/LnL7/nix-darwin/commit/2ff55ab1c5c238181c3b6f1bd78156e7d77812bb) | `` manual: get revision information when called from flake ``                   |
| [`a82d72d2`](https://github.com/LnL7/nix-darwin/commit/a82d72d25f67dff02afbd6fb72cd16e2ec040a68) | `` flake: expose docs on Linux as well ``                                       |
| [`5fbb7b76`](https://github.com/LnL7/nix-darwin/commit/5fbb7b7637307c89e52d7e73ed6c848353bda6a0) | `` zsh: only run shell initialization in /etc/zshenv when RCs are enabled ``    |
| [`f0a12692`](https://github.com/LnL7/nix-darwin/commit/f0a1269297c8ca7f5aa287166c2a9cfb6e13917c) | `` nix: don't allow using `auto-optimise-store` as it can corrupt the store ``  |
| [`110d49af`](https://github.com/LnL7/nix-darwin/commit/110d49af637c3da025b6b42a0caa81c1d63b2aed) | `` github-runner: Fix labels for different nixpkgs versions ``                  |
| [`222c3cb5`](https://github.com/LnL7/nix-darwin/commit/222c3cb558f4e56e3f9e84bb65fe23034f7f9c79) | `` ci: fix uninstaller failing to run in `install-against-unstable` ``          |
| [`3a89b614`](https://github.com/LnL7/nix-darwin/commit/3a89b614321ab8dad3962d79fc3a29bace9a8486) | `` uninstaller: check `nix-daemon` was correctly reinstalled ``                 |
| [`7bbc7c5d`](https://github.com/LnL7/nix-darwin/commit/7bbc7c5db686f4e57a29c82a185596f53d110647) | `` ci: test uninstallation of nix-darwin using flakes ``                        |
| [`ebca0c23`](https://github.com/LnL7/nix-darwin/commit/ebca0c23c95cc2d2c75b3c3a290fa99a886b9738) | `` uninstaller: switch to `writeShellApplication` ``                            |
| [`c3b406bd`](https://github.com/LnL7/nix-darwin/commit/c3b406bd1c6e60a69996dbbd529328e40d298bd7) | `` uninstaller: restore `*.before-nix-darwin` files ``                          |
| [`9cd45289`](https://github.com/LnL7/nix-darwin/commit/9cd45289c9200b5adf29ed4faaf8e00a8c06da9c) | `` uninstaller: reset any shells pointing to `/run/current-system/sw/bin` ``    |
| [`1b5fa6be`](https://github.com/LnL7/nix-darwin/commit/1b5fa6be405425ae5040d68c4a3bfff14fdf2100) | `` uninstaller: remove unnecessary attempt to delete `nix-daemon` ``            |
| [`84ad3a2d`](https://github.com/LnL7/nix-darwin/commit/84ad3a2d7ea74cabd7f71261ca4a191585d47beb) | `` uninstaller: remove `/run` symlink ``                                        |
| [`79608947`](https://github.com/LnL7/nix-darwin/commit/79608947e27163a2e74b1bec0812ce7a942cbdb8) | `` buildkit-agents: don't use `mkdir -p -m` ``                                  |
| [`3b738c76`](https://github.com/LnL7/nix-darwin/commit/3b738c765de1bb4ecc4993fa092b27dd46d495ed) | `` github-runner: replace `mkdir -p -m` with `umask` ``                         |
| [`cf130aa9`](https://github.com/LnL7/nix-darwin/commit/cf130aa9579fc1708ff4a265d2108eefa535e9b2) | `` users: don't generate `ensurePerms` when no users to manage ``               |
| [`32814a6e`](https://github.com/LnL7/nix-darwin/commit/32814a6eb1de3b564ff43e5b6453637b1eb25721) | `` users: replace runtime check to prevent deleting `root` with assertion ``    |
| [`fd510a71`](https://github.com/LnL7/nix-darwin/commit/fd510a7122d49cc1cbd72b9e70b1ae6b3c76c990) | `` system: replace `for f in $(ls ...)` with `for f in .../*` ``                |
| [`04199680`](https://github.com/LnL7/nix-darwin/commit/041996803af5497fb000e3f79621fa5bb6995057) | `` treewide: fix shellcheck warnings and errors ``                              |
| [`9afef995`](https://github.com/LnL7/nix-darwin/commit/9afef9950f28780ff24908496c36f27826a601cf) | `` checks: move manual `/run` instructions to activation ``                     |
| [`3ea11449`](https://github.com/LnL7/nix-darwin/commit/3ea11449387edeac72fbd7791d106af7553be6e2) | `` system: run `shellcheck` on `activate` and `activate-user` scripts ``        |
| [`2af06b08`](https://github.com/LnL7/nix-darwin/commit/2af06b086283be3ab3824a86f35f6301c95b372b) | `` examples: clean up ``                                                        |
| [`223a920a`](https://github.com/LnL7/nix-darwin/commit/223a920ab457160a245a588f4191f2b6782b3957) | `` ci: upgrade `actions/checkout` ``                                            |
| [`37b591bd`](https://github.com/LnL7/nix-darwin/commit/37b591bd8b3ca9641a8aff165f30927755b5dc20) | `` ci: remove unused workflows ``                                               |
| [`e0f243d1`](https://github.com/LnL7/nix-darwin/commit/e0f243d17e5c6281b2541c79b52be0270be9a360) | `` ci: run nix flake check ``                                                   |
| [`68637ee7`](https://github.com/LnL7/nix-darwin/commit/68637ee7dbdb194755697930c36272ad115af4a6) | `` flake: expose `jobs` from `release.nix` as a flattened attrset ``            |
| [`c13549d7`](https://github.com/LnL7/nix-darwin/commit/c13549d7a632fc107bc8802463806fc2002c9c54) | `` examples: drop `ofborg` example ``                                           |
| [`56915346`](https://github.com/LnL7/nix-darwin/commit/569153467be5f438e4f932a09bfba79adcecf856) | `` ofborg: automatically add `ofborg` to `known{Users,Groups}` ``               |
| [`dd48cbd7`](https://github.com/LnL7/nix-darwin/commit/dd48cbd7766baba246f0b2e2bd42baf67e0005d6) | `` examples: fix evaluation ``                                                  |
| [`56ac6182`](https://github.com/LnL7/nix-darwin/commit/56ac6182d3fcb449db620fac0658eedd56aa1597) | `` release: remove unnecessary use of `release-lib` ``                          |
| [`c904f6cd`](https://github.com/LnL7/nix-darwin/commit/c904f6cdcb02c85181cf478496b0b9a78308133a) | `` release: rename `release` to `release-lib` to match NixOS ``                 |
| [`8a03b185`](https://github.com/LnL7/nix-darwin/commit/8a03b1850b3adf005da3f35e696e801d700740ec) | `` release: remove package jobs ``                                              |
| [`e11dd028`](https://github.com/LnL7/nix-darwin/commit/e11dd028d38bd09ec4a1119742d735512775c8a6) | `` release: remove `unstable` job ``                                            |
| [`1a8c6cac`](https://github.com/LnL7/nix-darwin/commit/1a8c6cac8c7a9537fcf928714ca3778f4c59c2fd) | `` release: fix tests not running on `aarch64-darwin` ``                        |
| [`48e5c8de`](https://github.com/LnL7/nix-darwin/commit/48e5c8de1a4575441b46cb174afebfa02732c0ff) | `` Update modules/programs/zsh/default.nix ``                                  |
| [`897fc37c`](https://github.com/LnL7/nix-darwin/commit/897fc37c47d2592c475f8732f3f1a4fbc9f18f9e) | `` Update default.nix ``                                                        |
| [`84d14d40`](https://github.com/LnL7/nix-darwin/commit/84d14d404325380ec180f580332e8e85df232d06) | `` prometheus-node-exporter: fix log permissions ``                             |
| [`6ff3a49c`](https://github.com/LnL7/nix-darwin/commit/6ff3a49ceb1c98e96452542a6feadacc477eedff) | `` time: shellcheck fix ``                                                      |
| [`07db4e57`](https://github.com/LnL7/nix-darwin/commit/07db4e57d3596ae6de5877409ac6ec782e69afc8) | `` ci: switch to `macos-13` ``                                                  |
| [`53b9de4d`](https://github.com/LnL7/nix-darwin/commit/53b9de4d6ca51c38299f265630b811fed6d4fd05) | `` ci: remove tests to ensure submodules work ``                                |
| [`1d8c91b4`](https://github.com/LnL7/nix-darwin/commit/1d8c91b40e82853e76a0a308cfc5ddc5a72667d3) | `` darwin-rebuild: do not resolve flake path ``                                 |
| [`406cb56d`](https://github.com/LnL7/nix-darwin/commit/406cb56d06247487386667162131703f7d6cc68f) | `` Back out "Add support for submodules in flakes" ``                           |
| [`21809c42`](https://github.com/LnL7/nix-darwin/commit/21809c4261a421eb06b2d7b3ccd18ebadd921f96) | `` Allow configuring the fn key action ``                                       |
| [`0dacfdea`](https://github.com/LnL7/nix-darwin/commit/0dacfdea635b664812b8065e6b5449c43bf1a586) | `` Configure the folder that new Finder windows open ``                         |
| [`6c8d45fb`](https://github.com/LnL7/nix-darwin/commit/6c8d45fb20c40a8ccc73130d026d487b887a3de4) | `` module: add prometheus-node-exporter service ``                              |
| [`44c88484`](https://github.com/LnL7/nix-darwin/commit/44c88484c4c386f3eae8a5398e9b22a78d606e43) | `` add warning for enabling syntax highlighting and fast syntax highlighting `` |
| [`2839ef54`](https://github.com/LnL7/nix-darwin/commit/2839ef54aaaa0ca797659a1db45876260b93b1eb) | `` Add support for zsh-fast-syntax-highlighting ``                              |