### PR TITLE
chore(flake/home-manager): `53c587d2` -> `6be185eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740579671,
-        "narHash": "sha256-Dwt/3KknOQ4bgFG5YjqDT7oWRy27rPpDjAi2P0ok1zw=",
+        "lastModified": 1740606115,
+        "narHash": "sha256-GKe3vrIWcei4gSTckEzHr5Zf/g9NSofmsAnbkNYU+lM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "53c587d263f94aaf6a281745923c76bbec62bcf3",
+        "rev": "6be185eb76295e7562f5bf2da42afe374b8beb15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`6be185eb`](https://github.com/nix-community/home-manager/commit/6be185eb76295e7562f5bf2da42afe374b8beb15) | `` screen-locker: set Restart=always for all services (#6534) `` |
| [`44b86a72`](https://github.com/nix-community/home-manager/commit/44b86a72e73a7c3040ac54ed1c5eab5f156929bd) | `` xidlehook: set Restart=always (#6533) ``                      |