### PR TITLE
chore(flake/stylix): `d13ffb38` -> `74ee1ed5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -673,11 +673,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1732993760,
-        "narHash": "sha256-t1J6wgzGjvvGNfdd0ei8HnZf9sTw+SpvCNAX0i6Qgwc=",
+        "lastModified": 1733153724,
+        "narHash": "sha256-28nueT0pl+YpwUey44InOqct4+7p+DkiKOfkBBDCOeU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "d13ffb381c83b6139b9d67feff7addf18f8408fe",
+        "rev": "74ee1ed5057e44edbcc36aa189a91d31eda60485",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                      |
| --------------------------------------------------------------------------------------------- | ---------------------------- |
| [`74ee1ed5`](https://github.com/danth/stylix/commit/74ee1ed5057e44edbcc36aa189a91d31eda60485) | `` kubecolor: init (#657) `` |