### PR TITLE
chore(flake/flake-compat): `9ed2ac15` -> `ff81ac96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -179,11 +179,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1732722421,
-        "narHash": "sha256-HRJ/18p+WoXpWJkcdsk9St5ZiukCqSDgbOGFa8Okehg=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9ed2ac151eada2306ca8c418ebd97807bb08f6ac",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
| [`a220b6b7`](https://github.com/edolstra/flake-compat/commit/a220b6b7b9c8dcf86fd99e13a7f5f8a28e7c386f) | `` Fix non-fetchTree pure-eval use of builtins.path `` |