### PR TITLE
chore(flake/disko): `2db1d64f` -> `0d8c6ad4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741684000,
-        "narHash": "sha256-NQykaWIrn5zilncefIvW4jPQ76YMXVK/dMTzkSVDmdk=",
+        "lastModified": 1741786315,
+        "narHash": "sha256-VT65AE2syHVj6v/DGB496bqBnu1PXrrzwlw07/Zpllc=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "2db1d64fc084b1d15e3871dffc02c62a94ed6ed7",
+        "rev": "0d8c6ad4a43906d14abd5c60e0ffe7b587b213de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                      |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`eea05760`](https://github.com/nix-community/disko/commit/eea057603d42c149eac9d51d035a4b8071da62aa) | `` fix syntax of disk-deactivate.jq ``       |
| [`9a7ab516`](https://github.com/nix-community/disko/commit/9a7ab516cf49c0df2f4d45c067d3b94d391701b8) | `` Set `buildPlatform` in make-disk-image `` |
| [`87d86e49`](https://github.com/nix-community/disko/commit/87d86e499c91f0bb175625a02072b00192f65711) | `` fix eval for make-disk-image test ``      |
| [`23f112ad`](https://github.com/nix-community/disko/commit/23f112ad4e671d2204c284281bb3d69d711543d4) | `` flake.lock: Update ``                     |