### PR TITLE
chore(flake/lovesegfault-vim-config): `13b59ffd` -> `6a823bc1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742429272,
-        "narHash": "sha256-XT4PwxENBaoe97ff79kfIqecDxMqjshEsUsLOo7arCo=",
+        "lastModified": 1742432762,
+        "narHash": "sha256-OhupsQirZd6KwmN24vXdqMyAet+O2kaBrUAmAPCBToc=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "13b59ffd6f01614e884c9580f7a1d56d5f0624dd",
+        "rev": "6a823bc14aed166243c00a3267c5af8daa062489",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                    |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`6a823bc1`](https://github.com/lovesegfault/vim-config/commit/6a823bc14aed166243c00a3267c5af8daa062489) | `` chore(deps): bump cachix/cachix-action from 15 to 16 `` |
| [`428ae5d0`](https://github.com/lovesegfault/vim-config/commit/428ae5d024241133afe18f77b105a3119cf770c6) | `` chore(flake/nixpkgs): c80f6a7e -> b6eaf97c ``           |