### PR TITLE
chore(flake/nixos-hardware): `ca30f850` -> `4f339f6b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1736237814,
-        "narHash": "sha256-uTdscVaKjnRnBIMuu/oWwdiGhYd/JOQ4YZGHeCoroqs=",
+        "lastModified": 1736283893,
+        "narHash": "sha256-BG1FfTexFwNty5VhYjaQLMR6CMPfI3QRcaZrFQYu2EM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "ca30f8501ab452ca687a7fdcb2d43e1fb1732317",
+        "rev": "4f339f6be2b61662f957c2ee9eda0fa597d8a6d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message         |
| ----------------------------------------------------------------------------------------------------- | --------------- |
| [`4f339f6b`](https://github.com/NixOS/nixos-hardware/commit/4f339f6be2b61662f957c2ee9eda0fa597d8a6d6) | `` oversight `` |