### PR TITLE
chore(flake/home-manager): `26f6b862` -> `7f4c60a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741416850,
-        "narHash": "sha256-iqRxCsRxE/Q/3W1RHxQMthPKEda0hhY65uxEpE5TNk4=",
+        "lastModified": 1741461731,
+        "narHash": "sha256-BBQfGvO3GWOV+5tmqH14gNcZrRaQ7Q3tQx31Frzoip8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "26f6b862645ff281f3bada5d406e8c20de8d837c",
+        "rev": "7f4c60a3d6e548dbc13666565c22cb3f8dcdad44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`7f4c60a3`](https://github.com/nix-community/home-manager/commit/7f4c60a3d6e548dbc13666565c22cb3f8dcdad44) | `` podman: fix podman-user-wait-network-online (#6586) ``                |
| [`65d6043d`](https://github.com/nix-community/home-manager/commit/65d6043d32db2bf7fa22abd274443485cecef053) | `` flake.lock: Update (#6588) ``                                         |
| [`20a6b363`](https://github.com/nix-community/home-manager/commit/20a6b3631bb9b9308a3ed2348e261c9029b5f7eb) | `` navi: handle xdg directory on darwin (#6589) ``                       |
| [`b2314312`](https://github.com/nix-community/home-manager/commit/b2314312f2ee6893c83d0b5af74d949bc8530409) | `` zsh: correct syntax option to syntax-highlighting (#5792) ``          |
| [`2c87a647`](https://github.com/nix-community/home-manager/commit/2c87a6475fba12c9eb04ccb7375da0e32da48dc1) | `` flake-module: rename `homeManagerModules` to `homeModules` (#6406) `` |
| [`c040d1c5`](https://github.com/nix-community/home-manager/commit/c040d1c556476d9b82c7f3f1a0ce0906fcdf7108) | `` xembed-sni-proxy: change default package (#6587) ``                   |