### PR TITLE
chore(flake/home-manager): `9ebaa80a` -> `e952e949`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733754861,
-        "narHash": "sha256-3JKzIou54yjiMVmvgdJwopekEvZxX3JDT8DpKZs4oXY=",
+        "lastModified": 1733769654,
+        "narHash": "sha256-aVvYDt8eitZVF6fdOrSoIzYRkQ5Gh6kfRvqkiaDRLL0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9ebaa80a227eaca9c87c53ed515ade013bc2bca9",
+        "rev": "e952e94955dcc6fa2120c1430789fc41363f5237",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`e952e949`](https://github.com/nix-community/home-manager/commit/e952e94955dcc6fa2120c1430789fc41363f5237) | `` atuin: Prepare for daemon socket path in 18.4.0 ``       |
| [`77a792a0`](https://github.com/nix-community/home-manager/commit/77a792a0418227e69a2ba26728b47f2b8cf3b6ec) | `` atuin: Do not hard code prefix for daemon socket path `` |