### PR TITLE
chore(flake/lovesegfault-vim-config): `19da9e2b` -> `8586e25e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731888565,
-        "narHash": "sha256-Tf6U9DYC2hr6Li3jAsPMdm/HbNbtpQiN6SgYHqv14aY=",
+        "lastModified": 1731975075,
+        "narHash": "sha256-D12vZvrCKqFiMgKEGeKpDYwqntP973UpggFfb0cgWOg=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "19da9e2be0ce76eddc59e7217c8838aa2ca002dc",
+        "rev": "8586e25e94f0a603a903530349fa91b24e742eb5",
         "type": "github"
       },
       "original": {
@@ -521,11 +521,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729742964,
-        "narHash": "sha256-B4mzTcQ0FZHdpeWcpDYPERtyjJd/NIuaQ9+BV1h+MpA=",
+        "lastModified": 1731952509,
+        "narHash": "sha256-p4gB3Rhw8R6Ak4eMl8pqjCPOLCZRqaehZxdZ/mbFClM=",
         "owner": "nix-community",
         "repo": "nix-github-actions",
-        "rev": "e04df33f62cdcf93d73e9a04142464753a16db67",
+        "rev": "7b5f051df789b6b20d259924d349a9ba3319b226",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                     |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`8586e25e`](https://github.com/lovesegfault/vim-config/commit/8586e25e94f0a603a903530349fa91b24e742eb5) | `` chore(flake/nix-github-actions): e04df33f -> 7b5f051d `` |