### PR TITLE
chore(flake/lovesegfault-vim-config): `7a4d97d4` -> `b57a7012`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740701274,
-        "narHash": "sha256-9Q9KwdsTHlPnBjtSx/E2OQeNjQKIGeEYBK8glTKQ5vg=",
+        "lastModified": 1740874145,
+        "narHash": "sha256-zph3DMbDxDoRmzOjA5piQ1eLDjaq3rH5MoyEDNnSpMA=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "7a4d97d450ec410c29981915ca28f27db0914332",
+        "rev": "b57a70124a018e04a3722ae4b6915b07d1fd921f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`b57a7012`](https://github.com/lovesegfault/vim-config/commit/b57a70124a018e04a3722ae4b6915b07d1fd921f) | `` chore(flake/git-hooks): 9364dc02 -> 25d4946d ``   |
| [`d6fc9fe7`](https://github.com/lovesegfault/vim-config/commit/d6fc9fe7db61175fb1f564e8aeddb04c901abb8f) | `` chore(flake/flake-parts): 32ea77a0 -> 3876f6b8 `` |