### PR TITLE
chore(flake/nixpkgs): `550e11f2` -> `a3eaf5e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -571,11 +571,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738824222,
-        "narHash": "sha256-U3SNq+waitGIotmgg/Et3J7o4NvUtP2gb2VhME5QXiw=",
+        "lastModified": 1738961098,
+        "narHash": "sha256-yWNBf6VDW38tl179FEuJ0qukthVfB02kv+mRsfUsWC0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "550e11f27ba790351d390d9eca3b80ad0f0254e7",
+        "rev": "a3eaf5e8eca7cab680b964138fb79073704aca75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`830a2ca7`](https://github.com/NixOS/nixpkgs/commit/830a2ca72eb06ff87c1f851cec637feaedebd30f) | `` vangers: init at 2.0-unstable-2024-09-30 ``                                      |
| [`e8d0b02a`](https://github.com/NixOS/nixpkgs/commit/e8d0b02af0958823c955aaab3c82b03f54411d91) | `` Add rocqPackages.bignums ``                                                      |
| [`b34fef32`](https://github.com/NixOS/nixpkgs/commit/b34fef3268597e3f4b42364914cb6178569dbe5f) | `` coq: now a shim on top of rocq (starting with 9.0) ``                            |
| [`064a3047`](https://github.com/NixOS/nixpkgs/commit/064a30473b2aa7cf3b9f0346bad5a5506a9a62b0) | `` rocq: init at 9.0+rc1 ``                                                         |
| [`182fd631`](https://github.com/NixOS/nixpkgs/commit/182fd63145b3b172dc93ef406195d526959a1fa2) | `` lua51Packages.luarocks-nix: 0-unstable-2024-04-29 -> 0-unstable-2024-05-31 ``    |
| [`547acecd`](https://github.com/NixOS/nixpkgs/commit/547acecdf336bfda4e3d355657e066269b57455d) | `` teamspeak5_client: 5.0.0-beta77 -> 6.0.0-beta2; teamspeak refactors (#377748) `` |
| [`651df657`](https://github.com/NixOS/nixpkgs/commit/651df657551ae52ae343be55539970758cfaef38) | `` nextcloudPackages.hmr_enabler: switch to buildComposerProject2 (#380114) ``      |
| [`35390c3d`](https://github.com/NixOS/nixpkgs/commit/35390c3d7470d075081fc8cb9926b416a7fbc248) | `` davis: switch to buildComposerProject2 (#380098) ``                              |
| [`3aaea786`](https://github.com/NixOS/nixpkgs/commit/3aaea78679c68616fbf11a424460134fc6822c8e) | `` fastjet-contrib: 1.055 -> 1.100 ``                                               |
| [`3a3f931f`](https://github.com/NixOS/nixpkgs/commit/3a3f931fd25e5f46ebc138430f64cbb7d05fe1ef) | `` invoiceplane: switch to buildComposerProject2 and tag (#380112) ``               |
| [`6431bc14`](https://github.com/NixOS/nixpkgs/commit/6431bc1445447eee455a7b713b5eb3f67f326e05) | `` vscode:1.96.4 -->1.97.0 (#379962) ``                                             |
| [`58d0c70e`](https://github.com/NixOS/nixpkgs/commit/58d0c70e7abddae2eac04762e0d537e5ca091640) | `` gparted: 1.6.0 -> 1.7.0 ``                                                       |
| [`192a5218`](https://github.com/NixOS/nixpkgs/commit/192a52188cb7a31dd8482acb438e793f53d5d98e) | `` gpt4all: 3.4.2 -> 3.9.0 ``                                                       |
| [`bd44651c`](https://github.com/NixOS/nixpkgs/commit/bd44651c90b20cf4e9dedeedacc08ba5df2287d1) | `` projectable: 1.3.0 -> 1.3.2 ``                                                   |
| [`1abd560a`](https://github.com/NixOS/nixpkgs/commit/1abd560a083afc717c74a8426fc435631d39f66c) | `` duckx: init at 1.2.2 ``                                                          |
| [`a436a9dd`](https://github.com/NixOS/nixpkgs/commit/a436a9dd6d6164ccc7cdd28c82809856bf17551d) | `` string-view-lite: init at 1.8.0 ``                                               |
| [`22d656db`](https://github.com/NixOS/nixpkgs/commit/22d656db36abc30512136328e43426a48c5fac8e) | `` optional-lite: init at 3.6.0 ``                                                  |
| [`77ad0f57`](https://github.com/NixOS/nixpkgs/commit/77ad0f574f6dfb8d5c8d39d8cc1ae96c723b36db) | `` variant-lite: init at 2.0.0 ``                                                   |
| [`2d9b8fe5`](https://github.com/NixOS/nixpkgs/commit/2d9b8fe5d3a044d58f219544045eea6c422dfa3c) | `` composefs: 1.0.7 -> 1.0.8 ``                                                     |
| [`800da9b6`](https://github.com/NixOS/nixpkgs/commit/800da9b609ddaf3c00f34fe9560978414584f137) | `` python313Packages.ocrmypdf: use headless ghostscript ``                          |
| [`4f59e814`](https://github.com/NixOS/nixpkgs/commit/4f59e814255edba848689be6a7b7cb6719ce1398) | `` gnome-graphs: 1.8.2 -> 1.8.4 ``                                                  |
| [`d5d0d5a9`](https://github.com/NixOS/nixpkgs/commit/d5d0d5a96e2b89f14c817c47535f5581e258944e) | `` trunk-io: add meta.MainProgram ``                                                |
| [`8af087b4`](https://github.com/NixOS/nixpkgs/commit/8af087b47c875cae57139adfd6a96fff7b42ce78) | `` wireplumber: 0.5.7 -> 0.5.8 ``                                                   |
| [`36078884`](https://github.com/NixOS/nixpkgs/commit/3607888438881d7a182560e967c11f9896b950dd) | `` gancio: 1.22.0 -> 1.23.1 ``                                                      |
| [`9527ead8`](https://github.com/NixOS/nixpkgs/commit/9527ead890f07a6a343cb65ecebe80221dbb47a1) | `` vimPlugins.telescope-glyph-nvim: init at 2022-08-22 ``                           |
| [`670a9eee`](https://github.com/NixOS/nixpkgs/commit/670a9eeeb11e226a3b15cfe1ff0c44500789dd4b) | `` mieru: 3.11.1 -> 3.11.2 ``                                                       |
| [`e9394294`](https://github.com/NixOS/nixpkgs/commit/e93942948aa4091bbce5d658d065915f17b0977b) | `` vimPlugins.telescope-emoji-nvim: init at 2022-12-08 ``                           |
| [`5f2795bd`](https://github.com/NixOS/nixpkgs/commit/5f2795bdaee658fffbcad034378d86ba7a03bd31) | `` nextcloudPackages.apps: add sociallogin ``                                       |
| [`7ba831bc`](https://github.com/NixOS/nixpkgs/commit/7ba831bcd119c38e26e48646b157d63c640b0daa) | `` nextcloudPackages.apps: add files_retention ``                                   |
| [`c9166470`](https://github.com/NixOS/nixpkgs/commit/c91664705434fe31350d1adaefc3d8daf2513030) | `` nextcloudPackages.apps: add files_automatedtagging ``                            |
| [`d0ec1ddc`](https://github.com/NixOS/nixpkgs/commit/d0ec1ddc0e9f188d716405b995466cf3376b70ec) | `` nextcloudPackages.apps: add app_api ``                                           |
| [`aa5f054f`](https://github.com/NixOS/nixpkgs/commit/aa5f054f25d5afe378af7cecd465161a4ef7a179) | `` nextcloudPackages.apps: update ``                                                |
| [`93c1978b`](https://github.com/NixOS/nixpkgs/commit/93c1978b59862807cd9c3856117becae58fa355d) | `` lxgw-wenkai-tc: 1.501 -> 1.510 ``                                                |
| [`a55ff0c1`](https://github.com/NixOS/nixpkgs/commit/a55ff0c1edac7f7cfc2a352e3b8505cc157da42f) | `` python312Packages.experiment-utilities: fix build ``                             |
| [`298e6c47`](https://github.com/NixOS/nixpkgs/commit/298e6c473edb37adcd50b7e9295ac9dbe94d0e1e) | `` php84Extensions.mysqlnd: enable `--with-mysqlnd-ssl` flag ``                     |
| [`4455338f`](https://github.com/NixOS/nixpkgs/commit/4455338f9e38b677d671ccc86a3120b4f0abdfad) | `` vpl-gpu-rt: 25.1.0 -> 25.1.1 ``                                                  |
| [`40cb5a99`](https://github.com/NixOS/nixpkgs/commit/40cb5a996cced79ad4beef8df9ac5ee154cb54f4) | `` astroterm: 1.0.6 -> 1.0.7 ``                                                     |
| [`be389e61`](https://github.com/NixOS/nixpkgs/commit/be389e61bec01cf5c9435868affe329fc61c76c9) | `` twm: 0.11.0 -> 0.12.3 ``                                                         |
| [`dc81385e`](https://github.com/NixOS/nixpkgs/commit/dc81385ef189ce7d84492184d514db9f903f2c39) | `` walk: 1.10.0 -> 1.10.1 ``                                                        |
| [`9eea4de7`](https://github.com/NixOS/nixpkgs/commit/9eea4de768ad7220a61cd723ac495676b75a888d) | `` radicle-httpd: 0.18.0 -> 0.18.1 ``                                               |
| [`05e45b51`](https://github.com/NixOS/nixpkgs/commit/05e45b5131a468fe238ca35dff68941525c918e7) | `` television: 0.10.2 -> 0.10.4 ``                                                  |
| [`e8345e3d`](https://github.com/NixOS/nixpkgs/commit/e8345e3d1b53963f1d6b7ea0f28249eac5c3b63a) | `` release-cuda: add vllm ``                                                        |
| [`cfd3cd93`](https://github.com/NixOS/nixpkgs/commit/cfd3cd93d9eec12664bbd7fdfbe976682e9dde29) | `` grocy: switch to tag ``                                                          |
| [`f3e34484`](https://github.com/NixOS/nixpkgs/commit/f3e34484a4df1c10af4a58fbf66939c918d41cdf) | `` grocy: switch to buildComposerProject2 ``                                        |
| [`79aa62f5`](https://github.com/NixOS/nixpkgs/commit/79aa62f5f10bdc7f57c8d88623ae2006fcd40104) | `` python313Packages.aiomqtt: fix broken condition ``                               |
| [`f2d6fedd`](https://github.com/NixOS/nixpkgs/commit/f2d6feddeb1726f9b362038ac70dda28cec2328f) | `` pixelfed: switch to tag ``                                                       |
| [`ed17d529`](https://github.com/NixOS/nixpkgs/commit/ed17d529a8bfb7ee642b09fc032e76de5628586c) | `` pixelfed: switch to buildComposerProject2 ``                                     |
| [`65cb8da1`](https://github.com/NixOS/nixpkgs/commit/65cb8da1ef2d869eecdc8b91426ef3ee730f49e5) | `` roon-server: 2.0-1483 -> 2.0-1496 ``                                             |
| [`9674800b`](https://github.com/NixOS/nixpkgs/commit/9674800b20025c5dded8cc37fea9630717bc360c) | `` debootstrap: Add util-linux to bin path (#380066) ``                             |
| [`5917b52a`](https://github.com/NixOS/nixpkgs/commit/5917b52a1fb8a5eac11725b0920f9cba4aef6e24) | `` picocrypt: 1.45 → 1.46 (#377776) ``                                              |
| [`f76e8263`](https://github.com/NixOS/nixpkgs/commit/f76e8263836d5d07604889de30c2e83950a96095) | `` rectangle: 0.85 -> 0.86 ``                                                       |
| [`af4ce091`](https://github.com/NixOS/nixpkgs/commit/af4ce091cfcdb6ddcc1fe967fca2cd9f91c44a22) | `` rectangle: quote paths ``                                                        |
| [`94748ce2`](https://github.com/NixOS/nixpkgs/commit/94748ce2764a6e2d952ff6786ed9700337c808dc) | `` rectangle: `gitUpdater` -> `nix-update-script` ``                                |
| [`b92c4b3d`](https://github.com/NixOS/nixpkgs/commit/b92c4b3df62f9db3045d6e15da1e63c5930e8fd3) | `` rectangle: refactor `meta` ``                                                    |
| [`c9c945c6`](https://github.com/NixOS/nixpkgs/commit/c9c945c64d0506621291ddee9c263008fb361618) | `` rectangle: `rec` -> `finalAttrs` ``                                              |
| [`0acd0550`](https://github.com/NixOS/nixpkgs/commit/0acd0550648a8f97dfbe880445d1736ee6affad9) | `` agorakit: switch to tag ``                                                       |
| [`e34a63e2`](https://github.com/NixOS/nixpkgs/commit/e34a63e2b4ff0efc0e2d48974cd379ec1ecbb1ab) | `` agorakit: switch to buildComposerProject2 ``                                     |
| [`5b0503aa`](https://github.com/NixOS/nixpkgs/commit/5b0503aa4d93510b932fed8ee04ee28d67579bab) | `` ispc: 1.25.3 -> 1.26.0 ``                                                        |
| [`784baa4f`](https://github.com/NixOS/nixpkgs/commit/784baa4f19daf7a50c4ac1bff9fe01c63981dbbe) | `` bird: change alias back to bird2 ``                                             |
| [`f29f4411`](https://github.com/NixOS/nixpkgs/commit/f29f4411339c4f1d472483d627b8b28213e60f93) | `` Remove lib.mdDoc and add missing backticks ``                                    |
| [`4e7d2e34`](https://github.com/NixOS/nixpkgs/commit/4e7d2e3440b0e0d593e62852a213ac74c1a145c9) | `` bsc: 3.3.4 -> 3.3.5 ``                                                           |
| [`dc180c48`](https://github.com/NixOS/nixpkgs/commit/dc180c48b4be451e54a25e61d2f603613c284723) | `` yazi-unwrapped: 0.4.2 -> 25.2.7 (#380069) ``                                     |
| [`bd9b05fd`](https://github.com/NixOS/nixpkgs/commit/bd9b05fdf3c0b88d3e1f334ac7315acf26eb8e7e) | `` Revert "python3Packages.mitmproxy: 11.0.2 -> 11.1.0" ``                          |
| [`5fddd980`](https://github.com/NixOS/nixpkgs/commit/5fddd980c9abfed4d0b0065ed6d7ed9dc9f2a4e5) | `` python3Packages.vllm: 0.7.1 -> 0.7.2 ``                                          |
| [`e944a26c`](https://github.com/NixOS/nixpkgs/commit/e944a26c8b28144ba7a07c15b888f136d818dda8) | `` mergiraf: 0.4.0 -> 0.5.0 (#379972) ``                                            |
| [`f1b30a0d`](https://github.com/NixOS/nixpkgs/commit/f1b30a0daefb2376c7cfc0634b854b53d7947181) | `` virtualboxKvm: 20241220 -> 20250207 ``                                           |
| [`4e9df596`](https://github.com/NixOS/nixpkgs/commit/4e9df5961b5fbcccefd5053263058057f8a226fc) | `` xray: 25.1.1 -> 25.1.30 ``                                                       |
| [`bd8cd40f`](https://github.com/NixOS/nixpkgs/commit/bd8cd40fa1a968fbae6d332186a4a24a031a2ac4) | `` Revert "ispc: 1.25.3 -> 1.26.0" ``                                               |
| [`9ece690e`](https://github.com/NixOS/nixpkgs/commit/9ece690ebf6cba81a39c18b65739aa6d24445b98) | `` Add recyclarr module to module list and release notes ``                         |
| [`f8acbc6e`](https://github.com/NixOS/nixpkgs/commit/f8acbc6ee23be8fbb79ecd525aa51c84c5176991) | `` git-pw: 2.7.0 -> 2.7.1 ``                                                        |
| [`87419c8a`](https://github.com/NixOS/nixpkgs/commit/87419c8ae5fa4951a5ba6e646d61c7c1b2e21b5e) | `` nm-file-secret-agent: v1.0.0 -> v1.0.1 ``                                        |
| [`a09e851d`](https://github.com/NixOS/nixpkgs/commit/a09e851dc4f6327d847c8a6a2f34e82317b534d6) | `` playwright: 1.48.1 -> 1.50.1 ``                                                  |
| [`416b239a`](https://github.com/NixOS/nixpkgs/commit/416b239a170698d7e931460de88d948aa32d9308) | `` firebase-tools: 13.29.3 -> 13.30.0 ``                                            |
| [`f21a0ce4`](https://github.com/NixOS/nixpkgs/commit/f21a0ce4e03ea63dddb1fe86cdc425b0991b19ea) | `` python3Packages.devtools: relax asttokens dependency ``                          |
| [`468dbb51`](https://github.com/NixOS/nixpkgs/commit/468dbb51600b7eae629c18701b96626721297b9b) | `` python3Packages.gguf: add sentencepiece dependency ``                            |
| [`a658f75c`](https://github.com/NixOS/nixpkgs/commit/a658f75c7920e9c18ea0a9c801b2421cd05cbd51) | `` terraform-providers.aws: 5.84.0 -> 5.86.0 ``                                     |
| [`dc9a868c`](https://github.com/NixOS/nixpkgs/commit/dc9a868cc1444e953336af188bff8a5fe180883d) | `` spatialite_tools: fix build ``                                                   |
| [`58caa683`](https://github.com/NixOS/nixpkgs/commit/58caa683ded998372e698e83be2a3969a74840ca) | `` bold: init at 0.1.0 ``                                                           |
| [`271bbf8f`](https://github.com/NixOS/nixpkgs/commit/271bbf8f6e56b2a5e7c05a8a2c7de40fa7a0562a) | `` virtiofsd: 1.13.0 -> 1.13.1 ``                                                   |
| [`e958b1f7`](https://github.com/NixOS/nixpkgs/commit/e958b1f7cd40b6ef2020ea6176844e801ca33e01) | `` ctags-lsp: init at 0.6.1 ``                                                      |
| [`8f921e44`](https://github.com/NixOS/nixpkgs/commit/8f921e444375246da81cfd437bbe3d5f04af66ef) | `` vimPlugins.roslyn-nvim: switch to maintained fork ``                             |
| [`6115a5a8`](https://github.com/NixOS/nixpkgs/commit/6115a5a8f9f3996008cd4b5c516f1dc8b0e1ebaf) | `` zigpy-cli: 1.0.5 -> 1.1.0 ``                                                     |
| [`f1f88005`](https://github.com/NixOS/nixpkgs/commit/f1f880057526a5ed5af4b3f0390853c8dec38daf) | `` terraform-providers.google: 6.17.0 -> 6.19.0 ``                                  |
| [`93769921`](https://github.com/NixOS/nixpkgs/commit/93769921f9b53b071e29b07d05834ae9ab816ada) | `` ocamlPackages.vg: 0.9.4 → 0.9.5 ``                                               |
| [`1d509968`](https://github.com/NixOS/nixpkgs/commit/1d509968e75a89b54cc32d58fe92c8665fa77219) | `` ocamlPackages.postgresql: 5.0.0 → 5.1.3 ``                                       |
| [`5bb6b515`](https://github.com/NixOS/nixpkgs/commit/5bb6b5153e4462591792aa9160d430dd7b964f69) | `` tigerbeetle: 0.16.23 -> 0.16.26 ``                                               |
| [`e22015f2`](https://github.com/NixOS/nixpkgs/commit/e22015f23aacf09821f417da53aa8314f406da1a) | `` ast-grep: 0.34.3 -> 0.34.4 ``                                                    |
| [`16a6d2d8`](https://github.com/NixOS/nixpkgs/commit/16a6d2d8bea72e28aad10e360ed71e6081254edf) | `` tooling-language-server: init at 0.4.2 ``                                        |
| [`521bf766`](https://github.com/NixOS/nixpkgs/commit/521bf766baef4524b6e73b4342d7f04800a7bd50) | `` sigma-cli: 1.0.4 -> 1.0.5 ``                                                     |
| [`16b2a1ce`](https://github.com/NixOS/nixpkgs/commit/16b2a1ce171853fe0c315a412d66eb0156c9c559) | `` trufflehog: 3.88.3 -> 3.88.5 ``                                                  |
| [`752e1713`](https://github.com/NixOS/nixpkgs/commit/752e17132afa2e510af4cb3d8302a553164d6575) | `` python313Packages.tencentcloud-sdk-python: 3.0.1313 -> 3.0.1314 ``               |
| [`19b71a5b`](https://github.com/NixOS/nixpkgs/commit/19b71a5bfbd3962b3f295530fc5f9deb76d3d502) | `` microsocks: 1.0.4 -> 1.0.5 ``                                                    |
| [`c3327e7f`](https://github.com/NixOS/nixpkgs/commit/c3327e7f5e2257ed73dd85c29644839ff2b3351a) | `` python312Packages.dnachisel: 3.2.12 -> 3.2.13 ``                                 |
| [`82c06a7b`](https://github.com/NixOS/nixpkgs/commit/82c06a7b9f4095868a4e0d0b3965fe4128226716) | `` trivy: 0.59.0 -> 0.59.1 ``                                                       |
| [`236928dc`](https://github.com/NixOS/nixpkgs/commit/236928dc802cb5ec2c7e89d5eff24a435c32f537) | `` spyder: 6.0.3 -> 6.0.4 ``                                                        |
| [`1d466616`](https://github.com/NixOS/nixpkgs/commit/1d46661697380f575f9e75e01c4ad350d67b33b2) | `` python312Packages.spyder-kernels: 3.0.2 -> 3.0.3 ``                              |
| [`fcbfaf35`](https://github.com/NixOS/nixpkgs/commit/fcbfaf3528eae27b9eefb52ce457fdab5cf7e1c2) | `` python312Packages.numpyro: 0.16.1 -> 0.17.0 ``                                   |
| [`4cb1615d`](https://github.com/NixOS/nixpkgs/commit/4cb1615d3d9f0b08000cf94de5a68da39cca8b8d) | `` flarectl: 0.114.0 -> 0.115.0 ``                                                  |
| [`5f14a647`](https://github.com/NixOS/nixpkgs/commit/5f14a6470b33d1e7ff871cdc5c7ab9dbff22a087) | `` beam26Packages.elixir-ls: 0.26.2 -> 0.26.4 ``                                    |
| [`411c0ed3`](https://github.com/NixOS/nixpkgs/commit/411c0ed3f5cd459f03e1fa695ce09af67389d1ed) | `` spicedb-zed: 0.25.0 -> 0.26.0 ``                                                 |
| [`41aac754`](https://github.com/NixOS/nixpkgs/commit/41aac7546e648375f70382d56f8166269e6a753a) | `` neovim-node-client: build all workspaces ``                                      |
| [`f55a3ff7`](https://github.com/NixOS/nixpkgs/commit/f55a3ff719354cf6f1786340977764654256bc0e) | `` python312Packages.pbs-installer: 2025.01.06 -> 2025.02.05 ``                     |
| [`214915bc`](https://github.com/NixOS/nixpkgs/commit/214915bc69ffc27906461fab3900dc9265c08180) | `` nak: 0.10.1 -> 0.11.2 ``                                                         |
| [`1940fad7`](https://github.com/NixOS/nixpkgs/commit/1940fad70b34907358bbb0886a6d66f0c5aea25d) | `` ocamlPackages.curses: 1.0.8 → 1.0.11 ``                                          |
| [`50b8034d`](https://github.com/NixOS/nixpkgs/commit/50b8034d31fe0351f014ed80836ab8c524b45e9f) | `` codesnap: 0.8.3 -> 0.10.5 ``                                                     |
| [`0bd2ff33`](https://github.com/NixOS/nixpkgs/commit/0bd2ff337857ad99ea116fb6dbaa67fd3ec7c6b3) | `` python313Packages.langgraph-checkpoint-sqlite: skip bulk update ``               |
| [`6b73d037`](https://github.com/NixOS/nixpkgs/commit/6b73d0375f4e8ff0288f4295d375bacddb1240ca) | `` python313Packages.langgraph-checkpoint-postgres: skip bulk update ``             |
| [`90329415`](https://github.com/NixOS/nixpkgs/commit/903294155dd95bd6fd69189cb5bff595f53389a2) | `` python313Packages.langgraph-checkpoint: skip bulk update ``                      |
| [`ac284547`](https://github.com/NixOS/nixpkgs/commit/ac284547172f6b389e3addb833d95438082f71f4) | `` python313Packages.langgraph-cli: skip bulk update ``                             |
| [`516f5681`](https://github.com/NixOS/nixpkgs/commit/516f5681aebc7d29279608dd53ce7fc40408a3fb) | `` python313Packages.langgraph-sdk: skip bulk update ``                             |
| [`f4b8df61`](https://github.com/NixOS/nixpkgs/commit/f4b8df618bc9b9c5b88e48bec30c3252dfa62987) | `` python313Packages.langgraph: skip bulk update ``                                 |
| [`7c7aca17`](https://github.com/NixOS/nixpkgs/commit/7c7aca17be267e82c67bbf8e40d41f3372a604cd) | `` Revert "python3Packages.langgraph-checkpoint-sqlite: 2.0.1 -> 2.0.13" ``         |
| [`a3b735e1`](https://github.com/NixOS/nixpkgs/commit/a3b735e103c89cebcf8a3cf6f1f444400a404b89) | `` Revert "python3Packages.langgraph-checkpoint: 2.0.8 -> 2.0.13" ``                |
| [`262ba6e5`](https://github.com/NixOS/nixpkgs/commit/262ba6e53cab4036fa7cc6ed17d3630a11d6b91a) | `` Revert "python3Packages.langgraph-cli: 0.1.52 -> 2.0.13" ``                      |
| [`052ec593`](https://github.com/NixOS/nixpkgs/commit/052ec593355c0add5ab5225dfbe6dec62d30b2bc) | `` Revert "python3Packages.langgraph-sdk: 0.1.43 -> 2.0.13" ``                      |
| [`f27475e3`](https://github.com/NixOS/nixpkgs/commit/f27475e3ed162ee31e6d303b1bce732b75e3e8d9) | `` gnomeExtensions.lunar-calendar: fix usability ``                                 |
| [`85717e61`](https://github.com/NixOS/nixpkgs/commit/85717e613037fdc123b2b0961f6b414b78bfa46c) | `` fishPlugins.hydro: 2024-03-24 -> 2024-11-02 ``                                   |
| [`3daa74a2`](https://github.com/NixOS/nixpkgs/commit/3daa74a2211f1a8a7f5923dc510a45bac58ee27c) | `` erlang_nox: 27.2.1 -> 27.2.2 ``                                                  |
| [`29dc0233`](https://github.com/NixOS/nixpkgs/commit/29dc023397f949e26107f68a3d774592de52c2cb) | `` go-judge: 1.8.5 -> 1.8.7 ``                                                      |
| [`6a52de1f`](https://github.com/NixOS/nixpkgs/commit/6a52de1ffffe5747710c472a102293c950423d18) | `` Revert "python3Packages.langgraph: 0.2.56 -> 2.0.13" ``                          |
| [`06f4e972`](https://github.com/NixOS/nixpkgs/commit/06f4e972efa3fe78d8f2ab5d3cd14a1d071f411f) | `` llvmPackages: git -> 21.0.0, init 20.1.0-rc1 ``                                  |
| [`dc306bed`](https://github.com/NixOS/nixpkgs/commit/dc306bed83192452910b45eacf6c64aecee7cd2b) | `` llvmPackages: fix formatting ``                                                  |