### PR TITLE
chore(flake/home-manager): `e1ae908b` -> `420a0d95`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737968762,
-        "narHash": "sha256-xiPARGKwocaMtv+U/rgi+h2g56CZZEmrcl7ldRaslq8=",
+        "lastModified": 1738178313,
+        "narHash": "sha256-/8TLf6LkXGRGERzcWMNDeXjYaHSbexmfV+ofheo7K6k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e1ae908bcc30af792b0bb0a52e53b03d2577255e",
+        "rev": "420a0d9506b5dac4d86a68b9ef8e763624ad86c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`d71828a7`](https://github.com/nix-community/home-manager/commit/d71828a7dd0dc53cf3994e8737c84b4180cc6dfa) | `` ghostty: allow darwin users to manager their config (#6300) `` |
| [`c4650fb9`](https://github.com/nix-community/home-manager/commit/c4650fb9c0c4c8f7e1a43e6d72378246a4b50f3b) | `` cliphist: support multiple systemdTargets properly (#5669) ``  |
| [`5dc1c2e4`](https://github.com/nix-community/home-manager/commit/5dc1c2e40410f7dabef3ba8bf4fdb3145eae3ceb) | `` hyprland: add xdg.portal configuration (#5707) ``              |
| [`0ee8bfdd`](https://github.com/nix-community/home-manager/commit/0ee8bfdd04de611a93cf57dda01686b613cc587d) | `` firefox: add preConfig ``                                      |
| [`bd530df4`](https://github.com/nix-community/home-manager/commit/bd530df4e284310fee0fada3562de908009e1236) | `` firefox: avoid unnecessarily overriding package ``             |
| [`82455a84`](https://github.com/nix-community/home-manager/commit/82455a84e32af01c66e326e5a188795f324975a1) | `` nushell: allow multi-word aliases ``                           |
| [`709aaab1`](https://github.com/nix-community/home-manager/commit/709aaab1a5c35a8d1f1e7546efa226e09f3316fb) | `` nushell: set env in config.nu file ``                          |
| [`46c83c07`](https://github.com/nix-community/home-manager/commit/46c83c07b9a97a8f7633dd162dd9a3bbe511195b) | `` nushell: add settings option ``                                |
| [`a1df6c4c`](https://github.com/nix-community/home-manager/commit/a1df6c4c76a839661207105daa519e3de3b5fe15) | `` nushell: slight refactor ``                                    |
| [`1b4f2a48`](https://github.com/nix-community/home-manager/commit/1b4f2a48168b3d90e11365552d1e7e601a4be6b6) | `` zed-editor: add installRemoteServer option ``                  |
| [`0a64a209`](https://github.com/nix-community/home-manager/commit/0a64a209aa3c0e5ae528b9f25c3c5e9bb735dbb3) | `` flake.lock: Update ``                                          |