### PR TITLE
chore(flake/treefmt-nix): `3d0579f5` -> `b3b938ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -944,11 +944,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739829690,
-        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
+        "lastModified": 1742303424,
+        "narHash": "sha256-2R7cGdcA2npQQcIWu2cTlU63veTzwVZe78BliIuJT00=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
+        "rev": "b3b938ab8ba2e8a0ce9ee9b30ccfa5e903ae5753",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                           |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`b3b938ab`](https://github.com/numtide/treefmt-nix/commit/b3b938ab8ba2e8a0ce9ee9b30ccfa5e903ae5753) | `` rustfmt: fix for Rust packages from rust-overlay (#311) ``     |
| [`60fce901`](https://github.com/numtide/treefmt-nix/commit/60fce90101ee4da830e056507721f38310a59e0d) | `` ruff-format: add `lineLength` option; add maintainer (#316) `` |
| [`7620ff43`](https://github.com/numtide/treefmt-nix/commit/7620ff43d88e46f4fd8b38205dcaa9b308d3c3b6) | `` feat: add golines formatter (#319) ``                          |