### PR TITLE
chore(flake/treefmt-nix): `d1ed3b38` -> `f2cc121d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737103437,
-        "narHash": "sha256-uPNWcYbhY2fjY3HOfRCR5jsfzdzemhfxLSxwjXYXqNc=",
+        "lastModified": 1737483750,
+        "narHash": "sha256-5An1wq5U8sNycOBBg3nsDDgpwBmR9liOpDGlhliA6Xo=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "d1ed3b385f8130e392870cfb1dbfaff8a63a1899",
+        "rev": "f2cc121df15418d028a59c9737d38e3a90fbaf8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                             |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`e5eddb26`](https://github.com/numtide/treefmt-nix/commit/e5eddb2662dfa8d607dd9b17aeb05cdeaab6b172) | `` fantomas: remove invalid args `` |