### PR TITLE
chore(flake/nix-index-database): `ae15068e` -> `46579253`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739676768,
-        "narHash": "sha256-U1HQ7nzhJyVVXUgjU028UCkbLQLEIkg42+G7iIiBmlU=",
+        "lastModified": 1740281615,
+        "narHash": "sha256-dZWcbAQ1sF8oVv+zjSKkPVY0ebwENQEkz5vc6muXbKY=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "ae15068e79e22b76c344f0d7f8aed1bb1c5b0b63",
+        "rev": "465792533d03e6bb9dc849d58ab9d5e31fac9023",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`46579253`](https://github.com/nix-community/nix-index-database/commit/465792533d03e6bb9dc849d58ab9d5e31fac9023) | `` update generated.nix to release 2025-02-23-031515 `` |
| [`fb4ee0d4`](https://github.com/nix-community/nix-index-database/commit/fb4ee0d4d8a501a7c8b84cfb87c222b05eac53f0) | `` flake.lock: Update ``                                |