### PR TITLE
chore(flake/home-manager): `765cb91e` -> `f4a07823`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740188029,
-        "narHash": "sha256-pnPs+XSpR633G/q0gj+SDyL4RaDfiKlom86zEBPtq+M=",
+        "lastModified": 1740208222,
+        "narHash": "sha256-FqgPcK5BK+Mc4cGBCGz555UsVd/TQK9FvmuamBWu+ZY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "765cb91e9d5ab06ed8c92c25fc0e51d6c11d43cb",
+        "rev": "f4a07823a298deff0efb0db30f9318511de7c232",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`f4a07823`](https://github.com/nix-community/home-manager/commit/f4a07823a298deff0efb0db30f9318511de7c232) | `` chromium: add nativeMessagingHosts option (#6019) ``         |
| [`2b382e49`](https://github.com/nix-community/home-manager/commit/2b382e499aa2fa7ac78bdf1cee079d45fb3a0334) | `` earthly: init module (#6265) ``                              |
| [`c31b4e33`](https://github.com/nix-community/home-manager/commit/c31b4e330e40a4fbf55ceb59741bd75bbb9c622c) | `` accounts/email: provide realName option for alias (#6106) `` |
| [`f0f0d1ad`](https://github.com/nix-community/home-manager/commit/f0f0d1ade22b51eaaf4d16e6b3f4990d8c348f3e) | `` docs: update copyright year ``                               |
| [`439a125a`](https://github.com/nix-community/home-manager/commit/439a125afef8c97308ec0c6db75d38e15d92208d) | `` tests: remove with lib (#6511) ``                            |
| [`e495cd8c`](https://github.com/nix-community/home-manager/commit/e495cd8c805a050d404abcb658cfe8cdaf589990) | `` tests/firefox: add profiles-extensions (#6510) ``            |