### PR TITLE
chore(flake/home-manager): `a46e7020` -> `a9953635`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732025103,
-        "narHash": "sha256-qjEI64RKvDxRyEarY0jTzrZMa8ebezh2DEZmJJrpVdo=",
+        "lastModified": 1732482255,
+        "narHash": "sha256-GUffLwzawz5WRVfWaWCg78n/HrBJrOG7QadFY6rtV8A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a46e702093a5c46e192243edbd977d5749e7f294",
+        "rev": "a9953635d7f34e7358d5189751110f87e3ac17da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`a9953635`](https://github.com/nix-community/home-manager/commit/a9953635d7f34e7358d5189751110f87e3ac17da) | `` mopidy: restart service on config changes ``         |
| [`4d8d8c38`](https://github.com/nix-community/home-manager/commit/4d8d8c385e78f5f744e2e2f81f5c56fade6ca4eb) | `` zed-editor: add extraPackages option ``              |
| [`83002f18`](https://github.com/nix-community/home-manager/commit/83002f18468c4471d5f8de8c542ed2422badbf8f) | `` mopidy: restart the systemd service on failure ``    |
| [`98bf8de6`](https://github.com/nix-community/home-manager/commit/98bf8de65dc1ed12c6443b18f6f24d36e9c438d6) | `` volnoti: use cfg.package instead of pkgs ``          |
| [`f9fd45c5`](https://github.com/nix-community/home-manager/commit/f9fd45c512ef02c69557823543bb04051a41fa37) | `` volnoti: add self to maintainers ``                  |
| [`9ae941a4`](https://github.com/nix-community/home-manager/commit/9ae941a4cff40575feb7a64eb6cce70f733b12ed) | `` abook: remove platform linux assertion ``            |
| [`5e2f47c5`](https://github.com/nix-community/home-manager/commit/5e2f47c5a52707d250364401091e88021ba052a1) | `` hypridle: fix service when no config file ``         |
| [`bd58a113`](https://github.com/nix-community/home-manager/commit/bd58a1132e9b7f121f65313bc662ad6c8a05f878) | `` hyprpaper: fix service when no config file ``        |
| [`67cd4814`](https://github.com/nix-community/home-manager/commit/67cd4814a247fd0fe97171acb90659f7e304bcb8) | `` flake.lock: Update ``                                |
| [`92fef254`](https://github.com/nix-community/home-manager/commit/92fef254a9071fa41a13908281284e6a62b9c92e) | `` podman: install package and create config files ``   |
| [`ba9367b5`](https://github.com/nix-community/home-manager/commit/ba9367b5a98402fb3d2afe7aa58c432c43996720) | `` emacs: add darwin service ``                         |
| [`16fe7818`](https://github.com/nix-community/home-manager/commit/16fe78182e924c9a2b0cffa1f343efea80945ef2) | `` conky: update systemd exec path to config package `` |
| [`445d721e`](https://github.com/nix-community/home-manager/commit/445d721ecfbd92d83f857f12f1f99f5c8fa79951) | `` home-cursor: add hyprcursor support ``               |
| [`8cf9cb2e`](https://github.com/nix-community/home-manager/commit/8cf9cb2ee78aa129e5b8220135a511a2be254c0c) | `` tests: fix integration test ``                       |