### PR TITLE
chore(flake/lovesegfault-vim-config): `2a1b037f` -> `7a4d97d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740670683,
-        "narHash": "sha256-Ecfwxc/eS+AC0rq+AKTgAv3v3bl6NLEQj91aH4q7MI8=",
+        "lastModified": 1740701274,
+        "narHash": "sha256-9Q9KwdsTHlPnBjtSx/E2OQeNjQKIGeEYBK8glTKQ5vg=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "2a1b037f394db76f6f5b348ab8cb23178563bee3",
+        "rev": "7a4d97d450ec410c29981915ca28f27db0914332",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`7a4d97d4`](https://github.com/lovesegfault/vim-config/commit/7a4d97d450ec410c29981915ca28f27db0914332) | `` chore(flake/nixpkgs): 0196c017 -> 5135c594 `` |