### PR TITLE
chore(flake/disko): `0f31ad73` -> `d32f2d17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734011192,
-        "narHash": "sha256-NghuiWXx6Q3gwLiudiNwDpYQ1CPEUK7J+f9dWREN8KA=",
+        "lastModified": 1734088167,
+        "narHash": "sha256-OIitVU+IstPbX/NWn2jLF+/sT9dVKcO2FKeRAzlyX6c=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "0f31ad735e784315a22d9899d3ba24340ce64220",
+        "rev": "d32f2d1750d61a476a236526b725ec5a32e16342",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                      |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`d32f2d17`](https://github.com/nix-community/disko/commit/d32f2d1750d61a476a236526b725ec5a32e16342) | `` release: reset released flag ``                           |
| [`65a44150`](https://github.com/nix-community/disko/commit/65a441502c9382d41ada1adbc9bd31d6c9b00fe2) | `` release: v1.10.0 ``                                       |
| [`a0c967fe`](https://github.com/nix-community/disko/commit/a0c967fef4d74b263610d9087be8efa7b1bdcd04) | `` Add extraArgs to zfs_volume. ``                           |
| [`22cd4b7e`](https://github.com/nix-community/disko/commit/22cd4b7e491a2a95fb9bca0dfb5904e01569e87e) | `` check for db.sqlite rather than /nix/store ``             |
| [`98894c85`](https://github.com/nix-community/disko/commit/98894c85988a54e828a06db984aace21c718a0bb) | `` make-disk-image: create directories images in out path `` |