### PR TITLE
chore(flake/home-manager): `5031c6d2` -> `662fa98b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739470101,
-        "narHash": "sha256-NxNe32VB4XI/xIXrsKmIfrcgtEx5r/5s52pL3CpEcA4=",
+        "lastModified": 1739756364,
+        "narHash": "sha256-r8RxE0W3uhJ6unzbIddWTAzrpP9tMnmbj0F+DF+CTSM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5031c6d2978109336637977c165f82aa49fa16a7",
+        "rev": "662fa98bf488daa82ce8dc2bc443872952065ab9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`662fa98b`](https://github.com/nix-community/home-manager/commit/662fa98bf488daa82ce8dc2bc443872952065ab9) | `` nixpkgs-disabled: warn instead of assert (#6466) ``                     |
| [`25870c66`](https://github.com/nix-community/home-manager/commit/25870c6600660c93c5aa10f0f328a5eecd60150b) | `` nixos/common: fix `options` reference (#6473) ``                        |
| [`b15e9ec6`](https://github.com/nix-community/home-manager/commit/b15e9ec6769d770879759f086dd4e51fae7f2394) | `` flake-module: set _class (#6461) ``                                     |
| [`e5bc9c2a`](https://github.com/nix-community/home-manager/commit/e5bc9c2af1dca75271aeaeb39035ce7a6125c395) | `` git: reduce priority of signing.format (#6465) ``                       |
| [`ec130e70`](https://github.com/nix-community/home-manager/commit/ec130e700959ee10b63eedbc87758d20264a9588) | `` firefox: correct vendorPath of firefox forks (#6421) ``                 |
| [`eb44c160`](https://github.com/nix-community/home-manager/commit/eb44c1601ed99896525e983bc9b15eb8b4d5879e) | `` nixpkgs-disabled: fix `useGlobalPkgs` assertion (#6172) ``              |
| [`45c07fcf`](https://github.com/nix-community/home-manager/commit/45c07fcf7d28b5fb3ee189c260dee0a2e4d14317) | `` formatting according to HM's format tool ``                             |
| [`85e9d1cc`](https://github.com/nix-community/home-manager/commit/85e9d1cc8fa7be999c6fb05818154806e4e053c1) | `` syncthing: expand declarative config to Darwin ``                       |
| [`14223a82`](https://github.com/nix-community/home-manager/commit/14223a82611b14ee9a98c7725e76b5e51629c11d) | `` refactor launchd.agents.syncthing ``                                    |
| [`26454abc`](https://github.com/nix-community/home-manager/commit/26454abc03b7fbdeccd63f7696ebd451c74c4f7d) | `` provide RUNTIME_DIRECTORY manually if not given by systemd ``           |
| [`33ffe942`](https://github.com/nix-community/home-manager/commit/33ffe942525d57310ef64b34e95fb55c1535a7dc) | `` move curl shell function into string variable ``                        |
| [`17a78d3e`](https://github.com/nix-community/home-manager/commit/17a78d3eeddc70be09b53dfa34357b0845e9d11a) | `` nix variable for syncthing's configuration directory ``                 |
| [`53efb68b`](https://github.com/nix-community/home-manager/commit/53efb68b4b098a37b1584757e2e7f4119d7ad92c) | `` move syncthing-copy-keys to dedicated variable ``                       |
| [`8bc5e4c9`](https://github.com/nix-community/home-manager/commit/8bc5e4c9b277e571d6d639d82b0b9335a8e490a9) | `` git-maintenance: More details in the documentation ``                   |
| [`6d3163ae`](https://github.com/nix-community/home-manager/commit/6d3163aea47fdb1fe19744e91306a2ea4f602292) | `` git: change stateVersion check for compatiblity (#6453) ``              |
| [`67b9f9de`](https://github.com/nix-community/home-manager/commit/67b9f9de22c78bd1d2cf45583bfb18470d1d3ef8) | `` vscode: add windsurf directories (#6427) ``                             |
| [`582d3cd4`](https://github.com/nix-community/home-manager/commit/582d3cd42df7d2c7565d77119106336ea46e33df) | `` yubikey-agent: init service module (#6446) ``                           |
| [`9daae9a6`](https://github.com/nix-community/home-manager/commit/9daae9a67af7b4d341e2c806fa274a9c0925d7cf) | `` nixos/common: forward `nix.enable` from the OS configuration (#6383) `` |
| [`7da01bc4`](https://github.com/nix-community/home-manager/commit/7da01bc47ad48d696c96fcfd63d10063855d5486) | `` git: support alternate signing methods (#5516) ``                       |