### PR TITLE
chore(flake/flake-compat): `4a4fe463` -> `e3408d6a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -179,11 +179,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1732720106,
-        "narHash": "sha256-74rRgtsneSfPhGcQYpzX8zbUz7TNJjqpymt4jJh/kz0=",
+        "lastModified": 1732721812,
+        "narHash": "sha256-a5VfXXrzS/BG1vfnDh26W1Y73jc0Igbq5VC0xWs4gT4=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "4a4fe4634a34e87e8cd094fce0a4819afa5c1997",
+        "rev": "e3408d6ab25eb340bcfd131e36aed6ba262a4e9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                        |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
| [`3980b5e4`](https://github.com/edolstra/flake-compat/commit/3980b5e441bac46246f9f11c77085ed5a2c73912) | `` Expose revCount attribute for git inputs `` |
| [`520e73f6`](https://github.com/edolstra/flake-compat/commit/520e73f623ca5e1f61ee4b5f07a9a700e67c0e95) | `` Use builtins.fetchTree if available ``      |