### PR TITLE
chore(flake/nix-index-database): `26a0f969` -> `eeaf1084`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740886574,
-        "narHash": "sha256-jN6kJ41B6jUVDTebIWeebTvrKP6YiLd1/wMej4uq4Sk=",
+        "lastModified": 1741446546,
+        "narHash": "sha256-0z0GiUsUhjhZWa24bcAxqmlI3Ch8QvEeh42wghc6oVw=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "26a0f969549cf4d56f6e9046b9e0418b3f3b94a5",
+        "rev": "eeaf10849c3a0435323216885c0df7569dc95cb9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                           |
| ----------------------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`fdaa9d2f`](https://github.com/nix-community/nix-index-database/commit/fdaa9d2fb061b3c56e4db92df9d340ab268895dd) | `` More correct Darwin example `` |