### PR TITLE
chore(flake/nixpkgs): `807e9154` -> `76612b17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -571,11 +571,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730200266,
-        "narHash": "sha256-l253w0XMT8nWHGXuXqyiIC/bMvh1VRszGXgdpQlfhvU=",
+        "lastModified": 1731139594,
+        "narHash": "sha256-IigrKK3vYRpUu+HEjPL/phrfh7Ox881er1UEsZvw9Q4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "807e9154dcb16384b1b765ebe9cd2bba2ac287fd",
+        "rev": "76612b17c0ce71689921ca12d9ffdc9c23ce40b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`6ec4ba94`](https://github.com/NixOS/nixpkgs/commit/6ec4ba94c59f48a58eb33e7641763fe3ddab29ba) | `` nix-unit: 2.23.0 -> 2.24.0 ``                                          |
| [`c8fd06c3`](https://github.com/NixOS/nixpkgs/commit/c8fd06c3b23554bddf54148244bc3ef81aefba52) | `` nixos/tests/acme: wait for server to run before starting the target `` |
| [`75584cdd`](https://github.com/NixOS/nixpkgs/commit/75584cdd1406f1625faff4cd60ebaa9a83f2bec6) | `` pkgsLLVM.gettext: fixup clang compilation ``                           |
| [`7234221a`](https://github.com/NixOS/nixpkgs/commit/7234221a0ea3a5437a0920e29dd32ec377a8f699) | `` python312Packages.homeassistant-stubs: 2024.11.0 -> 2024.11.1 ``       |
| [`171e7de3`](https://github.com/NixOS/nixpkgs/commit/171e7de37e185876c9e6ba3b23f8c89a43c5fd02) | `` kanidm: 1.4.1 -> 1.4.2 ``                                              |
| [`87cabcd9`](https://github.com/NixOS/nixpkgs/commit/87cabcd984de62b88cb7b42d6322d4c1cccc4fb2) | `` python312Packages.ring-doorbell: 0.9.8 -> 0.9.9 ``                     |
| [`ee6df93f`](https://github.com/NixOS/nixpkgs/commit/ee6df93fe2a3299bc1fd3a88714357d699144105) | `` nixos/tests/acme: explicitly start the targets we wait for ``          |
| [`9c075c8f`](https://github.com/NixOS/nixpkgs/commit/9c075c8fa5de1ebdcf1ebfb5eb1126ea61a6c2cb) | `` gnat: 12.4.0 -> 13.3.0 ``                                              |
| [`e6342719`](https://github.com/NixOS/nixpkgs/commit/e6342719838410eff7889d9b1f086b0bcbff0cf6) | `` audacious: 4.4.1 -> 4.4.2 ``                                           |
| [`2616bed9`](https://github.com/NixOS/nixpkgs/commit/2616bed9345f85b741fd6dae4be863397c3d8bd6) | `` diffoscope: 282 -> 283 ``                                              |
| [`baf20ae6`](https://github.com/NixOS/nixpkgs/commit/baf20ae6d22ef98365b0862336dfd50cf3c9b369) | `` audacious-plugins: 4.4.1 -> 4.4.2 ``                                   |
| [`4209bebe`](https://github.com/NixOS/nixpkgs/commit/4209bebed841f4d9fba68afc963140e85aa674cf) | `` python312Packages.stookwijzer: 1.4.10 -> 1.5.0 ``                      |
| [`37b1cd76`](https://github.com/NixOS/nixpkgs/commit/37b1cd761d82160f38db2a64cb546ad8739d9ade) | `` python312Packages.aiovlc: add optional-dependencies ``                 |
| [`5aef7008`](https://github.com/NixOS/nixpkgs/commit/5aef70086f50dbd7b96e433887fd550617c7fe43) | `` python312Packages.aiovlc: 0.6.0 -> 0.6.1 ``                            |
| [`53ebf8d1`](https://github.com/NixOS/nixpkgs/commit/53ebf8d1b998e93e226345de9cca5faea6678381) | `` checkov: 3.2.281 -> 3.2.283 ``                                         |
| [`317f7f1a`](https://github.com/NixOS/nixpkgs/commit/317f7f1a4c599086cac578ba6e29369497fbcec6) | `` docs: make sample code valid Nix expressions ``                        |
| [`717248d7`](https://github.com/NixOS/nixpkgs/commit/717248d7283b98c0ab5d5f67cff1ceaffbdd81be) | `` treefmt2: 2.0.5 -> 2.1.0 (#354455) ``                                  |
| [`8e67b23d`](https://github.com/NixOS/nixpkgs/commit/8e67b23d40ba2f3fdbc068dbcff5f4742abad35b) | `` libfprint-focaltech-2808-a658: init at 1.94.4 ``                       |
| [`2a29ee73`](https://github.com/NixOS/nixpkgs/commit/2a29ee734cb9e6441b6297ba94ca7eeb460a412a) | `` hal-hardware-analyzer: 4.2.0 -> 4.4.1 ``                               |
| [`16e233eb`](https://github.com/NixOS/nixpkgs/commit/16e233eb94d6f5b7c91ee510a7584e9d9f32ebfb) | `` python312Packages.python-telegram-bot: 21.6 -> 21.7 ``                 |
| [`f5ddf1a7`](https://github.com/NixOS/nixpkgs/commit/f5ddf1a751b3036b37b8d63fec11f4bf9bf9d484) | `` home-assistant: 2024.11.0 -> 2024.11.1 ``                              |
| [`c7107912`](https://github.com/NixOS/nixpkgs/commit/c71079125f5b3fe382381756ddcb91c3b11621ed) | `` home-assistant.intents: 2024.11.4 -> 2024.11.6 ``                      |
| [`7dec9f22`](https://github.com/NixOS/nixpkgs/commit/7dec9f228a03b2186b0710da8821e4ac870b0eb6) | `` python312Packages.spotifyaio: 0.8.5 -> 0.8.7 ``                        |
| [`37976f9c`](https://github.com/NixOS/nixpkgs/commit/37976f9cfdd9860e5f78abe269b59e4bb5d640ea) | `` python312Packages.sense-energy: 0.13.2 -> 0.13.3 ``                    |
| [`27c3ae3b`](https://github.com/NixOS/nixpkgs/commit/27c3ae3b08e0708a45a3e19ac0477ab6cb08752c) | `` python312Packages.python-roborock: 2.6.1 -> 2.7.2 ``                   |
| [`e816e355`](https://github.com/NixOS/nixpkgs/commit/e816e355239021519ac261aa82215c70633f8185) | `` python312Packages.ha-ffmpeg: 3.2.1 -> 3.2.2 ``                         |
| [`621e3513`](https://github.com/NixOS/nixpkgs/commit/621e3513817699cbed7957ba7f0a020c906723b9) | `` python312Packages.google-nest-sdm: 6.1.3 -> 6.1.4 ``                   |
| [`a2e51f87`](https://github.com/NixOS/nixpkgs/commit/a2e51f8786959b5fa9dd598df781034e0cf4c618) | `` python312Packages.agent-py: 0.0.23 -> 0.0.24 ``                        |
| [`3e1a9ffb`](https://github.com/NixOS/nixpkgs/commit/3e1a9ffb61ae001dcacdf7ba0e71b70bf06e7016) | `` sudo: fix cross-compilation linking error ``                           |
| [`acb3dd99`](https://github.com/NixOS/nixpkgs/commit/acb3dd99091c2dadcf8b8447faff09834f38b206) | `` python311Packages.whispers: add missing deps, unbreak ``               |
| [`9d90eac4`](https://github.com/NixOS/nixpkgs/commit/9d90eac487efea2c81c0756755e5d02ec8720766) | `` nimble: 0-unstable-2024-05-14 -> 0.16.2 ``                             |
| [`ce43435b`](https://github.com/NixOS/nixpkgs/commit/ce43435b27200424357c77ed2c172a8858de450d) | `` jwhois: unbreak darwin ``                                              |
| [`e62a69dc`](https://github.com/NixOS/nixpkgs/commit/e62a69dc686070b68da31ea4a5aaa32c8c6acb70) | `` linux_5_4: 5.4.284 -> 5.4.285 ``                                       |
| [`d051f421`](https://github.com/NixOS/nixpkgs/commit/d051f421fb8f21dc591656a417a508afbf92bd5a) | `` packetry: init at 0.4.0 ``                                             |
| [`6a2e37b3`](https://github.com/NixOS/nixpkgs/commit/6a2e37b3189adb3703d65f1730f1f3645c470df8) | `` linux/update-mainline: fix oldest version check ``                     |
| [`7c1e8955`](https://github.com/NixOS/nixpkgs/commit/7c1e8955b7015f496d5611e5c62d270fbcb403da) | `` linux_latest-libre: 19643 -> 19663 ``                                  |
| [`040a0dae`](https://github.com/NixOS/nixpkgs/commit/040a0dae71928896326c70d8d2120548e248db06) | `` linux-rt_6_6: 6.6.52-rt43 -> 6.6.58-rt45 ``                            |
| [`0216aad1`](https://github.com/NixOS/nixpkgs/commit/0216aad1747f9f518f3139bfbd4a5662d0f899d0) | `` linux-rt_6_1: 6.1.111-rt42 -> 6.1.112-rt43 ``                          |
| [`f919f99e`](https://github.com/NixOS/nixpkgs/commit/f919f99e9c858544ac2a9eb897061fea384f4d69) | `` linux-rt_5_15: 5.15.167-rt79 -> 5.15.170-rt81 ``                       |
| [`878ea7b0`](https://github.com/NixOS/nixpkgs/commit/878ea7b096f53336c0619f17ce995360bf15220b) | `` linux_5_10: 5.10.228 -> 5.10.229 ``                                    |
| [`c51850c0`](https://github.com/NixOS/nixpkgs/commit/c51850c016fd8bf3de419e060a7ed0c69393bf16) | `` linux_5_15: 5.15.170 -> 5.15.171 ``                                    |
| [`bf6ccfcc`](https://github.com/NixOS/nixpkgs/commit/bf6ccfccdb0024d1653002f9b76c1c589f2fd2ff) | `` linux_6_1: 6.1.115 -> 6.1.116 ``                                       |
| [`cab288a3`](https://github.com/NixOS/nixpkgs/commit/cab288a30511bfc5bdd357c52ee0f8cd06564d85) | `` linux_6_6: 6.6.59 -> 6.6.60 ``                                         |
| [`019f743c`](https://github.com/NixOS/nixpkgs/commit/019f743c691cc4742ea48b08d50c782ab77d6e77) | `` linux_6_11: 6.11.6 -> 6.11.7 ``                                        |
| [`eaa9c5eb`](https://github.com/NixOS/nixpkgs/commit/eaa9c5eba82927f068ea66ee32bc752a1678ff8d) | `` linux_testing: 6.12-rc5 -> 6.12-rc6 ``                                 |
| [`e5d280c4`](https://github.com/NixOS/nixpkgs/commit/e5d280c40ba589019087d16cf402c93aa78979bb) | `` .github/labeler.yml: remove darwin and bsd ``                          |
| [`73d24364`](https://github.com/NixOS/nixpkgs/commit/73d24364fb3e5d90a687b22d0aa51597b48a7bc0) | `` netbox2netshot: 0.1.12 -> 0.1.13; fix build ``                         |
| [`5be55538`](https://github.com/NixOS/nixpkgs/commit/5be55538137a57aa946e56a04c2795668dbdbe21) | `` kdePackages: Frameworks 6.7 -> 6.8 ``                                  |
| [`fe6d94b8`](https://github.com/NixOS/nixpkgs/commit/fe6d94b8f99e1180d9ec14166d948c3b64482dc1) | `` Revert "haskellPackages: update stackage and hackage" ``               |
| [`2d78ec7c`](https://github.com/NixOS/nixpkgs/commit/2d78ec7c67dc535e061967de9b0f32f4d967fa0c) | `` python312Packages.simplemma: fix build ``                              |
| [`e6e2bff2`](https://github.com/NixOS/nixpkgs/commit/e6e2bff288c6cc2a5b2bd724a5c1fefb71af6870) | `` myks: 4.2.3 -> 4.2.4 ``                                                |
| [`bbcae031`](https://github.com/NixOS/nixpkgs/commit/bbcae0310621af4fbc418a67593fb4bd20252490) | `` gtk4-layer-shell: 1.0.3 -> 1.0.4 ``                                    |
| [`9479182a`](https://github.com/NixOS/nixpkgs/commit/9479182a74ac9ad1b0fc494e44aa035016b10fd0) | `` python312Packages.stumpy: fix build ``                                 |
| [`d4ab921f`](https://github.com/NixOS/nixpkgs/commit/d4ab921f9417c3d74782094359ffb41f19028948) | `` dnscontrol: 4.14.2 -> 4.14.3 ``                                        |
| [`43b7e27a`](https://github.com/NixOS/nixpkgs/commit/43b7e27aaacec251b66247e8caf4a55a75cb0219) | `` python3Packages.hidapi: Remove libusb dependency ``                    |
| [`453c0a84`](https://github.com/NixOS/nixpkgs/commit/453c0a8441ec3155ea0de1734db9728b18a938ec) | `` agate: 3.3.9 → 3.3.10 ``                                               |
| [`1315f481`](https://github.com/NixOS/nixpkgs/commit/1315f481277b79f088304618af0bb4c14aa20777) | `` maintainers: update aucub ``                                           |
| [`c89cc9e3`](https://github.com/NixOS/nixpkgs/commit/c89cc9e33f0d0dd95ac29046fda7b9f7770fda91) | `` flashmq: 1.17.2 → 1.17.3 ``                                            |
| [`a431e9d6`](https://github.com/NixOS/nixpkgs/commit/a431e9d6b93f96139ddc3b2c617da33911237404) | `` ludtwig: 0.8.3 -> 0.9.0 ``                                             |
| [`d631d045`](https://github.com/NixOS/nixpkgs/commit/d631d045367f73f0f2a920a34c687bd5589e1937) | `` python311Packages.semgrep: init at 1.74.0 ``                           |
| [`17926cc5`](https://github.com/NixOS/nixpkgs/commit/17926cc5211bf2afc987b2e87a497d50271e20b4) | `` fastp: 0.23.4 -> 0.24.0 ``                                             |
| [`b2a003ef`](https://github.com/NixOS/nixpkgs/commit/b2a003ef8321ff2461b65824babd6355ab8befa3) | `` tparse: 0.15.0 -> 0.16.0 ``                                            |
| [`4904e3f5`](https://github.com/NixOS/nixpkgs/commit/4904e3f5df2beecca432591d7ff96c83e767c6b5) | `` dbeaver-bin: fix on case-sensitive fs ``                               |
| [`bbf0e123`](https://github.com/NixOS/nixpkgs/commit/bbf0e1231e5246858e47df0384528e7395d0b12e) | `` dbeaver-bin: fix build on darwin, fixes #354475 ``                     |
| [`da7e2263`](https://github.com/NixOS/nixpkgs/commit/da7e2263a5909381476e77592505e13fec30cd74) | `` home-assistant-chip-core: fix native dependencies ``                   |
| [`39278a04`](https://github.com/NixOS/nixpkgs/commit/39278a04ce2db56f61b02b9ebb3ea49d31930f2f) | `` nemo-emblems: Disable nixpkgs-update ``                                |
| [`d93fee8b`](https://github.com/NixOS/nixpkgs/commit/d93fee8b20740389093e4fab23b5220aa9021190) | `` deepin: don't inherit libsForQt5 scope ``                              |
| [`58c60713`](https://github.com/NixOS/nixpkgs/commit/58c6071308f2c77624ef7c6c8259277fd4c04acd) | `` meshcentral: 1.1.32 -> 1.1.33 ``                                       |
| [`2074ec37`](https://github.com/NixOS/nixpkgs/commit/2074ec37fecad2b9e2cfe56e6507223f73a302d7) | `` python312Packages.chispa: add missing dep, unbreak ``                  |
| [`61e6b1f5`](https://github.com/NixOS/nixpkgs/commit/61e6b1f52dc8fd44119e2c80c1521ac8aefee78c) | `` nixos-facter: 0.1.1 -> 0.2.0 ``                                        |
| [`2addaab3`](https://github.com/NixOS/nixpkgs/commit/2addaab35a947de5b9fba37cbdffce5662f5a69a) | `` media-downloader: 5.1.0 -> 5.2.0 ``                                    |
| [`546749a2`](https://github.com/NixOS/nixpkgs/commit/546749a274a33333214c7b342302d919986c1b16) | `` python312Packages.linode-api: add missing dep, unbreak ``              |
| [`201990c7`](https://github.com/NixOS/nixpkgs/commit/201990c787c8082dd4042b2b4a9b271b40ba6717) | `` leetgo: 1.4.9 -> 1.4.10 ``                                             |
| [`f3b32bf6`](https://github.com/NixOS/nixpkgs/commit/f3b32bf6edc3474283980c9b9857f905f90ddb7e) | `` nixos-anywhere: 1.4.0 -> 1.5.0 ``                                      |
| [`4036a404`](https://github.com/NixOS/nixpkgs/commit/4036a4042f8a7459b0744dcff9ce01e660cf8642) | `` python311Packages.pypiserver: add missing deps, unbreak ``             |
| [`c2933f4c`](https://github.com/NixOS/nixpkgs/commit/c2933f4ca4a2b7e1e1a9976d3227ef52a4bc57d4) | `` Enable cdio_paranoia in mpd. ``                                        |
| [`9ef4d05b`](https://github.com/NixOS/nixpkgs/commit/9ef4d05b491d709c56172ede6d18d388b09e6ac9) | `` python312Packages.gguf: add missing dep, unbreak ``                    |
| [`b8e58677`](https://github.com/NixOS/nixpkgs/commit/b8e58677b552cbe71617bbdfbf50ea4743eb5e15) | `` pwvucontrol: 0.4.5 -> 0.4.7 ``                                         |
| [`1369cae5`](https://github.com/NixOS/nixpkgs/commit/1369cae5fe1a706530a515381a73223cf0a77932) | `` python311Packages.ahocorasick-rs: unbreak, add missing deps ``         |
| [`64fa24d5`](https://github.com/NixOS/nixpkgs/commit/64fa24d5ee4859b829b619c2d839ffe7e91b42d1) | `` xmake: 2.9.5 -> 2.9.6 ``                                               |
| [`3ce4ab2b`](https://github.com/NixOS/nixpkgs/commit/3ce4ab2b90c623db95ed2a1635f159bd7e019c99) | `` apx-gui: format with nixfmt ``                                         |
| [`7b094e2b`](https://github.com/NixOS/nixpkgs/commit/7b094e2b2b6b3a06d05117d74f8b17a4c820c1d7) | `` python312Packages.cx-freeze: unbreak ``                                |
| [`2fde3fa4`](https://github.com/NixOS/nixpkgs/commit/2fde3fa48202a63fb91912b0be686c702e3a09bf) | `` apx-gui: 1.0.3 -> 1.0.4 ``                                             |
| [`e90f96d2`](https://github.com/NixOS/nixpkgs/commit/e90f96d2fa4e183911adfbed8907b066be4b0672) | `` python312Packages.bx-python: add missing dep, unbreak ``               |
| [`14a23934`](https://github.com/NixOS/nixpkgs/commit/14a23934aa5832ac0a07245784a519cf836fd533) | `` cargo-leptos: 0.2.20 -> 0.2.21 ``                                      |
| [`218ad1bf`](https://github.com/NixOS/nixpkgs/commit/218ad1bf6ab44b5553165f4c524460bded982e9e) | `` mautrix-signal: add version test ``                                    |
| [`9e157282`](https://github.com/NixOS/nixpkgs/commit/9e1572824162b02e4fff522cf894d9134c6f4c54) | `` mautrix-signal: enable checks ``                                       |
| [`13d4678f`](https://github.com/NixOS/nixpkgs/commit/13d4678f73f10d199be768d05df55fb68ca94731) | `` mautrix-signal: fix build with goolm enabled ``                        |
| [`5c4a7c7f`](https://github.com/NixOS/nixpkgs/commit/5c4a7c7fa70f9f12a0f92f34191c1afb7615ba96) | `` jackett: 0.21.2831 -> 0.22.893 ``                                      |
| [`28335ee3`](https://github.com/NixOS/nixpkgs/commit/28335ee34d500fc48fe7b8ee69e016525d6062e1) | `` python312Packages.pyside6: 6.8.0 -> 6.8.0.2, cherry-pick patch ``      |
| [`ef75306d`](https://github.com/NixOS/nixpkgs/commit/ef75306d61a5a99bfa758e943afd3aee45aba812) | `` maintainers: update willbush ``                                        |
| [`b5394df7`](https://github.com/NixOS/nixpkgs/commit/b5394df77e04dd7d3a5139ec203e2b087bd377ee) | `` gh: 2.60.0 -> 2.61.0 ``                                                |
| [`95aa3d12`](https://github.com/NixOS/nixpkgs/commit/95aa3d12c670528f16d01262cad53a2c199c8814) | `` Revert "python3Packages.biopython: 1.83 -> 1.84" ``                    |
| [`220c6d08`](https://github.com/NixOS/nixpkgs/commit/220c6d0879f9bdf9c54901ec43809717119c7f2d) | `` Revert "biopython: fix eval" ``                                        |