### PR TITLE
chore(flake/stylix): `ff8ce4f3` -> `e72aa84d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -724,11 +724,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1739034502,
-        "narHash": "sha256-A6FBMYEIypFNTRPmLHF2vTGSB85e7skiNvoHJXtFne8=",
+        "lastModified": 1739117494,
+        "narHash": "sha256-HqUir6OE3oNrQRtlLA7oRHkKMGNMKHkAPqG5HFcODK8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ff8ce4f3d2ad4d09291fa079c12a523d9b1c6aa6",
+        "rev": "e72aa84da1c6982c11620a4154ded8c603f33f46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                     |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`e72aa84d`](https://github.com/danth/stylix/commit/e72aa84da1c6982c11620a4154ded8c603f33f46) | `` {vencord,vesktop}: revert attempt to support fonts (#844) ``             |
| [`7818098f`](https://github.com/danth/stylix/commit/7818098f4df4ee73667036c65909cf311d36968b) | `` treewide: remove trailing whitespaces and add trailing newline (#841) `` |
| [`be606eaa`](https://github.com/danth/stylix/commit/be606eaa87dfcf22c98f80453b42ec40dcbcdf36) | `` {vencord,vesktop}: fonts (#840) ``                                       |