### PR TITLE
chore(flake/stylix): `a4ed4168` -> `1d7b70ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,6 +176,22 @@
         "type": "github"
       }
     },
+    "firefox-gnome-theme": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1734969791,
+        "narHash": "sha256-A9PxLienMYJ/WUvqFie9qXrNC2MeRRYw7TG/q7DRjZg=",
+        "owner": "rafaelmardojai",
+        "repo": "firefox-gnome-theme",
+        "rev": "92f4890bd150fc9d97b61b3583680c0524a8cafe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rafaelmardojai",
+        "repo": "firefox-gnome-theme",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -286,9 +302,62 @@
         "type": "github"
       }
     },
+    "git-hooks_2": {
+      "inputs": {
+        "flake-compat": [
+          "stylix",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore_2",
+        "nixpkgs": [
+          "stylix",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "stylix",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731363552,
+        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "stylix",
           "git-hooks",
           "nixpkgs"
         ]
@@ -637,12 +706,14 @@
         "base16-fish": "base16-fish",
         "base16-helix": "base16-helix",
         "base16-vim": "base16-vim",
+        "firefox-gnome-theme": "firefox-gnome-theme",
         "flake-compat": [
           "flake-compat"
         ],
         "flake-utils": [
           "flake-utils"
         ],
+        "git-hooks": "git-hooks_2",
         "gnome-shell": "gnome-shell",
         "home-manager": [
           "home-manager"
@@ -653,14 +724,15 @@
         "systems": "systems",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
-        "tinted-tmux": "tinted-tmux"
+        "tinted-tmux": "tinted-tmux",
+        "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1735524788,
-        "narHash": "sha256-R4i8VCdSGLWHt6cL5p2Cmlh9MRodZsYO8moUjvxYb54=",
+        "lastModified": 1736201929,
+        "narHash": "sha256-TC6nITVcD+qxjPOWGmLAshuOkILocvzxfHj0Vsu6FAI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a4ed4168fb83289374f24cb8a039c6983637a076",
+        "rev": "1d7b70ed9ee4c3b24ed6b0c7c64a0ee5fcc4ae10",
         "type": "github"
       },
       "original": {
@@ -762,6 +834,22 @@
       "original": {
         "owner": "tinted-theming",
         "repo": "tinted-tmux",
+        "type": "github"
+      }
+    },
+    "tinted-zed": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1725758778,
+        "narHash": "sha256-8P1b6mJWyYcu36WRlSVbuj575QWIFZALZMTg5ID/sM4=",
+        "owner": "tinted-theming",
+        "repo": "base16-zed",
+        "rev": "122c9e5c0e6f27211361a04fae92df97940eccf9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-zed",
         "type": "github"
       }
     },


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                           |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`1d7b70ed`](https://github.com/danth/stylix/commit/1d7b70ed9ee4c3b24ed6b0c7c64a0ee5fcc4ae10) | `` firefox: add firefoxGnomeTheme.enable option (#702) ``                         |
| [`284c5b03`](https://github.com/danth/stylix/commit/284c5b03578eecbf3c680392ea7d0506834adc6b) | `` ci: run CI on PRs and limit push event to protected branches (#751) ``         |
| [`a6b53aa6`](https://github.com/danth/stylix/commit/a6b53aa677ab9bd9098abbdc47924854c76c3eb1) | `` gnome-text-editor: init (#747) ``                                              |
| [`b47ef3b8`](https://github.com/danth/stylix/commit/b47ef3b8560c3921404d72cec95d84632e355e01) | `` zed: init (#620) ``                                                            |
| [`ad64260a`](https://github.com/danth/stylix/commit/ad64260a75f0331d4d9b0db70f60634283e0aa5d) | `` treewide: add and apply nixfmt pre-commit hook ``                              |
| [`807c8189`](https://github.com/danth/stylix/commit/807c81894e9af60b105476c3dab679e9dc86686f) | `` stylix: add ghc developer shell ``                                             |
| [`708b2147`](https://github.com/danth/stylix/commit/708b2147c095a60994f56714968f00de531f8deb) | `` stylix: add hlint pre-commit hook ``                                           |
| [`439c6cf2`](https://github.com/danth/stylix/commit/439c6cf24e89730d3271baf10e5706df1cdecedf) | `` treewide: add and apply stylish-haskell ``                                     |
| [`4ceede75`](https://github.com/danth/stylix/commit/4ceede75042e362d3270b52d4870702a99915bb0) | `` ci: prevent the Check workflow from running duplicated checks outputs ``       |
| [`d3bdbf0c`](https://github.com/danth/stylix/commit/d3bdbf0c5b4656955be0019e821de6fa65a6bb78) | `` treewide: add and apply yamllint pre-commit hook ``                            |
| [`5ab7d034`](https://github.com/danth/stylix/commit/5ab7d0345a902f5f4c30f9c31ccf42c563ad6463) | `` treewide: add and apply typos pre-commit hook ``                               |
| [`2b85a562`](https://github.com/danth/stylix/commit/2b85a562355c80e1ef2f9070a3a44befdd7c9764) | `` ci: simplify workflows ``                                                      |
| [`fe72c230`](https://github.com/danth/stylix/commit/fe72c2306f517a865c23e9fc92fc72cc408c1ab7) | `` ci: update Ubuntu runner to ubuntu-24.04 ``                                    |
| [`1aa931f6`](https://github.com/danth/stylix/commit/1aa931f6f1eb85b4f8358e7ed3706ed82d3048ca) | `` ci: lock workflow dependencies to increase reproducibility ``                  |
| [`a0838923`](https://github.com/danth/stylix/commit/a0838923e45f63b2b46a132eaa02c45e03e8818a) | `` stylix: add nix-flake-check package ``                                         |
| [`e56d332c`](https://github.com/danth/stylix/commit/e56d332ca367bd021d3c584ac9130064916cd0c7) | `` stylix: add packages to checks output ``                                       |
| [`b3230ef3`](https://github.com/danth/stylix/commit/b3230ef39814b1c3809ffbad20f6361c8b737731) | `` stylix: integrate pre-commit hooks into developer shell ``                     |
| [`0d0af5f4`](https://github.com/danth/stylix/commit/0d0af5f4426104ed82b17d41f8763fcf84b2c0ea) | `` ci: consolidate Build and Lint workflows into single Check workflow ``         |
| [`60855608`](https://github.com/danth/stylix/commit/6085560893ae3620acf8d799dda138b207e6f5ed) | `` stylix: add deadnix and statix pre-commit hooks ``                             |
| [`3c54cb33`](https://github.com/danth/stylix/commit/3c54cb3384116d430e2a83c5d3d3f0dd59eb9ff2) | `` treewide: ignore unused arguments detected by deadnix ``                       |
| [`6ef37ca6`](https://github.com/danth/stylix/commit/6ef37ca6aaf82e59394d0a93acdc932af1739d58) | `` treewide: leverage direnv to automatically enter developer shell ``            |
| [`703f49aa`](https://github.com/danth/stylix/commit/703f49aaca9030b066bb60310d19d7cadfb4b376) | `` treewide: add developer shell ``                                               |
| [`7c8874b3`](https://github.com/danth/stylix/commit/7c8874b311c5ac7429a2384fc116cb9a69aaba84) | `` doc: remove "below" which was moved to a separate page (#727) ``               |
| [`18fd600c`](https://github.com/danth/stylix/commit/18fd600cd2ef008d0c5b23528d9307e97bf1da94) | `` doc: draw attention to release branches (#726) ``                              |
| [`2256b7d7`](https://github.com/danth/stylix/commit/2256b7d74bf2aec90d5c4e9acc7954ccb9cf34cf) | `` micro: init (#716) ``                                                          |
| [`fe25ebfd`](https://github.com/danth/stylix/commit/fe25ebfdc9591601885961183f3edaa9b8babcfb) | `` doc: update copyright year (#715) ``                                           |
| [`e0a41d3a`](https://github.com/danth/stylix/commit/e0a41d3a2562ce1b43cad8560333673d04b111b8) | `` kde: replace systemd unit with AutostartScript for theme application (#708) `` |
| [`0ce2a52d`](https://github.com/danth/stylix/commit/0ce2a52decf36d815065f8cda06586ed59ed3ef7) | `` yazi: add testbed, resolve 0.4.0 breaking changes, and improve names (#719) `` |
| [`6eb0597e`](https://github.com/danth/stylix/commit/6eb0597e345a7f4a16f7d7b14154fc151790b419) | `` ghostty: init (#703) ``                                                        |
| [`90f95c5d`](https://github.com/danth/stylix/commit/90f95c5d8408360fc38cb3a862565bcb08ae6aa8) | `` stylix: point nixpkgs input to more conventional nixos-unstable ref (#712) ``  |
| [`911c07f4`](https://github.com/danth/stylix/commit/911c07f40f816fd2d12a7dd750ca8bc421db9dd2) | `` fctix5: init (#718) ``                                                         |
| [`f48cab39`](https://github.com/danth/stylix/commit/f48cab39ba162c5eaef3d975aaac467c20db402b) | `` doc: document imageScalingMode options (#709) ``                               |