### PR TITLE
chore(flake/lovesegfault-vim-config): `c32e4b2e` -> `ad2e0790`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738973476,
-        "narHash": "sha256-lV5MmkDj+M0nxQqax1yMMIgmJ9GwpdSWjIbfZ3+eBHU=",
+        "lastModified": 1739145991,
+        "narHash": "sha256-9LX8n4bVj12ZiaNzEHt2Je3ASx98sTLcQiAL4gP+CfU=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "c32e4b2e1674fd2e627c7ade6f1ce098872ae39c",
+        "rev": "ad2e0790c461d87f22b41d499fe1a32f45047d79",
         "type": "github"
       },
       "original": {
@@ -633,11 +633,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738966895,
-        "narHash": "sha256-OXOh35rTEnFSO4vj/SDMIlDvFPGW0ba1XhZkfx+AlL0=",
+        "lastModified": 1739121491,
+        "narHash": "sha256-BEmyAozR3Pc2qwPtC4rgUglzi3cw4nv4fXEY23NxOrQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e7f20a602f6e08a70045f36c531bc44ba1baed07",
+        "rev": "13341a4c1238b7974e7bad9c7a6d5c51ca3cf81a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`ad2e0790`](https://github.com/lovesegfault/vim-config/commit/ad2e0790c461d87f22b41d499fe1a32f45047d79) | `` chore(flake/nixvim): e7f20a60 -> 13341a4c `` |