### PR TITLE
chore(flake/nixos-hardware): `f6581f1c` -> `0c657fd1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -556,11 +556,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1731403644,
-        "narHash": "sha256-T9V7CTucjRZ4Qc6pUEV/kpgNGzQbHWfGcfK6JJLfUeI=",
+        "lastModified": 1731740063,
+        "narHash": "sha256-6ErGxO5PdrVAfTCb8FBNcYx3AjAlCyOyGcZLo+tknKs=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f6581f1c3b137086e42a08a906bdada63045f991",
+        "rev": "0c657fd1342d7996874a19c6e5540fd6ab3cf876",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`0c657fd1`](https://github.com/NixOS/nixos-hardware/commit/0c657fd1342d7996874a19c6e5540fd6ab3cf876) | `` feat(Intel CoffeeLake): Added support ``    |
| [`dd93bef7`](https://github.com/NixOS/nixos-hardware/commit/dd93bef722ed86b56afda26902519ef69a52836d) | `` Reference intel core ultra in flake ``      |
| [`ccc638b2`](https://github.com/NixOS/nixos-hardware/commit/ccc638b24f7c29db45838588b5e747fddb1239af) | `` framework: Add Intel Core Ultra Series 1 `` |