### PR TITLE
chore(flake/disko): `84a5b936` -> `49f8aa79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735468753,
-        "narHash": "sha256-2dt1nOe9zf9pDkf5Kn7FUFyPRo581s0n90jxYXJ94l0=",
+        "lastModified": 1736199437,
+        "narHash": "sha256-TdU0a/x8048rbbJmkKWzSY1CtsbbGKNkIJcMdr8Zf4Q=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "84a5b93637cc16cbfcc61b6e1684d626df61eb21",
+        "rev": "49f8aa791f81ff2402039b3efe0c35b9386c4bcf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                        |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`5be012e9`](https://github.com/nix-community/disko/commit/5be012e91700ee3549fa2da481207ac715667652) | `` fix: Apply umask=0077 to /boot partition in all examples `` |
| [`c315045f`](https://github.com/nix-community/disko/commit/c315045f42b9be08d0a2af299c4f2335f7819c54) | `` flake.lock: Update ``                                       |