### PR TITLE
chore(flake/home-manager): `f8ef4541` -> `9786661d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -395,11 +395,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737299337,
-        "narHash": "sha256-0NBrY2A7buujKmeCbieopOMSbLxTu8TFcTLqAbTnQDw=",
+        "lastModified": 1737394973,
+        "narHash": "sha256-EW4oXMfnfA5sNM9Jqm+y98horWVvN66Gu7YIcEpFYZc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f8ef4541bb8a54a8b52f19b52912119e689529b3",
+        "rev": "9786661d57c476021c8a0c3e53bf9fa2b4f3328b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`9786661d`](https://github.com/nix-community/home-manager/commit/9786661d57c476021c8a0c3e53bf9fa2b4f3328b) | `` fcitx5: allow to set fcitx5-with-addons (#5770) `` |