### PR TITLE
chore(flake/home-manager): `c9d343cf` -> `22b418c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739416022,
-        "narHash": "sha256-Af1CIT+XlXEb+Dk11sgPDzJoOUiada2Xoj5hA8TBvLY=",
+        "lastModified": 1739458725,
+        "narHash": "sha256-k9AeUzs3phaTgfljRslR4iNTX9svBNhxoIw4QLd/V70=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c9d343cfa0565671cc7e8d5aefebaf61cc840abd",
+        "rev": "22b418c13fb0be43f4bc5c185f323a3237028594",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`22b418c1`](https://github.com/nix-community/home-manager/commit/22b418c13fb0be43f4bc5c185f323a3237028594) | `` bash: Make HISTFILESIZE and HISTSIZE nullable (#6443) `` |
| [`a70d7889`](https://github.com/nix-community/home-manager/commit/a70d788923061a00a488f60a01768ca4c6a8b727) | `` aerospace: fix workspace assignment config (#6442) ``    |