### PR TITLE
chore(flake/home-manager): `18780912` -> `1b0efe3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741791118,
-        "narHash": "sha256-4Y427uj0eql4yRU5rely3EcOlB9q457UDbG9omPtXiA=",
+        "lastModified": 1741879521,
+        "narHash": "sha256-GylyCwdUe2Kd69bC8txEX+A3H/DXBZl2a+GcmTcJw/g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "18780912345970e5b546b1b085385789b6935a83",
+        "rev": "1b0efe3d335f452595512c7b275e5dddfbfb28a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`1b0efe3d`](https://github.com/nix-community/home-manager/commit/1b0efe3d335f452595512c7b275e5dddfbfb28a5) | `` zsh: move option variables closer to usage ``                                     |
| [`ad487d38`](https://github.com/nix-community/home-manager/commit/ad487d3863e94ac839b2e1e451197ab5a4aafd1b) | `` zsh: move config variables closer to usage ``                                     |
| [`b5142d46`](https://github.com/nix-community/home-manager/commit/b5142d46a3f912ef99e9cec3e51d757fbeaf14ea) | `` zsh: remove with lib ``                                                           |
| [`56374cc6`](https://github.com/nix-community/home-manager/commit/56374cc64d58451b359bb4e8502387d3a96e7c7b) | `` zoxide: remove with lib ``                                                        |
| [`d30c1d30`](https://github.com/nix-community/home-manager/commit/d30c1d30bfbc287883c3d9e2ee811e2ac22ff879) | `` zoxide: move to bottom of zsh content ``                                          |
| [`6576167e`](https://github.com/nix-community/home-manager/commit/6576167e6b3f2b5c60e48b62f792410bd3b4824c) | `` macos-remap-keys: add (#6605) ``                                                  |
| [`ef257da5`](https://github.com/nix-community/home-manager/commit/ef257da52a299a47cc7235da270ab3b427a4ea5b) | `` docs: enhance comment for home.stateVersion option (#6116) ``                     |
| [`7832b5aa`](https://github.com/nix-community/home-manager/commit/7832b5aa95f68a421dc9b4b3c17dcf942ac6145b) | `` zsh: refactor zsh configuration for better order control over `.zshrc` (#6479) `` |