### PR TITLE
chore(flake/nix-index-database): `40d882b5` -> `bdba2469`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731593150,
-        "narHash": "sha256-FvksinoI2Y6kuwH+cKBu1oDA8uPGfoRqgtQV6O8GDc4=",
+        "lastModified": 1731814505,
+        "narHash": "sha256-l9ryrx1Twh08a+gxrMGM9O/aZKEimZfa6sZVyPCImgI=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "40d882b55e89add1ded379cc99edaab24983d6d9",
+        "rev": "bdba246946fb079b87b4cada4df9b1cdf1c06132",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`bdba2469`](https://github.com/nix-community/nix-index-database/commit/bdba246946fb079b87b4cada4df9b1cdf1c06132) | `` update generated.nix to release 2024-11-17-032302 `` |
| [`eb0ab066`](https://github.com/nix-community/nix-index-database/commit/eb0ab066371f12f21687f6201942860c6a8ea888) | `` flake.lock: Update ``                                |