### PR TITLE
chore(flake/home-manager): `edad23eb` -> `6c93eea8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739819404,
-        "narHash": "sha256-rlEJKgvu6cQMxzXoUIeqhKfSZU+WvOhItyHQH3WDWWg=",
+        "lastModified": 1739823458,
+        "narHash": "sha256-uHjpcdlWKrZEJxsGdlMRTe4jlMYAnNsjRxPSTrNMFvo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "edad23ebc1bcc226ef5eb57c8d779b9b425adca1",
+        "rev": "6c93eea85daddd0dc8d4a3a687473461f3122961",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`6c93eea8`](https://github.com/nix-community/home-manager/commit/6c93eea85daddd0dc8d4a3a687473461f3122961) | `` firefox: add HPSaucii maintainer ``                |
| [`27ffa351`](https://github.com/nix-community/home-manager/commit/27ffa35178bc6f359293a8809d32c5da23aaabc7) | `` firefox: add support for configuring extensions `` |
| [`3a0cf8f1`](https://github.com/nix-community/home-manager/commit/3a0cf8f1aae507ec9bb8c141369458ca0244a01b) | `` maintainers: add HPsaucii ``                       |