### PR TITLE
chore(flake/stylix): `aeb550ad` -> `c424b223`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -725,11 +725,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1739909171,
-        "narHash": "sha256-GmuW8XkOF6lSEQBeXzUCyr6tetbbxX8wpNJlwFqT/9E=",
+        "lastModified": 1740055719,
+        "narHash": "sha256-6UaZqK8+7byU2ORz6YpGccjDDoEd95Btr6qE6qbg5YM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "aeb550add3bfa1ce3ce249c3b3dad71ebb018318",
+        "rev": "c424b22396c5e40d2513ce03f94d0aa6d9cdd38f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                 |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`c424b223`](https://github.com/danth/stylix/commit/c424b22396c5e40d2513ce03f94d0aa6d9cdd38f) | `` swaylock: avoid inadvertently installing Swaylock `` |
| [`07797994`](https://github.com/danth/stylix/commit/0779799431088b10e0499ef04c2c7901df1087a4) | `` rio: init (#882) ``                                  |