### PR TITLE
chore(flake/home-manager): `1395379a` -> `f342df3a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734622215,
-        "narHash": "sha256-OOfI0XhSJGHblfdNDhfnn8QnZxng63rWk9eeJ2tCbiI=",
+        "lastModified": 1734808199,
+        "narHash": "sha256-MxlUcLjE8xLbrI1SJ2B2jftlg4wdutEILa3fgqwA98I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1395379a7a36e40f2a76e7b9936cc52950baa1be",
+        "rev": "f342df3ad938f205a913973b832f52c12546aac6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`f342df3a`](https://github.com/nix-community/home-manager/commit/f342df3ad938f205a913973b832f52c12546aac6) | `` flake.lock: Update ``                    |
| [`db9a98e1`](https://github.com/nix-community/home-manager/commit/db9a98e178b57a8aff46b3482dfccb3f4d8d4ce3) | `` pay-respects: add module ``              |
| [`99f54cdf`](https://github.com/nix-community/home-manager/commit/99f54cdfef395bb3de1c7b8dd422412de65b038d) | `` yazi: fix example option for settings `` |