### PR TITLE
chore(flake/stylix): `6fada03c` -> `74f1ac55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1741335745,
-        "narHash": "sha256-jsYqEZ/gll40Jgl8BhzEAYz4E86uwUm99RkaVY38chk=",
+        "lastModified": 1741377640,
+        "narHash": "sha256-ZopSHy31yPEJP8naV1yGdVNNrSbOytnKKJaHb6IXNDs=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "6fada03cd5e223aa9c111e7073118692065a7ee1",
+        "rev": "74f1ac55d3b09fb3be23563d398b430e756a6e83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                               |
| --------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`74f1ac55`](https://github.com/danth/stylix/commit/74f1ac55d3b09fb3be23563d398b430e756a6e83) | `` fnott: init (#948) ``              |
| [`7fc0a871`](https://github.com/danth/stylix/commit/7fc0a8716e753f0341300ebe34cda5f8a90527f8) | `` stylix: add editorconfig (#945) `` |