### PR TITLE
chore(flake/nixos-hardware): `18e9f975` -> `9b49e201`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -578,11 +578,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1740089251,
-        "narHash": "sha256-Y78mDBWoO8CLLTjQfPfII+KXFb6lAmF9GrLbyVBsIMM=",
+        "lastModified": 1740383684,
+        "narHash": "sha256-VRkQ2PaWS51oYDbNCsG/OLyTIrbVMUo8VIUKYtVMqYA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "18e9f9753e9ae261bcc7d3abe15745686991fd30",
+        "rev": "9b49e201401825b581167c9467ff3791420644cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
| [`9b49e201`](https://github.com/NixOS/nixos-hardware/commit/9b49e201401825b581167c9467ff3791420644cc) | `` framework/13-inch/intel-core-ultra-series1: add check for hardware.enableRedistributableFirmware (#1367) `` |
| [`f75203cc`](https://github.com/NixOS/nixos-hardware/commit/f75203cc311b092a4c11f909bacd2534a7078c37) | `` common/gpu/nvidia: remove a default value (#1373) ``                                                        |
| [`d2483459`](https://github.com/NixOS/nixos-hardware/commit/d2483459e8113004955d34a025d500c21a683883) | `` surface: linux 6.12.14 -> 6.12.16 ``                                                                        |