### PR TITLE
chore(flake/disko): `a08bfe06` -> `2ee76c86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734343412,
-        "narHash": "sha256-b7G8oFp0Nj01BYUJ6ENC9Qf/HsYAIZvN9k/p0Kg/PFU=",
+        "lastModified": 1734701201,
+        "narHash": "sha256-hk0roBX10j/hospoWIJIJj3i2skd7Oml6yKQBx7mTFk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "a08bfe06b39e94eec98dd089a2c1b18af01fef19",
+        "rev": "2ee76c861af3b895b3b104bae04777b61397485b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                               |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`d8f3cfc5`](https://github.com/nix-community/disko/commit/d8f3cfc582356736eac3c46164cfc11a31aa082b) | `` zfs: run load-key on mount ``                      |
| [`60375cf0`](https://github.com/nix-community/disko/commit/60375cf09645dd08f401af187e036771df31ec7e) | `` cli: remove traceValSeq that shouldn't be there `` |
| [`194a9965`](https://github.com/nix-community/disko/commit/194a9965d1531b6be224a249b0398c9dddd60a88) | `` flake.lock: Update ``                              |