### PR TITLE
chore(flake/stylix): `74f1ac55` -> `6eea250b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1741377640,
-        "narHash": "sha256-ZopSHy31yPEJP8naV1yGdVNNrSbOytnKKJaHb6IXNDs=",
+        "lastModified": 1741392477,
+        "narHash": "sha256-6ySHuduGhlZBv1uxEOlOeHWDEkKuLQ/O63DI+ZRfAmg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "74f1ac55d3b09fb3be23563d398b430e756a6e83",
+        "rev": "6eea250b10386be0fc23496d1039d76b3147680e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                    |
| --------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`6eea250b`](https://github.com/danth/stylix/commit/6eea250b10386be0fc23496d1039d76b3147680e) | `` dunst: fix opacity rounding (#965) ``   |
| [`4891f147`](https://github.com/danth/stylix/commit/4891f1471b682af073574dc51fa4810f1470ef8f) | `` stylix: simplify dummy values (#959) `` |