### PR TITLE
chore(flake/nixpkgs): `0aa47554` -> `825479c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -570,11 +570,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737632463,
-        "narHash": "sha256-38J9QfeGSej341ouwzqf77WIHAScihAKCt8PQJ+NH28=",
+        "lastModified": 1737746512,
+        "narHash": "sha256-nU6AezEX4EuahTO1YopzueAXfjFfmCHylYEFCagduHU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0aa475546ed21629c4f5bbf90e38c846a99ec9e9",
+        "rev": "825479c345a7f806485b7f00dbe3abb50641b083",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`92b7e18b`](https://github.com/NixOS/nixpkgs/commit/92b7e18b22734f0de238c92e695f5e93408addb4) | `` socalabs-sid: init at 1.1.0 (#372081) ``                                      |
| [`b376e96f`](https://github.com/NixOS/nixpkgs/commit/b376e96f521d932948aa3a62f7878bce3d26ef11) | `` quartus-prime-lite: add missing runtime dependency xorg.libXscrnSaver ``      |
| [`14ce74a5`](https://github.com/NixOS/nixpkgs/commit/14ce74a5ef2e36a2487492517f69cedafd949caa) | `` nixos/wyoming/piper: drop download directory ``                               |
| [`47eda6da`](https://github.com/NixOS/nixpkgs/commit/47eda6dab7a99bbf1be08311e0a9e20fa2d5de25) | `` nixos/wyoming/faster-whisper: drop download directory ``                      |
| [`309349b4`](https://github.com/NixOS/nixpkgs/commit/309349b4e73c7fa50317bed6508a82c5106b77f9) | `` pinact: 1.1.2 -> 1.2.0 ``                                                     |
| [`61235d44`](https://github.com/NixOS/nixpkgs/commit/61235d44719d52524f870bac9f56e6b4f7f0574e) | `` docs: fix devmode for manuals ``                                              |
| [`cdc904a6`](https://github.com/NixOS/nixpkgs/commit/cdc904a664157c5fba92954c42ce239164ae44c5) | `` open-webui: 0.5.6 -> 0.5.7 ``                                                 |
| [`ee38dc95`](https://github.com/NixOS/nixpkgs/commit/ee38dc95517b241df18892594ff902125fdac0e1) | `` discord-canary: 0.0.569 -> 0.0.574 ``                                         |
| [`7a3e1a68`](https://github.com/NixOS/nixpkgs/commit/7a3e1a683e29c5dc84fcc32b5fa97cf336dbbf6f) | `` discord-ptb: 0.0.126 -> 0.0.127 ``                                            |
| [`b99c35c4`](https://github.com/NixOS/nixpkgs/commit/b99c35c43391130a46d21337ed4f5c8c9efa2d70) | `` discord: 0.0.80 -> 0.0.81 ``                                                  |
| [`40db972a`](https://github.com/NixOS/nixpkgs/commit/40db972aa58b55a5d4e24c42fb9ca15c24ea938b) | `` pkgsCross.x86_64-darwin.discord-development: 0.0.76 -> 0.0.78 ``              |
| [`c0c6ad1f`](https://github.com/NixOS/nixpkgs/commit/c0c6ad1fe299283484e516775baee93ae25e2695) | `` pkgsCross.x86_64-darwin.discord-canary: 0.0.681 -> 0.0.686 ``                 |
| [`56876785`](https://github.com/NixOS/nixpkgs/commit/56876785a416c1060413203297599c5e4e7129f3) | `` pkgsCross.x86_64-darwin.discord-ptb: 0.0.156 -> 0.0.157 ``                    |
| [`604a9213`](https://github.com/NixOS/nixpkgs/commit/604a92135df47d8dd2366a6494ab5c10e768c487) | `` pkgsCross.x86_64-darwin.discord: 0.0.332 -> 0.0.333 ``                        |
| [`bcc7e1e1`](https://github.com/NixOS/nixpkgs/commit/bcc7e1e15b3448904ef3c68b23b651b396717e82) | `` hyprlock: 0.6.1 -> 0.6.2 (#376284) ``                                         |
| [`e3df5ede`](https://github.com/NixOS/nixpkgs/commit/e3df5ede4471e1d264886031289608e8c9c3f085) | `` python312Packages.aiowithings: 3.1.4 -> 3.1.5 ``                              |
| [`870951ce`](https://github.com/NixOS/nixpkgs/commit/870951ce361063f96c0e7ebbae561f8d0240c96b) | `` airwindows: init at 0-unstable-2025-01-06 (#371817) ``                        |
| [`d61756ab`](https://github.com/NixOS/nixpkgs/commit/d61756ab35a16d454a813435e225cc223bb6c1f2) | `` skim: 0.15.7 -> 0.16.0 ``                                                     |
| [`de0a829e`](https://github.com/NixOS/nixpkgs/commit/de0a829e5fa009f20aa4c3b297eb9f3c555100a0) | `` mise: add usage compatibility test (#369951) ``                               |
| [`aecfd851`](https://github.com/NixOS/nixpkgs/commit/aecfd8518cb2212c0faa4b52b5666ad90eb23966) | `` matomo: 5.2.1 -> 5.2.2 ``                                                     |
| [`a85fc0af`](https://github.com/NixOS/nixpkgs/commit/a85fc0af456a898b7a4c459f38429e05df958907) | `` jjui: 0.1 → 0.2 (#374472) ``                                                  |
| [`8915260a`](https://github.com/NixOS/nixpkgs/commit/8915260a4d9879d11c7b76d9e16b9bd0851de4f5) | `` monitorcontrol: 4.2.0 → 4.3.3 (#375061) ``                                    |
| [`4b5ee583`](https://github.com/NixOS/nixpkgs/commit/4b5ee5838b229d40923154b33cd837593f3d4dcc) | `` netdata: add myself as maintainer ``                                          |
| [`c354e012`](https://github.com/NixOS/nixpkgs/commit/c354e0128576a004f3f0dfbfa40f4895d2d69ce3) | `` wasmtime: 28.0.1 → 29.0.1 (#375834) ``                                        |
| [`f063cb28`](https://github.com/NixOS/nixpkgs/commit/f063cb28688dadea6b74c9f4c0067f6bf213403f) | `` shaka-packager: 3.4.1 → 3.4.2 (#375782) ``                                    |
| [`232d46e0`](https://github.com/NixOS/nixpkgs/commit/232d46e06e8239d556e72aa4ba439bce0baa23d1) | `` nixos/wyoming/openwakeword: fix eval ``                                       |
| [`c621c6bf`](https://github.com/NixOS/nixpkgs/commit/c621c6bf2a003a3dab72d2ac08ec94ed7f031abf) | `` roslyn-ls: fix read-only cache dir (#376364) ``                               |
| [`6d5b297b`](https://github.com/NixOS/nixpkgs/commit/6d5b297bc68f021d5fe9d43a3d1ba35a3b6d0663) | `` retrospy: add `mainProgram` ``                                                |
| [`5fbf3192`](https://github.com/NixOS/nixpkgs/commit/5fbf31922fdaba1db90fe16c1075cf1f70ba4089) | `` sunshine: fix build with cudaSupport (#375903) ``                             |
| [`f693581c`](https://github.com/NixOS/nixpkgs/commit/f693581cab1d06f8cee24a7386402fadeeb04daa) | `` betterdisplay: 3.3.0 -> 3.3.2 (#376067) ``                                    |
| [`64497b02`](https://github.com/NixOS/nixpkgs/commit/64497b020f9a774dd4bb7484e7a9794e58bfc08e) | `` shader-slang: 2025.3 → 2025.3.1 (#376342) ``                                  |
| [`d2a359ca`](https://github.com/NixOS/nixpkgs/commit/d2a359cae91682f0d10ff84188f38cafff81d84c) | `` python312Packages.pyopencl: mark as broken on x86_64-darwin too ``            |
| [`9d084f05`](https://github.com/NixOS/nixpkgs/commit/9d084f0589285a5eeb5a06d8f780ce7811458cf0) | `` retrospy: 6.6 -> 6.7 ``                                                       |
| [`bafca6cb`](https://github.com/NixOS/nixpkgs/commit/bafca6cbe151eb9229555bbf84f0108acc663000) | `` ocamlPackages.cpdf: 2.7.1 → 2.8 (#376363) ``                                  |
| [`dfa21029`](https://github.com/NixOS/nixpkgs/commit/dfa21029432108218a091f39dd0ec419f6f9f2dd) | `` tclPackages.wapp: 0-unstable-2024-05-23 -> 0-unstable-2024-11-22 ``           |
| [`933c1b5e`](https://github.com/NixOS/nixpkgs/commit/933c1b5e5a9cf5edfeb84a5c99f8504c9baf8b1b) | `` goattracker: 2.76 -> 2.77 ``                                                  |
| [`950d12c2`](https://github.com/NixOS/nixpkgs/commit/950d12c253b7201b4d766111a14ab4f00fb03e42) | `` mistral-rs: 0.3.2 -> 0.4.0 ``                                                 |
| [`f23503ac`](https://github.com/NixOS/nixpkgs/commit/f23503ac99b0fc43684d4641d6e3ce0b7abb19e6) | `` vimPlugins.llama-vim: init at 2025-01-24 ``                                   |
| [`dd83dc3f`](https://github.com/NixOS/nixpkgs/commit/dd83dc3f08343f01997f42dd9845f8fc714117b8) | `` vimPlugins.llama-vim: init at 2025-01-24 ``                                   |
| [`75d03b45`](https://github.com/NixOS/nixpkgs/commit/75d03b45a3977cbe917d882576a76e446d5d0545) | `` stract: update meta.description ``                                            |
| [`6609b5a3`](https://github.com/NixOS/nixpkgs/commit/6609b5a3156d0debb7352dcbc7fdce7038f29515) | `` stract: add ngi team to maintainers ``                                        |
| [`f8f19cac`](https://github.com/NixOS/nixpkgs/commit/f8f19caca1d4df8d139d228891bca0040182f4a0) | `` stract: add update script ``                                                  |
| [`cc3d676b`](https://github.com/NixOS/nixpkgs/commit/cc3d676b47de797192431d5a0c285c4b6d246ce3) | `` stract: 0-unstable-2024-09-14 -> 0-unstable-2024-12-11 ``                     |
| [`f6ea0851`](https://github.com/NixOS/nixpkgs/commit/f6ea085167f0833b0b3d0186101797c7026757cd) | `` circt: 1.101.0 -> 1.102.0 ``                                                  |
| [`be09d1ed`](https://github.com/NixOS/nixpkgs/commit/be09d1ed947ce4b6b46b5c706a55f3bc2a3d8319) | `` python313Packages.sigstore: 3.5.3 -> 3.6.1 ``                                 |
| [`483e9f80`](https://github.com/NixOS/nixpkgs/commit/483e9f80b54ce68681b136553fb4381d0b8f8b35) | `` python313Packages.betterproto: fix build ``                                   |
| [`a1009efa`](https://github.com/NixOS/nixpkgs/commit/a1009efabf319a3c83995eb3390ca1c83223102f) | `` python313Packages.rfc3161-client: init at 1.0.0 ``                            |
| [`3372e9a2`](https://github.com/NixOS/nixpkgs/commit/3372e9a22ef2b6c7e10cf235ff9018d44b75e5fb) | `` OpenTofu: sanity check withPlugins override (#376262) ``                      |
| [`01f1d45f`](https://github.com/NixOS/nixpkgs/commit/01f1d45ff8d95aa082d520fb466c447c49622df5) | `` python312Packages.numpyro: skip newly failing tests ``                        |
| [`17ea2a7a`](https://github.com/NixOS/nixpkgs/commit/17ea2a7abfdc7ac089001659179237e80fe4831b) | `` python312Packages.flax: skip failing tests ``                                 |
| [`1be61a4d`](https://github.com/NixOS/nixpkgs/commit/1be61a4d0fd9f821318bf6a6aa8a82a5a9447b0c) | `` python312Packages.jax: 0.4.38 -> 0.5.0 ``                                     |
| [`0e3e09ce`](https://github.com/NixOS/nixpkgs/commit/0e3e09ce0bc58553e99f4274524ce2551b790403) | `` python312Packages.jax-cuda12-plugin: 0.4.38 -> 0.5.0 ``                       |
| [`cf23a4de`](https://github.com/NixOS/nixpkgs/commit/cf23a4de665206bb479cb1d92a39e4a07d51fb7a) | `` python312Packages.jax-cuda12-pjrt: 0.4.38 -> 0.5.0 ``                         |
| [`07d2e6f5`](https://github.com/NixOS/nixpkgs/commit/07d2e6f577f8b6169991906eebeaad7ca4aae617) | `` python312Packages.jaxlib: 0.4.38 -> 0.5.0 ``                                  |
| [`08274450`](https://github.com/NixOS/nixpkgs/commit/08274450f1835aeed1c56dcc682498773db6d26e) | `` gh-dash: 4.9.0 -> 4.9.1 ``                                                    |
| [`d549d70c`](https://github.com/NixOS/nixpkgs/commit/d549d70c786529f4dcb585331d15de9211406900) | `` vimPlugins.sg-nvim: 1.1.0-unstable-2024-12-15 -> 1.1.0-unstable-2025-01-21 `` |
| [`5b961c87`](https://github.com/NixOS/nixpkgs/commit/5b961c87be05a5815a66559bbfccfd4c496f788a) | `` nixos/tests/installer: add shellcheck-minimal ``                              |
| [`6e267c25`](https://github.com/NixOS/nixpkgs/commit/6e267c2538bdbdb917f5eb2d30a7b1391d9bdbf2) | `` linux/hardened/patches/6.6: v6.6.69-hardened1 -> v6.6.73-hardened1 ``         |
| [`a54bf075`](https://github.com/NixOS/nixpkgs/commit/a54bf0759e9a762c101e8556de3809f522de139d) | `` linux/hardened/patches/6.12: v6.12.8-hardened1 -> v6.12.10-hardened1 ``       |
| [`e7de0bb2`](https://github.com/NixOS/nixpkgs/commit/e7de0bb2c74de2104e77dc6a94eaf64b5594202f) | `` linux/hardened/patches/6.1: v6.1.123-hardened1 -> v6.1.126-hardened1 ``       |
| [`f34c39df`](https://github.com/NixOS/nixpkgs/commit/f34c39dfdcbdf7996831618cc08f733d05a62eb8) | `` linux/hardened/patches/5.4: v5.4.288-hardened1 -> v5.4.289-hardened1 ``       |
| [`8a2fcf15`](https://github.com/NixOS/nixpkgs/commit/8a2fcf15bc49fb95972c43db93078faffacb699a) | `` linux/hardened/patches/5.15: v5.15.175-hardened1 -> v5.15.176-hardened1 ``    |
| [`e9f010a4`](https://github.com/NixOS/nixpkgs/commit/e9f010a47e73470b5678630b8cb9c199246a3fc6) | `` linux/hardened/patches/5.10: v5.10.232-hardened1 -> v5.10.233-hardened1 ``    |
| [`c2d02f13`](https://github.com/NixOS/nixpkgs/commit/c2d02f132bd194e2c27953298266beecb31953cc) | `` apacheHttpdPackages.php: 8.3.15 -> 8.3.16 ``                                  |
| [`5aa4b7f1`](https://github.com/NixOS/nixpkgs/commit/5aa4b7f130351c016a552436293ea5c2243b4558) | `` python313Packages.sigstore-rekor-types: add bot-wxt1221 as maintainers ``     |
| [`cb4ebf99`](https://github.com/NixOS/nixpkgs/commit/cb4ebf996d1c69f428490d4ecb8b23b44b237439) | `` vimPlugins.hlchunk-nvim: init at 2024-11-23 ``                                |
| [`c0280fba`](https://github.com/NixOS/nixpkgs/commit/c0280fbae450a245e149da20510b797a383ac6dd) | `` systemctl-tui: 0.3.10 -> 0.4.0 ``                                             |
| [`a5fcd78a`](https://github.com/NixOS/nixpkgs/commit/a5fcd78a3a1341d44980c5a97bd62d38fa2da18e) | `` strace: 6.12 -> 6.13 ``                                                       |
| [`079e535f`](https://github.com/NixOS/nixpkgs/commit/079e535f8c961dfa4bc4dd0b3c2cfd9af24d2c9f) | `` uv: 0.5.23 -> 0.5.24 ``                                                       |
| [`f35451f2`](https://github.com/NixOS/nixpkgs/commit/f35451f2a0137d4531cdcb384b7b4ec39bb25750) | `` why3: 1.7.2 → 1.8.0 ``                                                        |
| [`8d0549c6`](https://github.com/NixOS/nixpkgs/commit/8d0549c6bbc1b5b13bd507b12794f19d7812679b) | `` myks: 4.3.0 -> 4.3.1 ``                                                       |
| [`a22a3115`](https://github.com/NixOS/nixpkgs/commit/a22a31150802809cadcc6faa55ba369d12aef77d) | `` ecapture: 0.9.2 -> 0.9.3 ``                                                   |
| [`11de0087`](https://github.com/NixOS/nixpkgs/commit/11de0087000d07297df8de28638eb0b7e610b7e4) | `` vimPlugins.YouCompleteMe: add mel as maintainer ``                            |
| [`852e6fd7`](https://github.com/NixOS/nixpkgs/commit/852e6fd7234e819d8a914c1e76027bc10b0a43f9) | `` ycmd: replace maintainer siriobalmelli with mel ``                            |
| [`3e90066a`](https://github.com/NixOS/nixpkgs/commit/3e90066ad3276c9dc1599568ec0cd91cdb51f477) | `` maintainers: add mel ``                                                       |
| [`79c83d71`](https://github.com/NixOS/nixpkgs/commit/79c83d718e892756d40f7aaf2f712b345558e34e) | `` ycmd: correct gopls package and link path ``                                  |
| [`26f9a866`](https://github.com/NixOS/nixpkgs/commit/26f9a8662c21aa6aae5e5add58457c4fbbeb1356) | `` tre: 0.8.0 -> 0.9.0 ``                                                        |
| [`7499313b`](https://github.com/NixOS/nixpkgs/commit/7499313bab33e6d3b42d2d01a4a55bac2934076b) | `` qtcreator: 15.0.0 -> 15.0.1 ``                                                |
| [`650cc767`](https://github.com/NixOS/nixpkgs/commit/650cc76728dd3f69c356ed6197606ed1788af363) | `` fly: 7.12.0 -> 7.12.1 ``                                                      |
| [`2e997ef0`](https://github.com/NixOS/nixpkgs/commit/2e997ef08368815a3316fa8da44a50cdfab5d1cd) | `` libgda5: Add bot-wxt1221 as a maintainer ``                                   |
| [`7de8fbbc`](https://github.com/NixOS/nixpkgs/commit/7de8fbbc9e1daddcefff07d5528c0db46e9cdb7f) | `` libgdamm: Add bot-wxt1221 as a maintainer ``                                  |
| [`bf35bb19`](https://github.com/NixOS/nixpkgs/commit/bf35bb19b762d0f31f71a25914b329933ab96864) | `` libepc: Add bot-wxt1221 as a maintainer ``                                    |
| [`8bf08dfc`](https://github.com/NixOS/nixpkgs/commit/8bf08dfca3f56e22f900a8c8031897292a5f5550) | `` libepc: Unmaintain ``                                                         |
| [`c58ed693`](https://github.com/NixOS/nixpkgs/commit/c58ed69301acf37322939114418c9c13c50f41e9) | `` glom: Drop gnome team from maintainers ``                                     |
| [`b00b50a7`](https://github.com/NixOS/nixpkgs/commit/b00b50a73a73127f264efbbdf0782ad59af372ec) | `` libgdamm: Unmaintain ``                                                       |
| [`708566c9`](https://github.com/NixOS/nixpkgs/commit/708566c9cca536e3bcc69594177d4bcd3a7b9e4e) | `` libgda5: Unmaintain ``                                                        |
| [`403151ca`](https://github.com/NixOS/nixpkgs/commit/403151caf53cdbe6832bb5694ea19a5fa9d4e571) | `` libgda5: Rename from libgda ``                                                |
| [`511f40cc`](https://github.com/NixOS/nixpkgs/commit/511f40ccc4ba92572980ef84a65b325b37fb3700) | `` gtkd: Remove libgda propagation ``                                            |
| [`c32a7686`](https://github.com/NixOS/nixpkgs/commit/c32a7686c59a6c6105ef553594047ae49b81225f) | `` gnomeExtensions.pano: Switch to libgda6 ``                                    |
| [`d98adb30`](https://github.com/NixOS/nixpkgs/commit/d98adb30f2e40a755f23cce3f3fe9505ca15ddfb) | `` template-glib: 3.36.2 → 3.36.3 ``                                             |
| [`7cb09c99`](https://github.com/NixOS/nixpkgs/commit/7cb09c996c061d3d09da1627708a0686430222ff) | `` mutter: 47.3 → 47.4 ``                                                        |
| [`9c74e9cc`](https://github.com/NixOS/nixpkgs/commit/9c74e9ccc7d05b00fd2728421d2773a6dffd0349) | `` loupe: 47.2 → 47.4 ``                                                         |
| [`8d85a372`](https://github.com/NixOS/nixpkgs/commit/8d85a372fbfd7759566fe4f3b3e8b85dedd23810) | `` libwnck: 43.1 → 43.2 ``                                                       |
| [`0ebbe9d2`](https://github.com/NixOS/nixpkgs/commit/0ebbe9d2de0ad09a4ce3b04a2fb5885935ac81fe) | `` libgee: 0.20.6 → 0.20.8 ``                                                    |
| [`0885e3d1`](https://github.com/NixOS/nixpkgs/commit/0885e3d18fdadacfa9ea0568b5f72e680af1ed27) | `` libadwaita: 1.6.2 → 1.6.3 ``                                                  |
| [`899c5e06`](https://github.com/NixOS/nixpkgs/commit/899c5e06ef6893b6f23c847b959cece214c3ef92) | `` gupnp-av: 0.14.1 → 0.14.3 ``                                                  |
| [`3fccbcb3`](https://github.com/NixOS/nixpkgs/commit/3fccbcb373caa8f8d9902d69f754c242204e7c12) | `` gnome-software: 47.2 → 47.4 ``                                                |
| [`f23b8193`](https://github.com/NixOS/nixpkgs/commit/f23b819332871feca773210589f0f1cefec6586b) | `` gnome-shell-extensions: 47.2 → 47.3 ``                                        |
| [`161a3cb8`](https://github.com/NixOS/nixpkgs/commit/161a3cb85159ffa7de6b7196503de101745e5341) | `` gnome-shell: 47.2 → 47.3 ``                                                   |
| [`11b76794`](https://github.com/NixOS/nixpkgs/commit/11b76794e4e1e814fa619ed78bde6c58c0bf9b39) | `` gnome-remote-desktop: 47.2 → 47.3 ``                                          |
| [`ea6bb645`](https://github.com/NixOS/nixpkgs/commit/ea6bb645a69d772315fbefe11417a95a2dcf94f9) | `` gnome-control-center: 47.2 → 47.3 ``                                          |
| [`cb63927a`](https://github.com/NixOS/nixpkgs/commit/cb63927aa70d3512d5983994e57e6ab707dc3ad8) | `` almanah: 0.12.3 → 0.12.4 ``                                                   |
| [`a29cb611`](https://github.com/NixOS/nixpkgs/commit/a29cb611a5357470c0fd241cd56e3fc1a0a28dba) | `` xdg-user-dirs-gtk: 0.11 → 0.14 ``                                             |
| [`3d805610`](https://github.com/NixOS/nixpkgs/commit/3d8056107124e91077ea855b86a200aa65b465c3) | `` gcr_4: Switch to new version policy ``                                        |
| [`ab19cc4c`](https://github.com/NixOS/nixpkgs/commit/ab19cc4c38217bd0654e931fdcf646add4b8006d) | `` gnome.updateScript: Support Gcr’s new version policy ``                       |
| [`e5a2cbba`](https://github.com/NixOS/nixpkgs/commit/e5a2cbba8b4be33f25651eca192c004ec4f42538) | `` gnome.updateScript: Add doctests for version classifiers ``                   |
| [`264b4478`](https://github.com/NixOS/nixpkgs/commit/264b44789dd41fb319efad88f255a5a1534865e8) | `` gnome.updateScript: Simplify version predicate ``                             |
| [`fd6aabec`](https://github.com/NixOS/nixpkgs/commit/fd6aabecc2bb901942ebad754aabdd516c70404d) | `` kanidm: 1.4.5 -> 1.4.6 ``                                                     |
| [`def1fce4`](https://github.com/NixOS/nixpkgs/commit/def1fce42cbe4e345d0f345a4d684227203d5eec) | `` libretranslate: 1.6.2 -> 1.6.4 ``                                             |
| [`0fd6fe15`](https://github.com/NixOS/nixpkgs/commit/0fd6fe15331397972ee075c91e93a5cdc0658fef) | `` easytier: 2.1.1 -> 2.1.2 ``                                                   |
| [`f4d4ac07`](https://github.com/NixOS/nixpkgs/commit/f4d4ac071a4ca08dc3862db0c1c0693f976b3250) | `` pandoc: make reference workaround conditional on typst version ``             |
| [`ccb3770e`](https://github.com/NixOS/nixpkgs/commit/ccb3770e1aebb2c616b218c1980a276af3e4d2f8) | `` pandoc_3_6: fix incorrect dependency versions ``                              |
| [`1c275801`](https://github.com/NixOS/nixpkgs/commit/1c2758018b9f5b3096ad6915d7d09b1da8d142f7) | `` sunshine: 2025.118.151840 -> 2025.122.141614 ``                               |
| [`f207c424`](https://github.com/NixOS/nixpkgs/commit/f207c424e659c8812599bf56da88d6621ac84255) | `` dayon: 15.0.1 -> 15.0.2 ``                                                    |
| [`c53d26e4`](https://github.com/NixOS/nixpkgs/commit/c53d26e4f61c38c11f256258b9fb5414a8432e94) | `` font-manager: 0.9.0 -> 0.9.2 ``                                               |
| [`9d33d12d`](https://github.com/NixOS/nixpkgs/commit/9d33d12d217c07cbeba90b96d009ab3e351698c4) | `` mpris-timer: 2.0.5 -> 2.1.1 ``                                                |
| [`cf032645`](https://github.com/NixOS/nixpkgs/commit/cf032645cd423037cf0cef6ed00aa448b24cb0cb) | `` plasma-panel-spacer-extended: 1.9.0 -> 1.10.0 ``                              |