### PR TITLE
chore(flake/stylix): `5a69e8c6` -> `bc25f3d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -673,11 +673,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1733841628,
-        "narHash": "sha256-cSqwjZC9WOixjn33apjizc2FTSNennP9JvKw0L6Dvi8=",
+        "lastModified": 1733858997,
+        "narHash": "sha256-PMZdRUZQlouWgHFCFW8ANDFL6fUjZ67KAEaqRXwRwvc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "5a69e8c65787a962cb3b7ebd855942029a8cba5a",
+        "rev": "bc25f3d69d3bb54548b772d7c2771e65cc37dc10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`bc25f3d6`](https://github.com/danth/stylix/commit/bc25f3d69d3bb54548b772d7c2771e65cc37dc10) | `` emacs: set font for all frames, not just for new ones (#656) ``     |
| [`dd6605be`](https://github.com/danth/stylix/commit/dd6605be798b52bf588dadfda4431acf4145c1ed) | `` doc: encourage adding testbeds for new modules (#673) ``            |
| [`81148743`](https://github.com/danth/stylix/commit/81148743b9de7a5764c29f64bb9f388d0cea030e) | `` doc: remove documentation about legacy commit conventions (#672) `` |