### PR TITLE
chore(flake/darwin): `a35b08d0` -> `bc03f781`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733570843,
-        "narHash": "sha256-sQJAxY1TYWD1UyibN/FnN97paTFuwBw3Vp3DNCyKsMk=",
+        "lastModified": 1735218083,
+        "narHash": "sha256-MoUAbmXz9TEr7zlKDRO56DBJHe30+7B5X7nhXm+Vpc8=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "a35b08d09efda83625bef267eb24347b446c80b8",
+        "rev": "bc03f7818771a75716966ce8c23110b715eff2aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                    |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------ |
| [`2c86af2e`](https://github.com/LnL7/nix-darwin/commit/2c86af2e996ac6abbf9e1711f36c28d33b328df6) | `` programs.ssh: add extraConfig option `` |