### PR TITLE
chore(flake/home-manager): `bdf73272` -> `9f74e14a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740161702,
-        "narHash": "sha256-dUwfoRhWT22JjXn0iqmMWKsutELwSL01EdKeA9TXsHA=",
+        "lastModified": 1740177427,
+        "narHash": "sha256-1xUiN0Yvvl/r+XyyXiJHxw64FwUGBfKF+XA7Ugm8ElU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bdf73272a8408fedc7ca86d5ea47192f6d2dad54",
+        "rev": "9f74e14a2d9af4c6f2024cca7813b830b020f45e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                               |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`9f74e14a`](https://github.com/nix-community/home-manager/commit/9f74e14a2d9af4c6f2024cca7813b830b020f45e) | `` fcitx5: make boot after graphical session (#6432) ``               |
| [`6eed33a3`](https://github.com/nix-community/home-manager/commit/6eed33a3acb933224917964879634826716a3e5d) | `` jetbrains-remote: do not fail if files do not exist yet (#6502) `` |
| [`dde2fba6`](https://github.com/nix-community/home-manager/commit/dde2fba628af2891e2e1ba8abb8be4e597edd49e) | `` home-cursor: add sway support (#6459) ``                           |
| [`148a6b55`](https://github.com/nix-community/home-manager/commit/148a6b55651ac794f5c20bbd76780b4d8fed4334) | `` Translate using Weblate (Catalan) ``                               |