### PR TITLE
chore(flake/lovesegfault-vim-config): `39809a3d` -> `ab4569df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -480,11 +480,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736467703,
-        "narHash": "sha256-+rDUicBXeSy7STAPHqLSq6apIY+BOzJQgsRx2n6dirc=",
+        "lastModified": 1736516223,
+        "narHash": "sha256-j+OCR7OpZb2e8WKYG3h4k4h2hHFr7L6QdF5wAeDoywU=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "39809a3d7c9e93746214f530522f3ca00bd4b95b",
+        "rev": "ab4569dfbdcbc6e241b76e311ddfcc8e9651c0e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                 |
| -------------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`ab4569df`](https://github.com/lovesegfault/vim-config/commit/ab4569dfbdcbc6e241b76e311ddfcc8e9651c0e6) | `` feat(completion): add tmux source `` |
| [`704247dd`](https://github.com/lovesegfault/vim-config/commit/704247ddd6332d1d8ce88c98a3d832a02c6853f1) | `` feat: replace cmp with blink ``      |