### PR TITLE
chore(flake/home-manager): `45bcdbc9` -> `fcc4259c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -400,11 +400,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736336279,
-        "narHash": "sha256-9Xp2X7ofKY4h39vUbd4coNambsG7Y/9axLFyTXaXOMU=",
+        "lastModified": 1736349844,
+        "narHash": "sha256-jpmKC8zNcFMt9ATsju2mryBuimIm+bR7HETCp0Rxd3s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "45bcdbc910dc5131943bb6f7edb156617898fd1a",
+        "rev": "fcc4259cdbcb76138b48ed36b4f41c521910db0d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                            |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`fcc4259c`](https://github.com/nix-community/home-manager/commit/fcc4259cdbcb76138b48ed36b4f41c521910db0d) | `` treewide: stub tests (#6275) `` |
| [`456e599f`](https://github.com/nix-community/home-manager/commit/456e599f9101ed153dde268b4401c5d294ba6c8c) | `` wayfire: add module (#6066) ``  |