### PR TITLE
chore(flake/disko): `abc8baff` -> `47bc8dfb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732284644,
-        "narHash": "sha256-REGLarOB5McRMmFtOgNihEXXQILY6+2UBAY8lw8CJCI=",
+        "lastModified": 1732482708,
+        "narHash": "sha256-B1MQLiWi4bbeNiRXKxEkpztnKyWae4x0LyK32v3DjLk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "abc8baff333ac9dca930fc4921a26a8fc248e442",
+        "rev": "47bc8dfb6f48d5f66a3cb3a4cece83d8ace1f61a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                    |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`0433c7e8`](https://github.com/nix-community/disko/commit/0433c7e8832da9ab622d8a69abe45249f1f41f37) | `` also passthrough rootfs mountoptions `` |