### PR TITLE
chore(flake/lovesegfault-vim-config): `edd8ef57` -> `47b64f25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -480,11 +480,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736279199,
-        "narHash": "sha256-82H5++XL5mOl3BXvV6HQXrP9oOo3tOwjPFbnVCE7S58=",
+        "lastModified": 1736294871,
+        "narHash": "sha256-fsyup3D/BAGMdlBhYICVFrFG7waCM/pybaUomTtNpis=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "edd8ef574701a8f9a4eb3183ad087431c649bec4",
+        "rev": "47b64f25e5d8a597cc4908f7e0fe87a10f361777",
         "type": "github"
       },
       "original": {
@@ -637,11 +637,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736207155,
-        "narHash": "sha256-GHCR00qjM3Ux6GfZUQshZCpEIpTeNX+KF6sQ4tMVnqY=",
+        "lastModified": 1736292108,
+        "narHash": "sha256-0mGe0okcNDKp0A9lS/birSP0Z5oheqgrXzQeolHM9U8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "81c1ef2090928715b9c17529880b9b60fe3abfc8",
+        "rev": "0ebc64a2328fc0a0532f9544eb6c6e297135962e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`47b64f25`](https://github.com/lovesegfault/vim-config/commit/47b64f25e5d8a597cc4908f7e0fe87a10f361777) | `` chore(flake/nixpkgs): d70bd19e -> 8f3e1f80 `` |
| [`f43815ee`](https://github.com/lovesegfault/vim-config/commit/f43815ee9506344e1241613b3476d4d651849d74) | `` chore(flake/nixvim): 81c1ef20 -> 0ebc64a2 ``  |