### PR TITLE
chore(flake/lovesegfault-vim-config): `6a823bc1` -> `bcad8054`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742432762,
-        "narHash": "sha256-OhupsQirZd6KwmN24vXdqMyAet+O2kaBrUAmAPCBToc=",
+        "lastModified": 1742515688,
+        "narHash": "sha256-+aRq3pzyCdO3vN0+FYDsCy7EI1LaqL0rdRlxi0fUJkQ=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "6a823bc14aed166243c00a3267c5af8daa062489",
+        "rev": "bcad8054beae499fa16cac17dcfd70bbcba3c83e",
         "type": "github"
       },
       "original": {
@@ -637,11 +637,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742396414,
-        "narHash": "sha256-e9Uv44rVDAG2ohNejttl9Pq5r4dxIzWxt+1hvKTQK5E=",
+        "lastModified": 1742488644,
+        "narHash": "sha256-vXpu7G4aupNCPlv8kAo7Y/jocfSUwglkvNx5cR0XjBo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d79c291d5d80d587d518e0f530cc55adb0638c80",
+        "rev": "d44b33a1ea1a3e584a8c93164dbe0ba2ad4f3a13",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`bcad8054`](https://github.com/lovesegfault/vim-config/commit/bcad8054beae499fa16cac17dcfd70bbcba3c83e) | `` chore(flake/treefmt-nix): b3b938ab -> adc195ee `` |
| [`9c6f0ba7`](https://github.com/lovesegfault/vim-config/commit/9c6f0ba756b3dd8ec72bb4ce06aa824d30dea4e7) | `` chore(flake/nixvim): d79c291d -> d44b33a1 ``      |