### PR TITLE
chore(flake/nix-index-database): `c8470746` -> `02dadaef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735160596,
-        "narHash": "sha256-zD8ciZm42wi1ijHyS7J0dmBE3QXMA/qBfwW/SEXhiwI=",
+        "lastModified": 1735209697,
+        "narHash": "sha256-2Jp/V+5BiIzVCumEyWqiOmtLqF+sNn0nKSwHSev8BWg=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "c8470746a9f4d1ab4c7563db7da995595ed64ca2",
+        "rev": "02dadaeffe0bc761d46d3a9b317750374a160c46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                          |
| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`e609cc6e`](https://github.com/nix-community/nix-index-database/commit/e609cc6e0f9037b2bb02bd1104afcc1f6f936d33) | `` Revert "update generated.nix to release 2024-12-25-204532" `` |