### PR TITLE
chore(flake/git-hooks): `a548245d` -> `4a709a8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -312,11 +312,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740844297,
-        "narHash": "sha256-t7nPEm+7YXnW94gSlXkvfcxZ4aLn2a0xq7UpTmy7Jlk=",
+        "lastModified": 1740849354,
+        "narHash": "sha256-oy33+t09FraucSZ2rZ6qnD1Y1c8azKKmQuCvF2ytUko=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "a548245dc9fc0297f802746a48d6ce4a46f2d258",
+        "rev": "4a709a8ce9f8c08fa7ddb86761fe488ff7858a07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`741fee02`](https://github.com/cachix/git-hooks.nix/commit/741fee02daf336cbca92e2887fbfb6d36050d305) | `` feat: add proselint (#555) ``                           |
| [`8dd173fe`](https://github.com/cachix/git-hooks.nix/commit/8dd173fea096445d8e61c342827bb4a223231778) | `` fix: add configFile option ``                           |
| [`bf798609`](https://github.com/cachix/git-hooks.nix/commit/bf798609c796fb8e9945c5b87dc014c9b7a3058d) | `` feat: update pre-commit.nix to be "run" customizable `` |