### PR TITLE
chore(flake/darwin): `65cc1fa8` -> `62ba0a22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737504076,
-        "narHash": "sha256-/B4XJnzYU/6K1ZZOBIgsa3K4pqDJrnC2579c44c+4rI=",
+        "lastModified": 1737926801,
+        "narHash": "sha256-un7IETRNjUm83jM5Gd/7BO4rCzzkom46O0FDMo5toaI=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "65cc1fa8e36ceff067daf6cfb142331f02f524d3",
+        "rev": "62ba0a22426721c94e08f0779ed8235d5672869b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                   |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`b5b78887`](https://github.com/LnL7/nix-darwin/commit/b5b7888793329a8c70c216cae9db8a0180b3dcda) | `` nix-tools: set `$NIX_PATH` ``                          |
| [`4d0ae698`](https://github.com/LnL7/nix-darwin/commit/4d0ae6980d128baecf7e7f636e4df4a95740d628) | `` nix-tools: overwrite `$PATH` rather than prepending `` |
| [`3d95b013`](https://github.com/LnL7/nix-darwin/commit/3d95b013516aa3c97e645ad803d1a497097dab90) | `` nix-tools: make `systemPath` more readable ``          |
| [`02232f71`](https://github.com/LnL7/nix-darwin/commit/02232f71c5712d08d6fb9d0dbedec50509cebbba) | `` nix-tools: drop `nixPackage` ``                        |