### PR TITLE
chore(flake/darwin): `9175b4bb` -> `95eac71b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742013980,
-        "narHash": "sha256-34YbfwABU5nb0F5eaaJE3ujldaNDhmyxw7CWqhXJV08=",
+        "lastModified": 1742165923,
+        "narHash": "sha256-WKzuVsHXjuxYjS9KxKdpoPWpT37LofyS5llSssEw058=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "9175b4bb5f127fb7b5784b14f7e01abff24c378f",
+        "rev": "95eac71bf52b271523d0ca81dbbeb3182990fc24",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                            |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
| [`7b4a4951`](https://github.com/LnL7/nix-darwin/commit/7b4a4951dcec276a8a18e456ae1918444f05c805) | `` Back out "github-runner: replace `mkdir -p -m` with `umask`" `` |