### PR TITLE
chore(flake/nixpkgs): `eb62e6aa` -> `9e4d5190`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -570,11 +570,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736883708,
-        "narHash": "sha256-uQ+NQ0/xYU0N1CnXsa2zghgNaOPxWpMJXSUJJ9W7140=",
+        "lastModified": 1737469691,
+        "narHash": "sha256-nmKOgAU48S41dTPIXAq0AHZSehWUn6ZPrUKijHAMmIk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+        "rev": "9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`9e4d5190`](https://github.com/NixOS/nixpkgs/commit/9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab) | `` kubernetes: 1.32.0 -> 1.32.1 (#374210) ``                               |
| [`0b9b3ab5`](https://github.com/NixOS/nixpkgs/commit/0b9b3ab50446126c7aea4f8e65087e7bd50d60e1) | `` python312Packages.sagemaker-core: 1.0.17 -> 1.0.19 ``                   |
| [`e1996d7b`](https://github.com/NixOS/nixpkgs/commit/e1996d7bdaf4eafdb85690079b9e02b25dc14e4f) | `` nixos/public-inbox: bind key and cert paths ``                          |
| [`eb00bbcd`](https://github.com/NixOS/nixpkgs/commit/eb00bbcdaae633d0ed836d42e25c18cf56153759) | `` nixos/public-inbox: fix flaky test by waiting for sockets ``            |
| [`3c078626`](https://github.com/NixOS/nixpkgs/commit/3c0786266434402e0883685d98b9350e4343f65a) | `` nixos/public-inbox: fix test by creating Git repositories ``            |
| [`50784a28`](https://github.com/NixOS/nixpkgs/commit/50784a2835c150d6055861a5ad703a57b8070cbb) | `` agdaPackages.standard-library: 2.1.1 -> 2.2 ``                          |
| [`5b434ed8`](https://github.com/NixOS/nixpkgs/commit/5b434ed807f21919be5c612c5530613f11c3f604) | `` nixos/lib/test-driver: try more OCR options ``                          |
| [`441c2428`](https://github.com/NixOS/nixpkgs/commit/441c242855f25f336822c7e9f10a366a98b43f02) | `` nixos/tests: fix bonding test ``                                        |
| [`d21198f2`](https://github.com/NixOS/nixpkgs/commit/d21198f27deb4142053434d0bed74d8ab4aaa4fd) | `` ocamlPackages.odoc-parser: add momeemt to maintainers ``                |
| [`5b4048d9`](https://github.com/NixOS/nixpkgs/commit/5b4048d90028e5a3d0a58bc2e9ee806b99ee862c) | `` ocamlPackages.odoc-parser: 2.4.2 -> 2.4.4 ``                            |
| [`7d14256b`](https://github.com/NixOS/nixpkgs/commit/7d14256b9dffc647505752d48e24a9425c8ea7f6) | `` python312Packages.simple-parsing: 0.1.6 -> 0.1.7 ``                     |
| [`5c4a9835`](https://github.com/NixOS/nixpkgs/commit/5c4a9835ba7793a67c2fc2300eec0a148dbf8414) | `` gollama: 1.28.4 -> 1.28.5 ``                                            |
| [`a14a9c02`](https://github.com/NixOS/nixpkgs/commit/a14a9c026305dc582a67aff2386aca2789975935) | `` parca-agent: 0.35.1 -> 0.35.2 ``                                        |
| [`13fba900`](https://github.com/NixOS/nixpkgs/commit/13fba90003609eeab99fc96620776810c157fad7) | `` phpExtensions.opentelemetry: 1.1.0 -> 1.1.1 ``                          |
| [`92ff0268`](https://github.com/NixOS/nixpkgs/commit/92ff0268073cf3687aaf8ffc78f6d58a2c946876) | `` vieb: 12.1.0 -> 12.2.0 ``                                               |
| [`c0175f9f`](https://github.com/NixOS/nixpkgs/commit/c0175f9f84d3961161828796534d9922eaa1d510) | `` exo: 0.0.5-alpha -> 0.0.9-alpha ``                                      |
| [`7562f48a`](https://github.com/NixOS/nixpkgs/commit/7562f48a27b215dcf2b37097e7078d1ce1a1a325) | `` mprocs: 0.7.1 -> 0.7.2 ``                                               |
| [`ad370bf1`](https://github.com/NixOS/nixpkgs/commit/ad370bf1906d6e1cb78cd44dffdd884f901521b7) | `` google-chrome: Fix QT support ``                                        |
| [`ca043d9d`](https://github.com/NixOS/nixpkgs/commit/ca043d9d73e39d242a0894f22c2b3b67fa556ef4) | `` sqlc: 1.27.0 -> 1.28.0 ``                                               |
| [`25512825`](https://github.com/NixOS/nixpkgs/commit/2551282542322823280f1f9e1e70473f0144bec9) | `` ryujinx-greemdev: rename to ryubing, 1.2.78 -> 1.2.80 ``                |
| [`3d7ef2f0`](https://github.com/NixOS/nixpkgs/commit/3d7ef2f051dad929b48deebb6a4ed9da6bfbc3b6) | `` libgda: fix mysql ``                                                    |
| [`19a38ac7`](https://github.com/NixOS/nixpkgs/commit/19a38ac73284335c11bd667541840954a318cadb) | `` nixos/mediawiki: make changes for 1.43.0 ``                             |
| [`aee5b623`](https://github.com/NixOS/nixpkgs/commit/aee5b623e0121a1899ea24b5246c2bd184c6273f) | `` python313Packages.approvaltests: skip failing test ``                   |
| [`eac6cd05`](https://github.com/NixOS/nixpkgs/commit/eac6cd05b23e8cb6a7d7c152076604beea786593) | `` python313Packages.mrjob: depends on standard-pipes ``                   |
| [`f6843641`](https://github.com/NixOS/nixpkgs/commit/f68436411d17d9741aca6986b6bbc2733eac4ba3) | `` python313Packages.standard-pipes: init at 3.13.0 ``                     |
| [`e1468594`](https://github.com/NixOS/nixpkgs/commit/e146859479da60d93d7de66af1c54b2a9499f8a0) | `` python313Packages.ayla-iot-unofficial: 1.4.4 -> 1.4.5 ``                |
| [`7557759c`](https://github.com/NixOS/nixpkgs/commit/7557759c53e9b823bc106ad1766bfd1f1566a0d2) | `` python313Packages.aioraven: 0.7.0 -> 0.7.1 ``                           |
| [`f962ed7c`](https://github.com/NixOS/nixpkgs/commit/f962ed7c2fa50639a10319fa24345af708ff4d14) | `` gqrx: add darwin support ``                                             |
| [`a2ebcb81`](https://github.com/NixOS/nixpkgs/commit/a2ebcb81a95d49189a53d020cb8ed251a9c98838) | `` python313Packages.python-overseerr: 0.5.0 -> 0.6.0 ``                   |
| [`0ba4aab8`](https://github.com/NixOS/nixpkgs/commit/0ba4aab8de39b08f324a54b645a94e1d97813f97) | `` python313Packages.thermopro-ble: 0.10.0 -> 0.10.1 ``                    |
| [`e912cd94`](https://github.com/NixOS/nixpkgs/commit/e912cd9426a98f8b5bff0c13276a163a06f67288) | `` python313Packages.kasa-crypt: 0.4.4 -> 0.5.0 ``                         |
| [`7f98d52d`](https://github.com/NixOS/nixpkgs/commit/7f98d52d5fffa2e621082460d3626058c0dd9006) | `` python313Packages.cyclopts: 3.2.1 -> 3.3.0 ``                           |
| [`2c5a39ab`](https://github.com/NixOS/nixpkgs/commit/2c5a39abee5759d0c787ebe2f7d6ec0a14bf00db) | `` python313Packages.asteval: 1.0.5 -> 1.0.6 ``                            |
| [`2b04ddec`](https://github.com/NixOS/nixpkgs/commit/2b04ddeceae69f0276ed262500346846839ec948) | `` python313Packages.mitogen: 0.3.20 -> 0.3.21 ``                          |
| [`151b7f7b`](https://github.com/NixOS/nixpkgs/commit/151b7f7babefc1505f14ff2ff2da4baf028a3254) | `` haruna: 1.2.1 -> 1.3.0 ``                                               |
| [`0be7395f`](https://github.com/NixOS/nixpkgs/commit/0be7395f95ef9aa967dd41ca17ea5ae0855bd3c6) | `` nixos/readeck: init ``                                                  |
| [`452d86c8`](https://github.com/NixOS/nixpkgs/commit/452d86c88eaf4737cf68d373cc35e0f7836c8556) | `` readeck: init at 0.17.1 ``                                              |
| [`ed4efc01`](https://github.com/NixOS/nixpkgs/commit/ed4efc01cf4ea4fed8245a4821c18c706657c028) | `` luaPackages.orgmode: init at 0.3.61-1 ``                                |
| [`aad44b34`](https://github.com/NixOS/nixpkgs/commit/aad44b34121e383f728e33eaef74c2f2354aa6ca) | `` luaPackages.tree-sitter-orgmode: init at 1.3.2-1 ``                     |
| [`3c0a99ed`](https://github.com/NixOS/nixpkgs/commit/3c0a99ed60bc2337886c9619733a9e0187a76076) | `` mir,mir_2_15: Drop glog dependency ``                                   |
| [`0cd421fa`](https://github.com/NixOS/nixpkgs/commit/0cd421fa5f407d92ad56cd6b1d0dc92ae03b33bc) | `` build-support/vm: don't depend on the "unix" module ``                  |
| [`06ee6116`](https://github.com/NixOS/nixpkgs/commit/06ee6116190af961b278f3830352ced4971e1a41) | `` ci/request-reviews: Don't fail when there's too many reviewers ``       |
| [`38e021fa`](https://github.com/NixOS/nixpkgs/commit/38e021fa4443a30a43c36a39788c7cbbbdaf1a54) | `` quirc: fix cross build ``                                               |
| [`2d98f09b`](https://github.com/NixOS/nixpkgs/commit/2d98f09b17ae9235520c5060dcc7660f4805c9c8) | `` phpdocumentor: fix vendorHash ``                                        |
| [`118ef08e`](https://github.com/NixOS/nixpkgs/commit/118ef08eb41716dc54874e4e5617042d5b845aa2) | `` yutto: 2.0.0-rc.6 -> 2.0.0-rc.7 ``                                      |
| [`eaff6da5`](https://github.com/NixOS/nixpkgs/commit/eaff6da586ba5cd7be487dcb6f542e85b03ac15f) | `` minio: 2024-12-18T13-15-44Z -> 2025-01-18T00-31-37Z ``                  |
| [`1eb41e58`](https://github.com/NixOS/nixpkgs/commit/1eb41e586b4cb5edf9a6a5d2649a5306aff29b2c) | `` fstar: remove pnmadelaine as maintainer ``                              |
| [`30a77069`](https://github.com/NixOS/nixpkgs/commit/30a7706904f750fbeba4bef79e2217725de770e1) | `` certstream-server-go: init at 1.7.0 ``                                  |
| [`9466afac`](https://github.com/NixOS/nixpkgs/commit/9466afacfe1e5ce6c1af1eced501892cad8cfbde) | `` bt-migrate: mark as broken ``                                           |
| [`94f9d8b7`](https://github.com/NixOS/nixpkgs/commit/94f9d8b7c22a97b616db1ca7d554d7436ca76213) | `` jsoncons: 0.176.0 -> 1.1.0 ``                                           |
| [`0d32e69a`](https://github.com/NixOS/nixpkgs/commit/0d32e69acecbbc71a684ad575b0a24569f57a96b) | `` frankenphp: 1.4.0 -> 1.4.1 ``                                           |
| [`60520102`](https://github.com/NixOS/nixpkgs/commit/60520102f2ba74753b9aee92596f298c7aa9d52e) | `` python313Packages.tencentcloud-sdk-python: 3.0.1305 -> 3.0.1306 ``      |
| [`c39acbfa`](https://github.com/NixOS/nixpkgs/commit/c39acbfabae225c0f393b3fbc121466e6abef489) | `` crusader: init at 0.3.2 ``                                              |
| [`00137105`](https://github.com/NixOS/nixpkgs/commit/0013710590e1e0c8087b12b2de476b8b63805158) | `` manubulon-snmp-plugins: use versionCheckHook ``                         |
| [`80807847`](https://github.com/NixOS/nixpkgs/commit/80807847941a0393844d4684d949e2cc1a4024f1) | `` fwupd: 2.0.3 -> 2.0.4 ``                                                |
| [`80764733`](https://github.com/NixOS/nixpkgs/commit/8076473384121e1142748e92bdf7afd2d3a37c8f) | `` phpPackages.composer: fix included patch ``                             |
| [`f21517a1`](https://github.com/NixOS/nixpkgs/commit/f21517a167a73a6873d42a858734f598265d7b4e) | `` nodejs_23: 23.5.0 -> 23.6.0 ``                                          |
| [`a226f132`](https://github.com/NixOS/nixpkgs/commit/a226f13211ffedd597ac8bc44766ac8f4b8af946) | `` ci/eval: support "10.rebuild-${kernel}: 1" labels ``                    |
| [`5904143e`](https://github.com/NixOS/nixpkgs/commit/5904143e8589dc6f0aad6517e0935a185eec6543) | `` gurk-rs: 0.6.0 -> 0.6.1 ``                                              |
| [`34691a0b`](https://github.com/NixOS/nixpkgs/commit/34691a0b28eac4d160e885c8711533e18c09d87c) | `` gurk-rs: move to pkgs/by-name ``                                        |
| [`3e47905d`](https://github.com/NixOS/nixpkgs/commit/3e47905de2684f6046a8ecca1cd6898971259a4c) | `` fzf: 0.57.0 -> 0.58.0 ``                                                |
| [`0e8c1544`](https://github.com/NixOS/nixpkgs/commit/0e8c154442d1d59dabbc729d100ca9a8d8243a7a) | `` dino: remove tomfitzhenry@ as maintainer ``                             |
| [`db8996f0`](https://github.com/NixOS/nixpkgs/commit/db8996f0809493993a2ddb0f0000ba8af8597eaa) | `` television: 0.9.2 -> 0.9.3 ``                                           |
| [`d4c0bd6d`](https://github.com/NixOS/nixpkgs/commit/d4c0bd6dc5b929133e33e21b096b9737cca58031) | `` wf-config: fix and enable strictDeps ``                                 |
| [`ec4b54f3`](https://github.com/NixOS/nixpkgs/commit/ec4b54f3d04a825d311c0b69926eaa8a3a213c02) | `` nextcloud: Add britter as maintainer ``                                 |
| [`8e7b1073`](https://github.com/NixOS/nixpkgs/commit/8e7b1073fde774c48cb9d38076081a48d4ca7a58) | `` ocamlPackages.elpi: use correct version information ``                  |
| [`150f6f98`](https://github.com/NixOS/nixpkgs/commit/150f6f987e7ae15ce1514d4b41f44a27bd9e8f2f) | `` rainfrog: 0.2.10 -> 0.2.11 ``                                           |
| [`65779f98`](https://github.com/NixOS/nixpkgs/commit/65779f98dcaa7053f93bec7c6be75adc0eb1b266) | `` wofi-power-menu: add meta.changelog ``                                  |
| [`36347091`](https://github.com/NixOS/nixpkgs/commit/363470919ed424ecb193c4d87e8be54a5f7f0a3d) | `` wofi-power-menu: 0.2.5 -> 0.2.6 ``                                      |
| [`8e56483d`](https://github.com/NixOS/nixpkgs/commit/8e56483d50032f842e3ac6c4e57c732b9638b261) | `` python312Packages.timm: 1.0.13 -> 1.0.14 ``                             |
| [`397e5bb5`](https://github.com/NixOS/nixpkgs/commit/397e5bb5a79f85c86a4f5dcd3382d205aff3bec3) | `` rustc: mark broken for LLVM stdenv ``                                   |
| [`45fc2a09`](https://github.com/NixOS/nixpkgs/commit/45fc2a0940521a6864cefdb7e415672b4825fe64) | `` Revert "uhd: pin Boost 1.86" ``                                         |
| [`3b6f6581`](https://github.com/NixOS/nixpkgs/commit/3b6f658130e5ed7a027593a6f24c1c1c700f2b89) | `` init-script-builder: fix build (#375160) ``                             |
| [`33986ca1`](https://github.com/NixOS/nixpkgs/commit/33986ca158b28288e84a035d8dfe370afd571fa3) | `` {mattermost,mattermostLatest}: fix string escapes ``                    |
| [`8c0035ae`](https://github.com/NixOS/nixpkgs/commit/8c0035ae8f57b65dd055802100044c298439b99d) | `` release-notes/25.05: add Mattermost details ``                          |
| [`84c6d60c`](https://github.com/NixOS/nixpkgs/commit/84c6d60c263aa49c5430dec4ed9cefa9601f73e7) | `` manual: add mattermost.chapter.md ``                                    |
| [`f8eac009`](https://github.com/NixOS/nixpkgs/commit/f8eac009eed839d2d71f991f9c0df2e28da95a3d) | `` nixos/mattermost: modernize, support MySQL and mmctl ``                 |
| [`8944a425`](https://github.com/NixOS/nixpkgs/commit/8944a4259cb5d8c54c81408527f600e3ff44c15e) | `` mmctl: use correct Mattermost derivation ``                             |
| [`80093811`](https://github.com/NixOS/nixpkgs/commit/800938116f9ceecb921fec4d700e5ef5577521ca) | `` mattermost: enable test suite, mmctl support, and plugin building ``    |
| [`6a580ab6`](https://github.com/NixOS/nixpkgs/commit/6a580ab6705f535dc83982f84eeb35413dec4f0b) | `` nixos/release-small: add latestKernel test ``                           |
| [`e4d3693c`](https://github.com/NixOS/nixpkgs/commit/e4d3693cd8784f4eccee167a6d2722cec2c1f519) | `` perf: don't apply dmesg patch on 6.13, remove 6.10 patches ``           |
| [`d7356a72`](https://github.com/NixOS/nixpkgs/commit/d7356a72a6ecb1bca16317402854c698e0a14ad5) | `` linux_6_13: init ``                                                     |
| [`0ec2df46`](https://github.com/NixOS/nixpkgs/commit/0ec2df46bc4daab04b22113e9fd1b63de843ddee) | `` home-assistant-custom-components.homematicip_local: 1.78.1 -> 1.79.0 `` |
| [`5b7855d6`](https://github.com/NixOS/nixpkgs/commit/5b7855d61565abb15b230848086085b562c62011) | `` python313Packages.hahomematic: 2025.1.7 -> 2025.1.10 ``                 |
| [`0ca75b9e`](https://github.com/NixOS/nixpkgs/commit/0ca75b9e438455ebfccdda714ce20a9d715deb11) | `` terraform-providers.huaweicloud: 1.72.0 -> 1.72.1 ``                    |
| [`b2508634`](https://github.com/NixOS/nixpkgs/commit/b25086345bbcd124e9de4693a47fed5a44c8fbe4) | `` clouddrive2: 0.8.5 -> 0.8.6 ``                                          |
| [`a64584d9`](https://github.com/NixOS/nixpkgs/commit/a64584d9c022fe8baa83a216ae2d7e470009e412) | `` ytdl-sub: 2025.01.15 -> 2025.01.17 ``                                   |
| [`459806ae`](https://github.com/NixOS/nixpkgs/commit/459806aea2653e6a879fca7d9bc56c08635ceb36) | `` nextcloud-notify_push: 0.7.0 -> 1.0.0 ``                                |
| [`e6305a33`](https://github.com/NixOS/nixpkgs/commit/e6305a33bf221476ad898a28e44cb9704cab51f1) | `` v2rayn: 7.6.2 -> 7.7.0 ``                                               |
| [`360016ef`](https://github.com/NixOS/nixpkgs/commit/360016ef3f10021d63b7108307e62da896d43ce3) | `` terraform-providers.artifactory: 12.7.1 -> 12.8.1 ``                    |
| [`e57f7990`](https://github.com/NixOS/nixpkgs/commit/e57f79900d837dd5c147d77c1b8dc72e5374ae26) | `` flameshot: 12.1.0-unstable-2024-12-03 -> 12.1.0-unstable-2025-01-19 ``  |
| [`95dbf5b0`](https://github.com/NixOS/nixpkgs/commit/95dbf5b038a13db6062e407c757818b621f9b56f) | `` changedetection-io: 0.48.05 -> 0.48.06 ``                               |
| [`586e657c`](https://github.com/NixOS/nixpkgs/commit/586e657c4a69362e206c3d405377afb6b3aa9bc9) | `` pocketbase: 0.24.1 -> 0.24.4 ``                                         |
| [`f152a652`](https://github.com/NixOS/nixpkgs/commit/f152a652dd03830b568ba6e6dc5c3208a6317a77) | `` terraform-providers.grafana: 3.15.3 -> 3.16.0 ``                        |
| [`a8da7b01`](https://github.com/NixOS/nixpkgs/commit/a8da7b01f116ae3543a499487eabe8022ddf693f) | `` python312Packages.python-linkplay: 0.1.2 -> 0.1.3 ``                    |
| [`24d32f99`](https://github.com/NixOS/nixpkgs/commit/24d32f996c00317730e92f8fccdc6c070018889a) | `` sq: 0.48.4 -> 0.48.5 ``                                                 |
| [`eb453754`](https://github.com/NixOS/nixpkgs/commit/eb453754f44515407b2bc39c7c93ccda1cafcd86) | `` spfft: 1.1.0 -> 1.1.1 ``                                                |
| [`3cef4905`](https://github.com/NixOS/nixpkgs/commit/3cef4905f08361e896c6567f9ce682240277d34b) | `` cjson: fix building with clang ``                                       |
| [`a4677d48`](https://github.com/NixOS/nixpkgs/commit/a4677d48c1763423de84b92ed19c5050071fe0a0) | `` simpleDBus: 0.8.1 -> 0.9.0 ``                                           |
| [`7d0cbf1b`](https://github.com/NixOS/nixpkgs/commit/7d0cbf1b6ff7d13bc33e5ff9ebd1ac9830aa6c3a) | `` nwg-panel: 0.9.59 -> 0.9.61 ``                                          |