### PR TITLE
chore(flake/home-manager): `a51e94e5` -> `cb3f6e9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740238815,
-        "narHash": "sha256-YkI2wknhQfZu5l02nTeAFV0FuBTaB2Ly39Bvsj9PQao=",
+        "lastModified": 1740254115,
+        "narHash": "sha256-MwxDtYB/MSGZlr/xS+ExGYH2QgHk73ShD40shxjad/Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a51e94e51c7df10f078a2530ce125df7410b4f33",
+        "rev": "cb3f6e9b59d3a5e51ef9f7da2b8418d5c72aaef8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`cb3f6e9b`](https://github.com/nix-community/home-manager/commit/cb3f6e9b59d3a5e51ef9f7da2b8418d5c72aaef8) | `` htop: write-protect entire configuration directory ``                     |
| [`61d8f836`](https://github.com/nix-community/home-manager/commit/61d8f8366fc327a42cc212d62dfff06ae0c3f195) | `` htop: export defaultFields into lib ``                                    |
| [`546949fe`](https://github.com/nix-community/home-manager/commit/546949fea16cf75b4f670c75a5251afee3e5b20f) | `` tests/dircolors: test zsh path ``                                         |
| [`89b89340`](https://github.com/nix-community/home-manager/commit/89b89340556e6347f494ff45fd8f136f2741b4a4) | `` tests/dircolors: add xdg config test ``                                   |
| [`c327afbf`](https://github.com/nix-community/home-manager/commit/c327afbfd859fee74162e22a4275888f5deb89e3) | `` dircolors: refactor preferXdgDirectories ``                               |
| [`413e9b35`](https://github.com/nix-community/home-manager/commit/413e9b35f17b2f24fd3a7ecbfc1237d9c3d502fd) | `` dircolors: respect preferXdgDirectories if set ``                         |
| [`61d8fc9a`](https://github.com/nix-community/home-manager/commit/61d8fc9af0f8568ffaff93e4001cb607f88790f9) | `` firefox: Allow to add PKCS11 modules (#5608) ``                           |
| [`90504b9a`](https://github.com/nix-community/home-manager/commit/90504b9a893b64c308640c3b7475a480d113fb2b) | `` thunderbird: allow managing feed accounts (#5613) ``                      |
| [`7ceacd98`](https://github.com/nix-community/home-manager/commit/7ceacd98a9fc99743ae7d9a5c0a4ea7c72314da6) | `` wpaperd: add systemd service; move to services/ from programs/ (#6302) `` |
| [`e860bd49`](https://github.com/nix-community/home-manager/commit/e860bd49eaa577089de22d370f6126ee4f6e7914) | `` vscode: add profiles support (#5640) ``                                   |
| [`4949081d`](https://github.com/nix-community/home-manager/commit/4949081d1ee37ebb1ca9fbef289955d85aace405) | `` jqp: add module (#5716) ``                                                |