### PR TITLE
chore(flake/nix-fast-build): `f51f479d` -> `f67312c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -436,11 +436,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1732540608,
-        "narHash": "sha256-y1Q87PRcztZ2C1J/xGHk0VxY/T9wB6YL1nLtRbMYW5g=",
+        "lastModified": 1733068184,
+        "narHash": "sha256-F4DoxPQnhwqqTv/qEA0RAplhKssFVDSUYN/O19kQAew=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "f51f479d001317204f1a47302db36473dc12fc8f",
+        "rev": "f67312c5d1d5df48d3383817139ec3f578f8e753",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                       |
| ----------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`0188252d`](https://github.com/Mic92/nix-fast-build/commit/0188252d0883d23b621e39daf340c6bc74ea95ee) | `` add buildbot to mergify `` |
| [`86f2973d`](https://github.com/Mic92/nix-fast-build/commit/86f2973d0e0f28d1bc2e92ebbad90993d61e784f) | `` add dependabot ``          |
| [`f24c6c44`](https://github.com/Mic92/nix-fast-build/commit/f24c6c44e11f4f8a20fe4e756079ffdb4005c744) | `` update flake lock ``       |