### PR TITLE
chore(flake/home-manager): `1fd39a10` -> `db4386d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741502651,
-        "narHash": "sha256-7u8FF20WRvQsmfTuNuCerRzstuZ0XgkwWPkq+GoRfiA=",
+        "lastModified": 1741543064,
+        "narHash": "sha256-AjXyS3ACxWAd+h3NSkrflN+uC0Tq1XFqox472RF6yh0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1fd39a105575ea997b32a043a0dd2c49294add5b",
+        "rev": "db4386d686fb0b2788e7422e6a2299deace9c4b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`db4386d6`](https://github.com/nix-community/home-manager/commit/db4386d686fb0b2788e7422e6a2299deace9c4b1) | `` home-environment: add line-break after sessionSearchVariables (#6596) ``   |
| [`2967de4d`](https://github.com/nix-community/home-manager/commit/2967de4d1146f1b6aa820eed85b823ea2ebfd0fa) | `` debug: make NIX_DEBUG_INFO_DIRS a list of strings (#6595) ``               |
| [`cf47e7ea`](https://github.com/nix-community/home-manager/commit/cf47e7ea2182c5638fdd1b42de329cc7d185cf8b) | `` qt: use home.sessionSearchVariables ``                                     |
| [`ab56fd8d`](https://github.com/nix-community/home-manager/commit/ab56fd8db811581323bb7aecd9c47c5956b3b17c) | `` targets/generic-linux: use home.sessionSearchVariables for XCURSOR_PATH `` |
| [`5094e32c`](https://github.com/nix-community/home-manager/commit/5094e32ccea3168a5cb9ee6e3b7e74aaf4d866a9) | `` home-cursor: use home.sessionSearchVariables for XCURSOR_PATH ``           |
| [`daab3230`](https://github.com/nix-community/home-manager/commit/daab32302b0bdd9bfff9e75d32375353d95b9c4f) | `` debug: use home.sessionSearchVariables for NIX_DEBUG_INFO_DIRS ``          |
| [`601f8d07`](https://github.com/nix-community/home-manager/commit/601f8d073c0b2f1fb4601b4727fb43ba6412685b) | `` im/fcitx5: use home.sessionSearchVariables for QT_PLUGIN_PATH ``           |
| [`277eea1c`](https://github.com/nix-community/home-manager/commit/277eea1cc7a5c37ea0b9aa8198cd1f2db3d6715c) | `` home-environment: add home.sessionSearchVariables ``                       |
| [`07f505f9`](https://github.com/nix-community/home-manager/commit/07f505f91e0c7112550845425222f41865c4260a) | `` qt: add "kde6" to qt.platformTheme (#6493) ``                              |