### PR TITLE
chore(flake/lovesegfault-vim-config): `b66b114b` -> `f34d9726`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -480,11 +480,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736954756,
-        "narHash": "sha256-pPrfnZAfhTZ+u50cLZ7HK9wNs7KS2x4xH15b+6rmOBo=",
+        "lastModified": 1736965885,
+        "narHash": "sha256-zNATdkUGePGokGlvF3CXirXawtglvQeO44lAKv0s3tY=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "b66b114ba30dc4ad2dbe90ca1858dc12a1e9661a",
+        "rev": "f34d972643302f43aef4ff14535fad71bfd8f9d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`f34d9726`](https://github.com/lovesegfault/vim-config/commit/f34d972643302f43aef4ff14535fad71bfd8f9d2) | `` feat: add some more colorschemes ``                 |
| [`ef258ffe`](https://github.com/lovesegfault/vim-config/commit/ef258ffea6d91f48c49ada55de613e9e19b5c13a) | `` refactor(lualine): use auto theme ``                |
| [`5f54c743`](https://github.com/lovesegfault/vim-config/commit/5f54c743d4e05def34f509a75af3e08f776fda3f) | `` feat(telescope): enable live colorscheme preview `` |