### PR TITLE
chore(flake/stylix): `f403ca10` -> `f121a142`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -771,11 +771,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1740325841,
-        "narHash": "sha256-+Bn9uAlDP+412lPvUmWzgSS2rtmwBavHcgeqNsbg/DI=",
+        "lastModified": 1740334679,
+        "narHash": "sha256-FP8ggvqzdHQ1+vr0H9r+PQbFos9CtlO8bYK0tMnJK4o=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f403ca101e11d92332c028abefe35441ea5e403e",
+        "rev": "f121a142abde1b6aa9738e4c21a330c0ddd4eb70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                 |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`f121a142`](https://github.com/danth/stylix/commit/f121a142abde1b6aa9738e4c21a330c0ddd4eb70) | `` stylix: parametrize and change testbed field separator (#887) ``     |
| [`689fd55f`](https://github.com/danth/stylix/commit/689fd55ff286b01017c7d77acee6c904ce12f85c) | `` ci: make get-derivations job fail when input command fails (#888) `` |