### PR TITLE
chore(flake/home-manager): `ba4a1a11` -> `8f351726`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739233400,
-        "narHash": "sha256-fldFwXHP9Ndy/ADMDWNTpfWNsLdhZ8PP4DQyr1Igfo4=",
+        "lastModified": 1739287084,
+        "narHash": "sha256-CtRNJsqsXIArJV+AKWZVBMO8PD1FQB69br+WMtTJEgI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ba4a1a110204c27805d1a1b5c8b24b3a0da4d063",
+        "rev": "8f351726c5841d86854e7fa6003ea472352f5208",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`8f351726`](https://github.com/nix-community/home-manager/commit/8f351726c5841d86854e7fa6003ea472352f5208) | `` git-worktree-switcher: use lib.hm.shell.mkShellIntegrationOption `` |
| [`9c8169b4`](https://github.com/nix-community/home-manager/commit/9c8169b4466391999b1ad5ea86be4e79d560af52) | `` git-worktree-switcher: init module ``                               |
| [`59fe145f`](https://github.com/nix-community/home-manager/commit/59fe145f0bb7cfde99f148140a47a54deb8cc23f) | `` eww: make configDir optional (#6282) ``                             |