### PR TITLE
chore(flake/darwin): `bd921223` -> `09414c7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736819234,
-        "narHash": "sha256-deQVtIH4UJueELJqluAICUtX7OosD9paTP+5FgbiSwI=",
+        "lastModified": 1737085297,
+        "narHash": "sha256-0gpgsX7hCauT6pblVg+hrDnt83lPoYzq/2BqqyvU8Tc=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "bd921223ba7cdac346477d7ea5204d6f4736fcc6",
+        "rev": "09414c7e2def24a5c52e588017b8524bcb68972a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                        |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
| [`4075a3c2`](https://github.com/LnL7/nix-darwin/commit/4075a3c23aa7996acc960e61df9f21038136d08a) | `` Add support for additional window tiling options ``         |
| [`f959b887`](https://github.com/LnL7/nix-darwin/commit/f959b8878b2a2e27f2df024930e52cb68b0528be) | `` defaults-write: fix activation script conditionalization `` |
| [`47174f38`](https://github.com/LnL7/nix-darwin/commit/47174f38689dba3221883db5f908f7e3ef924ef6) | `` doc/manual: use `--replace-fail` ``                         |
| [`fe2fc038`](https://github.com/LnL7/nix-darwin/commit/fe2fc038fd2a63f23bc646b0f3ce022b7c9b3129) | `` defaults/universalaccess: remove docs for macOS < 11 ``     |
| [`c5b7b604`](https://github.com/LnL7/nix-darwin/commit/c5b7b604caad7924924f762b603a978c33091552) | `` darwin-rebuild: remove code for macOS < 11 ``               |
| [`8f4f3d8d`](https://github.com/LnL7/nix-darwin/commit/8f4f3d8d2d333248f5edf8bb9ef7c7d3274bf06f) | `` darwin-uninstaller: remove code for macOS < 11 ``           |
| [`1c21c941`](https://github.com/LnL7/nix-darwin/commit/1c21c9410eefec51cb7613d38250e49322eb0ab5) | `` system: remove unnecessary `sudo` ``                        |
| [`b721000d`](https://github.com/LnL7/nix-darwin/commit/b721000dc6990f3a9ac8e5f8c9fcd7431c4396af) | `` system: add missing newline ``                              |
| [`ed6c4aab`](https://github.com/LnL7/nix-darwin/commit/ed6c4aabeae2ae8869a647eee04a45372a74ab56) | `` system: remove code for macOS < 11 ``                       |
| [`303a8143`](https://github.com/LnL7/nix-darwin/commit/303a8143a43579d12b4996ad3ab0e8380ae8c8b5) | `` checks: check for macOS ≥ 11.3 ``                           |