### PR TITLE
chore(flake/home-manager): `1b0efe3d` -> `0b0baed7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741879521,
-        "narHash": "sha256-GylyCwdUe2Kd69bC8txEX+A3H/DXBZl2a+GcmTcJw/g=",
+        "lastModified": 1741894454,
+        "narHash": "sha256-Mu2YXrGr/8Cid6W44AXci/YYnASoXjGrMV9Sjs66oyc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1b0efe3d335f452595512c7b275e5dddfbfb28a5",
+        "rev": "0b0baed7b2bf6a5e365d4cba042b580a2bc32e34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`0b0baed7`](https://github.com/nix-community/home-manager/commit/0b0baed7b2bf6a5e365d4cba042b580a2bc32e34) | `` tests/default: blacklist sapling ``               |
| [`0e46e842`](https://github.com/nix-community/home-manager/commit/0e46e84279d3d8eb7dcb044cb8aa9baa93298e66) | `` zsh: cleanup empty / wrong generated lines ``     |
| [`5d511628`](https://github.com/nix-community/home-manager/commit/5d5116286269c4e11976f6450afde1b30c3834c0) | `` syncthing: have tray wait in submodule (#6617) `` |