### PR TITLE
chore(flake/home-manager): `8a68f18e` -> `296ddc64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742569620,
-        "narHash": "sha256-igC2cu+cPRB3E4QwKR+vGagyAtoyB+DrmWwDKm8jkaw=",
+        "lastModified": 1742588233,
+        "narHash": "sha256-Fi5g8H5FXMSRqy+mU6gPG0v+C9pzjYbkkiePtz8+PpA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8a68f18e96bcab13e4f97bece61e6602298a3141",
+        "rev": "296ddc64627f4a6a4eb447852d7346b9dd16197d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`296ddc64`](https://github.com/nix-community/home-manager/commit/296ddc64627f4a6a4eb447852d7346b9dd16197d) | `` zsh: adjust initContent priorities (#6676) `` |