### PR TITLE
chore(flake/nixpkgs): `0196c017` -> `303bd807`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -593,11 +593,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740367490,
-        "narHash": "sha256-WGaHVAjcrv+Cun7zPlI41SerRtfknGQap281+AakSAw=",
+        "lastModified": 1740828860,
+        "narHash": "sha256-cjbHI+zUzK5CPsQZqMhE3npTyYFt9tJ3+ohcfaOF/WM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0196c0175e9191c474c26ab5548db27ef5d34b05",
+        "rev": "303bd8071377433a2d8f76e684ec773d70c5b642",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`bb9abd73`](https://github.com/NixOS/nixpkgs/commit/bb9abd73464c9ec1bc79673e78a1b7e01b72f243) | `` spades: 4.0.0 -> 4.1.0 ``                                                              |
| [`e154a5da`](https://github.com/NixOS/nixpkgs/commit/e154a5da7dcb4911218c63974726bb041e776605) | `` vcmi: 1.6.6 -> 1.6.7 ``                                                                |
| [`ea6e596d`](https://github.com/NixOS/nixpkgs/commit/ea6e596d8e81f376b199a9201292993dcdbb9943) | `` cargo-sort: 1.1.0 -> 1.0.9 ``                                                          |
| [`d5a89602`](https://github.com/NixOS/nixpkgs/commit/d5a896024c9087cfa070637ed5da447d698302e9) | `` ayugram-desktop: add kaeeraa and s0me1newithhand7s to maintainers ``                   |
| [`1df8cc80`](https://github.com/NixOS/nixpkgs/commit/1df8cc80419e904d28c0271d675d96801cf87f20) | `` kubexporter: init at 0.6.3 ``                                                          |
| [`6c678cb7`](https://github.com/NixOS/nixpkgs/commit/6c678cb7f1729214a77d454ca95c712362576bf5) | `` vscode-extensions.equinusocio.vsc-material-theme{-icons}: move to aliases ``           |
| [`a75a0d15`](https://github.com/NixOS/nixpkgs/commit/a75a0d157699e17d5fd8355296ea81de57c4a87b) | `` maintainers: add bakito ``                                                             |
| [`2934e7b2`](https://github.com/NixOS/nixpkgs/commit/2934e7b22f6e8ff59e9acd61a4ca90811a8e73db) | `` vscode-extensions.bmewburn.vscode-intelephense-client: 1.14.1 -> 1.14.2 ``             |
| [`f5090d49`](https://github.com/NixOS/nixpkgs/commit/f5090d4920dfce82eb1c8f53e653541290391206) | `` perlPackages.SearchXapian: remove at 1.2.25.5 ``                                       |
| [`1fc36967`](https://github.com/NixOS/nixpkgs/commit/1fc36967926e06984823fbe36874ae71ba36ef4c) | `` public-inbox: use Xapian over SearchXapian ``                                          |
| [`07466089`](https://github.com/NixOS/nixpkgs/commit/074660896aa345b3502a8192f4758bb54c27a0e0) | `` perlPackages.Xapian: init at 1.4.27 ``                                                 |
| [`ea9c81bc`](https://github.com/NixOS/nixpkgs/commit/ea9c81bc8d62cf8b50b9900e095c4d31050e1c18) | `` gfs2-utils: 3.5.1 -> 3.6.0 ``                                                          |
| [`cd850d57`](https://github.com/NixOS/nixpkgs/commit/cd850d57e0df12812af9fdb060671ff9873714b8) | `` build-support/php: support `lib.extendMkDerivation` for `php.mkComposerVendor` ``      |
| [`862a3e90`](https://github.com/NixOS/nixpkgs/commit/862a3e90a063cdfd4f6ef06c7c9087eb8ad03c18) | `` build-support/php: support `lib.extendMkDerivation` for `php.buildComposerProject2` `` |
| [`568375f5`](https://github.com/NixOS/nixpkgs/commit/568375f50533ebfef22c9a1ee4de99c7f900b603) | `` deck: 1.44.1 -> 1.45.0 ``                                                              |
| [`76bebdf1`](https://github.com/NixOS/nixpkgs/commit/76bebdf18ffd0f02c6a59947bc241322ac9cfdd6) | `` heimdall-proxy: init at 0.15.5 ``                                                      |
| [`15f0e5ab`](https://github.com/NixOS/nixpkgs/commit/15f0e5abde7b9a73f3ed243185ab6c1a0b552980) | `` heimdall-proxy: init at 0.15.5 ``                                                      |
| [`52362420`](https://github.com/NixOS/nixpkgs/commit/52362420d17d8d88402f08abc464c8d57ce2e8d1) | `` changedetection-io: 0.49.1 -> 0.49.3 ``                                                |
| [`b803de6e`](https://github.com/NixOS/nixpkgs/commit/b803de6e930bcdf4d25591194fb040a348eae36d) | `` python312Packages.openstacksdk: 4.3.0 -> 4.4.0 ``                                      |
| [`d343afa1`](https://github.com/NixOS/nixpkgs/commit/d343afa12b56532903779dfe6fc64f34c1fbdbd4) | `` python313Packages.python-openstackclient: 7.2.1 -> 7.4.0 ``                            |
| [`3fc8dc55`](https://github.com/NixOS/nixpkgs/commit/3fc8dc557e9d08ce6c08faeac68629752f60ace8) | `` fcitx5-mcbopomofo: 2.9.0 -> 2.9.1 ``                                                   |
| [`0f490f14`](https://github.com/NixOS/nixpkgs/commit/0f490f14af3c70865bb60ad618732a29b2ee147e) | `` pantheon.wingpanel-applications-menu: 8.0.0 -> 8.0.1 ``                                |
| [`7c85fe54`](https://github.com/NixOS/nixpkgs/commit/7c85fe54a66917df352ac4a8b8fc20bc5dedff34) | `` stylelint: 16.14.1 -> 16.15.0 ``                                                       |
| [`5c3ef3a2`](https://github.com/NixOS/nixpkgs/commit/5c3ef3a2c3456e8a811d5c63a5a06a9ffcf9db5e) | `` jreleaser-cli: 1.16.0 -> 1.17.0 ``                                                     |
| [`b571e6d9`](https://github.com/NixOS/nixpkgs/commit/b571e6d98a0d4b6241b2f42a629f87198d677c35) | `` volanta: init at 1.10.10 ``                                                            |
| [`4878c1d9`](https://github.com/NixOS/nixpkgs/commit/4878c1d900387d7e10ef7eab6370cb9df96367d1) | `` maintainers: added SirBerg ``                                                          |
| [`3d368ed0`](https://github.com/NixOS/nixpkgs/commit/3d368ed050ba9915c7ccda13175f5deab3638374) | `` immich: 1.127.0 -> 1.128.0 ``                                                          |
| [`677a8a4c`](https://github.com/NixOS/nixpkgs/commit/677a8a4cec6eb91d3b0a86801ec0b7953b24ed31) | `` windsurf: 1.3.9 -> 1.3.10 ``                                                           |
| [`25725c82`](https://github.com/NixOS/nixpkgs/commit/25725c82a18347049facd62e5af3b6cadc91ba66) | `` python313Packages.systemd: use libredirect.hook ``                                     |
| [`fcba7060`](https://github.com/NixOS/nixpkgs/commit/fcba706038d2c56296ff007f70a52478c79a4dd0) | `` ast-grep: cleanup & fix on aarch64-linux ``                                            |
| [`538ba70e`](https://github.com/NixOS/nixpkgs/commit/538ba70e5910f791076f7b712e669db6b86f6189) | `` hyprls: 0.5.0 -> 0.5.2 ``                                                              |
| [`920df35a`](https://github.com/NixOS/nixpkgs/commit/920df35ad1cf9b7446155079faffdb7d78335acc) | `` python312Packages.django-stubs: 5.1.2 -> 5.1.3 ``                                      |
| [`afcc902c`](https://github.com/NixOS/nixpkgs/commit/afcc902c69cbecfe59cbb1ed31fcc2c320cf684c) | `` python312Packages.checkdmarc: 5.7.8 -> 5.8.1 ``                                        |
| [`cddd94c4`](https://github.com/NixOS/nixpkgs/commit/cddd94c4ce2b91eece0d9055b6fb253da61112e5) | `` vscode-extensions.equinusocio.vsc-material-theme: remove at 34.7.5 ``                  |
| [`6c70dec0`](https://github.com/NixOS/nixpkgs/commit/6c70dec0e2018e8e51e2830edca8e89694ad5248) | `` vscode-extensions.equinusocio.vsc-material-theme-icons: remove at 3.8.8 ``             |
| [`616deb29`](https://github.com/NixOS/nixpkgs/commit/616deb295288029ced19f4aaf6521e6bd2050939) | `` faircamp: 1.1.1 -> 1.2.0 ``                                                            |
| [`a09de6a9`](https://github.com/NixOS/nixpkgs/commit/a09de6a90256438bbe75297a46f0784b03c49b1a) | `` dedup-darwin: init at 0.0.6 ``                                                         |
| [`6d7ccd95`](https://github.com/NixOS/nixpkgs/commit/6d7ccd9566c51fc7c8558cb41f5ac3d57d6624ac) | `` perlPackages.NetSNMP: use libredirect.hook ``                                          |
| [`55998362`](https://github.com/NixOS/nixpkgs/commit/55998362c4a3e16d514e4088e1c563a6f9183a16) | `` python312Packages.elevenlabs: 1.51.0 -> 1.52.0 ``                                      |
| [`a49864a7`](https://github.com/NixOS/nixpkgs/commit/a49864a7c242d17915b8acc88f8f7b0ed25564f9) | `` python312Packages.weaviate-client: 4.10.4 -> 4.11.1 ``                                 |
| [`bae20f27`](https://github.com/NixOS/nixpkgs/commit/bae20f27d768e2b2451f003824ee2636fbc69c11) | `` voicevox: 0.22.4 -> 0.23.0 ``                                                          |
| [`cbef2a75`](https://github.com/NixOS/nixpkgs/commit/cbef2a7517d03244a6bab6d98ca1011b1b9092c3) | `` voicevox-engine: 0.22.2 -> 0.23.0 ``                                                   |
| [`1e0c366f`](https://github.com/NixOS/nixpkgs/commit/1e0c366f366f9cb99fdb390de56de4ed5e2044ff) | `` python312Packages.eliot: 1.16.0 -> 1.17.5 ``                                           |
| [`2563f38d`](https://github.com/NixOS/nixpkgs/commit/2563f38d01ea1f18c8044d9395fcfb2bd61f33ad) | `` mxnet: don't try to build on darwin ``                                                 |
| [`ee769d74`](https://github.com/NixOS/nixpkgs/commit/ee769d74cdb969415babdcfb1f2841011bb8e17c) | `` phpunit: 12.0.2 -> 12.0.5 ``                                                           |
| [`6a68ed86`](https://github.com/NixOS/nixpkgs/commit/6a68ed86182a0c753f0177076e3105941203c7dc) | `` cargo-show-asm: 0.2.47 -> 0.2.48 ``                                                    |
| [`861f591e`](https://github.com/NixOS/nixpkgs/commit/861f591eb72db72469270e4699379de83931c768) | `` hot-resize: init at 0.1.1 ``                                                           |
| [`b03ddc07`](https://github.com/NixOS/nixpkgs/commit/b03ddc0714297eb05561e5754465d9c8642502f3) | `` sedutil: 1.20.0 -> 1.49.6 ``                                                           |
| [`7315e80c`](https://github.com/NixOS/nixpkgs/commit/7315e80cb3c7e2682c9974373605a11774d0db15) | `` python312Packages.pylamarzocco: 1.4.6 -> 1.4.7 ``                                      |
| [`5bb6489b`](https://github.com/NixOS/nixpkgs/commit/5bb6489b2b225432351366791596593d499b4424) | `` vimPlugins.nvim-treesitter: update grammars ``                                         |
| [`d3563e6b`](https://github.com/NixOS/nixpkgs/commit/d3563e6b7c0141a474ac669c9c87853d866ae69e) | `` vimPlugins: resolve github repository redirects ``                                     |
| [`f4f79c9c`](https://github.com/NixOS/nixpkgs/commit/f4f79c9c9fa02ac21370e6b7080a48f3cfcb8daf) | `` vimPlugins: update on 2025-02-28 ``                                                    |
| [`764b1ae7`](https://github.com/NixOS/nixpkgs/commit/764b1ae7b65c3349bcd2432be0cb66a63259d1f6) | `` gpxsee: 13.35 -> 13.36 ``                                                              |
| [`413fe34e`](https://github.com/NixOS/nixpkgs/commit/413fe34e47670d6e82e4f48802d8ea7f8da59ecb) | `` mpvScripts.mpv-playlistmanager: 0-unstable-2025-01-08 -> 0-unstable-2025-02-23 ``      |
| [`6ec6eae5`](https://github.com/NixOS/nixpkgs/commit/6ec6eae5864379145d5ba3121e13271d82cea1fd) | `` Revert "nixos/grub: generate BLS entries" ``                                           |
| [`9f03bab3`](https://github.com/NixOS/nixpkgs/commit/9f03bab37c6df866341a4f62dc7abb4d56db872e) | `` ananicy-rules-cachyos: 0-unstable-2025-02-05 -> 0-unstable-2025-02-28 ``               |
| [`9e8390e3`](https://github.com/NixOS/nixpkgs/commit/9e8390e3b263c6233b146988298ae5da66f2682d) | `` vscode-extensions.bmewburn.vscode-intelephense-client: 1.12.5 -> 1.14.1 ``             |
| [`92a0f1c3`](https://github.com/NixOS/nixpkgs/commit/92a0f1c301192b8fc0bf7e7df824118e980764ae) | `` nix-output-monitor: 2.1.4 -> 2.1.5 ``                                                  |
| [`9e966214`](https://github.com/NixOS/nixpkgs/commit/9e966214638a7da75e43b9c9f2c34cd9e32b768f) | `` oh-my-zsh: 2025-02-14 -> 2025-02-19 (#385869) ``                                       |
| [`a719a4fe`](https://github.com/NixOS/nixpkgs/commit/a719a4fe041795e84acd8551df80efe49bdbdeda) | `` intelephense: 1.12.6 -> 1.14.1 ``                                                      |
| [`cfb72a5f`](https://github.com/NixOS/nixpkgs/commit/cfb72a5fd461e3c8a1115485bf01cc3e1217ed31) | `` terraform-providers.mongodbatlas: 1.26.1 -> 1.28.0 ``                                  |
| [`6795e949`](https://github.com/NixOS/nixpkgs/commit/6795e9498f885783cff1de45f71054dc810220df) | `` terraform-providers.ns1: 2.5.1 -> 2.5.2 ``                                             |
| [`30de7131`](https://github.com/NixOS/nixpkgs/commit/30de7131a407f677dfac7da66058fc32e6393eb8) | `` rainfrog: 0.2.13 -> 0.2.14 ``                                                          |
| [`e264a0df`](https://github.com/NixOS/nixpkgs/commit/e264a0df1aefa0ecfeb7940866eb853b56b7529a) | `` goose-lang: 0.9.1 -> 0.9.2 ``                                                          |
| [`717325ed`](https://github.com/NixOS/nixpkgs/commit/717325ed9c3c89fd561172ace3af6a41dc39d4b3) | `` fedifetcher: 7.1.14 -> 7.1.15 ``                                                       |
| [`0e102647`](https://github.com/NixOS/nixpkgs/commit/0e1026474f2d10709e1741d34925050a923094fa) | `` nemo-seahorse: init at 6.4.0 ``                                                        |
| [`24165559`](https://github.com/NixOS/nixpkgs/commit/2416555900cdcaddc0a045f44069fb6e8a67eee4) | `` python313Packages.drf-extra-fields: add pytz dependency ``                             |
| [`8954980a`](https://github.com/NixOS/nixpkgs/commit/8954980a7d4c79b6c2b80a2cc2321205654757f4) | `` python312Packages.zwave-js-server-python: 0.60.0 -> 0.60.1 ``                          |
| [`72fe6ca5`](https://github.com/NixOS/nixpkgs/commit/72fe6ca5f1f9339d0fa2e1234504d30552c59951) | `` dbeaver-bin: 24.3.4 -> 24.3.5 ``                                                       |
| [`d46ced5a`](https://github.com/NixOS/nixpkgs/commit/d46ced5ab5ed85bb4692224a4701017e7442ba7d) | `` code-cursor: 0.45.11 -> 0.45.14 ``                                                     |
| [`3fb6f4fe`](https://github.com/NixOS/nixpkgs/commit/3fb6f4fe9a6c080c419246b3cfdd0f35909a06d5) | `` openvino: enable npu/gpu support ``                                                    |
| [`259e17b6`](https://github.com/NixOS/nixpkgs/commit/259e17b69140aad09e11fd7a1da3157427b935e8) | `` libdeltachat: 1.156.0 -> 1.156.1 ``                                                    |
| [`979c08d1`](https://github.com/NixOS/nixpkgs/commit/979c08d171936c61bc2f6331226c04704c0a1e43) | `` tray-tui: init at 0.1.0 ``                                                             |
| [`077f472c`](https://github.com/NixOS/nixpkgs/commit/077f472c281bcc986d852a16e624c1382c102e2d) | `` efmt: 0.19.0 -> 0.19.1 ``                                                              |
| [`8bbce427`](https://github.com/NixOS/nixpkgs/commit/8bbce427ff6809673cb4edf1d7ddbc87b0e836cd) | `` all-the-package-names: 2.0.2042 -> 2.0.2070 ``                                         |
| [`ad130744`](https://github.com/NixOS/nixpkgs/commit/ad1307444c243be8ef0007a93fb7e436b2ab91ba) | `` dependency-track: 4.12.5 -> 4.12.6 ``                                                  |
| [`75403c4e`](https://github.com/NixOS/nixpkgs/commit/75403c4e2316308067b153bb294b891adb0ccdd2) | `` mutt: Add zlib to buildInputs ``                                                       |
| [`a94dc905`](https://github.com/NixOS/nixpkgs/commit/a94dc905b34f1d2cac0c6145311ec8699293c277) | `` webpack-cli: 5.1.4 -> 6.0.1 ``                                                         |
| [`cfeaf61d`](https://github.com/NixOS/nixpkgs/commit/cfeaf61d5933c375906e2ef1387ea84c211a7446) | `` paperless-ngx: set meta.mainProgram ``                                                 |
| [`3f29dce6`](https://github.com/NixOS/nixpkgs/commit/3f29dce6df22f1385fbb52f936daf54af10e4668) | `` nixos/tests/velocity: init ``                                                          |
| [`30f82d2e`](https://github.com/NixOS/nixpkgs/commit/30f82d2e883b178ea8da2496ba47c240ea32362b) | `` velocity: init at 3.4.0-unstable-2025-02-28 ``                                         |
| [`30696826`](https://github.com/NixOS/nixpkgs/commit/306968264396edc1fa1e26e7dda329bca69c4374) | `` freefilesync: 14.0 -> 14.2 ``                                                          |
| [`32ad75bf`](https://github.com/NixOS/nixpkgs/commit/32ad75bfe7f293c30b9d182d5852a5ba1690e3ba) | `` opencv: fix fallback which causes infinite recursion ``                                |
| [`22e9956a`](https://github.com/NixOS/nixpkgs/commit/22e9956a941c20188536168c5c32086016cea0e4) | `` opencv: fix ade hash to fix gapi support ``                                            |
| [`2eafee5f`](https://github.com/NixOS/nixpkgs/commit/2eafee5fcd47933e6a1e3a5c2e1187a785414994) | `` opencv: cleanup unused code ``                                                         |
| [`c2601d11`](https://github.com/NixOS/nixpkgs/commit/c2601d1118b68a54894b7a6a2599c8fa2c32d444) | `` coc-diagnostic: fix by removing dangling symlink ``                                    |
| [`188e27a2`](https://github.com/NixOS/nixpkgs/commit/188e27a26c9470468e535f963dd5548cda15d31e) | `` taze: init at 18.6.0 ``                                                                |
| [`bab68266`](https://github.com/NixOS/nixpkgs/commit/bab68266959577575206aff4bc93b4ec43397d5d) | `` ntpd-rs: 1.4.0 -> 1.5.0 ``                                                             |
| [`230a1fcb`](https://github.com/NixOS/nixpkgs/commit/230a1fcb1a5f3e5394c3f3a1420bae5f05cb4764) | `` vimPlugins.blink-cmp: 0.13.0 -> 0.13.1 ``                                              |
| [`f633c4e6`](https://github.com/NixOS/nixpkgs/commit/f633c4e69d4f6c7821a3aed13b63835970cc7feb) | `` n98-magerun2: 7.5.0 -> 8.0.0 ``                                                        |
| [`120c1d6d`](https://github.com/NixOS/nixpkgs/commit/120c1d6db4c0cf5de52be670280e8e0e16f6f923) | `` vimPlugins: remove nvim-web-devicons from vim-plugin-names ``                          |
| [`6816d4dd`](https://github.com/NixOS/nixpkgs/commit/6816d4dd1d3e879e78a5d13f93303d4d6591e23a) | `` python312Packages.django-import-export: 4.3.5 -> 4.3.7 ``                              |
| [`f70879f8`](https://github.com/NixOS/nixpkgs/commit/f70879f8d8ec8e9de94bdf0aa05ed781b37377f1) | `` python312Packages.folium: 0.19.4 -> 0.19.5 ``                                          |
| [`a6178d65`](https://github.com/NixOS/nixpkgs/commit/a6178d65c3722068c593abca5cf6884fb218f463) | `` mu: 1.12.8 -> 1.12.9 ``                                                                |
| [`ed500e2e`](https://github.com/NixOS/nixpkgs/commit/ed500e2ebe6e85773a90b9f403be212d5052faa9) | `` a-keys-path: init at 0.7.1 ``                                                          |
| [`0d1166e2`](https://github.com/NixOS/nixpkgs/commit/0d1166e2bb2e4e95523385da202898b070e2cd52) | `` pcl: add usertam to maintainers ``                                                     |
| [`50a5ea49`](https://github.com/NixOS/nixpkgs/commit/50a5ea49f361f6bf716ceaf7536118fe01d2d7b8) | `` pcl: fix build on darwin ``                                                            |
| [`bceedda5`](https://github.com/NixOS/nixpkgs/commit/bceedda59e65e3f6d0d7024f638906197c022ffc) | `` cherry-studio: init at 1.0.1 ``                                                        |
| [`a05f4efc`](https://github.com/NixOS/nixpkgs/commit/a05f4efc0664138a10ecf4512f889f58b57f57ca) | `` libastyle: 3.6.6 -> 3.6.7 ``                                                           |
| [`61016c1e`](https://github.com/NixOS/nixpkgs/commit/61016c1edaef05b9f7403ecb3381db2b582a9bac) | `` epic5: 3.0.2 -> 3.0.3 ``                                                               |
| [`f4d6f4e1`](https://github.com/NixOS/nixpkgs/commit/f4d6f4e1f372ce3aab1c51166606d5c91603a4e4) | `` pgpool: 4.5.5 -> 4.6.0 ``                                                              |
| [`9151cdb8`](https://github.com/NixOS/nixpkgs/commit/9151cdb81ea0f663388a62775677c8cdba4c7c20) | `` python3Packages.subliminal: set setuptools as build system ``                          |
| [`fdf10c7f`](https://github.com/NixOS/nixpkgs/commit/fdf10c7f6dd20ef867f16f277cfe8f2714cdb34e) | `` beetsPackages.alternatives: 0.13.1 -> 0.13.2 ``                                        |
| [`fc5e7b83`](https://github.com/NixOS/nixpkgs/commit/fc5e7b83407101159cb3158a55506b4765c411c3) | `` keycloak: 26.1.2 -> 26.1.3 ``                                                          |