### PR TITLE
chore(flake/nix-index-database): `296a2c99` -> `66537fb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741490098,
-        "narHash": "sha256-/tjVMbMzxJXrJaEk9N5esnbLebIZrkS1fbDJce/RiQg=",
+        "lastModified": 1741619381,
+        "narHash": "sha256-koZtlJRqi0/MD/AKd0KrXLA2NuBOVzlIyAJprjzpxZE=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "296a2c992a28b37427d062ade6e20d467e479e3f",
+        "rev": "66537fb185462ba9b07f4e6f2d54894a1b2d04ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                           |
| ----------------------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`5f83114e`](https://github.com/nix-community/nix-index-database/commit/5f83114eb638fba4f176cb81dd8795be1a632e1f) | `` README: fix links to flakes `` |