### PR TITLE
chore(flake/darwin): `e7a71f8e` -> `55d07816`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733302587,
-        "narHash": "sha256-iIJoFsmQp0/nWRhO5c9uCGN4z2ZAJlYfqzyNBoiwASc=",
+        "lastModified": 1733351379,
+        "narHash": "sha256-MTMsAhXxMMVHVN99jT8E0afOAOtt3JQWjYpTja94PAU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "e7a71f8ec55564f54791e0bd9274f2910c86f8f2",
+        "rev": "55d07816a0944f06a9df5ef174999a72fa4060c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                      |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------- |
| [`55d46b89`](https://github.com/LnL7/nix-darwin/commit/55d46b8997e16e52d8a05232f4444124e04ba686) | `` test(aerospace): assert config values ``  |
| [`9a595560`](https://github.com/LnL7/nix-darwin/commit/9a5955601847c728ffb98e70b89a359390b24d28) | `` fix(aerospace): allow startup commands `` |