### PR TITLE
chore(flake/lovesegfault-vim-config): `3f4cc692` -> `74f963ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -480,11 +480,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736640366,
-        "narHash": "sha256-RK0/3HDYSjjSWs6tqKilftdPORXV60dJY3UoNd53eRE=",
+        "lastModified": 1736726881,
+        "narHash": "sha256-mBBvPGtGIEG/KJpbib9VFEl8zFHZmgsr+HJZQFyzhNQ=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "3f4cc6926418cd6f01b666af63a9d693da27693c",
+        "rev": "74f963abea465bb83c9813c627a1f702004bd221",
         "type": "github"
       },
       "original": {
@@ -637,11 +637,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736598781,
-        "narHash": "sha256-Y0o9ahm6Kk0DumTo80/vKspkHOkbtFgKCNiICyRjhMs=",
+        "lastModified": 1736715511,
+        "narHash": "sha256-5YAiZ3wrEJ/fzFoCwNf14xqfRTvgdcnl/+y0vye3Y6A=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2fc2132a78753fc3d7ec732044eff7ad69530055",
+        "rev": "35d6c12626f9895cd5d8ccf5d19c3d00de394334",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`74f963ab`](https://github.com/lovesegfault/vim-config/commit/74f963abea465bb83c9813c627a1f702004bd221) | `` chore(flake/nixpkgs): bffc22eb -> 130595eb `` |
| [`627d7da7`](https://github.com/lovesegfault/vim-config/commit/627d7da70dbd1121b5142996c534b1cd94062a65) | `` chore(flake/nixvim): 2fc2132a -> 35d6c126 ``  |