### PR TITLE
chore(flake/darwin): `42be12b5` -> `31631ea6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740452771,
-        "narHash": "sha256-/tI1vFJ7/dXJqUmI+s0EV1F0DPe6dZvT444mrLUkrlU=",
+        "lastModified": 1740613821,
+        "narHash": "sha256-kShMCSUUTS319NF5JwIR0CfbYdiOsIELoq+WZQ4vubs=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "42be12b510253d750138ec90c66decc282298b44",
+        "rev": "31631ea68f1df3a658d4e85682da2fcf19b0244b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                         |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`b1db30ce`](https://github.com/LnL7/nix-darwin/commit/b1db30ce36f25eb07a7d4832cc2d29b1697c00f1) | `` networking: Restore the original /etc/hosts on activation `` |
| [`1d9f6224`](https://github.com/LnL7/nix-darwin/commit/1d9f622484f00df0a8c00b13f427e4175760cf3c) | `` Revert "Add networking.hosts and .hostFiles from nixos " ``  |