### PR TITLE
chore(flake/disko): `26ade100` -> `40da43e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739353546,
-        "narHash": "sha256-YTqXhBZvCdZLMBupWlCDvRFaTEhaHa2/Xc/p1sUdSZU=",
+        "lastModified": 1739517743,
+        "narHash": "sha256-CPfA2Wdfxz16CTsPFltFj65T0/HikkOa4pQvcts1df4=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "26ade1005191e0602a78b0f141970648445bafd9",
+        "rev": "40da43e8e5620505b9c8aacc4f0d7577ad1aff73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`40da43e8`](https://github.com/nix-community/disko/commit/40da43e8e5620505b9c8aacc4f0d7577ad1aff73) | `` Fix: Device dependencies not sorting correctly ``   |
| [`4b841b9c`](https://github.com/nix-community/disko/commit/4b841b9c3aaa816f3c7b9e4d5ea4d5e4cdf0bccb) | `` flake.lock: Update ``                               |
| [`fa88901f`](https://github.com/nix-community/disko/commit/fa88901f1e199b5e47f73125d902573b38a56dc8) | `` make-disk-image: fix virtiofs ``                    |
| [`9503f225`](https://github.com/nix-community/disko/commit/9503f225a47b0798098bc2c982b081e6f54d0991) | `` make-disk-image: fix build environment variables `` |