### PR TITLE
chore(flake/home-manager): `83bd3a26` -> `15b59d41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739314552,
-        "narHash": "sha256-ggVf2BclyIW3jexc/uvgsgJH4e2cuG6Nyg54NeXgbFI=",
+        "lastModified": 1739381933,
+        "narHash": "sha256-4gvobxITgcrNGfwsVG5a46QzQCX89btIYw23p0ilbcc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "83bd3a26ac0526ae04fa74df46738bb44b89dcdd",
+        "rev": "15b59d4191b993ebdfcb1f61b834fced217882ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                              |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`15b59d41`](https://github.com/nix-community/home-manager/commit/15b59d4191b993ebdfcb1f61b834fced217882ba) | `` eww: fix eww source creation ``                                   |
| [`d303453b`](https://github.com/nix-community/home-manager/commit/d303453b134cff1dec350ae2e50fec34d06bee73) | `` eww: add null configDir test ``                                   |
| [`1f6fa878`](https://github.com/nix-community/home-manager/commit/1f6fa878080fd1b59b21b43695fd523ea4cae8d6) | `` eww: added tests ``                                               |
| [`f8729b11`](https://github.com/nix-community/home-manager/commit/f8729b11ee49a40fc21b6ec6578a16e9a5261414) | `` eww: fix confDir config using missing attribute "types.isNull" `` |