### PR TITLE
chore(flake/darwin): `71a3a075` -> `ba9b3173`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735478292,
-        "narHash": "sha256-Ys9pSP9ch0SthhpbjnkCSJ9ZLfaNKnt/dcy7swjmS1A=",
+        "lastModified": 1736085891,
+        "narHash": "sha256-bTl9fcUo767VaSx4Q5kFhwiDpFQhBKna7lNbGsqCQiA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "71a3a075e3229a7518d76636bb762aef2bcb73ac",
+        "rev": "ba9b3173b0f642ada42b78fb9dfc37ca82266f6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                            |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
| [`6ee6262d`](https://github.com/LnL7/nix-darwin/commit/6ee6262d2468cf053f39cb53ea6272af337f2cf7) | `` Add --ignore-dependencies option for casks ``                                                   |
| [`89be82cb`](https://github.com/LnL7/nix-darwin/commit/89be82cb2b19b6371a786af6eb9effc79babb70f) | `` power: quote in string triggered shellcheck SC2016 ``                                           |
| [`0680f9e9`](https://github.com/LnL7/nix-darwin/commit/0680f9e9e1a2861e1513a4ffe5b483130ce736c7) | `` ci, readme: update stable nixpkgs to 24.11 ``                                                   |
| [`492a7200`](https://github.com/LnL7/nix-darwin/commit/492a72007ae2e7bd5895458fcd72ac2c8c9a0dc4) | `` power: echo to print in error messages ``                                                       |
| [`62d8f5f2`](https://github.com/LnL7/nix-darwin/commit/62d8f5f289341497ea0fa21814e734cbea69a0a1) | `` power: move the check for restartPowerfailure support to checks.nix ``                          |
| [`016b1608`](https://github.com/LnL7/nix-darwin/commit/016b1608eec6c54cfaece96b63ec9d1a6cd4672b) | `` power: restartAfterPowerFailure option is carried out in activation script only if supported `` |