### PR TITLE
chore(flake/home-manager): `f342df3a` -> `51160a09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734808199,
-        "narHash": "sha256-MxlUcLjE8xLbrI1SJ2B2jftlg4wdutEILa3fgqwA98I=",
+        "lastModified": 1734821669,
+        "narHash": "sha256-F7Z2tIJsUEhErpK0sGMep4xG/eTVuK2eBpvgh3cS2H8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f342df3ad938f205a913973b832f52c12546aac6",
+        "rev": "51160a097a850839b7eae7ef08d0d3e7e353dfc3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`51160a09`](https://github.com/nix-community/home-manager/commit/51160a097a850839b7eae7ef08d0d3e7e353dfc3) | `` thunderbird: implement `extensions` for profiles `` |