### PR TITLE
chore(flake/home-manager): `8264bfe3` -> `f1b1786e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734944412,
-        "narHash": "sha256-36QfCAl8V6nMIRUCgiC79VriJPUXXkHuR8zQA1vAtSU=",
+        "lastModified": 1734992499,
+        "narHash": "sha256-f9UyHMTb+BwF6RDZ8eO9HOkSlKeeSPBlcYhMmV1UNIk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8264bfe3a064d704c57df91e34b795b6ac7bad9e",
+        "rev": "f1b1786ea77739dcd181b920d430e30fb1608b8a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f1b1786e`](https://github.com/nix-community/home-manager/commit/f1b1786ea77739dcd181b920d430e30fb1608b8a) | `` swayr: avoid IFD `` |