### PR TITLE
chore(flake/home-manager): `697ba131` -> `86a0d627`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738192575,
-        "narHash": "sha256-2DFgkx6GgLqYyTR/wtEk+EiMiAuFZo7D4LfKjTDKLTc=",
+        "lastModified": 1738200030,
+        "narHash": "sha256-z2DVxun8fEH0yeVIyfL68hXht+k2h3vEwNVxJPOMCgU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "697ba1319fdc58c94dc94cd7908df554dc48d970",
+        "rev": "86a0d627cae02e8cc5d29eeb03de97f8c652a4bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`86a0d627`](https://github.com/nix-community/home-manager/commit/86a0d627cae02e8cc5d29eeb03de97f8c652a4bb) | `` home-manger: fix runtime closure (#5174) ``       |
| [`9ce5d0b8`](https://github.com/nix-community/home-manager/commit/9ce5d0b888a054945121394297ad34173d135547) | `` xdg-autostart: add module (#5251) ``              |
| [`7636b248`](https://github.com/nix-community/home-manager/commit/7636b248675e00d887ec0e6932c316d87f36dbf3) | `` hyprland: make package nullable (#5742) ``        |
| [`ba3338ab`](https://github.com/nix-community/home-manager/commit/ba3338ab990e4348a4e57fc4fdac758524cf7029) | `` waybar: allow setting layer to overlay (#5729) `` |