### PR TITLE
chore(flake/home-manager): `fc52a210` -> `0dfec9de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -400,11 +400,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736785676,
-        "narHash": "sha256-TY0jUwR3EW0fnS0X5wXMAVy6h4Z7Y6a3m+Yq++C9AyE=",
+        "lastModified": 1736883540,
+        "narHash": "sha256-dgPgoPUSg8cGAMqbhQRkww665sZtgzpWXxWjlyqhv94=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fc52a210b60f2f52c74eac41a8647c1573d2071d",
+        "rev": "0dfec9deb275854a56c97c356c40ef72e3a2e632",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`0dfec9de`](https://github.com/nix-community/home-manager/commit/0dfec9deb275854a56c97c356c40ef72e3a2e632) | `` hyprlock: remove with lib; ``                |
| [`a1f180af`](https://github.com/nix-community/home-manager/commit/a1f180af1710c2b4a2b9e1a8f6d8871840497393) | `` hyprlock: add bezier to importantPrefixes `` |