### PR TITLE
chore(flake/stylix): `963e77a3` -> `71eea3f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -673,11 +673,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1735253599,
-        "narHash": "sha256-aKLAUkdeMH2N5gMDNiOC7KghRNy1necLtLa9+zUcj1g=",
+        "lastModified": 1735512660,
+        "narHash": "sha256-mIorq1Wuu42H0+9HCNp6cMu7ZlddF9Q1u4CYJiWDBKk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "963e77a3a4fc2be670d5a9a6cbeb249b8a43808a",
+        "rev": "71eea3f02ae5c560bbc25e6d05e04beaf52f9dce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                             |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`defb43d4`](https://github.com/danth/stylix/commit/defb43d450dfc472682e64749334bd6f9ade91a5) | `` zathura: add testbed ``                          |
| [`6741c2ef`](https://github.com/danth/stylix/commit/6741c2ef6cb881acaf6904c6dc1a6a5cd181994f) | `` wezterm: add testbed ``                          |
| [`efb0e6f5`](https://github.com/danth/stylix/commit/efb0e6f59d0b8df5539acb239cd757402ba845b9) | `` vesktop: add testbed ``                          |
| [`491f7b3c`](https://github.com/danth/stylix/commit/491f7b3c93fe37403f033d1efd67ea350732b7e2) | `` qutebrowser: add testbed ``                      |
| [`0c162ff5`](https://github.com/danth/stylix/commit/0c162ff5a8474b419ffe5a9509f377b7980eb478) | `` kitty: add testbed ``                            |
| [`7fcf77f1`](https://github.com/danth/stylix/commit/7fcf77f1a9b4c849d6c7f742d7c93dd48554dab4) | `` gedit: add testbed ``                            |
| [`7cd8165f`](https://github.com/danth/stylix/commit/7cd8165fc1ced74a63ff216f1adefdae826d2e2c) | `` foot: add testbed ``                             |
| [`06218e77`](https://github.com/danth/stylix/commit/06218e77d01569881ec53f1ba5103b6b5e2ceada) | `` emacs: add testbed ``                            |
| [`8eb2da8d`](https://github.com/danth/stylix/commit/8eb2da8d502d66e4660049254fec82e3e3e14c19) | `` chromium: add testbed ``                         |
| [`2ce89d28`](https://github.com/danth/stylix/commit/2ce89d2821fbb6ef269cad5fdc7c1939e6a0e2b1) | `` alacritty: add testbed ``                        |
| [`146d92a2`](https://github.com/danth/stylix/commit/146d92a210743ca0dcdc43a1010ae11a0249a90d) | `` vscode: add testbed ``                           |
| [`6c67f751`](https://github.com/danth/stylix/commit/6c67f75101679ce3c7d415995e090c61944e3bed) | `` firefox: add testbed ``                          |
| [`195e3240`](https://github.com/danth/stylix/commit/195e32407441033407a6ea7ef531133c8e2bedb0) | `` stylix: add template for application testbeds `` |