### PR TITLE
chore(flake/home-manager): `70fbbf05` -> `b1b964ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741056285,
-        "narHash": "sha256-/JKDMVqq8PIqcGonBVKbKq1SooV3kzGmv+cp3rKAgPA=",
+        "lastModified": 1741128660,
+        "narHash": "sha256-GWaZ+KGxWYbOB15CSqktwngq0ccA1l2Ov3aUfl9jeY4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "70fbbf05a5594b0a72124ab211bff1d502c89e3f",
+        "rev": "b1b964ea9348aef08cab514fa88e9c99def6fd63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`b1b964ea`](https://github.com/nix-community/home-manager/commit/b1b964ea9348aef08cab514fa88e9c99def6fd63) | `` mbsync: support maildir paths containing spaces ``      |
| [`6f71acf7`](https://github.com/nix-community/home-manager/commit/6f71acf71bd6a8a6f3152769737a53af6da6ae63) | `` git: apply sendmailCmd instead of smtpServer (#6399) `` |
| [`3f08cd8e`](https://github.com/nix-community/home-manager/commit/3f08cd8ef77dcd7586075a460a61c8432baf25a9) | `` ci: add labels for firefox (#6520) ``                   |