### PR TITLE
chore(flake/home-manager): `f1b1786e` -> `35b98d20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734992499,
-        "narHash": "sha256-f9UyHMTb+BwF6RDZ8eO9HOkSlKeeSPBlcYhMmV1UNIk=",
+        "lastModified": 1735053786,
+        "narHash": "sha256-Gm+0DcbUS338vvkwyYWms5jsWlx8z8MeQBzcnIDuIkw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f1b1786ea77739dcd181b920d430e30fb1608b8a",
+        "rev": "35b98d20ca8f4ca1f6a2c30b8a2c8bb305a36d84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`35b98d20`](https://github.com/nix-community/home-manager/commit/35b98d20ca8f4ca1f6a2c30b8a2c8bb305a36d84) | `` treewide: change pacien to euxane ``        |
| [`afbf007b`](https://github.com/nix-community/home-manager/commit/afbf007bb5e05b7837be5485e221ea50c4fd4f1b) | `` tests: add integration test for nh ``       |
| [`64272584`](https://github.com/nix-community/home-manager/commit/64272584091a47e3762d1bfb40638fbe58dd756d) | `` tests: change to wait for network.target `` |
| [`aa8c3d7f`](https://github.com/nix-community/home-manager/commit/aa8c3d7f7d6b61d3273e943d4fb8bddf7a647431) | `` tests: remove stray line ``                 |