### PR TITLE
chore(flake/home-manager): `5056a1cf` -> `0918bb02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731832479,
-        "narHash": "sha256-icDDuYwJ0avTMZTxe1qyU/Baht5JOqw4pb5mWpR+hT0=",
+        "lastModified": 1731882691,
+        "narHash": "sha256-lJX1EJZSrITQAfN7hiBQh3EJ4U9uayWVHdwtFiJkmwE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5056a1cf0ce7c2a08ab50713b6c4af77975f6111",
+        "rev": "0918bb02385a6897e7a0180d23ee4587491eb0d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`0918bb02`](https://github.com/nix-community/home-manager/commit/0918bb02385a6897e7a0180d23ee4587491eb0d4) | `` ci: make dependabot consider release-24.11 ``           |
| [`aecd341d`](https://github.com/nix-community/home-manager/commit/aecd341dfead1c3ef7a3c15468ecd71e8343b7c6) | `` firefox: improve search engine disclaimer generation `` |