### PR TITLE
chore(flake/darwin): `61cee201` -> `edabc790`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732016537,
-        "narHash": "sha256-XwXUK+meYnlhdQz2TVE4Wv+tsx1CkdGbDPt1tRzCNH4=",
+        "lastModified": 1732229547,
+        "narHash": "sha256-vtUhSQFgDfyyNM6rgmn35A2T+L5PXBS0H89cxWK9N2A=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "61cee20168a3ebb71a9efd70a55adebaadfbe4d4",
+        "rev": "edabc790a834326dcb5810e2698fa743483510d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                       |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
| [`095ba550`](https://github.com/LnL7/nix-darwin/commit/095ba5502c83c5fd8173a1b0dbc99a0e1be7e42d) | `` default: expose all the `darwin-*` commands ``                             |
| [`d57e7486`](https://github.com/LnL7/nix-darwin/commit/d57e74864bccd31e081443733bfaee1eda85a242) | `` uninstaller: always specify `--extra-experimental-features` first ``       |
| [`2ca27ba7`](https://github.com/LnL7/nix-darwin/commit/2ca27ba780bb072e9fb80565684ad81c2664f9d0) | `` ci: source `/etc/bashrc` instead of `/etc/static/bashrc` ``                |
| [`9fe8a0a7`](https://github.com/LnL7/nix-darwin/commit/9fe8a0a7387d24a4e5113587256e37d5f1294486) | `` ci: check that switching to new configurations works after installation `` |
| [`a4d4d12e`](https://github.com/LnL7/nix-darwin/commit/a4d4d12e3885f9fea3100c73d024664ea9572f94) | `` examples: change default architecture to `aarch64-darwin` ``               |
| [`3c27b087`](https://github.com/LnL7/nix-darwin/commit/3c27b0874017b325b0ed7269705c0d2df5df42dc) | `` readme: update `Documentation` section ``                                  |
| [`60ed03d0`](https://github.com/LnL7/nix-darwin/commit/60ed03d0b10fa88054a73a0d34338f03f8d73f53) | `` installer: remove ``                                                       |
| [`62f9402a`](https://github.com/LnL7/nix-darwin/commit/62f9402af0a5412045385b8ba4cb79bd8880a2c3) | `` readme: add using `nix-darwin` section for non-flakes ``                   |
| [`65ea368e`](https://github.com/LnL7/nix-darwin/commit/65ea368ebbed4fa52a1a59fcb06848c49b310c9c) | `` installer: move channel creation to README ``                              |
| [`9a1bea70`](https://github.com/LnL7/nix-darwin/commit/9a1bea70d5728a19ee0a090dc0bcdeb73f09b7a4) | `` installer: move creating default configuration to README ``                |
| [`5cc3c00f`](https://github.com/LnL7/nix-darwin/commit/5cc3c00f9b689fa98c524674ddf5a569005e4bd9) | `` readme: move sections under new Channels section ``                        |
| [`57c14451`](https://github.com/LnL7/nix-darwin/commit/57c144515a59efde1dd59078e280a82b32626311) | `` system: always add /run to /etc/synthetic.conf on macOS 10.15 onwards ``   |