### PR TITLE
chore(flake/disko): `97c0c4d7` -> `84dd8eea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732221404,
-        "narHash": "sha256-fWTyjgGt+BHmkeJ5IxOR4zGF4/uc+ceWmhBjOBSVkgQ=",
+        "lastModified": 1732276338,
+        "narHash": "sha256-Auztf3VzYXvzT4VJ64Z/uJyTAsiqDF6JrjyIK620ro4=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "97c0c4d7072f19b598ed332e9f7f8ad562c6885b",
+        "rev": "84dd8eea9a06006d42b8af7cfd4fda4cf334db81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                  |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`3a8a8713`](https://github.com/nix-community/disko/commit/3a8a8713bf64f79696c4784ad3cf0fa988ca7938) | `` fix: restore nix 2.3 compatibility `` |