### PR TITLE
chore(flake/home-manager): `eb0f617a` -> `97a00e06`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742416832,
-        "narHash": "sha256-ycok0eJJcoknqaibdv/TEEEOUqovC42XCqbfLDYmnoQ=",
+        "lastModified": 1742442527,
+        "narHash": "sha256-P3hEYEIryixLQWeKOYjyxv6bIQIDoyNAuvEq+tfJc6k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "eb0f617aecbaf1eff5bacec789891e775af2f5a3",
+        "rev": "97a00e0659b2807454507eb3a593bd09b099bd80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`97a00e06`](https://github.com/nix-community/home-manager/commit/97a00e0659b2807454507eb3a593bd09b099bd80) | `` librespot: init module (#6229) ``                     |
| [`8675edf7`](https://github.com/nix-community/home-manager/commit/8675edf7d36bfc972f66481a33f4f453d3b2d06e) | `` fish: add command option for abbreviations (#6666) `` |
| [`cfaa4426`](https://github.com/nix-community/home-manager/commit/cfaa4426a3eee6e71ab02a4d72410e69abf06a12) | `` megasync: use getExe instead of getExe' (#6665) ``    |