### PR TITLE
chore(flake/lanzaboote): `3a3ed972` -> `21fc8d70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -464,11 +464,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1741259028,
-        "narHash": "sha256-QWgGXe9Ai8+hSwNEAqLjZoAvLwV3ywDzT+XBpfMOzuU=",
+        "lastModified": 1741382166,
+        "narHash": "sha256-FaOgKL/TLJTnYrA2Twb1Y7nOPCDoytLZBnKwMexSP8E=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "3a3ed972151121c8b159eb40e0be21146270e73b",
+        "rev": "21fc8d7035cb99e1c4b2988f3bf3fff6236bc086",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                         |
| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`724022dd`](https://github.com/nix-community/lanzaboote/commit/724022dd400ed5c2afbd93c92dca87a262f7f407) | `` flake: remove unneeded uki module ``         |
| [`874ea2f5`](https://github.com/nix-community/lanzaboote/commit/874ea2f5fb1c8b8917c3c9465c777f73aa1d9585) | `` stub: remove fat stub ``                     |
| [`657ace37`](https://github.com/nix-community/lanzaboote/commit/657ace37a4150a653d2f3303b16dbdd7067ce5cb) | `` stub: remove nix expressions for fat stub `` |