### PR TITLE
chore(flake/disko): `18d0a984` -> `ff356885`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738148035,
-        "narHash": "sha256-KYOATYEwaKysL3HdHdS5kbQMXvzS4iPJzJrML+3TKAo=",
+        "lastModified": 1738765162,
+        "narHash": "sha256-3Z40qHaFScWUCVQrGc4Y+RdoPsh1R/wIh+AN4cTXP0I=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "18d0a984cc2bc82cf61df19523a34ad463aa7f54",
+        "rev": "ff3568858c54bd306e9e1f2886f0f781df307dff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`ff356885`](https://github.com/nix-community/disko/commit/ff3568858c54bd306e9e1f2886f0f781df307dff) | `` style: make it prettier ``                                          |
| [`68ef26bb`](https://github.com/nix-community/disko/commit/68ef26bb78dd4e6298bd273362a1f89a14beccc1) | `` fix: use zfs kernel module which corresponds to user-space tools `` |