### PR TITLE
chore(flake/darwin): `55d07816` -> `a35b08d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733351379,
-        "narHash": "sha256-MTMsAhXxMMVHVN99jT8E0afOAOtt3JQWjYpTja94PAU=",
+        "lastModified": 1733570843,
+        "narHash": "sha256-sQJAxY1TYWD1UyibN/FnN97paTFuwBw3Vp3DNCyKsMk=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "55d07816a0944f06a9df5ef174999a72fa4060c7",
+        "rev": "a35b08d09efda83625bef267eb24347b446c80b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                     |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
| [`8752b6ae`](https://github.com/LnL7/nix-darwin/commit/8752b6ae3c0d6b44ca4ef28e50503f8efcec0096) | `` github-runner: add instructions for triggering a runner registration ``  |
| [`22cde06f`](https://github.com/LnL7/nix-darwin/commit/22cde06f497b97cbab4186292f9fd82487bbfecc) | `` github-runner: fix service not starting ``                               |
| [`06e1d770`](https://github.com/LnL7/nix-darwin/commit/06e1d770687a832a13aa23f37cdebeadc3af89b8) | `` github-runner: use `lib.getExe{,'}` ``                                   |
| [`d8255f09`](https://github.com/LnL7/nix-darwin/commit/d8255f09da39e603e710149dc87a5f3eaa4ff049) | `` github-runner: remove `with lib;` ``                                     |
| [`70957ab0`](https://github.com/LnL7/nix-darwin/commit/70957ab0c6a37fe72d21e1a2c273189a05c3670c) | `` linux-builder: default `maxJobs` to amount of cores for Linux builder `` |