### PR TITLE
chore(flake/home-manager): `95711f92` -> `d2c014e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741378606,
-        "narHash": "sha256-ytDmwV93lZ1f6jswJkxEQz5cBlwje/2rH/yUZDADZNs=",
+        "lastModified": 1741393072,
+        "narHash": "sha256-+Su28oU1FBvptj1AO0geJP+BcIJghSVxaNFagvW5K2M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "95711f926676018d279ba09fe7530d03b5d5b3e2",
+        "rev": "d2c014e1c73195d1958abec0c5ca6112b07b79da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                               |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`d2c014e1`](https://github.com/nix-community/home-manager/commit/d2c014e1c73195d1958abec0c5ca6112b07b79da) | `` treewide: null package support (#6582) ``                          |
| [`6c2b7940`](https://github.com/nix-community/home-manager/commit/6c2b79403e9ae852fbf1d55b29f2ea4d2aa43255) | `` treewide: use graphical-session.target for GUI services (#5785) `` |