### PR TITLE
chore(flake/stylix): `f121a142` -> `cbe42e21`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -771,11 +771,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1740334679,
-        "narHash": "sha256-FP8ggvqzdHQ1+vr0H9r+PQbFos9CtlO8bYK0tMnJK4o=",
+        "lastModified": 1740411821,
+        "narHash": "sha256-SZlay2R2BY7kgTPjxL7gLoSycAkyZuVge8xM/0UOUJc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f121a142abde1b6aa9738e4c21a330c0ddd4eb70",
+        "rev": "cbe42e21eed73ae135d1a30e0d722eb2d5fb61cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                  |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`cbe42e21`](https://github.com/danth/stylix/commit/cbe42e21eed73ae135d1a30e0d722eb2d5fb61cd) | `` treewide: rename wpaperd and vscode options (#905) `` |
| [`2c4b5bec`](https://github.com/danth/stylix/commit/2c4b5bec3685da042a2241d3b26af5ea66f2b062) | `` hyprlock: fix background color definition (#906) ``   |
| [`c8e4a0d2`](https://github.com/danth/stylix/commit/c8e4a0d2186d388e3c6f3240b8b3ae422a7780d7) | `` treewide: optionalize stylix.image option (#717) ``   |