### PR TITLE
chore(flake/stylix): `eb918dbf` -> `e309d64f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -673,11 +673,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1733427445,
-        "narHash": "sha256-E854RAbAX+DZHDo4HIk2nkqpIvvoAm+P7oDx7TmhWk8=",
+        "lastModified": 1733510476,
+        "narHash": "sha256-RH/8yIuo+fNLCjQ6e1mnXwmmxymjvfWC9JcbDuIA8TM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "eb918dbffa24c4dae497f3ce3173660f948d5237",
+        "rev": "e309d64fe7f203274a7913e1d2b74307d15ba122",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                      |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`c6547e2b`](https://github.com/danth/stylix/commit/c6547e2b2685db495c70b1f54dc08b6ed31b9a7b) | `` hyprland: remove with statement ``                                        |
| [`5282744c`](https://github.com/danth/stylix/commit/5282744c3439eac8db271ad1c6f3692ca04d4776) | `` hyprland: reduce local variable scopes ``                                 |
| [`638f30a6`](https://github.com/danth/stylix/commit/638f30a67e938495adfc992aa025b4b00bf3f4ee) | `` hyprland: inline single-use variable ``                                   |
| [`47f1504b`](https://github.com/danth/stylix/commit/47f1504b454bbb76a0bc58f9fa63f6e62ad58682) | `` hyprland: structurally separate unconditional and conditional settings `` |
| [`16e4ca7f`](https://github.com/danth/stylix/commit/16e4ca7fa71a5d7bd30c1654d753703dd2ce7b2c) | `` hyprland: add hyprpaper.enable option ``                                  |