### PR TITLE
chore(flake/stylix): `a9e37799` -> `a2d66f25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -673,11 +673,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1734110168,
-        "narHash": "sha256-Q0eeLYn45ErXlqGQyXmLLHGe1mqnUiK0Y9wZRa1SNFI=",
+        "lastModified": 1734531336,
+        "narHash": "sha256-BWwJTAiWmZudUdUbyets7e3zQfjvZYtkU51blBnUBjw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a9e3779949925ef22f5a215c5f49cf520dea30b1",
+        "rev": "a2d66f25478103ac9b4adc6d6713794f7005221e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`a2d66f25`](https://github.com/danth/stylix/commit/a2d66f25478103ac9b4adc6d6713794f7005221e) | `` treewide: extend stylix.imageScalingMode support `` |