### PR TITLE
chore(flake/nixpkgs): `d74a2335` -> `73cf49b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -571,11 +571,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739736696,
-        "narHash": "sha256-zON2GNBkzsIyALlOCFiEBcIjI4w38GYOb+P+R4S8Jsw=",
+        "lastModified": 1739866667,
+        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d74a2335ac9c133d6bbec9fc98d91a77f1604c1f",
+        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`df472f9c`](https://github.com/NixOS/nixpkgs/commit/df472f9cfe2b24b84f167db985661e8df7b4f85f) | `` libjaylink: 0.3.1 -> 0.4 ``                                                       |
| [`d364584d`](https://github.com/NixOS/nixpkgs/commit/d364584d4a5898dbf548bfa1c735d9b6fc7803a4) | `` libjaylink: Enable nix-update-script ``                                           |
| [`d30e3755`](https://github.com/NixOS/nixpkgs/commit/d30e3755f3aeedb1ad006f73a9387522ab12bd4a) | `` libjaylink: Use tag parameter instead of rev ``                                   |
| [`a7b40227`](https://github.com/NixOS/nixpkgs/commit/a7b402270dc3ac0f3170405c710d971d7535a5df) | `` libjaylink: Sort package inputs alphabetically ``                                 |
| [`21fe7f23`](https://github.com/NixOS/nixpkgs/commit/21fe7f239cddf0ec87a616aa8dfd669514790650) | `` python312Packages.mayavi: mark as broken on darwin ``                             |
| [`19fc3e56`](https://github.com/NixOS/nixpkgs/commit/19fc3e56ed8b8d77cfc78c34575fe44c65fbaaa3) | `` spicetify-cli: 2.38.9 -> 2.39.3 ``                                                |
| [`814ecdf1`](https://github.com/NixOS/nixpkgs/commit/814ecdf1a43cf3b88a0a934c9af31c2b8d24bbc4) | `` ocamlPackages.js_of_ocaml: 5.9.1 → 6.0.1 ``                                       |
| [`3452fcb1`](https://github.com/NixOS/nixpkgs/commit/3452fcb15f63a5b6f0b2cee3a8366af59563f8d3) | `` devenv: 1.4 -> 1.4.1 ``                                                           |
| [`0e12f014`](https://github.com/NixOS/nixpkgs/commit/0e12f014f2301e1f73125ece966250f08ed86ff4) | `` python313Packages.weaviate-client: break on darwin ``                             |
| [`e4e0b398`](https://github.com/NixOS/nixpkgs/commit/e4e0b39888eafbfa7274e9661bb238e2699c5c59) | `` python313Packages.polyfactory: 2.18.1-unstable-2024-12-22 -> 2.19.0 ``            |
| [`a2b85d4e`](https://github.com/NixOS/nixpkgs/commit/a2b85d4ef550b8dd77b04ee58769114f674b5c4d) | `` ocamlPackages.bitv: 1.3 -> 2.0 ``                                                 |
| [`9e6de4ab`](https://github.com/NixOS/nixpkgs/commit/9e6de4ab6d1b85e1faf5bf9ebdd29a071ccc0b47) | `` tailwindcss: revert back to v3 as default ``                                      |
| [`abacc561`](https://github.com/NixOS/nixpkgs/commit/abacc56123bb7ca3a0a33472e61bad12c0a089db) | `` python313Packages.aioesphomeapi: 29.0.0 -> 29.1.0 ``                              |
| [`99fb5230`](https://github.com/NixOS/nixpkgs/commit/99fb5230c6d1ef31ee47109c6b1fc178e5a9a4c8) | `` python313Packages.esphome-glyphsets: init at 0.1.0 ``                             |
| [`2a349d9d`](https://github.com/NixOS/nixpkgs/commit/2a349d9d3854bffe62fe0208feadc0d0af7221ab) | `` civo: 1.1.95 -> 1.1.97 ``                                                         |
| [`04892acd`](https://github.com/NixOS/nixpkgs/commit/04892acda1ad22f397965db5555dcc940fc13c99) | `` last: 1608 -> 1609 ``                                                             |
| [`02ad387f`](https://github.com/NixOS/nixpkgs/commit/02ad387f0d6b6d6c79ec907077fe82c5543648b5) | `` emacsPackages.ebuild-mode: 1.77 -> 1.78 ``                                        |
| [`ab44f18e`](https://github.com/NixOS/nixpkgs/commit/ab44f18e2143c5af93c2b818388368ca5bb50a07) | `` b3sum: 1.5.5 -> 1.6.0 ``                                                          |
| [`be2336e1`](https://github.com/NixOS/nixpkgs/commit/be2336e18b42773635e8cf556e0143a13dedf165) | `` treewide: cleanup paramiko.optional-dependency.ed25519 ``                         |
| [`8a254de2`](https://github.com/NixOS/nixpkgs/commit/8a254de229d2d1ecfed4c36d33788774a820d4bd) | `` Revert "python312Packages.smart-open: add pynacl to checkInputs" ``               |
| [`db8416a3`](https://github.com/NixOS/nixpkgs/commit/db8416a302be009f88602c1223bcc581367b2ca8) | `` Revert "python312Packages.tempest: add missing pynacl checkInput to fix build" `` |
| [`48c9e493`](https://github.com/NixOS/nixpkgs/commit/48c9e493f087eecec9b78a0318f0adb5df4cca88) | `` python312Packages.mayavi: fix build, pin to numpy_1 ``                            |
| [`c9377b15`](https://github.com/NixOS/nixpkgs/commit/c9377b15aadc81ed9ae071a5dcbaeb44cf311fad) | `` opcua-commander: fix build on darwin (#382748) ``                                 |
| [`f71056ce`](https://github.com/NixOS/nixpkgs/commit/f71056ce9a6faafa733335526bf31679d8c8e7e4) | `` vscode-extensions.ms-dotnettools.csharp: 2.61.28 -> 2.63.32 ``                    |
| [`6bb00cb3`](https://github.com/NixOS/nixpkgs/commit/6bb00cb366b81bb6677f2c30c4cde7800ecaa40b) | `` python312Packages.treescope: 0.1.8 -> 0.1.9 ``                                    |
| [`dc33239d`](https://github.com/NixOS/nixpkgs/commit/dc33239dc4804e210dff8ed0568abd4c91b8c4e4) | `` python312Packages.islpy: 2025.1.1 -> 2025.1.2 ``                                  |
| [`cf4c8e97`](https://github.com/NixOS/nixpkgs/commit/cf4c8e97ad99b24d3169c8d7e012abbe8ea83a3f) | `` nixos/networkd: add new options introduced in systemd 257 ``                      |
| [`48afbbe7`](https://github.com/NixOS/nixpkgs/commit/48afbbe751cadc291f9c3f17a57488e63b2cb203) | `` python312Packages.docling-ibm-models: 3.3.0 -> 3.3.2 ``                           |
| [`c38c1d48`](https://github.com/NixOS/nixpkgs/commit/c38c1d4897144cfaceb757f2fec03c368a66085c) | `` stalwart: pin tailwindcss ``                                                      |
| [`b8de31fe`](https://github.com/NixOS/nixpkgs/commit/b8de31feded8d1c5dca4f2648c20fe0975961ba9) | `` plausible: pin tailwindcss ``                                                     |
| [`43bb0323`](https://github.com/NixOS/nixpkgs/commit/43bb03239a2a277c28b9246ad6a04d13a5f690b4) | `` libdeltachat: 1.155.4 -> 1.155.6 ``                                               |
| [`e22c687f`](https://github.com/NixOS/nixpkgs/commit/e22c687f399091727b8f70341a76e593b4a8b39a) | `` deltachat-desktop: 1.52.1 -> 1.54.1 ``                                            |
| [`34a56602`](https://github.com/NixOS/nixpkgs/commit/34a56602304b90ec7f242ebec133f5fb6051fd55) | `` php83: 8.3.16 -> 8.3.17 ``                                                        |
| [`fc95c957`](https://github.com/NixOS/nixpkgs/commit/fc95c95737bc9773c4bc8e6fac4640bf038aab3d) | `` terraform-providers.proxmox: 2.9.14 -> 3.0.1-rc6 ``                               |
| [`7bb85613`](https://github.com/NixOS/nixpkgs/commit/7bb85613ab4006bb95465a939780dfa42c9cff59) | `` rimgo: pin tailwindcss ``                                                         |
| [`38f778ce`](https://github.com/NixOS/nixpkgs/commit/38f778cec223f996d618bb8e34919e594df3adb7) | `` python3Packages.drf-standardized-errors: fix patch url ``                         |
| [`0ff5e5eb`](https://github.com/NixOS/nixpkgs/commit/0ff5e5ebc255f819cc91faedd5efb9f0abf6bd7a) | `` memogram: 0.2.2 -> 0.2.4 ``                                                       |
| [`b80c7c0b`](https://github.com/NixOS/nixpkgs/commit/b80c7c0bd1809a18328d5ed842e646966ad0f093) | `` terraform-providers.launchdarkly: 2.21.5 -> 2.23.1 ``                             |
| [`c8f8c091`](https://github.com/NixOS/nixpkgs/commit/c8f8c0917ffa609e779051d618a2d7ef461f778d) | `` drum-machine: init at 1.0.0 ``                                                    |
| [`a3a07ac7`](https://github.com/NixOS/nixpkgs/commit/a3a07ac733f5aa4a1b1800d4a4042b65c6a9865f) | `` coqPackages.jasmin: init at 2024.07.2 (#382064) ``                                |
| [`7236b15a`](https://github.com/NixOS/nixpkgs/commit/7236b15ac72d2a36477b700b83501ab9ef3ed5a7) | `` gitea: 1.23.2 -> 1.23.3 ``                                                        |
| [`9d9b490e`](https://github.com/NixOS/nixpkgs/commit/9d9b490e9a6115dab9fe7724c2edf218c91a7fd6) | `` terraform-providers.signalfx: 9.7.1 -> 9.7.2 ``                                   |
| [`33775661`](https://github.com/NixOS/nixpkgs/commit/337756615375efc27d8c745629781011924c1632) | `` php84: 8.4.3 -> 8.4.4 ``                                                          |
| [`3df1bef9`](https://github.com/NixOS/nixpkgs/commit/3df1bef9a3d770717e24acecdc7681e747023ef9) | `` delineate: init at 0.1.0 ``                                                       |
| [`65f92845`](https://github.com/NixOS/nixpkgs/commit/65f928452e0d16a9d7893a41f3f372acc8c138df) | `` maintainers: add nekowinston ``                                                   |
| [`12deb291`](https://github.com/NixOS/nixpkgs/commit/12deb29171381969ff0ce2cad889c5af313fade5) | `` terraform-providers.vsphere: 2.11.0 -> 2.11.1 ``                                  |
| [`788902c8`](https://github.com/NixOS/nixpkgs/commit/788902c8a185168799758dee71b5902edde86e78) | `` terraform-providers.spacelift: 1.19.1 -> 1.20.0 ``                                |
| [`eb400924`](https://github.com/NixOS/nixpkgs/commit/eb4009247f671b346012a87302b8e3c29f496f41) | `` python3Packages.onnxruntime: buildInputs dep on onnxruntime ``                    |
| [`cf234c1d`](https://github.com/NixOS/nixpkgs/commit/cf234c1d6e4405a11e18c55062f20ee5f04c878f) | `` vimPlugins.blink-cmp: 0.12.2 -> 0.12.4 ``                                         |
| [`a5b2caac`](https://github.com/NixOS/nixpkgs/commit/a5b2caac92f37f372585738634bb5e10c72107a3) | `` humblebundle-downloader: init at 0.4.3 ``                                         |
| [`69171c1b`](https://github.com/NixOS/nixpkgs/commit/69171c1b722374039a26d400d0e0984caf53c325) | `` signalbackup-tools: 20250213-1 -> 20250217 ``                                     |
| [`53035684`](https://github.com/NixOS/nixpkgs/commit/53035684850779c37996434738694ad28ffb8adc) | `` prettypst: unstable-2024-10-20 -> 2.0.0 ``                                        |
| [`2dc66ded`](https://github.com/NixOS/nixpkgs/commit/2dc66dedcb314022e4eae29b3f309ba6094bf775) | `` dependency-track: 4.12.2 -> 4.12.5 ``                                             |
| [`11377d72`](https://github.com/NixOS/nixpkgs/commit/11377d720972e54450cd916305522b00af807ec7) | `` luaPackages.orgmode: fix tree-sitter-org error ``                                 |
| [`a2012b3e`](https://github.com/NixOS/nixpkgs/commit/a2012b3e438dc2a37e379b0525a9e487c164c9ab) | `` terraform-providers.pagerduty: 3.19.4 -> 3.21.0 ``                                |
| [`66164cd3`](https://github.com/NixOS/nixpkgs/commit/66164cd33e66dfd66d62ddd019b8fa20be32685e) | `` pmtiles: 1.25.0 -> 1.25.1 ``                                                      |
| [`c7536667`](https://github.com/NixOS/nixpkgs/commit/c75366679660bb11879aec70f0b95d98c42a53ae) | `` terraform-providers.minio: 3.2.3 -> 3.3.0 ``                                      |
| [`6ae98118`](https://github.com/NixOS/nixpkgs/commit/6ae981186ae71ed1c31b8dd1469f96107d8b8eaf) | `` terraform-providers.dme: 1.0.6 -> 1.0.7 ``                                        |
| [`d5988687`](https://github.com/NixOS/nixpkgs/commit/d59886879681c44a52836dacbb714bc95fc61c1d) | `` ncmpc: 0.51 -> 0.52 ``                                                            |
| [`9f848d0d`](https://github.com/NixOS/nixpkgs/commit/9f848d0d43a8ee51c3feff16f11e54ca3ef5903c) | `` python312Packages.docling: 2.20.0 -> 2.23.0 ``                                    |
| [`3cd3f5eb`](https://github.com/NixOS/nixpkgs/commit/3cd3f5eb5669fe1b18a55c5d7bd745b958c78776) | `` python312Packages.docling-core: 2.18.1 -> 2.19.1 ``                               |
| [`ebd23f3d`](https://github.com/NixOS/nixpkgs/commit/ebd23f3d766fa867efef5f5e448cc89ee4f75142) | `` kube-review: init at 0.4.0 ``                                                     |
| [`6e4e0015`](https://github.com/NixOS/nixpkgs/commit/6e4e0015a95551a5bd53341cb4c4e6c419d1afbf) | `` mainteiners: add ardubev16 ``                                                     |
| [`1cc293de`](https://github.com/NixOS/nixpkgs/commit/1cc293deea81e214d75d733c421ca296ebfa0b07) | `` python312Packages.annoy: cleanup & mark as broken on darwin ``                    |
| [`72823e90`](https://github.com/NixOS/nixpkgs/commit/72823e90a87e7b1056bbe176e1ccce6f9fbd0cf7) | `` strip-nondeterminism: 1.13.1 -> 1.14.1 ``                                         |
| [`201505e6`](https://github.com/NixOS/nixpkgs/commit/201505e6b7e1c996c63df3aa42403d191f3b42f7) | `` strip-nondeterminism: Add `updateScript` ``                                       |
| [`d149dabb`](https://github.com/NixOS/nixpkgs/commit/d149dabb544274b742df8c535ccb1ff8ca0e06e0) | `` nixos/oauth2-proxy-nginx: match files in location block exactly ``                |
| [`a0d87692`](https://github.com/NixOS/nixpkgs/commit/a0d8769244ab912cafdee16399b93bbb325ec8a6) | `` syncthingtray: set mainProgram ``                                                 |
| [`be8ad856`](https://github.com/NixOS/nixpkgs/commit/be8ad8564e904564c7578209549227d48f88a8d1) | `` home-assistant-custom-lovelace-modules.universal-remote-card: 4.3.8 -> 4.3.9 ``   |
| [`f8b78d43`](https://github.com/NixOS/nixpkgs/commit/f8b78d4329d8b3527e9656f2845dc81d5e0a2651) | `` trilinos: remove dangling symlink to fix build (#382649) ``                       |
| [`eaca5843`](https://github.com/NixOS/nixpkgs/commit/eaca584353c3be2c81a20c64da3126523d1ac818) | `` python312Packages.qcodes: 0.50.1 -> 0.51.0 ``                                     |
| [`e40c3342`](https://github.com/NixOS/nixpkgs/commit/e40c33427ef8c3a40876b61c524164b922a18604) | `` gopro-tool: init at 0-unstable-2024-04-18 ``                                      |
| [`23e2902b`](https://github.com/NixOS/nixpkgs/commit/23e2902b9d00a4a5ba5575690e8178363a6faaee) | `` python312Packages.transformers: 4.48.3 -> 4.49.0 ``                               |
| [`d09e6938`](https://github.com/NixOS/nixpkgs/commit/d09e693880fecb5ecb223a82ac56c3958a690767) | `` renode-unstable: 1.15.3+20250202git50d499e4e -> 1.15.3+20250214git71a264d7b ``    |
| [`99678b61`](https://github.com/NixOS/nixpkgs/commit/99678b61c6390d4290efe996d86cfe0ad1f8c166) | `` Revert "amazon-ec2-metadata-mock: init at 1.13.0" ``                              |
| [`eff11c8b`](https://github.com/NixOS/nixpkgs/commit/eff11c8bc5dd2dddc35a08242c71e1677d442f20) | `` home-assistant-component-tests.stream: disable failing test ``                    |
| [`25b5a22b`](https://github.com/NixOS/nixpkgs/commit/25b5a22bead30d87dbb80ac91e2fc63b2c0c17e2) | `` luaPackages: use writableTmpDirAsHomeHook ``                                      |
| [`f5dde77b`](https://github.com/NixOS/nixpkgs/commit/f5dde77b8030b83eb46771a73323aa2a25ddafa1) | `` python313Packages.tencentcloud-sdk-python: 3.0.1318 -> 3.0.1319 ``                |
| [`29e9d008`](https://github.com/NixOS/nixpkgs/commit/29e9d008f2d8988d0cbf782c4ffb5b1b2a7e0bb0) | `` hyprland-workspaces-tui: 1.1.0 -> 1.2.0 ``                                        |
| [`2c462b53`](https://github.com/NixOS/nixpkgs/commit/2c462b531d7a013af46cfb2e7372ea3396cbbbd2) | `` python312Packages.devito: 4.8.11 -> 4.8.12 ``                                     |
| [`8b4b5dbe`](https://github.com/NixOS/nixpkgs/commit/8b4b5dbefc546e6bab9fe64728b8ce2af33473d5) | `` python3Packages.jira: use build-system and dependencies ``                        |
| [`40386f1a`](https://github.com/NixOS/nixpkgs/commit/40386f1a37acc215f358334b199254f7121b089c) | `` swaylock-plugin: init at unstable-2025-01-28 ``                                   |
| [`50eeaac1`](https://github.com/NixOS/nixpkgs/commit/50eeaac136f85c9a60d40623991f0c26542a880b) | `` python3Packages.jira: don't use repo = pname ``                                   |
| [`69dd0734`](https://github.com/NixOS/nixpkgs/commit/69dd0734e0b2e699d6c1a24de9aeeae350c42a99) | `` python3Packages.jira: fix build ``                                                |
| [`2f969173`](https://github.com/NixOS/nixpkgs/commit/2f9691732e44cd9f6f6097924288c48c0918040e) | `` python3Packages.pex: 2.29.0 -> 2.33.1 ``                                          |
| [`126018cc`](https://github.com/NixOS/nixpkgs/commit/126018cca024a605304fd02d1da884629aeb32a0) | `` mautrix-meta: 0.4.3 -> 0.4.4 (#382695) ``                                         |
| [`f4e3a80f`](https://github.com/NixOS/nixpkgs/commit/f4e3a80f9a568b07a9e29d163808e7b34ded25f9) | `` feat: add package ocamlPackages.nice_parser ``                                    |
| [`43febf85`](https://github.com/NixOS/nixpkgs/commit/43febf853e7493c161d500c3b633a11393b10f88) | `` maintainers: add tiferrei ``                                                      |
| [`6f8dd244`](https://github.com/NixOS/nixpkgs/commit/6f8dd244bfc734f277a1a7028a780ebb8de004bf) | `` python310Packages.mistune: add missing dependency (#382535) ``                    |
| [`0270ce34`](https://github.com/NixOS/nixpkgs/commit/0270ce345450e9bbdb6470158f08ab18940d3778) | `` ginko: init at 0.0.8 ``                                                           |
| [`eb29e7c4`](https://github.com/NixOS/nixpkgs/commit/eb29e7c4486e258e61211a12d0df72512eff7c67) | `` python312Packages.bandit: 1.8.2 -> 1.8.3 ``                                       |
| [`46587e6b`](https://github.com/NixOS/nixpkgs/commit/46587e6b695f0972e802d97002736ee8036d6267) | `` movim: 0.29.1 → 0.29.2 ``                                                         |
| [`454c64c5`](https://github.com/NixOS/nixpkgs/commit/454c64c5104b7adb7ab68689778b9e389ac45622) | `` beancount: set passthru.skipBulkUpdate ``                                         |
| [`320ebb3f`](https://github.com/NixOS/nixpkgs/commit/320ebb3f96579dfa5bf2a8c8400d98016d94faf7) | `` python313Packages.aocd: fix build ``                                              |
| [`2c1c229f`](https://github.com/NixOS/nixpkgs/commit/2c1c229f035431aaf4b5987a233b9d63c9c39bf9) | `` libasn1c: 0.9.37 -> 0.9.38 ``                                                     |