### PR TITLE
chore(flake/nix-index-database): `0e3a8778` -> `896019f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729999765,
-        "narHash": "sha256-LYsavZXitFjjyETZoij8usXjTa7fa9AIF3Sk3MJSX+Y=",
+        "lastModified": 1731209121,
+        "narHash": "sha256-BF7FBh1hIYPDihdUlImHGsQzaJZVLLfYqfDx41wjuF0=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "0e3a8778c2ee218eff8de6aacf3d2fa6c33b2d4f",
+        "rev": "896019f04b22ce5db4c0ee4f89978694f44345c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`896019f0`](https://github.com/nix-community/nix-index-database/commit/896019f04b22ce5db4c0ee4f89978694f44345c3) | `` update generated.nix to release 2024-11-10-031357 `` |
| [`ddbdec98`](https://github.com/nix-community/nix-index-database/commit/ddbdec986ea89b1febebce875ff6660d38cf82da) | `` flake.lock: Update ``                                |
| [`cc2ddbf2`](https://github.com/nix-community/nix-index-database/commit/cc2ddbf2df8ef7cc933543b1b42b845ee4772318) | `` update generated.nix to release 2024-11-03-031757 `` |
| [`6ac0329a`](https://github.com/nix-community/nix-index-database/commit/6ac0329a7fcd811439df5150b25faeabbef58bec) | `` flake.lock: Update ``                                |