### PR TITLE
chore(flake/home-manager): `f3a2ff69` -> `705cf376`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731887066,
-        "narHash": "sha256-uw7K/RsYioJicV79Nl39yjtfhdfTDU2aRxnBgvFhkZ8=",
+        "lastModified": 1731964590,
+        "narHash": "sha256-NBqbPdUHFaIQILooq+a//vg18gHDgELIeru4L24hDX4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f3a2ff69586f3a54b461526e5702b1a2f81e740a",
+        "rev": "705cf3763a6d6074c1b7edb3ff0bb44efa7f091b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`705cf376`](https://github.com/nix-community/home-manager/commit/705cf3763a6d6074c1b7edb3ff0bb44efa7f091b) | `` Translate using Weblate (Ukrainian) `` |
| [`094265fc`](https://github.com/nix-community/home-manager/commit/094265fca0e000f8af3c38e4dde0e459f91d59f0) | `` Translate using Weblate (Italian) ``   |
| [`0bd5e9c7`](https://github.com/nix-community/home-manager/commit/0bd5e9c76c9f2f486f4bec0524e16026547df414) | `` librewolf: hide bookmarks option ``    |
| [`18462998`](https://github.com/nix-community/home-manager/commit/18462998b126c8e32bc34c56156690052d1b46c2) | `` librewolf: use mkFirefoxModule ``      |