### PR TITLE
chore(flake/nix-fast-build): `ed736c65` -> `a06a8b2c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -436,11 +436,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1734716067,
-        "narHash": "sha256-BCpd50t/3JU4ydiNfJxH3LzQDzyGbBI0CKWaeplnkVg=",
+        "lastModified": 1736168988,
+        "narHash": "sha256-jqH3cfg98+mRSB59WmJuWnvsSyOUNIOVZxf16Mh9/8s=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "ed736c65a8cb58a85369f6ee1c3f4403aa904fcc",
+        "rev": "a06a8b2c079f7b6dab491a12555387bdb737cc44",
         "type": "github"
       },
       "original": {
@@ -790,11 +790,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734543842,
-        "narHash": "sha256-/QceWozrNg915Db9x/Ie5k67n9wKgGdTFng+Z1Qw0kE=",
+        "lastModified": 1735905407,
+        "narHash": "sha256-1hKMRIT+QZNWX46e4gIovoQ7H8QRb7803ZH4qSKI45o=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "76159fc74eeac0599c3618e3601ac2b980a29263",
+        "rev": "29806abab803e498df96d82dd6f34b32eb8dd2c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`a06a8b2c`](https://github.com/Mic92/nix-fast-build/commit/a06a8b2c079f7b6dab491a12555387bdb737cc44) | `` flake.lock: Update ``                                          |
| [`19e76bc7`](https://github.com/Mic92/nix-fast-build/commit/19e76bc7cad95248befdce9c86fb6e1e088056c6) | `` mergify: delete old merge branches ``                          |
| [`908c3aca`](https://github.com/Mic92/nix-fast-build/commit/908c3aca3486120a575b6057bcddef07a810224f) | `` check for new cacheStatus attribute in nix-eval-jobs output `` |