### PR TITLE
chore(flake/home-manager): `597f9c2f` -> `ce9cb249`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741563526,
-        "narHash": "sha256-FAJ7jIwFq1gxbxS+cdhtTxFM8eLWgP0jQGaVIvA/bug=",
+        "lastModified": 1741579325,
+        "narHash": "sha256-BTBmY1E8z8k+5kiaI/DUWssQxjpUJvfZPDj41nt8FDo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "597f9c2f06af8791b31c48ad05471ac5afbd0f0a",
+        "rev": "ce9cb2496c48ebb33e42ee0ab82267f67b82f71e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                           |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`ce9cb249`](https://github.com/nix-community/home-manager/commit/ce9cb2496c48ebb33e42ee0ab82267f67b82f71e) | `` podman: added volume, image, and build quadlets (#6137) ``                     |
| [`f8bb0ba6`](https://github.com/nix-community/home-manager/commit/f8bb0ba6de361c43c1c1e9756375f23ffadac1f9) | `` zoxide: update mkOrder to place bash configuration at end of bashrc (#6572) `` |