### PR TITLE
chore(flake/darwin): `665cc04a` -> `5d6e0851`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740636552,
-        "narHash": "sha256-vBtVB8uU4Bxbyz43MhldAGX91i15j4LJI1Ss3mCCO7s=",
+        "lastModified": 1740755725,
+        "narHash": "sha256-amZbqP84H/ApugaT+TADXTB3NbjkVHI9Vac1saIk0kE=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "665cc04a60eb8ba47d41eadbe6264ca8a71943e8",
+        "rev": "5d6e0851b60508cffd66b4a6982440a40720338d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                             |
| ------------------------------------------------------------------------------------------------ | ----------------------------------- |
| [`7386d887`](https://github.com/LnL7/nix-darwin/commit/7386d8878ec409f672f64df24e4d00da04bfc8ce) | `` services/dnscrypt-proxy: init `` |