### PR TITLE
chore(flake/treefmt-nix): `84637a7a` -> `6209c381`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -810,11 +810,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732643199,
-        "narHash": "sha256-uI7TXEb231o8dkwB5AUCecx3AQtosRmL6hKgnckvjps=",
+        "lastModified": 1732894027,
+        "narHash": "sha256-2qbdorpq0TXHBWbVXaTqKoikN4bqAtAplTwGuII+oAc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "84637a7ab04179bdc42aa8fd0af1909fba76ad0c",
+        "rev": "6209c381904cab55796c5d7350e89681d3b2a8ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`6209c381`](https://github.com/numtide/treefmt-nix/commit/6209c381904cab55796c5d7350e89681d3b2a8ef) | `` google-java-format: add `aospStyle`, `includes`, `excludes` (#256) `` |
| [`4dadf4ff`](https://github.com/numtide/treefmt-nix/commit/4dadf4ff139114771292b5ad25b437f70bf7bec1) | `` texfmt: init (#266) ``                                                |