### PR TITLE
chore(flake/disko): `f720e64e` -> `bf0abfde`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736711425,
-        "narHash": "sha256-8hKhPQuMtXfJi+4lPvw3FBk/zSJVHeb726Zo0uF1PP8=",
+        "lastModified": 1737038063,
+        "narHash": "sha256-rMEuiK69MDhjz1JgbaeQ9mBDXMJ2/P8vmOYRbFndXsk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "f720e64ec37fa16ebba6354eadf310f81555cc07",
+        "rev": "bf0abfde48f469c256f2b0f481c6281ff04a5db2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                         |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`c53bfaa1`](https://github.com/nix-community/disko/commit/c53bfaa13a8de4995b22f7ac13c4c34e46fb368a) | `` zfs_volume: fix eval of _unmount if content is null ``       |
| [`1ae7c794`](https://github.com/nix-community/disko/commit/1ae7c794d93d79497aade51261634532202bcfda) | `` zfs_volume: add zfs_volume without content to zfs example `` |