### PR TITLE
chore(flake/stylix): `3a686a20` -> `f403ca10`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -771,11 +771,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1740241659,
-        "narHash": "sha256-2CXyPERfW6rm9R7nV73orfEsuqMlP/LoAfMUBK4s2jE=",
+        "lastModified": 1740325841,
+        "narHash": "sha256-+Bn9uAlDP+412lPvUmWzgSS2rtmwBavHcgeqNsbg/DI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "3a686a20b8f4dc026e561c1c5a85671c8cfeeb4f",
+        "rev": "f403ca101e11d92332c028abefe35441ea5e403e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                              |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`1398fc4d`](https://github.com/danth/stylix/commit/1398fc4dc8fd8e844ca23f275e87c988b0aa2c3f) | `` doc: use permalinks for option declarations ``                    |
| [`f4401071`](https://github.com/danth/stylix/commit/f4401071ea84ea6b4f90fb9b837760a0c9cceb63) | `` doc: add declaration entry ``                                     |
| [`4c04e0de`](https://github.com/danth/stylix/commit/4c04e0deceefb24ed4b8a0c788f3c673fd4ece06) | `` doc: redirect old reference pages to new location ``              |
| [`2b2f260a`](https://github.com/danth/stylix/commit/2b2f260a69ac3a0c327119c1b03f8ca1481ff7ef) | `` doc: collapse platforms and modules ``                            |
| [`99096ef3`](https://github.com/danth/stylix/commit/99096ef3e3dc186f67cc6470d2c92c67020a5c44) | `` doc: clarify global option ``                                     |
| [`13667122`](https://github.com/danth/stylix/commit/13667122ec568531e6447e0e8c14b06bf7d1ff08) | `` doc: standardize Bash code ``                                     |
| [`472bd50c`](https://github.com/danth/stylix/commit/472bd50c8538dc35f5af7576a11c07b7fcbf1205) | `` doc: store module documentation as a README within the module ``  |
| [`7afc6fb4`](https://github.com/danth/stylix/commit/7afc6fb46da6dd54a2e1d84991aabd09c16cb1a1) | `` doc: describe how to create module documentation ``               |
| [`d6796ff3`](https://github.com/danth/stylix/commit/d6796ff307fa9b0fbebf7379126c5871658f427e) | `` doc: fix some alerts not being rendered by `substituteInPlace` `` |
| [`de2057a0`](https://github.com/danth/stylix/commit/de2057a0006aec29370a39372a8c3f8269d005c4) | `` doc: disable section numbers ``                                   |
| [`77e58881`](https://github.com/danth/stylix/commit/77e58881df26be44ce8d04c8dbd5d4f179f7eefe) | `` doc: split modules into individual pages ``                       |
| [`e87bf16d`](https://github.com/danth/stylix/commit/e87bf16df961757649de40ad91be00b065813012) | `` stylix: use absolute paths for module imports ``                  |