### PR TITLE
chore(flake/nixos-hardware): `7c674c67` -> `ca30f850`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -492,11 +492,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1735388221,
-        "narHash": "sha256-e5IOgjQf0SZcFCEV/gMGrsI0gCJyqOKShBQU0iiM3Kg=",
+        "lastModified": 1736237814,
+        "narHash": "sha256-uTdscVaKjnRnBIMuu/oWwdiGhYd/JOQ4YZGHeCoroqs=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "7c674c6734f61157e321db595dbfcd8523e04e19",
+        "rev": "ca30f8501ab452ca687a7fdcb2d43e1fb1732317",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`ca30f850`](https://github.com/NixOS/nixos-hardware/commit/ca30f8501ab452ca687a7fdcb2d43e1fb1732317) | `` asus: init fa506ic ``                                                               |
| [`75a92053`](https://github.com/NixOS/nixos-hardware/commit/75a920536c1cbc9403bc61d7e7ba803d675ad8d3) | `` rpi2: switch to extlinux bootloader ``                                              |
| [`95a81255`](https://github.com/NixOS/nixos-hardware/commit/95a812557bf86d6204f1ef99e88f9d209fcde8b0) | `` update flake.lock ``                                                                |
| [`4c5c3be7`](https://github.com/NixOS/nixos-hardware/commit/4c5c3be74dc61a11346528e8240a655b8c26f0d2) | `` Slimbook/hero: Init ``                                                              |
| [`d3b4fe46`](https://github.com/NixOS/nixos-hardware/commit/d3b4fe46c86824d10ffa7b2fe2cb1bf09fb6eae7) | `` Adding support for GV302X* 2023 (#1285) ``                                          |
| [`b98df182`](https://github.com/NixOS/nixos-hardware/commit/b98df1827a48ebaa4db48ac98f178d5dfeae4275) | `` framework/13-inch/7040-amd: remove fprint workaround ``                             |
| [`8a2a2ef2`](https://github.com/NixOS/nixos-hardware/commit/8a2a2ef294e53084886d13c43be424153592a03b) | `` lenovo/yoga/7/14IAH7: init ``                                                       |
| [`90ecc4a2`](https://github.com/NixOS/nixos-hardware/commit/90ecc4a20c4ed533e2ff3c61c9d611e41427f5c2) | `` raspberry-pi.4.leds.{eth,pwr}: fix target rename ``                                 |
| [`c422baea`](https://github.com/NixOS/nixos-hardware/commit/c422baea263648af47aaa6650fa9a0f270ecac8d) | `` raspberry-pi.4.leds: enable overlays-dtmerge ``                                     |
| [`178ff0c3`](https://github.com/NixOS/nixos-hardware/commit/178ff0c3f5880c5ab8577411d04f7a8bae7c657a) | `` surface: linux 6.12.7 -> 6.12.8 ``                                                  |
| [`76dcc45e`](https://github.com/NixOS/nixos-hardware/commit/76dcc45ea64eb6c21bb8411e9159d67ea8dd6dab) | `` Bump linux-surface patches to arch-6.12.7-1 ``                                      |
| [`3713545a`](https://github.com/NixOS/nixos-hardware/commit/3713545aca79365cba20d7873b6e51044890b4e8) | `` starfive visionfive2: allow uboot and opensbi patches overrides ``                  |
| [`7eab0aa0`](https://github.com/NixOS/nixos-hardware/commit/7eab0aa0b7eb293c8a41a4319cd9e2045b78c234) | `` starfive visionfive2: allow uboot and opensbi source overrides ``                   |
| [`a2861aa6`](https://github.com/NixOS/nixos-hardware/commit/a2861aa6964fe7f76f7ec16ecbef2085bcf220ec) | `` fix: remove intel from services.xserver.videoDrivers due to deprecation in 24.11 `` |