### PR TITLE
chore(flake/git-hooks): `fcea9160` -> `1293270f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -312,11 +312,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741360107,
-        "narHash": "sha256-QKp83UTH0hGc7TYkQdX5JdagvBnP5169WyxXkMrkPqY=",
+        "lastModified": 1741373960,
+        "narHash": "sha256-7/JbMIY/QhdCFdpZ6bCRshClUdZK/LJw+e7OLJhU1iQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "fcea91603f24a41113c1b9e4043510b1b96e10bb",
+        "rev": "1293270f9d650ed794958dc97dcf497b425b465c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                       |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`10907c7f`](https://github.com/cachix/git-hooks.nix/commit/10907c7f1298610682d748e4476316d979d13455) | `` Remove extraneous check for git in PATH `` |
| [`843e005b`](https://github.com/cachix/git-hooks.nix/commit/843e005b4877e80446c87788e362537891b063ff) | `` disable expensive julia tests ``           |
| [`316f09cb`](https://github.com/cachix/git-hooks.nix/commit/316f09cb683baabd66d8b4a55c9b28d090005ff4) | `` docs: sort sections by name ``             |