### PR TITLE
chore(flake/home-manager): `51160a09` -> `cb27edb5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734821669,
-        "narHash": "sha256-F7Z2tIJsUEhErpK0sGMep4xG/eTVuK2eBpvgh3cS2H8=",
+        "lastModified": 1734862405,
+        "narHash": "sha256-bXZJvUMJ2A6sIpYcCUAGjYCD5UDzmpmQCdmJSkPhleU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "51160a097a850839b7eae7ef08d0d3e7e353dfc3",
+        "rev": "cb27edb5221d2f2920a03155f8becc502cf60e35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`cb27edb5`](https://github.com/nix-community/home-manager/commit/cb27edb5221d2f2920a03155f8becc502cf60e35) | `` waybar: add systemd restart triggers `` |
| [`f47b6c15`](https://github.com/nix-community/home-manager/commit/f47b6c153ad31187a519bd569ccbcb20acb16ce0) | `` cavalier: add module ``                 |
| [`c903b1f6`](https://github.com/nix-community/home-manager/commit/c903b1f6fbfc2039963806df896f698331b77aa8) | `` flake.lock: Update ``                   |