### PR TITLE
chore(flake/home-manager): `35b98d20` -> `b7a7cd5d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735053786,
-        "narHash": "sha256-Gm+0DcbUS338vvkwyYWms5jsWlx8z8MeQBzcnIDuIkw=",
+        "lastModified": 1735343815,
+        "narHash": "sha256-p7IJP/97zJda/wwCn1T2LJBz4olF5LjNf4uwhuyvARo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "35b98d20ca8f4ca1f6a2c30b8a2c8bb305a36d84",
+        "rev": "b7a7cd5dd1a74a9fe86ed4e016f91c78483b527a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`b7a7cd5d`](https://github.com/nix-community/home-manager/commit/b7a7cd5dd1a74a9fe86ed4e016f91c78483b527a) | `` pqiv: fix condition for writing pqivrc file `` |
| [`19398e50`](https://github.com/nix-community/home-manager/commit/19398e505a80db1a1c41207ee89e1b1770c5dcf6) | `` lesspipe: allow configuring package ``         |