### PR TITLE
chore(flake/nixos-hardware): `b12e3147` -> `e8516a23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -492,11 +492,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1734352517,
-        "narHash": "sha256-mfv+J/vO4nqmIOlq8Y1rRW8hVsGH3M+I2ESMjhuebDs=",
+        "lastModified": 1734862644,
+        "narHash": "sha256-04xesW7HITdF5WUmNM39WD4tkEERk3Ez2W1nNvdIvIw=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b12e314726a4226298fe82776b4baeaa7bcf3dcd",
+        "rev": "e8516a23524cc9083f5a02a8d64d14770e4c7c09",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`f6abeb02`](https://github.com/NixOS/nixos-hardware/commit/f6abeb027b4b874ad5a6fa59c2cfdee71e373a56) | `` raspberry-pi-4: fix devicetree filter `` |
| [`5e6a5463`](https://github.com/NixOS/nixos-hardware/commit/5e6a54633451002608cec7cc999c5ccdecda2c33) | `` raspberry-pi-4: add tv-hat overlay ``    |