### PR TITLE
chore(flake/disko): `4edb87a2` -> `5d6c85c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739582867,
-        "narHash": "sha256-rO528HmsiPi3RO9kZdYt0NnzN3pxpXz33m6H/sIFgzI=",
+        "lastModified": 1739598710,
+        "narHash": "sha256-x5sK19938Qsi1eWRjQrH/oSN3wT0jSVE2ZJRwDTyojs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "4edb87a2ac9010da6fea50fc56d67e123fca85f4",
+        "rev": "5d6c85c1d0bd634d46a9604e93bce935a06e033b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                   |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`5d6c85c1`](https://github.com/nix-community/disko/commit/5d6c85c1d0bd634d46a9604e93bce935a06e033b) | `` Update tests/zfs-encrypted-root.nix `` |
| [`d478e2f9`](https://github.com/nix-community/disko/commit/d478e2f9f3dd7b305e9a8a4fd234cfe52c770823) | `` zfs: add example for encrypted root `` |