### PR TITLE
chore(flake/treefmt-nix): `65712f5a` -> `e41e948c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -810,11 +810,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734704479,
-        "narHash": "sha256-MMi74+WckoyEWBRcg/oaGRvXC9BVVxDZNRMpL+72wBI=",
+        "lastModified": 1734982074,
+        "narHash": "sha256-N7M37KP7cHWoXicuE536GrVvU8nMDT/gpI1kja2hkdg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "65712f5af67234dad91a5a4baee986a8b62dbf8f",
+        "rev": "e41e948cf097cbf96ba4dff47a30ea6891af9f33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                              |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`e41e948c`](https://github.com/numtide/treefmt-nix/commit/e41e948cf097cbf96ba4dff47a30ea6891af9f33) | `` README: fix the formatter example to include the system (#284) `` |