### PR TITLE
chore(flake/home-manager): `74f0a854` -> `53c587d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740494361,
-        "narHash": "sha256-Dd/GhJ9qKmUwuhgt/PAROG8J6YdU2ZjtJI9SQX5sVQI=",
+        "lastModified": 1740579671,
+        "narHash": "sha256-Dwt/3KknOQ4bgFG5YjqDT7oWRy27rPpDjAi2P0ok1zw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "74f0a8546e3f2458c870cf90fc4b38ac1f498b17",
+        "rev": "53c587d263f94aaf6a281745923c76bbec62bcf3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                   |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`53c587d2`](https://github.com/nix-community/home-manager/commit/53c587d263f94aaf6a281745923c76bbec62bcf3) | `` tmux: fix shell example (#5361) ``                                     |
| [`87743e93`](https://github.com/nix-community/home-manager/commit/87743e9383d4cbf4138dc65dd644822fc38e7bbf) | `` firefox: deprecate vendorPath (#6519) ``                               |
| [`18e74c2e`](https://github.com/nix-community/home-manager/commit/18e74c2e0225189858cd29890eb68212844efccc) | `` aerc-accounts: improve logic for parsing XOAUTH2 URL params (#6530) `` |