### PR TITLE
chore(flake/nix-index-database): `55ab1e1d` -> `816a6ae8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735443188,
-        "narHash": "sha256-AydPpRBh8+NOkrLylG7vTsHrGO2b5L7XkMEL5HlzcA8=",
+        "lastModified": 1736047960,
+        "narHash": "sha256-hutd85FA1jUJhhqBRRJ+u7UHO9oFGD/RVm2x5w8WjVQ=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "55ab1e1df5daf2476e6b826b69a82862dcbd7544",
+        "rev": "816a6ae88774ba7e74314830546c29e134e0dffb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`816a6ae8`](https://github.com/nix-community/nix-index-database/commit/816a6ae88774ba7e74314830546c29e134e0dffb) | `` update generated.nix to release 2025-01-05-031613 `` |
| [`ff2883e9`](https://github.com/nix-community/nix-index-database/commit/ff2883e99aa3ab84e1cea129c0aad4f4b6dd1fec) | `` flake.lock: Update ``                                |