### PR TITLE
chore(flake/lanzaboote): `64d20cb2` -> `a65905a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -441,11 +441,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1737299073,
-        "narHash": "sha256-hOydnO9trHDo3qURqLSDdmE/pHNWDzlhkmyZ/gcBX2s=",
+        "lastModified": 1737639419,
+        "narHash": "sha256-AEEDktApTEZ5PZXNDkry2YV2k6t0dTgLPEmAZbnigXU=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "64d20cb2afaad8b73f4e38de41d27fb30a782bb5",
+        "rev": "a65905a09e2c43ff63be8c0e86a93712361f871e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                        |
| --------------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`ec7372a9`](https://github.com/nix-community/lanzaboote/commit/ec7372a988fffd661831a81468f4c2d330288066) | `` treewide: 0.4.1 -> 0.4.2 `` |