### PR TITLE
chore(flake/lovesegfault-vim-config): `4c63819e` -> `4dc026fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739750906,
-        "narHash": "sha256-0YpR43314pGbz/tA/bF4r4uKi9Zd/GfjkgDRjxj3FGk=",
+        "lastModified": 1739807809,
+        "narHash": "sha256-SQZMoYV37/jYWNnzssWS93CA95MaqoUNVoIm5ntLLVQ=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "4c63819e64081b749cd5ce681153399c561095d7",
+        "rev": "4dc026fef9a2e8fe96ce0d9bb43066b24f5c8457",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                               |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`4dc026fe`](https://github.com/lovesegfault/vim-config/commit/4dc026fef9a2e8fe96ce0d9bb43066b24f5c8457) | `` fix(lsp): re-enable lldb ``        |
| [`45e2ab1f`](https://github.com/lovesegfault/vim-config/commit/45e2ab1fbeccb68802355680b352885535ddba9c) | `` feat(lsp): add nixfmt-rfc-style `` |