### PR TITLE
chore(flake/home-manager): `a0046af1` -> `1e364297`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -395,11 +395,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737120639,
-        "narHash": "sha256-p5e/45V41YD3tMELuiNIoVCa25/w4nhOTm0B9MtdHFI=",
+        "lastModified": 1737188535,
+        "narHash": "sha256-O2ttwW1/dUc/Y+Rf48Njtr4tZpRJhy8FhafikekIjMY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a0046af169ce7b1da503974e1b22c48ef4d71887",
+        "rev": "1e36429705f9af2d00a517ba46a4f21ef8a8194f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`1e364297`](https://github.com/nix-community/home-manager/commit/1e36429705f9af2d00a517ba46a4f21ef8a8194f) | `` sbt: allow irregular plugins to be configured `` |
| [`495de1e1`](https://github.com/nix-community/home-manager/commit/495de1e197e7e113ad8877dad4c29a66482a093c) | `` Translate using Weblate (Danish) ``              |