### PR TITLE
chore(flake/lovesegfault-vim-config): `780dddb7` -> `53dec229`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -412,11 +412,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734825951,
-        "narHash": "sha256-slwE9upsNZaIYBJ7IoyuWt5i42BiAoE3xKjaCvxwC+A=",
+        "lastModified": 1734912535,
+        "narHash": "sha256-+bACiQbXS/t8GKjHhrE+zXGxf8ZOwZucdKggnhjAZ4k=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "780dddb71aaf0d68c6b9f5ed02c8c503b7eef484",
+        "rev": "53dec229c46269ac92849e57cfca09e9fb3f1be2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`53dec229`](https://github.com/lovesegfault/vim-config/commit/53dec229c46269ac92849e57cfca09e9fb3f1be2) | `` chore(flake/nixpkgs): d3c42f18 -> d70bd19e `` |