### PR TITLE
chore(flake/stylix): `b273375e` -> `e7c09d20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -750,11 +750,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1740584982,
-        "narHash": "sha256-4Ci+GoqFX8CLAI7IgsEoNDdJd4QvaU/MmHbkMcpyWeA=",
+        "lastModified": 1740644467,
+        "narHash": "sha256-i2ArXwncE2OmneLBllo5OlpLB2UsXU5JX+T+7or5OX4=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "b273375e6c2eab100e0f8a959d4932d0a6e50cad",
+        "rev": "e7c09d206680e6fe6771e1ac9a83515313feaf95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                            |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`21113945`](https://github.com/danth/stylix/commit/2111394586e922257168539142b2075e44c528b6) | `` Convert image path to string for Hyprlock fixing #918 (#925) `` |
| [`eab1ecf4`](https://github.com/danth/stylix/commit/eab1ecf41f2951e8655e7d66d19f21d5ab5fac4b) | `` docs: document configuring Standalone Nixvim ``                 |
| [`0a4755b6`](https://github.com/danth/stylix/commit/0a4755b656c28043c52063384fc68bbb30913903) | `` nixvim: expose config as read-only option ``                    |
| [`6c361e97`](https://github.com/danth/stylix/commit/6c361e9755d55df7c7eda10c5c40accdcf39da54) | `` nixvim: simplify enable conditions ``                           |