### PR TITLE
chore(flake/disko): `5fd852c4` -> `cb649938`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731549112,
-        "narHash": "sha256-c9I3i1CwZ10SoM5npQQVnfwgvB86jAS3lT4ZqkRoSOI=",
+        "lastModified": 1731746438,
+        "narHash": "sha256-f3SSp1axoOk0NAI7oFdRzbxG2XPBSIXC+/DaAXnvS1A=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "5fd852c4155a689098095406500d0ae3d04654a8",
+        "rev": "cb64993826fa7a477490be6ccb38ba1fa1e18fa8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                   |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`cb649938`](https://github.com/nix-community/disko/commit/cb64993826fa7a477490be6ccb38ba1fa1e18fa8) | `` cli: Fix "attribute missing" error when using flake `` |
| [`eaa51560`](https://github.com/nix-community/disko/commit/eaa51560df5352e501f9ada705282701d89c257d) | `` cli: Show error if flake's disko is incompatible ``    |
| [`9f97bd09`](https://github.com/nix-community/disko/commit/9f97bd0995b9bcee01b35dab6ba64ca6c1eb8caf) | `` lib: Fix jsonTypes evaluation ``                       |