### PR TITLE
chore(flake/lovesegfault-vim-config): `5fdab448` -> `fd814511`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -412,11 +412,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733097994,
-        "narHash": "sha256-FW7Qe9+5AL8pBoh5EGnERJvhe0auVtbRJJwlJmGufSo=",
+        "lastModified": 1733184538,
+        "narHash": "sha256-UZOXMzbj3DX7HwDOT69j3Akv9YgXNSVNzoxu+TZzikQ=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "5fdab448adb15968ccd741e8968aa86388583af1",
+        "rev": "fd814511e73b00218abd7a7dbd78455f79a3132a",
         "type": "github"
       },
       "original": {
@@ -585,11 +585,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733010437,
-        "narHash": "sha256-xPf3jjDBDA9oMVnWU5DJ8gINCq2EPiupvF/4rD/0eEI=",
+        "lastModified": 1733132296,
+        "narHash": "sha256-fYEf0IgsNJp/hcb+C3FKtJvVabPDQs64hdL0izNBwXc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "80e49e7fd3fa720b93d18e6d859d9b9e7aad4a62",
+        "rev": "e680b367c726e2ae37d541328fe81f8daaf49a6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`fd814511`](https://github.com/lovesegfault/vim-config/commit/fd814511e73b00218abd7a7dbd78455f79a3132a) | `` chore(flake/nixpkgs): 970e93b9 -> ac35b104 `` |
| [`00c36e51`](https://github.com/lovesegfault/vim-config/commit/00c36e5183d9204db924b6f90e1ce312c07eb43f) | `` chore(flake/nixvim): 80e49e7f -> e680b367 ``  |