### PR TITLE
chore(flake/home-manager): `9d0d48f4` -> `edad23eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739802995,
-        "narHash": "sha256-kZv0upOigS/4sUEgZuZd6/uO6s8X8oYOLk9/sGMsl+c=",
+        "lastModified": 1739819404,
+        "narHash": "sha256-rlEJKgvu6cQMxzXoUIeqhKfSZU+WvOhItyHQH3WDWWg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9d0d48f4c3d2fb1a8c8607da143bb567a741d914",
+        "rev": "edad23ebc1bcc226ef5eb57c8d779b9b425adca1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`edad23eb`](https://github.com/nix-community/home-manager/commit/edad23ebc1bcc226ef5eb57c8d779b9b425adca1) | `` mako: add max-history option (#6009) ``       |
| [`f4f6dd26`](https://github.com/nix-community/home-manager/commit/f4f6dd26985f1e44721325cb6d783d0cf4cd4dbc) | `` git: fix setting format on >=25.05 (#6480) `` |