### PR TITLE
chore(flake/lanzaboote): `a65905a0` -> `3bdeebbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -442,11 +442,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1737639419,
-        "narHash": "sha256-AEEDktApTEZ5PZXNDkry2YV2k6t0dTgLPEmAZbnigXU=",
+        "lastModified": 1739186342,
+        "narHash": "sha256-2j+sln9RwQn+g7J4GmdFFgvqXnLkvWBNMaUzONlkzUE=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "a65905a09e2c43ff63be8c0e86a93712361f871e",
+        "rev": "3bdeebbc484a09391c4f0ec8a37bb77809426660",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                            |
| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`84933941`](https://github.com/nix-community/lanzaboote/commit/849339412ceacddd2f71742b8491542933ed64a3) | `` docs: Fix nix-collect-garbage command syntax `` |