### PR TITLE
chore(flake/git-hooks): `42b1ba08` -> `fcea9160`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -312,11 +312,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740915799,
-        "narHash": "sha256-JvQvtaphZNmeeV+IpHgNdiNePsIpHD5U/7QN5AeY44A=",
+        "lastModified": 1741360107,
+        "narHash": "sha256-QKp83UTH0hGc7TYkQdX5JdagvBnP5169WyxXkMrkPqY=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "42b1ba089d2034d910566bf6b40830af6b8ec732",
+        "rev": "fcea91603f24a41113c1b9e4043510b1b96e10bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`fcea9160`](https://github.com/cachix/git-hooks.nix/commit/fcea91603f24a41113c1b9e4043510b1b96e10bb) | `` Revert "ci: use self-hosted runners" ``        |
| [`61fa9623`](https://github.com/cachix/git-hooks.nix/commit/61fa9623cba72d8bde0b84e264725584602e8cf2) | `` ci: use self-hosted runners ``                 |
| [`75796622`](https://github.com/cachix/git-hooks.nix/commit/75796622e2775e624944ff08e74777c383d2b65d) | `` docs: add supported but non-mentioned hooks `` |
| [`1b310e63`](https://github.com/cachix/git-hooks.nix/commit/1b310e63b6934f1231c47631fd6fe56214346c08) | `` docs: sort hook sections by name ``            |
| [`69f02f04`](https://github.com/cachix/git-hooks.nix/commit/69f02f043e8ad95dd34eb988343daea3481112f1) | `` feat: add selene hook ``                       |