### PR TITLE
chore(flake/disko): `639d1520` -> `da52cf40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731895210,
-        "narHash": "sha256-z76Q/OXLxO/RxMII3fIt/TG665DANiE2lVvnolK2lXk=",
+        "lastModified": 1732030699,
+        "narHash": "sha256-SBosboLvLqDv+7mNgRTIYDQbHE61rDDkXTJWiRX3PPo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "639d1520df9417ca2761536c3072688569e83c80",
+        "rev": "da52cf40206d7d1a419d07640eb47b2fb9ac2c21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                              |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`da52cf40`](https://github.com/nix-community/disko/commit/da52cf40206d7d1a419d07640eb47b2fb9ac2c21) | `` Add explanatory comment to examples/zfs-over-legacy.nix (#886) `` |