### PR TITLE
chore(flake/stylix): `965d1cb7` -> `2985ee9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -728,11 +728,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1736882096,
-        "narHash": "sha256-TQFkQ6RN8L/Xto5Ttt6hwJInFI5Nz2uCfXg5ci2q6UA=",
+        "lastModified": 1736955291,
+        "narHash": "sha256-h5y11C4vMi8VoIVeHr/xFJO5N1nWKiKoAILPPUl7P/8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "965d1cb7c84170200b4f05e68ebd27a88d171e8c",
+        "rev": "2985ee9b2836a725b04628d24f934212b96eacbe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                   |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`def1e485`](https://github.com/danth/stylix/commit/def1e485d5481f5e7df5465a22d8cf6c3d433ede) | `` stylix: make nix-flake-check package execution location-independent `` |
| [`0365d80e`](https://github.com/danth/stylix/commit/0365d80e2d3348bb8ad60dd0ef07474592387265) | `` stylix: decrease verbosity level of nix-flake-check package ``         |
| [`0969c2e7`](https://github.com/danth/stylix/commit/0969c2e792c942dc95d98381fa389340bbff10bb) | `` stylix: colorize and prefix nix-flake-check output ``                  |
| [`e88850f9`](https://github.com/danth/stylix/commit/e88850f9c27bd61a0452921e9c30210ee1a1ef06) | `` stylix: add progress bar to nix-flake-check package ``                 |