### PR TITLE
chore(flake/darwin): `34588d57` -> `c60b5c92`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731809072,
-        "narHash": "sha256-pOsDJQR0imnFLfpvTmRpHcP0tflyxtP/QIzokrKSP8U=",
+        "lastModified": 1731885500,
+        "narHash": "sha256-ZrztYfSOS33J+ewq5alBOSdnIyZ0/sr1iy7FyBe9zIg=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "34588d57cfc41c6953c54c93b6b685cab3b548ee",
+        "rev": "c60b5c924c6188a0b3ca2e139ead3d0f92ae5db5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                           |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
| [`4720d452`](https://github.com/LnL7/nix-darwin/commit/4720d452f8095703d1978700a1ea4f94eb3c1520) | `` manualHTML: support --redirects option in nixos-render-docs `` |