### PR TITLE
chore(flake/disko): `4d5d07d3` -> `b1a94497`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736437680,
-        "narHash": "sha256-9Sy17XguKdEU9M5peTrkWSlI/O5IAqjHzdzxbXnc30g=",
+        "lastModified": 1736526728,
+        "narHash": "sha256-vb/ldbBHRbfT9U7SoCYmxh+h+PHuFqGjCBO0bPXsze4=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "4d5d07d37ff773338e40a92088f45f4f88e509c8",
+        "rev": "b1a94497b1c27fe7f81e3e76990959f5051da18b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                             |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`b64dddf6`](https://github.com/nix-community/disko/commit/b64dddf61bd6cc61f397affe75c9b5cc8b5db7e0) | `` install-cli: use disks from diskMappings arg for grub devices `` |