### PR TITLE
chore(flake/nix-index-database): `895d81b6` -> `ae15068e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739071773,
-        "narHash": "sha256-/Ak+Quinhmdxa9m3shjm4lwwwqmzG8zzGhhhhgR1k9I=",
+        "lastModified": 1739676768,
+        "narHash": "sha256-U1HQ7nzhJyVVXUgjU028UCkbLQLEIkg42+G7iIiBmlU=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "895d81b6228bbd50a6ef22f5a58a504ca99763ea",
+        "rev": "ae15068e79e22b76c344f0d7f8aed1bb1c5b0b63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`ae15068e`](https://github.com/nix-community/nix-index-database/commit/ae15068e79e22b76c344f0d7f8aed1bb1c5b0b63) | `` update generated.nix to release 2025-02-16-031500 `` |
| [`52ef1072`](https://github.com/nix-community/nix-index-database/commit/52ef1072d57cfd0b4d2c375d646e7420ae2f5901) | `` flake.lock: Update ``                                |