### PR TITLE
chore(flake/home-manager): `1743615b` -> `60bb1109`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730490306,
-        "narHash": "sha256-AvCVDswOUM9D368HxYD25RsSKp+5o0L0/JHADjLoD38=",
+        "lastModified": 1731235328,
+        "narHash": "sha256-NjavpgE9/bMe/ABvZpyHIUeYF1mqR5lhaep3wB79ucs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1743615b61c7285976f85b303a36cdf88a556503",
+        "rev": "60bb110917844d354f3c18e05450606a435d2d10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`60bb1109`](https://github.com/nix-community/home-manager/commit/60bb110917844d354f3c18e05450606a435d2d10) | `` helix: fix wrapping of extraPackages ``     |
| [`73090072`](https://github.com/nix-community/home-manager/commit/73090072715c823dd19478a58ba4f241d27a577f) | `` news: fix typo ``                           |
| [`2f607e07`](https://github.com/nix-community/home-manager/commit/2f607e07f3ac7e53541120536708e824acccfaa8) | `` docs: home.sessionVariable clarification `` |
| [`8f6ca785`](https://github.com/nix-community/home-manager/commit/8f6ca7855d409aeebe2a582c6fd6b6a8d0bf5661) | `` flake.lock: Update ``                       |
| [`2c6a9b3c`](https://github.com/nix-community/home-manager/commit/2c6a9b3ccf1bb0930befadfed13195c2168d1287) | `` git: fix maintenance service ``             |