### PR TITLE
chore(flake/stylix): `6eea250b` -> `a7606826`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1741392477,
-        "narHash": "sha256-6ySHuduGhlZBv1uxEOlOeHWDEkKuLQ/O63DI+ZRfAmg=",
+        "lastModified": 1741533345,
+        "narHash": "sha256-wStpjHkVAuwYvs3oNSLWz8A2QkicfrGlP4rw2+OiyAU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "6eea250b10386be0fc23496d1039d76b3147680e",
+        "rev": "a76068262cfc16c04f9c07a6458715548b067450",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                      |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`a7606826`](https://github.com/danth/stylix/commit/a76068262cfc16c04f9c07a6458715548b067450) | `` palette: fix eval fail when image is null (#941) ``       |
| [`3fce9fb0`](https://github.com/danth/stylix/commit/3fce9fb038b7e24d5d6a2d5c10979d742364ef00) | `` treewide: propagate inputs and remove templates (#926) `` |