### PR TITLE
chore(flake/home-manager): `fb568d75` -> `ed030a78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740265252,
-        "narHash": "sha256-+LFsCsIUF/pJWL9S21m5NLcK5bgwRB4MwfV0Iu7tggY=",
+        "lastModified": 1740283128,
+        "narHash": "sha256-R61wtNknWWejnl+K0l4sxu/wnLNFbNe44tNM2zbj5yE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fb568d75cf6c81f30d49eeb73787e9b56454ba16",
+        "rev": "ed030a787938cae01d693ebaad52bbb672a4a69d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`ed030a78`](https://github.com/nix-community/home-manager/commit/ed030a787938cae01d693ebaad52bbb672a4a69d) | `` chromium: optional nativeMessagingHosts (#6515) ``            |
| [`3b6550f7`](https://github.com/nix-community/home-manager/commit/3b6550f710e754bc9f58c09583f2fa51d9fd14ed) | `` git: add option to use riff as diff tool (#5748) ``           |
| [`6b7cd508`](https://github.com/nix-community/home-manager/commit/6b7cd50812e884a559481c7905317005a968ec08) | `` tests: test librewolf the same way firefox is tested ``       |
| [`7f9ba30a`](https://github.com/nix-community/home-manager/commit/7f9ba30a28f02e51c4785b2cc32bf573f8eac021) | `` tests: check that all firefox derivatives can be installed `` |