### PR TITLE
chore(flake/darwin): `0b6f96a6` -> `a36049da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739034224,
-        "narHash": "sha256-Mj/8jDzh1KNmUhWqEeVlW3hO9MZkxqioJGnmR7rivaE=",
+        "lastModified": 1739229629,
+        "narHash": "sha256-zUWKsviMuelgB4PJNJuLZi/yvHnaLb1wZ9mOATjj9eM=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "0b6f96a6b9efcfa8d3cc8023008bcbcd1b9bc1a4",
+        "rev": "a36049dac55b6b00536ce8fb601ad3dd1cd8ba8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                |
| ------------------------------------------------------------------------------------------------ | -------------------------------------- |
| [`c31b6e8a`](https://github.com/LnL7/nix-darwin/commit/c31b6e8a0305fee46238387a3462ec060e377500) | `` homebrew: use `mas` from Nixpkgs `` |