### PR TITLE
chore(flake/lovesegfault-vim-config): `aebddca7` -> `ebfd73e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738109275,
-        "narHash": "sha256-5robmBwbptH4/Gf5+cExC6qPI/A7jL/zWwYL6ra8vTU=",
+        "lastModified": 1738255561,
+        "narHash": "sha256-0mm0l4BpXkJaJVdu5EDjR9+Rc+yflY7WKrBXQIFPkFw=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "aebddca75ebe2657f735166838da7a0fd7010d05",
+        "rev": "ebfd73e554c4417036d700719c10ff59d3f0aea9",
         "type": "github"
       },
       "original": {
@@ -633,11 +633,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738106190,
-        "narHash": "sha256-woDlUpfK4n1znQfGREKDLMVOQ4JZo7L6YY/sTPZGw0g=",
+        "lastModified": 1738188154,
+        "narHash": "sha256-2C0rEZ1l/X3nCwaQtulTXkmREZ/46TdWLYv1+BiCx3U=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "eeafe2a7153197982ccd6ad6678192bca1df446e",
+        "rev": "f584d1d70d36cd29d45abce91776f8425398a97f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`ebfd73e5`](https://github.com/lovesegfault/vim-config/commit/ebfd73e554c4417036d700719c10ff59d3f0aea9) | `` chore(flake/nixvim): eeafe2a7 -> f584d1d7 `` |