### PR TITLE
chore(flake/lovesegfault-vim-config): `2bd9188b` -> `db8307ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741738011,
-        "narHash": "sha256-lBSO62ykjy7U86l+SpdsrIXJ2jKldAukTRrIkEUPKhY=",
+        "lastModified": 1741910881,
+        "narHash": "sha256-VT3BaxYcDRHNYGl/8AzxzriytgJb697wjeVrpfi6yiA=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "2bd9188b4b7b3d128250e27e4e5b4ae10545ef0a",
+        "rev": "db8307eebc944c191756942c13689728d4c152f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`db8307ee`](https://github.com/lovesegfault/vim-config/commit/db8307eebc944c191756942c13689728d4c152f0) | `` chore(flake/nixpkgs): e3e32b64 -> 6607cf78 `` |