### PR TITLE
chore(flake/nixos-hardware): `113cd391` -> `4f4d97d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -578,11 +578,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1742180333,
-        "narHash": "sha256-SrvP0G0fxz35lvQxBhAeJOl6+BueIsxJ4azMX+l/kAU=",
+        "lastModified": 1742217307,
+        "narHash": "sha256-3fwpN7KN226ghLlpO9TR0/WpgQOmOj1e8bieUxpIYSk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "113cd3916682def185290145924fa30b30bda972",
+        "rev": "4f4d97d7b7be387286cc9c988760a7ebaa5be1f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`4f4d97d7`](https://github.com/NixOS/nixos-hardware/commit/4f4d97d7b7be387286cc9c988760a7ebaa5be1f1) | `` surface: linux 6.12.18 -> 6.12.19 ``                 |
| [`36d0027e`](https://github.com/NixOS/nixos-hardware/commit/36d0027ef4a2d23476a5e29bc7f76c8861912b57) | `` apple/t2: add Wi-Fi and Bluetooth firmware option `` |
| [`e8c83f07`](https://github.com/NixOS/nixos-hardware/commit/e8c83f075915408266b2f9794f49e65ac4b3c110) | `` apple/t2: sync patches ``                            |
| [`05fa89d1`](https://github.com/NixOS/nixos-hardware/commit/05fa89d1c502762064c964bcd2f7f304f3d6794f) | `` apple/t2: migrate renamed option ``                  |