### PR TITLE
chore(flake/home-manager): `30ea6fed` -> `f99c704f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738789832,
-        "narHash": "sha256-HdlMPfObPu5y7oDfH/w3vvlU3UTQ/bQjSULChZARm5M=",
+        "lastModified": 1738841109,
+        "narHash": "sha256-sEgE3nifaRU5gfAx33ds0tx/j+qM0/5/bHopv/w6c0c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "30ea6fed4e4b41693cebc2263373dd810de4de49",
+        "rev": "f99c704fe3a4cf8d72b2d568ec80bc38be1a9407",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`f99c704f`](https://github.com/nix-community/home-manager/commit/f99c704fe3a4cf8d72b2d568ec80bc38be1a9407) | `` bash: Make sure HISTFILE's directory exists ``  |
| [`15bd6736`](https://github.com/nix-community/home-manager/commit/15bd673658c189491cd896f06b3dd8f09bb0dfe4) | `` firefox: remove old unused test file (#6403) `` |