### PR TITLE
chore(flake/nixpkgs): `9e4d5190` -> `0aa47554`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -570,11 +570,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737469691,
-        "narHash": "sha256-nmKOgAU48S41dTPIXAq0AHZSehWUn6ZPrUKijHAMmIk=",
+        "lastModified": 1737632463,
+        "narHash": "sha256-38J9QfeGSej341ouwzqf77WIHAScihAKCt8PQJ+NH28=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab",
+        "rev": "0aa475546ed21629c4f5bbf90e38c846a99ec9e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`b43b1f04`](https://github.com/NixOS/nixpkgs/commit/b43b1f04c0d2003941b561c7fbfc7c9bb0e043b8) | `` python312Packages.vector: 1.6.0 -> 1.6.1 (#375927) ``                           |
| [`c86f1904`](https://github.com/NixOS/nixpkgs/commit/c86f190448145d603a817a63cb4f32c5e10e7338) | `` mysqltuner: 1.8.3 -> 2.6.0 ``                                                   |
| [`f0413353`](https://github.com/NixOS/nixpkgs/commit/f0413353abad5d3826571102243795bb80ed5444) | `` softether: fix build for GCC 14 (#375656) ``                                    |
| [`d51aeeb1`](https://github.com/NixOS/nixpkgs/commit/d51aeeb1fbc7c724505dd4872e11ccdf36a3ea74) | `` ci: Update pinned Nixpkgs ``                                                    |
| [`344756de`](https://github.com/NixOS/nixpkgs/commit/344756dea602e06f4238b7fee37041046263a74b) | `` appflowy: browser login redirect (#376016) ``                                   |
| [`bcad4f36`](https://github.com/NixOS/nixpkgs/commit/bcad4f36b978bd56017dd57bfb71892ce9c9e959) | `` mesa: 24.3.3 -> 24.3.4 ``                                                       |
| [`448235fa`](https://github.com/NixOS/nixpkgs/commit/448235fabe63770bfa621618a4b7ded5f7e07d00) | `` phpExtensions.opentelemetry: 1.1.1 -> 1.1.2 ``                                  |
| [`79615b07`](https://github.com/NixOS/nixpkgs/commit/79615b074842183a6b2476b36fb015600364f809) | `` libgbm: pin to 24.3.3 ``                                                        |
| [`91d6a840`](https://github.com/NixOS/nixpkgs/commit/91d6a8403f454860680e7c79cd2b943a74637356) | `` open-webui: 0.5.5 -> 0.5.6 ``                                                   |
| [`beb95095`](https://github.com/NixOS/nixpkgs/commit/beb95095e58f298783fd2b9b20ffbc3123f67061) | `` eza: 0.20.17 -> 0.20.18 ``                                                      |
| [`c990b1f6`](https://github.com/NixOS/nixpkgs/commit/c990b1f65cb7728b132ff314a22cb6e8b7b031f7) | `` raspberrypi-eeprom: 2024.11.12-2712 -> 2025.01.22-2712 ``                       |
| [`f77f16cc`](https://github.com/NixOS/nixpkgs/commit/f77f16cc45df4dbae4604b4ce80b273ddd89caea) | `` home-assistant-custom-lovelace-modules.universal-remote-card: 4.3.5 -> 4.3.7 `` |
| [`3c5992ce`](https://github.com/NixOS/nixpkgs/commit/3c5992ce875e9d059342c39cbd87fd68883d7c98) | `` namespace-cli: 0.0.399 -> 0.0.400 ``                                            |
| [`4bdf8415`](https://github.com/NixOS/nixpkgs/commit/4bdf84155ea8255c43469e4a10f37a6d72bf6007) | `` librime: 1.12.0 -> 1.13.0 ``                                                    |
| [`f702ebf5`](https://github.com/NixOS/nixpkgs/commit/f702ebf5940b25b2349e021efc26357334ec76f5) | `` mkBinaryCache: process items in parallel ``                                     |
| [`651bd53a`](https://github.com/NixOS/nixpkgs/commit/651bd53aa2234ebf8df034fb753aac6bd5d4f243) | `` kubedog: 0.12.3 -> 0.13.0 ``                                                    |
| [`8f540635`](https://github.com/NixOS/nixpkgs/commit/8f540635780dd2c7ee0ea41e78c7510615d2a789) | `` various: remove AndersonTorres from pkgs maintainership ``                      |
| [`e33e115c`](https://github.com/NixOS/nixpkgs/commit/e33e115ceb97e668c11a9e3c0b10a2978cfd45bf) | `` various: remove update scripts from orphaned elisp packages ``                  |
| [`078bf9df`](https://github.com/NixOS/nixpkgs/commit/078bf9dfd631572741f85b8c47c479253ab7acb2) | `` various: remove AndersonTorres from elisp maintainership ``                     |
| [`bc801145`](https://github.com/NixOS/nixpkgs/commit/bc80114502791eede3c1bf037dc40c660f2c2cf1) | `` various: remove AndersonTorres from modules maintainership ``                   |
| [`4d4d459a`](https://github.com/NixOS/nixpkgs/commit/4d4d459a922ad8477d8565a63262a9b82fe0f417) | `` nwg-look: 1.0.0 -> 1.0.2 ``                                                     |
| [`f22644ec`](https://github.com/NixOS/nixpkgs/commit/f22644ec040cc6377de31c6ba4ff6fde2b269422) | `` nwg-look: 0.2.7 -> 1.0.0 ``                                                     |
| [`fb61a770`](https://github.com/NixOS/nixpkgs/commit/fb61a770fff67545ad90cde13643345b15c9903b) | `` hyprpicker: 0.4.1 -> 0.4.2 ``                                                   |
| [`7e1cdfdf`](https://github.com/NixOS/nixpkgs/commit/7e1cdfdf9a7c2f447f72dd0bd1bb78710b582fd4) | `` cabinpkg: 0.10.1 -> 0.11.0, renamed from poac ``                                |
| [`bb48efa5`](https://github.com/NixOS/nixpkgs/commit/bb48efa52e14931d45dc7b3a58948cba8e50ce18) | `` teams-for-linux: 1.12.6 -> 1.12.7 ``                                            |
| [`b60c4ac7`](https://github.com/NixOS/nixpkgs/commit/b60c4ac7898801497eeecff76fb41348ef0b7cda) | `` yabai: 7.1.5 -> 7.1.6 ``                                                        |
| [`791817cd`](https://github.com/NixOS/nixpkgs/commit/791817cd1a1e60d32578df802f755cd123a4f288) | `` luaPackages: update on 2025-01-22 ``                                            |
| [`c7bad811`](https://github.com/NixOS/nixpkgs/commit/c7bad811efddc8533fa14dcb4b4e4d97e03a15d5) | `` terraform: 1.10.4 -> 1.10.5 ``                                                  |
| [`94f9e530`](https://github.com/NixOS/nixpkgs/commit/94f9e5302ec85f0e0ce3b20db6217250067c017c) | `` libdeltachat: 1.154.1 -> 1.154.3 ``                                             |
| [`bb3c31df`](https://github.com/NixOS/nixpkgs/commit/bb3c31df0f86564ba23aa67a393b40be17be5e09) | `` rapidfuzz-cpp: 3.3.0 -> 3.3.1 ``                                                |
| [`06489c0f`](https://github.com/NixOS/nixpkgs/commit/06489c0fa2b6441d3f8f84de93ef16372ad0bd62) | `` pineflash: init at 0.5.5 ``                                                     |
| [`005b2310`](https://github.com/NixOS/nixpkgs/commit/005b23108557ed839d4aa9374ac0f6422640705b) | `` bdfresize: fix configure and darwin build ``                                    |
| [`19632f28`](https://github.com/NixOS/nixpkgs/commit/19632f28c2824f672a968a48d91f1c96deeee7ca) | `` open-webui: 0.5.4 -> 0.5.5 ``                                                   |
| [`a97c7338`](https://github.com/NixOS/nixpkgs/commit/a97c7338eef8822c7bfb426e89b0393caeb925d9) | `` python312Packages.gcp-storage-emulator: init at 2024.08.03 ``                   |
| [`2a6ca481`](https://github.com/NixOS/nixpkgs/commit/2a6ca481f1ae4370be9295a55d15b509d12b212a) | `` chatterino{2,7}: pin boost to 1.86 ``                                           |
| [`b4dde01f`](https://github.com/NixOS/nixpkgs/commit/b4dde01f774385b0c11f1cb034641ec1d94365b7) | `` zed-editor: 0.169.3 -> 0.170.1 ``                                               |
| [`9cdbbbda`](https://github.com/NixOS/nixpkgs/commit/9cdbbbda8b62f56ec7e548bd6aa07af2dad524c6) | `` remmina: 1.4.37 -> 1.4.39 ``                                                    |
| [`9970d1fe`](https://github.com/NixOS/nixpkgs/commit/9970d1feec858e1bf9e6ead56a120e19d96748ef) | `` metals: 1.4.2 -> 1.5.0 ``                                                       |
| [`f5b54a08`](https://github.com/NixOS/nixpkgs/commit/f5b54a08fee334820638418c610e72afedf5dac4) | `` sdl3: add vulkan-headers/loader to dlopenPropagatedBuildInputs ``               |
| [`c51fa67c`](https://github.com/NixOS/nixpkgs/commit/c51fa67cdb1d0a77951e0974040e1e60ef260cf4) | `` terraform-providers.auth0: 1.9.1 -> 1.10.0 ``                                   |
| [`8f825e7c`](https://github.com/NixOS/nixpkgs/commit/8f825e7c16e565708c3e7bb6b823376c8dad79c7) | `` lomiri.lomiri-filemanager-app: 1.1.2 -> 1.1.3 ``                                |
| [`2e814e77`](https://github.com/NixOS/nixpkgs/commit/2e814e77d8db04352aa6ebdbb0b0717a9d8b9ef1) | `` lomiri.lomiri-schemas: 0.1.6 -> 0.1.7 ``                                        |
| [`b1901d9f`](https://github.com/NixOS/nixpkgs/commit/b1901d9f65d905c1e3d65e9d879124cc2a6867fb) | `` pulsarctl: 4.0.1.1 -> 4.0.1.2 ``                                                |
| [`8d5f9bc3`](https://github.com/NixOS/nixpkgs/commit/8d5f9bc3526e6997ea098616f642b7fd5d2616b9) | `` files-cli: 2.13.219 -> 2.13.231 ``                                              |
| [`8256c326`](https://github.com/NixOS/nixpkgs/commit/8256c326c22823eb0f2716f06fc0a7b1019a4d14) | `` llama-cpp: 4525 -> 4529 ``                                                      |
| [`d7e2aa02`](https://github.com/NixOS/nixpkgs/commit/d7e2aa02b98b9ab3dc7da079de8ad708f1f9c199) | `` cura-appimage: init at 5.9.0 ``                                                 |
| [`ce834c16`](https://github.com/NixOS/nixpkgs/commit/ce834c1662784b23f29f187dbcec17462b236083) | `` signalbackup-tools: 20250113-1 -> 20250122 ``                                   |
| [`c4cca0b7`](https://github.com/NixOS/nixpkgs/commit/c4cca0b7ffa2e5bcfab5ff5c29a0593b78f911b8) | `` freebsd.ports: fetchzip -> fetchgit ``                                          |
| [`b0752780`](https://github.com/NixOS/nixpkgs/commit/b0752780ee0155730033bb6425b0e2a219a64983) | `` python312Packages.mypy-boto3-sns: 1.36.0 -> 1.36.3 ``                           |
| [`2b21067f`](https://github.com/NixOS/nixpkgs/commit/2b21067f61bef19e195ede4210496ea8aeb29f42) | `` python312Packages.mypy-boto3-quicksight: 1.36.0 -> 1.36.3 ``                    |
| [`2e5e6f13`](https://github.com/NixOS/nixpkgs/commit/2e5e6f13d46c21698c033b625184bf14b7d277f3) | `` python312Packages.mypy-boto3-logs: 1.36.0 -> 1.36.3 ``                          |
| [`ae65f662`](https://github.com/NixOS/nixpkgs/commit/ae65f6627ad71f2643e1ea9f09ebacd5ecd60f6b) | `` python312Packages.mypy-boto3-iotsitewise: 1.36.0 -> 1.36.3 ``                   |
| [`3ef150c8`](https://github.com/NixOS/nixpkgs/commit/3ef150c8b64490f8f136b3dd4a05287a17caf8a9) | `` python312Packages.mypy-boto3-emr-serverless: 1.36.0 -> 1.36.3 ``                |
| [`3f5a8e4c`](https://github.com/NixOS/nixpkgs/commit/3f5a8e4c78ff641a0912f6e7221397482aa8cf8c) | `` python312Packages.mypy-boto3-connect: 1.36.0 -> 1.36.3 ``                       |
| [`ceb9b025`](https://github.com/NixOS/nixpkgs/commit/ceb9b025af430899cce050dddbe2da5bfe8c9d5e) | `` python312Packages.mypy-boto3-cognito-idp: 1.36.0 -> 1.36.3 ``                   |
| [`c89d8d5f`](https://github.com/NixOS/nixpkgs/commit/c89d8d5fdf1f339e7be953097876038f5250be66) | `` python312Packages.mypy-boto3-batch: 1.36.0 -> 1.36.3 ``                         |
| [`29a14407`](https://github.com/NixOS/nixpkgs/commit/29a144076ebfa1cf7523963d528240cf4a9e414c) | `` vigra: unstable-2022-01-11 -> 1.12.1 ``                                         |
| [`f7855413`](https://github.com/NixOS/nixpkgs/commit/f7855413db97106caa31cb39d9c86824dcef283c) | `` lubelogger: 1.4.2 -> 1.4.3 ``                                                   |
| [`d5350856`](https://github.com/NixOS/nixpkgs/commit/d5350856f32a84cb289702f5815b4526c3599e85) | `` dstat: drop ``                                                                  |
| [`1994df2b`](https://github.com/NixOS/nixpkgs/commit/1994df2b9a376d7badbd69a32eaf871a7a6c621d) | `` checkov: 3.2.353 -> 3.2.355 ``                                                  |
| [`8ba31e09`](https://github.com/NixOS/nixpkgs/commit/8ba31e09b90db1dac0993cad831c853a7ffb39d2) | `` python313Packages.tencentcloud-sdk-python: 3.0.1306 -> 3.0.1308 ``              |
| [`e408222b`](https://github.com/NixOS/nixpkgs/commit/e408222be12444b4b7acf11c094dd46dc14f295d) | `` python313Packages.botocore-stubs: 1.36.2 -> 1.36.3 ``                           |
| [`1558269d`](https://github.com/NixOS/nixpkgs/commit/1558269d98370e03943ade92c544507fedb986cc) | `` python313Packages.boto3-stubs: 1.36.2 -> 1.36.3 ``                              |
| [`bec77a7e`](https://github.com/NixOS/nixpkgs/commit/bec77a7e5393d0810eaeb95253a8db89a0e3207d) | `` python313Packages.publicsuffixlist: 1.0.2.20250121 -> 1.0.2.20250122 ``         |
| [`43e479b5`](https://github.com/NixOS/nixpkgs/commit/43e479b53f1ae2d705ed4e233b50115d31afc6b2) | `` vscode-extensions.saoudrizwan.claude-dev: 3.1.11 -> 3.2.5 ``                    |
| [`931f637c`](https://github.com/NixOS/nixpkgs/commit/931f637cfa1b64e7a6f6f97b5dc6ca6232377567) | `` nixos/opengamepadui: init ``                                                    |
| [`8999ddeb`](https://github.com/NixOS/nixpkgs/commit/8999ddeb1af464d6b37ae4b6b85b19f6847f9e4d) | `` opengamepadui: init at 0.35.7 ``                                                |
| [`04bdf80f`](https://github.com/NixOS/nixpkgs/commit/04bdf80f9887b987502dec3dfe7e2a6781159b5d) | `` paperless-ngx: 2.14.4 -> 2.14.5 ``                                              |
| [`5d0b417d`](https://github.com/NixOS/nixpkgs/commit/5d0b417dcb20a24e1584a9e34d2f6e411d326e2a) | `` php8{1-3}Extensions.phalcon: fix compilation with gcc 14 ``                     |
| [`24d1f848`](https://github.com/NixOS/nixpkgs/commit/24d1f8489139d969b3f11826975c93b10e62266e) | `` etlegacy: 2.83.1 -> 2.83.2 ``                                                   |
| [`6608171e`](https://github.com/NixOS/nixpkgs/commit/6608171e3baf92a76367cd457d7a7094cd5be875) | `` python310Packages.astropy: disable ``                                           |
| [`ec1cb639`](https://github.com/NixOS/nixpkgs/commit/ec1cb63901aa61783746a5fd6cb2de087ab19d9b) | `` imagemagick: move to openexr_3 ``                                               |
| [`3945fc61`](https://github.com/NixOS/nixpkgs/commit/3945fc6146bf4afa6196276df636d56e0bdc786d) | `` scala-cli: add agilesteel as maintainer ``                                      |
| [`faae724c`](https://github.com/NixOS/nixpkgs/commit/faae724cf27fe4d576cd381328fa9c376f755f98) | `` scala-cli: 1.5.4 -> 1.6.1 ``                                                    |
| [`622d18ca`](https://github.com/NixOS/nixpkgs/commit/622d18caf2ea0d5331375fad48242a4f4a838cb0) | `` goreleaser: 2.6.0 -> 2.6.1 ``                                                   |
| [`1be7fe5e`](https://github.com/NixOS/nixpkgs/commit/1be7fe5e1d8521dccecbee2c1d1e20964f764502) | `` nb: Use bashInteractive to fix shell subcommand (#375817) ``                    |
| [`e6288f40`](https://github.com/NixOS/nixpkgs/commit/e6288f407a51ff1cbe6de3d4f1e9e3345b3aa6f2) | `` openfga-cli: 0.6.2 -> 0.6.3 ``                                                  |