### PR TITLE
chore(flake/disko): `2ee76c86` -> `3a4de9fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734701201,
-        "narHash": "sha256-hk0roBX10j/hospoWIJIJj3i2skd7Oml6yKQBx7mTFk=",
+        "lastModified": 1735048446,
+        "narHash": "sha256-Tc35Y8H+krA6rZeOIczsaGAtobSSBPqR32AfNTeHDRc=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "2ee76c861af3b895b3b104bae04777b61397485b",
+        "rev": "3a4de9fa3a78ba7b7170dda6bd8b4cdab87c0b21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                              |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`7ea6edd8`](https://github.com/nix-community/disko/commit/7ea6edd85743171efef4b807e516c31991aca72c) | `` zfs-with-vdevs: add an example for using absolute device paths `` |