### PR TITLE
chore(flake/impermanence): `c64bed13` -> `4b3e914c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1736688610,
-        "narHash": "sha256-1Zl9xahw399UiZSJ9Vxs1W4WRFjO1SsNdVZQD4nghz0=",
+        "lastModified": 1737831083,
+        "narHash": "sha256-LJggUHbpyeDvNagTUrdhe/pRVp4pnS6wVKALS782gRI=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "c64bed13b562fc3bb454b48773d4155023ac31b7",
+        "rev": "4b3e914cdf97a5b536a889e939fb2fd2b043a170",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`4b3e914c`](https://github.com/nix-community/impermanence/commit/4b3e914cdf97a5b536a889e939fb2fd2b043a170) | `` fix(home): order of operations causing issue with files ``    |
| [`44e4c998`](https://github.com/nix-community/impermanence/commit/44e4c998504e285d4cdb76c1cdeca0e48c0896bf) | `` docs(home): improve method docs ``                            |
| [`5e884ea8`](https://github.com/nix-community/impermanence/commit/5e884ea82a9b35c8b8406245db749fe95c035061) | `` feat(home): add defaultDirectoryMethod ``                     |
| [`6b4df25b`](https://github.com/nix-community/impermanence/commit/6b4df25b7fc14acfa99ca59cec5833ad7a2a50db) | `` refactor(home): inline isSymlink, isBindfs, and getDirPath `` |
| [`339078d5`](https://github.com/nix-community/impermanence/commit/339078d596713ad32447a99d6e5a59413bda6626) | `` refactor(home): use coercedTo with directory type ``          |