### PR TITLE
chore(flake/darwin): `53a0c2fe` -> `713da7b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735427049,
-        "narHash": "sha256-rTpBl3xmKYDQTRWF8CRk/r1FoKPDVwqLHGoU7tfECvY=",
+        "lastModified": 1735470496,
+        "narHash": "sha256-Kx2ungOLiOXw+A/GDeeWGF91pu4Pxtf51A9VTJQKG1U=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "53a0c2fe6ed46ab33fc4a221c9f907a7b4c8a91c",
+        "rev": "713da7b75b9ed86b1aeef25981dc73f99ea0477f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                         |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`b8e184eb`](https://github.com/LnL7/nix-darwin/commit/b8e184ebf271367cf1c93d942e71ae51d2a248cb) | `` refactor: use enum as option type ``         |
| [`19bc0d6c`](https://github.com/LnL7/nix-darwin/commit/19bc0d6cbeacb20c5ca865d06c274152c42ffd22) | `` tests: add screencapture.target test case `` |
| [`25fb5271`](https://github.com/LnL7/nix-darwin/commit/25fb52710582c19ad811d1ac9a2fe9d8920c0a66) | `` feat: add screencapture.target option ``     |