### PR TITLE
chore(flake/disko): `c3b83db7` -> `a0c384e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732083565,
-        "narHash": "sha256-OAwz15InYr7IrzX3+JIgE7JYBR+65uFzm7rz+qb99dg=",
+        "lastModified": 1732109232,
+        "narHash": "sha256-iYh6h8yueU8IyOfNclbiBG2+fBFcjjUfXm90ZBzk0c0=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "c3b83db725d33e74d41324df6dc55d9098510483",
+        "rev": "a0c384e0a3b8bcaed30a6bcf3783f8a7c8b35be4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                 |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`92ad6784`](https://github.com/nix-community/disko/commit/92ad678418917a6826f9eabb34995b2b8e58229e) | `` Add examples for all special zpool vdev types ``     |
| [`caad5484`](https://github.com/nix-community/disko/commit/caad548415edb0cfe20d29a363aa98137fd7cc2b) | `` Make vdev sort only move empty modes to the start `` |
| [`d192ffd9`](https://github.com/nix-community/disko/commit/d192ffd9449cab0f31a86c3205384c20f45b288e) | `` Fix zpool create for disk vdev after mirror vdev ``  |
| [`6a472cc2`](https://github.com/nix-community/disko/commit/6a472cc24872d43524fc248e04c1d63803c342f1) | `` Fix zpool create with > 1 log/dedup/special vdev ``  |
| [`9b56c1af`](https://github.com/nix-community/disko/commit/9b56c1afdb56337b79769edcefbd32218c0181ba) | `` Add support for ZFS spare, log & dedup vdevs ``      |