### PR TITLE
chore(flake/lovesegfault-vim-config): `51b7bc9c` -> `f291b894`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732038792,
-        "narHash": "sha256-nxWROUl2NeVxee5bsfuXQ2nskOmXhaThP2I1QP8Ofrs=",
+        "lastModified": 1732061371,
+        "narHash": "sha256-SuryF7Lrz4+FNZHLbHpOAo+pSjslIHffXXd0BKsacHU=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "51b7bc9cf17bc02edea3c253b1015b47302c4ac6",
+        "rev": "f291b894b3ed7853708223a694ec44165c9b2a09",
         "type": "github"
       },
       "original": {
@@ -649,11 +649,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732014462,
-        "narHash": "sha256-6WPABLqswdWdSLd5YSbGlKaMhpSIXODasz3etxuC+K0=",
+        "lastModified": 1732035679,
+        "narHash": "sha256-J03v1XnxvsrrvHmzKVBZiwik8678IXfkH1/ZR954ujk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c674f10d189fcbcf961f3c19479ac44d7d2d6e50",
+        "rev": "929bb0cd1cffb9917ab14be9cdb3f27efd6f505f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`f291b894`](https://github.com/lovesegfault/vim-config/commit/f291b894b3ed7853708223a694ec44165c9b2a09) | `` chore(flake/nixvim): c674f10d -> 929bb0cd `` |