### PR TITLE
chore(flake/home-manager): `f4a07823` -> `a51e94e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740208222,
-        "narHash": "sha256-FqgPcK5BK+Mc4cGBCGz555UsVd/TQK9FvmuamBWu+ZY=",
+        "lastModified": 1740238815,
+        "narHash": "sha256-YkI2wknhQfZu5l02nTeAFV0FuBTaB2Ly39Bvsj9PQao=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f4a07823a298deff0efb0db30f9318511de7c232",
+        "rev": "a51e94e51c7df10f078a2530ce125df7410b4f33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`a51e94e5`](https://github.com/nix-community/home-manager/commit/a51e94e51c7df10f078a2530ce125df7410b4f33) | `` clipse: add module (#5777) ``                              |
| [`34d524f3`](https://github.com/nix-community/home-manager/commit/34d524f3edcf3a04c00ad2c09c24ec9d35d937f9) | `` imapnotify-accounts: remove with lib ``                    |
| [`dd21b9af`](https://github.com/nix-community/home-manager/commit/dd21b9afd5fefb0c80c3962869703acb3c56a5f2) | `` imapnotify: add extraArgs option to imapnotify-accounts `` |