### PR TITLE
chore(flake/home-manager): `1d0862ee` -> `d154a557`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731604581,
-        "narHash": "sha256-Qq2YZZaDTB3FZLWU/Hgh1uuWlUBl3cMLGB99bm7rFUM=",
+        "lastModified": 1731778696,
+        "narHash": "sha256-qQYeHamLt0z00G5MTSSxaTw/9zGdebEeYj4MDL+nOCI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1d0862ee2d7c6f6cd720d6f32213fa425004be10",
+        "rev": "d154a557da07645aaea3b3375317c234cf2eed82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                               |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`d154a557`](https://github.com/nix-community/home-manager/commit/d154a557da07645aaea3b3375317c234cf2eed82) | `` aerc: add support of account gpg config (#5298) ``                 |
| [`192f123e`](https://github.com/nix-community/home-manager/commit/192f123e4b5a4605c30566409ccacffc416e45c4) | `` nixos: add `key` to shared module to allow disabling it (#6017) `` |
| [`400e3c01`](https://github.com/nix-community/home-manager/commit/400e3c0152793ece616081870f979a2081a04f63) | `` nixos: always run home-manager on NixOS activation (#5780) ``      |