### PR TITLE
chore(flake/impermanence): `0d09341b` -> `3ed3f0ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -411,11 +411,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1730403150,
-        "narHash": "sha256-W1FH5aJ/GpRCOA7DXT/sJHFpa5r8sq2qAUncWwRZ3Gg=",
+        "lastModified": 1731242966,
+        "narHash": "sha256-B3C3JLbGw0FtLSWCjBxU961gLNv+BOOBC6WvstKLYMw=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "0d09341beeaa2367bac5d718df1404bf2ce45e6f",
+        "rev": "3ed3f0eaae9fcc0a8331e77e9319c8a4abd8a71a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`3ed3f0ea`](https://github.com/nix-community/impermanence/commit/3ed3f0eaae9fcc0a8331e77e9319c8a4abd8a71a) | `` nixos: Work around systemd-machine-id-commit issue (#229) `` |
| [`491695be`](https://github.com/nix-community/impermanence/commit/491695bea3f03fbb09aca07379cc78f23c31cfc9) | `` nixos: Use mkMerge to allow duplicate definitions ``         |
| [`0ee1aee7`](https://github.com/nix-community/impermanence/commit/0ee1aee7a617ac5f17ad75a6d0b1fed86eb8d1ad) | `` nixos: cfg.${name} -> config ``                              |