### PR TITLE
chore(flake/stylix): `d6951d0b` -> `6103431c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -723,11 +723,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1737861120,
-        "narHash": "sha256-V/GWU1BQwbxyZif9RBvwn10S1KX+86uPkkI41KQEcQQ=",
+        "lastModified": 1737930520,
+        "narHash": "sha256-CAgB9/o54SXzqWwypA+hL2ETxiHW92Y+Ou4fT581jdk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "d6951d0b2ffe74e4779a180e9b6a0e17627756e1",
+        "rev": "6103431cd2f9d4352e5493a4063cf57e307d355c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                           |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`6103431c`](https://github.com/danth/stylix/commit/6103431cd2f9d4352e5493a4063cf57e307d355c) | `` doc: Update tricks per tinted-theming schema changes (#792) `` |
| [`d5f02b54`](https://github.com/danth/stylix/commit/d5f02b541064763ada8b917834d55142af07b55c) | `` ghostty: be consistent with other terminals (#806) ``          |