### PR TITLE
chore(flake/darwin): `62ba0a22` -> `5c12a6f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737926801,
-        "narHash": "sha256-un7IETRNjUm83jM5Gd/7BO4rCzzkom46O0FDMo5toaI=",
+        "lastModified": 1738019511,
+        "narHash": "sha256-FZmImpFcbcW+ndgTL52TLn07D6h3hDorgzLcPEdRB6Q=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "62ba0a22426721c94e08f0779ed8235d5672869b",
+        "rev": "5c12a6f4a1c0ea764590a9e09c0d582d1c16e346",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                        |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
| [`4bff4bc8`](https://github.com/LnL7/nix-darwin/commit/4bff4bc8ae105dbc3a56ed5255fbde9495cbf4c1) | `` {activation-scripts,activate-system}: purify environment `` |
| [`ff80eacd`](https://github.com/LnL7/nix-darwin/commit/ff80eacd0f756fa2c410f9128b114eeb0b4e5bc5) | `` activation-scripts: remove `_status` ``                     |
| [`0e87d3d3`](https://github.com/LnL7/nix-darwin/commit/0e87d3d3914321ceea5b10a87f48b6ff6179e190) | `` activate-system: don’t `KeepAlive` ``                       |
| [`2119dd10`](https://github.com/LnL7/nix-darwin/commit/2119dd10f65e376dd42f32b0f7ec43577f48129a) | `` checks: remove `darwinChanges` ``                           |
| [`1e16e2a9`](https://github.com/LnL7/nix-darwin/commit/1e16e2a9c25b5a15040686be6f07d0ce67043260) | `` ci: use the PR head as `<darwin>` for install test ``       |