### PR TITLE
chore(flake/tinted-schemes): `61058a8d` -> `d5024d07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
     "tinted-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1731411556,
-        "narHash": "sha256-Tp1BpaF5qRav7O2TsSGjCfgRzhiasu4IuwROR66gz1o=",
+        "lastModified": 1733769397,
+        "narHash": "sha256-PXah6e8PK41T9vONsh9X4AVSO0Nq6OtwN4Hd22GizVo=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "61058a8d2e2bd4482b53d57a68feb56cdb991f0b",
+        "rev": "d5024d07713029d21aa45263e164913a0dfab0b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                      |
| ------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`d5024d07`](https://github.com/tinted-theming/schemes/commit/d5024d07713029d21aa45263e164913a0dfab0b6) | `` Update Deep Oceanic Next colors  (#37) `` |