### PR TITLE
chore(flake/lovesegfault-vim-config): `ef85bf78` -> `ee5bbd95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737158839,
-        "narHash": "sha256-uXajGLaNFtKM2sa+SHnue2XLmR6mnjEIiAAu2FdlEu8=",
+        "lastModified": 1737245159,
+        "narHash": "sha256-dM/2QShN1faCfsCINRhJAuwEAcTak1QNCpVSOxc9DW8=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "ef85bf782fff8f80d55b6fc28e5b35e342c38a04",
+        "rev": "ee5bbd953b6befed62e76bcdc28db541112c6f47",
         "type": "github"
       },
       "original": {
@@ -632,11 +632,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737143193,
-        "narHash": "sha256-+/BdPFrdJpgmzrMEUZMxsLeND8IvFtjyZbxHX2XrNv4=",
+        "lastModified": 1737200978,
+        "narHash": "sha256-QTUx/F8HVjrRIHQxHKrr72aPMj+cDk18WTbvBCCBBdI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "aa839cf994f6b9a6b38e755597452087beac0567",
+        "rev": "cbf960e5659054b2ccf27b67218782e69016bef5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`ee5bbd95`](https://github.com/lovesegfault/vim-config/commit/ee5bbd953b6befed62e76bcdc28db541112c6f47) | `` chore(flake/nixvim): aa839cf9 -> cbf960e5 `` |