### PR TITLE
chore(flake/home-manager): `22b418c1` -> `5031c6d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739458725,
-        "narHash": "sha256-k9AeUzs3phaTgfljRslR4iNTX9svBNhxoIw4QLd/V70=",
+        "lastModified": 1739470101,
+        "narHash": "sha256-NxNe32VB4XI/xIXrsKmIfrcgtEx5r/5s52pL3CpEcA4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "22b418c13fb0be43f4bc5c185f323a3237028594",
+        "rev": "5031c6d2978109336637977c165f82aa49fa16a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`5031c6d2`](https://github.com/nix-community/home-manager/commit/5031c6d2978109336637977c165f82aa49fa16a7) | `` syncthing: remove with lib ``     |
| [`20fac9bb`](https://github.com/nix-community/home-manager/commit/20fac9bbdf22d697ad68faabb7f95d4deba4f712) | `` syncthing: use package options `` |