### PR TITLE
chore(flake/treefmt-nix): `675d4a7f` -> `5f5c2787`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -787,11 +787,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731959974,
-        "narHash": "sha256-AsuUJfILHGteNuQgCuiWPzWOVgzBsbetUHRAVwW7FCw=",
+        "lastModified": 1732013921,
+        "narHash": "sha256-grEEN4LjL4DTDZUyZjVcj9dXRykH/SKnpOIADN0q5w8=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "675d4a7fc531799ae8dfca1986b79be7660559e2",
+        "rev": "5f5c2787576f3e39bbc2ebdbf8521b3177c5c19c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                         |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`5f5c2787`](https://github.com/numtide/treefmt-nix/commit/5f5c2787576f3e39bbc2ebdbf8521b3177c5c19c) | `` feat: update nixpkgs input (#260) ``                                         |
| [`a3e1cc8f`](https://github.com/numtide/treefmt-nix/commit/a3e1cc8f9ff919ab58f026b718377d133a2b4488) | `` just: fix includes config for both hidden and non-hidden justfiles (#263) `` |