### PR TITLE
chore(flake/git-hooks): `4c8e75ef` -> `aa9f40c9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -274,11 +274,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734261738,
-        "narHash": "sha256-3Lzk+7QyX8v60+km26D3dln7NMSA13vW+KYTkMkds6Q=",
+        "lastModified": 1734279981,
+        "narHash": "sha256-NdaCraHPp8iYMWzdXAt5Nv6sA3MUzlCiGiR586TCwo0=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4c8e75efbbdcc6f9203f64b1f21f8a55d2285264",
+        "rev": "aa9f40c906904ebd83da78e7f328cd8aeaeae785",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`2c69d710`](https://github.com/cachix/git-hooks.nix/commit/2c69d710c20b8856e18d01fd4f6d265175167eec) | `` chore: add a default priority to `cabal2nix` which ensures it runs after `hpack` `` |
| [`8a8d2b81`](https://github.com/cachix/git-hooks.nix/commit/8a8d2b81f465bb693c676a285f1ba93b4d3a8931) | `` make sure that clang-tools is in the same version across all platforms ``           |