### PR TITLE
chore(flake/nixpkgs): `ba487dbc` -> `e3e32b64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -593,11 +593,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741010256,
-        "narHash": "sha256-WZNlK/KX7Sni0RyqLSqLPbK8k08Kq7H7RijPJbq9KHM=",
+        "lastModified": 1741513245,
+        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ba487dbc9d04e0634c64e3b1f0d25839a0a68246",
+        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -176,7 +176,7 @@
                 allowUnfree = true;
                 allowAliases = true;
                 permittedInsecurePackages = [
-                  "jitsi-meet-1.0.8043"
+                  "electron-32.3.3"
                 ];
               };
             };


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                     |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| [`21e4b751`](https://github.com/NixOS/nixpkgs/commit/21e4b751ae4b931710d0fdc1187f2832ab2f647e) | `` trenchbroom: 2024.1 -> 2025.2 ``                                                                         |
| [`4abfe287`](https://github.com/NixOS/nixpkgs/commit/4abfe287524105544245bfbab9f41a657e257f6b) | `` mgba: adopt ``                                                                                           |
| [`e49336fd`](https://github.com/NixOS/nixpkgs/commit/e49336fd38625e3eb321c98ea2db953c332269df) | `` mgba: 0.10.4 -> 0.10.5 ``                                                                                |
| [`79e2d415`](https://github.com/NixOS/nixpkgs/commit/79e2d415e9012baee5673ea526d5cf1204883431) | `` python313Packages.boto3-stubs: 1.37.8 -> 1.37.9 ``                                                       |
| [`34c17c2a`](https://github.com/NixOS/nixpkgs/commit/34c17c2ae0df0a0a94c3b648b74866d00282d0d8) | `` python313Packages.botocore-stubs: 1.37.8 -> 1.37.9 ``                                                    |
| [`57b7f4d2`](https://github.com/NixOS/nixpkgs/commit/57b7f4d2dfa6b2c2d4b30b1910aa46350204205a) | `` python312Packages.mypy-boto3-elbv2: 1.37.0 -> 1.37.9 ``                                                  |
| [`67cc9a6c`](https://github.com/NixOS/nixpkgs/commit/67cc9a6cb4a7dda8e49d1d0f17abd9d2a327b3e5) | `` python312Packages.mypy-boto3-ec2: 1.37.5 -> 1.37.9 ``                                                    |
| [`917fe74b`](https://github.com/NixOS/nixpkgs/commit/917fe74b86fefbd9772e3802bb13149f1ae23bb8) | `` python312Packages.mypy-boto3-cloudfront: 1.37.2 -> 1.37.9 ``                                             |
| [`aa8bb539`](https://github.com/NixOS/nixpkgs/commit/aa8bb53991267915eb10b5dedf566712e56699d0) | `` pkgs/SDL_compat: symlink package config specification file into sdl.pc ``                                |
| [`6ee1752a`](https://github.com/NixOS/nixpkgs/commit/6ee1752a91be242aa4b75fd398d5998a631e8cf8) | `` moxide: 0.1.0 -> 0.2.0 ``                                                                                |
| [`c5f68ec3`](https://github.com/NixOS/nixpkgs/commit/c5f68ec37f0c3bfad2bd46aac3089a4d35031840) | `` boxflat: 1.27.1 -> 1.28.4 ``                                                                             |
| [`1e3e30d5`](https://github.com/NixOS/nixpkgs/commit/1e3e30d56649dd3a910da3dc4bc3091f0af68c4d) | `` nixos/h2o: clarify/format some docs to point to upstream config ``                                       |
| [`901b87f8`](https://github.com/NixOS/nixpkgs/commit/901b87f8fd4d5388a863cbde915f219fbaba8a23) | `` nixos/doc/rl-2411: mention iosched module ``                                                             |
| [`1513a50f`](https://github.com/NixOS/nixpkgs/commit/1513a50f2a046a1728fda71b126c70fa40c54ef2) | `` qpwgraph: 0.8.1 -> 0.8.2 ``                                                                              |
| [`6bf3337f`](https://github.com/NixOS/nixpkgs/commit/6bf3337ff59ff2e388658729fcd1de83bf3d4e60) | `` mesa: fix cross compilation ``                                                                           |
| [`d124a832`](https://github.com/NixOS/nixpkgs/commit/d124a832efe56ef55b808a2ea603fd81931e8c7f) | `` python313Packages.in-place: update build-system ``                                                       |
| [`6a54cb3a`](https://github.com/NixOS/nixpkgs/commit/6a54cb3a92d1df2a6ef59c1c51637cac0009dc06) | `` python313Packages.accuweather: 4.1.0 -> 4.2.0 ``                                                         |
| [`b3eb62da`](https://github.com/NixOS/nixpkgs/commit/b3eb62dabca9c4f179d3421e4f01b12bb1ad80b3) | `` python312Packages.apt: 2.9.2 -> 2.9.9 ``                                                                 |
| [`976faf0f`](https://github.com/NixOS/nixpkgs/commit/976faf0f79415c7c7679dffc8965b49c952c6bc5) | `` apt: 2.9.25 -> 2.9.31 ``                                                                                 |
| [`dcb250ae`](https://github.com/NixOS/nixpkgs/commit/dcb250aecc47ed727521bd9d62e23861e8b64bdf) | `` treefmt1: remove (#387745) ``                                                                            |
| [`98b1c2ef`](https://github.com/NixOS/nixpkgs/commit/98b1c2ef72d43bd56ec83d757178b867bf45f2c5) | `` automatic-timezoned: 2.0.60 -> 2.0.64 ``                                                                 |
| [`54bd09a5`](https://github.com/NixOS/nixpkgs/commit/54bd09a515fba7923c225364f379625f426b5a0f) | `` nixos/iosched: exclude loop devices by default ``                                                        |
| [`0eb6a300`](https://github.com/NixOS/nixpkgs/commit/0eb6a300f0b713cd512654118fca746a86209cb0) | `` obs-studio-plugins: mark some plugins as broken ``                                                       |
| [`4b64906c`](https://github.com/NixOS/nixpkgs/commit/4b64906ce933cf038dd62ea2eb1112cda76a78cd) | `` obs-studio-plugins.obs-hyperion: fix build ``                                                            |
| [`de0b5d91`](https://github.com/NixOS/nixpkgs/commit/de0b5d91b29e015c1fb34e575beb7724061f159a) | `` bitwarden-desktop: add darwin support and do minor refactor ``                                           |
| [`35689274`](https://github.com/NixOS/nixpkgs/commit/35689274647e7353b29e046f975df6df4cc2a800) | `` neatvnc: 0.9.3 -> 0.9.4 ``                                                                               |
| [`a07a42e9`](https://github.com/NixOS/nixpkgs/commit/a07a42e961d166115089fedc54c94d2349144e1c) | `` brave: 1.75.181 -> 1.76.73 ``                                                                            |
| [`84bdf736`](https://github.com/NixOS/nixpkgs/commit/84bdf736d02117a81571a8f4a991e3ab66263ab0) | `` lxgw-neoxihei: 1.213 -> 1.214 ``                                                                         |
| [`ffd42f24`](https://github.com/NixOS/nixpkgs/commit/ffd42f2414c01b93afb7ef8e39080d6cc65f4716) | `` kittycad-kcl-lsp: 0.1.69 -> 0.1.71 ``                                                                    |
| [`0d1585a0`](https://github.com/NixOS/nixpkgs/commit/0d1585a0f6ceeece4134baa6f5a247bd1a3a320f) | `` terraform-providers.bigip: 1.22.7 -> 1.22.8 ``                                                           |
| [`97c50585`](https://github.com/NixOS/nixpkgs/commit/97c50585a37bc034eea13a0457b159fdd9850581) | `` gql: 0.36.0 -> 0.37.0 ``                                                                                 |
| [`709055fb`](https://github.com/NixOS/nixpkgs/commit/709055fb7016c3d2c524e4d33810f5a0b9befffe) | `` konstraint: 0.40.0 -> 0.41.0 ``                                                                          |
| [`9cb5a1fa`](https://github.com/NixOS/nixpkgs/commit/9cb5a1fa3a0791cf043fe80fbb4729c38840a6c9) | `` terraform-providers.sumologic: 3.0.4 -> 3.0.5 ``                                                         |
| [`0a0418c1`](https://github.com/NixOS/nixpkgs/commit/0a0418c1534434e8ac262d487ab0fad9f2df3847) | `` vencord: use latest pnpm_10 ``                                                                           |
| [`4bf7bc6b`](https://github.com/NixOS/nixpkgs/commit/4bf7bc6bfe0a86326dfed07e3ee7ccb6d5b59f6f) | `` pnpm.fetchDeps: ignore packageManager field in package.json ``                                           |
| [`6770bd8f`](https://github.com/NixOS/nixpkgs/commit/6770bd8f0bd11a4b11a9a6fa748ac259355f3c21) | `` python313Packages.cyclopts: 3.9.1 -> 3.9.2 ``                                                            |
| [`9b5f94b5`](https://github.com/NixOS/nixpkgs/commit/9b5f94b51f5ae9b64db014fe624c5240dffd57a5) | `` treewide: replace references to SDL2.dev with lib.getDev and lib.getInclude ``                           |
| [`dc0dc031`](https://github.com/NixOS/nixpkgs/commit/dc0dc0313068d88e4f66e4fb26c3ee54a05ecf97) | `` python3Packages.litellm: add missing optional dependencies for proxy ``                                  |
| [`20dc9726`](https://github.com/NixOS/nixpkgs/commit/20dc9726861af661015c5ebea736f12389f652b3) | `` rofi: add pandoc to generate manpages ``                                                                 |
| [`16d30c56`](https://github.com/NixOS/nixpkgs/commit/16d30c563d4f26ba2e4c22e3ecf56b60b05ba0c2) | `` treewide: replace references to SDL.dev with lib.getDev SDL ``                                           |
| [`18d69a9d`](https://github.com/NixOS/nixpkgs/commit/18d69a9d14f1b61493bb645a1afd019ae4f8a8cd) | `` gocatcli: init at 1.0.6 ``                                                                               |
| [`568795a1`](https://github.com/NixOS/nixpkgs/commit/568795a1b6e8bad7bfa7f258e0492b351aae2dc4) | `` terraform-providers.equinix: 3.2.0 -> 3.4.0 ``                                                           |
| [`25a6112c`](https://github.com/NixOS/nixpkgs/commit/25a6112c0299beed3e1c0e033ad30671d63ab614) | `` terraform-providers.spotinst: 1.209.2 -> 1.211.0 ``                                                      |
| [`9833fa8d`](https://github.com/NixOS/nixpkgs/commit/9833fa8dbd3174fe99378c4c877f6976515aae61) | `` cudaPackages.tensorrt: remove old extension.nix ``                                                       |
| [`7611065d`](https://github.com/NixOS/nixpkgs/commit/7611065d9b348d35f35e2a78e94d4912b3f85e76) | `` wily: fix build for gcc14 ``                                                                             |
| [`a64e65b5`](https://github.com/NixOS/nixpkgs/commit/a64e65b58661b9924e9e846f30e317f14415deb1) | `` obs-studio: 31.0.1 -> 31.0.2 ``                                                                          |
| [`77d77c17`](https://github.com/NixOS/nixpkgs/commit/77d77c17c7abc914a46ccc1c87837469b82ddffc) | `` librewolf: 136.0-1 -> 136.0-2 ``                                                                         |
| [`04ebc42c`](https://github.com/NixOS/nixpkgs/commit/04ebc42c3551a2785af94cb54f9337726f877ead) | `` librewolf: add fpletz to maintainers ``                                                                  |
| [`a017ad70`](https://github.com/NixOS/nixpkgs/commit/a017ad7039ab5464fd81b443cbef20385d91cdc3) | `` librewolf-unwrapped: sync build patching with upstream ``                                                |
| [`329a253d`](https://github.com/NixOS/nixpkgs/commit/329a253d1aa17f981cec48ba5b5f8f093c5701f7) | `` python312Packages.fastembed: 0.5.1 -> 0.6.0 ``                                                           |
| [`191cb1ca`](https://github.com/NixOS/nixpkgs/commit/191cb1ca7a5299e579523639a76e230852572f7d) | `` python313Packages.ciscoconfparse: remove ``                                                              |
| [`4a9d9027`](https://github.com/NixOS/nixpkgs/commit/4a9d9027e093cfade8e1a8e90b2a174e7c41eaae) | `` python313Packages.ciscoconfparse2: init at 0.8.6 ``                                                      |
| [`e5de02b5`](https://github.com/NixOS/nixpkgs/commit/e5de02b50ce8c6d56e79e2cb05469af90c660b35) | `` python313Packages.scrypt: init at 0.8.27 ``                                                              |
| [`645e2def`](https://github.com/NixOS/nixpkgs/commit/645e2def5e01ca6401cf17d6085d020362fc244c) | `` labwc-tweaks-gtk: 0-unstable-2025-01-26 -> 0-unstable-2025-03-07 ``                                      |
| [`f6d17c2d`](https://github.com/NixOS/nixpkgs/commit/f6d17c2d8747c90d66454baae36316c045fd35a5) | `` CONTRIBUTING: fix a small typo ``                                                                        |
| [`d57ea7fe`](https://github.com/NixOS/nixpkgs/commit/d57ea7fe181f09f76fa5e0ce988257888297369c) | `` jp-zip-codes: 0-unstable-2025-02-01 -> 0-unstable-2025-03-01 ``                                          |
| [`cad01ebf`](https://github.com/NixOS/nixpkgs/commit/cad01ebfeb2165d6f75a7fb697c2d43092de78da) | `` python313Packages.hier-config: init at 3.2.2 ``                                                          |
| [`5cef95c4`](https://github.com/NixOS/nixpkgs/commit/5cef95c41ea7c5b52d827f127a8e403a7af7f3cf) | `` python313Packages.deprecat: remove ``                                                                    |
| [`4e0fb12e`](https://github.com/NixOS/nixpkgs/commit/4e0fb12e27922ce65b5d2e4cbf1912f72dafd98f) | `` jawiki-all-titles-in-ns0: 0-unstable-2025-02-01 -> 0-unstable-2025-03-01 ``                              |
| [`a65889ad`](https://github.com/NixOS/nixpkgs/commit/a65889ad2a95190bdf8943652d4063984cfd2477) | `` justbuild: 1.4.3 -> 1.5.0 ``                                                                             |
| [`9a7887ca`](https://github.com/NixOS/nixpkgs/commit/9a7887ca6545e2713f64af32c4a4bb8b929b7954) | `` python313Packages.django-pwa: update build-system ``                                                     |
| [`a7caa3c5`](https://github.com/NixOS/nixpkgs/commit/a7caa3c574f953405fbc63cc9d98587941a7c430) | `` spotube: 3.9.0 -> 4.0.0 ``                                                                               |
| [`3ea41d40`](https://github.com/NixOS/nixpkgs/commit/3ea41d4051a81f0869d3a8d560fc4384bdd70573) | `` wmenu: 0.1.9 -> 0.1.9-unstable-2025-03-01 ``                                                             |
| [`52653625`](https://github.com/NixOS/nixpkgs/commit/52653625a7d7d32a30f551d7a6e8618f09fb485e) | `` fishy: init at 0.2.1 ``                                                                                  |
| [`96e04bbf`](https://github.com/NixOS/nixpkgs/commit/96e04bbfabd9a6001339f027445a2987bb7bb219) | `` python312Packages.bytewax: use fetchCargoVendor ``                                                       |
| [`d5226dd2`](https://github.com/NixOS/nixpkgs/commit/d5226dd22c4a8461f8ec629d97d2169c7040dff6) | `` bws: use fetchCargoVendor ``                                                                             |
| [`02f3af2e`](https://github.com/NixOS/nixpkgs/commit/02f3af2ee4e332eaff1d5aa370a62bc2a24ae836) | `` browsers: use fetchCargoVendor ``                                                                        |
| [`0f8b77c9`](https://github.com/NixOS/nixpkgs/commit/0f8b77c9f942da5de8a2f3cfe2a36fb95fd0d4ff) | `` bite: use fetchCargoVendor ``                                                                            |
| [`349fdcd7`](https://github.com/NixOS/nixpkgs/commit/349fdcd745173d0a6df586b86f67f492e6a5e070) | `` mqtt-exporter: 1.6.1 -> 1.7.0 ``                                                                         |
| [`18e84362`](https://github.com/NixOS/nixpkgs/commit/18e84362b63808822ff4069465857449fd7a1efd) | `` mkBinaryCache: add missing .nar extension ``                                                             |
| [`afdc6ae6`](https://github.com/NixOS/nixpkgs/commit/afdc6ae625d951a696214ea47e178d5f6d05e85e) | `` python313Packages.django_5: 5.1.6 -> 5.1.7 ``                                                            |
| [`84bf4644`](https://github.com/NixOS/nixpkgs/commit/84bf4644fb437540b2ac2b99e76ba0c904f665e7) | `` iosevka-bin: 32.5.0 -> 33.0.1 ``                                                                         |
| [`f5f35fe4`](https://github.com/NixOS/nixpkgs/commit/f5f35fe488c04afe9bdffeb3a642404a8626a632) | `` thunderbird-bin-unwrapped: 128.7.1esr -> 128.8.0esr ``                                                   |
| [`e43340da`](https://github.com/NixOS/nixpkgs/commit/e43340da27c0e493a008c81cb07d5f26171eac12) | `` nixos/emacs: improve description of services.emacs.enable (#387966) ``                                   |
| [`1a4575f9`](https://github.com/NixOS/nixpkgs/commit/1a4575f9dbe76482f2a85f496c2aa3a7cd50b759) | `` nixos/modules: Add security.pki.caBundle option and make all services use it for CA bundles (#352244) `` |
| [`de42e24c`](https://github.com/NixOS/nixpkgs/commit/de42e24c4fc0a7090f8575e609458d6998459516) | `` librewolf-unwrapped: restore patch application ``                                                        |
| [`b9d99ad6`](https://github.com/NixOS/nixpkgs/commit/b9d99ad6dff76f18448eea586156557050295e9c) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.220 -> 0.13.222 ``                |
| [`f40557a4`](https://github.com/NixOS/nixpkgs/commit/f40557a42b728e73e05084274de64aed292a43d9) | `` python313Packages.homeassistant-stubs: 2025.3.0 -> 2025.3.1 ``                                           |
| [`a8294c09`](https://github.com/NixOS/nixpkgs/commit/a8294c092db3a625e8d2f08590fb9de3d53451d8) | `` home-assistant: 2025.3.0 -> 2025.3.1 ``                                                                  |
| [`dbd5f4e5`](https://github.com/NixOS/nixpkgs/commit/dbd5f4e5a6d1adadd5d5ed71526f6252ad18a3e8) | `` python313Packages.pysmartthings: 2.6.1 -> 2.7.0 ``                                                       |
| [`74c4f531`](https://github.com/NixOS/nixpkgs/commit/74c4f53149c21f545f122f58317c156c02e4b121) | `` python313Packages.py-synologydsm-api: 2.7.0 -> 2.7.1 ``                                                  |
| [`908c6f3c`](https://github.com/NixOS/nixpkgs/commit/908c6f3c39e0cb985b806eed514fc15a877892ab) | `` python313Packages.aiohomeconnect: 0.16.2 -> 0.16.3 ``                                                    |
| [`7c97c44d`](https://github.com/NixOS/nixpkgs/commit/7c97c44d2e442c7c26adbebe0ab74bb6938c1203) | `` rust-synapse-compress-state: rename from rust-synapse-state-compress ``                                  |