### PR TITLE
chore(flake/home-manager): `5b5de433` -> `6c3a7a0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733299172,
-        "narHash": "sha256-iaTXLdBtcHnXp6X4Xf2TgQPG1Ih+oB7ABjI3gEFDO74=",
+        "lastModified": 1733304249,
+        "narHash": "sha256-o6wNhr1ONxMuBJUGC9v0hEjFdv5rN6XzHJEL/rQJLjA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5b5de4338fad32dc709c900b4dcbbcd98b20dc4c",
+        "rev": "6c3a7a0b72c19ec994b85c57a1712d177bd809b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`6c3a7a0b`](https://github.com/nix-community/home-manager/commit/6c3a7a0b72c19ec994b85c57a1712d177bd809b2) | `` qt: reduce test closure ``           |
| [`8f4f57f9`](https://github.com/nix-community/home-manager/commit/8f4f57f9a67367881b1a36f93856ffef8646d428) | `` qt: update tooling for Plasma 6 ``   |
| [`70803283`](https://github.com/nix-community/home-manager/commit/70803283187c8f775ff561be4117e5b1a11b296e) | `` Translate using Weblate (Finnish) `` |