### PR TITLE
chore(flake/home-manager): `30cce684` -> `4e12151c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741914680,
-        "narHash": "sha256-Vu4DIZvgfWMzhUyxbHUrJaQb5232S5vuwxQ2sBcBVHk=",
+        "lastModified": 1741955947,
+        "narHash": "sha256-2lbURKclgKqBNm7hVRtWh0A7NrdsibD0EaWhahUVhhY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "30cce6848a5aa41ceb5fb33185b84868cc3e9bef",
+        "rev": "4e12151c9e014e2449e0beca2c0e9534b96a26b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                      |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`4e12151c`](https://github.com/nix-community/home-manager/commit/4e12151c9e014e2449e0beca2c0e9534b96a26b4) | `` megasync: add option to enable wayland `` |
| [`e30c6a41`](https://github.com/nix-community/home-manager/commit/e30c6a41bc8548738341d10c0b17f8fead8e55ee) | `` megasync: remove with lib ``              |