### PR TITLE
chore(flake/nixos-hardware): `4f339f6b` -> `8870dcaf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -560,11 +560,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1736283893,
-        "narHash": "sha256-BG1FfTexFwNty5VhYjaQLMR6CMPfI3QRcaZrFQYu2EM=",
+        "lastModified": 1736441705,
+        "narHash": "sha256-OL7leZ6KBhcDF3nEKe4aZVfIm6xQpb1Kb+mxySIP93o=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "4f339f6be2b61662f957c2ee9eda0fa597d8a6d6",
+        "rev": "8870dcaff63dfc6647fb10648b827e9d40b0a337",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`8870dcaf`](https://github.com/NixOS/nixos-hardware/commit/8870dcaff63dfc6647fb10648b827e9d40b0a337) | `` surface: linux 6.12.8 -> 6.12.9 ``                      |
| [`d73a04da`](https://github.com/NixOS/nixos-hardware/commit/d73a04dabfc4db21fca65b9d58eaea23573858ba) | `` gpu/intel/tiger-lake: don't try to use Xe by default `` |