### PR TITLE
chore(flake/darwin): `a36049da` -> `a6746213`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739229629,
-        "narHash": "sha256-zUWKsviMuelgB4PJNJuLZi/yvHnaLb1wZ9mOATjj9eM=",
+        "lastModified": 1739302241,
+        "narHash": "sha256-NXQXFU6HOschZ+8ZKrNOlwlHelez8vPl+dCiUaJ82/U=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "a36049dac55b6b00536ce8fb601ad3dd1cd8ba8c",
+        "rev": "a6746213b138fe7add88b19bafacd446de574ca7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                               |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
| [`a2e44a84`](https://github.com/LnL7/nix-darwin/commit/a2e44a84be1c6b951d1764a1d44fff37d8fc59f5) | `` changelog: document changes to Nix installation management ``      |
| [`00a8cb30`](https://github.com/LnL7/nix-darwin/commit/00a8cb30fa7d52681f3445de672db95479b83d8c) | `` readme: update information about Determinate ``                    |
| [`03877755`](https://github.com/LnL7/nix-darwin/commit/03877755e9f67e584381ecde74ed2c030639aa0c) | `` checks: add check for Determinate ``                               |
| [`fb2bc03f`](https://github.com/LnL7/nix-darwin/commit/fb2bc03f922d406621928a80b28225340cb2b070) | `` activation-scripts: add unmanaged system Nix to activation path `` |
| [`8a94b5b9`](https://github.com/LnL7/nix-darwin/commit/8a94b5b99bfa6aec7846bec63eba93d05f8f44d8) | `` nix-daemon: remove `services.nix-daemon.enable` ``                 |
| [`adc989f7`](https://github.com/LnL7/nix-darwin/commit/adc989f7ec9efd8bb4e1b6b48c15f4c0f41be018) | `` nix: remove `nix.configureBuildUsers` ``                           |
| [`c796587d`](https://github.com/LnL7/nix-darwin/commit/c796587d2ef4ab06f84c4f740931f579f719b6f5) | `` nix: remove `nix.useDaemon` ``                                     |
| [`e182d8df`](https://github.com/LnL7/nix-darwin/commit/e182d8dff6bd3b0913ae6531c6abae3ed1e38364) | `` nix: add `nix.enable` option to disable Nix management ``          |
| [`9b9c9a57`](https://github.com/LnL7/nix-darwin/commit/9b9c9a57b626d72c4def5c2ddb7253bccb19c75d) | `` nix: don’t set `$NIX_REMOTE` ``                                    |
| [`8f227c40`](https://github.com/LnL7/nix-darwin/commit/8f227c405e0d42dfdbfce9849c689152c083a48b) | `` nix: fix typo in assertion conditional ``                          |
| [`1f7ed1c7`](https://github.com/LnL7/nix-darwin/commit/1f7ed1c7fe20d9b9d410c4f385a7d13ae1f4349e) | `` checks: remove `nixChannels` check ``                              |