### PR TITLE
chore(flake/stylix): `d171b19c` -> `eb7b19c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -725,11 +725,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1739878543,
-        "narHash": "sha256-5jgxAqD48BxIgXGK1KjPFrck3exBage7lHNv+oY10A0=",
+        "lastModified": 1739892324,
+        "narHash": "sha256-3u0MZpiFl1+5FZcoSWhftl0R8pNKNfHQK1cM29vgpsw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "d171b19c1c76c32f9c8303a43d0176257aa25034",
+        "rev": "eb7b19c26030c534664c840405c995a493a98013",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                     |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`eb7b19c2`](https://github.com/danth/stylix/commit/eb7b19c26030c534664c840405c995a493a98013) | `` plymouth: support question and message widgets (#842) `` |
| [`9343b660`](https://github.com/danth/stylix/commit/9343b660c914a95d4a90f6bd40cda7c87b401445) | `` stylix: fix palette generator caching (#867) ``          |