### PR TITLE
chore(flake/stylix): `e309d64f` -> `5a69e8c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -673,11 +673,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1733510476,
-        "narHash": "sha256-RH/8yIuo+fNLCjQ6e1mnXwmmxymjvfWC9JcbDuIA8TM=",
+        "lastModified": 1733841628,
+        "narHash": "sha256-cSqwjZC9WOixjn33apjizc2FTSNennP9JvKw0L6Dvi8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e309d64fe7f203274a7913e1d2b74307d15ba122",
+        "rev": "5a69e8c65787a962cb3b7ebd855942029a8cba5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                         |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`5a69e8c6`](https://github.com/danth/stylix/commit/5a69e8c65787a962cb3b7ebd855942029a8cba5a) | `` ci: fix typo in target branch placeholder `` |
| [`b08769f6`](https://github.com/danth/stylix/commit/b08769f64e6f82a619abb44420539c93aaa2882a) | `` ci: implement automated backports (#664) ``  |
| [`23d9debf`](https://github.com/danth/stylix/commit/23d9debfdc43c996a1b0de94ebee0e2cde5ad79a) | `` vscode: extensive fonts ``                   |