### PR TITLE
chore(flake/disko): `5d6c85c1` -> `7dcd5cda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739598710,
-        "narHash": "sha256-x5sK19938Qsi1eWRjQrH/oSN3wT0jSVE2ZJRwDTyojs=",
+        "lastModified": 1739614136,
+        "narHash": "sha256-k0UV2AUL9iTYqdAH871ex2MPzfdTKGbqqbY754qu6M8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "5d6c85c1d0bd634d46a9604e93bce935a06e033b",
+        "rev": "7dcd5cda34cba135e4851b92bae6deb859af3884",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                          |
| ---------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`7dcd5cda`](https://github.com/nix-community/disko/commit/7dcd5cda34cba135e4851b92bae6deb859af3884) | `` add .git-blame-ignore-revs `` |
| [`ff2d853a`](https://github.com/nix-community/disko/commit/ff2d853a8451a802786878e70324a4781d40d62d) | `` treewide: format all files `` |
| [`c23ac289`](https://github.com/nix-community/disko/commit/c23ac2891c78e89766e58a1c075d903db53baf6f) | `` setup treefmt ``              |