### PR TITLE
chore(flake/disko): `b1a94497` -> `33827d2b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736526728,
-        "narHash": "sha256-vb/ldbBHRbfT9U7SoCYmxh+h+PHuFqGjCBO0bPXsze4=",
+        "lastModified": 1736591904,
+        "narHash": "sha256-LFO8pSrPKrH8OPq2HaAuBG5skk8/MNJ/9YmK3KsnSks=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "b1a94497b1c27fe7f81e3e76990959f5051da18b",
+        "rev": "33827d2bd16bfe2e21b62956526c72d313595dfd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                          |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`79a12e65`](https://github.com/nix-community/disko/commit/79a12e659bb3fd055e61922fec7b70426464c6d6) | `` disko: fix postVM beeing empty ``                             |
| [`ade21e2c`](https://github.com/nix-community/disko/commit/ade21e2c96b68a33f3614eea1fcdaa36c9ef77d3) | `` Fix typo ``                                                   |
| [`fe89f379`](https://github.com/nix-community/disko/commit/fe89f379e7ed69194264a0cfdcbcd6ff922d8bc3) | `` make-disk-image: fix function precedence breaks customQemu `` |