### PR TITLE
chore(flake/nixos-hardware): `9b49e201` -> `d58f642d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -578,11 +578,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1740383684,
-        "narHash": "sha256-VRkQ2PaWS51oYDbNCsG/OLyTIrbVMUo8VIUKYtVMqYA=",
+        "lastModified": 1740387674,
+        "narHash": "sha256-pGk/aA0EBvI6o4DeuZsr05Ig/r4uMlSaf5EWUZEWM10=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9b49e201401825b581167c9467ff3791420644cc",
+        "rev": "d58f642ddb23320965b27beb0beba7236e9117b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`d58f642d`](https://github.com/NixOS/nixos-hardware/commit/d58f642ddb23320965b27beb0beba7236e9117b5) | `` Rename dell/e7240 to dell/latitude/e7240 ``                      |
| [`55e9685e`](https://github.com/NixOS/nixos-hardware/commit/55e9685ec6291cb010d57198dafc2e60bf294b13) | `` Fix Gigabyte B650 suspend issue (#1385) ``                       |
| [`bbf25ca9`](https://github.com/NixOS/nixos-hardware/commit/bbf25ca940de16f74bf2264935bd748d6793228d) | `` radxa: allow platformFirmware to be overridable ``               |
| [`9430c63e`](https://github.com/NixOS/nixos-hardware/commit/9430c63e02d72eeb4d42b8df144f833a29d47f2e) | `` radxa/rock-pi-e: init ``                                         |
| [`76a98e39`](https://github.com/NixOS/nixos-hardware/commit/76a98e3958980a4f59bf75bf615347b39f5576c6) | `` rockchip/rk3328: init ``                                         |
| [`9d5dedae`](https://github.com/NixOS/nixos-hardware/commit/9d5dedae845305c219e18c5d5d32b3afe42e0f62) | `` radxa: clarify that the interface may subject to more changes `` |
| [`0b2e2fe9`](https://github.com/NixOS/nixos-hardware/commit/0b2e2fe9b312d973d347ec71ec9323685dd17e5b) | `` rockchip: support generic firmware installation ``               |
| [`ab84bd93`](https://github.com/NixOS/nixos-hardware/commit/ab84bd93a3988fcbb2380df6563e575634f4c06f) | `` radxa/rock-5b: init ``                                           |
| [`28f2a745`](https://github.com/NixOS/nixos-hardware/commit/28f2a7454f6278ce51c8ce70b2fe8f6452789200) | `` rockchip/rk3588: init ``                                         |
| [`79bc209b`](https://github.com/NixOS/nixos-hardware/commit/79bc209be8dbb9fd68f1d6612fe0305ea0534099) | `` radxa/rock-pi-4: init ``                                         |
| [`80340dcf`](https://github.com/NixOS/nixos-hardware/commit/80340dcf8634d6a8e0920c5696cad5293fc8b64b) | `` rockchip/rk3399: reverse dependency order ``                     |
| [`099d38a6`](https://github.com/NixOS/nixos-hardware/commit/099d38a69ed75b6f549aa0daadc08c075d44a4d7) | `` lenovo/thinkpad/p16s/amd/gen2: init ``                           |
| [`71cca26f`](https://github.com/NixOS/nixos-hardware/commit/71cca26f33cdef1fb6490b69bbf20f3ca08b1558) | `` Set Alder Lake support for the Aoostar R1 N100 ``                |
| [`8f44cbb4`](https://github.com/NixOS/nixos-hardware/commit/8f44cbb48c2f4a54e35d991a903a8528178ce1a8) | `` raspberry-pi-4: poe-hat: add PWM polarity value ``               |
| [`fb12c827`](https://github.com/NixOS/nixos-hardware/commit/fb12c8270abf8933256c5b0ac522776c18bd1dac) | `` dell/xps/13-9315: fix screen flickering ``                       |
| [`cda83120`](https://github.com/NixOS/nixos-hardware/commit/cda83120608d10c0f122b2ac472a9c0c3e592b91) | `` apple/t2: format with nixfmt ``                                  |
| [`a0252d66`](https://github.com/NixOS/nixos-hardware/commit/a0252d668cacd7df728c099e691aa3482ba664c3) | `` apple/t2: add option to select kernel release ``                 |
| [`d098b095`](https://github.com/NixOS/nixos-hardware/commit/d098b095003946adf5714cc8edee501d8cf08e74) | `` apple/t2: refactor kernel package, add stable kernel ``          |
| [`04be27ce`](https://github.com/NixOS/nixos-hardware/commit/04be27ce4950145d6ac19e246720fdd8951d4c6c) | `` apple/t2: update docs to remove old option ``                    |