### PR TITLE
chore(flake/lovesegfault-vim-config): `5fb6eabb` -> `7bd5d2ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -412,11 +412,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732666390,
-        "narHash": "sha256-jsxWbY380IkyssrARqrXjgKq1vhtF55aW5+mCVjWw/Y=",
+        "lastModified": 1732720889,
+        "narHash": "sha256-4nJCss2V5gNaLPXDb9JoKPXqfaxsUIIe62IPoz5UhEc=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "5fb6eabbe85bb0f1cab9e433e911b2d8133d1ddc",
+        "rev": "7bd5d2ce8ec6a26bdeef584b2790ffdc5ffde319",
         "type": "github"
       },
       "original": {
@@ -585,11 +585,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732629460,
-        "narHash": "sha256-Cr8EyxEFPbVmX6p8LsslFBjDEuVlFNPILrWlwbBNnNA=",
+        "lastModified": 1732661768,
+        "narHash": "sha256-3D1m2l/hMivhpVkmJoEM+4tQ9W5j6s4UESSnuVl/7LM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8b19d154823619af7ced464185e8d13ec80a758b",
+        "rev": "7eb106ab690ff3f37ef5d517763e68a78a7923e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                               |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`7bd5d2ce`](https://github.com/lovesegfault/vim-config/commit/7bd5d2ce8ec6a26bdeef584b2790ffdc5ffde319) | `` chore(flake/nixpkgs): 23e89b7d -> 4633a7c7 ``      |
| [`ab562d46`](https://github.com/lovesegfault/vim-config/commit/ab562d4644089c7b4f88c8558fa22a0a6844f313) | `` ci: remove macos-13 ``                             |
| [`400fdef9`](https://github.com/lovesegfault/vim-config/commit/400fdef9ee2c0e04ee6d5d5ebc1fec6f3f903ad9) | `` chore(flake/flake-compat): 0f9255e0 -> 4a4fe463 `` |
| [`922929f7`](https://github.com/lovesegfault/vim-config/commit/922929f76c937032ab7458f81983009a767fc481) | `` chore: remove x86_64-darwin ``                     |
| [`8df0352c`](https://github.com/lovesegfault/vim-config/commit/8df0352cd5bab6b33ffebfc105e7571b0aac0749) | `` chore(flake/nixvim): 8b19d154 -> 7eb106ab ``       |