### PR TITLE
chore(flake/lovesegfault-vim-config): `ad2e0790` -> `674dda4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739145991,
-        "narHash": "sha256-9LX8n4bVj12ZiaNzEHt2Je3ASx98sTLcQiAL4gP+CfU=",
+        "lastModified": 1739405244,
+        "narHash": "sha256-ymSxugDJogphyfuB9/+qIHGetuSfapkEwfoTIs5nCcg=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "ad2e0790c461d87f22b41d499fe1a32f45047d79",
+        "rev": "674dda4ef669fe95fc87494c905d94b485ec051c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`674dda4e`](https://github.com/lovesegfault/vim-config/commit/674dda4ef669fe95fc87494c905d94b485ec051c) | `` chore(flake/nixpkgs): 550e11f2 -> 64e75cd4 `` |