### PR TITLE
chore(flake/nixos-hardware): `cceee0a3` -> `e563803a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -492,11 +492,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1733217105,
-        "narHash": "sha256-fc6jTzIwCIVWTX50FtW6AZpuukuQWSEbPiyg6ZRGWFY=",
+        "lastModified": 1733481457,
+        "narHash": "sha256-IS3bxa4N1VMSh3/P6vhEAHQZecQ3oAlKCDvzCQSO5Is=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "cceee0a31d2f01bcc98b2fbd591327c06a4ea4f9",
+        "rev": "e563803af3526852b6b1d77107a81908c66a9fcf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`e563803a`](https://github.com/NixOS/nixos-hardware/commit/e563803af3526852b6b1d77107a81908c66a9fcf) | `` apple/t2: bump kernel from 6.11.7 to 6.12.2 ``   |
| [`22976281`](https://github.com/NixOS/nixos-hardware/commit/2297628136baca35c0a49df29f2407034708b5eb) | `` apple/t2: remove tiny-dfr and related options `` |