### PR TITLE
chore(flake/lovesegfault-vim-config): `4dc026fe` -> `d7963c89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739807809,
-        "narHash": "sha256-SQZMoYV37/jYWNnzssWS93CA95MaqoUNVoIm5ntLLVQ=",
+        "lastModified": 1739837287,
+        "narHash": "sha256-Qxknl24iDuvHWASQCiX7B1J42//wE5GvwOMH/snBkHA=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "4dc026fef9a2e8fe96ce0d9bb43066b24f5c8457",
+        "rev": "d7963c891bf3af8211ae668b11b5e01cbd6f4fe4",
         "type": "github"
       },
       "original": {
@@ -633,11 +633,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739708385,
-        "narHash": "sha256-H6qPfgE8P6rYMpwj9GsmcZEry52O3U82IqJJy6hx/88=",
+        "lastModified": 1739751913,
+        "narHash": "sha256-H72wNdLOl9CzfimXjDdKWnV0Mr8lpVF4m3HZ2m+fuck=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d636d254088a2fa49b585b79097a2766d4e3af80",
+        "rev": "3a66c8a33001d8bd79388c6b15eb1039f43f4192",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`d7963c89`](https://github.com/lovesegfault/vim-config/commit/d7963c891bf3af8211ae668b11b5e01cbd6f4fe4) | `` chore(flake/treefmt-nix): 4f09b473 -> 3d0579f5 `` |
| [`006e7822`](https://github.com/lovesegfault/vim-config/commit/006e7822236a75e9a195dee7ecd52c96810781fe) | `` chore(flake/nixvim): d636d254 -> 3a66c8a3 ``      |