### PR TITLE
chore(flake/nixpkgs): `2ff53fe6` -> `8bb37161`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -571,11 +571,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739446958,
-        "narHash": "sha256-+/bYK3DbPxMIvSL4zArkMX0LQvS7rzBKXnDXLfKyRVc=",
+        "lastModified": 1739580444,
+        "narHash": "sha256-+/bSz4EAVbqz8/HsIGLroF8aNaO8bLRL7WfACN+24g4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2ff53fe64443980e139eaa286017f53f88336dd0",
+        "rev": "8bb37161a0488b89830168b81c48aed11569cb93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`4f6e7363`](https://github.com/NixOS/nixpkgs/commit/4f6e736362e3132c3da1af11d0c35149dd9e3d20) | `` hyprlandPlugins.hy3: 0.47.0 -> 0.47.0-1 (#382126) ``                         |
| [`e2ea971c`](https://github.com/NixOS/nixpkgs/commit/e2ea971c1364ee9a2524b5894dcd1daf8b7877e0) | `` python3Packages.types-enum34: remove ``                                      |
| [`7ef96705`](https://github.com/NixOS/nixpkgs/commit/7ef96705d3a6135f60581bc9d8fd55bbc5446c92) | `` usacloud: init at 1.14.1 ``                                                  |
| [`f36ffa86`](https://github.com/NixOS/nixpkgs/commit/f36ffa86463ade1cd13e24cc0f35ba0d9b8a6fb7) | `` apprun-cli: init at 0.0.2 ``                                                 |
| [`0345b336`](https://github.com/NixOS/nixpkgs/commit/0345b336c2cc3c1b42a7742f89252819aad04384) | `` python312Packages.islpy: 2025.1 -> 2025.1.1 ``                               |
| [`d00446c6`](https://github.com/NixOS/nixpkgs/commit/d00446c603f820a609dbc46c51ff404d664fccea) | `` home-assistant: 2025.2.3 -> 2025.2.4 ``                                      |
| [`6aeaa71f`](https://github.com/NixOS/nixpkgs/commit/6aeaa71ff594b93e661c75042d81ff0ca2d22022) | `` python313Packages.zha: 0.0.48 -> 0.0.49 ``                                   |
| [`2fa9ad13`](https://github.com/NixOS/nixpkgs/commit/2fa9ad136b224ce6767cb5a9711a89bae918cfd2) | `` python313Packages.zha-quirks: 0.0.132 -> 0.0.133 ``                          |
| [`2379040e`](https://github.com/NixOS/nixpkgs/commit/2379040e8c247f18a04370f162442ea0cf2bbd90) | `` python313Packages.pyseventeentrack: 1.0.1 -> 1.0.2 ``                        |
| [`1ce18a72`](https://github.com/NixOS/nixpkgs/commit/1ce18a7278d31e6d1d119295dcc94ee2563bde39) | `` python313Packages.py-synologydsm-api: 2.6.2 -> 2.6.3 ``                      |
| [`a253bad5`](https://github.com/NixOS/nixpkgs/commit/a253bad5e91c8d74ce5be438d4b40175aea58606) | `` python313Packages.hass-nabucasa: 0.90.0 -> 0.92.0 ``                         |
| [`2c12bbf0`](https://github.com/NixOS/nixpkgs/commit/2c12bbf0e69660d6fdd936aa5ac260f65294d98b) | `` zed-editor: 0.173.9 -> 0.173.10 ``                                           |
| [`c6afce43`](https://github.com/NixOS/nixpkgs/commit/c6afce43c2c16765b7bc48b69fc16a855f8041ea) | `` python312Packages.textnets: fix build on darwin ``                           |
| [`0c87981c`](https://github.com/NixOS/nixpkgs/commit/0c87981c32d0ada22c1cd910e06d61236b70ed43) | `` python312Packages.blis: fallback to generic architecure when needed ``       |
| [`05d5ff4d`](https://github.com/NixOS/nixpkgs/commit/05d5ff4d55a0307007f18ae50ea6eb5afe6b0e29) | `` python312Packages.web3: 7.6.1 -> 7.8.0 ``                                    |
| [`31f600f0`](https://github.com/NixOS/nixpkgs/commit/31f600f01400298f6ca022de44f4968c6c785bf2) | `` python312Packages.eth-account: 0.13.4 -> 0.13.5 ``                           |
| [`ec6a3fde`](https://github.com/NixOS/nixpkgs/commit/ec6a3fdebbea68f250ee716d363f87c0f3dde575) | `` python312Packages.asn1tools: skip failing tests ``                           |
| [`4840ab72`](https://github.com/NixOS/nixpkgs/commit/4840ab7258c81090e40e3332ed1d9d5523ae7001) | `` python312Packages.librosa: disable on python3.13 ``                          |
| [`6d79b0b9`](https://github.com/NixOS/nixpkgs/commit/6d79b0b9f33c6c3346f964f4598eaa89ecd9a5fd) | `` python312Packages.librosa: mark as broken on aarch64-linux ``                |
| [`857374c8`](https://github.com/NixOS/nixpkgs/commit/857374c887a37944b73bdaf1f84d8abb83489820) | `` python312Packages.optuna: 4.2.0 -> 4.2.1 ``                                  |
| [`db9bc910`](https://github.com/NixOS/nixpkgs/commit/db9bc910a059df8f7effbf1a59e4124c70d1daed) | `` widevine-cdm: fix eval outside unsupported platforms ``                      |
| [`3952142b`](https://github.com/NixOS/nixpkgs/commit/3952142b9363829730ee9dd51fb9186d75671139) | `` python3Packages.moviepy: increase test timeout to 60s ``                     |
| [`4c117757`](https://github.com/NixOS/nixpkgs/commit/4c1177576b66694b861a3c03c59aab21924defc9) | `` google-alloydb-auth-proxy: 1.12.1 -> 1.12.2 ``                               |
| [`1e132c67`](https://github.com/NixOS/nixpkgs/commit/1e132c67b25a6404e988171c5acdfd12242f7af6) | `` phpExtensions.relay: 0.10.0 -> 0.10.1 ``                                     |
| [`6fc6d7e8`](https://github.com/NixOS/nixpkgs/commit/6fc6d7e8ed57bd9df9390846b6e0c38e7e5c6fc8) | `` bwa-mem2: fix compilation isssue ``                                          |
| [`f10bc7af`](https://github.com/NixOS/nixpkgs/commit/f10bc7af57a0142a6ed8d737056bf3038286bb70) | `` phpExtensions.swoole: 6.0.0 -> 6.0.1 ``                                      |
| [`fc8665b7`](https://github.com/NixOS/nixpkgs/commit/fc8665b70f0246039f707a4d756a1bc88ec80d07) | `` phpPackages.phpstan: 2.1.2 -> 2.1.5 ``                                       |
| [`584bfab2`](https://github.com/NixOS/nixpkgs/commit/584bfab2efbe16240298e8d29fc5f4076690b8a5) | `` phpExtensions.openswoole: 22.1.2 -> 25.2.0 ``                                |
| [`ecd8ad91`](https://github.com/NixOS/nixpkgs/commit/ecd8ad91c25ff26a2af0383fa74d5f3e66112c6f) | `` dotnet-ef: 9.0.1 -> 9.0.2 ``                                                 |
| [`4252194b`](https://github.com/NixOS/nixpkgs/commit/4252194be61c4e2249f5b7590f148fc341286160) | `` proselint: 0.13.0 -> 0.14.0 (#381194) ``                                     |
| [`fefeb81d`](https://github.com/NixOS/nixpkgs/commit/fefeb81dd41f0b12975bd5f5f5d298b4f6221128) | `` python312Packages.google-cloud-dataproc: 5.16.0 -> 5.17.0 ``                 |
| [`d5965556`](https://github.com/NixOS/nixpkgs/commit/d59655560f925fd983ae1f83e68d43c6817a51db) | `` zed-editor: 0.173.8 -> 0.173.9 ``                                            |
| [`b60e5490`](https://github.com/NixOS/nixpkgs/commit/b60e5490ec9de74024535fddcc4bf0517e319bf0) | `` bosh-cli: 7.8.6 -> 7.9.2 ``                                                  |
| [`7a0aff7a`](https://github.com/NixOS/nixpkgs/commit/7a0aff7a8a05caa18d7373a9b42634a5c892e402) | `` oxlint: build oxc_language_server binary ``                                  |
| [`140858cd`](https://github.com/NixOS/nixpkgs/commit/140858cd719da8b0725ce8a5ff5904c5d342e0a5) | `` fractal: 10 -> 10.1 ``                                                       |
| [`d5b260a8`](https://github.com/NixOS/nixpkgs/commit/d5b260a837ba7ae84e76a5f9b5a02997da11d2e6) | `` netatalk: 4.1.1 -> 4.1.2 ``                                                  |
| [`e8832afe`](https://github.com/NixOS/nixpkgs/commit/e8832afeb3c33557d5db59a11eed3e41909b1732) | `` scry: drop ``                                                                |
| [`de8b060c`](https://github.com/NixOS/nixpkgs/commit/de8b060c2c522026298808b490eb49c9cbb12c33) | `` nixos/conduwuit: block mistakenly allowed syscalls ``                        |
| [`0080181f`](https://github.com/NixOS/nixpkgs/commit/0080181fc63c5eab6767fbca18a41390620325da) | `` tabby: use useFetchCargoVendor ``                                            |
| [`19c429fd`](https://github.com/NixOS/nixpkgs/commit/19c429fdf98a3f9c3db5595420c9090261e7a2e6) | `` maintainers: add fazzi to maintainer list ``                                 |
| [`adbf994b`](https://github.com/NixOS/nixpkgs/commit/adbf994b8612d66422ca9d27bf403eb27d287e7c) | `` obs-studio-plugins.obs-pipewire-audio-capture: 1.1.5 -> 1.2.0 ``             |
| [`6825d6f9`](https://github.com/NixOS/nixpkgs/commit/6825d6f9f634a9fee82d980b2ef1672c6011e01c) | `` martian-mono: fix build ``                                                   |
| [`acdaaa59`](https://github.com/NixOS/nixpkgs/commit/acdaaa59bde5c2a6f21f1d73a67f2d00a1e421b8) | `` tabby: v0.23.1 -> v0.24.0 ``                                                 |
| [`b58df7fc`](https://github.com/NixOS/nixpkgs/commit/b58df7fc9d5f02c269091f2b0b81a6e06fc859bb) | `` linuxPackages.nvidiaPackages.vulkan_beta: 550.40.83 -> 550.40.85 ``          |
| [`4ff952cc`](https://github.com/NixOS/nixpkgs/commit/4ff952cca3e4c1b954e867bb587f029a98af6e15) | `` netbootxyz-efi: add maintainer ``                                            |
| [`0de36a55`](https://github.com/NixOS/nixpkgs/commit/0de36a55a07b92f3577ad62e9642caac497fe5f6) | `` weaviate: 1.28.4 -> 1.28.5 ``                                                |
| [`26014d34`](https://github.com/NixOS/nixpkgs/commit/26014d3455751e9e304d71ceb3996a8bb18c3566) | `` yabai: 7.1.9 -> 7.1.10 ``                                                    |
| [`0102b4d6`](https://github.com/NixOS/nixpkgs/commit/0102b4d6ca96a1afa2aed446ee300e8070a54a2d) | `` tippecanoe: 2.75.0 -> 2.75.1 ``                                              |
| [`c7032bb4`](https://github.com/NixOS/nixpkgs/commit/c7032bb4d4028c63115c3a2d6c4f49a032a7d900) | `` python312Packages.ale-py: 0.10.1 -> 0.10.2 ``                                |
| [`4ab80660`](https://github.com/NixOS/nixpkgs/commit/4ab80660c4bdae89aa5c8331248da505adb7608e) | `` nix-search-tv: 1.0.0 -> 2.0.0 ``                                             |
| [`429299c5`](https://github.com/NixOS/nixpkgs/commit/429299c5705e21f18ce7d12145c86675dc130de0) | `` ansible*: fail if setuptools pattern not found ``                            |
| [`abcfab4c`](https://github.com/NixOS/nixpkgs/commit/abcfab4cf157eab6850b07a9bfdbcdbf47abed98) | `` python3Packages.bpycv: unbreak on aarch64 ``                                 |
| [`e5093082`](https://github.com/NixOS/nixpkgs/commit/e50930826bfbac5613198684ec56dba664ccbafb) | `` python3Packages.boxx: remove tests since they are broken on all platforms `` |
| [`144ab8d5`](https://github.com/NixOS/nixpkgs/commit/144ab8d5c4a21a89cbcf913e0e9dc350fe606acd) | `` ansible: consolidate setuptools replace ``                                   |
| [`7a5b52d0`](https://github.com/NixOS/nixpkgs/commit/7a5b52d0af20d488ff401643e4837a54dab64b6a) | `` prometheus-postfix-exporter: 0.7.0 -> 0.8.0 ``                               |
| [`b99fa6e0`](https://github.com/NixOS/nixpkgs/commit/b99fa6e0290e4d50d491e037930bd8d469655bc1) | `` python312Packages: dash-bootstrap-templates: init at 1.3.0 ``                |
| [`6ae1e543`](https://github.com/NixOS/nixpkgs/commit/6ae1e543d0b6dcaa3f972625c35763713473df82) | `` cargo-tarpaulin: 0.31.5 -> 0.32.0 ``                                         |
| [`46de81e8`](https://github.com/NixOS/nixpkgs/commit/46de81e809539503a8f69fcc835b9b0d61879491) | `` apk-tools: 2.14.9 -> 2.14.10 ``                                              |
| [`c9dfe44a`](https://github.com/NixOS/nixpkgs/commit/c9dfe44a7da08a3384f3589e05ded6a312fbb70d) | `` foundry: 0.3.0 -> 1.0.0 ``                                                   |
| [`9a02ca1c`](https://github.com/NixOS/nixpkgs/commit/9a02ca1c76e67805cdd780b0e45dff89c87b2fdf) | `` amazon-ec2-metadata-mock: init at 1.13.0 ``                                  |
| [`9d6fdd0c`](https://github.com/NixOS/nixpkgs/commit/9d6fdd0c179540f268952ba59eaa4f5cd229b84b) | `` python3Packages.boxx: fix build ``                                           |
| [`c7126403`](https://github.com/NixOS/nixpkgs/commit/c71264034d52bdf794c716c9dde7bd5202ad6222) | `` libdatachannel: 0.22.4 -> 0.22.5 ``                                          |