### PR TITLE
chore(flake/disko): `da52cf40` -> `c3b83db7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732030699,
-        "narHash": "sha256-SBosboLvLqDv+7mNgRTIYDQbHE61rDDkXTJWiRX3PPo=",
+        "lastModified": 1732083565,
+        "narHash": "sha256-OAwz15InYr7IrzX3+JIgE7JYBR+65uFzm7rz+qb99dg=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "da52cf40206d7d1a419d07640eb47b2fb9ac2c21",
+        "rev": "c3b83db725d33e74d41324df6dc55d9098510483",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                 |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`c3b83db7`](https://github.com/nix-community/disko/commit/c3b83db725d33e74d41324df6dc55d9098510483) | `` module: Expose tests.enableOCR ``    |
| [`feeb365e`](https://github.com/nix-community/disko/commit/feeb365e31effdfef92a21176f88941fb2a7f126) | `` module: Expose tests.bootCommands `` |