### PR TITLE
chore(flake/nix-index-database): `f4a5ca57` -> `6e0b7f81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732519917,
-        "narHash": "sha256-AGXhwHdJV0q/WNgqwrR2zriubLr785b02FphaBtyt1Q=",
+        "lastModified": 1733024876,
+        "narHash": "sha256-vy9Q41hBE7Zg0yakF79neVgb3i3PQMSMR7uHPpPywFE=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "f4a5ca5771ba9ca31ad24a62c8d511a405303436",
+        "rev": "6e0b7f81367069589a480b91603a10bcf71f3103",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`6e0b7f81`](https://github.com/nix-community/nix-index-database/commit/6e0b7f81367069589a480b91603a10bcf71f3103) | `` update generated.nix to release 2024-12-01-033612 `` |
| [`fc9c0def`](https://github.com/nix-community/nix-index-database/commit/fc9c0def2633a44750f1f1cd9f03ab6c5ad5c7bb) | `` flake.lock: Update ``                                |