### PR TITLE
chore(flake/darwin): `6ace2f2d` -> `bd921223`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736631212,
-        "narHash": "sha256-mG9lRZBcPiAGiVJ9B97BJoIGQcSBWIVlBiN30QYCtG0=",
+        "lastModified": 1736819234,
+        "narHash": "sha256-deQVtIH4UJueELJqluAICUtX7OosD9paTP+5FgbiSwI=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "6ace2f2d12bdf74235d5cbf9fbd34a71c9716685",
+        "rev": "bd921223ba7cdac346477d7ea5204d6f4736fcc6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                    |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
| [`e33d37c4`](https://github.com/LnL7/nix-darwin/commit/e33d37c41f8040631f0cc16b032a1cf214aeeb4e) | `` {readme,examples/flake}: update for release branches `` |
| [`d5aeb4e5`](https://github.com/LnL7/nix-darwin/commit/d5aeb4e5b17c4e17b4eb515e088d6ea6babd14d8) | `` checks: recommend `sudo nix-channel` ``                 |
| [`efba3517`](https://github.com/LnL7/nix-darwin/commit/efba3517fcd8f034e01dfda1c94a865d11aaf69f) | `` eval-config: implement release branch checks ``         |
| [`c7b33c13`](https://github.com/LnL7/nix-darwin/commit/c7b33c131fcbb83eb2f47e07de5a8dee587e5d4b) | `` ci: only test one version ``                            |
| [`8a3ea966`](https://github.com/LnL7/nix-darwin/commit/8a3ea966bcb14655b231308e9d52195715c71692) | `` version: implement nix-darwin release versions ``       |
| [`0ef91bc1`](https://github.com/LnL7/nix-darwin/commit/0ef91bc148dc1873cdc21d8efbe3c65f91db311a) | `` flake: pin Nixpkgs explicitly ``                        |