### PR TITLE
chore(flake/home-manager): `30da4310` -> `fcac3d6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740840901,
-        "narHash": "sha256-nAHSkQJ2J5W8rGSReohh4xZ1b2edkG2UIj/4tF+ARAQ=",
+        "lastModified": 1740845322,
+        "narHash": "sha256-AXEgFj3C0YJhu9k1OhbRhiA6FnDr81dQZ65U3DhaWpw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "30da4310935450ea38931abf775ffe1dfab15355",
+        "rev": "fcac3d6d88302a5e64f6cb8014ac785e08874c8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`fcac3d6d`](https://github.com/nix-community/home-manager/commit/fcac3d6d88302a5e64f6cb8014ac785e08874c8d) | `` xdg: use mkOptionDefault ``                      |
| [`66505b85`](https://github.com/nix-community/home-manager/commit/66505b851b160a6937053a73b9b9808659df8c56) | `` xdg: add missing stateHome default for legacy `` |
| [`47c69496`](https://github.com/nix-community/home-manager/commit/47c694963e86b3e0f5d387506642a830871f331e) | `` tests: move xdg to cross platform tests ``       |
| [`17fd27a8`](https://github.com/nix-community/home-manager/commit/17fd27a8ea2d38c52f66c7685e766113ca4b2982) | `` tests: use mkDefault with enable ``              |