### PR TITLE
chore(flake/darwin): `2d9b6331` -> `e9f41de2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742373336,
-        "narHash": "sha256-oEF5dBlq8wGD3mkJ5PmFS1PGb28uYmvuy1IH6roIGkQ=",
+        "lastModified": 1742595055,
+        "narHash": "sha256-cEetDber6LF8W4ThmRc4rwKs/o8y2GH0pUdX7e6CnAQ=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "2d9b63316926aa130a5a51136d93b9be28808f26",
+        "rev": "e9f41de2a81f04390afd106959adf352a207628f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                             |
| ------------------------------------------------------------------------------------------------ | ----------------------------------- |
| [`d97323bc`](https://github.com/LnL7/nix-darwin/commit/d97323bc605fe47b002f6bc36b4910c0a251f2bc) | `` Docs: Fix references to NixOS `` |