### PR TITLE
chore(flake/home-manager): `d37f154d` -> `a46e7020`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732023606,
-        "narHash": "sha256-abW1g8UKSn/44j6EA60u0TWqC/ar8+YM9Z8YdUmOCLg=",
+        "lastModified": 1732025103,
+        "narHash": "sha256-qjEI64RKvDxRyEarY0jTzrZMa8ebezh2DEZmJJrpVdo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d37f154dba0d4c015f17a24314e89b77a7ba5ff3",
+        "rev": "a46e702093a5c46e192243edbd977d5749e7f294",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`a46e7020`](https://github.com/nix-community/home-manager/commit/a46e702093a5c46e192243edbd977d5749e7f294) | `` espanso: fix test failure `` |