### PR TITLE
chore(flake/nixos-hardware): `e8516a23` -> `def1d472`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -492,11 +492,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1734862644,
-        "narHash": "sha256-04xesW7HITdF5WUmNM39WD4tkEERk3Ez2W1nNvdIvIw=",
+        "lastModified": 1734954597,
+        "narHash": "sha256-QIhd8/0x30gEv8XEE1iAnrdMlKuQ0EzthfDR7Hwl+fk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e8516a23524cc9083f5a02a8d64d14770e4c7c09",
+        "rev": "def1d472c832d77885f174089b0d34854b007198",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`1db3c42d`](https://github.com/NixOS/nixos-hardware/commit/1db3c42d93e460f71f6cfd5ae20e669bc31b9a80) | `` surface: linux 6.12.4 -> 6.12.6 ``                      |
| [`73866b43`](https://github.com/NixOS/nixos-hardware/commit/73866b432618e6c542f45a9057eef6d5ac9a69cb) | `` dell-precision-5560: enable fwupd ``                    |
| [`68283046`](https://github.com/NixOS/nixos-hardware/commit/6828304671c6a1c4d104585887b6a7ad22208a58) | `` dell-precision-5560: remove redundant i915.modeset=1 `` |
| [`9988a79f`](https://github.com/NixOS/nixos-hardware/commit/9988a79f27589fe1c99513df37a5aab5df95e6c8) | `` add Thinkpad T14 AMD Gen 5 to readme ``                 |
| [`bad8e794`](https://github.com/NixOS/nixos-hardware/commit/bad8e79410eed70b35d6fde6eaf060a81328b774) | `` enable acpi.ec_no_wakeup in Thinkpad T14 AMD Gen 5 ``   |