### PR TITLE
chore(flake/home-manager): `9f74e14a` -> `765cb91e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740177427,
-        "narHash": "sha256-1xUiN0Yvvl/r+XyyXiJHxw64FwUGBfKF+XA7Ugm8ElU=",
+        "lastModified": 1740188029,
+        "narHash": "sha256-pnPs+XSpR633G/q0gj+SDyL4RaDfiKlom86zEBPtq+M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9f74e14a2d9af4c6f2024cca7813b830b020f45e",
+        "rev": "765cb91e9d5ab06ed8c92c25fc0e51d6c11d43cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`765cb91e`](https://github.com/nix-community/home-manager/commit/765cb91e9d5ab06ed8c92c25fc0e51d6c11d43cb) | `` psd: add missing module config options (#6230) `` |
| [`62d038f4`](https://github.com/nix-community/home-manager/commit/62d038f499b94d406df790dec04e201d222e5098) | `` nushell: reenable test ``                         |
| [`f0837fa6`](https://github.com/nix-community/home-manager/commit/f0837fa6730ad497f0329722263e2ef4683b09cf) | `` flake.lock: Update ``                             |
| [`e512de47`](https://github.com/nix-community/home-manager/commit/e512de4722831c850ec0681f69510fcba44f582d) | `` wluma: init module (#6463) ``                     |