### PR TITLE
chore(flake/stylix): `b00c9f46` -> `d513f59d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -724,11 +724,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1738278499,
-        "narHash": "sha256-q1SUyXSQ9znHTME53/vPLe+Ga3V1wW3X3gWfa8JsBUM=",
+        "lastModified": 1738611626,
+        "narHash": "sha256-IgjqlYPaS8Bg+jc6a691w27XDFhBeM7gkP4eDcR2EBs=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "b00c9f46ae6c27074d24d2db390f0ac5ebcc329f",
+        "rev": "d513f59da5856978c363d2f82103f708f4a6024d",
         "type": "github"
       },
       "original": {

--- a/users/bemeurer/graphical/linux.nix
+++ b/users/bemeurer/graphical/linux.nix
@@ -39,14 +39,7 @@
     gtk3.extraConfig.gtk-application-prefer-dark-theme = true;
   };
 
-  qt = {
-    enable = true;
-    platformTheme.name = "adwaita";
-    style = {
-      name = "adwaita";
-      package = pkgs.adwaita-qt;
-    };
-  };
+  qt.enable = true;
 
   services = {
     gpg-agent.pinentryPackage = pkgs.pinentry-gnome3;


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                    |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`d513f59d`](https://github.com/danth/stylix/commit/d513f59da5856978c363d2f82103f708f4a6024d) | `` stylix: update and simplify flake-compat instructions (#816) ``         |
| [`bae5cbb8`](https://github.com/danth/stylix/commit/bae5cbb8fb36bd74c5303df4f9727e640a15b10b) | `` doc: expand description of font units (#819) ``                         |
| [`596d6644`](https://github.com/danth/stylix/commit/596d6644077d6d25ff713e93b55efc867979959d) | `` kde: correct quotes in stylix-activate-kde to prevent failure (#832) `` |
| [`8be2aed2`](https://github.com/danth/stylix/commit/8be2aed2950ed7a0e0dcc270d74f28b6600c1e59) | `` qt: fix qt6ct directory name (#830) ``                                  |
| [`b7f50a56`](https://github.com/danth/stylix/commit/b7f50a56c3ccda1e6020e62b77a9f9ea80d6a656) | `` qt: add flexible theming with sensible defaults (#780) ``               |