### PR TITLE
chore(flake/tinted-schemes): `59d9dc3b` -> `a1bc2bd8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -867,11 +867,11 @@
     "tinted-schemes_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1740161196,
-        "narHash": "sha256-/qEq924mBc0Q7lcWKWSIEkptKOjUr/AoV+ma61Y1ymQ=",
+        "lastModified": 1740351358,
+        "narHash": "sha256-Hdk850xgAd3DL8KX0AbyU7tC834d3Lej1jOo3duWiOA=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "59d9dc3b27f76862aa35ea46289561e086f531ff",
+        "rev": "a1bc2bd89e693e7e3f5764cfe8114e2ae150e184",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                             |
| ------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`a1bc2bd8`](https://github.com/tinted-theming/schemes/commit/a1bc2bd89e693e7e3f5764cfe8114e2ae150e184) | `` Base24 mbadolato iterm2 (#13) `` |