### PR TITLE
chore(flake/nixos-hardware): `3e2ea8a4` -> `18e9f975`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -556,11 +556,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1739798439,
-        "narHash": "sha256-GyipmjbbQEaosel/+wq1xihCKbv0/e1LU00x/8b/fP4=",
+        "lastModified": 1740089251,
+        "narHash": "sha256-Y78mDBWoO8CLLTjQfPfII+KXFb6lAmF9GrLbyVBsIMM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3e2ea8a49d4d76276b0f4e2041df8ca5c0771371",
+        "rev": "18e9f9753e9ae261bcc7d3abe15745686991fd30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [`18e9f975`](https://github.com/NixOS/nixos-hardware/commit/18e9f9753e9ae261bcc7d3abe15745686991fd30) | `` dell-xps-15-9570: fix imports, refactor (closer to recent profiles and more explicit) (#1331) `` |