### PR TITLE
chore(flake/nixpkgs): `303bd807` -> `ba487dbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -593,11 +593,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740828860,
-        "narHash": "sha256-cjbHI+zUzK5CPsQZqMhE3npTyYFt9tJ3+ohcfaOF/WM=",
+        "lastModified": 1741010256,
+        "narHash": "sha256-WZNlK/KX7Sni0RyqLSqLPbK8k08Kq7H7RijPJbq9KHM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "303bd8071377433a2d8f76e684ec773d70c5b642",
+        "rev": "ba487dbc9d04e0634c64e3b1f0d25839a0a68246",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`66558120`](https://github.com/NixOS/nixpkgs/commit/665581202ac4eb9ac8963ca076f65b2b69732da3) | `` phpPackages.php-cs-fixer: fix hash ``                                           |
| [`e38c82f4`](https://github.com/NixOS/nixpkgs/commit/e38c82f4cc71fdbc066e93e9915b31d02471bd50) | `` frankenphp: 1.4.3 -> 1.4.4 ``                                                   |
| [`94e563c7`](https://github.com/NixOS/nixpkgs/commit/94e563c77fbe5c56290959970130904becfbab4e) | `` air-formatter: 0.4.0 -> 0.4.1 ``                                                |
| [`7768e6b9`](https://github.com/NixOS/nixpkgs/commit/7768e6b94fdec14ee0dc366aa850ea8f2dc11af1) | `` buildkite-agent: override buildVersion sentinel value to fix crashes ``         |
| [`bbfdb679`](https://github.com/NixOS/nixpkgs/commit/bbfdb679cc94beaa98084b1b66ef8ac37717efdb) | `` bacon: 3.10.0 -> 3.11.0 ``                                                      |
| [`86116722`](https://github.com/NixOS/nixpkgs/commit/86116722fd1d966eb4e2b10687eed8879efc6a82) | `` Revert "electron-bin: don't wrap inside libexec" ``                             |
| [`807a57ff`](https://github.com/NixOS/nixpkgs/commit/807a57ff887b345c87942c830cddb87d257cfa05) | `` Revert "electron-bin: remove leftover logic" ``                                 |
| [`d39e23d3`](https://github.com/NixOS/nixpkgs/commit/d39e23d37c832cd2e58c670fae7f1f59701b32d4) | `` vimPlugins.blink-cmp: fetch patches using a URL that gives us stable diffs ``   |
| [`4c5af104`](https://github.com/NixOS/nixpkgs/commit/4c5af10411bc08932cde9badaec212b988ce6c5b) | `` python312Packages.docling: 2.23.0 -> 2.25.1 ``                                  |
| [`44e8bf6e`](https://github.com/NixOS/nixpkgs/commit/44e8bf6e8a6d9b1bfee121e4717a49a03d2262f0) | `` python312Packages.docling-ibm-models: 3.3.2 -> 3.4.1 ``                         |
| [`9bc62609`](https://github.com/NixOS/nixpkgs/commit/9bc6260998b53825544192052f4cb9015fac9dc0) | `` Add coq Matrix package 8.18 (#373307) ``                                        |
| [`13392df4`](https://github.com/NixOS/nixpkgs/commit/13392df49ad13fdf5ac911f9f23505f9d52de7d9) | `` cargo-insta: Fix build ``                                                       |
| [`e3f8b2f1`](https://github.com/NixOS/nixpkgs/commit/e3f8b2f1445a7f9758186b28aa1d75d8ed4fd381) | `` update cargo-insta 1.40 -> 1.42.2 ``                                            |
| [`4798092a`](https://github.com/NixOS/nixpkgs/commit/4798092ab48eb0a9957767847f25b170a4096080) | `` wlx-overlay-s: 25.2.0 -> 25.3.0 ``                                              |
| [`dd82cce7`](https://github.com/NixOS/nixpkgs/commit/dd82cce76670a16c7f21e1bd769eee0d45d58fe5) | `` nixos/tandoor-recipes: fix default user and group creation ``                   |
| [`66f9dc73`](https://github.com/NixOS/nixpkgs/commit/66f9dc732ea5d273ee31eb8f8a22152f856e4972) | `` hyprgraphics: 0.1.1 -> 0.1.2 ``                                                 |
| [`7948ce98`](https://github.com/NixOS/nixpkgs/commit/7948ce986f26eced96fe8f59edda52330d459ecd) | `` hyprgraphics: fix meta, add libspng ``                                          |
| [`8450cd14`](https://github.com/NixOS/nixpkgs/commit/8450cd14668ed7a5342348af1d5318d5f4087761) | `` circt: 1.107.0 -> 1.108.0 (#386612) ``                                          |
| [`b455353e`](https://github.com/NixOS/nixpkgs/commit/b455353e842c1f7bc5726d6338175e3ed3386e4b) | `` python313Packages.iterfzf: 1.4.0.54.3 -> 1.4.0.60.2 ``                          |
| [`c4b1f020`](https://github.com/NixOS/nixpkgs/commit/c4b1f020863e6f9bc96b2a8a39f84bf934b2f388) | `` python313Packages.inkbird-ble: 0.7.0 -> 0.7.1 ``                                |
| [`3c705883`](https://github.com/NixOS/nixpkgs/commit/3c705883ef5068a6ef7c46aecb3b5a7e705a0146) | `` python313Packages.aiohomeconnect: 0.15.1 -> 0.16.0 ``                           |
| [`fd1c9b35`](https://github.com/NixOS/nixpkgs/commit/fd1c9b35959c1c0471117220d1f3ca5314e07088) | `` python313Packages.aiocomelit: 0.11.0 -> 0.11.1 ``                               |
| [`25622334`](https://github.com/NixOS/nixpkgs/commit/25622334ec79029500c19312d70a505dcc0fb921) | `` python313Packages.tencentcloud-sdk-python: 3.0.1327 -> 3.0.1328 ``              |
| [`95a3b72a`](https://github.com/NixOS/nixpkgs/commit/95a3b72a206b7682e284333ae2f751ce389b01dc) | `` python313Packages.publicsuffixlist: 1.0.2.20250301 -> 1.0.2.20250302 ``         |
| [`cc275c5d`](https://github.com/NixOS/nixpkgs/commit/cc275c5d513096b5f2f62d5a94e84965efb53222) | `` python313Packages.pypykatz: 0.6.10 -> 0.6.11 ``                                 |
| [`170af88f`](https://github.com/NixOS/nixpkgs/commit/170af88f666cb21294aece153bee9977fedcf570) | `` python313Packages.pyexploitdb: 0.2.69 -> 0.2.70 ``                              |
| [`a775d437`](https://github.com/NixOS/nixpkgs/commit/a775d43750dd8298216482c7170803a4b359d9b0) | `` python313Packages.motionblinds: 0.6.25 -> 0.6.26 ``                             |
| [`92e20413`](https://github.com/NixOS/nixpkgs/commit/92e20413be49c2cfd011cc456eacb1822c9bb6c7) | `` python313Packages.model-checker: 0.8.5 -> 0.8.6 ``                              |
| [`11cc0363`](https://github.com/NixOS/nixpkgs/commit/11cc03633fd19779aea68b47a51f7efb26221e5a) | `` python313Packages.botocore-stubs: 1.37.1 -> 1.37.4 ``                           |
| [`4cf11a00`](https://github.com/NixOS/nixpkgs/commit/4cf11a00a3ee33816aa4ba929a077bf71520ee05) | `` python312Packages.umap-learn: 0.5.7 -> 0.5.8 ``                                 |
| [`f2859fe2`](https://github.com/NixOS/nixpkgs/commit/f2859fe2355d0843a7a8d201fd27f9461cb54332) | `` python312Packages.ripser: cleanup & skip failing tests on darwin ``             |
| [`3f16388e`](https://github.com/NixOS/nixpkgs/commit/3f16388e73fd5348c482a927cc651d2363657a4f) | `` python312Packages.pynndescent: disable on aarch64-linux ``                      |
| [`5dee9a0f`](https://github.com/NixOS/nixpkgs/commit/5dee9a0f9b2c9480d6cb4757dac9804b0e788377) | `` polarity: latest-unstable-2025-02-13 -> latest-unstable-2025-02-28 ``           |
| [`d124a642`](https://github.com/NixOS/nixpkgs/commit/d124a64295c3b1fefcd292a30150b50b7861c673) | `` treewide: use mirror urls (#386594) ``                                          |
| [`cba76e39`](https://github.com/NixOS/nixpkgs/commit/cba76e399761ec7c00bac63f9f86322896f5460f) | `` mangojuice: 0.8.1 -> 0.8.2 ``                                                   |
| [`1f473129`](https://github.com/NixOS/nixpkgs/commit/1f473129f7182f7bf531b266c4dfa004699d9922) | `` v2ray-domain-list-community: 20250227085631 -> 20250302153845 ``                |
| [`5e93f9d1`](https://github.com/NixOS/nixpkgs/commit/5e93f9d111d74f14e67ba4dd6f410b2e7bee0774) | `` python312Packages.pynndescent: modernize ``                                     |
| [`862962af`](https://github.com/NixOS/nixpkgs/commit/862962af8713f891f4a1aea7f78163c9bd9613c8) | `` xdp-tools: patch to allow building with Emacs 30 ``                             |
| [`91c5feee`](https://github.com/NixOS/nixpkgs/commit/91c5feeefd014e1e26c48d3e74d04d330c475f08) | `` discord: 0.0.86 -> 0.0.87 ``                                                    |
| [`d4f02cfa`](https://github.com/NixOS/nixpkgs/commit/d4f02cfa2f0053e35cc55ba997bb5e4a58ff45e8) | `` ldeep: 1.0.81 -> 1.0.84 ``                                                      |
| [`6dee6be3`](https://github.com/NixOS/nixpkgs/commit/6dee6be3a1246264f13e2c159c4c8f9ab748f3c7) | `` walker: 0.12.15 -> 0.12.16 ``                                                   |
| [`41bae9ce`](https://github.com/NixOS/nixpkgs/commit/41bae9cef253b47a58520009af31c6532b9c6eef) | `` jjui: 0.4 -> 0.5 ``                                                             |
| [`482f0137`](https://github.com/NixOS/nixpkgs/commit/482f013748ffb0a12d8061b2bdda7fee4a121b0b) | `` troubadix: 25.2.0 -> 25.2.4 ``                                                  |
| [`a62aa5ae`](https://github.com/NixOS/nixpkgs/commit/a62aa5ae8d12f3d907c4cd5c3b00b56613868907) | `` armTrustedFirmwareTools: 2.12.0 -> 2.12.1 ``                                    |
| [`021ca2c9`](https://github.com/NixOS/nixpkgs/commit/021ca2c9fb878265174509a8af97003d5b6a03b7) | `` tideways-daemon: 1.9.32 -> 1.9.34 ``                                            |
| [`aeaabd5b`](https://github.com/NixOS/nixpkgs/commit/aeaabd5b12c199e34dbfc0391639c3d4defba736) | `` treewide: remove orphaned Cargo.lock files ``                                   |
| [`ff57751a`](https://github.com/NixOS/nixpkgs/commit/ff57751a72e65c815e2bd6ea15c9a227a211e62b) | `` pretix: relax django-boostrap3 constraint ``                                    |
| [`bb21d03a`](https://github.com/NixOS/nixpkgs/commit/bb21d03a8259280f8c247d9c825b387b41e785c1) | `` b3sum: 1.6.0 -> 1.6.1 ``                                                        |
| [`4967f4ff`](https://github.com/NixOS/nixpkgs/commit/4967f4ff4931a7101f7214149761956cb4948268) | `` home-assistant-custom-components.midea_ac: 2025.2.1 -> 2025.2.3 ``              |
| [`4924e708`](https://github.com/NixOS/nixpkgs/commit/4924e708ccbdae9a7ff180837d69f25b4428b875) | `` python313Packages.msmart-ng: 2025.2.1 -> 2025.2.2 ``                            |
| [`83c87826`](https://github.com/NixOS/nixpkgs/commit/83c878262e35eb0773d36ca2c02163a8115afd72) | `` python313Packages.django-bootstrap5: 24.3 -> 25.1 ``                            |
| [`036fc169`](https://github.com/NixOS/nixpkgs/commit/036fc169185874d511fc4af219390fdf9044d3a6) | `` drum-machine: 1.0.0 -> 1.3.1 ``                                                 |
| [`8b350ec6`](https://github.com/NixOS/nixpkgs/commit/8b350ec6590f3f8f560673cd303c0752f023dac5) | `` python313Packages.django-bootstrap3: 24.3 -> 25.1 ``                            |
| [`a7b99dda`](https://github.com/NixOS/nixpkgs/commit/a7b99dda99edb4380d669112a6a5287e6071d123) | `` python313Packages.django-js-asset: 3.0.1 -> 3.1 ``                              |
| [`aab3095c`](https://github.com/NixOS/nixpkgs/commit/aab3095cdce7dec25a59aef5de5b787cff102273) | `` libretro-shaders-slang: 0-unstable-2025-02-14 -> 0-unstable-2025-02-27 ``       |
| [`79e82b5b`](https://github.com/NixOS/nixpkgs/commit/79e82b5b85f16a8dd4d1c4461e6ef6d2e055be94) | `` pretalx: drop django-bootstrap4 dependency ``                                   |
| [`706283d8`](https://github.com/NixOS/nixpkgs/commit/706283d8513cee91206c55309cb96a93a6cd4c49) | `` python313Packages.django-bootstrap4: 25.1 -> 25.1 ``                            |
| [`1c447f37`](https://github.com/NixOS/nixpkgs/commit/1c447f37049d19e3d5ac3679eca494240d4874a6) | `` python313Packages.tlds: 2024092600 -> 2025022800 ``                             |
| [`5ca1ebd8`](https://github.com/NixOS/nixpkgs/commit/5ca1ebd85cb997cdeafac2cdc5ec3ae57210f869) | `` python3Packages.isbnlib: propagate setuptools ``                                |
| [`cf8f342c`](https://github.com/NixOS/nixpkgs/commit/cf8f342cf9c0fe5b022056d0240d4faf26507a2f) | `` python313Packages.swisshydrodata: fix build ``                                  |
| [`0a1cb045`](https://github.com/NixOS/nixpkgs/commit/0a1cb045b175fea881b40c4aab9205b7fbed9104) | `` heroic: add umu-launcher to fhsEnv ``                                           |
| [`59073e08`](https://github.com/NixOS/nixpkgs/commit/59073e08c144bb1da71cc1683bf947ca5e447801) | `` sarasa-gothic: 1.0.28 -> 1.0.29 ``                                              |
| [`8fcb6f1c`](https://github.com/NixOS/nixpkgs/commit/8fcb6f1c4948305af52d19f887b89011ee2c080d) | `` gamescope: 3.16.1 -> 3.16.2 ``                                                  |
| [`c45ac80d`](https://github.com/NixOS/nixpkgs/commit/c45ac80d7eafb9b32c6f22179131145a6c95190e) | `` crystal-dock: 2.7 -> 2.8 ``                                                     |
| [`e206e510`](https://github.com/NixOS/nixpkgs/commit/e206e510e9bc8914a2b1192aa622b0fd0bf90880) | `` gzdoom: 4.14.0 -> 4.14.1 ``                                                     |
| [`9f6eead2`](https://github.com/NixOS/nixpkgs/commit/9f6eead260e1e1e8dee21df54ee890b4bb82e4eb) | `` komikku: 1.70.0 -> 1.71.0 ``                                                    |
| [`9a498500`](https://github.com/NixOS/nixpkgs/commit/9a49850068d1c0b32a261f98bb8f8eeef9b3ac77) | `` zigbee2mqtt_2: 2.1.2 -> 2.1.3 ``                                                |
| [`e991b42b`](https://github.com/NixOS/nixpkgs/commit/e991b42b9b31514e7cd27c6bb0f7c54b8ae83268) | `` vimPlugins.blink-cmp: remove old patch and use upstream bypass method ``        |
| [`60f9abdb`](https://github.com/NixOS/nixpkgs/commit/60f9abdbf496399646f0f16781ac5dfa866027e8) | `` mkBinaryCache: add release notes entry about new zstd compression by default `` |
| [`bc28b6b4`](https://github.com/NixOS/nixpkgs/commit/bc28b6b4f6ed35bcea11dfd4480bd5dec43435d8) | `` nixos-rebuild-ng: Fix typo in README ``                                         |
| [`7c12d2cf`](https://github.com/NixOS/nixpkgs/commit/7c12d2cf8931642dc59fa08b3077e36ce989a76f) | `` video2x: init at 6.4.0 ``                                                       |
| [`7185fed3`](https://github.com/NixOS/nixpkgs/commit/7185fed383e040ace416c0e4283afc0a6ca11457) | `` rustus: 1.1.2 -> 1.1.3 ``                                                       |
| [`c063a288`](https://github.com/NixOS/nixpkgs/commit/c063a288356a8ae52ad7d1ad0a7a5de4abf28617) | `` nixos/tlp: fix NetworkManager RDW dispatcher script location (again) ``         |
| [`f748da70`](https://github.com/NixOS/nixpkgs/commit/f748da70d3808cd79077e281a9468a85488c9ca1) | `` tray-tui: 0.1.0 -> 0.2.0 ``                                                     |
| [`1be848df`](https://github.com/NixOS/nixpkgs/commit/1be848df711e350a64c4c83da8957c7c632eb3e6) | `` edk2: 202502 -> 202411 ``                                                       |
| [`058958a0`](https://github.com/NixOS/nixpkgs/commit/058958a07b8aff19976971b1f0a509499919286c) | `` diffoscope: 288 -> 289 ``                                                       |
| [`d7fde720`](https://github.com/NixOS/nixpkgs/commit/d7fde720f41c373dafd38f6b7d2528f1a97763ab) | `` ventoy-full: 1.1.01 -> 1.1.05 ``                                                |
| [`462768e0`](https://github.com/NixOS/nixpkgs/commit/462768e02bb66a9b93b699fad0605afa5883fee7) | `` terraform-providers.github: 6.5.0 -> 6.6.0 ``                                   |
| [`90350595`](https://github.com/NixOS/nixpkgs/commit/90350595221825e6518d51bf385bf37f08e37b16) | `` terraform-providers.fortios: 1.21.1 -> 1.22.0 ``                                |
| [`3066b43f`](https://github.com/NixOS/nixpkgs/commit/3066b43f0f0658d47f8175ce85340823b1c2b497) | `` terraform-providers.gitlab: 17.8.0 -> 17.9.0 ``                                 |
| [`8ad3d601`](https://github.com/NixOS/nixpkgs/commit/8ad3d601b6af9496bbfe062da6626eb1c43784f8) | `` terraform-providers.cloudinit: 2.3.5 -> 2.3.6 ``                                |
| [`47355aa3`](https://github.com/NixOS/nixpkgs/commit/47355aa3d03b10bf6f08e1ac17e58315f2f092a7) | `` newsflash: use fetchCargoVendor ``                                              |
| [`6b6e72c3`](https://github.com/NixOS/nixpkgs/commit/6b6e72c3c99118b2c15e2eed5fd7a64a87a1dd55) | `` tinymist: 0.13.2 -> 0.13.4 ``                                                   |
| [`ba41f18c`](https://github.com/NixOS/nixpkgs/commit/ba41f18cc35727dc638b17685a480d2fe83714e1) | `` syncthing: Install desktop entry for opening the web interface ``               |
| [`cb891143`](https://github.com/NixOS/nixpkgs/commit/cb891143905265e91022ee17d0279a267fb8f529) | `` stevenblack-blocklist: 3.15.17 -> 3.15.20 ``                                    |
| [`da52e41e`](https://github.com/NixOS/nixpkgs/commit/da52e41e2eef41ab8e45d23596d9705f0d8f4347) | `` virt-top: 1.1.1 -> 1.1.2 ``                                                     |
| [`c9b762b9`](https://github.com/NixOS/nixpkgs/commit/c9b762b935da814f68db3fc82d0d8131f0ecf67c) | `` dcmtk: update build flags, add patches ``                                       |
| [`5b6318d2`](https://github.com/NixOS/nixpkgs/commit/5b6318d2727b26f82f8c926e662c54f79ac0295c) | `` flexget: 3.15.7 -> 3.15.19 ``                                                   |
| [`4088f58a`](https://github.com/NixOS/nixpkgs/commit/4088f58a99da59bea45a3d4f0cdc4b7ddd4aef41) | `` digiham: fix repo, tag, description ``                                          |
| [`ab23320d`](https://github.com/NixOS/nixpkgs/commit/ab23320d2d2620bff5db67dae9d1c7a75d5862ae) | `` linux/hardened/patches/6.13: init at v6.13.5-hardened1 ``                       |
| [`607d955e`](https://github.com/NixOS/nixpkgs/commit/607d955e2ae1c91f439ac27f3b059d84d31c01b4) | `` linux/hardened/patches/6.12: v6.12.12-hardened1 -> v6.12.17-hardened1 ``        |
| [`4ed62fb7`](https://github.com/NixOS/nixpkgs/commit/4ed62fb7e281f4e8ae2a0e910ab020864bf844dc) | `` linux/hardened/patches/6.6: v6.6.75-hardened1 -> v6.6.80-hardened1 ``           |
| [`b2bcab69`](https://github.com/NixOS/nixpkgs/commit/b2bcab69157b6210ae19ac3de083f1a0c118c31f) | `` linux/hardened/patches/6.1: v6.1.128-hardened1 -> v6.1.129-hardened1 ``         |
| [`79049ef7`](https://github.com/NixOS/nixpkgs/commit/79049ef759178bb8dc7d16422c0be9427f11dbfc) | `` flightgear: 2020.3.19 -> 2024.1.1 ``                                            |
| [`141d29af`](https://github.com/NixOS/nixpkgs/commit/141d29af7d5a372a09fdcc3e2398234be2d15b52) | `` libqalculate: 5.5.1 -> 5.5.2 ``                                                 |
| [`56911820`](https://github.com/NixOS/nixpkgs/commit/56911820a7d468957eb43e62a04b3d187d267c27) | `` vscode-extensions.fstarlang.fstar-vscode-assistant: init at 0.17.1 ``           |
| [`437bbd63`](https://github.com/NixOS/nixpkgs/commit/437bbd63880208298324b2a10b4d1fe362973edc) | `` handbrake: 1.9.0 -> 1.9.2 ``                                                    |