### PR TITLE
chore(flake/lovesegfault-vim-config): `bea76622` -> `3f031c16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -412,11 +412,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733510421,
-        "narHash": "sha256-loO0BtbOZwS7TcFUk5L1L7nhaOgfCjwQGp+O0OKHs0s=",
+        "lastModified": 1733530068,
+        "narHash": "sha256-z2VlL7EgsY1PrSzaCI+zIcAJHvsC2xS6pu/Dy0KrCM8=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "bea76622d3205e336077cd2d347f0945c7830172",
+        "rev": "3f031c16dd24f3b20b88f9ccdd4ce860bda6c356",
         "type": "github"
       },
       "original": {
@@ -585,11 +585,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733431684,
-        "narHash": "sha256-Tbdi0SEOuxABTDp0sCI7wdTnmpcnQOPzPo4jSWP0u+8=",
+        "lastModified": 1733498727,
+        "narHash": "sha256-R+n4JfXjGrJG2gbhJPsZPTwdDsHoJvwxxpWcRY4KjyQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6348336db0e0b17ab6d9c73bc8206db84ebf00d1",
+        "rev": "ae78face8d6a09abe2504d41c035b6460c15a17b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`3f031c16`](https://github.com/lovesegfault/vim-config/commit/3f031c16dd24f3b20b88f9ccdd4ce860bda6c356) | `` chore(flake/nixpkgs): 55d15ad1 -> d0797a04 `` |
| [`0aed2594`](https://github.com/lovesegfault/vim-config/commit/0aed25943a4d1c8e71341660fa140b740852bd18) | `` chore(flake/nixvim): 6348336d -> ae78face ``  |