### PR TITLE
chore(flake/home-manager): `420a0d95` -> `697ba131`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738178313,
-        "narHash": "sha256-/8TLf6LkXGRGERzcWMNDeXjYaHSbexmfV+ofheo7K6k=",
+        "lastModified": 1738192575,
+        "narHash": "sha256-2DFgkx6GgLqYyTR/wtEk+EiMiAuFZo7D4LfKjTDKLTc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "420a0d9506b5dac4d86a68b9ef8e763624ad86c6",
+        "rev": "697ba1319fdc58c94dc94cd7908df554dc48d970",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
| [`697ba131`](https://github.com/nix-community/home-manager/commit/697ba1319fdc58c94dc94cd7908df554dc48d970) | `` waybar: allow setting systemd.target to null (#6241) ``                                                 |
| [`6fbbfb92`](https://github.com/nix-community/home-manager/commit/6fbbfb92409bf999fd80b78c7f7bc145d2d36f39) | `` Revert "thunderbird: add native host support (#6292)" (#6371) ``                                        |
| [`79eff1f6`](https://github.com/nix-community/home-manager/commit/79eff1f6b95c059ed0f9dfae9fd16689c1dda5ca) | `` zsh: added HIST_SAVE_NO_DUPS and HIST_FIND_NO_DUPS options to zsh for history configuration. (#6227) `` |
| [`6aa38ffd`](https://github.com/nix-community/home-manager/commit/6aa38ffdf77fb4250f5d832fd5a09eb99226fba7) | `` atuin: set socket path for darwin (#6248) ``                                                            |
| [`608b26d1`](https://github.com/nix-community/home-manager/commit/608b26d16ee69384580b1b14ac947d81d0240beb) | `` thunderbird: add native host support (#6292) ``                                                         |
| [`d5e5c0d0`](https://github.com/nix-community/home-manager/commit/d5e5c0d051d8d4f293d8c7550c167597427e058b) | `` aerospace: add module (#6279) ``                                                                        |