### PR TITLE
chore(flake/stylix): `5c84f02f` -> `168306ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1736274934,
-        "narHash": "sha256-mAAjaD6rPZLH7NDezJlZWAl8Se5BP0sboVnX8pvCNQ8=",
+        "lastModified": 1736300059,
+        "narHash": "sha256-z3mR+0gBN/iVM8UgfCSIxjgw4jm1bu1kjMKyQx9mGBc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "5c84f02fcfb4fc697f132e90b8b3f9598c809b96",
+        "rev": "168306ce7f5d823ccee8b7d4e112ea20671c2b8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                             |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`a8399897`](https://github.com/danth/stylix/commit/a8399897e85510de8698f9a3737d91143af704ef) | `` treewide: remove redundant empty line in testbeds (#760) ``      |
| [`6d986760`](https://github.com/danth/stylix/commit/6d9867604efd73274bbe40fe974af66e9e3faa04) | `` treewide: reduce indentation level with lib.singleton (#754) ``  |
| [`8be9e8ad`](https://github.com/danth/stylix/commit/8be9e8ad9a238ce11fc3a1a00d4baffa4eb9ed28) | `` ci: update Ubuntu runner to ubuntu-24.04 in Backport workflow `` |
| [`0db7d025`](https://github.com/danth/stylix/commit/0db7d025edaae15dd603c7c9874212a052ca328f) | `` ci: lock Ubuntu runner to ubuntu-22.04 in Backport workflow ``   |