### PR TITLE
chore(flake/lovesegfault-vim-config): `4d159cf9` -> `6299dcab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738454875,
-        "narHash": "sha256-vWbYd/njkKZhVyE6481X6oR4gXriMAKQRaGoOz1NTMM=",
+        "lastModified": 1738532209,
+        "narHash": "sha256-SXUJHKpUp51kkDpYdka5JmiWHoFqbLkfGUKVfGzpRkY=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "4d159cf978006edcf8f81eb6d9e9e255b0f80082",
+        "rev": "6299dcab62349aa18d55dcfd1d652bef71b51950",
         "type": "github"
       },
       "original": {
@@ -633,11 +633,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738451863,
-        "narHash": "sha256-JXA/ffSl42rZjqUgBq1I5C3NVYrFaTw8pGHca54QMis=",
+        "lastModified": 1738528611,
+        "narHash": "sha256-GRyyVXM/0pYnA8voPGZWTi9zDVkIO9O1fzA8cB4oO50=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2b03933101012cc5830d5dd7167d4544902a51b1",
+        "rev": "c284a509952eee265519674e67e70e73ddcbfd05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`6299dcab`](https://github.com/lovesegfault/vim-config/commit/6299dcab62349aa18d55dcfd1d652bef71b51950) | `` chore(flake/nixpkgs): 9d3ae807 -> 3a228057 `` |
| [`d37108ba`](https://github.com/lovesegfault/vim-config/commit/d37108ba133258293dccfb5379c41e50b4077b5c) | `` chore(flake/nixvim): 2b039331 -> c284a509 ``  |
| [`2dcc2d9c`](https://github.com/lovesegfault/vim-config/commit/2dcc2d9c260bff1046ce9d62491c078408262c59) | `` ci: move arm to ubuntu 22.04 ``               |