### PR TITLE
chore(flake/nixpkgs): `ac35b104` -> `55d15ad1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -507,11 +507,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733015953,
-        "narHash": "sha256-t4BBVpwG9B4hLgc6GUBuj3cjU7lP/PJfpTHuSqE+crk=",
+        "lastModified": 1733212471,
+        "narHash": "sha256-M1+uCoV5igihRfcUKrr1riygbe73/dzNnzPsmaLCmpo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ac35b104800bff9028425fec3b6e8a41de2bbfff",
+        "rev": "55d15ad12a74eb7d4646254e13638ad0c4128776",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`fa6edb45`](https://github.com/NixOS/nixpkgs/commit/fa6edb453d0c08131c60531e5d3f3c8078795861) | `` virt-manager: Add back gstreamer plugins ``                                       |
| [`bc678b28`](https://github.com/NixOS/nixpkgs/commit/bc678b2892694cdfb5167ff87156ba7fc6d07fd1) | `` nixos/gitwatch: fix module accounting ``                                          |
| [`78c8bf61`](https://github.com/NixOS/nixpkgs/commit/78c8bf61e0eb5aac926ac2095aa54e1deeb76295) | `` open-webui: add missing `emoji` dependency ``                                     |
| [`c21cb562`](https://github.com/NixOS/nixpkgs/commit/c21cb5620e246744accde9f18503a0bad2806db2) | `` pizauth: 1.0.5 -> 1.0.6 ``                                                        |
| [`907cb3d2`](https://github.com/NixOS/nixpkgs/commit/907cb3d253e2b35e23f97be5ef8a208dc41f9b8d) | `` Revert "lib/types: init {types.attrsWith}" ``                                     |
| [`afd9ca8b`](https://github.com/NixOS/nixpkgs/commit/afd9ca8bf0e032c3f364027e404b62d022fd72ce) | `` cargo-spellcheck: move to pkgs/by-name (#356513) ``                               |
| [`a29b3694`](https://github.com/NixOS/nixpkgs/commit/a29b36945dad5e5481a9269a921e1e8b1f36f541) | `` notepadqq: fix build ``                                                           |
| [`fd2ce826`](https://github.com/NixOS/nixpkgs/commit/fd2ce826313921e1a3716b414dde25a0ec9f8adc) | `` bdf2psf: 1.230 -> 1.232 ``                                                        |
| [`6369dcd1`](https://github.com/NixOS/nixpkgs/commit/6369dcd1327af7e075dd1b3d57eb8d67aecae88f) | `` python312Packages.yoda: 2.0.1 -> 2.0.2 ``                                         |
| [`5f4e098f`](https://github.com/NixOS/nixpkgs/commit/5f4e098fbdc5a05c76c79aa61b379962ec546efe) | `` typstyle: 0.12.5 -> 0.12.6 ``                                                     |
| [`d87278c8`](https://github.com/NixOS/nixpkgs/commit/d87278c8e119dafd1e13b5beaec45854e8b8d9de) | `` mujoco: 3.2.5 -> 3.2.6 ``                                                         |
| [`2ae24b12`](https://github.com/NixOS/nixpkgs/commit/2ae24b12461ece3c37f2fbe6e8674377ae8a330e) | `` nixos/gnupg: fix typo ``                                                          |
| [`c9f879c1`](https://github.com/NixOS/nixpkgs/commit/c9f879c1143754ab3eeb8a3cba1077d3d8860123) | `` zed-editor: 0.163.2 -> 0.163.3 ``                                                 |
| [`1649adc1`](https://github.com/NixOS/nixpkgs/commit/1649adc155e8a8296775a9f859df0a77945714a6) | `` nixos/prometheus: add fallback_scrape_protocol and scrape_protocols options ``    |
| [`6a4a92ac`](https://github.com/NixOS/nixpkgs/commit/6a4a92acc16c85eefb09423ba4fac16c9cc23733) | `` spl: 0.4.1 -> 0.4.2 ``                                                            |
| [`6e3ba153`](https://github.com/NixOS/nixpkgs/commit/6e3ba153f2cc943660cd84e9978fe9cb5701b4dc) | `` vscode-extensions.sas.sas-lsp: 1.11.0 -> 1.12.0 ``                                |
| [`f7727d11`](https://github.com/NixOS/nixpkgs/commit/f7727d11336a3a1331a02263915a93c2983aa5dd) | `` python312Packages.enlighten: 1.12.4 -> 1.13.0 ``                                  |
| [`ab143f4a`](https://github.com/NixOS/nixpkgs/commit/ab143f4a0a6212c16c1a1a685fddea99f2f3f971) | `` pythia: 8.311 -> 8.312 ``                                                         |
| [`44931482`](https://github.com/NixOS/nixpkgs/commit/449314825e46de832d5852f4d182e5bc2a6fdc9a) | `` ci/eval: Also count added packages as rebuilds ``                                 |
| [`399699f3`](https://github.com/NixOS/nixpkgs/commit/399699f33586c7c4c2747cbba0f36e39f4690818) | `` librepcb: 1.1.0 -> 1.2.0 ``                                                       |
| [`63a869db`](https://github.com/NixOS/nixpkgs/commit/63a869db05cac36de1010b8f165afa2d407e1d2f) | `` texlivePackages: add homepage (#321744) ``                                        |
| [`66d58959`](https://github.com/NixOS/nixpkgs/commit/66d58959130e9be9ec2a344df0fd4e6ec998c840) | `` buildFHSEnv: fix cross compilation ``                                             |
| [`71af5cf7`](https://github.com/NixOS/nixpkgs/commit/71af5cf7214c15789a876853ceabde5f893b15c0) | `` envision-unwrapped: 0-unstable-2024-10-20 -> 1.1.1 ``                             |
| [`299dc0eb`](https://github.com/NixOS/nixpkgs/commit/299dc0eb68d134434d12dee07346b05109df25cc) | `` osm2pgsql: 2.0.0 → 2.0.1 ``                                                       |
| [`c62f9b26`](https://github.com/NixOS/nixpkgs/commit/c62f9b26b01b0c1fa162fa81d473e568be3f67a7) | `` treewide: lib.warn -> lib.warnOnInstantiate ``                                    |
| [`cf9805af`](https://github.com/NixOS/nixpkgs/commit/cf9805af62a0b2cd5317b8c1e188e05220af81da) | `` lib.derivations: add warnOnInstantiate ``                                         |
| [`6a7837bb`](https://github.com/NixOS/nixpkgs/commit/6a7837bb958d741e3af40263bec94a14dbda3132) | `` python312Packages.dicomweb-client: 0.59.1 -> 0.59.3 ``                            |
| [`476e0b59`](https://github.com/NixOS/nixpkgs/commit/476e0b59aa5f940dc3beb1d2b078d86194e129ec) | `` Remove myself from maintainers. ``                                                |
| [`ae5d6bcc`](https://github.com/NixOS/nixpkgs/commit/ae5d6bcc8e5449db2a8bdc79cb0ebd822b393136) | `` mixxx: 2.4.1 -> 2.4.2 (#360507) ``                                                |
| [`c9bbb996`](https://github.com/NixOS/nixpkgs/commit/c9bbb9962cf7b979c26c86e99663a632feb0883e) | `` ci: Update pinned Nixpkgs ``                                                      |
| [`548eb277`](https://github.com/NixOS/nixpkgs/commit/548eb2776de07532d7ad3e92001be05be2f79190) | `` nixos/boot: remove lib.mdDoc from boot.modprobeConfig.useUbuntuModuleBlacklist `` |
| [`d57718d1`](https://github.com/NixOS/nixpkgs/commit/d57718d1b3446b219311eac2f7b148b9460f059c) | `` citrix-workspace: 24.5.0.76 -> 24.8.0.98 ``                                       |
| [`2227975f`](https://github.com/NixOS/nixpkgs/commit/2227975f9d04653da442a6246b81ea836e6b0bc7) | `` citrix-workspace: add flacks ``                                                   |
| [`af24e684`](https://github.com/NixOS/nixpkgs/commit/af24e6840b89c79da914128523b2d2b14789bfe7) | `` wireplumber: 0.5.6 -> 0.5.7 ``                                                    |
| [`62b5e44e`](https://github.com/NixOS/nixpkgs/commit/62b5e44e12982690da2d27fefb6489cb469a1262) | `` tinycompress: 1.2.11 -> 1.2.13 ``                                                 |
| [`9c3a8465`](https://github.com/NixOS/nixpkgs/commit/9c3a8465ed36a7381c8616e3805e634a6cc708fb) | `` mint-y-icons: 1.7.8 -> 1.7.9 ``                                                   |
| [`2596f0e2`](https://github.com/NixOS/nixpkgs/commit/2596f0e21c134c219c70b059684275b052778789) | `` python312Packages.flask-allowed-hosts: 1.1.2 -> 1.2.0 ``                          |
| [`2aed365b`](https://github.com/NixOS/nixpkgs/commit/2aed365b52a91562ba2866a63003be1497a48c2d) | `` python312Packages.uproot: 5.5.0 -> 5.5.1 ``                                       |
| [`4feb3eef`](https://github.com/NixOS/nixpkgs/commit/4feb3eeff3bc383bc2427a70d449e54ed2db0d64) | `` python312Packages.scikit-hep-testdata: 0.4.48 -> 0.5.0 ``                         |
| [`399e582e`](https://github.com/NixOS/nixpkgs/commit/399e582e18d54768edf9404dce6c4b03d3ac2001) | `` lib.types: improve performance on attrsWith ``                                    |
| [`d5eccbbb`](https://github.com/NixOS/nixpkgs/commit/d5eccbbbae7b781552d0e18ff54a3231b4e295ec) | `` lib/types: standardise attrsOf functor.wrapped warning and add a test ``          |
| [`2f6cdb78`](https://github.com/NixOS/nixpkgs/commit/2f6cdb78610c1a00ae982972591b5e547dd3a2ea) | `` shairport-sync-airplay2: 4.3.4 -> 4.3.5 ``                                        |
| [`14f4431d`](https://github.com/NixOS/nixpkgs/commit/14f4431d123be35ed23e49c23b3e3332b2dd4996) | `` lib/modules: Minor performance optimisation ``                                    |
| [`8622e100`](https://github.com/NixOS/nixpkgs/commit/8622e1001983768680f30995ca937bf0da6ce2bb) | `` python312Packages.refoss-ha: 1.2.4 -> 1.2.5 ``                                    |
| [`e193a72e`](https://github.com/NixOS/nixpkgs/commit/e193a72e60325e2a1ef16089dbb2f26c2ae180fc) | `` sums: 0.11 -> 0.13 ``                                                             |
| [`a145c869`](https://github.com/NixOS/nixpkgs/commit/a145c869064277943e601e5ecfca592877850843) | `` xlogo: 1.0.6 -> 1.0.7 ``                                                          |
| [`aeccc55b`](https://github.com/NixOS/nixpkgs/commit/aeccc55bcb4563abb6c5985ee105a7acaf181e4d) | `` zoom-us: 6.2.10 -> 6.2.11 ``                                                      |
| [`804b2e10`](https://github.com/NixOS/nixpkgs/commit/804b2e10ec90e9b3c0abe9390b35bffc809ae441) | `` python312Packages.torchrl: skip flaky tests ``                                    |
| [`59a78fb6`](https://github.com/NixOS/nixpkgs/commit/59a78fb6055d2b5a121a566bd7784b1e2f5c0b3d) | `` etlegacy-unwrapped: autoformat nixfmt ``                                          |
| [`b7e33cda`](https://github.com/NixOS/nixpkgs/commit/b7e33cda3254bf887efc624ee1e3ecd17a929fd3) | `` etlegacy-unwrapped: add more compilation flags ``                                 |
| [`96aa7516`](https://github.com/NixOS/nixpkgs/commit/96aa751629d689329cde627e92a15d452e239d75) | `` etlegacy-unwrapped: fix Darwin build ``                                           |
| [`187deac4`](https://github.com/NixOS/nixpkgs/commit/187deac429b5c1f384ae00bd5619d44e6e194a40) | `` python3Packages.netbox-plugin-prometheus-sd: specify source hash ``               |
| [`baad7715`](https://github.com/NixOS/nixpkgs/commit/baad7715eab2b500f7295f1e7323d348c4620ec5) | `` mint-themes: 2.1.9 -> 2.2.0 ``                                                    |
| [`201b0b05`](https://github.com/NixOS/nixpkgs/commit/201b0b054e8df23b632389b34aa147b333419520) | `` python3Packages.cyipopt: init at 1.5.0 ``                                         |
| [`9a0ae3a6`](https://github.com/NixOS/nixpkgs/commit/9a0ae3a604a5afc8aa8fd15ad6ca82914f74f2e9) | `` tandoor-recipes: drop maintainership ``                                           |
| [`798c3d20`](https://github.com/NixOS/nixpkgs/commit/798c3d20d385274073fbabcaf4ec85ef2ccb531f) | `` nixos/kea: fix settings example ``                                                |
| [`65350680`](https://github.com/NixOS/nixpkgs/commit/65350680a0b852f8991389f2f7f5395816159743) | `` gg-jj: init at 0.23.0 ``                                                          |
| [`38003ce5`](https://github.com/NixOS/nixpkgs/commit/38003ce53b4815bb1bc0250c3fd8de0da741faf9) | `` workflows/eval: Add the eval summary as a comment ``                              |
| [`d3694819`](https://github.com/NixOS/nixpkgs/commit/d369481934920ea94d5d1f162d6ca54a228d09de) | `` python312Packages.jupyter-docprovider: 1.0.0 -> 1.0.1 ``                          |
| [`bb6efb84`](https://github.com/NixOS/nixpkgs/commit/bb6efb84a3dca70cae4596d7d73d4f37a23ec996) | `` bitmask-vpn: fix calyx build (#348299) ``                                         |
| [`025394c3`](https://github.com/NixOS/nixpkgs/commit/025394c3f67caab255ac69ae2fe8195b0e478664) | `` shotcut: fix reference to ffmpeg in patch ``                                      |
| [`09801c98`](https://github.com/NixOS/nixpkgs/commit/09801c985b4449de0736603b1c2d8652bfab4b93) | `` vscode-extensions: make `pname` optional ``                                       |
| [`8f1d83ef`](https://github.com/NixOS/nixpkgs/commit/8f1d83efeb0f5506c9662e17eaf3df4151b70d28) | `` python312Packages.hstspreload: 2024.11.1 -> 2024.12.1 ``                          |
| [`118b50cb`](https://github.com/NixOS/nixpkgs/commit/118b50cb23bf036b71203c628ba8636281ba461e) | `` checkov: 3.2.322 -> 3.2.324 ``                                                    |
| [`7061537b`](https://github.com/NixOS/nixpkgs/commit/7061537bb7c5e049cb78de1e22865c8ff6ded3f2) | `` python312Packages.jupyter-server-ydoc: 1.0.0 -> 1.0.1 ``                          |
| [`a9f1795e`](https://github.com/NixOS/nixpkgs/commit/a9f1795e90f9af357d6e0b3d8d9c1540c9fc6475) | `` php.extensions.uuid: init at v1.2.1 ``                                            |
| [`8fc0ae40`](https://github.com/NixOS/nixpkgs/commit/8fc0ae40aa50e8b62f5c28d21574a807aada2e92) | `` python312Packages.usb-monitor: 1.21 -> 1.23 ``                                    |
| [`dfc70891`](https://github.com/NixOS/nixpkgs/commit/dfc70891556b4b33da7943c03583f991c8ec46bd) | `` python312Packages.wtf-peewee: 3.0.5 -> 3.0.6 ``                                   |
| [`82b685d6`](https://github.com/NixOS/nixpkgs/commit/82b685d683ea8e9860c5c8656556c7c04cad3b29) | `` kdePackages.fcitx5-qt: 5.1.7 -> 5.1.8 ``                                          |