### PR TITLE
chore(flake/home-manager): `c1fee8d4` -> `873e39d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733085484,
-        "narHash": "sha256-dVmNuUajnU18oHzBQWZm1BQtANCHaqNuxTHZQ+GN0r8=",
+        "lastModified": 1733133928,
+        "narHash": "sha256-gU40r9AfpIr4eq+0noM8yH1Hxf+EA3dqfIpFtQl8Y1E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c1fee8d4a60b89cae12b288ba9dbc608ff298163",
+        "rev": "873e39d5f4437d2f3ab06881fea8e63e45e1d011",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`873e39d5`](https://github.com/nix-community/home-manager/commit/873e39d5f4437d2f3ab06881fea8e63e45e1d011) | `` podman-container: fix tests and failing podman 5.3.0 service `` |
| [`d2e2bda6`](https://github.com/nix-community/home-manager/commit/d2e2bda6c050a61d51b8e395ad66b8fa48318e07) | `` nix-your-shell: fix creating required directory ``              |