### PR TITLE
chore(flake/stylix): `65c42633` -> `11780517`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -750,11 +750,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1741095125,
-        "narHash": "sha256-ols/7lAXc2qH8K9w+Bt64bW+a6rLXAk3O2JGoWdAK1g=",
+        "lastModified": 1741112087,
+        "narHash": "sha256-dBGwN4aHmX2QUXolZDhV+p06+WM5ZykL4wd9BD6bT7k=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "65c42633d4d0ebc49e8f077c289786b13a145509",
+        "rev": "11780517948f214b9f93d1bf5a2d29bc181d3a33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                     |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`11780517`](https://github.com/danth/stylix/commit/11780517948f214b9f93d1bf5a2d29bc181d3a33) | `` ncspot: match style guide better and add transparent bg (#938) ``        |
| [`afee64f3`](https://github.com/danth/stylix/commit/afee64f3c5090b4eadc30df46bad001015744858) | `` rio: add emoji font family and convert font size to pixel unit (#937) `` |