### PR TITLE
chore(flake/disko): `be1e4321` -> `af4a5806`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739760714,
-        "narHash": "sha256-SaGuzIQUTC2UPwX0aTm9W4aSEUcq3h6yZbi30piej2U=",
+        "lastModified": 1739791827,
+        "narHash": "sha256-l6ooDEtfzet9qRQxlb5A+H6eY7VPpdiGMwqX0nqD1xM=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "be1e4321c9fb3a4bc2c061dafcdb424937a74dad",
+        "rev": "af4a580628e98302bb922c01e1169ce08d7bee57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                      |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`af4a5806`](https://github.com/nix-community/disko/commit/af4a580628e98302bb922c01e1169ce08d7bee57) | `` docs/disko-images: fix codeblocks ``      |
| [`dc4687a5`](https://github.com/nix-community/disko/commit/dc4687a53d8246a60349018684663afcd7485397) | `` docs: disko-images: add binfmt section `` |