### PR TITLE
chore(flake/treefmt-nix): `f2cc121d` -> `bebf27d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -877,11 +877,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737483750,
-        "narHash": "sha256-5An1wq5U8sNycOBBg3nsDDgpwBmR9liOpDGlhliA6Xo=",
+        "lastModified": 1738070913,
+        "narHash": "sha256-j6jC12vCFsTGDmY2u1H12lMr62fnclNjuCtAdF1a4Nk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "f2cc121df15418d028a59c9737d38e3a90fbaf8f",
+        "rev": "bebf27d00f7d10ba75332a0541ac43676985dea3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                        |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`4976404a`](https://github.com/numtide/treefmt-nix/commit/4976404ace8526a7f6c77d8cebb02efaa1d1d28a) | `` treefmt-nix: fix dead documentation link `` |