### PR TITLE
chore(flake/stylix): `4d87b96c` -> `079feceb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -673,11 +673,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1734885904,
-        "narHash": "sha256-NxA4JnLuXyle2/nUKDbW8vORwSd+Z20limIl7DhlZbs=",
+        "lastModified": 1735151068,
+        "narHash": "sha256-sJ1/y4aXAZ22trJjY+nH/bJ+pydaDKf3wZtafM+Yjcs=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "4d87b96ceca38532f39c1b7efd8a9235bfcee3d6",
+        "rev": "079fecebad5f616561726359c89cedd811c8a722",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                               |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`079feceb`](https://github.com/danth/stylix/commit/079fecebad5f616561726359c89cedd811c8a722) | `` firefox: leverage Home Manager's mkFirefoxModule pattern (#695) `` |
| [`a70154ec`](https://github.com/danth/stylix/commit/a70154ec03034cfd1a88868dc0259456fc618435) | `` doc: resolve 'magick convert' deprecation warning (#697) ``        |