### PR TITLE
chore(flake/stylix): `4f489c63` -> `4d87b96c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -673,11 +673,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1734822296,
-        "narHash": "sha256-zYGz8vgtyha4TsrSUPmcfPAb0IlYADZy4KjeXI9Z+u8=",
+        "lastModified": 1734885904,
+        "narHash": "sha256-NxA4JnLuXyle2/nUKDbW8vORwSd+Z20limIl7DhlZbs=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "4f489c63932f014be856475154bf342f8a40f5ff",
+        "rev": "4d87b96ceca38532f39c1b7efd8a9235bfcee3d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                         |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`aec7be45`](https://github.com/danth/stylix/commit/aec7be45cf896c52c38ee99b7e1a21f4c6d4ccd4) | `` xresources: convert font size to a string `` |
| [`be3a33d5`](https://github.com/danth/stylix/commit/be3a33d58999e92b98152aedcc59238f1c299f87) | `` cava: add rainbow theme option (#638) ``     |
| [`75f38f9e`](https://github.com/danth/stylix/commit/75f38f9edffba44cf2f18f4df89850f9c3cb1ddb) | `` stylix: use floats for font sizes ``         |