### PR TITLE
chore(flake/tinted-schemes): `d5024d07` -> `5c6d92f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -808,11 +808,11 @@
     "tinted-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1733769397,
-        "narHash": "sha256-PXah6e8PK41T9vONsh9X4AVSO0Nq6OtwN4Hd22GizVo=",
+        "lastModified": 1736888641,
+        "narHash": "sha256-ioUzCnrFr5YsFtsSG+0QecR7/A1YUQPFOUYblGy4CLM=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "d5024d07713029d21aa45263e164913a0dfab0b6",
+        "rev": "5c6d92f20e5761e0bfd78ee88cb9fca72189c0cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                                              |
| ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`5c6d92f2`](https://github.com/tinted-theming/schemes/commit/5c6d92f20e5761e0bfd78ee88cb9fca72189c0cf) | `` Update tinted-theming gallery links in various README.md (#38) `` |