### PR TITLE
chore(flake/stylix): `ffba1f1b` -> `eb918dbf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -673,11 +673,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1733262405,
-        "narHash": "sha256-/AT315It87ll6mlZLYcmfoe6Uogx9MjPBCCZZZTq8xY=",
+        "lastModified": 1733427445,
+        "narHash": "sha256-E854RAbAX+DZHDo4HIk2nkqpIvvoAm+P7oDx7TmhWk8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ffba1f1bab63ea49541f812c72a4fcf305461d67",
+        "rev": "eb918dbffa24c4dae497f3ce3173660f948d5237",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                     |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`eb918dbf`](https://github.com/danth/stylix/commit/eb918dbffa24c4dae497f3ce3173660f948d5237) | `` doc: standardize license formatting (#661) ``            |
| [`32882de1`](https://github.com/danth/stylix/commit/32882de122465d5ac9d4cf0b08b969c879334bc7) | `` doc: update copyright and include contributors (#659) `` |