### PR TITLE
chore(flake/home-manager): `fcc4259c` -> `7e008565`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -400,11 +400,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736349844,
-        "narHash": "sha256-jpmKC8zNcFMt9ATsju2mryBuimIm+bR7HETCp0Rxd3s=",
+        "lastModified": 1736366465,
+        "narHash": "sha256-Fo68EF6p/N9GJyHiAUbXtiE7IJlb3IMjK86LuxFMsRU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fcc4259cdbcb76138b48ed36b4f41c521910db0d",
+        "rev": "7e00856596891850ba5ad4c5ecd2ed74468c08c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`7e008565`](https://github.com/nix-community/home-manager/commit/7e00856596891850ba5ad4c5ecd2ed74468c08c5) | `` flake.lock: Update ``        |
| [`54b330ac`](https://github.com/nix-community/home-manager/commit/54b330ac067e74314f8ca6b38af6fcfbd17f3e9e) | `` go: add telemetry options `` |