### PR TITLE
chore(flake/disko): `40da43e8` -> `e5115915`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739517743,
-        "narHash": "sha256-CPfA2Wdfxz16CTsPFltFj65T0/HikkOa4pQvcts1df4=",
+        "lastModified": 1739529569,
+        "narHash": "sha256-sQzLVCRPfAV/TJXru/jhCyecMXinG/sW8KLoYg0nOpk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "40da43e8e5620505b9c8aacc4f0d7577ad1aff73",
+        "rev": "e51159153b5fbe5c41caab41a7212df93c42d34b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                       |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`e5115915`](https://github.com/nix-community/disko/commit/e51159153b5fbe5c41caab41a7212df93c42d34b) | `` make-disk-image: format natively ``                        |
| [`64383404`](https://github.com/nix-community/disko/commit/64383404151be67ac1804fce50e139bab7eaebb3) | `` make-disk-image: add binfmt emulation ``                   |
| [`85942f35`](https://github.com/nix-community/disko/commit/85942f35d345daf4d402c05a8ee0c52f414a2168) | `` Revert "Fix: Device dependencies not sorting correctly" `` |