### PR TITLE
chore(flake/home-manager): `d00c6f6d` -> `9ebaa80a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733484277,
-        "narHash": "sha256-i5ay20XsvpW91N4URET/nOc0VQWOAd4c4vbqYtcH8Rc=",
+        "lastModified": 1733754861,
+        "narHash": "sha256-3JKzIou54yjiMVmvgdJwopekEvZxX3JDT8DpKZs4oXY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d00c6f6d0ad16d598bf7e2956f52c1d9d5de3c3a",
+        "rev": "9ebaa80a227eaca9c87c53ed515ade013bc2bca9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`9ebaa80a`](https://github.com/nix-community/home-manager/commit/9ebaa80a227eaca9c87c53ed515ade013bc2bca9) | `` thunderbird: set the correct SMTP server for aliases (#6177) `` |
| [`f63c15c1`](https://github.com/nix-community/home-manager/commit/f63c15c137f9e446af897c15218c1af9f06d91ad) | `` isync/mbsync: update module for 1.5.0 changes (#5918) ``        |