### PR TITLE
chore(flake/stylix): `1d7b70ed` -> `5c84f02f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1736201929,
-        "narHash": "sha256-TC6nITVcD+qxjPOWGmLAshuOkILocvzxfHj0Vsu6FAI=",
+        "lastModified": 1736274934,
+        "narHash": "sha256-mAAjaD6rPZLH7NDezJlZWAl8Se5BP0sboVnX8pvCNQ8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "1d7b70ed9ee4c3b24ed6b0c7c64a0ee5fcc4ae10",
+        "rev": "5c84f02fcfb4fc697f132e90b8b3f9598c809b96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                       |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`5c84f02f`](https://github.com/danth/stylix/commit/5c84f02fcfb4fc697f132e90b8b3f9598c809b96) | `` regreet: respect dark mode and unset extraCss for custom styling (#723) `` |