### PR TITLE
chore(flake/home-manager): `bf2a029b` -> `a8159195`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738266157,
-        "narHash": "sha256-nUfADd/h6YwGQWQB9pmT8dVkkQpfPG+gU6PVwCZmGzE=",
+        "lastModified": 1738275749,
+        "narHash": "sha256-PM+cGduJ05EZ+YXulqAwUFjvfKpPmW080mcuN6R1POw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bf2a029bcde2e223db10a0a3fb9a94dc9e833d75",
+        "rev": "a8159195bfaef3c64df75d3b1e6a68d49d392be9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`a8159195`](https://github.com/nix-community/home-manager/commit/a8159195bfaef3c64df75d3b1e6a68d49d392be9) | `` flake-module: fix naming ``              |
| [`234613d7`](https://github.com/nix-community/home-manager/commit/234613d77c939ff2e2c0f2c476a56d80930e5b8b) | `` neovim: remove with lib ``               |
| [`86b0f304`](https://github.com/nix-community/home-manager/commit/86b0f3049c3a5f3e8ec13a54a323ed3e2587ed93) | `` hyprland: add null package tests ``      |
| [`fee01c93`](https://github.com/nix-community/home-manager/commit/fee01c9351638a67ec8605a43f2e535c1c66266f) | `` hyprland: fix null package conditions `` |
| [`e3baf274`](https://github.com/nix-community/home-manager/commit/e3baf274f47678df6289c7482353cb6d38b7be5d) | `` bat: remove with lib ``                  |
| [`c90cd85b`](https://github.com/nix-community/home-manager/commit/c90cd85b04ff3348978b05ba73ffc8e1b74b9fce) | `` kitty: remove with lib ``                |
| [`2d731a33`](https://github.com/nix-community/home-manager/commit/2d731a33b193209cb88b874e508ea912765f7d99) | `` wezterm: remove with lib ``              |
| [`20fd9686`](https://github.com/nix-community/home-manager/commit/20fd9686b85dc64657a176466e23d0f3a5e1f760) | `` btop: remove with lib; ``                |