### PR TITLE
chore(flake/flake-parts): `3876f6b8` -> `f4330d22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -214,11 +214,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1740872218,
-        "narHash": "sha256-ZaMw0pdoUKigLpv9HiNDH2Pjnosg7NBYMJlHTIsHEUo=",
+        "lastModified": 1741352980,
+        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3876f6b87db82f33775b1ef5ea343986105db764",
+        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
         "type": "github"
       },
       "original": {
@@ -609,14 +609,17 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1740872140,
-        "narHash": "sha256-3wHafybyRfpUCLoE8M+uPVZinImg3xX+Nm6gEfN3G8I=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6d3702243441165a03f699f64416f635220f4f15.tar.gz"
+        "lastModified": 1740877520,
+        "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "147dee35aab2193b174e4c0868bd80ead5ce755c",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6d3702243441165a03f699f64416f635220f4f15.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "nixvim": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                                                                                    |
| -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
| [`18bae3ab`](https://github.com/hercules-ci/flake-parts/commit/18bae3abd9e674e31e97ac8790eafb4f5b85647c) | `` Revert "flake-update: Get the nixpkgs/lib subtree only" ``                                                              |
| [`2a248bba`](https://github.com/hercules-ci/flake-parts/commit/2a248bba8ab12d669c7d712eaeea26a27560b35f) | `` flake.lock: Update ``                                                                                                   |
| [`0210dccc`](https://github.com/hercules-ci/flake-parts/commit/0210dccc6433f6ebeb8801ff1285e446ed5aae9d) | `` Use inputs from `github:nix-community/nixpkgs.lib` instead of the hard-coded SHA-1 hash of the subdirectory git tree `` |