### PR TITLE
chore(flake/disko): `abc8baff` -> `2ed5e30f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732284644,
-        "narHash": "sha256-REGLarOB5McRMmFtOgNihEXXQILY6+2UBAY8lw8CJCI=",
+        "lastModified": 1732540163,
+        "narHash": "sha256-5EYzmoTpem2IB9JWzd41sL98pz3lyyCSTiCjv08i4Uk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "abc8baff333ac9dca930fc4921a26a8fc248e442",
+        "rev": "2ed5e30fc7e34adf455db8b02b9151d3922a54ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                       |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`3e83c110`](https://github.com/nix-community/disko/commit/3e83c1103855ea50fffc573277d5c680f357d8e3) | `` Fix evaluation when a GPT partition is left unformatted `` |
| [`8d80e4e8`](https://github.com/nix-community/disko/commit/8d80e4e8fc7a586d51575aa4f80daee5f6db0a85) | `` flake.lock: Update ``                                      |
| [`0433c7e8`](https://github.com/nix-community/disko/commit/0433c7e8832da9ab622d8a69abe45249f1f41f37) | `` also passthrough rootfs mountoptions ``                    |