### PR TITLE
chore(flake/stylix): `d513f59d` -> `708770fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -724,11 +724,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1738611626,
-        "narHash": "sha256-IgjqlYPaS8Bg+jc6a691w27XDFhBeM7gkP4eDcR2EBs=",
+        "lastModified": 1739029786,
+        "narHash": "sha256-gkdD7+IHBDzVO31Ih83DK9as4CIf4Ru3I6PVVesjQoI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "d513f59da5856978c363d2f82103f708f4a6024d",
+        "rev": "708770fcb045b6efb4c419ff7be9760d010699bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                    |
| --------------------------------------------------------------------------------------------- | -------------------------- |
| [`708770fc`](https://github.com/danth/stylix/commit/708770fcb045b6efb4c419ff7be9760d010699bc) | `` wayfire: init (#765) `` |
| [`b3ef236d`](https://github.com/danth/stylix/commit/b3ef236d22572618828f9e7019362cc89d877bd0) | `` glance: init (#827) ``  |
| [`87791e06`](https://github.com/danth/stylix/commit/87791e0665bd345127b7f35aca6e9195e74ef39c) | `` halloy: init (#825) ``  |