### PR TITLE
chore(flake/nix-index-database): `816a6ae8` -> `a2200b49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -545,11 +545,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736047960,
-        "narHash": "sha256-hutd85FA1jUJhhqBRRJ+u7UHO9oFGD/RVm2x5w8WjVQ=",
+        "lastModified": 1736440205,
+        "narHash": "sha256-QJgTI//KEGuEJC6FDxuI9Dq8PewIpnxD2NVx2/OHbfc=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "816a6ae88774ba7e74314830546c29e134e0dffb",
+        "rev": "a2200b499efa01ca8646173e94cdfcc93188f2b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message               |
| ----------------------------------------------------------------------------------------------------------------- | --------------------- |
| [`a2200b49`](https://github.com/nix-community/nix-index-database/commit/a2200b499efa01ca8646173e94cdfcc93188f2b8) | `` Add default.nix `` |