### PR TITLE
chore(flake/home-manager): `bf23fe41` -> `5b5de433`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733175814,
-        "narHash": "sha256-zFOtOaqjzZfPMsm1mwu98syv3y+jziAq5DfWygaMtLg=",
+        "lastModified": 1733299172,
+        "narHash": "sha256-iaTXLdBtcHnXp6X4Xf2TgQPG1Ih+oB7ABjI3gEFDO74=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bf23fe41082aa0289c209169302afd3397092f22",
+        "rev": "5b5de4338fad32dc709c900b4dcbbcd98b20dc4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`5b5de433`](https://github.com/nix-community/home-manager/commit/5b5de4338fad32dc709c900b4dcbbcd98b20dc4c) | `` kakoune: fix color scheme package XDG file ``             |
| [`256ec265`](https://github.com/nix-community/home-manager/commit/256ec2653e79363022a6042285dde3935816cea4) | `` flake.lock: Update ``                                     |
| [`dfdf59b2`](https://github.com/nix-community/home-manager/commit/dfdf59b2d539941aea5c26666c9ab809c1dc34df) | `` atuin: make daemon log level configurable ``              |
| [`f8bc330a`](https://github.com/nix-community/home-manager/commit/f8bc330a13f80e13e70967bca0e674f711218ea2) | `` atuin: capitalize mentions of "atuin" ``                  |
| [`c56aa0f5`](https://github.com/nix-community/home-manager/commit/c56aa0f51d058f41a7ba0c45bd3b6d9d244c0396) | `` atuin: assert version >= 18.2.0 when daemon is enabled `` |
| [`33c236f1`](https://github.com/nix-community/home-manager/commit/33c236f1d5eb3d1a3df202540794d590c2fe0a2f) | `` atuin: add water-sucks as maintainer ``                   |
| [`092b81b9`](https://github.com/nix-community/home-manager/commit/092b81b95615919b36cbb0e690dda8583b31013e) | `` atuin: configure daemon using systemd and launchd ``      |