### PR TITLE
chore(flake/nix-index-database): `79b7b8ea` -> `46a8f5fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737861961,
-        "narHash": "sha256-LIRtMvAwLGb8pBoamzgEF67oKlNPz4LuXiRPVZf+TpE=",
+        "lastModified": 1738466368,
+        "narHash": "sha256-PZhUjtvQZOH3PO0EYdTpQvcqkgkq1NkP2A6w9SPHYsk=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "79b7b8eae3243fc5aa9aad34ba6b9bbb2266f523",
+        "rev": "46a8f5fc9552b776bfc5c5c96ea3bede33f68f52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`46a8f5fc`](https://github.com/nix-community/nix-index-database/commit/46a8f5fc9552b776bfc5c5c96ea3bede33f68f52) | `` update generated.nix to release 2025-02-02-030235 `` |
| [`9000a22f`](https://github.com/nix-community/nix-index-database/commit/9000a22fbd820eedba37fc29a4b9652bfc3068c2) | `` flake.lock: Update ``                                |