### PR TITLE
chore(flake/lovesegfault-vim-config): `8a0d8090` -> `aa660a43`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741306036,
-        "narHash": "sha256-A003s0iwdeXkmUAeXiiqFjCbx3Udykugs+rA6lMR9S4=",
+        "lastModified": 1741392467,
+        "narHash": "sha256-5HDhBts9Y+RGWJy+gzQpOnC5/CplwxTJMVHLwAWcTW0=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "8a0d80900c608786f42216261cd5e7b1bec3ab3d",
+        "rev": "aa660a435f2bb3e3713ae9d5ec275ab66e3c75ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`aa660a43`](https://github.com/lovesegfault/vim-config/commit/aa660a435f2bb3e3713ae9d5ec275ab66e3c75ac) | `` chore(flake/git-hooks): 42b1ba08 -> b5a62751 ``   |
| [`d0d6f418`](https://github.com/lovesegfault/vim-config/commit/d0d6f41808a61a71acd5a912dce216b5b614e03b) | `` chore(flake/flake-parts): 3876f6b8 -> f4330d22 `` |