### PR TITLE
chore(flake/disko): `33827d2b` -> `f720e64e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736591904,
-        "narHash": "sha256-LFO8pSrPKrH8OPq2HaAuBG5skk8/MNJ/9YmK3KsnSks=",
+        "lastModified": 1736711425,
+        "narHash": "sha256-8hKhPQuMtXfJi+4lPvw3FBk/zSJVHeb726Zo0uF1PP8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "33827d2bd16bfe2e21b62956526c72d313595dfd",
+        "rev": "f720e64ec37fa16ebba6354eadf310f81555cc07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message              |
| ---------------------------------------------------------------------------------------------------- | -------------------- |
| [`f275b063`](https://github.com/nix-community/disko/commit/f275b06323f9b13666cb5e93856af3dd3b910990) | `` Fix minor typo `` |