### PR TITLE
chore(flake/home-manager): `a8159195` -> `801ddd86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738275749,
-        "narHash": "sha256-PM+cGduJ05EZ+YXulqAwUFjvfKpPmW080mcuN6R1POw=",
+        "lastModified": 1738378034,
+        "narHash": "sha256-mldSa2NhDlnjqeSSFTNnkXIDrCLltpJfhrHUMBBKEiY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a8159195bfaef3c64df75d3b1e6a68d49d392be9",
+        "rev": "801ddd8693481866c2cfb1efd44ddbae778ea572",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`801ddd86`](https://github.com/nix-community/home-manager/commit/801ddd8693481866c2cfb1efd44ddbae778ea572) | `` hyprland: use package stubs ``                          |
| [`9afd0220`](https://github.com/nix-community/home-manager/commit/9afd02201332756d4bbad273202ecc96049c53b2) | `` wayfire-stubs: add stubs for wayfire tests ``           |
| [`c4f28f28`](https://github.com/nix-community/home-manager/commit/c4f28f282f54fc15a60a3b258ecce77a44327958) | `` spectrwm-stubs: add stubs for spectrwm tests ``         |
| [`e17bdf31`](https://github.com/nix-community/home-manager/commit/e17bdf3191ad5f94c4037117f5635c8b1138c730) | `` herbstluftwm-stubs: add stubs for herbstluftwm tests `` |
| [`c4f4b1e2`](https://github.com/nix-community/home-manager/commit/c4f4b1e2fa335844aaa98d65066a5a434fa9ce22) | `` bspwm-stubs: add stubs for bspwm tests ``               |
| [`02dc2e82`](https://github.com/nix-community/home-manager/commit/02dc2e827f7c677cad1a4cbfcb7ad01728424351) | `` river-stubs: add stubs for river tests ``               |
| [`e0a2df31`](https://github.com/nix-community/home-manager/commit/e0a2df319302e975a6c8f7fc940315f425b337e8) | `` i3-stubs: add more stubs ``                             |
| [`64455251`](https://github.com/nix-community/home-manager/commit/644552519e74bde9c21ea7ec473d5eee67915d25) | `` sway-stubs: add more stubs ``                           |