### PR TITLE
chore(flake/home-manager): `1cd17a2f` -> `0daaded6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733342204,
-        "narHash": "sha256-MVgFAzk10tWV0SW3hV24/xeAxmkQ7peJYUUOi6cvVPM=",
+        "lastModified": 1733354384,
+        "narHash": "sha256-foZG2PLwumxYZkpXq7ajHDhuQlXaUeKfOpFfQpMviLM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1cd17a2f76f7711b06d5d59f1746cef602974498",
+        "rev": "0daaded612b0e6eaed0a63fc9d0778d8f05940fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`0daaded6`](https://github.com/nix-community/home-manager/commit/0daaded612b0e6eaed0a63fc9d0778d8f05940fe) | `` starship: replace `eval` with `source` for fish ``   |
| [`86ee1290`](https://github.com/nix-community/home-manager/commit/86ee1290d76bcd5f7ee6c80f181288a28ab0dca0) | `` starship: add `enableInteractive` option for fish `` |