### PR TITLE
chore(flake/lovesegfault-vim-config): `11302530` -> `f0d020ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -412,11 +412,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734480382,
-        "narHash": "sha256-FsPB9170jKbg6Dr8REEq+UetP3nNYLZhhjOWNFGdZY4=",
+        "lastModified": 1734566940,
+        "narHash": "sha256-WCo+iwoXNEJBLtHRrQ88LsSJ2WCQ5dxj1nYxnaCvAyk=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "11302530858aafe9e457a0535961e7dcdfd7219a",
+        "rev": "f0d020efb7eb9efe094d13f7d05788a5f3ed048c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`f0d020ef`](https://github.com/lovesegfault/vim-config/commit/f0d020efb7eb9efe094d13f7d05788a5f3ed048c) | `` chore(flake/nixpkgs): 3566ab72 -> d3c42f18 ``     |
| [`4fa79549`](https://github.com/lovesegfault/vim-config/commit/4fa79549cf737f4d114d9d4f813e7d8f73fa6c9c) | `` chore(flake/treefmt-nix): 0ce9d149 -> 76159fc7 `` |