### PR TITLE
chore(flake/darwin): `4a0bddd4` -> `991bb2f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741043630,
-        "narHash": "sha256-xJ4rzdkVUhY40pIPX1xXiWiGX+g8Dww43v/lew5lrxo=",
+        "lastModified": 1741112248,
+        "narHash": "sha256-Y340xoE1Vgo0eCDJi4srVjuwlr50vYSoyJrZeXHw3n0=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "4a0bddd49813e96da45e9b5159c35d62f2f52089",
+        "rev": "991bb2f6d46fc2ff7990913c173afdb0318314cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                 |
| ------------------------------------------------------------------------------------------------ | --------------------------------------- |
| [`d06cf700`](https://github.com/LnL7/nix-darwin/commit/d06cf700ee589527fde4bd9b91f899e7137c05a6) | `` homebrew: remove `--no-lock` flag `` |