### PR TITLE
chore(flake/treefmt-nix): `9e09d30a` -> `942ec968`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -810,11 +810,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735135567,
-        "narHash": "sha256-8T3K5amndEavxnludPyfj3Z1IkcFdRpR23q+T0BVeZE=",
+        "lastModified": 1735645903,
+        "narHash": "sha256-Twr7IstIqQc4tQIV9QlOW9sTBSnrrRKnN5U+WLKI+Xo=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "9e09d30a644c57257715902efbb3adc56c79cf28",
+        "rev": "942ec9683c8645af5ee5fd9088a413db41ff91d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                           |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`942ec968`](https://github.com/numtide/treefmt-nix/commit/942ec9683c8645af5ee5fd9088a413db41ff91d5) | `` README: count the number of programs (#286) `` |
| [`1deca81a`](https://github.com/numtide/treefmt-nix/commit/1deca81ad14b383a32db518af97af3ae3b77f8ed) | `` feat: add 'goimports' formatter (#285) ``      |