### PR TITLE
chore(flake/nixpkgs): `d70bd19e` -> `8f3e1f80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -575,11 +575,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734649271,
-        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
+        "lastModified": 1736012469,
+        "narHash": "sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs+rI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+        "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
         "type": "github"
       },
       "original": {

--- a/hardware/sound.nix
+++ b/hardware/sound.nix
@@ -2,8 +2,6 @@
 {
   environment.systemPackages = [ config.services.pipewire.package ];
 
-  hardware.pulseaudio.enable = lib.mkForce false;
-
   security.rtkit.enable = true;
 
   services.pipewire = {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`1d5cb8a3`](https://github.com/NixOS/nixpkgs/commit/1d5cb8a3330cbc7f323177591672fc6f1a31cae1) | `` pretix: fix tests after 2025-01-01 ``                                  |
| [`c4d943e9`](https://github.com/NixOS/nixpkgs/commit/c4d943e9eed5b3d717ae70289e440c4a22976630) | `` perlPackages.Testutf8: fix homepage ``                                 |
| [`1f3d0b2d`](https://github.com/NixOS/nixpkgs/commit/1f3d0b2d471358a782b8fe5779d0e37e4f4e0903) | `` volumeicon: update homepage ``                                         |
| [`62f35da2`](https://github.com/NixOS/nixpkgs/commit/62f35da2a1d8bee6fcbf650e282f09e161b98c88) | `` nixos/prometheus-exporters/fastly: fix secret handling ``              |
| [`483fc9b1`](https://github.com/NixOS/nixpkgs/commit/483fc9b12ba7633a4f1ef71bdc05bcd142695c3d) | `` codebuff: update homepage ``                                           |
| [`569425b7`](https://github.com/NixOS/nixpkgs/commit/569425b7d8a34f1240801bd48f0c462c9794edf7) | `` python312Packages.pysensors: update homepage ``                        |
| [`7870cd10`](https://github.com/NixOS/nixpkgs/commit/7870cd10d7d9223a3e4dd015fd0dabed0d89a05c) | `` twilight-kde: init at 0-unstable-2023-03-10 (#340903) ``               |
| [`963c58df`](https://github.com/NixOS/nixpkgs/commit/963c58df5464a50973efebd1827c97e02eeb689b) | `` ptext: init at 0-unstable-2024-08-19 (#336396) ``                      |
| [`75ad8522`](https://github.com/NixOS/nixpkgs/commit/75ad85225676171bb0743533f156b58b5023c35c) | `` epson-escpr: 1.7.20 -> 1.8.6 (#369304) ``                              |
| [`b78f2e31`](https://github.com/NixOS/nixpkgs/commit/b78f2e31747d7c1952c359dcbc9de8542b58f27d) | `` belle-sip: update homepage ``                                          |
| [`8cb3153b`](https://github.com/NixOS/nixpkgs/commit/8cb3153b64e4990e2db0ec760f1a85f00d7fee6c) | `` python313Packages.pympler: disable failing tests ``                    |
| [`7f9cd991`](https://github.com/NixOS/nixpkgs/commit/7f9cd9919ce8444bc6ab1e52c1e1a950ec56566d) | `` sing-box: 1.10.5 -> 1.10.6 ``                                          |
| [`79949f1d`](https://github.com/NixOS/nixpkgs/commit/79949f1d85e7bbee125746c6cdc534f46a9d3992) | `` limbo: 0.0.10 -> 0.0.11 ``                                             |
| [`9bf1108b`](https://github.com/NixOS/nixpkgs/commit/9bf1108bad5b155711b92287a53b6ca18894f658) | `` hatsu: 0.3.0 -> 0.3.2 ``                                               |
| [`b658e86b`](https://github.com/NixOS/nixpkgs/commit/b658e86b4316f90eb8b9abb30e9c3546035422a6) | `` twitch-dl: 2.9.2 -> 2.9.3 ``                                           |
| [`a28c17dc`](https://github.com/NixOS/nixpkgs/commit/a28c17dc23e35ac45150715e3bba56b08717a272) | `` ardour_7: fix dependencies ``                                          |
| [`22581ea9`](https://github.com/NixOS/nixpkgs/commit/22581ea9b5693cc53bb75795857f9d092dc71487) | `` nixos/tests/frigate: Add check for unauthenticated API ``              |
| [`733d5763`](https://github.com/NixOS/nixpkgs/commit/733d57633a4ebb5285ccb46ae41c3b529ddf8670) | `` harlequin: 1.25.2 -> 1.25.2-unstable-2024-12-30 ``                     |
| [`d2fa4b5d`](https://github.com/NixOS/nixpkgs/commit/d2fa4b5d460aa2c28057519439e9d2480adc75c7) | `` fixup! nixos-firewall-tool: fix cross-compilation ``                   |
| [`d1e24caf`](https://github.com/NixOS/nixpkgs/commit/d1e24caf355d0d875f5fe1db76959ec35e6aedaa) | `` gitea: drop myself (ma27) from maintainer list ``                      |
| [`fc5b81c1`](https://github.com/NixOS/nixpkgs/commit/fc5b81c18da010b22fa7e0b2b4160b56b3432da9) | `` plfit: 1.0.0 -> 1.0.1 ``                                               |
| [`a8f36e39`](https://github.com/NixOS/nixpkgs/commit/a8f36e39dcd9ac6f76c9ca5a9856401fd322d464) | `` unbound: fix cross-compilation (#370087) ``                            |
| [`f3987c0e`](https://github.com/NixOS/nixpkgs/commit/f3987c0e684bca9fb6c0319cf8d63af3bdb92709) | `` health-check: 0.04.00 -> 0.04.01 ``                                    |
| [`c9e86768`](https://github.com/NixOS/nixpkgs/commit/c9e86768c1ea25392127523887653d01c0b30852) | `` wezterm: add thiagokokada as maintainer ``                             |
| [`3b4a942a`](https://github.com/NixOS/nixpkgs/commit/3b4a942ab4ec7d0e3a79c0caf158b65edf877048) | `` wezterm: split headless variant in its own file ``                     |
| [`20c47244`](https://github.com/NixOS/nixpkgs/commit/20c47244e507f206052cd472e86fd7405cd0063b) | `` wezterm: move to pkgs/by-name ``                                       |
| [`7c4672bf`](https://github.com/NixOS/nixpkgs/commit/7c4672bfa8c6d78b9865b7503805ab7ca95e281f) | `` wezterm: 20240203-110809-5046fc22 -> 0-unstable-2025-01-03 ``          |
| [`cefbda9e`](https://github.com/NixOS/nixpkgs/commit/cefbda9e4cdc33950b9eba424d405ee791c6de34) | `` wezterm: sort inputs ``                                                |
| [`22295e97`](https://github.com/NixOS/nixpkgs/commit/22295e97fcf67256baa830672a6934ccfaa07564) | `` wezterm: add unstableGitUpdater as passthru.updateScript ``            |
| [`df185023`](https://github.com/NixOS/nixpkgs/commit/df185023654f09d2599f8dc8c8ad8d318bb7b3dc) | `` vimPlugins.blink-ripgrep-nvim: init at 2025-01-04 ``                   |
| [`22c7e046`](https://github.com/NixOS/nixpkgs/commit/22c7e04608d3b4de3d4da61492befa57e7097fe7) | `` docker-init: fix eval ``                                               |
| [`213dbf17`](https://github.com/NixOS/nixpkgs/commit/213dbf17746f910121b609bcb1a7db35478236d2) | `` ci/request-reviews: lowercase handles consistently ``                  |
| [`8f1da4b3`](https://github.com/NixOS/nixpkgs/commit/8f1da4b3ae926634a7e98ae1d09596f2dd6b4312) | `` nix-update: 1.7.0 -> 1.9.0 ``                                          |
| [`02728a77`](https://github.com/NixOS/nixpkgs/commit/02728a7701902878a1b171844321349e37546499) | `` lcalc: use libc++-compatible way of extending namespace std ``         |
| [`dc208d29`](https://github.com/NixOS/nixpkgs/commit/dc208d29520965349de61f434cf67719772d80d2) | `` nixpkgs-review: 3.0.0 -> 3.0.1 ``                                      |
| [`676d6e03`](https://github.com/NixOS/nixpkgs/commit/676d6e036432d10b9e9870be02a4335197d297fa) | `` shadps4: add liberodark to maintainers ``                              |
| [`01299c08`](https://github.com/NixOS/nixpkgs/commit/01299c081f87c6f5c7c42c6c41f4511e7732b7b5) | `` sage.tests: darwin sandbox fixes ``                                    |
| [`f7d6e4ae`](https://github.com/NixOS/nixpkgs/commit/f7d6e4ae13868e7faaa3d5c197062162e3b522b8) | `` slackdump: 2.6.1 -> 3.0.0 ``                                           |
| [`f0b18d81`](https://github.com/NixOS/nixpkgs/commit/f0b18d819b7c292184207ed64a3926b41e7c2ce0) | `` shadps4: 0.4.0-unstable-2024-12-23 > 0.5.0-unstable-2025-01-02 ``      |
| [`7978ab25`](https://github.com/NixOS/nixpkgs/commit/7978ab2557a45715b503b87d58859b61a7a66f1f) | `` kazumi: 1.4.8 -> 1.5.0 ``                                              |
| [`9e647535`](https://github.com/NixOS/nixpkgs/commit/9e6475352d53475fbe344e869c36ee59f43108c1) | `` sage.lib: ignore narrowing error on clang-19 ``                        |
| [`942ea8c7`](https://github.com/NixOS/nixpkgs/commit/942ea8c7af8dcc8e5dc5184ddeaecb0a1d60b761) | `` Revert "buildbot: add patch for compatibility with twisted 24.11.0" `` |
| [`8defe4cd`](https://github.com/NixOS/nixpkgs/commit/8defe4cd76245340e279332d7d8370dda567b3f3) | `` paperless-ngx: fix eval ``                                             |
| [`d4a0326f`](https://github.com/NixOS/nixpkgs/commit/d4a0326fab6c5766f54cf73348184f4cc2b4b34c) | `` dep-tree: 0.23.1 -> 0.23.3 ``                                          |
| [`43aaf362`](https://github.com/NixOS/nixpkgs/commit/43aaf362cf972777562cb0e8878b5fddc967a2a8) | `` python3Packages.mariadb: 1.1.10 -> 1.1.11 ``                           |
| [`26dce2b5`](https://github.com/NixOS/nixpkgs/commit/26dce2b5383cc0a499356361aa8016fcf3a65591) | `` comrak: 0.32.0 -> 0.33.0 ``                                            |
| [`a5d01f71`](https://github.com/NixOS/nixpkgs/commit/a5d01f718eaf9ca738581b4a3c780fb5046dd02f) | `` memray: 1.14.0 -> 1.15.0 ``                                            |
| [`34ba1df7`](https://github.com/NixOS/nixpkgs/commit/34ba1df71353de1307acb50a8364571d92d3275f) | `` textual: 0.86.1 -> 1.0.0 ``                                            |
| [`1fa77f64`](https://github.com/NixOS/nixpkgs/commit/1fa77f64fc55894f2d5c74695a1f6dddf8fd9ed8) | `` godns: 3.2.0 -> 3.2.1 ``                                               |
| [`a27e3395`](https://github.com/NixOS/nixpkgs/commit/a27e3395e3e158ce642bb57351baf42e07e105be) | `` net-news-wire: 6.1.5 -> 6.1.8 ``                                       |
| [`d35fc541`](https://github.com/NixOS/nixpkgs/commit/d35fc5417f250d53563b0a5bab8e5a13d5e9ad62) | `` act: 0.2.70 -> 0.2.71 ``                                               |
| [`d8401b9b`](https://github.com/NixOS/nixpkgs/commit/d8401b9b18e33c636f479f2eaab92e973d0963c8) | `` zinit: use tag instead of refs/tags ``                                 |
| [`a2792016`](https://github.com/NixOS/nixpkgs/commit/a2792016c89329d4f46991693bd45200fc91fb22) | `` zinit: fix _zinit not found ``                                         |
| [`62e22cdf`](https://github.com/NixOS/nixpkgs/commit/62e22cdfc722bdc7ad050ff3f1b854079e3fc2b0) | `` zinit: add nix-update-script ``                                        |
| [`e3036e0e`](https://github.com/NixOS/nixpkgs/commit/e3036e0e1be1050d5d31e1ec937d1578479dc440) | `` zinit: add maintainer moraxyc ``                                       |
| [`9713c984`](https://github.com/NixOS/nixpkgs/commit/9713c984c757c27b43f3bc5b278c1c2a2618a10d) | `` zinit: fix manpage not found ``                                        |
| [`a3df9206`](https://github.com/NixOS/nixpkgs/commit/a3df9206e2a000f915c7a658e4c6d4d76d979845) | `` zinit: refactor and modernize ``                                       |
| [`ef222a8e`](https://github.com/NixOS/nixpkgs/commit/ef222a8ea60a4c7e4f3857266f0b6b718e457597) | `` radvd: 2.20_rc1 -> 2.20 ``                                             |
| [`5a902436`](https://github.com/NixOS/nixpkgs/commit/5a902436c0daff1d40a41cc1c811754d57e87c11) | `` nezha-theme-user: init at 1.12.1 ``                                    |
| [`4784bc20`](https://github.com/NixOS/nixpkgs/commit/4784bc20c8a1a88bdeae6e0a866575a468da1c87) | `` diffoscope: fix the eval ``                                            |
| [`a322d5a6`](https://github.com/NixOS/nixpkgs/commit/a322d5a664c8d2fb53ecbac4b50c9639216d0346) | `` nezha-theme-nazhua: 0.4.20 -> 0.5.1 ``                                 |
| [`cbb8f5b9`](https://github.com/NixOS/nixpkgs/commit/cbb8f5b919d1ff0ed10cabb99b0e60feb8a50572) | `` nezha-theme-nazhua: 0.4.19 -> 0.4.20 ``                                |
| [`35112687`](https://github.com/NixOS/nixpkgs/commit/351126875500889be8f2d2064b9a305a7f849c4f) | `` nezha-theme-nazhua: init at 0.4.19 ``                                  |
| [`5d3993b9`](https://github.com/NixOS/nixpkgs/commit/5d3993b95de59a146cd406bf8d58a60d6eac3c07) | `` nix-forecast: fix meta.changelog ``                                    |
| [`af240f2f`](https://github.com/NixOS/nixpkgs/commit/af240f2fd5a2b0aa2398da4618b1515ff46d4ab6) | `` nix-forecast: 0.1.0 -> 0.2.0 ``                                        |
| [`3c989f13`](https://github.com/NixOS/nixpkgs/commit/3c989f13bbd086d5f2310b62a2d0a91333027592) | `` nix-forecast: add updateScript ``                                      |
| [`ad93f8df`](https://github.com/NixOS/nixpkgs/commit/ad93f8dfe35b3dc6468974e05878d3d44a1c6777) | `` cargo-lambda: 1.6.1 -> 1.6.2 ``                                        |
| [`1f2553f6`](https://github.com/NixOS/nixpkgs/commit/1f2553f6caf0c0792f4a9b23f233a8702e9fb8d0) | `` rclip: fix build ``                                                    |
| [`73266d7a`](https://github.com/NixOS/nixpkgs/commit/73266d7a66f68beec2eb746ec29c994fca2b3217) | `` auth0-cli: 1.6.1 -> 1.7.2 ``                                           |
| [`d7a789c2`](https://github.com/NixOS/nixpkgs/commit/d7a789c2a4ad52fad84f8d111f4dd694eb3f949e) | `` rain-bittorrent: 2.0.0 -> 2.1.0 ``                                     |
| [`c32c98f5`](https://github.com/NixOS/nixpkgs/commit/c32c98f53b9ae4280962d7385b1956fc01afa3c9) | `` wlr-which-key: 1.0.1 -> 1.1.0 ``                                       |
| [`eab4cd92`](https://github.com/NixOS/nixpkgs/commit/eab4cd92a85e46f6efd756ba319ea4f29e269165) | `` twitch-tui: 2.6.17 -> 2.6.18 ``                                        |
| [`4e971d82`](https://github.com/NixOS/nixpkgs/commit/4e971d82e24b4016920deeaed9f9f1e8a4025795) | `` sqlboiler: 4.17.1 -> 4.18.0 ``                                         |
| [`3e7223aa`](https://github.com/NixOS/nixpkgs/commit/3e7223aaf49ef7cb2102239a91e228a793eb6818) | `` semantic-release: 24.2.0 -> 24.2.1 ``                                  |