### PR TITLE
chore(flake/impermanence): `0ab2f858` -> `d000479f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -347,11 +347,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1734772301,
-        "narHash": "sha256-mQEQQzCTUlDiEw/EbblB510P/GQOmIPtKoJrqDqeGVc=",
+        "lastModified": 1734945620,
+        "narHash": "sha256-olIfsfJK4/GFmPH8mXMmBDAkzVQ1TWJmeGT3wBGfQPY=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "0ab2f858dfefe73402eb53fbe6a3bad4f6702d5f",
+        "rev": "d000479f4f41390ff7cf9204979660ad5dd16176",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`d000479f`](https://github.com/nix-community/impermanence/commit/d000479f4f41390ff7cf9204979660ad5dd16176) | `` ci: Add merge_group to check triggers ``                                     |
| [`fdd77e33`](https://github.com/nix-community/impermanence/commit/fdd77e33769ad3df528a728dc91aaee77f9bccec) | `` nixos: Fix boot for ZFS systems using non-systemd initrd ``                  |
| [`0528cc42`](https://github.com/nix-community/impermanence/commit/0528cc42f9b7633f2a0dff5603e353fdedb46855) | `` nixos: Improve handling of special file systems in create-needed-for-boot `` |