### PR TITLE
chore(flake/disko): `2ed5e30f` -> `869ba3a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732540163,
-        "narHash": "sha256-5EYzmoTpem2IB9JWzd41sL98pz3lyyCSTiCjv08i4Uk=",
+        "lastModified": 1732645828,
+        "narHash": "sha256-+4U2I2653JvPFxcux837ulwYS864QvEueIljUkwytsk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "2ed5e30fc7e34adf455db8b02b9151d3922a54ea",
+        "rev": "869ba3a87486289a4197b52a6c9e7222edf00b3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                         |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`255e11e8`](https://github.com/nix-community/disko/commit/255e11e83102a574336e4831ad82e199d280e84d) | `` module: add default for tests.bootCommand `` |