### PR TITLE
chore(flake/nix-index-database): `d583b2d1` -> `c8470746`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734838217,
-        "narHash": "sha256-zvMLS8BGn+kMG7tLLT3PJ67/S9yqZ9B7V8hKBa9cRRY=",
+        "lastModified": 1735160596,
+        "narHash": "sha256-zD8ciZm42wi1ijHyS7J0dmBE3QXMA/qBfwW/SEXhiwI=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "d583b2d142f0428313df099f4a2dcf2a0496aa78",
+        "rev": "c8470746a9f4d1ab4c7563db7da995595ed64ca2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`c8470746`](https://github.com/nix-community/nix-index-database/commit/c8470746a9f4d1ab4c7563db7da995595ed64ca2) | `` update generated.nix to release 2024-12-25-204532 `` |
| [`f3ea8bd1`](https://github.com/nix-community/nix-index-database/commit/f3ea8bd11b980aefb1324b0d71d7aee09db1c0a8) | `` set small db as default for comma ``                 |
| [`07f7fcb8`](https://github.com/nix-community/nix-index-database/commit/07f7fcb8de6ee50a472a119a02616fb1ed67a25f) | `` update generated.nix to release 2024-12-22-163440 `` |
| [`2ad40f1b`](https://github.com/nix-community/nix-index-database/commit/2ad40f1b4cf5512681509bb4ff79e87084888f10) | `` expose nix-index-small-database ``                   |
| [`e6926650`](https://github.com/nix-community/nix-index-database/commit/e6926650c0a6fcb7a7e80b963002c5e1403dea0e) | `` expose small db and nix-index package with it ``     |
| [`e2f645c6`](https://github.com/nix-community/nix-index-database/commit/e2f645c6bdd50f7767f3e90f41a59abdde77288f) | `` update generated.nix to release 2024-12-22-115534 `` |
| [`8abb006e`](https://github.com/nix-community/nix-index-database/commit/8abb006edb7d7e0e442f00c0bf705bc86ca7a88e) | `` generate small index ``                              |