### PR TITLE
chore(flake/treefmt-nix): `e41e948c` -> `9e09d30a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -810,11 +810,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734982074,
-        "narHash": "sha256-N7M37KP7cHWoXicuE536GrVvU8nMDT/gpI1kja2hkdg=",
+        "lastModified": 1735135567,
+        "narHash": "sha256-8T3K5amndEavxnludPyfj3Z1IkcFdRpR23q+T0BVeZE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e41e948cf097cbf96ba4dff47a30ea6891af9f33",
+        "rev": "9e09d30a644c57257715902efbb3adc56c79cf28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                   |
| ---------------------------------------------------------------------------------------------------- | ------------------------- |
| [`9e09d30a`](https://github.com/numtide/treefmt-nix/commit/9e09d30a644c57257715902efbb3adc56c79cf28) | `` sqruff: init (#283) `` |