### PR TITLE
chore(flake/darwin): `edabc790` -> `3c52583b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732229547,
-        "narHash": "sha256-vtUhSQFgDfyyNM6rgmn35A2T+L5PXBS0H89cxWK9N2A=",
+        "lastModified": 1732420287,
+        "narHash": "sha256-CzvYF4x6jUh/+NEEIFrIY5t1W/N3IA2bNZJiMXu9GTo=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "edabc790a834326dcb5810e2698fa743483510d0",
+        "rev": "3c52583b99666a349a6219dc1f0dd07d75c82d6a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                     |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------- |
| [`82ed8010`](https://github.com/LnL7/nix-darwin/commit/82ed8010ffb17b637cbbd916398ee3a4027cfb10) | `` ci: extend timeout and remove `tmate` `` |
| [`caa23e87`](https://github.com/LnL7/nix-darwin/commit/caa23e878f7f6fecb978bb91c1d208bf94a62c43) | `` github-runner: make `umask` quiet ``     |
| [`23f312e4`](https://github.com/LnL7/nix-darwin/commit/23f312e48a252e348fc8884f2abc7975f976aac0) | `` nix-tools: set `meta.mainProgram` ``     |