### PR TITLE
chore(flake/home-manager): `c657142e` -> `22a36aa7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742246081,
-        "narHash": "sha256-1e4oFbtdOOb6NqauHevWWjEUXZnfZ6RUAJJjn9i4YBc=",
+        "lastModified": 1742326330,
+        "narHash": "sha256-Tumt3tcMXJniSh7tw2gW+WAnVLeB3WWm+E+yYFnLBXo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c657142e24a43ea1035889f0b0a7c24598e0e18a",
+        "rev": "22a36aa709de7dd42b562a433b9cefecf104a6ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`22a36aa7`](https://github.com/nix-community/home-manager/commit/22a36aa709de7dd42b562a433b9cefecf104a6ee) | `` swww: add swww service module for swww-daemon (#6543) `` |
| [`fb74bb76`](https://github.com/nix-community/home-manager/commit/fb74bb76d94a6c55632376c931fc108131260ee9) | `` vscode: fix creation of storage.json file (#6650) ``     |