### PR TITLE
chore(flake/git-hooks): `94ee657f` -> `15a87ced`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -289,11 +289,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737043064,
-        "narHash": "sha256-I/OuxGwXwRi5gnFPsyCvVR+IfFstA+QXEpHu1hvsgD8=",
+        "lastModified": 1737301351,
+        "narHash": "sha256-2UNmLCKORvdBRhPGI8Vx0b6l7M8/QBey/nHLIxOl4jE=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "94ee657f6032d913fe0ef49adaa743804635b0bb",
+        "rev": "15a87cedeb67e3dbc8d2f7b9831990dffcf4e69f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`b24ef710`](https://github.com/cachix/git-hooks.nix/commit/b24ef710754ce68f2aa56e594e4d36419944ea30) | `` check: set HOME to a tmp dir to avoid polluting the working dir `` |
| [`46171f0a`](https://github.com/cachix/git-hooks.nix/commit/46171f0a3611501c72e0380e399af1bbb891d8d5) | `` hooks: add note for flake-based projects using paths ``            |
| [`baf942ec`](https://github.com/cachix/git-hooks.nix/commit/baf942ec75b17c77f02413a96ad61426a896e18a) | `` hooks: add examples ``                                             |
| [`bad35860`](https://github.com/cachix/git-hooks.nix/commit/bad358603b4ac83bb48840cb310dcf4138bf3793) | `` hooks: allow strings for path-based options ``                     |