### PR TITLE
chore(flake/lovesegfault-vim-config): `6e588a35` -> `bea76622`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -412,11 +412,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733443686,
-        "narHash": "sha256-kf1QbLZbAxesBUpYA15zXiKaOGmJcwfdMDv9Ovkcs1A=",
+        "lastModified": 1733510421,
+        "narHash": "sha256-loO0BtbOZwS7TcFUk5L1L7nhaOgfCjwQGp+O0OKHs0s=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "6e588a355abd70a574a75bfd62b801b75495f090",
+        "rev": "bea76622d3205e336077cd2d347f0945c7830172",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                           |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`bea76622`](https://github.com/lovesegfault/vim-config/commit/bea76622d3205e336077cd2d347f0945c7830172) | `` refactor: replace whitespace-nvim with trim `` |
| [`1bdab40b`](https://github.com/lovesegfault/vim-config/commit/1bdab40b5713073c8f4e2f71ffc68ce4452412e1) | `` refactor: use vim-suda option ``               |