### PR TITLE
chore(flake/home-manager): `10e99c43` -> `20665c6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735381016,
-        "narHash": "sha256-CyCZFhMUkuYbSD6bxB/r43EdmDE7hYeZZPTCv0GudO4=",
+        "lastModified": 1736204492,
+        "narHash": "sha256-CoBPRgkUex9Iz6qGSzi/BFVUQjndB0PmME2B6eEyeCs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "10e99c43cdf4a0713b4e81d90691d22c6a58bdf2",
+        "rev": "20665c6efa83d71020c8730f26706258ba5c6b2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`20665c6e`](https://github.com/nix-community/home-manager/commit/20665c6efa83d71020c8730f26706258ba5c6b2a) | `` home-manager: remove path: URI type for flake default `` |
| [`172b91bf`](https://github.com/nix-community/home-manager/commit/172b91bfb2b7f5c4a8c6ceac29fd53a01ef07196) | `` Translate using Weblate (German) ``                      |
| [`4795ebe6`](https://github.com/nix-community/home-manager/commit/4795ebe6cc6e5f60a3e66e3627b4f182ac4771b5) | `` Translate using Weblate (French) ``                      |
| [`5ad12b6e`](https://github.com/nix-community/home-manager/commit/5ad12b6ea06b84e48f6b677957c74f32d47bdee0) | `` flake.lock: Update ``                                    |
| [`0d7908bd`](https://github.com/nix-community/home-manager/commit/0d7908bd09165db6699908b7e3970f137327cbf0) | `` neomutt: Document how to bind Ctrl keys (#6254) ``       |
| [`11ab0854`](https://github.com/nix-community/home-manager/commit/11ab08541e61ac3bbf2ab27229f68622629401df) | `` ghostty: validate configuration on change ``             |
| [`a9987622`](https://github.com/nix-community/home-manager/commit/a9987622b7b93c82e147f198574e8e6ffbf5e327) | `` maintainers: updated username to midirhee12 ``           |
| [`14cb0c8c`](https://github.com/nix-community/home-manager/commit/14cb0c8cfaa28d62a0e0cb4829e921635cd2b296) | `` fnott: use config.wayland.systemd.target ``              |
| [`656ae5ab`](https://github.com/nix-community/home-manager/commit/656ae5aba2d48adfe5bb3aa8d433b9a50cfb2a11) | `` clipman: use config.wayland.systemd.target ``            |
| [`a6db8c8f`](https://github.com/nix-community/home-manager/commit/a6db8c8f6c201df0cfb5482241368ac02a5b17f3) | `` hypridle: use config.wayland.systemd.target ``           |
| [`da12f0b1`](https://github.com/nix-community/home-manager/commit/da12f0b143558490efc52b7f550e19d9fcf27909) | `` hyprpaper: use config.wayland.systemd.target ``          |
| [`8f48fea0`](https://github.com/nix-community/home-manager/commit/8f48fea0f8a8392f4b81da07333342824fdb35c9) | `` avizo: use config.wayland.systemd.target ``              |
| [`adcf0b62`](https://github.com/nix-community/home-manager/commit/adcf0b6281f4d8c00ea263c49f52a71130ee875f) | `` wob: use config.wayland.systemd.target ``                |
| [`51ba4aac`](https://github.com/nix-community/home-manager/commit/51ba4aacec867a1ecc2b92bf5ecdc66dbf9eb6c2) | `` swayosd: use config.wayland.systemd.target ``            |
| [`4cbc8a58`](https://github.com/nix-community/home-manager/commit/4cbc8a58ab94e5eea5fe3185837d6489579a7f68) | `` swaync: use config.wayland.systemd.target ``             |
| [`d3c500a8`](https://github.com/nix-community/home-manager/commit/d3c500a8f8f88587c0867ba13ae6dba6e3c58cec) | `` kanshi: use config.wayland.systemd.target ``             |
| [`8587c2ff`](https://github.com/nix-community/home-manager/commit/8587c2ff0ea82a93a265dbcbad7df88c80de1b9c) | `` waybar: use config.wayland.systemd.target ``             |
| [`89fe48b1`](https://github.com/nix-community/home-manager/commit/89fe48b1c1c51d5616343b71822a45f894b16dcf) | `` swayidle: use config.wayland.systemd.target ``           |
| [`0734cfab`](https://github.com/nix-community/home-manager/commit/0734cfab07a90a34bb91428e24646e5fe78d9e24) | `` wayland: add module ``                                   |
| [`1c8d4c8d`](https://github.com/nix-community/home-manager/commit/1c8d4c8d592e8fab4cff4397db5529ec6f078cf9) | `` mako: add center-left & center-right ``                  |
| [`7254063d`](https://github.com/nix-community/home-manager/commit/7254063d529d666f10d73ce3fe5756d6c325ddc3) | `` Update translation files ``                              |
| [`12327fc3`](https://github.com/nix-community/home-manager/commit/12327fc3d83ee6c3f39b1b8852d9139fa4d2a176) | `` Add translation using Weblate (Tamil) ``                 |
| [`7f16e9c3`](https://github.com/nix-community/home-manager/commit/7f16e9c3cb00ca6df680917ab37ebf00177a19e9) | `` Translate using Weblate (Tamil) ``                       |
| [`a6f37e57`](https://github.com/nix-community/home-manager/commit/a6f37e5785a5057ab43b4f5a64c590dcc709f043) | `` ghostty: fix configuration for bat syntax ``             |
| [`1e68dc75`](https://github.com/nix-community/home-manager/commit/1e68dc759b3b3e0dc56589ecd3e58c3699ff9b27) | `` home-manager: move profile management ``                 |
| [`1e2a9d2d`](https://github.com/nix-community/home-manager/commit/1e2a9d2d29216f3512e6a02905b4f88f11bf5d0e) | `` format: ignore system and user git config ``             |
| [`f4f8d09f`](https://github.com/nix-community/home-manager/commit/f4f8d09f909b4ef34afd9bad2284042d307bc95f) | `` home-manager: update copyright year ``                   |
| [`5f6aa268`](https://github.com/nix-community/home-manager/commit/5f6aa268e419d053c3d5025da740e390b12ac936) | `` ghostty: add module ``                                   |
| [`9a9fef31`](https://github.com/nix-community/home-manager/commit/9a9fef316ad191b3086edda465e850af282de4e0) | `` systemd: use sd-switch by default ``                     |
| [`5518f9d4`](https://github.com/nix-community/home-manager/commit/5518f9d43919c255653b235150010da32faa60c0) | `` home-manager: make show news a bit more robust ``        |
| [`59a4c43e`](https://github.com/nix-community/home-manager/commit/59a4c43e9ba6db24698c112720a58a334117de83) | `` bacon: fix configuration file location on Darwin ``      |
| [`2ac770c0`](https://github.com/nix-community/home-manager/commit/2ac770c007cc5dc26e6fe472956e6a23134dd124) | `` flake.lock: Update ``                                    |