### PR TITLE
chore(flake/stylix): `f1e00319` -> `fb773084`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1736530113,
-        "narHash": "sha256-a+IUtGdzESNSQEZkW99TXf5js8o4Oy9M4H2am+2ECp4=",
+        "lastModified": 1736706885,
+        "narHash": "sha256-hR3+Hth+mF8OyLjqislaetsho5WJyKNP6xCojQ1D2BY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f1e003194cb528bbd4eda50b781d1f703611782d",
+        "rev": "fb773084f74b2ddec103a2459847dabd2a65874c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                    |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`fb773084`](https://github.com/danth/stylix/commit/fb773084f74b2ddec103a2459847dabd2a65874c) | `` doc: fix two titles not using sentence case (#769) ``   |
| [`0a20c8d0`](https://github.com/danth/stylix/commit/0a20c8d0ede42be2ab75038f868f6b961d9d827f) | `` ci: standardize output redirection formatting (#756) `` |