### PR TITLE
chore(flake/tinted-schemes): `5c6d92f2` -> `ae31625b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -803,11 +803,11 @@
     "tinted-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1736888641,
-        "narHash": "sha256-ioUzCnrFr5YsFtsSG+0QecR7/A1YUQPFOUYblGy4CLM=",
+        "lastModified": 1737565458,
+        "narHash": "sha256-y+9cvOA6BLKT0WfebDsyUpUa/YxKow9hTjBp6HpQv68=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "5c6d92f20e5761e0bfd78ee88cb9fca72189c0cf",
+        "rev": "ae31625ba47aeaa4bf6a98cf11a8d4886f9463d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                            |
| ------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`ae31625b`](https://github.com/tinted-theming/schemes/commit/ae31625ba47aeaa4bf6a98cf11a8d4886f9463d9) | `` Fix variant since icy is a dark scheme (#36) `` |