### PR TITLE
chore(flake/lovesegfault-vim-config): `69d89d55` -> `968da3b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731449974,
-        "narHash": "sha256-Gsa450Gypc/lGRyZ2kk59sUQsruGZqVVpyB4cLnsldc=",
+        "lastModified": 1731456854,
+        "narHash": "sha256-SMS4YUpppSg5TiR3B2dLFIf87xGiHy2zeYVxEhxZYj8=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "69d89d55aacff483ea61d33cf34580616ef47f64",
+        "rev": "968da3b12ed2b630d94b34df6cd2123de55de390",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                            |
| -------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`968da3b1`](https://github.com/lovesegfault/vim-config/commit/968da3b12ed2b630d94b34df6cd2123de55de390) | `` chore(flake/nixpkgs): 807e9154 -> 76612b17 ``   |
| [`68b6a44f`](https://github.com/lovesegfault/vim-config/commit/68b6a44ff67c1bf3eff5014d44da5b744154e724) | `` chore(flake/git-hooks): af8a16fe -> cd1af27a `` |