### PR TITLE
chore(flake/darwin): `bc03f781` -> `53a0c2fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735218083,
-        "narHash": "sha256-MoUAbmXz9TEr7zlKDRO56DBJHe30+7B5X7nhXm+Vpc8=",
+        "lastModified": 1735427049,
+        "narHash": "sha256-rTpBl3xmKYDQTRWF8CRk/r1FoKPDVwqLHGoU7tfECvY=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "bc03f7818771a75716966ce8c23110b715eff2aa",
+        "rev": "53a0c2fe6ed46ab33fc4a221c9f907a7b4c8a91c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                          |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
| [`daf9d9fe`](https://github.com/LnL7/nix-darwin/commit/daf9d9fe5d5a7a5ef25aa446582f8c656aab2b9b) | `` fix(zsh): correct the path of zsh-fast-syntax-highlighting `` |
| [`2165857a`](https://github.com/LnL7/nix-darwin/commit/2165857a24668cc3cb09c052eb0d518a1dfa6d3f) | `` fish: add package option ``                                   |