### PR TITLE
chore(flake/lovesegfault-vim-config): `472a8823` -> `bc9bb1af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -412,11 +412,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735603524,
-        "narHash": "sha256-lM8Diyp+pXmtL7Qd/uULoa8i+yl9CFjnBXifK91UEVE=",
+        "lastModified": 1736208566,
+        "narHash": "sha256-ZEV4646Sph/wgjyaG1s1R6fSsviYjzzYjBY3BZ2spFQ=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "472a8823da2a56602111f6b4232609c1654ea8e3",
+        "rev": "bc9bb1af8d66bac3d96f00b5ff9bc3619fb71243",
         "type": "github"
       },
       "original": {
@@ -585,11 +585,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735600249,
-        "narHash": "sha256-7W5v98B2cQfvtsv42YsDM+6rk0hvLRz6IzUhE6NvPgw=",
+        "lastModified": 1736207155,
+        "narHash": "sha256-GHCR00qjM3Ux6GfZUQshZCpEIpTeNX+KF6sQ4tMVnqY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c04dda021b18a192c421ee79b877b341db5b2d69",
+        "rev": "81c1ef2090928715b9c17529880b9b60fe3abfc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`bc9bb1af`](https://github.com/lovesegfault/vim-config/commit/bc9bb1af8d66bac3d96f00b5ff9bc3619fb71243) | `` chore(flake/nixvim): 7896856d -> 81c1ef20 ``      |
| [`37745e16`](https://github.com/lovesegfault/vim-config/commit/37745e16c23c35b95e771d47dbcd8c7ec1ec24e4) | `` chore(flake/flake-parts): f2f7418c -> b905f6fc `` |
| [`b0eedcb3`](https://github.com/lovesegfault/vim-config/commit/b0eedcb3b7e963bc96f5ce793ca0d59e05c96d7e) | `` chore(flake/treefmt-nix): 1788ca5a -> 13c913f5 `` |
| [`613ccb88`](https://github.com/lovesegfault/vim-config/commit/613ccb8862bd3bcc69986c19babb9ee06d322755) | `` chore(flake/nixvim): e07a482f -> 7896856d ``      |
| [`45d5b517`](https://github.com/lovesegfault/vim-config/commit/45d5b517737016012bb110a511b98a34cccc5ad0) | `` chore(flake/treefmt-nix): 29806aba -> 1788ca5a `` |
| [`83bd66ea`](https://github.com/lovesegfault/vim-config/commit/83bd66eaf02bef49557bb132045c63194932294c) | `` chore(flake/nixvim): 91227dca -> e07a482f ``      |
| [`b5cd689c`](https://github.com/lovesegfault/vim-config/commit/b5cd689c8e7863a7796e077fe6b1712b05f6fb95) | `` chore(flake/treefmt-nix): 56c0ecd7 -> 29806aba `` |
| [`d8f913c8`](https://github.com/lovesegfault/vim-config/commit/d8f913c881e9a4fe91c67cadd309571bd1843d4f) | `` chore(flake/nixvim): 3285bbda -> 91227dca ``      |
| [`6e488030`](https://github.com/lovesegfault/vim-config/commit/6e4880303e98f30179b4622b1434a39dd5f9e819) | `` chore(flake/git-hooks): f0f0dc49 -> a5a96138 ``   |
| [`9191ad71`](https://github.com/lovesegfault/vim-config/commit/9191ad71b6634d156e52c02a5fed2ec648d80b12) | `` chore(flake/nixvim): 87ee6609 -> 3285bbda ``      |
| [`fe6864c2`](https://github.com/lovesegfault/vim-config/commit/fe6864c246ca916c866fc7089f9bdec2f364bd8b) | `` chore(flake/nixvim): caef3913 -> 87ee6609 ``      |
| [`885aa6e1`](https://github.com/lovesegfault/vim-config/commit/885aa6e1ad8fa9395ce8ce79edc4c967bdd04095) | `` chore(flake/flake-parts): 205b12d8 -> f2f7418c `` |
| [`409a8d05`](https://github.com/lovesegfault/vim-config/commit/409a8d0521b1742dc8b6e3e92d9035393fa52eff) | `` chore(flake/treefmt-nix): 9e09d30a -> 56c0ecd7 `` |
| [`89101573`](https://github.com/lovesegfault/vim-config/commit/89101573d946d22657a3d983e42e7edda5f568ba) | `` chore(flake/nixvim): c04dda02 -> caef3913 ``      |