### PR TITLE
chore(flake/lanzaboote): `21fc8d70` -> `d8099586`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -464,11 +464,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1741382166,
-        "narHash": "sha256-FaOgKL/TLJTnYrA2Twb1Y7nOPCDoytLZBnKwMexSP8E=",
+        "lastModified": 1741442524,
+        "narHash": "sha256-tVcxLDLLho8dWcO81Xj/3/ANLdVs0bGyCPyKjp70JWk=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "21fc8d7035cb99e1c4b2988f3bf3fff6236bc086",
+        "rev": "d8099586d9a84308ffedac07880e7f07a0180ff4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                               |
| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`fd220317`](https://github.com/nix-community/lanzaboote/commit/fd220317eee2aa3273d6a62686fea42d51d10b1e) | `` readme: remove stale references to the fat stub `` |