### PR TITLE
chore(flake/disko): `49f8aa79` -> `4d5d07d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736199437,
-        "narHash": "sha256-TdU0a/x8048rbbJmkKWzSY1CtsbbGKNkIJcMdr8Zf4Q=",
+        "lastModified": 1736437680,
+        "narHash": "sha256-9Sy17XguKdEU9M5peTrkWSlI/O5IAqjHzdzxbXnc30g=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "49f8aa791f81ff2402039b3efe0c35b9386c4bcf",
+        "rev": "4d5d07d37ff773338e40a92088f45f4f88e509c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                          |
| ---------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`b9ca21dc`](https://github.com/nix-community/disko/commit/b9ca21dc6c3038f0389f9382b8b406c2f7bfcd6d) | `` export nixosModule as file `` |
| [`b8aecf15`](https://github.com/nix-community/disko/commit/b8aecf159f474d8d2bfc7100d278a1ede8de1a6c) | `` flake.lock: Update ``         |