### PR TITLE
chore(flake/home-manager): `a0428685` -> `daf04c59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -395,11 +395,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737704314,
-        "narHash": "sha256-zta8jvOQ2wRCZmiwFEnS5iCulWAh8e+fLUlQxrgOBjM=",
+        "lastModified": 1737762889,
+        "narHash": "sha256-5HGG09bh/Yx0JA8wtBMAzt0HMCL1bYZ93x4IqzVExio=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a0428685572b134f6594e7d7f5db5e1febbab2d7",
+        "rev": "daf04c5950b676f47a794300657f1d3d14c1a120",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`daf04c59`](https://github.com/nix-community/home-manager/commit/daf04c5950b676f47a794300657f1d3d14c1a120) | `` ollama: add darwin support ``                   |
| [`1b9fe46e`](https://github.com/nix-community/home-manager/commit/1b9fe46e9fc3575eeb63ef42d73144e397593904) | `` home-manager: move tests into new test flake `` |
| [`b93e17c7`](https://github.com/nix-community/home-manager/commit/b93e17c73cca670460d0604c00ba0571eb5d4cad) | `` neovim: fix flaky test ``                       |
| [`15f7f9bc`](https://github.com/nix-community/home-manager/commit/15f7f9bc4e7aedcdd26e2f20fc4b46220ead584d) | `` himalaya: fix tests ``                          |
| [`e9068fac`](https://github.com/nix-community/home-manager/commit/e9068facd7bcfb99405d0e5e3b938f5e5ddc38e0) | `` himalaya: adjust package for released v1.0.0 `` |
| [`2ae3dd46`](https://github.com/nix-community/home-manager/commit/2ae3dd460f60822434959a92e8e19c9f9b7efce2) | `` himalaya: add xdg desktop entry ``              |
| [`5f5a9d5c`](https://github.com/nix-community/home-manager/commit/5f5a9d5cd23e6ff7f877ec66b498bb02585a72b0) | `` himalaya: make use of lib.getExe ``             |
| [`44ee9bc8`](https://github.com/nix-community/home-manager/commit/44ee9bc826770df1ab83c7e93f77fdaddd37523a) | `` himalaya: improve service ``                    |