### PR TITLE
chore(flake/nix-index-database): `eeaf1084` -> `296a2c99`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741446546,
-        "narHash": "sha256-0z0GiUsUhjhZWa24bcAxqmlI3Ch8QvEeh42wghc6oVw=",
+        "lastModified": 1741490098,
+        "narHash": "sha256-/tjVMbMzxJXrJaEk9N5esnbLebIZrkS1fbDJce/RiQg=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "eeaf10849c3a0435323216885c0df7569dc95cb9",
+        "rev": "296a2c992a28b37427d062ade6e20d467e479e3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`296a2c99`](https://github.com/nix-community/nix-index-database/commit/296a2c992a28b37427d062ade6e20d467e479e3f) | `` update generated.nix to release 2025-03-09-025742 `` |
| [`bb527ad1`](https://github.com/nix-community/nix-index-database/commit/bb527ad1e2ab6c59f3d2344fe043abaa7fd5a27d) | `` flake.lock: Update ``                                |