### PR TITLE
chore(flake/git-hooks): `25d4946d` -> `42b1ba08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -312,11 +312,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740870877,
-        "narHash": "sha256-LWDIJvKWMW0tiih1jTcAK0ncTi3S9IF3gOhpCT1ydik=",
+        "lastModified": 1740915799,
+        "narHash": "sha256-JvQvtaphZNmeeV+IpHgNdiNePsIpHD5U/7QN5AeY44A=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "25d4946dfc2021584f5bde1fbd2aa97353384a95",
+        "rev": "42b1ba089d2034d910566bf6b40830af6b8ec732",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`48ebf153`](https://github.com/cachix/git-hooks.nix/commit/48ebf1537f97ffb989c126530c58091e3b4b66d5) | `` fix(fourmolu): refer to its own settings `` |