### PR TITLE
chore(flake/nix-index-database): `f1e477a7` -> `311d6cf3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733629314,
-        "narHash": "sha256-U0vivjQFAwjNDYt49Krevs1murX9hKBFe2Ye0cHpgbU=",
+        "lastModified": 1734234111,
+        "narHash": "sha256-icEMqBt4HtGH52PU5FHidgBrNJvOfXH6VQKNtnD1aw8=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "f1e477a7dd11e27e7f98b646349cd66bbabf2fb8",
+        "rev": "311d6cf3ad3f56cb051ffab1f480b2909b3f754d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`311d6cf3`](https://github.com/nix-community/nix-index-database/commit/311d6cf3ad3f56cb051ffab1f480b2909b3f754d) | `` update generated.nix to release 2024-12-15-032933 `` |
| [`ad035087`](https://github.com/nix-community/nix-index-database/commit/ad03508704b42d0a0b9acb79978965e2f2373bbe) | `` flake.lock: Update ``                                |