### PR TITLE
chore(flake/treefmt-nix): `942ec968` -> `56c0ecd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -810,11 +810,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735645903,
-        "narHash": "sha256-Twr7IstIqQc4tQIV9QlOW9sTBSnrrRKnN5U+WLKI+Xo=",
+        "lastModified": 1735653038,
+        "narHash": "sha256-Q6xAmciTXDtZfUxf6c15QqtRR8BvX4edYPstF/uoqMk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "942ec9683c8645af5ee5fd9088a413db41ff91d5",
+        "rev": "56c0ecd79f7ba01a0ec027da015df751d6ca3ae7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                            |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`56c0ecd7`](https://github.com/numtide/treefmt-nix/commit/56c0ecd79f7ba01a0ec027da015df751d6ca3ae7) | `` schema: add global.on-unmatched option ``       |
| [`d7f8fa42`](https://github.com/numtide/treefmt-nix/commit/d7f8fa424443db3f5e518811c89e0f9c2033c997) | `` fmt: enable deadnix ``                          |
| [`3b6b91ef`](https://github.com/numtide/treefmt-nix/commit/3b6b91ef00f5fb4ab1e09cd4872e91e86c72e4e9) | `` fmt: fix check ``                               |
| [`a13a77c1`](https://github.com/numtide/treefmt-nix/commit/a13a77c1261341cb8bdd1b90d916f663c1bec098) | `` programs: add meta.maintainers in every file `` |
| [`3a92dc5f`](https://github.com/numtide/treefmt-nix/commit/3a92dc5faaec365df9070d975775b8b7c68d0d0d) | `` fmt: switch to nixfmt ``                        |
| [`59770511`](https://github.com/numtide/treefmt-nix/commit/597705118f16d1dcd0fef99707700d13b2b324d7) | `` fmt ``                                          |