### PR TITLE
chore(flake/git-hooks): `4a709a8c` -> `25d4946d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -312,11 +312,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740849354,
-        "narHash": "sha256-oy33+t09FraucSZ2rZ6qnD1Y1c8azKKmQuCvF2ytUko=",
+        "lastModified": 1740870877,
+        "narHash": "sha256-LWDIJvKWMW0tiih1jTcAK0ncTi3S9IF3gOhpCT1ydik=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4a709a8ce9f8c08fa7ddb86761fe488ff7858a07",
+        "rev": "25d4946dfc2021584f5bde1fbd2aa97353384a95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`3adca9e8`](https://github.com/cachix/git-hooks.nix/commit/3adca9e8ed94feefb52765a0645e65a8ced04c2c) | `` Exposes configPath to the run wrapper `` |