### PR TITLE
chore(flake/nixos-hardware): `45348ad6` -> `fe01780d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -492,11 +492,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1732483221,
-        "narHash": "sha256-kF6rDeCshoCgmQz+7uiuPdREVFuzhIorGOoPXMalL2U=",
+        "lastModified": 1733066523,
+        "narHash": "sha256-aQorWITXZu7b095UwnpUvcGt9dNJie/GO9r4hZfe2sU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "45348ad6fb8ac0e8415f6e5e96efe47dd7f39405",
+        "rev": "fe01780d356d70fd119a19277bff71d3e78dad00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`fe01780d`](https://github.com/NixOS/nixos-hardware/commit/fe01780d356d70fd119a19277bff71d3e78dad00) | `` Update flake.nix ``                                                                   |
| [`93183259`](https://github.com/NixOS/nixos-hardware/commit/9318325957572aae826cc37d4378412b0d49d5dc) | `` 「✨」 feat(Dell Precision 5530): Added Nvidia support and some other feature (#1254) `` |
| [`acdc2cd8`](https://github.com/NixOS/nixos-hardware/commit/acdc2cd8153ddefab79d2bd31ed5690cdf2d6314) | `` Fix typo in Lenovo IdeaPad 16AHP9 URL ``                                              |