### PR TITLE
chore(flake/darwin): `09414c7e` -> `87131f51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737085297,
-        "narHash": "sha256-0gpgsX7hCauT6pblVg+hrDnt83lPoYzq/2BqqyvU8Tc=",
+        "lastModified": 1737162735,
+        "narHash": "sha256-5T+HkouTMGaRm0rh3kgD4Z1O7ONKfgjyoPQH5rSyreU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "09414c7e2def24a5c52e588017b8524bcb68972a",
+        "rev": "87131f51f8256952d1a306b5521cedc2dc61aa08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                        |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
| [`8abb2e72`](https://github.com/LnL7/nix-darwin/commit/8abb2e7244b998a9d73818baa744044f8882e68b) | `` nix: add hashes for Determinate Systems installer v0.33.0 and v0.34.0 ``    |
| [`2fe899db`](https://github.com/LnL7/nix-darwin/commit/2fe899db70f8d2e9162e9ff44eef4f734787b5b1) | `` nix: check `/etc/nix/nix.custom.conf` hash ``                               |
| [`ff1d6384`](https://github.com/LnL7/nix-darwin/commit/ff1d6384dfa276ff4ab092fd9f37a66b5234466c) | `` {environment,nix-tools}: correct default `$PATH` ordering to match macOS `` |