### PR TITLE
chore(flake/disko): `e5115915` -> `4edb87a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739529569,
-        "narHash": "sha256-sQzLVCRPfAV/TJXru/jhCyecMXinG/sW8KLoYg0nOpk=",
+        "lastModified": 1739582867,
+        "narHash": "sha256-rO528HmsiPi3RO9kZdYt0NnzN3pxpXz33m6H/sIFgzI=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "e51159153b5fbe5c41caab41a7212df93c42d34b",
+        "rev": "4edb87a2ac9010da6fea50fc56d67e123fca85f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                              |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`4edb87a2`](https://github.com/nix-community/disko/commit/4edb87a2ac9010da6fea50fc56d67e123fca85f4) | `` test explicit gpt uuid optoin ``                  |
| [`a825e29a`](https://github.com/nix-community/disko/commit/a825e29a3b8246fa42a0b6ea38aab620c73ac783) | `` Use regex for UUID, adjust documentation a bit `` |
| [`bf440582`](https://github.com/nix-community/disko/commit/bf440582c49d48696a6bcbc2bc90d617be1f214d) | `` Use `concatMapStrings` ``                         |
| [`54be8abf`](https://github.com/nix-community/disko/commit/54be8abff07d97dec0a542611f1d1fcc22736e0f) | `` Add configration option for partition UUIDs ``    |