### PR TITLE
chore(flake/home-manager): `60bb1109` -> `ee8ff6d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731235328,
-        "narHash": "sha256-NjavpgE9/bMe/ABvZpyHIUeYF1mqR5lhaep3wB79ucs=",
+        "lastModified": 1731534694,
+        "narHash": "sha256-KvMam8x7QsIhD+dbykfoYV/nU0u1LVRQPO0vfySDdDs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "60bb110917844d354f3c18e05450606a435d2d10",
+        "rev": "ee8ff6d53fca9adec60238f63eb632300d0dffa0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`ee8ff6d5`](https://github.com/nix-community/home-manager/commit/ee8ff6d53fca9adec60238f63eb632300d0dffa0) | `` espanso: fix test for nixpkgs update ``        |
| [`7e42a37b`](https://github.com/nix-community/home-manager/commit/7e42a37bf7dffd7fe4c2b14e42161433d7182d66) | `` spotify-player: fix test for nixpkgs update `` |
| [`40746b5c`](https://github.com/nix-community/home-manager/commit/40746b5c77e9ab3fc2196802b637676574aaeb48) | `` alacritty: fix test for nixpkgs update ``      |
| [`149a48da`](https://github.com/nix-community/home-manager/commit/149a48da315988e36a6e12a82c49667a90d8031f) | `` flake.lock: Update ``                          |