### PR TITLE
chore(flake/nix-index-database): `02dadaef` -> `7e3246f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735209697,
-        "narHash": "sha256-2Jp/V+5BiIzVCumEyWqiOmtLqF+sNn0nKSwHSev8BWg=",
+        "lastModified": 1735222882,
+        "narHash": "sha256-kWNi45/mRjQMG+UpaZQ7KyPavYrKfle3WgLn9YeBBVg=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "02dadaeffe0bc761d46d3a9b317750374a160c46",
+        "rev": "7e3246f6ad43b44bc1c16d580d7bf6467f971530",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`7e3246f6`](https://github.com/nix-community/nix-index-database/commit/7e3246f6ad43b44bc1c16d580d7bf6467f971530) | `` update generated.nix to release 2024-12-26-140211 `` |
| [`0a961f69`](https://github.com/nix-community/nix-index-database/commit/0a961f691c4da1e7edc0c23afd6e8d6765499ce0) | `` Omit symlinks to avoid a file collision ``           |