### PR TITLE
chore(flake/darwin): `5c12a6f4` -> `349a74c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,11 +117,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738019511,
-        "narHash": "sha256-FZmImpFcbcW+ndgTL52TLn07D6h3hDorgzLcPEdRB6Q=",
+        "lastModified": 1738033138,
+        "narHash": "sha256-qlIM8A3bdL9c6PexhpS+QyZLO9y/8a3V75HVyJgDE5Q=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "5c12a6f4a1c0ea764590a9e09c0d582d1c16e346",
+        "rev": "349a74c66c596ef97ee97b4d80a3ca61227b6120",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                     |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
| [`cc9c8408`](https://github.com/LnL7/nix-darwin/commit/cc9c8408bb9f29b4afe919eff4ad922d054cf591) | `` Revert "{activation-scripts,activate-system}: purify environment" ``     |
| [`3509925a`](https://github.com/LnL7/nix-darwin/commit/3509925a8634f08b764922577d169757b94df97b) | `` readme: make `darwin-rebuild` use more explicit ``                       |
| [`2733527a`](https://github.com/LnL7/nix-darwin/commit/2733527a586bad9939edc829017acdbc99654d9b) | `` {environment,readme}: default configuration path to `/etc/nix-darwin` `` |
| [`5bc4677c`](https://github.com/LnL7/nix-darwin/commit/5bc4677c03b61213912de654a9409d225fd9fe07) | `` readme: reduce duplication in installation instructions ``               |