### PR TITLE
chore(flake/lovesegfault-vim-config): `8586e25e` -> `51b7bc9c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731975075,
-        "narHash": "sha256-D12vZvrCKqFiMgKEGeKpDYwqntP973UpggFfb0cgWOg=",
+        "lastModified": 1732038792,
+        "narHash": "sha256-nxWROUl2NeVxee5bsfuXQ2nskOmXhaThP2I1QP8Ofrs=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "8586e25e94f0a603a903530349fa91b24e742eb5",
+        "rev": "51b7bc9cf17bc02edea3c253b1015b47302c4ac6",
         "type": "github"
       },
       "original": {
@@ -649,11 +649,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731883908,
-        "narHash": "sha256-Yt/eVhoj+SwpsQVK0YxM8jou55ni0+dqANuQ2IvIA28=",
+        "lastModified": 1732014462,
+        "narHash": "sha256-6WPABLqswdWdSLd5YSbGlKaMhpSIXODasz3etxuC+K0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "5bc3fa6996ee37b754f2e815a165be6e4d0cfcb9",
+        "rev": "c674f10d189fcbcf961f3c19479ac44d7d2d6e50",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                                       |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`51b7bc9c`](https://github.com/lovesegfault/vim-config/commit/51b7bc9cf17bc02edea3c253b1015b47302c4ac6) | `` chore(flake/treefmt-nix): 746901bb -> 5f5c2787 ``                          |
| [`45036332`](https://github.com/lovesegfault/vim-config/commit/45036332895f0ed80f3d483e780f988055c9545f) | `` chore(flake/git-hooks): cd1af27a -> 3308484d ``                            |
| [`551a1612`](https://github.com/lovesegfault/vim-config/commit/551a1612c69522eda362280fba802f5c9b38fbd7) | `` chore(flake/nixvim): 5bc3fa69 -> c674f10d ``                               |
| [`6555d1d8`](https://github.com/lovesegfault/vim-config/commit/6555d1d86351774d0068bf3a07fb0a99a1fb6965) | `` chore(update-flakes): update bot email ``                                  |
| [`9795c9c0`](https://github.com/lovesegfault/vim-config/commit/9795c9c01fdf34f6fbbc400c9e5fec85b9428472) | `` chore(deps): bump DeterminateSystems/nix-installer-action from 15 to 16 `` |