### PR TITLE
chore(flake/home-manager): `eae06a96` -> `c657142e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742241223,
-        "narHash": "sha256-GyFiAxF1ou3lxdCFlLQJh2JdPpj7B+9mXQzieKSYo7g=",
+        "lastModified": 1742246081,
+        "narHash": "sha256-1e4oFbtdOOb6NqauHevWWjEUXZnfZ6RUAJJjn9i4YBc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "eae06a96af1903655f06cb401907555ea4048357",
+        "rev": "c657142e24a43ea1035889f0b0a7c24598e0e18a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`c657142e`](https://github.com/nix-community/home-manager/commit/c657142e24a43ea1035889f0b0a7c24598e0e18a) | `` thunderbird: add message filters option  (#6652) ``                         |
| [`b870fb2d`](https://github.com/nix-community/home-manager/commit/b870fb2d62ee0deb657951f83e8689143dce98c8) | `` zsh: update zsh initContent example to use lib.literalExpression (#6637) `` |
| [`18e7d548`](https://github.com/nix-community/home-manager/commit/18e7d548992eb1900fdaad5f1a3eb8fd849b0cdd) | `` ci: bump cachix/cachix-action from 15 to 16 (#6644) ``                      |