### PR TITLE
chore(flake/disko): `d32f2d17` -> `a08bfe06`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734088167,
-        "narHash": "sha256-OIitVU+IstPbX/NWn2jLF+/sT9dVKcO2FKeRAzlyX6c=",
+        "lastModified": 1734343412,
+        "narHash": "sha256-b7G8oFp0Nj01BYUJ6ENC9Qf/HsYAIZvN9k/p0Kg/PFU=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "d32f2d1750d61a476a236526b725ec5a32e16342",
+        "rev": "a08bfe06b39e94eec98dd089a2c1b18af01fef19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                    |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`dcd15a37`](https://github.com/nix-community/disko/commit/dcd15a37f7496aab14ea46789d606dbb326a0e37) | `` make-disk-image fix virtiofs support `` |
| [`d3e3aa7a`](https://github.com/nix-community/disko/commit/d3e3aa7a1413f24367b6ab375b823e5c1fefc560) | `` flake.lock: Update ``                   |