### PR TITLE
chore(flake/home-manager): `d2c014e1` -> `26f6b862`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741393072,
-        "narHash": "sha256-+Su28oU1FBvptj1AO0geJP+BcIJghSVxaNFagvW5K2M=",
+        "lastModified": 1741416850,
+        "narHash": "sha256-iqRxCsRxE/Q/3W1RHxQMthPKEda0hhY65uxEpE5TNk4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d2c014e1c73195d1958abec0c5ca6112b07b79da",
+        "rev": "26f6b862645ff281f3bada5d406e8c20de8d837c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`26f6b862`](https://github.com/nix-community/home-manager/commit/26f6b862645ff281f3bada5d406e8c20de8d837c) | `` tests/gh-dash: enable gh to test extension adding `` |
| [`5ab4305f`](https://github.com/nix-community/home-manager/commit/5ab4305f345ccf628fbcaa7a2dfd3696accd907b) | `` gh-dash: fix ``                                      |
| [`1347b0b4`](https://github.com/nix-community/home-manager/commit/1347b0b468ddf355657d58e50811238cfff517cb) | `` tests: move vinegar to linux only ``                 |
| [`3ade6542`](https://github.com/nix-community/home-manager/commit/3ade65425772e5ee25989726b41074fcb4a9a372) | `` tests/neovide: fix deprecation ``                    |